### PR TITLE
fix(onboard): heal stale must-change-password on existing test user

### DIFF
--- a/deploy/scripts/lib/onboard_isf_test_user.sh
+++ b/deploy/scripts/lib/onboard_isf_test_user.sh
@@ -351,6 +351,34 @@ for e in d.get('roles', []):
     return 0
 }
 
+# Clear a pending must-change-password flag on [test] without changing the
+# effective password: bounce final -> final.heal -> final through the
+# self-service change-password endpoint (a successful self-service change
+# clears the flag; admin reset would re-arm it). First hop 401 = the password
+# is not the expected one (operator changed it) — leave the account alone.
+# Heals users created by older onboard runs that left the flag set.
+onboard_bkn_safe_heal_test_password_flag() {
+    local _final="$1" _kurl="$2" _tmp _c1 _c2
+    [[ -z "${_kurl}" ]] && return 0
+    _tmp="${_final}.heal"
+    _c1="$(curl -sk -o /dev/null -w '%{http_code}' -X POST "${_kurl%/}/api/safe/v1/auth/change-password" \
+        -H 'Content-Type: application/json' \
+        -d "{\"account\":\"test\",\"old_password\":\"${_final}\",\"new_password\":\"${_tmp}\"}" 2>/dev/null)"
+    if [[ "${_c1}" != 20* ]]; then
+        [[ "${_c1}" == "401" ]] || log_warn "test password-flag heal probe got http ${_c1}; if first login still demands a password change, reset manually: openbkn admin user reset-password <id> --password '<tmp>' then change-password to the final one."
+        return 0
+    fi
+    _c2="$(curl -sk -o /dev/null -w '%{http_code}' -X POST "${_kurl%/}/api/safe/v1/auth/change-password" \
+        -H 'Content-Type: application/json' \
+        -d "{\"account\":\"test\",\"old_password\":\"${_tmp}\",\"new_password\":\"${_final}\"}" 2>/dev/null)"
+    if [[ "${_c2}" != 20* ]]; then
+        log_warn "test password left at ${_tmp} (restore hop got http ${_c2}); restore: curl -k -X POST ${_kurl%/}/api/safe/v1/auth/change-password -H 'Content-Type: application/json' -d '{\"account\":\"test\",\"old_password\":\"${_tmp}\",\"new_password\":\"${_final}\"}'"
+        return 1
+    fi
+    log_info "User [test]: cleared pending must-change-password (password unchanged)"
+    return 0
+}
+
 # Create + activate the business test user for bkn-safe. Gated on bkn-safe + an
 # authenticated openbkn admin session. Honors ONBOARD_SKIP_ISF_TEST_USER and
 # ONBOARD_TEST_USER_PASSWORD / ONBOARD_DEFAULT_TEST_USER_PASSWORD (default 111111).
@@ -379,6 +407,9 @@ onboard_provision_bkn_safe_test_user() {
     if [[ -n "${_id}" ]]; then
         log_info "User [test] already exists (id ${_id}); re-syncing business roles…"
         onboard_bkn_safe_assign_business_roles test || true
+        # Older onboard runs could leave must-change-password set (the heal is a
+        # no-op when the password was changed away from the default).
+        onboard_bkn_safe_heal_test_password_flag "${_final}" "${_kurl}" || true
         ONBOARD_REPORT_ISF_TEST_USER="ready (existed; business roles re-synced; password unchanged)"
         return 0
     fi


### PR DESCRIPTION
## 现象

VM 上 test 用户(密码 111111)首次登录仍被强制改密,虽然 onboard 声称已设好最终密码。

## 根因链(逐层排除后)

1. bkn-safe 设计:admin `reset-password` **总是**置 `must_change_password=true`(代设密码=临时,合理的安全默认)
2. onboard 对此有正确的补偿:reset 到临时密码 → 调自助 `POST /api/safe/v1/auth/change-password`(temp→final)清 flag —— 端点存在、ingress 已放行、VM 镜像已含,**新建用户路径没问题**
3. **真正缺口**:onboard 幂等路径 —— test 已存在时只重同步角色、"password unchanged" 直接返回。**老版本 onboard 跑出来的存量 test(flag=true)永远没人治**

## 修复

exists 路径加自愈:用最终密码走自助 change-password 弹跳(`final → final.heal → final`):

- 自助改密成功即清 flag,密码净效果不变
- 第一跳 401 = 运维改过密码 → 不碰该账号
- 第二跳失败 → warn 并给出恢复命令(密码留在 `.heal`,可一条 curl 复原)

幂等,可重复跑。CLI 零改动(端点已有)。

## 后续(另行)

- bkn-safe `PUT /users/:id/password` 可加可选 `mustChangePassword`(默认 true),CLI 加 `--final` flag,省掉两步舞 —— 跨仓,后补
- VM 存量 test 一次性治理:合并后重跑 onboard 即可,或手动跑两条 curl 弹跳

🤖 Generated with [Claude Code](https://claude.com/claude-code)