### PR TITLE
fix(deploy): refresh pod-sourced serviceHealth in install-status live merge

### DIFF
--- a/deploy/conf/install-status/merge.jq
+++ b/deploy/conf/install-status/merge.jq
@@ -44,5 +44,24 @@
              then {appVersion: ($m.tags | join(",")), versionSource: "live"}
              else {} end)
       end))
+# Refresh pod-sourced serviceHealth from live workloads too — otherwise the
+# top-line up/degraded count (the dashboard reads serviceHealth[].state) stays
+# frozen at publish time, so a service that was merely mid-restart during
+# install shows "degraded" forever even after it self-heals. HTTP-sourced
+# entries can't be re-probed here (jq only, no curl), so leave those as-is.
+# serviceHealth names may carry a "-svc" suffix the workload key lacks.
+| .serviceHealth |= ((. // []) | map(
+    . as $h
+    | if ($h.source == "pod")
+      then
+        (($actual[$h.name]) // ($actual[($h.name | rtrimstr("-svc"))]) // null) as $m
+        | if $m == null then .
+          else
+            . + {ready: "\($m.ready)/\($m.total)",
+                 state: (if ($m.total > 0 and $m.ready >= $m.total) then "up"
+                         elif $m.ready > 0 then "degraded"
+                         else "down" end)}
+          end
+      else . end))
 | .generatedAt = $now
 | .liveMergedAt = $now


### PR DESCRIPTION
## Bug

install-status 面板顶部「N services up / M degraded」计数读的是 `serviceHealth[].state`,但刷新器的 merge.jq 只刷 `.releases[].ready` + 镜像 tag,**从不碰 serviceHealth** —— 该数组冻结在安装那一刻。结果:某服务安装时恰好在重启(如 bkn-backend 等 vega-backend 启动时的 CrashLoop,或 pod 就绪探针 warmup),就**永远显示 degraded**,哪怕它早已自愈、对应卡片已转绿。顶部计数与卡片自相矛盾。

## 修复

merge.jq 对 `source=="pod"` 的 serviceHealth 条目,用实时工作负载 dump($actual)重算 ready/state;HTTP 探测型条目 jq 无 curl 没法复探,保持原样(它们也不是这次的问题源)。服务名可能带 `-svc` 后缀,匹配时兼容。

## 验证

对一个真实集群(2 个已自愈服务仍显示陈旧 degraded)跑合并:结果 **up=20 degraded=0**,与实际 pod 状态一致。

🤖 Generated with [Claude Code](https://claude.com/claude-code)