### PR TITLE
feat(ontology-query): add phase one trace context baseline

### DIFF
--- a/adp/bkn/ontology-query/TRACE.md
+++ b/adp/bkn/ontology-query/TRACE.md
@@ -1,0 +1,142 @@
+# ontology-query Trace Contract
+
+> 状态：阶段一模块接入合同  
+> 适用版本：`bkn.trace.schema.version=1.0.0`  
+> 依据：`bkn-docs/docs/foundry/bkn-trace/design/阶段一：OpenBKN 可观测记录规范与 Trace Context 基线.md`
+
+## Module
+
+- module name: `bkn-ontology`
+- observed service: `ontology-query`
+- owner: OpenBKN Foundry / BKN ontology
+- service identity: `ontology-query`
+- runtime: Go HTTP service
+- repository path: `adp/bkn/ontology-query`
+- contract version: `1.0.0`
+
+## Entry Operations
+
+| operation | trigger | required context | emitted spans | emitted events |
+| --- | --- | --- | --- | --- |
+| `bkn.object.query` | object instance query | `traceparent`、`bkn-request-id`、account/auth context | `bkn-ontology.request`、`bkn-ontology.instance.query` | `object.query.executed` |
+| `bkn.relation.query` | subgraph/path query | `traceparent`、`bkn-request-id`、account/auth context | `bkn-ontology.request`、`bkn-ontology.instance.query` | `relation.query.executed` |
+| `bkn.action_type.get` | action type query | `traceparent`、`bkn-request-id`、account/auth context | `bkn-ontology.request`、`bkn-ontology.schema.lookup` | `schema.read` |
+| `bkn.metric.get` | metric dry-run/data query | `traceparent`、`bkn-request-id`、account/auth context | `bkn-ontology.request`、`bkn-ontology.instance.query` | `object.query.executed` |
+
+## Inbound Context
+
+- accepted headers / metadata: `traceparent`、`bkn-request-id`、legacy `x-request-id`、`baggage`、`x-account-id`、`x-account-type`、`x-business-domain`。
+- `traceparent` parsing: global BKN middleware extracts W3C Trace Context before `TraceContextMiddleware` stores OpenBKN request context.
+- external trace trust policy: external trace must pass W3C validation before being treated as parent; unknown `tracestate` should not be propagated.
+- invalid context handling: invalid or missing request id is replaced by generated `req_<uuid>` value.
+- request id generation: `common.SetTraceContextToCtx` generates a request id when inbound `bkn-request-id` and `x-request-id` are missing or invalid.
+- tenant/account/auth context source: external endpoints use OAuth verification; internal endpoints use account headers. Request id is independent of account id and must not be placed in baggage.
+
+## Outbound Calls
+
+| target | protocol | propagated fields | baggage policy | timeout | retry |
+| --- | --- | --- | --- | --- | --- |
+| Vega backend | HTTP | `traceparent`、`bkn-request-id`、`x-request-id`、account headers | allowlist only | existing client timeout | existing retry policy |
+| BKN backend / ontology-manager | HTTP | `traceparent`、`bkn-request-id`、`x-request-id`、account headers | allowlist only | existing client timeout | existing retry policy |
+| Model factory | HTTP | `traceparent`、`bkn-request-id`、`x-request-id`、account headers | allowlist only | existing client timeout | existing retry policy |
+| Agent operator / Action services | HTTP | `traceparent`、`bkn-request-id`、`x-request-id`、account headers | allowlist only | existing client timeout | existing retry policy |
+
+Allowed baggage fields:
+
+```text
+bkn.account.type
+bkn.runtime.env
+```
+
+## Logs
+
+| log type | level | required fields | indexed fields | sensitive fields | example fixture |
+| --- | --- | --- | --- | --- | --- |
+| business | info | `trace_id`、`span_id`、`bkn.request.id`、`bkn.module.name`、`bkn.operation.name`、`bkn.status` | module、operation、status、kn id、object type | object instance full properties、row data | `fixtures/bkn-trace/positive.json` |
+| error | error | business fields + `error.category`、`error.code`、`error.retryable` | category、code、retryable | raw backend response、raw query payload | `fixtures/bkn-trace/sampling.json` |
+| audit | info | actor、policy、decision、resource ref | decision、object/resource class | raw resource content | `fixtures/bkn-trace/sampling.json` |
+
+## Spans
+
+| span name | kind | required attributes | parent/link rule | error mapping |
+| --- | --- | --- | --- | --- |
+| `bkn-ontology.request` | server | module、operation、status、request id、kn id | HTTP entry span | validation/authz/data/schema |
+| `bkn-ontology.schema.lookup` | internal/client | kn id、object/action/metric ids、status | child of request span | schema lookup failures map to `schema` |
+| `bkn-ontology.instance.query` | internal/client | kn id、object type、row count、truncated、status | child of request span | query failures map to `data` or `dependency` |
+
+## Events
+
+| event type | producer | payload summary | partial reason | retention class |
+| --- | --- | --- | --- | --- |
+| `schema.read` | ontology-query | kn id、object/action/metric ids、schema version | schema version missing / unauthorized | business event |
+| `object.query.executed` | ontology-query | object type、result count、truncated、classification | result truncated / data unavailable | business event |
+| `relation.query.executed` | ontology-query | relation path、node count、edge count、truncated | max path exceeded / unauthorized | business event |
+| `schema.change.requested` | BKN backend, not ontology-query | change summary and actor | not emitted by query service | audit event |
+
+## Business Refs
+
+| ref type | field | resolver | version field | visibility rule |
+| --- | --- | --- | --- | --- |
+| knowledge network | `bkn.kn.id` | BKN/ontology resolver | schema version | account/domain policy |
+| object type | `bkn.object_type.id` | BKN/ontology resolver | schema version | account/domain policy |
+| object instance | `bkn.object_instance.ref` | BKN/ontology + Vega resolver | data snapshot / as_of | account/domain policy |
+| property | `bkn.property.id` | BKN/ontology resolver | schema version | account/domain policy |
+| relation type | `bkn.relation_type.id` | BKN/ontology resolver | schema version | account/domain policy |
+| metric | `bkn.metric.id` | BKN metric resolver | metric definition version | account/domain policy |
+| action type | `bkn.action_type.id` | BKN action resolver | action definition version | account/domain policy |
+
+## Sensitive Data Rules
+
+- never log: token、authorization、cookie、完整 SQL、完整对象实例属性、行级数据、PII、连接串、对象存储裸 URL。
+- hash only: query body、large result summary、operator inputs。
+- controlled reference: `bkn.object_instance.ref`、row refs、snapshot refs。
+- redact: unauthorized object/resource detail、PII fields、policy restricted values。
+- `data.classification`: `public|internal|confidential|pii|secret`。
+- scanner patterns covered: token、authorization、cookie、SQL、PII、裸 URL、连接串。
+
+## Sampling
+
+- default: normal query success can follow platform sampling policy.
+- forced sampling: `error`、`timeout`、`denied`、authz failure、backend dependency failure、Action execution failure.
+- not sampled behavior: keep required business log and dropped counters.
+- dropped counters: S3 follow-up.
+
+## Retention And Alerts
+
+- log retention class: diagnostic/business logs.
+- event retention class: business event; error and denied paths forced retention.
+- audit retention class: policy decision and resource refs only, no raw source data.
+- health metrics: missing request id rate、missing traceparent rate、orphan span rate、event validation failure rate、sensitive field rejection count、dropped count。
+- alert thresholds: configured by deployment; sensitive field rejection and validation failure should alert immediately in CI.
+
+## Fixtures
+
+| fixture | path | purpose | expected result |
+| --- | --- | --- | --- |
+| positive | `fixtures/bkn-trace/positive.json` | schema/object/relation query baseline | pass |
+| negative | `fixtures/bkn-trace/negative_missing_request_id.json` | missing request id | fail |
+| propagation | `fixtures/bkn-trace/propagation.json` | object query propagation | pass |
+| sampling | `fixtures/bkn-trace/sampling.json` | forced sampled authz denial | pass |
+
+## Covered GWT
+
+- GWT-02 可信上游 Trace Context。
+- GWT-04 非法 traceparent / invalid context handling。
+- GWT-09 权限拒绝或脱敏。
+- GWT-10 敏感数据扫描。
+- GWT-13 字段索引分层。
+- GWT-15 partial evidence。
+
+## Known Gaps
+
+- runtime `schema.read`、`object.query.executed`、`relation.query.executed` event emitters are not complete in this branch.
+- current code baseline wires Vega backend outbound trace headers; ontology-manager/model-factory/agent-operator should be migrated to `common.MergeTraceHeaders` in follow-up commits.
+- full registry validation and indexing policy validation currently rely on `bkn-docs` validator follow-up.
+- S3 health metrics are not implemented yet.
+
+## Owner Sign-off
+
+- owner: OpenBKN Foundry / BKN ontology
+- reviewed at: 2026-07-21
+- reviewer: pending
+- compatibility risk: low; new headers are additive and legacy `x-request-id` remains supported.

--- a/adp/bkn/ontology-query/fixtures/bkn-trace/negative_missing_request_id.json
+++ b/adp/bkn/ontology-query/fixtures/bkn-trace/negative_missing_request_id.json
@@ -1,0 +1,42 @@
+{
+  "bkn.trace.schema.version": "1.0.0",
+  "fixture_id": "bkn_ontology_negative_missing_request_id",
+  "fixture_type": "negative",
+  "scenario": "bkn_ontology_missing_request_id",
+  "expected_result": "fail",
+  "trace": {
+    "trace_id": "72040000000000000000000000000004",
+    "traceparent": "00-72040000000000000000000000000004-7204000000000001-01",
+    "sampling.decision": "sampled"
+  },
+  "spans": [
+    {
+      "span_id": "7204000000000001",
+      "parent_span_id": null,
+      "name": "bkn-ontology.request",
+      "kind": "server",
+      "bkn.module.name": "bkn-ontology",
+      "bkn.operation.name": "bkn.schema.get",
+      "bkn.status": "ok",
+      "bkn.timestamp": "2026-07-21T06:13:00.000000000Z",
+      "duration_ms": 4
+    }
+  ],
+  "logs": [
+    {
+      "level": "info",
+      "message": "schema lookup completed",
+      "trace_id": "72040000000000000000000000000004",
+      "span_id": "7204000000000001",
+      "bkn.module.name": "bkn-ontology",
+      "bkn.operation.name": "bkn.schema.get",
+      "bkn.status": "ok",
+      "bkn.timestamp": "2026-07-21T06:13:00.004000000Z",
+      "bkn.trace.schema.version": "1.0.0"
+    }
+  ],
+  "events": [],
+  "baggage": {
+    "bkn.account.type": "service"
+  }
+}

--- a/adp/bkn/ontology-query/fixtures/bkn-trace/positive.json
+++ b/adp/bkn/ontology-query/fixtures/bkn-trace/positive.json
@@ -1,0 +1,65 @@
+{
+  "bkn.trace.schema.version": "1.0.0",
+  "fixture_id": "bkn_ontology_positive_schema_get",
+  "fixture_type": "positive",
+  "scenario": "bkn_ontology_schema_get_success",
+  "expected_result": "pass",
+  "trace": {
+    "trace_id": "72010000000000000000000000000001",
+    "bkn.request.id": "req_bkn_ontology_0001",
+    "traceparent": "00-72010000000000000000000000000001-7201000000000001-01",
+    "sampling.decision": "sampled"
+  },
+  "spans": [
+    {
+      "span_id": "7201000000000001",
+      "parent_span_id": null,
+      "name": "bkn-ontology.request",
+      "kind": "server",
+      "bkn.module.name": "bkn-ontology",
+      "bkn.operation.name": "bkn.schema.get",
+      "bkn.status": "ok",
+      "bkn.timestamp": "2026-07-21T06:10:00.000000000Z",
+      "duration_ms": 24
+    }
+  ],
+  "logs": [
+    {
+      "level": "info",
+      "message": "schema lookup completed",
+      "trace_id": "72010000000000000000000000000001",
+      "span_id": "7201000000000001",
+      "bkn.request.id": "req_bkn_ontology_0001",
+      "bkn.module.name": "bkn-ontology",
+      "bkn.operation.name": "bkn.schema.get",
+      "bkn.status": "ok",
+      "bkn.timestamp": "2026-07-21T06:10:00.024000000Z",
+      "bkn.trace.schema.version": "1.0.0",
+      "bkn.kn.id": "kn_demo",
+      "bkn.object_type.id": "customer"
+    }
+  ],
+  "events": [
+    {
+      "event_id": "evt_bkn_ontology_0001",
+      "event_type": "schema.read",
+      "bkn.trace.schema.version": "1.0.0",
+      "observed_at": "2026-07-21T06:10:00.022000000Z",
+      "emitted_at": "2026-07-21T06:10:00.025000000Z",
+      "producer_module": "bkn-ontology",
+      "trace_id": "72010000000000000000000000000001",
+      "span_id": "7201000000000001",
+      "bkn.request.id": "req_bkn_ontology_0001",
+      "bkn.operation.name": "bkn.schema.get",
+      "payload": {
+        "bkn.kn.id": "kn_demo",
+        "bkn.object_type.id": "customer",
+        "data.classification": "internal"
+      }
+    }
+  ],
+  "baggage": {
+    "bkn.account.type": "service",
+    "bkn.runtime.env": "test"
+  }
+}

--- a/adp/bkn/ontology-query/fixtures/bkn-trace/propagation.json
+++ b/adp/bkn/ontology-query/fixtures/bkn-trace/propagation.json
@@ -1,0 +1,57 @@
+{
+  "bkn.trace.schema.version": "1.0.0",
+  "fixture_id": "bkn_ontology_propagation_object_query",
+  "fixture_type": "propagation",
+  "scenario": "bkn_ontology_object_query_keeps_request_context",
+  "expected_result": "pass",
+  "trace": {
+    "trace_id": "72020000000000000000000000000002",
+    "bkn.request.id": "req_bkn_ontology_0002",
+    "traceparent": "00-72020000000000000000000000000002-7202000000000001-01",
+    "sampling.decision": "sampled"
+  },
+  "spans": [
+    {
+      "span_id": "7202000000000001",
+      "parent_span_id": null,
+      "name": "bkn-ontology.request",
+      "kind": "server",
+      "bkn.module.name": "bkn-ontology",
+      "bkn.operation.name": "bkn.object.query",
+      "bkn.status": "ok",
+      "bkn.timestamp": "2026-07-21T06:11:00.000000000Z",
+      "duration_ms": 51
+    },
+    {
+      "span_id": "7202000000000002",
+      "parent_span_id": "7202000000000001",
+      "name": "bkn-ontology.instance.query",
+      "kind": "internal",
+      "bkn.module.name": "bkn-ontology",
+      "bkn.operation.name": "bkn.object.query",
+      "bkn.status": "ok",
+      "bkn.timestamp": "2026-07-21T06:11:00.006000000Z",
+      "duration_ms": 45
+    }
+  ],
+  "logs": [
+    {
+      "level": "info",
+      "message": "object query completed with refs",
+      "trace_id": "72020000000000000000000000000002",
+      "span_id": "7202000000000002",
+      "bkn.request.id": "req_bkn_ontology_0002",
+      "bkn.module.name": "bkn-ontology",
+      "bkn.operation.name": "bkn.object.query",
+      "bkn.status": "ok",
+      "bkn.timestamp": "2026-07-21T06:11:00.051000000Z",
+      "bkn.trace.schema.version": "1.0.0",
+      "bkn.object_instance.ref": "objref_customer_hash_001"
+    }
+  ],
+  "events": [],
+  "baggage": {
+    "bkn.account.type": "app",
+    "bkn.runtime.env": "test"
+  }
+}

--- a/adp/bkn/ontology-query/fixtures/bkn-trace/sampling.json
+++ b/adp/bkn/ontology-query/fixtures/bkn-trace/sampling.json
@@ -1,0 +1,52 @@
+{
+  "bkn.trace.schema.version": "1.0.0",
+  "fixture_id": "bkn_ontology_sampling_forced_authz_deny",
+  "fixture_type": "sampling",
+  "scenario": "bkn_ontology_authz_deny_forced_sampled",
+  "expected_result": "pass",
+  "trace": {
+    "trace_id": "72030000000000000000000000000003",
+    "bkn.request.id": "req_bkn_ontology_0003",
+    "traceparent": "00-72030000000000000000000000000003-7203000000000001-01",
+    "sampling.decision": "forced_sampled"
+  },
+  "spans": [
+    {
+      "span_id": "7203000000000001",
+      "parent_span_id": null,
+      "name": "bkn-ontology.request",
+      "kind": "server",
+      "bkn.module.name": "bkn-ontology",
+      "bkn.operation.name": "bkn.relation.query",
+      "bkn.status": "denied",
+      "bkn.timestamp": "2026-07-21T06:12:00.000000000Z",
+      "duration_ms": 13,
+      "error.category": "authz",
+      "error.code": "BKN_ONTOLOGY_ACCESS_DENIED",
+      "error.retryable": false
+    }
+  ],
+  "logs": [
+    {
+      "level": "error",
+      "message": "relation query denied",
+      "trace_id": "72030000000000000000000000000003",
+      "span_id": "7203000000000001",
+      "bkn.request.id": "req_bkn_ontology_0003",
+      "bkn.module.name": "bkn-ontology",
+      "bkn.operation.name": "bkn.relation.query",
+      "bkn.status": "denied",
+      "bkn.timestamp": "2026-07-21T06:12:00.013000000Z",
+      "bkn.trace.schema.version": "1.0.0",
+      "bkn.auth.decision": "deny",
+      "error.category": "authz",
+      "error.code": "BKN_ONTOLOGY_ACCESS_DENIED",
+      "error.retryable": false
+    }
+  ],
+  "events": [],
+  "baggage": {
+    "bkn.account.type": "user",
+    "bkn.runtime.env": "test"
+  }
+}

--- a/adp/bkn/ontology-query/server/common/trace_context.go
+++ b/adp/bkn/ontology-query/server/common/trace_context.go
@@ -1,0 +1,163 @@
+package common
+
+import (
+	"context"
+	"crypto/rand"
+	"fmt"
+	"regexp"
+	"sort"
+	"strings"
+
+	"go.opentelemetry.io/otel/trace"
+)
+
+const (
+	HeaderTraceparent     = "traceparent"
+	HeaderBKNRequestID    = "bkn-request-id"
+	HeaderLegacyRequestID = "x-request-id"
+	HeaderBaggage         = "baggage"
+)
+
+type traceContextKey string
+
+const keyTraceContext traceContextKey = "bkn_trace_context"
+
+var bknRequestIDRe = regexp.MustCompile(`^req_[A-Za-z0-9_-]{8,128}$`)
+
+// TraceContext carries the OpenBKN phase-one correlation context.
+type TraceContext struct {
+	RequestID string
+	Baggage   map[string]string
+}
+
+func SetTraceContextToCtx(ctx context.Context, traceContext TraceContext) context.Context {
+	if !IsValidBKNRequestID(traceContext.RequestID) {
+		traceContext.RequestID = NewBKNRequestID()
+	}
+	traceContext.Baggage = sanitizeBaggage(traceContext.Baggage)
+	return context.WithValue(ctx, keyTraceContext, traceContext)
+}
+
+func GetTraceContextFromCtx(ctx context.Context) (TraceContext, bool) {
+	traceContext, ok := ctx.Value(keyTraceContext).(TraceContext)
+	return traceContext, ok
+}
+
+func TraceContextFromHeaders(getHeader func(string) string) TraceContext {
+	requestID := strings.TrimSpace(getHeader(HeaderBKNRequestID))
+	if requestID == "" {
+		requestID = strings.TrimSpace(getHeader(HeaderLegacyRequestID))
+	}
+	return TraceContext{
+		RequestID: requestID,
+		Baggage:   parseBaggage(getHeader(HeaderBaggage)),
+	}
+}
+
+func IsValidBKNRequestID(requestID string) bool {
+	return bknRequestIDRe.MatchString(requestID)
+}
+
+func NewBKNRequestID() string {
+	var b [16]byte
+	if _, err := rand.Read(b[:]); err != nil {
+		return "req_fallback"
+	}
+	b[6] = (b[6] & 0x0f) | 0x40
+	b[8] = (b[8] & 0x3f) | 0x80
+	return fmt.Sprintf("req_%08x-%04x-%04x-%04x-%012x", b[0:4], b[4:6], b[6:8], b[8:10], b[10:16])
+}
+
+func BuildTraceHeaders(ctx context.Context) map[string]string {
+	headers := map[string]string{}
+	traceContext, ok := GetTraceContextFromCtx(ctx)
+	if ok {
+		headers[HeaderBKNRequestID] = traceContext.RequestID
+		headers[HeaderLegacyRequestID] = traceContext.RequestID
+		if baggage := formatBaggage(traceContext.Baggage); baggage != "" {
+			headers[HeaderBaggage] = baggage
+		}
+	}
+	if traceparent := traceparentFromCtx(ctx); traceparent != "" {
+		headers[HeaderTraceparent] = traceparent
+	}
+	return headers
+}
+
+func MergeTraceHeaders(ctx context.Context, headers map[string]string) map[string]string {
+	if headers == nil {
+		headers = map[string]string{}
+	}
+	for key, value := range BuildTraceHeaders(ctx) {
+		headers[key] = value
+	}
+	return headers
+}
+
+func sanitizeBaggage(baggage map[string]string) map[string]string {
+	if len(baggage) == 0 {
+		return nil
+	}
+	cleaned := map[string]string{}
+	for key, value := range baggage {
+		switch key {
+		case "bkn.account.type", "bkn.runtime.env":
+			cleaned[key] = value
+		}
+	}
+	if len(cleaned) == 0 {
+		return nil
+	}
+	return cleaned
+}
+
+func parseBaggage(header string) map[string]string {
+	if strings.TrimSpace(header) == "" {
+		return nil
+	}
+	baggage := map[string]string{}
+	for _, item := range strings.Split(header, ",") {
+		key, value, ok := strings.Cut(item, "=")
+		if !ok {
+			continue
+		}
+		key = strings.TrimSpace(key)
+		value = strings.TrimSpace(value)
+		if key == "" {
+			continue
+		}
+		baggage[key] = value
+	}
+	if len(baggage) == 0 {
+		return nil
+	}
+	return baggage
+}
+
+func formatBaggage(baggage map[string]string) string {
+	if len(baggage) == 0 {
+		return ""
+	}
+	keys := make([]string, 0, len(baggage))
+	for key := range baggage {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	parts := make([]string, 0, len(keys))
+	for _, key := range keys {
+		parts = append(parts, key+"="+strings.TrimSpace(baggage[key]))
+	}
+	return strings.Join(parts, ",")
+}
+
+func traceparentFromCtx(ctx context.Context) string {
+	spanContext := trace.SpanContextFromContext(ctx)
+	if !spanContext.IsValid() {
+		return ""
+	}
+	flags := "00"
+	if spanContext.TraceFlags().IsSampled() {
+		flags = "01"
+	}
+	return fmt.Sprintf("00-%s-%s-%s", spanContext.TraceID().String(), spanContext.SpanID().String(), flags)
+}

--- a/adp/bkn/ontology-query/server/common/trace_context_test.go
+++ b/adp/bkn/ontology-query/server/common/trace_context_test.go
@@ -1,0 +1,95 @@
+package common
+
+import (
+	"context"
+	"testing"
+
+	"github.com/smartystreets/goconvey/convey"
+	"go.opentelemetry.io/otel/trace"
+)
+
+func TestTraceContextHelpers(t *testing.T) {
+	convey.Convey("SetTraceContextToCtx preserves valid request id and sanitizes baggage", t, func() {
+		ctx := SetTraceContextToCtx(context.Background(), TraceContext{
+			RequestID: "req_01JZVALIDREQUESTID000000010",
+			Baggage: map[string]string{
+				"bkn.account.type": "service",
+				"bkn.runtime.env":  "test",
+				"bkn.account.id":   "user-1",
+				"prompt":           "raw prompt",
+			},
+		})
+
+		traceCtx, ok := GetTraceContextFromCtx(ctx)
+		convey.So(ok, convey.ShouldBeTrue)
+		convey.So(traceCtx.RequestID, convey.ShouldEqual, "req_01JZVALIDREQUESTID000000010")
+		convey.So(traceCtx.Baggage, convey.ShouldResemble, map[string]string{
+			"bkn.account.type": "service",
+			"bkn.runtime.env":  "test",
+		})
+	})
+
+	convey.Convey("SetTraceContextToCtx generates a request id when missing or invalid", t, func() {
+		ctx := SetTraceContextToCtx(context.Background(), TraceContext{RequestID: "bad id"})
+
+		traceCtx, ok := GetTraceContextFromCtx(ctx)
+		convey.So(ok, convey.ShouldBeTrue)
+		convey.So(traceCtx.RequestID, convey.ShouldStartWith, "req_")
+		convey.So(IsValidBKNRequestID(traceCtx.RequestID), convey.ShouldBeTrue)
+	})
+}
+
+func TestTraceContextFromHeaders(t *testing.T) {
+	convey.Convey("TraceContextFromHeaders accepts bkn-request-id and falls back to x-request-id", t, func() {
+		headers := map[string]string{
+			HeaderBKNRequestID: "req_01JZVALIDREQUESTID000000011",
+			HeaderBaggage:      "bkn.account.type=user,bkn.account.id=user-1,bkn.runtime.env=test",
+		}
+
+		traceCtx := TraceContextFromHeaders(func(key string) string { return headers[key] })
+		ctx := SetTraceContextToCtx(context.Background(), traceCtx)
+		traceCtx, ok := GetTraceContextFromCtx(ctx)
+
+		convey.So(ok, convey.ShouldBeTrue)
+		convey.So(traceCtx.RequestID, convey.ShouldEqual, "req_01JZVALIDREQUESTID000000011")
+		convey.So(traceCtx.Baggage, convey.ShouldResemble, map[string]string{
+			"bkn.account.type": "user",
+			"bkn.runtime.env":  "test",
+		})
+
+		headers = map[string]string{HeaderLegacyRequestID: "req_01JZVALIDREQUESTID000000012"}
+		traceCtx = TraceContextFromHeaders(func(key string) string { return headers[key] })
+		ctx = SetTraceContextToCtx(context.Background(), traceCtx)
+		traceCtx, ok = GetTraceContextFromCtx(ctx)
+
+		convey.So(ok, convey.ShouldBeTrue)
+		convey.So(traceCtx.RequestID, convey.ShouldEqual, "req_01JZVALIDREQUESTID000000012")
+	})
+}
+
+func TestBuildTraceHeaders(t *testing.T) {
+	convey.Convey("BuildTraceHeaders propagates request id, traceparent, and allowed baggage", t, func() {
+		traceID := trace.TraceID{0x20, 0x21, 0x22, 0x23, 0x24, 0x25, 0x26, 0x27, 0x28, 0x29, 0x30, 0x31, 0x32, 0x33, 0x34, 0x35}
+		spanID := trace.SpanID{0x40, 0x41, 0x42, 0x43, 0x44, 0x45, 0x46, 0x47}
+		spanCtx := trace.NewSpanContext(trace.SpanContextConfig{
+			TraceID:    traceID,
+			SpanID:     spanID,
+			TraceFlags: trace.FlagsSampled,
+			Remote:     true,
+		})
+		ctx := trace.ContextWithSpanContext(context.Background(), spanCtx)
+		ctx = SetTraceContextToCtx(ctx, TraceContext{
+			RequestID: "req_01JZVALIDREQUESTID000000013",
+			Baggage: map[string]string{
+				"bkn.account.type": "service",
+				"bkn.account.id":   "user-1",
+			},
+		})
+
+		headers := BuildTraceHeaders(ctx)
+		convey.So(headers[HeaderBKNRequestID], convey.ShouldEqual, "req_01JZVALIDREQUESTID000000013")
+		convey.So(headers[HeaderLegacyRequestID], convey.ShouldEqual, "req_01JZVALIDREQUESTID000000013")
+		convey.So(headers[HeaderTraceparent], convey.ShouldEqual, "00-20212223242526272829303132333435-4041424344454647-01")
+		convey.So(headers[HeaderBaggage], convey.ShouldEqual, "bkn.account.type=service")
+	})
+}

--- a/adp/bkn/ontology-query/server/drivenadapters/vega_backend/vega_backend_access.go
+++ b/adp/bkn/ontology-query/server/drivenadapters/vega_backend/vega_backend_access.go
@@ -51,11 +51,11 @@ func (v *vegaBackendAccess) buildHeaders(ctx context.Context) map[string]string 
 		accountInfo = ctx.Value(interfaces.ACCOUNT_INFO_KEY).(interfaces.AccountInfo)
 	}
 	// 用当前token的用户去访问vega
-	return map[string]string{
+	return common.MergeTraceHeaders(ctx, map[string]string{
 		interfaces.CONTENT_TYPE_NAME:        interfaces.CONTENT_TYPE_JSON,
 		interfaces.HTTP_HEADER_ACCOUNT_ID:   accountInfo.ID,
 		interfaces.HTTP_HEADER_ACCOUNT_TYPE: accountInfo.Type,
-	}
+	})
 }
 
 func (v *vegaBackendAccess) QueryResourceData(ctx context.Context, resourceID string, params *interfaces.ResourceDataQueryParams) (*interfaces.DatasetQueryResponse, error) {

--- a/adp/bkn/ontology-query/server/drivenadapters/vega_backend/vega_backend_access_test.go
+++ b/adp/bkn/ontology-query/server/drivenadapters/vega_backend/vega_backend_access_test.go
@@ -1,0 +1,48 @@
+package vega_backend
+
+import (
+	"context"
+	"testing"
+
+	"github.com/smartystreets/goconvey/convey"
+	"go.opentelemetry.io/otel/trace"
+
+	"ontology-query/common"
+	"ontology-query/interfaces"
+)
+
+func TestVegaBackendAccessBuildHeadersPropagatesTraceContext(t *testing.T) {
+	convey.Convey("buildHeaders includes account and BKN trace context headers", t, func() {
+		traceID := trace.TraceID{0x50, 0x51, 0x52, 0x53, 0x54, 0x55, 0x56, 0x57, 0x58, 0x59, 0x60, 0x61, 0x62, 0x63, 0x64, 0x65}
+		spanID := trace.SpanID{0x70, 0x71, 0x72, 0x73, 0x74, 0x75, 0x76, 0x77}
+		spanCtx := trace.NewSpanContext(trace.SpanContextConfig{
+			TraceID:    traceID,
+			SpanID:     spanID,
+			TraceFlags: trace.FlagsSampled,
+			Remote:     true,
+		})
+		ctx := trace.ContextWithSpanContext(context.Background(), spanCtx)
+		ctx = context.WithValue(ctx, interfaces.ACCOUNT_INFO_KEY, interfaces.AccountInfo{
+			ID:   "user-1",
+			Type: "user",
+		})
+		ctx = common.SetTraceContextToCtx(ctx, common.TraceContext{
+			RequestID: "req_01JZVALIDREQUESTID000000016",
+			Baggage: map[string]string{
+				"bkn.account.type": "user",
+				"bkn.account.id":   "user-1",
+			},
+		})
+
+		access := &vegaBackendAccess{}
+		headers := access.buildHeaders(ctx)
+
+		convey.So(headers[interfaces.CONTENT_TYPE_NAME], convey.ShouldEqual, interfaces.CONTENT_TYPE_JSON)
+		convey.So(headers[interfaces.HTTP_HEADER_ACCOUNT_ID], convey.ShouldEqual, "user-1")
+		convey.So(headers[interfaces.HTTP_HEADER_ACCOUNT_TYPE], convey.ShouldEqual, "user")
+		convey.So(headers[common.HeaderBKNRequestID], convey.ShouldEqual, "req_01JZVALIDREQUESTID000000016")
+		convey.So(headers[common.HeaderLegacyRequestID], convey.ShouldEqual, "req_01JZVALIDREQUESTID000000016")
+		convey.So(headers[common.HeaderTraceparent], convey.ShouldEqual, "00-50515253545556575859606162636465-7071727374757677-01")
+		convey.So(headers[common.HeaderBaggage], convey.ShouldEqual, "bkn.account.type=user")
+	})
+}

--- a/adp/bkn/ontology-query/server/driveradapters/routers.go
+++ b/adp/bkn/ontology-query/server/driveradapters/routers.go
@@ -64,6 +64,7 @@ func NewRestHandler(appSetting *common.AppSetting) RestHandler {
 func (r *restHandler) RegisterPublic(c *gin.Engine) {
 	c.Use(r.AccessLog())
 	c.Use(middleware.TracingMiddleware())
+	c.Use(r.TraceContextMiddleware())
 	c.Use(r.LanguageMiddleware())
 
 	c.GET("/health", r.HealthCheck)
@@ -148,6 +149,15 @@ func (r *restHandler) verifyJsonContentType() gin.HandlerFunc {
 func (r *restHandler) LanguageMiddleware() gin.HandlerFunc {
 	return func(c *gin.Context) {
 		c.Request = c.Request.WithContext(rest.GetLanguageCtx(c))
+		c.Next()
+	}
+}
+
+// TraceContextMiddleware parses OpenBKN phase-one trace context into request context.
+func (r *restHandler) TraceContextMiddleware() gin.HandlerFunc {
+	return func(c *gin.Context) {
+		ctx := common.SetTraceContextToCtx(c.Request.Context(), common.TraceContextFromHeaders(c.GetHeader))
+		c.Request = c.Request.WithContext(ctx)
 		c.Next()
 	}
 }

--- a/adp/bkn/ontology-query/server/driveradapters/routers_test.go
+++ b/adp/bkn/ontology-query/server/driveradapters/routers_test.go
@@ -133,6 +133,35 @@ func Test_RestHandler_verifyJsonContentType(t *testing.T) {
 	})
 }
 
+func Test_RestHandler_TraceContextMiddleware(t *testing.T) {
+	Convey("Test RestHandler TraceContextMiddleware", t, func() {
+		test := setGinMode()
+		defer test()
+
+		handler := &restHandler{}
+		engine := gin.New()
+		engine.Use(handler.TraceContextMiddleware())
+		engine.GET("/test", func(c *gin.Context) {
+			traceCtx, ok := common.GetTraceContextFromCtx(c.Request.Context())
+			So(ok, ShouldBeTrue)
+			So(traceCtx.RequestID, ShouldEqual, "req_01JZVALIDREQUESTID000000015")
+			So(traceCtx.Baggage, ShouldResemble, map[string]string{
+				"bkn.account.type": "service",
+				"bkn.runtime.env":  "test",
+			})
+			c.Status(http.StatusOK)
+		})
+
+		req := httptest.NewRequest(http.MethodGet, "/test", nil)
+		req.Header.Set(common.HeaderBKNRequestID, "req_01JZVALIDREQUESTID000000015")
+		req.Header.Set(common.HeaderBaggage, "bkn.account.type=service,bkn.account.id=user-1,bkn.runtime.env=test,prompt=raw")
+		w := httptest.NewRecorder()
+		engine.ServeHTTP(w, req)
+
+		So(w.Result().StatusCode, ShouldEqual, http.StatusOK)
+	})
+}
+
 func Test_RestHandler_verifyOAuth(t *testing.T) {
 	Convey("Test RestHandler verifyOAuth", t, func() {
 		test := setGinMode()


### PR DESCRIPTION
## 背景

接入 BKN Trace 阶段一，保证 BKN/ontology 查询侧可以按统一 request id、traceparent、日志和 fixture 规范进入后续证据采集。

## 变更

- 增加 `ontology-query` 模块 `TRACE.md`。
- 增加 `fixtures/bkn-trace/*.json`，覆盖 schema/object 查询、传播和负向场景。
- 入口生成/继承 `bkn-request-id`。
- Vega backend 出站传播 `traceparent`、`bkn-request-id`、legacy `x-request-id` 与 allowlist baggage。

## 验证

- `I18N_MODE_UT=true go test ./...`
- `python3 /path/to/bkn-docs/docs/foundry/bkn-trace/validation/validate_phase1_fixture.py adp/bkn/ontology-query/fixtures/bkn-trace --pretty`

## GWT 覆盖

- GWT-09 权限拒绝或脱敏
- GWT-10 敏感数据扫描
- GWT-13 字段索引分层

## Known gaps

- ontology-manager、model-factory、agent-operator 出站 header 仍需迁移到统一 helper。
- runtime `schema.read/object.query.executed/relation.query.executed` event emitter 进入后续 S2/S3。
