### PR TITLE
feat(execution-factory): publish capabilities lab service

### DIFF
--- a/.github/workflows/release-adp-capabilities-lab.yml
+++ b/.github/workflows/release-adp-capabilities-lab.yml
@@ -1,0 +1,49 @@
+name: release-adp-capabilities-lab
+
+on:
+  push:
+    tags:
+      - 'v*'
+    branches: ['**']
+    paths:
+      - 'adp/execution-factory/capabilities-lab/**'
+      - '.github/workflows/release-adp-capabilities-lab.yml'
+      - '.github/workflows/reusable-*.yml'
+  workflow_dispatch:
+    inputs:
+      publish:
+        description: 'Publish to GHCR (true) or verify build only (false)'
+        type: boolean
+        default: false
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  test:
+    uses: ./.github/workflows/reusable-test.yml
+    with:
+      service-path: adp/execution-factory/capabilities-lab
+      stack: chart-only
+
+  build:
+    needs: test
+    uses: ./.github/workflows/reusable-build.yml
+    secrets: inherit
+    with:
+      service-path: adp/execution-factory/capabilities-lab
+      dockerfile: docker/Dockerfile
+      context: '.'
+      image-name: capabilities-lab
+      version: ${{ needs.test.outputs.version }}
+      publish: ${{ github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && inputs.publish) }}
+
+  chart:
+    needs: [test, build]
+    uses: ./.github/workflows/reusable-chart.yml
+    with:
+      service-path: adp/execution-factory/capabilities-lab
+      chart-path: helm/capabilities-lab
+      chart-name: capabilities-lab
+      version: ${{ needs.test.outputs.version }}
+      publish: ${{ github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && inputs.publish) }}

--- a/adp/execution-factory/capabilities-lab/helm/capabilities-lab/Chart.yaml
+++ b/adp/execution-factory/capabilities-lab/helm/capabilities-lab/Chart.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+appVersion: "1.0.0"
+description: Helm chart for the Execution Factory capabilities lab service
+name: capabilities-lab
+version: 0.1.0

--- a/adp/execution-factory/capabilities-lab/helm/capabilities-lab/templates/deployment.yaml
+++ b/adp/execution-factory/capabilities-lab/helm/capabilities-lab/templates/deployment.yaml
@@ -1,0 +1,117 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ .Release.Name }}
+  namespace: {{ .Values.namespace }}
+  labels:
+    app: {{ .Release.Name }}
+spec:
+  selector:
+    matchLabels:
+      app: {{ .Release.Name }}
+  replicas: {{ .Values.replicaCount }}
+  strategy:
+    rollingUpdate:
+      maxSurge: 0
+      maxUnavailable: 25%
+    type: RollingUpdate
+  template:
+    metadata:
+      labels:
+        app: {{ .Release.Name }}
+    spec:
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- if ne .Values.runMode "dev" }}
+      {{- if eq .Values.enableSecurityContext true }}
+      {{- with .Values.securityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- end }}
+      {{- end }}
+      containers:
+        - name: {{ .Release.Name }}
+          {{- if ne .Values.runMode "dev" }}
+          image: "{{ .Values.image.registry }}/{{ .Values.image.service.repository }}:{{ .Values.image.service.tag }}"
+          imagePullPolicy: {{ .Values.image.service.pullPolicy }}
+          {{- else }}
+          image: "acr.aishu.cn/client/godevenv:1.16.2"
+          {{- end }}
+          env:
+            - name: HOST
+              value: "0.0.0.0"
+            - name: PORT
+              value: {{ .Values.service.port | quote }}
+            - name: OPERATOR_INTEGRATION_URL
+              value: "{{ index .Values "depServices" "agent-operator-integration" "privateProtocol" }}://{{ index .Values "depServices" "agent-operator-integration" "privateHost" }}:{{ index .Values "depServices" "agent-operator-integration" "privatePort" }}"
+            - name: DEFAULT_BUSINESS_DOMAIN
+              value: {{ .Values.service.defaultBusinessDomain | quote }}
+            - name: DEFAULT_USER_ID
+              value: {{ .Values.service.defaultUserID | quote }}
+            - name: LAB_METRICS_ENABLED
+              value: {{ .Values.service.metricsEnabled | quote }}
+            - name: LAB_FEATURE_CATALOG
+              value: {{ .Values.service.features.catalog | quote }}
+            - name: LAB_FEATURE_FUNCTION
+              value: {{ .Values.service.features.function | quote }}
+            - name: LAB_FEATURE_IMPEX
+              value: {{ .Values.service.features.impex | quote }}
+            - name: LAB_FEATURE_MCP_SSE_WIZARD
+              value: {{ .Values.service.features.mcpSseWizard | quote }}
+            - name: LAB_FEATURE_SKILL_FILES
+              value: {{ .Values.service.features.skillFiles | quote }}
+            - name: LAB_HIDE_LEGACY_EXECUTION_FACTORY
+              value: {{ .Values.service.features.hideLegacyExecutionFactoryMenu | quote }}
+            {{- if .Values.env.language }}
+            - name: LANG
+              value: {{ .Values.env.language | quote }}
+            - name: LC_ALL
+              value: {{ .Values.env.language | quote }}
+            {{- end }}
+            {{- if .Values.env.timezone }}
+            - name: TZ
+              value: {{ .Values.env.timezone | quote }}
+            {{- end }}
+          ports:
+            - name: public-port
+              containerPort: {{ .Values.service.port }}
+          {{- if ne .Values.runMode "dev" }}
+          readinessProbe:
+            httpGet:
+              path: /api/capabilities-lab/v1/health
+              port: public-port
+            initialDelaySeconds: {{ .Values.service.readinessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.service.readinessProbe.periodSeconds }}
+            timeoutSeconds: {{ .Values.service.readinessProbe.timeoutSeconds }}
+            failureThreshold: {{ .Values.service.readinessProbe.failureThreshold }}
+          livenessProbe:
+            httpGet:
+              path: /api/capabilities-lab/v1/health
+              port: public-port
+            initialDelaySeconds: {{ .Values.service.livenessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.service.livenessProbe.periodSeconds }}
+            timeoutSeconds: {{ .Values.service.livenessProbe.timeoutSeconds }}
+            failureThreshold: {{ .Values.service.livenessProbe.failureThreshold }}
+          startupProbe:
+            httpGet:
+              path: /api/capabilities-lab/v1/health
+              port: public-port
+            initialDelaySeconds: {{ .Values.service.startupProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.service.startupProbe.periodSeconds }}
+            timeoutSeconds: {{ .Values.service.startupProbe.timeoutSeconds }}
+            failureThreshold: {{ .Values.service.startupProbe.failureThreshold }}
+          resources:
+            requests:
+              cpu: {{ .Values.resources.requests.cpu }}
+              memory: {{ .Values.resources.requests.memory }}
+            limits:
+              cpu: {{ .Values.resources.limits.cpu }}
+              memory: {{ .Values.resources.limits.memory }}
+          {{- end }}
+      dnsConfig:
+        options:
+          - name: single-request-reopen
+          - name: use-vc

--- a/adp/execution-factory/capabilities-lab/helm/capabilities-lab/templates/ingress.yaml
+++ b/adp/execution-factory/capabilities-lab/helm/capabilities-lab/templates/ingress.yaml
@@ -1,0 +1,28 @@
+{{- if .Values.service.ingress.enabled -}}
+{{- if .Values.service.ingress.interface }}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ .Values.moduleName }}-ingress
+  namespace: {{ .Values.namespace }}
+  annotations:
+    nginx.ingress.kubernetes.io/ssl-redirect: "false"
+    nginx.ingress.kubernetes.io/proxy-body-size: 2048m
+spec:
+{{- if index .Values.depServices "class-443" "ingressClass" }}
+  ingressClassName: {{ index .Values.depServices "class-443" "ingressClass" }}
+{{- end }}
+  rules:
+    - http:
+        paths:
+          {{- range .Values.service.ingress.interface.path }}
+          - path: {{ . }}
+            pathType: Prefix
+            backend:
+              service:
+                name: {{ $.Release.Name }}
+                port:
+                  number: {{ $.Values.service.port }}
+          {{- end }}
+{{- end }}
+{{- end }}

--- a/adp/execution-factory/capabilities-lab/helm/capabilities-lab/templates/service.yaml
+++ b/adp/execution-factory/capabilities-lab/helm/capabilities-lab/templates/service.yaml
@@ -1,0 +1,22 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ .Release.Name }}
+  namespace: {{ .Values.namespace }}
+  labels:
+    app: {{ .Release.Name }}
+spec:
+  {{- if .Values.service.enableDualStack }}
+  ipFamilies:
+    - IPv6
+    - IPv4
+  ipFamilyPolicy: PreferDualStack
+  {{- end }}
+  ports:
+    - name: public-port
+      port: {{ .Values.service.port }}
+      protocol: TCP
+      targetPort: public-port
+  selector:
+    app: {{ .Release.Name }}
+  type: {{ .Values.service.type }}

--- a/adp/execution-factory/capabilities-lab/helm/capabilities-lab/values.yaml
+++ b/adp/execution-factory/capabilities-lab/helm/capabilities-lab/values.yaml
@@ -1,0 +1,76 @@
+replicaCount: 1
+
+nodeSelector: {}
+
+namespace: openbkn
+moduleName: capabilities-lab
+
+runMode: release
+
+enableSecurityContext: true
+securityContext:
+  runAsUser: 5000
+  runAsGroup: 5000
+
+image:
+  registry: ghcr.io/openbkn-ai
+  service:
+    repository: capabilities-lab
+    tag: "__VERSION__"
+    pullPolicy: IfNotPresent
+
+service:
+  name: capabilities-lab
+  type: ClusterIP
+  enableDualStack: false
+  port: 9002
+  defaultBusinessDomain: bd_public
+  defaultUserID: capabilities-lab
+  metricsEnabled: true
+  features:
+    catalog: true
+    function: true
+    impex: true
+    mcpSseWizard: true
+    skillFiles: true
+    hideLegacyExecutionFactoryMenu: false
+  ingress:
+    enabled: true
+    interface:
+      path:
+        - /api/capabilities-lab/v1
+  readinessProbe:
+    initialDelaySeconds: 5
+    periodSeconds: 5
+    timeoutSeconds: 3
+    failureThreshold: 10
+  livenessProbe:
+    initialDelaySeconds: 5
+    periodSeconds: 5
+    timeoutSeconds: 3
+    failureThreshold: 6
+  startupProbe:
+    initialDelaySeconds: 5
+    periodSeconds: 5
+    timeoutSeconds: 5
+    failureThreshold: 30
+
+depServices:
+  class-443:
+    ingressClass: class-443
+  agent-operator-integration:
+    privateHost: agent-operator-integration
+    privatePort: 9000
+    privateProtocol: http
+
+env:
+  language: en_US.UTF-8
+  timezone: Asia/Shanghai
+
+resources:
+  requests:
+    cpu: 100m
+    memory: 128Mi
+  limits:
+    cpu: 1
+    memory: 1Gi

--- a/deploy/release-manifests/0.1.0/bkn-foundry.yaml
+++ b/deploy/release-manifests/0.1.0/bkn-foundry.yaml
@@ -39,6 +39,9 @@ releases:
   agent-operator-integration:
     chart: agent-operator-integration
     version: 0.1.0
+  capabilities-lab:
+    chart: capabilities-lab
+    version: 0.1.0
   agent-retrieval:
     chart: agent-retrieval
     version: 0.1.0


### PR DESCRIPTION
﻿## Summary
- add a Helm chart for `capabilities-lab`
- add release workflow `release-adp-capabilities-lab.yml`
- add `capabilities-lab` to the `bkn-foundry` 0.1.0 release manifest

## Notes
The `capabilities-lab` service code is already present on `origin/main` via the existing capabilities-lab PR. This branch only wires the service into the publish/deploy path.

## Verification
- `go test ./...` in `adp/execution-factory/capabilities-lab`
- `docker build -f docker/Dockerfile -t capabilities-lab:local .`
- `docker run --rm -v "${PWD}:/work" -w /work alpine/helm:3.15.4 lint adp/execution-factory/capabilities-lab/helm/capabilities-lab`
- `docker run --rm -v "${PWD}:/work" -w /work alpine/helm:3.15.4 template capabilities-lab adp/execution-factory/capabilities-lab/helm/capabilities-lab --namespace openbkn`
