### PR TITLE
feat(vega-backend): add phase one trace context baseline

### DIFF
--- a/adp/vega/vega-backend/TRACE.md
+++ b/adp/vega/vega-backend/TRACE.md
@@ -1,0 +1,140 @@
+# vega-backend Trace Contract
+
+> 状态：阶段一模块接入合同  
+> 适用版本：`bkn.trace.schema.version=1.0.0`  
+> 依据：`bkn-docs/docs/foundry/bkn-trace/design/阶段一：OpenBKN 可观测记录规范与 Trace Context 基线.md`
+
+## Module
+
+- module name: `vega-data`
+- observed service: `vega-backend`
+- owner: OpenBKN Foundry / Vega data
+- service identity: `vega-backend`
+- runtime: Go HTTP service
+- repository path: `adp/vega/vega-backend`
+- contract version: `1.0.0`
+
+## Entry Operations
+
+| operation | trigger | required context | emitted spans | emitted events |
+| --- | --- | --- | --- | --- |
+| `data.resource.query` | resource data query | `traceparent`、`bkn-request-id`、account/auth context | `vega-data.request`、`vega-data.query` | `data.query.executed` |
+| `data.catalog.get` | catalog/resource metadata query | `traceparent`、`bkn-request-id`、account/auth context | `vega-data.request` | `schema.read` / metadata read event |
+| `data.query.execute` | raw SQL / OpenSearch query | `traceparent`、`bkn-request-id`、resource refs | `vega-data.request`、`vega-data.query` | `data.query.executed`、`data.query.failed` |
+| `data.snapshot.create` | snapshot/export follow-up | `traceparent`、`bkn-request-id`、resource refs | `vega-data.snapshot` | `snapshot.created` |
+
+## Inbound Context
+
+- accepted headers / metadata: `traceparent`、`bkn-request-id`、legacy `x-request-id`、`baggage`、`x-account-id`、`x-account-type`、`x-business-domain`。
+- `traceparent` parsing: global BKN middleware extracts W3C Trace Context before `TraceContextMiddleware` stores OpenBKN request context.
+- external trace trust policy: external trace must pass W3C validation before being treated as parent; unknown `tracestate` should not be propagated.
+- invalid context handling: invalid or missing request id is replaced by generated `req_<uuid>` value.
+- request id generation: `common.SetTraceContextToCtx` generates a request id when inbound `bkn-request-id` and `x-request-id` are missing or invalid.
+- tenant/account/auth context source: external endpoints use OAuth verification; internal endpoints use account headers. Request id is independent of account id and must not be placed in baggage.
+
+## Outbound Calls
+
+| target | protocol | propagated fields | baggage policy | timeout | retry |
+| --- | --- | --- | --- | --- | --- |
+| permission service | HTTP | `traceparent`、`bkn-request-id`、`x-request-id`、account headers | allowlist only | existing client timeout | existing retry policy |
+| model factory | HTTP | `traceparent`、`bkn-request-id`、`x-request-id`、account headers | allowlist only | existing client timeout | existing retry policy |
+| bkn-agent semantic understanding | HTTP | `traceparent`、`bkn-request-id`、`x-request-id`、account headers | allowlist only | existing client timeout | existing retry policy |
+| local connector / database | internal driver | request id on context; no raw SQL in logs | no baggage | connector timeout | connector policy |
+
+Allowed baggage fields:
+
+```text
+bkn.account.type
+bkn.runtime.env
+```
+
+## Logs
+
+| log type | level | required fields | indexed fields | sensitive fields | example fixture |
+| --- | --- | --- | --- | --- | --- |
+| business | info | `trace_id`、`span_id`、`bkn.request.id`、`bkn.module.name`、`bkn.operation.name`、`bkn.status` | module、operation、status、resource id、catalog id | full SQL、full result set、row data | `fixtures/bkn-trace/positive.json` |
+| error | error | business fields + `error.category`、`error.code`、`error.retryable` | category、code、retryable | raw connector response、connection string | `fixtures/bkn-trace/sampling.json` |
+| audit | info | actor、policy、decision、resource ref | decision、resource class | raw data / PII | future policy fixture |
+
+## Spans
+
+| span name | kind | required attributes | parent/link rule | error mapping |
+| --- | --- | --- | --- | --- |
+| `vega-data.request` | server | module、operation、status、request id、resource/catalog id | HTTP entry span | validation/authz/data/dependency |
+| `vega-data.query` | internal/client | resource id、catalog id、query hash、row count、truncated、status | child of request span | query failures map to `data` or `timeout` |
+| `vega-data.snapshot` | internal | snapshot ref、hash、classification、retention | child/link from request span | snapshot failures map to `dependency` |
+
+## Events
+
+| event type | producer | payload summary | partial reason | retention class |
+| --- | --- | --- | --- | --- |
+| `data.query.executed` | vega-backend | resource id、catalog id、query hash、row count、truncated | result truncated / connector unavailable | business event |
+| `data.query.failed` | vega-backend | resource id、catalog id、query hash、error code、retryable | timeout / dependency / validation | forced retention on error |
+| `snapshot.created` | vega-backend | snapshot ref、hash、format、classification | snapshot unavailable | evidence ref |
+
+## Business Refs
+
+| ref type | field | resolver | version field | visibility rule |
+| --- | --- | --- | --- | --- |
+| resource | `bkn.resource.id` | Vega resolver | resource version / schema version | account/domain policy |
+| catalog | `bkn.catalog.id` | Vega resolver | catalog version | account/domain policy |
+| query | `query.hash` | Vega query resolver | query template id / hash | account/domain policy |
+| row/snapshot | `snapshot.ref` / row refs | Vega snapshot resolver | snapshot/as_of | account/domain policy |
+
+## Sensitive Data Rules
+
+- never log: token、authorization、cookie、完整 SQL、完整结果集、行级数据、PII、连接串、对象存储裸 URL。
+- hash only: raw SQL、OpenSearch DSL、query body、large result summary。
+- controlled reference: row refs、snapshot refs、large result artifacts。
+- redact: unauthorized resource detail、PII fields、secret connection metadata。
+- `data.classification`: `public|internal|confidential|pii|secret`。
+- scanner patterns covered: token、authorization、cookie、SQL、PII、裸 URL、连接串。
+- current code baseline: raw query and logic view SQL logs use `query.SafeQuerySummary` to emit `query_hash` and `query_length` instead of raw SQL.
+
+## Sampling
+
+- default: normal query success can follow platform sampling policy.
+- forced sampling: `error`、`timeout`、`denied`、connector failure、query validation failure。
+- not sampled behavior: keep required business log and dropped counters.
+- dropped counters: S3 follow-up.
+
+## Retention And Alerts
+
+- log retention class: diagnostic/business logs.
+- event retention class: business event; error and denied paths forced retention.
+- audit retention class: policy decision and resource refs only, no raw source data.
+- health metrics: missing request id rate、missing traceparent rate、orphan span rate、event validation failure rate、sensitive field rejection count、dropped count。
+- alert thresholds: configured by deployment; sensitive field rejection and validation failure should alert immediately in CI.
+
+## Fixtures
+
+| fixture | path | purpose | expected result |
+| --- | --- | --- | --- |
+| positive | `fixtures/bkn-trace/positive.json` | query hash success baseline | pass |
+| negative | `fixtures/bkn-trace/negative_sensitive_sql.json` | full SQL leakage rejection | fail |
+| propagation | `fixtures/bkn-trace/propagation.json` | snapshot/resource propagation | pass |
+| sampling | `fixtures/bkn-trace/sampling.json` | forced sampled timeout | pass |
+
+## Covered GWT
+
+- GWT-01 无上游上下文。
+- GWT-02 可信上游 Trace Context。
+- GWT-08 工具或依赖失败。
+- GWT-10 敏感数据扫描。
+- GWT-12 强制保留。
+- GWT-13 字段索引分层。
+- GWT-15 partial evidence。
+
+## Known Gaps
+
+- runtime `data.query.executed/data.query.failed/snapshot.created` event emitters are not complete in this branch.
+- outbound permission/model-factory/bkn-agent clients should be migrated to `common.MergeTraceHeaders` in follow-up commits.
+- full registry validation and indexing policy validation currently rely on `bkn-docs` validator follow-up.
+- S3 health metrics are not implemented yet.
+
+## Owner Sign-off
+
+- owner: OpenBKN Foundry / Vega data
+- reviewed at: 2026-07-21
+- reviewer: pending
+- compatibility risk: low; new headers are additive and legacy `x-request-id` remains supported.

--- a/adp/vega/vega-backend/fixtures/bkn-trace/negative_sensitive_sql.json
+++ b/adp/vega/vega-backend/fixtures/bkn-trace/negative_sensitive_sql.json
@@ -1,0 +1,44 @@
+{
+  "bkn.trace.schema.version": "1.0.0",
+  "fixture_id": "vega_data_negative_sensitive_sql",
+  "fixture_type": "negative",
+  "scenario": "vega_data_full_sql_leak",
+  "expected_result": "fail",
+  "trace": {
+    "trace_id": "73040000000000000000000000000004",
+    "bkn.request.id": "req_vega_data_0004",
+    "traceparent": "00-73040000000000000000000000000004-7304000000000001-01",
+    "sampling.decision": "sampled"
+  },
+  "spans": [
+    {
+      "span_id": "7304000000000001",
+      "parent_span_id": null,
+      "name": "vega-data.query",
+      "kind": "server",
+      "bkn.module.name": "vega-data",
+      "bkn.operation.name": "data.query.execute",
+      "bkn.status": "ok",
+      "bkn.timestamp": "2026-07-21T06:23:00.000000000Z",
+      "duration_ms": 11
+    }
+  ],
+  "logs": [
+    {
+      "level": "info",
+      "message": "executed select customer_id, phone from pii_table",
+      "trace_id": "73040000000000000000000000000004",
+      "span_id": "7304000000000001",
+      "bkn.request.id": "req_vega_data_0004",
+      "bkn.module.name": "vega-data",
+      "bkn.operation.name": "data.query.execute",
+      "bkn.status": "ok",
+      "bkn.timestamp": "2026-07-21T06:23:00.011000000Z",
+      "bkn.trace.schema.version": "1.0.0"
+    }
+  ],
+  "events": [],
+  "baggage": {
+    "bkn.account.type": "service"
+  }
+}

--- a/adp/vega/vega-backend/fixtures/bkn-trace/positive.json
+++ b/adp/vega/vega-backend/fixtures/bkn-trace/positive.json
@@ -1,0 +1,49 @@
+{
+  "bkn.trace.schema.version": "1.0.0",
+  "fixture_id": "vega_data_positive_query_hash",
+  "fixture_type": "positive",
+  "scenario": "vega_data_query_records_hash_and_result_size",
+  "expected_result": "pass",
+  "trace": {
+    "trace_id": "73010000000000000000000000000001",
+    "bkn.request.id": "req_vega_data_0001",
+    "traceparent": "00-73010000000000000000000000000001-7301000000000001-01",
+    "sampling.decision": "sampled"
+  },
+  "spans": [
+    {
+      "span_id": "7301000000000001",
+      "parent_span_id": null,
+      "name": "vega-data.query",
+      "kind": "server",
+      "bkn.module.name": "vega-data",
+      "bkn.operation.name": "data.query.execute",
+      "bkn.status": "ok",
+      "bkn.timestamp": "2026-07-21T06:20:00.000000000Z",
+      "duration_ms": 76
+    }
+  ],
+  "logs": [
+    {
+      "level": "info",
+      "message": "data query completed",
+      "trace_id": "73010000000000000000000000000001",
+      "span_id": "7301000000000001",
+      "bkn.request.id": "req_vega_data_0001",
+      "bkn.module.name": "vega-data",
+      "bkn.operation.name": "data.query.execute",
+      "bkn.status": "ok",
+      "bkn.timestamp": "2026-07-21T06:20:00.076000000Z",
+      "bkn.trace.schema.version": "1.0.0",
+      "bkn.resource.id": "resource_sales_demo",
+      "bkn.catalog.id": "catalog_demo",
+      "query.hash": "sha256:query_template_sales",
+      "result.row_count": 18
+    }
+  ],
+  "events": [],
+  "baggage": {
+    "bkn.account.type": "service",
+    "bkn.runtime.env": "test"
+  }
+}

--- a/adp/vega/vega-backend/fixtures/bkn-trace/propagation.json
+++ b/adp/vega/vega-backend/fixtures/bkn-trace/propagation.json
@@ -1,0 +1,64 @@
+{
+  "bkn.trace.schema.version": "1.0.0",
+  "fixture_id": "vega_data_propagation_snapshot",
+  "fixture_type": "propagation",
+  "scenario": "vega_data_snapshot_keeps_request_context",
+  "expected_result": "pass",
+  "trace": {
+    "trace_id": "73020000000000000000000000000002",
+    "bkn.request.id": "req_vega_data_0002",
+    "traceparent": "00-73020000000000000000000000000002-7302000000000001-01",
+    "sampling.decision": "sampled"
+  },
+  "spans": [
+    {
+      "span_id": "7302000000000001",
+      "parent_span_id": null,
+      "name": "vega-data.request",
+      "kind": "server",
+      "bkn.module.name": "vega-data",
+      "bkn.operation.name": "data.snapshot.create",
+      "bkn.status": "ok",
+      "bkn.timestamp": "2026-07-21T06:21:00.000000000Z",
+      "duration_ms": 64
+    }
+  ],
+  "logs": [
+    {
+      "level": "info",
+      "message": "snapshot ref created",
+      "trace_id": "73020000000000000000000000000002",
+      "span_id": "7302000000000001",
+      "bkn.request.id": "req_vega_data_0002",
+      "bkn.module.name": "vega-data",
+      "bkn.operation.name": "data.snapshot.create",
+      "bkn.status": "ok",
+      "bkn.timestamp": "2026-07-21T06:21:00.064000000Z",
+      "bkn.trace.schema.version": "1.0.0",
+      "snapshot.ref": "snapshot_ref_hash_001",
+      "data.classification": "internal"
+    }
+  ],
+  "events": [
+    {
+      "event_id": "evt_vega_snapshot_0002",
+      "event_type": "snapshot.created",
+      "bkn.trace.schema.version": "1.0.0",
+      "observed_at": "2026-07-21T06:21:00.062000000Z",
+      "emitted_at": "2026-07-21T06:21:00.065000000Z",
+      "producer_module": "vega-data",
+      "trace_id": "73020000000000000000000000000002",
+      "span_id": "7302000000000001",
+      "bkn.request.id": "req_vega_data_0002",
+      "bkn.operation.name": "data.snapshot.create",
+      "payload": {
+        "snapshot_ref": "snapshot_ref_hash_001",
+        "snapshot_hash": "sha256:snapshot_demo"
+      }
+    }
+  ],
+  "baggage": {
+    "bkn.account.type": "app",
+    "bkn.runtime.env": "test"
+  }
+}

--- a/adp/vega/vega-backend/fixtures/bkn-trace/sampling.json
+++ b/adp/vega/vega-backend/fixtures/bkn-trace/sampling.json
@@ -1,0 +1,51 @@
+{
+  "bkn.trace.schema.version": "1.0.0",
+  "fixture_id": "vega_data_sampling_forced_timeout",
+  "fixture_type": "sampling",
+  "scenario": "vega_data_timeout_forced_sampled",
+  "expected_result": "pass",
+  "trace": {
+    "trace_id": "73030000000000000000000000000003",
+    "bkn.request.id": "req_vega_data_0003",
+    "traceparent": "00-73030000000000000000000000000003-7303000000000001-01",
+    "sampling.decision": "forced_sampled"
+  },
+  "spans": [
+    {
+      "span_id": "7303000000000001",
+      "parent_span_id": null,
+      "name": "vega-data.query",
+      "kind": "server",
+      "bkn.module.name": "vega-data",
+      "bkn.operation.name": "data.query.execute",
+      "bkn.status": "timeout",
+      "bkn.timestamp": "2026-07-21T06:22:00.000000000Z",
+      "duration_ms": 30000,
+      "error.category": "timeout",
+      "error.code": "VEGA_DATA_QUERY_TIMEOUT",
+      "error.retryable": true
+    }
+  ],
+  "logs": [
+    {
+      "level": "error",
+      "message": "data query timed out",
+      "trace_id": "73030000000000000000000000000003",
+      "span_id": "7303000000000001",
+      "bkn.request.id": "req_vega_data_0003",
+      "bkn.module.name": "vega-data",
+      "bkn.operation.name": "data.query.execute",
+      "bkn.status": "timeout",
+      "bkn.timestamp": "2026-07-21T06:22:30.000000000Z",
+      "bkn.trace.schema.version": "1.0.0",
+      "error.category": "timeout",
+      "error.code": "VEGA_DATA_QUERY_TIMEOUT",
+      "error.retryable": true
+    }
+  ],
+  "events": [],
+  "baggage": {
+    "bkn.account.type": "service",
+    "bkn.runtime.env": "test"
+  }
+}

--- a/adp/vega/vega-backend/server/common/trace_context.go
+++ b/adp/vega/vega-backend/server/common/trace_context.go
@@ -1,0 +1,163 @@
+package common
+
+import (
+	"context"
+	"crypto/rand"
+	"fmt"
+	"regexp"
+	"sort"
+	"strings"
+
+	"go.opentelemetry.io/otel/trace"
+)
+
+const (
+	HeaderTraceparent     = "traceparent"
+	HeaderBKNRequestID    = "bkn-request-id"
+	HeaderLegacyRequestID = "x-request-id"
+	HeaderBaggage         = "baggage"
+)
+
+type traceContextKey string
+
+const keyTraceContext traceContextKey = "bkn_trace_context"
+
+var bknRequestIDRe = regexp.MustCompile(`^req_[A-Za-z0-9_-]{8,128}$`)
+
+// TraceContext carries the OpenBKN phase-one correlation context.
+type TraceContext struct {
+	RequestID string
+	Baggage   map[string]string
+}
+
+func SetTraceContextToCtx(ctx context.Context, traceContext TraceContext) context.Context {
+	if !IsValidBKNRequestID(traceContext.RequestID) {
+		traceContext.RequestID = NewBKNRequestID()
+	}
+	traceContext.Baggage = sanitizeBaggage(traceContext.Baggage)
+	return context.WithValue(ctx, keyTraceContext, traceContext)
+}
+
+func GetTraceContextFromCtx(ctx context.Context) (TraceContext, bool) {
+	traceContext, ok := ctx.Value(keyTraceContext).(TraceContext)
+	return traceContext, ok
+}
+
+func TraceContextFromHeaders(getHeader func(string) string) TraceContext {
+	requestID := strings.TrimSpace(getHeader(HeaderBKNRequestID))
+	if requestID == "" {
+		requestID = strings.TrimSpace(getHeader(HeaderLegacyRequestID))
+	}
+	return TraceContext{
+		RequestID: requestID,
+		Baggage:   parseBaggage(getHeader(HeaderBaggage)),
+	}
+}
+
+func IsValidBKNRequestID(requestID string) bool {
+	return bknRequestIDRe.MatchString(requestID)
+}
+
+func NewBKNRequestID() string {
+	var b [16]byte
+	if _, err := rand.Read(b[:]); err != nil {
+		return "req_fallback"
+	}
+	b[6] = (b[6] & 0x0f) | 0x40
+	b[8] = (b[8] & 0x3f) | 0x80
+	return fmt.Sprintf("req_%08x-%04x-%04x-%04x-%012x", b[0:4], b[4:6], b[6:8], b[8:10], b[10:16])
+}
+
+func BuildTraceHeaders(ctx context.Context) map[string]string {
+	headers := map[string]string{}
+	traceContext, ok := GetTraceContextFromCtx(ctx)
+	if ok {
+		headers[HeaderBKNRequestID] = traceContext.RequestID
+		headers[HeaderLegacyRequestID] = traceContext.RequestID
+		if baggage := formatBaggage(traceContext.Baggage); baggage != "" {
+			headers[HeaderBaggage] = baggage
+		}
+	}
+	if traceparent := traceparentFromCtx(ctx); traceparent != "" {
+		headers[HeaderTraceparent] = traceparent
+	}
+	return headers
+}
+
+func MergeTraceHeaders(ctx context.Context, headers map[string]string) map[string]string {
+	if headers == nil {
+		headers = map[string]string{}
+	}
+	for key, value := range BuildTraceHeaders(ctx) {
+		headers[key] = value
+	}
+	return headers
+}
+
+func sanitizeBaggage(baggage map[string]string) map[string]string {
+	if len(baggage) == 0 {
+		return nil
+	}
+	cleaned := map[string]string{}
+	for key, value := range baggage {
+		switch key {
+		case "bkn.account.type", "bkn.runtime.env":
+			cleaned[key] = value
+		}
+	}
+	if len(cleaned) == 0 {
+		return nil
+	}
+	return cleaned
+}
+
+func parseBaggage(header string) map[string]string {
+	if strings.TrimSpace(header) == "" {
+		return nil
+	}
+	baggage := map[string]string{}
+	for _, item := range strings.Split(header, ",") {
+		key, value, ok := strings.Cut(item, "=")
+		if !ok {
+			continue
+		}
+		key = strings.TrimSpace(key)
+		value = strings.TrimSpace(value)
+		if key == "" {
+			continue
+		}
+		baggage[key] = value
+	}
+	if len(baggage) == 0 {
+		return nil
+	}
+	return baggage
+}
+
+func formatBaggage(baggage map[string]string) string {
+	if len(baggage) == 0 {
+		return ""
+	}
+	keys := make([]string, 0, len(baggage))
+	for key := range baggage {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	parts := make([]string, 0, len(keys))
+	for _, key := range keys {
+		parts = append(parts, key+"="+strings.TrimSpace(baggage[key]))
+	}
+	return strings.Join(parts, ",")
+}
+
+func traceparentFromCtx(ctx context.Context) string {
+	spanContext := trace.SpanContextFromContext(ctx)
+	if !spanContext.IsValid() {
+		return ""
+	}
+	flags := "00"
+	if spanContext.TraceFlags().IsSampled() {
+		flags = "01"
+	}
+	return fmt.Sprintf("00-%s-%s-%s", spanContext.TraceID().String(), spanContext.SpanID().String(), flags)
+}

--- a/adp/vega/vega-backend/server/common/trace_context_test.go
+++ b/adp/vega/vega-backend/server/common/trace_context_test.go
@@ -1,0 +1,85 @@
+package common
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel/trace"
+)
+
+func TestTraceContextHelpers(t *testing.T) {
+	ctx := SetTraceContextToCtx(context.Background(), TraceContext{
+		RequestID: "req_01JZVALIDREQUESTID000000020",
+		Baggage: map[string]string{
+			"bkn.account.type": "service",
+			"bkn.runtime.env":  "test",
+			"bkn.account.id":   "user-1",
+			"prompt":           "raw prompt",
+		},
+	})
+
+	traceCtx, ok := GetTraceContextFromCtx(ctx)
+	require.True(t, ok)
+	require.Equal(t, "req_01JZVALIDREQUESTID000000020", traceCtx.RequestID)
+	require.Equal(t, map[string]string{
+		"bkn.account.type": "service",
+		"bkn.runtime.env":  "test",
+	}, traceCtx.Baggage)
+
+	ctx = SetTraceContextToCtx(context.Background(), TraceContext{RequestID: "bad id"})
+	traceCtx, ok = GetTraceContextFromCtx(ctx)
+	require.True(t, ok)
+	require.True(t, IsValidBKNRequestID(traceCtx.RequestID))
+}
+
+func TestTraceContextFromHeaders(t *testing.T) {
+	headers := map[string]string{
+		HeaderBKNRequestID: "req_01JZVALIDREQUESTID000000021",
+		HeaderBaggage:      "bkn.account.type=user,bkn.account.id=user-1,bkn.runtime.env=test",
+	}
+
+	traceCtx := TraceContextFromHeaders(func(key string) string { return headers[key] })
+	ctx := SetTraceContextToCtx(context.Background(), traceCtx)
+	traceCtx, ok := GetTraceContextFromCtx(ctx)
+
+	require.True(t, ok)
+	require.Equal(t, "req_01JZVALIDREQUESTID000000021", traceCtx.RequestID)
+	require.Equal(t, map[string]string{
+		"bkn.account.type": "user",
+		"bkn.runtime.env":  "test",
+	}, traceCtx.Baggage)
+
+	headers = map[string]string{HeaderLegacyRequestID: "req_01JZVALIDREQUESTID000000022"}
+	traceCtx = TraceContextFromHeaders(func(key string) string { return headers[key] })
+	ctx = SetTraceContextToCtx(context.Background(), traceCtx)
+	traceCtx, ok = GetTraceContextFromCtx(ctx)
+
+	require.True(t, ok)
+	require.Equal(t, "req_01JZVALIDREQUESTID000000022", traceCtx.RequestID)
+}
+
+func TestBuildTraceHeaders(t *testing.T) {
+	traceID := trace.TraceID{0x60, 0x61, 0x62, 0x63, 0x64, 0x65, 0x66, 0x67, 0x68, 0x69, 0x70, 0x71, 0x72, 0x73, 0x74, 0x75}
+	spanID := trace.SpanID{0x80, 0x81, 0x82, 0x83, 0x84, 0x85, 0x86, 0x87}
+	spanCtx := trace.NewSpanContext(trace.SpanContextConfig{
+		TraceID:    traceID,
+		SpanID:     spanID,
+		TraceFlags: trace.FlagsSampled,
+		Remote:     true,
+	})
+	ctx := trace.ContextWithSpanContext(context.Background(), spanCtx)
+	ctx = SetTraceContextToCtx(ctx, TraceContext{
+		RequestID: "req_01JZVALIDREQUESTID000000023",
+		Baggage: map[string]string{
+			"bkn.account.type": "service",
+			"bkn.account.id":   "user-1",
+		},
+	})
+
+	headers := BuildTraceHeaders(ctx)
+	require.Equal(t, "req_01JZVALIDREQUESTID000000023", headers[HeaderBKNRequestID])
+	require.Equal(t, "req_01JZVALIDREQUESTID000000023", headers[HeaderLegacyRequestID])
+	require.Equal(t, "00-60616263646566676869707172737475-8081828384858687-01", headers[HeaderTraceparent])
+	require.Equal(t, "bkn.account.type=service", headers[HeaderBaggage])
+}

--- a/adp/vega/vega-backend/server/driveradapters/router.go
+++ b/adp/vega/vega-backend/server/driveradapters/router.go
@@ -91,6 +91,7 @@ func NewRestHandler(appSetting *common.AppSetting, sw *worker.ScheduleWorker) Re
 func (r *restHandler) RegisterPublic(c *gin.Engine) {
 	c.Use(r.AccessLog())
 	c.Use(middleware.TracingMiddleware())
+	c.Use(r.TraceContextMiddleware())
 	c.Use(r.LanguageMiddleware())
 
 	c.GET("/health", r.HealthCheck)
@@ -297,6 +298,15 @@ func (r *restHandler) verifyJsonContentType() gin.HandlerFunc {
 func (r *restHandler) LanguageMiddleware() gin.HandlerFunc {
 	return func(c *gin.Context) {
 		c.Request = c.Request.WithContext(rest.GetLanguageCtx(c))
+		c.Next()
+	}
+}
+
+// TraceContextMiddleware parses OpenBKN phase-one trace context into request context.
+func (r *restHandler) TraceContextMiddleware() gin.HandlerFunc {
+	return func(c *gin.Context) {
+		ctx := common.SetTraceContextToCtx(c.Request.Context(), common.TraceContextFromHeaders(c.GetHeader))
+		c.Request = c.Request.WithContext(ctx)
 		c.Next()
 	}
 }

--- a/adp/vega/vega-backend/server/driveradapters/router_test.go
+++ b/adp/vega/vega-backend/server/driveradapters/router_test.go
@@ -113,3 +113,31 @@ func Test_RestHandler_VerifyJsonContentType(t *testing.T) {
 		assert.Contains(t, w.Body.String(), "VegaBackend.InvalidRequestHeader.ContentType")
 	})
 }
+
+func Test_RestHandler_TraceContextMiddleware(t *testing.T) {
+	restoreGinMode := setGinMode()
+	defer restoreGinMode()
+
+	engine := gin.New()
+	handler := &restHandler{}
+	engine.Use(handler.TraceContextMiddleware())
+	engine.GET("/trace", func(c *gin.Context) {
+		traceCtx, ok := common.GetTraceContextFromCtx(c.Request.Context())
+		require.True(t, ok)
+		assert.Equal(t, "req_01JZVALIDREQUESTID000000024", traceCtx.RequestID)
+		assert.Equal(t, map[string]string{
+			"bkn.account.type": "service",
+			"bkn.runtime.env":  "test",
+		}, traceCtx.Baggage)
+		c.Status(http.StatusNoContent)
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/trace", nil)
+	req.Header.Set(common.HeaderBKNRequestID, "req_01JZVALIDREQUESTID000000024")
+	req.Header.Set(common.HeaderBaggage, "bkn.account.type=service,bkn.account.id=user-1,bkn.runtime.env=test,prompt=raw")
+	w := httptest.NewRecorder()
+
+	engine.ServeHTTP(w, req)
+
+	require.Equal(t, http.StatusNoContent, w.Result().StatusCode)
+}

--- a/adp/vega/vega-backend/server/logics/connector/local/table/mariadb/mariadb_query.go
+++ b/adp/vega/vega-backend/server/logics/connector/local/table/mariadb/mariadb_query.go
@@ -17,6 +17,7 @@ import (
 	"github.com/openbkn-ai/bkn-comm-go/logger"
 
 	"vega-backend/interfaces"
+	"vega-backend/logics/connector/local/table/safelog"
 )
 
 // convertValue converts []byte to string for MariaDB driver compatibility
@@ -230,9 +231,9 @@ func (c *MariaDBConnector) ExecuteQuery(ctx context.Context, resource *interface
 
 	isAggregate := params.Aggregation != nil || len(params.GroupBy) > 0 || params.Having != nil
 	if isAggregate {
-		logger.Debugf("aggregate query: %s, args: %v", query, args)
+		logger.Debugf("aggregate query: %s", safelog.SQLSummary(query, args))
 	} else {
-		logger.Debugf("query: %s, args: %v", query, args)
+		logger.Debugf("query: %s", safelog.SQLSummary(query, args))
 	}
 
 	rows, err := c.db.QueryContext(ctx, query, args...)
@@ -280,7 +281,7 @@ func (c *MariaDBConnector) ExecuteQuery(ctx context.Context, resource *interface
 		if countErr != nil {
 			return nil, fmt.Errorf("failed to build count query: %w", countErr)
 		}
-		logger.Debugf("count query: %s, args: %v", countQuery, countArgs)
+		logger.Debugf("count query: %s", safelog.SQLSummary(countQuery, countArgs))
 		var total int64
 		row := c.db.QueryRowContext(ctx, countQuery, countArgs...)
 		if err := row.Scan(&total); err != nil {

--- a/adp/vega/vega-backend/server/logics/connector/local/table/postgresql/postgresql_query.go
+++ b/adp/vega/vega-backend/server/logics/connector/local/table/postgresql/postgresql_query.go
@@ -16,6 +16,7 @@ import (
 	"github.com/openbkn-ai/bkn-comm-go/logger"
 
 	"vega-backend/interfaces"
+	"vega-backend/logics/connector/local/table/safelog"
 )
 
 func convertRawValue(v any) any {
@@ -217,9 +218,9 @@ func (c *PostgresqlConnector) ExecuteQuery(ctx context.Context, resource *interf
 
 	isAggregate := params.Aggregation != nil || len(params.GroupBy) > 0 || params.Having != nil
 	if isAggregate {
-		logger.Debugf("postgresql aggregate query: %s, args: %v", query, args)
+		logger.Debugf("postgresql aggregate query: %s", safelog.SQLSummary(query, args))
 	} else {
-		logger.Debugf("postgresql query: %s, args: %v", query, args)
+		logger.Debugf("postgresql query: %s", safelog.SQLSummary(query, args))
 	}
 
 	rows, err := c.db.QueryContext(ctx, query, args...)
@@ -265,7 +266,7 @@ func (c *PostgresqlConnector) ExecuteQuery(ctx context.Context, resource *interf
 		if countErr != nil {
 			return nil, fmt.Errorf("failed to build count query: %w", countErr)
 		}
-		logger.Debugf("postgresql count query: %s, args: %v", countQuery, countArgs)
+		logger.Debugf("postgresql count query: %s", safelog.SQLSummary(countQuery, countArgs))
 		var total int64
 		row := c.db.QueryRowContext(ctx, countQuery, countArgs...)
 		if err := row.Scan(&total); err != nil {

--- a/adp/vega/vega-backend/server/logics/connector/local/table/safelog/safe_log.go
+++ b/adp/vega/vega-backend/server/logics/connector/local/table/safelog/safe_log.go
@@ -1,0 +1,12 @@
+package safelog
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+)
+
+func SQLSummary(sql string, args []any) string {
+	hash := sha256.Sum256([]byte(sql))
+	return fmt.Sprintf("query_hash=%s query_length=%d args_count=%d", hex.EncodeToString(hash[:]), len(sql), len(args))
+}

--- a/adp/vega/vega-backend/server/logics/connector/local/table/safelog/safe_log_test.go
+++ b/adp/vega/vega-backend/server/logics/connector/local/table/safelog/safe_log_test.go
@@ -1,0 +1,23 @@
+package safelog
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSQLSummaryDoesNotLeakSQLOrArgs(t *testing.T) {
+	sql := "SELECT email, phone FROM customer WHERE email = ? AND tenant_id = ?"
+	args := []any{"alice@example.com", "tenant-secret"}
+
+	summary := SQLSummary(sql, args)
+
+	assert.Contains(t, summary, "query_hash=")
+	assert.Contains(t, summary, "query_length=")
+	assert.Contains(t, summary, "args_count=2")
+	assert.NotContains(t, summary, sql)
+	assert.NotContains(t, strings.ToLower(summary), "select email")
+	assert.NotContains(t, summary, "alice@example.com")
+	assert.NotContains(t, summary, "tenant-secret")
+}

--- a/adp/vega/vega-backend/server/logics/query/raw_query_service.go
+++ b/adp/vega/vega-backend/server/logics/query/raw_query_service.go
@@ -70,8 +70,8 @@ func (rqs *rawQueryService) Execute(ctx context.Context, req *interfaces.RawQuer
 		}
 	}()
 
-	// 记录请求参数
-	logger.Infof("RawQueryRequest - query_type: %s, resource_type: %s, query: %v", req.QueryType, req.ResourceType, req.Query)
+	// 记录查询摘要，避免完整 SQL / DSL / PII 进入普通日志。
+	logger.Infof("RawQueryRequest - query_type: %s, resource_type: %s, %s", req.QueryType, req.ResourceType, SafeQuerySummary(req.Query))
 
 	// 1. 校验请求
 	if err := rqs.validateRequest(ctx, req); err != nil {
@@ -537,7 +537,7 @@ func ensureCatalogEnabled(ctx context.Context, catalog *interfaces.Catalog) erro
 // replaceResourceIDWithSchemaTable 将resource_id替换为catalog.schema.table格式
 func (rqs *rawQueryService) replaceResourceIDWithSchemaTable(ctx context.Context, sql any, resourceIDs []string, catalog *interfaces.Catalog) (string, error) {
 	replacedSQL := sql.(string)
-	logger.Infof("Before replace - sql: %s, resource_ids: %v", replacedSQL, resourceIDs)
+	logger.Infof("Before replace - %s, resource_ids: %v", SafeQuerySummary(replacedSQL), resourceIDs)
 
 	for _, resourceID := range resourceIDs {
 		// 获取资源信息
@@ -561,14 +561,14 @@ func (rqs *rawQueryService) replaceResourceIDWithSchemaTable(ctx context.Context
 		replacedSQL = regexp.MustCompile(regexp.QuoteMeta(placeholder2)).ReplaceAllString(replacedSQL, resource.SourceIdentifier)
 	}
 
-	logger.Infof("After replace - sql: %s", replacedSQL)
+	logger.Infof("After replace - %s", SafeQuerySummary(replacedSQL))
 	return replacedSQL, nil
 }
 
 // executeSQLWithQueryType 执行SQL查询并记录日志
 func (rqs *rawQueryService) executeSQLWithQueryType(ctx context.Context, catalog *interfaces.Catalog, sql string, queryType string) (*interfaces.RawQueryResponse, error) {
 	// 打印SQL日志，包含查询类型
-	logger.Infof("Executing %s query - sql: %s, catalog: %s", queryType, sql, catalog.Name)
+	logger.Infof("Executing %s query - %s, catalog: %s", queryType, SafeQuerySummary(sql), catalog.Name)
 
 	// 创建connector
 	connector, err := factory.GetFactory().CreateConnectorInstance(ctx, catalog.ConnectorType, catalog.ConnectorCfg)
@@ -778,7 +778,7 @@ func (rqs *rawQueryService) executeStreamQueryNewSession(ctx context.Context, re
 	}
 
 	// 记录query_id和query的对应关系
-	logger.Infof("Created stream query session - query_id: %s, query: %s, resource_ids: %v", session.QueryID, originalSQL, resourceIDs)
+	logger.Infof("Created stream query session - query_id: %s, %s, resource_ids: %v", session.QueryID, SafeQuerySummary(originalSQL), resourceIDs)
 
 	// 7. 执行查询
 	return rqs.executeSQLWithSession(ctx, req, resourceIDs, session)
@@ -806,8 +806,8 @@ func (rqs *rawQueryService) executeStreamQueryWithSession(ctx context.Context, r
 	}
 
 	// 记录使用已有会话时的query_id和query的对应关系
-	logger.Infof("Using existing stream query session - query_id: %s, query: %s, resource_ids: %v, offset: %d",
-		session.QueryID, session.OriginalSQL, session.ResourceIDs, session.Offset)
+	logger.Infof("Using existing stream query session - query_id: %s, %s, resource_ids: %v, offset: %d",
+		session.QueryID, SafeQuerySummary(session.OriginalSQL), session.ResourceIDs, session.Offset)
 
 	// 3. 执行查询
 	return rqs.executeSQLWithSession(ctx, req, resourceIDs, session)
@@ -887,7 +887,7 @@ func (rqs *rawQueryService) executeSQLWithSession(ctx context.Context, req *inte
 	var finalSQL string
 	// 匹配 LIMIT 子句（可能包含 OFFSET）
 	limitRegex := regexp.MustCompile(`(?i)\bLIMIT\s+(\d+)\s*(?:OFFSET\s+(\d+))?\s*$`)
-	logger.Infof("Before LIMIT/OFFSET processing - sql: %s", sqlParseResult.SQL)
+	logger.Infof("Before LIMIT/OFFSET processing - %s", SafeQuerySummary(sqlParseResult.SQL))
 	logger.Infof("LIMIT regex match: %v", limitRegex.MatchString(sqlParseResult.SQL))
 
 	// 计算当前页应该返回的数据量
@@ -909,16 +909,16 @@ func (rqs *rawQueryService) executeSQLWithSession(ctx context.Context, req *inte
 		}
 		// 使用计算后的limitSize替换用户指定的LIMIT值，并添加或替换OFFSET
 		finalSQL = limitRegex.ReplaceAllString(sqlParseResult.SQL, fmt.Sprintf("LIMIT %d OFFSET %d", limitSize, currentSession.Offset))
-		logger.Infof("Replaced existing LIMIT clause - finalSQL: %s", finalSQL)
+		logger.Infof("Replaced existing LIMIT clause - %s", SafeQuerySummary(finalSQL))
 	} else {
 		// 如果没有包含LIMIT子句，使用StreamSize添加它
 		finalSQL = fmt.Sprintf("%s LIMIT %d OFFSET %d", sqlParseResult.SQL, limitSize, currentSession.Offset)
-		logger.Infof("Added new LIMIT clause - finalSQL: %s", finalSQL)
+		logger.Infof("Added new LIMIT clause - %s", SafeQuerySummary(finalSQL))
 	}
 
 	// 记录执行查询的详细信息
-	logger.Infof("Executing stream query - query_id: %s, offset: %d, stream_size: %d, sql: %s",
-		currentSession.QueryID, currentSession.Offset, currentSession.StreamSize, finalSQL)
+	logger.Infof("Executing stream query - query_id: %s, offset: %d, stream_size: %d, %s",
+		currentSession.QueryID, currentSession.Offset, currentSession.StreamSize, SafeQuerySummary(finalSQL))
 
 	// 7. 使用会话中的catalog执行查询
 	result, err := rqs.executeSQLWithQueryType(ctx, currentSession.Catalog, finalSQL, "stream")

--- a/adp/vega/vega-backend/server/logics/query/safe_log.go
+++ b/adp/vega/vega-backend/server/logics/query/safe_log.go
@@ -1,0 +1,23 @@
+package query
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+)
+
+func SafeQuerySummary(query any) string {
+	var queryBytes []byte
+	queryType := "unknown"
+	switch value := query.(type) {
+	case string:
+		queryType = "sql"
+		queryBytes = []byte(value)
+	default:
+		queryType = "structured"
+		queryBytes, _ = json.Marshal(value)
+	}
+	hash := sha256.Sum256(queryBytes)
+	return fmt.Sprintf("query_type=%s query_hash=%s query_length=%d", queryType, hex.EncodeToString(hash[:]), len(queryBytes))
+}

--- a/adp/vega/vega-backend/server/logics/query/safe_log_test.go
+++ b/adp/vega/vega-backend/server/logics/query/safe_log_test.go
@@ -1,0 +1,30 @@
+package query
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestSafeQuerySummaryDoesNotLeakRawSQL(t *testing.T) {
+	rawSQL := "select * from customers where email = 'alice@example.com'"
+
+	summary := SafeQuerySummary(rawSQL)
+
+	require.Contains(t, summary, "query_hash=")
+	require.Contains(t, summary, "query_length=")
+	require.NotContains(t, summary, rawSQL)
+	require.NotContains(t, strings.ToLower(summary), "select * from")
+	require.NotContains(t, summary, "alice@example.com")
+}
+
+func TestSafeQuerySummaryHandlesStructuredQuery(t *testing.T) {
+	summary := SafeQuerySummary(map[string]any{
+		"query": map[string]any{"match": map[string]any{"email": "alice@example.com"}},
+	})
+
+	require.Contains(t, summary, "query_hash=")
+	require.Contains(t, summary, "query_type=structured")
+	require.NotContains(t, summary, "alice@example.com")
+}

--- a/adp/vega/vega-backend/server/logics/resource_data/logic_view/logic_view.go
+++ b/adp/vega/vega-backend/server/logics/resource_data/logic_view/logic_view.go
@@ -363,7 +363,7 @@ func (lvs *logicViewService) executeCompositeViewBySQL(ctx context.Context, view
 	}
 
 	finalSql := builder.Build()
-	logger.Infof("executeCompositeViewBySQL Final SQL: [%s]", finalSql)
+	logger.Infof("executeCompositeViewBySQL Final SQL: [%s]", query.SafeQuerySummary(finalSql))
 
 	if view.IsSingleSource {
 		var resourceType string


### PR DESCRIPTION
## 背景

接入 BKN Trace 阶段一，保证 Vega/data 查询、catalog、query hash 和数据引用路径具备统一可观测记录基线。

## 变更

- 增加 `vega-backend` 模块 `TRACE.md`。
- 增加 `fixtures/bkn-trace/*.json`，覆盖 query hash、传播、timeout forced sampling 和敏感 SQL 负向场景。
- 入口生成/继承 `bkn-request-id`。
- baggage 仅保留 allowlist 字段。
- raw query / logic view SQL 日志使用 `query.SafeQuerySummary` 脱敏摘要。

## 验证

- `go test ./...`
- `python3 /path/to/bkn-docs/docs/foundry/bkn-trace/validation/validate_phase1_fixture.py adp/vega/vega-backend/fixtures/bkn-trace --pretty`

## GWT 覆盖

- GWT-08 工具或依赖失败
- GWT-09 权限拒绝或脱敏
- GWT-10 敏感数据扫描
- GWT-12 强制保留
- GWT-13 字段索引分层

## Known gaps

- 真实 `data.query.started/data.query.completed/data.refs.resolved` runtime event emitter、catalog/row ref 运行证据和 S3 健康指标进入后续。
