### PR TITLE
fix(execution-factory): route user-management lookups to bkn-safe directory

### DIFF
--- a/adp/execution-factory/operator-integration/server/drivenadapters/user_management.go
+++ b/adp/execution-factory/operator-integration/server/drivenadapters/user_management.go
@@ -39,12 +39,14 @@ func NewUserManagementClient() interfaces.UserManagement {
 	}
 	syncOnce.Do(func() {
 		conf := config.NewConfigLoader()
-		um = &userManagementClient{
-			baseURL: fmt.Sprintf("%s://%s:%d/api/user-management", conf.UserMgnt.PrivateProtocol,
-				conf.UserMgnt.PrivateHost, conf.UserMgnt.PrivatePort),
-			logger:     conf.GetLogger(),
-			httpClient: rest.NewHTTPClient(),
-		}
+		um = selectUserManagement(func() interfaces.UserManagement {
+			return &userManagementClient{
+				baseURL: fmt.Sprintf("%s://%s:%d/api/user-management", conf.UserMgnt.PrivateProtocol,
+					conf.UserMgnt.PrivateHost, conf.UserMgnt.PrivatePort),
+				logger:     conf.GetLogger(),
+				httpClient: rest.NewHTTPClient(),
+			}
+		}, conf.GetLogger())
 	})
 	return um
 }

--- a/adp/execution-factory/operator-integration/server/drivenadapters/user_management_safe.go
+++ b/adp/execution-factory/operator-integration/server/drivenadapters/user_management_safe.go
@@ -1,0 +1,178 @@
+package drivenadapters
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"os"
+	"time"
+
+	"github.com/openbkn-ai/adp/execution-factory/operator-integration/server/interfaces"
+	"github.com/openbkn-ai/adp/execution-factory/operator-integration/server/utils"
+)
+
+// bkn-safe user-directory adapter + cutover switch for exec-factory.
+//
+// The ISF user-management service is retired; its replacement is bkn-safe's
+// directory API (/api/safe/v1/directory). The switch reuses the authz cutover
+// envs (see authorization_safe.go) so one flip moves both surfaces:
+//   - AUTHZ_PROVIDER != "bkn-safe" : ISF user-management (legacy default)
+//   - AUTHZ_PROVIDER == "bkn-safe" : bkn-safe directory at BKN_SAFE_URL
+//
+// Mapping (ISF -> bkn-safe):
+//   GET /v1/users/<ids>/<fields>  -> POST /api/safe/v1/directory/users-detail
+//   GET /v1/apps/<id>             -> POST /api/safe/v1/directory/names (app_ids)
+
+type safeUserManagement struct {
+	baseURL string
+	http    *http.Client
+	logger  interfaces.Logger
+}
+
+func newSafeUserManagement(baseURL string, logger interfaces.Logger) *safeUserManagement {
+	return &safeUserManagement{baseURL: baseURL, http: &http.Client{Timeout: 5 * time.Second}, logger: logger}
+}
+
+// safeUserDetail is the subset of bkn-safe's directory UserFull this adapter reads.
+type safeUserDetail struct {
+	ID      string   `json:"id"`
+	Account string   `json:"account"`
+	Name    string   `json:"name"`
+	Roles   []string `json:"roles"`
+}
+
+// GetUsersInfo returns the directory record for each EXISTING user id (missing
+// ids are omitted, matching the happy-path ISF behaviour). The fields argument
+// is ignored: bkn-safe returns the full record and callers pick what they need.
+func (s *safeUserManagement) GetUsersInfo(ctx context.Context, userIDs, fields []string) (infos []*interfaces.UserInfo, err error) {
+	infos = []*interfaces.UserInfo{}
+	userIDs = utils.UniqueStrings(userIDs)
+	if len(userIDs) == 0 {
+		return infos, nil
+	}
+	var out struct {
+		Users []safeUserDetail `json:"users"`
+	}
+	if err = s.post(ctx, "/api/safe/v1/directory/users-detail", map[string]any{"user_ids": userIDs}, &out); err != nil {
+		s.logger.WithContext(ctx).Warnf("[bkn-safe] users-detail failed: %v", err)
+		return nil, err
+	}
+	for _, u := range out.Users {
+		infos = append(infos, &interfaces.UserInfo{
+			UserID:      u.ID,
+			DisplayName: u.Name,
+			Account:     u.Account,
+			Roles:       u.Roles,
+		})
+	}
+	return infos, nil
+}
+
+func (s *safeUserManagement) GetUserInfo(ctx context.Context, userID string, fields ...string) (info *interfaces.UserInfo, err error) {
+	infos, err := s.GetUsersInfo(ctx, []string{userID}, fields)
+	if err != nil {
+		return nil, err
+	}
+	if len(infos) == 0 {
+		s.logger.WithContext(ctx).Errorf("GetUserInfo failed, user %s info not found", userID)
+		return nil, fmt.Errorf("user %s info not found", userID)
+	}
+	return infos[0], nil
+}
+
+// GetUsersName resolves display names; unknown ids degrade to UnknownUser so
+// audit/list rendering never fails on a deleted account (ISF 404-loop parity).
+func (s *safeUserManagement) GetUsersName(ctx context.Context, userIDs []string) (userMap map[string]string, err error) {
+	userMap = make(map[string]string)
+	lookup := make([]string, 0, len(userIDs))
+	for _, id := range utils.UniqueStrings(userIDs) {
+		if id == interfaces.SystemUser {
+			userMap[id] = interfaces.SystemUser
+			continue
+		}
+		lookup = append(lookup, id)
+	}
+	if len(lookup) == 0 {
+		return userMap, nil
+	}
+	infos, err := s.GetUsersInfo(ctx, lookup, []string{interfaces.DisplayName})
+	if err != nil {
+		return nil, err
+	}
+	for _, info := range infos {
+		userMap[info.UserID] = info.DisplayName
+	}
+	for _, id := range lookup {
+		if _, ok := userMap[id]; !ok {
+			userMap[id] = interfaces.UnknownUser
+		}
+	}
+	return userMap, nil
+}
+
+// GetAppInfo resolves an app account name via the directory names endpoint.
+// Unknown ids fall back to the id itself (same degradation as the noop client).
+func (s *safeUserManagement) GetAppInfo(ctx context.Context, appID string) (appInfo *interfaces.AppInfo, err error) {
+	var out struct {
+		AppNames []struct {
+			ID   string `json:"id"`
+			Name string `json:"name"`
+		} `json:"app_names"`
+	}
+	if err = s.post(ctx, "/api/safe/v1/directory/names", map[string]any{"app_ids": []string{appID}}, &out); err != nil {
+		s.logger.WithContext(ctx).Warnf("[bkn-safe] app name lookup failed: %v", err)
+		return nil, err
+	}
+	appInfo = &interfaces.AppInfo{ID: appID, Name: appID}
+	for _, a := range out.AppNames {
+		if a.ID == appID && a.Name != "" {
+			appInfo.Name = a.Name
+		}
+	}
+	return appInfo, nil
+}
+
+func (s *safeUserManagement) post(ctx context.Context, path string, body, out any) error {
+	b, _ := json.Marshal(body)
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, s.baseURL+path, bytes.NewReader(b))
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := s.http.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	data, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return fmt.Errorf("bkn-safe POST %s: %d: %s", path, resp.StatusCode, data)
+	}
+	if out != nil && len(data) > 0 {
+		return json.Unmarshal(data, out)
+	}
+	return nil
+}
+
+// selectUserManagement applies the bkn-safe cutover switch (same envs as
+// selectAuthz). Default/unset => the legacy ISF client built by the caller.
+func selectUserManagement(isf func() interfaces.UserManagement, logger interfaces.Logger) interfaces.UserManagement {
+	if os.Getenv("AUTHZ_PROVIDER") != "bkn-safe" {
+		return isf()
+	}
+	baseURL := os.Getenv("BKN_SAFE_URL")
+	if baseURL == "" {
+		logger.Warnf("[user-mgnt] AUTHZ_PROVIDER=bkn-safe but BKN_SAFE_URL empty; falling back to ISF")
+		return isf()
+	}
+	if _, err := url.Parse(baseURL); err != nil {
+		logger.Warnf("[user-mgnt] invalid BKN_SAFE_URL %q (%v); falling back to ISF", baseURL, err)
+		return isf()
+	}
+	logger.Infof("[user-mgnt] provider=bkn-safe directory at %s", baseURL)
+	return newSafeUserManagement(baseURL, logger)
+}

--- a/adp/execution-factory/operator-integration/server/drivenadapters/user_management_safe_test.go
+++ b/adp/execution-factory/operator-integration/server/drivenadapters/user_management_safe_test.go
@@ -1,0 +1,128 @@
+package drivenadapters
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/openbkn-ai/adp/execution-factory/operator-integration/server/interfaces"
+)
+
+type testLogger struct{}
+
+func (testLogger) Debug(...interface{})                             {}
+func (testLogger) Info(...interface{})                              {}
+func (testLogger) Warn(...interface{})                              {}
+func (testLogger) Error(...interface{})                             {}
+func (testLogger) Debugf(string, ...interface{})                    {}
+func (testLogger) Infof(string, ...interface{})                     {}
+func (testLogger) Warnf(string, ...interface{})                     {}
+func (testLogger) Errorf(string, ...interface{})                    {}
+func (l testLogger) WithContext(context.Context) interfaces.Logger  { return l }
+
+// fakeDirectory serves the two bkn-safe directory endpoints the adapter uses,
+// with one known user (u1/Alice) and one known app (app1/MES).
+func fakeDirectory(t *testing.T) *httptest.Server {
+	t.Helper()
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/safe/v1/directory/users-detail", func(w http.ResponseWriter, r *http.Request) {
+		var req struct {
+			UserIDs []string `json:"user_ids"`
+		}
+		_ = json.NewDecoder(r.Body).Decode(&req)
+		users := []map[string]any{}
+		for _, id := range req.UserIDs {
+			if id == "u1" {
+				users = append(users, map[string]any{
+					"id": "u1", "name": "Alice", "account": "alice", "roles": []string{"role-x"},
+				})
+			}
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{"users": users})
+	})
+	mux.HandleFunc("/api/safe/v1/directory/names", func(w http.ResponseWriter, r *http.Request) {
+		var req struct {
+			AppIDs []string `json:"app_ids"`
+		}
+		_ = json.NewDecoder(r.Body).Decode(&req)
+		apps := []map[string]string{}
+		for _, id := range req.AppIDs {
+			if id == "app1" {
+				apps = append(apps, map[string]string{"id": "app1", "name": "MES"})
+			}
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{"app_names": apps})
+	})
+	return httptest.NewServer(mux)
+}
+
+func TestSafeUserManagement(t *testing.T) {
+	srv := fakeDirectory(t)
+	defer srv.Close()
+	ctx := context.Background()
+	s := newSafeUserManagement(srv.URL, testLogger{})
+
+	t.Run("GetUsersInfo returns only existing users", func(t *testing.T) {
+		infos, err := s.GetUsersInfo(ctx, []string{"u1", "ghost"}, nil)
+		if err != nil {
+			t.Fatalf("GetUsersInfo: %v", err)
+		}
+		if len(infos) != 1 || infos[0].UserID != "u1" || infos[0].DisplayName != "Alice" ||
+			infos[0].Account != "alice" || len(infos[0].Roles) != 1 {
+			t.Fatalf("infos = %+v", infos)
+		}
+	})
+
+	t.Run("GetUserInfo errors on missing user", func(t *testing.T) {
+		if _, err := s.GetUserInfo(ctx, "ghost"); err == nil {
+			t.Fatal("expected error for missing user")
+		}
+		info, err := s.GetUserInfo(ctx, "u1")
+		if err != nil || info.DisplayName != "Alice" {
+			t.Fatalf("info = %+v err = %v", info, err)
+		}
+	})
+
+	t.Run("GetUsersName degrades missing ids and keeps SystemUser", func(t *testing.T) {
+		m, err := s.GetUsersName(ctx, []string{"u1", "ghost", interfaces.SystemUser})
+		if err != nil {
+			t.Fatalf("GetUsersName: %v", err)
+		}
+		if m["u1"] != "Alice" || m["ghost"] != interfaces.UnknownUser || m[interfaces.SystemUser] != interfaces.SystemUser {
+			t.Fatalf("map = %v", m)
+		}
+	})
+
+	t.Run("GetAppInfo resolves name with id fallback", func(t *testing.T) {
+		a, err := s.GetAppInfo(ctx, "app1")
+		if err != nil || a.Name != "MES" {
+			t.Fatalf("app = %+v err = %v", a, err)
+		}
+		a, err = s.GetAppInfo(ctx, "unknown-app")
+		if err != nil || a.Name != "unknown-app" {
+			t.Fatalf("fallback app = %+v err = %v", a, err)
+		}
+	})
+}
+
+func TestSelectUserManagement(t *testing.T) {
+	isf := func() interfaces.UserManagement { return &noopUserManagementClient{} }
+
+	t.Setenv("AUTHZ_PROVIDER", "")
+	if _, ok := selectUserManagement(isf, testLogger{}).(*noopUserManagementClient); !ok {
+		t.Fatal("unset provider should keep ISF client")
+	}
+
+	t.Setenv("AUTHZ_PROVIDER", "bkn-safe")
+	t.Setenv("BKN_SAFE_URL", "")
+	if _, ok := selectUserManagement(isf, testLogger{}).(*noopUserManagementClient); !ok {
+		t.Fatal("empty BKN_SAFE_URL should fall back to ISF client")
+	}
+
+	t.Setenv("BKN_SAFE_URL", "http://bkn-safe:3000")
+	if _, ok := selectUserManagement(isf, testLogger{}).(*safeUserManagement); !ok {
+		t.Fatal("bkn-safe provider should select the directory adapter")
+	}
+}

--- a/decision-agent/agent-backend/deploy/helm/agent-backend/values.yaml
+++ b/decision-agent/agent-backend/deploy/helm/agent-backend/values.yaml
@@ -105,12 +105,13 @@ depServices:
     userMgnt:
       host: user-management-private
       port: 30980
-    # ISF replacement: introspect/token against bkn-safe's paired hydra (cross-ns).
+    # ISF replacement: introspect/token against bkn-safe's paired hydra
+    # (same-namespace short names; the product installs everything into one ns).
     hydraPublic:
-      host: bkn-safe-hydra-public.bkn-safe
+      host: bkn-safe-hydra-public
       port: 4444
     hydraAdmin:
-      host: bkn-safe-hydra-admin.bkn-safe
+      host: bkn-safe-hydra-admin
       port: 4445
   # 数据库连接配置
   rds:


### PR DESCRIPTION
## Summary

Two leftovers from the ISF → bkn-safe cutover that break real deployments:

1. **execution-factory / operator-integration** still resolved user and app names via the retired ISF `user-management-private:30980`, so `skill register` (and any path that renders a creator name) 500s with a DNS error on every post-cutover deployment. Add `user_management_safe.go`: a bkn-safe directory adapter (`/api/safe/v1/directory/users-detail` + `/names`) behind the **same cutover switch as authz** (`AUTHZ_PROVIDER=bkn-safe` + `BKN_SAFE_URL`). Default stays on the legacy ISF client — fully revertible by flipping the env.
2. **agent-backend chart** hardcoded cross-namespace hydra hosts (`bkn-safe-hydra-{public,admin}.bkn-safe`), while the product installs bkn-safe into the same namespace — token introspection failed with NXDOMAIN. Use same-namespace short names, matching bkn-backend/ontology-query.

## Semantics preserved (vs the ISF client)

- `GetUsersName`: unknown ids degrade to `UnknownUser` (ISF 404-loop parity); `SystemUser` passthrough.
- `GetUserInfo`: missing user is an error.
- `GetAppInfo`: unknown app falls back to the id (same as the noop client).

## Testing

- New hermetic unit tests (httptest fake of the directory endpoints) cover all four interface methods plus the provider switch — pass.
- `go build ./... && go test ./server/...`: only pre-existing failure is `tests/local` `TestAPIMetadataAnalysis`, which fails identically on a clean tree.
- Live VM verification: the same flow previously failed with `dial tcp: lookup user-management-private`; with a directory-backed shim standing in for this adapter, skill register / publish and the full example 05 pipeline pass, and the hydra short-name fix is what made `agent create` work (was 401 + NXDOMAIN).

🤖 Generated with [Claude Code](https://claude.com/claude-code)