### PR TITLE
fix(vega-backend): finalize orphaned stopping build tasks

### DIFF
--- a/adp/vega/vega-backend/server/worker/build_task_reconciler.go
+++ b/adp/vega/vega-backend/server/worker/build_task_reconciler.go
@@ -23,6 +23,9 @@ const (
 	// buildTaskInitStaleAfter init 停留超过该时长且队列无对应消息即判为消息丢失；
 	// 需大于创建事务提交→入队完成的间隙，避免把正常创建流程误判为卡死
 	buildTaskInitStaleAfter = 3 * time.Minute
+	// buildTaskStoppingStaleAfter stopping 停留超过该时长且队列无对应消息即判为 worker 已不在；
+	// 自动落到 stopped，避免任务永久无法删除或重跑。
+	buildTaskStoppingStaleAfter = 3 * time.Minute
 	// reconcileListPageSize Inspector 翻页大小
 	reconcileListPageSize = 100
 )
@@ -59,7 +62,9 @@ func (r *buildTaskReconciler) run() {
 
 // reconcileOnce 执行一轮对账
 func (r *buildTaskReconciler) reconcileOnce(ctx context.Context) error {
-	tasks, _, err := r.taskAccess.List(ctx, interfaces.BuildTasksQueryParams{Statuses: []string{interfaces.BuildTaskStatusInit}})
+	tasks, _, err := r.taskAccess.List(ctx, interfaces.BuildTasksQueryParams{
+		Statuses: []string{interfaces.BuildTaskStatusInit, interfaces.BuildTaskStatusStopping},
+	})
 	if err != nil {
 		return err
 	}
@@ -72,19 +77,28 @@ func (r *buildTaskReconciler) reconcileOnce(ctx context.Context) error {
 		return err
 	}
 
-	stuck := findStuckBuildTasks(tasks, queued, time.Now(), buildTaskInitStaleAfter)
-	if len(stuck) == 0 {
-		return nil
+	now := time.Now()
+	stuckInit := findStuckBuildTasks(tasks, queued, now, buildTaskInitStaleAfter)
+	if len(stuckInit) > 0 {
+		client := r.aqa.CreateClient()
+		defer func() { _ = client.Close() }()
+		for _, task := range stuckInit {
+			if err := enqueueBuildTaskMessage(client, task); err != nil {
+				logger.Errorf("Reconciler re-enqueue build task %s failed: %v", task.ID, err)
+				continue
+			}
+			logger.Infof("Reconciler re-enqueued stuck build task %s (init since %s)",
+				task.ID, time.UnixMilli(task.UpdateTime).Format(time.RFC3339))
+		}
 	}
 
-	client := r.aqa.CreateClient()
-	defer func() { _ = client.Close() }()
-	for _, task := range stuck {
-		if err := enqueueBuildTaskMessage(client, task); err != nil {
-			logger.Errorf("Reconciler re-enqueue build task %s failed: %v", task.ID, err)
+	stuckStopping := findStuckStoppingBuildTasks(tasks, queued, now, buildTaskStoppingStaleAfter)
+	for _, task := range stuckStopping {
+		if err := r.taskAccess.UpdateStatus(ctx, task.ID, map[string]interface{}{"status": interfaces.BuildTaskStatusStopped}); err != nil {
+			logger.Errorf("Reconciler finalize stopping build task %s failed: %v", task.ID, err)
 			continue
 		}
-		logger.Infof("Reconciler re-enqueued stuck build task %s (init since %s)",
+		logger.Infof("Reconciler finalized stuck stopping build task %s (stopping since %s)",
 			task.ID, time.UnixMilli(task.UpdateTime).Format(time.RFC3339))
 	}
 	return nil
@@ -96,6 +110,25 @@ func findStuckBuildTasks(tasks []*interfaces.BuildTask, queuedIDs map[string]str
 	stuck := []*interfaces.BuildTask{}
 	for _, task := range tasks {
 		if task.Status != interfaces.BuildTaskStatusInit {
+			continue
+		}
+		if now.Sub(time.UnixMilli(task.UpdateTime)) < staleAfter {
+			continue
+		}
+		if _, ok := queuedIDs[task.ID]; ok {
+			continue
+		}
+		stuck = append(stuck, task)
+	}
+	return stuck
+}
+
+// findStuckStoppingBuildTasks 返回卡死停止任务：stopping 停留超过 staleAfter 且队列中无对应消息。
+// 队列中仍存在消息（尤其 active）时不处理，避免把仍在响应停止的 worker 提前落停。
+func findStuckStoppingBuildTasks(tasks []*interfaces.BuildTask, queuedIDs map[string]struct{}, now time.Time, staleAfter time.Duration) []*interfaces.BuildTask {
+	stuck := []*interfaces.BuildTask{}
+	for _, task := range tasks {
+		if task.Status != interfaces.BuildTaskStatusStopping {
 			continue
 		}
 		if now.Sub(time.UnixMilli(task.UpdateTime)) < staleAfter {

--- a/adp/vega/vega-backend/server/worker/build_task_reconciler_test.go
+++ b/adp/vega/vega-backend/server/worker/build_task_reconciler_test.go
@@ -46,3 +46,28 @@ func TestFindStuckBuildTasks(t *testing.T) {
 		assert.Empty(t, got)
 	})
 }
+
+func TestFindStuckStoppingBuildTasks(t *testing.T) {
+	t.Run("returns stopping tasks that are stale and absent from queue", func(t *testing.T) {
+		now := time.Date(2026, 7, 10, 16, 30, 0, 0, time.UTC)
+		staleAfter := 3 * time.Minute
+		ms := func(t time.Time) int64 { return t.UnixMilli() }
+
+		mkTask := func(id, status string, updatedAgo time.Duration) *interfaces.BuildTask {
+			return &interfaces.BuildTask{ID: id, Status: status, UpdateTime: ms(now.Add(-updatedAgo))}
+		}
+
+		tasks := []*interfaces.BuildTask{
+			mkTask("orphan-stopping", interfaces.BuildTaskStatusStopping, 10*time.Minute),
+			mkTask("active-stopping", interfaces.BuildTaskStatusStopping, 10*time.Minute),
+			mkTask("fresh-stopping", interfaces.BuildTaskStatusStopping, 10*time.Second),
+			mkTask("init", interfaces.BuildTaskStatusInit, 10*time.Minute),
+		}
+		queued := map[string]struct{}{"active-stopping": {}}
+
+		stuck := findStuckStoppingBuildTasks(tasks, queued, now, staleAfter)
+
+		require.Len(t, stuck, 1)
+		assert.Equal(t, "orphan-stopping", stuck[0].ID)
+	})
+}


### PR DESCRIPTION
# Pull Request

## What Changed

Brief description of changes:

- [x] Extend the build task reconciler to scan both `init` and `stopping` tasks
- [x] Auto-finalize stale orphaned `stopping` build tasks to `stopped`
- [x] Add unit coverage for stale `stopping` detection while preserving queued/active task protection

---

## Why

- Related Issue: openbkn-ai/bkn-foundry#183
- Related Feature: N/A
- Background:

A build task can remain in `stopping` after the worker/asynq execution has already disappeared. In that state, existing APIs treat the task as active, so users cannot delete it, rerun it, or update its config.

---

## How

- Key implementation points:
  - Add a stale threshold for `stopping` build tasks.
  - Reuse the reconciler's asynq scheduled/retry/pending/active queue scan.
  - Keep the existing stale `init` re-enqueue behavior unchanged.
  - Finalize only `stopping` tasks that are stale and absent from all inspected queues.
- Breaking changes (API, config, database, etc.):
  - None.

---

## Testing

- [x] Unit tests passed locally
- [ ] Integration tests passed locally
- [ ] Verified in test environment

Test notes:

```bash
go test -count=1 ./logics/build_task ./worker
go test ./... -coverprofile=/tmp/vega-backend-coverage.out
go tool cover -func=/tmp/vega-backend-coverage.out
```

Coverage note:

- Overall `vega-backend/server`: 24.3% statements
- `vega-backend/worker`: 37.7% statements

---

## Risk & Rollback

- Potential risks:
  - Low to medium. The reconciler now mutates stale `stopping` tasks, but only after the stale threshold and only when no matching asynq scheduled/retry/pending/active task is found.
- Rollback plan:
  - Revert this PR to restore the reconciler to only re-enqueueing stale `init` tasks.

---

## Additional Notes

- This PR does not relax delete/start/update validation for genuinely active `running` or `stopping` tasks.