### PR TITLE
feat(vega): isolate internal catalogs behind internal_catalog authz type

### DIFF
--- a/adp/bkn/bkn-backend/server/interfaces/vega_backend_access.go
+++ b/adp/bkn/bkn-backend/server/interfaces/vega_backend_access.go
@@ -39,6 +39,8 @@ type CatalogRequest struct {
 	Tags        []string `json:"tags"`
 	Description string   `json:"description"`
 	Enabled     bool     `json:"enabled"`
+	// Internal 系统内部目录：在权限服务按 internal_catalog 类型注册，仅超级管理员可见
+	Internal bool `json:"internal"`
 	// ConnectorType string         `json:"connector_type"`
 	// ConnectorCfg  map[string]any `json:"connector_config"`
 }

--- a/adp/bkn/bkn-backend/server/logics/ontology_init.go
+++ b/adp/bkn/bkn-backend/server/logics/ontology_init.go
@@ -119,6 +119,8 @@ func bknCatalogRequest() *interfaces.CatalogRequest {
 		Description: "BKN的逻辑命名空间",
 		Tags:        []string{"BKN", "概念索引"},
 		Enabled:     true,
+		// 系统内部目录：仅超级管理员可见，业务角色（数据管理员等）的 catalog:* 授权匹配不到
+		Internal: true,
 	}
 }
 

--- a/adp/execution-factory/operator-integration/server/interfaces/drivenadapters.go
+++ b/adp/execution-factory/operator-integration/server/interfaces/drivenadapters.go
@@ -847,6 +847,8 @@ type VegaCatalogRequest struct {
 	Name        string   `json:"name"`
 	Tags        []string `json:"tags"`
 	Description string   `json:"description"`
+	// Internal 系统内部目录：在权限服务按 internal_catalog 类型注册，仅超级管理员可见
+	Internal bool `json:"internal"`
 }
 
 type VegaCatalog struct {

--- a/adp/execution-factory/operator-integration/server/logics/skill/index_sync.go
+++ b/adp/execution-factory/operator-integration/server/logics/skill/index_sync.go
@@ -87,6 +87,8 @@ func (s *skillIndexSync) Init(ctx context.Context) (err error) {
 			Name:        executionFactoryCatalogID,
 			Tags:        []string{"execution-factory", "索引"},
 			Description: executionFactoryCatalogDesc,
+			// 系统内部目录：仅超级管理员可见，业务角色（数据管理员等）的 catalog:* 授权匹配不到
+			Internal: true,
 		})
 		if err != nil {
 			s.logger.WithContext(ctx).Errorf("create catalog failed, catalog_id=%s, err=%v", executionFactoryCatalogID, err)

--- a/adp/vega/vega-backend/migrations/dm8/0.9.0/04-add-catalog-internal.sql
+++ b/adp/vega/vega-backend/migrations/dm8/0.9.0/04-add-catalog-internal.sql
@@ -1,0 +1,12 @@
+-- Copyright 2026 openbkn.ai
+-- Copyright The kweaver.ai Authors.
+--
+-- Licensed under the Apache License, Version 2.0.
+-- See the LICENSE file in the project root for details.
+
+SET SCHEMA kweaver;
+
+ALTER TABLE t_catalog ADD COLUMN IF NOT EXISTS f_internal TINYINT NOT NULL DEFAULT 0;
+
+-- 存量系统内部目录补标记（BKN 概念索引、执行工厂 skill 索引）
+UPDATE t_catalog SET f_internal = 1 WHERE f_id IN ('adp_bkn_catalog', 'kweaver_execution_factory_catalog');

--- a/adp/vega/vega-backend/migrations/dm8/0.9.0/init.sql
+++ b/adp/vega/vega-backend/migrations/dm8/0.9.0/init.sql
@@ -108,6 +108,8 @@ CREATE TABLE IF NOT EXISTS t_catalog (
 
     f_type                    VARCHAR(20 CHAR) NOT NULL DEFAULT '',
     f_enabled                 TINYINT NOT NULL DEFAULT 1,
+    -- 是否系统内部目录：内部目录在权限服务按 internal_catalog 类型注册，仅超级管理员可见
+    f_internal                TINYINT NOT NULL DEFAULT 0,
 
     -- Physical Catalog 专属字段
     f_connector_type          VARCHAR(50 CHAR) NOT NULL DEFAULT '',

--- a/adp/vega/vega-backend/migrations/mariadb/0.9.0/04-add-catalog-internal.sql
+++ b/adp/vega/vega-backend/migrations/mariadb/0.9.0/04-add-catalog-internal.sql
@@ -1,0 +1,18 @@
+-- Copyright 2026 openbkn.ai
+-- Copyright The kweaver.ai Authors.
+--
+-- Licensed under the Apache License, Version 2.0.
+-- See the LICENSE file in the project root for details.
+
+USE kweaver;
+
+ALTER TABLE t_catalog ADD COLUMN IF NOT EXISTS f_internal BOOLEAN NOT NULL DEFAULT FALSE COMMENT '是否系统内部目录：内部目录在权限服务按 internal_catalog 类型注册，业务角色的 catalog:* 通配授权匹配不到，仅超级管理员可见';
+
+-- 存量系统内部目录补标记（BKN 概念索引、执行工厂 skill 索引）
+UPDATE t_catalog SET f_internal = TRUE WHERE f_id IN ('adp_bkn_catalog', 'kweaver_execution_factory_catalog');
+
+-- 注：标记后所有鉴权改按 internal_catalog/internal_resource 类型，bkn-safe 中按旧类型注册的
+-- 创建者实例策略成为无害残留（不授予任何业务角色权限）。如需清理，在 bkn-safe 库执行：
+--   DELETE FROM casbin_rule WHERE ptype='p' AND v1 IN (
+--     'catalog:adp_bkn_catalog', 'catalog:kweaver_execution_factory_catalog',
+--     'resource:adp_bkn_concept_dataset', 'resource:kweaver_execution_factory_skill_dataset');

--- a/adp/vega/vega-backend/migrations/mariadb/0.9.0/init.sql
+++ b/adp/vega/vega-backend/migrations/mariadb/0.9.0/init.sql
@@ -108,6 +108,7 @@ CREATE TABLE IF NOT EXISTS t_catalog (
 
     f_type                    VARCHAR(20) NOT NULL DEFAULT '' COMMENT '目录类型: physical, logical',
     f_enabled                 BOOLEAN NOT NULL DEFAULT TRUE COMMENT '是否启用',
+    f_internal                BOOLEAN NOT NULL DEFAULT FALSE COMMENT '是否系统内部目录：内部目录在权限服务按 internal_catalog 类型注册，业务角色的 catalog:* 通配授权匹配不到，仅超级管理员可见',
 
     -- Physical Catalog 专属字段
     f_connector_type          VARCHAR(50) NOT NULL DEFAULT '' COMMENT '数据源类型: mysql, postgresql, s3, kafka, elasticsearch, api, prometheus, etc.',

--- a/adp/vega/vega-backend/server/drivenadapters/catalog/catalog_access.go
+++ b/adp/vega/vega-backend/server/drivenadapters/catalog/catalog_access.go
@@ -86,6 +86,7 @@ func (ca *catalogAccess) Create(ctx context.Context, catalog *interfaces.Catalog
 			"f_description",
 			"f_type",
 			"f_enabled",
+			"f_internal",
 			"f_connector_type",
 			"f_connector_config",
 			"f_metadata",
@@ -107,6 +108,7 @@ func (ca *catalogAccess) Create(ctx context.Context, catalog *interfaces.Catalog
 			catalog.Description,
 			catalog.Type,
 			catalog.Enabled,
+			catalog.Internal,
 			catalog.ConnectorType,
 			connectorConfigStr,
 			metadataStr,
@@ -152,6 +154,7 @@ func (ca *catalogAccess) GetByID(ctx context.Context, id string) (*interfaces.Ca
 		"f_description",
 		"f_type",
 		"f_enabled",
+		"f_internal",
 		"f_connector_type",
 		"f_connector_config",
 		"f_metadata",
@@ -187,6 +190,7 @@ func (ca *catalogAccess) GetByID(ctx context.Context, id string) (*interfaces.Ca
 		&catalog.Description,
 		&catalog.Type,
 		&catalog.Enabled,
+		&catalog.Internal,
 		&catalog.ConnectorType,
 		&connectorConfigStr,
 		&metadataStr,
@@ -256,6 +260,7 @@ func (ca *catalogAccess) GetByIDs(ctx context.Context, ids []string) ([]*interfa
 		"f_description",
 		"f_type",
 		"f_enabled",
+		"f_internal",
 		"f_connector_type",
 		"f_connector_config",
 		"f_metadata",
@@ -300,6 +305,7 @@ func (ca *catalogAccess) GetByIDs(ctx context.Context, ids []string) ([]*interfa
 			&catalog.Description,
 			&catalog.Type,
 			&catalog.Enabled,
+			&catalog.Internal,
 			&catalog.ConnectorType,
 			&connectorConfigStr,
 			&metadataStr,
@@ -372,6 +378,7 @@ func (ca *catalogAccess) GetByName(ctx context.Context, name string) (*interface
 		"f_description",
 		"f_type",
 		"f_enabled",
+		"f_internal",
 		"f_connector_type",
 		"f_connector_config",
 		"f_metadata",
@@ -407,6 +414,7 @@ func (ca *catalogAccess) GetByName(ctx context.Context, name string) (*interface
 		&catalog.Description,
 		&catalog.Type,
 		&catalog.Enabled,
+		&catalog.Internal,
 		&catalog.ConnectorType,
 		&connectorConfigStr,
 		&metadataStr,
@@ -528,6 +536,40 @@ func (ca *catalogAccess) ListIDs(ctx context.Context, params interfaces.Catalogs
 	return ids, nil
 }
 
+// ListInternalIDs 列出所有系统内部目录的 ID（用于权限校验时按 internal_catalog 类型分组）。
+func (ca *catalogAccess) ListInternalIDs(ctx context.Context) ([]string, error) {
+	ctx, span := oteltrace.StartNamedClientSpan(ctx, "List internal catalog IDs")
+	defer span.End()
+
+	sqlStr, vals, err := sq.Select("f_id").From(CATALOG_TABLE_NAME).
+		Where(sq.Eq{"f_internal": true}).
+		ToSql()
+	if err != nil {
+		span.SetStatus(codes.Error, "Build sql failed")
+		return nil, err
+	}
+
+	rows, err := ca.db.QueryContext(ctx, sqlStr, vals...)
+	if err != nil {
+		span.SetStatus(codes.Error, "Query failed")
+		return nil, err
+	}
+	defer func() { _ = rows.Close() }()
+
+	ids := make([]string, 0)
+	for rows.Next() {
+		var id string
+		if err := rows.Scan(&id); err != nil {
+			span.SetStatus(codes.Error, "Scan row failed")
+			return nil, err
+		}
+		ids = append(ids, id)
+	}
+
+	span.SetStatus(codes.Ok, "")
+	return ids, nil
+}
+
 // List lists Catalogs with filters.
 func (ca *catalogAccess) List(ctx context.Context, params interfaces.CatalogsQueryParams) ([]*interfaces.Catalog, int64, error) {
 	ctx, span := oteltrace.StartNamedClientSpan(ctx, "List catalogs")
@@ -540,6 +582,7 @@ func (ca *catalogAccess) List(ctx context.Context, params interfaces.CatalogsQue
 		catalogExtCol(params, "f_description"),
 		catalogExtCol(params, "f_type"),
 		catalogExtCol(params, "f_enabled"),
+		catalogExtCol(params, "f_internal"),
 		catalogExtCol(params, "f_connector_type"),
 		catalogExtCol(params, "f_connector_config"),
 		catalogExtCol(params, "f_metadata"),
@@ -632,6 +675,7 @@ func (ca *catalogAccess) List(ctx context.Context, params interfaces.CatalogsQue
 			&catalog.Description,
 			&catalog.Type,
 			&catalog.Enabled,
+			&catalog.Internal,
 			&catalog.ConnectorType,
 			&connectorConfigStr,
 			&metadataStr,
@@ -690,7 +734,9 @@ func (ca *catalogAccess) ListAuthResources(ctx context.Context, params interface
 	builder := sq.Select(
 		"f_id",
 		"f_name",
-	).From(CATALOG_TABLE_NAME)
+	).From(CATALOG_TABLE_NAME).
+		// 系统内部目录按 internal_catalog 类型授权，不进入 catalog 类型的授权资源清单
+		Where(sq.Eq{"f_internal": false})
 
 	if params.ID != "" {
 		builder = builder.Where(sq.Eq{"f_id": params.ID})

--- a/adp/vega/vega-backend/server/interfaces/catalog.go
+++ b/adp/vega/vega-backend/server/interfaces/catalog.go
@@ -34,6 +34,8 @@ type Catalog struct {
 
 	Type    string `json:"type"`
 	Enabled bool   `json:"enabled"`
+	// Internal 系统内部目录：在权限服务按 internal_catalog 类型注册，仅超级管理员可见
+	Internal bool `json:"internal"`
 
 	ConnectorType string          `json:"connector_type"`
 	ConnectorCfg  ConnectorConfig `json:"connector_config"`
@@ -85,6 +87,10 @@ type CatalogRequest struct {
 	Enabled       bool            `json:"enabled"`
 	ConnectorType string          `json:"connector_type"`
 	ConnectorCfg  ConnectorConfig `json:"connector_config"`
+
+	// Internal 仅创建时生效，创建后不可变更（Update 忽略该字段）；
+	// 需要 internal_catalog 类型的 create 权限（默认仅超级管理员/系统 S2S 身份）
+	Internal bool `json:"internal,omitempty"`
 
 	// Extensions 根对象出现该键（含 null 需客户端避免）时整包替换；指针为 nil 表示请求体未携带该字段
 	Extensions *map[string]string `json:"extensions,omitempty"`

--- a/adp/vega/vega-backend/server/interfaces/catalog_access.go
+++ b/adp/vega/vega-backend/server/interfaces/catalog_access.go
@@ -26,6 +26,8 @@ type CatalogAccess interface {
 	List(ctx context.Context, params CatalogsQueryParams) ([]*Catalog, int64, error)
 	// ListIDs lists Catalog IDs with filters.
 	ListIDs(ctx context.Context, params CatalogsQueryParams) ([]string, error)
+	// ListInternalIDs 列出所有系统内部目录的 ID（用于权限校验时按 internal_catalog 类型分组）。
+	ListInternalIDs(ctx context.Context) ([]string, error)
 	// Update updates a Catalog.
 	Update(ctx context.Context, catalog *Catalog) error
 	// DeleteByIDs deletes Catalogs by IDs.

--- a/adp/vega/vega-backend/server/interfaces/catalog_service.go
+++ b/adp/vega/vega-backend/server/interfaces/catalog_service.go
@@ -28,6 +28,8 @@ type CatalogService interface {
 	DeleteByIDs(ctx context.Context, ids []string) error
 	// CheckExistByID checks if a Catalog exists by ID.
 	CheckExistByID(ctx context.Context, id string) (bool, error)
+	// ListInternalIDs 列出所有系统内部目录的 ID（用于资源权限校验时按 internal_resource 类型分组）。
+	ListInternalIDs(ctx context.Context) ([]string, error)
 	// CheckExistByName checks if a Catalog exists by name.
 	CheckExistByName(ctx context.Context, name string) (bool, error)
 	// TestConnection tests catalog connection.

--- a/adp/vega/vega-backend/server/interfaces/mock/mock_catalog_access.go
+++ b/adp/vega/vega-backend/server/interfaces/mock/mock_catalog_access.go
@@ -174,6 +174,21 @@ func (mr *MockCatalogAccessMockRecorder) ListIDs(ctx, params any) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListIDs", reflect.TypeOf((*MockCatalogAccess)(nil).ListIDs), ctx, params)
 }
 
+// ListInternalIDs mocks base method.
+func (m *MockCatalogAccess) ListInternalIDs(ctx context.Context) ([]string, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ListInternalIDs", ctx)
+	ret0, _ := ret[0].([]string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ListInternalIDs indicates an expected call of ListInternalIDs.
+func (mr *MockCatalogAccessMockRecorder) ListInternalIDs(ctx any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListInternalIDs", reflect.TypeOf((*MockCatalogAccess)(nil).ListInternalIDs), ctx)
+}
+
 // Update mocks base method.
 func (m *MockCatalogAccess) Update(ctx context.Context, catalog *interfaces.Catalog) error {
 	m.ctrl.T.Helper()

--- a/adp/vega/vega-backend/server/interfaces/mock/mock_catalog_service.go
+++ b/adp/vega/vega-backend/server/interfaces/mock/mock_catalog_service.go
@@ -56,6 +56,21 @@ func (mr *MockCatalogServiceMockRecorder) CheckExistByID(ctx, id any) *gomock.Ca
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CheckExistByID", reflect.TypeOf((*MockCatalogService)(nil).CheckExistByID), ctx, id)
 }
 
+// ListInternalIDs mocks base method.
+func (m *MockCatalogService) ListInternalIDs(ctx context.Context) ([]string, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ListInternalIDs", ctx)
+	ret0, _ := ret[0].([]string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ListInternalIDs indicates an expected call of ListInternalIDs.
+func (mr *MockCatalogServiceMockRecorder) ListInternalIDs(ctx any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListInternalIDs", reflect.TypeOf((*MockCatalogService)(nil).ListInternalIDs), ctx)
+}
+
 // CheckExistByName mocks base method.
 func (m *MockCatalogService) CheckExistByName(ctx context.Context, name string) (bool, error) {
 	m.ctrl.T.Helper()

--- a/adp/vega/vega-backend/server/interfaces/permission_access.go
+++ b/adp/vega/vega-backend/server/interfaces/permission_access.go
@@ -23,6 +23,11 @@ const (
 	AUTH_RESOURCE_TYPE_RESOURCE       = "resource"
 	AUTH_RESOURCE_TYPE_CONNECTOR_TYPE = "connector_type"
 
+	// 内部资源类型：系统内部 catalog 及其下资源按独立类型注册，
+	// 业务角色的 catalog:*/resource:* 通配授权匹配不到，仅超级管理员（* 通配）可见
+	AUTH_RESOURCE_TYPE_INTERNAL_CATALOG  = "internal_catalog"
+	AUTH_RESOURCE_TYPE_INTERNAL_RESOURCE = "internal_resource"
+
 	// 资源操作类型
 	OPERATION_TYPE_VIEW_DETAIL = "view_detail"
 	OPERATION_TYPE_CREATE      = "create"

--- a/adp/vega/vega-backend/server/logics/catalog/catalog_service.go
+++ b/adp/vega/vega-backend/server/logics/catalog/catalog_service.go
@@ -79,14 +79,83 @@ func NewCatalogService(appSetting *common.AppSetting) interfaces.CatalogService 
 	return cService
 }
 
+// catalogAuthResourceType 返回 catalog 在权限服务中的资源类型：
+// 系统内部目录按 internal_catalog 注册，业务角色的 catalog:* 通配授权匹配不到，仅超级管理员可见
+func catalogAuthResourceType(internal bool) string {
+	if internal {
+		return interfaces.AUTH_RESOURCE_TYPE_INTERNAL_CATALOG
+	}
+	return interfaces.AUTH_RESOURCE_TYPE_CATALOG
+}
+
+// partitionCatalogIDs 将目录 ID 按是否系统内部目录分组
+func partitionCatalogIDs(ids []string, internalSet map[string]struct{}) (normalIDs, internalIDs []string) {
+	normalIDs = make([]string, 0, len(ids))
+	internalIDs = make([]string, 0)
+	for _, id := range ids {
+		if _, ok := internalSet[id]; ok {
+			internalIDs = append(internalIDs, id)
+		} else {
+			normalIDs = append(normalIDs, id)
+		}
+	}
+	return normalIDs, internalIDs
+}
+
+// internalCatalogIDSet 查询所有系统内部目录 ID 集合
+func (cs *catalogService) internalCatalogIDSet(ctx context.Context) (map[string]struct{}, error) {
+	ids, err := cs.ca.ListInternalIDs(ctx)
+	if err != nil {
+		return nil, rest.NewHTTPError(ctx, http.StatusInternalServerError,
+			verrors.VegaBackend_Catalog_InternalError_GetFailed).WithErrorDetails(err.Error())
+	}
+	set := make(map[string]struct{}, len(ids))
+	for _, id := range ids {
+		set[id] = struct{}{}
+	}
+	return set, nil
+}
+
+// filterCatalogResources 按内部/普通目录分组做权限过滤：内部目录按 internal_catalog
+// 类型校验，普通目录按 catalog 类型校验，结果合并返回
+func (cs *catalogService) filterCatalogResources(ctx context.Context, ids []string,
+	internalSet map[string]struct{}, ops []string, allowOperation bool) (map[string]interfaces.PermissionResourceOps, error) {
+
+	normalIDs, internalIDs := partitionCatalogIDs(ids, internalSet)
+
+	result := make(map[string]interfaces.PermissionResourceOps, len(ids))
+	for _, group := range []struct {
+		authType string
+		ids      []string
+	}{
+		{interfaces.AUTH_RESOURCE_TYPE_CATALOG, normalIDs},
+		{interfaces.AUTH_RESOURCE_TYPE_INTERNAL_CATALOG, internalIDs},
+	} {
+		if len(group.ids) == 0 {
+			continue
+		}
+		matched, err := cs.ps.FilterResources(ctx, group.authType, group.ids, ops,
+			allowOperation, interfaces.COMMON_OPERATIONS)
+		if err != nil {
+			return nil, err
+		}
+		for _, resourceOps := range matched {
+			result[resourceOps.ResourceID] = resourceOps
+		}
+	}
+	return result, nil
+}
+
 // Create creates a new Catalog.
 func (cs *catalogService) Create(ctx context.Context, req *interfaces.CatalogRequest) (string, error) {
 	ctx, span := oteltrace.StartNamedInternalSpan(ctx, "Create catalog")
 	defer span.End()
 
-	// 判断userid是否有创建业务知识网络的权限（策略决策）
+	// 判断userid是否有创建业务知识网络的权限（策略决策）；
+	// 内部目录按 internal_catalog 类型校验，默认仅超级管理员/系统 S2S 身份可建
+	authType := catalogAuthResourceType(req.Internal)
 	err := cs.ps.CheckPermission(ctx, interfaces.PermissionResource{
-		Type: interfaces.AUTH_RESOURCE_TYPE_CATALOG,
+		Type: authType,
 		ID:   interfaces.RESOURCE_ID_ALL,
 	}, []string{interfaces.OPERATION_TYPE_CREATE})
 	if err != nil {
@@ -142,6 +211,7 @@ func (cs *catalogService) Create(ctx context.Context, req *interfaces.CatalogReq
 		Description:        req.Description,
 		Type:               catalogType,
 		Enabled:            req.Enabled,
+		Internal:           req.Internal,
 		ConnectorType:      req.ConnectorType,
 		ConnectorCfg:       req.ConnectorCfg,
 		HealthCheckEnabled: true,
@@ -179,7 +249,7 @@ func (cs *catalogService) Create(ctx context.Context, req *interfaces.CatalogReq
 	// 注册资源
 	err = cs.ps.CreateResources(ctx, []interfaces.PermissionResource{{
 		ID:   catalog.ID,
-		Type: interfaces.AUTH_RESOURCE_TYPE_CATALOG,
+		Type: authType,
 		Name: catalog.Name,
 	}}, interfaces.COMMON_OPERATIONS)
 	if err != nil {
@@ -210,8 +280,9 @@ func (cs *catalogService) GetByID(ctx context.Context, id string, withSensitiveF
 		return nil, rest.NewHTTPError(ctx, http.StatusNotFound, verrors.VegaBackend_Catalog_NotFound)
 	}
 
-	// 根据权限过滤有查看权限的对象，过滤后的数组的总长度就是总数，无需再请求总数
-	matchResoucesMap, err := cs.ps.FilterResources(ctx, interfaces.AUTH_RESOURCE_TYPE_CATALOG, []string{catalog.ID},
+	// 根据权限过滤有查看权限的对象，过滤后的数组的总长度就是总数，无需再请求总数；
+	// 内部目录按 internal_catalog 类型校验
+	matchResoucesMap, err := cs.ps.FilterResources(ctx, catalogAuthResourceType(catalog.Internal), []string{catalog.ID},
 		[]string{interfaces.OPERATION_TYPE_VIEW_DETAIL}, true, interfaces.COMMON_OPERATIONS)
 	if err != nil {
 		span.SetStatus(codes.Error, "Filter resources error")
@@ -281,9 +352,16 @@ func (cs *catalogService) GetByIDs(ctx context.Context, ids []string) ([]*interf
 		cs.removeSensitiveFields(c)
 	}
 
-	// 根据权限过滤有查看权限的对象，过滤后的数组的总长度就是总数，无需再请求总数
-	matchResoucesMap, err := cs.ps.FilterResources(ctx, interfaces.AUTH_RESOURCE_TYPE_CATALOG, ids,
-		[]string{interfaces.OPERATION_TYPE_VIEW_DETAIL}, true, interfaces.COMMON_OPERATIONS)
+	// 根据权限过滤有查看权限的对象，过滤后的数组的总长度就是总数，无需再请求总数；
+	// 内部目录按 internal_catalog 类型校验
+	internalSet := make(map[string]struct{})
+	for _, c := range catalogs {
+		if c.Internal {
+			internalSet[c.ID] = struct{}{}
+		}
+	}
+	matchResoucesMap, err := cs.filterCatalogResources(ctx, ids, internalSet,
+		[]string{interfaces.OPERATION_TYPE_VIEW_DETAIL}, true)
 	if err != nil {
 		span.SetStatus(codes.Error, "Filter resources error")
 		return nil, err
@@ -330,6 +408,13 @@ func (cs *catalogService) List(ctx context.Context, params interfaces.CatalogsQu
 		return []*interfaces.Catalog{}, 0, nil
 	}
 
+	// 内部目录 ID 集合，权限校验时按 internal_catalog 类型分组
+	internalSet, err := cs.internalCatalogIDSet(ctx)
+	if err != nil {
+		span.SetStatus(codes.Error, "List internal catalog IDs failed")
+		return []*interfaces.Catalog{}, 0, err
+	}
+
 	// 使用分批处理的方式过滤权限，每批处理1万个ID
 	batchSize := 10000
 	// 所有有权限的catalog及其操作权限
@@ -344,8 +429,8 @@ func (cs *catalogService) List(ctx context.Context, params interfaces.CatalogsQu
 
 		var batchMatchResources map[string]interfaces.PermissionResourceOps
 		// 校验权限管理的操作权限
-		batchMatchResources, err = cs.ps.FilterResources(ctx, interfaces.AUTH_RESOURCE_TYPE_CATALOG,
-			batchIDs, []string{interfaces.OPERATION_TYPE_VIEW_DETAIL}, true, interfaces.COMMON_OPERATIONS)
+		batchMatchResources, err = cs.filterCatalogResources(ctx, batchIDs, internalSet,
+			[]string{interfaces.OPERATION_TYPE_VIEW_DETAIL}, true)
 		if err != nil {
 			span.SetStatus(codes.Error, "Filter resources error")
 			return []*interfaces.Catalog{}, 0, err
@@ -455,9 +540,9 @@ func (cs *catalogService) Update(ctx context.Context, catalog *interfaces.Catalo
 		return rest.NewHTTPError(ctx, http.StatusNotFound, verrors.VegaBackend_Catalog_NotFound)
 	}
 
-	// 判断userid是否有修改权限
+	// 判断userid是否有修改权限；内部目录按 internal_catalog 类型校验
 	err := cs.ps.CheckPermission(ctx, interfaces.PermissionResource{
-		Type: interfaces.AUTH_RESOURCE_TYPE_CATALOG,
+		Type: catalogAuthResourceType(catalog.Internal),
 		ID:   catalog.ID,
 	}, []string{interfaces.OPERATION_TYPE_MODIFY})
 	if err != nil {
@@ -536,7 +621,7 @@ func (cs *catalogService) Update(ctx context.Context, catalog *interfaces.Catalo
 	if nameModified {
 		err = cs.ps.UpdateResource(ctx, interfaces.PermissionResource{
 			ID:   catalog.ID,
-			Type: interfaces.AUTH_RESOURCE_TYPE_CATALOG,
+			Type: catalogAuthResourceType(catalog.Internal),
 			Name: catalog.Name,
 		})
 		if err != nil {
@@ -558,7 +643,7 @@ func (cs *catalogService) SetEnabled(ctx context.Context, catalog *interfaces.Ca
 	}
 
 	err := cs.ps.CheckPermission(ctx, interfaces.PermissionResource{
-		Type: interfaces.AUTH_RESOURCE_TYPE_CATALOG,
+		Type: catalogAuthResourceType(catalog.Internal),
 		ID:   catalog.ID,
 	}, []string{interfaces.OPERATION_TYPE_MODIFY})
 	if err != nil {
@@ -602,9 +687,14 @@ func (cs *catalogService) DeleteByIDs(ctx context.Context, ids []string) error {
 		return nil
 	}
 
-	// 判断userid是否有删除权限
-	matchResoucesMap, err := cs.ps.FilterResources(ctx, interfaces.AUTH_RESOURCE_TYPE_CATALOG, ids,
-		[]string{interfaces.OPERATION_TYPE_DELETE}, true, interfaces.COMMON_OPERATIONS)
+	// 判断userid是否有删除权限；内部目录按 internal_catalog 类型校验
+	internalSet, err := cs.internalCatalogIDSet(ctx)
+	if err != nil {
+		span.SetStatus(codes.Error, "List internal catalog IDs failed")
+		return err
+	}
+	matchResoucesMap, err := cs.filterCatalogResources(ctx, ids, internalSet,
+		[]string{interfaces.OPERATION_TYPE_DELETE}, true)
 	if err != nil {
 		span.SetStatus(codes.Error, "Filter resources error")
 		return err
@@ -634,14 +724,31 @@ func (cs *catalogService) DeleteByIDs(ctx context.Context, ids []string) error {
 			verrors.VegaBackend_Resource_InternalError_DeleteFailed).WithErrorDetails(err.Error())
 	}
 
-	//  清除资源策略
-	err = cs.ps.DeleteResources(ctx, interfaces.AUTH_RESOURCE_TYPE_CATALOG, ids)
-	if err != nil {
-		return err
+	//  清除资源策略，按内部/普通目录分组删除对应类型的策略
+	normalIDs, internalIDs := partitionCatalogIDs(ids, internalSet)
+	if len(normalIDs) > 0 {
+		if err = cs.ps.DeleteResources(ctx, interfaces.AUTH_RESOURCE_TYPE_CATALOG, normalIDs); err != nil {
+			return err
+		}
+	}
+	if len(internalIDs) > 0 {
+		if err = cs.ps.DeleteResources(ctx, interfaces.AUTH_RESOURCE_TYPE_INTERNAL_CATALOG, internalIDs); err != nil {
+			return err
+		}
 	}
 
 	span.SetStatus(codes.Ok, "")
 	return nil
+}
+
+// ListInternalIDs 列出所有系统内部目录的 ID。
+func (cs *catalogService) ListInternalIDs(ctx context.Context) ([]string, error) {
+	ids, err := cs.ca.ListInternalIDs(ctx)
+	if err != nil {
+		return nil, rest.NewHTTPError(ctx, http.StatusInternalServerError,
+			verrors.VegaBackend_Catalog_InternalError_GetFailed).WithErrorDetails(err.Error())
+	}
+	return ids, nil
 }
 
 // CheckExistByID checks if a Catalog exists by ID.

--- a/adp/vega/vega-backend/server/logics/catalog/catalog_service_test.go
+++ b/adp/vega/vega-backend/server/logics/catalog/catalog_service_test.go
@@ -430,6 +430,7 @@ func TestList_ReturnAll(t *testing.T) {
 	ids := []string{"c1", "c2", "c3"}
 	catalogs := []*interfaces.Catalog{{ID: "c1"}, {ID: "c2"}, {ID: "c3"}}
 	mockCA.EXPECT().ListIDs(gomock.Any(), gomock.Any()).Return(ids, nil)
+	mockCA.EXPECT().ListInternalIDs(gomock.Any()).Return([]string{}, nil)
 	mockPS.EXPECT().FilterResources(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), true, gomock.Any()).
 		Return(map[string]interfaces.PermissionResourceOps{
 			"c1": {ResourceID: "c1"}, "c2": {ResourceID: "c2"}, "c3": {ResourceID: "c3"},
@@ -461,6 +462,7 @@ func TestList_Pagination(t *testing.T) {
 
 	ids := []string{"c1", "c2", "c3", "c4", "c5"}
 	mockCA.EXPECT().ListIDs(gomock.Any(), gomock.Any()).Return(ids, nil)
+	mockCA.EXPECT().ListInternalIDs(gomock.Any()).Return([]string{}, nil)
 	mockPS.EXPECT().FilterResources(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), true, gomock.Any()).
 		Return(map[string]interfaces.PermissionResourceOps{
 			"c1": {ResourceID: "c1"}, "c2": {ResourceID: "c2"}, "c3": {ResourceID: "c3"}, "c4": {ResourceID: "c4"}, "c5": {ResourceID: "c5"},
@@ -495,6 +497,7 @@ func TestList_OffsetBeyondTotal(t *testing.T) {
 
 	ids := []string{"c1", "c2"}
 	mockCA.EXPECT().ListIDs(gomock.Any(), gomock.Any()).Return(ids, nil)
+	mockCA.EXPECT().ListInternalIDs(gomock.Any()).Return([]string{}, nil)
 	mockPS.EXPECT().FilterResources(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), true, gomock.Any()).
 		Return(map[string]interfaces.PermissionResourceOps{
 			"c1": {ResourceID: "c1"}, "c2": {ResourceID: "c2"},
@@ -524,6 +527,7 @@ func TestList_PermissionFiltersOut(t *testing.T) {
 	ids := []string{"c1", "c2", "c3"}
 	catalogs := []*interfaces.Catalog{{ID: "c1"}, {ID: "c3"}}
 	mockCA.EXPECT().ListIDs(gomock.Any(), gomock.Any()).Return(ids, nil)
+	mockCA.EXPECT().ListInternalIDs(gomock.Any()).Return([]string{}, nil)
 	// 权限只返回 c1 和 c3，c2 被过滤
 	mockPS.EXPECT().FilterResources(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), true, gomock.Any()).
 		Return(map[string]interfaces.PermissionResourceOps{
@@ -567,5 +571,79 @@ func TestDeleteByIDs_Empty(t *testing.T) {
 	err := cs.DeleteByIDs(context.Background(), []string{})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+// ===== Internal catalog（系统内部目录） =====
+
+func TestCreate_InternalUsesInternalAuthType(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	mockCA := mock_interfaces.NewMockCatalogAccess(ctrl)
+	mockPS := mock_interfaces.NewMockPermissionService(ctrl)
+
+	mockPS.EXPECT().CheckPermission(gomock.Any(), interfaces.PermissionResource{
+		Type: interfaces.AUTH_RESOURCE_TYPE_INTERNAL_CATALOG,
+		ID:   interfaces.RESOURCE_ID_ALL,
+	}, []string{interfaces.OPERATION_TYPE_CREATE}).Return(nil)
+	mockCA.EXPECT().Create(gomock.Any(), gomock.Any()).DoAndReturn(
+		func(_ context.Context, catalog *interfaces.Catalog) error {
+			if !catalog.Internal {
+				t.Fatal("expected catalog.Internal=true")
+			}
+			return nil
+		},
+	)
+	mockPS.EXPECT().CreateResources(gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(
+		func(_ context.Context, resources []interfaces.PermissionResource, _ []string) error {
+			if resources[0].Type != interfaces.AUTH_RESOURCE_TYPE_INTERNAL_CATALOG {
+				t.Fatalf("expected internal_catalog auth type, got %s", resources[0].Type)
+			}
+			return nil
+		},
+	)
+
+	cs := &catalogService{ca: mockCA, ps: mockPS}
+	_, err := cs.Create(context.Background(), &interfaces.CatalogRequest{
+		Name:     "internal-catalog",
+		Internal: true,
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestList_InternalCatalogCheckedSeparately(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	mockCA := mock_interfaces.NewMockCatalogAccess(ctrl)
+	mockPS := mock_interfaces.NewMockPermissionService(ctrl)
+	mockUMS := mock_interfaces.NewMockUserMgmtService(ctrl)
+
+	ids := []string{"c1", "c2"}
+	mockCA.EXPECT().ListIDs(gomock.Any(), gomock.Any()).Return(ids, nil)
+	mockCA.EXPECT().ListInternalIDs(gomock.Any()).Return([]string{"c2"}, nil)
+	// 普通目录按 catalog 类型校验
+	mockPS.EXPECT().FilterResources(gomock.Any(), interfaces.AUTH_RESOURCE_TYPE_CATALOG,
+		[]string{"c1"}, gomock.Any(), true, gomock.Any()).
+		Return(map[string]interfaces.PermissionResourceOps{"c1": {ResourceID: "c1"}}, nil)
+	// 内部目录按 internal_catalog 类型校验；数据管理员等业务角色无授权 → 被过滤
+	mockPS.EXPECT().FilterResources(gomock.Any(), interfaces.AUTH_RESOURCE_TYPE_INTERNAL_CATALOG,
+		[]string{"c2"}, gomock.Any(), true, gomock.Any()).
+		Return(map[string]interfaces.PermissionResourceOps{}, nil)
+	mockCA.EXPECT().GetByIDs(gomock.Any(), []string{"c1"}).Return([]*interfaces.Catalog{{ID: "c1"}}, nil)
+	mockCA.EXPECT().AttachListExtensions(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
+	mockUMS.EXPECT().GetAccountNames(gomock.Any(), gomock.Any()).Return(nil)
+
+	cs := &catalogService{ca: mockCA, ps: mockPS, ums: mockUMS}
+	result, total, err := cs.List(context.Background(), interfaces.CatalogsQueryParams{
+		PaginationQueryParams: interfaces.PaginationQueryParams{Limit: -1},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if total != 1 {
+		t.Errorf("expected total 1, got %d", total)
+	}
+	if len(result) != 1 || result[0].ID != "c1" {
+		t.Errorf("expected only 'c1' visible, got %v", result)
 	}
 }

--- a/adp/vega/vega-backend/server/logics/resource/resource_service.go
+++ b/adp/vega/vega-backend/server/logics/resource/resource_service.go
@@ -66,14 +66,109 @@ func NewResourceService(appSetting *common.AppSetting) interfaces.ResourceServic
 	return rService
 }
 
+// resourceAuthResourceType 返回数据资源在权限服务中的资源类型：
+// 系统内部目录下的资源按 internal_resource 注册，业务角色的 resource:* 通配授权匹配不到，仅超级管理员可见
+func resourceAuthResourceType(internal bool) string {
+	if internal {
+		return interfaces.AUTH_RESOURCE_TYPE_INTERNAL_RESOURCE
+	}
+	return interfaces.AUTH_RESOURCE_TYPE_RESOURCE
+}
+
+// internalCatalogIDSet 查询所有系统内部目录 ID 集合
+func (rs *resourceService) internalCatalogIDSet(ctx context.Context) (map[string]struct{}, error) {
+	ids, err := rs.cs.ListInternalIDs(ctx)
+	if err != nil {
+		return nil, err
+	}
+	set := make(map[string]struct{}, len(ids))
+	for _, id := range ids {
+		set[id] = struct{}{}
+	}
+	return set, nil
+}
+
+// internalResourceIDSet 查询所有系统内部目录下的资源 ID 集合
+func (rs *resourceService) internalResourceIDSet(ctx context.Context) (map[string]struct{}, error) {
+	catalogIDs, err := rs.cs.ListInternalIDs(ctx)
+	if err != nil {
+		return nil, err
+	}
+	set := make(map[string]struct{})
+	for _, catalogID := range catalogIDs {
+		ids, err := rs.ra.ListIDs(ctx, interfaces.ResourcesQueryParams{CatalogID: catalogID})
+		if err != nil {
+			return nil, rest.NewHTTPError(ctx, http.StatusInternalServerError,
+				verrors.VegaBackend_Resource_InternalError_GetFailed).WithErrorDetails(err.Error())
+		}
+		for _, id := range ids {
+			set[id] = struct{}{}
+		}
+	}
+	return set, nil
+}
+
+// partitionResourceIDs 将资源 ID 按是否属于系统内部目录分组
+func partitionResourceIDs(ids []string, internalSet map[string]struct{}) (normalIDs, internalIDs []string) {
+	normalIDs = make([]string, 0, len(ids))
+	internalIDs = make([]string, 0)
+	for _, id := range ids {
+		if _, ok := internalSet[id]; ok {
+			internalIDs = append(internalIDs, id)
+		} else {
+			normalIDs = append(normalIDs, id)
+		}
+	}
+	return normalIDs, internalIDs
+}
+
+// filterResourcePermissions 按内部/普通资源分组做权限过滤：内部目录下的资源按
+// internal_resource 类型校验，其余按 resource 类型校验，结果合并返回
+func (rs *resourceService) filterResourcePermissions(ctx context.Context, ids []string,
+	internalSet map[string]struct{}, ops []string, allowOperation bool) (map[string]interfaces.PermissionResourceOps, error) {
+
+	normalIDs, internalIDs := partitionResourceIDs(ids, internalSet)
+
+	result := make(map[string]interfaces.PermissionResourceOps, len(ids))
+	for _, group := range []struct {
+		authType string
+		ids      []string
+	}{
+		{interfaces.AUTH_RESOURCE_TYPE_RESOURCE, normalIDs},
+		{interfaces.AUTH_RESOURCE_TYPE_INTERNAL_RESOURCE, internalIDs},
+	} {
+		if len(group.ids) == 0 {
+			continue
+		}
+		matched, err := rs.ps.FilterResources(ctx, group.authType, group.ids, ops,
+			allowOperation, interfaces.COMMON_OPERATIONS)
+		if err != nil {
+			return nil, err
+		}
+		for _, resourceOps := range matched {
+			result[resourceOps.ResourceID] = resourceOps
+		}
+	}
+	return result, nil
+}
+
 // Create creates a new Resource.
 func (rs *resourceService) Create(ctx context.Context, req *interfaces.ResourceRequest) (*interfaces.Resource, error) {
 	ctx, span := oteltrace.StartNamedInternalSpan(ctx, "Create resource")
 	defer span.End()
 
+	// 内部目录下的资源按 internal_resource 类型校验/注册，默认仅超级管理员/系统 S2S 身份可建
+	internalCatalogs, err := rs.internalCatalogIDSet(ctx)
+	if err != nil {
+		span.SetStatus(codes.Error, "List internal catalog IDs failed")
+		return nil, err
+	}
+	_, parentInternal := internalCatalogs[req.CatalogID]
+	authType := resourceAuthResourceType(parentInternal)
+
 	// 判断userid是否有创建数据资源的权限（策略决策）
-	err := rs.ps.CheckPermission(ctx, interfaces.PermissionResource{
-		Type: interfaces.AUTH_RESOURCE_TYPE_RESOURCE,
+	err = rs.ps.CheckPermission(ctx, interfaces.PermissionResource{
+		Type: authType,
 		ID:   interfaces.RESOURCE_ID_ALL,
 	}, []string{interfaces.OPERATION_TYPE_CREATE})
 	if err != nil {
@@ -177,7 +272,7 @@ func (rs *resourceService) Create(ctx context.Context, req *interfaces.ResourceR
 	// 注册资源
 	err = rs.ps.CreateResources(ctx, []interfaces.PermissionResource{{
 		ID:   resource.ID,
-		Type: interfaces.AUTH_RESOURCE_TYPE_RESOURCE,
+		Type: authType,
 		Name: resource.Name,
 	}}, interfaces.COMMON_OPERATIONS)
 	if err != nil {
@@ -208,8 +303,15 @@ func (rs *resourceService) GetByID(ctx context.Context, id string) (*interfaces.
 		return nil, rest.NewHTTPError(ctx, http.StatusNotFound, verrors.VegaBackend_Resource_NotFound)
 	}
 
-	// 根据权限过滤有查看权限的对象，过滤后的数组的总长度就是总数，无需再请求总数
-	matchResoucesMap, err := rs.ps.FilterResources(ctx, interfaces.AUTH_RESOURCE_TYPE_RESOURCE, []string{resource.ID},
+	// 根据权限过滤有查看权限的对象，过滤后的数组的总长度就是总数，无需再请求总数；
+	// 内部目录下的资源按 internal_resource 类型校验
+	internalCatalogs, err := rs.internalCatalogIDSet(ctx)
+	if err != nil {
+		span.SetStatus(codes.Error, "List internal catalog IDs failed")
+		return nil, err
+	}
+	_, parentInternal := internalCatalogs[resource.CatalogID]
+	matchResoucesMap, err := rs.ps.FilterResources(ctx, resourceAuthResourceType(parentInternal), []string{resource.ID},
 		[]string{interfaces.OPERATION_TYPE_VIEW_DETAIL}, true, interfaces.COMMON_OPERATIONS)
 	if err != nil {
 		span.SetStatus(codes.Error, "Filter resources error")
@@ -259,9 +361,21 @@ func (rs *resourceService) GetByIDs(ctx context.Context, ids []string) ([]*inter
 			WithErrorDetails(err.Error())
 	}
 
-	// 根据权限过滤有查看权限的对象，过滤后的数组的总长度就是总数，无需再请求总数
-	matchResoucesMap, err := rs.ps.FilterResources(ctx, interfaces.AUTH_RESOURCE_TYPE_RESOURCE, ids,
-		[]string{interfaces.OPERATION_TYPE_VIEW_DETAIL}, true, interfaces.COMMON_OPERATIONS)
+	// 根据权限过滤有查看权限的对象，过滤后的数组的总长度就是总数，无需再请求总数；
+	// 内部目录下的资源按 internal_resource 类型校验
+	internalCatalogs, err := rs.internalCatalogIDSet(ctx)
+	if err != nil {
+		span.SetStatus(codes.Error, "List internal catalog IDs failed")
+		return nil, err
+	}
+	internalResources := make(map[string]struct{})
+	for _, resource := range resources {
+		if _, ok := internalCatalogs[resource.CatalogID]; ok {
+			internalResources[resource.ID] = struct{}{}
+		}
+	}
+	matchResoucesMap, err := rs.filterResourcePermissions(ctx, ids, internalResources,
+		[]string{interfaces.OPERATION_TYPE_VIEW_DETAIL}, true)
 	if err != nil {
 		span.SetStatus(codes.Error, "Filter resources error")
 		return nil, err
@@ -344,6 +458,13 @@ func (rs *resourceService) List(ctx context.Context, params interfaces.Resources
 		return []*interfaces.Resource{}, 0, nil
 	}
 
+	// 内部目录下的资源 ID 集合，权限校验时按 internal_resource 类型分组
+	internalResources, err := rs.internalResourceIDSet(ctx)
+	if err != nil {
+		span.SetStatus(codes.Error, "List internal resource IDs failed")
+		return []*interfaces.Resource{}, 0, err
+	}
+
 	// 根据权限过滤有查看权限的ID数组
 	// 分批处理，每批1万个ids, fix权限接口报错prepared statement contains too many placeholders
 	batchSize := 10000
@@ -359,8 +480,8 @@ func (rs *resourceService) List(ctx context.Context, params interfaces.Resources
 
 		var batchMatchResources map[string]interfaces.PermissionResourceOps
 		// 校验权限管理的操作权限
-		batchMatchResources, err = rs.ps.FilterResources(ctx, interfaces.AUTH_RESOURCE_TYPE_RESOURCE,
-			batchIDs, []string{interfaces.OPERATION_TYPE_VIEW_DETAIL}, true, interfaces.COMMON_OPERATIONS)
+		batchMatchResources, err = rs.filterResourcePermissions(ctx, batchIDs, internalResources,
+			[]string{interfaces.OPERATION_TYPE_VIEW_DETAIL}, true)
 		if err != nil {
 			span.SetStatus(codes.Error, "Filter resources error")
 			return []*interfaces.Resource{}, 0, err
@@ -467,9 +588,16 @@ func (rs *resourceService) Update(ctx context.Context, resource *interfaces.Reso
 	}
 	nameModified := req.Name != resource.Name
 
-	// 判断userid是否有修改权限
-	err := rs.ps.CheckPermission(ctx, interfaces.PermissionResource{
-		Type: interfaces.AUTH_RESOURCE_TYPE_RESOURCE,
+	// 判断userid是否有修改权限；内部目录下的资源按 internal_resource 类型校验
+	internalCatalogs, err := rs.internalCatalogIDSet(ctx)
+	if err != nil {
+		span.SetStatus(codes.Error, "List internal catalog IDs failed")
+		return err
+	}
+	_, parentInternal := internalCatalogs[resource.CatalogID]
+	authType := resourceAuthResourceType(parentInternal)
+	err = rs.ps.CheckPermission(ctx, interfaces.PermissionResource{
+		Type: authType,
 		ID:   resource.ID,
 	}, []string{interfaces.OPERATION_TYPE_MODIFY})
 	if err != nil {
@@ -542,7 +670,7 @@ func (rs *resourceService) Update(ctx context.Context, resource *interfaces.Reso
 	if nameModified {
 		err = rs.ps.UpdateResource(ctx, interfaces.PermissionResource{
 			ID:   resource.ID,
-			Type: interfaces.AUTH_RESOURCE_TYPE_RESOURCE,
+			Type: authType,
 			Name: resource.Name,
 		})
 		if err != nil {
@@ -594,9 +722,14 @@ func (rs *resourceService) DeleteByIDs(ctx context.Context, ids []string) error 
 		return nil
 	}
 
-	// 判断userid是否有删除权限
-	matchResoucesMap, err := rs.ps.FilterResources(ctx, interfaces.AUTH_RESOURCE_TYPE_RESOURCE, ids,
-		[]string{interfaces.OPERATION_TYPE_DELETE}, true, interfaces.COMMON_OPERATIONS)
+	// 判断userid是否有删除权限；内部目录下的资源按 internal_resource 类型校验
+	internalResources, err := rs.internalResourceIDSet(ctx)
+	if err != nil {
+		span.SetStatus(codes.Error, "List internal resource IDs failed")
+		return err
+	}
+	matchResoucesMap, err := rs.filterResourcePermissions(ctx, ids, internalResources,
+		[]string{interfaces.OPERATION_TYPE_DELETE}, true)
 	if err != nil {
 		span.SetStatus(codes.Error, "Filter resources error")
 		return err
@@ -657,10 +790,17 @@ func (rs *resourceService) DeleteByIDs(ctx context.Context, ids []string) error 
 			WithErrorDetails(err.Error())
 	}
 
-	//  清除资源策略
-	err = rs.ps.DeleteResources(ctx, interfaces.AUTH_RESOURCE_TYPE_RESOURCE, ids)
-	if err != nil {
-		return err
+	//  清除资源策略，按内部/普通资源分组删除对应类型的策略
+	normalIDs, internalIDs := partitionResourceIDs(ids, internalResources)
+	if len(normalIDs) > 0 {
+		if err = rs.ps.DeleteResources(ctx, interfaces.AUTH_RESOURCE_TYPE_RESOURCE, normalIDs); err != nil {
+			return err
+		}
+	}
+	if len(internalIDs) > 0 {
+		if err = rs.ps.DeleteResources(ctx, interfaces.AUTH_RESOURCE_TYPE_INTERNAL_RESOURCE, internalIDs); err != nil {
+			return err
+		}
 	}
 
 	span.SetStatus(codes.Ok, "")
@@ -744,9 +884,18 @@ func (rs *resourceService) ListAuthResources(ctx context.Context, params interfa
 }
 
 func (rs *resourceService) filterAuthorizedResourceAuthResources(ctx context.Context, entries []*interfaces.AuthResourceEntry) ([]*interfaces.AuthResourceEntry, error) {
+	// 系统内部目录下的资源按 internal_resource 类型授权，不进入 resource 类型的授权资源清单
+	internalResources, err := rs.internalResourceIDSet(ctx)
+	if err != nil {
+		return nil, err
+	}
+
 	ids := make([]string, 0, len(entries))
 	for _, entry := range entries {
 		if entry == nil {
+			continue
+		}
+		if _, ok := internalResources[entry.ID]; ok {
 			continue
 		}
 		ids = append(ids, entry.ID)

--- a/adp/vega/vega-backend/server/logics/resource/resource_service_test.go
+++ b/adp/vega/vega-backend/server/logics/resource/resource_service_test.go
@@ -42,6 +42,10 @@ func newTestService(t *testing.T) (*resourceService,
 		cs:  mockCS,
 		bta: mockBTA,
 	}
+
+	// 默认无系统内部目录；覆盖 internal 行为的用例可叠加更具体的 EXPECT
+	mockCS.EXPECT().ListInternalIDs(gomock.Any()).Return([]string{}, nil).AnyTimes()
+
 	return rs, mockRA, mockPS, mockDS, mockUMS, mockCS, mockBTA
 }
 
@@ -463,5 +467,81 @@ func TestUpdate_Success(t *testing.T) {
 	})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+// ===== Internal catalog 下的资源（internal_resource 类型） =====
+
+func TestCreate_InternalCatalogResourceUsesInternalAuthType(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	mockRA := vmock.NewMockResourceAccess(ctrl)
+	mockPS := vmock.NewMockPermissionService(ctrl)
+	mockCS := vmock.NewMockCatalogService(ctrl)
+	rs := &resourceService{ra: mockRA, ps: mockPS, cs: mockCS}
+
+	mockCS.EXPECT().ListInternalIDs(gomock.Any()).Return([]string{"cat-internal"}, nil)
+	mockPS.EXPECT().CheckPermission(gomock.Any(), interfaces.PermissionResource{
+		Type: interfaces.AUTH_RESOURCE_TYPE_INTERNAL_RESOURCE,
+		ID:   interfaces.RESOURCE_ID_ALL,
+	}, []string{interfaces.OPERATION_TYPE_CREATE}).Return(nil)
+	mockCS.EXPECT().CheckExistByID(gomock.Any(), "cat-internal").Return(true, nil)
+	mockRA.EXPECT().Create(gomock.Any(), gomock.Any()).Return(nil)
+	mockPS.EXPECT().CreateResources(gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(
+		func(_ context.Context, resources []interfaces.PermissionResource, _ []string) error {
+			if resources[0].Type != interfaces.AUTH_RESOURCE_TYPE_INTERNAL_RESOURCE {
+				t.Fatalf("expected internal_resource auth type, got %s", resources[0].Type)
+			}
+			return nil
+		},
+	)
+
+	_, err := rs.Create(context.Background(), &interfaces.ResourceRequest{
+		CatalogID: "cat-internal",
+		Name:      "internal-res",
+		Category:  "table",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestList_InternalResourceCheckedSeparately(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	mockRA := vmock.NewMockResourceAccess(ctrl)
+	mockPS := vmock.NewMockPermissionService(ctrl)
+	mockCS := vmock.NewMockCatalogService(ctrl)
+	mockUMS := vmock.NewMockUserMgmtService(ctrl)
+	rs := &resourceService{ra: mockRA, ps: mockPS, cs: mockCS, ums: mockUMS}
+
+	mockRA.EXPECT().ListIDs(gomock.Any(), interfaces.ResourcesQueryParams{
+		PaginationQueryParams: interfaces.PaginationQueryParams{Limit: -1},
+	}).Return([]string{"r1", "r2"}, nil)
+	mockCS.EXPECT().ListInternalIDs(gomock.Any()).Return([]string{"cat-internal"}, nil)
+	mockRA.EXPECT().ListIDs(gomock.Any(), interfaces.ResourcesQueryParams{CatalogID: "cat-internal"}).
+		Return([]string{"r2"}, nil)
+	// 普通资源按 resource 类型校验
+	mockPS.EXPECT().FilterResources(gomock.Any(), interfaces.AUTH_RESOURCE_TYPE_RESOURCE,
+		[]string{"r1"}, gomock.Any(), true, gomock.Any()).
+		Return(map[string]interfaces.PermissionResourceOps{"r1": {ResourceID: "r1"}}, nil)
+	// 内部目录下的资源按 internal_resource 类型校验；业务角色无授权 → 被过滤
+	mockPS.EXPECT().FilterResources(gomock.Any(), interfaces.AUTH_RESOURCE_TYPE_INTERNAL_RESOURCE,
+		[]string{"r2"}, gomock.Any(), true, gomock.Any()).
+		Return(map[string]interfaces.PermissionResourceOps{}, nil)
+	mockRA.EXPECT().GetByIDsBasic(gomock.Any(), []string{"r1"}).
+		Return([]*interfaces.Resource{{ID: "r1"}}, nil)
+	mockRA.EXPECT().AttachListExtensions(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
+	mockUMS.EXPECT().GetAccountNames(gomock.Any(), gomock.Any()).Return(nil)
+
+	result, total, err := rs.List(context.Background(), interfaces.ResourcesQueryParams{
+		PaginationQueryParams: interfaces.PaginationQueryParams{Limit: -1},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if total != 1 {
+		t.Errorf("expected total 1, got %d", total)
+	}
+	if len(result) != 1 || result[0].ID != "r1" {
+		t.Errorf("expected only 'r1' visible, got %v", result)
 	}
 }


### PR DESCRIPTION
## 背景

系统内部 catalog（BKN 概念索引 `adp_bkn_catalog`、执行工厂 skill 索引 `kweaver_execution_factory_catalog`）此前按普通 `catalog`/`resource` 类型注册到 bkn-safe。数据管理员角色持有 `catalog:*`、`resource:*` 通配授权，因此能在列表里看到这些纯基础设施目录及其下数据集。需求：**即使持有数据管理员角色，也不能看到系统内部 catalog**。

## 方案

Casbin 模型纯 allow 无 deny，无法从通配授权里"抠掉"单个实例。改为**独立资源类型隔离**：内部 catalog 及其下资源在 bkn-safe 注册为 `internal_catalog:<id>` / `internal_resource:<id>`——业务角色的通配匹配不到，超级管理员的 `*` 通配照常全可见。**bkn-safe 零改动**。

## 变更

- **vega-backend**
  - `t_catalog` 新增 `f_internal` 列（mariadb + dm8：`init.sql` 全新部署 + `0.9.0/04-add-catalog-internal.sql` 升级迁移，迁移同时给两个存量内部 catalog 打标）
  - catalog/resource 服务在 create/get/list/update/delete 及授权资源清单全链路按 internal 标记选权限类型；列表把 ID 按内部/普通分组各做一次权限过滤
  - 创建 `internal=true` 的 catalog（及内部目录下的资源）需要对应 internal 类型的 create 权限，即仅超管/系统 S2S 身份；`internal` 创建后不可变（Update 忽略）
- **bkn-backend / execution-factory**：启动自建 catalog 的请求带 `Internal: true`（影响全新安装的首建路径）
- 旧类型下的创建者实例策略残留无害，清理 SQL 注释在迁移文件中

## 测试

- 单测：新增 4 个内部隔离用例（catalog/resource 的 Create 类型选择 + List 分组过滤）；三个服务 `go build` / `go test` 通过（存量失败与本 PR 无关）
- **验证 VM 端到端**（升级路径）：数据管理员用户 catalog/资源列表均不含内部条目、直接 GET 403；超管全可见可管理；bkn-backend 重启后 S2S 探测 catalog/dataset 正常；清理残留策略后复验无变化

🤖 Generated with [Claude Code](https://claude.com/claude-code)