### PR TITLE
fix(agent-retrieval): #114 Phase A — rerank model 可配 + 优雅降级

### DIFF
--- a/adp/context-loader/agent-retrieval/server/drivenadapters/mf_model_api_client.go
+++ b/adp/context-loader/agent-retrieval/server/drivenadapters/mf_model_api_client.go
@@ -33,6 +33,9 @@ type mfModelAPIClient struct {
 	logger     interfaces.Logger
 	baseURL    string
 	httpClient interfaces.HTTPClient
+	// defaultRerankModel 精排小模型名的部署级默认值（config.concept_search_config.rerank_model，
+	// 默认 "reranker"）。Rerank 收到空 model 时用它，避免把模型名硬编码进代码。
+	defaultRerankModel string
 }
 
 var (
@@ -46,9 +49,10 @@ func NewMFModelAPIClient() *mfModelAPIClient {
 	mfModelAPIClientOnce.Do(func() {
 		conf := config.NewConfigLoader()
 		mfModelAPIClientInst = &mfModelAPIClient{
-			logger:     conf.GetLogger(),
-			baseURL:    conf.MFModelAPI.BuildURL("/api/private/mf-model-api"),
-			httpClient: rest.NewHTTPClient(),
+			logger:             conf.GetLogger(),
+			baseURL:            conf.MFModelAPI.BuildURL("/api/private/mf-model-api"),
+			httpClient:         rest.NewHTTPClient(),
+			defaultRerankModel: conf.ConceptSearchConfig.RerankModel,
 		}
 	})
 	return mfModelAPIClientInst
@@ -124,10 +128,14 @@ func (c *mfModelAPIClient) Chat(ctx context.Context, req *interfaces.LLMChatReq)
 // DrivenRerankClient 接口实现
 // ============================================================
 
-// Rerank 对文档进行重排序；model 为空时回退默认 "reranker"
+// Rerank 对文档进行重排序。model 解析优先级：入参 model > 部署级默认
+// (config.concept_search_config.rerank_model) > 字面量 "reranker"（最后兜底）。
 func (c *mfModelAPIClient) Rerank(ctx context.Context, query string, documents []string, model string) (*interfaces.RerankResp, error) {
 	url := fmt.Sprintf("%s%s", c.baseURL, rerankURI)
 
+	if model == "" {
+		model = c.defaultRerankModel
+	}
 	if model == "" {
 		model = "reranker"
 	}

--- a/adp/context-loader/agent-retrieval/server/infra/config/config.go
+++ b/adp/context-loader/agent-retrieval/server/infra/config/config.go
@@ -150,8 +150,9 @@ type OpenSearchConfig struct {
 
 // KnConceptSearchConfig knowledge network concept search configuration
 type KnConceptSearchConfig struct {
-	ConceptRecallSize int `yaml:"concept_recall_size"` // Concept rough recall size
-	KnnKValue         int `yaml:"knn_k"`               // knn k value
+	ConceptRecallSize int    `yaml:"concept_recall_size"`             // Concept rough recall size
+	KnnKValue         int    `yaml:"knn_k"`                           // knn k value
+	RerankModel       string `yaml:"rerank_model" default:"reranker"` // 关系精排小模型名；空则回退 "reranker"。可指向工厂里实际注册的 rerank 小模型，无需改代码
 }
 
 // MFModelAPI 配置使用统一的 PrivateBaseConfig 结构

--- a/adp/context-loader/agent-retrieval/server/interfaces/drivenadapters.go
+++ b/adp/context-loader/agent-retrieval/server/interfaces/drivenadapters.go
@@ -286,6 +286,7 @@ type KnSearchReq struct {
 	RetrievalConfig any                   `json:"retrieval_config,omitempty"`
 	OnlySchema      *bool                 `json:"only_schema,omitempty"`
 	EnableRerank    *bool                 `json:"enable_rerank,omitempty"`
+	RerankModel     *string               `json:"rerank_model,omitempty"` // 精排小模型名覆盖；空走部署级默认
 	IncludeColumns  *bool                 `json:"include_columns,omitempty"`
 }
 

--- a/adp/context-loader/agent-retrieval/server/interfaces/kn_search_local.go
+++ b/adp/context-loader/agent-retrieval/server/interfaces/kn_search_local.go
@@ -23,6 +23,9 @@ type KnSearchLocalRequest struct {
 	RetrievalConfig *KnSearchRetrievalConfig `json:"retrieval_config,omitempty"`
 	OnlySchema      bool                     `json:"only_schema" default:"false"`
 	EnableRerank    bool                     `json:"enable_rerank" default:"true"`
+	// RerankModel overrides the relation fine-ranking small model; empty falls back
+	// to the deployment default (config.concept_search_config.rerank_model).
+	RerankModel string `json:"rerank_model,omitempty"`
 	// IncludeColumns adds each data property's physical column name (mapped_field)
 	// to the response for run_sql. Off by default to keep responses compact.
 	IncludeColumns bool `json:"include_columns" default:"false"`

--- a/adp/context-loader/agent-retrieval/server/interfaces/search_schema.go
+++ b/adp/context-loader/agent-retrieval/server/interfaces/search_schema.go
@@ -18,6 +18,11 @@ type SearchSchemaReq struct {
 	MaxConcepts  *int               `json:"max_concepts,omitempty" default:"10"`
 	SchemaBrief  *bool              `json:"schema_brief,omitempty" default:"false"`
 	EnableRerank *bool              `json:"enable_rerank,omitempty" default:"true"`
+	// RerankModel overrides the relation fine-ranking small model for this request.
+	// Ops/power-user escape hatch: empty falls back to the deployment default
+	// (config.concept_search_config.rerank_model). Not surfaced in the MCP tool
+	// schema — agents should not pick reranker model names.
+	RerankModel *string `json:"rerank_model,omitempty"`
 	// IncludeColumns, when true, adds each data property's physical column name
 	// (mapped_field) to the response, for writing run_sql against the resource.
 	// Off by default to keep the response compact.

--- a/adp/context-loader/agent-retrieval/server/logics/knsearch/concept_retrieval.go
+++ b/adp/context-loader/agent-retrieval/server/logics/knsearch/concept_retrieval.go
@@ -67,7 +67,7 @@ func (s *localSearchImpl) conceptRetrieval(
 	}
 
 	// 3. 关系类型排序（基于语义相关性）并取 Top-K
-	rankedRelations := s.rankRelationTypes(ctx, req.Query, networkDetail.ObjectTypes, networkDetail.RelationTypes, config.TopK, req.EnableRerank)
+	rankedRelations := s.rankRelationTypes(ctx, req.Query, networkDetail.ObjectTypes, networkDetail.RelationTypes, config.TopK, req.EnableRerank, req.RerankModel)
 	s.logger.WithContext(ctx).Debugf("[ConceptRetrieval] Ranked relations: %d -> top_k=%d", len(networkDetail.RelationTypes), len(rankedRelations))
 
 	// 4. 对象类型选择：按关系过滤 + 粗召回兜底补齐（以及无关系类型场景的排序截断）
@@ -166,7 +166,7 @@ func (s *localSearchImpl) conceptRetrievalByGroups(
 		return nil, err
 	}
 
-	rankedRelations := s.rankRelationTypes(ctx, req.Query, objects, relations, config.TopK, req.EnableRerank)
+	rankedRelations := s.rankRelationTypes(ctx, req.Query, objects, relations, config.TopK, req.EnableRerank, req.RerankModel)
 	selectedObjects := s.selectObjectTypesForConceptRetrieval(objects, rankedRelations, config.TopK)
 
 	brief := boolValue(config.SchemaBrief)
@@ -523,6 +523,7 @@ func (s *localSearchImpl) rankRelationTypes(
 	relations []*interfaces.RelationType,
 	topK int,
 	enableRerank bool,
+	rerankModel string,
 ) []*interfaces.RelationType {
 	if len(relations) == 0 {
 		return relations
@@ -562,10 +563,17 @@ func (s *localSearchImpl) rankRelationTypes(
 		documents[i] = buildRelationText(sourceName, relationName, targetName, rel.Comment)
 	}
 
-	// 调用 Rerank 服务（粗召回阶段固定用默认 reranker，不受 per-request 覆盖影响）
-	rerankResp, err := s.rerankClient.Rerank(ctx, query, documents, "")
+	// 调用 Rerank 服务；model 为空由 client 解析部署级默认（config.rerank_model → "reranker"）
+	rerankResp, err := s.rerankClient.Rerank(ctx, query, documents, rerankModel)
 	if err != nil {
-		s.logger.WithContext(ctx).Warnf("[RankRelationTypes] Rerank failed, fallback to simple match: %v", err)
+		// 优雅降级：reranker 不可用（未注册 / NameNotExist）时，不丢相关性。
+		// 优先按粗召回 BM25 _score 排序（已有的相关性信号，零额外延迟）；
+		// 仅当 _score 全为 0（如粗召回未启用）时才退到纯名称匹配。
+		s.logger.WithContext(ctx).Warnf("[RankRelationTypes] Rerank unavailable (%v); degrading to coarse-recall _score order", err)
+		if ranked, ok := rankRelationTypesByScore(relations, topK); ok {
+			return ranked
+		}
+		s.logger.WithContext(ctx).Warnf("[RankRelationTypes] coarse-recall _score all zero; falling back to simple name match")
 		return s.rankRelationTypesBySimpleMatch(query, relations, topK)
 	}
 
@@ -623,6 +631,33 @@ func buildRelationText(sourceName, relationName, targetName, relationComment str
 		parts = append(parts, strings.TrimSpace(targetName))
 	}
 	return strings.Join(parts, " ")
+}
+
+// rankRelationTypesByScore 按粗召回 BM25 _score 降序排序并取 Top-K，作为 Rerank
+// 不可用时的相关性保留降级路径。返回 ok=false 表示所有 _score 均为 0（例如未启用
+// 粗召回），此时应退到 rankRelationTypesBySimpleMatch。使用稳定排序，等分保留召回顺序。
+func rankRelationTypesByScore(relations []*interfaces.RelationType, topK int) ([]*interfaces.RelationType, bool) {
+	anyScore := false
+	for _, rel := range relations {
+		if rel != nil && rel.Score != 0 {
+			anyScore = true
+			break
+		}
+	}
+	if !anyScore {
+		return nil, false
+	}
+
+	sorted := make([]*interfaces.RelationType, len(relations))
+	copy(sorted, relations)
+	sort.SliceStable(sorted, func(i, j int) bool {
+		return sorted[i].Score > sorted[j].Score
+	})
+
+	if topK <= 0 || topK > len(sorted) {
+		topK = len(sorted)
+	}
+	return sorted[:topK], true
 }
 
 // rankRelationTypesBySimpleMatch 使用简单匹配进行排序（Rerank 失败时的回退）

--- a/adp/context-loader/agent-retrieval/server/logics/knsearch/concept_retrieval_test.go
+++ b/adp/context-loader/agent-retrieval/server/logics/knsearch/concept_retrieval_test.go
@@ -511,7 +511,7 @@ func TestRerankRelationPathsAcrossNetworks(t *testing.T) {
 	}
 
 	t.Run("PerNetworkAndTotal", func(t *testing.T) {
-		res := svc.rankRelationTypes(context.Background(), "query", objectTypes, relationTypes, 3, true)
+		res := svc.rankRelationTypes(context.Background(), "query", objectTypes, relationTypes, 3, true, "")
 		if len(res) != 3 {
 			t.Fatalf("Expected 3 relations, got %d", len(res))
 		}
@@ -524,7 +524,7 @@ func TestRerankRelationPathsAcrossNetworks(t *testing.T) {
 	})
 
 	t.Run("GlobalTotalLimit", func(t *testing.T) {
-		res := svc.rankRelationTypes(context.Background(), "query", objectTypes, relationTypes, 1, true)
+		res := svc.rankRelationTypes(context.Background(), "query", objectTypes, relationTypes, 1, true, "")
 		if len(res) != 1 {
 			t.Fatalf("Expected 1 relation, got %d", len(res))
 		}
@@ -532,6 +532,43 @@ func TestRerankRelationPathsAcrossNetworks(t *testing.T) {
 			t.Fatalf("Expected rel_b first, got %s", res[0].ID)
 		}
 	})
+}
+
+// TestRankRelationTypes_RerankUnavailable_DegradesToScore 验证 #114 Phase A：
+// reranker 不可用时降级到粗召回 _score 排序（保留相关性），而非丢相关性的名称匹配。
+func TestRankRelationTypes_RerankUnavailable_DegradesToScore(t *testing.T) {
+	svc := &localSearchImpl{
+		logger:       &mockLogger{},
+		rerankClient: &mockRerankClient{rerankError: errors.New("ModelFactory.ExternalSmallModel.Used.NameNotExist")},
+	}
+	objectTypes := []*interfaces.ObjectType{{ID: "obj_1", Name: "对象1"}, {ID: "obj_2", Name: "对象2"}}
+	// _score 无序给入：期望按 _score 降序返回（rel_b=0.9 > rel_c=0.8 > rel_a=0.3）
+	relationTypes := []*interfaces.RelationType{
+		{ID: "rel_a", Name: "关系A", Score: 0.3, SourceObjectTypeID: "obj_1", TargetObjectTypeID: "obj_2"},
+		{ID: "rel_b", Name: "关系B", Score: 0.9, SourceObjectTypeID: "obj_2", TargetObjectTypeID: "obj_1"},
+		{ID: "rel_c", Name: "关系C", Score: 0.8, SourceObjectTypeID: "obj_1", TargetObjectTypeID: "obj_2"},
+	}
+
+	res := svc.rankRelationTypes(context.Background(), "query", objectTypes, relationTypes, 2, true, "")
+	if len(res) != 2 {
+		t.Fatalf("Expected 2 relations, got %d", len(res))
+	}
+	if res[0].ID != "rel_b" || res[1].ID != "rel_c" {
+		t.Fatalf("Expected [rel_b, rel_c] by _score, got [%s, %s]", res[0].ID, res[1].ID)
+	}
+}
+
+// TestRankRelationTypesByScore_AllZero_SignalsFallback 验证 _score 全 0 时返回 ok=false，
+// 交由上层退到名称匹配。
+func TestRankRelationTypesByScore_AllZero_SignalsFallback(t *testing.T) {
+	relations := []*interfaces.RelationType{{ID: "rel_a"}, {ID: "rel_b"}}
+	if _, ok := rankRelationTypesByScore(relations, 2); ok {
+		t.Fatal("Expected ok=false when all _score are zero")
+	}
+	scored := []*interfaces.RelationType{{ID: "rel_a", Score: 0.1}}
+	if _, ok := rankRelationTypesByScore(scored, 1); !ok {
+		t.Fatal("Expected ok=true when some _score is non-zero")
+	}
 }
 
 func TestCalculateRelevanceScore(t *testing.T) {

--- a/adp/context-loader/agent-retrieval/server/logics/knsearch/convert.go
+++ b/adp/context-loader/agent-retrieval/server/logics/knsearch/convert.go
@@ -34,6 +34,9 @@ func KnSearchReqToLocal(req *interfaces.KnSearchReq) *interfaces.KnSearchLocalRe
 	if req.EnableRerank != nil {
 		local.EnableRerank = *req.EnableRerank
 	}
+	if req.RerankModel != nil {
+		local.RerankModel = *req.RerankModel
+	}
 	if req.IncludeColumns != nil {
 		local.IncludeColumns = *req.IncludeColumns
 	}

--- a/adp/context-loader/agent-retrieval/server/logics/knsearch/search_schema.go
+++ b/adp/context-loader/agent-retrieval/server/logics/knsearch/search_schema.go
@@ -104,6 +104,7 @@ func NormalizeSearchSchemaReq(req *interfaces.SearchSchemaReq) (*interfaces.KnSe
 		KnID:           knID,
 		OnlySchema:     &onlySchema,
 		EnableRerank:   req.EnableRerank,
+		RerankModel:    req.RerankModel,
 		IncludeColumns: req.IncludeColumns,
 		RetrievalConfig: &interfaces.RetrievalConfig{
 			ConceptRetrieval: &interfaces.ConceptRetrievalConfig{

--- a/docs/design/context-loader/features/114-search-schema-rerank-degradation.md
+++ b/docs/design/context-loader/features/114-search-schema-rerank-degradation.md
@@ -1,0 +1,169 @@
+---
+issue: "#114"
+branch: "fix/114-search-schema-rerank-degradation"
+module: "context-loader"
+status: "draft"
+author: "@sh00tg0a1"
+created: "2026-07-10"
+pr: ""
+---
+
+# Fix #114 (Phase A): search_schema reranker configurable + graceful degradation
+
+## Background And Goals
+
+`search_schema` on a knowledge network recalls candidate concepts (object /
+relation types) and then re-ranks them by semantic relevance. When the ranking
+stage fails, the tool returns concepts unrelated to the query (e.g. querying
+"裁判" returns the `award_winners / awards / players / teams` cluster), so
+Decision Agent cannot obtain the correct schema and loops on
+`search_schema` / `run_sql` / `describe_resource` (8+ useless retrievals for a
+single question).
+
+Issue #114 records three root causes. This document covers **Phase A only**,
+the first root cause, which is a self-contained agent-retrieval-only fix that
+removes a fragile external dependency:
+
+1. Fine-ranking calls
+   `mfModelAPIClient.Rerank(ctx, query, docs, "")` with an **always-empty**
+   model.
+2. The client hardcodes the empty model to the literal `"reranker"`
+   (`drivenadapters/mf_model_api_client.go:131`) and calls
+   `mf-model-api /v1/small-model/reranker`.
+3. The model factory frequently has **no model named `reranker`** registered
+   (only the embedding small model exists after a fresh deploy / VM wipe), so
+   mf-model-api returns `ModelFactory.ExternalSmallModel.Used.NameNotExist`
+   (400).
+4. `rankRelationTypes` catches the error and falls back to
+   `rankRelationTypesBySimpleMatch` (`concept_retrieval.go:568`), a name-only
+   match that **discards the coarse-recall relevance signal** → unrelated
+   concepts surface.
+
+Today this is worked around at the environment level by registering a
+`reranker` small model (adapter → dashscope `gte-rerank-v2`) in each target
+cluster's `t_small_model`. That keeps breaking on every fresh deploy. Phase A
+makes the ranking correct **without** depending on that registration.
+
+### Scope
+
+- **In scope (Phase A):** reranker model name configurable + per-request
+  override; relevance-preserving graceful degradation when the reranker is
+  unavailable. Agent-retrieval only. No bkn-backend / vega change.
+- **Out of scope:** object independent ranking / orphan recall
+  (`selectObjectTypesForConceptRetrieval`) → **Phase B**, tracked with #147
+  (same function). Concept-index vectors → a **separate issue** on the
+  KN-build side (bkn-backend / vega embed concepts into
+  `adp_bkn_concept_dataset`); agent-retrieval cannot populate that index.
+
+## Design
+
+### 1. Reranker model name configurable
+
+Today the reranker model name is a literal buried in the driven adapter. Move
+the default to config and allow a per-request override.
+
+- **Config default.** Add `RerankModel string` to `KnConceptSearchConfig`
+  (`infra/config/config.go`), `yaml:"rerank_model" default:"reranker"`. The
+  default preserves current behavior (`"reranker"`). Operators can point it at
+  whatever small model their factory actually has, without redeploying a new
+  binary or registering a placeholder model.
+
+- **Client stops hardcoding.** `mfModelAPIClient.Rerank` keeps
+  `if model == "" { model = "reranker" }` only as an ultimate safety net, but
+  the caller now always passes an explicit model, so the literal is no longer
+  the effective default.
+
+- **Per-request override.** `rankRelationTypes` currently receives
+  `enableRerank bool`. Extend the recall path to also carry a `rerankModel
+  string`: resolve as `perRequest ?? config.ConceptSearchConfig.RerankModel`.
+  Surface it on the request structs:
+  - `interfaces.SearchSchemaReq` → add `RerankModel *string
+    json:"rerank_model,omitempty"` (mirrors the existing
+    `rerank_llm_model` override pattern used by the LLM reranker).
+  - Thread through `KnSearchConceptRetrievalConfig` →
+    `rankRelationTypes(ctx, query, objects, relations, topK, enableRerank,
+    rerankModel)` → `Rerank(ctx, query, docs, rerankModel)`.
+
+  `rerank_model` is an **ops / power-user escape hatch**, not agent-facing
+  schema. It is exposed on the REST `/in` request body and internal config
+  only; it is **not** added to the MCP tool JSON Schema or the `.adp` toolset
+  (an LLM agent should not be choosing reranker model names). The graceful
+  degradation below is the actual reliability fix — `rerank_model` just lets an
+  operator override without a redeploy.
+
+### 2. Graceful degradation (relevance-preserving)
+
+When `Rerank` fails, do **not** re-score by name. The recalled relations and
+objects already carry a coarse-recall BM25 `_score`
+(`interfaces.RelationType.Score`, `interfaces.ObjectType.Score`), which is a
+real relevance signal. Degrade to that instead of throwing it away:
+
+```
+rerankResp, err := s.rerankClient.Rerank(ctx, query, documents, rerankModel)
+if err != nil {
+    s.logger.Warnf("[RankRelationTypes] Rerank unavailable (%v); "+
+        "degrading to coarse-recall _score order", err)
+    return rankRelationTypesByScore(relations, topK)   // sort by .Score desc, truncate
+}
+```
+
+`rankRelationTypesByScore` sorts by `rel.Score` descending and truncates to
+`topK`, using a stable sort so equal-score relations keep recall order. The
+existing name-only `rankRelationTypesBySimpleMatch` is retained **only** as a
+last resort for the degenerate case where every `_score` is zero (e.g.
+coarse-recall disabled), guarded explicitly rather than used as the default
+fallback.
+
+Rationale for BM25 `_score` over the existing `knrerank.rerankByLLM` (system
+default big model) as the primary fallback:
+
+- BM25 `_score` is already computed, zero extra latency, zero extra LLM cost,
+  and deterministic.
+- The LLM reranker adds a network round-trip and token cost on the hot
+  `search_schema` path, and itself depends on a reachable LLM. It is a heavier,
+  optional secondary — not needed to restore correctness. Left out of Phase A
+  to keep the change small and the failure mode simple.
+
+### Call sites touched
+
+- `interfaces/search_schema.go` — `SearchSchemaReq.RerankModel`.
+- `interfaces/kn_search_local.go` — carry `RerankModel` on the concept
+  retrieval config.
+- driver adapter for `/in` search_schema — map `rerank_model` into the local
+  request.
+- `logics/knsearch/concept_retrieval.go` — `rankRelationTypes` signature +
+  degradation branch; new `rankRelationTypesByScore`.
+- `drivenadapters/mf_model_api_client.go` — comment only (behavior unchanged;
+  literal now a safety net).
+- `infra/config/config.go` — `KnConceptSearchConfig.RerankModel`.
+
+## Acceptance Criteria
+
+- With **no** `reranker` model registered in the factory,
+  `POST /api/agent-retrieval/in/v1/kn/search_schema {"kn_id":"worldcup_vega_catalog_bkn","query":"球员","max_concepts":5}`
+  returns query-relevant concepts (player / match cluster), **not** the
+  `award_*` cluster. Logs show
+  `Rerank unavailable ...; degrading to coarse-recall _score order`, **not**
+  `fallback to simple match`.
+- With a `reranker` model registered, results are unchanged from today
+  (no regression).
+- `rerank_model` in the REST request body overrides the configured default and
+  reaches mf-model-api (verifiable in the mf-model-api request log).
+- `search_schema` MCP tool schema and the `.adp` toolset are unchanged
+  (`rerank_model` not surfaced to agents).
+
+## Failure Conditions (must NOT happen)
+
+- Reranker unavailable → returns concepts unrelated to the query.
+- Degradation path re-orders by name and buries the BM25-relevant concepts.
+- `rerank_model` passed but ignored (still hits `reranker`).
+- Any change under `adp/bkn` (bkn-backend) or `adp/vega`.
+
+## Out of Scope → Follow-ups
+
+- **Phase B (#147 + #114②):** `selectObjectTypesForConceptRetrieval` keeps
+  high coarse-recall-score orphan objects (relation-less but relevant tables,
+  e.g. `referees`) instead of returning only relation-endpoint objects.
+- **KN-build issue (#114③):** embed concept name+comment into
+  `adp_bkn_concept_dataset` so the KNN coarse-recall subquery is no longer a
+  no-op; or remove the misleading KNN subquery.


### PR DESCRIPTION
## 背景

`search_schema` 语义精排在 reranker 小模型未注册（新部署 / VM wipe 后常见）时，`Rerank` 返回 `ModelFactory.ExternalSmallModel.Used.NameNotExist`，被 `fallback to simple match` 捕获 → **丢失召回相关性** → 返回与查询无关的概念（查「裁判」返 `award_winners/awards/players/teams` 簇），Decision Agent 空转。

详见 #114。本 PR 只做 **Phase A**（第一个根因），**仅改 agent-retrieval，不动 bkn-backend / vega**。

## 改动

1. **reranker 模型名可配**
   - 新增 `config.concept_search_config.rerank_model`（默认 `"reranker"`，行为不变）；客户端不再把模型名硬编码为字面量。
   - 新增可选 per-request `rerank_model`，透传到 `Rerank(ctx, query, docs, model)`（REST `/in` 与内部请求）。**不**暴露到 MCP tool schema / `.adp`——agent 不应挑 reranker 模型名，这是运维逃生舱。
2. **优雅降级（保留相关性）**
   - Rerank 不可用时，按粗召回 BM25 `_score`（已有相关性信号、零额外延迟、确定性）稳定排序取 Top-K，取代丢相关性的 simple name match。
   - 仅当 `_score` 全为 0（如未启用粗召回）时，才退回名称匹配。
3. 单测覆盖降级路径（`_score` 排序）+ 全零回退信号。

## 验收

- 未注册 `reranker` 时，`search_schema {"kn_id":"worldcup_vega_catalog_bkn","query":"球员"}` 返回相关概念，日志出现 `Rerank unavailable ...; degrading to coarse-recall _score order`（不再是 `fallback to simple match`）。
- 已注册 `reranker` 时行为不变（无回归）。
- `rerank_model` 请求体覆盖生效并到达 mf-model-api。

## 不在本 PR（后续）

- **Phase B（#147 + #114②）**：`selectObjectTypesForConceptRetrieval` 保留高分孤儿对象（无关系但相关的表，如 `referees`）。
- **KN-build 侧 issue（#114③）**：概念 name+comment 向量化进 `adp_bkn_concept_dataset`，让 KNN 粗召回真正生效。

设计文档：`docs/design/context-loader/features/114-search-schema-rerank-degradation.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)