### PR TITLE
fix(vega): cascade-delete build tasks + indexes on resource/catalog delete

### DIFF
--- a/adp/vega/vega-backend/server/interfaces/build_task.go
+++ b/adp/vega/vega-backend/server/interfaces/build_task.go
@@ -130,3 +130,10 @@ type KeyValue struct {
 	Key   string
 	Value any
 }
+
+// BuildIndexName 返回构建任务对应的 OpenSearch 索引名。索引名 = 前缀-资源ID-任务ID，
+// 与任务一一对应。删除任务/资源/目录时据此 drop 索引，避免孤儿索引。
+// 单一来源：worker 建索引与各处级联清理都用它，别在多处手拼。
+func BuildIndexName(resourceID, buildTaskID string) string {
+	return BUILD_PREFIX + "-" + resourceID + "-" + buildTaskID
+}

--- a/adp/vega/vega-backend/server/logics/cascade.go
+++ b/adp/vega/vega-backend/server/logics/cascade.go
@@ -1,0 +1,72 @@
+// Copyright 2026 openbkn.ai
+// Copyright The kweaver.ai Authors.
+//
+// Licensed under the Apache License, Version 2.0.
+// See the LICENSE file in the project root for details.
+
+package logics
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/kweaver-ai/kweaver-go-lib/logger"
+	"github.com/kweaver-ai/kweaver-go-lib/rest"
+
+	verrors "vega-backend/errors"
+	"vega-backend/interfaces"
+)
+
+// DS 是 logics 层共享的 DatasetService，启动 wiring 处注入（见 SetDatasetService）。
+// 单独放全局而非由各 service 自行构造，是因为 dataset 包反向 import catalog——
+// catalog/cascade 不能直接 import dataset，只能在无环的启动处注入。
+var DS interfaces.DatasetService
+
+// SetDatasetService 在启动处注入 DatasetService（该处可安全 import dataset 包，无环）。
+func SetDatasetService(ds interfaces.DatasetService) { DS = ds }
+
+// CascadeDeleteBuildTasks 删除 filter 命中的所有构建任务及其 OpenSearch 索引，
+// 让"删资源"/"删数据连接(catalog)"不再留下孤儿任务行或孤儿索引。
+//
+// filter 须设 ResourceID（删单个资源）或 CatalogID（删整个 catalog 下全部资源）之一。
+// 任一命中任务处于 running/stopping → 整体拒绝（HasRunningExecution），不删任何东西，
+// 避免删一半留下不一致；用户需先停止再删。
+//
+// 索引 drop 失败仅记日志、不阻断（与既有"索引删除失败不影响资源删除"语义一致）；
+// 任务行删除失败才返回错误。放在 logics 包是因为它同时被 resource 与 catalog 两个
+// service 复用，而 logics/build_task 反向依赖 logics/catalog（放那会成环）。
+func CascadeDeleteBuildTasks(ctx context.Context, bta interfaces.BuildTaskAccess, ds interfaces.DatasetService, filter interfaces.BuildTasksQueryParams) error {
+	// Limit=0 → 不分页，取全部命中任务（含历史任务，连同其孤儿索引一并清）
+	filter.Limit = 0
+	filter.Offset = 0
+	tasks, _, err := bta.List(ctx, filter)
+	if err != nil {
+		return rest.NewHTTPError(ctx, http.StatusInternalServerError, verrors.VegaBackend_BuildTask_InternalError_GetFailed).
+			WithErrorDetails(err.Error())
+	}
+
+	// 先整体校验运行态：有任务在跑就拒绝，绝不删一半
+	running := make([]string, 0)
+	for _, t := range tasks {
+		if t.Status == interfaces.BuildTaskStatusRunning || t.Status == interfaces.BuildTaskStatusStopping {
+			running = append(running, t.ID)
+		}
+	}
+	if len(running) > 0 {
+		return rest.NewHTTPError(ctx, http.StatusConflict, verrors.VegaBackend_BuildTask_HasRunningExecution).
+			WithErrorDetails(map[string]any{"running_ids": running})
+	}
+
+	// 逐任务：drop 索引（尽力）+ 删任务行
+	for _, t := range tasks {
+		idx := interfaces.BuildIndexName(t.ResourceID, t.ID)
+		if err := ds.Delete(ctx, idx); err != nil {
+			logger.Errorf("cascade delete: drop index %s failed: %v", idx, err)
+		}
+		if err := bta.Delete(ctx, t.ID); err != nil {
+			return rest.NewHTTPError(ctx, http.StatusInternalServerError, verrors.VegaBackend_BuildTask_InternalError_DeleteFailed).
+				WithErrorDetails(err.Error())
+		}
+	}
+	return nil
+}

--- a/adp/vega/vega-backend/server/logics/catalog/catalog_service.go
+++ b/adp/vega/vega-backend/server/logics/catalog/catalog_service.go
@@ -54,6 +54,8 @@ type catalogService struct {
 	ra         interfaces.ResourceAccess
 	ps         interfaces.PermissionService
 	ums        interfaces.UserMgmtService
+	bta        interfaces.BuildTaskAccess // 删 catalog 时级联清其下资源的构建任务/索引
+	ds         interfaces.DatasetService  // 同上，drop OpenSearch 索引
 }
 
 // NewCatalogService creates a new CatalogService.
@@ -708,6 +710,26 @@ func (cs *catalogService) DeleteByIDs(ctx context.Context, ids []string) error {
 				return rest.NewHTTPError(ctx, http.StatusForbidden, rest.PublicError_Forbidden).
 					WithErrorDetails("Access denied: insufficient permissions for catalog's delete operation.")
 			}
+		}
+	}
+
+	// 删 catalog 前先级联清掉其下所有资源的构建任务 + OpenSearch 索引，
+	// 否则资源行被删后任务行与索引全成孤儿。运行中任务会拒绝整个删除（HasRunningExecution），
+	// 用户需先停止再删。放在删 catalog/resource 行之前，cascade 失败则什么都不删。
+	// bta/ds 默认走 logics 全局（生产）；测试经 struct 字段注入 mock。不在构造器读全局，
+	// 避开 dataset→catalog 的 sync.Once 初始化顺序坑（构造时 DS 可能尚未注入）。
+	bta, ds := cs.bta, cs.ds
+	if bta == nil {
+		bta = logics.BTA
+	}
+	if ds == nil {
+		ds = logics.DS
+	}
+	for _, id := range ids {
+		if err := logics.CascadeDeleteBuildTasks(ctx, bta, ds,
+			interfaces.BuildTasksQueryParams{CatalogID: id}); err != nil {
+			span.SetStatus(codes.Error, "Cascade delete build tasks failed")
+			return err
 		}
 	}
 

--- a/adp/vega/vega-backend/server/logics/catalog/catalog_service_test.go
+++ b/adp/vega/vega-backend/server/logics/catalog/catalog_service_test.go
@@ -574,6 +574,56 @@ func TestDeleteByIDs_Empty(t *testing.T) {
 	}
 }
 
+// 删 catalog 应级联清掉其下资源的构建任务 + OpenSearch 索引，不留孤儿。
+func TestDeleteByIDs_CascadesBuildTasksAndIndexes(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	mockCA := mock_interfaces.NewMockCatalogAccess(ctrl)
+	mockPS := mock_interfaces.NewMockPermissionService(ctrl)
+	mockRA := mock_interfaces.NewMockResourceAccess(ctrl)
+	mockBTA := mock_interfaces.NewMockBuildTaskAccess(ctrl)
+	mockDS := mock_interfaces.NewMockDatasetService(ctrl)
+
+	mockCA.EXPECT().ListInternalIDs(gomock.Any()).Return([]string{}, nil)
+	mockPS.EXPECT().FilterResources(gomock.Any(), interfaces.AUTH_RESOURCE_TYPE_CATALOG,
+		[]string{"c1"}, gomock.Any(), true, gomock.Any()).
+		Return(map[string]interfaces.PermissionResourceOps{"c1": {ResourceID: "c1"}}, nil)
+	// catalog c1 下一个已完成任务 t1(资源 r1) → 级联 drop 索引 + 删任务
+	mockBTA.EXPECT().List(gomock.Any(), gomock.Any()).
+		Return([]*interfaces.BuildTask{{ID: "t1", ResourceID: "r1", Status: "completed"}}, int64(1), nil)
+	mockDS.EXPECT().Delete(gomock.Any(), interfaces.BuildIndexName("r1", "t1")).Return(nil)
+	mockBTA.EXPECT().Delete(gomock.Any(), "t1").Return(nil)
+	mockCA.EXPECT().DeleteByIDs(gomock.Any(), []string{"c1"}).Return(nil)
+	mockRA.EXPECT().DeleteByCatalogIDs(gomock.Any(), []string{"c1"}).Return(nil)
+	mockPS.EXPECT().DeleteResources(gomock.Any(), interfaces.AUTH_RESOURCE_TYPE_CATALOG, []string{"c1"}).Return(nil)
+
+	cs := &catalogService{ca: mockCA, ps: mockPS, ra: mockRA, bta: mockBTA, ds: mockDS}
+	if err := cs.DeleteByIDs(context.Background(), []string{"c1"}); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+// 删 catalog 时其下有运行中任务 → 级联拒绝，catalog/资源都不删。
+func TestDeleteByIDs_RefusesWhenTaskRunning(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	mockCA := mock_interfaces.NewMockCatalogAccess(ctrl)
+	mockPS := mock_interfaces.NewMockPermissionService(ctrl)
+	mockBTA := mock_interfaces.NewMockBuildTaskAccess(ctrl)
+	mockDS := mock_interfaces.NewMockDatasetService(ctrl)
+
+	mockCA.EXPECT().ListInternalIDs(gomock.Any()).Return([]string{}, nil)
+	mockPS.EXPECT().FilterResources(gomock.Any(), interfaces.AUTH_RESOURCE_TYPE_CATALOG,
+		[]string{"c1"}, gomock.Any(), true, gomock.Any()).
+		Return(map[string]interfaces.PermissionResourceOps{"c1": {ResourceID: "c1"}}, nil)
+	mockBTA.EXPECT().List(gomock.Any(), gomock.Any()).
+		Return([]*interfaces.BuildTask{{ID: "t1", ResourceID: "r1", Status: "running"}}, int64(1), nil)
+	// 不应调用 ca.DeleteByIDs / bta.Delete / ds.Delete
+
+	cs := &catalogService{ca: mockCA, ps: mockPS, bta: mockBTA, ds: mockDS}
+	if err := cs.DeleteByIDs(context.Background(), []string{"c1"}); err == nil {
+		t.Fatalf("expected error when a build task is running")
+	}
+}
+
 // ===== Internal catalog（系统内部目录） =====
 
 func TestCreate_InternalUsesInternalAuthType(t *testing.T) {

--- a/adp/vega/vega-backend/server/logics/resource/resource_service.go
+++ b/adp/vega/vega-backend/server/logics/resource/resource_service.go
@@ -757,23 +757,13 @@ func (rs *resourceService) DeleteByIDs(ctx context.Context, ids []string) error 
 	for _, resource := range resources {
 		switch resource.Category {
 		case interfaces.ResourceCategoryTable:
-			// Check if dataset has build tasks
-			buildTask, err := rs.bta.GetByResourceID(ctx, resource.ID)
-			if err != nil {
-				span.SetStatus(codes.Error, "Get build task failed")
-				return rest.NewHTTPError(ctx, http.StatusInternalServerError, verrors.VegaBackend_Resource_InternalError_GetFailed).
-					WithErrorDetails(err.Error())
-			} else if buildTask != nil {
-				return rest.NewHTTPError(ctx, http.StatusBadRequest, verrors.VegaBackend_BuildTask_Exist).
-					WithErrorDetails("Cannot delete dataset, please delete build task first")
-			}
-			if resource.LocalIndexName != "" {
-				// 删除本地索引
-				err := rs.ds.Delete(ctx, resource.LocalIndexName)
-				if err != nil {
-					logger.Errorf("Delete local index failed: %v", err)
-					// 索引删除失败不影响资源删除，只记录错误
-				}
+			// 级联清掉该资源的全部构建任务 + 对应 OpenSearch 索引（含历史孤儿）。
+			// 改自原先"有任务就拒删"：现在删资源连带删任务/索引（危险操作由前端二次确认把关）。
+			// 运行中/停止中任务会被 cascade 拒绝（HasRunningExecution），用户需先停止再删。
+			if err := logics.CascadeDeleteBuildTasks(ctx, rs.bta, rs.ds,
+				interfaces.BuildTasksQueryParams{ResourceID: resource.ID}); err != nil {
+				span.SetStatus(codes.Error, "Cascade delete build tasks failed")
+				return err
 			}
 		case interfaces.ResourceCategoryDataset:
 			// Delete dataset

--- a/adp/vega/vega-backend/server/logics/resource/resource_service_test.go
+++ b/adp/vega/vega-backend/server/logics/resource/resource_service_test.go
@@ -326,10 +326,48 @@ func TestDeleteByIDs_Success(t *testing.T) {
 		Return([]*interfaces.Resource{{ID: "r1", Category: "table"}}, nil)
 	mockRA.EXPECT().DeleteByIDs(gomock.Any(), []string{"r1"}).Return(nil)
 	mockPS.EXPECT().DeleteResources(gomock.Any(), interfaces.AUTH_RESOURCE_TYPE_RESOURCE, []string{"r1"}).Return(nil)
-	mockBTA.EXPECT().GetByResourceID(gomock.Any(), "r1").Return(nil, nil)
+	// 级联：无构建任务时 List 返回空，不再走 GetByResourceID 拦截
+	mockBTA.EXPECT().List(gomock.Any(), gomock.Any()).Return([]*interfaces.BuildTask{}, int64(0), nil)
 	err := rs.DeleteByIDs(context.Background(), []string{"r1"})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+// 删资源时有构建任务：级联 drop 索引 + 删任务行，再删资源。
+func TestDeleteByIDs_CascadesBuildTaskAndIndex(t *testing.T) {
+	rs, mockRA, mockPS, mockDS, _, _, mockBTA := newTestService(t)
+	mockPS.EXPECT().FilterResources(gomock.Any(), interfaces.AUTH_RESOURCE_TYPE_RESOURCE,
+		[]string{"r1"}, gomock.Any(), true, gomock.Any()).
+		Return(map[string]interfaces.PermissionResourceOps{"r1": {ResourceID: "r1"}}, nil)
+	mockRA.EXPECT().GetByIDs(gomock.Any(), []string{"r1"}).
+		Return([]*interfaces.Resource{{ID: "r1", Category: "table"}}, nil)
+	// 一个已完成任务 t1 → 期望 drop 其索引并删任务行
+	mockBTA.EXPECT().List(gomock.Any(), gomock.Any()).
+		Return([]*interfaces.BuildTask{{ID: "t1", ResourceID: "r1", Status: "completed"}}, int64(1), nil)
+	mockDS.EXPECT().Delete(gomock.Any(), interfaces.BuildIndexName("r1", "t1")).Return(nil)
+	mockBTA.EXPECT().Delete(gomock.Any(), "t1").Return(nil)
+	mockRA.EXPECT().DeleteByIDs(gomock.Any(), []string{"r1"}).Return(nil)
+	mockPS.EXPECT().DeleteResources(gomock.Any(), interfaces.AUTH_RESOURCE_TYPE_RESOURCE, []string{"r1"}).Return(nil)
+	if err := rs.DeleteByIDs(context.Background(), []string{"r1"}); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+// 删资源时任务在运行中：级联拒绝，资源不删。
+func TestDeleteByIDs_RefusesWhenTaskRunning(t *testing.T) {
+	rs, mockRA, mockPS, _, _, _, mockBTA := newTestService(t)
+	mockPS.EXPECT().FilterResources(gomock.Any(), interfaces.AUTH_RESOURCE_TYPE_RESOURCE,
+		[]string{"r1"}, gomock.Any(), true, gomock.Any()).
+		Return(map[string]interfaces.PermissionResourceOps{"r1": {ResourceID: "r1"}}, nil)
+	mockRA.EXPECT().GetByIDs(gomock.Any(), []string{"r1"}).
+		Return([]*interfaces.Resource{{ID: "r1", Category: "table"}}, nil)
+	mockBTA.EXPECT().List(gomock.Any(), gomock.Any()).
+		Return([]*interfaces.BuildTask{{ID: "t1", ResourceID: "r1", Status: "running"}}, int64(1), nil)
+	// 不应调用 DeleteByIDs / bta.Delete / ds.Delete
+	err := rs.DeleteByIDs(context.Background(), []string{"r1"})
+	if err == nil {
+		t.Fatalf("expected error when a build task is running")
 	}
 }
 

--- a/adp/vega/vega-backend/server/main.go
+++ b/adp/vega/vega-backend/server/main.go
@@ -38,6 +38,7 @@ import (
 	"vega-backend/driveradapters"
 	"vega-backend/logics"
 	"vega-backend/logics/connectors/factory"
+	"vega-backend/logics/dataset"
 	logicsDiscoverSchedule "vega-backend/logics/discover_schedule"
 	logicsDiscoverTask "vega-backend/logics/discover_task"
 	"vega-backend/worker"
@@ -141,6 +142,9 @@ func main() {
 	logics.SetKafkaAccess(kafka.NewKafkaAccess(appSetting))
 	logics.SetModelFactoryAccess(model_factory.NewModelFactoryAccess(appSetting))
 	logics.SetResourceAccess(resource.NewResourceAccess(appSetting))
+	// 注入共享 DatasetService（cascade 删索引用）。须在上面各 Access 注入之后：
+	// dataset.NewDatasetService 内部会构造 logics/catalog（读 CA/RA 全局）。
+	logics.SetDatasetService(dataset.NewDatasetService(appSetting))
 
 	// 初始化 Connector Factory 并注册内置的 Local Connector Builder
 	factory.Init(appSetting)

--- a/adp/vega/vega-backend/server/worker/build_task_common.go
+++ b/adp/vega/vega-backend/server/worker/build_task_common.go
@@ -23,7 +23,7 @@ import (
 )
 
 func getIndexName(resourceID, buildTaskID string) string {
-	return interfaces.BUILD_PREFIX + "-" + resourceID + "-" + buildTaskID
+	return interfaces.BuildIndexName(resourceID, buildTaskID)
 }
 
 func getEmbeddingTopic(resourceID, buildTaskID string) string {


### PR DESCRIPTION
## Problem

Deleting data leaked OpenSearch indexes and orphaned build-task rows:

- **Resource delete** blocked if a build task existed ("please delete build task first") and only dropped the *current* index pointer (`LocalIndexName`) — historical task indexes leaked.
- **Catalog delete** removed catalog + resource rows but left **every build task AND index** behind (raw `ra.DeleteByCatalogIDs`, no task/index cleanup) — a silent orphan-bomb.

Net: `vega-build-*` indexes accumulate monotonically (every delete / every rebuild that swaps task id), with no entry point to reclaim them. This is the root cause behind "delete data → is the index gone? / re-scan → old index unusable?".

## Change

Unify cleanup behind `logics.CascadeDeleteBuildTasks(ctx, bta, ds, filter)`:
- Lists every build task for a resource (`resource_id`) or whole catalog (`catalog_id`).
- Drops each task's index `vega-build-<resID>-<taskID>` (via new `interfaces.BuildIndexName` — single source of truth, worker uses it too), then deletes the task row.
- **Refuses the whole delete** if any task is running/stopping (`HasRunningExecution`) — never delete half.
- Index drop is best-effort (logged); task-row delete failure is fatal.

Wiring:
- **resource delete**: replace the `BuildTask.Exist` block with a per-resource cascade.
- **catalog delete**: cascade per `catalog_id` before removing rows.
- Helper lives in package `logics` (not `logics/build_task`, which imports `logics/catalog`). Catalog can't import the `dataset` package (`dataset -> catalog` cycle), so the shared `DatasetService` is injected via `logics.DS` at startup and resolved field-or-global in catalog (keeps struct fields for test injection, avoids the `sync.Once` init-order trap).

## Tests
- resource + catalog: `CascadesBuildTasksAndIndexes` (drops index + deletes task + deletes rows), `RefusesWhenTaskRunning`.
- Existing delete tests updated to the new `List` path. Full `go test ./...` green.

## Pairs with (frontend, separate repo)
Deleting a 数据连接/数据资源 is now destructive (cascades indexes). Frontend should add an **informed double-check**: before delete, `GET /build-tasks?catalog_id=` (or `?resource_id=`); if non-empty, warn "已构建 N 个索引，删除将一并删除索引和构建任务，不可恢复" + typed-name confirmation for high blast radius. Re-scan (full rebuild) should warn "原索引重建完成前不可用".

🤖 Generated with [Claude Code](https://claude.com/claude-code)