### PR TITLE
feat(vega): 字段级全文索引(string/text)随构建任务参数化

### DIFF
--- a/adp/docs/api/vega/vega-backend-api/build-task.yaml
+++ b/adp/docs/api/vega/vega-backend-api/build-task.yaml
@@ -469,6 +469,12 @@ components:
         model_dimensions:
           description: 模型向量维度
           type: integer
+        fulltext_fields:
+          description: 已建全文索引的字段，逗号分隔
+          type: string
+        fulltext_analyzer:
+          description: 全文分词器；为空用默认 standard
+          type: string
     CreateBuildTaskRequest:
       description: 创建构建任务请求体
       type: object
@@ -498,6 +504,16 @@ components:
         model_dimensions:
           description: 模型向量维度；为 0 且 embedding_model 非空时按模型查询填入
           type: integer
+        fulltext_fields:
+          description: >
+            需建全文索引的字段，逗号分隔；仅 string/text 字段可选。
+            string 字段建索引时主字段保持 keyword（精确匹配/排序不变），额外加一个
+            `<字段>.fulltext` 分词子字段；text 字段主字段本身分词。全文检索随结构化
+            数据同步落地（不像 embedding 需异步补）。
+          type: string
+        fulltext_analyzer:
+          description: 全文分词器（standard/ik_max_word/hanlp_index 等）；为空用 OpenSearch 默认 standard
+          type: string
     StartBuildTaskRequest:
       description: 启动构建任务请求体（可选）
       type: object

--- a/adp/vega/vega-backend/migrations/dm8/0.9.0/05-add-build-task-fulltext.sql
+++ b/adp/vega/vega-backend/migrations/dm8/0.9.0/05-add-build-task-fulltext.sql
@@ -1,0 +1,14 @@
+-- Copyright 2026 openbkn.ai
+-- Copyright The kweaver.ai Authors.
+--
+-- Licensed under the Apache License, Version 2.0.
+-- See the LICENSE file in the project root for details.
+
+-- ==========================================
+-- 迁移脚本：t_build_task 增加全文索引字段配置
+-- ==========================================
+
+SET SCHEMA kweaver;
+
+ALTER TABLE t_build_task ADD COLUMN IF NOT EXISTS f_fulltext_fields VARCHAR(255 CHAR) NOT NULL DEFAULT '';
+ALTER TABLE t_build_task ADD COLUMN IF NOT EXISTS f_fulltext_analyzer VARCHAR(40 CHAR) NOT NULL DEFAULT '';

--- a/adp/vega/vega-backend/migrations/dm8/0.9.0/init.sql
+++ b/adp/vega/vega-backend/migrations/dm8/0.9.0/init.sql
@@ -414,6 +414,8 @@ CREATE TABLE IF NOT EXISTS t_build_task (
     f_build_key_fields        VARCHAR(255 CHAR) NOT NULL DEFAULT '',
     f_embedding_model         VARCHAR(40 CHAR) NOT NULL DEFAULT '',
     f_model_dimensions        INT NOT NULL DEFAULT 0,
+    f_fulltext_fields         VARCHAR(255 CHAR) NOT NULL DEFAULT '',
+    f_fulltext_analyzer       VARCHAR(40 CHAR) NOT NULL DEFAULT '',
     f_catalog_id              VARCHAR(40 CHAR) NOT NULL DEFAULT '',
 
     -- 索引

--- a/adp/vega/vega-backend/migrations/mariadb/0.9.0/05-add-build-task-fulltext.sql
+++ b/adp/vega/vega-backend/migrations/mariadb/0.9.0/05-add-build-task-fulltext.sql
@@ -1,0 +1,14 @@
+-- Copyright 2026 openbkn.ai
+-- Copyright The kweaver.ai Authors.
+--
+-- Licensed under the Apache License, Version 2.0.
+-- See the LICENSE file in the project root for details.
+
+-- ==========================================
+-- 迁移脚本：t_build_task 增加全文索引字段配置
+-- ==========================================
+
+USE kweaver;
+
+ALTER TABLE t_build_task ADD COLUMN IF NOT EXISTS f_fulltext_fields VARCHAR(255) NOT NULL DEFAULT '';
+ALTER TABLE t_build_task ADD COLUMN IF NOT EXISTS f_fulltext_analyzer VARCHAR(40) NOT NULL DEFAULT '';

--- a/adp/vega/vega-backend/migrations/mariadb/0.9.0/init.sql
+++ b/adp/vega/vega-backend/migrations/mariadb/0.9.0/init.sql
@@ -402,6 +402,8 @@ CREATE TABLE IF NOT EXISTS t_build_task (
     f_build_key_fields        VARCHAR(255) NOT NULL DEFAULT '' COMMENT '构建中依赖的特殊键字段',
     f_embedding_model         VARCHAR(40) NOT NULL DEFAULT '' COMMENT '嵌入模型',
     f_model_dimensions        INT NOT NULL DEFAULT 0 COMMENT '模型维度',
+    f_fulltext_fields         VARCHAR(255) NOT NULL DEFAULT '' COMMENT '需建全文索引的字段',
+    f_fulltext_analyzer       VARCHAR(40) NOT NULL DEFAULT '' COMMENT '全文分词器，空为默认 standard',
     f_catalog_id              VARCHAR(40) NOT NULL DEFAULT '' COMMENT '所属catalog ID',
 
     -- 索引

--- a/adp/vega/vega-backend/server/drivenadapters/build_task/build_task_access.go
+++ b/adp/vega/vega-backend/server/drivenadapters/build_task/build_task_access.go
@@ -55,6 +55,8 @@ func buildTaskColumns() []string {
 		"f_build_key_fields",
 		"f_embedding_model",
 		"f_model_dimensions",
+		"f_fulltext_fields",
+		"f_fulltext_analyzer",
 	}
 }
 
@@ -91,6 +93,8 @@ func scanBuildTask(scanner buildTaskScanner) (*interfaces.BuildTask, error) {
 		&buildTask.BuildKeyFields,
 		&buildTask.EmbeddingModel,
 		&buildTask.ModelDimensions,
+		&buildTask.FulltextFields,
+		&buildTask.FulltextAnalyzer,
 	)
 	if err != nil {
 		return nil, err
@@ -139,6 +143,8 @@ func (bta *buildTaskAccess) Create(ctx context.Context, buildTask *interfaces.Bu
 			buildTask.BuildKeyFields,
 			buildTask.EmbeddingModel,
 			buildTask.ModelDimensions,
+			buildTask.FulltextFields,
+			buildTask.FulltextAnalyzer,
 		).ToSql()
 	if err != nil {
 		span.SetStatus(codes.Error, "Build sql failed")

--- a/adp/vega/vega-backend/server/driveradapters/build_task_handler.go
+++ b/adp/vega/vega-backend/server/driveradapters/build_task_handler.go
@@ -120,6 +120,31 @@ func (r *restHandler) createBuildTask(c *gin.Context, visitor hydra.Visitor) {
 			}
 		}
 	}
+	if req.FulltextFields != "" {
+		for _, field := range strings.Split(req.FulltextFields, ",") {
+			field = strings.TrimSpace(field)
+			if field == "" {
+				continue
+			}
+			fieldType, ok := schemaFields[field]
+			if !ok {
+				httpErr := rest.NewHTTPError(ctx, http.StatusBadRequest, verrors.VegaBackend_InvalidParameter_RequestBody).
+					WithErrorDetails(fmt.Sprintf("fulltext_field '%s' not found in resource schema", field))
+				oteltrace.AddHttpAttrs4HttpError(span, httpErr)
+				rest.ReplyError(c, httpErr)
+				return
+			}
+			// 全文检索只对文本字段有意义：string 加 text 子字段、text 主字段分词；
+			// 其它类型无分词语义，直接拦下
+			if fieldType != interfaces.DataType_String && fieldType != interfaces.DataType_Text {
+				httpErr := rest.NewHTTPError(ctx, http.StatusBadRequest, verrors.VegaBackend_InvalidParameter_RequestBody).
+					WithErrorDetails(fmt.Sprintf("fulltext_field '%s' has type '%s', only string/text fields support fulltext", field, fieldType))
+				oteltrace.AddHttpAttrs4HttpError(span, httpErr)
+				rest.ReplyError(c, httpErr)
+				return
+			}
+		}
+	}
 
 	taskID, err := r.bts.CreateBuildTask(ctx, &req)
 	if err != nil {

--- a/adp/vega/vega-backend/server/interfaces/build_task.go
+++ b/adp/vega/vega-backend/server/interfaces/build_task.go
@@ -56,11 +56,13 @@ type BuildTask struct {
 	CreateTime      int64       `json:"create_time"`
 	Updater         AccountInfo `json:"updater"`
 	UpdateTime      int64       `json:"update_time"`
-	EmbeddingFields string      `json:"embedding_fields,omitempty"` // 需向量化嵌入字段
-	BuildKeyFields  string      `json:"build_key_fields"`           // 构建中依赖的特殊键字段，如批量构建依赖的有时序性的字段，流式构建依赖的唯一标识某行的字段
-	EmbeddingModel  string      `json:"embedding_model,omitempty"`  // 嵌入模型
-	ModelDimensions int         `json:"model_dimensions,omitempty"` // 模型维度
-	CatalogID       string      `json:"catalog_id"`
+	EmbeddingFields  string      `json:"embedding_fields,omitempty"`  // 需向量化嵌入字段
+	BuildKeyFields   string      `json:"build_key_fields"`            // 构建中依赖的特殊键字段，如批量构建依赖的有时序性的字段，流式构建依赖的唯一标识某行的字段
+	EmbeddingModel   string      `json:"embedding_model,omitempty"`   // 嵌入模型
+	ModelDimensions  int         `json:"model_dimensions,omitempty"`  // 模型维度
+	FulltextFields   string      `json:"fulltext_fields,omitempty"`   // 需建全文索引的字段(逗号分隔)；string→加 text 子字段，text→主字段分词
+	FulltextAnalyzer string      `json:"fulltext_analyzer,omitempty"` // 全文分词器(standard/ik_max_word/hanlp_index 等)，空为 OpenSearch 默认
+	CatalogID        string      `json:"catalog_id"`
 }
 
 // CreateBuildTaskRequest represents the request to create a build task.
@@ -68,10 +70,12 @@ type BuildTask struct {
 type CreateBuildTaskRequest struct {
 	ResourceID      string `json:"resource_id" binding:"required"`                // 关联 Resource ID
 	Mode            string `json:"mode" binding:"required,oneof=streaming batch"` // 任务模式：streaming/batch
-	EmbeddingFields string `json:"embedding_fields,omitempty"`                    // 需向量化嵌入字段
-	BuildKeyFields  string `json:"build_key_fields"`                              // 构建中依赖的特殊键字段，如批量构建依赖的有时序性的字段，流式构建依赖的唯一标识某行的字段
-	EmbeddingModel  string `json:"embedding_model,omitempty"`                     // 嵌入模型
-	ModelDimensions int    `json:"model_dimensions,omitempty"`                    // 模型维度
+	EmbeddingFields  string `json:"embedding_fields,omitempty"`                    // 需向量化嵌入字段
+	BuildKeyFields   string `json:"build_key_fields"`                              // 构建中依赖的特殊键字段，如批量构建依赖的有时序性的字段，流式构建依赖的唯一标识某行的字段
+	EmbeddingModel   string `json:"embedding_model,omitempty"`                     // 嵌入模型
+	ModelDimensions  int    `json:"model_dimensions,omitempty"`                    // 模型维度
+	FulltextFields   string `json:"fulltext_fields,omitempty"`                     // 需建全文索引的字段(逗号分隔)
+	FulltextAnalyzer string `json:"fulltext_analyzer,omitempty"`                   // 全文分词器，空为 OpenSearch 默认 standard
 }
 
 // UpdateBuildTaskStatusRequest represents update build task status request.

--- a/adp/vega/vega-backend/server/logics/build_task/build_task_service.go
+++ b/adp/vega/vega-backend/server/logics/build_task/build_task_service.go
@@ -155,10 +155,12 @@ func (bts *buildTaskService) CreateBuildTask(ctx context.Context, req *interface
 		CreateTime:      now,
 		Updater:         accountInfo,
 		UpdateTime:      now,
-		EmbeddingFields: req.EmbeddingFields,
-		BuildKeyFields:  req.BuildKeyFields,
-		EmbeddingModel:  req.EmbeddingModel,
-		ModelDimensions: req.ModelDimensions,
+		EmbeddingFields:  req.EmbeddingFields,
+		BuildKeyFields:   req.BuildKeyFields,
+		EmbeddingModel:   req.EmbeddingModel,
+		ModelDimensions:  req.ModelDimensions,
+		FulltextFields:   req.FulltextFields,
+		FulltextAnalyzer: req.FulltextAnalyzer,
 	}
 
 	if err := bts.bta.Create(ctx, buildTask); err != nil {

--- a/adp/vega/vega-backend/server/logics/connectors/local/index/opensearch/opensearch_condition.go
+++ b/adp/vega/vega-backend/server/logics/connectors/local/index/opensearch/opensearch_condition.go
@@ -152,6 +152,28 @@ func (c *OpenSearchConnector) ConvertFilterConditionWithOpr(condition interfaces
 	}
 }
 
+// fulltextFieldName 返回全文检索（match/match_phrase/multi_match）应命中的字段名。
+// string 字段的全文能力挂在 text 子字段上（见 applyFulltextFeature），必须用
+// `字段名.<子字段名>` 命中分词子字段，否则会落到 keyword 主字段做精确匹配；
+// text 字段主字段本身即全文，用裸字段名。
+func fulltextFieldName(prop *interfaces.Property) string {
+	if prop == nil {
+		return ""
+	}
+	if prop.Type == interfaces.DataType_String {
+		for _, f := range prop.Features {
+			if f.FeatureType == interfaces.PropertyFeatureType_Fulltext {
+				sub := f.FeatureName
+				if sub == "" {
+					sub = "fulltext"
+				}
+				return prop.Name + "." + sub
+			}
+		}
+	}
+	return prop.Name
+}
+
 // ConvertFilterConditionMultiMatch converts a MultiMatchCond to OpenSearch DSL.
 func (c *OpenSearchConnector) ConvertFilterConditionMultiMatch(condition interfaces.FilterCondition) (map[string]any, error) {
 
@@ -163,7 +185,7 @@ func (c *OpenSearchConnector) ConvertFilterConditionMultiMatch(condition interfa
 	value := cond.Cfg.Value
 	fields := make([]string, 0, len(cond.Fields))
 	for _, field := range cond.Fields {
-		fields = append(fields, field.Name)
+		fields = append(fields, fulltextFieldName(field))
 	}
 
 	multiMatchQuery := map[string]any{
@@ -641,7 +663,7 @@ func (c *OpenSearchConnector) ConvertFilterConditionMatch(condition interfaces.F
 		for _, field := range cond.Fields {
 			should = append(should, map[string]any{
 				"match": map[string]any{
-					field.Name: value,
+					fulltextFieldName(field): value,
 				},
 			})
 		}
@@ -656,7 +678,7 @@ func (c *OpenSearchConnector) ConvertFilterConditionMatch(condition interfaces.F
 		field := cond.Fields[0]
 		return map[string]any{
 			"match": map[string]any{
-				field.Name: value,
+				fulltextFieldName(field): value,
 			},
 		}, nil
 	}
@@ -680,7 +702,7 @@ func (c *OpenSearchConnector) ConvertFilterConditionMatchPhrase(condition interf
 		for _, field := range cond.Fields {
 			should = append(should, map[string]any{
 				"match_phrase": map[string]any{
-					field.Name: value,
+					fulltextFieldName(field): value,
 				},
 			})
 		}
@@ -695,7 +717,7 @@ func (c *OpenSearchConnector) ConvertFilterConditionMatchPhrase(condition interf
 		field := cond.Fields[0]
 		return map[string]any{
 			"match_phrase": map[string]any{
-				field.Name: value,
+				fulltextFieldName(field): value,
 			},
 		}, nil
 	}

--- a/adp/vega/vega-backend/server/logics/connectors/local/index/opensearch/opensearch_fulltext_test.go
+++ b/adp/vega/vega-backend/server/logics/connectors/local/index/opensearch/opensearch_fulltext_test.go
@@ -1,0 +1,168 @@
+// Copyright 2026 openbkn.ai
+// Copyright The kweaver.ai Authors.
+//
+// Licensed under the Apache License, Version 2.0.
+// See the LICENSE file in the project root for details.
+
+package opensearch
+
+import (
+	"testing"
+
+	"vega-backend/interfaces"
+)
+
+// string 字段带 fulltext 特性时，主字段仍为 keyword（精确匹配/排序不变），
+// 同时挂一个 text 子字段做全文检索；analyzer 从 feature.config 注入。
+// 复现 bug：此前 buildFieldMappings 对 fulltext 特性 `continue`，子字段从未生成。
+func TestBuildFieldMappings_StringFulltextAddsTextSubfield(t *testing.T) {
+	c := &OpenSearchConnector{}
+	schema := []*interfaces.Property{
+		{
+			Name: "team_name",
+			Type: interfaces.DataType_String,
+			Features: []interfaces.PropertyFeature{
+				{
+					FeatureName: "fulltext",
+					FeatureType: interfaces.PropertyFeatureType_Fulltext,
+					Config:      map[string]any{"analyzer": "ik_max_word"},
+				},
+			},
+		},
+	}
+
+	props, _, err := c.buildFieldMappings(schema)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	field, _ := props["team_name"].(map[string]any)
+	if field["type"] != "keyword" {
+		t.Fatalf("string main field must stay keyword, got %v", field["type"])
+	}
+	fields, ok := field["fields"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected text subfield, got none: %+v", field)
+	}
+	sub, ok := fields["fulltext"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected 'fulltext' subfield, got %+v", fields)
+	}
+	if sub["type"] != "text" {
+		t.Fatalf("fulltext subfield must be text, got %v", sub["type"])
+	}
+	if sub["analyzer"] != "ik_max_word" {
+		t.Fatalf("analyzer must propagate from config, got %v", sub["analyzer"])
+	}
+}
+
+// string + fulltext 无 config：仍建 text 子字段，用默认分词器（不设 analyzer）。
+func TestBuildFieldMappings_StringFulltextNoConfig(t *testing.T) {
+	c := &OpenSearchConnector{}
+	schema := []*interfaces.Property{
+		{
+			Name: "title",
+			Type: interfaces.DataType_String,
+			Features: []interfaces.PropertyFeature{
+				{FeatureName: "fulltext", FeatureType: interfaces.PropertyFeatureType_Fulltext},
+			},
+		},
+	}
+	props, _, err := c.buildFieldMappings(schema)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	field := props["title"].(map[string]any)
+	sub := field["fields"].(map[string]any)["fulltext"].(map[string]any)
+	if sub["type"] != "text" {
+		t.Fatalf("expected text subfield, got %v", sub["type"])
+	}
+	if _, has := sub["analyzer"]; has {
+		t.Fatalf("no config should mean no analyzer key, got %v", sub["analyzer"])
+	}
+}
+
+// string 同时带 keyword 与 fulltext：主字段 keyword(含 keyword config) + text 子字段。
+func TestBuildFieldMappings_StringKeywordAndFulltext(t *testing.T) {
+	c := &OpenSearchConnector{}
+	schema := []*interfaces.Property{
+		{
+			Name: "name",
+			Type: interfaces.DataType_String,
+			Features: []interfaces.PropertyFeature{
+				{FeatureName: "kw", FeatureType: interfaces.PropertyFeatureType_Keyword, Config: map[string]any{"ignore_above": 256}},
+				{FeatureName: "fulltext", FeatureType: interfaces.PropertyFeatureType_Fulltext, Config: map[string]any{"analyzer": "standard"}},
+			},
+		},
+	}
+	props, _, err := c.buildFieldMappings(schema)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	field := props["name"].(map[string]any)
+	if field["type"] != "keyword" {
+		t.Fatalf("main must be keyword, got %v", field["type"])
+	}
+	if field["ignore_above"] != 256 {
+		t.Fatalf("keyword config must apply to main field, got %v", field["ignore_above"])
+	}
+	sub := field["fields"].(map[string]any)["fulltext"].(map[string]any)
+	if sub["type"] != "text" || sub["analyzer"] != "standard" {
+		t.Fatalf("fulltext subfield wrong: %+v", sub)
+	}
+}
+
+// text 字段带 fulltext：主字段已是 text(全文)，把 analyzer 设到主字段。
+func TestBuildFieldMappings_TextFulltextSetsAnalyzer(t *testing.T) {
+	c := &OpenSearchConnector{}
+	schema := []*interfaces.Property{
+		{
+			Name: "body",
+			Type: interfaces.DataType_Text,
+			Features: []interfaces.PropertyFeature{
+				{FeatureName: "fulltext", FeatureType: interfaces.PropertyFeatureType_Fulltext, Config: map[string]any{"analyzer": "hanlp_index"}},
+			},
+		},
+	}
+	props, _, err := c.buildFieldMappings(schema)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	field := props["body"].(map[string]any)
+	if field["type"] != "text" {
+		t.Fatalf("text main field must stay text, got %v", field["type"])
+	}
+	if field["analyzer"] != "hanlp_index" {
+		t.Fatalf("analyzer must be set on text main field, got %v", field["analyzer"])
+	}
+}
+
+// match 查询命中 string 全文字段时必须用 `.fulltext` 子字段，否则落到 keyword 主字段做精确匹配。
+func TestFulltextFieldName_StringUsesSubfield(t *testing.T) {
+	prop := &interfaces.Property{
+		Name: "team_name",
+		Type: interfaces.DataType_String,
+		Features: []interfaces.PropertyFeature{
+			{FeatureName: "fulltext", FeatureType: interfaces.PropertyFeatureType_Fulltext},
+		},
+	}
+	if got := fulltextFieldName(prop); got != "team_name.fulltext" {
+		t.Fatalf("expected team_name.fulltext, got %s", got)
+	}
+}
+
+// text 字段主字段即全文，用裸字段名。
+func TestFulltextFieldName_TextUsesBareName(t *testing.T) {
+	prop := &interfaces.Property{Name: "body", Type: interfaces.DataType_Text}
+	if got := fulltextFieldName(prop); got != "body" {
+		t.Fatalf("expected body, got %s", got)
+	}
+}
+
+// string 字段无 fulltext 特性：用裸名（match 落到 keyword 主字段，行为不变）。
+func TestFulltextFieldName_StringNoFulltextBareName(t *testing.T) {
+	prop := &interfaces.Property{Name: "code", Type: interfaces.DataType_String}
+	if got := fulltextFieldName(prop); got != "code" {
+		t.Fatalf("expected code, got %s", got)
+	}
+}

--- a/adp/vega/vega-backend/server/logics/connectors/local/index/opensearch/opensearch_query.go
+++ b/adp/vega/vega-backend/server/logics/connectors/local/index/opensearch/opensearch_query.go
@@ -866,6 +866,37 @@ func formatInValuesForScript(values []any) string {
 	return fmt.Sprintf("[%s]", strings.Join(strValues, ", "))
 }
 
+// applyFulltextFeature 给字段挂全文检索能力。
+//   - string 字段：主字段保持 keyword（精确匹配/排序/聚合语义不变），
+//     额外加一个 text 子字段做分词全文检索；查询侧用 `字段名.<子字段名>` 命中。
+//   - text 字段：主字段本身即 text（已全文），仅把 analyzer 设到主字段。
+//
+// analyzer 等参数从 feature.Config 注入；无 config 时走 OpenSearch 默认分词器。
+func applyFulltextFeature(fieldProps map[string]any, columnType string, feature interfaces.PropertyFeature) {
+	switch columnType {
+	case interfaces.DataType_String:
+		subName := feature.FeatureName
+		if subName == "" {
+			subName = "fulltext"
+		}
+		sub := map[string]any{"type": "text"}
+		for k, v := range feature.Config {
+			sub[k] = v
+		}
+		fields, ok := fieldProps["fields"].(map[string]any)
+		if !ok {
+			fields = map[string]any{}
+			fieldProps["fields"] = fields
+		}
+		fields[subName] = sub
+	case interfaces.DataType_Text:
+		// 主字段已是 text（分词），把 analyzer 等直接设在主字段上
+		for k, v := range feature.Config {
+			fieldProps[k] = v
+		}
+	}
+}
+
 // buildFieldMappings 构建字段映射
 func (c *OpenSearchConnector) buildFieldMappings(schemaDefinition []*interfaces.Property) (map[string]any, bool, error) {
 	properties := map[string]any{}
@@ -914,6 +945,11 @@ func (c *OpenSearchConnector) buildFieldMappings(schemaDefinition []*interfaces.
 		// 处理字段特性
 		if column.Features != nil {
 			for _, feature := range column.Features {
+				// fulltext 不依赖 config（可无 analyzer 走默认分词器），单独处理
+				if feature.FeatureType == "fulltext" {
+					applyFulltextFeature(fieldProps, column.Type, feature)
+					continue
+				}
 				if feature.Config != nil {
 					switch feature.FeatureType {
 					case "keyword":
@@ -944,8 +980,6 @@ func (c *OpenSearchConnector) buildFieldMappings(schemaDefinition []*interfaces.
 						for k, v := range feature.Config {
 							fieldProps[k] = v
 						}
-					case "fulltext":
-						continue
 					default:
 						return nil, false, fmt.Errorf("unsupported feature type: %s", feature.FeatureType)
 					}

--- a/adp/vega/vega-backend/server/worker/build_handler_batch.go
+++ b/adp/vega/vega-backend/server/worker/build_handler_batch.go
@@ -136,6 +136,16 @@ func advanceCursor(cursor []interfaces.KeyValue, keys []string, lastItem map[str
 
 // executeBuild executes the build logic
 func (bh *batchBuildHandler) executeBuild(ctx context.Context, resource *interfaces.Resource, buildTaskInfo *interfaces.BuildTask, executeType string) error {
+	// 全文字段：把 fulltext 特性写回资源 schema 并持久化。必须在建索引前做，
+	// 才能让 createLocalIndex 据此生成 text 子字段 mapping；同时让查询侧
+	// fulltextFieldName 从资源 schema 解析出 `字段.fulltext` 命中分词子字段。
+	if buildTaskInfo.FulltextFields != "" {
+		if injectFulltextFeatures(resource, buildTaskInfo.FulltextFields, buildTaskInfo.FulltextAnalyzer) {
+			if err := bh.resAccess.Update(ctx, resource); err != nil {
+				return fmt.Errorf("persist fulltext schema failed: %w", err)
+			}
+		}
+	}
 	// 两个操作均幂等（embedding 任务靠 asynq TaskID 去重，索引已存在则跳过），
 	// 不能只在 init 时执行：stop→start 重启后老 embedding worker 已退出，
 	// 若不补发，文档 ID 堆积在 Kafka 无消费者，向量化永远停滞

--- a/adp/vega/vega-backend/server/worker/build_handler_cursor_test.go
+++ b/adp/vega/vega-backend/server/worker/build_handler_cursor_test.go
@@ -53,3 +53,50 @@ func TestAdvanceCursorMultipleKeys(t *testing.T) {
 }
 
 var _ = interfaces.KeyValue{} // 保持 import 稳定
+
+// injectFulltextFeatures 把 fulltext 特性写入指定字段，analyzer 进 config，幂等。
+func TestInjectFulltextFeatures(t *testing.T) {
+	res := &interfaces.Resource{SchemaDefinition: []*interfaces.Property{
+		{Name: "team_name", Type: interfaces.DataType_String},
+		{Name: "team_code", Type: interfaces.DataType_String},
+	}}
+	changed := injectFulltextFeatures(res, "team_name", "ik_max_word")
+	if !changed {
+		t.Fatal("expected changed=true")
+	}
+	tn := res.SchemaDefinition[0]
+	if len(tn.Features) != 1 || tn.Features[0].FeatureType != interfaces.PropertyFeatureType_Fulltext {
+		t.Fatalf("team_name must get fulltext feature, got %+v", tn.Features)
+	}
+	if tn.Features[0].Config["analyzer"] != "ik_max_word" {
+		t.Fatalf("analyzer must be in config, got %v", tn.Features[0].Config)
+	}
+	if len(res.SchemaDefinition[1].Features) != 0 {
+		t.Fatalf("unselected field must be untouched, got %+v", res.SchemaDefinition[1].Features)
+	}
+	// 幂等：再次注入不重复添加、不报改动
+	if injectFulltextFeatures(res, "team_name", "ik_max_word") {
+		t.Fatal("re-inject must be idempotent (changed=false)")
+	}
+	if len(tn.Features) != 1 {
+		t.Fatalf("idempotent re-inject must not duplicate, got %d", len(tn.Features))
+	}
+}
+
+// analyzer 为空时不写 config（走 OpenSearch 默认分词器）。
+func TestInjectFulltextFeatures_NoAnalyzerNoConfig(t *testing.T) {
+	res := &interfaces.Resource{SchemaDefinition: []*interfaces.Property{
+		{Name: "x", Type: interfaces.DataType_String},
+	}}
+	injectFulltextFeatures(res, "x", "")
+	if res.SchemaDefinition[0].Features[0].Config != nil {
+		t.Fatalf("empty analyzer must leave config nil, got %v", res.SchemaDefinition[0].Features[0].Config)
+	}
+}
+
+func TestFieldNameSet(t *testing.T) {
+	got := fieldNameSet(" a, b ,, c ")
+	if len(got) != 3 || !got["a"] || !got["b"] || !got["c"] {
+		t.Fatalf("expected {a,b,c}, got %+v", got)
+	}
+}

--- a/adp/vega/vega-backend/server/worker/build_task_common.go
+++ b/adp/vega/vega-backend/server/worker/build_task_common.go
@@ -81,16 +81,16 @@ func createLocalIndex(ctx context.Context, ds interfaces.DatasetService, buildTa
 	if exist {
 		return nil
 	}
+	// resource.SchemaDefinition 已由 executeBuild 写入 fulltext 特性（injectFulltextFeatures），
+	// 这里直接复用——buildFieldMappings 会据此给 string 字段建 text 子字段。
+	// embedding 字段额外追加独立的 _vector 字段。
 	if buildTask.EmbeddingFields != "" {
-		embeddingFields := strings.Split(buildTask.EmbeddingFields, ",")
 		var newSchema []*interfaces.Property
-		if resource.SchemaDefinition != nil {
-			newSchema = append(newSchema, resource.SchemaDefinition...)
-		}
-		for _, field := range embeddingFields {
+		newSchema = append(newSchema, resource.SchemaDefinition...)
+		for _, field := range strings.Split(buildTask.EmbeddingFields, ",") {
 			field = strings.TrimSpace(field)
 			if field != "" {
-				vectorProperty := &interfaces.Property{
+				newSchema = append(newSchema, &interfaces.Property{
 					Name: field + "_vector",
 					Type: interfaces.DataType_Vector,
 					Features: []interfaces.PropertyFeature{
@@ -108,13 +108,58 @@ func createLocalIndex(ctx context.Context, ds interfaces.DatasetService, buildTa
 							},
 						},
 					},
-				}
-				newSchema = append(newSchema, vectorProperty)
+				})
 			}
 		}
 		newResource.SchemaDefinition = newSchema
 	}
 	return ds.Create(ctx, &newResource)
+}
+
+// fieldNameSet 把逗号分隔的字段名解析为集合。
+func fieldNameSet(csv string) map[string]bool {
+	set := map[string]bool{}
+	for _, f := range strings.Split(csv, ",") {
+		if f = strings.TrimSpace(f); f != "" {
+			set[f] = true
+		}
+	}
+	return set
+}
+
+// hasFulltextFeature 判断字段是否已带 fulltext 特性。
+func hasFulltextFeature(prop *interfaces.Property) bool {
+	for _, f := range prop.Features {
+		if f.FeatureType == interfaces.PropertyFeatureType_Fulltext {
+			return true
+		}
+	}
+	return false
+}
+
+// injectFulltextFeatures 把 fulltext 特性写入 resource schema 中指定字段（原地、幂等），
+// 返回是否有改动。必须写回资源 schema 并持久化：既让建索引 mapping 生成 text 子字段，
+// 也让查询侧 fulltextFieldName 能从资源 schema 解析出 `字段.fulltext` 子字段。
+// analyzer 为空时不写 config，走 OpenSearch 默认分词器。
+func injectFulltextFeatures(resource *interfaces.Resource, fulltextFields, analyzer string) bool {
+	set := fieldNameSet(fulltextFields)
+	var config map[string]any
+	if analyzer != "" {
+		config = map[string]any{"analyzer": analyzer}
+	}
+	changed := false
+	for _, prop := range resource.SchemaDefinition {
+		if prop == nil || !set[prop.Name] || hasFulltextFeature(prop) {
+			continue
+		}
+		prop.Features = append(prop.Features, interfaces.PropertyFeature{
+			FeatureName: "fulltext",
+			FeatureType: interfaces.PropertyFeatureType_Fulltext,
+			Config:      config,
+		})
+		changed = true
+	}
+	return changed
 }
 
 // sendEmbeddingTask sends a embedding task to the queue


### PR DESCRIPTION
## 背景

资源层"全文索引"此前实际不可用:
- `buildFieldMappings` 对 `fulltext` 特性直接 `continue` 丢弃,只有字段本身是 `text` 类型才隐式分词;
- table 资源 schema 由 discover 派生(varchar→string→keyword),无任何接口能给字段声明全文。

本 PR 把全文检索做成**与 embedding 完全对称的构建任务参数**,string 字段也能建全文索引。

## 改动

**接口(前端用)**:`POST /api/vega-backend/v1/build-tasks` 新增
- `fulltext_fields`:逗号分隔,要建全文索引的字段(仅 string/text,后端校验)
- `fulltext_analyzer`:分词器,空为默认 `standard`(可填 `ik_max_word`/`hanlp_index` 等中文分词器)

**实现**:
- `executeBuild` 把 fulltext 特性写回资源 `schema_definition` 并持久化——索引 mapping 与查询侧字段解析二者一致(关键闭环,否则查询打不到子字段)。
- `buildFieldMappings`:string 字段 → 主字段保持 `keyword`(精确/排序/聚合不变)+ `<字段>.fulltext` text 子字段(带 analyzer);text 字段 → analyzer 设主字段。
- 查询侧 `match`/`match_phrase`/`multi_match`:string 全文字段解析为 `字段.fulltext` 子字段,否则裸字段名。
- `t_build_task` 增 `f_fulltext_fields` / `f_fulltext_analyzer`(mariadb + dm8 迁移 + 0.9.0 init)。
- handler 校验 fulltext_fields 必须 string/text。

## 全文 vs embedding(给前端参考)

| | embedding | fulltext |
|--|--|--|
| 参数 | `embedding_fields` + model/dimensions | `fulltext_fields` + analyzer |
| 建索引时机 | 异步第2段(向量化进度) | **同步**随 synced 落地,无独立进度 |
| 检索 | KNN 语义 | match 分词关键词 |
| 字段 | 加 `<字段>_vector` 独立字段 | 加 `<字段>.fulltext` 子字段 |

二者可同时选同一字段,互不冲突。

## VM 验证(World Cup wc_teams)

`fulltext_fields=team_name, fulltext_analyzer=standard` 建任务 → full 构建 → 公开数据 API:
- `match "united"` → United States / United Arab Emirates
- `match "korea"` → North Korea / South Korea
- mapping 实测:`team_name {type:keyword, fields:{fulltext:{type:text, analyzer:standard}}}`

## 已知限制

事后往已建索引增量加全文/向量需删任务全量重建(mapping 建好即冻结),见 #48。

## 测试

新增 buildFieldMappings(string/text/无config/keyword共存)、fulltextFieldName 解析、injectFulltextFeatures 幂等等单测;`go test ./...` 全绿,`go vet` 无新告警。

🤖 Generated with [Claude Code](https://claude.com/claude-code)