### PR TITLE
fix(vega): harden cursor continuation boundaries

### DIFF
--- a/adp/bkn/bkn-backend/server/logics/action_type/action_type_service.go
+++ b/adp/bkn/bkn-backend/server/logics/action_type/action_type_service.go
@@ -1049,6 +1049,7 @@ func (ats *actionTypeService) SearchActionTypes(ctx context.Context, query *inte
 		if cursor != "" {
 			paging = interfaces.ResourceDataPagingRequest{Cursor: cursor}
 		}
+		isCursorPaging := paging.Mode == "cursor" || paging.Cursor != ""
 		// 调用 dataset 查询
 		params := &interfaces.ResourceDataQueryParams{
 			FilterCondition: filterCondition,
@@ -1142,16 +1143,20 @@ func (ats *actionTypeService) SearchActionTypes(ctx context.Context, query *inte
 			nextCursor = datasetResp.Paging.NextCursor
 		}
 
-		// 如果已经收集到足够的数量或者没有更多数据了，跳出循环
-		if (query.Limit > 0 && len(actionTypes) >= query.Limit) || nextCursor == nil {
+		if query.Limit > 0 && len(actionTypes) >= query.Limit {
 			break
 		}
-
-		if nextCursor != nil {
+		if isCursorPaging {
+			if nextCursor == nil {
+				break
+			}
 			cursor = *nextCursor
-		} else {
-			offset += limit
+			continue
 		}
+		if len(datasetResp.Entries) < limit {
+			break
+		}
+		offset += limit
 	}
 
 	response.Entries = actionTypes

--- a/adp/bkn/bkn-backend/server/logics/action_type/action_type_service.go
+++ b/adp/bkn/bkn-backend/server/logics/action_type/action_type_service.go
@@ -1143,7 +1143,7 @@ func (ats *actionTypeService) SearchActionTypes(ctx context.Context, query *inte
 		}
 
 		// 如果已经收集到足够的数量或者没有更多数据了，跳出循环
-		if (query.Limit > 0 && len(actionTypes) >= query.Limit) || nextCursor == nil && len(datasetResp.Entries) < limit {
+		if (query.Limit > 0 && len(actionTypes) >= query.Limit) || nextCursor == nil {
 			break
 		}
 

--- a/adp/bkn/bkn-backend/server/logics/action_type/action_type_service.go
+++ b/adp/bkn/bkn-backend/server/logics/action_type/action_type_service.go
@@ -45,8 +45,8 @@ var (
 type actionTypeService struct {
 	appSetting *common.AppSetting
 	db         *sql.DB
-	ata        interfaces.ActionTypeAccess
 	aoa        interfaces.AgentOperatorAccess
+	ata        interfaces.ActionTypeAccess
 	cga        interfaces.ConceptGroupAccess
 	mfa        interfaces.ModelFactoryAccess
 	ots        interfaces.ObjectTypeService
@@ -986,6 +986,7 @@ func (ats *actionTypeService) SearchActionTypes(ctx context.Context, query *inte
 			return response, rest.NewHTTPError(ctx, http.StatusInternalServerError,
 				berrors.BknBackend_ActionType_InternalError).WithErrorDetails(errStr)
 		}
+
 		// 概念分组下没有行动类,返回空
 		if len(atIDArr) == 0 {
 			return response, nil
@@ -1033,7 +1034,10 @@ func (ats *actionTypeService) SearchActionTypes(ctx context.Context, query *inte
 	// 4. 迭代查询直到获取足够数量或没有更多数据。
 	actionTypes := []*interfaces.ActionType{}
 	var totalFilteredCount int64 = 0
-	offset := 0
+	sort := query.Sort
+	if len(sort) == 0 {
+		sort = []*interfaces.SortParams{{Field: "id", Direction: "asc"}}
+	}
 	cursor := query.Cursor
 	var nextCursor *string
 	limit := query.Limit
@@ -1042,20 +1046,16 @@ func (ats *actionTypeService) SearchActionTypes(ctx context.Context, query *inte
 	}
 
 	for {
-		paging := interfaces.ResourceDataPagingRequest{Mode: "single", Offset: offset, Limit: limit}
-		if len(query.Sort) > 0 {
-			paging.Mode = "cursor"
-		}
+		paging := interfaces.ResourceDataPagingRequest{Mode: "cursor", Limit: limit}
 		if cursor != "" {
 			paging = interfaces.ResourceDataPagingRequest{Cursor: cursor}
 		}
-		isCursorPaging := paging.Mode == "cursor" || paging.Cursor != ""
 		// 调用 dataset 查询
 		params := &interfaces.ResourceDataQueryParams{
 			FilterCondition: filterCondition,
 			Paging:          paging,
 			NeedTotal:       false,
-			Sort:            query.Sort,
+			Sort:            sort,
 		}
 		datasetResp, err := ats.vba.QueryResourceData(ctx, interfaces.BKN_DATASET_ID, params)
 		if err != nil {
@@ -1146,17 +1146,10 @@ func (ats *actionTypeService) SearchActionTypes(ctx context.Context, query *inte
 		if query.Limit > 0 && len(actionTypes) >= query.Limit {
 			break
 		}
-		if isCursorPaging {
-			if nextCursor == nil {
-				break
-			}
-			cursor = *nextCursor
-			continue
-		}
-		if len(datasetResp.Entries) < limit {
+		if nextCursor == nil {
 			break
 		}
-		offset += limit
+		cursor = *nextCursor
 	}
 
 	response.Entries = actionTypes

--- a/adp/bkn/bkn-backend/server/logics/action_type/action_type_service_test.go
+++ b/adp/bkn/bkn-backend/server/logics/action_type/action_type_service_test.go
@@ -1449,7 +1449,7 @@ func Test_actionTypeService_SearchActionTypes(t *testing.T) {
 			So(result, ShouldNotBeNil)
 		})
 
-		Convey("Single paging continues after a full page when concept-group filtering needs more entries\n", func() {
+		Convey("Default cursor paging continues after a full page when concept-group filtering needs more entries\n", func() {
 			query := &interfaces.ConceptsQuery{
 				KNID:          "kn1",
 				Branch:        interfaces.MAIN_BRANCH,
@@ -1459,18 +1459,20 @@ func Test_actionTypeService_SearchActionTypes(t *testing.T) {
 			ps.EXPECT().CheckPermission(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
 			cga.EXPECT().GetConceptGroupsTotal(gomock.Any(), gomock.Any()).Return(1, nil)
 			cga.EXPECT().GetActionTypeIDsFromConceptGroupRelation(gomock.Any(), gomock.Any()).Return([]string{"keep-1", "keep-2"}, nil)
+			nextCursor := "cursor-1"
 			gomock.InOrder(
 				vba.EXPECT().QueryResourceData(gomock.Any(), interfaces.BKN_DATASET_ID, gomock.Any()).
 					DoAndReturn(func(_ context.Context, _ string, params *interfaces.ResourceDataQueryParams) (*interfaces.DatasetQueryResponse, error) {
-						So(params.Paging, ShouldResemble, interfaces.ResourceDataPagingRequest{Mode: "single", Offset: 0, Limit: 2})
+						So(params.Paging, ShouldResemble, interfaces.ResourceDataPagingRequest{Mode: "cursor", Limit: 2})
+						So(params.Sort, ShouldResemble, []*interfaces.SortParams{{Field: "id", Direction: "asc"}})
 						return &interfaces.DatasetQueryResponse{Entries: []map[string]any{
 							{"id": "skip", "name": "skip"},
 							{"id": "keep-1", "name": "keep-1"},
-						}}, nil
+						}, Paging: &interfaces.ResourceDataPagingResult{NextCursor: &nextCursor}}, nil
 					}),
 				vba.EXPECT().QueryResourceData(gomock.Any(), interfaces.BKN_DATASET_ID, gomock.Any()).
 					DoAndReturn(func(_ context.Context, _ string, params *interfaces.ResourceDataQueryParams) (*interfaces.DatasetQueryResponse, error) {
-						So(params.Paging, ShouldResemble, interfaces.ResourceDataPagingRequest{Mode: "single", Offset: 2, Limit: 2})
+						So(params.Paging, ShouldResemble, interfaces.ResourceDataPagingRequest{Cursor: nextCursor})
 						return &interfaces.DatasetQueryResponse{Entries: []map[string]any{{"id": "keep-2", "name": "keep-2"}}}, nil
 					}),
 			)

--- a/adp/bkn/bkn-backend/server/logics/action_type/action_type_service_test.go
+++ b/adp/bkn/bkn-backend/server/logics/action_type/action_type_service_test.go
@@ -1449,6 +1449,39 @@ func Test_actionTypeService_SearchActionTypes(t *testing.T) {
 			So(result, ShouldNotBeNil)
 		})
 
+		Convey("Single paging continues after a full page when concept-group filtering needs more entries\n", func() {
+			query := &interfaces.ConceptsQuery{
+				KNID:          "kn1",
+				Branch:        interfaces.MAIN_BRANCH,
+				Limit:         2,
+				ConceptGroups: []string{"cg1"},
+			}
+			ps.EXPECT().CheckPermission(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
+			cga.EXPECT().GetConceptGroupsTotal(gomock.Any(), gomock.Any()).Return(1, nil)
+			cga.EXPECT().GetActionTypeIDsFromConceptGroupRelation(gomock.Any(), gomock.Any()).Return([]string{"keep-1", "keep-2"}, nil)
+			gomock.InOrder(
+				vba.EXPECT().QueryResourceData(gomock.Any(), interfaces.BKN_DATASET_ID, gomock.Any()).
+					DoAndReturn(func(_ context.Context, _ string, params *interfaces.ResourceDataQueryParams) (*interfaces.DatasetQueryResponse, error) {
+						So(params.Paging, ShouldResemble, interfaces.ResourceDataPagingRequest{Mode: "single", Offset: 0, Limit: 2})
+						return &interfaces.DatasetQueryResponse{Entries: []map[string]any{
+							{"id": "skip", "name": "skip"},
+							{"id": "keep-1", "name": "keep-1"},
+						}}, nil
+					}),
+				vba.EXPECT().QueryResourceData(gomock.Any(), interfaces.BKN_DATASET_ID, gomock.Any()).
+					DoAndReturn(func(_ context.Context, _ string, params *interfaces.ResourceDataQueryParams) (*interfaces.DatasetQueryResponse, error) {
+						So(params.Paging, ShouldResemble, interfaces.ResourceDataPagingRequest{Mode: "single", Offset: 2, Limit: 2})
+						return &interfaces.DatasetQueryResponse{Entries: []map[string]any{{"id": "keep-2", "name": "keep-2"}}}, nil
+					}),
+			)
+
+			result, err := service.SearchActionTypes(ctx, query)
+			So(err, ShouldBeNil)
+			So(len(result.Entries), ShouldEqual, 2)
+			So(result.Entries[0].ATID, ShouldEqual, "keep-1")
+			So(result.Entries[1].ATID, ShouldEqual, "keep-2")
+		})
+
 		Convey("Failed when concept groups not found\n", func() {
 			query := &interfaces.ConceptsQuery{
 				KNID:          "kn1",

--- a/adp/bkn/bkn-backend/server/logics/metric/metric_service.go
+++ b/adp/bkn/bkn-backend/server/logics/metric/metric_service.go
@@ -721,8 +721,6 @@ func (ms *metricService) SearchMetrics(ctx context.Context, query *interfaces.Co
 				query.KNID, query.Branch, query.ConceptGroups, err)
 			logger.Errorf(errStr)
 			span.SetStatus(codes.Error, errStr)
-			span.End()
-
 			return response, rest.NewHTTPError(ctx, http.StatusInternalServerError,
 				berrors.BknBackend_Metric_InternalError).WithErrorDetails(err.Error())
 		}
@@ -756,7 +754,10 @@ func (ms *metricService) SearchMetrics(ctx context.Context, query *interfaces.Co
 	}
 
 	entries := make([]*interfaces.MetricDefinition, 0)
-	offset := 0
+	sort := query.Sort
+	if len(sort) == 0 {
+		sort = []*interfaces.SortParams{{Field: "id", Direction: "asc"}}
+	}
 	cursor := query.Cursor
 	var nextCursor *string
 	limit := query.Limit
@@ -765,19 +766,15 @@ func (ms *metricService) SearchMetrics(ctx context.Context, query *interfaces.Co
 	}
 
 	for {
-		paging := interfaces.ResourceDataPagingRequest{Mode: "single", Offset: offset, Limit: limit}
-		if len(query.Sort) > 0 {
-			paging.Mode = "cursor"
-		}
+		paging := interfaces.ResourceDataPagingRequest{Mode: "cursor", Limit: limit}
 		if cursor != "" {
 			paging = interfaces.ResourceDataPagingRequest{Cursor: cursor}
 		}
-		isCursorPaging := paging.Mode == "cursor" || paging.Cursor != ""
 		params := &interfaces.ResourceDataQueryParams{
 			FilterCondition: filterCondition,
 			Paging:          paging,
 			NeedTotal:       false,
-			Sort:            query.Sort,
+			Sort:            sort,
 		}
 		datasetResp, err := ms.vba.QueryResourceData(ctx, interfaces.BKN_DATASET_ID, params)
 		if err != nil {
@@ -829,17 +826,10 @@ func (ms *metricService) SearchMetrics(ctx context.Context, query *interfaces.Co
 		if query.Limit > 0 && len(entries) >= query.Limit {
 			break
 		}
-		if isCursorPaging {
-			if nextCursor == nil {
-				break
-			}
-			cursor = *nextCursor
-			continue
-		}
-		if len(datasetResp.Entries) < limit {
+		if nextCursor == nil {
 			break
 		}
-		offset += limit
+		cursor = *nextCursor
 	}
 
 	response.Entries = entries

--- a/adp/bkn/bkn-backend/server/logics/metric/metric_service.go
+++ b/adp/bkn/bkn-backend/server/logics/metric/metric_service.go
@@ -824,10 +824,7 @@ func (ms *metricService) SearchMetrics(ctx context.Context, query *interfaces.Co
 			nextCursor = datasetResp.Paging.NextCursor
 		}
 
-		if (query.Limit > 0 && len(entries) >= query.Limit) || nextCursor == nil && len(datasetResp.Entries) < limit {
-			break
-		}
-		if nextCursor == nil {
+		if (query.Limit > 0 && len(entries) >= query.Limit) || nextCursor == nil {
 			break
 		}
 		cursor = *nextCursor

--- a/adp/bkn/bkn-backend/server/logics/metric/metric_service.go
+++ b/adp/bkn/bkn-backend/server/logics/metric/metric_service.go
@@ -689,7 +689,7 @@ func (ms *metricService) SearchMetrics(ctx context.Context, query *interfaces.Co
 	}
 
 	otIDMap := map[string]bool{}
-	var otIDs []string
+	otIDs := []string{}
 	if len(query.ConceptGroups) > 0 {
 		cgCnt, err := ms.cga.GetConceptGroupsTotal(ctx, interfaces.ConceptGroupsQueryParams{
 			KNID:   query.KNID,
@@ -721,6 +721,7 @@ func (ms *metricService) SearchMetrics(ctx context.Context, query *interfaces.Co
 				query.KNID, query.Branch, query.ConceptGroups, err)
 			logger.Errorf(errStr)
 			span.SetStatus(codes.Error, errStr)
+			span.End()
 
 			return response, rest.NewHTTPError(ctx, http.StatusInternalServerError,
 				berrors.BknBackend_Metric_InternalError).WithErrorDetails(err.Error())
@@ -754,23 +755,24 @@ func (ms *metricService) SearchMetrics(ctx context.Context, query *interfaces.Co
 		}
 	}
 
+	entries := make([]*interfaces.MetricDefinition, 0)
+	offset := 0
+	cursor := query.Cursor
+	var nextCursor *string
 	limit := query.Limit
 	if limit == 0 {
 		limit = interfaces.ConceptQueryLimit
 	}
 
-	entries := make([]*interfaces.MetricDefinition, 0)
-	cursor := query.Cursor
-	var nextCursor *string
-
 	for {
-		paging := interfaces.ResourceDataPagingRequest{Mode: "single", Limit: limit}
+		paging := interfaces.ResourceDataPagingRequest{Mode: "single", Offset: offset, Limit: limit}
 		if len(query.Sort) > 0 {
 			paging.Mode = "cursor"
 		}
 		if cursor != "" {
 			paging = interfaces.ResourceDataPagingRequest{Cursor: cursor}
 		}
+		isCursorPaging := paging.Mode == "cursor" || paging.Cursor != ""
 		params := &interfaces.ResourceDataQueryParams{
 			FilterCondition: filterCondition,
 			Paging:          paging,
@@ -824,10 +826,20 @@ func (ms *metricService) SearchMetrics(ctx context.Context, query *interfaces.Co
 			nextCursor = datasetResp.Paging.NextCursor
 		}
 
-		if (query.Limit > 0 && len(entries) >= query.Limit) || nextCursor == nil {
+		if query.Limit > 0 && len(entries) >= query.Limit {
 			break
 		}
-		cursor = *nextCursor
+		if isCursorPaging {
+			if nextCursor == nil {
+				break
+			}
+			cursor = *nextCursor
+			continue
+		}
+		if len(datasetResp.Entries) < limit {
+			break
+		}
+		offset += limit
 	}
 
 	response.Entries = entries

--- a/adp/bkn/bkn-backend/server/logics/metric/metric_service_test.go
+++ b/adp/bkn/bkn-backend/server/logics/metric/metric_service_test.go
@@ -547,7 +547,7 @@ func Test_metricService_SearchMetrics(t *testing.T) {
 			So(result.Entries[0].ScopeRef, ShouldEqual, "ot_keep")
 		})
 
-		Convey("Single paging continues after a full page when concept-group filtering needs more entries\n", func() {
+		Convey("Default cursor paging continues after a full page when concept-group filtering needs more entries\n", func() {
 			query := &interfaces.ConceptsQuery{
 				KNID:          "kn1",
 				Branch:        interfaces.MAIN_BRANCH,
@@ -557,18 +557,20 @@ func Test_metricService_SearchMetrics(t *testing.T) {
 			ps.EXPECT().CheckPermission(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
 			cga.EXPECT().GetConceptGroupsTotal(gomock.Any(), gomock.Any()).Return(1, nil)
 			cga.EXPECT().GetConceptIDsByConceptGroupIDs(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return([]string{"ot_keep"}, nil)
+			nextCursor := "cursor-1"
 			gomock.InOrder(
 				vba.EXPECT().QueryResourceData(gomock.Any(), interfaces.BKN_DATASET_ID, gomock.Any()).
 					DoAndReturn(func(_ context.Context, _ string, params *interfaces.ResourceDataQueryParams) (*interfaces.DatasetQueryResponse, error) {
-						So(params.Paging, ShouldResemble, interfaces.ResourceDataPagingRequest{Mode: "single", Offset: 0, Limit: 2})
+						So(params.Paging, ShouldResemble, interfaces.ResourceDataPagingRequest{Mode: "cursor", Limit: 2})
+						So(params.Sort, ShouldResemble, []*interfaces.SortParams{{Field: "id", Direction: "asc"}})
 						return &interfaces.DatasetQueryResponse{Entries: []map[string]any{
 							{"id": "skip", "name": "skip", "scope_ref": "ot_other"},
 							{"id": "keep-1", "name": "keep-1", "scope_ref": "ot_keep"},
-						}}, nil
+						}, Paging: &interfaces.ResourceDataPagingResult{NextCursor: &nextCursor}}, nil
 					}),
 				vba.EXPECT().QueryResourceData(gomock.Any(), interfaces.BKN_DATASET_ID, gomock.Any()).
 					DoAndReturn(func(_ context.Context, _ string, params *interfaces.ResourceDataQueryParams) (*interfaces.DatasetQueryResponse, error) {
-						So(params.Paging, ShouldResemble, interfaces.ResourceDataPagingRequest{Mode: "single", Offset: 2, Limit: 2})
+						So(params.Paging, ShouldResemble, interfaces.ResourceDataPagingRequest{Cursor: nextCursor})
 						return &interfaces.DatasetQueryResponse{Entries: []map[string]any{{"id": "keep-2", "name": "keep-2", "scope_ref": "ot_keep"}}}, nil
 					}),
 			)

--- a/adp/bkn/bkn-backend/server/logics/metric/metric_service_test.go
+++ b/adp/bkn/bkn-backend/server/logics/metric/metric_service_test.go
@@ -547,6 +547,39 @@ func Test_metricService_SearchMetrics(t *testing.T) {
 			So(result.Entries[0].ScopeRef, ShouldEqual, "ot_keep")
 		})
 
+		Convey("Single paging continues after a full page when concept-group filtering needs more entries\n", func() {
+			query := &interfaces.ConceptsQuery{
+				KNID:          "kn1",
+				Branch:        interfaces.MAIN_BRANCH,
+				Limit:         2,
+				ConceptGroups: []string{"cg1"},
+			}
+			ps.EXPECT().CheckPermission(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
+			cga.EXPECT().GetConceptGroupsTotal(gomock.Any(), gomock.Any()).Return(1, nil)
+			cga.EXPECT().GetConceptIDsByConceptGroupIDs(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return([]string{"ot_keep"}, nil)
+			gomock.InOrder(
+				vba.EXPECT().QueryResourceData(gomock.Any(), interfaces.BKN_DATASET_ID, gomock.Any()).
+					DoAndReturn(func(_ context.Context, _ string, params *interfaces.ResourceDataQueryParams) (*interfaces.DatasetQueryResponse, error) {
+						So(params.Paging, ShouldResemble, interfaces.ResourceDataPagingRequest{Mode: "single", Offset: 0, Limit: 2})
+						return &interfaces.DatasetQueryResponse{Entries: []map[string]any{
+							{"id": "skip", "name": "skip", "scope_ref": "ot_other"},
+							{"id": "keep-1", "name": "keep-1", "scope_ref": "ot_keep"},
+						}}, nil
+					}),
+				vba.EXPECT().QueryResourceData(gomock.Any(), interfaces.BKN_DATASET_ID, gomock.Any()).
+					DoAndReturn(func(_ context.Context, _ string, params *interfaces.ResourceDataQueryParams) (*interfaces.DatasetQueryResponse, error) {
+						So(params.Paging, ShouldResemble, interfaces.ResourceDataPagingRequest{Mode: "single", Offset: 2, Limit: 2})
+						return &interfaces.DatasetQueryResponse{Entries: []map[string]any{{"id": "keep-2", "name": "keep-2", "scope_ref": "ot_keep"}}}, nil
+					}),
+			)
+
+			result, err := service.SearchMetrics(ctx, query)
+			So(err, ShouldBeNil)
+			So(len(result.Entries), ShouldEqual, 2)
+			So(result.Entries[0].ID, ShouldEqual, "keep-1")
+			So(result.Entries[1].ID, ShouldEqual, "keep-2")
+		})
+
 		Convey("NeedTotal with concept groups uses batched scope_ref total\n", func() {
 			query := &interfaces.ConceptsQuery{
 				KNID:          "kn1",

--- a/adp/bkn/bkn-backend/server/logics/object_type/object_type_service.go
+++ b/adp/bkn/bkn-backend/server/logics/object_type/object_type_service.go
@@ -1506,7 +1506,6 @@ func (ots *objectTypeService) SearchObjectTypes(ctx context.Context,
 	otIDMap := map[string]bool{} // 分组下的对象类id
 	otIDs := []string{}          // 不同组下的对象类可以重叠，所以需要对对象类id的数组去重
 	if len(query.ConceptGroups) > 0 {
-
 		// 校验分组是否都存在，按分组id获取分组
 		cgCnt, err := ots.cga.GetConceptGroupsTotal(ctx, interfaces.ConceptGroupsQueryParams{
 			KNID:   query.KNID,
@@ -1592,6 +1591,7 @@ func (ots *objectTypeService) SearchObjectTypes(ctx context.Context,
 	// 4. 迭代查询直到获取足够数量或没有更多数据。
 	objectTypes := []*interfaces.ObjectType{}
 	var totalFilteredCount int64 = 0
+	offset := 0
 	cursor := query.Cursor
 	var nextCursor *string
 	limit := query.Limit
@@ -1600,13 +1600,14 @@ func (ots *objectTypeService) SearchObjectTypes(ctx context.Context,
 	}
 
 	for {
-		paging := interfaces.ResourceDataPagingRequest{Mode: "single", Limit: limit}
+		paging := interfaces.ResourceDataPagingRequest{Mode: "single", Offset: offset, Limit: limit}
 		if len(query.Sort) > 0 {
 			paging.Mode = "cursor"
 		}
 		if cursor != "" {
 			paging = interfaces.ResourceDataPagingRequest{Cursor: cursor}
 		}
+		isCursorPaging := paging.Mode == "cursor" || paging.Cursor != ""
 		// 调用 dataset 查询
 		params := &interfaces.ResourceDataQueryParams{
 			FilterCondition: filterCondition,
@@ -1698,15 +1699,25 @@ func (ots *objectTypeService) SearchObjectTypes(ctx context.Context,
 			nextCursor = datasetResp.Paging.NextCursor
 		}
 
-		// 如果已经收集到足够的数量或者没有更多数据了，跳出循环
-		if (query.Limit > 0 && len(objectTypes) >= query.Limit) || nextCursor == nil {
+		if query.Limit > 0 && len(objectTypes) >= query.Limit {
 			break
 		}
-		cursor = *nextCursor
+		if isCursorPaging {
+			if nextCursor == nil {
+				break
+			}
+			cursor = *nextCursor
+			continue
+		}
+		if len(datasetResp.Entries) < limit {
+			break
+		}
+		offset += limit
 	}
 
 	response.Entries = objectTypes
 	response.NextCursor = nextCursor
+	span.SetStatus(codes.Ok, "")
 	return response, nil
 }
 

--- a/adp/bkn/bkn-backend/server/logics/object_type/object_type_service.go
+++ b/adp/bkn/bkn-backend/server/logics/object_type/object_type_service.go
@@ -1591,7 +1591,10 @@ func (ots *objectTypeService) SearchObjectTypes(ctx context.Context,
 	// 4. 迭代查询直到获取足够数量或没有更多数据。
 	objectTypes := []*interfaces.ObjectType{}
 	var totalFilteredCount int64 = 0
-	offset := 0
+	sort := query.Sort
+	if len(sort) == 0 {
+		sort = []*interfaces.SortParams{{Field: "id", Direction: "asc"}}
+	}
 	cursor := query.Cursor
 	var nextCursor *string
 	limit := query.Limit
@@ -1600,20 +1603,16 @@ func (ots *objectTypeService) SearchObjectTypes(ctx context.Context,
 	}
 
 	for {
-		paging := interfaces.ResourceDataPagingRequest{Mode: "single", Offset: offset, Limit: limit}
-		if len(query.Sort) > 0 {
-			paging.Mode = "cursor"
-		}
+		paging := interfaces.ResourceDataPagingRequest{Mode: "cursor", Limit: limit}
 		if cursor != "" {
 			paging = interfaces.ResourceDataPagingRequest{Cursor: cursor}
 		}
-		isCursorPaging := paging.Mode == "cursor" || paging.Cursor != ""
 		// 调用 dataset 查询
 		params := &interfaces.ResourceDataQueryParams{
 			FilterCondition: filterCondition,
 			Paging:          paging,
 			NeedTotal:       false,
-			Sort:            query.Sort,
+			Sort:            sort,
 		}
 		datasetResp, err := ots.vba.QueryResourceData(ctx, interfaces.BKN_DATASET_ID, params)
 		if err != nil {
@@ -1702,17 +1701,10 @@ func (ots *objectTypeService) SearchObjectTypes(ctx context.Context,
 		if query.Limit > 0 && len(objectTypes) >= query.Limit {
 			break
 		}
-		if isCursorPaging {
-			if nextCursor == nil {
-				break
-			}
-			cursor = *nextCursor
-			continue
-		}
-		if len(datasetResp.Entries) < limit {
+		if nextCursor == nil {
 			break
 		}
-		offset += limit
+		cursor = *nextCursor
 	}
 
 	response.Entries = objectTypes

--- a/adp/bkn/bkn-backend/server/logics/object_type/object_type_service.go
+++ b/adp/bkn/bkn-backend/server/logics/object_type/object_type_service.go
@@ -1699,10 +1699,7 @@ func (ots *objectTypeService) SearchObjectTypes(ctx context.Context,
 		}
 
 		// 如果已经收集到足够的数量或者没有更多数据了，跳出循环
-		if (query.Limit > 0 && len(objectTypes) >= query.Limit) || nextCursor == nil && len(datasetResp.Entries) < limit {
-			break
-		}
-		if nextCursor == nil {
+		if (query.Limit > 0 && len(objectTypes) >= query.Limit) || nextCursor == nil {
 			break
 		}
 		cursor = *nextCursor

--- a/adp/bkn/bkn-backend/server/logics/object_type/object_type_service_test.go
+++ b/adp/bkn/bkn-backend/server/logics/object_type/object_type_service_test.go
@@ -2239,7 +2239,7 @@ func Test_objectTypeService_SearchObjectTypes(t *testing.T) {
 			So(result.Entries, ShouldNotBeNil)
 		})
 
-		Convey("Single paging continues after a full page when concept-group filtering needs more entries\n", func() {
+		Convey("Default cursor paging continues after a full page when concept-group filtering needs more entries\n", func() {
 			query := &interfaces.ConceptsQuery{
 				KNID:          "kn1",
 				Branch:        interfaces.MAIN_BRANCH,
@@ -2249,18 +2249,20 @@ func Test_objectTypeService_SearchObjectTypes(t *testing.T) {
 			ps.EXPECT().CheckPermission(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
 			cga.EXPECT().GetConceptGroupsTotal(gomock.Any(), gomock.Any()).Return(1, nil)
 			cga.EXPECT().GetConceptIDsByConceptGroupIDs(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return([]string{"keep-1", "keep-2"}, nil)
+			nextCursor := "cursor-1"
 			gomock.InOrder(
 				vba.EXPECT().QueryResourceData(gomock.Any(), interfaces.BKN_DATASET_ID, gomock.Any()).
 					DoAndReturn(func(_ context.Context, _ string, params *interfaces.ResourceDataQueryParams) (*interfaces.DatasetQueryResponse, error) {
-						So(params.Paging, ShouldResemble, interfaces.ResourceDataPagingRequest{Mode: "single", Offset: 0, Limit: 2})
+						So(params.Paging, ShouldResemble, interfaces.ResourceDataPagingRequest{Mode: "cursor", Limit: 2})
+						So(params.Sort, ShouldResemble, []*interfaces.SortParams{{Field: "id", Direction: "asc"}})
 						return &interfaces.DatasetQueryResponse{Entries: []map[string]any{
 							{"id": "skip", "name": "skip"},
 							{"id": "keep-1", "name": "keep-1"},
-						}}, nil
+						}, Paging: &interfaces.ResourceDataPagingResult{NextCursor: &nextCursor}}, nil
 					}),
 				vba.EXPECT().QueryResourceData(gomock.Any(), interfaces.BKN_DATASET_ID, gomock.Any()).
 					DoAndReturn(func(_ context.Context, _ string, params *interfaces.ResourceDataQueryParams) (*interfaces.DatasetQueryResponse, error) {
-						So(params.Paging, ShouldResemble, interfaces.ResourceDataPagingRequest{Mode: "single", Offset: 2, Limit: 2})
+						So(params.Paging, ShouldResemble, interfaces.ResourceDataPagingRequest{Cursor: nextCursor})
 						return &interfaces.DatasetQueryResponse{Entries: []map[string]any{{"id": "keep-2", "name": "keep-2"}}}, nil
 					}),
 			)

--- a/adp/bkn/bkn-backend/server/logics/object_type/object_type_service_test.go
+++ b/adp/bkn/bkn-backend/server/logics/object_type/object_type_service_test.go
@@ -2239,6 +2239,39 @@ func Test_objectTypeService_SearchObjectTypes(t *testing.T) {
 			So(result.Entries, ShouldNotBeNil)
 		})
 
+		Convey("Single paging continues after a full page when concept-group filtering needs more entries\n", func() {
+			query := &interfaces.ConceptsQuery{
+				KNID:          "kn1",
+				Branch:        interfaces.MAIN_BRANCH,
+				Limit:         2,
+				ConceptGroups: []string{"cg1"},
+			}
+			ps.EXPECT().CheckPermission(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
+			cga.EXPECT().GetConceptGroupsTotal(gomock.Any(), gomock.Any()).Return(1, nil)
+			cga.EXPECT().GetConceptIDsByConceptGroupIDs(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return([]string{"keep-1", "keep-2"}, nil)
+			gomock.InOrder(
+				vba.EXPECT().QueryResourceData(gomock.Any(), interfaces.BKN_DATASET_ID, gomock.Any()).
+					DoAndReturn(func(_ context.Context, _ string, params *interfaces.ResourceDataQueryParams) (*interfaces.DatasetQueryResponse, error) {
+						So(params.Paging, ShouldResemble, interfaces.ResourceDataPagingRequest{Mode: "single", Offset: 0, Limit: 2})
+						return &interfaces.DatasetQueryResponse{Entries: []map[string]any{
+							{"id": "skip", "name": "skip"},
+							{"id": "keep-1", "name": "keep-1"},
+						}}, nil
+					}),
+				vba.EXPECT().QueryResourceData(gomock.Any(), interfaces.BKN_DATASET_ID, gomock.Any()).
+					DoAndReturn(func(_ context.Context, _ string, params *interfaces.ResourceDataQueryParams) (*interfaces.DatasetQueryResponse, error) {
+						So(params.Paging, ShouldResemble, interfaces.ResourceDataPagingRequest{Mode: "single", Offset: 2, Limit: 2})
+						return &interfaces.DatasetQueryResponse{Entries: []map[string]any{{"id": "keep-2", "name": "keep-2"}}}, nil
+					}),
+			)
+
+			result, err := service.SearchObjectTypes(ctx, query)
+			So(err, ShouldBeNil)
+			So(len(result.Entries), ShouldEqual, 2)
+			So(result.Entries[0].OTID, ShouldEqual, "keep-1")
+			So(result.Entries[1].OTID, ShouldEqual, "keep-2")
+		})
+
 		Convey("Failed when concept groups not found\n", func() {
 			query := &interfaces.ConceptsQuery{
 				KNID:          "kn1",

--- a/adp/bkn/bkn-backend/server/logics/relation_type/relation_type_service.go
+++ b/adp/bkn/bkn-backend/server/logics/relation_type/relation_type_service.go
@@ -1011,6 +1011,7 @@ func (rts *relationTypeService) SearchRelationTypes(ctx context.Context,
 		if cursor != "" {
 			paging = interfaces.ResourceDataPagingRequest{Cursor: cursor}
 		}
+		isCursorPaging := paging.Mode == "cursor" || paging.Cursor != ""
 		// 调用 dataset 查询
 		params := &interfaces.ResourceDataQueryParams{
 			FilterCondition: filterCondition,
@@ -1073,16 +1074,20 @@ func (rts *relationTypeService) SearchRelationTypes(ctx context.Context,
 			nextCursor = datasetResp.Paging.NextCursor
 		}
 
-		// 如果已经收集到足够的数量或者没有更多数据了，跳出循环
-		if (query.Limit > 0 && len(relationTypes) >= query.Limit) || nextCursor == nil {
+		if query.Limit > 0 && len(relationTypes) >= query.Limit {
 			break
 		}
-
-		if nextCursor != nil {
+		if isCursorPaging {
+			if nextCursor == nil {
+				break
+			}
 			cursor = *nextCursor
-		} else {
-			offset += limit
+			continue
 		}
+		if len(datasetResp.Entries) < limit {
+			break
+		}
+		offset += limit
 	}
 
 	response.Entries = relationTypes

--- a/adp/bkn/bkn-backend/server/logics/relation_type/relation_type_service.go
+++ b/adp/bkn/bkn-backend/server/logics/relation_type/relation_type_service.go
@@ -995,7 +995,10 @@ func (rts *relationTypeService) SearchRelationTypes(ctx context.Context,
 	// 4. 迭代查询直到获取足够数量或没有更多数据
 	relationTypes := []*interfaces.RelationType{}
 	var totalFilteredCount int64 = 0
-	offset := 0
+	sort := query.Sort
+	if len(sort) == 0 {
+		sort = []*interfaces.SortParams{{Field: "id", Direction: "asc"}}
+	}
 	cursor := query.Cursor
 	var nextCursor *string
 	limit := query.Limit
@@ -1004,20 +1007,16 @@ func (rts *relationTypeService) SearchRelationTypes(ctx context.Context,
 	}
 
 	for {
-		paging := interfaces.ResourceDataPagingRequest{Mode: "single", Offset: offset, Limit: limit}
-		if len(query.Sort) > 0 {
-			paging.Mode = "cursor"
-		}
+		paging := interfaces.ResourceDataPagingRequest{Mode: "cursor", Limit: limit}
 		if cursor != "" {
 			paging = interfaces.ResourceDataPagingRequest{Cursor: cursor}
 		}
-		isCursorPaging := paging.Mode == "cursor" || paging.Cursor != ""
 		// 调用 dataset 查询
 		params := &interfaces.ResourceDataQueryParams{
 			FilterCondition: filterCondition,
 			Paging:          paging,
 			NeedTotal:       true,
-			Sort:            query.Sort,
+			Sort:            sort,
 		}
 		datasetResp, err := rts.vba.QueryResourceData(ctx, interfaces.BKN_DATASET_ID, params)
 		if err != nil {
@@ -1077,17 +1076,10 @@ func (rts *relationTypeService) SearchRelationTypes(ctx context.Context,
 		if query.Limit > 0 && len(relationTypes) >= query.Limit {
 			break
 		}
-		if isCursorPaging {
-			if nextCursor == nil {
-				break
-			}
-			cursor = *nextCursor
-			continue
-		}
-		if len(datasetResp.Entries) < limit {
+		if nextCursor == nil {
 			break
 		}
-		offset += limit
+		cursor = *nextCursor
 	}
 
 	response.Entries = relationTypes

--- a/adp/bkn/bkn-backend/server/logics/relation_type/relation_type_service.go
+++ b/adp/bkn/bkn-backend/server/logics/relation_type/relation_type_service.go
@@ -1074,7 +1074,7 @@ func (rts *relationTypeService) SearchRelationTypes(ctx context.Context,
 		}
 
 		// 如果已经收集到足够的数量或者没有更多数据了，跳出循环
-		if (query.Limit > 0 && len(relationTypes) >= query.Limit) || nextCursor == nil && len(datasetResp.Entries) < limit {
+		if (query.Limit > 0 && len(relationTypes) >= query.Limit) || nextCursor == nil {
 			break
 		}
 

--- a/adp/bkn/bkn-backend/server/logics/relation_type/relation_type_service_test.go
+++ b/adp/bkn/bkn-backend/server/logics/relation_type/relation_type_service_test.go
@@ -1671,7 +1671,7 @@ func Test_relationTypeService_SearchRelationTypes(t *testing.T) {
 			So(result.Entries, ShouldNotBeNil)
 		})
 
-		Convey("Single paging continues after a full page when concept-group filtering needs more entries\n", func() {
+		Convey("Default cursor paging continues after a full page when concept-group filtering needs more entries\n", func() {
 			query := &interfaces.ConceptsQuery{
 				KNID:          "kn1",
 				Branch:        interfaces.MAIN_BRANCH,
@@ -1681,18 +1681,20 @@ func Test_relationTypeService_SearchRelationTypes(t *testing.T) {
 			ps.EXPECT().CheckPermission(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
 			cga.EXPECT().GetConceptGroupsTotal(gomock.Any(), gomock.Any()).Return(1, nil)
 			cga.EXPECT().GetRelationTypeIDsFromConceptGroupRelation(gomock.Any(), gomock.Any()).Return([]string{"keep-1", "keep-2"}, nil)
+			nextCursor := "cursor-1"
 			gomock.InOrder(
 				vba.EXPECT().QueryResourceData(gomock.Any(), interfaces.BKN_DATASET_ID, gomock.Any()).
 					DoAndReturn(func(_ context.Context, _ string, params *interfaces.ResourceDataQueryParams) (*interfaces.DatasetQueryResponse, error) {
-						So(params.Paging, ShouldResemble, interfaces.ResourceDataPagingRequest{Mode: "single", Offset: 0, Limit: 2})
+						So(params.Paging, ShouldResemble, interfaces.ResourceDataPagingRequest{Mode: "cursor", Limit: 2})
+						So(params.Sort, ShouldResemble, []*interfaces.SortParams{{Field: "id", Direction: "asc"}})
 						return &interfaces.DatasetQueryResponse{Entries: []map[string]any{
 							{"id": "skip", "name": "skip"},
 							{"id": "keep-1", "name": "keep-1"},
-						}}, nil
+						}, Paging: &interfaces.ResourceDataPagingResult{NextCursor: &nextCursor}}, nil
 					}),
 				vba.EXPECT().QueryResourceData(gomock.Any(), interfaces.BKN_DATASET_ID, gomock.Any()).
 					DoAndReturn(func(_ context.Context, _ string, params *interfaces.ResourceDataQueryParams) (*interfaces.DatasetQueryResponse, error) {
-						So(params.Paging, ShouldResemble, interfaces.ResourceDataPagingRequest{Mode: "single", Offset: 2, Limit: 2})
+						So(params.Paging, ShouldResemble, interfaces.ResourceDataPagingRequest{Cursor: nextCursor})
 						return &interfaces.DatasetQueryResponse{Entries: []map[string]any{{"id": "keep-2", "name": "keep-2"}}}, nil
 					}),
 			)

--- a/adp/bkn/bkn-backend/server/logics/relation_type/relation_type_service_test.go
+++ b/adp/bkn/bkn-backend/server/logics/relation_type/relation_type_service_test.go
@@ -1671,6 +1671,39 @@ func Test_relationTypeService_SearchRelationTypes(t *testing.T) {
 			So(result.Entries, ShouldNotBeNil)
 		})
 
+		Convey("Single paging continues after a full page when concept-group filtering needs more entries\n", func() {
+			query := &interfaces.ConceptsQuery{
+				KNID:          "kn1",
+				Branch:        interfaces.MAIN_BRANCH,
+				Limit:         2,
+				ConceptGroups: []string{"cg1"},
+			}
+			ps.EXPECT().CheckPermission(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
+			cga.EXPECT().GetConceptGroupsTotal(gomock.Any(), gomock.Any()).Return(1, nil)
+			cga.EXPECT().GetRelationTypeIDsFromConceptGroupRelation(gomock.Any(), gomock.Any()).Return([]string{"keep-1", "keep-2"}, nil)
+			gomock.InOrder(
+				vba.EXPECT().QueryResourceData(gomock.Any(), interfaces.BKN_DATASET_ID, gomock.Any()).
+					DoAndReturn(func(_ context.Context, _ string, params *interfaces.ResourceDataQueryParams) (*interfaces.DatasetQueryResponse, error) {
+						So(params.Paging, ShouldResemble, interfaces.ResourceDataPagingRequest{Mode: "single", Offset: 0, Limit: 2})
+						return &interfaces.DatasetQueryResponse{Entries: []map[string]any{
+							{"id": "skip", "name": "skip"},
+							{"id": "keep-1", "name": "keep-1"},
+						}}, nil
+					}),
+				vba.EXPECT().QueryResourceData(gomock.Any(), interfaces.BKN_DATASET_ID, gomock.Any()).
+					DoAndReturn(func(_ context.Context, _ string, params *interfaces.ResourceDataQueryParams) (*interfaces.DatasetQueryResponse, error) {
+						So(params.Paging, ShouldResemble, interfaces.ResourceDataPagingRequest{Mode: "single", Offset: 2, Limit: 2})
+						return &interfaces.DatasetQueryResponse{Entries: []map[string]any{{"id": "keep-2", "name": "keep-2"}}}, nil
+					}),
+			)
+
+			result, err := service.SearchRelationTypes(ctx, query)
+			So(err, ShouldBeNil)
+			So(len(result.Entries), ShouldEqual, 2)
+			So(result.Entries[0].RTID, ShouldEqual, "keep-1")
+			So(result.Entries[1].RTID, ShouldEqual, "keep-2")
+		})
+
 		Convey("Failed when concept groups not found\n", func() {
 			query := &interfaces.ConceptsQuery{
 				KNID:          "kn1",

--- a/adp/bkn/bkn-backend/server/logics/risk_type/risk_type_service.go
+++ b/adp/bkn/bkn-backend/server/logics/risk_type/risk_type_service.go
@@ -587,6 +587,7 @@ func (rts *riskTypeService) SearchRiskTypes(ctx context.Context, query *interfac
 		if cursor != "" {
 			paging = interfaces.ResourceDataPagingRequest{Cursor: cursor}
 		}
+		isCursorPaging := paging.Mode == "cursor" || paging.Cursor != ""
 		params := &interfaces.ResourceDataQueryParams{
 			FilterCondition: filterCondition,
 			Paging:          paging,
@@ -640,15 +641,20 @@ func (rts *riskTypeService) SearchRiskTypes(ctx context.Context, query *interfac
 			nextCursor = datasetResp.Paging.NextCursor
 		}
 
-		if (query.Limit > 0 && len(riskTypes) >= query.Limit) || nextCursor == nil {
+		if query.Limit > 0 && len(riskTypes) >= query.Limit {
 			break
 		}
-
-		if nextCursor != nil {
+		if isCursorPaging {
+			if nextCursor == nil {
+				break
+			}
 			cursor = *nextCursor
-		} else {
-			offset += limit
+			continue
 		}
+		if len(datasetResp.Entries) < limit {
+			break
+		}
+		offset += limit
 	}
 
 	response.Entries = riskTypes

--- a/adp/bkn/bkn-backend/server/logics/risk_type/risk_type_service.go
+++ b/adp/bkn/bkn-backend/server/logics/risk_type/risk_type_service.go
@@ -571,7 +571,10 @@ func (rts *riskTypeService) SearchRiskTypes(ctx context.Context, query *interfac
 	}
 
 	riskTypes := []*interfaces.RiskType{}
-	offset := 0
+	sort := query.Sort
+	if len(sort) == 0 {
+		sort = []*interfaces.SortParams{{Field: "id", Direction: "asc"}}
+	}
 	cursor := query.Cursor
 	var nextCursor *string
 	limit := query.Limit
@@ -580,19 +583,15 @@ func (rts *riskTypeService) SearchRiskTypes(ctx context.Context, query *interfac
 	}
 
 	for {
-		paging := interfaces.ResourceDataPagingRequest{Mode: "single", Offset: offset, Limit: limit}
-		if len(query.Sort) > 0 {
-			paging.Mode = "cursor"
-		}
+		paging := interfaces.ResourceDataPagingRequest{Mode: "cursor", Limit: limit}
 		if cursor != "" {
 			paging = interfaces.ResourceDataPagingRequest{Cursor: cursor}
 		}
-		isCursorPaging := paging.Mode == "cursor" || paging.Cursor != ""
 		params := &interfaces.ResourceDataQueryParams{
 			FilterCondition: filterCondition,
 			Paging:          paging,
 			NeedTotal:       false,
-			Sort:            query.Sort,
+			Sort:            sort,
 		}
 		datasetResp, err := rts.vba.QueryResourceData(ctx, interfaces.BKN_DATASET_ID, params)
 		if err != nil {
@@ -644,17 +643,10 @@ func (rts *riskTypeService) SearchRiskTypes(ctx context.Context, query *interfac
 		if query.Limit > 0 && len(riskTypes) >= query.Limit {
 			break
 		}
-		if isCursorPaging {
-			if nextCursor == nil {
-				break
-			}
-			cursor = *nextCursor
-			continue
-		}
-		if len(datasetResp.Entries) < limit {
+		if nextCursor == nil {
 			break
 		}
-		offset += limit
+		cursor = *nextCursor
 	}
 
 	response.Entries = riskTypes

--- a/adp/bkn/bkn-backend/server/logics/risk_type/risk_type_service.go
+++ b/adp/bkn/bkn-backend/server/logics/risk_type/risk_type_service.go
@@ -640,7 +640,7 @@ func (rts *riskTypeService) SearchRiskTypes(ctx context.Context, query *interfac
 			nextCursor = datasetResp.Paging.NextCursor
 		}
 
-		if (query.Limit > 0 && len(riskTypes) >= query.Limit) || nextCursor == nil && len(datasetResp.Entries) < limit {
+		if (query.Limit > 0 && len(riskTypes) >= query.Limit) || nextCursor == nil {
 			break
 		}
 

--- a/adp/bkn/bkn-backend/server/logics/risk_type/risk_type_service_test.go
+++ b/adp/bkn/bkn-backend/server/logics/risk_type/risk_type_service_test.go
@@ -27,8 +27,8 @@ import (
 	bmock "bkn-backend/interfaces/mock"
 )
 
-func TestRiskTypeServiceSearchRiskTypesContinuesOffsetPaging(t *testing.T) {
-	Convey("SearchRiskTypes continues single paging after a full page\n", t, func() {
+func TestRiskTypeServiceSearchRiskTypesContinuesDefaultCursorPaging(t *testing.T) {
+	Convey("SearchRiskTypes continues default cursor paging after a full page\n", t, func() {
 		ctx := context.Background()
 		mockCtrl := gomock.NewController(t)
 		defer mockCtrl.Finish()
@@ -51,15 +51,17 @@ func TestRiskTypeServiceSearchRiskTypesContinuesOffsetPaging(t *testing.T) {
 		}
 
 		ps.EXPECT().CheckPermission(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
+		nextCursor := "cursor-1"
 		gomock.InOrder(
 			vba.EXPECT().QueryResourceData(gomock.Any(), interfaces.BKN_DATASET_ID, gomock.Any()).
 				DoAndReturn(func(_ context.Context, _ string, params *interfaces.ResourceDataQueryParams) (*interfaces.DatasetQueryResponse, error) {
-					So(params.Paging, ShouldResemble, interfaces.ResourceDataPagingRequest{Mode: "single", Offset: 0, Limit: interfaces.ConceptQueryLimit})
-					return &interfaces.DatasetQueryResponse{Entries: fullPage}, nil
+					So(params.Paging, ShouldResemble, interfaces.ResourceDataPagingRequest{Mode: "cursor", Limit: interfaces.ConceptQueryLimit})
+					So(params.Sort, ShouldResemble, []*interfaces.SortParams{{Field: "id", Direction: "asc"}})
+					return &interfaces.DatasetQueryResponse{Entries: fullPage, Paging: &interfaces.ResourceDataPagingResult{NextCursor: &nextCursor}}, nil
 				}),
 			vba.EXPECT().QueryResourceData(gomock.Any(), interfaces.BKN_DATASET_ID, gomock.Any()).
 				DoAndReturn(func(_ context.Context, _ string, params *interfaces.ResourceDataQueryParams) (*interfaces.DatasetQueryResponse, error) {
-					So(params.Paging, ShouldResemble, interfaces.ResourceDataPagingRequest{Mode: "single", Offset: interfaces.ConceptQueryLimit, Limit: interfaces.ConceptQueryLimit})
+					So(params.Paging, ShouldResemble, interfaces.ResourceDataPagingRequest{Cursor: nextCursor})
 					return &interfaces.DatasetQueryResponse{Entries: []map[string]any{{"id": "risk-last", "name": "risk-last"}}}, nil
 				}),
 		)

--- a/adp/bkn/bkn-backend/server/logics/risk_type/risk_type_service_test.go
+++ b/adp/bkn/bkn-backend/server/logics/risk_type/risk_type_service_test.go
@@ -1,0 +1,72 @@
+// Copyright openbkn.ai
+// Copyright The kweaver.ai Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package risk_type
+
+import (
+	"context"
+	"testing"
+
+	. "github.com/smartystreets/goconvey/convey"
+	"go.uber.org/mock/gomock"
+
+	"bkn-backend/common"
+	"bkn-backend/interfaces"
+	bmock "bkn-backend/interfaces/mock"
+)
+
+func TestRiskTypeServiceSearchRiskTypesContinuesOffsetPaging(t *testing.T) {
+	Convey("SearchRiskTypes continues single paging after a full page\n", t, func() {
+		ctx := context.Background()
+		mockCtrl := gomock.NewController(t)
+		defer mockCtrl.Finish()
+
+		vba := bmock.NewMockVegaBackendAccess(mockCtrl)
+		ps := bmock.NewMockPermissionService(mockCtrl)
+		service := &riskTypeService{
+			appSetting: &common.AppSetting{},
+			vba:        vba,
+			ps:         ps,
+		}
+		query := &interfaces.ConceptsQuery{
+			KNID:   "kn1",
+			Branch: interfaces.MAIN_BRANCH,
+		}
+
+		fullPage := make([]map[string]any, interfaces.ConceptQueryLimit)
+		for i := range fullPage {
+			fullPage[i] = map[string]any{"id": "risk", "name": "risk"}
+		}
+
+		ps.EXPECT().CheckPermission(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
+		gomock.InOrder(
+			vba.EXPECT().QueryResourceData(gomock.Any(), interfaces.BKN_DATASET_ID, gomock.Any()).
+				DoAndReturn(func(_ context.Context, _ string, params *interfaces.ResourceDataQueryParams) (*interfaces.DatasetQueryResponse, error) {
+					So(params.Paging, ShouldResemble, interfaces.ResourceDataPagingRequest{Mode: "single", Offset: 0, Limit: interfaces.ConceptQueryLimit})
+					return &interfaces.DatasetQueryResponse{Entries: fullPage}, nil
+				}),
+			vba.EXPECT().QueryResourceData(gomock.Any(), interfaces.BKN_DATASET_ID, gomock.Any()).
+				DoAndReturn(func(_ context.Context, _ string, params *interfaces.ResourceDataQueryParams) (*interfaces.DatasetQueryResponse, error) {
+					So(params.Paging, ShouldResemble, interfaces.ResourceDataPagingRequest{Mode: "single", Offset: interfaces.ConceptQueryLimit, Limit: interfaces.ConceptQueryLimit})
+					return &interfaces.DatasetQueryResponse{Entries: []map[string]any{{"id": "risk-last", "name": "risk-last"}}}, nil
+				}),
+		)
+
+		result, err := service.SearchRiskTypes(ctx, query)
+		So(err, ShouldBeNil)
+		So(len(result.Entries), ShouldEqual, interfaces.ConceptQueryLimit+1)
+		So(result.Entries[len(result.Entries)-1].RTID, ShouldEqual, "risk-last")
+	})
+}

--- a/adp/bkn/bkn-backend/server/worker/concept_syncer.go
+++ b/adp/bkn/bkn-backend/server/worker/concept_syncer.go
@@ -970,6 +970,28 @@ func (cs *ConceptSyncer) insertDatasetDataForMetrics(ctx context.Context, metric
 	return nil
 }
 
+const conceptSyncPageLimit = 10000
+
+func (cs *ConceptSyncer) queryAllDatasetEntries(ctx context.Context, filterCondition map[string]any) ([]map[string]any, error) {
+	params := &interfaces.ResourceDataQueryParams{
+		FilterCondition: filterCondition,
+		Sort:            []*interfaces.SortParams{{Field: "id", Direction: "asc"}},
+		Paging:          interfaces.ResourceDataPagingRequest{Mode: "cursor", Limit: conceptSyncPageLimit},
+	}
+	entries := make([]map[string]any, 0)
+	for {
+		response, err := cs.vba.QueryResourceData(ctx, interfaces.BKN_DATASET_ID, params)
+		if err != nil {
+			return nil, err
+		}
+		entries = append(entries, response.Entries...)
+		if response.Paging == nil || response.Paging.NextCursor == nil {
+			return entries, nil
+		}
+		params = &interfaces.ResourceDataQueryParams{Paging: interfaces.ResourceDataPagingRequest{Cursor: *response.Paging.NextCursor}}
+	}
+}
+
 func (cs *ConceptSyncer) getAllKNsFromDataset(ctx context.Context) (map[string]*interfaces.KN, error) {
 	filterCondition := map[string]any{
 		"field":      "module_type",
@@ -978,18 +1000,13 @@ func (cs *ConceptSyncer) getAllKNsFromDataset(ctx context.Context) (map[string]*
 		"value_from": "const",
 	}
 
-	params := &interfaces.ResourceDataQueryParams{
-		FilterCondition: filterCondition,
-		Paging:          interfaces.ResourceDataPagingRequest{Mode: "single", Limit: 10000},
-		NeedTotal:       false,
-	}
-	response, err := cs.vba.QueryResourceData(ctx, interfaces.BKN_DATASET_ID, params)
+	entries, err := cs.queryAllDatasetEntries(ctx, filterCondition)
 	if err != nil {
 		return map[string]*interfaces.KN{}, err
 	}
 
 	kns := map[string]*interfaces.KN{}
-	for _, entry := range response.Entries {
+	for _, entry := range entries {
 		kn := interfaces.KN{}
 		err := mapstructure.Decode(entry, &kn)
 		if err != nil {
@@ -1029,18 +1046,13 @@ func (cs *ConceptSyncer) getAllObjectTypesFromDatasetByKnID(ctx context.Context,
 		},
 	}
 
-	params := &interfaces.ResourceDataQueryParams{
-		FilterCondition: filterCondition,
-		Paging:          interfaces.ResourceDataPagingRequest{Mode: "single", Limit: 10000},
-		NeedTotal:       false,
-	}
-	response, err := cs.vba.QueryResourceData(ctx, interfaces.BKN_DATASET_ID, params)
+	entries, err := cs.queryAllDatasetEntries(ctx, filterCondition)
 	if err != nil {
 		return map[string]*interfaces.ObjectType{}, err
 	}
 
 	objectTypes := map[string]*interfaces.ObjectType{}
-	for _, entry := range response.Entries {
+	for _, entry := range entries {
 		// Deserialize logic_properties[].parameters from JSON string
 		if logicProps, ok := entry["logic_properties"].([]any); ok {
 			for _, lp := range logicProps {
@@ -1098,18 +1110,13 @@ func (cs *ConceptSyncer) getAllRelationTypesFromDatasetByKnID(ctx context.Contex
 		},
 	}
 
-	params := &interfaces.ResourceDataQueryParams{
-		FilterCondition: filterCondition,
-		Paging:          interfaces.ResourceDataPagingRequest{Mode: "single", Limit: 10000},
-		NeedTotal:       false,
-	}
-	response, err := cs.vba.QueryResourceData(ctx, interfaces.BKN_DATASET_ID, params)
+	entries, err := cs.queryAllDatasetEntries(ctx, filterCondition)
 	if err != nil {
 		return map[string]*interfaces.RelationType{}, err
 	}
 
 	relationTypes := map[string]*interfaces.RelationType{}
-	for _, entry := range response.Entries {
+	for _, entry := range entries {
 		relationType := interfaces.RelationType{}
 		err = mapstructure.Decode(entry, &relationType)
 		if err != nil {
@@ -1149,18 +1156,13 @@ func (cs *ConceptSyncer) getAllActionTypesFromDatasetByKnID(ctx context.Context,
 		},
 	}
 
-	params := &interfaces.ResourceDataQueryParams{
-		FilterCondition: filterCondition,
-		Paging:          interfaces.ResourceDataPagingRequest{Mode: "single", Limit: 10000},
-		NeedTotal:       false,
-	}
-	response, err := cs.vba.QueryResourceData(ctx, interfaces.BKN_DATASET_ID, params)
+	entries, err := cs.queryAllDatasetEntries(ctx, filterCondition)
 	if err != nil {
 		return map[string]*interfaces.ActionType{}, err
 	}
 
 	actionTypes := map[string]*interfaces.ActionType{}
-	for _, entry := range response.Entries {
+	for _, entry := range entries {
 		// Deserialize condition from JSON string
 		if condStr, exists := entry["condition"]; exists {
 			if condStrStr, ok := condStr.(string); ok && condStrStr != "" {
@@ -1226,18 +1228,13 @@ func (cs *ConceptSyncer) getAllRiskTypesFromDatasetByKnID(ctx context.Context,
 		},
 	}
 
-	params := &interfaces.ResourceDataQueryParams{
-		FilterCondition: filterCondition,
-		Paging:          interfaces.ResourceDataPagingRequest{Mode: "single", Limit: 10000},
-		NeedTotal:       false,
-	}
-	response, err := cs.vba.QueryResourceData(ctx, interfaces.BKN_DATASET_ID, params)
+	entries, err := cs.queryAllDatasetEntries(ctx, filterCondition)
 	if err != nil {
 		return map[string]*interfaces.RiskType{}, err
 	}
 
 	riskTypes := map[string]*interfaces.RiskType{}
-	for _, entry := range response.Entries {
+	for _, entry := range entries {
 		riskType := interfaces.RiskType{}
 		err := mapstructure.Decode(entry, &riskType)
 		if err != nil {
@@ -1277,18 +1274,13 @@ func (cs *ConceptSyncer) getAllConceptGroupsFromDatasetByKnID(ctx context.Contex
 		},
 	}
 
-	params := &interfaces.ResourceDataQueryParams{
-		FilterCondition: filterCondition,
-		Paging:          interfaces.ResourceDataPagingRequest{Mode: "single", Limit: 10000},
-		NeedTotal:       false,
-	}
-	response, err := cs.vba.QueryResourceData(ctx, interfaces.BKN_DATASET_ID, params)
+	entries, err := cs.queryAllDatasetEntries(ctx, filterCondition)
 	if err != nil {
 		return map[string]*interfaces.ConceptGroup{}, err
 	}
 
 	conceptGroups := map[string]*interfaces.ConceptGroup{}
-	for _, entry := range response.Entries {
+	for _, entry := range entries {
 		conceptGroup := interfaces.ConceptGroup{}
 		err := mapstructure.Decode(entry, &conceptGroup)
 		if err != nil {
@@ -1328,18 +1320,13 @@ func (cs *ConceptSyncer) getAllMetricsFromDatasetByKnID(ctx context.Context,
 		},
 	}
 
-	params := &interfaces.ResourceDataQueryParams{
-		FilterCondition: filterCondition,
-		Paging:          interfaces.ResourceDataPagingRequest{Mode: "single", Limit: 10000},
-		NeedTotal:       false,
-	}
-	response, err := cs.vba.QueryResourceData(ctx, interfaces.BKN_DATASET_ID, params)
+	entries, err := cs.queryAllDatasetEntries(ctx, filterCondition)
 	if err != nil {
 		return map[string]*interfaces.MetricDefinition{}, err
 	}
 
 	metrics := map[string]*interfaces.MetricDefinition{}
-	for _, entry := range response.Entries {
+	for _, entry := range entries {
 		md := interfaces.MetricDefinition{}
 		if err := mapstructure.WeakDecode(entry, &md); err != nil {
 			return map[string]*interfaces.MetricDefinition{}, err

--- a/adp/bkn/bkn-backend/server/worker/concept_syncer_test.go
+++ b/adp/bkn/bkn-backend/server/worker/concept_syncer_test.go
@@ -35,6 +35,40 @@ func TestNewConceptSyncer(t *testing.T) {
 	})
 }
 
+func TestConceptSyncerQueryAllDatasetEntriesUsesCursor(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	vba := bmock.NewMockVegaBackendAccess(ctrl)
+	cs := &ConceptSyncer{vba: vba}
+	nextCursor := "cursor-1"
+	filter := map[string]any{"field": "module_type"}
+
+	gomock.InOrder(
+		vba.EXPECT().QueryResourceData(gomock.Any(), interfaces.BKN_DATASET_ID, gomock.Any()).
+			DoAndReturn(func(_ context.Context, _ string, params *interfaces.ResourceDataQueryParams) (*interfaces.DatasetQueryResponse, error) {
+				if params.Paging.Mode != "cursor" || params.Paging.Limit != conceptSyncPageLimit || len(params.Sort) != 1 || params.Sort[0].Field != "id" {
+					t.Fatalf("unexpected initial paging request: %#v", params)
+				}
+				return &interfaces.DatasetQueryResponse{Entries: []map[string]any{{"id": "1"}}, Paging: &interfaces.ResourceDataPagingResult{NextCursor: &nextCursor}}, nil
+			}),
+		vba.EXPECT().QueryResourceData(gomock.Any(), interfaces.BKN_DATASET_ID, gomock.Any()).
+			DoAndReturn(func(_ context.Context, _ string, params *interfaces.ResourceDataQueryParams) (*interfaces.DatasetQueryResponse, error) {
+				if params.Paging.Cursor != nextCursor {
+					t.Fatalf("unexpected continuation request: %#v", params)
+				}
+				return &interfaces.DatasetQueryResponse{Entries: []map[string]any{{"id": "2"}}}, nil
+			}),
+	)
+
+	entries, err := cs.queryAllDatasetEntries(context.Background(), filter)
+	if err != nil {
+		t.Fatalf("queryAllDatasetEntries() error = %v", err)
+	}
+	if len(entries) != 2 {
+		t.Fatalf("queryAllDatasetEntries() returned %d entries, want 2", len(entries))
+	}
+}
+
 func TestConceptSyncer_handleKNs(t *testing.T) {
 	Convey("Test handleKNs", t, func() {
 		ctx := context.Background()

--- a/adp/vega/vega-backend/server/logics/query/raw_query_service.go
+++ b/adp/vega/vega-backend/server/logics/query/raw_query_service.go
@@ -429,6 +429,10 @@ func bindCursorResource(session *interfaces.CursorSession, req *interfaces.RawQu
 func validateCursorResourceBinding(ctx context.Context, session *interfaces.CursorSession,
 	req *interfaces.RawQueryRequest) error {
 	if session.ResourceDataResourceID == "" {
+		if req != nil && req.ResourceDataResourceID != "" {
+			return rest.NewHTTPError(ctx, http.StatusConflict, verrors.VegaBackend_Query_CursorResourceChanged).
+				WithErrorDetails("raw query cursor cannot be used for resource data paging")
+		}
 		return nil
 	}
 	if req == nil || req.ResourceDataResourceID != session.ResourceDataResourceID {

--- a/adp/vega/vega-backend/server/logics/query/raw_query_service_test.go
+++ b/adp/vega/vega-backend/server/logics/query/raw_query_service_test.go
@@ -254,13 +254,19 @@ func TestValidateCursorResourceBinding(t *testing.T) {
 	previousManager := rawQueryCursorSessions
 	rawQueryCursorSessions = newCursorSessionManager(10)
 	t.Cleanup(func() { rawQueryCursorSessions = previousManager })
+	rawSession, err := rawQueryCursorSessions.create("account-1", "catalog-1", nil, "SELECT 1", 1, 60, 60)
+	require.NoError(t, err)
+	err = validateCursorResourceBinding(context.Background(), rawSession, &interfaces.RawQueryRequest{ResourceDataResourceID: "logic-1"})
+	var httpErr *rest.HTTPError
+	require.ErrorAs(t, err, &httpErr)
+	assert.Equal(t, http.StatusConflict, httpErr.HTTPCode)
+	require.NoError(t, validateCursorResourceBinding(context.Background(), rawSession, &interfaces.RawQueryRequest{}))
 
 	session, err := rawQueryCursorSessions.create("account-1", "catalog-1", nil, "SELECT 1", 1, 60, 60)
 	require.NoError(t, err)
 	bindCursorResource(session, &interfaces.RawQueryRequest{ResourceDataResourceID: "logic-1", ResourceDataUpdateTime: 10})
 
 	err = validateCursorResourceBinding(context.Background(), session, &interfaces.RawQueryRequest{ResourceDataResourceID: "logic-2", ResourceDataUpdateTime: 10})
-	var httpErr *rest.HTTPError
 	require.ErrorAs(t, err, &httpErr)
 	assert.Equal(t, http.StatusConflict, httpErr.HTTPCode)
 	_, exists := rawQueryCursorSessions.acquire(session.ID)


### PR DESCRIPTION
# Pull Request

## What Changed

- [x] Reject use of an unbound Raw Query cursor through a Resource Data / Logic View endpoint.
- [x] End BKN concept-search pagination immediately when `next_cursor` is absent, preventing reuse of a closed cursor.
- [x] Replace Concept Sync single-page Dataset reads with stable `id ASC` cursor pagination, removing the 10,000-entry truncation limit.
- [x] Add regression coverage for the Dataset cursor loop and Raw Query cursor binding boundary.

---

## Why

- Related Issue: Follow-up to #275
- Background: The initial read-only Raw Query and cursor contract is already on `main`. This follow-up closes low-priority continuation edge cases found during review.

---

## How

- Resource Data delegation supplies an outer Resource binding; a cursor without that binding is now rejected rather than being treated as a Resource Data cursor.
- BKN search loops regard an absent `next_cursor` as terminal for every cursor backend.
- Concept Sync requests pages in cursor mode with deterministic `id ASC` ordering and follows the opaque cursor until completion.
- Breaking changes (API, config, database, etc.): None. No schema or configuration migration is required.

---

## Testing

- [x] Unit tests passed locally
- [ ] Integration tests passed locally
- [ ] Verified in test environment

Test notes:

- `go test ./logics/query -count=1`
- `go test -c -o /tmp/bkn-worker.test ./worker`
- BKN-wide compile errors were checked with `go test -run '^$' ./...`; package test execution remains subject to the existing locale working-directory setup.
- `git diff --check`

---

## Risk & Rollback

- Potential risks: Concept Sync now creates a bounded server-side cursor while reading more than one page; an expired cursor causes that sync run to fail and be retried by the existing job flow.
- Rollback plan: Revert this single commit. No persisted cursor state or database schema needs rollback.

---

## Additional Notes

- Base branch: `main` at the merged Issue #275 implementation.
