### PR TITLE
ci(release): mirror published images to Huawei SWR alongside GHCR

### DIFF
--- a/.github/workflows/release-adp-agent-retrieval.yml
+++ b/.github/workflows/release-adp-agent-retrieval.yml
@@ -29,6 +29,7 @@ jobs:
   build:
     needs: test
     uses: ./.github/workflows/reusable-build.yml
+    secrets: inherit
     with:
       service-path: adp/context-loader/agent-retrieval
       dockerfile: docker/Dockerfile

--- a/.github/workflows/release-adp-bkn-backend.yml
+++ b/.github/workflows/release-adp-bkn-backend.yml
@@ -29,6 +29,7 @@ jobs:
   build:
     needs: test
     uses: ./.github/workflows/reusable-build.yml
+    secrets: inherit
     with:
       service-path: adp/bkn/bkn-backend
       dockerfile: docker/Dockerfile

--- a/.github/workflows/release-adp-bkn-safe.yml
+++ b/.github/workflows/release-adp-bkn-safe.yml
@@ -32,6 +32,7 @@ jobs:
   build:
     needs: test
     uses: ./.github/workflows/reusable-build.yml
+    secrets: inherit
     with:
       service-path: bkn-safe
       dockerfile: Dockerfile

--- a/.github/workflows/release-adp-ontology-query.yml
+++ b/.github/workflows/release-adp-ontology-query.yml
@@ -29,6 +29,7 @@ jobs:
   build:
     needs: test
     uses: ./.github/workflows/reusable-build.yml
+    secrets: inherit
     with:
       service-path: adp/bkn/ontology-query
       dockerfile: docker/Dockerfile

--- a/.github/workflows/release-adp-operator-integration.yml
+++ b/.github/workflows/release-adp-operator-integration.yml
@@ -29,6 +29,7 @@ jobs:
   build:
     needs: test
     uses: ./.github/workflows/reusable-build.yml
+    secrets: inherit
     with:
       service-path: adp/execution-factory/operator-integration
       dockerfile: docker/Dockerfile

--- a/.github/workflows/release-adp-vega-backend.yml
+++ b/.github/workflows/release-adp-vega-backend.yml
@@ -31,6 +31,7 @@ jobs:
   build-vega-backend:
     needs: test
     uses: ./.github/workflows/reusable-build.yml
+    secrets: inherit
     with:
       service-path: adp/vega/vega-backend
       dockerfile: docker/Dockerfile
@@ -42,6 +43,7 @@ jobs:
   build-kafka-connect:
     needs: test
     uses: ./.github/workflows/reusable-build.yml
+    secrets: inherit
     with:
       service-path: adp/vega/vega-backend
       dockerfile: docker/Dockerfile-kafka-connect

--- a/.github/workflows/release-data-migrator.yml
+++ b/.github/workflows/release-data-migrator.yml
@@ -31,6 +31,7 @@ jobs:
   build:
     needs: test
     uses: ./.github/workflows/reusable-build.yml
+    secrets: inherit
     with:
       service-path: data-migrator
       dockerfile: Dockerfile

--- a/.github/workflows/release-decision-agent.yml
+++ b/.github/workflows/release-decision-agent.yml
@@ -37,6 +37,7 @@ jobs:
   build:
     needs: test
     uses: ./.github/workflows/reusable-build.yml
+    secrets: inherit
     with:
       # Dockerfile COPYs agent-backend/... so build context root must be decision-agent
       service-path: decision-agent

--- a/.github/workflows/release-infra-mf-model-api.yml
+++ b/.github/workflows/release-infra-mf-model-api.yml
@@ -35,6 +35,7 @@ jobs:
   build:
     needs: test
     uses: ./.github/workflows/reusable-build.yml
+    secrets: inherit
     with:
       service-path: infra/mf-model-api
       dockerfile: Dockerfile

--- a/.github/workflows/release-infra-mf-model-manager.yml
+++ b/.github/workflows/release-infra-mf-model-manager.yml
@@ -33,6 +33,7 @@ jobs:
   build:
     needs: test
     uses: ./.github/workflows/reusable-build.yml
+    secrets: inherit
     with:
       service-path: infra/mf-model-manager
       dockerfile: Dockerfile

--- a/.github/workflows/release-infra-model-factory-base.yml
+++ b/.github/workflows/release-infra-model-factory-base.yml
@@ -26,6 +26,7 @@ permissions:
 jobs:
   build:
     uses: ./.github/workflows/reusable-build.yml
+    secrets: inherit
     with:
       service-path: infra/model-factory-base
       dockerfile: Dockerfile

--- a/.github/workflows/release-infra-oss-gateway.yml
+++ b/.github/workflows/release-infra-oss-gateway.yml
@@ -32,6 +32,7 @@ jobs:
   build:
     needs: test
     uses: ./.github/workflows/reusable-build.yml
+    secrets: inherit
     with:
       service-path: infra/oss-gateway-backend
       dockerfile: Dockerfile

--- a/.github/workflows/release-infra-sandbox.yml
+++ b/.github/workflows/release-infra-sandbox.yml
@@ -35,6 +35,7 @@ jobs:
   build-python-base:
     needs: test
     uses: ./.github/workflows/reusable-build.yml
+    secrets: inherit
     with:
       service-path: infra/sandbox/images/bases/python
       dockerfile: Dockerfile
@@ -46,6 +47,7 @@ jobs:
   build-multi-language-base:
     needs: [test, build-python-base]
     uses: ./.github/workflows/reusable-build.yml
+    secrets: inherit
     with:
       service-path: infra/sandbox/images/bases/multi-language
       dockerfile: Dockerfile
@@ -60,6 +62,7 @@ jobs:
   build-control-plane:
     needs: test
     uses: ./.github/workflows/reusable-build.yml
+    secrets: inherit
     with:
       service-path: infra/sandbox
       dockerfile: sandbox_control_plane/Dockerfile
@@ -71,6 +74,7 @@ jobs:
   build-web:
     needs: test
     uses: ./.github/workflows/reusable-build.yml
+    secrets: inherit
     with:
       service-path: infra/sandbox/sandbox_web
       dockerfile: Dockerfile
@@ -82,6 +86,7 @@ jobs:
   build-template-python-basic:
     needs: [test, build-python-base]
     uses: ./.github/workflows/reusable-build.yml
+    secrets: inherit
     with:
       service-path: infra/sandbox
       dockerfile: images/templates/executor/Dockerfile
@@ -95,6 +100,7 @@ jobs:
   build-template-multi-language:
     needs: [test, build-multi-language-base]
     uses: ./.github/workflows/reusable-build.yml
+    secrets: inherit
     with:
       service-path: infra/sandbox
       dockerfile: images/templates/executor/Dockerfile

--- a/.github/workflows/release-trace-ai-agent-observability.yml
+++ b/.github/workflows/release-trace-ai-agent-observability.yml
@@ -30,6 +30,7 @@ jobs:
   build:
     needs: test
     uses: ./.github/workflows/reusable-build.yml
+    secrets: inherit
     with:
       service-path: trace-ai/agent-observability
       dockerfile: Dockerfile

--- a/.github/workflows/reusable-build.yml
+++ b/.github/workflows/reusable-build.yml
@@ -36,6 +36,22 @@ on:
         type: string
         default: ''
         description: 'Dockerfile target stage (empty = final stage)'
+      swr-registry:
+        type: string
+        default: 'swr.cn-east-3.myhuaweicloud.com'
+        description: 'Huawei SWR registry host for the mirror push'
+      swr-namespace:
+        type: string
+        default: 'openbkn-ai'
+        description: 'Huawei SWR organization/namespace for app images'
+    secrets:
+      # Optional: when set, every published image is mirrored to Huawei SWR in
+      # the same build. Absent (forks, credential-less runs) → mirror skipped,
+      # GHCR push unaffected. Callers opt in with `secrets: inherit`.
+      HUAWEI_SWR_USERNAME:
+        required: false
+      HUAWEI_SWR_PASSWORD:
+        required: false
 
 jobs:
   build:
@@ -43,6 +59,10 @@ jobs:
     permissions:
       contents: read
       packages: write
+    env:
+      # Surfaced so step `if:` can test credential presence — secrets aren't
+      # allowed in `if:` directly. Empty when the SWR secrets aren't set.
+      SWR_USERNAME: ${{ secrets.HUAWEI_SWR_USERNAME }}
     steps:
       - uses: actions/checkout@v4
 
@@ -58,6 +78,27 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ github.token }}
 
+      - name: Login to Huawei SWR
+        if: ${{ inputs.publish && env.SWR_USERNAME != '' }}
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ inputs.swr-registry }}
+          username: ${{ secrets.HUAWEI_SWR_USERNAME }}
+          password: ${{ secrets.HUAWEI_SWR_PASSWORD }}
+
+      - name: Compute image tags
+        id: tags
+        # GHCR always; SWR mirror only when publishing AND credentials present.
+        run: |
+          {
+            echo "tags<<EOF"
+            echo "ghcr.io/${{ github.repository_owner }}/${{ inputs.image-name }}:${{ inputs.version }}"
+            if [ "${{ inputs.publish }}" = "true" ] && [ -n "${SWR_USERNAME}" ]; then
+              echo "${{ inputs.swr-registry }}/${{ inputs.swr-namespace }}/${{ inputs.image-name }}:${{ inputs.version }}"
+            fi
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
+
       - name: Build and push image
         uses: docker/build-push-action@v6
         with:
@@ -69,4 +110,4 @@ jobs:
           push: ${{ inputs.publish }}
           provenance: false
           sbom: false
-          tags: ghcr.io/${{ github.repository_owner }}/${{ inputs.image-name }}:${{ inputs.version }}
+          tags: ${{ steps.tags.outputs.tags }}


### PR DESCRIPTION
## What

Every **published** image is now mirrored to Huawei SWR (`swr.cn-east-3.myhuaweicloud.com/openbkn-ai`) in the same build, in addition to GHCR.

## Why

Repo is now private; consumers pull images from public registries. Adding SWR as a second public mirror gives a domestic (China) pull path alongside GHCR.

## How

- `reusable-build.yml`: new `swr-registry` / `swr-namespace` inputs, optional `HUAWEI_SWR_USERNAME` / `HUAWEI_SWR_PASSWORD` secrets, an SWR login step, and a tag-compute step. A single buildx build emits both the GHCR and SWR tags — no second build.
- All 14 `release-*.yml` callers (18 build invocations) gain `secrets: inherit` so the reusable workflow can read the SWR secrets.
- Charts are **unchanged** (images only). `otelcol` has no build job — untouched.

## Push matrix

| Trigger | publish | Pushes to |
|---|---|---|
| tag push (`v*`) / branch push matching paths | true | **GHCR + SWR** |
| `workflow_dispatch` with `publish=true` | true | **GHCR + SWR** |
| `workflow_dispatch` default / PR / verify | false | nothing (build-only) |

When SWR secrets are absent (forks), the mirror is silently skipped and the GHCR push is unaffected.

## Validation

- All workflow YAML parses
- `actionlint` clean

## Prereqs (already in place)

- Repo secrets `HUAWEI_SWR_USERNAME` / `HUAWEI_SWR_PASSWORD` set
- SWR `openbkn-ai` organization exists with push permission

🤖 Generated with [Claude Code](https://claude.com/claude-code)