### PR TITLE
feat(agent-retrieval): tighten query_object_instance condition schema

### DIFF
--- a/adp/context-loader/agent-retrieval/server/driveradapters/mcp/schemas/query_object_instance.json
+++ b/adp/context-loader/agent-retrieval/server/driveradapters/mcp/schemas/query_object_instance.json
@@ -22,8 +22,43 @@
       },
       "condition": {
         "type": "object",
-        "description": "过滤条件结构，用于构建对象实例的查询筛选。支持多层嵌套：含 field（属性名）、operation（操作符，如 and/or/==/!=/in/like 等）、value 与 value_from（常量值，须同时使用）、以及 sub_conditions（子条件数组）。当 operation 为 and 或 or 时，通过 sub_conditions 递归嵌套同结构的条件，实现组合查询。",
-        "additionalProperties": true
+        "description": "过滤条件。operation 必填。比较算子（==/!=/>/>=/</<=/in/not_in/like/not_like/exist/not_exist/match）配 field + value + value_from；逻辑算子（and/or）配 sub_conditions 递归嵌套同结构条件。value 与 value_from 必须同时出现，value_from 仅支持 const。算子白名单以对象类的 condition_operations 为准。无过滤条件时可整体省略 condition。",
+        "required": ["operation"],
+        "properties": {
+          "field": {
+            "type": "string",
+            "description": "字段名（对象类属性）"
+          },
+          "operation": {
+            "type": "string",
+            "description": "条件操作符，具体支持以对象类的 condition_operations 为准",
+            "enum": ["and", "or", "==", "!=", ">", ">=", "<", "<=", "in", "not_in", "like", "not_like", "exist", "not_exist", "match"]
+          },
+          "sub_conditions": {
+            "type": "array",
+            "description": "子条件数组，用于 and/or 组合（元素为同结构 condition）",
+            "items": { "type": "object" }
+          },
+          "value_from": {
+            "type": "string",
+            "enum": ["const"],
+            "description": "值来源，仅支持 const；必须与 value 同时使用"
+          },
+          "value": {
+            "description": "字段值；与 value_from=const 同时使用。比较算子用单值，范围用 [min, max]，集合算子（in/not_in）用数组",
+            "oneOf": [
+              { "type": "string" },
+              { "type": "number" },
+              { "type": "boolean" },
+              { "type": "array", "items": { "oneOf": [
+                { "type": "string" },
+                { "type": "number" },
+                { "type": "boolean" }
+              ]}}
+            ]
+          }
+        },
+        "additionalProperties": false
       },
       "limit": {
         "type": "integer",


### PR DESCRIPTION
## 背景

`query_object_instance` 的 `condition` 之前是不透明 blob（`{type:object, additionalProperties:true}`），LLM 拿不到任何结构帮助，全靠中文散文拼条件。

而 `query_instance_subgraph` 早已是紧 schema，REST yaml + .adp 的 `Condition` 也都紧——**只有这个 MCP schema 落后**。

## 改动

把 `query_object_instance.json` 的 `condition` 追平为紧 schema：
- 声明 `field` / `operation`(enum 15 算子) / `sub_conditions` / `value` / `value_from`
- `required: ["operation"]`，`additionalProperties: false`
- 文案写清 `value`+`value_from` 耦合、`and/or` 用 `sub_conditions` 递归、算子白名单以对象类 `condition_operations` 为准

**镜像已上线的 `query_instance_subgraph` schema** 保证两工具一致，而非自造比后端更严的契约（避免误拒 backend-valid 输入）。

## 验证
- JSON 合法：required=[operation]、additionalProperties=false、operation.enum=15
- `go build ./server/driveradapters/mcp/...` 通过

Refs #80

🤖 Generated with [Claude Code](https://claude.com/claude-code)