### PR TITLE
fix(vega): drop index when a build task is deleted

### DIFF
--- a/adp/vega/vega-backend/server/logics/build_task/build_task_service.go
+++ b/adp/vega/vega-backend/server/logics/build_task/build_task_service.go
@@ -44,6 +44,7 @@ type buildTaskService struct {
 	bta        interfaces.BuildTaskAccess
 	mfa        interfaces.ModelFactoryAccess
 	ums        interfaces.UserMgmtService
+	ds         interfaces.DatasetService // 删任务时 drop 其 OpenSearch 索引；测试注入 mock，生产走 logics.DS
 }
 
 // NewBuildTaskService creates a new BuildTaskService.
@@ -555,7 +556,7 @@ func (bts *buildTaskService) DeleteBuildTasks(ctx context.Context, ids []string,
 	ctx, span := oteltrace.StartNamedInternalSpan(ctx, "Delete build tasks")
 	defer span.End()
 
-	toDelete := make([]string, 0, len(ids))
+	toDelete := make([]*interfaces.BuildTask, 0, len(ids))
 	missingIDs := make([]string, 0)
 	runningIDs := make([]string, 0)
 
@@ -574,7 +575,7 @@ func (bts *buildTaskService) DeleteBuildTasks(ctx context.Context, ids []string,
 			runningIDs = append(runningIDs, id)
 			continue
 		}
-		toDelete = append(toDelete, id)
+		toDelete = append(toDelete, buildTask)
 	}
 
 	if len(runningIDs) > 0 {
@@ -588,9 +589,20 @@ func (bts *buildTaskService) DeleteBuildTasks(ctx context.Context, ids []string,
 			WithErrorDetails(map[string]any{"missing_ids": missingIDs})
 	}
 
-	for _, id := range toDelete {
-		if err := bts.bta.Delete(ctx, id); err != nil {
-			otellog.LogError(ctx, fmt.Sprintf("Delete build task %s failed", id), err)
+	// ds 优先 struct 字段（测试注入），否则走 logics 全局（生产）
+	ds := bts.ds
+	if ds == nil {
+		ds = logics.DS
+	}
+	for _, bt := range toDelete {
+		// 先 drop 索引（尽力，失败仅记日志），再删任务行——与删资源/删 catalog 的级联
+		// 语义一致，避免 UI 单任务删除留下孤儿索引（#66 只覆盖了资源/目录两条路径）。
+		idx := interfaces.BuildIndexName(bt.ResourceID, bt.ID)
+		if err := ds.Delete(ctx, idx); err != nil {
+			otellog.LogError(ctx, fmt.Sprintf("Drop index %s for build task %s failed", idx, bt.ID), err)
+		}
+		if err := bts.bta.Delete(ctx, bt.ID); err != nil {
+			otellog.LogError(ctx, fmt.Sprintf("Delete build task %s failed", bt.ID), err)
 			return rest.NewHTTPError(ctx, http.StatusInternalServerError, verrors.VegaBackend_BuildTask_InternalError_DeleteFailed).
 				WithErrorDetails(err.Error())
 		}

--- a/adp/vega/vega-backend/server/logics/build_task/build_task_service_test.go
+++ b/adp/vega/vega-backend/server/logics/build_task/build_task_service_test.go
@@ -248,3 +248,36 @@ func TestComputeIndexHealth(t *testing.T) {
 		})
 	}
 }
+
+// 删任务应连带 drop 其 OpenSearch 索引（与删资源/删 catalog 级联语义一致）。
+func TestDeleteBuildTasks_DropsIndexAndRow(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	mockBTA := mock_interfaces.NewMockBuildTaskAccess(ctrl)
+	mockDS := mock_interfaces.NewMockDatasetService(ctrl)
+	service := &buildTaskService{bta: mockBTA, ds: mockDS}
+
+	mockBTA.EXPECT().GetByID(gomock.Any(), "t1").
+		Return(&interfaces.BuildTask{ID: "t1", ResourceID: "r1", Status: "completed"}, nil)
+	mockDS.EXPECT().Delete(gomock.Any(), interfaces.BuildIndexName("r1", "t1")).Return(nil)
+	mockBTA.EXPECT().Delete(gomock.Any(), "t1").Return(nil)
+
+	if err := service.DeleteBuildTasks(context.Background(), []string{"t1"}, false); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+// 任一任务运行中 → 整批 409，索引/行都不删。
+func TestDeleteBuildTasks_RefusesRunning(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	mockBTA := mock_interfaces.NewMockBuildTaskAccess(ctrl)
+	mockDS := mock_interfaces.NewMockDatasetService(ctrl)
+	service := &buildTaskService{bta: mockBTA, ds: mockDS}
+
+	mockBTA.EXPECT().GetByID(gomock.Any(), "t1").
+		Return(&interfaces.BuildTask{ID: "t1", ResourceID: "r1", Status: "running"}, nil)
+	// 不应调用 ds.Delete / bta.Delete
+
+	if err := service.DeleteBuildTasks(context.Background(), []string{"t1"}, false); err == nil {
+		t.Fatalf("expected 409 when a task is running")
+	}
+}


### PR DESCRIPTION
## Problem

PR #66 made **resource/catalog delete** cascade-drop OpenSearch indexes, but the **build-task batch delete** (`DELETE /build-tasks/{ids}` — the per-row 🗑 in the UI, the most-used delete entry point) still deleted only the DB row, leaving `vega-build-<res>-<task>` orphaned. Indexes kept leaking through that path.

## Change

`DeleteBuildTasks` now drops each task's index (`interfaces.BuildIndexName` + `ds.Delete`, best-effort/logged) before deleting the row.

Semantics **unchanged**: still all-or-nothing pre-validation — any `running`/`stopping` → `409` with `running_ids` (nothing deleted); missing → `404` unless `?ignore_missing=true`; success → `204`.

`DatasetService` is a new struct field resolved field-or-global (`logics.DS`) so tests inject a mock while production uses the startup-wired instance — same pattern as catalog, avoiding the `dataset -> catalog` import cycle.

All three delete paths (build task / resource / catalog) now reclaim indexes consistently.

## Tests
- `TestDeleteBuildTasks_DropsIndexAndRow`, `TestDeleteBuildTasks_RefusesRunning`. Full `go test ./...` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)