### PR TITLE
fix(bkn-backend): include metrics_total in KN statistics

### DIFF
--- a/adp/bkn/bkn-backend/server/errors/knowledge_network.go
+++ b/adp/bkn/bkn-backend/server/errors/knowledge_network.go
@@ -45,6 +45,7 @@ const (
 	BknBackend_KnowledgeNetwork_InternalError_GetObjectTypesTotalFailed   = "BknBackend.KnowledgeNetwork.InternalError.GetObjectTypesTotalFailed"
 	BknBackend_KnowledgeNetwork_InternalError_GetRelationTypesTotalFailed = "BknBackend.KnowledgeNetwork.InternalError.GetRelationTypesTotalFailed"
 	BknBackend_KnowledgeNetwork_InternalError_GetRiskTypesTotalFailed     = "BknBackend.KnowledgeNetwork.InternalError.GetRiskTypesTotalFailed"
+	BknBackend_KnowledgeNetwork_InternalError_GetMetricsTotalFailed       = "BknBackend.KnowledgeNetwork.InternalError.GetMetricsTotalFailed"
 	BknBackend_KnowledgeNetwork_InternalError_GetVectorFailed             = "BknBackend.KnowledgeNetwork.InternalError.GetVectorFailed"
 	BknBackend_KnowledgeNetwork_InternalError_InsertOpenSearchDataFailed  = "BknBackend.KnowledgeNetwork.InternalError.InsertOpenSearchDataFailed"
 	BknBackend_KnowledgeNetwork_InternalError_CreateObjectTypesFailed     = "BknBackend.KnowledgeNetwork.InternalError.CreateObjectTypesFailed"
@@ -94,6 +95,7 @@ var (
 		BknBackend_KnowledgeNetwork_InternalError_GetObjectTypesTotalFailed,
 		BknBackend_KnowledgeNetwork_InternalError_GetRelationTypesTotalFailed,
 		BknBackend_KnowledgeNetwork_InternalError_GetRiskTypesTotalFailed,
+		BknBackend_KnowledgeNetwork_InternalError_GetMetricsTotalFailed,
 		BknBackend_KnowledgeNetwork_InternalError_GetVectorFailed,
 		BknBackend_KnowledgeNetwork_InternalError_InsertOpenSearchDataFailed,
 		BknBackend_KnowledgeNetwork_InternalError_CreateObjectTypesFailed,

--- a/adp/bkn/bkn-backend/server/interfaces/knowledge_network.go
+++ b/adp/bkn/bkn-backend/server/interfaces/knowledge_network.go
@@ -216,6 +216,7 @@ type Statistics struct {
 	RtTotal       int `json:"relation_types_total"`
 	AtTotal       int `json:"action_types_total"`
 	RiskTypeTotal int `json:"risk_types_total"`
+	MetricsTotal  int `json:"metrics_total"`
 }
 
 // 业务知识网络的分页查询

--- a/adp/bkn/bkn-backend/server/locale/knowledge_network.en-US.toml
+++ b/adp/bkn/bkn-backend/server/locale/knowledge_network.en-US.toml
@@ -193,3 +193,8 @@ ErrorLink = "None"
 Description = "Get Risk Types Total In Knowledge Network Failed"
 Solution = "Please try again. If the error occurs again, please submit the work order or contact technical support."
 ErrorLink = "None"
+
+[BknBackend.KnowledgeNetwork.InternalError.GetMetricsTotalFailed]
+Description = "Get Metrics Total In Knowledge Network Failed"
+Solution = "Please try again. If the error occurs again, please submit the work order or contact technical support."
+ErrorLink = "None"

--- a/adp/bkn/bkn-backend/server/locale/knowledge_network.zh-CN.toml
+++ b/adp/bkn/bkn-backend/server/locale/knowledge_network.zh-CN.toml
@@ -193,3 +193,8 @@ ErrorLink = "暂无"
 Description = "获取业务知识网络下的风险类数量失败"
 Solution = "请重试该操作，若再次出现该错误请提交工单或联系技术支持工程师。"
 ErrorLink = "暂无"
+
+[BknBackend.KnowledgeNetwork.InternalError.GetMetricsTotalFailed]
+Description = "获取业务知识网络下的指标数量失败"
+Solution = "请重试该操作，若再次出现该错误请提交工单或联系技术支持工程师。"
+ErrorLink = "暂无"

--- a/adp/bkn/bkn-backend/server/logics/knowledge_network/knowledge_network_service.go
+++ b/adp/bkn/bkn-backend/server/logics/knowledge_network/knowledge_network_service.go
@@ -56,6 +56,7 @@ type knowledgeNetworkService struct {
 	cgs        interfaces.ConceptGroupService
 	js         interfaces.JobService
 	kna        interfaces.KNAccess
+	ma         interfaces.MetricAccess
 	ms         interfaces.MetricService
 	mfa        interfaces.ModelFactoryAccess
 	ota        interfaces.ObjectTypeAccess
@@ -81,6 +82,7 @@ func NewKNService(appSetting *common.AppSetting) interfaces.KNService {
 			db:         logics.DB,
 			js:         job.NewJobService(appSetting),
 			kna:        logics.KNA,
+			ma:         logics.MA,
 			ms:         metric.NewMetricService(appSetting),
 			mfa:        logics.MFA,
 			ota:        logics.OTA,
@@ -797,12 +799,27 @@ func (kns *knowledgeNetworkService) GetStatByKN(ctx context.Context, kn *interfa
 			berrors.BknBackend_KnowledgeNetwork_InternalError_GetRiskTypesTotalFailed).WithErrorDetails(err.Error())
 	}
 
+	// metrics 数量
+	metricsCnt, err := kns.ma.GetMetricsTotal(ctx, interfaces.MetricsListQueryParams{
+		KNID:   kn.KNID,
+		Branch: kn.Branch,
+	})
+	if err != nil {
+		logger.Errorf("GetMetricsTotal in knowledge network[%s] error: %s", kn.KNID, err.Error())
+		span.SetStatus(codes.Error, fmt.Sprintf("GetMetricsTotal in knowledge network[%s], error: %v", kn.KNID, err))
+		span.End()
+
+		return nil, rest.NewHTTPError(ctx, http.StatusInternalServerError,
+			berrors.BknBackend_KnowledgeNetwork_InternalError_GetMetricsTotalFailed).WithErrorDetails(err.Error())
+	}
+
 	statistics := &interfaces.Statistics{
 		CgTotal:       cgCnt,
 		OtTotal:       otCnt,
 		RtTotal:       rtCnt,
 		AtTotal:       atCnt,
 		RiskTypeTotal: riskTypeCnt,
+		MetricsTotal:  metricsCnt,
 	}
 
 	span.SetStatus(codes.Ok, "")

--- a/adp/bkn/bkn-backend/server/logics/knowledge_network/knowledge_network_service_test.go
+++ b/adp/bkn/bkn-backend/server/logics/knowledge_network/knowledge_network_service_test.go
@@ -188,6 +188,7 @@ func Test_knowledgeNetworkService_GetStatByKN(t *testing.T) {
 		ata := bmock.NewMockActionTypeAccess(mockCtrl)
 		cga := bmock.NewMockConceptGroupAccess(mockCtrl)
 		rtA := bmock.NewMockRiskTypeAccess(mockCtrl)
+		ma := bmock.NewMockMetricAccess(mockCtrl)
 
 		service := &knowledgeNetworkService{
 			appSetting: appSetting,
@@ -196,6 +197,7 @@ func Test_knowledgeNetworkService_GetStatByKN(t *testing.T) {
 			ata:        ata,
 			cga:        cga,
 			riskTypeA:  rtA,
+			ma:         ma,
 		}
 
 		Convey("Success getting statistics\n", func() {
@@ -209,6 +211,7 @@ func Test_knowledgeNetworkService_GetStatByKN(t *testing.T) {
 			ata.EXPECT().GetActionTypesTotal(gomock.Any(), gomock.Any()).Return(3, nil)
 			cga.EXPECT().GetConceptGroupsTotal(gomock.Any(), gomock.Any()).Return(2, nil)
 			rtA.EXPECT().GetRiskTypesTotal(gomock.Any(), gomock.Any()).Return(4, nil)
+			ma.EXPECT().GetMetricsTotal(gomock.Any(), gomock.Any()).Return(7, nil)
 
 			stats, err := service.GetStatByKN(ctx, kn)
 			So(err, ShouldBeNil)
@@ -218,6 +221,7 @@ func Test_knowledgeNetworkService_GetStatByKN(t *testing.T) {
 			So(stats.AtTotal, ShouldEqual, 3)
 			So(stats.CgTotal, ShouldEqual, 2)
 			So(stats.RiskTypeTotal, ShouldEqual, 4)
+			So(stats.MetricsTotal, ShouldEqual, 7)
 		})
 
 		Convey("Failed when getting object types total returns error\n", func() {
@@ -303,6 +307,26 @@ func Test_knowledgeNetworkService_GetStatByKN(t *testing.T) {
 			So(stats, ShouldBeNil)
 			httpErr := err.(*rest.HTTPError)
 			So(httpErr.BaseError.ErrorCode, ShouldEqual, berrors.BknBackend_KnowledgeNetwork_InternalError_GetRiskTypesTotalFailed)
+		})
+
+		Convey("Failed when getting metrics total returns error\n", func() {
+			kn := &interfaces.KN{
+				KNID:   "kn1",
+				Branch: interfaces.MAIN_BRANCH,
+			}
+
+			ota.EXPECT().GetObjectTypesTotal(gomock.Any(), gomock.Any()).Return(10, nil)
+			rta.EXPECT().GetRelationTypesTotal(gomock.Any(), gomock.Any()).Return(5, nil)
+			ata.EXPECT().GetActionTypesTotal(gomock.Any(), gomock.Any()).Return(3, nil)
+			cga.EXPECT().GetConceptGroupsTotal(gomock.Any(), gomock.Any()).Return(2, nil)
+			rtA.EXPECT().GetRiskTypesTotal(gomock.Any(), gomock.Any()).Return(4, nil)
+			ma.EXPECT().GetMetricsTotal(gomock.Any(), gomock.Any()).Return(0, rest.NewHTTPError(ctx, 500, berrors.BknBackend_KnowledgeNetwork_InternalError))
+
+			stats, err := service.GetStatByKN(ctx, kn)
+			So(err, ShouldNotBeNil)
+			So(stats, ShouldBeNil)
+			httpErr := err.(*rest.HTTPError)
+			So(httpErr.BaseError.ErrorCode, ShouldEqual, berrors.BknBackend_KnowledgeNetwork_InternalError_GetMetricsTotalFailed)
 		})
 	})
 }

--- a/docs/api/bkn/business-knowledge-network.yaml
+++ b/docs/api/bkn/business-knowledge-network.yaml
@@ -1773,6 +1773,9 @@ components:
         action_types_total:
           description: 行动类数量
           type: integer
+        metrics_total:
+          description: 指标数量
+          type: integer
     ConceptGroupInfo:
       description: 概念分组自身的信息
       type: object


### PR DESCRIPTION
## Summary
- `GetStatByKN` now counts metrics and returns `statistics.metrics_total`
- Adds `GetMetricsTotalFailed` error code, locales, and OpenAPI documentation

## Why
Studio sidebar showed metrics as 0 because the KN detail statistics payload never included metric totals (openbkn-ai/bkn-studio#169).

## Test plan
- [x] `I18N_MODE_UT=true go test ./logics/knowledge_network/ -run Test_knowledgeNetworkService_GetStatByKN`
- [ ] GET `/knowledge-networks/{id}?include_statistics=true` returns non-zero `metrics_total` when metrics exist

Fixes openbkn-ai/bkn-studio#169