### PR TITLE
优化(bkn-safe-chart)：移除内置的 MariaDB 并统一镜像仓库

### DIFF
--- a/bkn-safe/charts/bkn-safe/templates/deps.yaml
+++ b/bkn-safe/charts/bkn-safe/templates/deps.yaml
@@ -1,12 +1,9 @@
 {{- if .Values.bundledDeps.enabled }}
 {{- /* Cluster MariaDB creds from config.yaml depServices.rds (platform standard).
-       When present, the bkn-safe app DB uses it and the bundled MariaDB below is
-       skipped — only the hydra Postgres (which MariaDB can't host) is bundled. */}}
+       When present, the bkn-safe app DB uses it. */}}
 {{- $rds := (.Values.depServices | default dict).rds | default dict }}
 # Bundled dependencies: PostgreSQL (hydra's DB — MariaDB can't host hydra) is
-# always bundled here and PERSISTED on a PVC; the bundled MariaDB (bkn-safe's app
-# DB) deploys ONLY when no cluster depServices.rds is configured (pure dev). Hydra
-# is upstream ORY v26.2.0.
+# always bundled here and PERSISTED on a PVC. Hydra is upstream ORY v26.2.0.
 ---
 apiVersion: v1
 kind: PersistentVolumeClaim
@@ -39,7 +36,7 @@ spec:
     spec:
       containers:
         - name: postgres
-          image: {{ .Values.bundledDeps.postgresImage }}
+          image: "{{- if .Values.image.registry }}{{ .Values.image.registry }}/{{ end }}{{ .Values.bundledDeps.postgresImage }}"
           env:
             - { name: POSTGRES_USER, value: "hydra" }
             - { name: POSTGRES_PASSWORD, value: "secret" }
@@ -54,36 +51,6 @@ metadata: { name: {{ .Release.Name }}-postgres, namespace: {{ .Release.Namespace
 spec:
   selector: { app: {{ .Release.Name }}-postgres }
   ports: [{ port: 5432, targetPort: 5432 }]
-{{- if not $rds.host }}
----
-apiVersion: apps/v1
-kind: Deployment
-metadata:
-  name: {{ .Release.Name }}-mariadb
-  namespace: {{ .Release.Namespace }}
-spec:
-  replicas: 1
-  selector: { matchLabels: { app: {{ .Release.Name }}-mariadb } }
-  template:
-    metadata: { labels: { app: {{ .Release.Name }}-mariadb } }
-    spec:
-      containers:
-        - name: mariadb
-          image: {{ .Values.bundledDeps.mariadbImage }}
-          env:
-            - { name: MARIADB_ROOT_PASSWORD, value: {{ .Values.config.db.password | quote }} }
-            - { name: MARIADB_DATABASE, value: {{ .Values.config.db.name | quote }} }
-          ports: [{ containerPort: 3306 }]
-          volumeMounts: [{ name: data, mountPath: /var/lib/mysql }]
-      volumes: [{ name: data, emptyDir: {} }]
----
-apiVersion: v1
-kind: Service
-metadata: { name: {{ .Values.config.db.host }}, namespace: {{ .Release.Namespace }} }
-spec:
-  selector: { app: {{ .Release.Name }}-mariadb }
-  ports: [{ port: 3306, targetPort: 3306 }]
-{{- end }}
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -98,13 +65,13 @@ spec:
     spec:
       initContainers:
         - name: migrate
-          image: {{ .Values.bundledDeps.hydraImage }}
+          image: "{{- if .Values.image.registry }}{{ .Values.image.registry }}/{{ end }}{{ .Values.bundledDeps.hydraImage }}"
           command: ["hydra", "migrate", "sql", "-e", "--yes"]
           env:
             - { name: DSN, value: "postgres://hydra:secret@{{ .Release.Name }}-postgres:5432/hydra?sslmode=disable" }
       containers:
         - name: hydra
-          image: {{ .Values.bundledDeps.hydraImage }}
+          image: "{{- if .Values.image.registry }}{{ .Values.image.registry }}/{{ end }}{{ .Values.bundledDeps.hydraImage }}"
           args: ["serve", "all", "--dev"]
           env:
             - { name: DSN, value: "postgres://hydra:secret@{{ .Release.Name }}-postgres:5432/hydra?sslmode=disable" }

--- a/bkn-safe/charts/bkn-safe/values.yaml
+++ b/bkn-safe/charts/bkn-safe/values.yaml
@@ -130,16 +130,14 @@ resources:
 nodeSelector: {}
 
 # Bundled dependencies for non-production clusters (dev/staging/CI): an upstream
-# hydra v26.2.0 on PostgreSQL + a MariaDB for bkn-safe. In production set
-# enabled=false and point config.hydra/config.db at the real services.
+# hydra v26.2.0 on PostgreSQL. In production set enabled=false and point
+# config.hydra/config.db at the real services.
 bundledDeps:
   enabled: true
-  hydraImage: swr.cn-east-3.myhuaweicloud.com/openbkn-ai/oryd/hydra:v26.2.0
-  postgresImage: swr.cn-east-3.myhuaweicloud.com/openbkn-ai/postgres:16
-  mariadbImage: mariadb:11.4
+  hydraImage: oryd/hydra:v26.2.0
+  postgresImage: postgres:16
   # Persistent volume for the bundled hydra Postgres (survives pod restarts so
-  # OAuth clients/tokens/admin state aren't lost). The bundled MariaDB (app DB)
-  # only deploys when no cluster depServices.rds is set, so it stays ephemeral.
+  # OAuth clients/tokens/admin state aren't lost).
   postgresStorage: "5Gi"
   hydraSecretsSystem: "dev-only-change-me-32-bytes-secret"
   # Browser-facing public base URL of the gateway (TLS-terminating ingress),


### PR DESCRIPTION
- 移除内置依赖中的 MariaDB 部署（改用集群数据库）
- 将 bundledDeps 镜像仓库与 image.registry 配置统一
- 更新 hydraImage 和 postgresImage 使用相对路径