### PR TITLE
fix(vega-backend): improve PostgreSQL catalog discovery

### DIFF
--- a/adp/vega/vega-backend/server/interfaces/discover_worker.go
+++ b/adp/vega/vega-backend/server/interfaces/discover_worker.go
@@ -20,6 +20,7 @@ type DiscoverResult struct {
 	UnchangedCount int    `json:"unchanged_count"`
 	UpdatedCount   int    `json:"updated_count"`
 	RestoredCount  int    `json:"restored_count"`
+	FailedCount    int    `json:"failed_count"`
 	Message        string `json:"message"`
 }
 

--- a/adp/vega/vega-backend/server/interfaces/resource.go
+++ b/adp/vega/vega-backend/server/interfaces/resource.go
@@ -31,6 +31,7 @@ const (
 	DiscoverStatusUpdated   string = "updated"
 	DiscoverStatusRestored  string = "restored"
 	DiscoverStatusMissing   string = "missing"
+	DiscoverStatusError     string = "error"
 )
 
 var (

--- a/adp/vega/vega-backend/server/logics/connectors/local/table/mariadb/mariadb.go
+++ b/adp/vega/vega-backend/server/logics/connectors/local/table/mariadb/mariadb.go
@@ -242,6 +242,9 @@ func (c *MariaDBConnector) validateDatabases(ctx context.Context) error {
 		}
 		existingDBs[dbName] = true
 	}
+	if err := rows.Err(); err != nil {
+		return fmt.Errorf("failed to iterate databases: %w", err)
+	}
 
 	// 检查配置的数据库是否都存在
 	var notFoundDBs []string
@@ -313,6 +316,9 @@ func (c *MariaDBConnector) ExecuteRawSQL(ctx context.Context, sql string) (*inte
 			row[col] = convertValue(values[i])
 		}
 		response.Entries = append(response.Entries, row)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate rows failed: %w", err)
 	}
 
 	response.TotalCount = int64(len(response.Entries))

--- a/adp/vega/vega-backend/server/logics/connectors/local/table/mariadb/mariadb_discover.go
+++ b/adp/vega/vega-backend/server/logics/connectors/local/table/mariadb/mariadb_discover.go
@@ -42,6 +42,9 @@ func (c *MariaDBConnector) ListDatabases(ctx context.Context) ([]string, error) 
 			databases = append(databases, db)
 		}
 	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("failed to iterate databases: %w", err)
+	}
 	return databases, nil
 }
 
@@ -146,6 +149,9 @@ func (c *MariaDBConnector) ListTables(ctx context.Context) ([]*interfaces.TableM
 		}
 
 		tables = append(tables, meta)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("failed to iterate table info: %w", err)
 	}
 
 	return tables, nil
@@ -346,6 +352,9 @@ func (c *MariaDBConnector) fetchColumns(ctx context.Context, table *interfaces.T
 			pkColumns = append(pkColumns, col.Name)
 		}
 	}
+	if err := rows.Err(); err != nil {
+		return err
+	}
 
 	table.Columns = columns
 	table.PKs = pkColumns
@@ -400,6 +409,9 @@ func (c *MariaDBConnector) fetchIndexes(ctx context.Context, table *interfaces.T
 				Primary: name == "PRIMARY",
 			}
 		}
+	}
+	if err := rows.Err(); err != nil {
+		return err
 	}
 
 	var indices []interfaces.TableIndexMeta
@@ -464,6 +476,9 @@ func (c *MariaDBConnector) fetchForeignKeys(ctx context.Context, table *interfac
 			}
 		}
 	}
+	if err := rows.Err(); err != nil {
+		return err
+	}
 
 	// Note: Handling OnDelete/OnUpdate requires joining with REFERENTIAL_CONSTRAINTS, skipping for simplicity unless requested.
 
@@ -526,6 +541,9 @@ func (c *MariaDBConnector) GetMetadata(ctx context.Context) (map[string]any, err
 		if err := rows.Scan(&varName, &varValue); err == nil {
 			metadata[varName] = varValue
 		}
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
 	}
 
 	// 3. Infer Cluster Mode

--- a/adp/vega/vega-backend/server/logics/connectors/local/table/mariadb/mariadb_query.go
+++ b/adp/vega/vega-backend/server/logics/connectors/local/table/mariadb/mariadb_query.go
@@ -264,6 +264,9 @@ func (c *MariaDBConnector) ExecuteQuery(ctx context.Context, resource *interface
 		}
 		result.Rows = append(result.Rows, row)
 	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
 
 	// 处理总数（仅明细查询）：独立 COUNT 查询，与 postgresql 连接器对齐。
 	// 此前直接取 len(result.Rows)——即本页行数，超过一页的表 total 永远等于

--- a/adp/vega/vega-backend/server/logics/connectors/local/table/oracle/oracle.go
+++ b/adp/vega/vega-backend/server/logics/connectors/local/table/oracle/oracle.go
@@ -262,6 +262,9 @@ func (c *OracleConnector) validateSchemas(ctx context.Context) error {
 		}
 		existingSchemas[strings.ToUpper(schemaName)] = true
 	}
+	if err := rows.Err(); err != nil {
+		return fmt.Errorf("failed to iterate schemas: %w", err)
+	}
 
 	// Check if all configured schemas exist
 	var notFoundSchemas []string
@@ -300,6 +303,9 @@ func (c *OracleConnector) ListSchemas(ctx context.Context) ([]string, error) {
 		if !SYSTEM_SCHEMAS_MAP[strings.ToUpper(schema)] {
 			schemas = append(schemas, schema)
 		}
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("failed to iterate schemas: %w", err)
 	}
 	return schemas, nil
 }
@@ -379,6 +385,9 @@ func (c *OracleConnector) ListTables(ctx context.Context) ([]*interfaces.TableMe
 		}
 
 		tables = append(tables, meta)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("failed to iterate table info: %w", err)
 	}
 	return tables, nil
 }
@@ -522,6 +531,9 @@ func (c *OracleConnector) fetchColumns(ctx context.Context, table *interfaces.Ta
 		}
 		columns = append(columns, col)
 	}
+	if err := rows.Err(); err != nil {
+		return err
+	}
 
 	table.Columns = columns
 	return nil
@@ -573,6 +585,9 @@ func (c *OracleConnector) fetchIndexes(ctx context.Context, table *interfaces.Ta
 				Primary: name == strings.ToUpper(table.Name)+"_PK", // Oracle primary key naming convention
 			}
 		}
+	}
+	if err := rows.Err(); err != nil {
+		return err
 	}
 
 	var indexes []interfaces.TableIndexMeta
@@ -633,6 +648,9 @@ func (c *OracleConnector) fetchForeignKeys(ctx context.Context, table *interface
 			}
 		}
 	}
+	if err := rows.Err(); err != nil {
+		return err
+	}
 
 	var fks []interfaces.TableForeignKeyMeta
 	for _, fk := range fkMap {
@@ -688,6 +706,9 @@ func (c *OracleConnector) GetMetadata(ctx context.Context) (map[string]any, erro
 		if err := rows.Scan(&paramName, &paramValue); err == nil {
 			metadata[paramName] = paramValue
 		}
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
 	}
 
 	// Get version info

--- a/adp/vega/vega-backend/server/logics/connectors/local/table/postgresql/postgresql.go
+++ b/adp/vega/vega-backend/server/logics/connectors/local/table/postgresql/postgresql.go
@@ -31,6 +31,19 @@ type postgresqlConfig struct {
 	Options  map[string]any `mapstructure:"options"`
 }
 
+var (
+	SYSTEM_SCHEMAS = []string{
+		"information_schema",
+		"pg_catalog",
+		"pg_toast",
+	}
+	SYSTEM_SCHEMAS_MAP = map[string]bool{
+		"information_schema": true,
+		"pg_catalog":         true,
+		"pg_toast":           true,
+	}
+)
+
 const (
 	databaseNameMaxLength = 63 // PostgreSQL 标识符默认上限
 	portMin               = 1
@@ -279,6 +292,9 @@ func (c *PostgresqlConnector) ExecuteRawSQL(ctx context.Context, sql string) (*i
 			row[col] = convertValue(values[i], col, nil)
 		}
 		response.Entries = append(response.Entries, row)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate rows failed: %w", err)
 	}
 
 	response.TotalCount = int64(len(response.Entries))

--- a/adp/vega/vega-backend/server/logics/connectors/local/table/postgresql/postgresql_discover.go
+++ b/adp/vega/vega-backend/server/logics/connectors/local/table/postgresql/postgresql_discover.go
@@ -38,7 +38,7 @@ func (c *PostgresqlConnector) ListDatabases(ctx context.Context) ([]string, erro
 	}
 	var out []string
 	for _, s := range all {
-		if _, ok := allow[s]; ok {
+		if _, ok := allow[s]; ok && !SYSTEM_SCHEMAS_MAP[s] {
 			out = append(out, s)
 		}
 	}
@@ -46,13 +46,18 @@ func (c *PostgresqlConnector) ListDatabases(ctx context.Context) ([]string, erro
 }
 
 func (c *PostgresqlConnector) listUserSchemas(ctx context.Context) ([]string, error) {
-	rows, err := c.db.QueryContext(ctx, `
-SELECT nspname
-FROM pg_catalog.pg_namespace
-WHERE nspname NOT IN ('information_schema', 'pg_catalog', 'pg_toast')
-  AND nspname NOT LIKE 'pg\_temp\_%' ESCAPE '\'
-  AND nspname NOT LIKE 'pg\_toast\_temp\_%' ESCAPE '\'
-ORDER BY nspname`)
+	query, args, err := pgSq.Select("nspname").
+		From("pg_catalog.pg_namespace").
+		Where(sq.NotEq{"nspname": SYSTEM_SCHEMAS}).
+		Where(sq.Expr("NOT pg_is_other_temp_schema(oid)")).
+		Where(sq.Expr("oid <> pg_my_temp_schema()")).
+		OrderBy("nspname").
+		ToSql()
+	if err != nil {
+		return nil, fmt.Errorf("failed to build list schemas query: %w", err)
+	}
+
+	rows, err := c.db.QueryContext(ctx, query, args...)
 	if err != nil {
 		return nil, fmt.Errorf("failed to list schemas: %w", err)
 	}
@@ -66,33 +71,38 @@ ORDER BY nspname`)
 		}
 		schemas = append(schemas, name)
 	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
 	return schemas, nil
 }
 
-// ListTables 列出表与视图；TableMeta.Database 填 schema 名。
+// ListTables 列出表、视图和物化视图；TableMeta.Database 填 database 名，Schema 填 schema 名。
 func (c *PostgresqlConnector) ListTables(ctx context.Context) ([]*interfaces.TableMeta, error) {
 	if err := c.Connect(ctx); err != nil {
 		return nil, err
 	}
 
 	builder := pgSq.Select(
-		"t.table_schema",
-		"t.table_name",
-		"t.table_type",
+		"n.nspname AS table_schema",
+		"c.relname AS table_name",
+		"c.relkind::text AS relkind",
 		"COALESCE(obj_description(c.oid, 'pg_class'), '') AS description",
-	).From("information_schema.tables t").
-		Join("pg_catalog.pg_class c ON c.relname = t.table_name AND c.relnamespace = (SELECT oid FROM pg_catalog.pg_namespace WHERE nspname = t.table_schema)").
-		Where(sq.Eq{"t.table_catalog": c.currentCatalogName()}).
-		Where(sq.NotEq{"t.table_schema": []string{"information_schema", "pg_catalog"}}).
-		Where(sq.Expr("table_schema NOT LIKE ?", "pg\\_temp\\_%")).
-		Where(sq.Expr("table_schema NOT LIKE ?", "pg\\_toast\\_temp\\_%")).
-		Where(sq.Eq{"table_type": []string{"BASE TABLE", "VIEW", "FOREIGN TABLE", "MATERIALIZED VIEW"}})
+	).From("pg_catalog.pg_class c").
+		Join("pg_catalog.pg_namespace n ON n.oid = c.relnamespace").
+		// relkind: r=ordinary table, p=partitioned table, v=view, m=materialized view, f=foreign table.
+		Where(sq.Eq{"c.relkind": []string{"r", "p", "v", "m", "f"}}).
+		// relpersistence: p=permanent, u=unlogged, t=temporary.
+		Where(sq.NotEq{"c.relpersistence": "t"}).
+		Where(sq.Expr("has_table_privilege(c.oid, ?)", "SELECT")).
+		Where(sq.NotEq{"n.nspname": SYSTEM_SCHEMAS}).
+		Where(sq.Expr("NOT pg_is_other_temp_schema(n.oid)"))
 
 	if len(c.config.Schemas) > 0 {
-		builder = builder.Where(sq.Eq{"t.table_schema": c.config.Schemas})
+		builder = builder.Where(sq.Eq{"n.nspname": c.config.Schemas})
 	}
 
-	query, args, err := builder.OrderBy("t.table_schema", "table_name").ToSql()
+	query, args, err := builder.OrderBy("n.nspname", "c.relname").ToSql()
 	if err != nil {
 		return nil, fmt.Errorf("failed to build list tables query: %w", err)
 	}
@@ -105,34 +115,34 @@ func (c *PostgresqlConnector) ListTables(ctx context.Context) ([]*interfaces.Tab
 
 	var tables []*interfaces.TableMeta
 	for rows.Next() {
-		var schema, name, tableType, description string
-		if err := rows.Scan(&schema, &name, &tableType, &description); err != nil {
+		var schema, name, relKind, description string
+		if err := rows.Scan(&schema, &name, &relKind, &description); err != nil {
 			return nil, fmt.Errorf("failed to scan table info: %w", err)
-		}
-		tt := "table"
-		switch tableType {
-		case "VIEW":
-			tt = "view"
-		case "MATERIALIZED VIEW":
-			tt = "materialized_view"
-		case "FOREIGN TABLE":
-			tt = "table"
 		}
 		tables = append(tables, &interfaces.TableMeta{
 			Name:        name,
-			TableType:   tt,
+			TableType:   postgresqlTableTypeFromRelkind(relKind),
 			Database:    c.config.Database,
 			Schema:      schema,
 			Description: description,
 			Properties:  map[string]any{},
 		})
 	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("failed to iterate table info: %w", err)
+	}
 	return tables, nil
 }
 
-func (c *PostgresqlConnector) currentCatalogName() string {
-	// 连接已限定 database；current_database() 与 information_schema.tables.table_catalog 一致
-	return c.config.Database
+func postgresqlTableTypeFromRelkind(relKind string) string {
+	switch relKind {
+	case "v":
+		return "view"
+	case "m":
+		return "materialized_view"
+	default:
+		return "table"
+	}
 }
 
 // GetTableMeta 填充表元数据。
@@ -203,14 +213,45 @@ WHERE n.nspname = $1 AND c.relname = $2 AND c.relkind IN ('r', 'v', 'm', 'p', 'f
 
 func (c *PostgresqlConnector) fetchColumns(ctx context.Context, table *interfaces.TableMeta) error {
 	query := `
-SELECT column_name, data_type, udt_name, is_nullable, column_default,
-       character_maximum_length, numeric_precision, numeric_scale, datetime_precision,
-       collation_name, ordinal_position
-FROM information_schema.columns
-WHERE table_catalog = $1 AND table_schema = $2 AND table_name = $3
-ORDER BY ordinal_position`
+SELECT a.attname AS column_name,
+       format_type(a.atttypid, a.atttypmod) AS data_type,
+       t.typname AS udt_name,
+       CASE WHEN a.attnotnull THEN 'NO' ELSE 'YES' END AS is_nullable,
+       COALESCE(pg_get_expr(ad.adbin, ad.adrelid), '') AS column_default,
+       CASE
+           WHEN a.atttypmod > 0 AND t.typname IN ('bpchar', 'varchar') THEN a.atttypmod - 4
+           ELSE NULL
+       END AS character_maximum_length,
+       CASE
+           WHEN t.typname = 'numeric' AND a.atttypmod >= 0 THEN ((a.atttypmod - 4) >> 16) & 65535
+           WHEN t.typname IN ('int2', 'int4', 'int8') THEN NULL
+           WHEN t.typname IN ('float4', 'float8') THEN NULL
+           ELSE NULL
+       END AS numeric_precision,
+       CASE
+           WHEN t.typname = 'numeric' AND a.atttypmod >= 0 THEN (a.atttypmod - 4) & 65535
+           ELSE NULL
+       END AS numeric_scale,
+       CASE
+           WHEN t.typname IN ('time', 'timetz', 'timestamp', 'timestamptz') AND a.atttypmod >= 0 THEN a.atttypmod
+           ELSE NULL
+       END AS datetime_precision,
+       COALESCE(coll.collname, '') AS collation_name,
+       a.attnum AS ordinal_position,
+       COALESCE(col_description(a.attrelid, a.attnum), '') AS description
+FROM pg_catalog.pg_class c
+JOIN pg_catalog.pg_namespace n ON n.oid = c.relnamespace
+JOIN pg_catalog.pg_attribute a ON a.attrelid = c.oid
+JOIN pg_catalog.pg_type t ON t.oid = a.atttypid
+LEFT JOIN pg_catalog.pg_attrdef ad ON ad.adrelid = a.attrelid AND ad.adnum = a.attnum
+LEFT JOIN pg_catalog.pg_collation coll ON coll.oid = a.attcollation
+WHERE n.nspname = $1 AND c.relname = $2
+  AND c.relkind IN ('r', 'p', 'v', 'm', 'f')
+  AND a.attnum > 0
+  AND NOT a.attisdropped
+ORDER BY a.attnum`
 
-	rows, err := c.db.QueryContext(ctx, query, c.config.Database, table.Schema, table.Name)
+	rows, err := c.db.QueryContext(ctx, query, table.Schema, table.Name)
 	if err != nil {
 		return err
 	}
@@ -224,12 +265,13 @@ ORDER BY ordinal_position`
 	var columns []interfaces.TableColumnMeta
 	for rows.Next() {
 		var name, dataType, udtName, isNullable sql.NullString
-		var colDefault, collation sql.NullString
+		var colDefault, collation, description sql.NullString
 		var charMax, numPrec, numScale, dtPrec, ord sql.NullInt64
 
 		if err := rows.Scan(
 			&name, &dataType, &udtName, &isNullable, &colDefault,
 			&charMax, &numPrec, &numScale, &dtPrec, &collation, &ord,
+			&description,
 		); err != nil {
 			return err
 		}
@@ -247,7 +289,7 @@ ORDER BY ordinal_position`
 		columns = append(columns, interfaces.TableColumnMeta{
 			Name:        name.String,
 			Type:        orig,
-			Description: "",
+			Description: description.String,
 
 			Nullable:          strings.EqualFold(isNullable.String, "YES"),
 			DefaultValue:      colDefault.String,
@@ -259,6 +301,9 @@ ORDER BY ordinal_position`
 			OrdinalPosition:   int(ord.Int64),
 			ColumnKey:         colKey,
 		})
+	}
+	if err := rows.Err(); err != nil {
+		return err
 	}
 
 	table.Columns = columns
@@ -297,6 +342,9 @@ ORDER BY kcu.ordinal_position`
 			return nil, err
 		}
 		out[col] = true
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
 	}
 	return out, nil
 }
@@ -342,6 +390,9 @@ ORDER BY i.relname, k.n`
 				Primary: primary,
 			}
 		}
+	}
+	if err := rows.Err(); err != nil {
+		return err
 	}
 
 	var indices []interfaces.TableIndexMeta
@@ -396,6 +447,9 @@ ORDER BY c.conname, u1.ord1`
 			}
 		}
 	}
+	if err := rows.Err(); err != nil {
+		return err
+	}
 
 	var fks []interfaces.TableForeignKeyMeta
 	for _, fk := range fkMap {
@@ -432,6 +486,9 @@ WHERE name IN ('server_version','server_version_num','TimeZone','max_connections
 			return nil, err
 		}
 		meta[k] = v
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
 	}
 
 	meta["cluster_mode"] = "standalone"

--- a/adp/vega/vega-backend/server/logics/connectors/local/table/postgresql/postgresql_discover_test.go
+++ b/adp/vega/vega-backend/server/logics/connectors/local/table/postgresql/postgresql_discover_test.go
@@ -1,0 +1,31 @@
+// Copyright openbkn.ai
+// Copyright The kweaver.ai Authors.
+//
+// Licensed under the Apache License, Version 2.0.
+// See the LICENSE file in the project root for details.
+
+package postgresql
+
+import "testing"
+
+func TestPostgresqlTableTypeFromRelkind(t *testing.T) {
+	tests := []struct {
+		name    string
+		relKind string
+		want    string
+	}{
+		{name: "regular table", relKind: "r", want: "table"},
+		{name: "partitioned table", relKind: "p", want: "table"},
+		{name: "foreign table", relKind: "f", want: "table"},
+		{name: "view", relKind: "v", want: "view"},
+		{name: "materialized view", relKind: "m", want: "materialized_view"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := postgresqlTableTypeFromRelkind(tt.relKind); got != tt.want {
+				t.Fatalf("expected %s, got %s", tt.want, got)
+			}
+		})
+	}
+}

--- a/adp/vega/vega-backend/server/logics/connectors/local/table/postgresql/postgresql_query.go
+++ b/adp/vega/vega-backend/server/logics/connectors/local/table/postgresql/postgresql_query.go
@@ -251,6 +251,9 @@ func (c *PostgresqlConnector) ExecuteQuery(ctx context.Context, resource *interf
 		}
 		result.Rows = append(result.Rows, row)
 	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
 
 	// 处理总数（仅明细查询）
 	if params.NeedTotal && !isAggregate {

--- a/adp/vega/vega-backend/server/logics/connectors/local/table/table_connector.go
+++ b/adp/vega/vega-backend/server/logics/connectors/local/table/table_connector.go
@@ -50,6 +50,9 @@ func ScanRows(rows *sql.Rows) (*interfaces.QueryResult, error) {
 		}
 		result.Rows = append(result.Rows, row)
 	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
 
 	result.Total = int64(len(result.Rows))
 	return result, nil

--- a/adp/vega/vega-backend/server/worker/discover_handler_test.go
+++ b/adp/vega/vega-backend/server/worker/discover_handler_test.go
@@ -8,12 +8,14 @@ package worker
 
 import (
 	"context"
+	"errors"
 	"testing"
 
 	"go.uber.org/mock/gomock"
 
 	"vega-backend/interfaces"
 	vmock "vega-backend/interfaces/mock"
+	"vega-backend/logics/connectors"
 )
 
 func TestReconcileTableResourcesMarksNew(t *testing.T) {
@@ -119,9 +121,69 @@ func TestUpdateDiscoverResultForEnrichStatus(t *testing.T) {
 
 	updateDiscoverResultForEnrichStatus(result, interfaces.DiscoverStatusUnchanged)
 	updateDiscoverResultForEnrichStatus(result, interfaces.DiscoverStatusUpdated)
+	updateDiscoverResultForEnrichStatus(result, interfaces.DiscoverStatusError)
 
-	if result.UnchangedCount != 1 || result.UpdatedCount != 1 {
-		t.Fatalf("expected unchanged=1 updated=1, got unchanged=%d updated=%d", result.UnchangedCount, result.UpdatedCount)
+	if result.UnchangedCount != 1 || result.UpdatedCount != 1 || result.FailedCount != 1 {
+		t.Fatalf("expected unchanged=1 updated=1 failed=1, got unchanged=%d updated=%d failed=%d",
+			result.UnchangedCount, result.UpdatedCount, result.FailedCount)
+	}
+}
+
+func TestEnrichTableMetadataContinuesWhenOneTableFails(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	rs := vmock.NewMockResourceService(ctrl)
+	dh := &DiscoverHandler{rs: rs}
+
+	inaccessible := &interfaces.Resource{ID: "r1", SourceIdentifier: "public.no_access", LastDiscoverStatus: interfaces.DiscoverStatusNew}
+	accessible := &interfaces.Resource{
+		ID:                 "r2",
+		SourceIdentifier:   "public.erp_material",
+		LastDiscoverStatus: interfaces.DiscoverStatusNew,
+		SourceMetadata:     map[string]any{"original_name": "public.erp_material"},
+	}
+	connector := &fakeTableConnector{
+		metaErrByName: map[string]error{
+			"no_access": errors.New("permission denied"),
+		},
+		columnsByName: map[string][]interfaces.TableColumnMeta{
+			"erp_material": {{Name: "id", Type: "int4"}},
+		},
+	}
+
+	rs.EXPECT().UpdateResource(gomock.Any(), gomock.AssignableToTypeOf(&interfaces.Resource{})).
+		DoAndReturn(func(_ context.Context, resource *interfaces.Resource) error {
+			if resource.ID != "r1" {
+				t.Fatalf("expected failed resource r1 to be updated first, got %s", resource.ID)
+			}
+			if resource.LastDiscoverStatus != interfaces.DiscoverStatusError {
+				t.Fatalf("expected failed resource discover status error, got %s", resource.LastDiscoverStatus)
+			}
+			if resource.StatusMessage == "" {
+				t.Fatalf("expected failed resource status message")
+			}
+			return nil
+		})
+	rs.EXPECT().UpdateResource(gomock.Any(), gomock.AssignableToTypeOf(&interfaces.Resource{})).
+		DoAndReturn(func(_ context.Context, resource *interfaces.Resource) error {
+			if resource.ID != "r2" {
+				t.Fatalf("expected successful resource r2 to be updated, got %s", resource.ID)
+			}
+			if len(resource.SchemaDefinition) != 1 || resource.SchemaDefinition[0].Name != "id" {
+				t.Fatalf("expected successful resource schema to be enriched")
+			}
+			return nil
+		})
+
+	result := &interfaces.DiscoverResult{}
+	err := dh.enrichTableMetadata(context.Background(), connector, []tableDiscoverItem{
+		{resource: inaccessible, tableMeta: &interfaces.TableMeta{Name: "no_access", Schema: "public"}},
+		{resource: accessible, tableMeta: &interfaces.TableMeta{Name: "erp_material", Schema: "public"}},
+	}, result)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.FailedCount != 1 {
+		t.Fatalf("expected failed count 1, got %d", result.FailedCount)
 	}
 }
 
@@ -157,4 +219,68 @@ func TestSourceSnapshotHashChangesForSourceMetadata(t *testing.T) {
 	if got := sourceSnapshotHash(resource); got == before {
 		t.Fatalf("expected source snapshot hash to change when source metadata changes")
 	}
+}
+
+type fakeTableConnector struct {
+	metaErrByName map[string]error
+	columnsByName map[string][]interfaces.TableColumnMeta
+}
+
+func (c *fakeTableConnector) GetType() string { return "fake" }
+
+func (c *fakeTableConnector) GetName() string { return "fake" }
+
+func (c *fakeTableConnector) GetMode() string { return "local" }
+
+func (c *fakeTableConnector) GetCategory() string { return interfaces.ConnectorCategoryTable }
+
+func (c *fakeTableConnector) GetEnabled() bool { return true }
+
+func (c *fakeTableConnector) SetEnabled(bool) {}
+
+func (c *fakeTableConnector) GetSensitiveFields() []string { return nil }
+
+func (c *fakeTableConnector) GetFieldConfig() map[string]interfaces.ConnectorFieldConfig {
+	return nil
+}
+
+func (c *fakeTableConnector) New(interfaces.ConnectorConfig) (connectors.Connector, error) {
+	return c, nil
+}
+
+func (c *fakeTableConnector) Connect(context.Context) error { return nil }
+
+func (c *fakeTableConnector) Ping(context.Context) error { return nil }
+
+func (c *fakeTableConnector) Close(context.Context) error { return nil }
+
+func (c *fakeTableConnector) TestConnection(context.Context) error { return nil }
+
+func (c *fakeTableConnector) GetMetadata(context.Context) (map[string]any, error) {
+	return nil, nil
+}
+
+func (c *fakeTableConnector) MapType(nativeType string) string {
+	return nativeType
+}
+
+func (c *fakeTableConnector) ListDatabases(context.Context) ([]string, error) {
+	return nil, nil
+}
+
+func (c *fakeTableConnector) ListTables(context.Context) ([]*interfaces.TableMeta, error) {
+	return nil, nil
+}
+
+func (c *fakeTableConnector) GetTableMeta(_ context.Context, table *interfaces.TableMeta) error {
+	if err := c.metaErrByName[table.Name]; err != nil {
+		return err
+	}
+	table.Columns = c.columnsByName[table.Name]
+	return nil
+}
+
+func (c *fakeTableConnector) ExecuteQuery(context.Context, *interfaces.Resource,
+	*interfaces.ResourceDataQueryParams) (*interfaces.QueryResult, error) {
+	return nil, nil
 }

--- a/adp/vega/vega-backend/server/worker/discover_status.go
+++ b/adp/vega/vega-backend/server/worker/discover_status.go
@@ -79,10 +79,12 @@ func updateDiscoverResultForEnrichStatus(result *interfaces.DiscoverResult, stat
 		result.UpdatedCount++
 	case interfaces.DiscoverStatusUnchanged:
 		result.UnchangedCount++
+	case interfaces.DiscoverStatusError:
+		result.FailedCount++
 	}
 }
 
 func formatDiscoverResultMessage(result *interfaces.DiscoverResult) string {
-	return fmt.Sprintf("Discover completed: %d new, %d stale, %d unchanged, %d updated, %d restored",
-		result.NewCount, result.StaleCount, result.UnchangedCount, result.UpdatedCount, result.RestoredCount)
+	return fmt.Sprintf("Discover completed: %d new, %d stale, %d unchanged, %d updated, %d restored, %d failed",
+		result.NewCount, result.StaleCount, result.UnchangedCount, result.UpdatedCount, result.RestoredCount, result.FailedCount)
 }

--- a/adp/vega/vega-backend/server/worker/discover_table.go
+++ b/adp/vega/vega-backend/server/worker/discover_table.go
@@ -84,7 +84,14 @@ func (dh *DiscoverHandler) enrichTableMetadata(ctx context.Context, tableConnect
 		err := tableConnector.GetTableMeta(ctx, table)
 		if err != nil {
 			logger.Warnf("Failed to get metadata for table %s: %v", table.Name, err)
-			return err
+			resource.LastDiscoverStatus = interfaces.DiscoverStatusError
+			resource.StatusMessage = fmt.Sprintf("discover metadata failed: %v", err)
+			updateDiscoverResultForEnrichStatus(result, interfaces.DiscoverStatusError)
+			if updateErr := dh.rs.UpdateResource(ctx, resource); updateErr != nil {
+				logger.Errorf("Failed to update discover error for table %s: %v", table.Name, updateErr)
+				return updateErr
+			}
+			continue
 		}
 
 		// 填充 Resource 元数据 ：schema_definition 字段


### PR DESCRIPTION
# Pull Request

## What Changed

Brief description of changes:

- [x] Fix PostgreSQL catalog discovery to enumerate tables, views, materialized views, partitioned tables, and foreign tables from `pg_catalog`.
- [x] Skip inaccessible PostgreSQL relations during discovery and keep scanning when a single table metadata fetch fails.
- [x] Add discover failure status/count reporting and defensive `rows.Err()` checks across table connectors.

---

## Why

- Related Issue: openbkn-ai/bkn-studio#38
- Related Feature: Vega Catalog discovery
- Background: PostgreSQL scans missed materialized views and a table metadata permission error could interrupt the whole scan. This PR addresses the backend discovery behavior only; Studio display-name changes are intentionally left out.

---

## How

- Key implementation points:
  - PostgreSQL `ListTables` now reads `pg_class`/`pg_namespace`, maps `relkind` values, filters system/temp schemas, and requires `SELECT` privilege.
  - PostgreSQL column discovery now uses `pg_attribute`/`pg_type` so materialized views are handled consistently with tables and views.
  - Table metadata enrichment records `last_discover_status=error` and increments `failed_count` for a failed resource, then continues with the remaining resources.
  - MariaDB, PostgreSQL, Oracle, and shared table row scanners now check `rows.Err()` after iteration.
  - Added unit coverage for PostgreSQL relkind mapping and worker continuation after a single metadata failure.
- Breaking changes (API, config, database, etc.):
  - No breaking API changes expected. `failed_count` and `last_discover_status=error` are additive backend response/status values.

---

## Testing

- [x] Unit tests passed locally
- [ ] Integration tests passed locally
- [ ] Verified in test environment

Test notes:

```bash
go test ./logics/connectors/local/table/...
go test ./worker ./logics/connectors/local/index/opensearch
go test ./...
git diff --check
```

---

## Risk & Rollback

- Potential risks:
  - PostgreSQL discovery now uses native catalog tables instead of `information_schema`, so metadata shape may differ slightly for edge-case types.
  - `failed_count` is additive, but clients that explicitly validate response fields should tolerate it.
- Rollback plan:
  - Revert this PR to restore the previous information_schema-based PostgreSQL discovery and previous fail-fast enrichment behavior.

---

## Additional Notes

- Frontend/display-name behavior is intentionally not included in this PR.
- Manual verification against a real PostgreSQL database with a view, materialized view, and inaccessible table is recommended before release.
