### PR TITLE
feat(context-loader): add phase one trace context baseline

### DIFF
--- a/adp/context-loader/agent-retrieval/TRACE.md
+++ b/adp/context-loader/agent-retrieval/TRACE.md
@@ -1,0 +1,140 @@
+# context-loader Trace Contract
+
+> 状态：阶段一模块接入合同  
+> 适用版本：`bkn.trace.schema.version=1.0.0`  
+> 依据：`bkn-docs/docs/foundry/bkn-trace/design/阶段一：OpenBKN 可观测记录规范与 Trace Context 基线.md`
+
+## Module
+
+- module name: `context-loader`
+- owner: OpenBKN Foundry / context-loader
+- service identity: `context-loader`
+- runtime: Go HTTP / MCP / toolbox service
+- repository path: `adp/context-loader/agent-retrieval`
+- contract version: `1.0.0`
+
+## Entry Operations
+
+| operation | trigger | required context | emitted spans | emitted events |
+| --- | --- | --- | --- | --- |
+| `context.search_schema` | schema search HTTP/MCP/tool call | `traceparent`、`bkn-request-id`、account/auth context | `context-loader.request`、`context-loader.search` | `context.refs.resolved` |
+| `context.query_object` | object query HTTP/MCP/tool call | `traceparent`、`bkn-request-id`、account/auth context | `context-loader.request`、`context-loader.source.resolve` | `tool.called`、`tool.failed` |
+| `context.load_refs` | source refs load | `traceparent`、`bkn-request-id`、business refs | `context-loader.source.resolve` | `context.refs.resolved` |
+| `context.resolve_source` | source resolver call | `traceparent`、`bkn-request-id`、resource refs | `context-loader.source.resolve` | `context.refs.resolved` |
+
+## Inbound Context
+
+- accepted headers / metadata: `traceparent`、`bkn-request-id`、legacy `x-request-id`、`baggage`、`x-account-id`、`x-account-type`、`user_id`。
+- `traceparent` parsing: HTTP trace middleware extracts W3C Trace Context into OTel context; invalid external trace must not be propagated as an internal parent.
+- external trace trust policy: external trace can be linked or used as parent only after format validation and boundary classification.
+- invalid context handling: invalid or missing request id is replaced by a generated `req_<uuid>` value.
+- request id generation: `SetTraceContextToCtx` generates a request id when inbound `bkn-request-id` and `x-request-id` are missing or invalid.
+- tenant/account/auth context source: auth middleware reads account headers or public token introspection result; request id is independent of account id and must not be placed in baggage.
+
+## Outbound Calls
+
+| target | protocol | propagated fields | baggage policy | timeout | retry |
+| --- | --- | --- | --- | --- | --- |
+| BKN backend / ontology | HTTP | `traceparent`、`bkn-request-id`、`x-request-id`、account headers | allowlist only | existing client timeout | existing retry policy |
+| Vega/data | HTTP | `traceparent`、`bkn-request-id`、`x-request-id`、account headers | allowlist only | existing client timeout | existing retry policy |
+| Operator integration / toolbox | HTTP | `traceparent`、`bkn-request-id`、`x-request-id`、account headers | allowlist only | existing client timeout | existing retry policy |
+| MCP tools | MCP metadata / returned headers | `bkn-request-id`、account headers、allowed baggage | allowlist only | caller controlled | caller controlled |
+
+Allowed baggage fields:
+
+```text
+bkn.account.type
+bkn.runtime.env
+```
+
+## Logs
+
+| log type | level | required fields | indexed fields | sensitive fields | example fixture |
+| --- | --- | --- | --- | --- | --- |
+| business | info | `trace_id`、`span_id`、`bkn.request.id`、`bkn.module.name`、`bkn.operation.name`、`bkn.status` | module、operation、status、tool name、object type | source row、full result、signed URL | `fixtures/bkn-trace/positive.json` |
+| error | error | business fields + `error.category`、`error.code`、`error.retryable` | category、code、retryable | raw tool output、raw HTTP body | `fixtures/bkn-trace/sampling.json` |
+| audit | info | actor、policy、decision、resource ref | decision、resource class | raw resource content | 后续权限拒绝 fixture 补齐 |
+
+## Spans
+
+| span name | kind | required attributes | parent/link rule | error mapping |
+| --- | --- | --- | --- | --- |
+| `context-loader.request` | server | module、operation、status、request id | HTTP/MCP entry span | HTTP 4xx/5xx maps to validation/authz/dependency/tool |
+| `context-loader.search` | internal/client | kn id、object type、result count、duration | child of request span | search failure maps to schema/data/tool |
+| `context-loader.source.resolve` | internal/client | resource ref、row count、truncated、partial reason | child or linked async span | resolver failure maps to data/dependency |
+
+## Events
+
+| event type | producer | payload summary | partial reason | retention class |
+| --- | --- | --- | --- | --- |
+| `tool.called` | context-loader | tool id/name、args hash、result count、duration | source unavailable / result truncated | business event |
+| `tool.failed` | context-loader | tool id/name、error code、retryable | dependency timeout / validation failed | forced retention on error |
+| `context.refs.resolved` | context-loader | source ref count、classification、truncated | missing version / unauthorized / truncated | business event |
+
+## Business Refs
+
+| ref type | field | resolver | version field | visibility rule |
+| --- | --- | --- | --- | --- |
+| knowledge network | `bkn.kn.id` | BKN/ontology resolver | schema version | account/domain policy |
+| object type | `bkn.object_type.id` | BKN/ontology resolver | schema version | account/domain policy |
+| property | `bkn.property.id` | BKN/ontology resolver | schema version | account/domain policy |
+| relation type | `bkn.relation_type.id` | BKN/ontology resolver | schema version | account/domain policy |
+| resource | `bkn.resource.id` | Vega/data resolver | resource version / snapshot | account/domain policy |
+| tool | `bkn.tool.name` | toolbox registry | tool contract version | account/domain policy |
+
+## Sensitive Data Rules
+
+- never log: token、authorization、cookie、完整 prompt、完整 SQL、完整工具输入输出、完整 source row、PII、对象存储裸 URL、连接串。
+- hash only: tool args、tool result、query text、large result summary。
+- controlled reference: source refs、row refs、snapshot refs、large result artifacts。
+- redact: unauthorized source detail、PII fields、secret connection metadata。
+- `data.classification`: `public|internal|confidential|pii|secret`。
+- scanner patterns covered: token、authorization、cookie、prompt、SQL、PII、裸 URL、连接串。
+- telemetry span policy: HTTP headers are sanitized before being written to span attributes; request body is not recorded as raw content and is replaced by a redaction marker.
+
+## Sampling
+
+- default: normal success path can use sampled or not sampled based on platform policy.
+- forced sampling: `error`、`timeout`、`denied`、`tool.failed`、source resolver failure must be retained.
+- not sampled behavior: keep required business log and dropped counters.
+- dropped counters: `dropped span/event/log count` must be emitted by later telemetry integration.
+
+## Retention And Alerts
+
+- log retention class: diagnostic/business logs.
+- event retention class: business event; error and denied paths forced retention.
+- audit retention class: policy decision and resource refs only, no raw source data.
+- health metrics: missing request id rate、missing traceparent rate、orphan span rate、event validation failure rate、sensitive field rejection count、dropped count。
+- alert thresholds: configured by deployment; sensitive field rejection and validation failure should alert immediately in CI.
+
+## Fixtures
+
+| fixture | path | purpose | expected result |
+| --- | --- | --- | --- |
+| positive | `fixtures/bkn-trace/positive.json` | schema search success baseline | pass |
+| negative | `fixtures/bkn-trace/negative_baggage.json` | forbidden baggage field | fail |
+| propagation | `fixtures/bkn-trace/propagation.json` | inbound/outbound request context | pass |
+| sampling | `fixtures/bkn-trace/sampling.json` | forced sampled tool error | pass |
+
+## Covered GWT
+
+- GWT-02 可信上游 Trace Context。
+- GWT-05 baggage 违规。
+- GWT-06 MCP/toolbox 工具调用。
+- GWT-08 工具或依赖失败。
+- GWT-10 敏感数据扫描。
+- GWT-13 字段索引分层。
+
+## Known Gaps
+
+- full `tool.called/tool.failed/context.refs.resolved` runtime event emitter is not complete in this branch.
+- full registry validation and indexing policy validation currently rely on `bkn-docs` validator follow-up.
+- partial evidence resolver and audit-grade evidence snapshot belong to later BKN Trace phases.
+- S3 health metrics are not implemented yet.
+
+## Owner Sign-off
+
+- owner: OpenBKN Foundry / context-loader
+- reviewed at: 2026-07-21
+- reviewer: pending
+- compatibility risk: low; new headers are additive and legacy `x-request-id` remains supported.

--- a/adp/context-loader/agent-retrieval/TRACE.md
+++ b/adp/context-loader/agent-retrieval/TRACE.md
@@ -47,6 +47,13 @@ bkn.account.type
 bkn.runtime.env
 ```
 
+Trust policy:
+
+- `bkn.account.type` is an observability classification only, not an authentication or authorization source.
+- inbound client-provided `bkn.account.type` in `baggage` is not trusted and is dropped during trace context sanitization.
+- outbound `bkn.account.type` is derived from the server-side `AccountAuthContext` produced by header auth or token introspection.
+- downstream services must use account/auth headers and local policy context for access decisions, never `baggage`.
+
 ## Logs
 
 | log type | level | required fields | indexed fields | sensitive fields | example fixture |

--- a/adp/context-loader/agent-retrieval/fixtures/bkn-trace/negative_baggage.json
+++ b/adp/context-loader/agent-retrieval/fixtures/bkn-trace/negative_baggage.json
@@ -1,0 +1,45 @@
+{
+  "bkn.trace.schema.version": "1.0.0",
+  "fixture_id": "context_loader_negative_baggage",
+  "fixture_type": "negative",
+  "scenario": "context_loader_rejects_forbidden_baggage",
+  "expected_result": "fail",
+  "trace": {
+    "trace_id": "71040000000000000000000000000004",
+    "bkn.request.id": "req_context_loader_0004",
+    "traceparent": "00-71040000000000000000000000000004-7104000000000001-01",
+    "sampling.decision": "sampled"
+  },
+  "spans": [
+    {
+      "span_id": "7104000000000001",
+      "parent_span_id": null,
+      "name": "context-loader.request",
+      "kind": "server",
+      "bkn.module.name": "context-loader",
+      "bkn.operation.name": "context.search_schema",
+      "bkn.status": "ok",
+      "bkn.timestamp": "2026-07-21T06:03:00.000000000Z",
+      "duration_ms": 7
+    }
+  ],
+  "logs": [
+    {
+      "level": "info",
+      "message": "schema search completed",
+      "trace_id": "71040000000000000000000000000004",
+      "span_id": "7104000000000001",
+      "bkn.request.id": "req_context_loader_0004",
+      "bkn.module.name": "context-loader",
+      "bkn.operation.name": "context.search_schema",
+      "bkn.status": "ok",
+      "bkn.timestamp": "2026-07-21T06:03:00.007000000Z",
+      "bkn.trace.schema.version": "1.0.0"
+    }
+  ],
+  "events": [],
+  "baggage": {
+    "bkn.account.type": "service",
+    "bkn.account.id": "acct_forbidden"
+  }
+}

--- a/adp/context-loader/agent-retrieval/fixtures/bkn-trace/positive.json
+++ b/adp/context-loader/agent-retrieval/fixtures/bkn-trace/positive.json
@@ -1,0 +1,65 @@
+{
+  "bkn.trace.schema.version": "1.0.0",
+  "fixture_id": "context_loader_positive_search_schema",
+  "fixture_type": "positive",
+  "scenario": "context_loader_search_schema_success",
+  "expected_result": "pass",
+  "trace": {
+    "trace_id": "71010000000000000000000000000001",
+    "bkn.request.id": "req_context_loader_0001",
+    "traceparent": "00-71010000000000000000000000000001-7101000000000001-01",
+    "sampling.decision": "sampled"
+  },
+  "spans": [
+    {
+      "span_id": "7101000000000001",
+      "parent_span_id": null,
+      "name": "context-loader.request",
+      "kind": "server",
+      "bkn.module.name": "context-loader",
+      "bkn.operation.name": "context.search_schema",
+      "bkn.status": "ok",
+      "bkn.timestamp": "2026-07-21T06:00:00.000000000Z",
+      "duration_ms": 42
+    }
+  ],
+  "logs": [
+    {
+      "level": "info",
+      "message": "schema search completed",
+      "trace_id": "71010000000000000000000000000001",
+      "span_id": "7101000000000001",
+      "bkn.request.id": "req_context_loader_0001",
+      "bkn.module.name": "context-loader",
+      "bkn.operation.name": "context.search_schema",
+      "bkn.status": "ok",
+      "bkn.timestamp": "2026-07-21T06:00:00.042000000Z",
+      "bkn.trace.schema.version": "1.0.0",
+      "bkn.kn.id": "kn_demo",
+      "bkn.object_type.id": "customer",
+      "result.count": 3
+    }
+  ],
+  "events": [
+    {
+      "event_id": "evt_context_loader_0001",
+      "event_type": "context.refs.resolved",
+      "bkn.trace.schema.version": "1.0.0",
+      "observed_at": "2026-07-21T06:00:00.040000000Z",
+      "emitted_at": "2026-07-21T06:00:00.043000000Z",
+      "producer_module": "context-loader",
+      "trace_id": "71010000000000000000000000000001",
+      "span_id": "7101000000000001",
+      "bkn.request.id": "req_context_loader_0001",
+      "bkn.operation.name": "context.search_schema",
+      "payload": {
+        "result_count": 3,
+        "data.classification": "internal"
+      }
+    }
+  ],
+  "baggage": {
+    "bkn.account.type": "service",
+    "bkn.runtime.env": "test"
+  }
+}

--- a/adp/context-loader/agent-retrieval/fixtures/bkn-trace/propagation.json
+++ b/adp/context-loader/agent-retrieval/fixtures/bkn-trace/propagation.json
@@ -1,0 +1,58 @@
+{
+  "bkn.trace.schema.version": "1.0.0",
+  "fixture_id": "context_loader_propagation_tool_call",
+  "fixture_type": "propagation",
+  "scenario": "context_loader_joins_upstream_tool_call",
+  "expected_result": "pass",
+  "trace": {
+    "trace_id": "71020000000000000000000000000002",
+    "bkn.request.id": "req_context_loader_0002",
+    "traceparent": "00-71020000000000000000000000000002-7102000000000001-01",
+    "sampling.decision": "sampled"
+  },
+  "spans": [
+    {
+      "span_id": "7102000000000001",
+      "parent_span_id": null,
+      "name": "context-loader.request",
+      "kind": "server",
+      "bkn.module.name": "context-loader",
+      "bkn.operation.name": "context.query_object",
+      "bkn.status": "partial",
+      "bkn.timestamp": "2026-07-21T06:01:00.000000000Z",
+      "duration_ms": 58
+    },
+    {
+      "span_id": "7102000000000002",
+      "parent_span_id": "7102000000000001",
+      "name": "context-loader.source.resolve",
+      "kind": "internal",
+      "bkn.module.name": "context-loader",
+      "bkn.operation.name": "context.resolve_source",
+      "bkn.status": "partial",
+      "bkn.timestamp": "2026-07-21T06:01:00.020000000Z",
+      "duration_ms": 38
+    }
+  ],
+  "logs": [
+    {
+      "level": "info",
+      "message": "object query returned partial refs",
+      "trace_id": "71020000000000000000000000000002",
+      "span_id": "7102000000000002",
+      "bkn.request.id": "req_context_loader_0002",
+      "bkn.module.name": "context-loader",
+      "bkn.operation.name": "context.resolve_source",
+      "bkn.status": "partial",
+      "bkn.timestamp": "2026-07-21T06:01:00.058000000Z",
+      "bkn.trace.schema.version": "1.0.0",
+      "bkn.resource.id": "resource_demo",
+      "partial_reason": "source_ref_limited"
+    }
+  ],
+  "events": [],
+  "baggage": {
+    "bkn.account.type": "app",
+    "bkn.runtime.env": "test"
+  }
+}

--- a/adp/context-loader/agent-retrieval/fixtures/bkn-trace/sampling.json
+++ b/adp/context-loader/agent-retrieval/fixtures/bkn-trace/sampling.json
@@ -1,0 +1,51 @@
+{
+  "bkn.trace.schema.version": "1.0.0",
+  "fixture_id": "context_loader_sampling_forced_tool_error",
+  "fixture_type": "sampling",
+  "scenario": "context_loader_tool_error_forced_sampled",
+  "expected_result": "pass",
+  "trace": {
+    "trace_id": "71030000000000000000000000000003",
+    "bkn.request.id": "req_context_loader_0003",
+    "traceparent": "00-71030000000000000000000000000003-7103000000000001-01",
+    "sampling.decision": "forced_sampled"
+  },
+  "spans": [
+    {
+      "span_id": "7103000000000001",
+      "parent_span_id": null,
+      "name": "context-loader.request",
+      "kind": "server",
+      "bkn.module.name": "context-loader",
+      "bkn.operation.name": "context.load_refs",
+      "bkn.status": "error",
+      "bkn.timestamp": "2026-07-21T06:02:00.000000000Z",
+      "duration_ms": 19,
+      "error.category": "tool",
+      "error.code": "CONTEXT_TOOL_TIMEOUT",
+      "error.retryable": true
+    }
+  ],
+  "logs": [
+    {
+      "level": "error",
+      "message": "context loader tool timed out",
+      "trace_id": "71030000000000000000000000000003",
+      "span_id": "7103000000000001",
+      "bkn.request.id": "req_context_loader_0003",
+      "bkn.module.name": "context-loader",
+      "bkn.operation.name": "context.load_refs",
+      "bkn.status": "error",
+      "bkn.timestamp": "2026-07-21T06:02:00.019000000Z",
+      "bkn.trace.schema.version": "1.0.0",
+      "error.category": "tool",
+      "error.code": "CONTEXT_TOOL_TIMEOUT",
+      "error.retryable": true
+    }
+  ],
+  "events": [],
+  "baggage": {
+    "bkn.account.type": "service",
+    "bkn.runtime.env": "test"
+  }
+}

--- a/adp/context-loader/agent-retrieval/server/driveradapters/middleware.go
+++ b/adp/context-loader/agent-retrieval/server/driveradapters/middleware.go
@@ -81,6 +81,7 @@ func middlewareIntrospectVerify(hydra interfaces.Hydra, appKeys interfaces.AppKe
 		tokenInfo.UserAgent = c.GetHeader("User-Agent")
 
 		ctx = common.SetPublicAPIToCtx(ctx, true)
+		ctx = common.SetTraceContextToCtx(ctx, common.TraceContextFromHeaders(c.GetHeader))
 		// 设置认证上下文到context
 		authContext := &interfaces.AccountAuthContext{
 			AccountID:   tokenInfo.VisitorID,
@@ -98,6 +99,7 @@ func middlewareIntrospectVerify(hydra interfaces.Hydra, appKeys interfaces.AppKe
 func middlewareHeaderAuthContext() gin.HandlerFunc {
 	return func(c *gin.Context) {
 		ctx := c.Request.Context()
+		ctx = common.SetTraceContextToCtx(ctx, common.TraceContextFromHeaders(c.GetHeader))
 		// 获取Header中xAccountType账户类型
 		xAccountType := c.GetHeader(string(interfaces.HeaderXAccountType))
 

--- a/adp/context-loader/agent-retrieval/server/driveradapters/middleware_test.go
+++ b/adp/context-loader/agent-retrieval/server/driveradapters/middleware_test.go
@@ -111,7 +111,8 @@ func TestMiddlewareHeaderAuthContext_SetsTraceContext(t *testing.T) {
 		c, _ := gin.CreateTestContext(w)
 		c.Request = httptest.NewRequest(http.MethodGet, "/test", http.NoBody)
 		c.Request.Header.Set(common.HeaderBKNRequestID, "req_01JZVALIDREQUESTID000000002")
-		c.Request.Header.Set(common.HeaderBaggage, "bkn.account.type=service,bkn.account.id=user-1,prompt=raw,bkn.runtime.env=test")
+		c.Request.Header.Set(string(interfaces.HeaderXAccountType), "tenant")
+		c.Request.Header.Set(common.HeaderBaggage, "bkn.account.type=admin,bkn.account.id=user-1,prompt=raw,bkn.runtime.env=test")
 
 		mw := middlewareHeaderAuthContext()
 		mw(c)
@@ -120,14 +121,13 @@ func TestMiddlewareHeaderAuthContext_SetsTraceContext(t *testing.T) {
 		convey.So(ok, convey.ShouldBeTrue)
 		convey.So(traceCtx.RequestID, convey.ShouldEqual, "req_01JZVALIDREQUESTID000000002")
 		convey.So(traceCtx.Baggage, convey.ShouldResemble, map[string]string{
-			"bkn.account.type": "service",
-			"bkn.runtime.env":  "test",
+			"bkn.runtime.env": "test",
 		})
 
 		header := common.GetHeaderFromCtx(c.Request.Context())
 		convey.So(header[common.HeaderBKNRequestID], convey.ShouldEqual, "req_01JZVALIDREQUESTID000000002")
 		convey.So(header[common.HeaderLegacyRequestID], convey.ShouldEqual, "req_01JZVALIDREQUESTID000000002")
-		convey.So(header[common.HeaderBaggage], convey.ShouldEqual, "bkn.account.type=service,bkn.runtime.env=test")
+		convey.So(header[common.HeaderBaggage], convey.ShouldEqual, "bkn.account.type=tenant,bkn.runtime.env=test")
 	})
 
 	convey.Convey("middlewareHeaderAuthContext falls back to x-request-id and generates missing ids", t, func() {

--- a/adp/context-loader/agent-retrieval/server/driveradapters/middleware_test.go
+++ b/adp/context-loader/agent-retrieval/server/driveradapters/middleware_test.go
@@ -103,6 +103,58 @@ func TestMiddlewareHeaderAuthContext_LeavesMissingAccountHeadersEmpty(t *testing
 	})
 }
 
+func TestMiddlewareHeaderAuthContext_SetsTraceContext(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	convey.Convey("middlewareHeaderAuthContext preserves request id and sanitizes baggage", t, func() {
+		w := httptest.NewRecorder()
+		c, _ := gin.CreateTestContext(w)
+		c.Request = httptest.NewRequest(http.MethodGet, "/test", http.NoBody)
+		c.Request.Header.Set(common.HeaderBKNRequestID, "req_01JZVALIDREQUESTID000000002")
+		c.Request.Header.Set(common.HeaderBaggage, "bkn.account.type=service,bkn.account.id=user-1,prompt=raw,bkn.runtime.env=test")
+
+		mw := middlewareHeaderAuthContext()
+		mw(c)
+
+		traceCtx, ok := common.GetTraceContextFromCtx(c.Request.Context())
+		convey.So(ok, convey.ShouldBeTrue)
+		convey.So(traceCtx.RequestID, convey.ShouldEqual, "req_01JZVALIDREQUESTID000000002")
+		convey.So(traceCtx.Baggage, convey.ShouldResemble, map[string]string{
+			"bkn.account.type": "service",
+			"bkn.runtime.env":  "test",
+		})
+
+		header := common.GetHeaderFromCtx(c.Request.Context())
+		convey.So(header[common.HeaderBKNRequestID], convey.ShouldEqual, "req_01JZVALIDREQUESTID000000002")
+		convey.So(header[common.HeaderLegacyRequestID], convey.ShouldEqual, "req_01JZVALIDREQUESTID000000002")
+		convey.So(header[common.HeaderBaggage], convey.ShouldEqual, "bkn.account.type=service,bkn.runtime.env=test")
+	})
+
+	convey.Convey("middlewareHeaderAuthContext falls back to x-request-id and generates missing ids", t, func() {
+		w := httptest.NewRecorder()
+		c, _ := gin.CreateTestContext(w)
+		c.Request = httptest.NewRequest(http.MethodGet, "/test", http.NoBody)
+		c.Request.Header.Set(common.HeaderLegacyRequestID, "req_01JZVALIDREQUESTID000000003")
+
+		mw := middlewareHeaderAuthContext()
+		mw(c)
+
+		traceCtx, ok := common.GetTraceContextFromCtx(c.Request.Context())
+		convey.So(ok, convey.ShouldBeTrue)
+		convey.So(traceCtx.RequestID, convey.ShouldEqual, "req_01JZVALIDREQUESTID000000003")
+
+		w = httptest.NewRecorder()
+		c, _ = gin.CreateTestContext(w)
+		c.Request = httptest.NewRequest(http.MethodGet, "/test", http.NoBody)
+
+		mw(c)
+
+		traceCtx, ok = common.GetTraceContextFromCtx(c.Request.Context())
+		convey.So(ok, convey.ShouldBeTrue)
+		convey.So(common.IsValidBKNRequestID(traceCtx.RequestID), convey.ShouldBeTrue)
+	})
+}
+
 type stubPublicHydra struct{}
 
 func (stubPublicHydra) Introspect(_ context.Context, _ string) (*interfaces.TokenInfo, error) {

--- a/adp/context-loader/agent-retrieval/server/infra/common/context_manage.go
+++ b/adp/context-loader/agent-retrieval/server/infra/common/context_manage.go
@@ -8,9 +8,34 @@ package common
 
 import (
 	"context"
+	"crypto/rand"
+	"fmt"
+	"regexp"
+	"sort"
+	"strings"
 
 	"github.com/openbkn-ai/adp/context-loader/agent-retrieval/server/interfaces"
+	"go.opentelemetry.io/otel/trace"
 )
+
+const (
+	HeaderTraceparent     = "traceparent"
+	HeaderBKNRequestID    = "bkn-request-id"
+	HeaderLegacyRequestID = "x-request-id"
+	HeaderBaggage         = "baggage"
+)
+
+type traceContextKey string
+
+const keyTraceContext traceContextKey = "bkn_trace_context"
+
+var bknRequestIDRe = regexp.MustCompile(`^req_[A-Za-z0-9_-]{8,128}$`)
+
+// TraceContext carries the OpenBKN phase-one correlation context.
+type TraceContext struct {
+	RequestID string
+	Baggage   map[string]string
+}
 
 // GetLanguageFromCtx 从context中获取语言设置
 func GetLanguageFromCtx(ctx context.Context) Language {
@@ -67,14 +92,130 @@ func GetResponseFormatFromCtx(ctx context.Context) (interface{}, bool) {
 	return v, v != nil
 }
 
+func SetTraceContextToCtx(ctx context.Context, traceContext TraceContext) context.Context {
+	if !IsValidBKNRequestID(traceContext.RequestID) {
+		traceContext.RequestID = NewBKNRequestID()
+	}
+	traceContext.Baggage = sanitizeBaggage(traceContext.Baggage)
+	return context.WithValue(ctx, keyTraceContext, traceContext)
+}
+
+func GetTraceContextFromCtx(ctx context.Context) (TraceContext, bool) {
+	traceContext, ok := ctx.Value(keyTraceContext).(TraceContext)
+	return traceContext, ok
+}
+
+func TraceContextFromHeaders(getHeader func(string) string) TraceContext {
+	requestID := strings.TrimSpace(getHeader(HeaderBKNRequestID))
+	if requestID == "" {
+		requestID = strings.TrimSpace(getHeader(HeaderLegacyRequestID))
+	}
+	return TraceContext{
+		RequestID: requestID,
+		Baggage:   parseBaggage(getHeader(HeaderBaggage)),
+	}
+}
+
+func IsValidBKNRequestID(requestID string) bool {
+	return bknRequestIDRe.MatchString(requestID)
+}
+
+func NewBKNRequestID() string {
+	var b [16]byte
+	if _, err := rand.Read(b[:]); err != nil {
+		return "req_fallback"
+	}
+	b[6] = (b[6] & 0x0f) | 0x40
+	b[8] = (b[8] & 0x3f) | 0x80
+	return fmt.Sprintf("req_%08x-%04x-%04x-%04x-%012x", b[0:4], b[4:6], b[6:8], b[8:10], b[10:16])
+}
+
 // GetHeaderFromCtx 请求外部接口时，从context中获取Header参数传递
 func GetHeaderFromCtx(ctx context.Context) (header map[string]string) {
 	header = map[string]string{}
 	authContext, ok := GetAccountAuthContextFromCtx(ctx)
-	if !ok {
-		return
+	if ok {
+		header[string(interfaces.HeaderXAccountID)] = authContext.AccountID
+		header[string(interfaces.HeaderXAccountType)] = string(authContext.AccountType)
 	}
-	header[string(interfaces.HeaderXAccountID)] = authContext.AccountID
-	header[string(interfaces.HeaderXAccountType)] = string(authContext.AccountType)
+	traceContext, ok := GetTraceContextFromCtx(ctx)
+	if ok {
+		header[HeaderBKNRequestID] = traceContext.RequestID
+		header[HeaderLegacyRequestID] = traceContext.RequestID
+		if baggage := formatBaggage(traceContext.Baggage); baggage != "" {
+			header[HeaderBaggage] = baggage
+		}
+	}
+	if traceparent := traceparentFromCtx(ctx); traceparent != "" {
+		header[HeaderTraceparent] = traceparent
+	}
 	return
+}
+
+func sanitizeBaggage(baggage map[string]string) map[string]string {
+	if len(baggage) == 0 {
+		return nil
+	}
+	cleaned := map[string]string{}
+	for key, value := range baggage {
+		switch key {
+		case "bkn.account.type", "bkn.runtime.env":
+			cleaned[key] = value
+		}
+	}
+	if len(cleaned) == 0 {
+		return nil
+	}
+	return cleaned
+}
+
+func parseBaggage(header string) map[string]string {
+	if strings.TrimSpace(header) == "" {
+		return nil
+	}
+	baggage := map[string]string{}
+	for _, item := range strings.Split(header, ",") {
+		key, value, ok := strings.Cut(item, "=")
+		if !ok {
+			continue
+		}
+		key = strings.TrimSpace(key)
+		value = strings.TrimSpace(value)
+		if key == "" {
+			continue
+		}
+		baggage[key] = value
+	}
+	if len(baggage) == 0 {
+		return nil
+	}
+	return baggage
+}
+
+func formatBaggage(baggage map[string]string) string {
+	if len(baggage) == 0 {
+		return ""
+	}
+	keys := make([]string, 0, len(baggage))
+	for key := range baggage {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	parts := make([]string, 0, len(keys))
+	for _, key := range keys {
+		parts = append(parts, key+"="+strings.TrimSpace(baggage[key]))
+	}
+	return strings.Join(parts, ",")
+}
+
+func traceparentFromCtx(ctx context.Context) string {
+	spanContext := trace.SpanContextFromContext(ctx)
+	if !spanContext.IsValid() {
+		return ""
+	}
+	flags := "00"
+	if spanContext.TraceFlags().IsSampled() {
+		flags = "01"
+	}
+	return fmt.Sprintf("00-%s-%s-%s", spanContext.TraceID().String(), spanContext.SpanID().String(), flags)
 }

--- a/adp/context-loader/agent-retrieval/server/infra/common/context_manage.go
+++ b/adp/context-loader/agent-retrieval/server/infra/common/context_manage.go
@@ -10,6 +10,7 @@ import (
 	"context"
 	"crypto/rand"
 	"fmt"
+	"log"
 	"regexp"
 	"sort"
 	"strings"
@@ -123,6 +124,7 @@ func IsValidBKNRequestID(requestID string) bool {
 func NewBKNRequestID() string {
 	var b [16]byte
 	if _, err := rand.Read(b[:]); err != nil {
+		log.Printf("bkn trace request id generation degraded: %v", err)
 		return "req_fallback"
 	}
 	b[6] = (b[6] & 0x0f) | 0x40
@@ -142,7 +144,7 @@ func GetHeaderFromCtx(ctx context.Context) (header map[string]string) {
 	if ok {
 		header[HeaderBKNRequestID] = traceContext.RequestID
 		header[HeaderLegacyRequestID] = traceContext.RequestID
-		if baggage := formatBaggage(traceContext.Baggage); baggage != "" {
+		if baggage := formatBaggage(outboundBaggage(traceContext.Baggage, authContext)); baggage != "" {
 			header[HeaderBaggage] = baggage
 		}
 	}
@@ -159,13 +161,25 @@ func sanitizeBaggage(baggage map[string]string) map[string]string {
 	cleaned := map[string]string{}
 	for key, value := range baggage {
 		switch key {
-		case "bkn.account.type", "bkn.runtime.env":
+		case "bkn.runtime.env":
 			cleaned[key] = value
 		}
 	}
 	if len(cleaned) == 0 {
 		return nil
 	}
+	return cleaned
+}
+
+func outboundBaggage(baggage map[string]string, authContext *interfaces.AccountAuthContext) map[string]string {
+	cleaned := sanitizeBaggage(baggage)
+	if authContext == nil || strings.TrimSpace(string(authContext.AccountType)) == "" {
+		return cleaned
+	}
+	if cleaned == nil {
+		cleaned = map[string]string{}
+	}
+	cleaned["bkn.account.type"] = strings.TrimSpace(string(authContext.AccountType))
 	return cleaned
 }
 

--- a/adp/context-loader/agent-retrieval/server/infra/common/context_manage_test.go
+++ b/adp/context-loader/agent-retrieval/server/infra/common/context_manage_test.go
@@ -64,8 +64,7 @@ func TestTraceContextHelpers(t *testing.T) {
 		convey.So(ok, convey.ShouldBeTrue)
 		convey.So(traceCtx.RequestID, convey.ShouldEqual, "req_01JZVALIDREQUESTID000000000")
 		convey.So(traceCtx.Baggage, convey.ShouldResemble, map[string]string{
-			"bkn.account.type": "service",
-			"bkn.runtime.env":  "test",
+			"bkn.runtime.env": "test",
 		})
 	})
 
@@ -97,11 +96,32 @@ func TestGetHeaderFromCtxPropagatesTraceContext(t *testing.T) {
 				"bkn.account.id":   "user-1",
 			},
 		})
+		ctx = SetAccountAuthContextToCtx(ctx, &interfaces.AccountAuthContext{
+			AccountID:   "user-1",
+			AccountType: interfaces.AccessorType("tenant"),
+		})
 
 		header := GetHeaderFromCtx(ctx)
 		convey.So(header[HeaderBKNRequestID], convey.ShouldEqual, "req_01JZVALIDREQUESTID000000001")
 		convey.So(header[HeaderLegacyRequestID], convey.ShouldEqual, "req_01JZVALIDREQUESTID000000001")
 		convey.So(header[HeaderTraceparent], convey.ShouldEqual, "00-10111213141516171819202122232425-3031323334353637-01")
-		convey.So(header[HeaderBaggage], convey.ShouldEqual, "bkn.account.type=service")
+		convey.So(header[HeaderBaggage], convey.ShouldEqual, "bkn.account.type=tenant")
+	})
+
+	convey.Convey("GetHeaderFromCtx derives account baggage from trusted auth context", t, func() {
+		ctx := SetTraceContextToCtx(context.Background(), TraceContext{
+			RequestID: "req_01JZVALIDREQUESTID000000004",
+			Baggage: map[string]string{
+				"bkn.account.type": "admin",
+				"bkn.runtime.env":  "test",
+			},
+		})
+		ctx = SetAccountAuthContextToCtx(ctx, &interfaces.AccountAuthContext{
+			AccountID:   "user-1",
+			AccountType: interfaces.AccessorType("service"),
+		})
+
+		header := GetHeaderFromCtx(ctx)
+		convey.So(header[HeaderBaggage], convey.ShouldEqual, "bkn.account.type=service,bkn.runtime.env=test")
 	})
 }

--- a/adp/context-loader/agent-retrieval/server/infra/common/context_manage_test.go
+++ b/adp/context-loader/agent-retrieval/server/infra/common/context_manage_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/smartystreets/goconvey/convey"
+	"go.opentelemetry.io/otel/trace"
 
 	"github.com/openbkn-ai/adp/context-loader/agent-retrieval/server/interfaces"
 )
@@ -44,5 +45,63 @@ func TestGetHeaderFromCtx(t *testing.T) {
 		header := GetHeaderFromCtx(ctx)
 		convey.So(header[string(interfaces.HeaderXAccountID)], convey.ShouldEqual, "user-1")
 		convey.So(header[string(interfaces.HeaderXAccountType)], convey.ShouldEqual, "tenant")
+	})
+}
+
+func TestTraceContextHelpers(t *testing.T) {
+	convey.Convey("SetTraceContextToCtx preserves a valid request id and sanitizes baggage", t, func() {
+		ctx := SetTraceContextToCtx(context.Background(), TraceContext{
+			RequestID: "req_01JZVALIDREQUESTID000000000",
+			Baggage: map[string]string{
+				"bkn.account.type": "service",
+				"bkn.runtime.env":  "test",
+				"bkn.account.id":   "user-1",
+				"prompt":           "raw prompt",
+			},
+		})
+
+		traceCtx, ok := GetTraceContextFromCtx(ctx)
+		convey.So(ok, convey.ShouldBeTrue)
+		convey.So(traceCtx.RequestID, convey.ShouldEqual, "req_01JZVALIDREQUESTID000000000")
+		convey.So(traceCtx.Baggage, convey.ShouldResemble, map[string]string{
+			"bkn.account.type": "service",
+			"bkn.runtime.env":  "test",
+		})
+	})
+
+	convey.Convey("SetTraceContextToCtx generates a request id when missing or invalid", t, func() {
+		ctx := SetTraceContextToCtx(context.Background(), TraceContext{RequestID: "bad id"})
+
+		traceCtx, ok := GetTraceContextFromCtx(ctx)
+		convey.So(ok, convey.ShouldBeTrue)
+		convey.So(traceCtx.RequestID, convey.ShouldStartWith, "req_")
+		convey.So(IsValidBKNRequestID(traceCtx.RequestID), convey.ShouldBeTrue)
+	})
+}
+
+func TestGetHeaderFromCtxPropagatesTraceContext(t *testing.T) {
+	convey.Convey("GetHeaderFromCtx returns bkn request id, legacy request id, traceparent, and allowed baggage", t, func() {
+		traceID := trace.TraceID{0x10, 0x11, 0x12, 0x13, 0x14, 0x15, 0x16, 0x17, 0x18, 0x19, 0x20, 0x21, 0x22, 0x23, 0x24, 0x25}
+		spanID := trace.SpanID{0x30, 0x31, 0x32, 0x33, 0x34, 0x35, 0x36, 0x37}
+		spanCtx := trace.NewSpanContext(trace.SpanContextConfig{
+			TraceID:    traceID,
+			SpanID:     spanID,
+			TraceFlags: trace.FlagsSampled,
+			Remote:     true,
+		})
+		ctx := trace.ContextWithSpanContext(context.Background(), spanCtx)
+		ctx = SetTraceContextToCtx(ctx, TraceContext{
+			RequestID: "req_01JZVALIDREQUESTID000000001",
+			Baggage: map[string]string{
+				"bkn.account.type": "service",
+				"bkn.account.id":   "user-1",
+			},
+		})
+
+		header := GetHeaderFromCtx(ctx)
+		convey.So(header[HeaderBKNRequestID], convey.ShouldEqual, "req_01JZVALIDREQUESTID000000001")
+		convey.So(header[HeaderLegacyRequestID], convey.ShouldEqual, "req_01JZVALIDREQUESTID000000001")
+		convey.So(header[HeaderTraceparent], convey.ShouldEqual, "00-10111213141516171819202122232425-3031323334353637-01")
+		convey.So(header[HeaderBaggage], convey.ShouldEqual, "bkn.account.type=service")
 	})
 }

--- a/adp/context-loader/agent-retrieval/server/infra/telemetry/span_http.go
+++ b/adp/context-loader/agent-retrieval/server/infra/telemetry/span_http.go
@@ -14,6 +14,7 @@ import (
 	"io"
 	"net/http"
 	"regexp"
+	"sort"
 	"strings"
 
 	"github.com/openbkn-ai/bkn-comm-go/otel/oteltrace"
@@ -28,8 +29,6 @@ var clearUserPassRe = regexp.MustCompile(`(://)[^/]*@`)
 const (
 	// maxHeaderLogSize 请求头日志记录最大字节数
 	maxHeaderLogSize = 4096
-	// maxBodyLogSize 请求体日志记录最大字节数
-	maxBodyLogSize = 2048
 )
 
 // HTTPRequest 发起HTTP请求
@@ -56,26 +55,15 @@ func HTTPRequest(ctx context.Context, req *http.Request, fn func(req *http.Reque
 
 		// 记录请求头
 		if req.Header != nil {
-			headerBytes, _ := json.Marshal(req.Header)
-			headerStr := string(headerBytes)
+			headerStr := sanitizeHeadersForSpan(req.Header)
 			if len(headerStr) > maxHeaderLogSize {
 				headerStr = headerStr[:maxHeaderLogSize] + "...[truncated]"
 			}
 			span.SetAttributes(attribute.Key("http.request_headers").String(headerStr))
 		}
 
-		// 记录请求体
-		if req.Body != nil && req.ContentLength > 0 && req.ContentLength < 1024*1024 {
-			bodyBytes, _ := io.ReadAll(req.Body)
-			if len(bodyBytes) > 0 {
-				bodyStr := string(bodyBytes)
-				if len(bodyStr) > maxBodyLogSize {
-					bodyStr = bodyStr[:maxBodyLogSize] + "...[truncated]"
-				}
-				span.SetAttributes(attribute.Key("http.request_body").String(bodyStr))
-				// 重置Body以便后续读取
-				req.Body = io.NopCloser(bytes.NewBuffer(bodyBytes))
-			}
+		if req.Body != nil && req.ContentLength > 0 {
+			span.SetAttributes(attribute.Key("http.request_body").String(requestBodyPolicyForSpan(req.ContentLength)))
 		}
 
 		if req.Header == nil {
@@ -98,6 +86,53 @@ func HTTPRequest(ctx context.Context, req *http.Request, fn func(req *http.Reque
 	}
 	rsp, err = fn(req)
 	return
+}
+
+func sanitizeHeadersForSpan(headers http.Header) string {
+	sanitized := map[string][]string{}
+	keys := make([]string, 0, len(headers))
+	for key := range headers {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	for _, key := range keys {
+		values := headers.Values(key)
+		if isSensitiveHeader(key) {
+			sanitized[key] = []string{"[redacted]"}
+			continue
+		}
+		sanitized[key] = values
+	}
+	headerBytes, _ := json.Marshal(sanitized)
+	return string(headerBytes)
+}
+
+func isSensitiveHeader(key string) bool {
+	normalized := strings.ToLower(key)
+	return normalized == "authorization" ||
+		normalized == "x-authorization" ||
+		normalized == "cookie" ||
+		normalized == "set-cookie" ||
+		strings.Contains(normalized, "token") ||
+		strings.Contains(normalized, "api-key") ||
+		strings.Contains(normalized, "apikey") ||
+		strings.Contains(normalized, "secret")
+}
+
+func requestBodyPolicyForSpan(contentLength int64) string {
+	return jsonCompact(map[string]interface{}{
+		"redacted":       true,
+		"content_length": contentLength,
+		"reason":         "body omitted by BKN Trace phase-one sensitive data policy",
+	})
+}
+
+func jsonCompact(value interface{}) string {
+	bytes, err := json.Marshal(value)
+	if err != nil {
+		return `{"redacted":true}`
+	}
+	return string(bytes)
 }
 
 func recordHTTPErrorBody(rsp *http.Response) (err error) {

--- a/adp/context-loader/agent-retrieval/server/infra/telemetry/span_http_test.go
+++ b/adp/context-loader/agent-retrieval/server/infra/telemetry/span_http_test.go
@@ -1,0 +1,36 @@
+package telemetry
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/smartystreets/goconvey/convey"
+)
+
+func TestSanitizeHeadersForSpan(t *testing.T) {
+	convey.Convey("sanitizeHeadersForSpan redacts sensitive headers", t, func() {
+		headers := http.Header{}
+		headers.Set("Authorization", "Bearer token-secret")
+		headers.Set("Cookie", "session=secret")
+		headers.Set("X-Authorization", "Bearer x-secret")
+		headers.Set("Bkn-Request-Id", "req_01JZVALIDREQUESTID000000004")
+
+		sanitized := sanitizeHeadersForSpan(headers)
+
+		convey.So(sanitized, convey.ShouldContainSubstring, "req_01JZVALIDREQUESTID000000004")
+		convey.So(sanitized, convey.ShouldContainSubstring, "[redacted]")
+		convey.So(sanitized, convey.ShouldNotContainSubstring, "token-secret")
+		convey.So(sanitized, convey.ShouldNotContainSubstring, "session=secret")
+		convey.So(sanitized, convey.ShouldNotContainSubstring, "x-secret")
+	})
+}
+
+func TestRequestBodyPolicyForSpan(t *testing.T) {
+	convey.Convey("requestBodyPolicyForSpan never returns raw request body content", t, func() {
+		value := requestBodyPolicyForSpan(128)
+
+		convey.So(value, convey.ShouldContainSubstring, "redacted")
+		convey.So(value, convey.ShouldNotContainSubstring, "select * from")
+		convey.So(value, convey.ShouldNotContainSubstring, "prompt")
+	})
+}


### PR DESCRIPTION
## 背景

接入 BKN Trace 阶段一，确保 context-loader 的 MCP/toolbox、schema search、object query 等调用能按统一 request id 与 Trace Context 关联。

## 变更

- 增加模块 `TRACE.md`。
- 增加 `fixtures/bkn-trace/*.json`，覆盖 positive、negative、propagation、sampling。
- 入口生成/继承 `bkn-request-id`。
- 出站传播 `traceparent`、`bkn-request-id`、legacy `x-request-id`。
- baggage 仅保留 allowlist 字段。
- HTTP telemetry header 脱敏，body raw content 禁止进入 span。

## 验证

- `go test ./server/...`
- `python3 /path/to/bkn-docs/docs/foundry/bkn-trace/validation/validate_phase1_fixture.py fixtures/bkn-trace --pretty`

## GWT 覆盖

- GWT-02 可信上游 Trace Context
- GWT-05 baggage 违规
- GWT-06 MCP/toolbox 工具调用
- GWT-08 工具或依赖失败
- GWT-13 字段索引分层

## Known gaps

- 真实 `tool.called/tool.failed/context.refs.resolved` runtime event emitter 进入后续 S2/S3。
