### PR TITLE
fix(vega): filter catalog list by connector type

### DIFF
--- a/adp/vega/vega-backend/server/drivenadapters/catalog/catalog_access.go
+++ b/adp/vega/vega-backend/server/drivenadapters/catalog/catalog_access.go
@@ -615,6 +615,10 @@ func (ca *catalogAccess) List(ctx context.Context, params interfaces.CatalogsQue
 		builder = builder.Where(sq.Eq{catalogExtCol(params, "f_type"): params.Type})
 		countBuilder = countBuilder.Where(sq.Eq{catalogExtCol(params, "f_type"): params.Type})
 	}
+	if params.ConnectorType != "" {
+		builder = builder.Where(sq.Eq{catalogExtCol(params, "f_connector_type"): params.ConnectorType})
+		countBuilder = countBuilder.Where(sq.Eq{catalogExtCol(params, "f_connector_type"): params.ConnectorType})
+	}
 	if params.Enabled != nil {
 		builder = builder.Where(sq.Eq{catalogExtCol(params, "f_enabled"): *params.Enabled})
 		countBuilder = countBuilder.Where(sq.Eq{catalogExtCol(params, "f_enabled"): *params.Enabled})

--- a/adp/vega/vega-backend/server/drivenadapters/catalog/catalog_access_test.go
+++ b/adp/vega/vega-backend/server/drivenadapters/catalog/catalog_access_test.go
@@ -113,15 +113,16 @@ func TestCatalogAccessList(t *testing.T) {
 			Name:                  "Catalog",
 			Tag:                   "tag-a",
 			Type:                  interfaces.CatalogTypePhysical,
+			ConnectorType:         "postgresql",
 			Enabled:               &enabled,
 			HealthCheckStatus:     interfaces.CatalogHealthStatusHealthy,
 		}
 
-		mock.ExpectQuery(regexp.QuoteMeta("SELECT COUNT(*) FROM t_catalog WHERE f_name LIKE ? AND f_tags LIKE ? AND f_type = ? AND f_enabled = ? AND f_health_check_status = ?")).
-			WithArgs("%Catalog%", "%tag-a%", interfaces.CatalogTypePhysical, true, interfaces.CatalogHealthStatusHealthy).
+		mock.ExpectQuery(regexp.QuoteMeta("SELECT COUNT(*) FROM t_catalog WHERE f_name LIKE ? AND f_tags LIKE ? AND f_type = ? AND f_connector_type = ? AND f_enabled = ? AND f_health_check_status = ?")).
+			WithArgs("%Catalog%", "%tag-a%", interfaces.CatalogTypePhysical, "postgresql", true, interfaces.CatalogHealthStatusHealthy).
 			WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(int64(1)))
-		mock.ExpectQuery(regexp.QuoteMeta("SELECT f_id, f_name, f_tags, f_description, f_type, f_enabled, f_internal, f_connector_type, f_connector_config, f_metadata, f_health_check_enabled, f_health_check_status, f_last_check_time, f_health_check_result, f_creator, f_creator_type, f_create_time, f_updater, f_updater_type, f_update_time FROM t_catalog WHERE f_name LIKE ? AND f_tags LIKE ? AND f_type = ? AND f_enabled = ? AND f_health_check_status = ? ORDER BY f_name ASC")).
-			WithArgs("%Catalog%", "%tag-a%", interfaces.CatalogTypePhysical, true, interfaces.CatalogHealthStatusHealthy).
+		mock.ExpectQuery(regexp.QuoteMeta("SELECT f_id, f_name, f_tags, f_description, f_type, f_enabled, f_internal, f_connector_type, f_connector_config, f_metadata, f_health_check_enabled, f_health_check_status, f_last_check_time, f_health_check_result, f_creator, f_creator_type, f_create_time, f_updater, f_updater_type, f_update_time FROM t_catalog WHERE f_name LIKE ? AND f_tags LIKE ? AND f_type = ? AND f_connector_type = ? AND f_enabled = ? AND f_health_check_status = ? ORDER BY f_name ASC")).
+			WithArgs("%Catalog%", "%tag-a%", interfaces.CatalogTypePhysical, "postgresql", true, interfaces.CatalogHealthStatusHealthy).
 			WillReturnRows(catalogRows().AddRow(catalogRowValues(sampleCatalog())...))
 
 		got, total, err := access.List(context.Background(), params)

--- a/adp/vega/vega-backend/server/driveradapters/catalog_handler.go
+++ b/adp/vega/vega-backend/server/driveradapters/catalog_handler.go
@@ -65,6 +65,7 @@ func (r *restHandler) listCatalogs(c *gin.Context, visitor hydra.Visitor) {
 	name := strings.TrimSpace(c.Query("name"))
 	tag := strings.TrimSpace(c.Query("tag"))
 	typ := c.Query("type")
+	connectorType := strings.TrimSpace(c.Query("connector_type"))
 	var enabled *bool
 	if enabledStr := strings.TrimSpace(c.Query("enabled")); enabledStr != "" {
 		b, err := strconv.ParseBool(enabledStr)
@@ -106,6 +107,7 @@ func (r *restHandler) listCatalogs(c *gin.Context, visitor hydra.Visitor) {
 		Name:                  name,
 		Tag:                   tag,
 		Type:                  typ,
+		ConnectorType:         connectorType,
 		Enabled:               enabled,
 		HealthCheckStatus:     healthCheckStatus,
 		ExtensionKeys:         extKeys,

--- a/adp/vega/vega-backend/server/driveradapters/catalog_handler_test.go
+++ b/adp/vega/vega-backend/server/driveradapters/catalog_handler_test.go
@@ -107,6 +107,22 @@ func Test_CatalogRestHandler_ListCatalogs(t *testing.T) {
 		require.Equal(t, http.StatusOK, w.Result().StatusCode)
 	})
 
+	t.Run("success list catalogs with connector type", func(t *testing.T) {
+		engine, cs, _ := setupCatalogHandlerTest(t)
+		cs.EXPECT().List(gomock.Any(), gomock.Any()).
+			DoAndReturn(func(_ context.Context, params interfaces.CatalogsQueryParams) ([]*interfaces.Catalog, int64, error) {
+				assert.Equal(t, "postgresql", params.ConnectorType)
+				return []*interfaces.Catalog{}, int64(0), nil
+			})
+
+		req := httptest.NewRequest(http.MethodGet, url+"?connector_type=postgresql", nil)
+		w := httptest.NewRecorder()
+
+		engine.ServeHTTP(w, req)
+
+		require.Equal(t, http.StatusOK, w.Result().StatusCode)
+	})
+
 	t.Run("success list catalogs with enabled filter", func(t *testing.T) {
 		engine, cs, _ := setupCatalogHandlerTest(t)
 		cs.EXPECT().List(gomock.Any(), gomock.Any()).

--- a/adp/vega/vega-backend/server/interfaces/catalog.go
+++ b/adp/vega/vega-backend/server/interfaces/catalog.go
@@ -69,6 +69,7 @@ type CatalogsQueryParams struct {
 	Name              string
 	Tag               string
 	Type              string
+	ConnectorType     string
 	Enabled           *bool
 	HealthCheckStatus string
 	// ExtensionKeys / ExtensionValues 成对等长，多对 AND（列表筛选）


### PR DESCRIPTION
# Pull Request

## What Changed

Brief description of changes:

- [x] Vega catalog list API now reads `connector_type` into `CatalogsQueryParams`.
- [x] Catalog list and `COUNT(*)` queries filter on `f_connector_type` when the parameter is supplied.
- [x] Added handler and catalog-access regression coverage for parameter propagation and SQL bindings.
- [ ] Docs/doc 1

---

## Why

- Related Issue: [Issue #256](https://github.com/openbkn-ai/bkn-foundry/issues/256)
- Related Feature: Catalog list filtering
- Background: the backend previously ignored `connector_type`; frontend client-side filtering could hide mismatched entries, but server-side pagination and `total_count` remained incorrect.

---

## How

- Key implementation points:
  - Parse and trim `connector_type` in the catalog list handler.
  - Pass it through the list query model.
  - Apply `f_connector_type = ?` consistently to the list and count SQL builders.
  - Assert the handler parameter and both SQL query bindings in unit tests.
- Breaking changes (API, config, database, etc.): None. Existing optional query parameter now takes effect as intended.

---

## Testing

- [x] Unit tests passed locally
- [ ] Integration tests passed locally
- [ ] Verified in test environment

Test notes:

- `go test ./driveradapters ./drivenadapters/catalog`

---

## Risk & Rollback

- Potential risks: callers that depended on the previously ignored query parameter will receive the correctly narrowed result set and total count.
- Rollback plan: revert commit `35f0b717`.

---

## Additional Notes

- Screenshots, logs, documentation links, etc.: No UI or schema changes.