### PR TITLE
fix(migrations): default '' for vega f_index_config columns

### DIFF
--- a/migrations/vega-backend/mariadb/0.1.0/init.sql
+++ b/migrations/vega-backend/mariadb/0.1.0/init.sql
@@ -163,7 +163,7 @@ CREATE TABLE IF NOT EXISTS t_resource (
 
     -- Schema相关
     f_schema_definition       MEDIUMTEXT NOT NULL COMMENT 'Schema定义（JSON数组格式，包含所有字段信息）',
-    f_index_config            MEDIUMTEXT NOT NULL COMMENT '本地索引配置（JSON格式）',
+    f_index_config            MEDIUMTEXT NOT NULL DEFAULT '' COMMENT '本地索引配置（JSON格式）',
 
     -- LogicView 专属字段
     f_logic_type              VARCHAR(20) NOT NULL DEFAULT '' COMMENT '逻辑类型: derived(衍生), composite(复合), 仅LogicView使用',
@@ -386,7 +386,7 @@ CREATE TABLE IF NOT EXISTS t_build_task (
     f_mode                    VARCHAR(20) NOT NULL COMMENT '任务模式: full, incremental, realtime',
     
     -- 任务索引配置
-    f_index_config            TEXT NOT NULL COMMENT '索引配置快照(JSON)',
+    f_index_config            TEXT NOT NULL DEFAULT '' COMMENT '索引配置快照(JSON)',
 
     -- 任务状态
     f_status                  VARCHAR(20) NOT NULL COMMENT '任务状态: pending, running, completed, failed',


### PR DESCRIPTION
全新装机实测踩雷:`f_index_config`(t_resource / t_build_task 两处)NOT NULL 无默认,而现役 vega-backend main chart(0.1.0-main.20260709…)代码早于该列、INSERT 不带它,strict 模式直接 `Error 1364`,连带 bkn-backend 注册 concept dataset 无限 CrashLoop(2026-07-18 Apple Silicon kind 全新装复现)。

加 `DEFAULT ''` 让 schema 同时容忍新旧服务构建;认识该列的代码本来就显式写值,无行为变化。

合并后 CI 出新 core-data-migrator main tag,随后另提 PR 把首版 release manifest 钉到当前验证过的版本集(含新 migrator)——响应「当前主线就是第一个版本」。

🤖 Generated with [Claude Code](https://claude.com/claude-code)