### PR TITLE
fix(vega-backend): skip PostgreSQL partition child tables during discover

### DIFF
--- a/adp/vega/vega-backend/server/go.mod
+++ b/adp/vega/vega-backend/server/go.mod
@@ -3,6 +3,7 @@ module vega-backend
 go 1.25.0
 
 require (
+	github.com/DATA-DOG/go-sqlmock v1.5.2
 	github.com/Masterminds/squirrel v1.5.4
 	github.com/antlr4-go/antlr/v4 v4.13.1
 	github.com/bytedance/sonic v1.15.2

--- a/adp/vega/vega-backend/server/go.sum
+++ b/adp/vega/vega-backend/server/go.sum
@@ -4,6 +4,8 @@ gitee.com/chunanyong/dm v1.8.23 h1:IadSVTP3l1qv41yzTaHffpsAdNtyR3Bl2FwR9Xpgpb8=
 gitee.com/chunanyong/dm v1.8.23/go.mod h1:EPRJnuPFgbyOFgJ0TRYCTGzhq+ZT4wdyaj/GW/LLcNg=
 github.com/BurntSushi/toml v1.6.0 h1:dRaEfpa2VI55EwlIW72hMRHdWouJeRF7TPYhI+AUQjk=
 github.com/BurntSushi/toml v1.6.0/go.mod h1:ukJfTF/6rtPPRCnwkur4qwRxa8vTRFBF0uk2lLoLwho=
+github.com/DATA-DOG/go-sqlmock v1.5.2 h1:OcvFkGmslmlZibjAjaHm3L//6LiuBgolP7OputlJIzU=
+github.com/DATA-DOG/go-sqlmock v1.5.2/go.mod h1:88MAG/4G7SMwSE3CeA0ZKzrT5CiOU3OJ+JlNzwDqpNU=
 github.com/IBM/sarama v1.50.3 h1:zpY2iZYmt+z+0Bo3aYF+cD48OBt2hIgiDPZUuZKTXcc=
 github.com/IBM/sarama v1.50.3/go.mod h1:Jo4MSfdDT3ycmQj7/ab8eLZwnvwCKZm/8H7SCbtyo8U=
 github.com/Masterminds/squirrel v1.5.4 h1:uUcX/aBc8O7Fg9kaISIUsHXdKuqehiXAMQTYX8afzqM=
@@ -130,6 +132,7 @@ github.com/json-iterator/go v1.1.12 h1:PV8peI4a0ysnczrg+LtxykD8LfKY9ML6u2jnxaEnr
 github.com/json-iterator/go v1.1.12/go.mod h1:e30LSqwooZae/UwlEbR2852Gd8hjQvJoHmT4TnhNGBo=
 github.com/jtolds/gls v4.20.0+incompatible h1:xdiiI2gbIgH/gLH7ADydsJ1uDOEzR8yvV7C0MuV77Wo=
 github.com/jtolds/gls v4.20.0+incompatible/go.mod h1:QJZ7F/aHp+rZTRtaJ1ow/lLfFfVYBRgL+9YlvaHOwJU=
+github.com/kisielk/sqlstruct v0.0.0-20201105191214-5f3e10d3ab46/go.mod h1:yyMNCyc/Ib3bDTKd379tNMpB/7/H5TjM2Y9QJ5THLbE=
 github.com/klauspost/compress v1.18.6 h1:2jupLlAwFm95+YDR+NwD2MEfFO9d4z4Prjl1XXDjuao=
 github.com/klauspost/compress v1.18.6/go.mod h1:cwPg85FWrGar70rWktvGQj8/hthj3wpl0PGDogxkrSQ=
 github.com/klauspost/cpuid/v2 v2.3.0 h1:S4CRMLnYUhGeDFDqkGriYKdfoFlDnMtqTiI/sFzhA9Y=

--- a/adp/vega/vega-backend/server/logics/connectors/local/table/postgresql/postgresql_discover.go
+++ b/adp/vega/vega-backend/server/logics/connectors/local/table/postgresql/postgresql_discover.go
@@ -96,7 +96,8 @@ func (c *PostgresqlConnector) ListTables(ctx context.Context) ([]*interfaces.Tab
 		Where(sq.NotEq{"c.relpersistence": "t"}).
 		Where(sq.Expr("has_table_privilege(c.oid, ?)", "SELECT")).
 		Where(sq.NotEq{"n.nspname": SYSTEM_SCHEMAS}).
-		Where(sq.Expr("NOT pg_is_other_temp_schema(n.oid)"))
+		Where(sq.Expr("NOT pg_is_other_temp_schema(n.oid)")).
+		Where(sq.Expr("NOT EXISTS (SELECT 1 FROM pg_catalog.pg_inherits i WHERE i.inhrelid = c.oid)"))
 
 	if len(c.config.Schemas) > 0 {
 		builder = builder.Where(sq.Eq{"n.nspname": c.config.Schemas})

--- a/adp/vega/vega-backend/server/logics/connectors/local/table/postgresql/postgresql_discover_test.go
+++ b/adp/vega/vega-backend/server/logics/connectors/local/table/postgresql/postgresql_discover_test.go
@@ -6,7 +6,12 @@
 
 package postgresql
 
-import "testing"
+import (
+	"context"
+	"testing"
+
+	"github.com/DATA-DOG/go-sqlmock"
+)
 
 func TestPostgresqlTableTypeFromRelkind(t *testing.T) {
 	tests := []struct {
@@ -27,5 +32,51 @@ func TestPostgresqlTableTypeFromRelkind(t *testing.T) {
 				t.Fatalf("expected %s, got %s", tt.want, got)
 			}
 		})
+	}
+}
+
+func TestListTablesExcludesPartitionChildren(t *testing.T) {
+	db, mock, err := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherRegexp))
+	if err != nil {
+		t.Fatalf("sqlmock.New returned error: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+
+	connector := &PostgresqlConnector{
+		config: &postgresqlConfig{
+			Database: "appdb",
+			Schemas:  []string{"public", "analytics"},
+		},
+		connected: true,
+		db:        db,
+	}
+
+	rows := sqlmock.NewRows([]string{"table_schema", "table_name", "relkind", "description"}).
+		AddRow("public", "orders", "r", "ordinary table").
+		AddRow("public", "orders_partitioned", "p", "partitioned parent table").
+		AddRow("analytics", "orders_view", "v", "view")
+
+	mock.ExpectQuery("(?s).*pg_catalog\\.pg_inherits.*i\\.inhrelid = c\\.oid.*n\\.nspname IN.*").
+		WillReturnRows(rows)
+
+	tables, err := connector.ListTables(context.Background())
+	if err != nil {
+		t.Fatalf("ListTables returned error: %v", err)
+	}
+
+	if len(tables) != 3 {
+		t.Fatalf("expected 3 tables, got %d", len(tables))
+	}
+	if tables[0].Name != "orders" || tables[0].TableType != "table" || tables[0].Database != "appdb" || tables[0].Schema != "public" {
+		t.Fatalf("unexpected ordinary table metadata: %+v", tables[0])
+	}
+	if tables[1].Name != "orders_partitioned" || tables[1].TableType != "table" {
+		t.Fatalf("unexpected partitioned parent metadata: %+v", tables[1])
+	}
+	if tables[2].Name != "orders_view" || tables[2].TableType != "view" {
+		t.Fatalf("unexpected view metadata: %+v", tables[2])
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("sqlmock expectations were not met: %v", err)
 	}
 }


### PR DESCRIPTION
# Pull Request

## What Changed

Brief description of changes:

- [x] vega-backend PostgreSQL discover now excludes partition child tables from `ListTables`
- [x] Added `sqlmock` unit coverage for the PostgreSQL table discovery query
- [x] Preserved ordinary table, partition parent table, and view metadata mapping behavior

---

## Why

- Related Issue: Closes #168
- Related Feature: PostgreSQL catalog discover
- Background:
  PostgreSQL partition child tables are represented as ordinary relations and were previously included in catalog discover results. This caused Vega to create table resources for partition children, while the expected behavior is to expose the partition parent table and skip child partitions.

---

## How

- Key implementation points:
  - Added a `NOT EXISTS` filter against `pg_catalog.pg_inherits` in `PostgresqlConnector.ListTables`.
  - The filter excludes relations where `pg_inherits.inhrelid = c.oid`, which covers partition/inheritance child relations.
  - Kept existing relkind coverage for ordinary tables, partitioned parent tables, views, materialized views, and foreign tables.
  - Added `github.com/DATA-DOG/go-sqlmock` to test the generated query and returned table metadata without requiring a live PostgreSQL instance.
- Breaking changes (API, config, database, etc.):
  - No API, config, or schema changes.
  - Behavior change: existing resources created for partition child tables may be marked stale/missing on the next full discover because those source tables are no longer returned.

---

## Testing

- [x] Unit tests passed locally
- [ ] Integration tests passed locally
- [ ] Verified in test environment

Test notes:

```bash
go test ./logics/connectors/local/table/postgresql
go test ./worker ./logics/connectors/local/table/postgresql
```

---

## Risk & Rollback

- Potential risks:
  - Full discover may mark previously discovered partition child resources as stale/missing.
  - The `pg_inherits` filter also excludes classic inheritance child tables, which matches the current requirement to avoid child relations but should be noted for PG inheritance users.
- Rollback plan:
  - Revert this PR to restore the previous PostgreSQL table listing behavior.

---

## Additional Notes

- The PR keeps the query inline in `ListTables`; the regression test uses `sqlmock` instead of a helper-only SQL construction test.
