### PR TITLE
feat(agent-retrieval): add MCP server instructions with query-routing guide

### DIFF
--- a/adp/context-loader/agent-retrieval/server/driveradapters/mcp/app.go
+++ b/adp/context-loader/agent-retrieval/server/driveradapters/mcp/app.go
@@ -39,11 +39,31 @@ const (
 	toolKeyRunSQL                   = "run_sql"
 )
 
+// serverInstructions is returned at MCP initialize. It gives the LLM a
+// shared exploration order and query-routing guide once, instead of
+// repeating it across every tool description.
+const serverInstructions = `ContextLoader 知识网络查询工具集使用指南。
+
+探索顺序：
+1. list_knowledge_networks 获取 kn_id（其余工具都需要 kn_id）。
+2. search_schema 用自然语言找对象类，返回 ot_id、属性、condition_operations、data_source.id。
+3. 按查询类型选工具（见下）。
+
+查询分流：
+- 单对象类过滤 + 排序 + 分页（field op value，可 and/or 组合）→ query_object_instance；算子白名单以对象类的 condition_operations 为准。
+- 聚合 / 统计 / 排名（SUM、COUNT、AVG、GROUP BY、按聚合值排序、跨表 join）→ run_sql（Trino 只读 SQL）；表名用占位符 {{.<data_source.id>}}，data_source.id 取自 search_schema。query_object_instance 不支持聚合。
+- 沿关系多跳取子图 → query_instance_subgraph。
+- 逻辑属性（指标/算子）计算 → get_logic_properties_values。
+- 对象可执行行动召回 → get_action_info。
+
+提示：聚合类问题（如「每个 X 的 Y 总数/排名」）直接走 run_sql，不要用 query_object_instance 的 sort 近似。`
+
 // NewMCPHandler creates an http.Handler for the MCP Streamable HTTP Server.
 // Tool metadata comes from schemas/tools_meta.json; schemas from schemas/*.json.
 func NewMCPHandler() http.Handler {
 	mcpServer := server.NewMCPServer(serverName, serverVersion,
 		server.WithToolCapabilities(true),
+		server.WithInstructions(serverInstructions),
 	)
 
 	knSearchService := knsearch.NewKnSearchService()


### PR DESCRIPTION
## 背景

MCP server 只暴露 per-tool description，没有一处统一说明**探索顺序**和**查询分流**。实跑试金石（「梅西每届世界杯进球数」）时，agent 不知道聚合/排名类查询必须走 `run_sql`（`query_object_instance` 只能过滤+排序，不支持聚合）。

## 改动

`NewMCPServer` 加 `server.WithInstructions(...)`，在 MCP initialize 时返回一次性指南：
- **探索顺序**：list_knowledge_networks（拿 kn_id）→ search_schema（拿 ot_id/属性/condition_operations/data_source.id）→ 选工具
- **查询分流**：
  - 过滤 + 排序 + 分页 → `query_object_instance`
  - 聚合 / 统计 / 排名 / 跨表 join → `run_sql`（Trino，表名 `{{.<data_source.id>}}`）
  - 关系多跳 → `query_instance_subgraph`；逻辑属性 → `get_logic_properties_values`；行动召回 → `get_action_info`

落地 #82 的 **B 决策**（聚合走 run_sql），且只发一次，不必每个工具 description 重复。

## 验证
- `go build ./server/driveradapters/mcp/...` 通过
- [ ] 回归：Claude Code 重连 MCP，确认 initialize 返回 instructions

Refs #80, #82

🤖 Generated with [Claude Code](https://claude.com/claude-code)