### PR TITLE
feat(bkn-safe): admin API + ops script to manage login-client redirect_uris

### DIFF
--- a/bkn-safe/docs/oauth-redirect-uris.md
+++ b/bkn-safe/docs/oauth-redirect-uris.md
@@ -1,0 +1,73 @@
+# OAuth2 login-client redirect_uris
+
+The login clients (`openbkn-studio`, `openbkn-cli`, `openbkn-sdk`) live in **Hydra's**
+store, not in bkn-safe's database. Their `redirect_uris` are the only URLs Hydra
+will redirect a browser back to after login; a mismatch is the
+`invalid_request ... 'redirect_uri' ... does not match ... pre-registered redirect urls`
+error.
+
+There are three ways to manage them. Use the lowest one that fits.
+
+## 1. Standard dev port (no work)
+
+The chart already registers `http://localhost:8000/studio/callback`
+(`clientSeed.extraWebRedirectUris` default). If every frontend dev runs their local
+studio on **`localhost:8000`**, login works out of the box — no script, no redeploy.
+Standardize on this port and most redirect management disappears.
+
+## 2. Permanent / production addresses → chart values + redeploy
+
+Source of truth is the chart (in git). This survives every upgrade.
+
+- The gateway callback (`https://<accessAddress.host>/studio/callback`) is **derived
+  automatically** from `accessAddress` — nothing to add for the server-side studio.
+- Any extra permanent address goes in `charts/bkn-safe/values.yaml`:
+
+  ```yaml
+  clientSeed:
+    extraWebRedirectUris:
+      - "http://localhost:8000/studio/callback"
+      - "https://studio.example.com/studio/callback"
+  ```
+
+- Apply with `helm upgrade` — the post-upgrade seed job re-registers the clients.
+  No image rebuild (the redirect logic is Helm templating, not Go).
+
+## 3. Temporary / dev addresses → `deploy/scripts/bkn-redirect.sh`
+
+For a one-off (e.g. a dev on a non-standard port hitting a remote install) without a
+redeploy. Calls the bkn-safe admin API (gateway-exposed, RequireAdmin, audited).
+
+```bash
+openbkn auth login https://10.211.55.4   # must be a super-admin session
+export BKN_HOST=https://10.211.55.4
+deploy/scripts/bkn-redirect.sh add http://localhost:5173/studio/callback
+deploy/scripts/bkn-redirect.sh list
+deploy/scripts/bkn-redirect.sh del http://localhost:5173/studio/callback
+```
+
+> **Ephemeral.** A `helm upgrade` re-seeds clients from chart values and wipes
+> anything added this way. For anything that must stick, use option 2. Requires a
+> super-admin token, so this is an ops / team-lead tool, not per-developer
+> self-service (widening who can edit redirect_uris is a security boundary change).
+
+### Admin API used by the script
+
+```http
+GET    /api/safe/v1/admin/clients/:id/redirect-uris
+POST   /api/safe/v1/admin/clients/:id/redirect-uris   {"redirect_uri":"..."}
+DELETE /api/safe/v1/admin/clients/:id/redirect-uris   {"redirect_uri":"..."}
+```
+
+`:id` is restricted to the first-party clients (`openbkn-studio` / `-cli` / `-sdk`).
+`redirect_uri` must be an absolute `http(s)` URL with a host and no wildcard/fragment.
+
+## Which callback URL?
+
+`redirect_uri` = the address the **browser** is on + `/studio/callback`:
+
+- Studio served behind the gateway → `https://<gateway-host>/studio/callback`
+  (VM: `https://10.211.55.4/studio/callback`).
+- Local dev server → `http://localhost:<port>/studio/callback`.
+
+Use the public/gateway host, not an internal service name. Port 443 is omitted.

--- a/bkn-safe/server/internal/auth/hydra.go
+++ b/bkn-safe/server/internal/auth/hydra.go
@@ -75,6 +75,61 @@ func (h *HydraAdmin) AcceptUserCode(ctx context.Context, deviceChallenge, userCo
 	return out.RedirectTo, nil
 }
 
+// GetClientRedirectURIs returns the OAuth2 client's registered redirect_uris.
+func (h *HydraAdmin) GetClientRedirectURIs(ctx context.Context, clientID string) ([]string, error) {
+	cl, _, err := h.api.OAuth2API.GetOAuth2Client(ctx, clientID).Execute()
+	if err != nil {
+		return nil, fmt.Errorf("get oauth2 client %q: %w", clientID, err)
+	}
+	return cl.GetRedirectUris(), nil
+}
+
+// AddClientRedirectURI registers uri on the client (idempotent: a duplicate is a
+// no-op) and returns the resulting redirect_uris.
+func (h *HydraAdmin) AddClientRedirectURI(ctx context.Context, clientID, uri string) ([]string, error) {
+	return h.patchRedirectURIs(ctx, clientID, func(uris []string) []string {
+		for _, u := range uris {
+			if u == uri {
+				return uris // already present
+			}
+		}
+		return append(uris, uri)
+	})
+}
+
+// RemoveClientRedirectURI drops uri from the client (a no-op when absent) and
+// returns the resulting redirect_uris.
+func (h *HydraAdmin) RemoveClientRedirectURI(ctx context.Context, clientID, uri string) ([]string, error) {
+	return h.patchRedirectURIs(ctx, clientID, func(uris []string) []string {
+		out := make([]string, 0, len(uris))
+		for _, u := range uris {
+			if u != uri {
+				out = append(out, u)
+			}
+		}
+		return out
+	})
+}
+
+// patchRedirectURIs reads the client's current redirect_uris, applies mutate, and
+// writes the result back with a JSON Patch. Read-modify-write keeps merge and
+// idempotency logic here — hydra's patch has no add-unique-element operation. The
+// "add" op replaces the member when present (RFC 6902) so it works whether or not
+// the client already has any redirect_uris.
+func (h *HydraAdmin) patchRedirectURIs(ctx context.Context, clientID string, mutate func([]string) []string) ([]string, error) {
+	cl, _, err := h.api.OAuth2API.GetOAuth2Client(ctx, clientID).Execute()
+	if err != nil {
+		return nil, fmt.Errorf("get oauth2 client %q: %w", clientID, err)
+	}
+	next := mutate(cl.GetRedirectUris())
+	patch := []hydra.JsonPatch{{Op: "add", Path: "/redirect_uris", Value: next}}
+	out, _, err := h.api.OAuth2API.PatchOAuth2Client(ctx, clientID).JsonPatch(patch).Execute()
+	if err != nil {
+		return nil, fmt.Errorf("patch oauth2 client %q redirect_uris: %w", clientID, err)
+	}
+	return out.GetRedirectUris(), nil
+}
+
 // LoginRequest is the subset of hydra's login challenge bkn-safe needs.
 type LoginRequest struct {
 	Challenge string

--- a/bkn-safe/server/internal/auth/hydra_redirect_integration_test.go
+++ b/bkn-safe/server/internal/auth/hydra_redirect_integration_test.go
@@ -1,0 +1,128 @@
+//go:build integration
+
+package auth
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"net/http"
+	"os"
+	"testing"
+)
+
+// TestHydraRedirectLive exercises the redirect_uri admin methods against a REAL
+// hydra admin API — the path the stubbed httpapi unit tests cannot cover.
+//
+// Bring up the dev stack and point the test at hydra's admin port:
+//
+//	cd bkn-safe/dev && docker compose up -d postgres hydra-migrate hydra
+//	HYDRA_ADMIN_URL=http://127.0.0.1:4445 go test -tags integration \
+//	  -run TestHydraRedirectLive ./internal/auth/ -v
+//
+// Skips when HYDRA_ADMIN_URL is unset so the normal suite stays hermetic.
+func TestHydraRedirectLive(t *testing.T) {
+	base := os.Getenv("HYDRA_ADMIN_URL")
+	if base == "" {
+		t.Skip("HYDRA_ADMIN_URL unset — start bkn-safe/dev compose and set it to run this")
+	}
+
+	const clientID = "it-redirect-test"
+	const initial = "https://init.example/callback"
+	const added = "http://localhost:8000/studio/callback"
+
+	createClient(t, base, clientID, initial)
+	t.Cleanup(func() { deleteClient(t, base, clientID) })
+
+	h := NewHydraAdmin(base)
+	ctx := context.Background()
+
+	// baseline
+	got, err := h.GetClientRedirectURIs(ctx, clientID)
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	if !has(got, initial) {
+		t.Fatalf("baseline missing %q: %v", initial, got)
+	}
+
+	// add
+	got, err = h.AddClientRedirectURI(ctx, clientID, added)
+	if err != nil {
+		t.Fatalf("add: %v", err)
+	}
+	if !has(got, added) || !has(got, initial) {
+		t.Fatalf("after add want both, got %v", got)
+	}
+
+	// add again -> idempotent (no duplicate)
+	got, err = h.AddClientRedirectURI(ctx, clientID, added)
+	if err != nil {
+		t.Fatalf("re-add: %v", err)
+	}
+	if count(got, added) != 1 {
+		t.Fatalf("re-add not idempotent, %q appears %d times: %v", added, count(got, added), got)
+	}
+
+	// persisted? re-read
+	got, err = h.GetClientRedirectURIs(ctx, clientID)
+	if err != nil {
+		t.Fatalf("get after add: %v", err)
+	}
+	if !has(got, added) {
+		t.Fatalf("add did not persist: %v", got)
+	}
+
+	// remove
+	got, err = h.RemoveClientRedirectURI(ctx, clientID, added)
+	if err != nil {
+		t.Fatalf("remove: %v", err)
+	}
+	if has(got, added) {
+		t.Fatalf("after remove still present: %v", got)
+	}
+	if !has(got, initial) {
+		t.Fatalf("remove dropped the wrong uri: %v", got)
+	}
+}
+
+func createClient(t *testing.T, base, id, redirect string) {
+	t.Helper()
+	deleteClient(t, base, id) // idempotent: clear any leftover from a prior run
+	body := `{"client_id":"` + id + `","grant_types":["authorization_code"],` +
+		`"response_types":["code"],"token_endpoint_auth_method":"none",` +
+		`"redirect_uris":["` + redirect + `"]}`
+	req, _ := http.NewRequest(http.MethodPost, base+"/admin/clients", bytes.NewReader([]byte(body)))
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("create client: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		b, _ := io.ReadAll(resp.Body)
+		t.Fatalf("create client: hydra %d: %s", resp.StatusCode, b)
+	}
+}
+
+func deleteClient(t *testing.T, base, id string) {
+	t.Helper()
+	req, _ := http.NewRequest(http.MethodDelete, base+"/admin/clients/"+id, nil)
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return
+	}
+	resp.Body.Close()
+}
+
+func has(s []string, v string) bool { return count(s, v) > 0 }
+
+func count(s []string, v string) int {
+	n := 0
+	for _, x := range s {
+		if x == v {
+			n++
+		}
+	}
+	return n
+}

--- a/bkn-safe/server/internal/httpapi/clientadmin.go
+++ b/bkn-safe/server/internal/httpapi/clientadmin.go
@@ -1,0 +1,115 @@
+package httpapi
+
+import (
+	"context"
+	"net/http"
+	"net/url"
+	"strings"
+
+	"github.com/gin-gonic/gin"
+)
+
+// ClientManager is the slice of hydra's OAuth2 client admin that bkn-safe exposes:
+// reading and editing a login client's redirect_uris. *auth.HydraAdmin implements
+// it (production); tests inject an in-memory stub so no live hydra is needed.
+type ClientManager interface {
+	GetClientRedirectURIs(ctx context.Context, clientID string) ([]string, error)
+	AddClientRedirectURI(ctx context.Context, clientID, uri string) ([]string, error)
+	RemoveClientRedirectURI(ctx context.Context, clientID, uri string) ([]string, error)
+}
+
+// manageableClients are the first-party login clients whose redirect_uris an admin
+// may edit here. Restricting to the platform's own seeded clients (see
+// charts/bkn-safe client-seed-job) keeps this from being a generic hydra client
+// editor. Kept as its own list — not aliased to firstPartyClients — so loosening
+// what is editable never silently loosens what skips the consent screen.
+var manageableClients = map[string]bool{
+	"openbkn-studio": true,
+	"openbkn-cli":    true,
+	"openbkn-sdk":    true,
+}
+
+// registerClientAdmin mounts redirect-uri management for the platform's login
+// clients under the admin group (RequireAdmin + audited). This is a runtime
+// convenience: a helm upgrade re-seeds clients from chart values, so durable
+// redirect_uris still belong in clientSeed.extraWebRedirectUris.
+func registerClientAdmin(g *gin.RouterGroup, mgr ClientManager) {
+	// GET /clients/:id/redirect-uris -> { "redirect_uris": [...] }
+	g.GET("/clients/:id/redirect-uris", func(c *gin.Context) {
+		id := c.Param("id")
+		if !manageableClients[id] {
+			c.JSON(http.StatusForbidden, gin.H{"error": "client not manageable"})
+			return
+		}
+		uris, err := mgr.GetClientRedirectURIs(c.Request.Context(), id)
+		if err != nil {
+			serverError(c, err)
+			return
+		}
+		c.JSON(http.StatusOK, gin.H{"redirect_uris": uris})
+	})
+
+	// POST /clients/:id/redirect-uris { "redirect_uri": "..." } -> { "redirect_uris" }
+	// Idempotent: adding an already-registered uri returns the unchanged list.
+	g.POST("/clients/:id/redirect-uris", func(c *gin.Context) {
+		id := c.Param("id")
+		if !manageableClients[id] {
+			c.JSON(http.StatusForbidden, gin.H{"error": "client not manageable"})
+			return
+		}
+		var req struct {
+			RedirectURI string `json:"redirect_uri" binding:"required"`
+		}
+		if !bind(c, &req) {
+			return
+		}
+		if !validRedirectURI(req.RedirectURI) {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "redirect_uri must be an absolute http(s) URL with a host and no wildcard or fragment"})
+			return
+		}
+		uris, err := mgr.AddClientRedirectURI(c.Request.Context(), id, req.RedirectURI)
+		if err != nil {
+			serverError(c, err)
+			return
+		}
+		c.JSON(http.StatusOK, gin.H{"redirect_uris": uris})
+	})
+
+	// DELETE /clients/:id/redirect-uris { "redirect_uri": "..." } -> { "redirect_uris" }
+	g.DELETE("/clients/:id/redirect-uris", func(c *gin.Context) {
+		id := c.Param("id")
+		if !manageableClients[id] {
+			c.JSON(http.StatusForbidden, gin.H{"error": "client not manageable"})
+			return
+		}
+		var req struct {
+			RedirectURI string `json:"redirect_uri" binding:"required"`
+		}
+		if !bind(c, &req) {
+			return
+		}
+		uris, err := mgr.RemoveClientRedirectURI(c.Request.Context(), id, req.RedirectURI)
+		if err != nil {
+			serverError(c, err)
+			return
+		}
+		c.JSON(http.StatusOK, gin.H{"redirect_uris": uris})
+	})
+}
+
+// validRedirectURI accepts only an absolute http/https URL with a host and no
+// fragment or wildcard. hydra itself rejects wildcards and fragments; validating
+// up front turns a vague hydra 4xx into a clear 400.
+func validRedirectURI(raw string) bool {
+	if strings.ContainsAny(raw, "*") {
+		return false
+	}
+	u, err := url.Parse(raw)
+	if err != nil {
+		return false
+	}
+	if u.Scheme != "http" && u.Scheme != "https" {
+		return false
+	}
+	return u.Host != "" && u.Fragment == ""
+}

--- a/bkn-safe/server/internal/httpapi/clientadmin_test.go
+++ b/bkn-safe/server/internal/httpapi/clientadmin_test.go
@@ -1,0 +1,192 @@
+package httpapi
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/glebarez/sqlite"
+	"gorm.io/gorm"
+
+	"bkn-safe/internal/audit"
+	"bkn-safe/internal/auth"
+	"bkn-safe/internal/authz"
+	"bkn-safe/internal/database"
+	"bkn-safe/internal/directory"
+)
+
+// fakeClientManager is an in-memory ClientManager (clientID -> redirect_uris) so
+// the client-admin API can be tested without a live hydra.
+type fakeClientManager struct {
+	uris map[string][]string
+}
+
+func newFakeClientManager() *fakeClientManager {
+	return &fakeClientManager{uris: map[string][]string{
+		"openbkn-studio": {"https://host/callback"},
+	}}
+}
+
+func (f *fakeClientManager) GetClientRedirectURIs(_ context.Context, id string) ([]string, error) {
+	return f.uris[id], nil
+}
+
+func (f *fakeClientManager) AddClientRedirectURI(_ context.Context, id, uri string) ([]string, error) {
+	for _, u := range f.uris[id] {
+		if u == uri {
+			return f.uris[id], nil // idempotent
+		}
+	}
+	f.uris[id] = append(f.uris[id], uri)
+	return f.uris[id], nil
+}
+
+func (f *fakeClientManager) RemoveClientRedirectURI(_ context.Context, id, uri string) ([]string, error) {
+	out := make([]string, 0, len(f.uris[id]))
+	for _, u := range f.uris[id] {
+		if u != uri {
+			out = append(out, u)
+		}
+	}
+	f.uris[id] = out
+	return out, nil
+}
+
+// newClientAdminServer builds a server with the client-admin API mounted on top of
+// a fake ClientManager, with adminSub seeded as super-admin (Bearer adminSub passes
+// RequireAdmin).
+func newClientAdminServer(t *testing.T) (*gin.Engine, *fakeClientManager) {
+	t.Helper()
+	gin.SetMode(gin.TestMode)
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	if err != nil {
+		t.Fatalf("sqlite: %v", err)
+	}
+	if err := database.Migrate(db); err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+	e, err := authz.New(db)
+	if err != nil {
+		t.Fatalf("authz: %v", err)
+	}
+	if err := e.Grant(adminSub, "*", "*"); err != nil {
+		t.Fatalf("grant super-admin: %v", err)
+	}
+	fake := newFakeClientManager()
+	r := New(Deps{
+		Enforcer: e, DB: db, Directory: directory.New(db), Users: auth.NewUserStore(db),
+		Audit:         audit.New(db),
+		TokenVerifier: stubVerifier{},
+		ClientAdmin:   fake,
+	})
+	return r, fake
+}
+
+// redirectURIs decodes the { "redirect_uris": [...] } body.
+func redirectURIs(t *testing.T, body []byte) []string {
+	t.Helper()
+	var out struct {
+		RedirectURIs []string `json:"redirect_uris"`
+	}
+	if err := json.Unmarshal(body, &out); err != nil {
+		t.Fatalf("decode body %q: %v", body, err)
+	}
+	return out.RedirectURIs
+}
+
+func contains(s []string, want string) bool {
+	for _, v := range s {
+		if v == want {
+			return true
+		}
+	}
+	return false
+}
+
+func TestClientRedirectAuthGate(t *testing.T) {
+	r, _ := newClientAdminServer(t)
+	const path = "/api/safe/v1/admin/clients/openbkn-studio/redirect-uris"
+
+	if w := tokReq(t, r, http.MethodGet, path, nil, ""); w.Code != http.StatusUnauthorized {
+		t.Fatalf("no token: want 401, got %d", w.Code)
+	}
+	if w := tokReq(t, r, http.MethodGet, path, nil, "bad"); w.Code != http.StatusUnauthorized {
+		t.Fatalf("bad token: want 401, got %d", w.Code)
+	}
+	// valid token, but not a super-admin -> 403
+	if w := tokReq(t, r, http.MethodGet, path, nil, "user-2"); w.Code != http.StatusForbidden {
+		t.Fatalf("non-admin: want 403, got %d", w.Code)
+	}
+}
+
+func TestClientRedirectAddListDelete(t *testing.T) {
+	r, _ := newClientAdminServer(t)
+	const path = "/api/safe/v1/admin/clients/openbkn-studio/redirect-uris"
+	const uri = "http://localhost:8000/studio/callback"
+
+	// add
+	w := adminReq(t, r, http.MethodPost, path, map[string]string{"redirect_uri": uri})
+	if w.Code != http.StatusOK {
+		t.Fatalf("add: want 200, got %d: %s", w.Code, w.Body.String())
+	}
+	if !contains(redirectURIs(t, w.Body.Bytes()), uri) {
+		t.Fatalf("add: %q not in result %v", uri, redirectURIs(t, w.Body.Bytes()))
+	}
+
+	// add again -> idempotent (length unchanged)
+	w = adminReq(t, r, http.MethodPost, path, map[string]string{"redirect_uri": uri})
+	got := redirectURIs(t, w.Body.Bytes())
+	if w.Code != http.StatusOK || len(got) != 2 {
+		t.Fatalf("re-add: want 200 & len 2, got %d & %v", w.Code, got)
+	}
+
+	// list
+	w = adminReq(t, r, http.MethodGet, path, nil)
+	if w.Code != http.StatusOK || !contains(redirectURIs(t, w.Body.Bytes()), uri) {
+		t.Fatalf("list: want uri present, got %d & %v", w.Code, redirectURIs(t, w.Body.Bytes()))
+	}
+
+	// delete
+	w = adminReq(t, r, http.MethodDelete, path, map[string]string{"redirect_uri": uri})
+	if w.Code != http.StatusOK || contains(redirectURIs(t, w.Body.Bytes()), uri) {
+		t.Fatalf("delete: want uri gone, got %d & %v", w.Code, redirectURIs(t, w.Body.Bytes()))
+	}
+}
+
+func TestClientRedirectWhitelist(t *testing.T) {
+	r, _ := newClientAdminServer(t)
+	const path = "/api/safe/v1/admin/clients/some-third-party/redirect-uris"
+
+	if w := adminReq(t, r, http.MethodGet, path, nil); w.Code != http.StatusForbidden {
+		t.Fatalf("GET non-whitelisted: want 403, got %d", w.Code)
+	}
+	if w := adminReq(t, r, http.MethodPost, path, map[string]string{"redirect_uri": "https://h/cb"}); w.Code != http.StatusForbidden {
+		t.Fatalf("POST non-whitelisted: want 403, got %d", w.Code)
+	}
+}
+
+func TestClientRedirectValidation(t *testing.T) {
+	r, _ := newClientAdminServer(t)
+	const path = "/api/safe/v1/admin/clients/openbkn-studio/redirect-uris"
+
+	bad := []string{
+		"not-a-url",
+		"ftp://host/cb",
+		"https://host/cb#frag",
+		"https://*.host/cb",
+		"/just/a/path",
+	}
+	for _, uri := range bad {
+		w := adminReq(t, r, http.MethodPost, path, map[string]string{"redirect_uri": uri})
+		if w.Code != http.StatusBadRequest {
+			t.Fatalf("uri %q: want 400, got %d: %s", uri, w.Code, w.Body.String())
+		}
+	}
+
+	// missing field -> 400
+	if w := adminReq(t, r, http.MethodPost, path, map[string]string{}); w.Code != http.StatusBadRequest {
+		t.Fatalf("missing redirect_uri: want 400, got %d", w.Code)
+	}
+}

--- a/bkn-safe/server/internal/httpapi/router.go
+++ b/bkn-safe/server/internal/httpapi/router.go
@@ -28,6 +28,9 @@ type Deps struct {
 	// TokenVerifier validates admin-API bearer tokens. Defaults to Hydra when
 	// nil (production); tests inject a stub.
 	TokenVerifier TokenVerifier
+	// ClientAdmin manages login clients' redirect_uris (admin API). Defaults to
+	// Hydra when nil (production); tests inject a stub.
+	ClientAdmin ClientManager
 }
 
 // New builds the gin engine with all routes mounted.
@@ -79,6 +82,15 @@ func New(deps Deps) *gin.Engine {
 		registerDeptAdmin(admin, deps.Directory)
 		registerRoleBindings(admin, deps.Enforcer, deps.DB)
 		registerRoles(admin, deps.Enforcer, deps.DB)
+		// Login-client redirect-uri management. Falls back to Hydra in production;
+		// only mounted when a manager is available.
+		clientMgr := deps.ClientAdmin
+		if clientMgr == nil && deps.Hydra != nil {
+			clientMgr = deps.Hydra
+		}
+		if clientMgr != nil {
+			registerClientAdmin(admin, clientMgr)
+		}
 	}
 
 	// Self-service reads under /api/safe/v1/me — token-gated (RequireUser:

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -413,6 +413,35 @@ sudo bash deploy/preflight.sh --check-only --lenient
 kubectl logs -n <namespace> <pod-name>
 ```
 
+### OAuth login redirect_uri mismatch
+
+Login fails with `invalid_request ... 'redirect_uri' ... does not match ... pre-registered redirect urls`:
+the callback the browser sent is not in the login client's (`openbkn-studio`, etc.)
+registered list. These clients live in Hydra and are registered by the bkn-safe
+chart's client-seed Job from `accessAddress` and `clientSeed.*`. The callback is the
+browser's address + `/studio/callback` (e.g. `https://<access-address>/studio/callback`).
+
+```bash
+# 1. Standard dev port (least effort): run the local studio dev server on
+#    localhost:8000; http://localhost:8000/studio/callback is registered by default.
+
+# 2. Permanent / production address -> add to chart values, then reinstall (the
+#    seed Job re-registers it and it survives upgrades):
+#    add an entry to clientSeed.extraWebRedirectUris in
+#    bkn-safe/charts/bkn-safe/values.yaml. The server-side studio's gateway callback
+#    is derived from accessAddress automatically — no need to list it.
+
+# 3. Temporary / dev address -> no reinstall, add via the bkn-safe admin API
+#    (super-admin required; wiped on the next upgrade):
+export BKN_HOST=https://<access-address>
+openbkn auth login "$BKN_HOST"        # must be a super-admin session
+bash deploy/scripts/bkn-redirect.sh add  http://localhost:5173/studio/callback
+bash deploy/scripts/bkn-redirect.sh list
+bash deploy/scripts/bkn-redirect.sh del  http://localhost:5173/studio/callback
+```
+
+See [bkn-safe/docs/oauth-redirect-uris.md](../bkn-safe/docs/oauth-redirect-uris.md) for detail.
+
 ## 📄 License
 
 [Apache License 2.0](../LICENSE)

--- a/deploy/README.zh.md
+++ b/deploy/README.zh.md
@@ -408,6 +408,31 @@ sudo bash deploy/preflight.sh --check-only --lenient
 kubectl logs -n <namespace> <pod-name>
 ```
 
+### OAuth 登录回调地址（redirect_uri）不匹配
+
+登录报 `invalid_request ... 'redirect_uri' ... does not match ... pre-registered redirect urls`：
+浏览器发的回调地址不在该登录客户端（`openbkn-studio` 等）的注册列表里。这些客户端存在
+Hydra 里，由 bkn-safe chart 的 client-seed Job 按 `accessAddress` 与 `clientSeed.*` 注册。
+回调地址 = 浏览器所在地址 + `/studio/callback`（如 `https://<access-address>/studio/callback`）。
+
+```bash
+# 1. 统一本地端口（最省事）：前端本地 dev 跑 localhost:8000，
+#    回调 http://localhost:8000/studio/callback —— chart 默认已注册，开箱即用。
+
+# 2. 永久 / 生产地址 → 写进 chart 值后重装（seed Job 会重新注册，升级也带着）：
+#    bkn-safe/charts/bkn-safe/values.yaml 的 clientSeed.extraWebRedirectUris 增条目。
+#    服务器端 studio 的网关回调由 accessAddress 自动推出，无需手填。
+
+# 3. 临时 / dev 地址 → 不重装，调 bkn-safe admin 接口加（需超管，升级会被冲）：
+export BKN_HOST=https://<access-address>
+openbkn auth login "$BKN_HOST"        # 须为超管会话
+bash deploy/scripts/bkn-redirect.sh add  http://localhost:5173/studio/callback
+bash deploy/scripts/bkn-redirect.sh list
+bash deploy/scripts/bkn-redirect.sh del  http://localhost:5173/studio/callback
+```
+
+详见 [bkn-safe/docs/oauth-redirect-uris.md](../bkn-safe/docs/oauth-redirect-uris.md)。
+
 ## 📄 License
 
 [Apache License 2.0](../LICENSE)

--- a/deploy/scripts/bkn-redirect.sh
+++ b/deploy/scripts/bkn-redirect.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+# bkn-redirect.sh — list/add/remove an OAuth2 login client's redirect_uris via the
+# bkn-safe admin API (gateway-exposed), so a redirect can be registered without
+# kubectl or a helm redeploy.
+#
+# THIS IS THE EPHEMERAL/DEV PATH. A `helm upgrade` re-seeds the login clients from
+# chart values and WIPES anything added here. Durable redirect_uris belong in the
+# chart: clientSeed.extraWebRedirectUris (see bkn-safe/docs/oauth-redirect-uris.md).
+#
+# Requires the openbkn CLI (for an admin token) and a super-admin session — the
+# admin API is gated by RequireAdmin. A non-admin caller gets 403.
+#
+# Usage:
+#   bkn-redirect.sh list [client]
+#   bkn-redirect.sh add  <redirect_uri> [client]
+#   bkn-redirect.sh del  <redirect_uri> [client]
+#
+# Defaults: client = openbkn-studio.
+# Host: set BKN_HOST to the gateway base URL (e.g. https://10.211.55.4); when unset
+# the script reads it from `openbkn auth status`.
+set -euo pipefail
+
+CLIENT_DEFAULT="openbkn-studio"
+
+die() { echo "error: $*" >&2; exit 1; }
+
+command -v openbkn >/dev/null 2>&1 || die "openbkn CLI not found (needed for the admin token)"
+command -v curl    >/dev/null 2>&1 || die "curl not found"
+
+# Resolve the gateway base URL: BKN_HOST wins, else parse the active session.
+host="${BKN_HOST:-}"
+if [ -z "$host" ]; then
+  host="$(openbkn auth status 2>/dev/null | grep -oE 'https?://[^[:space:]]+' | head -1 || true)"
+fi
+[ -n "$host" ] || die "gateway base URL unknown — set BKN_HOST=https://<host> (or run 'openbkn auth login <url>')"
+host="${host%/}" # strip trailing slash
+
+token="$(openbkn auth token 2>/dev/null || true)"
+[ -n "$token" ] || die "no access token — run 'openbkn auth login <url>' and switch to a super-admin user"
+
+# api METHOD CLIENT [json-body]
+api() {
+  local method="$1" client="$2" body="${3:-}"
+  local url="$host/api/safe/v1/admin/clients/$client/redirect-uris"
+  if [ -n "$body" ]; then
+    curl -sk -X "$method" "$url" \
+      -H "Authorization: Bearer $token" -H 'Content-Type: application/json' -d "$body"
+  else
+    curl -sk -X "$method" "$url" -H "Authorization: Bearer $token"
+  fi
+}
+
+# uri_body URI -> {"redirect_uri":"URI"} with URI JSON-escaped (handles quotes/backslashes)
+uri_body() {
+  local uri="$1"
+  uri="${uri//\\/\\\\}"; uri="${uri//\"/\\\"}"
+  printf '{"redirect_uri":"%s"}' "$uri"
+}
+
+cmd="${1:-}"
+case "$cmd" in
+  list)
+    client="${2:-$CLIENT_DEFAULT}"
+    api GET "$client"
+    ;;
+  add)
+    uri="${2:-}"; [ -n "$uri" ] || die "usage: bkn-redirect.sh add <redirect_uri> [client]"
+    client="${3:-$CLIENT_DEFAULT}"
+    api POST "$client" "$(uri_body "$uri")"
+    ;;
+  del|delete|rm)
+    uri="${2:-}"; [ -n "$uri" ] || die "usage: bkn-redirect.sh del <redirect_uri> [client]"
+    client="${3:-$CLIENT_DEFAULT}"
+    api DELETE "$client" "$(uri_body "$uri")"
+    ;;
+  ""|-h|--help|help)
+    sed -n '2,30p' "$0" | sed 's/^# \{0,1\}//'
+    ;;
+  *)
+    die "unknown command '$cmd' (use: list | add | del)"
+    ;;
+esac
+echo


### PR DESCRIPTION
## What

Adds a token-gated admin surface to **read / add / remove an OAuth2 login client's `redirect_uris`** at runtime, plus an ops script and docs. Motivated by the recurring `invalid_request ... 'redirect_uri' ... does not match ... pre-registered redirect urls` login error.

Login clients (`openbkn-studio` / `-cli` / `-sdk`) live in **Hydra's** store, not bkn-safe's DB — so this wraps Hydra's admin API rather than touching GORM.

## Endpoints (under `/api/safe/v1/admin`, RequireAdmin + audited)

```
GET    /clients/:id/redirect-uris
POST   /clients/:id/redirect-uris   {"redirect_uri":"..."}
DELETE /clients/:id/redirect-uris   {"redirect_uri":"..."}
```

- `HydraAdmin` gains `GetClientRedirectURIs` / `AddClientRedirectURI` / `RemoveClientRedirectURI` (read-modify-write via JSON Patch, idempotent merge).
- `ClientManager` interface keeps handlers unit-testable without a live Hydra (in-memory stub in tests).
- `:id` restricted to first-party clients; `redirect_uri` must be an absolute `http(s)` URL with a host and no wildcard/fragment.

## Also

- `deploy/scripts/bkn-redirect.sh` — wraps the API (`openbkn` token + curl) for ops/team-lead use.
- `bkn-safe/docs/oauth-redirect-uris.md` — the three layers: standard dev port / chart values (durable) / script (ephemeral), and which callback URL to use.
- `deploy/README.md` + `README.zh.md` — Troubleshooting entry for the mismatch error.

## Scope / caveat

This is the **ephemeral** path: a `helm upgrade` re-seeds clients from chart values and wipes runtime changes. Durable redirect_uris belong in `clientSeed.extraWebRedirectUris` (the chart already auto-derives the gateway callback from `accessAddress`).

## Tests

`go test ./internal/httpapi/ ./internal/auth/` — green. New cases: auth gate (401/403), add/list/delete (idempotent), first-party whitelist (403), redirect_uri validation (400).

> Not yet verified against a live Hydra (handler logic is covered with a stubbed ClientManager); the real JSON-Patch path is exercised manually / via the dev compose stack.

🤖 Generated with [Claude Code](https://claude.com/claude-code)