### PR TITLE
feat(bkn-safe + context-loader): 用户自助签发的 AppKey 鉴权（MCP/REST）

### DIFF
--- a/adp/context-loader/agent-retrieval/helm/agent-retrieval/templates/configmap.yaml
+++ b/adp/context-loader/agent-retrieval/helm/agent-retrieval/templates/configmap.yaml
@@ -42,6 +42,10 @@ data:
       private_protocol: {{ index .Values "depServices" "agent-operator-integration" "privateProtocol" | quote }}
       private_host: {{ index .Values "depServices" "agent-operator-integration" "privateHost" | quote }}
       private_port: {{ index .Values "depServices" "agent-operator-integration" "privatePort" }}
+    bkn_safe:
+      private_protocol: {{ index .Values "depServices" "bkn-safe" "privateProtocol" | quote }}
+      private_host: {{ index .Values "depServices" "bkn-safe" "privateHost" | quote }}
+      private_port: {{ index .Values "depServices" "bkn-safe" "privatePort" }}
     redis:
       connectType: {{ .Values.depServices.redis.connectType | quote }}
       enableSSL: {{ .Values.depServices.redis.enableSSL }}

--- a/adp/context-loader/agent-retrieval/helm/agent-retrieval/values.yaml
+++ b/adp/context-loader/agent-retrieval/helm/agent-retrieval/values.yaml
@@ -111,6 +111,10 @@ depServices:
     privateHost: agent-operator-integration
     privatePort: 9000
     privateProtocol: http
+  bkn-safe:
+    privateHost: bkn-safe
+    privatePort: 3000
+    privateProtocol: http
   redis:
     connectType: sentinel
     enableSSL: false

--- a/adp/context-loader/agent-retrieval/server/drivenadapters/appkey.go
+++ b/adp/context-loader/agent-retrieval/server/drivenadapters/appkey.go
@@ -1,0 +1,112 @@
+// Copyright 2026 openbkn.ai
+// Copyright The kweaver.ai Authors.
+//
+// Licensed under the Apache License, Version 2.0.
+// See the LICENSE file in the project root for details.
+
+package drivenadapters
+
+import (
+	"context"
+	"net/http"
+	"sync"
+
+	jsoniter "github.com/json-iterator/go"
+
+	"github.com/openbkn-ai/adp/context-loader/agent-retrieval/server/infra/config"
+	"github.com/openbkn-ai/adp/context-loader/agent-retrieval/server/infra/errors"
+	"github.com/openbkn-ai/adp/context-loader/agent-retrieval/server/infra/rest"
+	"github.com/openbkn-ai/adp/context-loader/agent-retrieval/server/interfaces"
+	"github.com/openbkn-ai/adp/context-loader/agent-retrieval/server/utils"
+)
+
+// appKeyIntrospectURI is bkn-safe's internal AppKey verification endpoint
+// (tokenless, ClusterIP). Response mirrors OAuth2 introspection.
+const appKeyIntrospectURI = "/api/safe/v1/api-keys/introspect"
+
+type appKeyVerifier struct {
+	introspectURL string
+	logger        interfaces.Logger
+	httpClient    interfaces.HTTPClient
+}
+
+var (
+	appKeyOnce sync.Once
+	appKeyInst interfaces.AppKeyVerifier
+)
+
+// appKeyIntrospectResp is bkn-safe's verify response: 200 {active:false} on any
+// failure, otherwise the resolved owner identity.
+type appKeyIntrospectResp struct {
+	Active      bool   `json:"active"`
+	Sub         string `json:"sub"`          // owner accessor id
+	AccountType string `json:"account_type"` // bkn-safe account_type of the owner
+	KeyID       string `json:"key_id"`
+}
+
+// NewAppKeyVerifier builds the bkn-safe-backed AppKey verifier. Returns nil when
+// AUTH_ENABLED=false (AppKey verification is disabled together with auth); the
+// caller treats a nil verifier as "no AppKey support" and falls back to hydra.
+func NewAppKeyVerifier() interfaces.AppKeyVerifier {
+	appKeyOnce.Do(func() {
+		if !config.GetAuthEnabled() {
+			return // leave appKeyInst nil
+		}
+		conf := config.NewConfigLoader()
+		appKeyInst = &appKeyVerifier{
+			introspectURL: conf.BknSafe.BuildURL(appKeyIntrospectURI),
+			logger:        conf.GetLogger(),
+			httpClient:    rest.NewHTTPClient(),
+		}
+	})
+	return appKeyInst
+}
+
+// Verify resolves an AppKey to the owner's TokenInfo via bkn-safe. The result is
+// shaped exactly like a hydra introspection of the owner's OAuth token, so the
+// downstream AccountAuthContext (and all authz) is identical.
+func (v *appKeyVerifier) Verify(ctx context.Context, key string) (*interfaces.TokenInfo, error) {
+	body, _ := jsoniter.Marshal(map[string]string{"token": key})
+	header := map[string]string{"Content-Type": "application/json"}
+	_, resp, err := v.httpClient.Post(ctx, v.introspectURL, header, body)
+	if err != nil {
+		v.logger.WithContext(ctx).Error(err)
+		return nil, err
+	}
+
+	introspect := &appKeyIntrospectResp{}
+	if err := jsoniter.Unmarshal(utils.ObjectToByte(resp), introspect); err != nil {
+		v.logger.WithContext(ctx).Warnf("AppKey introspect decode failed: %+v, resp:%+v", err, resp)
+		return nil, errors.DefaultHTTPError(ctx, http.StatusInternalServerError, err.Error())
+	}
+	if !introspect.Active {
+		return nil, errors.DefaultHTTPError(ctx, http.StatusUnauthorized, "api key is invalid")
+	}
+
+	info := &interfaces.TokenInfo{
+		Active:     true,
+		VisitorID:  introspect.Sub,
+		VisitorTyp: appKeyVisitorType(introspect.AccountType),
+		AccountTyp: appKeyAccountType(introspect.AccountType),
+	}
+	return info, nil
+}
+
+// appKeyVisitorType maps a bkn-safe account_type to the gateway's VisitorType.
+// "app" (application account) -> Business; every other owner is a person-like
+// accessor -> RealName. This yields AccountAuthContext.AccountType == "user" for
+// normal users (matching the OAuth-token path).
+func appKeyVisitorType(accountType string) interfaces.VisitorType {
+	if accountType == "app" {
+		return interfaces.Business
+	}
+	return interfaces.RealName
+}
+
+// appKeyAccountType maps a bkn-safe account_type to the gateway's AccountType.
+func appKeyAccountType(accountType string) interfaces.AccountType {
+	if accountType == "id_card" {
+		return interfaces.IDCard
+	}
+	return interfaces.Other
+}

--- a/adp/context-loader/agent-retrieval/server/drivenadapters/appkey_test.go
+++ b/adp/context-loader/agent-retrieval/server/drivenadapters/appkey_test.go
@@ -1,0 +1,88 @@
+// Copyright 2026 openbkn.ai
+// Copyright The kweaver.ai Authors.
+//
+// Licensed under the Apache License, Version 2.0.
+// See the LICENSE file in the project root for details.
+
+package drivenadapters
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/smartystreets/goconvey/convey"
+	"go.uber.org/mock/gomock"
+
+	"github.com/openbkn-ai/adp/context-loader/agent-retrieval/server/interfaces"
+	"github.com/openbkn-ai/adp/context-loader/agent-retrieval/server/mocks"
+)
+
+func TestAppKeyVerify(t *testing.T) {
+	convey.Convey("appKeyVerifier.Verify", t, func() {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+		logger := mocks.NewMockLogger(ctrl)
+		httpClient := mocks.NewMockHTTPClient(ctrl)
+		logger.EXPECT().WithContext(gomock.Any()).Return(logger).AnyTimes()
+
+		v := &appKeyVerifier{
+			introspectURL: "http://bkn-safe:3000/api/safe/v1/api-keys/introspect",
+			logger:        logger,
+			httpClient:    httpClient,
+		}
+
+		convey.Convey("HTTP error -> error", func() {
+			logger.EXPECT().Error(gomock.Any()).Return()
+			httpClient.EXPECT().Post(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+				Return(0, nil, fmt.Errorf("connection error"))
+
+			_, err := v.Verify(context.Background(), "bak_x_y")
+			convey.So(err, convey.ShouldNotBeNil)
+		})
+
+		convey.Convey("decode error -> error", func() {
+			logger.EXPECT().Warnf(gomock.Any(), gomock.Any(), gomock.Any()).Return()
+			httpClient.EXPECT().Post(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+				Return(200, "not-an-object", nil)
+
+			_, err := v.Verify(context.Background(), "bak_x_y")
+			convey.So(err, convey.ShouldNotBeNil)
+		})
+
+		convey.Convey("inactive -> error", func() {
+			httpClient.EXPECT().Post(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+				Return(200, &appKeyIntrospectResp{Active: false}, nil)
+
+			_, err := v.Verify(context.Background(), "bak_x_y")
+			convey.So(err, convey.ShouldNotBeNil)
+		})
+
+		convey.Convey("active user -> RealName/user identity", func() {
+			httpClient.EXPECT().Post(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+				Return(200, &appKeyIntrospectResp{
+					Active:      true,
+					Sub:         "owner-1",
+					AccountType: "other",
+					KeyID:       "kid-1",
+				}, nil)
+
+			info, err := v.Verify(context.Background(), "bak_x_y")
+			convey.So(err, convey.ShouldBeNil)
+			convey.So(info.Active, convey.ShouldBeTrue)
+			convey.So(info.VisitorID, convey.ShouldEqual, "owner-1")
+			convey.So(info.VisitorTyp, convey.ShouldEqual, interfaces.RealName)
+			convey.So(info.VisitorTyp.ToAccessorType(), convey.ShouldEqual, interfaces.AccessorTypeUser)
+		})
+
+		convey.Convey("app account -> Business identity", func() {
+			httpClient.EXPECT().Post(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+				Return(200, &appKeyIntrospectResp{Active: true, Sub: "app-1", AccountType: "app"}, nil)
+
+			info, err := v.Verify(context.Background(), "bak_x_y")
+			convey.So(err, convey.ShouldBeNil)
+			convey.So(info.VisitorTyp, convey.ShouldEqual, interfaces.Business)
+			convey.So(info.VisitorTyp.ToAccessorType(), convey.ShouldEqual, interfaces.AccessorTypeApp)
+		})
+	})
+}

--- a/adp/context-loader/agent-retrieval/server/driveradapters/appkey_middleware_test.go
+++ b/adp/context-loader/agent-retrieval/server/driveradapters/appkey_middleware_test.go
@@ -1,0 +1,73 @@
+// Copyright 2026 openbkn.ai
+// Copyright The kweaver.ai Authors.
+//
+// Licensed under the Apache License, Version 2.0.
+// See the LICENSE file in the project root for details.
+
+package driveradapters
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/smartystreets/goconvey/convey"
+
+	"github.com/openbkn-ai/adp/context-loader/agent-retrieval/server/infra/common"
+	"github.com/openbkn-ai/adp/context-loader/agent-retrieval/server/interfaces"
+)
+
+// stubAppKeys records whether Verify ran and resolves to a fixed AppKey owner so
+// the test can tell the AppKey path apart from the hydra path (which resolves to
+// "user-1" via stubPublicHydra).
+type stubAppKeys struct{ called *bool }
+
+func (s stubAppKeys) Verify(_ context.Context, _ string) (*interfaces.TokenInfo, error) {
+	if s.called != nil {
+		*s.called = true
+	}
+	return &interfaces.TokenInfo{VisitorID: "appkey-owner", VisitorTyp: interfaces.RealName}, nil
+}
+
+// runIntrospect drives middlewareIntrospectVerify with the given verifier and
+// bearer token, returning the resolved auth context.
+func runIntrospect(appKeys interfaces.AppKeyVerifier, token string) *interfaces.AccountAuthContext {
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest(http.MethodGet, "/x", http.NoBody)
+	if token != "" {
+		c.Request.Header.Set("Authorization", "Bearer "+token)
+	}
+	middlewareIntrospectVerify(stubPublicHydra{}, appKeys)(c)
+	authCtx, _ := common.GetAccountAuthContextFromCtx(c.Request.Context())
+	return authCtx
+}
+
+func TestMiddlewareIntrospectVerify_AppKeyRouting(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	convey.Convey("middlewareIntrospectVerify routes by credential prefix", t, func() {
+		convey.Convey("bak_ token -> AppKey verifier resolves owner", func() {
+			called := false
+			ac := runIntrospect(stubAppKeys{called: &called}, interfaces.AppKeyPrefix+"keyid_secret")
+			convey.So(called, convey.ShouldBeTrue)
+			convey.So(ac, convey.ShouldNotBeNil)
+			convey.So(ac.AccountID, convey.ShouldEqual, "appkey-owner")
+			convey.So(ac.AccountType, convey.ShouldEqual, interfaces.AccessorTypeUser)
+		})
+
+		convey.Convey("non-bak_ token -> hydra introspection", func() {
+			called := false
+			ac := runIntrospect(stubAppKeys{called: &called}, "ory_at_token")
+			convey.So(called, convey.ShouldBeFalse) // AppKey verifier not consulted
+			convey.So(ac.AccountID, convey.ShouldEqual, "user-1")
+		})
+
+		convey.Convey("nil AppKey verifier -> bak_ token falls back to hydra", func() {
+			ac := runIntrospect(nil, interfaces.AppKeyPrefix+"keyid_secret")
+			convey.So(ac.AccountID, convey.ShouldEqual, "user-1")
+		})
+	})
+}

--- a/adp/context-loader/agent-retrieval/server/driveradapters/mcp/info.go
+++ b/adp/context-loader/agent-retrieval/server/driveradapters/mcp/info.go
@@ -93,7 +93,7 @@ func BuildMCPInfo(endpoint string) (*MCPInfo, error) {
 		Endpoint:            endpoint,
 		Protocol:            "MCP / JSON-RPC 2.0 (initialize → tools/list → tools/call)",
 		Transport:           "Streamable HTTP",
-		Auth:                "Bearer token via Authorization header",
+		Auth:                "Bearer credential via Authorization header — an OAuth access token, or a long-lived user-issued AppKey (prefix bak_). No other headers required.",
 		ToolCount:           len(tools),
 		Tools:               tools,
 		ClientConfigExample: cfg,

--- a/adp/context-loader/agent-retrieval/server/driveradapters/middleware.go
+++ b/adp/context-loader/agent-retrieval/server/driveradapters/middleware.go
@@ -55,14 +55,23 @@ func getToken(c *gin.Context) (token string) {
 	return token
 }
 
-// middlewareIntrospect 令牌内省中间件
-func middlewareIntrospectVerify(hydra interfaces.Hydra) gin.HandlerFunc {
+// middlewareIntrospect 令牌内省中间件。
+// 凭据二选一:以 AppKey 前缀(bak_)开头的交给 bkn-safe 校验(用户自助签发的 API Key),
+// 其余 bearer token 走 hydra 内省。两条路产出同一个 TokenInfo,下游认证上下文一致。
+func middlewareIntrospectVerify(hydra interfaces.Hydra, appKeys interfaces.AppKeyVerifier) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		ctx := c.Request.Context()
 		// 设置language信息到context
 		ctx = common.SetLanguageToCtx(ctx, common.GetLanguageInfo(c))
 
-		tokenInfo, err := hydra.Introspect(ctx, getToken(c))
+		token := getToken(c)
+		var tokenInfo *interfaces.TokenInfo
+		var err error
+		if appKeys != nil && strings.HasPrefix(token, interfaces.AppKeyPrefix) {
+			tokenInfo, err = appKeys.Verify(ctx, token)
+		} else {
+			tokenInfo, err = hydra.Introspect(ctx, token)
+		}
 		if err != nil {
 			rest.ReplyError(c, err)
 			c.Abort()

--- a/adp/context-loader/agent-retrieval/server/driveradapters/rest_public_handler.go
+++ b/adp/context-loader/agent-retrieval/server/driveradapters/rest_public_handler.go
@@ -27,6 +27,7 @@ import (
 
 type restPublicHandler struct {
 	Hydra                          interfaces.Hydra
+	AppKeys                        interfaces.AppKeyVerifier
 	KnRetrievalHandler             knretrieval.KnRetrievalHandler
 	MCPHandler                     http.Handler
 	KnLogicPropertyResolverHandler knlogicpropertyresolver.KnLogicPropertyResolverHandler
@@ -43,6 +44,7 @@ type restPublicHandler struct {
 func NewRestPublicHandler(logger interfaces.Logger) interfaces.HTTPRouterInterface {
 	return &restPublicHandler{
 		Hydra:                          drivenadapters.NewHydra(),
+		AppKeys:                        drivenadapters.NewAppKeyVerifier(),
 		KnRetrievalHandler:             knretrieval.NewKnRetrievalHandler(),
 		MCPHandler:                     mcp.NewMCPHandler(),
 		KnLogicPropertyResolverHandler: knlogicpropertyresolver.NewKnLogicPropertyResolverHandler(),
@@ -59,7 +61,7 @@ func NewRestPublicHandler(logger interfaces.Logger) interfaces.HTTPRouterInterfa
 // RegisterPublic 注册公共路由
 func (r *restPublicHandler) RegisterRouter(engine *gin.RouterGroup) {
 	mws := []gin.HandlerFunc{}
-	mws = append(mws, middlewareRequestLog(r.Logger), middlewareTrace, middlewareIntrospectVerify(r.Hydra), middlewareResponseFormat())
+	mws = append(mws, middlewareRequestLog(r.Logger), middlewareTrace, middlewareIntrospectVerify(r.Hydra, r.AppKeys), middlewareResponseFormat())
 	engine.Use(mws...)
 
 	engine.POST("/kn/semantic-search", r.KnRetrievalHandler.SemanticSearch)

--- a/adp/context-loader/agent-retrieval/server/infra/config/agent-retrieval.yaml
+++ b/adp/context-loader/agent-retrieval/server/infra/config/agent-retrieval.yaml
@@ -38,6 +38,10 @@ operator_integration:
   private_protocol: "http"
   private_host: "agent-operator-integration.kweaver"
   private_port: 9000
+bkn_safe: # bkn-safe 鉴权服务，用于校验用户自助签发的 AppKey（API Key）
+  private_protocol: "http"
+  private_host: "bkn-safe"
+  private_port: 3000
 redis:
   connectType: "sentinel"
   enableSSL: false

--- a/adp/context-loader/agent-retrieval/server/infra/config/config.go
+++ b/adp/context-loader/agent-retrieval/server/infra/config/config.go
@@ -36,8 +36,9 @@ type Config struct {
 	OAuth               OAuthConfig           `yaml:"oauth"`
 	BknBackend          PrivateBaseConfig     `yaml:"bkn_backend"`
 	OntologyQuery       PrivateBaseConfig     `yaml:"ontology_query"`
-	Vega                PrivateBaseConfig     `yaml:"vega"` // Vega data-catalog backend (run_sql / resource query)
+	Vega                PrivateBaseConfig     `yaml:"vega"`                 // Vega data-catalog backend (run_sql / resource query)
 	OperatorIntegration PrivateBaseConfig     `yaml:"operator_integration"` // Operator integration service configuration
+	BknSafe             PrivateBaseConfig     `yaml:"bkn_safe"`             // bkn-safe auth service (AppKey verification)
 	RedisConfig         RedisConfig           `yaml:"redis"`
 	Logger              interfaces.Logger     `yaml:"-"`
 	ConceptSearchConfig KnConceptSearchConfig `yaml:"concept_search_config"` // Knowledge network concept search configuration

--- a/adp/context-loader/agent-retrieval/server/interfaces/drivenadapters.go
+++ b/adp/context-loader/agent-retrieval/server/interfaces/drivenadapters.go
@@ -190,6 +190,18 @@ type Hydra interface {
 	Introspect(ctx context.Context, token string) (tokenInfo *TokenInfo, err error)
 }
 
+// AppKeyPrefix marks a user-issued AppKey (API Key) credential. The public-API
+// auth middleware branches on this prefix: keys are verified by bkn-safe, all
+// other bearer tokens by hydra introspection.
+const AppKeyPrefix = "bak_"
+
+// AppKeyVerifier resolves a user-issued AppKey to the owner's TokenInfo by asking
+// bkn-safe. It mirrors Hydra.Introspect's contract (same TokenInfo result) so the
+// gateway middleware can treat an AppKey and an OAuth token interchangeably.
+type AppKeyVerifier interface {
+	Verify(ctx context.Context, key string) (tokenInfo *TokenInfo, err error)
+}
+
 // KnowledgeRerankActionType Result set rerank type based on business knowledge network
 type KnowledgeRerankActionType string
 

--- a/bkn-safe/server/internal/auth/apikey.go
+++ b/bkn-safe/server/internal/auth/apikey.go
@@ -17,8 +17,21 @@ import (
 
 // KeyPrefix marks an AppKey credential. The MCP/REST gateway branches on this
 // prefix to route verification here (vs hydra introspection). Plaintext shape:
-// "bak_<keyid>_<secret>".
+// "bak_<keyid>_<secret>" — both halves are base62 (no '_'), so the separator is
+// unambiguous and the key is copy/URL-safe.
 const KeyPrefix = "bak_"
+
+// Key half lengths in base62 chars. keyIDLen → ~71 bits (collision-safe lookup
+// id); secretLen → ~160 bits (well past brute-force). Total plaintext ≈ 44 chars
+// (vs the old 101-char hex), comparable to GitHub/Stripe tokens.
+const (
+	keyIDLen  = 12
+	secretLen = 27
+)
+
+// base62Alphabet is the credential charset: digits + letters, no '_'/'-', so it
+// never collides with the key separator and is safe in URLs/headers.
+const base62Alphabet = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz"
 
 // ErrAPIKeyInvalid is the opaque verification failure: unknown/disabled/expired
 // key, bad secret, or a key whose owner is gone/disabled. Deliberately does not
@@ -47,8 +60,8 @@ type VerifiedKey struct {
 // nil = never expires. The caller has already authenticated the owner, so the key
 // can never grant more than the owner holds.
 func (s *APIKeyStore) Issue(ctx context.Context, ownerID, name string, expiresAt *time.Time) (string, *model.APIKey, error) {
-	keyID := NewID()         // 128-bit hex, public lookup half
-	secret := randomSecret() // 256-bit hex, the secret half
+	keyID := randBase62(keyIDLen)   // public lookup half
+	secret := randBase62(secretLen) // the secret half
 
 	rec := &model.APIKey{
 		ID:          NewID(),
@@ -163,6 +176,32 @@ func (s *APIKeyStore) Delete(ctx context.Context, id string) error {
 	return nil
 }
 
+// Regenerate rotates the secret of an existing key the caller owns: same row /
+// KeyID / name / expiry, brand-new secret. The OLD plaintext stops verifying
+// immediately (its secret no longer matches the stored hash); the new one-time
+// plaintext is returned. Re-enables a soft-disabled key and clears LastUsedAt.
+// This is the "I lost it / rotate on suspected leak" path — no need to recreate
+// and rename. Returns gorm.ErrRecordNotFound when the caller owns no such key.
+func (s *APIKeyStore) Regenerate(ctx context.Context, ownerID, id string) (string, *model.APIKey, error) {
+	var rec model.APIKey
+	err := s.db.WithContext(ctx).First(&rec, "id = ? AND owner_user_id = ?", id, ownerID).Error
+	if errors.Is(err, gorm.ErrRecordNotFound) {
+		return "", nil, gorm.ErrRecordNotFound
+	}
+	if err != nil {
+		return "", nil, err
+	}
+	secret := randBase62(secretLen)
+	rec.SecretHash = hashSecret(secret)
+	rec.LastUsedAt = nil
+	rec.Enabled = true
+	if err := s.db.WithContext(ctx).Model(&model.APIKey{}).Where("id = ?", id).
+		Updates(map[string]any{"secret_hash": rec.SecretHash, "last_used_at": nil, "enabled": true}).Error; err != nil {
+		return "", nil, err
+	}
+	return KeyPrefix + rec.KeyID + "_" + secret, &rec, nil
+}
+
 // splitKey parses "bak_<keyid>_<secret>" into its two halves. ok=false on any
 // shape mismatch (missing prefix, missing separator, empty half).
 func splitKey(plaintext string) (keyID, secret string, ok bool) {
@@ -177,11 +216,23 @@ func splitKey(plaintext string) (keyID, secret string, ok bool) {
 	return keyID, secret, true
 }
 
-// randomSecret returns a 256-bit hex secret.
-func randomSecret() string {
-	b := make([]byte, 32)
-	_, _ = rand.Read(b)
-	return hex.EncodeToString(b)
+// randBase62 returns n cryptographically-random base62 chars. Rejection sampling
+// (drop bytes >= 248 = 4*62) keeps the distribution uniform — no modulo bias.
+func randBase62(n int) string {
+	out := make([]byte, 0, n)
+	for len(out) < n {
+		buf := make([]byte, n)
+		_, _ = rand.Read(buf)
+		for _, b := range buf {
+			if b < 248 {
+				out = append(out, base62Alphabet[int(b)%62])
+				if len(out) == n {
+					break
+				}
+			}
+		}
+	}
+	return string(out)
 }
 
 // hashSecret returns the sha256 hex digest of a secret (high-entropy input, so a

--- a/bkn-safe/server/internal/auth/apikey.go
+++ b/bkn-safe/server/internal/auth/apikey.go
@@ -1,0 +1,192 @@
+package auth
+
+import (
+	"context"
+	"crypto/rand"
+	"crypto/sha256"
+	"crypto/subtle"
+	"encoding/hex"
+	"errors"
+	"strings"
+	"time"
+
+	"gorm.io/gorm"
+
+	"bkn-safe/internal/model"
+)
+
+// KeyPrefix marks an AppKey credential. The MCP/REST gateway branches on this
+// prefix to route verification here (vs hydra introspection). Plaintext shape:
+// "bak_<keyid>_<secret>".
+const KeyPrefix = "bak_"
+
+// ErrAPIKeyInvalid is the opaque verification failure: unknown/disabled/expired
+// key, bad secret, or a key whose owner is gone/disabled. Deliberately does not
+// distinguish causes to callers.
+var ErrAPIKeyInvalid = errors.New("invalid api key")
+
+// APIKeyStore issues, lists, revokes and verifies AppKeys, backed by GORM.
+type APIKeyStore struct {
+	db *gorm.DB
+}
+
+// NewAPIKeyStore builds an AppKey store.
+func NewAPIKeyStore(db *gorm.DB) *APIKeyStore { return &APIKeyStore{db: db} }
+
+// VerifiedKey is the resolved identity behind a valid AppKey: the owner it acts
+// as. AccountType mirrors the owner User row so downstream authz behaves exactly
+// as if the owner presented an OAuth token.
+type VerifiedKey struct {
+	KeyID       string
+	OwnerID     string
+	AccountType model.AccountType
+}
+
+// Issue mints a new AppKey for ownerID and returns the ONE-TIME plaintext key
+// (never recoverable afterwards) plus the stored record (no secret). expiresAt
+// nil = never expires. The caller has already authenticated the owner, so the key
+// can never grant more than the owner holds.
+func (s *APIKeyStore) Issue(ctx context.Context, ownerID, name string, expiresAt *time.Time) (string, *model.APIKey, error) {
+	keyID := NewID()         // 128-bit hex, public lookup half
+	secret := randomSecret() // 256-bit hex, the secret half
+
+	rec := &model.APIKey{
+		ID:          NewID(),
+		KeyID:       keyID,
+		OwnerUserID: ownerID,
+		Name:        name,
+		SecretHash:  hashSecret(secret),
+		ExpiresAt:   expiresAt,
+		Enabled:     true,
+	}
+	if err := s.db.WithContext(ctx).Create(rec).Error; err != nil {
+		return "", nil, err
+	}
+	plaintext := KeyPrefix + keyID + "_" + secret
+	return plaintext, rec, nil
+}
+
+// Verify validates a plaintext AppKey and resolves the owner identity. It checks,
+// in order: prefix/shape, key exists, key enabled, not expired, secret matches
+// (constant-time), owner user exists and is enabled. On success it best-effort
+// stamps LastUsedAt. Any failure returns ErrAPIKeyInvalid (opaque).
+func (s *APIKeyStore) Verify(ctx context.Context, plaintext string) (*VerifiedKey, error) {
+	keyID, secret, ok := splitKey(plaintext)
+	if !ok {
+		return nil, ErrAPIKeyInvalid
+	}
+
+	var rec model.APIKey
+	err := s.db.WithContext(ctx).First(&rec, "key_id = ?", keyID).Error
+	if errors.Is(err, gorm.ErrRecordNotFound) {
+		return nil, ErrAPIKeyInvalid
+	}
+	if err != nil {
+		return nil, err
+	}
+	if !rec.Enabled {
+		return nil, ErrAPIKeyInvalid
+	}
+	if rec.ExpiresAt != nil && time.Now().After(*rec.ExpiresAt) {
+		return nil, ErrAPIKeyInvalid
+	}
+	// Constant-time secret comparison over the hex digests.
+	if subtle.ConstantTimeCompare([]byte(hashSecret(secret)), []byte(rec.SecretHash)) != 1 {
+		return nil, ErrAPIKeyInvalid
+	}
+
+	// The key acts AS its owner — a disabled/deleted owner invalidates the key.
+	var owner model.User
+	err = s.db.WithContext(ctx).First(&owner, "id = ?", rec.OwnerUserID).Error
+	if errors.Is(err, gorm.ErrRecordNotFound) {
+		return nil, ErrAPIKeyInvalid
+	}
+	if err != nil {
+		return nil, err
+	}
+	if !owner.Enabled {
+		return nil, ErrAPIKeyInvalid
+	}
+
+	// Best-effort last-used stamp; never fail verification on a write error.
+	now := time.Now()
+	_ = s.db.WithContext(ctx).Model(&model.APIKey{}).
+		Where("key_id = ?", keyID).Update("last_used_at", now).Error
+
+	return &VerifiedKey{KeyID: keyID, OwnerID: owner.ID, AccountType: owner.AccountType}, nil
+}
+
+// ListByOwner returns ownerID's keys (newest first), never including any secret.
+func (s *APIKeyStore) ListByOwner(ctx context.Context, ownerID string) ([]model.APIKey, error) {
+	var keys []model.APIKey
+	err := s.db.WithContext(ctx).
+		Where("owner_user_id = ?", ownerID).
+		Order("created_at DESC").Find(&keys).Error
+	return keys, err
+}
+
+// ListAll returns every key (admin view), optionally filtered by owner. Never
+// includes any secret.
+func (s *APIKeyStore) ListAll(ctx context.Context, ownerFilter string) ([]model.APIKey, error) {
+	q := s.db.WithContext(ctx).Model(&model.APIKey{})
+	if ownerFilter != "" {
+		q = q.Where("owner_user_id = ?", ownerFilter)
+	}
+	var keys []model.APIKey
+	err := q.Order("created_at DESC").Find(&keys).Error
+	return keys, err
+}
+
+// DeleteOwned revokes a key only if it belongs to ownerID (self-service guard).
+// Returns gorm.ErrRecordNotFound when no such key is owned by the caller.
+func (s *APIKeyStore) DeleteOwned(ctx context.Context, ownerID, id string) error {
+	res := s.db.WithContext(ctx).Where("id = ? AND owner_user_id = ?", id, ownerID).Delete(&model.APIKey{})
+	if res.Error != nil {
+		return res.Error
+	}
+	if res.RowsAffected == 0 {
+		return gorm.ErrRecordNotFound
+	}
+	return nil
+}
+
+// Delete revokes any key by id (admin). Returns gorm.ErrRecordNotFound when the
+// key does not exist.
+func (s *APIKeyStore) Delete(ctx context.Context, id string) error {
+	res := s.db.WithContext(ctx).Where("id = ?", id).Delete(&model.APIKey{})
+	if res.Error != nil {
+		return res.Error
+	}
+	if res.RowsAffected == 0 {
+		return gorm.ErrRecordNotFound
+	}
+	return nil
+}
+
+// splitKey parses "bak_<keyid>_<secret>" into its two halves. ok=false on any
+// shape mismatch (missing prefix, missing separator, empty half).
+func splitKey(plaintext string) (keyID, secret string, ok bool) {
+	rest, found := strings.CutPrefix(strings.TrimSpace(plaintext), KeyPrefix)
+	if !found {
+		return "", "", false
+	}
+	keyID, secret, found = strings.Cut(rest, "_")
+	if !found || keyID == "" || secret == "" {
+		return "", "", false
+	}
+	return keyID, secret, true
+}
+
+// randomSecret returns a 256-bit hex secret.
+func randomSecret() string {
+	b := make([]byte, 32)
+	_, _ = rand.Read(b)
+	return hex.EncodeToString(b)
+}
+
+// hashSecret returns the sha256 hex digest of a secret (high-entropy input, so a
+// plain hash — not bcrypt — is sufficient and keeps per-request verify cheap).
+func hashSecret(secret string) string {
+	sum := sha256.Sum256([]byte(secret))
+	return hex.EncodeToString(sum[:])
+}

--- a/bkn-safe/server/internal/auth/apikey.go
+++ b/bkn-safe/server/internal/auth/apikey.go
@@ -38,6 +38,11 @@ const base62Alphabet = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrst
 // distinguish causes to callers.
 var ErrAPIKeyInvalid = errors.New("invalid api key")
 
+// ErrAPIKeyNameTaken is returned by Issue when the owner already has a key with
+// the same name. Names are unique PER OWNER (different owners may reuse a name),
+// so a user's key list stays unambiguous.
+var ErrAPIKeyNameTaken = errors.New("api key name already in use")
+
 // APIKeyStore issues, lists, revokes and verifies AppKeys, backed by GORM.
 type APIKeyStore struct {
 	db *gorm.DB
@@ -60,6 +65,18 @@ type VerifiedKey struct {
 // nil = never expires. The caller has already authenticated the owner, so the key
 // can never grant more than the owner holds.
 func (s *APIKeyStore) Issue(ctx context.Context, ownerID, name string, expiresAt *time.Time) (string, *model.APIKey, error) {
+	// Names are unique per owner so a user's key list is unambiguous. Checked at
+	// the app layer (not a DB unique index) because pre-existing rows may already
+	// hold duplicate names — a unique index would break AutoMigrate on them.
+	var dup int64
+	if err := s.db.WithContext(ctx).Model(&model.APIKey{}).
+		Where("owner_user_id = ? AND name = ?", ownerID, name).Count(&dup).Error; err != nil {
+		return "", nil, err
+	}
+	if dup > 0 {
+		return "", nil, ErrAPIKeyNameTaken
+	}
+
 	keyID := randBase62(keyIDLen)   // public lookup half
 	secret := randBase62(secretLen) // the secret half
 

--- a/bkn-safe/server/internal/auth/apikey_test.go
+++ b/bkn-safe/server/internal/auth/apikey_test.go
@@ -1,0 +1,183 @@
+package auth
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/glebarez/sqlite"
+	"gorm.io/gorm"
+
+	"bkn-safe/internal/database"
+	"bkn-safe/internal/model"
+)
+
+func newAPIKeyStore(t *testing.T) (*APIKeyStore, *gorm.DB) {
+	t.Helper()
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	if err != nil {
+		t.Fatalf("open sqlite: %v", err)
+	}
+	if err := database.Migrate(db); err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+	return NewAPIKeyStore(db), db
+}
+
+func seedUser(t *testing.T, db *gorm.DB, id string, enabled bool, at model.AccountType) {
+	t.Helper()
+	if err := db.Create(&model.User{ID: id, Account: id, Enabled: enabled, AccountType: at}).Error; err != nil {
+		t.Fatalf("seed user: %v", err)
+	}
+}
+
+func TestIssueAndVerify(t *testing.T) {
+	s, db := newAPIKeyStore(t)
+	ctx := context.Background()
+	seedUser(t, db, "u-1", true, model.AccountTypeOther)
+
+	plaintext, rec, err := s.Issue(ctx, "u-1", "ci-bot", nil) // never expires
+	if err != nil {
+		t.Fatalf("issue: %v", err)
+	}
+	if !strings.HasPrefix(plaintext, KeyPrefix) {
+		t.Errorf("plaintext missing prefix: %q", plaintext)
+	}
+	if rec.SecretHash == "" || strings.Contains(plaintext, rec.SecretHash) {
+		t.Errorf("secret must be hashed at rest and not equal plaintext")
+	}
+
+	v, err := s.Verify(ctx, plaintext)
+	if err != nil {
+		t.Fatalf("verify: %v", err)
+	}
+	if v.OwnerID != "u-1" || v.AccountType != model.AccountTypeOther {
+		t.Errorf("verify identity = %+v, want owner u-1 / other", v)
+	}
+
+	// LastUsedAt is stamped on successful verify.
+	var after model.APIKey
+	if err := db.First(&after, "key_id = ?", v.KeyID).Error; err != nil {
+		t.Fatal(err)
+	}
+	if after.LastUsedAt == nil {
+		t.Error("LastUsedAt not stamped after verify")
+	}
+}
+
+func TestVerifyAppAccountType(t *testing.T) {
+	s, db := newAPIKeyStore(t)
+	ctx := context.Background()
+	seedUser(t, db, "app-1", true, model.AccountTypeApp)
+	plaintext, _, _ := s.Issue(ctx, "app-1", "svc", nil)
+	v, err := s.Verify(ctx, plaintext)
+	if err != nil || v.AccountType != model.AccountTypeApp {
+		t.Fatalf("app key verify = %+v err=%v", v, err)
+	}
+}
+
+func TestVerifyWrongSecret(t *testing.T) {
+	s, db := newAPIKeyStore(t)
+	ctx := context.Background()
+	seedUser(t, db, "u-1", true, model.AccountTypeOther)
+	plaintext, _, _ := s.Issue(ctx, "u-1", "k", nil)
+
+	// Flip the last char of the secret half.
+	tampered := plaintext[:len(plaintext)-1] + flip(plaintext[len(plaintext)-1])
+	if _, err := s.Verify(ctx, tampered); !errors.Is(err, ErrAPIKeyInvalid) {
+		t.Errorf("tampered secret: want ErrAPIKeyInvalid, got %v", err)
+	}
+}
+
+func TestVerifyExpired(t *testing.T) {
+	s, db := newAPIKeyStore(t)
+	ctx := context.Background()
+	seedUser(t, db, "u-1", true, model.AccountTypeOther)
+	past := time.Now().Add(-time.Hour)
+	plaintext, _, _ := s.Issue(ctx, "u-1", "k", &past)
+	if _, err := s.Verify(ctx, plaintext); !errors.Is(err, ErrAPIKeyInvalid) {
+		t.Errorf("expired: want ErrAPIKeyInvalid, got %v", err)
+	}
+}
+
+func TestVerifyDisabledKey(t *testing.T) {
+	s, db := newAPIKeyStore(t)
+	ctx := context.Background()
+	seedUser(t, db, "u-1", true, model.AccountTypeOther)
+	plaintext, rec, _ := s.Issue(ctx, "u-1", "k", nil)
+	db.Model(&model.APIKey{}).Where("id = ?", rec.ID).Update("enabled", false)
+	if _, err := s.Verify(ctx, plaintext); !errors.Is(err, ErrAPIKeyInvalid) {
+		t.Errorf("disabled key: want ErrAPIKeyInvalid, got %v", err)
+	}
+}
+
+func TestVerifyDisabledOwnerInvalidatesKey(t *testing.T) {
+	s, db := newAPIKeyStore(t)
+	ctx := context.Background()
+	seedUser(t, db, "u-1", true, model.AccountTypeOther)
+	plaintext, _, _ := s.Issue(ctx, "u-1", "k", nil)
+	// Disabling the owner must immediately invalidate its keys.
+	db.Model(&model.User{}).Where("id = ?", "u-1").Update("enabled", false)
+	if _, err := s.Verify(ctx, plaintext); !errors.Is(err, ErrAPIKeyInvalid) {
+		t.Errorf("disabled owner: want ErrAPIKeyInvalid, got %v", err)
+	}
+}
+
+func TestVerifyMalformed(t *testing.T) {
+	s, _ := newAPIKeyStore(t)
+	ctx := context.Background()
+	for _, bad := range []string{"", "notakey", "bak_", "bak_onlyid", "ory_at_xyz", KeyPrefix + "_"} {
+		if _, err := s.Verify(ctx, bad); !errors.Is(err, ErrAPIKeyInvalid) {
+			t.Errorf("malformed %q: want ErrAPIKeyInvalid, got %v", bad, err)
+		}
+	}
+}
+
+func TestDeleteOwnedGuardsOwnership(t *testing.T) {
+	s, db := newAPIKeyStore(t)
+	ctx := context.Background()
+	seedUser(t, db, "u-1", true, model.AccountTypeOther)
+	seedUser(t, db, "u-2", true, model.AccountTypeOther)
+	plaintext, rec, _ := s.Issue(ctx, "u-1", "k", nil)
+
+	// Another user cannot revoke u-1's key.
+	if err := s.DeleteOwned(ctx, "u-2", rec.ID); !errors.Is(err, gorm.ErrRecordNotFound) {
+		t.Errorf("cross-owner delete: want ErrRecordNotFound, got %v", err)
+	}
+	// The owner can, after which the key no longer verifies.
+	if err := s.DeleteOwned(ctx, "u-1", rec.ID); err != nil {
+		t.Fatalf("owner delete: %v", err)
+	}
+	if _, err := s.Verify(ctx, plaintext); !errors.Is(err, ErrAPIKeyInvalid) {
+		t.Errorf("verify after revoke: want ErrAPIKeyInvalid, got %v", err)
+	}
+}
+
+func TestListByOwnerExcludesOthers(t *testing.T) {
+	s, db := newAPIKeyStore(t)
+	ctx := context.Background()
+	seedUser(t, db, "u-1", true, model.AccountTypeOther)
+	seedUser(t, db, "u-2", true, model.AccountTypeOther)
+	s.Issue(ctx, "u-1", "a", nil)
+	s.Issue(ctx, "u-1", "b", nil)
+	s.Issue(ctx, "u-2", "c", nil)
+
+	mine, err := s.ListByOwner(ctx, "u-1")
+	if err != nil || len(mine) != 2 {
+		t.Fatalf("ListByOwner u-1 = %d err=%v, want 2", len(mine), err)
+	}
+	all, err := s.ListAll(ctx, "")
+	if err != nil || len(all) != 3 {
+		t.Fatalf("ListAll = %d err=%v, want 3", len(all), err)
+	}
+}
+
+// flip returns a hex char different from b (to corrupt a secret deterministically).
+func flip(b byte) string {
+	if b == 'a' {
+		return "b"
+	}
+	return "a"
+}

--- a/bkn-safe/server/internal/auth/apikey_test.go
+++ b/bkn-safe/server/internal/auth/apikey_test.go
@@ -206,6 +206,33 @@ func TestRegenerate(t *testing.T) {
 	}
 }
 
+// TestIssueDuplicateNamePerOwner: a user can't reuse a name; different users can.
+func TestIssueDuplicateNamePerOwner(t *testing.T) {
+	s, db := newAPIKeyStore(t)
+	ctx := context.Background()
+	seedUser(t, db, "u-1", true, model.AccountTypeOther)
+	seedUser(t, db, "u-2", true, model.AccountTypeOther)
+
+	if _, _, err := s.Issue(ctx, "u-1", "ci", nil); err != nil {
+		t.Fatalf("first issue: %v", err)
+	}
+	if _, _, err := s.Issue(ctx, "u-1", "ci", nil); !errors.Is(err, ErrAPIKeyNameTaken) {
+		t.Errorf("dup name same owner: want ErrAPIKeyNameTaken, got %v", err)
+	}
+	// different owner, same name -> allowed
+	if _, _, err := s.Issue(ctx, "u-2", "ci", nil); err != nil {
+		t.Errorf("same name different owner should be allowed, got %v", err)
+	}
+	// after deleting, the name frees up
+	mine, _ := s.ListByOwner(ctx, "u-1")
+	if err := s.DeleteOwned(ctx, "u-1", mine[0].ID); err != nil {
+		t.Fatal(err)
+	}
+	if _, _, err := s.Issue(ctx, "u-1", "ci", nil); err != nil {
+		t.Errorf("reissue after delete should succeed, got %v", err)
+	}
+}
+
 // TestKeyFormat: the plaintext is the compact base62 shape and not absurdly long.
 func TestKeyFormat(t *testing.T) {
 	s, db := newAPIKeyStore(t)

--- a/bkn-safe/server/internal/auth/apikey_test.go
+++ b/bkn-safe/server/internal/auth/apikey_test.go
@@ -174,7 +174,57 @@ func TestListByOwnerExcludesOthers(t *testing.T) {
 	}
 }
 
-// flip returns a hex char different from b (to corrupt a secret deterministically).
+// TestRegenerate: rotating the secret invalidates the old plaintext, the new one
+// verifies, and the row identity (id/KeyID) is preserved.
+func TestRegenerate(t *testing.T) {
+	s, db := newAPIKeyStore(t)
+	ctx := context.Background()
+	seedUser(t, db, "u-1", true, model.AccountTypeOther)
+	old, rec, _ := s.Issue(ctx, "u-1", "k", nil)
+
+	// cross-owner cannot regenerate
+	if _, _, err := s.Regenerate(ctx, "u-2", rec.ID); !errors.Is(err, gorm.ErrRecordNotFound) {
+		t.Errorf("cross-owner regenerate: want ErrRecordNotFound, got %v", err)
+	}
+
+	fresh, rec2, err := s.Regenerate(ctx, "u-1", rec.ID)
+	if err != nil {
+		t.Fatalf("regenerate: %v", err)
+	}
+	if rec2.KeyID != rec.KeyID || rec2.ID != rec.ID {
+		t.Errorf("regenerate changed identity: %s/%s -> %s/%s", rec.ID, rec.KeyID, rec2.ID, rec2.KeyID)
+	}
+	if fresh == old {
+		t.Error("regenerate returned the same plaintext")
+	}
+	// old no longer verifies; new does
+	if _, err := s.Verify(ctx, old); !errors.Is(err, ErrAPIKeyInvalid) {
+		t.Errorf("old key after regenerate: want ErrAPIKeyInvalid, got %v", err)
+	}
+	if v, err := s.Verify(ctx, fresh); err != nil || v.OwnerID != "u-1" {
+		t.Errorf("new key verify = %+v err=%v", v, err)
+	}
+}
+
+// TestKeyFormat: the plaintext is the compact base62 shape and not absurdly long.
+func TestKeyFormat(t *testing.T) {
+	s, db := newAPIKeyStore(t)
+	seedUser(t, db, "u-1", true, model.AccountTypeOther)
+	plaintext, _, _ := s.Issue(context.Background(), "u-1", "k", nil)
+	if !strings.HasPrefix(plaintext, KeyPrefix) {
+		t.Fatalf("missing prefix: %q", plaintext)
+	}
+	if len(plaintext) > 60 { // ~44 expected; guard against hex-length regressions
+		t.Errorf("key too long (%d): %q", len(plaintext), plaintext)
+	}
+	body := strings.TrimPrefix(plaintext, KeyPrefix)
+	kid, secret, ok := strings.Cut(body, "_")
+	if !ok || len(kid) != keyIDLen || len(secret) != secretLen {
+		t.Errorf("unexpected shape: kid=%q secret=%q", kid, secret)
+	}
+}
+
+// flip returns a char different from b (to corrupt a secret deterministically).
 func flip(b byte) string {
 	if b == 'a' {
 		return "b"

--- a/bkn-safe/server/internal/httpapi/apikey.go
+++ b/bkn-safe/server/internal/httpapi/apikey.go
@@ -1,0 +1,182 @@
+package httpapi
+
+import (
+	"errors"
+	"net/http"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"gorm.io/gorm"
+
+	"bkn-safe/internal/auth"
+	"bkn-safe/internal/model"
+)
+
+// defaultKeyTTL is the validity granted when an issuer specifies neither an
+// explicit expires_at nor never_expire. Long-lived by design (the whole point of
+// an AppKey), but not unbounded — never-expire must be opted into explicitly.
+const defaultKeyTTL = 365 * 24 * time.Hour
+
+// registerMeAPIKeys mounts self-service AppKey management under /api/safe/v1/me/
+// api-keys (RequireUser): the caller issues/lists/revokes keys for ITSELF. The
+// owner is the verified token subject — never taken from the request body — so a
+// key can never be minted for, or read across, another identity.
+func registerMeAPIKeys(g *gin.RouterGroup, keys *auth.APIKeyStore) {
+	// POST /me/api-keys — issue a key. { name, expires_at?, never_expire? }
+	// expires_at: RFC3339; omitted -> default 1y; never_expire:true -> no expiry.
+	// Returns the plaintext key ONCE: { id, key_id, name, key, expires_at, created_at }.
+	g.POST("/api-keys", func(c *gin.Context) {
+		owner := c.GetString(ctxAccessorID)
+		var req struct {
+			Name        string  `json:"name" binding:"required"`
+			ExpiresAt   *string `json:"expires_at"`
+			NeverExpire bool    `json:"never_expire"`
+		}
+		if !bind(c, &req) {
+			return
+		}
+		exp, err := resolveExpiry(req.ExpiresAt, req.NeverExpire)
+		if err != nil {
+			c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+			return
+		}
+		plaintext, rec, err := keys.Issue(c.Request.Context(), owner, req.Name, exp)
+		if err != nil {
+			serverError(c, err)
+			return
+		}
+		body := apiKeyJSON(*rec, false)
+		body["key"] = plaintext // shown exactly once
+		c.JSON(http.StatusCreated, body)
+	})
+
+	// GET /me/api-keys — list the caller's keys (no secret). -> { keys:[...] }
+	g.GET("/api-keys", func(c *gin.Context) {
+		owner := c.GetString(ctxAccessorID)
+		list, err := keys.ListByOwner(c.Request.Context(), owner)
+		if err != nil {
+			serverError(c, err)
+			return
+		}
+		c.JSON(http.StatusOK, gin.H{"keys": apiKeysJSON(list, false)})
+	})
+
+	// DELETE /me/api-keys/:id — revoke one of the caller's own keys.
+	g.DELETE("/api-keys/:id", func(c *gin.Context) {
+		owner := c.GetString(ctxAccessorID)
+		err := keys.DeleteOwned(c.Request.Context(), owner, c.Param("id"))
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			c.JSON(http.StatusNotFound, gin.H{"error": "api key not found"})
+			return
+		}
+		if err != nil {
+			serverError(c, err)
+			return
+		}
+		c.Status(http.StatusNoContent)
+	})
+}
+
+// registerAdminAPIKeys mounts global AppKey oversight under /api/safe/v1/admin/
+// api-keys (RequireAdmin): list/revoke ANY user's keys for audit and incident
+// response.
+func registerAdminAPIKeys(g *gin.RouterGroup, keys *auth.APIKeyStore) {
+	// GET /admin/api-keys?owner_id= — list all keys (optionally one owner's).
+	g.GET("/api-keys", func(c *gin.Context) {
+		list, err := keys.ListAll(c.Request.Context(), c.Query("owner_id"))
+		if err != nil {
+			serverError(c, err)
+			return
+		}
+		c.JSON(http.StatusOK, gin.H{"keys": apiKeysJSON(list, true)})
+	})
+
+	// DELETE /admin/api-keys/:id — revoke any key by id.
+	g.DELETE("/api-keys/:id", func(c *gin.Context) {
+		err := keys.Delete(c.Request.Context(), c.Param("id"))
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			c.JSON(http.StatusNotFound, gin.H{"error": "api key not found"})
+			return
+		}
+		if err != nil {
+			serverError(c, err)
+			return
+		}
+		c.Status(http.StatusNoContent)
+	})
+}
+
+// registerAPIKeyVerify mounts the internal AppKey verification endpoint —
+// tokenless, ClusterIP-internal (same trust face as /authz and /directory). The
+// MCP/REST gateway calls it to resolve an AppKey to its owner identity. Response
+// mirrors OAuth2 introspection: 200 { active:false } on any failure (no leak of
+// why), 200 { active:true, sub, account_type, key_id } on success.
+func registerAPIKeyVerify(r gin.IRoutes, keys *auth.APIKeyStore) {
+	r.POST("/api/safe/v1/api-keys/introspect", func(c *gin.Context) {
+		var req struct {
+			Token string `json:"token" binding:"required"`
+		}
+		if !bind(c, &req) {
+			return
+		}
+		v, err := keys.Verify(c.Request.Context(), req.Token)
+		if err != nil {
+			// Includes ErrAPIKeyInvalid (expected) and DB errors; both => not active.
+			c.JSON(http.StatusOK, gin.H{"active": false})
+			return
+		}
+		c.JSON(http.StatusOK, gin.H{
+			"active":       true,
+			"sub":          v.OwnerID,
+			"account_type": v.AccountType,
+			"key_id":       v.KeyID,
+		})
+	})
+}
+
+// resolveExpiry turns the issue request's expiry inputs into a concrete pointer:
+// never_expire -> nil; explicit RFC3339 expires_at -> that instant (must be in
+// the future); neither -> now + defaultKeyTTL.
+func resolveExpiry(expiresAt *string, neverExpire bool) (*time.Time, error) {
+	if neverExpire {
+		return nil, nil
+	}
+	if expiresAt != nil && *expiresAt != "" {
+		t, err := time.Parse(time.RFC3339, *expiresAt)
+		if err != nil {
+			return nil, errors.New("expires_at must be RFC3339")
+		}
+		if !t.After(time.Now()) {
+			return nil, errors.New("expires_at must be in the future")
+		}
+		return &t, nil
+	}
+	t := time.Now().Add(defaultKeyTTL)
+	return &t, nil
+}
+
+// apiKeyJSON renders a key for API responses WITHOUT any secret. includeOwner
+// adds owner_user_id (admin views).
+func apiKeyJSON(k model.APIKey, includeOwner bool) gin.H {
+	h := gin.H{
+		"id":           k.ID,
+		"key_id":       k.KeyID,
+		"name":         k.Name,
+		"enabled":      k.Enabled,
+		"expires_at":   k.ExpiresAt,  // null = never expires
+		"last_used_at": k.LastUsedAt, // null = never used
+		"created_at":   k.CreatedAt,
+	}
+	if includeOwner {
+		h["owner_user_id"] = k.OwnerUserID
+	}
+	return h
+}
+
+func apiKeysJSON(list []model.APIKey, includeOwner bool) []gin.H {
+	out := make([]gin.H, 0, len(list))
+	for _, k := range list {
+		out = append(out, apiKeyJSON(k, includeOwner))
+	}
+	return out
+}

--- a/bkn-safe/server/internal/httpapi/apikey.go
+++ b/bkn-safe/server/internal/httpapi/apikey.go
@@ -41,6 +41,10 @@ func registerMeAPIKeys(g *gin.RouterGroup, keys *auth.APIKeyStore) {
 			return
 		}
 		plaintext, rec, err := keys.Issue(c.Request.Context(), owner, req.Name, exp)
+		if errors.Is(err, auth.ErrAPIKeyNameTaken) {
+			c.JSON(http.StatusConflict, gin.H{"error": "an api key with this name already exists"})
+			return
+		}
 		if err != nil {
 			serverError(c, err)
 			return

--- a/bkn-safe/server/internal/httpapi/apikey.go
+++ b/bkn-safe/server/internal/httpapi/apikey.go
@@ -75,6 +75,25 @@ func registerMeAPIKeys(g *gin.RouterGroup, keys *auth.APIKeyStore) {
 		}
 		c.Status(http.StatusNoContent)
 	})
+
+	// POST /me/api-keys/:id/regenerate — rotate the secret of the caller's own
+	// key (lost it / suspected leak). Old plaintext stops working immediately;
+	// the new plaintext is returned ONCE. Same id/name/expiry.
+	g.POST("/api-keys/:id/regenerate", func(c *gin.Context) {
+		owner := c.GetString(ctxAccessorID)
+		plaintext, rec, err := keys.Regenerate(c.Request.Context(), owner, c.Param("id"))
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			c.JSON(http.StatusNotFound, gin.H{"error": "api key not found"})
+			return
+		}
+		if err != nil {
+			serverError(c, err)
+			return
+		}
+		body := apiKeyJSON(*rec, false)
+		body["key"] = plaintext // shown exactly once
+		c.JSON(http.StatusOK, body)
+	})
 }
 
 // registerAdminAPIKeys mounts global AppKey oversight under /api/safe/v1/admin/

--- a/bkn-safe/server/internal/httpapi/apikey_test.go
+++ b/bkn-safe/server/internal/httpapi/apikey_test.go
@@ -220,6 +220,52 @@ func TestAPIKeyIntrospect(t *testing.T) {
 	}
 }
 
+// TestAPIKeyRegenerate: rotate returns a new one-time plaintext; the old key is
+// rejected by introspect, the new one is accepted; same id.
+func TestAPIKeyRegenerate(t *testing.T) {
+	r, _, db, _ := newAdminServer(t)
+	db.Create(&model.User{ID: "u-rg", Account: "rg", Enabled: true, AccountType: model.AccountTypeOther})
+
+	w := tokReq(t, r, http.MethodPost, meKeys, map[string]any{"name": "rg"}, "u-rg")
+	var first issued
+	_ = json.Unmarshal(w.Body.Bytes(), &first)
+
+	w = tokReq(t, r, http.MethodPost, meKeys+"/"+first.ID+"/regenerate", nil, "u-rg")
+	if w.Code != http.StatusOK {
+		t.Fatalf("regenerate: want 200, got %d (%s)", w.Code, w.Body.String())
+	}
+	var second issued
+	if err := json.Unmarshal(w.Body.Bytes(), &second); err != nil {
+		t.Fatal(err)
+	}
+	if second.ID != first.ID {
+		t.Errorf("regenerate changed id: %s -> %s", first.ID, second.ID)
+	}
+	if second.Key == "" || second.Key == first.Key {
+		t.Errorf("regenerate must return a new plaintext key")
+	}
+
+	introspect := func(token string) bool {
+		w := tokReq(t, r, http.MethodPost, introsURL, map[string]any{"token": token}, "")
+		var ir struct {
+			Active bool `json:"active"`
+		}
+		_ = json.Unmarshal(w.Body.Bytes(), &ir)
+		return ir.Active
+	}
+	if introspect(first.Key) {
+		t.Error("old key must be inactive after regenerate")
+	}
+	if !introspect(second.Key) {
+		t.Error("new key must be active after regenerate")
+	}
+
+	// regenerate of a non-owned / missing key -> 404
+	if w := tokReq(t, r, http.MethodPost, meKeys+"/nope/regenerate", nil, "u-rg"); w.Code != http.StatusNotFound {
+		t.Errorf("regenerate missing: want 404, got %d", w.Code)
+	}
+}
+
 // TestAPIKeyAdmin covers admin oversight: list all (with owner), filter, revoke
 // any; and that a non-admin is rejected.
 func TestAPIKeyAdmin(t *testing.T) {

--- a/bkn-safe/server/internal/httpapi/apikey_test.go
+++ b/bkn-safe/server/internal/httpapi/apikey_test.go
@@ -96,6 +96,24 @@ func TestAPIKeyIssueListRevoke(t *testing.T) {
 	}
 }
 
+// TestAPIKeyDuplicateName: issuing a second key with the same name -> 409.
+func TestAPIKeyDuplicateName(t *testing.T) {
+	r, _, db, _ := newAdminServer(t)
+	db.Create(&model.User{ID: "u-dup", Account: "dup", Enabled: true})
+
+	if w := tokReq(t, r, http.MethodPost, meKeys, map[string]any{"name": "same"}, "u-dup"); w.Code != http.StatusCreated {
+		t.Fatalf("first: want 201, got %d", w.Code)
+	}
+	if w := tokReq(t, r, http.MethodPost, meKeys, map[string]any{"name": "same"}, "u-dup"); w.Code != http.StatusConflict {
+		t.Errorf("dup name: want 409, got %d (%s)", w.Code, w.Body.String())
+	}
+	// different owner, same name -> ok
+	db.Create(&model.User{ID: "u-dup2", Account: "dup2", Enabled: true})
+	if w := tokReq(t, r, http.MethodPost, meKeys, map[string]any{"name": "same"}, "u-dup2"); w.Code != http.StatusCreated {
+		t.Errorf("other owner same name: want 201, got %d", w.Code)
+	}
+}
+
 // TestAPIKeyExpiryRules covers resolveExpiry via the handler: default 1y,
 // never_expire -> null, explicit future, and the 400s.
 func TestAPIKeyExpiryRules(t *testing.T) {

--- a/bkn-safe/server/internal/httpapi/apikey_test.go
+++ b/bkn-safe/server/internal/httpapi/apikey_test.go
@@ -1,0 +1,268 @@
+package httpapi
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"bkn-safe/internal/auth"
+	"bkn-safe/internal/model"
+)
+
+const (
+	meKeys    = "/api/safe/v1/me/api-keys"
+	adminKeys = "/api/safe/v1/admin/api-keys"
+	introsURL = "/api/safe/v1/api-keys/introspect"
+)
+
+// issued is the subset of the issue response the tests assert on.
+type issued struct {
+	ID        string  `json:"id"`
+	KeyID     string  `json:"key_id"`
+	Name      string  `json:"name"`
+	Key       string  `json:"key"`        // plaintext, returned exactly once
+	ExpiresAt *string `json:"expires_at"` // null = never expires
+}
+
+// TestAPIKeyIssueListRevoke covers the self-service happy path: issue returns a
+// one-time plaintext key; list never leaks a secret; revoke removes it.
+func TestAPIKeyIssueListRevoke(t *testing.T) {
+	r, _, db, _ := newAdminServer(t)
+	db.Create(&model.User{ID: "u-key", Account: "uk", Enabled: true})
+
+	// auth gate
+	if w := tokReq(t, r, http.MethodGet, meKeys, nil, ""); w.Code != http.StatusUnauthorized {
+		t.Fatalf("no token: want 401, got %d", w.Code)
+	}
+
+	w := tokReq(t, r, http.MethodPost, meKeys, map[string]any{"name": "k1"}, "u-key")
+	if w.Code != http.StatusCreated {
+		t.Fatalf("issue: want 201, got %d (%s)", w.Code, w.Body.String())
+	}
+	var iss issued
+	if err := json.Unmarshal(w.Body.Bytes(), &iss); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.HasPrefix(iss.Key, auth.KeyPrefix) {
+		t.Errorf("plaintext key %q must start with %q", iss.Key, auth.KeyPrefix)
+	}
+	if iss.KeyID == "" || iss.ID == "" || iss.Name != "k1" {
+		t.Errorf("issue body = %+v", iss)
+	}
+	if iss.ExpiresAt == nil {
+		t.Error("default issue must have a non-null expires_at (1y)")
+	}
+
+	// list: exactly one, and the secret/plaintext must NOT be present
+	w = tokReq(t, r, http.MethodGet, meKeys, nil, "u-key")
+	if w.Code != http.StatusOK {
+		t.Fatalf("list: want 200, got %d", w.Code)
+	}
+	body := w.Body.String()
+	if strings.Contains(body, "secret") || strings.Contains(body, iss.Key) {
+		t.Errorf("list leaks secret: %s", body)
+	}
+	var listResp struct {
+		Keys []map[string]any `json:"keys"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &listResp); err != nil {
+		t.Fatal(err)
+	}
+	if len(listResp.Keys) != 1 || listResp.Keys[0]["name"] != "k1" {
+		t.Fatalf("list = %+v", listResp.Keys)
+	}
+	if _, hasKey := listResp.Keys[0]["key"]; hasKey {
+		t.Error("list must not contain the plaintext key field")
+	}
+
+	// revoke
+	if w := tokReq(t, r, http.MethodDelete, meKeys+"/"+iss.ID, nil, "u-key"); w.Code != http.StatusNoContent {
+		t.Fatalf("revoke: want 204, got %d (%s)", w.Code, w.Body.String())
+	}
+	// revoke again -> 404
+	if w := tokReq(t, r, http.MethodDelete, meKeys+"/"+iss.ID, nil, "u-key"); w.Code != http.StatusNotFound {
+		t.Errorf("re-revoke: want 404, got %d", w.Code)
+	}
+	// list empty
+	w = tokReq(t, r, http.MethodGet, meKeys, nil, "u-key")
+	if err := json.Unmarshal(w.Body.Bytes(), &listResp); err != nil {
+		t.Fatal(err)
+	}
+	if len(listResp.Keys) != 0 {
+		t.Errorf("after revoke list = %+v, want empty", listResp.Keys)
+	}
+}
+
+// TestAPIKeyExpiryRules covers resolveExpiry via the handler: default 1y,
+// never_expire -> null, explicit future, and the 400s.
+func TestAPIKeyExpiryRules(t *testing.T) {
+	r, _, db, _ := newAdminServer(t)
+	db.Create(&model.User{ID: "u-exp", Account: "ue", Enabled: true})
+
+	decode := func(w *httptest.ResponseRecorder) issued {
+		t.Helper()
+		var i issued
+		if err := json.Unmarshal(w.Body.Bytes(), &i); err != nil {
+			t.Fatalf("decode: %v (%s)", err, w.Body.String())
+		}
+		return i
+	}
+
+	// default -> ~1 year out
+	w := tokReq(t, r, http.MethodPost, meKeys, map[string]any{"name": "d"}, "u-exp")
+	i := decode(w)
+	if i.ExpiresAt == nil {
+		t.Fatal("default expires_at must be set")
+	}
+	exp, err := time.Parse(time.RFC3339, *i.ExpiresAt)
+	if err != nil {
+		t.Fatalf("parse expires_at: %v", err)
+	}
+	if d := time.Until(exp); d < 360*24*time.Hour || d > 366*24*time.Hour {
+		t.Errorf("default expiry %v not ~1y", d)
+	}
+
+	// never_expire -> null
+	w = tokReq(t, r, http.MethodPost, meKeys, map[string]any{"name": "n", "never_expire": true}, "u-exp")
+	if decode(w).ExpiresAt != nil {
+		t.Error("never_expire must yield null expires_at")
+	}
+
+	// explicit future -> honored
+	future := time.Now().Add(48 * time.Hour).UTC().Format(time.RFC3339)
+	w = tokReq(t, r, http.MethodPost, meKeys, map[string]any{"name": "f", "expires_at": future}, "u-exp")
+	if got := decode(w).ExpiresAt; got == nil {
+		t.Error("explicit expires_at dropped")
+	}
+
+	// past -> 400
+	past := time.Now().Add(-time.Hour).UTC().Format(time.RFC3339)
+	if w := tokReq(t, r, http.MethodPost, meKeys, map[string]any{"name": "p", "expires_at": past}, "u-exp"); w.Code != http.StatusBadRequest {
+		t.Errorf("past expires_at: want 400, got %d", w.Code)
+	}
+	// bad format -> 400
+	if w := tokReq(t, r, http.MethodPost, meKeys, map[string]any{"name": "b", "expires_at": "not-a-date"}, "u-exp"); w.Code != http.StatusBadRequest {
+		t.Errorf("bad expires_at: want 400, got %d", w.Code)
+	}
+	// missing name -> 400 (binding required)
+	if w := tokReq(t, r, http.MethodPost, meKeys, map[string]any{}, "u-exp"); w.Code != http.StatusBadRequest {
+		t.Errorf("missing name: want 400, got %d", w.Code)
+	}
+}
+
+// TestAPIKeyOwnershipIsolation: a user cannot see or revoke another user's keys.
+func TestAPIKeyOwnershipIsolation(t *testing.T) {
+	r, _, db, _ := newAdminServer(t)
+	db.Create(&model.User{ID: "owner-a", Account: "a", Enabled: true})
+	db.Create(&model.User{ID: "owner-b", Account: "b", Enabled: true})
+
+	w := tokReq(t, r, http.MethodPost, meKeys, map[string]any{"name": "a-key"}, "owner-a")
+	var ia issued
+	_ = json.Unmarshal(w.Body.Bytes(), &ia)
+
+	// B cannot delete A's key
+	if w := tokReq(t, r, http.MethodDelete, meKeys+"/"+ia.ID, nil, "owner-b"); w.Code != http.StatusNotFound {
+		t.Errorf("cross-owner delete: want 404, got %d", w.Code)
+	}
+	// B's list does not include A's key
+	w = tokReq(t, r, http.MethodGet, meKeys, nil, "owner-b")
+	var lr struct {
+		Keys []map[string]any `json:"keys"`
+	}
+	_ = json.Unmarshal(w.Body.Bytes(), &lr)
+	if len(lr.Keys) != 0 {
+		t.Errorf("owner-b sees %d keys, want 0", len(lr.Keys))
+	}
+}
+
+// TestAPIKeyIntrospect covers the internal verify endpoint shape: active:true
+// resolves owner identity; bogus and revoked keys return active:false.
+func TestAPIKeyIntrospect(t *testing.T) {
+	r, _, db, _ := newAdminServer(t)
+	db.Create(&model.User{ID: "u-intro", Account: "ui", Enabled: true, AccountType: model.AccountTypeOther})
+
+	w := tokReq(t, r, http.MethodPost, meKeys, map[string]any{"name": "ik"}, "u-intro")
+	var iss issued
+	_ = json.Unmarshal(w.Body.Bytes(), &iss)
+
+	type introResp struct {
+		Active      bool   `json:"active"`
+		Sub         string `json:"sub"`
+		AccountType string `json:"account_type"`
+		KeyID       string `json:"key_id"`
+	}
+	post := func(token string) introResp {
+		t.Helper()
+		w := tokReq(t, r, http.MethodPost, introsURL, map[string]any{"token": token}, "")
+		if w.Code != http.StatusOK {
+			t.Fatalf("introspect: want 200, got %d", w.Code)
+		}
+		var ir introResp
+		if err := json.Unmarshal(w.Body.Bytes(), &ir); err != nil {
+			t.Fatal(err)
+		}
+		return ir
+	}
+
+	if ir := post(iss.Key); !ir.Active || ir.Sub != "u-intro" || ir.AccountType != string(model.AccountTypeOther) || ir.KeyID != iss.KeyID {
+		t.Errorf("valid introspect = %+v", ir)
+	}
+	if ir := post("bak_dead_beef"); ir.Active {
+		t.Error("bogus key must be inactive")
+	}
+	// revoke then introspect -> inactive
+	_ = tokReq(t, r, http.MethodDelete, meKeys+"/"+iss.ID, nil, "u-intro")
+	if ir := post(iss.Key); ir.Active {
+		t.Error("revoked key must be inactive")
+	}
+}
+
+// TestAPIKeyAdmin covers admin oversight: list all (with owner), filter, revoke
+// any; and that a non-admin is rejected.
+func TestAPIKeyAdmin(t *testing.T) {
+	r, _, db, _ := newAdminServer(t)
+	db.Create(&model.User{ID: "u-a1", Account: "a1", Enabled: true})
+
+	w := tokReq(t, r, http.MethodPost, meKeys, map[string]any{"name": "ak"}, "u-a1")
+	var iss issued
+	_ = json.Unmarshal(w.Body.Bytes(), &iss)
+
+	// non-admin -> 403
+	if w := tokReq(t, r, http.MethodGet, adminKeys, nil, "u-a1"); w.Code != http.StatusForbidden {
+		t.Errorf("non-admin admin-list: want 403, got %d", w.Code)
+	}
+
+	// admin list shows owner_user_id
+	w = adminReq(t, r, http.MethodGet, adminKeys, nil)
+	if w.Code != http.StatusOK {
+		t.Fatalf("admin list: want 200, got %d", w.Code)
+	}
+	var lr struct {
+		Keys []map[string]any `json:"keys"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &lr); err != nil {
+		t.Fatal(err)
+	}
+	if len(lr.Keys) != 1 || lr.Keys[0]["owner_user_id"] != "u-a1" {
+		t.Fatalf("admin list = %+v", lr.Keys)
+	}
+
+	// filter by owner
+	if w := adminReq(t, r, http.MethodGet, adminKeys+"?owner_id=nobody", nil); w.Code == http.StatusOK {
+		var f struct {
+			Keys []map[string]any `json:"keys"`
+		}
+		_ = json.Unmarshal(w.Body.Bytes(), &f)
+		if len(f.Keys) != 0 {
+			t.Errorf("owner filter = %+v, want empty", f.Keys)
+		}
+	}
+
+	// admin revokes any key
+	if w := adminReq(t, r, http.MethodDelete, adminKeys+"/"+iss.ID, nil); w.Code != http.StatusNoContent {
+		t.Errorf("admin revoke: want 204, got %d", w.Code)
+	}
+}

--- a/bkn-safe/server/internal/httpapi/router.go
+++ b/bkn-safe/server/internal/httpapi/router.go
@@ -46,6 +46,17 @@ func New(deps Deps) *gin.Engine {
 	// their own boundary and pass accessor_id.
 	registerAuthz(r, deps.Enforcer, deps.DB)
 
+	// AppKey (user-issued API key) store. Verification is internal, tokenless and
+	// ClusterIP-only (same trust face as /authz) — the Context Loader MCP/REST
+	// gateway calls /api/safe/v1/api-keys/introspect to resolve a key to its
+	// owner. Self-service issue/list/revoke is mounted on /me, admin oversight on
+	// /admin (both token-gated, below).
+	var apiKeys *auth.APIKeyStore
+	if deps.DB != nil {
+		apiKeys = auth.NewAPIKeyStore(deps.DB)
+		registerAPIKeyVerify(r, apiKeys)
+	}
+
 	// hydra login/consent/device provider pages.
 	if deps.Provider != nil && deps.Hydra != nil {
 		registerAuth(r, deps.Provider, deps.Hydra)
@@ -83,6 +94,10 @@ func New(deps Deps) *gin.Engine {
 		registerRoleBindings(admin, deps.Enforcer, deps.DB)
 		registerRoles(admin, deps.Enforcer, deps.DB)
 		registerObjectGrants(admin, deps.Enforcer, deps.DB)
+		// Global AppKey oversight: list/revoke any user's keys.
+		if apiKeys != nil {
+			registerAdminAPIKeys(admin, apiKeys)
+		}
 		// Login-client redirect-uri management. Falls back to Hydra in production;
 		// only mounted when a manager is available.
 		clientMgr := deps.ClientAdmin
@@ -99,6 +114,10 @@ func New(deps Deps) *gin.Engine {
 	if deps.Enforcer != nil && verifier != nil && deps.Directory != nil {
 		me := r.Group("/api/safe/v1/me", RequireUser(verifier))
 		registerMe(me, deps.Enforcer, deps.DB, deps.Directory)
+		// Self-service AppKey management (issue/list/revoke own keys).
+		if apiKeys != nil {
+			registerMeAPIKeys(me, apiKeys)
+		}
 	}
 
 	return r

--- a/bkn-safe/server/internal/model/model.go
+++ b/bkn-safe/server/internal/model/model.go
@@ -144,11 +144,33 @@ type AuditLog struct {
 	CreatedAt time.Time `json:"created_at" gorm:"index"`
 }
 
+// APIKey is a user-issued long-lived credential (AppKey). It authenticates AS its
+// owner: verification resolves the owner's id + account_type, so downstream authz
+// is identical to the owner using an OAuth token (no second permission system).
+//
+// The plaintext key has the shape "bak_<KeyID>_<secret>" and is shown ONCE at
+// issue time; only SecretHash (sha256 hex of the secret half) is stored. KeyID is
+// the public, indexed lookup half. Revoke deletes the row; Enabled is a defensive
+// soft-disable flag also checked on every verify. ExpiresAt nil = never expires.
+type APIKey struct {
+	ID          string `gorm:"primaryKey;size:64"`  // internal row id
+	KeyID       string `gorm:"uniqueIndex;size:64"` // public lookup half, embedded in the key
+	OwnerUserID string `gorm:"size:64;index"`       // User.ID this key acts as
+	Name        string `gorm:"size:128"`            // user-facing label
+	SecretHash  string `gorm:"size:128"`            // sha256 hex of the secret half
+	// ExpiresAt nil = never expires (explicit opt-in by the issuer). LastUsedAt is
+	// updated on each successful verify so stale/leaked keys can be spotted/reaped.
+	ExpiresAt  *time.Time `gorm:"index"`
+	LastUsedAt *time.Time
+	Enabled    bool
+	CreatedAt  time.Time
+}
+
 // AllModels is the migration set (Casbin's table is managed by its adapter).
 func AllModels() []any {
 	return []any{
 		&User{}, &Role{}, &Department{}, &UserDepartment{},
 		&Group{}, &GroupMember{}, &ResourceType{}, &Operation{},
-		&AuditLog{},
+		&AuditLog{}, &APIKey{},
 	}
 }

--- a/docs/appkey-design.md
+++ b/docs/appkey-design.md
@@ -64,13 +64,20 @@ AppKey 引入**用户自助签发的长期凭据**，以签发者本人身份鉴
 
 ## 4. Key 格式与哈希
 
-明文形状：`bak_<keyid>_<secret>`
+明文形状：`bak_<keyid>_<secret>`（约 44 字符，对标 GitHub/Stripe token）
 
 - `bak_` —— AppKey 前缀（`bkn app key`），网关分流判据 + 密钥扫描器/日志脱敏可识别。常量 `auth.KeyPrefix`（bkn-safe）与 `interfaces.AppKeyPrefix`（agent-retrieval）**两处必须一致**。
-- `keyid` —— 128-bit 随机 hex，公开，按它查行。
-- `secret` —— 256-bit 随机 hex，**只存 sha256**，明文仅签发时返回一次（show-once）。
+- `keyid` —— 12 位 base62（~71 bit），公开，按它查行。
+- `secret` —— 27 位 base62（~160 bit），**只存 sha256**，明文仅签发时返回一次（show-once）。
+- 用 **base62**（数字+字母，无 `_`/`-`）：分隔符 `_` 不歧义、URL/header 安全；随机用 crypto/rand + 拒绝采样（丢 ≥248 的字节）避免取模偏置。
 
 校验比对：按 `keyid` 查行 → `subtle.ConstantTimeCompare(sha256(secret), SecretHash)`。高熵随机串用 sha256 足够（非 bcrypt），保证每次请求校验廉价。
+
+### 轮换（regenerate）vs 可重看
+
+`POST /me/api-keys/:id/regenerate`：同 `id`/`KeyID`/`name`/有效期，换新 secret，旧明文立即失效，返回新一次性明文。这是**有意保留 show-once 的前提下**解决"丢了/疑似泄漏"的标准做法（GitHub "Regenerate token"）——不必删旧建新重配名字。
+
+明确**不做**"存下来可重看"：那要求存可解密凭据，DB/备份/日志任一泄漏即全量泄漏，破坏"只存哈希、泄库不致命"的核心性质。OpenAI/GitHub/Stripe/AWS 同样只 show-once。
 
 ---
 

--- a/docs/appkey-design.md
+++ b/docs/appkey-design.md
@@ -1,0 +1,153 @@
+# AppKey 设计与运维文档
+
+AppKey（用户自助签发的 API Key）的架构、数据模型、安全模型与部署说明。配套消费侧对接见 [appkey-integration.md](./appkey-integration.md)；需求/拆解见 Linear OPE-14、GitHub openbkn-ai/bkn-foundry#75。
+
+---
+
+## 1. 背景与目标
+
+Context Loader 的 MCP（`/api/agent-retrieval/v1/mcp`）与 REST（`/kn/*`）此前只接受 Hydra 签发的 OAuth access token（`ory_at_...`，~1h 过期）。外部客户端（Cursor / Claude Desktop / 脚本 / SDK）每次都要重新复制易过期 token，体验差。
+
+AppKey 引入**用户自助签发的长期凭据**，以签发者本人身份鉴权，权限同源；可自助签发 / 列出 / 撤销，管理员可全局管控。这是行业标准的 PAT（Personal Access Token）模式。
+
+非目标（v1 不做）：scope 细粒度限权、key 轮换接口、其它微服务接入、按账户类型限制签发。
+
+---
+
+## 2. 架构
+
+两个服务，单一咽喉：
+
+```
+客户端 ──Authorization: Bearer <凭据>──▶ agent-retrieval 网关
+                                          │ middlewareIntrospectVerify
+                                          │   token 前缀判别：
+                                          ├─ bak_…  ─▶ bkn-safe /api-keys/introspect ─▶ owner 身份
+                                          └─ 其余    ─▶ hydra /oauth2/introspect       ─▶ 用户身份
+                                          ▼
+                                   AccountAuthContext{AccountID, AccountType}
+                                          ▼
+                                   下游 casbin 授权（0 改动）
+```
+
+- **bkn-safe**：凭据权威。签发 / 存储 / 校验 / 撤销 AppKey。
+- **agent-retrieval**：消费方。仅在 `middlewareIntrospectVerify` 一处按 `bak_` 前缀分流；两条路产出**同一个** `*TokenInfo` → `AccountAuthContext`，下游一致。
+
+关键性质：AppKey 校验后解析出的是 **owner 的 accessor_id + account_type**，因此不是第二套权限系统 —— 授权完全复用用户本人的 casbin 策略。
+
+代码落点：
+- 网关分支：`adp/context-loader/agent-retrieval/server/driveradapters/middleware.go`（`middlewareIntrospectVerify`）
+- 验卡 adapter：`.../drivenadapters/appkey.go`
+- bkn-safe 凭据层：`bkn-safe/server/internal/auth/apikey.go`（store）、`.../internal/httpapi/apikey.go`（HTTP）、`.../internal/model/model.go`（`APIKey`）
+
+---
+
+## 3. 数据模型
+
+`APIKey`（GORM，AutoMigrate 建表 `api_keys`）：
+
+| 字段 | 类型 | 说明 |
+|---|---|---|
+| `ID` | string(64) PK | 行 id（删除 / 管理用） |
+| `KeyID` | string(64) uniqueIndex | 公开查找半段，嵌在明文里 |
+| `OwnerUserID` | string(64) index | 该 key 充当的 `User.ID` |
+| `Name` | string(128) | 用户可见标签 |
+| `SecretHash` | string(128) | secret 半段的 sha256 hex |
+| `ExpiresAt` | *time.Time index | nil = 永不过期 |
+| `LastUsedAt` | *time.Time | 每次成功校验更新 |
+| `Enabled` | bool | 防御性软禁用（校验也查） |
+| `CreatedAt` | time.Time | |
+
+注：撤销 = 删行（`DeleteOwned` / `Delete`）。`Enabled` 保留作未来"禁用不删"用途，校验路径也防御性检查。
+
+---
+
+## 4. Key 格式与哈希
+
+明文形状：`bak_<keyid>_<secret>`
+
+- `bak_` —— AppKey 前缀（`bkn app key`），网关分流判据 + 密钥扫描器/日志脱敏可识别。常量 `auth.KeyPrefix`（bkn-safe）与 `interfaces.AppKeyPrefix`（agent-retrieval）**两处必须一致**。
+- `keyid` —— 128-bit 随机 hex，公开，按它查行。
+- `secret` —— 256-bit 随机 hex，**只存 sha256**，明文仅签发时返回一次（show-once）。
+
+校验比对：按 `keyid` 查行 → `subtle.ConstantTimeCompare(sha256(secret), SecretHash)`。高熵随机串用 sha256 足够（非 bcrypt），保证每次请求校验廉价。
+
+---
+
+## 5. 信任面与端点
+
+| 端点 | 鉴权 | 暴露面 | 用途 |
+|---|---|---|---|
+| `POST/GET/DELETE /api/safe/v1/me/api-keys` | `RequireUser`（OAuth token） | 网关 | 用户自助签发/列出/撤销自己的 key |
+| `GET/DELETE /api/safe/v1/admin/api-keys` | `RequireAdmin` | 网关 | 管理员全局列出/撤销任意 key |
+| `POST /api/safe/v1/api-keys/introspect` | **免 token** | **仅 ClusterIP** | 网关验卡，解析 owner 身份 |
+
+验卡端点响应对齐 OAuth2 introspect：失败 `200 {active:false}`（不泄漏原因），成功 `200 {active:true, sub, account_type, key_id}`。
+
+> ⚠️ 验卡端点与 `/authz`、`/directory` 同信任面 —— **务必只在集群内网（ClusterIP）暴露**，不可经 ingress 对外。
+
+---
+
+## 6. 安全模型 / 威胁分析
+
+**核心约束**：AppKey 是 OAuth 身份的派生，不是平行身份提供者。
+
+- 签发必须有真实 OAuth 会话（`RequireUser`）→ key 权限永不超过本人。
+- bkn-safe 的 `RequireUser` 走 hydra 内省、**不认识 `bak_`** → 不能用 AppKey 调 `/me`、`/admin`、`/me/api-keys`。即**无"密钥造密钥"提权链**，AppKey 严格锁在 Context Loader 数据面。
+- 撤销即时生效（每次校验查库）。
+- owner 被禁用 / 删除 → 其 key 校验即失效（校验查 `User.Enabled`）。
+
+**爆炸半径**：AppKey 是一个与本人等权、长寿命的 bearer 凭据，会被塞进 MCP 客户端配置 / `.env` / shell history，泄漏面比交互 token 大。缓解：
+
+- 只存哈希、明文一次性。
+- `last_used_at` 落库 → 发现异常 / 清理僵尸 key。
+- 管理员全局撤销作为应急杠杆。
+- 默认 1 年而非永久；永不过期需显式勾选。
+
+**为何 v1 不做 scope**：先按 PAT 经典模式（全继承）落地；若 MCP key 跑在半可信环境，后续走 GitHub fine-grained PAT 路线加按工具/资源限权（v2）。
+
+**顺带清理**：公共链上客户端自带的 `x-account-id` / `x-account-type` 头在公共（introspect）链**不被读取**，但若被指到私有 header-trust 链存在冒充隐患 —— 文档/示例已移除这两个头。
+
+---
+
+## 7. 决策
+
+| 项 | 决策 |
+|---|---|
+| 默认有效期 | 1 年，可改 / 可设永不过期（显式勾选） |
+| scope 限权 | v1 不做，全继承 owner 权限 |
+| 管理员管控 | 可全局列出 / 撤销任意 key |
+| 创建鉴权 | 仅认证（OAuth 会话），不加额外授权门（无提权，符合 PAT 惯例） |
+| account_type 白名单 | 不做（明确否决） |
+
+---
+
+## 8. 运维 / 部署
+
+### bkn-safe
+- **无需 data-migrator**：表 `api_keys` 由启动时 GORM `AutoMigrate` 创建（`database.Migrate` → `model.AllModels()` 含 `APIKey`）。用 `kubectl set image` 升级也能自建表。
+- 验卡端点 `POST /api/safe/v1/api-keys/introspect` 随服务自动挂载（`deps.DB != nil` 时）。
+
+### agent-retrieval
+- 必须配置 bkn-safe 地址，否则 `bak_` 校验打到空 URL：
+  ```yaml
+  bkn_safe:
+    private_protocol: "http"
+    private_host: "bkn-safe"
+    private_port: 3000
+  ```
+  落点：`server/infra/config/config.go`（`BknSafe PrivateBaseConfig`）+ `agent-retrieval.yaml` + helm `configmap.yaml` / `values.yaml`。
+- `AUTH_ENABLED=false` 时 `NewAppKeyVerifier()` 返回 nil → `bak_` token 回落 hydra（noop），不崩。生效需 `AUTH_ENABLED=true`。
+- 改了配置需重启 pod（configmap 挂载文件）。
+
+### 验证（VM 已跑通）
+登录拿 OAuth token → `POST /me/api-keys` 拿 `bak_` → 当 `Authorization: Bearer` 调 `/mcp` 或 `/kn/*` → 撤销复验 401。完整矩阵见 OPE-14 评论 / [appkey-integration.md](./appkey-integration.md) §3。
+
+---
+
+## 9. 测试
+
+- bkn-safe store：`internal/auth/apikey_test.go`（签发/校验/过期/禁用/坏 secret/owner 禁用/越权删/列表隔离）。
+- bkn-safe httpapi：`internal/httpapi/apikey_test.go`（签发一次性明文/列表无 secret/撤销/`resolveExpiry` 默认1年·RFC3339·never_expire·过去时间400/越权删404/introspect active 形状/admin 管控/非管理员403）。
+- agent-retrieval adapter：`drivenadapters/appkey_test.go`（active→TokenInfo、account_type→VisitorType、inactive/HTTP/decode 错误）。
+- agent-retrieval 中间件：`driveradapters/appkey_middleware_test.go`（`bak_`→appkey、其余→hydra、nil verifier 回落）。

--- a/docs/appkey-integration.md
+++ b/docs/appkey-integration.md
@@ -63,6 +63,11 @@ base：`/api/safe/v1/me/api-keys`　鉴权：用户当前 OAuth token（`Authori
 - 用路径里的 `id`（不是 `key_id`）。成功 `204`，不存在/非本人 `404`。
 - 建议二次确认弹窗（撤销不可逆，且立即失效）。
 
+#### 轮换　`POST /api/safe/v1/me/api-keys/:id/regenerate`
+- 用途：**丢了 / 疑似泄漏** —— 不必删了重建重命名。同 `id`/`name`/有效期，换新 secret。
+- 旧明文**立即失效**，响应返回**新的一次性明文**（结构同签发：含 `key` 字段，只此一次）。成功 `200`，不存在/非本人 `404`。
+- 前端建议：key 条目上放个"重新生成"按钮 + 二次确认 + 新明文一次性展示。
+
 ### 1.2 管理员接口（治理 / 应急）
 
 base：`/api/safe/v1/admin/api-keys`　鉴权：管理员 OAuth token（`RequireAdmin`）

--- a/docs/appkey-integration.md
+++ b/docs/appkey-integration.md
@@ -49,6 +49,8 @@ base：`/api/safe/v1/me/api-keys`　鉴权：用户当前 OAuth token（`Authori
 ```
 > ⚠️ **`key` 字段是完整明文，只此一次**。前端必须：弹窗展示 + 一键复制 + 明确提示"关闭后无法再次查看"。**不要**把它存进任何可再次读取的地方。列表接口永远不会再返回它。
 
+> **名字按用户唯一**：同一用户已有同名 key 时签发返回 `409`（`{"error":"an api key with this name already exists"}`）。不同用户可同名。前端建议在签发前/提交时校验重名并给出友好提示。
+
 #### 列出　`GET /api/safe/v1/me/api-keys`
 ```json
 { "keys": [

--- a/docs/appkey-integration.md
+++ b/docs/appkey-integration.md
@@ -1,0 +1,153 @@
+# AppKey（用户自助签发的 API Key）对接文档
+
+面向**前端**（AppKey 管理页）与 **SDK / 外部客户端**（用 AppKey 访问 Context Loader）。
+
+实现见 issue #75，分支 `feat/app-key-auth`。已在 VM（`10.211.55.4`）端到端验证通过。
+
+---
+
+## 0. 一句话原理
+
+AppKey 是用户**自助签发的长期凭据**，以 `bak_` 开头。它**以签发者本人的身份**鉴权：校验后解析出 owner 的 `accessor_id` + `account_type`，下游授权与本人用 OAuth token 时**完全一致**，不是另一套权限。
+
+- **签发/管理**：走 bkn-safe，需要用户**当前的 OAuth 会话**（和调 `/me`、`/admin` 一样）。
+- **使用**：把 AppKey 当 `Authorization: Bearer` 用，**仅** Context Loader 的 MCP + REST 接口接受；平台其它服务仍要 OAuth token。
+- **撤销即时生效**（每次调用查库）。明文 key **只在签发时返回一次**，之后不可再取。
+
+---
+
+## 1. 前端：AppKey 管理页
+
+### 1.1 自助接口（用户管理自己的 key）
+
+base：`/api/safe/v1/me/api-keys`　鉴权：用户当前 OAuth token（`Authorization: Bearer <oauth-token>`）
+
+#### 签发　`POST /api/safe/v1/me/api-keys`
+
+请求：
+```json
+{ "name": "我的 Cursor", "expires_at": "2027-01-01T00:00:00Z", "never_expire": false }
+```
+| 字段 | 必填 | 说明 |
+|---|---|---|
+| `name` | 是 | 展示名，便于用户区分用途 |
+| `expires_at` | 否 | RFC3339；**省略 = 默认 1 年**；必须是将来时间，否则 400 |
+| `never_expire` | 否 | `true` = 永不过期（优先级高于 `expires_at`）。**建议做成需显式勾选 + 文案警示** |
+
+响应 `201`：
+```json
+{
+  "id": "7d6042...",
+  "key_id": "b3ffa7f4...",
+  "name": "我的 Cursor",
+  "key": "bak_b3ffa7f4..._fb74b234...",
+  "enabled": true,
+  "expires_at": "2027-06-26T11:49:59+02:00",
+  "last_used_at": null,
+  "created_at": "2026-06-26T11:49:59+02:00"
+}
+```
+> ⚠️ **`key` 字段是完整明文，只此一次**。前端必须：弹窗展示 + 一键复制 + 明确提示"关闭后无法再次查看"。**不要**把它存进任何可再次读取的地方。列表接口永远不会再返回它。
+
+#### 列出　`GET /api/safe/v1/me/api-keys`
+```json
+{ "keys": [
+  { "id": "...", "key_id": "b3ffa7f4...", "name": "我的 Cursor",
+    "enabled": true, "expires_at": "2027-...", "last_used_at": "2026-...", "created_at": "2026-..." }
+] }
+```
+- 无 secret。`last_used_at` 为 `null` 表示从未使用 —— 可用于"僵尸 key"提示。
+- `expires_at` 为 `null` 表示永不过期。
+
+#### 撤销　`DELETE /api/safe/v1/me/api-keys/:id`
+- 用路径里的 `id`（不是 `key_id`）。成功 `204`，不存在/非本人 `404`。
+- 建议二次确认弹窗（撤销不可逆，且立即失效）。
+
+### 1.2 管理员接口（治理 / 应急）
+
+base：`/api/safe/v1/admin/api-keys`　鉴权：管理员 OAuth token（`RequireAdmin`）
+
+- `GET /api/safe/v1/admin/api-keys?owner_id=<可选>` → 列出全部（或某用户）key，比自助多 `owner_user_id` 字段。
+- `DELETE /api/safe/v1/admin/api-keys/:id` → 撤销任意 key。
+
+> 管理员页用途：审计谁签了哪些 key、`last_used_at` 看活跃度、出事一键撤销。
+
+### 1.3 前端 UX 清单
+
+- [ ] 签发后明文一次性展示 + 复制 + "无法再次查看"提示
+- [ ] 有效期：默认 1 年；可选自定义日期；"永不过期"独立勾选 + 风险文案
+- [ ] 列表展示 `name / 创建时间 / 过期时间 / 最近使用 / 状态`
+- [ ] 撤销二次确认
+- [ ] 引导文案：告诉用户"把这个 key 填到 MCP 客户端 / SDK 的 Authorization 里，替代易过期的登录 token"
+- [ ] （管理员页）全量列表 + 按 owner 过滤 + 撤销
+
+---
+
+## 2. SDK / 外部客户端：用 AppKey 访问 Context Loader
+
+### 2.1 怎么用
+
+把 AppKey 放进 **`Authorization: Bearer`**，调 Context Loader：
+
+- MCP：`POST/GET https://<host>/api/agent-retrieval/v1/mcp` （Streamable HTTP）
+- REST：`POST https://<host>/api/agent-retrieval/v1/kn/*`
+
+网关按前缀自动分流：`bak_` → bkn-safe 验卡；其余 → 原 OAuth 内省。**两种凭据同一个 header、同一个端点，都能用**。
+
+### 2.2 MCP 客户端配置（Cursor / Claude Desktop 等）
+
+```json
+{
+  "mcpServers": {
+    "bkn-agent-retrieval": {
+      "type": "http",
+      "url": "https://<host>/api/agent-retrieval/v1/mcp",
+      "headers": {
+        "Authorization": "Bearer bak_<keyid>_<secret>"
+      }
+    }
+  }
+}
+```
+
+> 相比旧配置：**只需要 `Authorization` 一个头**。删掉 `x-account-id` / `x-account-type` —— 公共链上身份完全由凭据解析，这两个头不被读取（留着无用，且指向私有入口时有冒充隐患）。token 值从易过期的 `ory_at_...` 换成长期的 `bak_...` 即可，其余不变（drop-in）。
+
+### 2.3 REST 调用示例
+
+```bash
+curl -H "Authorization: Bearer bak_<keyid>_<secret>" \
+     -H "Content-Type: application/json" -d '{}' \
+     https://<host>/api/agent-retrieval/v1/kn/list_knowledge_networks
+```
+
+### 2.4 SDK 实现要点
+
+- 凭据来源：让用户在 SDK 配置里填 AppKey（从管理页复制）。SDK 不负责签发，只消费。
+- 注入方式：所有对 Context Loader 的请求统一加 `Authorization: Bearer <appkey>`。`getToken` 也兼容 `X-Authorization` 头与 `?token=` query，但**首选** `Authorization`。
+- 错误处理：
+  - `401` = key 无效 / 过期 / 已撤销 / owner 被禁用 → 提示用户去管理页**重新签发**（不要自动重试）。
+  - 其它 4xx/5xx 按正常 API 错误处理。
+- **范围限制**：AppKey **只**对 Context Loader MCP/REST 有效。SDK 若还要调 bkn-backend / vega / 其它服务，那些仍需 OAuth token —— 不要拿 AppKey 去调，会 401。
+- AppKey **不能**用来调 bkn-safe 的 `/me`、`/admin`、`/me/api-keys` —— 即不能用 AppKey 再签 AppKey（无提权链）。签发必须有真实 OAuth 会话。
+
+---
+
+## 3. 行为契约速查（已在 VM 验证）
+
+| 场景 | 结果 |
+|---|---|
+| 用 AppKey 调 Context Loader MCP/REST | 身份 = 签发者，授权同其本人 OAuth |
+| 用 OAuth token 调（旧方式） | 不受影响，照常工作 |
+| 无 token / 假 `bak_` / 过期 / 已撤销 key | `401` |
+| 撤销后立即复用 | 立刻 `401`（查库即时生效） |
+| 默认有效期 | 1 年（可改 / 可设永不过期） |
+| 权限范围 | v1 全继承 owner 权限，无 scope 细分 |
+| AppKey 调 bkn-safe `/me`、`/admin`、再签 key | `401`（仅数据面可用，无提权） |
+
+---
+
+## 4. 待补充（后续可做）
+
+- 前端 AppKey 管理页（本仓为后端，UI 在 Studio 前端仓）。
+- SDK 侧凭据配置 + 401 重签引导。
+- v2 可选：scope 细粒度限权（按工具/资源）、key 轮换（rotate）接口、签发账户类型白名单。


### PR DESCRIPTION
## 概要

为 Context Loader 的 MCP（`/api/agent-retrieval/v1/mcp`）+ REST（`/kn/*`）新增**用户自助签发的 AppKey（API Key）**鉴权，替代易过期的 OAuth Authorization token。AppKey 以签发者本人身份鉴权、权限同源；可自助签发/列出/撤销，管理员可全局管控。

需求/拆解：Linear OPE-14。设计 issue：#75。

## 改了什么

**bkn-safe（凭据权威）**
- `APIKey` model + AutoMigrate（表 `api_keys`，无需 data-migrator）
- `APIKeyStore`：签发（一次性明文 + sha256 存储）、校验（前缀/存在/启用/未过期/常量时间比对/owner 启用）、按 owner 列出、越权守卫删、admin 全量列/删
- HTTP：自助 `/api/safe/v1/me/api-keys`（RequireUser）、admin `/admin/api-keys`（RequireAdmin）、内部 `/api/safe/v1/api-keys/introspect`（免 token，ClusterIP）

**agent-retrieval（消费方，单一咽喉）**
- `middlewareIntrospectVerify` 按 `bak_` 前缀分流：AppKey → bkn-safe 验卡；其余 → hydra。两路出口同一个 `AccountAuthContext`，下游 0 改动
- 新 driven adapter `appkey.go` + `bkn_safe` config（config.go / yaml / helm）
- MCP info 示例去掉无效的 `x-account-*` 头

**文档**：`docs/appkey-integration.md`（前端+SDK 对接）、`docs/appkey-design.md`（架构/数据模型/信任面/威胁分析/运维）

**测试**：store 单测 + httpapi handler 测试 + agent-retrieval adapter/中间件测试，本地全绿。

## 验证

VM（10.211.55.4，ns openbkn）端到端跑通：签发→用卡调 MCP/REST→撤销复验 401、OAuth 路径回归正常、admin 管控。

## 待议（不阻塞合并，跟进 commit）

- **Key 长度/可见性**：当前 `bak_<keyid>_<secret>`（hex，~101 字符）、show-once + 只存哈希。产品侧在讨论"砍短"与"可重看"。可重看需加密存+二次鉴权（牺牲'DB 泄漏不致命'，需评审）；倾向 show-once + 加 regenerate。结论定后追加 commit。

## 范围外（其它仓 / 后续）

- 前端 AppKey 管理页（Studio 仓，OPE-21）
- SDK 凭据配置 + 401 重签（OPE-22）
- 发布版镜像 tag + 正式部署（OPE-23 余项）

🤖 Generated with [Claude Code](https://claude.com/claude-code)
