### PR TITLE
ci: 修复 Claude 评审静默失效(凭据名不匹配)

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -40,6 +40,6 @@ Workflow YAML files must stay in this directory (flat layout). GitHub does not l
 | [`release-adp-bkn-safe.yml`](./release-adp-bkn-safe.yml) | release-adp-bkn-safe | `push` (`bkn-safe/**`), `workflow_dispatch` | bkn-safe image + bkn-safe & hydra Helm charts (ISF replacement) |
 | [`release-infra-sandbox.yml`](./release-infra-sandbox.yml) | release-infra-sandbox | `push` (`infra/sandbox/**`), `workflow_dispatch` | sandbox bases (v1) + control-plane + web + 2 templates + 2 Helm charts |
 | [`automation-ghcr-cleanup.yml`](./automation-ghcr-cleanup.yml) | automation-ghcr-cleanup | `schedule` (weekly Sun 03:00 UTC), `workflow_dispatch` | Delete old GHCR container packages (branch-suffixed tags > 30d, untagged orphans); keeps semver/v1/v2/latest |
-| [`automation-claude-review.yml`](./automation-claude-review.yml) | Claude Code Review | `pull_request` (opened / reopened / ready_for_review), `workflow_dispatch` | Claude 代码评审（inline comments）；需 repo secret `ANTHROPIC_API_KEY`，缺失时跳过 |
+| [`automation-claude-review.yml`](./automation-claude-review.yml) | Claude Code Review | `pull_request` (opened / reopened / ready_for_review), `workflow_dispatch` | Claude 代码评审（inline comments）；需 repo secret `CLAUDE_CODE_OAUTH_TOKEN`，缺失时跳过 |
 
 When you add a workflow, append a row here and use a `paths` filter when it should only run for part of the monorepo.

--- a/.github/workflows/automation-claude-review.yml
+++ b/.github/workflows/automation-claude-review.yml
@@ -39,7 +39,7 @@ jobs:
       pull-requests: write
       id-token: write
     env:
-      ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+      CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
       PR_NUMBER: ${{ github.event.pull_request.number || inputs.pr_number }}
     steps:
       - name: Checkout repository
@@ -48,10 +48,10 @@ jobs:
           fetch-depth: 1
 
       - name: Claude review
-        if: env.ANTHROPIC_API_KEY != ''
+        if: env.CLAUDE_CODE_OAUTH_TOKEN != ''
         uses: anthropics/claude-code-action@v1
         with:
-          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           track_progress: true
           prompt: |
             REPO: ${{ github.repository }}
@@ -80,7 +80,7 @@ jobs:
           claude_args: |
             --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*)"
 
-      - name: Warn when API key missing
-        if: env.ANTHROPIC_API_KEY == ''
+      - name: Warn when credential missing
+        if: env.CLAUDE_CODE_OAUTH_TOKEN == ''
         run: |
-          echo "::warning::Secret ANTHROPIC_API_KEY not set — skipping Claude review."
+          echo "::warning::Secret CLAUDE_CODE_OAUTH_TOKEN not set — skipping Claude review."

--- a/.github/workflows/automation-claude-review.yml
+++ b/.github/workflows/automation-claude-review.yml
@@ -1,8 +1,12 @@
 name: Claude Code Review
 
-# 每个 PR 开启（或从 draft 转为 ready）时，由 Claude 做一次代码评审。
-# 与旧的 Copilot ruleset 行为对齐：只评审首版，不在每次 push 后重跑。
-# 需要重新评审时手动触发 workflow_dispatch 并填 PR 编号。
+# 由 Claude 对 PR 做代码评审：开启、重开、从 draft 转 ready，以及每次推送新提交时各跑一次。
+#
+# 覆盖每次推送而非只审首版，是因为评审之后追加的提交往往是「按意见快速改一下」，
+# 恰恰最容易引入新问题；只审首版会让这部分完全不过审。
+# 连续推送的浪费由下面的 concurrency 收敛：新一次运行会取消尚未完成的上一次。
+#
+# 需要对任意 PR 重新评审时，手动触发 workflow_dispatch 并填 PR 编号。
 #
 # 只对代码路径生效。纯配置类改动（release manifest 刷新、镜像同步、workflow 自身
 # 调整、文档）不进评审，既省额度也避免噪声。
@@ -11,7 +15,7 @@ name: Claude Code Review
 
 on:
   pull_request:
-    types: [opened, reopened, ready_for_review]
+    types: [opened, reopened, ready_for_review, synchronize]
     paths:
       - 'adp/**'
       - 'infra/**'


### PR DESCRIPTION
接 #341。#341 合入时只带走了路径过滤那一个提交,后续两个提交在合并之后才推上分支,因此没有进入 main。本 PR 补上剩余两条。

## 一、评审至今从未真正运行过

`#338` 合入的是第一版,用 `ANTHROPIC_API_KEY`;而仓库配置的 secret 是 `CLAUDE_CODE_OAUTH_TOKEN`。名字不匹配,于是每次触发都走跳过分支:

```
##[warning]Secret ANTHROPIC_API_KEY not set — skipping Claude review.
```

job 结论仍是 **success**——绿灯、零评论、零 inline review,没有任何信号提示评审没跑。实测于 run [29727792610](https://github.com/openbkn-ai/bkn-foundry/actions/runs/29727792610)(手动对 #339 触发)。

四处引用统一改为 `CLAUDE_CODE_OAUTH_TOKEN`。

## 二、触发时机覆盖每次推送

原先只在 `opened / reopened / ready_for_review` 时评审,PR 开启后追加的提交完全不过审。而评审之后追加的提交往往是「按意见快速改一下」,恰恰最容易引入新问题——把最该看的那部分排除在外了。

加上 `synchronize`。连续推送的浪费由已有的 `concurrency.cancel-in-progress` 收敛:新一次运行会取消尚未完成的上一次。

若后续发现重复评论过多,两个收敛手段:加 `use_sticky_comment` 把多次评审合并到同一条评论,或退回只审首版。

## 未改动的部分

- **路径过滤**:#341 已合入,本 PR 不动
- **只评论不改码**:`--allowedTools` 白名单只含 `mcp__github_inline_comment__create_inline_comment` 与 `Bash(gh pr comment|diff|view:*)`,不含 Edit / Write / git push / pr merge

## 验证

本地 `yaml.safe_load` 解析通过,并断言:凭据入参为 `claude_code_oauth_token`、`allowedTools` 不含任何写操作、`types` 含 `synchronize`、`paths` 保持四条代码路径。

**本 PR 自身不触发评审**——只改 `.github/workflows/`,不在 include 列表内。合入后对 #339 手动触发一次,才是真正的首次实跑。

## 建议(本 PR 未改)

跳过分支目前只发 `::warning::` 仍算 success。可考虑改为 `exit 1`,让凭据缺失直接红灯——否则同类问题还会以同样的方式静默复发,而这次已经发生过一回了。

🤖 Generated with [Claude Code](https://claude.com/claude-code)