### PR TITLE
feat(sandbox): expose session business context fields

### DIFF
--- a/adp/execution-factory/operator-integration/docs/apis/api_private/sandbox.yaml
+++ b/adp/execution-factory/operator-integration/docs/apis/api_private/sandbox.yaml
@@ -169,6 +169,21 @@ components:
           type: string
         source:
           type: string
+        task_id:
+          type: string
+          description: "Optional source task id extracted from session metadata."
+        capability_id:
+          type: string
+          description: "Optional source capability id extracted from session metadata."
+        capability_name:
+          type: string
+          description: "Optional source capability name extracted from session metadata."
+        user_id:
+          type: string
+          description: "Optional user id extracted from session metadata."
+        user_name:
+          type: string
+          description: "Optional user display name extracted from session metadata."
         template_id:
           type: string
         runtime_type:

--- a/adp/execution-factory/operator-integration/server/logics/sandbox/management.go
+++ b/adp/execution-factory/operator-integration/server/logics/sandbox/management.go
@@ -92,6 +92,11 @@ type SandboxSessionSummary struct {
 	ID                      string                   `json:"id"`
 	Status                  interfaces.SessionStatus `json:"status"`
 	Source                  string                   `json:"source"`
+	TaskID                  string                   `json:"task_id,omitempty"`
+	CapabilityID            string                   `json:"capability_id,omitempty"`
+	CapabilityName          string                   `json:"capability_name,omitempty"`
+	UserID                  string                   `json:"user_id,omitempty"`
+	UserName                string                   `json:"user_name,omitempty"`
 	TemplateID              string                   `json:"template_id"`
 	RuntimeType             string                   `json:"runtime_type"`
 	LanguageRuntime         string                   `json:"language_runtime,omitempty"`
@@ -294,6 +299,11 @@ func newSandboxSessionSummary(detail *interfaces.SessionDetail) *SandboxSessionS
 		ID:                      detail.ID,
 		Status:                  detail.Status,
 		Source:                  detectSessionSource(detail),
+		TaskID:                  readSessionEnvString(detail, "task_id", "taskId", "execution_task_id"),
+		CapabilityID:            readSessionEnvString(detail, "capability_id", "capabilityId", "source_capability_id"),
+		CapabilityName:          readSessionEnvString(detail, "capability_name", "capabilityName", "source_capability_name"),
+		UserID:                  readSessionEnvString(detail, "user_id", "userId", "created_by", "operator_user_id"),
+		UserName:                readSessionEnvString(detail, "user_name", "userName", "created_by_name", "operator_user_name"),
 		TemplateID:              detail.TemplateID,
 		RuntimeType:             detail.RuntimeType,
 		LanguageRuntime:         detail.LanguageRuntime,
@@ -307,14 +317,24 @@ func newSandboxSessionSummary(detail *interfaces.SessionDetail) *SandboxSessionS
 }
 
 func detectSessionSource(detail *interfaces.SessionDetail) string {
-	for _, key := range []string{"source", "execution_source", "capability_type"} {
+	if text := readSessionEnvString(detail, "source", "execution_source", "capability_type"); text != "" {
+		return text
+	}
+	return defaultSessionSource
+}
+
+func readSessionEnvString(detail *interfaces.SessionDetail, keys ...string) string {
+	if detail == nil || len(detail.EnvVars) == 0 {
+		return ""
+	}
+	for _, key := range keys {
 		if value, ok := detail.EnvVars[key]; ok {
 			if text := strings.TrimSpace(fmt.Sprint(value)); text != "" {
 				return text
 			}
 		}
 	}
-	return defaultSessionSource
+	return ""
 }
 
 func summarizeSessionError(detail *interfaces.SessionDetail) string {

--- a/adp/execution-factory/operator-integration/server/logics/sandbox/management_test.go
+++ b/adp/execution-factory/operator-integration/server/logics/sandbox/management_test.go
@@ -68,6 +68,14 @@ func TestSandboxManagementService(t *testing.T) {
 						Status:                     interfaces.SessionStatusRunning,
 						TemplateID:                 "python-basic",
 						RuntimeType:                "python",
+						EnvVars: map[string]any{
+							"source":          "function_debug",
+							"task_id":         "task_debug_001",
+							"capability_id":   "cap_weather",
+							"capability_name": "天气查询函数",
+							"user_id":         "user_001",
+							"user_name":       "alice",
+						},
 						DependencyInstallStatus:    "ready",
 						DependencyInstallError:     "",
 						LastActivityAt:             "2026-07-01T09:59:00Z",
@@ -94,6 +102,14 @@ func TestSandboxManagementService(t *testing.T) {
 				Status:                  interfaces.SessionStatusFailed,
 				TemplateID:              "python-basic",
 				RuntimeType:             "python",
+				EnvVars: map[string]any{
+					"execution_source": "skill_execution",
+					"task_id":          "task_skill_404",
+					"capability_id":    "cap_skill_summary",
+					"capability_name":  "总结 Skill",
+					"user_id":          "user_002",
+					"user_name":        "bob",
+				},
 				ResourceLimit:           map[string]any{"cpu": "1", "memory": "512Mi"},
 				WorkspacePath:           "/workspace/sess_aoi_1",
 				DependencyInstallStatus: "failed",
@@ -135,6 +151,12 @@ func TestSandboxManagementService(t *testing.T) {
 		So(err, ShouldBeNil)
 		So(client.listReq.Status, ShouldEqual, interfaces.SessionStatusFailed)
 		So(sessions.Total, ShouldEqual, 2)
+		So(sessions.Items[0].Source, ShouldEqual, "function_debug")
+		So(sessions.Items[0].TaskID, ShouldEqual, "task_debug_001")
+		So(sessions.Items[0].CapabilityID, ShouldEqual, "cap_weather")
+		So(sessions.Items[0].CapabilityName, ShouldEqual, "天气查询函数")
+		So(sessions.Items[0].UserID, ShouldEqual, "user_001")
+		So(sessions.Items[0].UserName, ShouldEqual, "alice")
 		So(sessions.Items[1].Source, ShouldEqual, "unknown")
 		So(sessions.Items[1].RecentErrorSummary, ShouldEqual, "numpy version conflict")
 		So(sessions.Items[1].DependencyInstallStatus, ShouldEqual, "failed")
@@ -143,6 +165,12 @@ func TestSandboxManagementService(t *testing.T) {
 		So(err, ShouldBeNil)
 		So(client.querySession, ShouldEqual, "sess_aoi_1")
 		So(detail.ID, ShouldEqual, "sess_aoi_1")
+		So(detail.Source, ShouldEqual, "skill_execution")
+		So(detail.TaskID, ShouldEqual, "task_skill_404")
+		So(detail.CapabilityID, ShouldEqual, "cap_skill_summary")
+		So(detail.CapabilityName, ShouldEqual, "总结 Skill")
+		So(detail.UserID, ShouldEqual, "user_002")
+		So(detail.UserName, ShouldEqual, "bob")
 		So(detail.RecentErrorSummary, ShouldEqual, "numpy version conflict")
 		So(detail.ResourceLimit["memory"], ShouldEqual, "512Mi")
 	})


### PR DESCRIPTION
## Summary
- Expose optional sandbox session business context fields from session env vars: task, capability, and user.
- Document the new fields in the private sandbox OpenAPI spec.
- Extend sandbox management service tests for these fields.

## Related
- Supports openbkn-ai/bkn-studio#27

## Verification
- GOTOOLCHAIN=go1.24.11 go test ./server/logics/sandbox ./server/driveradapters/sandbox -count=1 -v