### PR TITLE
fix(vega): build workers run downstream calls as the task creator

### DIFF
--- a/adp/vega/vega-backend/server/worker/build_handler_account_test.go
+++ b/adp/vega/vega-backend/server/worker/build_handler_account_test.go
@@ -1,0 +1,131 @@
+// Copyright 2026 openbkn.ai
+// Copyright The kweaver.ai Authors.
+//
+// Licensed under the Apache License, Version 2.0.
+// See the LICENSE file in the project root for details.
+
+package worker
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/bytedance/sonic"
+	"github.com/hibiken/asynq"
+	"go.uber.org/mock/gomock"
+
+	"vega-backend/interfaces"
+	vmock "vega-backend/interfaces/mock"
+)
+
+// 复现 bug：worker 异步执行构建任务时，必须把任务创建者(Creator)回填进 ctx，
+// 否则下游带权限检查的服务(如 CatalogService.GetByID)会报
+// "Access denied: missing account ID or type"。
+
+var testCreator = interfaces.AccountInfo{ID: "u1", Type: "user"}
+
+func accountFromCtx(ctx context.Context) (interfaces.AccountInfo, bool) {
+	ai, ok := ctx.Value(interfaces.ACCOUNT_INFO_KEY).(interfaces.AccountInfo)
+	return ai, ok
+}
+
+func newBuildTaskPayload(t *testing.T, msg any) []byte {
+	t.Helper()
+	payload, err := sonic.Marshal(msg)
+	if err != nil {
+		t.Fatalf("marshal task message failed: %v", err)
+	}
+	return payload
+}
+
+func TestBatchBuildHandlerInjectsCreatorIntoCtx(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	taskAccess := vmock.NewMockBuildTaskAccess(ctrl)
+	resAccess := vmock.NewMockResourceAccess(ctrl)
+	cs := vmock.NewMockCatalogService(ctrl)
+	bh := &batchBuildHandler{taskAccess: taskAccess, resAccess: resAccess, cs: cs}
+
+	taskAccess.EXPECT().GetByID(gomock.Any(), "t1").Return(&interfaces.BuildTask{
+		ID: "t1", ResourceID: "r1", Status: interfaces.BuildTaskStatusRunning, Creator: testCreator,
+	}, nil)
+	resAccess.EXPECT().GetByID(gomock.Any(), "r1").Return(&interfaces.Resource{ID: "r1", CatalogID: "c1"}, nil)
+	taskAccess.EXPECT().UpdateStatus(gomock.Any(), "t1", gomock.Any()).Return(nil).AnyTimes()
+
+	var gotAccount interfaces.AccountInfo
+	var hasAccount bool
+	cs.EXPECT().GetByID(gomock.Any(), "c1", true).DoAndReturn(
+		func(ctx context.Context, id string, withSensitiveFields bool) (*interfaces.Catalog, error) {
+			gotAccount, hasAccount = accountFromCtx(ctx)
+			return nil, errors.New("forbidden")
+		})
+
+	task := asynq.NewTask("build:batch", newBuildTaskPayload(t, interfaces.BatchBuildTaskMessage{TaskID: "t1"}))
+	if err := bh.HandleTask(context.Background(), task); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !hasAccount || gotAccount != testCreator {
+		t.Fatalf("expected creator %+v injected into ctx when calling catalog service, got %+v (present=%v)",
+			testCreator, gotAccount, hasAccount)
+	}
+}
+
+func TestStreamingBuildHandlerInjectsCreatorIntoCtx(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	taskAccess := vmock.NewMockBuildTaskAccess(ctrl)
+	resAccess := vmock.NewMockResourceAccess(ctrl)
+	cs := vmock.NewMockCatalogService(ctrl)
+	sh := &streamingBuildHandler{taskAccess: taskAccess, resAccess: resAccess, cs: cs}
+
+	taskAccess.EXPECT().GetByID(gomock.Any(), "t1").Return(&interfaces.BuildTask{
+		ID: "t1", ResourceID: "r1", Status: interfaces.BuildTaskStatusRunning, Creator: testCreator,
+	}, nil)
+	resAccess.EXPECT().GetByID(gomock.Any(), "r1").Return(&interfaces.Resource{ID: "r1", CatalogID: "c1"}, nil)
+
+	var gotAccount interfaces.AccountInfo
+	var hasAccount bool
+	cs.EXPECT().GetByID(gomock.Any(), "c1", true).DoAndReturn(
+		func(ctx context.Context, id string, withSensitiveFields bool) (*interfaces.Catalog, error) {
+			gotAccount, hasAccount = accountFromCtx(ctx)
+			return nil, errors.New("forbidden")
+		})
+
+	task := asynq.NewTask("build:streaming", newBuildTaskPayload(t, interfaces.StreamingBuildTaskMessage{TaskID: "t1"}))
+	err := sh.HandleTask(context.Background(), task)
+	if err == nil || !strings.Contains(err.Error(), "get catalog failed") {
+		t.Fatalf("expected get catalog failed error, got %v", err)
+	}
+	if !hasAccount || gotAccount != testCreator {
+		t.Fatalf("expected creator %+v injected into ctx when calling catalog service, got %+v (present=%v)",
+			testCreator, gotAccount, hasAccount)
+	}
+}
+
+func TestEmbeddingHandlerInjectsCreatorIntoCtx(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	taskAccess := vmock.NewMockBuildTaskAccess(ctrl)
+	resAccess := vmock.NewMockResourceAccess(ctrl)
+	eh := &embeddingHandler{taskAccess: taskAccess, resAccess: resAccess}
+
+	taskAccess.EXPECT().GetByID(gomock.Any(), "t1").Return(&interfaces.BuildTask{
+		ID: "t1", ResourceID: "r1", Status: interfaces.BuildTaskStatusRunning, Creator: testCreator,
+	}, nil)
+
+	var gotAccount interfaces.AccountInfo
+	var hasAccount bool
+	resAccess.EXPECT().GetByID(gomock.Any(), "r1").DoAndReturn(
+		func(ctx context.Context, id string) (*interfaces.Resource, error) {
+			gotAccount, hasAccount = accountFromCtx(ctx)
+			return nil, nil
+		})
+
+	task := asynq.NewTask("build:embedding", newBuildTaskPayload(t, interfaces.EmbeddingBuildTaskMessage{TaskID: "t1"}))
+	if err := eh.HandleTask(context.Background(), task); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !hasAccount || gotAccount != testCreator {
+		t.Fatalf("expected creator %+v injected into ctx after loading task, got %+v (present=%v)",
+			testCreator, gotAccount, hasAccount)
+	}
+}

--- a/adp/vega/vega-backend/server/worker/build_handler_batch.go
+++ b/adp/vega/vega-backend/server/worker/build_handler_batch.go
@@ -69,6 +69,8 @@ func (bh *batchBuildHandler) HandleTask(ctx context.Context, task *asynq.Task) e
 		// Task not found, return nil
 		return nil
 	}
+	// 异步任务无原始请求上下文，以任务创建者身份执行下游权限检查
+	ctx = context.WithValue(ctx, interfaces.ACCOUNT_INFO_KEY, buildTaskInfo.Creator)
 	resourceID := buildTaskInfo.ResourceID
 	logger.Infof("Starting build for task: %s, resource: %s", taskID, resourceID)
 

--- a/adp/vega/vega-backend/server/worker/build_handler_embedding.go
+++ b/adp/vega/vega-backend/server/worker/build_handler_embedding.go
@@ -82,6 +82,8 @@ func (eh *embeddingHandler) HandleTask(ctx context.Context, task *asynq.Task) er
 		// Task not found, return nil
 		return nil
 	}
+	// 异步任务无原始请求上下文，以任务创建者身份执行下游权限检查
+	ctx = context.WithValue(ctx, interfaces.ACCOUNT_INFO_KEY, buildTaskInfo.Creator)
 	logger.Infof("Starting embedding for task: %s, resource: %s", taskID, buildTaskInfo.ResourceID)
 
 	// Get resource info

--- a/adp/vega/vega-backend/server/worker/build_handler_streaming.go
+++ b/adp/vega/vega-backend/server/worker/build_handler_streaming.go
@@ -87,6 +87,8 @@ func (sh *streamingBuildHandler) HandleTask(ctx context.Context, task *asynq.Tas
 		// Task not found, return nil
 		return nil
 	}
+	// 异步任务无原始请求上下文，以任务创建者身份执行下游权限检查
+	ctx = context.WithValue(ctx, interfaces.ACCOUNT_INFO_KEY, buildTaskInfo.Creator)
 	resourceID := buildTaskInfo.ResourceID
 	logger.Infof("Starting build for task: %s, resource: %s", taskID, resourceID)
 


### PR DESCRIPTION
## Summary
- Async build handlers (batch / streaming / embedding) executed with no account context, so every index build failed at `CatalogService.GetByID` with `Access denied: missing account ID or type` (the error recorded in build-task `error_msg`; tasks stayed `running` at 0 synced / 0 vectorized)
- The task creator is already persisted on the build task — inject `buildTaskInfo.Creator` into ctx (`ACCOUNT_INFO_KEY`) at the top of each `HandleTask` so downstream permission-checked calls run as the creator
- Add `build_handler_account_test.go` reproducing the bug: asserts the catalog call receives the creator account from ctx for all three handlers

## Test plan
- [x] `go test ./worker/...` passes
- [ ] Redeploy + retrigger the 7 stuck build tasks on the validation VM and confirm sync/vectorize progress

🤖 Generated with [Claude Code](https://claude.com/claude-code)