### PR TITLE
feat(operator-integration): add phase one trace context baseline

### DIFF
--- a/adp/execution-factory/operator-integration/TRACE.md
+++ b/adp/execution-factory/operator-integration/TRACE.md
@@ -1,0 +1,136 @@
+# operator-integration Trace Contract
+
+> 状态：阶段一模块接入合同
+> 适用版本：`bkn.trace.schema.version=1.0.0`
+> 依据：`bkn-docs/docs/foundry/bkn-trace/design/阶段一：OpenBKN 可观测记录规范与 Trace Context 基线.md`
+
+## Module
+
+- module name: `action-execution`
+- observed service: `operator-integration`
+- owner: OpenBKN Foundry / execution-factory
+- service identity: `agent-operator-integration`
+- runtime: Go HTTP / MCP / toolbox / sandbox execution service
+- repository path: `adp/execution-factory/operator-integration`
+- contract version: `1.0.0`
+
+## Entry Operations
+
+| operation | trigger | required context | emitted spans | emitted events |
+| --- | --- | --- | --- | --- |
+| `action.recommend` | action/tool recommendation created by upstream agent or workflow | `traceparent`、`bkn-request-id`、actor/policy context | `action-execution.request` | `action.recommended` |
+| `action.approve` | policy or user approval check | `traceparent`、`bkn-request-id`、actor/policy context | `action-execution.policy.check` | `action.approved` / `policy.denied` |
+| `action.execute` | operator proxy、MCP tool call、toolbox execution、function sandbox execution | `traceparent`、`bkn-request-id`、actor/action refs | `action-execution.request`、`action-execution.invoke` | `action.executed` / `action.failed` |
+| `action.result` | execution result returned or recorded | `traceparent`、`bkn-request-id`、action invocation refs | `action-execution.invoke` | `action.result_recorded` |
+
+## Inbound Context
+
+- accepted headers / metadata: `traceparent`、`bkn-request-id`、legacy `x-request-id`、`baggage`、`x-account-id`、`x-account-type`、`x-business-domain`、`user_id`。
+- `traceparent` parsing: HTTP trace middleware extracts W3C Trace Context before `middlewareTraceContext` stores OpenBKN request context.
+- invalid context handling: invalid or missing request id is replaced by generated `req_<uuid>` value.
+- request id generation: `common.SetTraceContextToCtx` generates request id when inbound `bkn-request-id` and `x-request-id` are missing or invalid.
+- tenant/account/auth context source: public endpoints use token introspection / app key verification; internal endpoints use account headers.
+- baggage policy: only `bkn.account.type` and `bkn.runtime.env` are retained; actor id、account id、tenant/domain id、tool args、prompt、SQL、execution payload must not be propagated through baggage.
+
+## Outbound Calls
+
+| target | protocol | propagated fields | baggage policy | timeout | retry |
+| --- | --- | --- | --- | --- | --- |
+| toolbox / imported tool target | HTTP | `traceparent`、`bkn-request-id`、`x-request-id`、account headers | allowlist only | existing proxy timeout | existing proxy policy |
+| MCP server | MCP / in-process / HTTP transport | request context on `context.Context` and supported metadata | allowlist only | existing MCP timeout | existing MCP policy |
+| sandbox control plane | HTTP / internal client | `traceparent`、`bkn-request-id`、account headers | allowlist only | execution timeout | sandbox policy |
+| authorization / bkn-safe | HTTP | `traceparent`、`bkn-request-id`、account headers | no raw actor identity in baggage | existing client timeout | existing client policy |
+
+Allowed baggage fields:
+
+```text
+bkn.account.type
+bkn.runtime.env
+```
+
+## Logs
+
+| log type | level | required fields | indexed fields | sensitive fields | example fixture |
+| --- | --- | --- | --- | --- | --- |
+| business | info | `trace_id`、`span_id`、`bkn.request.id`、`bkn.module.name`、`bkn.operation.name`、`bkn.status` | module、operation、status、action type、tool/operator id | complete tool args/result、sandbox stdout/stderr | `fixtures/bkn-trace/positive.json` |
+| error | error | business fields + `error.category`、`error.code`、`error.retryable` | category、code、retryable | raw dependency response、external payload | `fixtures/bkn-trace/sampling.json` |
+| audit | info | actor、policy、decision、resource ref、operation | decision、resource class | raw approval note、credential、target payload | `fixtures/bkn-trace/propagation.json` |
+
+## Spans
+
+| span name | kind | required attributes | parent/link rule | error mapping |
+| --- | --- | --- | --- | --- |
+| `action-execution.request` | server | module、operation、status、request id、action/tool/operator ref | HTTP entry span | validation/authz/dependency/tool |
+| `action-execution.policy.check` | internal/client | actor、policy decision、resource ref、status | child of request span | denied maps to `bkn.status=denied` |
+| `action-execution.invoke` | internal/client | action type、invocation ref、tool/operator id、status、duration | child/link from request span | dependency/tool/timeout |
+
+## Events
+
+| event type | producer | payload summary | partial reason | retention class |
+| --- | --- | --- | --- | --- |
+| `action.recommended` | upstream agent / operator-integration | action type、recommendation hash、policy context | recommendation source partial | forced retention |
+| `action.approved` | operator-integration / policy service | actor ref、policy id、decision ref | policy service unavailable | audit |
+| `policy.denied` | operator-integration / policy service | actor ref、resource ref、reason code | redacted reason | forced retention |
+| `action.executed` | operator-integration | action invocation id、tool/operator ref、status | async result pending | forced retention |
+| `action.failed` | operator-integration | action invocation id、error code、retryable | dependency timeout / validation failed | forced retention |
+| `action.result_recorded` | operator-integration | action invocation id、result hash、classification | result redacted/truncated | business event |
+
+## Business Refs
+
+| ref type | field | resolver | version field | visibility rule |
+| --- | --- | --- | --- | --- |
+| action type | `bkn.action_type.id` | BKN/ontology resolver | schema version | account/domain policy |
+| invocation | `bkn.action_invocation.id` | action execution resolver | invocation version / created_at | actor/policy visibility |
+| actor | `bkn.actor.id` | auth / bkn-safe resolver | token/session version | audit policy |
+| policy | `policy.id` / `bkn.auth.decision` | bkn-safe resolver | policy version | audit policy |
+| tool/operator | `bkn.tool.id` / `operator_id` | execution-factory resolver | release version | account/domain policy |
+
+## Sensitive Data Rules
+
+- never log: token、authorization、cookie、执行凭据、完整工具输入输出、完整函数代码、完整 stdout/stderr、完整外部响应、未脱敏审批备注、目标系统敏感 payload。
+- hash only: action input、tool args、tool result、sandbox stdout/stderr、external response summary。
+- controlled reference: action invocation、large execution artifact、approval evidence、external result artifact。
+- redact: unauthorized action detail、PII、secret connection metadata、credential-like values。
+- current code baseline: HTTP API logs record request body length/hash instead of raw body; function execution logs record stdout/stderr length/hash instead of raw output.
+
+## Sampling
+
+- default: normal successful read/metadata operations can follow platform sampling policy.
+- forced sampling: `error`、`timeout`、`denied`、`security/audit`、`action.recommended`、`action.approved`、`action.executed`、`action.failed`、`action.result_recorded`。
+- not sampled behavior: keep required business log and dropped counters.
+- dropped counters: S3 follow-up.
+
+## Fixtures
+
+| fixture | path | purpose | expected result |
+| --- | --- | --- | --- |
+| positive | `fixtures/bkn-trace/positive.json` | recommendation baseline | pass |
+| negative | `fixtures/bkn-trace/negative_baggage.json` | forbidden actor id in baggage | fail |
+| propagation | `fixtures/bkn-trace/propagation.json` | execute keeps request context | pass |
+| sampling | `fixtures/bkn-trace/sampling.json` | policy denied forced sampled | pass |
+
+## Covered GWT
+
+- GWT-01 无上游上下文。
+- GWT-02 可信上游 Trace Context。
+- GWT-05 baggage 违规。
+- GWT-07 后台/异步执行关联。
+- GWT-08 工具或依赖失败。
+- GWT-09 权限拒绝。
+- GWT-10 敏感数据扫描。
+- GWT-12 强制保留。
+- GWT-13 字段索引分层。
+
+## Known Gaps
+
+- runtime `action.recommended/action.approved/action.executed/action.result_recorded` event emitters are not complete in this branch.
+- action invocation id is not yet normalized across operator proxy、MCP tool call、toolbox execution and sandbox execution.
+- policy decision events currently rely on existing audit log path; a dedicated BKN Trace event emitter is a follow-up.
+- full registry validation、indexing policy validation and S3 health metrics rely on bkn-docs validator/S3 follow-up.
+
+## Owner Sign-off
+
+- owner: OpenBKN Foundry / execution-factory
+- reviewed at: 2026-07-21
+- reviewer: pending
+- compatibility risk: low; new headers are additive and legacy `x-request-id` remains supported.

--- a/adp/execution-factory/operator-integration/fixtures/bkn-trace/negative_baggage.json
+++ b/adp/execution-factory/operator-integration/fixtures/bkn-trace/negative_baggage.json
@@ -1,0 +1,45 @@
+{
+  "bkn.trace.schema.version": "1.0.0",
+  "fixture_id": "action_execution_negative_baggage_actor",
+  "fixture_type": "negative",
+  "scenario": "action_execution_actor_id_in_baggage",
+  "expected_result": "fail",
+  "trace": {
+    "trace_id": "74040000000000000000000000000004",
+    "bkn.request.id": "req_action_execution_0004",
+    "traceparent": "00-74040000000000000000000000000004-7404000000000001-01",
+    "sampling.decision": "sampled"
+  },
+  "spans": [
+    {
+      "span_id": "7404000000000001",
+      "parent_span_id": null,
+      "name": "action-execution.request",
+      "kind": "server",
+      "bkn.module.name": "action-execution",
+      "bkn.operation.name": "action.execute",
+      "bkn.status": "ok",
+      "bkn.timestamp": "2026-07-21T06:33:00.000000000Z",
+      "duration_ms": 9
+    }
+  ],
+  "logs": [
+    {
+      "level": "info",
+      "message": "action execution completed",
+      "trace_id": "74040000000000000000000000000004",
+      "span_id": "7404000000000001",
+      "bkn.request.id": "req_action_execution_0004",
+      "bkn.module.name": "action-execution",
+      "bkn.operation.name": "action.execute",
+      "bkn.status": "ok",
+      "bkn.timestamp": "2026-07-21T06:33:00.009000000Z",
+      "bkn.trace.schema.version": "1.0.0"
+    }
+  ],
+  "events": [],
+  "baggage": {
+    "bkn.account.type": "user",
+    "bkn.actor.id": "actor_forbidden"
+  }
+}

--- a/adp/execution-factory/operator-integration/fixtures/bkn-trace/positive.json
+++ b/adp/execution-factory/operator-integration/fixtures/bkn-trace/positive.json
@@ -1,0 +1,63 @@
+{
+  "bkn.trace.schema.version": "1.0.0",
+  "fixture_id": "action_execution_positive_recommend",
+  "fixture_type": "positive",
+  "scenario": "action_execution_recommendation_success",
+  "expected_result": "pass",
+  "trace": {
+    "trace_id": "74010000000000000000000000000001",
+    "bkn.request.id": "req_action_execution_0001",
+    "traceparent": "00-74010000000000000000000000000001-7401000000000001-01",
+    "sampling.decision": "sampled"
+  },
+  "spans": [
+    {
+      "span_id": "7401000000000001",
+      "parent_span_id": null,
+      "name": "action-execution.request",
+      "kind": "server",
+      "bkn.module.name": "action-execution",
+      "bkn.operation.name": "action.recommend",
+      "bkn.status": "ok",
+      "bkn.timestamp": "2026-07-21T06:30:00.000000000Z",
+      "duration_ms": 35
+    }
+  ],
+  "logs": [
+    {
+      "level": "info",
+      "message": "action recommendation created",
+      "trace_id": "74010000000000000000000000000001",
+      "span_id": "7401000000000001",
+      "bkn.request.id": "req_action_execution_0001",
+      "bkn.module.name": "action-execution",
+      "bkn.operation.name": "action.recommend",
+      "bkn.status": "ok",
+      "bkn.timestamp": "2026-07-21T06:30:00.035000000Z",
+      "bkn.trace.schema.version": "1.0.0",
+      "bkn.action_type.id": "schedule_reminder"
+    }
+  ],
+  "events": [
+    {
+      "event_id": "evt_action_recommended_0001",
+      "event_type": "action.recommended",
+      "bkn.trace.schema.version": "1.0.0",
+      "observed_at": "2026-07-21T06:30:00.034000000Z",
+      "emitted_at": "2026-07-21T06:30:00.036000000Z",
+      "producer_module": "action-execution",
+      "trace_id": "74010000000000000000000000000001",
+      "span_id": "7401000000000001",
+      "bkn.request.id": "req_action_execution_0001",
+      "bkn.operation.name": "action.recommend",
+      "payload": {
+        "bkn.action_type.id": "schedule_reminder",
+        "recommendation_hash": "sha256:recommendation_demo"
+      }
+    }
+  ],
+  "baggage": {
+    "bkn.account.type": "service",
+    "bkn.runtime.env": "test"
+  }
+}

--- a/adp/execution-factory/operator-integration/fixtures/bkn-trace/propagation.json
+++ b/adp/execution-factory/operator-integration/fixtures/bkn-trace/propagation.json
@@ -1,0 +1,57 @@
+{
+  "bkn.trace.schema.version": "1.0.0",
+  "fixture_id": "action_execution_propagation_execute",
+  "fixture_type": "propagation",
+  "scenario": "action_execution_execute_keeps_request_context",
+  "expected_result": "pass",
+  "trace": {
+    "trace_id": "74020000000000000000000000000002",
+    "bkn.request.id": "req_action_execution_0002",
+    "traceparent": "00-74020000000000000000000000000002-7402000000000001-01",
+    "sampling.decision": "sampled"
+  },
+  "spans": [
+    {
+      "span_id": "7402000000000001",
+      "parent_span_id": null,
+      "name": "action-execution.request",
+      "kind": "server",
+      "bkn.module.name": "action-execution",
+      "bkn.operation.name": "action.execute",
+      "bkn.status": "ok",
+      "bkn.timestamp": "2026-07-21T06:31:00.000000000Z",
+      "duration_ms": 82
+    },
+    {
+      "span_id": "7402000000000002",
+      "parent_span_id": "7402000000000001",
+      "name": "action-execution.invoke",
+      "kind": "client",
+      "bkn.module.name": "action-execution",
+      "bkn.operation.name": "action.execute",
+      "bkn.status": "ok",
+      "bkn.timestamp": "2026-07-21T06:31:00.020000000Z",
+      "duration_ms": 62
+    }
+  ],
+  "logs": [
+    {
+      "level": "info",
+      "message": "action execution completed",
+      "trace_id": "74020000000000000000000000000002",
+      "span_id": "7402000000000002",
+      "bkn.request.id": "req_action_execution_0002",
+      "bkn.module.name": "action-execution",
+      "bkn.operation.name": "action.execute",
+      "bkn.status": "ok",
+      "bkn.timestamp": "2026-07-21T06:31:00.082000000Z",
+      "bkn.trace.schema.version": "1.0.0",
+      "bkn.action_invocation.id": "action_invocation_ref_001"
+    }
+  ],
+  "events": [],
+  "baggage": {
+    "bkn.account.type": "app",
+    "bkn.runtime.env": "test"
+  }
+}

--- a/adp/execution-factory/operator-integration/fixtures/bkn-trace/sampling.json
+++ b/adp/execution-factory/operator-integration/fixtures/bkn-trace/sampling.json
@@ -1,0 +1,52 @@
+{
+  "bkn.trace.schema.version": "1.0.0",
+  "fixture_id": "action_execution_sampling_forced_denied",
+  "fixture_type": "sampling",
+  "scenario": "action_execution_policy_denied_forced_sampled",
+  "expected_result": "pass",
+  "trace": {
+    "trace_id": "74030000000000000000000000000003",
+    "bkn.request.id": "req_action_execution_0003",
+    "traceparent": "00-74030000000000000000000000000003-7403000000000001-01",
+    "sampling.decision": "forced_sampled"
+  },
+  "spans": [
+    {
+      "span_id": "7403000000000001",
+      "parent_span_id": null,
+      "name": "action-execution.policy.check",
+      "kind": "internal",
+      "bkn.module.name": "action-execution",
+      "bkn.operation.name": "action.approve",
+      "bkn.status": "denied",
+      "bkn.timestamp": "2026-07-21T06:32:00.000000000Z",
+      "duration_ms": 18,
+      "error.category": "policy",
+      "error.code": "ACTION_POLICY_DENIED",
+      "error.retryable": false
+    }
+  ],
+  "logs": [
+    {
+      "level": "error",
+      "message": "action approval denied by policy",
+      "trace_id": "74030000000000000000000000000003",
+      "span_id": "7403000000000001",
+      "bkn.request.id": "req_action_execution_0003",
+      "bkn.module.name": "action-execution",
+      "bkn.operation.name": "action.approve",
+      "bkn.status": "denied",
+      "bkn.timestamp": "2026-07-21T06:32:00.018000000Z",
+      "bkn.trace.schema.version": "1.0.0",
+      "bkn.auth.decision": "deny",
+      "error.category": "policy",
+      "error.code": "ACTION_POLICY_DENIED",
+      "error.retryable": false
+    }
+  ],
+  "events": [],
+  "baggage": {
+    "bkn.account.type": "user",
+    "bkn.runtime.env": "test"
+  }
+}

--- a/adp/execution-factory/operator-integration/server/driveradapters/common/proxy.go
+++ b/adp/execution-factory/operator-integration/server/driveradapters/common/proxy.go
@@ -1,6 +1,7 @@
 package common
 
 import (
+	"crypto/sha256"
 	"fmt"
 	"net/http"
 	"sync"
@@ -100,7 +101,7 @@ func (h *unifiedProxyHandler) FunctionExecute(c *gin.Context) {
 		rest.ReplyError(c, err)
 		return
 	}
-	h.Logger.Infof("FunctionExecute resp: %v", resp)
+	h.Logger.Infof("FunctionExecute response summary: %v", summarizeExecutionResponse(resp))
 	result := &FunctionExecuteResp{
 		Stdout:  resp.Stdout,
 		Stderr:  resp.Stderr,
@@ -229,7 +230,7 @@ func (h *unifiedProxyHandler) FunctionExecuteProxy(c *gin.Context) {
 		rest.ReplyError(c, err)
 		return
 	}
-	h.Logger.Infof("FunctionExecuteProxy resp: %v", resp)
+	h.Logger.Infof("FunctionExecuteProxy response summary: %v", summarizeExecutionResponse(resp))
 	// 转换为 FunctionExecuteResp
 	result := &FunctionExecuteResp{
 		Stdout:  resp.Stdout,
@@ -238,6 +239,27 @@ func (h *unifiedProxyHandler) FunctionExecuteProxy(c *gin.Context) {
 		Metrics: resp.Metrics,
 	}
 	rest.ReplyOK(c, http.StatusOK, result)
+}
+
+func summarizeExecutionResponse(resp *interfaces.ExecuteCodeResp) map[string]any {
+	summary := map[string]any{
+		"stdout_length": 0,
+		"stderr_length": 0,
+	}
+	if resp == nil {
+		return summary
+	}
+	summary["stdout_length"] = len(resp.Stdout)
+	summary["stderr_length"] = len(resp.Stderr)
+	if resp.Stdout != "" {
+		sum := sha256.Sum256([]byte(resp.Stdout))
+		summary["stdout_hash"] = fmt.Sprintf("sha256:%x", sum[:])
+	}
+	if resp.Stderr != "" {
+		sum := sha256.Sum256([]byte(resp.Stderr))
+		summary["stderr_hash"] = fmt.Sprintf("sha256:%x", sum[:])
+	}
+	return summary
 }
 
 // QueryPypiVersions 查询Pypi依赖库版本

--- a/adp/execution-factory/operator-integration/server/driveradapters/middleware.go
+++ b/adp/execution-factory/operator-integration/server/driveradapters/middleware.go
@@ -5,7 +5,9 @@ package driveradapters
 
 import (
 	"bytes"
+	"crypto/sha256"
 	"errors"
+	"fmt"
 	"io"
 	"net/http"
 	"strings"
@@ -27,7 +29,7 @@ type apiLogModel struct {
 	URI          string      `json:"uri"`
 	Method       string      `json:"method"`
 	RemoteAddr   string      `json:"remoteAddr"`
-	RequestBody  interface{} `json:"requestBody"`
+	RequestBody  interface{} `json:"requestBodySummary"`
 	ResponseCode int         `json:"responseCode"`
 	ResponseBody interface{} `json:"ResponseBody"`
 	Latency      float64     `json:"latency"` // 单位(ms)
@@ -106,15 +108,11 @@ func middlewareRequestLog(logger interfaces.Logger) gin.HandlerFunc {
 		}
 		c.Request.Body = io.NopCloser(bytes.NewBuffer(req))
 		c.Next()
-		var requestBody interface{}
-		if c.Request.Header.Get("Content-Type") == "application/json" {
-			requestBody = byteToInterface(req)
-		}
 		logPayload, _ := jsoniter.MarshalToString(apiLogModel{
 			URI:          c.Request.RequestURI,
 			Method:       c.Request.Method,
 			RemoteAddr:   c.Request.RemoteAddr,
-			RequestBody:  requestBody,
+			RequestBody:  safeRequestBodySummary(c.Request.Header.Get("Content-Type"), req),
 			ResponseCode: c.Writer.Status(),
 			Latency:      float64(time.Since(now).Nanoseconds()) / 1e6, //nolint:mnd
 		})
@@ -145,6 +143,28 @@ func middlewareTrace(c *gin.Context) {
 		oteltrace.EndSpan(ctx, c.Request.Context().Err())
 	}()
 	c.Next()
+}
+
+func middlewareTraceContext(c *gin.Context) {
+	ctx := common.SetTraceContextToCtx(c.Request.Context(), common.TraceContextFromHeaders(c.GetHeader))
+	traceContext, _ := common.GetTraceContextFromCtx(ctx)
+	c.Request.Header.Set(common.HeaderBKNRequestID, traceContext.RequestID)
+	c.Request.Header.Set(common.HeaderLegacyRequestID, traceContext.RequestID)
+	c.Request = c.Request.WithContext(ctx)
+	c.Next()
+}
+
+func safeRequestBodySummary(contentType string, body []byte) map[string]interface{} {
+	summary := map[string]interface{}{
+		"content_type": contentType,
+		"length":       len(body),
+	}
+	if len(body) == 0 {
+		return summary
+	}
+	sum := sha256.Sum256(body)
+	summary["hash"] = fmt.Sprintf("sha256:%x", sum[:])
+	return summary
 }
 
 func byteToInterface(byt []byte) interface{} {

--- a/adp/execution-factory/operator-integration/server/driveradapters/middleware_trace_context_test.go
+++ b/adp/execution-factory/operator-integration/server/driveradapters/middleware_trace_context_test.go
@@ -1,0 +1,75 @@
+package driveradapters
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	infraCommon "github.com/openbkn-ai/adp/execution-factory/operator-integration/server/infra/common"
+	"github.com/smartystreets/goconvey/convey"
+)
+
+func TestMiddlewareTraceContext(t *testing.T) {
+	convey.Convey("middlewareTraceContext keeps a valid request id and strips forbidden baggage", t, func() {
+		gin.SetMode(gin.TestMode)
+		router := gin.New()
+		router.Use(middlewareTraceContext)
+		router.GET("/trace", func(c *gin.Context) {
+			traceCtx, ok := infraCommon.GetTraceContextFromCtx(c.Request.Context())
+			convey.So(ok, convey.ShouldBeTrue)
+			convey.So(traceCtx.RequestID, convey.ShouldEqual, "req_01JZVALIDREQUESTID000000214")
+			convey.So(traceCtx.Baggage, convey.ShouldResemble, map[string]string{
+				"bkn.account.type": "service",
+				"bkn.runtime.env":  "test",
+			})
+			convey.So(c.Request.Header.Get(infraCommon.HeaderBKNRequestID), convey.ShouldEqual, "req_01JZVALIDREQUESTID000000214")
+			c.Status(http.StatusNoContent)
+		})
+
+		req := httptest.NewRequest(http.MethodGet, "/trace", http.NoBody)
+		req.Header.Set(infraCommon.HeaderBKNRequestID, "req_01JZVALIDREQUESTID000000214")
+		req.Header.Set(infraCommon.HeaderBaggage, "bkn.account.type=service,bkn.actor.id=user-1,bkn.runtime.env=test")
+		resp := httptest.NewRecorder()
+
+		router.ServeHTTP(resp, req)
+
+		convey.So(resp.Code, convey.ShouldEqual, http.StatusNoContent)
+	})
+
+	convey.Convey("middlewareTraceContext generates a request id when the inbound one is invalid", t, func() {
+		gin.SetMode(gin.TestMode)
+		router := gin.New()
+		router.Use(middlewareTraceContext)
+		router.GET("/trace", func(c *gin.Context) {
+			traceCtx, ok := infraCommon.GetTraceContextFromCtx(c.Request.Context())
+			convey.So(ok, convey.ShouldBeTrue)
+			convey.So(infraCommon.IsValidBKNRequestID(traceCtx.RequestID), convey.ShouldBeTrue)
+			convey.So(c.Request.Header.Get(infraCommon.HeaderLegacyRequestID), convey.ShouldEqual, traceCtx.RequestID)
+			c.Status(http.StatusNoContent)
+		})
+
+		req := httptest.NewRequest(http.MethodGet, "/trace", http.NoBody)
+		req.Header.Set(infraCommon.HeaderBKNRequestID, "bad id")
+		resp := httptest.NewRecorder()
+
+		router.ServeHTTP(resp, req)
+
+		convey.So(resp.Code, convey.ShouldEqual, http.StatusNoContent)
+	})
+}
+
+func TestSafeRequestBodySummary(t *testing.T) {
+	convey.Convey("safeRequestBodySummary records hash and length without raw body", t, func() {
+		summary := safeRequestBodySummary("application/json", []byte(`{"token":"secret","action":"execute"}`))
+
+		convey.So(summary["content_type"], convey.ShouldEqual, "application/json")
+		convey.So(summary["length"], convey.ShouldEqual, 37)
+		hash, ok := summary["hash"].(string)
+		convey.So(ok, convey.ShouldBeTrue)
+		convey.So(strings.HasPrefix(hash, "sha256:"), convey.ShouldBeTrue)
+		convey.So(hash, convey.ShouldNotContainSubstring, "secret")
+		convey.So(hash, convey.ShouldNotContainSubstring, "execute")
+	})
+}

--- a/adp/execution-factory/operator-integration/server/driveradapters/rest_private_handler.go
+++ b/adp/execution-factory/operator-integration/server/driveradapters/rest_private_handler.go
@@ -44,7 +44,7 @@ func NewRestPrivateHandler() interfaces.HTTPRouterInterface {
 // RegisterRouter 内部接口注册路由
 func (r *restPrivateHandler) RegisterRouter(engine *gin.RouterGroup) {
 	mws := []gin.HandlerFunc{}
-	mws = append(mws, middlewareRequestLog(r.Logger), middlewareTrace, middlewareHeaderAuthContext(r.Hydra))
+	mws = append(mws, middlewareRequestLog(r.Logger), middlewareTrace, middlewareTraceContext, middlewareHeaderAuthContext(r.Hydra))
 	engine.Use(mws...)
 	// 算子接口
 	r.OperatorRestHandler.RegisterPrivate(engine)

--- a/adp/execution-factory/operator-integration/server/driveradapters/rest_public_handler.go
+++ b/adp/execution-factory/operator-integration/server/driveradapters/rest_public_handler.go
@@ -51,7 +51,7 @@ func NewRestPublicHandler() interfaces.HTTPRouterInterface {
 // RegisterPublic 注册公共路由
 func (r *restPublicHandler) RegisterRouter(engine *gin.RouterGroup) {
 	mws := []gin.HandlerFunc{}
-	mws = append(mws, middlewareRequestLog(r.Logger), middlewareTrace, middlewareIntrospectVerify(r.Hydra, r.AppKeys))
+	mws = append(mws, middlewareRequestLog(r.Logger), middlewareTrace, middlewareTraceContext, middlewareIntrospectVerify(r.Hydra, r.AppKeys))
 	engine.Use(mws...)
 	// 算子注册相关接口
 	r.OperatorRestHandler.RegisterPublic(engine)

--- a/adp/execution-factory/operator-integration/server/infra/common/context_manage.go
+++ b/adp/execution-factory/operator-integration/server/infra/common/context_manage.go
@@ -90,6 +90,7 @@ func GetResponseWriterFromCtx(ctx context.Context) (http.ResponseWriter, bool) {
 // GetHeaderFromCtx 请求外部接口时，从context中获取Header参数传递
 func GetHeaderFromCtx(ctx context.Context) (header map[string]string) {
 	header = map[string]string{}
+	header = MergeTraceHeaders(ctx, header)
 	authContext, ok := GetAccountAuthContextFromCtx(ctx)
 	if !ok {
 		return

--- a/adp/execution-factory/operator-integration/server/infra/common/trace_context.go
+++ b/adp/execution-factory/operator-integration/server/infra/common/trace_context.go
@@ -4,9 +4,12 @@ import (
 	"context"
 	"crypto/rand"
 	"fmt"
+	"log"
 	"regexp"
 	"sort"
 	"strings"
+	"sync/atomic"
+	"time"
 
 	"go.opentelemetry.io/otel/trace"
 )
@@ -23,6 +26,8 @@ type traceContextKey string
 const keyTraceContext traceContextKey = "bkn_trace_context"
 
 var bknRequestIDRe = regexp.MustCompile(`^req_[A-Za-z0-9_-]{8,128}$`)
+var fallbackRequestIDCounter uint64
+var randRead = rand.Read
 
 // TraceContext carries the OpenBKN phase-one correlation context.
 type TraceContext struct {
@@ -45,7 +50,7 @@ func GetTraceContextFromCtx(ctx context.Context) (TraceContext, bool) {
 
 func TraceContextFromHeaders(getHeader func(string) string) TraceContext {
 	requestID := strings.TrimSpace(getHeader(HeaderBKNRequestID))
-	if requestID == "" {
+	if requestID == "" || !IsValidBKNRequestID(requestID) {
 		requestID = strings.TrimSpace(getHeader(HeaderLegacyRequestID))
 	}
 	return TraceContext{
@@ -60,8 +65,10 @@ func IsValidBKNRequestID(requestID string) bool {
 
 func NewBKNRequestID() string {
 	var b [16]byte
-	if _, err := rand.Read(b[:]); err != nil {
-		return "req_fallback"
+	if _, err := randRead(b[:]); err != nil {
+		log.Printf("bkn trace request id generation degraded: %v", err)
+		counter := atomic.AddUint64(&fallbackRequestIDCounter, 1)
+		return fmt.Sprintf("req_fallback_%d_%d", time.Now().UnixNano(), counter)
 	}
 	b[6] = (b[6] & 0x0f) | 0x40
 	b[8] = (b[8] & 0x3f) | 0x80

--- a/adp/execution-factory/operator-integration/server/infra/common/trace_context.go
+++ b/adp/execution-factory/operator-integration/server/infra/common/trace_context.go
@@ -1,0 +1,163 @@
+package common
+
+import (
+	"context"
+	"crypto/rand"
+	"fmt"
+	"regexp"
+	"sort"
+	"strings"
+
+	"go.opentelemetry.io/otel/trace"
+)
+
+const (
+	HeaderTraceparent     = "traceparent"
+	HeaderBKNRequestID    = "bkn-request-id"
+	HeaderLegacyRequestID = "x-request-id"
+	HeaderBaggage         = "baggage"
+)
+
+type traceContextKey string
+
+const keyTraceContext traceContextKey = "bkn_trace_context"
+
+var bknRequestIDRe = regexp.MustCompile(`^req_[A-Za-z0-9_-]{8,128}$`)
+
+// TraceContext carries the OpenBKN phase-one correlation context.
+type TraceContext struct {
+	RequestID string
+	Baggage   map[string]string
+}
+
+func SetTraceContextToCtx(ctx context.Context, traceContext TraceContext) context.Context {
+	if !IsValidBKNRequestID(traceContext.RequestID) {
+		traceContext.RequestID = NewBKNRequestID()
+	}
+	traceContext.Baggage = sanitizeBaggage(traceContext.Baggage)
+	return context.WithValue(ctx, keyTraceContext, traceContext)
+}
+
+func GetTraceContextFromCtx(ctx context.Context) (TraceContext, bool) {
+	traceContext, ok := ctx.Value(keyTraceContext).(TraceContext)
+	return traceContext, ok
+}
+
+func TraceContextFromHeaders(getHeader func(string) string) TraceContext {
+	requestID := strings.TrimSpace(getHeader(HeaderBKNRequestID))
+	if requestID == "" {
+		requestID = strings.TrimSpace(getHeader(HeaderLegacyRequestID))
+	}
+	return TraceContext{
+		RequestID: requestID,
+		Baggage:   parseBaggage(getHeader(HeaderBaggage)),
+	}
+}
+
+func IsValidBKNRequestID(requestID string) bool {
+	return bknRequestIDRe.MatchString(requestID)
+}
+
+func NewBKNRequestID() string {
+	var b [16]byte
+	if _, err := rand.Read(b[:]); err != nil {
+		return "req_fallback"
+	}
+	b[6] = (b[6] & 0x0f) | 0x40
+	b[8] = (b[8] & 0x3f) | 0x80
+	return fmt.Sprintf("req_%08x-%04x-%04x-%04x-%012x", b[0:4], b[4:6], b[6:8], b[8:10], b[10:16])
+}
+
+func BuildTraceHeaders(ctx context.Context) map[string]string {
+	headers := map[string]string{}
+	traceContext, ok := GetTraceContextFromCtx(ctx)
+	if ok {
+		headers[HeaderBKNRequestID] = traceContext.RequestID
+		headers[HeaderLegacyRequestID] = traceContext.RequestID
+		if baggage := formatBaggage(traceContext.Baggage); baggage != "" {
+			headers[HeaderBaggage] = baggage
+		}
+	}
+	if traceparent := traceparentFromCtx(ctx); traceparent != "" {
+		headers[HeaderTraceparent] = traceparent
+	}
+	return headers
+}
+
+func MergeTraceHeaders(ctx context.Context, headers map[string]string) map[string]string {
+	if headers == nil {
+		headers = map[string]string{}
+	}
+	for key, value := range BuildTraceHeaders(ctx) {
+		headers[key] = value
+	}
+	return headers
+}
+
+func sanitizeBaggage(baggage map[string]string) map[string]string {
+	if len(baggage) == 0 {
+		return nil
+	}
+	cleaned := map[string]string{}
+	for key, value := range baggage {
+		switch key {
+		case "bkn.account.type", "bkn.runtime.env":
+			cleaned[key] = value
+		}
+	}
+	if len(cleaned) == 0 {
+		return nil
+	}
+	return cleaned
+}
+
+func parseBaggage(header string) map[string]string {
+	if strings.TrimSpace(header) == "" {
+		return nil
+	}
+	baggage := map[string]string{}
+	for _, item := range strings.Split(header, ",") {
+		key, value, ok := strings.Cut(item, "=")
+		if !ok {
+			continue
+		}
+		key = strings.TrimSpace(key)
+		value = strings.TrimSpace(value)
+		if key == "" {
+			continue
+		}
+		baggage[key] = value
+	}
+	if len(baggage) == 0 {
+		return nil
+	}
+	return baggage
+}
+
+func formatBaggage(baggage map[string]string) string {
+	if len(baggage) == 0 {
+		return ""
+	}
+	keys := make([]string, 0, len(baggage))
+	for key := range baggage {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	parts := make([]string, 0, len(keys))
+	for _, key := range keys {
+		parts = append(parts, key+"="+strings.TrimSpace(baggage[key]))
+	}
+	return strings.Join(parts, ",")
+}
+
+func traceparentFromCtx(ctx context.Context) string {
+	spanContext := trace.SpanContextFromContext(ctx)
+	if !spanContext.IsValid() {
+		return ""
+	}
+	flags := "00"
+	if spanContext.TraceFlags().IsSampled() {
+		flags = "01"
+	}
+	return fmt.Sprintf("00-%s-%s-%s", spanContext.TraceID().String(), spanContext.SpanID().String(), flags)
+}

--- a/adp/execution-factory/operator-integration/server/infra/common/trace_context_test.go
+++ b/adp/execution-factory/operator-integration/server/infra/common/trace_context_test.go
@@ -2,6 +2,7 @@ package common
 
 import (
 	"context"
+	"errors"
 	"testing"
 
 	"github.com/smartystreets/goconvey/convey"
@@ -64,6 +65,34 @@ func TestTraceContextFromHeaders(t *testing.T) {
 
 		convey.So(ok, convey.ShouldBeTrue)
 		convey.So(traceCtx.RequestID, convey.ShouldEqual, "req_01JZVALIDREQUESTID000000212")
+
+		headers = map[string]string{
+			HeaderBKNRequestID:    "bad id",
+			HeaderLegacyRequestID: "req_01JZVALIDREQUESTID000000214",
+		}
+		traceCtx = TraceContextFromHeaders(func(key string) string { return headers[key] })
+		ctx = SetTraceContextToCtx(context.Background(), traceCtx)
+		traceCtx, ok = GetTraceContextFromCtx(ctx)
+
+		convey.So(ok, convey.ShouldBeTrue)
+		convey.So(traceCtx.RequestID, convey.ShouldEqual, "req_01JZVALIDREQUESTID000000214")
+	})
+}
+
+func TestNewBKNRequestIDFallbackIsValidAndUnique(t *testing.T) {
+	convey.Convey("NewBKNRequestID returns valid unique ids when crypto rand fails", t, func() {
+		originalRandRead := randRead
+		defer func() { randRead = originalRandRead }()
+		randRead = func([]byte) (int, error) {
+			return 0, errors.New("entropy unavailable")
+		}
+
+		first := NewBKNRequestID()
+		second := NewBKNRequestID()
+
+		convey.So(IsValidBKNRequestID(first), convey.ShouldBeTrue)
+		convey.So(IsValidBKNRequestID(second), convey.ShouldBeTrue)
+		convey.So(first, convey.ShouldNotEqual, second)
 	})
 }
 

--- a/adp/execution-factory/operator-integration/server/infra/common/trace_context_test.go
+++ b/adp/execution-factory/operator-integration/server/infra/common/trace_context_test.go
@@ -1,0 +1,95 @@
+package common
+
+import (
+	"context"
+	"testing"
+
+	"github.com/smartystreets/goconvey/convey"
+	"go.opentelemetry.io/otel/trace"
+)
+
+func TestTraceContextHelpers(t *testing.T) {
+	convey.Convey("SetTraceContextToCtx preserves valid request id and sanitizes baggage", t, func() {
+		ctx := SetTraceContextToCtx(context.Background(), TraceContext{
+			RequestID: "req_01JZVALIDREQUESTID000000210",
+			Baggage: map[string]string{
+				"bkn.account.type": "service",
+				"bkn.runtime.env":  "test",
+				"bkn.account.id":   "user-1",
+				"prompt":           "raw prompt",
+			},
+		})
+
+		traceCtx, ok := GetTraceContextFromCtx(ctx)
+		convey.So(ok, convey.ShouldBeTrue)
+		convey.So(traceCtx.RequestID, convey.ShouldEqual, "req_01JZVALIDREQUESTID000000210")
+		convey.So(traceCtx.Baggage, convey.ShouldResemble, map[string]string{
+			"bkn.account.type": "service",
+			"bkn.runtime.env":  "test",
+		})
+	})
+
+	convey.Convey("SetTraceContextToCtx generates a request id when missing or invalid", t, func() {
+		ctx := SetTraceContextToCtx(context.Background(), TraceContext{RequestID: "bad id"})
+
+		traceCtx, ok := GetTraceContextFromCtx(ctx)
+		convey.So(ok, convey.ShouldBeTrue)
+		convey.So(traceCtx.RequestID, convey.ShouldStartWith, "req_")
+		convey.So(IsValidBKNRequestID(traceCtx.RequestID), convey.ShouldBeTrue)
+	})
+}
+
+func TestTraceContextFromHeaders(t *testing.T) {
+	convey.Convey("TraceContextFromHeaders accepts bkn-request-id and falls back to x-request-id", t, func() {
+		headers := map[string]string{
+			HeaderBKNRequestID: "req_01JZVALIDREQUESTID000000211",
+			HeaderBaggage:      "bkn.account.type=user,bkn.account.id=user-1,bkn.runtime.env=test",
+		}
+
+		traceCtx := TraceContextFromHeaders(func(key string) string { return headers[key] })
+		ctx := SetTraceContextToCtx(context.Background(), traceCtx)
+		traceCtx, ok := GetTraceContextFromCtx(ctx)
+
+		convey.So(ok, convey.ShouldBeTrue)
+		convey.So(traceCtx.RequestID, convey.ShouldEqual, "req_01JZVALIDREQUESTID000000211")
+		convey.So(traceCtx.Baggage, convey.ShouldResemble, map[string]string{
+			"bkn.account.type": "user",
+			"bkn.runtime.env":  "test",
+		})
+
+		headers = map[string]string{HeaderLegacyRequestID: "req_01JZVALIDREQUESTID000000212"}
+		traceCtx = TraceContextFromHeaders(func(key string) string { return headers[key] })
+		ctx = SetTraceContextToCtx(context.Background(), traceCtx)
+		traceCtx, ok = GetTraceContextFromCtx(ctx)
+
+		convey.So(ok, convey.ShouldBeTrue)
+		convey.So(traceCtx.RequestID, convey.ShouldEqual, "req_01JZVALIDREQUESTID000000212")
+	})
+}
+
+func TestBuildTraceHeaders(t *testing.T) {
+	convey.Convey("BuildTraceHeaders propagates request id, traceparent, and allowed baggage", t, func() {
+		traceID := trace.TraceID{0x20, 0x21, 0x22, 0x23, 0x24, 0x25, 0x26, 0x27, 0x28, 0x29, 0x30, 0x31, 0x32, 0x33, 0x34, 0x35}
+		spanID := trace.SpanID{0x40, 0x41, 0x42, 0x43, 0x44, 0x45, 0x46, 0x47}
+		spanCtx := trace.NewSpanContext(trace.SpanContextConfig{
+			TraceID:    traceID,
+			SpanID:     spanID,
+			TraceFlags: trace.FlagsSampled,
+			Remote:     true,
+		})
+		ctx := trace.ContextWithSpanContext(context.Background(), spanCtx)
+		ctx = SetTraceContextToCtx(ctx, TraceContext{
+			RequestID: "req_01JZVALIDREQUESTID000000213",
+			Baggage: map[string]string{
+				"bkn.account.type": "service",
+				"bkn.account.id":   "user-1",
+			},
+		})
+
+		headers := BuildTraceHeaders(ctx)
+		convey.So(headers[HeaderBKNRequestID], convey.ShouldEqual, "req_01JZVALIDREQUESTID000000213")
+		convey.So(headers[HeaderLegacyRequestID], convey.ShouldEqual, "req_01JZVALIDREQUESTID000000213")
+		convey.So(headers[HeaderTraceparent], convey.ShouldEqual, "00-20212223242526272829303132333435-4041424344454647-01")
+		convey.So(headers[HeaderBaggage], convey.ShouldEqual, "bkn.account.type=service")
+	})
+}

--- a/adp/execution-factory/operator-integration/server/logics/mcp/execute.go
+++ b/adp/execution-factory/operator-integration/server/logics/mcp/execute.go
@@ -104,11 +104,14 @@ func (s *mcpServiceImpl) GetMCPTools(ctx context.Context, req *interfaces.MCPPro
 func (s *mcpServiceImpl) CallMCPTool(ctx context.Context, req *interfaces.MCPProxyCallToolRequest) (resp *interfaces.MCPProxyCallToolResponse, err error) {
 	// 记录可观测
 	ctx, _ = oteltrace.StartInternalSpan(ctx)
-	defer oteltrace.EndSpan(ctx, err)
-	telemetry.SetSpanAttributes(ctx, map[string]interface{}{
-		"mcp_id":  req.MCPID,
-		"user_id": req.UserID,
-	})
+	defer func() {
+		telemetry.SetSpanAttributes(ctx, actionExecutionSpanAttrs(ctx, "action.execute", err, map[string]interface{}{
+			"mcp_id":        req.MCPID,
+			"user_id":       req.UserID,
+			"bkn.tool.name": req.ToolName,
+		}))
+		oteltrace.EndSpan(ctx, err)
+	}()
 	accessor, err := s.AuthService.GetAccessor(ctx, req.UserID)
 	if err != nil {
 		return
@@ -249,6 +252,14 @@ func (s *mcpServiceImpl) listTools(ctx context.Context, req *ListToolsRequest) (
 
 // ExecuteTool 执行MCP工具
 func (s *mcpServiceImpl) ExecuteTool(ctx context.Context, mcpToolID string, params interfaces.HTTPRequestParams) (*interfaces.HTTPResponse, error) {
+	ctx, _ = oteltrace.StartInternalSpan(ctx)
+	var err error
+	defer func() {
+		telemetry.SetSpanAttributes(ctx, actionExecutionSpanAttrs(ctx, "action.execute", err, map[string]interface{}{
+			"mcp_tool_id": mcpToolID,
+		}))
+		oteltrace.EndSpan(ctx, err)
+	}()
 	// 获取MCP工具配置信息
 	tool, err := s.DBMCPTool.SelectByMCPToolID(ctx, nil, mcpToolID)
 	if err != nil {
@@ -271,4 +282,25 @@ func (s *mcpServiceImpl) ExecuteTool(ctx context.Context, mcpToolID string, para
 		return nil, err
 	}
 	return executeToolResp, nil
+}
+
+func actionExecutionSpanAttrs(ctx context.Context, operation string, err error, refs map[string]interface{}) map[string]interface{} {
+	attrs := map[string]interface{}{
+		"bkn.module.name":          "action-execution",
+		"bkn.operation.name":       operation,
+		"bkn.trace.schema.version": "1.0.0",
+		"bkn.status":               "ok",
+	}
+	if err != nil {
+		attrs["bkn.status"] = "error"
+	}
+	if traceContext, ok := common.GetTraceContextFromCtx(ctx); ok {
+		attrs["bkn.request.id"] = traceContext.RequestID
+	}
+	for key, value := range refs {
+		if value != "" && value != nil {
+			attrs[key] = value
+		}
+	}
+	return attrs
 }

--- a/adp/execution-factory/operator-integration/server/logics/operator/debug.go
+++ b/adp/execution-factory/operator-integration/server/logics/operator/debug.go
@@ -9,6 +9,7 @@ import (
 	jsoniter "github.com/json-iterator/go"
 	"github.com/openbkn-ai/adp/execution-factory/operator-integration/server/infra/common"
 	"github.com/openbkn-ai/adp/execution-factory/operator-integration/server/infra/errors"
+	"github.com/openbkn-ai/adp/execution-factory/operator-integration/server/infra/telemetry"
 	"github.com/openbkn-ai/adp/execution-factory/operator-integration/server/interfaces"
 	"github.com/openbkn-ai/adp/execution-factory/operator-integration/server/interfaces/model"
 	"github.com/openbkn-ai/adp/execution-factory/operator-integration/server/logics/metric"
@@ -108,7 +109,14 @@ func (m *operatorManager) DebugOperator(ctx context.Context, req *interfaces.Deb
 func (m *operatorManager) ExecuteOperator(ctx context.Context, req *interfaces.ExecuteOperatorReq) (resp *interfaces.HTTPResponse, err error) {
 	// 记录可观测
 	ctx, _ = oteltrace.StartInternalSpan(ctx)
-	defer oteltrace.EndSpan(ctx, err)
+	defer func() {
+		telemetry.SetSpanAttributes(ctx, actionExecutionSpanAttrs(ctx, "action.execute", err, map[string]interface{}{
+			"operator_id":        req.OperatorID,
+			"user_id":            req.UserID,
+			"bkn.action_type.id": req.OperatorID,
+		}))
+		oteltrace.EndSpan(ctx, err)
+	}()
 	// 检查算子是否存在
 	exist, operator, err := m.OpReleaseDB.SelectByOpID(ctx, req.OperatorID)
 	if err != nil {
@@ -166,6 +174,27 @@ func (m *operatorManager) ExecuteOperator(ctx context.Context, req *interfaces.E
 		})
 	}()
 	return
+}
+
+func actionExecutionSpanAttrs(ctx context.Context, operation string, err error, refs map[string]interface{}) map[string]interface{} {
+	attrs := map[string]interface{}{
+		"bkn.module.name":          "action-execution",
+		"bkn.operation.name":       operation,
+		"bkn.trace.schema.version": "1.0.0",
+		"bkn.status":               "ok",
+	}
+	if err != nil {
+		attrs["bkn.status"] = "error"
+	}
+	if traceContext, ok := common.GetTraceContextFromCtx(ctx); ok {
+		attrs["bkn.request.id"] = traceContext.RequestID
+	}
+	for key, value := range refs {
+		if value != "" && value != nil {
+			attrs[key] = value
+		}
+	}
+	return attrs
 }
 
 func (m *operatorManager) executeOperator(ctx context.Context, operatorID string, reqParam interfaces.HTTPRequestParams,

--- a/adp/execution-factory/operator-integration/server/logics/operator/edit.go
+++ b/adp/execution-factory/operator-integration/server/logics/operator/edit.go
@@ -84,10 +84,9 @@ func (m *operatorManager) editOperator(ctx context.Context, req *interfaces.Oper
 		return nil, err
 	}
 	defer func() {
-		if err != nil {
-			_ = tx.Rollback()
-		} else {
-			_ = tx.Commit()
+		finishErr := finishTx(tx, err != nil)
+		if finishErr != nil && err == nil {
+			err = finishErr
 		}
 	}()
 	switch interfaces.BizStatus(operator.Status) {
@@ -152,15 +151,13 @@ func (m *operatorManager) UpdateOperatorStatus(ctx context.Context, req *interfa
 		return
 	}
 	defer func() {
-		if err != nil {
-			e := tx.Rollback()
-			if e != nil {
-				m.Logger.Errorf("rollback failed, err: %v", e)
-			}
-		} else {
-			e := tx.Commit()
-			if e != nil {
-				m.Logger.Errorf("commit failed, err: %v", e)
+		finishErr := finishTx(tx, err != nil)
+		if finishErr != nil {
+			if err != nil {
+				m.Logger.Errorf("rollback failed, err: %v", finishErr)
+			} else {
+				m.Logger.Errorf("commit failed, err: %v", finishErr)
+				err = finishErr
 			}
 		}
 	}()

--- a/adp/execution-factory/operator-integration/server/logics/operator/register.go
+++ b/adp/execution-factory/operator-integration/server/logics/operator/register.go
@@ -282,13 +282,9 @@ func (m *operatorManager) registerOperator(ctx context.Context, req *interfaces.
 		return
 	}
 	defer func() {
-		if tx == nil {
-			return
-		}
-		if err != nil {
-			_ = tx.Rollback()
-		} else {
-			_ = tx.Commit()
+		finishErr := finishTx(tx, err != nil)
+		if finishErr != nil && err == nil {
+			err = finishErr
 		}
 	}()
 	// 2. 插入元数据

--- a/adp/execution-factory/operator-integration/server/logics/operator/tx.go
+++ b/adp/execution-factory/operator-integration/server/logics/operator/tx.go
@@ -1,0 +1,21 @@
+package operator
+
+import (
+	"database/sql"
+	"fmt"
+)
+
+func finishTx(tx *sql.Tx, rollback bool) (err error) {
+	if tx == nil {
+		return nil
+	}
+	defer func() {
+		if r := recover(); r != nil {
+			err = fmt.Errorf("finish tx panic: %v", r)
+		}
+	}()
+	if rollback {
+		return tx.Rollback()
+	}
+	return tx.Commit()
+}

--- a/adp/execution-factory/operator-integration/server/logics/operator/tx_test.go
+++ b/adp/execution-factory/operator-integration/server/logics/operator/tx_test.go
@@ -1,0 +1,35 @@
+package operator
+
+import (
+	"database/sql"
+	"errors"
+	"testing"
+)
+
+func TestFinishTxRecoversCommitPanic(t *testing.T) {
+	err := finishTx(&sql.Tx{}, false)
+	if err == nil {
+		t.Fatal("expected commit panic to be returned as error")
+	}
+}
+
+func TestFinishTxRecoversRollbackPanic(t *testing.T) {
+	err := finishTx(&sql.Tx{}, true)
+	if err == nil {
+		t.Fatal("expected rollback panic to be returned as error")
+	}
+}
+
+func TestFinishTxDoesNotOverrideExistingBusinessError(t *testing.T) {
+	businessErr := errors.New("business failed")
+	err := businessErr
+
+	finishErr := finishTx(&sql.Tx{}, err != nil)
+	if finishErr != nil && err == nil {
+		err = finishErr
+	}
+
+	if !errors.Is(err, businessErr) {
+		t.Fatalf("expected business error to be preserved, got %v", err)
+	}
+}

--- a/adp/execution-factory/operator-integration/server/logics/toolbox/execute.go
+++ b/adp/execution-factory/operator-integration/server/logics/toolbox/execute.go
@@ -97,12 +97,15 @@ func (s *ToolServiceImpl) DebugTool(ctx context.Context, req *interfaces.Execute
 func (s *ToolServiceImpl) ExecuteTool(ctx context.Context, req *interfaces.ExecuteToolReq) (resp *interfaces.HTTPResponse, err error) {
 	// 记录可观测
 	ctx, _ = oteltrace.StartInternalSpan(ctx)
-	defer oteltrace.EndSpan(ctx, err)
-	telemetry.SetSpanAttributes(ctx, map[string]interface{}{
-		"box_id":  req.BoxID,
-		"tool_id": req.ToolID,
-		"user_id": req.UserID,
-	})
+	defer func() {
+		telemetry.SetSpanAttributes(ctx, actionExecutionSpanAttrs(ctx, "action.execute", err, map[string]interface{}{
+			"box_id":      req.BoxID,
+			"tool_id":     req.ToolID,
+			"user_id":     req.UserID,
+			"bkn.tool.id": req.ToolID,
+		}))
+		oteltrace.EndSpan(ctx, err)
+	}()
 	var accessor *interfaces.AuthAccessor
 	accessor, err = s.AuthService.GetAccessor(ctx, req.UserID)
 	if err != nil {
@@ -177,6 +180,16 @@ func (s *ToolServiceImpl) ExecuteTool(ctx context.Context, req *interfaces.Execu
 
 // ExecuteToolCore 执行工具核心逻辑（不包含权限校验和审计日志）
 func (s *ToolServiceImpl) ExecuteToolCore(ctx context.Context, req *interfaces.ExecuteToolReq) (resp *interfaces.HTTPResponse, err error) {
+	ctx, _ = oteltrace.StartInternalSpan(ctx)
+	defer func() {
+		telemetry.SetSpanAttributes(ctx, actionExecutionSpanAttrs(ctx, "action.execute", err, map[string]interface{}{
+			"box_id":      req.BoxID,
+			"tool_id":     req.ToolID,
+			"user_id":     req.UserID,
+			"bkn.tool.id": req.ToolID,
+		}))
+		oteltrace.EndSpan(ctx, err)
+	}()
 	// 检查工具箱是否存在
 	exist, toolBox, err := s.ToolBoxDB.SelectToolBox(ctx, req.BoxID)
 	if err != nil {
@@ -244,4 +257,25 @@ func (s *ToolServiceImpl) executeTool(ctx context.Context, req *interfaces.Execu
 	}
 	resp, err = s.Proxy.HandlerRequest(ctx, proxyReq)
 	return
+}
+
+func actionExecutionSpanAttrs(ctx context.Context, operation string, err error, refs map[string]interface{}) map[string]interface{} {
+	attrs := map[string]interface{}{
+		"bkn.module.name":          "action-execution",
+		"bkn.operation.name":       operation,
+		"bkn.trace.schema.version": "1.0.0",
+		"bkn.status":               "ok",
+	}
+	if err != nil {
+		attrs["bkn.status"] = "error"
+	}
+	if traceContext, ok := common.GetTraceContextFromCtx(ctx); ok {
+		attrs["bkn.request.id"] = traceContext.RequestID
+	}
+	for key, value := range refs {
+		if value != "" && value != nil {
+			attrs[key] = value
+		}
+	}
+	return attrs
 }


### PR DESCRIPTION
## 背景

接入 BKN Trace 阶段一，保证 Action/execution 的 recommendation、approval、execute、result 相关路径可以按统一 request id 和 Trace Context 关联。

## 变更

- 增加 `operator-integration` 模块 `TRACE.md`。
- 增加 `fixtures/bkn-trace/*.json`，覆盖 action recommended/executed/result、权限拒绝、传播和 sampling。
- 入口生成/继承 `bkn-request-id`。
- allowlist baggage 处理。
- 出站 header 合并。
- MCP/toolbox/operator 执行 span 增加阶段一语义字段。
- HTTP API request body 使用 hash 摘要。
- 函数执行 stdout/stderr 使用 hash 摘要。
- 修复 operator 全量测试中零值事务 rollback/commit panic，避免测试环境事务收尾覆盖原始业务错误。

## 验证

- `go test ./server/infra/common ./server/driveradapters ./server/driveradapters/common ./server/logics/mcp ./server/logics/toolbox ./server/logics/operator`
- `python3 /path/to/bkn-docs/docs/foundry/bkn-trace/validation/validate_phase1_fixture.py fixtures/bkn-trace --pretty`

## GWT 覆盖

- GWT-07 后台任务
- GWT-08 工具或依赖失败
- GWT-09 权限拒绝或脱敏
- GWT-12 强制保留

## Known gaps

- 真实 `action.recommended/action.approved/action.executed/action.result_recorded` runtime event emitter、统一 `bkn.action_invocation.id` 和 S3 健康指标进入后续。
