### PR TITLE
fix(deploy): default redis image to multi-arch 1.11.2-main tag

### DIFF
--- a/deploy/scripts/lib/common.sh
+++ b/deploy/scripts/lib/common.sh
@@ -1270,13 +1270,13 @@ REDIS_LOCAL_CHART_DIR="${REDIS_LOCAL_CHART_DIR:-${SCRIPT_DIR}/charts/redis}"
 REDIS_ARCHITECTURE="${REDIS_ARCHITECTURE:-sentinel}"  # standalone or sentinel
 # In offline mode, use offline registry; otherwise use SWR mirror
 if [[ "${OFFLINE_MODE}" == "true" ]]; then
-    REDIS_IMAGE="${REDIS_IMAGE:-${OFFLINE_REGISTRY}/openbkn-ai/redis:1.11.2-20251029.2.169ac3c0}"
+    REDIS_IMAGE="${REDIS_IMAGE:-${OFFLINE_REGISTRY}/openbkn-ai/redis:1.11.2-main.20260718025853.shaf24e971}"
 else
-    REDIS_IMAGE="${REDIS_IMAGE:-swr.cn-east-3.myhuaweicloud.com/openbkn-ai/redis:1.11.2-20251029.2.169ac3c0}"
+    REDIS_IMAGE="${REDIS_IMAGE:-swr.cn-east-3.myhuaweicloud.com/openbkn-ai/redis:1.11.2-main.20260718025853.shaf24e971}"
 fi
 REDIS_IMAGE_REGISTRY="${REDIS_IMAGE_REGISTRY:-}"
 REDIS_IMAGE_REPOSITORY="${REDIS_IMAGE_REPOSITORY:-redis}"
-REDIS_IMAGE_TAG="${REDIS_IMAGE_TAG:-1.11.2-20251029.2.169ac3c0}"
+REDIS_IMAGE_TAG="${REDIS_IMAGE_TAG:-1.11.2-main.20260718025853.shaf24e971}"
 REDIS_PERSISTENCE_ENABLED="${REDIS_PERSISTENCE_ENABLED:-true}"
 # Empty: pick cluster default StorageClass (e.g. kind "standard"); else local-path if that SC exists; else local-path.
 REDIS_STORAGE_CLASS="${REDIS_STORAGE_CLASS:-}"

--- a/deploy/scripts/sync-k8s-images.sh
+++ b/deploy/scripts/sync-k8s-images.sh
@@ -77,7 +77,7 @@ MARIADB_IMAGES=(
 
 # Required images for Redis
 REDIS_IMAGES=(
-    "openbkn-ai/redis:1.11.2-20251029.2.169ac3c0"
+    "openbkn-ai/redis:1.11.2-main.20260718025853.shaf24e971"
 )
 
 # Required images for Kafka


### PR DESCRIPTION
#290 跟进:main 已构建出多架构 tag `1.11.2-main.20260718025853.shaf24e971`(swr + ghcr 双端已验 amd64+arm64)。本 PR 把默认值切过去:

- `deploy/scripts/lib/common.sh`:`REDIS_IMAGE`(在线/离线两处)+ `REDIS_IMAGE_TAG`
- `deploy/scripts/sync-k8s-images.sh`:离线同步清单

旧默认 `1.11.2-20251029.2.169ac3c0` 是 amd64-only,arm64 集群(Apple Silicon kind / arm64 k3s)CrashLoop `exec format error`。

存量环境无感:镜像内容 = 官方 redis:7.4.6 + 同两脚本,PVC/ACL/密码不动,helm upgrade 平滑。

🤖 Generated with [Claude Code](https://claude.com/claude-code)