### PR TITLE
docs(api): index module display titles + drop duplicate top-bar title

### DIFF
--- a/.github/workflows/ci-docs-api.yml
+++ b/.github/workflows/ci-docs-api.yml
@@ -117,7 +117,7 @@ jobs:
             echo '<title>BKN Foundry API 文档中心</title>'
             echo '<style>body{margin:0;font:16px system-ui,sans-serif;color:#12212b}.bar{display:flex;gap:12px;align-items:center;padding:12px 20px;border-bottom:1px solid #e4eaf0;background:#fff}.bar b{font-size:15px}select{padding:6px 10px;font-size:14px;border:1px solid #e4eaf0;border-radius:8px}iframe{border:0;width:100%;height:calc(100vh - 50px);display:block}</style>'
             echo '</head><body>'
-            echo '<div class="bar"><b>BKN Foundry API 文档中心</b><label>版本 <select id="v" onchange="document.getElementById(&quot;f&quot;).src=&quot;versions/&quot;+this.value+&quot;/index.html&quot;"></select></label></div>'
+            echo '<div class="bar"><label>版本 <select id="v" onchange="document.getElementById(&quot;f&quot;).src=&quot;versions/&quot;+this.value+&quot;/index.html&quot;"></select></label></div>'
             printf '<iframe id="f" src="versions/%s/index.html"></iframe>\n' "$(echo "$VERSIONS" | head -1)"
             echo '<script>var vs=['
             for v in $VERSIONS; do printf '"%s",' "$v"; done

--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ TPL_DIR      := $(API_DIR)/_templates
 MODULE_DIRS  := $(dir $(wildcard $(API_DIR)/*/.))
 MODULES      := $(filter-out _shared _generated _templates,$(foreach d,$(MODULE_DIRS),$(notdir $(patsubst %/,%,$(d)))))
 
-.PHONY: api-docs api-docs-html api-docs-lint api-docs-clean print-moddesc print-resname
+.PHONY: api-docs api-docs-html api-docs-lint api-docs-clean print-modtitle print-moddesc print-resname
 
 ## api-docs-lint: 校验各模块 OpenAPI 文档合法且 $ref（含共享 schema）可解析。
 ## _shared/ 是 $ref 片段（无 openapi/info/paths 顶层），不作独立文档 lint，
@@ -48,6 +48,11 @@ api-docs:
 	done; \
 	rm -f "$$tmp"
 	@echo "done -> $(GEN_DIR)/"
+
+## 模块显示标题（index 分区标题用）。未列出的模块回落为目录名。
+MODTITLE_bkn            := BKN
+MODTITLE_ontology-query := Ontology 查询
+MODTITLE_vega           := VEGA 引擎
 
 ## 模块中文描述（index 卡片副标题用）。未列出的模块回落为空。
 MODDESC_bkn            := 业务知识网络：对象类 / 关系类 / 行动类 / 概念组 / 指标 / 导入导出
@@ -98,9 +103,10 @@ api-docs-html:
 	@idx="$(HTML_DIR)/index.html"; \
 	cat "$(TPL_DIR)/index-head.html" > "$$idx"; \
 	for m in $(MODULES); do \
+	  mt=$$(make -s print-modtitle MOD="$$m"); [ -n "$$mt" ] || mt="$$m"; \
 	  desc=$$(make -s print-moddesc MOD="$$m"); \
 	  count=$$(ls $(API_DIR)/$$m/*.yaml 2>/dev/null | wc -l | tr -d ' '); \
-	  printf '<section class="mod">\n<div class="mod-h"><h2>%s</h2><span class="count">%s</span></div>\n' "$$m" "$$count" >> "$$idx"; \
+	  printf '<section class="mod">\n<div class="mod-h"><h2>%s</h2><span class="count">%s</span></div>\n' "$$mt" "$$count" >> "$$idx"; \
 	  [ -n "$$desc" ] && printf '<p class="mod-desc">%s</p>\n' "$$desc" >> "$$idx"; \
 	  printf '<div class="grid">\n' >> "$$idx"; \
 	  for y in $(API_DIR)/$$m/*.yaml; do \
@@ -113,6 +119,10 @@ api-docs-html:
 	done; \
 	cat "$(TPL_DIR)/index-foot.html" >> "$$idx"
 	@echo "done -> $(HTML_DIR)/ (open index.html)"
+
+## print-modtitle: 内部辅助，回显某模块的显示标题（供 index 生成用）
+print-modtitle:
+	@echo "$(MODTITLE_$(MOD))"
 
 ## print-moddesc: 内部辅助，回显某模块的中文描述（供 index 生成用）
 print-moddesc:


### PR DESCRIPTION
## 概要

- 文档中心模块分区标题从目录名改为显示名：`bkn` → **BKN**、`ontology-query` → **Ontology 查询**、`vega` → **VEGA 引擎**（Makefile `MODTITLE_*` 映射，未列出的模块回落目录名）。
- Pages 顶层版本切换栏原本重复了 iframe 页内的大标题（视觉上「文档中心」出现两次），去掉顶栏标题只留版本下拉。

## 验证

本地 `make api-docs-html`：index 三个分区标题输出为 BKN / Ontology 查询 / VEGA 引擎；workflow YAML 解析通过。

🤖 Generated with [Claude Code](https://claude.com/claude-code)