### PR TITLE
fix(bkn-safe): 收紧角色绑定与授权写入的校验

### DIFF
--- a/.github/workflows/ci-bkn-safe.yml
+++ b/.github/workflows/ci-bkn-safe.yml
@@ -1,7 +1,10 @@
 name: ci-bkn-safe
 
-# Compile gate for PRs touching bkn-safe. Build-only for now; add `go test`
-# once the test harness is CI-ready.
+# Compile + unit-test gate for PRs touching bkn-safe. The suite is hermetic
+# (in-memory sqlite, no external services), so it needs no harness setup — it
+# was simply never wired in. While it was not, a seed invariant regressed on
+# main and stayed red for three days unnoticed (#254 changed the code without
+# the test).
 
 on:
   pull_request:
@@ -14,7 +17,7 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  build:
+  build-and-test:
     runs-on: ubuntu-latest
     defaults:
       run:
@@ -25,3 +28,4 @@ jobs:
         with:
           go-version-file: bkn-safe/server/go.mod
       - run: go build ./...
+      - run: go test ./...

--- a/bkn-safe/server/internal/httpapi/admin_test.go
+++ b/bkn-safe/server/internal/httpapi/admin_test.go
@@ -238,6 +238,125 @@ func TestThreeAdminRoleBindingsAreMutuallyExclusive(t *testing.T) {
 	}
 }
 
+// TestRoleBindingEscalationGuards covers the three ways a role-manager (the
+// `security` admin holds admin-role:members) could previously promote itself to
+// platform administrator without any other administrator's involvement:
+// binding super_admin, binding a system role to itself, and — via the two
+// sibling routes — minting a wildcard policy or grabbing safe_admin directly.
+func TestRoleBindingEscalationGuards(t *testing.T) {
+	r, e, db, users := newAdminServer(t)
+	ctx := t.Context()
+
+	const (
+		securityUser   = "u-security-esc"
+		securityRole   = "role-security-esc"
+		superRoleID    = "role-super-esc"
+		businessRoleID = "role-business-esc"
+		victim         = "u-victim-esc"
+	)
+	for _, id := range []string{securityUser, victim} {
+		if err := users.CreateLocalUser(ctx, &model.User{ID: id, Account: id, Name: id, Enabled: true}, "pw-init0"); err != nil {
+			t.Fatalf("create user %s: %v", id, err)
+		}
+	}
+	// The seeded super_admin role is identified by NAME, so the row must carry it.
+	if err := db.Create(&model.Role{ID: superRoleID, Name: superAdminRoleName, Source: model.RoleSourceSystem}).Error; err != nil {
+		t.Fatalf("create super role: %v", err)
+	}
+	if err := db.Create(&model.Role{ID: businessRoleID, Name: "builder", Source: model.RoleSourceBusiness}).Error; err != nil {
+		t.Fatalf("create business role: %v", err)
+	}
+	if err := e.Grant(superRoleID, "*", "*"); err != nil {
+		t.Fatalf("grant super role: %v", err)
+	}
+	// security: may administer (safe_admin) and may manage role membership and
+	// authorization — exactly the seeded grant set.
+	grantRoleOps(t, e, securityRole, "safe_admin", "manage")
+	grantRoleOps(t, e, securityRole, "admin-role", "members")
+	grantRoleOps(t, e, securityRole, "admin-authz", "grant")
+	bindRole(t, e, securityUser, securityRole)
+
+	// super_admin is a seed-fixed singleton: no caller may add a holder, and a
+	// holder may not appoint a successor either — there is no succession through
+	// this API at all.
+	t.Run("role-manager cannot bind super_admin", func(t *testing.T) {
+		if w := tokReq(t, r, http.MethodPost, "/api/safe/v1/admin/role-bindings", gin.H{
+			"accessor_id": victim, "role_id": superRoleID,
+		}, securityUser); w.Code != http.StatusForbidden {
+			t.Fatalf("want 403, got %d: %s", w.Code, w.Body.String())
+		}
+	})
+
+	t.Run("super_admin cannot appoint another super_admin", func(t *testing.T) {
+		if w := adminReq(t, r, http.MethodPost, "/api/safe/v1/admin/role-bindings", gin.H{
+			"accessor_id": victim, "role_id": superRoleID,
+		}); w.Code != http.StatusForbidden {
+			t.Fatalf("want 403, got %d: %s", w.Code, w.Body.String())
+		}
+	})
+
+	t.Run("super_admin binding cannot be removed either", func(t *testing.T) {
+		if w := adminReq(t, r, http.MethodDelete, "/api/safe/v1/admin/role-bindings", gin.H{
+			"accessor_id": adminSub, "role_id": superRoleID,
+		}); w.Code != http.StatusForbidden {
+			t.Fatalf("want 403, got %d: %s", w.Code, w.Body.String())
+		}
+	})
+
+	t.Run("cannot self-bind a system role", func(t *testing.T) {
+		sysRole := "role-system-esc"
+		if err := db.Create(&model.Role{ID: sysRole, Name: "ops", Source: model.RoleSourceSystem}).Error; err != nil {
+			t.Fatal(err)
+		}
+		if w := tokReq(t, r, http.MethodPost, "/api/safe/v1/admin/role-bindings", gin.H{
+			"accessor_id": securityUser, "role_id": sysRole,
+		}, securityUser); w.Code != http.StatusForbidden {
+			t.Fatalf("want 403, got %d: %s", w.Code, w.Body.String())
+		}
+	})
+
+	// Ordinary role assignment — including to oneself — must keep working.
+	t.Run("self-binding a business role still allowed", func(t *testing.T) {
+		if w := tokReq(t, r, http.MethodPost, "/api/safe/v1/admin/role-bindings", gin.H{
+			"accessor_id": securityUser, "role_id": businessRoleID,
+		}, securityUser); w.Code != http.StatusNoContent {
+			t.Fatalf("want 204, got %d: %s", w.Code, w.Body.String())
+		}
+	})
+
+	t.Run("custom role cannot be granted a wildcard type or operation", func(t *testing.T) {
+		if w := adminReq(t, r, http.MethodPost, "/api/safe/v1/admin/roles", gin.H{
+			"id": "role-custom-esc", "name": "custom-esc",
+		}); w.Code != http.StatusCreated {
+			t.Fatalf("create custom role: %d %s", w.Code, w.Body.String())
+		}
+		for _, body := range []gin.H{
+			{"resource": gin.H{"type": "*", "id": "*"}, "operations": []string{"view_detail"}},
+			{"resource": gin.H{"type": "agent", "id": "*"}, "operations": []string{"*"}},
+		} {
+			if w := tokReq(t, r, http.MethodPost, "/api/safe/v1/admin/roles/role-custom-esc/permissions", body, securityUser); w.Code != http.StatusBadRequest {
+				t.Fatalf("want 400 for %v, got %d: %s", body, w.Code, w.Body.String())
+			}
+		}
+		// Whole-type grants (concrete type, id "*") remain the documented use.
+		if w := tokReq(t, r, http.MethodPost, "/api/safe/v1/admin/roles/role-custom-esc/permissions", gin.H{
+			"resource": gin.H{"type": "agent", "id": "*"}, "operations": []string{"use"},
+		}, securityUser); w.Code != http.StatusNoContent {
+			t.Fatalf("whole-type grant should still work: %d %s", w.Code, w.Body.String())
+		}
+	})
+
+	t.Run("admin console cannot be object-granted", func(t *testing.T) {
+		if w := tokReq(t, r, http.MethodPost, "/api/safe/v1/admin/object-grants", gin.H{
+			"accessor_id": securityUser,
+			"resource":    gin.H{"type": adminConsoleResourceType, "id": "console"},
+			"operations":  []string{"manage"},
+		}, securityUser); w.Code != http.StatusForbidden {
+			t.Fatalf("want 403, got %d: %s", w.Code, w.Body.String())
+		}
+	})
+}
+
 func TestUserUpdateAndDelete(t *testing.T) {
 	r, e, db, users := newAdminServer(t)
 	ctx := t.Context()

--- a/bkn-safe/server/internal/httpapi/admin_test.go
+++ b/bkn-safe/server/internal/httpapi/admin_test.go
@@ -346,6 +346,14 @@ func TestRoleBindingEscalationGuards(t *testing.T) {
 		}
 	})
 
+	t.Run("admin console cannot be granted to a custom role either", func(t *testing.T) {
+		if w := tokReq(t, r, http.MethodPost, "/api/safe/v1/admin/roles/role-custom-esc/permissions", gin.H{
+			"resource": gin.H{"type": adminConsoleResourceType, "id": "console"}, "operations": []string{"manage"},
+		}, securityUser); w.Code != http.StatusForbidden {
+			t.Fatalf("want 403, got %d: %s", w.Code, w.Body.String())
+		}
+	})
+
 	t.Run("admin console cannot be object-granted", func(t *testing.T) {
 		if w := tokReq(t, r, http.MethodPost, "/api/safe/v1/admin/object-grants", gin.H{
 			"accessor_id": securityUser,

--- a/bkn-safe/server/internal/httpapi/authz.go
+++ b/bkn-safe/server/internal/httpapi/authz.go
@@ -607,6 +607,18 @@ func registerRoles(g *gin.RouterGroup, e *authz.Enforcer, db *gorm.DB) {
 			c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
 			return
 		}
+		// Same invariant the object-grant route enforces: administrative
+		// capability comes from a seeded role binding, never from a grant handed
+		// out at runtime. Without this, a custom role could be given
+		// safe_admin:console:manage and then bound to its own author. Today no
+		// role that can reach this route lacks that capability already, so this
+		// is defence in depth rather than a live hole — but that is a property of
+		// the current grant matrix, not of the code, and splitting out a
+		// role-management role would quietly turn it into one.
+		if req.Resource.Type == adminConsoleResourceType {
+			c.JSON(http.StatusForbidden, gin.H{"error": "admin console capability is granted by role binding, not by role permissions"})
+			return
+		}
 		for _, op := range req.Operations {
 			if err := e.GrantRolePermission(role.ID, req.Resource.Type, req.Resource.ID, op); err != nil {
 				serverError(c, err)

--- a/bkn-safe/server/internal/httpapi/authz.go
+++ b/bkn-safe/server/internal/httpapi/authz.go
@@ -6,6 +6,7 @@ package httpapi
 
 import (
 	"errors"
+	"log/slog"
 	"net/http"
 	"slices"
 
@@ -87,6 +88,14 @@ func registerAuthz(r *gin.Engine, e *authz.Enforcer, db *gorm.DB) {
 		if !bind(c, &req) {
 			return
 		}
+		// This route is tokenless by design (service-to-service, ClusterIP), so
+		// input validation is the only thing standing between a caller and an
+		// arbitrary policy row. It is staged deliberately — see policyGuard.
+		if err := rejectWildcardGrant(req.Resource.Type, req.Operations); err != nil {
+			c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+			return
+		}
+		auditPolicyWriteShape(c, db, "POST", req.AccessorID, req.Resource, req.Operations)
 		for _, op := range req.Operations {
 			if err := e.GrantObjectPermission(req.AccessorID, req.Resource.Type, req.Resource.ID, op); err != nil {
 				serverError(c, err)
@@ -105,6 +114,13 @@ func registerAuthz(r *gin.Engine, e *authz.Enforcer, db *gorm.DB) {
 		if !bind(c, &req) {
 			return
 		}
+		// A wildcard type here would drop every policy in the system — an
+		// authorization teardown, not a resource cleanup.
+		if err := rejectWildcardGrant(req.Resource.Type, nil); err != nil {
+			c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+			return
+		}
+		auditPolicyWriteShape(c, db, "DELETE", "", req.Resource, nil)
 		if err := e.RemoveResourcePolicies(req.Resource.Type, req.Resource.ID); err != nil {
 			serverError(c, err)
 			return
@@ -196,6 +212,40 @@ func registerRoleBindings(g *gin.RouterGroup, e *authz.Enforcer, db *gorm.DB) {
 			c.JSON(http.StatusBadRequest, gin.H{"error": "role_id does not match any role id: " + req.RoleID})
 			return
 		}
+		// Escalation guards. The permission gate on this route (admin-role:members)
+		// is held by `security` as well as `admin`, and neither the three-admin
+		// mutual-exclusion check below nor anything else stopped a holder from
+		// naming ITSELF as the grantee of a strictly more privileged role. Two
+		// narrow blocks close that without touching ordinary role assignment:
+		//
+		//  1. nobody may bind super_admin unless they already hold it — otherwise
+		//     the wildcard grant is one request away for any role-manager;
+		//  2. nobody may bind a seeded system role to themselves — self-promotion
+		//     always goes through another administrator.
+		//
+		// Business/custom roles are untouched: assigning those to anyone,
+		// including oneself, keeps working exactly as before.
+		caller := c.GetString(ctxAccessorID)
+		isSuper, err := isSuperAdminRoleID(c, db, req.RoleID)
+		if err != nil {
+			serverError(c, err)
+			return
+		}
+		if isSuper {
+			c.JSON(http.StatusForbidden, gin.H{"error": superAdminSeedOnlyMsg})
+			return
+		}
+		if caller != "" && caller == req.AccessorID {
+			role, err := roleByID(c, db, req.RoleID)
+			if err != nil {
+				serverError(c, err)
+				return
+			}
+			if role != nil && role.Source == model.RoleSourceSystem {
+				c.JSON(http.StatusForbidden, gin.H{"error": "a system role cannot be bound to yourself; ask another administrator"})
+				return
+			}
+		}
 		if isThreeAdminRoleID(req.RoleID) {
 			currentRoleIDs, err := e.RolesForAccessor(req.AccessorID)
 			if err != nil {
@@ -242,6 +292,18 @@ func registerRoleBindings(g *gin.RouterGroup, e *authz.Enforcer, db *gorm.DB) {
 		if !bind(c, &req) {
 			return
 		}
+		// Unbinding is blocked for the same reason binding is: with no API path
+		// to grant the role back, a removal would strip the platform of its only
+		// wildcard authority until a restart re-ran the seed.
+		isSuper, err := isSuperAdminRoleID(c, db, req.RoleID)
+		if err != nil {
+			serverError(c, err)
+			return
+		}
+		if isSuper {
+			c.JSON(http.StatusForbidden, gin.H{"error": superAdminSeedOnlyMsg})
+			return
+		}
 		if err := e.RemoveRole(req.AccessorID, req.RoleID); err != nil {
 			serverError(c, err)
 			return
@@ -253,6 +315,125 @@ func registerRoleBindings(g *gin.RouterGroup, e *authz.Enforcer, db *gorm.DB) {
 func isThreeAdminRoleID(roleID string) bool {
 	return slices.Contains(threeAdminRoleIDs, roleID)
 }
+
+// superAdminRoleName is the seeded role holding the platform-wide wildcard
+// grant (seed/data/roles.json). It is deliberately NOT part of
+// threeAdminRoleIDs: the three-admin rule is a separation-of-duties constraint
+// among admin/security/audit, while super_admin is a privilege ceiling. Adding
+// it to that list would make it mutually exclusive with the three, which the
+// seeded built-in admin (bound to super_admin) relies on not being the case.
+const superAdminRoleName = "super_admin"
+
+// policyGuard — why the tokenless /authz/policies validation is staged.
+//
+// The route writes casbin rows on behalf of every service that creates a
+// resource (12 call sites across vega, bkn, the execution factory and the model
+// factory), and bkn-safe ships independently of all of them, so there is no
+// window in which a stricter contract could be turned on atomically. The
+// staging is therefore:
+//
+//	stage 1 (here)  reject only the shapes no legitimate caller sends — a
+//	                wildcard resource type or a wildcard operation, both of
+//	                which produce a policy matching every object in the system.
+//	                Everything else is recorded, not refused.
+//	stage 2         require a service credential, accepted-but-logged at first,
+//	                so the un-migrated callers can be enumerated (#333).
+//	stage 3         flip both the credential and the shape findings below to
+//	                hard failures once the log is quiet.
+//
+// Deliberately NOT rejected in stage 1, despite looking wrong:
+//   - the all-zero "public" accessor — the execution factory grants built-in
+//     components to it on purpose (CreateIntCompPolicyForAllUsers);
+//   - a resource type absent from the seed catalog — vega owns two local-only
+//     types (internal_catalog, internal_resource) that were never registered;
+//   - an empty operation list — the execution factory sends one when a request
+//     carries no allow set, and it is a harmless no-op today;
+//   - a wildcard resource ID — bounded to one type, and cheap to keep working.
+func auditPolicyWriteShape(c *gin.Context, db *gorm.DB, verb, accessorID string, resource resourceRef, operations []string) {
+	var findings []string
+	if accessorID != "" {
+		if ok, err := accessorExists(c, db, accessorID); err == nil && !ok && accessorID != authz.PublicAccessorID {
+			findings = append(findings, "unknown accessor")
+		}
+	}
+	if resource.ID == "*" {
+		findings = append(findings, "wildcard resource id")
+	}
+	if valid, err := catalogOpSet(db, resource.Type); err == nil {
+		if len(valid) == 0 {
+			findings = append(findings, "resource type not in catalog")
+		} else {
+			for _, op := range operations {
+				if !valid[op] {
+					findings = append(findings, "operation not registered for type: "+op)
+				}
+			}
+		}
+	}
+	if len(findings) == 0 {
+		return
+	}
+	// Shadow only: this is the inventory that decides when stage 3 can land.
+	slog.WarnContext(c.Request.Context(), "authz policy write with a shape that a stricter contract would reject",
+		"verb", verb, "accessor_id", accessorID, "resource_type", resource.Type, "resource_id", resource.ID,
+		"operations", operations, "findings", findings, "client_ip", c.ClientIP())
+}
+
+// adminConsoleResourceType is the resource type whose grant opens the admin
+// surface (CanAdmin checks safe_admin:console:manage). It must only ever be
+// conferred by binding an administrative role, never by a one-off object grant
+// — otherwise the object-grant route becomes an admin-promotion route.
+const adminConsoleResourceType = "safe_admin"
+
+// rejectWildcardGrant blocks the two wildcard forms that make a policy match
+// everything. Callers that legitimately grant a whole resource type pass a
+// concrete type with id "*", which is unaffected.
+func rejectWildcardGrant(resourceType string, operations []string) error {
+	if resourceType == "*" {
+		return errors.New(`resource.type must be a concrete type (not "*")`)
+	}
+	for _, op := range operations {
+		if op == "*" {
+			return errors.New(`operation must be a concrete operation (not "*")`)
+		}
+	}
+	return nil
+}
+
+// roleByID loads a role without writing an HTTP response; nil means not found.
+// (loadRole is the handler-facing variant that answers 404 itself.)
+func roleByID(c *gin.Context, db *gorm.DB, id string) (*model.Role, error) {
+	var role model.Role
+	err := db.WithContext(c.Request.Context()).First(&role, "id = ?", id).Error
+	if errors.Is(err, gorm.ErrRecordNotFound) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	return &role, nil
+}
+
+// isSuperAdminRoleID reports whether roleID is the seeded super_admin role.
+// Resolved by name against the roles table rather than hardcoded, so it stays
+// correct if the seed UUID ever changes.
+func isSuperAdminRoleID(c *gin.Context, db *gorm.DB, roleID string) (bool, error) {
+	var n int64
+	if err := db.WithContext(c.Request.Context()).Model(&model.Role{}).
+		Where("id = ? AND name = ?", roleID, superAdminRoleName).Count(&n).Error; err != nil {
+		return false, err
+	}
+	return n > 0, nil
+}
+
+// superAdminSeedOnlyMsg explains why the super_admin membership is closed to
+// the API. The role is a singleton held by exactly one accessor, fixed by
+// seed/data/role-bindings.json: no API caller may add a holder (not even the
+// current one — there is no succession through this surface), and no API caller
+// may remove one, because after a removal nothing could put it back and the
+// platform would be left with no wildcard authority until a restart re-seeded
+// it. Changing the holder is a deliberate, out-of-band operation.
+const superAdminSeedOnlyMsg = "super_admin membership is fixed by the seed and cannot be changed through the API"
 
 // registerRoles mounts the role catalog endpoints (admin-only, under /admin).
 // Built-in (system/business) roles are read-only — their UUIDs are hardcoded in
@@ -415,6 +596,15 @@ func registerRoles(g *gin.RouterGroup, e *authz.Enforcer, db *gorm.DB) {
 			Operations []string    `json:"operations" binding:"required"`
 		}
 		if !bind(c, &req) {
+			return
+		}
+		// A wildcard resource TYPE (or operation) makes the policy match every
+		// object in the system — the same shape as the seeded super_admin grant.
+		// Minting that from a custom role turns this route into an escalation
+		// path. A wildcard resource ID stays allowed: "whole type" is this
+		// route's documented purpose and is what the admin console sends.
+		if err := rejectWildcardGrant(req.Resource.Type, req.Operations); err != nil {
+			c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
 			return
 		}
 		for _, op := range req.Operations {

--- a/bkn-safe/server/internal/httpapi/objectgrants.go
+++ b/bkn-safe/server/internal/httpapi/objectgrants.go
@@ -148,6 +148,14 @@ func registerObjectGrants(g *gin.RouterGroup, e *authz.Enforcer, db *gorm.DB) {
 			c.JSON(http.StatusBadRequest, gin.H{"error": "operations required; use DELETE to revoke a grant"})
 			return
 		}
+		// safe_admin:console:manage is exactly what CanAdmin tests, so granting it
+		// here would promote any grantee to platform administrator through the
+		// object-grant route — bypassing role binding and its escalation guards.
+		// Administrative capability is role-conferred only.
+		if req.Resource.Type == adminConsoleResourceType {
+			c.JSON(http.StatusForbidden, gin.H{"error": "admin console capability is granted by role binding, not by object grants"})
+			return
+		}
 		// Grantee must be a user (apps are user rows too). Departments/groups are
 		// rejected: their grants never match at enforce time.
 		ok, err := isUserAccessor(c, db, req.AccessorID)

--- a/bkn-safe/server/internal/httpapi/router_test.go
+++ b/bkn-safe/server/internal/httpapi/router_test.go
@@ -166,3 +166,98 @@ func TestAuthzBadRequest(t *testing.T) {
 		t.Errorf("expected 400, got %d", w.Code)
 	}
 }
+
+// TestPolicyWriteWildcardGuard covers the stage-1 contract on the tokenless
+// /authz/policies route: the two wildcard shapes that produce a policy matching
+// every object are refused, and every shape a real service sends today still
+// works. The second half is the compatibility evidence — 12 call sites across
+// vega, bkn, the execution factory and the model factory depend on it.
+func TestPolicyWriteWildcardGuard(t *testing.T) {
+	r, e, _ := newTestServer(t)
+
+	refused := []struct {
+		name string
+		body map[string]any
+	}{
+		{"wildcard type", map[string]any{
+			"accessor_id": "u-1",
+			"resource":    map[string]string{"type": "*", "id": "*"},
+			"operations":  []string{"view_detail"},
+		}},
+		{"wildcard operation", map[string]any{
+			"accessor_id": "u-1",
+			"resource":    map[string]string{"type": "agent", "id": "a-1"},
+			"operations":  []string{"*"},
+		}},
+	}
+	for _, c := range refused {
+		t.Run("refuse "+c.name, func(t *testing.T) {
+			if w := do(t, r, http.MethodPost, "/api/safe/v1/authz/policies", c.body); w.Code != http.StatusBadRequest {
+				t.Fatalf("want 400, got %d: %s", w.Code, w.Body.String())
+			}
+		})
+	}
+
+	t.Run("refuse wildcard type on delete", func(t *testing.T) {
+		if w := do(t, r, http.MethodDelete, "/api/safe/v1/authz/policies", map[string]any{
+			"resource": map[string]string{"type": "*", "id": "*"},
+		}); w.Code != http.StatusBadRequest {
+			t.Fatalf("want 400, got %d: %s", w.Code, w.Body.String())
+		}
+	})
+
+	// Shapes that are logged but must NOT be refused in stage 1.
+	allowed := []struct {
+		name string
+		body map[string]any
+	}{
+		{"ordinary creation grant", map[string]any{
+			"accessor_id": "u-1",
+			"resource":    map[string]string{"type": "agent", "id": "a-1"},
+			"operations":  []string{"use", "modify"},
+		}},
+		{"public accessor (built-in components)", map[string]any{
+			"accessor_id": authz.PublicAccessorID,
+			"resource":    map[string]string{"type": "tool_box", "id": "tb-1"},
+			"operations":  []string{"execute"},
+		}},
+		{"type outside the seeded catalog (vega internal_*)", map[string]any{
+			"accessor_id": "u-1",
+			"resource":    map[string]string{"type": "internal_resource", "id": "ir-1"},
+			"operations":  []string{"view_detail"},
+		}},
+		{"empty operation list (execution factory no-op)", map[string]any{
+			"accessor_id": "u-1",
+			"resource":    map[string]string{"type": "agent", "id": "a-2"},
+			"operations":  []string{},
+		}},
+		{"wildcard resource id", map[string]any{
+			"accessor_id": "u-1",
+			"resource":    map[string]string{"type": "agent", "id": "*"},
+			"operations":  []string{"use"},
+		}},
+	}
+	for _, c := range allowed {
+		t.Run("allow "+c.name, func(t *testing.T) {
+			if w := do(t, r, http.MethodPost, "/api/safe/v1/authz/policies", c.body); w.Code != http.StatusNoContent {
+				t.Fatalf("want 204, got %d: %s", w.Code, w.Body.String())
+			}
+		})
+	}
+
+	// The grants that were accepted must actually be in force.
+	ok, err := e.Check("u-1", "agent", "a-1", "use")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !ok {
+		t.Error("ordinary creation grant did not take effect")
+	}
+	ok, err = e.Check("someone-else", "tool_box", "tb-1", "execute")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !ok {
+		t.Error("public-accessor grant should reach every requester")
+	}
+}

--- a/bkn-safe/server/internal/seed/seed_test.go
+++ b/bkn-safe/server/internal/seed/seed_test.go
@@ -167,8 +167,15 @@ func TestSeedsAdminUser(t *testing.T) {
 	if !admin.Enabled || admin.Source != model.SourceLocal || admin.PasswordHash == "" {
 		t.Errorf("admin row malformed: %+v", admin)
 	}
-	if !admin.MustChangePassword {
-		t.Error("seeded admin must have MustChangePassword=true")
+	// The built-in admin is seeded WITHOUT a forced password change: #254 turned
+	// it off because unattended install logs in as admin immediately after the
+	// seed and a forced change blocks it. The assertion is pinned to that
+	// behaviour so the two cannot drift apart again — this test had been failing
+	// on main since #254 landed, unnoticed because CI did not run it.
+	// Whether to reintroduce a forced change (and how, without breaking
+	// unattended install) is an open decision tracked in #328.
+	if admin.MustChangePassword {
+		t.Error("seeded admin must not force a password change (would block unattended install, see #254)")
 	}
 	// Super-admin wildcard reaches the admin via the seeded role binding.
 	ok, err := e.Check(adminUserID, "catalog", "adp_bkn_catalog", "view_detail")


### PR DESCRIPTION
Closes #330。父 Epic：#328。

## 这个 PR 解决什么问题

审计 bkn-safe 时发现，持有"管理角色成员"权限的人（安全管理员即持有该权限）可以在无人配合的情况下，通过四条不同的操作路径把自己变成超级管理员。另外，服务之间调用的授权写入接口不校验写入内容，可以写进匹配系统中每一个对象的授权策略。本 PR 修复这些问题，并补上一道本应存在的 CI 检查。

## 一、四条可以自行提升为超级管理员的路径

**第一条：直接给自己绑定 `super_admin` 角色。** 代码中有一份"受保护角色"名单，用于保证系统管理员、安全管理员、审计管理员三者互斥（即 #238 建立的三权分立）。但这份名单只列了这三个角色，唯独漏了持有平台全量权限的 `super_admin`，因此绑定它不受任何限制；接口也不检查调用者是否把自己写成了被授予人。

现在的处理：`super_admin` 的归属**完全由安装时的初始化数据决定，接口上既不能新增持有者，也不能解除绑定**。即使当前的超级管理员本人也不能指定继任者，这是产品上明确的决定。禁止解除绑定的原因是：既然没有任何接口能把这个角色再绑回去，一旦解除，平台将失去唯一的全量权限持有者，只能靠重启服务重新执行初始化才能恢复。

**第二条：把系统级角色绑给自己。** 现在一律拒绝，自我提升必须经由另一位管理员操作。业务角色和自定义角色不受影响，包括分配给自己，行为与之前完全一致。

**第三条：绕道自定义角色。** 先新建一个自定义角色，给它授予"所有资源类型的所有操作"，再把这个角色绑给自己，效果等同于超级管理员。现在授权时不再接受"资源类型"或"操作"为通配符。需要说明的是，"资源编号"为通配符（即一次性授权某一整类资源）**仍然允许**，这是该接口的既定用途，管理台也在使用。

**第四条：绕道对象授权。** 判断一个人是否为管理员，实际检查的是他对 `safe_admin` 这一资源类型是否有管理权限，而对象授权接口原先可以直接授予它。现在该资源类型已从对象授权面移除，管理台权限只能通过角色绑定获得。

## 二、无需凭据即可写入任意授权策略的接口

`/authz/policies` 按设计是给后端服务之间调用的，不校验调用方身份，前提是"只有集群内部能访问"。但它同时对写入的内容不做任何检查：授予谁、授予什么资源、授予什么操作，全部原样落库。作为对比，供管理台使用的对象授权接口对这些都有完整校验，而两者写的是同一张表。

**本 PR 只做第一步。** 全平台有 12 处代码调用这个接口，分布在数据平台、知识网络、执行工厂和模型工厂，每次创建资源都会经过它；而 bkn-safe 与这些服务各自独立发版，不存在可以同时切换的时机。因此分三步：

1. **本 PR**：只拒绝正常调用方绝不会发送、但一旦出现就会让策略匹配系统中每一个对象的写法，即资源类型为通配符、或操作为通配符。删除接口同样拒绝通配的资源类型，否则一次调用就能清空全平台的授权数据。
2. **后续**：要求调用方携带服务凭据，但服务端先接受不带凭据的请求并记录下来，以便统计还有哪些调用方没有改造完（见 #333）。
3. **最后**：等记录清零，再把凭据和第 1 步之外的其他检查一并改为强制。

## 三、补上 CI 检查

bkn-safe 的 CI 此前只做编译，不跑单元测试，注释里写着"等测试环境就绪后再加"。实际上这套测试完全自足（使用内存数据库，不依赖任何外部服务），一直都能跑，只是从未接入。

正因为没接，一处测试失败在主干上存在了三天无人知晓：#254 关闭了内置管理员的"首次登录必须改密"，但没有同步修改断言。#254 这么做是有原因的——无人值守安装会在初始化完成后立即以管理员身份登录，强制改密会把安装卡住。因此本 PR **不改动该行为**，只把断言固定到 #254 的实际行为上，让两者不会再次分叉。是否以及如何在不影响无人值守安装的前提下重新引入强制改密，作为待定事项记录在 #328。

## 兼容性

这是本 PR 最需要评审的部分。改动落在全平台创建资源都会经过的授权写入路径上，一旦收得过紧，表现就是安装失败或功能不可用。

以下三种写法**看起来不合理，但真实调用方确实在这么用**，逐一核对调用方代码后确认保留，并写成测试固定下来：

| 写法 | 谁在用 | 收紧的后果 |
|---|---|---|
| 被授予人是全零编号的"公共访问者" | 执行工厂用它把内置组件授权给全体用户 | 内置工具箱、算子、MCP 组件注册后无人可用 |
| 资源类型不在初始化目录中 | 数据平台有两个自用类型从未注册进 bkn-safe | 这两类资源的授权全部写入失败 |
| 操作列表为空 | 执行工厂在请求不带授权集时会发空列表 | 目前是无副作用的空操作，拒绝它会让调用方报错 |

资源编号为通配符同样保留，其影响范围限于单一资源类型。这些写法改为记录到日志，等记录清零后才进行下一步收紧。

## 测试

新增两组测试，`go vet`、`go build`、`go test ./...` 全部通过：

- 四条提权路径逐条验证被拒绝，同时验证"业务角色分配给自己仍然允许""按整类资源授权仍然可用"这两项没有被误伤；
- 授权写入接口的三种拒绝写法与五种放行写法逐条验证，放行的部分即上表的兼容性证据，并验证放行后的授权确实生效。

## 测试环境验证结果

已在测试环境完成**存量升级**路径的验证：在既有数据库上替换镜像并滚动升级，初始化正常执行，全部服务运行正常，依赖 bkn-safe 的三个服务（知识网络、数据平台、执行工厂）均未出现授权相关报错。

授权写入接口的七种情形逐条实测，结果全部符合预期：三种应当拒绝的写法均被拒绝，四种应当放行的写法均正常写入。进一步验证了授权的实际效果：已授权的操作判定为允许，未授权的操作判定为拒绝，公共访问者的授权对任意请求者均生效。日志记录按预期工作，并实际印证了"数据平台自用资源类型确实不在初始化目录中"这一判断，说明不对其硬性拒绝是正确的。验证过程中产生的测试数据已清理。

## 尚未验证的部分

- **四条提权路径未在测试环境端到端验证。** 通过脚本获取管理员令牌时卡在授权码交换环节，属环境问题，与本 PR 无关。这四条已有针对真实路由的单元测试覆盖，测试环境能额外提供的只是令牌传递链路，而本 PR 未改动该部分。**建议合并前由人工在管理台上实际操作一遍角色绑定。**
- **全新安装路径未验证**（验证所用为存量环境）。
- 密码接口的访问频率限制已移出本 issue，由 #342（统一的访问频率限制与防暴力破解模块）承接。
