### PR TITLE
fix: bkn-agent agent-as-tool 工具名清洗为 OpenAI 合法 function name

### DIFF
--- a/docs/api/bkn-agent.yaml
+++ b/docs/api/bkn-agent.yaml
@@ -856,7 +856,8 @@ components:
         name:
           anyOf:
           - type: string
-            maxLength: 100
+            maxLength: 64
+            pattern: ^[a-zA-Z0-9_-]+$
           - type: 'null'
           title: Name
         description:

--- a/infra/bkn-agent/app/core/tools.py
+++ b/infra/bkn-agent/app/core/tools.py
@@ -6,7 +6,7 @@ from langchain_core.tools import StructuredTool
 from langchain_mcp_adapters.client import MultiServerMCPClient
 
 from app.config import config
-from app.core.toolbox import load_toolbox_tools
+from app.core.toolbox import _safe_name, load_toolbox_tools
 from app.errors import bad_request
 
 logger = logging.getLogger("bkn-agent.tools")
@@ -107,7 +107,11 @@ async def _agent_tool(
             await dao.set_task_status(session, task.task_id, "succeeded", output=output)
         return output
 
-    name = ref.get("name") or f"agent_{sub_agent.name}"
+    # OpenAI function name 只收 ASCII 字母数字 _ - 且 ≤64；AgentSpec.name 合法中文名
+    # 原样当工具名会让引用方每次模型请求稳定 400。统一走 _safe_name 清洗+截断，
+    # 全非 ASCII 名清洗后无字母数字则兜底 tool_{agent_id 前缀}；语义靠 description
+    # 传达（含原始中文名），不靠 function name。
+    name = _safe_name(ref.get("name") or f"agent_{sub_agent.name}", sub_agent.agent_id)
     description = ref.get("description") or f"调用子 agent「{sub_agent.name}」完成一次性任务。"
     return StructuredTool.from_function(coroutine=call_sub_agent, name=name, description=description)
 

--- a/infra/bkn-agent/app/models.py
+++ b/infra/bkn-agent/app/models.py
@@ -115,6 +115,10 @@ class ToolboxToolRef(_ToolRefBase):
 class AgentToolRef(_ToolRefBase):
     type: Literal["agent"]
     agent_id: str = Field(min_length=1, max_length=100)
+    # 显式工具名直接当 OpenAI function name：只收 ASCII 字母数字 _ -，≤64
+    # （中文/超长会让引用方每次模型请求稳定 400；中文语义放 description）。
+    # 运行时侧 tools.py 对派生名（agent_{中文名}）同样清洗兜底。
+    name: Optional[str] = Field(default=None, max_length=64, pattern=r"^[a-zA-Z0-9_-]+$")
 
 
 ToolRef = Annotated[

--- a/infra/bkn-agent/app/test/test_review_fixes2.py
+++ b/infra/bkn-agent/app/test/test_review_fixes2.py
@@ -285,3 +285,38 @@ def test_export_rejects_dirty_agent_with_clear_error(monkeypatch):
         assert "DirtyAgent" in r.json()["code"]
     finally:
         app.dependency_overrides.clear()
+
+
+def test_agent_tool_name_sanitized_for_openai():
+    """P1 五轮：中文/长 agent 名派生的 function name 必须清洗成 OpenAI 合法名。"""
+    from app.core.toolbox import _safe_name
+
+    # 中文名派生：agent_语义理解 → 清洗后仍含 agent 前缀字母，非法字符转 _
+    n = _safe_name("agent_语义理解", "d9bfcrlcr79gcukmqofg")
+    import re
+    assert re.fullmatch(r"[a-zA-Z0-9_-]{1,64}", n), n
+    # 全非 ASCII：兜底 tool_{id 前缀}
+    n2 = _safe_name("语义理解", "d9bfcrlcr79gcukmqofg")
+    assert re.fullmatch(r"[a-zA-Z0-9_-]{1,64}", n2) and n2.startswith("tool_")
+    # 超长截断
+    assert len(_safe_name("a" * 200, "x")) <= 64
+
+
+def test_agent_tool_ref_explicit_name_constrained():
+    """AgentToolRef 显式 name 只收 ASCII [a-zA-Z0-9_-] ≤64；mcp/toolbox 的 name 不受此限。"""
+    import pytest
+    from pydantic import ValidationError
+
+    from app.models import AgentSpec
+
+    ok = AgentSpec(name="t", mode="chat",
+                   tools=[{"type": "agent", "agent_id": "a1", "name": "semantic_v1"}])
+    assert ok.tools[0]["name"] == "semantic_v1"
+    for bad_name in ("语义理解", "has space", "x" * 65):
+        with pytest.raises(ValidationError):
+            AgentSpec(name="t", mode="chat",
+                      tools=[{"type": "agent", "agent_id": "a1", "name": bad_name}])
+    # mcp 连接名不是 function name，中文仍允许
+    m = AgentSpec(name="t", mode="chat",
+                  tools=[{"type": "mcp", "url": "http://x/mcp", "name": "外部服务"}])
+    assert m.tools[0]["name"] == "外部服务"


### PR DESCRIPTION
PR #237 合并后 review（@kenlee1988 第五轮 P1）的修复。

**问题**：`AgentSpec.name` 合法中文名派生 `agent_{中文名}` 直接当模型工具名，OpenAI function name 只收 ASCII `[a-zA-Z0-9_-]` ≤64——引用中文名 task agent 的一方**每次模型请求稳定 400**（整个 chat 不可用），而中文名是 name pattern 明确允许的一等公民。

**修复**：
- 运行时派生名复用 `toolbox._safe_name` 清洗+截断（全非 ASCII 兜底 `tool_{agent_id 前缀}`），语义靠 description（含原始中文名）传达
- `AgentToolRef` 显式 `name` 同 pattern ≤64 创建边界即拒（mcp 连接名非 function name，不受限）

补 2 测（84 全绿），契约重导出。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes #251