### PR TITLE
feat(execution-factory): 公开面支持 bak_ AppKey 凭据

### DIFF
--- a/adp/execution-factory/operator-integration/server/drivenadapters/appkey.go
+++ b/adp/execution-factory/operator-integration/server/drivenadapters/appkey.go
@@ -1,0 +1,118 @@
+// Copyright openbkn.ai
+//
+// Licensed under the OpenBKN License. See LICENSE-OPENBKN.txt in the project root.
+
+// Package drivenadapters 定义驱动适配器
+// @file appkey.go
+// @description: 实现 AppKey 校验接口，由 bkn-safe 完成校验
+package drivenadapters
+
+import (
+	"context"
+	"net/http"
+	"os"
+	"sync"
+
+	jsoniter "github.com/json-iterator/go"
+
+	"github.com/openbkn-ai/adp/execution-factory/operator-integration/server/infra/config"
+	"github.com/openbkn-ai/adp/execution-factory/operator-integration/server/infra/errors"
+	"github.com/openbkn-ai/adp/execution-factory/operator-integration/server/infra/rest"
+	"github.com/openbkn-ai/adp/execution-factory/operator-integration/server/interfaces"
+	"github.com/openbkn-ai/adp/execution-factory/operator-integration/server/utils"
+)
+
+// appKeyIntrospectURI 是 bkn-safe 的 AppKey 校验端点（集群内 ClusterIP，免令牌）。
+// 响应结构对齐 OAuth2 introspection。
+const appKeyIntrospectURI = "/api/safe/v1/api-keys/introspect"
+
+type appKeyVerifier struct {
+	introspectURL string
+	logger        interfaces.Logger
+	httpClient    interfaces.HTTPClient
+}
+
+var (
+	appKeyOnce sync.Once
+	appKeyInst interfaces.AppKeyVerifier
+)
+
+// appKeyIntrospectResp 是 bkn-safe 的校验响应：任何失败都返回 200 {active:false}，
+// 成功时带出持有者身份。
+type appKeyIntrospectResp struct {
+	Active      bool   `json:"active"`
+	Sub         string `json:"sub"`          // 持有者 accessor id
+	AccountType string `json:"account_type"` // 持有者在 bkn-safe 中的 account_type
+	KeyID       string `json:"key_id"`
+}
+
+// NewAppKeyVerifier 构造由 bkn-safe 支撑的 AppKey 校验器。
+// 以下两种情况返回 nil，调用方将其视为「不支持 AppKey」并回落到 hydra：
+//   - AUTH_ENABLED=false，认证整体关闭
+//   - BKN_SAFE_URL 为空，无法访问 bkn-safe
+//
+// 该降级与 authorization_safe.go 中 BKN_SAFE_URL 缺失时回落的处理保持一致。
+func NewAppKeyVerifier() interfaces.AppKeyVerifier {
+	appKeyOnce.Do(func() {
+		if !config.GetAuthEnabled() {
+			return // appKeyInst 保持 nil
+		}
+		baseURL := os.Getenv("BKN_SAFE_URL")
+		if baseURL == "" {
+			config.NewConfigLoader().GetLogger().Warnf("[appkey] BKN_SAFE_URL empty; AppKey verification disabled")
+			return // appKeyInst 保持 nil
+		}
+		appKeyInst = &appKeyVerifier{
+			introspectURL: baseURL + appKeyIntrospectURI,
+			logger:        config.NewConfigLoader().GetLogger(),
+			httpClient:    rest.NewHTTPClient(),
+		}
+	})
+	return appKeyInst
+}
+
+// Verify 经 bkn-safe 把 AppKey 解析为持有者的 TokenInfo。
+// 结果结构与 hydra 内省持有者 OAuth 令牌的产出完全一致，
+// 因此下游的 AccountAuthContext 与全部授权判定不受凭据类型影响。
+func (v *appKeyVerifier) Verify(ctx context.Context, key string) (*interfaces.TokenInfo, error) {
+	header := map[string]string{"Content-Type": "application/json"}
+	_, resp, err := v.httpClient.Post(ctx, v.introspectURL, header, map[string]string{"token": key})
+	if err != nil {
+		v.logger.WithContext(ctx).Errorf("AppKey introspect request failed: %v", err)
+		return nil, errors.DefaultHTTPError(ctx, http.StatusUnauthorized, "api key is invalid")
+	}
+
+	introspect := &appKeyIntrospectResp{}
+	if err := jsoniter.Unmarshal(utils.ObjectToByte(resp), introspect); err != nil {
+		v.logger.WithContext(ctx).Warnf("AppKey introspect decode failed: %+v, resp:%+v", err, resp)
+		return nil, errors.DefaultHTTPError(ctx, http.StatusInternalServerError, err.Error())
+	}
+	if !introspect.Active {
+		return nil, errors.DefaultHTTPError(ctx, http.StatusUnauthorized, "api key is invalid")
+	}
+
+	return &interfaces.TokenInfo{
+		Active:     true,
+		VisitorID:  introspect.Sub,
+		VisitorTyp: appKeyVisitorType(introspect.AccountType),
+		AccountTyp: appKeyAccountType(introspect.AccountType),
+	}, nil
+}
+
+// appKeyVisitorType 把 bkn-safe 的 account_type 映射为访问者类型。
+// "app"（应用账户）映射为 Business，其余持有者视为实名访问者映射为 RealName，
+// 从而使普通用户的 AccountAuthContext.AccountType 与 OAuth 令牌路径一致。
+func appKeyVisitorType(accountType string) interfaces.VisitorType {
+	if accountType == "app" {
+		return interfaces.Business
+	}
+	return interfaces.RealName
+}
+
+// appKeyAccountType 把 bkn-safe 的 account_type 映射为账户类型。
+func appKeyAccountType(accountType string) interfaces.AccountType {
+	if accountType == "id_card" {
+		return interfaces.IDCard
+	}
+	return interfaces.Other
+}

--- a/adp/execution-factory/operator-integration/server/drivenadapters/appkey.go
+++ b/adp/execution-factory/operator-integration/server/drivenadapters/appkey.go
@@ -26,6 +26,12 @@ import (
 // 响应结构对齐 OAuth2 introspection。
 const appKeyIntrospectURI = "/api/safe/v1/api-keys/introspect"
 
+// appKeyIntrospectTimeout 限制校验请求的耗时。
+// rest.NewHTTPClient() 的默认超时是 600 秒，用在认证路径上意味着 bkn-safe 一旦 hang 住，
+// 单个请求会占住连接 10 分钟。认证必须快速失败，故与 authorization_safe.go 对 bkn-safe
+// 的调用取同一档超时。
+const appKeyIntrospectTimeout = 5
+
 type appKeyVerifier struct {
 	introspectURL string
 	logger        interfaces.Logger
@@ -65,7 +71,7 @@ func NewAppKeyVerifier() interfaces.AppKeyVerifier {
 		appKeyInst = &appKeyVerifier{
 			introspectURL: baseURL + appKeyIntrospectURI,
 			logger:        config.NewConfigLoader().GetLogger(),
-			httpClient:    rest.NewHTTPClient(),
+			httpClient:    rest.NewHTTPClientWithOptions(rest.HTTPClientOptions{TimeOut: appKeyIntrospectTimeout}),
 		}
 	})
 	return appKeyInst

--- a/adp/execution-factory/operator-integration/server/drivenadapters/appkey_test.go
+++ b/adp/execution-factory/operator-integration/server/drivenadapters/appkey_test.go
@@ -1,0 +1,133 @@
+// Copyright openbkn.ai
+//
+// Licensed under the OpenBKN License. See LICENSE-OPENBKN.txt in the project root.
+
+package drivenadapters
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/openbkn-ai/adp/execution-factory/operator-integration/server/interfaces"
+	"github.com/openbkn-ai/adp/execution-factory/operator-integration/server/mocks"
+	. "github.com/smartystreets/goconvey/convey"
+	"go.uber.org/mock/gomock"
+)
+
+func TestAppKeyVerify(t *testing.T) {
+	Convey("appKeyVerifier.Verify", t, func() {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+		logger := mocks.NewMockLogger(ctrl)
+		httpClient := mocks.NewMockHTTPClient(ctrl)
+		logger.EXPECT().WithContext(gomock.Any()).Return(logger).AnyTimes()
+
+		v := &appKeyVerifier{
+			introspectURL: "http://bkn-safe:3000/api/safe/v1/api-keys/introspect",
+			logger:        logger,
+			httpClient:    httpClient,
+		}
+
+		Convey("bkn-safe 不可达时返回 401，不泄露内部错误", func() {
+			logger.EXPECT().Errorf(gomock.Any(), gomock.Any()).Return()
+			httpClient.EXPECT().Post(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+				Return(0, nil, fmt.Errorf("connection refused to internal host"))
+
+			info, err := v.Verify(context.Background(), "bak_abc")
+			So(err, ShouldNotBeNil)
+			So(info, ShouldBeNil)
+			So(err.Error(), ShouldNotContainSubstring, "connection refused")
+		})
+
+		Convey("响应无法解析时返回错误", func() {
+			logger.EXPECT().Warnf(gomock.Any(), gomock.Any(), gomock.Any()).Return()
+			httpClient.EXPECT().Post(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+				Return(200, "not-an-object", nil)
+
+			info, err := v.Verify(context.Background(), "bak_abc")
+			So(err, ShouldNotBeNil)
+			So(info, ShouldBeNil)
+		})
+
+		Convey("active=false（Key 非法或已撤销）返回 401", func() {
+			httpClient.EXPECT().Post(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+				Return(200, &appKeyIntrospectResp{Active: false}, nil)
+
+			info, err := v.Verify(context.Background(), "bak_revoked")
+			So(err, ShouldNotBeNil)
+			So(info, ShouldBeNil)
+		})
+
+		Convey("普通用户 Key 解析为实名访问者", func() {
+			httpClient.EXPECT().Post(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+				Return(200, &appKeyIntrospectResp{
+					Active:      true,
+					Sub:         "owner-1",
+					AccountType: "other",
+					KeyID:       "kid-1",
+				}, nil)
+
+			info, err := v.Verify(context.Background(), "bak_abc")
+			So(err, ShouldBeNil)
+			So(info.Active, ShouldBeTrue)
+			So(info.VisitorID, ShouldEqual, "owner-1")
+			So(info.VisitorTyp, ShouldEqual, interfaces.RealName)
+			// 下游 AccountAuthContext 取的是 ToAccessorType()，必须与 OAuth 令牌路径一致
+			So(info.VisitorTyp.ToAccessorType(), ShouldEqual, interfaces.AccessorTypeUser)
+		})
+
+		Convey("应用账户 Key 解析为 Business", func() {
+			httpClient.EXPECT().Post(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+				Return(200, &appKeyIntrospectResp{
+					Active:      true,
+					Sub:         "app-1",
+					AccountType: "app",
+				}, nil)
+
+			info, err := v.Verify(context.Background(), "bak_app")
+			So(err, ShouldBeNil)
+			So(info.VisitorTyp, ShouldEqual, interfaces.Business)
+		})
+
+		Convey("id_card 账户映射为 IDCard 账户类型", func() {
+			httpClient.EXPECT().Post(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+				Return(200, &appKeyIntrospectResp{
+					Active:      true,
+					Sub:         "user-2",
+					AccountType: "id_card",
+				}, nil)
+
+			info, err := v.Verify(context.Background(), "bak_idcard")
+			So(err, ShouldBeNil)
+			So(info.AccountTyp, ShouldEqual, interfaces.IDCard)
+		})
+	})
+}
+
+func TestGetToken(t *testing.T) {
+	Convey("GetToken 凭据提取", t, func() {
+		Convey("Authorization 头剥掉 Bearer 前缀", func() {
+			c := newHydraTestContext()
+			c.Request.Header.Set("Authorization", "Bearer bak_from_auth")
+			So(GetToken(c), ShouldEqual, "bak_from_auth")
+		})
+
+		Convey("Authorization 为空时回落 X-Authorization", func() {
+			c := newHydraTestContext()
+			c.Request.Header.Set("X-Authorization", "bak_from_xauth")
+			So(GetToken(c), ShouldEqual, "bak_from_xauth")
+		})
+
+		Convey("两个头都为空时回落 token 查询参数", func() {
+			c := newHydraTestContext()
+			c.Request.URL.RawQuery = "token=bak_from_query"
+			So(GetToken(c), ShouldEqual, "bak_from_query")
+		})
+
+		Convey("无凭据时返回空串", func() {
+			c := newHydraTestContext()
+			So(GetToken(c), ShouldEqual, "")
+		})
+	})
+}

--- a/adp/execution-factory/operator-integration/server/drivenadapters/hydra.go
+++ b/adp/execution-factory/operator-integration/server/drivenadapters/hydra.go
@@ -117,7 +117,7 @@ func (h *hydraService) GenerateVisitor(c *gin.Context) (info *interfaces.TokenIn
 // Introspect token内省
 func (h *hydraService) Introspect(c *gin.Context) (info *interfaces.TokenInfo, err error) {
 	ctx := c.Request.Context()
-	token := getToken(c)
+	token := GetToken(c)
 	target := fmt.Sprintf("%s%s", h.adminAddress, introspectURI)
 	header := map[string]string{"Content-Type": "application/x-www-form-urlencoded"}
 	_, resp, err := h.httpClient.Post(ctx, target, header, []byte(fmt.Sprintf("token=%v", token)))
@@ -182,7 +182,9 @@ func (h *hydraService) Introspect(c *gin.Context) (info *interfaces.TokenInfo, e
 	return
 }
 
-func getToken(c *gin.Context) (token string) {
+// GetToken 从请求中提取凭据，依次尝试 Authorization、X-Authorization 两个头，
+// 都为空时回落到 token 查询参数。公开面认证中间件用它判断凭据类型（见 interfaces.AppKeyPrefix）。
+func GetToken(c *gin.Context) (token string) {
 	tokenID := c.GetHeader("Authorization")
 	if tokenID == "" {
 		tokenID = c.GetHeader("X-Authorization")

--- a/adp/execution-factory/operator-integration/server/driveradapters/middleware.go
+++ b/adp/execution-factory/operator-integration/server/driveradapters/middleware.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"io"
 	"net/http"
+	"strings"
 	"time"
 
 	"github.com/gin-gonic/gin"
@@ -15,6 +16,7 @@ import (
 	"github.com/openbkn-ai/bkn-comm-go/otel/oteltrace"
 	"go.opentelemetry.io/otel/attribute"
 
+	"github.com/openbkn-ai/adp/execution-factory/operator-integration/server/drivenadapters"
 	"github.com/openbkn-ai/adp/execution-factory/operator-integration/server/infra/common"
 	oerrors "github.com/openbkn-ai/adp/execution-factory/operator-integration/server/infra/errors"
 	"github.com/openbkn-ai/adp/execution-factory/operator-integration/server/infra/rest"
@@ -34,10 +36,20 @@ type apiLogModel struct {
 // middlewareIntrospectVerify 令牌内省中间件
 // 若未开启认证，则从header中获取accountID和accountType，生成匿名tokenInfo
 // 若开启认证，则从header中获取token，调用hydra.Introspect验证token，若验证失败则返回错误
-func middlewareIntrospectVerify(hydra interfaces.Hydra) gin.HandlerFunc {
+//
+// 凭据二选一：以 AppKey 前缀（bak_）开头的交给 bkn-safe 校验（用户自助签发的 API Key），
+// 其余 bearer token 走 hydra 内省。两条路产出同一个 TokenInfo，下游认证上下文一致。
+// appKeys 为 nil 时（AUTH_ENABLED=false 或 BKN_SAFE_URL 未配置）全部走 hydra。
+func middlewareIntrospectVerify(hydra interfaces.Hydra, appKeys interfaces.AppKeyVerifier) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		ctx := c.Request.Context()
-		tokenInfo, err := hydra.Introspect(c)
+		var tokenInfo *interfaces.TokenInfo
+		var err error
+		if token := drivenadapters.GetToken(c); appKeys != nil && strings.HasPrefix(token, interfaces.AppKeyPrefix) {
+			tokenInfo, err = appKeys.Verify(ctx, token)
+		} else {
+			tokenInfo, err = hydra.Introspect(c)
+		}
 		if err != nil {
 			rest.ReplyError(c, err)
 			c.Abort()

--- a/adp/execution-factory/operator-integration/server/driveradapters/middleware_test.go
+++ b/adp/execution-factory/operator-integration/server/driveradapters/middleware_test.go
@@ -1,0 +1,126 @@
+// Copyright openbkn.ai
+//
+// Licensed under the OpenBKN License. See LICENSE-OPENBKN.txt in the project root.
+
+package driveradapters
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/openbkn-ai/adp/execution-factory/operator-integration/server/infra/common"
+	"github.com/openbkn-ai/adp/execution-factory/operator-integration/server/interfaces"
+	"github.com/openbkn-ai/adp/execution-factory/operator-integration/server/mocks"
+	. "github.com/smartystreets/goconvey/convey"
+	"go.uber.org/mock/gomock"
+)
+
+// runIntrospectMiddleware 用给定凭据跑一遍公开面认证中间件，
+// 返回响应记录与中间件放行后下游看到的认证上下文（未放行时为 nil）。
+func runIntrospectMiddleware(
+	hydra interfaces.Hydra,
+	appKeys interfaces.AppKeyVerifier,
+	authorization string,
+) (*httptest.ResponseRecorder, *interfaces.AccountAuthContext) {
+	gin.SetMode(gin.TestMode)
+	w := httptest.NewRecorder()
+	c, engine := gin.CreateTestContext(w)
+
+	var seen *interfaces.AccountAuthContext
+	engine.Use(middlewareIntrospectVerify(hydra, appKeys))
+	engine.GET("/probe", func(c *gin.Context) {
+		seen, _ = common.GetAccountAuthContextFromCtx(c.Request.Context())
+		c.Status(http.StatusOK)
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/probe", nil)
+	if authorization != "" {
+		req.Header.Set("Authorization", authorization)
+	}
+	c.Request = req
+	engine.ServeHTTP(w, req)
+	return w, seen
+}
+
+func TestMiddlewareIntrospectVerifyCredentialRouting(t *testing.T) {
+	Convey("公开面认证中间件按凭据前缀分流", t, func() {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+		hydra := mocks.NewMockHydra(ctrl)
+		appKeys := mocks.NewMockAppKeyVerifier(ctrl)
+
+		Convey("bak_ 前缀走 bkn-safe，不碰 hydra", func() {
+			appKeys.EXPECT().Verify(gomock.Any(), "bak_abc").Return(&interfaces.TokenInfo{
+				Active:     true,
+				VisitorID:  "owner-1",
+				VisitorTyp: interfaces.RealName,
+			}, nil).Times(1)
+			// hydra 未设置 EXPECT，被调用即失败
+
+			w, seen := runIntrospectMiddleware(hydra, appKeys, "Bearer bak_abc")
+			So(w.Code, ShouldEqual, http.StatusOK)
+			So(seen, ShouldNotBeNil)
+			So(seen.AccountID, ShouldEqual, "owner-1")
+			So(seen.AccountType, ShouldEqual, interfaces.AccessorTypeUser)
+		})
+
+		Convey("普通 bearer token 走 hydra，不碰 bkn-safe", func() {
+			hydra.EXPECT().Introspect(gomock.Any()).Return(&interfaces.TokenInfo{
+				Active:     true,
+				VisitorID:  "user-1",
+				VisitorTyp: interfaces.RealName,
+			}, nil).Times(1)
+			// appKeys 未设置 EXPECT，被调用即失败
+
+			w, seen := runIntrospectMiddleware(hydra, appKeys, "Bearer ory_at_normal")
+			So(w.Code, ShouldEqual, http.StatusOK)
+			So(seen.AccountID, ShouldEqual, "user-1")
+		})
+
+		Convey("两条凭据路径产出一致的认证上下文", func() {
+			appKeys.EXPECT().Verify(gomock.Any(), gomock.Any()).Return(&interfaces.TokenInfo{
+				Active: true, VisitorID: "same-1", VisitorTyp: interfaces.RealName,
+			}, nil)
+			hydra.EXPECT().Introspect(gomock.Any()).Return(&interfaces.TokenInfo{
+				Active: true, VisitorID: "same-1", VisitorTyp: interfaces.RealName,
+			}, nil)
+
+			_, viaKey := runIntrospectMiddleware(hydra, appKeys, "Bearer bak_same")
+			_, viaToken := runIntrospectMiddleware(hydra, appKeys, "Bearer ory_at_same")
+			So(viaKey.AccountID, ShouldEqual, viaToken.AccountID)
+			So(viaKey.AccountType, ShouldEqual, viaToken.AccountType)
+		})
+
+		Convey("AppKey 校验失败时中止请求，下游不执行", func() {
+			appKeys.EXPECT().Verify(gomock.Any(), gomock.Any()).
+				Return(nil, fmt.Errorf("api key is invalid"))
+
+			w, seen := runIntrospectMiddleware(hydra, appKeys, "Bearer bak_revoked")
+			So(w.Code, ShouldNotEqual, http.StatusOK)
+			So(seen, ShouldBeNil)
+		})
+
+		Convey("verifier 为 nil 时 bak_ 凭据回落 hydra，不 panic", func() {
+			// AUTH_ENABLED=false 或 BKN_SAFE_URL 未配置的部署形态
+			hydra.EXPECT().Introspect(gomock.Any()).Return(&interfaces.TokenInfo{
+				Active: true, VisitorID: "fallback-1", VisitorTyp: interfaces.RealName,
+			}, nil).Times(1)
+
+			w, seen := runIntrospectMiddleware(hydra, nil, "Bearer bak_abc")
+			So(w.Code, ShouldEqual, http.StatusOK)
+			So(seen.AccountID, ShouldEqual, "fallback-1")
+		})
+
+		Convey("无凭据时走 hydra，由其决定放行或拒绝", func() {
+			hydra.EXPECT().Introspect(gomock.Any()).Return(&interfaces.TokenInfo{
+				Active: true, VisitorID: "", VisitorTyp: interfaces.RealName,
+			}, nil).Times(1)
+
+			w, _ := runIntrospectMiddleware(hydra, appKeys, "")
+			So(w.Code, ShouldEqual, http.StatusOK)
+		})
+	})
+}

--- a/adp/execution-factory/operator-integration/server/driveradapters/rest_public_handler.go
+++ b/adp/execution-factory/operator-integration/server/driveradapters/rest_public_handler.go
@@ -14,6 +14,7 @@ import (
 
 type restPublicHandler struct {
 	Hydra                 interfaces.Hydra
+	AppKeys               interfaces.AppKeyVerifier
 	OperatorRestHandler   OperatorRestHandler
 	ToolBoxRestHandler    ToolBoxRestHandler
 	MCPRestHandler        MCPRestHandler
@@ -30,6 +31,7 @@ type restPublicHandler struct {
 func NewRestPublicHandler() interfaces.HTTPRouterInterface {
 	return &restPublicHandler{
 		Hydra:                 drivenadapters.NewHydra(),
+		AppKeys:               drivenadapters.NewAppKeyVerifier(),
 		OperatorRestHandler:   NewOperatorRestHandler(),
 		ToolBoxRestHandler:    NewToolBoxRestHandler(),
 		MCPRestHandler:        NewMCPRestHandler(),
@@ -46,7 +48,7 @@ func NewRestPublicHandler() interfaces.HTTPRouterInterface {
 // RegisterPublic 注册公共路由
 func (r *restPublicHandler) RegisterRouter(engine *gin.RouterGroup) {
 	mws := []gin.HandlerFunc{}
-	mws = append(mws, middlewareRequestLog(r.Logger), middlewareTrace, middlewareIntrospectVerify(r.Hydra))
+	mws = append(mws, middlewareRequestLog(r.Logger), middlewareTrace, middlewareIntrospectVerify(r.Hydra, r.AppKeys))
 	engine.Use(mws...)
 	// 算子注册相关接口
 	r.OperatorRestHandler.RegisterPublic(engine)

--- a/adp/execution-factory/operator-integration/server/interfaces/drivenadapters.go
+++ b/adp/execution-factory/operator-integration/server/interfaces/drivenadapters.go
@@ -158,6 +158,17 @@ type Hydra interface {
 	GenerateVisitor(c *gin.Context) (info *TokenInfo, err error)
 }
 
+// AppKeyPrefix 标识用户自助签发的 AppKey（API Key）凭据。
+// 公开面认证中间件按此前缀分流：带该前缀的交 bkn-safe 校验，其余 bearer token 走 hydra 内省。
+const AppKeyPrefix = "bak_"
+
+// AppKeyVerifier 将 AppKey 解析为持有者的 TokenInfo，由 bkn-safe 完成校验。
+// 返回值与 Hydra.Introspect 同构，因此中间件可以把 AppKey 与 OAuth 令牌等价处理，
+// 下游的 AccountAuthContext 与授权判定完全一致。
+type AppKeyVerifier interface {
+	Verify(ctx context.Context, key string) (tokenInfo *TokenInfo, err error)
+}
+
 const (
 	// DisplayName 用户显示名称
 	DisplayName = "name"

--- a/adp/execution-factory/operator-integration/server/mocks/drivenadapters.go
+++ b/adp/execution-factory/operator-integration/server/mocks/drivenadapters.go
@@ -73,6 +73,45 @@ func (mr *MockHydraMockRecorder) Introspect(c any) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Introspect", reflect.TypeOf((*MockHydra)(nil).Introspect), c)
 }
 
+// MockAppKeyVerifier is a mock of AppKeyVerifier interface.
+type MockAppKeyVerifier struct {
+	ctrl     *gomock.Controller
+	recorder *MockAppKeyVerifierMockRecorder
+	isgomock struct{}
+}
+
+// MockAppKeyVerifierMockRecorder is the mock recorder for MockAppKeyVerifier.
+type MockAppKeyVerifierMockRecorder struct {
+	mock *MockAppKeyVerifier
+}
+
+// NewMockAppKeyVerifier creates a new mock instance.
+func NewMockAppKeyVerifier(ctrl *gomock.Controller) *MockAppKeyVerifier {
+	mock := &MockAppKeyVerifier{ctrl: ctrl}
+	mock.recorder = &MockAppKeyVerifierMockRecorder{mock}
+	return mock
+}
+
+// EXPECT returns an object that allows the caller to indicate expected use.
+func (m *MockAppKeyVerifier) EXPECT() *MockAppKeyVerifierMockRecorder {
+	return m.recorder
+}
+
+// Verify mocks base method.
+func (m *MockAppKeyVerifier) Verify(ctx context.Context, key string) (*interfaces.TokenInfo, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Verify", ctx, key)
+	ret0, _ := ret[0].(*interfaces.TokenInfo)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// Verify indicates an expected call of Verify.
+func (mr *MockAppKeyVerifierMockRecorder) Verify(ctx, key any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Verify", reflect.TypeOf((*MockAppKeyVerifier)(nil).Verify), ctx, key)
+}
+
 // MockUserManagement is a mock of UserManagement interface.
 type MockUserManagement struct {
 	ctrl     *gomock.Controller


### PR DESCRIPTION
Closes #325 · 父 Epic #324 批次 0-C

## 问题

执行工厂不认用户自助签发的 AppKey。`operator-integration` 与 `capabilities-lab` 的 `server/` 下均无 `bak_` 相关实现（检索零命中），凭据一律走 hydra 内省被拒。

同期平台其他服务都已支持：

- `adp/context-loader/agent-retrieval/server/driveradapters/middleware.go:54-70`
- `infra/bkn-agent/app/auth.py`
- `infra/mf-model-api/app/utils/app_utils.py`（#143）

执行工厂是当前的能力缺口。

## 改动

公开面认证中间件按前缀分流：`bak_` 开头的交 bkn-safe 校验，其余 bearer token 仍走 hydra 内省。两条路产出同一个 `TokenInfo`，下游 `AccountAuthContext` 与全部授权判定不受凭据类型影响。

实现对齐 `agent-retrieval` 的既有写法，未引入新模式。

| 文件 | 改动 |
| --- | --- |
| `interfaces/drivenadapters.go` | 新增 `AppKeyPrefix` 常量与 `AppKeyVerifier` 接口 |
| `drivenadapters/appkey.go` | 新增。打 bkn-safe 的 `/api/safe/v1/api-keys/introspect` |
| `drivenadapters/hydra.go` | `getToken` 导出为 `GetToken`（中间件在 `driveradapters` 包，需跨包读凭据判类型） |
| `driveradapters/middleware.go` | `middlewareIntrospectVerify` 增加 `appKeys` 参数与前缀分支 |
| `driveradapters/rest_public_handler.go` | 接线 |
| `mocks/drivenadapters.go` | 生成，纯新增 39 行 |

**仅作用于公开面 `/v1`。** `internal-v1` 走 header 身份构造，不涉及。

### 降级行为

`AUTH_ENABLED=false` 或 `BKN_SAFE_URL` 未配置时 `NewAppKeyVerifier()` 返回 nil，全部凭据回落 hydra——即与本 PR 之前的行为完全一致。这与 `authorization_safe.go:288-292` 中 `BKN_SAFE_URL` 缺失时回落 ISF 的处理保持一致。

## 测试

新增 `server/driveradapters/middleware_test.go`，是该包的**首个测试文件**。此前中间件契约（鉴权、租户隔离）在整个 Go 测试面上覆盖为零，所有 handler 测试都用 `gin.New()` 手工挂单个 handler 绕开了中间件链。

覆盖六种情形：

- `bak_` 前缀走 bkn-safe，不碰 hydra（hydra 未设 EXPECT，被调用即失败）
- 普通 bearer token 走 hydra，不碰 bkn-safe
- 两条凭据路径产出一致的认证上下文
- AppKey 校验失败时中止请求，下游不执行
- verifier 为 nil 时 `bak_` 凭据回落 hydra，不 panic
- 无凭据时走 hydra

`server/drivenadapters/appkey_test.go` 覆盖 Verify 的六个分支，含「bkn-safe 不可达时返回 401 且不泄露内部错误详情」。

CI 等价全量套件本地通过：`go list ./... | grep -v /server/tests | grep -v /server/mocks | xargs go test` → 21 包全绿。

## 遗留：可访问的操作面范围待定

本 PR 只打通**认证**——中间件解析身份，授权判定在下游，因此 `bak_` 凭据当前可访问其持有者本就有权访问的全部接口，含写操作。

平台既有实践中该类 Key 侧重读操作面。执行工厂的写操作（算子注册、发布/下线、执行代理、沙箱代码执行）是否应当放开需产品确认。若结论是限制为只读，需要额外加一层路由级门禁，属独立改动。

已在 #325 中记录该待决项。

## 验证建议

VM 上用现有 `bak_` Key 打 `GET /api/agent-operator-integration/v1/operator/info/list`，预期从 401 变 200；同时用 bearer token 打同一接口确认无回归。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
