### PR TITLE
fix(vega-backend): protect active build task index deletion

### DIFF
--- a/adp/vega/vega-backend/server/driveradapters/build_task_handler.go
+++ b/adp/vega/vega-backend/server/driveradapters/build_task_handler.go
@@ -257,7 +257,8 @@ func (r *restHandler) listBuildTasks(c *gin.Context, visitor hydra.Visitor) {
 // =========================== DELETE /build-tasks/:ids ===========================
 
 // DeleteBuildTasksByEx handles DELETE /build-tasks/:ids (External).
-// `ids` is a comma-separated list. Optional query: ?ignore_missing=true
+// `ids` is a comma-separated list.
+// Optional query: ?ignore_missing=true&delete_active_index=true
 func (r *restHandler) DeleteBuildTasksByEx(c *gin.Context) {
 	visitor, err := r.verifyOAuth(rest.GetLanguageCtx(c), c)
 	if err != nil {
@@ -299,8 +300,9 @@ func (r *restHandler) deleteBuildTasks(c *gin.Context, visitor hydra.Visitor) {
 	}
 
 	ignoreMissing := strings.EqualFold(c.Query("ignore_missing"), "true")
+	deleteActiveIndex := strings.EqualFold(c.Query("delete_active_index"), "true")
 
-	if err := r.bts.DeleteBuildTasks(ctx, ids, ignoreMissing); err != nil {
+	if err := r.bts.DeleteBuildTasks(ctx, ids, ignoreMissing, deleteActiveIndex); err != nil {
 		httpErr := err.(*rest.HTTPError)
 		oteltrace.AddHttpAttrs4HttpError(span, httpErr)
 		rest.ReplyError(c, httpErr)

--- a/adp/vega/vega-backend/server/driveradapters/build_task_handler_test.go
+++ b/adp/vega/vega-backend/server/driveradapters/build_task_handler_test.go
@@ -131,3 +131,30 @@ func Test_BuildTaskRestHandler_ListBuildTasks(t *testing.T) {
 		})
 	})
 }
+
+func Test_BuildTaskRestHandler_DeleteBuildTasks(t *testing.T) {
+	Convey("Test BuildTaskHandler DeleteBuildTasks\n", t, func() {
+		test := setGinMode()
+		defer test()
+
+		engine := gin.New()
+		engine.Use(gin.Recovery())
+
+		mockCtrl := gomock.NewController(t)
+		defer mockCtrl.Finish()
+
+		bts := vmock.NewMockBuildTaskService(mockCtrl)
+		handler := MockNewRestHandler(&common.AppSetting{}, nil, nil, nil, bts, nil, nil, nil, nil, nil, nil)
+		handler.RegisterPublic(engine)
+
+		url := "/api/vega-backend/in/v1/build-tasks/t1,t2?ignore_missing=true&delete_active_index=true"
+
+		bts.EXPECT().DeleteBuildTasks(gomock.Any(), []string{"t1", "t2"}, true, true).Return(nil)
+
+		req := httptest.NewRequest(http.MethodDelete, url, nil)
+		w := httptest.NewRecorder()
+		engine.ServeHTTP(w, req)
+
+		So(w.Result().StatusCode, ShouldEqual, http.StatusNoContent)
+	})
+}

--- a/adp/vega/vega-backend/server/errors/build_task.go
+++ b/adp/vega/vega-backend/server/errors/build_task.go
@@ -23,6 +23,7 @@ const (
 	// 409 Conflict
 	VegaBackend_BuildTask_InvalidStateTransition = "VegaBackend.BuildTask.InvalidStateTransition"
 	VegaBackend_BuildTask_HasRunningExecution    = "VegaBackend.BuildTask.HasRunningExecution"
+	VegaBackend_BuildTask_ActiveIndexInUse       = "VegaBackend.BuildTask.ActiveIndexInUse"
 
 	// 500 Internal Server Error
 	VegaBackend_BuildTask_InternalError_CreateFailed          = "VegaBackend.BuildTask.InternalError.CreateFailed"
@@ -47,6 +48,7 @@ var BuildTaskErrCodeList = []string{
 	// 409 Conflict
 	VegaBackend_BuildTask_InvalidStateTransition,
 	VegaBackend_BuildTask_HasRunningExecution,
+	VegaBackend_BuildTask_ActiveIndexInUse,
 
 	// 500 Internal Server Error
 	VegaBackend_BuildTask_InternalError_CreateFailed,

--- a/adp/vega/vega-backend/server/go.mod
+++ b/adp/vega/vega-backend/server/go.mod
@@ -5,33 +5,33 @@ go 1.25.0
 require (
 	github.com/Masterminds/squirrel v1.5.4
 	github.com/antlr4-go/antlr/v4 v4.13.1
-	github.com/bytedance/sonic v1.15.1
+	github.com/bytedance/sonic v1.15.2
 	github.com/dlclark/regexp2 v1.12.0
 	github.com/fsnotify/fsnotify v1.10.1
 	github.com/gin-gonic/gin v1.12.0
-	github.com/go-sql-driver/mysql v1.9.3
+	github.com/go-sql-driver/mysql v1.10.0
 	github.com/google/uuid v1.6.0
 	github.com/hibiken/asynq v0.26.0
 	github.com/kweaver-ai/kweaver-go-lib v1.0.5
 	github.com/kweaver-ai/proton-mq-sdk-go v1.9.1
-	github.com/lib/pq v1.10.9
+	github.com/lib/pq v1.12.3
 	github.com/mitchellh/mapstructure v1.5.0
 	github.com/opensearch-project/opensearch-go/v2 v2.3.0
 	github.com/robfig/cron/v3 v3.0.1
 	github.com/rs/xid v1.6.0
-	github.com/segmentio/kafka-go v0.4.49
-	github.com/sijms/go-ora/v2 v2.8.24
+	github.com/segmentio/kafka-go v0.4.51
+	github.com/sijms/go-ora/v2 v2.9.0
 	github.com/smartystreets/goconvey v1.8.1
 	github.com/spf13/viper v1.21.0
-	go.opentelemetry.io/otel v1.43.0
-	go.opentelemetry.io/otel/trace v1.43.0
+	go.opentelemetry.io/otel v1.44.0
+	go.opentelemetry.io/otel/trace v1.44.0
 	go.uber.org/automaxprocs v1.6.0
 	go.uber.org/mock v0.6.0
-	golang.org/x/sync v0.20.0
+	golang.org/x/sync v0.21.0
 )
 
 require (
-	filippo.io/edwards25519 v1.1.0 // indirect
+	filippo.io/edwards25519 v1.2.0 // indirect
 	gitee.com/chunanyong/dm v1.8.22 // indirect
 	github.com/BurntSushi/toml v1.6.0 // indirect
 	github.com/IBM/sarama v1.48.0 // indirect
@@ -104,7 +104,7 @@ require (
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.43.0 // indirect
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp v1.43.0 // indirect
 	go.opentelemetry.io/otel/log v0.19.0 // indirect
-	go.opentelemetry.io/otel/metric v1.43.0 // indirect
+	go.opentelemetry.io/otel/metric v1.44.0 // indirect
 	go.opentelemetry.io/otel/sdk v1.43.0 // indirect
 	go.opentelemetry.io/otel/sdk/log v0.19.0 // indirect
 	go.opentelemetry.io/proto/otlp v1.10.0 // indirect

--- a/adp/vega/vega-backend/server/go.sum
+++ b/adp/vega/vega-backend/server/go.sum
@@ -1,5 +1,7 @@
 filippo.io/edwards25519 v1.1.0 h1:FNf4tywRC1HmFuKW5xopWpigGjJKiJSV0Cqo0cJWDaA=
 filippo.io/edwards25519 v1.1.0/go.mod h1:BxyFTGdWcka3PhytdK4V28tE5sGfRvvvRV7EaN4VDT4=
+filippo.io/edwards25519 v1.2.0 h1:crnVqOiS4jqYleHd9vaKZ+HKtHfllngJIiOpNpoJsjo=
+filippo.io/edwards25519 v1.2.0/go.mod h1:xzAOLCNug/yB62zG1bQ8uziwrIqIuxhctzJT18Q77mc=
 gitee.com/chunanyong/dm v1.8.22 h1:H7fsrnUIvEA0jlDWew7vwELry1ff+tLMIu2Fk2cIBSg=
 gitee.com/chunanyong/dm v1.8.22/go.mod h1:EPRJnuPFgbyOFgJ0TRYCTGzhq+ZT4wdyaj/GW/LLcNg=
 github.com/BurntSushi/toml v1.6.0 h1:dRaEfpa2VI55EwlIW72hMRHdWouJeRF7TPYhI+AUQjk=
@@ -35,6 +37,8 @@ github.com/bytedance/gopkg v0.1.4 h1:oZnQwnX82KAIWb7033bEwtxvTqXcYMxDBaQxo5JJHWM
 github.com/bytedance/gopkg v0.1.4/go.mod h1:v1zWfPm21Fb+OsyXN2VAHdL6TBb2L88anLQgdyje6R4=
 github.com/bytedance/sonic v1.15.1 h1:nJD5PmM0vY7J8CT6MxoqbVAAMhkSmV2HgRAUrrpLoOw=
 github.com/bytedance/sonic v1.15.1/go.mod h1:mT2NbXunuaEbnZ+mRIX/vYqKISmgEuHFDI4UzmKx2SA=
+github.com/bytedance/sonic v1.15.2 h1:90H+rcF/FwLXwfB1cudOLq/je83n683Utf4Cbp0xHCo=
+github.com/bytedance/sonic v1.15.2/go.mod h1:mT2NbXunuaEbnZ+mRIX/vYqKISmgEuHFDI4UzmKx2SA=
 github.com/bytedance/sonic/loader v0.5.1 h1:Ygpfa9zwRCCKSlrp5bBP/b/Xzc3VxsAW+5NIYXrOOpI=
 github.com/bytedance/sonic/loader v0.5.1/go.mod h1:AR4NYCk5DdzZizZ5djGqQ92eEhCCcdf5x77udYiSJRo=
 github.com/cenkalti/backoff/v4 v4.3.0 h1:MyRJ/UdXutAwSAT+s3wNd7MfTIcy71VQueUuFK343L8=
@@ -84,6 +88,8 @@ github.com/go-playground/validator/v10 v10.30.2 h1:JiFIMtSSHb2/XBUbWM4i/MpeQm9ZK
 github.com/go-playground/validator/v10 v10.30.2/go.mod h1:mAf2pIOVXjTEBrwUMGKkCWKKPs9NheYGabeB04txQSc=
 github.com/go-sql-driver/mysql v1.9.3 h1:U/N249h2WzJ3Ukj8SowVFjdtZKfu9vlLZxjPXV1aweo=
 github.com/go-sql-driver/mysql v1.9.3/go.mod h1:qn46aNg1333BRMNU69Lq93t8du/dwxI64Gl8i5p1WMU=
+github.com/go-sql-driver/mysql v1.10.0 h1:Q+1LV8DkHJvSYAdR83XzuhDaTykuDx0l6fkXxoWCWfw=
+github.com/go-sql-driver/mysql v1.10.0/go.mod h1:M+cqaI7+xxXGG9swrdeUIoPG3Y3KCkF0pZej+SK+nWk=
 github.com/go-viper/mapstructure/v2 v2.5.0 h1:vM5IJoUAy3d7zRSVtIwQgBj7BiWtMPfmPEgAXnvj1Ro=
 github.com/go-viper/mapstructure/v2 v2.5.0/go.mod h1:oJDH3BJKyqBA2TXFhDsKDGDTlndYOZ6rGS0BRZIxGhM=
 github.com/goccy/go-json v0.10.5 h1:Fq85nIqj+gXn/S5ahsiTlK3TmC85qgirsdTP/+DeaC4=
@@ -154,6 +160,8 @@ github.com/leodido/go-urn v1.4.0 h1:WT9HwE9SGECu3lg4d/dIA+jxlljEa1/ffXKmRjqdmIQ=
 github.com/leodido/go-urn v1.4.0/go.mod h1:bvxc+MVxLKB4z00jd1z+Dvzr47oO32F/QSNjSBOlFxI=
 github.com/lib/pq v1.10.9 h1:YXG7RB+JIjhP29X+OtkiDnYaXQwpS4JEWq7dtCCRUEw=
 github.com/lib/pq v1.10.9/go.mod h1:AlVN5x4E4T544tWzH6hKfbfQvm3HdbOxrmggDNAPY9o=
+github.com/lib/pq v1.12.3 h1:tTWxr2YLKwIvK90ZXEw8GP7UFHtcbTtty8zsI+YjrfQ=
+github.com/lib/pq v1.12.3/go.mod h1:/p+8NSbOcwzAEI7wiMXFlgydTwcgTr3OSKMsD2BitpA=
 github.com/mattn/go-isatty v0.0.20 h1:xfD0iDuEKnDkl03q4limB+vH+GxLEtL/jb4xVJSWWEY=
 github.com/mattn/go-isatty v0.0.20/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D7dTCTo3Y=
 github.com/mitchellh/mapstructure v1.5.0 h1:jeMsZIYE/09sWLaz43PL7Gy6RuMjD2eJVyuac5Z2hdY=
@@ -195,10 +203,14 @@ github.com/sagikazarmark/locafero v0.11.0 h1:1iurJgmM9G3PA/I+wWYIOw/5SyBtxapeHDc
 github.com/sagikazarmark/locafero v0.11.0/go.mod h1:nVIGvgyzw595SUSUE6tvCp3YYTeHs15MvlmU87WwIik=
 github.com/segmentio/kafka-go v0.4.49 h1:GJiNX1d/g+kG6ljyJEoi9++PUMdXGAxb7JGPiDCuNmk=
 github.com/segmentio/kafka-go v0.4.49/go.mod h1:Y1gn60kzLEEaW28YshXyk2+VCUKbJ3Qr6DrnT3i4+9E=
+github.com/segmentio/kafka-go v0.4.51 h1:JgDPPG75tC1rWIS2Me6MwcvXJ6f49UQ4HjAOef71Hno=
+github.com/segmentio/kafka-go v0.4.51/go.mod h1:Y1gn60kzLEEaW28YshXyk2+VCUKbJ3Qr6DrnT3i4+9E=
 github.com/shopspring/decimal v1.4.0 h1:bxl37RwXBklmTi0C79JfXCEBD1cqqHt0bbgBAGFp81k=
 github.com/shopspring/decimal v1.4.0/go.mod h1:gawqmDU56v4yIKSwfBSFip1HdCCXN8/+DMd9qYNcwME=
 github.com/sijms/go-ora/v2 v2.8.24 h1:TODRWjWGwJ1VlBOhbTLat+diTYe8HXq2soJeB+HMjnw=
 github.com/sijms/go-ora/v2 v2.8.24/go.mod h1:QgFInVi3ZWyqAiJwzBQA+nbKYKH77tdp1PYoCqhR2dU=
+github.com/sijms/go-ora/v2 v2.9.0 h1:+iQbUeTeCOFMb5BsOMgUhV8KWyrv9yjKpcK4x7+MFrg=
+github.com/sijms/go-ora/v2 v2.9.0/go.mod h1:QgFInVi3ZWyqAiJwzBQA+nbKYKH77tdp1PYoCqhR2dU=
 github.com/smarty/assertions v1.16.0 h1:EvHNkdRA4QHMrn75NZSoUQ/mAUXAYWfatfB01yTCzfY=
 github.com/smarty/assertions v1.16.0/go.mod h1:duaaFdCS0K9dnoM50iyek/eYINOZ64gbh1Xlf6LG7AI=
 github.com/smartystreets/goconvey v1.8.1 h1:qGjIddxOk4grTu9JPOU31tVfq3cNdBlNa5sSznIX1xY=
@@ -247,6 +259,8 @@ go.opentelemetry.io/auto/sdk v1.2.1 h1:jXsnJ4Lmnqd11kwkBV2LgLoFMZKizbCi5fNZ/ipaZ
 go.opentelemetry.io/auto/sdk v1.2.1/go.mod h1:KRTj+aOaElaLi+wW1kO/DZRXwkF4C5xPbEe3ZiIhN7Y=
 go.opentelemetry.io/otel v1.43.0 h1:mYIM03dnh5zfN7HautFE4ieIig9amkNANT+xcVxAj9I=
 go.opentelemetry.io/otel v1.43.0/go.mod h1:JuG+u74mvjvcm8vj8pI5XiHy1zDeoCS2LB1spIq7Ay0=
+go.opentelemetry.io/otel v1.44.0 h1:JjwHmHpA4iZ3wBxluu2fbbE7j4kqlE8jXyAyPXH7HqU=
+go.opentelemetry.io/otel v1.44.0/go.mod h1:BMgjTHL9WPRlRjL2oZCBTL4whCGtXch2H4BhOPIAyYc=
 go.opentelemetry.io/otel/exporters/otlp/otlplog/otlploghttp v0.19.0 h1:HIBTQ3VO5aupLKjC90JgMqpezVXwFuq6Ryjn0/izoag=
 go.opentelemetry.io/otel/exporters/otlp/otlplog/otlploghttp v0.19.0/go.mod h1:ji9vId85hMxqfvICA0Jt8JqEdrXaAkcpkI9HPXya0ro=
 go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.43.0 h1:88Y4s2C8oTui1LGM6bTWkw0ICGcOLCAI5l6zsD1j20k=
@@ -257,6 +271,8 @@ go.opentelemetry.io/otel/log v0.19.0 h1:KUZs/GOsw79TBBMfDWsXS+KZ4g2Ckzksd1ymzsIE
 go.opentelemetry.io/otel/log v0.19.0/go.mod h1:5DQYeGmxVIr4n0/BcJvF4upsraHjg6vudJJpnkL6Ipk=
 go.opentelemetry.io/otel/metric v1.43.0 h1:d7638QeInOnuwOONPp4JAOGfbCEpYb+K6DVWvdxGzgM=
 go.opentelemetry.io/otel/metric v1.43.0/go.mod h1:RDnPtIxvqlgO8GRW18W6Z/4P462ldprJtfxHxyKd2PY=
+go.opentelemetry.io/otel/metric v1.44.0 h1:1w0gILTcHdr3YI+ixLyjemwrVnsMURbTZFrSYCdDdmc=
+go.opentelemetry.io/otel/metric v1.44.0/go.mod h1:8O7hanEPBNgEMmybD3s2VBKcgWOCsA6tzHBPODAiquo=
 go.opentelemetry.io/otel/sdk v1.43.0 h1:pi5mE86i5rTeLXqoF/hhiBtUNcrAGHLKQdhg4h4V9Dg=
 go.opentelemetry.io/otel/sdk v1.43.0/go.mod h1:P+IkVU3iWukmiit/Yf9AWvpyRDlUeBaRg6Y+C58QHzg=
 go.opentelemetry.io/otel/sdk/log v0.19.0 h1:scYVLqT22D2gqXItnWiocLUKGH9yvkkeql5dBDiXyko=
@@ -267,6 +283,8 @@ go.opentelemetry.io/otel/sdk/metric v1.43.0 h1:S88dyqXjJkuBNLeMcVPRFXpRw2fuwdvfC
 go.opentelemetry.io/otel/sdk/metric v1.43.0/go.mod h1:C/RJtwSEJ5hzTiUz5pXF1kILHStzb9zFlIEe85bhj6A=
 go.opentelemetry.io/otel/trace v1.43.0 h1:BkNrHpup+4k4w+ZZ86CZoHHEkohws8AY+WTX09nk+3A=
 go.opentelemetry.io/otel/trace v1.43.0/go.mod h1:/QJhyVBUUswCphDVxq+8mld+AvhXZLhe+8WVFxiFff0=
+go.opentelemetry.io/otel/trace v1.44.0 h1:jxF5CsGYCe74MCRx2X4g7WsY/VBKRqqpNvXlX/6gtIk=
+go.opentelemetry.io/otel/trace v1.44.0/go.mod h1:oLl1jrMQAVo6v3GAggN+1VH9VIz9iUSvW53sW1Q8PIE=
 go.opentelemetry.io/proto/otlp v1.10.0 h1:IQRWgT5srOCYfiWnpqUYz9CVmbO8bFmKcwYxpuCSL2g=
 go.opentelemetry.io/proto/otlp v1.10.0/go.mod h1:/CV4QoCR/S9yaPj8utp3lvQPoqMtxXdzn7ozvvozVqk=
 go.uber.org/automaxprocs v1.6.0 h1:O3y2/QNTOdbF+e/dpXNNW7Rx2hZ4sTIPyybbxyNqTUs=
@@ -304,6 +322,8 @@ golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJ
 golang.org/x/sync v0.0.0-20220722155255-886fb9371eb4/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.20.0 h1:e0PTpb7pjO8GAtTs2dQ6jYa5BWYlMuX047Dco/pItO4=
 golang.org/x/sync v0.20.0/go.mod h1:9xrNwdLfx4jkKbNva9FpL6vEN7evnE43NNNJQ2LF3+0=
+golang.org/x/sync v0.21.0 h1:HLII4xRRTtCRkxYp4HNFF0Js/Og6q2i++KXbg0gHCwM=
+golang.org/x/sync v0.21.0/go.mod h1:9xrNwdLfx4jkKbNva9FpL6vEN7evnE43NNNJQ2LF3+0=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20201119102817-f84b799fce68/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=

--- a/adp/vega/vega-backend/server/interfaces/build_task_service.go
+++ b/adp/vega/vega-backend/server/interfaces/build_task_service.go
@@ -28,5 +28,5 @@ type BuildTaskService interface {
 	StopBuildTask(ctx context.Context, taskID string) error
 	// DeleteBuildTasks atomically deletes build tasks by IDs.
 	// Pre-validates: any missing id returns 404 unless ignoreMissing=true; any running/stopping id returns 409 (cannot be skipped).
-	DeleteBuildTasks(ctx context.Context, ids []string, ignoreMissing bool) error
+	DeleteBuildTasks(ctx context.Context, ids []string, ignoreMissing bool, deleteActiveIndex bool) error
 }

--- a/adp/vega/vega-backend/server/interfaces/mock/mock_build_task_service.go
+++ b/adp/vega/vega-backend/server/interfaces/mock/mock_build_task_service.go
@@ -57,17 +57,17 @@ func (mr *MockBuildTaskServiceMockRecorder) CreateBuildTask(ctx, req any) *gomoc
 }
 
 // DeleteBuildTasks mocks base method.
-func (m *MockBuildTaskService) DeleteBuildTasks(ctx context.Context, ids []string, ignoreMissing bool) error {
+func (m *MockBuildTaskService) DeleteBuildTasks(ctx context.Context, ids []string, ignoreMissing, deleteActiveIndex bool) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "DeleteBuildTasks", ctx, ids, ignoreMissing)
+	ret := m.ctrl.Call(m, "DeleteBuildTasks", ctx, ids, ignoreMissing, deleteActiveIndex)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // DeleteBuildTasks indicates an expected call of DeleteBuildTasks.
-func (mr *MockBuildTaskServiceMockRecorder) DeleteBuildTasks(ctx, ids, ignoreMissing any) *gomock.Call {
+func (mr *MockBuildTaskServiceMockRecorder) DeleteBuildTasks(ctx, ids, ignoreMissing, deleteActiveIndex any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteBuildTasks", reflect.TypeOf((*MockBuildTaskService)(nil).DeleteBuildTasks), ctx, ids, ignoreMissing)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteBuildTasks", reflect.TypeOf((*MockBuildTaskService)(nil).DeleteBuildTasks), ctx, ids, ignoreMissing, deleteActiveIndex)
 }
 
 // GetBuildTaskByID mocks base method.
@@ -130,20 +130,6 @@ func (mr *MockBuildTaskServiceMockRecorder) StartBuildTask(ctx, taskID, executeT
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StartBuildTask", reflect.TypeOf((*MockBuildTaskService)(nil).StartBuildTask), ctx, taskID, executeType)
 }
 
-// UpdateBuildTaskConfig mocks base method.
-func (m *MockBuildTaskService) UpdateBuildTaskConfig(ctx context.Context, taskID string, req *interfaces.UpdateBuildTaskConfigRequest) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "UpdateBuildTaskConfig", ctx, taskID, req)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// UpdateBuildTaskConfig indicates an expected call of UpdateBuildTaskConfig.
-func (mr *MockBuildTaskServiceMockRecorder) UpdateBuildTaskConfig(ctx, taskID, req any) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateBuildTaskConfig", reflect.TypeOf((*MockBuildTaskService)(nil).UpdateBuildTaskConfig), ctx, taskID, req)
-}
-
 // StopBuildTask mocks base method.
 func (m *MockBuildTaskService) StopBuildTask(ctx context.Context, taskID string) error {
 	m.ctrl.T.Helper()
@@ -156,4 +142,18 @@ func (m *MockBuildTaskService) StopBuildTask(ctx context.Context, taskID string)
 func (mr *MockBuildTaskServiceMockRecorder) StopBuildTask(ctx, taskID any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StopBuildTask", reflect.TypeOf((*MockBuildTaskService)(nil).StopBuildTask), ctx, taskID)
+}
+
+// UpdateBuildTaskConfig mocks base method.
+func (m *MockBuildTaskService) UpdateBuildTaskConfig(ctx context.Context, taskID string, req *interfaces.UpdateBuildTaskConfigRequest) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "UpdateBuildTaskConfig", ctx, taskID, req)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// UpdateBuildTaskConfig indicates an expected call of UpdateBuildTaskConfig.
+func (mr *MockBuildTaskServiceMockRecorder) UpdateBuildTaskConfig(ctx, taskID, req any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateBuildTaskConfig", reflect.TypeOf((*MockBuildTaskService)(nil).UpdateBuildTaskConfig), ctx, taskID, req)
 }

--- a/adp/vega/vega-backend/server/interfaces/mock/mock_catalog_service.go
+++ b/adp/vega/vega-backend/server/interfaces/mock/mock_catalog_service.go
@@ -56,21 +56,6 @@ func (mr *MockCatalogServiceMockRecorder) CheckExistByID(ctx, id any) *gomock.Ca
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CheckExistByID", reflect.TypeOf((*MockCatalogService)(nil).CheckExistByID), ctx, id)
 }
 
-// ListInternalIDs mocks base method.
-func (m *MockCatalogService) ListInternalIDs(ctx context.Context) ([]string, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ListInternalIDs", ctx)
-	ret0, _ := ret[0].([]string)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// ListInternalIDs indicates an expected call of ListInternalIDs.
-func (mr *MockCatalogServiceMockRecorder) ListInternalIDs(ctx any) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListInternalIDs", reflect.TypeOf((*MockCatalogService)(nil).ListInternalIDs), ctx)
-}
-
 // CheckExistByName mocks base method.
 func (m *MockCatalogService) CheckExistByName(ctx context.Context, name string) (bool, error) {
 	m.ctrl.T.Helper()
@@ -175,6 +160,21 @@ func (m *MockCatalogService) ListAuthResources(ctx context.Context, params inter
 func (mr *MockCatalogServiceMockRecorder) ListAuthResources(ctx, params any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListAuthResources", reflect.TypeOf((*MockCatalogService)(nil).ListAuthResources), ctx, params)
+}
+
+// ListInternalIDs mocks base method.
+func (m *MockCatalogService) ListInternalIDs(ctx context.Context) ([]string, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ListInternalIDs", ctx)
+	ret0, _ := ret[0].([]string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ListInternalIDs indicates an expected call of ListInternalIDs.
+func (mr *MockCatalogServiceMockRecorder) ListInternalIDs(ctx any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListInternalIDs", reflect.TypeOf((*MockCatalogService)(nil).ListInternalIDs), ctx)
 }
 
 // SetEnabled mocks base method.

--- a/adp/vega/vega-backend/server/interfaces/mock/mock_discover_task_service.go
+++ b/adp/vega/vega-backend/server/interfaces/mock/mock_discover_task_service.go
@@ -72,20 +72,6 @@ func (mr *MockDiscoverTaskServiceMockRecorder) Create(ctx, req any) *gomock.Call
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Create", reflect.TypeOf((*MockDiscoverTaskService)(nil).Create), ctx, req)
 }
 
-// Delete mocks base method.
-func (m *MockDiscoverTaskService) Delete(ctx context.Context, ids []string, ignoreMissing bool) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Delete", ctx, ids, ignoreMissing)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// Delete indicates an expected call of Delete.
-func (mr *MockDiscoverTaskServiceMockRecorder) Delete(ctx, ids, ignoreMissing any) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Delete", reflect.TypeOf((*MockDiscoverTaskService)(nil).Delete), ctx, ids, ignoreMissing)
-}
-
 // DebugTaskQueue mocks base method.
 func (m *MockDiscoverTaskService) DebugTaskQueue() <-chan *asynq.Task {
 	m.ctrl.T.Helper()
@@ -98,6 +84,20 @@ func (m *MockDiscoverTaskService) DebugTaskQueue() <-chan *asynq.Task {
 func (mr *MockDiscoverTaskServiceMockRecorder) DebugTaskQueue() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DebugTaskQueue", reflect.TypeOf((*MockDiscoverTaskService)(nil).DebugTaskQueue))
+}
+
+// Delete mocks base method.
+func (m *MockDiscoverTaskService) Delete(ctx context.Context, ids []string, ignoreMissing bool) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Delete", ctx, ids, ignoreMissing)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// Delete indicates an expected call of Delete.
+func (mr *MockDiscoverTaskServiceMockRecorder) Delete(ctx, ids, ignoreMissing any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Delete", reflect.TypeOf((*MockDiscoverTaskService)(nil).Delete), ctx, ids, ignoreMissing)
 }
 
 // GetByID mocks base method.

--- a/adp/vega/vega-backend/server/locale/build_task.en-US.toml
+++ b/adp/vega/vega-backend/server/locale/build_task.en-US.toml
@@ -23,6 +23,11 @@ Description = "Build task has running execution and cannot be deleted"
 Solution = "Stop the task before deleting it"
 ErrorLink = "No solution"
 
+[VegaBackend.BuildTask.ActiveIndexInUse]
+Description = "Build task index is currently the resource's active local index"
+Solution = "Pass delete_active_index=true to confirm deleting the active local index, or keep the default protection"
+ErrorLink = "No solution"
+
 [VegaBackend.BuildTask.InternalError.CreateFailed]
 Description = "Failed to create build task"
 Solution = "Please contact the administrator"

--- a/adp/vega/vega-backend/server/locale/build_task.zh-CN.toml
+++ b/adp/vega/vega-backend/server/locale/build_task.zh-CN.toml
@@ -23,6 +23,11 @@ Description = "构建任务正在运行，无法删除"
 Solution = "请先停止任务再删除"
 ErrorLink = "暂无"
 
+[VegaBackend.BuildTask.ActiveIndexInUse]
+Description = "构建任务索引是资源当前生效的本地索引"
+Solution = "如确认要删除当前生效的本地索引，请传入 delete_active_index=true；否则保持默认保护"
+ErrorLink = "暂无"
+
 [VegaBackend.BuildTask.InternalError.CreateFailed]
 Description = "创建构建任务失败"
 Solution = "请联系管理员"

--- a/adp/vega/vega-backend/server/logics/build_task/build_task_service.go
+++ b/adp/vega/vega-backend/server/logics/build_task/build_task_service.go
@@ -153,15 +153,15 @@ func (bts *buildTaskService) CreateBuildTask(ctx context.Context, req *interface
 
 	now := time.Now().UnixMilli()
 	buildTask := &interfaces.BuildTask{
-		ID:              xid.New().String(),
-		ResourceID:      resourceID,
-		CatalogID:       resource.CatalogID,
-		Status:          interfaces.BuildTaskStatusInit,
-		Mode:            req.Mode,
-		Creator:         accountInfo,
-		CreateTime:      now,
-		Updater:         accountInfo,
-		UpdateTime:      now,
+		ID:               xid.New().String(),
+		ResourceID:       resourceID,
+		CatalogID:        resource.CatalogID,
+		Status:           interfaces.BuildTaskStatusInit,
+		Mode:             req.Mode,
+		Creator:          accountInfo,
+		CreateTime:       now,
+		Updater:          accountInfo,
+		UpdateTime:       now,
 		EmbeddingFields:  req.EmbeddingFields,
 		BuildKeyFields:   req.BuildKeyFields,
 		EmbeddingModel:   req.EmbeddingModel,
@@ -551,14 +551,18 @@ func (bts *buildTaskService) StopBuildTask(ctx context.Context, taskID string) e
 //     unless ignoreMissing=true (then missing ids are dropped from the delete set).
 //   - If any task is in running/stopping status, returns 409 HasRunningExecution with {running_ids: [...]}.
 //     This check cannot be bypassed.
+//   - If any task owns the resource's current LocalIndexName, returns 409 ActiveIndexInUse
+//     unless deleteActiveIndex=true. When deleteActiveIndex=true, clears LocalIndexName before deleting.
 //   - Deletes pass-through tasks one-by-one. Mid-loop errors return 500 (rare, bounded by pre-validation).
-func (bts *buildTaskService) DeleteBuildTasks(ctx context.Context, ids []string, ignoreMissing bool) error {
+func (bts *buildTaskService) DeleteBuildTasks(ctx context.Context, ids []string, ignoreMissing bool, deleteActiveIndex bool) error {
 	ctx, span := oteltrace.StartNamedInternalSpan(ctx, "Delete build tasks")
 	defer span.End()
 
 	toDelete := make([]*interfaces.BuildTask, 0, len(ids))
 	missingIDs := make([]string, 0)
 	runningIDs := make([]string, 0)
+	activeIndexes := make([]map[string]string, 0)
+	activeResources := make(map[string]*interfaces.Resource)
 
 	for _, id := range ids {
 		buildTask, err := bts.bta.GetByID(ctx, id)
@@ -575,6 +579,23 @@ func (bts *buildTaskService) DeleteBuildTasks(ctx context.Context, ids []string,
 			runningIDs = append(runningIDs, id)
 			continue
 		}
+		resource, err := bts.ra.GetByID(ctx, buildTask.ResourceID)
+		if err != nil {
+			span.SetStatus(codes.Error, "Get resource failed")
+			return rest.NewHTTPError(ctx, http.StatusInternalServerError, verrors.VegaBackend_BuildTask_InternalError_GetFailed).
+				WithErrorDetails(err.Error())
+		}
+		if resource != nil {
+			idx := interfaces.BuildIndexName(buildTask.ResourceID, buildTask.ID)
+			if resource.LocalIndexName == idx {
+				activeIndexes = append(activeIndexes, map[string]string{
+					"resource_id":   buildTask.ResourceID,
+					"build_task_id": buildTask.ID,
+					"index_name":    idx,
+				})
+				activeResources[buildTask.ID] = resource
+			}
+		}
 		toDelete = append(toDelete, buildTask)
 	}
 
@@ -587,6 +608,25 @@ func (bts *buildTaskService) DeleteBuildTasks(ctx context.Context, ids []string,
 		span.SetStatus(codes.Error, "Some build tasks not found")
 		return rest.NewHTTPError(ctx, http.StatusNotFound, verrors.VegaBackend_BuildTask_NotFound).
 			WithErrorDetails(map[string]any{"missing_ids": missingIDs})
+	}
+	if len(activeIndexes) > 0 && !deleteActiveIndex {
+		span.SetStatus(codes.Error, "Some build task indexes are currently used by resources")
+		return rest.NewHTTPError(ctx, http.StatusConflict, verrors.VegaBackend_BuildTask_ActiveIndexInUse).
+			WithErrorDetails(map[string]any{"active_indexes": activeIndexes})
+	}
+	if deleteActiveIndex {
+		for taskID, resource := range activeResources {
+			resource.LocalIndexName = ""
+			if err := bts.ra.Update(ctx, resource); err != nil {
+				span.SetStatus(codes.Error, "Clear active local index failed")
+				return rest.NewHTTPError(ctx, http.StatusInternalServerError, verrors.VegaBackend_Resource_InternalError_UpdateFailed).
+					WithErrorDetails(map[string]any{
+						"build_task_id": taskID,
+						"resource_id":   resource.ID,
+						"error":         err.Error(),
+					})
+			}
+		}
 	}
 
 	// ds 优先 struct 字段（测试注入），否则走 logics 全局（生产）

--- a/adp/vega/vega-backend/server/logics/build_task/build_task_service_test.go
+++ b/adp/vega/vega-backend/server/logics/build_task/build_task_service_test.go
@@ -8,6 +8,7 @@ package build_task
 
 import (
 	"context"
+	"errors"
 	"net/http"
 	"testing"
 
@@ -253,16 +254,141 @@ func TestComputeIndexHealth(t *testing.T) {
 func TestDeleteBuildTasks_DropsIndexAndRow(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockBTA := mock_interfaces.NewMockBuildTaskAccess(ctrl)
+	mockRA := mock_interfaces.NewMockResourceAccess(ctrl)
 	mockDS := mock_interfaces.NewMockDatasetService(ctrl)
-	service := &buildTaskService{bta: mockBTA, ds: mockDS}
+	service := &buildTaskService{bta: mockBTA, ra: mockRA, ds: mockDS}
 
 	mockBTA.EXPECT().GetByID(gomock.Any(), "t1").
 		Return(&interfaces.BuildTask{ID: "t1", ResourceID: "r1", Status: "completed"}, nil)
+	mockRA.EXPECT().GetByID(gomock.Any(), "r1").
+		Return(&interfaces.Resource{ID: "r1", LocalIndexName: interfaces.BuildIndexName("r1", "old-task")}, nil)
 	mockDS.EXPECT().Delete(gomock.Any(), interfaces.BuildIndexName("r1", "t1")).Return(nil)
 	mockBTA.EXPECT().Delete(gomock.Any(), "t1").Return(nil)
 
-	if err := service.DeleteBuildTasks(context.Background(), []string{"t1"}, false); err != nil {
+	if err := service.DeleteBuildTasks(context.Background(), []string{"t1"}, false, false); err != nil {
 		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestDeleteBuildTasks_RefusesActiveLocalIndex(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	mockBTA := mock_interfaces.NewMockBuildTaskAccess(ctrl)
+	mockRA := mock_interfaces.NewMockResourceAccess(ctrl)
+	mockDS := mock_interfaces.NewMockDatasetService(ctrl)
+	service := &buildTaskService{bta: mockBTA, ra: mockRA, ds: mockDS}
+
+	idx := interfaces.BuildIndexName("r1", "t1")
+	mockBTA.EXPECT().GetByID(gomock.Any(), "t1").
+		Return(&interfaces.BuildTask{ID: "t1", ResourceID: "r1", Status: interfaces.BuildTaskStatusCompleted}, nil)
+	mockRA.EXPECT().GetByID(gomock.Any(), "r1").
+		Return(&interfaces.Resource{ID: "r1", LocalIndexName: idx}, nil)
+	// Active index conflicts must not delete either the index or the task row.
+
+	err := service.DeleteBuildTasks(context.Background(), []string{"t1"}, false, false)
+	httpErr, ok := err.(*rest.HTTPError)
+	if !ok {
+		t.Fatalf("expected HTTPError, got %T: %v", err, err)
+	}
+	if httpErr.HTTPCode != http.StatusConflict {
+		t.Fatalf("expected 409, got %d", httpErr.HTTPCode)
+	}
+	if httpErr.BaseError.ErrorCode != verrors.VegaBackend_BuildTask_ActiveIndexInUse {
+		t.Fatalf("expected %s, got %s", verrors.VegaBackend_BuildTask_ActiveIndexInUse, httpErr.BaseError.ErrorCode)
+	}
+}
+
+func TestDeleteBuildTasks_DeleteActiveLocalIndexWhenExplicitlyAllowed(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	mockBTA := mock_interfaces.NewMockBuildTaskAccess(ctrl)
+	mockRA := mock_interfaces.NewMockResourceAccess(ctrl)
+	mockDS := mock_interfaces.NewMockDatasetService(ctrl)
+	service := &buildTaskService{bta: mockBTA, ra: mockRA, ds: mockDS}
+
+	idx := interfaces.BuildIndexName("r1", "t1")
+	resource := &interfaces.Resource{ID: "r1", LocalIndexName: idx}
+	mockBTA.EXPECT().GetByID(gomock.Any(), "t1").
+		Return(&interfaces.BuildTask{ID: "t1", ResourceID: "r1", Status: interfaces.BuildTaskStatusCompleted}, nil)
+	mockRA.EXPECT().GetByID(gomock.Any(), "r1").Return(resource, nil)
+	mockRA.EXPECT().Update(gomock.Any(), gomock.Any()).
+		DoAndReturn(func(_ context.Context, got *interfaces.Resource) error {
+			if got.ID != "r1" {
+				t.Fatalf("expected resource r1, got %s", got.ID)
+			}
+			if got.LocalIndexName != "" {
+				t.Fatalf("expected LocalIndexName to be cleared, got %q", got.LocalIndexName)
+			}
+			return nil
+		})
+	mockDS.EXPECT().Delete(gomock.Any(), idx).Return(nil)
+	mockBTA.EXPECT().Delete(gomock.Any(), "t1").Return(nil)
+
+	if err := service.DeleteBuildTasks(context.Background(), []string{"t1"}, false, true); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestDeleteBuildTasks_ClearActiveLocalIndexFailureBlocksDeletion(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	mockBTA := mock_interfaces.NewMockBuildTaskAccess(ctrl)
+	mockRA := mock_interfaces.NewMockResourceAccess(ctrl)
+	mockDS := mock_interfaces.NewMockDatasetService(ctrl)
+	service := &buildTaskService{bta: mockBTA, ra: mockRA, ds: mockDS}
+
+	idx := interfaces.BuildIndexName("r1", "t1")
+	mockBTA.EXPECT().GetByID(gomock.Any(), "t1").
+		Return(&interfaces.BuildTask{ID: "t1", ResourceID: "r1", Status: interfaces.BuildTaskStatusCompleted}, nil)
+	mockRA.EXPECT().GetByID(gomock.Any(), "r1").
+		Return(&interfaces.Resource{ID: "r1", LocalIndexName: idx}, nil)
+	mockRA.EXPECT().Update(gomock.Any(), gomock.Any()).Return(errors.New("update failed"))
+	// Clearing LocalIndexName failed, so the index and task row must remain untouched.
+
+	err := service.DeleteBuildTasks(context.Background(), []string{"t1"}, false, true)
+	httpErr, ok := err.(*rest.HTTPError)
+	if !ok {
+		t.Fatalf("expected HTTPError, got %T: %v", err, err)
+	}
+	if httpErr.HTTPCode != http.StatusInternalServerError {
+		t.Fatalf("expected 500, got %d", httpErr.HTTPCode)
+	}
+}
+
+func TestDeleteBuildTasks_AllowsOrphanTaskWhenResourceMissing(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	mockBTA := mock_interfaces.NewMockBuildTaskAccess(ctrl)
+	mockRA := mock_interfaces.NewMockResourceAccess(ctrl)
+	mockDS := mock_interfaces.NewMockDatasetService(ctrl)
+	service := &buildTaskService{bta: mockBTA, ra: mockRA, ds: mockDS}
+
+	mockBTA.EXPECT().GetByID(gomock.Any(), "t1").
+		Return(&interfaces.BuildTask{ID: "t1", ResourceID: "missing-resource", Status: interfaces.BuildTaskStatusFailed}, nil)
+	mockRA.EXPECT().GetByID(gomock.Any(), "missing-resource").Return(nil, nil)
+	mockDS.EXPECT().Delete(gomock.Any(), interfaces.BuildIndexName("missing-resource", "t1")).Return(nil)
+	mockBTA.EXPECT().Delete(gomock.Any(), "t1").Return(nil)
+
+	if err := service.DeleteBuildTasks(context.Background(), []string{"t1"}, false, false); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestDeleteBuildTasks_ResourceLookupFailureBlocksDeletion(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	mockBTA := mock_interfaces.NewMockBuildTaskAccess(ctrl)
+	mockRA := mock_interfaces.NewMockResourceAccess(ctrl)
+	mockDS := mock_interfaces.NewMockDatasetService(ctrl)
+	service := &buildTaskService{bta: mockBTA, ra: mockRA, ds: mockDS}
+
+	mockBTA.EXPECT().GetByID(gomock.Any(), "t1").
+		Return(&interfaces.BuildTask{ID: "t1", ResourceID: "r1", Status: interfaces.BuildTaskStatusStopped}, nil)
+	mockRA.EXPECT().GetByID(gomock.Any(), "r1").Return(nil, errors.New("db unavailable"))
+	// If the guard cannot prove the index is safe to delete, deletion must not proceed.
+
+	err := service.DeleteBuildTasks(context.Background(), []string{"t1"}, false, false)
+	httpErr, ok := err.(*rest.HTTPError)
+	if !ok {
+		t.Fatalf("expected HTTPError, got %T: %v", err, err)
+	}
+	if httpErr.HTTPCode != http.StatusInternalServerError {
+		t.Fatalf("expected 500, got %d", httpErr.HTTPCode)
 	}
 }
 
@@ -277,7 +403,7 @@ func TestDeleteBuildTasks_RefusesRunning(t *testing.T) {
 		Return(&interfaces.BuildTask{ID: "t1", ResourceID: "r1", Status: "running"}, nil)
 	// 不应调用 ds.Delete / bta.Delete
 
-	if err := service.DeleteBuildTasks(context.Background(), []string{"t1"}, false); err == nil {
+	if err := service.DeleteBuildTasks(context.Background(), []string{"t1"}, false, true); err == nil {
 		t.Fatalf("expected 409 when a task is running")
 	}
 }


### PR DESCRIPTION
# Pull Request

## What Changed

Brief description of changes:

- [x] Add `delete_active_index=true` support for `DELETE /build-tasks/:ids`
- [x] Protect active build task indexes by default and return `409 ActiveIndexInUse`
- [x] Clear `resource.LocalIndexName` before explicitly deleting an active local index
- [x] Add localized error text and update generated mocks/tests
- [x] Update Go module dependency versions in `go.mod` / `go.sum`

---

## Why

- Related Issue: Closes #154
- Related Feature: VEGA build task local index lifecycle safety
- Background:
  - A completed build task may own the index currently referenced by `resource.LocalIndexName`.
  - Deleting that task previously could drop the OpenSearch index and delete the task row while leaving the resource pointing at a missing local index.
  - The new default behavior prevents accidental active-index deletion, while `delete_active_index=true` gives callers an explicit opt-in path that first clears `LocalIndexName`.

---

## How

- Key implementation points:
  - Parse `delete_active_index` in the build task DELETE handler and pass it through `BuildTaskService.DeleteBuildTasks`.
  - During delete pre-validation, load each task's resource and compare `resource.LocalIndexName` with `interfaces.BuildIndexName(task.ResourceID, task.ID)`.
  - If an active local index is found and `delete_active_index` is not true, return `409` with `VegaBackend.BuildTask.ActiveIndexInUse`.
  - If `delete_active_index=true`, clear and persist `resource.LocalIndexName` before dropping the index and deleting the task row.
  - Keep running/stopping task protection unchanged; the explicit flag does not bypass running task checks.
- Breaking changes (API, config, database, etc.):
  - `DELETE /build-tasks/:ids` now rejects active local index deletion by default.
  - Callers that intentionally delete the active local index must pass `delete_active_index=true`.
  - No database schema or config changes.

---

## Testing

- [x] Unit tests passed locally
- [ ] Integration tests passed locally
- [ ] Verified in test environment

Test notes:

```bash
go test -count=1 ./logics/build_task
go test -count=1 ./driveradapters
go test -count=1 ./logics/resource ./logics/catalog
```

---

## Risk & Rollback

- Potential risks:
  - API callers that relied on deleting an active local index without explicit confirmation now receive `409`.
  - `delete_active_index=true` clears `LocalIndexName`, so table resource queries fall back to source query behavior after deletion.
- Rollback plan:
  - Revert this PR to restore the previous build task deletion behavior.
  - If a resource is left with an unexpected `LocalIndexName`, rebuild the task or manually update the resource to the intended local index.

---

## Additional Notes

- Screenshots, logs, documentation links, etc.:
  - PR updates issue #154's accepted behavior to use the explicit `delete_active_index=true` confirmation flag.
