### PR TITLE
docs(deploy): fix stale clone path in dev README

### DIFF
--- a/deploy/dev/README.md
+++ b/deploy/dev/README.md
@@ -10,11 +10,11 @@ Local Kubernetes with **kind** plus the same Helm charts as Linux `deploy.sh`. N
 
 ### Repository (clone first)
 
-Scripts and vendored manifests live in the repo tree — **`mac.sh` is not a standalone installer.** Clone **[openbkn-ai/foundry](https://github.com/openbkn-ai/foundry)** (check out the branch you deploy from), then **`cd`** into **`deploy/`** before any command below:
+Scripts and vendored manifests live in the repo tree — **`mac.sh` is not a standalone installer.** Clone **[openbkn-ai/bkn-foundry](https://github.com/openbkn-ai/bkn-foundry)** (check out the branch you deploy from), then **`cd`** into **`deploy/`** before any command below:
 
 ```bash
-git clone https://github.com/openbkn-ai/foundry.git
-cd bkn-core/deploy   # always run bash ./dev/mac.sh ... from this directory
+git clone https://github.com/openbkn-ai/bkn-foundry.git
+cd bkn-foundry/deploy   # always run bash ./dev/mac.sh ... from this directory
 ```
 
 Same layout applies if your product tarball extracts to a **`bkn-core/`** root with a **`deploy/`** subdirectory.

--- a/deploy/dev/README.zh.md
+++ b/deploy/dev/README.zh.md
@@ -10,11 +10,11 @@
 
 ### 克隆仓库（先做好）
 
-脚本与清单在仓库目录内；**`mac.sh` 不能脱离仓库单独使用**。请先 **[clone openbkn-ai/foundry](https://github.com/openbkn-ai/foundry)**，并切换到实际部署所用分支，然后 **`cd` 进入 `deploy/`**：
+脚本与清单在仓库目录内；**`mac.sh` 不能脱离仓库单独使用**。请先 **[clone openbkn-ai/bkn-foundry](https://github.com/openbkn-ai/bkn-foundry)**，并切换到实际部署所用分支，然后 **`cd` 进入 `deploy/`**：
 
 ```bash
-git clone https://github.com/openbkn-ai/foundry.git
-cd bkn-core/deploy   # 在此目录执行 bash ./dev/mac.sh ...（与 deploy.sh 同层）
+git clone https://github.com/openbkn-ai/bkn-foundry.git
+cd bkn-foundry/deploy   # 在此目录执行 bash ./dev/mac.sh ...（与 deploy.sh 同层）
 ```
 
 从产品包解压时，路径中须有 **`deploy/`** 目录，布局与上文一致即可。


### PR DESCRIPTION
## What

The dev deploy README points first-time contributors at the wrong repo and directory:

- Repo is `openbkn-ai/bkn-foundry`, not `openbkn-ai/foundry`
- `git clone` lands in `bkn-foundry/`, not `bkn-core/`

Fixed the clone URL, repo link, and `cd` target in both `deploy/dev/README.md` and `README.zh.md`.

## Why

Following the steps verbatim fails today (clone URL 404s, then `cd bkn-core/deploy` misses). Surfaced while writing the developer guide's local-setup section.

## Scope

Docs only — no script or command changes. The `bkn-core` mac.sh subcommand alias and product-tarball root naming are left untouched (both still valid).

🤖 Generated with [Claude Code](https://claude.com/claude-code)