### PR TITLE
docs(rules): WORKFLOW 增加 Validating 状态（合并后环境验证）

### DIFF
--- a/rules/WORKFLOW.md
+++ b/rules/WORKFLOW.md
@@ -78,9 +78,9 @@ Every service / module has an Owner in [`.github/CODEOWNERS`](../.github/CODEOWN
 ### Issue Lifecycle
 
 ```text
-Open → Triaged → In Progress → In Review → Done
-         │                                    │
-         └─────────── Closed (Won't Fix) ─────┘
+Open → Triaged → In Progress → In Review → Validating → Done
+         │                                                │
+         └────────────── Closed (Won't Fix) ────────────┘
 ```
 
 | State | Action |
@@ -89,8 +89,11 @@ Open → Triaged → In Progress → In Review → Done
 | `Triaged` | Priority, Assignee, and Milestone assigned |
 | `In Progress` | Branch and design doc created; development started (**update tracking comment in Issue**, see next section) |
 | `In Review` | PR submitted; awaiting Code Review |
-| `Done` | PR merged; Issue closed automatically or manually |
+| `Validating` | PR merged; being validated in the target environment. Tasks with no environment-validation step skip this column |
+| `Done` | Validation passed (or PR merged, for tasks with no validation step); Issue closed automatically or manually |
 | `Closed (Won't Fix)` | Decided not to implement; reason stated in a comment |
+
+> **Validating vs. auto-close**: A PR whose body contains `Closes #` auto-closes the Issue on merge; if the board has the "Issue closed → Done" automation enabled, the item moves straight to Done. For tasks that need environment validation, drag the item back to `Validating` after merge and move it to `Done` once validation passes; if validation fails, reopen the Issue and move it back to `In Progress`.
 
 ### Issue Triage Rules
 
@@ -257,7 +260,7 @@ After starting development, post one tracking comment in the Issue. Update this 
 | **ETA** | YYYY-MM-DD |
 ```
 
-> **Note**: After the PR is merged, update this comment's Status to `Done` and add the PR link.
+> **Note**: After the PR is merged, update this comment's Status to `Done` (for tasks requiring environment validation, set it to `Validating` first, then `Done` once validation passes) and add the PR link.
 
 ---
 
@@ -507,7 +510,7 @@ Reviewers must confirm:
 After the PR is merged, the merger or Assignee must:
 
 1. Update the design doc's `status` to `implemented`
-2. Update the Issue tracking comment: set Status to `Done` and add the PR link
+2. Update the Issue tracking comment: set Status to `Done` (for tasks requiring environment validation, `Validating` first, then `Done` once validation passes) and add the PR link
 
 ---
 

--- a/rules/WORKFLOW.zh.md
+++ b/rules/WORKFLOW.zh.md
@@ -78,9 +78,9 @@
 ### Issue 生命周期
 
 ```text
-Open → Triaged → In Progress → In Review → Done
-         │                                    │
-         └─────────── Closed (Won't Fix) ─────┘
+Open → Triaged → In Progress → In Review → Validating → Done
+         │                                                │
+         └────────────── Closed (Won't Fix) ────────────┘
 ```
 
 | 状态 | 操作说明 |
@@ -89,8 +89,11 @@ Open → Triaged → In Progress → In Review → Done
 | `Triaged` | 已评估优先级、已分配 Assignee 和 Milestone |
 | `In Progress` | 已创建分支和设计文档，正在开发（**需在 Issue 中更新追踪信息**，见下节） |
 | `In Review` | PR 已提交，待 Code Review |
-| `Done` | PR 已合并，Issue 自动或手动关闭 |
+| `Validating` | PR 已合并，部署到目标环境验证中；无需环境验证的任务跳过此列 |
+| `Done` | 验证通过（或无需验证的任务 PR 已合并），Issue 自动或手动关闭 |
 | `Closed (Won't Fix)` | 决定不做，评论中说明原因 |
+
+> **Validating 与自动关闭的交互**：PR 描述带 `Closes #`，合并即自动关闭 Issue；若看板启用「Issue closed → Done」自动流转，任务会直接进 Done。需环境验证的任务在合并后手动拖回 `Validating`，验证通过再拖 `Done`；验证不通过则 reopen Issue 并拖回 `In Progress`。
 
 ### Issue 分配规范
 
@@ -257,7 +260,7 @@ git checkout -b feature/456-batch-import-nodes
 | **预计完成** | YYYY-MM-DD |
 ```
 
-> **说明**：PR 合并后将此评论的状态更新为 `Done`，并补充 PR 链接。
+> **说明**：PR 合并后将此评论的状态更新为 `Done`（需环境验证的任务先 `Validating`，验证通过再 `Done`），并补充 PR 链接。
 
 ---
 
@@ -507,7 +510,7 @@ Reviewer 在 Code Review 时需确认：
 PR 合并后由合并者或 Assignee 完成：
 
 1. 将设计文档的 `status` 更新为 `implemented`
-2. 更新 Issue 追踪评论，将状态改为 `Done` 并补充 PR 链接
+2. 更新 Issue 追踪评论，将状态改为 `Done`（需环境验证的任务先 `Validating`，验证通过再 `Done`）并补充 PR 链接
 
 ---
 


### PR DESCRIPTION
## 背景

GitHub Project「OpenBKN 0.1.0」Status 字段已新增 **Validating**（In review 与 Done 之间）：PR 合并后部署到目标环境（VM / 139.75）验证的环节。此前该阶段无状态可挂，任务只能滞留 In review 或提前进 Done。

## 变更

- 中英文 WORKFLOW 的 Issue 生命周期图加入 Validating
- 状态表补 Validating 行（语义：PR 已合并、目标环境验证中；无验证环节的任务跳过）
- 新增说明：与 `Closes #` 自动关 Issue →看板自动进 Done 的交互及操作建议（拖回 Validating / 验证失败 reopen）
- 追踪评论模板与「合并后操作」同步（先 Validating 再 Done）

仅文档改动，无代码。

🤖 Generated with [Claude Code](https://claude.com/claude-code)