### PR TITLE
fix(bkn-agent): 技能面从 capabilities-lab 收敛到执行工厂

### DIFF
--- a/infra/bkn-agent/app/config.py
+++ b/infra/bkn-agent/app/config.py
@@ -32,13 +32,8 @@ class Config:
         "e521d454-4a0b-4dc9-8a28-d0986de1cef9",
     )
 
-    # 技能面：capabilities-lab
-    CAPABILITIES_LAB_BASE = _env(
-        "CAPABILITIES_LAB_BASE",
-        "http://capabilities-lab:8080/api/capabilities-lab/v1",
-    )
-
-    # 算子工厂（operator-integration）：published agent 注册为 toolbox 工具（#212）
+    # 算子工厂（operator-integration）：published agent 注册为 toolbox 工具（#212）；
+    # 工具面与技能面统一走这里的 internal-v1（#322 把技能面从 capabilities-lab 收敛过来）
     OPERATOR_INTEGRATION_BASE = _env("OPERATOR_INTEGRATION_BASE", "http://agent-operator-integration:9000/api/agent-operator-integration")
     TOOLBOX_SYNC_ENABLED = _env("BKN_AGENT_TOOLBOX_SYNC", "true").lower() == "true"
     TOOLBOX_SYNC_RETRY_INITIAL_S = int(_env("BKN_AGENT_TOOLBOX_RETRY_INITIAL_S", "5"))

--- a/infra/bkn-agent/app/core/skills.py
+++ b/infra/bkn-agent/app/core/skills.py
@@ -21,25 +21,70 @@ def _cache_put(key: tuple[str, str, str], now: float, content: str) -> None:
     _cache[key] = (now, content)
 
 
+def normalize_skill_id(capability_id: str) -> str:
+    """capabilities-lab 的 capability id 形如 `skill:<uuid>`，执行工厂要裸 uuid。
+    两种都收，历史配置里存的带前缀 id 不至于失效。"""
+    return capability_id[6:] if capability_id.startswith("skill:") else capability_id
+
+
+def strip_frontmatter(text: str) -> str:
+    """发布态返回原始 SKILL.md（含 YAML frontmatter），注入前剥掉：
+    name/description 是给市场检索用的，进 system prompt 只是噪声。"""
+    if not text.startswith("---"):
+        return text.strip()
+    end = text.find("\n---", 3)
+    return text[end + 4 :].strip() if end != -1 else text.strip()
+
+
 async def _fetch_skill_content(session: aiohttp.ClientSession, capability_id: str, headers: dict) -> str:
-    url = f"{config.CAPABILITIES_LAB_BASE}/capabilities/{capability_id}/skill/content"
+    """从执行工厂取已发布技能正文，与 toolbox 同门（见 core/toolbox.py）。
+
+    走发布态而非管理态：管理态是草稿面，改技能会立刻改变线上 agent 行为，
+    发布流程就失去意义。代价是两跳——发布态只回 presigned URL 不回正文。
+    """
+    skill_id = normalize_skill_id(capability_id)
+    url = f"{config.OPERATOR_INTEGRATION_BASE}/internal-v1/skills/{skill_id}/content"
     async with session.get(url, headers=headers) as resp:
         if resp.status == 404:
             raise err(
                 400,
                 "Skill.NotFound",
                 "技能不存在",
-                f"capability {capability_id} 在 capabilities-lab 中不存在",
-                "请检查 capability_id，技能失效时不会被静默跳过。",
+                f"技能 {skill_id} 在执行工厂中不存在或未发布",
+                "请检查 skill_id，技能失效时不会被静默跳过。",
             )
         if resp.status != 200:
             raise err(
                 502,
                 "Skill.FetchFailed",
                 "技能拉取失败",
-                f"capabilities-lab 返回 {resp.status}（capability {capability_id}）",
+                f"执行工厂返回 {resp.status}（技能 {skill_id}）",
             )
-        return await resp.text()
+        meta = await resp.json()
+
+    # 第二跳：presigned URL 指向集群内 MinIO，不带业务身份，不能透传 headers
+    async with session.get(meta["url"]) as resp:
+        if resp.status != 200:
+            raise err(
+                502,
+                "Skill.FetchFailed",
+                "技能正文拉取失败",
+                f"对象存储返回 {resp.status}（技能 {skill_id}）",
+            )
+        body = strip_frontmatter(await resp.text())
+
+    # 附属文件清单必须进上下文：模型据此知道有哪些文件可读、以及 read_skill_file
+    # 要传的 skill_id —— 否则渐进式加载对模型不可见，等于没有。
+    others = [f["rel_path"] for f in (meta.get("files") or []) if f["rel_path"].upper() != "SKILL.MD"]
+    header = f"## 技能 {skill_id}\n"
+    if others:
+        header += (
+            f"\n本技能有以下附属文件，未加载进上下文，需要时用 read_skill_file 工具读取"
+            f"（skill_id={skill_id}，path 取下列之一）：\n"
+            + "".join(f"- {p}\n" for p in others)
+            + "\n"
+        )
+    return header + body
 
 
 async def load_skills(capability_ids: list[str], account_id: str, account_type: str) -> str:
@@ -52,8 +97,8 @@ async def load_skills(capability_ids: list[str], account_id: str, account_type: 
     now = time.monotonic()
     async with aiohttp.ClientSession(timeout=aiohttp.ClientTimeout(total=30)) as session:
         for cid in dict.fromkeys(capability_ids):
-            # 缓存键含调用方身份：capabilities-lab 可能按账户授权私有技能，只按
-            # capability_id 缓存会让 TTL 窗口内 B 拿到 A 的私有正文且不重发 B 身份。
+            # 缓存键含调用方身份：执行工厂可能按账户授权私有技能，只按
+            # skill_id 缓存会让 TTL 窗口内 B 拿到 A 的私有正文且不重发 B 身份。
             key = (account_type, account_id, cid)
             cached = _cache.get(key)
             if cached and now - cached[0] < config.SKILL_CACHE_TTL_S:
@@ -64,6 +109,6 @@ async def load_skills(capability_ids: list[str], account_id: str, account_type: 
             parts.append(content)
     body = "\n\n---\n\n".join(parts)
     return (
-        "\n\n# Skills\n\n以下技能已挂载。技能提到的附属文件不在上下文中，"
+        "\n\n# Skills\n\n以下技能已挂载，请按其中的说明执行。技能的附属文件不在上下文中，"
         "需要时调用 read_skill_file 工具按需读取。\n\n" + body
     )

--- a/infra/bkn-agent/app/core/tools.py
+++ b/infra/bkn-agent/app/core/tools.py
@@ -6,6 +6,7 @@ from langchain_core.tools import StructuredTool
 from langchain_mcp_adapters.client import MultiServerMCPClient
 
 from app.config import config
+from app.core.skills import normalize_skill_id
 from app.core.toolbox import load_toolbox_tools
 from app.errors import bad_request
 
@@ -113,14 +114,23 @@ async def _agent_tool(
 
 
 def _read_skill_file_tool(account_id: str, account_type: str) -> StructuredTool:
-    async def read_skill_file(capability_id: str, path: str) -> str:
-        """读取已挂载技能的附属文件（渐进式加载，大文件不常驻上下文）。"""
-        url = f"{config.CAPABILITIES_LAB_BASE}/capabilities/{capability_id}/skill/files/read"
+    async def read_skill_file(skill_id: str, path: str) -> str:
+        """读取已挂载技能的附属文件（渐进式加载，大文件不常驻上下文）。
+        skill_id 与 path 取 system prompt 中该技能条目列出的值。"""
+        sid = normalize_skill_id(skill_id)
+        url = f"{config.OPERATOR_INTEGRATION_BASE}/internal-v1/skills/{sid}/files/read"
         headers = {"x-account-id": account_id, "x-account-type": account_type}
         async with aiohttp.ClientSession(timeout=aiohttp.ClientTimeout(total=30)) as session:
-            async with session.post(url, json={"path": path}, headers=headers) as resp:
+            # 字段名是 rel_path，执行工厂侧 validate:"required"；发过 path 会 400
+            async with session.post(url, json={"rel_path": path}, headers=headers) as resp:
                 if resp.status != 200:
-                    return f"read_skill_file failed: HTTP {resp.status}"
+                    detail = (await resp.text())[:200]
+                    return f"read_skill_file failed: HTTP {resp.status} {detail}"
+                meta = await resp.json()
+            # 与 load_skills 同样两跳：发布态只回 presigned URL，不回正文
+            async with session.get(meta["url"]) as resp:
+                if resp.status != 200:
+                    return f"read_skill_file failed: 对象存储 HTTP {resp.status}"
                 return await resp.text()
 
     return StructuredTool.from_function(coroutine=read_skill_file, name="read_skill_file")

--- a/infra/bkn-agent/app/test/test_skill_source.py
+++ b/infra/bkn-agent/app/test/test_skill_source.py
@@ -1,0 +1,129 @@
+"""技能面从 capabilities-lab 收敛到执行工厂（#322）。
+
+原实现打 capabilities-lab，而该服务只认 Authorization/Cookie，不读 bkn-agent 发的
+x-account-id/x-account-type，导致挂了技能的 agent 一律 502。这里锁住新的调用契约。
+"""
+import asyncio
+
+import pytest
+
+from app.config import config
+from app.core import skills
+
+
+def test_normalize_skill_id_strips_prefix():
+    # capabilities-lab 时代的 capability id 带 `skill:` 前缀，执行工厂要裸 uuid
+    assert skills.normalize_skill_id("skill:abc-123") == "abc-123"
+    assert skills.normalize_skill_id("abc-123") == "abc-123"
+
+
+def test_strip_frontmatter():
+    raw = "---\nname: demo\ndescription: d\n---\n\n# Body\n\ntext\n"
+    assert skills.strip_frontmatter(raw) == "# Body\n\ntext"
+    # 无 frontmatter 时原样返回，不能吞掉正文首行
+    assert skills.strip_frontmatter("# Body\n\ntext\n") == "# Body\n\ntext"
+
+
+class _FakeResp:
+    def __init__(self, status=200, payload=None, text=""):
+        self.status = status
+        self._payload = payload
+        self._text = text
+
+    async def json(self):
+        return self._payload
+
+    async def text(self):
+        return self._text
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *a):
+        return False
+
+
+class _FakeSession:
+    """记录所有请求，按 URL 分发响应。"""
+
+    def __init__(self):
+        self.calls = []
+
+    def get(self, url, headers=None):
+        self.calls.append(("GET", url, headers, None))
+        if "/content" in url:
+            return _FakeResp(
+                200,
+                payload={
+                    "url": "http://minio/skill.md",
+                    "files": [
+                        {"rel_path": "SKILL.md"},
+                        {"rel_path": "reference.md"},
+                    ],
+                    "status": "published",
+                },
+            )
+        return _FakeResp(200, text="---\nname: n\n---\n\n# 正文\n")
+
+    def post(self, url, json=None, headers=None):
+        self.calls.append(("POST", url, headers, json))
+        return _FakeResp(200, payload={"url": "http://minio/ref.md"})
+
+
+def test_fetch_skill_content_hits_execution_factory():
+    sess = _FakeSession()
+    out = asyncio.run(skills._fetch_skill_content(sess, "skill:sid-1", {"x-account-id": "a"}))
+
+    meta_url = sess.calls[0][1]
+    assert meta_url.startswith(config.OPERATOR_INTEGRATION_BASE), "必须打执行工厂，不是 capabilities-lab"
+    assert "/internal-v1/skills/sid-1/content" in meta_url, "走 internal-v1，且 id 已剥前缀"
+    # 第二跳取对象存储正文，且不得带业务身份头（presigned URL 自带签名）
+    assert sess.calls[1][1] == "http://minio/skill.md"
+    assert sess.calls[1][2] is None
+
+    assert "# 正文" in out and "name: n" not in out, "frontmatter 应被剥掉"
+    # 附属文件清单要进上下文，否则模型不知道能读什么、也不知道 skill_id
+    assert "reference.md" in out and "sid-1" in out
+    assert "SKILL.md" not in out, "正文本身已注入，不应再列进待读清单"
+
+
+def test_fetch_skill_content_404_is_not_silent():
+    class _NotFound(_FakeSession):
+        def get(self, url, headers=None):
+            return _FakeResp(404)
+
+    with pytest.raises(Exception) as e:
+        asyncio.run(skills._fetch_skill_content(_NotFound(), "sid-x", {}))
+    assert getattr(e.value, "status_code", None) == 400
+
+
+def test_read_skill_file_uses_rel_path():
+    """原实现发 {"path": ...}，执行工厂要 rel_path（validate:"required"），每次必 400。"""
+    from app.core.tools import _read_skill_file_tool
+
+    tool = _read_skill_file_tool("acc", "user")
+    sess = _FakeSession()
+
+    import app.core.tools as tools_mod
+
+    class _CM:
+        def __init__(self, s):
+            self.s = s
+
+        async def __aenter__(self):
+            return self.s
+
+        async def __aexit__(self, *a):
+            return False
+
+    orig = tools_mod.aiohttp.ClientSession
+    tools_mod.aiohttp.ClientSession = lambda *a, **k: _CM(sess)
+    try:
+        asyncio.run(tool.coroutine(skill_id="skill:sid-1", path="reference.md"))
+    finally:
+        tools_mod.aiohttp.ClientSession = orig
+
+    method, url, _, body = sess.calls[0]
+    assert method == "POST"
+    assert "/internal-v1/skills/sid-1/files/read" in url
+    assert body == {"rel_path": "reference.md"}, "字段名必须是 rel_path"

--- a/infra/bkn-agent/charts/templates/deployment.yaml
+++ b/infra/bkn-agent/charts/templates/deployment.yaml
@@ -72,8 +72,6 @@ spec:
               value: {{ .Values.runtime.mfModelApiPrivateBase | quote }}
             - name: BKN_AGENT_DEFAULT_TOOLBOXES
               value: {{ .Values.runtime.defaultToolboxes | quote }}
-            - name: CAPABILITIES_LAB_BASE
-              value: {{ .Values.runtime.capabilitiesLabBase | quote }}
             - name: OPERATOR_INTEGRATION_BASE
               value: {{ .Values.runtime.operatorIntegrationBase | quote }}
             - name: BKN_AGENT_TOOLBOX_SYNC

--- a/infra/bkn-agent/charts/values.yaml
+++ b/infra/bkn-agent/charts/values.yaml
@@ -38,8 +38,7 @@ runtime:
   mfModelApiPrivateBase: "http://mf-model-api:9898/api/private/mf-model-api/v1"
   # 默认给每个 agent 挂载的执行工厂 toolbox（逗号分隔；默认=contextloader 内置工具集，置空不挂）
   defaultToolboxes: "e521d454-4a0b-4dc9-8a28-d0986de1cef9"
-  capabilitiesLabBase: "http://capabilities-lab:9002/api/capabilities-lab/v1"
-  # published agent 注册进算子工厂 toolbox（#212）
+  # published agent 注册进算子工厂 toolbox（#212）；工具面与技能面统一走这里（#322）
   operatorIntegrationBase: "http://agent-operator-integration:9000/api/agent-operator-integration"
   toolboxSync: "true"
   # toolbox 工具回调本服务的地址（box_svc_url）


### PR DESCRIPTION
Closes #322

## 问题

挂了技能的 agent 对话一律 502，不是降级而是直接失败：

```
502 {"code":"BknAgent.Skill.FetchFailed",
     "detail":"capabilities-lab 返回 502（capability 0d1585ba-...）"}
```

未挂技能的 agent 不受影响，所以此前的功能验证都没踩到。

## 根因

技能面打的是 capabilities-lab，而该服务只转发入站的 `Authorization` / `Cookie`，不读 bkn-agent 按 `/in` 约定发的 `x-account-id` / `x-account-type`（全仓搜不到这两个头）。请求以无 token 身份到达 operator-integration，被 401，门面再包成 502。

工具面（toolbox）不存在此问题——它直连执行工厂 `/internal-v1/tool-box/...`，用的正是这两个头。**技能面当初没跟上工具面收敛执行工厂那次改动。**

同一套 header 打两扇门，VM 实测：

| 目标 | 结果 |
| --- | --- |
| capabilities-lab `/capabilities/{id}/skill/content` | 502（上游 401 token invalid） |
| 执行工厂 `/internal-v1/skills/{id}/content` | 200 |

## 改动

技能面改走执行工厂 `internal-v1`，与 toolbox 同门。

顺带修掉三处**使渐进式加载此前完全不可用**的问题（都被这个 502 掩盖着）：

1. `read_skill_file` 请求体字段 `path` → `rel_path`。执行工厂侧是 `validate:"required"`，原字段名每次必 400；而工具把失败包成字符串返回给模型，模型只会理解成"这个文件读不到"继续编，**静默失败**。
2. 注入的 system prompt 从未告知 `skill_id` 与附属文件清单，模型根本无从调用该工具。现在每个技能条目带 `skill_id` 和可读文件列表。
3. 原实现把整个 HTTP 响应体（JSON 信封）注入 prompt，而不是其中的正文字段。

### 一处设计取舍：取发布态而非管理态

capabilities-lab 原本走的是 `management/content`（管理态，一跳直接回正文）。本次改走发布态：

- **管理态是草稿面**，改技能会立刻改变线上 agent 行为，发布流程将失去意义
- 代价是两跳：发布态只回 presigned URL 不回正文，第二跳取集群内 MinIO（已验证 bkn-agent pod 可达）
- 发布态返回原始 SKILL.md，注入前需剥掉 YAML frontmatter

如果评审认为 agent 应当能跑草稿技能（便于调试），这条可以改回管理态，但建议做成显式选项而非默认。

### 其他

- skill id 兼容两种形态：capabilities-lab 的 `skill:<uuid>` 前缀与执行工厂的裸 uuid
- `CAPABILITIES_LAB_BASE` 已无引用，连同 chart env 与 values 一并移除

## 验证

**单测**：79 passed（74 + 5 新增，锁住调用契约、`rel_path` 字段名、frontmatter 剥离、404 不静默）。

**VM 10.211.55.4 端到端**：

挂 `exp_session_echo` 技能对话（该技能的设计目的正是验证正文是否被真的注入）：

```
[exp_session_echo] RECEIVED session_id=ZZ-9987 from user
```

模型严格按技能正文的指令输出，正文确实生效。

挂 `supplier_expedite` 技能，要求模型读取附属脚本：`event: tool_call` 触发，模型正确答出 `request_expedite.py` 的环境变量（`SKU` / `SUPPLIER_ID` / `SLA_HOURS` / `TOOL_BACKEND_URL`）与请求端点 `${TOOL_BACKEND_URL}/supplier/expedite`——细节真实，非臆造。

## 不在本次范围

技能脚本执行（`POST /internal-v1/skills/{id}/execute`）未接入。该路由已存在且可用，但沙箱当前部署形态存在需先处理的隔离问题，另行评估。

## 与 #320 的关系

无冲突：#320 改的是 `graph.py` / `runner.py` / `llm.py` / `requirements.txt`，本 PR 改的是 `skills.py` / `tools.py` / `config.py` / chart。两者均基于 main，可任意顺序合入。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
