### PR TITLE
fix(execution-factory): implement bkn-safe ResourceList (#188)

### DIFF
--- a/adp/execution-factory/operator-integration/server/drivenadapters/authorization_safe.go
+++ b/adp/execution-factory/operator-integration/server/drivenadapters/authorization_safe.go
@@ -11,6 +11,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/url"
 	"os"
 	"time"
 
@@ -26,8 +27,7 @@ import (
 // BKN_SAFE_URL points at bkn-safe (e.g. http://bkn-safe:3000) for shadow/bkn-safe.
 //
 // safeAuthorization implements interfaces.Authorization against bkn-safe's clean
-// API (/api/safe/v1/authz/*). ResourceList has no business caller in exec-factory
-// (only ResourceFilterIDs is used), so it returns empty.
+// API (/api/safe/v1/authz/*).
 
 type safeAuthorization struct {
 	baseURL string
@@ -89,11 +89,87 @@ func (s *safeAuthorization) ResourceFilter(ctx context.Context, req *interfaces.
 	return out, nil
 }
 
-// ResourceList has no business caller in exec-factory (services enumerate their
-// own resources and filter via ResourceFilter). Return empty.
+// ResourceList enumerates resource-instance IDs the accessor may perform every
+// requested operation on. Type-wide grants (type:*) surface as ResourceIDAll;
+// multi-op requests intersect per-op enumerations (AND semantics).
 func (s *safeAuthorization) ResourceList(ctx context.Context, req *interfaces.ResourceListRequest) ([]*interfaces.AuthResourceResult, error) {
-	s.logger.WithContext(ctx).Debugf("[bkn-safe] ResourceList not implemented (unused); returning empty")
-	return []*interfaces.AuthResourceResult{}, nil
+	if req == nil || req.Accessor == nil || req.Resource == nil || len(req.Operation) == 0 {
+		return []*interfaces.AuthResourceResult{}, nil
+	}
+
+	ok, err := s.allowedAll(ctx, req.Accessor.ID, req.Resource.Type, interfaces.ResourceIDAll, req.Operation)
+	if err != nil {
+		return nil, err
+	}
+	if ok {
+		return []*interfaces.AuthResourceResult{{ID: interfaces.ResourceIDAll}}, nil
+	}
+
+	ids, err := s.accessibleResourceIDsAllOps(ctx, req.Accessor.ID, req.Resource.Type, req.Operation)
+	if err != nil {
+		return nil, err
+	}
+	out := make([]*interfaces.AuthResourceResult, 0, len(ids))
+	for _, id := range ids {
+		out = append(out, &interfaces.AuthResourceResult{ID: id})
+	}
+	return out, nil
+}
+
+func (s *safeAuthorization) accessibleResourceIDs(ctx context.Context, accessorID, rtype, op string) ([]string, error) {
+	var out struct {
+		IDs []string `json:"ids"`
+	}
+	q := url.Values{
+		"accessor_id":   {accessorID},
+		"resource_type": {rtype},
+		"operation":     {op},
+	}
+	if err := s.get(ctx, "/api/safe/v1/authz/resources", q, &out); err != nil {
+		return nil, err
+	}
+	return out.IDs, nil
+}
+
+func (s *safeAuthorization) accessibleResourceIDsAllOps(ctx context.Context, accessorID, rtype string, ops []interfaces.AuthOperationType) ([]string, error) {
+	ids, err := s.accessibleResourceIDs(ctx, accessorID, rtype, string(ops[0]))
+	if err != nil {
+		return nil, err
+	}
+	for _, op := range ops[1:] {
+		next, err := s.accessibleResourceIDs(ctx, accessorID, rtype, string(op))
+		if err != nil {
+			return nil, err
+		}
+		ids = intersectStringSlices(ids, next)
+		if len(ids) == 0 {
+			break
+		}
+	}
+	return ids, nil
+}
+
+func intersectStringSlices(a, b []string) []string {
+	if len(a) == 0 || len(b) == 0 {
+		return []string{}
+	}
+	set := make(map[string]struct{}, len(a))
+	for _, id := range a {
+		set[id] = struct{}{}
+	}
+	out := make([]string, 0, len(b))
+	seen := make(map[string]struct{}, len(b))
+	for _, id := range b {
+		if _, ok := set[id]; !ok {
+			continue
+		}
+		if _, dup := seen[id]; dup {
+			continue
+		}
+		seen[id] = struct{}{}
+		out = append(out, id)
+	}
+	return out
 }
 
 // CreatePolicy grants each accessor the allowed ops on its resource instance.
@@ -130,6 +206,29 @@ func (s *safeAuthorization) DeletePolicy(ctx context.Context, req *interfaces.Au
 
 func (s *safeAuthorization) post(ctx context.Context, path string, body, out any) error {
 	return s.do(ctx, http.MethodPost, path, body, out)
+}
+func (s *safeAuthorization) get(ctx context.Context, path string, query url.Values, out any) error {
+	target := s.baseURL + path
+	if len(query) > 0 {
+		target += "?" + query.Encode()
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, target, nil)
+	if err != nil {
+		return err
+	}
+	resp, err := s.http.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	data, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return fmt.Errorf("bkn-safe GET %s: %d: %s", path, resp.StatusCode, data)
+	}
+	if out != nil && len(data) > 0 {
+		return json.Unmarshal(data, out)
+	}
+	return nil
 }
 func (s *safeAuthorization) del(ctx context.Context, path string, body any) error {
 	return s.do(ctx, http.MethodDelete, path, body, nil)

--- a/adp/execution-factory/operator-integration/server/drivenadapters/authorization_safe_integration_test.go
+++ b/adp/execution-factory/operator-integration/server/drivenadapters/authorization_safe_integration_test.go
@@ -8,7 +8,8 @@
 // Run: BKN_SAFE_URL=http://127.0.0.1:13000 go test -tags integration ./drivenadapters/ -run SafeAuthz -v
 // Skipped unless BKN_SAFE_URL is set. Exercises the full Authorization interface
 // exec-factory relies on — grant (CreatePolicy/CreateOwnerPolicy), decide
-// (OperationCheck AND-semantics), filter (ResourceFilter), revoke (DeletePolicy).
+// (OperationCheck AND-semantics), filter (ResourceFilter), list (ResourceList),
+// revoke (DeletePolicy).
 package drivenadapters
 
 import (
@@ -102,7 +103,21 @@ func TestSafeAuthzEndToEnd(t *testing.T) {
 		t.Errorf("ResourceFilter = %v, want [tb1]", res)
 	}
 
-	// 5. revoke -> denied again
+	// 5. ResourceList returns the granted toolbox for view
+	listRes, err := s.ResourceList(ctx, &interfaces.ResourceListRequest{
+		Accessor:  acc,
+		Resource:  &interfaces.AuthResource{Type: rtype},
+		Operation: []interfaces.AuthOperationType{interfaces.AuthOperationTypeView},
+		Method:    interfaces.AuthMethodGet,
+	})
+	if err != nil {
+		t.Fatalf("ResourceList: %v", err)
+	}
+	if len(listRes) != 1 || listRes[0].ID != tb1 {
+		t.Errorf("ResourceList = %v, want [%s]", listRes, tb1)
+	}
+
+	// 6. revoke -> denied again
 	if err := s.DeletePolicy(ctx, &interfaces.AuthDeletePolicyRequest{
 		Method: interfaces.AuthMethodGet, Resources: []*interfaces.AuthResource{{ID: tb1, Type: rtype}},
 	}); err != nil {
@@ -112,5 +127,5 @@ func TestSafeAuthzEndToEnd(t *testing.T) {
 		t.Error("execute should be denied after DeletePolicy")
 	}
 
-	t.Log("bkn-safe authz adapter: grant -> check(AND) -> filter -> revoke all OK")
+	t.Log("bkn-safe authz adapter: grant -> check(AND) -> filter -> list -> revoke all OK")
 }

--- a/adp/execution-factory/operator-integration/server/drivenadapters/authorization_safe_test.go
+++ b/adp/execution-factory/operator-integration/server/drivenadapters/authorization_safe_test.go
@@ -1,0 +1,133 @@
+// Copyright openbkn.ai
+//
+// Licensed under the OpenBKN License. See LICENSE-OPENBKN.txt in the project root.
+
+package drivenadapters
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/openbkn-ai/adp/execution-factory/operator-integration/server/interfaces"
+)
+
+// fakeAuthz serves the bkn-safe authz endpoints the adapter uses.
+func fakeAuthz(t *testing.T) *httptest.Server {
+	t.Helper()
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/safe/v1/authz/check", func(w http.ResponseWriter, r *http.Request) {
+		var req struct {
+			AccessorID string `json:"accessor_id"`
+			Resource   struct {
+				Type string `json:"type"`
+				ID   string `json:"id"`
+			} `json:"resource"`
+			Operation string `json:"operation"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+		allowed := req.AccessorID == "admin" &&
+			req.Resource.Type == "skill" &&
+			req.Resource.ID == interfaces.ResourceIDAll &&
+			req.Operation == "view"
+		_ = json.NewEncoder(w).Encode(map[string]bool{"allowed": allowed})
+	})
+	mux.HandleFunc("/api/safe/v1/authz/resources", func(w http.ResponseWriter, r *http.Request) {
+		accessorID := r.URL.Query().Get("accessor_id")
+		rtype := r.URL.Query().Get("resource_type")
+		op := r.URL.Query().Get("operation")
+		var ids []string
+		switch {
+		case accessorID == "u1" && rtype == "skill" && op == "view":
+			ids = []string{"s1", "s2"}
+		case accessorID == "u1" && rtype == "skill" && op == "modify":
+			ids = []string{"s1", "s3"}
+		case accessorID == "u2" && rtype == "skill" && op == "view":
+			ids = []string{"s9"}
+		default:
+			ids = []string{}
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{"ids": ids})
+	})
+	return httptest.NewServer(mux)
+}
+
+func TestSafeAuthorizationResourceList(t *testing.T) {
+	srv := fakeAuthz(t)
+	defer srv.Close()
+	ctx := context.Background()
+	s := newSafeAuthorization(srv.URL, testLogger{})
+
+	t.Run("single operation returns accessible IDs", func(t *testing.T) {
+		res, err := s.ResourceList(ctx, &interfaces.ResourceListRequest{
+			Accessor: &interfaces.AuthAccessor{ID: "u1"},
+			Resource: &interfaces.AuthResource{Type: "skill"},
+			Operation: []interfaces.AuthOperationType{interfaces.AuthOperationTypeView},
+		})
+		if err != nil {
+			t.Fatalf("ResourceList: %v", err)
+		}
+		if len(res) != 2 || res[0].ID != "s1" || res[1].ID != "s2" {
+			t.Fatalf("ResourceList = %+v, want [s1 s2]", res)
+		}
+	})
+
+	t.Run("multi operation intersects IDs", func(t *testing.T) {
+		res, err := s.ResourceList(ctx, &interfaces.ResourceListRequest{
+			Accessor: &interfaces.AuthAccessor{ID: "u1"},
+			Resource: &interfaces.AuthResource{Type: "skill"},
+			Operation: []interfaces.AuthOperationType{
+				interfaces.AuthOperationTypeView,
+				interfaces.AuthOperationTypeModify,
+			},
+		})
+		if err != nil {
+			t.Fatalf("ResourceList: %v", err)
+		}
+		if len(res) != 1 || res[0].ID != "s1" {
+			t.Fatalf("ResourceList = %+v, want [s1]", res)
+		}
+	})
+
+	t.Run("type-wide grant returns ResourceIDAll", func(t *testing.T) {
+		res, err := s.ResourceList(ctx, &interfaces.ResourceListRequest{
+			Accessor: &interfaces.AuthAccessor{ID: "admin"},
+			Resource: &interfaces.AuthResource{Type: "skill"},
+			Operation: []interfaces.AuthOperationType{interfaces.AuthOperationTypeView},
+		})
+		if err != nil {
+			t.Fatalf("ResourceList: %v", err)
+		}
+		if len(res) != 1 || res[0].ID != interfaces.ResourceIDAll {
+			t.Fatalf("ResourceList = %+v, want [*]", res)
+		}
+	})
+
+	t.Run("empty operations returns empty", func(t *testing.T) {
+		res, err := s.ResourceList(ctx, &interfaces.ResourceListRequest{
+			Accessor: &interfaces.AuthAccessor{ID: "u1"},
+			Resource: &interfaces.AuthResource{Type: "skill"},
+		})
+		if err != nil {
+			t.Fatalf("ResourceList: %v", err)
+		}
+		if len(res) != 0 {
+			t.Fatalf("ResourceList = %+v, want []", res)
+		}
+	})
+}
+
+func TestIntersectStringSlices(t *testing.T) {
+	got := intersectStringSlices([]string{"a", "b", "c"}, []string{"b", "c", "d"})
+	if len(got) != 2 || got[0] != "b" || got[1] != "c" {
+		t.Fatalf("intersect = %v, want [b c]", got)
+	}
+	if len(intersectStringSlices(nil, []string{"a"})) != 0 {
+		t.Fatal("expected empty intersection when one side is empty")
+	}
+}


### PR DESCRIPTION
Closes #188

## 问题

当 `AUTHZ_PROVIDER=bkn-safe` 时，`safeAuthorization.ResourceList` 被硬编码为空结果。依赖 `ResourceListIDs` 进行鉴权过滤的 Skill、ToolBox、MCP 和 Operator 管理列表因此无法展示已授权资源。

## 改动

- 实现 `safeAuthorization.ResourceList`，调用 bkn-safe `GET /api/safe/v1/authz/resources` 枚举可访问资源。
- 单操作请求直接映射 bkn-safe 返回的资源 ID。
- 多操作请求按 `OperationCheck` 一致的 AND 语义，对各操作的资源 ID 取交集。
- 对类型级授权（`type:*`）返回 `ResourceIDAll`（`*`），以支持全量访问列表。
- 新增 GET 请求封装并正确编码查询参数。
- 增加单元测试及 bkn-safe 集成测试的 `ResourceList` 场景。

## 验证

- `branch-name-lint`、`commitlint`、L2 smoke harness 及 operator-integration unit tests 已通过。
- 真实 bkn-safe 集成验证可执行：

  ```bash
  cd adp/execution-factory/operator-integration/server
  BKN_SAFE_URL=http://127.0.0.1:13000 go test -tags integration ./drivenadapters/ -run SafeAuthz -v
  ```