### PR TITLE
feat(bkn-backend): get_kn detail_level=summary at source (progressive disclosure)

### DIFF
--- a/adp/bkn/bkn-backend/server/driveradapters/knowledge_network_handler.go
+++ b/adp/bkn/bkn-backend/server/driveradapters/knowledge_network_handler.go
@@ -738,6 +738,12 @@ func (r *restHandler) GetKN(c *gin.Context, visitor hydra.Visitor) {
 		kn.Statistics = statistics
 	}
 
+	// detail_level=summary 时在源头裁剪重字段（默认 full 保持向后兼容）；
+	// 完整字段映射按需走 object-types/:ot_ids、relation-types/:rt_ids 端点。
+	if c.DefaultQuery(interfaces.QueryParam_DetailLevel, interfaces.DetailLevel_Full) == interfaces.DetailLevel_Summary {
+		kn.SlimForSummary()
+	}
+
 	oteltrace.AddHttpAttrs4Ok(span, http.StatusOK)
 	logger.Debug("Handler GetKN Success")
 	rest.ReplyOK(c, http.StatusOK, kn)

--- a/adp/bkn/bkn-backend/server/interfaces/common.go
+++ b/adp/bkn/bkn-backend/server/interfaces/common.go
@@ -51,9 +51,16 @@ const (
 	DEFAULT_INCLUDE_DETAIL = "false"
 	DEFAULT_FORCE_DELETE   = "false"
 
-	QueryParam_ImportMode = "import_mode"
-	QueryParam_Mode       = "mode"
-	QueryParam_StrictMode = "strict_mode"
+	QueryParam_ImportMode  = "import_mode"
+	QueryParam_Mode        = "mode"
+	QueryParam_StrictMode  = "strict_mode"
+	QueryParam_DetailLevel = "detail_level"
+
+	// detail_level 取值：summary 只返骨架 + 属性名（砍字段映射/查询算子/逻辑属性
+	// 数据源与参数/关系映射规则，去重 concept_groups 嵌套）；full（默认）返全量。
+	// 完整字段映射按需走 object-types/:ids、relation-types/:ids 端点获取。
+	DetailLevel_Summary = "summary"
+	DetailLevel_Full    = "full"
 
 	// 对象的导入模式
 	ImportMode_Normal    = "normal"

--- a/adp/bkn/bkn-backend/server/interfaces/knowledge_network.go
+++ b/adp/bkn/bkn-backend/server/interfaces/knowledge_network.go
@@ -137,6 +137,62 @@ type KN struct {
 	Score  *float64  `json:"_score,omitempty"` // opensearch检索的得分，在概念搜索时使用
 }
 
+// SlimForSummary trims the exported KN detail for detail_level=summary.
+//
+// It keeps object / relation / action skeletons plus each property's
+// name / display_name / type / comment, and drops the heavy per-item detail:
+// data-property field mappings, index configs and query operators; logic-property
+// data sources, parameters and analysis dimensions; and relation mapping rules.
+// It also dedups concept_groups, whose nested object/relation/action instances
+// merely duplicate the top-level arrays every consumer reads — only
+// object_type_ids is kept as the group boundary.
+//
+// Callers fetch the dropped per-item detail on demand via the
+// object-types/:ot_ids and relation-types/:rt_ids endpoints.
+func (kn *KN) SlimForSummary() {
+	if kn == nil {
+		return
+	}
+	for _, ot := range kn.ObjectTypes {
+		slimObjectTypeForSummary(ot)
+	}
+	for _, rt := range kn.RelationTypes {
+		if rt != nil {
+			rt.MappingRules = nil
+		}
+	}
+	for _, cg := range kn.ConceptGroups {
+		if cg == nil {
+			continue
+		}
+		cg.ObjectTypes = nil
+		cg.RelationTypes = nil
+		cg.ActionTypes = nil
+	}
+}
+
+func slimObjectTypeForSummary(ot *ObjectType) {
+	if ot == nil {
+		return
+	}
+	for _, dp := range ot.DataProperties {
+		if dp == nil {
+			continue
+		}
+		dp.MappedField = nil
+		dp.IndexConfig = nil
+		dp.ConditionOperations = nil
+	}
+	for _, lp := range ot.LogicProperties {
+		if lp == nil {
+			continue
+		}
+		lp.DataSource = nil
+		lp.Parameters = nil
+		lp.AnalysisDims = nil
+	}
+}
+
 // KNBatchNamesReq 按 ID 批量取知识网络名称请求(对象级授权页回显，统一契约)
 type KNBatchNamesReq struct {
 	IDs []string `json:"ids"` // 待取名的知识网络 ID 列表，空列表返回空 entries

--- a/adp/bkn/bkn-backend/server/interfaces/knowledge_network_slim_test.go
+++ b/adp/bkn/bkn-backend/server/interfaces/knowledge_network_slim_test.go
@@ -1,0 +1,102 @@
+// Copyright openbkn.ai
+// Copyright The kweaver.ai Authors.
+//
+// Licensed under the Apache License, Version 2.0.
+// See the LICENSE file in the project root for details.
+
+package interfaces
+
+import (
+	"testing"
+
+	. "github.com/smartystreets/goconvey/convey"
+)
+
+func newExportKNFixture() *KN {
+	ot := &ObjectType{
+		ObjectTypeWithKeyField: ObjectTypeWithKeyField{
+			OTID:   "ot_order",
+			OTName: "order",
+			DataProperties: []*DataProperty{{
+				Name:                "amount",
+				DisplayName:         "金额",
+				Type:                "double",
+				Comment:             "订单金额",
+				MappedField:         &Field{},
+				IndexConfig:         &IndexConfig{},
+				ConditionOperations: []string{"gt", "lt"},
+			}},
+			LogicProperties: []*LogicProperty{{
+				Name:         "gmv",
+				Type:         "metric",
+				DataSource:   &ResourceInfo{},
+				Parameters:   []Parameter{{}},
+				AnalysisDims: []Field{{}},
+			}},
+		},
+	}
+	rt := &RelationType{
+		RelationTypeWithKeyField: RelationTypeWithKeyField{
+			RTID:               "rt_places",
+			RTName:             "places",
+			SourceObjectTypeID: "ot_customer",
+			TargetObjectTypeID: "ot_order",
+			MappingRules:       []any{map[string]any{"from": "a", "to": "b"}},
+		},
+	}
+	at := &ActionType{}
+	return &KN{
+		ObjectTypes:   []*ObjectType{ot},
+		RelationTypes: []*RelationType{rt},
+		ConceptGroups: []*ConceptGroup{{
+			CGID:          "cg1",
+			CGName:        "core",
+			ObjectTypeIDs: []string{"ot_order"},
+			ObjectTypes:   []*ObjectType{ot}, // duplicate of top-level
+			RelationTypes: []*RelationType{rt},
+			ActionTypes:   []*ActionType{at},
+		}},
+	}
+}
+
+func TestKN_SlimForSummary(t *testing.T) {
+	Convey("SlimForSummary strips heavy fields, keeps property names, dedups concept_groups", t, func() {
+		kn := newExportKNFixture()
+		kn.SlimForSummary()
+
+		dp := kn.ObjectTypes[0].DataProperties[0]
+		So(dp.Name, ShouldEqual, "amount")
+		So(dp.Type, ShouldEqual, "double")
+		So(dp.Comment, ShouldEqual, "订单金额")
+		So(dp.MappedField, ShouldBeNil)
+		So(dp.IndexConfig, ShouldBeNil)
+		So(dp.ConditionOperations, ShouldBeNil)
+
+		lp := kn.ObjectTypes[0].LogicProperties[0]
+		So(lp.Name, ShouldEqual, "gmv")
+		So(lp.DataSource, ShouldBeNil)
+		So(lp.Parameters, ShouldBeNil)
+		So(lp.AnalysisDims, ShouldBeNil)
+
+		So(kn.RelationTypes[0].SourceObjectTypeID, ShouldEqual, "ot_customer")
+		So(kn.RelationTypes[0].MappingRules, ShouldBeNil)
+
+		cg := kn.ConceptGroups[0]
+		So(cg.ObjectTypeIDs, ShouldResemble, []string{"ot_order"})
+		So(cg.ObjectTypes, ShouldBeNil)
+		So(cg.RelationTypes, ShouldBeNil)
+		So(cg.ActionTypes, ShouldBeNil)
+	})
+
+	Convey("SlimForSummary tolerates nil receiver and nil elements", t, func() {
+		var kn *KN
+		So(func() { kn.SlimForSummary() }, ShouldNotPanic)
+
+		kn2 := &KN{
+			ObjectTypes:   []*ObjectType{nil},
+			RelationTypes: []*RelationType{nil},
+			ConceptGroups: []*ConceptGroup{nil},
+		}
+		So(func() { kn2.SlimForSummary() }, ShouldNotPanic)
+	})
+}

--- a/adp/bkn/bkn-backend/server/interfaces/object_type.go
+++ b/adp/bkn/bkn-backend/server/interfaces/object_type.go
@@ -147,8 +147,8 @@ type LogicProperty struct {
 	Type        string `json:"type" mapstructure:"type"`
 	Comment     string `json:"comment" mapstructure:"comment"`
 	// Index        bool          `json:"index" mapstructure:"index"`
-	DataSource   *ResourceInfo `json:"data_source" mapstructure:"data_source"`
-	Parameters   []Parameter   `json:"parameters" mapstructure:"parameters"`
+	DataSource   *ResourceInfo `json:"data_source,omitempty" mapstructure:"data_source"`
+	Parameters   []Parameter   `json:"parameters,omitempty" mapstructure:"parameters"`
 	AnalysisDims []Field       `json:"analysis_dimensions,omitempty"`
 }
 

--- a/adp/bkn/bkn-backend/server/interfaces/relation_type.go
+++ b/adp/bkn/bkn-backend/server/interfaces/relation_type.go
@@ -28,7 +28,7 @@ type RelationTypeWithKeyField struct {
 	TargetObjectTypeID string `json:"target_object_type_id" mapstructure:"target_object_type_id"`
 
 	Type         string `json:"type" mapstructure:"type"`
-	MappingRules any    `json:"mapping_rules" mapstructure:"mapping_rules"` // 根据type来决定是不同的映射方式，direct对应的结构体是[]Mapping
+	MappingRules any    `json:"mapping_rules,omitempty" mapstructure:"mapping_rules"` // 根据type来决定是不同的映射方式，direct对应的结构体是[]Mapping
 }
 
 // knowledge_network


### PR DESCRIPTION
Closes #122 · Epic #120

## 动机
`GET /in/v1/knowledge-networks/{id}?mode=export` 一直返回全量 schema。agent-retrieval（#125 / PR #127）已在 adp 层裁剪成 summary，但**上游仍吐全量、仍干全活**。本 PR 在源头原生支持 summary，让 bkn-backend 直接返轻量骨架。

## 改动
- 端点新增 `detail_level` 查询参数：`summary` = 对象/关系/行动骨架 + 每属性仅 `name/display_name/type/comment`；`full`（**默认，向后兼容**）= 全量。
- summary 砍：data_property 的 `mapped_field`/`index_config`/`condition_operations`，logic_property 的 `data_source`/`parameters`/`analysis_dimensions`，relation 的 `mapping_rules`；并去重 `concept_groups` 嵌套（只留 `object_type_ids`，顶层数组才是权威来源）。
- 裁剪逻辑 `KN.SlimForSummary()`（interfaces 包）；handler 在 `ReplyOK` 前按 `detail_level` 调用。
- 补 `omitempty`：logic_property `data_source`/`parameters`、relation `mapping_rules`（`mapped_field`/`condition_operations` 原已有），nil 才真删 key。

## 下钻
完整字段映射 / mapping_rules 按需走**已有**端点 `…/object-types/:ot_ids`、`…/relation-types/:rt_ids`（无需新增 ids 到 export）。

## 契约一致
参数名 / 语义 / 字段与 agent-retrieval #125 对齐。后续 agent-retrieval 可改为直接透传后端 summary，去掉客户端 fetch-full-then-filter。

## 测试
- 单测 `TestKN_SlimForSummary`（interfaces 包，18 断言）绿。
- `go build ./...` 全绿。
- 注：`driveradapters`/`logics/knowledge_network` 包测试在本地因缺 `locale` 目录 fatal（pre-existing 测试环境依赖，非本 PR，已在原始码复现），CI 环境正常。

🤖 Generated with [Claude Code](https://claude.com/claude-code)