### PR TITLE
chore: normalize copyright headers (drop year, strip kweaver from net-new files)

### DIFF
--- a/adp/bkn/bkn-backend/script/clean_opensearch_index/script.py
+++ b/adp/bkn/bkn-backend/script/clean_opensearch_index/script.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
-# Copyright 2026 openbkn.ai
+# Copyright openbkn.ai
 # Copyright The kweaver.ai Authors.
 #
 # Licensed under the Apache License, Version 2.0.

--- a/adp/bkn/bkn-backend/script/delete_concept_index/script.py
+++ b/adp/bkn/bkn-backend/script/delete_concept_index/script.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
-# Copyright 2026 openbkn.ai
+# Copyright openbkn.ai
 # Copyright The kweaver.ai Authors.
 #
 # Licensed under the Apache License, Version 2.0.

--- a/adp/bkn/bkn-backend/server/common/condition/condition.go
+++ b/adp/bkn/bkn-backend/server/common/condition/condition.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/bkn/bkn-backend/server/common/condition/condition_and.go
+++ b/adp/bkn/bkn-backend/server/common/condition/condition_and.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/bkn/bkn-backend/server/common/condition/condition_and_test.go
+++ b/adp/bkn/bkn-backend/server/common/condition/condition_and_test.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/bkn/bkn-backend/server/common/condition/condition_eq.go
+++ b/adp/bkn/bkn-backend/server/common/condition/condition_eq.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/bkn/bkn-backend/server/common/condition/condition_eq_test.go
+++ b/adp/bkn/bkn-backend/server/common/condition/condition_eq_test.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/bkn/bkn-backend/server/common/condition/condition_in.go
+++ b/adp/bkn/bkn-backend/server/common/condition/condition_in.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/bkn/bkn-backend/server/common/condition/condition_in_test.go
+++ b/adp/bkn/bkn-backend/server/common/condition/condition_in_test.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/bkn/bkn-backend/server/common/condition/condition_knn.go
+++ b/adp/bkn/bkn-backend/server/common/condition/condition_knn.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/bkn/bkn-backend/server/common/condition/condition_knn_test.go
+++ b/adp/bkn/bkn-backend/server/common/condition/condition_knn_test.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/bkn/bkn-backend/server/common/condition/condition_like.go
+++ b/adp/bkn/bkn-backend/server/common/condition/condition_like.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/bkn/bkn-backend/server/common/condition/condition_like_test.go
+++ b/adp/bkn/bkn-backend/server/common/condition/condition_like_test.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/bkn/bkn-backend/server/common/condition/condition_match.go
+++ b/adp/bkn/bkn-backend/server/common/condition/condition_match.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/bkn/bkn-backend/server/common/condition/condition_match_phrase.go
+++ b/adp/bkn/bkn-backend/server/common/condition/condition_match_phrase.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/bkn/bkn-backend/server/common/condition/condition_match_phrase_test.go
+++ b/adp/bkn/bkn-backend/server/common/condition/condition_match_phrase_test.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/bkn/bkn-backend/server/common/condition/condition_match_test.go
+++ b/adp/bkn/bkn-backend/server/common/condition/condition_match_test.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/bkn/bkn-backend/server/common/condition/condition_multi_match.go
+++ b/adp/bkn/bkn-backend/server/common/condition/condition_multi_match.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/bkn/bkn-backend/server/common/condition/condition_multi_match_test.go
+++ b/adp/bkn/bkn-backend/server/common/condition/condition_multi_match_test.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/bkn/bkn-backend/server/common/condition/condition_not_eq.go
+++ b/adp/bkn/bkn-backend/server/common/condition/condition_not_eq.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/bkn/bkn-backend/server/common/condition/condition_not_eq_test.go
+++ b/adp/bkn/bkn-backend/server/common/condition/condition_not_eq_test.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/bkn/bkn-backend/server/common/condition/condition_not_in.go
+++ b/adp/bkn/bkn-backend/server/common/condition/condition_not_in.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/bkn/bkn-backend/server/common/condition/condition_not_in_test.go
+++ b/adp/bkn/bkn-backend/server/common/condition/condition_not_in_test.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/bkn/bkn-backend/server/common/condition/condition_not_like.go
+++ b/adp/bkn/bkn-backend/server/common/condition/condition_not_like.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/bkn/bkn-backend/server/common/condition/condition_not_like_test.go
+++ b/adp/bkn/bkn-backend/server/common/condition/condition_not_like_test.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/bkn/bkn-backend/server/common/condition/condition_or.go
+++ b/adp/bkn/bkn-backend/server/common/condition/condition_or.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/bkn/bkn-backend/server/common/condition/condition_or_test.go
+++ b/adp/bkn/bkn-backend/server/common/condition/condition_or_test.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/bkn/bkn-backend/server/common/condition/condition_regex.go
+++ b/adp/bkn/bkn-backend/server/common/condition/condition_regex.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/bkn/bkn-backend/server/common/condition/condition_regex_test.go
+++ b/adp/bkn/bkn-backend/server/common/condition/condition_regex_test.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/bkn/bkn-backend/server/common/condition/condition_test.go
+++ b/adp/bkn/bkn-backend/server/common/condition/condition_test.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/bkn/bkn-backend/server/common/condition/entity.go
+++ b/adp/bkn/bkn-backend/server/common/condition/entity.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/bkn/bkn-backend/server/common/condition/entity_test.go
+++ b/adp/bkn/bkn-backend/server/common/condition/entity_test.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/bkn/bkn-backend/server/common/convert.go
+++ b/adp/bkn/bkn-backend/server/common/convert.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/bkn/bkn-backend/server/common/convert_test.go
+++ b/adp/bkn/bkn-backend/server/common/convert_test.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/bkn/bkn-backend/server/common/http_client.go
+++ b/adp/bkn/bkn-backend/server/common/http_client.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/bkn/bkn-backend/server/common/logger.go
+++ b/adp/bkn/bkn-backend/server/common/logger.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/bkn/bkn-backend/server/common/setting.go
+++ b/adp/bkn/bkn-backend/server/common/setting.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/bkn/bkn-backend/server/common/util.go
+++ b/adp/bkn/bkn-backend/server/common/util.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/bkn/bkn-backend/server/common/util_test.go
+++ b/adp/bkn/bkn-backend/server/common/util_test.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/bkn/bkn-backend/server/common/visitor/visitor.go
+++ b/adp/bkn/bkn-backend/server/common/visitor/visitor.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/bkn/bkn-backend/server/drivenadapters/action_schedule/action_schedule_access.go
+++ b/adp/bkn/bkn-backend/server/drivenadapters/action_schedule/action_schedule_access.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/bkn/bkn-backend/server/drivenadapters/action_type/action_type_access.go
+++ b/adp/bkn/bkn-backend/server/drivenadapters/action_type/action_type_access.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/bkn/bkn-backend/server/drivenadapters/action_type/action_type_access_test.go
+++ b/adp/bkn/bkn-backend/server/drivenadapters/action_type/action_type_access_test.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/bkn/bkn-backend/server/drivenadapters/agent_operator/agent_operator_access.go
+++ b/adp/bkn/bkn-backend/server/drivenadapters/agent_operator/agent_operator_access.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/bkn/bkn-backend/server/drivenadapters/auth/hydra_auth_access.go
+++ b/adp/bkn/bkn-backend/server/drivenadapters/auth/hydra_auth_access.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/bkn/bkn-backend/server/drivenadapters/business_system/business_system_access.go
+++ b/adp/bkn/bkn-backend/server/drivenadapters/business_system/business_system_access.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/bkn/bkn-backend/server/drivenadapters/business_system/business_system_access_test.go
+++ b/adp/bkn/bkn-backend/server/drivenadapters/business_system/business_system_access_test.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/bkn/bkn-backend/server/drivenadapters/concept_group/concept_group_access.go
+++ b/adp/bkn/bkn-backend/server/drivenadapters/concept_group/concept_group_access.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/bkn/bkn-backend/server/drivenadapters/concept_group/concept_group_access_test.go
+++ b/adp/bkn/bkn-backend/server/drivenadapters/concept_group/concept_group_access_test.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/bkn/bkn-backend/server/drivenadapters/data_model/data_model_access.go
+++ b/adp/bkn/bkn-backend/server/drivenadapters/data_model/data_model_access.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/bkn/bkn-backend/server/drivenadapters/data_model/data_model_access_test.go
+++ b/adp/bkn/bkn-backend/server/drivenadapters/data_model/data_model_access_test.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/bkn/bkn-backend/server/drivenadapters/data_view/data_view_access.go
+++ b/adp/bkn/bkn-backend/server/drivenadapters/data_view/data_view_access.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/bkn/bkn-backend/server/drivenadapters/data_view/data_view_access_test.go
+++ b/adp/bkn/bkn-backend/server/drivenadapters/data_view/data_view_access_test.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/bkn/bkn-backend/server/drivenadapters/job/job_access.go
+++ b/adp/bkn/bkn-backend/server/drivenadapters/job/job_access.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/bkn/bkn-backend/server/drivenadapters/job/job_access_test.go
+++ b/adp/bkn/bkn-backend/server/drivenadapters/job/job_access_test.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/bkn/bkn-backend/server/drivenadapters/knowledge_network/knowledge_network_access.go
+++ b/adp/bkn/bkn-backend/server/drivenadapters/knowledge_network/knowledge_network_access.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/bkn/bkn-backend/server/drivenadapters/knowledge_network/knowledge_network_access_test.go
+++ b/adp/bkn/bkn-backend/server/drivenadapters/knowledge_network/knowledge_network_access_test.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/bkn/bkn-backend/server/drivenadapters/metric/metric_access.go
+++ b/adp/bkn/bkn-backend/server/drivenadapters/metric/metric_access.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/bkn/bkn-backend/server/drivenadapters/metric/metric_access_test.go
+++ b/adp/bkn/bkn-backend/server/drivenadapters/metric/metric_access_test.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/bkn/bkn-backend/server/drivenadapters/model_factory/model_factory_access.go
+++ b/adp/bkn/bkn-backend/server/drivenadapters/model_factory/model_factory_access.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/bkn/bkn-backend/server/drivenadapters/model_factory/model_factory_access_test.go
+++ b/adp/bkn/bkn-backend/server/drivenadapters/model_factory/model_factory_access_test.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/bkn/bkn-backend/server/drivenadapters/object_type/object_type_access.go
+++ b/adp/bkn/bkn-backend/server/drivenadapters/object_type/object_type_access.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/bkn/bkn-backend/server/drivenadapters/object_type/object_type_access_test.go
+++ b/adp/bkn/bkn-backend/server/drivenadapters/object_type/object_type_access_test.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/bkn/bkn-backend/server/drivenadapters/opensearch/opensearch_access.go
+++ b/adp/bkn/bkn-backend/server/drivenadapters/opensearch/opensearch_access.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/bkn/bkn-backend/server/drivenadapters/opensearch/opensearch_access_test.go
+++ b/adp/bkn/bkn-backend/server/drivenadapters/opensearch/opensearch_access_test.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/bkn/bkn-backend/server/drivenadapters/permission/permission_access.go
+++ b/adp/bkn/bkn-backend/server/drivenadapters/permission/permission_access.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/bkn/bkn-backend/server/drivenadapters/permission/permission_access_test.go
+++ b/adp/bkn/bkn-backend/server/drivenadapters/permission/permission_access_test.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/bkn/bkn-backend/server/drivenadapters/relation_type/relation_type_access.go
+++ b/adp/bkn/bkn-backend/server/drivenadapters/relation_type/relation_type_access.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/bkn/bkn-backend/server/drivenadapters/relation_type/relation_type_access_test.go
+++ b/adp/bkn/bkn-backend/server/drivenadapters/relation_type/relation_type_access_test.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/bkn/bkn-backend/server/drivenadapters/risk_type/risk_type_access.go
+++ b/adp/bkn/bkn-backend/server/drivenadapters/risk_type/risk_type_access.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/bkn/bkn-backend/server/drivenadapters/risk_type/risk_type_access_test.go
+++ b/adp/bkn/bkn-backend/server/drivenadapters/risk_type/risk_type_access_test.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/bkn/bkn-backend/server/drivenadapters/user_mgmt/user_mgmt_access.go
+++ b/adp/bkn/bkn-backend/server/drivenadapters/user_mgmt/user_mgmt_access.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/bkn/bkn-backend/server/drivenadapters/user_mgmt/user_mgmt_access_test.go
+++ b/adp/bkn/bkn-backend/server/drivenadapters/user_mgmt/user_mgmt_access_test.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/bkn/bkn-backend/server/drivenadapters/vega_backend/vega_backend_access.go
+++ b/adp/bkn/bkn-backend/server/drivenadapters/vega_backend/vega_backend_access.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/bkn/bkn-backend/server/driveradapters/action_schedule_handler.go
+++ b/adp/bkn/bkn-backend/server/driveradapters/action_schedule_handler.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/bkn/bkn-backend/server/driveradapters/action_schedule_handler_test.go
+++ b/adp/bkn/bkn-backend/server/driveradapters/action_schedule_handler_test.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/bkn/bkn-backend/server/driveradapters/action_type_handler.go
+++ b/adp/bkn/bkn-backend/server/driveradapters/action_type_handler.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/bkn/bkn-backend/server/driveradapters/action_type_handler_test.go
+++ b/adp/bkn/bkn-backend/server/driveradapters/action_type_handler_test.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/bkn/bkn-backend/server/driveradapters/bkn_handler.go
+++ b/adp/bkn/bkn-backend/server/driveradapters/bkn_handler.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/bkn/bkn-backend/server/driveradapters/bkn_handler_test.go
+++ b/adp/bkn/bkn-backend/server/driveradapters/bkn_handler_test.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/bkn/bkn-backend/server/driveradapters/concept_group_handler.go
+++ b/adp/bkn/bkn-backend/server/driveradapters/concept_group_handler.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/bkn/bkn-backend/server/driveradapters/concept_group_handler_test.go
+++ b/adp/bkn/bkn-backend/server/driveradapters/concept_group_handler_test.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/bkn/bkn-backend/server/driveradapters/job_handler.go
+++ b/adp/bkn/bkn-backend/server/driveradapters/job_handler.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/bkn/bkn-backend/server/driveradapters/job_handler_test.go
+++ b/adp/bkn/bkn-backend/server/driveradapters/job_handler_test.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/bkn/bkn-backend/server/driveradapters/knowledge_network_handler.go
+++ b/adp/bkn/bkn-backend/server/driveradapters/knowledge_network_handler.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/bkn/bkn-backend/server/driveradapters/knowledge_network_handler_test.go
+++ b/adp/bkn/bkn-backend/server/driveradapters/knowledge_network_handler_test.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/bkn/bkn-backend/server/driveradapters/metric_handler.go
+++ b/adp/bkn/bkn-backend/server/driveradapters/metric_handler.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/bkn/bkn-backend/server/driveradapters/object_type_handler.go
+++ b/adp/bkn/bkn-backend/server/driveradapters/object_type_handler.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/bkn/bkn-backend/server/driveradapters/object_type_handler_test.go
+++ b/adp/bkn/bkn-backend/server/driveradapters/object_type_handler_test.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/bkn/bkn-backend/server/driveradapters/relation_type_handler.go
+++ b/adp/bkn/bkn-backend/server/driveradapters/relation_type_handler.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/bkn/bkn-backend/server/driveradapters/relation_type_handler_test.go
+++ b/adp/bkn/bkn-backend/server/driveradapters/relation_type_handler_test.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/bkn/bkn-backend/server/driveradapters/resource_handler.go
+++ b/adp/bkn/bkn-backend/server/driveradapters/resource_handler.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/bkn/bkn-backend/server/driveradapters/resource_handler_test.go
+++ b/adp/bkn/bkn-backend/server/driveradapters/resource_handler_test.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/bkn/bkn-backend/server/driveradapters/risk_type_handler.go
+++ b/adp/bkn/bkn-backend/server/driveradapters/risk_type_handler.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/bkn/bkn-backend/server/driveradapters/routers.go
+++ b/adp/bkn/bkn-backend/server/driveradapters/routers.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/bkn/bkn-backend/server/driveradapters/routers_test.go
+++ b/adp/bkn/bkn-backend/server/driveradapters/routers_test.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/bkn/bkn-backend/server/driveradapters/validate.go
+++ b/adp/bkn/bkn-backend/server/driveradapters/validate.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/bkn/bkn-backend/server/driveradapters/validate_action_schedule.go
+++ b/adp/bkn/bkn-backend/server/driveradapters/validate_action_schedule.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/bkn/bkn-backend/server/driveradapters/validate_action_schedule_test.go
+++ b/adp/bkn/bkn-backend/server/driveradapters/validate_action_schedule_test.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/bkn/bkn-backend/server/driveradapters/validate_action_type.go
+++ b/adp/bkn/bkn-backend/server/driveradapters/validate_action_type.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/bkn/bkn-backend/server/driveradapters/validate_action_type_test.go
+++ b/adp/bkn/bkn-backend/server/driveradapters/validate_action_type_test.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/bkn/bkn-backend/server/driveradapters/validate_concept_group.go
+++ b/adp/bkn/bkn-backend/server/driveradapters/validate_concept_group.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/bkn/bkn-backend/server/driveradapters/validate_concept_group_test.go
+++ b/adp/bkn/bkn-backend/server/driveradapters/validate_concept_group_test.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/bkn/bkn-backend/server/driveradapters/validate_job.go
+++ b/adp/bkn/bkn-backend/server/driveradapters/validate_job.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/bkn/bkn-backend/server/driveradapters/validate_job_test.go
+++ b/adp/bkn/bkn-backend/server/driveradapters/validate_job_test.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/bkn/bkn-backend/server/driveradapters/validate_knowledge_network.go
+++ b/adp/bkn/bkn-backend/server/driveradapters/validate_knowledge_network.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/bkn/bkn-backend/server/driveradapters/validate_knowledge_network_test.go
+++ b/adp/bkn/bkn-backend/server/driveradapters/validate_knowledge_network_test.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/bkn/bkn-backend/server/driveradapters/validate_metric.go
+++ b/adp/bkn/bkn-backend/server/driveradapters/validate_metric.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/bkn/bkn-backend/server/driveradapters/validate_metric_test.go
+++ b/adp/bkn/bkn-backend/server/driveradapters/validate_metric_test.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/bkn/bkn-backend/server/driveradapters/validate_object_type.go
+++ b/adp/bkn/bkn-backend/server/driveradapters/validate_object_type.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/bkn/bkn-backend/server/driveradapters/validate_object_type_test.go
+++ b/adp/bkn/bkn-backend/server/driveradapters/validate_object_type_test.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/bkn/bkn-backend/server/driveradapters/validate_relation_type.go
+++ b/adp/bkn/bkn-backend/server/driveradapters/validate_relation_type.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/bkn/bkn-backend/server/driveradapters/validate_relation_type_test.go
+++ b/adp/bkn/bkn-backend/server/driveradapters/validate_relation_type_test.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/bkn/bkn-backend/server/driveradapters/validate_risk_type.go
+++ b/adp/bkn/bkn-backend/server/driveradapters/validate_risk_type.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/bkn/bkn-backend/server/driveradapters/validate_test.go
+++ b/adp/bkn/bkn-backend/server/driveradapters/validate_test.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/bkn/bkn-backend/server/errors/action_schedule.go
+++ b/adp/bkn/bkn-backend/server/errors/action_schedule.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/bkn/bkn-backend/server/errors/action_type.go
+++ b/adp/bkn/bkn-backend/server/errors/action_type.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/bkn/bkn-backend/server/errors/concept_group.go
+++ b/adp/bkn/bkn-backend/server/errors/concept_group.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/bkn/bkn-backend/server/errors/error_code.go
+++ b/adp/bkn/bkn-backend/server/errors/error_code.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/bkn/bkn-backend/server/errors/job.go
+++ b/adp/bkn/bkn-backend/server/errors/job.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/bkn/bkn-backend/server/errors/knowledge_network.go
+++ b/adp/bkn/bkn-backend/server/errors/knowledge_network.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/bkn/bkn-backend/server/errors/metric.go
+++ b/adp/bkn/bkn-backend/server/errors/metric.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/bkn/bkn-backend/server/errors/object_type.go
+++ b/adp/bkn/bkn-backend/server/errors/object_type.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/bkn/bkn-backend/server/errors/relation_type.go
+++ b/adp/bkn/bkn-backend/server/errors/relation_type.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/bkn/bkn-backend/server/errors/risk_type.go
+++ b/adp/bkn/bkn-backend/server/errors/risk_type.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/bkn/bkn-backend/server/interfaces/action_schedule.go
+++ b/adp/bkn/bkn-backend/server/interfaces/action_schedule.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/bkn/bkn-backend/server/interfaces/action_schedule_access.go
+++ b/adp/bkn/bkn-backend/server/interfaces/action_schedule_access.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/bkn/bkn-backend/server/interfaces/action_schedule_service.go
+++ b/adp/bkn/bkn-backend/server/interfaces/action_schedule_service.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/bkn/bkn-backend/server/interfaces/action_type.go
+++ b/adp/bkn/bkn-backend/server/interfaces/action_type.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/bkn/bkn-backend/server/interfaces/action_type_access.go
+++ b/adp/bkn/bkn-backend/server/interfaces/action_type_access.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/bkn/bkn-backend/server/interfaces/action_type_service.go
+++ b/adp/bkn/bkn-backend/server/interfaces/action_type_service.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/bkn/bkn-backend/server/interfaces/agent_operator_access.go
+++ b/adp/bkn/bkn-backend/server/interfaces/agent_operator_access.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/bkn/bkn-backend/server/interfaces/auth_access.go
+++ b/adp/bkn/bkn-backend/server/interfaces/auth_access.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/bkn/bkn-backend/server/interfaces/auth_service.go
+++ b/adp/bkn/bkn-backend/server/interfaces/auth_service.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/bkn/bkn-backend/server/interfaces/bkn.go
+++ b/adp/bkn/bkn-backend/server/interfaces/bkn.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/bkn/bkn-backend/server/interfaces/bkn_service.go
+++ b/adp/bkn/bkn-backend/server/interfaces/bkn_service.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/bkn/bkn-backend/server/interfaces/business_system_access.go
+++ b/adp/bkn/bkn-backend/server/interfaces/business_system_access.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/bkn/bkn-backend/server/interfaces/business_system_service.go
+++ b/adp/bkn/bkn-backend/server/interfaces/business_system_service.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/bkn/bkn-backend/server/interfaces/common.go
+++ b/adp/bkn/bkn-backend/server/interfaces/common.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/bkn/bkn-backend/server/interfaces/concept_group.go
+++ b/adp/bkn/bkn-backend/server/interfaces/concept_group.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/bkn/bkn-backend/server/interfaces/concept_group_access.go
+++ b/adp/bkn/bkn-backend/server/interfaces/concept_group_access.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/bkn/bkn-backend/server/interfaces/concept_group_service.go
+++ b/adp/bkn/bkn-backend/server/interfaces/concept_group_service.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/bkn/bkn-backend/server/interfaces/data_model_access.go
+++ b/adp/bkn/bkn-backend/server/interfaces/data_model_access.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/bkn/bkn-backend/server/interfaces/data_type/data_types.go
+++ b/adp/bkn/bkn-backend/server/interfaces/data_type/data_types.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/bkn/bkn-backend/server/interfaces/data_view_access.go
+++ b/adp/bkn/bkn-backend/server/interfaces/data_view_access.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/bkn/bkn-backend/server/interfaces/job.go
+++ b/adp/bkn/bkn-backend/server/interfaces/job.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/bkn/bkn-backend/server/interfaces/job_access.go
+++ b/adp/bkn/bkn-backend/server/interfaces/job_access.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/bkn/bkn-backend/server/interfaces/job_executor.go
+++ b/adp/bkn/bkn-backend/server/interfaces/job_executor.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/bkn/bkn-backend/server/interfaces/job_service.go
+++ b/adp/bkn/bkn-backend/server/interfaces/job_service.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/bkn/bkn-backend/server/interfaces/knowledge_network.go
+++ b/adp/bkn/bkn-backend/server/interfaces/knowledge_network.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/bkn/bkn-backend/server/interfaces/knowledge_network_access.go
+++ b/adp/bkn/bkn-backend/server/interfaces/knowledge_network_access.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/bkn/bkn-backend/server/interfaces/knowledge_network_service.go
+++ b/adp/bkn/bkn-backend/server/interfaces/knowledge_network_service.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/bkn/bkn-backend/server/interfaces/metric.go
+++ b/adp/bkn/bkn-backend/server/interfaces/metric.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/bkn/bkn-backend/server/interfaces/metric_access.go
+++ b/adp/bkn/bkn-backend/server/interfaces/metric_access.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/bkn/bkn-backend/server/interfaces/metric_service.go
+++ b/adp/bkn/bkn-backend/server/interfaces/metric_service.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/bkn/bkn-backend/server/interfaces/model_factory_access.go
+++ b/adp/bkn/bkn-backend/server/interfaces/model_factory_access.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/bkn/bkn-backend/server/interfaces/object_type.go
+++ b/adp/bkn/bkn-backend/server/interfaces/object_type.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/bkn/bkn-backend/server/interfaces/object_type_access.go
+++ b/adp/bkn/bkn-backend/server/interfaces/object_type_access.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/bkn/bkn-backend/server/interfaces/object_type_service.go
+++ b/adp/bkn/bkn-backend/server/interfaces/object_type_service.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/bkn/bkn-backend/server/interfaces/opensearch_access.go
+++ b/adp/bkn/bkn-backend/server/interfaces/opensearch_access.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/bkn/bkn-backend/server/interfaces/permission_access.go
+++ b/adp/bkn/bkn-backend/server/interfaces/permission_access.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/bkn/bkn-backend/server/interfaces/permission_service.go
+++ b/adp/bkn/bkn-backend/server/interfaces/permission_service.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/bkn/bkn-backend/server/interfaces/relation_type.go
+++ b/adp/bkn/bkn-backend/server/interfaces/relation_type.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/bkn/bkn-backend/server/interfaces/relation_type_access.go
+++ b/adp/bkn/bkn-backend/server/interfaces/relation_type_access.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/bkn/bkn-backend/server/interfaces/relation_type_service.go
+++ b/adp/bkn/bkn-backend/server/interfaces/relation_type_service.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/bkn/bkn-backend/server/interfaces/risk_type.go
+++ b/adp/bkn/bkn-backend/server/interfaces/risk_type.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/bkn/bkn-backend/server/interfaces/risk_type_access.go
+++ b/adp/bkn/bkn-backend/server/interfaces/risk_type_access.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/bkn/bkn-backend/server/interfaces/risk_type_service.go
+++ b/adp/bkn/bkn-backend/server/interfaces/risk_type_service.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/bkn/bkn-backend/server/interfaces/user_mgmt_access.go
+++ b/adp/bkn/bkn-backend/server/interfaces/user_mgmt_access.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/bkn/bkn-backend/server/interfaces/user_mgmt_service.go
+++ b/adp/bkn/bkn-backend/server/interfaces/user_mgmt_service.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/bkn/bkn-backend/server/interfaces/vega_backend_access.go
+++ b/adp/bkn/bkn-backend/server/interfaces/vega_backend_access.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/bkn/bkn-backend/server/locale/locale.go
+++ b/adp/bkn/bkn-backend/server/locale/locale.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/bkn/bkn-backend/server/logics/action_schedule/action_schedule_service.go
+++ b/adp/bkn/bkn-backend/server/logics/action_schedule/action_schedule_service.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/bkn/bkn-backend/server/logics/action_schedule/action_schedule_service_test.go
+++ b/adp/bkn/bkn-backend/server/logics/action_schedule/action_schedule_service_test.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/bkn/bkn-backend/server/logics/action_type/action_type_service.go
+++ b/adp/bkn/bkn-backend/server/logics/action_type/action_type_service.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/bkn/bkn-backend/server/logics/action_type/action_type_service_test.go
+++ b/adp/bkn/bkn-backend/server/logics/action_type/action_type_service_test.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/bkn/bkn-backend/server/logics/auth/auth_service.go
+++ b/adp/bkn/bkn-backend/server/logics/auth/auth_service.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/bkn/bkn-backend/server/logics/auth/auth_service_test.go
+++ b/adp/bkn/bkn-backend/server/logics/auth/auth_service_test.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/bkn/bkn-backend/server/logics/auth/hydra_auth_service.go
+++ b/adp/bkn/bkn-backend/server/logics/auth/hydra_auth_service.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/bkn/bkn-backend/server/logics/auth/noop_auth_service.go
+++ b/adp/bkn/bkn-backend/server/logics/auth/noop_auth_service.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/bkn/bkn-backend/server/logics/batchindex/batchindex.go
+++ b/adp/bkn/bkn-backend/server/logics/batchindex/batchindex.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/bkn/bkn-backend/server/logics/batchindex/batchindex_test.go
+++ b/adp/bkn/bkn-backend/server/logics/batchindex/batchindex_test.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/bkn/bkn-backend/server/logics/bkn/bkn_service.go
+++ b/adp/bkn/bkn-backend/server/logics/bkn/bkn_service.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/bkn/bkn-backend/server/logics/bkn/bkn_service_test.go
+++ b/adp/bkn/bkn-backend/server/logics/bkn/bkn_service_test.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/bkn/bkn-backend/server/logics/bkn_convert.go
+++ b/adp/bkn/bkn-backend/server/logics/bkn_convert.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/bkn/bkn-backend/server/logics/bkn_convert_test.go
+++ b/adp/bkn/bkn-backend/server/logics/bkn_convert_test.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/bkn/bkn-backend/server/logics/business_system/business_system_service.go
+++ b/adp/bkn/bkn-backend/server/logics/business_system/business_system_service.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/bkn/bkn-backend/server/logics/business_system/business_system_service_impl.go
+++ b/adp/bkn/bkn-backend/server/logics/business_system/business_system_service_impl.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/bkn/bkn-backend/server/logics/business_system/business_system_service_test.go
+++ b/adp/bkn/bkn-backend/server/logics/business_system/business_system_service_test.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/bkn/bkn-backend/server/logics/business_system/noop_business_system_service.go
+++ b/adp/bkn/bkn-backend/server/logics/business_system/noop_business_system_service.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/bkn/bkn-backend/server/logics/common.go
+++ b/adp/bkn/bkn-backend/server/logics/common.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/bkn/bkn-backend/server/logics/common_test.go
+++ b/adp/bkn/bkn-backend/server/logics/common_test.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/bkn/bkn-backend/server/logics/concept_group/concept_group_service.go
+++ b/adp/bkn/bkn-backend/server/logics/concept_group/concept_group_service.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/bkn/bkn-backend/server/logics/concept_group/concept_group_service_test.go
+++ b/adp/bkn/bkn-backend/server/logics/concept_group/concept_group_service_test.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/bkn/bkn-backend/server/logics/driven_access.go
+++ b/adp/bkn/bkn-backend/server/logics/driven_access.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/bkn/bkn-backend/server/logics/job/job_service.go
+++ b/adp/bkn/bkn-backend/server/logics/job/job_service.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/bkn/bkn-backend/server/logics/job/job_service_test.go
+++ b/adp/bkn/bkn-backend/server/logics/job/job_service_test.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/bkn/bkn-backend/server/logics/knowledge_network/knowledge_network_service.go
+++ b/adp/bkn/bkn-backend/server/logics/knowledge_network/knowledge_network_service.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/bkn/bkn-backend/server/logics/knowledge_network/knowledge_network_service_test.go
+++ b/adp/bkn/bkn-backend/server/logics/knowledge_network/knowledge_network_service_test.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/bkn/bkn-backend/server/logics/metric/metric_service.go
+++ b/adp/bkn/bkn-backend/server/logics/metric/metric_service.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/bkn/bkn-backend/server/logics/metric/metric_service_test.go
+++ b/adp/bkn/bkn-backend/server/logics/metric/metric_service_test.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/bkn/bkn-backend/server/logics/object_type/object_type_service.go
+++ b/adp/bkn/bkn-backend/server/logics/object_type/object_type_service.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/bkn/bkn-backend/server/logics/object_type/object_type_service_test.go
+++ b/adp/bkn/bkn-backend/server/logics/object_type/object_type_service_test.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/bkn/bkn-backend/server/logics/ontology_init.go
+++ b/adp/bkn/bkn-backend/server/logics/ontology_init.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/bkn/bkn-backend/server/logics/ontology_init_test.go
+++ b/adp/bkn/bkn-backend/server/logics/ontology_init_test.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/bkn/bkn-backend/server/logics/permission/noop_permission_service.go
+++ b/adp/bkn/bkn-backend/server/logics/permission/noop_permission_service.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/bkn/bkn-backend/server/logics/permission/permission_service.go
+++ b/adp/bkn/bkn-backend/server/logics/permission/permission_service.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/bkn/bkn-backend/server/logics/permission/permission_service_impl.go
+++ b/adp/bkn/bkn-backend/server/logics/permission/permission_service_impl.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/bkn/bkn-backend/server/logics/permission/permission_service_test.go
+++ b/adp/bkn/bkn-backend/server/logics/permission/permission_service_test.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/bkn/bkn-backend/server/logics/relation_type/relation_type_service.go
+++ b/adp/bkn/bkn-backend/server/logics/relation_type/relation_type_service.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/bkn/bkn-backend/server/logics/relation_type/relation_type_service_test.go
+++ b/adp/bkn/bkn-backend/server/logics/relation_type/relation_type_service_test.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/bkn/bkn-backend/server/logics/risk_type/risk_type_service.go
+++ b/adp/bkn/bkn-backend/server/logics/risk_type/risk_type_service.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/bkn/bkn-backend/server/logics/user_mgmt/noop_user_mgmt_service.go
+++ b/adp/bkn/bkn-backend/server/logics/user_mgmt/noop_user_mgmt_service.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/bkn/bkn-backend/server/logics/user_mgmt/user_mgmt_service.go
+++ b/adp/bkn/bkn-backend/server/logics/user_mgmt/user_mgmt_service.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/bkn/bkn-backend/server/logics/user_mgmt/user_mgmt_service_impl.go
+++ b/adp/bkn/bkn-backend/server/logics/user_mgmt/user_mgmt_service_impl.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/bkn/bkn-backend/server/logics/user_mgmt/user_mgmt_service_test.go
+++ b/adp/bkn/bkn-backend/server/logics/user_mgmt/user_mgmt_service_test.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/bkn/bkn-backend/server/main.go
+++ b/adp/bkn/bkn-backend/server/main.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/bkn/bkn-backend/server/version/version.go
+++ b/adp/bkn/bkn-backend/server/version/version.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/bkn/bkn-backend/server/worker/concept_syncer.go
+++ b/adp/bkn/bkn-backend/server/worker/concept_syncer.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/bkn/bkn-backend/server/worker/concept_syncer_test.go
+++ b/adp/bkn/bkn-backend/server/worker/concept_syncer_test.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/bkn/bkn-backend/server/worker/job.go
+++ b/adp/bkn/bkn-backend/server/worker/job.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/bkn/bkn-backend/server/worker/job_executor.go
+++ b/adp/bkn/bkn-backend/server/worker/job_executor.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/bkn/bkn-backend/server/worker/job_executor_test.go
+++ b/adp/bkn/bkn-backend/server/worker/job_executor_test.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/bkn/bkn-backend/server/worker/object_type_task.go
+++ b/adp/bkn/bkn-backend/server/worker/object_type_task.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/bkn/bkn-backend/server/worker/object_type_task_test.go
+++ b/adp/bkn/bkn-backend/server/worker/object_type_task_test.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/bkn/bkn-backend/server/worker/schedule_worker.go
+++ b/adp/bkn/bkn-backend/server/worker/schedule_worker.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/bkn/bkn-backend/tests/integration_tests/bkn/bkn_test.go
+++ b/adp/bkn/bkn-backend/tests/integration_tests/bkn/bkn_test.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/bkn/bkn-backend/tests/integration_tests/bkn/helpers/bkn_helpers.go
+++ b/adp/bkn/bkn-backend/tests/integration_tests/bkn/helpers/bkn_helpers.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/bkn/bkn-backend/tests/integration_tests/setup/config.go
+++ b/adp/bkn/bkn-backend/tests/integration_tests/setup/config.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/bkn/bkn-backend/tests/testutil/http_client.go
+++ b/adp/bkn/bkn-backend/tests/testutil/http_client.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/bkn/ontology-query/server/common/condition/condition.go
+++ b/adp/bkn/ontology-query/server/common/condition/condition.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/bkn/ontology-query/server/common/condition/condition_and.go
+++ b/adp/bkn/ontology-query/server/common/condition/condition_and.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/bkn/ontology-query/server/common/condition/condition_and_or_test.go
+++ b/adp/bkn/ontology-query/server/common/condition/condition_and_or_test.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/bkn/ontology-query/server/common/condition/condition_before.go
+++ b/adp/bkn/ontology-query/server/common/condition/condition_before.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/bkn/ontology-query/server/common/condition/condition_between.go
+++ b/adp/bkn/ontology-query/server/common/condition/condition_between.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/bkn/ontology-query/server/common/condition/condition_contain.go
+++ b/adp/bkn/ontology-query/server/common/condition/condition_contain.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/bkn/ontology-query/server/common/condition/condition_current.go
+++ b/adp/bkn/ontology-query/server/common/condition/condition_current.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/bkn/ontology-query/server/common/condition/condition_eq.go
+++ b/adp/bkn/ontology-query/server/common/condition/condition_eq.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/bkn/ontology-query/server/common/condition/condition_eq_test.go
+++ b/adp/bkn/ontology-query/server/common/condition/condition_eq_test.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/bkn/ontology-query/server/common/condition/condition_exist.go
+++ b/adp/bkn/ontology-query/server/common/condition/condition_exist.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/bkn/ontology-query/server/common/condition/condition_exist_test.go
+++ b/adp/bkn/ontology-query/server/common/condition/condition_exist_test.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/bkn/ontology-query/server/common/condition/condition_false.go
+++ b/adp/bkn/ontology-query/server/common/condition/condition_false.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/bkn/ontology-query/server/common/condition/condition_gt.go
+++ b/adp/bkn/ontology-query/server/common/condition/condition_gt.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/bkn/ontology-query/server/common/condition/condition_gt_test.go
+++ b/adp/bkn/ontology-query/server/common/condition/condition_gt_test.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/bkn/ontology-query/server/common/condition/condition_gte.go
+++ b/adp/bkn/ontology-query/server/common/condition/condition_gte.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/bkn/ontology-query/server/common/condition/condition_gte_test.go
+++ b/adp/bkn/ontology-query/server/common/condition/condition_gte_test.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/bkn/ontology-query/server/common/condition/condition_in.go
+++ b/adp/bkn/ontology-query/server/common/condition/condition_in.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/bkn/ontology-query/server/common/condition/condition_in_test.go
+++ b/adp/bkn/ontology-query/server/common/condition/condition_in_test.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/bkn/ontology-query/server/common/condition/condition_knn.go
+++ b/adp/bkn/ontology-query/server/common/condition/condition_knn.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/bkn/ontology-query/server/common/condition/condition_knn_test.go
+++ b/adp/bkn/ontology-query/server/common/condition/condition_knn_test.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/bkn/ontology-query/server/common/condition/condition_like.go
+++ b/adp/bkn/ontology-query/server/common/condition/condition_like.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/bkn/ontology-query/server/common/condition/condition_like_test.go
+++ b/adp/bkn/ontology-query/server/common/condition/condition_like_test.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/bkn/ontology-query/server/common/condition/condition_lt.go
+++ b/adp/bkn/ontology-query/server/common/condition/condition_lt.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/bkn/ontology-query/server/common/condition/condition_lt_test.go
+++ b/adp/bkn/ontology-query/server/common/condition/condition_lt_test.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/bkn/ontology-query/server/common/condition/condition_lte.go
+++ b/adp/bkn/ontology-query/server/common/condition/condition_lte.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/bkn/ontology-query/server/common/condition/condition_lte_test.go
+++ b/adp/bkn/ontology-query/server/common/condition/condition_lte_test.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/bkn/ontology-query/server/common/condition/condition_match.go
+++ b/adp/bkn/ontology-query/server/common/condition/condition_match.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/bkn/ontology-query/server/common/condition/condition_match_phrase.go
+++ b/adp/bkn/ontology-query/server/common/condition/condition_match_phrase.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/bkn/ontology-query/server/common/condition/condition_match_test.go
+++ b/adp/bkn/ontology-query/server/common/condition/condition_match_test.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/bkn/ontology-query/server/common/condition/condition_multi_match.go
+++ b/adp/bkn/ontology-query/server/common/condition/condition_multi_match.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/bkn/ontology-query/server/common/condition/condition_not_contain.go
+++ b/adp/bkn/ontology-query/server/common/condition/condition_not_contain.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/bkn/ontology-query/server/common/condition/condition_not_eq.go
+++ b/adp/bkn/ontology-query/server/common/condition/condition_not_eq.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/bkn/ontology-query/server/common/condition/condition_not_eq_test.go
+++ b/adp/bkn/ontology-query/server/common/condition/condition_not_eq_test.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/bkn/ontology-query/server/common/condition/condition_not_exist.go
+++ b/adp/bkn/ontology-query/server/common/condition/condition_not_exist.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/bkn/ontology-query/server/common/condition/condition_not_in.go
+++ b/adp/bkn/ontology-query/server/common/condition/condition_not_in.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/bkn/ontology-query/server/common/condition/condition_not_in_test.go
+++ b/adp/bkn/ontology-query/server/common/condition/condition_not_in_test.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/bkn/ontology-query/server/common/condition/condition_not_like.go
+++ b/adp/bkn/ontology-query/server/common/condition/condition_not_like.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/bkn/ontology-query/server/common/condition/condition_not_null.go
+++ b/adp/bkn/ontology-query/server/common/condition/condition_not_null.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/bkn/ontology-query/server/common/condition/condition_not_prefix.go
+++ b/adp/bkn/ontology-query/server/common/condition/condition_not_prefix.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/bkn/ontology-query/server/common/condition/condition_null.go
+++ b/adp/bkn/ontology-query/server/common/condition/condition_null.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/bkn/ontology-query/server/common/condition/condition_or.go
+++ b/adp/bkn/ontology-query/server/common/condition/condition_or.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/bkn/ontology-query/server/common/condition/condition_out_range.go
+++ b/adp/bkn/ontology-query/server/common/condition/condition_out_range.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/bkn/ontology-query/server/common/condition/condition_out_range_test.go
+++ b/adp/bkn/ontology-query/server/common/condition/condition_out_range_test.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/bkn/ontology-query/server/common/condition/condition_prefix.go
+++ b/adp/bkn/ontology-query/server/common/condition/condition_prefix.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/bkn/ontology-query/server/common/condition/condition_range.go
+++ b/adp/bkn/ontology-query/server/common/condition/condition_range.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/bkn/ontology-query/server/common/condition/condition_range_test.go
+++ b/adp/bkn/ontology-query/server/common/condition/condition_range_test.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/bkn/ontology-query/server/common/condition/condition_regex.go
+++ b/adp/bkn/ontology-query/server/common/condition/condition_regex.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/bkn/ontology-query/server/common/condition/condition_regex_test.go
+++ b/adp/bkn/ontology-query/server/common/condition/condition_regex_test.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/bkn/ontology-query/server/common/condition/condition_test.go
+++ b/adp/bkn/ontology-query/server/common/condition/condition_test.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/bkn/ontology-query/server/common/condition/condition_true.go
+++ b/adp/bkn/ontology-query/server/common/condition/condition_true.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/bkn/ontology-query/server/common/condition/entity.go
+++ b/adp/bkn/ontology-query/server/common/condition/entity.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/bkn/ontology-query/server/common/convert.go
+++ b/adp/bkn/ontology-query/server/common/convert.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/bkn/ontology-query/server/common/convert_test.go
+++ b/adp/bkn/ontology-query/server/common/convert_test.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/bkn/ontology-query/server/common/http_client.go
+++ b/adp/bkn/ontology-query/server/common/http_client.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/bkn/ontology-query/server/common/logger.go
+++ b/adp/bkn/ontology-query/server/common/logger.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/bkn/ontology-query/server/common/setting.go
+++ b/adp/bkn/ontology-query/server/common/setting.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/bkn/ontology-query/server/common/util.go
+++ b/adp/bkn/ontology-query/server/common/util.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/bkn/ontology-query/server/common/util_test.go
+++ b/adp/bkn/ontology-query/server/common/util_test.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/bkn/ontology-query/server/common/visitor/visitor.go
+++ b/adp/bkn/ontology-query/server/common/visitor/visitor.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/bkn/ontology-query/server/drivenadapters/agent_operator/agent_operator_access.go
+++ b/adp/bkn/ontology-query/server/drivenadapters/agent_operator/agent_operator_access.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/bkn/ontology-query/server/drivenadapters/agent_operator/agent_operator_access_test.go
+++ b/adp/bkn/ontology-query/server/drivenadapters/agent_operator/agent_operator_access_test.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/bkn/ontology-query/server/drivenadapters/auth/hydra_auth_access.go
+++ b/adp/bkn/ontology-query/server/drivenadapters/auth/hydra_auth_access.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/bkn/ontology-query/server/drivenadapters/model_factory/model_factory_access.go
+++ b/adp/bkn/ontology-query/server/drivenadapters/model_factory/model_factory_access.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/bkn/ontology-query/server/drivenadapters/model_factory/model_factory_access_test.go
+++ b/adp/bkn/ontology-query/server/drivenadapters/model_factory/model_factory_access_test.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/bkn/ontology-query/server/drivenadapters/ontology_manager/ontology_manager_access.go
+++ b/adp/bkn/ontology-query/server/drivenadapters/ontology_manager/ontology_manager_access.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/bkn/ontology-query/server/drivenadapters/ontology_manager/ontology_manager_access_test.go
+++ b/adp/bkn/ontology-query/server/drivenadapters/ontology_manager/ontology_manager_access_test.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/bkn/ontology-query/server/drivenadapters/opensearch/opensearch_access.go
+++ b/adp/bkn/ontology-query/server/drivenadapters/opensearch/opensearch_access.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/bkn/ontology-query/server/drivenadapters/opensearch/opensearch_access_test.go
+++ b/adp/bkn/ontology-query/server/drivenadapters/opensearch/opensearch_access_test.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/bkn/ontology-query/server/drivenadapters/uniquery/uniquery_access.go
+++ b/adp/bkn/ontology-query/server/drivenadapters/uniquery/uniquery_access.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/bkn/ontology-query/server/drivenadapters/uniquery/uniquery_access_test.go
+++ b/adp/bkn/ontology-query/server/drivenadapters/uniquery/uniquery_access_test.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/bkn/ontology-query/server/drivenadapters/vega_backend/vega_backend_access.go
+++ b/adp/bkn/ontology-query/server/drivenadapters/vega_backend/vega_backend_access.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/bkn/ontology-query/server/driveradapters/action_execution_handler.go
+++ b/adp/bkn/ontology-query/server/driveradapters/action_execution_handler.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/bkn/ontology-query/server/driveradapters/action_type_handler.go
+++ b/adp/bkn/ontology-query/server/driveradapters/action_type_handler.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/bkn/ontology-query/server/driveradapters/action_type_handler_test.go
+++ b/adp/bkn/ontology-query/server/driveradapters/action_type_handler_test.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/bkn/ontology-query/server/driveradapters/knowledge_network_handler.go
+++ b/adp/bkn/ontology-query/server/driveradapters/knowledge_network_handler.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/bkn/ontology-query/server/driveradapters/knowledge_network_handler_test.go
+++ b/adp/bkn/ontology-query/server/driveradapters/knowledge_network_handler_test.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/bkn/ontology-query/server/driveradapters/metric_handler.go
+++ b/adp/bkn/ontology-query/server/driveradapters/metric_handler.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/bkn/ontology-query/server/driveradapters/object_type_handler.go
+++ b/adp/bkn/ontology-query/server/driveradapters/object_type_handler.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/bkn/ontology-query/server/driveradapters/object_type_handler_test.go
+++ b/adp/bkn/ontology-query/server/driveradapters/object_type_handler_test.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/bkn/ontology-query/server/driveradapters/routers.go
+++ b/adp/bkn/ontology-query/server/driveradapters/routers.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/bkn/ontology-query/server/driveradapters/routers_test.go
+++ b/adp/bkn/ontology-query/server/driveradapters/routers_test.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/bkn/ontology-query/server/driveradapters/validate.go
+++ b/adp/bkn/ontology-query/server/driveradapters/validate.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/bkn/ontology-query/server/driveradapters/validate_metric.go
+++ b/adp/bkn/ontology-query/server/driveradapters/validate_metric.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/bkn/ontology-query/server/driveradapters/validate_metric_test.go
+++ b/adp/bkn/ontology-query/server/driveradapters/validate_metric_test.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/bkn/ontology-query/server/driveradapters/validate_test.go
+++ b/adp/bkn/ontology-query/server/driveradapters/validate_test.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/bkn/ontology-query/server/errors/action_execution.go
+++ b/adp/bkn/ontology-query/server/errors/action_execution.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/bkn/ontology-query/server/errors/action_type.go
+++ b/adp/bkn/ontology-query/server/errors/action_type.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/bkn/ontology-query/server/errors/error_code.go
+++ b/adp/bkn/ontology-query/server/errors/error_code.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/bkn/ontology-query/server/errors/knowledge_network.go
+++ b/adp/bkn/ontology-query/server/errors/knowledge_network.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/bkn/ontology-query/server/errors/metric.go
+++ b/adp/bkn/ontology-query/server/errors/metric.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/bkn/ontology-query/server/errors/object_type.go
+++ b/adp/bkn/ontology-query/server/errors/object_type.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/bkn/ontology-query/server/errors/risk_type.go
+++ b/adp/bkn/ontology-query/server/errors/risk_type.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/bkn/ontology-query/server/interfaces/action_execution.go
+++ b/adp/bkn/ontology-query/server/interfaces/action_execution.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/bkn/ontology-query/server/interfaces/action_logs_service.go
+++ b/adp/bkn/ontology-query/server/interfaces/action_logs_service.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/bkn/ontology-query/server/interfaces/action_scheduler_service.go
+++ b/adp/bkn/ontology-query/server/interfaces/action_scheduler_service.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/bkn/ontology-query/server/interfaces/action_type.go
+++ b/adp/bkn/ontology-query/server/interfaces/action_type.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/bkn/ontology-query/server/interfaces/action_type_service.go
+++ b/adp/bkn/ontology-query/server/interfaces/action_type_service.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/bkn/ontology-query/server/interfaces/agent_operator_access.go
+++ b/adp/bkn/ontology-query/server/interfaces/agent_operator_access.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/bkn/ontology-query/server/interfaces/auth_access.go
+++ b/adp/bkn/ontology-query/server/interfaces/auth_access.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/bkn/ontology-query/server/interfaces/auth_service.go
+++ b/adp/bkn/ontology-query/server/interfaces/auth_service.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/bkn/ontology-query/server/interfaces/common.go
+++ b/adp/bkn/ontology-query/server/interfaces/common.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/bkn/ontology-query/server/interfaces/data_type/data_types.go
+++ b/adp/bkn/ontology-query/server/interfaces/data_type/data_types.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/bkn/ontology-query/server/interfaces/knowledge_network.go
+++ b/adp/bkn/ontology-query/server/interfaces/knowledge_network.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/bkn/ontology-query/server/interfaces/knowledge_network_service.go
+++ b/adp/bkn/ontology-query/server/interfaces/knowledge_network_service.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/bkn/ontology-query/server/interfaces/metric.go
+++ b/adp/bkn/ontology-query/server/interfaces/metric.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/bkn/ontology-query/server/interfaces/metric_query_service.go
+++ b/adp/bkn/ontology-query/server/interfaces/metric_query_service.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/bkn/ontology-query/server/interfaces/model_factory_access.go
+++ b/adp/bkn/ontology-query/server/interfaces/model_factory_access.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/bkn/ontology-query/server/interfaces/object_type.go
+++ b/adp/bkn/ontology-query/server/interfaces/object_type.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/bkn/ontology-query/server/interfaces/object_type_service.go
+++ b/adp/bkn/ontology-query/server/interfaces/object_type_service.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/bkn/ontology-query/server/interfaces/ontology_manager_access.go
+++ b/adp/bkn/ontology-query/server/interfaces/ontology_manager_access.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/bkn/ontology-query/server/interfaces/opensearch_access.go
+++ b/adp/bkn/ontology-query/server/interfaces/opensearch_access.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/bkn/ontology-query/server/interfaces/relation_type.go
+++ b/adp/bkn/ontology-query/server/interfaces/relation_type.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/bkn/ontology-query/server/interfaces/risk_type.go
+++ b/adp/bkn/ontology-query/server/interfaces/risk_type.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/bkn/ontology-query/server/interfaces/risk_type_service.go
+++ b/adp/bkn/ontology-query/server/interfaces/risk_type_service.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/bkn/ontology-query/server/interfaces/uniquery_access.go
+++ b/adp/bkn/ontology-query/server/interfaces/uniquery_access.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/bkn/ontology-query/server/interfaces/vega_backend_access.go
+++ b/adp/bkn/ontology-query/server/interfaces/vega_backend_access.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/bkn/ontology-query/server/locale/locale.go
+++ b/adp/bkn/ontology-query/server/locale/locale.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/bkn/ontology-query/server/logics/action_logs/action_logs_service.go
+++ b/adp/bkn/ontology-query/server/logics/action_logs/action_logs_service.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/bkn/ontology-query/server/logics/action_logs/action_logs_service_test.go
+++ b/adp/bkn/ontology-query/server/logics/action_logs/action_logs_service_test.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/bkn/ontology-query/server/logics/action_scheduler/action_scheduler_service.go
+++ b/adp/bkn/ontology-query/server/logics/action_scheduler/action_scheduler_service.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/bkn/ontology-query/server/logics/action_scheduler/action_scheduler_service_test.go
+++ b/adp/bkn/ontology-query/server/logics/action_scheduler/action_scheduler_service_test.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/bkn/ontology-query/server/logics/action_scheduler/executor_test.go
+++ b/adp/bkn/ontology-query/server/logics/action_scheduler/executor_test.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/bkn/ontology-query/server/logics/action_scheduler/mcp_executor.go
+++ b/adp/bkn/ontology-query/server/logics/action_scheduler/mcp_executor.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/bkn/ontology-query/server/logics/action_scheduler/tool_executor.go
+++ b/adp/bkn/ontology-query/server/logics/action_scheduler/tool_executor.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/bkn/ontology-query/server/logics/action_type/action_type_service.go
+++ b/adp/bkn/ontology-query/server/logics/action_type/action_type_service.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/bkn/ontology-query/server/logics/action_type/action_type_service_test.go
+++ b/adp/bkn/ontology-query/server/logics/action_type/action_type_service_test.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/bkn/ontology-query/server/logics/auth/auth_service.go
+++ b/adp/bkn/ontology-query/server/logics/auth/auth_service.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/bkn/ontology-query/server/logics/auth/hydra_auth_service.go
+++ b/adp/bkn/ontology-query/server/logics/auth/hydra_auth_service.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/bkn/ontology-query/server/logics/auth/noop_auth_service.go
+++ b/adp/bkn/ontology-query/server/logics/auth/noop_auth_service.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/bkn/ontology-query/server/logics/common.go
+++ b/adp/bkn/ontology-query/server/logics/common.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/bkn/ontology-query/server/logics/common_test.go
+++ b/adp/bkn/ontology-query/server/logics/common_test.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/bkn/ontology-query/server/logics/driven_access.go
+++ b/adp/bkn/ontology-query/server/logics/driven_access.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/bkn/ontology-query/server/logics/driven_access_test.go
+++ b/adp/bkn/ontology-query/server/logics/driven_access_test.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/bkn/ontology-query/server/logics/knowledge_network/filtered_cross_join_expand.go
+++ b/adp/bkn/ontology-query/server/logics/knowledge_network/filtered_cross_join_expand.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/bkn/ontology-query/server/logics/knowledge_network/knowledge_network_service.go
+++ b/adp/bkn/ontology-query/server/logics/knowledge_network/knowledge_network_service.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/bkn/ontology-query/server/logics/knowledge_network/knowledge_network_service_test.go
+++ b/adp/bkn/ontology-query/server/logics/knowledge_network/knowledge_network_service_test.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/bkn/ontology-query/server/logics/metric/metric_query_service.go
+++ b/adp/bkn/ontology-query/server/logics/metric/metric_query_service.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/bkn/ontology-query/server/logics/metric/metric_query_service_test.go
+++ b/adp/bkn/ontology-query/server/logics/metric/metric_query_service_test.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/bkn/ontology-query/server/logics/object_type/object_type_service.go
+++ b/adp/bkn/ontology-query/server/logics/object_type/object_type_service.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/bkn/ontology-query/server/logics/object_type/object_type_service_test.go
+++ b/adp/bkn/ontology-query/server/logics/object_type/object_type_service_test.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/bkn/ontology-query/server/main.go
+++ b/adp/bkn/ontology-query/server/main.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/bkn/ontology-query/server/version/version.go
+++ b/adp/bkn/ontology-query/server/version/version.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/context-loader/agent-retrieval/server/drivenadapters/appkey.go
+++ b/adp/context-loader/agent-retrieval/server/drivenadapters/appkey.go
@@ -1,5 +1,4 @@
-// Copyright 2026 openbkn.ai
-// Copyright The kweaver.ai Authors.
+// Copyright openbkn.ai
 //
 // Licensed under the Apache License, Version 2.0.
 // See the LICENSE file in the project root for details.

--- a/adp/context-loader/agent-retrieval/server/drivenadapters/appkey_test.go
+++ b/adp/context-loader/agent-retrieval/server/drivenadapters/appkey_test.go
@@ -1,5 +1,4 @@
-// Copyright 2026 openbkn.ai
-// Copyright The kweaver.ai Authors.
+// Copyright openbkn.ai
 //
 // Licensed under the Apache License, Version 2.0.
 // See the LICENSE file in the project root for details.

--- a/adp/context-loader/agent-retrieval/server/drivenadapters/bkn_backend.go
+++ b/adp/context-loader/agent-retrieval/server/drivenadapters/bkn_backend.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/context-loader/agent-retrieval/server/drivenadapters/bkn_backend_test.go
+++ b/adp/context-loader/agent-retrieval/server/drivenadapters/bkn_backend_test.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/context-loader/agent-retrieval/server/drivenadapters/clients_test.go
+++ b/adp/context-loader/agent-retrieval/server/drivenadapters/clients_test.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/context-loader/agent-retrieval/server/drivenadapters/expand_filters_test.go
+++ b/adp/context-loader/agent-retrieval/server/drivenadapters/expand_filters_test.go
@@ -1,5 +1,4 @@
-// Copyright 2026 openbkn.ai
-// Copyright The kweaver.ai Authors.
+// Copyright openbkn.ai
 //
 // Licensed under the Apache License, Version 2.0.
 // See the LICENSE file in the project root for details.

--- a/adp/context-loader/agent-retrieval/server/drivenadapters/hydra.go
+++ b/adp/context-loader/agent-retrieval/server/drivenadapters/hydra.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/context-loader/agent-retrieval/server/drivenadapters/hydra_test.go
+++ b/adp/context-loader/agent-retrieval/server/drivenadapters/hydra_test.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/context-loader/agent-retrieval/server/drivenadapters/mf_model_api_client.go
+++ b/adp/context-loader/agent-retrieval/server/drivenadapters/mf_model_api_client.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/context-loader/agent-retrieval/server/drivenadapters/ontology_query.go
+++ b/adp/context-loader/agent-retrieval/server/drivenadapters/ontology_query.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/context-loader/agent-retrieval/server/drivenadapters/ontology_query_test.go
+++ b/adp/context-loader/agent-retrieval/server/drivenadapters/ontology_query_test.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/context-loader/agent-retrieval/server/drivenadapters/operator_integration.go
+++ b/adp/context-loader/agent-retrieval/server/drivenadapters/operator_integration.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/context-loader/agent-retrieval/server/drivenadapters/operator_integration_test.go
+++ b/adp/context-loader/agent-retrieval/server/drivenadapters/operator_integration_test.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/context-loader/agent-retrieval/server/drivenadapters/vega.go
+++ b/adp/context-loader/agent-retrieval/server/drivenadapters/vega.go
@@ -1,5 +1,4 @@
-// Copyright 2026 openbkn.ai
-// Copyright The kweaver.ai Authors.
+// Copyright openbkn.ai
 //
 // Licensed under the Apache License, Version 2.0.
 // See the LICENSE file in the project root for details.

--- a/adp/context-loader/agent-retrieval/server/driveradapters/appkey_middleware_test.go
+++ b/adp/context-loader/agent-retrieval/server/driveradapters/appkey_middleware_test.go
@@ -1,5 +1,4 @@
-// Copyright 2026 openbkn.ai
-// Copyright The kweaver.ai Authors.
+// Copyright openbkn.ai
 //
 // Licensed under the Apache License, Version 2.0.
 // See the LICENSE file in the project root for details.

--- a/adp/context-loader/agent-retrieval/server/driveradapters/http_health_handler.go
+++ b/adp/context-loader/agent-retrieval/server/driveradapters/http_health_handler.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/context-loader/agent-retrieval/server/driveradapters/knactionrecall/index.go
+++ b/adp/context-loader/agent-retrieval/server/driveradapters/knactionrecall/index.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/context-loader/agent-retrieval/server/driveradapters/knfindskills/index.go
+++ b/adp/context-loader/agent-retrieval/server/driveradapters/knfindskills/index.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/context-loader/agent-retrieval/server/driveradapters/knlogicpropertyresolver/index.go
+++ b/adp/context-loader/agent-retrieval/server/driveradapters/knlogicpropertyresolver/index.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/context-loader/agent-retrieval/server/driveradapters/knontologyjob/index.go
+++ b/adp/context-loader/agent-retrieval/server/driveradapters/knontologyjob/index.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/context-loader/agent-retrieval/server/driveradapters/knqueryobjectinstance/index.go
+++ b/adp/context-loader/agent-retrieval/server/driveradapters/knqueryobjectinstance/index.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/context-loader/agent-retrieval/server/driveradapters/knquerysubgraph/index.go
+++ b/adp/context-loader/agent-retrieval/server/driveradapters/knquerysubgraph/index.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/context-loader/agent-retrieval/server/driveradapters/knquerytools/index.go
+++ b/adp/context-loader/agent-retrieval/server/driveradapters/knquerytools/index.go
@@ -1,5 +1,4 @@
-// Copyright 2026 openbkn.ai
-// Copyright The kweaver.ai Authors.
+// Copyright openbkn.ai
 //
 // Licensed under the Apache License, Version 2.0.
 // See the LICENSE file in the project root for details.

--- a/adp/context-loader/agent-retrieval/server/driveradapters/knretrieval/index.go
+++ b/adp/context-loader/agent-retrieval/server/driveradapters/knretrieval/index.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/context-loader/agent-retrieval/server/driveradapters/knsearch/index.go
+++ b/adp/context-loader/agent-retrieval/server/driveradapters/knsearch/index.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/context-loader/agent-retrieval/server/driveradapters/mcp/app.go
+++ b/adp/context-loader/agent-retrieval/server/driveradapters/mcp/app.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/context-loader/agent-retrieval/server/driveradapters/mcp/info.go
+++ b/adp/context-loader/agent-retrieval/server/driveradapters/mcp/info.go
@@ -1,5 +1,4 @@
-// Copyright 2026 openbkn.ai
-// Copyright The kweaver.ai Authors.
+// Copyright openbkn.ai
 //
 // Licensed under the Apache License, Version 2.0.
 // See the LICENSE file in the project root for details.

--- a/adp/context-loader/agent-retrieval/server/driveradapters/mcp/response_format.go
+++ b/adp/context-loader/agent-retrieval/server/driveradapters/mcp/response_format.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/context-loader/agent-retrieval/server/driveradapters/mcp/schemas.go
+++ b/adp/context-loader/agent-retrieval/server/driveradapters/mcp/schemas.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/context-loader/agent-retrieval/server/driveradapters/mcp/tools.go
+++ b/adp/context-loader/agent-retrieval/server/driveradapters/mcp/tools.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/context-loader/agent-retrieval/server/driveradapters/mcp/tools_field_reduction_test.go
+++ b/adp/context-loader/agent-retrieval/server/driveradapters/mcp/tools_field_reduction_test.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/context-loader/agent-retrieval/server/driveradapters/mcpproxy/index.go
+++ b/adp/context-loader/agent-retrieval/server/driveradapters/mcpproxy/index.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/context-loader/agent-retrieval/server/driveradapters/middleware.go
+++ b/adp/context-loader/agent-retrieval/server/driveradapters/middleware.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/context-loader/agent-retrieval/server/driveradapters/rest_private_handler.go
+++ b/adp/context-loader/agent-retrieval/server/driveradapters/rest_private_handler.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/context-loader/agent-retrieval/server/driveradapters/rest_public_handler.go
+++ b/adp/context-loader/agent-retrieval/server/driveradapters/rest_public_handler.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/context-loader/agent-retrieval/server/infra/common/context_manage.go
+++ b/adp/context-loader/agent-retrieval/server/infra/common/context_manage.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/context-loader/agent-retrieval/server/infra/common/language.go
+++ b/adp/context-loader/agent-retrieval/server/infra/common/language.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/context-loader/agent-retrieval/server/infra/config/config.go
+++ b/adp/context-loader/agent-retrieval/server/infra/config/config.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/context-loader/agent-retrieval/server/infra/config/config_test.go
+++ b/adp/context-loader/agent-retrieval/server/infra/config/config_test.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/context-loader/agent-retrieval/server/infra/config/redis_config.go
+++ b/adp/context-loader/agent-retrieval/server/infra/config/redis_config.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/context-loader/agent-retrieval/server/infra/consts/key.go
+++ b/adp/context-loader/agent-retrieval/server/infra/consts/key.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/context-loader/agent-retrieval/server/infra/errors/error.go
+++ b/adp/context-loader/agent-retrieval/server/infra/errors/error.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/context-loader/agent-retrieval/server/infra/errors/error_code.go
+++ b/adp/context-loader/agent-retrieval/server/infra/errors/error_code.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/context-loader/agent-retrieval/server/infra/localize/localize.go
+++ b/adp/context-loader/agent-retrieval/server/infra/localize/localize.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/context-loader/agent-retrieval/server/infra/logger/logger.go
+++ b/adp/context-loader/agent-retrieval/server/infra/logger/logger.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/context-loader/agent-retrieval/server/infra/rest/http_client.go
+++ b/adp/context-loader/agent-retrieval/server/infra/rest/http_client.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/context-loader/agent-retrieval/server/infra/rest/reply.go
+++ b/adp/context-loader/agent-retrieval/server/infra/rest/reply.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/context-loader/agent-retrieval/server/infra/rest/response_format.go
+++ b/adp/context-loader/agent-retrieval/server/infra/rest/response_format.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/context-loader/agent-retrieval/server/infra/rest/response_format_test.go
+++ b/adp/context-loader/agent-retrieval/server/infra/rest/response_format_test.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/context-loader/agent-retrieval/server/infra/telemetry/jaeger.go
+++ b/adp/context-loader/agent-retrieval/server/infra/telemetry/jaeger.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/context-loader/agent-retrieval/server/infra/telemetry/log.go
+++ b/adp/context-loader/agent-retrieval/server/infra/telemetry/log.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/context-loader/agent-retrieval/server/infra/telemetry/span.go
+++ b/adp/context-loader/agent-retrieval/server/infra/telemetry/span.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/context-loader/agent-retrieval/server/infra/telemetry/span_db.go
+++ b/adp/context-loader/agent-retrieval/server/infra/telemetry/span_db.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/context-loader/agent-retrieval/server/infra/telemetry/span_http.go
+++ b/adp/context-loader/agent-retrieval/server/infra/telemetry/span_http.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/context-loader/agent-retrieval/server/infra/telemetry/trace.go
+++ b/adp/context-loader/agent-retrieval/server/infra/telemetry/trace.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/context-loader/agent-retrieval/server/infra/validator/validator10.go
+++ b/adp/context-loader/agent-retrieval/server/infra/validator/validator10.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/context-loader/agent-retrieval/server/interfaces/demo.go
+++ b/adp/context-loader/agent-retrieval/server/interfaces/demo.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/context-loader/agent-retrieval/server/interfaces/driven_agent.go
+++ b/adp/context-loader/agent-retrieval/server/interfaces/driven_agent.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/context-loader/agent-retrieval/server/interfaces/driven_bkn_backend.go
+++ b/adp/context-loader/agent-retrieval/server/interfaces/driven_bkn_backend.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/context-loader/agent-retrieval/server/interfaces/driven_ontology_query.go
+++ b/adp/context-loader/agent-retrieval/server/interfaces/driven_ontology_query.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/context-loader/agent-retrieval/server/interfaces/driven_operator_integration.go
+++ b/adp/context-loader/agent-retrieval/server/interfaces/driven_operator_integration.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/context-loader/agent-retrieval/server/interfaces/driven_vega.go
+++ b/adp/context-loader/agent-retrieval/server/interfaces/driven_vega.go
@@ -1,5 +1,4 @@
-// Copyright 2026 openbkn.ai
-// Copyright The kweaver.ai Authors.
+// Copyright openbkn.ai
 //
 // Licensed under the Apache License, Version 2.0.
 // See the LICENSE file in the project root for details.

--- a/adp/context-loader/agent-retrieval/server/interfaces/drivenadapters.go
+++ b/adp/context-loader/agent-retrieval/server/interfaces/drivenadapters.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/context-loader/agent-retrieval/server/interfaces/driveradapters.go
+++ b/adp/context-loader/agent-retrieval/server/interfaces/driveradapters.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/context-loader/agent-retrieval/server/interfaces/error.go
+++ b/adp/context-loader/agent-retrieval/server/interfaces/error.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/context-loader/agent-retrieval/server/interfaces/field_reduction_test.go
+++ b/adp/context-loader/agent-retrieval/server/interfaces/field_reduction_test.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/context-loader/agent-retrieval/server/interfaces/find_skills.go
+++ b/adp/context-loader/agent-retrieval/server/interfaces/find_skills.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/context-loader/agent-retrieval/server/interfaces/infra.go
+++ b/adp/context-loader/agent-retrieval/server/interfaces/infra.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/context-loader/agent-retrieval/server/interfaces/interface.go
+++ b/adp/context-loader/agent-retrieval/server/interfaces/interface.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/context-loader/agent-retrieval/server/interfaces/kn_action_recall.go
+++ b/adp/context-loader/agent-retrieval/server/interfaces/kn_action_recall.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/context-loader/agent-retrieval/server/interfaces/kn_logic_property_resolver.go
+++ b/adp/context-loader/agent-retrieval/server/interfaces/kn_logic_property_resolver.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/context-loader/agent-retrieval/server/interfaces/kn_search_local.go
+++ b/adp/context-loader/agent-retrieval/server/interfaces/kn_search_local.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/context-loader/agent-retrieval/server/interfaces/knretrieval.go
+++ b/adp/context-loader/agent-retrieval/server/interfaces/knretrieval.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/context-loader/agent-retrieval/server/interfaces/search_schema.go
+++ b/adp/context-loader/agent-retrieval/server/interfaces/search_schema.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/context-loader/agent-retrieval/server/logics/knactionrecall/get_action_info.go
+++ b/adp/context-loader/agent-retrieval/server/logics/knactionrecall/get_action_info.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/context-loader/agent-retrieval/server/logics/knactionrecall/get_action_info_test.go
+++ b/adp/context-loader/agent-retrieval/server/logics/knactionrecall/get_action_info_test.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/context-loader/agent-retrieval/server/logics/knactionrecall/index.go
+++ b/adp/context-loader/agent-retrieval/server/logics/knactionrecall/index.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/context-loader/agent-retrieval/server/logics/knactionrecall/schema_converter.go
+++ b/adp/context-loader/agent-retrieval/server/logics/knactionrecall/schema_converter.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/context-loader/agent-retrieval/server/logics/knfindskills/context_normalizer.go
+++ b/adp/context-loader/agent-retrieval/server/logics/knfindskills/context_normalizer.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/context-loader/agent-retrieval/server/logics/knfindskills/context_normalizer_test.go
+++ b/adp/context-loader/agent-retrieval/server/logics/knfindskills/context_normalizer_test.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/context-loader/agent-retrieval/server/logics/knfindskills/find_skills_service_test.go
+++ b/adp/context-loader/agent-retrieval/server/logics/knfindskills/find_skills_service_test.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/context-loader/agent-retrieval/server/logics/knfindskills/index.go
+++ b/adp/context-loader/agent-retrieval/server/logics/knfindskills/index.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/context-loader/agent-retrieval/server/logics/knfindskills/mock_test.go
+++ b/adp/context-loader/agent-retrieval/server/logics/knfindskills/mock_test.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/context-loader/agent-retrieval/server/logics/knfindskills/recall_coordinator.go
+++ b/adp/context-loader/agent-retrieval/server/logics/knfindskills/recall_coordinator.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/context-loader/agent-retrieval/server/logics/knfindskills/recall_coordinator_test.go
+++ b/adp/context-loader/agent-retrieval/server/logics/knfindskills/recall_coordinator_test.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/context-loader/agent-retrieval/server/logics/knfindskills/result_assembler.go
+++ b/adp/context-loader/agent-retrieval/server/logics/knfindskills/result_assembler.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/context-loader/agent-retrieval/server/logics/knfindskills/result_assembler_test.go
+++ b/adp/context-loader/agent-retrieval/server/logics/knfindskills/result_assembler_test.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/context-loader/agent-retrieval/server/logics/knfindskills/skill_query_condition_builder.go
+++ b/adp/context-loader/agent-retrieval/server/logics/knfindskills/skill_query_condition_builder.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/context-loader/agent-retrieval/server/logics/knfindskills/skill_query_condition_builder_test.go
+++ b/adp/context-loader/agent-retrieval/server/logics/knfindskills/skill_query_condition_builder_test.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/context-loader/agent-retrieval/server/logics/knfindskills/subgraph_request_builder.go
+++ b/adp/context-loader/agent-retrieval/server/logics/knfindskills/subgraph_request_builder.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/context-loader/agent-retrieval/server/logics/knfindskills/subgraph_request_builder_test.go
+++ b/adp/context-loader/agent-retrieval/server/logics/knfindskills/subgraph_request_builder_test.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/context-loader/agent-retrieval/server/logics/knlogicpropertyresolver/debug_collector.go
+++ b/adp/context-loader/agent-retrieval/server/logics/knlogicpropertyresolver/debug_collector.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/context-loader/agent-retrieval/server/logics/knlogicpropertyresolver/dynamic_params_llm.go
+++ b/adp/context-loader/agent-retrieval/server/logics/knlogicpropertyresolver/dynamic_params_llm.go
@@ -1,5 +1,4 @@
-// Copyright 2026 openbkn.ai
-// Copyright The kweaver.ai Authors.
+// Copyright openbkn.ai
 //
 // Licensed under the Apache License, Version 2.0.
 // See the LICENSE file in the project root for details.

--- a/adp/context-loader/agent-retrieval/server/logics/knlogicpropertyresolver/index.go
+++ b/adp/context-loader/agent-retrieval/server/logics/knlogicpropertyresolver/index.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/context-loader/agent-retrieval/server/logics/knlogicpropertyresolver/index_test.go
+++ b/adp/context-loader/agent-retrieval/server/logics/knlogicpropertyresolver/index_test.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/context-loader/agent-retrieval/server/logics/knquerysubgraph/index.go
+++ b/adp/context-loader/agent-retrieval/server/logics/knquerysubgraph/index.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/context-loader/agent-retrieval/server/logics/knquerysubgraph/index_test.go
+++ b/adp/context-loader/agent-retrieval/server/logics/knquerysubgraph/index_test.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/context-loader/agent-retrieval/server/logics/knrerank/knowledge_rerank.go
+++ b/adp/context-loader/agent-retrieval/server/logics/knrerank/knowledge_rerank.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/context-loader/agent-retrieval/server/logics/knrerank/knowledge_rerank_test.go
+++ b/adp/context-loader/agent-retrieval/server/logics/knrerank/knowledge_rerank_test.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/context-loader/agent-retrieval/server/logics/knresources/index.go
+++ b/adp/context-loader/agent-retrieval/server/logics/knresources/index.go
@@ -1,5 +1,4 @@
-// Copyright 2026 openbkn.ai
-// Copyright The kweaver.ai Authors.
+// Copyright openbkn.ai
 //
 // Licensed under the Apache License, Version 2.0.
 // See the LICENSE file in the project root for details.

--- a/adp/context-loader/agent-retrieval/server/logics/knresources/index_test.go
+++ b/adp/context-loader/agent-retrieval/server/logics/knresources/index_test.go
@@ -1,5 +1,4 @@
-// Copyright 2026 openbkn.ai
-// Copyright The kweaver.ai Authors.
+// Copyright openbkn.ai
 //
 // Licensed under the Apache License, Version 2.0.
 // See the LICENSE file in the project root for details.

--- a/adp/context-loader/agent-retrieval/server/logics/knretrieval/agent_intent_planning.go
+++ b/adp/context-loader/agent-retrieval/server/logics/knretrieval/agent_intent_planning.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/context-loader/agent-retrieval/server/logics/knretrieval/agent_intent_planning_test.go
+++ b/adp/context-loader/agent-retrieval/server/logics/knretrieval/agent_intent_planning_test.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/context-loader/agent-retrieval/server/logics/knretrieval/agent_intent_retrieval.go
+++ b/adp/context-loader/agent-retrieval/server/logics/knretrieval/agent_intent_retrieval.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/context-loader/agent-retrieval/server/logics/knretrieval/convert.go
+++ b/adp/context-loader/agent-retrieval/server/logics/knretrieval/convert.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/context-loader/agent-retrieval/server/logics/knretrieval/convert_test.go
+++ b/adp/context-loader/agent-retrieval/server/logics/knretrieval/convert_test.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/context-loader/agent-retrieval/server/logics/knretrieval/index.go
+++ b/adp/context-loader/agent-retrieval/server/logics/knretrieval/index.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/context-loader/agent-retrieval/server/logics/knretrieval/keyword_vector_retrieval.go
+++ b/adp/context-loader/agent-retrieval/server/logics/knretrieval/keyword_vector_retrieval.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/context-loader/agent-retrieval/server/logics/knretrieval/query_strategy.go
+++ b/adp/context-loader/agent-retrieval/server/logics/knretrieval/query_strategy.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/context-loader/agent-retrieval/server/logics/knretrieval/rerank.go
+++ b/adp/context-loader/agent-retrieval/server/logics/knretrieval/rerank.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/context-loader/agent-retrieval/server/logics/knretrieval/rerank_test.go
+++ b/adp/context-loader/agent-retrieval/server/logics/knretrieval/rerank_test.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/context-loader/agent-retrieval/server/logics/knrunsql/guard.go
+++ b/adp/context-loader/agent-retrieval/server/logics/knrunsql/guard.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/context-loader/agent-retrieval/server/logics/knrunsql/guard_test.go
+++ b/adp/context-loader/agent-retrieval/server/logics/knrunsql/guard_test.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/context-loader/agent-retrieval/server/logics/knrunsql/index.go
+++ b/adp/context-loader/agent-retrieval/server/logics/knrunsql/index.go
@@ -1,5 +1,4 @@
-// Copyright 2026 openbkn.ai
-// Copyright The kweaver.ai Authors.
+// Copyright openbkn.ai
 //
 // Licensed under the Apache License, Version 2.0.
 // See the LICENSE file in the project root for details.

--- a/adp/context-loader/agent-retrieval/server/logics/knsearch/concept_groups.go
+++ b/adp/context-loader/agent-retrieval/server/logics/knsearch/concept_groups.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/context-loader/agent-retrieval/server/logics/knsearch/concept_retrieval.go
+++ b/adp/context-loader/agent-retrieval/server/logics/knsearch/concept_retrieval.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/context-loader/agent-retrieval/server/logics/knsearch/config.go
+++ b/adp/context-loader/agent-retrieval/server/logics/knsearch/config.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/context-loader/agent-retrieval/server/logics/knsearch/convert.go
+++ b/adp/context-loader/agent-retrieval/server/logics/knsearch/convert.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/context-loader/agent-retrieval/server/logics/knsearch/convert_test.go
+++ b/adp/context-loader/agent-retrieval/server/logics/knsearch/convert_test.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/context-loader/agent-retrieval/server/logics/knsearch/index.go
+++ b/adp/context-loader/agent-retrieval/server/logics/knsearch/index.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/context-loader/agent-retrieval/server/logics/knsearch/index_legacy_contract_test.go
+++ b/adp/context-loader/agent-retrieval/server/logics/knsearch/index_legacy_contract_test.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/context-loader/agent-retrieval/server/logics/knsearch/index_test.go
+++ b/adp/context-loader/agent-retrieval/server/logics/knsearch/index_test.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/context-loader/agent-retrieval/server/logics/knsearch/mapped_field_column_test.go
+++ b/adp/context-loader/agent-retrieval/server/logics/knsearch/mapped_field_column_test.go
@@ -1,5 +1,4 @@
-// Copyright 2026 openbkn.ai
-// Copyright The kweaver.ai Authors.
+// Copyright openbkn.ai
 //
 // Licensed under the Apache License, Version 2.0.
 // See the LICENSE file in the project root for details.

--- a/adp/context-loader/agent-retrieval/server/logics/knsearch/search_schema.go
+++ b/adp/context-loader/agent-retrieval/server/logics/knsearch/search_schema.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/context-loader/agent-retrieval/server/logics/knsearch/semantic_instance_retrieval.go
+++ b/adp/context-loader/agent-retrieval/server/logics/knsearch/semantic_instance_retrieval.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/context-loader/agent-retrieval/server/logics/knsearch/semantic_searchable_fields.go
+++ b/adp/context-loader/agent-retrieval/server/logics/knsearch/semantic_searchable_fields.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/context-loader/agent-retrieval/server/logics/knsearch/semantic_searchable_fields_test.go
+++ b/adp/context-loader/agent-retrieval/server/logics/knsearch/semantic_searchable_fields_test.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/context-loader/agent-retrieval/server/logics/knsearch/service.go
+++ b/adp/context-loader/agent-retrieval/server/logics/knsearch/service.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/context-loader/agent-retrieval/server/main.go
+++ b/adp/context-loader/agent-retrieval/server/main.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/context-loader/agent-retrieval/server/tests/http/parse_json_simple_test.go
+++ b/adp/context-loader/agent-retrieval/server/tests/http/parse_json_simple_test.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/context-loader/agent-retrieval/server/utils/git.go
+++ b/adp/context-loader/agent-retrieval/server/utils/git.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/context-loader/agent-retrieval/server/utils/hash.go
+++ b/adp/context-loader/agent-retrieval/server/utils/hash.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/context-loader/agent-retrieval/server/utils/hash_test.go
+++ b/adp/context-loader/agent-retrieval/server/utils/hash_test.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/context-loader/agent-retrieval/server/utils/json.go
+++ b/adp/context-loader/agent-retrieval/server/utils/json.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/context-loader/agent-retrieval/server/utils/json_test.go
+++ b/adp/context-loader/agent-retrieval/server/utils/json_test.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/context-loader/agent-retrieval/server/utils/mcp.go
+++ b/adp/context-loader/agent-retrieval/server/utils/mcp.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/context-loader/agent-retrieval/server/utils/mcp_test.go
+++ b/adp/context-loader/agent-retrieval/server/utils/mcp_test.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/context-loader/agent-retrieval/server/utils/string.go
+++ b/adp/context-loader/agent-retrieval/server/utils/string.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/context-loader/agent-retrieval/server/utils/string_test.go
+++ b/adp/context-loader/agent-retrieval/server/utils/string_test.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/context-loader/agent-retrieval/server/utils/vector.go
+++ b/adp/context-loader/agent-retrieval/server/utils/vector.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/vega/vega-backend/server/common/http_client.go
+++ b/adp/vega/vega-backend/server/common/http_client.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/vega/vega-backend/server/common/logger.go
+++ b/adp/vega/vega-backend/server/common/logger.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/vega/vega-backend/server/common/setting.go
+++ b/adp/vega/vega-backend/server/common/setting.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/vega/vega-backend/server/common/utils.go
+++ b/adp/vega/vega-backend/server/common/utils.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/vega/vega-backend/server/common/visitor/visitor.go
+++ b/adp/vega/vega-backend/server/common/visitor/visitor.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/vega/vega-backend/server/drivenadapters/asynq/asynq_access.go
+++ b/adp/vega/vega-backend/server/drivenadapters/asynq/asynq_access.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/vega/vega-backend/server/drivenadapters/auth/hydra_auth_access.go
+++ b/adp/vega/vega-backend/server/drivenadapters/auth/hydra_auth_access.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/vega/vega-backend/server/drivenadapters/build_task/build_task_access.go
+++ b/adp/vega/vega-backend/server/drivenadapters/build_task/build_task_access.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/vega/vega-backend/server/drivenadapters/build_task/build_task_order_test.go
+++ b/adp/vega/vega-backend/server/drivenadapters/build_task/build_task_order_test.go
@@ -1,5 +1,4 @@
-// Copyright 2026 openbkn.ai
-// Copyright The kweaver.ai Authors.
+// Copyright openbkn.ai
 //
 // Licensed under the Apache License, Version 2.0.
 // See the LICENSE file in the project root for details.

--- a/adp/vega/vega-backend/server/drivenadapters/catalog/catalog_access.go
+++ b/adp/vega/vega-backend/server/drivenadapters/catalog/catalog_access.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/vega/vega-backend/server/drivenadapters/catalog/catalog_extension.go
+++ b/adp/vega/vega-backend/server/drivenadapters/catalog/catalog_extension.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/vega/vega-backend/server/drivenadapters/connector_type/connector_type_access.go
+++ b/adp/vega/vega-backend/server/drivenadapters/connector_type/connector_type_access.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/vega/vega-backend/server/drivenadapters/discover_schedule/discover_schedule_access.go
+++ b/adp/vega/vega-backend/server/drivenadapters/discover_schedule/discover_schedule_access.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/vega/vega-backend/server/drivenadapters/discover_task/discover_task_access.go
+++ b/adp/vega/vega-backend/server/drivenadapters/discover_task/discover_task_access.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/vega/vega-backend/server/drivenadapters/entityextension/store.go
+++ b/adp/vega/vega-backend/server/drivenadapters/entityextension/store.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/vega/vega-backend/server/drivenadapters/kafka/kafka_access.go
+++ b/adp/vega/vega-backend/server/drivenadapters/kafka/kafka_access.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/vega/vega-backend/server/drivenadapters/model_factory/model_factory_access.go
+++ b/adp/vega/vega-backend/server/drivenadapters/model_factory/model_factory_access.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/vega/vega-backend/server/drivenadapters/model_factory/model_factory_access_test.go
+++ b/adp/vega/vega-backend/server/drivenadapters/model_factory/model_factory_access_test.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/vega/vega-backend/server/drivenadapters/permission/permission_access.go
+++ b/adp/vega/vega-backend/server/drivenadapters/permission/permission_access.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/vega/vega-backend/server/drivenadapters/resource/resource_access.go
+++ b/adp/vega/vega-backend/server/drivenadapters/resource/resource_access.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/vega/vega-backend/server/drivenadapters/resource/resource_extension.go
+++ b/adp/vega/vega-backend/server/drivenadapters/resource/resource_extension.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/vega/vega-backend/server/driveradapters/auth_resource_handler.go
+++ b/adp/vega/vega-backend/server/driveradapters/auth_resource_handler.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/vega/vega-backend/server/driveradapters/auth_resource_handler_test.go
+++ b/adp/vega/vega-backend/server/driveradapters/auth_resource_handler_test.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/vega/vega-backend/server/driveradapters/build_task_create_validate_test.go
+++ b/adp/vega/vega-backend/server/driveradapters/build_task_create_validate_test.go
@@ -1,5 +1,4 @@
-// Copyright 2026 openbkn.ai
-// Copyright The kweaver.ai Authors.
+// Copyright openbkn.ai
 //
 // Licensed under the Apache License, Version 2.0.
 // See the LICENSE file in the project root for details.

--- a/adp/vega/vega-backend/server/driveradapters/build_task_handler.go
+++ b/adp/vega/vega-backend/server/driveradapters/build_task_handler.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/vega/vega-backend/server/driveradapters/build_task_handler_test.go
+++ b/adp/vega/vega-backend/server/driveradapters/build_task_handler_test.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/vega/vega-backend/server/driveradapters/catalog_handler.go
+++ b/adp/vega/vega-backend/server/driveradapters/catalog_handler.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/vega/vega-backend/server/driveradapters/catalog_handler_test.go
+++ b/adp/vega/vega-backend/server/driveradapters/catalog_handler_test.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/vega/vega-backend/server/driveradapters/connector_type_handler.go
+++ b/adp/vega/vega-backend/server/driveradapters/connector_type_handler.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/vega/vega-backend/server/driveradapters/connector_type_handler_test.go
+++ b/adp/vega/vega-backend/server/driveradapters/connector_type_handler_test.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/vega/vega-backend/server/driveradapters/discover_schedule_handler.go
+++ b/adp/vega/vega-backend/server/driveradapters/discover_schedule_handler.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/vega/vega-backend/server/driveradapters/discover_schedule_handler_test.go
+++ b/adp/vega/vega-backend/server/driveradapters/discover_schedule_handler_test.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/vega/vega-backend/server/driveradapters/discover_task_handler.go
+++ b/adp/vega/vega-backend/server/driveradapters/discover_task_handler.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/vega/vega-backend/server/driveradapters/discover_task_handler_test.go
+++ b/adp/vega/vega-backend/server/driveradapters/discover_task_handler_test.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/vega/vega-backend/server/driveradapters/driveradapters_test.go
+++ b/adp/vega/vega-backend/server/driveradapters/driveradapters_test.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/vega/vega-backend/server/driveradapters/query_handler.go
+++ b/adp/vega/vega-backend/server/driveradapters/query_handler.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/vega/vega-backend/server/driveradapters/resource_data_handler.go
+++ b/adp/vega/vega-backend/server/driveradapters/resource_data_handler.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/vega/vega-backend/server/driveradapters/resource_handler.go
+++ b/adp/vega/vega-backend/server/driveradapters/resource_handler.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/vega/vega-backend/server/driveradapters/resource_handler_test.go
+++ b/adp/vega/vega-backend/server/driveradapters/resource_handler_test.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/vega/vega-backend/server/driveradapters/router.go
+++ b/adp/vega/vega-backend/server/driveradapters/router.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/vega/vega-backend/server/driveradapters/validate.go
+++ b/adp/vega/vega-backend/server/driveradapters/validate.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/vega/vega-backend/server/driveradapters/validate_build_task.go
+++ b/adp/vega/vega-backend/server/driveradapters/validate_build_task.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/vega/vega-backend/server/driveradapters/validate_build_task_test.go
+++ b/adp/vega/vega-backend/server/driveradapters/validate_build_task_test.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/vega/vega-backend/server/driveradapters/validate_catalog.go
+++ b/adp/vega/vega-backend/server/driveradapters/validate_catalog.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/vega/vega-backend/server/driveradapters/validate_connector_type.go
+++ b/adp/vega/vega-backend/server/driveradapters/validate_connector_type.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/vega/vega-backend/server/driveradapters/validate_discover_schedule.go
+++ b/adp/vega/vega-backend/server/driveradapters/validate_discover_schedule.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/vega/vega-backend/server/driveradapters/validate_discover_schedule_test.go
+++ b/adp/vega/vega-backend/server/driveradapters/validate_discover_schedule_test.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/vega/vega-backend/server/driveradapters/validate_discover_task.go
+++ b/adp/vega/vega-backend/server/driveradapters/validate_discover_task.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/vega/vega-backend/server/driveradapters/validate_discover_task_test.go
+++ b/adp/vega/vega-backend/server/driveradapters/validate_discover_task_test.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/vega/vega-backend/server/driveradapters/validate_resource.go
+++ b/adp/vega/vega-backend/server/driveradapters/validate_resource.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/vega/vega-backend/server/driveradapters/validate_resource_data.go
+++ b/adp/vega/vega-backend/server/driveradapters/validate_resource_data.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/vega/vega-backend/server/driveradapters/validate_test.go
+++ b/adp/vega/vega-backend/server/driveradapters/validate_test.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/vega/vega-backend/server/errors/build_task.go
+++ b/adp/vega/vega-backend/server/errors/build_task.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/vega/vega-backend/server/errors/catalog.go
+++ b/adp/vega/vega-backend/server/errors/catalog.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/vega/vega-backend/server/errors/connector_type.go
+++ b/adp/vega/vega-backend/server/errors/connector_type.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/vega/vega-backend/server/errors/dataset.go
+++ b/adp/vega/vega-backend/server/errors/dataset.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/vega/vega-backend/server/errors/discover_schedule.go
+++ b/adp/vega/vega-backend/server/errors/discover_schedule.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/vega/vega-backend/server/errors/discover_task.go
+++ b/adp/vega/vega-backend/server/errors/discover_task.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/vega/vega-backend/server/errors/error_code.go
+++ b/adp/vega/vega-backend/server/errors/error_code.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/vega/vega-backend/server/errors/extensions.go
+++ b/adp/vega/vega-backend/server/errors/extensions.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/vega/vega-backend/server/errors/logic_view.go
+++ b/adp/vega/vega-backend/server/errors/logic_view.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/vega/vega-backend/server/errors/query.go
+++ b/adp/vega/vega-backend/server/errors/query.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/vega/vega-backend/server/errors/resource.go
+++ b/adp/vega/vega-backend/server/errors/resource.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/vega/vega-backend/server/interfaces/asynq_access.go
+++ b/adp/vega/vega-backend/server/interfaces/asynq_access.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/vega/vega-backend/server/interfaces/auth_access.go
+++ b/adp/vega/vega-backend/server/interfaces/auth_access.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/vega/vega-backend/server/interfaces/auth_resource.go
+++ b/adp/vega/vega-backend/server/interfaces/auth_resource.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/vega/vega-backend/server/interfaces/auth_service.go
+++ b/adp/vega/vega-backend/server/interfaces/auth_service.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/vega/vega-backend/server/interfaces/build_task.go
+++ b/adp/vega/vega-backend/server/interfaces/build_task.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/vega/vega-backend/server/interfaces/build_task_access.go
+++ b/adp/vega/vega-backend/server/interfaces/build_task_access.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/vega/vega-backend/server/interfaces/build_task_service.go
+++ b/adp/vega/vega-backend/server/interfaces/build_task_service.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/vega/vega-backend/server/interfaces/build_worker_batch.go
+++ b/adp/vega/vega-backend/server/interfaces/build_worker_batch.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/vega/vega-backend/server/interfaces/build_worker_embedding.go
+++ b/adp/vega/vega-backend/server/interfaces/build_worker_embedding.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/vega/vega-backend/server/interfaces/build_worker_streaming.go
+++ b/adp/vega/vega-backend/server/interfaces/build_worker_streaming.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/vega/vega-backend/server/interfaces/catalog.go
+++ b/adp/vega/vega-backend/server/interfaces/catalog.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/vega/vega-backend/server/interfaces/catalog_access.go
+++ b/adp/vega/vega-backend/server/interfaces/catalog_access.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/vega/vega-backend/server/interfaces/catalog_service.go
+++ b/adp/vega/vega-backend/server/interfaces/catalog_service.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/vega/vega-backend/server/interfaces/common.go
+++ b/adp/vega/vega-backend/server/interfaces/common.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/vega/vega-backend/server/interfaces/condition.go
+++ b/adp/vega/vega-backend/server/interfaces/condition.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/vega/vega-backend/server/interfaces/connector.go
+++ b/adp/vega/vega-backend/server/interfaces/connector.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/vega/vega-backend/server/interfaces/connector_type.go
+++ b/adp/vega/vega-backend/server/interfaces/connector_type.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/vega/vega-backend/server/interfaces/connector_type_access.go
+++ b/adp/vega/vega-backend/server/interfaces/connector_type_access.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/vega/vega-backend/server/interfaces/connector_type_service.go
+++ b/adp/vega/vega-backend/server/interfaces/connector_type_service.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/vega/vega-backend/server/interfaces/data_types.go
+++ b/adp/vega/vega-backend/server/interfaces/data_types.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/vega/vega-backend/server/interfaces/dataset_service.go
+++ b/adp/vega/vega-backend/server/interfaces/dataset_service.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/vega/vega-backend/server/interfaces/discover_schedule.go
+++ b/adp/vega/vega-backend/server/interfaces/discover_schedule.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/vega/vega-backend/server/interfaces/discover_schedule_access.go
+++ b/adp/vega/vega-backend/server/interfaces/discover_schedule_access.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/vega/vega-backend/server/interfaces/discover_schedule_service.go
+++ b/adp/vega/vega-backend/server/interfaces/discover_schedule_service.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/vega/vega-backend/server/interfaces/discover_strategy.go
+++ b/adp/vega/vega-backend/server/interfaces/discover_strategy.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/vega/vega-backend/server/interfaces/discover_strategy_test.go
+++ b/adp/vega/vega-backend/server/interfaces/discover_strategy_test.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/vega/vega-backend/server/interfaces/discover_task.go
+++ b/adp/vega/vega-backend/server/interfaces/discover_task.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/vega/vega-backend/server/interfaces/discover_task_access.go
+++ b/adp/vega/vega-backend/server/interfaces/discover_task_access.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/vega/vega-backend/server/interfaces/discover_task_service.go
+++ b/adp/vega/vega-backend/server/interfaces/discover_task_service.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/vega/vega-backend/server/interfaces/discover_worker.go
+++ b/adp/vega/vega-backend/server/interfaces/discover_worker.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/vega/vega-backend/server/interfaces/kafka_access.go
+++ b/adp/vega/vega-backend/server/interfaces/kafka_access.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/vega/vega-backend/server/interfaces/logic_view_service.go
+++ b/adp/vega/vega-backend/server/interfaces/logic_view_service.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/vega/vega-backend/server/interfaces/model_factory_access.go
+++ b/adp/vega/vega-backend/server/interfaces/model_factory_access.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/vega/vega-backend/server/interfaces/permission_access.go
+++ b/adp/vega/vega-backend/server/interfaces/permission_access.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/vega/vega-backend/server/interfaces/permission_service.go
+++ b/adp/vega/vega-backend/server/interfaces/permission_service.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/vega/vega-backend/server/interfaces/query.go
+++ b/adp/vega/vega-backend/server/interfaces/query.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/vega/vega-backend/server/interfaces/resource.go
+++ b/adp/vega/vega-backend/server/interfaces/resource.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/vega/vega-backend/server/interfaces/resource_access.go
+++ b/adp/vega/vega-backend/server/interfaces/resource_access.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/vega/vega-backend/server/interfaces/resource_data.go
+++ b/adp/vega/vega-backend/server/interfaces/resource_data.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/vega/vega-backend/server/interfaces/resource_data_service.go
+++ b/adp/vega/vega-backend/server/interfaces/resource_data_service.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/vega/vega-backend/server/interfaces/resource_service.go
+++ b/adp/vega/vega-backend/server/interfaces/resource_service.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/vega/vega-backend/server/interfaces/s2s_access.go
+++ b/adp/vega/vega-backend/server/interfaces/s2s_access.go
@@ -1,5 +1,4 @@
-// Copyright 2026 openbkn.ai
-// Copyright The kweaver.ai Authors.
+// Copyright openbkn.ai
 //
 // Licensed under the Apache License, Version 2.0.
 // See the LICENSE file in the project root for details.

--- a/adp/vega/vega-backend/server/interfaces/task_handler.go
+++ b/adp/vega/vega-backend/server/interfaces/task_handler.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/vega/vega-backend/server/interfaces/user_mgmt_access.go
+++ b/adp/vega/vega-backend/server/interfaces/user_mgmt_access.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/vega/vega-backend/server/interfaces/user_mgmt_service.go
+++ b/adp/vega/vega-backend/server/interfaces/user_mgmt_service.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/vega/vega-backend/server/locale/locale.go
+++ b/adp/vega/vega-backend/server/locale/locale.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/vega/vega-backend/server/logics/build_task/build_task_normalize_test.go
+++ b/adp/vega/vega-backend/server/logics/build_task/build_task_normalize_test.go
@@ -1,5 +1,4 @@
-// Copyright 2026 openbkn.ai
-// Copyright The kweaver.ai Authors.
+// Copyright openbkn.ai
 //
 // Licensed under the Apache License, Version 2.0.
 // See the LICENSE file in the project root for details.

--- a/adp/vega/vega-backend/server/logics/build_task/build_task_service.go
+++ b/adp/vega/vega-backend/server/logics/build_task/build_task_service.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/vega/vega-backend/server/logics/build_task/build_task_service_test.go
+++ b/adp/vega/vega-backend/server/logics/build_task/build_task_service_test.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/vega/vega-backend/server/logics/cascade.go
+++ b/adp/vega/vega-backend/server/logics/cascade.go
@@ -1,5 +1,4 @@
-// Copyright 2026 openbkn.ai
-// Copyright The kweaver.ai Authors.
+// Copyright openbkn.ai
 //
 // Licensed under the Apache License, Version 2.0.
 // See the LICENSE file in the project root for details.

--- a/adp/vega/vega-backend/server/logics/catalog/catalog_service.go
+++ b/adp/vega/vega-backend/server/logics/catalog/catalog_service.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/vega/vega-backend/server/logics/catalog/catalog_service_s2s_test.go
+++ b/adp/vega/vega-backend/server/logics/catalog/catalog_service_s2s_test.go
@@ -1,5 +1,4 @@
-// Copyright 2026 openbkn.ai
-// Copyright The kweaver.ai Authors.
+// Copyright openbkn.ai
 //
 // Licensed under the Apache License, Version 2.0.
 // See the LICENSE file in the project root for details.

--- a/adp/vega/vega-backend/server/logics/catalog/catalog_service_test.go
+++ b/adp/vega/vega-backend/server/logics/catalog/catalog_service_test.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/vega/vega-backend/server/logics/connector_type/connector_type_service.go
+++ b/adp/vega/vega-backend/server/logics/connector_type/connector_type_service.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/vega/vega-backend/server/logics/connectors/connector.go
+++ b/adp/vega/vega-backend/server/logics/connectors/connector.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/vega/vega-backend/server/logics/connectors/factory/factory.go
+++ b/adp/vega/vega-backend/server/logics/connectors/factory/factory.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/vega/vega-backend/server/logics/connectors/factory/init.go
+++ b/adp/vega/vega-backend/server/logics/connectors/factory/init.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/vega/vega-backend/server/logics/connectors/local/fileset/anyshare/anyshare.go
+++ b/adp/vega/vega-backend/server/logics/connectors/local/fileset/anyshare/anyshare.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/vega/vega-backend/server/logics/connectors/local/fileset/anyshare/anyshare_discover.go
+++ b/adp/vega/vega-backend/server/logics/connectors/local/fileset/anyshare/anyshare_discover.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/vega/vega-backend/server/logics/connectors/local/fileset/anyshare/anyshare_query.go
+++ b/adp/vega/vega-backend/server/logics/connectors/local/fileset/anyshare/anyshare_query.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/vega/vega-backend/server/logics/connectors/local/index/opensearch/opensearch.go
+++ b/adp/vega/vega-backend/server/logics/connectors/local/index/opensearch/opensearch.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/vega/vega-backend/server/logics/connectors/local/index/opensearch/opensearch_condition.go
+++ b/adp/vega/vega-backend/server/logics/connectors/local/index/opensearch/opensearch_condition.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/vega/vega-backend/server/logics/connectors/local/index/opensearch/opensearch_discover.go
+++ b/adp/vega/vega-backend/server/logics/connectors/local/index/opensearch/opensearch_discover.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/vega/vega-backend/server/logics/connectors/local/index/opensearch/opensearch_fulltext_test.go
+++ b/adp/vega/vega-backend/server/logics/connectors/local/index/opensearch/opensearch_fulltext_test.go
@@ -1,5 +1,4 @@
-// Copyright 2026 openbkn.ai
-// Copyright The kweaver.ai Authors.
+// Copyright openbkn.ai
 //
 // Licensed under the Apache License, Version 2.0.
 // See the LICENSE file in the project root for details.

--- a/adp/vega/vega-backend/server/logics/connectors/local/index/opensearch/opensearch_query.go
+++ b/adp/vega/vega-backend/server/logics/connectors/local/index/opensearch/opensearch_query.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/vega/vega-backend/server/logics/connectors/local/index/opensearch/type_mapping.go
+++ b/adp/vega/vega-backend/server/logics/connectors/local/index/opensearch/type_mapping.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/vega/vega-backend/server/logics/connectors/local/table/mariadb/mariadb.go
+++ b/adp/vega/vega-backend/server/logics/connectors/local/table/mariadb/mariadb.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/vega/vega-backend/server/logics/connectors/local/table/mariadb/mariadb_condition.go
+++ b/adp/vega/vega-backend/server/logics/connectors/local/table/mariadb/mariadb_condition.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/vega/vega-backend/server/logics/connectors/local/table/mariadb/mariadb_condition_test.go
+++ b/adp/vega/vega-backend/server/logics/connectors/local/table/mariadb/mariadb_condition_test.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/vega/vega-backend/server/logics/connectors/local/table/mariadb/mariadb_discover.go
+++ b/adp/vega/vega-backend/server/logics/connectors/local/table/mariadb/mariadb_discover.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/vega/vega-backend/server/logics/connectors/local/table/mariadb/mariadb_query.go
+++ b/adp/vega/vega-backend/server/logics/connectors/local/table/mariadb/mariadb_query.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/vega/vega-backend/server/logics/connectors/local/table/mariadb/type_mapping.go
+++ b/adp/vega/vega-backend/server/logics/connectors/local/table/mariadb/type_mapping.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/vega/vega-backend/server/logics/connectors/local/table/oracle/oracle.go
+++ b/adp/vega/vega-backend/server/logics/connectors/local/table/oracle/oracle.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/vega/vega-backend/server/logics/connectors/local/table/oracle/type_mapping.go
+++ b/adp/vega/vega-backend/server/logics/connectors/local/table/oracle/type_mapping.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/vega/vega-backend/server/logics/connectors/local/table/postgresql/postgresql.go
+++ b/adp/vega/vega-backend/server/logics/connectors/local/table/postgresql/postgresql.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/vega/vega-backend/server/logics/connectors/local/table/postgresql/postgresql_condition.go
+++ b/adp/vega/vega-backend/server/logics/connectors/local/table/postgresql/postgresql_condition.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/vega/vega-backend/server/logics/connectors/local/table/postgresql/postgresql_condition_test.go
+++ b/adp/vega/vega-backend/server/logics/connectors/local/table/postgresql/postgresql_condition_test.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/vega/vega-backend/server/logics/connectors/local/table/postgresql/postgresql_discover.go
+++ b/adp/vega/vega-backend/server/logics/connectors/local/table/postgresql/postgresql_discover.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/vega/vega-backend/server/logics/connectors/local/table/postgresql/postgresql_ident.go
+++ b/adp/vega/vega-backend/server/logics/connectors/local/table/postgresql/postgresql_ident.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/vega/vega-backend/server/logics/connectors/local/table/postgresql/postgresql_query.go
+++ b/adp/vega/vega-backend/server/logics/connectors/local/table/postgresql/postgresql_query.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/vega/vega-backend/server/logics/connectors/local/table/postgresql/type_mapping.go
+++ b/adp/vega/vega-backend/server/logics/connectors/local/table/postgresql/type_mapping.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/vega/vega-backend/server/logics/connectors/local/table/postgresql/type_mapping_test.go
+++ b/adp/vega/vega-backend/server/logics/connectors/local/table/postgresql/type_mapping_test.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/vega/vega-backend/server/logics/connectors/local/table/table_connector.go
+++ b/adp/vega/vega-backend/server/logics/connectors/local/table/table_connector.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/vega/vega-backend/server/logics/connectors/remote/http_client.go
+++ b/adp/vega/vega-backend/server/logics/connectors/remote/http_client.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/vega/vega-backend/server/logics/connectors/remote/remote_connector.go
+++ b/adp/vega/vega-backend/server/logics/connectors/remote/remote_connector.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/vega/vega-backend/server/logics/discover_schedule/discover_schedule_service.go
+++ b/adp/vega/vega-backend/server/logics/discover_schedule/discover_schedule_service.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/vega/vega-backend/server/logics/discover_task/discover_task_service.go
+++ b/adp/vega/vega-backend/server/logics/discover_task/discover_task_service.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/vega/vega-backend/server/logics/driven_access.go
+++ b/adp/vega/vega-backend/server/logics/driven_access.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/vega/vega-backend/server/logics/extensions/validate.go
+++ b/adp/vega/vega-backend/server/logics/extensions/validate.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/vega/vega-backend/server/logics/filter_condition/condition.go
+++ b/adp/vega/vega-backend/server/logics/filter_condition/condition.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/vega/vega-backend/server/logics/filter_condition/condition_and.go
+++ b/adp/vega/vega-backend/server/logics/filter_condition/condition_and.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/vega/vega-backend/server/logics/filter_condition/condition_before.go
+++ b/adp/vega/vega-backend/server/logics/filter_condition/condition_before.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/vega/vega-backend/server/logics/filter_condition/condition_between.go
+++ b/adp/vega/vega-backend/server/logics/filter_condition/condition_between.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/vega/vega-backend/server/logics/filter_condition/condition_contain.go
+++ b/adp/vega/vega-backend/server/logics/filter_condition/condition_contain.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/vega/vega-backend/server/logics/filter_condition/condition_current.go
+++ b/adp/vega/vega-backend/server/logics/filter_condition/condition_current.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/vega/vega-backend/server/logics/filter_condition/condition_empty.go
+++ b/adp/vega/vega-backend/server/logics/filter_condition/condition_empty.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/vega/vega-backend/server/logics/filter_condition/condition_equal.go
+++ b/adp/vega/vega-backend/server/logics/filter_condition/condition_equal.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/vega/vega-backend/server/logics/filter_condition/condition_exist.go
+++ b/adp/vega/vega-backend/server/logics/filter_condition/condition_exist.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/vega/vega-backend/server/logics/filter_condition/condition_false.go
+++ b/adp/vega/vega-backend/server/logics/filter_condition/condition_false.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/vega/vega-backend/server/logics/filter_condition/condition_gt.go
+++ b/adp/vega/vega-backend/server/logics/filter_condition/condition_gt.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/vega/vega-backend/server/logics/filter_condition/condition_gte.go
+++ b/adp/vega/vega-backend/server/logics/filter_condition/condition_gte.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/vega/vega-backend/server/logics/filter_condition/condition_in.go
+++ b/adp/vega/vega-backend/server/logics/filter_condition/condition_in.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/vega/vega-backend/server/logics/filter_condition/condition_knn_vector.go
+++ b/adp/vega/vega-backend/server/logics/filter_condition/condition_knn_vector.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/vega/vega-backend/server/logics/filter_condition/condition_like.go
+++ b/adp/vega/vega-backend/server/logics/filter_condition/condition_like.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/vega/vega-backend/server/logics/filter_condition/condition_lt.go
+++ b/adp/vega/vega-backend/server/logics/filter_condition/condition_lt.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/vega/vega-backend/server/logics/filter_condition/condition_lte.go
+++ b/adp/vega/vega-backend/server/logics/filter_condition/condition_lte.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/vega/vega-backend/server/logics/filter_condition/condition_match.go
+++ b/adp/vega/vega-backend/server/logics/filter_condition/condition_match.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/vega/vega-backend/server/logics/filter_condition/condition_match_phrase.go
+++ b/adp/vega/vega-backend/server/logics/filter_condition/condition_match_phrase.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/vega/vega-backend/server/logics/filter_condition/condition_multi_match.go
+++ b/adp/vega/vega-backend/server/logics/filter_condition/condition_multi_match.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/vega/vega-backend/server/logics/filter_condition/condition_not_contain.go
+++ b/adp/vega/vega-backend/server/logics/filter_condition/condition_not_contain.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/vega/vega-backend/server/logics/filter_condition/condition_not_empty.go
+++ b/adp/vega/vega-backend/server/logics/filter_condition/condition_not_empty.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/vega/vega-backend/server/logics/filter_condition/condition_not_equal.go
+++ b/adp/vega/vega-backend/server/logics/filter_condition/condition_not_equal.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/vega/vega-backend/server/logics/filter_condition/condition_not_exist.go
+++ b/adp/vega/vega-backend/server/logics/filter_condition/condition_not_exist.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/vega/vega-backend/server/logics/filter_condition/condition_not_in.go
+++ b/adp/vega/vega-backend/server/logics/filter_condition/condition_not_in.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/vega/vega-backend/server/logics/filter_condition/condition_not_like.go
+++ b/adp/vega/vega-backend/server/logics/filter_condition/condition_not_like.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/vega/vega-backend/server/logics/filter_condition/condition_not_null.go
+++ b/adp/vega/vega-backend/server/logics/filter_condition/condition_not_null.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/vega/vega-backend/server/logics/filter_condition/condition_not_prefix.go
+++ b/adp/vega/vega-backend/server/logics/filter_condition/condition_not_prefix.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/vega/vega-backend/server/logics/filter_condition/condition_null.go
+++ b/adp/vega/vega-backend/server/logics/filter_condition/condition_null.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/vega/vega-backend/server/logics/filter_condition/condition_operation.go
+++ b/adp/vega/vega-backend/server/logics/filter_condition/condition_operation.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/vega/vega-backend/server/logics/filter_condition/condition_or.go
+++ b/adp/vega/vega-backend/server/logics/filter_condition/condition_or.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/vega/vega-backend/server/logics/filter_condition/condition_out_range.go
+++ b/adp/vega/vega-backend/server/logics/filter_condition/condition_out_range.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/vega/vega-backend/server/logics/filter_condition/condition_prefix.go
+++ b/adp/vega/vega-backend/server/logics/filter_condition/condition_prefix.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/vega/vega-backend/server/logics/filter_condition/condition_range.go
+++ b/adp/vega/vega-backend/server/logics/filter_condition/condition_range.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/vega/vega-backend/server/logics/filter_condition/condition_regex.go
+++ b/adp/vega/vega-backend/server/logics/filter_condition/condition_regex.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/vega/vega-backend/server/logics/filter_condition/condition_test.go
+++ b/adp/vega/vega-backend/server/logics/filter_condition/condition_test.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/vega/vega-backend/server/logics/filter_condition/condition_true.go
+++ b/adp/vega/vega-backend/server/logics/filter_condition/condition_true.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/vega/vega-backend/server/logics/permission/noop_permission_service_test.go
+++ b/adp/vega/vega-backend/server/logics/permission/noop_permission_service_test.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/vega/vega-backend/server/logics/query/raw_query_service.go
+++ b/adp/vega/vega-backend/server/logics/query/raw_query_service.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/vega/vega-backend/server/logics/query/raw_query_service_test.go
+++ b/adp/vega/vega-backend/server/logics/query/raw_query_service_test.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/vega/vega-backend/server/logics/query/sqlglot/sqlglot.go
+++ b/adp/vega/vega-backend/server/logics/query/sqlglot/sqlglot.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/vega/vega-backend/server/logics/query/stream_query_manager.go
+++ b/adp/vega/vega-backend/server/logics/query/stream_query_manager.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/vega/vega-backend/server/logics/rate/concurrency_limiter.go
+++ b/adp/vega/vega-backend/server/logics/rate/concurrency_limiter.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/vega/vega-backend/server/logics/rate/concurrency_limiter_test.go
+++ b/adp/vega/vega-backend/server/logics/rate/concurrency_limiter_test.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/vega/vega-backend/server/logics/rate/config.go
+++ b/adp/vega/vega-backend/server/logics/rate/config.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/vega/vega-backend/server/logics/rate/errors.go
+++ b/adp/vega/vega-backend/server/logics/rate/errors.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/vega/vega-backend/server/logics/resource/logic_view.go
+++ b/adp/vega/vega-backend/server/logics/resource/logic_view.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/vega/vega-backend/server/logics/resource/logic_view_sql_test.go
+++ b/adp/vega/vega-backend/server/logics/resource/logic_view_sql_test.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/vega/vega-backend/server/logics/resource/resource_service.go
+++ b/adp/vega/vega-backend/server/logics/resource/resource_service.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/vega/vega-backend/server/logics/resource/resource_service_s2s_test.go
+++ b/adp/vega/vega-backend/server/logics/resource/resource_service_s2s_test.go
@@ -1,5 +1,4 @@
-// Copyright 2026 openbkn.ai
-// Copyright The kweaver.ai Authors.
+// Copyright openbkn.ai
 //
 // Licensed under the Apache License, Version 2.0.
 // See the LICENSE file in the project root for details.

--- a/adp/vega/vega-backend/server/logics/resource/resource_service_test.go
+++ b/adp/vega/vega-backend/server/logics/resource/resource_service_test.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/vega/vega-backend/server/logics/resource/status.go
+++ b/adp/vega/vega-backend/server/logics/resource/status.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/vega/vega-backend/server/logics/resource/status_test.go
+++ b/adp/vega/vega-backend/server/logics/resource/status_test.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/vega/vega-backend/server/logics/resource_data/logic_view/dsl/dsl.go
+++ b/adp/vega/vega-backend/server/logics/resource_data/logic_view/dsl/dsl.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/vega/vega-backend/server/logics/resource_data/logic_view/dsl/dsl_condition.go
+++ b/adp/vega/vega-backend/server/logics/resource_data/logic_view/dsl/dsl_condition.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/vega/vega-backend/server/logics/resource_data/logic_view/sql/parser/generate.go
+++ b/adp/vega/vega-backend/server/logics/resource_data/logic_view/sql/parser/generate.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/vega/vega-backend/server/logics/resource_data/logic_view/sql/parser/generate.sh
+++ b/adp/vega/vega-backend/server/logics/resource_data/logic_view/sql/parser/generate.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
-# Copyright 2026 openbkn.ai
+# Copyright openbkn.ai
 # Copyright The kweaver.ai Authors.
 # Licensed under the Apache License, Version 2.0.
 # See the LICENSE file in the project root for details.

--- a/adp/vega/vega-backend/server/logics/resource_data/logic_view/sql/parsing/sqlbase_base_listener.go
+++ b/adp/vega/vega-backend/server/logics/resource_data/logic_view/sql/parsing/sqlbase_base_listener.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/vega/vega-backend/server/logics/resource_data/logic_view/sql/parsing/sqlbase_lexer.go
+++ b/adp/vega/vega-backend/server/logics/resource_data/logic_view/sql/parsing/sqlbase_lexer.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/vega/vega-backend/server/logics/resource_data/logic_view/sql/parsing/sqlbase_listener.go
+++ b/adp/vega/vega-backend/server/logics/resource_data/logic_view/sql/parsing/sqlbase_listener.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/vega/vega-backend/server/logics/resource_data/logic_view/sql/parsing/sqlbase_parser.go
+++ b/adp/vega/vega-backend/server/logics/resource_data/logic_view/sql/parsing/sqlbase_parser.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/vega/vega-backend/server/logics/resource_data/logic_view/sql/sql.go
+++ b/adp/vega/vega-backend/server/logics/resource_data/logic_view/sql/sql.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/vega/vega-backend/server/logics/resource_data/logic_view/sql/sql_condition.go
+++ b/adp/vega/vega-backend/server/logics/resource_data/logic_view/sql/sql_condition.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/vega/vega-backend/server/logics/resource_data/resource_data_service_test.go
+++ b/adp/vega/vega-backend/server/logics/resource_data/resource_data_service_test.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/vega/vega-backend/server/logics/user_mgmt/noop_user_mgmt_service.go
+++ b/adp/vega/vega-backend/server/logics/user_mgmt/noop_user_mgmt_service.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/vega/vega-backend/server/logics/user_mgmt/user_mgmt_service.go
+++ b/adp/vega/vega-backend/server/logics/user_mgmt/user_mgmt_service.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/vega/vega-backend/server/logics/user_mgmt/user_mgmt_service_impl.go
+++ b/adp/vega/vega-backend/server/logics/user_mgmt/user_mgmt_service_impl.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/vega/vega-backend/server/main.go
+++ b/adp/vega/vega-backend/server/main.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/vega/vega-backend/server/version/version.go
+++ b/adp/vega/vega-backend/server/version/version.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/vega/vega-backend/server/worker/build_handler_account_test.go
+++ b/adp/vega/vega-backend/server/worker/build_handler_account_test.go
@@ -1,5 +1,4 @@
-// Copyright 2026 openbkn.ai
-// Copyright The kweaver.ai Authors.
+// Copyright openbkn.ai
 //
 // Licensed under the Apache License, Version 2.0.
 // See the LICENSE file in the project root for details.

--- a/adp/vega/vega-backend/server/worker/build_handler_batch.go
+++ b/adp/vega/vega-backend/server/worker/build_handler_batch.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/vega/vega-backend/server/worker/build_handler_cursor_test.go
+++ b/adp/vega/vega-backend/server/worker/build_handler_cursor_test.go
@@ -1,5 +1,4 @@
-// Copyright 2026 openbkn.ai
-// Copyright The kweaver.ai Authors.
+// Copyright openbkn.ai
 //
 // Licensed under the Apache License, Version 2.0.
 // See the LICENSE file in the project root for details.

--- a/adp/vega/vega-backend/server/worker/build_handler_embedding.go
+++ b/adp/vega/vega-backend/server/worker/build_handler_embedding.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/vega/vega-backend/server/worker/build_handler_embedding_loop_test.go
+++ b/adp/vega/vega-backend/server/worker/build_handler_embedding_loop_test.go
@@ -1,5 +1,4 @@
-// Copyright 2026 openbkn.ai
-// Copyright The kweaver.ai Authors.
+// Copyright openbkn.ai
 //
 // Licensed under the Apache License, Version 2.0.
 // See the LICENSE file in the project root for details.

--- a/adp/vega/vega-backend/server/worker/build_handler_streaming.go
+++ b/adp/vega/vega-backend/server/worker/build_handler_streaming.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/vega/vega-backend/server/worker/build_handler_vectorize_test.go
+++ b/adp/vega/vega-backend/server/worker/build_handler_vectorize_test.go
@@ -1,5 +1,4 @@
-// Copyright 2026 openbkn.ai
-// Copyright The kweaver.ai Authors.
+// Copyright openbkn.ai
 //
 // Licensed under the Apache License, Version 2.0.
 // See the LICENSE file in the project root for details.

--- a/adp/vega/vega-backend/server/worker/build_task_common.go
+++ b/adp/vega/vega-backend/server/worker/build_task_common.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/vega/vega-backend/server/worker/build_task_reconciler.go
+++ b/adp/vega/vega-backend/server/worker/build_task_reconciler.go
@@ -1,5 +1,4 @@
-// Copyright 2026 openbkn.ai
-// Copyright The kweaver.ai Authors.
+// Copyright openbkn.ai
 //
 // Licensed under the Apache License, Version 2.0.
 // See the LICENSE file in the project root for details.

--- a/adp/vega/vega-backend/server/worker/build_task_reconciler_test.go
+++ b/adp/vega/vega-backend/server/worker/build_task_reconciler_test.go
@@ -1,5 +1,4 @@
-// Copyright 2026 openbkn.ai
-// Copyright The kweaver.ai Authors.
+// Copyright openbkn.ai
 //
 // Licensed under the Apache License, Version 2.0.
 // See the LICENSE file in the project root for details.

--- a/adp/vega/vega-backend/server/worker/discover_fileset.go
+++ b/adp/vega/vega-backend/server/worker/discover_fileset.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/vega/vega-backend/server/worker/discover_handler.go
+++ b/adp/vega/vega-backend/server/worker/discover_handler.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/vega/vega-backend/server/worker/discover_handler_test.go
+++ b/adp/vega/vega-backend/server/worker/discover_handler_test.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/vega/vega-backend/server/worker/discover_index.go
+++ b/adp/vega/vega-backend/server/worker/discover_index.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/vega/vega-backend/server/worker/discover_status.go
+++ b/adp/vega/vega-backend/server/worker/discover_status.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/vega/vega-backend/server/worker/discover_table.go
+++ b/adp/vega/vega-backend/server/worker/discover_table.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/vega/vega-backend/server/worker/schedule_worker.go
+++ b/adp/vega/vega-backend/server/worker/schedule_worker.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/vega/vega-backend/server/worker/task_worker_manager.go
+++ b/adp/vega/vega-backend/server/worker/task_worker_manager.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/vega/vega-backend/tests/at/catalog/helpers/helpers.go
+++ b/adp/vega/vega-backend/tests/at/catalog/helpers/helpers.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/vega/vega-backend/tests/at/catalog/logical/catalog_test.go
+++ b/adp/vega/vega-backend/tests/at/catalog/logical/catalog_test.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/vega/vega-backend/tests/at/catalog/logical/helpers/helpers.go
+++ b/adp/vega/vega-backend/tests/at/catalog/logical/helpers/helpers.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/vega/vega-backend/tests/at/catalog/physical/index/opensearch/builder.go
+++ b/adp/vega/vega-backend/tests/at/catalog/physical/index/opensearch/builder.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/vega/vega-backend/tests/at/catalog/physical/index/opensearch/catalog_test.go
+++ b/adp/vega/vega-backend/tests/at/catalog/physical/index/opensearch/catalog_test.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/vega/vega-backend/tests/at/catalog/physical/table/mariadb/builder.go
+++ b/adp/vega/vega-backend/tests/at/catalog/physical/table/mariadb/builder.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/vega/vega-backend/tests/at/catalog/physical/table/mariadb/catalog_test.go
+++ b/adp/vega/vega-backend/tests/at/catalog/physical/table/mariadb/catalog_test.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/vega/vega-backend/tests/at/rate/concurrency_test.go
+++ b/adp/vega/vega-backend/tests/at/rate/concurrency_test.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/vega/vega-backend/tests/at/resource/build_task/build_task_test.go
+++ b/adp/vega/vega-backend/tests/at/resource/build_task/build_task_test.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/vega/vega-backend/tests/at/resource/dataset/dataset_test.go
+++ b/adp/vega/vega-backend/tests/at/resource/dataset/dataset_test.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/vega/vega-backend/tests/at/resource/helpers/catalog_builder.go
+++ b/adp/vega/vega-backend/tests/at/resource/helpers/catalog_builder.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/vega/vega-backend/tests/at/resource/helpers/fixtures.go
+++ b/adp/vega/vega-backend/tests/at/resource/helpers/fixtures.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/vega/vega-backend/tests/at/resource/helpers/helpers.go
+++ b/adp/vega/vega-backend/tests/at/resource/helpers/helpers.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/vega/vega-backend/tests/at/resource/helpers/suite.go
+++ b/adp/vega/vega-backend/tests/at/resource/helpers/suite.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/vega/vega-backend/tests/at/resource/helpers/test_cases.go
+++ b/adp/vega/vega-backend/tests/at/resource/helpers/test_cases.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/vega/vega-backend/tests/at/resource/index/opensearch/resource_test.go
+++ b/adp/vega/vega-backend/tests/at/resource/index/opensearch/resource_test.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/vega/vega-backend/tests/at/resource/table/mairadb/resource_test.go
+++ b/adp/vega/vega-backend/tests/at/resource/table/mairadb/resource_test.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/vega/vega-backend/tests/at/setup/config.go
+++ b/adp/vega/vega-backend/tests/at/setup/config.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/adp/vega/vega-backend/tests/testutil/http_client.go
+++ b/adp/vega/vega-backend/tests/testutil/http_client.go
@@ -1,4 +1,4 @@
-// Copyright 2026 openbkn.ai
+// Copyright openbkn.ai
 // Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.

--- a/bkn-safe/server/internal/auth/apikey_mask_test.go
+++ b/bkn-safe/server/internal/auth/apikey_mask_test.go
@@ -1,5 +1,4 @@
-// Copyright 2026 openbkn.ai
-// Copyright The kweaver.ai Authors.
+// Copyright openbkn.ai
 //
 // Licensed under the Apache License, Version 2.0.
 // See the LICENSE file in the project root for details.

--- a/data-migrator/server/__init__.py
+++ b/data-migrator/server/__init__.py
@@ -1,4 +1,4 @@
-# Copyright The kweaver.ai Authors.
+# Copyright openbkn.ai
 #
 # Licensed under the Apache License, Version 2.0.
 # See the LICENSE file in the project root for details.

--- a/data-migrator/server/config/__init__.py
+++ b/data-migrator/server/config/__init__.py
@@ -1,4 +1,4 @@
-# Copyright The kweaver.ai Authors.
+# Copyright openbkn.ai
 #
 # Licensed under the Apache License, Version 2.0.
 # See the LICENSE file in the project root for details.

--- a/data-migrator/server/config/loader.py
+++ b/data-migrator/server/config/loader.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
-# Copyright The kweaver.ai Authors.
+# Copyright openbkn.ai
 #
 # Licensed under the Apache License, Version 2.0.
 # See the LICENSE file in the project root for details.

--- a/data-migrator/server/config/models.py
+++ b/data-migrator/server/config/models.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
-# Copyright The kweaver.ai Authors.
+# Copyright openbkn.ai
 #
 # Licensed under the Apache License, Version 2.0.
 # See the LICENSE file in the project root for details.

--- a/data-migrator/server/data-migrator.py
+++ b/data-migrator/server/data-migrator.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
-# Copyright The kweaver.ai Authors.
+# Copyright openbkn.ai
 #
 # Licensed under the Apache License, Version 2.0.
 # See the LICENSE file in the project root for details.

--- a/data-migrator/server/db/__init__.py
+++ b/data-migrator/server/db/__init__.py
@@ -1,4 +1,4 @@
-# Copyright The kweaver.ai Authors.
+# Copyright openbkn.ai
 #
 # Licensed under the Apache License, Version 2.0.
 # See the LICENSE file in the project root for details.

--- a/data-migrator/server/db/connection.py
+++ b/data-migrator/server/db/connection.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
-# Copyright The kweaver.ai Authors.
+# Copyright openbkn.ai
 #
 # Licensed under the Apache License, Version 2.0.
 # See the LICENSE file in the project root for details.

--- a/data-migrator/server/db/dialect/__init__.py
+++ b/data-migrator/server/db/dialect/__init__.py
@@ -1,4 +1,4 @@
-# Copyright The kweaver.ai Authors.
+# Copyright openbkn.ai
 #
 # Licensed under the Apache License, Version 2.0.
 # See the LICENSE file in the project root for details.

--- a/data-migrator/server/db/dialect/_parser/__init__.py
+++ b/data-migrator/server/db/dialect/_parser/__init__.py
@@ -1,4 +1,4 @@
-# Copyright The kweaver.ai Authors.
+# Copyright openbkn.ai
 #
 # Licensed under the Apache License, Version 2.0.
 # See the LICENSE file in the project root for details.

--- a/data-migrator/server/db/dialect/_parser/base.py
+++ b/data-migrator/server/db/dialect/_parser/base.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
-# Copyright The kweaver.ai Authors.
+# Copyright openbkn.ai
 #
 # Licensed under the Apache License, Version 2.0.
 # See the LICENSE file in the project root for details.

--- a/data-migrator/server/db/dialect/_parser/dm8.py
+++ b/data-migrator/server/db/dialect/_parser/dm8.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
-# Copyright The kweaver.ai Authors.
+# Copyright openbkn.ai
 #
 # Licensed under the Apache License, Version 2.0.
 # See the LICENSE file in the project root for details.

--- a/data-migrator/server/db/dialect/_parser/kdb9.py
+++ b/data-migrator/server/db/dialect/_parser/kdb9.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
-# Copyright The kweaver.ai Authors.
+# Copyright openbkn.ai
 #
 # Licensed under the Apache License, Version 2.0.
 # See the LICENSE file in the project root for details.

--- a/data-migrator/server/db/dialect/_parser/mariadb.py
+++ b/data-migrator/server/db/dialect/_parser/mariadb.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
-# Copyright The kweaver.ai Authors.
+# Copyright openbkn.ai
 #
 # Licensed under the Apache License, Version 2.0.
 # See the LICENSE file in the project root for details.

--- a/data-migrator/server/db/dialect/base.py
+++ b/data-migrator/server/db/dialect/base.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
-# Copyright The kweaver.ai Authors.
+# Copyright openbkn.ai
 #
 # Licensed under the Apache License, Version 2.0.
 # See the LICENSE file in the project root for details.

--- a/data-migrator/server/db/dialect/dm8.py
+++ b/data-migrator/server/db/dialect/dm8.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
-# Copyright The kweaver.ai Authors.
+# Copyright openbkn.ai
 #
 # Licensed under the Apache License, Version 2.0.
 # See the LICENSE file in the project root for details.

--- a/data-migrator/server/db/dialect/factory.py
+++ b/data-migrator/server/db/dialect/factory.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
-# Copyright The kweaver.ai Authors.
+# Copyright openbkn.ai
 #
 # Licensed under the Apache License, Version 2.0.
 # See the LICENSE file in the project root for details.

--- a/data-migrator/server/db/dialect/goldendb.py
+++ b/data-migrator/server/db/dialect/goldendb.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
-# Copyright The kweaver.ai Authors.
+# Copyright openbkn.ai
 #
 # Licensed under the Apache License, Version 2.0.
 # See the LICENSE file in the project root for details.

--- a/data-migrator/server/db/dialect/kdb9.py
+++ b/data-migrator/server/db/dialect/kdb9.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
-# Copyright The kweaver.ai Authors.
+# Copyright openbkn.ai
 #
 # Licensed under the Apache License, Version 2.0.
 # See the LICENSE file in the project root for details.

--- a/data-migrator/server/db/dialect/mariadb.py
+++ b/data-migrator/server/db/dialect/mariadb.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
-# Copyright The kweaver.ai Authors.
+# Copyright openbkn.ai
 #
 # Licensed under the Apache License, Version 2.0.
 # See the LICENSE file in the project root for details.

--- a/data-migrator/server/db/dialect/mysql.py
+++ b/data-migrator/server/db/dialect/mysql.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
-# Copyright The kweaver.ai Authors.
+# Copyright openbkn.ai
 #
 # Licensed under the Apache License, Version 2.0.
 # See the LICENSE file in the project root for details.

--- a/data-migrator/server/db/dialect/tidb.py
+++ b/data-migrator/server/db/dialect/tidb.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
-# Copyright The kweaver.ai Authors.
+# Copyright openbkn.ai
 #
 # Licensed under the Apache License, Version 2.0.
 # See the LICENSE file in the project root for details.

--- a/data-migrator/server/db/operate.py
+++ b/data-migrator/server/db/operate.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
-# Copyright The kweaver.ai Authors.
+# Copyright openbkn.ai
 #
 # Licensed under the Apache License, Version 2.0.
 # See the LICENSE file in the project root for details.

--- a/data-migrator/server/fetch/__init__.py
+++ b/data-migrator/server/fetch/__init__.py
@@ -1,4 +1,4 @@
-# Copyright The kweaver.ai Authors.
+# Copyright openbkn.ai
 #
 # Licensed under the Apache License, Version 2.0.
 # See the LICENSE file in the project root for details.

--- a/data-migrator/server/fetch/executor.py
+++ b/data-migrator/server/fetch/executor.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
-# Copyright The kweaver.ai Authors.
+# Copyright openbkn.ai
 #
 # Licensed under the Apache License, Version 2.0.
 # See the LICENSE file in the project root for details.

--- a/data-migrator/server/lint/__init__.py
+++ b/data-migrator/server/lint/__init__.py
@@ -1,4 +1,4 @@
-# Copyright The kweaver.ai Authors.
+# Copyright openbkn.ai
 #
 # Licensed under the Apache License, Version 2.0.
 # See the LICENSE file in the project root for details.

--- a/data-migrator/server/lint/executor.py
+++ b/data-migrator/server/lint/executor.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
-# Copyright The kweaver.ai Authors.
+# Copyright openbkn.ai
 #
 # Licensed under the Apache License, Version 2.0.
 # See the LICENSE file in the project root for details.

--- a/data-migrator/server/lint/rds/__init__.py
+++ b/data-migrator/server/lint/rds/__init__.py
@@ -1,4 +1,4 @@
-# Copyright The kweaver.ai Authors.
+# Copyright openbkn.ai
 #
 # Licensed under the Apache License, Version 2.0.
 # See the LICENSE file in the project root for details.

--- a/data-migrator/server/lint/rds/base.py
+++ b/data-migrator/server/lint/rds/base.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
-# Copyright The kweaver.ai Authors.
+# Copyright openbkn.ai
 #
 # Licensed under the Apache License, Version 2.0.
 # See the LICENSE file in the project root for details.

--- a/data-migrator/server/lint/rds/dm8.py
+++ b/data-migrator/server/lint/rds/dm8.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
-# Copyright The kweaver.ai Authors.
+# Copyright openbkn.ai
 #
 # Licensed under the Apache License, Version 2.0.
 # See the LICENSE file in the project root for details.

--- a/data-migrator/server/lint/rds/kdb9.py
+++ b/data-migrator/server/lint/rds/kdb9.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
-# Copyright The kweaver.ai Authors.
+# Copyright openbkn.ai
 #
 # Licensed under the Apache License, Version 2.0.
 # See the LICENSE file in the project root for details.

--- a/data-migrator/server/lint/rds/mariadb.py
+++ b/data-migrator/server/lint/rds/mariadb.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
-# Copyright The kweaver.ai Authors.
+# Copyright openbkn.ai
 #
 # Licensed under the Apache License, Version 2.0.
 # See the LICENSE file in the project root for details.

--- a/data-migrator/server/migrate/__init__.py
+++ b/data-migrator/server/migrate/__init__.py
@@ -1,4 +1,4 @@
-# Copyright The kweaver.ai Authors.
+# Copyright openbkn.ai
 #
 # Licensed under the Apache License, Version 2.0.
 # See the LICENSE file in the project root for details.

--- a/data-migrator/server/migrate/executor.py
+++ b/data-migrator/server/migrate/executor.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
-# Copyright The kweaver.ai Authors.
+# Copyright openbkn.ai
 #
 # Licensed under the Apache License, Version 2.0.
 # See the LICENSE file in the project root for details.

--- a/data-migrator/server/migrate/history_manager.py
+++ b/data-migrator/server/migrate/history_manager.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
-# Copyright The kweaver.ai Authors.
+# Copyright openbkn.ai
 #
 # Licensed under the Apache License, Version 2.0.
 # See the LICENSE file in the project root for details.

--- a/data-migrator/server/migrate/json_executor.py
+++ b/data-migrator/server/migrate/json_executor.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
-# Copyright The kweaver.ai Authors.
+# Copyright openbkn.ai
 #
 # Licensed under the Apache License, Version 2.0.
 # See the LICENSE file in the project root for details.

--- a/data-migrator/server/migrate/script_selector.py
+++ b/data-migrator/server/migrate/script_selector.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
-# Copyright The kweaver.ai Authors.
+# Copyright openbkn.ai
 #
 # Licensed under the Apache License, Version 2.0.
 # See the LICENSE file in the project root for details.

--- a/data-migrator/server/migrate/task_manager.py
+++ b/data-migrator/server/migrate/task_manager.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
-# Copyright The kweaver.ai Authors.
+# Copyright openbkn.ai
 #
 # Licensed under the Apache License, Version 2.0.
 # See the LICENSE file in the project root for details.

--- a/data-migrator/server/utils/__init__.py
+++ b/data-migrator/server/utils/__init__.py
@@ -1,4 +1,4 @@
-# Copyright The kweaver.ai Authors.
+# Copyright openbkn.ai
 #
 # Licensed under the Apache License, Version 2.0.
 # See the LICENSE file in the project root for details.

--- a/data-migrator/server/utils/log.py
+++ b/data-migrator/server/utils/log.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
-# Copyright The kweaver.ai Authors.
+# Copyright openbkn.ai
 #
 # Licensed under the Apache License, Version 2.0.
 # See the LICENSE file in the project root for details.

--- a/data-migrator/server/utils/sql.py
+++ b/data-migrator/server/utils/sql.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
-# Copyright The kweaver.ai Authors.
+# Copyright openbkn.ai
 #
 # Licensed under the Apache License, Version 2.0.
 # See the LICENSE file in the project root for details.

--- a/data-migrator/server/utils/table_define.py
+++ b/data-migrator/server/utils/table_define.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
-# Copyright The kweaver.ai Authors.
+# Copyright openbkn.ai
 #
 # Licensed under the Apache License, Version 2.0.
 # See the LICENSE file in the project root for details.

--- a/data-migrator/server/utils/token.py
+++ b/data-migrator/server/utils/token.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
-# Copyright The kweaver.ai Authors.
+# Copyright openbkn.ai
 #
 # Licensed under the Apache License, Version 2.0.
 # See the LICENSE file in the project root for details.

--- a/data-migrator/server/utils/version.py
+++ b/data-migrator/server/utils/version.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
-# Copyright The kweaver.ai Authors.
+# Copyright openbkn.ai
 #
 # Licensed under the Apache License, Version 2.0.
 # See the LICENSE file in the project root for details.

--- a/data-migrator/server/verify/__init__.py
+++ b/data-migrator/server/verify/__init__.py
@@ -1,4 +1,4 @@
-# Copyright The kweaver.ai Authors.
+# Copyright openbkn.ai
 #
 # Licensed under the Apache License, Version 2.0.
 # See the LICENSE file in the project root for details.

--- a/data-migrator/server/verify/executor.py
+++ b/data-migrator/server/verify/executor.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
-# Copyright The kweaver.ai Authors.
+# Copyright openbkn.ai
 #
 # Licensed under the Apache License, Version 2.0.
 # See the LICENSE file in the project root for details.

--- a/data-migrator/server/verify/rds/__init__.py
+++ b/data-migrator/server/verify/rds/__init__.py
@@ -1,4 +1,4 @@
-# Copyright The kweaver.ai Authors.
+# Copyright openbkn.ai
 #
 # Licensed under the Apache License, Version 2.0.
 # See the LICENSE file in the project root for details.

--- a/data-migrator/server/verify/rds/dm8.py
+++ b/data-migrator/server/verify/rds/dm8.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
-# Copyright The kweaver.ai Authors.
+# Copyright openbkn.ai
 #
 # Licensed under the Apache License, Version 2.0.
 # See the LICENSE file in the project root for details.

--- a/data-migrator/server/verify/rds/kdb9.py
+++ b/data-migrator/server/verify/rds/kdb9.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
-# Copyright The kweaver.ai Authors.
+# Copyright openbkn.ai
 #
 # Licensed under the Apache License, Version 2.0.
 # See the LICENSE file in the project root for details.

--- a/data-migrator/server/verify/rds/mariadb.py
+++ b/data-migrator/server/verify/rds/mariadb.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
-# Copyright The kweaver.ai Authors.
+# Copyright openbkn.ai
 #
 # Licensed under the Apache License, Version 2.0.
 # See the LICENSE file in the project root for details.

--- a/data-migrator/server/verify/rds/mysql.py
+++ b/data-migrator/server/verify/rds/mysql.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
-# Copyright The kweaver.ai Authors.
+# Copyright openbkn.ai
 #
 # Licensed under the Apache License, Version 2.0.
 # See the LICENSE file in the project root for details.

--- a/data-migrator/tests/unit/__init__.py
+++ b/data-migrator/tests/unit/__init__.py
@@ -1,4 +1,4 @@
-# Copyright The kweaver.ai Authors.
+# Copyright openbkn.ai
 #
 # Licensed under the Apache License, Version 2.0.
 # See the LICENSE file in the project root for details.

--- a/data-migrator/tests/unit/conftest.py
+++ b/data-migrator/tests/unit/conftest.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
-# Copyright The kweaver.ai Authors.
+# Copyright openbkn.ai
 #
 # Licensed under the Apache License, Version 2.0.
 # See the LICENSE file in the project root for details.

--- a/data-migrator/tests/unit/test_ensure_deploy_tables.py
+++ b/data-migrator/tests/unit/test_ensure_deploy_tables.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
-# Copyright The kweaver.ai Authors.
+# Copyright openbkn.ai
 #
 # Licensed under the Apache License, Version 2.0.
 # See the LICENSE file in the project root for details.

--- a/data-migrator/tests/unit/test_execute_upgrade_files.py
+++ b/data-migrator/tests/unit/test_execute_upgrade_files.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
-# Copyright The kweaver.ai Authors.
+# Copyright openbkn.ai
 #
 # Licensed under the Apache License, Version 2.0.
 # See the LICENSE file in the project root for details.

--- a/data-migrator/tests/unit/test_fetch_executor.py
+++ b/data-migrator/tests/unit/test_fetch_executor.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
-# Copyright The kweaver.ai Authors.
+# Copyright openbkn.ai
 #
 # Licensed under the Apache License, Version 2.0.
 # See the LICENSE file in the project root for details.

--- a/data-migrator/tests/unit/test_history_manager.py
+++ b/data-migrator/tests/unit/test_history_manager.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
-# Copyright The kweaver.ai Authors.
+# Copyright openbkn.ai
 #
 # Licensed under the Apache License, Version 2.0.
 # See the LICENSE file in the project root for details.

--- a/data-migrator/tests/unit/test_lint/__init__.py
+++ b/data-migrator/tests/unit/test_lint/__init__.py
@@ -1,4 +1,4 @@
-# Copyright The kweaver.ai Authors.
+# Copyright openbkn.ai
 #
 # Licensed under the Apache License, Version 2.0.
 # See the LICENSE file in the project root for details.

--- a/data-migrator/tests/unit/test_lint/test_lint_dm8.py
+++ b/data-migrator/tests/unit/test_lint/test_lint_dm8.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
-# Copyright The kweaver.ai Authors.
+# Copyright openbkn.ai
 #
 # Licensed under the Apache License, Version 2.0.
 # See the LICENSE file in the project root for details.

--- a/data-migrator/tests/unit/test_lint/test_lint_kdb9.py
+++ b/data-migrator/tests/unit/test_lint/test_lint_kdb9.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
-# Copyright The kweaver.ai Authors.
+# Copyright openbkn.ai
 #
 # Licensed under the Apache License, Version 2.0.
 # See the LICENSE file in the project root for details.

--- a/data-migrator/tests/unit/test_lint/test_lint_mariadb.py
+++ b/data-migrator/tests/unit/test_lint/test_lint_mariadb.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
-# Copyright The kweaver.ai Authors.
+# Copyright openbkn.ai
 #
 # Licensed under the Apache License, Version 2.0.
 # See the LICENSE file in the project root for details.

--- a/data-migrator/tests/unit/test_migrate_service.py
+++ b/data-migrator/tests/unit/test_migrate_service.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
-# Copyright The kweaver.ai Authors.
+# Copyright openbkn.ai
 #
 # Licensed under the Apache License, Version 2.0.
 # See the LICENSE file in the project root for details.

--- a/data-migrator/tests/unit/test_parser_mariadb.py
+++ b/data-migrator/tests/unit/test_parser_mariadb.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
-# Copyright The kweaver.ai Authors.
+# Copyright openbkn.ai
 #
 # Licensed under the Apache License, Version 2.0.
 # See the LICENSE file in the project root for details.

--- a/data-migrator/tests/unit/test_rds_config.py
+++ b/data-migrator/tests/unit/test_rds_config.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
-# Copyright The kweaver.ai Authors.
+# Copyright openbkn.ai
 #
 # Licensed under the Apache License, Version 2.0.
 # See the LICENSE file in the project root for details.

--- a/data-migrator/tests/unit/test_run_script.py
+++ b/data-migrator/tests/unit/test_run_script.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
-# Copyright The kweaver.ai Authors.
+# Copyright openbkn.ai
 #
 # Licensed under the Apache License, Version 2.0.
 # See the LICENSE file in the project root for details.

--- a/data-migrator/tests/unit/test_script_selector.py
+++ b/data-migrator/tests/unit/test_script_selector.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
-# Copyright The kweaver.ai Authors.
+# Copyright openbkn.ai
 #
 # Licensed under the Apache License, Version 2.0.
 # See the LICENSE file in the project root for details.

--- a/data-migrator/tests/unit/test_task_manager.py
+++ b/data-migrator/tests/unit/test_task_manager.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
-# Copyright The kweaver.ai Authors.
+# Copyright openbkn.ai
 #
 # Licensed under the Apache License, Version 2.0.
 # See the LICENSE file in the project root for details.

--- a/data-migrator/tests/unit/test_token.py
+++ b/data-migrator/tests/unit/test_token.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
-# Copyright The kweaver.ai Authors.
+# Copyright openbkn.ai
 #
 # Licensed under the Apache License, Version 2.0.
 # See the LICENSE file in the project root for details.

--- a/data-migrator/tests/unit/test_version.py
+++ b/data-migrator/tests/unit/test_version.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
-# Copyright The kweaver.ai Authors.
+# Copyright openbkn.ai
 #
 # Licensed under the Apache License, Version 2.0.
 # See the LICENSE file in the project root for details.


### PR DESCRIPTION
## What

Mechanical copyright-header normalization across all source files. **839 files, header-only, zero code changes** (839 insertions / 867 deletions; the -28 net is the removed kweaver lines).

## Why

- Net-new files (written after the KWeaver fork) were carrying a `Copyright The kweaver.ai Authors.` notice they should not — they are not derived from KWeaver.
- The openbkn copyright line pinned a year (`2026`) that adds no legal value and diverged from the yearless `Copyright The kweaver.ai Authors.` style.

## Changes

| Op | Files | Effect |
|----|-------|--------|
| Drop year | ~743 | `Copyright 2026 openbkn.ai` → `Copyright openbkn.ai` |
| Strip kweaver line | 28 | net-new dual-header files → openbkn-only |
| Swap kweaver → openbkn | 68 | net-new kweaver-only headers → openbkn, Apache grant kept |

## Provenance method

Fork boundary = `f004249a` (rebrand from KWeaver). Each net-new file confirmed via `git log --follow`, so renamed-but-derived files are **not** misclassified (0 false positives across 100 candidates).

## Safeguards

- **743 KWeaver-derived files keep** their `Copyright The kweaver.ai Authors.` line unchanged — required by Apache-2.0 §4(c).
- Files mentioning `kweaver` only in an import path or docstring were left intact.
- No-header files (1010) were left as-is; no headers added.

## Post-state

| Header | Count |
|--------|-------|
| none | 1010 |
| both (openbkn+kweaver) | 743 (all KWeaver-derived) |
| openbkn-only | 211 |
| kweaver-only | 0 |

Verified: 0 residual `Copyright 2026 openbkn.ai`; 0 net-new files with a kweaver copyright notice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)