### PR TITLE
fix: eradicate embedding NameNotExist — vega sends model_id + mf-model-api tolerant resolution

### DIFF
--- a/adp/vega/vega-backend/server/drivenadapters/model_factory/model_factory_access.go
+++ b/adp/vega/vega-backend/server/drivenadapters/model_factory/model_factory_access.go
@@ -84,7 +84,7 @@ func (mfa *modelFactoryAccess) GetModelByName(ctx context.Context, modelName str
 	return &smallModel, nil
 }
 
-func (mfa *modelFactoryAccess) GetVector(ctx context.Context, modelName string, words []string) ([]*interfaces.VectorResp, error) {
+func (mfa *modelFactoryAccess) GetVector(ctx context.Context, modelID string, words []string) ([]*interfaces.VectorResp, error) {
 
 	ctx, span := oteltrace.StartNamedClientSpan(ctx, "GetVector")
 	defer span.End()
@@ -93,8 +93,8 @@ func (mfa *modelFactoryAccess) GetVector(ctx context.Context, modelName string, 
 		return []*interfaces.VectorResp{}, nil
 	}
 
-	if modelName == "" {
-		return nil, fmt.Errorf("model name cannot be empty")
+	if modelID == "" {
+		return nil, fmt.Errorf("model id cannot be empty")
 	}
 
 	httpUrl := fmt.Sprintf("%s/api/private/mf-model-api/v1/small-model/embeddings", mfa.mfAPIUrl)
@@ -102,9 +102,13 @@ func (mfa *modelFactoryAccess) GetVector(ctx context.Context, modelName string, 
 		"Content-Type": "application/json",
 	}
 
+	// buildTask.EmbeddingModel 存的是模型 **id**（已归一到 id），必须发 model_id 字段。
+	// mf-model-api 的 embeddings 解析：model 字段只按 model_name 查、model_id 字段才按 id 查。
+	// 之前把 id 塞进 model（名字）字段 → 按 name 查不到 → ModelFactory.ExternalSmallModel.Used.NameNotExist
+	// （偶尔“成功”只是撞上 model_id 查询写下的同名缓存 key，并非真解析成功）。
 	requestBody := map[string]any{
-		"model":    modelName,
-		"model_id": "",
+		"model":    "",
+		"model_id": modelID,
 		"input":    words,
 	}
 


### PR DESCRIPTION
## Problem

Embedding builds failed with `ModelFactory.ExternalSmallModel.Used.NameNotExist` → task `completed` with `vectorized 0%`, empty index. It looked **intermittent** ("时好时坏").

Two compounding bugs:
1. **vega** put the embedding model **id** into the request's `model` (name) field.
2. **mf-model-api** resolved `model` by name only (`WHERE f_model_name=...`), so an id-as-name never matched. The "intermittent success" was a **redis cache-key collision**: `model` and `model_id` shared one namespace `...:{value}:list`, so a real `model_id=<id>` lookup warmed `...:{id}:list` and a later broken `model=<id>` request transiently hit it (24h TTL).

## Fix (eradicated at the chokepoint)

**vega** (`model_factory_access.go`): `GetVector` sends the id in `model_id` (not `model`).

**mf-model-api** (root fix, benefits every caller):
- DAO `get_model_info_by_name_id` / `get_data_from_model_list_by_name_id`: resolve by `f_model_id = %s OR f_model_name = %s` (tolerant — id or name in either field works). Parameterized → closes the f-string SQL injection.
- Cache key namespaced by field (`...:name:{}` / `...:id:{}`, small-model + llm) → no more collision / false-hits.
- `small_model_controller`: `eval(res)` → `json.loads`/`json.dumps` (drops RCE-on-poisoned-cache; matches llm).
- Correct centralized invalidation (`invalidate_small_model_cache`): clears name+id keys, and edit clears the **old** name on rename (was leaving a 24h-stale key); delete clears name+id (id key was orphaned).

## Verified live (VM + 118 deployed)
- `model=<id>` (the previously-fatal case) → returns vectors, **4/4 stable** (no cache dependency).
- vega embedding restart: zero `NameNotExist`, vectorized climbs reliably.

## Follow-ups (separate)
- Sequential per-doc embedding is slow (~10/s) — batch multiple docs per `GetVector` call.
- LLM-model cache invalidation isn't wired in mf-model-api (CRUD likely in mf-model-manager) — pre-existing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)