### PR TITLE
fix(deploy): openbkn 0.1.0 fresh-install gaps — bkn-safe DB + opt-in CN mirrors

### DIFF
--- a/data-migrator/config.monorepo.yaml
+++ b/data-migrator/config.monorepo.yaml
@@ -28,6 +28,7 @@ databases:
   - adp
   - model_management
   - dip_data_agent
+  - safe # bkn-safe（ISF 替代鉴权服务）库；schema 由 bkn-safe 启动时 GORM AutoMigrate 建表，但库本身需 migrator 预建，否则首装报 Unknown database 'safe'
 
 check_rules:
   check_type: 3 # CheckLatest = 1, CheckRecently = 2, CheckAll = 3

--- a/decision-agent/agent-backend/agent-factory/src/drivenadapter/httpaccess/authzhttp/define.go
+++ b/decision-agent/agent-backend/agent-factory/src/drivenadapter/httpaccess/authzhttp/define.go
@@ -32,5 +32,8 @@ func NewAuthZHttpAcc(
 		publicBaseURL:  publicBaseURL,
 	}
 
-	return authZImpl
+	// 经 AUTHZ_PROVIDER 开关选择 authz 后端。此前直接返回 ISF 实现，导致
+	// MaybeShadow 形同虚设：即便 AUTHZ_PROVIDER=bkn-safe，InitPermission 等
+	// 仍打已退役的 ISF authorization-private 端点而 panic。
+	return MaybeShadow(authZImpl, logger)
 }

--- a/decision-agent/agent-backend/agent-factory/src/drivenadapter/httpaccess/authzhttp/define.go
+++ b/decision-agent/agent-backend/agent-factory/src/drivenadapter/httpaccess/authzhttp/define.go
@@ -32,8 +32,5 @@ func NewAuthZHttpAcc(
 		publicBaseURL:  publicBaseURL,
 	}
 
-	// 经 AUTHZ_PROVIDER 开关选择 authz 后端。此前直接返回 ISF 实现，导致
-	// MaybeShadow 形同虚设：即便 AUTHZ_PROVIDER=bkn-safe，InitPermission 等
-	// 仍打已退役的 ISF authorization-private 端点而 panic。
-	return MaybeShadow(authZImpl, logger)
+	return authZImpl
 }

--- a/deploy/scripts/services/k8s.sh
+++ b/deploy/scripts/services/k8s.sh
@@ -775,7 +775,36 @@ configure_containerd_runtime() {
     else
         log_info "✓ Systemd cgroup driver is enabled"
     fi
-    
+
+    # Opt-in 国内镜像源(CONTAINERD_CN_MIRROR=true):docker.io 上的第三方镜像
+    # (oryd/hydra、postgres、otel/opentelemetry-collector-contrib 等)在国内直连
+    # registry-1.docker.io 常超时。用 certs.d/hosts.toml 配多端点兜底(端点顺序尝试,
+    # 末位回落官方)。daocloud 白名单不含 oryd/hydra,故并列 1ms.run 兜底。
+    # 默认关闭,不影响可直连 docker.io 的环境。长远更优解是发布时把这些第三方镜像
+    # vendoring 进 ghcr.io/openbkn-ai,部署只从单一 registry 拉取。
+    if [[ "${CONTAINERD_CN_MIRROR:-false}" == "true" ]]; then
+        log_info "Configuring docker.io registry mirrors (CONTAINERD_CN_MIRROR=true)..."
+        local certs_dir="/etc/containerd/certs.d/docker.io"
+        mkdir -p "${certs_dir}"
+        cat > "${certs_dir}/hosts.toml" <<'EOF'
+server = "https://registry-1.docker.io"
+
+[host."https://docker.m.daocloud.io"]
+  capabilities = ["pull", "resolve"]
+
+[host."https://docker.1ms.run"]
+  capabilities = ["pull", "resolve"]
+
+[host."https://registry-1.docker.io"]
+  capabilities = ["pull", "resolve"]
+EOF
+        # 让 CRI 启用 certs.d(若 config.toml 未设 config_path 则注入)
+        if ! grep -q 'config_path = "/etc/containerd/certs.d"' /etc/containerd/config.toml; then
+            sed -i 's|\(\[plugins."io.containerd.grpc.v1.cri".registry\]\)|\1\n        config_path = "/etc/containerd/certs.d"|' /etc/containerd/config.toml
+        fi
+        log_info "✓ docker.io mirrors written to ${certs_dir}/hosts.toml"
+    fi
+
     # Restart containerd to apply configuration
     log_info "Restarting containerd to apply configuration..."
     systemctl daemon-reload


### PR DESCRIPTION
Genuinely-missing-in-main gaps found deploying openbkn 0.1.0 + bkn-safe on a clean x86_64 server.

### 1. bkn-safe crash-loops on "Unknown database 'safe'"
bkn-safe builds its tables via GORM AutoMigrate but cannot create its own database. The migrator's `databases:` list omitted `safe`, so a fresh install never created it. Added `safe`.

### 2. docker.io third-party images time out from China (opt-in mirror)
oryd/hydra, postgres, and the otel collector are pulled from docker.io and stall against registry-1.docker.io from the mainland. Gated by `CONTAINERD_CN_MIRROR=true`, write `certs.d/docker.io/hosts.toml` with verified CN endpoints (daocloud + 1ms.run, since daocloud's allowlist excludes oryd/hydra) and the official registry last. Off by default. Longer term these should be vendored into ghcr.io/openbkn-ai at release.

## Root-cause note (important)
Most of the other breakage in that deploy (agent-factory authz panic, operator-integration/vega-backend hitting the retired ISF `authorization-private:30920`, missing `f_internal` column) was NOT a main bug — it was deploying **published 0.1.0 images that predate the bkn-safe cutover (#25)**. main already routes authz through bkn-safe (chttpinject/MaybeShadow, chart bknSafe→env wiring). **The real fix for those is to rebuild + republish the 0.1.0 charts+images from current main.** This PR carries only the two items genuinely absent from main.

(An earlier commit added MaybeShadow to agent-factory's `NewAuthZHttpAcc`; reverted as redundant — chttpinject already wraps it since #25.)

## Test plan
- `go build` of the touched agent-factory package; `bash -n` of k8s.sh
- Verified live: creating `safe` lets bkn-safe seed + listen; CN mirror endpoints pull hydra/postgres/otel that previously timed out

🤖 Generated with [Claude Code](https://claude.com/claude-code)