### PR TITLE
chore: drop kweaver branding from rules/ + deploy.sh legacy compat

### DIFF
--- a/deploy/deploy.sh
+++ b/deploy/deploy.sh
@@ -3,16 +3,6 @@ set -e
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
-# Auto-migrate legacy ~/.kweaver-ai to ~/.openbkn-ai (one-time, when target absent).
-if [[ -z "${CONF_DIR:-}" && -d "${HOME}/.kweaver-ai" && ! -e "${HOME}/.openbkn-ai" ]]; then
-    if mv "${HOME}/.kweaver-ai" "${HOME}/.openbkn-ai" 2>/dev/null; then
-        echo "[migrate] moved ${HOME}/.kweaver-ai -> ${HOME}/.openbkn-ai" >&2
-    else
-        echo "[migrate][warn] failed to move ${HOME}/.kweaver-ai -> ${HOME}/.openbkn-ai; using legacy path" >&2
-        CONF_DIR="${HOME}/.kweaver-ai"
-    fi
-fi
-
 CONF_DIR="${CONF_DIR:-${HOME}/.openbkn-ai}"
 CONFIG_YAML_PATH="${CONFIG_YAML_PATH:-${CONF_DIR}/config.yaml}"
 
@@ -141,8 +131,8 @@ usage() {
     echo "                                Example: --set auth.enabled=false --set image.tag=latest"
     echo ""
     echo "Environment (optional, bkn-foundry install):"
-    echo "  (Context Loader ADP import moved to deploy/onboard.sh after kweaver auth — kweaver call impex; see onboard -h.)"
-    echo "  DEPLOY_BUSINESS_DOMAIN        x-business-domain for kweaver/onboard (default: bd_public)."
+    echo "  (Context Loader ADP import moved to deploy/onboard.sh after openbkn auth — openbkn call impex; see onboard -h.)"
+    echo "  DEPLOY_BUSINESS_DOMAIN        x-business-domain for openbkn/onboard (default: bd_public)."
     echo ""
     echo "  $0 bkn-foundry install --minimum                 # Minimum install (skip auth & business-domain)"
     echo "  $0 bkn-foundry install --set auth.enabled=false  # Install BKN Foundry with auth enforcement off"

--- a/rules/CONTRIBUTING.md
+++ b/rules/CONTRIBUTING.md
@@ -10,7 +10,7 @@ Please read this guide before submitting contributions to ensure consistent proc
 
 ## 🏗 Repository Layout
 
-BKN Foundry is a **monorepo** ([`kweaver-ai/kweaver-core`](https://github.com/kweaver-ai/kweaver-core)) that ships the platform's backend modules together. Pick the directory matching the component you want to change:
+BKN Foundry is a **monorepo** ([`openbkn-ai/bkn-foundry`](https://github.com/openbkn-ai/bkn-foundry)) that ships the platform's backend modules together. Pick the directory matching the component you want to change:
 
 | Module | Path | Description |
 | --- | --- | --- |
@@ -26,8 +26,8 @@ External CLI/SDKs that interact with this backend live in their own repositories
 
 | Repository | Purpose |
 | --- | --- |
-| [`kweaver-ai/kweaver-sdk`](https://github.com/kweaver-ai/kweaver-sdk) | `kweaver` CLI + TypeScript / Python SDK + AI agent skills (`kweaver-core`, `create-bkn`) |
-| [`kweaver-ai/kweaver-admin`](https://github.com/kweaver-ai/kweaver-admin) | `kweaver-admin` platform-administrator CLI + agent skill |
+| [`openbkn-ai/bkn-sdk`](https://github.com/openbkn-ai/bkn-sdk) | `openbkn` CLI + TypeScript / Python SDK + AI agent skills (`bkn-core`, `create-bkn`) |
+| [`openbkn-ai/bkn-admin`](https://github.com/openbkn-ai/bkn-admin) | `bkn-admin` platform-administrator CLI + agent skill |
 
 > **Note**: Each module has its own README (and often `AGENTS.md` / `CLAUDE.md`) with build, test, and dev-loop instructions in the language it is written in. Read them before making module-local changes.
 
@@ -71,7 +71,7 @@ When reporting a bug, please provide the following information:
   - Module affected (e.g. `adp/bkn`, `adp/vega/vega-backend`, `infra/sandbox`)
   - Runtime (Java / Go / Python / Node — and version, e.g. JDK 17, Go 1.23, Python 3.11)
   - OS (Linux distro + kernel, macOS, Windows)
-  - Cluster (single-node K3s / kubeadm / managed K8s) and how it was installed (`deploy.sh kweaver-core install [--minimum]`)
+  - Cluster (single-node K3s / kubeadm / managed K8s) and how it was installed (`deploy.sh core install [--minimum]`)
   - Storage backends as relevant (MariaDB / DM8, OpenSearch, Redis, Kafka)
 
 - **Reproduction Steps**: Clear, step-by-step instructions to reproduce the issue
@@ -90,7 +90,7 @@ When reporting a bug, please provide the following information:
 - Module: adp/bkn
 - Runtime: JDK 17
 - OS: Linux Ubuntu 22.04
-- Cluster: single-node K3s (deploy.sh kweaver-core install)
+- Cluster: single-node K3s (deploy.sh core install)
 - Database: MariaDB 11.4
 
 **Steps to Reproduce:**
@@ -422,7 +422,7 @@ When workflow count grows or shared logic emerges:
 
 ## 📝 Source Code Header Guidelines
 
-This section defines the standard source code file header used across **kweaver.ai** open-source projects.
+This section defines the standard source code file header used across **openbkn.ai** open-source projects.
 
 The goal is to ensure:
 
@@ -430,7 +430,7 @@ The goal is to ensure:
 - clear licensing (Apache License 2.0)
 - consistent and readable file documentation
 
-> **Note**: We use "The kweaver.ai Authors" instead of individual author names.
+> **Note**: We use "The openbkn.ai Authors" instead of individual author names.
 > Git history already tracks all contributors, and this approach is easier to maintain.
 
 ### Standard Header (Go / C / Java)
@@ -439,7 +439,7 @@ Use the following header for all core source files:
 
 ```go
 // Copyright 2026 openbkn.ai
-// Copyright The kweaver.ai Authors.
+// Copyright The openbkn.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.
 // See the LICENSE file in the project root for details.
@@ -451,7 +451,7 @@ Use the following header for all core source files:
 
 ```python
 # Copyright 2026 openbkn.ai
-# Copyright The kweaver.ai Authors.
+# Copyright The openbkn.ai Authors.
 #
 # Licensed under the Apache License, Version 2.0.
 # See the LICENSE file in the project root for details.
@@ -461,7 +461,7 @@ Use the following header for all core source files:
 
 ```ts
 /**
- * Copyright The kweaver.ai Authors.
+ * Copyright The openbkn.ai Authors.
  *
  * Licensed under the Apache License, Version 2.0.
  * See the LICENSE file in the project root for details.
@@ -473,7 +473,7 @@ Use the following header for all core source files:
 ```bash
 #!/usr/bin/env bash
 # Copyright 2026 openbkn.ai
-# Copyright The kweaver.ai Authors.
+# Copyright The openbkn.ai Authors.
 # Licensed under the Apache License, Version 2.0.
 # See the LICENSE file in the project root for details.
 ```
@@ -482,7 +482,7 @@ Use the following header for all core source files:
 
 ```html
 <!--
-  Copyright The kweaver.ai Authors.
+  Copyright The openbkn.ai Authors.
   Licensed under the Apache License, Version 2.0.
   See the LICENSE file in the project root for details.
 -->
@@ -495,7 +495,7 @@ after the license header (for key files only):
 
 ```go
 // Copyright 2026 openbkn.ai
-// Copyright The kweaver.ai Authors.
+// Copyright The openbkn.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.
 // See the LICENSE file in the project root for details.
@@ -528,7 +528,7 @@ Following the practice of major open-source projects (Kubernetes, TensorFlow, et
 
 - **Git history** already provides a complete and accurate record of all contributors
 - Individual author lists are **hard to maintain** and often become outdated
-- Using "The kweaver.ai Authors" ensures **consistent attribution** across all files
+- Using "The openbkn.ai Authors" ensures **consistent attribution** across all files
 - Contributors are recognized through the project's **CONTRIBUTORS** file and git log
 
 ### License Requirement
@@ -553,7 +553,7 @@ BKN Foundry is polyglot. You only need the toolchain(s) for the module(s) you to
 - **Java** (JDK 17+) and Maven for most ADP backend modules
 - **Go** (1.23+) for `infra/oss-gateway-backend`, several CLIs and small services
 - **Python** (3.11+) for `infra/mf-model-manager`, model / data utilities
-- **Node.js** — kweaver CLIs require **22+** (per [`@kweaver-ai/kweaver-sdk` on npm](https://www.npmjs.com/package/@kweaver-ai/kweaver-sdk)).
+- **Node.js** — OpenBKN CLIs require **22+** (per [`@openbkn/bkn-sdk` on npm](https://www.npmjs.com/package/@openbkn/bkn-sdk)).
 - **Docker** + a Kubernetes (single-node K3s / kubeadm / Docker Desktop) for end-to-end testing
 - **MariaDB 11.4+** (or DM8), **OpenSearch 2.x**, **Redis**, **Kafka** when running services that need them — usually provided by `deploy.sh`
 
@@ -561,11 +561,11 @@ Each module's `README.md` / `AGENTS.md` lists the exact prerequisites, build com
 
 ### Local Development
 
-1. **Clone your fork of `kweaver-core`:**
+1. **Clone your fork of `bkn-foundry`:**
 
    ```bash
-   git clone https://github.com/YOUR_USERNAME/kweaver-core.git
-   cd kweaver-core
+   git clone https://github.com/YOUR_USERNAME/bkn-foundry.git
+   cd bkn-foundry
    ```
 
 2. **Add upstream remote:**
@@ -591,8 +591,8 @@ Each module's `README.md` / `AGENTS.md` lists the exact prerequisites, build com
 
    ```bash
    cd deploy
-   ./deploy.sh kweaver-core install --minimum    # quick try
-   # or full install: ./deploy.sh kweaver-core install
+   ./deploy.sh core install --minimum    # quick try
+   # or full install: ./deploy.sh core install
    ```
 
 ---
@@ -603,7 +603,7 @@ Each module's `README.md` / `AGENTS.md` lists the exact prerequisites, build com
 
 Instead, please open a private report via GitHub's built-in security advisory flow:
 
-- [Report a vulnerability — kweaver-ai/kweaver-core](https://github.com/kweaver-ai/kweaver-core/security/advisories/new)
+- [Report a vulnerability — openbkn-ai/bkn-foundry](https://github.com/openbkn-ai/bkn-foundry/security/advisories/new)
 
 We will acknowledge receipt and work with you to address the issue. Please include reproduction steps, affected version (`git describe --tags`), and the impact you observed.
 

--- a/rules/CONTRIBUTING.zh.md
+++ b/rules/CONTRIBUTING.zh.md
@@ -10,7 +10,7 @@
 
 ## 🏗 仓库结构
 
-BKN Foundry 是一个 **monorepo**（[`kweaver-ai/kweaver-core`](https://github.com/kweaver-ai/kweaver-core)），平台后端各模块统一存放于此。请根据要修改的组件，进入对应目录：
+BKN Foundry 是一个 **monorepo**（[`openbkn-ai/bkn-foundry`](https://github.com/openbkn-ai/bkn-foundry)），平台后端各模块统一存放于此。请根据要修改的组件，进入对应目录：
 
 | 模块 | 路径 | 描述 |
 | --- | --- | --- |
@@ -26,8 +26,8 @@ BKN Foundry 是一个 **monorepo**（[`kweaver-ai/kweaver-core`](https://github.
 
 | 仓库 | 用途 |
 | --- | --- |
-| [`kweaver-ai/kweaver-sdk`](https://github.com/kweaver-ai/kweaver-sdk) | `kweaver` CLI + TypeScript / Python SDK + Agent Skills（`kweaver-core`、`create-bkn`） |
-| [`kweaver-ai/kweaver-admin`](https://github.com/kweaver-ai/kweaver-admin) | `kweaver-admin` 平台管理员 CLI + Agent Skill |
+| [`openbkn-ai/bkn-sdk`](https://github.com/openbkn-ai/bkn-sdk) | `openbkn` CLI + TypeScript / Python SDK + Agent Skills（`bkn-core`、`create-bkn`） |
+| [`openbkn-ai/bkn-admin`](https://github.com/openbkn-ai/bkn-admin) | `bkn-admin` 平台管理员 CLI + Agent Skill |
 
 > **说明**：每个模块都有自己的 README（通常还包括 `AGENTS.md` / `CLAUDE.md`），里面给出本模块语言对应的构建、测试与开发循环命令，请在动手前先看。
 
@@ -71,7 +71,7 @@ BKN Foundry 是一个 **monorepo**（[`kweaver-ai/kweaver-core`](https://github.
   - 受影响的模块（如 `adp/bkn`、`adp/vega/vega-backend`、`infra/sandbox`）
   - 运行时（Java / Go / Python / Node 及版本，如 JDK 17、Go 1.23、Python 3.11）
   - 操作系统（Linux 发行版与内核 / macOS / Windows）
-  - 集群形态（单机 K3s / kubeadm / 托管 K8s）以及安装方式（`deploy.sh kweaver-core install [--minimum]`）
+  - 集群形态（单机 K3s / kubeadm / 托管 K8s）以及安装方式（`deploy.sh core install [--minimum]`）
   - 涉及的存储/中间件（MariaDB / DM8、OpenSearch、Redis、Kafka）
 
 - **复现步骤**: 清晰、逐步的复现说明
@@ -90,7 +90,7 @@ BKN Foundry 是一个 **monorepo**（[`kweaver-ai/kweaver-core`](https://github.
 - 模块: adp/bkn
 - 运行时: JDK 17
 - 操作系统: Linux Ubuntu 22.04
-- 集群: 单机 K3s（deploy.sh kweaver-core install）
+- 集群: 单机 K3s（deploy.sh core install）
 - 数据库: MariaDB 11.4
 
 **复现步骤:**
@@ -421,7 +421,7 @@ git push origin feature/my-feature
 
 ## 📝 源代码文件头规范
 
-本节定义了 **kweaver.ai** 开源项目中使用的标准源代码文件头。
+本节定义了 **openbkn.ai** 开源项目中使用的标准源代码文件头。
 
 目标是确保：
 
@@ -429,7 +429,7 @@ git push origin feature/my-feature
 - 明确的许可证（Apache License 2.0）
 - 一致且可读的文件文档
 
-> **说明**：我们使用 "The kweaver.ai Authors" 而不是个人作者名。
+> **说明**：我们使用 "The openbkn.ai Authors" 而不是个人作者名。
 > Git 历史记录已经追踪了所有贡献者，这种方式更易于维护。
 
 ### 标准文件头（Go / C / Java）
@@ -438,7 +438,7 @@ git push origin feature/my-feature
 
 ```go
 // Copyright 2026 openbkn.ai
-// Copyright The kweaver.ai Authors.
+// Copyright The openbkn.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.
 // See the LICENSE file in the project root for details.
@@ -450,7 +450,7 @@ git push origin feature/my-feature
 
 ```python
 # Copyright 2026 openbkn.ai
-# Copyright The kweaver.ai Authors.
+# Copyright The openbkn.ai Authors.
 #
 # Licensed under the Apache License, Version 2.0.
 # See the LICENSE file in the project root for details.
@@ -460,7 +460,7 @@ git push origin feature/my-feature
 
 ```ts
 /**
- * Copyright The kweaver.ai Authors.
+ * Copyright The openbkn.ai Authors.
  *
  * Licensed under the Apache License, Version 2.0.
  * See the LICENSE file in the project root for details.
@@ -472,7 +472,7 @@ git push origin feature/my-feature
 ```bash
 #!/usr/bin/env bash
 # Copyright 2026 openbkn.ai
-# Copyright The kweaver.ai Authors.
+# Copyright The openbkn.ai Authors.
 # Licensed under the Apache License, Version 2.0.
 # See the LICENSE file in the project root for details.
 ```
@@ -481,7 +481,7 @@ git push origin feature/my-feature
 
 ```html
 <!--
-  Copyright The kweaver.ai Authors.
+  Copyright The openbkn.ai Authors.
   Licensed under the Apache License, Version 2.0.
   See the LICENSE file in the project root for details.
 -->
@@ -493,7 +493,7 @@ git push origin feature/my-feature
 
 ```go
 // Copyright 2026 openbkn.ai
-// Copyright The kweaver.ai Authors.
+// Copyright The openbkn.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.
 // See the LICENSE file in the project root for details.
@@ -526,7 +526,7 @@ git push origin feature/my-feature
 
 - **Git 历史**已经提供了所有贡献者的完整准确记录
 - 个人作者列表**难以维护**，容易过时
-- 使用 "The kweaver.ai Authors" 确保所有文件的**一致归属**
+- 使用 "The openbkn.ai Authors" 确保所有文件的**一致归属**
 - 贡献者通过项目的 **CONTRIBUTORS** 文件和 git log 获得认可
 
 ### 许可证要求
@@ -549,7 +549,7 @@ BKN Foundry 是多语言项目，**只需安装你要修改的模块所需的工
 - **Java**（JDK 17+）+ Maven —— ADP 大多数后端模块
 - **Go**（1.23+）—— `infra/oss-gateway-backend`、若干 CLI 与小型服务
 - **Python**（3.11+）—— `infra/mf-model-manager` 等模型/数据组件
-- **Node.js** —— kweaver 相关 CLI 需 **22+**（以 [npm 上 `kweaver-sdk`](https://www.npmjs.com/package/@kweaver-ai/kweaver-sdk) 的 `engines` 为准）
+- **Node.js** —— openbkn 相关 CLI 需 **22+**（以 [npm 上 `bkn-sdk`](https://www.npmjs.com/package/@openbkn/bkn-sdk) 的 `engines` 为准）
 - **Docker** + 一套 Kubernetes（单机 K3s / kubeadm / Docker Desktop）—— 端到端验证
 - **MariaDB 11.4+**（或 DM8）、**OpenSearch 2.x**、**Redis**、**Kafka** —— 仅在调试相关服务时需要，通常由 `deploy.sh` 提供
 
@@ -557,11 +557,11 @@ BKN Foundry 是多语言项目，**只需安装你要修改的模块所需的工
 
 ### 本地开发
 
-1. **克隆你 Fork 的 `kweaver-core`：**
+1. **克隆你 Fork 的 `bkn-foundry`：**
 
    ```bash
-   git clone https://github.com/YOUR_USERNAME/kweaver-core.git
-   cd kweaver-core
+   git clone https://github.com/YOUR_USERNAME/bkn-foundry.git
+   cd bkn-foundry
    ```
 
 2. **添加上游远程仓库：**
@@ -587,8 +587,8 @@ BKN Foundry 是多语言项目，**只需安装你要修改的模块所需的工
 
    ```bash
    cd deploy
-   ./deploy.sh kweaver-core install --minimum    # 快速体验
-   # 完整安装：./deploy.sh kweaver-core install
+   ./deploy.sh core install --minimum    # 快速体验
+   # 完整安装：./deploy.sh core install
    ```
 
 ---
@@ -599,7 +599,7 @@ BKN Foundry 是多语言项目，**只需安装你要修改的模块所需的工
 
 请通过 GitHub 内置的安全公告私密通道报告：
 
-- [报告漏洞 — kweaver-ai/kweaver-core](https://github.com/kweaver-ai/kweaver-core/security/advisories/new)
+- [报告漏洞 — openbkn-ai/bkn-foundry](https://github.com/openbkn-ai/bkn-foundry/security/advisories/new)
 
 我们会确认收到并与你协同修复。请在报告中包含：复现步骤、受影响版本（`git describe --tags`）以及你观察到的影响。
 

--- a/rules/README.md
+++ b/rules/README.md
@@ -2,7 +2,7 @@
 
 [中文](README.zh.md) | English
 
-This directory contains the development standards for the KWeaver project. If you're new, read them in the order below.
+This directory contains the development standards for the BKN Foundry project. If you're new, read them in the order below.
 
 ## Reading Order
 

--- a/rules/RELEASE.md
+++ b/rules/RELEASE.md
@@ -2,7 +2,7 @@
 
 [中文](RELEASE.zh.md) | English
 
-This document defines the version management, branching strategy, and release process for the KWeaver project.
+This document defines the version management, branching strategy, and release process for the BKN Foundry project.
 
 ---
 
@@ -273,7 +273,7 @@ git branch -D release/1.2.0
 
 ### Verify Release
 
-- Check the [GitHub Releases](https://github.com/kweaver-ai/kweaver-core/releases) page
+- Check the [GitHub Releases](https://github.com/openbkn-ai/bkn-foundry/releases) page
 - Verify artifact downloads and integrity
 - Confirm Docker images are pullable and Helm charts can be `helm pull`-ed
 - Confirm Python packages are installable from the target index

--- a/rules/RELEASE.zh.md
+++ b/rules/RELEASE.zh.md
@@ -274,7 +274,7 @@ git branch -D release/1.2.0
 
 ### 验证发布
 
-- 检查 [GitHub Releases](https://github.com/kweaver-ai/kweaver-core/releases) 页面
+- 检查 [GitHub Releases](https://github.com/openbkn-ai/bkn-foundry/releases) 页面
 - 验证制品下载和完整性
 - 确认 Docker 镜像可拉取，Helm Chart 可 `helm pull`
 - 确认 Python 包可在目标 index 安装

--- a/rules/WORKFLOW.md
+++ b/rules/WORKFLOW.md
@@ -545,7 +545,7 @@ BKN Foundry vX.Y.Z has been officially released!
 
 ## Download
 - GitHub Releases: <link>
-- Docker: docker pull kweaver/kweaver:vX.Y.Z
+- Images: `ghcr.io/openbkn-ai/<service>:vX.Y.Z` (per service)
 
 ## Full Changelog
 <CHANGELOG link>

--- a/rules/WORKFLOW.zh.md
+++ b/rules/WORKFLOW.zh.md
@@ -545,7 +545,7 @@ BKN Foundry vX.Y.Z 已正式发布！
 
 ## 下载
 - GitHub Releases: <链接>
-- Docker: docker pull kweaver/kweaver:vX.Y.Z
+- Images: `ghcr.io/openbkn-ai/<service>:vX.Y.Z` (per service)
 
 ## 完整变更日志
 <CHANGELOG 链接>


### PR DESCRIPTION
## What

- **rules/**: replace stale `KWeaver` branding with current names —
  repo `openbkn-ai/bkn-foundry` (was `kweaver-ai/kweaver-core`), CLI `openbkn`,
  SDK `@openbkn/bkn-sdk` / `openbkn-ai/bkn-sdk`, admin `openbkn-ai/bkn-admin`,
  `deploy.sh core install` (was `kweaver-core`), release images `ghcr.io/openbkn-ai/<service>`,
  copyright `openbkn.ai`.
- **deploy.sh**: remove the legacy `~/.kweaver-ai` -> `~/.openbkn-ai` auto-migration
  (no longer needed) and stale help wording.

## Kept on purpose

- **Upstream fork attribution**: `git remote add upstream https://github.com/kweaver-ai/kweaver-core.git`
  (this repo is an Apache-2.0 fork; the root README keeps the same attribution).
- **Functional `kweaver`** (not branding, removing would be breaking): DB schema name,
  Go dependency `kweaver-go-lib`, release-manifest filename `kweaver-core.yaml`,
  shell function names, the `kweaver-core` module alias.

## Not in this PR (findings)

- Other human-facing READMEs (root / sandbox / trace-ai) still carry some KWeaver branding.
- `rules/DEVELOPMENT|TESTING` scope lines reference retired/removed products (ISF -> bkn-safe, dataflow removed, decision-agent retired).

🤖 Generated with [Claude Code](https://claude.com/claude-code)