### PR TITLE
chore: license net-new files under OpenBKN License

### DIFF
--- a/adp/bkn/bkn-backend/server/drivenadapters/permission/shadow.go
+++ b/adp/bkn/bkn-backend/server/drivenadapters/permission/shadow.go
@@ -1,3 +1,7 @@
+// Copyright openbkn.ai
+//
+// Licensed under the OpenBKN License. See LICENSE-OPENBKN.txt in the project root.
+
 package permission
 
 import (

--- a/adp/context-loader/agent-retrieval/server/drivenadapters/appkey.go
+++ b/adp/context-loader/agent-retrieval/server/drivenadapters/appkey.go
@@ -1,7 +1,6 @@
 // Copyright openbkn.ai
 //
-// Licensed under the Apache License, Version 2.0.
-// See the LICENSE file in the project root for details.
+// Licensed under the OpenBKN License. See LICENSE-OPENBKN.txt in the project root.
 
 package drivenadapters
 

--- a/adp/context-loader/agent-retrieval/server/drivenadapters/appkey_test.go
+++ b/adp/context-loader/agent-retrieval/server/drivenadapters/appkey_test.go
@@ -1,7 +1,6 @@
 // Copyright openbkn.ai
 //
-// Licensed under the Apache License, Version 2.0.
-// See the LICENSE file in the project root for details.
+// Licensed under the OpenBKN License. See LICENSE-OPENBKN.txt in the project root.
 
 package drivenadapters
 

--- a/adp/context-loader/agent-retrieval/server/drivenadapters/expand_filters_test.go
+++ b/adp/context-loader/agent-retrieval/server/drivenadapters/expand_filters_test.go
@@ -1,7 +1,6 @@
 // Copyright openbkn.ai
 //
-// Licensed under the Apache License, Version 2.0.
-// See the LICENSE file in the project root for details.
+// Licensed under the OpenBKN License. See LICENSE-OPENBKN.txt in the project root.
 
 package drivenadapters
 

--- a/adp/context-loader/agent-retrieval/server/drivenadapters/vega.go
+++ b/adp/context-loader/agent-retrieval/server/drivenadapters/vega.go
@@ -1,7 +1,6 @@
 // Copyright openbkn.ai
 //
-// Licensed under the Apache License, Version 2.0.
-// See the LICENSE file in the project root for details.
+// Licensed under the OpenBKN License. See LICENSE-OPENBKN.txt in the project root.
 
 package drivenadapters
 

--- a/adp/context-loader/agent-retrieval/server/driveradapters/appkey_middleware_test.go
+++ b/adp/context-loader/agent-retrieval/server/driveradapters/appkey_middleware_test.go
@@ -1,7 +1,6 @@
 // Copyright openbkn.ai
 //
-// Licensed under the Apache License, Version 2.0.
-// See the LICENSE file in the project root for details.
+// Licensed under the OpenBKN License. See LICENSE-OPENBKN.txt in the project root.
 
 package driveradapters
 

--- a/adp/context-loader/agent-retrieval/server/driveradapters/knquerytools/index.go
+++ b/adp/context-loader/agent-retrieval/server/driveradapters/knquerytools/index.go
@@ -1,7 +1,6 @@
 // Copyright openbkn.ai
 //
-// Licensed under the Apache License, Version 2.0.
-// See the LICENSE file in the project root for details.
+// Licensed under the OpenBKN License. See LICENSE-OPENBKN.txt in the project root.
 
 // Package knquerytools provides HTTP handlers for the query tools that are also
 // exposed as MCP tools: run_sql, list_knowledge_networks, get_kn_detail,

--- a/adp/context-loader/agent-retrieval/server/driveradapters/mcp/info.go
+++ b/adp/context-loader/agent-retrieval/server/driveradapters/mcp/info.go
@@ -1,7 +1,6 @@
 // Copyright openbkn.ai
 //
-// Licensed under the Apache License, Version 2.0.
-// See the LICENSE file in the project root for details.
+// Licensed under the OpenBKN License. See LICENSE-OPENBKN.txt in the project root.
 
 package mcp
 

--- a/adp/context-loader/agent-retrieval/server/interfaces/driven_vega.go
+++ b/adp/context-loader/agent-retrieval/server/interfaces/driven_vega.go
@@ -1,7 +1,6 @@
 // Copyright openbkn.ai
 //
-// Licensed under the Apache License, Version 2.0.
-// See the LICENSE file in the project root for details.
+// Licensed under the OpenBKN License. See LICENSE-OPENBKN.txt in the project root.
 
 package interfaces
 

--- a/adp/context-loader/agent-retrieval/server/logics/knlogicpropertyresolver/dynamic_params_llm.go
+++ b/adp/context-loader/agent-retrieval/server/logics/knlogicpropertyresolver/dynamic_params_llm.go
@@ -1,7 +1,6 @@
 // Copyright openbkn.ai
 //
-// Licensed under the Apache License, Version 2.0.
-// See the LICENSE file in the project root for details.
+// Licensed under the OpenBKN License. See LICENSE-OPENBKN.txt in the project root.
 
 // Package knlogicpropertyresolver
 // file: dynamic_params_llm.go

--- a/adp/context-loader/agent-retrieval/server/logics/knresources/index.go
+++ b/adp/context-loader/agent-retrieval/server/logics/knresources/index.go
@@ -1,7 +1,6 @@
 // Copyright openbkn.ai
 //
-// Licensed under the Apache License, Version 2.0.
-// See the LICENSE file in the project root for details.
+// Licensed under the OpenBKN License. See LICENSE-OPENBKN.txt in the project root.
 
 // Package knresources 提供数据层「资源直查」能力（脱离本体）：list_resources / describe_resource。
 // 与 search_schema（本体/语义入口）互补，二者都喂给 run_sql。

--- a/adp/context-loader/agent-retrieval/server/logics/knresources/index_test.go
+++ b/adp/context-loader/agent-retrieval/server/logics/knresources/index_test.go
@@ -1,7 +1,6 @@
 // Copyright openbkn.ai
 //
-// Licensed under the Apache License, Version 2.0.
-// See the LICENSE file in the project root for details.
+// Licensed under the OpenBKN License. See LICENSE-OPENBKN.txt in the project root.
 
 package knresources
 

--- a/adp/context-loader/agent-retrieval/server/logics/knrunsql/index.go
+++ b/adp/context-loader/agent-retrieval/server/logics/knrunsql/index.go
@@ -1,7 +1,6 @@
 // Copyright openbkn.ai
 //
-// Licensed under the Apache License, Version 2.0.
-// See the LICENSE file in the project root for details.
+// Licensed under the OpenBKN License. See LICENSE-OPENBKN.txt in the project root.
 
 package knrunsql
 

--- a/adp/context-loader/agent-retrieval/server/logics/knsearch/mapped_field_column_test.go
+++ b/adp/context-loader/agent-retrieval/server/logics/knsearch/mapped_field_column_test.go
@@ -1,7 +1,6 @@
 // Copyright openbkn.ai
 //
-// Licensed under the Apache License, Version 2.0.
-// See the LICENSE file in the project root for details.
+// Licensed under the OpenBKN License. See LICENSE-OPENBKN.txt in the project root.
 
 package knsearch
 

--- a/adp/execution-factory/capabilities-lab/server/client/category.go
+++ b/adp/execution-factory/capabilities-lab/server/client/category.go
@@ -1,3 +1,7 @@
+// Copyright openbkn.ai
+//
+// Licensed under the OpenBKN License. See LICENSE-OPENBKN.txt in the project root.
+
 package client
 
 import (

--- a/adp/execution-factory/capabilities-lab/server/client/extensions.go
+++ b/adp/execution-factory/capabilities-lab/server/client/extensions.go
@@ -1,3 +1,7 @@
+// Copyright openbkn.ai
+//
+// Licensed under the OpenBKN License. See LICENSE-OPENBKN.txt in the project root.
+
 package client
 
 import (

--- a/adp/execution-factory/capabilities-lab/server/client/function.go
+++ b/adp/execution-factory/capabilities-lab/server/client/function.go
@@ -1,3 +1,7 @@
+// Copyright openbkn.ai
+//
+// Licensed under the OpenBKN License. See LICENSE-OPENBKN.txt in the project root.
+
 package client
 
 import (

--- a/adp/execution-factory/capabilities-lab/server/client/impex.go
+++ b/adp/execution-factory/capabilities-lab/server/client/impex.go
@@ -1,3 +1,7 @@
+// Copyright openbkn.ai
+//
+// Licensed under the OpenBKN License. See LICENSE-OPENBKN.txt in the project root.
+
 package client
 
 import (

--- a/adp/execution-factory/capabilities-lab/server/client/lifecycle.go
+++ b/adp/execution-factory/capabilities-lab/server/client/lifecycle.go
@@ -1,3 +1,7 @@
+// Copyright openbkn.ai
+//
+// Licensed under the OpenBKN License. See LICENSE-OPENBKN.txt in the project root.
+
 package client
 
 import (

--- a/adp/execution-factory/capabilities-lab/server/client/lineage.go
+++ b/adp/execution-factory/capabilities-lab/server/client/lineage.go
@@ -1,3 +1,7 @@
+// Copyright openbkn.ai
+//
+// Licensed under the OpenBKN License. See LICENSE-OPENBKN.txt in the project root.
+
 package client
 
 import (

--- a/adp/execution-factory/capabilities-lab/server/client/market.go
+++ b/adp/execution-factory/capabilities-lab/server/client/market.go
@@ -1,3 +1,7 @@
+// Copyright openbkn.ai
+//
+// Licensed under the OpenBKN License. See LICENSE-OPENBKN.txt in the project root.
+
 package client
 
 import (

--- a/adp/execution-factory/capabilities-lab/server/client/mcp_detail.go
+++ b/adp/execution-factory/capabilities-lab/server/client/mcp_detail.go
@@ -1,3 +1,7 @@
+// Copyright openbkn.ai
+//
+// Licensed under the OpenBKN License. See LICENSE-OPENBKN.txt in the project root.
+
 package client
 
 import (

--- a/adp/execution-factory/capabilities-lab/server/client/operator_integration.go
+++ b/adp/execution-factory/capabilities-lab/server/client/operator_integration.go
@@ -1,3 +1,7 @@
+// Copyright openbkn.ai
+//
+// Licensed under the OpenBKN License. See LICENSE-OPENBKN.txt in the project root.
+
 package client
 
 import (

--- a/adp/execution-factory/capabilities-lab/server/client/operator_integration_test.go
+++ b/adp/execution-factory/capabilities-lab/server/client/operator_integration_test.go
@@ -1,3 +1,7 @@
+// Copyright openbkn.ai
+//
+// Licensed under the OpenBKN License. See LICENSE-OPENBKN.txt in the project root.
+
 package client
 
 import (

--- a/adp/execution-factory/capabilities-lab/server/client/skill_mcp_wizard.go
+++ b/adp/execution-factory/capabilities-lab/server/client/skill_mcp_wizard.go
@@ -1,3 +1,7 @@
+// Copyright openbkn.ai
+//
+// Licensed under the OpenBKN License. See LICENSE-OPENBKN.txt in the project root.
+
 package client
 
 import (

--- a/adp/execution-factory/capabilities-lab/server/config/config.go
+++ b/adp/execution-factory/capabilities-lab/server/config/config.go
@@ -1,3 +1,7 @@
+// Copyright openbkn.ai
+//
+// Licensed under the OpenBKN License. See LICENSE-OPENBKN.txt in the project root.
+
 package config
 
 import (

--- a/adp/execution-factory/capabilities-lab/server/config/features.go
+++ b/adp/execution-factory/capabilities-lab/server/config/features.go
@@ -1,3 +1,7 @@
+// Copyright openbkn.ai
+//
+// Licensed under the OpenBKN License. See LICENSE-OPENBKN.txt in the project root.
+
 package config
 
 import "os"

--- a/adp/execution-factory/capabilities-lab/server/config/features_test.go
+++ b/adp/execution-factory/capabilities-lab/server/config/features_test.go
@@ -1,3 +1,7 @@
+// Copyright openbkn.ai
+//
+// Licensed under the OpenBKN License. See LICENSE-OPENBKN.txt in the project root.
+
 package config
 
 import "testing"

--- a/adp/execution-factory/capabilities-lab/server/handler/capabilities.go
+++ b/adp/execution-factory/capabilities-lab/server/handler/capabilities.go
@@ -1,3 +1,7 @@
+// Copyright openbkn.ai
+//
+// Licensed under the OpenBKN License. See LICENSE-OPENBKN.txt in the project root.
+
 package handler
 
 import (

--- a/adp/execution-factory/capabilities-lab/server/handler/gap_fill.go
+++ b/adp/execution-factory/capabilities-lab/server/handler/gap_fill.go
@@ -1,3 +1,7 @@
+// Copyright openbkn.ai
+//
+// Licensed under the OpenBKN License. See LICENSE-OPENBKN.txt in the project root.
+
 package handler
 
 import (

--- a/adp/execution-factory/capabilities-lab/server/handler/meta.go
+++ b/adp/execution-factory/capabilities-lab/server/handler/meta.go
@@ -1,3 +1,7 @@
+// Copyright openbkn.ai
+//
+// Licensed under the OpenBKN License. See LICENSE-OPENBKN.txt in the project root.
+
 package handler
 
 import (

--- a/adp/execution-factory/capabilities-lab/server/handler/middleware.go
+++ b/adp/execution-factory/capabilities-lab/server/handler/middleware.go
@@ -1,3 +1,7 @@
+// Copyright openbkn.ai
+//
+// Licensed under the OpenBKN License. See LICENSE-OPENBKN.txt in the project root.
+
 package handler
 
 import (

--- a/adp/execution-factory/capabilities-lab/server/handler/observability.go
+++ b/adp/execution-factory/capabilities-lab/server/handler/observability.go
@@ -1,3 +1,7 @@
+// Copyright openbkn.ai
+//
+// Licensed under the OpenBKN License. See LICENSE-OPENBKN.txt in the project root.
+
 package handler
 
 import (

--- a/adp/execution-factory/capabilities-lab/server/logic/actions.go
+++ b/adp/execution-factory/capabilities-lab/server/logic/actions.go
@@ -1,3 +1,7 @@
+// Copyright openbkn.ai
+//
+// Licensed under the OpenBKN License. See LICENSE-OPENBKN.txt in the project root.
+
 package logic
 
 import (

--- a/adp/execution-factory/capabilities-lab/server/logic/actions_orchestration_test.go
+++ b/adp/execution-factory/capabilities-lab/server/logic/actions_orchestration_test.go
@@ -1,3 +1,7 @@
+// Copyright openbkn.ai
+//
+// Licensed under the OpenBKN License. See LICENSE-OPENBKN.txt in the project root.
+
 package logic
 
 import (

--- a/adp/execution-factory/capabilities-lab/server/logic/audit.go
+++ b/adp/execution-factory/capabilities-lab/server/logic/audit.go
@@ -1,3 +1,7 @@
+// Copyright openbkn.ai
+//
+// Licensed under the OpenBKN License. See LICENSE-OPENBKN.txt in the project root.
+
 package logic
 
 import (

--- a/adp/execution-factory/capabilities-lab/server/logic/capability_get.go
+++ b/adp/execution-factory/capabilities-lab/server/logic/capability_get.go
@@ -1,3 +1,7 @@
+// Copyright openbkn.ai
+//
+// Licensed under the OpenBKN License. See LICENSE-OPENBKN.txt in the project root.
+
 package logic
 
 import (

--- a/adp/execution-factory/capabilities-lab/server/logic/capability_id.go
+++ b/adp/execution-factory/capabilities-lab/server/logic/capability_id.go
@@ -1,3 +1,7 @@
+// Copyright openbkn.ai
+//
+// Licensed under the OpenBKN License. See LICENSE-OPENBKN.txt in the project root.
+
 package logic
 
 import (

--- a/adp/execution-factory/capabilities-lab/server/logic/capability_id_test.go
+++ b/adp/execution-factory/capabilities-lab/server/logic/capability_id_test.go
@@ -1,3 +1,7 @@
+// Copyright openbkn.ai
+//
+// Licensed under the OpenBKN License. See LICENSE-OPENBKN.txt in the project root.
+
 package logic
 
 import "testing"

--- a/adp/execution-factory/capabilities-lab/server/logic/catalog.go
+++ b/adp/execution-factory/capabilities-lab/server/logic/catalog.go
@@ -1,3 +1,7 @@
+// Copyright openbkn.ai
+//
+// Licensed under the OpenBKN License. See LICENSE-OPENBKN.txt in the project root.
+
 package logic
 
 import (

--- a/adp/execution-factory/capabilities-lab/server/logic/function.go
+++ b/adp/execution-factory/capabilities-lab/server/logic/function.go
@@ -1,3 +1,7 @@
+// Copyright openbkn.ai
+//
+// Licensed under the OpenBKN License. See LICENSE-OPENBKN.txt in the project root.
+
 package logic
 
 import (

--- a/adp/execution-factory/capabilities-lab/server/logic/gap_fill.go
+++ b/adp/execution-factory/capabilities-lab/server/logic/gap_fill.go
@@ -1,3 +1,7 @@
+// Copyright openbkn.ai
+//
+// Licensed under the OpenBKN License. See LICENSE-OPENBKN.txt in the project root.
+
 package logic
 
 import (

--- a/adp/execution-factory/capabilities-lab/server/logic/group_name.go
+++ b/adp/execution-factory/capabilities-lab/server/logic/group_name.go
@@ -1,3 +1,7 @@
+// Copyright openbkn.ai
+//
+// Licensed under the OpenBKN License. See LICENSE-OPENBKN.txt in the project root.
+
 package logic
 
 import (

--- a/adp/execution-factory/capabilities-lab/server/logic/group_name_test.go
+++ b/adp/execution-factory/capabilities-lab/server/logic/group_name_test.go
@@ -1,3 +1,7 @@
+// Copyright openbkn.ai
+//
+// Licensed under the OpenBKN License. See LICENSE-OPENBKN.txt in the project root.
+
 package logic
 
 import "testing"

--- a/adp/execution-factory/capabilities-lab/server/logic/impex.go
+++ b/adp/execution-factory/capabilities-lab/server/logic/impex.go
@@ -1,3 +1,7 @@
+// Copyright openbkn.ai
+//
+// Licensed under the OpenBKN License. See LICENSE-OPENBKN.txt in the project root.
+
 package logic
 
 import (

--- a/adp/execution-factory/capabilities-lab/server/logic/impex_clone.go
+++ b/adp/execution-factory/capabilities-lab/server/logic/impex_clone.go
@@ -1,3 +1,7 @@
+// Copyright openbkn.ai
+//
+// Licensed under the OpenBKN License. See LICENSE-OPENBKN.txt in the project root.
+
 package logic
 
 import (

--- a/adp/execution-factory/capabilities-lab/server/logic/lifecycle.go
+++ b/adp/execution-factory/capabilities-lab/server/logic/lifecycle.go
@@ -1,3 +1,7 @@
+// Copyright openbkn.ai
+//
+// Licensed under the OpenBKN License. See LICENSE-OPENBKN.txt in the project root.
+
 package logic
 
 import (

--- a/adp/execution-factory/capabilities-lab/server/logic/list_filters.go
+++ b/adp/execution-factory/capabilities-lab/server/logic/list_filters.go
@@ -1,3 +1,7 @@
+// Copyright openbkn.ai
+//
+// Licensed under the OpenBKN License. See LICENSE-OPENBKN.txt in the project root.
+
 package logic
 
 import (

--- a/adp/execution-factory/capabilities-lab/server/logic/list_unified.go
+++ b/adp/execution-factory/capabilities-lab/server/logic/list_unified.go
@@ -1,3 +1,7 @@
+// Copyright openbkn.ai
+//
+// Licensed under the OpenBKN License. See LICENSE-OPENBKN.txt in the project root.
+
 package logic
 
 import (

--- a/adp/execution-factory/capabilities-lab/server/logic/metadata_function.go
+++ b/adp/execution-factory/capabilities-lab/server/logic/metadata_function.go
@@ -1,3 +1,7 @@
+// Copyright openbkn.ai
+//
+// Licensed under the OpenBKN License. See LICENSE-OPENBKN.txt in the project root.
+
 package logic
 
 import (

--- a/adp/execution-factory/capabilities-lab/server/logic/metadata_function_test.go
+++ b/adp/execution-factory/capabilities-lab/server/logic/metadata_function_test.go
@@ -1,3 +1,7 @@
+// Copyright openbkn.ai
+//
+// Licensed under the OpenBKN License. See LICENSE-OPENBKN.txt in the project root.
+
 package logic
 
 import (

--- a/adp/execution-factory/capabilities-lab/server/logic/metadata_openapi.go
+++ b/adp/execution-factory/capabilities-lab/server/logic/metadata_openapi.go
@@ -1,3 +1,7 @@
+// Copyright openbkn.ai
+//
+// Licensed under the OpenBKN License. See LICENSE-OPENBKN.txt in the project root.
+
 package logic
 
 import (

--- a/adp/execution-factory/capabilities-lab/server/logic/openapi_patch.go
+++ b/adp/execution-factory/capabilities-lab/server/logic/openapi_patch.go
@@ -1,3 +1,7 @@
+// Copyright openbkn.ai
+//
+// Licensed under the OpenBKN License. See LICENSE-OPENBKN.txt in the project root.
+
 package logic
 
 import "encoding/json"

--- a/adp/execution-factory/capabilities-lab/server/logic/orchestration.go
+++ b/adp/execution-factory/capabilities-lab/server/logic/orchestration.go
@@ -1,3 +1,7 @@
+// Copyright openbkn.ai
+//
+// Licensed under the OpenBKN License. See LICENSE-OPENBKN.txt in the project root.
+
 package logic
 
 import (

--- a/adp/execution-factory/capabilities-lab/server/logic/service.go
+++ b/adp/execution-factory/capabilities-lab/server/logic/service.go
@@ -1,3 +1,7 @@
+// Copyright openbkn.ai
+//
+// Licensed under the OpenBKN License. See LICENSE-OPENBKN.txt in the project root.
+
 package logic
 
 import (

--- a/adp/execution-factory/capabilities-lab/server/main.go
+++ b/adp/execution-factory/capabilities-lab/server/main.go
@@ -1,3 +1,7 @@
+// Copyright openbkn.ai
+//
+// Licensed under the OpenBKN License. See LICENSE-OPENBKN.txt in the project root.
+
 package main
 
 import (

--- a/adp/execution-factory/capabilities-lab/server/model/catalog.go
+++ b/adp/execution-factory/capabilities-lab/server/model/catalog.go
@@ -1,3 +1,7 @@
+// Copyright openbkn.ai
+//
+// Licensed under the OpenBKN License. See LICENSE-OPENBKN.txt in the project root.
+
 package model
 
 type CatalogEntry struct {

--- a/adp/execution-factory/capabilities-lab/server/model/extensions.go
+++ b/adp/execution-factory/capabilities-lab/server/model/extensions.go
@@ -1,3 +1,7 @@
+// Copyright openbkn.ai
+//
+// Licensed under the OpenBKN License. See LICENSE-OPENBKN.txt in the project root.
+
 package model
 
 type FunctionParameterDef struct {

--- a/adp/execution-factory/capabilities-lab/server/model/types.go
+++ b/adp/execution-factory/capabilities-lab/server/model/types.go
@@ -1,3 +1,7 @@
+// Copyright openbkn.ai
+//
+// Licensed under the OpenBKN License. See LICENSE-OPENBKN.txt in the project root.
+
 package model
 
 type Group struct {

--- a/adp/execution-factory/capabilities-lab/server/observability/audit.go
+++ b/adp/execution-factory/capabilities-lab/server/observability/audit.go
@@ -1,3 +1,7 @@
+// Copyright openbkn.ai
+//
+// Licensed under the OpenBKN License. See LICENSE-OPENBKN.txt in the project root.
+
 package observability
 
 import (

--- a/adp/execution-factory/capabilities-lab/server/observability/metrics.go
+++ b/adp/execution-factory/capabilities-lab/server/observability/metrics.go
@@ -1,3 +1,7 @@
+// Copyright openbkn.ai
+//
+// Licensed under the OpenBKN License. See LICENSE-OPENBKN.txt in the project root.
+
 package observability
 
 import (

--- a/adp/execution-factory/operator-integration/server/drivenadapters/authorization_safe.go
+++ b/adp/execution-factory/operator-integration/server/drivenadapters/authorization_safe.go
@@ -1,3 +1,7 @@
+// Copyright openbkn.ai
+//
+// Licensed under the OpenBKN License. See LICENSE-OPENBKN.txt in the project root.
+
 package drivenadapters
 
 import (

--- a/adp/execution-factory/operator-integration/server/drivenadapters/authorization_safe_integration_test.go
+++ b/adp/execution-factory/operator-integration/server/drivenadapters/authorization_safe_integration_test.go
@@ -1,5 +1,9 @@
 //go:build integration
 
+// Copyright openbkn.ai
+//
+// Licensed under the OpenBKN License. See LICENSE-OPENBKN.txt in the project root.
+
 // Integration test for the bkn-safe authz adapter against a REAL bkn-safe.
 // Run: BKN_SAFE_URL=http://127.0.0.1:13000 go test -tags integration ./drivenadapters/ -run SafeAuthz -v
 // Skipped unless BKN_SAFE_URL is set. Exercises the full Authorization interface

--- a/adp/execution-factory/operator-integration/server/drivenadapters/user_management_safe.go
+++ b/adp/execution-factory/operator-integration/server/drivenadapters/user_management_safe.go
@@ -1,3 +1,7 @@
+// Copyright openbkn.ai
+//
+// Licensed under the OpenBKN License. See LICENSE-OPENBKN.txt in the project root.
+
 package drivenadapters
 
 import (

--- a/adp/execution-factory/operator-integration/server/drivenadapters/user_management_safe_test.go
+++ b/adp/execution-factory/operator-integration/server/drivenadapters/user_management_safe_test.go
@@ -1,3 +1,7 @@
+// Copyright openbkn.ai
+//
+// Licensed under the OpenBKN License. See LICENSE-OPENBKN.txt in the project root.
+
 package drivenadapters
 
 import (

--- a/adp/execution-factory/operator-integration/server/logics/toolbox/openapi_bundle.go
+++ b/adp/execution-factory/operator-integration/server/logics/toolbox/openapi_bundle.go
@@ -1,3 +1,7 @@
+// Copyright openbkn.ai
+//
+// Licensed under the OpenBKN License. See LICENSE-OPENBKN.txt in the project root.
+
 package toolbox
 
 import (

--- a/adp/execution-factory/tests/common/__init__.py
+++ b/adp/execution-factory/tests/common/__init__.py
@@ -1,0 +1,3 @@
+# Copyright openbkn.ai
+#
+# Licensed under the OpenBKN License. See LICENSE-OPENBKN.txt in the project root.

--- a/adp/execution-factory/tests/common/assert_tools.py
+++ b/adp/execution-factory/tests/common/assert_tools.py
@@ -1,4 +1,8 @@
 # -*- coding:UTF-8 -*-
+# Copyright openbkn.ai
+#
+# Licensed under the OpenBKN License. See LICENSE-OPENBKN.txt in the project root.
+
 import json
 
 class AssertTools:

--- a/adp/execution-factory/tests/common/create_user.py
+++ b/adp/execution-factory/tests/common/create_user.py
@@ -1,4 +1,7 @@
 # -*- coding:UTF-8 -*-
+# Copyright openbkn.ai
+#
+# Licensed under the OpenBKN License. See LICENSE-OPENBKN.txt in the project root.
 
 import requests
 import json

--- a/adp/execution-factory/tests/common/delete_user.py
+++ b/adp/execution-factory/tests/common/delete_user.py
@@ -1,4 +1,7 @@
 # -*- coding:UTF-8 -*-
+# Copyright openbkn.ai
+#
+# Licensed under the OpenBKN License. See LICENSE-OPENBKN.txt in the project root.
 
 import requests
 import json

--- a/adp/execution-factory/tests/common/file_process.py
+++ b/adp/execution-factory/tests/common/file_process.py
@@ -1,4 +1,8 @@
 # -*- coding:UTF-8 -*-
+# Copyright openbkn.ai
+#
+# Licensed under the OpenBKN License. See LICENSE-OPENBKN.txt in the project root.
+
 import json
 import os
 from pathlib import Path

--- a/adp/execution-factory/tests/common/get_case_and_params.py
+++ b/adp/execution-factory/tests/common/get_case_and_params.py
@@ -1,4 +1,7 @@
 # -*- coding:UTF-8 -*-
+# Copyright openbkn.ai
+#
+# Licensed under the OpenBKN License. See LICENSE-OPENBKN.txt in the project root.
 
 from common.get_content import GetContent
 

--- a/adp/execution-factory/tests/common/get_content.py
+++ b/adp/execution-factory/tests/common/get_content.py
@@ -1,4 +1,8 @@
 # -*- coding:UTF-8 -*-
+# Copyright openbkn.ai
+#
+# Licensed under the OpenBKN License. See LICENSE-OPENBKN.txt in the project root.
+
 import configparser
 import json
 import yaml

--- a/adp/execution-factory/tests/common/get_token.py
+++ b/adp/execution-factory/tests/common/get_token.py
@@ -1,4 +1,7 @@
 # -*- coding:UTF-8 -*-
+# Copyright openbkn.ai
+#
+# Licensed under the OpenBKN License. See LICENSE-OPENBKN.txt in the project root.
 
 import os
 import sys

--- a/adp/execution-factory/tests/common/operator_db.py
+++ b/adp/execution-factory/tests/common/operator_db.py
@@ -1,4 +1,7 @@
 # -*- coding:UTF-8 -*-
+# Copyright openbkn.ai
+#
+# Licensed under the OpenBKN License. See LICENSE-OPENBKN.txt in the project root.
 
 import pymysql
 

--- a/adp/execution-factory/tests/common/request.py
+++ b/adp/execution-factory/tests/common/request.py
@@ -1,4 +1,7 @@
 # -*- coding:UTF-8 -*-
+# Copyright openbkn.ai
+#
+# Licensed under the OpenBKN License. See LICENSE-OPENBKN.txt in the project root.
 
 import requests
 import allure

--- a/adp/execution-factory/tests/lib/__init__.py
+++ b/adp/execution-factory/tests/lib/__init__.py
@@ -1,0 +1,3 @@
+# Copyright openbkn.ai
+#
+# Licensed under the OpenBKN License. See LICENSE-OPENBKN.txt in the project root.

--- a/adp/execution-factory/tests/lib/dataflow_como_operator.py
+++ b/adp/execution-factory/tests/lib/dataflow_como_operator.py
@@ -1,4 +1,7 @@
 # -*- coding:UTF-8 -*-
+# Copyright openbkn.ai
+#
+# Licensed under the OpenBKN License. See LICENSE-OPENBKN.txt in the project root.
 
 from common.get_content import GetContent
 from common.request import Request

--- a/adp/execution-factory/tests/lib/impex.py
+++ b/adp/execution-factory/tests/lib/impex.py
@@ -1,4 +1,8 @@
 # -*- coding:UTF-8 -*-
+# Copyright openbkn.ai
+#
+# Licensed under the OpenBKN License. See LICENSE-OPENBKN.txt in the project root.
+
 import os
 
 from common.get_content import GetContent

--- a/adp/execution-factory/tests/lib/mcp.py
+++ b/adp/execution-factory/tests/lib/mcp.py
@@ -1,4 +1,8 @@
 # -*- coding:UTF-8 -*-
+# Copyright openbkn.ai
+#
+# Licensed under the OpenBKN License. See LICENSE-OPENBKN.txt in the project root.
+
 import allure
 import requests
 

--- a/adp/execution-factory/tests/lib/mcp_internal.py
+++ b/adp/execution-factory/tests/lib/mcp_internal.py
@@ -1,4 +1,8 @@
 # -*- coding:UTF-8 -*-
+# Copyright openbkn.ai
+#
+# Licensed under the OpenBKN License. See LICENSE-OPENBKN.txt in the project root.
+
 from common.request import Request
 
 class InternalMCP():

--- a/adp/execution-factory/tests/lib/operator.py
+++ b/adp/execution-factory/tests/lib/operator.py
@@ -1,4 +1,7 @@
 # -*- coding:UTF-8 -*-
+# Copyright openbkn.ai
+#
+# Licensed under the OpenBKN License. See LICENSE-OPENBKN.txt in the project root.
 
 from common.get_content import GetContent
 from common.request import Request

--- a/adp/execution-factory/tests/lib/operator_internal.py
+++ b/adp/execution-factory/tests/lib/operator_internal.py
@@ -1,4 +1,8 @@
 # -*- coding:UTF-8 -*-
+# Copyright openbkn.ai
+#
+# Licensed under the OpenBKN License. See LICENSE-OPENBKN.txt in the project root.
+
 from common.request import Request
 
 class InternalOperator():

--- a/adp/execution-factory/tests/lib/permission.py
+++ b/adp/execution-factory/tests/lib/permission.py
@@ -1,4 +1,8 @@
 # -*- coding:UTF-8 -*-
+# Copyright openbkn.ai
+#
+# Licensed under the OpenBKN License. See LICENSE-OPENBKN.txt in the project root.
+
 import allure
 import requests
 

--- a/adp/execution-factory/tests/lib/relations.py
+++ b/adp/execution-factory/tests/lib/relations.py
@@ -1,4 +1,7 @@
 # -*- coding:UTF-8 -*-
+# Copyright openbkn.ai
+#
+# Licensed under the OpenBKN License. See LICENSE-OPENBKN.txt in the project root.
 
 from common.get_content import GetContent
 from common.request import Request

--- a/adp/execution-factory/tests/lib/tool_box.py
+++ b/adp/execution-factory/tests/lib/tool_box.py
@@ -1,4 +1,7 @@
 # -*- coding:UTF-8 -*-
+# Copyright openbkn.ai
+#
+# Licensed under the OpenBKN License. See LICENSE-OPENBKN.txt in the project root.
 
 from common.get_content import GetContent
 from common.request import Request

--- a/adp/execution-factory/tests/scripts/example.sh
+++ b/adp/execution-factory/tests/scripts/example.sh
@@ -1,0 +1,3 @@
+# Copyright openbkn.ai
+#
+# Licensed under the OpenBKN License. See LICENSE-OPENBKN.txt in the project root.

--- a/adp/execution-factory/tests/scripts/operator-run.sh
+++ b/adp/execution-factory/tests/scripts/operator-run.sh
@@ -1,4 +1,8 @@
 #!/bin/bash
+# Copyright openbkn.ai
+#
+# Licensed under the OpenBKN License. See LICENSE-OPENBKN.txt in the project root.
+
 set -xv
 
 # 暴漏mariadb端口

--- a/adp/execution-factory/tests/testcases/openbkn-smoke/conftest.py
+++ b/adp/execution-factory/tests/testcases/openbkn-smoke/conftest.py
@@ -1,4 +1,8 @@
 # -*- coding: utf-8 -*-
+# Copyright openbkn.ai
+#
+# Licensed under the OpenBKN License. See LICENSE-OPENBKN.txt in the project root.
+
 """OpenBKN smoke fixtures — no KWeaver platform (eisoo/Hydra) required."""
 
 import os

--- a/adp/execution-factory/tests/testcases/openbkn-smoke/test_mcp_and_function.py
+++ b/adp/execution-factory/tests/testcases/openbkn-smoke/test_mcp_and_function.py
@@ -1,4 +1,7 @@
 # -*- coding: utf-8 -*-
+# Copyright openbkn.ai
+#
+# Licensed under the OpenBKN License. See LICENSE-OPENBKN.txt in the project root.
 
 from lib.mcp import MCP
 from lib.tool_box import ToolBox

--- a/adp/execution-factory/tests/testcases/openbkn-smoke/test_operator_category.py
+++ b/adp/execution-factory/tests/testcases/openbkn-smoke/test_operator_category.py
@@ -1,4 +1,7 @@
 # -*- coding: utf-8 -*-
+# Copyright openbkn.ai
+#
+# Licensed under the OpenBKN License. See LICENSE-OPENBKN.txt in the project root.
 
 from lib.operator import Operator
 

--- a/adp/vega/vega-backend/server/drivenadapters/build_task/build_task_order_test.go
+++ b/adp/vega/vega-backend/server/drivenadapters/build_task/build_task_order_test.go
@@ -1,7 +1,6 @@
 // Copyright openbkn.ai
 //
-// Licensed under the Apache License, Version 2.0.
-// See the LICENSE file in the project root for details.
+// Licensed under the OpenBKN License. See LICENSE-OPENBKN.txt in the project root.
 
 package build_task
 

--- a/adp/vega/vega-backend/server/drivenadapters/permission/shadow.go
+++ b/adp/vega/vega-backend/server/drivenadapters/permission/shadow.go
@@ -1,3 +1,7 @@
+// Copyright openbkn.ai
+//
+// Licensed under the OpenBKN License. See LICENSE-OPENBKN.txt in the project root.
+
 package permission
 
 import (

--- a/adp/vega/vega-backend/server/driveradapters/build_task_create_validate_test.go
+++ b/adp/vega/vega-backend/server/driveradapters/build_task_create_validate_test.go
@@ -1,7 +1,6 @@
 // Copyright openbkn.ai
 //
-// Licensed under the Apache License, Version 2.0.
-// See the LICENSE file in the project root for details.
+// Licensed under the OpenBKN License. See LICENSE-OPENBKN.txt in the project root.
 
 package driveradapters
 

--- a/adp/vega/vega-backend/server/interfaces/s2s_access.go
+++ b/adp/vega/vega-backend/server/interfaces/s2s_access.go
@@ -1,7 +1,6 @@
 // Copyright openbkn.ai
 //
-// Licensed under the Apache License, Version 2.0.
-// See the LICENSE file in the project root for details.
+// Licensed under the OpenBKN License. See LICENSE-OPENBKN.txt in the project root.
 
 package interfaces
 

--- a/adp/vega/vega-backend/server/logics/build_task/build_task_normalize_test.go
+++ b/adp/vega/vega-backend/server/logics/build_task/build_task_normalize_test.go
@@ -1,7 +1,6 @@
 // Copyright openbkn.ai
 //
-// Licensed under the Apache License, Version 2.0.
-// See the LICENSE file in the project root for details.
+// Licensed under the OpenBKN License. See LICENSE-OPENBKN.txt in the project root.
 
 package build_task
 

--- a/adp/vega/vega-backend/server/logics/cascade.go
+++ b/adp/vega/vega-backend/server/logics/cascade.go
@@ -1,7 +1,6 @@
 // Copyright openbkn.ai
 //
-// Licensed under the Apache License, Version 2.0.
-// See the LICENSE file in the project root for details.
+// Licensed under the OpenBKN License. See LICENSE-OPENBKN.txt in the project root.
 
 package logics
 

--- a/adp/vega/vega-backend/server/logics/catalog/catalog_service_s2s_test.go
+++ b/adp/vega/vega-backend/server/logics/catalog/catalog_service_s2s_test.go
@@ -1,7 +1,6 @@
 // Copyright openbkn.ai
 //
-// Licensed under the Apache License, Version 2.0.
-// See the LICENSE file in the project root for details.
+// Licensed under the OpenBKN License. See LICENSE-OPENBKN.txt in the project root.
 
 package catalog
 

--- a/adp/vega/vega-backend/server/logics/connectors/local/index/opensearch/opensearch_fulltext_test.go
+++ b/adp/vega/vega-backend/server/logics/connectors/local/index/opensearch/opensearch_fulltext_test.go
@@ -1,7 +1,6 @@
 // Copyright openbkn.ai
 //
-// Licensed under the Apache License, Version 2.0.
-// See the LICENSE file in the project root for details.
+// Licensed under the OpenBKN License. See LICENSE-OPENBKN.txt in the project root.
 
 package opensearch
 

--- a/adp/vega/vega-backend/server/logics/resource/resource_service_s2s_test.go
+++ b/adp/vega/vega-backend/server/logics/resource/resource_service_s2s_test.go
@@ -1,7 +1,6 @@
 // Copyright openbkn.ai
 //
-// Licensed under the Apache License, Version 2.0.
-// See the LICENSE file in the project root for details.
+// Licensed under the OpenBKN License. See LICENSE-OPENBKN.txt in the project root.
 
 package resource
 

--- a/adp/vega/vega-backend/server/worker/build_handler_account_test.go
+++ b/adp/vega/vega-backend/server/worker/build_handler_account_test.go
@@ -1,7 +1,6 @@
 // Copyright openbkn.ai
 //
-// Licensed under the Apache License, Version 2.0.
-// See the LICENSE file in the project root for details.
+// Licensed under the OpenBKN License. See LICENSE-OPENBKN.txt in the project root.
 
 package worker
 

--- a/adp/vega/vega-backend/server/worker/build_handler_cursor_test.go
+++ b/adp/vega/vega-backend/server/worker/build_handler_cursor_test.go
@@ -1,7 +1,6 @@
 // Copyright openbkn.ai
 //
-// Licensed under the Apache License, Version 2.0.
-// See the LICENSE file in the project root for details.
+// Licensed under the OpenBKN License. See LICENSE-OPENBKN.txt in the project root.
 
 package worker
 

--- a/adp/vega/vega-backend/server/worker/build_handler_embedding_loop_test.go
+++ b/adp/vega/vega-backend/server/worker/build_handler_embedding_loop_test.go
@@ -1,7 +1,6 @@
 // Copyright openbkn.ai
 //
-// Licensed under the Apache License, Version 2.0.
-// See the LICENSE file in the project root for details.
+// Licensed under the OpenBKN License. See LICENSE-OPENBKN.txt in the project root.
 
 package worker
 

--- a/adp/vega/vega-backend/server/worker/build_handler_vectorize_test.go
+++ b/adp/vega/vega-backend/server/worker/build_handler_vectorize_test.go
@@ -1,7 +1,6 @@
 // Copyright openbkn.ai
 //
-// Licensed under the Apache License, Version 2.0.
-// See the LICENSE file in the project root for details.
+// Licensed under the OpenBKN License. See LICENSE-OPENBKN.txt in the project root.
 
 package worker
 

--- a/adp/vega/vega-backend/server/worker/build_task_reconciler.go
+++ b/adp/vega/vega-backend/server/worker/build_task_reconciler.go
@@ -1,7 +1,6 @@
 // Copyright openbkn.ai
 //
-// Licensed under the Apache License, Version 2.0.
-// See the LICENSE file in the project root for details.
+// Licensed under the OpenBKN License. See LICENSE-OPENBKN.txt in the project root.
 
 package worker
 

--- a/adp/vega/vega-backend/server/worker/build_task_reconciler_test.go
+++ b/adp/vega/vega-backend/server/worker/build_task_reconciler_test.go
@@ -1,7 +1,6 @@
 // Copyright openbkn.ai
 //
-// Licensed under the Apache License, Version 2.0.
-// See the LICENSE file in the project root for details.
+// Licensed under the OpenBKN License. See LICENSE-OPENBKN.txt in the project root.
 
 package worker
 

--- a/bkn-safe/cmd/authz-shadow/main.go
+++ b/bkn-safe/cmd/authz-shadow/main.go
@@ -1,3 +1,7 @@
+// Copyright openbkn.ai
+//
+// Licensed under the OpenBKN License. See LICENSE-OPENBKN.txt in the project root.
+
 // Command authz-shadow compares ISF authorization decisions with bkn-safe's for
 // the same requests — the safety net for the per-service authz cutover.
 //

--- a/bkn-safe/contract/authz_contract_test.go
+++ b/bkn-safe/contract/authz_contract_test.go
@@ -1,3 +1,7 @@
+// Copyright openbkn.ai
+//
+// Licensed under the OpenBKN License. See LICENSE-OPENBKN.txt in the project root.
+
 // authz_contract_test.go proves the Casbin RBAC-subset model (frozen in
 // docs/isf-replacement/contracts/README.md §4) reproduces ISF authorization
 // decisions on the frozen golden traffic. This validates the core replacement

--- a/bkn-safe/contract/introspect_contract_test.go
+++ b/bkn-safe/contract/introspect_contract_test.go
@@ -1,3 +1,7 @@
+// Copyright openbkn.ai
+//
+// Licensed under the OpenBKN License. See LICENSE-OPENBKN.txt in the project root.
+
 // Package contract holds executable freeze tests for the ISF replacement.
 //
 // introspect_contract_test.go proves that the frozen hydra introspect golden

--- a/bkn-safe/dev/seed-clients.sh
+++ b/bkn-safe/dev/seed-clients.sh
@@ -1,4 +1,8 @@
 #!/usr/bin/env bash
+# Copyright openbkn.ai
+#
+# Licensed under the OpenBKN License. See LICENSE-OPENBKN.txt in the project root.
+
 # Register the OAuth2 clients the ISF replacement needs, against the hydra admin
 # API. Idempotent: deletes by id first. Internal services need NO client (they
 # only introspect / propagate the user token) — only login entry-points do.

--- a/bkn-safe/dev/validate-device-e2e.sh
+++ b/bkn-safe/dev/validate-device-e2e.sh
@@ -1,4 +1,8 @@
 #!/usr/bin/env bash
+# Copyright openbkn.ai
+#
+# Licensed under the OpenBKN License. See LICENSE-OPENBKN.txt in the project root.
+
 # End-to-end validation of the OAuth2 Device Authorization Grant (RFC 8628) —
 # the "gh auth login" style flow: a headless CLI gets a user_code, a human
 # approves it in a browser, the CLI polls and receives access + refresh tokens.

--- a/bkn-safe/dev/validate-e2e.sh
+++ b/bkn-safe/dev/validate-e2e.sh
@@ -1,4 +1,8 @@
 #!/usr/bin/env bash
+# Copyright openbkn.ai
+#
+# Licensed under the OpenBKN License. See LICENSE-OPENBKN.txt in the project root.
+
 # End-to-end validation: bkn-safe (login/consent provider) + standard hydra.
 # Drives a full authorization-code flow as a human user, then introspects the
 # resulting token and asserts the §1 ext claims bkn-safe injected at consent.

--- a/bkn-safe/dev/validate-safe-api.sh
+++ b/bkn-safe/dev/validate-safe-api.sh
@@ -1,4 +1,8 @@
 #!/usr/bin/env bash
+# Copyright openbkn.ai
+#
+# Licensed under the OpenBKN License. See LICENSE-OPENBKN.txt in the project root.
+
 # Functional test of bkn-safe's API surface, split by trust boundary:
 #
 #   - internal (tokenless, ClusterIP): authz check/operations/policies, directory

--- a/bkn-safe/dev/validate.sh
+++ b/bkn-safe/dev/validate.sh
@@ -1,4 +1,8 @@
 #!/usr/bin/env bash
+# Copyright openbkn.ai
+#
+# Licensed under the OpenBKN License. See LICENSE-OPENBKN.txt in the project root.
+
 # Phase 1 smoke test against the real upstream hydra dev stack.
 #
 #   1. client_credentials → access token → introspect → assert the app-type

--- a/bkn-safe/server/config/config.go
+++ b/bkn-safe/server/config/config.go
@@ -1,3 +1,7 @@
+// Copyright openbkn.ai
+//
+// Licensed under the OpenBKN License. See LICENSE-OPENBKN.txt in the project root.
+
 // Package config loads bkn-safe configuration from the environment.
 package config
 

--- a/bkn-safe/server/internal/audit/audit.go
+++ b/bkn-safe/server/internal/audit/audit.go
@@ -1,3 +1,7 @@
+// Copyright openbkn.ai
+//
+// Licensed under the OpenBKN License. See LICENSE-OPENBKN.txt in the project root.
+
 // Package audit records and queries the bkn-safe admin audit trail: one row per
 // privileged mutation (who did what, to which target, with what outcome). It is
 // dependency-light on purpose (model + gorm only) so the HTTP layer can write to

--- a/bkn-safe/server/internal/auth/apikey.go
+++ b/bkn-safe/server/internal/auth/apikey.go
@@ -1,3 +1,7 @@
+// Copyright openbkn.ai
+//
+// Licensed under the OpenBKN License. See LICENSE-OPENBKN.txt in the project root.
+
 package auth
 
 import (

--- a/bkn-safe/server/internal/auth/apikey_mask_test.go
+++ b/bkn-safe/server/internal/auth/apikey_mask_test.go
@@ -1,7 +1,6 @@
 // Copyright openbkn.ai
 //
-// Licensed under the Apache License, Version 2.0.
-// See the LICENSE file in the project root for details.
+// Licensed under the OpenBKN License. See LICENSE-OPENBKN.txt in the project root.
 
 package auth
 

--- a/bkn-safe/server/internal/auth/apikey_test.go
+++ b/bkn-safe/server/internal/auth/apikey_test.go
@@ -1,3 +1,7 @@
+// Copyright openbkn.ai
+//
+// Licensed under the OpenBKN License. See LICENSE-OPENBKN.txt in the project root.
+
 package auth
 
 import (

--- a/bkn-safe/server/internal/auth/auth_test.go
+++ b/bkn-safe/server/internal/auth/auth_test.go
@@ -1,3 +1,7 @@
+// Copyright openbkn.ai
+//
+// Licensed under the OpenBKN License. See LICENSE-OPENBKN.txt in the project root.
+
 package auth
 
 import (

--- a/bkn-safe/server/internal/auth/hydra.go
+++ b/bkn-safe/server/internal/auth/hydra.go
@@ -1,3 +1,7 @@
+// Copyright openbkn.ai
+//
+// Licensed under the OpenBKN License. See LICENSE-OPENBKN.txt in the project root.
+
 package auth
 
 import (

--- a/bkn-safe/server/internal/auth/hydra_redirect_integration_test.go
+++ b/bkn-safe/server/internal/auth/hydra_redirect_integration_test.go
@@ -1,5 +1,9 @@
 //go:build integration
 
+// Copyright openbkn.ai
+//
+// Licensed under the OpenBKN License. See LICENSE-OPENBKN.txt in the project root.
+
 package auth
 
 import (

--- a/bkn-safe/server/internal/auth/ldap.go
+++ b/bkn-safe/server/internal/auth/ldap.go
@@ -1,3 +1,7 @@
+// Copyright openbkn.ai
+//
+// Licensed under the OpenBKN License. See LICENSE-OPENBKN.txt in the project root.
+
 package auth
 
 import (

--- a/bkn-safe/server/internal/auth/ldap_test.go
+++ b/bkn-safe/server/internal/auth/ldap_test.go
@@ -1,3 +1,7 @@
+// Copyright openbkn.ai
+//
+// Licensed under the OpenBKN License. See LICENSE-OPENBKN.txt in the project root.
+
 package auth
 
 import (

--- a/bkn-safe/server/internal/auth/provider.go
+++ b/bkn-safe/server/internal/auth/provider.go
@@ -1,3 +1,7 @@
+// Copyright openbkn.ai
+//
+// Licensed under the OpenBKN License. See LICENSE-OPENBKN.txt in the project root.
+
 package auth
 
 import (

--- a/bkn-safe/server/internal/auth/userstore.go
+++ b/bkn-safe/server/internal/auth/userstore.go
@@ -1,3 +1,7 @@
+// Copyright openbkn.ai
+//
+// Licensed under the OpenBKN License. See LICENSE-OPENBKN.txt in the project root.
+
 // Package auth implements bkn-safe's authentication: a local user store
 // (password verified with bcrypt) plus the hydra login/consent/device provider
 // that drives the OAuth2 flow and injects the introspect ext claims.

--- a/bkn-safe/server/internal/authz/authz.go
+++ b/bkn-safe/server/internal/authz/authz.go
@@ -1,3 +1,7 @@
+// Copyright openbkn.ai
+//
+// Licensed under the OpenBKN License. See LICENSE-OPENBKN.txt in the project root.
+
 // Package authz is bkn-safe's authorization engine: a Casbin RBAC model with
 // resource instances, backed by a GORM adapter (policies live in the shared DB).
 //

--- a/bkn-safe/server/internal/authz/authz_test.go
+++ b/bkn-safe/server/internal/authz/authz_test.go
@@ -1,3 +1,7 @@
+// Copyright openbkn.ai
+//
+// Licensed under the OpenBKN License. See LICENSE-OPENBKN.txt in the project root.
+
 package authz
 
 import (

--- a/bkn-safe/server/internal/database/database.go
+++ b/bkn-safe/server/internal/database/database.go
@@ -1,3 +1,7 @@
+// Copyright openbkn.ai
+//
+// Licensed under the OpenBKN License. See LICENSE-OPENBKN.txt in the project root.
+
 // Package database opens the GORM connection via the proton-rds driver.
 // proton-rds fakes Dameng(DM8)/Kingbase(KDB9) as MySQL wire at the
 // database/sql level, so xinchuang is transparent here — GORM always uses the

--- a/bkn-safe/server/internal/directory/directory.go
+++ b/bkn-safe/server/internal/directory/directory.go
@@ -1,3 +1,7 @@
+// Copyright openbkn.ai
+//
+// Licensed under the OpenBKN License. See LICENSE-OPENBKN.txt in the project root.
+
 // Package directory is bkn-safe's user/organization directory: users,
 // departments, groups, and name resolution. This is a CLEAN redesign of the
 // ISF user-management surface (no GET-in-body, no array-vs-map quirks) — the

--- a/bkn-safe/server/internal/directory/directory_test.go
+++ b/bkn-safe/server/internal/directory/directory_test.go
@@ -1,3 +1,7 @@
+// Copyright openbkn.ai
+//
+// Licensed under the OpenBKN License. See LICENSE-OPENBKN.txt in the project root.
+
 package directory
 
 import (

--- a/bkn-safe/server/internal/directory/hierarchy.go
+++ b/bkn-safe/server/internal/directory/hierarchy.go
@@ -1,3 +1,7 @@
+// Copyright openbkn.ai
+//
+// Licensed under the OpenBKN License. See LICENSE-OPENBKN.txt in the project root.
+
 package directory
 
 import (

--- a/bkn-safe/server/internal/directory/hierarchy_test.go
+++ b/bkn-safe/server/internal/directory/hierarchy_test.go
@@ -1,3 +1,7 @@
+// Copyright openbkn.ai
+//
+// Licensed under the OpenBKN License. See LICENSE-OPENBKN.txt in the project root.
+
 package directory
 
 import (

--- a/bkn-safe/server/internal/httpapi/admin_test.go
+++ b/bkn-safe/server/internal/httpapi/admin_test.go
@@ -1,3 +1,7 @@
+// Copyright openbkn.ai
+//
+// Licensed under the OpenBKN License. See LICENSE-OPENBKN.txt in the project root.
+
 package httpapi
 
 import (

--- a/bkn-safe/server/internal/httpapi/adminauth.go
+++ b/bkn-safe/server/internal/httpapi/adminauth.go
@@ -1,3 +1,7 @@
+// Copyright openbkn.ai
+//
+// Licensed under the OpenBKN License. See LICENSE-OPENBKN.txt in the project root.
+
 package httpapi
 
 import (

--- a/bkn-safe/server/internal/httpapi/apikey.go
+++ b/bkn-safe/server/internal/httpapi/apikey.go
@@ -1,3 +1,7 @@
+// Copyright openbkn.ai
+//
+// Licensed under the OpenBKN License. See LICENSE-OPENBKN.txt in the project root.
+
 package httpapi
 
 import (

--- a/bkn-safe/server/internal/httpapi/apikey_test.go
+++ b/bkn-safe/server/internal/httpapi/apikey_test.go
@@ -1,3 +1,7 @@
+// Copyright openbkn.ai
+//
+// Licensed under the OpenBKN License. See LICENSE-OPENBKN.txt in the project root.
+
 package httpapi
 
 import (

--- a/bkn-safe/server/internal/httpapi/audit.go
+++ b/bkn-safe/server/internal/httpapi/audit.go
@@ -1,3 +1,7 @@
+// Copyright openbkn.ai
+//
+// Licensed under the OpenBKN License. See LICENSE-OPENBKN.txt in the project root.
+
 package httpapi
 
 import (

--- a/bkn-safe/server/internal/httpapi/auth.go
+++ b/bkn-safe/server/internal/httpapi/auth.go
@@ -1,3 +1,7 @@
+// Copyright openbkn.ai
+//
+// Licensed under the OpenBKN License. See LICENSE-OPENBKN.txt in the project root.
+
 package httpapi
 
 import (

--- a/bkn-safe/server/internal/httpapi/authz.go
+++ b/bkn-safe/server/internal/httpapi/authz.go
@@ -1,3 +1,7 @@
+// Copyright openbkn.ai
+//
+// Licensed under the OpenBKN License. See LICENSE-OPENBKN.txt in the project root.
+
 package httpapi
 
 import (

--- a/bkn-safe/server/internal/httpapi/builtinadmin_test.go
+++ b/bkn-safe/server/internal/httpapi/builtinadmin_test.go
@@ -1,3 +1,7 @@
+// Copyright openbkn.ai
+//
+// Licensed under the OpenBKN License. See LICENSE-OPENBKN.txt in the project root.
+
 package httpapi
 
 import (

--- a/bkn-safe/server/internal/httpapi/clientadmin.go
+++ b/bkn-safe/server/internal/httpapi/clientadmin.go
@@ -1,3 +1,7 @@
+// Copyright openbkn.ai
+//
+// Licensed under the OpenBKN License. See LICENSE-OPENBKN.txt in the project root.
+
 package httpapi
 
 import (

--- a/bkn-safe/server/internal/httpapi/clientadmin_test.go
+++ b/bkn-safe/server/internal/httpapi/clientadmin_test.go
@@ -1,3 +1,7 @@
+// Copyright openbkn.ai
+//
+// Licensed under the OpenBKN License. See LICENSE-OPENBKN.txt in the project root.
+
 package httpapi
 
 import (

--- a/bkn-safe/server/internal/httpapi/directory.go
+++ b/bkn-safe/server/internal/httpapi/directory.go
@@ -1,3 +1,7 @@
+// Copyright openbkn.ai
+//
+// Licensed under the OpenBKN License. See LICENSE-OPENBKN.txt in the project root.
+
 package httpapi
 
 import (

--- a/bkn-safe/server/internal/httpapi/me.go
+++ b/bkn-safe/server/internal/httpapi/me.go
@@ -1,3 +1,7 @@
+// Copyright openbkn.ai
+//
+// Licensed under the OpenBKN License. See LICENSE-OPENBKN.txt in the project root.
+
 package httpapi
 
 import (

--- a/bkn-safe/server/internal/httpapi/me_test.go
+++ b/bkn-safe/server/internal/httpapi/me_test.go
@@ -1,3 +1,7 @@
+// Copyright openbkn.ai
+//
+// Licensed under the OpenBKN License. See LICENSE-OPENBKN.txt in the project root.
+
 package httpapi
 
 import (

--- a/bkn-safe/server/internal/httpapi/objectgrants.go
+++ b/bkn-safe/server/internal/httpapi/objectgrants.go
@@ -1,3 +1,7 @@
+// Copyright openbkn.ai
+//
+// Licensed under the OpenBKN License. See LICENSE-OPENBKN.txt in the project root.
+
 package httpapi
 
 import (

--- a/bkn-safe/server/internal/httpapi/objectgrants_test.go
+++ b/bkn-safe/server/internal/httpapi/objectgrants_test.go
@@ -1,3 +1,7 @@
+// Copyright openbkn.ai
+//
+// Licensed under the OpenBKN License. See LICENSE-OPENBKN.txt in the project root.
+
 package httpapi
 
 import (

--- a/bkn-safe/server/internal/httpapi/router.go
+++ b/bkn-safe/server/internal/httpapi/router.go
@@ -1,3 +1,7 @@
+// Copyright openbkn.ai
+//
+// Licensed under the OpenBKN License. See LICENSE-OPENBKN.txt in the project root.
+
 // Package httpapi wires bkn-safe's HTTP surface: health, the authz API, the
 // user-directory API, and the hydra login/consent/device provider pages.
 package httpapi

--- a/bkn-safe/server/internal/httpapi/router_test.go
+++ b/bkn-safe/server/internal/httpapi/router_test.go
@@ -1,3 +1,7 @@
+// Copyright openbkn.ai
+//
+// Licensed under the OpenBKN License. See LICENSE-OPENBKN.txt in the project root.
+
 package httpapi
 
 import (

--- a/bkn-safe/server/internal/httpapi/useradmin.go
+++ b/bkn-safe/server/internal/httpapi/useradmin.go
@@ -1,3 +1,7 @@
+// Copyright openbkn.ai
+//
+// Licensed under the OpenBKN License. See LICENSE-OPENBKN.txt in the project root.
+
 package httpapi
 
 import (

--- a/bkn-safe/server/internal/model/model.go
+++ b/bkn-safe/server/internal/model/model.go
@@ -1,3 +1,7 @@
+// Copyright openbkn.ai
+//
+// Licensed under the OpenBKN License. See LICENSE-OPENBKN.txt in the project root.
+
 // Package model holds bkn-safe's GORM domain model. This is a CLEAN redesign
 // (not the ISF schema): users/credentials/departments/groups/roles/memberships
 // plus the resource-type + operation catalog. Casbin policies live in the

--- a/bkn-safe/server/internal/seed/matrix_test.go
+++ b/bkn-safe/server/internal/seed/matrix_test.go
@@ -1,3 +1,7 @@
+// Copyright openbkn.ai
+//
+// Licensed under the OpenBKN License. See LICENSE-OPENBKN.txt in the project root.
+
 package seed
 
 import (

--- a/bkn-safe/server/internal/seed/seed.go
+++ b/bkn-safe/server/internal/seed/seed.go
@@ -1,3 +1,7 @@
+// Copyright openbkn.ai
+//
+// Licensed under the OpenBKN License. See LICENSE-OPENBKN.txt in the project root.
+
 // Package seed centrally initialises authorization data at bkn-safe startup:
 // roles, the resource-type/operation catalog, and role->permission grants.
 //

--- a/bkn-safe/server/internal/seed/seed_test.go
+++ b/bkn-safe/server/internal/seed/seed_test.go
@@ -1,3 +1,7 @@
+// Copyright openbkn.ai
+//
+// Licensed under the OpenBKN License. See LICENSE-OPENBKN.txt in the project root.
+
 package seed
 
 import (

--- a/bkn-safe/server/main.go
+++ b/bkn-safe/server/main.go
@@ -1,3 +1,7 @@
+// Copyright openbkn.ai
+//
+// Licensed under the OpenBKN License. See LICENSE-OPENBKN.txt in the project root.
+
 // Command bkn-safe is the ISF replacement auth service: authentication
 // (hydra login/consent/device provider), authorization (Casbin), and user
 // management (directory + LDAP). hydra issues the tokens.

--- a/data-migrator/copy_repos.py
+++ b/data-migrator/copy_repos.py
@@ -1,5 +1,9 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
+# Copyright openbkn.ai
+#
+# Licensed under the OpenBKN License. See LICENSE-OPENBKN.txt in the project root.
+
 """从本地目录复制服务文件到 repos - 参考 executor.py 实现"""
 import os
 import shutil

--- a/data-migrator/server/__init__.py
+++ b/data-migrator/server/__init__.py
@@ -1,4 +1,3 @@
 # Copyright openbkn.ai
 #
-# Licensed under the Apache License, Version 2.0.
-# See the LICENSE file in the project root for details.
+# Licensed under the OpenBKN License. See LICENSE-OPENBKN.txt in the project root.

--- a/data-migrator/server/config/__init__.py
+++ b/data-migrator/server/config/__init__.py
@@ -1,4 +1,3 @@
 # Copyright openbkn.ai
 #
-# Licensed under the Apache License, Version 2.0.
-# See the LICENSE file in the project root for details.
+# Licensed under the OpenBKN License. See LICENSE-OPENBKN.txt in the project root.

--- a/data-migrator/server/config/loader.py
+++ b/data-migrator/server/config/loader.py
@@ -2,8 +2,7 @@
 # -*- coding: utf-8 -*-
 # Copyright openbkn.ai
 #
-# Licensed under the Apache License, Version 2.0.
-# See the LICENSE file in the project root for details.
+# Licensed under the OpenBKN License. See LICENSE-OPENBKN.txt in the project root.
 """YAML 配置加载 + AppConfig 构建"""
 import os
 from logging import Logger

--- a/data-migrator/server/config/models.py
+++ b/data-migrator/server/config/models.py
@@ -2,8 +2,7 @@
 # -*- coding: utf-8 -*-
 # Copyright openbkn.ai
 #
-# Licensed under the Apache License, Version 2.0.
-# See the LICENSE file in the project root for details.
+# Licensed under the OpenBKN License. See LICENSE-OPENBKN.txt in the project root.
 """配置数据类"""
 from dataclasses import dataclass, field
 from typing import Dict, List, Optional

--- a/data-migrator/server/data-migrator.py
+++ b/data-migrator/server/data-migrator.py
@@ -2,8 +2,7 @@
 # -*- coding: utf-8 -*-
 # Copyright openbkn.ai
 #
-# Licensed under the Apache License, Version 2.0.
-# See the LICENSE file in the project root for details.
+# Licensed under the OpenBKN License. See LICENSE-OPENBKN.txt in the project root.
 """
 Data Migrator - 统一入口
 支持四个子命令: fetch / lint / verify / migrate

--- a/data-migrator/server/db/__init__.py
+++ b/data-migrator/server/db/__init__.py
@@ -1,4 +1,3 @@
 # Copyright openbkn.ai
 #
-# Licensed under the Apache License, Version 2.0.
-# See the LICENSE file in the project root for details.
+# Licensed under the OpenBKN License. See LICENSE-OPENBKN.txt in the project root.

--- a/data-migrator/server/db/connection.py
+++ b/data-migrator/server/db/connection.py
@@ -2,8 +2,7 @@
 # -*- coding: utf-8 -*-
 # Copyright openbkn.ai
 #
-# Licensed under the Apache License, Version 2.0.
-# See the LICENSE file in the project root for details.
+# Licensed under the OpenBKN License. See LICENSE-OPENBKN.txt in the project root.
 """数据库连接 - 适配 RDSConfig，去掉 admin_key/root_conn"""
 import rdsdriver
 

--- a/data-migrator/server/db/dialect/__init__.py
+++ b/data-migrator/server/db/dialect/__init__.py
@@ -1,4 +1,3 @@
 # Copyright openbkn.ai
 #
-# Licensed under the Apache License, Version 2.0.
-# See the LICENSE file in the project root for details.
+# Licensed under the OpenBKN License. See LICENSE-OPENBKN.txt in the project root.

--- a/data-migrator/server/db/dialect/_parser/__init__.py
+++ b/data-migrator/server/db/dialect/_parser/__init__.py
@@ -1,4 +1,3 @@
 # Copyright openbkn.ai
 #
-# Licensed under the Apache License, Version 2.0.
-# See the LICENSE file in the project root for details.
+# Licensed under the OpenBKN License. See LICENSE-OPENBKN.txt in the project root.

--- a/data-migrator/server/db/dialect/_parser/base.py
+++ b/data-migrator/server/db/dialect/_parser/base.py
@@ -2,8 +2,7 @@
 # -*- coding: utf-8 -*-
 # Copyright openbkn.ai
 #
-# Licensed under the Apache License, Version 2.0.
-# See the LICENSE file in the project root for details.
+# Licensed under the OpenBKN License. See LICENSE-OPENBKN.txt in the project root.
 """纯字符串解析公共基类 — 无 DB 依赖，无 rdsdriver 引用"""
 from server.utils.token import next_token
 

--- a/data-migrator/server/db/dialect/_parser/dm8.py
+++ b/data-migrator/server/db/dialect/_parser/dm8.py
@@ -2,8 +2,7 @@
 # -*- coding: utf-8 -*-
 # Copyright openbkn.ai
 #
-# Licensed under the Apache License, Version 2.0.
-# See the LICENSE file in the project root for details.
+# Licensed under the OpenBKN License. See LICENSE-OPENBKN.txt in the project root.
 """DM8 (达梦) 纯字符串解析器 — 无 DB 依赖"""
 from server.db.dialect._parser.base import RDSParser
 from server.utils.table_define import Database, Column

--- a/data-migrator/server/db/dialect/_parser/kdb9.py
+++ b/data-migrator/server/db/dialect/_parser/kdb9.py
@@ -2,8 +2,7 @@
 # -*- coding: utf-8 -*-
 # Copyright openbkn.ai
 #
-# Licensed under the Apache License, Version 2.0.
-# See the LICENSE file in the project root for details.
+# Licensed under the OpenBKN License. See LICENSE-OPENBKN.txt in the project root.
 """KDB9 (人大金仓) 纯字符串解析器 — 无 DB 依赖"""
 from server.db.dialect._parser.base import RDSParser
 from server.utils.table_define import Database, Column

--- a/data-migrator/server/db/dialect/_parser/mariadb.py
+++ b/data-migrator/server/db/dialect/_parser/mariadb.py
@@ -2,8 +2,7 @@
 # -*- coding: utf-8 -*-
 # Copyright openbkn.ai
 #
-# Licensed under the Apache License, Version 2.0.
-# See the LICENSE file in the project root for details.
+# Licensed under the OpenBKN License. See LICENSE-OPENBKN.txt in the project root.
 """MariaDB 纯字符串解析器 — 无 DB 依赖"""
 from server.db.dialect._parser.base import RDSParser
 from server.utils.table_define import Database, Column

--- a/data-migrator/server/db/dialect/base.py
+++ b/data-migrator/server/db/dialect/base.py
@@ -2,8 +2,7 @@
 # -*- coding: utf-8 -*-
 # Copyright openbkn.ai
 #
-# Licensed under the Apache License, Version 2.0.
-# See the LICENSE file in the project root for details.
+# Licensed under the OpenBKN License. See LICENSE-OPENBKN.txt in the project root.
 """数据库方言抽象基类 - 统一 check 和 migrate 的 SQL 执行逻辑"""
 import os
 from abc import ABC, abstractmethod

--- a/data-migrator/server/db/dialect/dm8.py
+++ b/data-migrator/server/db/dialect/dm8.py
@@ -2,8 +2,7 @@
 # -*- coding: utf-8 -*-
 # Copyright openbkn.ai
 #
-# Licensed under the Apache License, Version 2.0.
-# See the LICENSE file in the project root for details.
+# Licensed under the OpenBKN License. See LICENSE-OPENBKN.txt in the project root.
 """DM8 (达梦) 方言 - DB 连接 + SQL 模板 + 幂等执行"""
 from logging import Logger
 

--- a/data-migrator/server/db/dialect/factory.py
+++ b/data-migrator/server/db/dialect/factory.py
@@ -2,8 +2,7 @@
 # -*- coding: utf-8 -*-
 # Copyright openbkn.ai
 #
-# Licensed under the Apache License, Version 2.0.
-# See the LICENSE file in the project root for details.
+# Licensed under the OpenBKN License. See LICENSE-OPENBKN.txt in the project root.
 """方言工厂：db_type -> 方言实例"""
 from logging import Logger
 

--- a/data-migrator/server/db/dialect/goldendb.py
+++ b/data-migrator/server/db/dialect/goldendb.py
@@ -2,8 +2,7 @@
 # -*- coding: utf-8 -*-
 # Copyright openbkn.ai
 #
-# Licensed under the Apache License, Version 2.0.
-# See the LICENSE file in the project root for details.
+# Licensed under the OpenBKN License. See LICENSE-OPENBKN.txt in the project root.
 """GoldenDB 方言"""
 from logging import Logger
 

--- a/data-migrator/server/db/dialect/kdb9.py
+++ b/data-migrator/server/db/dialect/kdb9.py
@@ -2,8 +2,7 @@
 # -*- coding: utf-8 -*-
 # Copyright openbkn.ai
 #
-# Licensed under the Apache License, Version 2.0.
-# See the LICENSE file in the project root for details.
+# Licensed under the OpenBKN License. See LICENSE-OPENBKN.txt in the project root.
 """KDB9 (人大金仓) 方言 - DB 连接 + SQL 模板 + 幂等执行"""
 from logging import Logger
 

--- a/data-migrator/server/db/dialect/mariadb.py
+++ b/data-migrator/server/db/dialect/mariadb.py
@@ -2,8 +2,7 @@
 # -*- coding: utf-8 -*-
 # Copyright openbkn.ai
 #
-# Licensed under the Apache License, Version 2.0.
-# See the LICENSE file in the project root for details.
+# Licensed under the OpenBKN License. See LICENSE-OPENBKN.txt in the project root.
 """MariaDB 方言 - DB 连接 + SQL 模板 + 幂等执行"""
 import re
 from logging import Logger

--- a/data-migrator/server/db/dialect/mysql.py
+++ b/data-migrator/server/db/dialect/mysql.py
@@ -2,8 +2,7 @@
 # -*- coding: utf-8 -*-
 # Copyright openbkn.ai
 #
-# Licensed under the Apache License, Version 2.0.
-# See the LICENSE file in the project root for details.
+# Licensed under the OpenBKN License. See LICENSE-OPENBKN.txt in the project root.
 """MySQL 方言"""
 from logging import Logger
 

--- a/data-migrator/server/db/dialect/tidb.py
+++ b/data-migrator/server/db/dialect/tidb.py
@@ -2,8 +2,7 @@
 # -*- coding: utf-8 -*-
 # Copyright openbkn.ai
 #
-# Licensed under the Apache License, Version 2.0.
-# See the LICENSE file in the project root for details.
+# Licensed under the OpenBKN License. See LICENSE-OPENBKN.txt in the project root.
 """TiDB 方言"""
 from logging import Logger
 

--- a/data-migrator/server/db/operate.py
+++ b/data-migrator/server/db/operate.py
@@ -2,8 +2,7 @@
 # -*- coding: utf-8 -*-
 # Copyright openbkn.ai
 #
-# Licensed under the Apache License, Version 2.0.
-# See the LICENSE file in the project root for details.
+# Licensed under the OpenBKN License. See LICENSE-OPENBKN.txt in the project root.
 """数据库操作 - CRUD + DDL 执行"""
 from logging import Logger
 

--- a/data-migrator/server/fetch/__init__.py
+++ b/data-migrator/server/fetch/__init__.py
@@ -1,4 +1,3 @@
 # Copyright openbkn.ai
 #
-# Licensed under the Apache License, Version 2.0.
-# See the LICENSE file in the project root for details.
+# Licensed under the OpenBKN License. See LICENSE-OPENBKN.txt in the project root.

--- a/data-migrator/server/fetch/executor.py
+++ b/data-migrator/server/fetch/executor.py
@@ -2,8 +2,7 @@
 # -*- coding: utf-8 -*-
 # Copyright openbkn.ai
 #
-# Licensed under the Apache License, Version 2.0.
-# See the LICENSE file in the project root for details.
+# Licensed under the OpenBKN License. See LICENSE-OPENBKN.txt in the project root.
 """Git 拉取 + 目录收集 - 使用 GitPython 从 GitHub 克隆，适配 AppConfig"""
 import os
 import shutil

--- a/data-migrator/server/lint/__init__.py
+++ b/data-migrator/server/lint/__init__.py
@@ -1,4 +1,3 @@
 # Copyright openbkn.ai
 #
-# Licensed under the Apache License, Version 2.0.
-# See the LICENSE file in the project root for details.
+# Licensed under the OpenBKN License. See LICENSE-OPENBKN.txt in the project root.

--- a/data-migrator/server/lint/executor.py
+++ b/data-migrator/server/lint/executor.py
@@ -2,8 +2,7 @@
 # -*- coding: utf-8 -*-
 # Copyright openbkn.ai
 #
-# Licensed under the Apache License, Version 2.0.
-# See the LICENSE file in the project root for details.
+# Licensed under the OpenBKN License. See LICENSE-OPENBKN.txt in the project root.
 """lint 子命令入口 — 纯静态目录结构与 SQL 语法校验，无 DB 依赖"""
 from __future__ import annotations
 

--- a/data-migrator/server/lint/rds/__init__.py
+++ b/data-migrator/server/lint/rds/__init__.py
@@ -1,4 +1,3 @@
 # Copyright openbkn.ai
 #
-# Licensed under the Apache License, Version 2.0.
-# See the LICENSE file in the project root for details.
+# Licensed under the OpenBKN License. See LICENSE-OPENBKN.txt in the project root.

--- a/data-migrator/server/lint/rds/base.py
+++ b/data-migrator/server/lint/rds/base.py
@@ -2,8 +2,7 @@
 # -*- coding: utf-8 -*-
 # Copyright openbkn.ai
 #
-# Licensed under the Apache License, Version 2.0.
-# See the LICENSE file in the project root for details.
+# Licensed under the OpenBKN License. See LICENSE-OPENBKN.txt in the project root.
 """Lint 抽象基类 — 纯静态 SQL 校验，无 DB 依赖"""
 from abc import ABC, abstractmethod
 from logging import Logger

--- a/data-migrator/server/lint/rds/dm8.py
+++ b/data-migrator/server/lint/rds/dm8.py
@@ -2,8 +2,7 @@
 # -*- coding: utf-8 -*-
 # Copyright openbkn.ai
 #
-# Licensed under the Apache License, Version 2.0.
-# See the LICENSE file in the project root for details.
+# Licensed under the OpenBKN License. See LICENSE-OPENBKN.txt in the project root.
 """DM8 静态校验 — 继承 DM8Parser，无 DB 依赖"""
 from logging import Logger
 

--- a/data-migrator/server/lint/rds/kdb9.py
+++ b/data-migrator/server/lint/rds/kdb9.py
@@ -2,8 +2,7 @@
 # -*- coding: utf-8 -*-
 # Copyright openbkn.ai
 #
-# Licensed under the Apache License, Version 2.0.
-# See the LICENSE file in the project root for details.
+# Licensed under the OpenBKN License. See LICENSE-OPENBKN.txt in the project root.
 """KDB9 静态校验 — 继承 KDB9Parser，无 DB 依赖"""
 from logging import Logger
 

--- a/data-migrator/server/lint/rds/mariadb.py
+++ b/data-migrator/server/lint/rds/mariadb.py
@@ -2,8 +2,7 @@
 # -*- coding: utf-8 -*-
 # Copyright openbkn.ai
 #
-# Licensed under the Apache License, Version 2.0.
-# See the LICENSE file in the project root for details.
+# Licensed under the OpenBKN License. See LICENSE-OPENBKN.txt in the project root.
 """MariaDB 静态校验 — 继承 MariaDBParser，无 DB 依赖"""
 from logging import Logger
 

--- a/data-migrator/server/migrate/__init__.py
+++ b/data-migrator/server/migrate/__init__.py
@@ -1,4 +1,3 @@
 # Copyright openbkn.ai
 #
-# Licensed under the Apache License, Version 2.0.
-# See the LICENSE file in the project root for details.
+# Licensed under the OpenBKN License. See LICENSE-OPENBKN.txt in the project root.

--- a/data-migrator/server/migrate/executor.py
+++ b/data-migrator/server/migrate/executor.py
@@ -2,8 +2,7 @@
 # -*- coding: utf-8 -*-
 # Copyright openbkn.ai
 #
-# Licensed under the Apache License, Version 2.0.
-# See the LICENSE file in the project root for details.
+# Licensed under the OpenBKN License. See LICENSE-OPENBKN.txt in the project root.
 """迁移主循环
 
 流程：

--- a/data-migrator/server/migrate/history_manager.py
+++ b/data-migrator/server/migrate/history_manager.py
@@ -2,8 +2,7 @@
 # -*- coding: utf-8 -*-
 # Copyright openbkn.ai
 #
-# Licensed under the Apache License, Version 2.0.
-# See the LICENSE file in the project root for details.
+# Licensed under the OpenBKN License. See LICENSE-OPENBKN.txt in the project root.
 """t_schema_migration_history 管理 - 历史记录写入"""
 import datetime
 from logging import Logger

--- a/data-migrator/server/migrate/json_executor.py
+++ b/data-migrator/server/migrate/json_executor.py
@@ -2,8 +2,7 @@
 # -*- coding: utf-8 -*-
 # Copyright openbkn.ai
 #
-# Licensed under the Apache License, Version 2.0.
-# See the LICENSE file in the project root for details.
+# Licensed under the OpenBKN License. See LICENSE-OPENBKN.txt in the project root.
 """JSON 升级文件执行器 - 委托给 RDSDialect 的幂等操作方法"""
 import json
 from logging import Logger

--- a/data-migrator/server/migrate/script_selector.py
+++ b/data-migrator/server/migrate/script_selector.py
@@ -2,8 +2,7 @@
 # -*- coding: utf-8 -*-
 # Copyright openbkn.ai
 #
-# Licensed under the Apache License, Version 2.0.
-# See the LICENSE file in the project root for details.
+# Licensed under the OpenBKN License. See LICENSE-OPENBKN.txt in the project root.
 """脚本选择器 - 版本扫描、init.sql 查找、脚本排序
 
 新目录结构：脚本直接放在 <version>/ 下，无 pre/ 子目录。

--- a/data-migrator/server/migrate/task_manager.py
+++ b/data-migrator/server/migrate/task_manager.py
@@ -2,8 +2,7 @@
 # -*- coding: utf-8 -*-
 # Copyright openbkn.ai
 #
-# Licensed under the Apache License, Version 2.0.
-# See the LICENSE file in the project root for details.
+# Licensed under the OpenBKN License. See LICENSE-OPENBKN.txt in the project root.
 """t_schema_migration_task 管理 - INSERT/UPDATE/SELECT"""
 import datetime
 from enum import Enum

--- a/data-migrator/server/utils/__init__.py
+++ b/data-migrator/server/utils/__init__.py
@@ -1,4 +1,3 @@
 # Copyright openbkn.ai
 #
-# Licensed under the Apache License, Version 2.0.
-# See the LICENSE file in the project root for details.
+# Licensed under the OpenBKN License. See LICENSE-OPENBKN.txt in the project root.

--- a/data-migrator/server/utils/log.py
+++ b/data-migrator/server/utils/log.py
@@ -2,8 +2,7 @@
 # -*- coding: utf-8 -*-
 # Copyright openbkn.ai
 #
-# Licensed under the Apache License, Version 2.0.
-# See the LICENSE file in the project root for details.
+# Licensed under the OpenBKN License. See LICENSE-OPENBKN.txt in the project root.
 """日志工具 - 复用 server-old LogDiy，改名 data-migrator"""
 import re
 import sys

--- a/data-migrator/server/utils/sql.py
+++ b/data-migrator/server/utils/sql.py
@@ -2,8 +2,7 @@
 # -*- coding: utf-8 -*-
 # Copyright openbkn.ai
 #
-# Licensed under the Apache License, Version 2.0.
-# See the LICENSE file in the project root for details.
+# Licensed under the OpenBKN License. See LICENSE-OPENBKN.txt in the project root.
 """SQL 解析工具 - 基于 sqlparse 的 split + 注释过滤"""
 from logging import Logger
 from typing import List

--- a/data-migrator/server/utils/table_define.py
+++ b/data-migrator/server/utils/table_define.py
@@ -2,8 +2,7 @@
 # -*- coding: utf-8 -*-
 # Copyright openbkn.ai
 #
-# Licensed under the Apache License, Version 2.0.
-# See the LICENSE file in the project root for details.
+# Licensed under the OpenBKN License. See LICENSE-OPENBKN.txt in the project root.
 """数据库表结构定义 — 移植自 tools/utils/table_define.py"""
 import re
 from logging import Logger

--- a/data-migrator/server/utils/token.py
+++ b/data-migrator/server/utils/token.py
@@ -2,8 +2,7 @@
 # -*- coding: utf-8 -*-
 # Copyright openbkn.ai
 #
-# Licensed under the Apache License, Version 2.0.
-# See the LICENSE file in the project root for details.
+# Licensed under the OpenBKN License. See LICENSE-OPENBKN.txt in the project root.
 """SQL token 解析工具 — 移植自 tools/utils/util.py"""
 
 

--- a/data-migrator/server/utils/version.py
+++ b/data-migrator/server/utils/version.py
@@ -2,8 +2,7 @@
 # -*- coding: utf-8 -*-
 # Copyright openbkn.ai
 #
-# Licensed under the Apache License, Version 2.0.
-# See the LICENSE file in the project root for details.
+# Licensed under the OpenBKN License. See LICENSE-OPENBKN.txt in the project root.
 """版本号工具 - 合并 tools/utils/version.py + server-old/src/utils/util.py"""
 import re
 from typing import List, Optional

--- a/data-migrator/server/verify/__init__.py
+++ b/data-migrator/server/verify/__init__.py
@@ -1,4 +1,3 @@
 # Copyright openbkn.ai
 #
-# Licensed under the Apache License, Version 2.0.
-# See the LICENSE file in the project root for details.
+# Licensed under the OpenBKN License. See LICENSE-OPENBKN.txt in the project root.

--- a/data-migrator/server/verify/executor.py
+++ b/data-migrator/server/verify/executor.py
@@ -2,8 +2,7 @@
 # -*- coding: utf-8 -*-
 # Copyright openbkn.ai
 #
-# Licensed under the Apache License, Version 2.0.
-# See the LICENSE file in the project root for details.
+# Licensed under the OpenBKN License. See LICENSE-OPENBKN.txt in the project root.
 """verify 子命令入口 — 连接测试 DB，执行 SQL 校验 + schema 对比"""
 import json
 import os

--- a/data-migrator/server/verify/rds/__init__.py
+++ b/data-migrator/server/verify/rds/__init__.py
@@ -1,4 +1,3 @@
 # Copyright openbkn.ai
 #
-# Licensed under the Apache License, Version 2.0.
-# See the LICENSE file in the project root for details.
+# Licensed under the OpenBKN License. See LICENSE-OPENBKN.txt in the project root.

--- a/data-migrator/server/verify/rds/dm8.py
+++ b/data-migrator/server/verify/rds/dm8.py
@@ -2,8 +2,7 @@
 # -*- coding: utf-8 -*-
 # Copyright openbkn.ai
 #
-# Licensed under the Apache License, Version 2.0.
-# See the LICENSE file in the project root for details.
+# Licensed under the OpenBKN License. See LICENSE-OPENBKN.txt in the project root.
 """DM8 校验实现 — 继承 DM8Dialect (DB) + LintDM8 (静态校验)"""
 from logging import Logger
 

--- a/data-migrator/server/verify/rds/kdb9.py
+++ b/data-migrator/server/verify/rds/kdb9.py
@@ -2,8 +2,7 @@
 # -*- coding: utf-8 -*-
 # Copyright openbkn.ai
 #
-# Licensed under the Apache License, Version 2.0.
-# See the LICENSE file in the project root for details.
+# Licensed under the OpenBKN License. See LICENSE-OPENBKN.txt in the project root.
 """KDB9 校验实现 — 继承 KDB9Dialect (DB) + LintKDB9 (静态校验)"""
 from logging import Logger
 

--- a/data-migrator/server/verify/rds/mariadb.py
+++ b/data-migrator/server/verify/rds/mariadb.py
@@ -2,8 +2,7 @@
 # -*- coding: utf-8 -*-
 # Copyright openbkn.ai
 #
-# Licensed under the Apache License, Version 2.0.
-# See the LICENSE file in the project root for details.
+# Licensed under the OpenBKN License. See LICENSE-OPENBKN.txt in the project root.
 """MariaDB 校验实现 — 继承 MariaDBDialect (DB) + LintMariaDB (静态校验)"""
 from logging import Logger
 

--- a/data-migrator/server/verify/rds/mysql.py
+++ b/data-migrator/server/verify/rds/mysql.py
@@ -2,8 +2,7 @@
 # -*- coding: utf-8 -*-
 # Copyright openbkn.ai
 #
-# Licensed under the Apache License, Version 2.0.
-# See the LICENSE file in the project root for details.
+# Licensed under the OpenBKN License. See LICENSE-OPENBKN.txt in the project root.
 """MySQL 校验实现 — 继承 MySQLDialect (DB) + LintMySQL (静态校验)"""
 from logging import Logger
 

--- a/data-migrator/tests/integration/__init__.py
+++ b/data-migrator/tests/integration/__init__.py
@@ -1,0 +1,3 @@
+# Copyright openbkn.ai
+#
+# Licensed under the OpenBKN License. See LICENSE-OPENBKN.txt in the project root.

--- a/data-migrator/tests/unit/__init__.py
+++ b/data-migrator/tests/unit/__init__.py
@@ -1,4 +1,3 @@
 # Copyright openbkn.ai
 #
-# Licensed under the Apache License, Version 2.0.
-# See the LICENSE file in the project root for details.
+# Licensed under the OpenBKN License. See LICENSE-OPENBKN.txt in the project root.

--- a/data-migrator/tests/unit/conftest.py
+++ b/data-migrator/tests/unit/conftest.py
@@ -2,8 +2,7 @@
 # -*- coding: utf-8 -*-
 # Copyright openbkn.ai
 #
-# Licensed under the Apache License, Version 2.0.
-# See the LICENSE file in the project root for details.
+# Licensed under the OpenBKN License. See LICENSE-OPENBKN.txt in the project root.
 """共享测试 fixtures"""
 import logging
 import pytest

--- a/data-migrator/tests/unit/test_ensure_deploy_tables.py
+++ b/data-migrator/tests/unit/test_ensure_deploy_tables.py
@@ -2,8 +2,7 @@
 # -*- coding: utf-8 -*-
 # Copyright openbkn.ai
 #
-# Licensed under the Apache License, Version 2.0.
-# See the LICENSE file in the project root for details.
+# Licensed under the OpenBKN License. See LICENSE-OPENBKN.txt in the project root.
 """executor._ensure_deploy_tables 的 internal/external 分支测试"""
 import logging
 from unittest.mock import MagicMock, patch, call

--- a/data-migrator/tests/unit/test_execute_upgrade_files.py
+++ b/data-migrator/tests/unit/test_execute_upgrade_files.py
@@ -2,8 +2,7 @@
 # -*- coding: utf-8 -*-
 # Copyright openbkn.ai
 #
-# Licensed under the Apache License, Version 2.0.
-# See the LICENSE file in the project root for details.
+# Licensed under the OpenBKN License. See LICENSE-OPENBKN.txt in the project root.
 """MigrationExecutor._execute_upgrade_files 单元测试
 
 mock _run_script / task_mgr / history_mgr，专注断点续跑逻辑。

--- a/data-migrator/tests/unit/test_fetch_executor.py
+++ b/data-migrator/tests/unit/test_fetch_executor.py
@@ -2,8 +2,7 @@
 # -*- coding: utf-8 -*-
 # Copyright openbkn.ai
 #
-# Licensed under the Apache License, Version 2.0.
-# See the LICENSE file in the project root for details.
+# Licensed under the OpenBKN License. See LICENSE-OPENBKN.txt in the project root.
 """FetchExecutor._collect_repos 和 _copy_version_dirs 单元测试（无网络/无 git 依赖）"""
 import logging
 import pytest

--- a/data-migrator/tests/unit/test_history_manager.py
+++ b/data-migrator/tests/unit/test_history_manager.py
@@ -2,8 +2,7 @@
 # -*- coding: utf-8 -*-
 # Copyright openbkn.ai
 #
-# Licensed under the Apache License, Version 2.0.
-# See the LICENSE file in the project root for details.
+# Licensed under the OpenBKN License. See LICENSE-OPENBKN.txt in the project root.
 """HistoryManager 单元测试
 
 mock self.db（OperateDB），验证 record 行为。

--- a/data-migrator/tests/unit/test_lint/__init__.py
+++ b/data-migrator/tests/unit/test_lint/__init__.py
@@ -1,4 +1,3 @@
 # Copyright openbkn.ai
 #
-# Licensed under the Apache License, Version 2.0.
-# See the LICENSE file in the project root for details.
+# Licensed under the OpenBKN License. See LICENSE-OPENBKN.txt in the project root.

--- a/data-migrator/tests/unit/test_lint/test_lint_dm8.py
+++ b/data-migrator/tests/unit/test_lint/test_lint_dm8.py
@@ -2,8 +2,7 @@
 # -*- coding: utf-8 -*-
 # Copyright openbkn.ai
 #
-# Licensed under the Apache License, Version 2.0.
-# See the LICENSE file in the project root for details.
+# Licensed under the OpenBKN License. See LICENSE-OPENBKN.txt in the project root.
 import pytest
 from tests.unit.conftest import make_check_config
 from server.lint.rds.dm8 import LintDM8

--- a/data-migrator/tests/unit/test_lint/test_lint_kdb9.py
+++ b/data-migrator/tests/unit/test_lint/test_lint_kdb9.py
@@ -2,8 +2,7 @@
 # -*- coding: utf-8 -*-
 # Copyright openbkn.ai
 #
-# Licensed under the Apache License, Version 2.0.
-# See the LICENSE file in the project root for details.
+# Licensed under the OpenBKN License. See LICENSE-OPENBKN.txt in the project root.
 import pytest
 from server.lint.rds.kdb9 import LintKDB9
 from server.utils.table_define import Database, Column

--- a/data-migrator/tests/unit/test_lint/test_lint_mariadb.py
+++ b/data-migrator/tests/unit/test_lint/test_lint_mariadb.py
@@ -2,8 +2,7 @@
 # -*- coding: utf-8 -*-
 # Copyright openbkn.ai
 #
-# Licensed under the Apache License, Version 2.0.
-# See the LICENSE file in the project root for details.
+# Licensed under the OpenBKN License. See LICENSE-OPENBKN.txt in the project root.
 import pytest
 from tests.unit.conftest import make_check_config
 from server.lint.rds.mariadb import LintMariaDB

--- a/data-migrator/tests/unit/test_migrate_service.py
+++ b/data-migrator/tests/unit/test_migrate_service.py
@@ -2,8 +2,7 @@
 # -*- coding: utf-8 -*-
 # Copyright openbkn.ai
 #
-# Licensed under the Apache License, Version 2.0.
-# See the LICENSE file in the project root for details.
+# Licensed under the OpenBKN License. See LICENSE-OPENBKN.txt in the project root.
 """MigrationExecutor 高层流程单元测试
 
 覆盖：_migrate_service 路由、_install_service、_upgrade_service、_list_services

--- a/data-migrator/tests/unit/test_parser_mariadb.py
+++ b/data-migrator/tests/unit/test_parser_mariadb.py
@@ -2,8 +2,7 @@
 # -*- coding: utf-8 -*-
 # Copyright openbkn.ai
 #
-# Licensed under the Apache License, Version 2.0.
-# See the LICENSE file in the project root for details.
+# Licensed under the OpenBKN License. See LICENSE-OPENBKN.txt in the project root.
 """
 MariaDB parser 层单元测试 — 覆盖 RDSParser 基类 + MariaDBParser。
 所有测试纯字符串操作，无 DB 依赖。

--- a/data-migrator/tests/unit/test_rds_config.py
+++ b/data-migrator/tests/unit/test_rds_config.py
@@ -2,8 +2,7 @@
 # -*- coding: utf-8 -*-
 # Copyright openbkn.ai
 #
-# Licensed under the Apache License, Version 2.0.
-# See the LICENSE file in the project root for details.
+# Licensed under the OpenBKN License. See LICENSE-OPENBKN.txt in the project root.
 """RDSConfig source_type 校验 + loader 默认值 + secret_config 加载测试"""
 import textwrap
 import tempfile

--- a/data-migrator/tests/unit/test_run_script.py
+++ b/data-migrator/tests/unit/test_run_script.py
@@ -2,8 +2,7 @@
 # -*- coding: utf-8 -*-
 # Copyright openbkn.ai
 #
-# Licensed under the Apache License, Version 2.0.
-# See the LICENSE file in the project root for details.
+# Licensed under the OpenBKN License. See LICENSE-OPENBKN.txt in the project root.
 """MigrationExecutor._run_script 单元测试
 
 使用真实子进程验证 .py 脚本的执行、日志输出和异常处理。

--- a/data-migrator/tests/unit/test_script_selector.py
+++ b/data-migrator/tests/unit/test_script_selector.py
@@ -2,8 +2,7 @@
 # -*- coding: utf-8 -*-
 # Copyright openbkn.ai
 #
-# Licensed under the Apache License, Version 2.0.
-# See the LICENSE file in the project root for details.
+# Licensed under the OpenBKN License. See LICENSE-OPENBKN.txt in the project root.
 import os
 import logging
 import pytest

--- a/data-migrator/tests/unit/test_task_manager.py
+++ b/data-migrator/tests/unit/test_task_manager.py
@@ -2,8 +2,7 @@
 # -*- coding: utf-8 -*-
 # Copyright openbkn.ai
 #
-# Licensed under the Apache License, Version 2.0.
-# See the LICENSE file in the project root for details.
+# Licensed under the OpenBKN License. See LICENSE-OPENBKN.txt in the project root.
 """TaskManager 单元测试
 
 mock self.db（OperateDB），验证 SQL 内容和参数顺序正确性。

--- a/data-migrator/tests/unit/test_token.py
+++ b/data-migrator/tests/unit/test_token.py
@@ -2,8 +2,7 @@
 # -*- coding: utf-8 -*-
 # Copyright openbkn.ai
 #
-# Licensed under the Apache License, Version 2.0.
-# See the LICENSE file in the project root for details.
+# Licensed under the OpenBKN License. See LICENSE-OPENBKN.txt in the project root.
 import pytest
 from server.utils.token import next_token, next_tokens, find_matching_paren
 

--- a/data-migrator/tests/unit/test_version.py
+++ b/data-migrator/tests/unit/test_version.py
@@ -2,8 +2,7 @@
 # -*- coding: utf-8 -*-
 # Copyright openbkn.ai
 #
-# Licensed under the Apache License, Version 2.0.
-# See the LICENSE file in the project root for details.
+# Licensed under the OpenBKN License. See LICENSE-OPENBKN.txt in the project root.
 import pytest
 from server.utils.version import (
     compare_version,

--- a/deploy/scripts/bkn-redirect.sh
+++ b/deploy/scripts/bkn-redirect.sh
@@ -1,4 +1,8 @@
 #!/usr/bin/env bash
+# Copyright openbkn.ai
+#
+# Licensed under the OpenBKN License. See LICENSE-OPENBKN.txt in the project root.
+
 # bkn-redirect.sh — list/add/remove an OAuth2 login client's redirect_uris via the
 # bkn-safe admin API (gateway-exposed), so a redirect can be registered without
 # kubectl or a helm redeploy.

--- a/deploy/scripts/gen-dev-manifest.sh
+++ b/deploy/scripts/gen-dev-manifest.sh
@@ -1,4 +1,8 @@
 #!/usr/bin/env bash
+# Copyright openbkn.ai
+#
+# Licensed under the OpenBKN License. See LICENSE-OPENBKN.txt in the project root.
+
 # =============================================================================
 # gen-dev-manifest.sh — generate a dev/test release manifest with per-chart
 # versions resolved from GHCR, for:

--- a/deploy/scripts/lib/install_status.py
+++ b/deploy/scripts/lib/install_status.py
@@ -1,4 +1,8 @@
 #!/usr/bin/env python3
+# Copyright openbkn.ai
+#
+# Licensed under the OpenBKN License. See LICENSE-OPENBKN.txt in the project root.
+
 """
 Collect BKN Foundry install status and emit it as a human table (server-side
 `deploy.sh ... status`) or as a non-sensitive JSON snapshot (served at the

--- a/deploy/scripts/lib/onboard_oss_storage.sh
+++ b/deploy/scripts/lib/onboard_oss_storage.sh
@@ -1,4 +1,8 @@
 #!/usr/bin/env bash
+# Copyright openbkn.ai
+#
+# Licensed under the OpenBKN License. See LICENSE-OPENBKN.txt in the project root.
+
 # onboard_oss_storage.sh — register a default OSS storage in oss-gateway-backend.
 #
 # Skill registration and other file-asset features call oss-gateway's

--- a/deploy/scripts/lib/onboard_test_user.sh
+++ b/deploy/scripts/lib/onboard_test_user.sh
@@ -1,4 +1,8 @@
 #!/usr/bin/env bash
+# Copyright openbkn.ai
+#
+# Licensed under the OpenBKN License. See LICENSE-OPENBKN.txt in the project root.
+
 # Optional: first business test user (login: test) with all roles from openbkn admin "role list"
 # (on typical full stacks this is three business admin roles, e.g. 数据/AI/应用 管理员) + openbkn re-login
 # for ADP toolset impex (built-in  admin  often lacks  CommonAdd  on agent-operator;  test  with roles does).

--- a/deploy/scripts/services/status.sh
+++ b/deploy/scripts/services/status.sh
@@ -1,3 +1,6 @@
+# Copyright openbkn.ai
+#
+# Licensed under the OpenBKN License. See LICENSE-OPENBKN.txt in the project root.
 
 # BKN Foundry install-status — two views over one collector
 # (scripts/lib/install_status.py):

--- a/infra/mf-model-manager/app/test/test_get_user_info.py
+++ b/infra/mf-model-manager/app/test/test_get_user_info.py
@@ -1,3 +1,7 @@
+# Copyright openbkn.ai
+#
+# Licensed under the OpenBKN License. See LICENSE-OPENBKN.txt in the project root.
+
 import os
 import unittest
 from unittest import mock

--- a/scripts/verify-charts-vs-0.8.0.sh
+++ b/scripts/verify-charts-vs-0.8.0.sh
@@ -1,4 +1,8 @@
 #!/usr/bin/env bash
+# Copyright openbkn.ai
+#
+# Licensed under the OpenBKN License. See LICENSE-OPENBKN.txt in the project root.
+
 # verify-charts-vs-helm-repo.sh
 #
 # 验证仓库内的 helm chart 与 kweaver-ai/helm-repo 已发布的**最新版本** .tgz


### PR DESCRIPTION
## What

All source files created after the KWeaver fork (net-new, not in upstream `kweaver-core`) now carry the **OpenBKN License** header. **234 files, header-only, no code changes.**

## Policy

Per project decision: *net-new OpenBKN code → OpenBKN License; KWeaver-derived code → Apache 2.0.* License is a deliberate per-file choice (stated in each header), independent of authorship.

## Changes

| Bucket | Files | Action |
|--------|-------|--------|
| Net-new, no header | 14 | Add openbkn + OpenBKN License header (execution-factory capabilities-lab) |
| Net-new, Apache header | 170 | Switch Apache 2.0 → OpenBKN License (data-migrator, execution-factory, vega, context-loader, deploy, ...) |
| bkn-safe | 50 | OpenBKN License (already applied in prior step) |

Net-new header:
```
// Copyright openbkn.ai
//
// Licensed under the OpenBKN License. See LICENSE-OPENBKN.txt in the project root.
```

## Provenance & safety

- Fork boundary `f004249a`; each net-new file confirmed via `git log --follow` (0 rename false-positives across candidates).
- **KWeaver-derived files untouched** — keep Apache 2.0 + `Copyright The kweaver.ai Authors.` (Apache-2.0 §4(c)).
- Shebang, PEP 263 encoding lines, and Go build constraints preserved on insertion.
- All 6 `gofmt` warnings on changed Go files are pre-existing, not introduced here.

## Verified

- 234/234 net-new files → OpenBKN License; 0 residual Apache; 0 headerless.
- 0 derived files mislabeled; every changed file is in the net-new set.

## Mixed-license note

These components are now Apache (derived) + OpenBKN (net-new): `adp/execution-factory`, `adp/vega`, `adp/context-loader`, `adp/bkn`, `data-migrator`, `deploy`, `infra/mf-model-manager`. The `LICENSE` overview's per-component examples may warrant a follow-up update.

🤖 Generated with [Claude Code](https://claude.com/claude-code)