### PR TITLE
fix(execution-factory): 内部面下线 Ingress 暴露与沙箱注册（#326 第 3 步）

### DIFF
--- a/adp/execution-factory/operator-integration/docs/apis/api_public/sandbox.yaml
+++ b/adp/execution-factory/operator-integration/docs/apis/api_public/sandbox.yaml
@@ -1,10 +1,19 @@
 openapi: "3.0.3"
 info:
-  title: "Sandbox Runtime Private Management APIs"
+  title: "Sandbox Runtime Observability APIs"
   version: "1.0.0"
-  description: "Read-only Sandbox Runtime observability APIs for Execution Factory Lab."
+  description: |
+    Read-only Sandbox Runtime observability APIs for Execution Factory Lab.
+
+    These endpoints live on the public face only. Responses carry cross-tenant fields
+    (user_id, capability_id, workspace_path, pod_name, python_package_index_url), so
+    every route additionally requires the caller to be a super admin — the same
+    safe_admin:console:manage capability bkn-safe's Enforcer.CanAdmin checks.
+
+    They were previously registered on internal-v1 as well; that registration was
+    removed because the internal face does not verify tokens (see #326).
 servers:
-  - url: "http://127.0.0.1:9000/api/agent-operator-integration/internal-v1"
+  - url: "http://{host}:{port}/api/agent-operator-integration/v1"
 tags:
   - name: "Sandbox Runtime"
     description: "Read-only runtime health, pool, and session diagnostics."
@@ -20,6 +29,10 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/SandboxHealthResp"
+        "401":
+          description: "Missing or invalid credentials."
+        "403":
+          description: "Caller is not a super admin."
   /sandbox/pool:
     get:
       tags: ["Sandbox Runtime"]
@@ -31,6 +44,10 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/SandboxPoolResp"
+        "401":
+          description: "Missing or invalid credentials."
+        "403":
+          description: "Caller is not a super admin."
   /sandbox/sessions:
     get:
       tags: ["Sandbox Runtime"]
@@ -74,6 +91,10 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/SandboxSessionListResp"
+        "401":
+          description: "Missing or invalid credentials."
+        "403":
+          description: "Caller is not a super admin."
   /sandbox/sessions/{id}:
     get:
       tags: ["Sandbox Runtime"]
@@ -93,6 +114,10 @@ paths:
                 $ref: "#/components/schemas/SandboxSessionDetailResp"
         "404":
           description: "Session not found."
+        "401":
+          description: "Missing or invalid credentials."
+        "403":
+          description: "Caller is not a super admin."
 components:
   schemas:
     SandboxHealthResp:

--- a/adp/execution-factory/operator-integration/helm/agent-operator-integration/values.yaml
+++ b/adp/execution-factory/operator-integration/helm/agent-operator-integration/values.yaml
@@ -42,8 +42,12 @@ service:
       enabled: true
       interface:
         path:
+          # 只暴露公开面。internal-v1 不校验令牌——身份取自调用方自填的 X-Account-ID 头，
+          # 该头缺失时 hydra.go 会把调用者降级为硬编码管理员——一旦挂上 Ingress，其下约
+          # 40 条写接口（function/exec、intcomp 注册、impex 导入等）即可从集群外无凭据调用。
+          # 集群内调用方（bkn-agent、agent-retrieval）走 ClusterIP agent-operator-integration:9000，
+          # 不经 Ingress，不受影响。见 #326。
           - /api/agent-operator-integration/v1
-          - /api/agent-operator-integration/internal-v1
   type: ClusterIP
   enableDualStack: false
   port: 9000

--- a/adp/execution-factory/operator-integration/server/driveradapters/rest_private_handler.go
+++ b/adp/execution-factory/operator-integration/server/driveradapters/rest_private_handler.go
@@ -7,7 +7,6 @@ import (
 	"github.com/gin-gonic/gin"
 	"github.com/openbkn-ai/adp/execution-factory/operator-integration/server/drivenadapters"
 	"github.com/openbkn-ai/adp/execution-factory/operator-integration/server/driveradapters/common"
-	sandboxdriver "github.com/openbkn-ai/adp/execution-factory/operator-integration/server/driveradapters/sandbox"
 	"github.com/openbkn-ai/adp/execution-factory/operator-integration/server/infra/config"
 	"github.com/openbkn-ai/adp/execution-factory/operator-integration/server/interfaces"
 	"github.com/openbkn-ai/adp/execution-factory/operator-integration/server/logics/business_domain"
@@ -20,7 +19,6 @@ type restPrivateHandler struct {
 	UpgradeHandler        common.UpgradeHandler
 	UnifiedProxyHandler   common.UnifiedProxyHandler
 	ImpexHandler          common.ImpexHandler
-	SandboxHandler        sandboxdriver.ManagementHandler
 	Logger                interfaces.Logger
 	SkillRestHandler      SkillRestHandler
 	businessDomainService interfaces.IBusinessDomainService
@@ -36,7 +34,6 @@ func NewRestPrivateHandler() interfaces.HTTPRouterInterface {
 		UpgradeHandler:        common.NewUpgradeHandler(),
 		UnifiedProxyHandler:   common.NewUnifiedProxyHandler(),
 		ImpexHandler:          common.NewImpexHandler(),
-		SandboxHandler:        sandboxdriver.NewManagementHandler(),
 		Logger:                config.NewConfigLoader().GetLogger(),
 		SkillRestHandler:      NewSkillRestHandler(),
 		businessDomainService: business_domain.NewBusinessDomainService(),
@@ -57,9 +54,6 @@ func (r *restPrivateHandler) RegisterRouter(engine *gin.RouterGroup) {
 	r.MCPRestHandler.RegisterPrivate(engine)
 	// 技能接口
 	r.SkillRestHandler.RegisterPrivate(engine)
-	// Sandbox Runtime read-only management APIs.
-	r.SandboxHandler.RegisterPrivate(engine)
-
 	// 临时升级接口 - 仅在从旧版本升级到5.0.0.3时使用
 	engine.GET("/upgrade/v5003/migrate-history", r.UpgradeHandler.MigrateHistoryData)
 	// V0.6.0 -> V0.7.0升级接口

--- a/adp/execution-factory/operator-integration/server/driveradapters/sandbox/management.go
+++ b/adp/execution-factory/operator-integration/server/driveradapters/sandbox/management.go
@@ -14,7 +14,6 @@ import (
 )
 
 type ManagementHandler interface {
-	RegisterPrivate(engine *gin.RouterGroup)
 	RegisterPublic(engine *gin.RouterGroup)
 	GetHealth(c *gin.Context)
 	GetPool(c *gin.Context)
@@ -45,15 +44,7 @@ func NewManagementHandlerWithAuth(service sandbox.SandboxManagementService, auth
 	return &managementHandler{service: service, authService: authService}
 }
 
-func (h *managementHandler) RegisterPrivate(engine *gin.RouterGroup) {
-	group := engine.Group("/sandbox")
-	group.GET("/health", h.GetHealth)
-	group.GET("/pool", h.GetPool)
-	group.GET("/sessions", h.ListSessions)
-	group.GET("/sessions/:id", h.GetSessionDetail)
-}
-
-// RegisterPublic 在公开面注册同一组沙箱只读观测接口。
+// RegisterPublic 在公开面注册沙箱只读观测接口。
 //
 // 这四条接口原本只在 internal-v1 上，而 internal-v1 不校验令牌、身份由 X-Account-ID 头
 // 声明；为了让 Studio 的沙箱运行时页能访问，该前缀被开到了 Ingress（见 #326）。公开面走

--- a/adp/execution-factory/operator-integration/server/driveradapters/sandbox/management_test.go
+++ b/adp/execution-factory/operator-integration/server/driveradapters/sandbox/management_test.go
@@ -49,23 +49,6 @@ func (f *fakeManagementService) GetSessionDetail(ctx context.Context, sessionID 
 	}, nil
 }
 
-func TestManagementHandlerReadOnlyRoutes(t *testing.T) {
-	Convey("Sandbox management handler should expose only read-only routes", t, func() {
-		gin.SetMode(gin.TestMode)
-		engine := gin.New()
-		group := engine.Group("/api/agent-operator-integration/internal-v1")
-		NewManagementHandlerWithService(&fakeManagementService{}).RegisterPrivate(group)
-
-		So(performRequest(engine, http.MethodGet, "/api/agent-operator-integration/internal-v1/sandbox/health").Code, ShouldEqual, http.StatusOK)
-		So(performRequest(engine, http.MethodGet, "/api/agent-operator-integration/internal-v1/sandbox/pool").Code, ShouldEqual, http.StatusOK)
-		So(performRequest(engine, http.MethodGet, "/api/agent-operator-integration/internal-v1/sandbox/sessions?status=failed").Code, ShouldEqual, http.StatusOK)
-		So(performRequest(engine, http.MethodGet, "/api/agent-operator-integration/internal-v1/sandbox/sessions/sess_aoi_1").Code, ShouldEqual, http.StatusOK)
-
-		So(performRequest(engine, http.MethodDelete, "/api/agent-operator-integration/internal-v1/sandbox/sessions/sess_aoi_1").Code, ShouldEqual, http.StatusNotFound)
-		So(performRequest(engine, http.MethodPost, "/api/agent-operator-integration/internal-v1/sandbox/pool/prewarm").Code, ShouldEqual, http.StatusNotFound)
-	})
-}
-
 func performRequest(engine *gin.Engine, method, path string) *httptest.ResponseRecorder {
 	recorder := httptest.NewRecorder()
 	req := httptest.NewRequest(method, path, nil)
@@ -103,7 +86,6 @@ func newPublicEngine(authService interfaces.IAuthorizationService, accountID str
 	NewManagementHandlerWithAuth(&fakeManagementService{}, authService).RegisterPublic(group)
 	return engine
 }
-
 func TestManagementHandlerPublicRoutesRequireAdmin(t *testing.T) {
 	const base = "/api/agent-operator-integration/v1/sandbox"
 
@@ -150,5 +132,21 @@ func TestManagementHandlerPublicRoutesRequireAdmin(t *testing.T) {
 			So(performRequest(engine, http.MethodDelete, base+"/sessions/sess_1").Code, ShouldEqual, http.StatusNotFound)
 			So(performRequest(engine, http.MethodPost, base+"/pool/prewarm").Code, ShouldEqual, http.StatusNotFound)
 		})
+	})
+}
+
+// TestInternalFaceNoLongerRegistersSandbox 守住 #326 第 3 步：沙箱观测接口只在公开面
+// 注册。内部面不校验令牌，身份取自调用方自填的 X-Account-ID 头，一旦重新挂上就等于
+// 绕过公开面的超管门禁。ManagementHandler 已不再提供 RegisterPrivate——本用例确认
+// 接口面上不存在该方法，任何重新引入都会在编译期被此断言挡下。
+func TestInternalFaceNoLongerRegistersSandbox(t *testing.T) {
+	Convey("沙箱处理器不再暴露内部面注册入口", t, func() {
+		var handler ManagementHandler = NewManagementHandlerWithService(&fakeManagementService{})
+
+		_, hasPrivateRegistration := any(handler).(interface {
+			RegisterPrivate(engine *gin.RouterGroup)
+		})
+
+		So(hasPrivateRegistration, ShouldBeFalse)
 	})
 }


### PR DESCRIPTION
## 问题

`internal-v1` 不校验令牌：该路由组挂的是 `middlewareHeaderAuthContext`，身份完全来自调用方自填的 `X-Account-ID` 头，而 `hydra.go:78-96` 在该头缺失时把调用者降级为**硬编码管理员**。

`values.yaml` 却把整个前缀开在 Ingress 上，其下约 40 条写接口——`function/exec`、`intcomp` 注册、`impex` 导入等——因此可从集群外无凭据调用。

VM 实测改动前的暴露情况，集群外、不带任何凭据：

```
GET /api/agent-operator-integration/internal-v1/sandbox/health     -> 200
GET /api/agent-operator-integration/internal-v1/operator/category  -> 200
```

## 前置条件已满足

当初开这条 Ingress 是为了让 Studio 的沙箱页能访问。两个前置现已落地：

| 前置 | 状态 |
|---|---|
| 公开面提供同一组沙箱接口 + 超管门禁 | #339 已合 |
| Studio 切到 `/v1` | openbkn-ai/bkn-studio#179 已合 |

## 改动

- Ingress 路径表只保留 `/api/agent-operator-integration/v1`
- 删除沙箱在内部面的重复注册，`ManagementHandler` 不再提供 `RegisterPrivate`

## 兼容性

集群内调用方不受影响，两者均为 ClusterIP、不经 Ingress：

- bkn-agent：`OPERATOR_INTEGRATION_BASE` 默认 `http://agent-operator-integration:9000/api/agent-operator-integration`
- agent-retrieval：`depServices.agent-operator-integration.privateHost` = `agent-operator-integration:9000`

沙箱内部面无生产调用方，仅有单元测试引用。

## 测试调整

原 `TestManagementHandlerReadOnlyRoutes` 覆盖的只读路由面已由 #339 的公开面用例覆盖，故移除；新增 `TestInternalFaceNoLongerRegistersSandbox` 断言接口面上不再存在 `RegisterPrivate`，重新引入会被挡下。

## 验证

VM（10.211.55.4）实测：

| 场景 | 结果 |
|---|---|
| 集群外 `internal-v1` 的 `sandbox/health`、`operator/category`、`function/exec` | 均 404 |
| 集群外 `/v1/sandbox/health` 超管 | 200 |
| 集群外 `/v1/sandbox/health` 零权限账号 | 403 |
| 集群外 `/v1/sandbox/health` 匿名 | 401 |
| 集群内 ClusterIP 调 `internal-v1/operator/category` | 200，正常返回数据 |

`go build ./...` 与 `go test ./driveradapters/...` 全绿。

Refs #326
