### PR TITLE
fix(agent-retrieval): support TOON response_format for get_action_info & get_logic_properties_values

### DIFF
--- a/adp/context-loader/agent-retrieval/docs/apis/api_private/get_action_info.yaml
+++ b/adp/context-loader/agent-retrieval/docs/apis/api_private/get_action_info.yaml
@@ -37,6 +37,16 @@ paths:
               - app
               - anonymous
           description: 账户类型：user(用户), app(应用), anonymous(匿名)
+        - name: response_format
+          in: query
+          required: false
+          schema:
+            type: string
+            enum:
+              - json
+              - toon
+            default: json
+          description: 响应格式：json 或 toon，默认 json
       requestBody:
         required: true
         content:

--- a/adp/context-loader/agent-retrieval/server/bootstrap/tool_dependencies/context_loader_toolset.adp
+++ b/adp/context-loader/agent-retrieval/server/bootstrap/tool_dependencies/context_loader_toolset.adp
@@ -2133,6 +2133,20 @@
                       ],
                       "type": "string"
                     }
+                  },
+                  {
+                    "name": "response_format",
+                    "in": "query",
+                    "description": "响应格式：json 或 toon，默认 json",
+                    "required": false,
+                    "schema": {
+                      "default": "json",
+                      "enum": [
+                        "json",
+                        "toon"
+                      ],
+                      "type": "string"
+                    }
                   }
                 ],
                 "request_body": {

--- a/adp/context-loader/agent-retrieval/server/driveradapters/mcp/schemas/get_action_info.json
+++ b/adp/context-loader/agent-retrieval/server/driveradapters/mcp/schemas/get_action_info.json
@@ -2,6 +2,12 @@
   "input_schema": {
     "type": "object",
     "properties": {
+      "response_format": {
+        "type": "string",
+        "enum": ["json", "toon"],
+        "default": "toon",
+        "description": "文本格式：json 或 toon，默认 toon"
+      },
       "kn_id": {
         "type": "string",
         "description": "知识网络 ID。也可改用 X-Kn-ID 请求头传入。"

--- a/adp/context-loader/agent-retrieval/server/driveradapters/mcp/schemas/get_logic_properties_values.json
+++ b/adp/context-loader/agent-retrieval/server/driveradapters/mcp/schemas/get_logic_properties_values.json
@@ -2,6 +2,12 @@
   "input_schema": {
     "type": "object",
     "properties": {
+      "response_format": {
+        "type": "string",
+        "enum": ["json", "toon"],
+        "default": "toon",
+        "description": "文本格式：json 或 toon，默认 toon"
+      },
       "kn_id": {
         "type": "string",
         "description": "知识网络 ID。也可改用 X-Kn-ID 请求头传入。"

--- a/adp/context-loader/agent-retrieval/server/driveradapters/mcp/tools.go
+++ b/adp/context-loader/agent-retrieval/server/driveradapters/mcp/tools.go
@@ -15,7 +15,6 @@ import (
 	"github.com/mark3labs/mcp-go/mcp"
 
 	"github.com/openbkn-ai/adp/context-loader/agent-retrieval/server/infra/common"
-	"github.com/openbkn-ai/adp/context-loader/agent-retrieval/server/infra/rest"
 	"github.com/openbkn-ai/adp/context-loader/agent-retrieval/server/interfaces"
 	logicsKqs "github.com/openbkn-ai/adp/context-loader/agent-retrieval/server/logics/knquerysubgraph"
 	"github.com/openbkn-ai/adp/context-loader/agent-retrieval/server/logics/knrunsql"
@@ -196,7 +195,10 @@ func handleGetActionInfo(service interfaces.IKnActionRecallService) func(ctx con
 		if !ok {
 			return mcp.NewToolResultError("authentication required"), nil
 		}
-		format := rest.FormatJSON
+		format, err := GetResponseFormatFromRequest(req)
+		if err != nil {
+			return mcp.NewToolResultError(err.Error()), nil
+		}
 
 		actionReq := &interfaces.KnActionRecallRequest{}
 		if err := bindArguments(req, actionReq); err != nil {


### PR DESCRIPTION
## 背景

agent-retrieval 的 MCP 工具默认 `response_format: toon`（省 token），但两个工具的 TOON 支持不完整：
- `get_action_info`：handler 硬编码 `format := rest.FormatJSON`，恒 JSON，忽略请求
- `get_logic_properties_values`：handler 已读 format，但 MCP schema 没声明 `response_format`，LLM 选不了

## 改动（MCP，3 文件）

- `tools.go` `handleGetActionInfo`：改为 `GetResponseFormatFromRequest`（默认 toon，与其它 7 个 handler 一致）；删除随之 unused 的 `rest` import
- `get_action_info.json` + `get_logic_properties_values.json`：声明 `response_format`（enum json/toon，default toon）

## REST 侧
REST 公网端点已由全局 `middlewareResponseFormat()` 统一支持 response_format；`get_logic_properties_values.yaml` 已文档化。`get_action_info.yaml` 的文档缺口为小跟进项（功能已支持），未在本 PR 处理以保持聚焦。

## 验证
- `go build ./server/...` exit 0
- 两个 schema JSON 合法，response_format 已声明

## 边缘案例（建议）
- get_action_info 传 `response_format: json` → JSON；不传 → toon
- 非法 response_format 值 → GetResponseFormatFromRequest 返错（与其它工具一致行为）

Closes #91

🤖 Generated with [Claude Code](https://claude.com/claude-code)