### PR TITLE
fix(vega-backend): map timestamp fields to OpenSearch date

### DIFF
--- a/adp/vega/vega-backend/server/logics/connectors/local/index/opensearch/opensearch_query.go
+++ b/adp/vega/vega-backend/server/logics/connectors/local/index/opensearch/opensearch_query.go
@@ -915,7 +915,7 @@ func (c *OpenSearchConnector) buildFieldMappings(schemaDefinition []*interfaces.
 			fieldType = "scaled_float"
 		case "string":
 			fieldType = "keyword"
-		case "datetime":
+		case "datetime", "timestamp":
 			fieldType = "date"
 		case "time":
 			fieldType = "keyword"

--- a/adp/vega/vega-backend/server/logics/connectors/local/index/opensearch/type_mapping_test.go
+++ b/adp/vega/vega-backend/server/logics/connectors/local/index/opensearch/type_mapping_test.go
@@ -112,6 +112,7 @@ func TestOpenSearchBuildFieldMappingsBasicTypes(t *testing.T) {
 	properties, hasVector, err := connector.buildFieldMappings([]*interfaces.Property{
 		{Name: "id", Type: interfaces.DataType_Integer},
 		{Name: "amount", Type: interfaces.DataType_Decimal},
+		{Name: "last_login_time", Type: interfaces.DataType_Timestamp},
 		{Name: "payload", Type: interfaces.DataType_Json},
 		{Name: "embedding", Type: interfaces.DataType_Vector},
 		{
@@ -130,6 +131,7 @@ func TestOpenSearchBuildFieldMappingsBasicTypes(t *testing.T) {
 	require.NoError(t, err)
 	assert.True(t, hasVector)
 	assert.Equal(t, map[string]any{"type": "long"}, properties["id"])
+	assert.Equal(t, map[string]any{"type": "date"}, properties["last_login_time"])
 	assert.Equal(t, map[string]any{"type": "object"}, properties["payload"])
 
 	decimal := properties["amount"].(map[string]any)


### PR DESCRIPTION
# Pull Request

## What Changed

Brief description of changes:

- [x] Map Vega `timestamp` fields to OpenSearch `date` when building field mappings
- [x] Add unit coverage for `timestamp -> date` mapping in OpenSearch local index schema generation
- [ ] Docs/doc 1

---

## Why

- Related Issue: openbkn-ai/bkn-foundry#179 (timestamp mapping / Bug 1 only)
- Related Feature: N/A
- Background:

PostgreSQL `timestamp` / `timestamptz` columns are represented as Vega `timestamp` fields. Build tasks create the OpenSearch local index from the full resource schema, so an unmapped `timestamp` field was sent directly to OpenSearch and rejected because OpenSearch does not support a `timestamp` mapping type.

---

## How

- Key implementation points:
  - Treat `timestamp` the same as `datetime` in `buildFieldMappings`, mapping it to OpenSearch `date`.
  - Extend the existing OpenSearch field mapping unit test with a `last_login_time` timestamp field.
- Breaking changes (API, config, database, etc.):
  - None.

---

## Testing

- [x] Unit tests passed locally
- [ ] Integration tests passed locally
- [ ] Verified in test environment

Test notes:

```bash
go test ./logics/connectors/local/index/opensearch
```

---

## Risk & Rollback

- Potential risks:
  - Low. This only changes OpenSearch local index mapping for Vega `timestamp` fields from an unsupported mapping type to `date`.
- Rollback plan:
  - Revert this PR to restore the previous field mapping behavior.

---

## Additional Notes

- This PR intentionally does not change PostgreSQL `source_identifier` / table qualification behavior.