### PR TITLE
fix: bkn-agent 迁移 init.sql 补 USE openbkn（1046 建表失败）

### DIFF
--- a/migrations/bkn-agent/mariadb/0.1.0/init.sql
+++ b/migrations/bkn-agent/mariadb/0.1.0/init.sql
@@ -1,5 +1,8 @@
 -- bkn-agent 建表（Epic #202）。共享 openbkn 库，agent_ 前缀，纯新增零 ALTER。
 -- 由全局 core-data-migrator pre-upgrade hook 执行，幂等。
+-- USE 必须有：migrator 连接不带默认库，缺它执行报 1046 No database selected
+-- （与其他服务 init.sql 同惯例）。
+USE openbkn;
 
 create table if not exists t_agent
 (


### PR DESCRIPTION
Closes #286

migrator 连接不带默认库，init.sql 缺 `USE openbkn;`（其他服务均有）→ 全新安装 `(1046, 'No database selected')`，migrator job Error（23 实况）。补上并已在 23 以 migrator 同款无默认库连接验证幂等执行成功。

🤖 Generated with [Claude Code](https://claude.com/claude-code)