### PR TITLE
test(execution-factory): fix TestUpdateOperatorByOpenAPI after #23

### DIFF
--- a/adp/execution-factory/operator-integration/server/logics/operator/register_test.go
+++ b/adp/execution-factory/operator-integration/server/logics/operator/register_test.go
@@ -682,10 +682,11 @@ func TestUpdateOperatorByOpenAPI(t *testing.T) {
 		Convey("描述不合法", func() {
 			req.MetadataType = interfaces.MetadataTypeFunc
 			req.FunctionInput = &interfaces.FunctionInput{}
+			// Since #23 the edit request takes the description from req.Description
+			// (not the parsed metadata), so set it on the request.
+			req.Description = "Mock Description"
 			metadataDBs := []interfaces.IMetadataDB{
-				&model.FunctionMetadataDB{
-					Description: "Mock Description",
-				},
+				&model.FunctionMetadataDB{},
 			}
 			mockCategoryManager.EXPECT().CheckCategory(gomock.Any()).Return(true).Times(1)
 			mockMetadataService.EXPECT().ParseMetadata(gomock.Any(), gomock.Any(), gomock.Any()).Return(metadataDBs, nil).Times(1)


### PR DESCRIPTION
## 根因

PR #23(`d8c1eff0`,persist operator description)把 `UpdateOperatorByOpenAPI` 的描述来源从**解析的元数据**改成了 **`req.Description`**:

```diff
- Description: metadataDBs[0].GetDescription(),
+ Description: req.Description,
```

但没同步测试。「描述不合法」子用例仍把描述放在元数据里(`FunctionMetadataDB{Description: ...}`),`req.Description` 为空 → `ValidateOperatorDesc` 被跳过 → 流程走到 `GetAccessor`(无 mock)→ gomock 双报错。**main 的 operator-integration CI 自 6-08 起一直红**,#29/#30 都被它挡(被迫 admin 合并)。

## 修复

测试跟代码走(#23 的行为变更是有意的):子用例改为设 `req.Description = "Mock Description"`,元数据保持空。单文件。

## 验证

本地 CI 等价全套(`go list ./... | grep -v tests | grep -v mocks`)**19 包全 ok,零 FAIL**,含 `logics/operator`。

合并后 main 转绿,后续 PR 不再需要 `--admin` 绕过分支保护。

🤖 Generated with [Claude Code](https://claude.com/claude-code)