### PR TITLE
feat(operator-integration): add sandbox runtime observability

### DIFF
--- a/adp/execution-factory/operator-integration/docs/apis/api_private/sandbox.yaml
+++ b/adp/execution-factory/operator-integration/docs/apis/api_private/sandbox.yaml
@@ -1,0 +1,222 @@
+openapi: "3.0.3"
+info:
+  title: "Sandbox Runtime Private Management APIs"
+  version: "1.0.0"
+  description: "Read-only Sandbox Runtime observability APIs for Execution Factory Lab."
+servers:
+  - url: "http://127.0.0.1:9000/api/agent-operator-integration/internal-v1"
+tags:
+  - name: "Sandbox Runtime"
+    description: "Read-only runtime health, pool, and session diagnostics."
+paths:
+  /sandbox/health:
+    get:
+      tags: ["Sandbox Runtime"]
+      summary: "Get sandbox runtime health"
+      responses:
+        "200":
+          description: "Sandbox runtime health status."
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/SandboxHealthResp"
+  /sandbox/pool:
+    get:
+      tags: ["Sandbox Runtime"]
+      summary: "Get sandbox session pool status"
+      responses:
+        "200":
+          description: "Sandbox session pool status."
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/SandboxPoolResp"
+  /sandbox/sessions:
+    get:
+      tags: ["Sandbox Runtime"]
+      summary: "List sandbox sessions"
+      parameters:
+        - name: limit
+          in: query
+          required: false
+          schema:
+            type: integer
+        - name: offset
+          in: query
+          required: false
+          schema:
+            type: integer
+        - name: status
+          in: query
+          required: false
+          schema:
+            type: string
+            enum: ["creating", "running", "failed", "terminated"]
+        - name: source
+          in: query
+          required: false
+          schema:
+            type: string
+        - name: runtime
+          in: query
+          required: false
+          schema:
+            type: string
+        - name: abnormal_only
+          in: query
+          required: false
+          schema:
+            type: boolean
+      responses:
+        "200":
+          description: "Sandbox session list."
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/SandboxSessionListResp"
+  /sandbox/sessions/{id}:
+    get:
+      tags: ["Sandbox Runtime"]
+      summary: "Get sandbox session detail"
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          description: "Sandbox session detail."
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/SandboxSessionDetailResp"
+        "404":
+          description: "Session not found."
+components:
+  schemas:
+    SandboxHealthResp:
+      type: object
+      properties:
+        status:
+          type: string
+          enum: ["healthy", "degraded", "unhealthy"]
+        control_plane_reachable:
+          type: boolean
+        checked_at:
+          type: string
+        max_sessions:
+          type: integer
+        current_active_sessions:
+          type: integer
+        current_running_tasks:
+          type: integer
+        failed_sessions:
+          type: integer
+        message:
+          type: string
+    SandboxPoolResp:
+      type: object
+      properties:
+        max_sessions:
+          type: integer
+        active_sessions:
+          type: integer
+        max_concurrent_tasks:
+          type: integer
+        current_active_sessions:
+          type: integer
+        current_running_tasks:
+          type: integer
+        template_id:
+          type: string
+        session_resources:
+          type: object
+        sessions:
+          type: array
+          items:
+            $ref: "#/components/schemas/PoolSessionSnapshotResp"
+    PoolSessionSnapshotResp:
+      type: object
+      properties:
+        id:
+          type: string
+        running_tasks:
+          type: integer
+        last_used_at:
+          type: string
+    SandboxSessionListResp:
+      type: object
+      properties:
+        items:
+          type: array
+          items:
+            $ref: "#/components/schemas/SandboxSessionSummary"
+        total:
+          type: integer
+        limit:
+          type: integer
+        offset:
+          type: integer
+        has_more:
+          type: boolean
+    SandboxSessionSummary:
+      type: object
+      properties:
+        id:
+          type: string
+        status:
+          type: string
+        source:
+          type: string
+        template_id:
+          type: string
+        runtime_type:
+          type: string
+        language_runtime:
+          type: string
+        resource_limit:
+          type: object
+        dependency_install_status:
+          type: string
+        recent_error_summary:
+          type: string
+        created_at:
+          type: string
+        updated_at:
+          type: string
+        last_activity_at:
+          type: string
+    SandboxSessionDetailResp:
+      allOf:
+        - $ref: "#/components/schemas/SandboxSessionSummary"
+        - type: object
+          properties:
+            workspace_path:
+              type: string
+            runtime_node:
+              type: string
+            pod_name:
+              type: string
+            timeout:
+              type: integer
+            python_package_index_url:
+              type: string
+            requested_dependencies:
+              type: array
+              items:
+                type: object
+            installed_dependencies:
+              type: array
+              items:
+                type: object
+            dependency_install_started_at:
+              type: string
+            dependency_install_completed_at:
+              type: string
+            full_stdout_stderr_available:
+              type: boolean
+            governance_actions_available:
+              type: boolean
+            sensitive_diagnostics_redacted:
+              type: boolean

--- a/adp/execution-factory/operator-integration/docs/design/features/sandbox/116-sandbox-runtime-observability.md
+++ b/adp/execution-factory/operator-integration/docs/design/features/sandbox/116-sandbox-runtime-observability.md
@@ -1,0 +1,87 @@
+---
+issue: "#116"
+branch: "feature/116-sandbox-runtime-observability"
+module: "operator-integration"
+status: "draft"
+created: "2026-07-01"
+---
+
+# Feature #116: Sandbox Runtime Observability Entry
+
+## Goal
+
+Execution Factory Lab needs a runtime management entry that helps platform
+administrators diagnose function, Skill, MCP, and operator debugging failures.
+The first phase is read-only observability. It must answer:
+
+- is the sandbox control plane reachable;
+- is the session pool saturated;
+- which sessions are failed or abnormal;
+- what runtime, template, resource limits, dependencies, and recent error
+  summary belong to a session.
+
+## Product Boundary
+
+This change implements backend private management APIs in
+`operator-integration`. The Studio frontend is not in this repository, so the
+actual navigation entry should be added by the frontend project later:
+
+`Execution Factory Lab -> Runtime Management`
+
+The page can display `Sandbox Runtime` as the technical subtitle, but the user
+facing navigation should prefer "Runtime Management".
+
+## API Design
+
+The private route base is:
+
+`/api/agent-operator-integration/internal-v1/sandbox`
+
+Read-only endpoints:
+
+- `GET /health`
+- `GET /pool`
+- `GET /sessions`
+- `GET /sessions/{id}`
+
+The frontend must not call sandbox-control-plane directly. `operator-integration`
+is the boundary for auth context, future audit, field shaping, and redaction.
+
+## UX Contract
+
+The frontend should render:
+
+- top status cards for control plane health, pool usage, running tasks, and
+  failed sessions;
+- a session list with status, source, runtime, template, resource limit,
+  dependency status, create/update/last-active time, and recent error summary;
+- a details drawer with workspace, runtime node, pod, dependency lists, package
+  index, resource limits, and sanitized diagnostics.
+
+The first phase intentionally does not expose full stdout/stderr, terminate,
+delete, cleanup, prewarm, or dependency reinstall actions. The response exposes
+`governance_actions_available=false` and
+`full_stdout_stderr_available=false` so the UI can avoid showing action affordances.
+
+## Compatibility
+
+The change is additive. Existing function execution, Skill execution, MCP
+execution, and sandbox session pool behavior are unchanged.
+
+## Acceptance Criteria
+
+- [x] Private API exposes sandbox control plane health.
+- [x] Private API exposes session pool waterline and resource configuration.
+- [x] Private API lists sandbox sessions with status/runtime/source filters.
+- [x] Private API returns session detail with dependencies and sanitized error
+      summary.
+- [x] No write operation is exposed by the new sandbox management handler.
+- [x] Frontend integration boundary is documented because Studio is outside this
+      repository.
+
+## Future Work
+
+- Add Studio frontend navigation and pages.
+- Link function / Skill / operator debug failures to session id or task id.
+- Implement controlled governance actions in #117 with permission checks,
+  confirmation UX, and audit logs.

--- a/adp/execution-factory/operator-integration/server/driveradapters/rest_private_handler.go
+++ b/adp/execution-factory/operator-integration/server/driveradapters/rest_private_handler.go
@@ -7,6 +7,7 @@ import (
 	"github.com/gin-gonic/gin"
 	"github.com/openbkn-ai/adp/execution-factory/operator-integration/server/drivenadapters"
 	"github.com/openbkn-ai/adp/execution-factory/operator-integration/server/driveradapters/common"
+	sandboxdriver "github.com/openbkn-ai/adp/execution-factory/operator-integration/server/driveradapters/sandbox"
 	"github.com/openbkn-ai/adp/execution-factory/operator-integration/server/infra/config"
 	"github.com/openbkn-ai/adp/execution-factory/operator-integration/server/interfaces"
 	"github.com/openbkn-ai/adp/execution-factory/operator-integration/server/logics/business_domain"
@@ -19,6 +20,7 @@ type restPrivateHandler struct {
 	UpgradeHandler        common.UpgradeHandler
 	UnifiedProxyHandler   common.UnifiedProxyHandler
 	ImpexHandler          common.ImpexHandler
+	SandboxHandler        sandboxdriver.ManagementHandler
 	Logger                interfaces.Logger
 	SkillRestHandler      SkillRestHandler
 	businessDomainService interfaces.IBusinessDomainService
@@ -34,6 +36,7 @@ func NewRestPrivateHandler() interfaces.HTTPRouterInterface {
 		UpgradeHandler:        common.NewUpgradeHandler(),
 		UnifiedProxyHandler:   common.NewUnifiedProxyHandler(),
 		ImpexHandler:          common.NewImpexHandler(),
+		SandboxHandler:        sandboxdriver.NewManagementHandler(),
 		Logger:                config.NewConfigLoader().GetLogger(),
 		SkillRestHandler:      NewSkillRestHandler(),
 		businessDomainService: business_domain.NewBusinessDomainService(),
@@ -54,6 +57,8 @@ func (r *restPrivateHandler) RegisterRouter(engine *gin.RouterGroup) {
 	r.MCPRestHandler.RegisterPrivate(engine)
 	// 技能接口
 	r.SkillRestHandler.RegisterPrivate(engine)
+	// Sandbox Runtime read-only management APIs.
+	r.SandboxHandler.RegisterPrivate(engine)
 
 	// 临时升级接口 - 仅在从旧版本升级到5.0.0.3时使用
 	engine.GET("/upgrade/v5003/migrate-history", r.UpgradeHandler.MigrateHistoryData)

--- a/adp/execution-factory/operator-integration/server/driveradapters/sandbox/management.go
+++ b/adp/execution-factory/operator-integration/server/driveradapters/sandbox/management.go
@@ -1,0 +1,84 @@
+package sandbox
+
+import (
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+	"github.com/openbkn-ai/adp/execution-factory/operator-integration/server/drivenadapters"
+	"github.com/openbkn-ai/adp/execution-factory/operator-integration/server/infra/rest"
+	"github.com/openbkn-ai/adp/execution-factory/operator-integration/server/logics/sandbox"
+)
+
+type ManagementHandler interface {
+	RegisterPrivate(engine *gin.RouterGroup)
+	GetHealth(c *gin.Context)
+	GetPool(c *gin.Context)
+	ListSessions(c *gin.Context)
+	GetSessionDetail(c *gin.Context)
+}
+
+type managementHandler struct {
+	service sandbox.SandboxManagementService
+}
+
+func NewManagementHandler() ManagementHandler {
+	return &managementHandler{
+		service: sandbox.NewSandboxManagementService(
+			drivenadapters.NewSandBoxControlPlaneClient(),
+			sandbox.GetSessionPool(),
+		),
+	}
+}
+
+func NewManagementHandlerWithService(service sandbox.SandboxManagementService) ManagementHandler {
+	return &managementHandler{service: service}
+}
+
+func (h *managementHandler) RegisterPrivate(engine *gin.RouterGroup) {
+	group := engine.Group("/sandbox")
+	group.GET("/health", h.GetHealth)
+	group.GET("/pool", h.GetPool)
+	group.GET("/sessions", h.ListSessions)
+	group.GET("/sessions/:id", h.GetSessionDetail)
+}
+
+func (h *managementHandler) GetHealth(c *gin.Context) {
+	resp, err := h.service.GetHealth(c.Request.Context())
+	if err != nil {
+		rest.ReplyError(c, err)
+		return
+	}
+	rest.ReplyOK(c, http.StatusOK, resp)
+}
+
+func (h *managementHandler) GetPool(c *gin.Context) {
+	resp, err := h.service.GetPool(c.Request.Context())
+	if err != nil {
+		rest.ReplyError(c, err)
+		return
+	}
+	rest.ReplyOK(c, http.StatusOK, resp)
+}
+
+func (h *managementHandler) ListSessions(c *gin.Context) {
+	req := &sandbox.SandboxSessionListReq{}
+	if err := c.ShouldBindQuery(req); err != nil {
+		rest.ReplyError(c, err)
+		return
+	}
+	resp, err := h.service.ListSessions(c.Request.Context(), req)
+	if err != nil {
+		rest.ReplyError(c, err)
+		return
+	}
+	rest.ReplyOK(c, http.StatusOK, resp)
+}
+
+func (h *managementHandler) GetSessionDetail(c *gin.Context) {
+	resp, err := h.service.GetSessionDetail(c.Request.Context(), c.Param("id"))
+	if err != nil {
+		rest.ReplyError(c, err)
+		return
+	}
+	rest.ReplyOK(c, http.StatusOK, resp)
+}

--- a/adp/execution-factory/operator-integration/server/driveradapters/sandbox/management_test.go
+++ b/adp/execution-factory/operator-integration/server/driveradapters/sandbox/management_test.go
@@ -1,0 +1,54 @@
+package sandbox
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	logicssandbox "github.com/openbkn-ai/adp/execution-factory/operator-integration/server/logics/sandbox"
+	. "github.com/smartystreets/goconvey/convey"
+)
+
+type fakeManagementService struct{}
+
+func (f *fakeManagementService) GetHealth(ctx context.Context) (*logicssandbox.SandboxHealthResp, error) {
+	return &logicssandbox.SandboxHealthResp{Status: "healthy", ControlPlaneReachable: true}, nil
+}
+
+func (f *fakeManagementService) GetPool(ctx context.Context) (*logicssandbox.SandboxPoolResp, error) {
+	return &logicssandbox.SandboxPoolResp{MaxSessions: 3, CurrentActiveSessions: 1}, nil
+}
+
+func (f *fakeManagementService) ListSessions(ctx context.Context, req *logicssandbox.SandboxSessionListReq) (*logicssandbox.SandboxSessionListResp, error) {
+	return &logicssandbox.SandboxSessionListResp{Items: []*logicssandbox.SandboxSessionSummary{}, Total: 0}, nil
+}
+
+func (f *fakeManagementService) GetSessionDetail(ctx context.Context, sessionID string) (*logicssandbox.SandboxSessionDetailResp, error) {
+	return &logicssandbox.SandboxSessionDetailResp{SandboxSessionSummary: &logicssandbox.SandboxSessionSummary{ID: sessionID}}, nil
+}
+
+func TestManagementHandlerReadOnlyRoutes(t *testing.T) {
+	Convey("Sandbox management handler should expose only read-only routes", t, func() {
+		gin.SetMode(gin.TestMode)
+		engine := gin.New()
+		group := engine.Group("/api/agent-operator-integration/internal-v1")
+		NewManagementHandlerWithService(&fakeManagementService{}).RegisterPrivate(group)
+
+		So(performRequest(engine, http.MethodGet, "/api/agent-operator-integration/internal-v1/sandbox/health").Code, ShouldEqual, http.StatusOK)
+		So(performRequest(engine, http.MethodGet, "/api/agent-operator-integration/internal-v1/sandbox/pool").Code, ShouldEqual, http.StatusOK)
+		So(performRequest(engine, http.MethodGet, "/api/agent-operator-integration/internal-v1/sandbox/sessions?status=failed").Code, ShouldEqual, http.StatusOK)
+		So(performRequest(engine, http.MethodGet, "/api/agent-operator-integration/internal-v1/sandbox/sessions/sess_aoi_1").Code, ShouldEqual, http.StatusOK)
+
+		So(performRequest(engine, http.MethodDelete, "/api/agent-operator-integration/internal-v1/sandbox/sessions/sess_aoi_1").Code, ShouldEqual, http.StatusNotFound)
+		So(performRequest(engine, http.MethodPost, "/api/agent-operator-integration/internal-v1/sandbox/pool/prewarm").Code, ShouldEqual, http.StatusNotFound)
+	})
+}
+
+func performRequest(engine *gin.Engine, method, path string) *httptest.ResponseRecorder {
+	recorder := httptest.NewRecorder()
+	req := httptest.NewRequest(method, path, nil)
+	engine.ServeHTTP(recorder, req)
+	return recorder
+}

--- a/adp/execution-factory/operator-integration/server/logics/sandbox/management.go
+++ b/adp/execution-factory/operator-integration/server/logics/sandbox/management.go
@@ -1,0 +1,362 @@
+package sandbox
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/openbkn-ai/adp/execution-factory/operator-integration/server/infra/config"
+	"github.com/openbkn-ai/adp/execution-factory/operator-integration/server/infra/errors"
+	"github.com/openbkn-ai/adp/execution-factory/operator-integration/server/interfaces"
+)
+
+const (
+	sandboxHealthHealthy   = "healthy"
+	sandboxHealthDegraded  = "degraded"
+	sandboxHealthUnhealthy = "unhealthy"
+	defaultSessionSource   = "unknown"
+)
+
+type PoolSnapshot struct {
+	MaxSessions           int
+	ActiveSessions        int
+	MaxConcurrentTasks    int
+	CurrentActiveSessions int
+	CurrentRunningTasks   int
+	TemplateID            string
+	SessionResources      config.SessionResourcesConfig
+	Sessions              []PoolSessionSnapshot
+}
+
+type PoolSessionSnapshot struct {
+	ID           string
+	RunningTasks int
+	LastUsedAt   time.Time
+}
+
+type SandboxManagementService interface {
+	GetHealth(ctx context.Context) (*SandboxHealthResp, error)
+	GetPool(ctx context.Context) (*SandboxPoolResp, error)
+	ListSessions(ctx context.Context, req *SandboxSessionListReq) (*SandboxSessionListResp, error)
+	GetSessionDetail(ctx context.Context, sessionID string) (*SandboxSessionDetailResp, error)
+}
+
+type SandboxHealthResp struct {
+	Status                string `json:"status"`
+	ControlPlaneReachable bool   `json:"control_plane_reachable"`
+	CheckedAt             string `json:"checked_at"`
+	MaxSessions           int    `json:"max_sessions"`
+	CurrentActiveSessions int    `json:"current_active_sessions"`
+	CurrentRunningTasks   int    `json:"current_running_tasks"`
+	FailedSessions        int    `json:"failed_sessions"`
+	Message               string `json:"message,omitempty"`
+}
+
+type SandboxPoolResp struct {
+	MaxSessions           int                           `json:"max_sessions"`
+	ActiveSessions        int                           `json:"active_sessions"`
+	MaxConcurrentTasks    int                           `json:"max_concurrent_tasks"`
+	CurrentActiveSessions int                           `json:"current_active_sessions"`
+	CurrentRunningTasks   int                           `json:"current_running_tasks"`
+	TemplateID            string                        `json:"template_id"`
+	SessionResources      config.SessionResourcesConfig `json:"session_resources"`
+	Sessions              []PoolSessionSnapshotResp     `json:"sessions"`
+}
+
+type PoolSessionSnapshotResp struct {
+	ID           string `json:"id"`
+	RunningTasks int    `json:"running_tasks"`
+	LastUsedAt   string `json:"last_used_at,omitempty"`
+}
+
+type SandboxSessionListReq struct {
+	Limit        int                      `form:"limit"`
+	Offset       int                      `form:"offset"`
+	Status       interfaces.SessionStatus `form:"status"`
+	Source       string                   `form:"source"`
+	Runtime      string                   `form:"runtime"`
+	AbnormalOnly bool                     `form:"abnormal_only"`
+}
+
+type SandboxSessionListResp struct {
+	Items   []*SandboxSessionSummary `json:"items"`
+	Total   int                      `json:"total"`
+	Limit   int                      `json:"limit"`
+	Offset  int                      `json:"offset"`
+	HasMore bool                     `json:"has_more"`
+}
+
+type SandboxSessionSummary struct {
+	ID                      string                   `json:"id"`
+	Status                  interfaces.SessionStatus `json:"status"`
+	Source                  string                   `json:"source"`
+	TemplateID              string                   `json:"template_id"`
+	RuntimeType             string                   `json:"runtime_type"`
+	LanguageRuntime         string                   `json:"language_runtime,omitempty"`
+	ResourceLimit           map[string]any           `json:"resource_limit,omitempty"`
+	DependencyInstallStatus string                   `json:"dependency_install_status,omitempty"`
+	RecentErrorSummary      string                   `json:"recent_error_summary,omitempty"`
+	CreatedAt               string                   `json:"created_at,omitempty"`
+	UpdatedAt               string                   `json:"updated_at,omitempty"`
+	LastActivityAt          string                   `json:"last_activity_at,omitempty"`
+}
+
+type SandboxSessionDetailResp struct {
+	*SandboxSessionSummary
+	WorkspacePath                string                       `json:"workspace_path,omitempty"`
+	RuntimeNode                  string                       `json:"runtime_node,omitempty"`
+	PodName                      string                       `json:"pod_name,omitempty"`
+	Timeout                      int                          `json:"timeout,omitempty"`
+	PythonPackageIndexURL        string                       `json:"python_package_index_url,omitempty"`
+	RequestedDependencies        []*interfaces.DependencyInfo `json:"requested_dependencies,omitempty"`
+	InstalledDependencies        []*interfaces.DependencyInfo `json:"installed_dependencies,omitempty"`
+	DependencyInstallStartedAt   string                       `json:"dependency_install_started_at,omitempty"`
+	DependencyInstallCompletedAt string                       `json:"dependency_install_completed_at,omitempty"`
+	FullStdoutStderrAvailable    bool                         `json:"full_stdout_stderr_available"`
+	GovernanceActionsAvailable   bool                         `json:"governance_actions_available"`
+	SensitiveDiagnosticsRedacted bool                         `json:"sensitive_diagnostics_redacted"`
+}
+
+type sandboxManagementService struct {
+	client interfaces.SandBoxControlPlane
+	pool   interface {
+		Snapshot() PoolSnapshot
+	}
+}
+
+func NewSandboxManagementService(client interfaces.SandBoxControlPlane, pool interface {
+	Snapshot() PoolSnapshot
+}) SandboxManagementService {
+	return &sandboxManagementService{client: client, pool: pool}
+}
+
+func (s *sandboxManagementService) GetHealth(ctx context.Context) (*SandboxHealthResp, error) {
+	snapshot := s.pool.Snapshot()
+	limit := snapshot.MaxSessions
+	if limit <= 0 {
+		limit = defaultMaxSessions
+	}
+	resp, err := s.client.ListSessions(ctx, &interfaces.ListSessionsReq{Limit: limit})
+	checkedAt := time.Now().UTC().Format(time.RFC3339)
+	health := &SandboxHealthResp{
+		Status:                sandboxHealthHealthy,
+		ControlPlaneReachable: true,
+		CheckedAt:             checkedAt,
+		MaxSessions:           snapshot.MaxSessions,
+		CurrentActiveSessions: snapshot.CurrentActiveSessions,
+		CurrentRunningTasks:   snapshot.CurrentRunningTasks,
+	}
+	if err != nil {
+		health.Status = sandboxHealthUnhealthy
+		health.ControlPlaneReachable = false
+		health.Message = err.Error()
+		return health, nil
+	}
+	if resp != nil {
+		for _, item := range resp.Sessions {
+			if isAbnormalSession(item) {
+				health.FailedSessions++
+			}
+		}
+	}
+	if health.FailedSessions > 0 {
+		health.Status = sandboxHealthDegraded
+	}
+	return health, nil
+}
+
+func (s *sandboxManagementService) GetPool(ctx context.Context) (*SandboxPoolResp, error) {
+	snapshot := s.pool.Snapshot()
+	items := make([]PoolSessionSnapshotResp, 0, len(snapshot.Sessions))
+	for _, item := range snapshot.Sessions {
+		respItem := PoolSessionSnapshotResp{
+			ID:           item.ID,
+			RunningTasks: item.RunningTasks,
+		}
+		if !item.LastUsedAt.IsZero() {
+			respItem.LastUsedAt = item.LastUsedAt.UTC().Format(time.RFC3339)
+		}
+		items = append(items, respItem)
+	}
+	return &SandboxPoolResp{
+		MaxSessions:           snapshot.MaxSessions,
+		ActiveSessions:        snapshot.ActiveSessions,
+		MaxConcurrentTasks:    snapshot.MaxConcurrentTasks,
+		CurrentActiveSessions: snapshot.CurrentActiveSessions,
+		CurrentRunningTasks:   snapshot.CurrentRunningTasks,
+		TemplateID:            snapshot.TemplateID,
+		SessionResources:      snapshot.SessionResources,
+		Sessions:              items,
+	}, nil
+}
+
+func (s *sandboxManagementService) ListSessions(ctx context.Context, req *SandboxSessionListReq) (*SandboxSessionListResp, error) {
+	if req == nil {
+		req = &SandboxSessionListReq{}
+	}
+	resp, err := s.client.ListSessions(ctx, &interfaces.ListSessionsReq{
+		Limit:  req.Limit,
+		Offset: req.Offset,
+		Status: req.Status,
+	})
+	if err != nil {
+		return nil, err
+	}
+	result := &SandboxSessionListResp{
+		Items:   []*SandboxSessionSummary{},
+		Limit:   req.Limit,
+		Offset:  req.Offset,
+		HasMore: false,
+	}
+	if resp == nil {
+		return result, nil
+	}
+	result.Limit = resp.Limit
+	result.Offset = resp.Offset
+	result.HasMore = resp.HasMore
+	for _, item := range resp.Sessions {
+		summary := newSandboxSessionSummary(item)
+		if !matchSessionFilters(summary, req) {
+			continue
+		}
+		result.Items = append(result.Items, summary)
+	}
+	result.Total = len(result.Items)
+	return result, nil
+}
+
+func (s *sandboxManagementService) GetSessionDetail(ctx context.Context, sessionID string) (*SandboxSessionDetailResp, error) {
+	sessionID = strings.TrimSpace(sessionID)
+	if sessionID == "" {
+		return nil, errors.DefaultHTTPError(ctx, http.StatusBadRequest, "session_id is required")
+	}
+	exists, detail, err := s.client.QuerySession(ctx, sessionID)
+	if err != nil {
+		return nil, err
+	}
+	if !exists || detail == nil {
+		return nil, errors.DefaultHTTPError(ctx, http.StatusNotFound, fmt.Sprintf("session %s not found", sessionID))
+	}
+	summary := newSandboxSessionSummary(detail)
+	return &SandboxSessionDetailResp{
+		SandboxSessionSummary:        summary,
+		WorkspacePath:                detail.WorkspacePath,
+		RuntimeNode:                  detail.RuntimeNode,
+		PodName:                      detail.PodName,
+		Timeout:                      detail.Timeout,
+		PythonPackageIndexURL:        detail.PythonPackageIndexURL,
+		RequestedDependencies:        detail.RequestedDependencies,
+		InstalledDependencies:        detail.InstalledDependencies,
+		DependencyInstallStartedAt:   detail.DependencyInstallStartedAt,
+		DependencyInstallCompletedAt: detail.DependencyInstallCompletedAt,
+		FullStdoutStderrAvailable:    false,
+		GovernanceActionsAvailable:   false,
+		SensitiveDiagnosticsRedacted: true,
+	}, nil
+}
+
+func (p *sessionPoolImpl) Snapshot() PoolSnapshot {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	sessions := make([]PoolSessionSnapshot, 0, len(p.sessions))
+	runningTasks := 0
+	for _, item := range p.sessions {
+		if item == nil {
+			continue
+		}
+		runningTasks += item.RunningTasks
+		sessions = append(sessions, PoolSessionSnapshot{
+			ID:           item.ID,
+			RunningTasks: item.RunningTasks,
+			LastUsedAt:   item.LastUsedAt,
+		})
+	}
+	return PoolSnapshot{
+		MaxSessions:           p.maxSessions,
+		ActiveSessions:        p.activeSessions,
+		MaxConcurrentTasks:    p.maxConcurrentTasks,
+		CurrentActiveSessions: len(p.sessions),
+		CurrentRunningTasks:   runningTasks,
+		TemplateID:            p.templateID,
+		SessionResources:      p.reqConfig,
+		Sessions:              sessions,
+	}
+}
+
+func newSandboxSessionSummary(detail *interfaces.SessionDetail) *SandboxSessionSummary {
+	if detail == nil {
+		return &SandboxSessionSummary{Source: defaultSessionSource}
+	}
+	return &SandboxSessionSummary{
+		ID:                      detail.ID,
+		Status:                  detail.Status,
+		Source:                  detectSessionSource(detail),
+		TemplateID:              detail.TemplateID,
+		RuntimeType:             detail.RuntimeType,
+		LanguageRuntime:         detail.LanguageRuntime,
+		ResourceLimit:           detail.ResourceLimit,
+		DependencyInstallStatus: detail.DependencyInstallStatus,
+		RecentErrorSummary:      summarizeSessionError(detail),
+		CreatedAt:               detail.CreateAt,
+		UpdatedAt:               detail.UpdateAt,
+		LastActivityAt:          detail.LastActivityAt,
+	}
+}
+
+func detectSessionSource(detail *interfaces.SessionDetail) string {
+	for _, key := range []string{"source", "execution_source", "capability_type"} {
+		if value, ok := detail.EnvVars[key]; ok {
+			if text := strings.TrimSpace(fmt.Sprint(value)); text != "" {
+				return text
+			}
+		}
+	}
+	return defaultSessionSource
+}
+
+func summarizeSessionError(detail *interfaces.SessionDetail) string {
+	if detail == nil {
+		return ""
+	}
+	if text := strings.TrimSpace(detail.DependencyInstallError); text != "" {
+		return text
+	}
+	if detail.Status == interfaces.SessionStatusFailed {
+		return "session failed"
+	}
+	return ""
+}
+
+func matchSessionFilters(summary *SandboxSessionSummary, req *SandboxSessionListReq) bool {
+	if summary == nil || req == nil {
+		return true
+	}
+	if req.Source != "" && summary.Source != req.Source {
+		return false
+	}
+	if req.Runtime != "" && summary.RuntimeType != req.Runtime && summary.LanguageRuntime != req.Runtime {
+		return false
+	}
+	if req.AbnormalOnly && !isAbnormalSummary(summary) {
+		return false
+	}
+	return true
+}
+
+func isAbnormalSession(detail *interfaces.SessionDetail) bool {
+	if detail == nil {
+		return false
+	}
+	return detail.Status == interfaces.SessionStatusFailed ||
+		detail.DependencyInstallStatus == "failed" ||
+		strings.TrimSpace(detail.DependencyInstallError) != ""
+}
+
+func isAbnormalSummary(summary *SandboxSessionSummary) bool {
+	return summary.Status == interfaces.SessionStatusFailed ||
+		summary.DependencyInstallStatus == "failed" ||
+		strings.TrimSpace(summary.RecentErrorSummary) != ""
+}

--- a/adp/execution-factory/operator-integration/server/logics/sandbox/management_test.go
+++ b/adp/execution-factory/operator-integration/server/logics/sandbox/management_test.go
@@ -1,0 +1,149 @@
+package sandbox
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/openbkn-ai/adp/execution-factory/operator-integration/server/infra/config"
+	"github.com/openbkn-ai/adp/execution-factory/operator-integration/server/interfaces"
+	. "github.com/smartystreets/goconvey/convey"
+)
+
+type fakeSandboxControlPlane struct {
+	listReq      *interfaces.ListSessionsReq
+	listResp     *interfaces.ListSessionsResp
+	detail       *interfaces.SessionDetail
+	queryExists  bool
+	querySession string
+	queryErr     error
+}
+
+func (f *fakeSandboxControlPlane) GetTemplateDetail(ctx context.Context, tempID string) (any, error) {
+	return nil, nil
+}
+
+func (f *fakeSandboxControlPlane) CreateSession(ctx context.Context, req *interfaces.CreateSessionReq) (any, error) {
+	return nil, nil
+}
+
+func (f *fakeSandboxControlPlane) QuerySession(ctx context.Context, sessionID string) (bool, *interfaces.SessionDetail, error) {
+	f.querySession = sessionID
+	return f.queryExists, f.detail, f.queryErr
+}
+
+func (f *fakeSandboxControlPlane) DeleteSession(ctx context.Context, sessionID string) error {
+	return nil
+}
+
+func (f *fakeSandboxControlPlane) ListSessions(ctx context.Context, req *interfaces.ListSessionsReq) (*interfaces.ListSessionsResp, error) {
+	f.listReq = req
+	return f.listResp, nil
+}
+
+func (f *fakeSandboxControlPlane) ExecuteCodeSync(ctx context.Context, sessionID string, req *interfaces.ExecuteCodeReq) (*interfaces.ExecuteCodeResp, error) {
+	return nil, nil
+}
+
+func (f *fakeSandboxControlPlane) InstallPythonDependencies(ctx context.Context, sessionID string, req *interfaces.InstallDependenciesReq) (*interfaces.SessionDetail, error) {
+	return nil, nil
+}
+
+func (f *fakeSandboxControlPlane) UploadSkillArchive(ctx context.Context, sessionID string, req *interfaces.UploadSkillArchiveReq) (*interfaces.UploadSkillArchiveResp, error) {
+	return nil, nil
+}
+
+func (f *fakeSandboxControlPlane) ExecuteShell(ctx context.Context, sessionID string, req *interfaces.ExecuteShellReq) (*interfaces.ExecuteShellResp, error) {
+	return nil, nil
+}
+
+func TestSandboxManagementService(t *testing.T) {
+	Convey("Sandbox management service should expose read-only pool and session observability", t, func() {
+		now := time.Date(2026, 7, 1, 10, 0, 0, 0, time.UTC)
+		client := &fakeSandboxControlPlane{
+			listResp: &interfaces.ListSessionsResp{
+				Sessions: []*interfaces.SessionDetail{
+					{
+						ID:                         "sess_aoi_0",
+						Status:                     interfaces.SessionStatusRunning,
+						TemplateID:                 "python-basic",
+						RuntimeType:                "python",
+						DependencyInstallStatus:    "ready",
+						DependencyInstallError:     "",
+						LastActivityAt:             "2026-07-01T09:59:00Z",
+						InstalledDependencies:      []*interfaces.DependencyInfo{{Name: "numpy", Version: "1.26.4"}},
+						PythonPackageIndexURL:      "https://pypi.org/simple/",
+						DependencyInstallStartedAt: "2026-07-01T09:58:00Z",
+					},
+					{
+						ID:                      "sess_aoi_1",
+						Status:                  interfaces.SessionStatusFailed,
+						TemplateID:              "python-basic",
+						RuntimeType:             "python",
+						DependencyInstallStatus: "failed",
+						DependencyInstallError:  "numpy version conflict",
+					},
+				},
+				Total:   2,
+				Limit:   20,
+				Offset:  0,
+				HasMore: false,
+			},
+			detail: &interfaces.SessionDetail{
+				ID:                      "sess_aoi_1",
+				Status:                  interfaces.SessionStatusFailed,
+				TemplateID:              "python-basic",
+				RuntimeType:             "python",
+				ResourceLimit:           map[string]any{"cpu": "1", "memory": "512Mi"},
+				WorkspacePath:           "/workspace/sess_aoi_1",
+				DependencyInstallStatus: "failed",
+				DependencyInstallError:  "numpy version conflict",
+				LastActivityAt:          "2026-07-01T09:55:00Z",
+			},
+			queryExists: true,
+		}
+		pool := &sessionPoolImpl{
+			client:             client,
+			sessions:           map[string]*sessionItem{"sess_aoi_0": {ID: "sess_aoi_0", RunningTasks: 2, LastUsedAt: now}},
+			maxSessions:        3,
+			activeSessions:     1,
+			maxConcurrentTasks: 100,
+			templateID:         "python-basic",
+			reqConfig:          config.SessionResourcesConfig{CPU: "1", Memory: "512Mi", Disk: "1Gi", Timeout: 3600},
+		}
+		service := NewSandboxManagementService(client, pool)
+
+		health, err := service.GetHealth(context.Background())
+		So(err, ShouldBeNil)
+		So(health.Status, ShouldEqual, "degraded")
+		So(health.ControlPlaneReachable, ShouldBeTrue)
+		So(health.FailedSessions, ShouldEqual, 1)
+
+		poolResp, err := service.GetPool(context.Background())
+		So(err, ShouldBeNil)
+		So(poolResp.MaxSessions, ShouldEqual, 3)
+		So(poolResp.ActiveSessions, ShouldEqual, 1)
+		So(poolResp.CurrentActiveSessions, ShouldEqual, 1)
+		So(poolResp.CurrentRunningTasks, ShouldEqual, 2)
+		So(poolResp.SessionResources.Memory, ShouldEqual, "512Mi")
+
+		sessions, err := service.ListSessions(context.Background(), &SandboxSessionListReq{
+			Limit:  20,
+			Offset: 0,
+			Status: interfaces.SessionStatusFailed,
+		})
+		So(err, ShouldBeNil)
+		So(client.listReq.Status, ShouldEqual, interfaces.SessionStatusFailed)
+		So(sessions.Total, ShouldEqual, 2)
+		So(sessions.Items[1].Source, ShouldEqual, "unknown")
+		So(sessions.Items[1].RecentErrorSummary, ShouldEqual, "numpy version conflict")
+		So(sessions.Items[1].DependencyInstallStatus, ShouldEqual, "failed")
+
+		detail, err := service.GetSessionDetail(context.Background(), "sess_aoi_1")
+		So(err, ShouldBeNil)
+		So(client.querySession, ShouldEqual, "sess_aoi_1")
+		So(detail.ID, ShouldEqual, "sess_aoi_1")
+		So(detail.RecentErrorSummary, ShouldEqual, "numpy version conflict")
+		So(detail.ResourceLimit["memory"], ShouldEqual, "512Mi")
+	})
+}

--- a/adp/execution-factory/operator-integration/server/logics/sandbox/session_pool.go
+++ b/adp/execution-factory/operator-integration/server/logics/sandbox/session_pool.go
@@ -8,13 +8,13 @@ import (
 	"sync"
 	"time"
 
+	o11y "github.com/kweaver-ai/kweaver-go-lib/observability"
 	"github.com/openbkn-ai/adp/execution-factory/operator-integration/server/drivenadapters"
 	"github.com/openbkn-ai/adp/execution-factory/operator-integration/server/infra/config"
 	"github.com/openbkn-ai/adp/execution-factory/operator-integration/server/infra/errors"
 	"github.com/openbkn-ai/adp/execution-factory/operator-integration/server/infra/telemetry"
 	"github.com/openbkn-ai/adp/execution-factory/operator-integration/server/interfaces"
 	"github.com/openbkn-ai/adp/execution-factory/operator-integration/server/utils"
-	o11y "github.com/kweaver-ai/kweaver-go-lib/observability"
 )
 
 const (
@@ -44,6 +44,8 @@ type SessionPool interface {
 	ExecuteCode(ctx context.Context, req *interfaces.ExecuteCodeReq) (*interfaces.ExecuteCodeResp, error)
 	// 获取依赖库列表
 	GetDependencies(ctx context.Context) (resp *DependenciesInfo, err error)
+	// Snapshot returns read-only pool status for management and diagnostics.
+	Snapshot() PoolSnapshot
 	// 获取可用会话
 	AcquireSession(ctx context.Context) (sessionID string, err error)
 	// 归还会话

--- a/adp/execution-factory/operator-integration/server/logics/skill/reader_registry_test.go
+++ b/adp/execution-factory/operator-integration/server/logics/skill/reader_registry_test.go
@@ -120,6 +120,10 @@ func (f *fakeSessionPool) GetDependencies(ctx context.Context) (*sandbox.Depende
 	return nil, nil
 }
 
+func (f *fakeSessionPool) Snapshot() sandbox.PoolSnapshot {
+	return sandbox.PoolSnapshot{}
+}
+
 func (f *fakeSessionPool) AcquireSession(ctx context.Context) (string, error) {
 	return f.acquireFunc(ctx)
 }


### PR DESCRIPTION
## Summary

Closes #116.

This PR adds the first-phase read-only Sandbox Runtime observability backend for Execution Factory Lab.

Changes:
- add private read-only sandbox management APIs under `/api/agent-operator-integration/internal-v1/sandbox`:
  - `GET /sandbox/health`
  - `GET /sandbox/pool`
  - `GET /sandbox/sessions`
  - `GET /sandbox/sessions/{id}`
- add a sandbox management service that shapes control-plane session data and local session-pool snapshots for UI diagnostics;
- expose `SessionPool.Snapshot()` for read-only pool waterline inspection;
- register the new routes only on the private handler;
- add tests for service behavior and read-only HTTP routes;
- add private API YAML and a design note documenting the Studio frontend integration boundary.

## Verification

Passed:
- `GOTOOLCHAIN=go1.24.11 go test ./server/logics/sandbox -run TestSandboxManagementService -count=1 -v`
- `GOTOOLCHAIN=go1.24.11 go test ./server/driveradapters/sandbox -run TestManagementHandlerReadOnlyRoutes -count=1 -v`
- `GOTOOLCHAIN=go1.24.11 go test ./server/logics/sandbox ./server/driveradapters/sandbox ./server/logics/skill ./server/driveradapters -count=1`
- `git diff --cached --check`

Module-level note:
- An equivalent module test over `go list ./server/...` excluding `server/tests` and `server/mocks` still fails in existing `server/logics/operator` tests with nil transaction rollback panics in `edit_test.go` / `register_test.go`. The new sandbox, driver adapter, skill, and driveradapters packages passed.

## Scope notes

This PR intentionally does not add terminate/delete/cleanup/prewarm/write operations. Those are tracked separately in #117 and need permission checks, confirmation UX, and audit logs.

The Studio frontend entry is documented but not implemented here because the Studio frontend is outside this repository.