### PR TITLE
feat(bkn-safe): self-service profile update (PUT /api/safe/v1/me)

### DIFF
--- a/bkn-safe/docs/API.md
+++ b/bkn-safe/docs/API.md
@@ -169,11 +169,26 @@ curl -X POST $SAFE/api/safe/v1/authz/check -H 'Content-Type: application/json' \
 
 ```json
 { "id": "b38b...", "account": "test", "name": "测试用户", "email": "t@x.io",
-  "account_type": "user", "departments": ["d-9"],
-  "roles": ["数据管理员"], "role_ids": ["00990824-..."] }
+  "telephone": "13800000000", "account_type": "user", "enabled": true,
+  "departments": ["d-9"], "roles": ["数据管理员"], "role_ids": ["00990824-..."],
+  "updated_at": "2026-06-29T12:00:00Z" }
 ```
 
 > 菜单逻辑请依赖 `role_ids`(保号 UUID)而非 `roles`(显示名,可改名)。
+
+### PUT "" — 自助修改个人资料
+
+登录用户改**自己的**资料。目标恒为 token subject(无 `:id`),改不到别人,无需 admin 权限。仅 `name`/`email`/`telephone` 可写;`account_type`/`enabled`/部门/account/password 不在此(各有专属端点或 admin-only)。仅 body 中出现的键被修改,缺省键不动。
+
+```json
+PUT /api/safe/v1/me
+{ "name": "新名字", "email": "new@x.io", "telephone": "13800000000" }
+→ 204
+```
+
+- 校验:`name` 去空格后非空、≤255;`email` 非空时须为裸地址(无显示名),空串清空;`telephone` ≤64。
+- 无可更新字段 → 400;校验不过 → 400;subject 无用户行 → 404。
+- 改密码走 `POST /api/safe/v1/auth/change-password`(凭旧密码),不在此。
 
 ### GET /permissions — 当前访问者的全量权限列表
 

--- a/bkn-safe/server/internal/directory/directory.go
+++ b/bkn-safe/server/internal/directory/directory.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"time"
 
 	"gorm.io/gorm"
 	"gorm.io/gorm/clause"
@@ -46,15 +47,16 @@ type NamedRef struct {
 
 // UserDetail is the full user view (with roles + department chain ids).
 type UserDetail struct {
-	ID          string   `json:"id"`
-	Account     string   `json:"account"`
-	Name        string   `json:"name"`
-	Email       string   `json:"email"`
-	Telephone   string   `json:"telephone"`
-	Enabled     bool     `json:"enabled"`
-	AccountType string   `json:"account_type"`
-	Roles       []string `json:"roles"`
-	Departments []string `json:"departments"`
+	ID          string    `json:"id"`
+	Account     string    `json:"account"`
+	Name        string    `json:"name"`
+	Email       string    `json:"email"`
+	Telephone   string    `json:"telephone"`
+	Enabled     bool      `json:"enabled"`
+	AccountType string    `json:"account_type"`
+	Roles       []string  `json:"roles"`
+	Departments []string  `json:"departments"`
+	UpdatedAt   time.Time `json:"updated_at"`
 }
 
 // GetUser returns a user's detail, or gorm.ErrRecordNotFound.
@@ -66,6 +68,7 @@ func (s *Service) GetUser(ctx context.Context, id string) (*UserDetail, error) {
 	d := &UserDetail{
 		ID: u.ID, Account: u.Account, Name: u.Name, Email: u.Email,
 		Telephone: u.Telephone, Enabled: u.Enabled, AccountType: string(u.AccountType),
+		UpdatedAt: u.UpdatedAt,
 	}
 	// department ids
 	var uds []model.UserDepartment

--- a/bkn-safe/server/internal/httpapi/me.go
+++ b/bkn-safe/server/internal/httpapi/me.go
@@ -3,24 +3,27 @@ package httpapi
 import (
 	"errors"
 	"net/http"
+	"net/mail"
+	"strings"
 
 	"github.com/gin-gonic/gin"
 	"gorm.io/gorm"
 
+	"bkn-safe/internal/auth"
 	"bkn-safe/internal/authz"
 	"bkn-safe/internal/directory"
 	"bkn-safe/internal/model"
 )
 
-// registerMe mounts the self-service reads under /api/safe/v1/me.
+// registerMe mounts the self-service reads/writes under /api/safe/v1/me.
 // Token-gated by RequireUser: the accessor id comes from the verified bearer
-// token, never from the request — a caller can only read its own data.
+// token, never from the request — a caller can only read/edit its own data.
 // Frontends call these once after login to drive menu/button visibility; the
 // backend still enforces every request via /authz/check.
-func registerMe(g *gin.RouterGroup, e *authz.Enforcer, db *gorm.DB, dir *directory.Service) {
+func registerMe(g *gin.RouterGroup, e *authz.Enforcer, db *gorm.DB, dir *directory.Service, users *auth.UserStore) {
 	// GET "" -> the caller's identity and roles:
-	// { id, account, name, email, account_type, departments:[ids],
-	//   roles:[names], role_ids:[ids] }
+	// { id, account, name, email, telephone, account_type, enabled,
+	//   departments:[ids], roles:[names], role_ids:[ids], updated_at }
 	// Role names resolve via the roles table; a dangling binding (role row
 	// deleted) falls back to the raw id rather than being dropped.
 	g.GET("", func(c *gin.Context) {
@@ -67,12 +70,83 @@ func registerMe(g *gin.RouterGroup, e *authz.Enforcer, db *gorm.DB, dir *directo
 			"account":      user.Account,
 			"name":         user.Name,
 			"email":        user.Email,
+			"telephone":    user.Telephone,
 			"account_type": user.AccountType,
+			"enabled":      user.Enabled,
 			"departments":  user.Departments,
 			"roles":        roleNames,
 			"role_ids":     roleIDs,
+			"updated_at":   user.UpdatedAt,
 		})
 	})
+
+	// PUT "" -> self-service profile update. The target is ALWAYS the token
+	// subject (never an :id from the path/body), so a caller can only edit its
+	// own profile — no admin grant required. Only name/email/telephone are
+	// writable here; account_type, enabled, department membership, account, and
+	// password stay admin-only / have their own endpoints. Only keys present in
+	// the body are changed; an absent key is left untouched. -> 204.
+	if users != nil {
+		g.PUT("", func(c *gin.Context) {
+			var req struct {
+				Name      *string `json:"name"`
+				Email     *string `json:"email"`
+				Telephone *string `json:"telephone"`
+			}
+			if !bind(c, &req) {
+				return
+			}
+			fields := map[string]any{}
+			if req.Name != nil {
+				name := strings.TrimSpace(*req.Name)
+				if name == "" {
+					c.JSON(http.StatusBadRequest, gin.H{"error": "name cannot be empty"})
+					return
+				}
+				if len(name) > 255 {
+					c.JSON(http.StatusBadRequest, gin.H{"error": "name too long (max 255)"})
+					return
+				}
+				fields["name"] = name
+			}
+			if req.Email != nil {
+				email := strings.TrimSpace(*req.Email)
+				// An empty email clears the field; a non-empty one must parse as a
+				// single, bare address (no display name / list).
+				if email != "" {
+					addr, err := mail.ParseAddress(email)
+					if err != nil || addr.Name != "" || addr.Address != email {
+						c.JSON(http.StatusBadRequest, gin.H{"error": "invalid email"})
+						return
+					}
+				}
+				fields["email"] = email
+			}
+			if req.Telephone != nil {
+				tel := strings.TrimSpace(*req.Telephone)
+				if len(tel) > 64 {
+					c.JSON(http.StatusBadRequest, gin.H{"error": "telephone too long (max 64)"})
+					return
+				}
+				fields["telephone"] = tel
+			}
+			if len(fields) == 0 {
+				c.JSON(http.StatusBadRequest, gin.H{"error": "no updatable fields provided"})
+				return
+			}
+			sub := c.GetString(ctxAccessorID)
+			err := users.UpdateUser(c.Request.Context(), sub, fields)
+			if errors.Is(err, gorm.ErrRecordNotFound) {
+				c.JSON(http.StatusNotFound, gin.H{"error": "no user for token subject: " + sub})
+				return
+			}
+			if err != nil {
+				serverError(c, err)
+				return
+			}
+			c.Status(http.StatusNoContent)
+		})
+	}
 
 	// GET /permissions -> { is_admin, permissions:[ { resource{type,id}, operations:[...] } ] }
 	// Includes role-inherited grants; type-wide patterns keep id "*".

--- a/bkn-safe/server/internal/httpapi/me_test.go
+++ b/bkn-safe/server/internal/httpapi/me_test.go
@@ -85,6 +85,85 @@ func TestMeIdentity(t *testing.T) {
 	}
 }
 
+// PUT /me lets a user edit its own name/email/telephone; the target is the
+// token subject, so it can never touch another user. Validation rejects bad
+// email / empty name / empty body; non-writable fields are ignored.
+func TestMeUpdateProfile(t *testing.T) {
+	r, _, db, _ := newAdminServer(t)
+	const path = "/api/safe/v1/me"
+
+	db.Create(&model.User{ID: "u-me", Account: "me", Name: "Me", Email: "me@x.io", Enabled: true, AccountType: model.AccountTypeOther})
+	db.Create(&model.User{ID: "u-other", Account: "other", Name: "Other", Enabled: true})
+
+	// no token -> 401
+	if w := tokReq(t, r, http.MethodPut, path, map[string]any{"name": "X"}, ""); w.Code != http.StatusUnauthorized {
+		t.Errorf("no token: want 401, got %d", w.Code)
+	}
+	// subject without a user row -> 404
+	if w := tokReq(t, r, http.MethodPut, path, map[string]any{"name": "X"}, "ghost"); w.Code != http.StatusNotFound {
+		t.Errorf("ghost: want 404, got %d", w.Code)
+	}
+	// empty body -> 400
+	if w := tokReq(t, r, http.MethodPut, path, map[string]any{}, "u-me"); w.Code != http.StatusBadRequest {
+		t.Errorf("empty body: want 400, got %d", w.Code)
+	}
+	// empty name -> 400
+	if w := tokReq(t, r, http.MethodPut, path, map[string]any{"name": "  "}, "u-me"); w.Code != http.StatusBadRequest {
+		t.Errorf("empty name: want 400, got %d", w.Code)
+	}
+	// bad email -> 400
+	if w := tokReq(t, r, http.MethodPut, path, map[string]any{"email": "not-an-email"}, "u-me"); w.Code != http.StatusBadRequest {
+		t.Errorf("bad email: want 400, got %d", w.Code)
+	}
+	// display-name email form rejected -> 400
+	if w := tokReq(t, r, http.MethodPut, path, map[string]any{"email": "Me <me@x.io>"}, "u-me"); w.Code != http.StatusBadRequest {
+		t.Errorf("display-name email: want 400, got %d", w.Code)
+	}
+
+	// happy path: edit own profile. account_type is not writable here and is
+	// silently ignored.
+	body := map[string]any{"name": "  New Me  ", "email": "new@x.io", "telephone": "13800000000", "account_type": "id_card"}
+	if w := tokReq(t, r, http.MethodPut, path, body, "u-me"); w.Code != http.StatusNoContent {
+		t.Fatalf("update: want 204, got %d (%s)", w.Code, w.Body.String())
+	}
+	var got model.User
+	db.First(&got, "id = ?", "u-me")
+	if got.Name != "New Me" { // trimmed
+		t.Errorf("name = %q, want %q (trimmed)", got.Name, "New Me")
+	}
+	if got.Email != "new@x.io" || got.Telephone != "13800000000" {
+		t.Errorf("profile not applied: %+v", got)
+	}
+	if got.AccountType != model.AccountTypeOther {
+		t.Errorf("account_type changed to %q — must be ignored by self-update", got.AccountType)
+	}
+
+	// GET /me reflects the update, including the new fields.
+	w := tokReq(t, r, http.MethodGet, path, nil, "u-me")
+	if w.Code != http.StatusOK {
+		t.Fatalf("get: want 200, got %d", w.Code)
+	}
+	var resp struct {
+		Name      string `json:"name"`
+		Email     string `json:"email"`
+		Telephone string `json:"telephone"`
+		Enabled   bool   `json:"enabled"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if resp.Name != "New Me" || resp.Email != "new@x.io" || resp.Telephone != "13800000000" || !resp.Enabled {
+		t.Errorf("GET /me = %+v", resp)
+	}
+
+	// the edit never touched the other user.
+	var other model.User
+	db.First(&other, "id = ?", "u-other")
+	if other.Name != "Other" {
+		t.Errorf("u-other mutated: %+v", other)
+	}
+}
+
 func TestMePermissions(t *testing.T) {
 	r, e, _, _ := newAdminServer(t)
 	const path = "/api/safe/v1/me/permissions"

--- a/bkn-safe/server/internal/httpapi/router.go
+++ b/bkn-safe/server/internal/httpapi/router.go
@@ -113,7 +113,7 @@ func New(deps Deps) *gin.Engine {
 	// authn only), gateway-exposed. The caller reads its own permission list.
 	if deps.Enforcer != nil && verifier != nil && deps.Directory != nil {
 		me := r.Group("/api/safe/v1/me", RequireUser(verifier))
-		registerMe(me, deps.Enforcer, deps.DB, deps.Directory)
+		registerMe(me, deps.Enforcer, deps.DB, deps.Directory, deps.Users)
 		// Self-service AppKey management (issue/list/revoke own keys).
 		if apiKeys != nil {
 			registerMeAPIKeys(me, apiKeys)


### PR DESCRIPTION
Closes #92.

## 背景
登录用户能读自己的资料(`GET /api/safe/v1/me`),但写资料只有 admin 端点 `PUT /api/safe/v1/admin/users/:id`(需 admin 权限)。Studio 个人中心「资料」Tab 需要自助修改。本 PR 补上自助写。

## 改动
- **新增 `PUT /api/safe/v1/me`**:目标恒为 token subject(无 `:id`),只能改自己,免 admin 权限。仅 `name`/`email`/`telephone` 可写——`account_type`/`enabled`/部门/account/password 不在此(各有专属端点或 admin-only)。部分更新(仅 body 出现的键被改)。
  - 校验:`name` 去空格非空且 ≤255;`email` 非空须为裸地址(`net/mail`,拒显示名,空串清空);`telephone` ≤64。
  - 错误码:无可更新字段→400、校验不过→400、subject 无用户行→404、无 token→401。
- **`GET /api/safe/v1/me` 补字段**:`telephone` / `enabled` / `updated_at`(`directory.UserDetail` + `GetUser` 加 `updated_at`),喂前端资料页。

## 测试
- `TestMeUpdateProfile`:happy path + 越权不动别人 + 空 body / 空 name / 坏 email / 显示名 email / ghost subject / 无 token 全分支。
- `go test ./...` 全绿,`gofmt`/`go vet` 净。

## 待确认
issue 还要 **职位/title** 字段——`User` model 无此列,本 PR **未加**(要加需 schema 迁移)。如需,另开。

前端跟踪:openbkn-ai/bkn-studio#8 · Linear OPE-25

🤖 Generated with [Claude Code](https://claude.com/claude-code)