### PR TITLE
fix(deploy): unblock arm64 default install — mirror postgres, drop sandbox root ingress

### DIFF
--- a/.github/workflows/automation-mirror-swr-images.yml
+++ b/.github/workflows/automation-mirror-swr-images.yml
@@ -39,23 +39,29 @@ jobs:
             exit 1
           fi
 
-      - uses: docker/setup-buildx-action@v3
+      - name: Install skopeo
+        run: sudo apt-get update && sudo apt-get install -y skopeo
 
       - name: Login to Huawei SWR
-        uses: docker/login-action@v3
-        with:
-          registry: swr.cn-east-3.myhuaweicloud.com
-          username: ${{ secrets.HUAWEI_SWR_USERNAME }}
-          password: ${{ secrets.HUAWEI_SWR_PASSWORD }}
+        run: |
+          skopeo login swr.cn-east-3.myhuaweicloud.com \
+            -u "${{ secrets.HUAWEI_SWR_USERNAME }}" \
+            -p "${{ secrets.HUAWEI_SWR_PASSWORD }}"
 
       - name: Mirror images (full multi-arch manifests)
+        # skopeo copy --all preserves every platform in the manifest list;
+        # --format v2s2 rewrites OCI media types to Docker schema2, because SWR
+        # rejects an OCI image index with "Invalid image, fail to parse
+        # manifest.json" (same constraint the reusable-build handles via
+        # oci-mediatypes=false). buildx imagetools create can't force the
+        # media type, so it fails on OCI-index upstreams like postgres.
         run: |
           set -euo pipefail
           while read -r src dst; do
             [ -z "${src}" ] && continue
             target="${SWR_REGISTRY}/${SWR_NAMESPACE}/${dst}"
             echo "==> ${src}  ->  ${target}"
-            docker buildx imagetools create -t "${target}" "${src}"
+            skopeo copy --all --format v2s2 "docker://${src}" "docker://${target}"
             echo "--- verify platforms on mirror:"
-            docker buildx imagetools inspect "${target}" | grep -E "Platform:" || true
+            skopeo inspect --raw "docker://${target}" | grep -oE '"architecture":"[a-z0-9]+"' | sort -u || true
           done <<< "${MIRRORS}"

--- a/.github/workflows/automation-mirror-swr-images.yml
+++ b/.github/workflows/automation-mirror-swr-images.yml
@@ -42,26 +42,39 @@ jobs:
       - name: Install skopeo
         run: sudo apt-get update && sudo apt-get install -y skopeo
 
-      - name: Login to Huawei SWR
+      - name: Login to Huawei SWR (skopeo + docker)
         run: |
           skopeo login swr.cn-east-3.myhuaweicloud.com \
-            -u "${{ secrets.HUAWEI_SWR_USERNAME }}" \
-            -p "${{ secrets.HUAWEI_SWR_PASSWORD }}"
+            -u "${{ secrets.HUAWEI_SWR_USERNAME }}" -p "${{ secrets.HUAWEI_SWR_PASSWORD }}"
+          echo "${{ secrets.HUAWEI_SWR_PASSWORD }}" | docker login swr.cn-east-3.myhuaweicloud.com \
+            -u "${{ secrets.HUAWEI_SWR_USERNAME }}" --password-stdin
 
-      - name: Mirror images (full multi-arch manifests)
-        # skopeo copy --all preserves every platform in the manifest list;
-        # --format v2s2 rewrites OCI media types to Docker schema2, because SWR
-        # rejects an OCI image index with "Invalid image, fail to parse
-        # manifest.json" (same constraint the reusable-build handles via
-        # oci-mediatypes=false). buildx imagetools create can't force the
-        # media type, so it fails on OCI-index upstreams like postgres.
+      - name: Mirror images (multi-arch, Docker manifest list)
+        # SWR rejects OCI image indexes ("Invalid image, fail to parse
+        # manifest.json"), and buildx-built upstreams (e.g. postgres) carry
+        # in-toto attestation entries that skopeo's v2s2 conversion of the whole
+        # list chokes on. So copy each real platform individually (single-arch
+        # source has no attestation child -> v2s2 converts cleanly), then
+        # assemble a Docker-media-type manifest list SWR accepts. amd64+arm64
+        # cover every cluster we deploy to.
+        env:
+          PLATFORMS: "amd64 arm64"
         run: |
           set -euo pipefail
           while read -r src dst; do
             [ -z "${src}" ] && continue
             target="${SWR_REGISTRY}/${SWR_NAMESPACE}/${dst}"
             echo "==> ${src}  ->  ${target}"
-            skopeo copy --all --format v2s2 "docker://${src}" "docker://${target}"
+            arch_refs=()
+            for arch in ${PLATFORMS}; do
+              archtag="${target}-${arch}"
+              skopeo copy --format v2s2 --override-os linux --override-arch "${arch}" \
+                "docker://${src}" "docker://${archtag}"
+              arch_refs+=("${archtag}")
+            done
+            docker manifest rm "${target}" >/dev/null 2>&1 || true
+            docker manifest create "${target}" "${arch_refs[@]}"
+            docker manifest push "${target}"
             echo "--- verify platforms on mirror:"
-            skopeo inspect --raw "docker://${target}" | grep -oE '"architecture":"[a-z0-9]+"' | sort -u || true
+            docker manifest inspect "${target}" | grep -oE '"architecture": "[a-z0-9]+"' | sort -u || true
           done <<< "${MIRRORS}"

--- a/.github/workflows/automation-mirror-swr-images.yml
+++ b/.github/workflows/automation-mirror-swr-images.yml
@@ -31,6 +31,7 @@ jobs:
         docker.io/oryd/hydra:v26.2.0 oryd/hydra:v26.2.0
         docker.io/otel/opentelemetry-collector-contrib:0.148.0 otel/opentelemetry-collector-contrib:0.148.0
         docker.io/library/postgres:16 postgres:16
+        docker.io/portainer/kubectl-shell:latest portainer/kubectl-shell:latest
     steps:
       - name: Check credentials
         run: |

--- a/.github/workflows/automation-mirror-swr-images.yml
+++ b/.github/workflows/automation-mirror-swr-images.yml
@@ -30,6 +30,7 @@ jobs:
       MIRRORS: |
         docker.io/oryd/hydra:v26.2.0 oryd/hydra:v26.2.0
         docker.io/otel/opentelemetry-collector-contrib:0.148.0 otel/opentelemetry-collector-contrib:0.148.0
+        docker.io/library/postgres:16 postgres:16
     steps:
       - name: Check credentials
         run: |

--- a/infra/sandbox/deploy/helm/sandbox/values.yaml
+++ b/infra/sandbox/deploy/helm/sandbox/values.yaml
@@ -42,8 +42,12 @@ controlPlane:
     port: 8000
     annotations: {}
 
+  # Internal execution backend — callers reach it via the cluster service
+  # (sandbox-control-plane:8000), not the gateway. The catch-all "/" ingress was
+  # helm-template boilerplate and hijacked the gateway root from bkn-studio (the
+  # web UI), so nginx admission rejected studio's own "/" ingress. Disabled.
   ingress:
-    enabled: true
+    enabled: false
     className: "nginx"
     annotations: {}
     paths:


### PR DESCRIPTION
本机(Apple Silicon / kind)验证默认安装踩到两个硬阻塞,均从源头修:

## 1. swr postgres:16 单架构(amd64)
bkn-safe 捆绑的 postgres 在 arm64 起不来 → hydra init 卡 → client-seed job 挂 → bkn-safe 安装超时。加进 SWR mirror 清单补多架构(与已修的 oryd/hydra、otel-collector 同法)。

## 2. sandbox-control-plane 抢网关根路径
chart 带了 catch-all `host=_ path=/` Ingress(monorepo 重构 #111 的 helm 样板货),霸占网关根 → nginx admission 拒掉 bkn-studio 自己的 `/` ingress → studio 装失败。control-plane 是内网后端(调用方走集群 service sandbox-control-plane:8000,见其 OpenAPI),从不经网关 → 禁用该 ingress。

push 即触发:mirror workflow 推多架构 postgres 到 swr、sandbox chart 重新构建。之后默认装机不再需要任何手工干预。

发现方式:纯脚本 `bkn-foundry install` 装不完 = bug,逐个修到脚本能装完为止。

🤖 Generated with [Claude Code](https://claude.com/claude-code)