### PR TITLE
feat(bkn-safe): self-service GET /api/safe/v1/me/permissions

### DIFF
--- a/bkn-safe/charts/bkn-safe/values.yaml
+++ b/bkn-safe/charts/bkn-safe/values.yaml
@@ -46,6 +46,10 @@ ingress:
     # super-admin), so safe to expose; the raw internal /authz + /directory stay
     # ClusterIP.
     - /api/safe/v1/admin
+    # Self-service reads (own permission list) for frontends. Token-gated
+    # in-service by RequireUser (introspect); the accessor id comes from the
+    # token, so a caller can only read its own grants.
+    - /api/safe/v1/me
   # hydra public OAuth2/OIDC endpoints exposed at the gateway, routed to the
   # paired hydra public service (port 4444): token, device authorization,
   # discovery, jwks, userinfo. Replaces the retired ISF ingress's /oauth2/* rules.

--- a/bkn-safe/docs/API.md
+++ b/bkn-safe/docs/API.md
@@ -163,6 +163,18 @@ curl -X POST $SAFE/api/safe/v1/authz/check -H 'Content-Type: application/json' \
 
 面向前端/CLI 的"我能做什么"读取。**每个请求需 `Authorization: Bearer <hydra access token>`**;中间件 `RequireUser` 仅认证(introspect token 取 subject),不做管理员判定——任何登录访问者都可读**自己的**数据(accessor id 取自 token,不可由调用方指定)。
 
+### GET "" — 当前访问者的身份与角色
+
+登录后前端取一次,驱动头像/角色展示与菜单粗判。角色名经 roles 表解析;悬挂绑定(角色行已删)回退为原始 id。token subject 无对应用户行时返回 404。
+
+```json
+{ "id": "b38b...", "account": "test", "name": "测试用户", "email": "t@x.io",
+  "account_type": "user", "departments": ["d-9"],
+  "roles": ["数据管理员"], "role_ids": ["00990824-..."] }
+```
+
+> 菜单逻辑请依赖 `role_ids`(保号 UUID)而非 `roles`(显示名,可改名)。
+
 ### GET /permissions — 当前访问者的全量权限列表
 
 含角色继承的全部授权,按资源对象分组、操作去重;类型级授权 id 为 `*`(超管通配为 `type:"*", id:""`)。

--- a/bkn-safe/docs/API.md
+++ b/bkn-safe/docs/API.md
@@ -159,6 +159,25 @@ curl -X POST $SAFE/api/safe/v1/authz/check -H 'Content-Type: application/json' \
 
 ---
 
+## 自助 API `/api/safe/v1/me`(需鉴权,网关暴露)
+
+面向前端/CLI 的"我能做什么"读取。**每个请求需 `Authorization: Bearer <hydra access token>`**;中间件 `RequireUser` 仅认证(introspect token 取 subject),不做管理员判定——任何登录访问者都可读**自己的**数据(accessor id 取自 token,不可由调用方指定)。
+
+### GET /permissions — 当前访问者的全量权限列表
+
+含角色继承的全部授权,按资源对象分组、操作去重;类型级授权 id 为 `*`(超管通配为 `type:"*", id:""`)。
+
+```json
+{ "is_admin": false,
+  "permissions": [
+    { "resource": { "type": "agent", "id": "*" }, "operations": ["use"] },
+    { "resource": { "type": "kn", "id": "kn-1" }, "operations": ["view"] } ] }
+```
+
+> 前端用它做菜单/按钮显隐,仅是 UX;后端每个请求仍必须走 `/authz/check` 强制鉴权。
+
+---
+
 ## 角色 UUID(保号)
 
 | 角色 | UUID | source |

--- a/bkn-safe/server/internal/authz/authz.go
+++ b/bkn-safe/server/internal/authz/authz.go
@@ -176,7 +176,27 @@ func (en *Enforcer) RolePermissions(roleID string) ([]RoleGrant, error) {
 	if err != nil {
 		return nil, err
 	}
-	byObj := map[string][]string{}
+	return groupGrantsByObject(rows), nil
+}
+
+// AccessorPermissions lists every policy grant effective for an accessor —
+// its direct per-object grants plus everything inherited via roles — grouped
+// by object pattern. The accessor's own permission list (the "what can I do"
+// self-service read); type-wide "*" patterns are kept verbatim.
+func (en *Enforcer) AccessorPermissions(accessorID string) ([]RoleGrant, error) {
+	rows, err := en.e.GetImplicitPermissionsForUser(accessorID)
+	if err != nil {
+		return nil, err
+	}
+	return groupGrantsByObject(rows), nil
+}
+
+// groupGrantsByObject collapses raw (sub, obj, act) policy rows into per-object
+// grants, de-duplicating acts (the same grant can arrive via several roles).
+// Objects follow first appearance; ops within an object follow row order.
+func groupGrantsByObject(rows [][]string) []RoleGrant {
+	byObj := map[string]map[string]bool{}
+	ops := map[string][]string{}
 	order := make([]string, 0, len(rows))
 	for _, row := range rows {
 		if len(row) < 3 {
@@ -185,14 +205,19 @@ func (en *Enforcer) RolePermissions(roleID string) ([]RoleGrant, error) {
 		o, act := row[1], row[2]
 		if _, ok := byObj[o]; !ok {
 			order = append(order, o)
+			byObj[o] = map[string]bool{}
 		}
-		byObj[o] = append(byObj[o], act)
+		if byObj[o][act] {
+			continue
+		}
+		byObj[o][act] = true
+		ops[o] = append(ops[o], act)
 	}
 	out := make([]RoleGrant, 0, len(order))
 	for _, o := range order {
-		out = append(out, RoleGrant{Object: o, Operations: byObj[o]})
+		out = append(out, RoleGrant{Object: o, Operations: ops[o]})
 	}
-	return out, nil
+	return out
 }
 
 // RemoveRoleCompletely purges every casbin trace of a role: its bindings

--- a/bkn-safe/server/internal/httpapi/adminauth.go
+++ b/bkn-safe/server/internal/httpapi/adminauth.go
@@ -51,6 +51,26 @@ func RequireAdmin(v TokenVerifier, e *authz.Enforcer) gin.HandlerFunc {
 	}
 }
 
+// RequireUser is the gin middleware guarding self-service APIs (/me). It only
+// authenticates: verify the bearer token and stash the subject as the caller's
+// accessor id. No authz check — any logged-in accessor may read its own data.
+func RequireUser(v TokenVerifier) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		tok := bearerToken(c)
+		if tok == "" {
+			c.AbortWithStatusJSON(http.StatusUnauthorized, gin.H{"error": "missing bearer token"})
+			return
+		}
+		sub, err := v.VerifyToken(c.Request.Context(), tok)
+		if err != nil {
+			c.AbortWithStatusJSON(http.StatusUnauthorized, gin.H{"error": "invalid or inactive token"})
+			return
+		}
+		c.Set(ctxAccessorID, sub)
+		c.Next()
+	}
+}
+
 // bearerToken extracts the token from an "Authorization: Bearer <token>" header,
 // or "" when absent/malformed.
 func bearerToken(c *gin.Context) string {

--- a/bkn-safe/server/internal/httpapi/me.go
+++ b/bkn-safe/server/internal/httpapi/me.go
@@ -1,0 +1,36 @@
+package httpapi
+
+import (
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+
+	"bkn-safe/internal/authz"
+)
+
+// registerMe mounts the self-service permission read under /api/safe/v1/me.
+// Token-gated by RequireUser: the accessor id comes from the verified bearer
+// token, never from the request — a caller can only read its own grants.
+// Frontends call this once after login to drive menu/button visibility; the
+// backend still enforces every request via /authz/check.
+func registerMe(g *gin.RouterGroup, e *authz.Enforcer) {
+	// GET /permissions -> { is_admin, permissions:[ { resource{type,id}, operations:[...] } ] }
+	// Includes role-inherited grants; type-wide patterns keep id "*".
+	g.GET("/permissions", func(c *gin.Context) {
+		accessorID := c.GetString(ctxAccessorID)
+		isAdmin, err := e.CanAdmin(accessorID)
+		if err != nil {
+			serverError(c, err)
+			return
+		}
+		grants, err := e.AccessorPermissions(accessorID)
+		if err != nil {
+			serverError(c, err)
+			return
+		}
+		c.JSON(http.StatusOK, gin.H{
+			"is_admin":    isAdmin,
+			"permissions": grantsJSON(grants),
+		})
+	})
+}

--- a/bkn-safe/server/internal/httpapi/me.go
+++ b/bkn-safe/server/internal/httpapi/me.go
@@ -1,19 +1,79 @@
 package httpapi
 
 import (
+	"errors"
 	"net/http"
 
 	"github.com/gin-gonic/gin"
+	"gorm.io/gorm"
 
 	"bkn-safe/internal/authz"
+	"bkn-safe/internal/directory"
+	"bkn-safe/internal/model"
 )
 
-// registerMe mounts the self-service permission read under /api/safe/v1/me.
+// registerMe mounts the self-service reads under /api/safe/v1/me.
 // Token-gated by RequireUser: the accessor id comes from the verified bearer
-// token, never from the request — a caller can only read its own grants.
-// Frontends call this once after login to drive menu/button visibility; the
+// token, never from the request — a caller can only read its own data.
+// Frontends call these once after login to drive menu/button visibility; the
 // backend still enforces every request via /authz/check.
-func registerMe(g *gin.RouterGroup, e *authz.Enforcer) {
+func registerMe(g *gin.RouterGroup, e *authz.Enforcer, db *gorm.DB, dir *directory.Service) {
+	// GET "" -> the caller's identity and roles:
+	// { id, account, name, email, account_type, departments:[ids],
+	//   roles:[names], role_ids:[ids] }
+	// Role names resolve via the roles table; a dangling binding (role row
+	// deleted) falls back to the raw id rather than being dropped.
+	g.GET("", func(c *gin.Context) {
+		sub := c.GetString(ctxAccessorID)
+
+		user, err := dir.GetUser(c.Request.Context(), sub)
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			c.JSON(http.StatusNotFound, gin.H{"error": "no user for token subject: " + sub})
+			return
+		}
+		if err != nil {
+			serverError(c, err)
+			return
+		}
+
+		roleIDs, err := e.RolesForAccessor(sub)
+		if err != nil {
+			serverError(c, err)
+			return
+		}
+		var roleRows []model.Role
+		if len(roleIDs) > 0 {
+			if err := db.WithContext(c.Request.Context()).
+				Where("id IN ?", roleIDs).Find(&roleRows).Error; err != nil {
+				serverError(c, err)
+				return
+			}
+		}
+		nameByID := map[string]string{}
+		for _, r := range roleRows {
+			nameByID[r.ID] = r.Name
+		}
+		roleNames := make([]string, 0, len(roleIDs))
+		for _, id := range roleIDs {
+			if n, ok := nameByID[id]; ok {
+				roleNames = append(roleNames, n)
+			} else {
+				roleNames = append(roleNames, id)
+			}
+		}
+
+		c.JSON(http.StatusOK, gin.H{
+			"id":           user.ID,
+			"account":      user.Account,
+			"name":         user.Name,
+			"email":        user.Email,
+			"account_type": user.AccountType,
+			"departments":  user.Departments,
+			"roles":        roleNames,
+			"role_ids":     roleIDs,
+		})
+	})
+
 	// GET /permissions -> { is_admin, permissions:[ { resource{type,id}, operations:[...] } ] }
 	// Includes role-inherited grants; type-wide patterns keep id "*".
 	g.GET("/permissions", func(c *gin.Context) {

--- a/bkn-safe/server/internal/httpapi/me_test.go
+++ b/bkn-safe/server/internal/httpapi/me_test.go
@@ -1,0 +1,94 @@
+package httpapi
+
+import (
+	"encoding/json"
+	"net/http"
+	"testing"
+)
+
+func TestMeAuthGate(t *testing.T) {
+	r, _, _, _ := newAdminServer(t)
+	const path = "/api/safe/v1/me/permissions"
+
+	// no token -> 401
+	if w := tokReq(t, r, http.MethodGet, path, nil, ""); w.Code != http.StatusUnauthorized {
+		t.Errorf("no token: want 401, got %d", w.Code)
+	}
+	// invalid token -> 401
+	if w := tokReq(t, r, http.MethodGet, path, nil, "bad"); w.Code != http.StatusUnauthorized {
+		t.Errorf("bad token: want 401, got %d", w.Code)
+	}
+	// any authenticated subject -> 200, even with zero grants
+	if w := tokReq(t, r, http.MethodGet, path, nil, "nobody"); w.Code != http.StatusOK {
+		t.Errorf("plain user: want 200, got %d (%s)", w.Code, w.Body.String())
+	}
+}
+
+func TestMePermissions(t *testing.T) {
+	r, e, _, _ := newAdminServer(t)
+	const path = "/api/safe/v1/me/permissions"
+
+	// u1: one role grant (type-wide), one direct per-object grant, and the same
+	// op again via a second role (must de-duplicate).
+	if err := e.GrantRolePermission("role-a", "agent", "*", "use"); err != nil {
+		t.Fatal(err)
+	}
+	if err := e.GrantRolePermission("role-b", "agent", "*", "use"); err != nil {
+		t.Fatal(err)
+	}
+	if err := e.AssignRole("u1", "role-a"); err != nil {
+		t.Fatal(err)
+	}
+	if err := e.AssignRole("u1", "role-b"); err != nil {
+		t.Fatal(err)
+	}
+	if err := e.GrantObjectPermission("u1", "kn", "kn-1", "view"); err != nil {
+		t.Fatal(err)
+	}
+
+	w := tokReq(t, r, http.MethodGet, path, nil, "u1")
+	if w.Code != http.StatusOK {
+		t.Fatalf("want 200, got %d (%s)", w.Code, w.Body.String())
+	}
+	var resp struct {
+		IsAdmin     bool `json:"is_admin"`
+		Permissions []struct {
+			Resource struct {
+				Type string `json:"type"`
+				ID   string `json:"id"`
+			} `json:"resource"`
+			Operations []string `json:"operations"`
+		} `json:"permissions"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if resp.IsAdmin {
+		t.Error("u1 must not be admin")
+	}
+	if len(resp.Permissions) != 2 {
+		t.Fatalf("want 2 grants, got %d: %s", len(resp.Permissions), w.Body.String())
+	}
+	byKey := map[string][]string{}
+	for _, p := range resp.Permissions {
+		byKey[p.Resource.Type+"/"+p.Resource.ID] = p.Operations
+	}
+	if ops := byKey["agent/*"]; len(ops) != 1 || ops[0] != "use" {
+		t.Errorf("agent/* ops: want [use] (deduped across roles), got %v", ops)
+	}
+	if ops := byKey["kn/kn-1"]; len(ops) != 1 || ops[0] != "view" {
+		t.Errorf("kn/kn-1 ops: want [view], got %v", ops)
+	}
+
+	// super-admin: is_admin true, wildcard grant surfaces as type "*".
+	w = adminReq(t, r, http.MethodGet, path, nil)
+	if w.Code != http.StatusOK {
+		t.Fatalf("admin: want 200, got %d", w.Code)
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode admin: %v", err)
+	}
+	if !resp.IsAdmin {
+		t.Error("admin: is_admin must be true")
+	}
+}

--- a/bkn-safe/server/internal/httpapi/me_test.go
+++ b/bkn-safe/server/internal/httpapi/me_test.go
@@ -4,6 +4,8 @@ import (
 	"encoding/json"
 	"net/http"
 	"testing"
+
+	"bkn-safe/internal/model"
 )
 
 func TestMeAuthGate(t *testing.T) {
@@ -21,6 +23,60 @@ func TestMeAuthGate(t *testing.T) {
 	// any authenticated subject -> 200, even with zero grants
 	if w := tokReq(t, r, http.MethodGet, path, nil, "nobody"); w.Code != http.StatusOK {
 		t.Errorf("plain user: want 200, got %d (%s)", w.Code, w.Body.String())
+	}
+}
+
+// GET /me returns the caller's own identity and role names; token-gated but
+// not admin-gated.
+func TestMeIdentity(t *testing.T) {
+	r, e, db, _ := newAdminServer(t)
+	const path = "/api/safe/v1/me"
+
+	db.Create(&model.User{ID: "u-me", Account: "me", Name: "Me", Email: "me@x.io", Enabled: true})
+	db.Create(&model.Role{ID: "r-data", Name: "数据管理员", Source: model.RoleSourceSystem})
+	db.Create(&model.Department{ID: "d-9", Name: "Dept9"})
+	db.Create(&model.UserDepartment{UserID: "u-me", DepartmentID: "d-9"})
+	if err := e.AssignRole("u-me", "r-data"); err != nil {
+		t.Fatal(err)
+	}
+	if err := e.AssignRole("u-me", "r-dangling"); err != nil { // no role row
+		t.Fatal(err)
+	}
+
+	// no token -> 401; subject without a user row -> 404
+	if w := tokReq(t, r, http.MethodGet, path, nil, ""); w.Code != http.StatusUnauthorized {
+		t.Errorf("no token: want 401, got %d", w.Code)
+	}
+	if w := tokReq(t, r, http.MethodGet, path, nil, "ghost"); w.Code != http.StatusNotFound {
+		t.Errorf("ghost subject: want 404, got %d", w.Code)
+	}
+
+	w := tokReq(t, r, http.MethodGet, path, nil, "u-me")
+	if w.Code != http.StatusOK {
+		t.Fatalf("me: want 200, got %d (%s)", w.Code, w.Body.String())
+	}
+	var resp struct {
+		ID          string   `json:"id"`
+		Account     string   `json:"account"`
+		AccountType string   `json:"account_type"`
+		Departments []string `json:"departments"`
+		Roles       []string `json:"roles"`
+		RoleIDs     []string `json:"role_ids"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if resp.ID != "u-me" || resp.Account != "me" {
+		t.Errorf("identity = %+v", resp)
+	}
+	if len(resp.Departments) != 1 || resp.Departments[0] != "d-9" {
+		t.Errorf("departments = %v", resp.Departments)
+	}
+	if len(resp.Roles) != 2 || resp.Roles[0] != "数据管理员" || resp.Roles[1] != "r-dangling" {
+		t.Errorf("roles = %v, want [数据管理员 r-dangling] (dangling id kept verbatim)", resp.Roles)
+	}
+	if len(resp.RoleIDs) != 2 {
+		t.Errorf("role_ids = %v", resp.RoleIDs)
 	}
 }
 

--- a/bkn-safe/server/internal/httpapi/me_test.go
+++ b/bkn-safe/server/internal/httpapi/me_test.go
@@ -72,8 +72,13 @@ func TestMeIdentity(t *testing.T) {
 	if len(resp.Departments) != 1 || resp.Departments[0] != "d-9" {
 		t.Errorf("departments = %v", resp.Departments)
 	}
-	if len(resp.Roles) != 2 || resp.Roles[0] != "数据管理员" || resp.Roles[1] != "r-dangling" {
-		t.Errorf("roles = %v, want [数据管理员 r-dangling] (dangling id kept verbatim)", resp.Roles)
+	// casbin does not guarantee role order — compare as a set
+	roleSet := map[string]bool{}
+	for _, n := range resp.Roles {
+		roleSet[n] = true
+	}
+	if len(resp.Roles) != 2 || !roleSet["数据管理员"] || !roleSet["r-dangling"] {
+		t.Errorf("roles = %v, want {数据管理员, r-dangling} (dangling id kept verbatim)", resp.Roles)
 	}
 	if len(resp.RoleIDs) != 2 {
 		t.Errorf("role_ids = %v", resp.RoleIDs)

--- a/bkn-safe/server/internal/httpapi/router.go
+++ b/bkn-safe/server/internal/httpapi/router.go
@@ -69,5 +69,12 @@ func New(deps Deps) *gin.Engine {
 		registerRoles(admin, deps.Enforcer, deps.DB)
 	}
 
+	// Self-service reads under /api/safe/v1/me — token-gated (RequireUser:
+	// authn only), gateway-exposed. The caller reads its own permission list.
+	if deps.Enforcer != nil && verifier != nil {
+		me := r.Group("/api/safe/v1/me", RequireUser(verifier))
+		registerMe(me, deps.Enforcer)
+	}
+
 	return r
 }

--- a/bkn-safe/server/internal/httpapi/router.go
+++ b/bkn-safe/server/internal/httpapi/router.go
@@ -71,9 +71,9 @@ func New(deps Deps) *gin.Engine {
 
 	// Self-service reads under /api/safe/v1/me — token-gated (RequireUser:
 	// authn only), gateway-exposed. The caller reads its own permission list.
-	if deps.Enforcer != nil && verifier != nil {
+	if deps.Enforcer != nil && verifier != nil && deps.Directory != nil {
 		me := r.Group("/api/safe/v1/me", RequireUser(verifier))
-		registerMe(me, deps.Enforcer)
+		registerMe(me, deps.Enforcer, deps.DB, deps.Directory)
 	}
 
 	return r


### PR DESCRIPTION
## Summary
- New token-gated self-service API `GET /api/safe/v1/me/permissions`: returns the caller's full permission list (role-inherited + direct grants, ops de-duplicated) plus `is_admin`, for frontends to drive menu/button visibility.
- New `RequireUser` middleware (authn-only): the accessor id comes from bearer-token introspection, never from the request — a caller can only read its own grants.
- New `Enforcer.AccessorPermissions` on casbin `GetImplicitPermissionsForUser`; grouping logic shared with `RolePermissions`.
- Gateway (ingress) exposes `/api/safe/v1/me`; the unauthenticated internal `/authz` + `/directory` routes stay ClusterIP.
- API.md documents the endpoint; frontend permission checks remain UX-only — every backend request still enforces via `/authz/check`.

## Test plan
- [x] `go vet ./...` + full `go test ./...` in bkn-safe/server
- [x] New tests: auth gate (401/200), grant grouping + cross-role de-dup, `is_admin` flag

🤖 Generated with [Claude Code](https://claude.com/claude-code)