### PR TITLE
ci: mirror third-party images to SWR with full multi-arch manifests

### DIFF
--- a/.github/workflows/automation-mirror-swr-images.yml
+++ b/.github/workflows/automation-mirror-swr-images.yml
@@ -1,4 +1,4 @@
-name: mirror-third-party-images
+name: automation-mirror-swr-images
 
 # Mirror third-party images to Huawei SWR with their FULL multi-arch manifest.
 # Historical hand-mirroring copied amd64 only, which breaks arm64 clusters
@@ -13,7 +13,7 @@ on:
   push:
     branches: ['**']
     paths:
-      - '.github/workflows/mirror-third-party-images.yml'
+      - '.github/workflows/automation-mirror-swr-images.yml'
   workflow_dispatch: {}
 
 permissions:

--- a/.github/workflows/mirror-third-party-images.yml
+++ b/.github/workflows/mirror-third-party-images.yml
@@ -1,0 +1,60 @@
+name: mirror-third-party-images
+
+# Mirror third-party images to Huawei SWR with their FULL multi-arch manifest.
+# Historical hand-mirroring copied amd64 only, which breaks arm64 clusters
+# (Apple Silicon kind, arm64 k3s) — redis, oryd/hydra and otelcol all hit this.
+# `docker buildx imagetools create` copies the complete manifest list, so every
+# platform the upstream publishes lands on the mirror. Re-running is idempotent
+# and overwriting an amd64-only tag with the multi-arch list is purely additive.
+#
+# To add an image: append "<source-ref> <swr-repo-path>:<tag>" to MIRRORS below.
+
+on:
+  push:
+    branches: ['**']
+    paths:
+      - '.github/workflows/mirror-third-party-images.yml'
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+
+jobs:
+  mirror:
+    runs-on: ubuntu-latest
+    env:
+      SWR_REGISTRY: swr.cn-east-3.myhuaweicloud.com
+      SWR_NAMESPACE: openbkn-ai
+      SWR_USERNAME: ${{ secrets.HUAWEI_SWR_USERNAME }}
+      # One "<source-ref> <target-repo>:<tag>" pair per line.
+      MIRRORS: |
+        docker.io/oryd/hydra:v26.2.0 oryd/hydra:v26.2.0
+        docker.io/otel/opentelemetry-collector-contrib:0.148.0 otel/opentelemetry-collector-contrib:0.148.0
+    steps:
+      - name: Check credentials
+        run: |
+          if [ -z "${SWR_USERNAME}" ]; then
+            echo "HUAWEI_SWR_USERNAME not set (fork / credential-less run) — nothing to do."
+            exit 1
+          fi
+
+      - uses: docker/setup-buildx-action@v3
+
+      - name: Login to Huawei SWR
+        uses: docker/login-action@v3
+        with:
+          registry: swr.cn-east-3.myhuaweicloud.com
+          username: ${{ secrets.HUAWEI_SWR_USERNAME }}
+          password: ${{ secrets.HUAWEI_SWR_PASSWORD }}
+
+      - name: Mirror images (full multi-arch manifests)
+        run: |
+          set -euo pipefail
+          while read -r src dst; do
+            [ -z "${src}" ] && continue
+            target="${SWR_REGISTRY}/${SWR_NAMESPACE}/${dst}"
+            echo "==> ${src}  ->  ${target}"
+            docker buildx imagetools create -t "${target}" "${src}"
+            echo "--- verify platforms on mirror:"
+            docker buildx imagetools inspect "${target}" | grep -E "Platform:" || true
+          done <<< "${MIRRORS}"


### PR DESCRIPTION
## 背景

swr 上第三方镜像历史上手工搬运只搬了 amd64:`oryd/hydra:v26.2.0` amd64-only、`otel/opentelemetry-collector-contrib:0.148.0` 对 arm64 直接 NotFound。Apple Silicon / arm64 集群用 `--registry=swr` 装机,这两个 pod 起不来(2026-07-18 本机全量装实测,临时用 `kubectl set image` 指 docker.io 官方镜像绕过)。redis 此前是同类问题(#290 已修)。

## 方案

纯新增 workflow,不动现有代码:`docker buildx imagetools create` 把上游**完整 multi-arch manifest** 复制到 swr(幂等;覆盖 amd64-only tag 属纯增量,原 amd64 digest 不变)。镜像清单化(`MIRRORS` 列表),以后新增第三方镜像加一行,绝根「搬运丢架构」这类坑。

分支 push 即触发首跑,hydra + otelcol 的多架构 mirror 立即修复。

## 验证

合并前看本分支 workflow run 的 verify 输出(逐镜像列 Platform);或跑:
```bash
docker manifest inspect swr.cn-east-3.myhuaweicloud.com/openbkn-ai/oryd/hydra:v26.2.0 | grep architecture
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)