### PR TITLE
fix(bkn): include index config for concept dataset

### DIFF
--- a/adp/bkn/bkn-backend/server/interfaces/common.go
+++ b/adp/bkn/bkn-backend/server/interfaces/common.go
@@ -394,6 +394,9 @@ var (
 		Category:    "dataset",
 		Description: "BKN的概念存储数据集",
 		Tags:        []string{"BKN", "概念索引", "concept"},
+		// Vega requires this non-null resource-level configuration. Keep an
+		// explicit empty object so the internal create request includes it.
+		IndexConfig: &VegaResourceIndexConfig{},
 		// Status:           "active",
 		// SchemaDefinition: GetBKNConceptSchemaDefinition(vectorDim),
 	}

--- a/adp/bkn/bkn-backend/server/interfaces/vega_backend_access.go
+++ b/adp/bkn/bkn-backend/server/interfaces/vega_backend_access.go
@@ -65,7 +65,15 @@ type VegaResource struct {
 	Description string   `json:"description"`
 	Category    string   `json:"category"`
 	// Status           string      `json:"status"`
-	SchemaDefinition []*Property `json:"schema_definition,omitempty"`
+	SchemaDefinition []*Property              `json:"schema_definition,omitempty"`
+	IndexConfig      *VegaResourceIndexConfig `json:"index_config,omitempty"`
+}
+
+// VegaResourceIndexConfig mirrors vega-backend's resource-level index configuration.
+type VegaResourceIndexConfig struct {
+	BuildKeyFields          []string `json:"build_key_fields,omitempty"`
+	DefaultFulltextAnalyzer string   `json:"default_fulltext_analyzer,omitempty"`
+	DefaultEmbeddingModel   string   `json:"default_embedding_model,omitempty"`
 }
 
 // CatalogsListResponse represents catalogs list response

--- a/adp/bkn/bkn-backend/server/logics/ontology_init_test.go
+++ b/adp/bkn/bkn-backend/server/logics/ontology_init_test.go
@@ -7,6 +7,7 @@
 package logics
 
 import (
+	"encoding/json"
 	"testing"
 
 	. "github.com/smartystreets/goconvey/convey"
@@ -32,6 +33,26 @@ func Test_bknCatalogRequest(t *testing.T) {
 			So(req.Name, ShouldEqual, interfaces.BKN_CATALOG_NAME)
 		})
 	})
+}
+
+func TestBKNConceptDatasetIncludesEmptyIndexConfig(t *testing.T) {
+	data, err := json.Marshal(interfaces.BKN_CONCEPT_DATASET)
+	if err != nil {
+		t.Fatalf("marshal BKN concept dataset: %v", err)
+	}
+
+	var request map[string]any
+	if err := json.Unmarshal(data, &request); err != nil {
+		t.Fatalf("unmarshal BKN concept dataset: %v", err)
+	}
+
+	indexConfig, ok := request["index_config"]
+	if !ok {
+		t.Fatal("create dataset request must include index_config")
+	}
+	if config, ok := indexConfig.(map[string]any); !ok || len(config) != 0 {
+		t.Fatalf("index_config = %#v, want empty object", indexConfig)
+	}
 }
 
 // ── comparePropertyFeature ────────────────────────────────────────────────────


### PR DESCRIPTION
# Pull Request

## What Changed

Brief description of changes:

- [x] Add the Vega-compatible `index_config` DTO to BKN’s resource create request.
- [x] Send an explicit empty `index_config` object when initializing the BKN concept dataset.
- [x] Add a regression test for the serialized create-dataset request.
- [ ] Docs/doc 1

---

## Why

- Related Issue: [Issue #258](https://github.com/openbkn-ai/bkn-foundry/issues/258)
- Related Feature: BKN concept dataset initialization
- Background: Vega resource creation now has a non-null `f_index_config` schema contract. BKN’s cross-service DTO omitted the field, so its internal dataset-create request did not carry the new contract value.

---

## How

- Key implementation points:
  - Mirror Vega’s resource-level index configuration in `VegaResourceIndexConfig`.
  - Set `BKN_CONCEPT_DATASET.IndexConfig` to an empty configuration object so JSON serialization produces `"index_config": {}`.
  - Assert the field exists and is an empty JSON object in the initialization regression test.
- Breaking changes (API, config, database, etc.): None.

---

## Testing

- [x] Unit tests passed locally
- [ ] Integration tests passed locally
- [ ] Verified in test environment

Test notes:

- `go test ./interfaces`
- `TestBKNConceptDatasetIncludesEmptyIndexConfig` passed using the compiled `./logics` test binary from the server directory. The ordinary package command is blocked by an existing locale-relative-path initialization issue.

---

## Risk & Rollback

- Potential risks: The internal resource-create payload gains an empty optional JSON object. Vega accepts this configuration shape.
- Rollback plan: Revert commit `a502c21e`; the change is isolated to BKN’s Vega request contract and its regression test.

---

## Additional Notes

- The Vega database column remains non-null; this change fixes the caller contract instead of relying on a database default.