### PR TITLE
ci: 修复 Claude 评审静默失效，补路径过滤与推送触发

### DIFF
--- a/.github/workflows/automation-claude-review.yml
+++ b/.github/workflows/automation-claude-review.yml
@@ -3,10 +3,21 @@ name: Claude Code Review
 # 每个 PR 开启（或从 draft 转为 ready）时，由 Claude 做一次代码评审。
 # 与旧的 Copilot ruleset 行为对齐：只评审首版，不在每次 push 后重跑。
 # 需要重新评审时手动触发 workflow_dispatch 并填 PR 编号。
+#
+# 只对代码路径生效。纯配置类改动（release manifest 刷新、镜像同步、workflow 自身
+# 调整、文档）不进评审，既省额度也避免噪声。
+# 注意：GitHub Actions 不允许同一事件同时使用 paths 与 paths-ignore，因此这里
+# 只写 include 列表——未列出的路径自动跳过——并用 ! 前缀排除列表内的文档文件。
 
 on:
   pull_request:
     types: [opened, reopened, ready_for_review]
+    paths:
+      - 'adp/**'
+      - 'infra/**'
+      - 'bkn-safe/**'
+      - 'deploy/scripts/**'
+      - '!**/*.md'
   workflow_dispatch:
     inputs:
       pr_number:


### PR DESCRIPTION
接 #338。修一个静默失效问题，外加路径过滤。

## 问题一：评审从未真正运行过（静默跳过）

`#338` 合入的是第一版，用 `ANTHROPIC_API_KEY`；而仓库配置的 secret 是 `CLAUDE_CODE_OAUTH_TOKEN`。分支上那个改用 OAuth 的提交（`5ada08ee`）没有进入 main。

结果是每次触发都走到跳过分支：

```
##[warning]Secret ANTHROPIC_API_KEY not set — skipping Claude review.
```

而 job 结论仍是 **success**——绿灯，零评论，没有任何信号提示评审没跑。实测于 run [29727792610](https://github.com/openbkn-ai/bkn-foundry/actions/runs/29727792610)（手动对 #339 触发）。

本 PR cherry-pick 了 `5ada08ee`，四处引用统一改为 `CLAUDE_CODE_OAUTH_TOKEN`。

## 问题二：无路径过滤

评审对每个 PR 跑一次，但仓库里相当比例的 PR 是纯配置改动——release manifest 刷新（#313）、镜像同步（#312）、workflow 调整、文档。这些审了没有产出，既消耗额度也在 PR 上留噪声评论。

限定到四个代码路径：`adp/**`、`infra/**`、`bkn-safe/**`、`deploy/scripts/**`。

**为什么只有 include 列表，没有 `paths-ignore`：** GitHub Actions 不允许同一事件同时使用 `paths` 和 `paths-ignore`。未列出的路径自动跳过，效果等同于排除 `deploy/release-manifests/**` 与 `.github/workflows/**`；列表内的文档用 `!**/*.md` 排除。

`workflow_dispatch` 不受 `paths` 约束，需要时仍可手动指定任意 PR 重审。

## 未改动的部分

- **触发时机**：仍是 `[opened, reopened, ready_for_review]`，每个 PR 一次，不跟每次 push 重跑
- **只评论不改码**：`--allowedTools` 白名单只含 `mcp__github_inline_comment__create_inline_comment` 与 `Bash(gh pr comment|diff|view:*)`，不含 Edit / Write / git push / pr merge，与 `rules/WORKFLOW.md` 中「Agent 永不 merge/bypass」一致

## 验证

本地 `yaml.safe_load` 解析通过，并断言：凭据入参为 `claude_code_oauth_token`、`allowedTools` 不含任何写操作、`workflow_dispatch` 不受 paths 约束。文件名前缀符合 `lint-workflow-files.yml` 约束。

**本 PR 自身不触发评审**——它只改 `.github/workflows/`，不在 include 列表内。合入后可用 `workflow_dispatch` 指定任意 PR 做首次实跑。

## 建议的后续检查

跳过分支目前只发 `::warning::`，仍算 success。可考虑改为 `exit 1`，让凭据缺失直接红灯——否则同类问题还会静默复发。本 PR 未改动该行为，先听评审意见。

🤖 Generated with [Claude Code](https://claude.com/claude-code)