### PR TITLE
ci(release): trigger release builds on git tag push

### DIFF
--- a/.github/workflows/release-adp-agent-retrieval.yml
+++ b/.github/workflows/release-adp-agent-retrieval.yml
@@ -2,6 +2,8 @@ name: release-adp-agent-retrieval
 
 on:
   push:
+    tags:
+      - 'v*'
     branches: ['**']
     paths:
       - 'adp/context-loader/agent-retrieval/**'

--- a/.github/workflows/release-adp-bkn-backend.yml
+++ b/.github/workflows/release-adp-bkn-backend.yml
@@ -2,6 +2,8 @@ name: release-adp-bkn-backend
 
 on:
   push:
+    tags:
+      - 'v*'
     branches: ['**']
     paths:
       - 'adp/bkn/bkn-backend/**'

--- a/.github/workflows/release-adp-bkn-safe.yml
+++ b/.github/workflows/release-adp-bkn-safe.yml
@@ -5,6 +5,8 @@ name: release-adp-bkn-safe
 
 on:
   push:
+    tags:
+      - 'v*'
     branches: ['**']
     paths:
       - 'bkn-safe/**'

--- a/.github/workflows/release-adp-ontology-query.yml
+++ b/.github/workflows/release-adp-ontology-query.yml
@@ -2,6 +2,8 @@ name: release-adp-ontology-query
 
 on:
   push:
+    tags:
+      - 'v*'
     branches: ['**']
     paths:
       - 'adp/bkn/ontology-query/**'

--- a/.github/workflows/release-adp-operator-integration.yml
+++ b/.github/workflows/release-adp-operator-integration.yml
@@ -2,6 +2,8 @@ name: release-adp-operator-integration
 
 on:
   push:
+    tags:
+      - 'v*'
     branches: ['**']
     paths:
       - 'adp/execution-factory/operator-integration/**'

--- a/.github/workflows/release-adp-vega-backend.yml
+++ b/.github/workflows/release-adp-vega-backend.yml
@@ -4,6 +4,8 @@ name: release-adp-vega-backend
 
 on:
   push:
+    tags:
+      - 'v*'
     branches: ['**']
     paths:
       - 'adp/vega/vega-backend/**'

--- a/.github/workflows/release-data-migrator.yml
+++ b/.github/workflows/release-data-migrator.yml
@@ -2,6 +2,8 @@ name: release-data-migrator
 
 on:
   push:
+    tags:
+      - 'v*'
     branches: ['**']
     paths:
       - 'data-migrator/**'

--- a/.github/workflows/release-decision-agent.yml
+++ b/.github/workflows/release-decision-agent.yml
@@ -2,6 +2,8 @@ name: release-decision-agent
 
 on:
   push:
+    tags:
+      - 'v*'
     branches: ['**']
     paths:
       - 'decision-agent/**'

--- a/.github/workflows/release-infra-mf-model-api.yml
+++ b/.github/workflows/release-infra-mf-model-api.yml
@@ -8,6 +8,8 @@ name: release-infra-mf-model-api
 
 on:
   push:
+    tags:
+      - 'v*'
     branches: ['**']
     paths:
       - 'infra/mf-model-api/**'

--- a/.github/workflows/release-infra-mf-model-manager.yml
+++ b/.github/workflows/release-infra-mf-model-manager.yml
@@ -6,6 +6,8 @@ name: release-infra-mf-model-manager
 
 on:
   push:
+    tags:
+      - 'v*'
     branches: ['**']
     paths:
       - 'infra/mf-model-manager/**'

--- a/.github/workflows/release-infra-model-factory-base.yml
+++ b/.github/workflows/release-infra-model-factory-base.yml
@@ -6,6 +6,8 @@ name: release-infra-model-factory-base
 
 on:
   push:
+    tags:
+      - 'v*'
     branches: ['**']
     paths:
       - 'infra/model-factory-base/**'

--- a/.github/workflows/release-infra-oss-gateway.yml
+++ b/.github/workflows/release-infra-oss-gateway.yml
@@ -2,6 +2,8 @@ name: release-infra-oss-gateway
 
 on:
   push:
+    tags:
+      - 'v*'
     branches: ['**']
     paths:
       - 'infra/oss-gateway-backend/**'

--- a/.github/workflows/release-infra-sandbox.yml
+++ b/.github/workflows/release-infra-sandbox.yml
@@ -7,6 +7,8 @@ name: release-infra-sandbox
 
 on:
   push:
+    tags:
+      - 'v*'
     branches: ['**']
     paths:
       - 'infra/sandbox/**'

--- a/.github/workflows/release-proton-mariadb.yml
+++ b/.github/workflows/release-proton-mariadb.yml
@@ -5,6 +5,8 @@ name: release-proton-mariadb
 
 on:
   push:
+    tags:
+      - 'v*'
     branches: ['**']
     paths:
       - 'deploy/charts/proton-mariadb/**'

--- a/.github/workflows/release-trace-ai-agent-observability.yml
+++ b/.github/workflows/release-trace-ai-agent-observability.yml
@@ -2,6 +2,8 @@ name: release-trace-ai-agent-observability
 
 on:
   push:
+    tags:
+      - 'v*'
     branches: ['**']
     paths:
       - 'trace-ai/agent-observability/**'

--- a/.github/workflows/release-trace-ai-otelcol.yml
+++ b/.github/workflows/release-trace-ai-otelcol.yml
@@ -5,6 +5,8 @@ name: release-trace-ai-otelcol
 
 on:
   push:
+    tags:
+      - 'v*'
     branches: ['**']
     paths:
       - 'trace-ai/otelcol-contribute-chart/**'

--- a/.github/workflows/reusable-test.yml
+++ b/.github/workflows/reusable-test.yml
@@ -50,9 +50,15 @@ jobs:
           # Single source of truth: repo-root VERSION (shared by all services)
           BASE_VERSION="$(tr -d '[:space:]' < VERSION)"
           REF_NAME="${{ github.ref_name }}"
+          REF_TYPE="${{ github.ref_type }}"
           SHORT_SHA="$(git rev-parse --short=7 HEAD)"
 
-          if [[ "$REF_NAME" == release/* ]]; then
+          if [[ "$REF_TYPE" == "tag" ]]; then
+            # Tag push (e.g. v0.1.1-alpha) cuts a release: the tag IS the version
+            # (leading "v" stripped). This is what makes `git push` a tag publish a
+            # clean, immutable image/chart set across all services.
+            VERSION="${REF_NAME#v}"
+          elif [[ "$REF_NAME" == release/* ]]; then
             VERSION="$BASE_VERSION"
           else
             SANITIZED_BRANCH="$(echo "$REF_NAME" | tr '[:upper:]' '[:lower:]' | sed -E 's#[^0-9a-zA-Z.-]+#-#g; s#-+#-#g; s#^[.-]+##; s#[.-]+$##')"


### PR DESCRIPTION
## What

Make pushing a `v*` git tag cut a full release — build + publish a consistent image + chart set across **all** services in one shot.

- Add `tags: ['v*']` to every `release-*.yml` `on.push`.
- `reusable-test` resolve-version: on a **tag** push, use the tag name (leading `v` stripped) as the version — `v0.1.1-alpha` → `0.1.1-alpha`. Branch builds are unchanged (`release/*` → clean `VERSION`; other branches → `VERSION-branch.shaXXedited`).

## Why

Releasing previously needed per-service path pushes or manual `workflow_dispatch`. That let the published `0.1.0` artifacts **drift behind `main`** — the live `0.1.0` images were built before the bkn-safe authz cutover (PR #25), so a fresh `deploy.sh` pulled binaries that still call the retired `authorization-private` (BKN push / FilterResources fail, CrashLoop). A single `git tag` → coordinated rebuild fixes that going forward.

## Behavior notes

- Branch pushes keep their existing **path-filtered** CI. GitHub does **not** apply `push` path filters to tag pushes, so a `v*` tag fires every service regardless of which files changed.
- Tag pushes **publish** to GHCR (`event_name == 'push'` already gates `publish: true`).

## How to cut a release after merge

```bash
# optionally bump repo-root VERSION to match, then:
git tag v0.1.1-alpha
git push origin v0.1.1-alpha     # → all services build + publish :0.1.1-alpha
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)