### PR TITLE
chore(bkn-safe): remove the retired data_flow authz resource-type

### DIFF
--- a/bkn-safe/server/internal/httpapi/authz.go
+++ b/bkn-safe/server/internal/httpapi/authz.go
@@ -103,7 +103,7 @@ func registerAuthz(r *gin.Engine, e *authz.Enforcer, db *gorm.DB) {
 
 	// GET /resources — enumerate the concrete resource-instance IDs of a type
 	// that the accessor may perform op on (incl. role-inherited grants).
-	// Query: ?accessor_id=u1&resource_type=data_flow&operation=list
+	// Query: ?accessor_id=u1&resource_type=agent&operation=use
 	// -> { ids:[...] }. Type-wide ("*") grants are excluded; callers handle the
 	// is-admin case separately. (Generic accessor→instances enumeration.)
 	g.GET("/resources", func(c *gin.Context) {

--- a/bkn-safe/server/internal/seed/data/catalog.json
+++ b/bkn-safe/server/internal/seed/data/catalog.json
@@ -169,23 +169,6 @@
         {"id": "delete", "name": "删除"},
         {"id": "execute", "name": "调用/执行"}
       ]
-    },
-    {
-      "id": "data_flow",
-      "name": "数据流程",
-      "_source": "flow-automation",
-      "_note": "另有固定实例资源 dataflow_page:o11y(op: display)。legacy 兼容 op: only_admin/admin/share/publish/app_token/owner 未列入",
-      "operations": [
-        {"id": "list", "name": "列出"},
-        {"id": "create", "name": "创建"},
-        {"id": "modify", "name": "修改"},
-        {"id": "delete", "name": "删除"},
-        {"id": "view", "name": "查看"},
-        {"id": "manual_exec", "name": "手动执行"},
-        {"id": "run_statistics", "name": "运行统计"},
-        {"id": "run_with_app", "name": "应用运行"},
-        {"id": "display", "name": "展示(o11y 页)"}
-      ]
     }
   ]
 }

--- a/bkn-safe/server/internal/seed/data/grants.json
+++ b/bkn-safe/server/internal/seed/data/grants.json
@@ -56,13 +56,6 @@
       "id_pattern": "*",
       "operations": ["view_detail", "create", "modify", "delete", "authorize"]
     },
-    {
-      "role_id": "00990824-4bf7-11f0-8fa7-865d5643e61f",
-      "role_name": "数据管理员",
-      "resource_type": "data_flow",
-      "id_pattern": "*",
-      "operations": ["list", "create", "modify", "delete", "view", "manual_exec", "run_statistics", "run_with_app", "display"]
-    },
 
     {
       "role_id": "3fb94948-5169-11f0-b662-3a7bdba2913f",

--- a/bkn-safe/server/internal/seed/matrix_test.go
+++ b/bkn-safe/server/internal/seed/matrix_test.go
@@ -31,7 +31,7 @@ func TestRoleResourceMatrix(t *testing.T) {
 	// agreed role -> resource-type domain.
 	domain := map[string]map[string]bool{
 		appAdmin:  set("agent", "agent_tpl"),
-		dataAdmin: set("catalog", "resource", "connector_type", "knowledge_network", "stream_data_pipeline", "data_flow"),
+		dataAdmin: set("catalog", "resource", "connector_type", "knowledge_network", "stream_data_pipeline"),
 		aiAdmin:   set("operator", "skill", "mcp", "tool_box", "small_model"),
 	}
 	// a representative, granted op per resource type (positive case uses these).
@@ -40,7 +40,7 @@ func TestRoleResourceMatrix(t *testing.T) {
 		"stream_data_pipeline": "create", "catalog": "create", "resource": "create",
 		"connector_type": "create", "knowledge_network": "create",
 		"tool_box": "execute", "mcp": "execute", "operator": "execute", "skill": "execute",
-		"small_model": "execute", "data_flow": "create",
+		"small_model": "execute",
 	}
 	allTypes := make([]string, 0, len(repOp))
 	for tpe := range repOp {

--- a/bkn-safe/server/internal/seed/seed.go
+++ b/bkn-safe/server/internal/seed/seed.go
@@ -29,9 +29,11 @@ import (
 const (
 	adminUserID  = "266c6a42-6131-4d62-8f39-853e7093701c"
 	adminAccount = "admin"
-	// adminInitialPwd is the platform initial password (shared single source).
-	adminInitialPwd = auth.DefaultInitialPassword
 )
+
+// adminInitialPwd is the platform initial password (shared single source).
+// Not a const: auth.DefaultInitialPassword is a runtime var (env-overridable).
+var adminInitialPwd = auth.DefaultInitialPassword
 
 //go:embed data/roles.json
 var rolesJSON []byte

--- a/bkn-safe/server/internal/seed/seed_test.go
+++ b/bkn-safe/server/internal/seed/seed_test.go
@@ -99,7 +99,6 @@ func TestSeededRoleGrants(t *testing.T) {
 		{"app-admin not catalog", appAdmin, "catalog", "x", "create", false},
 		{"data-admin manages catalog", dataAdmin, "catalog", "x", "create", true},
 		{"data-admin manages knowledge_network", dataAdmin, "knowledge_network", "kn1", "data_query", true},
-		{"data-admin manages data_flow", dataAdmin, "data_flow", "f1", "manual_exec", true},
 		{"data-admin not operator", dataAdmin, "operator", "o1", "execute", false},
 		{"ai-admin manages operator", aiAdmin, "operator", "o1", "execute", true},
 		{"ai-admin manages skill", aiAdmin, "skill", "s1", "publish", true},


### PR DESCRIPTION
## What
Removes the `data_flow` authz resource-type — dead since the Dataflow subsystem
was retired. No live backend enforces it (only the seed catalog/grant + a stale
code comment referenced it).

- `seed/data/catalog.json`: drop the `data_flow` resource-type (9 ops incl the
  `dataflow_page:o11y` `display`).
- `seed/data/grants.json`: drop the 数据管理员 → data_flow grant.
- `seed/seed_test.go`: drop the data-admin/data_flow assertion.
- `httpapi/authz.go`: stale `/resources` example used `resource_type=data_flow` →
  use an extant example (agent/use).

Kept: `publish_to_be_data_flow_agent` (a distinct **agent** operation, not the
data_flow resource-type).

## Note
The `display` op was a fixed-instance `dataflow_page:o11y` permission; no backend
references it. If a separate frontend still renders a Dataflow o11y page gated on
it, that page is also gone with the subsystem.

🤖 Generated with [Claude Code](https://claude.com/claude-code)