### PR TITLE
feat(vega-buildtask): server-side sort + multi-status filter for /build-tasks list

### DIFF
--- a/adp/vega/vega-backend/server/drivenadapters/build_task/build_task_access.go
+++ b/adp/vega/vega-backend/server/drivenadapters/build_task/build_task_access.go
@@ -11,6 +11,7 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
+	"strings"
 	"sync"
 	"time"
 
@@ -362,9 +363,10 @@ func (bta *buildTaskAccess) List(ctx context.Context, params interfaces.BuildTas
 		builder = builder.Where(sq.Eq{"f_catalog_id": params.CatalogID})
 		countBuilder = countBuilder.Where(sq.Eq{"f_catalog_id": params.CatalogID})
 	}
-	if params.Status != "" {
-		builder = builder.Where(sq.Eq{"f_status": params.Status})
-		countBuilder = countBuilder.Where(sq.Eq{"f_status": params.Status})
+	if len(params.Statuses) > 0 {
+		// squirrel: Eq 的值为切片 → 生成 f_status IN (?,?,...)
+		builder = builder.Where(sq.Eq{"f_status": params.Statuses})
+		countBuilder = countBuilder.Where(sq.Eq{"f_status": params.Statuses})
 	}
 	if params.Mode != "" {
 		builder = builder.Where(sq.Eq{"f_mode": params.Mode})
@@ -382,11 +384,7 @@ func (bta *buildTaskAccess) List(ctx context.Context, params interfaces.BuildTas
 		return nil, 0, err
 	}
 
-	if params.Sort != "" && params.Direction != "" {
-		builder = builder.OrderBy(fmt.Sprintf("%s %s", params.Sort, params.Direction))
-	} else {
-		builder = builder.OrderBy("f_update_time DESC")
-	}
+	builder = builder.OrderBy(buildOrderByClause(params.OrderBy, params.Order))
 
 	if params.Limit > 0 {
 		builder = builder.Limit(uint64(params.Limit)).Offset(uint64(params.Offset))
@@ -420,6 +418,40 @@ func (bta *buildTaskAccess) List(ctx context.Context, params interfaces.BuildTas
 
 	span.SetStatus(codes.Ok, "")
 	return buildTasks, totalCount, nil
+}
+
+// buildOrderByClause 把 order_by/order 翻译成 ORDER BY 子句。排序在 List 中先于
+// LIMIT/OFFSET 全局应用,故活跃任务总落在第一页。order_by=default 忽略 order
+// (固定复合序);其余维度方向跟 order,并以 f_create_time DESC 兜底平手。
+func buildOrderByClause(orderBy, order string) string {
+	dir := "DESC"
+	if strings.EqualFold(order, interfaces.ASC_DIRECTION) {
+		dir = "ASC"
+	}
+	switch orderBy {
+	case interfaces.BuildTaskOrderByCreatedAt:
+		return "f_create_time " + dir
+	case interfaces.BuildTaskOrderByUpdatedAt:
+		return "f_update_time " + dir
+	case interfaces.BuildTaskOrderByMode:
+		return "f_mode " + dir + ", f_create_time DESC"
+	case interfaces.BuildTaskOrderByStatus:
+		return statusBucketCase() + " " + dir + ", f_create_time DESC"
+	default: // BuildTaskOrderByDefault 及未知值:活跃置顶(桶 ASC)+ 桶内最新在前
+		return statusBucketCase() + " ASC, f_create_time DESC"
+	}
+}
+
+// statusBucketCase 由 interfaces.BuildTaskStatusOrder 生成状态优先级 CASE 表达式。
+// 值全是后端常量,非用户输入,无 SQL 注入风险。
+func statusBucketCase() string {
+	var b strings.Builder
+	b.WriteString("CASE f_status")
+	for i, s := range interfaces.BuildTaskStatusOrder {
+		fmt.Fprintf(&b, " WHEN '%s' THEN %d", s, i+1)
+	}
+	b.WriteString(" ELSE 99 END")
+	return b.String()
 }
 
 // Delete deletes a build task by ID.

--- a/adp/vega/vega-backend/server/drivenadapters/build_task/build_task_order_test.go
+++ b/adp/vega/vega-backend/server/drivenadapters/build_task/build_task_order_test.go
@@ -1,0 +1,63 @@
+// Copyright 2026 openbkn.ai
+// Copyright The kweaver.ai Authors.
+//
+// Licensed under the Apache License, Version 2.0.
+// See the LICENSE file in the project root for details.
+
+package build_task
+
+import (
+	"testing"
+
+	. "github.com/smartystreets/goconvey/convey"
+
+	"vega-backend/interfaces"
+)
+
+func Test_buildOrderByClause(t *testing.T) {
+	Convey("buildOrderByClause\n", t, func() {
+
+		Convey("default: 活跃置顶(桶 ASC)+ 桶内最新在前,忽略 order\n", func() {
+			clause := buildOrderByClause(interfaces.BuildTaskOrderByDefault, "asc")
+			So(clause, ShouldContainSubstring, "CASE f_status")
+			So(clause, ShouldContainSubstring, "WHEN 'running' THEN 1")
+			So(clause, ShouldContainSubstring, "WHEN 'completed' THEN 6")
+			So(clause, ShouldEndWith, "END ASC, f_create_time DESC")
+		})
+
+		Convey("unknown order_by 兜底为 default\n", func() {
+			So(buildOrderByClause("bogus", "desc"), ShouldEndWith, "END ASC, f_create_time DESC")
+		})
+
+		Convey("created_at 跟 order 方向,无平手键\n", func() {
+			So(buildOrderByClause(interfaces.BuildTaskOrderByCreatedAt, "asc"), ShouldEqual, "f_create_time ASC")
+			So(buildOrderByClause(interfaces.BuildTaskOrderByCreatedAt, "desc"), ShouldEqual, "f_create_time DESC")
+		})
+
+		Convey("updated_at 跟 order 方向,无平手键\n", func() {
+			So(buildOrderByClause(interfaces.BuildTaskOrderByUpdatedAt, "asc"), ShouldEqual, "f_update_time ASC")
+			So(buildOrderByClause(interfaces.BuildTaskOrderByUpdatedAt, "desc"), ShouldEqual, "f_update_time DESC")
+		})
+
+		Convey("status 桶序跟 order 方向 + 平手 create DESC\n", func() {
+			So(buildOrderByClause(interfaces.BuildTaskOrderByStatus, "asc"), ShouldEndWith, "END ASC, f_create_time DESC")
+			So(buildOrderByClause(interfaces.BuildTaskOrderByStatus, "desc"), ShouldEndWith, "END DESC, f_create_time DESC")
+		})
+
+		Convey("mode 跟 order 方向 + 平手 create DESC\n", func() {
+			So(buildOrderByClause(interfaces.BuildTaskOrderByMode, "asc"), ShouldEqual, "f_mode ASC, f_create_time DESC")
+		})
+	})
+}
+
+func Test_statusBucketCase(t *testing.T) {
+	Convey("statusBucketCase 覆盖全部 6 状态且优先级与 BuildTaskStatusOrder 一致\n", t, func() {
+		clause := statusBucketCase()
+		for i, s := range interfaces.BuildTaskStatusOrder {
+			So(clause, ShouldContainSubstring, "WHEN '"+s+"' THEN ")
+			_ = i
+		}
+		So(clause, ShouldStartWith, "CASE f_status")
+		So(clause, ShouldEndWith, "ELSE 99 END")
+	})
+}

--- a/adp/vega/vega-backend/server/driveradapters/build_task_handler.go
+++ b/adp/vega/vega-backend/server/driveradapters/build_task_handler.go
@@ -20,7 +20,6 @@ import (
 	"github.com/kweaver-ai/kweaver-go-lib/otel/oteltrace"
 	"github.com/kweaver-ai/kweaver-go-lib/rest"
 
-	"vega-backend/common"
 	"vega-backend/common/visitor"
 	verrors "vega-backend/errors"
 	"vega-backend/interfaces"
@@ -231,32 +230,11 @@ func (r *restHandler) listBuildTasks(c *gin.Context, visitor hydra.Visitor) {
 	ctx = context.WithValue(ctx, interfaces.ACCOUNT_INFO_KEY, accountInfo)
 	oteltrace.AddHttpAttrs4API(span, oteltrace.GetAttrsByGinCtx(c))
 
-	offset := common.GetQueryOrDefault(c, "offset", interfaces.DEFAULT_OFFSET)
-	limit := common.GetQueryOrDefault(c, "limit", interfaces.DEFAULT_LIMIT)
-	sort := common.GetQueryOrDefault(c, "sort", "update_time")
-	direction := common.GetQueryOrDefault(c, "direction", interfaces.DESC_DIRECTION)
-
-	pageParam, err := validatePaginationQueryParams(ctx,
-		offset, limit, sort, direction, interfaces.BUILD_TASK_SORT)
+	params, err := parseBuildTaskListParams(ctx, c)
 	if err != nil {
 		httpErr := err.(*rest.HTTPError)
 		otellog.LogError(ctx, fmt.Sprintf("%s. %v", httpErr.BaseError.Description,
 			httpErr.BaseError.ErrorDetails), nil)
-		oteltrace.AddHttpAttrs4HttpError(span, httpErr)
-		rest.ReplyError(c, httpErr)
-		return
-	}
-
-	params := interfaces.BuildTasksQueryParams{
-		PaginationQueryParams: pageParam,
-		ResourceID:            c.Query("resource_id"),
-		CatalogID:             c.Query("catalog_id"),
-		Status:                c.Query("status"),
-		Mode:                  c.Query("mode"),
-	}
-
-	if err := ValidateBuildTaskQueryParams(ctx, params); err != nil {
-		httpErr := err.(*rest.HTTPError)
 		oteltrace.AddHttpAttrs4HttpError(span, httpErr)
 		rest.ReplyError(c, httpErr)
 		return

--- a/adp/vega/vega-backend/server/driveradapters/build_task_handler_test.go
+++ b/adp/vega/vega-backend/server/driveradapters/build_task_handler_test.go
@@ -56,8 +56,8 @@ func Test_BuildTaskRestHandler_ListBuildTasks(t *testing.T) {
 			So(w.Body.String(), ShouldContainSubstring, "VegaBackend.InvalidParameter.Limit")
 		})
 
-		Convey("Invalid sort field\n", func() {
-			req := httptest.NewRequest(http.MethodGet, url+"?sort=unknown_field", nil)
+		Convey("Invalid order_by\n", func() {
+			req := httptest.NewRequest(http.MethodGet, url+"?order_by=unknown_field", nil)
 			w := httptest.NewRecorder()
 			engine.ServeHTTP(w, req)
 
@@ -65,8 +65,8 @@ func Test_BuildTaskRestHandler_ListBuildTasks(t *testing.T) {
 			So(w.Body.String(), ShouldContainSubstring, "VegaBackend.InvalidParameter.Sort")
 		})
 
-		Convey("Invalid direction\n", func() {
-			req := httptest.NewRequest(http.MethodGet, url+"?direction=foo", nil)
+		Convey("Invalid order\n", func() {
+			req := httptest.NewRequest(http.MethodGet, url+"?order=foo", nil)
 			w := httptest.NewRecorder()
 			engine.ServeHTTP(w, req)
 
@@ -97,8 +97,8 @@ func Test_BuildTaskRestHandler_ListBuildTasks(t *testing.T) {
 				DoAndReturn(func(_ context.Context, params interfaces.BuildTasksQueryParams) ([]*interfaces.BuildTask, int64, error) {
 					So(params.Offset, ShouldEqual, 0)
 					So(params.Limit, ShouldEqual, 20)
-					So(params.Sort, ShouldEqual, "f_update_time")
-					So(params.Direction, ShouldEqual, interfaces.DESC_DIRECTION)
+					So(params.OrderBy, ShouldEqual, interfaces.BuildTaskOrderByDefault)
+					So(params.Order, ShouldEqual, interfaces.DESC_DIRECTION)
 					return []*interfaces.BuildTask{}, int64(0), nil
 				})
 
@@ -114,16 +114,16 @@ func Test_BuildTaskRestHandler_ListBuildTasks(t *testing.T) {
 				DoAndReturn(func(_ context.Context, params interfaces.BuildTasksQueryParams) ([]*interfaces.BuildTask, int64, error) {
 					So(params.ResourceID, ShouldEqual, "res-1")
 					So(params.CatalogID, ShouldEqual, "cat-1")
-					So(params.Status, ShouldEqual, interfaces.BuildTaskStatusCompleted)
+					So(params.Statuses, ShouldResemble, []string{interfaces.BuildTaskStatusCompleted})
 					So(params.Mode, ShouldEqual, interfaces.BuildTaskModeBatch)
 					So(params.Offset, ShouldEqual, 5)
 					So(params.Limit, ShouldEqual, 10)
-					So(params.Sort, ShouldEqual, "f_create_time")
-					So(params.Direction, ShouldEqual, interfaces.ASC_DIRECTION)
+					So(params.OrderBy, ShouldEqual, interfaces.BuildTaskOrderByCreatedAt)
+					So(params.Order, ShouldEqual, interfaces.ASC_DIRECTION)
 					return []*interfaces.BuildTask{}, int64(0), nil
 				})
 
-			req := httptest.NewRequest(http.MethodGet, url+"?resource_id=res-1&catalog_id=cat-1&status=completed&mode=batch&offset=5&limit=10&sort=create_time&direction=asc", nil)
+			req := httptest.NewRequest(http.MethodGet, url+"?resource_id=res-1&catalog_id=cat-1&status=completed&mode=batch&offset=5&limit=10&order_by=created_at&order=asc", nil)
 			w := httptest.NewRecorder()
 			engine.ServeHTTP(w, req)
 

--- a/adp/vega/vega-backend/server/driveradapters/validate_build_task.go
+++ b/adp/vega/vega-backend/server/driveradapters/validate_build_task.go
@@ -10,25 +10,107 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"strconv"
+	"strings"
 
+	"github.com/gin-gonic/gin"
 	"github.com/kweaver-ai/kweaver-go-lib/rest"
 
+	"vega-backend/common"
 	verrors "vega-backend/errors"
 	"vega-backend/interfaces"
 )
 
-func ValidateBuildTaskQueryParams(ctx context.Context, params interfaces.BuildTasksQueryParams) error {
-	if params.Status != "" && !isValidBuildTaskStatus(params.Status) {
-		return rest.NewHTTPError(ctx, http.StatusBadRequest, verrors.VegaBackend_BuildTask_InvalidStatus).
-			WithErrorDetails(fmt.Sprintf("invalid status: %s", params.Status))
+// parseBuildTaskListParams 解析并校验 GET /build-tasks 的全部 query:
+// 分页(offset/limit)、排序(order_by/order)、过滤(status 多值 / active 快捷 / mode)。
+// 排序与过滤均下沉服务端,排序全局先于分页(见 build_task_access.List),
+// 保证「构建中」永远排在第一页;total_count 始终为过滤后全量条数。
+func parseBuildTaskListParams(ctx context.Context, c *gin.Context) (interfaces.BuildTasksQueryParams, error) {
+	params := interfaces.BuildTasksQueryParams{}
+
+	// 分页:offset / limit(沿用既有规则,limit=-1 表示不分页)
+	offset := common.GetQueryOrDefault(c, "offset", interfaces.DEFAULT_OFFSET)
+	limit := common.GetQueryOrDefault(c, "limit", interfaces.DEFAULT_LIMIT)
+	off, err := strconv.Atoi(offset)
+	if err != nil || off < interfaces.MIN_OFFSET {
+		return params, rest.NewHTTPError(ctx, http.StatusBadRequest, verrors.VegaBackend_InvalidParameter_Offset).
+			WithErrorDetails(fmt.Sprintf("invalid offset: %s", offset))
+	}
+	lim, err := strconv.Atoi(limit)
+	if err != nil || (limit != interfaces.NO_LIMIT && (lim < interfaces.MIN_LIMIT || lim > interfaces.MAX_LIMIT)) {
+		return params, rest.NewHTTPError(ctx, http.StatusBadRequest, verrors.VegaBackend_InvalidParameter_Limit).
+			WithErrorDetails(fmt.Sprintf("invalid limit: %s", limit))
+	}
+	params.Offset = off
+	params.Limit = lim
+
+	// 排序:order_by / order
+	orderBy := common.GetQueryOrDefault(c, "order_by", interfaces.DEFAULT_BUILD_TASK_ORDER_BY)
+	if !isValidBuildTaskOrderBy(orderBy) {
+		return params, rest.NewHTTPError(ctx, http.StatusBadRequest, verrors.VegaBackend_InvalidParameter_Sort).
+			WithErrorDetails(fmt.Sprintf("invalid order_by: %s", orderBy))
+	}
+	order := common.GetQueryOrDefault(c, "order", interfaces.DEFAULT_BUILD_TASK_ORDER)
+	if order != interfaces.ASC_DIRECTION && order != interfaces.DESC_DIRECTION {
+		return params, rest.NewHTTPError(ctx, http.StatusBadRequest, verrors.VegaBackend_InvalidParameter_Direction).
+			WithErrorDetails(fmt.Sprintf("invalid order: %s", order))
+	}
+	params.OrderBy = orderBy
+	params.Order = order
+
+	// 过滤:active=true 快捷 = running+init,优先于 status;否则解析 status 多值(逗号分隔)
+	if active, _ := strconv.ParseBool(c.Query("active")); active {
+		params.Statuses = []string{interfaces.BuildTaskStatusRunning, interfaces.BuildTaskStatusInit}
+	} else if raw := c.Query("status"); raw != "" {
+		statuses, err := parseBuildTaskStatuses(ctx, raw)
+		if err != nil {
+			return params, err
+		}
+		params.Statuses = statuses
 	}
 
-	if params.Mode != "" && !isValidBuildTaskMode(params.Mode) {
-		return rest.NewHTTPError(ctx, http.StatusBadRequest, verrors.VegaBackend_BuildTask_InvalidParameter_Mode).
-			WithErrorDetails(fmt.Sprintf("invalid mode: %s", params.Mode))
+	// 过滤:mode
+	mode := c.Query("mode")
+	if mode != "" && !isValidBuildTaskMode(mode) {
+		return params, rest.NewHTTPError(ctx, http.StatusBadRequest, verrors.VegaBackend_BuildTask_InvalidParameter_Mode).
+			WithErrorDetails(fmt.Sprintf("invalid mode: %s", mode))
 	}
 
-	return nil
+	params.ResourceID = c.Query("resource_id")
+	params.CatalogID = c.Query("catalog_id")
+	params.Mode = mode
+	return params, nil
+}
+
+// parseBuildTaskStatuses 把逗号分隔的 status 拆成切片,逐个校验为后端枚举;任一非法即报错。
+// 空段(多余逗号/空白)跳过。
+func parseBuildTaskStatuses(ctx context.Context, raw string) ([]string, error) {
+	parts := strings.Split(raw, ",")
+	statuses := make([]string, 0, len(parts))
+	for _, p := range parts {
+		s := strings.TrimSpace(p)
+		if s == "" {
+			continue
+		}
+		if !isValidBuildTaskStatus(s) {
+			return nil, rest.NewHTTPError(ctx, http.StatusBadRequest, verrors.VegaBackend_BuildTask_InvalidStatus).
+				WithErrorDetails(fmt.Sprintf("invalid status: %s", s))
+		}
+		statuses = append(statuses, s)
+	}
+	return statuses, nil
+}
+
+func isValidBuildTaskOrderBy(o string) bool {
+	switch o {
+	case interfaces.BuildTaskOrderByDefault,
+		interfaces.BuildTaskOrderByCreatedAt,
+		interfaces.BuildTaskOrderByUpdatedAt,
+		interfaces.BuildTaskOrderByStatus,
+		interfaces.BuildTaskOrderByMode:
+		return true
+	}
+	return false
 }
 
 func isValidBuildTaskStatus(s string) bool {

--- a/adp/vega/vega-backend/server/driveradapters/validate_build_task_test.go
+++ b/adp/vega/vega-backend/server/driveradapters/validate_build_task_test.go
@@ -8,42 +8,128 @@ package driveradapters
 
 import (
 	"context"
+	"net/http"
+	"net/http/httptest"
 	"testing"
 
+	"github.com/gin-gonic/gin"
 	. "github.com/smartystreets/goconvey/convey"
 
 	"vega-backend/interfaces"
 )
 
-func Test_ValidateBuildTaskQueryParams(t *testing.T) {
-	Convey("Test ValidateBuildTaskQueryParams\n", t, func() {
+// newListCtx 造一个仅带 query 的 GET 测试上下文。
+func newListCtx(query string) *gin.Context {
+	gin.SetMode(gin.TestMode)
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest(http.MethodGet, "/build-tasks?"+query, nil)
+	return c
+}
+
+func Test_parseBuildTaskStatuses(t *testing.T) {
+	Convey("parseBuildTaskStatuses\n", t, func() {
 		ctx := context.Background()
 
-		Convey("Valid empty params\n", func() {
-			err := ValidateBuildTaskQueryParams(ctx, interfaces.BuildTasksQueryParams{})
+		Convey("single valid\n", func() {
+			ss, err := parseBuildTaskStatuses(ctx, "running")
 			So(err, ShouldBeNil)
+			So(ss, ShouldResemble, []string{"running"})
 		})
 
-		Convey("Valid status and mode\n", func() {
-			err := ValidateBuildTaskQueryParams(ctx, interfaces.BuildTasksQueryParams{
-				Status: interfaces.BuildTaskStatusCompleted,
-				Mode:   interfaces.BuildTaskModeBatch,
-			})
+		Convey("multi valid with spaces\n", func() {
+			ss, err := parseBuildTaskStatuses(ctx, "running, init")
 			So(err, ShouldBeNil)
+			So(ss, ShouldResemble, []string{"running", "init"})
 		})
 
-		Convey("Invalid status\n", func() {
-			err := ValidateBuildTaskQueryParams(ctx, interfaces.BuildTasksQueryParams{
-				Status: "unknown",
-			})
+		Convey("one invalid value -> error\n", func() {
+			_, err := parseBuildTaskStatuses(ctx, "running,unknown")
 			So(err, ShouldNotBeNil)
 		})
 
-		Convey("Invalid mode\n", func() {
-			err := ValidateBuildTaskQueryParams(ctx, interfaces.BuildTasksQueryParams{
-				Mode: "unknown",
-			})
+		Convey("only empty segments -> empty slice\n", func() {
+			ss, err := parseBuildTaskStatuses(ctx, ", , ")
+			So(err, ShouldBeNil)
+			So(len(ss), ShouldEqual, 0)
+		})
+	})
+}
+
+func Test_isValidBuildTaskOrderBy(t *testing.T) {
+	Convey("isValidBuildTaskOrderBy\n", t, func() {
+		So(isValidBuildTaskOrderBy(interfaces.BuildTaskOrderByDefault), ShouldBeTrue)
+		So(isValidBuildTaskOrderBy(interfaces.BuildTaskOrderByCreatedAt), ShouldBeTrue)
+		So(isValidBuildTaskOrderBy(interfaces.BuildTaskOrderByUpdatedAt), ShouldBeTrue)
+		So(isValidBuildTaskOrderBy(interfaces.BuildTaskOrderByStatus), ShouldBeTrue)
+		So(isValidBuildTaskOrderBy(interfaces.BuildTaskOrderByMode), ShouldBeTrue)
+		So(isValidBuildTaskOrderBy("progress"), ShouldBeFalse)
+		So(isValidBuildTaskOrderBy(""), ShouldBeFalse)
+	})
+}
+
+func Test_parseBuildTaskListParams(t *testing.T) {
+	Convey("parseBuildTaskListParams\n", t, func() {
+		ctx := context.Background()
+
+		Convey("defaults when no query\n", func() {
+			p, err := parseBuildTaskListParams(ctx, newListCtx(""))
+			So(err, ShouldBeNil)
+			So(p.Offset, ShouldEqual, 0)
+			So(p.Limit, ShouldEqual, 20)
+			So(p.OrderBy, ShouldEqual, interfaces.BuildTaskOrderByDefault)
+			So(p.Order, ShouldEqual, interfaces.DESC_DIRECTION)
+			So(len(p.Statuses), ShouldEqual, 0)
+		})
+
+		Convey("active=true -> running+init, overrides status\n", func() {
+			p, err := parseBuildTaskListParams(ctx, newListCtx("active=true&status=completed"))
+			So(err, ShouldBeNil)
+			So(p.Statuses, ShouldResemble, []string{interfaces.BuildTaskStatusRunning, interfaces.BuildTaskStatusInit})
+		})
+
+		Convey("multi-value status\n", func() {
+			p, err := parseBuildTaskListParams(ctx, newListCtx("status=running,init"))
+			So(err, ShouldBeNil)
+			So(p.Statuses, ShouldResemble, []string{"running", "init"})
+		})
+
+		Convey("order_by + order honored\n", func() {
+			p, err := parseBuildTaskListParams(ctx, newListCtx("order_by=created_at&order=asc"))
+			So(err, ShouldBeNil)
+			So(p.OrderBy, ShouldEqual, interfaces.BuildTaskOrderByCreatedAt)
+			So(p.Order, ShouldEqual, interfaces.ASC_DIRECTION)
+		})
+
+		Convey("invalid order_by -> error\n", func() {
+			_, err := parseBuildTaskListParams(ctx, newListCtx("order_by=bogus"))
 			So(err, ShouldNotBeNil)
+		})
+
+		Convey("invalid order -> error\n", func() {
+			_, err := parseBuildTaskListParams(ctx, newListCtx("order=sideways"))
+			So(err, ShouldNotBeNil)
+		})
+
+		Convey("invalid status -> error\n", func() {
+			_, err := parseBuildTaskListParams(ctx, newListCtx("status=running,nope"))
+			So(err, ShouldNotBeNil)
+		})
+
+		Convey("invalid mode -> error\n", func() {
+			_, err := parseBuildTaskListParams(ctx, newListCtx("mode=nope"))
+			So(err, ShouldNotBeNil)
+		})
+
+		Convey("negative offset -> error\n", func() {
+			_, err := parseBuildTaskListParams(ctx, newListCtx("offset=-1"))
+			So(err, ShouldNotBeNil)
+		})
+
+		Convey("limit=-1 (no-limit) allowed\n", func() {
+			p, err := parseBuildTaskListParams(ctx, newListCtx("limit=-1"))
+			So(err, ShouldBeNil)
+			So(p.Limit, ShouldEqual, -1)
 		})
 	})
 }

--- a/adp/vega/vega-backend/server/interfaces/build_task.go
+++ b/adp/vega/vega-backend/server/interfaces/build_task.go
@@ -21,6 +21,16 @@ const (
 	BuildTaskModeStreaming string = "streaming" // 流式
 	BuildTaskModeBatch     string = "batch"     // 批量
 
+	// build-task 列表排序维度(query: order_by)
+	BuildTaskOrderByDefault   string = "default"    // 活跃置顶分桶序(缺省)
+	BuildTaskOrderByCreatedAt string = "created_at" // 按创建时间
+	BuildTaskOrderByUpdatedAt string = "updated_at" // 按更新时间
+	BuildTaskOrderByStatus    string = "status"     // 按状态优先级桶序
+	BuildTaskOrderByMode      string = "mode"       // 按模式
+
+	DEFAULT_BUILD_TASK_ORDER_BY string = BuildTaskOrderByDefault
+	DEFAULT_BUILD_TASK_ORDER    string = DESC_DIRECTION
+
 	BuildTaskExecuteTypeIncremental string = "incremental" // 增量
 	BuildTaskExecuteTypeFull        string = "full"        // 全量
 
@@ -32,14 +42,17 @@ const (
 	BUILD_PREFIX = "vega-build"
 )
 
-var (
-	BUILD_TASK_SORT = map[string]string{
-		"create_time": "f_create_time",
-		"update_time": "f_update_time",
-		"status":      "f_status",
-		"mode":        "f_mode",
-	}
-)
+// BuildTaskStatusOrder 定义 default/status 排序的状态桶优先级(下标+1 即优先级)。
+// 活跃任务(running/init)置顶是核心诉求;顺序写死,既是 SQL CASE 的唯一来源,
+// 也保证「构建中」永远排在第一页。
+var BuildTaskStatusOrder = []string{
+	BuildTaskStatusRunning,   // 1 构建中/流式监听中
+	BuildTaskStatusInit,      // 2 排队中
+	BuildTaskStatusStopping,  // 3 停止中
+	BuildTaskStatusStopped,   // 4 已停止
+	BuildTaskStatusFailed,    // 5 失败
+	BuildTaskStatusCompleted, // 6 已完成
+}
 
 // BuildTask represents a build task entity.
 type BuildTask struct {
@@ -122,8 +135,10 @@ type BuildTasksQueryParams struct {
 	PaginationQueryParams
 	ResourceID string
 	CatalogID  string
-	Status     string
+	Statuses   []string // 多值状态过滤(IN);空为不过滤。active=true 等价 [running,init]
 	Mode       string
+	OrderBy    string // default|created_at|status|mode；缺省 default
+	Order      string // asc|desc；缺省 desc。order_by=default 时忽略(固定复合序)
 }
 
 type KeyValue struct {

--- a/adp/vega/vega-backend/server/worker/build_task_reconciler.go
+++ b/adp/vega/vega-backend/server/worker/build_task_reconciler.go
@@ -61,7 +61,7 @@ func (r *buildTaskReconciler) run() {
 
 // reconcileOnce 执行一轮对账
 func (r *buildTaskReconciler) reconcileOnce(ctx context.Context) error {
-	tasks, _, err := r.taskAccess.List(ctx, interfaces.BuildTasksQueryParams{Status: interfaces.BuildTaskStatusInit})
+	tasks, _, err := r.taskAccess.List(ctx, interfaces.BuildTasksQueryParams{Statuses: []string{interfaces.BuildTaskStatusInit}})
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
## What

Push sorting, filtering and pagination of `/build-tasks` list down to the backend so the frontend no longer pulls `limit:200` and sorts/filters in memory (breaks past ~200 tasks). Replaces the legacy single-status + `BUILD_TASK_SORT` 4-field map with a richer scheme.

## Sorting (new query params)

- `order_by`: `default | created_at | updated_at | status | mode` (default: `default`)
- `order`: `asc | desc` (default: `desc`); ignored when `order_by=default`
- **default order** = status-bucket priority (`running > init > stopping > stopped > failed > completed`) then `create_time DESC`, so active tasks always land on page 1. Applied globally before `LIMIT/OFFSET`.

## Filtering

- `status` now multi-value (CSV) → `f_status IN (...)`; each value validated
- `active=true` shortcut = `running,init` (takes precedence over `status`)

`total_count` stays the post-filter full count (separate `COUNT(*)`), unchanged.

## ⚠️ Breaking API change

New `order_by`/`order` params **replace** legacy `sort`/`direction`. Frontend must switch to the new params for this endpoint.

## Notes

- **No DB migration** — query-logic only, no new columns.
- Bucket order lives in `interfaces.BuildTaskStatusOrder` (single source for the SQL `CASE`).
- `buildOrderByClause`/`statusBucketCase` are pure + unit-tested; param parsing covered via gin test contexts.

## Verification

- Rebased onto latest `main` (clean, no conflicts); `BUILD_TASK_SORT` fully replaced, no dangling refs.
- `go build ./...` → exit 0
- `go test ./drivenadapters/build_task/... ./driveradapters/...` → all `ok`

🤖 Generated with [Claude Code](https://claude.com/claude-code)