### PR TITLE
feat(agent-retrieval): expose run_sql / list_kn / get_kn_detail to execution-factory via toolbox

### DIFF
--- a/adp/context-loader/agent-retrieval/server/bootstrap/tool_dependencies/context_loader_toolset.adp
+++ b/adp/context-loader/agent-retrieval/server/bootstrap/tool_dependencies/context_loader_toolset.adp
@@ -2624,6 +2624,492 @@
             "code": "",
             "dependencies": [],
             "dependencies_url": ""
+          },
+          {
+            "tool_id": "a82ef26d-7775-48be-bdc6-cd1d7f90867b",
+            "name": "run_sql",
+            "description": "对知识网络挂载的数据资源执行只读 SQL（Trino 方言）。表名用占位符 {{.resource_id}} 引用（resource_id 取自对象类的 data_source.id，可由 search_schema 获得）；vega 会解析成真实表并限量。仅允许 SELECT/WITH，禁止写入/DDL；单次查询的资源需同属一个数据目录（不支持跨目录 join）。",
+            "status": "enabled",
+            "metadata_type": "openapi",
+            "metadata": {
+              "version": "1839dd82-9cf3-4667-8748-27c2dcdabacd",
+              "summary": "run_sql",
+              "description": "对知识网络挂载的数据资源执行只读 SQL（Trino 方言）。表名用占位符 {{.resource_id}} 引用（resource_id 取自对象类的 data_source.id，可由 search_schema 获得）；vega 会解析成真实表并限量。仅允许 SELECT/WITH，禁止写入/DDL；单次查询的资源需同属一个数据目录（不支持跨目录 join）。",
+              "server_url": "http://agent-retrieval:30779",
+              "path": "/api/agent-retrieval/in/v1/kn/run_sql",
+              "method": "POST",
+              "create_time": 1776920840668983300,
+              "update_time": 1776920840668983300,
+              "create_user": "ede150ba-06f4-11f1-85aa-3a34099a4c4b",
+              "update_user": "ede150ba-06f4-11f1-85aa-3a34099a4c4b",
+              "api_spec": {
+                "parameters": [
+                  {
+                    "name": "x-account-id",
+                    "in": "header",
+                    "description": "账户ID，用于内部服务调用时传递账户信息",
+                    "required": false,
+                    "schema": {
+                      "type": "string"
+                    }
+                  },
+                  {
+                    "name": "x-account-type",
+                    "in": "header",
+                    "description": "账户类型：user(用户), app(应用), anonymous(匿名)",
+                    "required": false,
+                    "schema": {
+                      "enum": [
+                        "user",
+                        "app",
+                        "anonymous"
+                      ],
+                      "type": "string"
+                    }
+                  }
+                ],
+                "request_body": {
+                  "description": "",
+                  "content": {
+                    "application/json": {
+                      "schema": {
+                        "type": "object",
+                        "properties": {
+                          "response_format": {
+                            "type": "string",
+                            "enum": [
+                              "json",
+                              "toon"
+                            ],
+                            "default": "toon",
+                            "description": "文本格式：json 或 toon，默认 toon"
+                          },
+                          "sql": {
+                            "type": "string",
+                            "description": "只读 SQL（Trino 方言）。表名必须用占位符 {{.resource_id}} 引用，resource_id 取自对象类的 data_source.id（可经 search_schema 获得）。仅允许 SELECT / WITH，禁止任何写入与 DDL；不支持多语句；不支持跨数据目录 join（单次查询涉及的资源需同属一个 catalog）。vega 会自动限量（最多 10000 行）。"
+                          },
+                          "resource_type": {
+                            "type": "string",
+                            "description": "连接器类型（mysql / mariadb / postgresql）。留空则按 SQL 中第一个 {{.resource_id}} 自动解析，一般无需填写。"
+                          },
+                          "query_timeout": {
+                            "type": "integer",
+                            "description": "查询超时（秒），范围 1-3600，默认 60。可选。"
+                          }
+                        },
+                        "required": [
+                          "sql"
+                        ]
+                      }
+                    }
+                  },
+                  "required": true
+                },
+                "responses": [
+                  {
+                    "status_code": "200",
+                    "description": "ok",
+                    "content": {
+                      "application/json": {
+                        "schema": {
+                          "type": "object",
+                          "properties": {
+                            "columns": {
+                              "type": "array",
+                              "description": "结果列信息",
+                              "items": {
+                                "type": "object",
+                                "properties": {
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "type": {
+                                    "type": "string"
+                                  }
+                                },
+                                "additionalProperties": true
+                              }
+                            },
+                            "entries": {
+                              "type": "array",
+                              "description": "结果行",
+                              "items": {
+                                "type": "object",
+                                "additionalProperties": true
+                              }
+                            },
+                            "total_count": {
+                              "type": "integer",
+                              "description": "返回行数"
+                            },
+                            "warnings": {
+                              "type": "array",
+                              "items": {
+                                "type": "string"
+                              },
+                              "description": "非致命告警（如资源已弃用）"
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                ],
+                "components": null,
+                "callbacks": null,
+                "security": null,
+                "tags": null,
+                "external_docs": null
+              }
+            },
+            "use_rule": "",
+            "global_parameters": {
+              "name": "",
+              "description": "",
+              "required": false,
+              "in": "",
+              "type": "",
+              "value": null
+            },
+            "create_time": 1776920840668983300,
+            "update_time": 1776920840668983300,
+            "create_user": "ede150ba-06f4-11f1-85aa-3a34099a4c4b",
+            "update_user": "ede150ba-06f4-11f1-85aa-3a34099a4c4b",
+            "extend_info": null,
+            "resource_object": "tool",
+            "source_id": "1839dd82-9cf3-4667-8748-27c2dcdabacd",
+            "source_type": "openapi",
+            "script_type": "",
+            "code": "",
+            "dependencies": [],
+            "dependencies_url": ""
+          },
+          {
+            "tool_id": "863acc66-eb74-438a-bfe3-4db2e7def372",
+            "name": "list_knowledge_networks",
+            "description": "列出可用的知识网络（返回 kn_id、名称、描述）。其余查询工具均需 kn_id，作为探索的第一步入口。",
+            "status": "enabled",
+            "metadata_type": "openapi",
+            "metadata": {
+              "version": "262e6732-0759-4e62-8703-a52e84832006",
+              "summary": "list_knowledge_networks",
+              "description": "列出可用的知识网络（返回 kn_id、名称、描述）。其余查询工具均需 kn_id，作为探索的第一步入口。",
+              "server_url": "http://agent-retrieval:30779",
+              "path": "/api/agent-retrieval/in/v1/kn/list_knowledge_networks",
+              "method": "POST",
+              "create_time": 1776920840668983300,
+              "update_time": 1776920840668983300,
+              "create_user": "ede150ba-06f4-11f1-85aa-3a34099a4c4b",
+              "update_user": "ede150ba-06f4-11f1-85aa-3a34099a4c4b",
+              "api_spec": {
+                "parameters": [
+                  {
+                    "name": "x-account-id",
+                    "in": "header",
+                    "description": "账户ID，用于内部服务调用时传递账户信息",
+                    "required": false,
+                    "schema": {
+                      "type": "string"
+                    }
+                  },
+                  {
+                    "name": "x-account-type",
+                    "in": "header",
+                    "description": "账户类型：user(用户), app(应用), anonymous(匿名)",
+                    "required": false,
+                    "schema": {
+                      "enum": [
+                        "user",
+                        "app",
+                        "anonymous"
+                      ],
+                      "type": "string"
+                    }
+                  }
+                ],
+                "request_body": {
+                  "description": "",
+                  "content": {
+                    "application/json": {
+                      "schema": {
+                        "type": "object",
+                        "properties": {
+                          "response_format": {
+                            "type": "string",
+                            "enum": [
+                              "json",
+                              "toon"
+                            ],
+                            "default": "toon",
+                            "description": "文本格式：json 或 toon，默认 toon"
+                          },
+                          "name_pattern": {
+                            "type": "string",
+                            "description": "按知识网络名称模糊过滤，可选"
+                          },
+                          "limit": {
+                            "type": "integer",
+                            "description": "单页数量，默认 20"
+                          },
+                          "offset": {
+                            "type": "integer",
+                            "description": "偏移量，用于翻页，默认 0"
+                          },
+                          "sort": {
+                            "type": "string",
+                            "description": "排序字段，默认 update_time"
+                          },
+                          "direction": {
+                            "type": "string",
+                            "enum": [
+                              "asc",
+                              "desc"
+                            ],
+                            "description": "排序方向，默认 desc"
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "required": true
+                },
+                "responses": [
+                  {
+                    "status_code": "200",
+                    "description": "ok",
+                    "content": {
+                      "application/json": {
+                        "schema": {
+                          "type": "object",
+                          "properties": {
+                            "entries": {
+                              "type": "array",
+                              "description": "知识网络列表",
+                              "items": {
+                                "type": "object",
+                                "properties": {
+                                  "id": {
+                                    "type": "string",
+                                    "description": "知识网络 ID（即 kn_id，供其余查询工具使用）"
+                                  },
+                                  "name": {
+                                    "type": "string",
+                                    "description": "知识网络名称"
+                                  },
+                                  "description": {
+                                    "type": "string",
+                                    "description": "描述"
+                                  },
+                                  "module_type": {
+                                    "type": "string",
+                                    "description": "模块类型"
+                                  },
+                                  "business_domain": {
+                                    "type": "string",
+                                    "description": "业务域"
+                                  }
+                                },
+                                "additionalProperties": true
+                              }
+                            },
+                            "total_count": {
+                              "type": "integer",
+                              "description": "命中总数"
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                ],
+                "components": null,
+                "callbacks": null,
+                "security": null,
+                "tags": null,
+                "external_docs": null
+              }
+            },
+            "use_rule": "",
+            "global_parameters": {
+              "name": "",
+              "description": "",
+              "required": false,
+              "in": "",
+              "type": "",
+              "value": null
+            },
+            "create_time": 1776920840668983300,
+            "update_time": 1776920840668983300,
+            "create_user": "ede150ba-06f4-11f1-85aa-3a34099a4c4b",
+            "update_user": "ede150ba-06f4-11f1-85aa-3a34099a4c4b",
+            "extend_info": null,
+            "resource_object": "tool",
+            "source_id": "262e6732-0759-4e62-8703-a52e84832006",
+            "source_type": "openapi",
+            "script_type": "",
+            "code": "",
+            "dependencies": [],
+            "dependencies_url": ""
+          },
+          {
+            "tool_id": "9ab97b0d-8a65-4c23-bef6-f899a6a1f5f9",
+            "name": "get_kn_detail",
+            "description": "获取知识网络完整详情（直接包装 bkn-backend）：概念组、对象类型（含 data_source.id）、关系类型、行动类型。已知 kn_id 时一次性拿全量 schema。",
+            "status": "enabled",
+            "metadata_type": "openapi",
+            "metadata": {
+              "version": "b7c34d4e-b7e7-4e19-b667-1fde349bfcd9",
+              "summary": "get_kn_detail",
+              "description": "获取知识网络完整详情（直接包装 bkn-backend）：概念组、对象类型（含 data_source.id）、关系类型、行动类型。已知 kn_id 时一次性拿全量 schema。",
+              "server_url": "http://agent-retrieval:30779",
+              "path": "/api/agent-retrieval/in/v1/kn/get_kn_detail",
+              "method": "POST",
+              "create_time": 1776920840668983300,
+              "update_time": 1776920840668983300,
+              "create_user": "ede150ba-06f4-11f1-85aa-3a34099a4c4b",
+              "update_user": "ede150ba-06f4-11f1-85aa-3a34099a4c4b",
+              "api_spec": {
+                "parameters": [
+                  {
+                    "name": "x-account-id",
+                    "in": "header",
+                    "description": "账户ID，用于内部服务调用时传递账户信息",
+                    "required": false,
+                    "schema": {
+                      "type": "string"
+                    }
+                  },
+                  {
+                    "name": "x-account-type",
+                    "in": "header",
+                    "description": "账户类型：user(用户), app(应用), anonymous(匿名)",
+                    "required": false,
+                    "schema": {
+                      "enum": [
+                        "user",
+                        "app",
+                        "anonymous"
+                      ],
+                      "type": "string"
+                    }
+                  }
+                ],
+                "request_body": {
+                  "description": "",
+                  "content": {
+                    "application/json": {
+                      "schema": {
+                        "type": "object",
+                        "properties": {
+                          "response_format": {
+                            "type": "string",
+                            "enum": [
+                              "json",
+                              "toon"
+                            ],
+                            "default": "toon",
+                            "description": "文本格式：json 或 toon，默认 toon"
+                          },
+                          "kn_id": {
+                            "type": "string",
+                            "description": "知识网络 ID。也可改用 X-Kn-ID 请求头传入。"
+                          }
+                        },
+                        "required": [
+                          "kn_id"
+                        ]
+                      }
+                    }
+                  },
+                  "required": true
+                },
+                "responses": [
+                  {
+                    "status_code": "200",
+                    "description": "ok",
+                    "content": {
+                      "application/json": {
+                        "schema": {
+                          "type": "object",
+                          "properties": {
+                            "id": {
+                              "type": "string",
+                              "description": "知识网络 ID"
+                            },
+                            "name": {
+                              "type": "string",
+                              "description": "知识网络名称"
+                            },
+                            "comment": {
+                              "type": "string",
+                              "description": "描述"
+                            },
+                            "concept_groups": {
+                              "type": "array",
+                              "items": {
+                                "type": "object",
+                                "additionalProperties": true
+                              },
+                              "description": "概念组"
+                            },
+                            "object_types": {
+                              "type": "array",
+                              "items": {
+                                "type": "object",
+                                "additionalProperties": true
+                              },
+                              "description": "对象类型（含 data_source 等）"
+                            },
+                            "relation_types": {
+                              "type": "array",
+                              "items": {
+                                "type": "object",
+                                "additionalProperties": true
+                              },
+                              "description": "关系类型"
+                            },
+                            "action_types": {
+                              "type": "array",
+                              "items": {
+                                "type": "object",
+                                "additionalProperties": true
+                              },
+                              "description": "行动类型"
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                ],
+                "components": null,
+                "callbacks": null,
+                "security": null,
+                "tags": null,
+                "external_docs": null
+              }
+            },
+            "use_rule": "",
+            "global_parameters": {
+              "name": "",
+              "description": "",
+              "required": false,
+              "in": "",
+              "type": "",
+              "value": null
+            },
+            "create_time": 1776920840668983300,
+            "update_time": 1776920840668983300,
+            "create_user": "ede150ba-06f4-11f1-85aa-3a34099a4c4b",
+            "update_user": "ede150ba-06f4-11f1-85aa-3a34099a4c4b",
+            "extend_info": null,
+            "resource_object": "tool",
+            "source_id": "b7c34d4e-b7e7-4e19-b667-1fde349bfcd9",
+            "source_type": "openapi",
+            "script_type": "",
+            "code": "",
+            "dependencies": [],
+            "dependencies_url": ""
           }
         ],
         "create_time": 1776920840665934300,

--- a/adp/context-loader/agent-retrieval/server/driveradapters/knquerytools/index.go
+++ b/adp/context-loader/agent-retrieval/server/driveradapters/knquerytools/index.go
@@ -1,0 +1,120 @@
+// Copyright 2026 openbkn.ai
+// Copyright The kweaver.ai Authors.
+//
+// Licensed under the Apache License, Version 2.0.
+// See the LICENSE file in the project root for details.
+
+// Package knquerytools provides HTTP handlers for the query tools that are also
+// exposed as MCP tools: run_sql, list_knowledge_networks, get_kn_detail.
+// These internal REST endpoints back the operator-integration toolbox entries.
+package knquerytools
+
+import (
+	"net/http"
+	"sync"
+
+	"github.com/gin-gonic/gin"
+
+	"github.com/openbkn-ai/adp/context-loader/agent-retrieval/server/drivenadapters"
+	"github.com/openbkn-ai/adp/context-loader/agent-retrieval/server/infra/config"
+	"github.com/openbkn-ai/adp/context-loader/agent-retrieval/server/infra/errors"
+	"github.com/openbkn-ai/adp/context-loader/agent-retrieval/server/infra/rest"
+	"github.com/openbkn-ai/adp/context-loader/agent-retrieval/server/interfaces"
+	"github.com/openbkn-ai/adp/context-loader/agent-retrieval/server/logics/knrunsql"
+)
+
+// KnQueryToolsHandler 处理 run_sql / list_knowledge_networks / get_kn_detail 的内部 REST 入口。
+type KnQueryToolsHandler interface {
+	RunSQL(c *gin.Context)
+	ListKnowledgeNetworks(c *gin.Context)
+	GetKnDetail(c *gin.Context)
+}
+
+type knQueryToolsHandler struct {
+	logger     interfaces.Logger
+	runSQL     knrunsql.KnRunSQLService
+	bknBackend interfaces.BknBackendAccess
+}
+
+var (
+	once    sync.Once
+	handler KnQueryToolsHandler
+)
+
+// NewKnQueryToolsHandler 创建 KnQueryToolsHandler 单例。
+func NewKnQueryToolsHandler() KnQueryToolsHandler {
+	once.Do(func() {
+		conf := config.NewConfigLoader()
+		handler = &knQueryToolsHandler{
+			logger:     conf.GetLogger(),
+			runSQL:     knrunsql.NewKnRunSQLService(),
+			bknBackend: drivenadapters.NewBknBackendAccess(),
+		}
+	})
+	return handler
+}
+
+// RunSQL 对知识网络挂载的数据资源执行只读 SQL（强制 SELECT-only）。
+func (h *knQueryToolsHandler) RunSQL(c *gin.Context) {
+	ctx := c.Request.Context()
+	req := &knrunsql.RunSQLReq{}
+	if err := c.ShouldBindJSON(req); err != nil {
+		rest.ReplyError(c, errors.DefaultHTTPError(ctx, http.StatusBadRequest, err.Error()))
+		return
+	}
+
+	resp, err := h.runSQL.RunSQL(ctx, req)
+	if err != nil {
+		h.logger.WithContext(ctx).Warnf("[KnQueryToolsHandler#RunSQL] run sql failed: %v", err)
+		rest.ReplyError(c, errors.DefaultHTTPError(ctx, http.StatusBadRequest, err.Error()))
+		return
+	}
+	rest.ReplyOK(c, http.StatusOK, resp)
+}
+
+// ListKnowledgeNetworks 列出知识网络（发现 kn_id）。
+func (h *knQueryToolsHandler) ListKnowledgeNetworks(c *gin.Context) {
+	ctx := c.Request.Context()
+	req := &interfaces.ListKnReq{}
+	// body 可选；忽略空 body 的绑定错误。
+	_ = c.ShouldBindJSON(req)
+	if req.Limit == 0 {
+		req.Limit = 20
+	}
+
+	resp, err := h.bknBackend.ListKnowledgeNetworks(ctx, req)
+	if err != nil {
+		h.logger.WithContext(ctx).Warnf("[KnQueryToolsHandler#ListKnowledgeNetworks] failed: %v", err)
+		rest.ReplyError(c, err)
+		return
+	}
+	rest.ReplyOK(c, http.StatusOK, resp)
+}
+
+// getKnDetailReq get_kn_detail 入参。
+type getKnDetailReq struct {
+	KnID string `json:"kn_id" form:"kn_id"`
+}
+
+// GetKnDetail 获取知识网络完整详情（概念组 / 对象类 / 关系类 / 行动类）。
+func (h *knQueryToolsHandler) GetKnDetail(c *gin.Context) {
+	ctx := c.Request.Context()
+	req := &getKnDetailReq{}
+	_ = c.ShouldBindQuery(req)
+	_ = c.ShouldBindJSON(req)
+	if req.KnID == "" {
+		req.KnID = c.GetHeader("X-Kn-ID")
+	}
+	if req.KnID == "" {
+		rest.ReplyError(c, errors.DefaultHTTPError(ctx, http.StatusBadRequest, "kn_id is required"))
+		return
+	}
+
+	resp, err := h.bknBackend.GetKnowledgeNetworkDetail(ctx, req.KnID)
+	if err != nil {
+		h.logger.WithContext(ctx).Warnf("[KnQueryToolsHandler#GetKnDetail] failed: %v", err)
+		rest.ReplyError(c, err)
+		return
+	}
+	rest.ReplyOK(c, http.StatusOK, resp)
+}

--- a/adp/context-loader/agent-retrieval/server/driveradapters/mcp/app.go
+++ b/adp/context-loader/agent-retrieval/server/driveradapters/mcp/app.go
@@ -20,6 +20,7 @@ import (
 	logicsFs "github.com/openbkn-ai/adp/context-loader/agent-retrieval/server/logics/knfindskills"
 	logicsKlp "github.com/openbkn-ai/adp/context-loader/agent-retrieval/server/logics/knlogicpropertyresolver"
 	logicsKqs "github.com/openbkn-ai/adp/context-loader/agent-retrieval/server/logics/knquerysubgraph"
+	"github.com/openbkn-ai/adp/context-loader/agent-retrieval/server/logics/knrunsql"
 	"github.com/openbkn-ai/adp/context-loader/agent-retrieval/server/logics/knsearch"
 )
 
@@ -108,12 +109,12 @@ func NewMCPHandler() http.Handler {
 		handleGetKnDetail(bknBackend),
 	)
 
-	vegaAccess := drivenadapters.NewVegaAccess()
+	runSQLService := knrunsql.NewKnRunSQLService()
 	runSQLName, runSQLDesc := loadToolMeta(toolKeyRunSQL)
 	runSQLInput, runSQLOutput := loadToolSchemas(toolKeyRunSQL)
 	mcpServer.AddTool(
 		newToolWithSchemas(runSQLName, runSQLDesc, runSQLInput, runSQLOutput),
-		handleRunSQL(vegaAccess),
+		handleRunSQL(runSQLService),
 	)
 
 	streamableServer := server.NewStreamableHTTPServer(mcpServer,

--- a/adp/context-loader/agent-retrieval/server/driveradapters/mcp/tools.go
+++ b/adp/context-loader/agent-retrieval/server/driveradapters/mcp/tools.go
@@ -9,7 +9,6 @@ package mcp
 import (
 	"context"
 	"encoding/json"
-	"strings"
 
 	"github.com/creasty/defaults"
 	validator "github.com/go-playground/validator/v10"
@@ -19,6 +18,7 @@ import (
 	"github.com/openbkn-ai/adp/context-loader/agent-retrieval/server/infra/rest"
 	"github.com/openbkn-ai/adp/context-loader/agent-retrieval/server/interfaces"
 	logicsKqs "github.com/openbkn-ai/adp/context-loader/agent-retrieval/server/logics/knquerysubgraph"
+	"github.com/openbkn-ai/adp/context-loader/agent-retrieval/server/logics/knrunsql"
 	"github.com/openbkn-ai/adp/context-loader/agent-retrieval/server/logics/knsearch"
 )
 
@@ -253,62 +253,21 @@ func handleListKnowledgeNetworks(bkn interfaces.BknBackendAccess) func(ctx conte
 	}
 }
 
-// runSQLArgs run_sql 工具入参。
-type runSQLArgs struct {
-	SQL          string `json:"sql"`           // Trino 方言 SQL，表名用 {{.resource_id}} 占位
-	ResourceType string `json:"resource_type"` // 连接器类型，留空则按 resource_id 自动解析
-	QueryTimeout int    `json:"query_timeout"` // 查询超时（秒），可选
-}
-
 // handleRunSQL handles run_sql tool calls.
-// 对知识网络挂载的数据资源执行只读 SQL（强制 SELECT-only），底层走 vega 原始查询接口。
-func handleRunSQL(vega interfaces.DrivenVega) func(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+// 对知识网络挂载的数据资源执行只读 SQL（强制 SELECT-only），底层走共享 knrunsql 服务。
+func handleRunSQL(svc knrunsql.KnRunSQLService) func(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 	return func(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 		format, err := GetResponseFormatFromRequest(req)
 		if err != nil {
 			return mcp.NewToolResultError(err.Error()), nil
 		}
 
-		args := &runSQLArgs{}
-		if err := bindArguments(req, args); err != nil {
-			return mcp.NewToolResultError(err.Error()), nil
-		}
-		if strings.TrimSpace(args.SQL) == "" {
-			return mcp.NewToolResultError("sql is required"), nil
-		}
-
-		// 只读守卫：拒绝写入 / DDL / 多语句。
-		if err := ensureReadOnlySQL(args.SQL); err != nil {
+		sqlReq := &knrunsql.RunSQLReq{}
+		if err := bindArguments(req, sqlReq); err != nil {
 			return mcp.NewToolResultError(err.Error()), nil
 		}
 
-		// 必须通过 {{.resource_id}} 占位符引用资源，否则 vega 无法定位数据源。
-		resourceIDs := extractResourceIDs(args.SQL)
-		if len(resourceIDs) == 0 {
-			return mcp.NewToolResultError(
-				"sql must reference at least one data resource via the {{.resource_id}} placeholder",
-			), nil
-		}
-
-		// resource_type 未显式给出时，按第一个 resource_id 自动解析其连接器类型。
-		resourceType := strings.TrimSpace(args.ResourceType)
-		if resourceType == "" {
-			rt, err := vega.GetResourceConnectorType(ctx, resourceIDs[0])
-			if err != nil {
-				return mcp.NewToolResultError(
-					"failed to resolve resource_type from resource_id, pass resource_type explicitly: " + err.Error(),
-				), nil
-			}
-			resourceType = rt
-		}
-
-		queryReq := &interfaces.VegaRawQueryReq{
-			Query:        args.SQL,
-			ResourceType: resourceType,
-			QueryType:    "standard",
-			QueryTimeout: args.QueryTimeout,
-		}
-		resp, err := vega.RawQuery(ctx, queryReq)
+		resp, err := svc.RunSQL(ctx, sqlReq)
 		if err != nil {
 			return mcp.NewToolResultError(err.Error()), nil
 		}

--- a/adp/context-loader/agent-retrieval/server/driveradapters/rest_private_handler.go
+++ b/adp/context-loader/agent-retrieval/server/driveradapters/rest_private_handler.go
@@ -18,6 +18,7 @@ import (
 	"github.com/openbkn-ai/adp/context-loader/agent-retrieval/server/driveradapters/knontologyjob"
 	"github.com/openbkn-ai/adp/context-loader/agent-retrieval/server/driveradapters/knqueryobjectinstance"
 	"github.com/openbkn-ai/adp/context-loader/agent-retrieval/server/driveradapters/knquerysubgraph"
+	"github.com/openbkn-ai/adp/context-loader/agent-retrieval/server/driveradapters/knquerytools"
 	"github.com/openbkn-ai/adp/context-loader/agent-retrieval/server/driveradapters/knretrieval"
 	"github.com/openbkn-ai/adp/context-loader/agent-retrieval/server/driveradapters/knsearch"
 	"github.com/openbkn-ai/adp/context-loader/agent-retrieval/server/driveradapters/mcpproxy"
@@ -34,6 +35,7 @@ type restPrivateHandler struct {
 	MCPProxyHandler                mcpproxy.MCPProxyHandler
 	KnOntologyJobHandler           knontologyjob.KnOntologyJobHandler
 	KnFindSkillsHandler            knfindskills.KnFindSkillsHandler
+	KnQueryToolsHandler            knquerytools.KnQueryToolsHandler
 	Logger                         interfaces.Logger
 }
 
@@ -49,6 +51,7 @@ func NewRestPrivateHandler(logger interfaces.Logger) interfaces.HTTPRouterInterf
 		MCPProxyHandler:                mcpproxy.NewMCPProxyHandler(),
 		KnOntologyJobHandler:           knontologyjob.NewKnOntologyJobHandler(),
 		KnFindSkillsHandler:            knfindskills.NewKnFindSkillsHandler(),
+		KnQueryToolsHandler:            knquerytools.NewKnQueryToolsHandler(),
 		Logger:                         logger,
 	}
 }
@@ -69,6 +72,11 @@ func (r *restPrivateHandler) RegisterRouter(engine *gin.RouterGroup) {
 	engine.POST("/kn/find_skills", r.KnFindSkillsHandler.FindSkills)
 	engine.POST("/kn/full_build_ontology", r.KnOntologyJobHandler.FullBuildOntology)
 	engine.GET("/kn/full_ontology_building_status", r.KnOntologyJobHandler.GetFullOntologyBuildingStatus)
+
+	// 同时作为 MCP 工具 + operator-integration toolbox(OpenAPI HTTP)入口
+	engine.POST("/kn/run_sql", r.KnQueryToolsHandler.RunSQL)
+	engine.POST("/kn/list_knowledge_networks", r.KnQueryToolsHandler.ListKnowledgeNetworks)
+	engine.POST("/kn/get_kn_detail", r.KnQueryToolsHandler.GetKnDetail)
 
 	// MCP Proxy
 	engine.POST("/mcp/proxy/:mcp_id/tools/:tool_name/call", r.MCPProxyHandler.CallMCPTool)

--- a/adp/context-loader/agent-retrieval/server/driveradapters/rest_public_handler.go
+++ b/adp/context-loader/agent-retrieval/server/driveradapters/rest_public_handler.go
@@ -18,6 +18,7 @@ import (
 	"github.com/openbkn-ai/adp/context-loader/agent-retrieval/server/driveradapters/knlogicpropertyresolver"
 	"github.com/openbkn-ai/adp/context-loader/agent-retrieval/server/driveradapters/knqueryobjectinstance"
 	"github.com/openbkn-ai/adp/context-loader/agent-retrieval/server/driveradapters/knquerysubgraph"
+	"github.com/openbkn-ai/adp/context-loader/agent-retrieval/server/driveradapters/knquerytools"
 	"github.com/openbkn-ai/adp/context-loader/agent-retrieval/server/driveradapters/knretrieval"
 	"github.com/openbkn-ai/adp/context-loader/agent-retrieval/server/driveradapters/knsearch"
 	"github.com/openbkn-ai/adp/context-loader/agent-retrieval/server/driveradapters/mcp"
@@ -34,6 +35,7 @@ type restPublicHandler struct {
 	KnQuerySubgraphHandler         knquerysubgraph.KnQuerySubgraphHandler
 	KnSearchHandler                knsearch.KnSearchHandler
 	KnFindSkillsHandler            knfindskills.KnFindSkillsHandler
+	KnQueryToolsHandler            knquerytools.KnQueryToolsHandler
 	Logger                         interfaces.Logger
 }
 
@@ -49,6 +51,7 @@ func NewRestPublicHandler(logger interfaces.Logger) interfaces.HTTPRouterInterfa
 		KnQuerySubgraphHandler:         knquerysubgraph.NewKnQuerySubgraphHandler(),
 		KnSearchHandler:                knsearch.NewKnSearchHandler(),
 		KnFindSkillsHandler:            knfindskills.NewKnFindSkillsHandler(),
+		KnQueryToolsHandler:            knquerytools.NewKnQueryToolsHandler(),
 		Logger:                         logger,
 	}
 }
@@ -67,6 +70,11 @@ func (r *restPublicHandler) RegisterRouter(engine *gin.RouterGroup) {
 	engine.POST("/kn/search_schema", r.KnSearchHandler.SearchSchema)
 	engine.POST("/kn/kn_search", r.KnSearchHandler.KnSearch)
 	engine.POST("/kn/find_skills", r.KnFindSkillsHandler.FindSkills)
+
+	// 同时作为 MCP 工具 + operator-integration toolbox(OpenAPI HTTP)入口
+	engine.POST("/kn/run_sql", r.KnQueryToolsHandler.RunSQL)
+	engine.POST("/kn/list_knowledge_networks", r.KnQueryToolsHandler.ListKnowledgeNetworks)
+	engine.POST("/kn/get_kn_detail", r.KnQueryToolsHandler.GetKnDetail)
 
 	// MCP Server (Bearer token auth, supports Cursor/Claude Desktop)
 	// GET /mcp/info 返回自描述文档（工具目录 + 连接方式），其余走标准 MCP Streamable HTTP。

--- a/adp/context-loader/agent-retrieval/server/logics/knrunsql/guard.go
+++ b/adp/context-loader/agent-retrieval/server/logics/knrunsql/guard.go
@@ -4,7 +4,9 @@
 // Licensed under the Apache License, Version 2.0.
 // See the LICENSE file in the project root for details.
 
-package mcp
+// Package knrunsql provides the shared read-only SQL execution service used by
+// both the MCP run_sql tool and the internal REST endpoint.
+package knrunsql
 
 import (
 	"fmt"
@@ -12,17 +14,17 @@ import (
 	"strings"
 )
 
-// run_sql 工具的只读 SQL 守卫。
+// run_sql 只读 SQL 守卫。
 //
 // vega 的原始查询接口不校验语句类型（INSERT/UPDATE/DELETE/DDL 均会真正执行），
-// 对外只读 MCP 必须在工具层强制 SELECT-only。这里用「剥离注释与字符串字面量后再做词法判定」的
-// 方式做纵深防御：先消除可藏关键字的注释/字符串/占位符，再要求单语句、以 SELECT/WITH 开头、
-// 且不含任何写/DDL 关键字。它不是完整 SQL 解析器，但配合 vega 端的 LIMIT 兜底足以防住越权写。
+// 调用方必须强制 SELECT-only。这里用「剥离注释与字符串字面量后再做词法判定」做纵深防御：
+// 先消除可藏关键字的注释/字符串/占位符，再要求单语句、以 SELECT/WITH 开头、不含写/DDL 关键字。
+// 它不是完整 SQL 解析器，但配合 vega 端的 LIMIT 兜底足以防住越权写。
 
 var (
 	// resourcePlaceholderRe 与 vega extractResourceIDs 保持一致：{{.resource_id}} 或 {{resource_id}}。
 	resourcePlaceholderRe = regexp.MustCompile(`\{\{\.?(\w+)\}\}`)
-	// anyPlaceholderRe 用于在做关键字判定前把占位符整体替换掉，避免 {{.delete}} 之类内部词触发误判。
+	// anyPlaceholderRe 在关键字判定前把占位符整体替换掉，避免 {{.delete}} 之类内部词触发误判。
 	anyPlaceholderRe = regexp.MustCompile(`\{\{[^}]*\}\}`)
 	// startsWithSelectRe 允许前导空白与左括号（如 (SELECT ...) UNION ...）。
 	startsWithSelectRe = regexp.MustCompile(`(?is)^[\s(]*(SELECT|WITH)\b`)
@@ -30,8 +32,8 @@ var (
 	forbiddenKeywordRe = regexp.MustCompile(`(?i)\b(INSERT|UPDATE|DELETE|DROP|ALTER|CREATE|TRUNCATE|GRANT|REVOKE|REPLACE|MERGE|UPSERT|CALL|EXEC|EXECUTE|RENAME|LOAD|COPY|INTO|ATTACH|DETACH|USE|VACUUM|ANALYZE|REFRESH|COMMENT|PREPARE|DEALLOCATE)\b`)
 )
 
-// extractResourceIDs 从 SQL 中提取所有 {{.resource_id}} 占位符内的 resource_id（去重，保序）。
-func extractResourceIDs(sql string) []string {
+// ExtractResourceIDs 从 SQL 中提取所有 {{.resource_id}} 占位符内的 resource_id（去重，保序）。
+func ExtractResourceIDs(sql string) []string {
 	matches := resourcePlaceholderRe.FindAllStringSubmatch(sql, -1)
 	ids := make([]string, 0, len(matches))
 	seen := make(map[string]bool)
@@ -96,8 +98,8 @@ func stripSQLNoise(sql string) string {
 	return b.String()
 }
 
-// ensureReadOnlySQL 校验 SQL 为单条只读 SELECT/WITH 查询；违规返回错误。
-func ensureReadOnlySQL(sql string) error {
+// EnsureReadOnlySQL 校验 SQL 为单条只读 SELECT/WITH 查询；违规返回错误。
+func EnsureReadOnlySQL(sql string) error {
 	if strings.TrimSpace(sql) == "" {
 		return fmt.Errorf("sql is empty")
 	}

--- a/adp/context-loader/agent-retrieval/server/logics/knrunsql/guard_test.go
+++ b/adp/context-loader/agent-retrieval/server/logics/knrunsql/guard_test.go
@@ -4,7 +4,7 @@
 // Licensed under the Apache License, Version 2.0.
 // See the LICENSE file in the project root for details.
 
-package mcp
+package knrunsql
 
 import (
 	"reflect"
@@ -18,14 +18,12 @@ func TestEnsureReadOnlySQL_Allowed(t *testing.T) {
 		`WITH t AS (SELECT * FROM {{.res1}}) SELECT * FROM t`,
 		`(SELECT 1 FROM {{.res1}}) UNION (SELECT 2 FROM {{.res2}})`,
 		`SELECT * FROM {{.res1}};`, // 单个结尾分号允许
-		// 占位符内的词不应触发关键字判定
 		`SELECT * FROM {{.delete_logs}}`,
 		`SELECT * FROM {{.update_history}}`,
-		// 字符串字面量中的关键字不应触发判定
 		`SELECT * FROM {{.res1}} WHERE note = 'please delete later'`,
 	}
 	for _, sql := range cases {
-		if err := ensureReadOnlySQL(sql); err != nil {
+		if err := EnsureReadOnlySQL(sql); err != nil {
 			t.Errorf("expected allowed, got error for %q: %v", sql, err)
 		}
 	}
@@ -43,32 +41,28 @@ func TestEnsureReadOnlySQL_Rejected(t *testing.T) {
 		`ALTER TABLE {{.res1}} ADD COLUMN x int`,
 		`CREATE TABLE x (a int)`,
 		`GRANT ALL ON {{.res1}} TO u`,
-		// 多语句（注入式）
 		`SELECT * FROM {{.res1}}; DROP TABLE {{.res1}}`,
 		`SELECT 1; SELECT 2`,
-		// 用注释藏第二语句仍应被识别为多语句或非 SELECT 起手
 		`SELECT * FROM {{.res1}} -- harmless
 		 ; DELETE FROM {{.res1}}`,
-		// SELECT ... INTO OUTFILE 写文件
 		`SELECT * INTO OUTFILE '/tmp/x' FROM {{.res1}}`,
-		// 不以 SELECT/WITH 起手
 		`SHOW TABLES`,
 		`CALL some_proc()`,
 	}
 	for _, sql := range cases {
-		if err := ensureReadOnlySQL(sql); err == nil {
+		if err := EnsureReadOnlySQL(sql); err == nil {
 			t.Errorf("expected rejected, got nil error for %q", sql)
 		}
 	}
 }
 
 func TestExtractResourceIDs(t *testing.T) {
-	got := extractResourceIDs(`SELECT * FROM {{.res_a}} JOIN {{res_b}} ON 1=1 WHERE x IN (SELECT y FROM {{.res_a}})`)
+	got := ExtractResourceIDs(`SELECT * FROM {{.res_a}} JOIN {{res_b}} ON 1=1 WHERE x IN (SELECT y FROM {{.res_a}})`)
 	want := []string{"res_a", "res_b"}
 	if !reflect.DeepEqual(got, want) {
-		t.Errorf("extractResourceIDs = %v, want %v", got, want)
+		t.Errorf("ExtractResourceIDs = %v, want %v", got, want)
 	}
-	if ids := extractResourceIDs(`SELECT 1`); len(ids) != 0 {
+	if ids := ExtractResourceIDs(`SELECT 1`); len(ids) != 0 {
 		t.Errorf("expected no ids, got %v", ids)
 	}
 }

--- a/adp/context-loader/agent-retrieval/server/logics/knrunsql/index.go
+++ b/adp/context-loader/agent-retrieval/server/logics/knrunsql/index.go
@@ -1,0 +1,95 @@
+// Copyright 2026 openbkn.ai
+// Copyright The kweaver.ai Authors.
+//
+// Licensed under the Apache License, Version 2.0.
+// See the LICENSE file in the project root for details.
+
+package knrunsql
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"sync"
+
+	"github.com/openbkn-ai/adp/context-loader/agent-retrieval/server/drivenadapters"
+	"github.com/openbkn-ai/adp/context-loader/agent-retrieval/server/interfaces"
+)
+
+var (
+	// ErrSQLRequired sql 入参为空。
+	ErrSQLRequired = errors.New("sql is required")
+	// ErrNoResourcePlaceholder SQL 未通过 {{.resource_id}} 占位符引用任何数据资源。
+	ErrNoResourcePlaceholder = errors.New("sql must reference at least one data resource via the {{.resource_id}} placeholder")
+)
+
+// RunSQLReq run_sql 入参（MCP 工具与内部 REST 端点共用）。
+type RunSQLReq struct {
+	SQL          string `json:"sql"`           // Trino 方言 SQL，表名用 {{.resource_id}} 占位
+	ResourceType string `json:"resource_type"` // 连接器类型，留空则按 resource_id 自动解析
+	QueryTimeout int    `json:"query_timeout"` // 查询超时（秒），可选
+}
+
+// KnRunSQLService 对知识网络挂载的数据资源执行只读 SQL（强制 SELECT-only）。
+type KnRunSQLService interface {
+	RunSQL(ctx context.Context, req *RunSQLReq) (*interfaces.VegaRawQueryResp, error)
+}
+
+type knRunSQLService struct {
+	vega interfaces.DrivenVega
+}
+
+var (
+	once     sync.Once
+	instance KnRunSQLService
+)
+
+// NewKnRunSQLService 创建 KnRunSQLService 单例。
+func NewKnRunSQLService() KnRunSQLService {
+	once.Do(func() {
+		instance = &knRunSQLService{
+			vega: drivenadapters.NewVegaAccess(),
+		}
+	})
+	return instance
+}
+
+// NewKnRunSQLServiceWith 注入依赖创建（测试用）。
+func NewKnRunSQLServiceWith(vega interfaces.DrivenVega) KnRunSQLService {
+	return &knRunSQLService{vega: vega}
+}
+
+// RunSQL 守卫 → 提取 resource_id → 解析连接器类型 → 调 vega 原始查询。
+func (s *knRunSQLService) RunSQL(ctx context.Context, req *RunSQLReq) (*interfaces.VegaRawQueryResp, error) {
+	if req == nil || strings.TrimSpace(req.SQL) == "" {
+		return nil, ErrSQLRequired
+	}
+
+	// 只读守卫：拒绝写入 / DDL / 多语句。
+	if err := EnsureReadOnlySQL(req.SQL); err != nil {
+		return nil, err
+	}
+
+	// 必须通过 {{.resource_id}} 占位符引用资源，否则 vega 无法定位数据源。
+	resourceIDs := ExtractResourceIDs(req.SQL)
+	if len(resourceIDs) == 0 {
+		return nil, ErrNoResourcePlaceholder
+	}
+
+	// resource_type 未显式给出时，按第一个 resource_id 自动解析其连接器类型。
+	resourceType := strings.TrimSpace(req.ResourceType)
+	if resourceType == "" {
+		rt, err := s.vega.GetResourceConnectorType(ctx, resourceIDs[0])
+		if err != nil {
+			return nil, err
+		}
+		resourceType = rt
+	}
+
+	return s.vega.RawQuery(ctx, &interfaces.VegaRawQueryReq{
+		Query:        req.SQL,
+		ResourceType: resourceType,
+		QueryType:    "standard",
+		QueryTimeout: req.QueryTimeout,
+	})
+}


### PR DESCRIPTION
## What

Makes the three new query tools (`run_sql`, `list_knowledge_networks`, `get_kn_detail`, added as MCP tools in #62) usable by **execution-factory agents** via the existing **operator-integration toolbox** mechanism — the same path the existing 8 context-loader tools use.

### Why toolbox, not MCP registration
Execution-factory agents consume context-loader capabilities through the **`context_loader_toolset.adp`** toolbox (OpenAPI HTTP tools → `/api/agent-retrieval/in/v1/kn/*`), **not** via the MCP protocol. operator-integration's MCP proxy uses statically-configured headers and does not forward the caller's token, so an MCP-server registration would not authorize downstream calls. The toolbox path sidesteps that entirely (internal REST + header-trusted account context).

### Changes
- **Shared service** `logics/knrunsql`: run_sql core (SELECT-only guard + `{{.resource_id}}` extraction + connector-type resolution + vega `RawQuery`) extracted out of the MCP handler so both the MCP tool and the REST endpoint share it.
- **New handler** `driveradapters/knquerytools`: REST handlers for the three tools, on both public and internal routers:
  - `POST /kn/run_sql`
  - `POST /kn/list_knowledge_networks`
  - `POST /kn/get_kn_detail`
- **Toolbox package** `context_loader_toolset.adp`: 8 → 11 tools — three OpenAPI entries pointing at the internal `/in/v1/kn/*` endpoints. `tool_dependency_sync` pushes this to operator-integration at startup, so the new tools auto-register on deploy.

## Verification
- `go build` / `go vet` clean; `logics/knrunsql` guard tests pass (moved from the mcp package, exported).
- `.adp` validated as JSON; 11 tools, new entries carry correct method/path/body schema.
- Live VM verify of the toolbox import + execution-factory call is pending an image rebuild.

## Note
`execution_factory_tools.adp` is a *different* toolbox (svc_url → operator-integration) and is intentionally left unchanged — agent-retrieval tools belong in the context-loader toolbox (svc_url → agent-retrieval).

🤖 Generated with [Claude Code](https://claude.com/claude-code)