### PR TITLE
fix(vega): batch build cursor, embedding re-enqueue, build-task state machine

### DIFF
--- a/adp/docs/api/vega/vega-backend-api/build-task.yaml
+++ b/adp/docs/api/vega/vega-backend-api/build-task.yaml
@@ -231,13 +231,15 @@ paths:
     post:
       summary: 启动构建任务
       description: |
-        合法状态转移：`status ∈ {init, stopped}` → `running`。
+        合法状态转移：`status ∈ {init, stopped, completed, failed}` → `running`。
+        `failed` 允许重启：从 `synced_mark` 水位继续（batch incremental），
+        无需删除重建；worker 实际开始执行时会清空 `error_msg`。
 
         **响应 status 滞后**：HTTP 202 表示"启动指令已被接受并入队"，**不**表示
         status 已切换为 `running`。worker 实际执行时才会写为 `running`，
         客户端如需确认应轮询 GET。响应 body 为空。
 
-        **非幂等**：对已 running 的 task 再次 start 返回 409
+        **非幂等**：对已 running / stopping 的 task 再次 start 返回 409
         `VegaBackend.BuildTask.InvalidStateTransition`。
       requestBody:
         required: false
@@ -269,12 +271,15 @@ paths:
     post:
       summary: 停止构建任务
       description: |
-        合法状态转移：`status == running` → `stopping`。
+        合法状态转移：
+        - `running` → `stopping`：正常停止，worker 在批间检查点退出后写 `stopped`。
+        - `stopping` → `stopped`：强制完结。worker 已不在（重试耗尽 / 服务重启）时
+          `stopping` 不会被自动推进，再次调 stop 直接落停，使任务可删除。
 
         **响应 status 滞后**：HTTP 202 表示"停止指令已被记录"。`stopping → stopped`
         由 worker 异步推进，客户端可轮询 GET 拿最新 status。响应 body 为空。
 
-        **非幂等**：对非 running 状态的 task 调 stop 返回 409
+        **非幂等**：对非 running / stopping 状态的 task 调 stop 返回 409
         `VegaBackend.BuildTask.InvalidStateTransition`。
       responses:
         "202":

--- a/adp/vega/vega-backend/server/drivenadapters/resource/resource_access.go
+++ b/adp/vega/vega-backend/server/drivenadapters/resource/resource_access.go
@@ -385,8 +385,10 @@ func (ra *resourceAccess) AttachListExtensions(ctx context.Context, params inter
 	return attachResourceExtensions(ctx, ra.appSetting, params, resources)
 }
 
-// GetByIDsBasic retrieves Resources by IDs without parsing sourceMetadata, schemaDefinition and logicDefinition.
+// GetByIDsBasic retrieves Resources by IDs without fully parsing sourceMetadata, schemaDefinition and logicDefinition.
 // This method is optimized for memory usage when these large fields are not needed.
+// 仅从原始 JSON 中惰性提取规模信息（column_count/row_count），不反序列化完整结构；
+// 计数在 Go 侧完成以兼容多方言数据库（MariaDB/DM8/KDB9 等），不依赖 MySQL JSON 函数。
 func (ra *resourceAccess) GetByIDsBasic(ctx context.Context, ids []string) ([]*interfaces.Resource, error) {
 	ctx, span := oteltrace.StartNamedClientSpan(ctx, "Query resources by IDs (basic)")
 	defer span.End()
@@ -405,6 +407,8 @@ func (ra *resourceAccess) GetByIDsBasic(ctx context.Context, ids []string) ([]*i
 		"f_last_discover_status",
 		"f_database",
 		"f_source_identifier",
+		"f_source_metadata",
+		"f_schema_definition",
 		"f_logic_type",
 		"f_creator",
 		"f_creator_type",
@@ -433,7 +437,7 @@ func (ra *resourceAccess) GetByIDsBasic(ctx context.Context, ids []string) ([]*i
 	for rows.Next() {
 		resource := &interfaces.Resource{}
 		var tagsStr string
-		var database, sourceIdentifier sql.NullString
+		var database, sourceIdentifier, sourceMetadata, schemaDefinition sql.NullString
 
 		err := rows.Scan(
 			&resource.ID,
@@ -447,6 +451,8 @@ func (ra *resourceAccess) GetByIDsBasic(ctx context.Context, ids []string) ([]*i
 			&resource.LastDiscoverStatus,
 			&database,
 			&sourceIdentifier,
+			&sourceMetadata,
+			&schemaDefinition,
 			&resource.LogicType,
 			&resource.Creator.ID,
 			&resource.Creator.Type,
@@ -466,8 +472,22 @@ func (ra *resourceAccess) GetByIDsBasic(ctx context.Context, ids []string) ([]*i
 		resource.Tags = libCommon.TagString2TagSlice(tagsStr)
 		resource.Database = database.String
 		resource.SourceIdentifier = sourceIdentifier.String
-		// 不解析sourceMetadata、schemaDefinition和logicDefinition，以减少内存占用
-		// 这些字段在需要时可以单独获取
+		// 不反序列化sourceMetadata、schemaDefinition和logicDefinition的完整结构，以减少内存占用
+		// 仅惰性提取规模信息：列数（schema 顶层元素数）与源端行数估算（properties.row_count）
+		if schemaDefinition.Valid && schemaDefinition.String != "" {
+			if node, err := sonic.GetFromString(schemaDefinition.String); err == nil && node.Load() == nil {
+				if n, err := node.Len(); err == nil {
+					resource.ColumnCount = &n
+				}
+			}
+		}
+		if sourceMetadata.Valid && sourceMetadata.String != "" {
+			if node, err := sonic.GetFromString(sourceMetadata.String, "properties", "row_count"); err == nil {
+				if v, err := node.Int64(); err == nil {
+					resource.RowCount = &v
+				}
+			}
+		}
 
 		resources = append(resources, resource)
 	}

--- a/adp/vega/vega-backend/server/interfaces/resource.go
+++ b/adp/vega/vega-backend/server/interfaces/resource.go
@@ -62,6 +62,10 @@ type Resource struct {
 	SchemaDefinition []*Property    `json:"schema_definition,omitempty"` // Schema定义
 	LocalIndexName   string         `json:"index_name,omitempty"`        // 索引名称，由构建任务填充
 
+	// 规模信息：列表接口从原始 JSON 轻量计数得到，不反序列化完整结构；nil 表示源端无该信息（序列化时省略）
+	ColumnCount *int   `json:"column_count,omitempty"` // schema_definition 字段数
+	RowCount    *int64 `json:"row_count,omitempty"`    // 源端行数（最近一次 discover 的估算快照，仅部分资源类别有）
+
 	// Extensions 根级可检索业务 KV（t_entity_extension）；列表默认省略
 	Extensions map[string]string `json:"extensions,omitempty"`
 

--- a/adp/vega/vega-backend/server/logics/build_task/build_task_service.go
+++ b/adp/vega/vega-backend/server/logics/build_task/build_task_service.go
@@ -274,9 +274,11 @@ func (bts *buildTaskService) StartBuildTask(ctx context.Context, taskID string, 
 		span.SetStatus(codes.Error, "Build task not found")
 		return rest.NewHTTPError(ctx, http.StatusNotFound, verrors.VegaBackend_BuildTask_NotFound)
 	}
+	// failed 也允许重启：否则失败任务成死胡同，只能删除重建
 	if buildTask.Status != interfaces.BuildTaskStatusInit &&
 		buildTask.Status != interfaces.BuildTaskStatusStopped &&
-		buildTask.Status != interfaces.BuildTaskStatusCompleted {
+		buildTask.Status != interfaces.BuildTaskStatusCompleted &&
+		buildTask.Status != interfaces.BuildTaskStatusFailed {
 		span.SetStatus(codes.Error, "Invalid state transition for start")
 		return rest.NewHTTPError(ctx, http.StatusConflict, verrors.VegaBackend_BuildTask_InvalidStateTransition).
 			WithErrorDetails(fmt.Sprintf("cannot start task in status: %s", buildTask.Status))
@@ -344,14 +346,22 @@ func (bts *buildTaskService) StopBuildTask(ctx context.Context, taskID string) e
 		span.SetStatus(codes.Error, "Build task not found")
 		return rest.NewHTTPError(ctx, http.StatusNotFound, verrors.VegaBackend_BuildTask_NotFound)
 	}
-	if buildTask.Status != interfaces.BuildTaskStatusRunning {
+	if buildTask.Status != interfaces.BuildTaskStatusRunning &&
+		buildTask.Status != interfaces.BuildTaskStatusStopping {
 		span.SetStatus(codes.Error, "Invalid state transition for stop")
 		return rest.NewHTTPError(ctx, http.StatusConflict, verrors.VegaBackend_BuildTask_InvalidStateTransition).
 			WithErrorDetails(fmt.Sprintf("cannot stop task in status: %s", buildTask.Status))
 	}
 
+	// running → stopping：通知 worker 在批间检查点退出。
+	// stopping → stopped：兜底强制落停。worker 已不在（asynq 任务耗尽重试/服务重启）
+	// 时 stopping 永远不会被推进，任务卡死无法删除，二次 stop 即强制完结。
+	targetStatus := interfaces.BuildTaskStatusStopping
+	if buildTask.Status == interfaces.BuildTaskStatusStopping {
+		targetStatus = interfaces.BuildTaskStatusStopped
+	}
 	updates := map[string]any{
-		"status": interfaces.BuildTaskStatusStopping,
+		"status": targetStatus,
 	}
 	if err := bts.bta.UpdateStatus(ctx, taskID, updates); err != nil {
 		otellog.LogError(ctx, "Update build task status failed", err)

--- a/adp/vega/vega-backend/server/logics/build_task/build_task_service_test.go
+++ b/adp/vega/vega-backend/server/logics/build_task/build_task_service_test.go
@@ -73,3 +73,77 @@ func assertCatalogDisabledError(t *testing.T, err error) {
 		t.Fatalf("expected %s, got %s", verrors.VegaBackend_Catalog_IsDisabled, httpErr.BaseError.ErrorCode)
 	}
 }
+
+// failed 状态必须允许 start（否则失败任务只能删除重建）。
+// 借 catalog-disabled 错误证明状态检查已放行：若 failed 被状态机拒绝，
+// 错误将是 InvalidStateTransition 而非 Catalog_IsDisabled。
+func TestStartBuildTaskAllowsFailedStatus(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	mockCS := mock_interfaces.NewMockCatalogService(ctrl)
+	mockBTA := mock_interfaces.NewMockBuildTaskAccess(ctrl)
+	service := &buildTaskService{cs: mockCS, bta: mockBTA}
+
+	mockBTA.EXPECT().GetByID(gomock.Any(), "task-1").
+		Return(&interfaces.BuildTask{
+			ID:        "task-1",
+			CatalogID: "catalog-1",
+			Status:    interfaces.BuildTaskStatusFailed,
+		}, nil)
+	mockCS.EXPECT().GetByID(gomock.Any(), "catalog-1", false).
+		Return(&interfaces.Catalog{ID: "catalog-1", Enabled: false}, nil)
+
+	err := service.StartBuildTask(context.Background(), "task-1", interfaces.BuildTaskExecuteTypeIncremental)
+	assertCatalogDisabledError(t, err)
+}
+
+// running → stopping：正常停止路径。
+func TestStopBuildTaskRunningToStopping(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	mockBTA := mock_interfaces.NewMockBuildTaskAccess(ctrl)
+	service := &buildTaskService{bta: mockBTA}
+
+	mockBTA.EXPECT().GetByID(gomock.Any(), "task-1").
+		Return(&interfaces.BuildTask{ID: "task-1", Status: interfaces.BuildTaskStatusRunning}, nil)
+	mockBTA.EXPECT().UpdateStatus(gomock.Any(), "task-1",
+		map[string]any{"status": interfaces.BuildTaskStatusStopping}).Return(nil)
+
+	if err := service.StopBuildTask(context.Background(), "task-1"); err != nil {
+		t.Fatalf("expected nil, got %v", err)
+	}
+}
+
+// stopping → stopped：worker 已不在时 stopping 永远不会被推进，
+// 二次 stop 必须能强制落停，否则任务卡死无法删除。
+func TestStopBuildTaskForceFinalizesStuckStopping(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	mockBTA := mock_interfaces.NewMockBuildTaskAccess(ctrl)
+	service := &buildTaskService{bta: mockBTA}
+
+	mockBTA.EXPECT().GetByID(gomock.Any(), "task-1").
+		Return(&interfaces.BuildTask{ID: "task-1", Status: interfaces.BuildTaskStatusStopping}, nil)
+	mockBTA.EXPECT().UpdateStatus(gomock.Any(), "task-1",
+		map[string]any{"status": interfaces.BuildTaskStatusStopped}).Return(nil)
+
+	if err := service.StopBuildTask(context.Background(), "task-1"); err != nil {
+		t.Fatalf("expected nil, got %v", err)
+	}
+}
+
+// stopped 任务不可再 stop。
+func TestStopBuildTaskRejectsStoppedStatus(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	mockBTA := mock_interfaces.NewMockBuildTaskAccess(ctrl)
+	service := &buildTaskService{bta: mockBTA}
+
+	mockBTA.EXPECT().GetByID(gomock.Any(), "task-1").
+		Return(&interfaces.BuildTask{ID: "task-1", Status: interfaces.BuildTaskStatusStopped}, nil)
+
+	err := service.StopBuildTask(context.Background(), "task-1")
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	httpErr, ok := err.(*rest.HTTPError)
+	if !ok || httpErr.BaseError.ErrorCode != verrors.VegaBackend_BuildTask_InvalidStateTransition {
+		t.Fatalf("expected InvalidStateTransition, got %v", err)
+	}
+}

--- a/adp/vega/vega-backend/server/worker/build_handler_account_test.go
+++ b/adp/vega/vega-backend/server/worker/build_handler_account_test.go
@@ -45,7 +45,10 @@ func TestBatchBuildHandlerInjectsCreatorIntoCtx(t *testing.T) {
 	taskAccess := vmock.NewMockBuildTaskAccess(ctrl)
 	resAccess := vmock.NewMockResourceAccess(ctrl)
 	cs := vmock.NewMockCatalogService(ctrl)
-	bh := &batchBuildHandler{taskAccess: taskAccess, resAccess: resAccess, cs: cs}
+	ds := vmock.NewMockDatasetService(ctrl)
+	// executeBuild 现在无条件调 createLocalIndex（幂等），索引已存在直接跳过
+	ds.EXPECT().CheckExist(gomock.Any(), gomock.Any()).Return(true, nil).AnyTimes()
+	bh := &batchBuildHandler{taskAccess: taskAccess, resAccess: resAccess, cs: cs, ds: ds}
 
 	taskAccess.EXPECT().GetByID(gomock.Any(), "t1").Return(&interfaces.BuildTask{
 		ID: "t1", ResourceID: "r1", Status: interfaces.BuildTaskStatusRunning, Creator: testCreator,

--- a/adp/vega/vega-backend/server/worker/build_handler_batch.go
+++ b/adp/vega/vega-backend/server/worker/build_handler_batch.go
@@ -106,26 +106,42 @@ func (bh *batchBuildHandler) HandleTask(ctx context.Context, task *asynq.Task) e
 	return nil
 }
 
+// advanceCursor 把批读游标推进到本批最后一行的键值。
+// 注意必须按下标写回切片：此前用 `for _, kv := range` 改副本，游标永远停在
+// 第一批末尾，超过一个批次的表会无限重读同一区间（synced_count 膨胀、压垮索引）。
+func advanceCursor(cursor []interfaces.KeyValue, keys []string, lastItem map[string]any) []interfaces.KeyValue {
+	if len(cursor) == 0 {
+		for _, key := range keys {
+			cursor = append(cursor, interfaces.KeyValue{Key: key, Value: lastItem[key]})
+		}
+		return cursor
+	}
+	for i := range cursor {
+		cursor[i].Value = lastItem[cursor[i].Key]
+	}
+	return cursor
+}
+
 // executeBuild executes the build logic
 func (bh *batchBuildHandler) executeBuild(ctx context.Context, resource *interfaces.Resource, buildTaskInfo *interfaces.BuildTask, executeType string) error {
-	if buildTaskInfo.Status == interfaces.BuildTaskStatusInit {
-		if buildTaskInfo.EmbeddingFields != "" {
-			// send embedding task to queue
-			err := sendEmbeddingTask(bh.client, buildTaskInfo.ID)
-			if err != nil {
-				return fmt.Errorf("send embedding task failed: %w", err)
-			}
-			logger.Infof("Embedding task sent for task %s", buildTaskInfo.ID)
-		}
-		err := createLocalIndex(ctx, bh.ds, buildTaskInfo, resource)
+	// 两个操作均幂等（embedding 任务靠 asynq TaskID 去重，索引已存在则跳过），
+	// 不能只在 init 时执行：stop→start 重启后老 embedding worker 已退出，
+	// 若不补发，文档 ID 堆积在 Kafka 无消费者，向量化永远停滞
+	if buildTaskInfo.EmbeddingFields != "" {
+		err := sendEmbeddingTask(bh.client, buildTaskInfo.ID)
 		if err != nil {
-			return fmt.Errorf("create local index failed: %w", err)
+			return fmt.Errorf("send embedding task failed: %w", err)
 		}
+		logger.Infof("Embedding task sent for task %s", buildTaskInfo.ID)
+	}
+	err := createLocalIndex(ctx, bh.ds, buildTaskInfo, resource)
+	if err != nil {
+		return fmt.Errorf("create local index failed: %w", err)
 	}
 	indexName := getIndexName(resource.ID, buildTaskInfo.ID)
 
-	// Update task status to running
-	err := bh.taskAccess.UpdateStatus(ctx, buildTaskInfo.ID, map[string]interface{}{"status": interfaces.BuildTaskStatusRunning})
+	// Update task status to running; 实际开始执行时清掉上一轮残留的错误信息
+	err = bh.taskAccess.UpdateStatus(ctx, buildTaskInfo.ID, map[string]interface{}{"status": interfaces.BuildTaskStatusRunning, "errorMsg": ""})
 	if err != nil {
 		return fmt.Errorf("update build task status failed: %w", err)
 	}
@@ -286,18 +302,7 @@ func (bh *batchBuildHandler) executeBuild(ctx context.Context, resource *interfa
 			// Update lastBatchKeyValues with the last values in this batch
 			newSyncedMark := map[string]any{}
 			lastItem := result.Rows[readRows-1]
-			if len(lastBatchKeyValues) == 0 {
-				for _, key := range keys {
-					lastBatchKeyValues = append(lastBatchKeyValues, interfaces.KeyValue{
-						Key:   key,
-						Value: lastItem[key],
-					})
-				}
-			} else {
-				for _, kv := range lastBatchKeyValues {
-					kv.Value = lastItem[kv.Key]
-				}
-			}
+			lastBatchKeyValues = advanceCursor(lastBatchKeyValues, keys, lastItem)
 			for _, field := range batchFields {
 				newSyncedMark[field] = lastItem[field]
 			}

--- a/adp/vega/vega-backend/server/worker/build_handler_cursor_test.go
+++ b/adp/vega/vega-backend/server/worker/build_handler_cursor_test.go
@@ -1,0 +1,55 @@
+// Copyright 2026 openbkn.ai
+// Copyright The kweaver.ai Authors.
+//
+// Licensed under the Apache License, Version 2.0.
+// See the LICENSE file in the project root for details.
+
+package worker
+
+import (
+	"testing"
+
+	"vega-backend/interfaces"
+)
+
+// 复现 bug：批读游标必须随每批推进。此前实现用 `for _, kv := range` 修改
+// range 副本，游标永远停在第一批末尾，第二批起 gt 过滤条件不变，
+// 无限重读同一区间（synced_count 远超 total_count、重复写压垮索引）。
+func TestAdvanceCursorAdvancesAcrossBatches(t *testing.T) {
+	keys := []string{"key_id"}
+
+	// 第一批：空游标初始化为本批最后一行
+	cursor := advanceCursor(nil, keys, map[string]any{"key_id": "1000"})
+	if len(cursor) != 1 || cursor[0].Value != "1000" {
+		t.Fatalf("first batch: expected cursor key_id=1000, got %+v", cursor)
+	}
+
+	// 第二批：游标必须推进到新批次最后一行（bug 时停留在 1000）
+	cursor = advanceCursor(cursor, keys, map[string]any{"key_id": "2000"})
+	if cursor[0].Value != "2000" {
+		t.Fatalf("second batch: cursor stuck at %v, expected 2000", cursor[0].Value)
+	}
+
+	// 第三批：持续推进
+	cursor = advanceCursor(cursor, keys, map[string]any{"key_id": "3000"})
+	if cursor[0].Value != "3000" {
+		t.Fatalf("third batch: cursor stuck at %v, expected 3000", cursor[0].Value)
+	}
+}
+
+// 多键游标：每个键都取本批最后一行的对应值。
+func TestAdvanceCursorMultipleKeys(t *testing.T) {
+	keys := []string{"id", "name"}
+	cursor := advanceCursor(nil, keys, map[string]any{"id": 1, "name": "a"})
+	cursor = advanceCursor(cursor, keys, map[string]any{"id": 2, "name": "b"})
+
+	got := map[string]any{}
+	for _, kv := range cursor {
+		got[kv.Key] = kv.Value
+	}
+	if got["id"] != 2 || got["name"] != "b" {
+		t.Fatalf("expected id=2 name=b, got %+v", got)
+	}
+}
+
+var _ = interfaces.KeyValue{} // 保持 import 稳定

--- a/adp/vega/vega-backend/server/worker/build_handler_embedding.go
+++ b/adp/vega/vega-backend/server/worker/build_handler_embedding.go
@@ -235,8 +235,10 @@ func (eh *embeddingHandler) executeEmbedding(ctx context.Context, resource *inte
 						continue
 					}
 
-					// Update task status to completed
-					err = eh.taskAccess.UpdateStatus(ctx, buildTaskInfo.ID, map[string]interface{}{"status": interfaces.BuildTaskStatusCompleted})
+					// Update task status to completed；必须同时回写最终计数：
+					// 常规回写有 30 秒批量窗口，不在这里 flush 会丢最后一个窗口的进度
+					// （短任务整个跑完都在首个窗口内，界面会停在 0%）
+					err = eh.taskAccess.UpdateStatus(ctx, buildTaskInfo.ID, map[string]interface{}{"status": interfaces.BuildTaskStatusCompleted, "vectorizedCount": totalProcessed})
 					if err != nil {
 						logger.Errorf("update build task status to completed failed: %w", buildTaskInfo.ID, err)
 					}
@@ -287,13 +289,15 @@ func (eh *embeddingHandler) executeEmbedding(ctx context.Context, resource *inte
 					time.Sleep(retryInterval)
 					continue
 				}
-				totalProcessed++
+			}
+			// 源字段全为空的文档没有可嵌入文本，同样计入已处理：
+			// 分母（synced_count）包含它们，不计数则进度永远到不了 100%
+			totalProcessed++
 
-				// 批量更新任务状态
-				if time.Since(lastUpdateTime) > updateInterval {
-					_ = eh.taskAccess.UpdateStatus(ctx, buildTaskInfo.ID, map[string]interface{}{"vectorizedCount": totalProcessed})
-					lastUpdateTime = time.Now()
-				}
+			// 批量更新任务状态
+			if time.Since(lastUpdateTime) > updateInterval {
+				_ = eh.taskAccess.UpdateStatus(ctx, buildTaskInfo.ID, map[string]interface{}{"vectorizedCount": totalProcessed})
+				lastUpdateTime = time.Now()
 			}
 
 			// Commit the message to avoid reprocessing

--- a/adp/vega/vega-backend/server/worker/build_handler_streaming.go
+++ b/adp/vega/vega-backend/server/worker/build_handler_streaming.go
@@ -167,7 +167,7 @@ func (sh *streamingBuildHandler) HandleTask(ctx context.Context, task *asynq.Tas
 	}
 
 	// Update task status to running
-	_ = sh.taskAccess.UpdateStatus(ctx, taskID, map[string]interface{}{"status": interfaces.BuildTaskStatusRunning})
+	_ = sh.taskAccess.UpdateStatus(ctx, taskID, map[string]interface{}{"status": interfaces.BuildTaskStatusRunning, "errorMsg": ""})
 
 	// Execute build
 	err = sh.executeBuild(ctx, catalog, resource, buildTaskInfo, database, sourceId)


### PR DESCRIPTION
## 背景

VM 验证环境上 7 个 batch 构建任务全部停滞，排查出三个相互独立的 bug（均已在 VM 端到端复现并验证修复）。

## Bug 1：批读游标永不推进（数据重复读 + OpenSearch OOM）

`executeBuild` 用 `for _, kv := range lastBatchKeyValues` 更新游标——改的是 range 副本。游标永远停在第一批末尾，超过一个批次（>1000 行）的表从第二批起无限重读同一区间：13876 行的 `wc_squads` 表 `synced_count` 膨胀到 234,000，持续写入把 1Gi 内存的 OpenSearch 打到 OOMKilled（重启 5 次）。

修复：抽出 `advanceCursor()`，按下标写回切片；附复现测试。

## Bug 2：任务重启后向量化永远 0%

`sendEmbeddingTask` 只在 `status == init` 时入队，而 `/start` 只重新入队 batch 任务。stop→start 重启后老 embedding worker 已退出，文档 ID 堆积在 Kafka 无消费者，任务永远停在"构建中"、向量化 0%。

修复：embedding 任务补发与 `createLocalIndex` 改为每次执行都跑（两者均幂等：asynq TaskID 去重 / 索引存在即跳过）。

## Bug 3：状态机死胡同

- `failed` 任务不能 start，只能删除重建（丢失 synced_mark 水位）；
- worker 不在时（重试耗尽/服务重启）`stopping` 永远不会被推进到 `stopped`，任务卡死且不可删除；
- 任务恢复运行后 `error_msg` 不清空，UI 持续显示陈旧错误误导用户。

修复：允许 `failed → running`；二次 stop 强制 `stopping → stopped`（界面"停止"按钮对异常状态点两次即可解锁删除）；worker 实际开始执行时清空 `error_msg`。API 文档（build-task.yaml）同步更新。

## 测试

- 新增 `advanceCursor` 游标推进复现测试（修复前必失败）
- 新增 start/stop 状态转移测试 ×4
- `go test ./...` 全绿；`go vet` 无新告警
- VM 端到端：6 个存量任务强停→重启恢复；wc_squads 重建后全量 13876 行同步完成、向量化正常推进

## 前端跟进（不在本仓库）

`/index-builds` 页面前端不在 kowell-core。建议跟进：构建中任务加"停止"按钮（对 running 调一次 stop，对卡死 stopping 再调一次即强制落停），failed 任务加"重新启动"按钮。

🤖 Generated with [Claude Code](https://claude.com/claude-code)