### PR TITLE
feat(bkn-safe): object-level grants + LLM/large_model authz

### DIFF
--- a/adp/bkn/bkn-backend/server/drivenadapters/knowledge_network/knowledge_network_access.go
+++ b/adp/bkn/bkn-backend/server/drivenadapters/knowledge_network/knowledge_network_access.go
@@ -930,6 +930,57 @@ func (kna *knowledgeNetworkAccess) GetAllKNs(ctx context.Context) (map[string]*i
 	return KNs, nil
 }
 
+// GetKNNamesByIDs 按 ID 批量查询知识网络名称(轻查询，仅取 f_id/f_name)。缺失 id 略过、空 ids 返回空切片。
+func (kna *knowledgeNetworkAccess) GetKNNamesByIDs(ctx context.Context,
+	ids []string, branch string) ([]*interfaces.KNNameEntry, error) {
+	ctx, span := oteltrace.StartNamedClientSpan(ctx, "Select knowledge network names by ids")
+	defer span.End()
+
+	span.SetAttributes(
+		attr.Key("db_url").String(libdb.GetDBUrl()),
+		attr.Key("db_type").String(libdb.GetDBType()))
+
+	entries := make([]*interfaces.KNNameEntry, 0, len(ids))
+	if len(ids) == 0 {
+		span.SetStatus(codes.Ok, "")
+		return entries, nil
+	}
+
+	sqlStr, vals, err := sq.Select(
+		"f_id",
+		"f_name").
+		From(KN_TABLE_NAME).
+		Where(sq.Eq{"f_id": ids}).
+		Where(sq.Eq{"f_branch": branch}).
+		ToSql()
+	if err != nil {
+		otellog.LogError(ctx, "Failed to build the sql of select knowledge network names by ids, error", err)
+		return nil, err
+	}
+
+	// 记录处理的 sql 字符串
+	otellog.LogInfo(ctx, fmt.Sprintf("按ID批量查询业务知识网络名称的 sql 语句: %s; ids: %v", sqlStr, ids))
+
+	rows, err := kna.db.Query(sqlStr, vals...)
+	if err != nil {
+		otellog.LogError(ctx, "List data error", err)
+		return nil, err
+	}
+	defer func() { _ = rows.Close() }()
+
+	for rows.Next() {
+		entry := &interfaces.KNNameEntry{}
+		if err := rows.Scan(&entry.ID, &entry.Name); err != nil {
+			otellog.LogError(ctx, "Row scan error", err)
+			return nil, err
+		}
+		entries = append(entries, entry)
+	}
+
+	span.SetStatus(codes.Ok, "")
+	return entries, nil
+}
+
 func (kna *knowledgeNetworkAccess) ListKnSrcs(ctx context.Context,
 	query interfaces.KNsQueryParams) ([]interfaces.PermissionResource, error) {
 	ctx, span := oteltrace.StartNamedClientSpan(ctx, "Select knowledge networks")

--- a/adp/bkn/bkn-backend/server/driveradapters/knowledge_network_handler.go
+++ b/adp/bkn/bkn-backend/server/driveradapters/knowledge_network_handler.go
@@ -857,6 +857,38 @@ func (r *restHandler) GetRelationTypePaths(c *gin.Context, visitor hydra.Visitor
 	rest.ReplyOK(c, http.StatusOK, httpResult)
 }
 
+// QueryKNNamesByIDs 按 ID 批量取知识网络名称(对象级授权页回显，统一契约)。
+// 请求 {"ids":[...]}，响应 {"entries":[{"id","name"}]}；缺失 id 略过、空 ids 返回空 entries。
+// 绕过授权过滤：授权页需为用户无权但被引用的 KN 回显名称，故不做 token/权限校验，与
+// operator-integration 的 /skills/names、/operator/names、/tool-box/names 契约一致。
+func (r *restHandler) QueryKNNamesByIDs(c *gin.Context) {
+	logger.Debug("Handler QueryKNNamesByIDs Start")
+	ctx, span := oteltrace.StartServerSpan(c)
+	defer span.End()
+	oteltrace.AddHttpAttrs4API(span, oteltrace.GetAttrsByGinCtx(c))
+
+	req := interfaces.KNBatchNamesReq{}
+	if err := c.ShouldBindJSON(&req); err != nil {
+		httpErr := rest.NewHTTPError(ctx, http.StatusBadRequest, berrors.BknBackend_KnowledgeNetwork_InvalidParameter).
+			WithErrorDetails("Binding Parameter Failed: " + err.Error())
+		oteltrace.AddHttpAttrs4HttpError(span, httpErr)
+		rest.ReplyError(c, httpErr)
+		return
+	}
+
+	resp, err := r.kns.GetKNNamesByIDs(ctx, req.IDs)
+	if err != nil {
+		httpErr := err.(*rest.HTTPError)
+		oteltrace.AddHttpAttrs4HttpError(span, httpErr)
+		rest.ReplyError(c, httpErr)
+		return
+	}
+
+	logger.Debug("Handler QueryKNNamesByIDs Success")
+	oteltrace.AddHttpAttrs4Ok(span, http.StatusOK)
+	rest.ReplyOK(c, http.StatusOK, resp)
+}
+
 // 分页获取业务知识网络资源列表
 func (r *restHandler) ListKnSrcs(c *gin.Context) {
 	logger.Debug("tHandler ListKnSrcs Start")

--- a/adp/bkn/bkn-backend/server/driveradapters/routers.go
+++ b/adp/bkn/bkn-backend/server/driveradapters/routers.go
@@ -86,6 +86,8 @@ func (r *restHandler) RegisterPublic(c *gin.Engine) {
 	for _, apiV1 := range []*gin.RouterGroup{bknApiV1, otlApiV1} {
 		// 业务知识网络
 		apiV1.POST("/knowledge-networks", r.verifyJsonContentType(), r.CreateKNByEx)
+		// 按 ID 批量取名(对象级授权页回显，绕过授权过滤；静态段 names 与 :kn_id 不冲突)
+		apiV1.POST("/knowledge-networks/names", r.verifyJsonContentType(), r.QueryKNNamesByIDs)
 		apiV1.DELETE("/knowledge-networks/:kn_id", r.DeleteKN)
 		apiV1.PUT("/knowledge-networks/:kn_id", r.verifyJsonContentType(), r.UpdateKNByEx)
 		apiV1.GET("/knowledge-networks", r.ListKNsByEx)
@@ -171,6 +173,8 @@ func (r *restHandler) RegisterPublic(c *gin.Engine) {
 	for _, apiInV1 := range []*gin.RouterGroup{bknApiInV1, otlApiInV1} {
 		// 业务知识网络
 		apiInV1.POST("/knowledge-networks", r.verifyJsonContentType(), r.CreateKNByIn)
+		// 按 ID 批量取名(对象级授权页回显，绕过授权过滤；静态段 names 与 :kn_id 不冲突)
+		apiInV1.POST("/knowledge-networks/names", r.verifyJsonContentType(), r.QueryKNNamesByIDs)
 		apiInV1.PUT("/knowledge-networks/:kn_id", r.verifyJsonContentType(), r.UpdateKNByIn)
 		apiInV1.GET("/knowledge-networks", r.ListKNsByIn)
 		apiInV1.GET("/knowledge-networks/:kn_id", r.GetKNByIn)

--- a/adp/bkn/bkn-backend/server/interfaces/knowledge_network.go
+++ b/adp/bkn/bkn-backend/server/interfaces/knowledge_network.go
@@ -137,6 +137,23 @@ type KN struct {
 	Score  *float64  `json:"_score,omitempty"` // opensearch检索的得分，在概念搜索时使用
 }
 
+// KNBatchNamesReq 按 ID 批量取知识网络名称请求(对象级授权页回显，统一契约)
+type KNBatchNamesReq struct {
+	IDs []string `json:"ids"` // 待取名的知识网络 ID 列表，空列表返回空 entries
+}
+
+// KNNameEntry 单个 知识网络 ID->名称 条目
+type KNNameEntry struct {
+	ID   string `json:"id"`   // 知识网络 ID(string slug)
+	Name string `json:"name"` // 知识网络名称
+}
+
+// KNBatchNamesResp 按 ID 批量取知识网络名称响应
+// 容错：不存在的 ID 略过，不报错
+type KNBatchNamesResp struct {
+	Entries []*KNNameEntry `json:"entries"`
+}
+
 type Statistics struct {
 	CgTotal       int `json:"concept_groups_total"`
 	OtTotal       int `json:"object_types_total"`

--- a/adp/bkn/bkn-backend/server/interfaces/knowledge_network_access.go
+++ b/adp/bkn/bkn-backend/server/interfaces/knowledge_network_access.go
@@ -27,5 +27,9 @@ type KNAccess interface {
 	GetAllKNs(ctx context.Context) (map[string]*KN, error)
 	GetNeighborPathsBatch(ctx context.Context, otIDs []string, query RelationTypePathsBaseOnSource) (map[string][]RelationTypePath, error)
 
+	// GetKNNamesByIDs 按 ID 批量查询知识网络名称(轻查询，绕过授权过滤，仅用于对象级授权页回显)。
+	// 缺失的 id 略过、空 ids 返回空 entries。
+	GetKNNamesByIDs(ctx context.Context, ids []string, branch string) ([]*KNNameEntry, error)
+
 	ListKnSrcs(ctx context.Context, query KNsQueryParams) ([]PermissionResource, error)
 }

--- a/adp/bkn/bkn-backend/server/interfaces/knowledge_network_service.go
+++ b/adp/bkn/bkn-backend/server/interfaces/knowledge_network_service.go
@@ -29,4 +29,7 @@ type KNService interface {
 
 	// ValidateKN 仅校验知识网络整体依赖存在性，不写库。mode 与 CreateKN 的导入模式一致，用于名称/ID 与落库冲突的语义对齐。
 	ValidateKN(ctx context.Context, kn *KN, strictMode bool, mode string) error
+
+	// GetKNNamesByIDs 按 ID 批量取知识网络名称(对象级授权页回显)。绕过授权过滤，缺失 id 略过、空 ids 返回空 entries。
+	GetKNNamesByIDs(ctx context.Context, ids []string) (*KNBatchNamesResp, error)
 }

--- a/adp/bkn/bkn-backend/server/interfaces/mock/mock_knowledge_network_access.go
+++ b/adp/bkn/bkn-backend/server/interfaces/mock/mock_knowledge_network_access.go
@@ -133,6 +133,21 @@ func (mr *MockKNAccessMockRecorder) GetKNByID(ctx, knID, branch any) *gomock.Cal
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetKNByID", reflect.TypeOf((*MockKNAccess)(nil).GetKNByID), ctx, knID, branch)
 }
 
+// GetKNNamesByIDs mocks base method.
+func (m *MockKNAccess) GetKNNamesByIDs(ctx context.Context, ids []string, branch string) ([]*interfaces.KNNameEntry, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetKNNamesByIDs", ctx, ids, branch)
+	ret0, _ := ret[0].([]*interfaces.KNNameEntry)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetKNNamesByIDs indicates an expected call of GetKNNamesByIDs.
+func (mr *MockKNAccessMockRecorder) GetKNNamesByIDs(ctx, ids, branch any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetKNNamesByIDs", reflect.TypeOf((*MockKNAccess)(nil).GetKNNamesByIDs), ctx, ids, branch)
+}
+
 // GetKNsTotal mocks base method.
 func (m *MockKNAccess) GetKNsTotal(ctx context.Context, query interfaces.KNsQueryParams) (int, error) {
 	m.ctrl.T.Helper()

--- a/adp/bkn/bkn-backend/server/interfaces/mock/mock_knowledge_network_service.go
+++ b/adp/bkn/bkn-backend/server/interfaces/mock/mock_knowledge_network_service.go
@@ -118,6 +118,21 @@ func (mr *MockKNServiceMockRecorder) GetKNByID(ctx, knID, branch, mode any) *gom
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetKNByID", reflect.TypeOf((*MockKNService)(nil).GetKNByID), ctx, knID, branch, mode)
 }
 
+// GetKNNamesByIDs mocks base method.
+func (m *MockKNService) GetKNNamesByIDs(ctx context.Context, ids []string) (*interfaces.KNBatchNamesResp, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetKNNamesByIDs", ctx, ids)
+	ret0, _ := ret[0].(*interfaces.KNBatchNamesResp)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetKNNamesByIDs indicates an expected call of GetKNNamesByIDs.
+func (mr *MockKNServiceMockRecorder) GetKNNamesByIDs(ctx, ids any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetKNNamesByIDs", reflect.TypeOf((*MockKNService)(nil).GetKNNamesByIDs), ctx, ids)
+}
+
 // GetRelationTypePaths mocks base method.
 func (m *MockKNService) GetRelationTypePaths(ctx context.Context, query interfaces.RelationTypePathsBaseOnSource) ([]interfaces.RelationTypePath, error) {
 	m.ctrl.T.Helper()

--- a/adp/bkn/bkn-backend/server/logics/knowledge_network/knowledge_network_service.go
+++ b/adp/bkn/bkn-backend/server/logics/knowledge_network/knowledge_network_service.go
@@ -560,6 +560,46 @@ func (kns *knowledgeNetworkService) ListKNs(ctx context.Context, parameter inter
 	return KNs, total, nil
 }
 
+// GetKNNamesByIDs 按 ID 批量取知识网络名称(对象级授权页回显)。
+// 刻意不走 FilterResources 授权过滤：授权页需要为"用户无权但被授权对象引用"的 KN 回显名称，
+// 故此处只做轻量名称查询。缺失 id 略过、空 ids 返回空 entries、id 去重。
+func (kns *knowledgeNetworkService) GetKNNamesByIDs(ctx context.Context, ids []string) (*interfaces.KNBatchNamesResp, error) {
+	ctx, span := oteltrace.StartNamedInternalSpan(ctx, "按ID批量查询业务知识网络名称")
+	defer span.End()
+
+	resp := &interfaces.KNBatchNamesResp{Entries: []*interfaces.KNNameEntry{}}
+
+	// 去重，过滤空字符串
+	seen := make(map[string]struct{}, len(ids))
+	uniqueIDs := make([]string, 0, len(ids))
+	for _, id := range ids {
+		if id == "" {
+			continue
+		}
+		if _, ok := seen[id]; ok {
+			continue
+		}
+		seen[id] = struct{}{}
+		uniqueIDs = append(uniqueIDs, id)
+	}
+	if len(uniqueIDs) == 0 {
+		span.SetStatus(codes.Ok, "")
+		return resp, nil
+	}
+
+	entries, err := kns.kna.GetKNNamesByIDs(ctx, uniqueIDs, interfaces.MAIN_BRANCH)
+	if err != nil {
+		logger.Errorf("GetKNNamesByIDs error: %s", err.Error())
+		span.SetStatus(codes.Error, "按ID批量查询业务知识网络名称失败")
+		return resp, rest.NewHTTPError(ctx, http.StatusInternalServerError,
+			berrors.BknBackend_KnowledgeNetwork_InternalError).WithErrorDetails(err.Error())
+	}
+	resp.Entries = entries
+
+	span.SetStatus(codes.Ok, "")
+	return resp, nil
+}
+
 func (kns *knowledgeNetworkService) GetKNByID(ctx context.Context, knID string, branch string, mode string) (*interfaces.KN, error) {
 
 	// 获取业务知识网络

--- a/adp/execution-factory/operator-integration/server/dbaccess/skill_repository.go
+++ b/adp/execution-factory/operator-integration/server/dbaccess/skill_repository.go
@@ -278,6 +278,25 @@ func (s *skillRepositoryDB) applyFilterConditions(query *ormhelper.SelectBuilder
 	return query
 }
 
+// SelectSkillListByIDs 按 skillID 批量查询(仅未删除)，仅用于轻量取名场景。空入参短路返回空列表，防止 IN ()。
+func (s *skillRepositoryDB) SelectSkillListByIDs(ctx context.Context, skillIDs []string) (skills []*model.SkillRepositoryDB, err error) {
+	skills = []*model.SkillRepositoryDB{}
+	args := []interface{}{}
+	for _, id := range skillIDs {
+		if id != "" {
+			args = append(args, id)
+		}
+	}
+	if len(args) == 0 {
+		return
+	}
+	err = s.orm.Select().From(tbSkillRepository).
+		WhereIn("f_skill_id", args...).
+		WhereEq("f_is_deleted", false).
+		Get(ctx, &skills)
+	return
+}
+
 func (s *skillRepositoryDB) SelectSkillByName(ctx context.Context, tx *sql.Tx, name string, status []string) (exists bool, skillDB *model.SkillRepositoryDB, err error) {
 	orm := s.orm
 	if tx != nil {

--- a/adp/execution-factory/operator-integration/server/driveradapters/operator/index.go
+++ b/adp/execution-factory/operator-integration/server/driveradapters/operator/index.go
@@ -21,6 +21,7 @@ type OperatorHandler interface {
 	OperatorRegister(c *gin.Context)
 	OperatorQueryByOperatorID(c *gin.Context)
 	OperatorQueryPage(c *gin.Context)
+	OperatorQueryNamesByIDs(c *gin.Context)
 	OperatorUpdateByOpenAPI(c *gin.Context)
 	OperatorEdit(c *gin.Context)
 	OperatorDelete(c *gin.Context)

--- a/adp/execution-factory/operator-integration/server/driveradapters/operator/operator_query.go
+++ b/adp/execution-factory/operator-integration/server/driveradapters/operator/operator_query.go
@@ -71,3 +71,18 @@ func (op *operatorHandle) OperatorQueryPage(c *gin.Context) {
 	}
 	rest.ReplyOK(c, http.StatusOK, result)
 }
+
+// OperatorQueryNamesByIDs 按算子ID批量取名(给前端对象级授权页回显名称用)
+func (op *operatorHandle) OperatorQueryNamesByIDs(c *gin.Context) {
+	req := &interfaces.BatchNamesReq{}
+	if err := c.ShouldBindJSON(req); err != nil {
+		rest.ReplyError(c, errors.DefaultHTTPError(c.Request.Context(), http.StatusBadRequest, err.Error()))
+		return
+	}
+	result, err := op.OperatorManager.GetOperatorNamesByIDs(c.Request.Context(), req.IDs)
+	if err != nil {
+		rest.ReplyError(c, err)
+		return
+	}
+	rest.ReplyOK(c, http.StatusOK, result)
+}

--- a/adp/execution-factory/operator-integration/server/driveradapters/operator_handler.go
+++ b/adp/execution-factory/operator-integration/server/driveradapters/operator_handler.go
@@ -91,6 +91,8 @@ func (o *operatorRestHandler) RegisterPublic(engine *gin.RouterGroup) {
 	engine.GET("/operator/info/:operator_id", o.OperatorHandler.OperatorQueryByOperatorID)
 	// GET /api/agent-operator-integration/v1/operator/info/list
 	engine.GET("/operator/info/list", middlewareBusinessDomain(true, false, o.businessDomainService), o.OperatorHandler.OperatorQueryPage)
+	// POST /api/agent-operator-integration/v1/operator/names 按算子ID批量取名(前端对象级授权页回显)
+	engine.POST("/operator/names", o.OperatorHandler.OperatorQueryNamesByIDs)
 	// DELETE /api/agent-operator-integration/v1/operator/delete
 	engine.DELETE("/operator/delete", middlewareBusinessDomain(true, false, o.businessDomainService), o.OperatorHandler.OperatorDelete)
 	// POST /api/agent-operator-integration/v1/operator/status

--- a/adp/execution-factory/operator-integration/server/driveradapters/skill/index.go
+++ b/adp/execution-factory/operator-integration/server/driveradapters/skill/index.go
@@ -24,6 +24,7 @@ type SkillHandler interface {
 	UpdateSkillStatus(c *gin.Context)
 	DownloadSkill(c *gin.Context)
 	QuerySkillList(c *gin.Context)
+	QuerySkillNamesByIDs(c *gin.Context)
 	QuerySkillMarketList(c *gin.Context)
 	GetSkillMarketDetail(c *gin.Context)
 	GetSkillDetail(c *gin.Context)

--- a/adp/execution-factory/operator-integration/server/driveradapters/skill/skill.go
+++ b/adp/execution-factory/operator-integration/server/driveradapters/skill/skill.go
@@ -239,6 +239,21 @@ func (h *skillHandler) QuerySkillList(c *gin.Context) {
 	rest.ReplyOK(c, http.StatusOK, resp)
 }
 
+// QuerySkillNamesByIDs 按技能ID批量取名(给前端对象级授权页回显名称用)
+func (h *skillHandler) QuerySkillNamesByIDs(c *gin.Context) {
+	req := &interfaces.BatchNamesReq{}
+	if err := utils.GetBindJSONRaw(c, req); err != nil {
+		rest.ReplyError(c, err)
+		return
+	}
+	resp, err := h.Registry.GetSkillNamesByIDs(c.Request.Context(), req.IDs)
+	if err != nil {
+		rest.ReplyError(c, err)
+		return
+	}
+	rest.ReplyOK(c, http.StatusOK, resp)
+}
+
 func (h *skillHandler) QuerySkillMarketList(c *gin.Context) {
 	req := &interfaces.QuerySkillMarketListReq{}
 	if err := c.ShouldBindHeader(req); err != nil {

--- a/adp/execution-factory/operator-integration/server/driveradapters/skill_handler.go
+++ b/adp/execution-factory/operator-integration/server/driveradapters/skill_handler.go
@@ -62,6 +62,8 @@ func (r *skillRestHandler) RegisterPublic(engine *gin.RouterGroup) {
 	engine.POST("/skills", r.SkillHandler.RegisterSkill)
 	// 查询技能列表
 	engine.GET("/skills", r.SkillHandler.QuerySkillList)
+	// POST /api/agent-operator-integration/v1/skills/names 按技能ID批量取名(前端对象级授权页回显)
+	engine.POST("/skills/names", r.SkillHandler.QuerySkillNamesByIDs)
 	// 查询技能详情
 	engine.GET("/skills/:skill_id", r.SkillHandler.GetSkillDetail)
 	// 下载技能

--- a/adp/execution-factory/operator-integration/server/driveradapters/toolbox/index.go
+++ b/adp/execution-factory/operator-integration/server/driveradapters/toolbox/index.go
@@ -21,6 +21,7 @@ type ToolBoxHandler interface {
 	QueryToolBox(c *gin.Context)
 	DeleteToolBox(c *gin.Context)
 	QueryToolBoxPage(c *gin.Context)
+	QueryToolBoxNamesByIDs(c *gin.Context)
 	UpdateToolBoxStatus(c *gin.Context)
 	// 工具操作接口
 	CreateTool(c *gin.Context)

--- a/adp/execution-factory/operator-integration/server/driveradapters/toolbox/toolbox.go
+++ b/adp/execution-factory/operator-integration/server/driveradapters/toolbox/toolbox.go
@@ -152,6 +152,21 @@ func (h *toolBoxHandler) QueryToolBox(c *gin.Context) {
 	rest.ReplyOK(c, http.StatusOK, resp)
 }
 
+// QueryToolBoxNamesByIDs 按工具箱ID批量取名(给前端对象级授权页回显名称用)
+func (h *toolBoxHandler) QueryToolBoxNamesByIDs(c *gin.Context) {
+	req := &interfaces.BatchNamesReq{}
+	if err := c.ShouldBindJSON(req); err != nil {
+		rest.ReplyError(c, errors.DefaultHTTPError(c.Request.Context(), http.StatusBadRequest, err.Error()))
+		return
+	}
+	resp, err := h.ToolService.GetToolBoxNamesByIDs(c.Request.Context(), req.IDs)
+	if err != nil {
+		rest.ReplyError(c, err)
+		return
+	}
+	rest.ReplyOK(c, http.StatusOK, resp)
+}
+
 func (h *toolBoxHandler) UpdateToolBoxStatus(c *gin.Context) {
 	req := &interfaces.UpdateToolBoxStatusReq{}
 	err := c.ShouldBindHeader(req)

--- a/adp/execution-factory/operator-integration/server/driveradapters/toolbox_handler.go
+++ b/adp/execution-factory/operator-integration/server/driveradapters/toolbox_handler.go
@@ -62,6 +62,8 @@ func (r *toolboxRestHandler) RegisterPublic(engine *gin.RouterGroup) {
 	engine.GET("/tool-box/:box_id", r.ToolBoxHandler.QueryToolBox)
 	engine.DELETE("/tool-box/:box_id", middlewareBusinessDomain(true, false, r.businessDomainService), r.ToolBoxHandler.DeleteToolBox)
 	engine.GET("/tool-box/list", middlewareBusinessDomain(true, false, r.businessDomainService), r.ToolBoxHandler.QueryToolBoxPage)
+	// POST /api/agent-operator-integration/v1/tool-box/names 按工具箱ID批量取名(前端对象级授权页回显)
+	engine.POST("/tool-box/names", r.ToolBoxHandler.QueryToolBoxNamesByIDs)
 	// 工具
 	engine.POST("/tool-box/:box_id/tool", r.ToolBoxHandler.CreateTool)
 	engine.POST("/tool-box/:box_id/tool/:tool_id", r.ToolBoxHandler.UpdateTool)

--- a/adp/execution-factory/operator-integration/server/interfaces/logics_operator.go
+++ b/adp/execution-factory/operator-integration/server/interfaces/logics_operator.go
@@ -241,6 +241,8 @@ type OperatorManager interface {
 	// GetOperatorInfoByOperatorID 获取算子信息
 	GetOperatorInfoByOperatorID(ctx context.Context, req *GetOperatorInfoByOperatorIDReq) (*OperatorDataInfo, error)
 	GetOperatorQueryPage(ctx context.Context, req *PageQueryRequest) (*PageQueryResponse, error)
+	// GetOperatorNamesByIDs 按算子ID批量取名(容错：不存在的ID略过)
+	GetOperatorNamesByIDs(ctx context.Context, ids []string) (*BatchNamesResp, error)
 	// EditOperator 编辑算子
 	EditOperator(ctx context.Context, req *OperatorEditReq) (*OperatorEditResp, error)
 	// DeleteOperator 删除算子

--- a/adp/execution-factory/operator-integration/server/interfaces/logics_skill.go
+++ b/adp/execution-factory/operator-integration/server/interfaces/logics_skill.go
@@ -401,6 +401,8 @@ type SkillRegistry interface {
 	ExecuteSkill(ctx context.Context, req *ExecuteSkillReq) (*ExecuteSkillResp, error)
 	QuerySkillList(ctx context.Context, req *QuerySkillListReq) (*QuerySkillListResp, error)
 	GetSkillDetail(ctx context.Context, req *GetSkillDetailReq) (*SkillInfo, error)
+	// GetSkillNamesByIDs 按技能ID批量取名(容错：不存在的ID略过)
+	GetSkillNamesByIDs(ctx context.Context, ids []string) (*BatchNamesResp, error)
 	// 更新 Skill 状态
 	UpdateSkillStatus(ctx context.Context, req *UpdateSkillStatusReq) (*UpdateSkillStatusResp, error)
 }

--- a/adp/execution-factory/operator-integration/server/interfaces/logics_toolbox.go
+++ b/adp/execution-factory/operator-integration/server/interfaces/logics_toolbox.go
@@ -426,6 +426,8 @@ type IToolService interface {
 	GetToolBox(ctx context.Context, req *GetToolBoxReq, isMarket bool) (resp *ToolBoxToolInfo, err error)
 	DeleteBoxByID(ctx context.Context, req *DeleteBoxReq) (resp *DeleteBoxResp, err error)
 	QueryToolBoxList(ctx context.Context, req *QueryToolBoxListReq) (resp *QueryToolBoxListResp, err error)
+	// GetToolBoxNamesByIDs 按工具箱ID批量取名(容错：不存在的ID略过)
+	GetToolBoxNamesByIDs(ctx context.Context, ids []string) (resp *BatchNamesResp, err error)
 	QueryMarketToolBoxList(ctx context.Context, req *QueryMarketToolBoxListReq) (resp *QueryToolBoxListResp, err error)
 	UpdateToolBoxStatus(ctx context.Context, req *UpdateToolBoxStatusReq) (resp *UpdateToolBoxStatusResp, err error)
 	// 工具管理

--- a/adp/execution-factory/operator-integration/server/interfaces/model/skill_repository.go
+++ b/adp/execution-factory/operator-integration/server/interfaces/model/skill_repository.go
@@ -52,4 +52,6 @@ type ISkillRepository interface {
 	CountByWhereClause(ctx context.Context, tx *sql.Tx, filter map[string]interface{}) (count int64, err error)
 	DeleteSkillByID(ctx context.Context, tx *sql.Tx, skillID string) error
 	SelectSkillByName(ctx context.Context, tx *sql.Tx, name string, status []string) (bool, *SkillRepositoryDB, error)
+	// SelectSkillListByIDs 按 skillID 批量查询(未删除)，空入参返回空列表
+	SelectSkillListByIDs(ctx context.Context, skillIDs []string) (skills []*SkillRepositoryDB, err error)
 }

--- a/adp/execution-factory/operator-integration/server/interfaces/struct.go
+++ b/adp/execution-factory/operator-integration/server/interfaces/struct.go
@@ -43,6 +43,23 @@ type CommonPageResult struct {
 	HasPrev    bool `json:"has_prev"`    // 是否有上一页
 }
 
+// BatchNamesReq 按 ID 批量取名请求(operator/tool_box/skill 统一契约)
+type BatchNamesReq struct {
+	IDs []string `json:"ids"` // 待取名的 ID 列表，空列表返回空 entries
+}
+
+// NameEntry 单个 ID->名称 条目
+type NameEntry struct {
+	ID   string `json:"id"`   // 实体 ID
+	Name string `json:"name"` // 实体名称
+}
+
+// BatchNamesResp 按 ID 批量取名响应
+// 容错：不存在的 ID 略过，不报错
+type BatchNamesResp struct {
+	Entries []*NameEntry `json:"entries"`
+}
+
 // PtrBizIdentifiable 业务ID可识别接口指针
 type PtrBizIdentifiable[T any] interface {
 	*T

--- a/adp/execution-factory/operator-integration/server/logics/operator/query.go
+++ b/adp/execution-factory/operator-integration/server/logics/operator/query.go
@@ -79,6 +79,27 @@ func (m *operatorManager) getOperatorRegisterInfo(ctx context.Context, operatorI
 	return
 }
 
+// GetOperatorNamesByIDs 按算子ID批量取名(轻量只读，复用 SelectByOperatorIDs；不存在的ID略过)
+func (m *operatorManager) GetOperatorNamesByIDs(ctx context.Context, ids []string) (resp *interfaces.BatchNamesResp, err error) {
+	ctx, _ = o11y.StartInternalSpan(ctx)
+	defer o11y.EndSpan(ctx, err)
+	resp = &interfaces.BatchNamesResp{Entries: []*interfaces.NameEntry{}}
+	ids = utils.UniqueStrings(ids)
+	if len(ids) == 0 {
+		return
+	}
+	operatorList, err := m.DBOperatorManager.SelectByOperatorIDs(ctx, ids)
+	if err != nil {
+		m.Logger.WithContext(ctx).Errorf("select operators by ids failed, err: %v", err)
+		err = errors.DefaultHTTPError(ctx, http.StatusInternalServerError, err.Error())
+		return
+	}
+	for _, op := range operatorList {
+		resp.Entries = append(resp.Entries, &interfaces.NameEntry{ID: op.OperatorID, Name: op.Name})
+	}
+	return
+}
+
 // GetOperatorQueryPage 获取算子列表
 func (m *operatorManager) GetOperatorQueryPage(ctx context.Context, req *interfaces.PageQueryRequest) (result *interfaces.PageQueryResponse, err error) {
 	// 记录可观测

--- a/adp/execution-factory/operator-integration/server/logics/skill/registry.go
+++ b/adp/execution-factory/operator-integration/server/logics/skill/registry.go
@@ -1323,6 +1323,27 @@ func (r *skillRegistry) GetSkillDetail(ctx context.Context, req *interfaces.GetS
 	return skillInfo, nil
 }
 
+// GetSkillNamesByIDs 按技能ID批量取名(轻量只读，不存在的ID略过；不做对象级授权校验)
+func (r *skillRegistry) GetSkillNamesByIDs(ctx context.Context, ids []string) (resp *interfaces.BatchNamesResp, err error) {
+	ctx, _ = o11y.StartInternalSpan(ctx)
+	defer o11y.EndSpan(ctx, err)
+	resp = &interfaces.BatchNamesResp{Entries: []*interfaces.NameEntry{}}
+	ids = utils.UniqueStrings(ids)
+	if len(ids) == 0 {
+		return
+	}
+	skills, err := r.skillRepo.SelectSkillListByIDs(ctx, ids)
+	if err != nil {
+		r.Logger.WithContext(ctx).Errorf("select skills by ids failed, err: %v", err)
+		err = errors.DefaultHTTPError(ctx, http.StatusInternalServerError, err.Error())
+		return
+	}
+	for _, skill := range skills {
+		resp.Entries = append(resp.Entries, &interfaces.NameEntry{ID: skill.SkillID, Name: skill.Name})
+	}
+	return
+}
+
 func convertSkillDetail(skill *model.SkillRepositoryDB, categoryName string) *interfaces.SkillInfo {
 	return &interfaces.SkillInfo{
 		SkillID:      skill.SkillID,

--- a/adp/execution-factory/operator-integration/server/logics/toolbox/query.go
+++ b/adp/execution-factory/operator-integration/server/logics/toolbox/query.go
@@ -9,7 +9,29 @@ import (
 	"github.com/openbkn-ai/adp/execution-factory/operator-integration/server/interfaces"
 	"github.com/openbkn-ai/adp/execution-factory/operator-integration/server/interfaces/model"
 	"github.com/openbkn-ai/adp/execution-factory/operator-integration/server/utils"
+	o11y "github.com/kweaver-ai/kweaver-go-lib/observability"
 )
+
+// GetToolBoxNamesByIDs 按工具箱ID批量取名(轻量只读，复用 SelectListByBoxIDs；不存在的ID略过)
+func (s *ToolServiceImpl) GetToolBoxNamesByIDs(ctx context.Context, ids []string) (resp *interfaces.BatchNamesResp, err error) {
+	ctx, _ = o11y.StartInternalSpan(ctx)
+	defer o11y.EndSpan(ctx, err)
+	resp = &interfaces.BatchNamesResp{Entries: []*interfaces.NameEntry{}}
+	ids = utils.UniqueStrings(ids)
+	if len(ids) == 0 {
+		return
+	}
+	boxList, err := s.ToolBoxDB.SelectListByBoxIDs(ctx, ids)
+	if err != nil {
+		s.Logger.WithContext(ctx).Errorf("select toolboxes by ids failed, err: %v", err)
+		err = errors.DefaultHTTPError(ctx, http.StatusInternalServerError, err.Error())
+		return
+	}
+	for _, box := range boxList {
+		resp.Entries = append(resp.Entries, &interfaces.NameEntry{ID: box.BoxID, Name: box.Name})
+	}
+	return
+}
 
 func (s *ToolServiceImpl) toolBoxDBToToolBoxInfo(ctx context.Context, toolBox *model.ToolboxDB) (boxInfo *interfaces.ToolBoxInfo) {
 	boxInfo = &interfaces.ToolBoxInfo{

--- a/adp/execution-factory/operator-integration/server/mocks/logics_skill.go
+++ b/adp/execution-factory/operator-integration/server/mocks/logics_skill.go
@@ -101,6 +101,21 @@ func (mr *MockSkillRegistryMockRecorder) GetSkillDetail(ctx, req any) *gomock.Ca
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetSkillDetail", reflect.TypeOf((*MockSkillRegistry)(nil).GetSkillDetail), ctx, req)
 }
 
+// GetSkillNamesByIDs mocks base method.
+func (m *MockSkillRegistry) GetSkillNamesByIDs(ctx context.Context, ids []string) (*interfaces.BatchNamesResp, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetSkillNamesByIDs", ctx, ids)
+	ret0, _ := ret[0].(*interfaces.BatchNamesResp)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetSkillNamesByIDs indicates an expected call of GetSkillNamesByIDs.
+func (mr *MockSkillRegistryMockRecorder) GetSkillNamesByIDs(ctx, ids any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetSkillNamesByIDs", reflect.TypeOf((*MockSkillRegistry)(nil).GetSkillNamesByIDs), ctx, ids)
+}
+
 // PublishSkillHistory mocks base method.
 func (m *MockSkillRegistry) PublishSkillHistory(ctx context.Context, req *interfaces.PublishSkillHistoryReq) (*interfaces.PublishSkillHistoryResp, error) {
 	m.ctrl.T.Helper()
@@ -327,6 +342,75 @@ func (m *MockSkillReader) ReadSkillFile(ctx context.Context, req *interfaces.Rea
 func (mr *MockSkillReaderMockRecorder) ReadSkillFile(ctx, req any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReadSkillFile", reflect.TypeOf((*MockSkillReader)(nil).ReadSkillFile), ctx, req)
+}
+
+// MockSkillManagementReader is a mock of SkillManagementReader interface.
+type MockSkillManagementReader struct {
+	ctrl     *gomock.Controller
+	recorder *MockSkillManagementReaderMockRecorder
+	isgomock struct{}
+}
+
+// MockSkillManagementReaderMockRecorder is the mock recorder for MockSkillManagementReader.
+type MockSkillManagementReaderMockRecorder struct {
+	mock *MockSkillManagementReader
+}
+
+// NewMockSkillManagementReader creates a new mock instance.
+func NewMockSkillManagementReader(ctrl *gomock.Controller) *MockSkillManagementReader {
+	mock := &MockSkillManagementReader{ctrl: ctrl}
+	mock.recorder = &MockSkillManagementReaderMockRecorder{mock}
+	return mock
+}
+
+// EXPECT returns an object that allows the caller to indicate expected use.
+func (m *MockSkillManagementReader) EXPECT() *MockSkillManagementReaderMockRecorder {
+	return m.recorder
+}
+
+// DownloadManagementSkill mocks base method.
+func (m *MockSkillManagementReader) DownloadManagementSkill(ctx context.Context, req *interfaces.DownloadManagementSkillReq) (*interfaces.DownloadSkillResp, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DownloadManagementSkill", ctx, req)
+	ret0, _ := ret[0].(*interfaces.DownloadSkillResp)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// DownloadManagementSkill indicates an expected call of DownloadManagementSkill.
+func (mr *MockSkillManagementReaderMockRecorder) DownloadManagementSkill(ctx, req any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DownloadManagementSkill", reflect.TypeOf((*MockSkillManagementReader)(nil).DownloadManagementSkill), ctx, req)
+}
+
+// GetManagementContent mocks base method.
+func (m *MockSkillManagementReader) GetManagementContent(ctx context.Context, req *interfaces.GetManagementContentReq) (*interfaces.GetManagementContentResp, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetManagementContent", ctx, req)
+	ret0, _ := ret[0].(*interfaces.GetManagementContentResp)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetManagementContent indicates an expected call of GetManagementContent.
+func (mr *MockSkillManagementReaderMockRecorder) GetManagementContent(ctx, req any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetManagementContent", reflect.TypeOf((*MockSkillManagementReader)(nil).GetManagementContent), ctx, req)
+}
+
+// ReadManagementFile mocks base method.
+func (m *MockSkillManagementReader) ReadManagementFile(ctx context.Context, req *interfaces.ReadManagementFileReq) (*interfaces.ReadManagementFileResp, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ReadManagementFile", ctx, req)
+	ret0, _ := ret[0].(*interfaces.ReadManagementFileResp)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ReadManagementFile indicates an expected call of ReadManagementFile.
+func (mr *MockSkillManagementReaderMockRecorder) ReadManagementFile(ctx, req any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReadManagementFile", reflect.TypeOf((*MockSkillManagementReader)(nil).ReadManagementFile), ctx, req)
 }
 
 // MockSkillIndexBuildService is a mock of SkillIndexBuildService interface.

--- a/adp/execution-factory/operator-integration/server/mocks/model_skill_repository.go
+++ b/adp/execution-factory/operator-integration/server/mocks/model_skill_repository.go
@@ -133,6 +133,21 @@ func (mr *MockISkillRepositoryMockRecorder) SelectSkillByName(ctx, tx, name, sta
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SelectSkillByName", reflect.TypeOf((*MockISkillRepository)(nil).SelectSkillByName), ctx, tx, name, status)
 }
 
+// SelectSkillListByIDs mocks base method.
+func (m *MockISkillRepository) SelectSkillListByIDs(ctx context.Context, skillIDs []string) ([]*model.SkillRepositoryDB, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "SelectSkillListByIDs", ctx, skillIDs)
+	ret0, _ := ret[0].([]*model.SkillRepositoryDB)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// SelectSkillListByIDs indicates an expected call of SelectSkillListByIDs.
+func (mr *MockISkillRepositoryMockRecorder) SelectSkillListByIDs(ctx, skillIDs any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SelectSkillListByIDs", reflect.TypeOf((*MockISkillRepository)(nil).SelectSkillListByIDs), ctx, skillIDs)
+}
+
 // SelectSkillListPage mocks base method.
 func (m *MockISkillRepository) SelectSkillListPage(ctx context.Context, tx *sql.Tx, filter map[string]any, sort *ormhelper.SortParams, cursor *ormhelper.CursorParams) ([]*model.SkillRepositoryDB, error) {
 	m.ctrl.T.Helper()

--- a/adp/execution-factory/operator-integration/server/mocks/operator.go
+++ b/adp/execution-factory/operator-integration/server/mocks/operator.go
@@ -146,6 +146,21 @@ func (mr *MockOperatorManagerMockRecorder) GetOperatorInfoByOperatorID(ctx, req 
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetOperatorInfoByOperatorID", reflect.TypeOf((*MockOperatorManager)(nil).GetOperatorInfoByOperatorID), ctx, req)
 }
 
+// GetOperatorNamesByIDs mocks base method.
+func (m *MockOperatorManager) GetOperatorNamesByIDs(ctx context.Context, ids []string) (*interfaces.BatchNamesResp, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetOperatorNamesByIDs", ctx, ids)
+	ret0, _ := ret[0].(*interfaces.BatchNamesResp)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetOperatorNamesByIDs indicates an expected call of GetOperatorNamesByIDs.
+func (mr *MockOperatorManagerMockRecorder) GetOperatorNamesByIDs(ctx, ids any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetOperatorNamesByIDs", reflect.TypeOf((*MockOperatorManager)(nil).GetOperatorNamesByIDs), ctx, ids)
+}
+
 // GetOperatorQueryPage mocks base method.
 func (m *MockOperatorManager) GetOperatorQueryPage(ctx context.Context, req *interfaces.PageQueryRequest) (*interfaces.PageQueryResponse, error) {
 	m.ctrl.T.Helper()

--- a/adp/execution-factory/operator-integration/server/mocks/toolbox.go
+++ b/adp/execution-factory/operator-integration/server/mocks/toolbox.go
@@ -252,6 +252,21 @@ func (mr *MockIToolServiceMockRecorder) GetToolBox(ctx, req, isMarket any) *gomo
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetToolBox", reflect.TypeOf((*MockIToolService)(nil).GetToolBox), ctx, req, isMarket)
 }
 
+// GetToolBoxNamesByIDs mocks base method.
+func (m *MockIToolService) GetToolBoxNamesByIDs(ctx context.Context, ids []string) (*interfaces.BatchNamesResp, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetToolBoxNamesByIDs", ctx, ids)
+	ret0, _ := ret[0].(*interfaces.BatchNamesResp)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetToolBoxNamesByIDs indicates an expected call of GetToolBoxNamesByIDs.
+func (mr *MockIToolServiceMockRecorder) GetToolBoxNamesByIDs(ctx, ids any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetToolBoxNamesByIDs", reflect.TypeOf((*MockIToolService)(nil).GetToolBoxNamesByIDs), ctx, ids)
+}
+
 // HandleOperatorDeleteEvent mocks base method.
 func (m *MockIToolService) HandleOperatorDeleteEvent(ctx context.Context, message []byte) error {
 	m.ctrl.T.Helper()

--- a/bkn-safe/docs/frontend-object-grants-integration.md
+++ b/bkn-safe/docs/frontend-object-grants-integration.md
@@ -1,0 +1,151 @@
+# BKN Studio「授权管理」对接 bkn-safe 后端 — 前端改造说明
+
+> 背景：BKN Studio 的授权页（`js/data-authz.js` / `js/page-authorizations.js` /
+> `js/page-authz-drawer.js`）目前是**纯前端 mock**，权限点词表用的是旧 ISF 的
+> （`vega:catalog:*` / `model:invoke`…），调用的 `POST /authorization/v1/object-grants`
+> 也是虚构接口。后端已在 bkn-safe 落地真实的**对象级授权**接口，下面是对接说明。
+
+## 一、核心模型（和 mock 一致）
+
+把**一个具体资源实例**（某个 catalog / 某个模型 / 某个算子…）的若干操作权限，授予**一个用户**。
+建立在角色 RBAC 之上。**被授权方只支持「用户」**——部门已从后端移除（casbin 无 user→部门成员
+规则，授给部门是死策略）。请前端把 grantee 的「部门」选项去掉，只保留用户。
+
+## 二、真实接口（替换 mock 的 `/authorization/v1/object-grants`）
+
+全部在 **`/api/safe/v1/admin/object-grants`**，需 **管理员 Bearer Token**（`Authorization: Bearer <token>`），
+非管理员 403。
+
+### 1. 列出授权（总览页 / 按对象 / 按成员）
+```
+GET /api/safe/v1/admin/object-grants?accessor_id=&resource_type=&resource_id=
+```
+三个 query 都是可选过滤器（都不传=全量）。
+- 总览页：不带参
+- 「按对象」聚合：前端拿全量自己按 resource 分组，或带 `resource_type`+`resource_id`
+- 「按成员」聚合：带 `accessor_id`
+
+响应：
+```json
+{ "entries": [
+  { "accessor_id": "u-123", "resource": { "type": "catalog", "id": "d7ni..." }, "operations": ["view_detail","modify"] }
+] }
+```
+> 只返回「用户」对「具体实例」的授权；角色授权、类型级 `*` 通配不在此列。
+
+### 2. 新建 / 修改授权（set 语义，替换该用户在该对象上的整套权限点）
+```
+POST /api/safe/v1/admin/object-grants
+{ "accessor_id": "u-123", "resource": { "type": "catalog", "id": "d7ni..." }, "operations": ["view_detail","modify"] }
+```
+- 成功 `204`。**整套替换**：传什么就是什么（不是增量），勾掉的会被移除。
+- `operations` 不能为空（清空请用 DELETE）；`resource.id` 必须是具体值，不能传 `*`。
+- 后端校验：`accessor_id` 必须是已知用户；`operations` 必须是该 type 在词表里登记的操作，否则 400。
+
+### 3. 撤销某用户在某对象上的授权
+```
+DELETE /api/safe/v1/admin/object-grants
+{ "accessor_id": "u-123", "resource": { "type": "catalog", "id": "d7ni..." } }
+```
+成功 `204`，只撤这一个用户，不影响该对象上其他人的授权。
+
+## 三、权限点词表（**换掉 ISF 词表，用这套**）
+
+bkn-safe 的操作词表（`type` → `operations`），按这套渲染权限点 chip / 矩阵列：
+
+| type（resource.type） | 中文 | operations |
+|---|---|---|
+| `knowledge_network` | 知识网络 | `view_detail` `create` `modify` `delete` `data_query` `authorize` `task_manage` |
+| `catalog` | 数据目录 | `view_detail` `create` `modify` `delete` `authorize` `task_manage` |
+| `resource` | 数据资源 | `view_detail` `create` `modify` `delete` `authorize` `task_manage` |
+| `connector_type` | 连接器类型 | `view_detail` `create` `modify` `delete` `authorize` `task_manage` |
+| `stream_data_pipeline` | 流式数据管道 | `view_detail` `create` `modify` `delete` `authorize` `data_query` |
+| `operator` | 算子 | `create` `modify` `delete` `view` `publish` `unpublish` `authorize` `public_access` `execute` |
+| `tool_box` | 工具箱 | 同 operator |
+| `mcp` | MCP | 同 operator |
+| `skill` | Skill | 同 operator |
+| `small_model` | 小模型 | `create` `display` `modify` `delete` `execute` |
+| `large_model` | 大模型 | `create` `display` `modify` `delete` `execute` |
+| `agent` / `agent_tpl` | 智能体/模板 | （见后端 catalog.json，授权页一般不涉及） |
+
+> 注意：授权页面授给用户某对象时，通常只给「实例级」操作（如 `view_detail/modify/delete/execute/display`），
+> `create` 是「类型级」语义（在具体实例上没意义），按需从对象授权 UI 里隐藏 `create`。
+
+## 四、设计 `OBJ_TYPES` 需要调整
+
+| mock 里的 type | 改成后端 type | 说明 |
+|---|---|---|
+| `kn` | `knowledge_network` | 知识网络 |
+| `catalog` | `catalog` | 不变 |
+| `resource` | `resource` | 不变 |
+| `model` | `small_model` / `large_model` | **拆成两类**：小模型走 `small_model`，大模型（LLM）走 `large_model` |
+| （缺） | `operator` | **新增「算子」对象类型**（后端已支持） |
+
+## 五、配套接口（前端构建 UI 用）
+
+- **被授权方（用户）选择器**：用现有管理 API 列用户
+  `GET /api/safe/v1/admin/users`（搜索/分页，返回用户 id/name/account）。
+- **accessor_id → 用户名** 回显：`GET /api/safe/v1/directory/...` 或上面的 users 列表本地映射。
+- **要授权的「对象实例」从哪来**：bkn-safe **不存资源名**（它对资源 id 不透明）。
+  对象列表（某个 catalog/模型/算子的 id+名字）请前端**从各自的领域服务**取：
+  catalog/resource 走 vega，模型走 mf-model，算子走执行工厂。bkn-safe 只认 `type:id`。
+- **「授给某用户整类 / 一切」**：对象级接口**不支持** `*` 通配。需要「整类」或「全部」时，走**角色**：
+  `POST /api/safe/v1/admin/roles/:id/permissions`（`resource.id` 传 `*` = 整类）。
+  即设计里的「或者一切」应落到角色管理页，不在对象授权抽屉里。
+
+## 六、要点清单（给前端的 TODO）
+
+1. 删掉部门 grantee，只留用户。
+2. 接口换成 `/api/safe/v1/admin/object-grants`（GET/POST/DELETE），带管理员 Bearer Token。
+3. 权限点词表换成上面第三节这套（丢弃 `vega:* / model:* / ontology-manager:*`）。
+4. `OBJ_TYPES`：`kn→knowledge_network`、`model` 拆 `small_model`/`large_model`、新增 `operator`。
+5. POST 是「整套替换」语义，前端 set 好完整 operations 再提交；空集合走 DELETE。
+6. 对象实例列表从领域服务取，bkn-safe 不提供资源名。
+7. 「一切/整类」授权走角色页（`roles/:id/permissions`，id=`*`），不在对象抽屉。
+8. `src/api/admin.ts` 里打 `/api/authorization/v1` + ISFWeb thrift 的那套是旧 ISF，整体迁到 `/api/safe/v1/*`。
+
+## 七、对象 id → 名称解析（各领域服务，bkn-safe 不提供）
+
+bkn-safe 只存 `type:id`、对资源名不透明。授权页两处需要把 id 换成可读名称，**由各领域服务提供**：
+- **新建授权 · 对象选择器** → 用「列实例」接口（按类型列 id+name，可搜索分页）
+- **授权列表/分组 · 回显对象名** → 用「按 id 批量取名」接口
+
+### 7.1 列实例（id+name，搜索+分页）— 全部已就绪
+
+| type | 接口 |
+|---|---|
+| `catalog` | `GET /api/vega-backend/v1/catalogs?name=&offset=&limit=&sort=` |
+| `resource` | `GET /api/vega-backend/v1/resources?name=&catalog_id=&offset=&limit=` |
+| `small_model` | `GET /api/mf-model-manager/v1/small-model/list?model_name=&page=&size=` |
+| `large_model` | `GET /api/mf-model-manager/v1/llm/list?name=&page=&size=` |
+| `operator` | `GET /api/agent-operator-integration/v1/operator/info/list?name=&page=&page_size=` |
+| `tool_box` | `GET /api/agent-operator-integration/v1/tool-box/list?name=&page=&page_size=` |
+| `mcp` | `GET /api/agent-operator-integration/v1/mcp/list?name=&page=&page_size=` |
+| `skill` | `GET /api/agent-operator-integration/v1/skills?name=&page=&page_size=` |
+| `knowledge_network` | `GET /api/bkn-backend/v1/knowledge-networks?name_pattern=&offset=&limit=` |
+
+> 各接口响应里的 id/name 字段名不统一（vega/kn=`id`/`name`、operator=`operator_id`/`name`、toolbox=`box_id`/`box_name`、skill=`skill_id`/`name`、mcp=`mcp_id`/`name`、模型=`model_id`/`model_name`）。前端按类型映射成统一的 `{id, name}`。
+
+### 7.2 按 id 批量取名 — 统一契约
+
+**新增的 6 个接口统一契约**（catalog/resource/mcp 是各自已有的旧接口，形态不同，见下表备注）：
+```
+POST <上面对应服务前缀>/<resource>/names
+请求: {"ids": ["id1","id2", ...]}
+响应: {"entries": [{"id":"id1","name":"name1"}, ...]}   // 缺失 id 略过, 空 ids 返回 {"entries":[]}
+```
+
+| type | 批量取名接口 | 形态 |
+|---|---|---|
+| `small_model` | `POST /api/mf-model-manager/v1/small-model/names` | ✅ 统一契约（新）|
+| `large_model` | `POST /api/mf-model-manager/v1/llm/names` | ✅ 统一契约（新）|
+| `operator` | `POST /api/agent-operator-integration/v1/operator/names` | ✅ 统一契约（新）|
+| `tool_box` | `POST /api/agent-operator-integration/v1/tool-box/names` | ✅ 统一契约（新）|
+| `skill` | `POST /api/agent-operator-integration/v1/skills/names` | ✅ 统一契约（新）|
+| `knowledge_network` | `POST /api/bkn-backend/v1/knowledge-networks/names` | ✅ 统一契约（新）|
+| `catalog` | `GET /api/vega-backend/v1/catalogs/id1,id2,id3` | ⚠️ 旧接口：逗号分隔 path、返回完整对象、**任一 id 不存在整批 404**（取名前先确保 id 都有效，或退化为单个）|
+| `resource` | `GET /api/vega-backend/v1/resources/id1,id2,id3` | ⚠️ 同上 |
+| `mcp` | `GET /api/agent-operator-integration/v1/mcp/market/batch/{mcp_ids}/{fields}` | ⚠️ 旧接口：逗号分隔 path + 选字段，如 `.../batch/id1,id2/mcp_id,name` |
+
+> 批量取名为**低敏只读、不做对象级授权拦截**——授权列表里可能有「当前管理员无权但被授权对象引用」的对象，也要能回显名称。
+> id 一律 string（雪花/slug，无精度问题；`llm/add` 返回 id 已修为 string）。

--- a/bkn-safe/server/internal/authz/authz.go
+++ b/bkn-safe/server/internal/authz/authz.go
@@ -334,3 +334,105 @@ func (en *Enforcer) ResourcePolicies(resourceType, resourceID string) ([]Resourc
 	}
 	return out, nil
 }
+
+// ObjectGrant is one accessor's grant set on one concrete resource instance:
+// the cross-product cell of the object-level authorization matrix (who can do
+// what on which specific object). Powers the admin "授权管理" overview.
+type ObjectGrant struct {
+	AccessorID   string
+	ResourceType string
+	ResourceID   string
+	Operations   []string
+}
+
+// ListObjectGrants enumerates concrete per-object accessor grants across all
+// resources, grouped by (accessor, resource). Type-wide ("*" id) and bare-"*"
+// (super-admin) patterns are excluded — those belong to roles/seed, not the
+// object-grant surface. accessorID/resourceType/resourceID are optional filters
+// (empty = match any). Subjects are returned verbatim; the caller separates
+// user accessors from role subjects (casbin stores both as opaque ids).
+func (en *Enforcer) ListObjectGrants(accessorID, resourceType, resourceID string) ([]ObjectGrant, error) {
+	var rows [][]string
+	var err error
+	if accessorID != "" {
+		rows, err = en.e.GetFilteredPolicy(0, accessorID)
+	} else {
+		rows, err = en.e.GetPolicy()
+	}
+	if err != nil {
+		return nil, err
+	}
+	type key struct{ sub, rtype, rid string }
+	ops := map[key][]string{}
+	seen := map[key]map[string]bool{}
+	order := make([]key, 0, len(rows))
+	for _, row := range rows {
+		if len(row) < 3 {
+			continue
+		}
+		sub, o, act := row[0], row[1], row[2]
+		rtype, rid := splitObjectKey(o)
+		if rid == "" || rid == "*" { // skip type-wide / bare "*" (role/seed grants)
+			continue
+		}
+		if resourceType != "" && rtype != resourceType {
+			continue
+		}
+		if resourceID != "" && rid != resourceID {
+			continue
+		}
+		k := key{sub, rtype, rid}
+		if seen[k] == nil {
+			order = append(order, k)
+			seen[k] = map[string]bool{}
+		}
+		if seen[k][act] {
+			continue
+		}
+		seen[k][act] = true
+		ops[k] = append(ops[k], act)
+	}
+	out := make([]ObjectGrant, 0, len(order))
+	for _, k := range order {
+		out = append(out, ObjectGrant{
+			AccessorID: k.sub, ResourceType: k.rtype, ResourceID: k.rid, Operations: ops[k],
+		})
+	}
+	return out, nil
+}
+
+// SetObjectPermissions replaces an accessor's entire op set on one concrete
+// resource instance: it drops every existing (accessor, object) p-line and adds
+// one per op. The "edit a grant" write behind the admin object-grant page
+// (POST /policies only adds, never prunes). Passing no ops clears the grant.
+func (en *Enforcer) SetObjectPermissions(accessorID, resourceType, resourceID string, ops []string) error {
+	if err := en.RemoveAccessorResourcePolicies(accessorID, resourceType, resourceID); err != nil {
+		return err
+	}
+	for _, op := range ops {
+		if _, err := en.e.AddPolicy(accessorID, obj(resourceType, resourceID), op); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// RemoveAccessorResourcePolicies drops every op one accessor holds on one
+// concrete resource instance (revoke a single grantee's grant), leaving other
+// accessors' grants on the same resource intact — unlike RemoveResourcePolicies,
+// which wipes the resource for everyone on delete. Idempotent.
+func (en *Enforcer) RemoveAccessorResourcePolicies(accessorID, resourceType, resourceID string) error {
+	_, err := en.e.RemoveFilteredPolicy(0, accessorID, obj(resourceType, resourceID))
+	return err
+}
+
+// splitObjectKey splits a casbin object key "type:id" on the FIRST colon (the
+// id may itself contain colons). A bare "*" yields type "*", id "".
+func splitObjectKey(o string) (rtype, rid string) {
+	for i := 0; i < len(o); i++ {
+		if o[i] == ':' {
+			return o[:i], o[i+1:]
+		}
+	}
+	return o, ""
+}

--- a/bkn-safe/server/internal/httpapi/builtinadmin_test.go
+++ b/bkn-safe/server/internal/httpapi/builtinadmin_test.go
@@ -1,0 +1,42 @@
+package httpapi
+
+import (
+	"net/http"
+	"testing"
+
+	"bkn-safe/internal/model"
+	"bkn-safe/internal/seed"
+)
+
+// TestBuiltInAdminUserProtected verifies the user-admin API refuses to delete or
+// disable the built-in admin (defense in depth — deleting the only super-admin
+// would lock everyone out), while still allowing harmless edits like rename.
+func TestBuiltInAdminUserProtected(t *testing.T) {
+	r, _, db, users := newAdminServer(t)
+	ctx := t.Context()
+	if err := users.CreateLocalUser(ctx,
+		&model.User{ID: seed.AdminUserID, Account: "admin", Name: "Administrator", Enabled: true},
+		"pw-init0"); err != nil {
+		t.Fatal(err)
+	}
+	path := "/api/safe/v1/admin/users/" + seed.AdminUserID
+
+	if w := adminReq(t, r, http.MethodDelete, path, nil); w.Code != http.StatusForbidden {
+		t.Fatalf("delete built-in admin: want 403, got %d (%s)", w.Code, w.Body.String())
+	}
+	if w := adminReq(t, r, http.MethodPut, path, map[string]any{"enabled": false}); w.Code != http.StatusForbidden {
+		t.Fatalf("disable built-in admin: want 403, got %d (%s)", w.Code, w.Body.String())
+	}
+	// Non-disable edits are still allowed.
+	if w := adminReq(t, r, http.MethodPut, path, map[string]any{"name": "Boss"}); w.Code != http.StatusNoContent {
+		t.Fatalf("rename built-in admin: want 204, got %d (%s)", w.Code, w.Body.String())
+	}
+
+	var got model.User
+	if err := db.First(&got, "id = ?", seed.AdminUserID).Error; err != nil {
+		t.Fatal(err)
+	}
+	if !got.Enabled || got.Name != "Boss" {
+		t.Errorf("admin state wrong after guarded edits: %+v", got)
+	}
+}

--- a/bkn-safe/server/internal/httpapi/objectgrants.go
+++ b/bkn-safe/server/internal/httpapi/objectgrants.go
@@ -1,0 +1,178 @@
+package httpapi
+
+import (
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+	"gorm.io/gorm"
+
+	"bkn-safe/internal/authz"
+	"bkn-safe/internal/model"
+)
+
+// registerObjectGrants mounts the object-level authorization management API
+// under /admin (admin-only). It manages the "grant a specific object to a
+// specific user" matrix that sits ON TOP of role-based RBAC: each grant binds
+// one user accessor to concrete ops on one concrete resource instance
+// (catalog/operator/model/knowledge_network/…).
+//
+// This is the gateway-exposed, audited management surface for object grants.
+// The internal /api/safe/v1/authz/policies endpoints stay for service-to-service
+// "grant the creator access on resource create" calls; here every write is
+// validated (known user, concrete resource, catalog-registered ops) so the UI
+// can't mint dead policies.
+//
+// Grantees are USERS only. Departments are intentionally unsupported: casbin
+// holds no user→department membership rules, so a department grant would be a
+// dead policy that never matches at enforce time (see RolePermissions path for
+// the role-based alternative).
+func registerObjectGrants(g *gin.RouterGroup, e *authz.Enforcer, db *gorm.DB) {
+	// GET /object-grants?accessor_id=&resource_type=&resource_id=
+	// -> { entries:[ { accessor_id, resource{type,id}, operations:[...] } ] }
+	// All three query params are optional filters. Role-subject and public
+	// grants are excluded — this surface lists user object grants only.
+	g.GET("/object-grants", func(c *gin.Context) {
+		grants, err := e.ListObjectGrants(
+			c.Query("accessor_id"), c.Query("resource_type"), c.Query("resource_id"))
+		if err != nil {
+			serverError(c, err)
+			return
+		}
+		roleIDs, err := roleIDSet(c, db)
+		if err != nil {
+			serverError(c, err)
+			return
+		}
+		entries := make([]gin.H, 0, len(grants))
+		for _, gr := range grants {
+			if roleIDs[gr.AccessorID] || gr.AccessorID == authz.PublicAccessorID {
+				continue // not a user object grant
+			}
+			entries = append(entries, gin.H{
+				"accessor_id": gr.AccessorID,
+				"resource":    gin.H{"type": gr.ResourceType, "id": gr.ResourceID},
+				"operations":  gr.Operations,
+			})
+		}
+		c.JSON(http.StatusOK, gin.H{"entries": entries})
+	})
+
+	// POST /object-grants — set (replace) a user's exact op set on one concrete
+	// resource instance. { accessor_id, resource{type,id}, operations:[...] }
+	// Upsert semantics: the grant's ops become exactly `operations`. An empty
+	// list is rejected (use DELETE to revoke) so an accidental empty body can't
+	// silently wipe a grant.
+	g.POST("/object-grants", func(c *gin.Context) {
+		var req struct {
+			AccessorID string      `json:"accessor_id" binding:"required"`
+			Resource   resourceRef `json:"resource" binding:"required"`
+			Operations []string    `json:"operations" binding:"required"`
+		}
+		if !bind(c, &req) {
+			return
+		}
+		if req.Resource.ID == "" || req.Resource.ID == "*" {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "object grants target a concrete resource id (not \"*\")"})
+			return
+		}
+		if len(req.Operations) == 0 {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "operations required; use DELETE to revoke a grant"})
+			return
+		}
+		// Grantee must be a user (apps are user rows too). Departments/groups are
+		// rejected: their grants never match at enforce time.
+		ok, err := isUserAccessor(c, db, req.AccessorID)
+		if err != nil {
+			serverError(c, err)
+			return
+		}
+		if !ok {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "accessor_id must be a known user (object grants support user grantees only)"})
+			return
+		}
+		// Ops must be registered for the resource type — blocks typos that would
+		// create policies no /check can ever satisfy.
+		valid, err := catalogOpSet(db, req.Resource.Type)
+		if err != nil {
+			serverError(c, err)
+			return
+		}
+		if len(valid) == 0 {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "unknown resource type: " + req.Resource.Type})
+			return
+		}
+		for _, op := range req.Operations {
+			if !valid[op] {
+				c.JSON(http.StatusBadRequest, gin.H{"error": "operation not registered for " + req.Resource.Type + ": " + op})
+				return
+			}
+		}
+		if err := e.SetObjectPermissions(req.AccessorID, req.Resource.Type, req.Resource.ID, req.Operations); err != nil {
+			serverError(c, err)
+			return
+		}
+		c.Status(http.StatusNoContent)
+	})
+
+	// DELETE /object-grants — revoke one user's grant on one concrete resource
+	// instance, leaving other grantees on the same resource untouched.
+	// { accessor_id, resource{type,id} }
+	g.DELETE("/object-grants", func(c *gin.Context) {
+		var req struct {
+			AccessorID string      `json:"accessor_id" binding:"required"`
+			Resource   resourceRef `json:"resource" binding:"required"`
+		}
+		if !bind(c, &req) {
+			return
+		}
+		if req.Resource.ID == "" || req.Resource.ID == "*" {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "object grants target a concrete resource id (not \"*\")"})
+			return
+		}
+		if err := e.RemoveAccessorResourcePolicies(req.AccessorID, req.Resource.Type, req.Resource.ID); err != nil {
+			serverError(c, err)
+			return
+		}
+		c.Status(http.StatusNoContent)
+	})
+}
+
+// isUserAccessor reports whether id is a known user row (real user or app
+// account; both are model.User distinguished by account_type).
+func isUserAccessor(c *gin.Context, db *gorm.DB, id string) (bool, error) {
+	var n int64
+	if err := db.WithContext(c.Request.Context()).Model(&model.User{}).
+		Where("id = ?", id).Count(&n).Error; err != nil {
+		return false, err
+	}
+	return n > 0, nil
+}
+
+// roleIDSet loads every role id into a lookup set, used to exclude role subjects
+// from the user object-grant listing.
+func roleIDSet(c *gin.Context, db *gorm.DB) (map[string]bool, error) {
+	var ids []string
+	if err := db.WithContext(c.Request.Context()).Model(&model.Role{}).
+		Pluck("id", &ids).Error; err != nil {
+		return nil, err
+	}
+	set := make(map[string]bool, len(ids))
+	for _, id := range ids {
+		set[id] = true
+	}
+	return set, nil
+}
+
+// catalogOpSet returns the resource type's registered operation ids as a set
+// (membership-test form of catalogOps).
+func catalogOpSet(db *gorm.DB, resourceType string) (map[string]bool, error) {
+	ops, err := catalogOps(db, resourceType)
+	if err != nil {
+		return nil, err
+	}
+	set := make(map[string]bool, len(ops))
+	for _, op := range ops {
+		set[op] = true
+	}
+	return set, nil
+}

--- a/bkn-safe/server/internal/httpapi/objectgrants_test.go
+++ b/bkn-safe/server/internal/httpapi/objectgrants_test.go
@@ -1,0 +1,172 @@
+package httpapi
+
+import (
+	"encoding/json"
+	"net/http"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"gorm.io/gorm"
+
+	"bkn-safe/internal/model"
+)
+
+// seedCatalogOps registers operation ids for a resource type so the
+// object-grant op-validation has a catalog to check against.
+func seedCatalogOps(t *testing.T, db *gorm.DB, resourceType string, ops ...string) {
+	t.Helper()
+	for _, op := range ops {
+		row := model.Operation{ResourceTypeID: resourceType, ID: op, Name: op}
+		if err := db.Create(&row).Error; err != nil {
+			t.Fatalf("seed op %s/%s: %v", resourceType, op, err)
+		}
+	}
+}
+
+type ogEntry struct {
+	AccessorID string `json:"accessor_id"`
+	Resource   struct {
+		Type string `json:"type"`
+		ID   string `json:"id"`
+	} `json:"resource"`
+	Operations []string `json:"operations"`
+}
+
+func listObjectGrants(t *testing.T, r *gin.Engine, query string) []ogEntry {
+	t.Helper()
+	w := adminReq(t, r, http.MethodGet, "/api/safe/v1/admin/object-grants"+query, nil)
+	if w.Code != http.StatusOK {
+		t.Fatalf("list grants: want 200, got %d (%s)", w.Code, w.Body.String())
+	}
+	var body struct {
+		Entries []ogEntry `json:"entries"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &body); err != nil {
+		t.Fatalf("decode grants: %v", err)
+	}
+	return body.Entries
+}
+
+func TestObjectGrantsSetListRevoke(t *testing.T) {
+	r, e, db, users := newAdminServer(t)
+	ctx := t.Context()
+	if err := users.CreateLocalUser(ctx, &model.User{ID: "u-1", Account: "alice", Name: "Alice", Enabled: true}, "pw-init0"); err != nil {
+		t.Fatal(err)
+	}
+	seedCatalogOps(t, db, "catalog", "view_detail", "modify")
+
+	// set: grant u-1 two ops on catalog c1
+	w := adminReq(t, r, http.MethodPost, "/api/safe/v1/admin/object-grants", map[string]any{
+		"accessor_id": "u-1",
+		"resource":    map[string]any{"type": "catalog", "id": "c1"},
+		"operations":  []string{"view_detail", "modify"},
+	})
+	if w.Code != http.StatusNoContent {
+		t.Fatalf("grant: want 204, got %d (%s)", w.Code, w.Body.String())
+	}
+	if ok, _ := e.Check("u-1", "catalog", "c1", "modify"); !ok {
+		t.Fatal("grant did not take effect at enforce time")
+	}
+
+	// list (no filter) returns the grant
+	entries := listObjectGrants(t, r, "")
+	if len(entries) != 1 || entries[0].AccessorID != "u-1" || entries[0].Resource.ID != "c1" || len(entries[0].Operations) != 2 {
+		t.Fatalf("unexpected list: %+v", entries)
+	}
+	// filtered lists
+	if got := listObjectGrants(t, r, "?accessor_id=u-1"); len(got) != 1 {
+		t.Fatalf("accessor filter: %+v", got)
+	}
+	if got := listObjectGrants(t, r, "?resource_type=catalog&resource_id=c1"); len(got) != 1 {
+		t.Fatalf("resource filter: %+v", got)
+	}
+	if got := listObjectGrants(t, r, "?resource_id=other"); len(got) != 0 {
+		t.Fatalf("resource filter (miss): %+v", got)
+	}
+
+	// set again with a smaller op set: replace semantics drop "modify"
+	w = adminReq(t, r, http.MethodPost, "/api/safe/v1/admin/object-grants", map[string]any{
+		"accessor_id": "u-1",
+		"resource":    map[string]any{"type": "catalog", "id": "c1"},
+		"operations":  []string{"view_detail"},
+	})
+	if w.Code != http.StatusNoContent {
+		t.Fatalf("re-grant: want 204, got %d", w.Code)
+	}
+	if ok, _ := e.Check("u-1", "catalog", "c1", "modify"); ok {
+		t.Fatal("replace did not prune the dropped op")
+	}
+	if ok, _ := e.Check("u-1", "catalog", "c1", "view_detail"); !ok {
+		t.Fatal("replace dropped the kept op")
+	}
+
+	// revoke
+	w = adminReq(t, r, http.MethodDelete, "/api/safe/v1/admin/object-grants", map[string]any{
+		"accessor_id": "u-1",
+		"resource":    map[string]any{"type": "catalog", "id": "c1"},
+	})
+	if w.Code != http.StatusNoContent {
+		t.Fatalf("revoke: want 204, got %d (%s)", w.Code, w.Body.String())
+	}
+	if ok, _ := e.Check("u-1", "catalog", "c1", "view_detail"); ok {
+		t.Fatal("revoke did not remove the grant")
+	}
+	if got := listObjectGrants(t, r, ""); len(got) != 0 {
+		t.Fatalf("list after revoke: %+v", got)
+	}
+}
+
+func TestObjectGrantsValidation(t *testing.T) {
+	r, _, db, users := newAdminServer(t)
+	ctx := t.Context()
+	if err := users.CreateLocalUser(ctx, &model.User{ID: "u-1", Account: "alice", Enabled: true}, "pw-init0"); err != nil {
+		t.Fatal(err)
+	}
+	if err := db.Create(&model.Department{ID: "dep-1", Name: "Data"}).Error; err != nil {
+		t.Fatal(err)
+	}
+	seedCatalogOps(t, db, "catalog", "view_detail")
+
+	cases := []struct {
+		name string
+		body map[string]any
+	}{
+		{"department grantee", map[string]any{"accessor_id": "dep-1", "resource": map[string]any{"type": "catalog", "id": "c1"}, "operations": []string{"view_detail"}}},
+		{"unknown user", map[string]any{"accessor_id": "ghost", "resource": map[string]any{"type": "catalog", "id": "c1"}, "operations": []string{"view_detail"}}},
+		{"wildcard id", map[string]any{"accessor_id": "u-1", "resource": map[string]any{"type": "catalog", "id": "*"}, "operations": []string{"view_detail"}}},
+		{"unknown type", map[string]any{"accessor_id": "u-1", "resource": map[string]any{"type": "nope", "id": "c1"}, "operations": []string{"view_detail"}}},
+		{"unknown op", map[string]any{"accessor_id": "u-1", "resource": map[string]any{"type": "catalog", "id": "c1"}, "operations": []string{"bogus"}}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			w := adminReq(t, r, http.MethodPost, "/api/safe/v1/admin/object-grants", tc.body)
+			if w.Code != http.StatusBadRequest {
+				t.Fatalf("want 400, got %d (%s)", w.Code, w.Body.String())
+			}
+		})
+	}
+}
+
+// Role-subject and type-wide grants must not surface on the user object-grant
+// listing (that surface is users-on-concrete-objects only).
+func TestObjectGrantsExcludesRolesAndWildcards(t *testing.T) {
+	r, e, db, users := newAdminServer(t)
+	ctx := t.Context()
+	if err := users.CreateLocalUser(ctx, &model.User{ID: "u-1", Account: "alice", Enabled: true}, "pw-init0"); err != nil {
+		t.Fatal(err)
+	}
+	if err := db.Create(&model.Role{ID: "role-x", Name: "x", Source: "custom"}).Error; err != nil {
+		t.Fatal(err)
+	}
+	// a concrete grant to a ROLE (should be excluded)
+	_ = e.GrantRolePermission("role-x", "catalog", "c9", "view_detail")
+	// a type-wide grant to the user (id "*", should be excluded)
+	_ = e.GrantRolePermission("u-1", "catalog", "*", "view_detail")
+	// a concrete grant to the USER (should be included)
+	_ = e.GrantObjectPermission("u-1", "catalog", "c1", "view_detail")
+
+	entries := listObjectGrants(t, r, "")
+	if len(entries) != 1 || entries[0].AccessorID != "u-1" || entries[0].Resource.ID != "c1" {
+		t.Fatalf("listing must contain only the user concrete grant, got %+v", entries)
+	}
+}

--- a/bkn-safe/server/internal/httpapi/router.go
+++ b/bkn-safe/server/internal/httpapi/router.go
@@ -82,6 +82,7 @@ func New(deps Deps) *gin.Engine {
 		registerDeptAdmin(admin, deps.Directory)
 		registerRoleBindings(admin, deps.Enforcer, deps.DB)
 		registerRoles(admin, deps.Enforcer, deps.DB)
+		registerObjectGrants(admin, deps.Enforcer, deps.DB)
 		// Login-client redirect-uri management. Falls back to Hydra in production;
 		// only mounted when a manager is available.
 		clientMgr := deps.ClientAdmin

--- a/bkn-safe/server/internal/httpapi/useradmin.go
+++ b/bkn-safe/server/internal/httpapi/useradmin.go
@@ -11,6 +11,7 @@ import (
 	"bkn-safe/internal/authz"
 	"bkn-safe/internal/directory"
 	"bkn-safe/internal/model"
+	"bkn-safe/internal/seed"
 )
 
 // registerUserAdmin mounts the user-write surface bkn-safe needs to own
@@ -112,6 +113,13 @@ func registerUserAdmin(g *gin.RouterGroup, users *auth.UserStore, e *authz.Enfor
 		}
 		ctx := c.Request.Context()
 		id := c.Param("id")
+		// Defense in depth: the built-in admin is the only guaranteed super-admin;
+		// refuse to disable it (other edits like rename are fine). The frontend
+		// hides the control, but the API must not rely on that.
+		if id == seed.AdminUserID && req.Enabled != nil && !*req.Enabled {
+			c.JSON(http.StatusForbidden, gin.H{"error": "built-in admin user cannot be disabled"})
+			return
+		}
 		fields := map[string]any{}
 		if req.Name != nil {
 			fields["name"] = *req.Name
@@ -171,6 +179,12 @@ func registerUserAdmin(g *gin.RouterGroup, users *auth.UserStore, e *authz.Enfor
 	// its casbin role bindings / direct grants.
 	g.DELETE("/users/:id", func(c *gin.Context) {
 		id := c.Param("id")
+		// Defense in depth: never delete the built-in admin (deleting the only
+		// super-admin locks everyone out). The frontend hides the control too.
+		if id == seed.AdminUserID {
+			c.JSON(http.StatusForbidden, gin.H{"error": "built-in admin user cannot be deleted"})
+			return
+		}
 		err := users.DeleteUser(c.Request.Context(), id)
 		if errors.Is(err, gorm.ErrRecordNotFound) {
 			c.JSON(http.StatusNotFound, gin.H{"error": "user not found"})

--- a/bkn-safe/server/internal/seed/data/catalog.json
+++ b/bkn-safe/server/internal/seed/data/catalog.json
@@ -161,7 +161,19 @@
     {
       "id": "small_model",
       "name": "小模型",
-      "_source": "mf-model-manager (app/utils/permission_manager.py); 大模型/LLM 不过 authz",
+      "_source": "mf-model-manager (app/utils/permission_manager.py)",
+      "operations": [
+        {"id": "create", "name": "创建"},
+        {"id": "display", "name": "查看"},
+        {"id": "modify", "name": "修改"},
+        {"id": "delete", "name": "删除"},
+        {"id": "execute", "name": "调用/执行"}
+      ]
+    },
+    {
+      "id": "large_model",
+      "name": "大模型",
+      "_source": "mf-model-manager (LLM); object-grant 词表项 — enforce 仍需 mf-model-manager 接 /authz/check 才生效",
       "operations": [
         {"id": "create", "name": "创建"},
         {"id": "display", "name": "查看"},

--- a/bkn-safe/server/internal/seed/data/grants.json
+++ b/bkn-safe/server/internal/seed/data/grants.json
@@ -92,6 +92,13 @@
       "id_pattern": "*",
       "operations": ["create", "display", "modify", "delete", "execute"]
     },
+    {
+      "role_id": "3fb94948-5169-11f0-b662-3a7bdba2913f",
+      "role_name": "AI管理员",
+      "resource_type": "large_model",
+      "id_pattern": "*",
+      "operations": ["create", "display", "modify", "delete", "execute"]
+    },
 
     {
       "role_id": "7dcfcc9c-ad02-11e8-aa06-000c29358ad6",

--- a/bkn-safe/server/internal/seed/seed.go
+++ b/bkn-safe/server/internal/seed/seed.go
@@ -31,6 +31,11 @@ const (
 	adminAccount = "admin"
 )
 
+// AdminUserID is the built-in admin user's id, exported so callers can protect
+// it — the user-admin API refuses to delete or disable it (deleting the only
+// super-admin would lock everyone out). Same UUID as the S2S fallback identity.
+const AdminUserID = adminUserID
+
 // adminInitialPwd is the platform initial password (shared single source).
 // Not a const: auth.DefaultInitialPassword is a runtime var (env-overridable).
 var adminInitialPwd = auth.DefaultInitialPassword

--- a/infra/mf-model-manager/app/controller/llm_controller.py
+++ b/infra/mf-model-manager/app/controller/llm_controller.py
@@ -358,6 +358,20 @@ async def check_model(model_id, userId, language, role=""):
         return JSONResponse(status_code=500, content=DataBaseError)
 
 
+async def check_names_by_ids(model_ids, userId, language, role=""):
+    # 按 id 批量取名（对象级授权页回显用）：低敏只读，不做授权拦截；不存在的 id 直接略过
+    try:
+        if not isinstance(model_ids, list) or not model_ids:
+            return JSONResponse(status_code=200, content={"entries": []})
+        ids = [str(model_id) for model_id in model_ids]
+        original_res = llm_model_dao.get_model_info_by_ids(ids)
+        entries = [{"id": str(item["f_model_id"]), "name": item["f_model_name"]} for item in original_res]
+        return JSONResponse(status_code=200, content={"entries": entries})
+    except Exception as e:
+        StandLogger.error(e.args)
+        return JSONResponse(status_code=500, content=DataBaseError)
+
+
 # 新增大模型参数获取接口
 async def param_model(user):
     try:

--- a/infra/mf-model-manager/app/controller/llm_controller.py
+++ b/infra/mf-model-manager/app/controller/llm_controller.py
@@ -82,7 +82,9 @@ async def add_model(schema_para, userId, language, role=""):
                 resource_type="large_model", user_name=user_name, role=role)
             if not grant_ok:
                 raise Exception("add permission failed")
-            content = {"status": "ok", "id": model_id}
+            # id 返回 string：雪花 id 是 19 位整数(>2^53)，JSON number 会被 JS 客户端
+            # 精度截断(末位抹零)，导致前端拿到的 id 删不掉/查不到。与小模型一致返回字符串。
+            content = {"status": "ok", "id": str(model_id)}
             if quota is False:
                 # 需要预插入一条模型配额
                 conf_id = worker.get_id()

--- a/infra/mf-model-manager/app/controller/llm_controller.py
+++ b/infra/mf-model-manager/app/controller/llm_controller.py
@@ -15,6 +15,7 @@ from app.mydb.ConnectUtil import redis_util, get_redis_util
 from app.utils import llm_utils
 from app.utils.common import validate_required_params
 from app.utils.config_cache import quota_config_cache_tree
+from app.utils.permission_manager import permission_manager
 from app.utils.llm_utils import openai_series_stream, OpenAIClientRequest
 from app.utils.param_verify_utils import *
 from app.utils.reshape_utils import *
@@ -30,7 +31,7 @@ eng_dict = {
 
 
 # 保存大模型数据
-async def add_model(schema_para, userId, language):
+async def add_model(schema_para, userId, language, role=""):
     required_params = ["max_model_len"]
     missing_params = await validate_required_params(schema_para, required_params)
     if missing_params:
@@ -38,6 +39,13 @@ async def add_model(schema_para, userId, language):
         content = await get_error_message(code, language)
         content["detail"] = f"missing parameters: {', '.join(missing_params)}"
         return JSONResponse(status_code=status.HTTP_400_BAD_REQUEST, content=content)
+    # 创建权限校验（大模型走 bkn-safe authz，与小模型一致；资源 id 用通配 "*"）
+    permission = await permission_manager.check_single_permission(user_id=userId, resource_id="*",
+                                                                  operations="create",
+                                                                  resource_type="large_model",
+                                                                  role=role)
+    if not permission:
+        return JSONResponse(status_code=403, content=NotPermissionError)
     quota = schema_para.get("quota", False)
     content = await llm_add_verify(schema_para, userId)
     if content:
@@ -63,6 +71,17 @@ async def add_model(schema_para, userId, language):
                                                    userId, json.dumps(config),
                                                    schema_para["max_model_len"],
                                                    schema_para.get("model_parameters", None), quota)
+            # 把新建大模型的实例权限授予创建者（admin 用户在 add_permission 内部短路跳过）
+            if base_config.AUTH_ENABLED:
+                user_infos = await get_username_by_ids([userId])
+                user_name = user_infos.get(userId, "")
+            else:
+                user_name = ""
+            grant_ok = await permission_manager.add_permission(
+                user_id=userId, resource_id=str(model_id), resource_name="大模型",
+                resource_type="large_model", user_name=user_name, role=role)
+            if not grant_ok:
+                raise Exception("add permission failed")
             content = {"status": "ok", "id": model_id}
             if quota is False:
                 # 需要预插入一条模型配额
@@ -77,7 +96,7 @@ async def add_model(schema_para, userId, language):
 
 
 # 删除大模型
-async def remove_model(model_ids, userId, language):
+async def remove_model(model_ids, userId, language, role=""):
     try:
         if "model_ids" not in model_ids.keys():
             raise RequestValidationError([{"loc": ('body', "model_ids"), "type": "value_error.missing"}])
@@ -93,8 +112,20 @@ async def remove_model(model_ids, userId, language):
             if model_id not in model_dict:
                 StandLogger.error(LLMRemoveError["detail"])
                 return JSONResponse(status_code=400, content=LLMRemoveError)
+        # 删除权限校验：逐个待删模型校验 delete 权限（大模型走 bkn-safe authz，与小模型一致）
+        for model_id in model_ids["model_ids"]:
+            permission = await permission_manager.check_single_permission(
+                user_id=userId, resource_id=str(model_id), operations="delete",
+                resource_type="large_model", role=role)
+            if not permission:
+                error_dict = NotPermissionError.copy()
+                error_dict["detail"] = "部分模型无删除权限"
+                return JSONResponse(status_code=403, content=error_dict)
         llm_model_dao.delete_model_by_id(model_ids["model_ids"])
         model_quota_dao.delete_model_quota_by_model_id(model_ids["model_ids"])
+        # 清理 bkn-safe 中这些模型实例的全部授权策略
+        await permission_manager.delete_permission(resource_type="large_model",
+                                                   resource_ids=[str(mid) for mid in model_ids["model_ids"]])
         # 确保 redis_util 已初始化
         global redis_util
         if redis_util is None:
@@ -190,7 +221,7 @@ async def test_model(model_config, userId, language):
 
 
 # 重命名大模型
-async def edit_model(model_para, userId, language):
+async def edit_model(model_para, userId, language, role=""):
     content = llm_edit_verify(model_para)
     if content:
         StandLogger.error(content)
@@ -203,6 +234,12 @@ async def edit_model(model_para, userId, language):
                 StandLogger.error(LLMEdit2Error["detail"])
                 return JSONResponse(status_code=400, content=LLMEdit2Error)
             else:
+                # 修改权限校验（大模型走 bkn-safe authz，与小模型一致）
+                permission = await permission_manager.check_single_permission(
+                    user_id=userId, resource_id=str(model_para["model_id"]), operations="modify",
+                    resource_type="large_model", role=role)
+                if not permission:
+                    return JSONResponse(status_code=403, content=NotPermissionError)
                 info = llm_model_dao.get_data_from_model_list_by_id(model_para["model_id"])
                 old_quota = info[0]["f_quota"]
                 model_name = info[0]["f_model_name"]
@@ -300,11 +337,17 @@ async def source_model(userId, language, page, size, name, order, series, rule, 
 
 
 # 大模型信息查看接口
-async def check_model(model_id, userId, language):
+async def check_model(model_id, userId, language, role=""):
     idx_list = [idx["f_model_id"] for idx in llm_model_dao.get_all_model_list()]
     if model_id not in idx_list:
         StandLogger.error(LLMCheckError["detail"])
         return JSONResponse(status_code=400, content=LLMCheckError)
+    # 查看权限校验（大模型走 bkn-safe authz，与小模型一致）
+    permission = await permission_manager.check_single_permission(
+        user_id=userId, resource_id=str(model_id), operations="display",
+        resource_type="large_model", role=role)
+    if not permission:
+        return JSONResponse(status_code=403, content=NotPermissionError)
     try:
         result = reshape_check(llm_model_dao.get_data_from_model_list_by_id(model_id))
         return JSONResponse(status_code=200, content=result)

--- a/infra/mf-model-manager/app/controller/small_model_controller.py
+++ b/infra/mf-model-manager/app/controller/small_model_controller.py
@@ -292,6 +292,25 @@ async def get_info(model_id, user_id, role):
         return JSONResponse(status_code=400, content=error_dict)
 
 
+async def get_names_by_ids(model_ids, userId, language, role):
+    # 按 id 批量取名（对象级授权页回显用）：低敏只读，不做授权拦截；不存在的 id 直接略过
+    try:
+        if not isinstance(model_ids, list) or not model_ids:
+            return JSONResponse(status_code=200, content={"entries": []})
+        ids = [str(model_id) for model_id in model_ids]
+        try:
+            original_res = small_model_dao.get_model_info_by_ids(ids)
+        except Exception as e:
+            StandLogger.error(ModelFactory_MyPymysqlPool_Connection_ConnectError_Error["description"])
+            return JSONResponse(status_code=500, content=ModelFactory_MyPymysqlPool_Connection_ConnectError_Error)
+        entries = [{"id": str(item["f_model_id"]), "name": item["f_model_name"]} for item in original_res]
+        return JSONResponse(status_code=200, content={"entries": entries})
+    except Exception as e:
+        StandLogger.error(e.args)
+        error_dict = ModelFactory_ExternalSmallModel_UnknownError.copy()
+        return JSONResponse(status_code=400, content=error_dict)
+
+
 async def get_info_by_name(model_name):
     if not model_name:
         return JSONResponse(status_code=400, content=ModelFactory_ExternalSmallModel_GetInfo_IdNotExist_Error)

--- a/infra/mf-model-manager/app/dao/llm_model_dao.py
+++ b/infra/mf-model-manager/app/dao/llm_model_dao.py
@@ -52,6 +52,14 @@ class ModelDao():
         return res
 
     @connect_execute_close_db
+    def get_model_info_by_ids(self, model_ids, connection, cursor):
+        placeholders = ','.join(['%s'] * len(model_ids))
+        sql = f"""select f_model_id,f_model_name from t_llm_model where f_model_id IN ({placeholders})"""
+        cursor.execute(sql, model_ids)
+        res = cursor.fetchall()
+        return res
+
+    @connect_execute_close_db
     def get_data_from_model_list_by_id(self, model_id, connection, cursor):
         sql = """select f_create_by,f_create_time,f_model,f_model_config,f_model_id,
                             f_model_name,f_model_series,f_model_type,f_update_by,f_update_time,

--- a/infra/mf-model-manager/app/routers/llm_router.py
+++ b/infra/mf-model-manager/app/routers/llm_router.py
@@ -28,14 +28,14 @@ async def health_alive():
 @llm_route.post("/llm/add")
 async def add_llm(request: Request, model_para: dict = Body(...)):
     userId, language, role = await get_user_info(request)
-    return await add_model(model_para, userId, language)
+    return await add_model(model_para, userId, language, role)
 
 
 # 大模型删除接口
 @llm_route.post("/llm/delete")
 async def remove_llm(request: Request, model_ids: dict = Body(...)):
     userId, language, role = await get_user_info(request)
-    return await remove_model(model_ids, userId, language)
+    return await remove_model(model_ids, userId, language, role)
 
 
 # 大模型测试接口
@@ -49,7 +49,7 @@ async def test_llm_(request: Request, model_config: dict = Body(...)):
 @llm_route.post("/llm/edit")
 async def edit_llm(request: Request, model_para: dict = Body(...)):
     userId, language, role = await get_user_info(request)
-    return await edit_model(model_para, userId, language)
+    return await edit_model(model_para, userId, language, role)
 
 
 # 获取大模型列表接口
@@ -64,7 +64,7 @@ async def source_llm(request: Request, page, size, order='desc', rule='update_ti
 @llm_route.get("/llm/get")
 async def check_llm_(model_id, request: Request, ):
     userId, language, role = await get_user_info(request)
-    return await check_model(model_id, userId, language)
+    return await check_model(model_id, userId, language, role)
 
 
 # 获取api文档接口

--- a/infra/mf-model-manager/app/routers/llm_router.py
+++ b/infra/mf-model-manager/app/routers/llm_router.py
@@ -60,6 +60,13 @@ async def source_llm(request: Request, page, size, order='desc', rule='update_ti
     return await source_model(userId, language, page, size, name, order, series, rule, api_model, model_type, quota)
 
 
+# 大模型按 id 批量取名接口
+@llm_route.post("/llm/names")
+async def names_llm(request: Request, model_para: dict = Body(...)):
+    userId, language, role = await get_user_info(request)
+    return await check_names_by_ids(model_para.get("ids", []), userId, language, role)
+
+
 # 查看大模型接口
 @llm_route.get("/llm/get")
 async def check_llm_(model_id, request: Request, ):

--- a/infra/mf-model-manager/app/routers/small_model_router.py
+++ b/infra/mf-model-manager/app/routers/small_model_router.py
@@ -49,6 +49,12 @@ async def set_default(request: Request, model_para: dict = Body(...)):
     return await small_model_controller.set_default_model(model_para, userId, language, role)
 
 
+@small_model_router.post("/small-model/names")
+async def get_names(request: Request, model_para: dict = Body(...)):
+    userId, language, role = await get_user_info(request)
+    return await small_model_controller.get_names_by_ids(model_para.get("ids", []), userId, language, role)
+
+
 @small_model_router.post("/small-model/delete")
 async def delete_model(request: Request, model_para: dict = Body(...)):
     userId, language, role = await get_user_info(request)


### PR DESCRIPTION
## 改动
BKN 对象级授权(object-grants) + LLM/large_model 接入 bkn-safe authz。

- **bkn-safe**: object-grant 管理 API(`objectgrants.go`+测试)、authz 加 `large_model` 词表、内置 admin 防删/防禁、seed catalog/grants
- **mf-model-manager**: LLM CRUD 接入 bkn-safe authz(large_model)、`llm/add` 返回 id 为字符串(雪花精度)、llm/small-model router 微调
- **operator-integration**: id→name 批量接口(授权 UI 用)
- **docs**: `frontend-object-grants-integration.md`

6 commit / 46 文件 / +1265，含单测。对应"BKN Studio 对象级授权"后端，待前端对接。

> 注：本分支基于较早的 main，与已合并的 #70(小模型可配置化) 同改了 mf-model-manager 部分文件，合并前可能需 rebase 解冲突。

🤖 Generated with [Claude Code](https://claude.com/claude-code)