### PR TITLE
fix(vega-backend): check rows iteration errors

### DIFF
--- a/.github/workflows/ci-adp-vega.yml
+++ b/.github/workflows/ci-adp-vega.yml
@@ -26,3 +26,7 @@ jobs:
         with:
           go-version-file: adp/vega/vega-backend/server/go.mod
       - run: go build ./...
+      - uses: golangci/golangci-lint-action@v7
+        with:
+          version: v2.6.2
+          working-directory: adp/vega/vega-backend/server

--- a/adp/vega/vega-backend/server/.golangci.yml
+++ b/adp/vega/vega-backend/server/.golangci.yml
@@ -1,0 +1,6 @@
+version: "2"
+
+linters:
+  default: none
+  enable:
+    - rowserrcheck

--- a/adp/vega/vega-backend/server/drivenadapters/catalog/catalog_access.go
+++ b/adp/vega/vega-backend/server/drivenadapters/catalog/catalog_access.go
@@ -349,6 +349,11 @@ func (ca *catalogAccess) GetByIDs(ctx context.Context, ids []string) ([]*interfa
 
 		catalogs = append(catalogs, catalog)
 	}
+	if err := rows.Err(); err != nil {
+		logger.Errorf("Iterate catalog rows failed: %v", err)
+		span.SetStatus(codes.Error, "Rows iteration failed")
+		return []*interfaces.Catalog{}, err
+	}
 
 	if err := attachCatalogExtensions(ctx, ca.appSetting, interfaces.CatalogsQueryParams{IncludeExtensions: false}, catalogs); err != nil {
 		span.SetStatus(codes.Error, "Load catalog extensions failed")
@@ -531,6 +536,10 @@ func (ca *catalogAccess) ListIDs(ctx context.Context, params interfaces.Catalogs
 		}
 		ids = append(ids, id)
 	}
+	if err := rows.Err(); err != nil {
+		span.SetStatus(codes.Error, "Rows iteration failed")
+		return nil, err
+	}
 
 	span.SetStatus(codes.Ok, "")
 	return ids, nil
@@ -564,6 +573,10 @@ func (ca *catalogAccess) ListInternalIDs(ctx context.Context) ([]string, error) 
 			return nil, err
 		}
 		ids = append(ids, id)
+	}
+	if err := rows.Err(); err != nil {
+		span.SetStatus(codes.Error, "Rows iteration failed")
+		return nil, err
 	}
 
 	span.SetStatus(codes.Ok, "")
@@ -720,6 +733,10 @@ func (ca *catalogAccess) List(ctx context.Context, params interfaces.CatalogsQue
 
 		catalogs = append(catalogs, catalog)
 	}
+	if err := rows.Err(); err != nil {
+		span.SetStatus(codes.Error, "Rows iteration failed")
+		return nil, 0, err
+	}
 
 	if err := attachCatalogExtensions(ctx, ca.appSetting, params, catalogs); err != nil {
 		span.SetStatus(codes.Error, "Load catalog extensions failed")
@@ -786,6 +803,10 @@ func (ca *catalogAccess) ListAuthResources(ctx context.Context, params interface
 
 		entry.Type = interfaces.AUTH_RESOURCE_TYPE_CATALOG
 		entries = append(entries, entry)
+	}
+	if err := rows.Err(); err != nil {
+		span.SetStatus(codes.Error, "Rows iteration failed")
+		return nil, err
 	}
 
 	span.SetStatus(codes.Ok, "")

--- a/adp/vega/vega-backend/server/drivenadapters/catalog/catalog_access.go
+++ b/adp/vega/vega-backend/server/drivenadapters/catalog/catalog_access.go
@@ -537,6 +537,7 @@ func (ca *catalogAccess) ListIDs(ctx context.Context, params interfaces.Catalogs
 		ids = append(ids, id)
 	}
 	if err := rows.Err(); err != nil {
+		logger.Errorf("Iterate catalog rows failed: %v", err)
 		span.SetStatus(codes.Error, "Rows iteration failed")
 		return nil, err
 	}
@@ -575,6 +576,7 @@ func (ca *catalogAccess) ListInternalIDs(ctx context.Context) ([]string, error) 
 		ids = append(ids, id)
 	}
 	if err := rows.Err(); err != nil {
+		logger.Errorf("Iterate internal catalog rows failed: %v", err)
 		span.SetStatus(codes.Error, "Rows iteration failed")
 		return nil, err
 	}
@@ -734,6 +736,7 @@ func (ca *catalogAccess) List(ctx context.Context, params interfaces.CatalogsQue
 		catalogs = append(catalogs, catalog)
 	}
 	if err := rows.Err(); err != nil {
+		logger.Errorf("Iterate catalog rows failed: %v", err)
 		span.SetStatus(codes.Error, "Rows iteration failed")
 		return nil, 0, err
 	}
@@ -805,6 +808,7 @@ func (ca *catalogAccess) ListAuthResources(ctx context.Context, params interface
 		entries = append(entries, entry)
 	}
 	if err := rows.Err(); err != nil {
+		logger.Errorf("Iterate catalog authorization resource rows failed: %v", err)
 		span.SetStatus(codes.Error, "Rows iteration failed")
 		return nil, err
 	}

--- a/adp/vega/vega-backend/server/drivenadapters/catalog/catalog_access_test.go
+++ b/adp/vega/vega-backend/server/drivenadapters/catalog/catalog_access_test.go
@@ -103,6 +103,23 @@ func TestCatalogAccessListInternalIDs(t *testing.T) {
 	})
 }
 
+func TestCatalogAccessListIDsReturnsIterationError(t *testing.T) {
+	access, mock, cleanup := newCatalogAccessMock(t)
+	defer cleanup()
+
+	rows := sqlmock.NewRows([]string{"f_id"}).
+		AddRow("catalog-1").
+		AddRow("catalog-2").
+		RowError(1, errors.New("rows interrupted"))
+	mock.ExpectQuery("SELECT f_id FROM t_catalog").WillReturnRows(rows)
+
+	got, err := access.ListIDs(context.Background(), interfaces.CatalogsQueryParams{})
+
+	require.ErrorContains(t, err, "rows interrupted")
+	assert.Nil(t, got)
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
 func TestCatalogAccessList(t *testing.T) {
 	t.Run("returns catalogs with filters", func(t *testing.T) {
 		access, mock, cleanup := newCatalogAccessMock(t)

--- a/adp/vega/vega-backend/server/drivenadapters/connector_type/connector_type_access.go
+++ b/adp/vega/vega-backend/server/drivenadapters/connector_type/connector_type_access.go
@@ -287,6 +287,7 @@ func (cta *connectorTypeAccess) List(ctx context.Context, params interfaces.Conn
 		connectorTypes = append(connectorTypes, ct)
 	}
 	if err := rows.Err(); err != nil {
+		logger.Errorf("Iterate connector_type rows failed: %v", err)
 		span.SetStatus(codes.Error, "Rows iteration failed")
 		return nil, 0, err
 	}
@@ -344,6 +345,7 @@ func (cta *connectorTypeAccess) ListAuthResources(ctx context.Context, params in
 		entries = append(entries, entry)
 	}
 	if err := rows.Err(); err != nil {
+		logger.Errorf("Iterate connector_type authorization resource rows failed: %v", err)
 		span.SetStatus(codes.Error, "Rows iteration failed")
 		return nil, err
 	}

--- a/adp/vega/vega-backend/server/drivenadapters/connector_type/connector_type_access.go
+++ b/adp/vega/vega-backend/server/drivenadapters/connector_type/connector_type_access.go
@@ -286,6 +286,10 @@ func (cta *connectorTypeAccess) List(ctx context.Context, params interfaces.Conn
 
 		connectorTypes = append(connectorTypes, ct)
 	}
+	if err := rows.Err(); err != nil {
+		span.SetStatus(codes.Error, "Rows iteration failed")
+		return nil, 0, err
+	}
 
 	span.SetStatus(codes.Ok, "")
 	return connectorTypes, total, nil
@@ -338,6 +342,10 @@ func (cta *connectorTypeAccess) ListAuthResources(ctx context.Context, params in
 		}
 		entry.Type = interfaces.AuthResourceTypeConnectorType
 		entries = append(entries, entry)
+	}
+	if err := rows.Err(); err != nil {
+		span.SetStatus(codes.Error, "Rows iteration failed")
+		return nil, err
 	}
 
 	span.SetStatus(codes.Ok, "")

--- a/adp/vega/vega-backend/server/drivenadapters/discover_schedule/discover_schedule_access.go
+++ b/adp/vega/vega-backend/server/drivenadapters/discover_schedule/discover_schedule_access.go
@@ -373,6 +373,11 @@ func (dsa *discoverScheduleAccess) List(ctx context.Context, params interfaces.D
 		}
 		schedules = append(schedules, schedule)
 	}
+	if err := rows.Err(); err != nil {
+		logger.Errorf("Iterate discover_schedule rows failed: %v", err)
+		span.SetStatus(codes.Error, "Rows iteration failed")
+		return nil, 0, err
+	}
 
 	span.SetStatus(codes.Ok, "")
 	return schedules, total, nil
@@ -554,6 +559,11 @@ func (dsa *discoverScheduleAccess) GetEnabledSchedules(ctx context.Context) ([]*
 			return nil, err
 		}
 		schedules = append(schedules, schedule)
+	}
+	if err := rows.Err(); err != nil {
+		logger.Errorf("Iterate discover_schedule rows failed: %v", err)
+		span.SetStatus(codes.Error, "Rows iteration failed")
+		return nil, err
 	}
 
 	span.SetStatus(codes.Ok, "")

--- a/adp/vega/vega-backend/server/drivenadapters/discover_task/discover_task_access.go
+++ b/adp/vega/vega-backend/server/drivenadapters/discover_task/discover_task_access.go
@@ -287,6 +287,7 @@ func (dta *discoverTaskAccess) List(ctx context.Context, params interfaces.Disco
 		tasks = append(tasks, task)
 	}
 	if err := rows.Err(); err != nil {
+		logger.Errorf("Iterate discover_task rows failed: %v", err)
 		span.SetStatus(codes.Error, "Rows iteration failed")
 		return nil, 0, err
 	}

--- a/adp/vega/vega-backend/server/drivenadapters/discover_task/discover_task_access.go
+++ b/adp/vega/vega-backend/server/drivenadapters/discover_task/discover_task_access.go
@@ -286,6 +286,10 @@ func (dta *discoverTaskAccess) List(ctx context.Context, params interfaces.Disco
 
 		tasks = append(tasks, task)
 	}
+	if err := rows.Err(); err != nil {
+		span.SetStatus(codes.Error, "Rows iteration failed")
+		return nil, 0, err
+	}
 
 	span.SetStatus(codes.Ok, "")
 	return tasks, total, nil

--- a/adp/vega/vega-backend/server/drivenadapters/resource/resource_access.go
+++ b/adp/vega/vega-backend/server/drivenadapters/resource/resource_access.go
@@ -398,6 +398,11 @@ func (ra *resourceAccess) GetByIDs(ctx context.Context, ids []string) ([]*interf
 
 		resources = append(resources, resource)
 	}
+	if err := rows.Err(); err != nil {
+		logger.Errorf("Iterate resource rows failed: %v", err)
+		span.SetStatus(codes.Error, "Rows iteration failed")
+		return []*interfaces.Resource{}, err
+	}
 
 	if err := attachResourceExtensions(ctx, ra.appSetting, interfaces.ResourcesQueryParams{IncludeExtensions: false}, resources); err != nil {
 		span.SetStatus(codes.Error, "Load resource extensions failed")
@@ -518,6 +523,11 @@ func (ra *resourceAccess) GetByIDsBasic(ctx context.Context, ids []string) ([]*i
 		}
 
 		resources = append(resources, resource)
+	}
+	if err := rows.Err(); err != nil {
+		logger.Errorf("Iterate resource rows failed: %v", err)
+		span.SetStatus(codes.Error, "Rows iteration failed")
+		return []*interfaces.Resource{}, err
 	}
 
 	span.SetStatus(codes.Ok, "")
@@ -676,6 +686,10 @@ func (ra *resourceAccess) ListIDs(ctx context.Context, params interfaces.Resourc
 		}
 		ids = append(ids, id)
 	}
+	if err := rows.Err(); err != nil {
+		span.SetStatus(codes.Error, "Rows iteration failed")
+		return nil, err
+	}
 
 	span.SetStatus(codes.Ok, "")
 	return ids, nil
@@ -818,6 +832,10 @@ func (ra *resourceAccess) List(ctx context.Context, params interfaces.ResourcesQ
 		}
 
 		resources = append(resources, resource)
+	}
+	if err := rows.Err(); err != nil {
+		span.SetStatus(codes.Error, "Rows iteration failed")
+		return nil, 0, err
 	}
 
 	if err := attachResourceExtensions(ctx, ra.appSetting, params, resources); err != nil {
@@ -990,6 +1008,11 @@ func (ra *resourceAccess) GetByCatalogID(ctx context.Context, catalogID string) 
 
 		resources = append(resources, resource)
 	}
+	if err := rows.Err(); err != nil {
+		logger.Errorf("Iterate resource rows failed: %v", err)
+		span.SetStatus(codes.Error, "Rows iteration failed")
+		return nil, err
+	}
 
 	span.SetStatus(codes.Ok, "")
 	return resources, nil
@@ -1148,6 +1171,10 @@ func (ra *resourceAccess) ListAuthResources(ctx context.Context, params interfac
 		}
 		entry.Type = interfaces.AUTH_RESOURCE_TYPE_RESOURCE
 		entries = append(entries, entry)
+	}
+	if err := rows.Err(); err != nil {
+		span.SetStatus(codes.Error, "Rows iteration failed")
+		return nil, err
 	}
 
 	span.SetStatus(codes.Ok, "")

--- a/adp/vega/vega-backend/server/drivenadapters/resource/resource_access.go
+++ b/adp/vega/vega-backend/server/drivenadapters/resource/resource_access.go
@@ -687,6 +687,7 @@ func (ra *resourceAccess) ListIDs(ctx context.Context, params interfaces.Resourc
 		ids = append(ids, id)
 	}
 	if err := rows.Err(); err != nil {
+		logger.Errorf("Iterate resource ID rows failed: %v", err)
 		span.SetStatus(codes.Error, "Rows iteration failed")
 		return nil, err
 	}
@@ -834,6 +835,7 @@ func (ra *resourceAccess) List(ctx context.Context, params interfaces.ResourcesQ
 		resources = append(resources, resource)
 	}
 	if err := rows.Err(); err != nil {
+		logger.Errorf("Iterate resource rows failed: %v", err)
 		span.SetStatus(codes.Error, "Rows iteration failed")
 		return nil, 0, err
 	}
@@ -1173,6 +1175,7 @@ func (ra *resourceAccess) ListAuthResources(ctx context.Context, params interfac
 		entries = append(entries, entry)
 	}
 	if err := rows.Err(); err != nil {
+		logger.Errorf("Iterate resource authorization resource rows failed: %v", err)
 		span.SetStatus(codes.Error, "Rows iteration failed")
 		return nil, err
 	}

--- a/adp/vega/vega-backend/server/drivenadapters/resource/resource_access_test.go
+++ b/adp/vega/vega-backend/server/drivenadapters/resource/resource_access_test.go
@@ -412,6 +412,23 @@ func TestResourceAccessListIDs(t *testing.T) {
 	})
 }
 
+func TestResourceAccessListIDsReturnsIterationError(t *testing.T) {
+	access, mock, cleanup := newResourceAccessMock(t)
+	defer cleanup()
+
+	rows := sqlmock.NewRows([]string{"f_id"}).
+		AddRow("resource-1").
+		AddRow("resource-2").
+		RowError(1, errors.New("rows interrupted"))
+	mock.ExpectQuery("SELECT f_id FROM t_resource").WillReturnRows(rows)
+
+	got, err := access.ListIDs(context.Background(), interfaces.ResourcesQueryParams{})
+
+	require.ErrorContains(t, err, "rows interrupted")
+	assert.Nil(t, got)
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
 func TestResourceAccessDeleteByIDs(t *testing.T) {
 	t.Run("skips empty ids", func(t *testing.T) {
 		access, mock, cleanup := newResourceAccessMock(t)


### PR DESCRIPTION
## Description

补齐 VEGA driven adapters 中 16 个 rows.Next() 循环后的 rows.Err() 检查，避免迭代读取中断时将部分数据作为成功结果返回。

同时启用 golangci-lint 的 rowserrcheck 并接入 VEGA PR CI；新增 sqlmock 回归测试，覆盖已返回首行后发生迭代错误的情形。

## Links

Issue: Closes #276
Branch: fix/276-rows-err-checks

## Testing

- cd adp/vega/vega-backend/server && golangci-lint run ./...
- cd adp/vega/vega-backend && make test

## Compatibility

无 API、数据库或资源释放语义变更。