### PR TITLE
fix(deploy): don't leak Core image.registry into ISF charts

### DIFF
--- a/deploy/scripts/services/isf.sh
+++ b/deploy/scripts/services/isf.sh
@@ -238,10 +238,24 @@ install_isf() {
     
     # Create temporary config.yaml without rds.database field for ISF services
     local temp_config="${CONFIG_YAML_PATH}.isf.tmp"
-    log_info "Creating temporary config.yaml for ISF services (removing rds.database field)..."
-    
-    # Copy config.yaml and remove all database: lines (both top-level and nested under rds)
-    sed '/database:/d' "${CONFIG_YAML_PATH}" > "${temp_config}"
+    log_info "Creating temporary config.yaml for ISF services (removing rds.database + global image.registry)..."
+
+    # Copy config.yaml and strip two fields that must not reach the ISF charts:
+    #   - database: lines (both top-level and nested under rds)
+    #   - the top-level image.registry override
+    # The global image.registry (e.g. ghcr.io/openbkn-ai) targets the Core app
+    # images. ISF charts are AnyShare-derived and ship their own correct default
+    # registry (swr.cn-east-3.myhuaweicloud.com/kweaver-ai, repository as/<svc>);
+    # the ISF images are published there, not under ghcr.io/openbkn-ai/as/*.
+    # Letting the Core registry leak in via -f rewrites every ISF image to a
+    # private/non-existent ghcr path and the pre-install data-migrator job fails
+    # with 403/ImagePullBackOff. Drop the image: block so each ISF chart default wins.
+    awk '
+        /^image:/ { in_image = 1; next }      # drop the image: header
+        in_image && /^[[:space:]]/ { next }   # drop its indented children (registry, etc.)
+        in_image { in_image = 0 }              # first non-indented line ends the block
+        { print }
+    ' "${CONFIG_YAML_PATH}" | sed '/database:/d' > "${temp_config}"
     
     # Temporarily replace CONFIG_YAML_PATH with temp config
     local original_config="${CONFIG_YAML_PATH}"


### PR DESCRIPTION
## Problem

`deploy.sh isf install` passes the generated `config.yaml` to every ISF chart via `helm -f`. That config carries a single global `image.registry` (`ghcr.io/openbkn-ai`) meant for the **Core** app images (which are public on ghcr).

ISF charts are AnyShare-derived and ship their own correct default:

```yaml
image:
  registry: swr.cn-east-3.myhuaweicloud.com/kweaver-ai
  repository: as/isf-data-migrator
```

The ISF images are published on **swr**, not under `ghcr.io/openbkn-ai/as/*` (that path is private → 403). Letting the Core registry leak in via `-f` rewrites every ISF image to the private ghcr path, so the `stage: pre` `isf-data-migrator` job fails:

```
Image: ghcr.io/openbkn-ai/as/isf-data-migrator:0.8.0-20260514.1-2f7545f
Failed to pull ... 403 Forbidden  → ImagePullBackOff
Error: failed pre-install: timed out waiting for the condition
[ERROR] ISF services installation failed
```

## Fix

Strip the top-level `image:` block (header + indented children) from the ISF temp config — same approach already used for `database:` — so each ISF chart's own `image` defaults apply. Nested keys like `rds.registry` are unaffected.

## Evidence (parallels k3s host)

- `helm show values openbkn/isf-data-migrator` → default registry = `swr.cn-east-3.myhuaweicloud.com/kweaver-ai`
- `ctr pull swr.../as/isf-data-migrator:...` → succeeds
- `ctr pull ghcr.io/openbkn-ai/as/isf-data-migrator:...` → 403
- `ctr pull swr.../bkn-backend:0.1.0` (Core) → 401 (Core not on swr; correctly stays on ghcr)

Pairs with #18 (stale `isf-data-migrator` version pin); both are needed for `deploy.sh isf install` to succeed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)