### PR TITLE
feat(bkn-trace): add evidence event ingestion baseline

### DIFF
--- a/bkn-trace/agent-observability/README.md
+++ b/bkn-trace/agent-observability/README.md
@@ -5,7 +5,9 @@
 当前提供：
 - Trace 原始 DSL 查询接口：`POST /api/agent-observability/v1/traces/_search`
 - Conversation 维度包装查询接口：`GET /api/agent-observability/v1/traces/by-conversation?conversation_id=...`
+- Evidence 事件接收接口：`POST /api/agent-observability/v1/evidence/events`
 - OpenSearch 查询客户端
+- 阶段二 Evidence ingestion 校验、归一化和可替换存储接口
 - Swagger 文档生成
 - Docker 镜像构建
 - Helm Deployment Chart
@@ -18,6 +20,14 @@
 ```bash
 make test
 ```
+
+仅测试 BKN Trace 服务：
+
+```bash
+GOCACHE=/tmp/openbkn-go-build-cache GOMODCACHE=/tmp/openbkn-go-mod-cache go test ./...
+```
+
+阶段二 evidence ingestion 接口接受 `bkn.trace.schema.version=2.0.0` 的事件批次，包含 `trace` 与 `events`。当前版本先完成 contract 校验、敏感 payload 拒绝、归一化计数和内存 repository 写入；后续 PR 会把 repository 替换为持久化 evidence index。
 
 生成 Swagger 文档：
 

--- a/bkn-trace/agent-observability/src/boot/bootstrap.go
+++ b/bkn-trace/agent-observability/src/boot/bootstrap.go
@@ -6,8 +6,10 @@ import (
 
 	docs "github.com/openbkn-ai/bkn-foundry/bkn-trace/agent-observability/docs/swagger"
 	"github.com/openbkn-ai/bkn-foundry/bkn-trace/agent-observability/src/conf"
+	"github.com/openbkn-ai/bkn-foundry/bkn-trace/agent-observability/src/domain/service/evidencesvc"
 	"github.com/openbkn-ai/bkn-foundry/bkn-trace/agent-observability/src/domain/service/tracesvc"
 	"github.com/openbkn-ai/bkn-foundry/bkn-trace/agent-observability/src/drivenadapter/httpaccess/opensearchtraceaccess"
+	"github.com/openbkn-ai/bkn-foundry/bkn-trace/agent-observability/src/drivenadapter/memoryaccess/evidencestore"
 	"github.com/openbkn-ai/bkn-foundry/bkn-trace/agent-observability/src/driveradapter/api/httphandler"
 	"github.com/openbkn-ai/bkn-foundry/bkn-trace/agent-observability/src/infra/opensearch"
 	"github.com/openbkn-ai/bkn-foundry/bkn-trace/agent-observability/src/infra/server/httpserver"
@@ -37,10 +39,13 @@ func NewApp() *App {
 	traceDetailClient := opensearchtraceaccess.New(openSearchClient, openSearchConfig.TraceIndex)
 	traceQueryService := tracesvc.New(traceDetailClient)
 	traceHandler := httphandler.NewTraceHandler(traceQueryService)
+	evidenceService := evidencesvc.New(evidencestore.New())
+	evidenceHandler := httphandler.NewEvidenceHandler(evidenceService)
 
 	mux := http.NewServeMux()
 	mux.HandleFunc(APIBasePath+"/traces/_search", traceHandler.SearchTraces)
 	mux.HandleFunc(APIBasePath+"/traces/by-conversation", traceHandler.SearchTracesByConversationID)
+	mux.HandleFunc(APIBasePath+"/evidence/events", evidenceHandler.IngestEvidenceEvents)
 	mux.Handle(APIBasePath+"/swagger/", httpSwagger.Handler(
 		httpSwagger.URL(APIBasePath+"/swagger/doc.json"),
 	))

--- a/bkn-trace/agent-observability/src/domain/service/evidencesvc/service.go
+++ b/bkn-trace/agent-observability/src/domain/service/evidencesvc/service.go
@@ -16,19 +16,41 @@ var (
 	traceIDRE     = regexp.MustCompile(`^[0-9a-f]{32}$`)
 	requestIDRE   = regexp.MustCompile(`^req_[0-9A-Za-z_.-]+$`)
 	timestampRE   = regexp.MustCompile(`^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d{1,9})?Z$`)
-	rawKeyRE      = regexp.MustCompile(`(?i)(raw[_-]?(sql|prompt|answer|output|input)|row[_-]?data|authorization|cookie|token|api[_-]?key)`)
 )
 
 var sensitivePatterns = []*regexp.Regexp{
-	regexp.MustCompile(`(?i)authorization`),
-	regexp.MustCompile(`(?i)bearer\s+[A-Za-z0-9._-]+`),
-	regexp.MustCompile(`(?i)access[_-]?token`),
-	regexp.MustCompile(`(?i)api[_-]?key`),
-	regexp.MustCompile(`(?i)cookie`),
+	regexp.MustCompile(`(?i)\bauthorization\s*[:=]\s*\S+`),
+	regexp.MustCompile(`(?i)\bbearer\s+[A-Za-z0-9._-]+`),
+	regexp.MustCompile(`(?i)\b(access|refresh|id)[_-]?token\s*[:=]\s*[A-Za-z0-9._-]+`),
+	regexp.MustCompile(`(?i)\bapi[_-]?key\s*[:=]\s*[A-Za-z0-9._-]+`),
+	regexp.MustCompile(`(?i)\bcookie\s*[:=]\s*\S+`),
 	regexp.MustCompile(`(?is)\bselect\s+.+\s+from\b`),
-	regexp.MustCompile(`(?i)prompt\s*[:=]`),
-	regexp.MustCompile(`(?i)https?://[^\s"']+`),
-	regexp.MustCompile(`[\w.+-]+@[\w.-]+\.[A-Za-z]{2,}`),
+}
+
+var forbiddenRawKeys = map[string]struct{}{
+	"access-token":  {},
+	"access_token":  {},
+	"api-key":       {},
+	"api_key":       {},
+	"authorization": {},
+	"cookie":        {},
+	"id-token":      {},
+	"id_token":      {},
+	"raw-answer":    {},
+	"raw-input":     {},
+	"raw-output":    {},
+	"raw-prompt":    {},
+	"raw-sql":       {},
+	"raw_answer":    {},
+	"raw_input":     {},
+	"raw_output":    {},
+	"raw_prompt":    {},
+	"raw_sql":       {},
+	"refresh-token": {},
+	"refresh_token": {},
+	"row-data":      {},
+	"row_data":      {},
+	"token":         {},
 }
 
 var eventTypes = map[string]struct{}{
@@ -211,10 +233,8 @@ func checkRefs(payload map[string]any, base string, key string, knownClaims map[
 	claimID, ok := stringField(payload, "claim_id")
 	if !ok || claimID == "" {
 		add(errors, "BKN_TRACE_REQUIRED_FIELD_MISSING", base+".claim_id", "missing required field claim_id")
-	} else if len(knownClaims) > 0 {
-		if _, exists := knownClaims[claimID]; !exists {
-			add(errors, "BKN_TRACE_UNKNOWN_CLAIM_ID", base+".claim_id", "refs must point to a known claim_id")
-		}
+	} else if _, exists := knownClaims[claimID]; !exists {
+		add(errors, "BKN_TRACE_UNKNOWN_CLAIM_ID", base+".claim_id", "refs must point to a known claim_id in the same batch")
 	}
 	refs := arrayField(payload, key)
 	if len(refs) == 0 {
@@ -227,7 +247,7 @@ func checkSensitive(value any, path string, errors *evidencevo.ValidationErrors)
 	case map[string]any:
 		for k, v := range typed {
 			childPath := path + "." + k
-			if rawKeyRE.MatchString(k) {
+			if forbiddenRawKey(k) {
 				add(errors, "BKN_TRACE_FORBIDDEN_RAW_PAYLOAD_FIELD", childPath, "raw prompt, SQL, answer, tool IO, row data, token, cookie, or authorization fields are forbidden")
 			}
 			checkSensitive(v, childPath, errors)
@@ -244,6 +264,11 @@ func checkSensitive(value any, path string, errors *evidencevo.ValidationErrors)
 			}
 		}
 	}
+}
+
+func forbiddenRawKey(key string) bool {
+	_, ok := forbiddenRawKeys[strings.ToLower(key)]
+	return ok
 }
 
 func validTraceparent(value string) bool {

--- a/bkn-trace/agent-observability/src/domain/service/evidencesvc/service.go
+++ b/bkn-trace/agent-observability/src/domain/service/evidencesvc/service.go
@@ -1,0 +1,297 @@
+package evidencesvc
+
+import (
+	"context"
+	"encoding/json"
+	"regexp"
+	"strconv"
+	"strings"
+
+	"github.com/openbkn-ai/bkn-foundry/bkn-trace/agent-observability/src/domain/valueobject/evidencevo"
+	"github.com/openbkn-ai/bkn-foundry/bkn-trace/agent-observability/src/port/driven/ievidencestore"
+)
+
+var (
+	traceparentRE = regexp.MustCompile(`^00-([0-9a-f]{32})-([0-9a-f]{16})-[0-9a-f]{2}$`)
+	traceIDRE     = regexp.MustCompile(`^[0-9a-f]{32}$`)
+	requestIDRE   = regexp.MustCompile(`^req_[0-9A-Za-z_.-]+$`)
+	timestampRE   = regexp.MustCompile(`^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d{1,9})?Z$`)
+	rawKeyRE      = regexp.MustCompile(`(?i)(raw[_-]?(sql|prompt|answer|output|input)|row[_-]?data|authorization|cookie|token|api[_-]?key)`)
+)
+
+var sensitivePatterns = []*regexp.Regexp{
+	regexp.MustCompile(`(?i)authorization`),
+	regexp.MustCompile(`(?i)bearer\s+[A-Za-z0-9._-]+`),
+	regexp.MustCompile(`(?i)access[_-]?token`),
+	regexp.MustCompile(`(?i)api[_-]?key`),
+	regexp.MustCompile(`(?i)cookie`),
+	regexp.MustCompile(`(?is)\bselect\s+.+\s+from\b`),
+	regexp.MustCompile(`(?i)prompt\s*[:=]`),
+	regexp.MustCompile(`(?i)https?://[^\s"']+`),
+	regexp.MustCompile(`[\w.+-]+@[\w.-]+\.[A-Za-z]{2,}`),
+}
+
+var eventTypes = map[string]struct{}{
+	"claim.created":               {},
+	"evidence.refs.created":       {},
+	"business.refs.resolved":      {},
+	"structured_output.validated": {},
+	"agent_as_tool.invoked":       {},
+	"tool.budget.exhausted":       {},
+	"action.recommended":          {},
+	"action.approval_requested":   {},
+	"action.approved":             {},
+	"action.rejected":             {},
+	"action.executed":             {},
+	"action.result_recorded":      {},
+}
+
+type Service struct {
+	store ievidencestore.EvidenceStorePort
+}
+
+func New(store ievidencestore.EvidenceStorePort) *Service {
+	return &Service{store: store}
+}
+
+func (s *Service) Ingest(ctx context.Context, body []byte) (evidencevo.IngestResponse, evidencevo.ValidationErrors, error) {
+	var raw any
+	if err := json.Unmarshal(body, &raw); err != nil {
+		return evidencevo.IngestResponse{}, evidencevo.ValidationErrors{
+			evidencevo.NewValidationError("BKN_TRACE_INVALID_JSON", "$", "request body must be valid json"),
+		}, nil
+	}
+
+	errors := evidencevo.ValidationErrors{}
+	checkSensitive(raw, "$", &errors)
+	if len(errors) > 0 {
+		return evidencevo.IngestResponse{}, errors, nil
+	}
+
+	var req evidencevo.IngestRequest
+	if err := json.Unmarshal(body, &req); err != nil {
+		return evidencevo.IngestResponse{}, evidencevo.ValidationErrors{
+			evidencevo.NewValidationError("BKN_TRACE_INVALID_JSON", "$", "request body must match evidence ingest schema"),
+		}, nil
+	}
+
+	normalized := normalize(req, &errors)
+	if len(errors) > 0 {
+		return evidencevo.IngestResponse{}, errors, nil
+	}
+
+	if err := s.store.StoreEvidence(ctx, normalized); err != nil {
+		return evidencevo.IngestResponse{}, nil, err
+	}
+
+	return evidencevo.IngestResponse{
+		TraceID:          normalized.TraceID,
+		RequestID:        normalized.RequestID,
+		SchemaVersion:    normalized.SchemaVersion,
+		AcceptedEvents:   normalized.AcceptedEvents,
+		ClaimCount:       normalized.ClaimCount,
+		EvidenceRefCount: normalized.EvidenceRefCount,
+		BusinessRefCount: normalized.BusinessRefCount,
+	}, nil, nil
+}
+
+func normalize(req evidencevo.IngestRequest, errors *evidencevo.ValidationErrors) evidencevo.NormalizedTrace {
+	if req.SchemaVersion != evidencevo.ContractVersion {
+		add(errors, "BKN_TRACE_SCHEMA_VERSION_UNSUPPORTED", "$.bkn.trace.schema.version", "unsupported phase-two contract version")
+	}
+
+	checkTrace(req.Trace, errors)
+	if len(req.Events) == 0 {
+		add(errors, "BKN_TRACE_REQUIRED_FIELD_MISSING", "$.events", "phase-two evidence ingest requires events")
+	}
+
+	knownClaims := map[string]struct{}{}
+	for i, event := range req.Events {
+		if event.EventType == "claim.created" {
+			claimID, _ := stringField(event.Payload, "claim_id")
+			if claimID != "" {
+				knownClaims[claimID] = struct{}{}
+			}
+		}
+		if event.TraceID != req.Trace.TraceID || event.RequestID != req.Trace.RequestID {
+			add(errors, "BKN_TRACE_JOIN_FAILED", path("events", i), "event cannot join trace/request")
+		}
+	}
+
+	normalized := evidencevo.NormalizedTrace{
+		TraceID:        req.Trace.TraceID,
+		RequestID:      req.Trace.RequestID,
+		SchemaVersion:  req.SchemaVersion,
+		Events:         req.Events,
+		AcceptedEvents: len(req.Events),
+	}
+	for i, event := range req.Events {
+		checkEvent(event, i, knownClaims, &normalized, errors)
+	}
+	return normalized
+}
+
+func checkTrace(trace evidencevo.TraceContext, errors *evidencevo.ValidationErrors) {
+	required(trace.TraceID, "$.trace.trace_id", errors)
+	required(trace.Traceparent, "$.trace.traceparent", errors)
+	required(trace.RequestID, "$.trace.bkn.request.id", errors)
+	required(trace.AccountID, "$.trace.bkn.account.id", errors)
+	required(trace.AccountType, "$.trace.bkn.account.type", errors)
+	if trace.TenantID == "" && trace.BusinessDomain == "" {
+		add(errors, "BKN_TRACE_PERMISSION_CONTEXT_MISSING", "$.trace", "phase-two ingest requires bkn.tenant.id or business_domain")
+	}
+	if trace.TraceID != "" && !traceIDRE.MatchString(trace.TraceID) {
+		add(errors, "BKN_TRACE_REQUIRED_FIELD_MISSING", "$.trace.trace_id", "missing valid trace id")
+	}
+	if trace.RequestID != "" && !requestIDRE.MatchString(trace.RequestID) {
+		add(errors, "BKN_TRACE_REQUIRED_FIELD_MISSING", "$.trace.bkn.request.id", "missing valid bkn.request.id")
+	}
+	if trace.Traceparent != "" && !validTraceparent(trace.Traceparent) {
+		add(errors, "BKN_TRACE_INVALID_TRACEPARENT", "$.trace.traceparent", "invalid traceparent")
+	}
+}
+
+func checkEvent(event evidencevo.EvidenceEvent, i int, knownClaims map[string]struct{}, normalized *evidencevo.NormalizedTrace, errors *evidencevo.ValidationErrors) {
+	base := path("events", i)
+	required(event.EventID, base+".event_id", errors)
+	required(event.EventType, base+".event_type", errors)
+	required(event.SchemaVersion, base+".bkn.trace.schema.version", errors)
+	required(event.ObservedAt, base+".observed_at", errors)
+	required(event.EmittedAt, base+".emitted_at", errors)
+	required(event.Producer, base+".producer_module", errors)
+	required(event.TraceID, base+".trace_id", errors)
+	required(event.SpanID, base+".span_id", errors)
+	required(event.RequestID, base+".bkn.request.id", errors)
+	required(event.OperationName, base+".bkn.operation.name", errors)
+	if event.SchemaVersion != "" && event.SchemaVersion != evidencevo.ContractVersion {
+		add(errors, "BKN_TRACE_SCHEMA_VERSION_UNSUPPORTED", base+".bkn.trace.schema.version", "unsupported event contract version")
+	}
+	if event.ObservedAt != "" && !timestampRE.MatchString(event.ObservedAt) {
+		add(errors, "BKN_TRACE_INVALID_TIMESTAMP", base+".observed_at", "timestamp must be UTC RFC3339Nano")
+	}
+	if event.EmittedAt != "" && !timestampRE.MatchString(event.EmittedAt) {
+		add(errors, "BKN_TRACE_INVALID_TIMESTAMP", base+".emitted_at", "timestamp must be UTC RFC3339Nano")
+	}
+	if _, ok := eventTypes[event.EventType]; event.EventType != "" && !ok {
+		add(errors, "BKN_TRACE_EVENT_TYPE_UNREGISTERED", base+".event_type", "event type is not registered for phase two")
+	}
+	if event.Payload == nil {
+		add(errors, "BKN_TRACE_REQUIRED_FIELD_MISSING", base+".payload", "payload must be an object")
+		return
+	}
+
+	switch event.EventType {
+	case "claim.created":
+		checkClaim(event.Payload, base+".payload", normalized, errors)
+	case "evidence.refs.created":
+		checkRefs(event.Payload, base+".payload", "evidence_refs", knownClaims, errors)
+		normalized.EvidenceRefCount += len(arrayField(event.Payload, "evidence_refs"))
+	case "business.refs.resolved":
+		checkRefs(event.Payload, base+".payload", "business_refs", knownClaims, errors)
+		normalized.BusinessRefCount += len(arrayField(event.Payload, "business_refs"))
+	}
+}
+
+func checkClaim(payload map[string]any, base string, normalized *evidencevo.NormalizedTrace, errors *evidencevo.ValidationErrors) {
+	claimID, ok := stringField(payload, "claim_id")
+	if !ok || claimID == "" {
+		add(errors, "BKN_TRACE_REQUIRED_FIELD_MISSING", base+".claim_id", "missing required field claim_id")
+	}
+	requiredStringField(payload, "claim_type", base, errors)
+	requiredStringField(payload, "claim_hash", base, errors)
+	requiredStringField(payload, "visibility", base, errors)
+	requiredStringField(payload, "version_status", base, errors)
+	normalized.ClaimCount++
+	if claimID != "" {
+		normalized.ClaimIDs = append(normalized.ClaimIDs, claimID)
+	}
+}
+
+func checkRefs(payload map[string]any, base string, key string, knownClaims map[string]struct{}, errors *evidencevo.ValidationErrors) {
+	claimID, ok := stringField(payload, "claim_id")
+	if !ok || claimID == "" {
+		add(errors, "BKN_TRACE_REQUIRED_FIELD_MISSING", base+".claim_id", "missing required field claim_id")
+	} else if len(knownClaims) > 0 {
+		if _, exists := knownClaims[claimID]; !exists {
+			add(errors, "BKN_TRACE_UNKNOWN_CLAIM_ID", base+".claim_id", "refs must point to a known claim_id")
+		}
+	}
+	refs := arrayField(payload, key)
+	if len(refs) == 0 {
+		add(errors, "BKN_TRACE_REQUIRED_FIELD_MISSING", base+"."+key, key+" must be a non-empty array")
+	}
+}
+
+func checkSensitive(value any, path string, errors *evidencevo.ValidationErrors) {
+	switch typed := value.(type) {
+	case map[string]any:
+		for k, v := range typed {
+			childPath := path + "." + k
+			if rawKeyRE.MatchString(k) {
+				add(errors, "BKN_TRACE_FORBIDDEN_RAW_PAYLOAD_FIELD", childPath, "raw prompt, SQL, answer, tool IO, row data, token, cookie, or authorization fields are forbidden")
+			}
+			checkSensitive(v, childPath, errors)
+		}
+	case []any:
+		for i, v := range typed {
+			checkSensitive(v, path+"["+strconv.Itoa(i)+"]", errors)
+		}
+	case string:
+		for _, pattern := range sensitivePatterns {
+			if pattern.MatchString(typed) {
+				add(errors, "BKN_TRACE_SENSITIVE_VALUE_LEAKED", path, "sensitive value must be redacted, hashed, or referenced")
+				return
+			}
+		}
+	}
+}
+
+func validTraceparent(value string) bool {
+	match := traceparentRE.FindStringSubmatch(value)
+	if len(match) != 3 {
+		return false
+	}
+	return match[1] != strings.Repeat("0", 32) && match[2] != strings.Repeat("0", 16)
+}
+
+func required(value string, path string, errors *evidencevo.ValidationErrors) {
+	if value == "" {
+		add(errors, "BKN_TRACE_REQUIRED_FIELD_MISSING", path, "missing required field")
+	}
+}
+
+func requiredStringField(payload map[string]any, key string, base string, errors *evidencevo.ValidationErrors) {
+	value, ok := stringField(payload, key)
+	if !ok || value == "" {
+		add(errors, "BKN_TRACE_REQUIRED_FIELD_MISSING", base+"."+key, "missing required field "+key)
+	}
+}
+
+func stringField(payload map[string]any, key string) (string, bool) {
+	value, ok := payload[key]
+	if !ok {
+		return "", false
+	}
+	str, ok := value.(string)
+	return str, ok
+}
+
+func arrayField(payload map[string]any, key string) []any {
+	value, ok := payload[key]
+	if !ok {
+		return nil
+	}
+	items, ok := value.([]any)
+	if !ok {
+		return nil
+	}
+	return items
+}
+
+func add(errors *evidencevo.ValidationErrors, code, path, message string) {
+	*errors = append(*errors, evidencevo.NewValidationError(code, path, message))
+}
+
+func path(collection string, index int) string {
+	return "$." + collection + "[" + strconv.Itoa(index) + "]"
+}

--- a/bkn-trace/agent-observability/src/domain/service/evidencesvc/service_test.go
+++ b/bkn-trace/agent-observability/src/domain/service/evidencesvc/service_test.go
@@ -1,0 +1,211 @@
+package evidencesvc
+
+import (
+	"context"
+	"testing"
+
+	"github.com/openbkn-ai/bkn-foundry/bkn-trace/agent-observability/src/domain/valueobject/evidencevo"
+)
+
+type fakeStore struct {
+	calls int
+}
+
+func (s *fakeStore) StoreEvidence(_ context.Context, _ evidencevo.NormalizedTrace) error {
+	s.calls++
+	return nil
+}
+
+func TestIngestAcceptsPhaseTwoEvidenceBatch(t *testing.T) {
+	store := &fakeStore{}
+	service := New(store)
+
+	response, validationErrors, err := service.Ingest(context.Background(), []byte(validBatch()))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(validationErrors) > 0 {
+		t.Fatalf("unexpected validation errors: %+v", validationErrors)
+	}
+	if store.calls != 1 {
+		t.Fatalf("expected evidence to be stored once, got %d", store.calls)
+	}
+	if response.TraceID != "8c0d0000000000000000000000000001" {
+		t.Fatalf("unexpected trace id: %s", response.TraceID)
+	}
+	if response.AcceptedEvents != 3 || response.ClaimCount != 1 || response.EvidenceRefCount != 1 || response.BusinessRefCount != 1 {
+		t.Fatalf("unexpected response counts: %+v", response)
+	}
+}
+
+func TestIngestRejectsMissingClaimID(t *testing.T) {
+	store := &fakeStore{}
+	service := New(store)
+
+	_, validationErrors, err := service.Ingest(context.Background(), []byte(missingClaimIDBatch()))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(validationErrors) == 0 {
+		t.Fatal("expected validation errors")
+	}
+	if validationErrors[0].Code != "BKN_TRACE_REQUIRED_FIELD_MISSING" {
+		t.Fatalf("unexpected error code: %+v", validationErrors[0])
+	}
+	if store.calls != 0 {
+		t.Fatalf("invalid batch must not be stored")
+	}
+}
+
+func TestIngestRejectsSensitivePayload(t *testing.T) {
+	store := &fakeStore{}
+	service := New(store)
+
+	_, validationErrors, err := service.Ingest(context.Background(), []byte(sensitiveBatch()))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(validationErrors) == 0 {
+		t.Fatal("expected validation errors")
+	}
+	if validationErrors[0].Code != "BKN_TRACE_FORBIDDEN_RAW_PAYLOAD_FIELD" {
+		t.Fatalf("unexpected error code: %+v", validationErrors[0])
+	}
+	if store.calls != 0 {
+		t.Fatalf("invalid batch must not be stored")
+	}
+}
+
+func validBatch() string {
+	return `{
+  "bkn.trace.schema.version": "2.0.0",
+  "trace": {
+    "trace_id": "8c0d0000000000000000000000000001",
+    "bkn.request.id": "req_phase2_001",
+    "traceparent": "00-8c0d0000000000000000000000000001-1f12000000000001-01",
+    "bkn.tenant.id": "tenant_demo",
+    "bkn.account.id": "acct_demo",
+    "bkn.account.type": "app"
+  },
+  "events": [
+    {
+      "event_id": "evt_claim",
+      "event_type": "claim.created",
+      "bkn.trace.schema.version": "2.0.0",
+      "observed_at": "2026-07-22T04:00:00.000000000Z",
+      "emitted_at": "2026-07-22T04:00:00.001000000Z",
+      "producer_module": "third-party-agent",
+      "trace_id": "8c0d0000000000000000000000000001",
+      "span_id": "1f12000000000001",
+      "bkn.request.id": "req_phase2_001",
+      "bkn.operation.name": "agent.answer",
+      "payload": {
+        "claim_id": "claim_001",
+        "claim_type": "answer",
+        "claim_hash": "sha256:claim",
+        "visibility": "visible",
+        "version_status": "versioned"
+      }
+    },
+    {
+      "event_id": "evt_evidence",
+      "event_type": "evidence.refs.created",
+      "bkn.trace.schema.version": "2.0.0",
+      "observed_at": "2026-07-22T04:00:00.002000000Z",
+      "emitted_at": "2026-07-22T04:00:00.003000000Z",
+      "producer_module": "third-party-agent",
+      "trace_id": "8c0d0000000000000000000000000001",
+      "span_id": "1f12000000000001",
+      "bkn.request.id": "req_phase2_001",
+      "bkn.operation.name": "agent.answer",
+      "payload": {
+        "claim_id": "claim_001",
+        "evidence_refs": [{"ref_id": "eref_001"}]
+      }
+    },
+    {
+      "event_id": "evt_business",
+      "event_type": "business.refs.resolved",
+      "bkn.trace.schema.version": "2.0.0",
+      "observed_at": "2026-07-22T04:00:00.004000000Z",
+      "emitted_at": "2026-07-22T04:00:00.005000000Z",
+      "producer_module": "bkn-trace",
+      "trace_id": "8c0d0000000000000000000000000001",
+      "span_id": "1f12000000000001",
+      "bkn.request.id": "req_phase2_001",
+      "bkn.operation.name": "bkn_trace.resolve_business_refs",
+      "payload": {
+        "claim_id": "claim_001",
+        "business_refs": [{"ref_id": "bref_001"}]
+      }
+    }
+  ]
+}`
+}
+
+func missingClaimIDBatch() string {
+	return `{
+  "bkn.trace.schema.version": "2.0.0",
+  "trace": {
+    "trace_id": "8c0d0000000000000000000000000002",
+    "bkn.request.id": "req_phase2_002",
+    "traceparent": "00-8c0d0000000000000000000000000002-1f12000000000002-01",
+    "business_domain": "bd_demo",
+    "bkn.account.id": "acct_demo",
+    "bkn.account.type": "app"
+  },
+  "events": [
+    {
+      "event_id": "evt_claim_missing",
+      "event_type": "claim.created",
+      "bkn.trace.schema.version": "2.0.0",
+      "observed_at": "2026-07-22T04:00:00.000000000Z",
+      "emitted_at": "2026-07-22T04:00:00.001000000Z",
+      "producer_module": "third-party-agent",
+      "trace_id": "8c0d0000000000000000000000000002",
+      "span_id": "1f12000000000002",
+      "bkn.request.id": "req_phase2_002",
+      "bkn.operation.name": "agent.answer",
+      "payload": {
+        "claim_type": "answer",
+        "claim_hash": "sha256:claim",
+        "visibility": "visible",
+        "version_status": "versioned"
+      }
+    }
+  ]
+}`
+}
+
+func sensitiveBatch() string {
+	return `{
+  "bkn.trace.schema.version": "2.0.0",
+  "trace": {
+    "trace_id": "8c0d0000000000000000000000000003",
+    "bkn.request.id": "req_phase2_003",
+    "traceparent": "00-8c0d0000000000000000000000000003-1f12000000000003-01",
+    "business_domain": "bd_demo",
+    "bkn.account.id": "acct_demo",
+    "bkn.account.type": "app"
+  },
+  "events": [
+    {
+      "event_id": "evt_sensitive",
+      "event_type": "evidence.refs.created",
+      "bkn.trace.schema.version": "2.0.0",
+      "observed_at": "2026-07-22T04:00:00.000000000Z",
+      "emitted_at": "2026-07-22T04:00:00.001000000Z",
+      "producer_module": "vega-data",
+      "trace_id": "8c0d0000000000000000000000000003",
+      "span_id": "1f12000000000003",
+      "bkn.request.id": "req_phase2_003",
+      "bkn.operation.name": "data.query.execute",
+      "payload": {
+        "claim_id": "claim_003",
+        "evidence_refs": [{"ref_id": "eref_003"}],
+        "raw_sql": "select email from customer"
+      }
+    }
+  ]
+}`
+}

--- a/bkn-trace/agent-observability/src/domain/service/evidencesvc/service_test.go
+++ b/bkn-trace/agent-observability/src/domain/service/evidencesvc/service_test.go
@@ -2,6 +2,7 @@ package evidencesvc
 
 import (
 	"context"
+	"strings"
 	"testing"
 
 	"github.com/openbkn-ai/bkn-foundry/bkn-trace/agent-observability/src/domain/valueobject/evidencevo"
@@ -74,6 +75,138 @@ func TestIngestRejectsSensitivePayload(t *testing.T) {
 	if store.calls != 0 {
 		t.Fatalf("invalid batch must not be stored")
 	}
+}
+
+func TestIngestRejectsUnknownClaimIDWithoutClaimBatch(t *testing.T) {
+	store := &fakeStore{}
+	service := New(store)
+
+	_, validationErrors, err := service.Ingest(context.Background(), []byte(unknownClaimIDBatch()))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !hasValidationCode(validationErrors, "BKN_TRACE_UNKNOWN_CLAIM_ID") {
+		t.Fatalf("expected unknown claim id error, got %+v", validationErrors)
+	}
+	if store.calls != 0 {
+		t.Fatalf("invalid batch must not be stored")
+	}
+}
+
+func TestIngestRejectsJoinMismatch(t *testing.T) {
+	store := &fakeStore{}
+	service := New(store)
+	body := strings.Replace(validBatch(), `"bkn.request.id": "req_phase2_001",`, `"bkn.request.id": "req_phase2_other",`, 1)
+
+	_, validationErrors, err := service.Ingest(context.Background(), []byte(body))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !hasValidationCode(validationErrors, "BKN_TRACE_JOIN_FAILED") {
+		t.Fatalf("expected join failed error, got %+v", validationErrors)
+	}
+	if store.calls != 0 {
+		t.Fatalf("invalid batch must not be stored")
+	}
+}
+
+func TestIngestRejectsUnsupportedSchemaVersion(t *testing.T) {
+	store := &fakeStore{}
+	service := New(store)
+	body := strings.Replace(validBatch(), `"bkn.trace.schema.version": "2.0.0"`, `"bkn.trace.schema.version": "1.0.0"`, 1)
+
+	_, validationErrors, err := service.Ingest(context.Background(), []byte(body))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !hasValidationCode(validationErrors, "BKN_TRACE_SCHEMA_VERSION_UNSUPPORTED") {
+		t.Fatalf("expected unsupported schema error, got %+v", validationErrors)
+	}
+	if store.calls != 0 {
+		t.Fatalf("invalid batch must not be stored")
+	}
+}
+
+func TestIngestRejectsInvalidTraceparent(t *testing.T) {
+	store := &fakeStore{}
+	service := New(store)
+	body := strings.Replace(validBatch(), `"traceparent": "00-8c0d0000000000000000000000000001-1f12000000000001-01"`, `"traceparent": "00-00000000000000000000000000000000-0000000000000000-01"`, 1)
+
+	_, validationErrors, err := service.Ingest(context.Background(), []byte(body))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !hasValidationCode(validationErrors, "BKN_TRACE_INVALID_TRACEPARENT") {
+		t.Fatalf("expected invalid traceparent error, got %+v", validationErrors)
+	}
+	if store.calls != 0 {
+		t.Fatalf("invalid batch must not be stored")
+	}
+}
+
+func TestIngestRejectsInvalidTimestamp(t *testing.T) {
+	store := &fakeStore{}
+	service := New(store)
+	body := strings.Replace(validBatch(), `"observed_at": "2026-07-22T04:00:00.000000000Z"`, `"observed_at": "2026-07-22 04:00:00"`, 1)
+
+	_, validationErrors, err := service.Ingest(context.Background(), []byte(body))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !hasValidationCode(validationErrors, "BKN_TRACE_INVALID_TIMESTAMP") {
+		t.Fatalf("expected invalid timestamp error, got %+v", validationErrors)
+	}
+	if store.calls != 0 {
+		t.Fatalf("invalid batch must not be stored")
+	}
+}
+
+func TestIngestRejectsEmptyEvents(t *testing.T) {
+	store := &fakeStore{}
+	service := New(store)
+
+	_, validationErrors, err := service.Ingest(context.Background(), []byte(emptyEventsBatch()))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !hasValidationCode(validationErrors, "BKN_TRACE_REQUIRED_FIELD_MISSING") {
+		t.Fatalf("expected required field error, got %+v", validationErrors)
+	}
+	if store.calls != 0 {
+		t.Fatalf("invalid batch must not be stored")
+	}
+}
+
+func TestIngestAllowsReferenceLikeStringsAndNonSensitiveKeySubstrings(t *testing.T) {
+	store := &fakeStore{}
+	service := New(store)
+	body := strings.Replace(validBatch(), `"version_status": "versioned"`, `"version_status": "versioned",
+        "source_url": "https://docs.example.com/source/123",
+        "owner_ref": "user@company.com",
+        "prompt_note": "prompt: is a label in external documentation",
+        "token_bucket": "rate-limit-window",
+        "cookie_policy": "same-site",
+        "authorization_scope": "trace:evidence"`, 1)
+
+	_, validationErrors, err := service.Ingest(context.Background(), []byte(body))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(validationErrors) > 0 {
+		t.Fatalf("unexpected validation errors: %+v", validationErrors)
+	}
+	if store.calls != 1 {
+		t.Fatalf("expected evidence to be stored once, got %d", store.calls)
+	}
+}
+
+func hasValidationCode(validationErrors evidencevo.ValidationErrors, code string) bool {
+	for _, validationError := range validationErrors {
+		if validationError.Code == code {
+			return true
+		}
+	}
+	return false
 }
 
 func validBatch() string {
@@ -207,5 +340,52 @@ func sensitiveBatch() string {
       }
     }
   ]
+}`
+}
+
+func unknownClaimIDBatch() string {
+	return `{
+  "bkn.trace.schema.version": "2.0.0",
+  "trace": {
+    "trace_id": "8c0d0000000000000000000000000004",
+    "bkn.request.id": "req_phase2_004",
+    "traceparent": "00-8c0d0000000000000000000000000004-1f12000000000004-01",
+    "business_domain": "bd_demo",
+    "bkn.account.id": "acct_demo",
+    "bkn.account.type": "app"
+  },
+  "events": [
+    {
+      "event_id": "evt_unknown_claim",
+      "event_type": "evidence.refs.created",
+      "bkn.trace.schema.version": "2.0.0",
+      "observed_at": "2026-07-22T04:00:00.000000000Z",
+      "emitted_at": "2026-07-22T04:00:00.001000000Z",
+      "producer_module": "third-party-agent",
+      "trace_id": "8c0d0000000000000000000000000004",
+      "span_id": "1f12000000000004",
+      "bkn.request.id": "req_phase2_004",
+      "bkn.operation.name": "agent.answer",
+      "payload": {
+        "claim_id": "claim_DOES_NOT_EXIST",
+        "evidence_refs": [{"ref_id": "eref_004"}]
+      }
+    }
+  ]
+}`
+}
+
+func emptyEventsBatch() string {
+	return `{
+  "bkn.trace.schema.version": "2.0.0",
+  "trace": {
+    "trace_id": "8c0d0000000000000000000000000005",
+    "bkn.request.id": "req_phase2_005",
+    "traceparent": "00-8c0d0000000000000000000000000005-1f12000000000005-01",
+    "business_domain": "bd_demo",
+    "bkn.account.id": "acct_demo",
+    "bkn.account.type": "app"
+  },
+  "events": []
 }`
 }

--- a/bkn-trace/agent-observability/src/domain/valueobject/evidencevo/evidence.go
+++ b/bkn-trace/agent-observability/src/domain/valueobject/evidencevo/evidence.go
@@ -1,0 +1,77 @@
+package evidencevo
+
+import "encoding/json"
+
+const ContractVersion = "2.0.0"
+
+type IngestRequest struct {
+	SchemaVersion string          `json:"bkn.trace.schema.version"`
+	Trace         TraceContext    `json:"trace"`
+	Events        []EvidenceEvent `json:"events"`
+}
+
+type TraceContext struct {
+	TraceID        string `json:"trace_id"`
+	Traceparent    string `json:"traceparent"`
+	RequestID      string `json:"bkn.request.id"`
+	TenantID       string `json:"bkn.tenant.id,omitempty"`
+	BusinessDomain string `json:"business_domain,omitempty"`
+	AccountID      string `json:"bkn.account.id"`
+	AccountType    string `json:"bkn.account.type"`
+}
+
+type EvidenceEvent struct {
+	EventID       string          `json:"event_id"`
+	EventType     string          `json:"event_type"`
+	SchemaVersion string          `json:"bkn.trace.schema.version"`
+	ObservedAt    string          `json:"observed_at"`
+	EmittedAt     string          `json:"emitted_at"`
+	Producer      string          `json:"producer_module"`
+	TraceID       string          `json:"trace_id"`
+	SpanID        string          `json:"span_id"`
+	RequestID     string          `json:"bkn.request.id"`
+	OperationName string          `json:"bkn.operation.name"`
+	Payload       map[string]any  `json:"payload"`
+	RawPayload    json.RawMessage `json:"-"`
+}
+
+type ValidationError struct {
+	Code    string `json:"code"`
+	Path    string `json:"path"`
+	Message string `json:"message"`
+}
+
+type ValidationErrors []ValidationError
+
+func (e ValidationErrors) Error() string {
+	if len(e) == 0 {
+		return "validation failed"
+	}
+	return e[0].Code + ": " + e[0].Path
+}
+
+type NormalizedTrace struct {
+	TraceID          string
+	RequestID        string
+	SchemaVersion    string
+	Events           []EvidenceEvent
+	ClaimIDs         []string
+	AcceptedEvents   int
+	ClaimCount       int
+	EvidenceRefCount int
+	BusinessRefCount int
+}
+
+type IngestResponse struct {
+	TraceID          string `json:"trace_id"`
+	RequestID        string `json:"bkn.request.id"`
+	SchemaVersion    string `json:"bkn.trace.schema.version"`
+	AcceptedEvents   int    `json:"accepted_event_count"`
+	ClaimCount       int    `json:"claim_count"`
+	EvidenceRefCount int    `json:"evidence_ref_count"`
+	BusinessRefCount int    `json:"business_ref_count"`
+}
+
+func NewValidationError(code, path, message string) ValidationError {
+	return ValidationError{Code: code, Path: path, Message: message}
+}

--- a/bkn-trace/agent-observability/src/drivenadapter/memoryaccess/evidencestore/store.go
+++ b/bkn-trace/agent-observability/src/drivenadapter/memoryaccess/evidencestore/store.go
@@ -1,0 +1,30 @@
+package evidencestore
+
+import (
+	"context"
+	"sync"
+
+	"github.com/openbkn-ai/bkn-foundry/bkn-trace/agent-observability/src/domain/valueobject/evidencevo"
+)
+
+type Store struct {
+	mu     sync.Mutex
+	traces map[string][]evidencevo.NormalizedTrace
+}
+
+func New() *Store {
+	return &Store{traces: map[string][]evidencevo.NormalizedTrace{}}
+}
+
+func (s *Store) StoreEvidence(_ context.Context, trace evidencevo.NormalizedTrace) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.traces[trace.TraceID] = append(s.traces[trace.TraceID], trace)
+	return nil
+}
+
+func (s *Store) TraceCount(traceID string) int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return len(s.traces[traceID])
+}

--- a/bkn-trace/agent-observability/src/driveradapter/api/httphandler/evidence_handler.go
+++ b/bkn-trace/agent-observability/src/driveradapter/api/httphandler/evidence_handler.go
@@ -67,6 +67,7 @@ func (h *EvidenceHandler) IngestEvidenceEvents(w http.ResponseWriter, r *http.Re
 		writeJSON(w, http.StatusBadRequest, rdto.ErrorResponse{
 			Code:    validationErrors[0].Code,
 			Message: validationErrors[0].Message,
+			Details: validationErrors,
 		})
 		return
 	}

--- a/bkn-trace/agent-observability/src/driveradapter/api/httphandler/evidence_handler.go
+++ b/bkn-trace/agent-observability/src/driveradapter/api/httphandler/evidence_handler.go
@@ -1,0 +1,75 @@
+package httphandler
+
+import (
+	"io"
+	"net/http"
+
+	"github.com/openbkn-ai/bkn-foundry/bkn-trace/agent-observability/src/domain/service/evidencesvc"
+	"github.com/openbkn-ai/bkn-foundry/bkn-trace/agent-observability/src/driveradapter/api/rdto"
+)
+
+const maxEvidenceBodyBytes = 1 << 20
+
+type EvidenceHandler struct {
+	evidenceService *evidencesvc.Service
+}
+
+func NewEvidenceHandler(evidenceService *evidencesvc.Service) *EvidenceHandler {
+	return &EvidenceHandler{evidenceService: evidenceService}
+}
+
+// IngestEvidenceEvents godoc
+// @Summary Ingest BKN Trace phase-two evidence events
+// @Description Accepts claim.created, evidence.refs.created, and business.refs.resolved events and stores the normalized evidence model.
+// @Tags evidence
+// @Accept json
+// @Produce json
+// @Param request body string true "BKN Trace phase-two evidence event batch"
+// @Success 202 {object} map[string]interface{}
+// @Failure 400 {object} rdto.ErrorResponse
+// @Failure 405 {object} rdto.ErrorResponse
+// @Failure 500 {object} rdto.ErrorResponse
+// @Router /api/agent-observability/v1/evidence/events [post]
+func (h *EvidenceHandler) IngestEvidenceEvents(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		writeJSON(w, http.StatusMethodNotAllowed, rdto.ErrorResponse{
+			Code:    "METHOD_NOT_ALLOWED",
+			Message: "only POST is supported",
+		})
+		return
+	}
+
+	body, err := io.ReadAll(http.MaxBytesReader(w, r.Body, maxEvidenceBodyBytes))
+	if err != nil {
+		writeJSON(w, http.StatusBadRequest, rdto.ErrorResponse{
+			Code:    "INVALID_ARGUMENT",
+			Message: "failed to read request body",
+		})
+		return
+	}
+	if len(body) == 0 {
+		writeJSON(w, http.StatusBadRequest, rdto.ErrorResponse{
+			Code:    "INVALID_ARGUMENT",
+			Message: "evidence event body is required",
+		})
+		return
+	}
+
+	response, validationErrors, err := h.evidenceService.Ingest(r.Context(), body)
+	if err != nil {
+		writeJSON(w, http.StatusInternalServerError, rdto.ErrorResponse{
+			Code:    "INGEST_FAILED",
+			Message: "failed to ingest evidence events",
+		})
+		return
+	}
+	if len(validationErrors) > 0 {
+		writeJSON(w, http.StatusBadRequest, rdto.ErrorResponse{
+			Code:    validationErrors[0].Code,
+			Message: validationErrors[0].Message,
+		})
+		return
+	}
+
+	writeJSON(w, http.StatusAccepted, response)
+}

--- a/bkn-trace/agent-observability/src/driveradapter/api/httphandler/evidence_handler_test.go
+++ b/bkn-trace/agent-observability/src/driveradapter/api/httphandler/evidence_handler_test.go
@@ -1,0 +1,76 @@
+package httphandler
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/openbkn-ai/bkn-foundry/bkn-trace/agent-observability/src/domain/service/evidencesvc"
+	"github.com/openbkn-ai/bkn-foundry/bkn-trace/agent-observability/src/drivenadapter/memoryaccess/evidencestore"
+)
+
+func TestEvidenceHandlerAcceptsValidBatch(t *testing.T) {
+	handler := NewEvidenceHandler(evidencesvc.New(evidencestore.New()))
+	req := httptest.NewRequest(http.MethodPost, "/api/agent-observability/v1/evidence/events", strings.NewReader(validHandlerBatch()))
+	rec := httptest.NewRecorder()
+
+	handler.IngestEvidenceEvents(rec, req)
+
+	if rec.Code != http.StatusAccepted {
+		t.Fatalf("expected 202, got %d: %s", rec.Code, rec.Body.String())
+	}
+	if !strings.Contains(rec.Body.String(), `"accepted_event_count":1`) {
+		t.Fatalf("unexpected body: %s", rec.Body.String())
+	}
+}
+
+func TestEvidenceHandlerRejectsSensitivePayload(t *testing.T) {
+	handler := NewEvidenceHandler(evidencesvc.New(evidencestore.New()))
+	req := httptest.NewRequest(http.MethodPost, "/api/agent-observability/v1/evidence/events", strings.NewReader(strings.Replace(validHandlerBatch(), `"claim_hash": "sha256:claim"`, `"raw_sql": "select email from customer"`, 1)))
+	rec := httptest.NewRecorder()
+
+	handler.IngestEvidenceEvents(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d: %s", rec.Code, rec.Body.String())
+	}
+	if !strings.Contains(rec.Body.String(), "BKN_TRACE_FORBIDDEN_RAW_PAYLOAD_FIELD") {
+		t.Fatalf("unexpected body: %s", rec.Body.String())
+	}
+}
+
+func validHandlerBatch() string {
+	return `{
+  "bkn.trace.schema.version": "2.0.0",
+  "trace": {
+    "trace_id": "9c0d0000000000000000000000000001",
+    "bkn.request.id": "req_handler_001",
+    "traceparent": "00-9c0d0000000000000000000000000001-2f12000000000001-01",
+    "business_domain": "bd_demo",
+    "bkn.account.id": "acct_demo",
+    "bkn.account.type": "app"
+  },
+  "events": [
+    {
+      "event_id": "evt_claim",
+      "event_type": "claim.created",
+      "bkn.trace.schema.version": "2.0.0",
+      "observed_at": "2026-07-22T04:00:00.000000000Z",
+      "emitted_at": "2026-07-22T04:00:00.001000000Z",
+      "producer_module": "third-party-agent",
+      "trace_id": "9c0d0000000000000000000000000001",
+      "span_id": "2f12000000000001",
+      "bkn.request.id": "req_handler_001",
+      "bkn.operation.name": "agent.answer",
+      "payload": {
+        "claim_id": "claim_handler",
+        "claim_type": "answer",
+        "claim_hash": "sha256:claim",
+        "visibility": "visible",
+        "version_status": "versioned"
+      }
+    }
+  ]
+}`
+}

--- a/bkn-trace/agent-observability/src/driveradapter/api/httphandler/evidence_handler_test.go
+++ b/bkn-trace/agent-observability/src/driveradapter/api/httphandler/evidence_handler_test.go
@@ -40,6 +40,26 @@ func TestEvidenceHandlerRejectsSensitivePayload(t *testing.T) {
 	}
 }
 
+func TestEvidenceHandlerReturnsValidationErrorDetails(t *testing.T) {
+	handler := NewEvidenceHandler(evidencesvc.New(evidencestore.New()))
+	body := strings.Replace(validHandlerBatch(), `"claim_hash": "sha256:claim",`, "", 1)
+	body = strings.Replace(body, `"visibility": "visible",`, "", 1)
+	req := httptest.NewRequest(http.MethodPost, "/api/agent-observability/v1/evidence/events", strings.NewReader(body))
+	rec := httptest.NewRecorder()
+
+	handler.IngestEvidenceEvents(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d: %s", rec.Code, rec.Body.String())
+	}
+	if !strings.Contains(rec.Body.String(), `"details"`) {
+		t.Fatalf("expected validation details, got: %s", rec.Body.String())
+	}
+	if !strings.Contains(rec.Body.String(), `claim_hash`) || !strings.Contains(rec.Body.String(), `visibility`) {
+		t.Fatalf("expected all validation errors in details, got: %s", rec.Body.String())
+	}
+}
+
 func validHandlerBatch() string {
 	return `{
   "bkn.trace.schema.version": "2.0.0",

--- a/bkn-trace/agent-observability/src/driveradapter/api/rdto/error_response.go
+++ b/bkn-trace/agent-observability/src/driveradapter/api/rdto/error_response.go
@@ -3,6 +3,7 @@ package rdto
 type ErrorResponse struct {
 	Code    string `json:"code"`
 	Message string `json:"message"`
+	Details any    `json:"details,omitempty"`
 }
 
 type TraceSearchByConversationResponse struct {

--- a/bkn-trace/agent-observability/src/port/driven/ievidencestore/port.go
+++ b/bkn-trace/agent-observability/src/port/driven/ievidencestore/port.go
@@ -1,0 +1,11 @@
+package ievidencestore
+
+import (
+	"context"
+
+	"github.com/openbkn-ai/bkn-foundry/bkn-trace/agent-observability/src/domain/valueobject/evidencevo"
+)
+
+type EvidenceStorePort interface {
+	StoreEvidence(ctx context.Context, trace evidencevo.NormalizedTrace) error
+}


### PR DESCRIPTION
## Summary
- add BKN Trace phase-two evidence ingestion endpoint at `POST /api/agent-observability/v1/evidence/events`
- validate `2.0.0` evidence batches, trace/request join fields, claim ids, event registry, timestamps, and sensitive raw payload keys/values
- add normalized evidence model, replaceable store port, and in-memory store baseline for PR-2.2

## Tests
- `GOCACHE=/tmp/openbkn-go-build-cache GOMODCACHE=/tmp/openbkn-go-mod-cache go test ./...`

Refs openbkn-ai/bkn-foundry#270