### PR TITLE
ci: force Docker media types on image push so SWR accepts manifest

### DIFF
--- a/.github/workflows/reusable-build.yml
+++ b/.github/workflows/reusable-build.yml
@@ -111,3 +111,9 @@ jobs:
           provenance: false
           sbom: false
           tags: ${{ steps.tags.outputs.tags }}
+          # Force legacy Docker media types. BuildKit v0.31.0 flipped the
+          # default to OCI media types for all images (previously only when
+          # attestations/annotations were needed); Huawei SWR rejects the OCI
+          # image index with "Invalid image, fail to parse 'manifest.json'".
+          # GHCR accepts Docker media types fine, so one setting fixes both.
+          outputs: type=image,oci-mediatypes=false


### PR DESCRIPTION
## 问题

BuildKit v0.31.0 把默认改成对**所有** image 结果用 OCI media types(以前只在需要 annotations/attestations 时才用)。浮动 tag `moby/buildkit:buildx-stable-1` 于 2026-07-16 挪到 v0.31.2,CI runner 从此产出 OCI image index。

华为 SWR 不支持 OCI image index,推送直接报:

```
ERROR: failed to push swr.../bkn-safe: unknown: Invalid image, fail to parse 'manifest.json'
```

GHCR 收下、SWR 挂 → 整个 build 失败。已实锤炸掉 main 上的 `release-adp-bkn-safe`(run 29544848447)。日志里 `provenance`/`sbom` 都已 `disabled=true`,OCI 仍照出,证明是 v0.31.0 默认翻转,不是 attestation 触发。

## 修复

给 image exporter 设 `oci-mediatypes=false`,强制输出旧版 Docker media types。GHCR 向后兼容无碍,所以在共享的 `reusable-build` 里一处设置即覆盖全部 10 个 SWR 镜像的 release workflow,各服务 yml 无需改动。

```yaml
outputs: type=image,oci-mediatypes=false
```

与 `push`/`tags` 共存(docker 官方示例即此写法)。YAML 已本地校验通过。

## 影响面

- 触碰单文件 `.github/workflows/reusable-build.yml`
- 修复所有 `secrets: inherit` 走 reusable-build 的 release-*(bkn-safe / bkn-backend / vega-backend / mf-model-* / oss-gateway / agent-retrieval / operator-integration / model-factory-base / bkn-trace-* 等)

🤖 Generated with [Claude Code](https://claude.com/claude-code)