### PR TITLE
fix(charts): quote RDSUSER/RDSPASS in configmap (numeric password breaks install)

### DIFF
--- a/infra/mf-model-api/charts/templates/configmap.yaml
+++ b/infra/mf-model-api/charts/templates/configmap.yaml
@@ -2,8 +2,8 @@ apiVersion: v1
 data:
   RDSHOST: {{ .Values.depServices.rds.host | quote }}
   RDSPORT: {{ quote .Values.depServices.rds.port }}
-  RDSUSER: {{ .Values.depServices.rds.user }}
-  RDSPASS: {{ .Values.depServices.rds.password }}
+  RDSUSER: {{ .Values.depServices.rds.user | quote }}
+  RDSPASS: {{ .Values.depServices.rds.password | quote }}
   DB_TYPE: {{ .Values.depServices.rds.type | quote}}
   RDSDBNAME: {{ .Values.depServices.rds.database | quote }}
   OPENSEARCH_HOST: {{ .Values.depServices.opensearch.host | quote}}

--- a/infra/mf-model-manager/charts/templates/configmap.yaml
+++ b/infra/mf-model-manager/charts/templates/configmap.yaml
@@ -2,8 +2,8 @@ apiVersion: v1
 data:
   RDSHOST: {{ .Values.depServices.rds.host | quote }}
   RDSPORT: {{ quote .Values.depServices.rds.port }}
-  RDSUSER: {{ .Values.depServices.rds.user }}
-  RDSPASS: {{ .Values.depServices.rds.password }}
+  RDSUSER: {{ .Values.depServices.rds.user | quote }}
+  RDSPASS: {{ .Values.depServices.rds.password | quote }}
   DB_TYPE: {{ .Values.depServices.rds.type | quote}}
   RDSDBNAME: {{ .Values.depServices.rds.database | quote }}
   OPENSEARCH_HOST: {{ .Values.depServices.opensearch.host | quote}}

--- a/infra/oss-gateway-backend/charts/templates/configmap.yaml
+++ b/infra/oss-gateway-backend/charts/templates/configmap.yaml
@@ -2,8 +2,8 @@ apiVersion: v1
 data:
   RDSHOST: {{ .Values.depServices.rds.host | quote }}
   RDSPORT: {{ quote .Values.depServices.rds.port }}
-  RDSUSER: {{ .Values.depServices.rds.user }}
-  RDSPASS: {{ .Values.depServices.rds.password }}
+  RDSUSER: {{ .Values.depServices.rds.user | quote }}
+  RDSPASS: {{ .Values.depServices.rds.password | quote }}
   DB_TYPE: {{ .Values.depServices.rds.type | quote}}
   RDSDBNAME: {{ .Values.depServices.rds.database | quote }}
   CRYPTO_AES_KEY: {{ .Values.depServices.crypto.aesKey | quote }}


### PR DESCRIPTION
RDSUSER/RDSPASS were the only unquoted ConfigMap data values in the mf-model-api / mf-model-manager / oss-gateway-backend charts. MariaDB passwords come from `openssl rand -hex` (all-hex); ~0.9% of 10-char hex strings are all digits. An all-numeric RDSPASS rendered unquoted makes k8s reject the ConfigMap:

```
cannot unmarshal number into Go struct field ConfigMap.data of type string
```

**Confirmed on a real k3s install** — the generated rds password was a 10-digit number, mf-model-manager install failed at the ConfigMap. Fix: add `| quote` to RDSUSER + RDSPASS (every other value in these configmaps is already quoted).

Note: published 0.1.0 charts still carry the old templates; these 3 charts must be re-published at 0.1.0 for the fix to reach installs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)