### PR TITLE
ci(deploy): publish multi-arch platform redis image (amd64+arm64)

### DIFF
--- a/.github/workflows/release-deploy-redis.yml
+++ b/.github/workflows/release-deploy-redis.yml
@@ -1,0 +1,63 @@
+name: release-deploy-redis
+
+# Multi-arch build of the platform Redis image (deploy/images/redis).
+# Versioned off the redis chart line (1.11.2-*), NOT the repo VERSION — see
+# deploy/images/redis/README.md. Branch pushes publish a branch-tagged image
+# (same convention as the service pipelines), so a fix is testable pre-merge.
+
+on:
+  push:
+    branches: ['**']
+    paths:
+      - 'deploy/images/redis/**'
+      - '.github/workflows/release-deploy-redis.yml'
+      - '.github/workflows/reusable-build.yml'
+  workflow_dispatch:
+    inputs:
+      publish:
+        description: 'Publish to registries (true) or verify build only (false)'
+        type: boolean
+        default: false
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  resolve-version:
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.version.outputs.version }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - id: version
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          # Base = redis chart version (deploy/charts/redis-1.11.2.tgz), so
+          # image tags stay in the 1.11.2-* line the chart/scripts expect.
+          BASE_VERSION="1.11.2"
+          REF_NAME="${{ github.ref_name }}"
+          SHORT_SHA="$(git rev-parse --short=7 HEAD)"
+          SANITIZED_BRANCH="$(echo "$REF_NAME" | tr '[:upper:]' '[:lower:]' | sed -E 's#[^0-9a-zA-Z.-]+#-#g; s#-+#-#g; s#^[.-]+##; s#[.-]+$##')"
+          # Commit time (UTC), not build time — monotonic and re-run reproducible.
+          COMMIT_DATE="$(TZ=UTC git show -s --format=%cd --date=format-local:%Y%m%d%H%M%S HEAD)"
+          VERSION="$BASE_VERSION-$SANITIZED_BRANCH.$COMMIT_DATE.sha$SHORT_SHA"
+
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+
+  build:
+    needs: resolve-version
+    uses: ./.github/workflows/reusable-build.yml
+    secrets: inherit
+    with:
+      service-path: deploy/images/redis
+      dockerfile: Dockerfile
+      context: '.'
+      image-name: redis
+      version: ${{ needs.resolve-version.outputs.version }}
+      publish: ${{ github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && inputs.publish) }}

--- a/deploy/images/redis/Dockerfile
+++ b/deploy/images/redis/Dockerfile
@@ -1,0 +1,15 @@
+# Platform Redis image for the bundled sentinel-mode redis chart
+# (deploy/charts/redis-1.11.2.tgz).
+#
+# The chart's initContainer runs /config-init.sh and its probes run
+# /liveness-check.sh; neither is mounted from a ConfigMap, so both must be
+# baked into the image. The upstream image
+# (swr.cn-east-3.myhuaweicloud.com/openbkn-ai/redis:1.11.2-20251029.2.169ac3c0)
+# was amd64-only, which breaks Apple Silicon / arm64 dev clusters — this
+# rebuild is the same official redis base plus the same two scripts, published
+# multi-arch (linux/amd64 + linux/arm64) by release-deploy-redis.yml.
+FROM redis:7.4.6
+
+COPY config-init.sh /config-init.sh
+COPY liveness-check.sh /liveness-check.sh
+RUN chmod +x /liveness-check.sh /config-init.sh

--- a/deploy/images/redis/README.md
+++ b/deploy/images/redis/README.md
@@ -1,0 +1,41 @@
+# Platform Redis image
+
+Companion image for the bundled sentinel-mode redis chart
+(`deploy/charts/redis-1.11.2.tgz`, installed by `deploy.sh redis install`).
+
+## Why this exists
+
+The chart expects two scripts **inside the image** (nothing mounts them):
+
+- `/config-init.sh` — initContainer: renders `redis.conf` / `sentinel.conf` and
+  `users.acl` (root / monitor / sentinel users) onto the data PVC.
+- `/liveness-check.sh` — liveness/readiness probe helper.
+
+The original image (`swr.cn-east-3.myhuaweicloud.com/openbkn-ai/redis:1.11.2-20251029.2.169ac3c0`)
+shipped **amd64 only** — its `…-arm64` tag also contains an amd64 build — so
+Redis CrashLoops with `exec format error` on arm64 clusters (Apple Silicon
+kind, arm64 k3s). This directory rebuilds the identical image multi-arch.
+
+## Provenance
+
+- Base: official `redis:7.4.6` (Debian bookworm) — matches the original's base
+  layers (`REDIS_VERSION=7.4.6`).
+- `config-init.sh` / `liveness-check.sh`: extracted byte-identical from the
+  original amd64 image above.
+
+## Build & publish
+
+CI (`.github/workflows/release-deploy-redis.yml`) builds
+`linux/amd64,linux/arm64` on any push touching this directory and publishes to
+GHCR plus the Huawei SWR mirror as
+`redis:1.11.2-<branch>.<committime>.sha<short>` (base `1.11.2` = chart
+version, not the repo VERSION).
+
+Consumed via `REDIS_IMAGE_TAG` (default in `deploy/scripts/lib/common.sh`).
+
+Local one-off:
+
+```bash
+docker buildx build --platform linux/amd64,linux/arm64 \
+  -t <registry>/openbkn-ai/redis:<tag> --push deploy/images/redis
+```

--- a/deploy/images/redis/config-init.sh
+++ b/deploy/images/redis/config-init.sh
@@ -1,0 +1,285 @@
+#!/bin/bash
+
+echo "$(date) Start..."
+
+[ -z "${SERVICE}" ] && exit 1
+
+[ -z "${DOMAIN}" ] && exit 1
+
+[ -z "${REDIS_PORT}" ] && exit 1
+
+[ -z "${SENTINEL_PORT}" ] && exit 1
+
+[ -z "${MASTER_GROUP}" ] && exit 1
+[ -z "${QUORUM}" ] && exit 1
+
+[ -z "${SET_DEFAULT_USER}" ] && exit 1
+
+[ -z "${ROOT_USER}" ] && exit 1
+[ -z "${ROOT_PASS_ENCODE}" ] && exit 1
+ROOT_PASS=$(echo -n "${ROOT_PASS_ENCODE}" | base64 -d | awk '{ print $1 }')
+
+[ -z "${MONITOR_USER}" ] && exit 1
+[ -z "${MONITOR_PASS_ENCODE}" ] && exit 1
+MONITOR_PASS=$(echo -n "${MONITOR_PASS_ENCODE}" | base64 -d | awk '{ print $1 }')
+
+[ -z "${SENTINEL_USER}" ] && exit 1
+[ -z "${SENTINEL_PASS_ENCODE}" ] && exit 1
+SENTINEL_PASS=$(echo -n "${SENTINEL_PASS_ENCODE}" | base64 -d | awk '{ print $1 }')
+
+HOSTNAME="$(hostname)"
+INDEX="${HOSTNAME##*-}"
+
+REDIS_CONF="/data/conf/redis.conf"
+SENTINEL_CONF="/data/conf/sentinel.conf"
+
+USERS_ACL="/data/conf/users.acl"
+SENTINEL_ACL="/data/conf/sentinel-users.acl"
+
+MASTER=""
+
+set -eu
+
+sentinel_get_master() {
+set +e
+    redis-cli -h ${SERVICE} -p ${SENTINEL_PORT} --user ${SENTINEL_USER} --pass ${SENTINEL_PASS} --no-auth-warning --raw \
+        sentinel get-master-addr-by-name "${MASTER_GROUP}" | grep -v "${REDIS_PORT}"
+set -e
+}
+
+sentinel_get_master_retry() {
+    master=""
+    retry=${1}
+    sleep=3
+    for i in $(seq 1 "${retry}"); do
+        master=$(sentinel_get_master)
+        if [ -n "${master}" ]; then
+            break
+        fi
+        sleep $((sleep + i))
+    done
+    echo "${master}"
+}
+
+identify_master() {
+    echo "Identifying redis master (get-master-addr-by-name).."
+    echo "  using sentinel (${SERVICE}), sentinel group name (${MASTER_GROUP})"
+    echo "  $(date).."
+    MASTER="$(sentinel_get_master_retry 3)"
+    if [ -n "${MASTER}" ]; then
+        echo "  $(date) Found redis master (${MASTER})"
+    else
+        echo "  $(date) Did not find redis master (${MASTER})"
+    fi
+}
+
+sentinel_update() {
+    echo "Updating sentinel config.."
+    MY_SENTINEL_ID=$( echo -n "${SERVICE}-${INDEX}" | sha256sum | cut -c1-40 )
+    echo "  sentinel id (${MY_SENTINEL_ID}), sentinel grp (${MASTER_GROUP}), quorum (${QUORUM})"
+    echo "sentinel myid ${MY_SENTINEL_ID}" >> "${SENTINEL_CONF}"
+    echo "  redis master (${1}:${REDIS_PORT})"
+    echo "sentinel monitor ${MASTER_GROUP} ${1} ${REDIS_PORT} ${QUORUM}" >> "${SENTINEL_CONF}"
+    echo "sentinel announce-ip ${ANNOUNCE_IP}" >> ${SENTINEL_CONF}
+    echo "  announce (${ANNOUNCE_IP}:${SENTINEL_PORT})"
+    echo "sentinel announce-port ${SENTINEL_PORT}" >> ${SENTINEL_CONF}
+}
+
+redis_update() {
+    echo "Updating redis config.."
+    echo "  we are slave of redis master (${1}:${REDIS_PORT})"
+    echo "replicaof ${1} ${REDIS_PORT}" >> "${REDIS_CONF}"
+    echo "replica-announce-ip ${ANNOUNCE_IP}" >> ${REDIS_CONF}
+    echo "replica-announce-port ${REDIS_PORT}" >> ${REDIS_CONF}
+}
+
+copy_config() {
+    echo "Copying default redis config.."
+    echo "  to '${REDIS_CONF}'"
+    cp /readonly-config/redis.conf "${REDIS_CONF}"
+    echo "Copying default sentinel config.."
+    echo "  to '${SENTINEL_CONF}'"
+    cp /readonly-config/sentinel.conf "${SENTINEL_CONF}"
+
+    ROOT_PASS_SHA256=$(echo -n "${ROOT_PASS}" | sha256sum | awk '{ print $1 }')
+    SENTINEL_PASS_SHA256=$(echo -n "${SENTINEL_PASS}" | sha256sum | awk '{ print $1 }')
+
+    if [ ! -f "${USERS_ACL}" ]; then
+        echo "Copying default users acl file.."
+        echo "  to '${USERS_ACL}'"
+        cp /readonly-config/users.acl "${USERS_ACL}"
+
+        if [ "$SET_DEFAULT_USER" = "true" ]; then
+            echo "user default on #${ROOT_PASS_SHA256} ~* +@all allchannels" >> ${USERS_ACL}
+        else
+            echo "user default off #${ROOT_PASS_SHA256} ~* +@all allchannels" >> ${USERS_ACL}
+        fi
+
+        echo "user ${ROOT_USER} on #${ROOT_PASS_SHA256} ~* +@all allchannels" >> ${USERS_ACL}
+        echo "user sentinel-user on #${SENTINEL_PASS_SHA256} allchannels +multi +slaveof +ping +exec +subscribe +config|rewrite +role +publish +info +client|setname +client|kill +script|kill" >> ${USERS_ACL}
+        echo "user replica-user on #${SENTINEL_PASS_SHA256} +psync +replconf +ping" >> ${USERS_ACL}
+    else
+        if [ "$SET_DEFAULT_USER" = "true" ]; then
+            sed -i "s/^user default .*/user default on #${ROOT_PASS_SHA256} ~* +@all allchannels/" ${USERS_ACL}
+        else
+            sed -i "s/^user default .*/user default off #${ROOT_PASS_SHA256} ~* +@all allchannels/" ${USERS_ACL}
+        fi
+        sed -i "s/^user ${ROOT_USER} .*/user ${ROOT_USER} on #${ROOT_PASS_SHA256} ~* +@all allchannels/" ${USERS_ACL}
+        sed -i "s/^user sentinel-user .*/user sentinel-user on #${SENTINEL_PASS_SHA256} allchannels +multi +slaveof +ping +exec +subscribe +config|rewrite +role +publish +info +client|setname +client|kill +script|kill/" ${USERS_ACL}
+        sed -i "s/^user monitor-user .*/user monitor-user on #8d580eff577d0a63ab1fa7129f9802c3f995ae2ec1a871ff9f639087c993be8a -@all +ping +@connection +memory -readonly +strlen +config|get +xinfo +pfcount -quit +zcard +type +xlen -readwrite -command +client -wait +scard +llen +hlen +get +eval +slowlog +cluster|info +cluster|slots +cluster|nodes -hello -echo +info +latency +scan -reset -auth -asking/" ${USERS_ACL}
+    fi
+
+    if [ ! -f "${SENTINEL_ACL}" ]; then
+        echo "Copying default sentinel users acl file.."
+        echo "  to '${SENTINEL_ACL}'"
+        cp /readonly-config/sentinel-users.acl "${SENTINEL_ACL}"
+
+        if [ "$SET_DEFAULT_USER" = "true" ]; then
+            echo "user default on #${ROOT_PASS_SHA256} ~* +@all allchannels" >> ${SENTINEL_ACL}
+        else
+            echo "user default off #${ROOT_PASS_SHA256} ~* +@all allchannels" >> ${SENTINEL_ACL}
+        fi
+
+        echo "user ${ROOT_USER} on #${ROOT_PASS_SHA256} ~* +@all allchannels" >> ${SENTINEL_ACL}
+        echo "user sentinel-user on #${SENTINEL_PASS_SHA256} -@all +auth +client|getname +client|id +client|setname +command +hello +ping +role +sentinel|get-master-addr-by-name +sentinel|master +sentinel|myid +sentinel|replicas +sentinel|sentinels +sentinel|masters" >> ${SENTINEL_ACL}
+    else
+        if [ "$SET_DEFAULT_USER" = "true" ]; then
+            sed -i "s/^user default .*/user default on #${ROOT_PASS_SHA256} ~* +@all allchannels/" ${SENTINEL_ACL}
+        else
+            sed -i "s/^user default .*/user default off #${ROOT_PASS_SHA256} ~* +@all allchannels/" ${SENTINEL_ACL}
+        fi
+        sed -i "s/^user ${ROOT_USER} .*/user ${ROOT_USER} on #${ROOT_PASS_SHA256} ~* +@all allchannels/" ${SENTINEL_ACL}
+        sed -i "s/^user sentinel-user .*/user sentinel-user on #${SENTINEL_PASS_SHA256} -@all +auth +client|getname +client|id +client|setname +command +hello +ping +role +sentinel|get-master-addr-by-name +sentinel|master +sentinel|myid +sentinel|replicas +sentinel|sentinels +sentinel|masters/" ${SENTINEL_ACL}
+        sed -i "s/^user monitor-user .*/user monitor-user on #8d580eff577d0a63ab1fa7129f9802c3f995ae2ec1a871ff9f639087c993be8a -@all +ping +@connection -command +client -hello +info -auth +sentinel|masters +sentinel|replicas +sentinel|slaves +sentinel|sentinels +sentinel|ckquorum +sentinel|failover +sentinel|get-master-addr-by-name/" ${SENTINEL_ACL}
+    fi
+}
+
+setup_defaults() {
+    echo "Setting up defaults.."
+    echo "  using statefulset index (${INDEX})"
+    if [ "${INDEX}" = "0" ]; then
+        echo "Setting this pod as master for redis and sentinel.."
+        echo "  using announce (${ANNOUNCE_IP})"
+        redis_update "${ANNOUNCE_IP}"
+        sentinel_update "${ANNOUNCE_IP}"
+        echo "  make sure ${ANNOUNCE_IP} is not a slave (slaveof no one)"
+        sed -i "s/^.*replicaof.*//" "${REDIS_CONF}"
+    else
+        echo "Getting redis master ip.."
+        DEFAULT_MASTER="${SERVICE}-announce-0.${DOMAIN}"
+        echo "  blindly assuming (${DEFAULT_MASTER}) are master"
+        echo "Setting default slave config for redis and sentinel.."
+        echo "  using master ip (${DEFAULT_MASTER})"
+        redis_update "${DEFAULT_MASTER}"
+        sentinel_update "${DEFAULT_MASTER}"
+    fi
+}
+
+redis_ping() {
+set +e
+    redis_cli_args="-h ${MASTER} -p ${REDIS_PORT} --user ${MONITOR_USER} --pass ${MONITOR_PASS} --no-auth-warning"
+    redis-cli ${redis_cli_args} ping
+set -e
+}
+
+redis_ping_retry() {
+    ping=""
+    retry=${1}
+    sleep=3
+    for i in $(seq 1 "${retry}"); do
+        if [ "$(redis_ping)" = "PONG" ]; then
+            ping="PONG"
+            break
+        fi
+        sleep $((sleep + i))
+        MASTER=$(sentinel_get_master)
+    done
+    echo "${ping}"
+}
+
+find_master() {
+    echo "Verifying redis master.."
+    echo "  ping (${MASTER}:${REDIS_PORT})"
+    echo "  $(date).."
+    if [ "$(redis_ping_retry 3)" != "PONG" ]; then
+        echo "  $(date) Can't ping redis master (${MASTER})"
+        echo "Attempting to force failover (sentinel failover).."
+
+        echo "  on sentinel (${SERVICE}:${SENTINEL_PORT}), sentinel grp (${MASTER_GROUP})"
+        echo "  $(date).."
+        redis_cli_args="${SERVICE} -p ${SENTINEL_PORT} --user ${SENTINEL_USER} --pass ${SENTINEL_PASS} --no-auth-warning --raw"
+        if redis-cli ${redis_cli_args} sentinel failover "${MASTER_GROUP}" | grep -q "NOGOODSLAVE" ; then
+            echo "  $(date) Failover returned with 'NOGOODSLAVE'"
+            echo "Setting defaults for this pod.."
+            setup_defaults
+            return 0
+        fi
+
+        echo "Hold on for 10sec"
+        sleep 10
+        echo "We should get redis master's ip now. Asking (get-master-addr-by-name).."
+        echo "  sentinel (${SERVICE}:${SENTINEL_PORT}), sentinel grp (${MASTER_GROUP})"
+        echo "  $(date).."
+        MASTER="$(sentinel_get_master)"
+        if [ "${MASTER}" ]; then
+            echo "  $(date) Found redis master (${MASTER})"
+            echo "Updating redis and sentinel config.."
+            redis_update "${MASTER}"
+            sentinel_update "${MASTER}"
+
+            if [ "${MASTER}" = "${ANNOUNCE_IP}" ]; then
+                sed -i "s/^.*replicaof.*//" "${REDIS_CONF}"
+            fi
+        else
+            echo "$(date) Error: Could not failover, exiting..."
+            exit 1
+        fi
+    else
+        echo "  $(date) Found reachable redis master (${MASTER})"
+        echo "Updating redis and sentinel config.."
+        redis_update "${MASTER}"
+        sentinel_update "${MASTER}"
+    fi
+}
+
+check_aof() {
+    AOF_DIR="/data/appendonlydir"
+    if [ -d "${AOF_DIR}" ]; then
+        echo "检测到 AOF 目录 ${AOF_DIR}，开始检查所有 AOF 文件..."
+        for aof in "${AOF_DIR}"/*.aof; do
+            [ -e "${aof}" ] || continue
+            echo "检查文件: ${aof}"
+            if ! redis-check-aof "${aof}" >/dev/null 2>&1; then
+                echo "  文件损坏，备份并修复..."
+                cp "${aof}" "${aof}.bak.$(date +%s)"
+                echo "y" | redis-check-aof --fix "${aof}"
+            else
+                echo "  文件正常"
+            fi
+        done
+        echo "AOF 检查完成"
+    else
+        echo "AOF 目录 ${AOF_DIR} 不存在，跳过检查"
+    fi
+}
+
+mkdir -p /data/conf/
+
+echo "Initializing config.."
+copy_config
+
+# where is redis master
+identify_master
+
+echo "Identify announce ip for this pod.."
+ANNOUNCE_IP="${SERVICE}-announce-${INDEX}.${DOMAIN}"
+echo "  identified announce (${ANNOUNCE_IP})"
+if [ "${MASTER}" ]; then
+    find_master
+else
+    setup_defaults
+fi
+
+check_aof
+
+echo "$(date) Ready..."

--- a/deploy/images/redis/liveness-check.sh
+++ b/deploy/images/redis/liveness-check.sh
@@ -1,0 +1,54 @@
+#!/bin/bash
+
+[ -z "${PORT}" ] && exit 1
+[ -z "${MASTER_GROUP}" ] && exit 1
+[ -z "${MONITOR_USER}" ] && exit 1
+[ -z "${MONITOR_PASS_ENCODE}" ] && exit 1
+
+MONITOR_PASS=$(echo -n "${MONITOR_PASS_ENCODE}" | base64 -d | awk '{ print $1 }')
+redis_cli_args="-h localhost -p ${PORT} --user ${MONITOR_USER} --pass ${MONITOR_PASS} --no-auth-warning"
+response=$(redis-cli ${redis_cli_args} ping)
+if [ "${response}" != "PONG" ]; then
+    echo "${response}"
+    exit 1
+fi
+echo "response=${response}"
+
+if [[ "${PORT}" == "26379" ]]
+then
+    port="6379"
+    redis_sentinel_cli_args="-h localhost -p ${PORT} --user ${MONITOR_USER} --pass ${MONITOR_PASS} --no-auth-warning"
+    redis_cli_args="-h localhost -p ${port} --user ${MONITOR_USER} --pass ${MONITOR_PASS} --no-auth-warning"
+elif [[ "${PORT}" == "6379" ]]
+then
+    port="26379"
+    redis_sentinel_cli_args="-h localhost -p ${port} --user ${MONITOR_USER} --pass ${MONITOR_PASS} --no-auth-warning"
+    redis_cli_args="-h localhost -p ${PORT} --user ${MONITOR_USER} --pass ${MONITOR_PASS} --no-auth-warning"
+fi
+
+redis_sentinel_master_check="$(redis-cli --raw ${redis_sentinel_cli_args} sentinel get-master-addr-by-name ${MASTER_GROUP} | grep 'svc.cluster.local.')"
+redis_sentinel_master=${redis_sentinel_master_check}
+redis_master_check="$(redis-cli --raw ${redis_cli_args} info replication | grep 'master_host' | tr -d '\r')"
+redis_master=${redis_master_check#*:}
+
+if [[ "${redis_sentinel_master}" == "${redis_master}" ]]
+then
+    echo "redis sentinel monitor master is redis master ${redis_master}"
+elif [[ "${redis_sentinel_master}" != "${redis_master}" ]]
+then
+    echo "redis sentinel monitor master is ${redis_sentinel_master}, but redis master is ${redis_master}"
+    redis_master_check="$(redis-cli --raw ${redis_cli_args} info replication | grep 'role' | tr -d '\r')"
+    redis_master=${redis_master_check#*:}
+    redis_slave_check="$(redis-cli --raw ${redis_cli_args} info replication | grep 'connected_slaves' | tr -d '\r')"
+    redis_slave_num=${redis_slave_check#*:}
+    if [[ $redis_master == "master" ]] && [[ $(expr $redis_slave_num)+0 > 0 ]]
+    then
+        echo "redis sentinel monitor master is redis master ${redis_master}"
+    else
+        echo "redis sentinel monitor master is redis master ${redis_master}, but no enough good replicas, will be restarted"
+        exit 1
+    fi
+else
+  echo "redis sentinel monitor master is ${redis_sentinel_master}, not redis master ${redis_master}, will be restarted"
+  exit 1
+fi


### PR DESCRIPTION
## 背景

Mac(Apple Silicon)开发者跑 `deploy.sh` 装数据层时,Redis 卡在 helm `--wait` 超时(`UPGRADE FAILED: context deadline exceeded`)。排查实测:

- swr `openbkn-ai/redis` 仓三个 tag **全是 amd64**,连 `…-arm64` 后缀 tag 里也是 amd64 构建(tag 名打错)。
- arm64 kind 节点照拉(普通 v2 manifest 无平台协商),起容器 `exec format error` CrashLoop。
- 数据层其余镜像(mariadb/kafka/opensearch/ingress)均为 multi-arch,只有 redis 缺。

## 方案

镜像源码进仓 `deploy/images/redis/`:

- 原镜像解剖 = 官方 `redis:7.4.6` + 仅两个定制脚本(`/config-init.sh`、`/liveness-check.sh`,chart initContainer/探针依赖,无 ConfigMap 挂载)。
- 脚本从原 amd64 镜像逐字节抠出(md5 校验一致),Dockerfile 三行重建。
- 新 workflow `release-deploy-redis.yml` 走 `reusable-build`(默认 `linux/amd64,linux/arm64`),GHCR + swr mirror 双推。
- 版本基线用 redis chart 版本 `1.11.2-*`(非仓库 VERSION),沿用 `<branch>.<committime>.sha<short>` 排序方案。
- 本地已验证 arm64 构建:原生 aarch64 redis 7.4.6,脚本可执行、行为正常。

分支推送即发布分支 tag 镜像,合并前可先在 Apple Silicon 上实测。

## 合并后跟进(另提 PR)

1. 等 main 构建出 `1.11.2-main.<ts>.sha<7>` tag,bump `deploy/scripts/lib/common.sh` 的 `REDIS_IMAGE_TAG` 默认值 + `sync-k8s-images.sh` 清单。
2. ghcr 新包 `redis` 默认 private,需要匿名拉的话手动改 public。
3. swr 那个名不副实的旧 `…-arm64` tag 建议删除或重推,防继续误导。

🤖 Generated with [Claude Code](https://claude.com/claude-code)