### PR TITLE
feat(bkn-safe): seed Studio role permission model

### DIFF
--- a/bkn-safe/server/internal/authz/authz.go
+++ b/bkn-safe/server/internal/authz/authz.go
@@ -247,6 +247,14 @@ func (en *Enforcer) RemoveRoleCompletely(roleID string) error {
 	return err
 }
 
+// RemoveRolePermissions purges only the p-lines owned by a role, preserving its
+// member bindings. Seed uses this before re-applying the built-in permission
+// matrix so removed grants do not linger across upgrades.
+func (en *Enforcer) RemoveRolePermissions(roleID string) error {
+	_, err := en.e.RemoveFilteredPolicy(0, roleID)
+	return err
+}
+
 // RemoveAccessor purges every casbin trace of an accessor: its role bindings
 // (grouping g-lines with sub=accessor) and any concrete object policies granted
 // directly to it (p-lines with sub=accessor). Called when a user is deleted so

--- a/bkn-safe/server/internal/httpapi/admin_test.go
+++ b/bkn-safe/server/internal/httpapi/admin_test.go
@@ -216,12 +216,16 @@ func TestRoleCRUDAndBuiltInProtection(t *testing.T) {
 	w := adminReq(t, r, http.MethodGet, "/api/safe/v1/admin/roles", nil)
 	var list struct {
 		Roles []struct {
-			ID string `json:"id"`
+			ID        string `json:"id"`
+			CreatedAt string `json:"created_at"`
 		} `json:"roles"`
 	}
 	_ = json.Unmarshal(w.Body.Bytes(), &list)
 	if len(list.Roles) != 2 {
 		t.Fatalf("list: want 2 roles, got %d", len(list.Roles))
+	}
+	if list.Roles[0].CreatedAt == "" || list.Roles[1].CreatedAt == "" {
+		t.Fatalf("list role created_at should be returned: %+v", list.Roles)
 	}
 
 	if w := adminReq(t, r, http.MethodPut, "/api/safe/v1/admin/roles/c-1", map[string]any{"name": "Audit Team"}); w.Code != http.StatusNoContent {
@@ -241,12 +245,16 @@ func TestRoleCRUDAndBuiltInProtection(t *testing.T) {
 	_ = e.AssignRole("u-9", "c-1")
 	w = adminReq(t, r, http.MethodGet, "/api/safe/v1/admin/roles/c-1", nil)
 	var detail struct {
+		CreatedAt   string   `json:"created_at"`
 		Members     []string `json:"members"`
 		Permissions []struct {
 			Resource map[string]string `json:"resource"`
 		} `json:"permissions"`
 	}
 	_ = json.Unmarshal(w.Body.Bytes(), &detail)
+	if detail.CreatedAt == "" {
+		t.Error("detail role created_at should be returned")
+	}
 	if len(detail.Members) != 1 || detail.Members[0] != "u-9" {
 		t.Errorf("members = %v", detail.Members)
 	}

--- a/bkn-safe/server/internal/httpapi/authz.go
+++ b/bkn-safe/server/internal/httpapi/authz.go
@@ -451,7 +451,7 @@ func loadRole(c *gin.Context, db *gorm.DB, id string) (*model.Role, error) {
 func roleJSON(r model.Role) gin.H {
 	return gin.H{
 		"id": r.ID, "name": r.Name, "description": r.Description,
-		"source": r.Source, "built_in": r.BuiltIn(),
+		"source": r.Source, "built_in": r.BuiltIn(), "created_at": r.CreatedAt,
 	}
 }
 

--- a/bkn-safe/server/internal/seed/data/catalog.json
+++ b/bkn-safe/server/internal/seed/data/catalog.json
@@ -1,5 +1,5 @@
 {
-  "_comment": "Resource-type + operation catalog, extracted from each service's enums/consts (2026-06-03). Exact op id strings — these are the seed source of truth. NOTE: 'view' (exec-factory, flow-automation) and 'view_detail' (vega/bkn/pipeline) are DIFFERENT op strings — not normalized. Role->permission GRANTS are in grants.json and are pending role-definition decisions (only 应用管理员 grants are confirmed/coded today).",
+  "_comment": "Resource-type + operation catalog, extracted from each service's enums/consts (2026-06-03). Exact op id strings are the seed source of truth. NOTE: 'view' (exec-factory, flow-automation) and 'view_detail' (vega/bkn/pipeline) are DIFFERENT op strings and are not normalized. Role-to-permission grants are maintained in grants.json for the Studio 0.1.0 role model.",
   "resource_types": [
     {
       "id": "agent",
@@ -180,6 +180,65 @@
         {"id": "modify", "name": "修改"},
         {"id": "delete", "name": "删除"},
         {"id": "execute", "name": "调用/执行"}
+      ]
+    },
+    {
+      "id": "admin-user",
+      "name": "系统用户管理",
+      "_source": "bkn-studio system-admin",
+      "operations": [
+        {"id": "create", "name": "新建用户"},
+        {"id": "edit", "name": "编辑用户"},
+        {"id": "delete", "name": "删除用户"},
+        {"id": "toggle", "name": "启停账号"},
+        {"id": "reset-password", "name": "重置密码"}
+      ]
+    },
+    {
+      "id": "admin-dept",
+      "name": "系统部门管理",
+      "_source": "bkn-studio system-admin",
+      "operations": [
+        {"id": "create", "name": "新建部门"},
+        {"id": "edit", "name": "编辑部门"},
+        {"id": "delete", "name": "删除部门"},
+        {"id": "members", "name": "成员管理"}
+      ]
+    },
+    {
+      "id": "admin-role",
+      "name": "系统角色管理",
+      "_source": "bkn-studio system-admin",
+      "operations": [
+        {"id": "create", "name": "新建角色"},
+        {"id": "edit", "name": "编辑角色"},
+        {"id": "delete", "name": "删除角色"},
+        {"id": "members", "name": "成员管理"}
+      ]
+    },
+    {
+      "id": "admin-authz",
+      "name": "系统授权管理",
+      "_source": "bkn-studio system-admin",
+      "operations": [
+        {"id": "grant", "name": "授权"},
+        {"id": "revoke", "name": "撤权"}
+      ]
+    },
+    {
+      "id": "admin-audit",
+      "name": "系统审计日志",
+      "_source": "bkn-studio system-admin",
+      "operations": [
+        {"id": "view", "name": "查看"}
+      ]
+    },
+    {
+      "id": "safe_admin",
+      "name": "bkn-safe 管理 API",
+      "_source": "bkn-safe",
+      "operations": [
+        {"id": "manage", "name": "访问管理 API"}
       ]
     }
   ]

--- a/bkn-safe/server/internal/seed/data/grants.json
+++ b/bkn-safe/server/internal/seed/data/grants.json
@@ -1,9 +1,161 @@
 {
-  "_comment": "Role -> permission grants (2026-06-04). Business admins get FULL ops on the resource types in their domain (admin = full control); super admin gets a wildcard (*:* with act *). The other 5 system roles are seeded (role.json) but intentionally UNGRANTED — they can be activated later purely via the grant API / this file, no code change. Resource-type/operation source files: see docs/isf-replacement/contracts/authz-catalog.md. id_pattern '*' = whole type (keyMatch). 应用管理员 grants mirror DA's coded InitPermission; 数据/AI 管理员 are the agreed mapping (adjust as needed); model resource type TBD (model-factory not yet scanned).",
+  "_comment": "Studio 0.1.0 role -> permission grants. super_admin gets wildcard. admin/security/audit are three-admin roles. network_builder has business build permissions. normal_user can view/query/execute/invoke, but cannot create/edit/delete/publish/authorize.",
   "grants": [
     {
+      "role_id": "7dcfcc9c-ad02-11e8-aa06-000c29358ad6",
+      "role_name": "super_admin",
+      "resource_type": "",
+      "id_pattern": "*",
+      "operations": ["*"],
+      "_note": "wildcard: obj '*' matches any type:id (keyMatch), act '*' matches any op. resource_type empty => obj pattern is just '*'."
+    },
+
+    {
+      "role_id": "d2bd2082-ad03-11e8-aa06-000c29358ad6",
+      "role_name": "admin",
+      "resource_type": "safe_admin",
+      "id_pattern": "console",
+      "operations": ["manage"]
+    },
+    {
+      "role_id": "d2bd2082-ad03-11e8-aa06-000c29358ad6",
+      "role_name": "admin",
+      "resource_type": "admin-user",
+      "id_pattern": "*",
+      "operations": ["create", "edit", "delete", "toggle", "reset-password"]
+    },
+    {
+      "role_id": "d2bd2082-ad03-11e8-aa06-000c29358ad6",
+      "role_name": "admin",
+      "resource_type": "admin-dept",
+      "id_pattern": "*",
+      "operations": ["create", "edit", "delete", "members"]
+    },
+
+    {
+      "role_id": "d8998f72-ad03-11e8-aa06-000c29358ad6",
+      "role_name": "security",
+      "resource_type": "safe_admin",
+      "id_pattern": "console",
+      "operations": ["manage"]
+    },
+    {
+      "role_id": "d8998f72-ad03-11e8-aa06-000c29358ad6",
+      "role_name": "security",
+      "resource_type": "admin-role",
+      "id_pattern": "*",
+      "operations": ["create", "edit", "delete", "members"]
+    },
+    {
+      "role_id": "d8998f72-ad03-11e8-aa06-000c29358ad6",
+      "role_name": "security",
+      "resource_type": "admin-authz",
+      "id_pattern": "*",
+      "operations": ["grant", "revoke"]
+    },
+    {
+      "role_id": "d8998f72-ad03-11e8-aa06-000c29358ad6",
+      "role_name": "security",
+      "resource_type": "admin-user",
+      "id_pattern": "*",
+      "operations": ["edit", "toggle", "reset-password"]
+    },
+
+    {
+      "role_id": "def246f2-ad03-11e8-aa06-000c29358ad6",
+      "role_name": "audit",
+      "resource_type": "safe_admin",
+      "id_pattern": "console",
+      "operations": ["manage"]
+    },
+    {
+      "role_id": "def246f2-ad03-11e8-aa06-000c29358ad6",
+      "role_name": "audit",
+      "resource_type": "admin-audit",
+      "id_pattern": "*",
+      "operations": ["view"]
+    },
+
+    {
       "role_id": "1572fb82-526f-11f0-bde6-e674ec8dde71",
-      "role_name": "应用管理员",
+      "role_name": "network_builder",
+      "resource_type": "catalog",
+      "id_pattern": "*",
+      "operations": ["view_detail", "create", "modify", "delete", "authorize", "task_manage"]
+    },
+    {
+      "role_id": "1572fb82-526f-11f0-bde6-e674ec8dde71",
+      "role_name": "network_builder",
+      "resource_type": "resource",
+      "id_pattern": "*",
+      "operations": ["view_detail", "create", "modify", "delete", "authorize", "task_manage"]
+    },
+    {
+      "role_id": "1572fb82-526f-11f0-bde6-e674ec8dde71",
+      "role_name": "network_builder",
+      "resource_type": "connector_type",
+      "id_pattern": "*",
+      "operations": ["view_detail", "create", "modify", "delete", "authorize", "task_manage"]
+    },
+    {
+      "role_id": "1572fb82-526f-11f0-bde6-e674ec8dde71",
+      "role_name": "network_builder",
+      "resource_type": "knowledge_network",
+      "id_pattern": "*",
+      "operations": ["view_detail", "create", "modify", "delete", "data_query", "authorize", "task_manage"]
+    },
+    {
+      "role_id": "1572fb82-526f-11f0-bde6-e674ec8dde71",
+      "role_name": "network_builder",
+      "resource_type": "stream_data_pipeline",
+      "id_pattern": "*",
+      "operations": ["view_detail", "create", "modify", "delete", "authorize"]
+    },
+    {
+      "role_id": "1572fb82-526f-11f0-bde6-e674ec8dde71",
+      "role_name": "network_builder",
+      "resource_type": "operator",
+      "id_pattern": "*",
+      "operations": ["create", "modify", "delete", "view", "publish", "unpublish", "authorize", "public_access", "execute"]
+    },
+    {
+      "role_id": "1572fb82-526f-11f0-bde6-e674ec8dde71",
+      "role_name": "network_builder",
+      "resource_type": "skill",
+      "id_pattern": "*",
+      "operations": ["create", "modify", "delete", "view", "publish", "unpublish", "authorize", "public_access", "execute"]
+    },
+    {
+      "role_id": "1572fb82-526f-11f0-bde6-e674ec8dde71",
+      "role_name": "network_builder",
+      "resource_type": "mcp",
+      "id_pattern": "*",
+      "operations": ["create", "modify", "delete", "view", "publish", "unpublish", "authorize", "public_access", "execute"]
+    },
+    {
+      "role_id": "1572fb82-526f-11f0-bde6-e674ec8dde71",
+      "role_name": "network_builder",
+      "resource_type": "tool_box",
+      "id_pattern": "*",
+      "operations": ["create", "modify", "delete", "view", "publish", "unpublish", "authorize", "public_access", "execute"]
+    },
+    {
+      "role_id": "1572fb82-526f-11f0-bde6-e674ec8dde71",
+      "role_name": "network_builder",
+      "resource_type": "small_model",
+      "id_pattern": "*",
+      "operations": ["create", "display", "modify", "delete", "execute"]
+    },
+    {
+      "role_id": "1572fb82-526f-11f0-bde6-e674ec8dde71",
+      "role_name": "network_builder",
+      "resource_type": "large_model",
+      "id_pattern": "*",
+      "operations": ["create", "display", "modify", "delete", "execute"]
+    },
+    {
+      "role_id": "1572fb82-526f-11f0-bde6-e674ec8dde71",
+      "role_name": "network_builder",
       "resource_type": "agent",
       "id_pattern": "*",
       "operations": [
@@ -15,98 +167,81 @@
     },
     {
       "role_id": "1572fb82-526f-11f0-bde6-e674ec8dde71",
-      "role_name": "应用管理员",
+      "role_name": "network_builder",
       "resource_type": "agent_tpl",
       "id_pattern": "*",
       "operations": ["publish", "unpublish", "unpublish_other_user_agent_tpl"]
     },
 
     {
-      "role_id": "00990824-4bf7-11f0-8fa7-865d5643e61f",
-      "role_name": "数据管理员",
+      "role_id": "b5f9ac3e-992c-4bbd-8126-95e87e51c46e",
+      "role_name": "normal_user",
       "resource_type": "catalog",
       "id_pattern": "*",
-      "operations": ["view_detail", "create", "modify", "delete", "authorize", "task_manage"]
+      "operations": ["view_detail"]
     },
     {
-      "role_id": "00990824-4bf7-11f0-8fa7-865d5643e61f",
-      "role_name": "数据管理员",
+      "role_id": "b5f9ac3e-992c-4bbd-8126-95e87e51c46e",
+      "role_name": "normal_user",
       "resource_type": "resource",
       "id_pattern": "*",
-      "operations": ["view_detail", "create", "modify", "delete", "authorize", "task_manage"]
+      "operations": ["view_detail"]
     },
     {
-      "role_id": "00990824-4bf7-11f0-8fa7-865d5643e61f",
-      "role_name": "数据管理员",
-      "resource_type": "connector_type",
-      "id_pattern": "*",
-      "operations": ["view_detail", "create", "modify", "delete", "authorize", "task_manage"]
-    },
-    {
-      "role_id": "00990824-4bf7-11f0-8fa7-865d5643e61f",
-      "role_name": "数据管理员",
+      "role_id": "b5f9ac3e-992c-4bbd-8126-95e87e51c46e",
+      "role_name": "normal_user",
       "resource_type": "knowledge_network",
       "id_pattern": "*",
-      "operations": ["view_detail", "create", "modify", "delete", "data_query", "authorize", "task_manage"]
+      "operations": ["view_detail", "data_query"]
     },
     {
-      "role_id": "00990824-4bf7-11f0-8fa7-865d5643e61f",
-      "role_name": "数据管理员",
-      "resource_type": "stream_data_pipeline",
-      "id_pattern": "*",
-      "operations": ["view_detail", "create", "modify", "delete", "authorize"]
-    },
-
-    {
-      "role_id": "3fb94948-5169-11f0-b662-3a7bdba2913f",
-      "role_name": "AI管理员",
-      "resource_type": "operator",
-      "id_pattern": "*",
-      "operations": ["create", "modify", "delete", "view", "publish", "unpublish", "authorize", "public_access", "execute"]
-    },
-    {
-      "role_id": "3fb94948-5169-11f0-b662-3a7bdba2913f",
-      "role_name": "AI管理员",
-      "resource_type": "skill",
-      "id_pattern": "*",
-      "operations": ["create", "modify", "delete", "view", "publish", "unpublish", "authorize", "public_access", "execute"]
-    },
-    {
-      "role_id": "3fb94948-5169-11f0-b662-3a7bdba2913f",
-      "role_name": "AI管理员",
-      "resource_type": "mcp",
-      "id_pattern": "*",
-      "operations": ["create", "modify", "delete", "view", "publish", "unpublish", "authorize", "public_access", "execute"]
-    },
-    {
-      "role_id": "3fb94948-5169-11f0-b662-3a7bdba2913f",
-      "role_name": "AI管理员",
-      "resource_type": "tool_box",
-      "id_pattern": "*",
-      "operations": ["create", "modify", "delete", "view", "publish", "unpublish", "authorize", "public_access", "execute"]
-    },
-    {
-      "role_id": "3fb94948-5169-11f0-b662-3a7bdba2913f",
-      "role_name": "AI管理员",
+      "role_id": "b5f9ac3e-992c-4bbd-8126-95e87e51c46e",
+      "role_name": "normal_user",
       "resource_type": "small_model",
       "id_pattern": "*",
-      "operations": ["create", "display", "modify", "delete", "execute"]
+      "operations": ["display", "execute"]
     },
     {
-      "role_id": "3fb94948-5169-11f0-b662-3a7bdba2913f",
-      "role_name": "AI管理员",
+      "role_id": "b5f9ac3e-992c-4bbd-8126-95e87e51c46e",
+      "role_name": "normal_user",
       "resource_type": "large_model",
       "id_pattern": "*",
-      "operations": ["create", "display", "modify", "delete", "execute"]
+      "operations": ["display", "execute"]
     },
-
     {
-      "role_id": "7dcfcc9c-ad02-11e8-aa06-000c29358ad6",
-      "role_name": "超级管理员",
-      "resource_type": "",
+      "role_id": "b5f9ac3e-992c-4bbd-8126-95e87e51c46e",
+      "role_name": "normal_user",
+      "resource_type": "operator",
       "id_pattern": "*",
-      "operations": ["*"],
-      "_note": "wildcard: obj '*' matches any type:id (keyMatch), act '*' matches any op. resource_type empty => obj pattern is just '*'."
+      "operations": ["view", "execute"]
+    },
+    {
+      "role_id": "b5f9ac3e-992c-4bbd-8126-95e87e51c46e",
+      "role_name": "normal_user",
+      "resource_type": "skill",
+      "id_pattern": "*",
+      "operations": ["view", "execute"]
+    },
+    {
+      "role_id": "b5f9ac3e-992c-4bbd-8126-95e87e51c46e",
+      "role_name": "normal_user",
+      "resource_type": "mcp",
+      "id_pattern": "*",
+      "operations": ["view", "execute"]
+    },
+    {
+      "role_id": "b5f9ac3e-992c-4bbd-8126-95e87e51c46e",
+      "role_name": "normal_user",
+      "resource_type": "tool_box",
+      "id_pattern": "*",
+      "operations": ["view", "execute"]
+    },
+    {
+      "role_id": "b5f9ac3e-992c-4bbd-8126-95e87e51c46e",
+      "role_name": "normal_user",
+      "resource_type": "agent",
+      "id_pattern": "*",
+      "operations": ["use"]
     }
   ]
 }

--- a/bkn-safe/server/internal/seed/data/role-bindings.json
+++ b/bkn-safe/server/internal/seed/data/role-bindings.json
@@ -1,11 +1,11 @@
 {
-  "_comment": "Accessor -> role bindings (g grouping policy). The admin account UUID 266c6a42... is the identity backend services fall back to for tokenless service-to-service calls (e.g. bkn->vega GetCatalogByID via the internal /in/v1 route, which skips token introspection but still runs resource authz). Binding it to 超级管理员 (wildcard *:* act *) replicates ISF's super-admin grant so internal calls pass FilterResources. UUIDs preserved from ISF (role: roles.json; accessor: bkn ADMIN_ACCOUNT_ID, adp/bkn/bkn-backend/server/interfaces/permission_access.go).",
+  "_comment": "Accessor -> role bindings (g grouping policy). The admin account UUID 266c6a42... is the identity backend services fall back to for tokenless service-to-service calls (e.g. bkn->vega GetCatalogByID via the internal /in/v1 route, which skips token introspection but still runs resource authz). Binding it to super_admin (wildcard *:* act *) keeps internal calls passing FilterResources. UUIDs preserved from ISF (role: roles.json; accessor: bkn ADMIN_ACCOUNT_ID, adp/bkn/bkn-backend/server/interfaces/permission_access.go).",
   "bindings": [
     {
       "accessor_id": "266c6a42-6131-4d62-8f39-853e7093701c",
       "accessor_note": "admin / S2S fallback identity",
       "role_id": "7dcfcc9c-ad02-11e8-aa06-000c29358ad6",
-      "role_name": "超级管理员"
+      "role_name": "super_admin"
     }
   ]
 }

--- a/bkn-safe/server/internal/seed/data/roles.json
+++ b/bkn-safe/server/internal/seed/data/roles.json
@@ -1,11 +1,8 @@
 [
-  {"id": "7dcfcc9c-ad02-11e8-aa06-000c29358ad6", "name": "超级管理员", "description": "超级管理员(supper)", "source": "system"},
-  {"id": "d2bd2082-ad03-11e8-aa06-000c29358ad6", "name": "系统管理员", "description": "系统管理员(admin)", "source": "system"},
-  {"id": "d8998f72-ad03-11e8-aa06-000c29358ad6", "name": "安全管理员", "description": "安全管理员(security)", "source": "system"},
-  {"id": "def246f2-ad03-11e8-aa06-000c29358ad6", "name": "审计管理员", "description": "审计管理员(audit)", "source": "system"},
-  {"id": "e63e1c88-ad03-11e8-aa06-000c29358ad6", "name": "组织管理员", "description": "组织管理员(organization manager)", "source": "system"},
-  {"id": "f06ac18e-ad03-11e8-aa06-000c29358ad6", "name": "组织审计员", "description": "组织审计员(organization audit)", "source": "system"},
-  {"id": "00990824-4bf7-11f0-8fa7-865d5643e61f", "name": "数据管理员", "description": "主要管理多模态数据湖、本体引擎、以及Dataflow中数据处理流模块", "source": "business"},
-  {"id": "3fb94948-5169-11f0-b662-3a7bdba2913f", "name": "AI管理员", "description": "主要管理Dataflow中逻辑和行动下所有资源，可接入及训练模型", "source": "business"},
-  {"id": "1572fb82-526f-11f0-bde6-e674ec8dde71", "name": "应用管理员", "description": "可创建系统智能体和自定义空间，可发布智能体和智能体模版、管理内置智能体等", "source": "business"}
+  {"id": "7dcfcc9c-ad02-11e8-aa06-000c29358ad6", "name": "super_admin", "description": "超级管理员：内置隐藏 / 受控，平台全量权限，人数极少", "source": "system"},
+  {"id": "d2bd2082-ad03-11e8-aa06-000c29358ad6", "name": "admin", "description": "系统管理员：系统运行维护、用户 / 部门基础管理", "source": "system"},
+  {"id": "d8998f72-ad03-11e8-aa06-000c29358ad6", "name": "security", "description": "安全管理员：角色管理、授权管理、账号安全管理", "source": "system"},
+  {"id": "def246f2-ad03-11e8-aa06-000c29358ad6", "name": "audit", "description": "审计管理员：审计日志、权限配置审查、管理行为监督", "source": "system"},
+  {"id": "1572fb82-526f-11f0-bde6-e674ec8dde71", "name": "network_builder", "description": "业务网络构建者：数据连接、数据目录、知识网络、模型资源、执行工厂的业务建设", "source": "business"},
+  {"id": "b5f9ac3e-992c-4bbd-8126-95e87e51c46e", "name": "normal_user", "description": "普通用户：各模块查看、查询、执行与调用，不含创建、编辑、删除、发布、授权", "source": "business"}
 ]

--- a/bkn-safe/server/internal/seed/matrix_test.go
+++ b/bkn-safe/server/internal/seed/matrix_test.go
@@ -10,11 +10,10 @@ import (
 	"bkn-safe/internal/authz"
 )
 
-// TestRoleResourceMatrix is the authz equivalence / no-leak proof: for every
-// business role × every resource type, a user bound to that role is allowed a
-// representative op IFF the type is in the role's agreed domain — and denied
-// everywhere else (no cross-domain leakage). Super-admin allows everything; an
-// unroled user allows nothing. This pins the full seeded authorization model.
+// TestRoleResourceMatrix is the authz equivalence / no-leak proof: default
+// business roles only get their intended resource/action domain. Super-admin
+// allows everything; an unroled user allows nothing. This pins the full seeded
+// authorization model.
 func TestRoleResourceMatrix(t *testing.T) {
 	db := newDB(t)
 	e, err := authz.New(db)
@@ -26,18 +25,11 @@ func TestRoleResourceMatrix(t *testing.T) {
 	}
 
 	const (
-		appAdmin   = "1572fb82-526f-11f0-bde6-e674ec8dde71"
-		dataAdmin  = "00990824-4bf7-11f0-8fa7-865d5643e61f"
-		aiAdmin    = "3fb94948-5169-11f0-b662-3a7bdba2913f"
-		superAdmin = "7dcfcc9c-ad02-11e8-aa06-000c29358ad6"
+		networkBuilder = "1572fb82-526f-11f0-bde6-e674ec8dde71"
+		normalUser     = "b5f9ac3e-992c-4bbd-8126-95e87e51c46e"
+		superAdmin     = "7dcfcc9c-ad02-11e8-aa06-000c29358ad6"
 	)
 
-	// agreed role -> resource-type domain.
-	domain := map[string]map[string]bool{
-		appAdmin:  set("agent", "agent_tpl"),
-		dataAdmin: set("catalog", "resource", "connector_type", "knowledge_network", "stream_data_pipeline"),
-		aiAdmin:   set("operator", "skill", "mcp", "tool_box", "small_model"),
-	}
 	// a representative, granted op per resource type (positive case uses these).
 	repOp := map[string]string{
 		"agent": "use", "agent_tpl": "publish",
@@ -46,26 +38,43 @@ func TestRoleResourceMatrix(t *testing.T) {
 		"tool_box": "execute", "mcp": "execute", "operator": "execute", "skill": "execute",
 		"small_model": "execute",
 	}
+	roleAllowed := map[string]map[string]string{
+		networkBuilder: repOp,
+		normalUser: {
+			"agent":             "use",
+			"catalog":           "view_detail",
+			"resource":          "view_detail",
+			"knowledge_network": "data_query",
+			"tool_box":          "execute",
+			"mcp":               "execute",
+			"operator":          "execute",
+			"skill":             "execute",
+			"small_model":       "execute",
+		},
+	}
 	allTypes := make([]string, 0, len(repOp))
 	for tpe := range repOp {
 		allTypes = append(allTypes, tpe)
 	}
 
 	// Each role's user; plus super-admin and an unroled user.
-	roles := []string{appAdmin, dataAdmin, aiAdmin}
+	roles := []string{networkBuilder, normalUser}
 	for _, role := range roles {
 		user := "u-" + role
 		if err := e.AssignRole(user, role); err != nil {
 			t.Fatal(err)
 		}
 		for _, tpe := range allTypes {
-			want := domain[role][tpe]
-			got, err := e.Check(user, tpe, "inst-1", repOp[tpe])
+			op, want := roleAllowed[role][tpe]
+			if !want {
+				op = repOp[tpe]
+			}
+			got, err := e.Check(user, tpe, "inst-1", op)
 			if err != nil {
 				t.Fatal(err)
 			}
 			if got != want {
-				t.Errorf("role=%s type=%s op=%s: got allow=%v, want %v (domain=%v)", role, tpe, repOp[tpe], got, want, domain[role][tpe])
+				t.Errorf("role=%s type=%s op=%s: got allow=%v, want %v", role, tpe, op, got, want)
 			}
 		}
 	}
@@ -90,12 +99,4 @@ func TestRoleResourceMatrix(t *testing.T) {
 			t.Errorf("unroled user must be denied %s:%s", tpe, repOp[tpe])
 		}
 	}
-}
-
-func set(xs ...string) map[string]bool {
-	m := make(map[string]bool, len(xs))
-	for _, x := range xs {
-		m[x] = true
-	}
-	return m
 }

--- a/bkn-safe/server/internal/seed/seed.go
+++ b/bkn-safe/server/internal/seed/seed.go
@@ -36,6 +36,13 @@ const (
 	adminAccount = "admin"
 )
 
+var deprecatedSeedRoleIDs = []string{
+	"e63e1c88-ad03-11e8-aa06-000c29358ad6", // 组织管理员
+	"f06ac18e-ad03-11e8-aa06-000c29358ad6", // 组织审计员
+	"00990824-4bf7-11f0-8fa7-865d5643e61f", // 数据管理员
+	"3fb94948-5169-11f0-b662-3a7bdba2913f", // AI管理员
+}
+
 // AdminUserID is the built-in admin user's id, exported so callers can protect
 // it — the user-admin API refuses to delete or disable it (deleting the only
 // super-admin would lock everyone out). Same UUID as the S2S fallback identity.
@@ -95,6 +102,9 @@ func Apply(db *gorm.DB, enforcer *authz.Enforcer) error {
 	}
 	if err := seedCatalog(db); err != nil {
 		return fmt.Errorf("seed catalog: %w", err)
+	}
+	if err := reconcileSeedRoles(db, enforcer); err != nil {
+		return fmt.Errorf("reconcile seed roles: %w", err)
 	}
 	if err := seedGrants(enforcer); err != nil {
 		return fmt.Errorf("seed grants: %w", err)
@@ -165,6 +175,29 @@ func seedRoles(db *gorm.DB) error {
 		Columns:   []clause.Column{{Name: "id"}},
 		DoUpdates: clause.AssignmentColumns([]string{"name", "description", "source"}),
 	}).Create(&rows).Error
+}
+
+func reconcileSeedRoles(db *gorm.DB, enforcer *authz.Enforcer) error {
+	var roles []roleSeed
+	if err := json.Unmarshal(rolesJSON, &roles); err != nil {
+		return err
+	}
+
+	for _, r := range roles {
+		if err := enforcer.RemoveRolePermissions(r.ID); err != nil {
+			return err
+		}
+	}
+
+	for _, roleID := range deprecatedSeedRoleIDs {
+		if err := enforcer.RemoveRoleCompletely(roleID); err != nil {
+			return err
+		}
+		if err := db.Delete(&model.Role{}, "id = ?", roleID).Error; err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 func seedCatalog(db *gorm.DB) error {

--- a/bkn-safe/server/internal/seed/seed_test.go
+++ b/bkn-safe/server/internal/seed/seed_test.go
@@ -28,7 +28,7 @@ func newDB(t *testing.T) *gorm.DB {
 }
 
 // TestApplySeedsRolesCatalogGrants verifies the central seed lands roles + the
-// catalog and that the app-admin grant makes a real decision pass.
+// catalog and that the network-builder grant makes a real decision pass.
 func TestApplySeedsRolesCatalogGrants(t *testing.T) {
 	db := newDB(t)
 	e, err := authz.New(db)
@@ -39,41 +39,51 @@ func TestApplySeedsRolesCatalogGrants(t *testing.T) {
 		t.Fatalf("apply seed: %v", err)
 	}
 
-	// 9 roles, with the preserved business UUIDs present.
+	// 6 Studio roles, with the preserved three-admin UUIDs present.
 	var roleCount int64
 	db.Model(&model.Role{}).Count(&roleCount)
-	if roleCount != 9 {
-		t.Errorf("role count = %d, want 9", roleCount)
+	if roleCount != 6 {
+		t.Errorf("role count = %d, want 6", roleCount)
 	}
-	for _, id := range []string{
-		"1572fb82-526f-11f0-bde6-e674ec8dde71", // 应用管理员
-		"00990824-4bf7-11f0-8fa7-865d5643e61f", // 数据管理员
-		"3fb94948-5169-11f0-b662-3a7bdba2913f", // AI管理员
+	for id, name := range map[string]string{
+		"7dcfcc9c-ad02-11e8-aa06-000c29358ad6": "super_admin",
+		"d2bd2082-ad03-11e8-aa06-000c29358ad6": "admin",
+		"d8998f72-ad03-11e8-aa06-000c29358ad6": "security",
+		"def246f2-ad03-11e8-aa06-000c29358ad6": "audit",
+		"1572fb82-526f-11f0-bde6-e674ec8dde71": "network_builder",
+		"b5f9ac3e-992c-4bbd-8126-95e87e51c46e": "normal_user",
 	} {
 		var r model.Role
 		if err := db.First(&r, "id = ?", id).Error; err != nil {
 			t.Errorf("preserved role %s missing: %v", id, err)
 		}
+		if r.Name != name {
+			t.Errorf("role %s name = %q, want %q", id, r.Name, name)
+		}
 	}
 
-	// agent resource type + its operations seeded.
+	// agent and Studio admin resource types + their operations seeded.
 	var opCount int64
 	db.Model(&model.Operation{}).Where("resource_type_id = ?", "agent").Count(&opCount)
 	if opCount == 0 {
 		t.Error("expected agent operations seeded")
 	}
+	db.Model(&model.Operation{}).Where("resource_type_id = ?", "admin-user").Count(&opCount)
+	if opCount == 0 {
+		t.Error("expected admin-user operations seeded")
+	}
 
-	// app-admin grant works: a user bound to the role can use an agent.
+	// network_builder grant works: a user bound to the role can create business resources.
 	const user = "u-1"
 	if err := e.AssignRole(user, "1572fb82-526f-11f0-bde6-e674ec8dde71"); err != nil {
 		t.Fatal(err)
 	}
-	ok, err := e.Check(user, "agent", "any-agent-id", "use")
+	ok, err := e.Check(user, "knowledge_network", "kn-1", "create")
 	if err != nil {
 		t.Fatal(err)
 	}
 	if !ok {
-		t.Error("app-admin should be able to use agent:* after seed")
+		t.Error("network_builder should be able to create knowledge networks after seed")
 	}
 }
 
@@ -90,23 +100,32 @@ func TestSeededRoleGrants(t *testing.T) {
 	}
 
 	const (
-		appAdmin   = "1572fb82-526f-11f0-bde6-e674ec8dde71"
-		dataAdmin  = "00990824-4bf7-11f0-8fa7-865d5643e61f"
-		aiAdmin    = "3fb94948-5169-11f0-b662-3a7bdba2913f"
-		superAdmin = "7dcfcc9c-ad02-11e8-aa06-000c29358ad6"
+		superAdmin     = "7dcfcc9c-ad02-11e8-aa06-000c29358ad6"
+		admin          = "d2bd2082-ad03-11e8-aa06-000c29358ad6"
+		security       = "d8998f72-ad03-11e8-aa06-000c29358ad6"
+		audit          = "def246f2-ad03-11e8-aa06-000c29358ad6"
+		networkBuilder = "1572fb82-526f-11f0-bde6-e674ec8dde71"
+		normalUser     = "b5f9ac3e-992c-4bbd-8126-95e87e51c46e"
 	)
 	cases := []struct {
 		name, role, typ, id, op string
 		want                    bool
 	}{
-		{"app-admin uses agent", appAdmin, "agent", "x", "use", true},
-		{"app-admin not catalog", appAdmin, "catalog", "x", "create", false},
-		{"data-admin manages catalog", dataAdmin, "catalog", "x", "create", true},
-		{"data-admin manages knowledge_network", dataAdmin, "knowledge_network", "kn1", "data_query", true},
-		{"data-admin not operator", dataAdmin, "operator", "o1", "execute", false},
-		{"ai-admin manages operator", aiAdmin, "operator", "o1", "execute", true},
-		{"ai-admin manages skill", aiAdmin, "skill", "s1", "publish", true},
-		{"ai-admin not catalog", aiAdmin, "catalog", "x", "create", false},
+		{"admin manages users", admin, "admin-user", "x", "create", true},
+		{"admin not role grant", admin, "admin-authz", "x", "grant", false},
+		{"security manages roles", security, "admin-role", "x", "create", true},
+		{"security can reset password", security, "admin-user", "x", "reset-password", true},
+		{"security not audit", security, "admin-audit", "x", "view", false},
+		{"audit views audit logs", audit, "admin-audit", "x", "view", true},
+		{"audit not user edit", audit, "admin-user", "x", "edit", false},
+		{"network-builder manages catalog", networkBuilder, "catalog", "x", "create", true},
+		{"network-builder manages skill", networkBuilder, "skill", "s1", "publish", true},
+		{"network-builder not system users", networkBuilder, "admin-user", "x", "create", false},
+		{"normal-user can query knowledge", normalUser, "knowledge_network", "kn1", "data_query", true},
+		{"normal-user can execute skill", normalUser, "skill", "s1", "execute", true},
+		{"normal-user can use agent", normalUser, "agent", "a1", "use", true},
+		{"normal-user cannot create catalog", normalUser, "catalog", "x", "create", false},
+		{"normal-user cannot publish skill", normalUser, "skill", "s1", "publish", false},
 		{"super-admin does anything (agent)", superAdmin, "agent", "x", "use", true},
 		{"super-admin does anything (any type/op)", superAdmin, "whatever", "z", "some_random_op", true},
 	}
@@ -194,7 +213,90 @@ func TestApplyIdempotent(t *testing.T) {
 	}
 	var roleCount int64
 	db.Model(&model.Role{}).Count(&roleCount)
-	if roleCount != 9 {
-		t.Errorf("role count after re-seed = %d, want 9", roleCount)
+	if roleCount != 6 {
+		t.Errorf("role count after re-seed = %d, want 6", roleCount)
+	}
+}
+
+func TestApplyReconcilesDeprecatedSeedRoles(t *testing.T) {
+	db := newDB(t)
+	e, err := authz.New(db)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	const (
+		deprecatedDataAdmin = "00990824-4bf7-11f0-8fa7-865d5643e61f"
+		user                = "u-legacy"
+	)
+	if err := db.Create(&model.Role{
+		ID:          deprecatedDataAdmin,
+		Name:        "数据管理员",
+		Description: "legacy seeded role",
+		Source:      model.RoleSourceBusiness,
+	}).Error; err != nil {
+		t.Fatal(err)
+	}
+	if err := e.AssignRole(user, deprecatedDataAdmin); err != nil {
+		t.Fatal(err)
+	}
+	if err := e.GrantRolePermission(deprecatedDataAdmin, "catalog", "*", "create"); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := Apply(db, e); err != nil {
+		t.Fatalf("apply: %v", err)
+	}
+
+	var count int64
+	if err := db.Model(&model.Role{}).Where("id = ?", deprecatedDataAdmin).Count(&count).Error; err != nil {
+		t.Fatal(err)
+	}
+	if count != 0 {
+		t.Fatalf("deprecated role still exists after seed reconcile")
+	}
+	if ok, err := e.Check(user, "catalog", "c1", "create"); err != nil {
+		t.Fatal(err)
+	} else if ok {
+		t.Fatal("deprecated role binding/grant still allows catalog create")
+	}
+}
+
+func TestApplyReconcilesCurrentSeedRoleGrants(t *testing.T) {
+	db := newDB(t)
+	e, err := authz.New(db)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	const (
+		normalUserRole = "b5f9ac3e-992c-4bbd-8126-95e87e51c46e"
+		user           = "u-stale-grant"
+	)
+	if err := e.AssignRole(user, normalUserRole); err != nil {
+		t.Fatal(err)
+	}
+	if err := e.GrantRolePermission(normalUserRole, "admin-user", "*", "create"); err != nil {
+		t.Fatal(err)
+	}
+	if ok, err := e.Check(user, "admin-user", "u1", "create"); err != nil {
+		t.Fatal(err)
+	} else if !ok {
+		t.Fatal("test setup failed: stale grant did not take effect")
+	}
+
+	if err := Apply(db, e); err != nil {
+		t.Fatalf("apply: %v", err)
+	}
+
+	if ok, err := e.Check(user, "admin-user", "u1", "create"); err != nil {
+		t.Fatal(err)
+	} else if ok {
+		t.Fatal("stale current-role grant still allows admin-user create")
+	}
+	if ok, err := e.Check(user, "catalog", "c1", "view_detail"); err != nil {
+		t.Fatal(err)
+	} else if !ok {
+		t.Fatal("normal_user desired grant was not restored after reconcile")
 	}
 }


### PR DESCRIPTION
关联 issue：openbkn-ai/bkn-studio#118

## 处理内容
- 将 bkn-safe seed 的标准角色调整为 6 个 Studio 角色：`super_admin`、`admin`、`security`、`audit`、`network_builder`、`normal_user`。
- 更新角色默认授权矩阵，按三员职责和业务角色拆分系统管理、授权管理、审计、业务建设和普通调用权限。
- 内置 admin 默认保留 `super_admin` 绑定。
- 增加 seed reconcile：重置标准角色默认权限，并清理旧内置角色及其 Casbin 绑定/授权。
- 补充旧角色清理、现存标准角色旧 grant 清理和新授权恢复的回归测试。

## 冲突检查
- 已执行 `git fetch origin main`。
- 已执行 `git merge-tree --write-tree HEAD origin/main`，结果：无冲突。

## 验证
- `go test ./internal/seed ./internal/authz -count=1`

## 注意
- 替换已安装环境的 bkn-safe 镜像后，seed 会更新角色/权限数据。
- 旧角色用户需要重新分配到新角色，或后续补充旧角色绑定迁移。