### PR TITLE
fix(model-manager): harden LLM default/test/monitor APIs

### DIFF
--- a/docs/api/mf-model-manager/large-model.yaml
+++ b/docs/api/mf-model-manager/large-model.yaml
@@ -1,0 +1,273 @@
+openapi: 3.1.0
+info:
+  title: mf-model-manager large model APIs
+  version: 0.1.0
+  description: |
+    Large model management APIs maintained by mf-model-manager.
+
+    This document currently records the API contracts touched by the model
+    management bug fixes in `fix/model-management-bugs`.
+servers:
+  - url: /api/mf-model-manager/v1
+security:
+  - BearerAuth: []
+tags:
+  - name: ModelManager
+    description: Large model management APIs
+paths:
+  /llm/test:
+    post:
+      tags:
+        - ModelManager
+      summary: Test large model connection
+      operationId: testLargeModelConnection
+      description: |
+        Tests whether the submitted large model configuration can reach the
+        upstream model service.
+
+        For `model_series=openai`, the service sends a real Azure OpenAI chat
+        completions request to the configured deployment. Invalid `api_url`,
+        `api_model` or `api_key` values return `400` instead of being reported
+        as success.
+
+        Successful responses are normalized to `{ "status": "ok", "id": "..." }`.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/LlmTestRequest'
+            examples:
+              existingModel:
+                summary: Test an existing model by id
+                value:
+                  model_id: "1234567890123456789"
+              changedOpenAIConfig:
+                summary: Test changed OpenAI series config
+                value:
+                  change: true
+                  model_series: openai
+                  model_type: llm
+                  model_config:
+                    api_url: https://example.openai.azure.com/
+                    api_model: gpt-4o
+                    api_key: sk_xxx
+      responses:
+        '200':
+          description: Test connection succeeded
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/StatusResponse'
+              examples:
+                success:
+                  value:
+                    status: ok
+                    id: "1234567890123456789"
+        '400':
+          description: Test connection failed or request parameters are invalid
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/FastApiError'
+        '500':
+          description: Internal service error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/FastApiError'
+  /llm/default/edit:
+    post:
+      tags:
+        - ModelManager
+      summary: Set or clear default large model
+      operationId: editDefaultLargeModel
+      description: |
+        Sets or clears the default large model.
+
+        `default=true` marks the model as the default model and clears the
+        previous default. `default=false` clears the default flag from the
+        specified model. The response includes the resulting default state.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/EditDefaultModelRequest'
+            examples:
+              setDefault:
+                value:
+                  model_id: "1234567890123456789"
+                  default: true
+              clearDefault:
+                value:
+                  model_id: "1234567890123456789"
+                  default: false
+      responses:
+        '200':
+          description: Default model state updated
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/EditDefaultModelResponse'
+              examples:
+                clearDefault:
+                  value:
+                    status: ok
+                    id: "1234567890123456789"
+                    default: false
+        '400':
+          description: Invalid request or model does not exist
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/FastApiError'
+        '403':
+          description: Current user is not allowed to edit the default model
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/FastApiError'
+        '500':
+          description: Internal service error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/FastApiError'
+  /llm/monitor/overview:
+    get:
+      tags:
+        - ModelManager
+      summary: Get large model monitor overview
+      operationId: getLargeModelMonitorOverview
+      description: |
+        Returns large model usage metrics in the requested date range.
+
+        `start_time` and `end_time` must use `YYYY-MM-DD` format. `start_time`
+        must be earlier than or equal to `end_time`; otherwise the service
+        returns `400`.
+
+        The aggregate result only includes records whose `f_model_id` still
+        exists in `t_llm_model`, so non-current or stale model operation records
+        are excluded from the overview.
+      parameters:
+        - name: start_time
+          in: query
+          required: true
+          schema:
+            type: string
+            format: date
+          example: "2026-07-01"
+        - name: end_time
+          in: query
+          required: true
+          schema:
+            type: string
+            format: date
+          example: "2026-07-20"
+        - name: model_id
+          in: query
+          required: false
+          schema:
+            type: string
+          description: Optional large model id. Empty means all visible large models.
+      responses:
+        '200':
+          description: Monitor overview returned
+          content:
+            application/json:
+              schema:
+                type: object
+                additionalProperties: true
+        '400':
+          description: Missing or invalid date range
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/FastApiError'
+        '500':
+          description: Internal service error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/FastApiError'
+components:
+  securitySchemes:
+    BearerAuth:
+      type: http
+      scheme: bearer
+      bearerFormat: JWT
+  schemas:
+    LlmTestRequest:
+      type: object
+      properties:
+        model_id:
+          type: string
+          description: Existing large model id. Used when testing a saved model.
+        change:
+          type: boolean
+          default: false
+          description: Whether to test the submitted config instead of the saved config.
+        model_series:
+          type: string
+          description: Model provider or protocol series.
+          examples: [openai, claude, others]
+        model_type:
+          type: string
+          description: Large model type.
+          enum: [llm, rlm, vu]
+        model_config:
+          type: object
+          additionalProperties: true
+          properties:
+            api_url:
+              type: string
+            api_model:
+              type: string
+            api_key:
+              type: string
+          description: Upstream model service configuration.
+    EditDefaultModelRequest:
+      type: object
+      required:
+        - model_id
+        - default
+      properties:
+        model_id:
+          type: string
+          description: Large model id.
+        default:
+          type: boolean
+          description: true sets the model as default; false clears its default flag.
+    StatusResponse:
+      type: object
+      required:
+        - status
+      properties:
+        status:
+          type: string
+          const: ok
+        id:
+          type: string
+    EditDefaultModelResponse:
+      allOf:
+        - $ref: '#/components/schemas/StatusResponse'
+        - type: object
+          required:
+            - default
+          properties:
+            default:
+              type: boolean
+              description: Resulting default state.
+    FastApiError:
+      type: object
+      additionalProperties: true
+      properties:
+        code:
+          type: string
+        description:
+          type: string
+        detail:
+          type: string
+        solution:
+          type: string

--- a/infra/mf-model-manager/app/controller/llm_controller.py
+++ b/infra/mf-model-manager/app/controller/llm_controller.py
@@ -975,6 +975,7 @@ async def get_monitor_data(userId, language, model_id):
 
 
 async def edit_default_model(model_para, userId, language):
+    global redis_util
     if base_config.AUTH_ENABLED and userId != "266c6a42-6131-4d62-8f39-853e7093701c":
         error_dict = ModelFactory_Router_ParamError_TypeError_Error.copy()
         error_dict['description'] = "无操作权限"
@@ -1002,6 +1003,16 @@ async def edit_default_model(model_para, userId, language):
             return JSONResponse(status_code=400, content=error_dict)
 
         # 获取当前默认模型
+        set_default = model_para["default"]
+        if not set_default:
+            llm_model_dao.update_model_default_status(model_id, False)
+            default_cache_name = "default_model_3ed523"
+            default_cache_key = f"dip:model-api:llm:{default_cache_name}:list"
+            if redis_util is None:
+                redis_util = await get_redis_util()
+            await redis_util.delete_str(default_cache_key)
+            return JSONResponse(status_code=200, content={"status": "ok", "id": model_id, "default": False})
+
         old_default_data = llm_model_dao.get_default_model()
         old_model_id = ""
         if old_default_data:
@@ -1021,11 +1032,10 @@ async def edit_default_model(model_para, userId, language):
         llm_model_dao.update_model_default_status(model_id, True)
         default_cache_name = "default_model_3ed523"
         default_cache_key = f"dip:model-api:llm:{default_cache_name}:list"
-        global redis_util
         if redis_util is None:
             redis_util = await get_redis_util()
         await redis_util.delete_str(default_cache_key)
-        content = {"status": "ok", "id": model_id}
+        content = {"status": "ok", "id": model_id, "default": True}
         return JSONResponse(status_code=200, content=content)
 
     except Exception as e:

--- a/infra/mf-model-manager/app/controller/llm_controller.py
+++ b/infra/mf-model-manager/app/controller/llm_controller.py
@@ -1047,22 +1047,29 @@ async def get_overview_data(userId, language, model_id, start_time, end_time):
     try:
         if not start_time:
             error_dict = ModelFactory_Router_ParamError_ParamMissing_Error.copy()
-            error_dict["deatil"] = "Param start_time is required"
+            error_dict["detail"] = "Param start_time is required"
             return JSONResponse(status_code=400, content=error_dict)
         if not end_time:
             error_dict = ModelFactory_Router_ParamError_ParamMissing_Error.copy()
-            error_dict["deatil"] = "Param end_time is required"
+            error_dict["detail"] = "Param end_time is required"
             return JSONResponse(status_code=400, content=error_dict)
 
         # 验证 start_time 和 end_time 的格式是否为 YYYY-MM-DD
         date_pattern = r'^\d{4}-\d{2}-\d{2}$'
         if not re.match(date_pattern, start_time):
             error_dict = ModelFactory_Router_ParamError_TypeError_Error.copy()
-            error_dict["deatil"] = "Param start_time must be in YYYY-MM-DD format"
+            error_dict["detail"] = "Param start_time must be in YYYY-MM-DD format"
             return JSONResponse(status_code=400, content=error_dict)
         if not re.match(date_pattern, end_time):
             error_dict = ModelFactory_Router_ParamError_TypeError_Error.copy()
-            error_dict["deatil"] = "Param end_time must be in YYYY-MM-DD format"
+            error_dict["detail"] = "Param end_time must be in YYYY-MM-DD format"
+            return JSONResponse(status_code=400, content=error_dict)
+        start_date = datetime.strptime(start_time, "%Y-%m-%d")
+        end_date = datetime.strptime(end_time, "%Y-%m-%d")
+        if start_date > end_date:
+            error_dict = ModelFactory_Router_ParamError_TypeError_Error.copy()
+            error_dict["description"] = "Invalid date range"
+            error_dict["detail"] = "Param start_time must be earlier than or equal to end_time"
             return JSONResponse(status_code=400, content=error_dict)
 
         core_metrics, trend_analysis, qps_analysis = llm_model_dao.get_overview_data(model_id, start_time, end_time,

--- a/infra/mf-model-manager/app/dao/llm_model_dao.py
+++ b/infra/mf-model-manager/app/dao/llm_model_dao.py
@@ -426,13 +426,14 @@ class ModelDao():
                 SUM(f_input_tokens + f_output_tokens) AS total_tokens,
                 SUM(f_input_tokens) AS input_tokens,
                 SUM(f_output_tokens) AS output_tokens
-            FROM t_model_op_detail
-            WHERE DATE(f_create_time) BETWEEN '{start_time}' AND '{end_time}'
+            FROM t_model_op_detail d
+            INNER JOIN t_llm_model m ON d.f_model_id = m.f_model_id
+            WHERE DATE(d.f_create_time) BETWEEN '{start_time}' AND '{end_time}'
             """
         if model_id:
-            sql1 += f" and f_model_id='{model_id}'"
+            sql1 += f" and d.f_model_id='{model_id}'"
         if userId != "266c6a42-6131-4d62-8f39-853e7093701c":
-            sql1 += f" and f_user_id='{userId}'"
+            sql1 += f" and d.f_user_id='{userId}'"
         cursor.execute(sql1)
         core_metrics = cursor.fetchall()
         sql2 = f"""
@@ -450,22 +451,25 @@ class ModelDao():
             END AS avg_first_time,
             SUM(f_input_tokens + f_output_tokens) / 86400.0 AS avg_rate,
             ROUND(SUM(f_total_count) / 86400.0, 6) AS avg_qps
-        FROM t_model_op_detail
-        WHERE DATE(f_create_time) BETWEEN '{start_time}' AND '{end_time}'"""
+        FROM t_model_op_detail d
+        INNER JOIN t_llm_model m ON d.f_model_id = m.f_model_id
+        WHERE DATE(d.f_create_time) BETWEEN '{start_time}' AND '{end_time}'"""
         if model_id:
-            sql2 += f" and f_model_id='{model_id}'"
+            sql2 += f" and d.f_model_id='{model_id}'"
         if userId != "266c6a42-6131-4d62-8f39-853e7093701c":
-            sql2 += f" and f_user_id='{userId}'"
-        sql2 += " GROUP BY DATE(f_create_time) ORDER BY date_group"
+            sql2 += f" and d.f_user_id='{userId}'"
+        sql2 += " GROUP BY DATE(d.f_create_time) ORDER BY date_group"
         cursor.execute(sql2)
         trend_analysis = cursor.fetchall()
-        sql3 = f"""SELECT DATE_FORMAT(f_create_time, '%Y-%m-%d %H:%i:00') AS date_group,ROUND(SUM(f_total_count) / 300, 6) AS avg_qps
-                  FROM t_model_op_detail WHERE DATE(f_create_time) BETWEEN '{start_time}' AND '{end_time}'"""
+        sql3 = f"""SELECT DATE_FORMAT(d.f_create_time, '%Y-%m-%d %H:%i:00') AS date_group,ROUND(SUM(f_total_count) / 300, 6) AS avg_qps
+                  FROM t_model_op_detail d
+                  INNER JOIN t_llm_model m ON d.f_model_id = m.f_model_id
+                  WHERE DATE(d.f_create_time) BETWEEN '{start_time}' AND '{end_time}'"""
         if model_id:
-            sql3 += f" and f_model_id='{model_id}'"
+            sql3 += f" and d.f_model_id='{model_id}'"
         if userId != "266c6a42-6131-4d62-8f39-853e7093701c":
-            sql3 += f" and f_user_id='{userId}'"
-        sql3 += " GROUP BY DATE_FORMAT(f_create_time, '%Y-%m-%d %H:%i:00') ORDER BY date_group desc limit 96"
+            sql3 += f" and d.f_user_id='{userId}'"
+        sql3 += " GROUP BY DATE_FORMAT(d.f_create_time, '%Y-%m-%d %H:%i:00') ORDER BY date_group desc limit 96"
         cursor.execute(sql3)
         qps_analysis = cursor.fetchall()
         return core_metrics, trend_analysis, qps_analysis

--- a/infra/mf-model-manager/app/dao/llm_model_dao.py
+++ b/infra/mf-model-manager/app/dao/llm_model_dao.py
@@ -414,18 +414,18 @@ class ModelDao():
     def get_overview_data(self, model_id, start_time, end_time, userId, connection, cursor):
         # 计算end_time向前8小时的时间
         sql1 = f"""SELECT
-                SUM(f_total_count) AS total_usage,
+                SUM(d.f_total_count) AS total_usage,
                 CASE
-                    WHEN SUM(f_total_count) = 0 THEN 0
-                    ELSE (SUM(f_failed_count) / SUM(f_total_count))
+                    WHEN SUM(d.f_total_count) = 0 THEN 0
+                    ELSE (SUM(d.f_failed_count) / SUM(d.f_total_count))
                 END AS error_rate,
                 CASE
-                    WHEN SUM(f_total_count) = 0 THEN 0
-                    ELSE SUM(f_average_total_time * f_total_count) / SUM(f_total_count)
+                    WHEN SUM(d.f_total_count) = 0 THEN 0
+                    ELSE SUM(d.f_average_total_time * d.f_total_count) / SUM(d.f_total_count)
                 END AS avg_response_time,
-                SUM(f_input_tokens + f_output_tokens) AS total_tokens,
-                SUM(f_input_tokens) AS input_tokens,
-                SUM(f_output_tokens) AS output_tokens
+                SUM(d.f_input_tokens + d.f_output_tokens) AS total_tokens,
+                SUM(d.f_input_tokens) AS input_tokens,
+                SUM(d.f_output_tokens) AS output_tokens
             FROM t_model_op_detail d
             INNER JOIN t_llm_model m ON d.f_model_id = m.f_model_id
             WHERE DATE(d.f_create_time) BETWEEN '{start_time}' AND '{end_time}'
@@ -438,19 +438,19 @@ class ModelDao():
         core_metrics = cursor.fetchall()
         sql2 = f"""
             SELECT
-            DATE(f_create_time) AS date_group,
-            SUM(f_input_tokens) AS input_tokens,
-            SUM(f_output_tokens) AS output_tokens,
+            DATE(d.f_create_time) AS date_group,
+            SUM(d.f_input_tokens) AS input_tokens,
+            SUM(d.f_output_tokens) AS output_tokens,
             CASE
-                WHEN SUM(f_total_count) = 0 THEN 0
-                ELSE SUM(f_average_total_time * f_total_count) / SUM(f_total_count)
+                WHEN SUM(d.f_total_count) = 0 THEN 0
+                ELSE SUM(d.f_average_total_time * d.f_total_count) / SUM(d.f_total_count)
             END AS avg_total_time,
             CASE
-                WHEN SUM(f_total_count) = 0 THEN 0
-                ELSE SUM(f_average_first_time * f_total_count) / SUM(f_total_count)
+                WHEN SUM(d.f_total_count) = 0 THEN 0
+                ELSE SUM(d.f_average_first_time * d.f_total_count) / SUM(d.f_total_count)
             END AS avg_first_time,
-            SUM(f_input_tokens + f_output_tokens) / 86400.0 AS avg_rate,
-            ROUND(SUM(f_total_count) / 86400.0, 6) AS avg_qps
+            SUM(d.f_input_tokens + d.f_output_tokens) / 86400.0 AS avg_rate,
+            ROUND(SUM(d.f_total_count) / 86400.0, 6) AS avg_qps
         FROM t_model_op_detail d
         INNER JOIN t_llm_model m ON d.f_model_id = m.f_model_id
         WHERE DATE(d.f_create_time) BETWEEN '{start_time}' AND '{end_time}'"""
@@ -461,7 +461,7 @@ class ModelDao():
         sql2 += " GROUP BY DATE(d.f_create_time) ORDER BY date_group"
         cursor.execute(sql2)
         trend_analysis = cursor.fetchall()
-        sql3 = f"""SELECT DATE_FORMAT(d.f_create_time, '%Y-%m-%d %H:%i:00') AS date_group,ROUND(SUM(f_total_count) / 300, 6) AS avg_qps
+        sql3 = f"""SELECT DATE_FORMAT(d.f_create_time, '%Y-%m-%d %H:%i:00') AS date_group,ROUND(SUM(d.f_total_count) / 300, 6) AS avg_qps
                   FROM t_model_op_detail d
                   INNER JOIN t_llm_model m ON d.f_model_id = m.f_model_id
                   WHERE DATE(d.f_create_time) BETWEEN '{start_time}' AND '{end_time}'"""

--- a/infra/mf-model-manager/app/test/test_model_controller.py
+++ b/infra/mf-model-manager/app/test/test_model_controller.py
@@ -221,7 +221,10 @@ class TestTestModel(TestCase):
     def test_test_model_fail_openai_non_200(self):
         loop = asyncio.new_event_loop()
         asyncio.set_event_loop(loop)
-        session = self._Session(self._Response(401, '{"error":"invalid api key"}'))
+        session = self._Session(self._Response(
+            401,
+            '{"error":{"code":"AuthenticationError","message":"the API key or AK/SK in the request is missing or invalid","type":"Unauthorized"}}'
+        ))
         verify_utils.aiohttp.ClientSession = mock.Mock(return_value=session)
         request = {"model_id": "111"}
         llm_model_dao.get_data_from_model_list_by_id = mock.Mock(return_value=[{
@@ -235,7 +238,10 @@ class TestTestModel(TestCase):
         res = loop.run_until_complete(
             llm_controller.test_model(request, "111", "zh"))
         self.assertEqual(res.status_code, 400)
-        self.assertEqual(json.loads(res.body)["code"], "ModelFactory.ModelController.TestModel.Error")
+        body = json.loads(res.body)
+        self.assertEqual(body["code"], "ModelFactory.ModelController.TestModel.Error")
+        self.assertEqual(body["description"], "模型服务认证失败，请检查 API Key、AK/SK 或授权配置")
+        self.assertEqual(body["solution"], "模型服务认证失败，请检查 API Key、AK/SK 或授权配置")
 
     def test_test_model_fail_unreachable(self):
         # 非 openai series 走真实 HTTP，连接失败 -> 返回 TestModel.Error

--- a/infra/mf-model-manager/app/test/test_model_controller.py
+++ b/infra/mf-model-manager/app/test/test_model_controller.py
@@ -359,6 +359,57 @@ class TestCheckModel(TestCase):
         self.assertEqual(json.loads(res.body)["model_id"], "111")
 
 
+class TestEditDefaultModel(TestCase):
+    def setUp(self) -> None:
+        self.check_model_is_exist = llm_model_dao.check_model_is_exist
+        self.get_default_model = llm_model_dao.get_default_model
+        self.update_model_default_status = llm_model_dao.update_model_default_status
+        self.redis_util = llm_controller.redis_util
+
+    def tearDown(self) -> None:
+        llm_model_dao.check_model_is_exist = self.check_model_is_exist
+        llm_model_dao.get_default_model = self.get_default_model
+        llm_model_dao.update_model_default_status = self.update_model_default_status
+        llm_controller.redis_util = self.redis_util
+        StandLogger.stand_log_shutdown()
+
+    def _redis_mock(self):
+        redis_mock = mock.MagicMock()
+        redis_mock.delete_str = mock.AsyncMock(return_value=None)
+        return redis_mock
+
+    def test_edit_default_model_unsets_current_default(self):
+        loop = asyncio.new_event_loop()
+        asyncio.set_event_loop(loop)
+        llm_controller.redis_util = self._redis_mock()
+        llm_model_dao.check_model_is_exist = mock.Mock(return_value=True)
+        llm_model_dao.get_default_model = mock.Mock(return_value=[{"f_model_id": "111"}])
+        llm_model_dao.update_model_default_status = mock.Mock(return_value=None)
+
+        res = loop.run_until_complete(
+            llm_controller.edit_default_model({"model_id": "111", "default": False}, "111", "zh"))
+
+        body = json.loads(res.body)
+        self.assertEqual(res.status_code, 200)
+        self.assertEqual(body["default"], False)
+        llm_model_dao.update_model_default_status.assert_called_once_with("111", False)
+        llm_model_dao.get_default_model.assert_not_called()
+
+    def test_edit_default_model_rejects_duplicate_set_default(self):
+        loop = asyncio.new_event_loop()
+        asyncio.set_event_loop(loop)
+        llm_controller.redis_util = self._redis_mock()
+        llm_model_dao.check_model_is_exist = mock.Mock(return_value=True)
+        llm_model_dao.get_default_model = mock.Mock(return_value=[{"f_model_id": "111"}])
+        llm_model_dao.update_model_default_status = mock.Mock(return_value=None)
+
+        res = loop.run_until_complete(
+            llm_controller.edit_default_model({"model_id": "111", "default": True}, "111", "zh"))
+
+        self.assertEqual(res.status_code, 400)
+        llm_model_dao.update_model_default_status.assert_not_called()
+
+
 if __name__ == '__main__':
     import unittest
 

--- a/infra/mf-model-manager/app/test/test_model_controller.py
+++ b/infra/mf-model-manager/app/test/test_model_controller.py
@@ -1,12 +1,11 @@
 from datetime import datetime
 from unittest import TestCase, mock
 
-from llmadapter.llms.llm_factory import llm_factory
 from sse_starlette import EventSourceResponse
 
 from app.dao.llm_model_dao import llm_model_dao
 from app.logs.stand_log import StandLogger
-from app.utils import llm_utils
+from app.utils import llm_utils, verify_utils
 from app.controller import llm_controller
 import asyncio
 import json
@@ -155,15 +154,51 @@ class TestAddModel(TestCase):
 class TestTestModel(TestCase):
     def setUp(self) -> None:
         self.get_data_from_model_list_by_id = llm_model_dao.get_data_from_model_list_by_id
+        self.ClientSession = verify_utils.aiohttp.ClientSession
 
     def tearDown(self) -> None:
         llm_model_dao.get_data_from_model_list_by_id = self.get_data_from_model_list_by_id
+        verify_utils.aiohttp.ClientSession = self.ClientSession
         StandLogger.stand_log_shutdown()
 
+    class _Response:
+        def __init__(self, status, body="{}"):
+            self.status = status
+            self.body = body
+            self.encoding = None
+            self.content = []
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb):
+            return False
+
+        async def text(self):
+            return self.body
+
+    class _Session:
+        def __init__(self, response):
+            self.response = response
+            self.post_args = None
+            self.post_kwargs = None
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb):
+            return False
+
+        def post(self, *args, **kwargs):
+            self.post_args = args
+            self.post_kwargs = kwargs
+            return self.response
+
     def test_test_model_success_openai(self):
-        # series=openai 时 llm_test 不发真实请求，直接返回 status=True
         loop = asyncio.new_event_loop()
         asyncio.set_event_loop(loop)
+        session = self._Session(self._Response(200))
+        verify_utils.aiohttp.ClientSession = mock.Mock(return_value=session)
         request = {"model_id": "111"}
         llm_model_dao.get_data_from_model_list_by_id = mock.Mock(return_value=[{
             "f_model_id": "111",
@@ -175,7 +210,32 @@ class TestTestModel(TestCase):
         }])
         res = loop.run_until_complete(
             llm_controller.test_model(request, "111", "zh"))
-        self.assertEqual(json.loads(res.body)["res"]["status"], True)
+        self.assertEqual(json.loads(res.body)["status"], "ok")
+        self.assertEqual(session.post_args[0],
+                         "https://artificial-intelligence-01.openai.azure.com/"
+                         "openai/deployments/gpt-4-32k/chat/completions"
+                         "?api-version=2023-05-15&api-type=azure")
+        self.assertEqual(session.post_kwargs["json"]["model"], "gpt-4-32k")
+        self.assertEqual(session.post_kwargs["headers"], {"api-key": "111"})
+
+    def test_test_model_fail_openai_non_200(self):
+        loop = asyncio.new_event_loop()
+        asyncio.set_event_loop(loop)
+        session = self._Session(self._Response(401, '{"error":"invalid api key"}'))
+        verify_utils.aiohttp.ClientSession = mock.Mock(return_value=session)
+        request = {"model_id": "111"}
+        llm_model_dao.get_data_from_model_list_by_id = mock.Mock(return_value=[{
+            "f_model_id": "111",
+            "f_create_by": "111",
+            "f_is_delete": 0,
+            "f_model_config": '{"api_key": "bad-key", "api_model": "bad-model", "api_url": "https://example.invalid/v1/chat/completions"}',
+            "f_model_series": "openai",
+            "f_model_type": "chat",
+        }])
+        res = loop.run_until_complete(
+            llm_controller.test_model(request, "111", "zh"))
+        self.assertEqual(res.status_code, 400)
+        self.assertEqual(json.loads(res.body)["code"], "ModelFactory.ModelController.TestModel.Error")
 
     def test_test_model_fail_unreachable(self):
         # 非 openai series 走真实 HTTP，连接失败 -> 返回 TestModel.Error

--- a/infra/mf-model-manager/app/test/test_model_controller.py
+++ b/infra/mf-model-manager/app/test/test_model_controller.py
@@ -410,6 +410,28 @@ class TestEditDefaultModel(TestCase):
         llm_model_dao.update_model_default_status.assert_not_called()
 
 
+class TestModelOverviewData(TestCase):
+    def setUp(self) -> None:
+        self.get_overview_data = llm_model_dao.get_overview_data
+
+    def tearDown(self) -> None:
+        llm_model_dao.get_overview_data = self.get_overview_data
+        StandLogger.stand_log_shutdown()
+
+    def test_get_overview_data_rejects_reversed_date_range(self):
+        loop = asyncio.new_event_loop()
+        asyncio.set_event_loop(loop)
+        llm_model_dao.get_overview_data = mock.Mock(return_value=([], [], []))
+
+        res = loop.run_until_complete(
+            llm_controller.get_overview_data("111", "zh", "", "2026-07-14", "2026-07-13"))
+
+        body = json.loads(res.body)
+        self.assertEqual(res.status_code, 400)
+        self.assertEqual(body["detail"], "Param start_time must be earlier than or equal to end_time")
+        llm_model_dao.get_overview_data.assert_not_called()
+
+
 if __name__ == '__main__':
     import unittest
 

--- a/infra/mf-model-manager/app/test/test_model_dao.py
+++ b/infra/mf-model-manager/app/test/test_model_dao.py
@@ -386,6 +386,47 @@ class TestGetModelDefaultParas(TestCase):
 # 对应测试类（TestRenameModel / TestGetApiModelByModelType）随之删除。
 
 
+class TestGetOverviewData(TestCase):
+    def setUp(self) -> None:
+        self.mysqlPool = PymysqlPool
+
+    def tearDown(self) -> None:
+        PymysqlPool = self.mysqlPool
+        StandLogger.stand_log_shutdown()
+
+    def test_get_overview_data_scopes_all_to_current_llm_models(self):
+        m1 = mock.MagicMock()
+        m2 = mock.MagicMock()
+        m1.connection.return_value = m2
+        m3 = mock.MagicMock()
+        m3.fetchall.return_value = []
+        m2.cursor.return_value = m3
+        PymysqlPool.get_pool = mock.Mock(return_value=m1)
+
+        llm_model_dao.get_overview_data("", "2026-07-13", "2026-07-14", "266c6a42-6131-4d62-8f39-853e7093701c")
+
+        executed_sql = "\n".join(call.args[0] for call in m3.execute.call_args_list)
+        self.assertEqual(m3.execute.call_count, 3)
+        self.assertEqual(executed_sql.count("INNER JOIN t_llm_model m ON d.f_model_id = m.f_model_id"), 3)
+        self.assertIn("FROM t_model_op_detail d", executed_sql)
+        self.assertNotIn(" t_small_model ", executed_sql)
+
+    def test_get_overview_data_filters_by_llm_model_id_alias(self):
+        m1 = mock.MagicMock()
+        m2 = mock.MagicMock()
+        m1.connection.return_value = m2
+        m3 = mock.MagicMock()
+        m3.fetchall.return_value = []
+        m2.cursor.return_value = m3
+        PymysqlPool.get_pool = mock.Mock(return_value=m1)
+
+        llm_model_dao.get_overview_data("model-1", "2026-07-13", "2026-07-14", "user-1")
+
+        executed_sql = "\n".join(call.args[0] for call in m3.execute.call_args_list)
+        self.assertEqual(executed_sql.count("and d.f_model_id='model-1'"), 3)
+        self.assertEqual(executed_sql.count("and d.f_user_id='user-1'"), 3)
+
+
 if __name__ == '__main__':
     import unittest
 

--- a/infra/mf-model-manager/app/test/test_model_dao.py
+++ b/infra/mf-model-manager/app/test/test_model_dao.py
@@ -409,6 +409,10 @@ class TestGetOverviewData(TestCase):
         self.assertEqual(m3.execute.call_count, 3)
         self.assertEqual(executed_sql.count("INNER JOIN t_llm_model m ON d.f_model_id = m.f_model_id"), 3)
         self.assertIn("FROM t_model_op_detail d", executed_sql)
+        self.assertIn("DATE(d.f_create_time) AS date_group", executed_sql)
+        self.assertIn("DATE_FORMAT(d.f_create_time", executed_sql)
+        self.assertNotIn("DATE(f_create_time)", executed_sql)
+        self.assertNotIn("SUM(f_total_count)", executed_sql)
         self.assertNotIn(" t_small_model ", executed_sql)
 
     def test_get_overview_data_filters_by_llm_model_id_alias(self):

--- a/infra/mf-model-manager/app/utils/verify_utils.py
+++ b/infra/mf-model-manager/app/utils/verify_utils.py
@@ -3,8 +3,6 @@ import json
 import aiohttp
 from fastapi.responses import JSONResponse
 from func_timeout import func_set_timeout
-from llmadapter.llms.llm_factory import llm_factory
-from llmadapter.schema import AIMessage
 from urllib3.exceptions import MaxRetryError
 from app.commons.errors import ModelFactory_ModelController_TestModel_Error_Error, LLMTestError
 from app.logs.stand_log import StandLogger
@@ -13,40 +11,45 @@ from app.core.config import base_config
 
 @func_set_timeout(30)
 async def llm_test(series, config, llm_id, user_id, model_type):
-    message = [AIMessage(content="你是")]
     content = "测试连接失败，请重新检查信息"
-    prompt = "你是"
     # 区分openai和其他模型
     if series == 'openai':
         try:
-            try:
-                if "api_key" not in config.keys():
-                    LLMTestError['description'] = "api_key 参数缺失"
-                    LLMTestError['detail'] = "openai大模型需要 api_key"
-                    return JSONResponse(status_code=500, content=LLMTestError)
-                llm = llm_factory.create_llm(llm_type="openai",
-                                             api_type="azure",
-                                             api_version="2023-03-15-preview",
-                                             openai_api_base=config['api_url'],
-                                             openai_api_key=config['api_key'],
-                                             engine=config['api_model'],
-                                             temperature=0.2,
-                                             max_tokens=400)
-                # if llm_id != "":
-                #     log_info = logics.AddModelUsedAudit(
-                #         model_id=llm_id, user_id=user_id, input_tokens=5,
-                #         output_tokens=10)
-                #     await add_llm_model_call_log(log_info)
-                return JSONResponse(status_code=200, content={"res": {"status": True, "model_type": "chat"}})
-
-            except Exception as e:
-                print(e)
-                # if llm_id != "":
-                #     log_info = logics.AddModelUsedAudit(
-                #         model_id=llm_id, user_id=user_id, input_tokens=5,
-                #         output_tokens=10)
-                #     await add_llm_model_call_log(log_info)
-                return JSONResponse(status_code=200, content={"res": {"status": True, "model_type": "chat"}})
+            if "api_key" not in config.keys():
+                LLMTestError['description'] = "api_key parameter is missing"
+                LLMTestError['detail'] = "openai model requires api_key"
+                return JSONResponse(status_code=400, content=LLMTestError)
+            params = {
+                "messages": [
+                    {
+                        "content": "hello",
+                        "role": "user"
+                    }
+                ],
+                "model": config["api_model"],
+                "stream": False,
+                "max_tokens": 16
+            }
+            headers = {
+                "api-key": config["api_key"]
+            }
+            async with aiohttp.ClientSession(timeout=base_config.test_llm_timeout) as session:
+                url = config["api_url"] + (
+                    f"openai/deployments/{config['api_model']}/chat/completions"
+                    "?api-version=2023-05-15&api-type=azure"
+                )
+                async with session.post(url, json=params, headers=headers, ssl=False) as response:
+                    response.encoding = 'utf-8'
+                    if response.status != 200:
+                        error_dict = ModelFactory_ModelController_TestModel_Error_Error.copy()
+                        error_dict["description"] = error_dict["solution"] = content
+                        try:
+                            error_dict["detail"] = await response.text()
+                        except Exception as err:
+                            StandLogger.error(str(err))
+                        error_dict["description"] = "model config error, please check model information"
+                        return JSONResponse(status_code=400, content=error_dict)
+            return JSONResponse(status_code=200, content={"status": "ok", "id": llm_id})
         except Exception as e:
             print(e)
             if isinstance(e.args[0], MaxRetryError):

--- a/infra/mf-model-manager/app/utils/verify_utils.py
+++ b/infra/mf-model-manager/app/utils/verify_utils.py
@@ -9,6 +9,44 @@ from app.logs.stand_log import StandLogger
 from app.core.config import base_config
 
 
+def _semantic_model_test_error(detail, fallback):
+    upstream_code = ""
+    upstream_type = ""
+    upstream_message = ""
+    try:
+        payload = json.loads(detail)
+        if isinstance(payload, dict):
+            error = payload.get("error")
+            if isinstance(error, dict):
+                upstream_code = str(error.get("code") or "")
+                upstream_type = str(error.get("type") or "")
+                upstream_message = str(error.get("message") or "")
+            elif isinstance(error, str):
+                upstream_message = error
+            if not upstream_message:
+                for key in ("message", "detail", "error_description"):
+                    if payload.get(key):
+                        upstream_message = str(payload[key])
+                        break
+    except Exception:
+        pass
+
+    raw = " ".join(
+        [upstream_code, upstream_type, upstream_message, str(detail)]
+    ).lower()
+    if any(token in raw for token in ("auth", "unauthorized", "api key", "ak/sk", "apikey", "401")):
+        return "模型服务认证失败，请检查 API Key、AK/SK 或授权配置"
+    if any(token in raw for token in ("deploymentnotfound", "model not found", "not found", "404")):
+        return "模型或部署不存在，请检查 API Model 和模型服务地址"
+    if any(token in raw for token in ("timeout", "timed out")):
+        return "模型服务连接超时，请检查服务地址和网络连通性"
+    if any(token in raw for token in ("connection", "connect", "dns", "name resolution", "enotfound")):
+        return "无法访问模型服务，请检查 API URL 和网络连通性"
+    if upstream_message:
+        return f"模型服务返回错误：{upstream_message}"
+    return fallback
+
+
 @func_set_timeout(30)
 async def llm_test(series, config, llm_id, user_id, model_type):
     content = "测试连接失败，请重新检查信息"
@@ -42,23 +80,25 @@ async def llm_test(series, config, llm_id, user_id, model_type):
                     response.encoding = 'utf-8'
                     if response.status != 200:
                         error_dict = ModelFactory_ModelController_TestModel_Error_Error.copy()
-                        error_dict["description"] = error_dict["solution"] = content
+                        detail = ""
                         try:
-                            error_dict["detail"] = await response.text()
+                            detail = await response.text()
                         except Exception as err:
                             StandLogger.error(str(err))
-                        error_dict["description"] = "model config error, please check model information"
+                        error_dict["detail"] = detail
+                        description = _semantic_model_test_error(detail, content)
+                        error_dict["description"] = error_dict["solution"] = description
                         return JSONResponse(status_code=400, content=error_dict)
             return JSONResponse(status_code=200, content={"status": "ok", "id": llm_id})
         except Exception as e:
             print(e)
-            if isinstance(e.args[0], MaxRetryError):
+            detail = str(e.args[0]) if e.args else str(e)
+            if e.args and isinstance(e.args[0], MaxRetryError):
                 content = "无法访问该链接，请检查该链接是否可以访问"
             error_dict = ModelFactory_ModelController_TestModel_Error_Error.copy()
-            error_dict["detail"] = str(e.args[0])
-            error_dict["description"] = error_dict["solution"] = content
-            if not isinstance(e.args[0], MaxRetryError):
-                error_dict["description"] = "模型配置错误，请检查模型信息"
+            error_dict["detail"] = detail
+            description = _semantic_model_test_error(detail, content)
+            error_dict["description"] = error_dict["solution"] = description
             # if error_dict["detail"].strip(" ") != "":
             #     error_dict["description"] = error_dict["detail"]
             # if len(error_dict["description"]) > 500:
@@ -180,12 +220,14 @@ async def llm_test(series, config, llm_id, user_id, model_type):
                     response.encoding = 'utf-8'
                     if response.status != 200:
                         error_dict = ModelFactory_ModelController_TestModel_Error_Error.copy()
-                        error_dict["description"] = error_dict["solution"] = content
+                        detail = ""
                         try:
-                            error_dict["detail"] = await response.text()
+                            detail = await response.text()
                         except Exception as e:
                             StandLogger.error(str(e))
-                        error_dict["description"] = "模型配置错误，请检查模型信息"
+                        error_dict["detail"] = detail
+                        description = _semantic_model_test_error(detail, content)
+                        error_dict["description"] = error_dict["solution"] = description
                         return JSONResponse(status_code=400, content=error_dict)
                     async for chunk in response.content:
                         chunk = chunk.decode('utf-8')
@@ -219,11 +261,11 @@ async def llm_test(series, config, llm_id, user_id, model_type):
         except Exception as e:
             StandLogger.error(str(e))
             content = "测试连接失败，请重新检查信息"
-            if isinstance(e.args[0], MaxRetryError):
+            detail = str(e.args[0]) if e.args else str(e)
+            if e.args and isinstance(e.args[0], MaxRetryError):
                 content = "无法访问该链接，请检查该链接是否可以访问"
             error_dict = ModelFactory_ModelController_TestModel_Error_Error.copy()
-            error_dict["detail"] = str(e.args[0])
-            error_dict["description"] = error_dict["solution"] = content
-            if not isinstance(e.args[0], MaxRetryError):
-                error_dict["description"] = "模型配置错误，请检查模型信息"
+            error_dict["detail"] = detail
+            description = _semantic_model_test_error(detail, content)
+            error_dict["description"] = error_dict["solution"] = description
             return JSONResponse(status_code=400, content=error_dict)


### PR DESCRIPTION
## Summary
- Allow unsetting the current default LLM (`/llm/default/edit` with `default=false`) and return explicit default state.
- Validate OpenAI/Azure test-connection with a real chat completions request so bad keys/deployments fail instead of reporting success (`Fixes #249`).
- Align `/llm/monitor/overview` statistics to current LLM models, validate reversed date ranges (400), and qualify joined metric columns to avoid MySQL ambiguity.
- Map upstream model test failures to actionable Chinese error descriptions for Studio.
- Document the changed API behavior in `docs/api/mf-model-manager/large-model.yaml`.

Related: openbkn-ai/bkn-studio#121, openbkn-ai/bkn-studio#126, openbkn-ai/bkn-studio#127.

## Test plan
- [ ] Unset default LLM via `/llm/default/edit` with `default=false`; confirm response and cache clear; setting a duplicate default still rejected.
- [ ] Test-connection for openai series: valid config succeeds; invalid API key / missing deployment / timeout return semantic failures (not false success).
- [ ] `/llm/monitor/overview`: reversed `start_time`/`end_time` returns 400; overview aggregates only current LLM models; no ambiguous-column SQL errors after join.
- [ ] Run `infra/mf-model-manager` unit tests (`test_model_controller.py`, `test_model_dao.py`).
