### PR TITLE
feat(bkn-safe): License 服务器——集成 licverify,持证/激活/续期/向内分发

### DIFF
--- a/bkn-safe/dev/license-e2e.sh
+++ b/bkn-safe/dev/license-e2e.sh
@@ -1,0 +1,126 @@
+#!/usr/bin/env bash
+# license-e2e.sh — end-to-end test of the bkn-safe license hub against a REAL
+# license-server, started locally from source (never a shared issuer).
+#
+# Flow: build issuer → keygen → two reviewer accounts → serve (email
+# verification off, loopback only) → register a customer → survey → apply
+# community (auto-issued) + professional (dual approval) → hand the unbound
+# .lic files to `go test -tags e2e`, which drives internal/license.Service
+# through true activation, first-wins conflicts, copied-cert rejection and
+# renewal binding checks.
+#
+# Usage:
+#   dev/license-e2e.sh                 # LS_SRC defaults to ../../license-server (sibling checkout)
+#   LS_SRC=/path/to/license-server dev/license-e2e.sh
+set -euo pipefail
+
+HERE="$(cd "$(dirname "$0")" && pwd)"
+SERVER_DIR="$HERE/../server"
+LS_SRC="${LS_SRC:-$(cd "$HERE/../.." && pwd)/../license-server}"
+# Worktree checkouts nest the repo under .claude/worktrees/...; fall back to
+# the conventional sibling of the main checkout.
+if [[ ! -d "$LS_SRC/server" ]]; then
+  LS_SRC="$HOME/Work/openbkn/license-server"
+fi
+if [[ ! -d "$LS_SRC/server" ]]; then
+  echo "license-server source not found — set LS_SRC=/path/to/license-server" >&2
+  exit 1
+fi
+
+PORT="${PORT:-18341}"
+ISSUER="http://127.0.0.1:$PORT"
+WORK="$(mktemp -d "${TMPDIR:-/tmp}/license-e2e.XXXXXX")"
+CJ_CUST="$WORK/cookies-customer.txt"
+CJ_REV1="$WORK/cookies-rev1.txt"
+CJ_REV2="$WORK/cookies-rev2.txt"
+SERVER_PID=""
+cleanup() {
+  [[ -n "$SERVER_PID" ]] && kill "$SERVER_PID" 2>/dev/null || true
+  rm -rf "$WORK"
+}
+trap cleanup EXIT
+
+say() { printf '\n== %s\n' "$*"; }
+
+# jq is required for response plumbing.
+command -v jq >/dev/null || { echo "jq is required" >&2; exit 1; }
+
+say "build license-server from $LS_SRC"
+(cd "$LS_SRC/server" && go build -o "$WORK/license-server" .)
+
+say "keygen + reviewer accounts"
+(cd "$WORK" && ./license-server keygen -dir ./keys -kid e2e-01)
+(cd "$WORK" && LS_NEW_PASSWORD='E2e-pass-1!' ./license-server useradd -email rev1@e2e.local -system-admin -reviewer)
+(cd "$WORK" && LS_NEW_PASSWORD='E2e-pass-2!' ./license-server useradd -email rev2@e2e.local -reviewer)
+
+say "serve on $ISSUER (email verification OFF, loopback only)"
+# exec so $SERVER_PID is the server itself, not a wrapper subshell — otherwise
+# the trap kills the wrapper and a stale issuer keeps squatting on the port.
+(cd "$WORK" && exec env LS_ADDR="127.0.0.1:$PORT" LS_DB="$WORK/data/license.db" LS_KEYS_DIR="$WORK/keys" \
+  LS_REQUIRE_EMAIL_VERIFICATION=0 ./license-server serve >"$WORK/server.log" 2>&1) &
+SERVER_PID=$!
+for _ in $(seq 1 50); do
+  curl -sf "$ISSUER/api/healthz" >/dev/null && break
+  sleep 0.2
+done
+curl -sf "$ISSUER/api/healthz" >/dev/null || { echo "issuer did not come up"; tail -20 "$WORK/server.log"; exit 1; }
+
+api() { # api <curl-args...> — fails the script on HTTP >= 400
+  local out
+  out="$(curl -sS -w '\n%{http_code}' "$@")"
+  local code="${out##*$'\n'}"
+  local body="${out%$'\n'*}"
+  if [[ "$code" -ge 400 ]]; then
+    echo "HTTP $code: $body" >&2
+    return 1
+  fi
+  printf '%s' "$body"
+}
+
+say "register + login customer"
+api -X POST "$ISSUER/api/register" -H 'Content-Type: application/json' \
+  -d '{"email":"customer@e2e.local","password":"E2e-pass-c!","name":"e2e customer","company":"e2e"}' >/dev/null
+api -c "$CJ_CUST" -X POST "$ISSUER/api/auth/login" -H 'Content-Type: application/json' \
+  -d '{"email":"customer@e2e.local","password":"E2e-pass-c!"}' >/dev/null
+
+say "survey (application gate)"
+api -b "$CJ_CUST" -X PUT "$ISSUER/api/portal/survey" -H 'Content-Type: application/json' -d '{
+  "answers": {
+    "role": "企事业单位技术人员",
+    "phone": "13800000000",
+    "llms": ["Claude"],
+    "scenarios": ["企业知识助手"],
+    "usage_plan": "技术研究和学习",
+    "project_stage": "有，正在规划",
+    "agent_platforms": ["LangChain"],
+    "data_platforms": ["数据仓库 / 湖仓"]
+  }
+}' >/dev/null
+
+say "apply community (auto-issued)"
+COMMUNITY_JSON="$(api -b "$CJ_CUST" -X POST "$ISSUER/api/portal/requests" -H 'Content-Type: application/json' \
+  -d '{"edition":"community","project":"e2e-community"}')"
+echo "$COMMUNITY_JSON" | jq -er '.license.license' >"$WORK/community.lic"
+
+say "apply professional (dual review)"
+REQ_ID="$(api -b "$CJ_CUST" -X POST "$ISSUER/api/portal/requests" -H 'Content-Type: application/json' \
+  -d '{"edition":"professional","project":"e2e-pro"}' | jq -er '.id')"
+
+api -c "$CJ_REV1" -X POST "$ISSUER/api/auth/login" -H 'Content-Type: application/json' \
+  -d '{"email":"rev1@e2e.local","password":"E2e-pass-1!"}' >/dev/null
+api -c "$CJ_REV2" -X POST "$ISSUER/api/auth/login" -H 'Content-Type: application/json' \
+  -d '{"email":"rev2@e2e.local","password":"E2e-pass-2!"}' >/dev/null
+api -b "$CJ_REV1" -X POST "$ISSUER/api/admin/requests/$REQ_ID/approve" >/dev/null
+api -b "$CJ_REV2" -X POST "$ISSUER/api/admin/requests/$REQ_ID/approve" >/dev/null
+
+api -b "$CJ_CUST" "$ISSUER/api/portal/licenses" \
+  | jq -er '[.licenses[] | select(.edition=="professional")][0].text' >"$WORK/pro.lic"
+
+say "run go test -tags e2e"
+(cd "$SERVER_DIR" && \
+  LICENSE_E2E_ISSUER="$ISSUER" \
+  LICENSE_E2E_COMMUNITY="$WORK/community.lic" \
+  LICENSE_E2E_PRO="$WORK/pro.lic" \
+  go test -tags e2e -count=1 -v ./internal/license/ -run 'TestE2E')
+
+say "e2e OK"

--- a/bkn-safe/server/config/config.go
+++ b/bkn-safe/server/config/config.go
@@ -14,9 +14,30 @@ type Config struct {
 	DB       DBConfig
 	Hydra    HydraConfig
 	LDAP     LDAPConfig
+	License  LicenseConfig `yaml:"license"`
 	// SeedOnStart controls whether roles/resource-types/operations/grants are
 	// seeded into the DB at startup (idempotent). Default true.
 	SeedOnStart bool `yaml:"seed_on_start"`
+}
+
+// LicenseConfig points bkn-safe at the license-server (activation + renewal).
+// bkn-safe is the cluster's ONLY egress to the issuer; modules pull the license
+// from bkn-safe and verify locally. The verification public keys are NOT here
+// on purpose — they are compiled in (licverify/keys), a configurable key would
+// be a self-signing hole.
+type LicenseConfig struct {
+	// ServerURL is the issuer base URL (e.g. https://license.openbkn.ai).
+	// Empty = pure offline deployment: never calls out, activation runs via
+	// request-code/receipt instead.
+	ServerURL string `yaml:"server_url"`
+	// CAFile adds a PEM CA to the trust pool for ServerURL (the issuer
+	// currently serves a self-signed certificate on a bare IP).
+	CAFile string `yaml:"ca_file"`
+	// InsecureSkipVerify disables TLS verification towards ServerURL (logged
+	// loudly). Safe-ish only because licenses are Ed25519-signed — a hijacked
+	// transport can at worst deny renewal, not forge a license. Remove once the
+	// issuer has a real domain + certificate.
+	InsecureSkipVerify bool `yaml:"insecure_skip_verify"`
 }
 
 // DBConfig points bkn-safe at its database. The openbkn-rds driver fakes

--- a/bkn-safe/server/config/load.go
+++ b/bkn-safe/server/config/load.go
@@ -97,6 +97,15 @@ func applyEnv(cfg *Config) {
 	if v := os.Getenv("SAFE_LDAP_USER_FILTER"); v != "" {
 		cfg.LDAP.UserFilter = v
 	}
+	if v := os.Getenv("SAFE_LICENSE_SERVER_URL"); v != "" {
+		cfg.License.ServerURL = v
+	}
+	if v := os.Getenv("SAFE_LICENSE_CA_FILE"); v != "" {
+		cfg.License.CAFile = v
+	}
+	if v, ok := envBool("SAFE_LICENSE_INSECURE_SKIP_VERIFY"); ok {
+		cfg.License.InsecureSkipVerify = v
+	}
 }
 
 func envInt(k string) (int, bool) {

--- a/bkn-safe/server/go.mod
+++ b/bkn-safe/server/go.mod
@@ -61,6 +61,7 @@ require (
 	github.com/microsoft/go-mssqldb v1.6.0 // indirect
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.2 // indirect
+	github.com/openbkn-ai/licverify v0.2.0 // indirect
 	github.com/pelletier/go-toml/v2 v2.2.4 // indirect
 	github.com/quic-go/qpack v0.6.0 // indirect
 	github.com/quic-go/quic-go v0.59.0 // indirect

--- a/bkn-safe/server/go.sum
+++ b/bkn-safe/server/go.sum
@@ -165,6 +165,8 @@ github.com/modocache/gover v0.0.0-20171022184752-b58185e213c5/go.mod h1:caMODM3P
 github.com/montanaflynn/stats v0.7.0/go.mod h1:etXPPgVO6n31NxCd9KQUMvCM+ve0ruNzt6R8Bnaayow=
 github.com/openbkn-ai/bkn-comm-go v0.0.4 h1:oYmrMuayyTrDn3fZ+La7PXTuJV4wjHcKr5HTVVolBOo=
 github.com/openbkn-ai/bkn-comm-go v0.0.4/go.mod h1:pyx5ux3IT4zZrUoqni6DVzLaFe1fY8dwAl6wL8PAf7I=
+github.com/openbkn-ai/licverify v0.2.0 h1:pUFRK5kpbVyeH3dMaqVlh19cCAHVq65NOy9Jrl/5e+Y=
+github.com/openbkn-ai/licverify v0.2.0/go.mod h1:9Cnmt/tl7JN48+EjsGCjQERs1mNjuaBHdM+oVx0gvS4=
 github.com/ory/hydra-client-go/v2 v2.2.0 h1:g8hw0YQD5Us1aAgZj7OyBmBGSDwlnY9/2Pb/pQQq8YE=
 github.com/ory/hydra-client-go/v2 v2.2.0/go.mod h1:h0DSI2kQA3S2fN7HyD8DNWcvbgDmYRSxfhwu/mSBhH8=
 github.com/pelletier/go-toml/v2 v2.2.4 h1:mye9XuhQ6gvn5h28+VilKrrPoQVanw5PMw/TB0t5Ec4=

--- a/bkn-safe/server/internal/httpapi/license.go
+++ b/bkn-safe/server/internal/httpapi/license.go
@@ -1,0 +1,244 @@
+// Copyright openbkn.ai
+//
+// Licensed under the OpenBKN License. See LICENSE-OPENBKN.txt in the project root.
+
+package httpapi
+
+import (
+	"errors"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/openbkn-ai/licverify"
+
+	"bkn-safe/internal/auth"
+	"bkn-safe/internal/license"
+)
+
+// registerLicenseAdmin mounts the license management surface on the admin
+// group (RequireAdmin + audit middleware are inherited from the group).
+// bkn-safe is the cluster's license hub — import/activation/removal happen
+// here and nowhere else; modules only ever read.
+func registerLicenseAdmin(g *gin.RouterGroup, svc *license.Service) {
+	// POST /license/import — verify and store a .lic; on online deployments an
+	// unbound license is auto-activated. { license } -> license detail.
+	// 409 with stored:true = stored fine but the issuer refused activation.
+	g.POST("/license/import", func(c *gin.Context) {
+		importLicense(c, svc)
+	})
+
+	// POST /license/receipt — import the offline activation receipt (a signed,
+	// fingerprint-bound .lic from the customer portal). Same verification as
+	// import; a separate route so the UI flow and the audit trail read right.
+	g.POST("/license/receipt", func(c *gin.Context) {
+		importLicense(c, svc)
+	})
+
+	// GET /license — current license detail (weak judgement; modules gate by
+	// verifying the signature themselves).
+	g.GET("/license", func(c *gin.Context) {
+		c.JSON(http.StatusOK, licenseDetail(svc))
+	})
+
+	// POST /license/activate — report the installed license to the issuer and
+	// store the reissued, fingerprint-bound text.
+	g.POST("/license/activate", func(c *gin.Context) {
+		snap, err := svc.Activate(c.Request.Context())
+		if err != nil {
+			status := http.StatusBadGateway
+			switch {
+			case errors.Is(err, license.ErrOfflineDeployment), errors.Is(err, license.ErrNoLicense):
+				status = http.StatusBadRequest
+			case errors.Is(err, license.ErrActivatedElsewhere):
+				status = http.StatusConflict
+			}
+			c.JSON(status, gin.H{"error": err.Error()})
+			return
+		}
+		_ = snap
+		c.JSON(http.StatusOK, licenseDetail(svc))
+	})
+
+	// GET /license/fingerprint — this cluster's machine code. Works with no
+	// license installed: the activation guide shows it for portal registration,
+	// and admins quote it for unbind support.
+	g.GET("/license/fingerprint", func(c *gin.Context) {
+		c.JSON(http.StatusOK, gin.H{"instance_fp": svc.Fingerprint()})
+	})
+
+	// GET /license/activation-code — the offline activation request code the
+	// customer pastes into the license portal (shown next to the fingerprint,
+	// both copyable).
+	g.GET("/license/activation-code", func(c *gin.Context) {
+		fp, code, licID := svc.ActivationCode()
+		c.JSON(http.StatusOK, gin.H{"instance_fp": fp, "activation_code": code, "lic_id": licID})
+	})
+
+	// DELETE /license — drop the installed license (back to unactivated).
+	g.DELETE("/license", func(c *gin.Context) {
+		if err := svc.Remove(c.Request.Context()); err != nil {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+			return
+		}
+		c.Status(http.StatusNoContent)
+	})
+}
+
+func importLicense(c *gin.Context, svc *license.Service) {
+	var req struct {
+		License string `json:"license" binding:"required"`
+	}
+	if !bind(c, &req) {
+		return
+	}
+	_, actErr, err := svc.Import(c.Request.Context(), req.License)
+	if err != nil {
+		status := http.StatusInternalServerError
+		switch {
+		case errors.Is(err, license.ErrBadLicense):
+			status = http.StatusBadRequest
+		case errors.Is(err, license.ErrBoundElsewhere):
+			status = http.StatusConflict
+		}
+		c.JSON(status, gin.H{"error": err.Error()})
+		return
+	}
+	if actErr != nil {
+		// Stored, but the issuer refused/failed activation — the admin should
+		// see both facts, not lose the import.
+		status := http.StatusBadGateway
+		if errors.Is(actErr, license.ErrActivatedElsewhere) {
+			status = http.StatusConflict
+		}
+		c.JSON(status, gin.H{"stored": true, "error": actErr.Error(), "license": licenseDetail(svc)})
+		return
+	}
+	c.JSON(http.StatusOK, licenseDetail(svc))
+}
+
+// registerLicenseInternal mounts the in-cluster distribution surface. It is
+// NOT anonymous (upstream hard rule): callers authenticate with an AppKey —
+// the existing service-identity mechanism. What is distributed is the signed
+// license text; modules verify it locally and never trust these answers for
+// gating.
+func registerLicenseInternal(r *gin.Engine, svc *license.Service, keysStore *auth.APIKeyStore) {
+	g := r.Group("/api/safe/v1/internal/license", RequireAppKey(keysStore))
+
+	// GET /current — the raw .lic + ETag. Modules poll with If-None-Match
+	// (≤5 min upstream contract); 304 keeps steady-state traffic body-free.
+	g.GET("/current", func(c *gin.Context) {
+		text, etag, err := svc.Current()
+		if err != nil {
+			if errors.Is(err, license.ErrNoLicense) {
+				c.JSON(http.StatusNotFound, gin.H{"error": "no license installed"})
+				return
+			}
+			c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+			return
+		}
+		quoted := `"` + etag + `"`
+		if match := c.GetHeader("If-None-Match"); match != "" && strings.Contains(match, etag) {
+			c.Header("ETag", quoted)
+			c.Status(http.StatusNotModified)
+			return
+		}
+		c.Header("ETag", quoted)
+		c.JSON(http.StatusOK, gin.H{"license": text, "etag": etag})
+	})
+
+	// GET /status — bkn-safe's pre-computed judgement (state + validity times).
+	// Weak: for dashboards and ops, never for gating.
+	g.GET("/status", func(c *gin.Context) {
+		c.JSON(http.StatusOK, licenseStatus(svc))
+	})
+
+	// GET /capabilities — the features/limits the license carries, plus the
+	// state needed to interpret them (fallback = community set applies). The
+	// frontend shows/hides entries by this; enforcement stays server-side.
+	g.GET("/capabilities", func(c *gin.Context) {
+		snap := svc.State()
+		resp := gin.H{
+			"state":    snap.State,
+			"features": []string{},
+			"limits":   map[string]int64{},
+		}
+		if snap.Payload != nil {
+			if snap.Payload.Features != nil {
+				resp["features"] = snap.Payload.Features
+			}
+			if snap.Payload.Limits != nil {
+				resp["limits"] = snap.Payload.Limits
+			}
+			resp["edition"] = snap.Payload.Edition
+		}
+		c.JSON(http.StatusOK, resp)
+	})
+}
+
+// RequireAppKey authenticates service callers by AppKey (Authorization:
+// Bearer bak_...). Any active key passes — this fences the surface off from
+// anonymous traffic, it is not a per-caller authorization scheme.
+func RequireAppKey(keysStore *auth.APIKeyStore) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		tok := bearerToken(c)
+		if tok == "" {
+			c.AbortWithStatusJSON(http.StatusUnauthorized, gin.H{"error": "missing bearer AppKey"})
+			return
+		}
+		v, err := keysStore.Verify(c.Request.Context(), tok)
+		if err != nil {
+			c.AbortWithStatusJSON(http.StatusUnauthorized, gin.H{"error": "invalid AppKey"})
+			return
+		}
+		c.Set(ctxAccessorID, v.OwnerID)
+		c.Next()
+	}
+}
+
+// licenseStatus is the weak-judgement view shared by the internal status
+// endpoint and the admin detail.
+func licenseStatus(svc *license.Service) gin.H {
+	snap := svc.State()
+	h := gin.H{
+		"state":     snap.State,
+		"activated": svc.Activated(),
+	}
+	if snap.Err != nil {
+		h["error"] = snap.Err.Error()
+	}
+	if snap.RenewErr != nil {
+		h["renew_error"] = snap.RenewErr.Error()
+	}
+	if p := snap.Payload; p != nil {
+		h["edition"] = p.Edition
+		h["expires_at"] = p.ExpiresAt
+		h["contract_expires_at"] = p.ContractExpiresAt
+		if snap.State == licverify.StateGrace && p.ExpiresAt != 0 {
+			graceEnd := time.Unix(p.ExpiresAt, 0).Add(licverify.GracePeriod)
+			days := int(time.Until(graceEnd).Hours() / 24)
+			if days < 0 {
+				days = 0
+			}
+			h["grace_remaining_days"] = days
+		}
+	}
+	return h
+}
+
+// licenseDetail is the admin view: status plus identity/customer/features and
+// the instance fingerprint (the activation guide needs fingerprint + code
+// visible side by side).
+func licenseDetail(svc *license.Service) gin.H {
+	h := licenseStatus(svc)
+	h["instance_fp"] = svc.Fingerprint()
+	if p := svc.State().Payload; p != nil {
+		h["lic_id"] = p.LicID
+		h["customer"] = p.Customer
+		h["issued_at"] = p.IssuedAt
+		h["features"] = p.Features
+		h["limits"] = p.Limits
+	}
+	return h
+}

--- a/bkn-safe/server/internal/httpapi/license_test.go
+++ b/bkn-safe/server/internal/httpapi/license_test.go
@@ -1,0 +1,311 @@
+// Copyright openbkn.ai
+//
+// Licensed under the OpenBKN License. See LICENSE-OPENBKN.txt in the project root.
+
+package httpapi
+
+import (
+	"crypto/ed25519"
+	"crypto/rand"
+	"encoding/base64"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/glebarez/sqlite"
+	"github.com/openbkn-ai/licverify"
+	"gorm.io/gorm"
+
+	"bkn-safe/config"
+	"bkn-safe/internal/audit"
+	"bkn-safe/internal/auth"
+	"bkn-safe/internal/authz"
+	"bkn-safe/internal/database"
+	"bkn-safe/internal/directory"
+	"bkn-safe/internal/license"
+	"bkn-safe/internal/model"
+)
+
+// newLicenseServer builds a full server with the license surfaces mounted: a
+// self-signed test key table, the stub token verifier, and adminSub as
+// super-admin (same trust setup as newAdminServer).
+func newLicenseServer(t *testing.T) (*gin.Engine, *gorm.DB, ed25519.PrivateKey) {
+	t.Helper()
+	gin.SetMode(gin.TestMode)
+	t.Setenv(licverify.EnvInstanceID, "test-cluster-uid")
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	if err != nil {
+		t.Fatalf("sqlite: %v", err)
+	}
+	if err := database.Migrate(db); err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+	e, err := authz.New(db)
+	if err != nil {
+		t.Fatalf("authz: %v", err)
+	}
+	if err := e.Grant(adminSub, "*", "*"); err != nil {
+		t.Fatalf("grant super-admin: %v", err)
+	}
+	pub, priv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	svc, err := license.NewWithKeyTable(db, config.LicenseConfig{}, audit.New(db),
+		map[string]ed25519.PublicKey{"test": pub})
+	if err != nil {
+		t.Fatalf("license service: %v", err)
+	}
+	r := New(Deps{
+		Enforcer: e, DB: db, Directory: directory.New(db), Users: auth.NewUserStore(db),
+		Audit:         audit.New(db),
+		TokenVerifier: stubVerifier{},
+		License:       svc,
+	})
+	return r, db, priv
+}
+
+func signTestLic(t *testing.T, priv ed25519.PrivateKey, mut func(p map[string]any)) string {
+	t.Helper()
+	now := time.Now().Unix()
+	p := map[string]any{
+		"lic_id":              "lic-http",
+		"kid":                 "test",
+		"edition":             "professional",
+		"customer":            map[string]string{"name": "acme"},
+		"issued_at":           now - 3600,
+		"expires_at":          now + 90*86400,
+		"contract_expires_at": now + 365*86400,
+		"features":            []string{"rbac_basic"},
+		"limits":              map[string]int64{"max_users": 100},
+	}
+	if mut != nil {
+		mut(p)
+	}
+	b, _ := json.Marshal(p)
+	sig := ed25519.Sign(priv, b)
+	return "v1." + base64.RawURLEncoding.EncodeToString(b) + "." + base64.RawURLEncoding.EncodeToString(sig)
+}
+
+const licAdminBase = "/api/safe/v1/admin/license"
+
+func TestLicenseAdminRequiresToken(t *testing.T) {
+	r, _, _ := newLicenseServer(t)
+	if w := do(t, r, http.MethodGet, licAdminBase, nil); w.Code != http.StatusUnauthorized {
+		t.Fatalf("unauthenticated admin read = %d, want 401", w.Code)
+	}
+}
+
+func TestLicenseFingerprintWithoutLicense(t *testing.T) {
+	r, _, _ := newLicenseServer(t)
+	w := adminReq(t, r, http.MethodGet, licAdminBase+"/fingerprint", nil)
+	if w.Code != http.StatusOK {
+		t.Fatalf("fingerprint = %d (%s)", w.Code, w.Body.String())
+	}
+	var resp struct {
+		InstanceFP string `json:"instance_fp"`
+	}
+	_ = json.Unmarshal(w.Body.Bytes(), &resp)
+	if resp.InstanceFP == "" {
+		t.Fatal("machine code must be available before any license is imported")
+	}
+}
+
+func TestLicenseActivationCodeWithoutLicense(t *testing.T) {
+	r, _, _ := newLicenseServer(t)
+	w := adminReq(t, r, http.MethodGet, licAdminBase+"/activation-code", nil)
+	if w.Code != http.StatusOK {
+		t.Fatalf("activation-code = %d", w.Code)
+	}
+	var resp struct {
+		InstanceFP     string `json:"instance_fp"`
+		ActivationCode string `json:"activation_code"`
+	}
+	_ = json.Unmarshal(w.Body.Bytes(), &resp)
+	if resp.InstanceFP == "" || resp.ActivationCode == "" {
+		t.Fatalf("both fingerprint and code must be present: %s", w.Body.String())
+	}
+}
+
+func TestLicenseImportInvalidRejected(t *testing.T) {
+	r, _, _ := newLicenseServer(t)
+	w := adminReq(t, r, http.MethodPost, licAdminBase+"/import", map[string]string{"license": "garbage"})
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("import garbage = %d, want 400", w.Code)
+	}
+}
+
+func TestLicenseImportDetailAndRemove(t *testing.T) {
+	r, _, priv := newLicenseServer(t)
+
+	w := adminReq(t, r, http.MethodPost, licAdminBase+"/import",
+		map[string]string{"license": signTestLic(t, priv, nil)})
+	if w.Code != http.StatusOK {
+		t.Fatalf("import = %d (%s)", w.Code, w.Body.String())
+	}
+
+	w = adminReq(t, r, http.MethodGet, licAdminBase, nil)
+	var detail struct {
+		State      string   `json:"state"`
+		Edition    string   `json:"edition"`
+		Activated  bool     `json:"activated"`
+		InstanceFP string   `json:"instance_fp"`
+		LicID      string   `json:"lic_id"`
+		Features   []string `json:"features"`
+	}
+	_ = json.Unmarshal(w.Body.Bytes(), &detail)
+	if detail.State != string(licverify.StateValid) || detail.Edition != "professional" ||
+		detail.LicID != "lic-http" || len(detail.Features) != 1 || detail.InstanceFP == "" {
+		t.Fatalf("detail = %s", w.Body.String())
+	}
+	if detail.Activated {
+		t.Fatal("unbound license on an offline deployment must read activated=false")
+	}
+
+	if w = adminReq(t, r, http.MethodDelete, licAdminBase, nil); w.Code != http.StatusNoContent {
+		t.Fatalf("delete = %d", w.Code)
+	}
+	w = adminReq(t, r, http.MethodGet, licAdminBase, nil)
+	_ = json.Unmarshal(w.Body.Bytes(), &detail)
+	if detail.State != string(licverify.StateInvalid) {
+		t.Fatalf("state after remove = %s", detail.State)
+	}
+}
+
+func TestLicenseReceiptFingerprintMismatch(t *testing.T) {
+	r, _, priv := newLicenseServer(t)
+	w := adminReq(t, r, http.MethodPost, licAdminBase+"/receipt",
+		map[string]string{"license": signTestLic(t, priv, func(p map[string]any) {
+			p["hw_fingerprint"] = "fp_deadbeefdeadbeef"
+		})})
+	if w.Code != http.StatusConflict {
+		t.Fatalf("foreign-bound receipt = %d, want 409 (%s)", w.Code, w.Body.String())
+	}
+}
+
+func TestLicenseActivateOffline(t *testing.T) {
+	r, _, priv := newLicenseServer(t)
+	adminReq(t, r, http.MethodPost, licAdminBase+"/import",
+		map[string]string{"license": signTestLic(t, priv, nil)})
+	w := adminReq(t, r, http.MethodPost, licAdminBase+"/activate", nil)
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("activate with no issuer configured = %d, want 400", w.Code)
+	}
+}
+
+// internal face ---------------------------------------------------------------
+
+func issueAppKey(t *testing.T, db *gorm.DB) string {
+	t.Helper()
+	// Verification resolves the key to its owner, so the owner must exist.
+	if err := db.Create(&model.User{ID: "svc-module", Account: "svc-module", Name: "module", Enabled: true}).Error; err != nil {
+		t.Fatal(err)
+	}
+	plaintext, _, err := auth.NewAPIKeyStore(db).Issue(t.Context(), "svc-module", "module key", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return plaintext
+}
+
+func TestLicenseInternalRequiresAppKey(t *testing.T) {
+	r, _, _ := newLicenseServer(t)
+	for _, tok := range []string{"", "bak_bogus_bogus"} {
+		w := tokReq(t, r, http.MethodGet, "/api/safe/v1/internal/license/status", nil, tok)
+		if w.Code != http.StatusUnauthorized {
+			t.Fatalf("token %q = %d, want 401", tok, w.Code)
+		}
+	}
+}
+
+func TestLicenseInternalCurrentAndETag(t *testing.T) {
+	r, db, priv := newLicenseServer(t)
+	key := issueAppKey(t, db)
+
+	// No license yet: 404.
+	w := tokReq(t, r, http.MethodGet, "/api/safe/v1/internal/license/current", nil, key)
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("current with no license = %d, want 404", w.Code)
+	}
+
+	adminReq(t, r, http.MethodPost, licAdminBase+"/import",
+		map[string]string{"license": signTestLic(t, priv, nil)})
+
+	w = tokReq(t, r, http.MethodGet, "/api/safe/v1/internal/license/current", nil, key)
+	if w.Code != http.StatusOK {
+		t.Fatalf("current = %d", w.Code)
+	}
+	etag := w.Header().Get("ETag")
+	var resp struct {
+		License string `json:"license"`
+		ETag    string `json:"etag"`
+	}
+	_ = json.Unmarshal(w.Body.Bytes(), &resp)
+	if etag == "" || resp.License == "" {
+		t.Fatalf("current must carry ETag and text: %s", w.Body.String())
+	}
+	// The distributed text must verify locally — that is the whole point.
+	if _, p := licverify.Eval(resp.License, map[string]ed25519.PublicKey{"test": priv.Public().(ed25519.PublicKey)}); p == nil {
+		t.Fatal("distributed license text does not verify")
+	}
+
+	// Conditional poll: 304 without a body.
+	req := tokReq2(t, r, http.MethodGet, "/api/safe/v1/internal/license/current", key, etag)
+	if req.Code != http.StatusNotModified {
+		t.Fatalf("If-None-Match = %d, want 304", req.Code)
+	}
+
+	// Re-import (a "renewal"): ETag changes and the poll misses.
+	adminReq(t, r, http.MethodPost, licAdminBase+"/import",
+		map[string]string{"license": signTestLic(t, priv, func(p map[string]any) { p["lic_id"] = "lic-renewed" })})
+	req = tokReq2(t, r, http.MethodGet, "/api/safe/v1/internal/license/current", key, etag)
+	if req.Code != http.StatusOK {
+		t.Fatalf("post-renewal poll = %d, want 200", req.Code)
+	}
+	if req.Header().Get("ETag") == etag {
+		t.Fatal("ETag must change when the license changes")
+	}
+}
+
+func TestLicenseInternalStatusAndCapabilities(t *testing.T) {
+	r, db, priv := newLicenseServer(t)
+	key := issueAppKey(t, db)
+	adminReq(t, r, http.MethodPost, licAdminBase+"/import",
+		map[string]string{"license": signTestLic(t, priv, nil)})
+
+	w := tokReq(t, r, http.MethodGet, "/api/safe/v1/internal/license/status", nil, key)
+	var st struct {
+		State     string `json:"state"`
+		Edition   string `json:"edition"`
+		ExpiresAt int64  `json:"expires_at"`
+	}
+	_ = json.Unmarshal(w.Body.Bytes(), &st)
+	if st.State != string(licverify.StateValid) || st.Edition != "professional" || st.ExpiresAt == 0 {
+		t.Fatalf("status = %s", w.Body.String())
+	}
+
+	w = tokReq(t, r, http.MethodGet, "/api/safe/v1/internal/license/capabilities", nil, key)
+	var caps struct {
+		State    string           `json:"state"`
+		Features []string         `json:"features"`
+		Limits   map[string]int64 `json:"limits"`
+	}
+	_ = json.Unmarshal(w.Body.Bytes(), &caps)
+	if len(caps.Features) != 1 || caps.Features[0] != "rbac_basic" || caps.Limits["max_users"] != 100 {
+		t.Fatalf("capabilities = %s", w.Body.String())
+	}
+}
+
+// tokReq2 issues an authenticated request with an If-None-Match header.
+func tokReq2(t *testing.T, r *gin.Engine, method, path, token, etag string) *httptest.ResponseRecorder {
+	t.Helper()
+	req := httptest.NewRequest(method, path, nil)
+	req.Header.Set("Authorization", "Bearer "+token)
+	req.Header.Set("If-None-Match", etag)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	return w
+}

--- a/bkn-safe/server/internal/httpapi/router.go
+++ b/bkn-safe/server/internal/httpapi/router.go
@@ -16,6 +16,7 @@ import (
 	"bkn-safe/internal/auth"
 	"bkn-safe/internal/authz"
 	"bkn-safe/internal/directory"
+	"bkn-safe/internal/license"
 )
 
 // Deps are the collaborators the HTTP layer needs.
@@ -35,6 +36,9 @@ type Deps struct {
 	// ClientAdmin manages login clients' redirect_uris (admin API). Defaults to
 	// Hydra when nil (production); tests inject a stub.
 	ClientAdmin ClientManager
+	// License is the cluster license hub. When nil, the license admin and
+	// internal distribution endpoints are not mounted.
+	License *license.Service
 }
 
 // New builds the gin engine with all routes mounted.
@@ -111,6 +115,17 @@ func New(deps Deps) *gin.Engine {
 		if clientMgr != nil {
 			registerClientAdmin(admin, clientMgr)
 		}
+		// Cluster license hub management (import/activate/remove + detail).
+		if deps.License != nil {
+			registerLicenseAdmin(admin, deps.License)
+		}
+	}
+
+	// In-cluster license distribution: modules pull the signed text and verify
+	// locally. AppKey-authenticated (not anonymous, unlike /authz — upstream
+	// hard rule for this surface).
+	if deps.License != nil && apiKeys != nil {
+		registerLicenseInternal(r, deps.License, apiKeys)
 	}
 
 	// Self-service reads under /api/safe/v1/me — token-gated (RequireUser:

--- a/bkn-safe/server/internal/license/client.go
+++ b/bkn-safe/server/internal/license/client.go
@@ -1,0 +1,90 @@
+// Copyright openbkn.ai
+//
+// Licensed under the OpenBKN License. See LICENSE-OPENBKN.txt in the project root.
+
+package license
+
+import (
+	"bytes"
+	"context"
+	"crypto/tls"
+	"crypto/x509"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"os"
+	"time"
+
+	"bkn-safe/config"
+)
+
+// ErrActivatedElsewhere is the issuer's 409: the license is already bound to a
+// different instance fingerprint. Recovery is an admin unbind on the issuer
+// side, not a retry.
+var ErrActivatedElsewhere = errors.New("license: already activated by another instance")
+
+// httpClientFor builds the egress client towards the issuer. The issuer
+// currently serves a self-signed certificate on a bare IP, so the trust root is
+// configurable (extra CA file) or — logged loudly — verification can be skipped.
+// Either way license authenticity is untouched: certificates are Ed25519-signed,
+// a hijacked transport can only deny renewal.
+func httpClientFor(cfg config.LicenseConfig) (*http.Client, error) {
+	tlsCfg := &tls.Config{}
+	if cfg.CAFile != "" {
+		pem, err := os.ReadFile(cfg.CAFile)
+		if err != nil {
+			return nil, fmt.Errorf("license: read ca_file: %w", err)
+		}
+		pool := x509.NewCertPool()
+		if !pool.AppendCertsFromPEM(pem) {
+			return nil, fmt.Errorf("license: ca_file %s contains no usable PEM certificate", cfg.CAFile)
+		}
+		tlsCfg.RootCAs = pool
+	}
+	if cfg.InsecureSkipVerify {
+		tlsCfg.InsecureSkipVerify = true
+		slog.Warn("license: TLS verification towards the license server is DISABLED (insecure_skip_verify); remove once the issuer has a trusted certificate")
+	}
+	return &http.Client{
+		Timeout:   30 * time.Second,
+		Transport: &http.Transport{TLSClientConfig: tlsCfg},
+	}, nil
+}
+
+// activate reports this instance to the issuer and returns the reissued
+// license (hw_fingerprint embedded). 409 maps to ErrActivatedElsewhere.
+func activate(ctx context.Context, hc *http.Client, serverURL, licText, fp string) (string, error) {
+	body, _ := json.Marshal(map[string]string{"license": licText, "instance_fp": fp})
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, serverURL+"/api/licenses/activate", bytes.NewReader(body))
+	if err != nil {
+		return "", err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := hc.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("license: activate request: %w", err)
+	}
+	defer resp.Body.Close()
+	var out struct {
+		License string `json:"license"`
+		Error   string `json:"error"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
+		return "", fmt.Errorf("license: activate response: %w", err)
+	}
+	if resp.StatusCode == http.StatusConflict {
+		if out.Error != "" {
+			return "", fmt.Errorf("%w: %s", ErrActivatedElsewhere, out.Error)
+		}
+		return "", ErrActivatedElsewhere
+	}
+	if resp.StatusCode != http.StatusOK || out.License == "" {
+		if out.Error != "" {
+			return "", fmt.Errorf("license: activate refused: %s", out.Error)
+		}
+		return "", fmt.Errorf("license: activate http %d", resp.StatusCode)
+	}
+	return out.License, nil
+}

--- a/bkn-safe/server/internal/license/e2e_test.go
+++ b/bkn-safe/server/internal/license/e2e_test.go
@@ -1,0 +1,221 @@
+// Copyright openbkn.ai
+//
+// Licensed under the OpenBKN License. See LICENSE-OPENBKN.txt in the project root.
+
+//go:build e2e
+
+// End-to-end test against a REAL license-server (started locally by
+// dev/license-e2e.sh — never a shared/public issuer). Covers what the unit
+// suite fakes: true activation reissue, first-wins conflicts, renewal with
+// binding checks. Skips unless LICENSE_E2E_ISSUER is set.
+//
+//	LICENSE_E2E_ISSUER       http://127.0.0.1:18341
+//	LICENSE_E2E_COMMUNITY    path to an UNBOUND community .lic
+//	LICENSE_E2E_PRO          path to an UNBOUND professional .lic
+package license
+
+import (
+	"bytes"
+	"crypto/ed25519"
+	"encoding/json"
+	"net/http"
+	"os"
+	"testing"
+
+	"github.com/openbkn-ai/licverify"
+
+	"bkn-safe/config"
+	"bkn-safe/internal/audit"
+)
+
+const (
+	e2eClusterA = "e2e-cluster-A"
+	e2eClusterB = "e2e-cluster-B"
+)
+
+func e2eIssuer(t *testing.T) string {
+	t.Helper()
+	url := os.Getenv("LICENSE_E2E_ISSUER")
+	if url == "" {
+		t.Skip("LICENSE_E2E_ISSUER not set — run via dev/license-e2e.sh")
+	}
+	return url
+}
+
+// e2eKeys fetches the issuer's published verification keys (/api/keys). In
+// production keys are compiled in; the e2e issuer generates a throwaway pair.
+func e2eKeys(t *testing.T, issuer string) map[string]ed25519.PublicKey {
+	t.Helper()
+	resp, err := http.Get(issuer + "/api/keys")
+	if err != nil {
+		t.Fatalf("fetch keys: %v", err)
+	}
+	defer resp.Body.Close()
+	var kv struct {
+		Keys []struct {
+			Kid       string `json:"kid"`
+			PublicKey string `json:"public_key"`
+		} `json:"keys"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&kv); err != nil {
+		t.Fatalf("decode keys: %v", err)
+	}
+	out := make(map[string]ed25519.PublicKey, len(kv.Keys))
+	for _, k := range kv.Keys {
+		pub, err := licverify.ParsePublicKey(k.PublicKey)
+		if err != nil {
+			t.Fatalf("key %s: %v", k.Kid, err)
+		}
+		out[k.Kid] = pub
+	}
+	if len(out) == 0 {
+		t.Fatal("issuer published no keys")
+	}
+	return out
+}
+
+func e2eLic(t *testing.T, env string) string {
+	t.Helper()
+	path := os.Getenv(env)
+	if path == "" {
+		t.Skipf("%s not set", env)
+	}
+	b, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return string(b)
+}
+
+func e2eService(t *testing.T, issuer, instanceID string, keys map[string]ed25519.PublicKey) *Service {
+	t.Helper()
+	t.Setenv(licverify.EnvInstanceID, instanceID)
+	db := testDB(t)
+	svc, err := NewWithKeyTable(db, config.LicenseConfig{ServerURL: issuer}, audit.New(db), keys)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return svc
+}
+
+func TestE2EActivateBindsAndIsIdempotent(t *testing.T) {
+	issuer := e2eIssuer(t)
+	keys := e2eKeys(t, issuer)
+	lic := e2eLic(t, "LICENSE_E2E_COMMUNITY")
+
+	svc := e2eService(t, issuer, e2eClusterA, keys)
+	snap, actErr, err := svc.Import(t.Context(), lic)
+	if err != nil || actErr != nil {
+		t.Fatalf("import: err=%v actErr=%v", err, actErr)
+	}
+	if snap.State != licverify.StateValid || !svc.Activated() {
+		t.Fatalf("state=%s activated=%v after online import", snap.State, svc.Activated())
+	}
+	wantFP := licverify.FingerprintFrom("env:" + e2eClusterA)
+	if snap.Payload.HWFingerprint != wantFP {
+		t.Fatalf("bound fp = %s, want %s", snap.Payload.HWFingerprint, wantFP)
+	}
+
+	// Same instance re-imports the original unbound code (reinstall): the
+	// issuer must treat it as idempotent, not first-wins it away.
+	snap, actErr, err = svc.Import(t.Context(), lic)
+	if err != nil || actErr != nil {
+		t.Fatalf("re-import: err=%v actErr=%v", err, actErr)
+	}
+	if !svc.Activated() {
+		t.Fatal("re-import lost the activation")
+	}
+
+	// Explicit re-activate is also idempotent.
+	if _, err := svc.Activate(t.Context()); err != nil {
+		t.Fatalf("re-activate: %v", err)
+	}
+}
+
+func TestE2EFirstWinsAgainstSecondCluster(t *testing.T) {
+	issuer := e2eIssuer(t)
+	keys := e2eKeys(t, issuer)
+	lic := e2eLic(t, "LICENSE_E2E_COMMUNITY") // already activated by cluster A above
+
+	svcB := e2eService(t, issuer, e2eClusterB, keys)
+	_, actErr, err := svcB.Import(t.Context(), lic)
+	if err != nil {
+		t.Fatalf("import on cluster B: %v", err)
+	}
+	if actErr == nil {
+		t.Fatal("cluster B activating cluster A's license must conflict (first-wins)")
+	}
+}
+
+func TestE2ECopiedBoundCertRejectedLocally(t *testing.T) {
+	issuer := e2eIssuer(t)
+	keys := e2eKeys(t, issuer)
+	lic := e2eLic(t, "LICENSE_E2E_COMMUNITY")
+
+	// Cluster A activates and holds the bound reissue.
+	svcA := e2eService(t, issuer, e2eClusterA, keys)
+	if _, actErr, err := svcA.Import(t.Context(), lic); err != nil || actErr != nil {
+		t.Fatalf("cluster A import: err=%v actErr=%v", err, actErr)
+	}
+	bound, _, err := svcA.Current()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Cluster B copies the bound certificate: local verification alone must
+	// reject it — no issuer round-trip involved.
+	svcB := e2eService(t, issuer, e2eClusterB, keys)
+	if _, _, err := svcB.Import(t.Context(), bound); err != ErrBoundElsewhere {
+		t.Fatalf("copied bound cert: err=%v, want ErrBoundElsewhere", err)
+	}
+}
+
+func TestE2ERenewChecksBinding(t *testing.T) {
+	issuer := e2eIssuer(t)
+	keys := e2eKeys(t, issuer)
+	lic := e2eLic(t, "LICENSE_E2E_PRO")
+
+	svc := e2eService(t, issuer, e2eClusterA, keys)
+	if _, actErr, err := svc.Import(t.Context(), lic); err != nil || actErr != nil {
+		t.Fatalf("import pro: err=%v actErr=%v", err, actErr)
+	}
+	bound, _, err := svc.Current()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	renew := func(text, fp string) (int, string) {
+		body, _ := json.Marshal(map[string]string{"license": text, "instance_fp": fp})
+		resp, err := http.Post(issuer+"/api/licenses/renew", "application/json", bytes.NewReader(body))
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer resp.Body.Close()
+		var out struct {
+			License string `json:"license"`
+			Error   string `json:"error"`
+		}
+		_ = json.NewDecoder(resp.Body).Decode(&out)
+		return resp.StatusCode, out.License
+	}
+
+	// Renew with the WRONG fingerprint: refused — a copied code cannot keep
+	// itself alive through renewal.
+	if code, _ := renew(bound, licverify.FingerprintFrom("env:"+e2eClusterB)); code != http.StatusConflict {
+		t.Fatalf("renew with foreign fp = %d, want 409", code)
+	}
+
+	// Renew with the bound fingerprint: a fresh certificate that verifies and
+	// carries the same binding.
+	code, fresh := renew(bound, licverify.FingerprintFrom("env:"+e2eClusterA))
+	if code != http.StatusOK || fresh == "" {
+		t.Fatalf("renew = %d", code)
+	}
+	state, p := licverify.Eval(fresh, keys)
+	if state != licverify.StateValid || p.HWFingerprint != licverify.FingerprintFrom("env:"+e2eClusterA) {
+		t.Fatalf("renewed cert: state=%s fp=%s", state, p.HWFingerprint)
+	}
+	if p.LicID == "" {
+		t.Fatal("renewed cert missing lic_id")
+	}
+}

--- a/bkn-safe/server/internal/license/service.go
+++ b/bkn-safe/server/internal/license/service.go
@@ -1,0 +1,361 @@
+// Copyright openbkn.ai
+//
+// Licensed under the OpenBKN License. See LICENSE-OPENBKN.txt in the project root.
+
+// Package license makes bkn-safe the cluster's license hub: it holds the one
+// signed .lic (DB row), is the cluster's only egress to the license-server
+// (activation + auto-renewal), re-verifies hourly, and hands the license text
+// out to modules — which verify it locally with licverify. bkn-safe's own
+// answers are weak judgements (UI, monitoring); the signature is the only
+// trust root. Design: bkn-docs docs/foundry/bkn-safe/design/issue-224-license-hub.md,
+// upstream spec: license-server docs/bkn-safe-license-integration.md.
+package license
+
+import (
+	"context"
+	"crypto/ed25519"
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/openbkn-ai/licverify"
+	"github.com/openbkn-ai/licverify/keys"
+	"gorm.io/gorm"
+
+	"bkn-safe/config"
+	"bkn-safe/internal/audit"
+	"bkn-safe/internal/model"
+)
+
+const rowID = "current"
+
+// clockTolerance is how far the clock may sit behind the persisted high-water
+// mark before we call it a rollback (NTP steps and timezone fixes stay under
+// this; a rollback that would un-expire a license does not).
+const clockTolerance = 24 * time.Hour
+
+var (
+	// ErrBadLicense: malformed text, unknown kid, or bad signature — never stored.
+	ErrBadLicense = errors.New("license: malformed or signature invalid")
+	// ErrBoundElsewhere: the license embeds another instance's fingerprint (a
+	// copied certificate) — never stored.
+	ErrBoundElsewhere = errors.New("license: bound to a different instance")
+	// ErrNoLicense: no license installed.
+	ErrNoLicense = errors.New("license: no license installed")
+	// ErrOfflineDeployment: the action needs a license server but none is
+	// configured — use the offline request-code/receipt flow instead.
+	ErrOfflineDeployment = errors.New("license: no license server configured (offline deployment)")
+)
+
+// Service owns the license row and the verification/renewal loop. All gating
+// answers come from the embedded licverify.Guard's atomic snapshot.
+type Service struct {
+	db        *gorm.DB
+	guard     *licverify.Guard
+	keys      map[string]ed25519.PublicKey
+	fp        string
+	serverURL string
+	hc        *http.Client
+	audit     *audit.Store
+
+	// mu serializes mutations (import/activate/remove). Reads go through the
+	// guard snapshot and need no lock.
+	mu           sync.Mutex
+	lastRenewErr string
+}
+
+// New builds the service with the official compiled-in key table. The
+// fingerprint comes from licverify (OPENBKN_INSTANCE_ID in K8s); failing to
+// resolve one is an error — the caller decides whether to run without a
+// license hub, bkn-safe itself must not be blocked by licensing.
+func New(db *gorm.DB, cfg config.LicenseConfig, aud *audit.Store) (*Service, error) {
+	return NewWithKeyTable(db, cfg, aud, keys.Official())
+}
+
+// NewWithKeyTable exists so tests can inject a self-signed test key table.
+// Production code has exactly one caller: New with keys.Official(). Keys are
+// compiled in, never read from config, env, or any endpoint (hard rule — a
+// configurable key is a self-signing hole).
+func NewWithKeyTable(db *gorm.DB, cfg config.LicenseConfig, aud *audit.Store, keyTable map[string]ed25519.PublicKey) (*Service, error) {
+	fp, err := licverify.Fingerprint()
+	if err != nil {
+		return nil, fmt.Errorf("license: resolve instance fingerprint: %w", err)
+	}
+	hc, err := httpClientFor(cfg)
+	if err != nil {
+		return nil, err
+	}
+	s := &Service{
+		db:        db,
+		keys:      keyTable,
+		fp:        fp,
+		serverURL: strings.TrimRight(cfg.ServerURL, "/"),
+		hc:        hc,
+		audit:     aud,
+	}
+	renewURL := ""
+	if s.serverURL != "" {
+		renewURL = s.serverURL + "/api/licenses/renew"
+	}
+	g, err := licverify.NewGuard(licverify.GuardConfig{
+		Keys:       keyTable,
+		Load:       s.loadText,
+		Store:      s.storeText,
+		RenewURL:   renewURL,
+		InstanceFP: fp,
+		HTTPClient: hc,
+		Logf: func(format string, args ...any) {
+			slog.Info("license: " + fmt.Sprintf(format, args...))
+		},
+		OnChange: s.onChange,
+	})
+	if err != nil {
+		return nil, err
+	}
+	s.guard = g
+	return s, nil
+}
+
+// State returns the current gating snapshot (atomic, hot-path safe).
+func (s *Service) State() licverify.Snapshot { return s.guard.State() }
+
+// Fingerprint returns this cluster's instance fingerprint. Available with or
+// without a license — the activation guide shows it before anything is imported.
+func (s *Service) Fingerprint() string { return s.fp }
+
+// Activated reports whether the current license is bound to this instance.
+func (s *Service) Activated() bool {
+	snap := s.guard.State()
+	return snap.Payload != nil && snap.Payload.HWFingerprint != ""
+}
+
+// ActivationCode returns the offline activation request code the customer
+// pastes into the license portal. With no license installed the lic_id half is
+// empty; the portal then binds whichever license the code is submitted against.
+func (s *Service) ActivationCode() (fp, code, licID string) {
+	if snap := s.guard.State(); snap.Payload != nil {
+		licID = snap.Payload.LicID
+	}
+	return s.fp, licverify.ActivationCode(licID, s.fp), licID
+}
+
+// Current returns the raw license text and its ETag for module distribution.
+// The ETag changes exactly when the text changes (renewal, import).
+func (s *Service) Current() (text, etag string, err error) {
+	text, err = s.loadText()
+	if err != nil {
+		return "", "", err
+	}
+	if text == "" {
+		return "", "", ErrNoLicense
+	}
+	return text, ETag(text), nil
+}
+
+// ETag derives the distribution ETag of a license text.
+func ETag(text string) string {
+	sum := sha256.Sum256([]byte(text))
+	return hex.EncodeToString(sum[:8])
+}
+
+// Import verifies and stores a .lic (admin import and offline receipt share
+// this). Signature-invalid or foreign-bound texts are rejected without
+// storing. An unbound license on an online deployment is auto-activated;
+// activation trouble comes back in actErr with the license already stored, so
+// the caller can report "stored, activation pending" instead of losing the
+// import.
+func (s *Service) Import(ctx context.Context, text string) (snap licverify.Snapshot, actErr, err error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	text = strings.TrimSpace(text)
+	state, p := licverify.Eval(text, s.keys)
+	if state == licverify.StateInvalid {
+		return s.guard.State(), nil, ErrBadLicense
+	}
+	if licverify.VerifyBound(p, s.fp) != nil {
+		return s.guard.State(), nil, ErrBoundElsewhere
+	}
+	if err := s.storeText(text); err != nil {
+		return s.guard.State(), nil, err
+	}
+	snap = s.guard.Refresh()
+	if p.HWFingerprint == "" && s.serverURL != "" {
+		fresh, aerr := activate(ctx, s.hc, s.serverURL, text, s.fp)
+		if aerr != nil {
+			return snap, aerr, nil
+		}
+		if serr := s.storeText(fresh); serr != nil {
+			return snap, serr, nil
+		}
+		snap = s.guard.Refresh()
+	}
+	return snap, nil, nil
+}
+
+// Activate reports the installed license to the issuer and stores the reissued
+// (fingerprint-bound) text. Re-activating an already-bound license is
+// idempotent on the issuer side.
+func (s *Service) Activate(ctx context.Context) (licverify.Snapshot, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.serverURL == "" {
+		return s.guard.State(), ErrOfflineDeployment
+	}
+	text, err := s.loadText()
+	if err != nil {
+		return s.guard.State(), err
+	}
+	if text == "" {
+		return s.guard.State(), ErrNoLicense
+	}
+	fresh, err := activate(ctx, s.hc, s.serverURL, text, s.fp)
+	if err != nil {
+		return s.guard.State(), err
+	}
+	if err := s.storeText(fresh); err != nil {
+		return s.guard.State(), err
+	}
+	return s.guard.Refresh(), nil
+}
+
+// Remove deletes the installed license (back to the unactivated state). Data
+// is never locked by license state; this only drops paid gating.
+func (s *Service) Remove(ctx context.Context) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if err := s.db.WithContext(ctx).Delete(&model.License{}, "id = ?", rowID).Error; err != nil {
+		return err
+	}
+	s.guard.Refresh()
+	return nil
+}
+
+// RenewNow forces one renewing evaluation (what an hourly tick does). Blocking.
+func (s *Service) RenewNow() licverify.Snapshot {
+	snap := s.guard.RenewNow()
+	s.trackRenewErr(snap)
+	return snap
+}
+
+// Run drives the hourly loop: re-evaluate (renew when the window calls for
+// it — the Guard renews inside the last third and throughout grace) and
+// advance the clock high-water mark. Call as a goroutine.
+func (s *Service) Run(ctx context.Context) {
+	t := time.NewTicker(time.Hour)
+	defer t.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-t.C:
+			s.RenewNow()
+			s.checkClock(time.Now())
+		}
+	}
+}
+
+// loadText is the Guard's Load hook: the license text, "" when none installed.
+func (s *Service) loadText() (string, error) {
+	var row model.License
+	err := s.db.First(&row, "id = ?", rowID).Error
+	if errors.Is(err, gorm.ErrRecordNotFound) {
+		return "", nil
+	}
+	if err != nil {
+		return "", err
+	}
+	return row.Text, nil
+}
+
+// storeText persists a license under an optimistic lock. Losing the race means
+// another replica just wrote (typically its own renewal of the same license);
+// the loser reports failure and re-reads on its next cycle rather than
+// clobbering a fresher certificate with a stale one.
+func (s *Service) storeText(text string) error {
+	var row model.License
+	err := s.db.First(&row, "id = ?", rowID).Error
+	if errors.Is(err, gorm.ErrRecordNotFound) {
+		return s.db.Create(&model.License{ID: rowID, Text: text, Version: 1}).Error
+	}
+	if err != nil {
+		return err
+	}
+	res := s.db.Model(&model.License{}).
+		Where("id = ? AND version = ?", rowID, row.Version).
+		Updates(map[string]any{"text": text, "version": row.Version + 1})
+	if res.Error != nil {
+		return res.Error
+	}
+	if res.RowsAffected == 0 {
+		return errors.New("license: lost concurrent update, keeping the other writer's text")
+	}
+	return nil
+}
+
+// checkClock persists the max timestamp ever seen and flags large rollbacks —
+// the one lever an offline deployment has to stretch an expired license. It
+// detects and audits; it never blocks (matching the never-lock-data promise).
+func (s *Service) checkClock(now time.Time) {
+	var row model.License
+	err := s.db.First(&row, "id = ?", rowID).Error
+	if err != nil {
+		return // nothing installed (or DB blip): nothing to guard
+	}
+	if now.Unix() < row.HighWater-int64(clockTolerance/time.Second) {
+		behind := time.Duration(row.HighWater-now.Unix()) * time.Second
+		slog.Warn("license: system clock is far behind the recorded high-water mark", "behind", behind)
+		s.auditRecord("license.clock-rollback", fmt.Sprintf("clock behind high-water mark by %s", behind))
+		return // never lower the mark
+	}
+	if now.Unix() > row.HighWater {
+		s.db.Model(&model.License{}).Where("id = ?", rowID).Update("high_water", now.Unix())
+	}
+}
+
+// onChange logs and audits state transitions. The Guard fires this only on
+// change, not steady state; the boot transition from the zero state is logged
+// but not audited (one row per restart would be noise).
+func (s *Service) onChange(old, cur licverify.Snapshot) {
+	slog.Info("license state", "from", old.State, "to", cur.State)
+	if old.State == "" {
+		return
+	}
+	s.auditRecord("license.state-change", fmt.Sprintf("%s -> %s", old.State, cur.State))
+}
+
+// trackRenewErr audits the first failure of a renewal streak (hourly repeats
+// only log) and resets on success.
+func (s *Service) trackRenewErr(snap licverify.Snapshot) {
+	if snap.RenewErr == nil {
+		s.lastRenewErr = ""
+		return
+	}
+	msg := snap.RenewErr.Error()
+	if msg == s.lastRenewErr {
+		return
+	}
+	s.lastRenewErr = msg
+	s.auditRecord("license.renew-failed", msg)
+}
+
+func (s *Service) auditRecord(action, detail string) {
+	if s.audit == nil {
+		return
+	}
+	if err := s.audit.Record(context.Background(), audit.Entry{
+		ActorID:  "system:license",
+		Method:   "SYSTEM",
+		Resource: "license",
+		Action:   action,
+		Detail:   detail,
+		Status:   http.StatusOK,
+	}); err != nil {
+		slog.Error("license: audit record failed", "err", err)
+	}
+}

--- a/bkn-safe/server/internal/license/service_test.go
+++ b/bkn-safe/server/internal/license/service_test.go
@@ -1,0 +1,479 @@
+// Copyright openbkn.ai
+//
+// Licensed under the OpenBKN License. See LICENSE-OPENBKN.txt in the project root.
+
+package license
+
+import (
+	"crypto/ed25519"
+	"crypto/rand"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/glebarez/sqlite"
+	"github.com/openbkn-ai/licverify"
+	"gorm.io/gorm"
+
+	"bkn-safe/config"
+	"bkn-safe/internal/audit"
+	"bkn-safe/internal/database"
+	"bkn-safe/internal/model"
+)
+
+const testInstanceID = "test-cluster-uid"
+
+// testKeys returns a fresh self-signed test key table (kid "test") plus the
+// private key for signing test licenses. Never resembles the official table.
+func testKeys(t *testing.T) (map[string]ed25519.PublicKey, ed25519.PrivateKey) {
+	t.Helper()
+	pub, priv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return map[string]ed25519.PublicKey{"test": pub}, priv
+}
+
+// signLic builds a signed v1 license from a payload map (format identical to
+// production certificates).
+func signLic(t *testing.T, priv ed25519.PrivateKey, p map[string]any) string {
+	t.Helper()
+	if _, ok := p["kid"]; !ok {
+		p["kid"] = "test"
+	}
+	b, err := json.Marshal(p)
+	if err != nil {
+		t.Fatal(err)
+	}
+	sig := ed25519.Sign(priv, b)
+	return "v1." + base64.RawURLEncoding.EncodeToString(b) + "." + base64.RawURLEncoding.EncodeToString(sig)
+}
+
+func testDB(t *testing.T) *gorm.DB {
+	t.Helper()
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := database.Migrate(db); err != nil {
+		t.Fatal(err)
+	}
+	return db
+}
+
+func newTestService(t *testing.T, db *gorm.DB, cfg config.LicenseConfig, keyTable map[string]ed25519.PublicKey) *Service {
+	t.Helper()
+	t.Setenv(licverify.EnvInstanceID, testInstanceID)
+	svc, err := NewWithKeyTable(db, cfg, audit.New(db), keyTable)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return svc
+}
+
+func localFP() string { return licverify.FingerprintFrom("env:" + testInstanceID) }
+
+// payload builders ------------------------------------------------------------
+
+func validPayload() map[string]any {
+	now := time.Now().Unix()
+	return map[string]any{
+		"lic_id":              "lic-valid",
+		"edition":             "professional",
+		"customer":            map[string]string{"name": "acme", "project": "p1"},
+		"issued_at":           now - 3600,
+		"expires_at":          now + 90*86400,
+		"contract_expires_at": now + 365*86400,
+		"features":            []string{"rbac_basic", "source_sync"},
+		"limits":              map[string]int64{"max_users": 100},
+	}
+}
+
+func TestStateMachine(t *testing.T) {
+	keyTable, priv := testKeys(t)
+	now := time.Now().Unix()
+
+	cases := []struct {
+		name  string
+		mut   func(p map[string]any)
+		state licverify.State
+	}{
+		{"valid", func(p map[string]any) {}, licverify.StateValid},
+		{"perpetual community", func(p map[string]any) {
+			p["expires_at"] = 0
+			p["contract_expires_at"] = 0
+			p["edition"] = "community"
+		}, licverify.StateValid},
+		{"grace within 30d", func(p map[string]any) {
+			p["issued_at"] = now - 100*86400
+			p["expires_at"] = now - 10*86400
+		}, licverify.StateGrace},
+		{"fallback beyond grace", func(p map[string]any) {
+			p["issued_at"] = now - 200*86400
+			p["expires_at"] = now - 40*86400
+			p["contract_expires_at"] = 0
+		}, licverify.StateFallback},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			db := testDB(t)
+			svc := newTestService(t, db, config.LicenseConfig{}, keyTable)
+			p := validPayload()
+			tc.mut(p)
+			snap, actErr, err := svc.Import(t.Context(), signLic(t, priv, p))
+			if err != nil || actErr != nil {
+				t.Fatalf("import: err=%v actErr=%v", err, actErr)
+			}
+			if snap.State != tc.state {
+				t.Fatalf("state = %s, want %s", snap.State, tc.state)
+			}
+		})
+	}
+}
+
+func TestImportRejectsBadLicense(t *testing.T) {
+	keyTable, priv := testKeys(t)
+	db := testDB(t)
+	svc := newTestService(t, db, config.LicenseConfig{}, keyTable)
+
+	for name, text := range map[string]string{
+		"garbage":     "not-a-license",
+		"tampered":    signLic(t, priv, validPayload())[:40] + "x" + signLic(t, priv, validPayload())[41:],
+		"unknown kid": signLic(t, priv, func() map[string]any { p := validPayload(); p["kid"] = "rogue"; return p }()),
+	} {
+		t.Run(name, func(t *testing.T) {
+			_, _, err := svc.Import(t.Context(), text)
+			if !errors.Is(err, ErrBadLicense) {
+				t.Fatalf("err = %v, want ErrBadLicense", err)
+			}
+		})
+	}
+	if _, _, err := svc.Current(); !errors.Is(err, ErrNoLicense) {
+		t.Fatalf("rejected imports must not store: %v", err)
+	}
+}
+
+func TestImportRejectsForeignBoundLicense(t *testing.T) {
+	keyTable, priv := testKeys(t)
+	db := testDB(t)
+	svc := newTestService(t, db, config.LicenseConfig{}, keyTable)
+
+	p := validPayload()
+	p["hw_fingerprint"] = "fp_deadbeefdeadbeef" // someone else's machine
+	_, _, err := svc.Import(t.Context(), signLic(t, priv, p))
+	if !errors.Is(err, ErrBoundElsewhere) {
+		t.Fatalf("err = %v, want ErrBoundElsewhere", err)
+	}
+}
+
+func TestImportOfflineUnboundStaysUnactivated(t *testing.T) {
+	keyTable, priv := testKeys(t)
+	db := testDB(t)
+	svc := newTestService(t, db, config.LicenseConfig{}, keyTable)
+
+	snap, actErr, err := svc.Import(t.Context(), signLic(t, priv, validPayload()))
+	if err != nil || actErr != nil {
+		t.Fatalf("import: err=%v actErr=%v", err, actErr)
+	}
+	if snap.State != licverify.StateValid {
+		t.Fatalf("state = %s", snap.State)
+	}
+	if svc.Activated() {
+		t.Fatal("offline import of an unbound license must stay unactivated")
+	}
+}
+
+func TestImportAutoActivatesOnline(t *testing.T) {
+	keyTable, priv := testKeys(t)
+
+	issuer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/licenses/activate" {
+			http.NotFound(w, r)
+			return
+		}
+		var req struct {
+			License    string `json:"license"`
+			InstanceFP string `json:"instance_fp"`
+		}
+		_ = json.NewDecoder(r.Body).Decode(&req)
+		if req.InstanceFP != localFP() {
+			t.Errorf("activate fp = %s, want %s", req.InstanceFP, localFP())
+		}
+		p := validPayload()
+		p["hw_fingerprint"] = req.InstanceFP
+		_ = json.NewEncoder(w).Encode(map[string]string{"license": signLic(t, priv, p)})
+	}))
+	defer issuer.Close()
+
+	db := testDB(t)
+	svc := newTestService(t, db, config.LicenseConfig{ServerURL: issuer.URL}, keyTable)
+	snap, actErr, err := svc.Import(t.Context(), signLic(t, priv, validPayload()))
+	if err != nil || actErr != nil {
+		t.Fatalf("import: err=%v actErr=%v", err, actErr)
+	}
+	if snap.Payload == nil || snap.Payload.HWFingerprint != localFP() {
+		t.Fatal("import on an online deployment must store the reissued, bound license")
+	}
+	if !svc.Activated() {
+		t.Fatal("Activated() = false after auto-activation")
+	}
+}
+
+func TestImportSurfacesActivationConflict(t *testing.T) {
+	keyTable, priv := testKeys(t)
+	issuer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusConflict)
+		_ = json.NewEncoder(w).Encode(map[string]string{"error": "already activated"})
+	}))
+	defer issuer.Close()
+
+	db := testDB(t)
+	svc := newTestService(t, db, config.LicenseConfig{ServerURL: issuer.URL}, keyTable)
+	_, actErr, err := svc.Import(t.Context(), signLic(t, priv, validPayload()))
+	if err != nil {
+		t.Fatalf("import err = %v", err)
+	}
+	if !errors.Is(actErr, ErrActivatedElsewhere) {
+		t.Fatalf("actErr = %v, want ErrActivatedElsewhere", actErr)
+	}
+	// The license is stored regardless — the import must not be lost.
+	if _, _, err := svc.Current(); err != nil {
+		t.Fatalf("license must be stored despite activation conflict: %v", err)
+	}
+}
+
+func TestActivateOfflineRefused(t *testing.T) {
+	keyTable, priv := testKeys(t)
+	db := testDB(t)
+	svc := newTestService(t, db, config.LicenseConfig{}, keyTable)
+	if _, _, err := svc.Import(t.Context(), signLic(t, priv, validPayload())); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := svc.Activate(t.Context()); !errors.Is(err, ErrOfflineDeployment) {
+		t.Fatalf("err = %v, want ErrOfflineDeployment", err)
+	}
+}
+
+func TestReceiptFingerprintMismatchRejected(t *testing.T) {
+	// The offline receipt flow imports a bound license; a receipt for another
+	// machine (copied) must be rejected — same guardrail as import.
+	TestImportRejectsForeignBoundLicense(t)
+}
+
+func TestRenewReplacesLicenseAndETag(t *testing.T) {
+	keyTable, priv := testKeys(t)
+	now := time.Now().Unix()
+
+	// Bound license deep inside the last third of its window: issued 90 days
+	// ago, 10 days left of a 100-day window.
+	old := validPayload()
+	old["issued_at"] = now - 90*86400
+	old["expires_at"] = now + 10*86400
+	old["hw_fingerprint"] = localFP()
+
+	fresh := validPayload()
+	fresh["lic_id"] = "lic-renewed"
+	fresh["hw_fingerprint"] = localFP()
+
+	issuer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/licenses/renew" {
+			http.NotFound(w, r)
+			return
+		}
+		_ = json.NewEncoder(w).Encode(map[string]string{"license": signLic(t, priv, fresh)})
+	}))
+	defer issuer.Close()
+
+	db := testDB(t)
+	svc := newTestService(t, db, config.LicenseConfig{ServerURL: issuer.URL}, keyTable)
+	if err := svc.storeText(signLic(t, priv, old)); err != nil {
+		t.Fatal(err)
+	}
+	_, before, err := svc.Current()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	snap := svc.RenewNow()
+	if snap.RenewErr != nil {
+		t.Fatalf("renew err: %v", snap.RenewErr)
+	}
+	if snap.Payload == nil || snap.Payload.LicID != "lic-renewed" {
+		t.Fatalf("payload after renew = %+v", snap.Payload)
+	}
+	_, after, err := svc.Current()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if before == after {
+		t.Fatal("ETag must change when the license text changes")
+	}
+}
+
+func TestRenewFailureKeepsStateAndAudits(t *testing.T) {
+	keyTable, priv := testKeys(t)
+	now := time.Now().Unix()
+
+	issuer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusBadGateway)
+		_ = json.NewEncoder(w).Encode(map[string]string{"error": "issuer down"})
+	}))
+	issuer.Close() // unreachable: the pulled-network-cable case
+
+	old := validPayload()
+	old["issued_at"] = now - 90*86400
+	old["expires_at"] = now + 10*86400
+	old["hw_fingerprint"] = localFP()
+
+	db := testDB(t)
+	svc := newTestService(t, db, config.LicenseConfig{ServerURL: issuer.URL}, keyTable)
+	if err := svc.storeText(signLic(t, priv, old)); err != nil {
+		t.Fatal(err)
+	}
+
+	snap := svc.RenewNow()
+	if snap.State != licverify.StateValid {
+		t.Fatalf("a failed renew must not degrade state: %s", snap.State)
+	}
+	if snap.RenewErr == nil {
+		t.Fatal("RenewErr must surface the failure")
+	}
+	var n int64
+	db.Model(&model.AuditLog{}).Where("action = ?", "license.renew-failed").Count(&n)
+	if n != 1 {
+		t.Fatalf("renew failure audit rows = %d, want 1", n)
+	}
+	// A second identical failure is logged, not re-audited (no hourly spam).
+	svc.RenewNow()
+	db.Model(&model.AuditLog{}).Where("action = ?", "license.renew-failed").Count(&n)
+	if n != 1 {
+		t.Fatalf("repeat failure re-audited: rows = %d", n)
+	}
+}
+
+func TestRestartRecovery(t *testing.T) {
+	keyTable, priv := testKeys(t)
+	db := testDB(t)
+	svc := newTestService(t, db, config.LicenseConfig{}, keyTable)
+	p := validPayload()
+	p["hw_fingerprint"] = localFP()
+	if _, _, err := svc.Import(t.Context(), signLic(t, priv, p)); err != nil {
+		t.Fatal(err)
+	}
+
+	// "Restart": a fresh service over the same DB must come up licensed.
+	svc2 := newTestService(t, db, config.LicenseConfig{}, keyTable)
+	if snap := svc2.State(); snap.State != licverify.StateValid {
+		t.Fatalf("state after restart = %s", snap.State)
+	}
+	if !svc2.Activated() {
+		t.Fatal("activation must survive a restart")
+	}
+}
+
+func TestRemove(t *testing.T) {
+	keyTable, priv := testKeys(t)
+	db := testDB(t)
+	svc := newTestService(t, db, config.LicenseConfig{}, keyTable)
+	if _, _, err := svc.Import(t.Context(), signLic(t, priv, validPayload())); err != nil {
+		t.Fatal(err)
+	}
+	if err := svc.Remove(t.Context()); err != nil {
+		t.Fatal(err)
+	}
+	if snap := svc.State(); snap.State != licverify.StateInvalid {
+		t.Fatalf("state after remove = %s", snap.State)
+	}
+	if _, _, err := svc.Current(); !errors.Is(err, ErrNoLicense) {
+		t.Fatalf("current after remove: %v", err)
+	}
+}
+
+func TestActivationCodeWithoutLicense(t *testing.T) {
+	keyTable, _ := testKeys(t)
+	db := testDB(t)
+	svc := newTestService(t, db, config.LicenseConfig{}, keyTable)
+
+	fp, code, licID := svc.ActivationCode()
+	if fp != localFP() {
+		t.Fatalf("fp = %s", fp)
+	}
+	if licID != "" {
+		t.Fatalf("licID with no license = %q", licID)
+	}
+	raw, err := base64.RawURLEncoding.DecodeString(code)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var decoded map[string]string
+	if err := json.Unmarshal(raw, &decoded); err != nil {
+		t.Fatal(err)
+	}
+	if decoded["instance_fp"] != localFP() {
+		t.Fatalf("code fp = %s", decoded["instance_fp"])
+	}
+}
+
+func TestClockHighWater(t *testing.T) {
+	keyTable, priv := testKeys(t)
+	db := testDB(t)
+	svc := newTestService(t, db, config.LicenseConfig{}, keyTable)
+	if _, _, err := svc.Import(t.Context(), signLic(t, priv, validPayload())); err != nil {
+		t.Fatal(err)
+	}
+
+	now := time.Now()
+	svc.checkClock(now)
+	var row model.License
+	if err := db.First(&row, "id = ?", rowID).Error; err != nil {
+		t.Fatal(err)
+	}
+	if row.HighWater != now.Unix() {
+		t.Fatalf("high water = %d, want %d", row.HighWater, now.Unix())
+	}
+
+	// A 48h rollback (beyond the 24h tolerance) is audited and never lowers
+	// the mark.
+	svc.checkClock(now.Add(-48 * time.Hour))
+	var n int64
+	db.Model(&model.AuditLog{}).Where("action = ?", "license.clock-rollback").Count(&n)
+	if n != 1 {
+		t.Fatalf("rollback audit rows = %d, want 1", n)
+	}
+	db.First(&row, "id = ?", rowID)
+	if row.HighWater != now.Unix() {
+		t.Fatal("rollback must not lower the high-water mark")
+	}
+
+	// Small skew within tolerance: no audit.
+	svc.checkClock(now.Add(-time.Hour))
+	db.Model(&model.AuditLog{}).Where("action = ?", "license.clock-rollback").Count(&n)
+	if n != 1 {
+		t.Fatalf("in-tolerance skew audited: rows = %d", n)
+	}
+}
+
+func TestExternalWriterVisibleAfterRefresh(t *testing.T) {
+	// Another replica renews (writes the row); this replica's next evaluation
+	// must pick the fresh text up from the DB, not a cached copy.
+	keyTable, priv := testKeys(t)
+	db := testDB(t)
+	svc := newTestService(t, db, config.LicenseConfig{}, keyTable)
+	if _, _, err := svc.Import(t.Context(), signLic(t, priv, validPayload())); err != nil {
+		t.Fatal(err)
+	}
+
+	fresh := validPayload()
+	fresh["lic_id"] = "lic-other-replica"
+	db.Model(&model.License{}).Where("id = ?", rowID).
+		Updates(map[string]any{"text": signLic(t, priv, fresh), "version": gorm.Expr("version + 1")})
+
+	snap := svc.RenewNow() // an hourly tick re-loads from the DB
+	if snap.Payload == nil || snap.Payload.LicID != "lic-other-replica" {
+		t.Fatalf("payload = %+v, want the other replica's license", snap.Payload)
+	}
+}

--- a/bkn-safe/server/internal/model/model.go
+++ b/bkn-safe/server/internal/model/model.go
@@ -176,11 +176,31 @@ type APIKey struct {
 	CreatedAt  time.Time
 }
 
+// License is the cluster's single license record (bkn-safe is the cluster-wide
+// license holder — see docs/foundry/bkn-safe/design/issue-224-license-hub.md in
+// bkn-docs). One row with a fixed ID; the activation state lives inside Text
+// (the signed .lic embeds hw_fingerprint after activation), so surviving a
+// restart needs nothing beyond this row.
+type License struct {
+	ID string `gorm:"primaryKey;size:16"` // fixed "current"
+	// Text is the raw signed .lic. Its signature — not this row — is what
+	// modules and bkn-safe itself trust; the DB is only a mailbox.
+	Text string `gorm:"type:text"`
+	// HighWater is the largest unix timestamp the background re-verify loop has
+	// seen, persisted to detect large clock rollbacks on offline deployments.
+	HighWater int64
+	// Version is an optimistic lock: concurrent renewals (multi-replica) must
+	// not overwrite each other's freshly reissued license with a stale one.
+	Version   int64
+	UpdatedAt time.Time
+	CreatedAt time.Time
+}
+
 // AllModels is the migration set (Casbin's table is managed by its adapter).
 func AllModels() []any {
 	return []any{
 		&User{}, &Role{}, &Department{}, &UserDepartment{},
 		&Group{}, &GroupMember{}, &ResourceType{}, &Operation{},
-		&AuditLog{}, &APIKey{},
+		&AuditLog{}, &APIKey{}, &License{},
 	}
 }

--- a/bkn-safe/server/main.go
+++ b/bkn-safe/server/main.go
@@ -8,6 +8,7 @@
 package main
 
 import (
+	"context"
 	"flag"
 	"log/slog"
 	"os"
@@ -19,6 +20,7 @@ import (
 	"bkn-safe/internal/database"
 	"bkn-safe/internal/directory"
 	"bkn-safe/internal/httpapi"
+	"bkn-safe/internal/license"
 	"bkn-safe/internal/seed"
 )
 
@@ -70,6 +72,20 @@ func main() {
 	}
 	provider := auth.NewProvider(authenticator, hydraAdmin, userStore)
 	dir := directory.New(db)
+	auditStore := audit.New(db)
+
+	// Cluster license hub: hold the one .lic, be the only egress to the
+	// license-server, distribute to modules. Licensing must never block the
+	// auth service itself — on failure (e.g. no resolvable instance
+	// fingerprint) bkn-safe runs without the license surface.
+	licSvc, err := license.New(db, cfg.License, auditStore)
+	if err != nil {
+		slog.Error("license hub disabled", "err", err)
+		licSvc = nil
+	} else {
+		go licSvc.Run(context.Background())
+		slog.Info("license hub enabled", "instance_fp", licSvc.Fingerprint(), "server_url", cfg.License.ServerURL)
+	}
 
 	r := httpapi.New(httpapi.Deps{
 		Enforcer:  enforcer,
@@ -78,7 +94,8 @@ func main() {
 		Hydra:     hydraAdmin,
 		Directory: dir,
 		Users:     userStore,
-		Audit:     audit.New(db),
+		Audit:     auditStore,
+		License:   licSvc,
 	})
 	slog.Info("bkn-safe listening", "addr", cfg.HTTPAddr)
 	if err := r.Run(cfg.HTTPAddr); err != nil {


### PR DESCRIPTION
Closes #224

## 概要

bkn-safe 成为集群 License 服务器:唯一持证点 + 唯一 license-server 外联点。模块后续从内部面拉证文本本地验签(强门控),bkn-safe 应答只作弱判定。

- 设计文档: https://github.com/openbkn-ai/bkn-docs/pull/2
- 上游权威设计: license-server 仓 `docs/bkn-safe-license-integration.md` + `docs/product-integration.md`

## 改动

| 块 | 内容 |
|---|---|
| `internal/license` | 嵌入 licverify.Guard(公钥仅 `keys.Official()` 编译期内置);证落库单行表+乐观锁(防多副本续期互踩);每小时重验+窗口后 1/3 自动续期;时钟高水位检测回拨(审计不阻断) |
| 管理面 | `/api/safe/v1/admin/license`:import / 详情 / activate / **fingerprint(无证可调)** / activation-code / receipt / DELETE;复用 RequireAdmin+审计中间件 |
| 内部面 | `/api/safe/v1/internal/license`:current(ETag/304)/ status / capabilities;AppKey 鉴权,不匿名暴露 |
| 出网 | activate/renew client 可配 CA 或显式 skip-verify+告警(签发机现为裸 IP 自签证书);`license.server_url` 留空 = 纯离线,永不外呼 |
| config | `license.{server_url,ca_file,insecure_skip_verify}` + SAFE_LICENSE_* env 覆盖 |

## 硬性纪律对照

- ✅ 公钥编译期内置,全仓无从配置/env 读公钥的代码(测试注入走 `NewWithKeyTable`,生产唯一调用方是 `New`)
- ✅ 任何 license 状态不锁数据(bkn-safe 不因 license 拒绝任何既有 API;license hub 初始化失败仅禁用 license 面,不阻服务)
- ✅ 外联收敛:只有 bkn-safe 出网
- ✅ 全动作审计(导入/激活/移除走 admin 审计中间件;续期失败/状态迁移/时钟回拨系统审计)

## 测试

`go test ./...` 全绿。自签测试证覆盖:状态机四态(valid/grace/fallback/invalid + expires_at=0)、复制证拒绝(import+receipt)、激活冲突 409(证仍落库不丢)、续期替换+ETag 变化、拔网线(续期失败不降档+审计去重)、重启自恢复、时钟高水位、内部面 401/304、未激活态可取机器码。

## 不在本 PR

- chart 注入 `OPENBKN_INSTANCE_ID`(kube-system ns UID)+ 模块服务 AppKey 预置(deploy 侧)
- 模块侧强门控样板、Studio 激活引导页

🤖 Generated with [Claude Code](https://claude.com/claude-code)
