### PR TITLE
ci: 放宽 Claude 评审的工具白名单与轮次上限

### DIFF
--- a/.github/workflows/automation-claude-review.yml
+++ b/.github/workflows/automation-claude-review.yml
@@ -96,8 +96,13 @@ jobs:
             - 不确定的推测标注为「待确认」，不要当成缺陷断言。
             - 没问题就说没问题，不要为了凑数提格式化/命名类的琐碎意见。
 
+          # 48 文件 / 28 commit 这种大 PR，只给 gh pr diff 不够：Claude 需要进
+          # 文件看上下文、比对具体 commit，会伸手 Read/Grep/git diff 等未授权工具而被拒。
+          # 之前一次评审因此连撞 12 次 permission denial、耗尽轮次、评论冻在「进行中」。
+          # 补齐只读检视工具（Read/Grep/Glob/LS + git diff/log/show）并放宽轮次上限。
           claude_args: |
-            --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*)"
+            --max-turns 60
+            --allowedTools "mcp__github_inline_comment__create_inline_comment,Read,Grep,Glob,LS,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(git diff:*),Bash(git log:*),Bash(git show:*)"
 
       - name: Warn when credential missing
         if: env.CLAUDE_CODE_OAUTH_TOKEN == ''


### PR DESCRIPTION
## 问题

大 PR 评审卡在「代码评审进行中」不出最终结论。根因不是卡死：job 实际 `success`、`is_error: false`，但 `permission_denials_count: 12`——12 次工具调用被拒。

Claude 先发「进行中」评论 + 任务清单，随后连撞未授权工具（进文件看上下文、比对 commit 需要的 `Read`/`Grep`/`git diff` 等不在白名单），轮次耗尽后放弃，没写最终评审、没勾清单。SDK 把「拒绝」当正常返回 `success`，job 变绿掩盖失败，评论冻结半路。

## 改动

`automation-claude-review.yml` 的 `claude_args`：

- `--allowedTools` 补只读检视工具：`Read,Grep,Glob,LS` + `Bash(git diff:*),Bash(git log:*),Bash(git show:*)`
- 新增 `--max-turns 60`，避免大 diff（48 文件 / 28 commit）撞轮次墙

保留原有 inline comment MCP 与 `gh pr diff/view/comment`。

🤖 Generated with [Claude Code](https://claude.com/claude-code)