### PR TITLE
feat(bkn-safe): 部门成员写入 + 管理审计日志

### DIFF
--- a/bkn-safe/docs/admin-api-frontend-changes.md
+++ b/bkn-safe/docs/admin-api-frontend-changes.md
@@ -1,0 +1,167 @@
+# bkn-safe 管理 API 变更 —— 给前端的完整回应
+
+针对前端在对接 `/api/safe/v1/admin/*` 时提出的缺口清单的逐条回应。所有端点均在 admin 组下，鉴权同现有：`Authorization: Bearer <超管 token>`（`RequireAdmin` = token introspect + casbin 超管校验）。
+
+> 已部署到验证 VM（10.211.55.4，ns `openbkn`，镜像 `bkn-safe:0.1.1-alpha-deptaudit`）。代码见 PR #59。
+
+## 结论速览
+
+| 前端提出的缺口 | 结论 | 说明 |
+|---|---|---|
+| 人员↔部门归属写不了 | ✅ **已加** | 部门成员写端点 + 用户建/改内联 `department_ids` |
+| 审计日志 | ✅ **已加** | 自动记录所有变更类 admin 请求 + 查询端点 |
+| 部门扩展字段（负责人/编码/邮箱/备注） | ❌ **按定调不做** | 模型不扩，前端不要依赖这些字段 |
+| 冻结/解冻（独立于 enabled） | ❌ **按定调不做** | 继续用 `enabled` 表达停用/启用 |
+| 搜索只 account/name 子串 | 未变 | 邮箱/部门/状态筛选仍客户端做 |
+| 角色无 displayName | 未变 | 标识+显示名合并到 `name` |
+| 权限是对象元组非扁平点 | 未变 | 角色权限 UI 按对象授权做（见末节） |
+
+---
+
+## 1. 人员归属写
+
+### 1a. 部门成员写端点（部门视角，与已有 `GET .../members` 对称）
+
+幂等。
+
+```
+POST   /api/safe/v1/admin/departments/:id/members
+DELETE /api/safe/v1/admin/departments/:id/members
+Body:  { "user_ids": ["u-1", "u-2"] }
+```
+
+| 场景 | 状态码 | 返回 |
+|---|---|---|
+| 成功 | `204` | 无 body |
+| 部门不存在 | `404` | `{"error":"department not found"}` |
+| 某 user_id 不存在（仅 POST） | `400` | `{"error":"unknown user id: [ghost]"}`，**整批拒绝，一个都不写** |
+
+- POST 重复添加同一人 → 仍 `204`，不产生重复行。
+- DELETE 移除不在部门里的人 → 仍 `204`（幂等）。
+
+### 1b. 用户建/改内联 `department_ids`（用户视角，编辑表单一步到位）
+
+**新建**（`POST /api/safe/v1/admin/users`）：可选 `department_ids`，建用户后归入这些部门。同时**新增收 `telephone`**（之前只有 update 收，现已对齐）。
+
+```jsonc
+POST /api/safe/v1/admin/users
+{
+  "account": "alice",          // 必填
+  "name": "Alice",
+  "email": "alice@x.com",
+  "telephone": "13800000000",  // 新增
+  "password": "...",           // 可选，缺省发平台初始密码 openbkn 并强制改密
+  "account_type": "other",
+  "department_ids": ["d-1","d-2"]  // 可选，初始归属
+}
+// -> 201 { "id": "..." }
+// 任一部门 id 不存在 -> 400，且不会创建用户（先校验后建，无脏数据）
+```
+
+**修改**（`PUT /api/safe/v1/admin/users/:id`）：`department_ids` 为**替换**语义。
+
+- 传数组 → 用该集合**整组替换**用户的部门归属。
+- 传 `[]`（空数组）→ **清空**全部归属。
+- **不传该 key** → 归属**不动**（只改其它资料字段）。
+
+```jsonc
+PUT /api/safe/v1/admin/users/:id
+{ "name": "Alicia", "department_ids": ["d-2"] }   // 改名 + 归属只留 d-2
+{ "department_ids": [] }                          // 仅清空归属（其它不动）
+{ "telephone": "..." }                            // 仅改资料，归属不动
+// -> 204
+// 部门 id 不存在 -> 400（写入前校验，原归属不变）
+// 用户不存在 -> 404
+```
+
+> 1a 与 1b 二选一即可，按 UI 形态选：组织树拖人用 1a，用户编辑表单选部门用 1b。底层同一张多对多表，互通。
+
+### 读取（已有，回显用）
+
+- `GET /api/safe/v1/admin/users/:id` 返回 `departments: [deptId...]` —— 编辑表单回显归属用它。
+- `GET /api/safe/v1/admin/departments/:id/members` 返回部门下成员（直接成员，不含子部门）。
+- `GET /api/safe/v1/me` 的 `departments` 字段同样反映当前登录人归属。
+
+---
+
+## 2. 审计日志
+
+每个**变更类**（POST/PUT/DELETE）且**通过鉴权**的 admin 请求自动落一条。**GET 不记**（读不进审计，无回环）；鉴权失败（401/403）不记。
+
+```
+GET /api/safe/v1/admin/audit-logs
+  ?actor_id=&resource=&action=&target_id=&from=&to=&offset=&limit=
+```
+
+| 参数 | 说明 |
+|---|---|
+| `actor_id` | 操作人 user id |
+| `resource` | 顶层名词：`users` \| `departments` \| `roles` \| `role-bindings` |
+| `action` | 点分路由：`users`、`users.password`、`departments`、`departments.members`、`roles`、`roles.permissions`、`role-bindings` |
+| `target_id` | 被操作对象 id（路由 `:id`，无则空串） |
+| `from` / `to` | **RFC3339** 时间戳（如 `2026-06-17T00:00:00Z`），格式错 → `400` |
+| `offset` / `limit` | 分页，`limit` 默认 50、上限 500 |
+
+返回（**按时间倒序**）：
+
+```jsonc
+{
+  "total": 123,
+  "logs": [
+    {
+      "id": "…",
+      "actor_id": "<操作人 user id>",
+      "method": "DELETE",
+      "resource": "users",
+      "action": "users",
+      "target_id": "u-9",
+      "status": 404,            // 真实 HTTP 码，失败操作也记
+      "client_ip": "10.0.0.1",
+      "created_at": "2026-06-17T08:30:00Z"
+    }
+  ]
+}
+```
+
+前端实现要点：
+
+- **谁做的**：`actor_id` 是 user id，不是名字。用 `POST /api/safe/v1/directory/names {user_ids:[...]}` 批量解析显示名。
+- **做了什么**：`action` 单独不区分增改删，靠 `method` 区分。建议前端做映射表渲染人话：
+
+| method | action | 显示 |
+|---|---|---|
+| POST | `users` | 新建用户 |
+| PUT | `users` | 修改用户 |
+| DELETE | `users` | 删除用户 |
+| PUT | `users.password` | 重置密码 |
+| POST | `departments` | 新建部门 |
+| PUT | `departments` | 修改部门 |
+| DELETE | `departments` | 删除部门 |
+| POST | `departments.members` | 部门加人 |
+| DELETE | `departments.members` | 部门移人 |
+| POST | `roles` | 新建角色 |
+| PUT | `roles` | 修改角色 |
+| DELETE | `roles` | 删除角色 |
+| POST | `roles.permissions` | 角色授权 |
+| DELETE | `roles.permissions` | 角色撤权 |
+| POST | `role-bindings` | 绑定角色 |
+| DELETE | `role-bindings` | 解绑角色 |
+
+- **失败筛选**：`status` 为真实码，4xx/5xx 都有条目，可做「失败操作」过滤。
+
+---
+
+## 3. 未变项 —— 前端按真实模型实现（后端不会改）
+
+1. **用户搜索**：`GET /admin/users?search=` 只匹配 `account`/`name` 子串（另有 `?account=` 精确查）。邮箱/部门/状态筛选客户端做（注意分页）。
+2. **角色搜索**：`GET /admin/roles` 只有 `?source=` 过滤，无文本搜索，客户端过滤。
+3. **角色 displayName**：角色只有 `name` + `description`，无独立显示名。设计的「标识 + 显示名」合并到 `name`。
+4. **角色权限模型**：是**对象元组**，不是扁平权限点。授权/撤权：
+   ```
+   POST   /api/safe/v1/admin/roles/:id/permissions
+   DELETE /api/safe/v1/admin/roles/:id/permissions
+   Body:  { "resource": { "type": "catalog", "id": "*" }, "operations": ["read","write"] }
+   ```
+   `id:"*"` = 对整类资源授权；具体 id = 对单实例授权（即「给某个数据连接授权」）。角色权限 UI 必须按对象授权做，不能用「勾选扁平权限点」。内置角色（system/business）权限只读，改它 → `403`。
+5. **冻结/解冻**：无独立状态，用 `PUT /admin/users/:id {"enabled":false/true}` 表达停用/启用。
+6. **部门扩展字段**：部门只有 `name`/`parent_id`/`type`，无负责人/编码/邮箱/备注，表单不要带这些。

--- a/bkn-safe/server/internal/audit/audit.go
+++ b/bkn-safe/server/internal/audit/audit.go
@@ -1,0 +1,117 @@
+// Package audit records and queries the bkn-safe admin audit trail: one row per
+// privileged mutation (who did what, to which target, with what outcome). It is
+// dependency-light on purpose (model + gorm only) so the HTTP layer can write to
+// it from middleware without coupling auditing to auth/directory.
+package audit
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"time"
+
+	"gorm.io/gorm"
+
+	"bkn-safe/internal/model"
+)
+
+// Store reads and writes the audit trail over GORM.
+type Store struct {
+	db *gorm.DB
+}
+
+// New builds an audit store.
+func New(db *gorm.DB) *Store { return &Store{db: db} }
+
+// Entry is a single audit record to persist. ID and the timestamp are assigned
+// by Record (the caller supplies only the request facts).
+type Entry struct {
+	ActorID  string
+	Method   string
+	Resource string
+	Action   string
+	TargetID string
+	Status   int
+	ClientIP string
+}
+
+// Record persists one audit entry. The returned error is for logging only —
+// auditing must never break the request it is recording, so callers swallow it.
+func (s *Store) Record(ctx context.Context, e Entry) error {
+	row := model.AuditLog{
+		ID:       newID(),
+		ActorID:  e.ActorID,
+		Method:   e.Method,
+		Resource: e.Resource,
+		Action:   e.Action,
+		TargetID: e.TargetID,
+		Status:   e.Status,
+		ClientIP: e.ClientIP,
+	}
+	return s.db.WithContext(ctx).Create(&row).Error
+}
+
+// Filter narrows a List query. Zero-value fields are not applied. From/To bound
+// CreatedAt (inclusive lower, exclusive upper).
+type Filter struct {
+	ActorID  string
+	Resource string
+	Action   string
+	TargetID string
+	From     time.Time
+	To       time.Time
+	Offset   int
+	Limit    int
+}
+
+// List returns a page of audit entries (newest first) matching the filter, plus
+// the total matching count. Limit<=0 defaults to 50 and is capped at 500.
+func (s *Store) List(ctx context.Context, f Filter) ([]model.AuditLog, int64, error) {
+	limit := f.Limit
+	if limit <= 0 {
+		limit = 50
+	}
+	if limit > 500 {
+		limit = 500
+	}
+	offset := f.Offset
+	if offset < 0 {
+		offset = 0
+	}
+	q := s.db.WithContext(ctx).Model(&model.AuditLog{})
+	if f.ActorID != "" {
+		q = q.Where("actor_id = ?", f.ActorID)
+	}
+	if f.Resource != "" {
+		q = q.Where("resource = ?", f.Resource)
+	}
+	if f.Action != "" {
+		q = q.Where("action = ?", f.Action)
+	}
+	if f.TargetID != "" {
+		q = q.Where("target_id = ?", f.TargetID)
+	}
+	if !f.From.IsZero() {
+		q = q.Where("created_at >= ?", f.From)
+	}
+	if !f.To.IsZero() {
+		q = q.Where("created_at < ?", f.To)
+	}
+	var total int64
+	if err := q.Count(&total).Error; err != nil {
+		return nil, 0, err
+	}
+	logs := make([]model.AuditLog, 0, limit)
+	if err := q.Order("created_at DESC").Offset(offset).Limit(limit).Find(&logs).Error; err != nil {
+		return nil, 0, err
+	}
+	return logs, total, nil
+}
+
+// newID returns a random 128-bit hex id (same scheme as auth.NewID, duplicated
+// here to keep this package free of the auth dependency).
+func newID() string {
+	b := make([]byte, 16)
+	_, _ = rand.Read(b)
+	return hex.EncodeToString(b)
+}

--- a/bkn-safe/server/internal/directory/directory.go
+++ b/bkn-safe/server/internal/directory/directory.go
@@ -7,8 +7,10 @@ package directory
 import (
 	"context"
 	"errors"
+	"fmt"
 
 	"gorm.io/gorm"
+	"gorm.io/gorm/clause"
 
 	"bkn-safe/internal/model"
 )
@@ -18,6 +20,15 @@ import (
 // them first (no cascade: deleting a non-empty subtree is too blunt to do
 // implicitly).
 var ErrDepartmentNotEmpty = errors.New("department not empty")
+
+// ErrUnknownUser is returned by AddDepartmentMembers when one or more user ids
+// don't reference an existing user. The membership would dangle (no FK), so the
+// whole call is rejected and nothing is written.
+var ErrUnknownUser = errors.New("unknown user id")
+
+// ErrUnknownDepartment is returned by SetUserDepartments/DepartmentsExist when
+// one or more department ids don't reference an existing department.
+var ErrUnknownDepartment = errors.New("unknown department id")
 
 // Service provides directory queries over GORM.
 type Service struct {
@@ -227,6 +238,166 @@ func (s *Service) DepartmentMembers(ctx context.Context, deptID string) ([]UserS
 		return nil, err
 	}
 	return out, nil
+}
+
+// AddDepartmentMembers maps the given users into the department. Idempotent: a
+// user already in the department is left as-is (no duplicate, no error). The
+// department must exist (else gorm.ErrRecordNotFound) and every user id must
+// reference an existing user (else ErrUnknownUser) — nothing is written when
+// either check fails.
+func (s *Service) AddDepartmentMembers(ctx context.Context, deptID string, userIDs []string) error {
+	if err := s.requireDepartment(ctx, deptID); err != nil {
+		return err
+	}
+	ids := dedupeNonEmpty(userIDs)
+	if len(ids) == 0 {
+		return nil
+	}
+	if err := s.requireUsersExist(ctx, ids); err != nil {
+		return err
+	}
+	rows := make([]model.UserDepartment, 0, len(ids))
+	for _, uid := range ids {
+		rows = append(rows, model.UserDepartment{UserID: uid, DepartmentID: deptID})
+	}
+	// Composite PK (user_id, department_id): skip rows already present so the
+	// call is idempotent rather than erroring on a duplicate key.
+	return s.db.WithContext(ctx).Clauses(clause.OnConflict{DoNothing: true}).Create(&rows).Error
+}
+
+// RemoveDepartmentMembers removes the given users from the department.
+// Idempotent: a user not currently in the department is silently ignored. The
+// department must exist (else gorm.ErrRecordNotFound).
+func (s *Service) RemoveDepartmentMembers(ctx context.Context, deptID string, userIDs []string) error {
+	if err := s.requireDepartment(ctx, deptID); err != nil {
+		return err
+	}
+	ids := dedupeNonEmpty(userIDs)
+	if len(ids) == 0 {
+		return nil
+	}
+	return s.db.WithContext(ctx).
+		Where("department_id = ? AND user_id IN ?", deptID, ids).
+		Delete(&model.UserDepartment{}).Error
+}
+
+// requireDepartment returns gorm.ErrRecordNotFound when no department has the id.
+func (s *Service) requireDepartment(ctx context.Context, id string) error {
+	var n int64
+	if err := s.db.WithContext(ctx).Model(&model.Department{}).Where("id = ?", id).Count(&n).Error; err != nil {
+		return err
+	}
+	if n == 0 {
+		return gorm.ErrRecordNotFound
+	}
+	return nil
+}
+
+// requireUsersExist returns ErrUnknownUser (wrapping the missing ids) unless
+// every id references an existing user row.
+func (s *Service) requireUsersExist(ctx context.Context, ids []string) error {
+	var found []string
+	if err := s.db.WithContext(ctx).Model(&model.User{}).
+		Where("id IN ?", ids).Pluck("id", &found).Error; err != nil {
+		return err
+	}
+	if len(found) == len(ids) {
+		return nil
+	}
+	have := make(map[string]bool, len(found))
+	for _, id := range found {
+		have[id] = true
+	}
+	missing := make([]string, 0)
+	for _, id := range ids {
+		if !have[id] {
+			missing = append(missing, id)
+		}
+	}
+	return fmt.Errorf("%w: %v", ErrUnknownUser, missing)
+}
+
+// dedupeNonEmpty returns the input with empty strings and duplicates removed,
+// preserving first-seen order.
+func dedupeNonEmpty(ids []string) []string {
+	seen := make(map[string]bool, len(ids))
+	out := make([]string, 0, len(ids))
+	for _, id := range ids {
+		if id == "" || seen[id] {
+			continue
+		}
+		seen[id] = true
+		out = append(out, id)
+	}
+	return out
+}
+
+// SetUserDepartments REPLACES the user's department memberships with exactly the
+// given set (the user-centric counterpart of the department member endpoints):
+// an empty/absent list clears all of the user's memberships. Idempotent. The
+// user must exist (else gorm.ErrRecordNotFound) and every department id must
+// reference an existing department (else ErrUnknownDepartment) — the whole
+// replace is transactional, so a bad id leaves the prior memberships untouched.
+func (s *Service) SetUserDepartments(ctx context.Context, userID string, deptIDs []string) error {
+	if err := s.requireUser(ctx, userID); err != nil {
+		return err
+	}
+	ids := dedupeNonEmpty(deptIDs)
+	if err := s.DepartmentsExist(ctx, ids); err != nil {
+		return err
+	}
+	return s.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+		if err := tx.Where("user_id = ?", userID).Delete(&model.UserDepartment{}).Error; err != nil {
+			return err
+		}
+		if len(ids) == 0 {
+			return nil
+		}
+		rows := make([]model.UserDepartment, 0, len(ids))
+		for _, did := range ids {
+			rows = append(rows, model.UserDepartment{UserID: userID, DepartmentID: did})
+		}
+		return tx.Clauses(clause.OnConflict{DoNothing: true}).Create(&rows).Error
+	})
+}
+
+// requireUser returns gorm.ErrRecordNotFound when no user has the id.
+func (s *Service) requireUser(ctx context.Context, id string) error {
+	var n int64
+	if err := s.db.WithContext(ctx).Model(&model.User{}).Where("id = ?", id).Count(&n).Error; err != nil {
+		return err
+	}
+	if n == 0 {
+		return gorm.ErrRecordNotFound
+	}
+	return nil
+}
+
+// DepartmentsExist returns ErrUnknownDepartment (wrapping the missing ids) unless
+// every id references an existing department. An empty list is a no-op (nil).
+func (s *Service) DepartmentsExist(ctx context.Context, ids []string) error {
+	if len(ids) == 0 {
+		return nil
+	}
+	var found []string
+	if err := s.db.WithContext(ctx).Model(&model.Department{}).
+		Where("id IN ?", ids).Pluck("id", &found).Error; err != nil {
+		return err
+	}
+	if len(found) == len(ids) {
+		return nil
+	}
+	have := make(map[string]bool, len(found))
+	for _, id := range found {
+		have[id] = true
+	}
+	missing := make([]string, 0)
+	for _, id := range ids {
+		if !have[id] {
+			missing = append(missing, id)
+		}
+	}
+	return fmt.Errorf("%w: %v", ErrUnknownDepartment, missing)
 }
 
 // CreateDepartment inserts a new department node. The caller supplies the id

--- a/bkn-safe/server/internal/httpapi/admin_test.go
+++ b/bkn-safe/server/internal/httpapi/admin_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/glebarez/sqlite"
 	"gorm.io/gorm"
 
+	"bkn-safe/internal/audit"
 	"bkn-safe/internal/auth"
 	"bkn-safe/internal/authz"
 	"bkn-safe/internal/database"
@@ -56,6 +57,7 @@ func newAdminServer(t *testing.T) (*gin.Engine, *authz.Enforcer, *gorm.DB, *auth
 	users := auth.NewUserStore(db)
 	r := New(Deps{
 		Enforcer: e, DB: db, Directory: directory.New(db), Users: users,
+		Audit:         audit.New(db),
 		TokenVerifier: stubVerifier{},
 	})
 	return r, e, db, users
@@ -429,5 +431,212 @@ func TestRoleBindingValidatesAccessorAndRole(t *testing.T) {
 			map[string]any{"accessor_id": id, "role_id": "r-real"}); w.Code != http.StatusNoContent {
 			t.Errorf("bind %s: want 204, got %d (%s)", id, w.Code, w.Body.String())
 		}
+	}
+}
+
+func TestDepartmentMembershipWrite(t *testing.T) {
+	r, _, db, users := newAdminServer(t)
+	ctx := t.Context()
+	db.Create(&model.Department{ID: "d-eng", Name: "Engineering"})
+	for _, u := range []*model.User{
+		{ID: "u-1", Account: "alice", Name: "Alice", Enabled: true},
+		{ID: "u-2", Account: "bob", Name: "Bob", Enabled: true},
+	} {
+		if err := users.CreateLocalUser(ctx, u, "pw-init0"); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	// assign two members
+	if w := adminReq(t, r, http.MethodPost, "/api/safe/v1/admin/departments/d-eng/members",
+		map[string]any{"user_ids": []string{"u-1", "u-2"}}); w.Code != http.StatusNoContent {
+		t.Fatalf("add members: want 204, got %d (%s)", w.Code, w.Body.String())
+	}
+	// idempotent re-add -> still 204, no duplicate row
+	if w := adminReq(t, r, http.MethodPost, "/api/safe/v1/admin/departments/d-eng/members",
+		map[string]any{"user_ids": []string{"u-1"}}); w.Code != http.StatusNoContent {
+		t.Fatalf("re-add: want 204, got %d", w.Code)
+	}
+	var n int64
+	db.Model(&model.UserDepartment{}).Where("department_id = ?", "d-eng").Count(&n)
+	if n != 2 {
+		t.Fatalf("membership rows = %d, want 2 (idempotent)", n)
+	}
+
+	// GET members reflects the writes
+	w := adminReq(t, r, http.MethodGet, "/api/safe/v1/admin/departments/d-eng/members", nil)
+	var mem struct {
+		Total int `json:"total"`
+	}
+	_ = json.Unmarshal(w.Body.Bytes(), &mem)
+	if mem.Total != 2 {
+		t.Errorf("members total = %d, want 2", mem.Total)
+	}
+
+	// user detail shows the department
+	w = adminReq(t, r, http.MethodGet, "/api/safe/v1/admin/users/u-1", nil)
+	var detail struct {
+		Departments []string `json:"departments"`
+	}
+	_ = json.Unmarshal(w.Body.Bytes(), &detail)
+	if len(detail.Departments) != 1 || detail.Departments[0] != "d-eng" {
+		t.Errorf("user departments = %v", detail.Departments)
+	}
+
+	// unknown user -> 400 (nothing written)
+	if w := adminReq(t, r, http.MethodPost, "/api/safe/v1/admin/departments/d-eng/members",
+		map[string]any{"user_ids": []string{"ghost"}}); w.Code != http.StatusBadRequest {
+		t.Errorf("unknown user: want 400, got %d (%s)", w.Code, w.Body.String())
+	}
+	// unknown department -> 404
+	if w := adminReq(t, r, http.MethodPost, "/api/safe/v1/admin/departments/ghost/members",
+		map[string]any{"user_ids": []string{"u-1"}}); w.Code != http.StatusNotFound {
+		t.Errorf("unknown dept: want 404, got %d", w.Code)
+	}
+
+	// remove one member (idempotent: a non-member id is ignored)
+	if w := adminReq(t, r, http.MethodDelete, "/api/safe/v1/admin/departments/d-eng/members",
+		map[string]any{"user_ids": []string{"u-1", "never-was"}}); w.Code != http.StatusNoContent {
+		t.Fatalf("remove member: want 204, got %d", w.Code)
+	}
+	db.Model(&model.UserDepartment{}).Where("department_id = ?", "d-eng").Count(&n)
+	if n != 1 {
+		t.Errorf("after remove rows = %d, want 1", n)
+	}
+
+	// still one member -> department delete remains blocked (409)
+	if w := adminReq(t, r, http.MethodDelete, "/api/safe/v1/admin/departments/d-eng", nil); w.Code != http.StatusConflict {
+		t.Errorf("delete dept with member: want 409, got %d", w.Code)
+	}
+}
+
+func TestAuditTrail(t *testing.T) {
+	r, _, db, _ := newAdminServer(t)
+
+	// three mutations: create dept (POST, no :id), rename it (PUT, :id), and
+	// delete a ghost user (DELETE, :id -> 404 but still audited).
+	adminReq(t, r, http.MethodPost, "/api/safe/v1/admin/departments",
+		map[string]any{"id": "d-1", "name": "Root"})
+	adminReq(t, r, http.MethodPut, "/api/safe/v1/admin/departments/d-1",
+		map[string]any{"name": "Renamed"})
+	adminReq(t, r, http.MethodDelete, "/api/safe/v1/admin/users/ghost", nil)
+	// a GET must NOT be audited (no feedback loop on the read path)
+	adminReq(t, r, http.MethodGet, "/api/safe/v1/admin/departments", nil)
+
+	var total int64
+	db.Model(&model.AuditLog{}).Count(&total)
+	if total != 3 {
+		t.Fatalf("audit rows = %d, want 3 (GET excluded)", total)
+	}
+
+	type logRow struct {
+		ActorID  string `json:"actor_id"`
+		Method   string `json:"method"`
+		Resource string `json:"resource"`
+		Action   string `json:"action"`
+		TargetID string `json:"target_id"`
+		Status   int    `json:"status"`
+	}
+	type listResp struct {
+		Logs  []logRow `json:"logs"`
+		Total int      `json:"total"`
+	}
+
+	// filter by resource=users -> the single ghost-delete, recorded with its 404
+	w := adminReq(t, r, http.MethodGet, "/api/safe/v1/admin/audit-logs?resource=users", nil)
+	if w.Code != http.StatusOK {
+		t.Fatalf("list audit: %d (%s)", w.Code, w.Body.String())
+	}
+	var users listResp
+	_ = json.Unmarshal(w.Body.Bytes(), &users)
+	if users.Total != 1 || len(users.Logs) != 1 {
+		t.Fatalf("resource=users: total=%d len=%d", users.Total, len(users.Logs))
+	}
+	got := users.Logs[0]
+	if got.ActorID != adminSub || got.Method != http.MethodDelete || got.Action != "users" ||
+		got.TargetID != "ghost" || got.Status != http.StatusNotFound {
+		t.Errorf("ghost-delete entry = %+v", got)
+	}
+
+	// filter by resource=departments -> the create + rename
+	w = adminReq(t, r, http.MethodGet, "/api/safe/v1/admin/audit-logs?resource=departments", nil)
+	var depts listResp
+	_ = json.Unmarshal(w.Body.Bytes(), &depts)
+	if depts.Total != 2 {
+		t.Errorf("resource=departments: total=%d, want 2", depts.Total)
+	}
+}
+
+func TestUserDepartmentInlineSet(t *testing.T) {
+	r, _, db, _ := newAdminServer(t)
+	db.Create(&model.Department{ID: "d-1", Name: "D1"})
+	db.Create(&model.Department{ID: "d-2", Name: "D2"})
+
+	// create with department_ids
+	w := adminReq(t, r, http.MethodPost, "/api/safe/v1/admin/users",
+		map[string]any{"id": "u-1", "account": "alice", "name": "Alice",
+			"department_ids": []string{"d-1", "d-2"}})
+	if w.Code != http.StatusCreated {
+		t.Fatalf("create: want 201, got %d (%s)", w.Code, w.Body.String())
+	}
+	var n int64
+	db.Model(&model.UserDepartment{}).Where("user_id = ?", "u-1").Count(&n)
+	if n != 2 {
+		t.Fatalf("memberships after create = %d, want 2", n)
+	}
+
+	// create with an unknown dept -> 400 and NO orphan user
+	w = adminReq(t, r, http.MethodPost, "/api/safe/v1/admin/users",
+		map[string]any{"id": "u-bad", "account": "bad", "department_ids": []string{"ghost"}})
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("create bad dept: want 400, got %d (%s)", w.Code, w.Body.String())
+	}
+	db.Model(&model.User{}).Where("id = ?", "u-bad").Count(&n)
+	if n != 0 {
+		t.Errorf("orphan user created on bad dept: %d", n)
+	}
+
+	// update REPLACES the set: u-1 -> only d-2
+	if w := adminReq(t, r, http.MethodPut, "/api/safe/v1/admin/users/u-1",
+		map[string]any{"department_ids": []string{"d-2"}}); w.Code != http.StatusNoContent {
+		t.Fatalf("replace depts: want 204, got %d (%s)", w.Code, w.Body.String())
+	}
+	var got []model.UserDepartment
+	db.Where("user_id = ?", "u-1").Find(&got)
+	if len(got) != 1 || got[0].DepartmentID != "d-2" {
+		t.Errorf("after replace = %v", got)
+	}
+
+	// empty array CLEARS memberships
+	if w := adminReq(t, r, http.MethodPut, "/api/safe/v1/admin/users/u-1",
+		map[string]any{"department_ids": []string{}}); w.Code != http.StatusNoContent {
+		t.Fatalf("clear depts: want 204, got %d", w.Code)
+	}
+	db.Model(&model.UserDepartment{}).Where("user_id = ?", "u-1").Count(&n)
+	if n != 0 {
+		t.Errorf("memberships after clear = %d, want 0", n)
+	}
+
+	// profile-only update (no department_ids key) is still accepted
+	if w := adminReq(t, r, http.MethodPut, "/api/safe/v1/admin/users/u-1",
+		map[string]any{"name": "Alicia"}); w.Code != http.StatusNoContent {
+		t.Errorf("profile-only update: want 204, got %d", w.Code)
+	}
+
+	// update with an unknown dept -> 400, prior set left untouched
+	db.Create(&model.UserDepartment{UserID: "u-1", DepartmentID: "d-1"})
+	if w := adminReq(t, r, http.MethodPut, "/api/safe/v1/admin/users/u-1",
+		map[string]any{"department_ids": []string{"d-1", "ghost"}}); w.Code != http.StatusBadRequest {
+		t.Errorf("update bad dept: want 400, got %d", w.Code)
+	}
+	db.Model(&model.UserDepartment{}).Where("user_id = ?", "u-1").Count(&n)
+	if n != 1 {
+		t.Errorf("memberships after failed update = %d, want 1 (unchanged)", n)
+	}
+
+	// department_ids-only update on an unknown user -> 404
+	if w := adminReq(t, r, http.MethodPut, "/api/safe/v1/admin/users/ghost",
+		map[string]any{"department_ids": []string{"d-1"}}); w.Code != http.StatusNotFound {
+		t.Errorf("depts update ghost user: want 404, got %d", w.Code)
 	}
 }

--- a/bkn-safe/server/internal/httpapi/audit.go
+++ b/bkn-safe/server/internal/httpapi/audit.go
@@ -1,0 +1,101 @@
+package httpapi
+
+import (
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/gin-gonic/gin"
+
+	"bkn-safe/internal/audit"
+)
+
+const adminPathPrefix = "/api/safe/v1/admin/"
+
+// auditMiddleware records every mutating (non-GET) admin request that reaches a
+// handler — i.e. one that already passed RequireAdmin, so the accessor id is
+// set. It runs the request first, then records the resulting status. Recording
+// errors are attached to the gin context (logged) but never fail the request:
+// auditing must not break the operation it audits. Read requests are skipped, so
+// the audit-log read endpoint itself produces no entries (no feedback loop).
+func auditMiddleware(store *audit.Store) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		c.Next()
+		switch c.Request.Method {
+		case http.MethodGet, http.MethodHead, http.MethodOptions:
+			return
+		}
+		resource, action := auditTarget(c.FullPath())
+		if err := store.Record(c.Request.Context(), audit.Entry{
+			ActorID:  c.GetString(ctxAccessorID),
+			Method:   c.Request.Method,
+			Resource: resource,
+			Action:   action,
+			TargetID: c.Param("id"),
+			Status:   c.Writer.Status(),
+			ClientIP: c.ClientIP(),
+		}); err != nil {
+			_ = c.Error(err)
+		}
+	}
+}
+
+// auditTarget derives the resource (top-level admin noun) and action (dotted
+// non-param route segments) from the matched route template. E.g.
+// "/api/safe/v1/admin/departments/:id/members" -> ("departments",
+// "departments.members"); "/api/safe/v1/admin/users" -> ("users", "users").
+// Method (carried separately) distinguishes create/update/delete.
+func auditTarget(fullPath string) (resource, action string) {
+	rest := strings.TrimPrefix(fullPath, adminPathPrefix)
+	parts := make([]string, 0, 3)
+	for _, seg := range strings.Split(rest, "/") {
+		if seg == "" || strings.HasPrefix(seg, ":") {
+			continue
+		}
+		parts = append(parts, seg)
+	}
+	if len(parts) == 0 {
+		return "", ""
+	}
+	return parts[0], strings.Join(parts, ".")
+}
+
+// registerAuditReads mounts the audit-log read endpoint under the admin group.
+// It is a GET, so auditMiddleware does not record calls to it.
+func registerAuditReads(g *gin.RouterGroup, store *audit.Store) {
+	// GET /audit-logs — list audit entries newest-first, filterable. Query:
+	// ?actor_id=&resource=&action=&target_id=&from=&to=&offset=&limit=
+	// from/to are RFC3339 timestamps. -> { logs:[...], total }
+	g.GET("/audit-logs", func(c *gin.Context) {
+		f := audit.Filter{
+			ActorID:  c.Query("actor_id"),
+			Resource: c.Query("resource"),
+			Action:   c.Query("action"),
+			TargetID: c.Query("target_id"),
+			Offset:   atoiDefault(c.Query("offset"), 0),
+			Limit:    atoiDefault(c.Query("limit"), 0),
+		}
+		if v := c.Query("from"); v != "" {
+			t, err := time.Parse(time.RFC3339, v)
+			if err != nil {
+				c.JSON(http.StatusBadRequest, gin.H{"error": "from must be an RFC3339 timestamp"})
+				return
+			}
+			f.From = t
+		}
+		if v := c.Query("to"); v != "" {
+			t, err := time.Parse(time.RFC3339, v)
+			if err != nil {
+				c.JSON(http.StatusBadRequest, gin.H{"error": "to must be an RFC3339 timestamp"})
+				return
+			}
+			f.To = t
+		}
+		logs, total, err := store.List(c.Request.Context(), f)
+		if err != nil {
+			serverError(c, err)
+			return
+		}
+		c.JSON(http.StatusOK, gin.H{"logs": logs, "total": total})
+	})
+}

--- a/bkn-safe/server/internal/httpapi/directory.go
+++ b/bkn-safe/server/internal/httpapi/directory.go
@@ -351,4 +351,52 @@ func registerDeptAdmin(g *gin.RouterGroup, dir *directory.Service) {
 		}
 		c.Status(http.StatusNoContent)
 	})
+
+	// POST /departments/:id/members — assign users to the department (the write
+	// counterpart of GET .../members). Idempotent. { user_ids:[...] }
+	// 404 if the department is unknown; 400 if any user id is unknown (in which
+	// case nothing is written).
+	g.POST("/departments/:id/members", func(c *gin.Context) {
+		var req struct {
+			UserIDs []string `json:"user_ids" binding:"required"`
+		}
+		if !bind(c, &req) {
+			return
+		}
+		err := dir.AddDepartmentMembers(c.Request.Context(), c.Param("id"), req.UserIDs)
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			c.JSON(http.StatusNotFound, gin.H{"error": "department not found"})
+			return
+		}
+		if errors.Is(err, directory.ErrUnknownUser) {
+			c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+			return
+		}
+		if err != nil {
+			serverError(c, err)
+			return
+		}
+		c.Status(http.StatusNoContent)
+	})
+
+	// DELETE /departments/:id/members — remove users from the department.
+	// Idempotent. { user_ids:[...] }. 404 if the department is unknown.
+	g.DELETE("/departments/:id/members", func(c *gin.Context) {
+		var req struct {
+			UserIDs []string `json:"user_ids" binding:"required"`
+		}
+		if !bind(c, &req) {
+			return
+		}
+		err := dir.RemoveDepartmentMembers(c.Request.Context(), c.Param("id"), req.UserIDs)
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			c.JSON(http.StatusNotFound, gin.H{"error": "department not found"})
+			return
+		}
+		if err != nil {
+			serverError(c, err)
+			return
+		}
+		c.Status(http.StatusNoContent)
+	})
 }

--- a/bkn-safe/server/internal/httpapi/router.go
+++ b/bkn-safe/server/internal/httpapi/router.go
@@ -8,6 +8,7 @@ import (
 	"github.com/gin-gonic/gin"
 	"gorm.io/gorm"
 
+	"bkn-safe/internal/audit"
 	"bkn-safe/internal/auth"
 	"bkn-safe/internal/authz"
 	"bkn-safe/internal/directory"
@@ -21,6 +22,9 @@ type Deps struct {
 	Hydra     *auth.HydraAdmin
 	Directory *directory.Service
 	Users     *auth.UserStore
+	// Audit records admin-API mutations. When nil, the audit middleware and the
+	// audit-log read endpoint are not mounted (auditing off).
+	Audit *audit.Store
 	// TokenVerifier validates admin-API bearer tokens. Defaults to Hydra when
 	// nil (production); tests inject a stub.
 	TokenVerifier TokenVerifier
@@ -62,7 +66,15 @@ func New(deps Deps) *gin.Engine {
 	}
 	if deps.Enforcer != nil && verifier != nil && deps.Users != nil && deps.Directory != nil {
 		admin := r.Group("/api/safe/v1/admin", RequireAdmin(verifier, deps.Enforcer))
-		registerUserAdmin(admin, deps.Users, deps.Enforcer)
+		// Audit every mutating admin request. Use() must precede the route
+		// registrations below: gin snapshots the group's handler chain at
+		// register time. The middleware sits after RequireAdmin, so it only runs
+		// for authenticated callers (failed-auth 401/403 are not audited).
+		if deps.Audit != nil {
+			admin.Use(auditMiddleware(deps.Audit))
+			registerAuditReads(admin, deps.Audit)
+		}
+		registerUserAdmin(admin, deps.Users, deps.Enforcer, deps.Directory)
 		registerAdminReads(admin, deps.Directory)
 		registerDeptAdmin(admin, deps.Directory)
 		registerRoleBindings(admin, deps.Enforcer, deps.DB)

--- a/bkn-safe/server/internal/httpapi/useradmin.go
+++ b/bkn-safe/server/internal/httpapi/useradmin.go
@@ -9,26 +9,42 @@ import (
 
 	"bkn-safe/internal/auth"
 	"bkn-safe/internal/authz"
+	"bkn-safe/internal/directory"
 	"bkn-safe/internal/model"
 )
 
 // registerUserAdmin mounts the user-write surface bkn-safe needs to own
 // identities: create/update/delete a local user and set a password. Role
-// assignment is the authz role-binding endpoint. The enforcer is used to purge
-// an accessor's casbin bindings/grants on delete. Mounted under the admin group
+// assignment is the authz role-binding endpoint; department membership can be
+// set inline (department_ids) or via the department member endpoints. The
+// enforcer is used to purge an accessor's casbin bindings/grants on delete; the
+// directory service applies department_ids. Mounted under the admin group
 // (RequireAdmin) — these are privileged, token-gated operations.
-func registerUserAdmin(g *gin.RouterGroup, users *auth.UserStore, e *authz.Enforcer) {
-	// POST /users — create a local (password) user. -> { id }
+func registerUserAdmin(g *gin.RouterGroup, users *auth.UserStore, e *authz.Enforcer, dir *directory.Service) {
+	// POST /users — create a local (password) user, optionally placing it in
+	// departments (department_ids). -> { id }
 	g.POST("/users", func(c *gin.Context) {
 		var req struct {
-			ID          string `json:"id"`
-			Account     string `json:"account" binding:"required"`
-			Name        string `json:"name"`
-			Email       string `json:"email"`
-			Password    string `json:"password"` // optional: defaults to the platform initial password
-			AccountType string `json:"account_type"`
+			ID            string   `json:"id"`
+			Account       string   `json:"account" binding:"required"`
+			Name          string   `json:"name"`
+			Email         string   `json:"email"`
+			Telephone     string   `json:"telephone"`
+			Password      string   `json:"password"` // optional: defaults to the platform initial password
+			AccountType   string   `json:"account_type"`
+			DepartmentIDs []string `json:"department_ids"` // optional: initial department membership
 		}
 		if !bind(c, &req) {
+			return
+		}
+		ctx := c.Request.Context()
+		// Validate departments BEFORE creating the user, so an unknown id fails
+		// the request without leaving an orphaned user behind.
+		if err := dir.DepartmentsExist(ctx, req.DepartmentIDs); errors.Is(err, directory.ErrUnknownDepartment) {
+			c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+			return
+		} else if err != nil {
+			serverError(c, err)
 			return
 		}
 		if req.ID == "" {
@@ -45,11 +61,17 @@ func registerUserAdmin(g *gin.RouterGroup, users *auth.UserStore, e *authz.Enfor
 		}
 		u := &model.User{
 			ID: req.ID, Account: req.Account, Name: req.Name, Email: req.Email,
-			Enabled: true, AccountType: at,
+			Telephone: req.Telephone, Enabled: true, AccountType: at,
 		}
-		if err := users.CreateLocalUser(c.Request.Context(), u, req.Password); err != nil {
+		if err := users.CreateLocalUser(ctx, u, req.Password); err != nil {
 			serverError(c, err)
 			return
+		}
+		if len(req.DepartmentIDs) > 0 {
+			if err := dir.SetUserDepartments(ctx, u.ID, req.DepartmentIDs); err != nil {
+				serverError(c, err)
+				return
+			}
 		}
 		c.JSON(http.StatusCreated, gin.H{"id": u.ID})
 	})
@@ -70,21 +92,26 @@ func registerUserAdmin(g *gin.RouterGroup, users *auth.UserStore, e *authz.Enfor
 		c.Status(http.StatusNoContent)
 	})
 
-	// PUT /users/:id — update mutable profile fields. Only the fields present in
-	// the body are changed (account and password are not editable here). A bool
-	// "enabled" is always applied (no way to omit a primitive in JSON), so this
-	// doubles as the enable/disable path.
+	// PUT /users/:id — update mutable profile fields and/or department membership.
+	// Only the keys present in the body are changed (account and password are not
+	// editable here). A bool "enabled" is always applied when present, so this
+	// doubles as the enable/disable path. "department_ids", when present, REPLACES
+	// the user's full department set (an empty array clears it); omit the key to
+	// leave memberships untouched.
 	g.PUT("/users/:id", func(c *gin.Context) {
 		var req struct {
-			Name        *string `json:"name"`
-			Email       *string `json:"email"`
-			Telephone   *string `json:"telephone"`
-			Enabled     *bool   `json:"enabled"`
-			AccountType *string `json:"account_type"`
+			Name          *string   `json:"name"`
+			Email         *string   `json:"email"`
+			Telephone     *string   `json:"telephone"`
+			Enabled       *bool     `json:"enabled"`
+			AccountType   *string   `json:"account_type"`
+			DepartmentIDs *[]string `json:"department_ids"`
 		}
 		if !bind(c, &req) {
 			return
 		}
+		ctx := c.Request.Context()
+		id := c.Param("id")
 		fields := map[string]any{}
 		if req.Name != nil {
 			fields["name"] = *req.Name
@@ -101,18 +128,41 @@ func registerUserAdmin(g *gin.RouterGroup, users *auth.UserStore, e *authz.Enfor
 		if req.AccountType != nil {
 			fields["account_type"] = *req.AccountType
 		}
-		if len(fields) == 0 {
+		if len(fields) == 0 && req.DepartmentIDs == nil {
 			c.JSON(http.StatusBadRequest, gin.H{"error": "no updatable fields provided"})
 			return
 		}
-		err := users.UpdateUser(c.Request.Context(), c.Param("id"), fields)
-		if errors.Is(err, gorm.ErrRecordNotFound) {
-			c.JSON(http.StatusNotFound, gin.H{"error": "user not found"})
-			return
+		// Validate departments up-front so a bad id fails before any write lands.
+		if req.DepartmentIDs != nil {
+			if err := dir.DepartmentsExist(ctx, *req.DepartmentIDs); errors.Is(err, directory.ErrUnknownDepartment) {
+				c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+				return
+			} else if err != nil {
+				serverError(c, err)
+				return
+			}
 		}
-		if err != nil {
-			serverError(c, err)
-			return
+		if len(fields) > 0 {
+			err := users.UpdateUser(ctx, id, fields)
+			if errors.Is(err, gorm.ErrRecordNotFound) {
+				c.JSON(http.StatusNotFound, gin.H{"error": "user not found"})
+				return
+			}
+			if err != nil {
+				serverError(c, err)
+				return
+			}
+		}
+		if req.DepartmentIDs != nil {
+			err := dir.SetUserDepartments(ctx, id, *req.DepartmentIDs)
+			if errors.Is(err, gorm.ErrRecordNotFound) {
+				c.JSON(http.StatusNotFound, gin.H{"error": "user not found"})
+				return
+			}
+			if err != nil {
+				serverError(c, err)
+				return
+			}
 		}
 		c.Status(http.StatusNoContent)
 	})

--- a/bkn-safe/server/internal/model/model.go
+++ b/bkn-safe/server/internal/model/model.go
@@ -30,22 +30,22 @@ const (
 // User is an identity in the directory. Password lives here for local users;
 // LDAP users authenticate against the external directory (PasswordHash empty).
 type User struct {
-	ID           string      `gorm:"primaryKey;size:64"`
-	Account      string      `gorm:"uniqueIndex;size:128"` // login name
-	Name         string      `gorm:"size:255"`
-	Email        string      `gorm:"size:255;index"`
-	Telephone    string      `gorm:"size:64"`
+	ID        string `gorm:"primaryKey;size:64"`
+	Account   string `gorm:"uniqueIndex;size:128"` // login name
+	Name      string `gorm:"size:255"`
+	Email     string `gorm:"size:255;index"`
+	Telephone string `gorm:"size:64"`
 	// No GORM "default:true": a default would override an explicit Enabled=false
 	// on insert (GORM treats the bool zero value as unset). Callers set Enabled.
 	Enabled      bool
-	Source       Source `gorm:"size:16;default:local"`
+	Source       Source      `gorm:"size:16;default:local"`
 	AccountType  AccountType `gorm:"size:16;default:other"`
 	PasswordHash string      `gorm:"size:255"` // bcrypt; empty for ldap/app
 	// MustChangePassword forces a password change before the login is accepted.
 	// Set on the seeded built-in admin (initial password); cleared by SetPassword.
 	MustChangePassword bool
-	CreatedAt    time.Time
-	UpdatedAt    time.Time
+	CreatedAt          time.Time
+	UpdatedAt          time.Time
 }
 
 // Role source values. system|business roles are SEEDED built-ins (their UUIDs
@@ -122,10 +122,28 @@ type Operation struct {
 	Description    string `gorm:"size:1024"`
 }
 
+// AuditLog records a privileged admin-API mutation: who (ActorID, the verified
+// token subject), what (Method + Resource + Action + TargetID), and the outcome
+// (Status). One row per non-GET request that passes RequireAdmin; reads are not
+// audited. Method distinguishes create/update/delete on the same Action (e.g.
+// POST vs PUT vs DELETE on "users").
+type AuditLog struct {
+	ID        string    `json:"id" gorm:"primaryKey;size:64"`
+	ActorID   string    `json:"actor_id" gorm:"size:64;index"`   // token subject that performed the action
+	Method    string    `json:"method" gorm:"size:8"`            // POST | PUT | DELETE
+	Resource  string    `json:"resource" gorm:"size:64;index"`   // top-level admin noun, e.g. "users"
+	Action    string    `json:"action" gorm:"size:128;index"`    // dotted route, e.g. "departments.members"
+	TargetID  string    `json:"target_id" gorm:"size:128;index"` // :id path param, "" when the route has none
+	Status    int       `json:"status"`                          // HTTP status code of the response
+	ClientIP  string    `json:"client_ip" gorm:"size:64"`
+	CreatedAt time.Time `json:"created_at" gorm:"index"`
+}
+
 // AllModels is the migration set (Casbin's table is managed by its adapter).
 func AllModels() []any {
 	return []any{
 		&User{}, &Role{}, &Department{}, &UserDepartment{},
 		&Group{}, &GroupMember{}, &ResourceType{}, &Operation{},
+		&AuditLog{},
 	}
 }

--- a/bkn-safe/server/main.go
+++ b/bkn-safe/server/main.go
@@ -8,6 +8,7 @@ import (
 	"os"
 
 	"bkn-safe/config"
+	"bkn-safe/internal/audit"
 	"bkn-safe/internal/auth"
 	"bkn-safe/internal/authz"
 	"bkn-safe/internal/database"
@@ -59,6 +60,7 @@ func main() {
 		Hydra:     hydraAdmin,
 		Directory: dir,
 		Users:     userStore,
+		Audit:     audit.New(db),
 	})
 	slog.Info("bkn-safe listening", "addr", cfg.HTTPAddr)
 	if err := r.Run(cfg.HTTPAddr); err != nil {


### PR DESCRIPTION
补齐前端在对接 bkn-safe `/api/safe/v1/admin/*` 时反馈的两个硬缺口。按产品定调，**部门扩展字段**（负责人/编码/邮箱/备注）与独立于 `enabled` 的**冻结/解冻**状态本次不做。

## 1. 人员归属写（组织架构「人员归属」）
- `POST` / `DELETE /api/safe/v1/admin/departments/:id/members` — 与已有 `GET .../members` 对称的写端点，幂等；部门不存在 → 404，任一 user_id 不存在 → 400（整批拒绝，不写）。
- 用户 `create`/`update` 支持内联 `department_ids`：PUT 为**替换**整组（`[]` 清空、不传该 key 不动），编辑表单可一步设置归属；写入前校验部门存在。`create` 同时补收 `telephone`（与 update 对齐）。

## 2. 审计日志
- `model.AuditLog` + `internal/audit`（Record + 可过滤 List）。
- admin 组中间件记录每个过了 `RequireAdmin` 的**变更类**（非 GET）请求：actor / method / resource / action / target_id / status / client_ip。鉴权失败(401/403)与读请求不记。
- `GET /api/safe/v1/admin/audit-logs` — 倒序，按 actor_id / resource / action / target_id / from / to 过滤，分页。

## 测试
覆盖成员增删/幂等/校验、内联 department_ids 的替换/清空/校验、审计落库与 GET 排除与按 resource 过滤。`go build` / `go vet` / `go test ./...` 全绿（go1.25.6）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)