### PR TITLE
fix(vega-backend): normalize table schema source identifiers

### DIFF
--- a/adp/vega/vega-backend/server/interfaces/connector.go
+++ b/adp/vega/vega-backend/server/interfaces/connector.go
@@ -21,7 +21,6 @@ type TableMeta struct {
 	PKs         []string              `json:"primary_keys"`
 	Indices     []TableIndexMeta      `json:"indices"`      // 索引列表
 	ForeignKeys []TableForeignKeyMeta `json:"foreign_keys"` // 外键列表
-
 }
 
 // TableColumnMeta represents column metadata.

--- a/adp/vega/vega-backend/server/logics/connectors/connector.go
+++ b/adp/vega/vega-backend/server/logics/connectors/connector.go
@@ -49,8 +49,6 @@ type TableConnector interface {
 	// MapType 将源端原生类型映射为 VEGA 统一类型；不识别一律返回 Other
 	MapType(nativeType string) string
 
-	// ListDatabases 列出实例下所有可访问的数据库
-	ListDatabases(ctx context.Context) ([]string, error)
 	ListTables(ctx context.Context) ([]*interfaces.TableMeta, error)
 	GetTableMeta(ctx context.Context, table *interfaces.TableMeta) error
 

--- a/adp/vega/vega-backend/server/logics/connectors/local/table/mariadb/mariadb.go
+++ b/adp/vega/vega-backend/server/logics/connectors/local/table/mariadb/mariadb.go
@@ -227,8 +227,9 @@ func (c *MariaDBConnector) TestConnection(ctx context.Context) error {
 
 // validateDatabases 验证配置的数据库是否存在
 func (c *MariaDBConnector) validateDatabases(ctx context.Context) error {
-	// 获取所有数据库列表
-	rows, err := c.db.QueryContext(ctx, "SHOW DATABASES")
+	// 获取所有数据库/schema 列表；MariaDB 中 database 与 schema 等价。
+	rows, err := c.db.QueryContext(ctx,
+		"SELECT SCHEMA_NAME FROM information_schema.SCHEMATA ORDER BY SCHEMA_NAME")
 	if err != nil {
 		return fmt.Errorf("failed to list databases: %w", err)
 	}

--- a/adp/vega/vega-backend/server/logics/connectors/local/table/mariadb/mariadb_additional_test.go
+++ b/adp/vega/vega-backend/server/logics/connectors/local/table/mariadb/mariadb_additional_test.go
@@ -104,7 +104,7 @@ func TestMariaDBConnectorValidateDatabases(t *testing.T) {
 		connector, mock, cleanup := newMariaDBConnectorMock(t, []string{"app", "audit"})
 		defer cleanup()
 
-		mock.ExpectQuery("SHOW DATABASES").
+		mock.ExpectQuery("SELECT SCHEMA_NAME FROM information_schema\\.SCHEMATA ORDER BY SCHEMA_NAME").
 			WillReturnRows(sqlmock.NewRows([]string{"Database"}).AddRow("app").AddRow("audit").AddRow("mysql"))
 
 		require.NoError(t, connector.validateDatabases(context.Background()))
@@ -115,7 +115,7 @@ func TestMariaDBConnectorValidateDatabases(t *testing.T) {
 		connector, mock, cleanup := newMariaDBConnectorMock(t, []string{"app"})
 		defer cleanup()
 
-		mock.ExpectQuery("SHOW DATABASES").
+		mock.ExpectQuery("SELECT SCHEMA_NAME FROM information_schema\\.SCHEMATA ORDER BY SCHEMA_NAME").
 			WillReturnError(errors.New("db down"))
 
 		err := connector.validateDatabases(context.Background())
@@ -129,7 +129,7 @@ func TestMariaDBConnectorValidateDatabases(t *testing.T) {
 		connector, mock, cleanup := newMariaDBConnectorMock(t, []string{"missing"})
 		defer cleanup()
 
-		mock.ExpectQuery("SHOW DATABASES").
+		mock.ExpectQuery("SELECT SCHEMA_NAME FROM information_schema\\.SCHEMATA ORDER BY SCHEMA_NAME").
 			WillReturnRows(sqlmock.NewRows([]string{"Database"}).AddRow("app"))
 
 		err := connector.validateDatabases(context.Background())

--- a/adp/vega/vega-backend/server/logics/connectors/local/table/mariadb/mariadb_discover.go
+++ b/adp/vega/vega-backend/server/logics/connectors/local/table/mariadb/mariadb_discover.go
@@ -20,34 +20,6 @@ import (
 	"vega-backend/interfaces"
 )
 
-// ListDatabases 列出实例下所有可访问的用户数据库（排除系统库）。
-func (c *MariaDBConnector) ListDatabases(ctx context.Context) ([]string, error) {
-	if err := c.Connect(ctx); err != nil {
-		return nil, err
-	}
-
-	rows, err := c.db.QueryContext(ctx, "SHOW DATABASES")
-	if err != nil {
-		return nil, fmt.Errorf("failed to list databases: %w", err)
-	}
-	defer func() { _ = rows.Close() }()
-
-	var databases []string
-	for rows.Next() {
-		var db string
-		if err := rows.Scan(&db); err != nil {
-			return nil, fmt.Errorf("failed to scan database name: %w", err)
-		}
-		if !SYSTEM_DBS_MAP[db] {
-			databases = append(databases, db)
-		}
-	}
-	if err := rows.Err(); err != nil {
-		return nil, fmt.Errorf("failed to iterate databases: %w", err)
-	}
-	return databases, nil
-}
-
 // ListTables 返回数据库中的所有表。
 // 如果 Config.Database 非空，只列出该数据库的表；
 // 如果 Config.Database 为空（实例级连接），遍历所有用户数据库，返回的 TableMeta.Database 字段标记所属库。
@@ -121,6 +93,7 @@ func (c *MariaDBConnector) ListTables(ctx context.Context) ([]*interfaces.TableM
 			TableType:   tableType,
 			Description: description.String,
 			Database:    schema,
+			Schema:      schema,
 		}
 
 		// Populate Properties

--- a/adp/vega/vega-backend/server/logics/connectors/local/table/oracle/oracle.go
+++ b/adp/vega/vega-backend/server/logics/connectors/local/table/oracle/oracle.go
@@ -87,11 +87,6 @@ type OracleConnector struct {
 	db        *sql.DB
 }
 
-func (c *OracleConnector) ListDatabases(ctx context.Context) ([]string, error) {
-	//TODO implement me
-	panic("implement me")
-}
-
 // NewOracleConnector creates Oracle connector builder
 func NewOracleConnector() connectors.TableConnector {
 	return &OracleConnector{}
@@ -279,35 +274,6 @@ func (c *OracleConnector) validateSchemas(ctx context.Context) error {
 	}
 
 	return nil
-}
-
-// ListSchemas lists all accessible user schemas (excluding system schemas) under the instance.
-func (c *OracleConnector) ListSchemas(ctx context.Context) ([]string, error) {
-	if err := c.Connect(ctx); err != nil {
-		return nil, err
-	}
-
-	query := "SELECT USERNAME FROM ALL_USERS WHERE ORACLE_MAINTAINED = 'N' ORDER BY USERNAME"
-	rows, err := c.db.QueryContext(ctx, query)
-	if err != nil {
-		return nil, fmt.Errorf("failed to list schemas: %w", err)
-	}
-	defer func() { _ = rows.Close() }()
-
-	var schemas []string
-	for rows.Next() {
-		var schema string
-		if err := rows.Scan(&schema); err != nil {
-			return nil, fmt.Errorf("failed to scan schema name: %w", err)
-		}
-		if !SYSTEM_SCHEMAS_MAP[strings.ToUpper(schema)] {
-			schemas = append(schemas, schema)
-		}
-	}
-	if err := rows.Err(); err != nil {
-		return nil, fmt.Errorf("failed to iterate schemas: %w", err)
-	}
-	return schemas, nil
 }
 
 // ListTables returns all tables in the database.

--- a/adp/vega/vega-backend/server/logics/connectors/local/table/oracle/oracle_additional_test.go
+++ b/adp/vega/vega-backend/server/logics/connectors/local/table/oracle/oracle_additional_test.go
@@ -59,21 +59,6 @@ func TestOracleConnectorValidateSchemas(t *testing.T) {
 	})
 }
 
-func TestOracleConnectorListSchemas(t *testing.T) {
-	connector, mock, cleanup := newOracleConnectorMock(t, nil)
-	defer cleanup()
-	connector.connected = true
-
-	mock.ExpectQuery("SELECT USERNAME FROM ALL_USERS WHERE ORACLE_MAINTAINED = 'N' ORDER BY USERNAME").
-		WillReturnRows(sqlmock.NewRows([]string{"USERNAME"}).AddRow("APP").AddRow("SYS").AddRow("AUDIT"))
-
-	got, err := connector.ListSchemas(context.Background())
-
-	require.NoError(t, err)
-	assert.Equal(t, []string{"APP", "AUDIT"}, got)
-	require.NoError(t, mock.ExpectationsWereMet())
-}
-
 func TestOracleConnectorListTables(t *testing.T) {
 	t.Run("filters configured schemas", func(t *testing.T) {
 		connector, mock, cleanup := newOracleConnectorMock(t, []string{"app"})

--- a/adp/vega/vega-backend/server/logics/connectors/local/table/postgresql/postgresql_discover.go
+++ b/adp/vega/vega-backend/server/logics/connectors/local/table/postgresql/postgresql_discover.go
@@ -19,64 +19,6 @@ import (
 
 var pgSq = sq.StatementBuilder.PlaceholderFormat(sq.Dollar)
 
-// ListDatabases 列出当前连接 database 下可访问的用户 schema（接口名沿用；PostgreSQL 下即 schema 列表）。
-func (c *PostgresqlConnector) ListDatabases(ctx context.Context) ([]string, error) {
-	if err := c.Connect(ctx); err != nil {
-		return nil, err
-	}
-
-	all, err := c.listUserSchemas(ctx)
-	if err != nil {
-		return nil, err
-	}
-	if len(c.config.Schemas) == 0 {
-		return all, nil
-	}
-	allow := make(map[string]struct{}, len(c.config.Schemas))
-	for _, s := range c.config.Schemas {
-		allow[s] = struct{}{}
-	}
-	var out []string
-	for _, s := range all {
-		if _, ok := allow[s]; ok && !SYSTEM_SCHEMAS_MAP[s] {
-			out = append(out, s)
-		}
-	}
-	return out, nil
-}
-
-func (c *PostgresqlConnector) listUserSchemas(ctx context.Context) ([]string, error) {
-	query, args, err := pgSq.Select("nspname").
-		From("pg_catalog.pg_namespace").
-		Where(sq.NotEq{"nspname": SYSTEM_SCHEMAS}).
-		Where(sq.Expr("NOT pg_is_other_temp_schema(oid)")).
-		Where(sq.Expr("oid <> pg_my_temp_schema()")).
-		OrderBy("nspname").
-		ToSql()
-	if err != nil {
-		return nil, fmt.Errorf("failed to build list schemas query: %w", err)
-	}
-
-	rows, err := c.db.QueryContext(ctx, query, args...)
-	if err != nil {
-		return nil, fmt.Errorf("failed to list schemas: %w", err)
-	}
-	defer func() { _ = rows.Close() }()
-
-	var schemas []string
-	for rows.Next() {
-		var name string
-		if err := rows.Scan(&name); err != nil {
-			return nil, err
-		}
-		schemas = append(schemas, name)
-	}
-	if err := rows.Err(); err != nil {
-		return nil, err
-	}
-	return schemas, nil
-}
-
 // ListTables 列出表、视图和物化视图；TableMeta.Database 填 database 名，Schema 填 schema 名。
 func (c *PostgresqlConnector) ListTables(ctx context.Context) ([]*interfaces.TableMeta, error) {
 	if err := c.Connect(ctx); err != nil {

--- a/adp/vega/vega-backend/server/worker/discover_handler_test.go
+++ b/adp/vega/vega-backend/server/worker/discover_handler_test.go
@@ -129,6 +129,40 @@ func TestUpdateDiscoverResultForEnrichStatus(t *testing.T) {
 	}
 }
 
+func TestBuildSourceIdentifierUsesSchemaAsQueryableNamespace(t *testing.T) {
+	dh := &DiscoverHandler{}
+
+	cases := []struct {
+		name  string
+		table *interfaces.TableMeta
+		want  string
+	}{
+		{
+			name:  "postgresql schema table",
+			table: &interfaces.TableMeta{Database: "ecommerce_db", Schema: "public", Name: "supplier_catalog"},
+			want:  "public.supplier_catalog",
+		},
+		{
+			name:  "mariadb schema equals database",
+			table: &interfaces.TableMeta{Database: "ecommerce_db", Schema: "ecommerce_db", Name: "supplier_catalog"},
+			want:  "ecommerce_db.supplier_catalog",
+		},
+		{
+			name:  "database fallback",
+			table: &interfaces.TableMeta{Database: "ecommerce_db", Name: "supplier_catalog"},
+			want:  "ecommerce_db.supplier_catalog",
+		},
+	}
+
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := dh.buildSourceIdentifier(tt.table); got != tt.want {
+				t.Fatalf("expected %q, got %q", tt.want, got)
+			}
+		})
+	}
+}
+
 func TestEnrichTableMetadataContinuesWhenOneTableFails(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	rs := vmock.NewMockResourceService(ctrl)
@@ -262,10 +296,6 @@ func (c *fakeTableConnector) GetMetadata(context.Context) (map[string]any, error
 
 func (c *fakeTableConnector) MapType(nativeType string) string {
 	return nativeType
-}
-
-func (c *fakeTableConnector) ListDatabases(context.Context) ([]string, error) {
-	return nil, nil
 }
 
 func (c *fakeTableConnector) ListTables(context.Context) ([]*interfaces.TableMeta, error) {

--- a/adp/vega/vega-backend/server/worker/discover_table.go
+++ b/adp/vega/vega-backend/server/worker/discover_table.go
@@ -245,10 +245,10 @@ func (dh *DiscoverHandler) reconcileTableResources(ctx context.Context, catalog 
 func (dh *DiscoverHandler) buildSourceIdentifier(table *interfaces.TableMeta) string {
 	identifier := table.Name
 	if table.Schema != "" {
-		identifier = fmt.Sprintf("%s.%s", table.Schema, identifier)
+		return fmt.Sprintf("%s.%s", table.Schema, identifier)
 	}
 	if table.Database != "" {
-		return fmt.Sprintf("%s.%s", table.Database, identifier)
+		identifier = fmt.Sprintf("%s.%s", table.Database, identifier)
 	}
 	return identifier
 }


### PR DESCRIPTION
# Pull Request

## What Changed

Brief description of changes:

- [x] Removed unused `ListDatabases` / `ListSchemas` methods from the table connector interface and implementations.
- [x] Updated table source identifier construction to prefer `TableMeta.Schema` as the queryable namespace.
- [x] Populated MariaDB table metadata with `Schema = TABLE_SCHEMA` alongside `Database = TABLE_SCHEMA`.
- [x] Switched MariaDB configured database validation from `SHOW DATABASES` to `information_schema.SCHEMATA`.
- [x] Removed obsolete Oracle schema-listing test and updated worker tests for source identifier behavior.

---

## Why

- Related Issue: Closes #174
- Related Feature: VEGA table discovery metadata normalization
- Background:
  PostgreSQL uses a required database connection target plus optional schemas, while MariaDB treats database and schema as equivalent. VEGA source identifiers should use the queryable namespace (`schema.table` / `database.table`) rather than mixing connection database metadata into PostgreSQL table names.

---

## How

- Key implementation points:
  - `buildSourceIdentifier` now returns `schema.table` when `TableMeta.Schema` is present, with `database.table` retained as a fallback.
  - MariaDB discovery fills both `Database` and `Schema` from `TABLE_SCHEMA`.
  - The unused schema/database listing method was removed from `TableConnector`, along with unused connector implementations.
  - MariaDB database existence validation now queries `information_schema.SCHEMATA`.
- Breaking changes (API, config, database, etc.):
  - Internal Go interface change: `TableConnector` no longer includes the unused `ListDatabases` / `ListSchemas` method.
  - No external API, database schema, or connector config format changes.

---

## Testing

- [x] Unit tests passed locally
- [ ] Integration tests passed locally
- [ ] Verified in test environment

Test notes:

```bash
go test ./logics/connectors ./logics/connectors/local/table/mariadb ./logics/connectors/local/table/postgresql ./logics/connectors/local/table/oracle ./worker
```

---

## Risk & Rollback

- Potential risks:
  - Existing PostgreSQL resources previously discovered with incorrect three-part source identifiers may need rediscovery or data cleanup because this change intentionally does not add legacy three-part compatibility.
  - Internal code that still expects `TableConnector.ListDatabases` would fail to compile; local package tests cover current in-repo callers.
- Rollback plan:
  - Revert this PR to restore the previous table connector interface and source identifier behavior.

---

## Additional Notes

- PR diff was reviewed with `gh pr diff 175`.
