### PR TITLE
docs(license): align LICENSE/NOTICE/CONTRIBUTING with net-new OpenBKN policy

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,39 +1,48 @@
 BKN Foundry — Licensing Overview
 Copyright (c) 2026 OpenBKN
 
-BKN Foundry is multi-licensed. Different components are governed by
-different licenses depending on their origin and copyright ownership.
-The license applicable to each file is stated in that file's header.
-For a per-component breakdown and attribution, see the NOTICE file.
+BKN Foundry is multi-licensed. The license applicable to each file is
+stated in that file's header; this overview and the NOTICE file explain
+the model and per-component attribution.
+
+Two licenses apply, assigned per file by origin:
 
 --------------------------------------------------------------------
-1. Components originating from the upstream project
-   kweaver-ai/kweaver-core
+1. Upstream files from kweaver-ai/kweaver-core (Apache License 2.0)
 --------------------------------------------------------------------
-   Licensed under the Apache License, Version 2.0.
+   Files that originate from the upstream project — and OpenBKN's
+   modifications to those pre-existing files — are licensed under the
+   Apache License, Version 2.0.
    Full text: LICENSE-APACHE.txt
-   Original copyright notices are retained in the source files as
-   required by Section 4 of the Apache License, Version 2.0.
+   Original copyright, patent, trademark and attribution notices are
+   retained in the source files as required by Section 4 of the Apache
+   License, Version 2.0.
 
-   Examples: BKN Engine, Context Loader, VEGA, Dataflow,
+   Upstream components: BKN Engine, Context Loader, VEGA, Dataflow,
    Exec Factory.
 
 --------------------------------------------------------------------
-2. OpenBKN access-layer components
+2. OpenBKN net-new files (OpenBKN License)
 --------------------------------------------------------------------
-   Licensed under the Apache License, Version 2.0.
-   Full text: LICENSE-APACHE.txt
-
-   Examples: BKN SDK / CLI, BKN Skill.
-
---------------------------------------------------------------------
-3. OpenBKN modules
---------------------------------------------------------------------
-   Licensed under the OpenBKN License (a modified version of the
-   Apache License, Version 2.0, with Additional Conditions).
+   Source files newly authored by OpenBKN — i.e. not present in the
+   upstream project — are licensed under the OpenBKN License, a modified
+   version of the Apache License, Version 2.0, with Additional
+   Conditions.
    Full text: LICENSE-OPENBKN.txt
 
-   Examples: BKN Safe, BKN Studio.
+   Fully OpenBKN components: BKN Safe, BKN Studio, BKN SDK / CLI,
+   BKN Skill, Capabilities Lab, Data Migrator.
 
 --------------------------------------------------------------------
+Mixed-licensed components
+--------------------------------------------------------------------
+   Some upstream-derived components also contain OpenBKN net-new files
+   and are therefore licensed per file: Apache 2.0 for upstream files,
+   OpenBKN License for OpenBKN net-new files. These include
+   adp/execution-factory, adp/vega, adp/context-loader, adp/bkn,
+   infra/mf-model-manager and deploy. Always consult the individual
+   file header.
+
+--------------------------------------------------------------------
+Third-party dependencies retain their own licenses.
 For commercial licensing inquiries: <CONTACT EMAIL / URL>

--- a/NOTICE
+++ b/NOTICE
@@ -2,61 +2,53 @@ BKN Foundry
 Copyright 2026 OpenBKN
 
 This product is multi-licensed. See the LICENSE file and the per-file
-headers for the license applicable to each component.
+headers for the license applicable to each file.
 
 ================================================================
-1. Components originating from kweaver-ai/kweaver-core
-   (Apache License 2.0)
+1. Files from kweaver-ai/kweaver-core (Apache License 2.0)
 ================================================================
 This product includes software originally developed by The kweaver.ai
 Authors (https://github.com/kweaver-ai/kweaver-core), licensed under
 the Apache License, Version 2.0. This repository is a fork of
 kweaver-ai/kweaver-core.
 
-The following components originate from the upstream project and remain
-under the Apache License, Version 2.0. Original copyright, patent,
-trademark, and attribution notices are retained in the corresponding
-source files as required by Section 4 of the Apache License,
-Version 2.0:
+Files that originate from the upstream project remain under the Apache
+License, Version 2.0. Original copyright, patent, trademark, and
+attribution notices are retained in the corresponding source files as
+required by Section 4 of the Apache License, Version 2.0. OpenBKN's
+modifications to these pre-existing files are also licensed under the
+Apache License, Version 2.0; OpenBKN's added copyright notice, together
+with the Git history, marks the files it has changed.
 
-  - BKN Engine
-  - Context Loader
-  - VEGA
-  - Dataflow
-  - Exec Factory
-
-Modifications made by OpenBKN to these components are also licensed
-under the Apache License, Version 2.0, and modified files are marked as
-having been changed.
+Upstream components: BKN Engine, Context Loader, VEGA, Dataflow,
+Exec Factory.
 
 Full license text: LICENSE-APACHE.txt
 
 ================================================================
-2. OpenBKN access-layer components (Apache License 2.0)
+2. OpenBKN net-new files (OpenBKN License)
 ================================================================
-The following components are independently developed by OpenBKN and
-are licensed by OpenBKN under the Apache License, Version 2.0:
-
-  - BKN SDK / CLI
-  - BKN Skill
-
-Full license text: LICENSE-APACHE.txt
-
-================================================================
-3. OpenBKN modules (OpenBKN License)
-================================================================
-The following components are independently developed by OpenBKN, do
-not contain upstream kweaver-core code, are copyright OpenBKN, and
-are licensed under the OpenBKN License (a modified version of the
-Apache License, Version 2.0, with Additional Conditions):
+Source files newly authored by OpenBKN — not present in the upstream
+kweaver-core project and copyright OpenBKN — are licensed under the
+OpenBKN License (a modified version of the Apache License, Version 2.0,
+with Additional Conditions):
 
   - BKN Safe
   - BKN Studio
+  - BKN SDK / CLI
+  - BKN Skill
+  - Capabilities Lab
+  - Data Migrator
+
+Several upstream-derived components also contain OpenBKN net-new files
+and are licensed per file accordingly (Apache 2.0 for upstream files,
+OpenBKN License for OpenBKN net-new files): adp/execution-factory,
+adp/vega, adp/context-loader, adp/bkn, infra/mf-model-manager, deploy.
 
 Full license text: LICENSE-OPENBKN.txt
 
 ================================================================
-4. Historical versions
+3. Historical versions
 ================================================================
 Versions of this repository previously distributed under the Apache
 License, Version 2.0 remain available under that license; their grant

--- a/bkn-safe/Dockerfile
+++ b/bkn-safe/Dockerfile
@@ -1,5 +1,5 @@
-# Copyright 2026 openbkn.ai
-# Licensed under the Apache License, Version 2.0.
+# Copyright openbkn.ai
+# Licensed under the OpenBKN License. See LICENSE-OPENBKN.txt in the project root.
 #
 # Production image for bkn-safe (ISF replacement auth service). The dev image
 # (dev/Dockerfile) wraps a host-cross-compiled binary; this one builds in-image.

--- a/rules/CONTRIBUTING.md
+++ b/rules/CONTRIBUTING.md
@@ -427,83 +427,56 @@ This section defines the standard source code file header used across **openbkn.
 The goal is to ensure:
 
 - clear copyright ownership
-- clear licensing (Apache License 2.0)
+- clear licensing (Apache 2.0 for upstream files, OpenBKN License for OpenBKN net-new files)
 - consistent and readable file documentation
 
-> **Note**: We use "The openbkn.ai Authors" instead of individual author names.
+> **Note**: We use a single `Copyright openbkn.ai` line instead of individual author names.
 > Git history already tracks all contributors, and this approach is easier to maintain.
 
-### Standard Header (Go / C / Java)
+### Which header to use
 
-Use the following header for all core source files:
+Pick the header by the file's origin:
+
+- **OpenBKN net-new files** — newly authored by OpenBKN, not present in
+  the upstream `kweaver-ai/kweaver-core` project — use the **OpenBKN
+  License** header.
+- **Upstream-derived files** — originating from `kweaver-ai/kweaver-core`
+  — use the **Apache 2.0** header and keep the upstream copyright line.
+
+Do **not** remove the `Copyright The kweaver.ai Authors.` line from
+upstream-derived files; it is required by Section 4 of the Apache
+License, Version 2.0. Do **not** add a year to the copyright line.
+
+### OpenBKN net-new header
+
+Go / C / Java / TypeScript / JavaScript:
 
 ```go
-// Copyright 2026 openbkn.ai
-// Copyright The openbkn.ai Authors.
+// Copyright openbkn.ai
 //
-// Licensed under the Apache License, Version 2.0.
-// See the LICENSE file in the project root for details.
+// Licensed under the OpenBKN License. See LICENSE-OPENBKN.txt in the project root.
 ```
 
-### Language-Specific Variants
-
-#### Python
+Python / Shell (use `#`, after any shebang and encoding line):
 
 ```python
-# Copyright 2026 openbkn.ai
-# Copyright The openbkn.ai Authors.
+# Copyright openbkn.ai
 #
-# Licensed under the Apache License, Version 2.0.
-# See the LICENSE file in the project root for details.
+# Licensed under the OpenBKN License. See LICENSE-OPENBKN.txt in the project root.
 ```
 
-#### JavaScript / TypeScript
-
-```ts
-/**
- * Copyright The openbkn.ai Authors.
- *
- * Licensed under the Apache License, Version 2.0.
- * See the LICENSE file in the project root for details.
- */
-```
-
-#### Shell
-
-```bash
-#!/usr/bin/env bash
-# Copyright 2026 openbkn.ai
-# Copyright The openbkn.ai Authors.
-# Licensed under the Apache License, Version 2.0.
-# See the LICENSE file in the project root for details.
-```
-
-#### HTML / XML
-
-```html
-<!--
-  Copyright The openbkn.ai Authors.
-  Licensed under the Apache License, Version 2.0.
-  See the LICENSE file in the project root for details.
--->
-```
-
-### Derived or Forked Files (Optional)
-
-If a file was originally derived from another project, you may add an origin note
-after the license header (for key files only):
+### Upstream-derived (Apache 2.0) header
 
 ```go
-// Copyright 2026 openbkn.ai
-// Copyright The openbkn.ai Authors.
+// Copyright openbkn.ai
+// Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.
 // See the LICENSE file in the project root for details.
-//
-// This file is derived from [original-project](https://github.com/org/repo)
 ```
 
-This is optional but recommended for transparency and community trust.
+Use `#` comment syntax for Python and Shell. Place the header after any
+shebang (`#!`) and, for Python, after the encoding declaration.
 
 ### Scope
 
@@ -528,13 +501,14 @@ Following the practice of major open-source projects (Kubernetes, TensorFlow, et
 
 - **Git history** already provides a complete and accurate record of all contributors
 - Individual author lists are **hard to maintain** and often become outdated
-- Using "The openbkn.ai Authors" ensures **consistent attribution** across all files
+- A single `Copyright openbkn.ai` line ensures **consistent attribution** across all files
 - Contributors are recognized through the project's **CONTRIBUTORS** file and git log
 
 ### License Requirement
 
-All repositories **must** include a `LICENSE` file containing the full text of
-the Apache License, Version 2.0.
+All repositories **must** include a `LICENSE` overview plus the full
+license texts they reference: `LICENSE-APACHE.txt` for Apache 2.0 files
+and `LICENSE-OPENBKN.txt` for OpenBKN License files.
 
 ### Guiding Principle
 
@@ -619,7 +593,7 @@ We will acknowledge receipt and work with you to address the issue. Please inclu
 
 ## 📜 License
 
-By contributing to BKN Foundry, you agree that your contributions will be licensed under the Apache License 2.0.
+By contributing to BKN Foundry, you agree that your contribution is licensed under the same license as the file you change (inbound = outbound): the Apache License 2.0 for upstream-derived files, or the OpenBKN License for OpenBKN net-new files. New files follow the license policy of the module they belong to.
 
 ---
 

--- a/rules/CONTRIBUTING.zh.md
+++ b/rules/CONTRIBUTING.zh.md
@@ -426,82 +426,54 @@ git push origin feature/my-feature
 目标是确保：
 
 - 明确的版权归属
-- 明确的许可证（Apache License 2.0）
+- 明确的许可证（上游文件用 Apache 2.0，OpenBKN 净新文件用 OpenBKN License）
 - 一致且可读的文件文档
 
-> **说明**：我们使用 "The openbkn.ai Authors" 而不是个人作者名。
+> **说明**：我们用单行 `Copyright openbkn.ai` 而不是个人作者名。
 > Git 历史记录已经追踪了所有贡献者，这种方式更易于维护。
 
-### 标准文件头（Go / C / Java）
+### 用哪个文件头
 
-所有核心源文件使用以下文件头：
+按文件来源选择：
+
+- **OpenBKN 净新文件**——由 OpenBKN 新写、不在上游
+  `kweaver-ai/kweaver-core` 中的文件——用 **OpenBKN License** 头。
+- **上游衍生文件**——来自 `kweaver-ai/kweaver-core`——用 **Apache 2.0**
+  头，并保留上游版权行。
+
+**禁止**删除上游衍生文件的 `Copyright The kweaver.ai Authors.` 行——
+它是 Apache License 2.0 第 4 节的强制要求。版权行**不加年份**。
+
+### OpenBKN 净新文件头
+
+Go / C / Java / TypeScript / JavaScript：
 
 ```go
-// Copyright 2026 openbkn.ai
-// Copyright The openbkn.ai Authors.
+// Copyright openbkn.ai
 //
-// Licensed under the Apache License, Version 2.0.
-// See the LICENSE file in the project root for details.
+// Licensed under the OpenBKN License. See LICENSE-OPENBKN.txt in the project root.
 ```
 
-### 各语言变体
-
-#### Python
+Python / Shell（用 `#`，置于 shebang 与编码声明之后）：
 
 ```python
-# Copyright 2026 openbkn.ai
-# Copyright The openbkn.ai Authors.
+# Copyright openbkn.ai
 #
-# Licensed under the Apache License, Version 2.0.
-# See the LICENSE file in the project root for details.
+# Licensed under the OpenBKN License. See LICENSE-OPENBKN.txt in the project root.
 ```
 
-#### JavaScript / TypeScript
-
-```ts
-/**
- * Copyright The openbkn.ai Authors.
- *
- * Licensed under the Apache License, Version 2.0.
- * See the LICENSE file in the project root for details.
- */
-```
-
-#### Shell
-
-```bash
-#!/usr/bin/env bash
-# Copyright 2026 openbkn.ai
-# Copyright The openbkn.ai Authors.
-# Licensed under the Apache License, Version 2.0.
-# See the LICENSE file in the project root for details.
-```
-
-#### HTML / XML
-
-```html
-<!--
-  Copyright The openbkn.ai Authors.
-  Licensed under the Apache License, Version 2.0.
-  See the LICENSE file in the project root for details.
--->
-```
-
-### 派生或 Fork 的文件（可选）
-
-如果文件最初来自其他项目，可以在许可证头后添加来源说明（仅用于关键文件）：
+### 上游衍生（Apache 2.0）文件头
 
 ```go
-// Copyright 2026 openbkn.ai
-// Copyright The openbkn.ai Authors.
+// Copyright openbkn.ai
+// Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.
 // See the LICENSE file in the project root for details.
-//
-// This file is derived from [original-project](https://github.com/org/repo)
 ```
 
-这是可选的，但建议添加以保持透明度和社区信任。
+Python / Shell 用 `#` 注释；文件头置于 shebang（`#!`）之后，Python 还须置于
+编码声明之后。
 
 ### 适用范围
 
@@ -526,12 +498,13 @@ git push origin feature/my-feature
 
 - **Git 历史**已经提供了所有贡献者的完整准确记录
 - 个人作者列表**难以维护**，容易过时
-- 使用 "The openbkn.ai Authors" 确保所有文件的**一致归属**
+- 单行 `Copyright openbkn.ai` 确保所有文件的**一致归属**
 - 贡献者通过项目的 **CONTRIBUTORS** 文件和 git log 获得认可
 
 ### 许可证要求
 
-所有仓库**必须**包含一个 `LICENSE` 文件，其中包含 Apache License 2.0 的完整文本。
+所有仓库**必须**包含 `LICENSE` 总览，以及其引用的完整许可证文本：Apache 2.0
+文件用 `LICENSE-APACHE.txt`，OpenBKN License 文件用 `LICENSE-OPENBKN.txt`。
 
 ### 指导原则
 
@@ -615,7 +588,9 @@ BKN Foundry 是多语言项目，**只需安装你要修改的模块所需的工
 
 ## 📜 许可证
 
-通过向 BKN Foundry 贡献，你同意你的贡献将在 Apache License 2.0 下许可。
+通过向 BKN Foundry 贡献，你同意你的贡献采用与所改文件相同的许可证（inbound =
+outbound）：上游衍生文件用 Apache License 2.0，OpenBKN 净新文件用 OpenBKN
+License。新文件遵循其所属模块的许可证策略。
 
 ---
 


### PR DESCRIPTION
## What

The source-header passes (#121, #126) moved OpenBKN net-new code to the OpenBKN License, but the overview docs still described the old model. This syncs the docs. **5 files, docs + one Dockerfile header, no code.**

## Changes

| File | Change |
|------|--------|
| `LICENSE` | Restructure to a per-file, origin-based model: Apache 2.0 for upstream files, OpenBKN License for OpenBKN net-new. Drop stale "access-layer = Apache" bucket (SDK/CLI/Skill are OpenBKN). Add mixed-licensed-components note. |
| `NOTICE` | Move BKN SDK/CLI + Skill to OpenBKN section; add Capabilities Lab, Data Migrator; note mixed components; soften the "changed files" wording to what's actually true (added copyright + Git history). |
| `rules/CONTRIBUTING.md` / `.zh.md` | Replace outdated Apache-only header templates with the real convention (no year, no "Authors" line), split by origin. Fix CLA to inbound = outbound per file. |
| `bkn-safe/Dockerfile` | Apache header (with year) → OpenBKN License — the one non-source file the header sweeps missed. |

## Why

Before this, `LICENSE §2` said BKN SDK/CLI = Apache, `LICENSE §3` listed only BKN Safe/Studio as OpenBKN, and `CONTRIBUTING` said all contributions are Apache 2.0 — each contradicting the actual per-file license now in the headers. A reader (customer, partner, scanner) would get the wrong answer.

## Scope / follow-ups

- **Out of repo:** BKN SDK and BKN Studio live in separate repos (`bkn-sdk`, `bkn-studio`) — their own license fixes are tracked separately.
- **Deferred (P1):** machine-readable metadata — SPDX identifiers, `LICENSES/`, LICENSE-MATRIX, SBOM, image OCI labels, Helm chart annotations.
- Modified-upstream-file marking (Apache §4b) is satisfied in practice by the added `Copyright openbkn.ai` line + Git history.

🤖 Generated with [Claude Code](https://claude.com/claude-code)