### PR TITLE
docs(release-notes): drop the upstream kweaver-core pointer

### DIFF
--- a/release-notes/README.md
+++ b/release-notes/README.md
@@ -1,6 +1,3 @@
 # Release Notes
 
 Release notes for BKN Foundry will be published here.
-
-> Earlier notes from the upstream project are available at
-> [kweaver-ai/kweaver-core](https://github.com/kweaver-ai/kweaver-core).


### PR DESCRIPTION
按要求移除 release-notes/README.md 里指向上游 kweaver-ai/kweaver-core 的说明句。

🤖 Generated with [Claude Code](https://claude.com/claude-code)