### PR TITLE
feat(bkn-safe): masked AppKey display hint for key lists

### DIFF
--- a/bkn-safe/server/internal/auth/apikey.go
+++ b/bkn-safe/server/internal/auth/apikey.go
@@ -85,6 +85,7 @@ func (s *APIKeyStore) Issue(ctx context.Context, ownerID, name string, expiresAt
 		KeyID:       keyID,
 		OwnerUserID: ownerID,
 		Name:        name,
+		Masked:      maskKey(keyID, secret),
 		SecretHash:  hashSecret(secret),
 		ExpiresAt:   expiresAt,
 		Enabled:     true,
@@ -210,10 +211,11 @@ func (s *APIKeyStore) Regenerate(ctx context.Context, ownerID, id string) (strin
 	}
 	secret := randBase62(secretLen)
 	rec.SecretHash = hashSecret(secret)
+	rec.Masked = maskKey(rec.KeyID, secret) // tail comes from the secret, which changed
 	rec.LastUsedAt = nil
 	rec.Enabled = true
 	if err := s.db.WithContext(ctx).Model(&model.APIKey{}).Where("id = ?", id).
-		Updates(map[string]any{"secret_hash": rec.SecretHash, "last_used_at": nil, "enabled": true}).Error; err != nil {
+		Updates(map[string]any{"secret_hash": rec.SecretHash, "masked": rec.Masked, "last_used_at": nil, "enabled": true}).Error; err != nil {
 		return "", nil, err
 	}
 	return KeyPrefix + rec.KeyID + "_" + secret, &rec, nil
@@ -231,6 +233,35 @@ func splitKey(plaintext string) (keyID, secret string, ok bool) {
 		return "", "", false
 	}
 	return keyID, secret, true
+}
+
+// maskKey builds the one-time display hint stored at issue time: the prefix, the
+// first 4 chars of the public key id, "****", and the last 4 chars of the secret,
+// e.g. "bak_2882****SWua". Enough to recognize a key in a list without revealing
+// it. The secret tail is not sensitive on its own and never allows reconstruction.
+func maskKey(keyID, secret string) string {
+	return KeyPrefix + head(keyID, 4) + "****" + tail(secret, 4)
+}
+
+// MaskFromKeyID derives a display hint from the public key id alone, for rows
+// issued before the Masked column existed (no secret material is recoverable, so
+// the tail comes from the key id): "bak_2882****c2f8".
+func MaskFromKeyID(keyID string) string {
+	return KeyPrefix + head(keyID, 4) + "****" + tail(keyID, 4)
+}
+
+func head(s string, n int) string {
+	if len(s) < n {
+		return s
+	}
+	return s[:n]
+}
+
+func tail(s string, n int) string {
+	if len(s) < n {
+		return s
+	}
+	return s[len(s)-n:]
 }
 
 // randBase62 returns n cryptographically-random base62 chars. Rejection sampling

--- a/bkn-safe/server/internal/auth/apikey_mask_test.go
+++ b/bkn-safe/server/internal/auth/apikey_mask_test.go
@@ -1,0 +1,30 @@
+// Copyright 2026 openbkn.ai
+// Copyright The kweaver.ai Authors.
+//
+// Licensed under the Apache License, Version 2.0.
+// See the LICENSE file in the project root for details.
+
+package auth
+
+import "testing"
+
+func TestMaskKey(t *testing.T) {
+	// prefix + first 4 of key id + "****" + last 4 of secret
+	if got, want := maskKey("2882bb603277", "BSxTZHTBiJXk4QoUBc0u17zSWua"), "bak_2882****SWua"; got != want {
+		t.Fatalf("maskKey = %q, want %q", got, want)
+	}
+}
+
+func TestMaskFromKeyID(t *testing.T) {
+	// fallback for legacy rows: tail comes from the key id itself
+	if got, want := MaskFromKeyID("2882bb603277"), "bak_2882****3277"; got != want {
+		t.Fatalf("MaskFromKeyID = %q, want %q", got, want)
+	}
+}
+
+func TestMask_ShortInputsNoPanic(t *testing.T) {
+	// halves shorter than 4 must not panic or slice out of range
+	_ = maskKey("ab", "cd")
+	_ = MaskFromKeyID("x")
+	_ = maskKey("", "")
+}

--- a/bkn-safe/server/internal/httpapi/apikey.go
+++ b/bkn-safe/server/internal/httpapi/apikey.go
@@ -181,10 +181,18 @@ func resolveExpiry(expiresAt *string, neverExpire bool) (*time.Time, error) {
 // apiKeyJSON renders a key for API responses WITHOUT any secret. includeOwner
 // adds owner_user_id (admin views).
 func apiKeyJSON(k model.APIKey, includeOwner bool) gin.H {
+	// masked is a non-secret display hint so users can tell keys apart in a list.
+	// Rows issued before the Masked column existed fall back to a key-id-derived
+	// hint (the public key id is always available).
+	masked := k.Masked
+	if masked == "" {
+		masked = auth.MaskFromKeyID(k.KeyID)
+	}
 	h := gin.H{
 		"id":           k.ID,
 		"key_id":       k.KeyID,
 		"name":         k.Name,
+		"masked":       masked,
 		"enabled":      k.Enabled,
 		"expires_at":   k.ExpiresAt,  // null = never expires
 		"last_used_at": k.LastUsedAt, // null = never used

--- a/bkn-safe/server/internal/model/model.go
+++ b/bkn-safe/server/internal/model/model.go
@@ -157,6 +157,7 @@ type APIKey struct {
 	KeyID       string `gorm:"uniqueIndex;size:64"` // public lookup half, embedded in the key
 	OwnerUserID string `gorm:"size:64;index"`       // User.ID this key acts as
 	Name        string `gorm:"size:128"`            // user-facing label
+	Masked      string `gorm:"size:64"`             // one-time display hint, e.g. "bak_2882****SWua"; safe to list
 	SecretHash  string `gorm:"size:128"`            // sha256 hex of the secret half
 	// ExpiresAt nil = never expires (explicit opt-in by the issuer). LastUsedAt is
 	// updated on each successful verify so stale/leaked keys can be spotted/reaped.

--- a/docs/appkey-design.md
+++ b/docs/appkey-design.md
@@ -52,6 +52,7 @@ AppKey 引入**用户自助签发的长期凭据**，以签发者本人身份鉴
 | `KeyID` | string(64) uniqueIndex | 公开查找半段，嵌在明文里 |
 | `OwnerUserID` | string(64) index | 该 key 充当的 `User.ID` |
 | `Name` | string(128) | 用户可见标签 |
+| `Masked` | string(64) | 脱敏展示提示 `bak_<keyID前4>****<secret尾4>`，签发时算好落库；非密钥、可安全列出，用于区分 key。旧行为空 → 列表回退用 keyID 推导 |
 | `SecretHash` | string(128) | secret 半段的 sha256 hex |
 | `ExpiresAt` | *time.Time index | nil = 永不过期 |
 | `LastUsedAt` | *time.Time | 每次成功校验更新 |

--- a/docs/appkey-integration.md
+++ b/docs/appkey-integration.md
@@ -41,6 +41,7 @@ base：`/api/safe/v1/me/api-keys`　鉴权：用户当前 OAuth token（`Authori
   "key_id": "b3ffa7f4...",
   "name": "我的 Cursor",
   "key": "bak_b3ffa7f4..._fb74b234...",
+  "masked": "bak_b3ff****b234",
   "enabled": true,
   "expires_at": "2027-06-26T11:49:59+02:00",
   "last_used_at": null,
@@ -48,17 +49,20 @@ base：`/api/safe/v1/me/api-keys`　鉴权：用户当前 OAuth token（`Authori
 }
 ```
 > ⚠️ **`key` 字段是完整明文，只此一次**。前端必须：弹窗展示 + 一键复制 + 明确提示"关闭后无法再次查看"。**不要**把它存进任何可再次读取的地方。列表接口永远不会再返回它。
+>
+> `masked` 是脱敏展示提示（`bak_` + key_id 前 4 + `****` + secret 尾 4），**非密钥**、可安全长期展示在列表里，用来让用户区分各个 key（明文看不到时也认得出哪个）。
 
 > **名字按用户唯一**：同一用户已有同名 key 时签发返回 `409`（`{"error":"an api key with this name already exists"}`）。不同用户可同名。前端建议在签发前/提交时校验重名并给出友好提示。
 
 #### 列出　`GET /api/safe/v1/me/api-keys`
 ```json
 { "keys": [
-  { "id": "...", "key_id": "b3ffa7f4...", "name": "我的 Cursor",
+  { "id": "...", "key_id": "b3ffa7f4...", "name": "我的 Cursor", "masked": "bak_b3ff****b234",
     "enabled": true, "expires_at": "2027-...", "last_used_at": "2026-...", "created_at": "2026-..." }
 ] }
 ```
-- 无 secret。`last_used_at` 为 `null` 表示从未使用 —— 可用于"僵尸 key"提示。
+- 无 secret。`masked` 是脱敏展示串（前缀+key_id 前4+`****`+secret 尾4），列表里用它显示密钥、供用户区分；旧版（无此列时签发的）key 回退用 key_id 推导尾4。
+- `last_used_at` 为 `null` 表示从未使用 —— 可用于"僵尸 key"提示。
 - `expires_at` 为 `null` 表示永不过期。
 
 #### 撤销　`DELETE /api/safe/v1/me/api-keys/:id`
@@ -83,7 +87,7 @@ base：`/api/safe/v1/admin/api-keys`　鉴权：管理员 OAuth token（`Require
 
 - [ ] 签发后明文一次性展示 + 复制 + "无法再次查看"提示
 - [ ] 有效期：默认 1 年；可选自定义日期；"永不过期"独立勾选 + 风险文案
-- [ ] 列表展示 `name / 创建时间 / 过期时间 / 最近使用 / 状态`
+- [ ] 列表展示 `name / 密钥脱敏（masked）/ 创建时间 / 过期时间 / 最近使用 / 状态`（密钥列直接渲染 `masked`，别再自行拼接）
 - [ ] 撤销二次确认
 - [ ] 引导文案：告诉用户"把这个 key 填到 MCP 客户端 / SDK 的 Authorization 里，替代易过期的登录 token"
 - [ ] （管理员页）全量列表 + 按 owner 过滤 + 撤销


### PR DESCRIPTION
## Why
The AppKey list only showed `id` + `name`. The full plaintext is shown once at issue time and never again, so users can't tell their keys apart in the list (which `bak_…` is which?).

## What
Store a **non-secret masked hint** at issue time and return it on create + list:

```
bak_<first 4 of key_id>****<last 4 of secret>   e.g.  bak_2882****SWua
```

Enough to recognize a key; never enough to reconstruct it (the secret tail alone is not usable).

- **model**: `APIKey.Masked` column — `AutoMigrate` adds it, no manual migration.
- **auth**: `maskKey` computed in `Issue`, refreshed in `Regenerate` (the secret tail changes). `MaskFromKeyID` fallback for rows issued before the column existed — derives the tail from the public key id (no secret is recoverable).
- **httpapi**: `apiKeyJSON` returns `"masked"` (empty → key-id-derived fallback), so it appears in both the create (`201`) and list responses.
- **docs**: `docs/appkey-design.md` + `docs/appkey-integration.md` updated (field + UX note).

## Frontend
Render the `masked` field directly instead of building a hint locally (today it shows the full `key_id` + dots). Separate frontend repo — this PR only provides the field.

## Tests
`maskKey` / `MaskFromKeyID` format + short-input no-panic; full bkn-safe suite passes (no regression).

🤖 Generated with [Claude Code](https://claude.com/claude-code)