### PR TITLE
build(data-migrator): upgrade dependencies and switch RDS SDK

### DIFF
--- a/data-migrator/server/requirements.txt
+++ b/data-migrator/server/requirements.txt
@@ -1,12 +1,8 @@
-PyYAML>=6.0
-sqlparse>=0.5.0
-pymongo>=4.16.0
-opensearch-py>=3.1.0
+PyYAML>=6.0.3
+sqlparse>=0.5.5
+pymongo>=4.17.0
+opensearch-py>=3.2.0
 
 # RDS 多数据库驱动
-git+https://github.com/kweaver-ai/proton-rds-sdk-py.git@release/2.0.0
-# 其传递依赖：
-# pymysql[rsa]==1.1.2
-# dmPython==2.5.26       # 达梦数据库，需官方驱动包，按需安装
-# ksycopg2==2.9.0        # 人大金仓，需官方驱动包，按需安装
+git+https://github.com/openbkn-ai/bkn-comm-py.git@v0.0.1
 


### PR DESCRIPTION
# Pull Request

## What Changed

Brief description of changes:

- [x] Updated `data-migrator/server/requirements.txt` dependency minimums for PyYAML, sqlparse, pymongo, and opensearch-py.
- [x] Replaced the RDS SDK dependency source from `kweaver-ai/proton-rds-sdk-py@release/2.0.0` to `openbkn-ai/bkn-comm-py@v0.0.1`.
- [x] Removed stale comments that listed the old SDK's transitive database driver dependencies.

---

## Why

- Related Issue: N/A - existing PR #167 did not reference an issue.
- Related Feature: data-migrator dependency refresh and OpenBKN RDS SDK migration.
- Background: data-migrator should consume the OpenBKN Python common package for RDS support and keep its direct Python dependency constraints current.

---

## How

- Key implementation points:
  - Raised compatible lower bounds for core Python packages used by data-migrator.
  - Swapped the Git dependency URL to the OpenBKN-maintained `bkn-comm-py` tag.
  - Kept the change limited to the server requirements file.
- Breaking changes (API, config, database, etc.):
  - The Python RDS dependency source changes from the old proton SDK repository to `bkn-comm-py`.
  - No application code, API, schema, or runtime configuration files are changed in this PR.

---

## Testing

- [ ] Unit tests passed locally
- [ ] Integration tests passed locally
- [ ] Verified in test environment

Test notes:

- Local tests were not run as part of this PR body update.
- GitHub Actions observed for PR #167 are passing:
  - Branch Name Lint
  - Commit Message Lint
  - release-data-migrator resolve-version
  - release-data-migrator test
  - release-data-migrator build
  - release-data-migrator chart package

---

## Risk & Rollback

- Potential risks:
  - Builds or installs can fail if `openbkn-ai/bkn-comm-py@v0.0.1` is unavailable or has dependency incompatibilities in downstream environments.
  - Runtime behavior may differ if the new RDS SDK package exposes different driver behavior than the old proton SDK package.
- Rollback plan:
  - Revert the PR commit to restore the previous dependency pins and `proton-rds-sdk-py` Git dependency.

---

## Additional Notes

- Diff inspected: 1 file changed, 5 additions and 9 deletions.
- PR metadata updated by Codex using the repository pull request template.
