### PR TITLE
ci: 修复 Claude 评审的手动触发路径

### DIFF
--- a/.github/workflows/automation-claude-review.yml
+++ b/.github/workflows/automation-claude-review.yml
@@ -49,14 +49,29 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
-          fetch-depth: 1
+          # pull_request 事件下 checkout 会自动落到 PR 的 merge ref；
+          # workflow_dispatch 下只会拿到默认分支，需要下一步显式切到 PR 分支，
+          # 因此这里放开深度以便 gh pr checkout 能建立分支。
+          fetch-depth: ${{ github.event_name == 'workflow_dispatch' && 0 || 1 }}
+
+      - name: Checkout PR branch (manual trigger)
+        if: github.event_name == 'workflow_dispatch'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          gh pr checkout "$PR_NUMBER"
+          echo "已切到 PR #$PR_NUMBER: $(git rev-parse --abbrev-ref HEAD) @ $(git rev-parse --short HEAD)"
 
       - name: Claude review
         if: env.CLAUDE_CODE_OAUTH_TOKEN != ''
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          track_progress: true
+          # track_progress 只支持 pull_request / issues / issue_comment /
+          # pull_request_review(_comment) 事件，在 workflow_dispatch 下会直接
+          # 报错退出——手动触发那条路径因此从未可用。按事件类型开关。
+          track_progress: ${{ github.event_name != 'workflow_dispatch' }}
           prompt: |
             REPO: ${{ github.repository }}
             PR NUMBER: ${{ env.PR_NUMBER }}


### PR DESCRIPTION
接 #343。凭据修好之后，手动触发这条路径暴露出两个问题——两个都会让 `workflow_dispatch` 完全不可用。

## 问题一：`track_progress` 与 `workflow_dispatch` 不兼容

```
##[error]Action failed with error: track_progress is only supported for events:
pull_request, issues, issue_comment, pull_request_review_comment,
pull_request_review. Current event: workflow_dispatch
```

action 直接报错退出。也就是说 workflow 自带的 `pr_number` 输入从加上那天起就是形同虚设的。

改为按事件类型开关：`track_progress: ${{ github.event_name != 'workflow_dispatch' }}`。

## 问题二：手动触发时检出的是 main，不是 PR 分支

`pull_request` 事件下 `actions/checkout` 会自动落到 PR 的 merge ref；`workflow_dispatch` 下只拿到默认分支。即便问题一修好，评审的也是 main 的代码，而不是 PR 的改动——会得到一份看似正常、实则完全无关的评审。

补一步 `gh pr checkout "$PR_NUMBER"`，并把 `fetch-depth` 在手动触发时放开到 0 供其建立分支。

## 验证

实测于 run [29728907236](https://github.com/openbkn-ai/bkn-foundry/actions/runs/29728907236)（对 #339 手动触发）。#343 的凭据修复生效后，这次是**真实红灯**而非静默 success，错误信息才得以暴露。

本地 `yaml.safe_load` 解析通过，步骤顺序与条件符合预期。

## 仍未改动

`pull_request` 自动触发那条路径一直是好的，本 PR 不涉及。

跳过分支目前只发 `::warning::` 仍算 success，建议改成 `exit 1`——凭据类问题已经以静默方式发生过一次（#343）。仍未改，想先听意见。

🤖 Generated with [Claude Code](https://claude.com/claude-code)