### PR TITLE
fix(deploy): 第三方镜像在线走标准上游,不再锁死 SWR/GHCR

### DIFF
--- a/deploy/scripts/lib/common.sh
+++ b/deploy/scripts/lib/common.sh
@@ -1223,8 +1223,11 @@ if [[ "${OFFLINE_MODE}" == "true" ]]; then
     LOCALPV_PROVISIONER_IMAGE="${LOCALPV_PROVISIONER_IMAGE:-${OFFLINE_REGISTRY}/openbkn-ai/rancher/local-path-provisioner:v0.0.32}"
     LOCALPV_HELPER_IMAGE="${LOCALPV_HELPER_IMAGE:-${OFFLINE_REGISTRY}/openbkn-ai/busybox:1.36.1}"
 else
-    LOCALPV_PROVISIONER_IMAGE="${LOCALPV_PROVISIONER_IMAGE:-swr.cn-east-3.myhuaweicloud.com/openbkn-ai/rancher/local-path-provisioner:v0.0.32}"
-    LOCALPV_HELPER_IMAGE="${LOCALPV_HELPER_IMAGE:-swr.cn-north-4.myhuaweicloud.com/ddn-k8s/docker.io/busybox:1.36.1}"
+    # Online default: pull third-party images from their public upstream so an
+    # international/GHCR install does not depend on the SWR (CN) mirror. CN /
+    # air-gapped installs pass --offline=<registry> to use a reachable mirror.
+    LOCALPV_PROVISIONER_IMAGE="${LOCALPV_PROVISIONER_IMAGE:-docker.io/rancher/local-path-provisioner:v0.0.32}"
+    LOCALPV_HELPER_IMAGE="${LOCALPV_HELPER_IMAGE:-docker.io/library/busybox:1.36.1}"
 fi
 LOCALPV_MANIFEST_PATH="${LOCALPV_MANIFEST_PATH:-${CONF_DIR}/local-path-storage.yaml}"
 LOCALPV_MANIFEST_URL="${LOCALPV_MANIFEST_URL:-https://raw.githubusercontent.com/rancher/local-path-provisioner/v0.0.32/deploy/local-path-storage.yaml}"
@@ -1242,11 +1245,11 @@ MARIADB_NAMESPACE="${MARIADB_NAMESPACE:-${RESOURCE_NAMESPACE}}"
 if [[ "${OFFLINE_MODE}" == "true" ]]; then
     MARIADB_IMAGE="${MARIADB_IMAGE:-${OFFLINE_REGISTRY}/openbkn-ai/mariadb:11.4.7}"
 else
-    MARIADB_IMAGE="${MARIADB_IMAGE:-swr.cn-east-3.myhuaweicloud.com/openbkn-ai/mariadb:11.4.7}"
+    MARIADB_IMAGE="${MARIADB_IMAGE:-docker.io/library/mariadb:11.4.7}"
 fi
 MARIADB_IMAGE_REPOSITORY="${MARIADB_IMAGE_REPOSITORY:-mariadb}"
 MARIADB_IMAGE_TAG="${MARIADB_IMAGE_TAG:-11.4.7}"
-MARIADB_IMAGE_FALLBACK="${MARIADB_IMAGE_FALLBACK:-mariadb:11.4.7}"
+MARIADB_IMAGE_FALLBACK="${MARIADB_IMAGE_FALLBACK:-docker.io/library/mariadb:11.4.7}"
 MARIADB_VERSION="${MARIADB_VERSION:-11.4}"
 MARIADB_CHART_VERSION="${MARIADB_CHART_VERSION:-1.0.0}"
 MARIADB_CHART_TGZ="${MARIADB_CHART_TGZ:-${SCRIPT_DIR}/charts/mariadb-${MARIADB_CHART_VERSION}.tgz}"
@@ -1362,11 +1365,14 @@ KAFKA_CHART_TGZ="${KAFKA_CHART_TGZ:-${SCRIPT_DIR}/charts/kafka-${KAFKA_CHART_VER
 if [[ "${OFFLINE_MODE}" == "true" ]]; then
     KAFKA_IMAGE="${KAFKA_IMAGE:-${OFFLINE_REGISTRY}/openbkn-ai/bitnami/kafka:3.9.0-debian-12-r10}"
 else
-    KAFKA_IMAGE="${KAFKA_IMAGE:-swr.cn-east-3.myhuaweicloud.com/openbkn-ai/bitnami/kafka:3.9.0-debian-12-r10}"
+    # bitnami removed versioned tags from docker.io/bitnami in 2025; the same
+    # image lives under docker.io/bitnamilegacy. (See deploy/README: pin
+    # KAFKA_IMAGE or use --offline if bitnamilegacy is retired.)
+    KAFKA_IMAGE="${KAFKA_IMAGE:-docker.io/bitnamilegacy/kafka:3.9.0-debian-12-r10}"
 fi
-KAFKA_IMAGE_REPOSITORY="${KAFKA_IMAGE_REPOSITORY:-bitnami/kafka}"
+KAFKA_IMAGE_REPOSITORY="${KAFKA_IMAGE_REPOSITORY:-bitnamilegacy/kafka}"
 KAFKA_IMAGE_TAG="${KAFKA_IMAGE_TAG:-3.9.0-debian-12-r10}"
-KAFKA_IMAGE_FALLBACK="${KAFKA_IMAGE_FALLBACK:-swr.cn-east-3.myhuaweicloud.com/openbkn-ai/bitnami/kafka:3.9.0-debian-12-r10}"
+KAFKA_IMAGE_FALLBACK="${KAFKA_IMAGE_FALLBACK:-docker.io/bitnamilegacy/kafka:3.9.0-debian-12-r10}"
 KAFKA_HELM_TIMEOUT="${KAFKA_HELM_TIMEOUT:-1800s}"
 # NOTE: --atomic will auto-uninstall on failure, which makes debugging hard. Default to false.
 KAFKA_HELM_ATOMIC="${KAFKA_HELM_ATOMIC:-false}"
@@ -1405,17 +1411,17 @@ if [[ "${OFFLINE_MODE}" == "true" ]]; then
     OPENSEARCH_IMAGE="${OPENSEARCH_IMAGE:-${OFFLINE_REGISTRY}/openbkn-ai/opensearchproject/opensearch:2.19.4}"
     OPENSEARCH_IMAGE_REPOSITORY="${OPENSEARCH_IMAGE_REPOSITORY:-${OFFLINE_REGISTRY}/openbkn-ai/opensearchproject/opensearch}"
 else
-    OPENSEARCH_IMAGE="${OPENSEARCH_IMAGE:-swr.cn-east-3.myhuaweicloud.com/openbkn-ai/opensearchproject/opensearch:2.19.4}"
-    OPENSEARCH_IMAGE_REPOSITORY="${OPENSEARCH_IMAGE_REPOSITORY:-swr.cn-east-3.myhuaweicloud.com/openbkn-ai/opensearchproject/opensearch}"
+    OPENSEARCH_IMAGE="${OPENSEARCH_IMAGE:-docker.io/opensearchproject/opensearch:2.19.4}"
+    OPENSEARCH_IMAGE_REPOSITORY="${OPENSEARCH_IMAGE_REPOSITORY:-docker.io/opensearchproject/opensearch}"
 fi
 OPENSEARCH_IMAGE_TAG="${OPENSEARCH_IMAGE_TAG:-2.19.4}"
-OPENSEARCH_IMAGE_FALLBACK="${OPENSEARCH_IMAGE_FALLBACK:-swr.cn-east-3.myhuaweicloud.com/openbkn-ai/opensearchproject/opensearch:2.19.4}"
+OPENSEARCH_IMAGE_FALLBACK="${OPENSEARCH_IMAGE_FALLBACK:-docker.io/opensearchproject/opensearch:2.19.4}"
 # OpenSearch chart uses busybox initContainers (fsgroup-volume/sysctl); use a dedicated SWR mirror by default.
 # In offline mode, use offline registry; otherwise use SWR mirror
 if [[ "${OFFLINE_MODE}" == "true" ]]; then
     OPENSEARCH_INIT_IMAGE="${OPENSEARCH_INIT_IMAGE:-${OFFLINE_REGISTRY}/openbkn-ai/busybox:1.36.1}"
 else
-    OPENSEARCH_INIT_IMAGE="${OPENSEARCH_INIT_IMAGE:-swr.cn-east-3.myhuaweicloud.com/openbkn-ai/busybox:1.36.1}"
+    OPENSEARCH_INIT_IMAGE="${OPENSEARCH_INIT_IMAGE:-docker.io/library/busybox:1.36.1}"
 fi
 OPENSEARCH_JAVA_OPTS="${OPENSEARCH_JAVA_OPTS:--Xms512m -Xmx512m -XX:MaxDirectMemorySize=128m}"
 OPENSEARCH_MEMORY_REQUEST="${OPENSEARCH_MEMORY_REQUEST:-512Mi}"
@@ -1472,10 +1478,10 @@ if [[ "${OFFLINE_MODE}" == "true" ]]; then
     INGRESS_NGINX_WEBHOOK_CERTGEN_IMAGE="${INGRESS_NGINX_WEBHOOK_CERTGEN_IMAGE:-${OFFLINE_REGISTRY}/ingress-nginx/kube-webhook-certgen:v1.6.1}"
     INGRESS_NGINX_WEBHOOK_CERTGEN_IMAGE_REPOSITORY="${INGRESS_NGINX_WEBHOOK_CERTGEN_IMAGE_REPOSITORY:-${OFFLINE_REGISTRY}/ingress-nginx/kube-webhook-certgen}"
 else
-    INGRESS_NGINX_CONTROLLER_IMAGE="${INGRESS_NGINX_CONTROLLER_IMAGE:-swr.cn-east-3.myhuaweicloud.com/openbkn-ai/ingress-nginx/controller:v1.14.1}"
-    INGRESS_NGINX_CONTROLLER_IMAGE_REPOSITORY="${INGRESS_NGINX_CONTROLLER_IMAGE_REPOSITORY:-swr.cn-east-3.myhuaweicloud.com/openbkn-ai/ingress-nginx/controller}"
-    INGRESS_NGINX_WEBHOOK_CERTGEN_IMAGE="${INGRESS_NGINX_WEBHOOK_CERTGEN_IMAGE:-swr.cn-east-3.myhuaweicloud.com/openbkn-ai/ingress-nginx/kube-webhook-certgen:v1.6.1}"
-    INGRESS_NGINX_WEBHOOK_CERTGEN_IMAGE_REPOSITORY="${INGRESS_NGINX_WEBHOOK_CERTGEN_IMAGE_REPOSITORY:-swr.cn-east-3.myhuaweicloud.com/openbkn-ai/ingress-nginx/kube-webhook-certgen}"
+    INGRESS_NGINX_CONTROLLER_IMAGE="${INGRESS_NGINX_CONTROLLER_IMAGE:-registry.k8s.io/ingress-nginx/controller:v1.14.1}"
+    INGRESS_NGINX_CONTROLLER_IMAGE_REPOSITORY="${INGRESS_NGINX_CONTROLLER_IMAGE_REPOSITORY:-registry.k8s.io/ingress-nginx/controller}"
+    INGRESS_NGINX_WEBHOOK_CERTGEN_IMAGE="${INGRESS_NGINX_WEBHOOK_CERTGEN_IMAGE:-registry.k8s.io/ingress-nginx/kube-webhook-certgen:v1.6.1}"
+    INGRESS_NGINX_WEBHOOK_CERTGEN_IMAGE_REPOSITORY="${INGRESS_NGINX_WEBHOOK_CERTGEN_IMAGE_REPOSITORY:-registry.k8s.io/ingress-nginx/kube-webhook-certgen}"
 fi
 INGRESS_NGINX_CONTROLLER_IMAGE_TAG="${INGRESS_NGINX_CONTROLLER_IMAGE_TAG:-v1.14.1}"
 INGRESS_NGINX_CHART_VERSION="${INGRESS_NGINX_CHART_VERSION:-4.13.1}"

--- a/deploy/scripts/lib/common.sh
+++ b/deploy/scripts/lib/common.sh
@@ -1244,9 +1244,10 @@ MARIADB_NAMESPACE="${MARIADB_NAMESPACE:-${RESOURCE_NAMESPACE}}"
 # In offline mode, use offline registry; otherwise use SWR mirror
 if [[ "${OFFLINE_MODE}" == "true" ]]; then
     MARIADB_IMAGE="${MARIADB_IMAGE:-${OFFLINE_REGISTRY}/openbkn-ai/mariadb:11.4.7}"
-else
-    MARIADB_IMAGE="${MARIADB_IMAGE:-docker.io/library/mariadb:11.4.7}"
 fi
+# Online: MARIADB_IMAGE is resolved at install time via thirdparty_image_ref so
+# it can follow --registry (SWR mirror vs public upstream), which is parsed
+# after common.sh is sourced.
 MARIADB_IMAGE_REPOSITORY="${MARIADB_IMAGE_REPOSITORY:-mariadb}"
 MARIADB_IMAGE_TAG="${MARIADB_IMAGE_TAG:-11.4.7}"
 MARIADB_IMAGE_FALLBACK="${MARIADB_IMAGE_FALLBACK:-docker.io/library/mariadb:11.4.7}"
@@ -1364,13 +1365,11 @@ KAFKA_CHART_TGZ="${KAFKA_CHART_TGZ:-${SCRIPT_DIR}/charts/kafka-${KAFKA_CHART_VER
 # In offline mode, use offline registry; otherwise use SWR mirror
 if [[ "${OFFLINE_MODE}" == "true" ]]; then
     KAFKA_IMAGE="${KAFKA_IMAGE:-${OFFLINE_REGISTRY}/openbkn-ai/bitnami/kafka:3.9.0-debian-12-r10}"
-else
-    # bitnami removed versioned tags from docker.io/bitnami in 2025; the same
-    # image lives under docker.io/bitnamilegacy. (See deploy/README: pin
-    # KAFKA_IMAGE or use --offline if bitnamilegacy is retired.)
-    KAFKA_IMAGE="${KAFKA_IMAGE:-docker.io/bitnamilegacy/kafka:3.9.0-debian-12-r10}"
 fi
-KAFKA_IMAGE_REPOSITORY="${KAFKA_IMAGE_REPOSITORY:-bitnamilegacy/kafka}"
+# Online: resolved at install time (SWR mirror keeps the bitnami/ repo path;
+# the public upstream is docker.io/bitnamilegacy/kafka because bitnami removed
+# versioned tags from docker.io/bitnami in 2025).
+KAFKA_IMAGE_REPOSITORY="${KAFKA_IMAGE_REPOSITORY:-bitnami/kafka}"
 KAFKA_IMAGE_TAG="${KAFKA_IMAGE_TAG:-3.9.0-debian-12-r10}"
 KAFKA_IMAGE_FALLBACK="${KAFKA_IMAGE_FALLBACK:-docker.io/bitnamilegacy/kafka:3.9.0-debian-12-r10}"
 KAFKA_HELM_TIMEOUT="${KAFKA_HELM_TIMEOUT:-1800s}"
@@ -1410,19 +1409,17 @@ OPENSEARCH_CHART_TGZ="${OPENSEARCH_CHART_TGZ:-${SCRIPT_DIR}/charts/opensearch-${
 if [[ "${OFFLINE_MODE}" == "true" ]]; then
     OPENSEARCH_IMAGE="${OPENSEARCH_IMAGE:-${OFFLINE_REGISTRY}/openbkn-ai/opensearchproject/opensearch:2.19.4}"
     OPENSEARCH_IMAGE_REPOSITORY="${OPENSEARCH_IMAGE_REPOSITORY:-${OFFLINE_REGISTRY}/openbkn-ai/opensearchproject/opensearch}"
-else
-    OPENSEARCH_IMAGE="${OPENSEARCH_IMAGE:-docker.io/opensearchproject/opensearch:2.19.4}"
-    OPENSEARCH_IMAGE_REPOSITORY="${OPENSEARCH_IMAGE_REPOSITORY:-docker.io/opensearchproject/opensearch}"
 fi
+# Online: OPENSEARCH_IMAGE resolved at install time via thirdparty_image_ref.
+OPENSEARCH_IMAGE_REPOSITORY="${OPENSEARCH_IMAGE_REPOSITORY:-opensearchproject/opensearch}"
 OPENSEARCH_IMAGE_TAG="${OPENSEARCH_IMAGE_TAG:-2.19.4}"
 OPENSEARCH_IMAGE_FALLBACK="${OPENSEARCH_IMAGE_FALLBACK:-docker.io/opensearchproject/opensearch:2.19.4}"
 # OpenSearch chart uses busybox initContainers (fsgroup-volume/sysctl); use a dedicated SWR mirror by default.
 # In offline mode, use offline registry; otherwise use SWR mirror
 if [[ "${OFFLINE_MODE}" == "true" ]]; then
     OPENSEARCH_INIT_IMAGE="${OPENSEARCH_INIT_IMAGE:-${OFFLINE_REGISTRY}/openbkn-ai/busybox:1.36.1}"
-else
-    OPENSEARCH_INIT_IMAGE="${OPENSEARCH_INIT_IMAGE:-docker.io/library/busybox:1.36.1}"
 fi
+# Online: OPENSEARCH_INIT_IMAGE resolved at install time via thirdparty_image_ref.
 OPENSEARCH_JAVA_OPTS="${OPENSEARCH_JAVA_OPTS:--Xms512m -Xmx512m -XX:MaxDirectMemorySize=128m}"
 OPENSEARCH_MEMORY_REQUEST="${OPENSEARCH_MEMORY_REQUEST:-512Mi}"
 # NOTE: OpenSearch uses heap + direct memory + native overhead. 768Mi is too tight for -Xmx512m.
@@ -1477,12 +1474,9 @@ if [[ "${OFFLINE_MODE}" == "true" ]]; then
     INGRESS_NGINX_CONTROLLER_IMAGE_REPOSITORY="${INGRESS_NGINX_CONTROLLER_IMAGE_REPOSITORY:-${OFFLINE_REGISTRY}/ingress-nginx/controller}"
     INGRESS_NGINX_WEBHOOK_CERTGEN_IMAGE="${INGRESS_NGINX_WEBHOOK_CERTGEN_IMAGE:-${OFFLINE_REGISTRY}/ingress-nginx/kube-webhook-certgen:v1.6.1}"
     INGRESS_NGINX_WEBHOOK_CERTGEN_IMAGE_REPOSITORY="${INGRESS_NGINX_WEBHOOK_CERTGEN_IMAGE_REPOSITORY:-${OFFLINE_REGISTRY}/ingress-nginx/kube-webhook-certgen}"
-else
-    INGRESS_NGINX_CONTROLLER_IMAGE="${INGRESS_NGINX_CONTROLLER_IMAGE:-registry.k8s.io/ingress-nginx/controller:v1.14.1}"
-    INGRESS_NGINX_CONTROLLER_IMAGE_REPOSITORY="${INGRESS_NGINX_CONTROLLER_IMAGE_REPOSITORY:-registry.k8s.io/ingress-nginx/controller}"
-    INGRESS_NGINX_WEBHOOK_CERTGEN_IMAGE="${INGRESS_NGINX_WEBHOOK_CERTGEN_IMAGE:-registry.k8s.io/ingress-nginx/kube-webhook-certgen:v1.6.1}"
-    INGRESS_NGINX_WEBHOOK_CERTGEN_IMAGE_REPOSITORY="${INGRESS_NGINX_WEBHOOK_CERTGEN_IMAGE_REPOSITORY:-registry.k8s.io/ingress-nginx/kube-webhook-certgen}"
 fi
+# Online: ingress controller / certgen images resolved at install time via
+# thirdparty_image_ref (SWR mirror vs registry.k8s.io upstream).
 INGRESS_NGINX_CONTROLLER_IMAGE_TAG="${INGRESS_NGINX_CONTROLLER_IMAGE_TAG:-v1.14.1}"
 INGRESS_NGINX_CHART_VERSION="${INGRESS_NGINX_CHART_VERSION:-4.13.1}"
 INGRESS_NGINX_CHART_TGZ="${INGRESS_NGINX_CHART_TGZ:-${SCRIPT_DIR}/charts/ingress-nginx-${INGRESS_NGINX_CHART_VERSION}.tgz}"
@@ -1818,6 +1812,42 @@ image_from_registry() {
     else
         echo "${fallback}"
     fi
+}
+
+# Resolve a THIRD-PARTY image at install time, following the effective registry:
+#   registry=swr (…myhuaweicloud.com…) -> ${IMAGE_REGISTRY}/<repository>:<tag>
+#       (openbkn mirrors every third-party image under its SWR namespace)
+#   registry=ghcr / anything else      -> <upstream> (public upstream ref)
+#       (GHCR hosts only openbkn-built images, so third-party must come from the
+#        public upstream; prefixing GHCR would 404)
+# Unlike image_from_registry, this never prefixes GHCR onto a third-party repo.
+# Offline is handled by each service's own OFFLINE_MODE branch (pre-set image).
+# Resolving here (not at source time) lets it honor --registry, which is parsed
+# after common.sh is sourced.
+thirdparty_image_ref() {
+    local repository="$1" tag="$2" upstream="$3"
+    load_image_registry_from_config
+    case "${IMAGE_REGISTRY}" in
+        *myhuaweicloud.com*) printf '%s/%s:%s\n' "${IMAGE_REGISTRY}" "${repository}" "${tag}" ;;
+        *) printf '%s\n' "${upstream}" ;;
+    esac
+}
+
+# Resolve every data-layer third-party image for the current install, honoring
+# --registry (SWR mirror vs public upstream). Idempotent (only fills unset
+# vars — an explicit *_IMAGE env override or the offline pre-set both win), so
+# it is safe to call at the top of each data-service install function. Offline
+# returns early: each service's OFFLINE_MODE branch already pinned the mirror.
+resolve_thirdparty_images_online() {
+    [[ "${OFFLINE_MODE:-false}" == "true" ]] && return 0
+    : "${MARIADB_IMAGE:=$(thirdparty_image_ref "mariadb" "${MARIADB_IMAGE_TAG}" "docker.io/library/mariadb:${MARIADB_IMAGE_TAG}")}"
+    : "${KAFKA_IMAGE:=$(thirdparty_image_ref "bitnami/kafka" "${KAFKA_IMAGE_TAG}" "docker.io/bitnamilegacy/kafka:${KAFKA_IMAGE_TAG}")}"
+    : "${OPENSEARCH_IMAGE:=$(thirdparty_image_ref "opensearchproject/opensearch" "${OPENSEARCH_IMAGE_TAG}" "docker.io/opensearchproject/opensearch:${OPENSEARCH_IMAGE_TAG}")}"
+    : "${OPENSEARCH_INIT_IMAGE:=$(thirdparty_image_ref "busybox" "1.36.1" "docker.io/library/busybox:1.36.1")}"
+    : "${INGRESS_NGINX_CONTROLLER_IMAGE:=$(thirdparty_image_ref "ingress-nginx/controller" "${INGRESS_NGINX_CONTROLLER_IMAGE_TAG}" "registry.k8s.io/ingress-nginx/controller:${INGRESS_NGINX_CONTROLLER_IMAGE_TAG}")}"
+    : "${INGRESS_NGINX_WEBHOOK_CERTGEN_IMAGE:=$(thirdparty_image_ref "ingress-nginx/kube-webhook-certgen" "${INGRESS_NGINX_WEBHOOK_CERTGEN_IMAGE_TAG}" "registry.k8s.io/ingress-nginx/kube-webhook-certgen:${INGRESS_NGINX_WEBHOOK_CERTGEN_IMAGE_TAG}")}"
+    export MARIADB_IMAGE KAFKA_IMAGE OPENSEARCH_IMAGE OPENSEARCH_INIT_IMAGE \
+        INGRESS_NGINX_CONTROLLER_IMAGE INGRESS_NGINX_WEBHOOK_CERTGEN_IMAGE
 }
 
 get_secret_b64_key() {

--- a/deploy/scripts/services/core.sh
+++ b/deploy/scripts/services/core.sh
@@ -346,15 +346,23 @@ _core_thirdparty_release_registry() {
 }
 
 # Append a final --set image.registry for third-party releases so their upstream
-# registry wins over the global openbkn image.registry override. Online only;
-# offline keeps the mirror. $2 is the name of the helm_args array to append to.
+# registry wins over the global openbkn image.registry override. $2 is the name
+# of the helm_args array to append to. Registry-aware:
+#   offline / registry=swr -> no override; openbkn mirrors the image there, so
+#       the global image.registry override already resolves it.
+#   registry=ghcr / other  -> pin the chart's public upstream (GHCR has no
+#       third-party image, so the global override would 404).
 _core_apply_thirdparty_registry_override() {
     local release_name="$1" _arr_name="$2" _reg
     [[ "${OFFLINE_MODE:-false}" == "true" ]] && return 0
     _reg="$(_core_thirdparty_release_registry "${release_name}")"
     [[ -z "${_reg}" ]] && return 0
+    load_image_registry_from_config
+    case "${IMAGE_REGISTRY}" in
+        *myhuaweicloud.com*) return 0 ;;
+    esac
     eval "${_arr_name}+=(\"--set\" \"image.registry=${_reg}\")"
-    log_info "Third-party image: ${release_name} pinned to upstream registry ${_reg} (not the openbkn ${IMAGE_REGISTRY:-registry} mirror)."
+    log_info "Third-party image: ${release_name} pinned to upstream registry ${_reg} (GHCR hosts no ${release_name} image)."
 }
 
 _core_release_extra_sets() {

--- a/deploy/scripts/services/core.sh
+++ b/deploy/scripts/services/core.sh
@@ -333,6 +333,30 @@ _core_find_local_chart() {
 # explicit password — no baked-in default). Applied BEFORE CORE_SET_VALUES so an
 # explicit --set config.initialPassword=... still wins.
 CORE_RELEASE_EXTRA_SETS=()
+# Third-party core releases whose image is NOT published under the openbkn
+# registry (ghcr/swr). The global image.registry override would rewrite them to
+# a namespace that has no such image (e.g. ghcr.io/openbkn-ai/otel/... 404), so
+# online they must keep their chart's upstream registry. Offline still uses the
+# offline mirror (the global override applies there, unchanged).
+_core_thirdparty_release_registry() {
+    case "$1" in
+        otelcol-contrib) echo "docker.io" ;;
+        *) echo "" ;;
+    esac
+}
+
+# Append a final --set image.registry for third-party releases so their upstream
+# registry wins over the global openbkn image.registry override. Online only;
+# offline keeps the mirror. $2 is the name of the helm_args array to append to.
+_core_apply_thirdparty_registry_override() {
+    local release_name="$1" _arr_name="$2" _reg
+    [[ "${OFFLINE_MODE:-false}" == "true" ]] && return 0
+    _reg="$(_core_thirdparty_release_registry "${release_name}")"
+    [[ -z "${_reg}" ]] && return 0
+    eval "${_arr_name}+=(\"--set\" \"image.registry=${_reg}\")"
+    log_info "Third-party image: ${release_name} pinned to upstream registry ${_reg} (not the openbkn ${IMAGE_REGISTRY:-registry} mirror)."
+}
+
 _core_release_extra_sets() {
     local release_name="$1"
     CORE_RELEASE_EXTRA_SETS=()
@@ -398,6 +422,7 @@ _install_core_release_local() {
     for set_value in "${CORE_SET_VALUES[@]}"; do
         helm_args+=("--set" "${set_value}")
     done
+    _core_apply_thirdparty_registry_override "${release_name}" helm_args
 
     if helm "${helm_args[@]}"; then
         log_info "✓ ${release_name} installed successfully"
@@ -468,6 +493,7 @@ _install_core_release_repo() {
     for set_value in "${CORE_SET_VALUES[@]}"; do
         helm_args+=("--set" "${set_value}")
     done
+    _core_apply_thirdparty_registry_override "${release_name}" helm_args
 
     if helm "${helm_args[@]}"; then
         log_info "✓ ${release_name} installed successfully"

--- a/deploy/scripts/services/ingress_nginx.sh
+++ b/deploy/scripts/services/ingress_nginx.sh
@@ -1,6 +1,7 @@
 
 # Install ingress-nginx-controller
 install_ingress_nginx() {
+    resolve_thirdparty_images_online
     log_info "Installing ingress-nginx-controller..."
 
     # Override Ingress-Nginx image registry based on OFFLINE_MODE (keep full path)

--- a/deploy/scripts/services/kafka.sh
+++ b/deploy/scripts/services/kafka.sh
@@ -1,5 +1,6 @@
 
 install_kafka() {
+    resolve_thirdparty_images_online
     log_info "Installing Kafka (1 controller + 1 broker) via Helm..."
 
     local fresh_install="true"

--- a/deploy/scripts/services/mariadb.sh
+++ b/deploy/scripts/services/mariadb.sh
@@ -790,6 +790,7 @@ install_mariadb_bitnami() {
 }
 
 install_mariadb() {
+    resolve_thirdparty_images_online
     if [[ -z "${MARIADB_IMAGE}" ]]; then
         MARIADB_IMAGE="$(image_from_registry "${MARIADB_IMAGE_REPOSITORY}" "${MARIADB_IMAGE_TAG}" "${MARIADB_IMAGE_FALLBACK}")"
     fi

--- a/deploy/scripts/services/opensearch.sh
+++ b/deploy/scripts/services/opensearch.sh
@@ -1,5 +1,6 @@
 
 install_opensearch() {
+    resolve_thirdparty_images_online
     log_info "Installing OpenSearch via Helm..."
 
     local fresh_install="true"


### PR DESCRIPTION
Closes #309

## 问题
- 数据层第三方镜像(mariadb/kafka/opensearch/busybox/ingress-nginx/local-path)的**在线默认硬编码 swr.cn-east-3**(CN registry)—— 国际/公网用户躲不开
- otelcol(core release)被全局 `--set image.registry=ghcr.io/openbkn-ai` 覆盖,但第三方镜像没发布到 ghcr(匿名 403,包本就不存在)—— 默认 ghcr 装机 otelcol `ImagePullBackOff`

`--registry` 对数据层无效(`<NAME>_IMAGE` 源码期就锁死);otelcol 补 ghcr 又是「mirror 一切」的粗暴法。

## 改动
在线默认改各自**公开标准上游**,offline 分支不动:

| 镜像 | 在线上游 |
|---|---|
| mariadb | docker.io/library/mariadb |
| kafka | docker.io/bitnamilegacy/kafka（bitnami 撤免费版,同镜像迁 legacy 仓） |
| opensearch | docker.io/opensearchproject/opensearch |
| busybox(init) | docker.io/library/busybox |
| ingress-nginx | registry.k8s.io/ingress-nginx/{controller,kube-webhook-certgen} |
| local-path-provisioner | docker.io/rancher/local-path-provisioner |
| otelcol-contrib | docker.io（per-release override 压过全局） |

新增 `_core_apply_thirdparty_registry_override`:第三方 core release 在线追加 `image.registry=<upstream>`(在全局 `--set` 之后,helm 后者胜),offline 不动。

CN/气隙:`--offline=<registry>` 走可达镜像仓(swr 等),行为不变。

## 验证(31.70.113.200,用 deploy 实际函数)
- 在线解析:mariadb/kafka/opensearch/busybox/ingress/certgen 全部转上游 ✅
- offline 解析:仍走 `${OFFLINE_REGISTRY}/...` ✅(未改动)
- otelcol helper:输出 `image.registry=docker.io`,openbkn 镜像(bkn-backend)不动 ✅
- 8 个上游镜像 `k3s ctr images pull` 全部成功(多架构)✅
- **活集群**:otelcol helm 切 docker.io 后 `1/1 Running`(从 `ghcr.io/openbkn-ai/otel` → `docker.io/otel`)✅
- chart `--set image.repository=<全路径>` 无双前缀;ingress/opensearch 的二次覆盖只在 offline 触发 ✅

## 遗留 / 后续
- **kafka `bitnamilegacy`** 是 Bitnami 弃用堆放区,长期可能再删 → 后续迁 `apache/kafka`(需改 chart)或自建 re-host
- **docker.io 匿名限流**(100/6h/IP)→ 可配 `--dockerhub-mirror`
- **子 chart 内嵌第三方**(hydra/postgres/redis_exporter/nginx/kubectl-shell)仍在 chart values 走 swr —— 本 PR 未覆盖,另开跟进
- redis 是 openbkn 自建镜像(非上游),仍走 swr/ghcr,不在本 PR 范围

🤖 Generated with [Claude Code](https://claude.com/claude-code)