### PR TITLE
docs(vega): sync OpenAPI contracts with backend

### DIFF
--- a/docs/api/vega/README.md
+++ b/docs/api/vega/README.md
@@ -9,17 +9,19 @@
 | [auth-resource.yaml](auth-resource.yaml) | AuthResource | `GET /auth-resources`（按 `resource_type` 获取可授权资源） |
 | [catalog.yaml](catalog.yaml) | Catalog | `GET/POST /catalogs`、`GET/PUT/DELETE /catalogs/{id(s)}`、`POST .../enable`、`POST .../disable`、`GET /catalogs/{id}/health-status`、`POST /catalogs/{id}/test-connection` |
 | [connector-type.yaml](connector-type.yaml) | ConnectorType | `GET/POST /connector-types`、`GET/PUT/DELETE /connector-types/{type}`、`POST .../enable`、`POST .../disable` |
-| [discover-task.yaml](discover-task.yaml) | DiscoverTask | `POST /catalogs/{cid}/discover`（手动触发）、`GET /discover-tasks`、`GET /discover-tasks/{id}` |
-| [discover-schedule.yaml](discover-schedule.yaml) | DiscoverSchedule | `GET/POST /discover-schedules`、`GET/PUT/DELETE /discover-schedules/{sid}`、`POST .../enable`、`POST .../disable`、`GET /catalogs/{cid}/discover-schedules`（便利视图） |
-| [resource.yaml](resource.yaml) | Resource | `GET/POST /resources`、`GET/PUT/DELETE /resources/{id(s)}`、`GET /catalogs/{ids}/resources`（便利视图）、其它 dataset / buildtask 子端点 |
-| [query.yaml](query.yaml) | Query | `POST /query/execute`（结构化查询） |
-| [query-endpoints-comparison.md](query-endpoints-comparison.md) | — | 设计参考：查询相关端点的对比与归属说明（非 OpenAPI 文档） |
+| [discover-task.yaml](discover-task.yaml) | DiscoverTask | `POST /catalogs/{id}/discover`、`GET /discover-tasks`、`GET /discover-tasks/{id}`、`DELETE /discover-tasks/{ids}` |
+| [discover-schedule.yaml](discover-schedule.yaml) | DiscoverSchedule | `GET/POST /discover-schedules`、`GET/PUT/DELETE /discover-schedules/{id}`、`POST .../enable`、`POST .../disable` |
+| [resource.yaml](resource.yaml) | Resource | `GET/POST /resources`、`GET/PUT/DELETE /resources/{id(s)}` |
+| [resource-data.yaml](resource-data.yaml) | ResourceData | `POST/PUT /resources/{id}/data`、`GET/PUT/DELETE /resources/{id}/data/{doc_id(s)}` |
+| [raw-query.yaml](raw-query.yaml) | RawQuery | `POST /resources/query` |
+| [build-task.yaml](build-task.yaml) | BuildTask | `GET/POST /build-tasks`、`GET/DELETE /build-tasks/{id(s)}`、`POST .../start`、`POST .../stop` |
+| [semantic-understanding-task.yaml](semantic-understanding-task.yaml) | SemanticUnderstandingTask | `GET/POST /semantic-understanding-tasks`、`GET/DELETE /semantic-understanding-tasks/{id(s)}` |
 
 ## 约定
 
 - **OpenAPI 版本**：3.1.1。
 - **错误响应**：所有非 2xx 响应统一返回 `Error` schema（对应 `kweaver-go-lib/rest.BaseError`），各文件自含一份定义。
-- **内部接口**：`/api/vega-backend/in/v1/...` 与 `/api/vega-backend/v1/...` 一一对应，请求 / 响应结构完全一致；区别仅在鉴权方式（外部 OAuth Token，内部 Header `X-Account-ID` / `X-Account-Type`）。各文件仅描述外部接口，内部接口在 `info.description` 中统一说明。
-- **跨资源便利端点**：归属到"被过滤的目标资源"所在的文件。例如 `GET /catalogs/{cid}/discover-schedules` 是按 catalog 过滤 schedule，归 `discover-schedule.yaml`；`POST /catalogs/{cid}/discover` 创建 DiscoverTask 实例，归 `discover-task.yaml`。
+- **内部接口**：多数业务端点同时提供 `/api/vega-backend/in/v1/...`，与对应外部端点的请求 / 响应结构一致；区别仅在鉴权方式（外部 OAuth Token，内部 Header `X-Account-ID` / `X-Account-Type`）。本文档仅描述外部接口；请以 `driveradapters/router.go` 中实际注册的内部路由为准。
+- **跨资源动作端点**：`POST /catalogs/{id}/discover` 创建 DiscoverTask 实例，定义在 `discover-task.yaml`。
 - **Catalog / Resource `extensions`（Issue #382，方案 B）**：OpenAPI 定义在 [catalog.yaml](catalog.yaml)、[resource.yaml](resource.yaml)。请求/响应与列表投影仅 **`extensions`**；列表筛选 query 为 **`extension_key` / `extension_value`**；`include_extensions`、`include_extension_keys` 见两文件。持久化表 **`t_entity_extension`** 及约定见 `info.description` 与设计稿
   [catalog-resource-labels-scheme-b-design.md](../../../design/vega/features/vega-backend/dip-for-extension/catalog-resource-labels-scheme-b-design.md)。

--- a/docs/api/vega/auth-resource.yaml
+++ b/docs/api/vega/auth-resource.yaml
@@ -15,8 +15,10 @@ info:
   version: 0.1.0
 servers:
   - url: /api/vega-backend/v1
+security:
+  - OAuth2: []
 paths:
-  /api/vega-backend/v1/auth-resources:
+  /auth-resources:
     get:
       operationId: listAuthResources
       summary: 获取授权资源列表
@@ -87,6 +89,9 @@ paths:
         "500":
           $ref: "#/components/responses/InternalServerError"
 components:
+  securitySchemes:
+    OAuth2:
+      $ref: "../_shared/auth.yaml#/components/securitySchemes/OAuth2"
   schemas:
     AuthResource:
       description: 可授权资源简要信息

--- a/docs/api/vega/build-task.yaml
+++ b/docs/api/vega/build-task.yaml
@@ -6,7 +6,7 @@ info:
     Vega Backend 构建任务（BuildTask）相关 API。
 
     BuildTask 是顶级独立资源，每条 task 关联 1 个 Resource，对其执行 streaming /
-    batch / embedding 三种模式之一的构建。状态机：
+    batch 两种模式之一的构建。状态机：
 
       init → running → stopping → stopped
                     ↘ completed
@@ -22,8 +22,10 @@ info:
   version: 0.1.0
 servers:
   - url: /api/vega-backend/v1
+security:
+  - OAuth2: []
 paths:
-  /api/vega-backend/v1/build-tasks:
+  /build-tasks:
     get:
       summary: 获取构建任务列表
       description: 分页获取构建任务；支持按 resource_id / catalog_id / status / mode 过滤。
@@ -58,7 +60,6 @@ paths:
             enum:
               - streaming
               - batch
-              - embedding
         - name: offset
           description: 分页偏移量，>=0，默认 0
           in: query
@@ -74,19 +75,20 @@ paths:
             type: integer
             format: int64
             default: 20
-        - name: sort
-          description: 排序字段，默认 update_time
+        - name: order_by
+          description: 排序字段；默认 `default`（构建中的任务优先）
           in: query
           schema:
             type: string
             enum:
-              - create_time
-              - update_time
+              - default
+              - created_at
+              - updated_at
               - status
               - mode
-            default: update_time
-        - name: direction
-          description: 排序方向，默认 desc
+            default: default
+        - name: order
+          description: 排序方向，默认 desc；`order_by=default` 时固定使用服务端复合排序
           in: query
           schema:
             type: string
@@ -94,6 +96,11 @@ paths:
               - asc
               - desc
             default: desc
+        - name: active
+          description: "`true` 时筛选 `running` 与 `init`，优先于 `status`"
+          in: query
+          schema:
+            type: boolean
       responses:
         "200":
           description: ok
@@ -156,10 +163,10 @@ paths:
           $ref: "#/components/responses/NotAcceptable"
         "500":
           $ref: "#/components/responses/InternalServerError"
-  /api/vega-backend/v1/build-tasks/{id}:
+  /build-tasks/{id}:
     parameters:
       - name: id
-        description: BuildTask ID
+        description: BuildTask ID；DELETE 时可传逗号分隔的 ID 列表
         in: path
         required: true
         schema:
@@ -179,15 +186,6 @@ paths:
           $ref: "#/components/responses/NotFound"
         "500":
           $ref: "#/components/responses/InternalServerError"
-  /api/vega-backend/v1/build-tasks/{ids}:
-    parameters:
-      - name: ids
-        description: |
-          BuildTask ID 列表，逗号分隔（单条即长度为 1 的退化情形）。
-        in: path
-        required: true
-        schema:
-          type: string
     delete:
       summary: 删除构建任务（整体事务）
       description: |
@@ -209,6 +207,12 @@ paths:
           schema:
             type: boolean
             default: false
+        - name: delete_active_index
+          description: 是否删除当前活跃索引；默认 `false`
+          in: query
+          schema:
+            type: boolean
+            default: false
       responses:
         "204":
           description: 删除成功
@@ -220,7 +224,7 @@ paths:
           $ref: "#/components/responses/Conflict"
         "500":
           $ref: "#/components/responses/InternalServerError"
-  /api/vega-backend/v1/build-tasks/{id}/start:
+  /build-tasks/{id}/start:
     parameters:
       - name: id
         description: BuildTask ID
@@ -260,7 +264,7 @@ paths:
           $ref: "#/components/responses/Conflict"
         "500":
           $ref: "#/components/responses/InternalServerError"
-  /api/vega-backend/v1/build-tasks/{id}/stop:
+  /build-tasks/{id}/stop:
     parameters:
       - name: id
         description: BuildTask ID
@@ -293,6 +297,9 @@ paths:
         "500":
           $ref: "#/components/responses/InternalServerError"
 components:
+  securitySchemes:
+    OAuth2:
+      $ref: "../_shared/auth.yaml#/components/securitySchemes/OAuth2"
   responses:
     BadRequest:
       description: 请求参数 / 请求体非法
@@ -362,9 +369,7 @@ components:
         - vectorized_count
         - creator
         - create_time
-        - updater
         - update_time
-        - build_key_fields
       properties:
         id:
           description: 全局唯一 ID
@@ -391,7 +396,6 @@ components:
           enum:
             - streaming
             - batch
-            - embedding
         total_count:
           description: 总数
           type: integer
@@ -416,33 +420,70 @@ components:
           description: 创建时间，毫秒级时间戳
           type: integer
           format: int64
-        updater:
-          $ref: "#/components/schemas/AccountInfo"
         update_time:
           description: 更新时间，毫秒级时间戳
           type: integer
           format: int64
-        embedding_fields:
-          description: 需向量化的字段，逗号分隔
+        failure_detail:
+          description: 任务完成但存在部分向量化失败时的明细
           type: string
+        index_config:
+          $ref: "#/components/schemas/BuildTaskIndexConfig"
+        index_health:
+          $ref: "#/components/schemas/IndexHealth"
+    BuildTaskIndexConfig:
+      description: 创建任务时从 Resource 派生的索引配置快照
+      type: object
+      properties:
         build_key_fields:
-          description: |
-            构建中依赖的特殊键字段，逗号分隔。
-            - batch 模式：依赖具有时序性的字段（如 update_time）
-            - streaming 模式：依赖唯一标识某行的字段（如主键）
+          type: array
+          items:
+            type: string
+        features:
+          type: object
+          additionalProperties:
+            $ref: "#/components/schemas/BuildTaskFieldIndexFeature"
+    BuildTaskFieldIndexFeature:
+      type: object
+      properties:
+        vector:
+          type: object
+          required:
+            - model_id
+            - dimensions
+          properties:
+            model_id:
+              type: string
+            dimensions:
+              type: integer
+        fulltext:
+          type: object
+          properties:
+            analyzer:
+              type: string
+    IndexHealth:
+      description: 索引派生健康状态；不持久化
+      type: object
+      required:
+        - embedding
+        - fulltext
+        - usable
+      properties:
+        embedding:
           type: string
-        embedding_model:
-          description: 嵌入模型名
+          enum:
+            - none
+            - building
+            - ok
+            - partial
+            - failed
+        fulltext:
           type: string
-        model_dimensions:
-          description: 模型向量维度
-          type: integer
-        fulltext_fields:
-          description: 已建全文索引的字段，逗号分隔
-          type: string
-        fulltext_analyzer:
-          description: 全文分词器；为空用默认 standard
-          type: string
+          enum:
+            - none
+            - ok
+        usable:
+          type: boolean
     CreateBuildTaskRequest:
       description: 创建构建任务请求体
       type: object
@@ -459,40 +500,20 @@ components:
           enum:
             - streaming
             - batch
-            - embedding
-        embedding_fields:
-          description: 需向量化的字段，逗号分隔
-          type: string
-        build_key_fields:
-          description: 构建键字段，逗号分隔；batch 模式必填
-          type: string
-        embedding_model:
-          description: 嵌入模型名；为空且 embedding_fields 非空时使用默认模型
-          type: string
-        model_dimensions:
-          description: 模型向量维度；为 0 且 embedding_model 非空时按模型查询填入
-          type: integer
-        fulltext_fields:
-          description: >
-            需建全文索引的字段，逗号分隔；仅 string/text 字段可选。
-            string 字段建索引时主字段保持 keyword（精确匹配/排序不变），额外加一个
-            `<字段>.fulltext` 分词子字段；text 字段主字段本身分词。全文检索随结构化
-            数据同步落地（不像 embedding 需异步补）。
-          type: string
-        fulltext_analyzer:
-          description: 全文分词器（standard/ik_max_word/hanlp_index 等）；为空用 OpenSearch 默认 standard
-          type: string
-    StartBuildTaskRequest:
-      description: 启动构建任务请求体（可选）
-      type: object
-      properties:
         execute_type:
-          description: 执行类型；默认 incremental
+          description: batch 执行类型；省略时服务端默认 `full`
           type: string
           enum:
             - incremental
             - full
-          default: incremental
+    StartBuildTaskRequest:
+      description: 启动构建任务请求体（可选）
+      type: object
+      properties:
+        reset:
+          description: 为 true 时忽略已有 `synced_mark`，从头执行
+          type: boolean
+          default: false
     ListBuildTasks:
       description: 构建任务列表
       type: object

--- a/docs/api/vega/catalog.yaml
+++ b/docs/api/vega/catalog.yaml
@@ -47,12 +47,14 @@ info:
   version: 0.2.1
 servers:
   - url: /api/vega-backend/v1
+security:
+  - OAuth2: []
 paths:
-  /api/vega-backend/v1/catalogs:
+  /catalogs:
     get:
       summary: 获取 catalog 列表
       description: |
-        分页获取 catalog；支持按 name、tag、type、health_check_status 过滤。
+        分页获取 catalog；支持按 name、tag、type、connector_type、health_check_status 过滤。
 
         **KV 筛选**：`extension_key` / `extension_value` 为数组 query。
         序列化形如 `extension_key=a&extension_key=b&extension_value=1&extension_value=2`。参与筛选的一组参数 **必须等长**，
@@ -76,6 +78,11 @@ paths:
             enum:
               - physical
               - logical
+        - name: connector_type
+          description: 按连接器类型过滤
+          in: query
+          schema:
+            type: string
         - name: health_check_status
           description: 按健康检查状态过滤
           in: query
@@ -210,9 +217,9 @@ paths:
                 $ref: "../_shared/errors.yaml#/components/schemas/Error"
         "500":
           $ref: "#/components/responses/InternalServerError"
-  /api/vega-backend/v1/catalogs/{ids}:
+  /catalogs/{id}:
     parameters:
-      - name: ids
+      - name: id
         description: catalog ID，多个用英文逗号分隔（如 `id1,id2,id3`）
         in: path
         required: true
@@ -253,14 +260,6 @@ paths:
           $ref: "#/components/responses/NotFound"
         "500":
           $ref: "#/components/responses/InternalServerError"
-  /api/vega-backend/v1/catalogs/{id}:
-    parameters:
-      - name: id
-        description: catalog ID
-        in: path
-        required: true
-        schema:
-          type: string
     put:
       summary: 修改 catalog
       description: |
@@ -309,7 +308,7 @@ paths:
                 $ref: "../_shared/errors.yaml#/components/schemas/Error"
         "500":
           $ref: "#/components/responses/InternalServerError"
-  /api/vega-backend/v1/catalogs/{id}/enable:
+  /catalogs/{id}/enable:
     parameters:
       - name: id
         description: catalog ID
@@ -331,7 +330,7 @@ paths:
           $ref: "#/components/responses/NotFound"
         "500":
           $ref: "#/components/responses/InternalServerError"
-  /api/vega-backend/v1/catalogs/{id}/disable:
+  /catalogs/{id}/disable:
     parameters:
       - name: id
         description: catalog ID
@@ -353,7 +352,7 @@ paths:
           $ref: "#/components/responses/NotFound"
         "500":
           $ref: "#/components/responses/InternalServerError"
-  /api/vega-backend/v1/catalogs/{id}/health-status:
+  /catalogs/{id}/health-status:
     parameters:
       - name: id
         description: catalog ID
@@ -375,7 +374,7 @@ paths:
           $ref: "#/components/responses/Unauthorized"
         "500":
           $ref: "#/components/responses/InternalServerError"
-  /api/vega-backend/v1/catalogs/{id}/test-connection:
+  /catalogs/{id}/test-connection:
     parameters:
       - name: id
         description: catalog ID
@@ -407,6 +406,9 @@ paths:
         "500":
           $ref: "#/components/responses/InternalServerError"
 components:
+  securitySchemes:
+    OAuth2:
+      $ref: "../_shared/auth.yaml#/components/securitySchemes/OAuth2"
   responses:
     BadRequest:
       description: |
@@ -516,6 +518,9 @@ components:
         enabled:
           description: 是否启用
           type: boolean
+        internal:
+          description: 是否为内部 Catalog
+          type: boolean
         connector_type:
           description: 连接器类型标识（参见 connector-type.yaml）
           type: string
@@ -610,6 +615,9 @@ components:
           description: 连接器配置；字段由 ConnectorType.field_config 决定
           type: object
           additionalProperties: true
+        internal:
+          description: 是否创建为内部 Catalog；省略时为 `false`
+          type: boolean
         extensions:
           $ref: "#/components/schemas/EntityExtensions"
     ListCatalogs:

--- a/docs/api/vega/connector-type.yaml
+++ b/docs/api/vega/connector-type.yaml
@@ -12,8 +12,10 @@ info:
   version: 0.1.0
 servers:
   - url: /api/vega-backend/v1
+security:
+  - OAuth2: []
 paths:
-  /api/vega-backend/v1/connector-types:
+  /connector-types:
     get:
       summary: 获取连接器类型列表
       description: 分页获取已注册的连接器类型；支持按 name、tag、mode、category、enabled 过滤。
@@ -129,7 +131,7 @@ paths:
                 $ref: "../_shared/errors.yaml#/components/schemas/Error"
         "500":
           $ref: "#/components/responses/InternalServerError"
-  /api/vega-backend/v1/connector-types/{type}:
+  /connector-types/{type}:
     parameters:
       - name: type
         description: 连接器类型标识（如 mysql、postgresql）
@@ -208,7 +210,7 @@ paths:
           $ref: "#/components/responses/NotFound"
         "500":
           $ref: "#/components/responses/InternalServerError"
-  /api/vega-backend/v1/connector-types/{type}/enable:
+  /connector-types/{type}/enable:
     parameters:
       - name: type
         description: 连接器类型标识
@@ -228,7 +230,7 @@ paths:
           $ref: "#/components/responses/NotFound"
         "500":
           $ref: "#/components/responses/InternalServerError"
-  /api/vega-backend/v1/connector-types/{type}/disable:
+  /connector-types/{type}/disable:
     parameters:
       - name: type
         description: 连接器类型标识
@@ -249,6 +251,9 @@ paths:
         "500":
           $ref: "#/components/responses/InternalServerError"
 components:
+  securitySchemes:
+    OAuth2:
+      $ref: "../_shared/auth.yaml#/components/securitySchemes/OAuth2"
   responses:
     BadRequest:
       description: 请求参数 / 请求体非法

--- a/docs/api/vega/discover-schedule.yaml
+++ b/docs/api/vega/discover-schedule.yaml
@@ -20,8 +20,10 @@ info:
   version: 0.1.0
 servers:
   - url: /api/vega-backend/v1
+security:
+  - OAuth2: []
 paths:
-  /api/vega-backend/v1/discover-schedules:
+  /discover-schedules:
     post:
       summary: 创建发现调度
       description: |
@@ -129,7 +131,7 @@ paths:
           $ref: "#/components/responses/Unauthorized"
         "500":
           $ref: "#/components/responses/InternalServerError"
-  /api/vega-backend/v1/discover-schedules/{id}:
+  /discover-schedules/{id}:
     parameters:
       - name: id
         description: DiscoverSchedule ID
@@ -204,7 +206,7 @@ paths:
           $ref: "#/components/responses/NotFound"
         "500":
           $ref: "#/components/responses/InternalServerError"
-  /api/vega-backend/v1/discover-schedules/{id}/enable:
+  /discover-schedules/{id}/enable:
     parameters:
       - name: id
         description: DiscoverSchedule ID
@@ -226,7 +228,7 @@ paths:
           $ref: "#/components/responses/NotFound"
         "500":
           $ref: "#/components/responses/InternalServerError"
-  /api/vega-backend/v1/discover-schedules/{id}/disable:
+  /discover-schedules/{id}/disable:
     parameters:
       - name: id
         description: DiscoverSchedule ID
@@ -251,6 +253,9 @@ paths:
         "500":
           $ref: "#/components/responses/InternalServerError"
 components:
+  securitySchemes:
+    OAuth2:
+      $ref: "../_shared/auth.yaml#/components/securitySchemes/OAuth2"
   responses:
     BadRequest:
       description: |
@@ -328,7 +333,7 @@ components:
         - catalog_id
         - cron_expr
         - enabled
-        - strategies
+        - strategy
         - creator
         - create_time
         - updater
@@ -365,16 +370,13 @@ components:
           description: |
             是否启用；**只读**输出字段，状态切换走 `POST .../enable` `POST .../disable`
           type: boolean
-        strategies:
-          description: |
-            发现策略集合，元素为 `insert` / `delete` / `update`；空数组表示全部。
-          type: array
-          items:
-            type: string
-            enum:
-              - insert
-              - delete
-              - update
+        strategy:
+          description: 发现策略；创建或更新时省略则默认为 `full_sync`
+          type: string
+          enum:
+            - full_sync
+            - create_only
+            - cleanup_only
         last_run:
           description: 上次执行时间，毫秒时间戳；系统维护
           type: integer
@@ -401,16 +403,13 @@ components:
 
         - 创建时 `name`、`catalog_id` 与 `cron_expr` 必填；`enabled` 默认 false（可同时传 true 一步启用）
         - PUT 时 `catalog_id` 必填且必须与当前一致（空串 / 缺失视为不一致 → 409 CatalogMismatch）；
-          `enabled` 必须与当前一致（否则 409 EnabledFieldNotAllowed）；`id` 可省略，携带时被忽略
+          `enabled` 必须与当前一致（否则 409 EnabledFieldNotAllowed）。
       type: object
       required:
         - name
         - catalog_id
         - cron_expr
       properties:
-        id:
-          description: 创建时省略；PUT 时如携带必须与 path 一致
-          type: string
         name:
           description: 调度名称，必填，最大长度 255
           type: string
@@ -437,16 +436,13 @@ components:
           description: |
             创建时可选（默认 false）；PUT 时必须与当前一致，否则 409 EnabledFieldNotAllowed
           type: boolean
-        strategies:
-          description: |
-            发现策略，元素必须是 `insert` / `delete` / `update` 的子集；空数组表示全部
-          type: array
-          items:
-            type: string
-            enum:
-              - insert
-              - delete
-              - update
+        strategy:
+          description: 发现策略；省略时服务端默认 `full_sync`
+          type: string
+          enum:
+            - full_sync
+            - create_only
+            - cleanup_only
     ListDiscoverSchedules:
       description: 调度列表响应
       type: object

--- a/docs/api/vega/discover-task.yaml
+++ b/docs/api/vega/discover-task.yaml
@@ -19,8 +19,10 @@ info:
   version: 0.1.0
 servers:
   - url: /api/vega-backend/v1
+security:
+  - OAuth2: []
 paths:
-  /api/vega-backend/v1/discover-tasks:
+  /discover-tasks:
     get:
       summary: 获取发现任务列表
       description: 分页获取发现任务；支持按 catalog_id / schedule_id / status / trigger_type 过滤。
@@ -96,10 +98,10 @@ paths:
           $ref: "#/components/responses/Unauthorized"
         "500":
           $ref: "#/components/responses/InternalServerError"
-  /api/vega-backend/v1/discover-tasks/{id}:
+  /discover-tasks/{id}:
     parameters:
       - name: id
-        description: DiscoverTask ID
+        description: DiscoverTask ID；DELETE 时可传逗号分隔的 ID 列表
         in: path
         required: true
         schema:
@@ -119,16 +121,6 @@ paths:
           $ref: "#/components/responses/NotFound"
         "500":
           $ref: "#/components/responses/InternalServerError"
-  /api/vega-backend/v1/discover-tasks/{ids}:
-    parameters:
-      - name: ids
-        description: |
-          DiscoverTask ID 列表，逗号分隔（单条即长度为 1 的退化情形）。
-          重复 id 在 service 层会被去重。
-        in: path
-        required: true
-        schema:
-          type: string
     delete:
       summary: 删除发现任务（整体事务）
       description: |
@@ -162,7 +154,7 @@ paths:
           $ref: "#/components/responses/Conflict"
         "500":
           $ref: "#/components/responses/InternalServerError"
-  /api/vega-backend/v1/catalogs/{id}/discover:
+  /catalogs/{id}/discover:
     parameters:
       - name: id
         description: Catalog ID
@@ -177,10 +169,16 @@ paths:
         的 DiscoverTask 并立即返回 task id；实际发现执行由 worker 异步推进。客户端可用
         返回的 task id 通过 `GET /discover-tasks/{id}` 轮询执行进度。
 
-        无 request body。本端点保留 RPC 风格嵌套形态——是对 catalog 的动作而非创建顶层
-        task；详见 [discover_task_redesign.md] §1 非目标。
+        可选请求体 `{"strategy":"full_sync|create_only|cleanup_only"}`；省略时默认
+        `full_sync`。本端点保留 RPC 风格嵌套形态——是对 catalog 的动作而非创建顶层 task。
 
         仅支持 `type=physical` 的 catalog；`type=logical` 会返回 400。
+      requestBody:
+        required: false
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/DiscoverTriggerRequest"
       responses:
         "200":
           description: 触发成功，DiscoverTask 已创建并入队
@@ -198,9 +196,18 @@ paths:
             application/json:
               schema:
                 $ref: "../_shared/errors.yaml#/components/schemas/Error"
+        "409":
+          description: Catalog 已禁用
+          content:
+            application/json:
+              schema:
+                $ref: "../_shared/errors.yaml#/components/schemas/Error"
         "500":
           $ref: "#/components/responses/InternalServerError"
 components:
+  securitySchemes:
+    OAuth2:
+      $ref: "../_shared/auth.yaml#/components/securitySchemes/OAuth2"
   responses:
     BadRequest:
       description: 请求参数 / 请求体非法
@@ -282,7 +289,7 @@ components:
         - id
         - catalog_id
         - schedule_id
-        - strategies
+        - strategy
         - trigger_type
         - status
         - progress
@@ -300,17 +307,13 @@ components:
           description: |
             关联的 DiscoverSchedule ID。trigger_type=manual 时为空字符串。
           type: string
-        strategies:
-          description: |
-            发现策略，可为以下零或多个：`insert` / `delete` / `update`。
-            空数组表示对所有策略执行。
-          type: array
-          items:
-            type: string
-            enum:
-              - insert
-              - delete
-              - update
+        strategy:
+          description: 发现策略
+          type: string
+          enum:
+            - full_sync
+            - create_only
+            - cleanup_only
         trigger_type:
           description: 触发方式
           type: string
@@ -357,6 +360,16 @@ components:
         id:
           description: 新建 DiscoverTask 的 ID；可用 `GET /discover-tasks/{id}` 轮询进度
           type: string
+    DiscoverTriggerRequest:
+      description: 手动触发发现时的可选策略；省略时服务端使用 `full_sync`
+      type: object
+      properties:
+        strategy:
+          type: string
+          enum:
+            - full_sync
+            - create_only
+            - cleanup_only
     ListDiscoverTasks:
       description: 发现任务列表
       type: object

--- a/docs/api/vega/raw-query.yaml
+++ b/docs/api/vega/raw-query.yaml
@@ -25,8 +25,10 @@ info:
   version: 0.1.0
 servers:
   - url: /api/vega-backend/v1
+security:
+  - OAuth2: []
 paths:
-  /api/vega-backend/v1/resources/query:
+  /resources/query:
     post:
       summary: 执行原生查询（SQL 或 DSL）
       description: |
@@ -65,6 +67,9 @@ paths:
         "500":
           $ref: "#/components/responses/InternalServerError"
 components:
+  securitySchemes:
+    OAuth2:
+      $ref: "../_shared/auth.yaml#/components/securitySchemes/OAuth2"
   responses:
     BadRequest:
       description: |
@@ -177,6 +182,11 @@ components:
           description: 总条数（标准查询返回完整命中数；流式查询为已返回累计数）
           type: integer
           format: int64
+        warnings:
+          description: 非阻断告警
+          type: array
+          items:
+            type: string
     ColumnInfo:
       description: 列元数据
       type: object

--- a/docs/api/vega/resource-data.yaml
+++ b/docs/api/vega/resource-data.yaml
@@ -24,8 +24,10 @@ info:
   version: 0.1.0
 servers:
   - url: /api/vega-backend/v1
+security:
+  - OAuth2: []
 paths:
-  /api/vega-backend/v1/resources/{id}/data:
+  /resources/{id}/data:
     parameters:
       - name: id
         description: Resource ID
@@ -132,7 +134,7 @@ paths:
           $ref: "#/components/responses/NotAcceptable"
         "500":
           $ref: "#/components/responses/InternalServerError"
-  /api/vega-backend/v1/resources/{id}/data/{doc_ids}:
+  /resources/{id}/data/{doc_ids}:
     parameters:
       - name: id
         description: Resource ID
@@ -140,7 +142,7 @@ paths:
         required: true
         schema:
           type: string
-      - name: doc_ids
+      - name: doc_id
         description: |
           文档 ID 列表，逗号分隔（单条即长度 1 的退化情形）。
           缺失 id 静默跳过；本端点不接受 `?ignore_missing` 参数。
@@ -170,20 +172,6 @@ paths:
           $ref: "#/components/responses/NotFound"
         "500":
           $ref: "#/components/responses/InternalServerError"
-  /api/vega-backend/v1/resources/{id}/data/{doc_id}:
-    parameters:
-      - name: id
-        description: Resource ID
-        in: path
-        required: true
-        schema:
-          type: string
-      - name: doc_id
-        description: 文档 ID
-        in: path
-        required: true
-        schema:
-          type: string
     get:
       summary: 获取单条文档
       description: |
@@ -239,6 +227,9 @@ paths:
         "500":
           $ref: "#/components/responses/InternalServerError"
 components:
+  securitySchemes:
+    OAuth2:
+      $ref: "../_shared/auth.yaml#/components/securitySchemes/OAuth2"
   responses:
     BadRequest:
       description: |
@@ -316,20 +307,76 @@ components:
           description: 每页数量
           type: integer
           format: int64
-          default: 20
+          default: 10
         sort:
           description: 排序字段
-          type: string
-        direction:
-          description: 排序方向
-          type: string
-          enum:
-            - asc
-            - desc
+          type: array
+          items:
+            $ref: "#/components/schemas/SortField"
+        output_fields:
+          description: 指定输出字段列表
+          type: array
+          items:
+            type: string
         need_total:
           description: 是否在响应里携带 total_count
           type: boolean
           default: false
+        search_after:
+          description: OpenSearch `search_after` 游标值
+          type: array
+          items: {}
+        query_type:
+          description: 查询类型
+          type: string
+        aggregation:
+          $ref: "#/components/schemas/Aggregation"
+        group_by:
+          type: array
+          items:
+            $ref: "#/components/schemas/GroupByItem"
+        having:
+          $ref: "#/components/schemas/HavingClause"
+    SortField:
+      type: object
+      required:
+        - field
+        - direction
+      properties:
+        field:
+          type: string
+        direction:
+          type: string
+          enum: [asc, desc]
+    Aggregation:
+      type: object
+      required: [property, aggr]
+      properties:
+        property: { type: string }
+        aggr:
+          type: string
+          enum: [count, count_distinct, sum, max, min, avg]
+        alias: { type: string }
+    GroupByItem:
+      type: object
+      required: [property]
+      properties:
+        property: { type: string }
+        description: { type: string }
+        calendar_interval:
+          type: string
+          enum: [minute, hour, day, week, month, quarter, year]
+    HavingClause:
+      type: object
+      required: [field, operation, value]
+      properties:
+        field:
+          type: string
+          enum: [__value, "count(*)"]
+        operation:
+          type: string
+          enum: ["==", "!=", ">", ">=", "<", "<=", in, not_in, range, out_range]
+        value: {}
     ListResponse:
       description: |
         查询响应。`total_count` 仅在请求 `need_total=true` 时返回。
@@ -346,6 +393,11 @@ components:
           description: 总条数（仅 need_total=true 时返回）
           type: integer
           format: int64
+        warnings:
+          description: 非阻断告警
+          type: array
+          items:
+            type: string
     IdsResponse:
       description: 写入操作的响应，含成功的文档 ID 数组
       type: object

--- a/docs/api/vega/resource.yaml
+++ b/docs/api/vega/resource.yaml
@@ -51,8 +51,10 @@ info:
   version: 0.2.1
 servers:
   - url: /api/vega-backend/v1
+security:
+  - OAuth2: []
 paths:
-  /api/vega-backend/v1/resources:
+  /resources:
     get:
       summary: 获取资源列表
       description: |
@@ -222,9 +224,9 @@ paths:
           $ref: "#/components/responses/Conflict"
         "500":
           $ref: "#/components/responses/InternalServerError"
-  /api/vega-backend/v1/resources/{ids}:
+  /resources/{id}:
     parameters:
-      - name: ids
+      - name: id
         description: |
           Resource ID 列表，逗号分隔（单条即长度 1 的退化情形）。
         in: path
@@ -275,14 +277,6 @@ paths:
           $ref: "#/components/responses/NotFound"
         "500":
           $ref: "#/components/responses/InternalServerError"
-  /api/vega-backend/v1/resources/{id}:
-    parameters:
-      - name: id
-        description: Resource ID
-        in: path
-        required: true
-        schema:
-          type: string
     put:
       summary: 更新资源
       description: |
@@ -314,6 +308,9 @@ paths:
         "500":
           $ref: "#/components/responses/InternalServerError"
 components:
+  securitySchemes:
+    OAuth2:
+      $ref: "../_shared/auth.yaml#/components/securitySchemes/OAuth2"
   responses:
     BadRequest:
       description: |
@@ -592,6 +589,9 @@ components:
         status_message:
           description: 状态说明（stale/deprecated 时填充）
           type: string
+        last_discover_status:
+          description: 最近一次资源发现的观察状态
+          type: string
         database:
           description: 所属数据库（实例级 Catalog 时填充）
           type: string
@@ -609,9 +609,18 @@ components:
           type: array
           items:
             $ref: "#/components/schemas/Property"
+        index_config:
+          $ref: "#/components/schemas/ResourceIndexConfig"
         index_name:
           description: 关联索引名（由构建任务填充）
           type: string
+        column_count:
+          description: "`schema_definition` 的字段数"
+          type: integer
+        row_count:
+          description: 最近一次发现记录的源端行数估算
+          type: integer
+          format: int64
         logic_type:
           description: 逻辑视图类型（仅 category=logicview 有意义）
           type: string
@@ -710,10 +719,24 @@ components:
           type: array
           items:
             $ref: "#/components/schemas/Property"
+        index_config:
+          $ref: "#/components/schemas/ResourceIndexConfig"
         logic_definition:
           type: array
           items:
             $ref: "#/components/schemas/LogicDefinitionNode"
+    ResourceIndexConfig:
+      description: 本地索引构建配置
+      type: object
+      properties:
+        build_key_fields:
+          type: array
+          items:
+            type: string
+        default_fulltext_analyzer:
+          type: string
+        default_embedding_model:
+          type: string
     ListResources:
       description: 资源列表响应
       type: object

--- a/docs/api/vega/semantic-understanding-task.yaml
+++ b/docs/api/vega/semantic-understanding-task.yaml
@@ -1,0 +1,198 @@
+---
+openapi: 3.1.1
+info:
+  title: Semantic Understanding Task
+  version: 0.1.0
+  description: |
+    Vega Backend 语义理解异步任务 API。任务可针对单个 Resource 或整个 Catalog 创建；
+    worker 将任务提交给 bkn-agent，并异步写回结果与应用状态。
+servers:
+  - url: /api/vega-backend/v1
+security:
+  - OAuth2: []
+paths:
+  /semantic-understanding-tasks:
+    get:
+      summary: 获取语义理解任务列表
+      parameters:
+        - name: scope
+          in: query
+          schema:
+            type: string
+            enum: [resource, catalog]
+        - name: catalog_id
+          in: query
+          schema: { type: string }
+        - name: resource_id
+          in: query
+          schema: { type: string }
+        - name: status
+          description: 逗号分隔的状态列表；`active=true` 时筛选 pending 与 running。
+          in: query
+          schema:
+            type: string
+        - name: active
+          in: query
+          schema: { type: boolean }
+        - name: offset
+          in: query
+          schema: { type: integer, minimum: 0, default: 0 }
+        - name: limit
+          in: query
+          schema: { type: integer, default: 20 }
+        - name: sort
+          in: query
+          schema:
+            type: string
+            enum: [create_time, update_time, status, scope]
+            default: create_time
+        - name: direction
+          in: query
+          schema:
+            type: string
+            enum: [asc, desc]
+            default: desc
+      responses:
+        "200":
+          description: ok
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/ListSemanticUnderstandingTasks" }
+        "400": { $ref: "#/components/responses/BadRequest" }
+        "401": { $ref: "#/components/responses/Unauthorized" }
+        "500": { $ref: "#/components/responses/InternalServerError" }
+    post:
+      summary: 创建语义理解任务
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema: { $ref: "#/components/schemas/CreateSemanticUnderstandingTaskRequest" }
+      responses:
+        "201":
+          description: 创建成功
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/SemanticUnderstandingTask" }
+        "400": { $ref: "#/components/responses/BadRequest" }
+        "401": { $ref: "#/components/responses/Unauthorized" }
+        "404": { $ref: "#/components/responses/NotFound" }
+        "409": { $ref: "#/components/responses/Conflict" }
+        "500": { $ref: "#/components/responses/InternalServerError" }
+  /semantic-understanding-tasks/{id}:
+    parameters:
+      - name: id
+        in: path
+        required: true
+        schema: { type: string }
+    get:
+      summary: 获取语义理解任务详情
+      responses:
+        "200":
+          description: ok
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/SemanticUnderstandingTask" }
+        "401": { $ref: "#/components/responses/Unauthorized" }
+        "404": { $ref: "#/components/responses/NotFound" }
+        "500": { $ref: "#/components/responses/InternalServerError" }
+    delete:
+      summary: 删除语义理解任务
+      description: 路径参数可为逗号分隔的任务 ID；运行中的任务不可删除。
+      parameters:
+        - name: ignore_missing
+          in: query
+          schema: { type: boolean, default: false }
+      responses:
+        "204": { description: 删除成功 }
+        "400": { $ref: "#/components/responses/BadRequest" }
+        "401": { $ref: "#/components/responses/Unauthorized" }
+        "404": { $ref: "#/components/responses/NotFound" }
+        "409": { $ref: "#/components/responses/Conflict" }
+        "500": { $ref: "#/components/responses/InternalServerError" }
+components:
+  securitySchemes:
+    OAuth2:
+      $ref: "../_shared/auth.yaml#/components/securitySchemes/OAuth2"
+  responses:
+    BadRequest:
+      description: 请求参数或请求体非法
+      content: { application/json: { schema: { $ref: "../_shared/errors.yaml#/components/schemas/Error" } } }
+    Unauthorized:
+      description: OAuth Token 校验失败
+      content: { application/json: { schema: { $ref: "../_shared/errors.yaml#/components/schemas/Error" } } }
+    NotFound:
+      description: 资源不存在
+      content: { application/json: { schema: { $ref: "../_shared/errors.yaml#/components/schemas/Error" } } }
+    Conflict:
+      description: 状态冲突或已有活动任务
+      content: { application/json: { schema: { $ref: "../_shared/errors.yaml#/components/schemas/Error" } } }
+    InternalServerError:
+      description: 服务内部错误
+      content: { application/json: { schema: { $ref: "../_shared/errors.yaml#/components/schemas/Error" } } }
+  schemas:
+    AccountInfo:
+      type: object
+      required: [id, type]
+      properties:
+        id: { type: string }
+        type: { type: string }
+        name: { type: string }
+    SamplePolicy:
+      type: object
+      properties:
+        masked: { type: boolean }
+        max_rows: { type: integer }
+    CreateSemanticUnderstandingTaskRequest:
+      type: object
+      required: [scope]
+      properties:
+        scope: { type: string, enum: [resource, catalog] }
+        catalog_id: { type: string }
+        resource_id: { type: string }
+        apply_mode: { type: string, enum: [dry_run, fill_empty, force], default: fill_empty }
+        confidence_threshold: { type: number, format: double, default: 0.75 }
+        include_sample_rows: { type: boolean }
+        sample_policy: { $ref: "#/components/schemas/SamplePolicy" }
+      allOf:
+        - if:
+            properties: { scope: { const: resource } }
+          then:
+            required: [resource_id]
+        - if:
+            properties: { scope: { const: catalog } }
+          then:
+            required: [catalog_id]
+    SemanticUnderstandingTask:
+      type: object
+      required: [id, scope, catalog_id, agent_id, input, input_hash, status, apply_mode, confidence_threshold, confidence, applied, creator, create_time, update_time]
+      properties:
+        id: { type: string }
+        scope: { type: string, enum: [resource, catalog] }
+        catalog_id: { type: string }
+        resource_id: { type: string }
+        agent_task_id: { type: string }
+        agent_id: { type: string }
+        input: { type: string }
+        input_hash: { type: string }
+        status: { type: string, enum: [pending, running, succeeded, failed] }
+        apply_mode: { type: string, enum: [dry_run, fill_empty, force] }
+        result_json: { type: string }
+        confidence_threshold: { type: number, format: double }
+        confidence: { type: number, format: double }
+        confidence_detail_json: { type: string }
+        apply_detail_json: { type: string }
+        applied: { type: boolean }
+        applied_time: { type: integer, format: int64 }
+        failure_detail: { type: string }
+        creator: { $ref: "#/components/schemas/AccountInfo" }
+        create_time: { type: integer, format: int64 }
+        update_time: { type: integer, format: int64 }
+    ListSemanticUnderstandingTasks:
+      type: object
+      required: [entries, total_count]
+      properties:
+        entries:
+          type: array
+          items: { $ref: "#/components/schemas/SemanticUnderstandingTask" }
+        total_count: { type: integer, format: int64 }


### PR DESCRIPTION
## What Changed

- [x] 对齐 Vega OpenAPI 路径、请求参数、请求/响应字段与当前后端实现。
- [x] 新增 SemanticUnderstandingTask 外部 API 文档。
- [x] 补充外部 OAuth2 安全方案与 README API 索引。

---

## Why

- Related Issue: #285
- Background: `docs/api/vega` 与 `vega-backend` 实现存在路径、字段和参数漂移，影响调用方与文档生成工具。

---

## How

- 统一外部 API 基础路径为 `/api/vega-backend/v1`，OpenAPI paths 使用相对路径。
- 对齐 BuildTask、DiscoverTask、DiscoverSchedule、Catalog、Resource、ResourceData、RawQuery 的契约。
- 合并语义等价的单条/批量 path item，消除 OpenAPI 模板冲突。
- Breaking changes: 文档契约修正；服务端实际 URL 和行为未变。

---

## Testing

- [x] `npx @redocly/cli lint --config .redocly.yaml docs/api/vega/*.yaml`
- [x] `go test ./driveradapters`

---

## Risk & Rollback

- Potential risks: 调用方若曾依赖旧文档中的错误字段或路径拼接，需要按实际服务契约调整。
- Rollback plan: revert commit `eec5744c`。

---

## Additional Notes

- 新增 `docs/api/vega/semantic-understanding-task.yaml`。
- 仅修改 API 文档；后端代码未包含在本 PR。
