### PR TITLE
feat(agent-retrieval): slim get_kn_detail summary to name+type props (TOON tables)

### DIFF
--- a/adp/context-loader/agent-retrieval/server/driveradapters/mcp/schemas/get_kn_detail.json
+++ b/adp/context-loader/agent-retrieval/server/driveradapters/mcp/schemas/get_kn_detail.json
@@ -16,7 +16,7 @@
         "type": "string",
         "enum": ["summary", "full"],
         "default": "summary",
-        "description": "详情级别。summary（默认）：对象类/关系类/行动类骨架 + 属性名（name/type/comment），不含字段映射、查询算子、映射规则，足够理解 schema 与规划查询；需要某对象完整字段映射改调 get_object_types，要关系 mapping_rules 改调 get_relation_types。full：一次返回全量（体积大，慎用）。"
+        "description": "详情级别。summary（默认）：对象类/关系类/行动类骨架 + 每个属性仅 name+type（扁平同构，TOON 渲染成紧凑表格），不含 display_name/comment/字段映射/查询算子/映射规则，足够理解 schema 与规划查询；需要某对象完整字段映射（含 comment）改调 get_object_types，要关系 mapping_rules 改调 get_relation_types。full：一次返回全量（体积大，慎用）。"
       }
     },
     "required": ["kn_id"]

--- a/adp/context-loader/agent-retrieval/server/driveradapters/mcp/schemas/tools_meta.json
+++ b/adp/context-loader/agent-retrieval/server/driveradapters/mcp/schemas/tools_meta.json
@@ -29,7 +29,7 @@
   },
   "get_kn_detail": {
     "name": "get_kn_detail",
-    "description": "获取知识网络 schema（概念组、对象类型含 data_source.id、关系类型、行动类型）。默认 detail_level=summary：返回骨架 + 每个属性的 name/type/comment，不含字段映射、查询算子、映射规则——足够理解结构与规划查询，体积小。需要某对象的完整字段映射时调 get_object_types，需要关系的 mapping_rules 时调 get_relation_types。detail_level=full 一次拿全量（体积大，慎用）。"
+    "description": "获取知识网络 schema（概念组、对象类型含 data_source.id、关系类型、行动类型）。默认 detail_level=summary：返回骨架 + 每个属性仅 name+type（不含 display_name/comment/字段映射/查询算子/映射规则）——足够理解结构与规划查询，体积小。需要某对象的完整字段映射（含 comment）时调 get_object_types，需要关系的 mapping_rules 时调 get_relation_types。detail_level=full 一次拿全量（体积大，慎用）。"
   },
   "get_object_types": {
     "name": "get_object_types",

--- a/adp/context-loader/agent-retrieval/server/driveradapters/mcp/toon_tabular_test.go
+++ b/adp/context-loader/agent-retrieval/server/driveradapters/mcp/toon_tabular_test.go
@@ -1,0 +1,51 @@
+// Copyright openbkn.ai
+// Copyright The kweaver.ai Authors.
+//
+// Licensed under the Apache License, Version 2.0.
+// See the LICENSE file in the project root for details.
+
+package mcp
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/openbkn-ai/adp/context-loader/agent-retrieval/server/infra/rest"
+	"github.com/openbkn-ai/adp/context-loader/agent-retrieval/server/interfaces"
+)
+
+// After Slim(summary), each data_property is a flat {name,type} object, so TOON
+// renders the array as a compact table instead of expanding each property.
+func TestSummaryDataPropertiesRenderAsToonTable(t *testing.T) {
+	d := &interfaces.KnowledgeNetworkDetail{
+		ID:   "kn-1",
+		Name: "sales",
+		ObjectTypes: []*interfaces.ObjectType{{
+			ID:   "ot_order",
+			Name: "order",
+			DataProperties: []*interfaces.DataProperty{
+				{Name: "amount", DisplayName: "金额", Type: "double", Comment: "订单金额", MappedField: map[string]any{"column": "amt"}},
+				{Name: "status", DisplayName: "状态", Type: "string", Comment: "订单状态", MappedField: map[string]any{"column": "st"}},
+			},
+		}},
+	}
+	d.Slim(interfaces.DetailLevelSummary)
+
+	_, body, err := rest.MarshalResponse(rest.FormatTOON, d)
+	if err != nil {
+		t.Fatalf("marshal toon: %v", err)
+	}
+	out := string(body)
+	t.Logf("TOON output:\n%s", out)
+
+	// tabular header lists the columns once: data_properties[#2]{...}
+	if !strings.Contains(out, "data_properties[#2]{") {
+		t.Errorf("expected tabular data_properties header, got:\n%s", out)
+	}
+	// heavy/dropped fields must be absent
+	for _, banned := range []string{"mapped_field", "display_name", "金额", "订单金额"} {
+		if strings.Contains(out, banned) {
+			t.Errorf("summary TOON should not contain %q, got:\n%s", banned, out)
+		}
+	}
+}

--- a/adp/context-loader/agent-retrieval/server/interfaces/driven_bkn_backend.go
+++ b/adp/context-loader/agent-retrieval/server/interfaces/driven_bkn_backend.go
@@ -71,9 +71,9 @@ type DataProperty struct {
 	// Name is the property name. Can only contain lowercase letters, numbers, underscores (_),
 	// hyphens (-), and cannot start with underscore or hyphen
 	Name                string            `json:"name"`
-	DisplayName         string            `json:"display_name"`                   // Property display name
+	DisplayName         string            `json:"display_name,omitempty"`         // Property display name
 	Type                string            `json:"type"`                           // Property data type. In addition to view field types, there are metric, objective, event, trace, log, operator
-	Comment             string            `json:"comment"`                        // Comment
+	Comment             string            `json:"comment,omitempty"`              // Comment
 	MappedField         any               `json:"mapped_field,omitempty"`         // View field info
 	ConditionOperations []KnOperationType `json:"condition_operations,omitempty"` // List of query condition operators supported by this data property
 }
@@ -352,10 +352,15 @@ func (d *KnowledgeNetworkDetail) Slim(level string) {
 		if o == nil {
 			continue
 		}
+		// summary keeps only name+type per property so the array is flat and uniform
+		// (TOON then renders it as a compact table); drop display_name/comment and the
+		// heavy mapped_field/operators/logic sources. Full detail via get_object_types.
 		for _, p := range o.DataProperties {
 			if p == nil {
 				continue
 			}
+			p.DisplayName = ""
+			p.Comment = ""
 			p.MappedField = nil
 			p.ConditionOperations = nil
 		}
@@ -363,6 +368,8 @@ func (d *KnowledgeNetworkDetail) Slim(level string) {
 			if lp == nil {
 				continue
 			}
+			lp.DisplayName = ""
+			lp.Comment = ""
 			lp.DataSource = nil
 			lp.Parameters = nil
 		}
@@ -393,10 +400,12 @@ type RelationTypesResp struct {
 	Missing       []string        `json:"missing,omitempty"`
 }
 
-// FilterObjectTypes returns the full object types whose ID (or, as a fallback,
-// Name) appears in ids, in request order and de-duplicated, plus the ids that
-// matched nothing. Object types retain all fields — this is the drill-down that
-// get_kn_detail's summary level omits.
+// FilterObjectTypes returns the object types whose ID (or, as a fallback, Name)
+// appears in ids, in request order and de-duplicated, plus the ids that matched
+// nothing. This is the drill-down that get_kn_detail's summary level omits; it
+// keeps the heavy per-property detail (mapped_field, condition_operations, logic
+// sources) so results stay run_sql-capable, but drops the property display_name
+// (a UI label of little value to an agent).
 func (d *KnowledgeNetworkDetail) FilterObjectTypes(ids []string) (matched []*ObjectType, missing []string) {
 	if d == nil {
 		return nil, ids
@@ -425,6 +434,16 @@ func (d *KnowledgeNetworkDetail) FilterObjectTypes(ids []string) (matched []*Obj
 			continue
 		}
 		seen[o.ID] = true
+		for _, p := range o.DataProperties {
+			if p != nil {
+				p.DisplayName = ""
+			}
+		}
+		for _, lp := range o.LogicProperties {
+			if lp != nil {
+				lp.DisplayName = ""
+			}
+		}
 		matched = append(matched, o)
 	}
 	return matched, missing

--- a/adp/context-loader/agent-retrieval/server/interfaces/driven_bkn_backend_slim_test.go
+++ b/adp/context-loader/agent-retrieval/server/interfaces/driven_bkn_backend_slim_test.go
@@ -18,16 +18,19 @@ func newDetailFixture() *KnowledgeNetworkDetail {
 		Name: "order",
 		DataProperties: []*DataProperty{{
 			Name:                "amount",
+			DisplayName:         "金额",
 			Type:                "double",
 			Comment:             "订单金额",
 			MappedField:         map[string]any{"column": "amt"},
 			ConditionOperations: []KnOperationType{"gt", "lt"},
 		}},
 		LogicProperties: []*LogicPropertyDef{{
-			Name:       "gmv",
-			Type:       "metric",
-			DataSource: map[string]any{"formula": "sum(amount)"},
-			Parameters: []PropertyParameter{{Name: "window", Type: "string"}},
+			Name:        "gmv",
+			DisplayName: "GMV",
+			Type:        "metric",
+			Comment:     "总额",
+			DataSource:  map[string]any{"formula": "sum(amount)"},
+			Parameters:  []PropertyParameter{{Name: "window", Type: "string"}},
 		}},
 		PrimaryKeys: []string{"id"},
 	}
@@ -60,15 +63,20 @@ func TestSlim_Summary(t *testing.T) {
 		d := newDetailFixture()
 		d.Slim(DetailLevelSummary)
 
+		// summary keeps only name+type per property (flat/uniform → TOON tabular)
 		dp := d.ObjectTypes[0].DataProperties[0]
 		convey.So(dp.Name, convey.ShouldEqual, "amount")
 		convey.So(dp.Type, convey.ShouldEqual, "double")
-		convey.So(dp.Comment, convey.ShouldEqual, "订单金额")
+		convey.So(dp.DisplayName, convey.ShouldEqual, "")
+		convey.So(dp.Comment, convey.ShouldEqual, "")
 		convey.So(dp.MappedField, convey.ShouldBeNil)
 		convey.So(dp.ConditionOperations, convey.ShouldBeNil)
 
 		lp := d.ObjectTypes[0].LogicProperties[0]
 		convey.So(lp.Name, convey.ShouldEqual, "gmv")
+		convey.So(string(lp.Type), convey.ShouldEqual, "metric")
+		convey.So(lp.DisplayName, convey.ShouldEqual, "")
+		convey.So(lp.Comment, convey.ShouldEqual, "")
 		convey.So(lp.DataSource, convey.ShouldBeNil)
 		convey.So(lp.Parameters, convey.ShouldBeNil)
 
@@ -126,7 +134,9 @@ func TestFilterObjectTypes(t *testing.T) {
 		matched, missing := d.FilterObjectTypes([]string{"ot_order"})
 		convey.So(len(matched), convey.ShouldEqual, 1)
 		convey.So(matched[0].ID, convey.ShouldEqual, "ot_order")
-		convey.So(matched[0].DataProperties[0].MappedField, convey.ShouldNotBeNil) // full detail retained
+		convey.So(matched[0].DataProperties[0].MappedField, convey.ShouldNotBeNil)  // full detail retained
+		convey.So(matched[0].DataProperties[0].Comment, convey.ShouldEqual, "订单金额") // comment kept in drill
+		convey.So(matched[0].DataProperties[0].DisplayName, convey.ShouldEqual, "") // display_name dropped in drill
 		convey.So(missing, convey.ShouldBeEmpty)
 
 		matched, _ = d.FilterObjectTypes([]string{"order"}) // by name


### PR DESCRIPTION
Closes #132 · Refs #120

## 动机
get_kn_detail summary 仍列出每个对象**全部** data_properties，每条带 display_name + 冗长自动 comment（worldcup bookings 26 属性）；MCP TOON 输出还**没表格化**——属性带嵌套 mapped_field / 变长 comment，破坏 TOON 扁平同构表格化前提，逐条展开。

## 改动（仅 agent-retrieval）
- **summary 属性瘦到 name+type**：Slim 清 data/logic property 的 display_name+comment。属性变扁平同构 → TOON 出表：
  ```
  data_properties[#2]{name,type}:
    amount,double
    status,string
  ```
  既省体积又是「真 TOON」。
- **drill 砍 display_name**：FilterObjectTypes 清返回对象属性的 display_name，留 name/type/comment/mapped_field（run_sql 映射还在）。
- DataProperty.DisplayName/Comment 补 omitempty。
- 更新描述。

## 不改
不碰 bkn-backend / vega / 其它服务。

## 测试
- Slim summary：属性只剩 name+type。
- FilterObjectTypes：drill 砍 display_name、留 comment/mapped_field。
- 新 `TestSummaryDataPropertiesRenderAsToonTable`：验证 TOON 含 `data_properties[#2]{name,type}:` 且无 mapped_field/display_name/comment。
- 全模块 20 包 test 绿。

🤖 Generated with [Claude Code](https://claude.com/claude-code)