### PR TITLE
fix(bkn-safe): /me/permissions 折叠瘦身 + token introspect 缓存,治登录「大」与「慢」(#353)

### DIFF
--- a/adp/vega/vega-backend/server/driveradapters/resource_handler.go
+++ b/adp/vega/vega-backend/server/driveradapters/resource_handler.go
@@ -270,6 +270,16 @@ func (r *restHandler) getResources(c *gin.Context, visitor hydra.Visitor) {
 
 	ids := strings.Split(c.Param("id"), ",")
 
+	// A multi-id GET is a display-resolution batch: return the resources that
+	// exist and skip the missing ones instead of 404-ing the whole request, so a
+	// single deleted id (e.g. a stale object-grant pointing at a removed
+	// resource) can't poison the entire page's detail lookup. Callers detect the
+	// dropped ids from the response (fewer entries than ids requested). A
+	// single-id GET stays strict — fetching one resource that does not exist is a
+	// 404. ?ignore_missing=true forces tolerance even for a single id (mirrors
+	// the batch DELETE convention).
+	ignoreMissing := strings.EqualFold(strings.TrimSpace(c.Query("ignore_missing")), "true")
+
 	resources, err := r.rs.GetByIDs(ctx, ids)
 	if err != nil {
 		httpErr := err.(*rest.HTTPError)
@@ -278,7 +288,8 @@ func (r *restHandler) getResources(c *gin.Context, visitor hydra.Visitor) {
 		return
 	}
 
-	if len(resources) != len(ids) {
+	strict := len(ids) == 1 && !ignoreMissing
+	if strict && len(resources) != len(ids) {
 		for _, id := range ids {
 			found := false
 			for _, resource := range resources {

--- a/adp/vega/vega-backend/server/driveradapters/resource_handler.go
+++ b/adp/vega/vega-backend/server/driveradapters/resource_handler.go
@@ -270,14 +270,12 @@ func (r *restHandler) getResources(c *gin.Context, visitor hydra.Visitor) {
 
 	ids := strings.Split(c.Param("id"), ",")
 
-	// A multi-id GET is a display-resolution batch: return the resources that
-	// exist and skip the missing ones instead of 404-ing the whole request, so a
-	// single deleted id (e.g. a stale object-grant pointing at a removed
-	// resource) can't poison the entire page's detail lookup. Callers detect the
-	// dropped ids from the response (fewer entries than ids requested). A
-	// single-id GET stays strict — fetching one resource that does not exist is a
-	// 404. ?ignore_missing=true forces tolerance even for a single id (mirrors
-	// the batch DELETE convention).
+	// By default any missing id 404s the whole request (all-or-nothing), for both
+	// single- and multi-id GETs — matching the strict default of the sibling
+	// batch DELETE. ?ignore_missing=true opts into tolerance: skip the missing
+	// ids and return the found ones (the caller detects drops from fewer entries
+	// than ids requested). That opt-in is the display-resolution escape hatch for
+	// a stale object-grant pointing at a removed resource.
 	ignoreMissing := strings.EqualFold(strings.TrimSpace(c.Query("ignore_missing")), "true")
 
 	resources, err := r.rs.GetByIDs(ctx, ids)
@@ -288,8 +286,7 @@ func (r *restHandler) getResources(c *gin.Context, visitor hydra.Visitor) {
 		return
 	}
 
-	strict := len(ids) == 1 && !ignoreMissing
-	if strict && len(resources) != len(ids) {
+	if !ignoreMissing && len(resources) != len(ids) {
 		for _, id := range ids {
 			found := false
 			for _, resource := range resources {

--- a/adp/vega/vega-backend/server/driveradapters/resource_handler_test.go
+++ b/adp/vega/vega-backend/server/driveradapters/resource_handler_test.go
@@ -186,7 +186,7 @@ func Test_ResourceRestHandler_GetResources(t *testing.T) {
 		assert.Contains(t, w.Body.String(), `"id":"res-2"`)
 	})
 
-	t.Run("returns not found when any id is missing", func(t *testing.T) {
+	t.Run("multi-id batch returns the found ones and skips missing", func(t *testing.T) {
 		engine, _, rs := setupResourceHandlerTest(t)
 		rs.EXPECT().GetByIDs(gomock.Any(), []string{"res-1", "res-2"}).
 			Return([]*interfaces.Resource{{ID: "res-1", Name: "one"}}, nil)
@@ -196,8 +196,38 @@ func Test_ResourceRestHandler_GetResources(t *testing.T) {
 
 		engine.ServeHTTP(w, req)
 
+		require.Equal(t, http.StatusOK, w.Result().StatusCode)
+		assert.Contains(t, w.Body.String(), `"id":"res-1"`)
+		assert.NotContains(t, w.Body.String(), `"id":"res-2"`)
+		assert.NotContains(t, w.Body.String(), "not found")
+	})
+
+	t.Run("single missing id still returns 404", func(t *testing.T) {
+		engine, _, rs := setupResourceHandlerTest(t)
+		rs.EXPECT().GetByIDs(gomock.Any(), []string{"res-x"}).
+			Return([]*interfaces.Resource{}, nil)
+
+		req := httptest.NewRequest(http.MethodGet, "/api/vega-backend/in/v1/resources/res-x", nil)
+		w := httptest.NewRecorder()
+
+		engine.ServeHTTP(w, req)
+
 		require.Equal(t, http.StatusNotFound, w.Result().StatusCode)
-		assert.Contains(t, w.Body.String(), "id res-2 not found")
+		assert.Contains(t, w.Body.String(), "id res-x not found")
+	})
+
+	t.Run("ignore_missing tolerates a missing single id", func(t *testing.T) {
+		engine, _, rs := setupResourceHandlerTest(t)
+		rs.EXPECT().GetByIDs(gomock.Any(), []string{"res-x"}).
+			Return([]*interfaces.Resource{}, nil)
+
+		req := httptest.NewRequest(http.MethodGet, "/api/vega-backend/in/v1/resources/res-x?ignore_missing=true", nil)
+		w := httptest.NewRecorder()
+
+		engine.ServeHTTP(w, req)
+
+		require.Equal(t, http.StatusOK, w.Result().StatusCode)
+		assert.NotContains(t, w.Body.String(), "not found")
 	})
 }
 

--- a/adp/vega/vega-backend/server/driveradapters/resource_handler_test.go
+++ b/adp/vega/vega-backend/server/driveradapters/resource_handler_test.go
@@ -186,12 +186,27 @@ func Test_ResourceRestHandler_GetResources(t *testing.T) {
 		assert.Contains(t, w.Body.String(), `"id":"res-2"`)
 	})
 
-	t.Run("multi-id batch returns the found ones and skips missing", func(t *testing.T) {
+	t.Run("multi-id with a missing id 404s by default", func(t *testing.T) {
 		engine, _, rs := setupResourceHandlerTest(t)
 		rs.EXPECT().GetByIDs(gomock.Any(), []string{"res-1", "res-2"}).
 			Return([]*interfaces.Resource{{ID: "res-1", Name: "one"}}, nil)
 
 		req := httptest.NewRequest(http.MethodGet, url, nil)
+		w := httptest.NewRecorder()
+
+		engine.ServeHTTP(w, req)
+
+		// Default is strict all-or-nothing, same as the batch DELETE convention.
+		require.Equal(t, http.StatusNotFound, w.Result().StatusCode)
+		assert.Contains(t, w.Body.String(), "id res-2 not found")
+	})
+
+	t.Run("ignore_missing skips missing ids in a multi-id batch", func(t *testing.T) {
+		engine, _, rs := setupResourceHandlerTest(t)
+		rs.EXPECT().GetByIDs(gomock.Any(), []string{"res-1", "res-2"}).
+			Return([]*interfaces.Resource{{ID: "res-1", Name: "one"}}, nil)
+
+		req := httptest.NewRequest(http.MethodGet, url+"?ignore_missing=true", nil)
 		w := httptest.NewRecorder()
 
 		engine.ServeHTTP(w, req)

--- a/adp/vega/vega-backend/tests/at/resource/helpers/test_cases.go
+++ b/adp/vega/vega-backend/tests/at/resource/helpers/test_cases.go
@@ -420,8 +420,13 @@ func RunCommonReadTests(suite *TestSuite) {
 		// 批量获取（包含不存在的ID）
 		ids := []string{existingID, "non-existent-id-99999"}
 		batchResp := suite.GetResources(ids)
-		// 部分不存在时，应返回存在的部分或报错
-		So(batchResp.StatusCode, ShouldEqual, http.StatusNotFound)
+		// 多 id 批量为展示解析：部分不存在时返回存在的部分（跳过缺失），不整批 404
+		So(batchResp.StatusCode, ShouldEqual, http.StatusOK)
+		if batchResp.Body != nil {
+			if entries, ok := batchResp.Body["entries"].([]any); ok {
+				So(len(entries), ShouldEqual, 1)
+			}
+		}
 	})
 
 	Convey("RM206: 按catalog_id过滤列表", func() {

--- a/adp/vega/vega-backend/tests/at/resource/helpers/test_cases.go
+++ b/adp/vega/vega-backend/tests/at/resource/helpers/test_cases.go
@@ -420,13 +420,9 @@ func RunCommonReadTests(suite *TestSuite) {
 		// 批量获取（包含不存在的ID）
 		ids := []string{existingID, "non-existent-id-99999"}
 		batchResp := suite.GetResources(ids)
-		// 多 id 批量为展示解析：部分不存在时返回存在的部分（跳过缺失），不整批 404
-		So(batchResp.StatusCode, ShouldEqual, http.StatusOK)
-		if batchResp.Body != nil {
-			if entries, ok := batchResp.Body["entries"].([]any); ok {
-				So(len(entries), ShouldEqual, 1)
-			}
-		}
+		// 默认严格：任一 id 不存在则整批 404（与批量 DELETE 约定一致）。
+		// 需容忍缺失时调用方传 ?ignore_missing=true。
+		So(batchResp.StatusCode, ShouldEqual, http.StatusNotFound)
 	})
 
 	Convey("RM206: 按catalog_id过滤列表", func() {

--- a/bkn-safe/server/go.mod
+++ b/bkn-safe/server/go.mod
@@ -14,8 +14,10 @@ require (
 	github.com/glebarez/sqlite v1.7.0
 	github.com/go-ldap/ldap/v3 v3.4.13
 	github.com/openbkn-ai/bkn-comm-go v0.0.4
+	github.com/openbkn-ai/licverify v0.2.0
 	github.com/ory/hydra-client-go/v2 v2.2.0
 	golang.org/x/crypto v0.53.0
+	golang.org/x/sync v0.21.0
 	gopkg.in/yaml.v3 v3.0.1
 	gorm.io/driver/mysql v1.5.7
 	gorm.io/gorm v1.25.12
@@ -61,7 +63,6 @@ require (
 	github.com/microsoft/go-mssqldb v1.6.0 // indirect
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.2 // indirect
-	github.com/openbkn-ai/licverify v0.2.0 // indirect
 	github.com/pelletier/go-toml/v2 v2.2.4 // indirect
 	github.com/quic-go/qpack v0.6.0 // indirect
 	github.com/quic-go/quic-go v0.59.0 // indirect
@@ -73,7 +74,6 @@ require (
 	golang.org/x/arch v0.26.0 // indirect
 	golang.org/x/net v0.56.0 // indirect
 	golang.org/x/oauth2 v0.17.0 // indirect
-	golang.org/x/sync v0.21.0 // indirect
 	golang.org/x/sys v0.46.0 // indirect
 	golang.org/x/text v0.39.0 // indirect
 	google.golang.org/appengine v1.6.7 // indirect

--- a/bkn-safe/server/internal/authz/authz.go
+++ b/bkn-safe/server/internal/authz/authz.go
@@ -307,8 +307,15 @@ func (en *Enforcer) EffectivePermissions(accessorID string, q PermQuery) (hasWil
 			continue
 		}
 		// Instance row: keep only ops beyond the type-wide set; drop if fully
-		// covered (this is what removes the per-instance fan-out).
+		// covered (this is what removes the per-instance fan-out). A type-wide
+		// ActAll ("*") grant covers every op on the type, so the instance row is
+		// always redundant — handle it explicitly rather than relying on literal
+		// op matching. (rejectWildcardGrant keeps a "type:*"/"*" grant off the
+		// write paths today, so this branch is defensive.)
 		tw := typeWide[rtype]
+		if tw[ActAll] {
+			continue
+		}
 		extra := make([]string, 0, len(g.Operations))
 		for _, op := range g.Operations {
 			if tw[op] {

--- a/bkn-safe/server/internal/authz/authz.go
+++ b/bkn-safe/server/internal/authz/authz.go
@@ -195,18 +195,6 @@ func (en *Enforcer) RolePermissions(roleID string) ([]RoleGrant, error) {
 	return groupGrantsByObject(rows), nil
 }
 
-// AccessorPermissions lists every policy grant effective for an accessor —
-// its direct per-object grants plus everything inherited via roles — grouped
-// by object pattern. The accessor's own permission list (the "what can I do"
-// self-service read); type-wide "*" patterns are kept verbatim.
-func (en *Enforcer) AccessorPermissions(accessorID string) ([]RoleGrant, error) {
-	rows, err := en.e.GetImplicitPermissionsForUser(accessorID)
-	if err != nil {
-		return nil, err
-	}
-	return groupGrantsByObject(rows), nil
-}
-
 // groupGrantsByObject collapses raw (sub, obj, act) policy rows into per-object
 // grants, de-duplicating acts (the same grant can arrive via several roles).
 // Objects follow first appearance; ops within an object follow row order.
@@ -234,6 +222,119 @@ func groupGrantsByObject(rows [][]string) []RoleGrant {
 		out = append(out, RoleGrant{Object: o, Operations: ops[o]})
 	}
 	return out
+}
+
+// PermQuery narrows an EffectivePermissions read. The zero value returns the
+// full effective set; ResourceType scopes to one type and ResourceIDs further
+// narrows the instance exception rows (ResourceIDs is only meaningful with a
+// ResourceType set).
+type PermQuery struct {
+	ResourceType string   // "" = all types
+	ResourceIDs  []string // empty = all instances of the type
+}
+
+// EffectivePermissions returns the accessor's authorization as a COLLAPSED,
+// effective set rather than one row per (instance, op) — the payload behind the
+// /me/permissions self-service read. It exists to keep that response bounded:
+// its size is proportional to (#types + #real exceptions), not to the number of
+// resource instances the accessor can see.
+//
+// Two shapes:
+//
+//   - Resource wildcard holder: if the accessor holds a bare "*"/"*" grant, the
+//     whole set collapses to a single {type:"*", id:"*", ops:["*"]} row (scoped:
+//     projected onto the queried type as {type, id:"*", ops:["*"]}). This is
+//     gated on the ACTUAL wildcard grant, NOT on CanAdmin/is_admin: an
+//     admin-console-only role holds safe_admin:console:manage without the
+//     resource wildcard and must not be reported as all-powerful over every
+//     resource. hasWildcard reports whether this short-circuit fired.
+//
+//   - Otherwise, per type: one type-wide row {type, id:"*", typeWideOps} plus an
+//     instance row ONLY when that instance grants ops beyond its type-wide set
+//     (the row carries just the surplus ops). Instances fully covered by a
+//     type-wide grant are dropped. Callers/frontends judge "may do op on
+//     (type,id)" as op ∈ typeWide(type) OR op ∈ instance(type,id) — i.e. they
+//     union the id:"*" row with the instance row.
+//
+// Object/op order follows GetImplicitPermissionsForUser; callers treat the
+// result as sets.
+func (en *Enforcer) EffectivePermissions(accessorID string, q PermQuery) (hasWildcard bool, grants []RoleGrant, err error) {
+	rows, err := en.e.GetImplicitPermissionsForUser(accessorID)
+	if err != nil {
+		return false, nil, err
+	}
+	grouped := groupGrantsByObject(rows)
+
+	// Wildcard short-circuit — keyed on a real "*"/"*" grant, not is_admin.
+	for _, g := range grouped {
+		rtype, _ := splitObjectKey(g.Object)
+		if rtype == ActAll && hasOp(g.Operations, ActAll) {
+			if q.ResourceType == "" {
+				return true, []RoleGrant{{Object: ActAll + ":" + ActAll, Operations: []string{ActAll}}}, nil
+			}
+			return true, []RoleGrant{{Object: q.ResourceType + ":*", Operations: []string{ActAll}}}, nil
+		}
+	}
+
+	// Type-wide op set per type (the id "*" rows).
+	typeWide := map[string]map[string]bool{}
+	for _, g := range grouped {
+		rtype, rid := splitObjectKey(g.Object)
+		if rid == "*" {
+			if typeWide[rtype] == nil {
+				typeWide[rtype] = map[string]bool{}
+			}
+			for _, op := range g.Operations {
+				typeWide[rtype][op] = true
+			}
+		}
+	}
+
+	idFilter := map[string]bool{}
+	for _, id := range q.ResourceIDs {
+		idFilter[id] = true
+	}
+
+	out := make([]RoleGrant, 0, len(grouped))
+	for _, g := range grouped {
+		rtype, rid := splitObjectKey(g.Object)
+		if q.ResourceType != "" && rtype != q.ResourceType {
+			continue
+		}
+		if rid == "*" {
+			// Type-wide row: always kept within scope; the frontend unions on it.
+			out = append(out, RoleGrant{Object: g.Object, Operations: g.Operations})
+			continue
+		}
+		// Instance row: keep only ops beyond the type-wide set; drop if fully
+		// covered (this is what removes the per-instance fan-out).
+		tw := typeWide[rtype]
+		extra := make([]string, 0, len(g.Operations))
+		for _, op := range g.Operations {
+			if tw[op] {
+				continue
+			}
+			extra = append(extra, op)
+		}
+		if len(extra) == 0 {
+			continue
+		}
+		if len(idFilter) > 0 && !idFilter[rid] {
+			continue
+		}
+		out = append(out, RoleGrant{Object: g.Object, Operations: extra})
+	}
+	return false, out, nil
+}
+
+// hasOp reports whether ops contains want.
+func hasOp(ops []string, want string) bool {
+	for _, op := range ops {
+		if op == want {
+			return true
+		}
+	}
+	return false
 }
 
 // RemoveRoleCompletely purges every casbin trace of a role: its bindings

--- a/bkn-safe/server/internal/authz/effectiveperms_test.go
+++ b/bkn-safe/server/internal/authz/effectiveperms_test.go
@@ -1,0 +1,202 @@
+// Copyright openbkn.ai
+//
+// Licensed under the OpenBKN License. See LICENSE-OPENBKN.txt in the project root.
+
+package authz
+
+import (
+	"sort"
+	"testing"
+)
+
+// byObject indexes collapsed grants by "type:id" -> sorted ops, for set compare.
+func byObject(grants []RoleGrant) map[string][]string {
+	out := map[string][]string{}
+	for _, g := range grants {
+		ops := append([]string(nil), g.Operations...)
+		sort.Strings(ops)
+		out[g.Object] = ops
+	}
+	return out
+}
+
+func eqOps(got []string, want ...string) bool {
+	if len(got) != len(want) {
+		return false
+	}
+	sort.Strings(want)
+	for i := range got {
+		if got[i] != want[i] {
+			return false
+		}
+	}
+	return true
+}
+
+// A resource-wildcard holder collapses to a single {*:*, [*]} row; scoped, the
+// wildcard projects onto the queried type.
+func TestEffectivePermissionsWildcard(t *testing.T) {
+	e := newTestEnforcer(t)
+	const super = "u-super"
+	mustNoErr(t, e.Grant(super, "*", "*")) // bare super-admin grant
+
+	// Even with extra concrete grants, the wildcard supersedes everything.
+	mustNoErr(t, e.GrantObjectPermission(super, "resource", "r1", "view_detail"))
+
+	has, grants, err := e.EffectivePermissions(super, PermQuery{})
+	mustNoErr(t, err)
+	if !has {
+		t.Fatal("hasWildcard: want true")
+	}
+	if len(grants) != 1 || grants[0].Object != "*:*" || !eqOps(grants[0].Operations, "*") {
+		t.Fatalf("wildcard set = %+v, want single *:* [*]", grants)
+	}
+
+	// Scoped: project onto the queried type.
+	has, grants, err = e.EffectivePermissions(super, PermQuery{ResourceType: "large_model"})
+	mustNoErr(t, err)
+	if !has || len(grants) != 1 || grants[0].Object != "large_model:*" || !eqOps(grants[0].Operations, "*") {
+		t.Fatalf("scoped wildcard = %+v, want large_model:* [*]", grants)
+	}
+}
+
+// An admin-console capability (safe_admin:console:manage) makes CanAdmin true but
+// is NOT a resource wildcard: EffectivePermissions must return the real grants,
+// never the {*:*} row. This is the over-report guard.
+func TestEffectivePermissionsAdminConsoleIsNotWildcard(t *testing.T) {
+	e := newTestEnforcer(t)
+	const (
+		role = "r-user-admin"
+		user = "u-admin"
+	)
+	mustNoErr(t, e.GrantRolePermission(role, "safe_admin", "console", "manage"))
+	mustNoErr(t, e.GrantRolePermission(role, "admin-user", "*", "view"))
+	mustNoErr(t, e.AssignRole(user, role))
+
+	// Sanity: this user IS an admin by the console check.
+	admin, err := e.CanAdmin(user)
+	mustNoErr(t, err)
+	if !admin {
+		t.Fatal("CanAdmin: want true for admin-console role")
+	}
+
+	has, grants, err := e.EffectivePermissions(user, PermQuery{})
+	mustNoErr(t, err)
+	if has {
+		t.Fatal("hasWildcard: want false — admin-console is not a resource wildcard")
+	}
+	idx := byObject(grants)
+	if _, ok := idx["*:*"]; ok {
+		t.Fatalf("must not emit *:* for admin-console-only user: %+v", grants)
+	}
+	if !eqOps(idx["safe_admin:console"], "manage") || !eqOps(idx["admin-user:*"], "view") {
+		t.Fatalf("real grants not preserved: %+v", grants)
+	}
+}
+
+// An instance grant fully covered by its type-wide grant is dropped.
+func TestEffectivePermissionsInstanceCoveredByTypeWide(t *testing.T) {
+	e := newTestEnforcer(t)
+	const (
+		role = "r-a"
+		user = "u1"
+	)
+	mustNoErr(t, e.GrantRolePermission(role, "agent", "*", "use"))
+	mustNoErr(t, e.AssignRole(user, role))
+	mustNoErr(t, e.GrantObjectPermission(user, "agent", "a1", "use")) // redundant
+
+	has, grants, err := e.EffectivePermissions(user, PermQuery{})
+	mustNoErr(t, err)
+	if has {
+		t.Fatal("hasWildcard: want false")
+	}
+	idx := byObject(grants)
+	if _, ok := idx["agent:a1"]; ok {
+		t.Fatalf("agent:a1 should be dropped (covered by agent:*): %+v", grants)
+	}
+	if !eqOps(idx["agent:*"], "use") {
+		t.Fatalf("agent:* = %v, want [use]", idx["agent:*"])
+	}
+}
+
+// An instance that grants ops beyond its type-wide set keeps only the surplus.
+func TestEffectivePermissionsInstanceExceedsTypeWide(t *testing.T) {
+	e := newTestEnforcer(t)
+	const (
+		role = "r-a"
+		user = "u1"
+	)
+	mustNoErr(t, e.GrantRolePermission(role, "agent", "*", "view"))
+	mustNoErr(t, e.AssignRole(user, role))
+	mustNoErr(t, e.GrantObjectPermission(user, "agent", "a1", "view")) // covered
+	mustNoErr(t, e.GrantObjectPermission(user, "agent", "a1", "edit")) // surplus
+
+	_, grants, err := e.EffectivePermissions(user, PermQuery{})
+	mustNoErr(t, err)
+	idx := byObject(grants)
+	if !eqOps(idx["agent:*"], "view") {
+		t.Fatalf("agent:* = %v, want [view]", idx["agent:*"])
+	}
+	if !eqOps(idx["agent:a1"], "edit") {
+		t.Fatalf("agent:a1 = %v, want [edit] (surplus only)", idx["agent:a1"])
+	}
+}
+
+// A pure instance grant with no type-wide grant survives in full.
+func TestEffectivePermissionsPureInstance(t *testing.T) {
+	e := newTestEnforcer(t)
+	const user = "u1"
+	mustNoErr(t, e.GrantObjectPermission(user, "resource", "r1", "view_detail"))
+
+	_, grants, err := e.EffectivePermissions(user, PermQuery{})
+	mustNoErr(t, err)
+	idx := byObject(grants)
+	if !eqOps(idx["resource:r1"], "view_detail") {
+		t.Fatalf("resource:r1 = %v, want [view_detail]", idx["resource:r1"])
+	}
+}
+
+// Scope filters: resource_type narrows to one type; resource_id narrows instance
+// rows while always keeping the type-wide id:"*" row.
+func TestEffectivePermissionsScope(t *testing.T) {
+	e := newTestEnforcer(t)
+	const (
+		role = "r-a"
+		user = "u1"
+	)
+	mustNoErr(t, e.GrantRolePermission(role, "resource", "*", "view_detail"))
+	mustNoErr(t, e.AssignRole(user, role))
+	// Two instances with a surplus op beyond the type-wide view_detail.
+	mustNoErr(t, e.GrantObjectPermission(user, "resource", "r1", "modify"))
+	mustNoErr(t, e.GrantObjectPermission(user, "resource", "r2", "modify"))
+	// A different type that must be filtered out.
+	mustNoErr(t, e.GrantObjectPermission(user, "agent", "a1", "use"))
+
+	// resource_type only: drops agent, keeps resource:* + both instances.
+	_, grants, err := e.EffectivePermissions(user, PermQuery{ResourceType: "resource"})
+	mustNoErr(t, err)
+	idx := byObject(grants)
+	if _, ok := idx["agent:a1"]; ok {
+		t.Fatalf("agent:a1 must be filtered by resource_type: %+v", grants)
+	}
+	if !eqOps(idx["resource:*"], "view_detail") {
+		t.Fatalf("resource:* = %v", idx["resource:*"])
+	}
+	if !eqOps(idx["resource:r1"], "modify") || !eqOps(idx["resource:r2"], "modify") {
+		t.Fatalf("both instances expected: %+v", grants)
+	}
+
+	// resource_id=r1: narrows instances to r1, still keeps resource:* row.
+	_, grants, err = e.EffectivePermissions(user, PermQuery{ResourceType: "resource", ResourceIDs: []string{"r1"}})
+	mustNoErr(t, err)
+	idx = byObject(grants)
+	if _, ok := idx["resource:r2"]; ok {
+		t.Fatalf("resource:r2 must be narrowed out: %+v", grants)
+	}
+	if !eqOps(idx["resource:*"], "view_detail") {
+		t.Fatalf("type-wide row must remain under resource_id filter: %+v", grants)
+	}
+	if !eqOps(idx["resource:r1"], "modify") {
+		t.Fatalf("resource:r1 = %v", idx["resource:r1"])
+	}
+}

--- a/bkn-safe/server/internal/authz/effectiveperms_test.go
+++ b/bkn-safe/server/internal/authz/effectiveperms_test.go
@@ -142,6 +142,38 @@ func TestEffectivePermissionsInstanceExceedsTypeWide(t *testing.T) {
 	}
 }
 
+// A type-wide ActAll ("*") grant covers every op on the type, so instance rows
+// are dropped whatever their ops — even ops not literally in the type-wide set.
+// (Defensive: rejectWildcardGrant keeps such a grant off the HTTP write paths,
+// but the fold must not silently fail if one ever exists.)
+func TestEffectivePermissionsTypeWideActAllCoversInstances(t *testing.T) {
+	e := newTestEnforcer(t)
+	const (
+		role = "r-a"
+		user = "u1"
+	)
+	mustNoErr(t, e.GrantRolePermission(role, "agent", "*", "*")) // type-wide ActAll
+	mustNoErr(t, e.AssignRole(user, role))
+	mustNoErr(t, e.GrantObjectPermission(user, "agent", "a1", "use"))
+	mustNoErr(t, e.GrantObjectPermission(user, "agent", "a2", "publish"))
+
+	has, grants, err := e.EffectivePermissions(user, PermQuery{})
+	mustNoErr(t, err)
+	if has {
+		t.Fatal("hasWildcard: want false — this is a type-scoped ActAll, not a bare */*")
+	}
+	idx := byObject(grants)
+	if _, ok := idx["agent:a1"]; ok {
+		t.Errorf("agent:a1 must be dropped under type-wide agent:*/[*]: %+v", grants)
+	}
+	if _, ok := idx["agent:a2"]; ok {
+		t.Errorf("agent:a2 must be dropped under type-wide agent:*/[*]: %+v", grants)
+	}
+	if !eqOps(idx["agent:*"], "*") {
+		t.Errorf("agent:* = %v, want [*]", idx["agent:*"])
+	}
+}
+
 // A pure instance grant with no type-wide grant survives in full.
 func TestEffectivePermissionsPureInstance(t *testing.T) {
 	e := newTestEnforcer(t)

--- a/bkn-safe/server/internal/httpapi/me.go
+++ b/bkn-safe/server/internal/httpapi/me.go
@@ -153,7 +153,17 @@ func registerMe(g *gin.RouterGroup, e *authz.Enforcer, db *gorm.DB, dir *directo
 	}
 
 	// GET /permissions -> { is_admin, permissions:[ { resource{type,id}, operations:[...] } ] }
-	// Includes role-inherited grants; type-wide patterns keep id "*".
+	// Returns the EFFECTIVE (collapsed) authorization, not one row per instance:
+	// a resource-wildcard holder gets a single {type:"*",id:"*",ops:["*"]} row;
+	// everyone else gets one type-wide row per type plus an instance row only
+	// where that instance's ops exceed the type-wide set (carrying just the
+	// surplus). The frontend unions the id:"*" row with instance rows to judge
+	// a concrete (type,id). is_admin stays a separate flag (CanAdmin), decoupled
+	// from whether permissions is the wildcard single row.
+	//
+	// Optional scope filters: ?resource_type=<T> narrows to one type;
+	// &resource_id=<id1,id2,...> (comma-separated) narrows the instance rows,
+	// keeping the type-wide id:"*" row. resource_id requires resource_type.
 	g.GET("/permissions", func(c *gin.Context) {
 		accessorID := c.GetString(ctxAccessorID)
 		isAdmin, err := e.CanAdmin(accessorID)
@@ -161,7 +171,23 @@ func registerMe(g *gin.RouterGroup, e *authz.Enforcer, db *gorm.DB, dir *directo
 			serverError(c, err)
 			return
 		}
-		grants, err := e.AccessorPermissions(accessorID)
+		resourceType := c.Query("resource_type")
+		var resourceIDs []string
+		if raw := c.Query("resource_id"); raw != "" {
+			for _, id := range strings.Split(raw, ",") {
+				if id = strings.TrimSpace(id); id != "" {
+					resourceIDs = append(resourceIDs, id)
+				}
+			}
+		}
+		if len(resourceIDs) > 0 && resourceType == "" {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "resource_id requires resource_type"})
+			return
+		}
+		_, grants, err := e.EffectivePermissions(accessorID, authz.PermQuery{
+			ResourceType: resourceType,
+			ResourceIDs:  resourceIDs,
+		})
 		if err != nil {
 			serverError(c, err)
 			return

--- a/bkn-safe/server/internal/httpapi/me.go
+++ b/bkn-safe/server/internal/httpapi/me.go
@@ -19,12 +19,18 @@ import (
 	"bkn-safe/internal/model"
 )
 
-// registerMe mounts the self-service reads/writes under /api/safe/v1/me.
-// Token-gated by RequireUser: the accessor id comes from the verified bearer
-// token, never from the request — a caller can only read/edit its own data.
+// registerMeReads mounts the READ-ONLY self-service endpoints under
+// /api/safe/v1/me (GET "" and GET /permissions). Token-gated by RequireUser:
+// the accessor id comes from the verified bearer token, never from the request.
 // Frontends call these once after login to drive menu/button visibility; the
 // backend still enforces every request via /authz/check.
-func registerMe(g *gin.RouterGroup, e *authz.Enforcer, db *gorm.DB, dir *directory.Service, users *auth.UserStore) {
+//
+// These two are the endpoints the login burst hits in parallel, so the caller
+// mounts them behind the introspection cache. Mutating /me endpoints (profile
+// PUT, API-key issue/revoke) are registered separately on an UNCACHED verifier
+// (see registerMeProfile / registerMeAPIKeys) so a revoked token cannot mutate
+// within the read cache's TTL window.
+func registerMeReads(g *gin.RouterGroup, e *authz.Enforcer, db *gorm.DB, dir *directory.Service) {
 	// GET "" -> the caller's identity and roles:
 	// { id, account, name, email, telephone, account_type, enabled,
 	//   departments:[ids], roles:[names], role_ids:[ids], updated_at }
@@ -84,74 +90,6 @@ func registerMe(g *gin.RouterGroup, e *authz.Enforcer, db *gorm.DB, dir *directo
 		})
 	})
 
-	// PUT "" -> self-service profile update. The target is ALWAYS the token
-	// subject (never an :id from the path/body), so a caller can only edit its
-	// own profile — no admin grant required. Only name/email/telephone are
-	// writable here; account_type, enabled, department membership, account, and
-	// password stay admin-only / have their own endpoints. Only keys present in
-	// the body are changed; an absent key is left untouched. -> 204.
-	if users != nil {
-		g.PUT("", func(c *gin.Context) {
-			var req struct {
-				Name      *string `json:"name"`
-				Email     *string `json:"email"`
-				Telephone *string `json:"telephone"`
-			}
-			if !bind(c, &req) {
-				return
-			}
-			fields := map[string]any{}
-			if req.Name != nil {
-				name := strings.TrimSpace(*req.Name)
-				if name == "" {
-					c.JSON(http.StatusBadRequest, gin.H{"error": "name cannot be empty"})
-					return
-				}
-				if len(name) > 255 {
-					c.JSON(http.StatusBadRequest, gin.H{"error": "name too long (max 255)"})
-					return
-				}
-				fields["name"] = name
-			}
-			if req.Email != nil {
-				email := strings.TrimSpace(*req.Email)
-				// An empty email clears the field; a non-empty one must parse as a
-				// single, bare address (no display name / list).
-				if email != "" {
-					addr, err := mail.ParseAddress(email)
-					if err != nil || addr.Name != "" || addr.Address != email {
-						c.JSON(http.StatusBadRequest, gin.H{"error": "invalid email"})
-						return
-					}
-				}
-				fields["email"] = email
-			}
-			if req.Telephone != nil {
-				tel := strings.TrimSpace(*req.Telephone)
-				if len(tel) > 64 {
-					c.JSON(http.StatusBadRequest, gin.H{"error": "telephone too long (max 64)"})
-					return
-				}
-				fields["telephone"] = tel
-			}
-			if len(fields) == 0 {
-				c.JSON(http.StatusBadRequest, gin.H{"error": "no updatable fields provided"})
-				return
-			}
-			sub := c.GetString(ctxAccessorID)
-			err := users.UpdateUser(c.Request.Context(), sub, fields)
-			if errors.Is(err, gorm.ErrRecordNotFound) {
-				c.JSON(http.StatusNotFound, gin.H{"error": "no user for token subject: " + sub})
-				return
-			}
-			if err != nil {
-				serverError(c, err)
-				return
-			}
-			c.Status(http.StatusNoContent)
-		})
-	}
-
 	// GET /permissions -> { is_admin, permissions:[ { resource{type,id}, operations:[...] } ] }
 	// Returns the EFFECTIVE (collapsed) authorization, not one row per instance:
 	// a resource-wildcard holder gets a single {type:"*",id:"*",ops:["*"]} row;
@@ -196,5 +134,81 @@ func registerMe(g *gin.RouterGroup, e *authz.Enforcer, db *gorm.DB, dir *directo
 			"is_admin":    isAdmin,
 			"permissions": grantsJSON(grants),
 		})
+	})
+}
+
+// registerMeProfile mounts the MUTATING self-service profile endpoint (PUT "")
+// under /api/safe/v1/me. It is registered on an UNCACHED verifier (unlike the
+// read-only endpoints in registerMeReads) so a revoked token cannot edit the
+// profile within the read cache's TTL window.
+//
+// PUT "" -> self-service profile update. The target is ALWAYS the token subject
+// (never an :id from the path/body), so a caller can only edit its own profile —
+// no admin grant required. Only name/email/telephone are writable here;
+// account_type, enabled, department membership, account, and password stay
+// admin-only / have their own endpoints. Only keys present in the body are
+// changed; an absent key is left untouched. -> 204.
+func registerMeProfile(g *gin.RouterGroup, users *auth.UserStore) {
+	if users == nil {
+		return
+	}
+	g.PUT("", func(c *gin.Context) {
+		var req struct {
+			Name      *string `json:"name"`
+			Email     *string `json:"email"`
+			Telephone *string `json:"telephone"`
+		}
+		if !bind(c, &req) {
+			return
+		}
+		fields := map[string]any{}
+		if req.Name != nil {
+			name := strings.TrimSpace(*req.Name)
+			if name == "" {
+				c.JSON(http.StatusBadRequest, gin.H{"error": "name cannot be empty"})
+				return
+			}
+			if len(name) > 255 {
+				c.JSON(http.StatusBadRequest, gin.H{"error": "name too long (max 255)"})
+				return
+			}
+			fields["name"] = name
+		}
+		if req.Email != nil {
+			email := strings.TrimSpace(*req.Email)
+			// An empty email clears the field; a non-empty one must parse as a
+			// single, bare address (no display name / list).
+			if email != "" {
+				addr, err := mail.ParseAddress(email)
+				if err != nil || addr.Name != "" || addr.Address != email {
+					c.JSON(http.StatusBadRequest, gin.H{"error": "invalid email"})
+					return
+				}
+			}
+			fields["email"] = email
+		}
+		if req.Telephone != nil {
+			tel := strings.TrimSpace(*req.Telephone)
+			if len(tel) > 64 {
+				c.JSON(http.StatusBadRequest, gin.H{"error": "telephone too long (max 64)"})
+				return
+			}
+			fields["telephone"] = tel
+		}
+		if len(fields) == 0 {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "no updatable fields provided"})
+			return
+		}
+		sub := c.GetString(ctxAccessorID)
+		err := users.UpdateUser(c.Request.Context(), sub, fields)
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			c.JSON(http.StatusNotFound, gin.H{"error": "no user for token subject: " + sub})
+			return
+		}
+		if err != nil {
+			serverError(c, err)
+			return
+		}
+		c.Status(http.StatusNoContent)
 	})
 }

--- a/bkn-safe/server/internal/httpapi/me_cache_test.go
+++ b/bkn-safe/server/internal/httpapi/me_cache_test.go
@@ -1,0 +1,110 @@
+// Copyright openbkn.ai
+//
+// Licensed under the OpenBKN License. See LICENSE-OPENBKN.txt in the project root.
+
+package httpapi
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/glebarez/sqlite"
+	"gorm.io/gorm"
+
+	"bkn-safe/internal/auth"
+	"bkn-safe/internal/authz"
+	"bkn-safe/internal/database"
+	"bkn-safe/internal/directory"
+	"bkn-safe/internal/model"
+)
+
+// revocableVerifier resolves any non-empty token to itself until Revoke flips
+// it, after which every call fails — simulating a token revoked mid-session.
+type revocableVerifier struct{ revoked atomic.Bool }
+
+func (v *revocableVerifier) VerifyToken(_ context.Context, token string) (string, error) {
+	if v.revoked.Load() || token == "" {
+		return "", errors.New("revoked")
+	}
+	return token, nil
+}
+
+// TestMeMutatingEndpointsBypassCache proves the introspection cache is scoped to
+// the READ-ONLY /me endpoints. After a token is revoked, GET /me/permissions may
+// still succeed within the cache TTL, but mutating requests (POST /me/api-keys,
+// PUT /me) must fail immediately because they run on the uncached verifier —
+// otherwise a revoked token could mint a long-lived API key inside the cache
+// window.
+func TestMeMutatingEndpointsBypassCache(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	if err != nil {
+		t.Fatalf("sqlite: %v", err)
+	}
+	if err := database.Migrate(db); err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+	e, err := authz.New(db)
+	if err != nil {
+		t.Fatalf("authz: %v", err)
+	}
+	users := auth.NewUserStore(db)
+	if err := users.CreateLocalUser(t.Context(),
+		&model.User{ID: "u-k", Account: "uk", Enabled: true}, "pw-init0"); err != nil {
+		t.Fatal(err)
+	}
+
+	v := &revocableVerifier{}
+	r := New(Deps{
+		Enforcer: e, DB: db, Directory: directory.New(db), Users: users,
+		TokenVerifier: v,
+	})
+
+	call := func(method, path, body string) int {
+		var rdr *strings.Reader
+		if body != "" {
+			rdr = strings.NewReader(body)
+		}
+		var req *http.Request
+		if rdr != nil {
+			req = httptest.NewRequest(method, path, rdr)
+			req.Header.Set("Content-Type", "application/json")
+		} else {
+			req = httptest.NewRequest(method, path, nil)
+		}
+		req.Header.Set("Authorization", "Bearer u-k")
+		w := httptest.NewRecorder()
+		r.ServeHTTP(w, req)
+		return w.Code
+	}
+
+	// Warm the read cache for token u-k.
+	if code := call(http.MethodGet, "/api/safe/v1/me/permissions", ""); code != http.StatusOK {
+		t.Fatalf("warm read: want 200, got %d", code)
+	}
+
+	// Revoke the token.
+	v.revoked.Store(true)
+
+	// Read-only endpoint is still served from the cache within its TTL.
+	if code := call(http.MethodGet, "/api/safe/v1/me/permissions", ""); code != http.StatusOK {
+		t.Fatalf("cached read after revoke: want 200, got %d", code)
+	}
+
+	// Mutating endpoints must reject immediately — they run on the uncached
+	// verifier, so a revoked token cannot mint a long-lived API key or edit the
+	// profile inside the read cache window.
+	if code := call(http.MethodPost, "/api/safe/v1/me/api-keys",
+		`{"name":"k","never_expire":true}`); code != http.StatusUnauthorized {
+		t.Fatalf("api-key create after revoke: want 401, got %d", code)
+	}
+	if code := call(http.MethodPut, "/api/safe/v1/me", `{"name":"x"}`); code != http.StatusUnauthorized {
+		t.Fatalf("profile update after revoke: want 401, got %d", code)
+	}
+}

--- a/bkn-safe/server/internal/httpapi/me_test.go
+++ b/bkn-safe/server/internal/httpapi/me_test.go
@@ -7,6 +7,7 @@ package httpapi
 import (
 	"encoding/json"
 	"net/http"
+	"net/http/httptest"
 	"testing"
 
 	"bkn-safe/internal/model"
@@ -224,7 +225,8 @@ func TestMePermissions(t *testing.T) {
 		t.Errorf("kn/kn-1 ops: want [view], got %v", ops)
 	}
 
-	// super-admin: is_admin true, wildcard grant surfaces as type "*".
+	// super-admin (holds "*"/"*"): is_admin true AND permissions collapses to a
+	// single {type:"*", id:"*", ops:["*"]} row — not the per-instance fan-out.
 	w = adminReq(t, r, http.MethodGet, path, nil)
 	if w.Code != http.StatusOK {
 		t.Fatalf("admin: want 200, got %d", w.Code)
@@ -234,5 +236,92 @@ func TestMePermissions(t *testing.T) {
 	}
 	if !resp.IsAdmin {
 		t.Error("admin: is_admin must be true")
+	}
+	if len(resp.Permissions) != 1 {
+		t.Fatalf("admin: want single collapsed row, got %d: %s", len(resp.Permissions), w.Body.String())
+	}
+	if p := resp.Permissions[0]; p.Resource.Type != "*" || p.Resource.ID != "*" ||
+		len(p.Operations) != 1 || p.Operations[0] != "*" {
+		t.Errorf("admin collapsed row = %+v, want {*,*,[*]}", resp.Permissions[0])
+	}
+}
+
+// TestMePermissionsScope covers the scope filters and their validation.
+func TestMePermissionsScope(t *testing.T) {
+	r, e, _, _ := newAdminServer(t)
+	const path = "/api/safe/v1/me/permissions"
+
+	// u1: type-wide large_model:* [display,execute] via role, plus two instance
+	// surplus grants, plus an unrelated agent grant that scope must filter out.
+	if err := e.GrantRolePermission("role-m", "large_model", "*", "display"); err != nil {
+		t.Fatal(err)
+	}
+	if err := e.GrantRolePermission("role-m", "large_model", "*", "execute"); err != nil {
+		t.Fatal(err)
+	}
+	if err := e.AssignRole("u1", "role-m"); err != nil {
+		t.Fatal(err)
+	}
+	if err := e.GrantObjectPermission("u1", "large_model", "m1", "modify"); err != nil { // surplus
+		t.Fatal(err)
+	}
+	if err := e.GrantObjectPermission("u1", "large_model", "m2", "modify"); err != nil { // surplus
+		t.Fatal(err)
+	}
+	if err := e.GrantObjectPermission("u1", "agent", "a1", "use"); err != nil { // filtered out
+		t.Fatal(err)
+	}
+
+	decode := func(w *httptest.ResponseRecorder) map[string][]string {
+		t.Helper()
+		if w.Code != http.StatusOK {
+			t.Fatalf("want 200, got %d (%s)", w.Code, w.Body.String())
+		}
+		var resp struct {
+			Permissions []struct {
+				Resource struct {
+					Type string `json:"type"`
+					ID   string `json:"id"`
+				} `json:"resource"`
+				Operations []string `json:"operations"`
+			} `json:"permissions"`
+		}
+		if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+			t.Fatalf("decode: %v", err)
+		}
+		out := map[string][]string{}
+		for _, p := range resp.Permissions {
+			out[p.Resource.Type+"/"+p.Resource.ID] = p.Operations
+		}
+		return out
+	}
+
+	// resource_type=large_model: only large_model rows (type-wide + instances).
+	got := decode(tokReq(t, r, http.MethodGet, path+"?resource_type=large_model", nil, "u1"))
+	if _, ok := got["agent/a1"]; ok {
+		t.Errorf("agent/a1 must be filtered by resource_type: %v", got)
+	}
+	if got["large_model/*"] == nil {
+		t.Errorf("type-wide large_model/* row missing: %v", got)
+	}
+	if len(got["large_model/m1"]) != 1 || got["large_model/m1"][0] != "modify" {
+		t.Errorf("large_model/m1 surplus = %v, want [modify]", got["large_model/m1"])
+	}
+
+	// resource_id=m1: narrows instances to m1 but keeps the type-wide row.
+	got = decode(tokReq(t, r, http.MethodGet, path+"?resource_type=large_model&resource_id=m1", nil, "u1"))
+	if _, ok := got["large_model/m2"]; ok {
+		t.Errorf("large_model/m2 must be narrowed out: %v", got)
+	}
+	if got["large_model/*"] == nil {
+		t.Errorf("type-wide row must remain under resource_id filter: %v", got)
+	}
+	if got["large_model/m1"] == nil {
+		t.Errorf("large_model/m1 expected: %v", got)
+	}
+
+	// resource_id without resource_type -> 400.
+	if w := tokReq(t, r, http.MethodGet, path+"?resource_id=m1", nil, "u1"); w.Code != http.StatusBadRequest {
+		t.Errorf("resource_id without resource_type: want 400, got %d", w.Code)
 	}
 }

--- a/bkn-safe/server/internal/httpapi/objectgrants.go
+++ b/bkn-safe/server/internal/httpapi/objectgrants.go
@@ -82,6 +82,18 @@ func registerObjectGrants(g *gin.RouterGroup, e *authz.Enforcer, db *gorm.DB) {
 		whereSQL := strings.Join(where, " AND ")
 		qdb := db.WithContext(c.Request.Context())
 
+		// Grouped views for the admin UI: group_by=object lists distinct objects
+		// (each with its grantee count + union of ops), group_by=grantee lists
+		// distinct grantees (each with its object count). The UI paginates GROUPS
+		// (e.g. 10 objects/page), which a flat grant page cannot serve — one
+		// object's grants may span pages, so client-side grouping would have to
+		// pull every grant. Grouping happens in SQL, so a page stays small
+		// regardless of the total grant count.
+		if gb := c.Query("group_by"); gb == "object" || gb == "grantee" {
+			listGroupedObjectGrants(c, qdb, gb, whereSQL, args)
+			return
+		}
+
 		// total = number of (accessor, object) groups after filtering.
 		var total int64
 		if err := qdb.Raw(
@@ -243,6 +255,81 @@ func registerObjectGrants(g *gin.RouterGroup, e *authz.Enforcer, db *gorm.DB) {
 		}
 		c.Status(http.StatusNoContent)
 	})
+}
+
+// listGroupedObjectGrants serves the grouped, paginated object-grant views the
+// admin UI needs: group_by=object (distinct objects, each with a grantee count)
+// or group_by=grantee (distinct grantees, each with an object count). Both carry
+// the union of operations. Grouping + pagination run in SQL so a page is a
+// handful of groups no matter how many grants exist. `whereSQL`/`args` are the
+// same concrete-grant filter the flat listing uses (roles/public/type-wide
+// already excluded, plus any request filters).
+func listGroupedObjectGrants(c *gin.Context, qdb *gorm.DB, groupBy, whereSQL string, args []any) {
+	keyCol, cntCol := "v1", "v0" // group_by=object: key on the object, count grantees
+	if groupBy == "grantee" {
+		keyCol, cntCol = "v0", "v1"
+	}
+
+	var total int64
+	if err := qdb.Raw(
+		"SELECT COUNT(*) FROM (SELECT 1 FROM casbin_rule WHERE "+whereSQL+" GROUP BY "+keyCol+") t",
+		args...).Scan(&total).Error; err != nil {
+		serverError(c, err)
+		return
+	}
+
+	sql := "SELECT " + keyCol + " AS k, COUNT(DISTINCT " + cntCol + ") AS cnt, " +
+		"GROUP_CONCAT(DISTINCT v2) AS ops FROM casbin_rule WHERE " + whereSQL +
+		" GROUP BY " + keyCol + " ORDER BY " + keyCol
+	rowArgs := append([]any{}, args...)
+	if _, limitSet := c.GetQuery("limit"); limitSet {
+		limit := atoiDefault(c.Query("limit"), 0)
+		if limit <= 0 {
+			limit = 50
+		}
+		if limit > 500 {
+			limit = 500
+		}
+		offset := atoiDefault(c.Query("offset"), 0)
+		if offset < 0 {
+			offset = 0
+		}
+		sql += " LIMIT ? OFFSET ?"
+		rowArgs = append(rowArgs, limit, offset)
+	}
+
+	var rows []struct {
+		K   string
+		Cnt int64
+		Ops string
+	}
+	if err := qdb.Raw(sql, rowArgs...).Scan(&rows).Error; err != nil {
+		serverError(c, err)
+		return
+	}
+
+	groups := make([]gin.H, 0, len(rows))
+	for _, r := range rows {
+		var ops []string
+		if r.Ops != "" {
+			ops = strings.Split(r.Ops, ",")
+		}
+		if groupBy == "object" {
+			rtype, rid, _ := strings.Cut(r.K, ":")
+			groups = append(groups, gin.H{
+				"object":        gin.H{"type": rtype, "id": rid},
+				"grantee_count": r.Cnt,
+				"operations":    ops,
+			})
+		} else {
+			groups = append(groups, gin.H{
+				"accessor_id":  r.K,
+				"object_count": r.Cnt,
+				"operations":   ops,
+			})
+		}
+	}
+	c.JSON(http.StatusOK, gin.H{"groups": groups, "total": total})
 }
 
 // isUserAccessor reports whether id is a known user row (real user or app

--- a/bkn-safe/server/internal/httpapi/objectgrants.go
+++ b/bkn-safe/server/internal/httpapi/objectgrants.go
@@ -43,64 +43,77 @@ func registerObjectGrants(g *gin.RouterGroup, e *authz.Enforcer, db *gorm.DB) {
 		resourceID := objectGrantQueryParam(c, "resource_id", "obj_id")
 		search := strings.TrimSpace(c.Query("search"))
 
-		grants, err := e.ListObjectGrants(accessorID, resourceType, resourceID)
-		if err != nil {
-			serverError(c, err)
-			return
+		// Read the casbin_rule grant table directly (not casbin's in-memory
+		// GetPolicy) so filtering, grouping and pagination all happen in SQL:
+		// the query is O(page) instead of materializing every grant. Object keys
+		// are "type:id" (obj()); splitObjectKey splits on the FIRST colon, so the
+		// rtype/rid expressions below mirror it with INSTR/SUBSTR — portable
+		// across sqlite (tests) and MariaDB (prod). casbin autosave keeps this
+		// table in sync with the in-memory model on every grant/revoke.
+		const rtypeExpr = "SUBSTR(v1, 1, INSTR(v1, ':') - 1)"
+		const ridExpr = "SUBSTR(v1, INSTR(v1, ':') + 1)"
+
+		where := []string{
+			"ptype = 'p'",
+			"INSTR(v1, ':') > 0",               // has the type:id shape
+			ridExpr + " NOT IN ('', '*')",      // concrete instance only (skip type-wide / bare "*")
+			"v0 NOT IN (SELECT id FROM roles)", // role subjects are not user object grants
+			"v0 <> ?",                          // exclude the public accessor
 		}
-		roleIDs, err := roleIDSet(c, db)
-		if err != nil {
+		args := []any{authz.PublicAccessorID}
+		if accessorID != "" {
+			where = append(where, "v0 = ?")
+			args = append(args, accessorID)
+		}
+		if resourceType != "" {
+			where = append(where, rtypeExpr+" = ?")
+			args = append(args, resourceType)
+		}
+		if resourceID != "" {
+			where = append(where, ridExpr+" = ?")
+			args = append(args, resourceID)
+		}
+		if search != "" {
+			like := "%" + search + "%"
+			where = append(where,
+				"(v0 IN (SELECT id FROM users WHERE account LIKE ? OR name LIKE ?) OR "+ridExpr+" LIKE ?)")
+			args = append(args, like, like, like)
+		}
+		whereSQL := strings.Join(where, " AND ")
+		qdb := db.WithContext(c.Request.Context())
+
+		// total = number of (accessor, object) groups after filtering.
+		var total int64
+		if err := qdb.Raw(
+			"SELECT COUNT(*) FROM (SELECT 1 FROM casbin_rule WHERE "+whereSQL+" GROUP BY v0, v1) t",
+			args...).Scan(&total).Error; err != nil {
 			serverError(c, err)
 			return
 		}
 
-		var userSearch map[string]bool
-		if search != "" {
-			userSearch, err = userIDsMatchingSearch(c, db, search)
-			if err != nil {
+		resp := gin.H{"total": total}
+		if c.Query("include_summary") == "true" {
+			var objects, grantees int64
+			if err := qdb.Raw("SELECT COUNT(DISTINCT v1) FROM casbin_rule WHERE "+whereSQL, args...).
+				Scan(&objects).Error; err != nil {
 				serverError(c, err)
 				return
 			}
-		}
-		searchLower := strings.ToLower(search)
-
-		entries := make([]gin.H, 0, len(grants))
-		objectIDs := make(map[string]bool)
-		granteeIDs := make(map[string]bool)
-		for _, gr := range grants {
-			if roleIDs[gr.AccessorID] || gr.AccessorID == authz.PublicAccessorID {
-				continue // not a user object grant
+			if err := qdb.Raw("SELECT COUNT(DISTINCT v0) FROM casbin_rule WHERE "+whereSQL, args...).
+				Scan(&grantees).Error; err != nil {
+				serverError(c, err)
+				return
 			}
-			if search != "" {
-				if !userSearch[gr.AccessorID] && !strings.Contains(strings.ToLower(gr.ResourceID), searchLower) {
-					continue
-				}
-			}
-			entries = append(entries, gin.H{
-				"accessor_id": gr.AccessorID,
-				"resource":    gin.H{"type": gr.ResourceType, "id": gr.ResourceID},
-				"operations":  gr.Operations,
-			})
-			objectIDs[gr.ResourceType+":"+gr.ResourceID] = true
-			granteeIDs[gr.AccessorID] = true
+			resp["summary"] = gin.H{"grants": total, "objects": objects, "grantees": grantees}
 		}
 
-		total := len(entries)
-		resp := gin.H{
-			"entries": entries,
-			"total":   total,
-		}
-		if c.Query("include_summary") == "true" {
-			resp["summary"] = gin.H{
-				"grants":   total,
-				"objects":  len(objectIDs),
-				"grantees": len(granteeIDs),
-			}
-		}
-
-		_, limitSet := c.GetQuery("limit")
-		if limitSet {
-			offset := atoiDefault(c.Query("offset"), 0)
+		// entries page: one row per (accessor, object), ops aggregated. Ordered by
+		// (v0, v1) so paging is deterministic.
+		rowsSQL := "SELECT v0 AS accessor, " + rtypeExpr + " AS rtype, " + ridExpr + " AS rid, " +
+			"GROUP_CONCAT(DISTINCT v2) AS ops FROM casbin_rule WHERE " + whereSQL +
+			" GROUP BY v0, v1 ORDER BY v0, v1"
+		rowArgs := append([]any{}, args...)
+		if _, limitSet := c.GetQuery("limit"); limitSet {
 			limit := atoiDefault(c.Query("limit"), 0)
 			if limit <= 0 {
 				limit = 50
@@ -108,20 +121,38 @@ func registerObjectGrants(g *gin.RouterGroup, e *authz.Enforcer, db *gorm.DB) {
 			if limit > 500 {
 				limit = 500
 			}
+			offset := atoiDefault(c.Query("offset"), 0)
 			if offset < 0 {
 				offset = 0
 			}
-			if offset >= len(entries) {
-				entries = []gin.H{}
-			} else {
-				end := offset + limit
-				if end > len(entries) {
-					end = len(entries)
-				}
-				entries = entries[offset:end]
-			}
-			resp["entries"] = entries
+			rowsSQL += " LIMIT ? OFFSET ?"
+			rowArgs = append(rowArgs, limit, offset)
 		}
+
+		var rows []struct {
+			Accessor string
+			Rtype    string
+			Rid      string
+			Ops      string
+		}
+		if err := qdb.Raw(rowsSQL, rowArgs...).Scan(&rows).Error; err != nil {
+			serverError(c, err)
+			return
+		}
+
+		entries := make([]gin.H, 0, len(rows))
+		for _, row := range rows {
+			var ops []string
+			if row.Ops != "" {
+				ops = strings.Split(row.Ops, ",")
+			}
+			entries = append(entries, gin.H{
+				"accessor_id": row.Accessor,
+				"resource":    gin.H{"type": row.Rtype, "id": row.Rid},
+				"operations":  ops,
+			})
+		}
+		resp["entries"] = entries
 
 		c.JSON(http.StatusOK, resp)
 	})
@@ -225,42 +256,11 @@ func isUserAccessor(c *gin.Context, db *gorm.DB, id string) (bool, error) {
 	return n > 0, nil
 }
 
-// roleIDSet loads every role id into a lookup set, used to exclude role subjects
-// from the user object-grant listing.
-func roleIDSet(c *gin.Context, db *gorm.DB) (map[string]bool, error) {
-	var ids []string
-	if err := db.WithContext(c.Request.Context()).Model(&model.Role{}).
-		Pluck("id", &ids).Error; err != nil {
-		return nil, err
-	}
-	set := make(map[string]bool, len(ids))
-	for _, id := range ids {
-		set[id] = true
-	}
-	return set, nil
-}
-
 func objectGrantQueryParam(c *gin.Context, primary, alias string) string {
 	if v := c.Query(primary); v != "" {
 		return v
 	}
 	return c.Query(alias)
-}
-
-// userIDsMatchingSearch returns user ids whose account or name matches search.
-func userIDsMatchingSearch(c *gin.Context, db *gorm.DB, search string) (map[string]bool, error) {
-	var ids []string
-	like := "%" + search + "%"
-	if err := db.WithContext(c.Request.Context()).Model(&model.User{}).
-		Where("account LIKE ? OR name LIKE ?", like, like).
-		Pluck("id", &ids).Error; err != nil {
-		return nil, err
-	}
-	set := make(map[string]bool, len(ids))
-	for _, id := range ids {
-		set[id] = true
-	}
-	return set, nil
 }
 
 // catalogOpSet returns the resource type's registered operation ids as a set

--- a/bkn-safe/server/internal/httpapi/objectgrants.go
+++ b/bkn-safe/server/internal/httpapi/objectgrants.go
@@ -121,6 +121,13 @@ func registerObjectGrants(g *gin.RouterGroup, e *authz.Enforcer, db *gorm.DB) {
 
 		// entries page: one row per (accessor, object), ops aggregated. Ordered by
 		// (v0, v1) so paging is deterministic.
+		//
+		// GROUP_CONCAT(DISTINCT v2) is safe against MariaDB's default 1024-byte
+		// group_concat_max_len: DISTINCT collapses the ops to the operation
+		// VOCABULARY (a fixed ~dozen ids like view_detail/modify/authorize), not
+		// per-grant, so the concatenation is bounded by vocabulary size — not grant
+		// count — and stays far under 1024. Op ids contain no ",", so splitting the
+		// result on "," below is safe.
 		rowsSQL := "SELECT v0 AS accessor, " + rtypeExpr + " AS rtype, " + ridExpr + " AS rid, " +
 			"GROUP_CONCAT(DISTINCT v2) AS ops FROM casbin_rule WHERE " + whereSQL +
 			" GROUP BY v0, v1 ORDER BY v0, v1"
@@ -278,6 +285,9 @@ func listGroupedObjectGrants(c *gin.Context, qdb *gorm.DB, groupBy, whereSQL str
 		return
 	}
 
+	// GROUP_CONCAT(DISTINCT v2): as in the flat listing, DISTINCT collapses ops to
+	// the fixed operation vocabulary (a comma-free ~dozen ids), so the result
+	// stays well under group_concat_max_len and splits cleanly on ",".
 	sql := "SELECT " + keyCol + " AS k, COUNT(DISTINCT " + cntCol + ") AS cnt, " +
 		"GROUP_CONCAT(DISTINCT v2) AS ops FROM casbin_rule WHERE " + whereSQL +
 		" GROUP BY " + keyCol + " ORDER BY " + keyCol

--- a/bkn-safe/server/internal/httpapi/objectgrants_test.go
+++ b/bkn-safe/server/internal/httpapi/objectgrants_test.go
@@ -245,3 +245,89 @@ func TestObjectGrantsPaginationAndSearch(t *testing.T) {
 		t.Fatalf("obj_* aliases: %+v", got)
 	}
 }
+
+func TestObjectGrantsGroupedViews(t *testing.T) {
+	r, _, db, users := newAdminServer(t)
+	ctx := t.Context()
+	for _, u := range []model.User{
+		{ID: "u-1", Account: "alice", Name: "Alice", Enabled: true},
+		{ID: "u-2", Account: "bob", Name: "Bob", Enabled: true},
+	} {
+		if err := users.CreateLocalUser(ctx, &u, "pw-init0"); err != nil {
+			t.Fatal(err)
+		}
+	}
+	seedCatalogOps(t, db, "catalog", "view_detail", "modify")
+
+	grant := func(accessorID, id string, ops ...string) {
+		t.Helper()
+		w := adminReq(t, r, http.MethodPost, "/api/safe/v1/admin/object-grants", map[string]any{
+			"accessor_id": accessorID,
+			"resource":    map[string]any{"type": "catalog", "id": id},
+			"operations":  ops,
+		})
+		if w.Code != http.StatusNoContent {
+			t.Fatalf("grant %s/%s: %d (%s)", accessorID, id, w.Code, w.Body.String())
+		}
+	}
+	// c1: granted to both u-1 and u-2; c2: only u-1.
+	grant("u-1", "c1", "view_detail", "modify")
+	grant("u-2", "c1", "view_detail")
+	grant("u-1", "c2", "view_detail")
+
+	decode := func(query string) struct {
+		Groups []map[string]any `json:"groups"`
+		Total  int              `json:"total"`
+	} {
+		t.Helper()
+		w := adminReq(t, r, http.MethodGet, "/api/safe/v1/admin/object-grants"+query, nil)
+		if w.Code != http.StatusOK {
+			t.Fatalf("grouped list %s: %d (%s)", query, w.Code, w.Body.String())
+		}
+		var body struct {
+			Groups []map[string]any `json:"groups"`
+			Total  int              `json:"total"`
+		}
+		if err := json.Unmarshal(w.Body.Bytes(), &body); err != nil {
+			t.Fatalf("decode: %v", err)
+		}
+		return body
+	}
+
+	// group_by=object: 2 distinct objects (c1, c2); c1 has 2 grantees, c2 has 1.
+	byObj := decode("?group_by=object")
+	if byObj.Total != 2 || len(byObj.Groups) != 2 {
+		t.Fatalf("group_by=object: total=%d groups=%d", byObj.Total, len(byObj.Groups))
+	}
+	for _, g := range byObj.Groups {
+		obj := g["object"].(map[string]any)
+		want := 1.0
+		if obj["id"] == "c1" {
+			want = 2.0
+		}
+		if g["grantee_count"].(float64) != want {
+			t.Fatalf("object %v grantee_count = %v, want %v", obj["id"], g["grantee_count"], want)
+		}
+	}
+
+	// group_by=grantee: 2 distinct grantees; u-1 on 2 objects, u-2 on 1.
+	byGrantee := decode("?group_by=grantee")
+	if byGrantee.Total != 2 || len(byGrantee.Groups) != 2 {
+		t.Fatalf("group_by=grantee: total=%d groups=%d", byGrantee.Total, len(byGrantee.Groups))
+	}
+	for _, g := range byGrantee.Groups {
+		want := 1.0
+		if g["accessor_id"] == "u-1" {
+			want = 2.0
+		}
+		if g["object_count"].(float64) != want {
+			t.Fatalf("grantee %v object_count = %v, want %v", g["accessor_id"], g["object_count"], want)
+		}
+	}
+
+	// grouped pagination: 1 object per page, total still 2.
+	page := decode("?group_by=object&limit=1&offset=0")
+	if page.Total != 2 || len(page.Groups) != 1 {
+		t.Fatalf("grouped pagination: total=%d groups=%d", page.Total, len(page.Groups))
+	}
+}

--- a/bkn-safe/server/internal/httpapi/router.go
+++ b/bkn-safe/server/internal/httpapi/router.go
@@ -86,13 +86,17 @@ func New(deps Deps) *gin.Engine {
 	if verifier == nil && deps.Hydra != nil {
 		verifier = deps.Hydra
 	}
-	// Wrap the verifier in a short-TTL, singleflight-deduplicated cache. Every
-	// token-gated request (admin + /me) introspects via hydra; the frontend fires
-	// /me and /me/permissions in parallel at login, so this collapses that pair
-	// into one upstream introspection and absorbs repeat pulls. Authorization is
-	// unaffected — only the token->subject step is cached, casbin still runs live.
-	if verifier != nil {
-		verifier = newCachingVerifier(verifier, verifierCacheTTL)
+	// The introspection cache is scoped to /me ONLY. The frontend fires /me and
+	// /me/permissions in parallel at login, so a short-TTL, singleflight-
+	// deduplicated cache collapses that pair into one upstream introspection and
+	// absorbs repeat pulls. It is NOT applied to /admin: that surface keeps the
+	// raw verifier so a revoked/logged-out token stops working on mutating admin
+	// operations immediately, rather than up to a TTL later — the revocation-lag
+	// trade-off stays confined to read-only self-service. Authorization (casbin)
+	// is realtime on both regardless; only the token->subject step is cached.
+	meVerifier := verifier
+	if meVerifier != nil {
+		meVerifier = newCachingVerifier(meVerifier, verifierCacheTTL)
 	}
 	if deps.Enforcer != nil && verifier != nil && deps.Users != nil && deps.Directory != nil {
 		admin := r.Group("/api/safe/v1/admin", RequireAdmin(verifier, deps.Enforcer))
@@ -139,7 +143,7 @@ func New(deps Deps) *gin.Engine {
 	// Self-service reads under /api/safe/v1/me — token-gated (RequireUser:
 	// authn only), gateway-exposed. The caller reads its own permission list.
 	if deps.Enforcer != nil && verifier != nil && deps.Directory != nil {
-		me := r.Group("/api/safe/v1/me", RequireUser(verifier))
+		me := r.Group("/api/safe/v1/me", RequireUser(meVerifier))
 		registerMe(me, deps.Enforcer, deps.DB, deps.Directory, deps.Users)
 		// Self-service AppKey management (issue/list/revoke own keys).
 		if apiKeys != nil {

--- a/bkn-safe/server/internal/httpapi/router.go
+++ b/bkn-safe/server/internal/httpapi/router.go
@@ -86,6 +86,14 @@ func New(deps Deps) *gin.Engine {
 	if verifier == nil && deps.Hydra != nil {
 		verifier = deps.Hydra
 	}
+	// Wrap the verifier in a short-TTL, singleflight-deduplicated cache. Every
+	// token-gated request (admin + /me) introspects via hydra; the frontend fires
+	// /me and /me/permissions in parallel at login, so this collapses that pair
+	// into one upstream introspection and absorbs repeat pulls. Authorization is
+	// unaffected — only the token->subject step is cached, casbin still runs live.
+	if verifier != nil {
+		verifier = newCachingVerifier(verifier, verifierCacheTTL)
+	}
 	if deps.Enforcer != nil && verifier != nil && deps.Users != nil && deps.Directory != nil {
 		admin := r.Group("/api/safe/v1/admin", RequireAdmin(verifier, deps.Enforcer))
 		// Audit every mutating admin request. Use() must precede the route

--- a/bkn-safe/server/internal/httpapi/router.go
+++ b/bkn-safe/server/internal/httpapi/router.go
@@ -143,11 +143,20 @@ func New(deps Deps) *gin.Engine {
 	// Self-service reads under /api/safe/v1/me — token-gated (RequireUser:
 	// authn only), gateway-exposed. The caller reads its own permission list.
 	if deps.Enforcer != nil && verifier != nil && deps.Directory != nil {
-		me := r.Group("/api/safe/v1/me", RequireUser(meVerifier))
-		registerMe(me, deps.Enforcer, deps.DB, deps.Directory, deps.Users)
+		// Read-only /me (GET "" + GET /permissions): the login burst fires these
+		// two in parallel, so they get the cached, singleflight-deduplicated
+		// verifier.
+		meReads := r.Group("/api/safe/v1/me", RequireUser(meVerifier))
+		registerMeReads(meReads, deps.Enforcer, deps.DB, deps.Directory)
+
+		// Mutating /me (profile PUT, AppKey issue/revoke) uses the RAW verifier so
+		// a revoked/logged-out token cannot edit the profile or mint a long-lived
+		// API key within the read cache's TTL window.
+		meWrites := r.Group("/api/safe/v1/me", RequireUser(verifier))
+		registerMeProfile(meWrites, deps.Users)
 		// Self-service AppKey management (issue/list/revoke own keys).
 		if apiKeys != nil {
-			registerMeAPIKeys(me, apiKeys)
+			registerMeAPIKeys(meWrites, apiKeys)
 		}
 	}
 

--- a/bkn-safe/server/internal/httpapi/verifier_cache.go
+++ b/bkn-safe/server/internal/httpapi/verifier_cache.go
@@ -22,6 +22,12 @@ import (
 // on refresh / re-nav — so a few seconds buys the whole win.
 const verifierCacheTTL = 10 * time.Second
 
+// verifierIntrospectTimeout bounds the shared upstream introspection performed
+// inside a singleflight group. That call is decoupled from any single caller's
+// context (see VerifyToken), so it needs its own deadline instead of inheriting
+// a caller's cancellation.
+const verifierIntrospectTimeout = 10 * time.Second
+
 // cachingVerifier wraps a TokenVerifier with two independent latency cuts:
 //
 //   - singleflight de-duplication: /me and /me/permissions load in parallel with
@@ -81,7 +87,15 @@ func (c *cachingVerifier) VerifyToken(ctx context.Context, token string) (string
 		if s, ok := c.lookup(key); ok {
 			return s, nil
 		}
-		s, err := c.inner.VerifyToken(ctx, token)
+		// The shared introspection must NOT inherit the triggering caller's
+		// cancellation: whichever caller wins the flight would otherwise drag all
+		// the other waiters down with its cancel error — e.g. the browser aborts
+		// one of the parallel /me + /me/permissions requests and the healthy one
+		// gets a spurious 401. Decouple from any single caller's context and give
+		// the shared call its own deadline.
+		sfCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), verifierIntrospectTimeout)
+		defer cancel()
+		s, err := c.inner.VerifyToken(sfCtx, token)
 		if err != nil {
 			return "", err // not cached: fail-closed, re-verified next request
 		}

--- a/bkn-safe/server/internal/httpapi/verifier_cache.go
+++ b/bkn-safe/server/internal/httpapi/verifier_cache.go
@@ -1,0 +1,137 @@
+// Copyright openbkn.ai
+//
+// Licensed under the OpenBKN License. See LICENSE-OPENBKN.txt in the project root.
+
+package httpapi
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"sync"
+	"time"
+
+	"golang.org/x/sync/singleflight"
+)
+
+// verifierCacheTTL bounds how long a successful token->subject introspection is
+// reused before hydra is asked again. It is deliberately short: a token revoked
+// (or expired) upstream still verifies for up to this long (revocation lag). The
+// window only has to be wide enough to absorb the login burst — the frontend
+// fires /me and /me/permissions in parallel right after login and re-pulls them
+// on refresh / re-nav — so a few seconds buys the whole win.
+const verifierCacheTTL = 10 * time.Second
+
+// cachingVerifier wraps a TokenVerifier with two independent latency cuts:
+//
+//   - singleflight de-duplication: /me and /me/permissions load in parallel with
+//     the SAME bearer token at startup. A plain cache does not help that pair —
+//     both miss and both introspect. singleflight collapses concurrent calls for
+//     one token into a SINGLE upstream introspection; the others wait on it.
+//   - a short-TTL success cache: repeat calls within verifierCacheTTL (refresh /
+//     re-nav) return the cached subject without touching hydra.
+//
+// Only successful, active verifications are cached. Errors and inactive tokens
+// are never stored, so the underlying verifier's fail-closed contract holds:
+// a revoked token is re-checked on the very next request after the cache lapses.
+// The cache keys on a sha256 of the token, never the raw bearer string.
+//
+// Caching only the SUBJECT (identity) is safe: authorization is re-evaluated
+// live by the casbin enforcer on every request, so a permission change takes
+// effect immediately regardless of this cache.
+type cachingVerifier struct {
+	inner TokenVerifier
+	ttl   time.Duration
+	now   func() time.Time // injectable clock; defaults to time.Now
+
+	mu    sync.Mutex
+	cache map[string]cacheEntry
+	group singleflight.Group
+}
+
+type cacheEntry struct {
+	subject   string
+	expiresAt time.Time
+}
+
+// newCachingVerifier wraps inner with a ttl-bounded success cache. A ttl <= 0
+// disables caching but keeps singleflight de-duplication of concurrent calls.
+func newCachingVerifier(inner TokenVerifier, ttl time.Duration) *cachingVerifier {
+	return &cachingVerifier{
+		inner: inner,
+		ttl:   ttl,
+		now:   time.Now,
+		cache: map[string]cacheEntry{},
+	}
+}
+
+// VerifyToken returns the token subject from cache when fresh, otherwise from a
+// singleflight-shared introspection of the underlying verifier.
+func (c *cachingVerifier) VerifyToken(ctx context.Context, token string) (string, error) {
+	key := tokenCacheKey(token)
+
+	if sub, ok := c.lookup(key); ok {
+		return sub, nil
+	}
+
+	// Concurrent callers with the same token share one upstream introspection.
+	sub, err, _ := c.group.Do(key, func() (any, error) {
+		// A sibling flight may have populated the cache between our outer miss
+		// and acquiring this call — re-check before hitting the network.
+		if s, ok := c.lookup(key); ok {
+			return s, nil
+		}
+		s, err := c.inner.VerifyToken(ctx, token)
+		if err != nil {
+			return "", err // not cached: fail-closed, re-verified next request
+		}
+		c.store(key, s)
+		return s, nil
+	})
+	if err != nil {
+		return "", err
+	}
+	return sub.(string), nil
+}
+
+func (c *cachingVerifier) lookup(key string) (string, bool) {
+	if c.ttl <= 0 {
+		return "", false
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	e, ok := c.cache[key]
+	if !ok {
+		return "", false
+	}
+	if !c.now().Before(e.expiresAt) {
+		delete(c.cache, key)
+		return "", false
+	}
+	return e.subject, true
+}
+
+func (c *cachingVerifier) store(key, subject string) {
+	if c.ttl <= 0 {
+		return
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	now := c.now()
+	// Opportunistic sweep on write: entries live only ttl (seconds), so dropping
+	// the expired ones here keeps the map bounded to roughly the distinct tokens
+	// seen in the last ttl window — no background janitor goroutine needed.
+	for k, e := range c.cache {
+		if !now.Before(e.expiresAt) {
+			delete(c.cache, k)
+		}
+	}
+	c.cache[key] = cacheEntry{subject: subject, expiresAt: now.Add(c.ttl)}
+}
+
+// tokenCacheKey derives a stable, non-reversible cache key so raw bearer tokens
+// are never held as map keys.
+func tokenCacheKey(token string) string {
+	sum := sha256.Sum256([]byte(token))
+	return hex.EncodeToString(sum[:])
+}

--- a/bkn-safe/server/internal/httpapi/verifier_cache_test.go
+++ b/bkn-safe/server/internal/httpapi/verifier_cache_test.go
@@ -1,0 +1,183 @@
+// Copyright openbkn.ai
+//
+// Licensed under the OpenBKN License. See LICENSE-OPENBKN.txt in the project root.
+
+package httpapi
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// countingVerifier records how many times the underlying introspection ran and
+// maps token->subject the same way the production stub does (token == subject).
+type countingVerifier struct {
+	calls atomic.Int64
+	fail  bool
+	// block, when non-nil, holds each VerifyToken call until the channel is
+	// closed — used to force concurrent calls to overlap for the singleflight
+	// test.
+	block chan struct{}
+}
+
+func (v *countingVerifier) VerifyToken(_ context.Context, token string) (string, error) {
+	v.calls.Add(1)
+	if v.block != nil {
+		<-v.block
+	}
+	if v.fail || token == "" {
+		return "", errors.New("inactive")
+	}
+	return token, nil
+}
+
+func TestCachingVerifier_HitWithinTTL(t *testing.T) {
+	inner := &countingVerifier{}
+	c := newCachingVerifier(inner, verifierCacheTTL)
+
+	for i := 0; i < 5; i++ {
+		sub, err := c.VerifyToken(context.Background(), "tok-a")
+		if err != nil || sub != "tok-a" {
+			t.Fatalf("call %d: sub=%q err=%v", i, sub, err)
+		}
+	}
+	if got := inner.calls.Load(); got != 1 {
+		t.Fatalf("want 1 upstream introspect, got %d", got)
+	}
+}
+
+func TestCachingVerifier_DistinctTokens(t *testing.T) {
+	inner := &countingVerifier{}
+	c := newCachingVerifier(inner, verifierCacheTTL)
+
+	for _, tok := range []string{"a", "b", "c", "a", "b"} {
+		if sub, err := c.VerifyToken(context.Background(), tok); err != nil || sub != tok {
+			t.Fatalf("tok %q: sub=%q err=%v", tok, sub, err)
+		}
+	}
+	// a, b, c each introspected once; the repeat a, b are cache hits.
+	if got := inner.calls.Load(); got != 3 {
+		t.Fatalf("want 3 upstream introspects, got %d", got)
+	}
+}
+
+func TestCachingVerifier_ExpiryReVerifies(t *testing.T) {
+	inner := &countingVerifier{}
+	c := newCachingVerifier(inner, 10*time.Second)
+	base := time.Unix(1_000_000, 0)
+	nowVal := base
+	c.now = func() time.Time { return nowVal }
+
+	if _, err := c.VerifyToken(context.Background(), "tok"); err != nil {
+		t.Fatal(err)
+	}
+	// Still within TTL: cache hit.
+	nowVal = base.Add(9 * time.Second)
+	if _, err := c.VerifyToken(context.Background(), "tok"); err != nil {
+		t.Fatal(err)
+	}
+	if got := inner.calls.Load(); got != 1 {
+		t.Fatalf("within TTL: want 1 introspect, got %d", got)
+	}
+	// Past TTL: re-introspect.
+	nowVal = base.Add(11 * time.Second)
+	if _, err := c.VerifyToken(context.Background(), "tok"); err != nil {
+		t.Fatal(err)
+	}
+	if got := inner.calls.Load(); got != 2 {
+		t.Fatalf("past TTL: want 2 introspects, got %d", got)
+	}
+}
+
+func TestCachingVerifier_ErrorsNotCached(t *testing.T) {
+	inner := &countingVerifier{fail: true}
+	c := newCachingVerifier(inner, verifierCacheTTL)
+
+	// Two failing calls must both hit upstream — a rejected token is never cached
+	// (fail-closed: re-verified every request).
+	for i := 0; i < 2; i++ {
+		if _, err := c.VerifyToken(context.Background(), "tok"); err == nil {
+			t.Fatalf("call %d: want error", i)
+		}
+	}
+	if got := inner.calls.Load(); got != 2 {
+		t.Fatalf("want 2 introspects (no caching of failures), got %d", got)
+	}
+
+	// Once upstream starts accepting, the success is cached as usual.
+	inner.fail = false
+	for i := 0; i < 3; i++ {
+		if _, err := c.VerifyToken(context.Background(), "tok"); err != nil {
+			t.Fatalf("recovered call %d: %v", i, err)
+		}
+	}
+	if got := inner.calls.Load(); got != 3 {
+		t.Fatalf("want 3 total introspects (2 fail + 1 cached success), got %d", got)
+	}
+}
+
+func TestCachingVerifier_SingleflightConcurrent(t *testing.T) {
+	inner := &countingVerifier{block: make(chan struct{})}
+	c := newCachingVerifier(inner, verifierCacheTTL)
+
+	const n = 20
+	var wg sync.WaitGroup
+	subs := make([]string, n)
+	errs := make([]error, n)
+	for i := 0; i < n; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			subs[i], errs[i] = c.VerifyToken(context.Background(), "same-tok")
+		}(i)
+	}
+
+	// Give the goroutines time to funnel into the in-flight introspection, then
+	// release the single blocked upstream call.
+	time.Sleep(50 * time.Millisecond)
+	close(inner.block)
+	wg.Wait()
+
+	if got := inner.calls.Load(); got != 1 {
+		t.Fatalf("singleflight: want 1 upstream introspect for %d concurrent callers, got %d", n, got)
+	}
+	for i := 0; i < n; i++ {
+		if errs[i] != nil || subs[i] != "same-tok" {
+			t.Fatalf("caller %d: sub=%q err=%v", i, subs[i], errs[i])
+		}
+	}
+}
+
+func TestCachingVerifier_TTLDisabledStillDedups(t *testing.T) {
+	inner := &countingVerifier{block: make(chan struct{})}
+	c := newCachingVerifier(inner, 0) // caching off
+
+	const n = 10
+	var wg sync.WaitGroup
+	for i := 0; i < n; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			_, _ = c.VerifyToken(context.Background(), "tok")
+		}()
+	}
+	time.Sleep(50 * time.Millisecond)
+	close(inner.block)
+	wg.Wait()
+
+	// Concurrent calls still collapse via singleflight even with caching off.
+	if got := inner.calls.Load(); got != 1 {
+		t.Fatalf("ttl=0 concurrent: want 1 introspect, got %d", got)
+	}
+	// But a later, non-overlapping call re-introspects (nothing cached).
+	if _, err := c.VerifyToken(context.Background(), "tok"); err != nil {
+		t.Fatal(err)
+	}
+	if got := inner.calls.Load(); got != 2 {
+		t.Fatalf("ttl=0 sequential: want 2 introspects, got %d", got)
+	}
+}


### PR DESCRIPTION
## 问题

`GET /api/safe/v1/me/permissions` 在资源规模大时逐个「实例 × 操作」铺开,响应约 **806KB / 数秒**。前端登录并行拉 `/me` 与 `/me/permissions`,两处叠加放大登录体感:一是**包大**,二是**慢**——两个端点各自经 token 门禁,每请求都向 hydra introspect 一次,登录并行拉即两发 introspect、无任何复用。本 PR 一并处理这两点。

## 改动(仅 bkn-safe)

### 1. 响应折叠瘦身(治「大」)

- **默认返回「有效授权」折叠**(`authz.EffectivePermissions`):
  - 持真实资源通配 `*`/`*` 的账号 → 单行 `{type:"*",id:"*",ops:["*"]}`;按类型查时投影为 `{type,id:"*",ops:["*"]}`。**gate 在真实通配授权而非 `is_admin`** —— 只持 `safe_admin:console:manage` 的 admin 子角色不会被误报为全资源可做一切。
  - 其余账号 → 每类型一条类型级行;实例行仅在其操作**超出类型级**时保留,且只带增量。被类型级覆盖的实例行整条丢弃。
- **scope 过滤**:`?resource_type=<T>` 与 `&resource_id=<id1,id2,...>`;`resource_id` 需配 `resource_type`,否则 400。
- 删除换掉后成为死代码的旧 `AccessorPermissions`。

响应结构与 `is_admin` 语义不变;**无 DB 迁移**。

### 2. token introspect 缓存(治「慢」)

`/me`、`/me/permissions`(以及 admin 面)均 token 门禁,每请求都向 hydra introspect;前端登录并行拉前两者即两发 introspect、零复用。将 `TokenVerifier` 包一层缓存装饰器(`cachingVerifier`):

- **singleflight 去重并发**:并发的同一 token 请求合并为**一发**上游 introspect,其余等结果——这才真正把登录那对并行调用压成 1 次(纯 TTL 缓存救不了首发并发,两个都 miss)。
- **短 TTL 成功缓存(10s)**:窗口内重复调用(刷页 / 切菜单)直接命中,不打 hydra。key = `sha256(token)`,不裸存 bearer;写时机会性扫过期,无常驻 goroutine。
- **fail-closed 不变**:只缓存成功且 active 的结果,出错 / inactive 一律不缓存,下一请求重验;吊销后最多 TTL(10s)内仍判有效(revocation 滞后,与 token 过期滞后同级,可接受)。
- **只缓存身份,不缓存权限**:casbin 仍每请求实时判权,权限 / 角色变更即时生效。

hydra 侧 token 寿命(默认 access_token 1h)未改。

## 前端契约(需同批上线)

实例行只带「超出类型级的增量」。判权须 union 类型级 `id:"*"` 行与实例行:`op ∈ typeWide(T) ∪ instance(T,id)`。introspect 缓存对前端透明,端点 / 响应结构均不变。

## 验证

- **折叠瘦身**:单测 6 例(通配 / admin-console 非通配 / 覆盖丢弃 / 增量保留 / 纯实例 / scope),独立审查越权 / 漏权 / scope / 边界 / nil-map 均无问题。实机实测(VM arm64 + 测试服 14.103.77.23 amd64):admin `/me/permissions` 从约 806KB 降到 **87 字节**;scope 投影、400 校验均正确。
- **introspect 缓存**:单测 6 例 `-race`(TTL 命中 / 异 token / 过期重验 / 错误不缓存 / **20 并发 singleflight = 1 发** / TTL=0 仍去重)全绿。
- authz + httpapi 全包回归绿,gofmt + vet 干净。

## 关联

- 设计文档:bkn-docs `docs/foundry/bkn-safe/design/issue-353-me-permissions-授权折叠瘦身.md`
- **#353**:本 PR 已一并处理延迟(introspect 缓存),但**先不自动关闭**——待测试服 14.103.77.23 实测登录延迟改善后再转 validating / 收口。
- 建议挂 #328 授权面加固 Epic 止血批次。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
