### PR TITLE
refactor+test(agent-retrieval): extract expandFilters + lock filters↔condition equivalence

### DIFF
--- a/adp/context-loader/agent-retrieval/server/drivenadapters/expand_filters_test.go
+++ b/adp/context-loader/agent-retrieval/server/drivenadapters/expand_filters_test.go
@@ -1,0 +1,89 @@
+// Copyright 2026 openbkn.ai
+// Copyright The kweaver.ai Authors.
+//
+// Licensed under the Apache License, Version 2.0.
+// See the LICENSE file in the project root for details.
+
+package drivenadapters
+
+import (
+	"testing"
+
+	"github.com/smartystreets/goconvey/convey"
+
+	"github.com/openbkn-ai/adp/context-loader/agent-retrieval/server/interfaces"
+)
+
+// TestExpandFilters locks the equivalence between the flat `filters` shortcut
+// and the nested `condition` it expands to. The "Messi" case mirrors the
+// condition that was verified live to return the correct goal rows.
+func TestExpandFilters(t *testing.T) {
+	convey.Convey("expandFilters", t, func() {
+
+		convey.Convey("filters 展开为等价的 and 嵌套 condition（梅西用例）", func() {
+			req := &interfaces.QueryObjectInstancesReq{
+				OtID: "goals",
+				Filters: []interfaces.FlatFilter{
+					{Field: "family_name", Op: interfaces.KnOperationTypeEqual, Value: "Messi"},
+					{Field: "own_goal", Op: interfaces.KnOperationTypeEqual, Value: 0},
+				},
+			}
+
+			expandFilters(req)
+
+			// 糖衣字段清空，不下发给 ontology-query
+			convey.So(req.Filters, convey.ShouldBeNil)
+
+			// 等价于手写的 and 嵌套 condition（每个叶子 value_from=const）
+			convey.So(req.Cond, convey.ShouldNotBeNil)
+			convey.So(req.Cond.Operation, convey.ShouldEqual, interfaces.KnOperationTypeAnd)
+			convey.So(req.Cond.SubConditions, convey.ShouldHaveLength, 2)
+
+			s0 := req.Cond.SubConditions[0]
+			convey.So(s0.Field, convey.ShouldEqual, "family_name")
+			convey.So(s0.Operation, convey.ShouldEqual, interfaces.KnOperationTypeEqual)
+			convey.So(s0.Value, convey.ShouldEqual, "Messi")
+			convey.So(s0.ValueFrom, convey.ShouldEqual, interfaces.CondValueFromConst)
+
+			s1 := req.Cond.SubConditions[1]
+			convey.So(s1.Field, convey.ShouldEqual, "own_goal")
+			convey.So(s1.Operation, convey.ShouldEqual, interfaces.KnOperationTypeEqual)
+			convey.So(s1.Value, convey.ShouldEqual, 0)
+			convey.So(s1.ValueFrom, convey.ShouldEqual, interfaces.CondValueFromConst)
+		})
+
+		convey.Convey("condition 与 filters 同传时 condition 优先，filters 被清空", func() {
+			req := &interfaces.QueryObjectInstancesReq{
+				Cond:    &interfaces.KnCondition{Operation: interfaces.KnOperationTypeOr},
+				Filters: []interfaces.FlatFilter{{Field: "x", Op: interfaces.KnOperationTypeEqual, Value: 1}},
+			}
+
+			expandFilters(req)
+
+			// 既有 condition 未被覆盖（仍是 or，不是 filters 展开出的 and）
+			convey.So(req.Cond.Operation, convey.ShouldEqual, interfaces.KnOperationTypeOr)
+			convey.So(req.Cond.SubConditions, convey.ShouldBeEmpty)
+			convey.So(req.Filters, convey.ShouldBeNil)
+		})
+
+		convey.Convey("filters 为空时不改动 condition", func() {
+			req := &interfaces.QueryObjectInstancesReq{OtID: "goals"}
+			expandFilters(req)
+			convey.So(req.Cond, convey.ShouldBeNil)
+			convey.So(req.Filters, convey.ShouldBeNil)
+		})
+
+		convey.Convey("in 算子的数组值原样透传", func() {
+			req := &interfaces.QueryObjectInstancesReq{
+				Filters: []interfaces.FlatFilter{
+					{Field: "tournament_name", Op: interfaces.KnOperationTypeIn, Value: []any{"2014", "2022"}},
+				},
+			}
+			expandFilters(req)
+			convey.So(req.Cond.SubConditions, convey.ShouldHaveLength, 1)
+			leaf := req.Cond.SubConditions[0]
+			convey.So(leaf.Operation, convey.ShouldEqual, interfaces.KnOperationTypeIn)
+			convey.So(leaf.Value, convey.ShouldResemble, []any{"2014", "2022"})
+		})
+	})
+}

--- a/adp/context-loader/agent-retrieval/server/drivenadapters/ontology_query.go
+++ b/adp/context-loader/agent-retrieval/server/drivenadapters/ontology_query.go
@@ -57,28 +57,37 @@ func NewOntologyQueryAccess() interfaces.DrivenOntologyQuery {
 }
 
 // QueryObjectInstances 检索指定对象类的对象的详细数据
+// expandFilters converts the flat Filters shortcut into a nested AND
+// condition so downstream only ever sees `condition`. It is a no-op when
+// there are no filters. When condition is already set it leaves condition
+// untouched (condition wins), but it always clears Filters so the sugar
+// field is never forwarded to ontology-query. Each filter becomes a leaf
+// with value_from=const.
+func expandFilters(req *interfaces.QueryObjectInstancesReq) {
+	if len(req.Filters) == 0 {
+		return
+	}
+	if req.Cond == nil {
+		subs := make([]*interfaces.KnCondition, 0, len(req.Filters))
+		for _, f := range req.Filters {
+			subs = append(subs, &interfaces.KnCondition{
+				Field:     f.Field,
+				Operation: f.Op,
+				Value:     f.Value,
+				ValueFrom: interfaces.CondValueFromConst,
+			})
+		}
+		req.Cond = &interfaces.KnCondition{
+			Operation:     interfaces.KnOperationTypeAnd,
+			SubConditions: subs,
+		}
+	}
+	req.Filters = nil
+}
+
 func (o *ontologyQueryClient) QueryObjectInstances(ctx context.Context, req *interfaces.QueryObjectInstancesReq) (resp *interfaces.QueryObjectInstancesResp, err error) {
 	// Expand the flat `filters` sugar into a nested condition before forwarding.
-	// Filters are AND-combined; value_from defaults to const. condition wins if
-	// both are set. Clear Filters so the sugar field is never sent downstream.
-	if len(req.Filters) > 0 {
-		if req.Cond == nil {
-			subs := make([]*interfaces.KnCondition, 0, len(req.Filters))
-			for _, f := range req.Filters {
-				subs = append(subs, &interfaces.KnCondition{
-					Field:     f.Field,
-					Operation: f.Op,
-					Value:     f.Value,
-					ValueFrom: interfaces.CondValueFromConst,
-				})
-			}
-			req.Cond = &interfaces.KnCondition{
-				Operation:     interfaces.KnOperationTypeAnd,
-				SubConditions: subs,
-			}
-		}
-		req.Filters = nil
-	}
+	expandFilters(req)
 
 	uri := fmt.Sprintf(queryObjectInstancesURI, req.KnID, req.OtID, req.IncludeTypeInfo, req.IncludeLogicParams)
 	url := fmt.Sprintf("%s%s", o.baseURL, uri)


### PR DESCRIPTION
## 背景（范围已变）

flat `filters` 糖衣特性原本在本 PR，但 **#89(`test(mf-model)`) 是 squash 合并，其分支基于本分支派生，把整个 filters 特性一并带进了 main**（内联版）。因此本 PR 去重后只剩两件事：

1. **重构**：把 `filters→condition` 展开从 `QueryObjectInstances` 抽成纯函数 `expandFilters`，便于单测（行为不变）。
2. **测试**：锁定 `filters` 与嵌套 `condition` 的等价。

## 等价验证

`expandFilters` 单测（20 断言全过）：
- **梅西用例**断言 `filters:[family_name==Messi, own_goal==0]` 展开出的 `and{两个叶子, value_from=const}` —— **正是之前对 live MCP 实测返回 13 进球的那个 condition**
- condition + filters 同传 → condition 优先，filters 清空
- 空 filters → no-op
- in 算子数组值原样透传

## 验证
- `go build ./server/...` exit 0
- `go test ./server/drivenadapters/` 全绿（含既有用例，重构未破坏）

## 注意
filters 特性经 #89 squash 进入 main 时**未经本 PR review**（分支派生导致）。功能已实测正确，本 PR 补齐重构与等价测试。

Refs #80