### PR TITLE
fix(sandbox): track execution context for reused sessions

### DIFF
--- a/adp/execution-factory/operator-integration/server/driveradapters/common/proxy.go
+++ b/adp/execution-factory/operator-integration/server/driveradapters/common/proxy.go
@@ -8,6 +8,7 @@ import (
 	"github.com/creasty/defaults"
 	"github.com/gin-gonic/gin"
 	"github.com/go-playground/validator/v10"
+	"github.com/google/uuid"
 	"github.com/openbkn-ai/adp/execution-factory/operator-integration/server/infra/config"
 	"github.com/openbkn-ai/adp/execution-factory/operator-integration/server/infra/errors"
 	"github.com/openbkn-ai/adp/execution-factory/operator-integration/server/infra/rest"
@@ -95,6 +96,15 @@ func (h *unifiedProxyHandler) FunctionExecute(c *gin.Context) {
 		Metrics: resp.Metrics,
 	}
 	rest.ReplyOK(c, http.StatusOK, result)
+}
+
+func buildFunctionProxyExecutionEnv(version string) map[string]any {
+	return map[string]any{
+		"source":              "function_proxy",
+		"task_id":             "function_proxy_" + uuid.NewString(),
+		"capability_id":       "function_version:" + version,
+		"function_version_id": version,
+	}
 }
 
 // FunctionExecuteResp 函数执行响应
@@ -189,15 +199,11 @@ func (h *unifiedProxyHandler) FunctionExecuteProxy(c *gin.Context) {
 		dependencies = utils.JSONToObject[[]*interfaces.DependencyInfo](metadata.GetDependencies())
 	}
 	execReq := &interfaces.ExecuteCodeReq{
-		Code:     code,
-		Event:    event,
-		Timeout:  int(req.Timeout / 1000),
-		Language: scriptType,
-		EnvVars: map[string]any{
-			"source":        "function_proxy",
-			"task_id":       req.Version,
-			"capability_id": req.Version,
-		},
+		Code:                  code,
+		Event:                 event,
+		Timeout:               int(req.Timeout / 1000),
+		Language:              scriptType,
+		EnvVars:               buildFunctionProxyExecutionEnv(req.Version),
 		Dependencies:          dependencies,
 		PythonPackageIndexURL: metadata.GetDependenciesURL(),
 	}

--- a/adp/execution-factory/operator-integration/server/driveradapters/common/proxy_test.go
+++ b/adp/execution-factory/operator-integration/server/driveradapters/common/proxy_test.go
@@ -1,0 +1,23 @@
+package common
+
+import (
+	"strings"
+	"testing"
+
+	. "github.com/smartystreets/goconvey/convey"
+)
+
+func TestBuildFunctionProxyExecutionEnv(t *testing.T) {
+	Convey("Function proxy execution context should separate task and capability identifiers", t, func() {
+		version := "11111111-1111-4111-8111-111111111111"
+
+		env := buildFunctionProxyExecutionEnv(version)
+
+		So(env["source"], ShouldEqual, "function_proxy")
+		So(env["function_version_id"], ShouldEqual, version)
+		So(env["task_id"], ShouldNotEqual, version)
+		So(strings.HasPrefix(env["task_id"].(string), "function_proxy_"), ShouldBeTrue)
+		So(env["capability_id"], ShouldNotEqual, version)
+		So(env["capability_id"], ShouldEqual, "function_version:"+version)
+	})
+}

--- a/adp/execution-factory/operator-integration/server/logics/sandbox/management.go
+++ b/adp/execution-factory/operator-integration/server/logics/sandbox/management.go
@@ -31,9 +31,10 @@ type PoolSnapshot struct {
 }
 
 type PoolSessionSnapshot struct {
-	ID           string
-	RunningTasks int
-	LastUsedAt   time.Time
+	ID               string
+	RunningTasks     int
+	LastUsedAt       time.Time
+	ExecutionContext map[string]any
 }
 
 type SandboxManagementService interface {
@@ -201,6 +202,7 @@ func (s *sandboxManagementService) ListSessions(ctx context.Context, req *Sandbo
 	if req == nil {
 		req = &SandboxSessionListReq{}
 	}
+	executionContexts := executionContextBySession(s.pool.Snapshot())
 	resp, err := s.client.ListSessions(ctx, &interfaces.ListSessionsReq{
 		Limit:  req.Limit,
 		Offset: req.Offset,
@@ -223,6 +225,7 @@ func (s *sandboxManagementService) ListSessions(ctx context.Context, req *Sandbo
 	result.HasMore = resp.HasMore
 	for _, item := range resp.Sessions {
 		summary := newSandboxSessionSummary(item)
+		applyExecutionContext(summary, executionContexts[summary.ID])
 		if !matchSessionFilters(summary, req) {
 			continue
 		}
@@ -245,6 +248,7 @@ func (s *sandboxManagementService) GetSessionDetail(ctx context.Context, session
 		return nil, errors.DefaultHTTPError(ctx, http.StatusNotFound, fmt.Sprintf("session %s not found", sessionID))
 	}
 	summary := newSandboxSessionSummary(detail)
+	applyExecutionContext(summary, executionContextBySession(s.pool.Snapshot())[sessionID])
 	return &SandboxSessionDetailResp{
 		SandboxSessionSummary:        summary,
 		WorkspacePath:                detail.WorkspacePath,
@@ -274,9 +278,10 @@ func (p *sessionPoolImpl) Snapshot() PoolSnapshot {
 		}
 		runningTasks += item.RunningTasks
 		sessions = append(sessions, PoolSessionSnapshot{
-			ID:           item.ID,
-			RunningTasks: item.RunningTasks,
-			LastUsedAt:   item.LastUsedAt,
+			ID:               item.ID,
+			RunningTasks:     item.RunningTasks,
+			LastUsedAt:       item.LastUsedAt,
+			ExecutionContext: cloneSessionEnvVars(item.ExecutionContext),
 		})
 	}
 	return PoolSnapshot{
@@ -335,6 +340,42 @@ func readSessionEnvString(detail *interfaces.SessionDetail, keys ...string) stri
 		}
 	}
 	return ""
+}
+
+func executionContextBySession(snapshot PoolSnapshot) map[string]map[string]any {
+	contexts := make(map[string]map[string]any, len(snapshot.Sessions))
+	for _, item := range snapshot.Sessions {
+		if item.ID == "" || len(item.ExecutionContext) == 0 {
+			continue
+		}
+		contexts[item.ID] = item.ExecutionContext
+	}
+	return contexts
+}
+
+func applyExecutionContext(summary *SandboxSessionSummary, envVars map[string]any) {
+	if summary == nil || len(envVars) == 0 {
+		return
+	}
+	detail := &interfaces.SessionDetail{EnvVars: envVars}
+	if text := detectSessionSource(detail); text != "" {
+		summary.Source = text
+	}
+	if text := readSessionEnvString(detail, "task_id", "taskId", "execution_task_id"); text != "" {
+		summary.TaskID = text
+	}
+	if text := readSessionEnvString(detail, "capability_id", "capabilityId", "source_capability_id"); text != "" {
+		summary.CapabilityID = text
+	}
+	if text := readSessionEnvString(detail, "capability_name", "capabilityName", "source_capability_name"); text != "" {
+		summary.CapabilityName = text
+	}
+	if text := readSessionEnvString(detail, "user_id", "userId", "created_by", "operator_user_id"); text != "" {
+		summary.UserID = text
+	}
+	if text := readSessionEnvString(detail, "user_name", "userName", "created_by_name", "operator_user_name"); text != "" {
+		summary.UserName = text
+	}
 }
 
 func summarizeSessionError(detail *interfaces.SessionDetail) string {

--- a/adp/execution-factory/operator-integration/server/logics/sandbox/management_test.go
+++ b/adp/execution-factory/operator-integration/server/logics/sandbox/management_test.go
@@ -64,10 +64,10 @@ func TestSandboxManagementService(t *testing.T) {
 			listResp: &interfaces.ListSessionsResp{
 				Sessions: []*interfaces.SessionDetail{
 					{
-						ID:                         "sess_aoi_0",
-						Status:                     interfaces.SessionStatusRunning,
-						TemplateID:                 "python-basic",
-						RuntimeType:                "python",
+						ID:          "sess_aoi_0",
+						Status:      interfaces.SessionStatusRunning,
+						TemplateID:  "python-basic",
+						RuntimeType: "python",
 						EnvVars: map[string]any{
 							"source":          "function_debug",
 							"task_id":         "task_debug_001",
@@ -98,10 +98,10 @@ func TestSandboxManagementService(t *testing.T) {
 				HasMore: false,
 			},
 			detail: &interfaces.SessionDetail{
-				ID:                      "sess_aoi_1",
-				Status:                  interfaces.SessionStatusFailed,
-				TemplateID:              "python-basic",
-				RuntimeType:             "python",
+				ID:          "sess_aoi_1",
+				Status:      interfaces.SessionStatusFailed,
+				TemplateID:  "python-basic",
+				RuntimeType: "python",
 				EnvVars: map[string]any{
 					"execution_source": "skill_execution",
 					"task_id":          "task_skill_404",
@@ -173,5 +173,84 @@ func TestSandboxManagementService(t *testing.T) {
 		So(detail.UserName, ShouldEqual, "bob")
 		So(detail.RecentErrorSummary, ShouldEqual, "numpy version conflict")
 		So(detail.ResourceLimit["memory"], ShouldEqual, "512Mi")
+	})
+}
+
+func TestSandboxManagementServiceUsesPoolExecutionContextOverSessionEnv(t *testing.T) {
+	Convey("Sandbox management service should prefer latest execution context over reusable session env", t, func() {
+		client := &fakeSandboxControlPlane{
+			listResp: &interfaces.ListSessionsResp{
+				Sessions: []*interfaces.SessionDetail{
+					{
+						ID:          "sess_aoi_0",
+						Status:      interfaces.SessionStatusRunning,
+						TemplateID:  "python-basic",
+						RuntimeType: "python",
+						EnvVars: map[string]any{
+							"source":          "function_debug",
+							"task_id":         "task_old",
+							"capability_id":   "cap_old",
+							"capability_name": "old capability",
+							"user_id":         "user_old",
+							"user_name":       "old-user",
+						},
+					},
+				},
+				Total: 1,
+				Limit: 20,
+			},
+			detail: &interfaces.SessionDetail{
+				ID:          "sess_aoi_0",
+				Status:      interfaces.SessionStatusRunning,
+				TemplateID:  "python-basic",
+				RuntimeType: "python",
+				EnvVars: map[string]any{
+					"source":        "function_debug",
+					"task_id":       "task_old",
+					"capability_id": "cap_old",
+					"user_id":       "user_old",
+					"user_name":     "old-user",
+				},
+			},
+			queryExists: true,
+		}
+		pool := &sessionPoolImpl{
+			client: client,
+			sessions: map[string]*sessionItem{
+				"sess_aoi_0": {
+					ID:           "sess_aoi_0",
+					RunningTasks: 0,
+					LastUsedAt:   time.Now(),
+					ExecutionContext: map[string]any{
+						"source":          "function_debug",
+						"task_id":         "task_new",
+						"capability_id":   "cap_new",
+						"capability_name": "new capability",
+						"user_id":         "user_new",
+						"user_name":       "new-user",
+					},
+				},
+			},
+			maxSessions:        1,
+			activeSessions:     1,
+			maxConcurrentTasks: 10,
+		}
+		service := NewSandboxManagementService(client, pool)
+
+		sessions, err := service.ListSessions(context.Background(), &SandboxSessionListReq{Limit: 20})
+		So(err, ShouldBeNil)
+		So(sessions.Items, ShouldHaveLength, 1)
+		So(sessions.Items[0].TaskID, ShouldEqual, "task_new")
+		So(sessions.Items[0].CapabilityID, ShouldEqual, "cap_new")
+		So(sessions.Items[0].CapabilityName, ShouldEqual, "new capability")
+		So(sessions.Items[0].UserID, ShouldEqual, "user_new")
+		So(sessions.Items[0].UserName, ShouldEqual, "new-user")
+
+		detail, err := service.GetSessionDetail(context.Background(), "sess_aoi_0")
+		So(err, ShouldBeNil)
+		So(detail.TaskID, ShouldEqual, "task_new")
+		So(detail.CapabilityID, ShouldEqual, "cap_new")
+		So(detail.UserID, ShouldEqual, "user_new")
+		So(detail.UserName, ShouldEqual, "new-user")
 	})
 }

--- a/adp/execution-factory/operator-integration/server/logics/sandbox/session_pool.go
+++ b/adp/execution-factory/operator-integration/server/logics/sandbox/session_pool.go
@@ -53,10 +53,11 @@ type SessionPool interface {
 }
 
 type sessionItem struct {
-	ID           string
-	Dependencies []*interfaces.DependencyInfo
-	RunningTasks int
-	LastUsedAt   time.Time
+	ID               string
+	Dependencies     []*interfaces.DependencyInfo
+	RunningTasks     int
+	LastUsedAt       time.Time
+	ExecutionContext map[string]any
 }
 
 type sessionPoolImpl struct {
@@ -164,6 +165,7 @@ func (p *sessionPoolImpl) ExecuteCode(ctx context.Context, req *interfaces.Execu
 	if err != nil {
 		return nil, err
 	}
+	p.recordExecutionContext(sessionID, req.EnvVars)
 	defer p.ReleaseSession(sessionID)
 	// 安装依赖库
 	if len(req.Dependencies) > 0 && req.PythonPackageIndexURL != "" {
@@ -338,6 +340,18 @@ func cloneSessionEnvVars(envVars map[string]any) map[string]any {
 		cloned[key] = value
 	}
 	return cloned
+}
+
+func (p *sessionPoolImpl) recordExecutionContext(sessionID string, envVars map[string]any) {
+	if len(envVars) == 0 {
+		return
+	}
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if item, ok := p.sessions[sessionID]; ok && item != nil {
+		item.ExecutionContext = cloneSessionEnvVars(envVars)
+		item.LastUsedAt = time.Now()
+	}
 }
 
 func (p *sessionPoolImpl) waitForSessionRunning(ctx context.Context, sessionID string) error {

--- a/adp/execution-factory/operator-integration/server/logics/sandbox/session_pool_test.go
+++ b/adp/execution-factory/operator-integration/server/logics/sandbox/session_pool_test.go
@@ -124,3 +124,58 @@ func TestGetDependenciesCachesFromSessionQuery(t *testing.T) {
 		So(item.Dependencies, ShouldResemble, firstDetail.InstalledDependencies)
 	})
 }
+
+func TestExecuteCodeRecordsExecutionContextWhenReusingSession(t *testing.T) {
+	Convey("ExecuteCode should record request context even when reusing a prewarmed session", t, func() {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		mockClient := mocks.NewMockSandBoxControlPlane(ctrl)
+		pool := &sessionPoolImpl{
+			client: mockClient,
+			sessions: map[string]*sessionItem{
+				"sess_aoi_0": {
+					ID:           "sess_aoi_0",
+					RunningTasks: 0,
+					LastUsedAt:   time.Now(),
+				},
+			},
+			maxSessions:        1,
+			maxConcurrentTasks: 10,
+			logger:             logger.DefaultLogger(),
+			stopCh:             make(chan struct{}),
+		}
+
+		execEnv := map[string]any{
+			"source":          "function_debug",
+			"task_id":         "task_reuse_001",
+			"capability_id":   "cap_reuse_weather",
+			"capability_name": "weather_reuse",
+			"user_id":         "user_reuse",
+			"user_name":       "reuse-user",
+		}
+
+		gomock.InOrder(
+			mockClient.EXPECT().
+				QuerySession(gomock.Any(), "sess_aoi_0").
+				Return(true, &interfaces.SessionDetail{ID: "sess_aoi_0", Status: interfaces.SessionStatusRunning}, nil),
+			mockClient.EXPECT().
+				ExecuteCodeSync(gomock.Any(), "sess_aoi_0", gomock.AssignableToTypeOf(&interfaces.ExecuteCodeReq{})).
+				Return(&interfaces.ExecuteCodeResp{SessionID: "sess_aoi_0", ReturnValue: map[string]any{"ok": true}}, nil),
+		)
+
+		resp, err := pool.ExecuteCode(context.Background(), &interfaces.ExecuteCodeReq{
+			Code:     "def handler(event):\n    return event",
+			Event:    map[string]any{"city": "beijing"},
+			Language: "python",
+			EnvVars:  execEnv,
+		})
+
+		So(err, ShouldBeNil)
+		So(resp.SessionID, ShouldEqual, "sess_aoi_0")
+
+		snapshot := pool.Snapshot()
+		So(snapshot.Sessions, ShouldHaveLength, 1)
+		So(snapshot.Sessions[0].ExecutionContext, ShouldResemble, execEnv)
+	})
+}


### PR DESCRIPTION
﻿## Summary
- Record the latest execution context on sandbox sessions even when a prewarmed/reusable session is used.
- Prefer the pool execution context in sandbox runtime management list/detail responses so attribution reflects the latest execution.
- Separate FunctionExecuteProxy execution task id from function version capability identity and include `function_version_id` explicitly.

Fixes #136
Fixes #137

## Tests
- `go test ./server/logics/sandbox -run "TestExecuteCodeRecordsExecutionContextWhenReusingSession|TestSandboxManagementServiceUsesPoolExecutionContextOverSessionEnv" -count=1 -v`
- `go test ./server/driveradapters/common -run TestBuildFunctionProxyExecutionEnv -count=1 -v`
- `go test ./server/logics/sandbox ./server/driveradapters/common -count=1`
- `go test -count=1 -gcflags="all=-N -l" <all operator-integration packages except /server/tests and /server/mocks>`
