### PR TITLE
fix(deploy): remove orphaned bkn-safe on auth→no-auth downgrade

### DIFF
--- a/deploy/scripts/services/core.sh
+++ b/deploy/scripts/services/core.sh
@@ -500,7 +500,17 @@ install_core() {
         local -a _kept_releases=()
         for release_name in "${release_names[@]}"; do
             if [[ "${release_name}" == "bkn-safe" ]]; then
-                log_info "auth.enabled=false: skipping bkn-safe auth stack (override: --set bknSafe.install=true)"
+                # Downgrade cleanup: if bkn-safe is already installed (auth → no-auth),
+                # uninstall it so it doesn't linger orphaned (services now run auth-off).
+                # The app DB lives in the shared cluster MariaDB and survives; only the
+                # bundled hydra + its Postgres session state are removed.
+                if helm status "bkn-safe" -n "${namespace}" >/dev/null 2>&1; then
+                    log_warn "auth.enabled=false but bkn-safe is installed — uninstalling it (downgrade to no-auth; keep it with --set bknSafe.install=true)."
+                    helm uninstall "bkn-safe" -n "${namespace}" >/dev/null 2>&1 \
+                        || log_warn "bkn-safe uninstall failed; remove manually: helm uninstall bkn-safe -n ${namespace}"
+                else
+                    log_info "auth.enabled=false: skipping bkn-safe auth stack (override: --set bknSafe.install=true)"
+                fi
                 continue
             fi
             _kept_releases+=("${release_name}")


### PR DESCRIPTION
## Problem
`--minimum` / `--set auth.enabled=false` only kept bkn-safe out of the INSTALL
set. Re-installing a previously auth-enabled cluster in no-auth mode left the
existing bkn-safe (+ bundled hydra + Postgres) **running but orphaned** —
services are auth-off, yet the auth stack lingered (wasted resources,
inconsistent state).

## Fix
When auth is disabled and bkn-safe is already installed, uninstall it as part of
the install (downgrade cleanup). The app DB lives in the shared cluster MariaDB
and survives; only the bundled hydra + its Postgres session state are removed.
Keep it with `--set bknSafe.install=true`.

## Verification (VM)
`install --minimum` on an auth cluster: log `auth.enabled=false but bkn-safe is
installed — uninstalling it`; afterwards no bkn-safe helm release / pods,
config `auth.enabled=false`, services `AUTH_ENABLED=false`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)