### PR TITLE
fix(deploy): gen-dev-manifest 跟随 GHCR tags 分页,修复 --latest 解析过期版本

### DIFF
--- a/deploy/scripts/gen-dev-manifest.sh
+++ b/deploy/scripts/gen-dev-manifest.sh
@@ -114,15 +114,27 @@ SSL_CTX=_make_ssl_context()
 
 def reg_tags(chart):
     """List tags for charts/<chart> via the GHCR OCI registry (no gh; anonymous
-    token works for public packages)."""
+    token works for public packages). GHCR pages tags/list at 100 per response
+    with a Link: rel="next" header; busy charts overflow one page, and taking
+    only the first page resolves stale "latest" versions — follow every page."""
     repo=f"{ORG}/charts/{chart}"
     try:
         tok=json.load(urllib.request.urlopen(
             f"https://ghcr.io/token?scope=repository:{repo}:pull",
             timeout=20, context=SSL_CTX))["token"]
-        req=urllib.request.Request(f"https://ghcr.io/v2/{repo}/tags/list",
-                                   headers={"Authorization": f"Bearer {tok}"})
-        return json.load(urllib.request.urlopen(req, timeout=20, context=SSL_CTX)).get("tags") or []
+        tags=[]
+        url=f"https://ghcr.io/v2/{repo}/tags/list?n=1000"
+        for _ in range(100):  # hard stop well above any real tag count
+            req=urllib.request.Request(url, headers={"Authorization": f"Bearer {tok}"})
+            resp=urllib.request.urlopen(req, timeout=20, context=SSL_CTX)
+            tags+=json.load(resp).get("tags") or []
+            m=re.search(r'<([^>]+)>\s*;\s*rel="next"', resp.headers.get("Link") or "")
+            if not m:
+                break
+            url=m.group(1)
+            if url.startswith("/"):
+                url="https://ghcr.io"+url
+        return tags
     except ssl.SSLCertVerificationError:
         # don't swallow silently at the top level; surfaced after the resolve
         # loop if every chart ends up NOT FOUND (see the macOS-CA hint below).


### PR DESCRIPTION
Closes #295

## 问题

`gen-dev-manifest.sh` 的 `reg_tags()` 对 GHCR `tags/list` 只请求一次,而 GHCR 每页只返回 100 条(带 `Link: rel="next"`)。tag 多的 chart 在 `--latest` 下解析到截断页里的旧 main build。

实测(31.70.113.200 全新装):vega-backend/kafka-connect 被解析到 0709、bkn-safe 0708,GHCR 实际最新为 0718/0717。新 migrator + 旧 vega 二进制歪斜 → `t_resource.f_index_config` NOT NULL 无默认,bkn-backend 启动 `Error 1364` panic CrashLoop。

## 修复

`reg_tags()` 循环跟随 `Link: rel="next"` 取全所有页;100 页硬上限护栏;分页 URL 相对路径补 host。其余解析逻辑不动。

## 验证

修复后本地跑 `./gen-dev-manifest.sh --latest`:

```
vega-backend    0.1.0-main.20260718025820.sha353bc84   (修复前: 0709)
kafka-connect   0.1.0-main.20260718025820.sha353bc84   (修复前: 0709)
bkn-safe        0.1.0-main.20260717074224.shafa7b93c   (修复前: 0708)
```

与 GHCR 实际最新 main build 一致(即 31.70 部署时手工钉正的同一组版本)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)