### PR TITLE
feat(mf-model-api): accept bak_ AppKeys for model invocation auth

### DIFF
--- a/infra/mf-model-api/app/commons/errors/__init__.py
+++ b/infra/mf-model-api/app/commons/errors/__init__.py
@@ -1216,6 +1216,13 @@ HydraServiceError = {
     "solution": "请检查hrdra服务状态",
     "link": ""
 }
+BknSafeServiceError = {
+    "code": "BknSafeServiceError",
+    "description": "调用bkn-safe服务异常",
+    "detail": "调用bkn-safe服务异常",
+    "solution": "请检查bkn-safe服务状态",
+    "link": ""
+}
 UserManagementError = {
     "code": "UserManagementServiceError",
     "description": "调用user-management服务异常",

--- a/infra/mf-model-api/app/test/test_app_utils.py
+++ b/infra/mf-model-api/app/test/test_app_utils.py
@@ -195,6 +195,93 @@ class TestAuthMiddleware:
             response = await auth_middleware(mock_request, mock_call_next)
             assert response.status_code == 401
 
+    @staticmethod
+    def _mock_session(status, body):
+        """构造 aiohttp.ClientSession mock,返回 (session_cm, session)"""
+        mock_response = AsyncMock()
+        mock_response.status = status
+        mock_response.text = AsyncMock(return_value=body)
+
+        mock_post_cm = AsyncMock()
+        mock_post_cm.__aenter__ = AsyncMock(return_value=mock_response)
+        mock_post_cm.__aexit__ = AsyncMock(return_value=None)
+
+        mock_session = AsyncMock()
+        mock_session.post = Mock(return_value=mock_post_cm)
+
+        mock_session_cm = AsyncMock()
+        mock_session_cm.__aenter__ = AsyncMock(return_value=mock_session)
+        mock_session_cm.__aexit__ = AsyncMock(return_value=None)
+        return mock_session_cm, mock_session
+
+    @pytest.mark.asyncio
+    async def test_appkey_valid_user(self, mock_request, mock_call_next):
+        """测试有效 bak_ AppKey:走 bkn-safe introspect,注入 user 身份头"""
+        mock_request.url.path = "/api/v1/test"
+        mock_request.headers = {"Authorization": "Bearer bak_kid_secret"}
+
+        session_cm, session = self._mock_session(
+            200, '{"active": true, "sub": "user123", "account_type": "email", "key_id": "kid"}')
+        with patch('app.utils.app_utils.aiohttp.ClientSession', return_value=session_cm), \
+                patch.dict('os.environ', {"BKN_SAFE_URL": "http://safe:8080"}):
+            response = await auth_middleware(mock_request, mock_call_next)
+            assert response.status_code == 200
+            session.post.assert_called_once_with(
+                "http://safe:8080/api/safe/v1/api-keys/introspect",
+                json={"token": "bak_kid_secret"})
+            assert (b"x-account-id", b"user123") in mock_request.scope['headers']
+            assert (b"x-account-type", b"user") in mock_request.scope['headers']
+
+    @pytest.mark.asyncio
+    async def test_appkey_valid_app_account(self, mock_request, mock_call_next):
+        """测试应用账户的 AppKey:account_type=app 映射为 app 角色"""
+        mock_request.url.path = "/api/v1/test"
+        mock_request.headers = {"Authorization": "Bearer bak_kid_secret"}
+
+        session_cm, _ = self._mock_session(
+            200, '{"active": true, "sub": "app456", "account_type": "app", "key_id": "kid"}')
+        with patch('app.utils.app_utils.aiohttp.ClientSession', return_value=session_cm), \
+                patch.dict('os.environ', {"BKN_SAFE_URL": "http://safe:8080"}):
+            response = await auth_middleware(mock_request, mock_call_next)
+            assert response.status_code == 200
+            assert (b"x-account-type", b"app") in mock_request.scope['headers']
+
+    @pytest.mark.asyncio
+    async def test_appkey_inactive(self, mock_request, mock_call_next):
+        """测试无效/过期 AppKey:bkn-safe 返回 active=false → 401"""
+        mock_request.url.path = "/api/v1/test"
+        mock_request.headers = {"Authorization": "Bearer bak_kid_secret"}
+
+        session_cm, _ = self._mock_session(200, '{"active": false}')
+        with patch('app.utils.app_utils.aiohttp.ClientSession', return_value=session_cm), \
+                patch.dict('os.environ', {"BKN_SAFE_URL": "http://safe:8080"}):
+            response = await auth_middleware(mock_request, mock_call_next)
+            assert response.status_code == 401
+
+    @pytest.mark.asyncio
+    async def test_appkey_without_bkn_safe_url(self, mock_request, mock_call_next):
+        """测试 BKN_SAFE_URL 未配置:bak_ key 一律 401(fail-closed),不打 hydra"""
+        mock_request.url.path = "/api/v1/test"
+        mock_request.headers = {"Authorization": "Bearer bak_kid_secret"}
+
+        with patch.dict('os.environ', {}, clear=True):
+            with patch('app.utils.app_utils.aiohttp.ClientSession') as mock_session_cls:
+                response = await auth_middleware(mock_request, mock_call_next)
+                assert response.status_code == 401
+                mock_session_cls.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_appkey_service_error(self, mock_request, mock_call_next):
+        """测试 bkn-safe 服务异常:非 200 → 400 BknSafeServiceError"""
+        mock_request.url.path = "/api/v1/test"
+        mock_request.headers = {"Authorization": "Bearer bak_kid_secret"}
+
+        session_cm, _ = self._mock_session(500, 'internal error')
+        with patch('app.utils.app_utils.aiohttp.ClientSession', return_value=session_cm), \
+                patch.dict('os.environ', {"BKN_SAFE_URL": "http://safe:8080"}):
+            response = await auth_middleware(mock_request, mock_call_next)
+            assert response.status_code == 400
+
 
 class TestRequestSizeMiddleware:
     """测试RequestSizeMiddleware类"""

--- a/infra/mf-model-api/app/utils/app_utils.py
+++ b/infra/mf-model-api/app/utils/app_utils.py
@@ -1,11 +1,13 @@
 import asyncio
 import json
+import os
+
 import aiohttp
 from fastapi import FastAPI, Request
 from fastapi.responses import JSONResponse
 from starlette.middleware.base import BaseHTTPMiddleware
 
-from app.commons.errors import UnauthorizedError, HydraServiceError
+from app.commons.errors import UnauthorizedError, HydraServiceError, BknSafeServiceError
 from app.core.config import base_config, server_info, observability_config
 from app.logs import log_init, sys_log
 from app.mydb.ConnectUtil import get_redis_util
@@ -41,6 +43,48 @@ async def shutdown_event():
     shutdown_observability()
 
 
+# 用户自助签发的 AppKey 前缀(bkn-safe 签发),与 bkn-safe auth.KeyPrefix 保持一致
+APP_KEY_PREFIX = "bak_"
+
+
+async def _verify_app_key(token):
+    """AppKey(bak_ 前缀)走 bkn-safe 内部校验接口 /api/safe/v1/api-keys/introspect,
+    响应形如 OAuth2 introspection:任何失败均为 200 {active:false}。
+    校验通过返回 (user_id, role);无效或 BKN_SAFE_URL 未配置(fail-closed)返回错误响应。"""
+    bkn_safe_url = os.getenv("BKN_SAFE_URL", "")
+    if not bkn_safe_url:
+        return JSONResponse(
+            status_code=401,
+            content=UnauthorizedError
+        )
+    url = f"{bkn_safe_url}/api/safe/v1/api-keys/introspect"
+    try:
+        async with aiohttp.ClientSession() as session:
+            async with session.post(url, json={"token": token}) as response:
+                if response.status != 200:
+                    error_dict = BknSafeServiceError.copy()
+                    error_dict["detail"] = await response.text()
+                    return JSONResponse(
+                        status_code=400,
+                        content=error_dict
+                    )
+                result = json.loads(await response.text())
+    except Exception:
+        return JSONResponse(
+            status_code=400,
+            content=BknSafeServiceError
+        )
+    if not result.get("active", False):
+        return JSONResponse(
+            status_code=401,
+            content=UnauthorizedError
+        )
+    user_id = result.get("sub", "")
+    # bkn-safe account_type: "app"=应用账户,其余按用户处理,与 hydra 路径的 role 口径一致
+    role = "app" if result.get("account_type", "") == "app" else "user"
+    return user_id, role
+
+
 async def auth_middleware(request: Request, call_next):
     path = request.url.path
     if path.startswith("/api/v1/health"):
@@ -60,6 +104,16 @@ async def auth_middleware(request: Request, call_next):
                 content=UnauthorizedError
             )
         token = auth_header[7:]
+        # 凭据二选一:bak_ 前缀的 AppKey 交给 bkn-safe 校验,其余 bearer token 走 hydra 内省
+        if token.startswith(APP_KEY_PREFIX):
+            verified = await _verify_app_key(token)
+            if isinstance(verified, JSONResponse):
+                return verified
+            user_id, role = verified
+            request.scope['headers'].append((b"x-account-id", user_id.encode()))
+            request.scope['headers'].append((b"x-account-type", role.encode()))
+            response = await call_next(request)
+            return response
         hydra_url = f"http://{base_config.OAUTHADMINHOST}:{base_config.OAUTHADMINPORT}/admin/oauth2/introspect"
         async with aiohttp.ClientSession() as session:
             try:


### PR DESCRIPTION
Closes #142

## 问题

模型调用（mf-model-api：OpenAI 兼容 chat / embedding / rerank / 小模型调用）的鉴权中间件只有 hydra introspect 一条路。用户自助签发的 AppKey（`bak_` 前缀，bkn-safe 签发）不是 hydra token，一律 401。目前全仓库只有 context-loader MCP 入口（agent-retrieval）支持 bak_ key。

## 改动

与 agent-retrieval 网关对齐，凭据二选一：

- Bearer token 以 `bak_` 开头 → 调 bkn-safe 内部校验接口 `POST /api/safe/v1/api-keys/introspect`（ClusterIP 内部、tokenless；任何失败 200 `{active:false}`）
- 其余 → 维持 hydra introspect 不变

校验通过注入与 hydra 路径一致的 `x-account-id` / `x-account-type` 头（bkn-safe `account_type == "app"` → `app`，其余 → `user`），下游审计/权限逻辑无感。

- bkn-safe 地址复用 chart 已注入的 `BKN_SAFE_URL` env（directory 切换已在用），无 chart 改动
- `BKN_SAFE_URL` 未配置时 `bak_` key 一律 401（fail-closed），不回落 hydra
- bkn-safe 非 200 → 400 `BknSafeServiceError`（新错误码，对齐 `HydraServiceError` 形制）

## 测试

新增 5 个中间件单测（有效 user key / app 账户 key / active=false / URL 未配置 fail-closed / 服务异常）。按 issue #2 配方在 `model-factory-base:v2` 镜像内跑全量：

```
266 passed, 3 skipped
```

（此前基线 261 passed + 本 PR 新增 5。）

## 范围外

mf-model-manager、operator-integration 等其他 hydra-only 服务不在本次范围（见 #142）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)