### PR TITLE
feat(bkn-agent): add phase one trace context baseline

### DIFF
--- a/docs/api/bkn-agent.yaml
+++ b/docs/api/bkn-agent.yaml
@@ -945,6 +945,9 @@ components:
         solution:
           type: string
           title: Solution
+        trace_id:
+          type: string
+          title: Trace Id
         link:
           type: string
           title: Link
@@ -955,6 +958,7 @@ components:
       - description
       - detail
       - solution
+      - trace_id
       title: ErrorEnvelope
       description: 平台统一错误封套（所有非 2xx 响应）。
     ExportPackage:

--- a/infra/bkn-agent/TRACE.md
+++ b/infra/bkn-agent/TRACE.md
@@ -1,0 +1,111 @@
+# bkn-agent Trace Contract
+
+> 状态：阶段一模块接入合同
+> 适用版本：`bkn.trace.schema.version=1.0.0`  
+> 依据：`bkn-docs/docs/foundry/bkn-trace/design/阶段一：OpenBKN 可观测记录规范与 Trace Context 基线.md`
+
+## Module
+
+- module name: `bkn-agent`
+- owner: OpenBKN Foundry
+- service identity: platform internal agent runtime
+- runtime: FastAPI / LangChain / LangGraph
+- contract version: `1.0.0`
+
+## Entry Operations
+
+| operation | trigger | required context | emitted spans | emitted events |
+| --- | --- | --- | --- | --- |
+| `bkn-agent.health` | `GET /api/v1/health` | optional upstream `traceparent` / `bkn-request-id` | FastAPI server span | none |
+| `bkn-agent.agent.*` | agent CRUD routes | account identity, request context | FastAPI server span | none in phase one |
+| `bkn-agent.chat` | `POST /api/bkn-agent/v1/chat` | account identity, agent id, optional thread id | FastAPI server span, `agent.chat` business span, LangChain spans when OTel enabled | SSE meta/token/tool/error/done stream events; BKN Trace event envelope is phase-two work |
+| `bkn-agent.task` | `POST /api/bkn-agent/v1/run` / `POST /invoke/{agent_id}` | account identity, agent id, task context | FastAPI server span, `agent.task` business span, LangChain spans when OTel enabled | task status is persisted in DB; BKN Trace event envelope is phase-two work |
+
+## Inbound Context
+
+- accepted headers: `traceparent`, `bkn-request-id`, legacy `x-request-id`, `x-account-id`, `x-account-type`
+- `traceparent` parsing: W3C version `00`; all-zero trace id or span id is rejected
+- external trace handling: valid upstream `traceparent` is treated as `bkn.trace.entry_boundary=external`
+- invalid context handling: invalid `traceparent` is discarded and a new internal trace id is generated
+- request id generation: use inbound `bkn-request-id` or legacy `x-request-id` when valid; otherwise generate `req_<uuid>`
+- response headers: always return `x-trace-id`, `bkn-request-id`, `x-request-id`, `traceparent`
+
+## Outbound Calls
+
+| target | protocol | propagated fields | baggage policy | timeout | retry |
+| --- | --- | --- | --- | --- | --- |
+| toolbox / MCP tools | HTTP / MCP adapter | phase-one propagation pending in toolbox client | baggage not propagated | existing tool timeout policy | existing retry policy |
+| model provider | OpenAI-compatible HTTP through LangChain | OTel instrumentation when enabled | baggage not propagated | model/provider config | provider policy |
+| checkpoint store | MySQL | request context not propagated | baggage not propagated | DB config | DB driver policy |
+
+## Logs
+
+| log type | level | required fields | indexed fields | sensitive fields | fixture |
+| --- | --- | --- | --- | --- | --- |
+| request context | implicit via response headers and span attributes | `trace_id`, `bkn.request.id`, `bkn.module.name` | module, operation, status | no prompt/SQL/token | `app/test/test_smoke.py` |
+| error | error / HTTP error response | `trace_id`, error envelope fields | error code | no raw secret | `app/test/test_smoke.py` |
+| OTel setup | info/warning | service name, endpoint summary | module | no token | covered by import path |
+
+## Spans
+
+| span name | kind | required attributes | parent/link rule | error mapping |
+| --- | --- | --- | --- | --- |
+| FastAPI server span | server | `bkn.request.id`, `trace_id`, route, status when OTel enabled | follows OTel FastAPI instrumentation | HTTP status |
+| `agent.chat` | internal | `bkn.agent.id`, `bkn.thread.id`, `bkn.prompt.source`, `bkn.prompt.version`, `bkn.request.id` | child of request span when active | stream error event in phase one |
+| `agent.task` | internal | `bkn.agent.id`, `task.depth`, `bkn.prompt.source`, `bkn.prompt.version`, `bkn.request.id` | child of request span when active | exception maps to task failure |
+
+## Events
+
+| event type | producer | payload summary | partial reason | retention class |
+| --- | --- | --- | --- | --- |
+| SSE `meta/token/tool_call/structured/done/error` | chat stream | user-visible stream protocol | not BKN Trace event envelope yet | transient stream |
+| `task.status.changed` | pending phase-two emitter | task old/new status and failure summary | emitter not implemented in phase one code | business event |
+| `tool.called` / `tool.failed` | pending toolbox propagation | tool id/name and hash-only args/result | toolbox client propagation pending | business event |
+
+## Business Refs
+
+| ref type | field | resolver | version field | visibility rule |
+| --- | --- | --- | --- | --- |
+| agent | `bkn.agent.id` | agent DAO | agent update time | account-scoped APIs |
+| thread | `bkn.thread.id` | thread DAO/checkpointer | thread update time | owner scoped |
+| task | `bkn.task.id` | task DAO | task update time | owner scoped |
+| prompt | `bkn.prompt.version` | prompt DAO | prompt version | account override rules |
+
+## Sensitive Data Rules
+
+- never log: authorization, cookie, access token, full prompt, full model output, full tool args/result
+- hash only: future prompt/tool/model payload evidence
+- controlled reference: future evidence snapshot refs
+- redact: HTTP error responses use short error summaries
+- `data.classification`: not emitted by bkn-agent phase-one code yet
+
+## Sampling
+
+- default: OTel sampler/provider default
+- forced sampling: not implemented in bkn-agent phase-one code
+- not sampled behavior: response headers and error trace id still returned
+- dropped counters: pending BKN Trace governance metrics
+
+## Retention And Alerts
+
+- log retention class: runtime log retention by deployment
+- event retention class: not emitted yet
+- audit retention class: HTTP auth failures return trace id; audit event emission pending
+- health metrics: pending BKN Trace governance metrics
+- alert thresholds: pending platform-level alerting
+
+## Fixtures
+
+| fixture | path | purpose | expected result |
+| --- | --- | --- | --- |
+| positive | `fixtures/bkn-trace/positive.json` + `app/test/test_smoke.py::test_health` | generated request id / trace headers | pass |
+| propagation | `fixtures/bkn-trace/propagation.json` + `app/test/test_smoke.py::test_trace_context_propagates_request_id_and_traceparent` | inbound `traceparent` and `bkn-request-id` propagation | pass |
+| negative | `fixtures/bkn-trace/negative_invalid_traceparent.json` + `app/test/test_smoke.py::test_invalid_traceparent_is_not_reused` | invalid all-zero traceparent rejected | fail for contract fixture; pass for pytest rejection behavior |
+| sampling | `fixtures/bkn-trace/sampling.json` + `app/test/test_smoke.py::test_auth_fail_closed_without_identity` | forced retained error / error body trace id equals `x-trace-id` | pass |
+
+## Known Gaps
+
+- toolbox/MCP outbound propagation is not fully implemented yet.
+- structured BKN Trace event envelope emission is not implemented yet.
+- forced sampling and dropped counters are not implemented yet.
+- full event emitter fixtures are contract-level until the phase-two BKN Trace event envelope exists.

--- a/infra/bkn-agent/app/core/graph.py
+++ b/infra/bkn-agent/app/core/graph.py
@@ -88,6 +88,7 @@ async def stream_chat(
         "prompt.source": prompt_source,
         "prompt.version": prompt_version,
     }
+    span_attrs.update(observability.context_attributes())
 
     async def _events() -> AsyncIterator[str]:
         try:

--- a/infra/bkn-agent/app/main.py
+++ b/infra/bkn-agent/app/main.py
@@ -9,6 +9,7 @@ from starlette.exceptions import HTTPException as StarletteHTTPException
 
 from app.bootstrap import toolbox_sync
 from app.models import ErrorEnvelope
+from app import observability
 from app.observability import setup_otel
 from app.routers import agents, chat, impex, prompts, tasks, threads
 
@@ -54,6 +55,25 @@ app.include_router(threads.router, prefix=API_PREFIX, tags=["BknAgent"], respons
 app.include_router(impex.router, prefix=API_PREFIX, tags=["BknAgent"], responses=_ERRORS)
 
 
+@app.middleware("http")
+async def bkn_trace_context_middleware(request: Request, call_next):
+    ctx = observability.build_context(request.headers)
+    request.state.bkn_trace_context = ctx
+    token = observability.set_context(ctx)
+    try:
+        response = await call_next(request)
+    finally:
+        observability.reset_context(token)
+    for key, value in {
+        observability.TRACE_ID_HEADER: ctx.trace_id,
+        observability.REQUEST_ID_HEADER: ctx.request_id,
+        observability.LEGACY_REQUEST_ID_HEADER: ctx.request_id,
+        "traceparent": ctx.traceparent,
+    }.items():
+        response.headers[key] = value
+    return response
+
+
 @app.get("/api/v1/health")
 async def health():
     return {"status": "ok"}
@@ -72,7 +92,9 @@ async def validation_handler(request: Request, exc: RequestValidationError):
             "detail": detail,
             "solution": "请检查请求体格式。",
             "link": "",
+            "trace_id": observability.current_trace_id(),
         },
+        headers=observability.response_headers(),
     )
 
 
@@ -84,7 +106,7 @@ async def http_exception_handler(request: Request, exc: StarletteHTTPException):
     （如 404/405 路由默认串）补齐成封套。"""
     detail = exc.detail
     if isinstance(detail, dict) and "code" in detail:
-        content = detail
+        content = observability.enrich_error(detail)
     else:
         content = {
             "code": f"BknAgent.Http.{exc.status_code}",
@@ -92,8 +114,11 @@ async def http_exception_handler(request: Request, exc: StarletteHTTPException):
             "detail": str(detail) if detail else "",
             "solution": "",
             "link": "",
+            "trace_id": observability.current_trace_id(),
         }
-    return JSONResponse(status_code=exc.status_code, content=content, headers=getattr(exc, "headers", None))
+    headers = dict(getattr(exc, "headers", None) or {})
+    headers.update(observability.response_headers())
+    return JSONResponse(status_code=exc.status_code, content=content, headers=headers)
 
 
 @app.exception_handler(Exception)
@@ -113,5 +138,7 @@ async def unhandled_handler(request: Request, exc: Exception):
             "detail": f"{type(exc).__name__}: {exc}",
             "solution": "查看 bkn-agent 日志与 trace_id 定位；下游不可用时稍后重试。",
             "link": "",
+            "trace_id": observability.current_trace_id(),
         },
+        headers=observability.response_headers(),
     )

--- a/infra/bkn-agent/app/main.py
+++ b/infra/bkn-agent/app/main.py
@@ -130,6 +130,7 @@ async def unhandled_handler(request: Request, exc: Exception):
     契约里「4XX/5XX 一律 ErrorEnvelope」的约定，SDK 侧解析直接崩。
     """
     logger.exception("[BknAgent] unhandled error on %s %s", request.method, request.url.path)
+    ctx = observability.context_from_request(request)
     return JSONResponse(
         status_code=500,
         content={
@@ -138,7 +139,7 @@ async def unhandled_handler(request: Request, exc: Exception):
             "detail": f"{type(exc).__name__}: {exc}",
             "solution": "查看 bkn-agent 日志与 trace_id 定位；下游不可用时稍后重试。",
             "link": "",
-            "trace_id": observability.current_trace_id(),
+            "trace_id": observability.current_trace_id(ctx),
         },
-        headers=observability.response_headers(),
+        headers=observability.response_headers(ctx),
     )

--- a/infra/bkn-agent/app/models.py
+++ b/infra/bkn-agent/app/models.py
@@ -327,6 +327,7 @@ class ErrorEnvelope(BaseModel):
     description: str
     detail: str
     solution: str
+    trace_id: str
     link: str = ""
 
 

--- a/infra/bkn-agent/app/observability.py
+++ b/infra/bkn-agent/app/observability.py
@@ -87,6 +87,10 @@ def parse_traceparent(value: str | None) -> tuple[Optional[str], Optional[str]]:
     return trace_id, span_id
 
 
+def format_traceparent(trace_id: str, span_id: str, flags: str = "01") -> str:
+    return f"00-{trace_id}-{span_id}-{flags}"
+
+
 def build_context(headers) -> TraceContext:
     """Build BKN Trace phase-one context from inbound request headers.
 
@@ -100,7 +104,7 @@ def build_context(headers) -> TraceContext:
     request_id = headers.get(REQUEST_ID_HEADER) or headers.get(LEGACY_REQUEST_ID_HEADER)
     if not _valid_request_id(request_id):
         request_id = _new_request_id()
-    traceparent = incoming_traceparent if span_id else f"00-{trace_id}-{_new_span_id()}-01"
+    traceparent = format_traceparent(trace_id, span_id) if span_id else format_traceparent(trace_id, _new_span_id())
     return TraceContext(
         trace_id=trace_id,
         request_id=request_id,
@@ -122,13 +126,17 @@ def current_context() -> Optional[TraceContext]:
     return _current_context.get()
 
 
-def current_trace_id() -> str:
-    ctx = current_context()
+def context_from_request(request) -> Optional[TraceContext]:
+    return getattr(getattr(request, "state", None), "bkn_trace_context", None)
+
+
+def current_trace_id(ctx: Optional[TraceContext] = None) -> str:
+    ctx = ctx or current_context()
     return ctx.trace_id if ctx else _new_trace_id()
 
 
-def response_headers() -> dict[str, str]:
-    ctx = current_context()
+def response_headers(ctx: Optional[TraceContext] = None) -> dict[str, str]:
+    ctx = ctx or current_context()
     if not ctx:
         return {}
     return {

--- a/infra/bkn-agent/app/observability.py
+++ b/infra/bkn-agent/app/observability.py
@@ -1,9 +1,33 @@
 import logging
 import os
+import re
+import uuid
+from contextvars import ContextVar
+from dataclasses import dataclass
+from typing import Optional
 
 logger = logging.getLogger("bkn-agent.otel")
 
 _tracer = None
+TRACE_SCHEMA_VERSION = "1.0.0"
+MODULE_NAME = "bkn-agent"
+REQUEST_ID_HEADER = "bkn-request-id"
+LEGACY_REQUEST_ID_HEADER = "x-request-id"
+TRACE_ID_HEADER = "x-trace-id"
+_TRACEPARENT_RE = re.compile(r"^00-([0-9a-f]{32})-([0-9a-f]{16})-[0-9a-f]{2}$")
+_REQUEST_ID_RE = re.compile(r"^(req_[0-9A-Za-z_.-]+|[0-9A-Za-z_.-]{8,128})$")
+
+
+@dataclass(frozen=True)
+class TraceContext:
+    trace_id: str
+    request_id: str
+    traceparent: str
+    entry_boundary: str
+    upstream_span_id: Optional[str] = None
+
+
+_current_context: ContextVar[Optional[TraceContext]] = ContextVar("bkn_trace_context", default=None)
 
 
 def setup_otel(app) -> None:
@@ -35,6 +59,127 @@ def setup_otel(app) -> None:
         logger.warning("OTel setup failed, tracing disabled: %s", e)
 
 
+def _new_trace_id() -> str:
+    return uuid.uuid4().hex
+
+
+def _new_span_id() -> str:
+    return uuid.uuid4().hex[:16]
+
+
+def _new_request_id() -> str:
+    return f"req_{uuid.uuid4().hex}"
+
+
+def _valid_request_id(value: str | None) -> bool:
+    return bool(value and _REQUEST_ID_RE.match(value))
+
+
+def parse_traceparent(value: str | None) -> tuple[Optional[str], Optional[str]]:
+    if not value:
+        return None, None
+    match = _TRACEPARENT_RE.match(value.strip().lower())
+    if not match:
+        return None, None
+    trace_id, span_id = match.groups()
+    if trace_id == "0" * 32 or span_id == "0" * 16:
+        return None, None
+    return trace_id, span_id
+
+
+def build_context(headers) -> TraceContext:
+    """Build BKN Trace phase-one context from inbound request headers.
+
+    `traceparent` carries W3C trace identity. `bkn-request-id` is the OpenBKN
+    business correlation key and is intentionally separate from baggage.
+    """
+    incoming_traceparent = headers.get("traceparent")
+    trace_id, span_id = parse_traceparent(incoming_traceparent)
+    entry_boundary = "external" if trace_id else "internal"
+    trace_id = trace_id or _new_trace_id()
+    request_id = headers.get(REQUEST_ID_HEADER) or headers.get(LEGACY_REQUEST_ID_HEADER)
+    if not _valid_request_id(request_id):
+        request_id = _new_request_id()
+    traceparent = incoming_traceparent if span_id else f"00-{trace_id}-{_new_span_id()}-01"
+    return TraceContext(
+        trace_id=trace_id,
+        request_id=request_id,
+        traceparent=traceparent,
+        entry_boundary=entry_boundary,
+        upstream_span_id=span_id,
+    )
+
+
+def set_context(ctx: TraceContext):
+    return _current_context.set(ctx)
+
+
+def reset_context(token) -> None:
+    _current_context.reset(token)
+
+
+def current_context() -> Optional[TraceContext]:
+    return _current_context.get()
+
+
+def current_trace_id() -> str:
+    ctx = current_context()
+    return ctx.trace_id if ctx else _new_trace_id()
+
+
+def response_headers() -> dict[str, str]:
+    ctx = current_context()
+    if not ctx:
+        return {}
+    return {
+        TRACE_ID_HEADER: ctx.trace_id,
+        REQUEST_ID_HEADER: ctx.request_id,
+        LEGACY_REQUEST_ID_HEADER: ctx.request_id,
+        "traceparent": ctx.traceparent,
+    }
+
+
+def enrich_error(content: dict) -> dict:
+    enriched = dict(content)
+    enriched.setdefault("trace_id", current_trace_id())
+    return enriched
+
+
+def context_attributes() -> dict:
+    ctx = current_context()
+    attrs = {
+        "bkn.module.name": MODULE_NAME,
+        "bkn.trace.schema.version": TRACE_SCHEMA_VERSION,
+    }
+    if ctx:
+        attrs.update(
+            {
+                "bkn.request.id": ctx.request_id,
+                "bkn.trace.entry_boundary": ctx.entry_boundary,
+                "trace_id": ctx.trace_id,
+                "traceparent": ctx.traceparent,
+            }
+        )
+    return attrs
+
+
+def _normalized_attributes(attributes: dict) -> dict:
+    normalized = dict(attributes)
+    aliases = {
+        "agent.id": "bkn.agent.id",
+        "thread.id": "bkn.thread.id",
+        "task.id": "bkn.task.id",
+        "prompt.source": "bkn.prompt.source",
+        "prompt.version": "bkn.prompt.version",
+    }
+    for old, new in aliases.items():
+        if old in normalized and new not in normalized:
+            normalized[new] = normalized[old]
+    for key, value in context_attributes().items():
+        normalized.setdefault(key, value)
+    return {k: v for k, v in normalized.items() if v is not None}
+
+
 def span(name: str, attributes: dict):
     """业务外层 span（agent.chat / agent.task），挂 agent_id/thread_id/task_id 等属性。"""
     if _tracer is None:
@@ -42,5 +187,5 @@ def span(name: str, attributes: dict):
 
         return nullcontext()
     return _tracer.start_as_current_span(
-        name, attributes={k: v for k, v in attributes.items() if v is not None}
+        name, attributes=_normalized_attributes(attributes)
     )

--- a/infra/bkn-agent/app/test/test_smoke.py
+++ b/infra/bkn-agent/app/test/test_smoke.py
@@ -10,6 +10,40 @@ def test_health():
     r = client.get("/api/v1/health")
     assert r.status_code == 200
     assert r.json()["status"] == "ok"
+    assert r.headers["x-trace-id"]
+    assert r.headers["bkn-request-id"].startswith("req_")
+    assert r.headers["x-request-id"] == r.headers["bkn-request-id"]
+    assert r.headers["traceparent"].startswith(f"00-{r.headers['x-trace-id']}-")
+
+
+def test_trace_context_propagates_request_id_and_traceparent():
+    trace_id = "1234567890abcdef1234567890abcdef"
+    span_id = "1234567890abcdef"
+    r = client.get(
+        "/api/v1/health",
+        headers={
+            "traceparent": f"00-{trace_id}-{span_id}-01",
+            "bkn-request-id": "req_external_123",
+        },
+    )
+    assert r.status_code == 200
+    assert r.headers["x-trace-id"] == trace_id
+    assert r.headers["bkn-request-id"] == "req_external_123"
+    assert r.headers["x-request-id"] == "req_external_123"
+    assert r.headers["traceparent"] == f"00-{trace_id}-{span_id}-01"
+
+
+def test_invalid_traceparent_is_not_reused():
+    r = client.get(
+        "/api/v1/health",
+        headers={
+            "traceparent": "00-00000000000000000000000000000000-0000000000000000-01",
+            "bkn-request-id": "req_external_456",
+        },
+    )
+    assert r.status_code == 200
+    assert r.headers["x-trace-id"] != "00000000000000000000000000000000"
+    assert r.headers["bkn-request-id"] == "req_external_456"
 
 
 def test_auth_fail_closed_without_identity():
@@ -18,6 +52,7 @@ def test_auth_fail_closed_without_identity():
     # 顶层扁平 ErrorEnvelope（非 {"detail": {...}} 嵌套）
     assert r.json()["code"] == "BknAgent.Auth.AccountRequired"
     assert "detail" in r.json() and isinstance(r.json()["detail"], str)
+    assert r.json()["trace_id"] == r.headers["x-trace-id"]
 
 
 def test_auth_rejects_anonymous():
@@ -34,6 +69,7 @@ def test_validation_error_uses_platform_error_shape():
     body = r.json()
     assert body["code"] == "BknAgent.ParamError.FormatError"
     assert body["solution"]
+    assert body["trace_id"] == r.headers["x-trace-id"]
 
 
 def test_thread_requires_identity():
@@ -79,7 +115,11 @@ def test_thread_missing_and_foreign_owner_indistinguishable(monkeypatch):
         app.dependency_overrides.pop(key, None)
 
     assert r_missing.status_code == r_foreign.status_code == 404
-    assert r_missing.json() == r_foreign.json()
+    missing_body = r_missing.json()
+    foreign_body = r_foreign.json()
+    assert missing_body.pop("trace_id") == r_missing.headers["x-trace-id"]
+    assert foreign_body.pop("trace_id") == r_foreign.headers["x-trace-id"]
+    assert missing_body == foreign_body
 
 
 def test_thread_owner_reads_history(monkeypatch):

--- a/infra/bkn-agent/app/test/test_smoke.py
+++ b/infra/bkn-agent/app/test/test_smoke.py
@@ -33,6 +33,21 @@ def test_trace_context_propagates_request_id_and_traceparent():
     assert r.headers["traceparent"] == f"00-{trace_id}-{span_id}-01"
 
 
+def test_traceparent_is_normalized_before_response():
+    trace_id = "ABCDEFABCDEFABCDEFABCDEFABCDEFAB"
+    span_id = "ABCDEFABCDEFABCD"
+    r = client.get(
+        "/api/v1/health",
+        headers={
+            "traceparent": f" 00-{trace_id}-{span_id}-01 ",
+            "bkn-request-id": "req_external_124",
+        },
+    )
+    assert r.status_code == 200
+    assert r.headers["x-trace-id"] == trace_id.lower()
+    assert r.headers["traceparent"] == f"00-{trace_id.lower()}-{span_id.lower()}-01"
+
+
 def test_invalid_traceparent_is_not_reused():
     r = client.get(
         "/api/v1/health",
@@ -70,6 +85,41 @@ def test_validation_error_uses_platform_error_shape():
     assert body["code"] == "BknAgent.ParamError.FormatError"
     assert body["solution"]
     assert body["trace_id"] == r.headers["x-trace-id"]
+
+
+def test_unhandled_exception_preserves_trace_context(monkeypatch):
+    from app import dao
+    from app.db import get_session
+
+    async def fake_session():
+        yield None
+
+    async def fail_list_agents(session, page, size):
+        raise RuntimeError("db down")
+
+    app.dependency_overrides[get_session] = fake_session
+    monkeypatch.setattr(dao, "list_agents", fail_list_agents)
+    try:
+        trace_id = "1234567890abcdef1234567890abcdef"
+        span_id = "1234567890abcdef"
+        error_client = TestClient(app, raise_server_exceptions=False)
+        r = error_client.get(
+            "/api/bkn-agent/v1/agents",
+            headers={
+                **SVC,
+                "traceparent": f"00-{trace_id}-{span_id}-01",
+                "bkn-request-id": "req_external_500",
+            },
+        )
+    finally:
+        app.dependency_overrides.pop(get_session, None)
+
+    assert r.status_code == 500
+    assert r.headers["x-trace-id"] == trace_id
+    assert r.headers["bkn-request-id"] == "req_external_500"
+    assert r.headers["x-request-id"] == "req_external_500"
+    assert r.headers["traceparent"] == f"00-{trace_id}-{span_id}-01"
+    assert r.json()["trace_id"] == trace_id
 
 
 def test_thread_requires_identity():

--- a/infra/bkn-agent/fixtures/bkn-trace/negative_invalid_traceparent.json
+++ b/infra/bkn-agent/fixtures/bkn-trace/negative_invalid_traceparent.json
@@ -1,0 +1,45 @@
+{
+  "bkn.trace.schema.version": "1.0.0",
+  "fixture_id": "bkn_agent_negative_invalid_traceparent",
+  "fixture_type": "negative",
+  "scenario": "bkn_agent_rejects_all_zero_traceparent",
+  "expected_result": "fail",
+  "trace": {
+    "trace_id": "7a040000000000000000000000000004",
+    "bkn.request.id": "req_bkn_agent_invalid_0004",
+    "traceparent": "00-00000000000000000000000000000000-0000000000000000-01",
+    "sampling.decision": "sampled"
+  },
+  "spans": [
+    {
+      "span_id": "7a04000000000001",
+      "parent_span_id": null,
+      "name": "bkn-agent.request",
+      "kind": "server",
+      "bkn.module.name": "bkn-agent",
+      "bkn.operation.name": "bkn-agent.health",
+      "bkn.status": "ok",
+      "bkn.timestamp": "2026-07-21T05:03:00.000000000Z",
+      "duration_ms": 5
+    }
+  ],
+  "logs": [
+    {
+      "level": "info",
+      "message": "request completed after rejecting invalid trace context",
+      "trace_id": "7a040000000000000000000000000004",
+      "span_id": "7a04000000000001",
+      "bkn.request.id": "req_bkn_agent_invalid_0004",
+      "bkn.module.name": "bkn-agent",
+      "bkn.operation.name": "bkn-agent.health",
+      "bkn.status": "ok",
+      "bkn.timestamp": "2026-07-21T05:03:00.005000000Z",
+      "bkn.trace.schema.version": "1.0.0"
+    }
+  ],
+  "events": [],
+  "baggage": {
+    "bkn.account.type": "service",
+    "bkn.runtime.env": "test"
+  }
+}

--- a/infra/bkn-agent/fixtures/bkn-trace/positive.json
+++ b/infra/bkn-agent/fixtures/bkn-trace/positive.json
@@ -1,0 +1,47 @@
+{
+  "bkn.trace.schema.version": "1.0.0",
+  "fixture_id": "bkn_agent_positive_health",
+  "fixture_type": "positive",
+  "scenario": "bkn_agent_generates_trace_context_without_upstream",
+  "expected_result": "pass",
+  "trace": {
+    "trace_id": "7a010000000000000000000000000001",
+    "bkn.request.id": "req_bkn_agent_health_0001",
+    "traceparent": "00-7a010000000000000000000000000001-7a01000000000001-01",
+    "sampling.decision": "sampled"
+  },
+  "spans": [
+    {
+      "span_id": "7a01000000000001",
+      "parent_span_id": null,
+      "name": "bkn-agent.request",
+      "kind": "server",
+      "bkn.module.name": "bkn-agent",
+      "bkn.operation.name": "bkn-agent.health",
+      "bkn.status": "ok",
+      "bkn.timestamp": "2026-07-21T05:00:00.000000000Z",
+      "duration_ms": 8
+    }
+  ],
+  "logs": [
+    {
+      "level": "info",
+      "message": "health request completed",
+      "trace_id": "7a010000000000000000000000000001",
+      "span_id": "7a01000000000001",
+      "bkn.request.id": "req_bkn_agent_health_0001",
+      "bkn.module.name": "bkn-agent",
+      "bkn.operation.name": "bkn-agent.health",
+      "bkn.status": "ok",
+      "bkn.timestamp": "2026-07-21T05:00:00.008000000Z",
+      "bkn.trace.schema.version": "1.0.0",
+      "bkn.account.type": "service",
+      "duration_ms": 8
+    }
+  ],
+  "events": [],
+  "baggage": {
+    "bkn.account.type": "service",
+    "bkn.runtime.env": "test"
+  }
+}

--- a/infra/bkn-agent/fixtures/bkn-trace/propagation.json
+++ b/infra/bkn-agent/fixtures/bkn-trace/propagation.json
@@ -1,0 +1,60 @@
+{
+  "bkn.trace.schema.version": "1.0.0",
+  "fixture_id": "bkn_agent_propagation_external_context",
+  "fixture_type": "propagation",
+  "scenario": "bkn_agent_preserves_valid_traceparent_and_request_id",
+  "expected_result": "pass",
+  "trace": {
+    "trace_id": "7a020000000000000000000000000002",
+    "bkn.request.id": "req_bkn_agent_external_0002",
+    "traceparent": "00-7a020000000000000000000000000002-7a02000000000001-01",
+    "sampling.decision": "sampled"
+  },
+  "spans": [
+    {
+      "span_id": "7a02000000000001",
+      "parent_span_id": null,
+      "name": "bkn-agent.request",
+      "kind": "server",
+      "bkn.module.name": "bkn-agent",
+      "bkn.operation.name": "bkn-agent.chat",
+      "bkn.status": "ok",
+      "bkn.timestamp": "2026-07-21T05:01:00.000000000Z",
+      "duration_ms": 90
+    },
+    {
+      "span_id": "7a02000000000002",
+      "parent_span_id": "7a02000000000001",
+      "name": "agent.chat",
+      "kind": "internal",
+      "bkn.module.name": "bkn-agent",
+      "bkn.operation.name": "bkn-agent.chat",
+      "bkn.status": "ok",
+      "bkn.timestamp": "2026-07-21T05:01:00.010000000Z",
+      "bkn.agent.id": "agent_profile_demo",
+      "bkn.thread.id": "thread_profile_demo",
+      "duration_ms": 80
+    }
+  ],
+  "logs": [
+    {
+      "level": "info",
+      "message": "chat request completed",
+      "trace_id": "7a020000000000000000000000000002",
+      "span_id": "7a02000000000002",
+      "bkn.request.id": "req_bkn_agent_external_0002",
+      "bkn.module.name": "bkn-agent",
+      "bkn.operation.name": "bkn-agent.chat",
+      "bkn.status": "ok",
+      "bkn.timestamp": "2026-07-21T05:01:00.090000000Z",
+      "bkn.trace.schema.version": "1.0.0",
+      "bkn.agent.id": "agent_profile_demo",
+      "bkn.thread.id": "thread_profile_demo"
+    }
+  ],
+  "events": [],
+  "baggage": {
+    "bkn.account.type": "user",
+    "bkn.runtime.env": "test"
+  }
+}

--- a/infra/bkn-agent/fixtures/bkn-trace/sampling.json
+++ b/infra/bkn-agent/fixtures/bkn-trace/sampling.json
@@ -1,0 +1,72 @@
+{
+  "bkn.trace.schema.version": "1.0.0",
+  "fixture_id": "bkn_agent_sampling_forced_error",
+  "fixture_type": "sampling",
+  "scenario": "bkn_agent_error_path_is_forced_sampled",
+  "expected_result": "pass",
+  "trace": {
+    "trace_id": "7a030000000000000000000000000003",
+    "bkn.request.id": "req_bkn_agent_error_0003",
+    "traceparent": "00-7a030000000000000000000000000003-7a03000000000001-01",
+    "sampling.decision": "forced_sampled"
+  },
+  "spans": [
+    {
+      "span_id": "7a03000000000001",
+      "parent_span_id": null,
+      "name": "bkn-agent.request",
+      "kind": "server",
+      "bkn.module.name": "bkn-agent",
+      "bkn.operation.name": "bkn-agent.task",
+      "bkn.status": "error",
+      "bkn.timestamp": "2026-07-21T05:02:00.000000000Z",
+      "duration_ms": 33,
+      "error.category": "model",
+      "error.code": "BKN_AGENT_MODEL_UNAVAILABLE",
+      "error.retryable": true
+    }
+  ],
+  "logs": [
+    {
+      "level": "error",
+      "message": "task failed with retryable model error",
+      "trace_id": "7a030000000000000000000000000003",
+      "span_id": "7a03000000000001",
+      "bkn.request.id": "req_bkn_agent_error_0003",
+      "bkn.module.name": "bkn-agent",
+      "bkn.operation.name": "bkn-agent.task",
+      "bkn.status": "error",
+      "bkn.timestamp": "2026-07-21T05:02:00.033000000Z",
+      "bkn.trace.schema.version": "1.0.0",
+      "error.category": "model",
+      "error.code": "BKN_AGENT_MODEL_UNAVAILABLE",
+      "error.retryable": true
+    }
+  ],
+  "events": [
+    {
+      "event_id": "evt_bkn_agent_error_0003",
+      "event_type": "agent.task.failed",
+      "bkn.trace.schema.version": "1.0.0",
+      "observed_at": "2026-07-21T05:02:00.033000000Z",
+      "emitted_at": "2026-07-21T05:02:00.034000000Z",
+      "sequence_no": 1,
+      "attempt_no": 1,
+      "producer_module": "bkn-agent",
+      "trace_id": "7a030000000000000000000000000003",
+      "span_id": "7a03000000000001",
+      "bkn.request.id": "req_bkn_agent_error_0003",
+      "bkn.operation.name": "bkn-agent.task",
+      "payload": {
+        "error.category": "model",
+        "error.code": "BKN_AGENT_MODEL_UNAVAILABLE",
+        "error.retryable": true,
+        "data.classification": "internal"
+      }
+    }
+  ],
+  "baggage": {
+    "bkn.account.type": "service",
+    "bkn.runtime.env": "test"
+  }
+}


### PR DESCRIPTION
## 背景

接入 BKN Trace 阶段一：OpenBKN 可观测记录规范与 Trace Context 基线。`bkn-agent` 是被观测模块之一，需要先具备统一 request id、traceparent、错误响应 trace id 对齐和模块级 fixture。

## 变更

- 增加 `infra/bkn-agent/TRACE.md`。
- 增加 `infra/bkn-agent/fixtures/bkn-trace/*.json`，覆盖 positive、negative、propagation、sampling。
- 健康检查和错误响应返回 `x-trace-id`、`bkn-request-id`、legacy `x-request-id`、`traceparent`。
- 支持合法上游 `traceparent` / `bkn-request-id` 继承，拒绝复用非法 all-zero `traceparent`。

## 验证

- `.venv-trace/bin/python -m pytest -q infra/bkn-agent/app/test/test_smoke.py`
  - 结果：`10 passed, 1 warning`
- `python3 /path/to/bkn-docs/docs/foundry/bkn-trace/validation/validate_phase1_fixture.py infra/bkn-agent/fixtures/bkn-trace --pretty`
  - 结果：positive/propagation/sampling pass，negative 按预期 fail

## GWT 覆盖

- GWT-01 无上游上下文
- GWT-04 非法 traceparent
- GWT-08 工具或依赖失败
- GWT-12 强制保留

## Known gaps

- toolbox/MCP 出站传播、结构化 BKN Trace event envelope、forced sampling counters 和 dropped counters 进入后续 S2/S3。
