### PR TITLE
feat(sandbox): expose runtime context for management UI

### DIFF
--- a/adp/execution-factory/capabilities-lab/server/client/function.go
+++ b/adp/execution-factory/capabilities-lab/server/client/function.go
@@ -15,10 +15,16 @@ import (
 )
 
 type ExecuteFunctionRequest struct {
-	Code     string                 `json:"code"`
-	Event    map[string]interface{} `json:"event,omitempty"`
-	Language string                 `json:"language,omitempty"`
-	Timeout  int                    `json:"timeout,omitempty"`
+	Code           string                 `json:"code"`
+	Event          map[string]interface{} `json:"event,omitempty"`
+	Language       string                 `json:"language,omitempty"`
+	Timeout        int                    `json:"timeout,omitempty"`
+	Source         string                 `json:"source,omitempty"`
+	TaskID         string                 `json:"task_id,omitempty"`
+	CapabilityID   string                 `json:"capability_id,omitempty"`
+	CapabilityName string                 `json:"capability_name,omitempty"`
+	UserID         string                 `json:"user_id,omitempty"`
+	UserName       string                 `json:"user_name,omitempty"`
 }
 
 type ExecuteFunctionResponse struct {

--- a/adp/execution-factory/capabilities-lab/server/client/operator_integration_test.go
+++ b/adp/execution-factory/capabilities-lab/server/client/operator_integration_test.go
@@ -5,7 +5,10 @@
 package client
 
 import (
+	"context"
 	"encoding/json"
+	"net/http"
+	"net/http/httptest"
 	"testing"
 )
 
@@ -29,5 +32,63 @@ func TestCreateToolFailureMessageUsesErrorMsgDescription(t *testing.T) {
 
 	if got := resp.Failures[0].Message(); got != "工具 “test” 已存在" {
 		t.Fatalf("Message() = %q", got)
+	}
+}
+
+func TestExecuteFunctionForwardsSandboxRuntimeContext(t *testing.T) {
+	var payload map[string]interface{}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/agent-operator-integration/v1/function/execute" {
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+		if got := r.Header.Get("x-business-domain"); got != "bd_public" {
+			t.Fatalf("x-business-domain = %q", got)
+		}
+		if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
+			t.Fatalf("decode payload: %v", err)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"result":{"result":{"ok":true}}}`))
+	}))
+	defer server.Close()
+
+	client := &OperatorIntegrationClient{
+		BaseURL: server.URL,
+		HTTP:    server.Client(),
+	}
+
+	_, err := client.ExecuteFunction(
+		context.Background(),
+		"bd_public",
+		"user_001",
+		ExecuteFunctionRequest{
+			Code:           "def handler(event):\n    return event\n",
+			Event:          map[string]interface{}{"city": "beijing"},
+			Language:       "python",
+			Timeout:        30,
+			Source:         "function_debug",
+			TaskID:         "task_e2e_001",
+			CapabilityID:   "cap_function_weather",
+			CapabilityName: "weather_normalizer",
+			UserID:         "user_001",
+			UserName:       "alice",
+		},
+	)
+	if err != nil {
+		t.Fatalf("ExecuteFunction() error = %v", err)
+	}
+
+	assertPayloadString(t, payload, "source", "function_debug")
+	assertPayloadString(t, payload, "task_id", "task_e2e_001")
+	assertPayloadString(t, payload, "capability_id", "cap_function_weather")
+	assertPayloadString(t, payload, "capability_name", "weather_normalizer")
+	assertPayloadString(t, payload, "user_id", "user_001")
+	assertPayloadString(t, payload, "user_name", "alice")
+}
+
+func assertPayloadString(t *testing.T, payload map[string]interface{}, key, want string) {
+	t.Helper()
+	if got, _ := payload[key].(string); got != want {
+		t.Fatalf("payload[%q] = %q, want %q; full payload: %+v", key, got, want, payload)
 	}
 }

--- a/adp/execution-factory/capabilities-lab/server/logic/function.go
+++ b/adp/execution-factory/capabilities-lab/server/logic/function.go
@@ -144,10 +144,16 @@ func (s *Service) ExecutePython(
 	}
 
 	resp, err := s.Client.ExecuteFunction(ctx, businessDomain, s.DefaultUserID, client.ExecuteFunctionRequest{
-		Code:     req.Code,
-		Event:    req.Event,
-		Language: "python",
-		Timeout:  req.Timeout,
+		Code:           req.Code,
+		Event:          req.Event,
+		Language:       "python",
+		Timeout:        req.Timeout,
+		Source:         req.Source,
+		TaskID:         req.TaskID,
+		CapabilityID:   req.CapabilityID,
+		CapabilityName: req.CapabilityName,
+		UserID:         req.UserID,
+		UserName:       req.UserName,
 	})
 	if err != nil {
 		return nil, err

--- a/adp/execution-factory/capabilities-lab/server/model/extensions.go
+++ b/adp/execution-factory/capabilities-lab/server/model/extensions.go
@@ -26,9 +26,15 @@ type CreateFunctionCapabilityResponse struct {
 }
 
 type ExecutePythonRequest struct {
-	Code    string                 `json:"code" binding:"required"`
-	Event   map[string]interface{} `json:"event,omitempty"`
-	Timeout int                    `json:"timeout,omitempty"`
+	Code           string                 `json:"code" binding:"required"`
+	Event          map[string]interface{} `json:"event,omitempty"`
+	Timeout        int                    `json:"timeout,omitempty"`
+	Source         string                 `json:"source,omitempty"`
+	TaskID         string                 `json:"task_id,omitempty"`
+	CapabilityID   string                 `json:"capability_id,omitempty"`
+	CapabilityName string                 `json:"capability_name,omitempty"`
+	UserID         string                 `json:"user_id,omitempty"`
+	UserName       string                 `json:"user_name,omitempty"`
 }
 
 type ExecutePythonResponse struct {

--- a/adp/execution-factory/operator-integration/helm/agent-operator-integration/values.yaml
+++ b/adp/execution-factory/operator-integration/helm/agent-operator-integration/values.yaml
@@ -38,6 +38,7 @@ service:
       interface:
         path:
           - /api/agent-operator-integration/v1
+          - /api/agent-operator-integration/internal-v1
   type: ClusterIP
   enableDualStack: false
   port: 9000

--- a/adp/execution-factory/operator-integration/server/driveradapters/common/proxy.go
+++ b/adp/execution-factory/operator-integration/server/driveradapters/common/proxy.go
@@ -78,6 +78,7 @@ func (h *unifiedProxyHandler) FunctionExecute(c *gin.Context) {
 		Event:                 req.Event,
 		Language:              req.Language,
 		Timeout:               req.Timeout,
+		EnvVars:               buildFunctionExecutionEnv(req),
 		Dependencies:          req.Dependencies,
 		PythonPackageIndexURL: req.DependenciesURL,
 	}
@@ -102,6 +103,32 @@ type FunctionExecuteResp struct {
 	Stderr  string `json:"stderr"`  // 标准错误输出
 	Result  any    `json:"result"`  // 执行结果值
 	Metrics any    `json:"metrics"` // 执行指标
+}
+
+func buildFunctionExecutionEnv(req *interfaces.FunctionProxyExecuteCodeReq) map[string]any {
+	env := map[string]any{"source": "function_debug"}
+	if req == nil {
+		return env
+	}
+	if req.Source != "" {
+		env["source"] = req.Source
+	}
+	if req.TaskID != "" {
+		env["task_id"] = req.TaskID
+	}
+	if req.CapabilityID != "" {
+		env["capability_id"] = req.CapabilityID
+	}
+	if req.CapabilityName != "" {
+		env["capability_name"] = req.CapabilityName
+	}
+	if req.UserID != "" {
+		env["user_id"] = req.UserID
+	}
+	if req.UserName != "" {
+		env["user_name"] = req.UserName
+	}
+	return env
 }
 
 // FunctionExecuteProxyReq 函数执行代理请求参数
@@ -162,10 +189,15 @@ func (h *unifiedProxyHandler) FunctionExecuteProxy(c *gin.Context) {
 		dependencies = utils.JSONToObject[[]*interfaces.DependencyInfo](metadata.GetDependencies())
 	}
 	execReq := &interfaces.ExecuteCodeReq{
-		Code:                  code,
-		Event:                 event,
-		Timeout:               int(req.Timeout / 1000),
-		Language:              scriptType,
+		Code:     code,
+		Event:    event,
+		Timeout:  int(req.Timeout / 1000),
+		Language: scriptType,
+		EnvVars: map[string]any{
+			"source":        "function_proxy",
+			"task_id":       req.Version,
+			"capability_id": req.Version,
+		},
 		Dependencies:          dependencies,
 		PythonPackageIndexURL: metadata.GetDependenciesURL(),
 	}

--- a/adp/execution-factory/operator-integration/server/infra/common/ormhelper/example/example_test.go
+++ b/adp/execution-factory/operator-integration/server/infra/common/ormhelper/example/example_test.go
@@ -246,13 +246,19 @@ func TestUpdateBuilder_Build(t *testing.T) {
 		WhereEq("f_id", "test-id").
 		Build()
 
-	expectedQuery := "UPDATE `test_db`.`t_mcp_server_config` SET f_status = ?, f_update_time = ? WHERE f_id = ?"
-	if query != expectedQuery {
-		t.Errorf("Expected query: %s, got: %s", expectedQuery, query)
-	}
-
-	if len(args) != 3 {
-		t.Errorf("Expected 3 args, got %d", len(args))
+	expectedStatusFirst := "UPDATE `test_db`.`t_mcp_server_config` SET f_status = ?, f_update_time = ? WHERE f_id = ?"
+	expectedTimeFirst := "UPDATE `test_db`.`t_mcp_server_config` SET f_update_time = ?, f_status = ? WHERE f_id = ?"
+	switch query {
+	case expectedStatusFirst:
+		if len(args) != 3 || args[0] != "inactive" || args[1] != 123456789 || args[2] != "test-id" {
+			t.Errorf("Unexpected args for status-first query: %v", args)
+		}
+	case expectedTimeFirst:
+		if len(args) != 3 || args[0] != 123456789 || args[1] != "inactive" || args[2] != "test-id" {
+			t.Errorf("Unexpected args for time-first query: %v", args)
+		}
+	default:
+		t.Errorf("Unexpected update query: %s", query)
 	}
 }
 

--- a/adp/execution-factory/operator-integration/server/interfaces/drivenadapters.go
+++ b/adp/execution-factory/operator-integration/server/interfaces/drivenadapters.go
@@ -522,6 +522,7 @@ type ExecuteCodeReq struct {
 	Language              string            `json:"language" default:"python"`                                   // 执行语言
 	Timeout               int               `json:"timeout,omitempty"`                                           // 超时时间，单位秒
 	WorkingDirectory      string            `json:"working_directory,omitempty"`                                 // 工作目录，相对于 workspace 根目录
+	EnvVars               map[string]any    `json:"env_vars,omitempty"`                                          // 会话业务上下文环境变量
 	Dependencies          []*DependencyInfo `json:"dependencies,omitempty"`                                      // 依赖资源
 	PythonPackageIndexURL string            `json:"python_package_index_url" default:"https://pypi.org/simple/"` // 安装源URL
 }

--- a/adp/execution-factory/operator-integration/server/interfaces/logics_proxy.go
+++ b/adp/execution-factory/operator-integration/server/interfaces/logics_proxy.go
@@ -35,6 +35,12 @@ type FunctionProxyExecuteCodeReq struct {
 	Event           map[string]any    `json:"event" validate:"required"`                                     // 事件
 	Language        string            `json:"language" default:"python"`                                     // 执行语言
 	Timeout         int               `json:"timeout,omitempty"`                                             // 超时时间，单位秒
+	Source          string            `json:"source,omitempty"`                                              // 执行来源
+	TaskID          string            `json:"task_id,omitempty"`                                             // 任务ID
+	CapabilityID    string            `json:"capability_id,omitempty"`                                       // 能力ID
+	CapabilityName  string            `json:"capability_name,omitempty"`                                     // 能力名称
+	UserID          string            `json:"user_id,omitempty"`                                             // 用户ID
+	UserName        string            `json:"user_name,omitempty"`                                           // 用户名
 	Dependencies    []*DependencyInfo `json:"dependencies,omitempty"`                                        // 依赖资源
 	DependenciesURL string            `json:"dependencies_url,omitempty" default:"https://pypi.org/simple/"` // 安装源URL
 }

--- a/adp/execution-factory/operator-integration/server/logics/sandbox/session_pool.go
+++ b/adp/execution-factory/operator-integration/server/logics/sandbox/session_pool.go
@@ -160,7 +160,7 @@ func (p *sessionPoolImpl) ExecuteCode(ctx context.Context, req *interfaces.Execu
 		"code":     req.Code,
 		"event":    req.Event,
 	})
-	sessionID, err := p.AcquireSession(ctx)
+	sessionID, err := p.acquireSessionWithEnv(ctx, req.EnvVars)
 	if err != nil {
 		return nil, err
 	}
@@ -197,6 +197,10 @@ func (p *sessionPoolImpl) AcquireSession(ctx context.Context) (sessionID string,
 	return p.acquireSession(ctx, maxRetryCount)
 }
 
+func (p *sessionPoolImpl) acquireSessionWithEnv(ctx context.Context, envVars map[string]any) (sessionID string, err error) {
+	return p.acquireSessionWithOptions(ctx, maxRetryCount, envVars)
+}
+
 func (p *sessionPoolImpl) initSessions() {
 	ctx := context.Background()
 	recoveredCount := 0
@@ -218,6 +222,10 @@ func (p *sessionPoolImpl) initSessions() {
 
 // acquireSession 从会话池中获取一个会话
 func (p *sessionPoolImpl) acquireSession(ctx context.Context, retryCount int) (sessionID string, err error) {
+	return p.acquireSessionWithOptions(ctx, retryCount, nil)
+}
+
+func (p *sessionPoolImpl) acquireSessionWithOptions(ctx context.Context, retryCount int, envVars map[string]any) (sessionID string, err error) {
 	// 记录可观测
 	ctx, _ = o11y.StartInternalSpan(ctx)
 	defer o11y.EndSpan(ctx, err)
@@ -237,7 +245,7 @@ func (p *sessionPoolImpl) acquireSession(ctx context.Context, retryCount int) (s
 		}
 		// 暂停时间: 每次重试间隔增加 1 秒
 		time.Sleep(time.Duration(count) * time.Second)
-		sessionID, err = p.acquireSession(ctx, count-1)
+		sessionID, err = p.acquireSessionWithOptions(ctx, count-1, envVars)
 	}(retryCount)
 	// 1. 堆叠分配策略：寻找负载最高但未满的会话
 	bestSession := p.findBestSession()
@@ -269,7 +277,7 @@ func (p *sessionPoolImpl) acquireSession(ctx context.Context, retryCount int) (s
 
 	// 5. 执行远程创建
 	p.logger.Infof("Creating new session slot: %s", targetID)
-	if err = p.ensureRemoteSession(ctx, targetID); err != nil {
+	if err = p.ensureRemoteSessionWithEnv(ctx, targetID, envVars); err != nil {
 		p.logger.Errorf("Failed to create session %s: %v", targetID, err)
 		// 创建失败，移除占位符
 		// 容错重试：如果当前 ID 创建失败，递归尝试下一个可用 ID
@@ -283,6 +291,10 @@ func (p *sessionPoolImpl) acquireSession(ctx context.Context, retryCount int) (s
 }
 
 func (p *sessionPoolImpl) ensureRemoteSession(ctx context.Context, sessionID string) error {
+	return p.ensureRemoteSessionWithEnv(ctx, sessionID, nil)
+}
+
+func (p *sessionPoolImpl) ensureRemoteSessionWithEnv(ctx context.Context, sessionID string, envVars map[string]any) error {
 	// 创建前检查是否存在
 	exists, _, err := p.querySessionAndCache(ctx, sessionID)
 	if err != nil {
@@ -298,6 +310,7 @@ func (p *sessionPoolImpl) ensureRemoteSession(ctx context.Context, sessionID str
 			CPU:        p.reqConfig.CPU,
 			Memory:     p.reqConfig.Memory,
 			Disk:       p.reqConfig.Disk,
+			EnvVars:    cloneSessionEnvVars(envVars),
 		}
 
 		_, err := p.client.CreateSession(ctx, req)
@@ -314,6 +327,17 @@ func (p *sessionPoolImpl) ensureRemoteSession(ctx context.Context, sessionID str
 	}
 	p.addSession(sessionID)
 	return nil
+}
+
+func cloneSessionEnvVars(envVars map[string]any) map[string]any {
+	if len(envVars) == 0 {
+		return nil
+	}
+	cloned := make(map[string]any, len(envVars))
+	for key, value := range envVars {
+		cloned[key] = value
+	}
+	return cloned
 }
 
 func (p *sessionPoolImpl) waitForSessionRunning(ctx context.Context, sessionID string) error {

--- a/adp/execution-factory/operator-integration/server/logics/sandbox/session_pool_test.go
+++ b/adp/execution-factory/operator-integration/server/logics/sandbox/session_pool_test.go
@@ -5,12 +5,71 @@ import (
 	"testing"
 	"time"
 
+	"github.com/openbkn-ai/adp/execution-factory/operator-integration/server/infra/config"
 	"github.com/openbkn-ai/adp/execution-factory/operator-integration/server/infra/logger"
 	"github.com/openbkn-ai/adp/execution-factory/operator-integration/server/interfaces"
 	"github.com/openbkn-ai/adp/execution-factory/operator-integration/server/mocks"
 	. "github.com/smartystreets/goconvey/convey"
 	"go.uber.org/mock/gomock"
 )
+
+func TestExecuteCodeCreatesSessionWithBusinessContextEnv(t *testing.T) {
+	Convey("ExecuteCode should pass business context env vars when creating a sandbox session", t, func() {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		mockClient := mocks.NewMockSandBoxControlPlane(ctrl)
+		pool := &sessionPoolImpl{
+			client:             mockClient,
+			sessions:           map[string]*sessionItem{},
+			maxSessions:        1,
+			maxConcurrentTasks: 10,
+			logger:             logger.DefaultLogger(),
+			stopCh:             make(chan struct{}),
+			templateID:         "python-basic",
+			reqConfig:          config.SessionResourcesConfig{CPU: "1", Memory: "512Mi", Disk: "1Gi", Timeout: 3600},
+		}
+
+		expectedEnv := map[string]any{
+			"source":          "function_debug",
+			"task_id":         "task_e2e_001",
+			"capability_id":   "cap_function_weather",
+			"capability_name": "天气归一化函数",
+			"user_id":         "user_001",
+			"user_name":       "alice",
+		}
+
+		gomock.InOrder(
+			mockClient.EXPECT().
+				QuerySession(gomock.Any(), "sess_aoi_0").
+				Return(false, nil, nil),
+			mockClient.EXPECT().
+				CreateSession(gomock.Any(), gomock.AssignableToTypeOf(&interfaces.CreateSessionReq{})).
+				DoAndReturn(func(ctx context.Context, req *interfaces.CreateSessionReq) (any, error) {
+					So(req.ID, ShouldEqual, "sess_aoi_0")
+					So(req.TemplateID, ShouldEqual, "python-basic")
+					So(req.EnvVars, ShouldResemble, expectedEnv)
+					return nil, nil
+				}),
+			mockClient.EXPECT().
+				QuerySession(gomock.Any(), "sess_aoi_0").
+				Return(true, &interfaces.SessionDetail{ID: "sess_aoi_0", Status: interfaces.SessionStatusRunning}, nil),
+			mockClient.EXPECT().
+				ExecuteCodeSync(gomock.Any(), "sess_aoi_0", gomock.AssignableToTypeOf(&interfaces.ExecuteCodeReq{})).
+				Return(&interfaces.ExecuteCodeResp{SessionID: "sess_aoi_0", ReturnValue: map[string]any{"ok": true}}, nil),
+		)
+
+		resp, err := pool.ExecuteCode(context.Background(), &interfaces.ExecuteCodeReq{
+			Code:     "def handler(event):\n    return event",
+			Event:    map[string]any{"city": "beijing"},
+			Language: "python",
+			EnvVars:  expectedEnv,
+		})
+
+		So(err, ShouldBeNil)
+		So(resp.SessionID, ShouldEqual, "sess_aoi_0")
+	})
+}
 
 func TestGetDependenciesCachesFromSessionQuery(t *testing.T) {
 	Convey("GetDependencies caches dependencies from QuerySession", t, func() {


### PR DESCRIPTION
## Summary
- Expose `agent-operator-integration` private sandbox APIs through Helm ingress by adding `/api/agent-operator-integration/internal-v1`.
- Preserve Function debug business context from bkn-studio through capabilities-lab and operator-integration into sandbox session `env_vars`.
- Add regression tests for capabilities-lab request forwarding and sandbox session creation with business context.

## Why
The sandbox runtime management UI needs real sessions that carry source/task/capability/user context. Without the BFF and operator-integration propagation, Function debug runs create sandbox sessions that cannot be attributed in the management page. Without the ingress path, the UI cannot reach the read-only `internal-v1` APIs in deployed environments.

## Verification
- `go test ./server/client ./server/logic ./server/handler -count=1` from `adp/execution-factory/capabilities-lab`
- `go test ./server/logics/sandbox ./server/driveradapters/sandbox ./server/driveradapters/common -count=1` from `adp/execution-factory/operator-integration`
- `helm lint ./helm/agent-operator-integration -f ./helm/agent-operator-integration/values.yaml`
- `helm template agent-operator-integration ./helm/agent-operator-integration -f ./helm/agent-operator-integration/values.yaml | Select-String -Pattern '/api/agent-operator-integration'`
- `git diff --check`

## Related
- Supports openbkn-ai/bkn-studio#27
- Complements openbkn-ai/bkn-studio#28