### PR TITLE
fix(vega): also bypass internal-catalog authz on S2S data reads

### DIFF
--- a/adp/vega/vega-backend/server/logics/catalog/catalog_service.go
+++ b/adp/vega/vega-backend/server/logics/catalog/catalog_service.go
@@ -284,18 +284,25 @@ func (cs *catalogService) GetByID(ctx context.Context, id string, withSensitiveF
 
 	// 根据权限过滤有查看权限的对象，过滤后的数组的总长度就是总数，无需再请求总数；
 	// 内部目录按 internal_catalog 类型校验
-	matchResoucesMap, err := cs.ps.FilterResources(ctx, catalogAuthResourceType(catalog.Internal), []string{catalog.ID},
-		[]string{interfaces.OPERATION_TYPE_VIEW_DETAIL}, true, interfaces.COMMON_OPERATIONS)
-	if err != nil {
-		span.SetStatus(codes.Error, "Filter resources error")
-		return nil, err
-	}
-
-	if resrc, exist := matchResoucesMap[catalog.ID]; exist {
-		catalog.Operations = resrc.Operations // 用户当前有权限的操作
+	if catalog.Internal && interfaces.IsS2SInternalAccess(ctx) {
+		// 内部目录经集群内 S2S 访问（/in/ 内网端点）：系统内部基础设施默认放行，
+		// 不做 per-account view_detail 校验。与 resource 服务的同款豁免配套，
+		// 覆盖内部 dataset 数据查询时对其所属内部 catalog 的二次鉴权。外网端点不会带该标记。
+		catalog.Operations = interfaces.COMMON_OPERATIONS
 	} else {
-		return nil, rest.NewHTTPError(ctx, http.StatusForbidden, rest.PublicError_Forbidden).
-			WithErrorDetails(fmt.Sprintf("Access denied: insufficient permissions for[%v]", interfaces.OPERATION_TYPE_VIEW_DETAIL))
+		matchResoucesMap, err := cs.ps.FilterResources(ctx, catalogAuthResourceType(catalog.Internal), []string{catalog.ID},
+			[]string{interfaces.OPERATION_TYPE_VIEW_DETAIL}, true, interfaces.COMMON_OPERATIONS)
+		if err != nil {
+			span.SetStatus(codes.Error, "Filter resources error")
+			return nil, err
+		}
+
+		if resrc, exist := matchResoucesMap[catalog.ID]; exist {
+			catalog.Operations = resrc.Operations // 用户当前有权限的操作
+		} else {
+			return nil, rest.NewHTTPError(ctx, http.StatusForbidden, rest.PublicError_Forbidden).
+				WithErrorDetails(fmt.Sprintf("Access denied: insufficient permissions for[%v]", interfaces.OPERATION_TYPE_VIEW_DETAIL))
+		}
 	}
 
 	accountInfos := []*interfaces.AccountInfo{&catalog.Creator, &catalog.Updater}

--- a/adp/vega/vega-backend/server/logics/catalog/catalog_service_s2s_test.go
+++ b/adp/vega/vega-backend/server/logics/catalog/catalog_service_s2s_test.go
@@ -1,0 +1,76 @@
+// Copyright 2026 openbkn.ai
+// Copyright The kweaver.ai Authors.
+//
+// Licensed under the Apache License, Version 2.0.
+// See the LICENSE file in the project root for details.
+
+package catalog
+
+import (
+	"context"
+	"testing"
+
+	"go.uber.org/mock/gomock"
+
+	"vega-backend/interfaces"
+	vmock "vega-backend/interfaces/mock"
+)
+
+func newS2SCatalogService(t *testing.T) (
+	*catalogService, *vmock.MockCatalogAccess, *vmock.MockPermissionService, *vmock.MockUserMgmtService) {
+	ctrl := gomock.NewController(t)
+	ca := vmock.NewMockCatalogAccess(ctrl)
+	ps := vmock.NewMockPermissionService(ctrl)
+	ums := vmock.NewMockUserMgmtService(ctrl)
+	cs := &catalogService{ca: ca, ps: ps, ums: ums}
+	return cs, ca, ps, ums
+}
+
+// 内部目录经 S2S 标记访问 → 跳过 view_detail 鉴权放行。FilterResources 不应被调用。
+func TestCatalogGetByID_S2SInternal_Bypass(t *testing.T) {
+	cs, ca, _, ums := newS2SCatalogService(t)
+	ca.EXPECT().GetByID(gomock.Any(), "c1").
+		Return(&interfaces.Catalog{ID: "c1", Internal: true}, nil)
+	ums.EXPECT().GetAccountNames(gomock.Any(), gomock.Any()).Return(nil)
+	// 不设置 ps.FilterResources EXPECT：若被调用，gomock 会因 unexpected call 失败。
+
+	ctx := interfaces.WithS2SInternalAccess(context.Background())
+	cat, err := cs.GetByID(ctx, "c1", false)
+	if err != nil {
+		t.Fatalf("内部目录 S2S 访问应放行，却报错: %v", err)
+	}
+	if cat == nil || len(cat.Operations) == 0 {
+		t.Fatalf("放行后应回填 operations，got %+v", cat)
+	}
+}
+
+// 内部目录无 S2S 标记 → FilterResources 空 → 403。
+func TestCatalogGetByID_Internal_NoMarker_Forbidden(t *testing.T) {
+	cs, ca, ps, _ := newS2SCatalogService(t)
+	ca.EXPECT().GetByID(gomock.Any(), "c1").
+		Return(&interfaces.Catalog{ID: "c1", Internal: true}, nil)
+	ps.EXPECT().FilterResources(gomock.Any(), interfaces.AUTH_RESOURCE_TYPE_INTERNAL_CATALOG,
+		gomock.Any(), gomock.Any(), true, gomock.Any()).
+		Return(map[string]interfaces.PermissionResourceOps{}, nil)
+
+	_, err := cs.GetByID(context.Background(), "c1", false)
+	if err == nil {
+		t.Fatalf("内部目录无 S2S 标记应被拒，却放行了")
+	}
+}
+
+// 非内部目录即便带 S2S 标记 → 仍按 per-account 鉴权（FilterResources 空 → 403）。
+func TestCatalogGetByID_NonInternal_WithMarker_StillAuthz(t *testing.T) {
+	cs, ca, ps, _ := newS2SCatalogService(t)
+	ca.EXPECT().GetByID(gomock.Any(), "c1").
+		Return(&interfaces.Catalog{ID: "c1", Internal: false}, nil)
+	ps.EXPECT().FilterResources(gomock.Any(), interfaces.AUTH_RESOURCE_TYPE_CATALOG,
+		gomock.Any(), gomock.Any(), true, gomock.Any()).
+		Return(map[string]interfaces.PermissionResourceOps{}, nil)
+
+	ctx := interfaces.WithS2SInternalAccess(context.Background())
+	_, err := cs.GetByID(ctx, "c1", false)
+	if err == nil {
+		t.Fatalf("非内部目录即便带 S2S 标记也应按 per-account 鉴权拒绝，却放行了")
+	}
+}


### PR DESCRIPTION
Follow-up to #77. Verifying #77 on the VM surfaced a **second** per-account authz gate on the same data-read path.

After the resource gate (`resourceService.GetByID`) was opened for internal-resource S2S reads, `resource_data_service.Query` resolves the resource's catalog via `catalogService.GetByID(catalogID, true)`, which runs the same `internal_catalog` `view_detail` check and 403s non-admin callers:

```
VegaBackend.Resource.InternalError: failed to get catalog: Public.Forbidden ... insufficient permissions for[view_detail]
```

So internal concept-dataset reads were still blocked even with #77.

## Fix
Apply the same marker-gated bypass to `catalogService.GetByID`: an internal catalog accessed under S2S internal access (`IsS2SInternalAccess(ctx)`, set only on vega `/in/` endpoints) skips the per-account `view_detail` check. External `/v1` and non-internal catalogs keep their existing authz.

## Tests
- internal + S2S → allowed (bypass, `FilterResources` not called)
- internal + no marker → 403
- non-internal + marker → still per-account authz

`go build`, `go vet`, and the new tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)