### PR TITLE
fix(execution-factory): 公开面函数执行与 AI 生成接口补授权门禁（#345 高危项）

### DIFF
--- a/adp/execution-factory/operator-integration/server/driveradapters/common/ai_generation.go
+++ b/adp/execution-factory/operator-integration/server/driveradapters/common/ai_generation.go
@@ -14,6 +14,7 @@ import (
 	"github.com/openbkn-ai/adp/execution-factory/operator-integration/server/infra/validator"
 	"github.com/openbkn-ai/adp/execution-factory/operator-integration/server/interfaces"
 	"github.com/openbkn-ai/adp/execution-factory/operator-integration/server/logics/aigeneration"
+	"github.com/openbkn-ai/adp/execution-factory/operator-integration/server/logics/auth"
 	"github.com/openbkn-ai/adp/execution-factory/operator-integration/server/utils"
 )
 
@@ -28,6 +29,7 @@ type aiGenerationHandler struct {
 	aiGenerationService interfaces.AIGenerationService
 	Logger              interfaces.Logger
 	Validator           interfaces.Validator
+	AuthService         interfaces.IAuthorizationService
 }
 
 var (
@@ -43,13 +45,22 @@ func NewAIGenerationHandler() AIGenerationHandler {
 			aiGenerationService: aigeneration.NewAIGenerationService(),
 			Logger:              confLoader.GetLogger(),
 			Validator:           validator.NewValidator(),
+			AuthService:         auth.NewAuthServiceImpl(),
 		}
 	})
 	return aiGenerationH
 }
 
 // FunctionAIGeneration 处理函数 AI 生成请求
+//
+// 该接口调用大模型生成函数代码并消耗额度，在公开面要求调用方在算子类型上持有 create
+// 权限——与「生成出来的函数最终落地为算子」保持同一口径（见 #345）。
 func (h *aiGenerationHandler) FunctionAIGeneration(c *gin.Context) {
+	if err := requireOperatorTypePermission(c.Request.Context(), h.AuthService,
+		interfaces.AuthOperationTypeCreate); err != nil {
+		rest.ReplyError(c, err)
+		return
+	}
 	req := &interfaces.FunctionAIGenerateReq{}
 	if err := c.ShouldBindUri(req); err != nil {
 		rest.ReplyError(c, err)
@@ -192,6 +203,11 @@ func isEndMarker(line string) bool {
 
 // GetPromptTemplate 获取指定类型的提示词模板
 func (h *aiGenerationHandler) GetPromptTemplate(c *gin.Context) {
+	if err := requireOperatorTypePermission(c.Request.Context(), h.AuthService,
+		interfaces.AuthOperationTypeCreate); err != nil {
+		rest.ReplyError(c, err)
+		return
+	}
 	req := &interfaces.GetPromptTemplateReq{}
 	if err := c.ShouldBindUri(req); err != nil {
 		rest.ReplyError(c, err)

--- a/adp/execution-factory/operator-integration/server/driveradapters/common/authz.go
+++ b/adp/execution-factory/operator-integration/server/driveradapters/common/authz.go
@@ -1,0 +1,57 @@
+package common
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/openbkn-ai/adp/execution-factory/operator-integration/server/infra/common"
+	"github.com/openbkn-ai/adp/execution-factory/operator-integration/server/infra/errors"
+	"github.com/openbkn-ai/adp/execution-factory/operator-integration/server/interfaces"
+)
+
+// requireOperatorTypePermission 校验调用方在算子类型上持有指定操作权限。
+//
+// 用于 /function/execute、/ai_generate/* 这类不隶属于任何已存在资源的端点：它们操作的是
+// 尚未落库的函数代码，没有资源 ID 可判，因此按类型级（ResourceIDAll）判定，口径与
+// logics/auth/decision.go 中 CheckCreatePermission 一致。
+//
+// 仅在公开面生效。内部面（internal-v1）由服务间调用，身份来自 X-Account-ID 头而非经校验的
+// 令牌，沿用服务内既有惯用法（见 logics/operator/query.go:31）跳过判定，避免打断现有调用方。
+func requireOperatorTypePermission(
+	ctx context.Context,
+	authService interfaces.IAuthorizationService,
+	operation interfaces.AuthOperationType,
+) error {
+	if !common.IsPublicAPIFromCtx(ctx) {
+		return nil
+	}
+	authContext, ok := common.GetAccountAuthContextFromCtx(ctx)
+	if !ok || authContext == nil {
+		return errors.DefaultHTTPError(ctx, http.StatusUnauthorized, "authentication required")
+	}
+	accessor := &interfaces.AuthAccessor{
+		ID:   authContext.AccountID,
+		Type: authContext.AccountType,
+	}
+	authorized, err := authService.OperationCheckAll(ctx, accessor,
+		interfaces.ResourceIDAll, interfaces.AuthResourceTypeOperator, operation)
+	if err != nil {
+		return err
+	}
+	if !authorized {
+		return errors.NewHTTPError(ctx, http.StatusForbidden, forbiddenCodeFor(operation), nil)
+	}
+	return nil
+}
+
+// forbiddenCodeFor 返回与操作对应的拒绝错误码，使前端拿到的提示与动作一致。
+func forbiddenCodeFor(operation interfaces.AuthOperationType) errors.ErrorCode {
+	switch operation {
+	case interfaces.AuthOperationTypeExecute:
+		return errors.ErrExtCommonUseForbidden
+	case interfaces.AuthOperationTypeCreate:
+		return errors.ErrExtCommonAddForbidden
+	default:
+		return errors.ErrExtCommonViewForbidden
+	}
+}

--- a/adp/execution-factory/operator-integration/server/driveradapters/common/authz_routes_test.go
+++ b/adp/execution-factory/operator-integration/server/driveradapters/common/authz_routes_test.go
@@ -1,0 +1,103 @@
+package common
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/openbkn-ai/adp/execution-factory/operator-integration/server/infra/common"
+	"github.com/openbkn-ai/adp/execution-factory/operator-integration/server/interfaces"
+	"github.com/openbkn-ai/adp/execution-factory/operator-integration/server/mocks"
+	. "github.com/smartystreets/goconvey/convey"
+	"go.uber.org/mock/gomock"
+)
+
+// newGatedPublicEngine 按 rest_public_handler.go 的接线方式注册三条受门禁保护的公开面
+// 路由，并模拟 middlewareIntrospectVerify 的产出（公开面标记 + 已校验身份）。
+//
+// 处理器的其余依赖留空：授权被拒时应当在触达任何业务逻辑之前返回，因此若门禁调用被误删，
+// 请求会继续往下走并因空依赖 panic 或返回非 403，两种情况本用例都会失败。
+func newGatedPublicEngine(authService interfaces.IAuthorizationService) *gin.Engine {
+	gin.SetMode(gin.TestMode)
+	engine := gin.New()
+	engine.Use(func(c *gin.Context) {
+		ctx := common.SetPublicAPIToCtx(c.Request.Context(), true)
+		ctx = common.SetAccountAuthContextToCtx(ctx, &interfaces.AccountAuthContext{
+			AccountID:   testAccountID,
+			AccountType: interfaces.AccessorTypeUser,
+		})
+		c.Request = c.Request.WithContext(ctx)
+		c.Next()
+	})
+
+	proxy := &unifiedProxyHandler{AuthService: authService}
+	aiGen := &aiGenerationHandler{AuthService: authService}
+
+	group := engine.Group("/api/agent-operator-integration/v1")
+	group.POST("/function/execute", proxy.FunctionExecute)
+	group.POST("/ai_generate/function/:type", aiGen.FunctionAIGeneration)
+	group.GET("/ai_generate/prompt/:type", aiGen.GetPromptTemplate)
+	return engine
+}
+
+// TestGatedPublicRoutesRejectUnauthorized 守住门禁的接线点。
+//
+// authz_test.go 只覆盖了 requireOperatorTypePermission 这个辅助函数本身；若有人重构
+// proxy.go / ai_generation.go 时删掉了 handler 里的那行调用，那些用例仍会全绿。本用例
+// 走完整的 gin 路由，因此调用点被撤掉时会立刻失败。
+func TestGatedPublicRoutesRejectUnauthorized(t *testing.T) {
+	type route struct {
+		method string
+		path   string
+		body   string
+	}
+	routes := []route{
+		{http.MethodPost, "/api/agent-operator-integration/v1/function/execute", `{"code":"print(1)","language":"python"}`},
+		{http.MethodPost, "/api/agent-operator-integration/v1/ai_generate/function/code", `{}`},
+		{http.MethodGet, "/api/agent-operator-integration/v1/ai_generate/prompt/code", ""},
+	}
+
+	Convey("缺权限时三条公开面路由一律拒绝", t, func() {
+		for _, r := range routes {
+			ctrl := gomock.NewController(t)
+			authService := mocks.NewMockIAuthorizationService(ctrl)
+			authService.EXPECT().
+				OperationCheckAll(gomock.Any(), gomock.Any(), interfaces.ResourceIDAll,
+					interfaces.AuthResourceTypeOperator, gomock.Any()).
+				Return(false, nil).
+				Times(1)
+
+			engine := newGatedPublicEngine(authService)
+			recorder := httptest.NewRecorder()
+			req := httptest.NewRequest(r.method, r.path, strings.NewReader(r.body))
+			req.Header.Set("Content-Type", "application/json")
+			engine.ServeHTTP(recorder, req)
+
+			So(recorder.Code, ShouldEqual, http.StatusForbidden)
+			ctrl.Finish()
+		}
+	})
+
+	Convey("门禁在解析请求体之前生效，畸形请求体同样先被拒", t, func() {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+		authService := mocks.NewMockIAuthorizationService(ctrl)
+		authService.EXPECT().
+			OperationCheckAll(gomock.Any(), gomock.Any(), interfaces.ResourceIDAll,
+				interfaces.AuthResourceTypeOperator, interfaces.AuthOperationTypeExecute).
+			Return(false, nil)
+
+		engine := newGatedPublicEngine(authService)
+		recorder := httptest.NewRecorder()
+		req := httptest.NewRequest(http.MethodPost,
+			"/api/agent-operator-integration/v1/function/execute",
+			strings.NewReader("not-json-at-all"))
+		req.Header.Set("Content-Type", "application/json")
+		engine.ServeHTTP(recorder, req)
+
+		// 若门禁排在 ShouldBindJSON 之后，这里会是 400 而不是 403。
+		So(recorder.Code, ShouldEqual, http.StatusForbidden)
+	})
+}

--- a/adp/execution-factory/operator-integration/server/driveradapters/common/authz_test.go
+++ b/adp/execution-factory/operator-integration/server/driveradapters/common/authz_test.go
@@ -1,0 +1,83 @@
+package common
+
+import (
+	"context"
+	"testing"
+
+	"github.com/openbkn-ai/adp/execution-factory/operator-integration/server/infra/common"
+	"github.com/openbkn-ai/adp/execution-factory/operator-integration/server/infra/errors"
+	"github.com/openbkn-ai/adp/execution-factory/operator-integration/server/interfaces"
+	"github.com/openbkn-ai/adp/execution-factory/operator-integration/server/mocks"
+	. "github.com/smartystreets/goconvey/convey"
+	"go.uber.org/mock/gomock"
+)
+
+const testAccountID = "11111111-1111-4111-8111-111111111111"
+
+// publicCtx 构造一个带已校验身份的公开面 context，等价于 middlewareIntrospectVerify 的产物。
+func publicCtx() context.Context {
+	ctx := common.SetPublicAPIToCtx(context.Background(), true)
+	return common.SetAccountAuthContextToCtx(ctx, &interfaces.AccountAuthContext{
+		AccountID:   testAccountID,
+		AccountType: interfaces.AccessorTypeUser,
+	})
+}
+
+func TestRequireOperatorTypePermission(t *testing.T) {
+	Convey("公开面持有权限时放行", t, func() {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+		authService := mocks.NewMockIAuthorizationService(ctrl)
+		authService.EXPECT().
+			OperationCheckAll(gomock.Any(), gomock.Any(), interfaces.ResourceIDAll,
+				interfaces.AuthResourceTypeOperator, interfaces.AuthOperationTypeExecute).
+			Return(true, nil)
+
+		err := requireOperatorTypePermission(publicCtx(), authService, interfaces.AuthOperationTypeExecute)
+
+		So(err, ShouldBeNil)
+	})
+
+	Convey("公开面缺权限时拒绝，错误码随操作而变", t, func() {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+		authService := mocks.NewMockIAuthorizationService(ctrl)
+		authService.EXPECT().
+			OperationCheckAll(gomock.Any(), gomock.Any(), interfaces.ResourceIDAll,
+				interfaces.AuthResourceTypeOperator, interfaces.AuthOperationTypeExecute).
+			Return(false, nil)
+
+		err := requireOperatorTypePermission(publicCtx(), authService, interfaces.AuthOperationTypeExecute)
+
+		So(err, ShouldNotBeNil)
+	})
+
+	Convey("公开面无身份时按未认证拒绝，且不去问授权服务", t, func() {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+		authService := mocks.NewMockIAuthorizationService(ctrl)
+
+		ctx := common.SetPublicAPIToCtx(context.Background(), true)
+		err := requireOperatorTypePermission(ctx, authService, interfaces.AuthOperationTypeExecute)
+
+		So(err, ShouldNotBeNil)
+	})
+
+	Convey("内部面直接放行，不触发授权判定", t, func() {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+		authService := mocks.NewMockIAuthorizationService(ctrl)
+
+		err := requireOperatorTypePermission(context.Background(), authService, interfaces.AuthOperationTypeExecute)
+
+		So(err, ShouldBeNil)
+	})
+}
+
+func TestForbiddenCodeFor(t *testing.T) {
+	Convey("拒绝错误码与动作对应", t, func() {
+		So(forbiddenCodeFor(interfaces.AuthOperationTypeExecute), ShouldEqual, errors.ErrExtCommonUseForbidden)
+		So(forbiddenCodeFor(interfaces.AuthOperationTypeCreate), ShouldEqual, errors.ErrExtCommonAddForbidden)
+		So(forbiddenCodeFor(interfaces.AuthOperationTypeView), ShouldEqual, errors.ErrExtCommonViewForbidden)
+	})
+}

--- a/adp/execution-factory/operator-integration/server/driveradapters/common/proxy.go
+++ b/adp/execution-factory/operator-integration/server/driveradapters/common/proxy.go
@@ -13,6 +13,7 @@ import (
 	"github.com/openbkn-ai/adp/execution-factory/operator-integration/server/infra/errors"
 	"github.com/openbkn-ai/adp/execution-factory/operator-integration/server/infra/rest"
 	"github.com/openbkn-ai/adp/execution-factory/operator-integration/server/interfaces"
+	"github.com/openbkn-ai/adp/execution-factory/operator-integration/server/logics/auth"
 	"github.com/openbkn-ai/adp/execution-factory/operator-integration/server/logics/metadata"
 	"github.com/openbkn-ai/adp/execution-factory/operator-integration/server/logics/sandbox"
 	"github.com/openbkn-ai/adp/execution-factory/operator-integration/server/utils"
@@ -33,6 +34,7 @@ type unifiedProxyHandler struct {
 	Logger          interfaces.Logger
 	MetadataService interfaces.IMetadataService
 	SessionPool     sandbox.SessionPool
+	AuthService     interfaces.IAuthorizationService
 }
 
 var (
@@ -47,14 +49,24 @@ func NewUnifiedProxyHandler() UnifiedProxyHandler {
 			Logger:          conf.Logger,
 			MetadataService: metadata.NewMetadataService(),
 			SessionPool:     sandbox.GetSessionPool(),
+			AuthService:     auth.NewAuthServiceImpl(),
 		}
 	})
 	return proxyHandler
 }
 
 // FunctionExecute 函数执行
+//
+// 该接口在沙箱中执行调用方提交的任意代码，因此在公开面要求调用方在算子类型上持有 execute
+// 权限（见 #345）。此前公开面无任何授权判定，任何持有有效令牌的账号——包括权限集为空的
+// 账号——都可借此获得沙箱内的代码执行能力。
 func (h *unifiedProxyHandler) FunctionExecute(c *gin.Context) {
 	var err error
+	if err = requireOperatorTypePermission(c.Request.Context(), h.AuthService,
+		interfaces.AuthOperationTypeExecute); err != nil {
+		rest.ReplyError(c, err)
+		return
+	}
 	req := &interfaces.FunctionProxyExecuteCodeReq{}
 	if err = c.ShouldBindJSON(req); err != nil {
 		err = errors.NewHTTPError(c.Request.Context(), http.StatusBadRequest, errors.ErrExtDebugParamsInvalid,


### PR DESCRIPTION
## 问题

执行工厂公开面 `/api/agent-operator-integration/v1` 上，`/function/execute` 在沙箱中执行调用方提交的任意 Python 代码，此前无任何授权判定：introspect 中间件只校验令牌有效，此后不再判定调用方对资源的权限。

任何持有有效令牌的账号——包括权限集为空的账号——都可借此获得沙箱内的代码执行能力。#326 处理的沙箱观测接口泄露的是跨租户元信息，这一条泄露的是执行能力。

`/ai_generate/*` 同样无判定，可被任意账号用于消耗大模型额度。

## 改动

三条接口按类型级（`ResourceIDAll`）判定算子权限：

| 端点 | 门禁 |
|---|---|
| `POST /function/execute` | `operator:execute` |
| `POST /ai_generate/function/:type` | `operator:create` |
| `GET /ai_generate/prompt/:type` | `operator:create` |

这些端点操作的是尚未落库的函数代码，没有资源 ID 可判，因此按类型级判定，口径与 `logics/auth/decision.go` 中 `CheckCreatePermission` 一致。`ai_generate` 取 `create` 而非 `execute`，是与「生成出来的函数最终落地为算子」对齐。

## 兼容性

三处确认：

1. **内部面不受影响。** 门禁挂在 `IsPublicAPIFromCtx(ctx)` 之后，沿用服务内既有惯用法（`logics/operator/query.go:31`）。`internal-v1` 身份来自 `X-Account-ID` 头而非经校验的令牌，跳过判定，现有服务间调用行为不变。
2. **鉴权关闭的部署不受影响。** `AUTH_ENABLED=false` 时 `NewAuthServiceImpl` 返回 `noopAuthService`，`OperationCheckAll` 恒为 `true`。
3. **capabilities-lab 非本次打断。** `capabilities-lab/server/client/function.go:56` 调用本接口的公开面路径且不带 `Authorization` 头，该调用在本次改动前即被 introspect 中间件以 401 拒绝。

## 验证

VM（10.211.55.4）实测，新建 `permissions:[]` 的零权限账号作为对照：

| 场景 | 结果 |
|---|---|
| `/function/execute` 零权限账号 | 403 `CommonUseForbidden` |
| `/function/execute` 普通用户（持 `operator:execute`） | 200，正常进入沙箱执行 |
| `/ai_generate/function/*` 零权限账号 | 403 |
| `/ai_generate/prompt/*` 零权限账号 | 403 |
| `/ai_generate/prompt/*` 普通用户 | 400（参数校验，已过鉴权门） |

单元测试覆盖：持权放行、缺权拒绝、无身份按未认证拒绝且不询问授权服务、内部面直接放行。`go build ./...` 与 `go test ./driveradapters/...` 全绿。

## 范围

本 PR 只覆盖 #345 清单中的高危项。算子分类 CRUD、skill 索引构建、`names` 批量查询等其余条目另行处理。

Refs #345
