### PR TITLE
fix(vega): 修复 batch 构建键校验与索引映射

### DIFF
--- a/adp/vega/vega-backend/server/errors/build_task.go
+++ b/adp/vega/vega-backend/server/errors/build_task.go
@@ -10,12 +10,13 @@ package errors
 // BuildTask 相关错误码
 const (
 	// 400 Bad Request
-	VegaBackend_BuildTask_Exist                       = "VegaBackend.BuildTask.Exist"
-	VegaBackend_BuildTask_Running                     = "VegaBackend.BuildTask.Running"
-	VegaBackend_BuildTask_InvalidStatus               = "VegaBackend.BuildTask.InvalidStatus"
-	VegaBackend_BuildTask_InvalidExecuteType          = "VegaBackend.BuildTask.InvalidExecuteType"
-	VegaBackend_BuildTask_InvalidParameter_ResourceID = "VegaBackend.BuildTask.InvalidParameter.ResourceID"
-	VegaBackend_BuildTask_InvalidParameter_Mode       = "VegaBackend.BuildTask.InvalidParameter.Mode"
+	VegaBackend_BuildTask_Exist                           = "VegaBackend.BuildTask.Exist"
+	VegaBackend_BuildTask_Running                         = "VegaBackend.BuildTask.Running"
+	VegaBackend_BuildTask_InvalidStatus                   = "VegaBackend.BuildTask.InvalidStatus"
+	VegaBackend_BuildTask_InvalidExecuteType              = "VegaBackend.BuildTask.InvalidExecuteType"
+	VegaBackend_BuildTask_InvalidParameter_ResourceID     = "VegaBackend.BuildTask.InvalidParameter.ResourceID"
+	VegaBackend_BuildTask_InvalidParameter_Mode           = "VegaBackend.BuildTask.InvalidParameter.Mode"
+	VegaBackend_BuildTask_InvalidParameter_BuildKeyFields = "VegaBackend.BuildTask.InvalidParameter.BuildKeyFields"
 
 	// 404 Not Found
 	VegaBackend_BuildTask_NotFound = "VegaBackend.BuildTask.NotFound"
@@ -41,6 +42,7 @@ var BuildTaskErrCodeList = []string{
 	VegaBackend_BuildTask_InvalidExecuteType,
 	VegaBackend_BuildTask_InvalidParameter_ResourceID,
 	VegaBackend_BuildTask_InvalidParameter_Mode,
+	VegaBackend_BuildTask_InvalidParameter_BuildKeyFields,
 
 	// 404 Not Found
 	VegaBackend_BuildTask_NotFound,

--- a/adp/vega/vega-backend/server/locale/build_task.en-US.toml
+++ b/adp/vega/vega-backend/server/locale/build_task.en-US.toml
@@ -13,6 +13,11 @@ Description = "Invalid build task mode"
 Solution = "Mode must be one of: streaming, batch"
 ErrorLink = "No solution"
 
+[VegaBackend.BuildTask.InvalidParameter.BuildKeyFields]
+Description = "Invalid batch build key fields"
+Solution = "Configure at least one build_key_fields field from the resource schema in index_config"
+ErrorLink = "No solution"
+
 [VegaBackend.BuildTask.InvalidStateTransition]
 Description = "Invalid build task state transition"
 Solution = "Check current task status; start requires status in {init, stopped}; stop requires status == running"

--- a/adp/vega/vega-backend/server/locale/build_task.zh-CN.toml
+++ b/adp/vega/vega-backend/server/locale/build_task.zh-CN.toml
@@ -13,6 +13,11 @@ Description = "构建任务模式无效"
 Solution = "mode 必须为 streaming / batch 之一"
 ErrorLink = "暂无"
 
+[VegaBackend.BuildTask.InvalidParameter.BuildKeyFields]
+Description = "批量构建键无效"
+Solution = "请在资源 index_config 中配置至少一个存在于 schema 的 build_key_fields 字段"
+ErrorLink = "暂无"
+
 [VegaBackend.BuildTask.InvalidStateTransition]
 Description = "构建任务状态转移非法"
 Solution = "检查当前状态；start 要求 status 为 init 或 stopped；stop 要求 status 为 running"

--- a/adp/vega/vega-backend/server/logics/build_task/build_task_service.go
+++ b/adp/vega/vega-backend/server/logics/build_task/build_task_service.go
@@ -129,6 +129,12 @@ func (bts *buildTaskService) Create(ctx context.Context, req *interfaces.CreateB
 		span.SetStatus(codes.Error, "Invalid execute type")
 		return "", err
 	}
+	if req.Mode == interfaces.BuildTaskModeBatch {
+		if err := validateBatchBuildKeyFields(ctx, resource); err != nil {
+			span.SetStatus(codes.Error, "Invalid batch build key fields")
+			return "", err
+		}
+	}
 
 	cat, err := bts.cs.GetByID(ctx, resource.CatalogID, false)
 	if err != nil {
@@ -184,6 +190,14 @@ func (bts *buildTaskService) Create(ctx context.Context, req *interfaces.CreateB
 
 	span.SetStatus(codes.Ok, "")
 	return buildTask.ID, nil
+}
+
+func validateBatchBuildKeyFields(ctx context.Context, resource *interfaces.Resource) error {
+	if resource.IndexConfig == nil || len(resource.IndexConfig.BuildKeyFields) == 0 {
+		return rest.NewHTTPError(ctx, http.StatusBadRequest, verrors.VegaBackend_BuildTask_InvalidParameter_BuildKeyFields).
+			WithErrorDetails("batch build task requires at least one build_key_fields entry")
+	}
+	return nil
 }
 
 func normalizeCreateBuildTaskExecuteType(ctx context.Context, req *interfaces.CreateBuildTaskRequest) (string, error) {

--- a/adp/vega/vega-backend/server/logics/build_task/build_task_service_test.go
+++ b/adp/vega/vega-backend/server/logics/build_task/build_task_service_test.go
@@ -26,6 +26,25 @@ import (
 )
 
 func TestBuildTaskServiceCreateBuildTask(t *testing.T) {
+	t.Run("rejects batch task without build key fields", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		mockRS := mock_interfaces.NewMockResourceService(ctrl)
+		service := &buildTaskService{rs: mockRS}
+
+		mockRS.EXPECT().GetByID(gomock.Any(), "resource-1").Return(&interfaces.Resource{
+			ID:        "resource-1",
+			CatalogID: "catalog-1",
+			Category:  interfaces.ResourceCategoryTable,
+		}, nil)
+
+		_, err := service.Create(context.Background(), &interfaces.CreateBuildTaskRequest{
+			ResourceID: "resource-1",
+			Mode:       interfaces.BuildTaskModeBatch,
+		})
+		httpErr := requireHTTPError(t, err, verrors.VegaBackend_BuildTask_InvalidParameter_BuildKeyFields)
+		assert.Equal(t, http.StatusBadRequest, httpErr.HTTPCode)
+	})
+
 	t.Run("rejects disabled catalog", func(t *testing.T) {
 		ctrl := gomock.NewController(t)
 		mockCS := mock_interfaces.NewMockCatalogService(ctrl)
@@ -34,9 +53,11 @@ func TestBuildTaskServiceCreateBuildTask(t *testing.T) {
 
 		mockRS.EXPECT().GetByID(gomock.Any(), "resource-1").
 			Return(&interfaces.Resource{
-				ID:        "resource-1",
-				CatalogID: "catalog-1",
-				Category:  interfaces.ResourceCategoryTable,
+				ID:               "resource-1",
+				CatalogID:        "catalog-1",
+				Category:         interfaces.ResourceCategoryTable,
+				IndexConfig:      &interfaces.ResourceIndexConfig{BuildKeyFields: []string{"id"}},
+				SchemaDefinition: []*interfaces.Property{{Name: "id"}},
 			}, nil)
 		mockCS.EXPECT().GetByID(gomock.Any(), "catalog-1", false).
 			Return(&interfaces.Catalog{ID: "catalog-1", Enabled: false}, nil)
@@ -53,9 +74,11 @@ func TestBuildTaskServiceCreateBuildTask(t *testing.T) {
 
 		mockRS.EXPECT().GetByID(gomock.Any(), "resource-1").
 			Return(&interfaces.Resource{
-				ID:        "resource-1",
-				CatalogID: "catalog-1",
-				Category:  interfaces.ResourceCategoryTable,
+				ID:               "resource-1",
+				CatalogID:        "catalog-1",
+				Category:         interfaces.ResourceCategoryTable,
+				IndexConfig:      &interfaces.ResourceIndexConfig{BuildKeyFields: []string{"id"}},
+				SchemaDefinition: []*interfaces.Property{{Name: "id"}},
 			}, nil)
 		mockCS.EXPECT().GetByID(gomock.Any(), "catalog-1", false).
 			Return(&interfaces.Catalog{ID: "catalog-1", Enabled: true}, nil)
@@ -109,6 +132,7 @@ func TestBuildTaskServiceCreateBuildTask(t *testing.T) {
 					DefaultFulltextAnalyzer: "ik_max_word",
 				},
 				SchemaDefinition: []*interfaces.Property{
+					{Name: "id"},
 					{
 						Name: "family_name",
 						Features: []interfaces.PropertyFeature{
@@ -174,6 +198,7 @@ func TestBuildTaskServiceCreateBuildTask(t *testing.T) {
 				DefaultFulltextAnalyzer: "ik_max_word",
 			},
 			SchemaDefinition: []*interfaces.Property{
+				{Name: "id"},
 				{
 					Name: "family_name",
 					Features: []interfaces.PropertyFeature{
@@ -228,9 +253,11 @@ func TestBuildTaskServiceCreateBuildTask(t *testing.T) {
 				CatalogID: "catalog-1",
 				Category:  interfaces.ResourceCategoryTable,
 				IndexConfig: &interfaces.ResourceIndexConfig{
+					BuildKeyFields:        []string{"id"},
 					DefaultEmbeddingModel: "default-model",
 				},
 				SchemaDefinition: []*interfaces.Property{
+					{Name: "id"},
 					{
 						Name: "family_name",
 						Features: []interfaces.PropertyFeature{
@@ -291,6 +318,7 @@ func TestBuildTaskServiceCreateBuildTask(t *testing.T) {
 					DefaultFulltextAnalyzer: "default_analyzer",
 				},
 				SchemaDefinition: []*interfaces.Property{
+					{Name: "id"},
 					{
 						Name: "title",
 						Features: []interfaces.PropertyFeature{
@@ -362,9 +390,11 @@ func TestBuildTaskServiceCreateBuildTask(t *testing.T) {
 				CatalogID: "catalog-1",
 				Category:  interfaces.ResourceCategoryTable,
 				IndexConfig: &interfaces.ResourceIndexConfig{
+					BuildKeyFields:        []string{"id"},
 					DefaultEmbeddingModel: "bogus-model",
 				},
 				SchemaDefinition: []*interfaces.Property{
+					{Name: "id"},
 					{
 						Name: "family_name",
 						Features: []interfaces.PropertyFeature{

--- a/adp/vega/vega-backend/server/logics/connector/local/index/opensearch/opensearch_query.go
+++ b/adp/vega/vega-backend/server/logics/connector/local/index/opensearch/opensearch_query.go
@@ -977,6 +977,14 @@ func (c *OpenSearchConnector) buildFieldMappings(schemaDefinition []*interfaces.
 							}
 						}
 					case "vector":
+						// A vector feature on a source field describes VEGA's embedding
+						// workflow. Only the generated *_vector field is an OpenSearch
+						// vector mapping; its configuration must not be applied to the
+						// source field (for example, a keyword field cannot accept
+						// embedding_model).
+						if column.Type != interfaces.DataType_Vector {
+							continue
+						}
 						for k, v := range feature.Config {
 							fieldProps[k] = v
 						}

--- a/adp/vega/vega-backend/server/logics/connector/local/index/opensearch/type_mapping_test.go
+++ b/adp/vega/vega-backend/server/logics/connector/local/index/opensearch/type_mapping_test.go
@@ -106,6 +106,22 @@ func TestOpenSearchBuildFieldMappings(t *testing.T) {
 		assert.Equal(t, map[string]any{"type": "keyword", "ignore_above": 128}, bodyFields["raw"])
 	})
 
+	t.Run("does not apply embedding metadata to a non-vector field", func(t *testing.T) {
+		properties, hasVector, err := conn.buildFieldMappings([]*interfaces.Property{
+			{Name: "material_name", Type: interfaces.DataType_String, Features: []interfaces.PropertyFeature{
+				{FeatureType: interfaces.PropertyFeatureType_Vector, Config: map[string]any{"embedding_model": "embedding-model"}},
+			}},
+			{Name: "material_name_vector", Type: interfaces.DataType_Vector, Features: []interfaces.PropertyFeature{
+				{FeatureType: interfaces.PropertyFeatureType_Vector, Config: map[string]any{"dimension": 1024}},
+			}},
+		})
+
+		require.NoError(t, err)
+		assert.True(t, hasVector)
+		assert.Equal(t, map[string]any{"type": "keyword"}, properties["material_name"])
+		assert.Equal(t, map[string]any{"type": "knn_vector", "dimension": 1024}, properties["material_name_vector"])
+	})
+
 	t.Run("rejects unsupported feature type with config", func(t *testing.T) {
 		properties, hasVector, err := conn.buildFieldMappings([]*interfaces.Property{
 			{Name: "name", Type: interfaces.DataType_String, Features: []interfaces.PropertyFeature{

--- a/adp/vega/vega-backend/server/logics/resource/resource_service.go
+++ b/adp/vega/vega-backend/server/logics/resource/resource_service.go
@@ -993,6 +993,9 @@ func (rs *resourceService) validateResourceUpdateScope(ctx context.Context, reso
 }
 
 func (rs *resourceService) validateIndexConfigModels(ctx context.Context, schema []*interfaces.Property, indexConfig *interfaces.ResourceIndexConfig) error {
+	if err := validateIndexConfigBuildKeyFields(ctx, schema, indexConfig); err != nil {
+		return err
+	}
 	if rs.mfs == nil {
 		return nil
 	}
@@ -1033,6 +1036,26 @@ func (rs *resourceService) validateIndexConfigModels(ctx context.Context, schema
 					WithErrorDetails(fmt.Sprintf("embedding model %q for field %q not found", modelName, fieldName))
 			}
 			checkedModels[modelName] = struct{}{}
+		}
+	}
+	return nil
+}
+
+func validateIndexConfigBuildKeyFields(ctx context.Context, schema []*interfaces.Property, indexConfig *interfaces.ResourceIndexConfig) error {
+	if indexConfig == nil || len(indexConfig.BuildKeyFields) == 0 {
+		return nil
+	}
+
+	schemaFields := make(map[string]struct{}, len(schema))
+	for _, prop := range schema {
+		if prop != nil {
+			schemaFields[prop.Name] = struct{}{}
+		}
+	}
+	for _, field := range indexConfig.BuildKeyFields {
+		if _, exists := schemaFields[field]; !exists {
+			return rest.NewHTTPError(ctx, http.StatusBadRequest, verrors.VegaBackend_InvalidParameter_RequestBody).
+				WithErrorDetails(fmt.Sprintf("build_key_fields field %q is not in the resource schema", field))
 		}
 	}
 	return nil

--- a/adp/vega/vega-backend/server/logics/resource/resource_service_test.go
+++ b/adp/vega/vega-backend/server/logics/resource/resource_service_test.go
@@ -14,6 +14,7 @@ import (
 	"testing"
 
 	"github.com/openbkn-ai/bkn-comm-go/rest"
+	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
 
 	verrors "vega-backend/errors"
@@ -51,6 +52,30 @@ func newTestService(t *testing.T) (*resourceService,
 	mockCS.EXPECT().ListInternalIDs(gomock.Any()).Return([]string{}, nil).AnyTimes()
 
 	return rs, mockRA, mockPS, mockDS, mockUMS, mockCS, mockBTA
+}
+
+func TestValidateIndexConfigBuildKeyFields(t *testing.T) {
+	schema := []*interfaces.Property{{Name: "id"}, {Name: "updated_at"}}
+
+	t.Run("allows an empty build key configuration", func(t *testing.T) {
+		require.NoError(t, validateIndexConfigBuildKeyFields(context.Background(), schema, nil))
+	})
+
+	t.Run("allows build keys defined in schema", func(t *testing.T) {
+		err := validateIndexConfigBuildKeyFields(context.Background(), schema, &interfaces.ResourceIndexConfig{
+			BuildKeyFields: []string{"updated_at", "id"},
+		})
+		require.NoError(t, err)
+	})
+
+	t.Run("rejects build keys absent from schema", func(t *testing.T) {
+		err := validateIndexConfigBuildKeyFields(context.Background(), schema, &interfaces.ResourceIndexConfig{
+			BuildKeyFields: []string{"missing_id"},
+		})
+		httpErr := err.(*rest.HTTPError)
+		require.Equal(t, http.StatusBadRequest, httpErr.HTTPCode)
+		require.Contains(t, httpErr.BaseError.ErrorDetails, `build_key_fields field "missing_id"`)
+	})
 }
 
 func TestResourceServiceCheckExistByID(t *testing.T) {
@@ -843,6 +868,7 @@ func TestResourceServiceUpdate(t *testing.T) {
 			Name:             "table",
 			LocalIndexName:   "vega-build-r1-task-1",
 			SourceIdentifier: "public.orders",
+			SchemaDefinition: []*interfaces.Property{{Name: "id"}, {Name: "updated_at"}},
 			IndexConfig: &interfaces.ResourceIndexConfig{
 				BuildKeyFields: []string{"id"},
 			},

--- a/adp/vega/vega-backend/server/worker/build_worker_batch.go
+++ b/adp/vega/vega-backend/server/worker/build_worker_batch.go
@@ -358,8 +358,10 @@ func (bbw *batchBuildWorker) executeBuild(ctx context.Context, resource *interfa
 			// Convert documents to upsert format
 			upsertRequests := make([]map[string]any, 0, readRows)
 			for _, doc := range result.Rows {
-				// Create document ID using getNewDocID function
 				docID := getNewDocID(lastBatchKeyValues, doc)
+				if docID == "" {
+					return fmt.Errorf("build document ID: no build key values found in source row")
+				}
 				upsertRequests = append(upsertRequests, map[string]any{"id": docID, "document": doc})
 			}
 


### PR DESCRIPTION
# Pull Request

## What Changed

- [x] batch Build Task 创建时要求 Resource 配置非空 `index_config.build_key_fields`，否则返回 400。
- [x] Resource 创建/更新时校验每个构建键均存在于 `schema_definition`。
- [x] batch worker 在最终文档 ID 为空时，调用 OpenSearch 前终止，避免 `id is missing`。
- [x] 非 vector 原字段不再将 vector feature 的 `embedding_model` 等 VEGA 元数据透传到 OpenSearch mapping。
- [x] 补充构建键与 OpenSearch mapping 单元测试。

---

## Why

- Related Issue: Closes #289
- Background:
  - batch 构建缺少构建键时会在 OpenSearch bulk update 阶段报 `_id` 缺失。
  - `material_name` 等 keyword/string 字段的 vector feature 会导致 OpenSearch mapping 出现不支持的 `embedding_model` 参数。

---

## How

- 将构建键字段归属校验集中到 Resource 的创建/更新路径；Build Task 层仅处理 batch 模式的非空要求。
- 保留最小运行时保护：仅当最终 ID 为空时阻止 OpenSearch 写入。
- 仅对真正的 `vector` 字段应用 vector mapping 配置；源字段上的 vector feature 仅作为 VEGA 向量化元数据。
- Breaking changes: 对缺少构建键的 batch 任务创建，以及引用不存在 schema 字段的 Resource 配置，现返回 400。

---

## Testing

- [x] Unit tests passed locally
- [ ] Integration tests passed locally
- [ ] Verified in test environment

Test notes:

- `go test ./...`
- 本地手工 batch 重试已验证任务可越过此前的模型服务阻塞；当前卡在本地 OpenSearch port-forward 的 `EOF`，尚未完成端到端环境验证。

---

## Risk & Rollback

- Potential risks:
  - 既有 Resource 若保存了不存在的构建键字段，后续更新会被拒绝，需先修正配置。
  - 已存在的 OpenSearch 索引不会被本改动自动修复；需要重新执行构建以创建正确 mapping。
- Rollback plan:
  - Revert `28bcb0cb` 和 `a889ce7a`。

---

## Additional Notes

- 未包含本地 `vega-backend-config.yaml` 改动。
