### PR TITLE
fix(onboard/preflight): drop eisoo.com + kweaver-admin, pin CLI to @openbkn/bkn-sdk@alpha

### DIFF
--- a/deploy/README.md
+++ b/deploy/README.md
@@ -129,7 +129,7 @@ export INGRESS_NGINX_HTTPS_PORT=8443
 # 4. (Recommended) Post-install bootstrap
 #    Registers an LLM + embedding (skips when already there), patches the BKN ConfigMap
 #    only when the default actually changes, and on a full ISF install creates the business
-#    user `test`, assigns every role from `kweaver-admin role list`, switches `kweaver` to
+#    user `test`, assigns every role from `openbkn admin role list`, switches `openbkn` to
 #    that user, and imports the Context Loader toolset.
 sudo bash ./onboard.sh        # interactive
 sudo bash ./onboard.sh -y     # non-interactive (uses defaults)
@@ -140,7 +140,7 @@ sudo bash ./onboard.sh --help # all flags (--config=models.yaml, --enable-bkn-se
 
 > Full preflight / onboard flow, ISF dual-CLI auth and Mermaid diagrams: see [help/en/install.md — Post-install: `onboard.sh`](../help/en/install.md#post-install-onboardsh).
 
-> **`onboard.sh` runtime messages** are **English**; on ISF HTTP **401001017**, a **TTY** prompts (**Enter**=`auth change-password` default; **`o`**=OAuth browser). Chinese + English context: [`dev/README.md`](../dev/README.md#onboard-and-kweaver-admin-full-isf) · [`dev/README.zh.md`](../dev/README.zh.md); product docs [`help/zh/install.md`](../help/zh/install.md) / [`help/en/install.md`](../help/en/install.md).
+> **`onboard.sh` runtime messages** are **English**; on ISF HTTP **401001017**, a **TTY** prompts (**Enter**=`auth change-password` default; **`o`**=OAuth browser). Chinese + English context: [`dev/README.md`](../dev/README.md#onboard-and-openbkn-full-isf) · [`dev/README.zh.md`](../dev/README.zh.md); product docs [`help/zh/install.md`](../help/zh/install.md) / [`help/en/install.md`](../help/en/install.md).
 
 ### Dev/test: pick chart versions (`--version_file`)
 

--- a/deploy/README.zh.md
+++ b/deploy/README.zh.md
@@ -127,8 +127,8 @@ export INGRESS_NGINX_HTTPS_PORT=8443
 
 # 4.（推荐）安装后引导
 #    注册 LLM + embedding（已有则跳过）；只有当默认 embedding 实际变更时才会 patch BKN ConfigMap；
-#    在 ISF 全量下还会创建业务用户 `test`、把 `kweaver-admin role list` 中所有角色都挂上、
-#    切换 `kweaver` 到该用户身份，并导入 Context Loader 工具集。
+#    在 ISF 全量下还会创建业务用户 `test`、把 `openbkn admin role list` 中所有角色都挂上、
+#    切换 `openbkn` 到该用户身份，并导入 Context Loader 工具集。
 sudo bash ./onboard.sh        # 交互模式
 sudo bash ./onboard.sh -y     # 非交互模式（按默认）
 sudo bash ./onboard.sh --help # 全部参数（--config=models.yaml、--enable-bkn-search、--skip-context-loader 等）

--- a/deploy/dev/README.md
+++ b/deploy/dev/README.md
@@ -112,16 +112,16 @@ See also: top-of-file comments in [`mac.sh`](mac.sh), `bash ./dev/mac.sh -h`.
 
 - **`kweaver-core-data-migrator` / pre-install job `BackoffLimitExceeded`:** ensure the **data layer** is up (normally automatic with **`kweaver-core install`**; otherwise run **`bash ./dev/mac.sh data-services install`**). Ensure **`depServices.rds`** points at in-cluster MariaDB after install (`mac-config` loopback placeholders may be updated when MariaDB is installed). Remove a failed release if Helm left it pending: `helm uninstall kweaver-core-data-migrator -n <namespace>` then re-run `kweaver-core install`.
 
-### Onboard and `kweaver-admin` (full ISF)
+### Onboard and `openbkn` (full ISF)
 
-`bash ./dev/mac.sh onboard` runs **`onboard.sh`** with **`CONFIG_YAML_PATH`** (usually `dev/conf/mac-config.yaml`). On a **full** install with ISF, the script calls **`kweaver-admin auth login`** with HTTP `-u`/`-p`. When the backend returns **401001017** (factory-default password blocked for HTTP `/oauth2/signin`), **if stdin and stdout are both a terminal**, **`onboard.sh` prompts** for the recovery method: **[Enter]** runs **`kweaver-admin auth change-password`** (CLI, default); **`o`** or **`oauth`** runs browser OAuth (**`auth login`** without `-u`/`-p`). After successful change-password, it asks once for the new password and retries HTTP **`auth login`**. **`onboard.sh` runtime hints stay English.**
+`bash ./dev/mac.sh onboard` runs **`onboard.sh`** with **`CONFIG_YAML_PATH`** (usually `dev/conf/mac-config.yaml`). On a **full** install with ISF, the script calls **`openbkn auth login`** with HTTP `-u`/`-p`. When the backend returns **401001017** (factory-default password blocked for HTTP `/oauth2/signin`), **if stdin and stdout are both a terminal**, **`onboard.sh` prompts** for the recovery method: **[Enter]** runs **`openbkn auth change-password`** (CLI, default); **`o`** or **`oauth`** runs browser OAuth (**`auth login`** without `-u`/`-p`). After successful change-password, it asks once for the new password and retries HTTP **`auth login`**. **`onboard.sh` runtime hints stay English.**
 
 | Approach | Typical command |
 |----------|-----------------|
-| OAuth / browser | `kweaver-admin auth login https://<access-address> -k` *(omit `-u` and `-p`)* |
-| HTTP change-password | `kweaver-admin auth change-password https://<access-address> -u admin -k` *(URL required)* |
-| Non-interactive | `kweaver-admin auth login … -p '<initial>' --new-password '<new>' -k`; then `export ONBOARD_DEFAULT_KWEAVER_PASSWORD` before `onboard -y` |
+| OAuth / browser | `openbkn auth login https://<access-address> -k` *(omit `-u` and `-p`)* |
+| HTTP change-password | `openbkn auth change-password https://<access-address> -u admin -k` *(URL required)* |
+| Non-interactive | `openbkn auth login … -p '<initial>' --new-password '<new>' -k`; then `export ONBOARD_DEFAULT_KWEAVER_PASSWORD` before `onboard -y` |
 
-**Always pass the platform base URL** on the CLI. If you omit it, `kweaver-admin` uses the saved **active profile** from `kweaver-admin auth list`, which may be a different cluster — **not** a Helm `accessAddress` misread.
+**Always pass the platform base URL** on the CLI. If you omit it, `openbkn` uses the saved **active profile** from `openbkn auth list`, which may be a different cluster — **not** a Helm `accessAddress` misread.
 
 Details: [`help/en/install.md`](../../help/en/install.md) · [`help/zh/install.md`](../../help/zh/install.md) (administrator tool / 401001017).

--- a/deploy/dev/README.zh.md
+++ b/deploy/dev/README.zh.md
@@ -110,16 +110,16 @@ docker stop $(docker ps -q --filter "label=io.x-k8s.kind.cluster=${CLUSTER}")
 - **`cluster up` 报 Docker API / `docker.sock`：**多为 **CLI 已装但引擎未起**。请先启动 **Docker Desktop**，`docker info` 通过后重试。**`doctor --fix`** 不会拉起守护进程。
 - **`kweaver-core-data-migrator` / Job `BackoffLimitExceeded`：**确认数据层就绪（一般由 **`kweaver-core install` 自动安装**；否则 **`data-services install`**）。确认 **`depServices.rds`** 指向集群内 MariaDB；必要时 `helm uninstall kweaver-core-data-migrator -n <namespace>` 后再装 Core。
 
-### Onboard 与 `kweaver-admin`（全量 ISF）
+### Onboard 与 `openbkn`（全量 ISF）
 
-**`bash ./dev/mac.sh onboard`** 调用 **`onboard.sh`**（`CONFIG_YAML_PATH` 多为 **`dev/conf/mac-config.yaml`**）。**全量 + ISF** 时会用 HTTP **`-u`/`-p`** 执行 **`kweaver-admin auth login`**。若返回 **401001017**，在 **标准输入与标准输出均为终端** 时，**脚本会先询问方式**：（**默认回车**）执行 **`auth change-password`（CLI）**；输入 **`o` / `oauth`** 则用浏览器 OAuth（无 `-u`/`-p` 的 **`auth login`**）。CLI 改密成功后会再问一次新密码并重试 HTTP 登录。无 TTY（如纯 **`onboard -y` 流水线**）时只打印英文备选说明。**终端里脚本提示仍为英文。**
+**`bash ./dev/mac.sh onboard`** 调用 **`onboard.sh`**（`CONFIG_YAML_PATH` 多为 **`dev/conf/mac-config.yaml`**）。**全量 + ISF** 时会用 HTTP **`-u`/`-p`** 执行 **`openbkn auth login`**。若返回 **401001017**，在 **标准输入与标准输出均为终端** 时，**脚本会先询问方式**：（**默认回车**）执行 **`auth change-password`（CLI）**；输入 **`o` / `oauth`** 则用浏览器 OAuth（无 `-u`/`-p` 的 **`auth login`**）。CLI 改密成功后会再问一次新密码并重试 HTTP 登录。无 TTY（如纯 **`onboard -y` 流水线**）时只打印英文备选说明。**终端里脚本提示仍为英文。**
 
 | 方式 | 命令要点 |
 |------|----------|
-| OAuth / 浏览器 | `kweaver-admin auth login https://<访问地址> -k`，**不要**加 `-u`/`-p` |
-| HTTP 改密 | `kweaver-admin auth change-password https://<访问地址> -u admin -k`，**必须写 URL** |
-| 非交互 | `kweaver-admin auth login … -p '<初始>' --new-password '<新>' -k`；`onboard -y` 前 **`export ONBOARD_DEFAULT_KWEAVER_PASSWORD`** |
+| OAuth / 浏览器 | `openbkn auth login https://<访问地址> -k`，**不要**加 `-u`/`-p` |
+| HTTP 改密 | `openbkn auth change-password https://<访问地址> -u admin -k`，**必须写 URL** |
+| 非交互 | `openbkn auth login … -p '<初始>' --new-password '<新>' -k`；`onboard -y` 前 **`export ONBOARD_DEFAULT_KWEAVER_PASSWORD`** |
 
-**务必在命令中写出平台访问基址**；省略时 CLI 使用 **`kweaver-admin auth list`** 里当前激活会话的地址，易连到其它环境，**并非** Helm 误读 `accessAddress`。
+**务必在命令中写出平台访问基址**；省略时 CLI 使用 **`openbkn auth list`** 里当前激活会话的地址，易连到其它环境，**并非** Helm 误读 `accessAddress`。
 
-详见 [`help/zh/install.md`](../../help/zh/install.md)、[`help/en/install.md`](../../help/en/install.md)（完整安装后的 `kweaver-admin` / 401001017）。
+详见 [`help/zh/install.md`](../../help/zh/install.md)、[`help/en/install.md`](../../help/en/install.md)（完整安装后的 `openbkn` / 401001017）。

--- a/deploy/onboard.sh
+++ b/deploy/onboard.sh
@@ -100,10 +100,10 @@ ONBOARD_SKIP_ISF_TEST_USER="${ONBOARD_SKIP_ISF_TEST_USER:-false}"
 # Populated by onboard_kweaver_tls_insecure_args_to_array (usually empty or -k).
 declare -a ONBOARD_TLS_INSECURE_ARGS=()
 
-# openbkn auth: HTTP sign-in defaults (ISF / full install). Console account is usually  admin  /  eisoo.com  if not changed.
+# openbkn auth: HTTP sign-in defaults (ISF / full install). Console account is usually  admin  /  openbkn  if not changed.
 # Override in CI. Used when you press Enter at username/password prompts.
 : "${ONBOARD_DEFAULT_KWEAVER_USER:=admin}"
-: "${ONBOARD_DEFAULT_KWEAVER_PASSWORD:=eisoo.com}"
+: "${ONBOARD_DEFAULT_KWEAVER_PASSWORD:=openbkn}"
 
 # ISF: first business user  test  (after  openbkn admin user create ) — platform default is 123456 until  reset-password;
 # we set this for onboard default /  -y  / empty Enter. Override: ONBOARD_TEST_USER_PASSWORD; rename default: ONBOARD_DEFAULT_TEST_USER_PASSWORD
@@ -264,7 +264,7 @@ usage() {
     echo "                onboard uses deploy/dev/conf/mac-config.yaml when that file exists (same as mac.sh)."
     echo "                Else host primary IPv4 + ONBOARD_DEFAULT_ACCESS_SCHEME (https by default)."
     echo "                Set ONBOARD_DEFAULT_ACCESS_BASE to force a URL; ONBOARD_DEFAULT_ACCESS_PORT / SCHEME override fallback IP path."
-    echo "  openbkn auth: you confirm URL. ISF+full: HTTP defaults user=admin pass=eisoo.com (if still default); override with ONBOARD_DEFAULT_KWEAVER_USER / _PASSWORD. Enter keeps defaults. Minimum: default --no-auth; Enter to accept."
+    echo "  openbkn auth: you confirm URL. ISF+full: HTTP defaults user=admin pass=openbkn (if still default); override with ONBOARD_DEFAULT_KWEAVER_USER / _PASSWORD. Enter keeps defaults. Minimum: default --no-auth; Enter to accept."
     echo "  openbkn admin auth (ISF): use  auth login <url> -u admin -p <pass>  (append -k for https:// + self-signed); optional  auth login <url> -k  without -u/-p for browser OAuth. If HTTP sign-in returns 401001017, a TTY prompts: [Enter]=run  auth change-password  then HTTP login; o=OAuth browser. Non-TTY / -y prints hints (change-password or  login … --new-password). Then openbkn re-logs in as user test for impex and model steps."
     echo "  Node: onboard is not a login shell — it auto-loads nvm/fnm/asdf/Volta and Homebrew paths so an already-configured Node 22+ is found without re-asking. ONBOARD_SKIP_NVM_INIT=true skips that; ONBOARD_NVM_VERSION=22 (default) is used after  nvm.sh  load."
     echo "  (preflight on the server: sudo bash ./preflight.sh --fix still optional; this script can install Node in your *user* account via nvm.)"
@@ -419,7 +419,7 @@ onboard_ensure_kweaver_cli() {
         exit 1
     fi
     if [[ "${ONBOARD_SKIP_KWEAVER_INSTALL:-false}" == "true" ]]; then
-        log_error "openbkn not in PATH. Install: npm i -g @openbkn/bkn-sdk  (or unset ONBOARD_SKIP_KWEAVER_INSTALL to allow this script to run npm -g.)"
+        log_error "openbkn not in PATH. Install: npm i -g @openbkn/bkn-sdk@alpha  (or unset ONBOARD_SKIP_KWEAVER_INSTALL to allow this script to run npm -g.)"
         exit 1
     fi
     if [[ "${ONBOARD_ASSUME_YES}" == "true" ]]; then
@@ -428,15 +428,15 @@ onboard_ensure_kweaver_cli() {
         echo ""
         read -r -p "openbkn CLI not in PATH. Install @openbkn/bkn-sdk globally now? (npm i -g) [Y/n]: " _obk
         if [[ "${_obk}" =~ ^[Nn] ]]; then
-            log_error "openbkn is required. Run:  npm i -g @openbkn/bkn-sdk"
+            log_error "openbkn is required. Run:  npm i -g @openbkn/bkn-sdk@alpha"
             exit 1
         fi
     else
-        log_error "openbkn not in PATH. In a TTY you get a Y/n prompt; without a TTY use  $0 -y  or install: npm i -g @openbkn/bkn-sdk"
+        log_error "openbkn not in PATH. In a TTY you get a Y/n prompt; without a TTY use  $0 -y  or install: npm i -g @openbkn/bkn-sdk@alpha"
         exit 1
     fi
-    if ! npm i -g @openbkn/bkn-sdk; then
-        log_error "npm i -g @openbkn/bkn-sdk failed. Check registry/proxy, or EACCES (avoid sudo; use nvm user prefix.)"
+    if ! npm i -g @openbkn/bkn-sdk@alpha; then
+        log_error "npm i -g @openbkn/bkn-sdk@alpha failed. Check registry/proxy, or EACCES (avoid sudo; use nvm user prefix.)"
         exit 1
     fi
     hash -r 2>/dev/null || true
@@ -588,13 +588,13 @@ onboard_kweaver_auth_login_echo_cmd() {
     onboard_log_info "Running: $(onboard_argv_q openbkn auth login "${_url}" "$@")"
 }
 
-# After access URL is chosen: ISF → HTTP sign-in (defaults admin / eisoo.com if unchanged) or browser; no ISF → --no-auth (Enter) or HTTP.
+# After access URL is chosen: ISF → HTTP sign-in (defaults admin / openbkn if unchanged) or browser; no ISF → --no-auth (Enter) or HTTP.
 # Env: ONBOARD_DEFAULT_KWEAVER_USER, ONBOARD_DEFAULT_KWEAVER_PASSWORD, ONBOARD_ASSUME_YES (non-interactive: ISF=HTTP+defaults, min=--no-auth).
 onboard_kweaver_auth_login_for_url() {
     local _kurl="$1"
     local _u _p _duser _dpass
     _duser="${ONBOARD_DEFAULT_KWEAVER_USER:-admin}"
-    _dpass="${ONBOARD_DEFAULT_KWEAVER_PASSWORD:-eisoo.com}"
+    _dpass="${ONBOARD_DEFAULT_KWEAVER_PASSWORD:-openbkn}"
     onboard_kweaver_tls_insecure_args_to_array "${_kurl}"
     local _kv
     _kv="$(openbkn --version 2>/dev/null | grep -Eo '[vV]?[0-9]+\.[0-9]+\.[0-9]+' | tail -1 || true)"
@@ -790,7 +790,7 @@ onboard_kweaver_admin_auth_login_for_url() {
     local _kurl="$1"
     local _u _p _duser _dpass _kad_out
     _duser="${ONBOARD_DEFAULT_KWEAVER_USER:-admin}"
-    _dpass="${ONBOARD_DEFAULT_KWEAVER_PASSWORD:-eisoo.com}"
+    _dpass="${ONBOARD_DEFAULT_KWEAVER_PASSWORD:-openbkn}"
     onboard_kweaver_tls_insecure_args_to_array "${_kurl}"
     # Block until the ISF client-registration route is live, so login doesn't race a 404.
     onboard_wait_isf_oauth_clients_ready "${_kurl}"
@@ -923,8 +923,8 @@ onboard_ensure_kweaver_admin_for_isf() {
     fi
     if [[ "${ONBOARD_ASSUME_YES}" == "true" ]]; then
         onboard_log_info "ISF: installing @openbkn/bkn-sdk (-y)…"
-        if ! npm i -g @openbkn/bkn-sdk; then
-            onboard_log_warn "npm i -g @openbkn/bkn-sdk failed; install manually, then: openbkn admin auth login <url> -u admin -p '<password>'  (-k only for https:// + self-signed; openbkn admin: HTTP sign-in, no flag)"
+        if ! npm i -g @openbkn/bkn-sdk@alpha; then
+            onboard_log_warn "npm i -g @openbkn/bkn-sdk@alpha failed; install manually, then: openbkn admin auth login <url> -u admin -p '<password>'  (-k only for https:// + self-signed; openbkn admin: HTTP sign-in, no flag)"
         fi
         hash -r 2>/dev/null || true
         onboard_prepend_npm_global_bin_to_path
@@ -937,13 +937,13 @@ onboard_ensure_kweaver_admin_for_isf() {
         return 0
     fi
     echo ""
-    read -r -p "ISF: run  npm i -g @openbkn/bkn-sdk  to create user [test] (re-run is OK if already installed) [Y/n]: " _kadm
+    read -r -p "ISF: run  npm i -g @openbkn/bkn-sdk@alpha  to create user [test] (re-run is OK if already installed) [Y/n]: " _kadm
     if [[ -n "${_kadm}" && "${_kadm}" =~ ^[Nn] ]]; then
-        onboard_log_warn "openbkn admin not installed: user test will not be created this run. Install later: npm i -g @openbkn/bkn-sdk"
+        onboard_log_warn "openbkn admin not installed: user test will not be created this run. Install later: npm i -g @openbkn/bkn-sdk@alpha"
         return 0
     fi
-    if ! npm i -g @openbkn/bkn-sdk; then
-        onboard_log_warn "npm i -g @openbkn/bkn-sdk failed (registry, proxy, or EACCES)."
+    if ! npm i -g @openbkn/bkn-sdk@alpha; then
+        onboard_log_warn "npm i -g @openbkn/bkn-sdk@alpha failed (registry, proxy, or EACCES)."
         return 0
     fi
     onboard_prepend_npm_global_bin_to_path
@@ -962,7 +962,7 @@ onboard_ensure_kweaver_admin_auth_for_isf() {
     fi
     onboard_prepend_npm_global_bin_to_path
     if ! command -v openbkn &>/dev/null; then
-        onboard_log_err "ISF (full) install: openbkn admin is not on PATH. Install: npm i -g @openbkn/bkn-sdk, add npm global bin to PATH, then re-run. (Unset ONBOARD_SKIP_KWEAVER_ADMIN_INSTALL if that blocked the install step.)"
+        onboard_log_err "ISF (full) install: openbkn admin is not on PATH. Install: npm i -g @openbkn/bkn-sdk@alpha, add npm global bin to PATH, then re-run. (Unset ONBOARD_SKIP_KWEAVER_ADMIN_INSTALL if that blocked the install step.)"
         exit 1
     fi
     if openbkn admin --json user list --limit 1 &>/dev/null; then
@@ -970,7 +970,7 @@ onboard_ensure_kweaver_admin_auth_for_isf() {
         return 0
     fi
     onboard_log_warn "ISF (full install):  openbkn  and  openbkn admin  are two different logins — two different saved sessions. The sign-in you just did only applies to  openbkn  (the SDK), not to  openbkn admin  (user/role management)."
-    onboard_log_warn "Next, sign in to  openbkn admin  the same way as  openbkn  (HTTP). User:  ${ONBOARD_DEFAULT_KWEAVER_USER:-admin} ; password: the same as the web console (factory default is often  ${ONBOARD_DEFAULT_KWEAVER_PASSWORD:-eisoo.com}  if you did not change it). After that, this script can create  test  and re-login  openbkn  as  test  for Context Loader / ADP import."
+    onboard_log_warn "Next, sign in to  openbkn admin  the same way as  openbkn  (HTTP). User:  ${ONBOARD_DEFAULT_KWEAVER_USER:-admin} ; password: the same as the web console (factory default is often  ${ONBOARD_DEFAULT_KWEAVER_PASSWORD:-openbkn}  if you did not change it). After that, this script can create  test  and re-login  openbkn  as  test  for Context Loader / ADP import."
     local _url _defu _go
     if [[ "${ONBOARD_ASSUME_YES}" == "true" ]]; then
         _defu="$(onboard_default_access_base_url 2>/dev/null || true)"

--- a/deploy/onboard.sh
+++ b/deploy/onboard.sh
@@ -257,7 +257,7 @@ usage() {
     echo "                ONBOARD_DEFAULT_TEST_USER_PASSWORD=...  first-user  test  password (default 111111;  -y  non-interactive)"
     echo "                ONBOARD_KWEAVER_IMPEX_NO_RELLOGIN=1  skip  openbkn auth  as  test  before impex (use current openbkn session)"
     echo "                ONBOARD_NO_COMPLETION_REPORT=1  do not print the English completion report at the end"
-    echo "                ONBOARD_FORCE_INSECURE_LOGIN=true  always pass -k (--insecure) to openbkn/kweaver-admin auth login (even for http:// bases; default false)"
+    echo "                ONBOARD_FORCE_INSECURE_LOGIN=true  always pass -k (--insecure) to openbkn auth login (even for http:// bases; default false)"
     echo "                ONBOARD_SKIP_CONFIG_ACCESS_URL=true  do not derive default URL from CONFIG_YAML_PATH accessAddress"
     echo "  Default BKN Foundry access URL (openbkn auth): accessAddress in CONFIG_YAML_PATH when present;"
     echo "                on macOS, if CONFIG_YAML_PATH is still deploy/conf/config.yaml (~/.openbkn-ai not used yet),"

--- a/deploy/preflight.sh
+++ b/deploy/preflight.sh
@@ -42,7 +42,7 @@ usage() {
     echo "  --list-fixes         Run checks then list fixes that would be offered (no changes; requires root)"
     echo "  --output=json        Emit JSON summary to stdout (human logs to stderr); requires python3"
     echo "  --role=target|admin|both  Target = kubectl/helm only; admin = kweaver/node/npm; both = all (default)"
-    echo "                              kweaver CLIs need Node.js ${PREFLIGHT_KWEAVER_MIN_NODE_MAJOR}+ (per @kweaver-ai/kweaver-sdk on npm; help/zh/install.md)"
+    echo "                              openbkn CLI needs Node.js ${PREFLIGHT_KWEAVER_MIN_NODE_MAJOR}+ (per @openbkn/bkn-sdk@alpha on npm; help/zh/install.md)"
     echo "  --no-recheck         Do not re-run full checks after applying fixes"
     echo "  --lenient            Downgrade install-blocking [FAIL] items (sysctl, ip_forward, kernel modules,"
     echo "                       containerd, kubectl, helm, swap, broken apt sources, missing k8s/containerd"

--- a/deploy/preflight.sh
+++ b/deploy/preflight.sh
@@ -38,7 +38,7 @@ usage() {
     echo "  --fix-allow=LIST     Comma-separated fix names to auto-approve (others are skipped)."
     echo "                       Names: k3s-uninstall,kubeadm-reset,k8s-pkgs-repo,k8s-bins,kubernetes-cni,containerd-install,helm-v3,"
     echo "                       docker-disable,chrony,firewalld,ufw,selinux,system-tuning,bridge-sysctl,kernel-limits,nofile-limits,ipv6-disable,iptables-legacy,etc-hosts,"
-    echo "                       onboard-tooling,nodejs-npm,node-22,kweaver-sdk,kweaver-admin"
+    echo "                       onboard-tooling,nodejs-npm,node-22,kweaver-sdk"
     echo "  --list-fixes         Run checks then list fixes that would be offered (no changes; requires root)"
     echo "  --output=json        Emit JSON summary to stdout (human logs to stderr); requires python3"
     echo "  --role=target|admin|both  Target = kubectl/helm only; admin = kweaver/node/npm; both = all (default)"

--- a/deploy/scripts/lib/onboard_isf_test_user.sh
+++ b/deploy/scripts/lib/onboard_isf_test_user.sh
@@ -210,7 +210,7 @@ onboard_offer_isf_test_user() {
     }
     command -v openbkn &>/dev/null || {
         ONBOARD_REPORT_ISF_TEST_USER="error: openbkn admin not on PATH"
-        onboard_log_err "ISF: openbkn admin not found. Install: npm i -g @openbkn/bkn-sdk, then: export PATH=\"\$(npm config get prefix 2>/dev/null)/bin:\$PATH\"  and re-run: $0"
+        onboard_log_err "ISF: openbkn admin not found. Install: npm i -g @openbkn/bkn-sdk@alpha, then: export PATH=\"\$(npm config get prefix 2>/dev/null)/bin:\$PATH\"  and re-run: $0"
         exit 1
     }
 
@@ -274,7 +274,7 @@ onboard_ensure_isf_test_for_kweaver_impex() {
         return 0
     fi
     if ! command -v openbkn &>/dev/null; then
-        log_warn "Context Loader (ISF): openbkn admin not on PATH; cannot prepare user [test]. Install: npm i -g @openbkn/bkn-sdk, then re-run."
+        log_warn "Context Loader (ISF): openbkn admin not on PATH; cannot prepare user [test]. Install: npm i -g @openbkn/bkn-sdk@alpha, then re-run."
         return 1
     fi
     if ! openbkn admin --json user list --limit 1 &>/dev/null; then

--- a/deploy/scripts/lib/preflight_checks.sh
+++ b/deploy/scripts/lib/preflight_checks.sh
@@ -17,14 +17,14 @@ declare -a PREFLIGHT_JSON_FIXED=()
 declare -a PREFLIGHT_JSON_DECLINED=()
 declare -a PREFLIGHT_FAIL_SNAPSHOT=()
 
-# Node major for kweaver / onboard / kweaver-admin in this deploy path (default 22: aligns with
-# @kweaver-ai/kweaver-sdk; we use the same bar for kweaver-admin even if npm lists >=18). Override for experiments.
+# Node major for openbkn / onboard in this deploy path (default 22: aligns with
+# @openbkn/bkn-sdk@alpha; same bar even if npm lists >=18). Override for experiments.
 PREFLIGHT_KWEAVER_MIN_NODE_MAJOR="${PREFLIGHT_KWEAVER_MIN_NODE_MAJOR:-22}"
 # Minimum CPython for deploy/scripts/lib/onboard_*.py; enforced when python3 is on PATH.
 PREFLIGHT_MIN_PYTHON_MAJOR="${PREFLIGHT_MIN_PYTHON_MAJOR:-3}"
 PREFLIGHT_MIN_PYTHON_MINOR="${PREFLIGHT_MIN_PYTHON_MINOR:-6}"
 # If the user does not install Node 22+ on the server they ran preflight on, they need *some* environment with it.
-PREFLIGHT_OFFHOST_NODE22_HINT="If you do not upgrade Node on this host, run ./onboard.sh and kweaver CLIs from a machine (or job) where Node ${PREFLIGHT_KWEAVER_MIN_NODE_MAJOR}+ is on PATH — e.g. your laptop, a jump box with nvm, a devcontainer, or CI."
+PREFLIGHT_OFFHOST_NODE22_HINT="If you do not upgrade Node on this host, run ./onboard.sh and the openbkn CLI from a machine (or job) where Node ${PREFLIGHT_KWEAVER_MIN_NODE_MAJOR}+ is on PATH — e.g. your laptop, a jump box with nvm, a devcontainer, or CI."
 
 # Strict mode (default true): items that block install AND are auto-fixable by --fix
 # are reported as [FAIL] instead of [WARN], so check-only exits 1 (not 2) and operators
@@ -1423,14 +1423,14 @@ preflight_node_major() {
 
 preflight_check_admin_tools() {
     preflight_skip "admin-tools" && return 0
-    log_info "Checking admin / optional tools (node, npm, kweaver, kweaver-admin) — target Node ${PREFLIGHT_KWEAVER_MIN_NODE_MAJOR}+; below that is [WARN] only (not [FAIL])..."
+    log_info "Checking admin / optional tools (node, npm, openbkn) — target Node ${PREFLIGHT_KWEAVER_MIN_NODE_MAJOR}+; below that is [WARN] only (not [FAIL])..."
 
     local _nmj
     _nmj=""
     if command -v node &>/dev/null; then
         _nmj="$(preflight_node_major)"
         if [[ -n "${_nmj}" && $(( 10#${_nmj} )) -ge ${PREFLIGHT_KWEAVER_MIN_NODE_MAJOR} ]]; then
-            preflight_ok "node: $(node -v 2>/dev/null) (>= ${PREFLIGHT_KWEAVER_MIN_NODE_MAJOR}; kweaver-sdk + onboard; this installer also uses the same for kweaver-admin)"
+            preflight_ok "node: $(node -v 2>/dev/null) (>= ${PREFLIGHT_KWEAVER_MIN_NODE_MAJOR}; openbkn CLI + onboard)"
         else
             preflight_warn "node: $(node -v 2>/dev/null) (need ${PREFLIGHT_KWEAVER_MIN_NODE_MAJOR}+. Not a hard failure. Fix: sudo bash ./preflight.sh --fix → allow onboard-tooling, then accept node-22 (nvm/NodeSource), or upgrade Node yourself. ${PREFLIGHT_OFFHOST_NODE22_HINT}"
         fi
@@ -1444,37 +1444,16 @@ preflight_check_admin_tools() {
         preflight_warn "npm not in PATH (usually bundled with Node; sudo bash ./preflight.sh --fix can offer nodejs-npm, then node-22)"
     fi
 
-    if command -v kweaver &>/dev/null; then
+    if command -v openbkn &>/dev/null; then
         if ! command -v node &>/dev/null; then
-            preflight_ok "kweaver: $(kweaver --version 2>/dev/null | head -1 || echo ok) (node issue called out above)"
+            preflight_ok "openbkn: $(openbkn --version 2>/dev/null | head -1 || echo ok) (node issue called out above)"
         elif [[ -n "${_nmj}" && $(( 10#${_nmj} )) -ge ${PREFLIGHT_KWEAVER_MIN_NODE_MAJOR} ]]; then
-            preflight_ok "kweaver: $(kweaver --version 2>/dev/null | head -1 || echo ok)"
+            preflight_ok "openbkn: $(openbkn --version 2>/dev/null | head -1 || echo ok) (provides 'openbkn admin')"
         else
-            preflight_warn "kweaver on PATH, but Node is < ${PREFLIGHT_KWEAVER_MIN_NODE_MAJOR} — prefer upgrading to Node ${PREFLIGHT_KWEAVER_MIN_NODE_MAJOR}+ (npm i -g and onboard expect that here). ${PREFLIGHT_OFFHOST_NODE22_HINT}"
+            preflight_warn "openbkn on PATH, but Node is < ${PREFLIGHT_KWEAVER_MIN_NODE_MAJOR} — prefer upgrading to Node ${PREFLIGHT_KWEAVER_MIN_NODE_MAJOR}+ (npm i -g and onboard expect that here). ${PREFLIGHT_OFFHOST_NODE22_HINT}"
         fi
     else
-        preflight_warn "kweaver CLI not in PATH (npm i -g @kweaver-ai/kweaver-sdk; or sudo bash ./preflight.sh --fix after Node ${PREFLIGHT_KWEAVER_MIN_NODE_MAJOR}+). ${PREFLIGHT_OFFHOST_NODE22_HINT}"
-    fi
-
-    if command -v kweaver-admin &>/dev/null; then
-        if ! command -v node &>/dev/null; then
-            preflight_ok "kweaver-admin: $(kweaver-admin --version 2>/dev/null | head -1 || echo ok) (node issue called out above)"
-        elif [[ -n "${_nmj}" && $(( 10#${_nmj} )) -ge ${PREFLIGHT_KWEAVER_MIN_NODE_MAJOR} ]]; then
-            preflight_ok "kweaver-admin: $(kweaver-admin --version 2>/dev/null | head -1 || echo ok)"
-        else
-            preflight_warn "kweaver-admin on PATH, but Node is < ${PREFLIGHT_KWEAVER_MIN_NODE_MAJOR} — this deploy path standardizes on ${PREFLIGHT_KWEAVER_MIN_NODE_MAJOR}+ (same as kweaver-sdk); upgrade via sudo bash ./preflight.sh --fix → onboard-tooling + node-22 if you opt in. ${PREFLIGHT_OFFHOST_NODE22_HINT}"
-        fi
-    else
-        if [[ "${PREFLIGHT_KWEAVER_RELEASE_NAMES:-}" == *authentication* \
-            || "${PREFLIGHT_KWEAVER_RELEASE_NAMES:-}" == *user-management* \
-            || "${PREFLIGHT_KWEAVER_RELEASE_NAMES:-}" == *eacp* \
-            || "${PREFLIGHT_KWEAVER_RELEASE_NAMES:-}" == *isfweb* ]]; then
-            if ! command -v node &>/dev/null || [[ -z "${_nmj}" || $(( 10#${_nmj} )) -lt ${PREFLIGHT_KWEAVER_MIN_NODE_MAJOR} ]]; then
-                preflight_warn "kweaver-admin not in PATH; cluster has ISF-related components — get Node ${PREFLIGHT_KWEAVER_MIN_NODE_MAJOR}+ first, then: npm i -g @kweaver-ai/kweaver-admin (or sudo bash ./preflight.sh --fix: onboard-tooling → node-22 → kweaver-admin). ${PREFLIGHT_OFFHOST_NODE22_HINT}"
-            else
-                preflight_warn "kweaver-admin not in PATH (ISF-related release detected; install: npm i -g @kweaver-ai/kweaver-admin, or sudo bash ./preflight.sh --fix and approve kweaver-admin). ${PREFLIGHT_OFFHOST_NODE22_HINT}"
-            fi
-        fi
+        preflight_warn "openbkn CLI not in PATH (npm i -g @openbkn/bkn-sdk@alpha; or sudo bash ./preflight.sh --fix after Node ${PREFLIGHT_KWEAVER_MIN_NODE_MAJOR}+). 'openbkn admin' ships with it. ${PREFLIGHT_OFFHOST_NODE22_HINT}"
     fi
 }
 
@@ -2205,7 +2184,7 @@ preflight_print_fix_preview() {
     for line in "${PREFLIGHT_FAIL_SNAPSHOT[@]}"; do
         log_info "  * ${line}"
     done
-    log_info "  Suggested fix names: k3s-uninstall (k8s/kubeadm path only), kubeadm-reset, k8s-pkgs-repo (writes apt OR yum/dnf pkgs.k8s.io repo; legacy name k8s-apt-source still works in --fix-allow), k8s-bins, kubernetes-cni (/opt/cni/bin loopback for kubelet pod sandbox), containerd-install, helm-v3, docker-disable (stop/disable docker.service + docker.socket — CRI conflict with k3s or containerd), chrony, firewalld, ufw, selinux, system-tuning, bridge-sysctl, kernel-limits, nofile-limits (writes /etc/security/limits.d + systemd LimitNOFILE drop-ins), ipv6-disable (writes /etc/sysctl.d/99-kweaver-disable-ipv6.conf + restarts docker for hosts where AAAA resolves but IPv6 routing is broken), iptables-legacy, etc-hosts, onboard-tooling, nodejs-npm, node-22, kweaver-sdk, kweaver-admin (opt-in; bundle onboard-tooling asks if this host will run ./onboard.sh). Default distro is k8s (kubeadm); use --distro=k3s or KUBE_DISTRO=k3s for single-node k3s checks/fixes."
+    log_info "  Suggested fix names: k3s-uninstall (k8s/kubeadm path only), kubeadm-reset, k8s-pkgs-repo (writes apt OR yum/dnf pkgs.k8s.io repo; legacy name k8s-apt-source still works in --fix-allow), k8s-bins, kubernetes-cni (/opt/cni/bin loopback for kubelet pod sandbox), containerd-install, helm-v3, docker-disable (stop/disable docker.service + docker.socket — CRI conflict with k3s or containerd), chrony, firewalld, ufw, selinux, system-tuning, bridge-sysctl, kernel-limits, nofile-limits (writes /etc/security/limits.d + systemd LimitNOFILE drop-ins), ipv6-disable (writes /etc/sysctl.d/99-kweaver-disable-ipv6.conf + restarts docker for hosts where AAAA resolves but IPv6 routing is broken), iptables-legacy, etc-hosts, onboard-tooling, nodejs-npm, node-22, kweaver-sdk (opt-in; bundle onboard-tooling asks if this host will run ./onboard.sh). Default distro is k8s (kubeadm); use --distro=k3s or KUBE_DISTRO=k3s for single-node k3s checks/fixes."
     log_info "------------------------------------------------------------------"
 }
 
@@ -2239,16 +2218,8 @@ preflight_onboard_tooling_needed() {
     if [[ -n "${_om}" && $(( 10#${_om} )) -lt ${PREFLIGHT_KWEAVER_MIN_NODE_MAJOR} ]]; then
         return 0
     fi
-    if ! command -v kweaver &>/dev/null; then
+    if ! command -v openbkn &>/dev/null; then
         return 0
-    fi
-    if [[ "${PREFLIGHT_KWEAVER_RELEASE_NAMES:-}" == *authentication* \
-        || "${PREFLIGHT_KWEAVER_RELEASE_NAMES:-}" == *user-management* \
-        || "${PREFLIGHT_KWEAVER_RELEASE_NAMES:-}" == *eacp* \
-        || "${PREFLIGHT_KWEAVER_RELEASE_NAMES:-}" == *isfweb* ]]; then
-        if ! command -v kweaver-admin &>/dev/null; then
-            return 0
-        fi
     fi
     return 1
 }
@@ -2306,8 +2277,7 @@ preflight_fix_allow_includes_onboard_step() {
     [[ "${PREFLIGHT_FIX_ALLOW}" == *"|onboard-tooling|"* ]] \
         || [[ "${PREFLIGHT_FIX_ALLOW}" == *"|nodejs-npm|"* ]] \
         || [[ "${PREFLIGHT_FIX_ALLOW}" == *"|node-22|"* ]] \
-        || [[ "${PREFLIGHT_FIX_ALLOW}" == *"|kweaver-sdk|"* ]] \
-        || [[ "${PREFLIGHT_FIX_ALLOW}" == *"|kweaver-admin|"* ]]
+        || [[ "${PREFLIGHT_FIX_ALLOW}" == *"|kweaver-sdk|"* ]]
 }
 
 # --- safe auto-fixes (requires root) ------------------------------------------
@@ -2656,14 +2626,14 @@ preflight_apply_safe_fixes() {
     # --- Node / kweaver: first ask if THIS host will run ./onboard.sh (needs minimum Node + kweaver on PATH) ----
     local _ot_run=false
     if [[ "${PREFLIGHT_ROLE:-both}" == "target" ]]; then
-        log_info "  -> skipping onboard-tooling / node-22 / kweaver-sdk / kweaver-admin: PREFLIGHT_ROLE=target (admin tooling lives on another host)"
+        log_info "  -> skipping onboard-tooling / node-22 / kweaver-sdk: PREFLIGHT_ROLE=target (admin tooling lives on another host)"
     elif preflight_was_declined "onboard-tooling"; then
         log_info "  -> skipping onboard-tooling: previously declined ($(_preflight_decision_file onboard-tooling)). Re-prompt: sudo rm $(_preflight_decision_file onboard-tooling) (or run preflight with PREFLIGHT_FORGET_DECISIONS=true)"
     elif preflight_onboard_tooling_needed; then
         if preflight_fix_allow_includes_onboard_step; then
             _ot_run=true
         elif preflight_confirm_fix "onboard-tooling" \
-            "Will you run ./onboard.sh (and optionally kweaver CLIs) on this machine? We standardize on Node ${PREFLIGHT_KWEAVER_MIN_NODE_MAJOR}+ (kweaver-sdk, kweaver-admin, onboard); we can nvm/NodeSource → npm -g in the next prompts if you say Yes" \
+            "Will you run ./onboard.sh (and optionally the openbkn CLI) on this machine? We standardize on Node ${PREFLIGHT_KWEAVER_MIN_NODE_MAJOR}+ (openbkn CLI, onboard); we can nvm/NodeSource → npm -g in the next prompts if you say Yes" \
             "Choose No if you will run onboard/CLIs on another host with Node ${PREFLIGHT_KWEAVER_MIN_NODE_MAJOR}+ (nvm, container, laptop, etc.). If you stay on this machine without node-22, you still need that other environment. Yes = may run node-22 and global npm; each step y/N unless -y. Saying No is REMEMBERED — preflight will not ask again until you remove the sentinel."; then
             _ot_run=true
         else
@@ -2703,33 +2673,16 @@ preflight_apply_safe_fixes() {
         local _npmj
         _npmj="$(preflight_node_major)"
         if [[ -z "${_npmj}" || $(( 10#${_npmj} )) -lt ${PREFLIGHT_KWEAVER_MIN_NODE_MAJOR} ]]; then
-            preflight_warn "Skipping kweaver-sdk / kweaver-admin global npm installs: need Node ${PREFLIGHT_KWEAVER_MIN_NODE_MAJOR}+ (current: $(node -v 2>/dev/null || echo 'no node')). Run node-22 fix with consent, or upgrade Node manually, then re-run preflight --fix. ${PREFLIGHT_OFFHOST_NODE22_HINT}"
+            preflight_warn "Skipping openbkn CLI (@openbkn/bkn-sdk@alpha) global npm install: need Node ${PREFLIGHT_KWEAVER_MIN_NODE_MAJOR}+ (current: $(node -v 2>/dev/null || echo 'no node')). Run node-22 fix with consent, or upgrade Node manually, then re-run preflight --fix. ${PREFLIGHT_OFFHOST_NODE22_HINT}"
         else
-        if ! command -v kweaver &>/dev/null; then
+        if ! command -v openbkn &>/dev/null; then
             if preflight_confirm_fix "kweaver-sdk" \
-                "npm install -g @kweaver-ai/kweaver-sdk" \
-                "User accepted: installs kweaver CLI. Requires working npm and Node ${PREFLIGHT_KWEAVER_MIN_NODE_MAJOR}+ on PATH in this root shell (same as https://www.npmjs.com/package/@kweaver-ai/kweaver-sdk)."; then
-                if npm install -g @kweaver-ai/kweaver-sdk; then
-                    preflight_fixed "Installed @kweaver-ai/kweaver-sdk ($(kweaver --version 2>/dev/null | head -n1 || echo ok))"
+                "npm install -g @openbkn/bkn-sdk@alpha" \
+                "User accepted: installs the openbkn CLI (provides 'openbkn admin'). Requires working npm and Node ${PREFLIGHT_KWEAVER_MIN_NODE_MAJOR}+ on PATH in this root shell (same as https://www.npmjs.com/package/@openbkn/bkn-sdk)."; then
+                if npm install -g @openbkn/bkn-sdk@alpha; then
+                    preflight_fixed "Installed @openbkn/bkn-sdk@alpha ($(openbkn --version 2>/dev/null | head -n1 || echo ok))"
                 else
-                    preflight_warn "npm install -g @kweaver-ai/kweaver-sdk failed (check npm registry / proxy)"
-                fi
-            fi
-        fi
-
-        if [[ "${PREFLIGHT_KWEAVER_RELEASE_NAMES:-}" == *authentication* \
-            || "${PREFLIGHT_KWEAVER_RELEASE_NAMES:-}" == *user-management* \
-            || "${PREFLIGHT_KWEAVER_RELEASE_NAMES:-}" == *eacp* \
-            || "${PREFLIGHT_KWEAVER_RELEASE_NAMES:-}" == *isfweb* ]]; then
-            if ! command -v kweaver-admin &>/dev/null; then
-                if preflight_confirm_fix "kweaver-admin" \
-                    "npm install -g @kweaver-ai/kweaver-admin" \
-                    "User accepted: ISF admin CLI. This path requires Node ${PREFLIGHT_KWEAVER_MIN_NODE_MAJOR}+ (stricter than npm engines may show). Token store: ~/.kweaver-admin/"; then
-                    if npm install -g @kweaver-ai/kweaver-admin; then
-                        preflight_fixed "Installed @kweaver-ai/kweaver-admin ($(kweaver-admin --version 2>/dev/null | head -n1 || echo ok))"
-                    else
-                        preflight_warn "npm install -g @kweaver-ai/kweaver-admin failed (check npm registry / proxy)"
-                    fi
+                    preflight_warn "npm install -g @openbkn/bkn-sdk@alpha failed (check npm registry / proxy)"
                 fi
             fi
         fi


### PR DESCRIPTION
## Why

Onboard/preflight carried ISF-era leftovers that break a fresh openbkn + bkn-safe install:

1. **`eisoo.com`** was the default sign-in password. Worse, onboard.sh set it as the *global* default (`:=eisoo.com`) at the top, which shadowed the bkn-safe path's `:-openbkn` fallback — so headless onboard signed in with the wrong password.
2. **CLI install was untagged** (`@openbkn/bkn-sdk`), which can resolve to an old/absent "latest".
3. **preflight still installed `@kweaver-ai/kweaver-sdk` and probed the `kweaver` / `kweaver-admin` binaries** — pre-rebrand. The `kweaver-sdk` --fix installed the wrong package and never satisfied its own check.

## What

- **eisoo.com → openbkn** everywhere in onboard.sh (default password is now bkn-safe's actual `DefaultInitialPassword`).
- **Pin every CLI install to `@openbkn/bkn-sdk@alpha`** (onboard.sh, onboard_isf_test_user.sh, preflight.sh, preflight_checks.sh).
- **preflight kweaver→openbkn**: `command -v openbkn`, `openbkn --version`, install `@openbkn/bkn-sdk@alpha`.
- **Drop kweaver-admin entirely** — `openbkn admin` is a subcommand of `@openbkn/bkn-sdk`, so the separate ISF admin CLI check / --fix / --fix-allow gate / help text are removed, and all `kweaver-admin` mentions in deploy/ docs are rewritten to `openbkn` / `openbkn admin role list`.

Internal identifiers left unchanged on purpose: `PREFLIGHT_KWEAVER_*` vars, `99-kweaver-*.conf` files, helm release-name matching, and the `kweaver-sdk` --fix id.

## Test

- `grep` confirms 0 `eisoo` / 0 `@kweaver-ai` / 0 `kweaver-admin` / 0 `command -v kweaver` left in deploy/.
- `bash -n` clean on onboard.sh, preflight.sh, preflight_checks.sh, onboard_isf_test_user.sh.

🤖 Generated with [Claude Code](https://claude.com/claude-code)