### PR TITLE
feat(bkn-safe): 审计日志记录脱敏请求体 detail

### DIFF
--- a/bkn-safe/docs/admin-api-frontend-changes.md
+++ b/bkn-safe/docs/admin-api-frontend-changes.md
@@ -111,11 +111,12 @@ GET /api/safe/v1/admin/audit-logs
     {
       "id": "…",
       "actor_id": "<操作人 user id>",
-      "method": "DELETE",
-      "resource": "users",
-      "action": "users",
-      "target_id": "u-9",
-      "status": 404,            // 真实 HTTP 码，失败操作也记
+      "method": "POST",
+      "resource": "departments",
+      "action": "departments.members",
+      "target_id": "d-1",                    // 路由 :id（这里是部门 id）
+      "detail": "{\"user_ids\":[\"u-3\"]}",  // 脱敏后的请求体快照
+      "status": 204,
       "client_ip": "10.0.0.1",
       "created_at": "2026-06-17T08:30:00Z"
     }
@@ -126,7 +127,18 @@ GET /api/safe/v1/admin/audit-logs
 前端实现要点：
 
 - **谁做的**：`actor_id` 是 user id，不是名字。用 `POST /api/safe/v1/directory/names {user_ids:[...]}` 批量解析显示名。
-- **做了什么**：`action` 单独不区分增改删，靠 `method` 区分。建议前端做映射表渲染人话：
+- **对哪个对象**：`target_id` 是裸 id（部门/用户/角色 uuid），**必须解析成名字**再显示，否则就是一串 hex。按 `resource` 分流解析：
+  - `departments` → `POST /directory/names {department_ids:[target_id]}`
+  - `users` → `POST /directory/names {user_ids:[target_id]}`
+  - `roles` → 用 `GET /admin/roles` 的 id→name 映射
+  - `target_id` 为空（如新建类，无 `:id`）→ 对象列从 `detail` 取（见下）
+- **改了什么内容**：`detail` 是**脱敏 + 截断**的请求体 JSON 快照（字符串，需 `JSON.parse`）。`password`/`new_password`/`old_password` 已掩码成 `***`。用它补全 `target_id` 看不到的信息：
+  - 部门加人/移人 → `detail.user_ids`（再走 `/directory/names` 解析成人名，显示「把 张三、李四 加入 研发部」）
+  - 新建部门/用户 → `detail.name`（target_id 为空时对象列显示它，如「新建部门：研发部」）
+  - 改用户/部门 → `detail` 里有哪些 key 就是改了哪些字段
+  - 角色授权/撤权 → `detail.resource` + `detail.operations`
+  - `detail` 为 `""`（空体或非 JSON）→ 不显示内容行
+- **做了什么动作**：`action` 单独不区分增改删，靠 `method` 区分。建议前端做映射表渲染人话：
 
 | method | action | 显示 |
 |---|---|---|

--- a/bkn-safe/server/internal/audit/audit.go
+++ b/bkn-safe/server/internal/audit/audit.go
@@ -31,6 +31,7 @@ type Entry struct {
 	Resource string
 	Action   string
 	TargetID string
+	Detail   string
 	Status   int
 	ClientIP string
 }
@@ -45,6 +46,7 @@ func (s *Store) Record(ctx context.Context, e Entry) error {
 		Resource: e.Resource,
 		Action:   e.Action,
 		TargetID: e.TargetID,
+		Detail:   e.Detail,
 		Status:   e.Status,
 		ClientIP: e.ClientIP,
 	}

--- a/bkn-safe/server/internal/httpapi/admin_test.go
+++ b/bkn-safe/server/internal/httpapi/admin_test.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/gin-gonic/gin"
@@ -638,5 +639,51 @@ func TestUserDepartmentInlineSet(t *testing.T) {
 	if w := adminReq(t, r, http.MethodPut, "/api/safe/v1/admin/users/ghost",
 		map[string]any{"department_ids": []string{"d-1"}}); w.Code != http.StatusNotFound {
 		t.Errorf("depts update ghost user: want 404, got %d", w.Code)
+	}
+}
+
+func TestAuditDetailCapture(t *testing.T) {
+	r, _, db, users := newAdminServer(t)
+	if err := users.CreateLocalUser(t.Context(), &model.User{ID: "u-1", Account: "alice", Name: "Alice", Enabled: true}, "pw-init0"); err != nil {
+		t.Fatal(err)
+	}
+
+	// a create carries its body into Detail (so "新建部门" shows the name)
+	adminReq(t, r, http.MethodPost, "/api/safe/v1/admin/departments",
+		map[string]any{"id": "d-1", "name": "研发部"})
+	// a password reset must be recorded with the password MASKED
+	adminReq(t, r, http.MethodPut, "/api/safe/v1/admin/users/u-1/password",
+		map[string]any{"password": "s3cr3t-should-not-appear"})
+
+	detailFor := func(action string) string {
+		w := adminReq(t, r, http.MethodGet, "/api/safe/v1/admin/audit-logs?action="+action, nil)
+		var resp struct {
+			Logs []struct {
+				Detail string `json:"detail"`
+			} `json:"logs"`
+		}
+		_ = json.Unmarshal(w.Body.Bytes(), &resp)
+		if len(resp.Logs) != 1 {
+			t.Fatalf("action=%s: want 1 log, got %d", action, len(resp.Logs))
+		}
+		return resp.Logs[0].Detail
+	}
+
+	if d := detailFor("departments"); !strings.Contains(d, "研发部") {
+		t.Errorf("create-dept detail missing name: %q", d)
+	}
+	pw := detailFor("users.password")
+	if strings.Contains(pw, "s3cr3t-should-not-appear") {
+		t.Fatalf("password leaked into audit detail: %q", pw)
+	}
+	if !strings.Contains(pw, "***") {
+		t.Errorf("password not masked in audit detail: %q", pw)
+	}
+
+	// sanity: the password is also not anywhere in the raw stored column
+	var n int64
+	db.Model(&model.AuditLog{}).Where("detail LIKE ?", "%s3cr3t%").Count(&n)
+	if n != 0 {
+		t.Errorf("password substring found in %d audit rows", n)
 	}
 }

--- a/bkn-safe/server/internal/httpapi/audit.go
+++ b/bkn-safe/server/internal/httpapi/audit.go
@@ -1,6 +1,9 @@
 package httpapi
 
 import (
+	"bytes"
+	"encoding/json"
+	"io"
 	"net/http"
 	"strings"
 	"time"
@@ -12,17 +15,36 @@ import (
 
 const adminPathPrefix = "/api/safe/v1/admin/"
 
+// maxAuditBody caps how much of the request body the audit middleware buffers
+// for the Detail snapshot — enough for any normal admin payload, bounded so a
+// huge body can't blow up memory or the column.
+const maxAuditBody = 64 << 10
+
+// maxAuditDetail caps the stored Detail string (the column is 2048).
+const maxAuditDetail = 2000
+
+// sensitiveBodyKeys are masked in the audit Detail snapshot so credentials never
+// land in the trail.
+var sensitiveBodyKeys = []string{"password", "new_password", "old_password"}
+
 // auditMiddleware records every mutating (non-GET) admin request that reaches a
 // handler — i.e. one that already passed RequireAdmin, so the accessor id is
-// set. It runs the request first, then records the resulting status. Recording
-// errors are attached to the gin context (logged) but never fail the request:
-// auditing must not break the operation it audits. Read requests are skipped, so
-// the audit-log read endpoint itself produces no entries (no feedback loop).
+// set. It buffers the request body up front (restoring it for the handler), runs
+// the request, then records actor/action/target, the resulting status, and a
+// redacted Detail snapshot of the body. Recording errors are attached to the gin
+// context (logged) but never fail the request: auditing must not break the
+// operation it audits. Read requests are skipped, so the audit-log read endpoint
+// itself produces no entries (no feedback loop).
 func auditMiddleware(store *audit.Store) gin.HandlerFunc {
 	return func(c *gin.Context) {
+		var raw []byte
+		if isMutating(c.Request.Method) && c.Request.Body != nil {
+			// Buffer (bounded) then restore the body so the handler still reads it.
+			raw, _ = io.ReadAll(io.LimitReader(c.Request.Body, maxAuditBody))
+			c.Request.Body = io.NopCloser(bytes.NewReader(raw))
+		}
 		c.Next()
-		switch c.Request.Method {
-		case http.MethodGet, http.MethodHead, http.MethodOptions:
+		if !isMutating(c.Request.Method) {
 			return
 		}
 		resource, action := auditTarget(c.FullPath())
@@ -32,12 +54,49 @@ func auditMiddleware(store *audit.Store) gin.HandlerFunc {
 			Resource: resource,
 			Action:   action,
 			TargetID: c.Param("id"),
+			Detail:   auditDetail(raw),
 			Status:   c.Writer.Status(),
 			ClientIP: c.ClientIP(),
 		}); err != nil {
 			_ = c.Error(err)
 		}
 	}
+}
+
+// isMutating reports whether the method is a write the audit trail records.
+func isMutating(method string) bool {
+	switch method {
+	case http.MethodGet, http.MethodHead, http.MethodOptions:
+		return false
+	}
+	return true
+}
+
+// auditDetail turns a JSON request body into a redacted, truncated snapshot for
+// the audit Detail column: sensitive keys are masked, the rest is preserved so a
+// reader can see WHAT changed. Returns "" for an empty or non-object body (no
+// useful detail to record).
+func auditDetail(raw []byte) string {
+	if len(raw) == 0 {
+		return ""
+	}
+	var m map[string]any
+	if err := json.Unmarshal(raw, &m); err != nil {
+		return "" // array/scalar/invalid — nothing structured to summarize
+	}
+	for _, k := range sensitiveBodyKeys {
+		if _, ok := m[k]; ok {
+			m[k] = "***"
+		}
+	}
+	b, err := json.Marshal(m)
+	if err != nil {
+		return ""
+	}
+	if len(b) > maxAuditDetail {
+		return string(b[:maxAuditDetail])
+	}
+	return string(b)
 }
 
 // auditTarget derives the resource (top-level admin noun) and action (dotted

--- a/bkn-safe/server/internal/model/model.go
+++ b/bkn-safe/server/internal/model/model.go
@@ -123,18 +123,23 @@ type Operation struct {
 }
 
 // AuditLog records a privileged admin-API mutation: who (ActorID, the verified
-// token subject), what (Method + Resource + Action + TargetID), and the outcome
-// (Status). One row per non-GET request that passes RequireAdmin; reads are not
-// audited. Method distinguishes create/update/delete on the same Action (e.g.
-// POST vs PUT vs DELETE on "users").
+// token subject), what (Method + Resource + Action + TargetID + Detail), and the
+// outcome (Status). One row per non-GET request that passes RequireAdmin; reads
+// are not audited. Method distinguishes create/update/delete on the same Action
+// (e.g. POST vs PUT vs DELETE on "users").
 type AuditLog struct {
-	ID        string    `json:"id" gorm:"primaryKey;size:64"`
-	ActorID   string    `json:"actor_id" gorm:"size:64;index"`   // token subject that performed the action
-	Method    string    `json:"method" gorm:"size:8"`            // POST | PUT | DELETE
-	Resource  string    `json:"resource" gorm:"size:64;index"`   // top-level admin noun, e.g. "users"
-	Action    string    `json:"action" gorm:"size:128;index"`    // dotted route, e.g. "departments.members"
-	TargetID  string    `json:"target_id" gorm:"size:128;index"` // :id path param, "" when the route has none
-	Status    int       `json:"status"`                          // HTTP status code of the response
+	ID       string `json:"id" gorm:"primaryKey;size:64"`
+	ActorID  string `json:"actor_id" gorm:"size:64;index"`   // token subject that performed the action
+	Method   string `json:"method" gorm:"size:8"`            // POST | PUT | DELETE
+	Resource string `json:"resource" gorm:"size:64;index"`   // top-level admin noun, e.g. "users"
+	Action   string `json:"action" gorm:"size:128;index"`    // dotted route, e.g. "departments.members"
+	TargetID string `json:"target_id" gorm:"size:128;index"` // :id path param, "" when the route has none
+	// Detail is a redacted, truncated JSON snapshot of the request body (password
+	// fields masked), so a reader can tell WHAT changed — which users a
+	// department gained, a created node's name, etc. "" when the body is
+	// empty/non-JSON.
+	Detail    string    `json:"detail" gorm:"size:2048"`
+	Status    int       `json:"status"` // HTTP status code of the response
 	ClientIP  string    `json:"client_ip" gorm:"size:64"`
 	CreatedAt time.Time `json:"created_at" gorm:"index"`
 }


### PR DESCRIPTION
审计日志此前只记 谁/动作/对象id/状态，看不出**具体改了什么**：「部门加人」不知加了谁、「新建部门」对象为空（新建 id 在响应里、非路由参数）。

新增 `detail` 列：中间件缓冲请求体（有界，随后回填给 handler），存**脱敏+截断**的 JSON 快照 —— `password`/`new_password`/`old_password` 掩码为 `***`，凭据绝不入库。

效果：成员加人 `{"user_ids":[...]}`、新建 `{"name":"研发部"}`、重置密码 `{"password":"***"}`。

- `AutoMigrate` 启动时给 `audit_logs` 加 `detail` 列，无需手动迁移。
- 测试覆盖建库 body 捕获 + 密码掩码（含原始列扫描断言密钥不落库）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)