### PR TITLE
docs(context-loader): refresh MCP server docs to current 9-tool state

### DIFF
--- a/adp/context-loader/agent-retrieval/docs/prd/feature-mcp-server/实现设计文档.md
+++ b/adp/context-loader/agent-retrieval/docs/prd/feature-mcp-server/实现设计文档.md
@@ -6,53 +6,98 @@
 |------|------|
 | **需求编号** | feature-mcp-server |
 | **关联需求文档** | [需求设计文档.md](./需求设计文档.md) |
-| **文档版本** | v1.0 |
+| **文档版本** | v2.0 |
 | **创建日期** | 2026-02-01 |
+| **最近更新** | 2026-06-23 |
+
+> **本文定位**：只描述 MCP Server 的**实现意图与关键设计决策**（为什么这样做），不维护工具清单与字段级 schema。
+> 工具的权威事实源：
+> - 元数据（名称/描述）：`server/driveradapters/mcp/schemas/tools_meta.json`（随二进制内嵌）
+> - 输入/输出 schema：`server/driveradapters/mcp/schemas/<tool>.json`
+> - 运行时自描述：`GET /api/agent-retrieval/v1/mcp/info`
+> - 人读参考：[../../release/tool-usage-guide.md](../../release/tool-usage-guide.md)
+>
+> 工具增删改只动上述 JSON + handler，本文不随之变动。
 
 ---
 
 ## 1. 概述
 
-本文档描述 Agent Retrieval Streamable HTTP MCP Server 的技术实现方案，包括代码结构、Gin 集成、Context 透传、kn_id Header 获取和 ToolHandler 设计。
+本文档描述 Agent Retrieval Streamable HTTP MCP Server 的技术实现方案：在现有 Gin 应用中挂载一个 MCP Server，把 context-loader 的知识网络检索能力以 MCP 工具形式对外暴露，供 Cursor、Claude Desktop 及其它 Agent 接入。
 
 ### 1.1 设计目标
 
-1. **最小侵入**：在现有 Gin 应用中挂载 MCP Server，复用中间件与业务逻辑
-2. **认证与上下文**：确保 ToolHandler 能获取 token 和 kn_id（通过 Header）
-3. **可扩展**：便于后续增加更多 MCP 工具
+1. **最小侵入**：在现有 Gin 应用中挂载 MCP Server，复用中间件与 `logics` 业务层，不复制业务逻辑
+2. **认证与上下文**：ToolHandler 能拿到 token 内省得到的账户上下文（account_id/account_type）与 kn_id
+3. **数据驱动、零硬编码清单**：工具的名称/描述/schema 全部来自内嵌 JSON，新增工具不改注册框架，也不改文档
+4. **同一能力多入口**：同一份业务逻辑同时服务 MCP、内部 REST 与执行工厂 toolbox，避免三套实现漂移
 
 ### 1.2 设计原则
 
 - **单一职责**：MCP 相关代码集中在 `mcp` 子包
-- **复用**：KnSearch 逻辑复用现有 logics 层
-- **配置驱动**：MCP 端点路径等可配置
+- **复用**：检索/查询逻辑复用现有 `logics` 层 service
+- **单一事实源**：工具元数据与 schema 集中在 `schemas/*.json`，注册逻辑、`/mcp/info` 自描述、外部文档都读它
 
 ---
 
 ## 2. 架构设计
 
-### 2.1 分层架构图
+### 2.1 分层架构
 
 ```
 ┌─────────────────────────────────────────────────────────────────┐
-│                     Driver Adapters (HTTP)                       │
-│  ┌─────────────────────┐    ┌──────────────────────────────────┐ │
-│  │ rest_public_handler │    │ mcp/ (NEW)                        │ │
-│  │   - KnRetrieval      │    │   - StreamableHTTPServer 挂载    │ │
-│  │   - KnSearch (新增)  │    │   - 路由: /mcp/*                  │ │
-│  │   - MCP Server       │    │   - 中间件: IntrospectVerify      │ │
-│  └─────────────────────┘    └──────────────────────────────────┘ │
-├─────────────────────────────────────────────────────────────────┤
-│                     Business Logic                               │
-│  ┌─────────────────────────────────────────────────────────────┐ │
-│  │ logics/knsearch/  (复用)                                     │ │
-│  └─────────────────────────────────────────────────────────────┘ │
-└─────────────────────────────────────────────────────────────────┘
+│                     Driver Adapters (HTTP)                        │
+│  ┌─────────────────────────┐   ┌───────────────────────────────┐ │
+│  │ rest_public_handler      │   │ mcp/ (MCP Server)             │ │
+│  │  /api/agent-retrieval/v1 │   │  - 内嵌 schemas/*.json         │ │
+│  │  - REST 工具入口(/kn/*)   │   │  - 数据驱动 AddTool            │ │
+│  │  - 挂载 MCP: /mcp/*path   │──▶│  - StreamableHTTPServer        │ │
+│  │  - /mcp/info 自描述       │   │  - GET /mcp/info               │ │
+│  │  中间件: IntrospectVerify │   └───────────────────────────────┘ │
+│  └─────────────────────────┘                                       │
+│  ┌─────────────────────────┐                                       │
+│  │ rest_private_handler     │   内部入口(toolbox/服务间)            │
+│  │  /api/agent-retrieval/in/v1                                      │
+│  └─────────────────────────┘                                       │
+├───────────────────────────────────────────────────────────────────┤
+│                     Business Logic (logics/*)  —— 复用              │
+│   knsearch / knquerysubgraph / knlogicpropertyresolver /            │
+│   knactionrecall / knfindskills / knrunsql + drivenadapters(BKN)    │
+└───────────────────────────────────────────────────────────────────┘
 ```
 
-**说明**：MCP Server 挂载在**公开接口**路由组（`/api/agent-retrieval/v1`）下，使用 `middlewareIntrospectVerify`（Bearer token 认证），以支持 Cursor、Claude Desktop 等外部 MCP 客户端。需将 KnSearchHandler 添加到 rest_public_handler。
+**挂载位置**：MCP Server 挂在**公开路由组** `/api/agent-retrieval/v1` 下（完整端点 `/api/agent-retrieval/v1/mcp`），使用 `middlewareIntrospectVerify`（Bearer token 认证），以支持外部 MCP 客户端。
 
-### 2.2 请求流
+### 2.2 三入口设计（关键决策）
+
+同一份 `logics` service 同时被三种入口消费：
+
+| 入口 | 路径前缀 | 消费者 | 认证 |
+|------|----------|--------|------|
+| MCP Server | `/api/agent-retrieval/v1/mcp` | Cursor / Claude Desktop / 外部 Agent | Bearer（IntrospectVerify） |
+| 公开 REST | `/api/agent-retrieval/v1/kn/*` | 外部直连 | Bearer（IntrospectVerify） |
+| 内部 REST | `/api/agent-retrieval/in/v1/kn/*` | 服务间调用、执行工厂 toolbox | Header 账户上下文 |
+
+> 其中 `run_sql` / `list_knowledge_networks` / `get_kn_detail` 明确按「MCP 工具 + toolbox(OpenAPI HTTP) 入口」双重定位注册（见 `rest_public_handler.go` / `rest_private_handler.go` 中 `/kn/run_sql` 等路由注释）。
+
+### 2.3 数据驱动的工具注册（关键决策）
+
+工具不在代码里硬编码名称与 schema，而是：
+
+```
+schemas/ (//go:embed)
+├── tools_meta.json          # { "<tool>": { name, description } }
+├── <tool>.json              # { input_schema, output_schema }
+└── ...
+```
+
+- `schemas.go`：`//go:embed schemas/*.json`，提供 `loadToolMeta(key)`（取 name/description）与 `loadToolSchemas(key)`（取 input/output schema）。读不到或缺 `input_schema` 直接 panic —— **启动即暴露契约缺失**，不容忍静默坏元数据。
+- `app.go` `NewMCPHandler()`：对每个工具 `mcpServer.AddTool(newToolWithSchemas(name, desc, in, out), handler)`，schema 与 handler 解耦。新增工具 = 加一个 `schemas/<tool>.json` + 一段 handler + 一次 `AddTool`，注册框架不动。
+- `info.go` `BuildMCPInfo()`：`GET /mcp/info` 复用同一批 JSON 组装自描述文档，**与 MCP `tools/list` 永远一致**。
+
+**设计理由**：工具集是高频变更项（已从 1 个长到 9 个）。把清单与 schema 留在 JSON、让注册/自描述/文档都引用它，是避免「代码改了文档没改」漂移的根因解。
+
+### 2.4 请求流
 
 ```mermaid
 sequenceDiagram
@@ -60,255 +105,176 @@ sequenceDiagram
     participant Gin as Gin Router
     participant MW as middlewareIntrospectVerify
     participant MCP as StreamableHTTPServer
-    participant TH as ToolHandler (kn_search)
+    participant TH as ToolHandler
+    participant SVC as logics service
 
-    Client->>Gin: POST /mcp/tools/call (Authorization: Bearer, X-Kn-ID)
-    Gin->>MW: 进入中间件链
-    MW->>MW: Hydra.Introspect(token)，SetAccountAuthContextToCtx
-    MW->>MW: SetAccountAuthContextToCtx(ctx)
+    Client->>Gin: POST /api/agent-retrieval/v1/mcp (Authorization: Bearer [, X-Kn-ID])
+    Gin->>MW: 中间件链
+    MW->>MW: Hydra.Introspect(token) -> SetAccountAuthContextToCtx
     MW->>MCP: c.Next() -> ServeHTTP(c.Writer, c.Request)
-    MCP->>MCP: WithHTTPContextFunc: ctx = r.Context()
-    MCP->>TH: handleKnSearch(ctx, req)
-    TH->>TH: GetAccountAuthContextFromCtx(ctx)
-    TH->>TH: req.Header.Get("X-Kn-ID") 或 req.GetString("kn_id")
-    TH->>TH: KnSearchLogic.Search(...)
-    TH-->>Client: CallToolResult
+    MCP->>MCP: WithHTTPContextFunc: ctx = r.Context()  (透传认证上下文)
+    MCP->>TH: handler(ctx, req)
+    TH->>TH: GetAccountAuthContextFromCtx(ctx) -> account_id/type
+    TH->>TH: kn_id := arguments.kn_id ?? Header X-Kn-ID  (按工具策略)
+    TH->>TH: GetResponseFormatFromRequest(req)  (默认 toon)
+    TH->>SVC: 调用复用的业务逻辑
+    TH-->>Client: BuildMCPToolResult(resp, format)
 ```
 
-### 2.3 kn_id 获取逻辑
+### 2.5 kn_id 获取策略（按工具分级）
 
-```
-┌─────────────────────────────────────────────────────────────┐
-│ ToolHandler: handleKnSearch(ctx, req)                        │
-├─────────────────────────────────────────────────────────────┤
-│ 1. knID := req.Header.Get("X-Kn-ID")                        │
-│ 2. if knID == "" { knID = req.GetString("kn_id", "") }      │
-│ 3. if knID == "" { return error "kn_id is required..." }    │
-│ 4. query := req.GetString("query", "")                      │
-│ 5. if query == "" { return error "query is required" }       │
-│ 6. 构造 KnSearchReq，调用 KnSearchService.KnSearch          │
-└─────────────────────────────────────────────────────────────┘
-```
+历史设计要求所有工具强制走 `X-Kn-ID` Header；现按工具语义分级（实际逻辑见各 handler）：
+
+| 策略 | 工具 | 说明 |
+|------|------|------|
+| arguments 优先，Header 兜底 | `query_object_instance`、`query_instance_subgraph`、`get_kn_detail` 等 | `kn_id` 取 arguments，缺省回落 `X-Kn-ID`，两者皆空报错 |
+| Header 优先 / 注入请求 | `search_schema`、`get_logic_properties_values`、`get_action_info` | `X-Kn-ID` 注入到下游请求；账户上下文从 ctx 注入 |
+| 必须 Header | `find_skills` | 缺 `X-Kn-ID` 直接报 `kn_id is required (configure X-Kn-ID header)` |
+| 不需要 kn_id | `list_knowledge_networks`、`run_sql` | `list_*` 用于发现 kn_id；`run_sql` 用 `{{.resource_id}}` 占位符引用资源 |
+
+> 设计理由不变：kn_id 多为连接级配置，放 Header 可减少 LLM 每轮生成负担；但 `list_knowledge_networks` 作为「发现 kn_id」入口必须无 kn_id 可用，`run_sql` 以 resource_id 为粒度，故不强制。
+
+### 2.6 返回格式（response_format）
+
+- 入口统一经 `GetResponseFormatFromRequest(req)` 解析 arguments 中的 `response_format`，**默认 `toon`**，可选 `json`。
+- `BuildMCPToolResult(resp, format)`：`structuredContent` 始终是原始对象；文本内容按 format 输出 TOON 或 JSON。
+- 设计理由：TOON 比 JSON token 更省，作为 Agent 默认消费格式；保留 `json` 供调试与兼容。
 
 ---
 
 ## 3. 代码结构
 
-### 3.1 新增文件
+### 3.1 mcp 子包文件
 
 | 文件 | 职责 |
 |------|------|
-| `server/driveradapters/mcp/app.go` | 创建 MCPServer、StreamableHTTPServer，注册工具，返回 http.Handler |
-| `server/driveradapters/mcp/tools.go` | kn_search ToolHandler 实现，含 kn_id Header 获取逻辑 |
-| `server/driveradapters/mcp/config.go` | MCP 相关配置（端点路径等） |
+| `server/driveradapters/mcp/app.go` | `NewMCPHandler()`：创建 MCPServer、数据驱动 `AddTool`、构造 StreamableHTTPServer；定义 server 名 `context-loader`、版本、端点常量与各 tool key |
+| `server/driveradapters/mcp/tools.go` | 各工具 ToolHandler 实现（kn_id 获取、参数绑定、调用 logics、构造结果）；`getKnIDFromHeader` / `getStringArg` / `bindArguments` 等公共逻辑 |
+| `server/driveradapters/mcp/schemas.go` | `//go:embed schemas/*.json`；`loadToolMeta` / `loadToolSchemas` |
+| `server/driveradapters/mcp/info.go` | `BuildMCPInfo()`：组装 `/mcp/info` 自描述文档（含 client_config_example） |
+| `server/driveradapters/mcp/response_format.go` | `GetResponseFormatFromRequest` / `BuildMCPToolResult`（JSON / TOON） |
+| `server/driveradapters/mcp/schemas/*.json` | 工具元数据（`tools_meta.json`）与逐工具输入/输出 schema |
 
-### 3.2 修改文件
+### 3.2 集成点
 
-| 文件 | 变更说明 |
+| 文件 | 集成说明 |
 |------|----------|
-| `server/driveradapters/rest_public_handler.go` | 添加 KnSearchHandler，注册 MCP 路由，挂载 StreamableHTTPServer |
-| `go.mod` | 添加 mark3labs/mcp-go v0.43.2 依赖（若尚未引入） |
+| `server/driveradapters/rest_public_handler.go` | 公开组注册各 `/kn/*` REST 工具入口；`engine.Any("/mcp/*path", r.handleMCP)` 挂载 MCP，`GET …/mcp/info` 在 catch-all 内分流到 `BuildMCPInfo` |
+| `server/driveradapters/rest_private_handler.go` | 内部组注册同名 `/kn/*` 入口（toolbox/服务间）+ MCP Proxy `/mcp/proxy/:mcp_id/tools/:tool_name/call` |
+| `server/main.go` | `Group("/api/agent-retrieval/v1")` 公开、`Group("/api/agent-retrieval/in/v1")` 内部 |
 
 ---
 
-## 4. 核心实现
+## 4. 核心实现（要点）
 
-### 4.1 MCP Server 创建 (app.go)
+### 4.1 MCP Server 创建（app.go）
 
 ```go
-package mcp
-
-import (
-    "context"
-    "net/http"
-
-    "github.com/mark3labs/mcp-go/mcp"
-    "github.com/mark3labs/mcp-go/server"
-)
-
-func NewMCPHandler(knSearchHandler interfaces.KnSearchHandler) http.Handler {
-    mcpServer := server.NewMCPServer("agent-retrieval-mcp", "1.0.0",
+func NewMCPHandler() http.Handler {
+    mcpServer := server.NewMCPServer(serverName /* "context-loader" */, serverVersion,
         server.WithToolCapabilities(true),
     )
 
-    // 注册 kn_search 工具
-    registerKnSearchTool(mcpServer, knSearchHandler)
+    // 数据驱动注册：每个工具 = 内嵌 JSON 的 (name, desc, input, output) + handler
+    name, desc := loadToolMeta(toolKeySearchSchema)
+    in, out := loadToolSchemas(toolKeySearchSchema)
+    mcpServer.AddTool(newToolWithSchemas(name, desc, in, out), handleSearchSchema(knSearchService))
+    // ... 其余工具同模式（清单见 schemas/tools_meta.json）
 
-    streamableServer := server.NewStreamableHTTPServer(mcpServer,
+    return server.NewStreamableHTTPServer(mcpServer,
         server.WithHTTPContextFunc(func(ctx context.Context, r *http.Request) context.Context {
-            return r.Context() // 透传 Gin 的 Context（含认证信息）
+            return r.Context() // 透传 Gin Context（含认证信息）
         }),
-        server.WithEndpointPath("/api/agent-retrieval/v1/mcp"),
+        server.WithEndpointPath(endpointPath /* "/api/agent-retrieval/v1/mcp" */),
     )
-
-    return streamableServer
 }
 ```
 
-### 4.2 ToolHandler 实现 (tools.go)
+### 4.2 ToolHandler 共性（tools.go）
 
-```go
-func handleKnSearch(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
-    // 1. 获取认证信息
-    authCtx, ok := common.GetAccountAuthContextFromCtx(ctx)
-    if !ok {
-        return mcp.NewToolResultError("authentication required"), nil
-    }
+每个 handler 遵循同一骨架：
+1. 取认证上下文 `GetAccountAuthContextFromCtx(ctx)`（需要账户的工具缺失则返回 `authentication required`）
+2. 解析 `response_format`（默认 toon）
+3. `bindArguments(req, &reqStruct)` 反序列化 arguments
+4. 按 §2.5 策略解析 `kn_id`
+5. 注入 account_id/account_type，必要参数校验
+6. 调用复用的 `logics` service
+7. `BuildMCPToolResult(resp, format)` 返回
 
-    // 2. 获取 kn_id：优先 Header X-Kn-ID，兜底 arguments
-    knID := req.Header.Get("X-Kn-ID")
-    if knID == "" {
-        knID = req.GetString("kn_id", "")
-    }
-    if knID == "" {
-        return mcp.NewToolResultError(
-            "kn_id is required (configure X-Kn-ID header or pass kn_id in arguments)",
-        ), nil
-    }
+### 4.3 /mcp/info 自描述（info.go）
 
-    // 3. 获取 query
-    query := req.GetString("query", "")
-    if query == "" {
-        return mcp.NewToolResultError("query is required"), nil
-    }
-
-    // 4. 构造 KnSearchReq，调用 KnSearchService（本期仅支持 query/kn_id/only_schema/enable_rerank）
-    searchReq := &interfaces.KnSearchReq{
-        KnID:         knID,
-        Query:        query,
-        OnlySchema:   req.GetBool("only_schema", false),
-        EnableRerank: req.GetBool("enable_rerank", true),
-    }
-
-    resp, err := knSearchService.KnSearch(ctx, searchReq)
-    if err != nil {
-        return mcp.NewToolResultError(err.Error()), nil
-    }
-
-    return mcp.NewToolResultText(utils.ObjectToJSON(resp)), nil
-}
-```
-
-### 4.3 Gin 路由注册
-
-```go
-// rest_public_handler.go
-mws := append(mws, middlewareRequestLog(r.Logger), middlewareTrace, middlewareIntrospectVerify(r.Hydra))
-engine.Use(mws...)
-
-// ... 现有路由（如 /kn/semantic-search）...
-
-// MCP Server（Bearer token 认证，支持 Cursor/Claude Desktop）
-mcpHandler := mcp.NewMCPHandler(r.KnSearchHandler)
-engine.Any("/mcp/*path", gin.WrapH(mcpHandler))
-```
-
-**说明**：MCP 挂载在公开路由组 `/api/agent-retrieval/v1` 下，完整路径为 `/api/agent-retrieval/v1/mcp/*`。`WithEndpointPath` 需与 Gin 路由前缀一致。
-
----
-
-## 5. kn_search 工具 Schema
-
-本期仅支持 query/kn_id/only_schema/enable_rerank，后续可扩展：
+`GET /api/agent-retrieval/v1/mcp/info` 返回（无需先走 MCP 握手）：
 
 ```json
 {
-  "name": "kn_search",
-  "description": "基于知识网络的智能检索。支持概念召回（对象类型、关系类型、操作类型）与语义实例召回（nodes）。kn_id 需通过 HTTP Header X-Kn-ID 配置。",
-  "inputSchema": {
-    "type": "object",
-    "properties": {
-      "query": {
-        "type": "string",
-        "description": "用户查询问题或关键词，多个关键词之间用空格隔开"
-      },
-      "kn_id": {
-        "type": "string",
-        "description": "知识网络ID。可选，若已通过 Header X-Kn-ID 配置则无需传递；若传递则覆盖 Header 值"
-      },
-      "only_schema": {
-        "type": "boolean",
-        "default": false,
-        "description": "是否只召回概念，不召回语义实例"
-      },
-      "enable_rerank": {
-        "type": "boolean",
-        "default": true,
-        "description": "是否对关系类型启用 Rerank"
-      }
-    },
-    "required": ["query"]
-  }
+  "service": "context-loader",
+  "endpoint": "<本服务 MCP 端点>",
+  "protocol": "MCP / JSON-RPC 2.0 (initialize → tools/list → tools/call)",
+  "transport": "Streamable HTTP",
+  "auth": "Bearer token via Authorization header",
+  "tool_count": <n>,
+  "tools": [ { "name", "description", "input_schema", "output_schema" }, ... ],
+  "client_config_example": { "mcpServers": { "context-loader": { "url": "...", "headers": { "Authorization": "Bearer <access-token>" } } } }
 }
 ```
 
+工具列表与 schema 均来自内嵌 JSON，**与 `tools/list` 同源**。
+
 ---
 
-## 6. 依赖版本
+## 5. 依赖版本
 
 | 依赖 | 版本 | 说明 |
 |------|------|------|
-| github.com/mark3labs/mcp-go | v0.43.2 | 当前最新稳定版，含 StreamableHTTPServer、WithHTTPContextFunc、CallToolRequest.Header |
-
-**go.mod 添加**：
-```
-require github.com/mark3labs/mcp-go v0.43.2
-```
+| github.com/mark3labs/mcp-go | v0.43.2 | StreamableHTTPServer、WithHTTPContextFunc、CallToolRequest.Header、NewToolWithRawSchema、NewToolResultStructured |
 
 ---
 
-## 7. 配置项
+## 6. 测试范围
 
-| 配置项 | 说明 | 默认值 |
-|--------|------|--------|
-| mcp.endpoint_path | MCP 端点基础路径 | /api/agent-retrieval/v1/mcp |
-| mcp.enabled | 是否启用 MCP Server | true |
-
----
-
-## 8. 测试范围
-
-### 8.1 单元测试
+### 6.1 单元测试
 
 | 测试内容 | 验证点 |
 |---------|--------|
-| handleKnSearch | 正确解析参数、获取 authCtx 和 kn_id |
-| kn_id 获取优先级 | Header 优先，arguments 兜底，arguments 可覆盖 |
-| handleKnSearch 无认证 | 返回认证错误 |
-| handleKnSearch 无 kn_id | 返回 `kn_id is required...` |
-| handleKnSearch 无 query | 返回 `query is required` |
+| `loadToolMeta` / `loadToolSchemas` | 内嵌 JSON 可读；缺 `input_schema` panic |
+| ToolHandler kn_id 解析 | 按 §2.5 策略：arguments 覆盖 Header、Header 兜底、必填校验 |
+| ToolHandler 无认证 | 需要账户的工具返回 `authentication required` |
+| `GetResponseFormatFromRequest` | 默认 toon；显式 json/toon 正确解析 |
+| `BuildMCPToolResult` | structuredContent 为原对象，文本随 format 切换 |
 
-### 8.2 集成测试
+### 6.2 集成测试
 
 | 测试场景 | 验证点 |
 |---------|--------|
-| MCP 客户端连接 | initialize、tools/list 正常 |
-| 调用 kn_search（Header 传 kn_id） | 参数正确、结果与 REST 一致 |
-| 调用 kn_search（arguments 传 kn_id） | 参数正确、结果与 REST 一致 |
+| MCP 客户端连接 | initialize、tools/list 正常，工具数 == tools_meta.json |
+| `GET /mcp/info` | 字段完整，tools 与 tools/list 一致 |
+| 调用各工具 | 结果与对应 REST 入口一致 |
 | 未认证请求 | 401 |
 
-### 8.3 回归测试
+### 6.3 回归测试
 
 | 测试场景 | 验证点 |
 |---------|--------|
-| REST /kn/kn_search | 功能不受影响 |
+| 公开/内部 REST `/kn/*` | 功能不受影响 |
+| 执行工厂 toolbox 入口 | run_sql / list_kn / get_kn_detail 仍可被 toolbox 消费 |
 | MCP Proxy | 功能不受影响 |
 
 ---
 
-## 9. 风险与缓解
+## 7. 风险与缓解
 
 | 风险 | 缓解措施 |
 |------|----------|
 | mcp-go API 变更 | 锁定 v0.43.2，升级前验证 |
 | Context 未透传 | 通过 WithHTTPContextFunc 显式透传 r.Context() |
-| Header 未传递 | 确认 mcp-go 文档，使用 req.Header |
-| mcp-remote 不支持多 Header | 查阅 mcp-remote 文档，必要时使用单 Header 或环境变量 |
+| schema JSON 与 handler 不一致 | 启动 panic + 集成测试校验 tools/list 与 /mcp/info 同源 |
+| 工具集变更引发文档漂移 | 工具清单不入文档，统一指向 tools_meta.json + /mcp/info |
 
 ---
 
-## 10. 修订历史
+## 8. 修订历史
 
 | 版本 | 日期 | 修改人 | 修改内容 |
 |------|------|--------|----------|
 | v1.0 | 2026-02-01 | - | 初始版本，kn_search 工具、kn_id Header 获取逻辑 |
+| v2.0 | 2026-06-23 | - | 对齐实现现状：server 名改 `context-loader`；数据驱动注册（内嵌 schemas/*.json）；新增 `/mcp/info` 自描述与 `response_format`（默认 toon）；kn_id 改为按工具分级；三入口（MCP/REST/toolbox）说明。文档瘦身为「设计意图」，工具清单与 schema 改为指向 tools_meta.json + /mcp/info 唯一事实源 |

--- a/adp/context-loader/agent-retrieval/docs/prd/feature-mcp-server/需求设计文档.md
+++ b/adp/context-loader/agent-retrieval/docs/prd/feature-mcp-server/需求设计文档.md
@@ -6,8 +6,15 @@
 |------|------|
 | **需求编号** | feature-mcp-server |
 | **基线版本** | feature-806350 (KnSearch 模块) |
-| **文档版本** | v1.0 |
+| **文档版本** | v2.0 |
 | **创建日期** | 2026-02-01 |
+| **最近更新** | 2026-06-23 |
+
+> **本文定位**：描述 MCP Server 的**需求与设计意图**，不维护逐工具清单与字段级 schema。
+> 工具清单的权威事实源：
+> - 元数据：`server/driveradapters/mcp/schemas/tools_meta.json`
+> - 运行时自描述：`GET /api/agent-retrieval/v1/mcp/info`
+> - 人读参考：[../../release/tool-usage-guide.md](../../release/tool-usage-guide.md)
 
 ---
 
@@ -15,142 +22,105 @@
 
 ### 1.1 业务背景
 
-Agent Retrieval 服务提供 KnSearch、KnRetrieval、Action Recall 等能力，当前通过 REST API 对外暴露。随着 MCP（Model Context Protocol）生态发展，需要让 MCP 客户端（如 Cursor、Claude Desktop）能够直接连接 Agent Retrieval，以 MCP 工具形式调用知识网络检索能力。
+Agent Retrieval（context-loader）提供 Schema 探索、实例查询、逻辑属性解析、行动召回、Skill 发现、只读 SQL 等知识网络检索能力，原本仅通过 REST API 对外暴露。随着 MCP（Model Context Protocol）生态发展，需要让 MCP 客户端（如 Cursor、Claude Desktop）及其它 Agent 直接连接 context-loader，以 MCP 工具形式调用这些能力。
 
 ### 1.2 需求来源
 
-- **产品需求**：支持 MCP 客户端（Cursor、Claude Desktop 等）直接接入 Agent Retrieval 的知识网络能力
-- **技术需求**：复用现有 Gin 框架与认证中间件，在 ToolHandler 中获取 token 信息和 kn_id
+- **产品需求**：支持 MCP 客户端直接接入 context-loader 的知识网络能力
+- **技术需求**：复用现有 Gin 框架与认证中间件，在 ToolHandler 中获取 token 信息与 kn_id；工具集随业务演进可持续扩展且不引发文档漂移
 
 ---
 
 ## 2. 工具清单
 
-### 2.1 规划工具（全部封装为 MCP Tool）
+### 2.1 唯一事实源
 
-将以下 REST 接口全部封装为 MCP 工具，供 MCP 客户端（Cursor、Claude Desktop 等）调用：
+MCP 工具集**不在本文枚举**，避免与代码漂移。工具的名称/描述/输入输出 schema 全部内嵌在服务中并对外自描述：
 
-| 工具名称 | 描述 | 对应 REST 接口 | 状态 |
-|---------|------|----------------|------|
-| kn_schema_search | 语义检索概念（Schema），返回与 query 相关的对象类/关系类/行动类 | POST /kn/semantic-search | 规划 |
-| kn_search | 知识网络智能检索（v2），支持概念召回与语义实例召回 | POST /kn/kn_search | 规划 |
-| query_object_instance | 单对象类实例过滤查询，按条件查询实例列表 | POST /kn/query_object_instance | 规划 |
-| query_instance_subgraph | 沿关系路径拉取实例子图，支持多跳查询 | POST /kn/query_instance_subgraph | 规划 |
-| resolve_logic_properties | 逻辑属性解析，针对实例批量计算指标/算子 | POST /kn/logic-property-resolver | 规划 |
-| get_action_info | 行动信息召回，针对对象实例返回可执行行动（Function Call 定义） | POST /kn/get_action_info | 规划 |
+| 事实源 | 用途 |
+|--------|------|
+| `schemas/tools_meta.json` + `schemas/<tool>.json` | 随二进制内嵌的工具元数据与 schema（注册逻辑、自描述、文档同源） |
+| `GET /api/agent-retrieval/v1/mcp/info` | 运行时自描述：返回 service / endpoint / protocol / auth / tool_count / tools[] / client_config_example，无需先走 MCP 握手 |
+| [tool-usage-guide.md](../../release/tool-usage-guide.md) | 面向开发接入的人读参考（用途、关键参数、最小示例、Data Agent 配置） |
 
-### 2.2 工具依赖与调用链
+> 当前实现的工具（语义分组，详情以事实源为准）：
+> - `search_*`：`search_schema`（统一 Schema 探索入口）
+> - `query_*`：`query_object_instance`、`query_instance_subgraph`
+> - `find_*`：`find_skills`
+> - `get_*`：`get_logic_properties_values`、`get_action_info`、`get_kn_detail`
+> - 发现/数据：`list_knowledge_networks`、`run_sql`
+>
+> 其中 `run_sql` / `list_knowledge_networks` / `get_kn_detail` 同时作为执行工厂 toolbox（OpenAPI HTTP）入口注册。
 
-- **探索发现**：`kn_schema_search` / `kn_search` → 获取概念（ot_id、rt_id、at_id 等）
-- **精确查询**：`query_object_instance` / `query_instance_subgraph` → 获取实例与事实
-- **逻辑属性**：`resolve_logic_properties` → 依赖 Schema + 实例结果
-- **行动召回**：`get_action_info` → 依赖 Schema（at_id）+ 实例（unique_identity）
+### 2.2 工具语义分层
 
-详细工具使用规则见 [工具使用指南](../../releases/v5.0.4/tool-usage-guide.md)。
+- **探索发现**（`search_*`）→ 获取概念（ot_id、rt_id、at_id 等）
+- **精确查询**（`query_*`）→ 获取实例与事实
+- **候选资源发现**（`find_*`）→ 在业务边界内发现可装配资源（Skill）
+- **确定性获取/计算**（`get_*`）→ 逻辑属性、行动定义、KN 详情
+- **发现与只读数据** → `list_knowledge_networks`（发现 kn_id）、`run_sql`（资源只读查询）
 
-### 2.3 kn_search 工具说明（示例）
-
-- **功能**：根据用户 query 和知识网络 ID（kn_id），召回相关概念（object_types、relation_types、action_types）及语义实例（nodes）
-- **必填参数**：
-  - `query`：用户查询问题或关键词（通过 MCP 工具 arguments 传递）
-  - `kn_id`：知识网络 ID（**通过 HTTP Header `X-Kn-ID` 传递**，见下文设计）
-- **可选参数**：only_schema、enable_rerank（本期仅支持，后续可扩展）
+详细工具使用规则见 [工具使用指南](../../release/tool-usage-guide.md)。
 
 ---
 
-## 3. kn_id 通过 Header 传递的设计
+## 3. kn_id 传递设计
 
-### 3.1 设计决策
+### 3.1 设计决策（按工具分级）
 
-**kn_id 必须通过 MCP 客户端的 HTTP Header `X-Kn-ID` 配置传入**，不作为 MCP 工具 arguments 的必填参数。
+历史方案要求所有工具强制通过 Header `X-Kn-ID` 传 kn_id。当前按工具语义分级：
+
+| 策略 | 工具 | 说明 |
+|------|------|------|
+| arguments 优先，Header 兜底 | `query_object_instance`、`query_instance_subgraph`、`get_kn_detail` 等 | `kn_id` 取 arguments；缺省回落 `X-Kn-ID`；两者皆空报错 |
+| Header 注入下游 | `search_schema`、`get_logic_properties_values`、`get_action_info` | `X-Kn-ID` 注入到下游请求 |
+| 必须 Header | `find_skills` | 缺 `X-Kn-ID` 直接报错 |
+| 不需要 kn_id | `list_knowledge_networks`、`run_sql` | `list_*` 用于发现 kn_id；`run_sql` 以 `{{.resource_id}}` 占位符引用资源 |
 
 ### 3.2 设计理由
 
 | 考量 | 说明 |
 |------|------|
-| **用户使用习惯** | kn_id 是知识网络标识，用户通常在**连接 MCP Server 时**选定一个知识网络，属于连接级配置 |
-| **减少 LLM 负担** | 若放在 arguments 中，LLM 每次调用都需生成 kn_id，增加 token 消耗且易出错 |
-| **一次性配置** | 放在 Header 中，用户可在 Cursor/Claude Desktop 配置文件中一次性设置，无需每次对话指定 |
-| **多知识网络场景** | 若用户需切换知识网络，可配置多个 MCP Server 连接（每个连接对应不同 X-Kn-ID），或通过 arguments 覆盖（见下文） |
+| **用户使用习惯** | kn_id 多为连接级配置，用户连接 MCP Server 时选定知识网络 |
+| **减少 LLM 负担** | 放 Header 可避免每次调用都让 LLM 生成 kn_id，省 token、少出错 |
+| **发现类例外** | `list_knowledge_networks` 是「发现 kn_id」入口，必须无 kn_id 可用；`run_sql` 以 resource_id 为粒度，故不强制 kn_id |
+| **单次覆盖** | 支持 arguments 传 kn_id 覆盖 Header，便于单次切换知识网络 |
 
-### 3.3 获取优先级
+### 3.3 Header 规范
 
-ToolHandler 中 kn_id 的获取逻辑：
-
-1. **优先**：`req.Header.Get("X-Kn-ID")`（MCP 客户端在连接时配置的 Header）
-2. **兜底**：`req.GetString("kn_id", "")`（工具 arguments 中的 kn_id，用于单次调用覆盖）
-3. **校验**：若两者均为空，返回错误 `kn_id is required (configure X-Kn-ID header or pass kn_id in arguments)`
-
-### 3.4 Header 规范
-
-| Header 名称 | 必填 | 说明 |
-|-------------|------|------|
-| X-Kn-ID | kn_search 调用时必填 | 知识网络 ID，由用户在 MCP 客户端配置中设置 |
-| Authorization | 是 | Bearer token，用于认证（middlewareIntrospectVerify） |
-
-### 3.5 MCP 客户端如何传递 Header
-
-MCP 客户端（如 Cursor、Claude Desktop）通过 **mcp-remote** 等适配器连接 Streamable HTTP MCP Server 时，可使用 `--header` 参数传递自定义 Header：
-
-```bash
-npx mcp-remote https://agent-retrieval.example.com/api/agent-retrieval/v1/mcp \
-  --header "Authorization: Bearer YOUR_TOKEN" \
-  --header "X-Kn-ID: your_kn_id_here"
-```
-
-用户需在配置文件中将 `YOUR_TOKEN` 和 `your_kn_id_here` 替换为实际值。
+| Header | 必填 | 说明 |
+|--------|------|------|
+| Authorization | 是 | Bearer token，用于 `middlewareIntrospectVerify` 认证 |
+| X-Kn-ID | 视工具而定（见 §3.1） | 知识网络 ID，由 MCP 客户端在连接时配置 |
 
 ---
 
 ## 4. 功能性需求
 
-### 4.1 需求清单
-
 | 需求ID | 需求名称 | 优先级 | 描述 |
 |--------|---------|--------|------|
-| FR-001 | MCP Server | P0 | 提供 MCP Server，供 Cursor、Claude Desktop 等 MCP 客户端连接 |
-| FR-002 | 工具封装 | P0 | 将 6 个 REST 接口封装为 MCP 工具：kn_schema_search、kn_search、query_object_instance、query_instance_subgraph、resolve_logic_properties、get_action_info |
-| FR-003 | 认证与 kn_id 配置 | P0 | 支持 Bearer token 认证；kn_id 可在连接时通过 Header X-Kn-ID 配置，无需每次调用传递 |
-
-### 4.2 需求详细说明
-
-#### FR-003: 认证与 kn_id 配置（补充）
-
-**描述**：MCP 客户端在连接时通过 HTTP Header 传递 `Authorization`（Bearer token）和 `X-Kn-ID`（知识网络 ID）。ToolHandler 可获取认证信息与 kn_id。
-
-**验收标准**：
-- ✅ ToolHandler 能正确读取 X-Kn-ID
-- ✅ 若 Header 和 arguments 均无 kn_id，返回明确错误
-- ✅ arguments 中的 kn_id 可覆盖 Header 中的值（用于单次调用切换知识网络）
+| FR-001 | MCP Server | P0 | 提供 Streamable HTTP MCP Server，供 Cursor、Claude Desktop 等 MCP 客户端连接 |
+| FR-002 | 工具封装（数据驱动） | P0 | 将 context-loader 检索/查询能力封装为 MCP 工具，工具元数据与 schema 由内嵌 JSON 驱动注册，清单以 `tools_meta.json` / `/mcp/info` 为准，新增工具不改注册框架 |
+| FR-003 | 认证与 kn_id 配置 | P0 | 支持 Bearer token 认证；kn_id 按工具分级，可在连接时通过 Header `X-Kn-ID` 配置或由 arguments 传入（见 §3） |
+| FR-004 | 自描述与多入口 | P1 | 提供 `GET /mcp/info` 自描述；部分工具同时作为内部 REST 与执行工厂 toolbox 入口（同一业务逻辑） |
+| FR-005 | 返回格式 | P1 | 支持 `response_format`（`toon` 默认 / `json`），TOON 更省 token，作为 Agent 默认消费格式 |
 
 ---
 
 ## 5. 用户配置与使用示例
 
-### 5.1 MCP Server 暴露方式
-
-Agent Retrieval 部署后，MCP Server 端点格式为：
+### 5.1 MCP Server 端点
 
 ```
-https://{host}:{port}/api/agent-retrieval/v1/mcp
+http://{host}:{port}/api/agent-retrieval/v1/mcp
 ```
 
-- `{host}`：agent-retrieval 服务地址（如 `agent-retrieval.example.com` 或内网地址）
-- `{port}`：服务端口（如 `443` 或 `30779`）
-- 路径：`/api/agent-retrieval/v1/mcp` 为 MCP Streamable HTTP 端点基础路径
-- **认证**：使用 Bearer token（middlewareIntrospectVerify），与 Cursor/Claude Desktop 等外部 MCP 客户端兼容
+- 认证：Bearer token（`middlewareIntrospectVerify`），与外部 MCP 客户端兼容
+- 自描述：`GET http://{host}:{port}/api/agent-retrieval/v1/mcp/info`
 
-### 5.2 前置条件
+### 5.2 Cursor / Claude Desktop 配置示例
 
-1. **认证 Token**：用户需具备有效的 Bearer token（通过 Hydra 内省验证）
-2. **知识网络 ID**：用户需知道要检索的知识网络 ID（kn_id）
-3. **mcp-remote**：Cursor、Claude Desktop 等客户端需通过 mcp-remote 适配器连接远程 Streamable HTTP MCP Server
-
-### 5.3 Cursor 配置示例
-
-**配置文件路径**：`~/.cursor/mcp.json`
-
-**简化配置（直接配置 url + headers）**：
+`~/.cursor/mcp.json`（Claude Desktop 配置文件路径见其官方文档，结构相同）：
 
 ```json
 {
@@ -158,159 +128,60 @@ https://{host}:{port}/api/agent-retrieval/v1/mcp
     "context-loader": {
       "url": "http://{host}:{port}/api/agent-retrieval/v1/mcp",
       "headers": {
-        "Authorization": "Bearer 替换为实际token",
-        "X-Kn-ID": "替换为实际kn_id"
+        "Authorization": "Bearer 替换为实际token"
       }
     }
   }
 }
 ```
 
-**说明**：
-- `context-loader`：MCP Server 在 Cursor 中的显示名称，可自定义
-- 将 `替换为实际token` / `替换为实际kn_id` 替换为真实值
+- `context-loader`：MCP Server 显示名，可自定义
+- **kn_id 按工具分级**：仅需走 Header 的工具（如 `find_skills`）才需额外配置 `"X-Kn-ID": "替换为实际kn_id"`；其余工具可由 arguments 传 kn_id，或先用 `list_knowledge_networks` 发现
 
-```json
-{
-  "mcpServers": {
-    "agent-retrieval-kn-search": {
-      "command": "npx",
-      "args": [
-        "-y",
-        "mcp-remote",
-        "https://agent-retrieval.example.com/api/agent-retrieval/v1/mcp",
-        "--header",
-        "Authorization: Bearer 替换为实际token",
-        "--header",
-        "X-Kn-ID: 替换为实际kn_id"
-      ]
-    }
-  }
-}
+经 mcp-remote 适配（stdio 客户端连接 HTTP MCP Server）时，用 `--header` 传同名 Header：
+
+```bash
+npx mcp-remote http://{host}:{port}/api/agent-retrieval/v1/mcp \
+  --header "Authorization: Bearer 替换为实际token"
 ```
 
-**说明**：
-- `agent-retrieval-kn-search`：MCP Server 在 Cursor 中的显示名称，可自定义
-- 将 `替换为实际token` 替换为有效的 Bearer token
-- 将 `替换为实际kn_id` 替换为要检索的知识网络 ID
-- 若需使用环境变量（避免敏感信息写入配置文件），可参考 mcp-remote 文档配置 `env`
+### 5.3 多知识网络
 
-### 5.4 Claude Desktop 配置示例
+切换知识网络的方式：调用时由 arguments 传 `kn_id`；或对仅 Header 取 kn_id 的工具，配置多个 MCP Server 连接（各自 `X-Kn-ID`）。
 
-**配置文件路径**：
-- macOS：`~/Library/Application Support/Claude/claude_desktop_config.json`
-- Windows：`%APPDATA%\Claude\claude_desktop_config.json`
-
-```json
-{
-  "mcpServers": {
-    "agent-retrieval-kn-search": {
-      "command": "npx",
-      "args": [
-        "-y",
-        "mcp-remote",
-        "https://agent-retrieval.example.com/api/agent-retrieval/v1/mcp",
-        "--header",
-        "Authorization: Bearer YOUR_ACCESS_TOKEN",
-        "--header",
-        "X-Kn-ID: your_knowledge_network_id"
-      ]
-    }
-  }
-}
-```
-
-**说明**：与 Cursor 类似，将 `YOUR_ACCESS_TOKEN` 和 `your_knowledge_network_id` 替换为实际值。
-
-### 5.5 使用示例
-
-配置完成并重启 Cursor/Claude Desktop 后：
-
-1. **连接成功**：客户端会显示 MCP Server 已连接（如锤子图标或 MCP 指示器）
-2. **查看工具**：点击 MCP 指示器可看到 `kn_search` 工具
-3. **调用示例**：用户可输入自然语言，由 AI 调用 kn_search 工具，例如：
-   - *"帮我检索一下知识网络中与'糖尿病治疗方案'相关的内容"*
-   - *"搜索知识网络中关于'患者'和'诊断'的概念"*
-4. **工具参数**：AI 会传递 `query` 参数（用户问题或关键词），`kn_id` 已通过 Header 配置，无需在每次调用时指定
-
-### 5.6 多知识网络配置
-
-若用户需同时使用多个知识网络，可配置多个 MCP Server 连接：
-
-```json
-{
-  "mcpServers": {
-    "agent-retrieval-kn-001": {
-      "command": "npx",
-      "args": [
-        "-y",
-        "mcp-remote",
-        "https://agent-retrieval.example.com/api/agent-retrieval/v1/mcp",
-        "--header",
-        "Authorization: Bearer YOUR_TOKEN",
-        "--header",
-        "X-Kn-ID: kn_id_001"
-      ]
-    },
-    "agent-retrieval-kn-002": {
-      "command": "npx",
-      "args": [
-        "-y",
-        "mcp-remote",
-        "https://agent-retrieval.example.com/api/agent-retrieval/v1/mcp",
-        "--header",
-        "Authorization: Bearer YOUR_TOKEN",
-        "--header",
-        "X-Kn-ID: kn_id_002"
-      ]
-    }
-  }
-}
-```
-
-用户在不同对话中可选择不同的 MCP Server，从而使用不同的知识网络。
-
-### 5.7 注意事项
+### 5.4 注意事项
 
 | 事项 | 说明 |
 |------|------|
 | Token 有效期 | Bearer token 过期后需更新配置并重启客户端 |
 | kn_id 有效性 | 需确保 kn_id 对应用户有权限访问的知识网络 |
 | 网络可达性 | 客户端需能访问 agent-retrieval 服务地址 |
-| mcp-remote 版本 | 建议使用支持 `--header` 的 mcp-remote 版本 |
 
 ---
 
 ## 6. 非功能性需求
 
-### 6.1 性能需求
+### 6.1 性能
 
 | 指标 | 要求 | 说明 |
 |------|------|------|
-| 响应时间 | 与 REST 接口一致 | KnSearch 逻辑复用，无额外开销 |
-| 并发 | 支持多 MCP 客户端并发连接 | 无状态设计 |
+| 响应时间 | 与 REST 入口一致 | 复用 logics 层，无额外开销 |
+| 并发 | 支持多客户端并发 | 无状态设计 |
 
-### 6.2 安全需求
-
-| 需求 | 描述 |
-|------|------|
-| 认证 | 必须通过 middlewareIntrospectVerify 认证 |
-| 参数校验 | kn_id（Header 或 arguments）、query 等必填参数需校验 |
-| Header 透传 | 仅透传业务需要的 Header（X-Kn-ID、Authorization） |
-
-### 6.3 可观测性需求
+### 6.2 安全
 
 | 需求 | 描述 |
 |------|------|
-| 日志 | 关键步骤记录 Debug 日志，错误记录 Error 日志 |
-| 追踪 | 错误日志包含 tool_name、kn_id、错误详情 |
+| 认证 | 必须通过 `middlewareIntrospectVerify` |
+| 参数校验 | kn_id（按工具）、必填 arguments 需校验 |
+| run_sql 约束 | 仅 SELECT/WITH，禁写入/DDL，vega 强制限量（见 schema） |
 
-### 6.4 兼容性需求
+### 6.3 兼容性
 
 | 需求 | 描述 |
 |------|------|
-| 向后兼容 | 不影响现有 REST 接口和 MCP Proxy |
-| mcp-go 版本 | v0.43.2（当前最新稳定版，含 Header、WithHTTPContextFunc） |
+| 向后兼容 | 不影响现有 REST 接口与 MCP Proxy |
+| mcp-go 版本 | v0.43.2 |
 
 ---
 
@@ -320,28 +191,19 @@ https://{host}:{port}/api/agent-retrieval/v1/mcp
 
 | 端点 | 方法 | 说明 |
 |------|------|------|
-| /api/agent-retrieval/v1/mcp/initialize | POST | MCP 会话初始化 |
-| /api/agent-retrieval/v1/mcp/tools/list | POST | 列出工具 |
-| /api/agent-retrieval/v1/mcp/tools/call | POST | 调用工具 |
-| /api/agent-retrieval/v1/mcp/* | POST | 其他 MCP 标准端点 |
+| /api/agent-retrieval/v1/mcp/info | GET | 自描述文档（工具目录 + 连接方式），无需 MCP 握手 |
+| /api/agent-retrieval/v1/mcp | POST | MCP Streamable HTTP（initialize / tools/list / tools/call） |
 
 ### 7.2 请求头
 
 | Header | 必填 | 说明 |
 |--------|------|------|
-| Authorization | 是 | Bearer token，用于 middlewareIntrospectVerify |
-| X-Kn-ID | 调用 kn_search 时必填 | 知识网络 ID，由 MCP 客户端在连接时配置 |
+| Authorization | 是 | Bearer token |
+| X-Kn-ID | 视工具而定 | 见 §3.1 |
 
-### 7.3 kn_search 工具参数（arguments）
+### 7.3 工具参数
 
-为先打通流程，本期仅支持以下参数，后续可扩展：
-
-| 参数 | 类型 | 必填 | 说明 |
-|------|------|------|------|
-| query | string | 是 | 用户查询问题或关键词 |
-| kn_id | string | 否 | 若 Header 已配置 X-Kn-ID，可省略；否则必填；若同时存在则 arguments 优先 |
-| only_schema | boolean | 否 | 是否只召回概念，默认 false |
-| enable_rerank | boolean | 否 | 是否启用 Rerank，默认 true |
+逐工具 arguments 与 schema 以 `schemas/<tool>.json` / `GET /mcp/info` / [tool-usage-guide.md](../../release/tool-usage-guide.md) 为准。所有工具均支持可选 `response_format`（`toon` 默认 / `json`）。
 
 ---
 
@@ -350,10 +212,10 @@ https://{host}:{port}/api/agent-retrieval/v1/mcp
 | 错误场景 | HTTP 状态码 | 处理方式 |
 |---------|-------------|----------|
 | 未认证 | 401 | 中间件层拒绝 |
-| kn_id 缺失 | 400 | 返回 `kn_id is required (configure X-Kn-ID header or pass kn_id in arguments)` |
-| query 缺失 | 400 | 返回 `query is required` |
+| kn_id 缺失（按工具要求） | 400 | 返回明确错误（如 `kn_id is required ...`） |
+| 必填 arguments 缺失 | 400 | 返回校验错误 |
 | 工具不存在 | 404 | MCP 标准错误 |
-| KnSearch 执行失败 | 500 | 记录日志并返回错误 |
+| 业务逻辑执行失败 | 500 | 记录日志并返回错误 |
 
 ---
 
@@ -365,6 +227,7 @@ https://{host}:{port}/api/agent-retrieval/v1/mcp
 | Streamable HTTP | - | mcp-go 的请求/响应式 HTTP 传输 |
 | 内省 | Introspect | 通过 Hydra 验证 token 并获取用户信息 |
 | kn_id | - | 知识网络 ID |
+| TOON | - | 比 JSON 更省 token 的文本编码，MCP 工具默认返回格式 |
 | mcp-remote | - | 连接远程 MCP Server 的适配器，支持 stdio 客户端连接 HTTP MCP Server |
 
 ---
@@ -374,4 +237,4 @@ https://{host}:{port}/api/agent-retrieval/v1/mcp
 | 版本 | 日期 | 修改人 | 修改内容 |
 |------|------|--------|----------|
 | v1.0 | 2026-02-01 | - | 初始版本，工具清单（kn_search）、kn_id Header 设计、用户配置与使用示例 |
-eader 设计、用户配置与使用示例 |
+| v2.0 | 2026-06-23 | - | 对齐实现现状：工具清单改为指向 `tools_meta.json` + `/mcp/info` + tool-usage-guide.md（不再在文内枚举）；kn_id 改为按工具分级；新增 `/mcp/info`、`response_format`、多入口（toolbox）说明；server 名 `context-loader`；配置示例简化为仅 Authorization；修复失效链接与文末残行 |

--- a/adp/context-loader/agent-retrieval/docs/release/tool-usage-guide.md
+++ b/adp/context-loader/agent-retrieval/docs/release/tool-usage-guide.md
@@ -6,13 +6,14 @@
 
 | 字段 | 值 |
 | :--- | :--- |
-| 文档版本 | v1.6 |
+| 文档版本 | v1.7 |
 | 适用版本 | context-loader v0.8.0 |
 | 发布日期 | 2026-04-28 |
 | 状态 | 正式发布 |
 
 | 修订日期 | 修订说明 |
 | :--- | :--- |
+| 2026-06-23 | 新增 `run_sql` / `list_knowledge_networks` / `get_kn_detail` 三个工具说明；补充 MCP 自描述端点 `/mcp/info` 与「同一能力多入口（MCP / REST / 执行工厂 toolbox）」说明 |
 | 2026-05-12 | 补充 ContextLoader 标准工具集已内置到服务中，并随服务启动自动同步到执行工厂；新增工具集契约版本描述规则 |
 | 2026-04-28 | 更新为 context-loader `0.8.0`；`search_schema` 增加 `search_scope.concept_groups`，用于按 BKN 概念分组限定 object / relation / action schema 召回范围，并向 metric schema 检索透传分组条件 |
 | 2026-04-23 | 更新为 context-loader `0.7.0`；本版 release 仅纳入 `issue-189` / `issue-234`；`search_schema` 的 HTTP `kn_id` 改为通过 body 传递，并补充 `metric_types` 发布口径 |
@@ -26,6 +27,14 @@
 ContextLoader 标准工具集已内置在服务中，随服务启动自动同步到执行工厂。工具集名称保持为 `contextloader工具集`，描述规则固定为 `ContextLoader 标准内置工具集；契约版本: x.y.z`。
 
 契约版本仅在工具列表、工具参数 Schema 或工具语义发生变化时更新；服务 bugfix、内部实现优化、文档调整不单独更新契约版本。
+
+## 工具目录与自描述
+
+工具清单与逐工具 schema 的**权威事实源**是服务内嵌的 `server/driveradapters/mcp/schemas/tools_meta.json` 与 `schemas/<tool>.json`，本文是面向接入的人读快照，以事实源为准。
+
+- 运行时自描述：`GET /api/agent-retrieval/v1/mcp/info` 返回 service / endpoint / protocol / auth / tool_count / tools[]（含 input/output schema）/ client_config_example，无需先走 MCP 握手即可了解全部工具。
+- 同一能力多入口：同一份业务逻辑同时对外暴露为 **MCP 工具**、**REST 接口** 与（部分工具）**执行工厂 toolbox（OpenAPI HTTP）**。其中 `run_sql` / `list_knowledge_networks` / `get_kn_detail` 即按 MCP + toolbox 双入口注册。
+- 返回格式：所有 MCP 工具支持可选 `response_format`（`toon` 默认 / `json`）；MCP 文本默认 TOON，REST 默认 JSON。
 
 ## 1. 什么是 context-loader
 
@@ -132,6 +141,9 @@ curl -X POST "http://agent-retrieval:30779/api/agent-retrieval/in/v1/kn/query_ob
 | `find_skills` | 在业务边界内发现 Skill 候选 | 已知 `kn_id`，想知道当前场景下可考虑装配哪些 Skill 时 |
 | `get_logic_properties_values` | 逻辑属性解析（指标/算子） | 值需要按上下文动态计算时 |
 | `get_action_info` | 动态工具发现（Function Call 定义） | 针对具体对象实例，想知道“能做什么动作”时 |
+| `list_knowledge_networks` | 列出可用知识网络（返回 kn_id） | 不知道有哪些 kn_id、需先发现知识网络时 |
+| `get_kn_detail` | 一次性获取某知识网络完整 Schema（包装 bkn-backend） | 已知 kn_id，想一次拿全量概念组/对象类/关系类/行动类时 |
+| `run_sql` | 对知识网络挂载的数据资源执行只读 SQL（Trino） | 需要在单个数据目录内做结构化只读查询/聚合时 |
 
 ### 4.3 工具依赖（四类工具如何衔接）
 
@@ -512,6 +524,77 @@ Data Agent 配置（建议）：
 | `at_id` | 模型生成 | 请求体参数 | `模型生成` |
 | `_instance_identities` | 模型生成 | 请求体参数（可选） | `模型生成` |
 
+### 6.8 list_knowledge_networks（知识网络发现）
+
+> Schema 以 MCP 内嵌 [schemas/list_knowledge_networks.json](../../server/driveradapters/mcp/schemas/list_knowledge_networks.json) / `GET /mcp/info` 为准。
+
+- API：`POST /api/agent-retrieval/in/v1/kn/list_knowledge_networks`
+- 作用：列出可用知识网络，返回 `kn_id` 及基本信息；是其余需要 `kn_id` 的工具的前置发现入口
+- 无需 `kn_id`（本工具用于发现 kn_id）
+
+请求体（关键字段，均可选）：
+
+| 字段 | 必填 | 说明 |
+| :--- | :--- | :--- |
+| `name_pattern` | 否 | 按知识网络名称模糊过滤 |
+| `limit` | 否 | 单页数量，默认 20 |
+| `offset` | 否 | 偏移量，用于翻页，默认 0 |
+| `sort` | 否 | 排序字段，默认 `update_time` |
+| `direction` | 否 | 排序方向 `asc` / `desc`，默认 `desc` |
+
+返回要点：
+
+- `entries`：知识网络列表，每项含 `id`（即 kn_id）、`name`、`description`、`module_type`、`business_domain`
+- `total_count`：命中总数
+
+### 6.9 get_kn_detail（知识网络完整详情）
+
+> Schema 以 MCP 内嵌 [schemas/get_kn_detail.json](../../server/driveradapters/mcp/schemas/get_kn_detail.json) / `GET /mcp/info` 为准。
+
+- API：`POST /api/agent-retrieval/in/v1/kn/get_kn_detail`
+- 作用：直接包装 bkn-backend，已知 `kn_id` 时一次性返回知识网络完整 Schema
+- 与 `search_schema` 区别：`search_schema` 按 query 召回相关概念子集；`get_kn_detail` 返回全量 Schema，不做相关性筛选
+
+请求体：
+
+| 字段 | 必填 | 说明 |
+| :--- | :--- | :--- |
+| `kn_id` | 是 | 知识网络 ID（也可改用 `X-Kn-ID` 请求头传入） |
+
+返回要点：
+
+- `id` / `name` / `comment`：知识网络基本信息
+- `concept_groups` / `object_types`（含 `data_source`）/ `relation_types` / `action_types`：全量 Schema
+
+### 6.10 run_sql（资源只读 SQL）
+
+> Schema 以 MCP 内嵌 [schemas/run_sql.json](../../server/driveradapters/mcp/schemas/run_sql.json) / `GET /mcp/info` 为准。
+
+- API：`POST /api/agent-retrieval/in/v1/kn/run_sql`
+- 作用：对知识网络挂载的数据资源执行只读 SQL（Trino 方言），底层由 vega 解析占位符并强制限量
+- 无需 `kn_id`：表名以占位符 `{{.resource_id}}` 引用资源，`resource_id` 取自对象类的 `data_source.id`（可由 `search_schema` / `get_kn_detail` 获得）
+
+请求体：
+
+| 字段 | 必填 | 说明 |
+| :--- | :--- | :--- |
+| `sql` | 是 | 只读 SQL（Trino 方言）。表名用 `{{.resource_id}}` 占位符引用；仅允许 `SELECT` / `WITH`，禁止写入与 DDL；不支持多语句；不支持跨数据目录 join（单次查询资源需同属一个 catalog） |
+| `resource_type` | 否 | 连接器类型（mysql / mariadb / postgresql）。留空则按 SQL 中第一个 `{{.resource_id}}` 自动解析 |
+| `query_timeout` | 否 | 查询超时（秒），范围 1-3600，默认 60 |
+
+安全与约束：
+
+- 仅 `SELECT` / `WITH`，任何写入 / DDL / 多语句被拒
+- 单次查询涉及的资源需同属一个数据目录（不支持跨 catalog join）
+- vega 自动限量（最多 10000 行）
+
+返回要点：
+
+- `columns`：结果列信息（name / type）
+- `entries`：结果行
+- `total_count`：返回行数
+- `warnings`：非致命告警（如资源已弃用）
+
 ## 7. 集成场景与最佳实践
 
 ### 7.1 场景：从问题到可审计事实链
@@ -534,3 +617,5 @@ Data Agent 配置（建议）：
 - `find_skills.yaml`
 - `get_logic_properties_values.yaml`
 - `get_action_info.yaml`
+
+> `run_sql` / `list_knowledge_networks` / `get_kn_detail` 无独立 OpenAPI YAML；其 schema 以 MCP 内嵌的 `server/driveradapters/mcp/schemas/<tool>.json` 与 `GET /api/agent-retrieval/v1/mcp/info` 为准。


### PR DESCRIPTION
## 背景

`feature-mcp-server` 设计文档停在 v1.0（单 `kn_search` 工具、仅 `X-Kn-ID`、`/mcp/tools/call` 端点），而代码已演进到 **9 个数据驱动工具** + `/mcp/info` 自描述端点 + `response_format` 默认 TOON + 三入口（MCP / REST / 执行工厂 toolbox）。文档严重过时。

## 改动（3 文件，纯文档）

- **实现设计文档.md → v2.0**：瘦身为设计意图（数据驱动注册、三入口、kn_id 分级、`/mcp/info`、`response_format`）。工具清单/字段改为指向 `tools_meta.json` + `/mcp/info` 唯一事实源，不再文内枚举。server 名更正为 `context-loader`，删掉不存在的 `config.go`。
- **需求设计文档.md → v2.0**：工具清单 2.1 改为事实源指针；kn_id 改为按工具分级；配置示例简化为仅 `Authorization`；修复失效链接与文末残行。
- **tool-usage-guide.md → v1.7**：补 `run_sql` / `list_knowledge_networks` / `get_kn_detail` 工具参考 + 总览行 + 「工具目录与自描述」节 + 修订记录。

## 设计原则

工具清单留在 `tools_meta.json` + `/mcp/info`（运行时自描述，与 `tools/list` 同源），设计文档只讲意图。工具增删改只动 JSON + handler，文档不再随之漂移。

> 仅文档变更，不涉及代码逻辑。

🤖 Generated with [Claude Code](https://claude.com/claude-code)