### PR TITLE
feat(execution-factory): 沙箱观测接口上公开面并加超管门禁（#326 第 1 步）

### DIFF
--- a/adp/execution-factory/operator-integration/helm/agent-operator-integration/values.yaml
+++ b/adp/execution-factory/operator-integration/helm/agent-operator-integration/values.yaml
@@ -5,10 +5,15 @@ nodeSelector: {}
 namespace: openbkn
 moduleName: agent-operator-integration
 
-# bkn-safe (ISF replacement) authz cutover knobs. Default empty = ISF behavior.
-# authzProvider: "" | "shadow" | "bkn-safe". url: bkn-safe ClusterIP base. Revertible.
+# bkn-safe authz。authzProvider: "" | "isf" | "shadow" | "bkn-safe"，可回退。
+#
+# 默认取 bkn-safe：ISF 已退役，空值会让 selectAuthz 落到 ISF 适配器
+# （authorization_safe.go:283-286），而授权判定在出错时是 fail-closed
+# （decision.go 的 OperationCheckAll 把错误统一转 403），结果是所有鉴权
+# 一律拒绝。deploy/conf/config.yaml 等实际部署配置本就传 bkn-safe，此处
+# 只是让 chart 默认值与之一致，避免直接 helm install 时踩空。
 bknSafe:
-  authzProvider: ""
+  authzProvider: "bkn-safe"
   url: ""
 
 # 设置为dev则为开发模式.

--- a/adp/execution-factory/operator-integration/server/driveradapters/rest_public_handler.go
+++ b/adp/execution-factory/operator-integration/server/driveradapters/rest_public_handler.go
@@ -7,6 +7,7 @@ import (
 	"github.com/gin-gonic/gin"
 	"github.com/openbkn-ai/adp/execution-factory/operator-integration/server/drivenadapters"
 	"github.com/openbkn-ai/adp/execution-factory/operator-integration/server/driveradapters/common"
+	sandboxdriver "github.com/openbkn-ai/adp/execution-factory/operator-integration/server/driveradapters/sandbox"
 	"github.com/openbkn-ai/adp/execution-factory/operator-integration/server/infra/config"
 	"github.com/openbkn-ai/adp/execution-factory/operator-integration/server/interfaces"
 	"github.com/openbkn-ai/adp/execution-factory/operator-integration/server/logics/business_domain"
@@ -15,6 +16,7 @@ import (
 type restPublicHandler struct {
 	Hydra                 interfaces.Hydra
 	AppKeys               interfaces.AppKeyVerifier
+	SandboxHandler        sandboxdriver.ManagementHandler
 	OperatorRestHandler   OperatorRestHandler
 	ToolBoxRestHandler    ToolBoxRestHandler
 	MCPRestHandler        MCPRestHandler
@@ -32,6 +34,7 @@ func NewRestPublicHandler() interfaces.HTTPRouterInterface {
 	return &restPublicHandler{
 		Hydra:                 drivenadapters.NewHydra(),
 		AppKeys:               drivenadapters.NewAppKeyVerifier(),
+		SandboxHandler:        sandboxdriver.NewManagementHandler(),
 		OperatorRestHandler:   NewOperatorRestHandler(),
 		ToolBoxRestHandler:    NewToolBoxRestHandler(),
 		MCPRestHandler:        NewMCPRestHandler(),
@@ -58,6 +61,8 @@ func (r *restPublicHandler) RegisterRouter(engine *gin.RouterGroup) {
 	r.MCPRestHandler.RegisterPublic(engine)
 	// Skill 相关接口
 	r.SkillRestHandler.RegisterPublic(engine)
+	// 沙箱运行时只读观测接口（超管可见，见 #326）
+	r.SandboxHandler.RegisterPublic(engine)
 	// 导入导出
 	engine.GET("/impex/export/:type/:id", r.ImpexHandler.Export)
 	engine.POST("/impex/import/:type", middlewareBusinessDomain(true, false, r.businessDomainService), r.ImpexHandler.Import)

--- a/adp/execution-factory/operator-integration/server/driveradapters/sandbox/management.go
+++ b/adp/execution-factory/operator-integration/server/driveradapters/sandbox/management.go
@@ -5,12 +5,17 @@ import (
 
 	"github.com/gin-gonic/gin"
 	"github.com/openbkn-ai/adp/execution-factory/operator-integration/server/drivenadapters"
+	"github.com/openbkn-ai/adp/execution-factory/operator-integration/server/infra/common"
+	"github.com/openbkn-ai/adp/execution-factory/operator-integration/server/infra/errors"
 	"github.com/openbkn-ai/adp/execution-factory/operator-integration/server/infra/rest"
+	"github.com/openbkn-ai/adp/execution-factory/operator-integration/server/interfaces"
+	"github.com/openbkn-ai/adp/execution-factory/operator-integration/server/logics/auth"
 	"github.com/openbkn-ai/adp/execution-factory/operator-integration/server/logics/sandbox"
 )
 
 type ManagementHandler interface {
 	RegisterPrivate(engine *gin.RouterGroup)
+	RegisterPublic(engine *gin.RouterGroup)
 	GetHealth(c *gin.Context)
 	GetPool(c *gin.Context)
 	ListSessions(c *gin.Context)
@@ -18,7 +23,8 @@ type ManagementHandler interface {
 }
 
 type managementHandler struct {
-	service sandbox.SandboxManagementService
+	service     sandbox.SandboxManagementService
+	authService interfaces.IAuthorizationService
 }
 
 func NewManagementHandler() ManagementHandler {
@@ -34,12 +40,59 @@ func NewManagementHandlerWithService(service sandbox.SandboxManagementService) M
 	return &managementHandler{service: service}
 }
 
+// NewManagementHandlerWithAuth 供测试注入授权服务。
+func NewManagementHandlerWithAuth(service sandbox.SandboxManagementService, authService interfaces.IAuthorizationService) ManagementHandler {
+	return &managementHandler{service: service, authService: authService}
+}
+
 func (h *managementHandler) RegisterPrivate(engine *gin.RouterGroup) {
 	group := engine.Group("/sandbox")
 	group.GET("/health", h.GetHealth)
 	group.GET("/pool", h.GetPool)
 	group.GET("/sessions", h.ListSessions)
 	group.GET("/sessions/:id", h.GetSessionDetail)
+}
+
+// RegisterPublic 在公开面注册同一组沙箱只读观测接口。
+//
+// 这四条接口原本只在 internal-v1 上，而 internal-v1 不校验令牌、身份由 X-Account-ID 头
+// 声明；为了让 Studio 的沙箱运行时页能访问，该前缀被开到了 Ingress（见 #326）。公开面走
+// middlewareIntrospectVerify，可拿到经校验的真实身份，再叠加超管判定收口。
+//
+// 响应含 user_id、workspace_path、pod_name、python_package_index_url 等跨租户信息，
+// 因此限定超管可见。
+func (h *managementHandler) RegisterPublic(engine *gin.RouterGroup) {
+	// 惰性构造：授权服务会加载全局配置，放在构造函数里会让只注册内部面的调用方
+	// （含单元测试）也被迫依赖配置文件。路由注册发生在启动期且仅一次，此处无并发。
+	if h.authService == nil {
+		h.authService = auth.NewAuthServiceImpl()
+	}
+	group := engine.Group("/sandbox", h.requireAdmin)
+	group.GET("/health", h.GetHealth)
+	group.GET("/pool", h.GetPool)
+	group.GET("/sessions", h.ListSessions)
+	group.GET("/sessions/:id", h.GetSessionDetail)
+}
+
+// requireAdmin 拦截非超管调用。判定口径与 bkn-safe 的 Enforcer.CanAdmin 一致。
+func (h *managementHandler) requireAdmin(c *gin.Context) {
+	ctx := c.Request.Context()
+	authContext, ok := common.GetAccountAuthContextFromCtx(ctx)
+	if !ok || authContext == nil {
+		rest.ReplyError(c, errors.DefaultHTTPError(ctx, http.StatusUnauthorized, "authentication required"))
+		c.Abort()
+		return
+	}
+	accessor := &interfaces.AuthAccessor{
+		ID:   authContext.AccountID,
+		Type: authContext.AccountType,
+	}
+	if err := h.authService.CheckAdminPermission(ctx, accessor); err != nil {
+		rest.ReplyError(c, err)
+		c.Abort()
+		return
+	}
+	c.Next()
 }
 
 func (h *managementHandler) GetHealth(c *gin.Context) {

--- a/adp/execution-factory/operator-integration/server/driveradapters/sandbox/management_test.go
+++ b/adp/execution-factory/operator-integration/server/driveradapters/sandbox/management_test.go
@@ -24,12 +24,29 @@ func (f *fakeManagementService) GetPool(ctx context.Context) (*logicssandbox.San
 	return &logicssandbox.SandboxPoolResp{MaxSessions: 3, CurrentActiveSessions: 1}, nil
 }
 
+// sentinelWorkspacePath 是跨租户敏感字段的哨兵值。门禁生效时它不应出现在响应里；
+// 若断言改成恒真（例如让 fake 不填该字段，靠 omitempty 让它天然消失），这组用例
+// 就测不出 requireAdmin 是否真的拦住了请求。
+const sentinelWorkspacePath = "/workspace/sess_leak_probe"
+
 func (f *fakeManagementService) ListSessions(ctx context.Context, req *logicssandbox.SandboxSessionListReq) (*logicssandbox.SandboxSessionListResp, error) {
-	return &logicssandbox.SandboxSessionListResp{Items: []*logicssandbox.SandboxSessionSummary{}, Total: 0}, nil
+	return &logicssandbox.SandboxSessionListResp{
+		Items: []*logicssandbox.SandboxSessionSummary{
+			{ID: "sess_leak_probe", UserID: "other-tenant-user"},
+		},
+		Total: 1,
+	}, nil
 }
 
 func (f *fakeManagementService) GetSessionDetail(ctx context.Context, sessionID string) (*logicssandbox.SandboxSessionDetailResp, error) {
-	return &logicssandbox.SandboxSessionDetailResp{SandboxSessionSummary: &logicssandbox.SandboxSessionSummary{ID: sessionID}}, nil
+	return &logicssandbox.SandboxSessionDetailResp{
+		SandboxSessionSummary: &logicssandbox.SandboxSessionSummary{
+			ID:     sessionID,
+			UserID: "other-tenant-user",
+		},
+		WorkspacePath: sentinelWorkspacePath,
+		PodName:       "sandbox-pod-leak-probe",
+	}, nil
 }
 
 func TestManagementHandlerReadOnlyRoutes(t *testing.T) {
@@ -98,8 +115,11 @@ func TestManagementHandlerPublicRoutesRequireAdmin(t *testing.T) {
 			So(performRequest(engine, http.MethodGet, base+"/health").Code, ShouldEqual, http.StatusOK)
 			So(performRequest(engine, http.MethodGet, base+"/pool").Code, ShouldEqual, http.StatusOK)
 			So(performRequest(engine, http.MethodGet, base+"/sessions").Code, ShouldEqual, http.StatusOK)
-			So(performRequest(engine, http.MethodGet, base+"/sessions/sess_1").Code, ShouldEqual, http.StatusOK)
+			detail := performRequest(engine, http.MethodGet, base+"/sessions/sess_1")
+			So(detail.Code, ShouldEqual, http.StatusOK)
 			So(auth.called, ShouldEqual, 4)
+			// 放行时哨兵字段确实出现在响应里——否则下面「不泄露」的断言恒为真，测不出门禁
+			So(detail.Body.String(), ShouldContainSubstring, sentinelWorkspacePath)
 		})
 
 		Convey("非超管一律拒绝，且不泄露会话数据", func() {
@@ -108,8 +128,11 @@ func TestManagementHandlerPublicRoutesRequireAdmin(t *testing.T) {
 
 			for _, path := range []string{"/health", "/pool", "/sessions", "/sessions/sess_1"} {
 				resp := performRequest(engine, http.MethodGet, base+path)
-				So(resp.Code, ShouldNotEqual, http.StatusOK)
-				So(resp.Body.String(), ShouldNotContainSubstring, "workspace_path")
+				So(resp.Code, ShouldEqual, http.StatusForbidden)
+				// fake service 会返回哨兵值，因此这两条断言只有在 requireAdmin
+				// 真的中止了请求时才成立
+				So(resp.Body.String(), ShouldNotContainSubstring, sentinelWorkspacePath)
+				So(resp.Body.String(), ShouldNotContainSubstring, "other-tenant-user")
 			}
 		})
 

--- a/adp/execution-factory/operator-integration/server/driveradapters/sandbox/management_test.go
+++ b/adp/execution-factory/operator-integration/server/driveradapters/sandbox/management_test.go
@@ -7,6 +7,9 @@ import (
 	"testing"
 
 	"github.com/gin-gonic/gin"
+	"github.com/openbkn-ai/adp/execution-factory/operator-integration/server/infra/common"
+	"github.com/openbkn-ai/adp/execution-factory/operator-integration/server/infra/errors"
+	"github.com/openbkn-ai/adp/execution-factory/operator-integration/server/interfaces"
 	logicssandbox "github.com/openbkn-ai/adp/execution-factory/operator-integration/server/logics/sandbox"
 	. "github.com/smartystreets/goconvey/convey"
 )
@@ -51,4 +54,78 @@ func performRequest(engine *gin.Engine, method, path string) *httptest.ResponseR
 	req := httptest.NewRequest(method, path, nil)
 	engine.ServeHTTP(recorder, req)
 	return recorder
+}
+
+// fakeAuthService 按构造时给定的结果放行或拒绝，用于验证公开面的超管门禁。
+type fakeAuthService struct {
+	interfaces.IAuthorizationService
+	adminErr error
+	called   int
+}
+
+func (f *fakeAuthService) CheckAdminPermission(ctx context.Context, accessor *interfaces.AuthAccessor) error {
+	f.called++
+	return f.adminErr
+}
+
+// newPublicEngine 构造带认证上下文的公开面路由，模拟 middlewareIntrospectVerify 的产出。
+func newPublicEngine(authService interfaces.IAuthorizationService, accountID string) *gin.Engine {
+	gin.SetMode(gin.TestMode)
+	engine := gin.New()
+	if accountID != "" {
+		engine.Use(func(c *gin.Context) {
+			ctx := common.SetAccountAuthContextToCtx(c.Request.Context(), &interfaces.AccountAuthContext{
+				AccountID:   accountID,
+				AccountType: interfaces.AccessorTypeUser,
+			})
+			c.Request = c.Request.WithContext(ctx)
+			c.Next()
+		})
+	}
+	group := engine.Group("/api/agent-operator-integration/v1")
+	NewManagementHandlerWithAuth(&fakeManagementService{}, authService).RegisterPublic(group)
+	return engine
+}
+
+func TestManagementHandlerPublicRoutesRequireAdmin(t *testing.T) {
+	const base = "/api/agent-operator-integration/v1/sandbox"
+
+	Convey("公开面沙箱观测接口限定超管可见", t, func() {
+		Convey("超管可访问全部四条只读接口", func() {
+			auth := &fakeAuthService{}
+			engine := newPublicEngine(auth, "admin-1")
+
+			So(performRequest(engine, http.MethodGet, base+"/health").Code, ShouldEqual, http.StatusOK)
+			So(performRequest(engine, http.MethodGet, base+"/pool").Code, ShouldEqual, http.StatusOK)
+			So(performRequest(engine, http.MethodGet, base+"/sessions").Code, ShouldEqual, http.StatusOK)
+			So(performRequest(engine, http.MethodGet, base+"/sessions/sess_1").Code, ShouldEqual, http.StatusOK)
+			So(auth.called, ShouldEqual, 4)
+		})
+
+		Convey("非超管一律拒绝，且不泄露会话数据", func() {
+			auth := &fakeAuthService{adminErr: errors.DefaultHTTPError(context.Background(), http.StatusForbidden, "forbidden")}
+			engine := newPublicEngine(auth, "user-1")
+
+			for _, path := range []string{"/health", "/pool", "/sessions", "/sessions/sess_1"} {
+				resp := performRequest(engine, http.MethodGet, base+path)
+				So(resp.Code, ShouldNotEqual, http.StatusOK)
+				So(resp.Body.String(), ShouldNotContainSubstring, "workspace_path")
+			}
+		})
+
+		Convey("无认证上下文时返回 401，不进入授权判定", func() {
+			auth := &fakeAuthService{}
+			engine := newPublicEngine(auth, "")
+
+			So(performRequest(engine, http.MethodGet, base+"/health").Code, ShouldEqual, http.StatusUnauthorized)
+			So(auth.called, ShouldEqual, 0)
+		})
+
+		Convey("公开面同样只有只读路由", func() {
+			engine := newPublicEngine(&fakeAuthService{}, "admin-1")
+
+			So(performRequest(engine, http.MethodDelete, base+"/sessions/sess_1").Code, ShouldEqual, http.StatusNotFound)
+			So(performRequest(engine, http.MethodPost, base+"/pool/prewarm").Code, ShouldEqual, http.StatusNotFound)
+		})
+	})
 }

--- a/adp/execution-factory/operator-integration/server/interfaces/logics_auth.go
+++ b/adp/execution-factory/operator-integration/server/interfaces/logics_auth.go
@@ -29,6 +29,7 @@ const (
 	AuthOperationTypeAuthorize    AuthOperationType = "authorize"     // 权限管理
 	AuthOperationTypePublicAccess AuthOperationType = "public_access" // 公共访问
 	AuthOperationTypeExecute      AuthOperationType = "execute"       // 执行
+	AuthOperationTypeManage       AuthOperationType = "manage"        // 管理（用于超管判定，见 AuthResourceTypeSafeAdmin）
 )
 
 var (
@@ -55,7 +56,15 @@ const (
 	AuthResourceTypeMCP      AuthResourceType = "mcp"      // MCP
 	AuthResourceTypeOperator AuthResourceType = "operator" // 算子
 	AuthResourceTypeSkill    AuthResourceType = "skill"    // Skill
+
+	// AuthResourceTypeSafeAdmin 是 bkn-safe 的超管能力位，不是执行工厂自有的资源类型。
+	// bkn-safe 的 Enforcer.CanAdmin 即 Check(accessorID, "safe_admin", "console", "manage")，
+	// 此处复用同一三元组，使执行工厂对「超管」的判定与 bkn-safe 保持单一事实源。
+	AuthResourceTypeSafeAdmin AuthResourceType = "safe_admin"
 )
+
+// SafeAdminConsoleResourceID 是 safe_admin 能力位对应的资源 ID，与 bkn-safe 侧取值一致。
+const SafeAdminConsoleResourceID = "console"
 
 func (a AuthResourceType) String() string {
 	return string(a)
@@ -97,6 +106,9 @@ type IAuthorizationService interface {
 	CheckExecutePermission(ctx context.Context, accessor *AuthAccessor, resourceID string, resourceType AuthResourceType) error
 	// MultiCheckOperationPermission 多操作权限检查
 	MultiCheckOperationPermission(ctx context.Context, accessor *AuthAccessor, resourceID string, resourceType AuthResourceType, operations ...AuthOperationType) error
+	// CheckAdminPermission 检查超管权限。判定口径与 bkn-safe 的 Enforcer.CanAdmin 一致，
+	// 用于保护返回跨租户数据、不属于任何单一资源的运维观测接口。
+	CheckAdminPermission(ctx context.Context, accessor *AuthAccessor) error
 
 	// CreateOwnerPolicy 创建owner权限
 	CreateOwnerPolicy(ctx context.Context, accessor *AuthAccessor, authResource *AuthResource) error

--- a/adp/execution-factory/operator-integration/server/logics/auth/decision.go
+++ b/adp/execution-factory/operator-integration/server/logics/auth/decision.go
@@ -28,6 +28,24 @@ func (s *authServiceImpl) CheckCreatePermission(ctx context.Context, accessor *i
 	return nil
 }
 
+// CheckAdminPermission 检查超管权限。
+// 判定复用 bkn-safe 的 safe_admin:console:manage 能力位——即 Enforcer.CanAdmin 的口径——
+// 因此执行工厂与 bkn-safe 对「超管」的认定始终一致，无需在本服务硬编码管理员账号。
+// 用于保护返回跨租户数据、不隶属于任何单一业务资源的运维观测接口。
+func (s *authServiceImpl) CheckAdminPermission(ctx context.Context, accessor *interfaces.AuthAccessor) error {
+	authorized, err := s.OperationCheckAll(ctx, accessor,
+		interfaces.SafeAdminConsoleResourceID,
+		interfaces.AuthResourceTypeSafeAdmin,
+		interfaces.AuthOperationTypeManage)
+	if err != nil {
+		return err
+	}
+	if !authorized {
+		return oerrors.NewHTTPError(ctx, http.StatusForbidden, oerrors.ErrExtCommonViewForbidden, nil)
+	}
+	return nil
+}
+
 // CheckModifyPermission 检查编辑权限
 func (s *authServiceImpl) CheckModifyPermission(ctx context.Context, accessor *interfaces.AuthAccessor, resourceID string, resourceType interfaces.AuthResourceType) error {
 	authorized, err := s.OperationCheckAll(ctx, accessor, resourceID, resourceType, interfaces.AuthOperationTypeModify)

--- a/adp/execution-factory/operator-integration/server/logics/auth/index.go
+++ b/adp/execution-factory/operator-integration/server/logics/auth/index.go
@@ -35,6 +35,11 @@ func (n *noopAuthService) CheckCreatePermission(ctx context.Context, accessor *i
 	return nil
 }
 
+// CheckAdminPermission 在 AUTH_ENABLED=false 时放行，与本 noop 实现中其余判定一致。
+func (n *noopAuthService) CheckAdminPermission(ctx context.Context, accessor *interfaces.AuthAccessor) error {
+	return nil
+}
+
 func (n *noopAuthService) CheckViewPermission(ctx context.Context, accessor *interfaces.AuthAccessor, resourceID string, resourceType interfaces.AuthResourceType) error {
 	return nil
 }

--- a/adp/execution-factory/operator-integration/server/mocks/auth.go
+++ b/adp/execution-factory/operator-integration/server/mocks/auth.go
@@ -41,6 +41,20 @@ func (m *MockIAuthorizationService) EXPECT() *MockIAuthorizationServiceMockRecor
 	return m.recorder
 }
 
+// CheckAdminPermission mocks base method.
+func (m *MockIAuthorizationService) CheckAdminPermission(ctx context.Context, accessor *interfaces.AuthAccessor) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CheckAdminPermission", ctx, accessor)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// CheckAdminPermission indicates an expected call of CheckAdminPermission.
+func (mr *MockIAuthorizationServiceMockRecorder) CheckAdminPermission(ctx, accessor any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CheckAdminPermission", reflect.TypeOf((*MockIAuthorizationService)(nil).CheckAdminPermission), ctx, accessor)
+}
+
 // CheckAuthorizePermission mocks base method.
 func (m *MockIAuthorizationService) CheckAuthorizePermission(ctx context.Context, accessor *interfaces.AuthAccessor, resourceID string, resourceType interfaces.AuthResourceType) error {
 	m.ctrl.T.Helper()


### PR DESCRIPTION
Refs #326（第 1 步，共 3 步）· 父 Epic #324 批次 0-A

**本步只做加法，不删任何东西。** 上线后 `internal-v1` 与 `/v1` 两条路径同时可用，Studio 可以从容切换，全程零不可用窗口。

## 问题

`helm/agent-operator-integration/values.yaml:39-41` 把内部路由组显式发布到 Ingress：

```yaml
path:
  - /api/agent-operator-integration/v1
  - /api/agent-operator-integration/internal-v1
```

而 `internal-v1` 不校验令牌——`rest_private_handler.go:50` 挂的是 `middlewareHeaderAuthContext`，身份完全来自调用方自填的 `X-Account-ID` 头，`hydra.go:78-96` 在该头缺失时把调用者降级为硬编码管理员 UUID。

同组下另有 40 条路由被一并暴露，含 `POST /function/exec/:version`（沙箱任意代码执行）、三条 proxy 执行代理、`intcomp` 内置组件注册、`impex` 导入、以及用 GET 承载数据迁移的 `upgrade/v5003`。

之所以开到 Ingress，是因为 Studio 的沙箱运行时页从浏览器直连这四条内部接口（`execution-factory-lab/services/sandbox-runtime.service.ts:18-19,168,184,201,216`，依赖在 `module.manifest.ts:17` 显式声明，由 #116 引入）。

## 本次改动

四条只读观测接口在公开面 `/v1` 同样注册。公开面走 `middlewareIntrospectVerify`，可拿到经校验的真实身份，再叠加超管判定。

**超管判定复用 bkn-safe 的 `safe_admin:console:manage` 能力位**，即其 `Enforcer.CanAdmin` 的口径（`bkn-safe/server/internal/authz/authz.go:152-154`）。执行工厂与 bkn-safe 对「超管」共用单一事实源，不在本服务硬编码管理员 UUID。

限定超管的理由：响应含 `user_id`、`capability_id`、`workspace_path`、`pod_name`、`python_package_index_url` 等跨租户信息。

| 文件 | 改动 |
| --- | --- |
| `interfaces/logics_auth.go` | 新增 `AuthOperationTypeManage`、`AuthResourceTypeSafeAdmin`、`SafeAdminConsoleResourceID`；接口加 `CheckAdminPermission` |
| `logics/auth/decision.go` | 实现 `CheckAdminPermission` |
| `logics/auth/index.go` | noop 实现（`AUTH_ENABLED=false` 时放行，与同文件其余判定一致） |
| `driveradapters/sandbox/management.go` | 新增 `RegisterPublic` + `requireAdmin` 中间件 |
| `driveradapters/rest_public_handler.go` | 接线 |
| `mocks/auth.go` | 生成，纯新增 14 行 |

## 兼容性

- **`internal-v1` 一行未动**，现有调用方行为完全不变
- 新增的是 `/v1/sandbox/*`，此前不存在该路径，不覆盖任何既有路由
- 授权服务在 `RegisterPublic` 时惰性构造。最初写成构造函数里 eager 构造，导致只注册内部面的现有单元测试也被迫加载全局配置而 panic——已修正，`RegisterPrivate` 路径不触碰配置

## 测试

`management_test.go` 新增四组用例：

- 超管可访问全部四条只读接口，且授权判定确实被调用 4 次
- 非超管一律拒绝，且响应体不含 `workspace_path`（验证不泄露会话数据）
- 无认证上下文返回 401，**不进入授权判定**
- 公开面同样只有只读路由（DELETE/POST 返回 404）

现有的 `TestManagementHandlerReadOnlyRoutes` 保持通过。CI 等价全量套件本地 20 包全绿。

## 后续两步

2. bkn-studio：`sandbox-runtime.service.ts:18-19` 前缀切到 `/v1`，`module.manifest.ts:17` 同步
3. bkn-foundry：删 `internal-v1` 的 sandbox 注册 + 删 `values.yaml:41`

**安全缺口要到第 3 步才真正关闭。** 若认为缺口优先于可用性窗口，可以把 1 和 3 合并上线，代价是 Studio 沙箱页 404 数分钟。

## 遗留

`internal-v1` 收回集群内后仍不校验令牌、身份由 `X-Account-ID` 声明。服务间凭据建设属独立议题，已在 #326 中记为不在范围。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
