### PR TITLE
fix(vega): auto-enqueue on create + stop losing vectors on transient embedding failures

### DIFF
--- a/adp/vega/vega-backend/server/drivenadapters/asynq/asynq_access.go
+++ b/adp/vega/vega-backend/server/drivenadapters/asynq/asynq_access.go
@@ -46,6 +46,11 @@ func (aqa *asynqAccess) CreateClient() *asynq.Client {
 	return asynq.NewClient(redisOpt)
 }
 
+// CreateInspector creates and returns the Asynq inspector for queue introspection.
+func (aqa *asynqAccess) CreateInspector() *asynq.Inspector {
+	return asynq.NewInspector(aqa.getRedisClientOpt())
+}
+
 // CreateServer creates and returns the Asynq server for processing tasks.
 func (aqa *asynqAccess) CreateServer() *asynq.Server {
 	redisOpt := aqa.getRedisClientOpt()

--- a/adp/vega/vega-backend/server/driveradapters/build_task_create_validate_test.go
+++ b/adp/vega/vega-backend/server/driveradapters/build_task_create_validate_test.go
@@ -1,0 +1,112 @@
+// Copyright 2026 openbkn.ai
+// Copyright The kweaver.ai Authors.
+//
+// Licensed under the Apache License, Version 2.0.
+// See the LICENSE file in the project root for details.
+
+package driveradapters
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	. "github.com/smartystreets/goconvey/convey"
+	"go.uber.org/mock/gomock"
+
+	"vega-backend/common"
+	"vega-backend/interfaces"
+	vmock "vega-backend/interfaces/mock"
+)
+
+// 复现 bug：嵌入字段只校验存在性不校验类型，选了非文本字段（integer/datetime 等）
+// 创建成功，但运行时被当作空文本静默跳过——产出永远为空的 _vector 列且进度 100%。
+// 现在创建时即拦截：embedding_field 仅允许 string/text。
+
+func Test_BuildTaskRestHandler_CreateBuildTask_EmbeddingFieldType(t *testing.T) {
+	Convey("Test CreateBuildTask embedding field type validation\n", t, func() {
+		test := setGinMode()
+		defer test()
+
+		engine := gin.New()
+		engine.Use(gin.Recovery())
+
+		mockCtrl := gomock.NewController(t)
+		defer mockCtrl.Finish()
+
+		rs := vmock.NewMockResourceService(mockCtrl)
+		bts := vmock.NewMockBuildTaskService(mockCtrl)
+		handler := MockNewRestHandler(&common.AppSetting{}, nil, nil, rs, bts, nil, nil, nil, nil, nil, nil)
+		handler.RegisterPublic(engine)
+
+		resource := &interfaces.Resource{
+			ID: "res-1",
+			SchemaDefinition: []*interfaces.Property{
+				{Name: "id", Type: interfaces.DataType_Integer},
+				{Name: "name", Type: interfaces.DataType_String},
+				{Name: "summary", Type: interfaces.DataType_Text},
+				{Name: "created_at", Type: interfaces.DataType_Datetime},
+			},
+		}
+		rs.EXPECT().GetByID(gomock.Any(), "res-1").Return(resource, nil).AnyTimes()
+
+		url := "/api/vega-backend/in/v1/build-tasks"
+		post := func(body string) *httptest.ResponseRecorder {
+			req := httptest.NewRequest(http.MethodPost, url, strings.NewReader(body))
+			req.Header.Set("Content-Type", "application/json")
+			w := httptest.NewRecorder()
+			engine.ServeHTTP(w, req)
+			return w
+		}
+
+		Convey("Reject integer embedding field\n", func() {
+			w := post(`{"resource_id":"res-1","mode":"batch","build_key_fields":"id","embedding_fields":"id"}`)
+			So(w.Result().StatusCode, ShouldEqual, http.StatusBadRequest)
+			So(w.Body.String(), ShouldContainSubstring, "only string/text fields can be embedded")
+		})
+
+		Convey("Reject datetime embedding field mixed with valid ones\n", func() {
+			w := post(`{"resource_id":"res-1","mode":"batch","build_key_fields":"id","embedding_fields":"name,created_at"}`)
+			So(w.Result().StatusCode, ShouldEqual, http.StatusBadRequest)
+			So(w.Body.String(), ShouldContainSubstring, "created_at")
+		})
+
+		Convey("Reject unknown embedding field\n", func() {
+			w := post(`{"resource_id":"res-1","mode":"batch","build_key_fields":"id","embedding_fields":"nope"}`)
+			So(w.Result().StatusCode, ShouldEqual, http.StatusBadRequest)
+			So(w.Body.String(), ShouldContainSubstring, "not found in resource schema")
+		})
+
+		Convey("Accept string and text embedding fields\n", func() {
+			bts.EXPECT().CreateBuildTask(gomock.Any(), gomock.Any()).Return("task-1", nil)
+			w := post(`{"resource_id":"res-1","mode":"batch","build_key_fields":"id","embedding_fields":"name,summary"}`)
+			So(w.Result().StatusCode, ShouldEqual, http.StatusCreated)
+		})
+	})
+}
+
+// fulltext 特征支持 text 与 string（ES 风格 multi-field 下 string 同样可分词检索）；
+// keyword 仍仅 string，vector 仅 vector。
+func Test_IsFeatureSupported_Matrix(t *testing.T) {
+	cases := []struct {
+		fieldType   string
+		featureType string
+		want        bool
+	}{
+		{interfaces.DataType_Text, interfaces.PropertyFeatureType_Fulltext, true},
+		{interfaces.DataType_String, interfaces.PropertyFeatureType_Fulltext, true},
+		{interfaces.DataType_Integer, interfaces.PropertyFeatureType_Fulltext, false},
+		{interfaces.DataType_String, interfaces.PropertyFeatureType_Keyword, true},
+		{interfaces.DataType_Text, interfaces.PropertyFeatureType_Keyword, false},
+		{interfaces.DataType_Vector, interfaces.PropertyFeatureType_Vector, true},
+		{interfaces.DataType_String, interfaces.PropertyFeatureType_Vector, false},
+		{interfaces.DataType_Text, "unknown", false},
+	}
+	for _, tc := range cases {
+		if got := IsFeatureSupported(tc.fieldType, tc.featureType); got != tc.want {
+			t.Errorf("IsFeatureSupported(%s, %s) = %v, want %v", tc.fieldType, tc.featureType, got, tc.want)
+		}
+	}
+}

--- a/adp/vega/vega-backend/server/driveradapters/build_task_handler.go
+++ b/adp/vega/vega-backend/server/driveradapters/build_task_handler.go
@@ -79,14 +79,14 @@ func (r *restHandler) createBuildTask(c *gin.Context, visitor hydra.Visitor) {
 		return
 	}
 
-	schemaFields := make(map[string]bool, len(resource.SchemaDefinition))
+	schemaFields := make(map[string]string, len(resource.SchemaDefinition))
 	for _, prop := range resource.SchemaDefinition {
-		schemaFields[prop.Name] = true
+		schemaFields[prop.Name] = prop.Type
 	}
 	if req.BuildKeyFields != "" {
 		for _, key := range strings.Split(req.BuildKeyFields, ",") {
 			key = strings.TrimSpace(key)
-			if key != "" && !schemaFields[key] {
+			if _, ok := schemaFields[key]; key != "" && !ok {
 				httpErr := rest.NewHTTPError(ctx, http.StatusBadRequest, verrors.VegaBackend_InvalidParameter_RequestBody).
 					WithErrorDetails(fmt.Sprintf("build_key_field '%s' not found in resource schema", key))
 				oteltrace.AddHttpAttrs4HttpError(span, httpErr)
@@ -98,9 +98,22 @@ func (r *restHandler) createBuildTask(c *gin.Context, visitor hydra.Visitor) {
 	if req.EmbeddingFields != "" {
 		for _, field := range strings.Split(req.EmbeddingFields, ",") {
 			field = strings.TrimSpace(field)
-			if field != "" && !schemaFields[field] {
+			if field == "" {
+				continue
+			}
+			fieldType, ok := schemaFields[field]
+			if !ok {
 				httpErr := rest.NewHTTPError(ctx, http.StatusBadRequest, verrors.VegaBackend_InvalidParameter_RequestBody).
 					WithErrorDetails(fmt.Sprintf("embedding_field '%s' not found in resource schema", field))
+				oteltrace.AddHttpAttrs4HttpError(span, httpErr)
+				rest.ReplyError(c, httpErr)
+				return
+			}
+			// 向量化只对文本字段有意义：非 string/text 字段在运行时会被当作空文本静默跳过，
+			// 产出永远为空的 _vector 列且进度照常 100%，这里直接拦下
+			if fieldType != interfaces.DataType_String && fieldType != interfaces.DataType_Text {
+				httpErr := rest.NewHTTPError(ctx, http.StatusBadRequest, verrors.VegaBackend_InvalidParameter_RequestBody).
+					WithErrorDetails(fmt.Sprintf("embedding_field '%s' has type '%s', only string/text fields can be embedded", field, fieldType))
 				oteltrace.AddHttpAttrs4HttpError(span, httpErr)
 				rest.ReplyError(c, httpErr)
 				return

--- a/adp/vega/vega-backend/server/driveradapters/validate_resource.go
+++ b/adp/vega/vega-backend/server/driveradapters/validate_resource.go
@@ -472,7 +472,8 @@ func validateFeatures(ctx context.Context, fieldsMap map[string]*interfaces.View
 func IsFeatureSupported(fieldType string, featureType string) bool {
 	switch featureType {
 	case interfaces.PropertyFeatureType_Fulltext:
-		return fieldType == interfaces.DataType_Text
+		// 全文检索支持 text 与 string：ES 风格 multi-field 下 string 字段同样可分词检索
+		return fieldType == interfaces.DataType_Text || fieldType == interfaces.DataType_String
 	case interfaces.PropertyFeatureType_Keyword:
 		return fieldType == interfaces.DataType_String
 	case interfaces.PropertyFeatureType_Vector:

--- a/adp/vega/vega-backend/server/driveradapters/validate_test.go
+++ b/adp/vega/vega-backend/server/driveradapters/validate_test.go
@@ -181,6 +181,9 @@ func Test_Validate_CreateResourceCategory(t *testing.T) {
 		})
 	})
 }
+// 注意分层：ValidateResourceRequest 的 dataset 路径只做"schema 非空 + extensions"
+// 兜底校验（字段级校验为兼容 v0.8.0 历史 schema 已断开，见 validateDatasetRequest
+// 注释）；字段级规则由保留待接回的 validateDatasetFields 承载，直接对它测试。
 func Test_Validate_DatasetRequest(t *testing.T) {
 	baseReq := func(props []*interfaces.Property) *interfaces.ResourceRequest {
 		return &interfaces.ResourceRequest{
@@ -201,92 +204,111 @@ func Test_Validate_DatasetRequest(t *testing.T) {
 			So(err, ShouldNotBeNil)
 		})
 
-		Convey("Reject empty field name\n", func() {
+		Convey("Field-level rules are not enforced at request entry (v0.8.0 compat)\n", func() {
 			err := ValidateResourceRequest(context.Background(), baseReq([]*interfaces.Property{
-				{Name: "", Type: interfaces.DataType_String},
+				{Name: "dup", Type: interfaces.DataType_String},
+				{Name: "dup", Type: interfaces.DataType_Integer},
 			}))
+			So(err, ShouldBeNil)
+		})
+	})
+
+	Convey("Test validateDatasetFields\n", t, func() {
+		Convey("Reject empty field name\n", func() {
+			err := validateDatasetFields(context.Background(), []*interfaces.Property{
+				{Name: "", Type: interfaces.DataType_String},
+			})
 			So(err, ShouldNotBeNil)
 		})
 
 		Convey("Reject field name length exceeded\n", func() {
-			err := ValidateResourceRequest(context.Background(), baseReq([]*interfaces.Property{
+			err := validateDatasetFields(context.Background(), []*interfaces.Property{
 				{Name: strings.Repeat("a", interfaces.MaxLength_PropertyName+1), Type: interfaces.DataType_String},
-			}))
+			})
 			So(err, ShouldNotBeNil)
 		})
 
 		Convey("Reject display name length exceeded\n", func() {
-			err := ValidateResourceRequest(context.Background(), baseReq([]*interfaces.Property{
+			err := validateDatasetFields(context.Background(), []*interfaces.Property{
 				{Name: "f1", DisplayName: strings.Repeat("a", interfaces.MaxLength_PropertyDisplayName+1), Type: interfaces.DataType_String},
-			}))
+			})
 			So(err, ShouldNotBeNil)
 		})
 
 		Convey("Reject description length exceeded\n", func() {
-			err := ValidateResourceRequest(context.Background(), baseReq([]*interfaces.Property{
+			err := validateDatasetFields(context.Background(), []*interfaces.Property{
 				{Name: "f1", Description: strings.Repeat("a", interfaces.MaxLength_PropertyDescription+1), Type: interfaces.DataType_String},
-			}))
+			})
 			So(err, ShouldNotBeNil)
 		})
 
 		Convey("Reject duplicate field name\n", func() {
-			err := ValidateResourceRequest(context.Background(), baseReq([]*interfaces.Property{
+			err := validateDatasetFields(context.Background(), []*interfaces.Property{
 				{Name: "f1", Type: interfaces.DataType_String},
 				{Name: "f1", Type: interfaces.DataType_Integer},
-			}))
+			})
 			So(err, ShouldNotBeNil)
 		})
 
 		Convey("Reject duplicate display name\n", func() {
-			err := ValidateResourceRequest(context.Background(), baseReq([]*interfaces.Property{
+			err := validateDatasetFields(context.Background(), []*interfaces.Property{
 				{Name: "f1", DisplayName: "same", Type: interfaces.DataType_String},
 				{Name: "f2", DisplayName: "same", Type: interfaces.DataType_String},
-			}))
+			})
 			So(err, ShouldNotBeNil)
 		})
 
 		Convey("Reject invalid feature type\n", func() {
-			err := ValidateResourceRequest(context.Background(), baseReq([]*interfaces.Property{
+			err := validateDatasetFields(context.Background(), []*interfaces.Property{
 				{Name: "f1", Type: interfaces.DataType_Text, Features: []interfaces.PropertyFeature{
 					{FeatureName: "feat1", FeatureType: "bogus", RefProperty: "f1", IsNative: true},
 				}},
-			}))
+			})
 			So(err, ShouldNotBeNil)
 		})
 
 		Convey("Reject non-native feature with missing ref_property\n", func() {
-			err := ValidateResourceRequest(context.Background(), baseReq([]*interfaces.Property{
+			err := validateDatasetFields(context.Background(), []*interfaces.Property{
 				{Name: "f1", Type: interfaces.DataType_Text, Features: []interfaces.PropertyFeature{
 					{FeatureName: "feat1", FeatureType: interfaces.PropertyFeatureType_Fulltext, RefProperty: "missing"},
 				}},
-			}))
+			})
 			So(err, ShouldNotBeNil)
 		})
 
 		Convey("Reject feature with mismatched ref type\n", func() {
-			err := ValidateResourceRequest(context.Background(), baseReq([]*interfaces.Property{
+			err := validateDatasetFields(context.Background(), []*interfaces.Property{
 				{Name: "f1", Type: interfaces.DataType_Integer},
 				{Name: "f2", Type: interfaces.DataType_Text, Features: []interfaces.PropertyFeature{
 					{FeatureName: "feat1", FeatureType: interfaces.PropertyFeatureType_Keyword, RefProperty: "f1"},
 				}},
-			}))
+			})
 			So(err, ShouldNotBeNil)
 		})
 
 		Convey("Accept minimal valid dataset\n", func() {
-			err := ValidateResourceRequest(context.Background(), baseReq([]*interfaces.Property{
+			err := validateDatasetFields(context.Background(), []*interfaces.Property{
 				{Name: "id", Type: interfaces.DataType_Integer},
 				{Name: "name", Type: interfaces.DataType_String},
-			}))
+			})
 			So(err, ShouldBeNil)
 		})
 
 		Convey("Accept dataset with native fulltext feature\n", func() {
-			err := ValidateResourceRequest(context.Background(), baseReq([]*interfaces.Property{
+			err := validateDatasetFields(context.Background(), []*interfaces.Property{
 				{Name: "body", Type: interfaces.DataType_Text, Features: []interfaces.PropertyFeature{
 					{FeatureName: "body.ft", FeatureType: interfaces.PropertyFeatureType_Fulltext, RefProperty: "body", IsNative: true},
 				}},
-			}))
+			})
+			So(err, ShouldBeNil)
+		})
+
+		Convey("Accept fulltext feature referencing string field\n", func() {
+			err := validateDatasetFields(context.Background(), []*interfaces.Property{
+				{Name: "title", Type: interfaces.DataType_String, Features: []interfaces.PropertyFeature{
+					{FeatureName: "title.ft", FeatureType: interfaces.PropertyFeatureType_Fulltext, RefProperty: "title"},
+				}},
+			})
 			So(err, ShouldBeNil)
 		})
 	})

--- a/adp/vega/vega-backend/server/interfaces/asynq_access.go
+++ b/adp/vega/vega-backend/server/interfaces/asynq_access.go
@@ -25,4 +25,6 @@ type AsynqAccess interface {
 	CreateClient() *asynq.Client
 	// CreateServer creates and returns the Asynq server for processing tasks.
 	CreateServer() *asynq.Server
+	// CreateInspector creates and returns the Asynq inspector for queue introspection.
+	CreateInspector() *asynq.Inspector
 }

--- a/adp/vega/vega-backend/server/interfaces/mock/mock_asynq_access.go
+++ b/adp/vega/vega-backend/server/interfaces/mock/mock_asynq_access.go
@@ -54,6 +54,20 @@ func (mr *MockAsynqAccessMockRecorder) CreateClient() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateClient", reflect.TypeOf((*MockAsynqAccess)(nil).CreateClient))
 }
 
+// CreateInspector mocks base method.
+func (m *MockAsynqAccess) CreateInspector() *asynq.Inspector {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CreateInspector")
+	ret0, _ := ret[0].(*asynq.Inspector)
+	return ret0
+}
+
+// CreateInspector indicates an expected call of CreateInspector.
+func (mr *MockAsynqAccessMockRecorder) CreateInspector() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateInspector", reflect.TypeOf((*MockAsynqAccess)(nil).CreateInspector))
+}
+
 // CreateServer mocks base method.
 func (m *MockAsynqAccess) CreateServer() *asynq.Server {
 	m.ctrl.T.Helper()

--- a/adp/vega/vega-backend/server/logics/build_task/build_task_service.go
+++ b/adp/vega/vega-backend/server/logics/build_task/build_task_service.go
@@ -300,7 +300,17 @@ func (bts *buildTaskService) StartBuildTask(ctx context.Context, taskID string, 
 			WithErrorDetails("catalog is disabled")
 	}
 
-	// status transition to running is performed by worker on actual execution，only need to enqueue the task
+	// 入队前先置回 init：worker 出队时会跳过 stopped/stopping 的任务
+	// （防止排队中被停止的任务复活），stopped 状态直接入队会被误跳过。
+	// running 仍由 worker 实际执行时落账。
+	if buildTask.Status != interfaces.BuildTaskStatusInit {
+		if err := bts.bta.UpdateStatus(ctx, taskID, map[string]any{"status": interfaces.BuildTaskStatusInit}); err != nil {
+			otellog.LogError(ctx, "Update build task status failed", err)
+			return rest.NewHTTPError(ctx, http.StatusInternalServerError, verrors.VegaBackend_BuildTask_InternalError_UpdateFailed).
+				WithErrorDetails(err.Error())
+		}
+	}
+
 	payload, err := sonic.Marshal(&interfaces.BatchBuildTaskMessage{
 		TaskID:      taskID,
 		ExecuteType: executeType,
@@ -347,7 +357,8 @@ func (bts *buildTaskService) StopBuildTask(ctx context.Context, taskID string) e
 		return rest.NewHTTPError(ctx, http.StatusNotFound, verrors.VegaBackend_BuildTask_NotFound)
 	}
 	if buildTask.Status != interfaces.BuildTaskStatusRunning &&
-		buildTask.Status != interfaces.BuildTaskStatusStopping {
+		buildTask.Status != interfaces.BuildTaskStatusStopping &&
+		buildTask.Status != interfaces.BuildTaskStatusInit {
 		span.SetStatus(codes.Error, "Invalid state transition for stop")
 		return rest.NewHTTPError(ctx, http.StatusConflict, verrors.VegaBackend_BuildTask_InvalidStateTransition).
 			WithErrorDetails(fmt.Sprintf("cannot stop task in status: %s", buildTask.Status))
@@ -356,8 +367,11 @@ func (bts *buildTaskService) StopBuildTask(ctx context.Context, taskID string) e
 	// running → stopping：通知 worker 在批间检查点退出。
 	// stopping → stopped：兜底强制落停。worker 已不在（asynq 任务耗尽重试/服务重启）
 	// 时 stopping 永远不会被推进，任务卡死无法删除，二次 stop 即强制完结。
+	// init → stopped：排队中尚无 worker 观察 stopping，直接落停；
+	// 出队时 worker 检查到 stopped 即跳过，不会复活执行。
 	targetStatus := interfaces.BuildTaskStatusStopping
-	if buildTask.Status == interfaces.BuildTaskStatusStopping {
+	if buildTask.Status == interfaces.BuildTaskStatusStopping ||
+		buildTask.Status == interfaces.BuildTaskStatusInit {
 		targetStatus = interfaces.BuildTaskStatusStopped
 	}
 	updates := map[string]any{

--- a/adp/vega/vega-backend/server/logics/build_task/build_task_service.go
+++ b/adp/vega/vega-backend/server/logics/build_task/build_task_service.go
@@ -167,8 +167,41 @@ func (bts *buildTaskService) CreateBuildTask(ctx context.Context, req *interface
 			WithErrorDetails(err.Error())
 	}
 
+	// 创建即入队执行：客户端创建后不会再调 /start，不入队任务会永远停在 init（界面"排队中"）。
+	// 入队失败仅记日志，任务保持 init，可由 /start 重新触发
+	bts.enqueueBuildTask(ctx, buildTask, interfaces.BuildTaskExecuteTypeFull)
+
 	span.SetStatus(codes.Ok, "")
 	return buildTask.ID, nil
+}
+
+// enqueueBuildTask 按任务模式投递到 asynq 队列；入队失败仅记录日志，任务保持当前状态
+func (bts *buildTaskService) enqueueBuildTask(ctx context.Context, buildTask *interfaces.BuildTask, executeType string) {
+	payload, err := sonic.Marshal(&interfaces.BatchBuildTaskMessage{
+		TaskID:      buildTask.ID,
+		ExecuteType: executeType,
+	})
+	if err != nil {
+		otellog.LogError(ctx, "Marshal build task message failed", err)
+		return
+	}
+
+	typename := interfaces.BuildTaskTypeBatch
+	if buildTask.Mode == interfaces.BuildTaskModeStreaming {
+		typename = interfaces.BuildTaskTypeStreaming
+	}
+	asynqTask := asynq.NewTask(typename, payload)
+	client := logics.AQA.CreateClient()
+	if _, err := client.Enqueue(asynqTask,
+		asynq.Queue(interfaces.DefaultQueue),
+		asynq.MaxRetry(interfaces.BUILD_TASK_MAX_RETRY_COUNT),
+		asynq.Timeout(math.MaxInt64),
+		asynq.Deadline(time.Unix(math.MaxInt64/1000000000, math.MaxInt64%1000000000)),
+	); err != nil {
+		otellog.LogError(ctx, "Enqueue build task failed", err)
+	} else {
+		logger.Infof("Build task %s enqueued for execution", buildTask.ID)
+	}
 }
 
 // GetBuildTaskByID retrieves a build task by ID.
@@ -311,30 +344,7 @@ func (bts *buildTaskService) StartBuildTask(ctx context.Context, taskID string, 
 		}
 	}
 
-	payload, err := sonic.Marshal(&interfaces.BatchBuildTaskMessage{
-		TaskID:      taskID,
-		ExecuteType: executeType,
-	})
-	if err != nil {
-		otellog.LogError(ctx, "Marshal build task message failed", err)
-	} else {
-		typename := interfaces.BuildTaskTypeBatch
-		if buildTask.Mode == interfaces.BuildTaskModeStreaming {
-			typename = interfaces.BuildTaskTypeStreaming
-		}
-		asynqTask := asynq.NewTask(typename, payload)
-		client := logics.AQA.CreateClient()
-		if _, err := client.Enqueue(asynqTask,
-			asynq.Queue(interfaces.DefaultQueue),
-			asynq.MaxRetry(interfaces.BUILD_TASK_MAX_RETRY_COUNT),
-			asynq.Timeout(math.MaxInt64),
-			asynq.Deadline(time.Unix(math.MaxInt64/1000000000, math.MaxInt64%1000000000)),
-		); err != nil {
-			otellog.LogError(ctx, "Enqueue build task failed", err)
-		} else {
-			logger.Infof("Build task %s enqueued for execution", taskID)
-		}
-	}
+	bts.enqueueBuildTask(ctx, buildTask, executeType)
 
 	span.SetStatus(codes.Ok, "")
 	return nil

--- a/adp/vega/vega-backend/server/logics/connectors/local/table/mariadb/mariadb_query.go
+++ b/adp/vega/vega-backend/server/logics/connectors/local/table/mariadb/mariadb_query.go
@@ -265,9 +265,25 @@ func (c *MariaDBConnector) ExecuteQuery(ctx context.Context, resource *interface
 		result.Rows = append(result.Rows, row)
 	}
 
-	// 处理总数：设置为实际返回的记录数
-	if params.NeedTotal {
-		result.Total = int64(len(result.Rows))
+	// 处理总数（仅明细查询）：独立 COUNT 查询，与 postgresql 连接器对齐。
+	// 此前直接取 len(result.Rows)——即本页行数，超过一页的表 total 永远等于
+	// LIMIT（构建任务进度条显示 "20802 / 1000" 即此 bug）
+	if params.NeedTotal && !isAggregate {
+		countBuilder := sq.Select("COUNT(1)").From(resource.SourceIdentifier)
+		if condition != nil {
+			countBuilder = countBuilder.Where(condition)
+		}
+		countQuery, countArgs, countErr := countBuilder.ToSql()
+		if countErr != nil {
+			return nil, fmt.Errorf("failed to build count query: %w", countErr)
+		}
+		logger.Debugf("count query: %s, args: %v", countQuery, countArgs)
+		var total int64
+		row := c.db.QueryRowContext(ctx, countQuery, countArgs...)
+		if err := row.Scan(&total); err != nil {
+			return nil, fmt.Errorf("failed to scan total: %w", err)
+		}
+		result.Total = total
 	}
 
 	return result, nil

--- a/adp/vega/vega-backend/server/worker/build_handler_batch.go
+++ b/adp/vega/vega-backend/server/worker/build_handler_batch.go
@@ -69,6 +69,18 @@ func (bh *batchBuildHandler) HandleTask(ctx context.Context, task *asynq.Task) e
 		// Task not found, return nil
 		return nil
 	}
+	// 排队期间被停止的任务直接跳过，避免出队后复活覆写状态。
+	// stopping 出队说明原 worker 已不在，兜底落停。
+	if buildTaskInfo.Status == interfaces.BuildTaskStatusStopped ||
+		buildTaskInfo.Status == interfaces.BuildTaskStatusStopping {
+		logger.Infof("Task %s is %s, skip execution", taskID, buildTaskInfo.Status)
+		if buildTaskInfo.Status == interfaces.BuildTaskStatusStopping {
+			if err := bh.taskAccess.UpdateStatus(ctx, taskID, map[string]interface{}{"status": interfaces.BuildTaskStatusStopped}); err != nil {
+				return fmt.Errorf("update build task status failed: %w", err)
+			}
+		}
+		return nil
+	}
 	// 异步任务无原始请求上下文，以任务创建者身份执行下游权限检查
 	ctx = context.WithValue(ctx, interfaces.ACCOUNT_INFO_KEY, buildTaskInfo.Creator)
 	resourceID := buildTaskInfo.ResourceID

--- a/adp/vega/vega-backend/server/worker/build_handler_batch.go
+++ b/adp/vega/vega-backend/server/worker/build_handler_batch.go
@@ -161,6 +161,13 @@ func (bh *batchBuildHandler) executeBuild(ctx context.Context, resource *interfa
 	lastSyncedMark := buildTaskInfo.SyncedMark
 	if executeType == interfaces.BuildTaskExecuteTypeFull {
 		lastSyncedMark = ""
+		// 全量重跑从头读、向量也整体重做，进度计数器一并清零，
+		// 否则跨运行累计出 synced > total 的显示
+		buildTaskInfo.SyncedCount = 0
+		buildTaskInfo.VectorizedCount = 0
+		if err := bh.taskAccess.UpdateStatus(ctx, buildTaskInfo.ID, map[string]interface{}{"syncedCount": int64(0), "vectorizedCount": int64(0), "syncedMark": ""}); err != nil {
+			return fmt.Errorf("update build task status failed: %w", err)
+		}
 	}
 
 	batchFields := strings.Split(buildTaskInfo.BuildKeyFields, ",")

--- a/adp/vega/vega-backend/server/worker/build_handler_embedding.go
+++ b/adp/vega/vega-backend/server/worker/build_handler_embedding.go
@@ -17,6 +17,7 @@ import (
 	"github.com/bytedance/sonic"
 	"github.com/hibiken/asynq"
 	"github.com/kweaver-ai/kweaver-go-lib/logger"
+	"github.com/segmentio/kafka-go"
 
 	"vega-backend/common"
 	"vega-backend/interfaces"
@@ -176,6 +177,8 @@ func (eh *embeddingHandler) executeEmbedding(ctx context.Context, resource *inte
 	lastUpdateTime := time.Now()
 	updateInterval := 30 * time.Second // embedding速度慢，至少每30秒更新一次
 	consecutiveReadErrs := 0           // 连续非超时读错误计数，达到上限放弃本轮交给 asynq 重试
+	consecutiveCommitErrs := 0         // 连续位点提交失败计数，达到上限放弃本轮交给 asynq 重试
+	lastMessageTime := time.Now()
 	for {
 		// Check task status before each iteration
 		taskStatus, err := eh.taskAccess.GetStatus(ctx, buildTaskInfo.ID)
@@ -216,6 +219,13 @@ func (eh *embeddingHandler) executeEmbedding(ctx context.Context, resource *inte
 			if err != nil {
 				if errors.Is(err, context.DeadlineExceeded) {
 					consecutiveReadErrs = 0
+					// 批量模式空闲看门狗：同步侧早已发完（含哨兵），长时间一条消息都
+					// 读不到说明消费组会话假死（分区被死实例占着/会话丢失但不报错）。
+					// 重建会话从已提交位点续读；流式模式空闲是常态，不适用
+					if buildTaskInfo.Mode == interfaces.BuildTaskModeBatch && time.Since(lastMessageTime) > embeddingIdleRebuildAfter {
+						_ = eh.taskAccess.UpdateStatus(ctx, buildTaskInfo.ID, map[string]interface{}{"vectorizedCount": totalProcessed})
+						return fmt.Errorf("no message for %s on batch task, rebuilding consumer session", embeddingIdleRebuildAfter)
+					}
 					// 超时，检查是否需要更新任务状态
 					if totalProcessed > buildTaskInfo.VectorizedCount && time.Since(lastUpdateTime) > updateInterval {
 						_ = eh.taskAccess.UpdateStatus(ctx, buildTaskInfo.ID, map[string]interface{}{"vectorizedCount": totalProcessed})
@@ -228,7 +238,7 @@ func (eh *embeddingHandler) executeEmbedding(ctx context.Context, resource *inte
 					// 原地重试只会让任务永久冻结：放弃本轮，交给 asynq 重试重建
 					// reader 与消费组会话，从已提交位点续读
 					consecutiveReadErrs++
-					if consecutiveReadErrs >= embeddingReadMaxConsecutiveErrors {
+					if consecutiveReadErrs >= embeddingKafkaMaxConsecutiveErrors {
 						_ = eh.taskAccess.UpdateStatus(ctx, buildTaskInfo.ID, map[string]interface{}{"vectorizedCount": totalProcessed})
 						return fmt.Errorf("read message from kafka: %w", err)
 					}
@@ -237,11 +247,12 @@ func (eh *embeddingHandler) executeEmbedding(ctx context.Context, resource *inte
 				continue
 			}
 			consecutiveReadErrs = 0
+			lastMessageTime = time.Now()
 
 			// 解析文档 ID；畸形消息重试无意义：提交跳过，避免后续位点提交把它悄悄盖掉
 			docID := extractDocID(msg.Value)
 			if docID == "" {
-				_ = eh.kafkaAccess.CommitMessages(ctx, reader, msg)
+				_ = eh.commitMessages(reader, msg)
 				continue
 			}
 
@@ -252,7 +263,7 @@ func (eh *embeddingHandler) executeEmbedding(ctx context.Context, resource *inte
 			if docID == interfaces.EmptyDocumentID {
 				// 触发哨兵立刻提交：Kafka 提交是绝对位点、后写覆盖，若留到收尾才提交，
 				// 会把 drain 期间已推进的位点倒拨回哨兵处，下次启动整段重放、计数虚高
-				if err := eh.kafkaAccess.CommitMessages(ctx, reader, msg); err != nil {
+				if err := eh.commitMessages(reader, msg); err != nil {
 					logger.Errorf("Failed to commit end sentinel for task %s: %v", buildTaskInfo.ID, err)
 				}
 				emptyPolls := 0
@@ -278,7 +289,7 @@ func (eh *embeddingHandler) executeEmbedding(ctx context.Context, resource *inte
 							countProcessed(dDocID)
 						}
 					}
-					_ = eh.kafkaAccess.CommitMessages(ctx, reader, dmsg)
+					_ = eh.commitMessages(reader, dmsg)
 				}
 
 				// 排空后补扫重试耗尽的失败文档
@@ -351,8 +362,17 @@ func (eh *embeddingHandler) executeEmbedding(ctx context.Context, resource *inte
 			}
 
 			// Commit the message to avoid reprocessing
-			if err := eh.kafkaAccess.CommitMessages(ctx, reader, msg); err != nil {
+			if err := eh.commitMessages(reader, msg); err != nil {
 				logger.Errorf("Failed to commit message: %v", err)
+				// 会话死亡后提交永远失败，位点不再推进：放弃本轮交给 asynq 重建会话，
+				// 已处理未提交的文档重放时由 per-doc 去重计数兜底
+				consecutiveCommitErrs++
+				if consecutiveCommitErrs >= embeddingKafkaMaxConsecutiveErrors {
+					_ = eh.taskAccess.UpdateStatus(ctx, buildTaskInfo.ID, map[string]interface{}{"vectorizedCount": totalProcessed})
+					return fmt.Errorf("commit message to kafka: %w", err)
+				}
+			} else {
+				consecutiveCommitErrs = 0
 			}
 		}
 	}
@@ -393,9 +413,23 @@ func (eh *embeddingHandler) vectorizeDocWithRetry(ctx context.Context, indexName
 	return vErr
 }
 
-// 连续非超时读错误达到该次数即放弃本轮执行：消费组协调连接一旦死亡，
+// 连续非超时读错误/提交失败达到该次数即放弃本轮执行：消费组协调连接一旦死亡，
 // 旧 reader 上的读写永远失败，必须由 asynq 重试重建会话
-const embeddingReadMaxConsecutiveErrors = 3
+const embeddingKafkaMaxConsecutiveErrors = 3
+
+// 位点提交的有界超时：asynq 任务 ctx 无截止时间，消费组会话死亡后 kafka-go 的
+// CommitMessages 会在无界 ctx 上永久阻塞，消费循环静默冻结且不响应 stop
+const embeddingCommitTimeout = 30 * time.Second
+
+// 批量任务连续读不到任何消息的重建阈值（见循环内看门狗注释）
+const embeddingIdleRebuildAfter = 10 * time.Minute
+
+// commitMessages 带有界超时提交位点
+func (eh *embeddingHandler) commitMessages(reader *kafka.Reader, msgs ...kafka.Message) error {
+	cctx, cancel := context.WithTimeout(context.Background(), embeddingCommitTimeout)
+	defer cancel()
+	return eh.kafkaAccess.CommitMessages(cctx, reader, msgs...)
+}
 
 // vectorizeDoc 对单个文档执行取数→嵌入→写回，返回错误表示本次尝试整体失败、可重试
 func (eh *embeddingHandler) vectorizeDoc(ctx context.Context, indexName, docID, model string, embeddingFields []string) error {

--- a/adp/vega/vega-backend/server/worker/build_handler_embedding.go
+++ b/adp/vega/vega-backend/server/worker/build_handler_embedding.go
@@ -229,25 +229,45 @@ func (eh *embeddingHandler) executeEmbedding(ctx context.Context, resource *inte
 			}
 			consecutiveReadErrs = 0
 
-			// Parse Kafka message to extract document ID
-			var messageData map[string]any
-			if err := sonic.Unmarshal(msg.Value, &messageData); err != nil {
-				// 消息畸形，重试无意义：提交跳过，避免后续位点提交把它悄悄盖掉
-				logger.Errorf("Failed to unmarshal message value: %v", err)
+			// 解析文档 ID；畸形消息重试无意义：提交跳过，避免后续位点提交把它悄悄盖掉
+			docID := extractDocID(msg.Value)
+			if docID == "" {
 				_ = eh.kafkaAccess.CommitMessages(ctx, reader, msg)
 				continue
 			}
 
-			// Get document ID from message
-			docID, ok := messageData["document_id"].(string)
-			if !ok || docID == "" {
-				logger.Errorf("Invalid document ID in message")
-				_ = eh.kafkaAccess.CommitMessages(ctx, reader, msg)
-				continue
-			}
-
-			// 结束哨兵：同步侧已发完全部文档，先补扫失败文档，再收尾
+			// 结束哨兵。哨兵不可直接信任：上一轮哨兵 commit 失败会留在原位，新消费者
+			// 一上来先读到旧哨兵，若立即收尾则本轮文档原封未动（线上复现：teams 重建后
+			// LAG=89，向量一个没写）。先把队列排空——连续 N 次空轮询才认为干净，
+			// 途中文档照常处理、多余哨兵只提交不重复收尾
 			if docID == interfaces.EmptyDocumentID {
+				emptyPolls := 0
+				for emptyPolls < embeddingDrainEmptyPolls {
+					drainCtx, cancelDrain := context.WithTimeout(context.Background(), embeddingDrainPollTimeout)
+					dmsg, derr := eh.kafkaAccess.ReadMessage(drainCtx, reader)
+					cancelDrain()
+					if derr != nil {
+						if errors.Is(derr, context.DeadlineExceeded) {
+							emptyPolls++
+							continue
+						}
+						logger.Errorf("Drain read failed for task %s: %v", buildTaskInfo.ID, derr)
+						_ = eh.taskAccess.UpdateStatus(ctx, buildTaskInfo.ID, map[string]interface{}{"vectorizedCount": totalProcessed})
+						return fmt.Errorf("drain read message from kafka: %w", derr)
+					}
+					emptyPolls = 0
+					dDocID := extractDocID(dmsg.Value)
+					if dDocID != "" && dDocID != interfaces.EmptyDocumentID {
+						if err := eh.vectorizeDocWithRetry(ctx, indexName, dDocID, buildTaskInfo.EmbeddingModel, embeddingFields, retryInterval); err != nil {
+							failedDocIDs = append(failedDocIDs, dDocID)
+						} else {
+							totalProcessed++
+						}
+					}
+					_ = eh.kafkaAccess.CommitMessages(ctx, reader, dmsg)
+				}
+
+				// 排空后补扫重试耗尽的失败文档
 				stillFailed := []string{}
 				for _, failedID := range failedDocIDs {
 					if err := eh.vectorizeDoc(ctx, indexName, failedID, buildTaskInfo.EmbeddingModel, embeddingFields); err != nil {
@@ -302,17 +322,7 @@ func (eh *embeddingHandler) executeEmbedding(ctx context.Context, resource *inte
 			// 单文档带重试：嵌入服务限流等瞬时错误最常见。
 			// 重试耗尽则记入失败清单并照常提交位点——原先的 sleep+continue 看似会重试，
 			// 实际 reader 已前移，后续消息提交位点时把失败文档悄悄盖掉，向量永久缺失且无痕迹
-			var vErr error
-			for attempt := 1; attempt <= embeddingDocMaxAttempts; attempt++ {
-				if vErr = eh.vectorizeDoc(ctx, indexName, docID, buildTaskInfo.EmbeddingModel, embeddingFields); vErr == nil {
-					break
-				}
-				logger.Errorf("Vectorize document %s attempt %d/%d failed: %v", docID, attempt, embeddingDocMaxAttempts, vErr)
-				if attempt < embeddingDocMaxAttempts {
-					eh.pause(retryInterval)
-				}
-			}
-			if vErr != nil {
+			if err := eh.vectorizeDocWithRetry(ctx, indexName, docID, buildTaskInfo.EmbeddingModel, embeddingFields, retryInterval); err != nil {
 				failedDocIDs = append(failedDocIDs, docID)
 			} else {
 				totalProcessed++
@@ -334,6 +344,38 @@ func (eh *embeddingHandler) executeEmbedding(ctx context.Context, resource *inte
 
 // 单文档向量化的最大尝试次数（含首次）；超过后记入失败清单，完成前补扫一轮
 const embeddingDocMaxAttempts = 3
+
+// 哨兵后的排空参数：连续 N 次空轮询（每次最长等待 PollTimeout）认为队列已干净
+const (
+	embeddingDrainEmptyPolls  = 2
+	embeddingDrainPollTimeout = 10 * time.Second
+)
+
+// extractDocID 解析嵌入消息中的 document_id；畸形消息返回空串（调用方提交跳过）
+func extractDocID(value []byte) string {
+	var messageData map[string]any
+	if err := sonic.Unmarshal(value, &messageData); err != nil {
+		logger.Errorf("Failed to unmarshal message value: %v", err)
+		return ""
+	}
+	docID, _ := messageData["document_id"].(string)
+	return docID
+}
+
+// vectorizeDocWithRetry 带有界重试的单文档向量化；返回错误表示重试已耗尽
+func (eh *embeddingHandler) vectorizeDocWithRetry(ctx context.Context, indexName, docID, model string, embeddingFields []string, retryInterval time.Duration) error {
+	var vErr error
+	for attempt := 1; attempt <= embeddingDocMaxAttempts; attempt++ {
+		if vErr = eh.vectorizeDoc(ctx, indexName, docID, model, embeddingFields); vErr == nil {
+			return nil
+		}
+		logger.Errorf("Vectorize document %s attempt %d/%d failed: %v", docID, attempt, embeddingDocMaxAttempts, vErr)
+		if attempt < embeddingDocMaxAttempts {
+			eh.pause(retryInterval)
+		}
+	}
+	return vErr
+}
 
 // 连续非超时读错误达到该次数即放弃本轮执行：消费组协调连接一旦死亡，
 // 旧 reader 上的读写永远失败，必须由 asynq 重试重建会话

--- a/adp/vega/vega-backend/server/worker/build_handler_embedding.go
+++ b/adp/vega/vega-backend/server/worker/build_handler_embedding.go
@@ -35,6 +35,16 @@ type embeddingHandler struct {
 	connector   connectors.IndexConnector
 	kafkaAccess interfaces.KafkaAccess
 	mfa         interfaces.ModelFactoryAccess
+	sleep       func(time.Duration) // 重试等待，测试中注入空实现避免真实 sleep
+}
+
+// pause 等待指定时长；未注入时使用 time.Sleep
+func (eh *embeddingHandler) pause(d time.Duration) {
+	if eh.sleep != nil {
+		eh.sleep(d)
+		return
+	}
+	time.Sleep(d)
 }
 
 // NewEmbeddingBuildHandler creates a new embedding handler.
@@ -156,12 +166,13 @@ func (eh *embeddingHandler) executeEmbedding(ctx context.Context, resource *inte
 	failedDocIDs := []string{}
 	lastUpdateTime := time.Now()
 	updateInterval := 30 * time.Second // embedding速度慢，至少每30秒更新一次
+	consecutiveReadErrs := 0           // 连续非超时读错误计数，达到上限放弃本轮交给 asynq 重试
 	for {
 		// Check task status before each iteration
 		taskStatus, err := eh.taskAccess.GetStatus(ctx, buildTaskInfo.ID)
 		if err != nil {
 			logger.Errorf("Failed to get task status: %v", err)
-			time.Sleep(retryInterval)
+			eh.pause(retryInterval)
 			continue
 		}
 
@@ -183,16 +194,19 @@ func (eh *embeddingHandler) executeEmbedding(ctx context.Context, resource *inte
 			logger.Infof("Kafka subscription context canceled, exiting")
 			// 最后一次更新任务状态
 			_ = eh.taskAccess.UpdateStatus(context.Background(), buildTaskInfo.ID, map[string]interface{}{"vectorizedCount": totalProcessed})
-			return nil
+			// 必须返回错误：返回 nil 会让 asynq 把任务标记成功，重启后不再投递，
+			// 任务状态永久停在 running（界面"构建中"冻结），只能人工 stop→start 救活
+			return ctx.Err()
 		default:
 			// 创建带超时的上下文，避免ReadMessage一直阻塞
 			timeoutCtx, cancel := context.WithTimeout(context.Background(), updateInterval)
-			defer cancel()
 
 			// Read message from Kafka
 			msg, err := eh.kafkaAccess.ReadMessage(timeoutCtx, reader)
+			cancel()
 			if err != nil {
 				if errors.Is(err, context.DeadlineExceeded) {
+					consecutiveReadErrs = 0
 					// 超时，检查是否需要更新任务状态
 					if totalProcessed > buildTaskInfo.VectorizedCount && time.Since(lastUpdateTime) > updateInterval {
 						_ = eh.taskAccess.UpdateStatus(ctx, buildTaskInfo.ID, map[string]interface{}{"vectorizedCount": totalProcessed})
@@ -201,10 +215,19 @@ func (eh *embeddingHandler) executeEmbedding(ctx context.Context, resource *inte
 					}
 				} else {
 					logger.Errorf("Embedding task Failed to read message from Kafka: %v", err)
-					time.Sleep(retryInterval)
+					// 消费组协调连接死亡（broker 重启/rebalance）后读取永远失败，
+					// 原地重试只会让任务永久冻结：放弃本轮，交给 asynq 重试重建
+					// reader 与消费组会话，从已提交位点续读
+					consecutiveReadErrs++
+					if consecutiveReadErrs >= embeddingReadMaxConsecutiveErrors {
+						_ = eh.taskAccess.UpdateStatus(ctx, buildTaskInfo.ID, map[string]interface{}{"vectorizedCount": totalProcessed})
+						return fmt.Errorf("read message from kafka: %w", err)
+					}
+					eh.pause(retryInterval)
 				}
 				continue
 			}
+			consecutiveReadErrs = 0
 
 			// Parse Kafka message to extract document ID
 			var messageData map[string]any
@@ -242,9 +265,21 @@ func (eh *embeddingHandler) executeEmbedding(ctx context.Context, resource *inte
 					return fmt.Errorf("update resource index name: %w", err)
 				}
 
+				// 哨兵到达说明同步侧已发完、且组内已消费全部文档消息。
+				// 同任务可能短暂存在两个消费者（asynq 重投的旧实例 + 新一轮入队的实例），
+				// 单分区下旧实例抢走文档、新实例只读到哨兵，内存计数只覆盖自己的切片；
+				// 以最新 synced - 已知失败 为下限对齐，避免完成态写出 0 这类假计数
+				finalCount := totalProcessed
+				if fresh, err := eh.taskAccess.GetByID(ctx, buildTaskInfo.ID); err == nil && fresh != nil {
+					if c := fresh.SyncedCount - int64(len(stillFailed)); c > finalCount {
+						logger.Infof("Embedding count for task %s aligned to synced: local=%d, final=%d (split consumers suspected)", buildTaskInfo.ID, totalProcessed, c)
+						finalCount = c
+					}
+				}
+
 				updates := map[string]interface{}{
 					"status":          interfaces.BuildTaskStatusCompleted,
-					"vectorizedCount": totalProcessed,
+					"vectorizedCount": finalCount,
 				}
 				// 重试耗尽的文档如实记录：完成态但向量不全时，error_msg 说明缺了哪些
 				if len(stillFailed) > 0 {
@@ -256,9 +291,11 @@ func (eh *embeddingHandler) executeEmbedding(ctx context.Context, resource *inte
 					logger.Errorf("update build task status to completed failed: task %s, %v", buildTaskInfo.ID, err)
 				}
 
-				// Commit the message to avoid reprocessing
-				_ = eh.kafkaAccess.CommitMessages(ctx, reader, msg)
-				logger.Infof("Embedding finished for task %s: %d processed, %d failed", buildTaskInfo.ID, totalProcessed, len(stillFailed))
+				// 哨兵提交失败会在消费组留下 LAG 并触发日后重投，必须留痕
+				if err := eh.kafkaAccess.CommitMessages(ctx, reader, msg); err != nil {
+					logger.Errorf("Failed to commit end sentinel for task %s: %v", buildTaskInfo.ID, err)
+				}
+				logger.Infof("Embedding finished for task %s: %d processed, %d failed", buildTaskInfo.ID, finalCount, len(stillFailed))
 				return nil
 			}
 
@@ -272,7 +309,7 @@ func (eh *embeddingHandler) executeEmbedding(ctx context.Context, resource *inte
 				}
 				logger.Errorf("Vectorize document %s attempt %d/%d failed: %v", docID, attempt, embeddingDocMaxAttempts, vErr)
 				if attempt < embeddingDocMaxAttempts {
-					time.Sleep(retryInterval)
+					eh.pause(retryInterval)
 				}
 			}
 			if vErr != nil {
@@ -297,6 +334,10 @@ func (eh *embeddingHandler) executeEmbedding(ctx context.Context, resource *inte
 
 // 单文档向量化的最大尝试次数（含首次）；超过后记入失败清单，完成前补扫一轮
 const embeddingDocMaxAttempts = 3
+
+// 连续非超时读错误达到该次数即放弃本轮执行：消费组协调连接一旦死亡，
+// 旧 reader 上的读写永远失败，必须由 asynq 重试重建会话
+const embeddingReadMaxConsecutiveErrors = 3
 
 // vectorizeDoc 对单个文档执行取数→嵌入→写回，返回错误表示本次尝试整体失败、可重试
 func (eh *embeddingHandler) vectorizeDoc(ctx context.Context, indexName, docID, model string, embeddingFields []string) error {

--- a/adp/vega/vega-backend/server/worker/build_handler_embedding.go
+++ b/adp/vega/vega-backend/server/worker/build_handler_embedding.go
@@ -151,6 +151,9 @@ func (eh *embeddingHandler) executeEmbedding(ctx context.Context, resource *inte
 	// Message processing loop
 	retryInterval := interfaces.BUILD_TASK_RETRY_INTERVAL * time.Second
 	totalProcessed := buildTaskInfo.VectorizedCount
+	// 重试耗尽仍失败的文档：完成前补扫一轮，仍失败则写入 error_msg
+	// （仅会话内记录；worker 中途崩溃时这些文档的位点已提交，靠全量重跑恢复）
+	failedDocIDs := []string{}
 	lastUpdateTime := time.Now()
 	updateInterval := 30 * time.Second // embedding速度慢，至少每30秒更新一次
 	for {
@@ -206,8 +209,9 @@ func (eh *embeddingHandler) executeEmbedding(ctx context.Context, resource *inte
 			// Parse Kafka message to extract document ID
 			var messageData map[string]any
 			if err := sonic.Unmarshal(msg.Value, &messageData); err != nil {
+				// 消息畸形，重试无意义：提交跳过，避免后续位点提交把它悄悄盖掉
 				logger.Errorf("Failed to unmarshal message value: %v", err)
-				time.Sleep(retryInterval)
+				_ = eh.kafkaAccess.CommitMessages(ctx, reader, msg)
 				continue
 			}
 
@@ -215,84 +219,67 @@ func (eh *embeddingHandler) executeEmbedding(ctx context.Context, resource *inte
 			docID, ok := messageData["document_id"].(string)
 			if !ok || docID == "" {
 				logger.Errorf("Invalid document ID in message")
-				time.Sleep(retryInterval)
+				_ = eh.kafkaAccess.CommitMessages(ctx, reader, msg)
 				continue
 			}
 
-			// Get document from dataset
-			document, err := eh.ds.GetDocument(ctx, indexName, docID)
-			if err != nil {
-				// Check if document ID is EmptyDocumentID
-				if docID == interfaces.EmptyDocumentID {
-					logger.Infof("Empty document ID detected, skipping: %s", docID)
-
-					// Update resource index name
-					indexName := getIndexName(resource.ID, buildTaskInfo.ID)
-					err = updateResourceIndexName(ctx, resource, eh.resAccess, eh.ds, indexName)
-					if err != nil {
-						logger.Errorf("Failed to update resource index name: %v", err)
-						time.Sleep(retryInterval)
-						continue
-					}
-
-					// Update task status to completed；必须同时回写最终计数：
-					// 常规回写有 30 秒批量窗口，不在这里 flush 会丢最后一个窗口的进度
-					// （短任务整个跑完都在首个窗口内，界面会停在 0%）
-					err = eh.taskAccess.UpdateStatus(ctx, buildTaskInfo.ID, map[string]interface{}{"status": interfaces.BuildTaskStatusCompleted, "vectorizedCount": totalProcessed})
-					if err != nil {
-						logger.Errorf("update build task status to completed failed: %w", buildTaskInfo.ID, err)
-					}
-
-					// Commit the message to avoid reprocessing
-					_ = eh.kafkaAccess.CommitMessages(ctx, reader, msg)
-					logger.Infof("CommitMessages")
-					return nil
-				}
-				logger.Errorf("Failed to get document %s: %v", docID, err)
-				time.Sleep(retryInterval)
-				continue
-			}
-
-			// 处理结果并进行嵌入
-			updateDoc := make(map[string]any)
-			fields := []string{}
-			words := []string{}
-			for _, field := range embeddingFields {
-				if value, exists := document[field]; exists {
-					if text, ok := value.(string); ok && text != "" {
-						fields = append(fields, field)
-						words = append(words, text)
+			// 结束哨兵：同步侧已发完全部文档，先补扫失败文档，再收尾
+			if docID == interfaces.EmptyDocumentID {
+				stillFailed := []string{}
+				for _, failedID := range failedDocIDs {
+					if err := eh.vectorizeDoc(ctx, indexName, failedID, buildTaskInfo.EmbeddingModel, embeddingFields); err != nil {
+						logger.Errorf("Vectorize document %s failed in final sweep: %v", failedID, err)
+						stillFailed = append(stillFailed, failedID)
+					} else {
+						totalProcessed++
 					}
 				}
-			}
-			vectorResp, err := eh.mfa.GetVector(ctx, buildTaskInfo.EmbeddingModel, words)
-			if err != nil || len(vectorResp) != len(words) {
-				logger.Errorf("GetVector failed: %v", err)
-				time.Sleep(retryInterval)
-				continue
-			}
-			for i, field := range fields {
-				if resp := vectorResp[i]; resp.Vector != nil {
-					updateDoc[field+"_vector"] = resp.Vector
+
+				// 索引名落账持久失败则不提交哨兵，整个任务交给 asynq 重试：
+				// 重启后从最后提交位点续读，哨兵会重新投递
+				if err := updateResourceIndexName(ctx, resource, eh.resAccess, eh.ds, indexName); err != nil {
+					logger.Errorf("Failed to update resource index name: %v", err)
+					return fmt.Errorf("update resource index name: %w", err)
 				}
+
+				updates := map[string]interface{}{
+					"status":          interfaces.BuildTaskStatusCompleted,
+					"vectorizedCount": totalProcessed,
+				}
+				// 重试耗尽的文档如实记录：完成态但向量不全时，error_msg 说明缺了哪些
+				if len(stillFailed) > 0 {
+					updates["errorMsg"] = formatVectorizeFailures(stillFailed)
+				}
+				// 必须同时回写最终计数：常规回写有 30 秒批量窗口，
+				// 不在这里 flush 会丢最后一个窗口的进度（短任务界面会停在 0%）
+				if err := eh.taskAccess.UpdateStatus(ctx, buildTaskInfo.ID, updates); err != nil {
+					logger.Errorf("update build task status to completed failed: task %s, %v", buildTaskInfo.ID, err)
+				}
+
+				// Commit the message to avoid reprocessing
+				_ = eh.kafkaAccess.CommitMessages(ctx, reader, msg)
+				logger.Infof("Embedding finished for task %s: %d processed, %d failed", buildTaskInfo.ID, totalProcessed, len(stillFailed))
+				return nil
 			}
 
-			// 保存嵌入结果
-			if len(updateDoc) > 0 {
-				updateReq := map[string]any{
-					"id":       docID,
-					"document": updateDoc,
+			// 单文档带重试：嵌入服务限流等瞬时错误最常见。
+			// 重试耗尽则记入失败清单并照常提交位点——原先的 sleep+continue 看似会重试，
+			// 实际 reader 已前移，后续消息提交位点时把失败文档悄悄盖掉，向量永久缺失且无痕迹
+			var vErr error
+			for attempt := 1; attempt <= embeddingDocMaxAttempts; attempt++ {
+				if vErr = eh.vectorizeDoc(ctx, indexName, docID, buildTaskInfo.EmbeddingModel, embeddingFields); vErr == nil {
+					break
 				}
-				_, err := eh.ds.UpsertDocuments(ctx, indexName, []map[string]any{updateReq})
-				if err != nil {
-					logger.Errorf("Update document failed: %v", err)
+				logger.Errorf("Vectorize document %s attempt %d/%d failed: %v", docID, attempt, embeddingDocMaxAttempts, vErr)
+				if attempt < embeddingDocMaxAttempts {
 					time.Sleep(retryInterval)
-					continue
 				}
 			}
-			// 源字段全为空的文档没有可嵌入文本，同样计入已处理：
-			// 分母（synced_count）包含它们，不计数则进度永远到不了 100%
-			totalProcessed++
+			if vErr != nil {
+				failedDocIDs = append(failedDocIDs, docID)
+			} else {
+				totalProcessed++
+			}
 
 			// 批量更新任务状态
 			if time.Since(lastUpdateTime) > updateInterval {
@@ -306,4 +293,72 @@ func (eh *embeddingHandler) executeEmbedding(ctx context.Context, resource *inte
 			}
 		}
 	}
+}
+
+// 单文档向量化的最大尝试次数（含首次）；超过后记入失败清单，完成前补扫一轮
+const embeddingDocMaxAttempts = 3
+
+// vectorizeDoc 对单个文档执行取数→嵌入→写回，返回错误表示本次尝试整体失败、可重试
+func (eh *embeddingHandler) vectorizeDoc(ctx context.Context, indexName, docID, model string, embeddingFields []string) error {
+	document, err := eh.ds.GetDocument(ctx, indexName, docID)
+	if err != nil {
+		return fmt.Errorf("get document: %w", err)
+	}
+
+	fields := []string{}
+	words := []string{}
+	for _, field := range embeddingFields {
+		if value, exists := document[field]; exists {
+			if text, ok := value.(string); ok && text != "" {
+				fields = append(fields, field)
+				words = append(words, text)
+			}
+		}
+	}
+	// 源字段全为空的文档没有可嵌入文本，视为成功：
+	// 分母（synced_count）包含它们，不计数则进度永远到不了 100%
+	if len(words) == 0 {
+		return nil
+	}
+
+	vectorResp, err := eh.mfa.GetVector(ctx, model, words)
+	if err != nil {
+		return fmt.Errorf("get vector: %w", err)
+	}
+	if len(vectorResp) != len(words) {
+		return fmt.Errorf("get vector: got %d vectors for %d texts", len(vectorResp), len(words))
+	}
+
+	updateDoc := make(map[string]any)
+	for i, field := range fields {
+		if resp := vectorResp[i]; resp.Vector != nil {
+			updateDoc[field+"_vector"] = resp.Vector
+		}
+	}
+	if len(updateDoc) == 0 {
+		return nil
+	}
+
+	updateReq := map[string]any{
+		"id":       docID,
+		"document": updateDoc,
+	}
+	if _, err := eh.ds.UpsertDocuments(ctx, indexName, []map[string]any{updateReq}); err != nil {
+		return fmt.Errorf("upsert document: %w", err)
+	}
+	return nil
+}
+
+// formatVectorizeFailures 生成完成态下向量缺失的说明，ID 列表截断避免撑爆 error_msg
+func formatVectorizeFailures(failed []string) string {
+	const maxListed = 20
+	listed := failed
+	if len(listed) > maxListed {
+		listed = listed[:maxListed]
+	}
+	msg := fmt.Sprintf("vectorization failed for %d documents: %s", len(failed), strings.Join(listed, ","))
+	if len(failed) > maxListed {
+		msg += fmt.Sprintf(" ... and %d more", len(failed)-maxListed)
+	}
+	return msg
 }

--- a/adp/vega/vega-backend/server/worker/build_handler_embedding.go
+++ b/adp/vega/vega-backend/server/worker/build_handler_embedding.go
@@ -164,6 +164,15 @@ func (eh *embeddingHandler) executeEmbedding(ctx context.Context, resource *inte
 	// 重试耗尽仍失败的文档：完成前补扫一轮，仍失败则写入 error_msg
 	// （仅会话内记录；worker 中途崩溃时这些文档的位点已提交，靠全量重跑恢复）
 	failedDocIDs := []string{}
+	// 会话内已计数文档：位点倒拨/重复投递会让同一文档消息被处理多次，
+	// 向量写入幂等无害，但计数会虚高出 vectorized > synced，按 docID 去重
+	seenDocIDs := map[string]struct{}{}
+	countProcessed := func(docID string) {
+		if _, ok := seenDocIDs[docID]; !ok {
+			seenDocIDs[docID] = struct{}{}
+			totalProcessed++
+		}
+	}
 	lastUpdateTime := time.Now()
 	updateInterval := 30 * time.Second // embedding速度慢，至少每30秒更新一次
 	consecutiveReadErrs := 0           // 连续非超时读错误计数，达到上限放弃本轮交给 asynq 重试
@@ -266,7 +275,7 @@ func (eh *embeddingHandler) executeEmbedding(ctx context.Context, resource *inte
 						if err := eh.vectorizeDocWithRetry(ctx, indexName, dDocID, buildTaskInfo.EmbeddingModel, embeddingFields, retryInterval); err != nil {
 							failedDocIDs = append(failedDocIDs, dDocID)
 						} else {
-							totalProcessed++
+							countProcessed(dDocID)
 						}
 					}
 					_ = eh.kafkaAccess.CommitMessages(ctx, reader, dmsg)
@@ -279,7 +288,7 @@ func (eh *embeddingHandler) executeEmbedding(ctx context.Context, resource *inte
 						logger.Errorf("Vectorize document %s failed in final sweep: %v", failedID, err)
 						stillFailed = append(stillFailed, failedID)
 					} else {
-						totalProcessed++
+						countProcessed(failedID)
 					}
 				}
 
@@ -293,12 +302,17 @@ func (eh *embeddingHandler) executeEmbedding(ctx context.Context, resource *inte
 				// 哨兵到达说明同步侧已发完、且组内已消费全部文档消息。
 				// 同任务可能短暂存在两个消费者（asynq 重投的旧实例 + 新一轮入队的实例），
 				// 单分区下旧实例抢走文档、新实例只读到哨兵，内存计数只覆盖自己的切片；
-				// 以最新 synced - 已知失败 为下限对齐，避免完成态写出 0 这类假计数
+				// 以最新 synced - 已知失败 为下限、synced 为上限对齐：
+				// 向量数不可能超过同步数，历史重放/恢复续跑造成的虚高一并封顶
 				finalCount := totalProcessed
 				if fresh, err := eh.taskAccess.GetByID(ctx, buildTaskInfo.ID); err == nil && fresh != nil {
 					if c := fresh.SyncedCount - int64(len(stillFailed)); c > finalCount {
 						logger.Infof("Embedding count for task %s aligned to synced: local=%d, final=%d (split consumers suspected)", buildTaskInfo.ID, totalProcessed, c)
 						finalCount = c
+					}
+					if finalCount > fresh.SyncedCount {
+						logger.Infof("Embedding count for task %s capped at synced: local=%d, synced=%d (replayed messages suspected)", buildTaskInfo.ID, finalCount, fresh.SyncedCount)
+						finalCount = fresh.SyncedCount
 					}
 				}
 
@@ -327,7 +341,7 @@ func (eh *embeddingHandler) executeEmbedding(ctx context.Context, resource *inte
 			if err := eh.vectorizeDocWithRetry(ctx, indexName, docID, buildTaskInfo.EmbeddingModel, embeddingFields, retryInterval); err != nil {
 				failedDocIDs = append(failedDocIDs, docID)
 			} else {
-				totalProcessed++
+				countProcessed(docID)
 			}
 
 			// 批量更新任务状态

--- a/adp/vega/vega-backend/server/worker/build_handler_embedding.go
+++ b/adp/vega/vega-backend/server/worker/build_handler_embedding.go
@@ -241,6 +241,11 @@ func (eh *embeddingHandler) executeEmbedding(ctx context.Context, resource *inte
 			// LAG=89，向量一个没写）。先把队列排空——连续 N 次空轮询才认为干净，
 			// 途中文档照常处理、多余哨兵只提交不重复收尾
 			if docID == interfaces.EmptyDocumentID {
+				// 触发哨兵立刻提交：Kafka 提交是绝对位点、后写覆盖，若留到收尾才提交，
+				// 会把 drain 期间已推进的位点倒拨回哨兵处，下次启动整段重放、计数虚高
+				if err := eh.kafkaAccess.CommitMessages(ctx, reader, msg); err != nil {
+					logger.Errorf("Failed to commit end sentinel for task %s: %v", buildTaskInfo.ID, err)
+				}
 				emptyPolls := 0
 				for emptyPolls < embeddingDrainEmptyPolls {
 					drainCtx, cancelDrain := context.WithTimeout(context.Background(), embeddingDrainPollTimeout)
@@ -311,10 +316,7 @@ func (eh *embeddingHandler) executeEmbedding(ctx context.Context, resource *inte
 					logger.Errorf("update build task status to completed failed: task %s, %v", buildTaskInfo.ID, err)
 				}
 
-				// 哨兵提交失败会在消费组留下 LAG 并触发日后重投，必须留痕
-				if err := eh.kafkaAccess.CommitMessages(ctx, reader, msg); err != nil {
-					logger.Errorf("Failed to commit end sentinel for task %s: %v", buildTaskInfo.ID, err)
-				}
+				// 触发哨兵已在 drain 入口提交；这里不可再提交——会把位点倒拨回哨兵处
 				logger.Infof("Embedding finished for task %s: %d processed, %d failed", buildTaskInfo.ID, finalCount, len(stillFailed))
 				return nil
 			}

--- a/adp/vega/vega-backend/server/worker/build_handler_embedding_loop_test.go
+++ b/adp/vega/vega-backend/server/worker/build_handler_embedding_loop_test.go
@@ -1,0 +1,115 @@
+// Copyright 2026 openbkn.ai
+// Copyright The kweaver.ai Authors.
+//
+// Licensed under the Apache License, Version 2.0.
+// See the LICENSE file in the project root for details.
+
+package worker
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/segmentio/kafka-go"
+	"go.uber.org/mock/gomock"
+
+	"vega-backend/interfaces"
+	vmock "vega-backend/interfaces/mock"
+)
+
+// 复现两个把任务永久冻成"构建中"的 bug：
+//
+// 1. 进程收到 SIGTERM（pod 更替）时 ctx 取消，executeEmbedding 返回 nil——asynq 把
+//    任务标记为成功，重启后不再投递，任务状态停在 running，向量化进度永久冻结，
+//    只能人工 stop→start 救活。取消必须返回 ctx.Err()，让 asynq 重启后重试续跑。
+//
+// 2. 消费组协调连接死亡（broker 重启/rebalance）后，reader 上的读和位点提交永远
+//    返回 "use of closed network connection"，原实现 sleep+continue 在死 reader 上
+//    无限重试，任务同样永久冻结。连续非超时读错误必须放弃本轮、返回错误，由 asynq
+//    重试重建 reader 与消费组会话，从已提交位点续读。
+//
+// 两条路径都必须先回写 vectorizedCount，否则丢最后一个批量窗口的进度。
+
+func newLoopHandler(t *testing.T) (*embeddingHandler, *vmock.MockBuildTaskAccess, *vmock.MockKafkaAccess) {
+	t.Helper()
+	ctrl := gomock.NewController(t)
+	ta := vmock.NewMockBuildTaskAccess(ctrl)
+	ka := vmock.NewMockKafkaAccess(ctrl)
+	return &embeddingHandler{
+		taskAccess:  ta,
+		kafkaAccess: ka,
+		sleep:       func(time.Duration) {},
+	}, ta, ka
+}
+
+func loopFixtures() (*interfaces.Resource, *interfaces.BuildTask) {
+	resource := &interfaces.Resource{ID: "r1"}
+	task := &interfaces.BuildTask{
+		ID:              "t1",
+		ResourceID:      "r1",
+		EmbeddingFields: "team_name",
+		EmbeddingModel:  "m1",
+		VectorizedCount: 7,
+	}
+	return resource, task
+}
+
+func expectKafkaSession(ka *vmock.MockKafkaAccess) {
+	ka.EXPECT().CreateTopic(gomock.Any(), gomock.Any()).Return(nil)
+	ka.EXPECT().NewReader(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, nil)
+	ka.EXPECT().CloseReader(gomock.Any())
+}
+
+func expectCountFlush(ta *vmock.MockBuildTaskAccess, count int64) *gomock.Call {
+	return ta.EXPECT().UpdateStatus(gomock.Any(), "t1", gomock.AssignableToTypeOf(map[string]interface{}{})).
+		DoAndReturn(func(_ context.Context, _ string, updates map[string]interface{}) error {
+			if got, ok := updates["vectorizedCount"].(int64); !ok || got != count {
+				return errors.New("vectorizedCount not flushed")
+			}
+			return nil
+		})
+}
+
+func TestExecuteEmbedding_CtxCanceledReturnsErrorForRequeue(t *testing.T) {
+	eh, ta, ka := newLoopHandler(t)
+	resource, task := loopFixtures()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // 模拟 SIGTERM：asynq 在关停时取消任务 ctx
+
+	expectKafkaSession(ka)
+	ta.EXPECT().GetStatus(gomock.Any(), "t1").Return(interfaces.BuildTaskStatusRunning, nil)
+	flush := expectCountFlush(ta, 7)
+
+	err := eh.executeEmbedding(ctx, resource, task)
+	if err == nil {
+		t.Fatal("ctx 取消必须返回错误让 asynq 重投递；返回 nil 任务被标成功，重启后永久冻结")
+	}
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("expected context.Canceled, got %v", err)
+	}
+	_ = flush
+}
+
+func TestExecuteEmbedding_PersistentReadErrorGivesUpForRetry(t *testing.T) {
+	eh, ta, ka := newLoopHandler(t)
+	resource, task := loopFixtures()
+
+	deadConn := errors.New("committing message: use of closed network connection")
+
+	expectKafkaSession(ka)
+	ta.EXPECT().GetStatus(gomock.Any(), "t1").Return(interfaces.BuildTaskStatusRunning, nil).Times(embeddingReadMaxConsecutiveErrors)
+	ka.EXPECT().ReadMessage(gomock.Any(), gomock.Any()).Return(kafka.Message{}, deadConn).Times(embeddingReadMaxConsecutiveErrors)
+	expectCountFlush(ta, 7)
+
+	err := eh.executeEmbedding(context.Background(), resource, task)
+	if err == nil {
+		t.Fatal("持久性读错误必须返回错误交给 asynq 重建 reader；sleep+continue 会在死连接上永久冻结")
+	}
+	if !strings.Contains(err.Error(), "use of closed network connection") {
+		t.Fatalf("expected wrapped read error, got %v", err)
+	}
+}

--- a/adp/vega/vega-backend/server/worker/build_handler_embedding_loop_test.go
+++ b/adp/vega/vega-backend/server/worker/build_handler_embedding_loop_test.go
@@ -94,6 +94,45 @@ func TestExecuteEmbedding_CtxCanceledReturnsErrorForRequeue(t *testing.T) {
 	_ = flush
 }
 
+// 复现 bug：消费组会话死亡后 kafka-go CommitMessages 在无界 ctx 上永久阻塞或持续
+// 失败，消费循环既不推进也不响应 stop（线上复现：任务冻在 10381/10401 六小时，
+// stop 后 60 秒状态仍是 stopping）。提交必须有界，连续提交失败必须放弃本轮交给
+// asynq 重建消费组会话。
+func TestExecuteEmbedding_PersistentCommitErrorGivesUpForRetry(t *testing.T) {
+	eh, ta, ka := newLoopHandler(t)
+	ctrl := gomock.NewController(t)
+	ds := vmock.NewMockDatasetService(ctrl)
+	eh.ds = ds
+	resource, task := loopFixtures()
+
+	deadCommit := errors.New("commit on dead generation")
+	docMsg := func(id string) kafka.Message {
+		return kafka.Message{Value: []byte(`{"document_id":"` + id + `"}`)}
+	}
+
+	expectKafkaSession(ka)
+	ta.EXPECT().GetStatus(gomock.Any(), "t1").Return(interfaces.BuildTaskStatusRunning, nil).AnyTimes()
+	gomock.InOrder(
+		ka.EXPECT().ReadMessage(gomock.Any(), gomock.Any()).Return(docMsg("d1"), nil),
+		ka.EXPECT().ReadMessage(gomock.Any(), gomock.Any()).Return(docMsg("d2"), nil),
+		ka.EXPECT().ReadMessage(gomock.Any(), gomock.Any()).Return(docMsg("d3"), nil),
+	)
+	// 空文本文档：vectorizeDoc 直接成功，不触发嵌入调用
+	ds.EXPECT().GetDocument(gomock.Any(), gomock.Any(), gomock.Any()).
+		Return(map[string]any{"team_name": ""}, nil).Times(3)
+	ka.EXPECT().CommitMessages(gomock.Any(), gomock.Any(), gomock.Any()).
+		Return(deadCommit).Times(embeddingKafkaMaxConsecutiveErrors)
+	ta.EXPECT().UpdateStatus(gomock.Any(), "t1", gomock.Any()).Return(nil).AnyTimes()
+
+	err := eh.executeEmbedding(context.Background(), resource, task)
+	if err == nil {
+		t.Fatal("连续提交失败必须返回错误交给 asynq 重建会话；否则循环静默冻结且不响应 stop")
+	}
+	if !strings.Contains(err.Error(), "commit") {
+		t.Fatalf("expected wrapped commit error, got %v", err)
+	}
+}
+
 func TestExecuteEmbedding_PersistentReadErrorGivesUpForRetry(t *testing.T) {
 	eh, ta, ka := newLoopHandler(t)
 	resource, task := loopFixtures()
@@ -101,8 +140,8 @@ func TestExecuteEmbedding_PersistentReadErrorGivesUpForRetry(t *testing.T) {
 	deadConn := errors.New("committing message: use of closed network connection")
 
 	expectKafkaSession(ka)
-	ta.EXPECT().GetStatus(gomock.Any(), "t1").Return(interfaces.BuildTaskStatusRunning, nil).Times(embeddingReadMaxConsecutiveErrors)
-	ka.EXPECT().ReadMessage(gomock.Any(), gomock.Any()).Return(kafka.Message{}, deadConn).Times(embeddingReadMaxConsecutiveErrors)
+	ta.EXPECT().GetStatus(gomock.Any(), "t1").Return(interfaces.BuildTaskStatusRunning, nil).Times(embeddingKafkaMaxConsecutiveErrors)
+	ka.EXPECT().ReadMessage(gomock.Any(), gomock.Any()).Return(kafka.Message{}, deadConn).Times(embeddingKafkaMaxConsecutiveErrors)
 	expectCountFlush(ta, 7)
 
 	err := eh.executeEmbedding(context.Background(), resource, task)

--- a/adp/vega/vega-backend/server/worker/build_handler_streaming.go
+++ b/adp/vega/vega-backend/server/worker/build_handler_streaming.go
@@ -87,6 +87,18 @@ func (sh *streamingBuildHandler) HandleTask(ctx context.Context, task *asynq.Tas
 		// Task not found, return nil
 		return nil
 	}
+	// 排队期间被停止的任务直接跳过，避免出队后复活覆写状态。
+	// stopping 出队说明原 worker 已不在，兜底落停。
+	if buildTaskInfo.Status == interfaces.BuildTaskStatusStopped ||
+		buildTaskInfo.Status == interfaces.BuildTaskStatusStopping {
+		logger.Infof("Task %s is %s, skip execution", taskID, buildTaskInfo.Status)
+		if buildTaskInfo.Status == interfaces.BuildTaskStatusStopping {
+			if err := sh.taskAccess.UpdateStatus(ctx, taskID, map[string]interface{}{"status": interfaces.BuildTaskStatusStopped}); err != nil {
+				return fmt.Errorf("update build task status failed: %w", err)
+			}
+		}
+		return nil
+	}
 	// 异步任务无原始请求上下文，以任务创建者身份执行下游权限检查
 	ctx = context.WithValue(ctx, interfaces.ACCOUNT_INFO_KEY, buildTaskInfo.Creator)
 	resourceID := buildTaskInfo.ResourceID

--- a/adp/vega/vega-backend/server/worker/build_handler_vectorize_test.go
+++ b/adp/vega/vega-backend/server/worker/build_handler_vectorize_test.go
@@ -1,0 +1,131 @@
+// Copyright 2026 openbkn.ai
+// Copyright The kweaver.ai Authors.
+//
+// Licensed under the Apache License, Version 2.0.
+// See the LICENSE file in the project root for details.
+
+package worker
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+	"testing"
+
+	"go.uber.org/mock/gomock"
+
+	"vega-backend/interfaces"
+	vmock "vega-backend/interfaces/mock"
+)
+
+// 复现 bug：嵌入循环里 GetVector/GetDocument/Upsert 瞬时失败的文档被 sleep+continue
+// 跳过后，后续消息提交 Kafka 位点会把它们悄悄盖掉，向量永久缺失（线上 wc_teams 缺 Iran、
+// wc_tournaments 缺 1954/1958 两届）。vectorizeDoc 把单文档处理收敛成可重试单元，
+// 失败必须如实返回错误，由调用方记入失败清单。
+
+func newVectorizeHandler(t *testing.T) (*embeddingHandler, *vmock.MockDatasetService, *vmock.MockModelFactoryAccess) {
+	t.Helper()
+	ctrl := gomock.NewController(t)
+	ds := vmock.NewMockDatasetService(ctrl)
+	mfa := vmock.NewMockModelFactoryAccess(ctrl)
+	return &embeddingHandler{ds: ds, mfa: mfa}, ds, mfa
+}
+
+func TestVectorizeDoc_Success(t *testing.T) {
+	eh, ds, mfa := newVectorizeHandler(t)
+	ctx := t.Context()
+
+	ds.EXPECT().GetDocument(ctx, "idx", "doc1").
+		Return(map[string]any{"team_name": "Iran", "other": 1}, nil)
+	mfa.EXPECT().GetVector(ctx, "m1", []string{"Iran"}).
+		Return([]*interfaces.VectorResp{{Vector: []float32{0.1, 0.2}}}, nil)
+	ds.EXPECT().UpsertDocuments(ctx, "idx", gomock.Any()).
+		DoAndReturn(func(_ any, _ string, reqs []map[string]any) ([]string, error) {
+			if len(reqs) != 1 || reqs[0]["id"] != "doc1" {
+				t.Fatalf("unexpected upsert request: %v", reqs)
+			}
+			doc := reqs[0]["document"].(map[string]any)
+			if _, ok := doc["team_name_vector"]; !ok {
+				t.Fatalf("vector field missing in upsert: %v", doc)
+			}
+			return []string{"doc1"}, nil
+		})
+
+	if err := eh.vectorizeDoc(ctx, "idx", "doc1", "m1", []string{"team_name"}); err != nil {
+		t.Fatalf("expected success, got %v", err)
+	}
+}
+
+func TestVectorizeDoc_EmptyTextIsSuccessWithoutEmbedding(t *testing.T) {
+	eh, ds, _ := newVectorizeHandler(t)
+	ctx := t.Context()
+
+	// 源字段为空/缺失：不调嵌入模型、不写回，但视为成功（分母里有它）
+	ds.EXPECT().GetDocument(ctx, "idx", "doc1").
+		Return(map[string]any{"team_name": ""}, nil)
+
+	if err := eh.vectorizeDoc(ctx, "idx", "doc1", "m1", []string{"team_name"}); err != nil {
+		t.Fatalf("expected success for empty-text doc, got %v", err)
+	}
+}
+
+func TestVectorizeDoc_FailuresReturnError(t *testing.T) {
+	boom := errors.New("boom")
+
+	cases := []struct {
+		name  string
+		setup func(ds *vmock.MockDatasetService, mfa *vmock.MockModelFactoryAccess, ctx any)
+	}{
+		{"get document fails", func(ds *vmock.MockDatasetService, mfa *vmock.MockModelFactoryAccess, ctx any) {
+			ds.EXPECT().GetDocument(ctx, "idx", "doc1").Return(nil, boom)
+		}},
+		{"get vector fails", func(ds *vmock.MockDatasetService, mfa *vmock.MockModelFactoryAccess, ctx any) {
+			ds.EXPECT().GetDocument(ctx, "idx", "doc1").Return(map[string]any{"f": "text"}, nil)
+			mfa.EXPECT().GetVector(ctx, "m1", []string{"text"}).Return(nil, boom)
+		}},
+		{"vector count mismatch", func(ds *vmock.MockDatasetService, mfa *vmock.MockModelFactoryAccess, ctx any) {
+			ds.EXPECT().GetDocument(ctx, "idx", "doc1").Return(map[string]any{"f": "text"}, nil)
+			mfa.EXPECT().GetVector(ctx, "m1", []string{"text"}).Return([]*interfaces.VectorResp{}, nil)
+		}},
+		{"upsert fails", func(ds *vmock.MockDatasetService, mfa *vmock.MockModelFactoryAccess, ctx any) {
+			ds.EXPECT().GetDocument(ctx, "idx", "doc1").Return(map[string]any{"f": "text"}, nil)
+			mfa.EXPECT().GetVector(ctx, "m1", []string{"text"}).
+				Return([]*interfaces.VectorResp{{Vector: []float32{0.1}}}, nil)
+			ds.EXPECT().UpsertDocuments(ctx, "idx", gomock.Any()).Return(nil, boom)
+		}},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			eh, ds, mfa := newVectorizeHandler(t)
+			ctx := t.Context()
+			tc.setup(ds, mfa, ctx)
+			if err := eh.vectorizeDoc(ctx, "idx", "doc1", "m1", []string{"f"}); err == nil {
+				t.Fatal("expected error, got nil")
+			}
+		})
+	}
+}
+
+func TestFormatVectorizeFailures_Truncates(t *testing.T) {
+	failed := make([]string, 25)
+	for i := range failed {
+		failed[i] = fmt.Sprintf("doc%02d", i)
+	}
+
+	msg := formatVectorizeFailures(failed)
+	if !strings.Contains(msg, "failed for 25 documents") {
+		t.Fatalf("missing total count: %s", msg)
+	}
+	if !strings.Contains(msg, "and 5 more") {
+		t.Fatalf("missing truncation suffix: %s", msg)
+	}
+	if strings.Contains(msg, "doc20") {
+		t.Fatalf("should list only first 20 ids: %s", msg)
+	}
+
+	short := formatVectorizeFailures([]string{"a", "b"})
+	if strings.Contains(short, "more") || !strings.Contains(short, "a,b") {
+		t.Fatalf("short list should be complete: %s", short)
+	}
+}

--- a/adp/vega/vega-backend/server/worker/build_task_reconciler.go
+++ b/adp/vega/vega-backend/server/worker/build_task_reconciler.go
@@ -1,0 +1,172 @@
+// Copyright 2026 openbkn.ai
+// Copyright The kweaver.ai Authors.
+//
+// Licensed under the Apache License, Version 2.0.
+// See the LICENSE file in the project root for details.
+
+package worker
+
+import (
+	"context"
+	"math"
+	"time"
+
+	"github.com/bytedance/sonic"
+	"github.com/hibiken/asynq"
+	"github.com/kweaver-ai/kweaver-go-lib/logger"
+
+	"vega-backend/interfaces"
+	"vega-backend/logics"
+)
+
+const (
+	// buildTaskReconcileInterval 对账周期
+	buildTaskReconcileInterval = 5 * time.Minute
+	// buildTaskInitStaleAfter init 停留超过该时长且队列无对应消息即判为消息丢失；
+	// 需大于创建事务提交→入队完成的间隙，避免把正常创建流程误判为卡死
+	buildTaskInitStaleAfter = 3 * time.Minute
+	// reconcileListPageSize Inspector 翻页大小
+	reconcileListPageSize = 100
+)
+
+// buildTaskReconciler 周期对账自愈：任务创建即入队，但入队消息会因 pod 更替或
+// 入队失败而丢失，DB 状态停在 init（界面"排队中"）后没有任何机制重新入队。
+// 对账把"init 超时且 asynq 队列中无对应消息"的任务重新入队，消除永久假排队。
+type buildTaskReconciler struct {
+	taskAccess interfaces.BuildTaskAccess
+	aqa        interfaces.AsynqAccess
+}
+
+func newBuildTaskReconciler() *buildTaskReconciler {
+	return &buildTaskReconciler{
+		taskAccess: logics.BTA,
+		aqa:        logics.AQA,
+	}
+}
+
+// run 周期执行对账；启动即跑首轮，覆盖"重启前丢消息"的存量卡死任务
+func (r *buildTaskReconciler) run() {
+	defer func() {
+		if err := recover(); err != nil {
+			logger.Errorf("Build task reconciler exited with panic: %v", err)
+		}
+	}()
+	for {
+		if err := r.reconcileOnce(context.Background()); err != nil {
+			logger.Errorf("Build task reconcile failed: %v", err)
+		}
+		time.Sleep(buildTaskReconcileInterval)
+	}
+}
+
+// reconcileOnce 执行一轮对账
+func (r *buildTaskReconciler) reconcileOnce(ctx context.Context) error {
+	tasks, _, err := r.taskAccess.List(ctx, interfaces.BuildTasksQueryParams{Status: interfaces.BuildTaskStatusInit})
+	if err != nil {
+		return err
+	}
+	if len(tasks) == 0 {
+		return nil
+	}
+
+	queued, err := r.queuedBuildTaskIDs()
+	if err != nil {
+		return err
+	}
+
+	stuck := findStuckBuildTasks(tasks, queued, time.Now(), buildTaskInitStaleAfter)
+	if len(stuck) == 0 {
+		return nil
+	}
+
+	client := r.aqa.CreateClient()
+	defer func() { _ = client.Close() }()
+	for _, task := range stuck {
+		if err := enqueueBuildTaskMessage(client, task); err != nil {
+			logger.Errorf("Reconciler re-enqueue build task %s failed: %v", task.ID, err)
+			continue
+		}
+		logger.Infof("Reconciler re-enqueued stuck build task %s (init since %s)",
+			task.ID, time.UnixMilli(task.UpdateTime).Format(time.RFC3339))
+	}
+	return nil
+}
+
+// findStuckBuildTasks 返回卡死任务：init 停留超过 staleAfter 且队列中无对应消息。
+// 纯判定函数，便于单测。
+func findStuckBuildTasks(tasks []*interfaces.BuildTask, queuedIDs map[string]struct{}, now time.Time, staleAfter time.Duration) []*interfaces.BuildTask {
+	stuck := []*interfaces.BuildTask{}
+	for _, task := range tasks {
+		if task.Status != interfaces.BuildTaskStatusInit {
+			continue
+		}
+		if now.Sub(time.UnixMilli(task.UpdateTime)) < staleAfter {
+			continue
+		}
+		if _, ok := queuedIDs[task.ID]; ok {
+			continue
+		}
+		stuck = append(stuck, task)
+	}
+	return stuck
+}
+
+// queuedBuildTaskIDs 收集 asynq 队列中所有构建消息对应的任务 ID。
+// 扫描顺序约束：消息只会沿 scheduled/retry → pending → active 方向流动，
+// 按上游到下游的顺序扫描保证迁移中的消息至少出现在一个列表里，不会被误判为丢失。
+func (r *buildTaskReconciler) queuedBuildTaskIDs() (map[string]struct{}, error) {
+	inspector := r.aqa.CreateInspector()
+	defer func() { _ = inspector.Close() }()
+
+	ids := map[string]struct{}{}
+	listFuncs := []func(string, ...asynq.ListOption) ([]*asynq.TaskInfo, error){
+		inspector.ListScheduledTasks,
+		inspector.ListRetryTasks,
+		inspector.ListPendingTasks,
+		inspector.ListActiveTasks,
+	}
+	for _, list := range listFuncs {
+		for page := 1; ; page++ {
+			infos, err := list(interfaces.DefaultQueue, asynq.PageSize(reconcileListPageSize), asynq.Page(page))
+			if err != nil {
+				return nil, err
+			}
+			for _, info := range infos {
+				if info.Type != interfaces.BuildTaskTypeBatch && info.Type != interfaces.BuildTaskTypeStreaming {
+					continue
+				}
+				var msg interfaces.BatchBuildTaskMessage
+				if err := sonic.Unmarshal(info.Payload, &msg); err == nil && msg.TaskID != "" {
+					ids[msg.TaskID] = struct{}{}
+				}
+			}
+			if len(infos) < reconcileListPageSize {
+				break
+			}
+		}
+	}
+	return ids, nil
+}
+
+// enqueueBuildTaskMessage 重新投递构建消息，与 build_task_service.enqueueBuildTask 对齐。
+// 执行类型用增量：从未跑过的任务游标为空，增量等效全量；跑过一半的任务沿游标续跑。
+func enqueueBuildTaskMessage(client *asynq.Client, task *interfaces.BuildTask) error {
+	payload, err := sonic.Marshal(&interfaces.BatchBuildTaskMessage{
+		TaskID:      task.ID,
+		ExecuteType: interfaces.BuildTaskExecuteTypeIncremental,
+	})
+	if err != nil {
+		return err
+	}
+	typename := interfaces.BuildTaskTypeBatch
+	if task.Mode == interfaces.BuildTaskModeStreaming {
+		typename = interfaces.BuildTaskTypeStreaming
+	}
+	_, err = client.Enqueue(asynq.NewTask(typename, payload),
+		asynq.Queue(interfaces.DefaultQueue),
+		asynq.MaxRetry(interfaces.BUILD_TASK_MAX_RETRY_COUNT),
+		asynq.Timeout(math.MaxInt64),
+		asynq.Deadline(time.Unix(math.MaxInt64/1000000000, math.MaxInt64%1000000000)),
+	)
+	return err
+}

--- a/adp/vega/vega-backend/server/worker/build_task_reconciler_test.go
+++ b/adp/vega/vega-backend/server/worker/build_task_reconciler_test.go
@@ -1,0 +1,53 @@
+// Copyright 2026 openbkn.ai
+// Copyright The kweaver.ai Authors.
+//
+// Licensed under the Apache License, Version 2.0.
+// See the LICENSE file in the project root for details.
+
+package worker
+
+import (
+	"testing"
+	"time"
+
+	"vega-backend/interfaces"
+)
+
+// 复现 bug：任务创建即入队，但入队消息会因 pod 更替/入队失败而丢失；DB 状态停在
+// init（界面"排队中"），没有任何机制重新入队，任务永久假排队，只能人工 stop→start。
+// findStuckBuildTasks 是对账判定核心：init 超过时限且队列中无对应消息的任务判为卡死。
+
+func TestFindStuckBuildTasks(t *testing.T) {
+	now := time.Date(2026, 6, 11, 22, 0, 0, 0, time.UTC)
+	staleAfter := 3 * time.Minute
+	ms := func(t time.Time) int64 { return t.UnixMilli() }
+
+	mkTask := func(id, status string, updatedAgo time.Duration) *interfaces.BuildTask {
+		return &interfaces.BuildTask{ID: id, Status: status, UpdateTime: ms(now.Add(-updatedAgo))}
+	}
+
+	tasks := []*interfaces.BuildTask{
+		mkTask("lost", interfaces.BuildTaskStatusInit, 10*time.Minute),     // 卡死：超时且不在队列
+		mkTask("queued", interfaces.BuildTaskStatusInit, 10*time.Minute),   // 正常排队：队列中有消息
+		mkTask("fresh", interfaces.BuildTaskStatusInit, 10*time.Second),    // 刚创建：创建→入队存在间隙，不能误判
+		mkTask("running", interfaces.BuildTaskStatusRunning, 10*time.Minute), // 防御：非 init 不碰
+	}
+	queued := map[string]struct{}{"queued": {}}
+
+	stuck := findStuckBuildTasks(tasks, queued, now, staleAfter)
+
+	if len(stuck) != 1 || stuck[0].ID != "lost" {
+		ids := []string{}
+		for _, s := range stuck {
+			ids = append(ids, s.ID)
+		}
+		t.Fatalf("expected exactly [lost], got %v", ids)
+	}
+}
+
+func TestFindStuckBuildTasks_EmptyInputs(t *testing.T) {
+	now := time.Now()
+	if got := findStuckBuildTasks(nil, nil, now, time.Minute); len(got) != 0 {
+		t.Fatalf("expected empty result for nil input, got %d", len(got))
+	}
+}

--- a/adp/vega/vega-backend/server/worker/task_worker_manager.go
+++ b/adp/vega/vega-backend/server/worker/task_worker_manager.go
@@ -63,6 +63,10 @@ func (tw *TaskWorkerManger) Start() {
 		}
 	}()
 
+	// 自愈对账：入队消息丢失（pod 更替/入队失败）的任务会永远停在 init（界面"排队中"），
+	// 周期对账把它们重新入队
+	go newBuildTaskReconciler().run()
+
 	if common.GetDebugMode() {
 		go func() {
 			logger.Info("debug task channel subscriber started")


### PR DESCRIPTION
## Summary

Follow-up to #43, fixing the remaining build-task issues found on the validation VM:

- **Tasks stuck in "排队中" forever** (`4c979622`): clients create a task and never call `/start`, but create never enqueued. Create now enqueues immediately (full run); enqueue extracted into a shared helper, `/start` semantics unchanged.
- **Vectors silently lost on transient embedding failures** (`ffa89847`): the consume loop's `sleep+continue` error handling never actually retried — the Kafka reader had advanced, and committing any later message buried the failed offset. On the VM this left `wc_teams` missing the "Iran" vector and `wc_tournaments` missing the 1954/1958 entries. Single-doc work is now a retryable unit (3 bounded attempts), exhausted docs are retried once more before completion, and survivors are recorded in `error_msg` so a completed task with missing vectors says so.
- Also rides along (committed earlier on this branch): counter reset on full rebuild (`5cf848e9`), real COUNT for total + queue-safe start/stop transitions (`053967c3`).

## Test plan
- New unit tests: `vectorizeDoc` success/empty-text/all failure modes, `formatVectorizeFailures` truncation; existing worker + build_task suites pass
- `go build ./...`, targeted `go vet` clean (full `./...` vet only flags pre-existing generated ANTLR parser noise)
- Deployed to validation VM as `vega-backend:worker-fixes-2`: `column_count`/`row_count` confirmed live on `GET /resources`; behavioral verification of queued-task start + tournament rebuild pending

🤖 Generated with [Claude Code](https://claude.com/claude-code)