### PR TITLE
ci: Claude 评审模型改用 Opus 4.8

### DIFF
--- a/.github/workflows/automation-claude-review.yml
+++ b/.github/workflows/automation-claude-review.yml
@@ -101,6 +101,7 @@ jobs:
           # 之前一次评审因此连撞 12 次 permission denial、耗尽轮次、评论冻在「进行中」。
           # 补齐只读检视工具（Read/Grep/Glob/LS + git diff/log/show）并放宽轮次上限。
           claude_args: |
+            --model claude-opus-4-8
             --max-turns 60
             --allowedTools "mcp__github_inline_comment__create_inline_comment,Read,Grep,Glob,LS,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(git diff:*),Bash(git log:*),Bash(git show:*)"
 


### PR DESCRIPTION
## 背景

评审 workflow 默认走 `claude-sonnet-5`。大 PR（本仓高频，48 文件级别）的正确性与安全审查更吃模型能力。

## 改动

`automation-claude-review.yml` 的 `claude_args` 增加 `--model claude-opus-4-8`。

- **质量** Opus 4.8 找 bug 的 recall 与 precision 均优于 Sonnet 5，误报更少、遗漏更少；对兼容性/迁移这类本仓高事故来源的判断更稳。
- **成本** 约为 Sonnet 5 的数倍，但评审是低频、单次、价值高的场景，值得。

叠加在 #366（只读工具白名单 + `--max-turns 60`）之上，共同解决大 PR 评审冻结问题。

🤖 Generated with [Claude Code](https://claude.com/claude-code)