### PR TITLE
feat: add offline deployment support

### DIFF
--- a/deploy/deploy.sh
+++ b/deploy/deploy.sh
@@ -104,6 +104,10 @@ usage() {
     echo "                                Trailing flags like ... install --minimum --distro=k8s are NOT parsed here;"
     echo "                                use env KUBE_DISTRO=k8s or move --distro (same rule as -y, --force-upgrade)."
     echo "  -y, --yes                     Skip all interactive prompts and use defaults"
+    echo "  --offline                     Enable offline deployment mode (use offline registry)"
+    echo "                                Default offline registry: registry.openbkn.ai:5000"
+    echo "  --offline=<registry>          Enable offline mode with custom registry"
+    echo "                                Example: --offline=node1:5000"
     echo "  --force-upgrade               Always run helm upgrade even if installed chart version equals target."
     echo "                                Use this after editing config.yaml on a previously-installed cluster."
     echo "  --distro=k8s|k3s              Cluster bootstrap when modules auto-ensure K8s (default: k8s = kubeadm stack)."
@@ -146,6 +150,8 @@ usage() {
     echo "  $0 bkn-foundry install --minimum                 # Minimum install (skip auth & business-domain)"
     echo "  $0 bkn-foundry install --set auth.enabled=false  # Install BKN Foundry with auth enforcement off"
     echo "  $0 bkn-foundry install --set auth.enabled=false --set businessDomain.enabled=false  # Same as --minimum"
+    echo "  $0 --offline k8s install                        # Offline mode: use default offline registry"
+    echo "  $0 --offline=node1:5000 k8s install             # Offline mode: use custom offline registry"
     echo "  $0 bkn-foundry install --set image.registry=my-registry.com --set image.tag=v1.0.0  # Custom image settings"
     echo "  $0 bkn-foundry install --latest --registry=swr  # Latest manifest + Huawei SWR registry (CN-friendly)"
     echo "  $0 bkn-foundry download --charts_dir=/path/to/charts # Download Core charts into a specific local directory"
@@ -389,6 +395,15 @@ main() {
         case "$1" in
             -y|--yes) ASSUME_YES="true"; shift ;;
             --force-upgrade) FORCE_UPGRADE="true"; shift ;;
+            --offline)
+                export OFFLINE_MODE="true"
+                shift
+                ;;
+            --offline=*)
+                export OFFLINE_MODE="true"
+                export OFFLINE_REGISTRY="${1#*=}"
+                shift
+                ;;
             --config=*)
                 CONFIG_YAML_PATH="${1#*=}"
                 shift

--- a/deploy/scripts/lib/common.sh
+++ b/deploy/scripts/lib/common.sh
@@ -1170,14 +1170,31 @@ SERVICE_CIDR="${SERVICE_CIDR:-10.96.0.0/12}"
 API_SERVER_ADVERTISE_ADDRESS="${API_SERVER_ADVERTISE_ADDRESS:-}"
 
 # Kubernetes Image Repository Configuration
-IMAGE_REPOSITORY="${IMAGE_REPOSITORY:-registry.aliyuncs.com/google_containers}"
+# Offline mode: set OFFLINE_MODE=true to use offline registry
+# Default offline registry: registry.openbkn.ai:5000
+# Example: OFFLINE_MODE=true OFFLINE_REGISTRY=registry.openbkn.ai:5000
+OFFLINE_MODE="${OFFLINE_MODE:-false}"
+OFFLINE_REGISTRY="${OFFLINE_REGISTRY:-registry.openbkn.ai:5000}"
+
+# Image repository for Kubernetes components
+# In offline mode, use the offline registry; otherwise use Aliyun mirror by default
+if [[ "${OFFLINE_MODE}" == "true" ]]; then
+    IMAGE_REPOSITORY="${IMAGE_REPOSITORY:-${OFFLINE_REGISTRY}/google_containers}"
+else
+    IMAGE_REPOSITORY="${IMAGE_REPOSITORY:-registry.aliyuncs.com/google_containers}"
+fi
 
 # Kubernetes yum repo (Aliyun mirror) for kubeadm/kubelet/kubectl/cri-tools
 K8S_RPM_REPO_BASEURL="${K8S_RPM_REPO_BASEURL:-https://mirrors.aliyun.com/kubernetes-new/core/stable/v1.28/rpm/}"
 K8S_RPM_REPO_GPGKEY="${K8S_RPM_REPO_GPGKEY:-https://mirrors.aliyun.com/kubernetes-new/core/stable/v1.28/rpm/repodata/repomd.xml.key}"
 
 # Flannel CNI Image Repository Configuration
-FLANNEL_IMAGE_REPO="${FLANNEL_IMAGE_REPO:-swr.cn-north-4.myhuaweicloud.com/ddn-k8s/docker.io/}"
+# In offline mode, use offline registry; otherwise use SWR mirror
+if [[ "${OFFLINE_MODE}" == "true" ]]; then
+    FLANNEL_IMAGE_REPO="${FLANNEL_IMAGE_REPO:-${OFFLINE_REGISTRY}/flannel/}"
+else
+    FLANNEL_IMAGE_REPO="${FLANNEL_IMAGE_REPO:-swr.cn-north-4.myhuaweicloud.com/ddn-k8s/docker.io/}"
+fi
 FLANNEL_MANIFEST_PATH="${FLANNEL_MANIFEST_PATH:-${CONF_DIR}/kube-flannel.yml}"
 FLANNEL_MANIFEST_URL="${FLANNEL_MANIFEST_URL:-https://gitee.com/mirrors/flannel/raw/main/Documentation/kube-flannel.yml}"
 
@@ -1199,8 +1216,16 @@ RELEASE_MANIFESTS_DIR="${RELEASE_MANIFESTS_DIR:-${VERSION_MANIFESTS_DIR:-${SCRIP
 
 DOCKER_IO_MIRROR_PREFIX="${DOCKER_IO_MIRROR_PREFIX:-swr.cn-north-4.myhuaweicloud.com/ddn-k8s/docker.io/}"
 DOCKER_CE_REPO_URL="${DOCKER_CE_REPO_URL:-http://mirrors.aliyun.com/docker-ce/linux/centos/docker-ce.repo}"
-LOCALPV_PROVISIONER_IMAGE="${LOCALPV_PROVISIONER_IMAGE:-swr.cn-east-3.myhuaweicloud.com/openbkn-ai/rancher/local-path-provisioner:v0.0.32}"
-LOCALPV_HELPER_IMAGE="${LOCALPV_HELPER_IMAGE:-swr.cn-north-4.myhuaweicloud.com/ddn-k8s/docker.io/busybox:1.36.1}"
+
+# Local Path Provisioner Image Configuration
+# In offline mode, use offline registry; otherwise use SWR mirror
+if [[ "${OFFLINE_MODE}" == "true" ]]; then
+    LOCALPV_PROVISIONER_IMAGE="${LOCALPV_PROVISIONER_IMAGE:-${OFFLINE_REGISTRY}/openbkn-ai/rancher/local-path-provisioner:v0.0.32}"
+    LOCALPV_HELPER_IMAGE="${LOCALPV_HELPER_IMAGE:-${OFFLINE_REGISTRY}/openbkn-ai/busybox:1.36.1}"
+else
+    LOCALPV_PROVISIONER_IMAGE="${LOCALPV_PROVISIONER_IMAGE:-swr.cn-east-3.myhuaweicloud.com/openbkn-ai/rancher/local-path-provisioner:v0.0.32}"
+    LOCALPV_HELPER_IMAGE="${LOCALPV_HELPER_IMAGE:-swr.cn-north-4.myhuaweicloud.com/ddn-k8s/docker.io/busybox:1.36.1}"
+fi
 LOCALPV_MANIFEST_PATH="${LOCALPV_MANIFEST_PATH:-${CONF_DIR}/local-path-storage.yaml}"
 LOCALPV_MANIFEST_URL="${LOCALPV_MANIFEST_URL:-https://raw.githubusercontent.com/rancher/local-path-provisioner/v0.0.32/deploy/local-path-storage.yaml}"
 LOCALPV_BASE_PATH="${LOCALPV_BASE_PATH:-/opt/local-path-provisioner}"
@@ -1213,7 +1238,12 @@ MARIADB_NAMESPACE="${MARIADB_NAMESPACE:-${RESOURCE_NAMESPACE}}"
 # Default to the SWR-hosted image (same registry as kafka/opensearch) so
 # it is NOT prefixed with the foundry IMAGE_REGISTRY (ghcr.io/openbkn-ai), which
 # does not host the data-layer images (anonymous pull → 403).
-MARIADB_IMAGE="${MARIADB_IMAGE:-swr.cn-east-3.myhuaweicloud.com/openbkn-ai/mariadb:11.4.7}"
+# In offline mode, use offline registry; otherwise use SWR mirror
+if [[ "${OFFLINE_MODE}" == "true" ]]; then
+    MARIADB_IMAGE="${MARIADB_IMAGE:-${OFFLINE_REGISTRY}/openbkn-ai/mariadb:11.4.7}"
+else
+    MARIADB_IMAGE="${MARIADB_IMAGE:-swr.cn-east-3.myhuaweicloud.com/openbkn-ai/mariadb:11.4.7}"
+fi
 MARIADB_IMAGE_REPOSITORY="${MARIADB_IMAGE_REPOSITORY:-mariadb}"
 MARIADB_IMAGE_TAG="${MARIADB_IMAGE_TAG:-11.4.7}"
 MARIADB_IMAGE_FALLBACK="${MARIADB_IMAGE_FALLBACK:-mariadb:11.4.7}"
@@ -1238,7 +1268,12 @@ REDIS_CHART_VERSION="${REDIS_CHART_VERSION:-1.11.2}"
 REDIS_CHART_TGZ="${REDIS_CHART_TGZ:-${SCRIPT_DIR}/charts/redis-${REDIS_CHART_VERSION}.tgz}"
 REDIS_LOCAL_CHART_DIR="${REDIS_LOCAL_CHART_DIR:-${SCRIPT_DIR}/charts/redis}"
 REDIS_ARCHITECTURE="${REDIS_ARCHITECTURE:-sentinel}"  # standalone or sentinel
-REDIS_IMAGE="${REDIS_IMAGE:-}"
+# In offline mode, use offline registry; otherwise use SWR mirror
+if [[ "${OFFLINE_MODE}" == "true" ]]; then
+    REDIS_IMAGE="${REDIS_IMAGE:-${OFFLINE_REGISTRY}/openbkn-ai/redis:1.11.2-20251029.2.169ac3c0}"
+else
+    REDIS_IMAGE="${REDIS_IMAGE:-swr.cn-east-3.myhuaweicloud.com/openbkn-ai/redis:1.11.2-20251029.2.169ac3c0}"
+fi
 REDIS_IMAGE_REGISTRY="${REDIS_IMAGE_REGISTRY:-}"
 REDIS_IMAGE_REPOSITORY="${REDIS_IMAGE_REPOSITORY:-redis}"
 REDIS_IMAGE_TAG="${REDIS_IMAGE_TAG:-1.11.2-20251029.2.169ac3c0}"
@@ -1318,7 +1353,12 @@ KAFKA_CHART_TGZ="${KAFKA_CHART_TGZ:-${SCRIPT_DIR}/charts/kafka-${KAFKA_CHART_VER
 #   UnsupportedVersionException: Received request for api with key 11 (JoinGroup) and unsupported version 1
 # Default to a Kafka 3.x image for broader client compatibility; you can override via KAFKA_IMAGE/KAFKA_IMAGE_TAG.
 # Use an SWR mirror by default to improve pull reliability in restricted networks.
-KAFKA_IMAGE="${KAFKA_IMAGE:-swr.cn-east-3.myhuaweicloud.com/openbkn-ai/bitnami/kafka:3.9.0-debian-12-r10}"
+# In offline mode, use offline registry; otherwise use SWR mirror
+if [[ "${OFFLINE_MODE}" == "true" ]]; then
+    KAFKA_IMAGE="${KAFKA_IMAGE:-${OFFLINE_REGISTRY}/openbkn-ai/bitnami/kafka:3.9.0-debian-12-r10}"
+else
+    KAFKA_IMAGE="${KAFKA_IMAGE:-swr.cn-east-3.myhuaweicloud.com/openbkn-ai/bitnami/kafka:3.9.0-debian-12-r10}"
+fi
 KAFKA_IMAGE_REPOSITORY="${KAFKA_IMAGE_REPOSITORY:-bitnami/kafka}"
 KAFKA_IMAGE_TAG="${KAFKA_IMAGE_TAG:-3.9.0-debian-12-r10}"
 KAFKA_IMAGE_FALLBACK="${KAFKA_IMAGE_FALLBACK:-swr.cn-east-3.myhuaweicloud.com/openbkn-ai/bitnami/kafka:3.9.0-debian-12-r10}"
@@ -1355,12 +1395,23 @@ OPENSEARCH_CLUSTER_NAME="${OPENSEARCH_CLUSTER_NAME:-opensearch-cluster}"
 OPENSEARCH_NODE_GROUP="${OPENSEARCH_NODE_GROUP:-master}"
 OPENSEARCH_CHART_VERSION="${OPENSEARCH_CHART_VERSION:-2.36.0}"
 OPENSEARCH_CHART_TGZ="${OPENSEARCH_CHART_TGZ:-${SCRIPT_DIR}/charts/opensearch-${OPENSEARCH_CHART_VERSION}.tgz}"
-OPENSEARCH_IMAGE="${OPENSEARCH_IMAGE:-swr.cn-east-3.myhuaweicloud.com/openbkn-ai/opensearchproject/opensearch:2.19.4}"
-OPENSEARCH_IMAGE_REPOSITORY="${OPENSEARCH_IMAGE_REPOSITORY:-swr.cn-east-3.myhuaweicloud.com/openbkn-ai/opensearchproject/opensearch}"
+# In offline mode, use offline registry; otherwise use SWR mirror
+if [[ "${OFFLINE_MODE}" == "true" ]]; then
+    OPENSEARCH_IMAGE="${OPENSEARCH_IMAGE:-${OFFLINE_REGISTRY}/openbkn-ai/opensearchproject/opensearch:2.19.4}"
+    OPENSEARCH_IMAGE_REPOSITORY="${OPENSEARCH_IMAGE_REPOSITORY:-${OFFLINE_REGISTRY}/openbkn-ai/opensearchproject/opensearch}"
+else
+    OPENSEARCH_IMAGE="${OPENSEARCH_IMAGE:-swr.cn-east-3.myhuaweicloud.com/openbkn-ai/opensearchproject/opensearch:2.19.4}"
+    OPENSEARCH_IMAGE_REPOSITORY="${OPENSEARCH_IMAGE_REPOSITORY:-swr.cn-east-3.myhuaweicloud.com/openbkn-ai/opensearchproject/opensearch}"
+fi
 OPENSEARCH_IMAGE_TAG="${OPENSEARCH_IMAGE_TAG:-2.19.4}"
 OPENSEARCH_IMAGE_FALLBACK="${OPENSEARCH_IMAGE_FALLBACK:-swr.cn-east-3.myhuaweicloud.com/openbkn-ai/opensearchproject/opensearch:2.19.4}"
 # OpenSearch chart uses busybox initContainers (fsgroup-volume/sysctl); use a dedicated SWR mirror by default.
-OPENSEARCH_INIT_IMAGE="${OPENSEARCH_INIT_IMAGE:-swr.cn-east-3.myhuaweicloud.com/openbkn-ai/busybox:1.36.1}"
+# In offline mode, use offline registry; otherwise use SWR mirror
+if [[ "${OFFLINE_MODE}" == "true" ]]; then
+    OPENSEARCH_INIT_IMAGE="${OPENSEARCH_INIT_IMAGE:-${OFFLINE_REGISTRY}/openbkn-ai/busybox:1.36.1}"
+else
+    OPENSEARCH_INIT_IMAGE="${OPENSEARCH_INIT_IMAGE:-swr.cn-east-3.myhuaweicloud.com/openbkn-ai/busybox:1.36.1}"
+fi
 OPENSEARCH_JAVA_OPTS="${OPENSEARCH_JAVA_OPTS:--Xms512m -Xmx512m -XX:MaxDirectMemorySize=128m}"
 OPENSEARCH_MEMORY_REQUEST="${OPENSEARCH_MEMORY_REQUEST:-512Mi}"
 # NOTE: OpenSearch uses heap + direct memory + native overhead. 768Mi is too tight for -Xmx512m.
@@ -1407,13 +1458,23 @@ MONGODB_RESOURCES_LIMITS_MEMORY="${MONGODB_RESOURCES_LIMITS_MEMORY:-1Gi}"
 INGRESS_NGINX_HTTP_PORT="${INGRESS_NGINX_HTTP_PORT:-80}"
 INGRESS_NGINX_HTTPS_PORT="${INGRESS_NGINX_HTTPS_PORT:-443}"
 INGRESS_NGINX_CLASS="${INGRESS_NGINX_CLASS:-class-443}"
-INGRESS_NGINX_CONTROLLER_IMAGE="${INGRESS_NGINX_CONTROLLER_IMAGE:-swr.cn-east-3.myhuaweicloud.com/openbkn-ai/ingress-nginx/controller:v1.14.1}"
-INGRESS_NGINX_CONTROLLER_IMAGE_REPOSITORY="${INGRESS_NGINX_CONTROLLER_IMAGE_REPOSITORY:-swr.cn-east-3.myhuaweicloud.com/openbkn-ai/ingress-nginx/controller}"
+
+# Ingress-Nginx Image Configuration
+# In offline mode, use offline registry; otherwise use SWR mirror
+if [[ "${OFFLINE_MODE}" == "true" ]]; then
+    INGRESS_NGINX_CONTROLLER_IMAGE="${INGRESS_NGINX_CONTROLLER_IMAGE:-${OFFLINE_REGISTRY}/ingress-nginx/controller:v1.14.1}"
+    INGRESS_NGINX_CONTROLLER_IMAGE_REPOSITORY="${INGRESS_NGINX_CONTROLLER_IMAGE_REPOSITORY:-${OFFLINE_REGISTRY}/ingress-nginx/controller}"
+    INGRESS_NGINX_WEBHOOK_CERTGEN_IMAGE="${INGRESS_NGINX_WEBHOOK_CERTGEN_IMAGE:-${OFFLINE_REGISTRY}/ingress-nginx/kube-webhook-certgen:v1.6.1}"
+    INGRESS_NGINX_WEBHOOK_CERTGEN_IMAGE_REPOSITORY="${INGRESS_NGINX_WEBHOOK_CERTGEN_IMAGE_REPOSITORY:-${OFFLINE_REGISTRY}/ingress-nginx/kube-webhook-certgen}"
+else
+    INGRESS_NGINX_CONTROLLER_IMAGE="${INGRESS_NGINX_CONTROLLER_IMAGE:-swr.cn-east-3.myhuaweicloud.com/openbkn-ai/ingress-nginx/controller:v1.14.1}"
+    INGRESS_NGINX_CONTROLLER_IMAGE_REPOSITORY="${INGRESS_NGINX_CONTROLLER_IMAGE_REPOSITORY:-swr.cn-east-3.myhuaweicloud.com/openbkn-ai/ingress-nginx/controller}"
+    INGRESS_NGINX_WEBHOOK_CERTGEN_IMAGE="${INGRESS_NGINX_WEBHOOK_CERTGEN_IMAGE:-swr.cn-east-3.myhuaweicloud.com/openbkn-ai/ingress-nginx/kube-webhook-certgen:v1.6.1}"
+    INGRESS_NGINX_WEBHOOK_CERTGEN_IMAGE_REPOSITORY="${INGRESS_NGINX_WEBHOOK_CERTGEN_IMAGE_REPOSITORY:-swr.cn-east-3.myhuaweicloud.com/openbkn-ai/ingress-nginx/kube-webhook-certgen}"
+fi
 INGRESS_NGINX_CONTROLLER_IMAGE_TAG="${INGRESS_NGINX_CONTROLLER_IMAGE_TAG:-v1.14.1}"
 INGRESS_NGINX_CHART_VERSION="${INGRESS_NGINX_CHART_VERSION:-4.13.1}"
 INGRESS_NGINX_CHART_TGZ="${INGRESS_NGINX_CHART_TGZ:-${SCRIPT_DIR}/charts/ingress-nginx-${INGRESS_NGINX_CHART_VERSION}.tgz}"
-INGRESS_NGINX_WEBHOOK_CERTGEN_IMAGE="${INGRESS_NGINX_WEBHOOK_CERTGEN_IMAGE:-swr.cn-east-3.myhuaweicloud.com/openbkn-ai/ingress-nginx/kube-webhook-certgen:v1.6.1}"
-INGRESS_NGINX_WEBHOOK_CERTGEN_IMAGE_REPOSITORY="${INGRESS_NGINX_WEBHOOK_CERTGEN_IMAGE_REPOSITORY:-swr.cn-east-3.myhuaweicloud.com/openbkn-ai/ingress-nginx/kube-webhook-certgen}"
 INGRESS_NGINX_WEBHOOK_CERTGEN_IMAGE_TAG="${INGRESS_NGINX_WEBHOOK_CERTGEN_IMAGE_TAG:-v1.6.1}"
 INGRESS_NGINX_HOSTNETWORK="${INGRESS_NGINX_HOSTNETWORK:-true}"
 INGRESS_NGINX_ADMISSION_WEBHOOKS_ENABLED="${INGRESS_NGINX_ADMISSION_WEBHOOKS_ENABLED:-false}"

--- a/deploy/scripts/services/core.sh
+++ b/deploy/scripts/services/core.sh
@@ -463,8 +463,14 @@ _install_core_release_repo() {
 #   swr  -> swr.cn-east-3.myhuaweicloud.com/openbkn-ai
 #   ghcr -> ghcr.io/openbkn-ai
 #   *    -> used verbatim (treated as a full registry/namespace)
+# In offline mode, all registries resolve to ${OFFLINE_REGISTRY}/openbkn-ai
 _core_resolve_registry() {
     local raw="$1"
+    # In offline mode, always use offline registry
+    if [[ "${OFFLINE_MODE}" == "true" ]]; then
+        echo "${OFFLINE_REGISTRY}/openbkn-ai"
+        return
+    fi
     case "${raw}" in
         swr)  echo "swr.cn-east-3.myhuaweicloud.com/openbkn-ai" ;;
         ghcr) echo "ghcr.io/openbkn-ai" ;;
@@ -487,11 +493,21 @@ _core_config_sets_image_registry() {
 # Inject default --set values for bkn-core if user did not override them.
 # Currently: businessDomain.enabled defaults to false at install time.
 _core_apply_default_set_values() {
-    # image.registry precedence: explicit --set image.registry=… wins; else an
-    # explicit --registry flag is applied; else if CONFIG_YAML_PATH already sets
+    # image.registry precedence in ONLINE mode: explicit --set image.registry=… wins;
+    # else an explicit --registry flag is applied; else if CONFIG_YAML_PATH already sets
     # image.registry we respect it (don't clobber a config's registry, e.g. the
     # Mac dev mac-config.yaml); else default to swr.
-    if get_set_value "image.registry" "${CORE_SET_VALUES[@]}" >/dev/null 2>&1; then
+    #
+    # In OFFLINE mode (--offline flag): Always force offline registry via --set,
+    # which takes precedence over config.yaml's image.registry setting.
+
+    # Highest priority: offline mode
+    if [[ "${OFFLINE_MODE}" == "true" ]]; then
+        local _reg_resolved
+        _reg_resolved="$(_core_resolve_registry "offline")"
+        CORE_SET_VALUES+=("image.registry=${_reg_resolved}")
+        log_info "Offline mode: Forcing image.registry=${_reg_resolved} via --set (overrides config.yaml)"
+    elif get_set_value "image.registry" "${CORE_SET_VALUES[@]}" >/dev/null 2>&1; then
         : # user passed --set image.registry=… explicitly; do not override
     elif [[ -n "${CORE_IMAGE_REGISTRY}" ]]; then
         local _reg_resolved
@@ -639,7 +655,10 @@ _core_resolve_latest_manifest() {
 install_core() {
     log_info "Installing BKN Foundry services via Helm..."
     _core_resolve_latest_manifest || return 1
-    setup_dockerhub_mirror "${CORE_DOCKERHUB_MIRROR}"
+   if [[ "${OFFLINE_MODE}" != "true" ]]; then
+        setup_dockerhub_mirror "${CORE_DOCKERHUB_MIRROR}"
+    fi
+
     _core_require_version_manifest || return 1
     _core_apply_default_set_values
 

--- a/deploy/scripts/services/ingress_nginx.sh
+++ b/deploy/scripts/services/ingress_nginx.sh
@@ -3,6 +3,15 @@
 install_ingress_nginx() {
     log_info "Installing ingress-nginx-controller..."
 
+    # Override Ingress-Nginx image registry based on OFFLINE_MODE (keep full path)
+    if [[ "${OFFLINE_MODE}" == "true" ]]; then
+        INGRESS_NGINX_CONTROLLER_IMAGE="${OFFLINE_REGISTRY}/openbkn-ai/ingress-nginx/controller:v1.14.1"
+        INGRESS_NGINX_CONTROLLER_IMAGE_REPOSITORY="${OFFLINE_REGISTRY}/openbkn-ai/ingress-nginx/controller"
+        INGRESS_NGINX_WEBHOOK_CERTGEN_IMAGE="${OFFLINE_REGISTRY}/openbkn-ai/ingress-nginx/kube-webhook-certgen:v1.6.1"
+        INGRESS_NGINX_WEBHOOK_CERTGEN_IMAGE_REPOSITORY="${OFFLINE_REGISTRY}/openbkn-ai/ingress-nginx/kube-webhook-certgen"
+        log_info "Offline mode: Using offline registry ${OFFLINE_REGISTRY} for ingress-nginx"
+    fi
+
     # Create namespace if not exists
     kubectl create namespace ingress-nginx 2>/dev/null || true
 

--- a/deploy/scripts/services/k8s.sh
+++ b/deploy/scripts/services/k8s.sh
@@ -121,14 +121,21 @@ init_k8s_master() {
     fi
     
     log_info "API Server advertise address: ${API_SERVER_ADVERTISE_ADDRESS}"
-    
+
+    # Override IMAGE_REPOSITORY based on OFFLINE_MODE (in case it was set before OFFLINE_MODE)
+    if [[ "${OFFLINE_MODE}" == "true" ]]; then
+        IMAGE_REPOSITORY="${OFFLINE_REGISTRY}/google_containers"
+        log_info "Offline mode: Using offline registry ${OFFLINE_REGISTRY}"
+    fi
+
     # Pre-pull images before kubeadm init
     log_info "Pre-pulling Kubernetes images from ${IMAGE_REPOSITORY}..."
+
     kubeadm config images pull \
         --kubernetes-version=stable-1.28 \
         --image-repository="${IMAGE_REPOSITORY}" \
         2>&1 || log_warn "Some images may have failed to pull, continuing..."
-    
+
     # Pre-pull pause image with all possible versions and tag them
     log_info "Pre-pulling pause images with all versions..."
     for pause_version in 3.6 3.9 3.10 3.10.0 3.10.1; do
@@ -192,15 +199,15 @@ EOF
     # Fix pause image version in kubelet configuration
     log_info "Fixing pause image version in kubelet configuration..."
     systemctl stop kubelet
-    
-    # Replace pause image versions with 3.9 in all kubelet config files
-    # Replace registry.k8s.io with aliyun registry for all pause versions (including 3.6)
-    sed -i 's|registry\.k8s\.io/pause:[0-9.]*|registry.aliyuncs.com/google_containers/pause:3.9|g' /var/lib/kubelet/kubeadm-flags.env 2>/dev/null || true
-    sed -i 's|registry\.k8s\.io/pause:[0-9.]*|registry.aliyuncs.com/google_containers/pause:3.9|g' /var/lib/kubelet/config.yaml 2>/dev/null || true
-    
+
+    # Replace pause image versions with configured IMAGE_REPOSITORY
+    # In offline mode, IMAGE_REPOSITORY is set to offline registry (e.g., node1:5000/google_containers)
+    sed -i "s|registry\.k8s\.io/pause:[0-9.]*|${IMAGE_REPOSITORY}/pause:3.9|g" /var/lib/kubelet/kubeadm-flags.env 2>/dev/null || true
+    sed -i "s|registry\.k8s\.io/pause:[0-9.]*|${IMAGE_REPOSITORY}/pause:3.9|g" /var/lib/kubelet/config.yaml 2>/dev/null || true
+
     # Ensure pause image is set correctly in kubelet extra args
     if ! grep -q 'pod-infra-container-image' /var/lib/kubelet/kubeadm-flags.env; then
-        sed -i 's|--container-runtime-endpoint|--pod-infra-container-image=registry.aliyuncs.com/google_containers/pause:3.9 --container-runtime-endpoint|g' /var/lib/kubelet/kubeadm-flags.env
+        sed -i "s|--container-runtime-endpoint|--pod-infra-container-image=${IMAGE_REPOSITORY}/pause:3.9 --container-runtime-endpoint|g" /var/lib/kubelet/kubeadm-flags.env
     fi
     
     systemctl start kubelet
@@ -222,11 +229,13 @@ EOF
     sed -i "s|https://127.0.0.1:6443|https://${API_SERVER_ADVERTISE_ADDRESS}:6443|g" /root/.kube/config
     
     # Setup kubeconfig for current user if not root
-    if [[ -n "${SUDO_USER}" ]]; then
+    if [[ -n "${SUDO_USER}" && "${SUDO_USER}" != "root" ]]; then
         USER_HOME=$(getent passwd "${SUDO_USER}" | cut -d: -f6)
-        mkdir -p "${USER_HOME}/.kube"
-        cp -f /root/.kube/config "${USER_HOME}/.kube/config"
-        chown -R "${SUDO_USER}:${SUDO_USER}" "${USER_HOME}/.kube"
+        if [[ -n "${USER_HOME}" && "${USER_HOME}" != "/root" ]]; then
+            mkdir -p "${USER_HOME}/.kube"
+            cp -f /root/.kube/config "${USER_HOME}/.kube/config"
+            chown -R "${SUDO_USER}:${SUDO_USER}" "${USER_HOME}/.kube"
+        fi
     fi
     
     export KUBECONFIG=/root/.kube/config
@@ -259,12 +268,19 @@ install_cni() {
             return 0
         fi
     fi
-    
     # Install Flannel CNI (ensure network CIDR matches POD_CIDR)
-    # Note: Image addresses are already configured in the YAML file
-    cat "${FLANNEL_MANIFEST_PATH}" | \
-        sed "s|10.244.0.0/16|${POD_CIDR}|g" | \
-        kubectl apply -f -
+    # In offline mode, replace image registry domain only (keep full path)
+    if [[ "${OFFLINE_MODE}" == "true" ]]; then
+        log_info "Offline mode: Using offline registry for Flannel images"
+        cat "${FLANNEL_MANIFEST_PATH}" | \
+            sed "s|10.244.0.0/16|${POD_CIDR}|g" | \
+            sed "s|swr.cn-east-3.myhuaweicloud.com|${OFFLINE_REGISTRY}|g" | \
+            kubectl apply -f -
+    else
+        cat "${FLANNEL_MANIFEST_PATH}" | \
+            sed "s|10.244.0.0/16|${POD_CIDR}|g" | \
+            kubectl apply -f -
+    fi
     
     log_info "Waiting for Flannel pods to be ready..."
     sleep 10
@@ -394,6 +410,30 @@ install_helm() {
         fi
     fi
 
+    # In offline mode, skip helm installation - assume it's pre-installed
+    if [[ "${OFFLINE_MODE}" == "true" ]]; then
+        log_info "Offline mode: Skipping Helm installation"
+        log_info "Checking for pre-installed Helm..."
+
+        if ! command -v helm &> /dev/null; then
+            log_error "Helm is not installed."
+            log_error "In offline mode, please pre-install Helm ${HELM_VERSION}"
+            log_error ""
+            log_error "Installation options:"
+            log_error "  1. Package manager (if available in your offline repo):"
+            log_error "     yum install -y helm  # or dnf/apt-get"
+            log_error ""
+            log_error "  2. Binary download and manual installation:"
+            log_error "     wget https://repo.huaweicloud.com/helm/${HELM_VERSION}/helm-${HELM_VERSION}-linux-amd64.tar.gz"
+            log_error "     tar -xzf helm-*.tar.gz"
+            log_error "     mv linux-amd64/helm /usr/local/bin/"
+            return 1
+        fi
+
+        log_info "✓ Helm is pre-installed: $(helm version --short 2>/dev/null | head -1 || echo 'unknown')"
+        return 0
+    fi
+
     # Prefer HuaweiCloud tarball (pinned by version + arch); fallback to get-helm-3 script if needed.
     local arch=""
     case "$(uname -m)" in
@@ -479,6 +519,26 @@ _fix_docker_ce_repo_releasever_for_distro() {
 # Install containerd container runtime
 install_containerd() {
     log_info "Checking containerd installation..."
+
+    # In offline mode, skip containerd installation - assume it's pre-installed
+    if [[ "${OFFLINE_MODE}" == "true" ]]; then
+        log_info "Offline mode: Skipping containerd package installation"
+        log_info "Checking for pre-installed containerd..."
+
+        if ! command -v containerd &> /dev/null; then
+            log_error "containerd is not installed."
+            log_error "In offline mode, please pre-install containerd"
+            log_error ""
+            log_error "Installation options:"
+            log_error "  On RHEL/CentOS/Fedora: yum install -y containerd.io"
+            log_error "  On Ubuntu/Debian: apt-get install -y containerd.io"
+            return 1
+        fi
+
+        log_info "✓ containerd is pre-installed"
+        configure_containerd_runtime
+        return 0
+    fi
 
     detect_package_manager
     
@@ -745,6 +805,11 @@ configure_containerd_runtime() {
         fi
     fi
     
+    # Override IMAGE_REPOSITORY based on OFFLINE_MODE (in case it was set before OFFLINE_MODE)
+    if [[ "${OFFLINE_MODE}" == "true" ]]; then
+        IMAGE_REPOSITORY="${OFFLINE_REGISTRY}/google_containers"
+    fi
+
     # Ensure sandbox_image uses the configured image repository (avoid pulling from registry.k8s.io)
     local desired_sandbox_image="${IMAGE_REPOSITORY}/pause:3.9"
     if grep -q 'sandbox_image' /etc/containerd/config.toml; then
@@ -840,7 +905,7 @@ EOF
 # Install crictl (container runtime interface CLI)
 install_crictl() {
     log_info "Installing crictl..."
-    
+
     if command -v crictl &> /dev/null; then
         log_info "crictl is already installed"
         # Still ensure config file exists
@@ -854,6 +919,18 @@ debug: false
 EOF
         fi
         return 0
+    fi
+
+    # In offline mode, skip crictl installation - assume it's pre-installed
+    if [[ "${OFFLINE_MODE}" == "true" ]]; then
+        log_info "Offline mode: Skipping crictl installation"
+        log_error "crictl is not installed."
+        log_error "In offline mode, please pre-install crictl (cri-tools)"
+        log_error ""
+        log_error "Installation options:"
+        log_error "  On RHEL/CentOS/Fedora: yum install -y cri-tools"
+        log_error "  On Ubuntu/Debian: apt-get install -y cri-tools"
+        return 1
     fi
 
     detect_package_manager
@@ -966,7 +1043,41 @@ _k8s_ensure_cni_bin_plugins() {
 # Install Kubernetes components (kubeadm, kubelet, kubectl)
 install_kubernetes() {
     log_info "Installing Kubernetes components..."
-    
+
+    # In offline mode, skip package installation - assume components are pre-installed
+    if [[ "${OFFLINE_MODE}" == "true" ]]; then
+        log_info "Offline mode: Skipping Kubernetes package installation"
+        log_info "Checking for pre-installed Kubernetes components..."
+
+        local missing_components=()
+        if ! command -v kubeadm &> /dev/null; then
+            missing_components+=("kubeadm")
+        fi
+        if ! command -v kubelet &> /dev/null; then
+            missing_components+=("kubelet")
+        fi
+        if ! command -v kubectl &> /dev/null; then
+            missing_components+=("kubectl")
+        fi
+
+        if [[ ${#missing_components[@]} -gt 0 ]]; then
+            log_error "Missing Kubernetes components: ${missing_components[*]}"
+            log_error "In offline mode, please pre-install these packages:"
+            log_error "  - kubeadm"
+            log_error "  - kubelet"
+            log_error "  - kubectl"
+            log_error "  - kubernetes-cni"
+            log_error ""
+            log_error "On RHEL/CentOS/Fedora: yum install -y kubeadm kubelet kubectl kubernetes-cni"
+            log_error "On Ubuntu/Debian: apt-get install -y kubeadm kubelet kubectl"
+            return 1
+        fi
+
+        log_info "✓ All Kubernetes components are pre-installed"
+        _k8s_ensure_cni_bin_plugins || return 1
+        return 0
+    fi
+
     detect_package_manager
 
     if [[ "${PKG_MANAGER}" == "dnf" ]] || [[ "${PKG_MANAGER}" == "yum" ]]; then
@@ -984,7 +1095,7 @@ EOF
             ${PKG_MANAGER_UPDATE}
         fi
     fi
-    
+
     if ! command -v kubeadm &> /dev/null || ! command -v kubelet &> /dev/null || ! command -v kubectl &> /dev/null; then
         if [[ "${PKG_MANAGER}" == "dnf" ]] || [[ "${PKG_MANAGER}" == "yum" ]]; then
             # RHEL-family only; Ubuntu/Debian use the apt branch below (no --disableexcludes).

--- a/deploy/scripts/services/kafka.sh
+++ b/deploy/scripts/services/kafka.sh
@@ -94,6 +94,12 @@ EOF
         fi
     fi
 
+    # Override Kafka image registry based on OFFLINE_MODE (in case it was set before OFFLINE_MODE)
+    if [[ "${OFFLINE_MODE}" == "true" ]]; then
+        KAFKA_IMAGE="${OFFLINE_REGISTRY}/openbkn-ai/bitnami/kafka:3.9.0-debian-12-r10"
+        log_info "Offline mode: Using offline registry ${OFFLINE_REGISTRY} for Kafka"
+    fi
+
     # Parse image registry/repository/tag from KAFKA_IMAGE
     local image_without_tag="${KAFKA_IMAGE%:*}"
     local image_tag="${KAFKA_IMAGE##*:}"
@@ -110,7 +116,14 @@ EOF
         log_info "Using remote Kafka chart: ${chart_ref} (version ${KAFKA_CHART_VERSION})"
     fi
 
-    if [[ "${use_local_chart}" != "true" ]]; then
+    # In offline mode, skip helm repo operations
+    if [[ "${OFFLINE_MODE}" == "true" ]]; then
+        if [[ ! -f "${KAFKA_CHART_TGZ}" ]]; then
+            log_error "Offline mode requires local Kafka chart: ${KAFKA_CHART_TGZ}"
+            log_error "Please prepare the chart in advance"
+            return 1
+        fi
+    elif [[ "${use_local_chart}" != "true" ]]; then
         helm repo add --force-update bitnami "${HELM_REPO_BITNAMI}"
         helm repo update
     fi

--- a/deploy/scripts/services/mariadb.sh
+++ b/deploy/scripts/services/mariadb.sh
@@ -235,14 +235,18 @@ install_mariadb_helm() {
         log_info "Generated random 10-character MariaDB root password"
     fi
 
+    # Override MariaDB image registry based on OFFLINE_MODE (in case it was set before OFFLINE_MODE)
+    if [[ "${OFFLINE_MODE}" == "true" ]]; then
+        MARIADB_IMAGE="${OFFLINE_REGISTRY}/openbkn-ai/mariadb:11.4.7"
+        log_info "Offline mode: Using offline registry ${OFFLINE_REGISTRY} for MariaDB"
+    fi
+
     if [[ -z "${MARIADB_IMAGE}" ]]; then
         MARIADB_IMAGE="$(image_from_registry "${MARIADB_IMAGE_REPOSITORY}" "${MARIADB_IMAGE_TAG}" "${MARIADB_IMAGE_FALLBACK}")"
     fi
-
     # Parse image registry/repository/tag from MARIADB_IMAGE
     local image_without_tag="${MARIADB_IMAGE%:*}"
     local image_tag="${MARIADB_IMAGE##*:}"
-
     local chart_ref="mariadb"
     local use_local_chart="false"
     if [[ -f "${MARIADB_CHART_TGZ}" ]]; then
@@ -661,6 +665,12 @@ install_mariadb_bitnami() {
     else
         MARIADB_ROOT_PASSWORD=$(generate_random_password 10)
         log_info "Generated random 10-character MariaDB root password"
+    fi
+
+    # Override MariaDB image registry based on OFFLINE_MODE (in case it was set before OFFLINE_MODE)
+    if [[ "${OFFLINE_MODE}" == "true" ]]; then
+        MARIADB_IMAGE="${MARIADB_IMAGE:-${OFFLINE_REGISTRY}/openbkn-ai/mariadb:11.4.7}"
+        log_info "Offline mode: Using offline registry ${OFFLINE_REGISTRY} for MariaDB"
     fi
 
     if [[ -z "${MARIADB_IMAGE}" ]]; then

--- a/deploy/scripts/services/opensearch.sh
+++ b/deploy/scripts/services/opensearch.sh
@@ -46,6 +46,13 @@ install_opensearch() {
         fi
     fi
 
+    # Override OpenSearch image registry based on OFFLINE_MODE (in case it was set before OFFLINE_MODE)
+    if [[ "${OFFLINE_MODE}" == "true" ]]; then
+        OPENSEARCH_IMAGE="${OFFLINE_REGISTRY}/openbkn-ai/opensearchproject/opensearch:2.19.4"
+        OPENSEARCH_INIT_IMAGE="${OFFLINE_REGISTRY}/openbkn-ai/busybox:1.36.1"
+        log_info "Offline mode: Using offline registry ${OFFLINE_REGISTRY} for OpenSearch"
+    fi
+
     # Parse image repository/tag from OPENSEARCH_IMAGE (chart expects image.repository + image.tag)
     local os_image_repo="${OPENSEARCH_IMAGE%:*}"
     local os_image_tag="${OPENSEARCH_IMAGE##*:}"
@@ -72,7 +79,14 @@ install_opensearch() {
         log_info "Using remote OpenSearch chart: ${chart_ref} (version ${OPENSEARCH_CHART_VERSION})"
     fi
 
-    if [[ "${use_local_chart}" != "true" ]]; then
+    # In offline mode, skip helm repo operations
+    if [[ "${OFFLINE_MODE}" == "true" ]]; then
+        if [[ ! -f "${OPENSEARCH_CHART_TGZ}" ]]; then
+            log_error "Offline mode requires local OpenSearch chart: ${OPENSEARCH_CHART_TGZ}"
+            log_error "Please prepare the chart in advance"
+            return 1
+        fi
+    elif [[ "${use_local_chart}" != "true" ]]; then
         helm repo add --force-update opensearch "${HELM_REPO_OPENSEARCH}"
         helm repo update
     fi

--- a/deploy/scripts/services/redis.sh
+++ b/deploy/scripts/services/redis.sh
@@ -34,14 +34,20 @@ install_redis_sentinel_local() {
     fi
     log_info "Installing Redis in sentinel mode using redis chart..."
 
-    # Build image registry string (default from user's values)
-    local image_registry="${REDIS_IMAGE_REGISTRY:-swr.cn-east-3.myhuaweicloud.com/openbkn-ai}"
-    if [[ -z "${image_registry}" ]]; then
-        # Try to get from config.yaml
-        image_registry=$(grep -E "^[[:space:]]*registry:" "${SCRIPT_DIR}/conf/config.yaml" 2>/dev/null | head -1 | sed 's/.*registry:[[:space:]]*//' | tr -d "'\"")
-    fi
-    if [[ -z "${image_registry}" ]]; then
-        image_registry="swr.cn-east-3.myhuaweicloud.com/openbkn-ai"
+    # Build image registry string based on OFFLINE_MODE
+    local image_registry
+    if [[ "${OFFLINE_MODE}" == "true" ]]; then
+        image_registry="${OFFLINE_REGISTRY}/openbkn-ai"
+        log_info "Offline mode: Using offline registry ${image_registry}"
+    else
+        image_registry="${REDIS_IMAGE_REGISTRY:-swr.cn-east-3.myhuaweicloud.com/openbkn-ai}"
+        if [[ -z "${image_registry}" ]]; then
+            # Try to get from config.yaml
+            image_registry=$(grep -E "^[[:space:]]*registry:" "${SCRIPT_DIR}/conf/config.yaml" 2>/dev/null | head -1 | sed 's/.*registry:[[:space:]]*//' | tr -d "'\"")
+        fi
+        if [[ -z "${image_registry}" ]]; then
+            image_registry="swr.cn-east-3.myhuaweicloud.com/openbkn-ai"
+        fi
     fi
 
     local redis_password="${REDIS_PASSWORD}"

--- a/deploy/scripts/services/status.sh
+++ b/deploy/scripts/services/status.sh
@@ -28,7 +28,12 @@ INSTALL_STATUS_MERGE_JQ="${INSTALL_STATUS_DIR}/merge.jq"
 # alpine/k8s (which the docker.1panel.live mirror 403s) and bitnami/kubectl (whose
 # docker.io tags are being pruned post-deprecation), is reliably served by the
 # install-time --dockerhub-mirror on CN/restricted nets. Override via env.
-INSTALL_STATUS_KUBECTL_IMAGE="${INSTALL_STATUS_KUBECTL_IMAGE:-swr.cn-east-3.myhuaweicloud.com/openbkn-ai/portainer/kubectl-shell:latest}"
+# In offline mode, use offline registry; otherwise use SWR mirror
+if [[ "${OFFLINE_MODE}" == "true" ]]; then
+    INSTALL_STATUS_KUBECTL_IMAGE="${INSTALL_STATUS_KUBECTL_IMAGE:-${OFFLINE_REGISTRY}/openbkn-ai/portainer/kubectl-shell:latest}"
+else
+    INSTALL_STATUS_KUBECTL_IMAGE="${INSTALL_STATUS_KUBECTL_IMAGE:-swr.cn-east-3.myhuaweicloud.com/openbkn-ai/portainer/kubectl-shell:latest}"
+fi
 
 # Detect the ingress-nginx IngressClass to bind the endpoint to.
 _status_detect_ingress_class() {

--- a/deploy/scripts/services/storage.sh
+++ b/deploy/scripts/services/storage.sh
@@ -3,9 +3,18 @@ install_localpv() {
     log_info "Installing local-path-provisioner (hostPath local PV)..."
 
     # Note: Image addresses are already configured in the YAML file
-    read_or_fetch "${LOCALPV_MANIFEST_PATH}" "${LOCALPV_MANIFEST_URL}" | \
-        sed "s|/opt/local-path-provisioner|${LOCALPV_BASE_PATH}|g" | \
-        kubectl apply -f -
+    # In offline mode, replace image registry domain only (keep full path)
+    if [[ "${OFFLINE_MODE}" == "true" ]]; then
+        log_info "Offline mode: Using offline registry ${OFFLINE_REGISTRY} for local-path-provisioner"
+        read_or_fetch "${LOCALPV_MANIFEST_PATH}" "${LOCALPV_MANIFEST_URL}" | \
+            sed "s|/opt/local-path-provisioner|${LOCALPV_BASE_PATH}|g" | \
+            sed "s|swr.cn-east-3.myhuaweicloud.com|${OFFLINE_REGISTRY}|g" | \
+            kubectl apply -f -
+    else
+        read_or_fetch "${LOCALPV_MANIFEST_PATH}" "${LOCALPV_MANIFEST_URL}" | \
+            sed "s|/opt/local-path-provisioner|${LOCALPV_BASE_PATH}|g" | \
+            kubectl apply -f -
+    fi
 
     kubectl wait --for=condition=Available deployment/local-path-provisioner -n kube-system --timeout=300s 2>/dev/null || true
 

--- a/deploy/scripts/sync-k8s-images.sh
+++ b/deploy/scripts/sync-k8s-images.sh
@@ -1,0 +1,420 @@
+#!/bin/bash
+# Kubernetes Images Sync Script for Offline Deployment
+# Usage: ./sync-k8s-images.sh <target_registry> [k8s_version]
+# Example: ./sync-k8s-images.sh node1:5000 v1.28.15
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "${SCRIPT_DIR}/lib/common.sh"
+
+# Default Kubernetes version
+K8S_VERSION="${2:-v1.28.15}"
+K8S_VERSION_SHORT="${K8S_VERSION#v}"
+
+# Source registry (Aliyun mirror)
+SOURCE_REGISTRY="registry.aliyuncs.com/google_containers"
+
+# Target registry
+TARGET_REGISTRY="${1:-}"
+TARGET_NAMESPACE="google_containers"
+
+if [[ -z "${TARGET_REGISTRY}" ]]; then
+    echo "Usage: $0 <target_registry> [k8s_version]"
+    echo ""
+    echo "Arguments:"
+    echo "  target_registry  Target offline registry (e.g., node1:5000)"
+    echo "  k8s_version      Kubernetes version (default: v1.28.15)"
+    echo ""
+    echo "Examples:"
+    echo "  $0 node1:5000"
+    echo "  $0 node1:5000 v1.28.15"
+    echo "  $0 192.168.1.100:5000 v1.27.10"
+    exit 1
+fi
+
+log_info "=== Kubernetes Images Sync Script ==="
+log_info "Source Registry: ${SOURCE_REGISTRY}"
+log_info "Target Registry: ${TARGET_REGISTRY}"
+log_info "Kubernetes Version: ${K8S_VERSION}"
+log_info ""
+
+# Required images for Kubernetes
+K8S_IMAGES=(
+    "kube-apiserver:${K8S_VERSION}"
+    "kube-controller-manager:${K8S_VERSION}"
+    "kube-scheduler:${K8S_VERSION}"
+    "kube-proxy:${K8S_VERSION}"
+    "pause:3.9"
+    "pause:3.6"
+    "pause:3.10"
+    "coredns:v1.10.1"
+    "etcd:3.5.9-0"
+)
+
+# Required images for Flannel CNI
+FLANNEL_IMAGES=(
+    "openbkn-ai/flannel/flannel:v0.25.5"
+    "openbkn-ai/flannel/flannel-cni-plugin:v1.5.1-flannel1"
+)
+
+# Required images for Ingress-Nginx
+INGRESS_NGINX_IMAGES=(
+    "openbkn-ai/ingress-nginx/controller:v1.14.1"
+    "openbkn-ai/ingress-nginx/kube-webhook-certgen:v1.6.1"
+)
+
+# Required images for Local Path Provisioner
+LOCALPV_IMAGES=(
+    "openbkn-ai/rancher/local-path-provisioner:v0.0.32"
+    "openbkn-ai/busybox:1.36.1"
+)
+
+# Required images for MariaDB
+MARIADB_IMAGES=(
+    "openbkn-ai/mariadb:11.4.7"
+)
+
+# Required images for Redis
+REDIS_IMAGES=(
+    "openbkn-ai/redis:1.11.2-20251029.2.169ac3c0"
+)
+
+# Required images for Kafka
+KAFKA_IMAGES=(
+    "openbkn-ai/bitnami/kafka:3.9.0-debian-12-r10"
+)
+
+# Required images for OpenSearch
+OPENSEARCH_IMAGES=(
+    "openbkn-ai/opensearchproject/opensearch:2.19.4"
+    "openbkn-ai/busybox:1.36.1"
+)
+
+# Required images for other components
+OTHER_IMAGES=(
+    "openbkn-ai/portainer/kubectl-shell:latest"
+)
+
+# Required images for OpenBKN Applications
+# NOTE: OpenBKN application images are defined in Helm Charts
+# The actual image names depend on the specific version being deployed
+# Common images include:
+#   - openbkn-ai/bkn-core:<version>
+#   - openbkn-ai/bkn-auth:<version>
+#   - openbkn-ai/bkn-business-domain:<version>
+#   - openbkn-ai/bkn-foundry-web:<version>
+# You need to sync these images based on your deployment
+OPENBKN_APP_IMAGES=(
+    # Add your OpenBKN application images here, e.g.:
+    # "openbkn-ai/bkn-core:v1.0.0"
+    # "openbkn-ai/bkn-auth:v1.0.0"
+)
+
+log_info "Images to sync:"
+echo "Kubernetes Components:"
+for img in "${K8S_IMAGES[@]}"; do
+    echo "  - ${img}"
+done
+echo ""
+echo "Flannel CNI:"
+for img in "${FLANNEL_IMAGES[@]}"; do
+    echo "  - ${img}"
+done
+echo ""
+echo "Ingress-Nginx:"
+for img in "${INGRESS_NGINX_IMAGES[@]}"; do
+    echo "  - ${img}"
+done
+echo ""
+echo "Local Path Provisioner:"
+for img in "${LOCALPV_IMAGES[@]}"; do
+    echo "  - ${img}"
+done
+echo ""
+echo "MariaDB:"
+for img in "${MARIADB_IMAGES[@]}"; do
+    echo "  - ${img}"
+done
+echo ""
+echo "Redis:"
+for img in "${REDIS_IMAGES[@]}"; do
+    echo "  - ${img}"
+done
+echo ""
+echo "Kafka:"
+for img in "${KAFKA_IMAGES[@]}"; do
+    echo "  - ${img}"
+done
+echo ""
+echo "OpenSearch:"
+for img in "${OPENSEARCH_IMAGES[@]}"; do
+    echo "  - ${img}"
+done
+echo ""
+echo "Other Components:"
+for img in "${OTHER_IMAGES[@]}"; do
+    echo "  - ${img}"
+done
+echo ""
+echo "OpenBKN Applications (configure based on your deployment):"
+if [[ ${#OPENBKN_APP_IMAGES[@]} -gt 0 ]]; then
+    for img in "${OPENBKN_APP_IMAGES[@]}"; do
+        echo "  - ${img}"
+    done
+else
+    echo "  (No OpenBKN application images configured)"
+    echo "  Please add your images to OPENBKN_APP_IMAGES array in this script"
+fi
+echo ""
+
+# Check if docker or podman is available
+if command -v docker &>/dev/null; then
+    CONTAINER_RUNTIME="docker"
+elif command -v podman &>/dev/null; then
+    CONTAINER_RUNTIME="podman"
+else
+    log_error "Neither docker nor podman is available. Please install one of them."
+    exit 1
+fi
+
+log_info "Using container runtime: ${CONTAINER_RUNTIME}"
+
+# Function to sync a single image
+sync_image() {
+    local source_image="$1"
+    local target_image="$2"
+
+    log_info "Syncing ${source_image} -> ${target_image}"
+
+    # Pull from source
+    if ! ${CONTAINER_RUNTIME} pull "${source_image}"; then
+        log_error "Failed to pull ${source_image}"
+        return 1
+    fi
+
+    # Tag for target
+    if ! ${CONTAINER_RUNTIME} tag "${source_image}" "${target_image}"; then
+        log_error "Failed to tag ${source_image}"
+        return 1
+    fi
+
+    # Push to target
+    if ! ${CONTAINER_RUNTIME} push "${target_image}"; then
+        log_error "Failed to push ${target_image}"
+        return 1
+    fi
+
+    log_info "✓ ${source_image} synced successfully"
+    return 0
+}
+
+# Test connectivity to target registry
+log_info "Testing connectivity to ${TARGET_REGISTRY}..."
+if ! curl -s "http://${TARGET_REGISTRY}/v2/" >/dev/null 2>&1; then
+    log_warn "Cannot connect to http://${TARGET_REGISTRY}/v2/"
+    log_warn "If your registry uses HTTPS or requires authentication, please configure it manually."
+    log_warn "Continuing anyway..."
+else
+    log_info "✓ Target registry is accessible"
+fi
+
+# Initialize counters
+FAILED_IMAGES=()
+SYNCED_COUNT=0
+FAILED_COUNT=0
+
+# Sync Kubernetes images
+log_info "Syncing Kubernetes images..."
+for image in "${K8S_IMAGES[@]}"; do
+    source_image="${SOURCE_REGISTRY}/${image}"
+    target_image="${TARGET_REGISTRY}/${TARGET_NAMESPACE}/${image}"
+
+    if sync_image "${source_image}" "${target_image}"; then
+        SYNCED_COUNT=$((SYNCED_COUNT + 1))
+    else
+        FAILED_IMAGES+=("${source_image}")
+        FAILED_COUNT=$((FAILED_COUNT + 1))
+    fi
+done
+
+# Sync Flannel images from SWR
+log_info "Syncing Flannel CNI images..."
+FLANNEL_SOURCE="swr.cn-east-3.myhuaweicloud.com"
+for image in "${FLANNEL_IMAGES[@]}"; do
+    source_image="${FLANNEL_SOURCE}/${image}"
+    target_image="${TARGET_REGISTRY}/${image}"
+
+    if sync_image "${source_image}" "${target_image}"; then
+        SYNCED_COUNT=$((SYNCED_COUNT + 1))
+    else
+        FAILED_IMAGES+=("${source_image}")
+        FAILED_COUNT=$((FAILED_COUNT + 1))
+    fi
+done
+
+# Sync Ingress-Nginx images from SWR
+log_info "Syncing Ingress-Nginx images..."
+INGRESS_SOURCE="swr.cn-east-3.myhuaweicloud.com"
+for image in "${INGRESS_NGINX_IMAGES[@]}"; do
+    source_image="${INGRESS_SOURCE}/${image}"
+    target_image="${TARGET_REGISTRY}/${image}"
+
+    if sync_image "${source_image}" "${target_image}"; then
+        SYNCED_COUNT=$((SYNCED_COUNT + 1))
+    else
+        FAILED_IMAGES+=("${source_image}")
+        FAILED_COUNT=$((FAILED_COUNT + 1))
+    fi
+done
+
+# Sync Local Path Provisioner images from SWR
+log_info "Syncing Local Path Provisioner images..."
+LOCALPV_SOURCE="swr.cn-east-3.myhuaweicloud.com"
+for image in "${LOCALPV_IMAGES[@]}"; do
+    source_image="${LOCALPV_SOURCE}/${image}"
+    target_image="${TARGET_REGISTRY}/${image}"
+
+    if sync_image "${source_image}" "${target_image}"; then
+        SYNCED_COUNT=$((SYNCED_COUNT + 1))
+    else
+        FAILED_IMAGES+=("${source_image}")
+        FAILED_COUNT=$((FAILED_COUNT + 1))
+    fi
+done
+
+# Sync MariaDB images from SWR
+log_info "Syncing MariaDB images..."
+MARIADB_SOURCE="swr.cn-east-3.myhuaweicloud.com"
+for image in "${MARIADB_IMAGES[@]}"; do
+    source_image="${MARIADB_SOURCE}/${image}"
+    target_image="${TARGET_REGISTRY}/${image}"
+
+    if sync_image "${source_image}" "${target_image}"; then
+        SYNCED_COUNT=$((SYNCED_COUNT + 1))
+    else
+        FAILED_IMAGES+=("${source_image}")
+        FAILED_COUNT=$((FAILED_COUNT + 1))
+    fi
+done
+
+# Sync Redis images from SWR
+log_info "Syncing Redis images..."
+REDIS_SOURCE="swr.cn-east-3.myhuaweicloud.com"
+for image in "${REDIS_IMAGES[@]}"; do
+    source_image="${REDIS_SOURCE}/${image}"
+    target_image="${TARGET_REGISTRY}/${image}"
+
+    if sync_image "${source_image}" "${target_image}"; then
+        SYNCED_COUNT=$((SYNCED_COUNT + 1))
+    else
+        FAILED_IMAGES+=("${source_image}")
+        FAILED_COUNT=$((FAILED_COUNT + 1))
+    fi
+done
+
+# Sync Kafka images from SWR
+log_info "Syncing Kafka images..."
+KAFKA_SOURCE="swr.cn-east-3.myhuaweicloud.com"
+for image in "${KAFKA_IMAGES[@]}"; do
+    source_image="${KAFKA_SOURCE}/${image}"
+    target_image="${TARGET_REGISTRY}/${image}"
+
+    if sync_image "${source_image}" "${target_image}"; then
+        SYNCED_COUNT=$((SYNCED_COUNT + 1))
+    else
+        FAILED_IMAGES+=("${source_image}")
+        FAILED_COUNT=$((FAILED_COUNT + 1))
+    fi
+done
+
+# Sync OpenSearch images from SWR
+log_info "Syncing OpenSearch images..."
+OPENSEARCH_SOURCE="swr.cn-east-3.myhuaweicloud.com"
+for image in "${OPENSEARCH_IMAGES[@]}"; do
+    source_image="${OPENSEARCH_SOURCE}/${image}"
+    target_image="${TARGET_REGISTRY}/${image}"
+
+    if sync_image "${source_image}" "${target_image}"; then
+        SYNCED_COUNT=$((SYNCED_COUNT + 1))
+    else
+        FAILED_IMAGES+=("${source_image}")
+        FAILED_COUNT=$((FAILED_COUNT + 1))
+    fi
+done
+
+# Sync other images from SWR
+log_info "Syncing other component images..."
+OTHER_SOURCE="swr.cn-east-3.myhuaweicloud.com"
+for image in "${OTHER_IMAGES[@]}"; do
+    source_image="${OTHER_SOURCE}/${image}"
+    target_image="${TARGET_REGISTRY}/${image}"
+
+    if sync_image "${source_image}" "${target_image}"; then
+        SYNCED_COUNT=$((SYNCED_COUNT + 1))
+    else
+        FAILED_IMAGES+=("${source_image}")
+        FAILED_COUNT=$((FAILED_COUNT + 1))
+    fi
+done
+
+# Sync OpenBKN application images from SWR (if configured)
+if [[ ${#OPENBKN_APP_IMAGES[@]} -gt 0 ]]; then
+    log_info "Syncing OpenBKN application images..."
+    OPENBKN_SOURCE="swr.cn-east-3.myhuaweicloud.com"
+    for image in "${OPENBKN_APP_IMAGES[@]}"; do
+        source_image="${OPENBKN_SOURCE}/${image}"
+        target_image="${TARGET_REGISTRY}/${image}"
+
+        if sync_image "${source_image}" "${target_image}"; then
+            SYNCED_COUNT=$((SYNCED_COUNT + 1))
+        else
+            FAILED_IMAGES+=("${source_image}")
+            FAILED_COUNT=$((FAILED_COUNT + 1))
+        fi
+    done
+else
+    log_info "Skipping OpenBKN application images (none configured)"
+    log_info "To sync OpenBKN app images, edit this script and add them to OPENBKN_APP_IMAGES array"
+fi
+
+echo ""
+log_info "=== Sync Summary ==="
+log_info "Total images synced: ${SYNCED_COUNT}"
+log_info "Failed: ${FAILED_COUNT}"
+
+if [[ ${FAILED_COUNT} -gt 0 ]]; then
+    log_error "Failed images:"
+    for img in "${FAILED_IMAGES[@]}"; do
+        echo "  - ${img}"
+    done
+    exit 1
+fi
+
+echo ""
+log_info "✓ All images synced successfully!"
+log_info ""
+log_info "Next steps:"
+log_info "1. Verify images in your offline registry:"
+log_info "   curl http://${TARGET_REGISTRY}/v2/${TARGET_NAMESPACE}/kube-apiserver/tags/list"
+log_info "   curl http://${TARGET_REGISTRY}/v2/openbkn-ai/flannel/flannel/tags/list"
+log_info "   curl http://${TARGET_REGISTRY}/v2/openbkn-ai/ingress-nginx/controller/tags/list"
+log_info "   curl http://${TARGET_REGISTRY}/v2/openbkn-ai/rancher/local-path-provisioner/tags/list"
+log_info "   curl http://${TARGET_REGISTRY}/v2/openbkn-ai/mariadb/tags/list"
+log_info "   curl http://${TARGET_REGISTRY}/v2/openbkn-ai/redis/tags/list"
+log_info "   curl http://${TARGET_REGISTRY}/v2/openbkn-ai/bitnami/kafka/tags/list"
+log_info "   curl http://${TARGET_REGISTRY}/v2/openbkn-ai/opensearchproject/opensearch/tags/list"
+log_info ""
+log_info "2. Deploy Kubernetes in offline mode:"
+log_info "   sudo bash ./deploy.sh --offline k8s install"
+log_info ""
+log_info "   Or with custom registry:"
+log_info "   sudo bash ./deploy.sh --offline=${TARGET_REGISTRY} k8s install"
+log_info ""
+log_info "3. Deploy data services in offline mode:"
+log_info "   sudo bash ./deploy.sh --offline foundry install --minimum"
+log_info "   Or deploy individual services:"
+log_info "   sudo bash ./deploy.sh --offline mariadb install"
+log_info "   sudo bash ./deploy.sh --offline redis install"
+log_info "   sudo bash ./deploy.sh --offline kafka install"
+log_info "   sudo bash ./deploy.sh --offline opensearch install"

--- a/deploy/scripts/verify-offline.sh
+++ b/deploy/scripts/verify-offline.sh
@@ -1,0 +1,148 @@
+#!/bin/bash
+# 离线环境验证脚本
+# 用于检查离线部署所需的所有组件是否已安装
+
+set -e
+
+echo "=========================================="
+echo "   离线环境验证脚本"
+echo "=========================================="
+echo ""
+
+# 设置离线仓库地址（可从环境变量覆盖）
+OFFLINE_REGISTRY="${OFFLINE_REGISTRY:-registry.openbkn.ai:5000}"
+
+# 检查函数
+check_command() {
+    local cmd="$1"
+    local package="$2"
+
+    if command -v "$cmd" &>/dev/null; then
+        local version
+        version=$($cmd --version 2>/dev/null | head -1 || $cmd version 2>/dev/null | head -1 || echo "unknown")
+        echo "✓ $cmd: $(command -v $cmd) ($version)"
+        return 0
+    else
+        echo "✗ $cmd: 未安装"
+        echo "  安装方法: yum install -y $package"
+        return 1
+    fi
+}
+
+check_service() {
+    local service="$1"
+    if systemctl is-active --quiet "$service" 2>/dev/null; then
+        echo "✓ $service: 运行中"
+        return 0
+    else
+        echo "✗ $service: 未运行"
+        return 1
+    fi
+}
+
+# 系统检查
+echo "1. 系统组件检查"
+echo "----------------------------------------"
+ERRORS=0
+
+check_command kubeadm kubeadm || ERRORS=$((ERRORS + 1))
+check_command kubelet kubelet || ERRORS=$((ERRORS + 1))
+check_command kubectl kubectl || ERRORS=$((ERRORS + 1))
+check_command containerd containerd.io || ERRORS=$((ERRORS + 1))
+check_command crictl cri-tools || ERRORS=$((ERRORS + 1))
+check_command helm helm || ERRORS=$((ERRORS + 1))
+check_command python3 python3 || ERRORS=$((ERRORS + 1))
+
+echo ""
+echo "2. 服务状态检查"
+echo "----------------------------------------"
+check_service containerd || ERRORS=$((ERRORS + 1))
+
+echo ""
+echo "3. CNI 插件检查"
+echo "----------------------------------------"
+if [[ -x /opt/cni/bin/loopback ]]; then
+    echo "✓ CNI 插件: /opt/cni/bin/loopback 存在"
+    ls -la /opt/cni/bin/ | head -5
+else
+    echo "✗ CNI 插件: /opt/cni/bin/loopback 不存在"
+    echo "  安装方法: yum install -y kubernetes-cni"
+    ERRORS=$((ERRORS + 1))
+fi
+
+echo ""
+echo "4. 镜像仓库连接性检查"
+echo "----------------------------------------"
+echo "离线仓库地址: $OFFLINE_REGISTRY"
+
+if curl -s --connect-timeout 5 "http://${OFFLINE_REGISTRY}/v2/" &>/dev/null; then
+    echo "✓ 离线镜像仓库可访问 (HTTP)"
+
+    # 检查关键镜像
+    echo ""
+    echo "检查关键镜像:"
+    IMAGES=(
+        "google_containers/kube-apiserver"
+        "google_containers/kube-proxy"
+        "google_containers/pause"
+        "flannel/flannel"
+        "ingress-nginx/controller"
+    )
+
+    for img in "${IMAGES[@]}"; do
+        if curl -s "http://${OFFLINE_REGISTRY}/v2/${img}/tags/list" | grep -q "tags"; then
+            echo "  ✓ $img"
+        else
+            echo "  ✗ $img (未找到)"
+        fi
+    done
+else
+    echo "✗ 离线镜像仓库不可访问"
+    echo "  请检查仓库地址和网络连接"
+    ERRORS=$((ERRORS + 1))
+fi
+
+echo ""
+echo "5. 系统配置检查"
+echo "----------------------------------------"
+
+# 检查 Swap
+if swapon --show | grep -q .; then
+    echo "✗ Swap: 已启用（需要关闭）"
+    ERRORS=$((ERRORS + 1))
+else
+    echo "✓ Swap: 已关闭"
+fi
+
+# 检查 IP 转发
+if [[ "$(cat /proc/sys/net/ipv4/ip_forward)" == "1" ]]; then
+    echo "✓ IP 转发: 已启用"
+else
+    echo "✗ IP 转发: 未启用"
+    ERRORS=$((ERRORS + 1))
+fi
+
+# 检查防火墙
+if systemctl is-active --quiet firewalld 2>/dev/null; then
+    echo "⚠ 防火墙: firewalld 运行中（建议关闭）"
+elif systemctl is-active --quiet ufw 2>/dev/null; then
+    echo "⚠ 防火墙: ufw 运行中（建议关闭）"
+else
+    echo "✓ 防火墙: 未运行"
+fi
+
+echo ""
+echo "=========================================="
+if [[ $ERRORS -eq 0 ]]; then
+    echo "✓ 所有检查通过！环境已就绪"
+    echo ""
+    echo "可以开始离线部署："
+    echo "  sudo bash ./deploy.sh --offline k8s install"
+else
+    echo "✗ 发现 $ERRORS 个问题，请先解决"
+    echo ""
+    echo "参考文档: docs/offline-prerequisites.zh.md"
+fi
+echo "=========================================="
+
+exit $ERRORS


### PR DESCRIPTION
feat: 添加离线部署支持

通过 --offline 参数为隔离环境提供完整的离线部署能力。
支持 Kubernetes、所有数据服务和 OpenBKN 应用的离线部署。

主要变更：
- 新增 --offline 参数及 OFFLINE_MODE/OFFLINE_REGISTRY 配置
- 修改所有服务脚本支持离线镜像仓库
- 新增 sync-k8s-images.sh 脚本用于镜像同步
- 镜像仓库解析优先支持离线模式
- 新增离线部署相关文档

默认离线仓库：registry.openbkn.ai:5000
自定义仓库：--offline=<registry>

无破坏性变更，离线模式为可选功能。