### PR TITLE
fix(ci): monotonic build version via embedded commit date

### DIFF
--- a/.github/workflows/reusable-test.yml
+++ b/.github/workflows/reusable-test.yml
@@ -62,7 +62,13 @@ jobs:
             VERSION="$BASE_VERSION"
           else
             SANITIZED_BRANCH="$(echo "$REF_NAME" | tr '[:upper:]' '[:lower:]' | sed -E 's#[^0-9a-zA-Z.-]+#-#g; s#-+#-#g; s#^[.-]+##; s#[.-]+$##')"
-            VERSION="$BASE_VERSION-$SANITIZED_BRANCH.sha$SHORT_SHA"
+            # Embed the commit time (UTC, fixed-width YYYYMMDDHHMMSS) so the
+            # prerelease is monotonically sortable as a plain string — picking
+            # "newest" needs no resolving the sha against a local git history
+            # (the old scheme silently mis-ordered on shallow/foreign checkouts).
+            # Commit time, not build time, so CI re-runs stay reproducible.
+            COMMIT_DATE="$(TZ=UTC git show -s --format=%cd --date=format-local:%Y%m%d%H%M%S HEAD)"
+            VERSION="$BASE_VERSION-$SANITIZED_BRANCH.$COMMIT_DATE.sha$SHORT_SHA"
           fi
 
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -170,7 +170,7 @@ source (`branch` / `stable` / `base`). Requires `gh` (authenticated,
 
 Before a release is cut there is **no clean stable**, so to install the **newest
 build of every component** use `--latest` — it resolves each chart to its newest
-`…-main.sha…` build (ordered by git commit time), else latest stable:
+`…-main.<date>.sha…` build (ordered by the commit time embedded in the tag), else latest stable:
 
 ```bash
 ./scripts/gen-dev-manifest.sh --latest --out=/tmp/m.yaml
@@ -186,7 +186,7 @@ On clusters that can't reach `docker.io` or pull GHCR image blobs (read timeouts
 `foundry install` accepts three flags so the **script** handles it — no manual
 `crictl pull`/retag:
 
-- **`--registry=<swr / ghcr / host/ns>`** — image registry for **BKN images** (sugar for `--set image.registry`). `swr` → `swr.cn-east-3.myhuaweicloud.com/openbkn-ai`, `ghcr` → `ghcr.io/openbkn-ai`. Precedence: explicit `--set image.registry=…` > `--registry` > an `image.registry` already in your `--config` YAML (respected, e.g. `dev/conf/mac-config.yaml`) > default `swr`. SWR mirrors the same `…-main.sha…` build tags as GHCR.
+- **`--registry=<swr / ghcr / host/ns>`** — image registry for **BKN images** (sugar for `--set image.registry`). `swr` → `swr.cn-east-3.myhuaweicloud.com/openbkn-ai`, `ghcr` → `ghcr.io/openbkn-ai`. Precedence: explicit `--set image.registry=…` > `--registry` > an `image.registry` already in your `--config` YAML (respected, e.g. `dev/conf/mac-config.yaml`) > default `swr`. SWR mirrors the same `…-main.<date>.sha…` build tags as GHCR.
 - **`--dockerhub-mirror=<auto / host / off>`** — containerd `docker.io` mirror for **third-party images** (otel/hydra/postgres/minio). Writes `/etc/containerd/certs.d/docker.io/hosts.toml` (needs root + a containerd `config_path` certs.d; else it warns and skips, never fails). **Defaults to `auto`** — probes a candidate list and picks the first mirror that serves this stack's docker.io images over the mirror (`?ns=docker.io`) protocol (sentinel `oryd/hydra`; `docker.m.daocloud.io` 403s namespaced repos there, so a fixed default isn't safe). Pass a host to pin one (e.g. `docker.1panel.live`); `off` disables. Candidate list overridable via `KWEAVER_DOCKERHUB_MIRROR_CANDIDATES`.
 - **`--latest`** — when no `--version_file` is given, auto-runs `gen-dev-manifest.sh --latest` and installs the result (run from a repo checkout — it needs `git`).
 

--- a/deploy/README.zh.md
+++ b/deploy/README.zh.md
@@ -166,7 +166,7 @@ sudo bash ./deploy.sh --distro=k3s foundry install --minimum --version_file=/tmp
 需要 `gh`（已登录，`package:read`）+ `python3`；详见 `./scripts/gen-dev-manifest.sh -h`。
 
 发版之前没有干净 stable，要装**每个组件的最新构建**用 `--latest` —— 逐 chart 取
-其最新 `…-main.sha…` 构建（按 git 提交时间排序），否则回退最新 stable：
+其最新 `…-main.<日期>.sha…` 构建（按 tag 内嵌的提交时间排序），否则回退最新 stable：
 
 ```bash
 ./scripts/gen-dev-manifest.sh --latest --out=/tmp/m.yaml
@@ -181,7 +181,7 @@ sudo bash ./deploy.sh --distro=k3s foundry install --minimum --version_file=/tmp
 集群连不上 `docker.io` 或拉不动 GHCR 镜像层（read timeout）时，`foundry install` 支持
 三个参数，让**脚本自己处理**——无需手动 `crictl pull`/重打 tag：
 
-- **`--registry=<swr / ghcr / host/ns>`** —— **BKN 镜像**的 registry（`--set image.registry` 的糖）。`swr` → `swr.cn-east-3.myhuaweicloud.com/openbkn-ai`，`ghcr` → `ghcr.io/openbkn-ai`。优先级：显式 `--set image.registry=…` > `--registry` > `--config` YAML 里已有的 `image.registry`（尊重，如 `dev/conf/mac-config.yaml`）> 默认 `swr`。SWR 与 GHCR 同步同样的 `…-main.sha…` 构建 tag。
+- **`--registry=<swr / ghcr / host/ns>`** —— **BKN 镜像**的 registry（`--set image.registry` 的糖）。`swr` → `swr.cn-east-3.myhuaweicloud.com/openbkn-ai`，`ghcr` → `ghcr.io/openbkn-ai`。优先级：显式 `--set image.registry=…` > `--registry` > `--config` YAML 里已有的 `image.registry`（尊重，如 `dev/conf/mac-config.yaml`）> 默认 `swr`。SWR 与 GHCR 同步同样的 `…-main.<日期>.sha…` 构建 tag。
 - **`--dockerhub-mirror=<auto / host / off>`** —— **第三方镜像**（otel/hydra/postgres/minio）的 containerd `docker.io` mirror。写 `/etc/containerd/certs.d/docker.io/hosts.toml`（需 root + containerd 配了 `config_path` certs.d；否则告警跳过、不报错）。**默认 `auto`** —— 探测候选列表，选第一个能经 mirror（`?ns=docker.io`）协议服务本栈 docker.io 镜像的（标志镜像 `oryd/hydra`；`docker.m.daocloud.io` 对带 namespace 的仓库会 403，所以固定默认不安全）。传 host 钉死某个（如 `docker.1panel.live`）；`off` 关闭。候选列表可用 `KWEAVER_DOCKERHUB_MIRROR_CANDIDATES` 覆盖。
 - **`--latest`** —— 没给 `--version_file` 时自动跑 `gen-dev-manifest.sh --latest` 并安装结果（需在仓库 checkout 内运行，依赖 `git`）。
 

--- a/deploy/scripts/gen-dev-manifest.sh
+++ b/deploy/scripts/gen-dev-manifest.sh
@@ -19,9 +19,10 @@
 # With no --branch it is pure stable: every chart = highest clean semver.
 #
 # --latest overrides the above: resolve EACH chart to its NEWEST main build,
-# i.e. among tags of the form <semver>-main.sha<7hex>, pick the sha with the
-# most recent git commit timestamp. If a chart has no -main.sha build, fall
-# back to stable (highest clean semver), then to the normal missing/error
+# i.e. among tags of the form <semver>-main.<YYYYMMDDHHMMSS>.sha<7hex>, pick the
+# one with the most recent embedded commit time (a plain string compare on the
+# fixed-width date — no local git history needed). If a chart has no such build,
+# fall back to stable (highest clean semver), then to the normal missing/error
 # handling. --latest is independent of --branch; if both are given, --latest
 # wins. Use this for "newest of everything from main", restricted-network safe.
 #
@@ -146,34 +147,33 @@ def highest_semver(tags):
     if not cand: return None
     return max(cand, key=lambda t:tuple(int(x) for x in SEMVER.match(t).groups()))
 
-MAIN_BUILD=re.compile(r'.*-main\.sha([0-9a-f]{7})')
-
-def _commit_time(sha):
-    """git commit timestamp (epoch secs) for a 7-char sha; 0 if not resolvable
-    locally (sorts last)."""
-    try:
-        out=subprocess.run(["git","show","-s","--format=%ct",sha],
-                           capture_output=True, text=True, cwd=REPO_DIR)
-        if out.returncode==0 and out.stdout.strip():
-            return int(out.stdout.strip())
-    except Exception:
-        pass
-    return 0
+# <semver>-main.<YYYYMMDDHHMMSS>.sha<7hex> — CI embeds the commit time, so the
+# fixed-width date sorts lexicographically == chronologically (no local git).
+MAIN_BUILD=re.compile(r'.*-main\.(\d{14})\.sha[0-9a-f]{7}$')
 
 def newest_main_build(tags):
-    """Among tags of the form <semver>-main.sha<7hex>, the one whose git commit
-    timestamp is most recent (shas unknown locally -> ts 0, sorted last)."""
-    cand=[(t, MAIN_BUILD.fullmatch(t).group(1)) for t in tags if MAIN_BUILD.fullmatch(t)]
+    """Among tags of the form <semver>-main.<date>.sha<7hex>, the one with the
+    most recent embedded commit time. Pure string compare on the fixed-width
+    date — no sha-to-history lookup, so it can't silently mis-order on a
+    shallow/foreign checkout the way the old commit-time-via-git scheme did."""
+    cand=[]
+    for t in tags:
+        m=MAIN_BUILD.fullmatch(t)
+        if m: cand.append((t, m.group(1)))
     if not cand: return None
-    return max(cand, key=lambda ts:(_commit_time(ts[1]), ts[0]))[0]
+    return max(cand, key=lambda ts: ts[1])[0]
 
+# Branch build at an exact HEAD sha. Accepts both the dated form
+# (-<san>.<date>.sha<7>) and the legacy un-dated form (-<san>.sha<7>).
 def _branch_tag(tags, san, sha):
     """Tag for a branch = the build at the branch HEAD sha exactly. No HEAD-sha
     build (component not rebuilt on this branch, or branch not fetched) -> None,
     so the caller falls back to stable rather than picking a stale older build."""
     if not sha: return None
-    exact=[t for t in tags if t.endswith(f"-{san}.sha{sha}")]
-    return exact[0] if exact else None
+    pat=re.compile(rf'-{re.escape(san)}\.(?:\d{{14}}\.)?sha{re.escape(sha)}$')
+    for t in tags:
+        if pat.search(t): return t
+    return None
 
 def resolve(chart):
     tags=reg_tags(chart)


### PR DESCRIPTION
## Problem

Branch builds are tagged `<semver>-<branch>.sha<7>`. The git sha is a hash, **not monotonic**, so `gen-dev-manifest.sh --latest` ordered `-main` builds by resolving each sha against **local** git history (`git show -s --format=%ct`).

On a shallow / foreign checkout (deploy machines, not dev boxes) the sha isn't in the local repo → `_commit_time` returns `0` → selection **silently** degrades to lexicographic sha order → picks a stale "latest" with **no error**. `deploy.sh foundry install --latest` delegates to `gen-dev-manifest.sh --latest` (`deploy/scripts/services/core.sh:599`), so it inherited the same bug.

## Fix

Embed the commit time (UTC, fixed-width `YYYYMMDDHHMMSS`) into the prerelease:

```
0.1.0-main.20260630123051.sha9698064
```

- Date sorts **lexicographically == chronologically** → picking newest is a pure string compare, **no git lookup**.
- **Commit** time (not build time) → CI re-runs stay reproducible.
- Numeric prerelease segment has no leading zero (year-first) → valid SemVer; precedence is now monotonic too.

## Changes

- `reusable-test.yml`: version now `<semver>-<branch>.<date>.sha<7>`.
- `gen-dev-manifest.sh`: match the dated form, sort by embedded date, drop the fragile `_commit_time` git lookup. `_branch_tag` accepts **both** dated and legacy un-dated forms (branch resolution stays backward compatible).
- READMEs: tag-shape docs.

## Compatibility

- Branch resolution: unaffected (matcher accepts both forms).
- `--latest`: only matches the dated form, so legacy `-main.sha<7>` images fall back to **stable** — expected, next push to main republishes in the new format.

## Note

Supersedes #106 (closed when its head branch was deleted; not merged). Rebased onto current `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)