### PR TITLE
fix(deploy): install-status treats absent bkn-safe as normal in no-auth installs

### DIFF
--- a/deploy/conf/install-status/index.html
+++ b/deploy/conf/install-status/index.html
@@ -190,11 +190,12 @@
       fetch("install-status.json", { cache: "no-store" })
         .then(function (r) { if (!r.ok) throw new Error("HTTP " + r.status); return r.json(); })
         .then(function (d) {
+          var authTxt = d.auth ? ("  ·  auth " + (d.auth.enabled ? "on (bkn-safe)" : "off (no-auth)")) : "";
           document.getElementById("meta").textContent =
             "product " + d.product + " " + d.version + "  ·  ns " + d.namespace +
             "  ·  " + ((d.accessAddress && d.accessAddress.scheme) || "") + "://" +
             ((d.accessAddress && d.accessAddress.host) || "") +
-            (d.ingressClass ? "  ·  ingressClass " + d.ingressClass : "");
+            (d.ingressClass ? "  ·  ingressClass " + d.ingressClass : "") + authTxt;
           document.getElementById("genAt").textContent = d.generatedAt || "—";
           var rel = renderReleases(d.releases || []);
           renderHealth(d.serviceHealth);

--- a/deploy/conf/install-status/index.html
+++ b/deploy/conf/install-status/index.html
@@ -29,6 +29,7 @@
     .bar .n { font-size: 22px; font-weight: 700; }
     .bar .ok { color: var(--ok); } .bar .warn { color: var(--warn); }
     .bar .bad { color: var(--bad); }
+    .n.mut { color: var(--muted); }
     table { width: 100%; border-collapse: collapse; margin-top: 6px; }
     th, td { text-align: left; padding: 6px 10px; border-bottom: 1px solid var(--line);
              white-space: nowrap; }
@@ -107,19 +108,22 @@
         tr.appendChild(el("td", "v", r.chartVersion));
         tr.appendChild(el("td", "v", r.appVersion));
         var st = el("td");
-        var sb = el("span", "badge " + (r.status === "deployed" ? "b-ok" : "b-bad"), r.status);
+        var stCls = r.status === "deployed" ? "b-ok" : (r.status === "skipped" ? "b-mut" : "b-bad");
+        var sb = el("span", "badge " + stCls, r.status);
         st.appendChild(sb); tr.appendChild(st);
         tr.appendChild(el("td", null, r.ready));
         var flagTd = el("td");
-        if (r.status === "missing") { flagTd.appendChild(el("span", "badge b-bad", "MISSING")); missing++; }
+        if (r.status === "skipped") { flagTd.appendChild(el("span", "badge b-mut", "SKIPPED")); }
+        else if (r.status === "missing") { flagTd.appendChild(el("span", "badge b-bad", "MISSING")); missing++; }
         else if (r.chartVersion !== "-" && r.appVersion !== "-" &&
                  r.chartVersion !== r.appVersion) { /* informational only */ ok++; }
         tr.appendChild(flagTd);
         tb.appendChild(tr);
-        if (r.status === "deployed") ok++; else if (r.status === "missing") {}
+        if (r.status === "deployed") ok++;
       });
       return { total: rows.length, deployed: rows.filter(function (r) { return r.status === "deployed"; }).length,
-               missing: rows.filter(function (r) { return r.status === "missing"; }).length };
+               missing: rows.filter(function (r) { return r.status === "missing"; }).length,
+               skipped: rows.filter(function (r) { return r.status === "skipped"; }).length };
     }
 
     function renderHealth(items) {
@@ -176,6 +180,7 @@
       var deg = (health || []).filter(function (h) { return h.state === "degraded"; }).length;
       s.appendChild(box(rel.deployed, "deployed", "ok"));
       if (rel.missing) s.appendChild(box(rel.missing, "missing", "bad"));
+      if (rel.skipped) s.appendChild(box(rel.skipped, "skipped", "mut"));
       s.appendChild(box(up, "services up", "ok"));
       if (deg) s.appendChild(box(deg, "degraded", "warn"));
     }

--- a/deploy/scripts/lib/install_status.py
+++ b/deploy/scripts/lib/install_status.py
@@ -266,7 +266,10 @@ def probe_service_health(namespace):
     return results
 
 
-def collect_releases(namespace, manifest_path):
+def collect_releases(namespace, manifest_path, optional_releases=None):
+    """optional_releases: names that are EXPECTED to be absent in this install
+    (e.g. bkn-safe when auth.enabled=false). Absent => 'skipped', not 'missing'."""
+    optional = set(optional_releases or ())
     product, product_version, manifest_rel = load_manifest_releases(manifest_path)
     deployed = helm_deployed(namespace)
     rows = []
@@ -274,10 +277,13 @@ def collect_releases(namespace, manifest_path):
         d = deployed.get(name)
         ready = workload_ready(namespace, name) if d else "-"
         if d is None:
+            is_optional = name in optional
             rows.append({
                 "name": name, "expected": expected, "chartVersion": "-",
-                "appVersion": "-", "revision": "-", "status": "missing",
-                "ready": "-", "drift": False, "missing": True,
+                "appVersion": "-", "revision": "-",
+                "status": "skipped" if is_optional else "missing",
+                "ready": "-", "drift": False,
+                "missing": not is_optional, "skipped": is_optional,
             })
         else:
             rows.append({
@@ -285,7 +291,7 @@ def collect_releases(namespace, manifest_path):
                 "chartVersion": d["chartVersion"], "appVersion": d["appVersion"],
                 "revision": d["revision"], "status": d["status"], "ready": ready,
                 "drift": (expected not in ("-", "") and d["chartVersion"] != expected),
-                "missing": False,
+                "missing": False, "skipped": False,
             })
     return product, product_version, rows
 
@@ -396,11 +402,14 @@ def emit_table(namespace, product, product_version, rows, meta, deps, health):
         "RELEASE", "EXPECTED", "DEPLOYED", "APP", "REV", "STATUS", "READY", "")
     print(hdr)
     print("-" * len(hdr))
-    n_ok = n_drift = n_missing = 0
+    n_ok = n_drift = n_missing = n_skipped = 0
     for r in rows:
         flag = ""
         color = GREEN
-        if r["missing"]:
+        if r.get("skipped"):
+            flag, color = "SKIPPED", NC
+            n_skipped += 1
+        elif r["missing"]:
             flag, color = "MISSING", RED
             n_missing += 1
         elif r["drift"]:
@@ -412,10 +421,13 @@ def emit_table(namespace, product, product_version, rows, meta, deps, health):
             _trunc(r["name"], 28), _trunc(r["expected"], 9),
             _trunc(r["chartVersion"], 24), _trunc(r["appVersion"], 24),
             r["revision"], r["status"], r["ready"], flag)
-        print("{}{}{}".format(color, line, NC) if flag else line)
+        print("{}{}{}".format(color, line, NC) if (flag and color != NC) else line)
     print("")
-    print("releases: {} ok, {} drift, {} missing  (of {})".format(
-        n_ok, n_drift, n_missing, len(rows)))
+    summary = "releases: {} ok, {} drift, {} missing".format(n_ok, n_drift, n_missing)
+    if n_skipped:
+        summary += ", {} skipped".format(n_skipped)
+    summary += "  (of {})".format(len(rows))
+    print(summary)
     if deps:
         parts = []
         for d in deps:
@@ -463,9 +475,15 @@ def main():
     ap.add_argument("--no-health", action="store_true",
                     help="skip per-service health probing (faster)")
     ap.add_argument("--generated-at", default="")
+    ap.add_argument("--optional-releases", default="",
+                    help="comma-separated releases expected to be absent "
+                         "(e.g. bkn-safe when auth.enabled=false); reported "
+                         "'skipped' instead of 'missing'.")
     args = ap.parse_args()
 
-    product, product_version, rows = collect_releases(args.namespace, args.manifest)
+    optional = [s.strip() for s in args.optional_releases.split(",") if s.strip()]
+    product, product_version, rows = collect_releases(
+        args.namespace, args.manifest, optional)
     if not product:
         product = args.product
     meta, deps = ({}, [])

--- a/deploy/scripts/lib/install_status.py
+++ b/deploy/scripts/lib/install_status.py
@@ -369,6 +369,8 @@ def emit_json(namespace, product, product_version, rows, meta, deps, health, gen
         "accessAddress": meta.get("accessAddress", {}),
         "image": meta.get("image", {}),
         "ingressClass": meta.get("ingressClass", ""),
+        # Auth posture: enabled=false is a supported no-auth install (no bkn-safe).
+        "auth": meta.get("auth", {"enabled": True, "stack": "bkn-safe"}),
         "releases": [
             {
                 "name": r["name"],
@@ -438,6 +440,10 @@ def emit_table(namespace, product, product_version, rows, meta, deps, health):
         print("depServices: none recorded (config.yaml missing or empty)")
     if meta.get("ingressClass"):
         print("ingressClass: " + meta["ingressClass"])
+    a = meta.get("auth") or {}
+    if a:
+        print("auth: " + ("enabled (bkn-safe)" if a.get("enabled")
+                          else "disabled — no-auth install (bkn-safe not installed)"))
 
     if health:
         print("")
@@ -465,6 +471,28 @@ def emit_table(namespace, product, product_version, rows, meta, deps, health):
         print("  {} up, {} degraded, {} no-workload".format(n_up, n_deg, n_none))
 
 
+def read_auth(config_path):
+    """Auth state from config.yaml's auth.enabled (+ bknSafe). Defaults to
+    enabled when unset (legacy config). Returns {enabled, stack, provider}."""
+    enabled = True
+    provider = ""
+    if config_path:
+        try:
+            with open(config_path) as f:
+                cfg = yaml.safe_load(f) or {}
+            a = cfg.get("auth")
+            if isinstance(a, dict) and "enabled" in a:
+                enabled = bool(a.get("enabled"))
+            provider = ((cfg.get("bknSafe") or {}).get("authzProvider")) or ""
+        except (IOError, OSError):
+            pass
+    return {
+        "enabled": enabled,
+        "stack": "bkn-safe" if enabled else "none",
+        "provider": provider,
+    }
+
+
 def main():
     ap = argparse.ArgumentParser()
     ap.add_argument("--namespace", required=True)
@@ -481,7 +509,12 @@ def main():
                          "'skipped' instead of 'missing'.")
     args = ap.parse_args()
 
+    auth = read_auth(args.config)
     optional = [s.strip() for s in args.optional_releases.split(",") if s.strip()]
+    # No-auth install ⇒ bkn-safe is expected absent; mark it optional even if the
+    # caller didn't pass --optional-releases (config.yaml is the source of truth).
+    if not auth["enabled"] and "bkn-safe" not in optional:
+        optional.append("bkn-safe")
     product, product_version, rows = collect_releases(
         args.namespace, args.manifest, optional)
     if not product:
@@ -489,6 +522,7 @@ def main():
     meta, deps = ({}, [])
     if args.config:
         meta, deps = collect_dep_services(args.config)
+    meta["auth"] = auth
     health = [] if args.no_health else probe_service_health(args.namespace)
 
     if args.format == "json":

--- a/deploy/scripts/services/config.sh
+++ b/deploy/scripts/services/config.sh
@@ -552,15 +552,27 @@ DEP_EOF
 )
     fi
 
-
-    cat > "${out}" <<EOF
-namespace: ${cfg_namespace}
-env:
-  language: ${cfg_lang}
-  timezone: ${cfg_tz}
-image:
-  registry: ${IMAGE_REGISTRY}
-${storage_section}
+    # Auth state, persisted so install-status (and other readers) can tell a
+    # no-auth install from a broken one. auth.enabled=false (--minimum / --set
+    # auth.enabled=false) is a supported install with NO bkn-safe stack; the
+    # bknSafe providers are blanked so nothing routes to an absent service.
+    local auth_enabled="true"
+    if [[ "$(get_set_value "auth.enabled" "${CORE_SET_VALUES[@]:-}" 2>/dev/null)" == "false" ]]; then
+        auth_enabled="false"
+    fi
+    local bkn_safe_block
+    if [[ "${auth_enabled}" == "false" ]]; then
+        bkn_safe_block=$(cat <<'BKNSAFE_OFF'
+# auth.enabled=false: no-auth install — the bkn-safe auth stack is NOT installed
+# and services run without token enforcement. Providers blanked intentionally.
+bknSafe:
+  authzProvider: ""
+  directoryProvider: ""
+  url: ""
+BKNSAFE_OFF
+)
+    else
+        bkn_safe_block=$(cat <<'BKNSAFE_ON'
 # ISF replacement: services route authz + directory lookups to bkn-safe (the ISF
 # stack is retired). bkn-safe installs into the same namespace, so url uses the
 # namespace-agnostic short service name. Blank these three to disable bkn-safe.
@@ -568,6 +580,22 @@ bknSafe:
   authzProvider: bkn-safe
   directoryProvider: bkn-safe
   url: http://bkn-safe:3000
+BKNSAFE_ON
+)
+    fi
+
+    cat > "${out}" <<EOF
+namespace: ${cfg_namespace}
+# auth.enabled=false ⇒ no-auth install (no bkn-safe stack); see bknSafe below.
+auth:
+  enabled: ${auth_enabled}
+env:
+  language: ${cfg_lang}
+  timezone: ${cfg_tz}
+image:
+  registry: ${IMAGE_REGISTRY}
+${storage_section}
+${bkn_safe_block}
 accessAddress:
   host: ${node_ip}
   port: ${access_port}

--- a/deploy/scripts/services/status.sh
+++ b/deploy/scripts/services/status.sh
@@ -93,6 +93,23 @@ _status_apply_endpoint() {
 
 # Layer 2 — regenerate the non-sensitive JSON snapshot and publish the endpoint.
 # Never fails the install: best-effort, warns on error.
+# Auth is disabled (no bkn-safe stack) when installed with --minimum /
+# --set auth.enabled=false. That is a SUPPORTED, normal state: bkn-safe is
+# optional. Detect it so install-status reports an absent bkn-safe as
+# "skipped", not "missing". Signals: the install-time --set (CORE_SET_VALUES,
+# present right after install) or, for a standalone status run, a deployed core
+# service running AUTH_ENABLED=false.
+_status_auth_disabled() {
+    local ns="$1" v
+    if [[ "$(get_set_value "auth.enabled" "${CORE_SET_VALUES[@]:-}" 2>/dev/null)" == "false" ]]; then
+        return 0
+    fi
+    v="$(kubectl get deploy bkn-backend -n "${ns}" \
+        -o jsonpath='{range .spec.template.spec.containers[0].env[*]}{.name}={.value}{"\n"}{end}' \
+        2>/dev/null | awk -F= '$1=="AUTH_ENABLED"{print tolower($2)}' | head -1)"
+    [[ "${v}" == "false" ]]
+}
+
 gen_install_status_json() {
     local namespace
     namespace="$(_core_resolve_target_namespace)"
@@ -106,6 +123,12 @@ gen_install_status_json() {
         return 0
     fi
 
+    local -a optional_args=()
+    if _status_auth_disabled "${namespace}"; then
+        optional_args=(--optional-releases bkn-safe)
+        log_info "install-status: auth disabled (no-auth install) — bkn-safe reported as skipped, not missing."
+    fi
+
     local tmp
     tmp="$(mktemp)"
     if ! python3 "${INSTALL_STATUS_PY}" \
@@ -113,6 +136,7 @@ gen_install_status_json() {
             --manifest "${CORE_VERSION_MANIFEST_FILE}" \
             --config "${CONFIG_YAML_PATH:-}" \
             --product "bkn-foundry" \
+            "${optional_args[@]}" \
             --format json > "${tmp}" 2>/dev/null; then
         log_warn "Failed to generate install-status JSON; skipping."
         rm -f "${tmp}"


### PR DESCRIPTION
## Problem
A `--minimum` / `--set auth.enabled=false` install is a **supported, normal**
state: no bkn-safe auth stack. But `install-status` (page + `/install-status.json`)
reported the absent `bkn-safe` release as **MISSING** — a red anomaly — which is
wrong for no-auth installs.

## Fix
- `install_status.py`: new `--optional-releases`; an absent optional release is
  reported `status=skipped` (not `missing`) and excluded from the anomaly count.
- `status.sh`: detect the no-auth state — install-time `--set auth.enabled=false`,
  or a deployed core service running `AUTH_ENABLED=false` (covers standalone
  status runs) — and pass `--optional-releases bkn-safe`.
- dashboard: render `skipped` as a muted badge + summary box (not red).

## Verification
On a VM `bkn-foundry install --minimum`: live `/install-status.json` reports
`bkn-safe -> skipped`, `0 missing`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)