### PR TITLE
fix(vega/build-task): 归一 embedding_model 到模型 ID + 新增 failure_detail

### DIFF
--- a/adp/vega/vega-backend/migrations/mariadb/0.9.0/06-add-build-task-failure-detail.sql
+++ b/adp/vega/vega-backend/migrations/mariadb/0.9.0/06-add-build-task-failure-detail.sql
@@ -1,0 +1,15 @@
+-- Copyright 2026 openbkn.ai
+-- Copyright The kweaver.ai Authors.
+--
+-- Licensed under the Apache License, Version 2.0.
+-- See the LICENSE file in the project root for details.
+
+-- ==========================================
+-- 迁移脚本：t_build_task 增加部分向量化失败明细字段
+-- 与 f_error_msg 区分：f_error_msg 记录整任务硬失败，
+-- f_failure_detail 记录 completed 但部分文档向量化失败的明细。
+-- ==========================================
+
+USE kweaver;
+
+ALTER TABLE t_build_task ADD COLUMN IF NOT EXISTS f_failure_detail TEXT NOT NULL DEFAULT '' COMMENT '构建完成但部分文档向量化失败的明细';

--- a/adp/vega/vega-backend/migrations/mariadb/0.9.0/init.sql
+++ b/adp/vega/vega-backend/migrations/mariadb/0.9.0/init.sql
@@ -389,6 +389,7 @@ CREATE TABLE IF NOT EXISTS t_build_task (
     f_vectorized_count        BIGINT NOT NULL DEFAULT 0 COMMENT '已做向量数',
     f_synced_mark             VARCHAR(100) DEFAULT NULL COMMENT '同步标记',
     f_error_msg               TEXT DEFAULT NULL COMMENT '错误信息',
+    f_failure_detail          TEXT NOT NULL DEFAULT '' COMMENT '构建完成但部分文档向量化失败的明细（区别于 f_error_msg 的整任务硬失败）',
 
     -- 审计字段
     f_creator                 VARCHAR(40) NOT NULL DEFAULT '' COMMENT '创建者id',

--- a/adp/vega/vega-backend/server/drivenadapters/build_task/build_task_access.go
+++ b/adp/vega/vega-backend/server/drivenadapters/build_task/build_task_access.go
@@ -57,6 +57,7 @@ func buildTaskColumns() []string {
 		"f_model_dimensions",
 		"f_fulltext_fields",
 		"f_fulltext_analyzer",
+		"f_failure_detail",
 	}
 }
 
@@ -95,6 +96,7 @@ func scanBuildTask(scanner buildTaskScanner) (*interfaces.BuildTask, error) {
 		&buildTask.ModelDimensions,
 		&buildTask.FulltextFields,
 		&buildTask.FulltextAnalyzer,
+		&buildTask.FailureDetail,
 	)
 	if err != nil {
 		return nil, err
@@ -145,6 +147,7 @@ func (bta *buildTaskAccess) Create(ctx context.Context, buildTask *interfaces.Bu
 			buildTask.ModelDimensions,
 			buildTask.FulltextFields,
 			buildTask.FulltextAnalyzer,
+			buildTask.FailureDetail,
 		).ToSql()
 	if err != nil {
 		span.SetStatus(codes.Error, "Build sql failed")
@@ -281,6 +284,7 @@ func (bta *buildTaskAccess) UpdateStatus(ctx context.Context, id string, updates
 		"modelDimensions":  "f_model_dimensions",
 		"fulltextFields":   "f_fulltext_fields",
 		"fulltextAnalyzer": "f_fulltext_analyzer",
+		"failureDetail":    "f_failure_detail",
 	}
 
 	builder := sq.Update(BUILD_TASK_TABLE_NAME)

--- a/adp/vega/vega-backend/server/interfaces/build_task.go
+++ b/adp/vega/vega-backend/server/interfaces/build_task.go
@@ -52,6 +52,7 @@ type BuildTask struct {
 	VectorizedCount int64       `json:"vectorized_count"` // 已做向量数
 	SyncedMark      string      `json:"synced_mark"`      // 同步标记
 	ErrorMsg        string      `json:"error_msg,omitempty"`
+	FailureDetail   string      `json:"failure_detail,omitempty"` // 构建完成但部分文档向量化失败的明细，区别于 error_msg 的整任务硬失败
 	Creator         AccountInfo `json:"creator"`
 	CreateTime      int64       `json:"create_time"`
 	Updater         AccountInfo `json:"updater"`

--- a/adp/vega/vega-backend/server/logics/build_task/build_task_normalize_test.go
+++ b/adp/vega/vega-backend/server/logics/build_task/build_task_normalize_test.go
@@ -1,0 +1,200 @@
+// Copyright 2026 openbkn.ai
+// Copyright The kweaver.ai Authors.
+//
+// Licensed under the Apache License, Version 2.0.
+// See the LICENSE file in the project root for details.
+
+package build_task
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/hibiken/asynq"
+	"github.com/kweaver-ai/kweaver-go-lib/rest"
+	"go.uber.org/mock/gomock"
+
+	"vega-backend/interfaces"
+	mock_interfaces "vega-backend/interfaces/mock"
+	"vega-backend/logics"
+)
+
+// neutralizeEnqueue 让 CreateBuildTask/UpdateBuildTaskConfig 末尾的 enqueueBuildTask
+// 不 panic：CreateClient 返回真实但指向不可达 redis 的 client，Enqueue 会失败，
+// 而 enqueueBuildTask 对入队失败仅记日志、不影响返回值。
+func neutralizeEnqueue(t *testing.T, ctrl *gomock.Controller) {
+	t.Helper()
+	mockAQA := mock_interfaces.NewMockAsynqAccess(ctrl)
+	client := asynq.NewClient(asynq.RedisClientOpt{Addr: "127.0.0.1:0"})
+	mockAQA.EXPECT().CreateClient().Return(client).AnyTimes()
+	prev := logics.AQA
+	logics.AQA = mockAQA
+	t.Cleanup(func() {
+		logics.AQA = prev
+		_ = client.Close()
+	})
+}
+
+// 传入模型名 → 落库归一为模型 ID，并按模型补全维度。
+func TestCreateBuildTaskNormalizesModelNameToID(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	mockCS := mock_interfaces.NewMockCatalogService(ctrl)
+	mockRA := mock_interfaces.NewMockResourceAccess(ctrl)
+	mockBTA := mock_interfaces.NewMockBuildTaskAccess(ctrl)
+	mockMFA := mock_interfaces.NewMockModelFactoryAccess(ctrl)
+	neutralizeEnqueue(t, ctrl)
+	service := &buildTaskService{cs: mockCS, ra: mockRA, bta: mockBTA, mfa: mockMFA}
+
+	mockRA.EXPECT().GetByID(gomock.Any(), "resource-1").
+		Return(&interfaces.Resource{ID: "resource-1", CatalogID: "catalog-1", Category: interfaces.ResourceCategoryTable}, nil)
+	mockCS.EXPECT().GetByID(gomock.Any(), "catalog-1", false).
+		Return(&interfaces.Catalog{ID: "catalog-1", Enabled: true}, nil)
+	mockBTA.EXPECT().GetByResourceID(gomock.Any(), "resource-1").Return(nil, nil)
+	mockMFA.EXPECT().GetModelByName(gomock.Any(), "text-embedding-v4").
+		Return(&interfaces.SmallModel{ModelID: "2064382281006583808", ModelName: "text-embedding-v4", EmbeddingDim: 1024}, nil)
+
+	var captured *interfaces.BuildTask
+	mockBTA.EXPECT().Create(gomock.Any(), gomock.Any()).
+		DoAndReturn(func(_ context.Context, bt *interfaces.BuildTask) error {
+			captured = bt
+			return nil
+		})
+
+	_, err := service.CreateBuildTask(context.Background(), &interfaces.CreateBuildTaskRequest{
+		ResourceID:      "resource-1",
+		Mode:            interfaces.BuildTaskModeBatch,
+		EmbeddingFields: "family_name,given_name",
+		EmbeddingModel:  "text-embedding-v4",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if captured == nil {
+		t.Fatal("bta.Create was not called")
+	}
+	if captured.EmbeddingModel != "2064382281006583808" {
+		t.Fatalf("embedding_model not normalized to id: got %q", captured.EmbeddingModel)
+	}
+	if captured.ModelDimensions != 1024 {
+		t.Fatalf("model_dimensions not filled from model: got %d", captured.ModelDimensions)
+	}
+}
+
+// 传入已是模型 ID（按名查不到）且带维度 → 原样保留为 ID，不报错。
+func TestCreateBuildTaskKeepsModelIDWhenNameLookupFails(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	mockCS := mock_interfaces.NewMockCatalogService(ctrl)
+	mockRA := mock_interfaces.NewMockResourceAccess(ctrl)
+	mockBTA := mock_interfaces.NewMockBuildTaskAccess(ctrl)
+	mockMFA := mock_interfaces.NewMockModelFactoryAccess(ctrl)
+	neutralizeEnqueue(t, ctrl)
+	service := &buildTaskService{cs: mockCS, ra: mockRA, bta: mockBTA, mfa: mockMFA}
+
+	mockRA.EXPECT().GetByID(gomock.Any(), "resource-1").
+		Return(&interfaces.Resource{ID: "resource-1", CatalogID: "catalog-1", Category: interfaces.ResourceCategoryTable}, nil)
+	mockCS.EXPECT().GetByID(gomock.Any(), "catalog-1", false).
+		Return(&interfaces.Catalog{ID: "catalog-1", Enabled: true}, nil)
+	mockBTA.EXPECT().GetByResourceID(gomock.Any(), "resource-1").Return(nil, nil)
+	mockMFA.EXPECT().GetModelByName(gomock.Any(), "2064382281006583808").
+		Return(nil, fmt.Errorf("model not found"))
+
+	var captured *interfaces.BuildTask
+	mockBTA.EXPECT().Create(gomock.Any(), gomock.Any()).
+		DoAndReturn(func(_ context.Context, bt *interfaces.BuildTask) error {
+			captured = bt
+			return nil
+		})
+
+	_, err := service.CreateBuildTask(context.Background(), &interfaces.CreateBuildTaskRequest{
+		ResourceID:      "resource-1",
+		Mode:            interfaces.BuildTaskModeBatch,
+		EmbeddingFields: "family_name,given_name",
+		EmbeddingModel:  "2064382281006583808",
+		ModelDimensions: 1024,
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if captured == nil {
+		t.Fatal("bta.Create was not called")
+	}
+	if captured.EmbeddingModel != "2064382281006583808" {
+		t.Fatalf("embedding_model id was altered: got %q", captured.EmbeddingModel)
+	}
+}
+
+// 既解析不到（无效名/未知 id）又没给维度 → 报错，且不落库、不入队。
+func TestCreateBuildTaskErrorsWhenModelUnresolvableAndNoDimensions(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	mockCS := mock_interfaces.NewMockCatalogService(ctrl)
+	mockRA := mock_interfaces.NewMockResourceAccess(ctrl)
+	mockBTA := mock_interfaces.NewMockBuildTaskAccess(ctrl)
+	mockMFA := mock_interfaces.NewMockModelFactoryAccess(ctrl)
+	service := &buildTaskService{cs: mockCS, ra: mockRA, bta: mockBTA, mfa: mockMFA}
+
+	mockRA.EXPECT().GetByID(gomock.Any(), "resource-1").
+		Return(&interfaces.Resource{ID: "resource-1", CatalogID: "catalog-1", Category: interfaces.ResourceCategoryTable}, nil)
+	mockCS.EXPECT().GetByID(gomock.Any(), "catalog-1", false).
+		Return(&interfaces.Catalog{ID: "catalog-1", Enabled: true}, nil)
+	mockBTA.EXPECT().GetByResourceID(gomock.Any(), "resource-1").Return(nil, nil)
+	mockMFA.EXPECT().GetModelByName(gomock.Any(), "bogus-model").
+		Return(nil, fmt.Errorf("model not found"))
+	// bta.Create 不应被调用：未设置 EXPECT，gomock 会在被调用时失败。
+
+	_, err := service.CreateBuildTask(context.Background(), &interfaces.CreateBuildTaskRequest{
+		ResourceID:      "resource-1",
+		Mode:            interfaces.BuildTaskModeBatch,
+		EmbeddingFields: "family_name,given_name",
+		EmbeddingModel:  "bogus-model",
+	})
+	if err == nil {
+		t.Fatal("expected error for unresolvable model without dimensions")
+	}
+	httpErr, ok := err.(*rest.HTTPError)
+	if !ok {
+		t.Fatalf("expected HTTPError, got %T", err)
+	}
+	if httpErr.HTTPCode != http.StatusInternalServerError {
+		t.Fatalf("expected HTTP 500, got %d", httpErr.HTTPCode)
+	}
+}
+
+// 编辑配置同样把模型名归一为 ID 写回。
+func TestUpdateBuildTaskConfigNormalizesModelNameToID(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	mockCS := mock_interfaces.NewMockCatalogService(ctrl)
+	mockBTA := mock_interfaces.NewMockBuildTaskAccess(ctrl)
+	mockMFA := mock_interfaces.NewMockModelFactoryAccess(ctrl)
+	neutralizeEnqueue(t, ctrl)
+	service := &buildTaskService{cs: mockCS, bta: mockBTA, mfa: mockMFA}
+
+	mockBTA.EXPECT().GetByID(gomock.Any(), "task-1").
+		Return(&interfaces.BuildTask{ID: "task-1", CatalogID: "catalog-1", Mode: interfaces.BuildTaskModeBatch, Status: interfaces.BuildTaskStatusInit}, nil)
+	mockCS.EXPECT().GetByID(gomock.Any(), "catalog-1", false).
+		Return(&interfaces.Catalog{ID: "catalog-1", Enabled: true}, nil)
+	mockMFA.EXPECT().GetModelByName(gomock.Any(), "text-embedding-v4").
+		Return(&interfaces.SmallModel{ModelID: "2064382281006583808", ModelName: "text-embedding-v4", EmbeddingDim: 1024}, nil)
+
+	var captured map[string]any
+	mockBTA.EXPECT().UpdateStatus(gomock.Any(), "task-1", gomock.Any()).
+		DoAndReturn(func(_ context.Context, _ string, updates map[string]any) error {
+			captured = updates
+			return nil
+		})
+
+	err := service.UpdateBuildTaskConfig(context.Background(), "task-1", &interfaces.UpdateBuildTaskConfigRequest{
+		EmbeddingFields: "family_name,given_name",
+		EmbeddingModel:  "text-embedding-v4",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if captured["embeddingModel"] != "2064382281006583808" {
+		t.Fatalf("embedding_model not normalized to id on update: got %v", captured["embeddingModel"])
+	}
+	if captured["modelDimensions"] != 1024 {
+		t.Fatalf("model_dimensions not filled on update: got %v", captured["modelDimensions"])
+	}
+}

--- a/adp/vega/vega-backend/server/logics/build_task/build_task_service.go
+++ b/adp/vega/vega-backend/server/logics/build_task/build_task_service.go
@@ -134,14 +134,20 @@ func (bts *buildTaskService) CreateBuildTask(ctx context.Context, req *interface
 	if req.EmbeddingModel == "" && req.EmbeddingFields != "" {
 		req.EmbeddingModel = interfaces.DEFAULT_EMBEDDING_MODEL
 	}
-	if req.EmbeddingModel != "" && req.ModelDimensions == 0 {
-		embeddingModel, err := bts.mfa.GetModelByName(ctx, req.EmbeddingModel)
-		if err != nil {
+	if req.EmbeddingModel != "" {
+		// embedding_model 统一归一化为模型 ID 存储：传入是模型名则解析为 ID 并补全维度；
+		// 传入已是模型 ID 时 GetModelByName 按名查不到（err != nil），此时若已带维度则原样保留为 ID。
+		// 既解析不到又没维度则无法建向量索引，按错误处理。
+		if embeddingModel, err := bts.mfa.GetModelByName(ctx, req.EmbeddingModel); err == nil {
+			req.EmbeddingModel = embeddingModel.ModelID
+			if req.ModelDimensions == 0 {
+				req.ModelDimensions = embeddingModel.EmbeddingDim
+			}
+		} else if req.ModelDimensions == 0 {
 			span.SetStatus(codes.Error, "Get model by name failed")
 			return "", rest.NewHTTPError(ctx, http.StatusInternalServerError, verrors.VegaBackend_BuildTask_InternalError_CreateFailed).
 				WithErrorDetails(err.Error())
 		}
-		req.ModelDimensions = embeddingModel.EmbeddingDim
 	}
 
 	now := time.Now().UnixMilli()
@@ -414,14 +420,19 @@ func (bts *buildTaskService) UpdateBuildTaskConfig(ctx context.Context, taskID s
 	if embeddingModel == "" && req.EmbeddingFields != "" {
 		embeddingModel = interfaces.DEFAULT_EMBEDDING_MODEL
 	}
-	if embeddingModel != "" && modelDimensions == 0 {
-		model, err := bts.mfa.GetModelByName(ctx, embeddingModel)
-		if err != nil {
+	if embeddingModel != "" {
+		// 归一化逻辑与 CreateBuildTask 对齐：embedding_model 统一存模型 ID。
+		// 传入是模型名则解析为 ID 并补全维度；传入已是 ID 时按名查不到，已带维度则原样保留。
+		if model, err := bts.mfa.GetModelByName(ctx, embeddingModel); err == nil {
+			embeddingModel = model.ModelID
+			if modelDimensions == 0 {
+				modelDimensions = model.EmbeddingDim
+			}
+		} else if modelDimensions == 0 {
 			span.SetStatus(codes.Error, "Get model by name failed")
 			return rest.NewHTTPError(ctx, http.StatusInternalServerError, verrors.VegaBackend_BuildTask_InternalError_CreateFailed).
 				WithErrorDetails(err.Error())
 		}
-		modelDimensions = model.EmbeddingDim
 	}
 
 	// 更新配置并置回 init：worker 出队执行时落 running，并对 full 重建 drop 旧索引

--- a/adp/vega/vega-backend/server/worker/build_handler_embedding.go
+++ b/adp/vega/vega-backend/server/worker/build_handler_embedding.go
@@ -331,9 +331,11 @@ func (eh *embeddingHandler) executeEmbedding(ctx context.Context, resource *inte
 					"status":          interfaces.BuildTaskStatusCompleted,
 					"vectorizedCount": finalCount,
 				}
-				// 重试耗尽的文档如实记录：完成态但向量不全时，error_msg 说明缺了哪些
+				// 重试耗尽的文档如实记录到 failure_detail（与 error_msg 区分：completed 但向量不全时，
+				// failure_detail 说明缺了哪些；error_msg 仅留给整任务硬失败）。显式置空以清除上一轮重建的陈旧明细。
+				updates["failureDetail"] = ""
 				if len(stillFailed) > 0 {
-					updates["errorMsg"] = formatVectorizeFailures(stillFailed)
+					updates["failureDetail"] = formatVectorizeFailures(stillFailed)
 				}
 				// 必须同时回写最终计数：常规回写有 30 秒批量窗口，
 				// 不在这里 flush 会丢最后一个窗口的进度（短任务界面会停在 0%）


### PR DESCRIPTION
## 背景

排查"索引构建任务能否看日志 / 前端能否获取"时，查看 VM 上两个 build task 暴露出两个问题。

## 坑1 — `f_embedding_model` 字段 id/name 混存

同一列有的任务存模型**名**（`text-embedding-v4`），有的存模型 **ID**（`2064382281006583808`）。根因：`CreateBuildTask` / `UpdateBuildTaskConfig` 仅在未传 `model_dimensions` 时才解析模型，且直接存客户端原值——传 id + 维度就原样进库未归一。

- 后果：前端/消费方无法确定字段格式，显示模型名需分支处理或反查；数据不一致。
- 运行时未炸，因为 mf-model-api 的 embeddings 端按 name/id 双查兜底。

**修复**：create + update 统一把 `embedding_model` 归一为模型 **ID** 存储。传入是模型名则解析为 ID 并补全维度；传入已是 ID（按名查不到）且带维度则原样保留；既解析不到又无维度则报错（向量索引必须有维度）。worker 的向量化调用不变。

## 坑2 — 部分向量化失败不可见 / `error_msg` 语义混用

某些文档向量化失败但任务整体 `completed` 时，失败明细被写进 `f_error_msg`——与"整任务硬失败"共用同一字段，消费方只能靠 status 区分。无独立的"部分失败明细"出口。

**修复**：新增 `t_build_task.f_failure_detail`（`TEXT NOT NULL DEFAULT ''`）。worker 完成时把逐文档失败摘要写入该列（干净跑显式清空，避免重建后残留陈旧明细），`error_msg` 只留给整任务硬失败。经现有 `GET /build-tasks/:id` 与列表端点的结构体自动带出，**不新增端点**。含 `init.sql` DDL（新装）与幂等 `ALTER` 迁移 `0.9.0/06`（升级）。

## 测试

- **单测**（`logics/build_task`）：name→id 归一、id 原样保留、无解析+无维度报错、edit 路径归一，4 个用例全过 + 原有用例全过。
- **VM 端到端**（全量 Dockerfile 构建镜像部署 + 迁移施于真实库）：
  - 坑2：存量任务 GET / LIST 全 200，迁移后存量行 `f_failure_detail` 非 NULL，scan 安全。
  - 坑1：在无任务表上建临时任务传模型名 `text-embedding-v4`，GET 回 `embedding_model=2064382281006583808`（ID）+ `model_dimensions=1024`，验证后清理。

## 注意

升级生产需走正规 data-migrator（迁移文件 `0.9.0/06` 已在分支内），勿用 `kubectl set image` 绕过 helm pre-upgrade hook，否则缺列。

🤖 Generated with [Claude Code](https://claude.com/claude-code)