### PR TITLE
fix(ontology-query): propagate Vega calls through client span

### DIFF
--- a/adp/bkn/ontology-query/server/drivenadapters/vega_backend/vega_backend_access.go
+++ b/adp/bkn/ontology-query/server/drivenadapters/vega_backend/vega_backend_access.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/bytedance/sonic"
 	"github.com/openbkn-ai/bkn-comm-go/logger"
+	"github.com/openbkn-ai/bkn-comm-go/otel/oteltrace"
 	"github.com/openbkn-ai/bkn-comm-go/rest"
 
 	"ontology-query/common"
@@ -59,6 +60,9 @@ func (v *vegaBackendAccess) buildHeaders(ctx context.Context) map[string]string 
 }
 
 func (v *vegaBackendAccess) QueryResourceData(ctx context.Context, resourceID string, params *interfaces.ResourceDataQueryParams) (*interfaces.DatasetQueryResponse, error) {
+	ctx, span := oteltrace.StartNamedClientSpan(ctx, "QueryResourceData")
+	defer span.End()
+
 	httpURL := fmt.Sprintf("%s/resources/%s/data", v.baseURL, url.PathEscape(resourceID))
 	headers := v.buildHeaders(ctx)
 	headers[interfaces.HTTP_HEADER_METHOD_OVERRIDE] = http.MethodGet

--- a/adp/bkn/ontology-query/server/drivenadapters/vega_backend/vega_backend_access_test.go
+++ b/adp/bkn/ontology-query/server/drivenadapters/vega_backend/vega_backend_access_test.go
@@ -2,10 +2,17 @@ package vega_backend
 
 import (
 	"context"
+	"net/http"
+	"regexp"
+	"strings"
 	"testing"
 
+	rmock "github.com/openbkn-ai/bkn-comm-go/rest/mock"
 	"github.com/smartystreets/goconvey/convey"
+	"go.opentelemetry.io/otel"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
 	"go.opentelemetry.io/otel/trace"
+	"go.uber.org/mock/gomock"
 
 	"ontology-query/common"
 	"ontology-query/interfaces"
@@ -44,5 +51,60 @@ func TestVegaBackendAccessBuildHeadersPropagatesTraceContext(t *testing.T) {
 		convey.So(headers[common.HeaderLegacyRequestID], convey.ShouldEqual, "req_01JZVALIDREQUESTID000000016")
 		convey.So(headers[common.HeaderTraceparent], convey.ShouldEqual, "00-50515253545556575859606162636465-7071727374757677-01")
 		convey.So(headers[common.HeaderBaggage], convey.ShouldEqual, "bkn.account.type=user")
+	})
+}
+
+func TestVegaBackendAccessQueryResourceDataUsesLocalClientSpan(t *testing.T) {
+	convey.Convey("QueryResourceData changes outbound parent span id while preserving trace id", t, func() {
+		originalProvider := otel.GetTracerProvider()
+		tp := sdktrace.NewTracerProvider()
+		otel.SetTracerProvider(tp)
+		defer func() {
+			otel.SetTracerProvider(originalProvider)
+			_ = tp.Shutdown(context.Background())
+		}()
+
+		mockCtrl := gomock.NewController(t)
+		defer mockCtrl.Finish()
+		mockHTTPClient := rmock.NewMockHTTPClient(mockCtrl)
+
+		traceID := trace.TraceID{0x50, 0x51, 0x52, 0x53, 0x54, 0x55, 0x56, 0x57, 0x58, 0x59, 0x60, 0x61, 0x62, 0x63, 0x64, 0x65}
+		upstreamSpanID := trace.SpanID{0x70, 0x71, 0x72, 0x73, 0x74, 0x75, 0x76, 0x77}
+		spanCtx := trace.NewSpanContext(trace.SpanContextConfig{
+			TraceID:    traceID,
+			SpanID:     upstreamSpanID,
+			TraceFlags: trace.FlagsSampled,
+			Remote:     true,
+		})
+		ctx := trace.ContextWithSpanContext(context.Background(), spanCtx)
+		ctx = context.WithValue(ctx, interfaces.ACCOUNT_INFO_KEY, interfaces.AccountInfo{
+			ID:   "user-1",
+			Type: "user",
+		})
+		ctx = common.SetTraceContextToCtx(ctx, common.TraceContext{
+			RequestID: "req_01JZVALIDREQUESTID000000017",
+		})
+
+		var outboundTraceparent string
+		mockHTTPClient.EXPECT().
+			PostNoUnmarshal(gomock.Any(), "http://vega/resources/resource-1/data", gomock.Any(), gomock.Any()).
+			DoAndReturn(func(_ context.Context, _ string, headers map[string]string, _ any) (int, []byte, error) {
+				outboundTraceparent = headers[common.HeaderTraceparent]
+				return http.StatusOK, []byte(`{"entries":[]}`), nil
+			})
+
+		access := &vegaBackendAccess{
+			httpClient: mockHTTPClient,
+			baseURL:    "http://vega",
+		}
+		_, err := access.QueryResourceData(ctx, "resource-1", &interfaces.ResourceDataQueryParams{})
+
+		convey.So(err, convey.ShouldBeNil)
+		convey.So(outboundTraceparent, convey.ShouldNotBeEmpty)
+		match := regexp.MustCompile(`^00-([0-9a-f]{32})-([0-9a-f]{16})-01$`).FindStringSubmatch(outboundTraceparent)
+		convey.So(match, convey.ShouldHaveLength, 3)
+		convey.So(match[1], convey.ShouldEqual, traceID.String())
+		convey.So(match[2], convey.ShouldNotEqual, upstreamSpanID.String())
+		convey.So(strings.Contains(outboundTraceparent, upstreamSpanID.String()), convey.ShouldBeFalse)
 	})
 }


### PR DESCRIPTION
## Summary

Fixes the post-review trace propagation gap found after #362:

- `QueryResourceData` now creates a local ontology-query client span before calling Vega.
- Outbound `traceparent` keeps the inbound trace-id but uses ontology-query's local client span-id, so Vega calls no longer reuse the upstream parent span-id directly.
- Adds a regression test that captures the outgoing Vega headers and asserts same trace-id plus changed span-id.

## Verification

- `go test ./drivenadapters/vega_backend ./common`
- Earlier full branch verification before extracting this follow-up: `I18N_MODE_UT=true go test ./...`
- Earlier phase-one fixture verification before extracting this follow-up: `/Users/leecky/openbkn/bkn-docs/docs/foundry/bkn-trace/validation/run_phase1_fixture_validation.sh`

## Context

The original #362 PR was already merged at `ec6722eb` via squash merge before this fix could be included, so this PR carries only the follow-up fix against current `main`.
