### PR TITLE
fix(bkn-safe): align openbkn-studio OAuth redirect to /studio/callback

### DIFF
--- a/bkn-safe/charts/bkn-safe/templates/client-seed-job.yaml
+++ b/bkn-safe/charts/bkn-safe/templates/client-seed-job.yaml
@@ -27,7 +27,7 @@ spec:
           image: "{{- if .Values.image.registry }}{{ .Values.image.registry }}/{{ end }}{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           {{- /* The openbkn-studio SPA callback is browser-facing at the gateway,
-                 so derive it from accessAddress (https://host[:port]/callback) when
+                 so derive it from accessAddress (https://host[:port]/studio/callback) when
                  set; otherwise fall back to clientSeed.webRedirectUri (dev). Any
                  clientSeed.extraWebRedirectUris are appended (local web dev against
                  a remote install). The CLI callback stays loopback (the CLI runs on
@@ -38,9 +38,9 @@ spec:
             {{- $scheme := $aa.scheme | default "https" }}
             {{- $port := $aa.port | toString }}
             {{- if or (and (eq $scheme "https") (eq $port "443")) (and (eq $scheme "http") (eq $port "80")) }}
-              {{- $web = printf "%s://%s/callback" $scheme $aa.host }}
+              {{- $web = printf "%s://%s/studio/callback" $scheme $aa.host }}
             {{- else }}
-              {{- $web = printf "%s://%s:%s/callback" $scheme $aa.host $port }}
+              {{- $web = printf "%s://%s:%s/studio/callback" $scheme $aa.host $port }}
             {{- end }}
           {{- end }}
           {{- $webUris := list $web }}
@@ -48,7 +48,7 @@ spec:
             {{- if not (has . $webUris) }}{{- $webUris = append $webUris . }}{{- end }}
           {{- end }}
           {{- $logoutUris := list }}
-          {{- range $webUris }}{{- $logoutUris = append $logoutUris (trimSuffix "callback" .) }}{{- end }}
+          {{- range $webUris }}{{- $logoutUris = append $logoutUris (trimSuffix "/callback" .) }}{{- end }}
           env:
             - name: ADMIN
               value: {{ .Values.config.hydra.adminURL | quote }}

--- a/bkn-safe/charts/bkn-safe/values.yaml
+++ b/bkn-safe/charts/bkn-safe/values.yaml
@@ -69,18 +69,18 @@ ingress:
 #   openbkn-studio  — authorization_code + PKCE (browser / SPA)
 #   openbkn-cli     — authorization_code + PKCE (CLI headless password login)
 # Idempotent (delete+create). The openbkn-studio SPA callback derives from
-# accessAddress (https://host/callback) at install time; webRedirectUri is the
+# accessAddress (https://host/studio/callback) at install time; webRedirectUri is the
 # dev fallback when no accessAddress is set.
 clientSeed:
   enabled: true
   # Matches the bkn-studio vite dev server port (fixed via strictPort).
-  webRedirectUri: "http://localhost:8000/callback"
+  webRedirectUri: "http://localhost:8000/studio/callback"
   # Appended to openbkn-studio's redirect_uris IN ADDITION to the
   # accessAddress-derived gateway callback, so a local web dev server can
   # complete the OAuth flow against a remote install. Clear this list for
   # hardened/production installs.
   extraWebRedirectUris:
-    - "http://localhost:8000/callback"
+    - "http://localhost:8000/studio/callback"
   # Loopback redirect for the CLI password flow; must match the SDK's
   # `http://127.0.0.1:<DEFAULT_REDIRECT_PORT>/callback` (default port 9010).
   cliRedirectUri: "http://127.0.0.1:9010/callback"

--- a/bkn-safe/dev/seed-clients.sh
+++ b/bkn-safe/dev/seed-clients.sh
@@ -12,15 +12,18 @@
 # Env:
 #   HYDRA_ADMIN       admin endpoint (default dev http://127.0.0.1:4445; in-cluster
 #                     use http://bkn-safe-hydra-admin:4445)
-#   WEB_REDIRECT_URI  SPA callback (default dev http://localhost:3000/callback;
-#                     set to the real https://<host>/callback in prod)
+#   WEB_REDIRECT_URI  SPA callback (default dev http://localhost:8000/studio/callback;
+#                     set to the real https://<host>/studio/callback in prod)
+#   WEB_LOGOUT_URI    SPA post-logout landing page (default derives from
+#                     WEB_REDIRECT_URI by dropping the trailing /callback)
 #   CLI_REDIRECT_URI  CLI loopback callback; must match the SDK's
 #                     http://127.0.0.1:<DEFAULT_REDIRECT_PORT>/callback (port 9010).
 #                     Never dialed — the SDK reads the code off the 302 Location.
 set -euo pipefail
 
 ADMIN="${HYDRA_ADMIN:-http://127.0.0.1:4445}"
-WEB_REDIRECT_URI="${WEB_REDIRECT_URI:-http://localhost:3000/callback}"
+WEB_REDIRECT_URI="${WEB_REDIRECT_URI:-http://localhost:8000/studio/callback}"
+WEB_LOGOUT_URI="${WEB_LOGOUT_URI:-${WEB_REDIRECT_URI%/callback}}"
 CLI_REDIRECT_URI="${CLI_REDIRECT_URI:-http://127.0.0.1:9010/callback}"
 
 create() { # $1=json
@@ -60,10 +63,11 @@ create "{
   \"response_types\": [\"code\"],
   \"token_endpoint_auth_method\": \"none\",
   \"redirect_uris\": [\"${WEB_REDIRECT_URI}\"],
+  \"post_logout_redirect_uris\": [\"${WEB_LOGOUT_URI}\"],
   \"scope\": \"openid offline\",
   \"audience\": [\"bkn-safe\"]
 }" >/dev/null
-echo "  + openbkn-studio (authorization_code + PKCE, public; redirect=${WEB_REDIRECT_URI})"
+echo "  + openbkn-studio (authorization_code + PKCE, public; redirect=${WEB_REDIRECT_URI}, logout=${WEB_LOGOUT_URI})"
 
 del openbkn-cli
 create "{


### PR DESCRIPTION
Update Hydra client seed URLs for the studio SPA path and fix logout URI trimming so post-logout redirects resolve correctly.

# Pull Request

## What Changed

Brief description of changes:

- [ ] Feature/module 1
- [ ] Feature/module 2
- [ ] Docs/doc 1

---

## Why

- Related Issue: [Issue #123](link-to-issue)
- Related Feature: [Feature Name](link-to-feature)
- Background:

---

## How

- Key implementation points:
- Breaking changes (API, config, database, etc.):

---

## Testing

- [ ] Unit tests passed locally
- [ ] Integration tests passed locally
- [ ] Verified in test environment

Test notes:

---

## Risk & Rollback

- Potential risks:
- Rollback plan:

---

## Additional Notes

- Screenshots, logs, documentation links, etc.:
