### PR TITLE
fix(vega-buildtask): surface embedding-build failure (cause + per-index health)

### DIFF
--- a/adp/vega/vega-backend/server/interfaces/build_task.go
+++ b/adp/vega/vega-backend/server/interfaces/build_task.go
@@ -64,6 +64,21 @@ type BuildTask struct {
 	FulltextFields   string      `json:"fulltext_fields,omitempty"`   // 需建全文索引的字段(逗号分隔)；string→加 text 子字段，text→主字段分词
 	FulltextAnalyzer string      `json:"fulltext_analyzer,omitempty"` // 全文分词器(standard/ik_max_word/hanlp_index 等)，空为 OpenSearch 默认
 	CatalogID        string      `json:"catalog_id"`
+
+	// IndexHealth 为响应时计算的派生状态，**不落库**：让消费方无需自己推断
+	// "completed 其实是失败"。service 层在返回前填充。
+	IndexHealth *IndexHealth `json:"index_health,omitempty"`
+}
+
+// IndexHealth 拆分各索引的健康度。status=completed 只代表 sync 完成 + fulltext 生效，
+// 不代表 embedding 索引可用——本结构把两者分开，整体可用性看 Usable。
+type IndexHealth struct {
+	// none(未建) | building(进行中) | ok | partial(部分文档缺向量) | failed(全部缺向量)
+	Embedding string `json:"embedding"`
+	// none(未建) | ok（全文随同步即时生效，建了即 ok）
+	Fulltext string `json:"fulltext"`
+	// embedding 索引是否完全可用（none 或 ok 为 true；partial/failed/building 为 false）
+	Usable bool `json:"usable"`
 }
 
 // CreateBuildTaskRequest represents the request to create a build task.

--- a/adp/vega/vega-backend/server/logics/build_task/build_task_service.go
+++ b/adp/vega/vega-backend/server/logics/build_task/build_task_service.go
@@ -235,8 +235,36 @@ func (bts *buildTaskService) GetBuildTaskByID(ctx context.Context, id string) (*
 			verrors.VegaBackend_BuildTask_InternalError_GetAccountNamesFailed).WithErrorDetails(err.Error())
 	}
 
+	buildTask.IndexHealth = computeIndexHealth(buildTask)
 	span.SetStatus(codes.Ok, "")
 	return buildTask, nil
+}
+
+// computeIndexHealth 按当前计数派生各索引健康度（不落库）。embedding 与 fulltext
+// 相互独立：fulltext 随同步即时生效，建了即 ok；embedding 要等向量写满才算 ok。
+// 仅在终态给出 ok/partial/failed，进行中统一 building，避免把中途进度误报成失败。
+func computeIndexHealth(bt *interfaces.BuildTask) *interfaces.IndexHealth {
+	h := &interfaces.IndexHealth{Embedding: "none", Fulltext: "none"}
+	if bt.FulltextFields != "" {
+		h.Fulltext = "ok"
+	}
+	switch {
+	case bt.EmbeddingFields == "":
+		h.Embedding = "none"
+	case bt.Status == interfaces.BuildTaskStatusRunning || bt.Status == interfaces.BuildTaskStatusInit:
+		h.Embedding = "building"
+	case bt.SyncedCount == 0:
+		// 无数据可向量化，空索引视为可用
+		h.Embedding = "ok"
+	case bt.VectorizedCount >= bt.SyncedCount:
+		h.Embedding = "ok"
+	case bt.VectorizedCount == 0:
+		h.Embedding = "failed"
+	default:
+		h.Embedding = "partial"
+	}
+	h.Usable = h.Embedding == "none" || h.Embedding == "ok"
+	return h
 }
 
 // GetBuildTaskByResourceID retrieves a build task by resource ID.
@@ -258,6 +286,7 @@ func (bts *buildTaskService) GetBuildTaskByResourceID(ctx context.Context, resou
 			return nil, rest.NewHTTPError(ctx, http.StatusInternalServerError,
 				verrors.VegaBackend_BuildTask_InternalError_GetAccountNamesFailed).WithErrorDetails(err.Error())
 		}
+		buildTask.IndexHealth = computeIndexHealth(buildTask)
 	}
 
 	span.SetStatus(codes.Ok, "")
@@ -279,6 +308,7 @@ func (bts *buildTaskService) ListBuildTasks(ctx context.Context, params interfac
 	accountInfos := make([]*interfaces.AccountInfo, 0, len(buildTasks)*2)
 	for _, bt := range buildTasks {
 		accountInfos = append(accountInfos, &bt.Creator, &bt.Updater)
+		bt.IndexHealth = computeIndexHealth(bt)
 	}
 	if err := bts.ums.GetAccountNames(ctx, accountInfos); err != nil {
 		span.SetStatus(codes.Error, "GetAccountNames error")

--- a/adp/vega/vega-backend/server/logics/build_task/build_task_service_test.go
+++ b/adp/vega/vega-backend/server/logics/build_task/build_task_service_test.go
@@ -198,3 +198,53 @@ func TestUpdateBuildTaskConfigRejectsNoFields(t *testing.T) {
 		t.Fatalf("expected 400, got %v", err)
 	}
 }
+
+func TestComputeIndexHealth(t *testing.T) {
+	cases := []struct {
+		name          string
+		bt            interfaces.BuildTask
+		wantEmbedding string
+		wantFulltext  string
+		wantUsable    bool
+	}{
+		{
+			name:          "embedding all failed (completed but vectorized=0) -> failed, fulltext ok, unusable",
+			bt:            interfaces.BuildTask{Status: "completed", EmbeddingFields: "name", FulltextFields: "name", SyncedCount: 6, VectorizedCount: 0},
+			wantEmbedding: "failed", wantFulltext: "ok", wantUsable: false,
+		},
+		{
+			name:          "embedding partial -> partial, unusable",
+			bt:            interfaces.BuildTask{Status: "completed", EmbeddingFields: "name", SyncedCount: 6, VectorizedCount: 4},
+			wantEmbedding: "partial", wantFulltext: "none", wantUsable: false,
+		},
+		{
+			name:          "embedding full -> ok, usable",
+			bt:            interfaces.BuildTask{Status: "completed", EmbeddingFields: "name", SyncedCount: 6, VectorizedCount: 6},
+			wantEmbedding: "ok", wantFulltext: "none", wantUsable: true,
+		},
+		{
+			name:          "no embedding requested -> none, usable",
+			bt:            interfaces.BuildTask{Status: "completed", FulltextFields: "name", SyncedCount: 6},
+			wantEmbedding: "none", wantFulltext: "ok", wantUsable: true,
+		},
+		{
+			name:          "running -> building, not usable yet",
+			bt:            interfaces.BuildTask{Status: "running", EmbeddingFields: "name", SyncedCount: 6, VectorizedCount: 2},
+			wantEmbedding: "building", wantFulltext: "none", wantUsable: false,
+		},
+		{
+			name:          "empty table -> ok, usable",
+			bt:            interfaces.BuildTask{Status: "completed", EmbeddingFields: "name", SyncedCount: 0, VectorizedCount: 0},
+			wantEmbedding: "ok", wantFulltext: "none", wantUsable: true,
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			h := computeIndexHealth(&c.bt)
+			if h.Embedding != c.wantEmbedding || h.Fulltext != c.wantFulltext || h.Usable != c.wantUsable {
+				t.Fatalf("got embedding=%s fulltext=%s usable=%v, want %s/%s/%v",
+					h.Embedding, h.Fulltext, h.Usable, c.wantEmbedding, c.wantFulltext, c.wantUsable)
+			}
+		})
+	}
+}

--- a/adp/vega/vega-backend/server/worker/build_handler_embedding.go
+++ b/adp/vega/vega-backend/server/worker/build_handler_embedding.go
@@ -292,12 +292,16 @@ func (eh *embeddingHandler) executeEmbedding(ctx context.Context, resource *inte
 					_ = eh.commitMessages(reader, dmsg)
 				}
 
-				// 排空后补扫重试耗尽的失败文档
+				// 排空后补扫重试耗尽的失败文档；保留一个代表性错误作为根因。
+				// 整批同一原因（如模型不存在/不可达）时，最后一条即可解释全部失败——
+				// 仅记 docID 列表看不出"为什么"，failure_detail 必须带上这个 cause。
 				stillFailed := []string{}
+				var failureCause error
 				for _, failedID := range failedDocIDs {
 					if err := eh.vectorizeDoc(ctx, indexName, failedID, buildTaskInfo.EmbeddingModel, embeddingFields); err != nil {
 						logger.Errorf("Vectorize document %s failed in final sweep: %v", failedID, err)
 						stillFailed = append(stillFailed, failedID)
+						failureCause = err
 					} else {
 						countProcessed(failedID)
 					}
@@ -335,7 +339,7 @@ func (eh *embeddingHandler) executeEmbedding(ctx context.Context, resource *inte
 				// failure_detail 说明缺了哪些；error_msg 仅留给整任务硬失败）。显式置空以清除上一轮重建的陈旧明细。
 				updates["failureDetail"] = ""
 				if len(stillFailed) > 0 {
-					updates["failureDetail"] = formatVectorizeFailures(stillFailed)
+					updates["failureDetail"] = formatVectorizeFailures(stillFailed, failureCause)
 				}
 				// 必须同时回写最终计数：常规回写有 30 秒批量窗口，
 				// 不在这里 flush 会丢最后一个窗口的进度（短任务界面会停在 0%）
@@ -484,14 +488,25 @@ func (eh *embeddingHandler) vectorizeDoc(ctx context.Context, indexName, docID, 
 	return nil
 }
 
-// formatVectorizeFailures 生成完成态下向量缺失的说明，ID 列表截断避免撑爆 error_msg
-func formatVectorizeFailures(failed []string) string {
+// formatVectorizeFailures 生成完成态下向量缺失的说明：先给根因（cause），再列文档 ID。
+// cause 让消费方（UI/SDK）一眼看出"为什么"——整批同因失败时（模型不存在/不可达）
+// 只有 ID 列表无从判断索引为何不可用。ID 列表与 cause 均截断，避免撑爆 failure_detail。
+func formatVectorizeFailures(failed []string, cause error) string {
 	const maxListed = 20
+	const maxCauseLen = 300
 	listed := failed
 	if len(listed) > maxListed {
 		listed = listed[:maxListed]
 	}
-	msg := fmt.Sprintf("vectorization failed for %d documents: %s", len(failed), strings.Join(listed, ","))
+	msg := fmt.Sprintf("vectorization failed for %d documents", len(failed))
+	if cause != nil {
+		causeStr := cause.Error()
+		if len(causeStr) > maxCauseLen {
+			causeStr = causeStr[:maxCauseLen] + "..."
+		}
+		msg += fmt.Sprintf(" (cause: %s)", causeStr)
+	}
+	msg += ": " + strings.Join(listed, ",")
 	if len(failed) > maxListed {
 		msg += fmt.Sprintf(" ... and %d more", len(failed)-maxListed)
 	}

--- a/adp/vega/vega-backend/server/worker/build_handler_vectorize_test.go
+++ b/adp/vega/vega-backend/server/worker/build_handler_vectorize_test.go
@@ -113,7 +113,7 @@ func TestFormatVectorizeFailures_Truncates(t *testing.T) {
 		failed[i] = fmt.Sprintf("doc%02d", i)
 	}
 
-	msg := formatVectorizeFailures(failed)
+	msg := formatVectorizeFailures(failed, nil)
 	if !strings.Contains(msg, "failed for 25 documents") {
 		t.Fatalf("missing total count: %s", msg)
 	}
@@ -124,8 +124,28 @@ func TestFormatVectorizeFailures_Truncates(t *testing.T) {
 		t.Fatalf("should list only first 20 ids: %s", msg)
 	}
 
-	short := formatVectorizeFailures([]string{"a", "b"})
+	short := formatVectorizeFailures([]string{"a", "b"}, nil)
 	if strings.Contains(short, "more") || !strings.Contains(short, "a,b") {
 		t.Fatalf("short list should be complete: %s", short)
+	}
+}
+
+// 根因必须落进 failure_detail：整批同因失败（如模型不存在）时，
+// 仅有 docID 列表无从判断索引为何不可用，cause 是 UI/SDK 的唯一可见信号。
+func TestFormatVectorizeFailures_IncludesCause(t *testing.T) {
+	cause := errors.New("get vector request failed with status code: 400, ModelFactory.ExternalSmallModel.Used.NameNotExist")
+	msg := formatVectorizeFailures([]string{"1-", "2-"}, cause)
+	if !strings.Contains(msg, "cause: ") || !strings.Contains(msg, "NameNotExist") {
+		t.Fatalf("failure detail must surface the root cause: %s", msg)
+	}
+	if !strings.Contains(msg, "1-,2-") {
+		t.Fatalf("doc ids still listed after cause: %s", msg)
+	}
+
+	// 超长 cause 截断，避免撑爆 failure_detail
+	long := errors.New(strings.Repeat("x", 600))
+	capped := formatVectorizeFailures([]string{"1-"}, long)
+	if !strings.Contains(capped, "...") || len(capped) > 500 {
+		t.Fatalf("long cause should be truncated: len=%d", len(capped))
 	}
 }


### PR DESCRIPTION
## Problem

A build task with embedding requested can finish as **`completed` with `vectorized_count=0`** — sync and the fulltext index succeed independently, so the task reaches the embedding sentinel and is marked completed even when *every* document failed to vectorize. Two gaps made this invisible:

1. The only failure signal, `failure_detail`, listed just document IDs (`vectorization failed for 6 documents: 1-,2-,...`) — **not why**. Observed live: all docs failed with a transient `ModelFactory.ExternalSmallModel.Used.NameNotExist` from the embedding model call.
2. `completed` was treated as full success by consumers (the UI showed green "已完成 + 向量化 0%"), so an empty/unusable embedding index read as success. **`completed` ≠ usable index.**

## Changes

**1. `failure_detail` carries the root cause** (`build_handler_embedding.go`)
Capture a representative error from the final retry sweep and prepend it as `(cause: ...)`, truncated to 300 chars:
```
vectorization failed for 6 documents (cause: get vector: ...NameNotExist...): 1-,...
```

**2. Per-index health in build-task responses** (`interfaces/build_task.go`, `logics/build_task/build_task_service.go`)
Computed `index_health` (no schema migration; populated in the service layer, never persisted):
```jsonc
index_health: {
  embedding: "none | building | ok | partial | failed",
  fulltext:  "none | ok",   // fulltext is immediate with sync
  usable:    false           // embedding index fully usable (none|ok)
}
```
Status stays `completed` — fulltext is a separate, working index, so flipping to `failed` would misreport it. Consumers now read one explicit signal instead of inferring health from raw counts.

## Tests
- `TestFormatVectorizeFailures_IncludesCause` (cause surfaced + truncated; doc IDs still listed)
- `TestComputeIndexHealth` (all-failed / partial / ok / none / running / empty-table)
- Existing `TestFormatVectorizeFailures_Truncates`, `TestVectorizeDoc_*`, build_task service tests green.

## Follow-up (separate, frontend repo)
`build-task.service.ts`: consume `index_health` — render a degraded badge + `failure_detail` instead of green "已完成 + 0%".

🤖 Generated with [Claude Code](https://claude.com/claude-code)