### PR TITLE
fix(agent-retrieval): declare kn_id in MCP tool schemas to match REST

### DIFF
--- a/adp/context-loader/agent-retrieval/server/driveradapters/mcp/schemas/find_skills.json
+++ b/adp/context-loader/agent-retrieval/server/driveradapters/mcp/schemas/find_skills.json
@@ -1,13 +1,17 @@
 {
   "input_schema": {
     "type": "object",
-    "required": ["object_type_id"],
+    "required": ["kn_id", "object_type_id"],
     "properties": {
       "response_format": {
         "type": "string",
         "enum": ["json", "toon"],
         "default": "toon",
         "description": "文本格式：json 或 toon，默认 toon"
+      },
+      "kn_id": {
+        "type": "string",
+        "description": "知识网络 ID。也可改用 X-Kn-ID 请求头传入。"
       },
       "object_type_id": {
         "type": "string",

--- a/adp/context-loader/agent-retrieval/server/driveradapters/mcp/schemas/get_action_info.json
+++ b/adp/context-loader/agent-retrieval/server/driveradapters/mcp/schemas/get_action_info.json
@@ -2,6 +2,10 @@
   "input_schema": {
     "type": "object",
     "properties": {
+      "kn_id": {
+        "type": "string",
+        "description": "知识网络 ID。也可改用 X-Kn-ID 请求头传入。"
+      },
       "at_id": {
         "type": "string",
         "description": "行动类型ID"
@@ -15,7 +19,7 @@
         }
       }
     },
-    "required": ["at_id"]
+    "required": ["kn_id", "at_id"]
   },
   "output_schema": {
     "type": "object",

--- a/adp/context-loader/agent-retrieval/server/driveradapters/mcp/schemas/get_logic_properties_values.json
+++ b/adp/context-loader/agent-retrieval/server/driveradapters/mcp/schemas/get_logic_properties_values.json
@@ -2,6 +2,10 @@
   "input_schema": {
     "type": "object",
     "properties": {
+      "kn_id": {
+        "type": "string",
+        "description": "知识网络 ID。也可改用 X-Kn-ID 请求头传入。"
+      },
       "ot_id": {
         "type": "string",
         "description": "对象类型ID"
@@ -32,7 +36,7 @@
         "description": "可选。覆盖动态参数生成所用大模型；为空走系统默认大模型。仅供测试/验证指定模型。"
       }
     },
-    "required": ["ot_id", "query", "_instance_identities", "properties"]
+    "required": ["kn_id", "ot_id", "query", "_instance_identities", "properties"]
   },
   "output_schema": {
     "type": "object",

--- a/adp/context-loader/agent-retrieval/server/driveradapters/mcp/schemas/query_instance_subgraph.json
+++ b/adp/context-loader/agent-retrieval/server/driveradapters/mcp/schemas/query_instance_subgraph.json
@@ -8,6 +8,10 @@
         "default": "toon",
         "description": "文本格式：json 或 toon，默认 toon"
       },
+      "kn_id": {
+        "type": "string",
+        "description": "知识网络 ID。也可改用 X-Kn-ID 请求头传入。"
+      },
       "include_logic_params": {
         "type": "boolean",
         "description": "是否返回逻辑属性计算参数，默认 false"
@@ -114,7 +118,7 @@
         }
       }
     },
-    "required": ["relation_type_paths"]
+    "required": ["kn_id", "relation_type_paths"]
   },
   "output_schema": {
     "type": "object",

--- a/adp/context-loader/agent-retrieval/server/driveradapters/mcp/schemas/query_object_instance.json
+++ b/adp/context-loader/agent-retrieval/server/driveradapters/mcp/schemas/query_object_instance.json
@@ -8,6 +8,10 @@
         "default": "toon",
         "description": "文本格式：json 或 toon，默认 toon"
       },
+      "kn_id": {
+        "type": "string",
+        "description": "知识网络 ID。也可改用 X-Kn-ID 请求头传入。"
+      },
       "ot_id": {
         "type": "string",
         "description": "对象类型ID"
@@ -42,7 +46,7 @@
         "description": "指定返回的对象属性字段列表，默认返回所有属性"
       }
     },
-    "required": ["ot_id"]
+    "required": ["kn_id", "ot_id"]
   },
   "output_schema": {
     "type": "object",

--- a/adp/context-loader/agent-retrieval/server/driveradapters/mcp/schemas/search_schema.json
+++ b/adp/context-loader/agent-retrieval/server/driveradapters/mcp/schemas/search_schema.json
@@ -8,6 +8,10 @@
         "default": "toon",
         "description": "文本格式：json 或 toon，默认 toon"
       },
+      "kn_id": {
+        "type": "string",
+        "description": "知识网络 ID。也可改用 X-Kn-ID 请求头传入。"
+      },
       "query": {
         "type": "string",
         "description": "用户查询问题或关键词，多个关键词之间用空格隔开"
@@ -62,7 +66,7 @@
         "description": "是否对关系类型启用 Rerank"
       }
     },
-    "required": ["query"]
+    "required": ["kn_id", "query"]
   },
   "output_schema": {
     "type": "object",

--- a/adp/context-loader/agent-retrieval/server/driveradapters/mcp/tools.go
+++ b/adp/context-loader/agent-retrieval/server/driveradapters/mcp/tools.go
@@ -343,10 +343,13 @@ func handleFindSkills(service interfaces.IFindSkillsService) func(ctx context.Co
 			return mcp.NewToolResultError("authentication required"), nil
 		}
 
-		knID := getKnIDFromHeader(req)
+		knID := getStringArg(req, "kn_id", "")
+		if knID == "" {
+			knID = getKnIDFromHeader(req)
+		}
 		if knID == "" {
 			return mcp.NewToolResultError(
-				"kn_id is required (configure X-Kn-ID header)",
+				"kn_id is required (pass kn_id in body or configure X-Kn-ID header)",
 			), nil
 		}
 


### PR DESCRIPTION
## 背景

实跑 MCP（「梅西每届世界杯进球数」试金石）发现：6 个查询工具的 MCP `tools/list` inputSchema **未声明 `kn_id`**，而 REST/OpenAPI yaml 都有。Claude Code 这类无法每调用注入 `X-Kn-ID` header 的 MCP client，LLM 看不到该在 body 传 `kn_id`，**首调即报 `kn_id is required`**，只能撞错恢复。

## 改动

给 6 个工具的 MCP inputSchema 加 `kn_id`（property + required，文案仿 `get_kn_detail`：「知识网络 ID。也可改用 X-Kn-ID 请求头传入。」）：
- `search_schema`
- `query_object_instance`
- `query_instance_subgraph`
- `get_logic_properties_values`
- `get_action_info`
- `find_skills`

`find_skills` 额外修 handler：原来**只读 header 且覆盖 body 值**，现改为先读 body `kn_id` 再 header 兜底，与 `get_kn_detail` / `query_object_instance` 一致。

**未动**：`run_sql`（`handleRunSQL` 根本不读 kn_id，按 `{{.resource_id}}` 占位符解析资源）、`list_knowledge_networks`（无需）、`get_kn_detail`（已对，作样板）。

## 验证
- 6 个 schema JSON 合法，kn_id property + required 全到位
- `go build ./server/driveradapters/mcp/...` 通过
- [ ] 回归：用 Claude Code MCP 重跑试金石，确认首调不再报 kn_id 缺失（需重启加载新 schema）

Closes #83

🤖 Generated with [Claude Code](https://claude.com/claude-code)