### PR TITLE
feat(deploy): install-status 快照集群内自动刷新（jq 合并 + try_files 降级）

### DIFF
--- a/deploy/conf/install-status/endpoint.yaml
+++ b/deploy/conf/install-status/endpoint.yaml
@@ -13,9 +13,13 @@
 #   - /install-status.workloads.json raw `kubectl get deploy,sts -o json` — the
 #     dashboard overlays per-release readiness and service health from it, so
 #     the whole page tracks reality without re-running publish-status.
+#   - /install-status.live.json      publish-time snapshot merged with actual
+#     image tags + readiness (merge.jq); nginx serves it as /install-status.json
+#     via try_files, falling back to the static snapshot when the refresher is
+#     down — the page's stale-snapshot banner then doubles as the outage alert.
 # It needs a ServiceAccount with a minimal Role (pods/deployments/statefulsets
-# read only — NO secrets, NO helm). The rich version/drift/dep snapshot
-# (install-status.json) stays as the externally-collected, publish-time data.
+# read only — NO secrets, NO helm). The expected release list still comes from
+# the publish-time snapshot, mounted read-only from the data ConfigMap.
 #
 # Placeholders __NAMESPACE__ / __INGRESS_CLASS__ / __KUBECTL_IMAGE__ are
 # substituted by status.sh.
@@ -89,6 +93,14 @@ spec:
                   && mv /live/pods.json.tmp /live/pods.json
                 kubectl get deploy,sts -n "__NAMESPACE__" -o json > /live/workloads.json.tmp 2>>/live/err.log \
                   && mv /live/workloads.json.tmp /live/workloads.json
+                # live-merge the publish-time snapshot with actual image tags;
+                # any failure keeps the previous live file (nginx falls back)
+                jq -n --arg now "$(date -u +%FT%TZ)" \
+                    --slurpfile snap /data/install-status.json \
+                    --slurpfile work /live/workloads.json \
+                    -f /scripts/merge.jq > /live/install-status.live.json.tmp 2>>/live/err.log \
+                  && mv /live/install-status.live.json.tmp /live/install-status.live.json \
+                  || rm -f /live/install-status.live.json.tmp
                 sleep "${INTERVAL:-60}"
               done
           env:
@@ -104,6 +116,12 @@ spec:
           volumeMounts:
             - name: live
               mountPath: /live
+            - name: data
+              mountPath: /data
+              readOnly: true
+            - name: scripts
+              mountPath: /scripts
+              readOnly: true
         - name: nginx
           image: swr.cn-east-3.myhuaweicloud.com/openbkn-ai/library/nginx:1.27-alpine
           ports:
@@ -143,6 +161,13 @@ spec:
             items:
               - key: index.html
                 path: index.html
+        - name: scripts
+          configMap:
+            name: install-status-nginx
+            items:
+              - key: merge.jq
+                path: merge.jq
+            optional: true
         - name: data
           configMap:
             name: install-status-data

--- a/deploy/conf/install-status/index.html
+++ b/deploy/conf/install-status/index.html
@@ -116,7 +116,10 @@
         tr.setAttribute("data-rel", r.name);
         tr.appendChild(el("td", null, r.name));
         tr.appendChild(el("td", "v", r.chartVersion));
-        tr.appendChild(el("td", "v", r.appVersion));
+        var av = el("td", "v", r.appVersion);
+        // in-cluster merge overlays the actual running image tag
+        if (r.versionSource === "live") av.appendChild(el("span", "src", "live"));
+        tr.appendChild(av);
         var st = el("td");
         var stCls = r.status === "deployed" ? "b-ok" : (r.status === "skipped" ? "b-mut" : "b-bad");
         var sb = el("span", "badge " + stCls, r.status);
@@ -209,8 +212,10 @@
             (d.ingressClass ? "  ·  ingressClass " + d.ingressClass : "") + authTxt;
           // generatedAt is UTC ISO ("...Z") — render in the viewer's timezone.
           var genTs = Date.parse(d.generatedAt || "");
-          document.getElementById("genAt").textContent =
-            genTs ? new Date(genTs).toLocaleString() : (d.generatedAt || "—");
+          var genTxt = genTs ? new Date(genTs).toLocaleString() : (d.generatedAt || "—");
+          // liveMergedAt marks the in-cluster auto-refreshed variant (merge.py)
+          if (d.liveMergedAt) genTxt += " · auto (in-cluster)";
+          document.getElementById("genAt").textContent = genTxt;
           var rel = renderReleases(d.releases || []);
           renderHealth(d.serviceHealth);
           renderDeps(d.depServices);

--- a/deploy/conf/install-status/merge.jq
+++ b/deploy/conf/install-status/merge.jq
@@ -1,0 +1,48 @@
+# In-cluster live merge for the install-status snapshot (runs in the refresher
+# via jq — the kubectl-shell image ships jq but no python).
+#
+# Inputs (via --slurpfile):
+#   $snap — publish-time snapshot /data/install-status.json (expected releases)
+#   $work — refresher dump /live/workloads.json (actual deploy/sts state)
+# Arg:
+#   $now  — UTC ISO timestamp
+#
+# Output: the snapshot with per-release appVersion overlaid from the actual
+# running image tags (versionSource=live), readiness refreshed, and
+# generatedAt/liveMergedAt set to $now. Any error aborts jq; the wrapper keeps
+# the previous live file, so failures degrade to pre-existing behaviour.
+
+($snap[0]) as $s
+| ($work[0]) as $w
+| (reduce ($w.items // [])[] as $it ({};
+    ($it.metadata // {}) as $md
+    | ((($md.annotations // {})["meta.helm.sh/release-name"])
+        // (($md.labels // {})["app.kubernetes.io/instance"])
+        // $md.name) as $rel
+    | if $rel == null then .
+      else
+        (.[$rel] // {tags: [], ready: 0, total: 0}) as $e
+        | ([($it.spec.template.spec.containers // [])[]
+            | .image
+            | split("/") | last
+            | if contains(":") then (split(":") | last) else "latest" end
+           ]) as $tags
+        | .[$rel] = {
+            tags:  (($e.tags + $tags) | unique),
+            ready: ($e.ready + ($it.status.readyReplicas // 0)),
+            total: ($e.total + ($it.spec.replicas // 1))
+          }
+      end)) as $actual
+| $s
+| .releases |= ((. // []) | map(
+    . as $r
+    | ($actual[$r.name] // null) as $m
+    | if $m == null then .
+      else
+        . + {ready: "\($m.ready)/\($m.total)"}
+          + (if ($m.tags | length) > 0
+             then {appVersion: ($m.tags | join(",")), versionSource: "live"}
+             else {} end)
+      end))
+| .generatedAt = $now
+| .liveMergedAt = $now

--- a/deploy/conf/install-status/nginx.conf
+++ b/deploy/conf/install-status/nginx.conf
@@ -11,11 +11,16 @@ server {
   }
 
   # Raw non-sensitive JSON snapshot (the dashboard fetches this).
+  # Prefer the in-cluster live merge (refresher's merge.py: real image tags,
+  # fresh generatedAt); fall back to the publish-time static snapshot when the
+  # refresher is down — its stale generatedAt then trips the dashboard banner,
+  # which doubles as the refresher-outage alert.
   location = /install-status.json {
     default_type application/json;
     charset utf-8;
     add_header Cache-Control "no-store";
-    alias /data/install-status.json;
+    root /;
+    try_files /live/install-status.live.json /data/install-status.json =404;
   }
 
   # Live snapshots, regenerated in-cluster by the refresher sidecar every

--- a/deploy/scripts/services/status.sh
+++ b/deploy/scripts/services/status.sh
@@ -20,6 +20,7 @@ INSTALL_STATUS_DIR="${SCRIPT_DIR}/conf/install-status"
 INSTALL_STATUS_ENDPOINT_TPL="${INSTALL_STATUS_DIR}/endpoint.yaml"
 INSTALL_STATUS_NGINX_CONF="${INSTALL_STATUS_DIR}/nginx.conf"
 INSTALL_STATUS_INDEX_HTML="${INSTALL_STATUS_DIR}/index.html"
+INSTALL_STATUS_MERGE_JQ="${INSTALL_STATUS_DIR}/merge.jq"
 
 # Image for the install-status refresher sidecar (live pod-health snapshot).
 # MUST contain a /bin/sh and kubectl — distroless kubectl images (rancher/kubectl)
@@ -77,12 +78,18 @@ _status_apply_endpoint() {
         return 0
     fi
 
-    # nginx conf + dashboard HTML ConfigMap (built from real files, not inlined
-    # YAML — keeps them un-escaped and editable). Idempotent.
+    # nginx conf + dashboard HTML + in-cluster merge script ConfigMap (built
+    # from real files, not inlined YAML — keeps them un-escaped and editable).
+    # Idempotent.
     if [[ -f "${INSTALL_STATUS_NGINX_CONF}" && -f "${INSTALL_STATUS_INDEX_HTML}" ]]; then
+        local -a cm_files=(
+            --from-file=nginx.conf="${INSTALL_STATUS_NGINX_CONF}"
+            --from-file=index.html="${INSTALL_STATUS_INDEX_HTML}"
+        )
+        [[ -f "${INSTALL_STATUS_MERGE_JQ}" ]] \
+            && cm_files+=(--from-file=merge.jq="${INSTALL_STATUS_MERGE_JQ}")
         kubectl create configmap install-status-nginx \
-            --from-file=nginx.conf="${INSTALL_STATUS_NGINX_CONF}" \
-            --from-file=index.html="${INSTALL_STATUS_INDEX_HTML}" \
+            "${cm_files[@]}" \
             -n "${namespace}" \
             --dry-run=client -o yaml 2>/dev/null \
             | kubectl apply -f - >/dev/null 2>&1 \
@@ -90,6 +97,13 @@ _status_apply_endpoint() {
     else
         log_warn "install-status nginx.conf / index.html missing under ${INSTALL_STATUS_DIR}."
     fi
+
+    # Drop the legacy standalone refresher stack (early live-overlay iteration,
+    # superseded by the refresher sidecar in this Deployment). Idempotent.
+    kubectl delete deployment/install-status-rt service/install-status-rt \
+        serviceaccount/install-status-rt role/install-status-rt \
+        rolebinding/install-status-rt \
+        -n "${namespace}" --ignore-not-found >/dev/null 2>&1 || true
 
     local ingress_class
     ingress_class="$(_status_detect_ingress_class)"

--- a/docs/design/deploy/features/204-install-status-auto-snapshot.md
+++ b/docs/design/deploy/features/204-install-status-auto-snapshot.md
@@ -1,0 +1,44 @@
+# install-status 快照集群内自动刷新
+
+- Issue: [#204](https://github.com/openbkn-ai/bkn-foundry/issues/204)
+- 分支: `feature/204-install-status-auto-snapshot`
+- 涉及: `deploy/conf/install-status/`、`deploy/scripts/services/status.sh`
+
+## 1. 背景
+
+install-status 页面数据分两层：Ready/健康由 pod 内 refresher 容器实时刷新；版本/组件清单/依赖端点是 `publish-status` 时落进 configmap 的静态快照，超 24h 页面弹横幅要求手动重跑。快照里唯一真正会"过期"的是**版本号**——而 refresher dump 的 `workloads.json` 里每个 Deployment 的镜像 tag 就是真实运行版本，数据已在手边，只差合并。
+
+## 2. 方案
+
+refresher 循环内新增一步。实现语言选 **jq**（1.7.1）——refresher 实际镜像
+portainer/kubectl-shell **没有 python**，只有 jq/busybox（早期误判 python 可用，
+是探到了已删除的 install-status-rt 容器；VM 实测修正）：
+
+```
+kubectl get pods      → /live/pods.json          （不变）
+kubectl get deploy,sts → /live/workloads.json     （不变）
+jq -f /scripts/merge.jq：
+    /data/install-status.json   （期望清单，configmap 卷挂载，零 RBAC）
+  + /live/workloads.json        （实际状态）
+  → 版本列 = 镜像 tag（versionSource=live）、ready 同步、generatedAt=now
+  → 原子写 /live/install-status.live.json（失败即弃 tmp，保留上一版）
+```
+
+nginx 的 `/install-status.json` 改 `try_files`：优先 live 版，refresher 挂掉自动退回静态快照——退回后 generatedAt 变旧、原横幅弹出，**横幅语义自动转为 refresher 失联告警**，逻辑零改动。
+
+`_status_apply_endpoint` 同时：把 merge.py 加入 install-status-nginx configmap；清理历史遗留的 `install-status-rt` 全套资源（早期实时化迭代产物，与本体重复，`--ignore-not-found` 幂等删除）。
+
+## 3. 边界与不做的事
+
+- **零新增 RBAC**：期望清单走 configmap 卷挂载（pod 声明，不经 API）；实际版本用现有 deploy/sts 读权限。不读 helm release secrets（全 ns secrets 读权限爆炸半径不可接受，见 issue 评论）。
+- merge.py 任何异常 exit 0,不影响既有 pods/workloads 两个文件；上一版 live 文件保留。
+- 期望清单（该装哪些组件）仍只在 publish 时更新——它只随 deploy.sh 升级变化，而升级流程本来就会重新 publish，闭环。
+- 安装主机 cron 方案不采用、不产品化；VM 上的临时 cron 在本方案部署后删除。
+
+## 4. 验收
+
+1. 不跑 publish-status，`/install-status.json` 的 generatedAt 每分钟自动前进，横幅不出现。
+2. 版本列显示真实镜像 tag（含 `kubectl set image` 热修后的值），带 live 标。
+3. 杀掉 refresher 容器 → 降级为静态快照，横幅恢复出现（失联告警语义）。
+4. publish 后集群内不存在任何 install-status-rt 资源。
+5. VM + 139.75 两台实测。


### PR DESCRIPTION
Closes #204

## 改动

install-status 的版本/依赖快照改为**集群内自动刷新**，`snapshot is N day(s) old` 横幅与手动 `publish-status` 依赖消除。

- **merge.jq（新增）**：refresher 每轮（60s）把 publish 时的期望快照（`/data/install-status.json`，configmap 卷挂载）与实际集群状态（`/live/workloads.json`）合并——版本列 = 运行中容器镜像 tag（`versionSource=live`，`kubectl set image` 热修也如实反映）、readiness 同步、`generatedAt`/`liveMergedAt` 刷新——原子写 `/live/install-status.live.json`。任何失败弃 tmp 保留上一版。
- **nginx try_files**：`/install-status.json` 优先 live 版，refresher 失联自动退回静态快照；退回后 generatedAt 变旧、原横幅弹出——**横幅语义自动转为 refresher 失联告警**，页面逻辑零改动。
- **endpoint.yaml**：refresher 增加 merge 步骤 + `/data`（configmap，只读）与 `/scripts`（merge.jq）挂载。**零新增 RBAC**——期望清单走卷挂载不经 API；不读 helm secrets（全 ns secrets 权限爆炸半径不可接受，见 issue 评论）。
- **status.sh**：install-status-nginx configmap 增加 merge.jq。
- **index.html**：版本列加 `live` 小标；生成时间标注 `auto (in-cluster)`。
- 实现语言为 **jq 1.7.1**：refresher 镜像 portainer/kubectl-shell 无 python。

## 测试

- merge.jq 夹具单测通过：镜像 tag 解析（含带端口 registry）、多容器/多工作负载聚合、缺失 release 保持原值、readiness 聚合、时间戳刷新。
- endpoint.yaml 占位符替换后 YAML 校验通过（6 docs）；status.sh `bash -n` 通过。
- 功能验证：generatedAt 每 60s 自动前进、版本列带 live 镜像 tag；删除 live 文件 → 立即回退静态快照 → 下一轮自愈。

## 设计文档

`docs/design/deploy/features/204-install-status-auto-snapshot.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
