### PR TITLE
chore(bkn-agent): 依赖升级到 langchain/langgraph 1.x

### DIFF
--- a/docs/api/bkn-agent.yaml
+++ b/docs/api/bkn-agent.yaml
@@ -567,7 +567,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ExportPackage-Output'
+                $ref: '#/components/schemas/ExportPackage'
         4XX:
           description: 平台错误封套（400 参数/401 身份/404 不存在/409 冲突）
           content:
@@ -620,23 +620,7 @@ components:
       required:
       - deleted
       title: AgentDeleted
-    AgentExportItem-Input:
-      properties:
-        agent_id:
-          type: string
-          title: Agent Id
-        spec:
-          $ref: '#/components/schemas/AgentSpec'
-        prompt:
-          anyOf:
-          - $ref: '#/components/schemas/PromptExport'
-          - type: 'null'
-      type: object
-      required:
-      - agent_id
-      - spec
-      title: AgentExportItem
-    AgentExportItem-Output:
+    AgentExportItem:
       properties:
         agent_id:
           type: string
@@ -732,7 +716,8 @@ components:
           title: Prompt Id
         prompt_vars_schema:
           anyOf:
-          - type: object
+          - additionalProperties: true
+            type: object
           - type: 'null'
           title: Prompt Vars Schema
         model:
@@ -810,7 +795,8 @@ components:
           title: Prompt Id
         prompt_vars_schema:
           anyOf:
-          - type: object
+          - additionalProperties: true
+            type: object
           - type: 'null'
           title: Prompt Vars Schema
         model:
@@ -867,8 +853,6 @@ components:
           title: Description
         type:
           type: string
-          enum:
-          - agent
           const: agent
           title: Type
         agent_id:
@@ -907,11 +891,13 @@ components:
           - type: 'null'
           title: Prompt Override
         prompt_vars:
+          additionalProperties: true
           type: object
           title: Prompt Vars
         response_format:
           anyOf:
-          - type: object
+          - additionalProperties: true
+            type: object
           - type: 'null'
           title: Response Format
       type: object
@@ -971,12 +957,10 @@ components:
       - solution
       title: ErrorEnvelope
       description: 平台统一错误封套（所有非 2xx 响应）。
-    ExportPackage-Input:
+    ExportPackage:
       properties:
         format:
           type: string
-          enum:
-          - bkn-agent/v1
           const: bkn-agent/v1
           title: Format
           default: bkn-agent/v1
@@ -985,29 +969,7 @@ components:
           title: Exported At
         items:
           items:
-            $ref: '#/components/schemas/AgentExportItem-Input'
-          type: array
-          title: Items
-      type: object
-      required:
-      - exported_at
-      - items
-      title: ExportPackage
-    ExportPackage-Output:
-      properties:
-        format:
-          type: string
-          enum:
-          - bkn-agent/v1
-          const: bkn-agent/v1
-          title: Format
-          default: bkn-agent/v1
-        exported_at:
-          type: integer
-          title: Exported At
-        items:
-          items:
-            $ref: '#/components/schemas/AgentExportItem-Output'
+            $ref: '#/components/schemas/AgentExportItem'
           type: array
           title: Items
       type: object
@@ -1065,7 +1027,7 @@ components:
     ImportRequest:
       properties:
         package:
-          $ref: '#/components/schemas/ExportPackage-Input'
+          $ref: '#/components/schemas/ExportPackage'
       type: object
       required:
       - package
@@ -1103,11 +1065,13 @@ components:
           - type: 'null'
           title: Prompt Override
         prompt_vars:
+          additionalProperties: true
           type: object
           title: Prompt Vars
         response_format:
           anyOf:
-          - type: object
+          - additionalProperties: true
+            type: object
           - type: 'null'
           title: Response Format
       type: object
@@ -1131,8 +1095,6 @@ components:
           title: Description
         type:
           type: string
-          enum:
-          - mcp
           const: mcp
           title: Type
         url:
@@ -1154,8 +1116,6 @@ components:
           title: Deleted
         fallback:
           type: string
-          enum:
-          - default
           const: default
           title: Fallback
       type: object
@@ -1183,8 +1143,6 @@ components:
           title: Account Id
         source:
           type: string
-          enum:
-          - override
           const: override
           title: Source
       type: object
@@ -1206,7 +1164,8 @@ components:
           title: Content
         vars_schema:
           anyOf:
-          - type: object
+          - additionalProperties: true
+            type: object
           - type: 'null'
           title: Vars Schema
       type: object
@@ -1254,7 +1213,8 @@ components:
           title: Content
         vars_schema:
           anyOf:
-          - type: object
+          - additionalProperties: true
+            type: object
           - type: 'null'
           title: Vars Schema
         update_user:
@@ -1280,7 +1240,8 @@ components:
           title: Content
         vars_schema:
           anyOf:
-          - type: object
+          - additionalProperties: true
+            type: object
           - type: 'null'
           title: Vars Schema
       type: object
@@ -1318,7 +1279,8 @@ components:
           title: Content
         vars_schema:
           anyOf:
-          - type: object
+          - additionalProperties: true
+            type: object
           - type: 'null'
           title: Vars Schema
       type: object
@@ -1347,7 +1309,8 @@ components:
           title: Content
         vars_schema:
           anyOf:
-          - type: object
+          - additionalProperties: true
+            type: object
           - type: 'null'
           title: Vars Schema
         create_user:
@@ -1383,11 +1346,13 @@ components:
           - type: 'null'
           title: Prompt Override
         prompt_vars:
+          additionalProperties: true
           type: object
           title: Prompt Vars
         response_format:
           anyOf:
-          - type: object
+          - additionalProperties: true
+            type: object
           - type: 'null'
           title: Response Format
       type: object
@@ -1413,7 +1378,8 @@ components:
           title: Status
         input:
           anyOf:
-          - type: object
+          - additionalProperties: true
+            type: object
           - type: 'null'
           title: Input
         output:
@@ -1510,8 +1476,6 @@ components:
           title: Description
         type:
           type: string
-          enum:
-          - toolbox
           const: toolbox
           title: Type
         box_id:

--- a/infra/bkn-agent/app/core/graph.py
+++ b/infra/bkn-agent/app/core/graph.py
@@ -3,8 +3,8 @@ import json
 import uuid
 from typing import AsyncIterator
 
+from langchain.agents import create_agent
 from langchain_core.messages import AIMessage, AIMessageChunk, HumanMessage, ToolMessage
-from langgraph.prebuilt import create_react_agent
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app import dao, observability
@@ -94,8 +94,8 @@ async def stream_chat(
             yield _sse("meta", {"thread_id": thread_id, "agent_id": agent.agent_id})
             with observability.span("agent.chat", span_attrs):
                 async with open_checkpointer() as checkpointer:
-                    graph = create_react_agent(
-                        model, tools, prompt=system_prompt, checkpointer=checkpointer
+                    graph = create_agent(
+                        model, tools, system_prompt=system_prompt, checkpointer=checkpointer
                     )
                     cfg = {
                         "configurable": {"thread_id": thread_id},

--- a/infra/bkn-agent/app/core/llm.py
+++ b/infra/bkn-agent/app/core/llm.py
@@ -6,8 +6,8 @@ from app.config import config
 
 
 def normalize_response_format(rf: Optional[dict[str, Any]]) -> Optional[dict[str, Any]]:
-    """create_react_agent 的 response_format 底层过 convert_to_openai_function：纯 JSON Schema
-    若缺 name/title 会被判 `Unsupported function`。缺就补个 title，调用方可直接传裸 schema。"""
+    """with_structured_output 底层过 convert_to_openai_function：纯 JSON Schema 若缺
+    name/title 会被判 `Unsupported function`。缺就补个 title，调用方可直接传裸 schema。"""
     if isinstance(rf, dict) and "title" not in rf and "name" not in rf:
         return {"title": "StructuredResponse", **rf}
     return rf

--- a/infra/bkn-agent/app/core/runner.py
+++ b/infra/bkn-agent/app/core/runner.py
@@ -2,8 +2,8 @@ import asyncio
 import json
 from typing import Any, Optional
 
+from langchain.agents import create_agent
 from langchain_core.messages import AIMessage
-from langgraph.prebuilt import create_react_agent
 
 from app import dao, observability
 from app.config import config
@@ -72,7 +72,7 @@ async def run_agent_once(
             "prompt.version": prompt_version,
         },
     ):
-        graph = create_react_agent(model, tools, prompt=system_prompt)
+        graph = create_agent(model, tools, system_prompt=system_prompt)
         async with asyncio.timeout(timeout_s):
             result = await graph.ainvoke(
                 {"messages": [("user", message)]},

--- a/infra/bkn-agent/app/test/test_structured_output.py
+++ b/infra/bkn-agent/app/test/test_structured_output.py
@@ -86,7 +86,7 @@ class _FakeCM:
 
 
 def _wire(monkeypatch, captured):
-    monkeypatch.setattr(runner, "create_react_agent", lambda *a, **k: _FakeGraph())
+    monkeypatch.setattr(runner, "create_agent", lambda *a, **k: _FakeGraph())
 
     def fake_model(m, streaming=True, max_output_tokens=None):
         captured.setdefault("streaming", []).append(streaming)

--- a/infra/bkn-agent/requirements.txt
+++ b/infra/bkn-agent/requirements.txt
@@ -1,28 +1,32 @@
 # 运行服务
-fastapi~=0.115.0
-uvicorn[standard]~=0.30.0
-pydantic~=2.9.0
+fastapi~=0.139.0
+uvicorn[standard]~=0.51.0
+pydantic~=2.13.0
 
 # 编排引擎
-langgraph~=0.2.60
-langchain-core~=0.3.29
-langchain-openai~=0.2.14
-langchain-mcp-adapters~=0.1.0
-langgraph-checkpoint-mysql~=2.0.15
+# langchain 主包是 create_agent 的落点（1.x 起 agent 构造从 langgraph.prebuilt 迁出）
+langchain~=1.3.14
+langgraph~=1.2.9
+langchain-core~=1.4.9
+langchain-openai~=1.3.5
+langchain-mcp-adapters~=0.3.0
+langgraph-checkpoint-mysql~=3.0.0
 
 # 数据与外呼
-sqlalchemy[asyncio]~=2.0.36
+sqlalchemy[asyncio]~=2.0.51
+# aiomysql 保持 0.2：checkpoint 连接参数（charset/init_command）只能在真实 MySQL
+# 上验证，单测覆盖不到，不与本次升级同批冒险
 aiomysql~=0.2.0
-aiohttp~=3.10.0
+aiohttp~=3.14.0
 
 # 契约（docs/api/bkn-agent.yaml 导出与漂移测试）
 pyyaml~=6.0
 
 # 可观测（OTLP → otelcol-contrib → agent-observability）
-opentelemetry-sdk~=1.29
-opentelemetry-exporter-otlp-proto-http~=1.29
-opentelemetry-instrumentation-fastapi~=0.50b0
-openinference-instrumentation-langchain~=0.1.29
+opentelemetry-sdk~=1.44.0
+opentelemetry-exporter-otlp-proto-http~=1.44.0
+opentelemetry-instrumentation-fastapi~=0.65b0
+openinference-instrumentation-langchain~=0.1.67
 
 # 结构化输出降级：JSON Schema 校验
-jsonschema~=4.23
+jsonschema~=4.26


### PR DESCRIPTION
Closes #319

## 背景

bkn-agent 首次提交（#237，2026-07-17）的 `requirements.txt` 钉的是 2024-12 / 2025-01 的版本，而 langgraph 1.0 于 2025-10-17 发布。这不是历史包袱——是三天前写入时版本号未经核对。服务上线三天、checkpoint 表近乎空、prebuilt API 只有两个调用点，当前是升级代价最低的时点。

## 变更

| 包 | 前 | 后 |
| --- | --- | --- |
| langgraph | 0.2.60 | 1.2.9 |
| langchain-core | 0.3.29 | 1.4.9 |
| langchain（新增） | — | 1.3.14 |
| langchain-openai | 0.2.14 | 1.3.5 |
| langchain-mcp-adapters | 0.1.0 | 0.3.0 |
| langgraph-checkpoint-mysql | 2.0.15 | 3.0.0 |
| fastapi / pydantic / otel / openinference | 2024 年底一批 | 当前 |

代码侧只有两处：`app/core/graph.py` 与 `app/core/runner.py` 的 `create_react_agent` → `create_agent`（`prompt` 参数更名 `system_prompt`）。langchain 1.x 起 agent 构造从 `langgraph.prebuilt` 迁到 `langchain.agents`，故新增 langchain 主包依赖。

`aiomysql` 有意保持 0.2：checkpoint 的连接参数（charset / init_command，见 `app/core/checkpoint.py` 中 collation 1267 的注释）只能在真实 MySQL 上验证，单测覆盖不到，不与本次同批冒险。

## 需要评审的契约变更

pydantic 2.9 → 2.13 的 JSON Schema 生成有三处变化，两处等价、一处对外可见：

1. **（可见）** `ExportPackage-Input` / `-Output`、`AgentExportItem-Input` / `-Output` 各自合并为单一组件 `ExportPackage` / `AgentExportItem`。pydantic 2.13 在 validation 与 serialization schema 一致时不再拆分。从 `docs/api/bkn-agent.yaml` 生成客户端代码的调用方会看到组件改名。
2. （等价）裸 `dict` 字段显式输出 `additionalProperties: true`——本就是 JSON Schema 默认值。
3. （等价）单值 `Literal` 只发 `const`，不再 `const` + `enum` 双写。

第 1 条影响面实际约等于零（服务三天大，且是 import/export 内部结构），但按仓里「spec 先行」的规矩不应混在依赖升级里默默通过，故单独列出请评审。spec 已按 `scripts/export_openapi.py` 重新导出。

## 验证

**单测**：74 passed。升级前为 73 passed + 1 failed——那条 `test_max_output_tokens_passes_to_model` 报 `AttributeError: module 'langchain' has no attribute 'verbose'`，根因是 requirements 未装 langchain 主包而 langchain-core 0.3 的 globals 需要它；本次补齐主包后自然消失。

**镜像**：amd64 / arm64 两个平台在镜像内从零 pip install 均通过（验证新依赖集可独立解出，而非依赖本地已有环境）。

**VM（10.211.55.4，arm64/k3s）端到端**，逐项通过：

- SSE 流式：`meta` / `token` / `done` 事件正常
- **跨轮记忆**：同一 thread 第一轮告知姓名、第二轮正确回忆 → MySQL checkpointer 在 langgraph 1.x + langgraph-checkpoint 4.1.1 + checkpoint-mysql 3.0.0 下读写正常（本次最大风险项）
- 历史回读 `GET /threads/{id}`：四条消息完整（user / assistant 各两条）
- 结构化输出：`event: structured` 正常产出
- 工具调用：`event: tool_call` 触发，工具执行并回灌模型（langchain-mcp-adapters 0.3 装载正常）
- OTLP：日志无 instrumentation / 导出错误

**测试服 14.103.77.23**：已部署 `0.1.1-lc1x-1`，服务健康、单测行为一致。该环境未配置默认大模型（`ModelFactory.ExternalSmallModel.Used.NameNotExist`，与本 PR 无关），故端到端 LLM 链路改在 VM 验证。

## 附带观察（非本 PR 引入，不在此修）

- 结构化输出的原生路径在 dashscope 上被拒（`'messages' must contain the word 'json'`），按设计降级到提示词模式并成功。降级逻辑工作正常，但原生路径对该 provider 实际恒不可用，值得单独评估。
- 仓库 label 集里没有 WORKFLOW.md 描述的 `type: bug|feature|task|docs`，也没有 `bkn-agent` 服务标签，该模块的 CODEOWNERS 自动路由是空跑。
- 建议后续加 CI 依赖时效检查（pinned 落后 latest 超过 N 个 minor 即告警），避免同类问题复发。已在 #319 记录。

## 后续

升级完成后可按需引入 langchain 1.x middleware（TodoList / Filesystem / Summarization），即 deepagents 的拆分零件。本 PR 不含任何新能力。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
