### PR TITLE
fix(vega): allow internal-resource data reads over S2S without per-account authz

### DIFF
--- a/adp/vega/vega-backend/server/driveradapters/resource_data_handler.go
+++ b/adp/vega/vega-backend/server/driveradapters/resource_data_handler.go
@@ -40,23 +40,28 @@ func (r *restHandler) PostResourceDataByEx(c *gin.Context) {
 	if err != nil {
 		return
 	}
-	r.postResourceData(c, visitor)
+	r.postResourceData(c, visitor, false)
 }
 
 // PostResourceDataByIn handles POST /api/vega-backend/in/v1/resources/:id/data (Internal).
 func (r *restHandler) PostResourceDataByIn(c *gin.Context) {
 	visitor := visitor.GenerateVisitor(c)
-	r.postResourceData(c, visitor)
+	// 内网 /in/ 为集群内 S2S 边界：标记 S2S，使内部基础设施资源默认放行 per-account 鉴权。
+	r.postResourceData(c, visitor, true)
 }
 
 // postResourceData dispatches POST /resources/:id/data to the right branch based on
-// X-HTTP-Method-Override header.
-func (r *restHandler) postResourceData(c *gin.Context, visitor hydra.Visitor) {
+// X-HTTP-Method-Override header. s2sInternal 为 true 时（仅 /in/ 内网端点），
+// 内部目录资源跳过 per-account view_detail 校验。
+func (r *restHandler) postResourceData(c *gin.Context, visitor hydra.Visitor, s2sInternal bool) {
 	ctx, span := oteltrace.StartServerSpan(c)
 	defer span.End()
 
 	accountInfo := interfaces.AccountInfo{ID: visitor.ID, Type: string(visitor.Type)}
 	ctx = context.WithValue(ctx, interfaces.ACCOUNT_INFO_KEY, accountInfo)
+	if s2sInternal {
+		ctx = interfaces.WithS2SInternalAccess(ctx)
+	}
 	oteltrace.AddHttpAttrs4API(span, oteltrace.GetAttrsByGinCtx(c))
 
 	override := strings.ToUpper(c.GetHeader(interfaces.HTTP_HEADER_METHOD_OVERRIDE))

--- a/adp/vega/vega-backend/server/interfaces/s2s_access.go
+++ b/adp/vega/vega-backend/server/interfaces/s2s_access.go
@@ -1,0 +1,27 @@
+// Copyright 2026 openbkn.ai
+// Copyright The kweaver.ai Authors.
+//
+// Licensed under the Apache License, Version 2.0.
+// See the LICENSE file in the project root for details.
+
+package interfaces
+
+import "context"
+
+// s2sInternalAccessKey 标记当前请求来自集群内部 S2S 调用（/in/ 内网端点）。
+// 用于系统内部基础设施资源（internal_resource，如 BKN 概念 dataset）在被
+// 内部服务代用户访问时默认放行 per-account 鉴权——这类资源从不授权给业务用户，
+// 对其做 per-account view_detail 校验只会误拒。仅 /in/ 内网处理器设置该标记，
+// 外网 /v1 端点不受影响。
+type s2sInternalAccessKey struct{}
+
+// WithS2SInternalAccess 在 ctx 上标记为内部 S2S 访问。仅由 /in/ 内网处理器调用。
+func WithS2SInternalAccess(ctx context.Context) context.Context {
+	return context.WithValue(ctx, s2sInternalAccessKey{}, true)
+}
+
+// IsS2SInternalAccess 判断 ctx 是否被标记为内部 S2S 访问。
+func IsS2SInternalAccess(ctx context.Context) bool {
+	v, ok := ctx.Value(s2sInternalAccessKey{}).(bool)
+	return ok && v
+}

--- a/adp/vega/vega-backend/server/logics/resource/resource_service.go
+++ b/adp/vega/vega-backend/server/logics/resource/resource_service.go
@@ -311,18 +311,25 @@ func (rs *resourceService) GetByID(ctx context.Context, id string) (*interfaces.
 		return nil, err
 	}
 	_, parentInternal := internalCatalogs[resource.CatalogID]
-	matchResoucesMap, err := rs.ps.FilterResources(ctx, resourceAuthResourceType(parentInternal), []string{resource.ID},
-		[]string{interfaces.OPERATION_TYPE_VIEW_DETAIL}, true, interfaces.COMMON_OPERATIONS)
-	if err != nil {
-		span.SetStatus(codes.Error, "Filter resources error")
-		return nil, err
-	}
-
-	if resrc, exist := matchResoucesMap[resource.ID]; exist {
-		resource.Operations = resrc.Operations // 用户当前有权限的操作
+	if parentInternal && interfaces.IsS2SInternalAccess(ctx) {
+		// 内部目录资源经集群内 S2S 访问（/in/ 内网端点）：系统内部基础设施默认放行，
+		// 不做 per-account view_detail 校验——这类资源从不授权给业务用户，
+		// 内部服务代用户访问时按 per-account 校验只会误拒。外网端点不会带该标记。
+		resource.Operations = interfaces.COMMON_OPERATIONS
 	} else {
-		return nil, rest.NewHTTPError(ctx, http.StatusForbidden, rest.PublicError_Forbidden).
-			WithErrorDetails(fmt.Sprintf("Access denied: insufficient permissions for[%v]", interfaces.OPERATION_TYPE_VIEW_DETAIL))
+		matchResoucesMap, err := rs.ps.FilterResources(ctx, resourceAuthResourceType(parentInternal), []string{resource.ID},
+			[]string{interfaces.OPERATION_TYPE_VIEW_DETAIL}, true, interfaces.COMMON_OPERATIONS)
+		if err != nil {
+			span.SetStatus(codes.Error, "Filter resources error")
+			return nil, err
+		}
+
+		if resrc, exist := matchResoucesMap[resource.ID]; exist {
+			resource.Operations = resrc.Operations // 用户当前有权限的操作
+		} else {
+			return nil, rest.NewHTTPError(ctx, http.StatusForbidden, rest.PublicError_Forbidden).
+				WithErrorDetails(fmt.Sprintf("Access denied: insufficient permissions for[%v]", interfaces.OPERATION_TYPE_VIEW_DETAIL))
+		}
 	}
 
 	accountInfos := []*interfaces.AccountInfo{&resource.Creator, &resource.Updater}

--- a/adp/vega/vega-backend/server/logics/resource/resource_service_s2s_test.go
+++ b/adp/vega/vega-backend/server/logics/resource/resource_service_s2s_test.go
@@ -1,0 +1,79 @@
+// Copyright 2026 openbkn.ai
+// Copyright The kweaver.ai Authors.
+//
+// Licensed under the Apache License, Version 2.0.
+// See the LICENSE file in the project root for details.
+
+package resource
+
+import (
+	"context"
+	"testing"
+
+	"go.uber.org/mock/gomock"
+
+	"vega-backend/interfaces"
+	vmock "vega-backend/interfaces/mock"
+)
+
+// newS2STestService 构建 resourceService，internalCatalogIDs 指定哪些目录为系统内部目录。
+func newS2STestService(t *testing.T, internalCatalogIDs []string) (
+	*resourceService, *vmock.MockResourceAccess, *vmock.MockPermissionService, *vmock.MockUserMgmtService) {
+	ctrl := gomock.NewController(t)
+	ra := vmock.NewMockResourceAccess(ctrl)
+	ps := vmock.NewMockPermissionService(ctrl)
+	ums := vmock.NewMockUserMgmtService(ctrl)
+	cs := vmock.NewMockCatalogService(ctrl)
+	rs := &resourceService{ra: ra, ps: ps, ums: ums, cs: cs}
+	cs.EXPECT().ListInternalIDs(gomock.Any()).Return(internalCatalogIDs, nil).AnyTimes()
+	return rs, ra, ps, ums
+}
+
+// 内部资源经 S2S 标记访问 → 跳过 view_detail 鉴权，放行。FilterResources 不应被调用。
+func TestGetByID_S2SInternal_Bypass(t *testing.T) {
+	rs, ra, _, ums := newS2STestService(t, []string{"cat-int"})
+	ra.EXPECT().GetByID(gomock.Any(), "r1").
+		Return(&interfaces.Resource{ID: "r1", CatalogID: "cat-int"}, nil)
+	ums.EXPECT().GetAccountNames(gomock.Any(), gomock.Any()).Return(nil)
+	// 不设置 ps.FilterResources EXPECT：若被调用，gomock 会因 unexpected call 失败。
+
+	ctx := interfaces.WithS2SInternalAccess(context.Background())
+	res, err := rs.GetByID(ctx, "r1")
+	if err != nil {
+		t.Fatalf("内部资源 S2S 访问应放行，却报错: %v", err)
+	}
+	if res == nil || len(res.Operations) == 0 {
+		t.Fatalf("放行后应回填 operations，got %+v", res)
+	}
+}
+
+// 内部资源无 S2S 标记（外网 / 普通用户）→ FilterResources 命中空 → 403。
+func TestGetByID_Internal_NoMarker_Forbidden(t *testing.T) {
+	rs, ra, ps, _ := newS2STestService(t, []string{"cat-int"})
+	ra.EXPECT().GetByID(gomock.Any(), "r1").
+		Return(&interfaces.Resource{ID: "r1", CatalogID: "cat-int"}, nil)
+	ps.EXPECT().FilterResources(gomock.Any(), interfaces.AUTH_RESOURCE_TYPE_INTERNAL_RESOURCE,
+		gomock.Any(), gomock.Any(), true, gomock.Any()).
+		Return(map[string]interfaces.PermissionResourceOps{}, nil)
+
+	_, err := rs.GetByID(context.Background(), "r1")
+	if err == nil {
+		t.Fatalf("内部资源无 S2S 标记应被拒，却放行了")
+	}
+}
+
+// 非内部资源即便带 S2S 标记 → 仍走 per-account 鉴权（FilterResources 空 → 403）。
+func TestGetByID_NonInternal_WithMarker_StillAuthz(t *testing.T) {
+	rs, ra, ps, _ := newS2STestService(t, []string{}) // 无内部目录 → 该资源非内部
+	ra.EXPECT().GetByID(gomock.Any(), "r1").
+		Return(&interfaces.Resource{ID: "r1", CatalogID: "cat-user"}, nil)
+	ps.EXPECT().FilterResources(gomock.Any(), interfaces.AUTH_RESOURCE_TYPE_RESOURCE,
+		gomock.Any(), gomock.Any(), true, gomock.Any()).
+		Return(map[string]interfaces.PermissionResourceOps{}, nil)
+
+	ctx := interfaces.WithS2SInternalAccess(context.Background())
+	_, err := rs.GetByID(ctx, "r1")
+	if err == nil {
+		t.Fatalf("非内部资源即便带 S2S 标记也应按 per-account 鉴权拒绝，却放行了")
+	}
+}


### PR DESCRIPTION
## Problem

`search_schema` with `include_metric_types: true` fails for non-admin users:

```
BknBackend.Metric.InternalError
QueryDatasetData failed: Access denied: insufficient permissions for[view_detail]
```

**Call chain (3 services, all internal `/in/`, header-trust, no token):**

```
Studio ──/v1 (token)──► agent-retrieval ──/in──► bkn-backend ──/in──► vega-backend
```

BKN concept search (metric/object/relation/...) queries its **own internal infra dataset** `adp_bkn_concept_dataset` via vega `POST /in/v1/resources/{id}/data`, forwarding the **end-user account**. That dataset lives in an internal catalog, registered as `internal_resource` (superadmin-only). A non-admin end-user has no grant → 403 `view_detail` → wrapped as `BknBackend.Metric.InternalError`.

Internal infrastructure is system plumbing — never granted to business users. Gating it by the end-user's permissions for the service's own access only mis-denies.

## Fix

Mark requests arriving on vega's internal `/in/` endpoints as **S2S internal access**. When resolving an **internal-catalog** resource under that marker, skip the per-account `view_detail` check. External `/v1` and non-internal resources keep their existing per-account authz unchanged.

- `interfaces/s2s_access.go`: `WithS2SInternalAccess` / `IsS2SInternalAccess` context marker — **no identity / uuid involved**.
- `resource_data_handler.go`: `/in/` (`ByIn`) marks S2S; external `/v1` (`ByEx`) does not.
- `resource_service.go` `GetByID`: bypass `view_detail` **only when** internal resource **AND** S2S marker present.

### Why marker (not "forward admin")
Forwarding a system/admin identity would depend on a hardcoded superadmin uuid (`ADMIN_ACCOUNT_ID`, duplicated across 3 services) that breaks on any deployment whose seeded admin differs. The marker keys on resource class + request origin only — zero identity, deployment-independent, and consistent with the existing `/in/` no-token header-trust boundary.

## Tests
- `internal + S2S` → allowed (bypass, `FilterResources` not called)
- `internal + no marker` (external/user) → 403
- `non-internal + marker` → still per-account authz (403 when unauthorized)

`go build`, `go vet`, and the new tests pass.

## Follow-up
Deploy vega-backend to VM + 118 and confirm non-admin `search_schema` with metrics no longer 403s.

🤖 Generated with [Claude Code](https://claude.com/claude-code)