### PR TITLE
fix(deploy): diagnose stale/unreachable kubeconfig on platform-prereq failure (#97 part 1)

### DIFF
--- a/deploy/scripts/lib/common.sh
+++ b/deploy/scripts/lib/common.sh
@@ -1402,6 +1402,26 @@ log_error() {
     echo -e "${RED}[ERROR]${NC} $1"
 }
 
+# Diagnose a likely-stale / unreachable kubeconfig context. Call on failure paths
+# where kubectl could not reach a cluster — most often the active kubeconfig points
+# at a leftover context from a previously-installed platform (e.g. an old AnyShare
+# cluster), not the cluster this install set up.
+diagnose_cluster_context() {
+    local ctx server
+    ctx="$(kubectl config current-context 2>/dev/null || echo '(none)')"
+    server="$(kubectl config view --minify -o jsonpath='{.clusters[0].cluster.server}' 2>/dev/null || true)"
+    log_warn "Active kubectl context: ${ctx}  (apiserver: ${server:-unknown})"
+    log_warn "KUBECONFIG=${KUBECONFIG:-<default ~/.kube/config>}"
+    if ! kubectl cluster-info >/dev/null 2>&1; then
+        log_error "That Kubernetes API is unreachable — the install did not reach a working cluster."
+        log_error "If you expected a fresh local cluster, a stale kubeconfig may be overriding it:"
+        log_error "  k3s    : unset KUBECONFIG; export KUBECONFIG=/etc/rancher/k3s/k3s.yaml; kubectl get nodes"
+        log_error "  kubeadm: export KUBECONFIG=/etc/kubernetes/admin.conf; kubectl get nodes"
+        log_error "  or move a leftover config aside: mv ~/.kube/config ~/.kube/config.bak"
+        log_error "If '${server:-that server}' IS your intended cluster, fix its apiserver/load-balancer reachability and re-run."
+    fi
+}
+
 k8s_is_running() {
     if ! command -v kubectl >/dev/null 2>&1; then
         return 1

--- a/deploy/scripts/services/core.sh
+++ b/deploy/scripts/services/core.sh
@@ -441,6 +441,7 @@ install_core() {
 
     if ! ensure_platform_prerequisites; then
         log_error "Failed to ensure platform prerequisites for BKN Foundry"
+        diagnose_cluster_context
         return 1
     fi
 


### PR DESCRIPTION
## 背景(#97 part 1)

机器若残留旧平台的 kubeconfig(如旧 AnyShare/proton 集群 `proton-cs.lb.aishu.cn`),deploy.sh 会**沿用那个旧 context** → 所有 kubectl/helm 打到不可达集群 → 只报含糊的 "Failed to ensure platform prerequisites",用户无从下手(这正是实际遇到的报错)。

## 改动(加性,仅失败路径,不改控制流)
- `common.sh` 新增 `diagnose_cluster_context()`:打印当前 context + apiserver + 生效的 KUBECONFIG;当 API 不可达时给出**可执行指引**(切到本地 k3s/kubeadm kubeconfig、或挪走残留 `~/.kube/config`、或修复目标集群可达性)。
- `core.sh` 在 `install_core` 的 prereq 失败处调用它。

失败时输出示例:
```
[WARN] Active kubectl context: proton-cs  (apiserver: https://proton-cs.lb.aishu.cn:8443)
[WARN] KUBECONFIG=<default ~/.kube/config>
[ERROR] That Kubernetes API is unreachable — the install did not reach a working cluster.
[ERROR] If you expected a fresh local cluster, a stale kubeconfig may be overriding it:
[ERROR]   k3s    : unset KUBECONFIG; export KUBECONFIG=/etc/rancher/k3s/k3s.yaml; kubectl get nodes
[ERROR]   ...
```

## 验证
- `bash -n` 通过(common.sh + core.sh);函数实跑确认输出格式
- 加性改动,happy path 不受影响
- (sourced lib 的 SC2148 "no shebang" 是预存,与本改无关)

## 未做(#97 part 2,需决策)
仓库残留 proton/aishu **依赖**(`proton-rds-sdk-go`/`proton-mq-sdk-go` 被 6/4 个服务用且撑**信创 DM8/KDB9** 支持、`proton-*` charts、`acr.aishu.cn` base 镜像)—— 砍除涉及信创支持取舍,需产品决策,留 #97。

Refs #97

🤖 Generated with [Claude Code](https://claude.com/claude-code)