### PR TITLE
feat(agent-retrieval): MCP query tools (run_sql, list/detail KN), info endpoint, instance pagination

### DIFF
--- a/adp/bkn/ontology-query/server/interfaces/common.go
+++ b/adp/bkn/ontology-query/server/interfaces/common.go
@@ -107,6 +107,8 @@ type PageQuery struct {
 	// 分页信息
 	NeedTotal bool `json:"need_total"`
 	Limit     int  `json:"limit"`
+	// Offset 偏移翻页：仅资源（vega 表源）路径生效；与 search_after 互斥（传了 search_after 时被忽略）。
+	Offset int `json:"offset"`
 	// UseSearchAfter bool          `json:"use_search_after"` // 业务知识网络只提供search after的方式，不需要提供这个参数
 	Sort []*SortParams `json:"sort"`
 	SearchAfterParams

--- a/adp/bkn/ontology-query/server/logics/object_type/object_type_service.go
+++ b/adp/bkn/ontology-query/server/logics/object_type/object_type_service.go
@@ -466,6 +466,7 @@ func (ots *objectTypeService) getObjectsFromResource(ctx context.Context, query 
 	params := &interfaces.ResourceDataQueryParams{
 		NeedTotal:       query.NeedTotal,
 		Limit:           query.Limit,
+		Offset:          query.Offset,
 		Sort:            resourceSort,
 		SearchAfter:     query.SearchAfter,
 		FilterCondition: logics.CondCfgToFilterMap(viewQuery.Filters),

--- a/adp/context-loader/agent-retrieval/helm/agent-retrieval/templates/configmap.yaml
+++ b/adp/context-loader/agent-retrieval/helm/agent-retrieval/templates/configmap.yaml
@@ -43,6 +43,10 @@ data:
       private_protocol: {{ index .Values "depServices" "ontology-query" "privateProtocol" | quote }}
       private_host: {{ index .Values "depServices" "ontology-query" "privateHost" | quote }}
       private_port: {{ index .Values "depServices" "ontology-query" "privatePort" }}
+    vega:
+      private_protocol: {{ index .Values "depServices" "vega-backend" "privateProtocol" | quote }}
+      private_host: {{ index .Values "depServices" "vega-backend" "privateHost" | quote }}
+      private_port: {{ index .Values "depServices" "vega-backend" "privatePort" }}
     operator_integration:
       private_protocol: {{ index .Values "depServices" "agent-operator-integration" "privateProtocol" | quote }}
       private_host: {{ index .Values "depServices" "agent-operator-integration" "privateHost" | quote }}

--- a/adp/context-loader/agent-retrieval/helm/agent-retrieval/values.yaml
+++ b/adp/context-loader/agent-retrieval/helm/agent-retrieval/values.yaml
@@ -114,6 +114,10 @@ depServices:
     privateHost: ontology-query-svc
     privatePort: 13018
     privateProtocol: http
+  vega-backend:
+    privateHost: vega-backend-svc
+    privatePort: 13014
+    privateProtocol: http
   agent-operator-integration:
     privateHost: agent-operator-integration
     privatePort: 9000

--- a/adp/context-loader/agent-retrieval/server/drivenadapters/bkn_backend.go
+++ b/adp/context-loader/agent-retrieval/server/drivenadapters/bkn_backend.go
@@ -48,6 +48,68 @@ func NewBknBackendAccess() interfaces.BknBackendAccess {
 	return bknAccess
 }
 
+// ListKnowledgeNetworks 列出知识网络（GET /in/v1/knowledge-networks），用于让外部发现 kn_id。
+func (b *bknBackendAccess) ListKnowledgeNetworks(ctx context.Context, req *interfaces.ListKnReq) (resp *interfaces.ListKnResp, err error) {
+	src := fmt.Sprintf("%s/in/v1/knowledge-networks", b.baseURL)
+	header := common.GetHeaderFromCtx(ctx)
+	header[rest.ContentTypeKey] = rest.ContentTypeJSON
+
+	queryValues := url.Values{}
+	if req != nil {
+		if req.NamePattern != "" {
+			queryValues.Set("name_pattern", req.NamePattern)
+		}
+		if req.Limit > 0 {
+			queryValues.Set("limit", strconv.Itoa(req.Limit))
+		}
+		if req.Offset > 0 {
+			queryValues.Set("offset", strconv.Itoa(req.Offset))
+		}
+		if req.Sort != "" {
+			queryValues.Set("sort", req.Sort)
+		}
+		if req.Direction != "" {
+			queryValues.Set("direction", req.Direction)
+		}
+	}
+
+	respCode, respBody, err := b.httpClient.GetNoUnmarshal(ctx, src, queryValues, header)
+	if err != nil {
+		b.logger.WithContext(ctx).Errorf("[BknBackendAccess] ListKnowledgeNetworks request failed, err: %v", err)
+		return nil, infraErr.DefaultHTTPError(ctx, respCode,
+			fmt.Sprintf("[BknBackendAccess] ListKnowledgeNetworks request failed, err: %v", err))
+	}
+
+	if (respCode < http.StatusOK) || (respCode >= http.StatusMultipleChoices) {
+		b.logger.Errorf("[BknBackendAccess] ListKnowledgeNetworks get resp failed, [%s], %v\n", src, respBody)
+
+		var baseError interfaces.KnBaseError
+		if err := sonic.Unmarshal(respBody, &baseError); err != nil {
+			b.logger.Errorf("unmarshal KnBaseError failed: %v\n", err)
+			return nil, err
+		}
+
+		return nil, &infraErr.HTTPError{
+			HTTPCode:     respCode,
+			Code:         baseError.ErrorCode,
+			Description:  baseError.Description,
+			Solution:     baseError.Solution,
+			ErrorLink:    baseError.ErrorLink,
+			ErrorDetails: baseError.ErrorDetails,
+		}
+	}
+
+	resp = &interfaces.ListKnResp{}
+	if len(respBody) == 0 {
+		return resp, nil
+	}
+	if err := sonic.Unmarshal(respBody, resp); err != nil {
+		b.logger.Errorf("[BknBackendAccess] ListKnowledgeNetworks unmarshal response failed: %v\n", err)
+		return nil, err
+	}
+	return resp, nil
+}
+
 // GetKnowledgeNetworkDetail 获取知识网络详情（include_detail=true, mode=export）
 // 对应 Python 的 _get_knowledge_network_detail
 func (b *bknBackendAccess) GetKnowledgeNetworkDetail(ctx context.Context, knID string) (*interfaces.KnowledgeNetworkDetail, error) {

--- a/adp/context-loader/agent-retrieval/server/drivenadapters/vega.go
+++ b/adp/context-loader/agent-retrieval/server/drivenadapters/vega.go
@@ -1,0 +1,138 @@
+// Copyright 2026 openbkn.ai
+// Copyright The kweaver.ai Authors.
+//
+// Licensed under the Apache License, Version 2.0.
+// See the LICENSE file in the project root for details.
+
+package drivenadapters
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/url"
+	"sync"
+
+	"github.com/bytedance/sonic"
+
+	"github.com/openbkn-ai/adp/context-loader/agent-retrieval/server/infra/common"
+	"github.com/openbkn-ai/adp/context-loader/agent-retrieval/server/infra/config"
+	infraErr "github.com/openbkn-ai/adp/context-loader/agent-retrieval/server/infra/errors"
+	"github.com/openbkn-ai/adp/context-loader/agent-retrieval/server/infra/rest"
+	"github.com/openbkn-ai/adp/context-loader/agent-retrieval/server/interfaces"
+)
+
+type vegaAccess struct {
+	logger     interfaces.Logger
+	baseURL    string
+	httpClient interfaces.HTTPClient
+}
+
+var (
+	vegaAccessOnce sync.Once
+	vegaAccessInst interfaces.DrivenVega
+)
+
+// NewVegaAccess 创建 vega 后端访问对象（只读查询）。
+func NewVegaAccess() interfaces.DrivenVega {
+	vegaAccessOnce.Do(func() {
+		conf := config.NewConfigLoader()
+		vegaAccessInst = &vegaAccess{
+			logger:     conf.GetLogger(),
+			baseURL:    conf.Vega.BuildURL("/api/vega-backend"),
+			httpClient: rest.NewHTTPClient(),
+		}
+	})
+	return vegaAccessInst
+}
+
+// RawQuery 调用 vega 内网原始查询接口执行 SQL。
+func (v *vegaAccess) RawQuery(ctx context.Context, req *interfaces.VegaRawQueryReq) (*interfaces.VegaRawQueryResp, error) {
+	src := fmt.Sprintf("%s/in/v1/resources/query", v.baseURL)
+	header := common.GetHeaderFromCtx(ctx)
+	header[rest.ContentTypeKey] = rest.ContentTypeJSON
+
+	respCode, respBody, err := v.httpClient.PostNoUnmarshal(ctx, src, header, req)
+	if err != nil {
+		v.logger.WithContext(ctx).Errorf("[VegaAccess] RawQuery request failed, err: %v", err)
+		return nil, infraErr.DefaultHTTPError(ctx, respCode,
+			fmt.Sprintf("[VegaAccess] RawQuery request failed, err: %v", err))
+	}
+	if (respCode < http.StatusOK) || (respCode >= http.StatusMultipleChoices) {
+		v.logger.WithContext(ctx).Errorf("[VegaAccess] RawQuery resp failed, code=%d, body=%s", respCode, string(respBody))
+		return nil, infraErr.DefaultHTTPError(ctx, respCode,
+			fmt.Sprintf("vega raw query failed: %s", string(respBody)))
+	}
+
+	resp := &interfaces.VegaRawQueryResp{}
+	if len(respBody) == 0 {
+		return resp, nil
+	}
+	if err := sonic.Unmarshal(respBody, resp); err != nil {
+		v.logger.WithContext(ctx).Errorf("[VegaAccess] RawQuery unmarshal failed: %v", err)
+		return nil, infraErr.DefaultHTTPError(ctx, http.StatusInternalServerError,
+			fmt.Sprintf("parse vega raw query response failed: %v", err))
+	}
+	return resp, nil
+}
+
+// vegaEntriesWrapper vega get-by-ids 接口统一的 {"entries":[...]} 信封。
+type vegaResourceLite struct {
+	ID        string `json:"id"`
+	CatalogID string `json:"catalog_id"`
+}
+
+type vegaResourceEnvelope struct {
+	Entries []vegaResourceLite `json:"entries"`
+}
+
+type vegaCatalogLite struct {
+	ID            string `json:"id"`
+	ConnectorType string `json:"connector_type"`
+}
+
+type vegaCatalogEnvelope struct {
+	Entries []vegaCatalogLite `json:"entries"`
+}
+
+// GetResourceConnectorType resource_id -> catalog_id -> connector_type（两跳）。
+func (v *vegaAccess) GetResourceConnectorType(ctx context.Context, resourceID string) (string, error) {
+	header := common.GetHeaderFromCtx(ctx)
+	header[rest.ContentTypeKey] = rest.ContentTypeJSON
+
+	// 1) resource -> catalog_id
+	resSrc := fmt.Sprintf("%s/in/v1/resources/%s", v.baseURL, url.PathEscape(resourceID))
+	code, body, err := v.httpClient.GetNoUnmarshal(ctx, resSrc, url.Values{}, header)
+	if err != nil || code < http.StatusOK || code >= http.StatusMultipleChoices {
+		return "", infraErr.DefaultHTTPError(ctx, code,
+			fmt.Sprintf("[VegaAccess] get resource %s failed: code=%d, err=%v, body=%s", resourceID, code, err, string(body)))
+	}
+	var resEnv vegaResourceEnvelope
+	if err := sonic.Unmarshal(body, &resEnv); err != nil {
+		return "", infraErr.DefaultHTTPError(ctx, http.StatusInternalServerError,
+			fmt.Sprintf("parse vega resource response failed: %v", err))
+	}
+	if len(resEnv.Entries) == 0 || resEnv.Entries[0].CatalogID == "" {
+		return "", infraErr.DefaultHTTPError(ctx, http.StatusBadRequest,
+			fmt.Sprintf("resource %s not found or has no catalog", resourceID))
+	}
+	catalogID := resEnv.Entries[0].CatalogID
+
+	// 2) catalog -> connector_type
+	catSrc := fmt.Sprintf("%s/in/v1/catalogs/%s", v.baseURL, url.PathEscape(catalogID))
+	code, body, err = v.httpClient.GetNoUnmarshal(ctx, catSrc, url.Values{}, header)
+	if err != nil || code < http.StatusOK || code >= http.StatusMultipleChoices {
+		return "", infraErr.DefaultHTTPError(ctx, code,
+			fmt.Sprintf("[VegaAccess] get catalog %s failed: code=%d, err=%v, body=%s", catalogID, code, err, string(body)))
+	}
+	var catEnv vegaCatalogEnvelope
+	if err := sonic.Unmarshal(body, &catEnv); err != nil {
+		return "", infraErr.DefaultHTTPError(ctx, http.StatusInternalServerError,
+			fmt.Sprintf("parse vega catalog response failed: %v", err))
+	}
+	if len(catEnv.Entries) == 0 || catEnv.Entries[0].ConnectorType == "" {
+		return "", infraErr.DefaultHTTPError(ctx, http.StatusBadRequest,
+			fmt.Sprintf("catalog %s not found or has no connector_type", catalogID))
+	}
+	return catEnv.Entries[0].ConnectorType, nil
+}

--- a/adp/context-loader/agent-retrieval/server/driveradapters/mcp/app.go
+++ b/adp/context-loader/agent-retrieval/server/driveradapters/mcp/app.go
@@ -33,6 +33,9 @@ const (
 	toolKeyGetLogicPropertiesValues = "get_logic_properties_values"
 	toolKeyGetActionInfo            = "get_action_info"
 	toolKeyFindSkills               = "find_skills"
+	toolKeyListKnowledgeNetworks    = "list_knowledge_networks"
+	toolKeyGetKnDetail              = "get_kn_detail"
+	toolKeyRunSQL                   = "run_sql"
 )
 
 // NewMCPHandler creates an http.Handler for the MCP Streamable HTTP Server.
@@ -88,6 +91,29 @@ func NewMCPHandler() http.Handler {
 	mcpServer.AddTool(
 		newToolWithSchemas(findSkillsName, findSkillsDesc, fsInput, fsOutput),
 		handleFindSkills(findSkillsService),
+	)
+
+	bknBackend := drivenadapters.NewBknBackendAccess()
+	listKnName, listKnDesc := loadToolMeta(toolKeyListKnowledgeNetworks)
+	listKnInput, listKnOutput := loadToolSchemas(toolKeyListKnowledgeNetworks)
+	mcpServer.AddTool(
+		newToolWithSchemas(listKnName, listKnDesc, listKnInput, listKnOutput),
+		handleListKnowledgeNetworks(bknBackend),
+	)
+
+	getKnDetailName, getKnDetailDesc := loadToolMeta(toolKeyGetKnDetail)
+	knDetailInput, knDetailOutput := loadToolSchemas(toolKeyGetKnDetail)
+	mcpServer.AddTool(
+		newToolWithSchemas(getKnDetailName, getKnDetailDesc, knDetailInput, knDetailOutput),
+		handleGetKnDetail(bknBackend),
+	)
+
+	vegaAccess := drivenadapters.NewVegaAccess()
+	runSQLName, runSQLDesc := loadToolMeta(toolKeyRunSQL)
+	runSQLInput, runSQLOutput := loadToolSchemas(toolKeyRunSQL)
+	mcpServer.AddTool(
+		newToolWithSchemas(runSQLName, runSQLDesc, runSQLInput, runSQLOutput),
+		handleRunSQL(vegaAccess),
 	)
 
 	streamableServer := server.NewStreamableHTTPServer(mcpServer,

--- a/adp/context-loader/agent-retrieval/server/driveradapters/mcp/info.go
+++ b/adp/context-loader/agent-retrieval/server/driveradapters/mcp/info.go
@@ -1,0 +1,101 @@
+// Copyright 2026 openbkn.ai
+// Copyright The kweaver.ai Authors.
+//
+// Licensed under the Apache License, Version 2.0.
+// See the LICENSE file in the project root for details.
+
+package mcp
+
+import (
+	"encoding/json"
+	"fmt"
+	"sort"
+)
+
+// MCPToolInfo 单个工具的对外说明（名称 / 描述 / 输入输出 schema）。
+type MCPToolInfo struct {
+	Name         string          `json:"name"`
+	Description  string          `json:"description"`
+	InputSchema  json.RawMessage `json:"input_schema,omitempty"`
+	OutputSchema json.RawMessage `json:"output_schema,omitempty"`
+}
+
+// MCPInfo MCP 服务自描述文档：端点、协议、鉴权、工具目录、客户端配置示例。
+// 供 Agent / 人通过 GET 一次性了解如何集成，无需先走 MCP 握手。
+type MCPInfo struct {
+	Service             string          `json:"service"`
+	Endpoint            string          `json:"endpoint"`
+	Protocol            string          `json:"protocol"`
+	Transport           string          `json:"transport"`
+	Auth                string          `json:"auth"`
+	ToolCount           int             `json:"tool_count"`
+	Tools               []MCPToolInfo   `json:"tools"`
+	ClientConfigExample json.RawMessage `json:"client_config_example"`
+}
+
+// tryLoadToolSchemas 与 loadToolSchemas 同源，但读不到/解析失败时返回 nil 而非 panic，
+// 供 info 端点容错使用。
+func tryLoadToolSchemas(toolKey string) (input, output json.RawMessage) {
+	data, err := schemasFS.ReadFile(fmt.Sprintf("schemas/%s.json", toolKey))
+	if err != nil {
+		return nil, nil
+	}
+	var wrapper toolSchemaFile
+	if err := json.Unmarshal(data, &wrapper); err != nil {
+		return nil, nil
+	}
+	return wrapper.InputSchema, wrapper.OutputSchema
+}
+
+// BuildMCPInfo 基于内嵌的 tools_meta.json + schemas/*.json 组装 MCP 自描述文档。
+// endpoint 为本服务对外的 MCP Streamable HTTP 地址。
+func BuildMCPInfo(endpoint string) (*MCPInfo, error) {
+	data, err := schemasFS.ReadFile("schemas/tools_meta.json")
+	if err != nil {
+		return nil, fmt.Errorf("read tools_meta.json: %w", err)
+	}
+	var meta map[string]ToolMeta
+	if err := json.Unmarshal(data, &meta); err != nil {
+		return nil, fmt.Errorf("parse tools_meta.json: %w", err)
+	}
+
+	keys := make([]string, 0, len(meta))
+	for k := range meta {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+
+	tools := make([]MCPToolInfo, 0, len(keys))
+	for _, key := range keys {
+		m := meta[key]
+		in, out := tryLoadToolSchemas(key)
+		tools = append(tools, MCPToolInfo{
+			Name:         m.Name,
+			Description:  m.Description,
+			InputSchema:  in,
+			OutputSchema: out,
+		})
+	}
+
+	cfg, _ := json.Marshal(map[string]any{
+		"mcpServers": map[string]any{
+			serverName: map[string]any{
+				"url": endpoint,
+				"headers": map[string]string{
+					"Authorization": "Bearer <access-token>",
+				},
+			},
+		},
+	})
+
+	return &MCPInfo{
+		Service:             serverName,
+		Endpoint:            endpoint,
+		Protocol:            "MCP / JSON-RPC 2.0 (initialize → tools/list → tools/call)",
+		Transport:           "Streamable HTTP",
+		Auth:                "Bearer token via Authorization header",
+		ToolCount:           len(tools),
+		Tools:               tools,
+		ClientConfigExample: cfg,
+	}, nil
+}

--- a/adp/context-loader/agent-retrieval/server/driveradapters/mcp/schemas/get_kn_detail.json
+++ b/adp/context-loader/agent-retrieval/server/driveradapters/mcp/schemas/get_kn_detail.json
@@ -1,0 +1,30 @@
+{
+  "input_schema": {
+    "type": "object",
+    "properties": {
+      "response_format": {
+        "type": "string",
+        "enum": ["json", "toon"],
+        "default": "toon",
+        "description": "文本格式：json 或 toon，默认 toon"
+      },
+      "kn_id": {
+        "type": "string",
+        "description": "知识网络 ID。也可改用 X-Kn-ID 请求头传入。"
+      }
+    },
+    "required": ["kn_id"]
+  },
+  "output_schema": {
+    "type": "object",
+    "properties": {
+      "id": { "type": "string", "description": "知识网络 ID" },
+      "name": { "type": "string", "description": "知识网络名称" },
+      "comment": { "type": "string", "description": "描述" },
+      "concept_groups": { "type": "array", "items": { "type": "object", "additionalProperties": true }, "description": "概念组" },
+      "object_types": { "type": "array", "items": { "type": "object", "additionalProperties": true }, "description": "对象类型（含 data_source 等）" },
+      "relation_types": { "type": "array", "items": { "type": "object", "additionalProperties": true }, "description": "关系类型" },
+      "action_types": { "type": "array", "items": { "type": "object", "additionalProperties": true }, "description": "行动类型" }
+    }
+  }
+}

--- a/adp/context-loader/agent-retrieval/server/driveradapters/mcp/schemas/list_knowledge_networks.json
+++ b/adp/context-loader/agent-retrieval/server/driveradapters/mcp/schemas/list_knowledge_networks.json
@@ -1,0 +1,58 @@
+{
+  "input_schema": {
+    "type": "object",
+    "properties": {
+      "response_format": {
+        "type": "string",
+        "enum": ["json", "toon"],
+        "default": "toon",
+        "description": "文本格式：json 或 toon，默认 toon"
+      },
+      "name_pattern": {
+        "type": "string",
+        "description": "按知识网络名称模糊过滤，可选"
+      },
+      "limit": {
+        "type": "integer",
+        "description": "单页数量，默认 20"
+      },
+      "offset": {
+        "type": "integer",
+        "description": "偏移量，用于翻页，默认 0"
+      },
+      "sort": {
+        "type": "string",
+        "description": "排序字段，默认 update_time"
+      },
+      "direction": {
+        "type": "string",
+        "enum": ["asc", "desc"],
+        "description": "排序方向，默认 desc"
+      }
+    }
+  },
+  "output_schema": {
+    "type": "object",
+    "properties": {
+      "entries": {
+        "type": "array",
+        "description": "知识网络列表",
+        "items": {
+          "type": "object",
+          "properties": {
+            "id": { "type": "string", "description": "知识网络 ID（即 kn_id，供其余查询工具使用）" },
+            "name": { "type": "string", "description": "知识网络名称" },
+            "description": { "type": "string", "description": "描述" },
+            "module_type": { "type": "string", "description": "模块类型" },
+            "business_domain": { "type": "string", "description": "业务域" }
+          },
+          "additionalProperties": true
+        }
+      },
+      "total_count": {
+        "type": "integer",
+        "description": "命中总数"
+      }
+    }
+  }
+}

--- a/adp/context-loader/agent-retrieval/server/driveradapters/mcp/schemas/query_object_instance.json
+++ b/adp/context-loader/agent-retrieval/server/driveradapters/mcp/schemas/query_object_instance.json
@@ -23,7 +23,16 @@
       },
       "limit": {
         "type": "integer",
-        "description": "返回数量限制，默认 10，范围 1-10000"
+        "description": "单页返回数量，默认 10，范围 1-10000"
+      },
+      "search_after": {
+        "type": "array",
+        "items": {},
+        "description": "游标分页（对象索引/数据视图路径）：传上一次响应返回的 search_after 取下一页；首次不传。仅顺翻，不跳页。"
+      },
+      "offset": {
+        "type": "integer",
+        "description": "偏移翻页（资源/vega 表源路径）：跳过前 N 条，支持跳到任意页。与 search_after 互斥（同传时 search_after 优先）。"
       },
       "properties": {
         "type": "array",
@@ -45,6 +54,15 @@
           "type": "object",
           "additionalProperties": true
         }
+      },
+      "total_count": {
+        "type": "integer",
+        "description": "命中总数（仅在底层启用 need_total 时有效）"
+      },
+      "search_after": {
+        "type": "array",
+        "items": {},
+        "description": "下一页游标：非空时作为下次请求的 search_after 传入以取下一页；为空表示已无更多数据。"
       }
     }
   }

--- a/adp/context-loader/agent-retrieval/server/driveradapters/mcp/schemas/run_sql.json
+++ b/adp/context-loader/agent-retrieval/server/driveradapters/mcp/schemas/run_sql.json
@@ -1,0 +1,54 @@
+{
+  "input_schema": {
+    "type": "object",
+    "properties": {
+      "response_format": {
+        "type": "string",
+        "enum": ["json", "toon"],
+        "default": "toon",
+        "description": "文本格式：json 或 toon，默认 toon"
+      },
+      "sql": {
+        "type": "string",
+        "description": "只读 SQL（Trino 方言）。表名必须用占位符 {{.resource_id}} 引用，resource_id 取自对象类的 data_source.id（可经 search_schema 获得）。仅允许 SELECT / WITH，禁止任何写入与 DDL；不支持多语句；不支持跨数据目录 join（单次查询涉及的资源需同属一个 catalog）。vega 会自动限量（最多 10000 行）。"
+      },
+      "resource_type": {
+        "type": "string",
+        "description": "连接器类型（mysql / mariadb / postgresql）。留空则按 SQL 中第一个 {{.resource_id}} 自动解析，一般无需填写。"
+      },
+      "query_timeout": {
+        "type": "integer",
+        "description": "查询超时（秒），范围 1-3600，默认 60。可选。"
+      }
+    },
+    "required": ["sql"]
+  },
+  "output_schema": {
+    "type": "object",
+    "properties": {
+      "columns": {
+        "type": "array",
+        "description": "结果列信息",
+        "items": {
+          "type": "object",
+          "properties": {
+            "name": { "type": "string" },
+            "type": { "type": "string" }
+          },
+          "additionalProperties": true
+        }
+      },
+      "entries": {
+        "type": "array",
+        "description": "结果行",
+        "items": { "type": "object", "additionalProperties": true }
+      },
+      "total_count": { "type": "integer", "description": "返回行数" },
+      "warnings": {
+        "type": "array",
+        "items": { "type": "string" },
+        "description": "非致命告警（如资源已弃用）"
+      }
+    }
+  }
+}

--- a/adp/context-loader/agent-retrieval/server/driveradapters/mcp/schemas/tools_meta.json
+++ b/adp/context-loader/agent-retrieval/server/driveradapters/mcp/schemas/tools_meta.json
@@ -5,7 +5,7 @@
   },
   "query_object_instance": {
     "name": "query_object_instance",
-    "description": "单对象类实例过滤查询。已知对象类与过滤条件时，查询实例列表。"
+    "description": "单对象类实例过滤查询。已知对象类与过滤条件时，查询实例列表。支持 search_after 游标顺序翻页（用上一页返回的 search_after 取下一页，不支持跳页）。"
   },
   "query_instance_subgraph": {
     "name": "query_instance_subgraph",
@@ -22,5 +22,17 @@
   "find_skills": {
     "name": "find_skills",
     "description": "技能召回。根据知识网络、对象类型、实例上下文等召回匹配的可用技能列表。"
+  },
+  "list_knowledge_networks": {
+    "name": "list_knowledge_networks",
+    "description": "列出可用的知识网络（返回 kn_id、名称、描述）。其余查询工具均需 kn_id，作为探索的第一步入口。"
+  },
+  "get_kn_detail": {
+    "name": "get_kn_detail",
+    "description": "获取知识网络完整详情（直接包装 bkn-backend）：概念组、对象类型（含 data_source.id）、关系类型、行动类型。已知 kn_id 时一次性拿全量 schema。"
+  },
+  "run_sql": {
+    "name": "run_sql",
+    "description": "对知识网络挂载的数据资源执行只读 SQL（Trino 方言）。表名用占位符 {{.resource_id}} 引用（resource_id 取自对象类的 data_source.id，可由 search_schema 获得）；vega 会解析成真实表并限量。仅允许 SELECT/WITH，禁止写入/DDL；单次查询的资源需同属一个数据目录（不支持跨目录 join）。"
   }
 }

--- a/adp/context-loader/agent-retrieval/server/driveradapters/mcp/sql_guard.go
+++ b/adp/context-loader/agent-retrieval/server/driveradapters/mcp/sql_guard.go
@@ -1,0 +1,128 @@
+// Copyright 2026 openbkn.ai
+// Copyright The kweaver.ai Authors.
+//
+// Licensed under the Apache License, Version 2.0.
+// See the LICENSE file in the project root for details.
+
+package mcp
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+)
+
+// run_sql 工具的只读 SQL 守卫。
+//
+// vega 的原始查询接口不校验语句类型（INSERT/UPDATE/DELETE/DDL 均会真正执行），
+// 对外只读 MCP 必须在工具层强制 SELECT-only。这里用「剥离注释与字符串字面量后再做词法判定」的
+// 方式做纵深防御：先消除可藏关键字的注释/字符串/占位符，再要求单语句、以 SELECT/WITH 开头、
+// 且不含任何写/DDL 关键字。它不是完整 SQL 解析器，但配合 vega 端的 LIMIT 兜底足以防住越权写。
+
+var (
+	// resourcePlaceholderRe 与 vega extractResourceIDs 保持一致：{{.resource_id}} 或 {{resource_id}}。
+	resourcePlaceholderRe = regexp.MustCompile(`\{\{\.?(\w+)\}\}`)
+	// anyPlaceholderRe 用于在做关键字判定前把占位符整体替换掉，避免 {{.delete}} 之类内部词触发误判。
+	anyPlaceholderRe = regexp.MustCompile(`\{\{[^}]*\}\}`)
+	// startsWithSelectRe 允许前导空白与左括号（如 (SELECT ...) UNION ...）。
+	startsWithSelectRe = regexp.MustCompile(`(?is)^[\s(]*(SELECT|WITH)\b`)
+	// forbiddenKeywordRe 写入 / DDL / 权限 / 过程类关键字黑名单（剥离注释与字符串后判定）。
+	forbiddenKeywordRe = regexp.MustCompile(`(?i)\b(INSERT|UPDATE|DELETE|DROP|ALTER|CREATE|TRUNCATE|GRANT|REVOKE|REPLACE|MERGE|UPSERT|CALL|EXEC|EXECUTE|RENAME|LOAD|COPY|INTO|ATTACH|DETACH|USE|VACUUM|ANALYZE|REFRESH|COMMENT|PREPARE|DEALLOCATE)\b`)
+)
+
+// extractResourceIDs 从 SQL 中提取所有 {{.resource_id}} 占位符内的 resource_id（去重，保序）。
+func extractResourceIDs(sql string) []string {
+	matches := resourcePlaceholderRe.FindAllStringSubmatch(sql, -1)
+	ids := make([]string, 0, len(matches))
+	seen := make(map[string]bool)
+	for _, m := range matches {
+		if len(m) > 1 && !seen[m[1]] {
+			seen[m[1]] = true
+			ids = append(ids, m[1])
+		}
+	}
+	return ids
+}
+
+// stripSQLNoise 去除行注释(-- 与 #)、块注释(/* */)、单引号字符串与反引号标识符，
+// 以免其中藏有关键字或分号干扰守卫判定。
+func stripSQLNoise(sql string) string {
+	var b strings.Builder
+	runes := []rune(sql)
+	n := len(runes)
+	for i := 0; i < n; i++ {
+		c := runes[i]
+		switch {
+		case c == '-' && i+1 < n && runes[i+1] == '-': // 行注释 --
+			for i < n && runes[i] != '\n' {
+				i++
+			}
+			b.WriteByte(' ')
+		case c == '#': // 行注释 #
+			for i < n && runes[i] != '\n' {
+				i++
+			}
+			b.WriteByte(' ')
+		case c == '/' && i+1 < n && runes[i+1] == '*': // 块注释 /* */
+			i += 2
+			for i+1 < n && !(runes[i] == '*' && runes[i+1] == '/') {
+				i++
+			}
+			i++ // 跳过结尾的 '/'
+			b.WriteByte(' ')
+		case c == '\'': // 单引号字符串（'' 转义）
+			i++
+			for i < n {
+				if runes[i] == '\'' {
+					if i+1 < n && runes[i+1] == '\'' {
+						i += 2
+						continue
+					}
+					break
+				}
+				i++
+			}
+			b.WriteByte(' ')
+		case c == '`': // 反引号标识符
+			i++
+			for i < n && runes[i] != '`' {
+				i++
+			}
+			b.WriteByte(' ')
+		default:
+			b.WriteRune(c)
+		}
+	}
+	return b.String()
+}
+
+// ensureReadOnlySQL 校验 SQL 为单条只读 SELECT/WITH 查询；违规返回错误。
+func ensureReadOnlySQL(sql string) error {
+	if strings.TrimSpace(sql) == "" {
+		return fmt.Errorf("sql is empty")
+	}
+
+	cleaned := stripSQLNoise(sql)
+	// 占位符整体替换为中性词，避免内部词触发关键字判定。
+	cleaned = anyPlaceholderRe.ReplaceAllString(cleaned, " _rid_ ")
+	cleaned = strings.TrimSpace(cleaned)
+	if cleaned == "" {
+		return fmt.Errorf("sql has no executable statement")
+	}
+
+	// 去掉结尾的分号与空白后，不允许再出现分号（即禁止多语句）。
+	trimmed := strings.TrimRight(cleaned, "; \t\r\n")
+	if strings.Contains(trimmed, ";") {
+		return fmt.Errorf("multiple statements are not allowed; only a single read-only SELECT is permitted")
+	}
+
+	if !startsWithSelectRe.MatchString(trimmed) {
+		return fmt.Errorf("only read-only queries are allowed: statement must start with SELECT or WITH")
+	}
+
+	if loc := forbiddenKeywordRe.FindString(trimmed); loc != "" {
+		return fmt.Errorf("forbidden keyword %q detected: run_sql is read-only (no writes/DDL)", strings.ToUpper(loc))
+	}
+
+	return nil
+}

--- a/adp/context-loader/agent-retrieval/server/driveradapters/mcp/sql_guard_test.go
+++ b/adp/context-loader/agent-retrieval/server/driveradapters/mcp/sql_guard_test.go
@@ -1,0 +1,74 @@
+// Copyright 2026 openbkn.ai
+// Copyright The kweaver.ai Authors.
+//
+// Licensed under the Apache License, Version 2.0.
+// See the LICENSE file in the project root for details.
+
+package mcp
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestEnsureReadOnlySQL_Allowed(t *testing.T) {
+	cases := []string{
+		`SELECT * FROM {{.res1}} LIMIT 10`,
+		`select id, name from {{.res1}} where age > 18`,
+		`WITH t AS (SELECT * FROM {{.res1}}) SELECT * FROM t`,
+		`(SELECT 1 FROM {{.res1}}) UNION (SELECT 2 FROM {{.res2}})`,
+		`SELECT * FROM {{.res1}};`, // 单个结尾分号允许
+		// 占位符内的词不应触发关键字判定
+		`SELECT * FROM {{.delete_logs}}`,
+		`SELECT * FROM {{.update_history}}`,
+		// 字符串字面量中的关键字不应触发判定
+		`SELECT * FROM {{.res1}} WHERE note = 'please delete later'`,
+	}
+	for _, sql := range cases {
+		if err := ensureReadOnlySQL(sql); err != nil {
+			t.Errorf("expected allowed, got error for %q: %v", sql, err)
+		}
+	}
+}
+
+func TestEnsureReadOnlySQL_Rejected(t *testing.T) {
+	cases := []string{
+		``,
+		`   `,
+		`DELETE FROM {{.res1}}`,
+		`DROP TABLE {{.res1}}`,
+		`INSERT INTO {{.res1}} VALUES (1)`,
+		`UPDATE {{.res1}} SET a = 1`,
+		`TRUNCATE TABLE {{.res1}}`,
+		`ALTER TABLE {{.res1}} ADD COLUMN x int`,
+		`CREATE TABLE x (a int)`,
+		`GRANT ALL ON {{.res1}} TO u`,
+		// 多语句（注入式）
+		`SELECT * FROM {{.res1}}; DROP TABLE {{.res1}}`,
+		`SELECT 1; SELECT 2`,
+		// 用注释藏第二语句仍应被识别为多语句或非 SELECT 起手
+		`SELECT * FROM {{.res1}} -- harmless
+		 ; DELETE FROM {{.res1}}`,
+		// SELECT ... INTO OUTFILE 写文件
+		`SELECT * INTO OUTFILE '/tmp/x' FROM {{.res1}}`,
+		// 不以 SELECT/WITH 起手
+		`SHOW TABLES`,
+		`CALL some_proc()`,
+	}
+	for _, sql := range cases {
+		if err := ensureReadOnlySQL(sql); err == nil {
+			t.Errorf("expected rejected, got nil error for %q", sql)
+		}
+	}
+}
+
+func TestExtractResourceIDs(t *testing.T) {
+	got := extractResourceIDs(`SELECT * FROM {{.res_a}} JOIN {{res_b}} ON 1=1 WHERE x IN (SELECT y FROM {{.res_a}})`)
+	want := []string{"res_a", "res_b"}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("extractResourceIDs = %v, want %v", got, want)
+	}
+	if ids := extractResourceIDs(`SELECT 1`); len(ids) != 0 {
+		t.Errorf("expected no ids, got %v", ids)
+	}
+}

--- a/adp/context-loader/agent-retrieval/server/driveradapters/mcp/tools.go
+++ b/adp/context-loader/agent-retrieval/server/driveradapters/mcp/tools.go
@@ -9,6 +9,7 @@ package mcp
 import (
 	"context"
 	"encoding/json"
+	"strings"
 
 	"github.com/creasty/defaults"
 	validator "github.com/go-playground/validator/v10"
@@ -212,6 +213,132 @@ func handleGetActionInfo(service interfaces.IKnActionRecallService) func(ctx con
 		}
 
 		resp, err := service.GetActionInfo(ctx, actionReq)
+		if err != nil {
+			return mcp.NewToolResultError(err.Error()), nil
+		}
+		result, err := BuildMCPToolResult(resp, format)
+		if err != nil {
+			return mcp.NewToolResultError(err.Error()), nil
+		}
+		return result, nil
+	}
+}
+
+// handleListKnowledgeNetworks handles list_knowledge_networks tool calls.
+// 用于让外部 Agent 发现可用的 kn_id（其余查询工具的前置）。
+func handleListKnowledgeNetworks(bkn interfaces.BknBackendAccess) func(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	return func(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		format, err := GetResponseFormatFromRequest(req)
+		if err != nil {
+			return mcp.NewToolResultError(err.Error()), nil
+		}
+
+		listReq := &interfaces.ListKnReq{}
+		if err := bindArguments(req, listReq); err != nil {
+			return mcp.NewToolResultError(err.Error()), nil
+		}
+		if listReq.Limit == 0 {
+			listReq.Limit = 20
+		}
+
+		resp, err := bkn.ListKnowledgeNetworks(ctx, listReq)
+		if err != nil {
+			return mcp.NewToolResultError(err.Error()), nil
+		}
+		result, err := BuildMCPToolResult(resp, format)
+		if err != nil {
+			return mcp.NewToolResultError(err.Error()), nil
+		}
+		return result, nil
+	}
+}
+
+// runSQLArgs run_sql 工具入参。
+type runSQLArgs struct {
+	SQL          string `json:"sql"`           // Trino 方言 SQL，表名用 {{.resource_id}} 占位
+	ResourceType string `json:"resource_type"` // 连接器类型，留空则按 resource_id 自动解析
+	QueryTimeout int    `json:"query_timeout"` // 查询超时（秒），可选
+}
+
+// handleRunSQL handles run_sql tool calls.
+// 对知识网络挂载的数据资源执行只读 SQL（强制 SELECT-only），底层走 vega 原始查询接口。
+func handleRunSQL(vega interfaces.DrivenVega) func(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	return func(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		format, err := GetResponseFormatFromRequest(req)
+		if err != nil {
+			return mcp.NewToolResultError(err.Error()), nil
+		}
+
+		args := &runSQLArgs{}
+		if err := bindArguments(req, args); err != nil {
+			return mcp.NewToolResultError(err.Error()), nil
+		}
+		if strings.TrimSpace(args.SQL) == "" {
+			return mcp.NewToolResultError("sql is required"), nil
+		}
+
+		// 只读守卫：拒绝写入 / DDL / 多语句。
+		if err := ensureReadOnlySQL(args.SQL); err != nil {
+			return mcp.NewToolResultError(err.Error()), nil
+		}
+
+		// 必须通过 {{.resource_id}} 占位符引用资源，否则 vega 无法定位数据源。
+		resourceIDs := extractResourceIDs(args.SQL)
+		if len(resourceIDs) == 0 {
+			return mcp.NewToolResultError(
+				"sql must reference at least one data resource via the {{.resource_id}} placeholder",
+			), nil
+		}
+
+		// resource_type 未显式给出时，按第一个 resource_id 自动解析其连接器类型。
+		resourceType := strings.TrimSpace(args.ResourceType)
+		if resourceType == "" {
+			rt, err := vega.GetResourceConnectorType(ctx, resourceIDs[0])
+			if err != nil {
+				return mcp.NewToolResultError(
+					"failed to resolve resource_type from resource_id, pass resource_type explicitly: " + err.Error(),
+				), nil
+			}
+			resourceType = rt
+		}
+
+		queryReq := &interfaces.VegaRawQueryReq{
+			Query:        args.SQL,
+			ResourceType: resourceType,
+			QueryType:    "standard",
+			QueryTimeout: args.QueryTimeout,
+		}
+		resp, err := vega.RawQuery(ctx, queryReq)
+		if err != nil {
+			return mcp.NewToolResultError(err.Error()), nil
+		}
+
+		result, err := BuildMCPToolResult(resp, format)
+		if err != nil {
+			return mcp.NewToolResultError(err.Error()), nil
+		}
+		return result, nil
+	}
+}
+
+// handleGetKnDetail handles get_kn_detail tool calls.
+// 直接包装 bkn-backend，返回知识网络完整详情（概念组 / 对象类 / 关系类 / 行动类）。
+func handleGetKnDetail(bkn interfaces.BknBackendAccess) func(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	return func(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		format, err := GetResponseFormatFromRequest(req)
+		if err != nil {
+			return mcp.NewToolResultError(err.Error()), nil
+		}
+
+		knID := getStringArg(req, "kn_id", "")
+		if knID == "" {
+			knID = getKnIDFromHeader(req)
+		}
+		if knID == "" {
+			return mcp.NewToolResultError("kn_id is required"), nil
+		}
+
+		resp, err := bkn.GetKnowledgeNetworkDetail(ctx, knID)
 		if err != nil {
 			return mcp.NewToolResultError(err.Error()), nil
 		}

--- a/adp/context-loader/agent-retrieval/server/driveradapters/rest_public_handler.go
+++ b/adp/context-loader/agent-retrieval/server/driveradapters/rest_public_handler.go
@@ -8,6 +8,7 @@ package driveradapters
 
 import (
 	"net/http"
+	"strings"
 
 	"github.com/gin-gonic/gin"
 
@@ -68,5 +69,33 @@ func (r *restPublicHandler) RegisterRouter(engine *gin.RouterGroup) {
 	engine.POST("/kn/find_skills", r.KnFindSkillsHandler.FindSkills)
 
 	// MCP Server (Bearer token auth, supports Cursor/Claude Desktop)
-	engine.Any("/mcp/*path", gin.WrapH(r.MCPHandler))
+	// GET /mcp/info 返回自描述文档（工具目录 + 连接方式），其余走标准 MCP Streamable HTTP。
+	engine.Any("/mcp/*path", r.handleMCP)
+}
+
+// handleMCP 在 MCP catch-all 路由内分流：GET …/mcp/info 返回自描述文档，其余交给 MCP Server。
+func (r *restPublicHandler) handleMCP(c *gin.Context) {
+	if c.Request.Method == http.MethodGet && c.Param("path") == "/info" {
+		info, err := mcp.BuildMCPInfo(mcpEndpointURL(c.Request))
+		if err != nil {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+			return
+		}
+		c.JSON(http.StatusOK, info)
+		return
+	}
+	r.MCPHandler.ServeHTTP(c.Writer, c.Request)
+}
+
+// mcpEndpointURL 依据请求推导本服务对外的 MCP 端点（去掉末尾的 /info）。
+func mcpEndpointURL(req *http.Request) string {
+	scheme := "http"
+	if req.TLS != nil {
+		scheme = "https"
+	}
+	if p := req.Header.Get("X-Forwarded-Proto"); p != "" {
+		scheme = p
+	}
+	base := strings.TrimSuffix(req.URL.Path, "/info")
+	return scheme + "://" + req.Host + base
 }

--- a/adp/context-loader/agent-retrieval/server/infra/config/agent-retrieval.yaml
+++ b/adp/context-loader/agent-retrieval/server/infra/config/agent-retrieval.yaml
@@ -35,6 +35,10 @@ ontology_query:
   private_protocol: "http"
   private_host: "ontology-query-svc.kweaver"
   private_port: 13018
+vega:
+  private_protocol: "http"
+  private_host: "vega-backend-svc.kweaver"
+  private_port: 13014
 data_retrieval:
   private_protocol: "http"
   private_host: "data-retrieval.kweaver"

--- a/adp/context-loader/agent-retrieval/server/infra/config/config.go
+++ b/adp/context-loader/agent-retrieval/server/infra/config/config.go
@@ -36,6 +36,7 @@ type Config struct {
 	OAuth               OAuthConfig           `yaml:"oauth"`
 	BknBackend          PrivateBaseConfig     `yaml:"bkn_backend"`
 	OntologyQuery       PrivateBaseConfig     `yaml:"ontology_query"`
+	Vega                PrivateBaseConfig     `yaml:"vega"` // Vega data-catalog backend (run_sql / resource query)
 	AgentApp            PrivateBaseConfig     `yaml:"agent_app"`
 	OperatorIntegration PrivateBaseConfig     `yaml:"operator_integration"` // Operator integration service configuration
 	RedisConfig         RedisConfig           `yaml:"redis"`

--- a/adp/context-loader/agent-retrieval/server/interfaces/driven_bkn_backend.go
+++ b/adp/context-loader/agent-retrieval/server/interfaces/driven_bkn_backend.go
@@ -315,9 +315,36 @@ type KnowledgeNetworkDetail struct {
 }
 
 // BknBackendAccess BKN backend ontology management interface
+// ListKnReq 列出知识网络的查询参数
+type ListKnReq struct {
+	NamePattern string `json:"name_pattern,omitempty"` // 按名称模糊过滤
+	Limit       int    `json:"limit,omitempty"`        // 单页数量，默认 20
+	Offset      int    `json:"offset,omitempty"`       // 偏移，用于翻页
+	Sort        string `json:"sort,omitempty"`         // 排序字段，默认 update_time
+	Direction   string `json:"direction,omitempty"`    // asc / desc，默认 desc
+}
+
+// KnBrief 知识网络概要（list 用）
+type KnBrief struct {
+	ID             string `json:"id"`
+	Name           string `json:"name"`
+	Description    string `json:"description,omitempty"`
+	ModuleType     string `json:"module_type,omitempty"`
+	BusinessDomain string `json:"business_domain,omitempty"`
+}
+
+// ListKnResp 知识网络列表响应
+type ListKnResp struct {
+	Entries    []*KnBrief `json:"entries"`
+	TotalCount int64      `json:"total_count"`
+}
+
 type BknBackendAccess interface {
 	// GetKnowledgeNetworkDetail Get knowledge network detail with full schema (include_detail=true, mode=export)
 	GetKnowledgeNetworkDetail(ctx context.Context, knID string) (*KnowledgeNetworkDetail, error)
+
+	// ListKnowledgeNetworks 列出知识网络（用于发现 kn_id）
+	ListKnowledgeNetworks(ctx context.Context, req *ListKnReq) (resp *ListKnResp, err error)
 
 	// SearchObjectTypes Search object types
 	SearchObjectTypes(ctx context.Context, query *QueryConceptsReq) (objectTypes *ObjectTypeConcepts, err error)

--- a/adp/context-loader/agent-retrieval/server/interfaces/driven_ontology_query.go
+++ b/adp/context-loader/agent-retrieval/server/interfaces/driven_ontology_query.go
@@ -26,11 +26,19 @@ type QueryObjectInstancesReq struct {
 	Cond               *KnCondition `json:"condition"`                                     // Retrieval conditions
 	Limit              int          `json:"limit" validate:"min=1,max=10000" default:"10"` // Quantity limit, default 10, range 1-10000
 	Properties         []string     `json:"properties"`                                    // 指定返回的对象属性字段列表，默认返回所有属性
+	// SearchAfter 游标分页：传入上一页响应返回的 search_after，用于顺序拉取下一页；首次查询留空。
+	// 适用于对象索引 / 数据视图路径（顺翻，不跳页）。
+	SearchAfter []any `json:"search_after,omitempty"`
+	// Offset 偏移翻页：适用于资源（vega 表源）路径，支持跳到任意页；与 search_after 互斥。
+	Offset int `json:"offset,omitempty"`
 }
 
 type QueryObjectInstancesResp struct {
 	Data          []any          `json:"datas"`                 // List of object instances
 	ObjectConcept map[string]any `json:"object_type,omitempty"` // Object type definition，由 req.include_type_info 控制是否返回
+	TotalCount    int64          `json:"total_count,omitempty"` // 命中总数（need_total 时有效）
+	// SearchAfter 下一页游标：非空时把它作为下次请求的 search_after 传入以取下一页；为空表示无更多数据。
+	SearchAfter []any `json:"search_after,omitempty"`
 }
 
 // QueryLogicPropertiesReq Request for querying logic properties values

--- a/adp/context-loader/agent-retrieval/server/interfaces/driven_vega.go
+++ b/adp/context-loader/agent-retrieval/server/interfaces/driven_vega.go
@@ -1,0 +1,42 @@
+// Copyright 2026 openbkn.ai
+// Copyright The kweaver.ai Authors.
+//
+// Licensed under the Apache License, Version 2.0.
+// See the LICENSE file in the project root for details.
+
+package interfaces
+
+import "context"
+
+// VegaRawQueryReq vega 原始 SQL 查询请求（只读）。
+// Query 为 Trino 方言 SQL，表名用 {{.resource_id}} 占位符引用，由 vega 解析成真实表名。
+type VegaRawQueryReq struct {
+	Query        string `json:"query"`                   // Trino 方言 SQL
+	ResourceType string `json:"resource_type"`           // 连接器类型：mysql / mariadb / postgresql
+	QueryType    string `json:"query_type,omitempty"`    // standard / stream，默认 standard
+	QueryTimeout int    `json:"query_timeout,omitempty"` // 查询超时（秒），1-3600
+}
+
+// VegaColumn vega 查询返回的列信息。
+type VegaColumn struct {
+	Name string `json:"name"`
+	Type string `json:"type,omitempty"`
+}
+
+// VegaRawQueryResp vega 原始查询响应。
+type VegaRawQueryResp struct {
+	Columns    []VegaColumn     `json:"columns"`
+	Entries    []map[string]any `json:"entries"`
+	Stats      map[string]any   `json:"stats,omitempty"`
+	TotalCount int64            `json:"total_count"`
+	Warnings   []string         `json:"warnings,omitempty"`
+}
+
+// DrivenVega vega 数据目录后端访问接口（只读查询）。
+type DrivenVega interface {
+	// RawQuery 执行只读 SQL。调用方（MCP 工具层）须自行保证 SELECT-only，本接口不做语句校验。
+	RawQuery(ctx context.Context, req *VegaRawQueryReq) (*VegaRawQueryResp, error)
+	// GetResourceConnectorType 按 resource_id 解析其所属 catalog 的连接器类型，
+	// 用于自动填充 RawQueryReq.ResourceType。
+	GetResourceConnectorType(ctx context.Context, resourceID string) (string, error)
+}

--- a/adp/context-loader/agent-retrieval/server/logics/knfindskills/mock_test.go
+++ b/adp/context-loader/agent-retrieval/server/logics/knfindskills/mock_test.go
@@ -59,6 +59,10 @@ func (m *testBknBackend) GetKnowledgeNetworkDetail(ctx context.Context, knID str
 	return nil, nil
 }
 
+func (m *testBknBackend) ListKnowledgeNetworks(ctx context.Context, req *interfaces.ListKnReq) (*interfaces.ListKnResp, error) {
+	return &interfaces.ListKnResp{}, nil
+}
+
 func (m *testBknBackend) SearchObjectTypes(ctx context.Context, req *interfaces.QueryConceptsReq) (*interfaces.ObjectTypeConcepts, error) {
 	return nil, nil
 }

--- a/adp/context-loader/agent-retrieval/server/logics/knsearch/mock_test.go
+++ b/adp/context-loader/agent-retrieval/server/logics/knsearch/mock_test.go
@@ -74,6 +74,10 @@ func (m *mockBknBackend) GetKnowledgeNetworkDetail(ctx context.Context, knID str
 	return m.networkDetail, m.networkError
 }
 
+func (m *mockBknBackend) ListKnowledgeNetworks(ctx context.Context, req *interfaces.ListKnReq) (*interfaces.ListKnResp, error) {
+	return &interfaces.ListKnResp{}, nil
+}
+
 func (m *mockBknBackend) SearchObjectTypes(ctx context.Context, req *interfaces.QueryConceptsReq) (*interfaces.ObjectTypeConcepts, error) {
 	m.objectTypesReq = req
 	return m.objectTypesResp, m.objectTypesError

--- a/adp/context-loader/agent-retrieval/server/logics/knsearch/search_schema_test.go
+++ b/adp/context-loader/agent-retrieval/server/logics/knsearch/search_schema_test.go
@@ -29,6 +29,10 @@ func (s *stubSearchSchemaBknBackend) GetKnowledgeNetworkDetail(_ context.Context
 	return nil, nil
 }
 
+func (s *stubSearchSchemaBknBackend) ListKnowledgeNetworks(_ context.Context, _ *interfaces.ListKnReq) (*interfaces.ListKnResp, error) {
+	return &interfaces.ListKnResp{}, nil
+}
+
 func (s *stubSearchSchemaBknBackend) SearchObjectTypes(_ context.Context, _ *interfaces.QueryConceptsReq) (*interfaces.ObjectTypeConcepts, error) {
 	return nil, nil
 }


### PR DESCRIPTION
## What

Adds query-oriented MCP tools to the **agent-retrieval** context-loader MCP server (`/api/agent-retrieval/v1/mcp`), plus instance-query pagination and a self-describe endpoint.

### New MCP tools
- **`run_sql`** — read-only Trino SQL over KN-mounted vega resources via `{{.resource_id}}` placeholders. Includes a **SELECT-only guard** (rejects DML/DDL/multi-statement, comment/string/placeholder-aware) and **automatic connector-type resolution** (resource_id → catalog → connector type). New vega drivenadapter (`RawQuery` + resolution).
- **`list_knowledge_networks`** — discover `kn_id` (wraps bkn-backend).
- **`get_kn_detail`** — full KN schema: concept groups / object / relation / action types (wraps bkn-backend `GetKnowledgeNetworkDetail`).

### query_object_instance pagination
- **search_after** cursor passthrough (object-index / data-view paths — ontology-query already emits cursors there).
- **offset** passthrough (vega table-source path): `ontology-query` `PageQuery` + `getObjectsFromResource` now forward `Offset`; agent-retrieval req + schema expose it. (vega table connectors already emit `LIMIT/OFFSET`.)

### Discovery
- **`GET /api/agent-retrieval/v1/mcp/info`** — self-describe doc (tool catalog with schemas + ready-to-paste client config), no MCP handshake required.

### Infra
- New vega drivenadapter; vega service wired into config (`config.go`, yaml, helm configmap + values).

## Verification
Live on VM (openbkn ns), built image deployed:
- All 9 tools callable via **Context Loader CLI** (`openbkn context tools/tool-call`) and the **openbkn SDK** (`@openbkn/bkn-sdk` `client.context.*`).
- `run_sql` returns real rows; guard rejects `DELETE`/`DROP`/multi-statement; resource_type auto-resolved.
- `/mcp/info` and `get_kn_detail` return correct data.
- **offset path**: compiles + `go vet` clean on both services; vega `LIMIT/OFFSET` support confirmed in code. Live VM verify is pending a paired image rebuild (deferred — VM build infra contention at time of writing).

## Not included (follow-up)
- Registering agent-retrieval's MCP into **operator-integration** (execution-factory market). Needs an auth decision first: op-integration's proxy uses statically-configured headers and does not forward the caller token, while agent-retrieval's `/mcp` requires Bearer. Recommended path: expose an internal (unauth, header-trusting) MCP endpoint for op-integration + self-register at startup. Tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)