### PR TITLE
fix(deploy,examples): embedding batch cap, example backend bind, prereq docs

### DIFF
--- a/deploy/conf/models.yaml.example
+++ b/deploy/conf/models.yaml.example
@@ -19,7 +19,9 @@ embedding:
     api_key: ${SILICONFLOW_API_KEY}
     api_url: https://api.siliconflow.cn/v1/embeddings
     api_model: BAAI/bge-m3
-    batch_size: 32
+    # texts per embedding request. Keep <= 10 for DashScope text-embedding-v* (hard cap);
+    # other providers (SiliconFlow/OpenAI) allow more. 10 is a safe default for all.
+    batch_size: 10
     max_tokens: 512
     embedding_dim: 1024
     # Mark one embedding as the default for BKN semantic search (bkn-backend + ontology-query)

--- a/deploy/notes/bkn-safe-image-republish.md
+++ b/deploy/notes/bkn-safe-image-republish.md
@@ -1,0 +1,87 @@
+# Republishing backend images for the bkn-safe authz cutover
+
+The released `*:0.1.0` images were built **before** the bkn-safe authz cutover
+(PR #25, commit `a7af985d`). Their binaries still call the retired ISF
+`authorization-private` service, so on a fresh deploy:
+
+- `bkn-backend` / `vega-backend` BKN push + `FilterResources` fail
+  (`CheckPermissionFailed` / `FilterResourcesFailed`), and `bkn-backend`
+  CrashLoops once a catalog exists (startup `GetCatalogByID` → vega → ISF).
+- `mf-model-api` public authz routes 403 (hits `authorization-private`).
+
+**The source is already correct** — every service applies the `AUTHZ_PROVIDER`
+switch in-tree (vega/bkn `main.go` → `MaybeShadow`; agent-factory
+`chttpinject/authz.go`; operator-integration `NewAuthorization` → `selectAuthz`;
+mf-model-api `permission_manager.py`). The fix is to **rebuild + republish the
+images from current source** and ensure the deploy env sets the switch.
+
+## 1. Build + push images (needs `docker login ghcr.io`)
+
+```bash
+REG=ghcr.io/openbkn-ai
+TAG=0.1.1            # bump (recommended) or reuse 0.1.0 to overwrite in place
+GOPROXY_URL=https://goproxy.cn,direct          # drop outside CN
+BUILD_IMAGE=docker.m.daocloud.io/library/golang:1.25.10   # or golang:1.25.10
+BASE_UBUNTU=docker.m.daocloud.io/library/ubuntu:24.04      # or ubuntu:24.04
+
+# --- bkn-backend (Go, CGO) — plain Dockerfile build ---
+( cd adp/bkn/bkn-backend && docker build -f docker/Dockerfile \
+    --build-arg BUILD_IMAGE="$BUILD_IMAGE" --build-arg BASE_IMAGE="$BASE_UBUNTU" \
+    --build-arg GOPROXY_URL="$GOPROXY_URL" --build-arg SERVER_VERSION="$TAG" \
+    -t "$REG/bkn-backend:$TAG" . )
+
+# --- vega-backend (Go, CGO) — its prod stage pip-installs sqlglot (slow/blocked
+#     in CN), so build the binary then OVERLAY onto the existing base image ---
+( cd adp/vega/vega-backend
+  docker run --rm -v "$PWD/server:/go/src" -w /go/src \
+    -e GOPROXY="$GOPROXY_URL" -e CGO_ENABLED=1 -e GOFLAGS=-mod=mod "$BUILD_IMAGE" \
+    bash -c "go mod download && go build -ldflags '-s -w -X vega-backend/version.ServerVersion=$TAG' -o ./bin/vega-backend-server"
+  printf 'FROM %s/vega-backend:0.1.0\nCOPY bin/vega-backend-server /opt/vega-backend/vega-backend-server\n' "$REG" > /tmp/vega.Dockerfile
+  docker build -f /tmp/vega.Dockerfile -t "$REG/vega-backend:$TAG" server )
+
+# --- agent-backend (agent-factory) and mf-model-api ---
+# Rebuild from their own docker/Dockerfile the same way (Go: plain build;
+# mf-model-api is Python/pyinstaller — overlay onto :0.1.0 if the build is slow).
+
+docker push "$REG/bkn-backend:$TAG"
+docker push "$REG/vega-backend:$TAG"
+# docker push "$REG/agent-backend:$TAG"
+# docker push "$REG/mf-model-api:$TAG"
+```
+
+> Air-gapped / k3s nodes: instead of `docker push`, import straight into the
+> node's containerd: `docker save "$REG/<svc>:$TAG" | ctr -n k8s.io images import -`.
+
+## 2. Point the deployments at the new tag
+
+If you bumped to `0.1.1`, set the image tag in the chart values (or directly):
+
+```bash
+NS=openbkn
+for s in bkn-backend vega-backend; do
+  kubectl -n "$NS" set image deploy/$s $s=ghcr.io/openbkn-ai/$s:0.1.1
+  kubectl -n "$NS" rollout status deploy/$s --timeout=200s
+done
+# verify each pod logs:  [authz] provider=bkn-safe (authoritative) at http://bkn-safe:3000
+```
+
+## 3. Fill the missing deploy env (config, not code)
+
+`mf-model-api` ships without the authz switch env, so its public routes still
+hit ISF. Add it (chart values `env:` or a quick patch):
+
+```bash
+kubectl -n openbkn set env deploy/mf-model-api \
+  AUTHZ_PROVIDER=bkn-safe BKN_SAFE_URL=http://bkn-safe:3000
+kubectl -n openbkn rollout status deploy/mf-model-api --timeout=180s
+```
+
+(`ontology-query` similarly lacks the env; add the same pair if its authz path
+is exercised.)
+
+## 4. Drop the temporary 118 overlay tags
+
+On 118 the live `bkn-backend` / `vega-backend` run a locally-built
+`:0.1.0-authzfix` overlay. Once `:0.1.1` (or rebuilt `:0.1.0`) is published,
+re-point those deployments at the official tag so nothing depends on a
+node-local image.

--- a/deploy/onboard.sh
+++ b/deploy/onboard.sh
@@ -1164,6 +1164,7 @@ if [[ "${INTERACTIVE}" == "true" ]]; then
             read -r -p "api_model: " em_am
             read -r -p "api_url: " em_url
             read -r -p "embedding_dim [1024]: " em_dim
+            read -r -p "batch_size [10] (texts per embedding request; DashScope text-embedding-v* caps at 10): " em_batch
             if [[ -n "${_bkn_current_default}" ]]; then
                 read -r -p "BKN default is currently [${_bkn_current_default}]. Set [${em_n}] as the new BKN default (will patch ConfigMaps and restart bkn-backend / ontology-query)? [y/N]: " em_bkn
                 if [[ "${em_bkn}" =~ ^[Yy] ]]; then
@@ -1175,7 +1176,7 @@ if [[ "${INTERACTIVE}" == "true" ]]; then
                     _new_em_set_default="true"
                 fi
             fi
-            onboard_ensure_small_model "${em_n}" "embedding" "${em_key}" "${em_url}" "${em_am}" 32 512 "${em_dim:-1024}"
+            onboard_ensure_small_model "${em_n}" "embedding" "${em_key}" "${em_url}" "${em_am}" "${em_batch:-10}" 512 "${em_dim:-1024}"
             if [[ "${_new_em_set_default}" == "true" ]]; then
                 bkn_default_name="${em_n}"
             fi

--- a/deploy/scripts/lib/onboard_models.sh
+++ b/deploy/scripts/lib/onboard_models.sh
@@ -141,7 +141,7 @@ ${name}"
 
 # Args: name, type, api_key, api_url, api_model, batch, max_tok, emb_dim
 onboard_ensure_small_model() {
-    local name="$1" stype="$2" akey="$3" aurl="$4" amodel="$5" batch="${6:-32}" maxtok="${7:-512}" embdim="${8:-1024}"
+    local name="$1" stype="$2" akey="$3" aurl="$4" amodel="$5" batch="${6:-10}" maxtok="${7:-512}" embdim="${8:-1024}"
     if printf '%s\n' "${_POSTI_EXISTING_SM}" | grep -qFx "${name}"; then
         onboard_log_info "Small model already registered, skip: ${name}"
         return 0

--- a/examples/05-skill-routing-loop/env.sample
+++ b/examples/05-skill-routing-loop/env.sample
@@ -19,12 +19,18 @@ DB_USER=root
 DB_PASS=changeme
 
 # ── Mock business backend ────────────────────────────────────────────────────
+# Install deps first: pip install -r tool_backend/requirements.txt  (Python >= 3.7)
 # Local port for the mock ERP/MES that Skills call. Change if 8765 is in use.
 TOOL_BACKEND_PORT=8765
 
-# URL reachable from the execution-factory sandbox when builtin_skill_execute_script
-# runs. Keep the default for local verification; set this to a routable host/IP if
-# you want the platform-side Skill script to call the mock backend directly.
+# Interface server.py binds. Default 0.0.0.0 so an in-cluster platform/agent can reach
+# it via the host's routable IP. Set 127.0.0.1 only for a purely local (same-host) run.
+# TOOL_BACKEND_BIND=0.0.0.0
+
+# URL the platform/execution-factory sandbox uses to reach the mock backend. For a
+# local same-host run, http://127.0.0.1:8765 is fine. When the platform runs in k8s,
+# set this to the runner's cluster-routable IP (e.g. the node's internal IP),
+# NOT 127.0.0.1 — e.g. http://<node-internal-ip>:8765.
 TOOL_BACKEND_PUBLIC_URL=http://127.0.0.1:8765
 
 # ── Optional ─────────────────────────────────────────────────────────────────

--- a/examples/05-skill-routing-loop/tool_backend/server.py
+++ b/examples/05-skill-routing-loop/tool_backend/server.py
@@ -103,5 +103,9 @@ def healthz():
 
 
 if __name__ == "__main__":
-    print(f"[tool_backend] listening on 127.0.0.1:{PORT}", file=sys.stderr)
-    app.run(host="127.0.0.1", port=PORT, debug=False)
+    # Bind 0.0.0.0 by default so the platform/agent (running in-cluster) can reach
+    # this mock backend via the host's routable IP set in TOOL_BACKEND_PUBLIC_URL.
+    # Override with TOOL_BACKEND_BIND=127.0.0.1 for a purely local run.
+    host = os.environ.get("TOOL_BACKEND_BIND", "0.0.0.0")
+    print(f"[tool_backend] listening on {host}:{PORT}", file=sys.stderr)
+    app.run(host=host, port=PORT, debug=False)

--- a/examples/README.md
+++ b/examples/README.md
@@ -30,7 +30,17 @@ vim .env        # Fill in DB_HOST, DB_USER, DB_PASS, etc.
 
 All examples require:
 - openbkn CLI: `npm install -g @openbkn/bkn-sdk` (Node ≥ 22)
-- Platform login: `openbkn auth login https://<your-platform-url>`
+- Platform login as an admin/super-admin: `openbkn auth login https://<your-platform-url>`
+  (a non-admin user cannot create catalogs / KNs — `Public.Forbidden`)
+- `jq` and `python3` **≥ 3.7** on the runner (the scripts use `from __future__ import annotations`;
+  CentOS/RHEL 8 ships 3.6 — install `python38` and put it first on `PATH`)
+- MySQL reachable **from the runner AND from the platform/Vega pods** — set `DB_HOST` to a
+  cluster-routable address (Service ClusterIP / DNS), not `127.0.0.1`
+- For BKN semantic search, a registered embedding model (DashScope `text-embedding-v*` needs
+  `api_url` ending in `/compatible-mode/v1/embeddings` and `batch_size <= 10`)
+
+> Behind a restrictive network, fetch upstream CSVs via a mirror (e.g. jsDelivr
+> `https://cdn.jsdelivr.net/gh/<owner>/<repo>@<ref>/<path>`) and pull images via `docker.m.daocloud.io`.
 
 See the README inside each example for specific prerequisites.
 

--- a/examples/README.zh.md
+++ b/examples/README.zh.md
@@ -29,7 +29,17 @@ vim .env        # 填写 DB_HOST、DB_USER、DB_PASS 等
 
 所有示例需要：
 - openbkn CLI：`npm install -g @openbkn/bkn-sdk`（Node ≥ 22）
-- 平台登录：`openbkn auth login https://<your-platform-url>`
+- 以**管理员/超级管理员**登录平台：`openbkn auth login https://<your-platform-url>`
+  （非管理员用户无法创建 catalog / 知识网络，会报 `Public.Forbidden`）
+- runner 上需 `jq` 与 `python3` **≥ 3.7**（脚本用了 `from __future__ import annotations`；
+  CentOS/RHEL 8 自带 3.6 → 装 `python38` 并置于 `PATH` 最前)
+- MySQL 需 **runner 与平台/Vega Pod 都能访问** —— `DB_HOST` 填集群可路由地址
+  (Service ClusterIP / DNS),不要用 `127.0.0.1`
+- BKN 语义搜索需注册 embedding 模型(DashScope `text-embedding-v*` 的 `api_url` 要以
+  `/compatible-mode/v1/embeddings` 结尾,且 `batch_size <= 10`)
+
+> 网络受限时,上游 CSV 走镜像拉取(如 jsDelivr `https://cdn.jsdelivr.net/gh/<owner>/<repo>@<ref>/<path>`),
+> 容器镜像走 `docker.m.daocloud.io`。
 
 各示例的详细前置条件见对应 README。
 


### PR DESCRIPTION
## What

Gaps found while loading examples 01–06 on a fresh openbkn deploy (118). All are deploy/example-level — **no backend authz code change** (vega/bkn-backend/agent-factory/operator-integration already apply the `AUTHZ_PROVIDER` switch in-tree; the live failures were stale `0.1.0` images built before the bkn-safe cutover + missing deploy env).

## Changes

- **onboard embedding `batch_size`**: was hardcoded `32`, but DashScope `text-embedding-v*` caps a request at **10** inputs → registration failed (`batch size larger than 10`) and BKN push then errored on concept/object-type vectorization. Now prompted in `onboard.sh` (default 10), and the defaults in `onboard_ensure_small_model` + `models.yaml.example` lowered to 10 (safe for all providers).
- **examples/05 `tool_backend/server.py`**: bind `0.0.0.0` by default (overridable via `TOOL_BACKEND_BIND`) so an in-cluster agent can reach the mock backend via the host's routable IP; `env.sample` documents `TOOL_BACKEND_PUBLIC_URL` must be cluster-routable + the `pip install` step.
- **examples README (en/zh)**: prerequisites — admin/super-admin login (non-admins get `Public.Forbidden`), `jq` + `python>=3.7` (CentOS/RHEL 8 ships 3.6), cluster-routable `DB_HOST`, DashScope embedding `api_url`/`batch` rules, mirror fallbacks.
- **`deploy/notes/bkn-safe-image-republish.md`**: runbook to rebuild/republish the stale `0.1.0` images from current source + fill the missing `mf-model-api` authz env.

## Not in this PR (ops follow-up, see runbook)

- Republish `bkn-backend` / `vega-backend` (+ `agent-backend`, `mf-model-api`) images from current source (the `0.1.0` artifacts predate PR #25).
- `mf-model-api` / `ontology-query` deploy env need `AUTHZ_PROVIDER=bkn-safe` + `BKN_SAFE_URL` (applied live on 118).

🤖 Generated with [Claude Code](https://claude.com/claude-code)