### PR TITLE
fix(deploy): pin isf-data-migrator to published 0.8.0-20260514.1 build

### DIFF
--- a/deploy/release-manifests/0.1.0/isf.yaml
+++ b/deploy/release-manifests/0.1.0/isf.yaml
@@ -8,7 +8,7 @@ source:
 releases:
   isf-data-migrator:
     chart: isf-data-migrator
-    version: 0.8.0-20260424.1-2f7545f
+    version: 0.8.0-20260514.1-2f7545f
     stage: pre
   hydra:
     chart: hydra


### PR DESCRIPTION
## Problem

The `0.1.0` ISF release manifest (`deploy/release-manifests/0.1.0/isf.yaml`) pinned `isf-data-migrator` at `0.8.0-20260424.1-2f7545f`, a build that is **not** published in the `openbkn` helm repo index (only `0.8.0-20260514.1-2f7545f` exists).

`isf-data-migrator` is the `stage: pre` release, so it installs first — meaning **every** `deploy.sh isf install` aborts immediately:

```
Error: chart "isf-data-migrator" matching 0.8.0-20260424.1-2f7545f not found in openbkn index
[ERROR] ✗ Failed to install isf-data-migrator
[ERROR] ISF services installation failed
```

The other 12 ISF releases already pin published `20260514` builds; only this entry was stale.

## Fix

Bump `isf-data-migrator` → `0.8.0-20260514.1-2f7545f` (the published build). Reproduced on the parallels k3s test host: the full ISF stack proceeds past the migrator once corrected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)