### PR TITLE
fix(example-03): action lifecycle passes end-to-end on resource-backed object types

### DIFF
--- a/examples/03-action-lifecycle/run.sh
+++ b/examples/03-action-lifecycle/run.sh
@@ -80,6 +80,11 @@ AT_ID=""
 SCHED_ID=""
 
 cleanup() {
+    if [ "${KEEP_RESOURCES:-0}" = "1" ]; then
+        echo ""; echo "=== Cleanup skipped (KEEP_RESOURCES=1) ==="
+        echo "  Inspect: kweaver toolbox list | grep eval_action_toolbox ; kweaver bkn action-log list $KN_ID"
+        return 0
+    fi
     echo ""
     echo "=== Cleanup ==="
     [ -n "$SCHED_ID" ] && kweaver bkn action-schedule delete "$KN_ID" "$SCHED_ID" -y 2>/dev/null \
@@ -165,7 +170,7 @@ echo ""
 echo "=== Step 3: Register action tool backend ==="
 BOX_JSON=$(kweaver toolbox create \
     --name "eval_action_toolbox_${TIMESTAMP}" \
-    --service-url "http://ontology-manager-svc:13014" \
+    --service-url "http://bkn-backend-svc:13014" \
     --description "Demo toolbox for action-lifecycle example")
 debug_dump_json "create toolbox" "$BOX_JSON"
 BOX_ID=$(echo "$BOX_JSON" | python3 -c \
@@ -183,9 +188,9 @@ cat > "$_OPENAPI_TMP" <<'OPENAPI'
 {
   "openapi": "3.0.0",
   "info": {"title": "采购单风险跟进", "version": "1.0.0"},
-  "servers": [{"url": "http://ontology-manager-svc:13014"}],
+  "servers": [{"url": "http://bkn-backend-svc:13014"}],
   "paths": {
-    "/api/ontology-manager/in/v1/health": {
+    "/health": {
       "get": {
         "summary": "采购单风险跟进",
         "operationId": "follow_up_at_risk_po",
@@ -229,10 +234,11 @@ body = {
         'box_id': '$BOX_ID',
         'tool_id': '$TOOL_ID'
     },
-    'condition': {
+    'cond': {
         'object_type_id': '$MAT_OT_ID',
         'field': 'material_risk',
         'operation': '==',
+        'value_from': 'const',
         'value': 'critical'
     }
 }
@@ -253,12 +259,13 @@ echo "  Action type: $AT_ID"
 # ── Step 7: Query — verify affected instances ─────────────────────────────────
 echo ""
 echo "=== Step 7: Query — which materials need replenishment? ==="
-QUERY_JSON=$(kweaver bkn action-type query "$KN_ID" "$AT_ID" '{}' 2>&1 || true)
+QUERY_JSON=$(kweaver bkn action-type query "$KN_ID" "$AT_ID" '{}' 2>/dev/null || true)
 debug_dump_json "action-type query" "$QUERY_JSON"
 AFFECTED=$(echo "$QUERY_JSON" | python3 -c \
-    "import sys,json; d=json.load(sys.stdin); print(d.get('total_count',0))" 2>/dev/null || echo "unknown")
-echo "  Found $AFFECTED material(s) with critically low inventory"
-echo "  (The knowledge network identified these via inventory-material-order relationships)"
+    "import sys,json; d=json.load(sys.stdin); print(d.get('total_count') or len(d.get('actions') or d.get('entries') or []))" 2>/dev/null || echo "0")
+echo "  Action would target $AFFECTED material instance(s) (candidate set for 物料库存告急补货预警)"
+echo "  Note: the action condition (material_risk == critical) filters at data_view-backed query time."
+echo "        On real-time resource-backed object types it is not applied here, so all rows are listed."
 
 # Capture first identity for use in Step 10
 FIRST_IDENTITY=$(echo "$QUERY_JSON" | python3 -c "

--- a/examples/03-action-lifecycle/run.sh
+++ b/examples/03-action-lifecycle/run.sh
@@ -267,17 +267,6 @@ echo "  Action would target $AFFECTED material instance(s) (candidate set for �
 echo "  Note: the action condition (material_risk == critical) filters at data_view-backed query time."
 echo "        On real-time resource-backed object types it is not applied here, so all rows are listed."
 
-# Capture first identity for use in Step 10
-FIRST_IDENTITY=$(echo "$QUERY_JSON" | python3 -c "
-import sys,json
-d=json.load(sys.stdin)
-actions=d.get('actions',[])
-if actions:
-    print(json.dumps(actions[0].get('_instance_identity',{})))
-else:
-    print('{}')
-" 2>/dev/null || echo "{}")
-
 # ── Step 8: Create action schedule ────────────────────────────────────────────
 echo ""
 echo "=== Step 8: Schedule — every day at 08:00 ==="
@@ -317,23 +306,24 @@ echo "=== Step 10: Trigger action — first run ==="
 echo "  (In production this runs automatically at 08:00.)"
 echo "  Executing now so you can see results immediately..."
 
-EXEC_BODY=$(python3 -c "import json,sys; print(json.dumps({'_instance_identities': [json.loads('$FIRST_IDENTITY')]}))" 2>/dev/null \
-    || python3 -c "import json; print(json.dumps({'_instance_identities': [{}]}))")
+# Execute on the whole candidate set (empty _instance_identities) rather than a
+# single derived identity. On real-time resource-backed object types, passing a
+# specific identity hits a backend defect that rewrites it into an empty
+# condition ("sub condition size is 0", see issue #10); the all-instances form
+# is unaffected and exercises the same tool dispatch + audit path.
+EXEC_BODY='{"_instance_identities": []}'
 EXEC_JSON=$(kweaver bkn action-type execute "$KN_ID" "$AT_ID" "$EXEC_BODY" \
-    --timeout 60 2>&1 || true)
+    --timeout 60 2>/dev/null || true)
 debug_dump_json "action-type execute" "$EXEC_JSON"
 
 EXEC_ID=$(echo "$EXEC_JSON" | python3 -c \
-    "import sys,json; print(json.load(sys.stdin).get('id',''))" 2>/dev/null || true)
+    "import sys,json; d=json.load(sys.stdin); print(d.get('execution_id') or d.get('id',''))" 2>/dev/null || true)
 EXEC_STATUS=$(echo "$EXEC_JSON" | python3 -c \
     "import sys,json; print(json.load(sys.stdin).get('status','unknown'))" 2>/dev/null || true)
-EXEC_TOTAL=$(echo "$EXEC_JSON" | python3 -c \
-    "import sys,json; print(json.load(sys.stdin).get('total_count',0))" 2>/dev/null || true)
 
 echo "  Execution ID : ${EXEC_ID:-n/a}"
-echo "  Instances    : $EXEC_TOTAL"
-echo "  Status       : $EXEC_STATUS"
-echo "  (demo tool has no real backend — the execution record is what matters)"
+echo "  Status       : ${EXEC_STATUS:-unknown}"
+echo "  The action's tool was dispatched; see the audit log below for the record."
 
 # ── Step 11: Audit log ────────────────────────────────────────────────────────
 echo ""


### PR DESCRIPTION
## What

Makes `examples/03-action-lifecycle` pass end-to-end against the Vega catalog/resource model.

- Point the action's tool at a real service (`bkn-backend-svc:13014`, `/health`) instead of the dropped `ontology-manager-svc`.
- Use the correct condition key `cond` with `{object_type_id, field, operation, value_from, value}`.
- Step 10 executes over the full candidate set (`_instance_identities: []`) instead of a derived single identity — the single-identity path hits a backend defect that rewrites the identity into an empty condition (`sub condition size is 0`, see #10) and returns HTTP 400. Empty identities dispatches the tool and lands a `completed` record in the audit log.
- Parse `execution_id` (success shape); drop `2>&1` so CLI warnings don't corrupt the JSON capture.
- Honest action-query output + `KEEP_RESOURCES=1`-guarded cleanup.

## Verification

Full 11-step run on k3s (parallels VM, ns `kowell`): all steps pass, Step 10 `Status: completed`, audit log shows the dispatched run.

Backend root cause + workaround documented in #10.

🤖 Generated with [Claude Code](https://claude.com/claude-code)