### PR TITLE
fix(deploy): give the OCI/repo release install a hook timeout

### DIFF
--- a/deploy/scripts/services/core.sh
+++ b/deploy/scripts/services/core.sh
@@ -449,6 +449,14 @@ _install_core_release_repo() {
         helm_args+=("--version" "${release_version}")
     fi
 
+    # Bound the post-install hook wait. Helm always waits for post-install hooks
+    # (e.g. bkn-safe's client-seed Job) even without --wait, and defaults to only
+    # 5m — a cold first-install image pull of a hook's dependency (bkn-safe's
+    # bundled postgres, ~8m on a slow CN pull from SWR) blows past that and the
+    # whole release is reported failed even though it self-heals. Match the local
+    # path's explicit timeout, but generous enough for cold pulls (configurable).
+    helm_args+=("--timeout=${CORE_HELM_TIMEOUT:-900s}")
+
     helm_args+=("--devel")
 
     # Per-release values first, then all --set values (so explicit --set wins)


### PR DESCRIPTION
## Bug

全新脚本装(空集群、空库、Apple Silicon)时 bkn-safe 安装报失败中止,bkn-studio 没装成。

根因:`_install_core_release_repo`(所有 OCI/ghcr 安装走的路径)**没传 `--timeout`**,helm 对 post-install hook 的等待用默认 **5 分钟**。bkn-safe 的 client-seed hook 等 hydra、hydra 等自带 postgres;首装冷拉 `postgres:16`(swr,慢网 ~8 分钟)超过 5 分钟 → helm 判 bkn-safe 失败 → 装机在 bkn-safe 处中止(尽管栈随后自愈)。local-chart 路径本就有 `--timeout=600s`,repo 路径漏了。

## 修复

repo 路径补 `--timeout=${CORE_HELM_TIMEOUT:-900s}`(可配,默认 900s 容冷拉),与 local 路径对齐。

🤖 Generated with [Claude Code](https://claude.com/claude-code)