### PR TITLE
fix(bkn-safe): public root-department grants + role-binding validation

### DIFF
--- a/bkn-safe/server/internal/authz/authz.go
+++ b/bkn-safe/server/internal/authz/authz.go
@@ -24,6 +24,12 @@ import (
 //
 //	r = sub, obj, act   sub=accessorID, obj="type:id", act=operation
 //	g = _, _            user/app -> role (UUID-preserved)
+//
+// The matcher also accepts policies whose subject is PublicAccessorID: ISF's
+// "grant to the root department = everyone" convention. bkn-safe keeps no
+// user→department g rules (membership lives in relational tables only), so a
+// root-department grant would otherwise never match any requester; instead the
+// matcher treats it as a public grant, scoped as usual by object and act.
 const modelConf = `
 [request_definition]
 r = sub, obj, act
@@ -38,8 +44,14 @@ g = _, _
 e = some(where (p.eft == allow))
 
 [matchers]
-m = g(r.sub, p.sub) && keyMatch(r.obj, p.obj) && (p.act == "*" || r.act == p.act)
+m = (g(r.sub, p.sub) || p.sub == "` + PublicAccessorID + `") && keyMatch(r.obj, p.obj) && (p.act == "*" || r.act == p.act)
 `
+
+// PublicAccessorID is the root-department accessor: a policy granted to this
+// subject applies to every requester (see modelConf). The UUID is the ISF root
+// department id, written by e.g. execution-factory's CreateIntCompPolicyForAllUsers
+// (interfaces.AccessorRootDepartmentID) for built-in toolbox public access.
+const PublicAccessorID = "00000000-0000-0000-0000-000000000000"
 
 // ActAll is the wildcard act: a policy with act "*" grants every operation on
 // the matched object (used for the super-admin "do everything" grant).

--- a/bkn-safe/server/internal/authz/authz_test.go
+++ b/bkn-safe/server/internal/authz/authz_test.go
@@ -60,6 +60,39 @@ func TestRoleGrantAndWildcard(t *testing.T) {
 	}
 }
 
+// TestPublicAccessorGrant covers the root-department-as-everyone convention:
+// a policy whose subject is PublicAccessorID matches ANY requesting subject,
+// scoped strictly to the granted object and op (ISF "grant to root department
+// = public" semantics; bkn-safe has no user→department g rules, so this is
+// resolved in the matcher instead).
+func TestPublicAccessorGrant(t *testing.T) {
+	e := newTestEnforcer(t)
+	mustNoErr(t, e.GrantObjectPermission(PublicAccessorID, "tool_box", "tb1", "public_access"))
+	mustNoErr(t, e.GrantObjectPermission(PublicAccessorID, "tool_box", "tb1", "execute"))
+
+	cases := []struct {
+		sub, typ, id, op string
+		want             bool
+		why              string
+	}{
+		{"u-anyone", "tool_box", "tb1", "public_access", true, "public grant matches any subject"},
+		{"u-anyone", "tool_box", "tb1", "execute", true, "public grant matches any subject"},
+		{"u-anyone", "tool_box", "tb1", "delete", false, "ungranted op must stay denied"},
+		{"u-anyone", "tool_box", "tb2", "execute", false, "public grant must not leak to sibling object"},
+		{"u-anyone", "agent", "tb1", "execute", false, "public grant must not leak to other type"},
+		{PublicAccessorID, "tool_box", "tb1", "execute", true, "the public subject itself still matches"},
+	}
+	for _, c := range cases {
+		got, err := e.Check(c.sub, c.typ, c.id, c.op)
+		if err != nil {
+			t.Fatalf("check(%s,%s:%s,%s): %v", c.sub, c.typ, c.id, c.op, err)
+		}
+		if got != c.want {
+			t.Errorf("Check(%s, %s:%s, %s) = %v, want %v — %s", c.sub, c.typ, c.id, c.op, got, c.want, c.why)
+		}
+	}
+}
+
 // TestAllowedOps mirrors ISF resource-operation: returns the allowed subset.
 func TestAllowedOps(t *testing.T) {
 	e := newTestEnforcer(t)

--- a/bkn-safe/server/internal/httpapi/admin_test.go
+++ b/bkn-safe/server/internal/httpapi/admin_test.go
@@ -363,7 +363,9 @@ func TestDepartmentDetailAndMembers(t *testing.T) {
 }
 
 func TestRoleBindingsListAndUnbind(t *testing.T) {
-	r, e, _, _ := newAdminServer(t)
+	r, e, db, _ := newAdminServer(t)
+	db.Create(&model.User{ID: "u-1", Account: "u1", Name: "U1", Enabled: true})
+	db.Create(&model.Role{ID: "r-a", Name: "RoleA", Source: model.RoleSourceCustom})
 
 	if w := adminReq(t, r, http.MethodPost, "/api/safe/v1/admin/role-bindings",
 		map[string]any{"accessor_id": "u-1", "role_id": "r-a"}); w.Code != http.StatusNoContent {
@@ -392,5 +394,40 @@ func TestRoleBindingsListAndUnbind(t *testing.T) {
 
 	if w := adminReq(t, r, http.MethodGet, "/api/safe/v1/admin/role-bindings", nil); w.Code != http.StatusBadRequest {
 		t.Errorf("missing accessor_id: want 400, got %d", w.Code)
+	}
+}
+
+// Binding must reference an existing accessor (user/department/group) and an
+// existing role — a typo'd accessor (e.g. an account NAME instead of its ID)
+// must fail loudly, not 204 into a grant that never matches at enforce time.
+func TestRoleBindingValidatesAccessorAndRole(t *testing.T) {
+	r, _, db, _ := newAdminServer(t)
+	db.Create(&model.User{ID: "u-real", Account: "real", Name: "Real", Enabled: true})
+	db.Create(&model.Role{ID: "r-real", Name: "RoleReal", Source: model.RoleSourceCustom})
+
+	// account name passed where the user ID belongs -> 400
+	if w := adminReq(t, r, http.MethodPost, "/api/safe/v1/admin/role-bindings",
+		map[string]any{"accessor_id": "real", "role_id": "r-real"}); w.Code != http.StatusBadRequest {
+		t.Errorf("unknown accessor: want 400, got %d (%s)", w.Code, w.Body.String())
+	}
+	// unknown role -> 400
+	if w := adminReq(t, r, http.MethodPost, "/api/safe/v1/admin/role-bindings",
+		map[string]any{"accessor_id": "u-real", "role_id": "r-ghost"}); w.Code != http.StatusBadRequest {
+		t.Errorf("unknown role: want 400, got %d (%s)", w.Code, w.Body.String())
+	}
+	// both valid -> 204
+	if w := adminReq(t, r, http.MethodPost, "/api/safe/v1/admin/role-bindings",
+		map[string]any{"accessor_id": "u-real", "role_id": "r-real"}); w.Code != http.StatusNoContent {
+		t.Errorf("valid bind: want 204, got %d (%s)", w.Code, w.Body.String())
+	}
+
+	// department and group accessors are also valid binding subjects
+	db.Create(&model.Department{ID: "d-1", Name: "Dept"})
+	db.Create(&model.Group{ID: "g-1", Name: "Group"})
+	for _, id := range []string{"d-1", "g-1"} {
+		if w := adminReq(t, r, http.MethodPost, "/api/safe/v1/admin/role-bindings",
+			map[string]any{"accessor_id": id, "role_id": "r-real"}); w.Code != http.StatusNoContent {
+			t.Errorf("bind %s: want 204, got %d (%s)", id, w.Code, w.Body.String())
+		}
 	}
 }

--- a/bkn-safe/server/internal/httpapi/authz.go
+++ b/bkn-safe/server/internal/httpapi/authz.go
@@ -153,14 +153,36 @@ func registerAuthz(r *gin.Engine, e *authz.Enforcer, db *gorm.DB) {
 
 // registerRoleBindings mounts the accessor↔role binding endpoints (bind / list /
 // unbind). Admin-only — mounted under the /admin group behind RequireAdmin.
-func registerRoleBindings(g *gin.RouterGroup, e *authz.Enforcer) {
+func registerRoleBindings(g *gin.RouterGroup, e *authz.Enforcer, db *gorm.DB) {
 	// POST /role-bindings — bind an accessor to a role. { accessor_id, role_id }
+	// Both ids must reference existing rows: casbin stores the strings verbatim,
+	// so a typo'd accessor (e.g. an account name instead of its ID) would 204
+	// into a grant that never matches at enforce time.
 	g.POST("/role-bindings", func(c *gin.Context) {
 		var req struct {
 			AccessorID string `json:"accessor_id" binding:"required"`
 			RoleID     string `json:"role_id" binding:"required"`
 		}
 		if !bind(c, &req) {
+			return
+		}
+		ok, err := accessorExists(c, db, req.AccessorID)
+		if err != nil {
+			serverError(c, err)
+			return
+		}
+		if !ok {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "accessor_id does not match any user, department or group id: " + req.AccessorID})
+			return
+		}
+		var n int64
+		if err := db.WithContext(c.Request.Context()).Model(&model.Role{}).
+			Where("id = ?", req.RoleID).Count(&n).Error; err != nil {
+			serverError(c, err)
+			return
+		}
+		if n == 0 {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "role_id does not match any role id: " + req.RoleID})
 			return
 		}
 		if err := e.AssignRole(req.AccessorID, req.RoleID); err != nil {
@@ -452,6 +474,22 @@ func splitObject(o string) (rtype, rid string) {
 		}
 	}
 	return o, ""
+}
+
+// accessorExists reports whether the id is a known binding subject: a user,
+// department or group id.
+func accessorExists(c *gin.Context, db *gorm.DB, id string) (bool, error) {
+	ctx := c.Request.Context()
+	for _, m := range []any{&model.User{}, &model.Department{}, &model.Group{}} {
+		var n int64
+		if err := db.WithContext(ctx).Model(m).Where("id = ?", id).Count(&n).Error; err != nil {
+			return false, err
+		}
+		if n > 0 {
+			return true, nil
+		}
+	}
+	return false, nil
 }
 
 // catalogOps returns the operation ids registered for a resource type.

--- a/bkn-safe/server/internal/httpapi/router.go
+++ b/bkn-safe/server/internal/httpapi/router.go
@@ -65,7 +65,7 @@ func New(deps Deps) *gin.Engine {
 		registerUserAdmin(admin, deps.Users, deps.Enforcer)
 		registerAdminReads(admin, deps.Directory)
 		registerDeptAdmin(admin, deps.Directory)
-		registerRoleBindings(admin, deps.Enforcer)
+		registerRoleBindings(admin, deps.Enforcer, deps.DB)
 		registerRoles(admin, deps.Enforcer, deps.DB)
 	}
 


### PR DESCRIPTION
## Summary
Two authz fixes:

- **Root-department grants were dead rules.** ISF's convention grants "everyone" access by writing a policy for the root department (all-zero UUID) — e.g. execution-factory's `CreateIntCompPolicyForAllUsers` for built-in toolbox public access. bkn-safe keeps no user→department `g` rules (membership lives in relational tables only), so those policies never matched any requester. The casbin matcher now treats `PublicAccessorID` policies as public grants, still scoped by object and act.
- **`POST /admin/role-bindings` accepted nonexistent ids.** casbin stores subjects verbatim, so binding a typo'd accessor (e.g. an account *name* instead of its ID) returned 204 but produced a grant that never matches at enforce time. Both `accessor_id` (user / department / group) and `role_id` are now validated against the directory — 400 on unknown ids.

## Test plan
- [x] `go test ./internal/authz/... ./internal/httpapi/...` passes (new: `TestPublicAccessorGrant`, `TestRoleBindingValidatesAccessorAndRole`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)