### PR TITLE
#7 fix(bkn): enable BKN logical catalog at creation

### DIFF
--- a/adp/bkn/bkn-backend/server/interfaces/vega_backend_access.go
+++ b/adp/bkn/bkn-backend/server/interfaces/vega_backend_access.go
@@ -38,6 +38,7 @@ type CatalogRequest struct {
 	Name        string   `json:"name"`
 	Tags        []string `json:"tags"`
 	Description string   `json:"description"`
+	Enabled     bool     `json:"enabled"`
 	// ConnectorType string         `json:"connector_type"`
 	// ConnectorCfg  map[string]any `json:"connector_config"`
 }

--- a/adp/bkn/bkn-backend/server/logics/ontology_init.go
+++ b/adp/bkn/bkn-backend/server/logics/ontology_init.go
@@ -47,15 +47,7 @@ func Init(ctx context.Context, appSetting *common.AppSetting) error {
 	if catalog == nil {
 		// Create catalog
 		logger.Infof("Catalog %s not found, creating...", interfaces.BKN_CATALOG_NAME)
-		catalogReq := &interfaces.CatalogRequest{
-			ID:          interfaces.BKN_CATALOG_ID,
-			Name:        interfaces.BKN_CATALOG_NAME,
-			Description: "BKN的逻辑命名空间",
-			Tags:        []string{"BKN", "概念索引"},
-			// ConnectorType: "logical",
-			// ConnectorCfg:  make(map[string]any),
-		}
-		catalog, err = VBA.CreateCatalog(ctx, catalogReq)
+		catalog, err = VBA.CreateCatalog(ctx, bknCatalogRequest())
 		if err != nil {
 			logger.Errorf("CreateCatalog err:%v", err)
 			return err
@@ -114,6 +106,20 @@ func Init(ctx context.Context, appSetting *common.AppSetting) error {
 
 	logger.Info("Init BKN Dataset Success")
 	return nil
+}
+
+// bknCatalogRequest builds the create request for the BKN logical namespace catalog.
+// Enabled MUST be true: a logical catalog has no connector/connectivity gate, and if
+// it is created disabled, BKN search/query fails with VegaBackend.Catalog.IsDisabled
+// because bkn-backend never enables it afterward (issue #7).
+func bknCatalogRequest() *interfaces.CatalogRequest {
+	return &interfaces.CatalogRequest{
+		ID:          interfaces.BKN_CATALOG_ID,
+		Name:        interfaces.BKN_CATALOG_NAME,
+		Description: "BKN的逻辑命名空间",
+		Tags:        []string{"BKN", "概念索引"},
+		Enabled:     true,
+	}
 }
 
 // deepCompareSchemas compares two Property arrays deeply

--- a/adp/bkn/bkn-backend/server/logics/ontology_init_test.go
+++ b/adp/bkn/bkn-backend/server/logics/ontology_init_test.go
@@ -14,6 +14,26 @@ import (
 	"bkn-backend/interfaces"
 )
 
+// ── bknCatalogRequest ─────────────────────────────────────────────────────────
+
+// Regression for issue #7: the BKN logical namespace catalog must be created with
+// Enabled=true, otherwise it lands disabled and BKN search/query fails with
+// VegaBackend.Catalog.IsDisabled.
+func Test_bknCatalogRequest(t *testing.T) {
+	Convey("Test bknCatalogRequest\n", t, func() {
+		req := bknCatalogRequest()
+
+		Convey("Catalog is enabled at creation (issue #7)\n", func() {
+			So(req.Enabled, ShouldBeTrue)
+		})
+
+		Convey("Uses the BKN catalog id and name\n", func() {
+			So(req.ID, ShouldEqual, interfaces.BKN_CATALOG_ID)
+			So(req.Name, ShouldEqual, interfaces.BKN_CATALOG_NAME)
+		})
+	})
+}
+
 // ── comparePropertyFeature ────────────────────────────────────────────────────
 
 func Test_comparePropertyFeature(t *testing.T) {


### PR DESCRIPTION
Fixes #7. (Supersedes #8, auto-closed by a branch rename.)

## Problem

The BKN logical namespace catalog `adp_bkn_catalog` was created disabled. Any BKN `search` / `object-type query` that reads through Vega failed with HTTP 500:

```
{"code":"BknBackend.RelationType.InternalError",
 "details":"QueryDatasetData failed: {\"error_code\":\"VegaBackend.Catalog.IsDisabled\",\"error_details\":\"catalog is disabled\"}"}
```

## Root cause

- `bkn-backend`'s `CatalogRequest` DTO (`server/interfaces/vega_backend_access.go`) had **no `Enabled` field**, so the JSON sent to vega-backend never carried `enabled`.
- vega-backend's create handler stores `req.Enabled` directly → Go zero value `false`.
- `bkn-backend` never calls the enable endpoint afterward, so the catalog stays disabled permanently.

A logical catalog has no connector/connectivity gate, so it must be enabled from inception.

## Change

- Add `Enabled bool` to the bkn-backend `CatalogRequest` DTO.
- Extract `bknCatalogRequest()` builder in `ontology_init.go` and set `Enabled: true`.
- Add regression test `Test_bknCatalogRequest` asserting the invariant.

## Test

```
I18N_MODE_UT=true go test ./logics/   # ok
```

Before the fix the `Enabled` field did not exist, so the test failed to compile (red); after, it passes (green). Full `logics` suite green, `go vet` clean.

## Follow-up (not in this PR)

vega-backend's `CatalogRequest.Enabled` uses bool zero-value semantics — any caller that omits it defaults to disabled. Worth hardening upstream (force `Enabled=true` for `type=logical`, or switch to `*bool` to distinguish "unset" from "explicit false"). Tracked in #7.

🤖 Generated with [Claude Code](https://claude.com/claude-code)