### PR TITLE
fix(vega-backend): updateResourceIndexName should not delete old index

### DIFF
--- a/adp/vega/vega-backend/server/worker/build_handler_batch.go
+++ b/adp/vega/vega-backend/server/worker/build_handler_batch.go
@@ -406,7 +406,7 @@ func (bh *batchBuildHandler) executeBuild(ctx context.Context, resource *interfa
 
 	if buildTaskInfo.EmbeddingFields == "" {
 		// Update resource index name
-		err = updateResourceIndexName(ctx, resource, bh.resAccess, bh.ds, indexName)
+		err = updateResourceIndexName(ctx, resource, bh.resAccess, indexName)
 		if err != nil {
 			return fmt.Errorf("failed to update resource index name: %v", err)
 		}

--- a/adp/vega/vega-backend/server/worker/build_handler_embedding.go
+++ b/adp/vega/vega-backend/server/worker/build_handler_embedding.go
@@ -309,7 +309,7 @@ func (eh *embeddingHandler) executeEmbedding(ctx context.Context, resource *inte
 
 				// 索引名落账持久失败则不提交哨兵，整个任务交给 asynq 重试：
 				// 重启后从最后提交位点续读，哨兵会重新投递
-				if err := updateResourceIndexName(ctx, resource, eh.resAccess, eh.ds, indexName); err != nil {
+				if err := updateResourceIndexName(ctx, resource, eh.resAccess, indexName); err != nil {
 					logger.Errorf("Failed to update resource index name: %v", err)
 					return fmt.Errorf("update resource index name: %w", err)
 				}

--- a/adp/vega/vega-backend/server/worker/build_handler_streaming.go
+++ b/adp/vega/vega-backend/server/worker/build_handler_streaming.go
@@ -381,7 +381,7 @@ func (sh *streamingBuildHandler) executeBuild(ctx context.Context, catalog *inte
 
 				if !updatedIndexName && op != "r" {
 					// Full snapshot is completed, update index name in resource
-					if err := updateResourceIndexName(ctx, resource, sh.resAccess, sh.ds, indexName); err != nil {
+					if err := updateResourceIndexName(ctx, resource, sh.resAccess, indexName); err != nil {
 						logger.Errorf("Failed to update resource index name: %v", err)
 					} else {
 						updatedIndexName = true

--- a/adp/vega/vega-backend/server/worker/build_task_common.go
+++ b/adp/vega/vega-backend/server/worker/build_task_common.go
@@ -53,20 +53,23 @@ func getNewDocID(primaryKeyValues []interfaces.KeyValue, document map[string]any
 }
 
 // updateResourceIndexName updates the index name of a resource
-func updateResourceIndexName(ctx context.Context, resource *interfaces.Resource, ra interfaces.ResourceAccess, ds interfaces.DatasetService, indexName string) error {
+func updateResourceIndexName(ctx context.Context, resource *interfaces.Resource, ra interfaces.ResourceAccess, indexName string) error {
 	if resource.LocalIndexName == "" {
 		resource.LocalIndexName = indexName
 		return ra.Update(ctx, resource)
 	}
 
-	if resource.LocalIndexName != indexName {
-		err := ds.Delete(ctx, resource.LocalIndexName)
-		if err != nil {
-			return fmt.Errorf("delete local index failed: %w", err)
-		}
-		resource.LocalIndexName = indexName
-		return ra.Update(ctx, resource)
+	if resource.LocalIndexName == indexName {
+		return nil
 	}
+
+	oldIndexName := resource.LocalIndexName
+	resource.LocalIndexName = indexName
+	if err := ra.Update(ctx, resource); err != nil {
+		resource.LocalIndexName = oldIndexName
+		return err
+	}
+
 	return nil
 }
 

--- a/adp/vega/vega-backend/server/worker/build_task_common_test.go
+++ b/adp/vega/vega-backend/server/worker/build_task_common_test.go
@@ -1,0 +1,64 @@
+// Copyright openbkn.ai
+//
+// Licensed under the OpenBKN License. See LICENSE-OPENBKN.txt in the project root.
+
+package worker
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"go.uber.org/mock/gomock"
+
+	"vega-backend/interfaces"
+	vmock "vega-backend/interfaces/mock"
+)
+
+func TestUpdateResourceIndexNameEmptyOldIndex(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	ra := vmock.NewMockResourceAccess(ctrl)
+	resource := &interfaces.Resource{ID: "r1"}
+
+	ra.EXPECT().Update(gomock.Any(), resource).DoAndReturn(func(_ context.Context, got *interfaces.Resource) error {
+		if got.LocalIndexName != "new-index" {
+			t.Fatalf("expected new-index, got %q", got.LocalIndexName)
+		}
+		return nil
+	})
+
+	if err := updateResourceIndexName(context.Background(), resource, ra, "new-index"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestUpdateResourceIndexNameUnchangedIndex(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	ra := vmock.NewMockResourceAccess(ctrl)
+	resource := &interfaces.Resource{ID: "r1", LocalIndexName: "same-index"}
+
+	if err := updateResourceIndexName(context.Background(), resource, ra, "same-index"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestUpdateResourceIndexNameUpdateFailureKeepsOldIndex(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	ra := vmock.NewMockResourceAccess(ctrl)
+	resource := &interfaces.Resource{ID: "r1", LocalIndexName: "old-index"}
+
+	ra.EXPECT().Update(gomock.Any(), resource).DoAndReturn(func(_ context.Context, got *interfaces.Resource) error {
+		if got.LocalIndexName != "new-index" {
+			t.Fatalf("expected attempted update to new-index, got %q", got.LocalIndexName)
+		}
+		return errors.New("update failed")
+	})
+
+	err := updateResourceIndexName(context.Background(), resource, ra, "new-index")
+	if err == nil {
+		t.Fatal("expected update error")
+	}
+	if resource.LocalIndexName != "old-index" {
+		t.Fatalf("expected in-memory LocalIndexName restored to old-index, got %q", resource.LocalIndexName)
+	}
+}


### PR DESCRIPTION
# Pull Request

## What Changed

- Removed old-index deletion logic from `updateResourceIndexName`.
- Removed the `ds interfaces.DatasetService` parameter from `updateResourceIndexName`.
- Updated all call sites in `build_handler_batch.go`, `build_handler_streaming.go`, and `build_handler_embedding.go`.
- Removed the obsolete unit test `TestUpdateResourceIndexNameDeleteOldIndexFailureIsBestEffort` and updated remaining tests to match the new signature.

---

## Why

- Related Issue: [#155](https://github.com/openbkn-ai/bkn-foundry/issues/155)
- Index cleanup should be a global policy concern, not a side effect of updating a resource pointer.
- The index name is already bound to the build task (`vega-build-{resourceID}-{taskID}`), and task deletion already drops the corresponding index.
- Keeping `ds.Delete` inside `updateResourceIndexName` mixes resource metadata update with storage lifecycle management and makes rollback unsafe.

---

## How

- `updateResourceIndexName` now only switches `resource.LocalIndexName` to the new index name and persists the change.
- If persistence fails, the in-memory value is rolled back to the old index name.
- Old indexes are left untouched; they will be removed when their associated build tasks are deleted or by a future global cleanup policy.

---

## Testing

- [x] Unit tests passed locally
- [ ] Integration tests passed locally
- [ ] Verified in test environment

Test notes:
```
cd adp/vega/vega-backend/server
go test ./worker/... -run TestUpdateResourceIndexName -v
# PASS
```

---

## Risk & Rollback

- Potential risks: Until a global cleanup strategy is implemented, completed rebuilds may leave orphan indexes in OpenSearch, consuming disk space.
- Rollback plan: Revert this PR to restore eager deletion in `updateResourceIndexName`.

---

## Additional Notes

- This is a follow-up refinement of PR #157 / Issue #155.
