### PR TITLE
fix(execution-factory): persist operator description on OpenAPI register/update

### DIFF
--- a/adp/execution-factory/operator-integration/server/interfaces/logics_operator.go
+++ b/adp/execution-factory/operator-integration/server/interfaces/logics_operator.go
@@ -45,6 +45,7 @@ type OperatorRegisterReq struct {
 	DirectPublish          bool                    `json:"direct_publish,omitempty" form:"direct_publish,omitempty"`                                          // 直接发布
 	FunctionInput          *FunctionInput          `json:"function_input,omitempty" form:"function_input,omitempty"`                                          // 函数输入参数
 	Data                   string                  `json:"data" form:"data"`                                                                                  // 算子元数据，当算子元数据类型为openapi时必填
+	Description            string                  `json:"description" form:"description"`                                                                    // 算子描述
 }
 
 // OperatorRegisterResp 单个算子注册结果

--- a/adp/execution-factory/operator-integration/server/logics/operator/register.go
+++ b/adp/execution-factory/operator-integration/server/logics/operator/register.go
@@ -104,7 +104,7 @@ func (m *operatorManager) UpdateOperatorByOpenAPI(ctx context.Context, req *inte
 	updateReq := &interfaces.OperatorEditReq{
 		OperatorID:  req.OperatorID,
 		Name:        metadataDBs[0].GetSummary(),
-		Description: metadataDBs[0].GetDescription(),
+		Description: req.Description,
 		OperatorInfoEdit: &interfaces.OperatorInfoEdit{
 			Type:          req.OperatorInfo.Type,
 			ExecutionMode: req.OperatorInfo.ExecutionMode,
@@ -244,6 +244,9 @@ func (m *operatorManager) registerOperator(ctx context.Context, req *interfaces.
 	err = m.validateOperator(ctx, metadataDB)
 	if err != nil {
 		return
+	}
+	if req.Description != "" {
+		metadataDB.SetDescription(req.Description)
 	}
 	// 设置创建人和更新人
 	metadataDB.SetCreateInfo(accessor.ID)


### PR DESCRIPTION
## Summary
- Add `description` to `OperatorRegisterReq` so multipart register/update requests can carry operator description
- Persist `req.Description` during OpenAPI register and update instead of reusing stale metadata description
- Aligns backend with bkn-studio execution-factory OpenAPI save flow

## Test plan
- [ ] Register OpenAPI operator with explicit `description` and verify detail/list shows it
- [ ] Update operator description via register/update endpoint and confirm it survives reopen
- [ ] Regression: register without `description` still succeeds