### PR TITLE
fix #377 在安装或升级  时， 端口、Helm 升级触发条件和 Pod 更新策略没有对齐，导致改端口后无法正确生效。

### DIFF
--- a/deploy/README.md
+++ b/deploy/README.md
@@ -122,9 +122,15 @@ bash ./deploy.sh bkn-foundry install \
   --access_address=<your-ip> \
   --api_server_address=<your-ip>
 
+# If you include a port in --access_address, that port is used for the matching
+# ingress protocol when the script installs ingress-nginx (for example, https://...:8443
+# updates the HTTPS ingress port, while http://...:8080 updates the HTTP port).
+
 # (Optional) Customize ingress ports (default 80/443):
 export INGRESS_NGINX_HTTP_PORT=8080
 export INGRESS_NGINX_HTTPS_PORT=8443
+# Re-run the same install command after changing these values; the script now
+# detects port drift and upgrades the existing ingress-nginx release.
 
 # 4. (Recommended) Post-install bootstrap
 #    Registers an LLM + embedding (skips when already there), patches the BKN ConfigMap

--- a/deploy/README.zh.md
+++ b/deploy/README.zh.md
@@ -121,9 +121,15 @@ bash ./deploy.sh bkn-foundry install \
   --access_address=<你的IP> \
   --api_server_address=<你的IP>
 
+# 如果 `--access_address` 里带了端口，脚本在安装 ingress-nginx 时会把它
+# 用到对应协议的 ingress 端口上（例如 https://...:8443 会更新 HTTPS 端口，
+# http://...:8080 会更新 HTTP 端口）。
+
 # （可选）自定义 ingress 端口（默认 80/443）：
 export INGRESS_NGINX_HTTP_PORT=8080
 export INGRESS_NGINX_HTTPS_PORT=8443
+# 修改后请重新执行同一个安装命令；脚本现在会检测端口漂移并升级
+# 已存在的 ingress-nginx release。
 
 # 4.（推荐）安装后引导
 #    注册 LLM + embedding（已有则跳过）；只有当默认 embedding 实际变更时才会 patch BKN ConfigMap；

--- a/deploy/deploy.sh
+++ b/deploy/deploy.sh
@@ -256,6 +256,22 @@ _upsert_access_address() {
     mv "${tmp}" "${CONFIG_YAML_PATH}"
 }
 
+_sync_ingress_ports_from_access_address() {
+    local port="$1"
+    local scheme="$2"
+
+    [[ -n "${port}" ]] || return 0
+
+    case "${scheme,,}" in
+        http)
+            export INGRESS_NGINX_HTTP_PORT="${port}"
+            ;;
+        https|*)
+            export INGRESS_NGINX_HTTPS_PORT="${port}"
+            ;;
+    esac
+}
+
 confirm_access_address_before_install() {
     local confirm_switch="${CONFIRM_ACCESS_ADDRESS:-true}"
     local config_missing_before="false"
@@ -313,6 +329,7 @@ confirm_access_address_before_install() {
     fi
 
     local url="${scheme}://${host}:${port}${path}"
+    _sync_ingress_ports_from_access_address "${port}" "${scheme}"
 
     # If provided via CLI arg, skip interactive confirmation
     if [[ -n "${OPENBKN_ACCESS_ADDRESS:-}" ]]; then

--- a/deploy/deploy.sh
+++ b/deploy/deploy.sh
@@ -272,6 +272,18 @@ _sync_ingress_ports_from_access_address() {
     esac
 }
 
+_default_access_port_for_scheme() {
+    local scheme="${1:-https}"
+    case "${scheme,,}" in
+        http)
+            printf '%s' "${INGRESS_NGINX_HTTP_PORT:-80}"
+            ;;
+        https|*)
+            printf '%s' "${INGRESS_NGINX_HTTPS_PORT:-443}"
+            ;;
+    esac
+}
+
 confirm_access_address_before_install() {
     local confirm_switch="${CONFIRM_ACCESS_ADDRESS:-true}"
     local config_missing_before="false"
@@ -318,14 +330,14 @@ confirm_access_address_before_install() {
         else
             host="${addr}"
         fi
-        port="${port:-${raw_port:-${INGRESS_NGINX_HTTPS_PORT:-443}}}"
+        port="${port:-${raw_port:-$(_default_access_port_for_scheme "${scheme:-${raw_scheme:-https}}")}}"
         path="${path:-${raw_path:-/}}"
         scheme="${scheme:-${raw_scheme:-https}}"
     else
         host="${raw_host:-$(_detect_node_ip)}"
-        port="${raw_port:-${INGRESS_NGINX_HTTPS_PORT:-443}}"
-        path="${raw_path:-/}"
         scheme="${raw_scheme:-https}"
+        port="${raw_port:-$(_default_access_port_for_scheme "${scheme}")}"
+        path="${raw_path:-/}"
     fi
 
     local url="${scheme}://${host}:${port}${path}"

--- a/deploy/deploy.sh
+++ b/deploy/deploy.sh
@@ -290,14 +290,6 @@ confirm_access_address_before_install() {
     if [[ ! -f "${CONFIG_YAML_PATH}" ]]; then
         config_missing_before="true"
     fi
-    if [[ "${confirm_switch}" == "false" ]]; then
-        # Still materialize CONFIG_YAML_PATH when missing so installs read namespace/accessAddress from one file.
-        if [[ "${config_missing_before}" == "true" ]] && [[ "${AUTO_GENERATE_CONFIG:-true}" == "true" ]]; then
-            log_info "Config not found, generating: ${CONFIG_YAML_PATH}"
-            generate_config_yaml
-        fi
-        return 0
-    fi
 
     local raw_host raw_port raw_path raw_scheme
     raw_host="$(_read_access_address_field "host")"
@@ -342,6 +334,20 @@ confirm_access_address_before_install() {
 
     local url="${scheme}://${host}:${port}${path}"
     _sync_ingress_ports_from_access_address "${port}" "${scheme}"
+
+    if [[ "${confirm_switch}" == "false" ]]; then
+        # Still materialize CONFIG_YAML_PATH when missing so installs read namespace/accessAddress from one file.
+        if [[ "${config_missing_before}" == "true" ]] && [[ "${AUTO_GENERATE_CONFIG:-true}" == "true" ]]; then
+            log_info "Config not found, generating: ${CONFIG_YAML_PATH}"
+            generate_config_yaml
+        fi
+
+        if [[ -n "${OPENBKN_ACCESS_ADDRESS:-}" ]]; then
+            log_info "Using accessAddress from --access_address: ${url}"
+            _upsert_access_address "${host}" "${port}" "${path}" "${scheme}"
+        fi
+        return 0
+    fi
 
     # If provided via CLI arg, skip interactive confirmation
     if [[ -n "${OPENBKN_ACCESS_ADDRESS:-}" ]]; then

--- a/deploy/scripts/services/config.sh
+++ b/deploy/scripts/services/config.sh
@@ -51,9 +51,17 @@ generate_config_yaml() {
         fi
     fi
     
-    # Use existing values or defaults for other accessAddress fields
-    local access_port="${cfg_access_port:-${INGRESS_NGINX_HTTPS_PORT:-443}}"
+    # Use existing values or defaults for other accessAddress fields.
+    # Keep the default port aligned with the selected scheme so HTTP installs
+    # do not silently inherit the HTTPS port and vice versa.
     local access_scheme="${cfg_access_scheme:-https}"
+    local access_port_default
+    if [[ "${access_scheme,,}" == "http" ]]; then
+        access_port_default="${INGRESS_NGINX_HTTP_PORT:-80}"
+    else
+        access_port_default="${INGRESS_NGINX_HTTPS_PORT:-443}"
+    fi
+    local access_port="${cfg_access_port:-${access_port_default}}"
     local access_path="${cfg_access_path:-/}"
 
     # Storage (local-path)

--- a/deploy/scripts/services/ingress_nginx.sh
+++ b/deploy/scripts/services/ingress_nginx.sh
@@ -1,5 +1,87 @@
 
 # Install ingress-nginx-controller
+_ingress_nginx_live_http_port() {
+    if [[ "${INGRESS_NGINX_HOSTNETWORK}" == "true" ]]; then
+        kubectl -n ingress-nginx get deploy ingress-nginx-controller \
+            -o jsonpath='{.spec.template.spec.containers[0].ports[?(@.name=="http")].hostPort}' 2>/dev/null || true
+    else
+        kubectl -n ingress-nginx get svc ingress-nginx-controller \
+            -o jsonpath='{.spec.ports[?(@.name=="http")].nodePort}' 2>/dev/null || true
+    fi
+}
+
+_ingress_nginx_live_https_port() {
+    if [[ "${INGRESS_NGINX_HOSTNETWORK}" == "true" ]]; then
+        kubectl -n ingress-nginx get deploy ingress-nginx-controller \
+            -o jsonpath='{.spec.template.spec.containers[0].ports[?(@.name=="https")].hostPort}' 2>/dev/null || true
+    else
+        kubectl -n ingress-nginx get svc ingress-nginx-controller \
+            -o jsonpath='{.spec.ports[?(@.name=="https")].nodePort}' 2>/dev/null || true
+    fi
+}
+
+_ingress_nginx_release_needs_upgrade() {
+    local current_image=""
+    local current_http_port=""
+    local current_https_port=""
+    local current_service_type=""
+    local current_host_network=""
+    local current_webhook_exists="false"
+
+    current_image="$(kubectl -n ingress-nginx get deploy ingress-nginx-controller -o jsonpath='{.spec.template.spec.containers[0].image}' 2>/dev/null || true)"
+    if kubectl get validatingwebhookconfiguration ingress-nginx-admission >/dev/null 2>&1; then
+        current_webhook_exists="true"
+    fi
+
+    if [[ "${INGRESS_NGINX_HOSTNETWORK}" == "true" ]]; then
+        current_host_network="$(kubectl -n ingress-nginx get deploy ingress-nginx-controller -o jsonpath='{.spec.template.spec.hostNetwork}' 2>/dev/null || true)"
+        current_http_port="$(_ingress_nginx_live_http_port)"
+        current_https_port="$(_ingress_nginx_live_https_port)"
+        if [[ "${current_host_network}" != "true" ]]; then
+            return 0
+        fi
+    else
+        current_service_type="$(kubectl -n ingress-nginx get svc ingress-nginx-controller -o jsonpath='{.spec.type}' 2>/dev/null || true)"
+        current_http_port="$(_ingress_nginx_live_http_port)"
+        current_https_port="$(_ingress_nginx_live_https_port)"
+        if [[ "${current_service_type}" != "NodePort" ]]; then
+            return 0
+        fi
+    fi
+
+    if [[ -z "${current_image}" || "${current_image}" != "${INGRESS_NGINX_CONTROLLER_IMAGE}" ]]; then
+        return 0
+    fi
+
+    if [[ "${INGRESS_NGINX_HOSTNETWORK}" == "true" ]]; then
+        if [[ "${current_http_port}" != "${INGRESS_NGINX_HTTP_PORT:-80}" ]]; then
+            return 0
+        fi
+        if [[ "${current_https_port}" != "${INGRESS_NGINX_HTTPS_PORT:-443}" ]]; then
+            return 0
+        fi
+    else
+        if [[ "${current_http_port}" != "${INGRESS_NGINX_HTTP_PORT}" ]]; then
+            return 0
+        fi
+        if [[ "${current_https_port}" != "${INGRESS_NGINX_HTTPS_PORT}" ]]; then
+            return 0
+        fi
+    fi
+
+    if [[ "${INGRESS_NGINX_ADMISSION_WEBHOOKS_ENABLED}" == "true" ]]; then
+        if [[ "${current_webhook_exists}" != "true" ]]; then
+            return 0
+        fi
+    else
+        if [[ "${current_webhook_exists}" == "true" ]]; then
+            return 0
+        fi
+    fi
+
+    return 1
+}
+
 install_ingress_nginx() {
     log_info "Installing ingress-nginx-controller..."
 
@@ -20,22 +102,11 @@ install_ingress_nginx() {
 
     if helm status ingress-nginx -n ingress-nginx >/dev/null 2>&1; then
         if kubectl -n ingress-nginx rollout status deployment/ingress-nginx-controller --timeout=3s >/dev/null 2>&1; then
-            local current_image=""
-            current_image="$(kubectl -n ingress-nginx get deploy ingress-nginx-controller -o jsonpath='{.spec.template.spec.containers[0].image}' 2>/dev/null || true)"
-            if [[ -n "${current_image}" && "${current_image}" == "${INGRESS_NGINX_CONTROLLER_IMAGE}" ]]; then
-                if [[ "${INGRESS_NGINX_ADMISSION_WEBHOOKS_ENABLED}" != "true" ]]; then
-                    if kubectl get validatingwebhookconfiguration ingress-nginx-admission >/dev/null 2>&1; then
-                        log_warn "ingress-nginx admission webhook still exists but is disabled in config; upgrading/cleaning..."
-                    else
-                        log_info "ingress-nginx is already installed with desired image (${current_image}), skipping"
-                        return 0
-                    fi
-                else
-                    log_info "ingress-nginx is already installed with desired image (${current_image}), skipping"
-                    return 0
-                fi
+            if [[ "${FORCE_UPGRADE}" != "true" ]] && ! _ingress_nginx_release_needs_upgrade; then
+                log_info "ingress-nginx is already installed with the desired image and ports, skipping"
+                return 0
             fi
-            log_warn "ingress-nginx installed but image differs (${current_image} != ${INGRESS_NGINX_CONTROLLER_IMAGE}); upgrading..."
+            log_warn "ingress-nginx release exists but desired state changed; upgrading..."
         fi
     fi
 
@@ -100,6 +171,7 @@ install_ingress_nginx() {
             --set controller.hostNetwork=true
             --set controller.dnsPolicy=ClusterFirstWithHostNet
             --set controller.service.type=ClusterIP
+            --set controller.updateStrategy.type=Recreate
             --set controller.containerPort.http="${INGRESS_NGINX_HTTP_PORT:-80}"
             --set controller.containerPort.https="${INGRESS_NGINX_HTTPS_PORT:-443}"
             --set controller.hostPort.enabled=true


### PR DESCRIPTION
## Symptoms

1. 安装时填写了 `accessAddress.port`，但 `ingress-nginx-controller` 实际端口没有同步变化。
2. 修改 `INGRESS_NGINX_HTTP_PORT` / `INGRESS_NGINX_HTTPS_PORT` 后重新执行安装脚本，脚本会误判 release 已存在并跳过 `helm upgrade`。
3. 即使触发了 `helm upgrade`，在 `hostNetwork/hostPort` 模式下，默认滚动升级会让新旧 Pod 同时争抢同一主机端口，导致新 Pod Pending，必须手动删除旧 Pod。

## Root Cause

- `accessAddress.port` 只被当作对外访问 URL 的端口，没有联动到 ingress controller 的实际监听端口。
- `install_ingress_nginx()` 只比较镜像，没有把端口变化、hostNetwork/NodePort 模式变化、webhook 开关变化纳入升级判断。
- `hostNetwork/hostPort` 场景下使用默认滚动升级策略，会在单节点上造成端口冲突。

## Expected Behavior

- 输入 `--access_address=https://x.x.x.x:8443` 后，HTTPS ingress 端口应同步为 `8443`。
- 修改 ingress 端口后，脚本应识别端口漂移并执行 `helm upgrade`。
- `hostNetwork=true` 时，升级应避免新旧 Pod 同时占用同一主机端口。

## Actual Behavior

- 端口变更后脚本可能直接跳过升级。
- 已安装 release 的 Pod 在升级时可能因 hostPort 冲突而无法调度。
- 需要手动删除旧 Pod 才能让新 Pod 启动。

## Fix Direction

- 同步 `accessAddress.port` 到对应协议的 ingress 端口变量。
- 生成 `config.yaml` 时，`accessAddress.port` 默认值按 `scheme` 选择。
- 增加 ingress-nginx 的升级漂移检测：
  - 镜像
  - http/https 端口
  - hostNetwork / NodePort 模式
  - webhook 开关状态
- `hostNetwork=true` 时将 `controller.updateStrategy.type` 设置为 `Recreate`。

## Verification

- `bash -n deploy/deploy.sh`
- `bash -n deploy/scripts/services/config.sh`
- `bash -n deploy/scripts/services/ingress_nginx.sh`

## Notes

- 相关日志中可见：
  - `didn't have free ports for the requested pod ports`
  - 新 Pod `Pending`
  - 旧 Pod 仍在 `Running`