### PR TITLE
fix(#371): 解除 get_action_info 死锁 + 补齐行动执行/查询闭环

### DIFF
--- a/adp/bkn/ontology-query/server/logics/action_scheduler/action_scheduler_service.go
+++ b/adp/bkn/ontology-query/server/logics/action_scheduler/action_scheduler_service.go
@@ -103,7 +103,7 @@ func (s *actionSchedulerService) ExecuteAction(ctx context.Context, req *interfa
 
 	if missing := logics.MissingActionInputDynamicParamNames(&actionType, req.DynamicParams); len(missing) > 0 {
 		return nil, rest.NewHTTPError(ctx, http.StatusBadRequest, oerrors.OntologyQuery_ActionExecution_InvalidParameter).
-			WithErrorDetails(fmt.Sprintf("当前请求执行的行动类[%s]所需的动态参数未完整传入，缺少参数 %v，请在请求的 dynamic_params 中填充", actionType.ATName, missing))
+			WithErrorDetails(fmt.Sprintf("当前请求执行的行动类[%s]所需的动态参数未完整传入，缺少参数 %s，请在请求的 dynamic_params 中填充", actionType.ATName, logics.FormatMissingParamNames(missing)))
 	}
 
 	// Get instances based on action type configuration and request parameters

--- a/adp/bkn/ontology-query/server/logics/action_type/action_type_service.go
+++ b/adp/bkn/ontology-query/server/logics/action_type/action_type_service.go
@@ -79,11 +79,9 @@ func (ats *actionTypeService) GetActionsByActionTypeID(ctx context.Context,
 		return resps, httpErr
 	}
 
-	if missing := logics.MissingActionInputDynamicParamNames(&actionType, query.DynamicParams); len(missing) > 0 {
-		return resps, rest.NewHTTPError(ctx, http.StatusBadRequest,
-			oerrors.OntologyQuery_ActionType_InvalidParameter_DynamicParams).
-			WithErrorDetails(fmt.Sprintf("当前请求查询的行动类[%s]所需的动态参数未完整传入，缺少参数 %v，请在请求的 dynamic_params 中填充", actionType.ATName, missing))
-	}
+	// 注意：行动召回/预览路径（get_action_info 走此路）不校验动态参数完整性。
+	// 该阶段目的是返回行动的可执行定义与参数 schema，Agent 需先读到 schema 才知道要传哪些动态参数；
+	// 若此处强制校验会造成死锁（见 issue #371，#291 regression）。动态参数完整性校验只在执行阶段（ExecuteAction）进行。
 
 	// 2. 检查是否绑定了对象类
 	isObjectTypeBound := actionType.ObjectTypeID != ""

--- a/adp/bkn/ontology-query/server/logics/action_type/action_type_service_test.go
+++ b/adp/bkn/ontology-query/server/logics/action_type/action_type_service_test.go
@@ -317,7 +317,10 @@ func Test_actionTypeService_GetActionsByActionTypeID(t *testing.T) {
 			So(result.Actions[0].DynamicParams["input_param"], ShouldEqual, "user_supplied")
 		})
 
-		Convey("失败 - 参数来源为输入但未提供 dynamic_params", func() {
+		// issue #371（#291 regression）：召回/预览路径不再校验动态参数完整性。
+		// get_action_info 走此路，需先拿到 schema 才知道要传哪些动态参数；
+		// 缺参时应成功返回行动定义（缺失的 input 参数值为空），而非 400 死锁。
+		Convey("成功 - 参数来源为输入但未提供 dynamic_params（召回不校验完整性）", func() {
 			query := &interfaces.ActionQuery{
 				KNID:         knID,
 				ActionTypeID: actionTypeID,
@@ -341,18 +344,34 @@ func Test_actionTypeService_GetActionsByActionTypeID(t *testing.T) {
 				},
 			}
 
+			objects := interfaces.Objects{
+				Datas: []map[string]any{
+					{"id": "123"},
+				},
+				ObjectType: &interfaces.ObjectType{
+					ObjectTypeWithKeyField: interfaces.ObjectTypeWithKeyField{
+						OTID: objectTypeID,
+					},
+				},
+			}
+			objectType := interfaces.ObjectType{
+				ObjectTypeWithKeyField: interfaces.ObjectTypeWithKeyField{
+					OTID: objectTypeID,
+				},
+			}
+
 			omAccess.EXPECT().GetActionType(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(actionType, map[string]any{"id": actionType.ATID}, true, nil)
+			omAccess.EXPECT().GetObjectType(gomock.Any(), gomock.Any(), gomock.Any(), objectTypeID).Return(objectType, true, nil)
+			ots.EXPECT().GetObjectsByObjectTypeID(gomock.Any(), gomock.Any()).Return(objects, nil)
 
 			result, err := service.GetActionsByActionTypeID(ctx, query)
-			So(err, ShouldNotBeNil)
-			httpErr, ok := err.(*rest.HTTPError)
-			So(ok, ShouldBeTrue)
-			So(httpErr.HTTPCode, ShouldEqual, http.StatusBadRequest)
-			So(httpErr.BaseError.ErrorCode, ShouldEqual, oerrors.OntologyQuery_ActionType_InvalidParameter_DynamicParams)
-			So(result.TotalCount, ShouldEqual, 0)
+			So(err, ShouldBeNil)
+			So(result.TotalCount, ShouldEqual, 1)
+			// 缺失的 input 参数在召回结果中值为空（nil），交由执行阶段填充/校验
+			So(result.Actions[0].DynamicParams["input_param"], ShouldBeNil)
 		})
 
-		Convey("失败 - 多个 input 参数但 dynamic_params 只给了部分", func() {
+		Convey("成功 - 多个 input 参数但 dynamic_params 只给了部分（召回不校验完整性）", func() {
 			query := &interfaces.ActionQuery{
 				KNID:         knID,
 				ActionTypeID: actionTypeID,
@@ -377,18 +396,34 @@ func Test_actionTypeService_GetActionsByActionTypeID(t *testing.T) {
 				},
 			}
 
+			objects := interfaces.Objects{
+				Datas: []map[string]any{
+					{"id": "123"},
+				},
+				ObjectType: &interfaces.ObjectType{
+					ObjectTypeWithKeyField: interfaces.ObjectTypeWithKeyField{
+						OTID: objectTypeID,
+					},
+				},
+			}
+			objectType := interfaces.ObjectType{
+				ObjectTypeWithKeyField: interfaces.ObjectTypeWithKeyField{
+					OTID: objectTypeID,
+				},
+			}
+
 			omAccess.EXPECT().GetActionType(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(actionType, map[string]any{"id": actionType.ATID}, true, nil)
+			omAccess.EXPECT().GetObjectType(gomock.Any(), gomock.Any(), gomock.Any(), objectTypeID).Return(objectType, true, nil)
+			ots.EXPECT().GetObjectsByObjectTypeID(gomock.Any(), gomock.Any()).Return(objects, nil)
 
 			result, err := service.GetActionsByActionTypeID(ctx, query)
-			So(err, ShouldNotBeNil)
-			httpErr, ok := err.(*rest.HTTPError)
-			So(ok, ShouldBeTrue)
-			So(httpErr.HTTPCode, ShouldEqual, http.StatusBadRequest)
-			So(httpErr.BaseError.ErrorCode, ShouldEqual, oerrors.OntologyQuery_ActionType_InvalidParameter_DynamicParams)
-			So(result.TotalCount, ShouldEqual, 0)
+			So(err, ShouldBeNil)
+			So(result.TotalCount, ShouldEqual, 1)
+			So(result.Actions[0].DynamicParams["input_a"], ShouldEqual, "v1")
+			So(result.Actions[0].DynamicParams["input_b"], ShouldBeNil)
 		})
 
-		Convey("失败 - dynamic_params 中某 input 为 null", func() {
+		Convey("成功 - dynamic_params 中某 input 为 null（召回不校验完整性）", func() {
 			query := &interfaces.ActionQuery{
 				KNID:         knID,
 				ActionTypeID: actionTypeID,
@@ -412,15 +447,30 @@ func Test_actionTypeService_GetActionsByActionTypeID(t *testing.T) {
 				},
 			}
 
+			objects := interfaces.Objects{
+				Datas: []map[string]any{
+					{"id": "123"},
+				},
+				ObjectType: &interfaces.ObjectType{
+					ObjectTypeWithKeyField: interfaces.ObjectTypeWithKeyField{
+						OTID: objectTypeID,
+					},
+				},
+			}
+			objectType := interfaces.ObjectType{
+				ObjectTypeWithKeyField: interfaces.ObjectTypeWithKeyField{
+					OTID: objectTypeID,
+				},
+			}
+
 			omAccess.EXPECT().GetActionType(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(actionType, map[string]any{"id": actionType.ATID}, true, nil)
+			omAccess.EXPECT().GetObjectType(gomock.Any(), gomock.Any(), gomock.Any(), objectTypeID).Return(objectType, true, nil)
+			ots.EXPECT().GetObjectsByObjectTypeID(gomock.Any(), gomock.Any()).Return(objects, nil)
 
 			result, err := service.GetActionsByActionTypeID(ctx, query)
-			So(err, ShouldNotBeNil)
-			httpErr, ok := err.(*rest.HTTPError)
-			So(ok, ShouldBeTrue)
-			So(httpErr.HTTPCode, ShouldEqual, http.StatusBadRequest)
-			So(httpErr.BaseError.ErrorCode, ShouldEqual, oerrors.OntologyQuery_ActionType_InvalidParameter_DynamicParams)
-			So(result.TotalCount, ShouldEqual, 0)
+			So(err, ShouldBeNil)
+			So(result.TotalCount, ShouldEqual, 1)
+			So(result.Actions[0].DynamicParams["input_param"], ShouldBeNil)
 		})
 
 		Convey("成功 - 包含类型信息", func() {

--- a/adp/bkn/ontology-query/server/logics/common.go
+++ b/adp/bkn/ontology-query/server/logics/common.go
@@ -1354,3 +1354,16 @@ func MissingActionInputDynamicParamNames(actionType *interfaces.ActionType, dyna
 	}
 	return missing
 }
+
+// FormatMissingParamNames renders a missing-parameter name list as a quoted,
+// comma-separated string like `"message", "name"`. Using fmt's default %v on a
+// []string yields space-separated names without delimiters (e.g. `[message name]`),
+// which reads as a single parameter named "message name" and misleads callers/agents
+// (see issue #371). This helper keeps each name individually quoted and comma-separated.
+func FormatMissingParamNames(names []string) string {
+	quoted := make([]string, 0, len(names))
+	for _, n := range names {
+		quoted = append(quoted, fmt.Sprintf("%q", n))
+	}
+	return strings.Join(quoted, ", ")
+}

--- a/adp/bkn/ontology-query/server/logics/common_test.go
+++ b/adp/bkn/ontology-query/server/logics/common_test.go
@@ -1665,3 +1665,61 @@ func TestCondCfgToFilterMap(t *testing.T) {
 		So(m["field"], ShouldEqual, "f1")
 	})
 }
+
+func Test_MissingActionInputDynamicParamNames(t *testing.T) {
+	mkAT := func(params ...interfaces.Parameter) *interfaces.ActionType {
+		return &interfaces.ActionType{Parameters: params}
+	}
+	inputParam := func(name string) interfaces.Parameter {
+		return interfaces.Parameter{Name: name, ValueFrom: interfaces.LOGIC_PARAMS_VALUE_FROM_INPUT}
+	}
+	propParam := func(name string) interfaces.Parameter {
+		return interfaces.Parameter{Name: name, ValueFrom: interfaces.LOGIC_PARAMS_VALUE_FROM_PROP}
+	}
+
+	Convey("Test MissingActionInputDynamicParamNames", t, func() {
+		Convey("nil dynamicParams -> all input params missing", func() {
+			missing := MissingActionInputDynamicParamNames(mkAT(inputParam("message"), inputParam("name")), nil)
+			So(missing, ShouldResemble, []string{"message", "name"})
+		})
+		Convey("partial dynamicParams -> only unfilled input params missing", func() {
+			missing := MissingActionInputDynamicParamNames(
+				mkAT(inputParam("message"), inputParam("name")),
+				map[string]any{"message": "hi"},
+			)
+			So(missing, ShouldResemble, []string{"name"})
+		})
+		Convey("null value counts as missing", func() {
+			missing := MissingActionInputDynamicParamNames(
+				mkAT(inputParam("message")),
+				map[string]any{"message": nil},
+			)
+			So(missing, ShouldResemble, []string{"message"})
+		})
+		Convey("non-input params are never reported", func() {
+			missing := MissingActionInputDynamicParamNames(mkAT(propParam("from_prop")), nil)
+			So(missing, ShouldBeEmpty)
+		})
+		Convey("all filled -> nothing missing", func() {
+			missing := MissingActionInputDynamicParamNames(
+				mkAT(inputParam("message"), inputParam("name")),
+				map[string]any{"message": "hi", "name": "zhangsan"},
+			)
+			So(missing, ShouldBeEmpty)
+		})
+	})
+}
+
+func Test_FormatMissingParamNames(t *testing.T) {
+	Convey("Test FormatMissingParamNames", t, func() {
+		Convey("multiple names -> quoted, comma-separated (issue #371, no ambiguous [a b])", func() {
+			So(FormatMissingParamNames([]string{"message", "name"}), ShouldEqual, `"message", "name"`)
+		})
+		Convey("single name -> quoted", func() {
+			So(FormatMissingParamNames([]string{"message"}), ShouldEqual, `"message"`)
+		})
+		Convey("empty -> empty string", func() {
+			So(FormatMissingParamNames(nil), ShouldEqual, "")
+		})
+	})
+}

--- a/adp/context-loader/agent-retrieval/server/bootstrap/tool_dependencies/context_loader_toolset.adp
+++ b/adp/context-loader/agent-retrieval/server/bootstrap/tool_dependencies/context_loader_toolset.adp
@@ -1,3763 +1,4356 @@
 {
-  "toolbox": {
-    "configs": [
-      {
-        "box_id": "e521d454-4a0b-4dc9-8a28-d0986de1cef9",
-        "box_name": "contextloader工具集",
-        "box_desc": "ContextLoader 标准内置工具集；契约版本: 0.9.0",
-        "box_svc_url": "http://agent-retrieval:30779",
-        "status": "published",
-        "category_type": "data_query",
-        "category_name": "数据查询",
-        "is_internal": true,
-        "source": "custom",
-        "tools": [
-          {
-            "tool_id": "05275bb1-46e2-4727-9c6f-97d9ea0af94b",
-            "name": "get_logic_properties_values",
-            "description": "根据 query 生成 dynamic_params，批量查询指定对象的逻辑属性值。",
-            "status": "enabled",
-            "metadata_type": "openapi",
-            "metadata": {
-              "version": "bd55b7ef-8804-4690-af9d-b9996bf5d3ea",
-              "summary": "get_logic_properties_values",
-              "description": "根据 query 生成 dynamic_params，批量查询指定对象的逻辑属性值。",
-              "server_url": "http://agent-retrieval:30779",
-              "path": "/api/agent-retrieval/in/v1/kn/logic-property-resolver",
-              "method": "POST",
-              "create_time": 1776920840666727400,
-              "update_time": 1776920840666727400,
-              "create_user": "ede150ba-06f4-11f1-85aa-3a34099a4c4b",
-              "update_user": "ede150ba-06f4-11f1-85aa-3a34099a4c4b",
-              "api_spec": {
-                "parameters": [
-                  {
-                    "name": "x-account-id",
-                    "in": "header",
-                    "description": "账户ID，用于内部服务调用时传递账户信息",
-                    "required": false,
-                    "schema": {
-                      "type": "string"
-                    }
-                  },
-                  {
-                    "name": "x-account-type",
-                    "in": "header",
-                    "description": "账户类型：user(用户), app(应用), anonymous(匿名)",
-                    "required": false,
-                    "schema": {
-                      "enum": [
-                        "user",
-                        "app",
-                        "anonymous"
-                      ],
-                      "type": "string"
-                    }
-                  },
-                  {
-                    "name": "response_format",
-                    "in": "query",
-                    "description": "响应格式：json 或 toon，默认 json",
-                    "required": false,
-                    "schema": {
-                      "default": "json",
-                      "enum": [
-                        "json",
-                        "toon"
-                      ],
-                      "type": "string"
-                    }
-                  }
-                ],
-                "request_body": {
-                  "description": "",
-                  "content": {
-                    "application/json": {
-                      "examples": {
-                        "示例": {
-                          "value": {
-                            "_instance_identities": [
-                              {
-                                "company_id": "company_000001"
-                              }
-                            ],
-                            "kn_id": "kn_medical",
-                            "ot_id": "company",
-                            "properties": [
-                              "approved_drug_count",
-                              "business_health_score"
-                            ],
-                            "query": "最近一年这些药企的药品上市数量和健康度"
-                          }
-                        }
-                      },
-                      "schema": {
-                        "$ref": "#/components/schemas/ResolveLogicPropertiesRequest"
-                      }
-                    }
-                  },
-                  "required": false
-                },
-                "responses": [
-                  {
-                    "status_code": "200",
-                    "description": "ok",
-                    "content": {
-                      "application/json": {
-                        "schema": {
-                          "$ref": "#/components/schemas/ResolveLogicPropertiesResponse"
-                        }
-                      }
-                    }
-                  },
-                  {
-                    "status_code": "400",
-                    "description": "bad request",
-                    "content": {
-                      "application/json": {
-                        "schema": {
-                          "$ref": "#/components/schemas/Error"
-                        }
-                      }
-                    }
-                  },
-                  {
-                    "status_code": "500",
-                    "description": "internal error",
-                    "content": {
-                      "application/json": {
-                        "schema": {
-                          "$ref": "#/components/schemas/Error"
-                        }
-                      }
-                    }
-                  }
-                ],
-                "components": {
-                  "schemas": {
-                    "ResolveLogicPropertiesResponse": {
-                      "oneOf": [
-                        {
-                          "$ref": "#/components/schemas/ObjectPropertiesValuesResponse"
-                        },
-                        {
-                          "$ref": "#/components/schemas/MissingParamsError"
-                        }
-                      ],
-                      "description": "成功返回 datas；缺参时返回 error_code、missing（含 hint）"
-                    },
-                    "ObjectPropertiesValuesResponse": {
-                      "properties": {
-                        "debug": {
-                          "$ref": "#/components/schemas/ResolveDebugInfo"
-                        },
-                        "datas": {
-                          "items": {
-                            "type": "object"
-                          },
-                          "type": "array",
-                          "description": "与 _instance_identities 顺序对齐，每项含主键和请求的 properties"
-                        }
-                      },
-                      "type": "object",
-                      "required": [
-                        "datas"
-                      ]
-                    },
-                    "ResolveDebugInfo": {
-                      "properties": {
-                        "warnings": {
-                          "items": {
-                            "type": "string"
-                          },
-                          "type": "array"
-                        },
-                        "dynamic_params": {
-                          "type": "object"
-                        },
-                        "now_ms": {
-                          "type": "integer"
-                        },
-                        "trace_id": {
-                          "type": "string"
-                        }
-                      },
-                      "type": "object"
-                    },
-                    "MissingParamsError": {
-                      "type": "object",
-                      "properties": {
-                        "message": {
-                          "type": "string"
-                        },
-                        "missing": {
-                          "items": {
-                            "type": "object",
-                            "properties": {
-                              "params": {
-                                "type": "array",
-                                "items": {
-                                  "type": "object",
-                                  "properties": {
-                                    "name": {
-                                      "type": "string"
-                                    },
-                                    "hint": {
-                                      "type": "string"
-                                    }
-                                  }
-                                }
-                              },
-                              "property": {
-                                "type": "string"
-                              }
-                            }
-                          },
-                          "type": "array"
-                        },
-                        "error_code": {
-                          "type": "string"
-                        }
-                      }
-                    },
-                    "Error": {
-                      "type": "object",
-                      "properties": {
-                        "error_code": {
-                          "type": "string"
-                        },
-                        "message": {
-                          "type": "string"
-                        }
-                      }
-                    },
-                    "ResolveLogicPropertiesRequest": {
-                      "type": "object",
-                      "required": [
-                        "kn_id",
-                        "ot_id",
-                        "query",
-                        "_instance_identities",
-                        "properties"
-                      ],
-                      "properties": {
-                        "query": {
-                          "type": "string",
-                          "description": "用户查询，需含时间（如\"最近一年\"）、统计维度、业务上下文，用于生成 dynamic_params"
-                        },
-                        "_instance_identities": {
-                          "items": {
-                            "type": "object"
-                          },
-                          "type": "array",
-                          "description": "对象实例标识数组。**必须从上游提取，不可臆造。** 流程：先调 query_object_instance 或 query_instance_subgraph → 从每个对象的 _instance_identity 字段取值 → 按原顺序组成数组传入。"
-                        },
-                        "additional_context": {
-                          "description": "可选。补充上下文，如 timezone、instant、step、对象属性等，帮助生成 dynamic_params。",
-                          "type": "string"
-                        },
-                        "kn_id": {
-                          "description": "知识网络ID。例 kn_medical",
-                          "type": "string"
-                        },
-                        "options": {
-                          "$ref": "#/components/schemas/ResolveOptions"
-                        },
-                        "ot_id": {
-                          "description": "对象类ID。例 company、drug",
-                          "type": "string"
-                        },
-                        "properties": {
-                          "description": "逻辑属性名列表（metric/operator）。自动生成 dynamic_params 并查询。",
-                          "items": {
-                            "type": "string"
-                          },
-                          "type": "array"
-                        }
-                      }
-                    },
-                    "ResolveOptions": {
-                      "properties": {
-                        "return_debug": {
-                          "description": "是否返回 debug（dynamic_params、warnings 等）。默认 false",
-                          "type": "boolean"
-                        }
-                      },
-                      "type": "object",
-                      "description": "【可选配置】控制接口行为的高级选项\n"
-                    }
-                  }
-                },
-                "callbacks": null,
-                "security": null,
-                "tags": null,
-                "external_docs": null
-              }
-            },
-            "use_rule": "",
-            "global_parameters": {
-              "name": "",
-              "description": "",
-              "required": false,
-              "in": "",
-              "type": "",
-              "value": null
-            },
-            "create_time": 1776920840668983300,
-            "update_time": 1776920840668983300,
-            "create_user": "ede150ba-06f4-11f1-85aa-3a34099a4c4b",
-            "update_user": "ede150ba-06f4-11f1-85aa-3a34099a4c4b",
-            "extend_info": null,
-            "resource_object": "tool",
-            "source_id": "bd55b7ef-8804-4690-af9d-b9996bf5d3ea",
-            "source_type": "openapi",
-            "script_type": "",
-            "code": "",
-            "dependencies": [],
-            "dependencies_url": ""
-          },
-          {
-            "tool_id": "52b35175-cee3-41ea-91c0-1d70e8371f9c",
-            "name": "search_schema",
-            "description": "统一的 Schema 探索入口。根据 query 返回相关 object_types、relation_types、action_types。",
-            "status": "enabled",
-            "metadata_type": "openapi",
-            "metadata": {
-              "version": "c8371e6b-7d72-47a0-a64c-b3c1bd2f0018",
-              "summary": "search_schema",
-              "description": "统一的 Schema 探索入口。适用于还不确定应该继续调用哪个\n`query_*`、`find_*`、`get_*` 工具时，先通过该接口探索相关 schema 概念。\n",
-              "server_url": "http://agent-retrieval:30779",
-              "path": "/api/agent-retrieval/in/v1/kn/search_schema",
-              "method": "POST",
-              "create_time": 1776920840666727400,
-              "update_time": 1776920840666727400,
-              "create_user": "ede150ba-06f4-11f1-85aa-3a34099a4c4b",
-              "update_user": "ede150ba-06f4-11f1-85aa-3a34099a4c4b",
-              "api_spec": {
-                "parameters": [
-                  {
-                    "name": "x-account-id",
-                    "in": "header",
-                    "description": "账户ID，用于内部服务调用时传递账户信息",
-                    "required": false,
-                    "schema": {
-                      "type": "string"
-                    }
-                  },
-                  {
-                    "name": "x-account-type",
-                    "in": "header",
-                    "description": "账户类型：user(用户), app(应用), anonymous(匿名)",
-                    "required": false,
-                    "schema": {
-                      "enum": [
-                        "user",
-                        "app",
-                        "anonymous"
-                      ],
-                      "type": "string"
-                    }
-                  },
-                  {
-                    "name": "response_format",
-                    "in": "query",
-                    "description": "响应格式：json 或 toon，默认 json",
-                    "required": false,
-                    "schema": {
-                      "default": "json",
-                      "enum": [
-                        "json",
-                        "toon"
-                      ],
-                      "type": "string"
-                    }
-                  }
-                ],
-                "request_body": {
-                  "description": "",
-                  "content": {
-                    "application/json": {
-                      "schema": {
-                        "$ref": "#/components/schemas/SearchSchemaRequest"
-                      }
-                    }
-                  },
-                  "required": false
-                },
-                "responses": [
-                  {
-                    "status_code": "200",
-                    "description": "成功返回 Schema 探索结果",
-                    "content": {
-                      "application/json": {
-                        "schema": {
-                          "$ref": "#/components/schemas/SearchSchemaResponse"
-                        }
-                      }
-                    }
-                  },
-                  {
-                    "status_code": "400",
-                    "description": "参数错误",
-                    "content": {
-                      "application/json": {
-                        "schema": {
-                          "$ref": "#/components/schemas/ErrorResponse"
-                        }
-                      }
-                    }
-                  },
-                  {
-                    "status_code": "500",
-                    "description": "服务器内部错误",
-                    "content": {
-                      "application/json": {
-                        "schema": {
-                          "$ref": "#/components/schemas/ErrorResponse"
-                        }
-                      }
-                    }
-                  }
-                ],
-                "components": {
-                  "schemas": {
-                    "ErrorResponse": {
-                      "properties": {
-                        "description": {
-                          "type": "string"
-                        },
-                        "details": {
-                          "description": "错误详情"
-                        },
-                        "link": {
-                          "type": "string"
-                        },
-                        "solution": {
-                          "type": "string"
-                        },
-                        "code": {
-                          "type": "string"
-                        }
-                      },
-                      "type": "object"
-                    },
-                    "SearchSchemaRequest": {
-                      "type": "object",
-                      "required": [
-                        "query",
-                        "kn_id"
-                      ],
-                      "properties": {
-                        "schema_brief": {
-                          "default": false,
-                          "type": "boolean",
-                          "description": "是否返回精简 Schema，默认返回相对完整的 Schema"
-                        },
-                        "search_scope": {
-                          "$ref": "#/components/schemas/SearchScope"
-                        },
-                        "enable_rerank": {
-                          "description": "是否启用关系类型 Rerank",
-                          "default": true,
-                          "type": "boolean"
-                        },
-                        "include_columns": {
-                          "description": "是否在每个对象类的 data_property 上额外返回物理列名 column（取自 mapped_field）。写 run_sql 时列名要用 column（物理列），而非 name（逻辑名）；二者可不同，同一资源可被多个对象类用不同逻辑名映射。默认 false 保持响应精简。",
-                          "default": false,
-                          "type": "boolean"
-                        },
-                        "kn_id": {
-                          "type": "string",
-                          "description": "知识网络ID。HTTP 接口通过 request body 传入。"
-                        },
-                        "max_concepts": {
-                          "type": "integer",
-                          "description": "Schema 候选规模上限",
-                          "default": 10
-                        },
-                        "query": {
-                          "type": "string",
-                          "description": "用户查询问题或关键词"
-                        }
-                      }
-                    },
-                    "SearchScope": {
-                      "type": "object",
-                      "description": "Schema 探索范围。至少需要开启一种概念类型；不传时默认四类全开。\n`concept_groups` 用于按 BKN 概念分组限定 Schema 召回范围，只作用于概念层发现，不作为实例数据过滤条件。\n`search_scope` 仅约束响应输出，不阻断系统内部使用相关线索辅助召回。\n四个资源开关不能同时为 `false`；若同时为 `false`，接口返回参数错误。\n",
-                      "properties": {
-                        "concept_groups": {
-                          "type": "array",
-                          "description": "BKN 概念分组 ID 列表，用于限定 object_types、relation_types、action_types 与 metric_types 的 Schema 召回范围；不传或为空数组表示不限定分组。分组语义由 BKN 完成（ContextLoader 直接调用 BKN 分组搜索接口并把列表透传下去）。当传入的分组在该知识网络中不存在时，BKN 当前会返回 5xx 错误（如 'BknBackend.ObjectType.InternalError' 含 'all concept group not found ...'），本工具会直接向上透传该错误而不是返回空结果，调用方据此区分'分组不存在'与'分组合法但范围内无概念'。",
-                          "items": {
-                            "type": "string"
-                          }
-                        },
-                        "include_metric_types": {
-                          "description": "是否包含指标类",
-                          "default": true,
-                          "type": "boolean"
-                        },
-                        "include_object_types": {
-                          "default": true,
-                          "type": "boolean",
-                          "description": "是否包含对象类"
-                        },
-                        "include_relation_types": {
-                          "type": "boolean",
-                          "description": "是否包含关系类",
-                          "default": true
-                        },
-                        "include_action_types": {
-                          "type": "boolean",
-                          "description": "是否包含动作类",
-                          "default": true
-                        }
-                      }
-                    },
-                    "SearchSchemaResponse": {
-                      "properties": {
-                        "relation_types": {
-                          "description": "关系类型列表",
-                          "items": {
-                            "type": "object"
-                          },
-                          "type": "array"
-                        },
-                        "action_types": {
-                          "items": {
-                            "type": "object"
-                          },
-                          "type": "array",
-                          "description": "动作类型列表"
-                        },
-                        "metric_types": {
-                          "items": {
-                            "type": "object"
-                          },
-                          "type": "array",
-                          "description": "指标类型列表"
-                        },
-                        "object_types": {
-                          "description": "对象类型列表",
-                          "items": {
-                            "type": "object"
-                          },
-                          "type": "array"
-                        }
-                      },
-                      "type": "object"
-                    }
-                  }
-                },
-                "callbacks": null,
-                "security": null,
-                "tags": [
-                  "SchemaSearch"
-                ],
-                "external_docs": null
-              }
-            },
-            "use_rule": "",
-            "global_parameters": {
-              "name": "",
-              "description": "",
-              "required": false,
-              "in": "",
-              "type": "",
-              "value": null
-            },
-            "create_time": 1776920840668983300,
-            "update_time": 1776920840668983300,
-            "create_user": "ede150ba-06f4-11f1-85aa-3a34099a4c4b",
-            "update_user": "ede150ba-06f4-11f1-85aa-3a34099a4c4b",
-            "extend_info": null,
-            "resource_object": "tool",
-            "source_id": "c8371e6b-7d72-47a0-a64c-b3c1bd2f0018",
-            "source_type": "openapi",
-            "script_type": "",
-            "code": "",
-            "dependencies": [],
-            "dependencies_url": ""
-          },
-          {
-            "tool_id": "5467284c-f25a-4665-8f05-a320dd6e1ec3",
-            "name": "get_kn_index_build_status",
-            "description": "查询最新50个构建任务的整体状态（按创建时间倒排）。如果所有任务都已完成则返回completed，如果有任务正在运行则返回running",
-            "status": "enabled",
-            "metadata_type": "openapi",
-            "metadata": {
-              "version": "168f0ebd-ef5a-49aa-b2f1-dce0850733f8",
-              "summary": "get_kn_index_build_status",
-              "description": "查询最新50个构建任务的整体状态（按创建时间倒排）。如果所有任务都已完成则返回completed，如果有任务正在运行则返回running",
-              "server_url": "http://agent-retrieval:30779",
-              "path": "/api/agent-retrieval/in/v1/kn/full_ontology_building_status",
-              "method": "GET",
-              "create_time": 1776920840666727400,
-              "update_time": 1776920840666727400,
-              "create_user": "ede150ba-06f4-11f1-85aa-3a34099a4c4b",
-              "update_user": "ede150ba-06f4-11f1-85aa-3a34099a4c4b",
-              "api_spec": {
-                "parameters": [
-                  {
-                    "name": "x-account-id",
-                    "in": "header",
-                    "description": "账户ID，用于内部服务调用时传递账户信息",
-                    "required": false,
-                    "schema": {
-                      "type": "string"
-                    }
-                  },
-                  {
-                    "name": "x-account-type",
-                    "in": "header",
-                    "description": "账户类型：user(用户), app(应用), anonymous(匿名)",
-                    "required": false,
-                    "schema": {
-                      "enum": [
-                        "user",
-                        "app",
-                        "anonymous"
-                      ],
-                      "type": "string"
-                    }
-                  },
-                  {
-                    "name": "kn_id",
-                    "in": "query",
-                    "description": "业务知识网络ID",
-                    "required": true,
-                    "schema": {
-                      "type": "string"
-                    }
-                  }
-                ],
-                "request_body": {
-                  "description": "",
-                  "content": {},
-                  "required": false
-                },
-                "responses": [
-                  {
-                    "status_code": "200",
-                    "description": "成功返回构建状态",
-                    "content": {
-                      "application/json": {
-                        "example": {
-                          "kn_id": "d5levlh818p1vl2slp60",
-                          "state": "completed",
-                          "state_detail": "All latest 50 jobs are completed"
-                        },
-                        "schema": {
-                          "$ref": "#/components/schemas/BuildStatusSimpleResponse"
-                        }
-                      }
-                    }
-                  },
-                  {
-                    "status_code": "400",
-                    "description": "参数错误",
-                    "content": {
-                      "application/json": {
-                        "schema": {
-                          "$ref": "#/components/schemas/ErrorResponse"
-                        }
-                      }
-                    }
-                  },
-                  {
-                    "status_code": "401",
-                    "description": "未授权",
-                    "content": {
-                      "application/json": {
-                        "schema": {
-                          "$ref": "#/components/schemas/ErrorResponse"
-                        }
-                      }
-                    }
-                  },
-                  {
-                    "status_code": "500",
-                    "description": "服务器内部错误",
-                    "content": {
-                      "application/json": {
-                        "schema": {
-                          "$ref": "#/components/schemas/ErrorResponse"
-                        }
-                      }
-                    }
-                  }
-                ],
-                "components": {
-                  "schemas": {
-                    "ErrorResponse": {
-                      "type": "object",
-                      "properties": {
-                        "code": {
-                          "type": "string",
-                          "description": "错误码"
-                        },
-                        "description": {
-                          "type": "string",
-                          "description": "错误描述"
-                        },
-                        "detail": {
-                          "description": "错误详情",
-                          "type": "object"
-                        },
-                        "link": {
-                          "description": "错误链接",
-                          "type": "string"
-                        },
-                        "solution": {
-                          "description": "解决方案",
-                          "type": "string"
-                        }
-                      }
-                    },
-                    "BuildStatusSimpleResponse": {
-                      "properties": {
-                        "state_detail": {
-                          "type": "string",
-                          "description": "状态详情"
-                        },
-                        "kn_id": {
-                          "type": "string",
-                          "description": "业务知识网络ID"
-                        },
-                        "state": {
-                          "description": "构建状态（running表示有任务正在运行，completed表示所有任务都已完成）",
-                          "enum": [
-                            "running",
-                            "completed"
-                          ],
-                          "type": "string"
-                        }
-                      },
-                      "type": "object",
-                      "description": "构建状态响应",
-                      "required": [
-                        "kn_id",
-                        "state",
-                        "state_detail"
-                      ]
-                    }
-                  }
-                },
-                "callbacks": null,
-                "security": null,
-                "tags": [
-                  "OntologyJob"
-                ],
-                "external_docs": null
-              }
-            },
-            "use_rule": "",
-            "global_parameters": {
-              "name": "",
-              "description": "",
-              "required": false,
-              "in": "",
-              "type": "",
-              "value": null
-            },
-            "create_time": 1776920840668983300,
-            "update_time": 1776920840668983300,
-            "create_user": "ede150ba-06f4-11f1-85aa-3a34099a4c4b",
-            "update_user": "ede150ba-06f4-11f1-85aa-3a34099a4c4b",
-            "extend_info": null,
-            "resource_object": "tool",
-            "source_id": "168f0ebd-ef5a-49aa-b2f1-dce0850733f8",
-            "source_type": "openapi",
-            "script_type": "",
-            "code": "",
-            "dependencies": [],
-            "dependencies_url": ""
-          },
-          {
-            "tool_id": "3c78c9da-0bd5-48b4-b23b-960972d4d2af",
-            "name": "create_kn_index_build_job",
-            "description": "创建一个全量构建业务知识网络的任务",
-            "status": "enabled",
-            "metadata_type": "openapi",
-            "metadata": {
-              "version": "28462a3e-575c-4ada-b939-dc840d6fcb5f",
-              "summary": "create_kn_index_build_job",
-              "description": "创建一个全量构建业务知识网络的任务",
-              "server_url": "http://agent-retrieval:30779",
-              "path": "/api/agent-retrieval/in/v1/kn/full_build_ontology",
-              "method": "POST",
-              "create_time": 1776920840666727400,
-              "update_time": 1776920840666727400,
-              "create_user": "ede150ba-06f4-11f1-85aa-3a34099a4c4b",
-              "update_user": "ede150ba-06f4-11f1-85aa-3a34099a4c4b",
-              "api_spec": {
-                "parameters": [
-                  {
-                    "name": "x-account-id",
-                    "in": "header",
-                    "description": "账户ID，用于内部服务调用时传递账户信息",
-                    "required": false,
-                    "schema": {
-                      "type": "string"
-                    }
-                  },
-                  {
-                    "name": "x-account-type",
-                    "in": "header",
-                    "description": "账户类型：user(用户), app(应用), anonymous(匿名)",
-                    "required": false,
-                    "schema": {
-                      "enum": [
-                        "user",
-                        "app",
-                        "anonymous"
-                      ],
-                      "type": "string"
-                    }
-                  }
-                ],
-                "request_body": {
-                  "description": "",
-                  "content": {
-                    "application/json": {
-                      "example": {
-                        "kn_id": "kn_1234567890",
-                        "name": "全量构建任务"
-                      },
-                      "schema": {
-                        "$ref": "#/components/schemas/CreateJobRequest"
-                      }
-                    }
-                  },
-                  "required": false
-                },
-                "responses": [
-                  {
-                    "status_code": "201",
-                    "description": "创建成功",
-                    "content": {
-                      "application/json": {
-                        "example": {
-                          "id": "job_1234567890"
-                        },
-                        "schema": {
-                          "$ref": "#/components/schemas/CreateJobResponse"
-                        }
-                      }
-                    }
-                  },
-                  {
-                    "status_code": "400",
-                    "description": "参数错误",
-                    "content": {
-                      "application/json": {
-                        "schema": {
-                          "$ref": "#/components/schemas/ErrorResponse"
-                        }
-                      }
-                    }
-                  },
-                  {
-                    "status_code": "401",
-                    "description": "未授权",
-                    "content": {
-                      "application/json": {
-                        "schema": {
-                          "$ref": "#/components/schemas/ErrorResponse"
-                        }
-                      }
-                    }
-                  },
-                  {
-                    "status_code": "500",
-                    "description": "服务器内部错误",
-                    "content": {
-                      "application/json": {
-                        "schema": {
-                          "$ref": "#/components/schemas/ErrorResponse"
-                        }
-                      }
-                    }
-                  }
-                ],
-                "components": {
-                  "schemas": {
-                    "ErrorResponse": {
-                      "properties": {
-                        "detail": {
-                          "description": "错误详情",
-                          "type": "object"
-                        },
-                        "link": {
-                          "description": "错误链接",
-                          "type": "string"
-                        },
-                        "solution": {
-                          "description": "解决方案",
-                          "type": "string"
-                        },
-                        "code": {
-                          "type": "string",
-                          "description": "错误码"
-                        },
-                        "description": {
-                          "description": "错误描述",
-                          "type": "string"
-                        }
-                      },
-                      "type": "object"
-                    },
-                    "CreateJobRequest": {
-                      "required": [
-                        "kn_id",
-                        "name"
-                      ],
-                      "properties": {
-                        "name": {
-                          "description": "任务名称",
-                          "type": "string"
-                        },
-                        "kn_id": {
-                          "type": "string",
-                          "description": "业务知识网络ID"
-                        }
-                      },
-                      "type": "object"
-                    },
-                    "CreateJobResponse": {
-                      "properties": {
-                        "id": {
-                          "description": "任务ID",
-                          "type": "string"
-                        }
-                      },
-                      "type": "object"
-                    }
-                  }
-                },
-                "callbacks": null,
-                "security": null,
-                "tags": [
-                  "OntologyJob"
-                ],
-                "external_docs": null
-              }
-            },
-            "use_rule": "",
-            "global_parameters": {
-              "name": "",
-              "description": "",
-              "required": false,
-              "in": "",
-              "type": "",
-              "value": null
-            },
-            "create_time": 1776920840668983300,
-            "update_time": 1776920840668983300,
-            "create_user": "ede150ba-06f4-11f1-85aa-3a34099a4c4b",
-            "update_user": "ede150ba-06f4-11f1-85aa-3a34099a4c4b",
-            "extend_info": null,
-            "resource_object": "tool",
-            "source_id": "28462a3e-575c-4ada-b939-dc840d6fcb5f",
-            "source_type": "openapi",
-            "script_type": "",
-            "code": "",
-            "dependencies": [],
-            "dependencies_url": ""
-          },
-          {
-            "tool_id": "8542b7c2-f82a-4c1e-ab8c-83e2e73ccfdf",
-            "name": "query_instance_subgraph",
-            "description": "基于预定义的关系路径查询知识图谱中的对象子图。支持多条路径查询，每条路径返回独立子图。对象以map形式返回，支持过滤条件和排序。query_type需设为\"relation_path\"。\r\n",
-            "status": "enabled",
-            "metadata_type": "openapi",
-            "metadata": {
-              "version": "859c997b-3558-4feb-a60d-432681994dff",
-              "summary": "query_instance_subgraph",
-              "description": "基于预定义的关系路径查询知识图谱中的对象子图。支持多条路径查询，每条路径返回独立子图。对象以map形式返回，支持过滤条件和排序。query_type需设为\"relation_path\"。\n",
-              "server_url": "http://agent-retrieval:30779",
-              "path": "/api/agent-retrieval/in/v1/kn/query_instance_subgraph",
-              "method": "POST",
-              "create_time": 1776920840666727400,
-              "update_time": 1776920840666727400,
-              "create_user": "ede150ba-06f4-11f1-85aa-3a34099a4c4b",
-              "update_user": "ede150ba-06f4-11f1-85aa-3a34099a4c4b",
-              "api_spec": {
-                "parameters": [
-                  {
-                    "name": "x-account-id",
-                    "in": "header",
-                    "description": "账户ID，用于内部服务调用时传递账户信息",
-                    "required": false,
-                    "schema": {
-                      "type": "string"
-                    }
-                  },
-                  {
-                    "name": "x-account-type",
-                    "in": "header",
-                    "description": "账户类型：user(用户), app(应用), anonymous(匿名)",
-                    "required": false,
-                    "schema": {
-                      "enum": [
-                        "user",
-                        "app",
-                        "anonymous"
-                      ],
-                      "type": "string"
-                    }
-                  },
-                  {
-                    "name": "kn_id",
-                    "in": "query",
-                    "description": "业务知识网络ID",
-                    "required": true,
-                    "schema": {
-                      "type": "string"
-                    }
-                  },
-                  {
-                    "name": "include_logic_params",
-                    "in": "query",
-                    "description": "包含逻辑属性的计算参数，默认false，返回结果不包含逻辑属性的字段和值",
-                    "required": false,
-                    "schema": {
-                      "type": "boolean"
-                    }
-                  },
-                  {
-                    "name": "response_format",
-                    "in": "query",
-                    "description": "响应格式：json 或 toon，默认 json",
-                    "required": false,
-                    "schema": {
-                      "default": "json",
-                      "enum": [
-                        "json",
-                        "toon"
-                      ],
-                      "type": "string"
-                    }
-                  }
-                ],
-                "request_body": {
-                  "description": "子图查询请求体",
-                  "content": {
-                    "application/json": {
-                      "schema": {
-                        "$ref": "#/components/schemas/SubGraphQueryBaseOnTypePath"
-                      }
-                    }
-                  },
-                  "required": false
-                },
-                "responses": [
-                  {
-                    "status_code": "200",
-                    "description": "对象子图查询响应体",
-                    "content": {
-                      "application/json": {
-                        "schema": {
-                          "$ref": "#/components/schemas/PathEntries"
-                        }
-                      }
-                    }
-                  }
-                ],
-                "components": {
-                  "schemas": {
-                    "RelationPath": {
-                      "required": [
-                        "relations",
-                        "length"
-                      ],
-                      "properties": {
-                        "relations": {
-                          "items": {
-                            "$ref": "#/components/schemas/Relation"
-                          },
-                          "type": "array",
-                          "description": "路径的边集合，沿着路径顺序出现的边"
-                        },
-                        "length": {
-                          "type": "integer",
-                          "description": "当前路径的长度"
-                        }
-                      },
-                      "type": "object",
-                      "description": "对象的关系路径"
-                    },
-                    "SubGraphQueryBaseOnTypePath": {
-                      "required": [
-                        "relation_type_paths"
-                      ],
-                      "properties": {
-                        "relation_type_paths": {
-                          "type": "array",
-                          "description": "关系类路径集合,数组中可以包含多条不同的关系路径，系统会同时查询并返回所有路径的结果。每条路径必须符合严格的顺序和方向要求。",
-                          "items": {
-                            "$ref": "#/components/schemas/RelationTypePath"
-                          }
-                        }
-                      },
-                      "type": "object",
-                      "description": "查询请求的顶层结构。用于基于关系类路径查询对象子图。relation_type_paths数组中可以包含多条不同的关系路径，系统会同时查询并返回所有路径的结果。每条路径必须符合严格的顺序和方向要求。"
-                    },
-                    "ObjectTypeOnPath": {
-                      "properties": {
-                        "sort": {
-                          "description": "对当前对象类的排序字段",
-                          "items": {
-                            "$ref": "#/components/schemas/Sort"
-                          },
-                          "type": "array"
-                        },
-                        "condition": {
-                          "$ref": "#/components/schemas/Condition"
-                        },
-                        "id": {
-                          "type": "string",
-                          "description": "对象类id"
-                        },
-                        "limit": {
-                          "type": "integer",
-                          "description": "对象类获取对象数量的限制"
-                        }
-                      },
-                      "type": "object",
-                      "description": "路径中的对象类信息",
-                      "required": [
-                        "id",
-                        "condition",
-                        "limit"
-                      ]
-                    },
-                    "ObjectSubGraphResponse": {
-                      "properties": {
-                        "objects": {
-                          "type": "object",
-                          "description": "子图中的对象map，格式为：\n{\n  \"对象ID1\": {ObjectInfoInSubgraph对象1},\n  \"对象ID2\": {ObjectInfoInSubgraph对象2}\n}\n其中key是ObjectInfoInSubgraph中的id属性，value是完整的ObjectInfoInSubgraph对象。\n动态数据字段，其值可以是基本类型、MetricProperty或OperatorProperty\n"
-                        },
-                        "relation_paths": {
-                          "description": "对象的关系路径集合",
-                          "items": {
-                            "$ref": "#/components/schemas/RelationPath"
-                          },
-                          "type": "array"
-                        },
-                        "search_after": {
-                          "description": "表示返回的最后一个起点类对象的排序值，获取这个用于下一次 search_after 分页",
-                          "items": {},
-                          "type": "array"
-                        },
-                        "total_count": {
-                          "description": "起点对象类的总条数",
-                          "type": "integer"
-                        }
-                      },
-                      "type": "object",
-                      "description": "对象子图",
-                      "required": [
-                        "objects",
-                        "relation_paths",
-                        "total_count",
-                        "search_after"
-                      ]
-                    },
-                    "Condition": {
-                      "properties": {
-                        "field": {
-                          "type": "string",
-                          "description": "字段名称，也即对象类的属性名称"
-                        },
-                        "operation": {
-                          "type": "string",
-                          "description": "查询条件操作符。**注意：** 虽然这里列出了所有可能的操作符，但每个对象类实际支持的操作符列表以对象类定义中的 `condition_operations` 字段为准。",
-                          "enum": [
-                            "and",
-                            "or",
-                            "==",
-                            "!=",
-                            ">",
-                            ">=",
-                            "<",
-                            "<=",
-                            "in",
-                            "not_in",
-                            "like",
-                            "not_like",
-                            "exist",
-                            "not_exist",
-                            "match"
-                          ]
-                        },
-                        "sub_conditions": {
-                          "items": {
-                            "$ref": "#/components/schemas/Condition"
-                          },
-                          "type": "array",
-                          "description": "子过滤条件数组，用于逻辑操作符(and/or)的组合查询"
-                        },
-                        "value": {
-                          "description": "字段值，格式根据操作符类型而定：\n- 比较操作符: 单个值\n- 范围查询: [min, max]数组\n- 集合操作: 值数组\n- 向量搜索: 特定格式数组\n\n**必须与 `value_from: \"const\"` 同时使用**\n",
-                          "oneOf": [
-                            {
-                              "type": "string"
-                            },
-                            {
-                              "type": "number"
-                            },
-                            {
-                              "type": "boolean"
-                            },
-                            {
-                              "type": "array",
-                              "items": {
-                                "oneOf": [
-                                  {
-                                    "type": "string"
-                                  },
-                                  {
-                                    "type": "number"
-                                  },
-                                  {
-                                    "type": "boolean"
-                                  }
-                                ]
-                              }
-                            }
-                          ]
-                        },
-                        "value_from": {
-                          "type": "string",
-                          "description": "字段值来源。\n\n**重要：** 当前仅支持 \"const\"（常量值），且必须与 `value` 字段同时使用\n",
-                          "enum": [
-                            "const"
-                          ]
-                        }
-                      },
-                      "type": "object",
-                      "description": "过滤条件结构，用于构建对象实例的查询筛选条件。\n\n**重要规则：**\n- `value_from` 和 `value` 必须同时使用，不能单独使用\n- `value_from` 当前仅支持 \"const\"（常量值）\n- 当使用 `value_from: \"const\"` 时，必须同时提供 `value` 字段\n",
-                      "required": [
-                        "operation"
-                      ]
-                    },
-                    "Relation": {
-                      "description": "一度关系（边）",
-                      "required": [
-                        "relation_type_id",
-                        "relation_type_name",
-                        "source_object_id",
-                        "target_object_id"
-                      ],
-                      "properties": {
-                        "relation_type_id": {
-                          "description": "关系类id",
-                          "type": "string"
-                        },
-                        "relation_type_name": {
-                          "description": "关系类名称",
-                          "type": "string"
-                        },
-                        "source_object_id": {
-                          "type": "string",
-                          "description": "起点对象id"
-                        },
-                        "target_object_id": {
-                          "description": "终点对象id",
-                          "type": "string"
-                        }
-                      },
-                      "type": "object"
-                    },
-                    "TypeEdge": {
-                      "type": "object",
-                      "description": "路径中的边信息。**方向和顺序极其重要**！通过关系类id确定边，通过路径的起点对象类id和终点对象类id来确定当前路径的方向为正向还是反向，与关系类的起终点一致为正向，相反则为反向。每个TypeEdge必须与路径中的前后对象类型严格对应，这直接影响查询结果的正确性。",
-                      "required": [
-                        "relation_type_id",
-                        "source_object_type_id",
-                        "target_object_type_id"
-                      ],
-                      "properties": {
-                        "source_object_type_id": {
-                          "type": "string",
-                          "description": "路径的起点对象类id"
-                        },
-                        "target_object_type_id": {
-                          "description": "路径的终点对象类id",
-                          "type": "string"
-                        },
-                        "relation_type_id": {
-                          "description": "关系类id",
-                          "type": "string"
-                        }
-                      }
-                    },
-                    "PathEntries": {
-                      "required": [
-                        "entries"
-                      ],
-                      "properties": {
-                        "entries": {
-                          "type": "array",
-                          "description": "路径子图",
-                          "items": {
-                            "$ref": "#/components/schemas/ObjectSubGraphResponse"
-                          }
-                        }
-                      },
-                      "type": "object",
-                      "description": "路径子图返回体"
-                    },
-                    "Sort": {
-                      "properties": {
-                        "direction": {
-                          "type": "string",
-                          "description": "排序方向",
-                          "enum": [
-                            "desc",
-                            "asc"
-                          ]
-                        },
-                        "field": {
-                          "type": "string",
-                          "description": "排序字段"
-                        }
-                      },
-                      "type": "object",
-                      "description": "排序字段",
-                      "required": [
-                        "field",
-                        "direction"
-                      ]
-                    },
-                    "RelationTypePath": {
-                      "required": [
-                        "relation_types",
-                        "object_types"
-                      ],
-                      "properties": {
-                        "object_types": {
-                          "items": {
-                            "$ref": "#/components/schemas/ObjectTypeOnPath"
-                          },
-                          "type": "array",
-                          "description": "路径中的对象类集合，**顺序必须严格**与路径中节点出现顺序保持一致。对于n跳路径，object_types数组长度应为n+1，且必须按照source_object_type → 中间节点 → target_object_type的顺序排列。如果某个节点没有过滤条件或者排序或者限制数量，也必须保留其id字段以确保顺序正确。"
-                        },
-                        "relation_types": {
-                          "items": {
-                            "$ref": "#/components/schemas/TypeEdge"
-                          },
-                          "type": "array",
-                          "description": "路径的边集合，**顺序必须严格**按照路径中关系出现的顺序排列。对于n跳路径，relation_types数组长度应为n，且必须与object_types数组中的对象类型严格对应：第i个relation_type的source_object_type_id必须等于object_types数组中第i个对象的id，target_object_type_id必须等于object_types数组中第i+1个对象的id。"
-                        },
-                        "limit": {
-                          "description": "当前路径返回的路径数量的限制。",
-                          "type": "integer"
-                        }
-                      },
-                      "type": "object",
-                      "description": "基于路径获取对象子图。**这是查询的核心结构**！用于定义完整的关系路径查询模板，包括路径中的所有对象类型和关系类型。object_types和relation_types数组的顺序**必须严格对应**，共同构成一个完整的关系路径。"
-                    }
-                  }
-                },
-                "callbacks": null,
-                "security": null,
-                "tags": null,
-                "external_docs": null
-              }
-            },
-            "use_rule": "",
-            "global_parameters": {
-              "name": "",
-              "description": "",
-              "required": false,
-              "in": "",
-              "type": "",
-              "value": null
-            },
-            "create_time": 1776920840668983300,
-            "update_time": 1776920840668983300,
-            "create_user": "ede150ba-06f4-11f1-85aa-3a34099a4c4b",
-            "update_user": "ede150ba-06f4-11f1-85aa-3a34099a4c4b",
-            "extend_info": null,
-            "resource_object": "tool",
-            "source_id": "859c997b-3558-4feb-a60d-432681994dff",
-            "source_type": "openapi",
-            "script_type": "",
-            "code": "",
-            "dependencies": [],
-            "dependencies_url": ""
-          },
-          {
-            "tool_id": "f46fa5df-f371-447f-8451-2d2f34cc78e9",
-            "name": "query_object_instance",
-            "description": "根据单个对象类查询对象实例，该接口基于业务知识网络语义检索接口返回的对象类定义，查询具体的对象实例数据。",
-            "status": "enabled",
-            "metadata_type": "openapi",
-            "metadata": {
-              "version": "3c8de1d0-4943-4460-a600-dc7e979a7573",
-              "summary": "query_object_instance",
-              "description": "根据单个对象类查询对象实例，该接口基于业务知识网络语义检索接口返回的对象类定义，查询具体的对象实例数据。",
-              "server_url": "http://agent-retrieval:30779",
-              "path": "/api/agent-retrieval/in/v1/kn/query_object_instance",
-              "method": "POST",
-              "create_time": 1776920840666727400,
-              "update_time": 1776920840666727400,
-              "create_user": "ede150ba-06f4-11f1-85aa-3a34099a4c4b",
-              "update_user": "ede150ba-06f4-11f1-85aa-3a34099a4c4b",
-              "api_spec": {
-                "parameters": [
-                  {
-                    "name": "x-account-id",
-                    "in": "header",
-                    "description": "账户ID，用于内部服务调用时传递账户信息",
-                    "required": false,
-                    "schema": {
-                      "type": "string"
-                    }
-                  },
-                  {
-                    "name": "x-account-type",
-                    "in": "header",
-                    "description": "账户类型：user(用户), app(应用), anonymous(匿名)",
-                    "required": false,
-                    "schema": {
-                      "enum": [
-                        "user",
-                        "app",
-                        "anonymous"
-                      ],
-                      "type": "string"
-                    }
-                  },
-                  {
-                    "name": "kn_id",
-                    "in": "query",
-                    "description": "业务知识网络ID",
-                    "required": true,
-                    "schema": {
-                      "type": "string"
-                    }
-                  },
-                  {
-                    "name": "ot_id",
-                    "in": "query",
-                    "description": "对象类ID",
-                    "required": true,
-                    "schema": {
-                      "type": "string"
-                    }
-                  },
-                  {
-                    "name": "include_logic_params",
-                    "in": "query",
-                    "description": "包含逻辑属性的计算参数，默认false，返回结果不包含逻辑属性的字段和值",
-                    "required": false,
-                    "schema": {
-                      "type": "boolean"
-                    }
-                  },
-                  {
-                    "name": "response_format",
-                    "in": "query",
-                    "description": "响应格式：json 或 toon，默认 json",
-                    "required": false,
-                    "schema": {
-                      "default": "json",
-                      "enum": [
-                        "json",
-                        "toon"
-                      ],
-                      "type": "string"
-                    }
-                  }
-                ],
-                "request_body": {
-                  "description": "",
-                  "content": {
-                    "application/json": {
-                      "schema": {
-                        "$ref": "#/components/schemas/FirstQueryWithSearchAfter"
-                      }
-                    }
-                  },
-                  "required": false
-                },
-                "responses": [
-                  {
-                    "status_code": "200",
-                    "description": "ok",
-                    "content": {
-                      "application/json": {
-                        "schema": {
-                          "$ref": "#/components/schemas/ObjectDataResponse"
-                        }
-                      }
-                    }
-                  }
-                ],
-                "components": {
-                  "schemas": {
-                    "LogicSource": {
-                      "properties": {
-                        "id": {
-                          "type": "string",
-                          "description": "数据来源ID"
-                        },
-                        "name": {
-                          "type": "string",
-                          "description": "名称。查看详情时返回。"
-                        },
-                        "type": {
-                          "type": "string",
-                          "description": "数据来源类型",
-                          "enum": [
-                            "metric",
-                            "operator"
-                          ]
-                        }
-                      },
-                      "type": "object",
-                      "description": "数据来源",
-                      "required": [
-                        "type",
-                        "id"
-                      ]
-                    },
-                    "FirstQueryWithSearchAfter": {
-                      "properties": {
-                        "sort": {
-                          "description": "排序字段，默认使用 @timestamp排序，排序方向为 desc",
-                          "items": {
-                            "$ref": "#/components/schemas/Sort"
-                          },
-                          "type": "array"
-                        },
-                        "condition": {
-                          "$ref": "#/components/schemas/Condition"
-                        },
-                        "filters": {
-                          "description": "扁平过滤简写：多个条件按 and 组合，覆盖「字段 op 值 [AND ...]」常见场景。与 condition 互斥（同传时 condition 优先）；需要 or/嵌套时改用 condition。",
-                          "items": {
-                            "$ref": "#/components/schemas/FlatFilter"
-                          },
-                          "type": "array"
-                        },
-                        "limit": {
-                          "type": "integer",
-                          "description": "返回的数量，默认值 10。范围 1-100",
-                          "default": 10
-                        },
-                        "need_total": {
-                          "description": "是否需要总数，默认false",
-                          "type": "boolean"
-                        },
-                        "properties": {
-                          "items": {
-                            "type": "string"
-                          },
-                          "type": "array",
-                          "description": "指定返回的对象属性字段列表，默认返回所有属性。"
-                        }
-                      },
-                      "type": "object",
-                      "description": "分页查询的第一次查询请求"
-                    },
-                    "FlatFilter": {
-                      "description": "扁平过滤项：单个 field-op-value 比较。多个 FlatFilter 按 and 组合。value_from 自动取 const，无需提供。仅含比较算子，不支持 and/or（逻辑组合请用 Condition）。",
-                      "required": [
-                        "field",
-                        "op",
-                        "value"
-                      ],
-                      "properties": {
-                        "field": {
-                          "description": "字段名（对象类属性）",
-                          "type": "string"
-                        },
-                        "op": {
-                          "description": "比较算子；白名单以对象类的 condition_operations 为准",
-                          "enum": ["==", "!=", ">", ">=", "<", "<=", "in", "not_in", "like", "not_like", "exist", "not_exist", "match"],
-                          "type": "string"
-                        },
-                        "value": {
-                          "description": "字段值；集合算子（in/not_in）用数组"
-                        }
-                      },
-                      "type": "object"
-                    },
-                    "Parameter4Metric": {
-                      "description": "逻辑参数",
-                      "required": [
-                        "name",
-                        "value_from",
-                        "operation"
-                      ],
-                      "properties": {
-                        "name": {
-                          "type": "string",
-                          "description": "参数名称"
-                        },
-                        "operation": {
-                          "description": "操作符。映射指标模型的属性时，此字段必须",
-                          "enum": [
-                            "in",
-                            "=",
-                            "!=",
-                            ">",
-                            ">=",
-                            "<",
-                            "<="
-                          ],
-                          "type": "string"
-                        },
-                        "value": {
-                          "type": "string",
-                          "description": "参数值。value_from=property时，填入的是对象类的数据属性名称；value_from=input时，不设置此字段"
-                        },
-                        "value_from": {
-                          "enum": [
-                            "property",
-                            "input"
-                          ],
-                          "type": "string",
-                          "description": "值来源"
-                        }
-                      },
-                      "type": "object"
-                    },
-                    "ObjectTypeDetail": {
-                      "type": "object",
-                      "description": "对象类信息",
-                      "properties": {
-                        "comment": {
-                          "type": "string",
-                          "description": "备注（可以为空）"
-                        },
-                        "create_time": {
-                          "format": "int64",
-                          "description": "创建时间",
-                          "type": "integer"
-                        },
-                        "display_key": {
-                          "description": "对象实例的显示属性",
-                          "type": "string"
-                        },
-                        "data_properties": {
-                          "type": "array",
-                          "description": "数据属性",
-                          "items": {
-                            "$ref": "#/components/schemas/DataProperty"
-                          }
-                        },
-                        "primary_keys": {
-                          "description": "主键",
-                          "items": {
-                            "type": "string"
-                          },
-                          "type": "array"
-                        },
-                        "kn_id": {
-                          "description": "业务知识网络id",
-                          "type": "string"
-                        },
-                        "icon": {
-                          "description": "图标",
-                          "type": "string"
-                        },
-                        "tags": {
-                          "description": "标签。 （可以为空）",
-                          "items": {
-                            "type": "string"
-                          },
-                          "type": "array"
-                        },
-                        "color": {
-                          "description": "颜色",
-                          "type": "string"
-                        },
-                        "detail": {
-                          "description": "说明书。按需返回，若指定了include_detail=true，则返回，否则不返回。列表查询时不返回此字段",
-                          "type": "string"
-                        },
-                        "name": {
-                          "type": "string",
-                          "description": "对象类名称"
-                        },
-                        "concept_groups": {
-                          "type": "array",
-                          "description": "概念分组id",
-                          "items": {
-                            "$ref": "#/components/schemas/ConceptGroup"
-                          }
-                        },
-                        "data_source": {
-                          "$ref": "#/components/schemas/DataSource"
-                        },
-                        "logic_properties": {
-                          "description": "逻辑属性",
-                          "items": {
-                            "$ref": "#/components/schemas/LogicProperty"
-                          },
-                          "type": "array"
-                        },
-                        "update_time": {
-                          "type": "integer",
-                          "format": "int64",
-                          "description": "最近一次更新时间"
-                        },
-                        "branch": {
-                          "type": "string",
-                          "description": "分支ID"
-                        },
-                        "creator": {
-                          "type": "string",
-                          "description": "创建人ID"
-                        },
-                        "updater": {
-                          "description": "最近一次修改人",
-                          "type": "string"
-                        },
-                        "id": {
-                          "description": "对象类ID",
-                          "type": "string"
-                        },
-                        "module_type": {
-                          "description": "模块类型",
-                          "enum": [
-                            "object_type"
-                          ],
-                          "type": "string"
-                        }
-                      }
-                    },
-                    "Parameter4Operator": {
-                      "required": [
-                        "name",
-                        "value_from"
-                      ],
-                      "properties": {
-                        "value_from": {
-                          "type": "string",
-                          "description": "值来源",
-                          "enum": [
-                            "property",
-                            "input"
-                          ]
-                        },
-                        "name": {
-                          "type": "string",
-                          "description": "参数名称"
-                        },
-                        "source": {
-                          "description": "参数来源",
-                          "type": "string"
-                        },
-                        "type": {
-                          "type": "string",
-                          "description": "参数类型"
-                        },
-                        "value": {
-                          "description": "参数值。value_from=property时，填入的是对象类的数据属性名称；value_from=input时，不设置此字段",
-                          "type": "string"
-                        }
-                      },
-                      "type": "object",
-                      "description": "逻辑参数"
-                    },
-                    "Sort": {
-                      "type": "object",
-                      "description": "排序字段",
-                      "required": [
-                        "field",
-                        "direction"
-                      ],
-                      "properties": {
-                        "direction": {
-                          "type": "string",
-                          "description": "排序方向",
-                          "enum": [
-                            "desc",
-                            "asc"
-                          ]
-                        },
-                        "field": {
-                          "description": "排序字段",
-                          "type": "string"
-                        }
-                      }
-                    },
-                    "VectorConfig": {
-                      "type": "object",
-                      "description": "向量索引的配置",
-                      "required": [
-                        "dimension"
-                      ],
-                      "properties": {
-                        "dimension": {
-                          "type": "integer",
-                          "description": "向量维度"
-                        }
-                      }
-                    },
-                    "DataSource": {
-                      "required": [
-                        "type",
-                        "id"
-                      ],
-                      "properties": {
-                        "name": {
-                          "type": "string",
-                          "description": "名称。查看详情时返回。"
-                        },
-                        "type": {
-                          "type": "string",
-                          "description": "数据来源类型为数据视图",
-                          "enum": [
-                            "data_view"
-                          ]
-                        },
-                        "id": {
-                          "description": "数据视图ID",
-                          "type": "string"
-                        }
-                      },
-                      "type": "object",
-                      "description": "数据来源"
-                    },
-                    "DataProperty": {
-                      "type": "object",
-                      "description": "数据属性",
-                      "required": [
-                        "name",
-                        "display_name",
-                        "type",
-                        "comment",
-                        "mapped_field",
-                        "index",
-                        "fulltext_config",
-                        "vector_config"
-                      ],
-                      "properties": {
-                        "mapped_field": {
-                          "$ref": "#/components/schemas/ViewField"
-                        },
-                        "name": {
-                          "type": "string",
-                          "description": "属性名称。只能包含小写英文字母、数字、下划线（_）、连字符（-），且不能以下划线和连字符开头"
-                        },
-                        "type": {
-                          "description": "属性数据类型。除了视图的字段类型之外，还有 metric、objective、event、trace、log、operator",
-                          "type": "string"
-                        },
-                        "vector_config": {
-                          "$ref": "#/components/schemas/VectorConfig"
-                        },
-                        "comment": {
-                          "type": "string",
-                          "description": "属性描述"
-                        },
-                        "display_name": {
-                          "type": "string",
-                          "description": "属性显示名"
-                        },
-                        "fulltext_config": {
-                          "$ref": "#/components/schemas/FulltextConfig"
-                        },
-                        "index": {
-                          "description": "是否开启索引，默认是true",
-                          "type": "boolean"
-                        }
-                      }
-                    },
-                    "Parameter": {
-                      "description": "逻辑/指标参数",
-                      "oneOf": [
-                        {
-                          "$ref": "#/components/schemas/Parameter4Operator"
-                        },
-                        {
-                          "$ref": "#/components/schemas/Parameter4Metric"
-                        }
-                      ],
-                      "type": "object"
-                    },
-                    "FulltextConfig": {
-                      "description": "全文索引的配置",
-                      "required": [
-                        "analyzer",
-                        "field_keyword"
-                      ],
-                      "properties": {
-                        "field_keyword": {
-                          "type": "boolean",
-                          "description": "是否保留原始字符串，保留原始字符串可用于精确匹配。默认是false"
-                        },
-                        "analyzer": {
-                          "type": "string",
-                          "description": "分词器",
-                          "enum": [
-                            "standard",
-                            "ik_max_word"
-                          ]
-                        }
-                      },
-                      "type": "object"
-                    },
-                    "ObjectDataResponse": {
-                      "type": "object",
-                      "description": "节点（对象类）信息",
-                      "required": [
-                        "groups",
-                        "type",
-                        "datas",
-                        "search_after"
-                      ],
-                      "properties": {
-                        "datas": {
-                          "description": "对象实例数据。动态数据字段，其值可以是基本类型、MetricProperty或OperatorProperty",
-                          "items": {
-                            "type": "object"
-                          },
-                          "type": "array"
-                        },
-                        "object_type": {
-                          "$ref": "#/components/schemas/ObjectTypeDetail"
-                        },
-                        "search_after": {
-                          "type": "array",
-                          "description": "表示返回的最后一个文档的排序值，获取这个用于下一次 search_after 分页",
-                          "items": {}
-                        },
-                        "total_count": {
-                          "description": "总条数",
-                          "type": "integer"
-                        }
-                      }
-                    },
-                    "ConceptGroup": {
-                      "description": "概念分组",
-                      "required": [
-                        "id",
-                        "name"
-                      ],
-                      "properties": {
-                        "name": {
-                          "description": "概念分组名称",
-                          "type": "string"
-                        },
-                        "id": {
-                          "description": "概念分组ID",
-                          "type": "string"
-                        }
-                      },
-                      "type": "object"
-                    },
-                    "Condition": {
-                      "type": "object",
-                      "description": "过滤条件结构，用于构建对象实例的查询筛选条件。\n\n**重要规则：**\n- `value_from` 和 `value` 必须同时使用，不能单独使用\n- `value_from` 当前仅支持 \"const\"（常量值）\n- 当使用 `value_from: \"const\"` 时，必须同时提供 `value` 字段\n",
-                      "required": [
-                        "operation"
-                      ],
-                      "properties": {
-                        "field": {
-                          "description": "字段名称，也即对象类的属性名称",
-                          "type": "string"
-                        },
-                        "operation": {
-                          "description": "查询条件操作符。\n**注意：** 虽然这里列出了所有可能的操作符，但每个对象类实际支持的操作符列表以对象类定义中的 `condition_operations` 字段为准。\n",
-                          "enum": [
-                            "and",
-                            "or",
-                            "==",
-                            "!=",
-                            ">",
-                            ">=",
-                            "<",
-                            "<=",
-                            "in",
-                            "not_in",
-                            "like",
-                            "not_like",
-                            "exist",
-                            "not_exist",
-                            "match"
-                          ],
-                          "type": "string"
-                        },
-                        "sub_conditions": {
-                          "description": "子过滤条件数组，用于逻辑操作符(and/or)的组合查询",
-                          "items": {
-                            "$ref": "#/components/schemas/Condition"
-                          },
-                          "type": "array"
-                        },
-                        "value": {
-                          "description": "字段值，格式根据操作符类型而定：\n- 比较操作符: 单个值\n- 范围查询: [min, max]数组\n- 集合操作: 值数组\n- 向量搜索: 特定格式数组\n\n**必须与 `value_from: \"const\"` 同时使用**\n"
-                        },
-                        "value_from": {
-                          "description": "字段值来源。\n\n**重要：** 当前仅支持 \"const\"（常量值），且必须与 `value` 字段同时使用\n",
-                          "enum": [
-                            "const"
-                          ],
-                          "type": "string"
-                        }
-                      }
-                    },
-                    "ViewField": {
-                      "description": "视图字段信息",
-                      "required": [
-                        "name"
-                      ],
-                      "properties": {
-                        "name": {
-                          "description": "字段名称",
-                          "type": "string"
-                        },
-                        "type": {
-                          "description": "视图字段类型，查看时有此字段",
-                          "type": "string"
-                        },
-                        "display_name": {
-                          "description": "字段显示名.查看时有此字段",
-                          "type": "string"
-                        }
-                      },
-                      "type": "object"
-                    },
-                    "LogicProperty": {
-                      "required": [
-                        "name",
-                        "data_source",
-                        "parameters"
-                      ],
-                      "properties": {
-                        "name": {
-                          "description": "属性名称。只能包含小写英文字母、数字、下划线（_）、连字符（-），且不能以下划线和连字符开头",
-                          "type": "string"
-                        },
-                        "parameters": {
-                          "items": {
-                            "$ref": "#/components/schemas/Parameter"
-                          },
-                          "type": "array",
-                          "description": "逻辑所需的参数"
-                        },
-                        "type": {
-                          "type": "string",
-                          "description": "属性数据类型。除了视图的字段类型之外，还有 metric、objective、event、trace、log、operator"
-                        },
-                        "comment": {
-                          "description": "属性描述",
-                          "type": "string"
-                        },
-                        "data_source": {
-                          "$ref": "#/components/schemas/LogicSource"
-                        },
-                        "display_name": {
-                          "type": "string",
-                          "description": "属性显示名"
-                        },
-                        "index": {
-                          "type": "boolean",
-                          "description": "是否开启索引，默认是true"
-                        }
-                      },
-                      "type": "object",
-                      "description": "逻辑属性"
-                    }
-                  }
-                },
-                "callbacks": null,
-                "security": null,
-                "tags": null,
-                "external_docs": null
-              }
-            },
-            "use_rule": "",
-            "global_parameters": {
-              "name": "",
-              "description": "",
-              "required": false,
-              "in": "",
-              "type": "",
-              "value": null
-            },
-            "create_time": 1776920840668983300,
-            "update_time": 1776920840668983300,
-            "create_user": "ede150ba-06f4-11f1-85aa-3a34099a4c4b",
-            "update_user": "ede150ba-06f4-11f1-85aa-3a34099a4c4b",
-            "extend_info": null,
-            "resource_object": "tool",
-            "source_id": "3c8de1d0-4943-4460-a600-dc7e979a7573",
-            "source_type": "openapi",
-            "script_type": "",
-            "code": "",
-            "dependencies": [],
-            "dependencies_url": ""
-          },
-          {
-            "tool_id": "00929c5f-3375-4ddc-9fb0-c48a24707f39",
-            "name": "get_action_info",
-            "description": "根据对象实例标识召回关联行动，返回 _dynamic_tools。",
-            "status": "enabled",
-            "metadata_type": "openapi",
-            "metadata": {
-              "version": "7eb88316-d921-4361-ad08-2c1c812e5448",
-              "summary": "get_action_info",
-              "description": "根据对象实例标识召回关联行动，返回 _dynamic_tools。",
-              "server_url": "http://agent-retrieval:30779",
-              "path": "/api/agent-retrieval/in/v1/kn/get_action_info",
-              "method": "POST",
-              "create_time": 1776920840666727400,
-              "update_time": 1776920840666727400,
-              "create_user": "ede150ba-06f4-11f1-85aa-3a34099a4c4b",
-              "update_user": "ede150ba-06f4-11f1-85aa-3a34099a4c4b",
-              "api_spec": {
-                "parameters": [
-                  {
-                    "name": "x-account-id",
-                    "in": "header",
-                    "description": "账户ID，用于内部服务调用时传递账户信息",
-                    "required": false,
-                    "schema": {
-                      "type": "string"
-                    }
-                  },
-                  {
-                    "name": "x-account-type",
-                    "in": "header",
-                    "description": "账户类型：user(用户), app(应用), anonymous(匿名)",
-                    "required": false,
-                    "schema": {
-                      "enum": [
-                        "user",
-                        "app",
-                        "anonymous"
-                      ],
-                      "type": "string"
-                    }
-                  },
-                  {
-                    "name": "response_format",
-                    "in": "query",
-                    "description": "响应格式：json 或 toon，默认 json",
-                    "required": false,
-                    "schema": {
-                      "default": "json",
-                      "enum": [
-                        "json",
-                        "toon"
-                      ],
-                      "type": "string"
-                    }
-                  }
-                ],
-                "request_body": {
-                  "description": "",
-                  "content": {
-                    "application/json": {
-                      "examples": {
-                        "multi_instance_example": {
-                          "summary": "多对象实例示例",
-                          "value": {
-                            "_instance_identities": [
-                              {
-                                "disease_id": "disease_000001"
-                              },
-                              {
-                                "disease_id": "disease_000002"
-                              }
-                            ],
-                            "at_id": "generate_treatment_plan",
-                            "kn_id": "kn_medical"
-                          }
-                        },
-                        "single_instance_example": {
-                          "summary": "单对象实例示例",
-                          "value": {
-                            "_instance_identities": [
-                              {
-                                "disease_id": "disease_000001"
-                              }
-                            ],
-                            "at_id": "generate_treatment_plan",
-                            "kn_id": "kn_medical"
-                          }
-                        }
-                      },
-                      "schema": {
-                        "$ref": "#/components/schemas/ActionRecallRequest"
-                      }
-                    }
-                  },
-                  "required": false
-                },
-                "responses": [
-                  {
-                    "status_code": "200",
-                    "description": "成功返回动态工具列表",
-                    "content": {
-                      "application/json": {
-                        "schema": {
-                          "$ref": "#/components/schemas/ActionRecallResponse"
-                        }
-                      }
-                    }
-                  },
-                  {
-                    "status_code": "400",
-                    "description": "请求参数错误",
-                    "content": {
-                      "application/json": {
-                        "examples": {
-                          "invalid_request": {
-                            "value": {
-                              "code": "INVALID_REQUEST",
-                              "description": "_instance_identities 格式错误"
-                            }
-                          }
-                        },
-                        "schema": {
-                          "$ref": "#/components/schemas/ErrorResponse"
-                        }
-                      }
-                    }
-                  },
-                  {
-                    "status_code": "500",
-                    "description": "服务器内部错误",
-                    "content": {
-                      "application/json": {
-                        "schema": {
-                          "$ref": "#/components/schemas/ErrorResponse"
-                        }
-                      }
-                    }
-                  },
-                  {
-                    "status_code": "502",
-                    "description": "上游服务不可用",
-                    "content": {
-                      "application/json": {
-                        "schema": {
-                          "$ref": "#/components/schemas/ErrorResponse"
-                        }
-                      }
-                    }
-                  }
-                ],
-                "components": {
-                  "schemas": {
-                    "ErrorResponse": {
-                      "type": "object",
-                      "properties": {
-                        "description": {
-                          "type": "string"
-                        },
-                        "code": {
-                          "type": "string"
-                        }
-                      }
-                    },
-                    "ActionRecallRequest": {
-                      "required": [
-                        "kn_id",
-                        "at_id"
-                      ],
-                      "properties": {
-                        "at_id": {
-                          "type": "string",
-                          "description": "行动类ID（从 Schema 获取）"
-                        },
-                        "kn_id": {
-                          "description": "知识网络ID",
-                          "type": "string"
-                        },
-                        "_instance_identities": {
-                          "description": "对象实例标识列表（可选）。每个元素为主键键值对，必须从 query_object_instance 或 query_instance_subgraph 返回的 _instance_identity 字段提取，不可臆造。",
-                          "items": {
-                            "type": "object"
-                          },
-                          "type": "array"
-                        }
-                      },
-                      "type": "object"
-                    },
-                    "ActionRecallResponse": {
-                      "type": "object",
-                      "required": [
-                        "_dynamic_tools"
-                      ],
-                      "properties": {
-                        "_dynamic_tools": {
-                          "description": "Function Call 格式的工具列表",
-                          "items": {
-                            "properties": {
-                              "parameters": {
-                                "type": "object"
-                              },
-                              "api_url": {
-                                "type": "string"
-                              },
-                              "description": {
-                                "type": "string"
-                              },
-                              "fixed_params": {
-                                "type": "object"
-                              },
-                              "name": {
-                                "type": "string"
-                              }
-                            },
-                            "type": "object"
-                          },
-                          "type": "array"
-                        },
-                        "headers": {
-                          "type": "object"
-                        }
-                      }
-                    }
-                  }
-                },
-                "callbacks": null,
-                "security": null,
-                "tags": [
-                  "action-recall"
-                ],
-                "external_docs": null
-              }
-            },
-            "use_rule": "",
-            "global_parameters": {
-              "name": "",
-              "description": "",
-              "required": false,
-              "in": "",
-              "type": "",
-              "value": null
-            },
-            "create_time": 1776920840668983300,
-            "update_time": 1776920840668983300,
-            "create_user": "ede150ba-06f4-11f1-85aa-3a34099a4c4b",
-            "update_user": "ede150ba-06f4-11f1-85aa-3a34099a4c4b",
-            "extend_info": null,
-            "resource_object": "tool",
-            "source_id": "7eb88316-d921-4361-ad08-2c1c812e5448",
-            "source_type": "openapi",
-            "script_type": "",
-            "code": "",
-            "dependencies": [],
-            "dependencies_url": ""
-          },
-          {
-            "tool_id": "74498bbd-2bdf-4db3-a4da-a90133c7fb65",
-            "name": "find_skills",
-            "description": "基于业务上下文召回 Skill 候选列表。\r\n\r\n**召回模式选择规则（自动判断，无需显式指定）：**\r\n\r\n| 请求参数 | 召回模式 |\r\n|---------|---------|\r\n| 仅 kn_id | 网络级（Mode 1） |\r\n| kn_id + object_type_id | 对象类级（Mode 2） |\r\n| kn_id + object_type_id + instance_identities | 实例级（Mode 3） |\r\n\r\n**网络级特殊规则：** 仅当 skills ObjectType 与任意其他 ObjectType 都不存在 RelationType 时才返回结果，\r\n否则返回空列表（需要更精确的 object_type_id 才能召回）。\r\n\r\n**skill_query 说明：** 传入时会对 skills 实例的 name/description 字段追加文本过滤条件（支持 knn/match/like，\r\n优先使用已构建的向量/索引能力），若 BKN 中 skills ObjectType 不存在或元数据获取失败则返回 502。\r\n",
-            "status": "enabled",
-            "metadata_type": "openapi",
-            "metadata": {
-              "version": "69c7eb67-6e11-4df0-bd8f-293c0f4c92bc",
-              "summary": "find_skills",
-              "description": "基于业务上下文召回 Skill 候选列表。\n\n**召回模式选择规则（自动判断，无需显式指定）：**\n\n| 请求参数 | 召回模式 |\n|---------|---------|\n| 仅 kn_id | 网络级（Mode 1） |\n| kn_id + object_type_id | 对象类级（Mode 2） |\n| kn_id + object_type_id + instance_identities | 实例级（Mode 3） |\n\n**网络级特殊规则：** 仅当 skills ObjectType 与任意其他 ObjectType 都不存在 RelationType 时才返回结果，\n否则返回空列表（需要更精确的 object_type_id 才能召回）。\n\n**skill_query 说明：** 传入时会对 skills 实例的 name/description 字段追加文本过滤条件（支持 knn/match/like，\n优先使用已构建的向量/索引能力），若 BKN 中 skills ObjectType 不存在或元数据获取失败则返回 502。\n",
-              "server_url": "http://agent-retrieval:30779",
-              "path": "/api/agent-retrieval/in/v1/kn/find_skills",
-              "method": "POST",
-              "create_time": 1776920840666727400,
-              "update_time": 1776920840666727400,
-              "create_user": "ede150ba-06f4-11f1-85aa-3a34099a4c4b",
-              "update_user": "ede150ba-06f4-11f1-85aa-3a34099a4c4b",
-              "api_spec": {
-                "parameters": [
-                  {
-                    "name": "x-account-id",
-                    "in": "header",
-                    "description": "账户 ID，用于内部服务调用时传递账户信息",
-                    "required": false,
-                    "schema": {
-                      "type": "string"
-                    }
-                  },
-                  {
-                    "name": "x-account-type",
-                    "in": "header",
-                    "description": "账户类型：user（用户）、app（应用）、anonymous（匿名）",
-                    "required": false,
-                    "schema": {
-                      "enum": [
-                        "user",
-                        "app",
-                        "anonymous"
-                      ],
-                      "type": "string"
-                    }
-                  },
-                  {
-                    "name": "response_format",
-                    "in": "query",
-                    "description": "响应格式：json 或 toon，默认 json",
-                    "required": false,
-                    "schema": {
-                      "default": "json",
-                      "enum": [
-                        "json",
-                        "toon"
-                      ],
-                      "type": "string"
-                    }
-                  }
-                ],
-                "request_body": {
-                  "description": "",
-                  "content": {
-                    "application/json": {
-                      "examples": {
-                        "instance_level": {
-                          "summary": "实例级召回（kn_id + object_type_id + instance_identities）",
-                          "value": {
-                            "instance_identities": [
-                              {
-                                "contract_id": "C-2024-001"
-                              }
-                            ],
-                            "kn_id": "kn_legal",
-                            "object_type_id": "contract",
-                            "top_k": 10
-                          }
-                        },
-                        "network_level": {
-                          "summary": "网络级召回（仅 kn_id）",
-                          "value": {
-                            "kn_id": "kn_legal",
-                            "top_k": 10
-                          }
-                        },
-                        "object_type_level": {
-                          "summary": "对象类级召回（kn_id + object_type_id）",
-                          "value": {
-                            "kn_id": "kn_legal",
-                            "object_type_id": "contract",
-                            "top_k": 10
-                          }
-                        },
-                        "with_skill_query": {
-                          "summary": "带语义过滤的实例级召回",
-                          "value": {
-                            "instance_identities": [
-                              {
-                                "contract_id": "C-2024-001"
-                              }
-                            ],
-                            "kn_id": "kn_legal",
-                            "object_type_id": "contract",
-                            "skill_query": "合同审查",
-                            "top_k": 5
-                          }
-                        }
-                      },
-                      "schema": {
-                        "$ref": "#/components/schemas/FindSkillsRequest"
-                      }
-                    }
-                  },
-                  "required": false
-                },
-                "responses": [
-                  {
-                    "status_code": "200",
-                    "description": "成功返回 Skill 候选列表（可能为空列表）",
-                    "content": {
-                      "application/json": {
-                        "examples": {
-                          "empty_result_network_scope": {
-                            "summary": "无匹配 Skill（网络级但 skills 有关联）",
-                            "value": {
-                              "entries": [],
-                              "message": "当前知识网络中的 Skill 不是全局生效，网络级范围未返回结果。请补充 object_type_id；如已定位到实例，再补充 instance_identities 后重试。"
-                            }
-                          },
-                          "empty_result_no_binding": {
-                            "summary": "无匹配 Skill（对象类未配置 Skill 绑定）",
-                            "value": {
-                              "entries": [],
-                              "message": "当前对象类未配置 Skill 绑定关系，无法在该范围内召回 Skill。请确认该对象类是否已绑定 Skill。"
-                            }
-                          },
-                          "success_with_results": {
-                            "summary": "返回 Skill 候选",
-                            "value": {
-                              "entries": [
-                                {
-                                  "description": "对合同条款进行全面审查，识别风险点",
-                                  "name": "合同审查",
-                                  "skill_id": "skill_contract_review"
-                                },
-                                {
-                                  "description": "提取合同中的关键条款和义务",
-                                  "name": "关键条款提取",
-                                  "skill_id": "skill_clause_extract"
-                                }
-                              ]
-                            }
-                          }
-                        },
-                        "schema": {
-                          "$ref": "#/components/schemas/FindSkillsResponse"
-                        }
-                      }
-                    }
-                  },
-                  {
-                    "status_code": "400",
-                    "description": "请求参数错误",
-                    "content": {
-                      "application/json": {
-                        "examples": {
-                          "instance_without_object_type": {
-                            "value": {
-                              "code": "INVALID_REQUEST",
-                              "description": "instance_identities 不为空时 object_type_id 也必须提供"
-                            }
-                          },
-                          "missing_kn_id": {
-                            "value": {
-                              "code": "INVALID_REQUEST",
-                              "description": "kn_id 为必填字段"
-                            }
-                          }
-                        },
-                        "schema": {
-                          "$ref": "#/components/schemas/ErrorResponse"
-                        }
-                      }
-                    }
-                  },
-                  {
-                    "status_code": "502",
-                    "description": "上游服务不可用（BKN 或 ontology-query 异常）",
-                    "content": {
-                      "application/json": {
-                        "examples": {
-                          "skills_ot_not_found": {
-                            "value": {
-                              "code": "BAD_GATEWAY",
-                              "description": "skill_query requires skills ObjectType (id=skills) but none found in kn_id=kn_legal"
-                            }
-                          }
-                        },
-                        "schema": {
-                          "$ref": "#/components/schemas/ErrorResponse"
-                        }
-                      }
-                    }
-                  }
-                ],
-                "components": {
-                  "schemas": {
-                    "FindSkillsRequest": {
-                      "required": [
-                        "kn_id",
-                        "object_type_id"
-                      ],
-                      "properties": {
-                        "skill_query": {
-                          "description": "可选的 Skill 语义过滤词，对 skills 实例的 name/description 字段追加文本过滤。\nBKN 已构建向量时使用 knn，已构建全文索引时使用 match，否则使用 like。\n若 skills ObjectType 元数据获取失败则返回 502。\n",
-                          "type": "string"
-                        },
-                        "top_k": {
-                          "description": "最多返回的 Skill 数量，默认 10，最大 20",
-                          "default": 10,
-                          "type": "integer"
-                        },
-                        "instance_identities": {
-                          "type": "array",
-                          "description": "对象实例标识列表。每个元素为主键键值对，必须从 query_object_instance 或\nquery_instance_subgraph 返回的 _instance_identity 字段提取，不可臆造。\n传入时 object_type_id 也必须提供，否则返回 400。\n",
-                          "items": {
-                            "type": "object"
-                          }
-                        },
-                        "kn_id": {
-                          "type": "string",
-                          "description": "知识网络 ID"
-                        },
-                        "object_type_id": {
-                          "description": "业务对象类型 ID（从 search_schema 返回的概念结果获取）。\n不传时为网络级召回；传入时为对象类级或实例级召回。\n",
-                          "type": "string"
-                        }
-                      },
-                      "type": "object"
-                    },
-                    "FindSkillsResponse": {
-                      "required": [
-                        "entries"
-                      ],
-                      "properties": {
-                        "entries": {
-                          "items": {
-                            "$ref": "#/components/schemas/SkillItem"
-                          },
-                          "type": "array",
-                          "description": "Skill 候选列表，按命中层级优先级（实例级 > 对象类级 > 网络级）和相关性分数降序排列。\n同优先级同分数时按 skill_id 字典序排列，保证顺序稳定。\n无匹配时返回空数组。\n"
-                        },
-                        "message": {
-                          "type": "string",
-                          "description": "空结果说明信息。仅当 entries 为空且接口返回 200 时出现。\n用于向调用方（Agent）解释当前为什么没有结果，以及下一步建议。\nentries 非空时不返回此字段。支持多语言（由请求 X-Language 头决定）。\n"
-                        }
-                      },
-                      "type": "object"
-                    },
-                    "SkillItem": {
-                      "required": [
-                        "skill_id",
-                        "name"
-                      ],
-                      "properties": {
-                        "skill_id": {
-                          "description": "Skill 唯一标识，由 execution-factory 写入 BKN skills ObjectType 时确定",
-                          "type": "string"
-                        },
-                        "description": {
-                          "type": "string",
-                          "description": "Skill 功能描述（可选，BKN 中无此属性时不返回）"
-                        },
-                        "name": {
-                          "description": "Skill 名称",
-                          "type": "string"
-                        }
-                      },
-                      "type": "object"
-                    },
-                    "ErrorResponse": {
-                      "properties": {
-                        "code": {
-                          "type": "string",
-                          "description": "错误码"
-                        },
-                        "description": {
-                          "type": "string",
-                          "description": "错误详情"
-                        }
-                      },
-                      "type": "object"
-                    }
-                  }
-                },
-                "callbacks": null,
-                "security": null,
-                "tags": [
-                  "skill-recall"
-                ],
-                "external_docs": null
-              }
-            },
-            "use_rule": "",
-            "global_parameters": {
-              "name": "",
-              "description": "",
-              "required": false,
-              "in": "",
-              "type": "",
-              "value": null
-            },
-            "create_time": 1776920840668983300,
-            "update_time": 1776920840668983300,
-            "create_user": "ede150ba-06f4-11f1-85aa-3a34099a4c4b",
-            "update_user": "ede150ba-06f4-11f1-85aa-3a34099a4c4b",
-            "extend_info": null,
-            "resource_object": "tool",
-            "source_id": "69c7eb67-6e11-4df0-bd8f-293c0f4c92bc",
-            "source_type": "openapi",
-            "script_type": "",
-            "code": "",
-            "dependencies": [],
-            "dependencies_url": ""
-          },
-          {
-            "tool_id": "a82ef26d-7775-48be-bdc6-cd1d7f90867b",
-            "name": "run_sql",
-            "description": "对知识网络挂载的数据资源执行只读 SQL（Trino 方言）。表名用占位符 {{.resource_id}} 引用（resource_id 取自对象类的 data_source.id，可由 search_schema 获得）；vega 会解析成真实表并限量。仅允许 SELECT/WITH，禁止写入/DDL；单次查询的资源需同属一个数据目录（不支持跨目录 join）。",
-            "status": "enabled",
-            "metadata_type": "openapi",
-            "metadata": {
-              "version": "1839dd82-9cf3-4667-8748-27c2dcdabacd",
-              "summary": "run_sql",
-              "description": "对知识网络挂载的数据资源执行只读 SQL（Trino 方言）。表名用占位符 {{.resource_id}} 引用（resource_id 取自对象类的 data_source.id，可由 search_schema 获得）；vega 会解析成真实表并限量。仅允许 SELECT/WITH，禁止写入/DDL；单次查询的资源需同属一个数据目录（不支持跨目录 join）。",
-              "server_url": "http://agent-retrieval:30779",
-              "path": "/api/agent-retrieval/in/v1/kn/run_sql",
-              "method": "POST",
-              "create_time": 1776920840668983300,
-              "update_time": 1776920840668983300,
-              "create_user": "ede150ba-06f4-11f1-85aa-3a34099a4c4b",
-              "update_user": "ede150ba-06f4-11f1-85aa-3a34099a4c4b",
-              "api_spec": {
-                "parameters": [
-                  {
-                    "name": "x-account-id",
-                    "in": "header",
-                    "description": "账户ID，用于内部服务调用时传递账户信息",
-                    "required": false,
-                    "schema": {
-                      "type": "string"
-                    }
-                  },
-                  {
-                    "name": "x-account-type",
-                    "in": "header",
-                    "description": "账户类型：user(用户), app(应用), anonymous(匿名)",
-                    "required": false,
-                    "schema": {
-                      "enum": [
-                        "user",
-                        "app",
-                        "anonymous"
-                      ],
-                      "type": "string"
-                    }
-                  }
-                ],
-                "request_body": {
-                  "description": "",
-                  "content": {
-                    "application/json": {
-                      "schema": {
-                        "type": "object",
-                        "properties": {
-                          "response_format": {
-                            "type": "string",
-                            "enum": [
-                              "json",
-                              "toon"
-                            ],
-                            "default": "toon",
-                            "description": "文本格式：json 或 toon，默认 toon"
-                          },
-                          "sql": {
-                            "type": "string",
-                            "description": "只读 SQL（Trino 方言）。表名必须用占位符 {{.resource_id}} 引用，resource_id 取自对象类的 data_source.id（可经 search_schema 获得）。仅允许 SELECT / WITH，禁止任何写入与 DDL；不支持多语句；不支持跨数据目录 join（单次查询涉及的资源需同属一个 catalog）。vega 会自动限量（最多 10000 行）。"
-                          },
-                          "resource_type": {
-                            "type": "string",
-                            "description": "连接器类型（mysql / mariadb / postgresql）。留空则按 SQL 中第一个 {{.resource_id}} 自动解析，一般无需填写。"
-                          },
-                          "query_timeout": {
-                            "type": "integer",
-                            "description": "查询超时（秒），范围 1-3600，默认 60。可选。"
-                          }
-                        },
-                        "required": [
-                          "sql"
-                        ]
-                      }
-                    }
-                  },
-                  "required": true
-                },
-                "responses": [
-                  {
-                    "status_code": "200",
-                    "description": "ok",
-                    "content": {
-                      "application/json": {
-                        "schema": {
-                          "type": "object",
-                          "properties": {
-                            "columns": {
-                              "type": "array",
-                              "description": "结果列信息",
-                              "items": {
-                                "type": "object",
-                                "properties": {
-                                  "name": {
-                                    "type": "string"
-                                  },
-                                  "type": {
-                                    "type": "string"
-                                  }
-                                },
-                                "additionalProperties": true
-                              }
-                            },
-                            "entries": {
-                              "type": "array",
-                              "description": "结果行",
-                              "items": {
-                                "type": "object",
-                                "additionalProperties": true
-                              }
-                            },
-                            "total_count": {
-                              "type": "integer",
-                              "description": "返回行数"
-                            },
-                            "warnings": {
-                              "type": "array",
-                              "items": {
-                                "type": "string"
-                              },
-                              "description": "非致命告警（如资源已弃用）"
-                            }
-                          }
-                        }
-                      }
-                    }
-                  }
-                ],
-                "components": null,
-                "callbacks": null,
-                "security": null,
-                "tags": null,
-                "external_docs": null
-              }
-            },
-            "use_rule": "",
-            "global_parameters": {
-              "name": "",
-              "description": "",
-              "required": false,
-              "in": "",
-              "type": "",
-              "value": null
-            },
-            "create_time": 1776920840668983300,
-            "update_time": 1776920840668983300,
-            "create_user": "ede150ba-06f4-11f1-85aa-3a34099a4c4b",
-            "update_user": "ede150ba-06f4-11f1-85aa-3a34099a4c4b",
-            "extend_info": null,
-            "resource_object": "tool",
-            "source_id": "1839dd82-9cf3-4667-8748-27c2dcdabacd",
-            "source_type": "openapi",
-            "script_type": "",
-            "code": "",
-            "dependencies": [],
-            "dependencies_url": ""
-          },
-          {
-            "tool_id": "863acc66-eb74-438a-bfe3-4db2e7def372",
-            "name": "list_knowledge_networks",
-            "description": "列出可用的知识网络（返回 kn_id、名称、描述）。其余查询工具均需 kn_id，作为探索的第一步入口。",
-            "status": "enabled",
-            "metadata_type": "openapi",
-            "metadata": {
-              "version": "262e6732-0759-4e62-8703-a52e84832006",
-              "summary": "list_knowledge_networks",
-              "description": "列出可用的知识网络（返回 kn_id、名称、描述）。其余查询工具均需 kn_id，作为探索的第一步入口。",
-              "server_url": "http://agent-retrieval:30779",
-              "path": "/api/agent-retrieval/in/v1/kn/list_knowledge_networks",
-              "method": "POST",
-              "create_time": 1776920840668983300,
-              "update_time": 1776920840668983300,
-              "create_user": "ede150ba-06f4-11f1-85aa-3a34099a4c4b",
-              "update_user": "ede150ba-06f4-11f1-85aa-3a34099a4c4b",
-              "api_spec": {
-                "parameters": [
-                  {
-                    "name": "x-account-id",
-                    "in": "header",
-                    "description": "账户ID，用于内部服务调用时传递账户信息",
-                    "required": false,
-                    "schema": {
-                      "type": "string"
-                    }
-                  },
-                  {
-                    "name": "x-account-type",
-                    "in": "header",
-                    "description": "账户类型：user(用户), app(应用), anonymous(匿名)",
-                    "required": false,
-                    "schema": {
-                      "enum": [
-                        "user",
-                        "app",
-                        "anonymous"
-                      ],
-                      "type": "string"
-                    }
-                  }
-                ],
-                "request_body": {
-                  "description": "",
-                  "content": {
-                    "application/json": {
-                      "schema": {
-                        "type": "object",
-                        "properties": {
-                          "response_format": {
-                            "type": "string",
-                            "enum": [
-                              "json",
-                              "toon"
-                            ],
-                            "default": "toon",
-                            "description": "文本格式：json 或 toon，默认 toon"
-                          },
-                          "name_pattern": {
-                            "type": "string",
-                            "description": "按知识网络名称模糊过滤，可选"
-                          },
-                          "limit": {
-                            "type": "integer",
-                            "description": "单页数量，默认 20"
-                          },
-                          "offset": {
-                            "type": "integer",
-                            "description": "偏移量，用于翻页，默认 0"
-                          },
-                          "sort": {
-                            "type": "string",
-                            "description": "排序字段，默认 update_time"
-                          },
-                          "direction": {
-                            "type": "string",
-                            "enum": [
-                              "asc",
-                              "desc"
-                            ],
-                            "description": "排序方向，默认 desc"
-                          }
-                        }
-                      }
-                    }
-                  },
-                  "required": true
-                },
-                "responses": [
-                  {
-                    "status_code": "200",
-                    "description": "ok",
-                    "content": {
-                      "application/json": {
-                        "schema": {
-                          "type": "object",
-                          "properties": {
-                            "entries": {
-                              "type": "array",
-                              "description": "知识网络列表",
-                              "items": {
-                                "type": "object",
-                                "properties": {
-                                  "id": {
-                                    "type": "string",
-                                    "description": "知识网络 ID（即 kn_id，供其余查询工具使用）"
-                                  },
-                                  "name": {
-                                    "type": "string",
-                                    "description": "知识网络名称"
-                                  },
-                                  "description": {
-                                    "type": "string",
-                                    "description": "描述"
-                                  },
-                                  "module_type": {
-                                    "type": "string",
-                                    "description": "模块类型"
-                                  },
-                                  "business_domain": {
-                                    "type": "string",
-                                    "description": "业务域"
-                                  }
-                                },
-                                "additionalProperties": true
-                              }
-                            },
-                            "total_count": {
-                              "type": "integer",
-                              "description": "命中总数"
-                            }
-                          }
-                        }
-                      }
-                    }
-                  }
-                ],
-                "components": null,
-                "callbacks": null,
-                "security": null,
-                "tags": null,
-                "external_docs": null
-              }
-            },
-            "use_rule": "",
-            "global_parameters": {
-              "name": "",
-              "description": "",
-              "required": false,
-              "in": "",
-              "type": "",
-              "value": null
-            },
-            "create_time": 1776920840668983300,
-            "update_time": 1776920840668983300,
-            "create_user": "ede150ba-06f4-11f1-85aa-3a34099a4c4b",
-            "update_user": "ede150ba-06f4-11f1-85aa-3a34099a4c4b",
-            "extend_info": null,
-            "resource_object": "tool",
-            "source_id": "262e6732-0759-4e62-8703-a52e84832006",
-            "source_type": "openapi",
-            "script_type": "",
-            "code": "",
-            "dependencies": [],
-            "dependencies_url": ""
-          },
-          {
-            "tool_id": "9ab97b0d-8a65-4c23-bef6-f899a6a1f5f9",
-            "name": "get_kn_detail",
-            "description": "获取知识网络 schema（概念组、对象类型含 data_source.id、关系类型、行动类型）。默认 detail_level=summary：骨架 + 属性名（name/type/comment），不含字段映射 / 查询算子 / 映射规则，足够理解结构与规划查询；需要完整字段映射 / 映射规则时用 detail_level=full 拿全量。",
-            "status": "enabled",
-            "metadata_type": "openapi",
-            "metadata": {
-              "version": "b7c34d4e-b7e7-4e19-b667-1fde349bfcd9",
-              "summary": "get_kn_detail",
-              "description": "获取知识网络 schema（概念组、对象类型含 data_source.id、关系类型、行动类型）。默认 detail_level=summary：骨架 + 属性名（name/type/comment），不含字段映射 / 查询算子 / 映射规则，足够理解结构与规划查询；需要完整字段映射 / 映射规则时用 detail_level=full 拿全量。",
-              "server_url": "http://agent-retrieval:30779",
-              "path": "/api/agent-retrieval/in/v1/kn/get_kn_detail",
-              "method": "POST",
-              "create_time": 1776920840668983300,
-              "update_time": 1776920840668983300,
-              "create_user": "ede150ba-06f4-11f1-85aa-3a34099a4c4b",
-              "update_user": "ede150ba-06f4-11f1-85aa-3a34099a4c4b",
-              "api_spec": {
-                "parameters": [
-                  {
-                    "name": "x-account-id",
-                    "in": "header",
-                    "description": "账户ID，用于内部服务调用时传递账户信息",
-                    "required": false,
-                    "schema": {
-                      "type": "string"
-                    }
-                  },
-                  {
-                    "name": "x-account-type",
-                    "in": "header",
-                    "description": "账户类型：user(用户), app(应用), anonymous(匿名)",
-                    "required": false,
-                    "schema": {
-                      "enum": [
-                        "user",
-                        "app",
-                        "anonymous"
-                      ],
-                      "type": "string"
-                    }
-                  }
-                ],
-                "request_body": {
-                  "description": "",
-                  "content": {
-                    "application/json": {
-                      "schema": {
-                        "type": "object",
-                        "properties": {
-                          "response_format": {
-                            "type": "string",
-                            "enum": [
-                              "json",
-                              "toon"
-                            ],
-                            "default": "toon",
-                            "description": "文本格式：json 或 toon，默认 toon"
-                          },
-                          "kn_id": {
-                            "type": "string",
-                            "description": "知识网络 ID。也可改用 X-Kn-ID 请求头传入。"
-                          },
-                          "detail_level": {
-                            "type": "string",
-                            "enum": [
-                              "summary",
-                              "full"
-                            ],
-                            "default": "summary",
-                            "description": "详情级别。summary（默认）：骨架 + 属性名（name/type/comment），不含字段映射 / 查询算子 / 映射规则；需要完整字段映射 / 映射规则时用 full。"
-                          }
-                        },
-                        "required": [
-                          "kn_id"
-                        ]
-                      }
-                    }
-                  },
-                  "required": true
-                },
-                "responses": [
-                  {
-                    "status_code": "200",
-                    "description": "ok",
-                    "content": {
-                      "application/json": {
-                        "schema": {
-                          "type": "object",
-                          "properties": {
-                            "id": {
-                              "type": "string",
-                              "description": "知识网络 ID"
-                            },
-                            "name": {
-                              "type": "string",
-                              "description": "知识网络名称"
-                            },
-                            "comment": {
-                              "type": "string",
-                              "description": "描述"
-                            },
-                            "concept_groups": {
-                              "type": "array",
-                              "items": {
-                                "type": "object",
-                                "additionalProperties": true
-                              },
-                              "description": "概念组"
-                            },
-                            "object_types": {
-                              "type": "array",
-                              "items": {
-                                "type": "object",
-                                "additionalProperties": true
-                              },
-                              "description": "对象类型（含 data_source 等）"
-                            },
-                            "relation_types": {
-                              "type": "array",
-                              "items": {
-                                "type": "object",
-                                "additionalProperties": true
-                              },
-                              "description": "关系类型"
-                            },
-                            "action_types": {
-                              "type": "array",
-                              "items": {
-                                "type": "object",
-                                "additionalProperties": true
-                              },
-                              "description": "行动类型"
-                            }
-                          }
-                        }
-                      }
-                    }
-                  }
-                ],
-                "components": null,
-                "callbacks": null,
-                "security": null,
-                "tags": null,
-                "external_docs": null
-              }
-            },
-            "use_rule": "",
-            "global_parameters": {
-              "name": "",
-              "description": "",
-              "required": false,
-              "in": "",
-              "type": "",
-              "value": null
-            },
-            "create_time": 1776920840668983300,
-            "update_time": 1776920840668983300,
-            "create_user": "ede150ba-06f4-11f1-85aa-3a34099a4c4b",
-            "update_user": "ede150ba-06f4-11f1-85aa-3a34099a4c4b",
-            "extend_info": null,
-            "resource_object": "tool",
-            "source_id": "b7c34d4e-b7e7-4e19-b667-1fde349bfcd9",
-            "source_type": "openapi",
-            "script_type": "",
-            "code": "",
-            "dependencies": [],
-            "dependencies_url": ""
-          },
-          {
-            "tool_id": "007bb878-29ee-40ed-9d55-bbea8d9f55eb",
-            "name": "get_object_types",
-            "description": "按 id 批量取对象类的完整定义（data_properties 含 mapped_field/condition_operations，logic_properties 含 data_source/parameters）。渐进式下钻：先 get_kn_detail(summary) 拿对象 id，再用本工具展开。ids 支持多个，未匹配的在 missing 返回。",
-            "status": "enabled",
-            "metadata_type": "openapi",
-            "metadata": {
-              "version": "192b5f4e-5d29-4ecb-9c45-77e38852978b",
-              "summary": "get_object_types",
-              "description": "按 id 批量取对象类的完整定义（data_properties 含 mapped_field/condition_operations，logic_properties 含 data_source/parameters）。渐进式下钻：先 get_kn_detail(summary) 拿对象 id，再用本工具展开。ids 支持多个，未匹配的在 missing 返回。",
-              "server_url": "http://agent-retrieval:30779",
-              "path": "/api/agent-retrieval/in/v1/kn/get_object_types",
-              "method": "POST",
-              "create_time": 1776920840668983300,
-              "update_time": 1776920840668983300,
-              "create_user": "ede150ba-06f4-11f1-85aa-3a34099a4c4b",
-              "update_user": "ede150ba-06f4-11f1-85aa-3a34099a4c4b",
-              "api_spec": {
-                "parameters": [
-                  {
-                    "name": "x-account-id",
-                    "in": "header",
-                    "description": "账户ID，用于内部服务调用时传递账户信息",
-                    "required": false,
-                    "schema": {
-                      "type": "string"
-                    }
-                  },
-                  {
-                    "name": "x-account-type",
-                    "in": "header",
-                    "description": "账户类型：user(用户), app(应用), anonymous(匿名)",
-                    "required": false,
-                    "schema": {
-                      "enum": [
-                        "user",
-                        "app",
-                        "anonymous"
-                      ],
-                      "type": "string"
-                    }
-                  }
-                ],
-                "request_body": {
-                  "description": "",
-                  "content": {
-                    "application/json": {
-                      "schema": {
-                        "type": "object",
-                        "properties": {
-                          "response_format": {
-                            "type": "string",
-                            "enum": [
-                              "json",
-                              "toon"
-                            ],
-                            "default": "toon",
-                            "description": "文本格式：json 或 toon，默认 toon"
-                          },
-                          "kn_id": {
-                            "type": "string",
-                            "description": "知识网络 ID。也可改用 X-Kn-ID 请求头传入。"
-                          },
-                          "ids": {
-                            "type": "array",
-                            "items": {
-                              "type": "string"
-                            },
-                            "description": "要展开的对象类 id（取自 get_kn_detail summary 的 object_types[].id，也接受 name）。支持多个。"
-                          }
-                        },
-                        "required": [
-                          "kn_id",
-                          "ids"
-                        ]
-                      }
-                    }
-                  },
-                  "required": true
-                },
-                "responses": [
-                  {
-                    "status_code": "200",
-                    "description": "ok",
-                    "content": {
-                      "application/json": {
-                        "schema": {
-                          "type": "object",
-                          "properties": {
-                            "kn_id": {
-                              "type": "string",
-                              "description": "知识网络 ID"
-                            },
-                            "object_types": {
-                              "type": "array",
-                              "items": {
-                                "type": "object",
-                                "additionalProperties": true
-                              },
-                              "description": "对象类完整定义（含 data_properties / logic_properties 的映射细节）"
-                            },
-                            "missing": {
-                              "type": "array",
-                              "items": {
-                                "type": "string"
-                              },
-                              "description": "请求了但未匹配到的 id"
-                            }
-                          }
-                        }
-                      }
-                    }
-                  }
-                ],
-                "components": null,
-                "callbacks": null,
-                "security": null,
-                "tags": null,
-                "external_docs": null
-              }
-            },
-            "use_rule": "",
-            "global_parameters": {
-              "name": "",
-              "description": "",
-              "required": false,
-              "in": "",
-              "type": "",
-              "value": null
-            },
-            "create_time": 1776920840668983300,
-            "update_time": 1776920840668983300,
-            "create_user": "ede150ba-06f4-11f1-85aa-3a34099a4c4b",
-            "update_user": "ede150ba-06f4-11f1-85aa-3a34099a4c4b",
-            "extend_info": null,
-            "resource_object": "tool",
-            "source_id": "192b5f4e-5d29-4ecb-9c45-77e38852978b",
-            "source_type": "openapi",
-            "script_type": "",
-            "code": "",
-            "dependencies": [],
-            "dependencies_url": ""
-          },
-          {
-            "tool_id": "f961b785-e06e-4633-ac29-ff0b3ae94c12",
-            "name": "get_relation_types",
-            "description": "按 id 批量取关系类的完整定义（含 mapping_rules、source/target 对象名）。渐进式下钻：先 get_kn_detail(summary) 拿关系 id，再用本工具展开。ids 支持多个，未匹配的在 missing 返回。",
-            "status": "enabled",
-            "metadata_type": "openapi",
-            "metadata": {
-              "version": "72ae911c-9cb3-4ba1-8f53-2711701d9a68",
-              "summary": "get_relation_types",
-              "description": "按 id 批量取关系类的完整定义（含 mapping_rules、source/target 对象名）。渐进式下钻：先 get_kn_detail(summary) 拿关系 id，再用本工具展开。ids 支持多个，未匹配的在 missing 返回。",
-              "server_url": "http://agent-retrieval:30779",
-              "path": "/api/agent-retrieval/in/v1/kn/get_relation_types",
-              "method": "POST",
-              "create_time": 1776920840668983300,
-              "update_time": 1776920840668983300,
-              "create_user": "ede150ba-06f4-11f1-85aa-3a34099a4c4b",
-              "update_user": "ede150ba-06f4-11f1-85aa-3a34099a4c4b",
-              "api_spec": {
-                "parameters": [
-                  {
-                    "name": "x-account-id",
-                    "in": "header",
-                    "description": "账户ID，用于内部服务调用时传递账户信息",
-                    "required": false,
-                    "schema": {
-                      "type": "string"
-                    }
-                  },
-                  {
-                    "name": "x-account-type",
-                    "in": "header",
-                    "description": "账户类型：user(用户), app(应用), anonymous(匿名)",
-                    "required": false,
-                    "schema": {
-                      "enum": [
-                        "user",
-                        "app",
-                        "anonymous"
-                      ],
-                      "type": "string"
-                    }
-                  }
-                ],
-                "request_body": {
-                  "description": "",
-                  "content": {
-                    "application/json": {
-                      "schema": {
-                        "type": "object",
-                        "properties": {
-                          "response_format": {
-                            "type": "string",
-                            "enum": [
-                              "json",
-                              "toon"
-                            ],
-                            "default": "toon",
-                            "description": "文本格式：json 或 toon，默认 toon"
-                          },
-                          "kn_id": {
-                            "type": "string",
-                            "description": "知识网络 ID。也可改用 X-Kn-ID 请求头传入。"
-                          },
-                          "ids": {
-                            "type": "array",
-                            "items": {
-                              "type": "string"
-                            },
-                            "description": "要展开的关系类 id（取自 get_kn_detail summary 的 relation_types[].id，也接受 name）。支持多个。"
-                          }
-                        },
-                        "required": [
-                          "kn_id",
-                          "ids"
-                        ]
-                      }
-                    }
-                  },
-                  "required": true
-                },
-                "responses": [
-                  {
-                    "status_code": "200",
-                    "description": "ok",
-                    "content": {
-                      "application/json": {
-                        "schema": {
-                          "type": "object",
-                          "properties": {
-                            "kn_id": {
-                              "type": "string",
-                              "description": "知识网络 ID"
-                            },
-                            "relation_types": {
-                              "type": "array",
-                              "items": {
-                                "type": "object",
-                                "additionalProperties": true
-                              },
-                              "description": "关系类完整定义（含 mapping_rules、source/target 对象名）"
-                            },
-                            "missing": {
-                              "type": "array",
-                              "items": {
-                                "type": "string"
-                              },
-                              "description": "请求了但未匹配到的 id"
-                            }
-                          }
-                        }
-                      }
-                    }
-                  }
-                ],
-                "components": null,
-                "callbacks": null,
-                "security": null,
-                "tags": null,
-                "external_docs": null
-              }
-            },
-            "use_rule": "",
-            "global_parameters": {
-              "name": "",
-              "description": "",
-              "required": false,
-              "in": "",
-              "type": "",
-              "value": null
-            },
-            "create_time": 1776920840668983300,
-            "update_time": 1776920840668983300,
-            "create_user": "ede150ba-06f4-11f1-85aa-3a34099a4c4b",
-            "update_user": "ede150ba-06f4-11f1-85aa-3a34099a4c4b",
-            "extend_info": null,
-            "resource_object": "tool",
-            "source_id": "72ae911c-9cb3-4ba1-8f53-2711701d9a68",
-            "source_type": "openapi",
-            "script_type": "",
-            "code": "",
-            "dependencies": [],
-            "dependencies_url": ""
-          },
-          {
-            "tool_id": "6717eb6b-d933-4fbb-b680-e53969671cab",
-            "name": "list_resources",
-            "description": "数据层资源直查（脱离本体）：列出当前账户有权查看的数据资源（resource_id、name、type、catalog_id），可按 catalog_id / type 过滤。配合 describe_resource + run_sql。",
-            "status": "enabled",
-            "metadata_type": "openapi",
-            "metadata": {
-              "version": "22e619f1-280c-49f3-b583-30bd7afb7922",
-              "summary": "list_resources",
-              "description": "数据层资源直查（脱离本体）：列出当前账户有权查看的数据资源，可按 catalog_id / type 过滤。资源未建成对象类、或想绕本体直查数据时用。配合 describe_resource + run_sql。",
-              "server_url": "http://agent-retrieval:30779",
-              "path": "/api/agent-retrieval/in/v1/kn/list_resources",
-              "method": "POST",
-              "create_time": 1776920840668983300,
-              "update_time": 1776920840668983300,
-              "create_user": "ede150ba-06f4-11f1-85aa-3a34099a4c4b",
-              "update_user": "ede150ba-06f4-11f1-85aa-3a34099a4c4b",
-              "api_spec": {
-                "parameters": [
-                  {
-                    "name": "x-account-id",
-                    "in": "header",
-                    "description": "账户ID，用于内部服务调用时传递账户信息",
-                    "required": false,
-                    "schema": {
-                      "type": "string"
-                    }
-                  },
-                  {
-                    "name": "x-account-type",
-                    "in": "header",
-                    "description": "账户类型：user(用户), app(应用), anonymous(匿名)",
-                    "required": false,
-                    "schema": {
-                      "enum": [
-                        "user",
-                        "app",
-                        "anonymous"
-                      ],
-                      "type": "string"
-                    }
-                  }
-                ],
-                "request_body": {
-                  "description": "",
-                  "content": {
-                    "application/json": {
-                      "schema": {
-                        "type": "object",
-                        "properties": {
-                          "response_format": {
-                            "type": "string",
-                            "enum": [
-                              "json",
-                              "toon"
-                            ],
-                            "default": "toon",
-                            "description": "文本格式：json 或 toon，默认 toon"
-                          },
-                          "catalog_id": {
-                            "type": "string",
-                            "description": "可选。限定某数据目录（catalog）下的资源。"
-                          },
-                          "type": {
-                            "type": "string",
-                            "description": "可选。按资源类别过滤（table / file / fileset / api / metric / topic / index / logicview / dataset）。"
-                          },
-                          "offset": {
-                            "type": "integer",
-                            "description": "可选。分页偏移，默认 0。"
-                          },
-                          "limit": {
-                            "type": "integer",
-                            "description": "可选。分页大小，默认 20。"
-                          }
-                        }
-                      }
-                    }
-                  },
-                  "required": false
-                },
-                "responses": [
-                  {
-                    "status_code": "200",
-                    "description": "ok",
-                    "content": {
-                      "application/json": {
-                        "schema": {
-                          "type": "object",
-                          "properties": {
-                            "entries": {
-                              "type": "array",
-                              "description": "资源列表（仅含当前账户有权查看的资源）",
-                              "items": {
-                                "type": "object",
-                                "properties": {
-                                  "resource_id": {
-                                    "type": "string"
-                                  },
-                                  "name": {
-                                    "type": "string"
-                                  },
-                                  "type": {
-                                    "type": "string"
-                                  },
-                                  "status": {
-                                    "type": "string"
-                                  },
-                                  "catalog_id": {
-                                    "type": "string"
-                                  }
-                                },
-                                "additionalProperties": true
-                              }
-                            },
-                            "total_count": {
-                              "type": "integer",
-                              "description": "符合过滤条件的资源总数"
-                            }
-                          }
-                        }
-                      }
-                    }
-                  }
-                ],
-                "components": null,
-                "callbacks": null,
-                "security": null,
-                "tags": null,
-                "external_docs": null
-              }
-            },
-            "use_rule": "",
-            "global_parameters": {
-              "name": "",
-              "description": "",
-              "required": false,
-              "in": "",
-              "type": "",
-              "value": null
-            },
-            "create_time": 1776920840668983300,
-            "update_time": 1776920840668983300,
-            "create_user": "ede150ba-06f4-11f1-85aa-3a34099a4c4b",
-            "update_user": "ede150ba-06f4-11f1-85aa-3a34099a4c4b",
-            "extend_info": null,
-            "resource_object": "tool",
-            "source_id": "22e619f1-280c-49f3-b583-30bd7afb7922",
-            "source_type": "openapi",
-            "script_type": "",
-            "code": "",
-            "dependencies": [],
-            "dependencies_url": ""
-          },
-          {
-            "tool_id": "0c76b2f0-6902-4179-8670-1bd94ef55b58",
-            "name": "describe_resource",
-            "description": "取单个数据资源的物理 schema：connector_type 与列（columns:[{name,type}]）。写 run_sql 前用它拿物理列名。入参 resource_id 取自 list_resources。",
-            "status": "enabled",
-            "metadata_type": "openapi",
-            "metadata": {
-              "version": "f02d1fb4-aa97-4c93-98f0-2b062e437632",
-              "summary": "describe_resource",
-              "description": "取单个数据资源的物理 schema：connector_type 与列（columns:[{name,type}]）。写 run_sql 前用它拿物理列名。入参 resource_id 取自 list_resources。",
-              "server_url": "http://agent-retrieval:30779",
-              "path": "/api/agent-retrieval/in/v1/kn/describe_resource",
-              "method": "POST",
-              "create_time": 1776920840668983300,
-              "update_time": 1776920840668983300,
-              "create_user": "ede150ba-06f4-11f1-85aa-3a34099a4c4b",
-              "update_user": "ede150ba-06f4-11f1-85aa-3a34099a4c4b",
-              "api_spec": {
-                "parameters": [
-                  {
-                    "name": "x-account-id",
-                    "in": "header",
-                    "description": "账户ID，用于内部服务调用时传递账户信息",
-                    "required": false,
-                    "schema": {
-                      "type": "string"
-                    }
-                  },
-                  {
-                    "name": "x-account-type",
-                    "in": "header",
-                    "description": "账户类型：user(用户), app(应用), anonymous(匿名)",
-                    "required": false,
-                    "schema": {
-                      "enum": [
-                        "user",
-                        "app",
-                        "anonymous"
-                      ],
-                      "type": "string"
-                    }
-                  }
-                ],
-                "request_body": {
-                  "description": "",
-                  "content": {
-                    "application/json": {
-                      "schema": {
-                        "type": "object",
-                        "properties": {
-                          "response_format": {
-                            "type": "string",
-                            "enum": [
-                              "json",
-                              "toon"
-                            ],
-                            "default": "toon",
-                            "description": "文本格式：json 或 toon，默认 toon"
-                          },
-                          "resource_id": {
-                            "type": "string",
-                            "description": "资源 ID（取自 list_resources 的 resource_id）。"
-                          }
-                        },
-                        "required": [
-                          "resource_id"
-                        ]
-                      }
-                    }
-                  },
-                  "required": true
-                },
-                "responses": [
-                  {
-                    "status_code": "200",
-                    "description": "ok",
-                    "content": {
-                      "application/json": {
-                        "schema": {
-                          "type": "object",
-                          "properties": {
-                            "resource_id": {
-                              "type": "string"
-                            },
-                            "connector_type": {
-                              "type": "string",
-                              "description": "连接器类型（mysql / mariadb / postgresql）"
-                            },
-                            "columns": {
-                              "type": "array",
-                              "description": "物理列。写 run_sql 时列名用此处的 name。",
-                              "items": {
-                                "type": "object",
-                                "properties": {
-                                  "name": {
-                                    "type": "string"
-                                  },
-                                  "type": {
-                                    "type": "string"
-                                  },
-                                  "description": {
-                                    "type": "string"
-                                  }
-                                },
-                                "additionalProperties": true
-                              }
-                            }
-                          }
-                        }
-                      }
-                    }
-                  }
-                ],
-                "components": null,
-                "callbacks": null,
-                "security": null,
-                "tags": null,
-                "external_docs": null
-              }
-            },
-            "use_rule": "",
-            "global_parameters": {
-              "name": "",
-              "description": "",
-              "required": false,
-              "in": "",
-              "type": "",
-              "value": null
-            },
-            "create_time": 1776920840668983300,
-            "update_time": 1776920840668983300,
-            "create_user": "ede150ba-06f4-11f1-85aa-3a34099a4c4b",
-            "update_user": "ede150ba-06f4-11f1-85aa-3a34099a4c4b",
-            "extend_info": null,
-            "resource_object": "tool",
-            "source_id": "f02d1fb4-aa97-4c93-98f0-2b062e437632",
-            "source_type": "openapi",
-            "script_type": "",
-            "code": "",
-            "dependencies": [],
-            "dependencies_url": ""
+ "toolbox": {
+  "configs": [
+   {
+    "box_id": "e521d454-4a0b-4dc9-8a28-d0986de1cef9",
+    "box_name": "contextloader工具集",
+    "box_desc": "ContextLoader 标准内置工具集；契约版本: 0.9.0",
+    "box_svc_url": "http://agent-retrieval:30779",
+    "status": "published",
+    "category_type": "data_query",
+    "category_name": "数据查询",
+    "is_internal": true,
+    "source": "custom",
+    "tools": [
+     {
+      "tool_id": "05275bb1-46e2-4727-9c6f-97d9ea0af94b",
+      "name": "get_logic_properties_values",
+      "description": "根据 query 生成 dynamic_params，批量查询指定对象的逻辑属性值。",
+      "status": "enabled",
+      "metadata_type": "openapi",
+      "metadata": {
+       "version": "bd55b7ef-8804-4690-af9d-b9996bf5d3ea",
+       "summary": "get_logic_properties_values",
+       "description": "根据 query 生成 dynamic_params，批量查询指定对象的逻辑属性值。",
+       "server_url": "http://agent-retrieval:30779",
+       "path": "/api/agent-retrieval/in/v1/kn/logic-property-resolver",
+       "method": "POST",
+       "create_time": 1776920840666727400,
+       "update_time": 1776920840666727400,
+       "create_user": "ede150ba-06f4-11f1-85aa-3a34099a4c4b",
+       "update_user": "ede150ba-06f4-11f1-85aa-3a34099a4c4b",
+       "api_spec": {
+        "parameters": [
+         {
+          "name": "x-account-id",
+          "in": "header",
+          "description": "账户ID，用于内部服务调用时传递账户信息",
+          "required": false,
+          "schema": {
+           "type": "string"
           }
+         },
+         {
+          "name": "x-account-type",
+          "in": "header",
+          "description": "账户类型：user(用户), app(应用), anonymous(匿名)",
+          "required": false,
+          "schema": {
+           "enum": [
+            "user",
+            "app",
+            "anonymous"
+           ],
+           "type": "string"
+          }
+         },
+         {
+          "name": "response_format",
+          "in": "query",
+          "description": "响应格式：json 或 toon，默认 json",
+          "required": false,
+          "schema": {
+           "default": "json",
+           "enum": [
+            "json",
+            "toon"
+           ],
+           "type": "string"
+          }
+         }
         ],
-        "create_time": 1776920840665934300,
-        "update_time": 1776920840665934300,
-        "create_user": "ede150ba-06f4-11f1-85aa-3a34099a4c4b",
-        "update_user": "ede150ba-06f4-11f1-85aa-3a34099a4c4b",
-        "metadata_type": "openapi"
-      }
-    ]
-  }
+        "request_body": {
+         "description": "",
+         "content": {
+          "application/json": {
+           "examples": {
+            "示例": {
+             "value": {
+              "_instance_identities": [
+               {
+                "company_id": "company_000001"
+               }
+              ],
+              "kn_id": "kn_medical",
+              "ot_id": "company",
+              "properties": [
+               "approved_drug_count",
+               "business_health_score"
+              ],
+              "query": "最近一年这些药企的药品上市数量和健康度"
+             }
+            }
+           },
+           "schema": {
+            "$ref": "#/components/schemas/ResolveLogicPropertiesRequest"
+           }
+          }
+         },
+         "required": false
+        },
+        "responses": [
+         {
+          "status_code": "200",
+          "description": "ok",
+          "content": {
+           "application/json": {
+            "schema": {
+             "$ref": "#/components/schemas/ResolveLogicPropertiesResponse"
+            }
+           }
+          }
+         },
+         {
+          "status_code": "400",
+          "description": "bad request",
+          "content": {
+           "application/json": {
+            "schema": {
+             "$ref": "#/components/schemas/Error"
+            }
+           }
+          }
+         },
+         {
+          "status_code": "500",
+          "description": "internal error",
+          "content": {
+           "application/json": {
+            "schema": {
+             "$ref": "#/components/schemas/Error"
+            }
+           }
+          }
+         }
+        ],
+        "components": {
+         "schemas": {
+          "ResolveLogicPropertiesResponse": {
+           "oneOf": [
+            {
+             "$ref": "#/components/schemas/ObjectPropertiesValuesResponse"
+            },
+            {
+             "$ref": "#/components/schemas/MissingParamsError"
+            }
+           ],
+           "description": "成功返回 datas；缺参时返回 error_code、missing（含 hint）"
+          },
+          "ObjectPropertiesValuesResponse": {
+           "properties": {
+            "debug": {
+             "$ref": "#/components/schemas/ResolveDebugInfo"
+            },
+            "datas": {
+             "items": {
+              "type": "object"
+             },
+             "type": "array",
+             "description": "与 _instance_identities 顺序对齐，每项含主键和请求的 properties"
+            }
+           },
+           "type": "object",
+           "required": [
+            "datas"
+           ]
+          },
+          "ResolveDebugInfo": {
+           "properties": {
+            "warnings": {
+             "items": {
+              "type": "string"
+             },
+             "type": "array"
+            },
+            "dynamic_params": {
+             "type": "object"
+            },
+            "now_ms": {
+             "type": "integer"
+            },
+            "trace_id": {
+             "type": "string"
+            }
+           },
+           "type": "object"
+          },
+          "MissingParamsError": {
+           "type": "object",
+           "properties": {
+            "message": {
+             "type": "string"
+            },
+            "missing": {
+             "items": {
+              "type": "object",
+              "properties": {
+               "params": {
+                "type": "array",
+                "items": {
+                 "type": "object",
+                 "properties": {
+                  "name": {
+                   "type": "string"
+                  },
+                  "hint": {
+                   "type": "string"
+                  }
+                 }
+                }
+               },
+               "property": {
+                "type": "string"
+               }
+              }
+             },
+             "type": "array"
+            },
+            "error_code": {
+             "type": "string"
+            }
+           }
+          },
+          "Error": {
+           "type": "object",
+           "properties": {
+            "error_code": {
+             "type": "string"
+            },
+            "message": {
+             "type": "string"
+            }
+           }
+          },
+          "ResolveLogicPropertiesRequest": {
+           "type": "object",
+           "required": [
+            "kn_id",
+            "ot_id",
+            "query",
+            "_instance_identities",
+            "properties"
+           ],
+           "properties": {
+            "query": {
+             "type": "string",
+             "description": "用户查询，需含时间（如\"最近一年\"）、统计维度、业务上下文，用于生成 dynamic_params"
+            },
+            "_instance_identities": {
+             "items": {
+              "type": "object"
+             },
+             "type": "array",
+             "description": "对象实例标识数组。**必须从上游提取，不可臆造。** 流程：先调 query_object_instance 或 query_instance_subgraph → 从每个对象的 _instance_identity 字段取值 → 按原顺序组成数组传入。"
+            },
+            "additional_context": {
+             "description": "可选。补充上下文，如 timezone、instant、step、对象属性等，帮助生成 dynamic_params。",
+             "type": "string"
+            },
+            "kn_id": {
+             "description": "知识网络ID。例 kn_medical",
+             "type": "string"
+            },
+            "options": {
+             "$ref": "#/components/schemas/ResolveOptions"
+            },
+            "ot_id": {
+             "description": "对象类ID。例 company、drug",
+             "type": "string"
+            },
+            "properties": {
+             "description": "逻辑属性名列表（metric/operator）。自动生成 dynamic_params 并查询。",
+             "items": {
+              "type": "string"
+             },
+             "type": "array"
+            }
+           }
+          },
+          "ResolveOptions": {
+           "properties": {
+            "return_debug": {
+             "description": "是否返回 debug（dynamic_params、warnings 等）。默认 false",
+             "type": "boolean"
+            }
+           },
+           "type": "object",
+           "description": "【可选配置】控制接口行为的高级选项\n"
+          }
+         }
+        },
+        "callbacks": null,
+        "security": null,
+        "tags": null,
+        "external_docs": null
+       }
+      },
+      "use_rule": "",
+      "global_parameters": {
+       "name": "",
+       "description": "",
+       "required": false,
+       "in": "",
+       "type": "",
+       "value": null
+      },
+      "create_time": 1776920840668983300,
+      "update_time": 1776920840668983300,
+      "create_user": "ede150ba-06f4-11f1-85aa-3a34099a4c4b",
+      "update_user": "ede150ba-06f4-11f1-85aa-3a34099a4c4b",
+      "extend_info": null,
+      "resource_object": "tool",
+      "source_id": "bd55b7ef-8804-4690-af9d-b9996bf5d3ea",
+      "source_type": "openapi",
+      "script_type": "",
+      "code": "",
+      "dependencies": [],
+      "dependencies_url": ""
+     },
+     {
+      "tool_id": "52b35175-cee3-41ea-91c0-1d70e8371f9c",
+      "name": "search_schema",
+      "description": "统一的 Schema 探索入口。根据 query 返回相关 object_types、relation_types、action_types。",
+      "status": "enabled",
+      "metadata_type": "openapi",
+      "metadata": {
+       "version": "c8371e6b-7d72-47a0-a64c-b3c1bd2f0018",
+       "summary": "search_schema",
+       "description": "统一的 Schema 探索入口。适用于还不确定应该继续调用哪个\n`query_*`、`find_*`、`get_*` 工具时，先通过该接口探索相关 schema 概念。\n",
+       "server_url": "http://agent-retrieval:30779",
+       "path": "/api/agent-retrieval/in/v1/kn/search_schema",
+       "method": "POST",
+       "create_time": 1776920840666727400,
+       "update_time": 1776920840666727400,
+       "create_user": "ede150ba-06f4-11f1-85aa-3a34099a4c4b",
+       "update_user": "ede150ba-06f4-11f1-85aa-3a34099a4c4b",
+       "api_spec": {
+        "parameters": [
+         {
+          "name": "x-account-id",
+          "in": "header",
+          "description": "账户ID，用于内部服务调用时传递账户信息",
+          "required": false,
+          "schema": {
+           "type": "string"
+          }
+         },
+         {
+          "name": "x-account-type",
+          "in": "header",
+          "description": "账户类型：user(用户), app(应用), anonymous(匿名)",
+          "required": false,
+          "schema": {
+           "enum": [
+            "user",
+            "app",
+            "anonymous"
+           ],
+           "type": "string"
+          }
+         },
+         {
+          "name": "response_format",
+          "in": "query",
+          "description": "响应格式：json 或 toon，默认 json",
+          "required": false,
+          "schema": {
+           "default": "json",
+           "enum": [
+            "json",
+            "toon"
+           ],
+           "type": "string"
+          }
+         }
+        ],
+        "request_body": {
+         "description": "",
+         "content": {
+          "application/json": {
+           "schema": {
+            "$ref": "#/components/schemas/SearchSchemaRequest"
+           }
+          }
+         },
+         "required": false
+        },
+        "responses": [
+         {
+          "status_code": "200",
+          "description": "成功返回 Schema 探索结果",
+          "content": {
+           "application/json": {
+            "schema": {
+             "$ref": "#/components/schemas/SearchSchemaResponse"
+            }
+           }
+          }
+         },
+         {
+          "status_code": "400",
+          "description": "参数错误",
+          "content": {
+           "application/json": {
+            "schema": {
+             "$ref": "#/components/schemas/ErrorResponse"
+            }
+           }
+          }
+         },
+         {
+          "status_code": "500",
+          "description": "服务器内部错误",
+          "content": {
+           "application/json": {
+            "schema": {
+             "$ref": "#/components/schemas/ErrorResponse"
+            }
+           }
+          }
+         }
+        ],
+        "components": {
+         "schemas": {
+          "ErrorResponse": {
+           "properties": {
+            "description": {
+             "type": "string"
+            },
+            "details": {
+             "description": "错误详情"
+            },
+            "link": {
+             "type": "string"
+            },
+            "solution": {
+             "type": "string"
+            },
+            "code": {
+             "type": "string"
+            }
+           },
+           "type": "object"
+          },
+          "SearchSchemaRequest": {
+           "type": "object",
+           "required": [
+            "query",
+            "kn_id"
+           ],
+           "properties": {
+            "schema_brief": {
+             "default": false,
+             "type": "boolean",
+             "description": "是否返回精简 Schema，默认返回相对完整的 Schema"
+            },
+            "search_scope": {
+             "$ref": "#/components/schemas/SearchScope"
+            },
+            "enable_rerank": {
+             "description": "是否启用关系类型 Rerank",
+             "default": true,
+             "type": "boolean"
+            },
+            "include_columns": {
+             "description": "是否在每个对象类的 data_property 上额外返回物理列名 column（取自 mapped_field）。写 run_sql 时列名要用 column（物理列），而非 name（逻辑名）；二者可不同，同一资源可被多个对象类用不同逻辑名映射。默认 false 保持响应精简。",
+             "default": false,
+             "type": "boolean"
+            },
+            "kn_id": {
+             "type": "string",
+             "description": "知识网络ID。HTTP 接口通过 request body 传入。"
+            },
+            "max_concepts": {
+             "type": "integer",
+             "description": "Schema 候选规模上限",
+             "default": 10
+            },
+            "query": {
+             "type": "string",
+             "description": "用户查询问题或关键词"
+            }
+           }
+          },
+          "SearchScope": {
+           "type": "object",
+           "description": "Schema 探索范围。至少需要开启一种概念类型；不传时默认四类全开。\n`concept_groups` 用于按 BKN 概念分组限定 Schema 召回范围，只作用于概念层发现，不作为实例数据过滤条件。\n`search_scope` 仅约束响应输出，不阻断系统内部使用相关线索辅助召回。\n四个资源开关不能同时为 `false`；若同时为 `false`，接口返回参数错误。\n",
+           "properties": {
+            "concept_groups": {
+             "type": "array",
+             "description": "BKN 概念分组 ID 列表，用于限定 object_types、relation_types、action_types 与 metric_types 的 Schema 召回范围；不传或为空数组表示不限定分组。分组语义由 BKN 完成（ContextLoader 直接调用 BKN 分组搜索接口并把列表透传下去）。当传入的分组在该知识网络中不存在时，BKN 当前会返回 5xx 错误（如 'BknBackend.ObjectType.InternalError' 含 'all concept group not found ...'），本工具会直接向上透传该错误而不是返回空结果，调用方据此区分'分组不存在'与'分组合法但范围内无概念'。",
+             "items": {
+              "type": "string"
+             }
+            },
+            "include_metric_types": {
+             "description": "是否包含指标类",
+             "default": true,
+             "type": "boolean"
+            },
+            "include_object_types": {
+             "default": true,
+             "type": "boolean",
+             "description": "是否包含对象类"
+            },
+            "include_relation_types": {
+             "type": "boolean",
+             "description": "是否包含关系类",
+             "default": true
+            },
+            "include_action_types": {
+             "type": "boolean",
+             "description": "是否包含动作类",
+             "default": true
+            }
+           }
+          },
+          "SearchSchemaResponse": {
+           "properties": {
+            "relation_types": {
+             "description": "关系类型列表",
+             "items": {
+              "type": "object"
+             },
+             "type": "array"
+            },
+            "action_types": {
+             "items": {
+              "type": "object"
+             },
+             "type": "array",
+             "description": "动作类型列表"
+            },
+            "metric_types": {
+             "items": {
+              "type": "object"
+             },
+             "type": "array",
+             "description": "指标类型列表"
+            },
+            "object_types": {
+             "description": "对象类型列表",
+             "items": {
+              "type": "object"
+             },
+             "type": "array"
+            }
+           },
+           "type": "object"
+          }
+         }
+        },
+        "callbacks": null,
+        "security": null,
+        "tags": [
+         "SchemaSearch"
+        ],
+        "external_docs": null
+       }
+      },
+      "use_rule": "",
+      "global_parameters": {
+       "name": "",
+       "description": "",
+       "required": false,
+       "in": "",
+       "type": "",
+       "value": null
+      },
+      "create_time": 1776920840668983300,
+      "update_time": 1776920840668983300,
+      "create_user": "ede150ba-06f4-11f1-85aa-3a34099a4c4b",
+      "update_user": "ede150ba-06f4-11f1-85aa-3a34099a4c4b",
+      "extend_info": null,
+      "resource_object": "tool",
+      "source_id": "c8371e6b-7d72-47a0-a64c-b3c1bd2f0018",
+      "source_type": "openapi",
+      "script_type": "",
+      "code": "",
+      "dependencies": [],
+      "dependencies_url": ""
+     },
+     {
+      "tool_id": "5467284c-f25a-4665-8f05-a320dd6e1ec3",
+      "name": "get_kn_index_build_status",
+      "description": "查询最新50个构建任务的整体状态（按创建时间倒排）。如果所有任务都已完成则返回completed，如果有任务正在运行则返回running",
+      "status": "enabled",
+      "metadata_type": "openapi",
+      "metadata": {
+       "version": "168f0ebd-ef5a-49aa-b2f1-dce0850733f8",
+       "summary": "get_kn_index_build_status",
+       "description": "查询最新50个构建任务的整体状态（按创建时间倒排）。如果所有任务都已完成则返回completed，如果有任务正在运行则返回running",
+       "server_url": "http://agent-retrieval:30779",
+       "path": "/api/agent-retrieval/in/v1/kn/full_ontology_building_status",
+       "method": "GET",
+       "create_time": 1776920840666727400,
+       "update_time": 1776920840666727400,
+       "create_user": "ede150ba-06f4-11f1-85aa-3a34099a4c4b",
+       "update_user": "ede150ba-06f4-11f1-85aa-3a34099a4c4b",
+       "api_spec": {
+        "parameters": [
+         {
+          "name": "x-account-id",
+          "in": "header",
+          "description": "账户ID，用于内部服务调用时传递账户信息",
+          "required": false,
+          "schema": {
+           "type": "string"
+          }
+         },
+         {
+          "name": "x-account-type",
+          "in": "header",
+          "description": "账户类型：user(用户), app(应用), anonymous(匿名)",
+          "required": false,
+          "schema": {
+           "enum": [
+            "user",
+            "app",
+            "anonymous"
+           ],
+           "type": "string"
+          }
+         },
+         {
+          "name": "kn_id",
+          "in": "query",
+          "description": "业务知识网络ID",
+          "required": true,
+          "schema": {
+           "type": "string"
+          }
+         }
+        ],
+        "request_body": {
+         "description": "",
+         "content": {},
+         "required": false
+        },
+        "responses": [
+         {
+          "status_code": "200",
+          "description": "成功返回构建状态",
+          "content": {
+           "application/json": {
+            "example": {
+             "kn_id": "d5levlh818p1vl2slp60",
+             "state": "completed",
+             "state_detail": "All latest 50 jobs are completed"
+            },
+            "schema": {
+             "$ref": "#/components/schemas/BuildStatusSimpleResponse"
+            }
+           }
+          }
+         },
+         {
+          "status_code": "400",
+          "description": "参数错误",
+          "content": {
+           "application/json": {
+            "schema": {
+             "$ref": "#/components/schemas/ErrorResponse"
+            }
+           }
+          }
+         },
+         {
+          "status_code": "401",
+          "description": "未授权",
+          "content": {
+           "application/json": {
+            "schema": {
+             "$ref": "#/components/schemas/ErrorResponse"
+            }
+           }
+          }
+         },
+         {
+          "status_code": "500",
+          "description": "服务器内部错误",
+          "content": {
+           "application/json": {
+            "schema": {
+             "$ref": "#/components/schemas/ErrorResponse"
+            }
+           }
+          }
+         }
+        ],
+        "components": {
+         "schemas": {
+          "ErrorResponse": {
+           "type": "object",
+           "properties": {
+            "code": {
+             "type": "string",
+             "description": "错误码"
+            },
+            "description": {
+             "type": "string",
+             "description": "错误描述"
+            },
+            "detail": {
+             "description": "错误详情",
+             "type": "object"
+            },
+            "link": {
+             "description": "错误链接",
+             "type": "string"
+            },
+            "solution": {
+             "description": "解决方案",
+             "type": "string"
+            }
+           }
+          },
+          "BuildStatusSimpleResponse": {
+           "properties": {
+            "state_detail": {
+             "type": "string",
+             "description": "状态详情"
+            },
+            "kn_id": {
+             "type": "string",
+             "description": "业务知识网络ID"
+            },
+            "state": {
+             "description": "构建状态（running表示有任务正在运行，completed表示所有任务都已完成）",
+             "enum": [
+              "running",
+              "completed"
+             ],
+             "type": "string"
+            }
+           },
+           "type": "object",
+           "description": "构建状态响应",
+           "required": [
+            "kn_id",
+            "state",
+            "state_detail"
+           ]
+          }
+         }
+        },
+        "callbacks": null,
+        "security": null,
+        "tags": [
+         "OntologyJob"
+        ],
+        "external_docs": null
+       }
+      },
+      "use_rule": "",
+      "global_parameters": {
+       "name": "",
+       "description": "",
+       "required": false,
+       "in": "",
+       "type": "",
+       "value": null
+      },
+      "create_time": 1776920840668983300,
+      "update_time": 1776920840668983300,
+      "create_user": "ede150ba-06f4-11f1-85aa-3a34099a4c4b",
+      "update_user": "ede150ba-06f4-11f1-85aa-3a34099a4c4b",
+      "extend_info": null,
+      "resource_object": "tool",
+      "source_id": "168f0ebd-ef5a-49aa-b2f1-dce0850733f8",
+      "source_type": "openapi",
+      "script_type": "",
+      "code": "",
+      "dependencies": [],
+      "dependencies_url": ""
+     },
+     {
+      "tool_id": "3c78c9da-0bd5-48b4-b23b-960972d4d2af",
+      "name": "create_kn_index_build_job",
+      "description": "创建一个全量构建业务知识网络的任务",
+      "status": "enabled",
+      "metadata_type": "openapi",
+      "metadata": {
+       "version": "28462a3e-575c-4ada-b939-dc840d6fcb5f",
+       "summary": "create_kn_index_build_job",
+       "description": "创建一个全量构建业务知识网络的任务",
+       "server_url": "http://agent-retrieval:30779",
+       "path": "/api/agent-retrieval/in/v1/kn/full_build_ontology",
+       "method": "POST",
+       "create_time": 1776920840666727400,
+       "update_time": 1776920840666727400,
+       "create_user": "ede150ba-06f4-11f1-85aa-3a34099a4c4b",
+       "update_user": "ede150ba-06f4-11f1-85aa-3a34099a4c4b",
+       "api_spec": {
+        "parameters": [
+         {
+          "name": "x-account-id",
+          "in": "header",
+          "description": "账户ID，用于内部服务调用时传递账户信息",
+          "required": false,
+          "schema": {
+           "type": "string"
+          }
+         },
+         {
+          "name": "x-account-type",
+          "in": "header",
+          "description": "账户类型：user(用户), app(应用), anonymous(匿名)",
+          "required": false,
+          "schema": {
+           "enum": [
+            "user",
+            "app",
+            "anonymous"
+           ],
+           "type": "string"
+          }
+         }
+        ],
+        "request_body": {
+         "description": "",
+         "content": {
+          "application/json": {
+           "example": {
+            "kn_id": "kn_1234567890",
+            "name": "全量构建任务"
+           },
+           "schema": {
+            "$ref": "#/components/schemas/CreateJobRequest"
+           }
+          }
+         },
+         "required": false
+        },
+        "responses": [
+         {
+          "status_code": "201",
+          "description": "创建成功",
+          "content": {
+           "application/json": {
+            "example": {
+             "id": "job_1234567890"
+            },
+            "schema": {
+             "$ref": "#/components/schemas/CreateJobResponse"
+            }
+           }
+          }
+         },
+         {
+          "status_code": "400",
+          "description": "参数错误",
+          "content": {
+           "application/json": {
+            "schema": {
+             "$ref": "#/components/schemas/ErrorResponse"
+            }
+           }
+          }
+         },
+         {
+          "status_code": "401",
+          "description": "未授权",
+          "content": {
+           "application/json": {
+            "schema": {
+             "$ref": "#/components/schemas/ErrorResponse"
+            }
+           }
+          }
+         },
+         {
+          "status_code": "500",
+          "description": "服务器内部错误",
+          "content": {
+           "application/json": {
+            "schema": {
+             "$ref": "#/components/schemas/ErrorResponse"
+            }
+           }
+          }
+         }
+        ],
+        "components": {
+         "schemas": {
+          "ErrorResponse": {
+           "properties": {
+            "detail": {
+             "description": "错误详情",
+             "type": "object"
+            },
+            "link": {
+             "description": "错误链接",
+             "type": "string"
+            },
+            "solution": {
+             "description": "解决方案",
+             "type": "string"
+            },
+            "code": {
+             "type": "string",
+             "description": "错误码"
+            },
+            "description": {
+             "description": "错误描述",
+             "type": "string"
+            }
+           },
+           "type": "object"
+          },
+          "CreateJobRequest": {
+           "required": [
+            "kn_id",
+            "name"
+           ],
+           "properties": {
+            "name": {
+             "description": "任务名称",
+             "type": "string"
+            },
+            "kn_id": {
+             "type": "string",
+             "description": "业务知识网络ID"
+            }
+           },
+           "type": "object"
+          },
+          "CreateJobResponse": {
+           "properties": {
+            "id": {
+             "description": "任务ID",
+             "type": "string"
+            }
+           },
+           "type": "object"
+          }
+         }
+        },
+        "callbacks": null,
+        "security": null,
+        "tags": [
+         "OntologyJob"
+        ],
+        "external_docs": null
+       }
+      },
+      "use_rule": "",
+      "global_parameters": {
+       "name": "",
+       "description": "",
+       "required": false,
+       "in": "",
+       "type": "",
+       "value": null
+      },
+      "create_time": 1776920840668983300,
+      "update_time": 1776920840668983300,
+      "create_user": "ede150ba-06f4-11f1-85aa-3a34099a4c4b",
+      "update_user": "ede150ba-06f4-11f1-85aa-3a34099a4c4b",
+      "extend_info": null,
+      "resource_object": "tool",
+      "source_id": "28462a3e-575c-4ada-b939-dc840d6fcb5f",
+      "source_type": "openapi",
+      "script_type": "",
+      "code": "",
+      "dependencies": [],
+      "dependencies_url": ""
+     },
+     {
+      "tool_id": "8542b7c2-f82a-4c1e-ab8c-83e2e73ccfdf",
+      "name": "query_instance_subgraph",
+      "description": "基于预定义的关系路径查询知识图谱中的对象子图。支持多条路径查询，每条路径返回独立子图。对象以map形式返回，支持过滤条件和排序。query_type需设为\"relation_path\"。\r\n",
+      "status": "enabled",
+      "metadata_type": "openapi",
+      "metadata": {
+       "version": "859c997b-3558-4feb-a60d-432681994dff",
+       "summary": "query_instance_subgraph",
+       "description": "基于预定义的关系路径查询知识图谱中的对象子图。支持多条路径查询，每条路径返回独立子图。对象以map形式返回，支持过滤条件和排序。query_type需设为\"relation_path\"。\n",
+       "server_url": "http://agent-retrieval:30779",
+       "path": "/api/agent-retrieval/in/v1/kn/query_instance_subgraph",
+       "method": "POST",
+       "create_time": 1776920840666727400,
+       "update_time": 1776920840666727400,
+       "create_user": "ede150ba-06f4-11f1-85aa-3a34099a4c4b",
+       "update_user": "ede150ba-06f4-11f1-85aa-3a34099a4c4b",
+       "api_spec": {
+        "parameters": [
+         {
+          "name": "x-account-id",
+          "in": "header",
+          "description": "账户ID，用于内部服务调用时传递账户信息",
+          "required": false,
+          "schema": {
+           "type": "string"
+          }
+         },
+         {
+          "name": "x-account-type",
+          "in": "header",
+          "description": "账户类型：user(用户), app(应用), anonymous(匿名)",
+          "required": false,
+          "schema": {
+           "enum": [
+            "user",
+            "app",
+            "anonymous"
+           ],
+           "type": "string"
+          }
+         },
+         {
+          "name": "kn_id",
+          "in": "query",
+          "description": "业务知识网络ID",
+          "required": true,
+          "schema": {
+           "type": "string"
+          }
+         },
+         {
+          "name": "include_logic_params",
+          "in": "query",
+          "description": "包含逻辑属性的计算参数，默认false，返回结果不包含逻辑属性的字段和值",
+          "required": false,
+          "schema": {
+           "type": "boolean"
+          }
+         },
+         {
+          "name": "response_format",
+          "in": "query",
+          "description": "响应格式：json 或 toon，默认 json",
+          "required": false,
+          "schema": {
+           "default": "json",
+           "enum": [
+            "json",
+            "toon"
+           ],
+           "type": "string"
+          }
+         }
+        ],
+        "request_body": {
+         "description": "子图查询请求体",
+         "content": {
+          "application/json": {
+           "schema": {
+            "$ref": "#/components/schemas/SubGraphQueryBaseOnTypePath"
+           }
+          }
+         },
+         "required": false
+        },
+        "responses": [
+         {
+          "status_code": "200",
+          "description": "对象子图查询响应体",
+          "content": {
+           "application/json": {
+            "schema": {
+             "$ref": "#/components/schemas/PathEntries"
+            }
+           }
+          }
+         }
+        ],
+        "components": {
+         "schemas": {
+          "RelationPath": {
+           "required": [
+            "relations",
+            "length"
+           ],
+           "properties": {
+            "relations": {
+             "items": {
+              "$ref": "#/components/schemas/Relation"
+             },
+             "type": "array",
+             "description": "路径的边集合，沿着路径顺序出现的边"
+            },
+            "length": {
+             "type": "integer",
+             "description": "当前路径的长度"
+            }
+           },
+           "type": "object",
+           "description": "对象的关系路径"
+          },
+          "SubGraphQueryBaseOnTypePath": {
+           "required": [
+            "relation_type_paths"
+           ],
+           "properties": {
+            "relation_type_paths": {
+             "type": "array",
+             "description": "关系类路径集合,数组中可以包含多条不同的关系路径，系统会同时查询并返回所有路径的结果。每条路径必须符合严格的顺序和方向要求。",
+             "items": {
+              "$ref": "#/components/schemas/RelationTypePath"
+             }
+            }
+           },
+           "type": "object",
+           "description": "查询请求的顶层结构。用于基于关系类路径查询对象子图。relation_type_paths数组中可以包含多条不同的关系路径，系统会同时查询并返回所有路径的结果。每条路径必须符合严格的顺序和方向要求。"
+          },
+          "ObjectTypeOnPath": {
+           "properties": {
+            "sort": {
+             "description": "对当前对象类的排序字段",
+             "items": {
+              "$ref": "#/components/schemas/Sort"
+             },
+             "type": "array"
+            },
+            "condition": {
+             "$ref": "#/components/schemas/Condition"
+            },
+            "id": {
+             "type": "string",
+             "description": "对象类id"
+            },
+            "limit": {
+             "type": "integer",
+             "description": "对象类获取对象数量的限制"
+            }
+           },
+           "type": "object",
+           "description": "路径中的对象类信息",
+           "required": [
+            "id",
+            "condition",
+            "limit"
+           ]
+          },
+          "ObjectSubGraphResponse": {
+           "properties": {
+            "objects": {
+             "type": "object",
+             "description": "子图中的对象map，格式为：\n{\n  \"对象ID1\": {ObjectInfoInSubgraph对象1},\n  \"对象ID2\": {ObjectInfoInSubgraph对象2}\n}\n其中key是ObjectInfoInSubgraph中的id属性，value是完整的ObjectInfoInSubgraph对象。\n动态数据字段，其值可以是基本类型、MetricProperty或OperatorProperty\n"
+            },
+            "relation_paths": {
+             "description": "对象的关系路径集合",
+             "items": {
+              "$ref": "#/components/schemas/RelationPath"
+             },
+             "type": "array"
+            },
+            "search_after": {
+             "description": "表示返回的最后一个起点类对象的排序值，获取这个用于下一次 search_after 分页",
+             "items": {},
+             "type": "array"
+            },
+            "total_count": {
+             "description": "起点对象类的总条数",
+             "type": "integer"
+            }
+           },
+           "type": "object",
+           "description": "对象子图",
+           "required": [
+            "objects",
+            "relation_paths",
+            "total_count",
+            "search_after"
+           ]
+          },
+          "Condition": {
+           "properties": {
+            "field": {
+             "type": "string",
+             "description": "字段名称，也即对象类的属性名称"
+            },
+            "operation": {
+             "type": "string",
+             "description": "查询条件操作符。**注意：** 虽然这里列出了所有可能的操作符，但每个对象类实际支持的操作符列表以对象类定义中的 `condition_operations` 字段为准。",
+             "enum": [
+              "and",
+              "or",
+              "==",
+              "!=",
+              ">",
+              ">=",
+              "<",
+              "<=",
+              "in",
+              "not_in",
+              "like",
+              "not_like",
+              "exist",
+              "not_exist",
+              "match"
+             ]
+            },
+            "sub_conditions": {
+             "items": {
+              "$ref": "#/components/schemas/Condition"
+             },
+             "type": "array",
+             "description": "子过滤条件数组，用于逻辑操作符(and/or)的组合查询"
+            },
+            "value": {
+             "description": "字段值，格式根据操作符类型而定：\n- 比较操作符: 单个值\n- 范围查询: [min, max]数组\n- 集合操作: 值数组\n- 向量搜索: 特定格式数组\n\n**必须与 `value_from: \"const\"` 同时使用**\n",
+             "oneOf": [
+              {
+               "type": "string"
+              },
+              {
+               "type": "number"
+              },
+              {
+               "type": "boolean"
+              },
+              {
+               "type": "array",
+               "items": {
+                "oneOf": [
+                 {
+                  "type": "string"
+                 },
+                 {
+                  "type": "number"
+                 },
+                 {
+                  "type": "boolean"
+                 }
+                ]
+               }
+              }
+             ]
+            },
+            "value_from": {
+             "type": "string",
+             "description": "字段值来源。\n\n**重要：** 当前仅支持 \"const\"（常量值），且必须与 `value` 字段同时使用\n",
+             "enum": [
+              "const"
+             ]
+            }
+           },
+           "type": "object",
+           "description": "过滤条件结构，用于构建对象实例的查询筛选条件。\n\n**重要规则：**\n- `value_from` 和 `value` 必须同时使用，不能单独使用\n- `value_from` 当前仅支持 \"const\"（常量值）\n- 当使用 `value_from: \"const\"` 时，必须同时提供 `value` 字段\n",
+           "required": [
+            "operation"
+           ]
+          },
+          "Relation": {
+           "description": "一度关系（边）",
+           "required": [
+            "relation_type_id",
+            "relation_type_name",
+            "source_object_id",
+            "target_object_id"
+           ],
+           "properties": {
+            "relation_type_id": {
+             "description": "关系类id",
+             "type": "string"
+            },
+            "relation_type_name": {
+             "description": "关系类名称",
+             "type": "string"
+            },
+            "source_object_id": {
+             "type": "string",
+             "description": "起点对象id"
+            },
+            "target_object_id": {
+             "description": "终点对象id",
+             "type": "string"
+            }
+           },
+           "type": "object"
+          },
+          "TypeEdge": {
+           "type": "object",
+           "description": "路径中的边信息。**方向和顺序极其重要**！通过关系类id确定边，通过路径的起点对象类id和终点对象类id来确定当前路径的方向为正向还是反向，与关系类的起终点一致为正向，相反则为反向。每个TypeEdge必须与路径中的前后对象类型严格对应，这直接影响查询结果的正确性。",
+           "required": [
+            "relation_type_id",
+            "source_object_type_id",
+            "target_object_type_id"
+           ],
+           "properties": {
+            "source_object_type_id": {
+             "type": "string",
+             "description": "路径的起点对象类id"
+            },
+            "target_object_type_id": {
+             "description": "路径的终点对象类id",
+             "type": "string"
+            },
+            "relation_type_id": {
+             "description": "关系类id",
+             "type": "string"
+            }
+           }
+          },
+          "PathEntries": {
+           "required": [
+            "entries"
+           ],
+           "properties": {
+            "entries": {
+             "type": "array",
+             "description": "路径子图",
+             "items": {
+              "$ref": "#/components/schemas/ObjectSubGraphResponse"
+             }
+            }
+           },
+           "type": "object",
+           "description": "路径子图返回体"
+          },
+          "Sort": {
+           "properties": {
+            "direction": {
+             "type": "string",
+             "description": "排序方向",
+             "enum": [
+              "desc",
+              "asc"
+             ]
+            },
+            "field": {
+             "type": "string",
+             "description": "排序字段"
+            }
+           },
+           "type": "object",
+           "description": "排序字段",
+           "required": [
+            "field",
+            "direction"
+           ]
+          },
+          "RelationTypePath": {
+           "required": [
+            "relation_types",
+            "object_types"
+           ],
+           "properties": {
+            "object_types": {
+             "items": {
+              "$ref": "#/components/schemas/ObjectTypeOnPath"
+             },
+             "type": "array",
+             "description": "路径中的对象类集合，**顺序必须严格**与路径中节点出现顺序保持一致。对于n跳路径，object_types数组长度应为n+1，且必须按照source_object_type → 中间节点 → target_object_type的顺序排列。如果某个节点没有过滤条件或者排序或者限制数量，也必须保留其id字段以确保顺序正确。"
+            },
+            "relation_types": {
+             "items": {
+              "$ref": "#/components/schemas/TypeEdge"
+             },
+             "type": "array",
+             "description": "路径的边集合，**顺序必须严格**按照路径中关系出现的顺序排列。对于n跳路径，relation_types数组长度应为n，且必须与object_types数组中的对象类型严格对应：第i个relation_type的source_object_type_id必须等于object_types数组中第i个对象的id，target_object_type_id必须等于object_types数组中第i+1个对象的id。"
+            },
+            "limit": {
+             "description": "当前路径返回的路径数量的限制。",
+             "type": "integer"
+            }
+           },
+           "type": "object",
+           "description": "基于路径获取对象子图。**这是查询的核心结构**！用于定义完整的关系路径查询模板，包括路径中的所有对象类型和关系类型。object_types和relation_types数组的顺序**必须严格对应**，共同构成一个完整的关系路径。"
+          }
+         }
+        },
+        "callbacks": null,
+        "security": null,
+        "tags": null,
+        "external_docs": null
+       }
+      },
+      "use_rule": "",
+      "global_parameters": {
+       "name": "",
+       "description": "",
+       "required": false,
+       "in": "",
+       "type": "",
+       "value": null
+      },
+      "create_time": 1776920840668983300,
+      "update_time": 1776920840668983300,
+      "create_user": "ede150ba-06f4-11f1-85aa-3a34099a4c4b",
+      "update_user": "ede150ba-06f4-11f1-85aa-3a34099a4c4b",
+      "extend_info": null,
+      "resource_object": "tool",
+      "source_id": "859c997b-3558-4feb-a60d-432681994dff",
+      "source_type": "openapi",
+      "script_type": "",
+      "code": "",
+      "dependencies": [],
+      "dependencies_url": ""
+     },
+     {
+      "tool_id": "f46fa5df-f371-447f-8451-2d2f34cc78e9",
+      "name": "query_object_instance",
+      "description": "根据单个对象类查询对象实例，该接口基于业务知识网络语义检索接口返回的对象类定义，查询具体的对象实例数据。",
+      "status": "enabled",
+      "metadata_type": "openapi",
+      "metadata": {
+       "version": "3c8de1d0-4943-4460-a600-dc7e979a7573",
+       "summary": "query_object_instance",
+       "description": "根据单个对象类查询对象实例，该接口基于业务知识网络语义检索接口返回的对象类定义，查询具体的对象实例数据。",
+       "server_url": "http://agent-retrieval:30779",
+       "path": "/api/agent-retrieval/in/v1/kn/query_object_instance",
+       "method": "POST",
+       "create_time": 1776920840666727400,
+       "update_time": 1776920840666727400,
+       "create_user": "ede150ba-06f4-11f1-85aa-3a34099a4c4b",
+       "update_user": "ede150ba-06f4-11f1-85aa-3a34099a4c4b",
+       "api_spec": {
+        "parameters": [
+         {
+          "name": "x-account-id",
+          "in": "header",
+          "description": "账户ID，用于内部服务调用时传递账户信息",
+          "required": false,
+          "schema": {
+           "type": "string"
+          }
+         },
+         {
+          "name": "x-account-type",
+          "in": "header",
+          "description": "账户类型：user(用户), app(应用), anonymous(匿名)",
+          "required": false,
+          "schema": {
+           "enum": [
+            "user",
+            "app",
+            "anonymous"
+           ],
+           "type": "string"
+          }
+         },
+         {
+          "name": "kn_id",
+          "in": "query",
+          "description": "业务知识网络ID",
+          "required": true,
+          "schema": {
+           "type": "string"
+          }
+         },
+         {
+          "name": "ot_id",
+          "in": "query",
+          "description": "对象类ID",
+          "required": true,
+          "schema": {
+           "type": "string"
+          }
+         },
+         {
+          "name": "include_logic_params",
+          "in": "query",
+          "description": "包含逻辑属性的计算参数，默认false，返回结果不包含逻辑属性的字段和值",
+          "required": false,
+          "schema": {
+           "type": "boolean"
+          }
+         },
+         {
+          "name": "response_format",
+          "in": "query",
+          "description": "响应格式：json 或 toon，默认 json",
+          "required": false,
+          "schema": {
+           "default": "json",
+           "enum": [
+            "json",
+            "toon"
+           ],
+           "type": "string"
+          }
+         }
+        ],
+        "request_body": {
+         "description": "",
+         "content": {
+          "application/json": {
+           "schema": {
+            "$ref": "#/components/schemas/FirstQueryWithSearchAfter"
+           }
+          }
+         },
+         "required": false
+        },
+        "responses": [
+         {
+          "status_code": "200",
+          "description": "ok",
+          "content": {
+           "application/json": {
+            "schema": {
+             "$ref": "#/components/schemas/ObjectDataResponse"
+            }
+           }
+          }
+         }
+        ],
+        "components": {
+         "schemas": {
+          "LogicSource": {
+           "properties": {
+            "id": {
+             "type": "string",
+             "description": "数据来源ID"
+            },
+            "name": {
+             "type": "string",
+             "description": "名称。查看详情时返回。"
+            },
+            "type": {
+             "type": "string",
+             "description": "数据来源类型",
+             "enum": [
+              "metric",
+              "operator"
+             ]
+            }
+           },
+           "type": "object",
+           "description": "数据来源",
+           "required": [
+            "type",
+            "id"
+           ]
+          },
+          "FirstQueryWithSearchAfter": {
+           "properties": {
+            "sort": {
+             "description": "排序字段，默认使用 @timestamp排序，排序方向为 desc",
+             "items": {
+              "$ref": "#/components/schemas/Sort"
+             },
+             "type": "array"
+            },
+            "condition": {
+             "$ref": "#/components/schemas/Condition"
+            },
+            "filters": {
+             "description": "扁平过滤简写：多个条件按 and 组合，覆盖「字段 op 值 [AND ...]」常见场景。与 condition 互斥（同传时 condition 优先）；需要 or/嵌套时改用 condition。",
+             "items": {
+              "$ref": "#/components/schemas/FlatFilter"
+             },
+             "type": "array"
+            },
+            "limit": {
+             "type": "integer",
+             "description": "返回的数量，默认值 10。范围 1-100",
+             "default": 10
+            },
+            "need_total": {
+             "description": "是否需要总数，默认false",
+             "type": "boolean"
+            },
+            "properties": {
+             "items": {
+              "type": "string"
+             },
+             "type": "array",
+             "description": "指定返回的对象属性字段列表，默认返回所有属性。"
+            }
+           },
+           "type": "object",
+           "description": "分页查询的第一次查询请求"
+          },
+          "FlatFilter": {
+           "description": "扁平过滤项：单个 field-op-value 比较。多个 FlatFilter 按 and 组合。value_from 自动取 const，无需提供。仅含比较算子，不支持 and/or（逻辑组合请用 Condition）。",
+           "required": [
+            "field",
+            "op",
+            "value"
+           ],
+           "properties": {
+            "field": {
+             "description": "字段名（对象类属性）",
+             "type": "string"
+            },
+            "op": {
+             "description": "比较算子；白名单以对象类的 condition_operations 为准",
+             "enum": [
+              "==",
+              "!=",
+              ">",
+              ">=",
+              "<",
+              "<=",
+              "in",
+              "not_in",
+              "like",
+              "not_like",
+              "exist",
+              "not_exist",
+              "match"
+             ],
+             "type": "string"
+            },
+            "value": {
+             "description": "字段值；集合算子（in/not_in）用数组"
+            }
+           },
+           "type": "object"
+          },
+          "Parameter4Metric": {
+           "description": "逻辑参数",
+           "required": [
+            "name",
+            "value_from",
+            "operation"
+           ],
+           "properties": {
+            "name": {
+             "type": "string",
+             "description": "参数名称"
+            },
+            "operation": {
+             "description": "操作符。映射指标模型的属性时，此字段必须",
+             "enum": [
+              "in",
+              "=",
+              "!=",
+              ">",
+              ">=",
+              "<",
+              "<="
+             ],
+             "type": "string"
+            },
+            "value": {
+             "type": "string",
+             "description": "参数值。value_from=property时，填入的是对象类的数据属性名称；value_from=input时，不设置此字段"
+            },
+            "value_from": {
+             "enum": [
+              "property",
+              "input"
+             ],
+             "type": "string",
+             "description": "值来源"
+            }
+           },
+           "type": "object"
+          },
+          "ObjectTypeDetail": {
+           "type": "object",
+           "description": "对象类信息",
+           "properties": {
+            "comment": {
+             "type": "string",
+             "description": "备注（可以为空）"
+            },
+            "create_time": {
+             "format": "int64",
+             "description": "创建时间",
+             "type": "integer"
+            },
+            "display_key": {
+             "description": "对象实例的显示属性",
+             "type": "string"
+            },
+            "data_properties": {
+             "type": "array",
+             "description": "数据属性",
+             "items": {
+              "$ref": "#/components/schemas/DataProperty"
+             }
+            },
+            "primary_keys": {
+             "description": "主键",
+             "items": {
+              "type": "string"
+             },
+             "type": "array"
+            },
+            "kn_id": {
+             "description": "业务知识网络id",
+             "type": "string"
+            },
+            "icon": {
+             "description": "图标",
+             "type": "string"
+            },
+            "tags": {
+             "description": "标签。 （可以为空）",
+             "items": {
+              "type": "string"
+             },
+             "type": "array"
+            },
+            "color": {
+             "description": "颜色",
+             "type": "string"
+            },
+            "detail": {
+             "description": "说明书。按需返回，若指定了include_detail=true，则返回，否则不返回。列表查询时不返回此字段",
+             "type": "string"
+            },
+            "name": {
+             "type": "string",
+             "description": "对象类名称"
+            },
+            "concept_groups": {
+             "type": "array",
+             "description": "概念分组id",
+             "items": {
+              "$ref": "#/components/schemas/ConceptGroup"
+             }
+            },
+            "data_source": {
+             "$ref": "#/components/schemas/DataSource"
+            },
+            "logic_properties": {
+             "description": "逻辑属性",
+             "items": {
+              "$ref": "#/components/schemas/LogicProperty"
+             },
+             "type": "array"
+            },
+            "update_time": {
+             "type": "integer",
+             "format": "int64",
+             "description": "最近一次更新时间"
+            },
+            "branch": {
+             "type": "string",
+             "description": "分支ID"
+            },
+            "creator": {
+             "type": "string",
+             "description": "创建人ID"
+            },
+            "updater": {
+             "description": "最近一次修改人",
+             "type": "string"
+            },
+            "id": {
+             "description": "对象类ID",
+             "type": "string"
+            },
+            "module_type": {
+             "description": "模块类型",
+             "enum": [
+              "object_type"
+             ],
+             "type": "string"
+            }
+           }
+          },
+          "Parameter4Operator": {
+           "required": [
+            "name",
+            "value_from"
+           ],
+           "properties": {
+            "value_from": {
+             "type": "string",
+             "description": "值来源",
+             "enum": [
+              "property",
+              "input"
+             ]
+            },
+            "name": {
+             "type": "string",
+             "description": "参数名称"
+            },
+            "source": {
+             "description": "参数来源",
+             "type": "string"
+            },
+            "type": {
+             "type": "string",
+             "description": "参数类型"
+            },
+            "value": {
+             "description": "参数值。value_from=property时，填入的是对象类的数据属性名称；value_from=input时，不设置此字段",
+             "type": "string"
+            }
+           },
+           "type": "object",
+           "description": "逻辑参数"
+          },
+          "Sort": {
+           "type": "object",
+           "description": "排序字段",
+           "required": [
+            "field",
+            "direction"
+           ],
+           "properties": {
+            "direction": {
+             "type": "string",
+             "description": "排序方向",
+             "enum": [
+              "desc",
+              "asc"
+             ]
+            },
+            "field": {
+             "description": "排序字段",
+             "type": "string"
+            }
+           }
+          },
+          "VectorConfig": {
+           "type": "object",
+           "description": "向量索引的配置",
+           "required": [
+            "dimension"
+           ],
+           "properties": {
+            "dimension": {
+             "type": "integer",
+             "description": "向量维度"
+            }
+           }
+          },
+          "DataSource": {
+           "required": [
+            "type",
+            "id"
+           ],
+           "properties": {
+            "name": {
+             "type": "string",
+             "description": "名称。查看详情时返回。"
+            },
+            "type": {
+             "type": "string",
+             "description": "数据来源类型为数据视图",
+             "enum": [
+              "data_view"
+             ]
+            },
+            "id": {
+             "description": "数据视图ID",
+             "type": "string"
+            }
+           },
+           "type": "object",
+           "description": "数据来源"
+          },
+          "DataProperty": {
+           "type": "object",
+           "description": "数据属性",
+           "required": [
+            "name",
+            "display_name",
+            "type",
+            "comment",
+            "mapped_field",
+            "index",
+            "fulltext_config",
+            "vector_config"
+           ],
+           "properties": {
+            "mapped_field": {
+             "$ref": "#/components/schemas/ViewField"
+            },
+            "name": {
+             "type": "string",
+             "description": "属性名称。只能包含小写英文字母、数字、下划线（_）、连字符（-），且不能以下划线和连字符开头"
+            },
+            "type": {
+             "description": "属性数据类型。除了视图的字段类型之外，还有 metric、objective、event、trace、log、operator",
+             "type": "string"
+            },
+            "vector_config": {
+             "$ref": "#/components/schemas/VectorConfig"
+            },
+            "comment": {
+             "type": "string",
+             "description": "属性描述"
+            },
+            "display_name": {
+             "type": "string",
+             "description": "属性显示名"
+            },
+            "fulltext_config": {
+             "$ref": "#/components/schemas/FulltextConfig"
+            },
+            "index": {
+             "description": "是否开启索引，默认是true",
+             "type": "boolean"
+            }
+           }
+          },
+          "Parameter": {
+           "description": "逻辑/指标参数",
+           "oneOf": [
+            {
+             "$ref": "#/components/schemas/Parameter4Operator"
+            },
+            {
+             "$ref": "#/components/schemas/Parameter4Metric"
+            }
+           ],
+           "type": "object"
+          },
+          "FulltextConfig": {
+           "description": "全文索引的配置",
+           "required": [
+            "analyzer",
+            "field_keyword"
+           ],
+           "properties": {
+            "field_keyword": {
+             "type": "boolean",
+             "description": "是否保留原始字符串，保留原始字符串可用于精确匹配。默认是false"
+            },
+            "analyzer": {
+             "type": "string",
+             "description": "分词器",
+             "enum": [
+              "standard",
+              "ik_max_word"
+             ]
+            }
+           },
+           "type": "object"
+          },
+          "ObjectDataResponse": {
+           "type": "object",
+           "description": "节点（对象类）信息",
+           "required": [
+            "groups",
+            "type",
+            "datas",
+            "search_after"
+           ],
+           "properties": {
+            "datas": {
+             "description": "对象实例数据。动态数据字段，其值可以是基本类型、MetricProperty或OperatorProperty",
+             "items": {
+              "type": "object"
+             },
+             "type": "array"
+            },
+            "object_type": {
+             "$ref": "#/components/schemas/ObjectTypeDetail"
+            },
+            "search_after": {
+             "type": "array",
+             "description": "表示返回的最后一个文档的排序值，获取这个用于下一次 search_after 分页",
+             "items": {}
+            },
+            "total_count": {
+             "description": "总条数",
+             "type": "integer"
+            }
+           }
+          },
+          "ConceptGroup": {
+           "description": "概念分组",
+           "required": [
+            "id",
+            "name"
+           ],
+           "properties": {
+            "name": {
+             "description": "概念分组名称",
+             "type": "string"
+            },
+            "id": {
+             "description": "概念分组ID",
+             "type": "string"
+            }
+           },
+           "type": "object"
+          },
+          "Condition": {
+           "type": "object",
+           "description": "过滤条件结构，用于构建对象实例的查询筛选条件。\n\n**重要规则：**\n- `value_from` 和 `value` 必须同时使用，不能单独使用\n- `value_from` 当前仅支持 \"const\"（常量值）\n- 当使用 `value_from: \"const\"` 时，必须同时提供 `value` 字段\n",
+           "required": [
+            "operation"
+           ],
+           "properties": {
+            "field": {
+             "description": "字段名称，也即对象类的属性名称",
+             "type": "string"
+            },
+            "operation": {
+             "description": "查询条件操作符。\n**注意：** 虽然这里列出了所有可能的操作符，但每个对象类实际支持的操作符列表以对象类定义中的 `condition_operations` 字段为准。\n",
+             "enum": [
+              "and",
+              "or",
+              "==",
+              "!=",
+              ">",
+              ">=",
+              "<",
+              "<=",
+              "in",
+              "not_in",
+              "like",
+              "not_like",
+              "exist",
+              "not_exist",
+              "match"
+             ],
+             "type": "string"
+            },
+            "sub_conditions": {
+             "description": "子过滤条件数组，用于逻辑操作符(and/or)的组合查询",
+             "items": {
+              "$ref": "#/components/schemas/Condition"
+             },
+             "type": "array"
+            },
+            "value": {
+             "description": "字段值，格式根据操作符类型而定：\n- 比较操作符: 单个值\n- 范围查询: [min, max]数组\n- 集合操作: 值数组\n- 向量搜索: 特定格式数组\n\n**必须与 `value_from: \"const\"` 同时使用**\n"
+            },
+            "value_from": {
+             "description": "字段值来源。\n\n**重要：** 当前仅支持 \"const\"（常量值），且必须与 `value` 字段同时使用\n",
+             "enum": [
+              "const"
+             ],
+             "type": "string"
+            }
+           }
+          },
+          "ViewField": {
+           "description": "视图字段信息",
+           "required": [
+            "name"
+           ],
+           "properties": {
+            "name": {
+             "description": "字段名称",
+             "type": "string"
+            },
+            "type": {
+             "description": "视图字段类型，查看时有此字段",
+             "type": "string"
+            },
+            "display_name": {
+             "description": "字段显示名.查看时有此字段",
+             "type": "string"
+            }
+           },
+           "type": "object"
+          },
+          "LogicProperty": {
+           "required": [
+            "name",
+            "data_source",
+            "parameters"
+           ],
+           "properties": {
+            "name": {
+             "description": "属性名称。只能包含小写英文字母、数字、下划线（_）、连字符（-），且不能以下划线和连字符开头",
+             "type": "string"
+            },
+            "parameters": {
+             "items": {
+              "$ref": "#/components/schemas/Parameter"
+             },
+             "type": "array",
+             "description": "逻辑所需的参数"
+            },
+            "type": {
+             "type": "string",
+             "description": "属性数据类型。除了视图的字段类型之外，还有 metric、objective、event、trace、log、operator"
+            },
+            "comment": {
+             "description": "属性描述",
+             "type": "string"
+            },
+            "data_source": {
+             "$ref": "#/components/schemas/LogicSource"
+            },
+            "display_name": {
+             "type": "string",
+             "description": "属性显示名"
+            },
+            "index": {
+             "type": "boolean",
+             "description": "是否开启索引，默认是true"
+            }
+           },
+           "type": "object",
+           "description": "逻辑属性"
+          }
+         }
+        },
+        "callbacks": null,
+        "security": null,
+        "tags": null,
+        "external_docs": null
+       }
+      },
+      "use_rule": "",
+      "global_parameters": {
+       "name": "",
+       "description": "",
+       "required": false,
+       "in": "",
+       "type": "",
+       "value": null
+      },
+      "create_time": 1776920840668983300,
+      "update_time": 1776920840668983300,
+      "create_user": "ede150ba-06f4-11f1-85aa-3a34099a4c4b",
+      "update_user": "ede150ba-06f4-11f1-85aa-3a34099a4c4b",
+      "extend_info": null,
+      "resource_object": "tool",
+      "source_id": "3c8de1d0-4943-4460-a600-dc7e979a7573",
+      "source_type": "openapi",
+      "script_type": "",
+      "code": "",
+      "dependencies": [],
+      "dependencies_url": ""
+     },
+     {
+      "tool_id": "00929c5f-3375-4ddc-9fb0-c48a24707f39",
+      "name": "get_action_info",
+      "description": "根据对象实例标识召回关联行动，返回 _dynamic_tools。",
+      "status": "enabled",
+      "metadata_type": "openapi",
+      "metadata": {
+       "version": "7eb88316-d921-4361-ad08-2c1c812e5448",
+       "summary": "get_action_info",
+       "description": "根据对象实例标识召回关联行动，返回 _dynamic_tools。",
+       "server_url": "http://agent-retrieval:30779",
+       "path": "/api/agent-retrieval/in/v1/kn/get_action_info",
+       "method": "POST",
+       "create_time": 1776920840666727400,
+       "update_time": 1776920840666727400,
+       "create_user": "ede150ba-06f4-11f1-85aa-3a34099a4c4b",
+       "update_user": "ede150ba-06f4-11f1-85aa-3a34099a4c4b",
+       "api_spec": {
+        "parameters": [
+         {
+          "name": "x-account-id",
+          "in": "header",
+          "description": "账户ID，用于内部服务调用时传递账户信息",
+          "required": false,
+          "schema": {
+           "type": "string"
+          }
+         },
+         {
+          "name": "x-account-type",
+          "in": "header",
+          "description": "账户类型：user(用户), app(应用), anonymous(匿名)",
+          "required": false,
+          "schema": {
+           "enum": [
+            "user",
+            "app",
+            "anonymous"
+           ],
+           "type": "string"
+          }
+         },
+         {
+          "name": "response_format",
+          "in": "query",
+          "description": "响应格式：json 或 toon，默认 json",
+          "required": false,
+          "schema": {
+           "default": "json",
+           "enum": [
+            "json",
+            "toon"
+           ],
+           "type": "string"
+          }
+         }
+        ],
+        "request_body": {
+         "description": "",
+         "content": {
+          "application/json": {
+           "examples": {
+            "multi_instance_example": {
+             "summary": "多对象实例示例",
+             "value": {
+              "_instance_identities": [
+               {
+                "disease_id": "disease_000001"
+               },
+               {
+                "disease_id": "disease_000002"
+               }
+              ],
+              "at_id": "generate_treatment_plan",
+              "kn_id": "kn_medical"
+             }
+            },
+            "single_instance_example": {
+             "summary": "单对象实例示例",
+             "value": {
+              "_instance_identities": [
+               {
+                "disease_id": "disease_000001"
+               }
+              ],
+              "at_id": "generate_treatment_plan",
+              "kn_id": "kn_medical"
+             }
+            }
+           },
+           "schema": {
+            "$ref": "#/components/schemas/ActionRecallRequest"
+           }
+          }
+         },
+         "required": false
+        },
+        "responses": [
+         {
+          "status_code": "200",
+          "description": "成功返回动态工具列表",
+          "content": {
+           "application/json": {
+            "schema": {
+             "$ref": "#/components/schemas/ActionRecallResponse"
+            }
+           }
+          }
+         },
+         {
+          "status_code": "400",
+          "description": "请求参数错误",
+          "content": {
+           "application/json": {
+            "examples": {
+             "invalid_request": {
+              "value": {
+               "code": "INVALID_REQUEST",
+               "description": "_instance_identities 格式错误"
+              }
+             }
+            },
+            "schema": {
+             "$ref": "#/components/schemas/ErrorResponse"
+            }
+           }
+          }
+         },
+         {
+          "status_code": "500",
+          "description": "服务器内部错误",
+          "content": {
+           "application/json": {
+            "schema": {
+             "$ref": "#/components/schemas/ErrorResponse"
+            }
+           }
+          }
+         },
+         {
+          "status_code": "502",
+          "description": "上游服务不可用",
+          "content": {
+           "application/json": {
+            "schema": {
+             "$ref": "#/components/schemas/ErrorResponse"
+            }
+           }
+          }
+         }
+        ],
+        "components": {
+         "schemas": {
+          "ErrorResponse": {
+           "type": "object",
+           "properties": {
+            "description": {
+             "type": "string"
+            },
+            "code": {
+             "type": "string"
+            }
+           }
+          },
+          "ActionRecallRequest": {
+           "required": [
+            "kn_id",
+            "at_id"
+           ],
+           "properties": {
+            "at_id": {
+             "type": "string",
+             "description": "行动类ID（从 Schema 获取）"
+            },
+            "kn_id": {
+             "description": "知识网络ID",
+             "type": "string"
+            },
+            "_instance_identities": {
+             "description": "对象实例标识列表（可选）。每个元素为主键键值对，必须从 query_object_instance 或 query_instance_subgraph 返回的 _instance_identity 字段提取，不可臆造。",
+             "items": {
+              "type": "object"
+             },
+             "type": "array"
+            }
+           },
+           "type": "object"
+          },
+          "ActionRecallResponse": {
+           "type": "object",
+           "required": [
+            "_dynamic_tools"
+           ],
+           "properties": {
+            "_dynamic_tools": {
+             "description": "Function Call 格式的工具列表",
+             "items": {
+              "properties": {
+               "parameters": {
+                "type": "object"
+               },
+               "api_url": {
+                "type": "string"
+               },
+               "description": {
+                "type": "string"
+               },
+               "fixed_params": {
+                "type": "object"
+               },
+               "name": {
+                "type": "string"
+               }
+              },
+              "type": "object"
+             },
+             "type": "array"
+            },
+            "headers": {
+             "type": "object"
+            }
+           }
+          }
+         }
+        },
+        "callbacks": null,
+        "security": null,
+        "tags": [
+         "action-recall"
+        ],
+        "external_docs": null
+       }
+      },
+      "use_rule": "",
+      "global_parameters": {
+       "name": "",
+       "description": "",
+       "required": false,
+       "in": "",
+       "type": "",
+       "value": null
+      },
+      "create_time": 1776920840668983300,
+      "update_time": 1776920840668983300,
+      "create_user": "ede150ba-06f4-11f1-85aa-3a34099a4c4b",
+      "update_user": "ede150ba-06f4-11f1-85aa-3a34099a4c4b",
+      "extend_info": null,
+      "resource_object": "tool",
+      "source_id": "7eb88316-d921-4361-ad08-2c1c812e5448",
+      "source_type": "openapi",
+      "script_type": "",
+      "code": "",
+      "dependencies": [],
+      "dependencies_url": ""
+     },
+     {
+      "tool_id": "74498bbd-2bdf-4db3-a4da-a90133c7fb65",
+      "name": "find_skills",
+      "description": "基于业务上下文召回 Skill 候选列表。\r\n\r\n**召回模式选择规则（自动判断，无需显式指定）：**\r\n\r\n| 请求参数 | 召回模式 |\r\n|---------|---------|\r\n| 仅 kn_id | 网络级（Mode 1） |\r\n| kn_id + object_type_id | 对象类级（Mode 2） |\r\n| kn_id + object_type_id + instance_identities | 实例级（Mode 3） |\r\n\r\n**网络级特殊规则：** 仅当 skills ObjectType 与任意其他 ObjectType 都不存在 RelationType 时才返回结果，\r\n否则返回空列表（需要更精确的 object_type_id 才能召回）。\r\n\r\n**skill_query 说明：** 传入时会对 skills 实例的 name/description 字段追加文本过滤条件（支持 knn/match/like，\r\n优先使用已构建的向量/索引能力），若 BKN 中 skills ObjectType 不存在或元数据获取失败则返回 502。\r\n",
+      "status": "enabled",
+      "metadata_type": "openapi",
+      "metadata": {
+       "version": "69c7eb67-6e11-4df0-bd8f-293c0f4c92bc",
+       "summary": "find_skills",
+       "description": "基于业务上下文召回 Skill 候选列表。\n\n**召回模式选择规则（自动判断，无需显式指定）：**\n\n| 请求参数 | 召回模式 |\n|---------|---------|\n| 仅 kn_id | 网络级（Mode 1） |\n| kn_id + object_type_id | 对象类级（Mode 2） |\n| kn_id + object_type_id + instance_identities | 实例级（Mode 3） |\n\n**网络级特殊规则：** 仅当 skills ObjectType 与任意其他 ObjectType 都不存在 RelationType 时才返回结果，\n否则返回空列表（需要更精确的 object_type_id 才能召回）。\n\n**skill_query 说明：** 传入时会对 skills 实例的 name/description 字段追加文本过滤条件（支持 knn/match/like，\n优先使用已构建的向量/索引能力），若 BKN 中 skills ObjectType 不存在或元数据获取失败则返回 502。\n",
+       "server_url": "http://agent-retrieval:30779",
+       "path": "/api/agent-retrieval/in/v1/kn/find_skills",
+       "method": "POST",
+       "create_time": 1776920840666727400,
+       "update_time": 1776920840666727400,
+       "create_user": "ede150ba-06f4-11f1-85aa-3a34099a4c4b",
+       "update_user": "ede150ba-06f4-11f1-85aa-3a34099a4c4b",
+       "api_spec": {
+        "parameters": [
+         {
+          "name": "x-account-id",
+          "in": "header",
+          "description": "账户 ID，用于内部服务调用时传递账户信息",
+          "required": false,
+          "schema": {
+           "type": "string"
+          }
+         },
+         {
+          "name": "x-account-type",
+          "in": "header",
+          "description": "账户类型：user（用户）、app（应用）、anonymous（匿名）",
+          "required": false,
+          "schema": {
+           "enum": [
+            "user",
+            "app",
+            "anonymous"
+           ],
+           "type": "string"
+          }
+         },
+         {
+          "name": "response_format",
+          "in": "query",
+          "description": "响应格式：json 或 toon，默认 json",
+          "required": false,
+          "schema": {
+           "default": "json",
+           "enum": [
+            "json",
+            "toon"
+           ],
+           "type": "string"
+          }
+         }
+        ],
+        "request_body": {
+         "description": "",
+         "content": {
+          "application/json": {
+           "examples": {
+            "instance_level": {
+             "summary": "实例级召回（kn_id + object_type_id + instance_identities）",
+             "value": {
+              "instance_identities": [
+               {
+                "contract_id": "C-2024-001"
+               }
+              ],
+              "kn_id": "kn_legal",
+              "object_type_id": "contract",
+              "top_k": 10
+             }
+            },
+            "network_level": {
+             "summary": "网络级召回（仅 kn_id）",
+             "value": {
+              "kn_id": "kn_legal",
+              "top_k": 10
+             }
+            },
+            "object_type_level": {
+             "summary": "对象类级召回（kn_id + object_type_id）",
+             "value": {
+              "kn_id": "kn_legal",
+              "object_type_id": "contract",
+              "top_k": 10
+             }
+            },
+            "with_skill_query": {
+             "summary": "带语义过滤的实例级召回",
+             "value": {
+              "instance_identities": [
+               {
+                "contract_id": "C-2024-001"
+               }
+              ],
+              "kn_id": "kn_legal",
+              "object_type_id": "contract",
+              "skill_query": "合同审查",
+              "top_k": 5
+             }
+            }
+           },
+           "schema": {
+            "$ref": "#/components/schemas/FindSkillsRequest"
+           }
+          }
+         },
+         "required": false
+        },
+        "responses": [
+         {
+          "status_code": "200",
+          "description": "成功返回 Skill 候选列表（可能为空列表）",
+          "content": {
+           "application/json": {
+            "examples": {
+             "empty_result_network_scope": {
+              "summary": "无匹配 Skill（网络级但 skills 有关联）",
+              "value": {
+               "entries": [],
+               "message": "当前知识网络中的 Skill 不是全局生效，网络级范围未返回结果。请补充 object_type_id；如已定位到实例，再补充 instance_identities 后重试。"
+              }
+             },
+             "empty_result_no_binding": {
+              "summary": "无匹配 Skill（对象类未配置 Skill 绑定）",
+              "value": {
+               "entries": [],
+               "message": "当前对象类未配置 Skill 绑定关系，无法在该范围内召回 Skill。请确认该对象类是否已绑定 Skill。"
+              }
+             },
+             "success_with_results": {
+              "summary": "返回 Skill 候选",
+              "value": {
+               "entries": [
+                {
+                 "description": "对合同条款进行全面审查，识别风险点",
+                 "name": "合同审查",
+                 "skill_id": "skill_contract_review"
+                },
+                {
+                 "description": "提取合同中的关键条款和义务",
+                 "name": "关键条款提取",
+                 "skill_id": "skill_clause_extract"
+                }
+               ]
+              }
+             }
+            },
+            "schema": {
+             "$ref": "#/components/schemas/FindSkillsResponse"
+            }
+           }
+          }
+         },
+         {
+          "status_code": "400",
+          "description": "请求参数错误",
+          "content": {
+           "application/json": {
+            "examples": {
+             "instance_without_object_type": {
+              "value": {
+               "code": "INVALID_REQUEST",
+               "description": "instance_identities 不为空时 object_type_id 也必须提供"
+              }
+             },
+             "missing_kn_id": {
+              "value": {
+               "code": "INVALID_REQUEST",
+               "description": "kn_id 为必填字段"
+              }
+             }
+            },
+            "schema": {
+             "$ref": "#/components/schemas/ErrorResponse"
+            }
+           }
+          }
+         },
+         {
+          "status_code": "502",
+          "description": "上游服务不可用（BKN 或 ontology-query 异常）",
+          "content": {
+           "application/json": {
+            "examples": {
+             "skills_ot_not_found": {
+              "value": {
+               "code": "BAD_GATEWAY",
+               "description": "skill_query requires skills ObjectType (id=skills) but none found in kn_id=kn_legal"
+              }
+             }
+            },
+            "schema": {
+             "$ref": "#/components/schemas/ErrorResponse"
+            }
+           }
+          }
+         }
+        ],
+        "components": {
+         "schemas": {
+          "FindSkillsRequest": {
+           "required": [
+            "kn_id",
+            "object_type_id"
+           ],
+           "properties": {
+            "skill_query": {
+             "description": "可选的 Skill 语义过滤词，对 skills 实例的 name/description 字段追加文本过滤。\nBKN 已构建向量时使用 knn，已构建全文索引时使用 match，否则使用 like。\n若 skills ObjectType 元数据获取失败则返回 502。\n",
+             "type": "string"
+            },
+            "top_k": {
+             "description": "最多返回的 Skill 数量，默认 10，最大 20",
+             "default": 10,
+             "type": "integer"
+            },
+            "instance_identities": {
+             "type": "array",
+             "description": "对象实例标识列表。每个元素为主键键值对，必须从 query_object_instance 或\nquery_instance_subgraph 返回的 _instance_identity 字段提取，不可臆造。\n传入时 object_type_id 也必须提供，否则返回 400。\n",
+             "items": {
+              "type": "object"
+             }
+            },
+            "kn_id": {
+             "type": "string",
+             "description": "知识网络 ID"
+            },
+            "object_type_id": {
+             "description": "业务对象类型 ID（从 search_schema 返回的概念结果获取）。\n不传时为网络级召回；传入时为对象类级或实例级召回。\n",
+             "type": "string"
+            }
+           },
+           "type": "object"
+          },
+          "FindSkillsResponse": {
+           "required": [
+            "entries"
+           ],
+           "properties": {
+            "entries": {
+             "items": {
+              "$ref": "#/components/schemas/SkillItem"
+             },
+             "type": "array",
+             "description": "Skill 候选列表，按命中层级优先级（实例级 > 对象类级 > 网络级）和相关性分数降序排列。\n同优先级同分数时按 skill_id 字典序排列，保证顺序稳定。\n无匹配时返回空数组。\n"
+            },
+            "message": {
+             "type": "string",
+             "description": "空结果说明信息。仅当 entries 为空且接口返回 200 时出现。\n用于向调用方（Agent）解释当前为什么没有结果，以及下一步建议。\nentries 非空时不返回此字段。支持多语言（由请求 X-Language 头决定）。\n"
+            }
+           },
+           "type": "object"
+          },
+          "SkillItem": {
+           "required": [
+            "skill_id",
+            "name"
+           ],
+           "properties": {
+            "skill_id": {
+             "description": "Skill 唯一标识，由 execution-factory 写入 BKN skills ObjectType 时确定",
+             "type": "string"
+            },
+            "description": {
+             "type": "string",
+             "description": "Skill 功能描述（可选，BKN 中无此属性时不返回）"
+            },
+            "name": {
+             "description": "Skill 名称",
+             "type": "string"
+            }
+           },
+           "type": "object"
+          },
+          "ErrorResponse": {
+           "properties": {
+            "code": {
+             "type": "string",
+             "description": "错误码"
+            },
+            "description": {
+             "type": "string",
+             "description": "错误详情"
+            }
+           },
+           "type": "object"
+          }
+         }
+        },
+        "callbacks": null,
+        "security": null,
+        "tags": [
+         "skill-recall"
+        ],
+        "external_docs": null
+       }
+      },
+      "use_rule": "",
+      "global_parameters": {
+       "name": "",
+       "description": "",
+       "required": false,
+       "in": "",
+       "type": "",
+       "value": null
+      },
+      "create_time": 1776920840668983300,
+      "update_time": 1776920840668983300,
+      "create_user": "ede150ba-06f4-11f1-85aa-3a34099a4c4b",
+      "update_user": "ede150ba-06f4-11f1-85aa-3a34099a4c4b",
+      "extend_info": null,
+      "resource_object": "tool",
+      "source_id": "69c7eb67-6e11-4df0-bd8f-293c0f4c92bc",
+      "source_type": "openapi",
+      "script_type": "",
+      "code": "",
+      "dependencies": [],
+      "dependencies_url": ""
+     },
+     {
+      "tool_id": "a82ef26d-7775-48be-bdc6-cd1d7f90867b",
+      "name": "run_sql",
+      "description": "对知识网络挂载的数据资源执行只读 SQL（Trino 方言）。表名用占位符 {{.resource_id}} 引用（resource_id 取自对象类的 data_source.id，可由 search_schema 获得）；vega 会解析成真实表并限量。仅允许 SELECT/WITH，禁止写入/DDL；单次查询的资源需同属一个数据目录（不支持跨目录 join）。",
+      "status": "enabled",
+      "metadata_type": "openapi",
+      "metadata": {
+       "version": "1839dd82-9cf3-4667-8748-27c2dcdabacd",
+       "summary": "run_sql",
+       "description": "对知识网络挂载的数据资源执行只读 SQL（Trino 方言）。表名用占位符 {{.resource_id}} 引用（resource_id 取自对象类的 data_source.id，可由 search_schema 获得）；vega 会解析成真实表并限量。仅允许 SELECT/WITH，禁止写入/DDL；单次查询的资源需同属一个数据目录（不支持跨目录 join）。",
+       "server_url": "http://agent-retrieval:30779",
+       "path": "/api/agent-retrieval/in/v1/kn/run_sql",
+       "method": "POST",
+       "create_time": 1776920840668983300,
+       "update_time": 1776920840668983300,
+       "create_user": "ede150ba-06f4-11f1-85aa-3a34099a4c4b",
+       "update_user": "ede150ba-06f4-11f1-85aa-3a34099a4c4b",
+       "api_spec": {
+        "parameters": [
+         {
+          "name": "x-account-id",
+          "in": "header",
+          "description": "账户ID，用于内部服务调用时传递账户信息",
+          "required": false,
+          "schema": {
+           "type": "string"
+          }
+         },
+         {
+          "name": "x-account-type",
+          "in": "header",
+          "description": "账户类型：user(用户), app(应用), anonymous(匿名)",
+          "required": false,
+          "schema": {
+           "enum": [
+            "user",
+            "app",
+            "anonymous"
+           ],
+           "type": "string"
+          }
+         }
+        ],
+        "request_body": {
+         "description": "",
+         "content": {
+          "application/json": {
+           "schema": {
+            "type": "object",
+            "properties": {
+             "response_format": {
+              "type": "string",
+              "enum": [
+               "json",
+               "toon"
+              ],
+              "default": "toon",
+              "description": "文本格式：json 或 toon，默认 toon"
+             },
+             "sql": {
+              "type": "string",
+              "description": "只读 SQL（Trino 方言）。表名必须用占位符 {{.resource_id}} 引用，resource_id 取自对象类的 data_source.id（可经 search_schema 获得）。仅允许 SELECT / WITH，禁止任何写入与 DDL；不支持多语句；不支持跨数据目录 join（单次查询涉及的资源需同属一个 catalog）。vega 会自动限量（最多 10000 行）。"
+             },
+             "resource_type": {
+              "type": "string",
+              "description": "连接器类型（mysql / mariadb / postgresql）。留空则按 SQL 中第一个 {{.resource_id}} 自动解析，一般无需填写。"
+             },
+             "query_timeout": {
+              "type": "integer",
+              "description": "查询超时（秒），范围 1-3600，默认 60。可选。"
+             }
+            },
+            "required": [
+             "sql"
+            ]
+           }
+          }
+         },
+         "required": true
+        },
+        "responses": [
+         {
+          "status_code": "200",
+          "description": "ok",
+          "content": {
+           "application/json": {
+            "schema": {
+             "type": "object",
+             "properties": {
+              "columns": {
+               "type": "array",
+               "description": "结果列信息",
+               "items": {
+                "type": "object",
+                "properties": {
+                 "name": {
+                  "type": "string"
+                 },
+                 "type": {
+                  "type": "string"
+                 }
+                },
+                "additionalProperties": true
+               }
+              },
+              "entries": {
+               "type": "array",
+               "description": "结果行",
+               "items": {
+                "type": "object",
+                "additionalProperties": true
+               }
+              },
+              "total_count": {
+               "type": "integer",
+               "description": "返回行数"
+              },
+              "warnings": {
+               "type": "array",
+               "items": {
+                "type": "string"
+               },
+               "description": "非致命告警（如资源已弃用）"
+              }
+             }
+            }
+           }
+          }
+         }
+        ],
+        "components": null,
+        "callbacks": null,
+        "security": null,
+        "tags": null,
+        "external_docs": null
+       }
+      },
+      "use_rule": "",
+      "global_parameters": {
+       "name": "",
+       "description": "",
+       "required": false,
+       "in": "",
+       "type": "",
+       "value": null
+      },
+      "create_time": 1776920840668983300,
+      "update_time": 1776920840668983300,
+      "create_user": "ede150ba-06f4-11f1-85aa-3a34099a4c4b",
+      "update_user": "ede150ba-06f4-11f1-85aa-3a34099a4c4b",
+      "extend_info": null,
+      "resource_object": "tool",
+      "source_id": "1839dd82-9cf3-4667-8748-27c2dcdabacd",
+      "source_type": "openapi",
+      "script_type": "",
+      "code": "",
+      "dependencies": [],
+      "dependencies_url": ""
+     },
+     {
+      "tool_id": "863acc66-eb74-438a-bfe3-4db2e7def372",
+      "name": "list_knowledge_networks",
+      "description": "列出可用的知识网络（返回 kn_id、名称、描述）。其余查询工具均需 kn_id，作为探索的第一步入口。",
+      "status": "enabled",
+      "metadata_type": "openapi",
+      "metadata": {
+       "version": "262e6732-0759-4e62-8703-a52e84832006",
+       "summary": "list_knowledge_networks",
+       "description": "列出可用的知识网络（返回 kn_id、名称、描述）。其余查询工具均需 kn_id，作为探索的第一步入口。",
+       "server_url": "http://agent-retrieval:30779",
+       "path": "/api/agent-retrieval/in/v1/kn/list_knowledge_networks",
+       "method": "POST",
+       "create_time": 1776920840668983300,
+       "update_time": 1776920840668983300,
+       "create_user": "ede150ba-06f4-11f1-85aa-3a34099a4c4b",
+       "update_user": "ede150ba-06f4-11f1-85aa-3a34099a4c4b",
+       "api_spec": {
+        "parameters": [
+         {
+          "name": "x-account-id",
+          "in": "header",
+          "description": "账户ID，用于内部服务调用时传递账户信息",
+          "required": false,
+          "schema": {
+           "type": "string"
+          }
+         },
+         {
+          "name": "x-account-type",
+          "in": "header",
+          "description": "账户类型：user(用户), app(应用), anonymous(匿名)",
+          "required": false,
+          "schema": {
+           "enum": [
+            "user",
+            "app",
+            "anonymous"
+           ],
+           "type": "string"
+          }
+         }
+        ],
+        "request_body": {
+         "description": "",
+         "content": {
+          "application/json": {
+           "schema": {
+            "type": "object",
+            "properties": {
+             "response_format": {
+              "type": "string",
+              "enum": [
+               "json",
+               "toon"
+              ],
+              "default": "toon",
+              "description": "文本格式：json 或 toon，默认 toon"
+             },
+             "name_pattern": {
+              "type": "string",
+              "description": "按知识网络名称模糊过滤，可选"
+             },
+             "limit": {
+              "type": "integer",
+              "description": "单页数量，默认 20"
+             },
+             "offset": {
+              "type": "integer",
+              "description": "偏移量，用于翻页，默认 0"
+             },
+             "sort": {
+              "type": "string",
+              "description": "排序字段，默认 update_time"
+             },
+             "direction": {
+              "type": "string",
+              "enum": [
+               "asc",
+               "desc"
+              ],
+              "description": "排序方向，默认 desc"
+             }
+            }
+           }
+          }
+         },
+         "required": true
+        },
+        "responses": [
+         {
+          "status_code": "200",
+          "description": "ok",
+          "content": {
+           "application/json": {
+            "schema": {
+             "type": "object",
+             "properties": {
+              "entries": {
+               "type": "array",
+               "description": "知识网络列表",
+               "items": {
+                "type": "object",
+                "properties": {
+                 "id": {
+                  "type": "string",
+                  "description": "知识网络 ID（即 kn_id，供其余查询工具使用）"
+                 },
+                 "name": {
+                  "type": "string",
+                  "description": "知识网络名称"
+                 },
+                 "description": {
+                  "type": "string",
+                  "description": "描述"
+                 },
+                 "module_type": {
+                  "type": "string",
+                  "description": "模块类型"
+                 },
+                 "business_domain": {
+                  "type": "string",
+                  "description": "业务域"
+                 }
+                },
+                "additionalProperties": true
+               }
+              },
+              "total_count": {
+               "type": "integer",
+               "description": "命中总数"
+              }
+             }
+            }
+           }
+          }
+         }
+        ],
+        "components": null,
+        "callbacks": null,
+        "security": null,
+        "tags": null,
+        "external_docs": null
+       }
+      },
+      "use_rule": "",
+      "global_parameters": {
+       "name": "",
+       "description": "",
+       "required": false,
+       "in": "",
+       "type": "",
+       "value": null
+      },
+      "create_time": 1776920840668983300,
+      "update_time": 1776920840668983300,
+      "create_user": "ede150ba-06f4-11f1-85aa-3a34099a4c4b",
+      "update_user": "ede150ba-06f4-11f1-85aa-3a34099a4c4b",
+      "extend_info": null,
+      "resource_object": "tool",
+      "source_id": "262e6732-0759-4e62-8703-a52e84832006",
+      "source_type": "openapi",
+      "script_type": "",
+      "code": "",
+      "dependencies": [],
+      "dependencies_url": ""
+     },
+     {
+      "tool_id": "9ab97b0d-8a65-4c23-bef6-f899a6a1f5f9",
+      "name": "get_kn_detail",
+      "description": "获取知识网络 schema（概念组、对象类型含 data_source.id、关系类型、行动类型）。默认 detail_level=summary：骨架 + 属性名（name/type/comment），不含字段映射 / 查询算子 / 映射规则，足够理解结构与规划查询；需要完整字段映射 / 映射规则时用 detail_level=full 拿全量。",
+      "status": "enabled",
+      "metadata_type": "openapi",
+      "metadata": {
+       "version": "b7c34d4e-b7e7-4e19-b667-1fde349bfcd9",
+       "summary": "get_kn_detail",
+       "description": "获取知识网络 schema（概念组、对象类型含 data_source.id、关系类型、行动类型）。默认 detail_level=summary：骨架 + 属性名（name/type/comment），不含字段映射 / 查询算子 / 映射规则，足够理解结构与规划查询；需要完整字段映射 / 映射规则时用 detail_level=full 拿全量。",
+       "server_url": "http://agent-retrieval:30779",
+       "path": "/api/agent-retrieval/in/v1/kn/get_kn_detail",
+       "method": "POST",
+       "create_time": 1776920840668983300,
+       "update_time": 1776920840668983300,
+       "create_user": "ede150ba-06f4-11f1-85aa-3a34099a4c4b",
+       "update_user": "ede150ba-06f4-11f1-85aa-3a34099a4c4b",
+       "api_spec": {
+        "parameters": [
+         {
+          "name": "x-account-id",
+          "in": "header",
+          "description": "账户ID，用于内部服务调用时传递账户信息",
+          "required": false,
+          "schema": {
+           "type": "string"
+          }
+         },
+         {
+          "name": "x-account-type",
+          "in": "header",
+          "description": "账户类型：user(用户), app(应用), anonymous(匿名)",
+          "required": false,
+          "schema": {
+           "enum": [
+            "user",
+            "app",
+            "anonymous"
+           ],
+           "type": "string"
+          }
+         }
+        ],
+        "request_body": {
+         "description": "",
+         "content": {
+          "application/json": {
+           "schema": {
+            "type": "object",
+            "properties": {
+             "response_format": {
+              "type": "string",
+              "enum": [
+               "json",
+               "toon"
+              ],
+              "default": "toon",
+              "description": "文本格式：json 或 toon，默认 toon"
+             },
+             "kn_id": {
+              "type": "string",
+              "description": "知识网络 ID。也可改用 X-Kn-ID 请求头传入。"
+             },
+             "detail_level": {
+              "type": "string",
+              "enum": [
+               "summary",
+               "full"
+              ],
+              "default": "summary",
+              "description": "详情级别。summary（默认）：骨架 + 属性名（name/type/comment），不含字段映射 / 查询算子 / 映射规则；需要完整字段映射 / 映射规则时用 full。"
+             }
+            },
+            "required": [
+             "kn_id"
+            ]
+           }
+          }
+         },
+         "required": true
+        },
+        "responses": [
+         {
+          "status_code": "200",
+          "description": "ok",
+          "content": {
+           "application/json": {
+            "schema": {
+             "type": "object",
+             "properties": {
+              "id": {
+               "type": "string",
+               "description": "知识网络 ID"
+              },
+              "name": {
+               "type": "string",
+               "description": "知识网络名称"
+              },
+              "comment": {
+               "type": "string",
+               "description": "描述"
+              },
+              "concept_groups": {
+               "type": "array",
+               "items": {
+                "type": "object",
+                "additionalProperties": true
+               },
+               "description": "概念组"
+              },
+              "object_types": {
+               "type": "array",
+               "items": {
+                "type": "object",
+                "additionalProperties": true
+               },
+               "description": "对象类型（含 data_source 等）"
+              },
+              "relation_types": {
+               "type": "array",
+               "items": {
+                "type": "object",
+                "additionalProperties": true
+               },
+               "description": "关系类型"
+              },
+              "action_types": {
+               "type": "array",
+               "items": {
+                "type": "object",
+                "additionalProperties": true
+               },
+               "description": "行动类型"
+              }
+             }
+            }
+           }
+          }
+         }
+        ],
+        "components": null,
+        "callbacks": null,
+        "security": null,
+        "tags": null,
+        "external_docs": null
+       }
+      },
+      "use_rule": "",
+      "global_parameters": {
+       "name": "",
+       "description": "",
+       "required": false,
+       "in": "",
+       "type": "",
+       "value": null
+      },
+      "create_time": 1776920840668983300,
+      "update_time": 1776920840668983300,
+      "create_user": "ede150ba-06f4-11f1-85aa-3a34099a4c4b",
+      "update_user": "ede150ba-06f4-11f1-85aa-3a34099a4c4b",
+      "extend_info": null,
+      "resource_object": "tool",
+      "source_id": "b7c34d4e-b7e7-4e19-b667-1fde349bfcd9",
+      "source_type": "openapi",
+      "script_type": "",
+      "code": "",
+      "dependencies": [],
+      "dependencies_url": ""
+     },
+     {
+      "tool_id": "007bb878-29ee-40ed-9d55-bbea8d9f55eb",
+      "name": "get_object_types",
+      "description": "按 id 批量取对象类的完整定义（data_properties 含 mapped_field/condition_operations，logic_properties 含 data_source/parameters）。渐进式下钻：先 get_kn_detail(summary) 拿对象 id，再用本工具展开。ids 支持多个，未匹配的在 missing 返回。",
+      "status": "enabled",
+      "metadata_type": "openapi",
+      "metadata": {
+       "version": "192b5f4e-5d29-4ecb-9c45-77e38852978b",
+       "summary": "get_object_types",
+       "description": "按 id 批量取对象类的完整定义（data_properties 含 mapped_field/condition_operations，logic_properties 含 data_source/parameters）。渐进式下钻：先 get_kn_detail(summary) 拿对象 id，再用本工具展开。ids 支持多个，未匹配的在 missing 返回。",
+       "server_url": "http://agent-retrieval:30779",
+       "path": "/api/agent-retrieval/in/v1/kn/get_object_types",
+       "method": "POST",
+       "create_time": 1776920840668983300,
+       "update_time": 1776920840668983300,
+       "create_user": "ede150ba-06f4-11f1-85aa-3a34099a4c4b",
+       "update_user": "ede150ba-06f4-11f1-85aa-3a34099a4c4b",
+       "api_spec": {
+        "parameters": [
+         {
+          "name": "x-account-id",
+          "in": "header",
+          "description": "账户ID，用于内部服务调用时传递账户信息",
+          "required": false,
+          "schema": {
+           "type": "string"
+          }
+         },
+         {
+          "name": "x-account-type",
+          "in": "header",
+          "description": "账户类型：user(用户), app(应用), anonymous(匿名)",
+          "required": false,
+          "schema": {
+           "enum": [
+            "user",
+            "app",
+            "anonymous"
+           ],
+           "type": "string"
+          }
+         }
+        ],
+        "request_body": {
+         "description": "",
+         "content": {
+          "application/json": {
+           "schema": {
+            "type": "object",
+            "properties": {
+             "response_format": {
+              "type": "string",
+              "enum": [
+               "json",
+               "toon"
+              ],
+              "default": "toon",
+              "description": "文本格式：json 或 toon，默认 toon"
+             },
+             "kn_id": {
+              "type": "string",
+              "description": "知识网络 ID。也可改用 X-Kn-ID 请求头传入。"
+             },
+             "ids": {
+              "type": "array",
+              "items": {
+               "type": "string"
+              },
+              "description": "要展开的对象类 id（取自 get_kn_detail summary 的 object_types[].id，也接受 name）。支持多个。"
+             }
+            },
+            "required": [
+             "kn_id",
+             "ids"
+            ]
+           }
+          }
+         },
+         "required": true
+        },
+        "responses": [
+         {
+          "status_code": "200",
+          "description": "ok",
+          "content": {
+           "application/json": {
+            "schema": {
+             "type": "object",
+             "properties": {
+              "kn_id": {
+               "type": "string",
+               "description": "知识网络 ID"
+              },
+              "object_types": {
+               "type": "array",
+               "items": {
+                "type": "object",
+                "additionalProperties": true
+               },
+               "description": "对象类完整定义（含 data_properties / logic_properties 的映射细节）"
+              },
+              "missing": {
+               "type": "array",
+               "items": {
+                "type": "string"
+               },
+               "description": "请求了但未匹配到的 id"
+              }
+             }
+            }
+           }
+          }
+         }
+        ],
+        "components": null,
+        "callbacks": null,
+        "security": null,
+        "tags": null,
+        "external_docs": null
+       }
+      },
+      "use_rule": "",
+      "global_parameters": {
+       "name": "",
+       "description": "",
+       "required": false,
+       "in": "",
+       "type": "",
+       "value": null
+      },
+      "create_time": 1776920840668983300,
+      "update_time": 1776920840668983300,
+      "create_user": "ede150ba-06f4-11f1-85aa-3a34099a4c4b",
+      "update_user": "ede150ba-06f4-11f1-85aa-3a34099a4c4b",
+      "extend_info": null,
+      "resource_object": "tool",
+      "source_id": "192b5f4e-5d29-4ecb-9c45-77e38852978b",
+      "source_type": "openapi",
+      "script_type": "",
+      "code": "",
+      "dependencies": [],
+      "dependencies_url": ""
+     },
+     {
+      "tool_id": "f961b785-e06e-4633-ac29-ff0b3ae94c12",
+      "name": "get_relation_types",
+      "description": "按 id 批量取关系类的完整定义（含 mapping_rules、source/target 对象名）。渐进式下钻：先 get_kn_detail(summary) 拿关系 id，再用本工具展开。ids 支持多个，未匹配的在 missing 返回。",
+      "status": "enabled",
+      "metadata_type": "openapi",
+      "metadata": {
+       "version": "72ae911c-9cb3-4ba1-8f53-2711701d9a68",
+       "summary": "get_relation_types",
+       "description": "按 id 批量取关系类的完整定义（含 mapping_rules、source/target 对象名）。渐进式下钻：先 get_kn_detail(summary) 拿关系 id，再用本工具展开。ids 支持多个，未匹配的在 missing 返回。",
+       "server_url": "http://agent-retrieval:30779",
+       "path": "/api/agent-retrieval/in/v1/kn/get_relation_types",
+       "method": "POST",
+       "create_time": 1776920840668983300,
+       "update_time": 1776920840668983300,
+       "create_user": "ede150ba-06f4-11f1-85aa-3a34099a4c4b",
+       "update_user": "ede150ba-06f4-11f1-85aa-3a34099a4c4b",
+       "api_spec": {
+        "parameters": [
+         {
+          "name": "x-account-id",
+          "in": "header",
+          "description": "账户ID，用于内部服务调用时传递账户信息",
+          "required": false,
+          "schema": {
+           "type": "string"
+          }
+         },
+         {
+          "name": "x-account-type",
+          "in": "header",
+          "description": "账户类型：user(用户), app(应用), anonymous(匿名)",
+          "required": false,
+          "schema": {
+           "enum": [
+            "user",
+            "app",
+            "anonymous"
+           ],
+           "type": "string"
+          }
+         }
+        ],
+        "request_body": {
+         "description": "",
+         "content": {
+          "application/json": {
+           "schema": {
+            "type": "object",
+            "properties": {
+             "response_format": {
+              "type": "string",
+              "enum": [
+               "json",
+               "toon"
+              ],
+              "default": "toon",
+              "description": "文本格式：json 或 toon，默认 toon"
+             },
+             "kn_id": {
+              "type": "string",
+              "description": "知识网络 ID。也可改用 X-Kn-ID 请求头传入。"
+             },
+             "ids": {
+              "type": "array",
+              "items": {
+               "type": "string"
+              },
+              "description": "要展开的关系类 id（取自 get_kn_detail summary 的 relation_types[].id，也接受 name）。支持多个。"
+             }
+            },
+            "required": [
+             "kn_id",
+             "ids"
+            ]
+           }
+          }
+         },
+         "required": true
+        },
+        "responses": [
+         {
+          "status_code": "200",
+          "description": "ok",
+          "content": {
+           "application/json": {
+            "schema": {
+             "type": "object",
+             "properties": {
+              "kn_id": {
+               "type": "string",
+               "description": "知识网络 ID"
+              },
+              "relation_types": {
+               "type": "array",
+               "items": {
+                "type": "object",
+                "additionalProperties": true
+               },
+               "description": "关系类完整定义（含 mapping_rules、source/target 对象名）"
+              },
+              "missing": {
+               "type": "array",
+               "items": {
+                "type": "string"
+               },
+               "description": "请求了但未匹配到的 id"
+              }
+             }
+            }
+           }
+          }
+         }
+        ],
+        "components": null,
+        "callbacks": null,
+        "security": null,
+        "tags": null,
+        "external_docs": null
+       }
+      },
+      "use_rule": "",
+      "global_parameters": {
+       "name": "",
+       "description": "",
+       "required": false,
+       "in": "",
+       "type": "",
+       "value": null
+      },
+      "create_time": 1776920840668983300,
+      "update_time": 1776920840668983300,
+      "create_user": "ede150ba-06f4-11f1-85aa-3a34099a4c4b",
+      "update_user": "ede150ba-06f4-11f1-85aa-3a34099a4c4b",
+      "extend_info": null,
+      "resource_object": "tool",
+      "source_id": "72ae911c-9cb3-4ba1-8f53-2711701d9a68",
+      "source_type": "openapi",
+      "script_type": "",
+      "code": "",
+      "dependencies": [],
+      "dependencies_url": ""
+     },
+     {
+      "tool_id": "6717eb6b-d933-4fbb-b680-e53969671cab",
+      "name": "list_resources",
+      "description": "数据层资源直查（脱离本体）：列出当前账户有权查看的数据资源（resource_id、name、type、catalog_id），可按 catalog_id / type 过滤。配合 describe_resource + run_sql。",
+      "status": "enabled",
+      "metadata_type": "openapi",
+      "metadata": {
+       "version": "22e619f1-280c-49f3-b583-30bd7afb7922",
+       "summary": "list_resources",
+       "description": "数据层资源直查（脱离本体）：列出当前账户有权查看的数据资源，可按 catalog_id / type 过滤。资源未建成对象类、或想绕本体直查数据时用。配合 describe_resource + run_sql。",
+       "server_url": "http://agent-retrieval:30779",
+       "path": "/api/agent-retrieval/in/v1/kn/list_resources",
+       "method": "POST",
+       "create_time": 1776920840668983300,
+       "update_time": 1776920840668983300,
+       "create_user": "ede150ba-06f4-11f1-85aa-3a34099a4c4b",
+       "update_user": "ede150ba-06f4-11f1-85aa-3a34099a4c4b",
+       "api_spec": {
+        "parameters": [
+         {
+          "name": "x-account-id",
+          "in": "header",
+          "description": "账户ID，用于内部服务调用时传递账户信息",
+          "required": false,
+          "schema": {
+           "type": "string"
+          }
+         },
+         {
+          "name": "x-account-type",
+          "in": "header",
+          "description": "账户类型：user(用户), app(应用), anonymous(匿名)",
+          "required": false,
+          "schema": {
+           "enum": [
+            "user",
+            "app",
+            "anonymous"
+           ],
+           "type": "string"
+          }
+         }
+        ],
+        "request_body": {
+         "description": "",
+         "content": {
+          "application/json": {
+           "schema": {
+            "type": "object",
+            "properties": {
+             "response_format": {
+              "type": "string",
+              "enum": [
+               "json",
+               "toon"
+              ],
+              "default": "toon",
+              "description": "文本格式：json 或 toon，默认 toon"
+             },
+             "catalog_id": {
+              "type": "string",
+              "description": "可选。限定某数据目录（catalog）下的资源。"
+             },
+             "type": {
+              "type": "string",
+              "description": "可选。按资源类别过滤（table / file / fileset / api / metric / topic / index / logicview / dataset）。"
+             },
+             "offset": {
+              "type": "integer",
+              "description": "可选。分页偏移，默认 0。"
+             },
+             "limit": {
+              "type": "integer",
+              "description": "可选。分页大小，默认 20。"
+             }
+            }
+           }
+          }
+         },
+         "required": false
+        },
+        "responses": [
+         {
+          "status_code": "200",
+          "description": "ok",
+          "content": {
+           "application/json": {
+            "schema": {
+             "type": "object",
+             "properties": {
+              "entries": {
+               "type": "array",
+               "description": "资源列表（仅含当前账户有权查看的资源）",
+               "items": {
+                "type": "object",
+                "properties": {
+                 "resource_id": {
+                  "type": "string"
+                 },
+                 "name": {
+                  "type": "string"
+                 },
+                 "type": {
+                  "type": "string"
+                 },
+                 "status": {
+                  "type": "string"
+                 },
+                 "catalog_id": {
+                  "type": "string"
+                 }
+                },
+                "additionalProperties": true
+               }
+              },
+              "total_count": {
+               "type": "integer",
+               "description": "符合过滤条件的资源总数"
+              }
+             }
+            }
+           }
+          }
+         }
+        ],
+        "components": null,
+        "callbacks": null,
+        "security": null,
+        "tags": null,
+        "external_docs": null
+       }
+      },
+      "use_rule": "",
+      "global_parameters": {
+       "name": "",
+       "description": "",
+       "required": false,
+       "in": "",
+       "type": "",
+       "value": null
+      },
+      "create_time": 1776920840668983300,
+      "update_time": 1776920840668983300,
+      "create_user": "ede150ba-06f4-11f1-85aa-3a34099a4c4b",
+      "update_user": "ede150ba-06f4-11f1-85aa-3a34099a4c4b",
+      "extend_info": null,
+      "resource_object": "tool",
+      "source_id": "22e619f1-280c-49f3-b583-30bd7afb7922",
+      "source_type": "openapi",
+      "script_type": "",
+      "code": "",
+      "dependencies": [],
+      "dependencies_url": ""
+     },
+     {
+      "tool_id": "0c76b2f0-6902-4179-8670-1bd94ef55b58",
+      "name": "describe_resource",
+      "description": "取单个数据资源的物理 schema：connector_type 与列（columns:[{name,type}]）。写 run_sql 前用它拿物理列名。入参 resource_id 取自 list_resources。",
+      "status": "enabled",
+      "metadata_type": "openapi",
+      "metadata": {
+       "version": "f02d1fb4-aa97-4c93-98f0-2b062e437632",
+       "summary": "describe_resource",
+       "description": "取单个数据资源的物理 schema：connector_type 与列（columns:[{name,type}]）。写 run_sql 前用它拿物理列名。入参 resource_id 取自 list_resources。",
+       "server_url": "http://agent-retrieval:30779",
+       "path": "/api/agent-retrieval/in/v1/kn/describe_resource",
+       "method": "POST",
+       "create_time": 1776920840668983300,
+       "update_time": 1776920840668983300,
+       "create_user": "ede150ba-06f4-11f1-85aa-3a34099a4c4b",
+       "update_user": "ede150ba-06f4-11f1-85aa-3a34099a4c4b",
+       "api_spec": {
+        "parameters": [
+         {
+          "name": "x-account-id",
+          "in": "header",
+          "description": "账户ID，用于内部服务调用时传递账户信息",
+          "required": false,
+          "schema": {
+           "type": "string"
+          }
+         },
+         {
+          "name": "x-account-type",
+          "in": "header",
+          "description": "账户类型：user(用户), app(应用), anonymous(匿名)",
+          "required": false,
+          "schema": {
+           "enum": [
+            "user",
+            "app",
+            "anonymous"
+           ],
+           "type": "string"
+          }
+         }
+        ],
+        "request_body": {
+         "description": "",
+         "content": {
+          "application/json": {
+           "schema": {
+            "type": "object",
+            "properties": {
+             "response_format": {
+              "type": "string",
+              "enum": [
+               "json",
+               "toon"
+              ],
+              "default": "toon",
+              "description": "文本格式：json 或 toon，默认 toon"
+             },
+             "resource_id": {
+              "type": "string",
+              "description": "资源 ID（取自 list_resources 的 resource_id）。"
+             }
+            },
+            "required": [
+             "resource_id"
+            ]
+           }
+          }
+         },
+         "required": true
+        },
+        "responses": [
+         {
+          "status_code": "200",
+          "description": "ok",
+          "content": {
+           "application/json": {
+            "schema": {
+             "type": "object",
+             "properties": {
+              "resource_id": {
+               "type": "string"
+              },
+              "connector_type": {
+               "type": "string",
+               "description": "连接器类型（mysql / mariadb / postgresql）"
+              },
+              "columns": {
+               "type": "array",
+               "description": "物理列。写 run_sql 时列名用此处的 name。",
+               "items": {
+                "type": "object",
+                "properties": {
+                 "name": {
+                  "type": "string"
+                 },
+                 "type": {
+                  "type": "string"
+                 },
+                 "description": {
+                  "type": "string"
+                 }
+                },
+                "additionalProperties": true
+               }
+              }
+             }
+            }
+           }
+          }
+         }
+        ],
+        "components": null,
+        "callbacks": null,
+        "security": null,
+        "tags": null,
+        "external_docs": null
+       }
+      },
+      "use_rule": "",
+      "global_parameters": {
+       "name": "",
+       "description": "",
+       "required": false,
+       "in": "",
+       "type": "",
+       "value": null
+      },
+      "create_time": 1776920840668983300,
+      "update_time": 1776920840668983300,
+      "create_user": "ede150ba-06f4-11f1-85aa-3a34099a4c4b",
+      "update_user": "ede150ba-06f4-11f1-85aa-3a34099a4c4b",
+      "extend_info": null,
+      "resource_object": "tool",
+      "source_id": "f02d1fb4-aa97-4c93-98f0-2b062e437632",
+      "source_type": "openapi",
+      "script_type": "",
+      "code": "",
+      "dependencies": [],
+      "dependencies_url": ""
+     },
+     {
+      "tool_id": "cbf21a24-bfc2-5d0b-ba38-8f737650a194",
+      "name": "execute_action",
+      "description": "执行行动。先用 get_action_info 获取 dynamic_params schema，再填入真实动态参数值触发执行（异步，返回 execution_id）。",
+      "status": "enabled",
+      "metadata_type": "openapi",
+      "metadata": {
+       "version": "c3101053-cebb-5066-b93c-ba2514c231fd",
+       "summary": "execute_action",
+       "description": "执行行动。先用 get_action_info 获取 dynamic_params schema，再填入真实动态参数值触发执行（异步，返回 execution_id）。",
+       "server_url": "http://agent-retrieval:30779",
+       "path": "/api/agent-retrieval/in/v1/kn/execute_action",
+       "method": "POST",
+       "create_time": 1776920840666727400,
+       "update_time": 1776920840666727400,
+       "create_user": "ede150ba-06f4-11f1-85aa-3a34099a4c4b",
+       "update_user": "ede150ba-06f4-11f1-85aa-3a34099a4c4b",
+       "api_spec": {
+        "parameters": [
+         {
+          "name": "x-account-id",
+          "in": "header",
+          "description": "账户ID，用于内部服务调用时传递账户信息",
+          "required": false,
+          "schema": {
+           "type": "string"
+          }
+         },
+         {
+          "name": "x-account-type",
+          "in": "header",
+          "description": "账户类型：user(用户), app(应用), anonymous(匿名)",
+          "required": false,
+          "schema": {
+           "enum": [
+            "user",
+            "app",
+            "anonymous"
+           ],
+           "type": "string"
+          }
+         },
+         {
+          "name": "response_format",
+          "in": "query",
+          "description": "响应格式：json 或 toon，默认 json",
+          "required": false,
+          "schema": {
+           "default": "json",
+           "enum": [
+            "json",
+            "toon"
+           ],
+           "type": "string"
+          }
+         }
+        ],
+        "request_body": {
+         "description": "",
+         "content": {
+          "application/json": {
+           "examples": {
+            "example": {
+             "summary": "执行通知行动",
+             "value": {
+              "kn_id": "kn_demo",
+              "at_id": "notify",
+              "_instance_identities": [
+               {
+                "id": "1"
+               }
+              ],
+              "dynamic_params": {
+               "message": "hello",
+               "name": "张三"
+              }
+             }
+            }
+           },
+           "schema": {
+            "type": "object",
+            "properties": {
+             "kn_id": {
+              "type": "string",
+              "description": "知识网络 ID"
+             },
+             "at_id": {
+              "type": "string",
+              "description": "行动类型 ID，由 search_schema 或 get_kn_detail 返回"
+             },
+             "_instance_identities": {
+              "type": "array",
+              "description": "目标实例列表；为空时按行动条件扫描",
+              "items": {
+               "type": "object",
+               "additionalProperties": true
+              }
+             },
+             "dynamic_params": {
+              "type": "object",
+              "description": "动态参数值（对应 value_from=input 的参数）；先用 get_action_info 获取参数名再逐个填入",
+              "additionalProperties": true
+             }
+            },
+            "required": [
+             "kn_id",
+             "at_id"
+            ]
+           }
+          }
+         },
+         "required": true
+        },
+        "responses": [
+         {
+          "status_code": "200",
+          "description": "成功返回动态工具列表",
+          "content": {
+           "application/json": {
+            "schema": {
+             "$ref": "#/components/schemas/ActionRecallResponse"
+            }
+           }
+          }
+         },
+         {
+          "status_code": "400",
+          "description": "请求参数错误",
+          "content": {
+           "application/json": {
+            "examples": {
+             "invalid_request": {
+              "value": {
+               "code": "INVALID_REQUEST",
+               "description": "_instance_identities 格式错误"
+              }
+             }
+            },
+            "schema": {
+             "$ref": "#/components/schemas/ErrorResponse"
+            }
+           }
+          }
+         },
+         {
+          "status_code": "500",
+          "description": "服务器内部错误",
+          "content": {
+           "application/json": {
+            "schema": {
+             "$ref": "#/components/schemas/ErrorResponse"
+            }
+           }
+          }
+         },
+         {
+          "status_code": "502",
+          "description": "上游服务不可用",
+          "content": {
+           "application/json": {
+            "schema": {
+             "$ref": "#/components/schemas/ErrorResponse"
+            }
+           }
+          }
+         }
+        ],
+        "components": {
+         "schemas": {}
+        },
+        "callbacks": null,
+        "security": null,
+        "tags": [
+         "action-recall"
+        ],
+        "external_docs": null
+       }
+      },
+      "use_rule": "",
+      "global_parameters": {
+       "name": "",
+       "description": "",
+       "required": false,
+       "in": "",
+       "type": "",
+       "value": null
+      },
+      "create_time": 1776920840668983300,
+      "update_time": 1776920840668983300,
+      "create_user": "ede150ba-06f4-11f1-85aa-3a34099a4c4b",
+      "update_user": "ede150ba-06f4-11f1-85aa-3a34099a4c4b",
+      "extend_info": null,
+      "resource_object": "tool",
+      "source_id": "c3101053-cebb-5066-b93c-ba2514c231fd",
+      "source_type": "openapi",
+      "script_type": "",
+      "code": "",
+      "dependencies": [],
+      "dependencies_url": ""
+     },
+     {
+      "tool_id": "916d7a79-2929-5b7d-8810-77fec4627302",
+      "name": "get_action_execution",
+      "description": "查询单次行动执行的状态与结果。用 execute_action 返回的 execution_id 查询整体 status 与逐对象 results。",
+      "status": "enabled",
+      "metadata_type": "openapi",
+      "metadata": {
+       "version": "20be9d79-c268-5f3c-a3e8-2a5537e759dc",
+       "summary": "get_action_execution",
+       "description": "查询单次行动执行的状态与结果。用 execute_action 返回的 execution_id 查询整体 status 与逐对象 results。",
+       "server_url": "http://agent-retrieval:30779",
+       "path": "/api/agent-retrieval/in/v1/kn/get_action_execution",
+       "method": "POST",
+       "create_time": 1776920840666727400,
+       "update_time": 1776920840666727400,
+       "create_user": "ede150ba-06f4-11f1-85aa-3a34099a4c4b",
+       "update_user": "ede150ba-06f4-11f1-85aa-3a34099a4c4b",
+       "api_spec": {
+        "parameters": [
+         {
+          "name": "x-account-id",
+          "in": "header",
+          "description": "账户ID，用于内部服务调用时传递账户信息",
+          "required": false,
+          "schema": {
+           "type": "string"
+          }
+         },
+         {
+          "name": "x-account-type",
+          "in": "header",
+          "description": "账户类型：user(用户), app(应用), anonymous(匿名)",
+          "required": false,
+          "schema": {
+           "enum": [
+            "user",
+            "app",
+            "anonymous"
+           ],
+           "type": "string"
+          }
+         },
+         {
+          "name": "response_format",
+          "in": "query",
+          "description": "响应格式：json 或 toon，默认 json",
+          "required": false,
+          "schema": {
+           "default": "json",
+           "enum": [
+            "json",
+            "toon"
+           ],
+           "type": "string"
+          }
+         }
+        ],
+        "request_body": {
+         "description": "",
+         "content": {
+          "application/json": {
+           "examples": {
+            "example": {
+             "summary": "查询执行结果",
+             "value": {
+              "kn_id": "kn_demo",
+              "execution_id": "exec_xxx"
+             }
+            }
+           },
+           "schema": {
+            "type": "object",
+            "properties": {
+             "kn_id": {
+              "type": "string",
+              "description": "知识网络 ID"
+             },
+             "execution_id": {
+              "type": "string",
+              "description": "行动执行 ID，由 execute_action 返回"
+             }
+            },
+            "required": [
+             "kn_id",
+             "execution_id"
+            ]
+           }
+          }
+         },
+         "required": true
+        },
+        "responses": [
+         {
+          "status_code": "200",
+          "description": "成功返回动态工具列表",
+          "content": {
+           "application/json": {
+            "schema": {
+             "$ref": "#/components/schemas/ActionRecallResponse"
+            }
+           }
+          }
+         },
+         {
+          "status_code": "400",
+          "description": "请求参数错误",
+          "content": {
+           "application/json": {
+            "examples": {
+             "invalid_request": {
+              "value": {
+               "code": "INVALID_REQUEST",
+               "description": "_instance_identities 格式错误"
+              }
+             }
+            },
+            "schema": {
+             "$ref": "#/components/schemas/ErrorResponse"
+            }
+           }
+          }
+         },
+         {
+          "status_code": "500",
+          "description": "服务器内部错误",
+          "content": {
+           "application/json": {
+            "schema": {
+             "$ref": "#/components/schemas/ErrorResponse"
+            }
+           }
+          }
+         },
+         {
+          "status_code": "502",
+          "description": "上游服务不可用",
+          "content": {
+           "application/json": {
+            "schema": {
+             "$ref": "#/components/schemas/ErrorResponse"
+            }
+           }
+          }
+         }
+        ],
+        "components": {
+         "schemas": {}
+        },
+        "callbacks": null,
+        "security": null,
+        "tags": [
+         "action-recall"
+        ],
+        "external_docs": null
+       }
+      },
+      "use_rule": "",
+      "global_parameters": {
+       "name": "",
+       "description": "",
+       "required": false,
+       "in": "",
+       "type": "",
+       "value": null
+      },
+      "create_time": 1776920840668983300,
+      "update_time": 1776920840668983300,
+      "create_user": "ede150ba-06f4-11f1-85aa-3a34099a4c4b",
+      "update_user": "ede150ba-06f4-11f1-85aa-3a34099a4c4b",
+      "extend_info": null,
+      "resource_object": "tool",
+      "source_id": "20be9d79-c268-5f3c-a3e8-2a5537e759dc",
+      "source_type": "openapi",
+      "script_type": "",
+      "code": "",
+      "dependencies": [],
+      "dependencies_url": ""
+     },
+     {
+      "tool_id": "7692d738-8e31-59dc-97e4-9020e3d0cbc5",
+      "name": "list_action_executions",
+      "description": "列出行动执行历史，可按行动类型、状态、触发方式过滤并分页。",
+      "status": "enabled",
+      "metadata_type": "openapi",
+      "metadata": {
+       "version": "00e89be6-bfde-578c-bc2f-80866e86554a",
+       "summary": "list_action_executions",
+       "description": "列出行动执行历史，可按行动类型、状态、触发方式过滤并分页。",
+       "server_url": "http://agent-retrieval:30779",
+       "path": "/api/agent-retrieval/in/v1/kn/list_action_executions",
+       "method": "POST",
+       "create_time": 1776920840666727400,
+       "update_time": 1776920840666727400,
+       "create_user": "ede150ba-06f4-11f1-85aa-3a34099a4c4b",
+       "update_user": "ede150ba-06f4-11f1-85aa-3a34099a4c4b",
+       "api_spec": {
+        "parameters": [
+         {
+          "name": "x-account-id",
+          "in": "header",
+          "description": "账户ID，用于内部服务调用时传递账户信息",
+          "required": false,
+          "schema": {
+           "type": "string"
+          }
+         },
+         {
+          "name": "x-account-type",
+          "in": "header",
+          "description": "账户类型：user(用户), app(应用), anonymous(匿名)",
+          "required": false,
+          "schema": {
+           "enum": [
+            "user",
+            "app",
+            "anonymous"
+           ],
+           "type": "string"
+          }
+         },
+         {
+          "name": "response_format",
+          "in": "query",
+          "description": "响应格式：json 或 toon，默认 json",
+          "required": false,
+          "schema": {
+           "default": "json",
+           "enum": [
+            "json",
+            "toon"
+           ],
+           "type": "string"
+          }
+         }
+        ],
+        "request_body": {
+         "description": "",
+         "content": {
+          "application/json": {
+           "examples": {
+            "example": {
+             "summary": "列出最近执行",
+             "value": {
+              "kn_id": "kn_demo",
+              "limit": 20
+             }
+            }
+           },
+           "schema": {
+            "type": "object",
+            "properties": {
+             "kn_id": {
+              "type": "string",
+              "description": "知识网络 ID"
+             },
+             "action_type_id": {
+              "type": "string",
+              "description": "按行动类型过滤（可选）"
+             },
+             "status": {
+              "type": "string",
+              "description": "按状态过滤（可选）：pending/running/completed/failed/cancelled"
+             },
+             "trigger_type": {
+              "type": "string",
+              "description": "按触发方式过滤（可选）：manual/scheduled"
+             },
+             "start_time_from": {
+              "type": "integer",
+              "description": "起始时间下界 Unix 毫秒（可选）"
+             },
+             "start_time_to": {
+              "type": "integer",
+              "description": "起始时间上界 Unix 毫秒（可选）"
+             },
+             "offset": {
+              "type": "integer",
+              "description": "分页偏移（可选）"
+             },
+             "limit": {
+              "type": "integer",
+              "description": "分页条数（可选），默认 20 最大 1000"
+             }
+            },
+            "required": [
+             "kn_id"
+            ]
+           }
+          }
+         },
+         "required": true
+        },
+        "responses": [
+         {
+          "status_code": "200",
+          "description": "成功返回动态工具列表",
+          "content": {
+           "application/json": {
+            "schema": {
+             "$ref": "#/components/schemas/ActionRecallResponse"
+            }
+           }
+          }
+         },
+         {
+          "status_code": "400",
+          "description": "请求参数错误",
+          "content": {
+           "application/json": {
+            "examples": {
+             "invalid_request": {
+              "value": {
+               "code": "INVALID_REQUEST",
+               "description": "_instance_identities 格式错误"
+              }
+             }
+            },
+            "schema": {
+             "$ref": "#/components/schemas/ErrorResponse"
+            }
+           }
+          }
+         },
+         {
+          "status_code": "500",
+          "description": "服务器内部错误",
+          "content": {
+           "application/json": {
+            "schema": {
+             "$ref": "#/components/schemas/ErrorResponse"
+            }
+           }
+          }
+         },
+         {
+          "status_code": "502",
+          "description": "上游服务不可用",
+          "content": {
+           "application/json": {
+            "schema": {
+             "$ref": "#/components/schemas/ErrorResponse"
+            }
+           }
+          }
+         }
+        ],
+        "components": {
+         "schemas": {}
+        },
+        "callbacks": null,
+        "security": null,
+        "tags": [
+         "action-recall"
+        ],
+        "external_docs": null
+       }
+      },
+      "use_rule": "",
+      "global_parameters": {
+       "name": "",
+       "description": "",
+       "required": false,
+       "in": "",
+       "type": "",
+       "value": null
+      },
+      "create_time": 1776920840668983300,
+      "update_time": 1776920840668983300,
+      "create_user": "ede150ba-06f4-11f1-85aa-3a34099a4c4b",
+      "update_user": "ede150ba-06f4-11f1-85aa-3a34099a4c4b",
+      "extend_info": null,
+      "resource_object": "tool",
+      "source_id": "00e89be6-bfde-578c-bc2f-80866e86554a",
+      "source_type": "openapi",
+      "script_type": "",
+      "code": "",
+      "dependencies": [],
+      "dependencies_url": ""
+     }
+    ],
+    "create_time": 1776920840665934300,
+    "update_time": 1776920840665934300,
+    "create_user": "ede150ba-06f4-11f1-85aa-3a34099a4c4b",
+    "update_user": "ede150ba-06f4-11f1-85aa-3a34099a4c4b",
+    "metadata_type": "openapi"
+   }
+  ]
+ }
 }

--- a/adp/context-loader/agent-retrieval/server/drivenadapters/ontology_query.go
+++ b/adp/context-loader/agent-retrieval/server/drivenadapters/ontology_query.go
@@ -39,6 +39,8 @@ const (
 	queryLogicPropertiesURI = "/in/v1/knowledge-networks/%s/object-types/%s/properties"
 	// https://{host}:{port}/api/ontology-query/v1/knowledge-networks/:kn_id/action-types/:at_id
 	queryActionsURI = "/in/v1/knowledge-networks/%s/action-types/%s"
+	// https://{host}:{port}/api/ontology-query/in/v1/knowledge-networks/:kn_id/action-types/:at_id/execute
+	executeActionsURI = "/in/v1/knowledge-networks/%s/action-types/%s/execute"
 	// https://{host}:{port}/api/ontology-query/in/v1/knowledge-networks/:kn_id/subgraph
 	queryInstanceSubgraphURI = "/in/v1/knowledge-networks/%s/subgraph"
 )
@@ -189,6 +191,49 @@ func (o *ontologyQueryClient) QueryActions(ctx context.Context, req *interfaces.
 	// 记录响应日志
 	respJSON, _ := json.Marshal(resp)
 	o.logger.WithContext(ctx).Debugf("[OntologyQuery#QueryActions] Response: %s", string(respJSON))
+
+	return resp, nil
+}
+
+// ExecuteActions 执行行动（异步），返回 execution_id
+func (o *ontologyQueryClient) ExecuteActions(ctx context.Context, req *interfaces.ExecuteActionsRequest) (resp *interfaces.ExecuteActionsResponse, err error) {
+	uri := fmt.Sprintf(executeActionsURI, req.KnID, req.AtID)
+	url := fmt.Sprintf("%s%s", o.baseURL, uri)
+
+	// 构建请求体（真实执行，携带动态参数；不设 method-override，为真正的 POST）
+	body := map[string]any{
+		"_instance_identities": req.InstanceIdentities,
+	}
+	if len(req.DynamicParams) > 0 {
+		body["dynamic_params"] = req.DynamicParams
+	}
+
+	// 记录请求日志
+	bodyJSON, _ := json.Marshal(body)
+	o.logger.WithContext(ctx).Debugf("[OntologyQuery#ExecuteActions] URL: %s", url)
+	o.logger.WithContext(ctx).Debugf("[OntologyQuery#ExecuteActions] Request Body: %s", string(bodyJSON))
+
+	header := common.GetHeaderFromCtx(ctx)
+	header[rest.ContentTypeKey] = rest.ContentTypeJSON
+
+	_, respBody, err := o.httpClient.Post(ctx, url, header, body)
+	if err != nil {
+		o.logger.WithContext(ctx).Errorf("[OntologyQuery#ExecuteActions] Request failed, err: %v", err)
+		return nil, infraErr.DefaultHTTPError(ctx, http.StatusBadGateway, fmt.Sprintf("行动执行接口调用失败: %v", err))
+	}
+
+	resp = &interfaces.ExecuteActionsResponse{}
+	resultByt := utils.ObjectToByte(respBody)
+	err = json.Unmarshal(resultByt, resp)
+	if err != nil {
+		o.logger.WithContext(ctx).Errorf("[OntologyQuery#ExecuteActions] Unmarshal failed, body: %s, err: %v", string(resultByt), err)
+		err = infraErr.DefaultHTTPError(ctx, http.StatusInternalServerError, fmt.Sprintf("解析行动执行响应失败: %v", err))
+		return nil, err
+	}
+
+	// 记录响应日志
+	respJSON, _ := json.Marshal(resp)
+	o.logger.WithContext(ctx).Debugf("[OntologyQuery#ExecuteActions] Response: %s", string(respJSON))
 
 	return resp, nil
 }

--- a/adp/context-loader/agent-retrieval/server/drivenadapters/ontology_query.go
+++ b/adp/context-loader/agent-retrieval/server/drivenadapters/ontology_query.go
@@ -11,6 +11,8 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"net/url"
+	"strconv"
 	"sync"
 
 	"github.com/openbkn-ai/adp/context-loader/agent-retrieval/server/infra/common"
@@ -41,6 +43,10 @@ const (
 	queryActionsURI = "/in/v1/knowledge-networks/%s/action-types/%s"
 	// https://{host}:{port}/api/ontology-query/in/v1/knowledge-networks/:kn_id/action-types/:at_id/execute
 	executeActionsURI = "/in/v1/knowledge-networks/%s/action-types/%s/execute"
+	// https://{host}:{port}/api/ontology-query/in/v1/knowledge-networks/:kn_id/action-executions/:execution_id
+	getActionExecutionURI = "/in/v1/knowledge-networks/%s/action-executions/%s"
+	// https://{host}:{port}/api/ontology-query/in/v1/knowledge-networks/:kn_id/action-logs
+	listActionExecutionsURI = "/in/v1/knowledge-networks/%s/action-logs"
 	// https://{host}:{port}/api/ontology-query/in/v1/knowledge-networks/:kn_id/subgraph
 	queryInstanceSubgraphURI = "/in/v1/knowledge-networks/%s/subgraph"
 )
@@ -236,6 +242,83 @@ func (o *ontologyQueryClient) ExecuteActions(ctx context.Context, req *interface
 	o.logger.WithContext(ctx).Debugf("[OntologyQuery#ExecuteActions] Response: %s", string(respJSON))
 
 	return resp, nil
+}
+
+// GetActionExecution 查询单次行动执行的状态与结果
+func (o *ontologyQueryClient) GetActionExecution(ctx context.Context, req *interfaces.GetActionExecutionRequest) (map[string]any, error) {
+	uri := fmt.Sprintf(getActionExecutionURI, req.KnID, req.ExecutionID)
+	reqURL := fmt.Sprintf("%s%s", o.baseURL, uri)
+
+	o.logger.WithContext(ctx).Debugf("[OntologyQuery#GetActionExecution] URL: %s", reqURL)
+
+	header := common.GetHeaderFromCtx(ctx)
+	header[rest.ContentTypeKey] = rest.ContentTypeJSON
+
+	_, respBody, err := o.httpClient.Get(ctx, reqURL, nil, header)
+	if err != nil {
+		o.logger.WithContext(ctx).Errorf("[OntologyQuery#GetActionExecution] Request failed, err: %v", err)
+		return nil, infraErr.DefaultHTTPError(ctx, http.StatusBadGateway, fmt.Sprintf("行动执行查询接口调用失败: %v", err))
+	}
+
+	result := map[string]any{}
+	resultByt := utils.ObjectToByte(respBody)
+	if err = json.Unmarshal(resultByt, &result); err != nil {
+		o.logger.WithContext(ctx).Errorf("[OntologyQuery#GetActionExecution] Unmarshal failed, body: %s, err: %v", string(resultByt), err)
+		return nil, infraErr.DefaultHTTPError(ctx, http.StatusInternalServerError, fmt.Sprintf("解析行动执行查询响应失败: %v", err))
+	}
+
+	return result, nil
+}
+
+// ListActionExecutions 列出行动执行历史（可过滤，分页）
+func (o *ontologyQueryClient) ListActionExecutions(ctx context.Context, req *interfaces.ListActionExecutionsRequest) (map[string]any, error) {
+	uri := fmt.Sprintf(listActionExecutionsURI, req.KnID)
+	reqURL := fmt.Sprintf("%s%s", o.baseURL, uri)
+
+	query := url.Values{}
+	if req.ActionTypeID != "" {
+		query.Set("action_type_id", req.ActionTypeID)
+	}
+	if req.Status != "" {
+		query.Set("status", req.Status)
+	}
+	if req.TriggerType != "" {
+		query.Set("trigger_type", req.TriggerType)
+	}
+	if req.StartTimeFrom > 0 {
+		query.Set("start_time_from", strconv.FormatInt(req.StartTimeFrom, 10))
+	}
+	if req.StartTimeTo > 0 {
+		query.Set("start_time_to", strconv.FormatInt(req.StartTimeTo, 10))
+	}
+	if req.Offset > 0 {
+		query.Set("offset", strconv.Itoa(req.Offset))
+	}
+	if req.Limit > 0 {
+		query.Set("limit", strconv.Itoa(req.Limit))
+	}
+	// 默认返回总数，便于分页
+	query.Set("need_total", "true")
+
+	o.logger.WithContext(ctx).Debugf("[OntologyQuery#ListActionExecutions] URL: %s?%s", reqURL, query.Encode())
+
+	header := common.GetHeaderFromCtx(ctx)
+	header[rest.ContentTypeKey] = rest.ContentTypeJSON
+
+	_, respBody, err := o.httpClient.Get(ctx, reqURL, query, header)
+	if err != nil {
+		o.logger.WithContext(ctx).Errorf("[OntologyQuery#ListActionExecutions] Request failed, err: %v", err)
+		return nil, infraErr.DefaultHTTPError(ctx, http.StatusBadGateway, fmt.Sprintf("行动执行历史查询接口调用失败: %v", err))
+	}
+
+	result := map[string]any{}
+	resultByt := utils.ObjectToByte(respBody)
+	if err = json.Unmarshal(resultByt, &result); err != nil {
+		o.logger.WithContext(ctx).Errorf("[OntologyQuery#ListActionExecutions] Unmarshal failed, body: %s, err: %v", string(resultByt), err)
+		return nil, infraErr.DefaultHTTPError(ctx, http.StatusInternalServerError, fmt.Sprintf("解析行动执行历史查询响应失败: %v", err))
+	}
+
+	return result, nil
 }
 
 // QueryInstanceSubgraph 查询对象子图

--- a/adp/context-loader/agent-retrieval/server/drivenadapters/ontology_query.go
+++ b/adp/context-loader/agent-retrieval/server/drivenadapters/ontology_query.go
@@ -13,6 +13,7 @@ import (
 	"net/http"
 	"net/url"
 	"strconv"
+	"strings"
 	"sync"
 
 	"github.com/openbkn-ai/adp/context-loader/agent-retrieval/server/infra/common"
@@ -214,10 +215,14 @@ func (o *ontologyQueryClient) ExecuteActions(ctx context.Context, req *interface
 		body["dynamic_params"] = req.DynamicParams
 	}
 
-	// 记录请求日志
-	bodyJSON, _ := json.Marshal(body)
-	o.logger.WithContext(ctx).Debugf("[OntologyQuery#ExecuteActions] URL: %s", url)
-	o.logger.WithContext(ctx).Debugf("[OntologyQuery#ExecuteActions] Request Body: %s", string(bodyJSON))
+	// 记录请求日志（脱敏：dynamic_params 是任意工具输入，可能含令牌/密码等敏感值，
+	// 仅记录参数名与实例数，不输出参数值。见 PR #379 review P1）
+	dynamicParamKeys := make([]string, 0, len(req.DynamicParams))
+	for k := range req.DynamicParams {
+		dynamicParamKeys = append(dynamicParamKeys, k)
+	}
+	o.logger.WithContext(ctx).Debugf("[OntologyQuery#ExecuteActions] URL: %s, instances: %d, dynamic_param_keys: %v",
+		url, len(req.InstanceIdentities), dynamicParamKeys)
 
 	header := common.GetHeaderFromCtx(ctx)
 	header[rest.ContentTypeKey] = rest.ContentTypeJSON
@@ -296,6 +301,15 @@ func (o *ontologyQueryClient) ListActionExecutions(ctx context.Context, req *int
 	}
 	if req.Limit > 0 {
 		query.Set("limit", strconv.Itoa(req.Limit))
+	}
+	// 游标分页：下游 action-logs 以逗号分隔字符串接收 search_after（GET query），
+	// 故将上一页返回的 search_after 数组按元素拼成逗号分隔转发。
+	if len(req.SearchAfter) > 0 {
+		parts := make([]string, 0, len(req.SearchAfter))
+		for _, v := range req.SearchAfter {
+			parts = append(parts, fmt.Sprintf("%v", v))
+		}
+		query.Set("search_after", strings.Join(parts, ","))
 	}
 	// 默认返回总数，便于分页
 	query.Set("need_total", "true")

--- a/adp/context-loader/agent-retrieval/server/driveradapters/knactionrecall/index.go
+++ b/adp/context-loader/agent-retrieval/server/driveradapters/knactionrecall/index.go
@@ -25,6 +25,7 @@ import (
 // KnActionRecallHandler 业务知识网络行动召回处理器
 type KnActionRecallHandler interface {
 	GetActionInfo(c *gin.Context)
+	ExecuteAction(c *gin.Context)
 }
 
 type knActionRecallHandler struct {
@@ -98,5 +99,57 @@ func (h *knActionRecallHandler) GetActionInfo(c *gin.Context) {
 	}
 
 	// 返回成功响应
+	rest.ReplyOK(c, http.StatusOK, resp)
+}
+
+// ExecuteAction 执行行动（异步）
+func (h *knActionRecallHandler) ExecuteAction(c *gin.Context) {
+	var err error
+	req := &interfaces.KnActionExecuteRequest{}
+
+	// 绑定 Header
+	if err = c.ShouldBindHeader(req); err != nil {
+		err = errors.DefaultHTTPError(c.Request.Context(), http.StatusBadRequest, err.Error())
+		rest.ReplyError(c, err)
+		return
+	}
+
+	// 绑定 Query Parameters
+	if err = c.ShouldBindQuery(req); err != nil {
+		err = errors.DefaultHTTPError(c.Request.Context(), http.StatusBadRequest, err.Error())
+		rest.ReplyError(c, err)
+		return
+	}
+
+	// 绑定 JSON Body
+	if err = c.ShouldBindJSON(req); err != nil {
+		err = errors.DefaultHTTPError(c.Request.Context(), http.StatusBadRequest, err.Error())
+		rest.ReplyError(c, err)
+		return
+	}
+
+	// 设置默认值
+	if err = defaults.Set(req); err != nil {
+		err = errors.DefaultHTTPError(c.Request.Context(), http.StatusBadRequest, err.Error())
+		rest.ReplyError(c, err)
+		return
+	}
+
+	// 参数校验
+	err = validator.New().Struct(req)
+	if err != nil {
+		rest.ReplyError(c, err)
+		return
+	}
+
+	// 调用业务逻辑
+	resp, err := h.KnActionRecallService.ExecuteAction(c.Request.Context(), req)
+	if err != nil {
+		h.Logger.Errorf("[KnActionRecallHandler#ExecuteAction] ExecuteAction failed, err: %v", err)
+		rest.ReplyError(c, err)
+		return
+	}
+
+	// 返回成功响应（异步，返回 execution_id）
 	rest.ReplyOK(c, http.StatusOK, resp)
 }

--- a/adp/context-loader/agent-retrieval/server/driveradapters/knactionrecall/index.go
+++ b/adp/context-loader/agent-retrieval/server/driveradapters/knactionrecall/index.go
@@ -26,6 +26,8 @@ import (
 type KnActionRecallHandler interface {
 	GetActionInfo(c *gin.Context)
 	ExecuteAction(c *gin.Context)
+	GetActionExecution(c *gin.Context)
+	ListActionExecutions(c *gin.Context)
 }
 
 type knActionRecallHandler struct {
@@ -151,5 +153,85 @@ func (h *knActionRecallHandler) ExecuteAction(c *gin.Context) {
 	}
 
 	// 返回成功响应（异步，返回 execution_id）
+	rest.ReplyOK(c, http.StatusOK, resp)
+}
+
+// GetActionExecution 查询单次行动执行的状态与结果
+func (h *knActionRecallHandler) GetActionExecution(c *gin.Context) {
+	var err error
+	req := &interfaces.KnGetActionExecutionRequest{}
+
+	if err = c.ShouldBindHeader(req); err != nil {
+		err = errors.DefaultHTTPError(c.Request.Context(), http.StatusBadRequest, err.Error())
+		rest.ReplyError(c, err)
+		return
+	}
+	if err = c.ShouldBindQuery(req); err != nil {
+		err = errors.DefaultHTTPError(c.Request.Context(), http.StatusBadRequest, err.Error())
+		rest.ReplyError(c, err)
+		return
+	}
+	if err = c.ShouldBindJSON(req); err != nil {
+		err = errors.DefaultHTTPError(c.Request.Context(), http.StatusBadRequest, err.Error())
+		rest.ReplyError(c, err)
+		return
+	}
+	if err = defaults.Set(req); err != nil {
+		err = errors.DefaultHTTPError(c.Request.Context(), http.StatusBadRequest, err.Error())
+		rest.ReplyError(c, err)
+		return
+	}
+	if err = validator.New().Struct(req); err != nil {
+		rest.ReplyError(c, err)
+		return
+	}
+
+	resp, err := h.KnActionRecallService.GetActionExecution(c.Request.Context(), req)
+	if err != nil {
+		h.Logger.Errorf("[KnActionRecallHandler#GetActionExecution] GetActionExecution failed, err: %v", err)
+		rest.ReplyError(c, err)
+		return
+	}
+
+	rest.ReplyOK(c, http.StatusOK, resp)
+}
+
+// ListActionExecutions 列出行动执行历史（可过滤，分页）
+func (h *knActionRecallHandler) ListActionExecutions(c *gin.Context) {
+	var err error
+	req := &interfaces.KnListActionExecutionsRequest{}
+
+	if err = c.ShouldBindHeader(req); err != nil {
+		err = errors.DefaultHTTPError(c.Request.Context(), http.StatusBadRequest, err.Error())
+		rest.ReplyError(c, err)
+		return
+	}
+	if err = c.ShouldBindQuery(req); err != nil {
+		err = errors.DefaultHTTPError(c.Request.Context(), http.StatusBadRequest, err.Error())
+		rest.ReplyError(c, err)
+		return
+	}
+	if err = c.ShouldBindJSON(req); err != nil {
+		err = errors.DefaultHTTPError(c.Request.Context(), http.StatusBadRequest, err.Error())
+		rest.ReplyError(c, err)
+		return
+	}
+	if err = defaults.Set(req); err != nil {
+		err = errors.DefaultHTTPError(c.Request.Context(), http.StatusBadRequest, err.Error())
+		rest.ReplyError(c, err)
+		return
+	}
+	if err = validator.New().Struct(req); err != nil {
+		rest.ReplyError(c, err)
+		return
+	}
+
+	resp, err := h.KnActionRecallService.ListActionExecutions(c.Request.Context(), req)
+	if err != nil {
+		h.Logger.Errorf("[KnActionRecallHandler#ListActionExecutions] ListActionExecutions failed, err: %v", err)
+		rest.ReplyError(c, err)
+		return
+	}
+
 	rest.ReplyOK(c, http.StatusOK, resp)
 }

--- a/adp/context-loader/agent-retrieval/server/driveradapters/mcp/app.go
+++ b/adp/context-loader/agent-retrieval/server/driveradapters/mcp/app.go
@@ -35,6 +35,8 @@ const (
 	toolKeyGetLogicPropertiesValues = "get_logic_properties_values"
 	toolKeyGetActionInfo            = "get_action_info"
 	toolKeyExecuteAction           = "execute_action"
+	toolKeyGetActionExecution      = "get_action_execution"
+	toolKeyListActionExecutions    = "list_action_executions"
 	toolKeyFindSkills               = "find_skills"
 	toolKeyListKnowledgeNetworks    = "list_knowledge_networks"
 	toolKeyGetKnDetail              = "get_kn_detail"
@@ -136,6 +138,20 @@ func NewMCPHandler() http.Handler {
 	mcpServer.AddTool(
 		newToolWithSchemas(executeActionName, executeActionDesc, eaInput, eaOutput),
 		handleExecuteAction(getActionInfoService),
+	)
+
+	getActionExecutionName, getActionExecutionDesc := localeBundle.ToolMeta(toolKeyGetActionExecution)
+	gaeInput, gaeOutput := localeBundle.ToolSchemas(toolKeyGetActionExecution)
+	mcpServer.AddTool(
+		newToolWithSchemas(getActionExecutionName, getActionExecutionDesc, gaeInput, gaeOutput),
+		handleGetActionExecution(getActionInfoService),
+	)
+
+	listActionExecutionsName, listActionExecutionsDesc := localeBundle.ToolMeta(toolKeyListActionExecutions)
+	laeInput, laeOutput := localeBundle.ToolSchemas(toolKeyListActionExecutions)
+	mcpServer.AddTool(
+		newToolWithSchemas(listActionExecutionsName, listActionExecutionsDesc, laeInput, laeOutput),
+		handleListActionExecutions(getActionInfoService),
 	)
 
 	findSkillsService := logicsFs.NewFindSkillsService()

--- a/adp/context-loader/agent-retrieval/server/driveradapters/mcp/app.go
+++ b/adp/context-loader/agent-retrieval/server/driveradapters/mcp/app.go
@@ -34,6 +34,7 @@ const (
 	toolKeyQueryInstanceSubgraph    = "query_instance_subgraph"
 	toolKeyGetLogicPropertiesValues = "get_logic_properties_values"
 	toolKeyGetActionInfo            = "get_action_info"
+	toolKeyExecuteAction           = "execute_action"
 	toolKeyFindSkills               = "find_skills"
 	toolKeyListKnowledgeNetworks    = "list_knowledge_networks"
 	toolKeyGetKnDetail              = "get_kn_detail"
@@ -128,6 +129,13 @@ func NewMCPHandler() http.Handler {
 	mcpServer.AddTool(
 		newToolWithSchemas(getActionInfoName, getActionInfoDesc, gaiInput, gaiOutput),
 		handleGetActionInfo(getActionInfoService),
+	)
+
+	executeActionName, executeActionDesc := localeBundle.ToolMeta(toolKeyExecuteAction)
+	eaInput, eaOutput := localeBundle.ToolSchemas(toolKeyExecuteAction)
+	mcpServer.AddTool(
+		newToolWithSchemas(executeActionName, executeActionDesc, eaInput, eaOutput),
+		handleExecuteAction(getActionInfoService),
 	)
 
 	findSkillsService := logicsFs.NewFindSkillsService()

--- a/adp/context-loader/agent-retrieval/server/driveradapters/mcp/schemas/execute_action.json
+++ b/adp/context-loader/agent-retrieval/server/driveradapters/mcp/schemas/execute_action.json
@@ -1,0 +1,54 @@
+{
+  "input_schema": {
+    "type": "object",
+    "properties": {
+      "kn_id": {
+        "type": "string",
+        "description": "知识网络 ID。也可改用 X-Kn-ID 请求头传入。"
+      },
+      "at_id": {
+        "type": "string",
+        "description": "行动类型 ID，由 search_schema 或 get_kn_detail 返回。"
+      },
+      "_instance_identities": {
+        "type": "array",
+        "description": "目标实例列表；为空时由行动驱动按行动条件扫描全部匹配实例。每个元素需从 query_object_instance 或 query_instance_subgraph 的 _instance_identity 字段提取，不可臆造。",
+        "items": {
+          "type": "object",
+          "description": "实例标识对象，包含动态的属性键值对",
+          "additionalProperties": true
+        }
+      },
+      "dynamic_params": {
+        "type": "object",
+        "description": "行动的动态参数值（对应行动类型中 value_from=input 的参数）。请先调用 get_action_info 获取该行动的 dynamic_params schema 与参数名，再在此按名逐个填入真实值。注意：每个参数是独立的键，不要把多个参数名拼成一个键。",
+        "additionalProperties": true
+      }
+    },
+    "required": [
+      "kn_id",
+      "at_id"
+    ]
+  },
+  "output_schema": {
+    "type": "object",
+    "properties": {
+      "execution_id": {
+        "type": "string",
+        "description": "本次执行的 ID，可用于查询执行状态与结果"
+      },
+      "status": {
+        "type": "string",
+        "description": "执行状态，提交后通常为 pending"
+      },
+      "message": {
+        "type": "string",
+        "description": "提交结果说明"
+      },
+      "created_at": {
+        "type": "integer",
+        "description": "提交时间（Unix 毫秒）"
+      }
+    }
+  }
+}

--- a/adp/context-loader/agent-retrieval/server/driveradapters/mcp/schemas/get_action_execution.json
+++ b/adp/context-loader/agent-retrieval/server/driveradapters/mcp/schemas/get_action_execution.json
@@ -1,0 +1,54 @@
+{
+  "input_schema": {
+    "type": "object",
+    "properties": {
+      "kn_id": {
+        "type": "string",
+        "description": "知识网络 ID。也可改用 X-Kn-ID 请求头传入。"
+      },
+      "execution_id": {
+        "type": "string",
+        "description": "行动执行 ID，由 execute_action 返回。"
+      }
+    },
+    "required": [
+      "kn_id",
+      "execution_id"
+    ]
+  },
+  "output_schema": {
+    "type": "object",
+    "description": "单次行动执行的详情，含整体状态与逐对象结果。",
+    "properties": {
+      "id": {
+        "type": "string",
+        "description": "执行 ID"
+      },
+      "status": {
+        "type": "string",
+        "description": "整体状态：pending/running/completed/failed/cancelled"
+      },
+      "total_count": {
+        "type": "integer",
+        "description": "本次执行涉及的对象总数"
+      },
+      "success_count": {
+        "type": "integer",
+        "description": "成功对象数"
+      },
+      "failed_count": {
+        "type": "integer",
+        "description": "失败对象数"
+      },
+      "results": {
+        "type": "array",
+        "description": "逐对象执行结果（含 status、parameters、result/error 等）",
+        "items": {
+          "type": "object",
+          "additionalProperties": true
+        }
+      }
+    },
+    "additionalProperties": true
+  }
+}

--- a/adp/context-loader/agent-retrieval/server/driveradapters/mcp/schemas/get_action_execution.json
+++ b/adp/context-loader/agent-retrieval/server/driveradapters/mcp/schemas/get_action_execution.json
@@ -2,6 +2,15 @@
   "input_schema": {
     "type": "object",
     "properties": {
+      "response_format": {
+        "type": "string",
+        "enum": [
+          "json",
+          "toon"
+        ],
+        "default": "toon",
+        "description": "响应格式：json 或 toon，默认 toon（更省 token）。"
+      },
       "kn_id": {
         "type": "string",
         "description": "知识网络 ID。也可改用 X-Kn-ID 请求头传入。"

--- a/adp/context-loader/agent-retrieval/server/driveradapters/mcp/schemas/list_action_executions.json
+++ b/adp/context-loader/agent-retrieval/server/driveradapters/mcp/schemas/list_action_executions.json
@@ -1,0 +1,66 @@
+{
+  "input_schema": {
+    "type": "object",
+    "properties": {
+      "kn_id": {
+        "type": "string",
+        "description": "知识网络 ID。也可改用 X-Kn-ID 请求头传入。"
+      },
+      "action_type_id": {
+        "type": "string",
+        "description": "按行动类型 ID 过滤（可选）。"
+      },
+      "status": {
+        "type": "string",
+        "description": "按执行状态过滤（可选）：pending/running/completed/failed/cancelled。"
+      },
+      "trigger_type": {
+        "type": "string",
+        "description": "按触发方式过滤（可选）：manual/scheduled。"
+      },
+      "start_time_from": {
+        "type": "integer",
+        "description": "起始时间下界（Unix 毫秒，可选）。"
+      },
+      "start_time_to": {
+        "type": "integer",
+        "description": "起始时间上界（Unix 毫秒，可选）。"
+      },
+      "offset": {
+        "type": "integer",
+        "description": "分页偏移（可选）。"
+      },
+      "limit": {
+        "type": "integer",
+        "description": "分页条数（可选），默认 20，最大 1000。"
+      }
+    },
+    "required": [
+      "kn_id"
+    ]
+  },
+  "output_schema": {
+    "type": "object",
+    "description": "行动执行历史列表（分页）。",
+    "properties": {
+      "total_count": {
+        "type": "integer",
+        "description": "匹配的执行总数"
+      },
+      "entries": {
+        "type": "array",
+        "description": "执行记录列表（每条含 id、action_type_id、status、计数、时间与 action_type_snapshot 等）",
+        "items": {
+          "type": "object",
+          "additionalProperties": true
+        }
+      },
+      "search_after": {
+        "type": "array",
+        "description": "分页游标；将本值作为下一页请求的 search_after 传入以继续翻页",
+        "items": {}
+      }
+    },
+    "additionalProperties": true
+  }
+}

--- a/adp/context-loader/agent-retrieval/server/driveradapters/mcp/schemas/list_action_executions.json
+++ b/adp/context-loader/agent-retrieval/server/driveradapters/mcp/schemas/list_action_executions.json
@@ -58,7 +58,7 @@
       },
       "entries": {
         "type": "array",
-        "description": "执行记录列表（每条含 id、action_type_id、status、计数、时间与 action_type_snapshot 等）",
+        "description": "执行记录列表（每条含 id、action_type_id、status、计数、时间等概览字段；action_type_snapshot 等重货已剔除以省 token）",
         "items": {
           "type": "object",
           "additionalProperties": true

--- a/adp/context-loader/agent-retrieval/server/driveradapters/mcp/schemas/list_action_executions.json
+++ b/adp/context-loader/agent-retrieval/server/driveradapters/mcp/schemas/list_action_executions.json
@@ -42,6 +42,11 @@
       "limit": {
         "type": "integer",
         "description": "分页条数（可选），默认 20，最大 1000。"
+      },
+      "search_after": {
+        "type": "array",
+        "description": "游标分页（可选）：将上一页响应返回的 search_after 原样传入以获取下一页，比 offset 更适合深翻页。",
+        "items": {}
       }
     },
     "required": [

--- a/adp/context-loader/agent-retrieval/server/driveradapters/mcp/schemas/list_action_executions.json
+++ b/adp/context-loader/agent-retrieval/server/driveradapters/mcp/schemas/list_action_executions.json
@@ -2,6 +2,15 @@
   "input_schema": {
     "type": "object",
     "properties": {
+      "response_format": {
+        "type": "string",
+        "enum": [
+          "json",
+          "toon"
+        ],
+        "default": "toon",
+        "description": "响应格式：json 或 toon，默认 toon（更省 token）。"
+      },
       "kn_id": {
         "type": "string",
         "description": "知识网络 ID。也可改用 X-Kn-ID 请求头传入。"

--- a/adp/context-loader/agent-retrieval/server/driveradapters/mcp/schemas/locales/en-US/schema_descriptions.json
+++ b/adp/context-loader/agent-retrieval/server/driveradapters/mcp/schemas/locales/en-US/schema_descriptions.json
@@ -189,7 +189,7 @@
     "input_schema.properties.limit.description": "Pagination size (optional), default 20, max 1000.",
     "output_schema.description": "Paginated action execution history.",
     "output_schema.properties.total_count.description": "Total number of matching executions.",
-    "output_schema.properties.entries.description": "List of execution records (each with id, action_type_id, status, counts, timestamps and action_type_snapshot).",
+    "output_schema.properties.entries.description": "List of execution records (each with id, action_type_id, status, counts, timestamps; action_type_snapshot and other heavy fields are stripped to save tokens).",
     "output_schema.properties.search_after.description": "Pagination cursor; pass this value as search_after in the next request to continue paging.",
     "input_schema.properties.response_format.description": "Response format: json or toon, default toon (fewer tokens)."
   }

--- a/adp/context-loader/agent-retrieval/server/driveradapters/mcp/schemas/locales/en-US/schema_descriptions.json
+++ b/adp/context-loader/agent-retrieval/server/driveradapters/mcp/schemas/locales/en-US/schema_descriptions.json
@@ -155,5 +155,15 @@
     "output_schema.properties.relation_types.description": "Matched relation types.",
     "output_schema.properties.action_types.description": "Matched action types.",
     "output_schema.properties.metric_types.description": "Matched metric types."
+  },
+  "execute_action": {
+    "input_schema.properties.kn_id.description": "Knowledge network id. Can also be supplied by the X-Kn-ID request header.",
+    "input_schema.properties.at_id.description": "Action type id returned by search_schema or get_kn_detail.",
+    "input_schema.properties._instance_identities.description": "Target instances; when empty the action driver scans all instances matching the action condition. Each element must be taken from the _instance_identity field of query_object_instance or query_instance_subgraph, never fabricated.",
+    "input_schema.properties.dynamic_params.description": "Dynamic parameter values for the action (parameters whose value_from=input). First call get_action_info to obtain this action's dynamic_params schema and parameter names, then fill in the real values by name. Each parameter is a separate key; do not concatenate multiple parameter names into one key.",
+    "output_schema.properties.execution_id.description": "Execution id, usable to query execution status and results.",
+    "output_schema.properties.status.description": "Execution status; usually pending right after submission.",
+    "output_schema.properties.message.description": "Submission result message.",
+    "output_schema.properties.created_at.description": "Submission time (Unix milliseconds)."
   }
 }

--- a/adp/context-loader/agent-retrieval/server/driveradapters/mcp/schemas/locales/en-US/schema_descriptions.json
+++ b/adp/context-loader/agent-retrieval/server/driveradapters/mcp/schemas/locales/en-US/schema_descriptions.json
@@ -175,7 +175,8 @@
     "output_schema.properties.total_count.description": "Total number of objects involved in this execution.",
     "output_schema.properties.success_count.description": "Number of succeeded objects.",
     "output_schema.properties.failed_count.description": "Number of failed objects.",
-    "output_schema.properties.results.description": "Per-object execution results (each with status, parameters, result/error, etc.)."
+    "output_schema.properties.results.description": "Per-object execution results (each with status, parameters, result/error, etc.).",
+    "input_schema.properties.response_format.description": "Response format: json or toon, default toon (fewer tokens)."
   },
   "list_action_executions": {
     "input_schema.properties.kn_id.description": "Knowledge network id. Can also be supplied by the X-Kn-ID request header.",
@@ -189,6 +190,7 @@
     "output_schema.description": "Paginated action execution history.",
     "output_schema.properties.total_count.description": "Total number of matching executions.",
     "output_schema.properties.entries.description": "List of execution records (each with id, action_type_id, status, counts, timestamps and action_type_snapshot).",
-    "output_schema.properties.search_after.description": "Pagination cursor; pass this value as search_after in the next request to continue paging."
+    "output_schema.properties.search_after.description": "Pagination cursor; pass this value as search_after in the next request to continue paging.",
+    "input_schema.properties.response_format.description": "Response format: json or toon, default toon (fewer tokens)."
   }
 }

--- a/adp/context-loader/agent-retrieval/server/driveradapters/mcp/schemas/locales/en-US/schema_descriptions.json
+++ b/adp/context-loader/agent-retrieval/server/driveradapters/mcp/schemas/locales/en-US/schema_descriptions.json
@@ -165,5 +165,30 @@
     "output_schema.properties.status.description": "Execution status; usually pending right after submission.",
     "output_schema.properties.message.description": "Submission result message.",
     "output_schema.properties.created_at.description": "Submission time (Unix milliseconds)."
+  },
+  "get_action_execution": {
+    "input_schema.properties.kn_id.description": "Knowledge network id. Can also be supplied by the X-Kn-ID request header.",
+    "input_schema.properties.execution_id.description": "Action execution id, returned by execute_action.",
+    "output_schema.description": "Details of a single action execution, including overall status and per-object results.",
+    "output_schema.properties.id.description": "Execution id.",
+    "output_schema.properties.status.description": "Overall status: pending/running/completed/failed/cancelled.",
+    "output_schema.properties.total_count.description": "Total number of objects involved in this execution.",
+    "output_schema.properties.success_count.description": "Number of succeeded objects.",
+    "output_schema.properties.failed_count.description": "Number of failed objects.",
+    "output_schema.properties.results.description": "Per-object execution results (each with status, parameters, result/error, etc.)."
+  },
+  "list_action_executions": {
+    "input_schema.properties.kn_id.description": "Knowledge network id. Can also be supplied by the X-Kn-ID request header.",
+    "input_schema.properties.action_type_id.description": "Filter by action type id (optional).",
+    "input_schema.properties.status.description": "Filter by execution status (optional): pending/running/completed/failed/cancelled.",
+    "input_schema.properties.trigger_type.description": "Filter by trigger type (optional): manual/scheduled.",
+    "input_schema.properties.start_time_from.description": "Lower bound of start time (Unix milliseconds, optional).",
+    "input_schema.properties.start_time_to.description": "Upper bound of start time (Unix milliseconds, optional).",
+    "input_schema.properties.offset.description": "Pagination offset (optional).",
+    "input_schema.properties.limit.description": "Pagination size (optional), default 20, max 1000.",
+    "output_schema.description": "Paginated action execution history.",
+    "output_schema.properties.total_count.description": "Total number of matching executions.",
+    "output_schema.properties.entries.description": "List of execution records (each with id, action_type_id, status, counts, timestamps and action_type_snapshot).",
+    "output_schema.properties.search_after.description": "Pagination cursor; pass this value as search_after in the next request to continue paging."
   }
 }

--- a/adp/context-loader/agent-retrieval/server/driveradapters/mcp/schemas/locales/en-US/tools_meta.json
+++ b/adp/context-loader/agent-retrieval/server/driveradapters/mcp/schemas/locales/en-US/tools_meta.json
@@ -23,6 +23,14 @@
     "name": "execute_action",
     "description": "Execute an action. First call get_action_info to obtain the action's dynamic_params schema, then fill in the real dynamic parameter values to trigger execution (asynchronous, returns an execution_id)."
   },
+  "get_action_execution": {
+    "name": "get_action_execution",
+    "description": "Query the status and results of a single action execution. Use the execution_id returned by execute_action to fetch the overall status and per-object results."
+  },
+  "list_action_executions": {
+    "name": "list_action_executions",
+    "description": "List action execution history, filterable by action type, status, and trigger type, with pagination."
+  },
   "find_skills": {
     "name": "find_skills",
     "description": "Find available skills that match a knowledge network, object type, instance context, or user intent."

--- a/adp/context-loader/agent-retrieval/server/driveradapters/mcp/schemas/locales/en-US/tools_meta.json
+++ b/adp/context-loader/agent-retrieval/server/driveradapters/mcp/schemas/locales/en-US/tools_meta.json
@@ -19,6 +19,10 @@
     "name": "get_action_info",
     "description": "Return executable action definitions for object instances, including dynamic tool schemas that an agent can call."
   },
+  "execute_action": {
+    "name": "execute_action",
+    "description": "Execute an action. First call get_action_info to obtain the action's dynamic_params schema, then fill in the real dynamic parameter values to trigger execution (asynchronous, returns an execution_id)."
+  },
   "find_skills": {
     "name": "find_skills",
     "description": "Find available skills that match a knowledge network, object type, instance context, or user intent."

--- a/adp/context-loader/agent-retrieval/server/driveradapters/mcp/schemas/tools_meta.json
+++ b/adp/context-loader/agent-retrieval/server/driveradapters/mcp/schemas/tools_meta.json
@@ -23,6 +23,14 @@
     "name": "execute_action",
     "description": "执行行动。先用 get_action_info 获取行动的 dynamic_params schema，再填入真实动态参数值触发执行（异步，返回 execution_id）。"
   },
+  "get_action_execution": {
+    "name": "get_action_execution",
+    "description": "查询单次行动执行的状态与结果。用 execute_action 返回的 execution_id 查询整体 status 与逐对象 results。"
+  },
+  "list_action_executions": {
+    "name": "list_action_executions",
+    "description": "列出行动执行历史，可按行动类型、状态、触发方式过滤并分页。"
+  },
   "find_skills": {
     "name": "find_skills",
     "description": "技能召回。根据知识网络、对象类型、实例上下文等召回匹配的可用技能列表。"

--- a/adp/context-loader/agent-retrieval/server/driveradapters/mcp/schemas/tools_meta.json
+++ b/adp/context-loader/agent-retrieval/server/driveradapters/mcp/schemas/tools_meta.json
@@ -19,6 +19,10 @@
     "name": "get_action_info",
     "description": "行动信息召回。针对对象实例返回可执行行动的工具定义。"
   },
+  "execute_action": {
+    "name": "execute_action",
+    "description": "执行行动。先用 get_action_info 获取行动的 dynamic_params schema，再填入真实动态参数值触发执行（异步，返回 execution_id）。"
+  },
   "find_skills": {
     "name": "find_skills",
     "description": "技能召回。根据知识网络、对象类型、实例上下文等召回匹配的可用技能列表。"

--- a/adp/context-loader/agent-retrieval/server/driveradapters/mcp/tools.go
+++ b/adp/context-loader/agent-retrieval/server/driveradapters/mcp/tools.go
@@ -270,6 +270,78 @@ func handleExecuteAction(service interfaces.IKnActionRecallService) func(ctx con
 	}
 }
 
+// handleGetActionExecution handles get_action_execution tool calls.
+// 与 execute_action 配对：用 execute_action 返回的 execution_id 查询该次执行的 status 与 results。
+func handleGetActionExecution(service interfaces.IKnActionRecallService) func(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	return func(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		authCtx, ok := common.GetAccountAuthContextFromCtx(ctx)
+		if !ok {
+			return mcp.NewToolResultError("authentication required"), nil
+		}
+
+		getReq := &interfaces.KnGetActionExecutionRequest{}
+		if err := bindArguments(req, getReq); err != nil {
+			return mcp.NewToolResultError(err.Error()), nil
+		}
+		if getReq.KnID == "" {
+			getReq.KnID = getKnIDFromHeader(req)
+		}
+		getReq.AccountID = authCtx.AccountID
+		getReq.AccountType = string(authCtx.AccountType)
+
+		if err := validator.New().Struct(getReq); err != nil {
+			return mcp.NewToolResultError(err.Error()), nil
+		}
+
+		resp, err := service.GetActionExecution(ctx, getReq)
+		if err != nil {
+			return mcp.NewToolResultError(err.Error()), nil
+		}
+		// 执行状态/结果需机器可消费，始终返回 JSON。
+		result, err := BuildMCPToolResult(resp, rest.FormatJSON)
+		if err != nil {
+			return mcp.NewToolResultError(err.Error()), nil
+		}
+		return result, nil
+	}
+}
+
+// handleListActionExecutions handles list_action_executions tool calls.
+// 列出行动执行历史（可按行动类型/状态/触发方式过滤，分页）。
+func handleListActionExecutions(service interfaces.IKnActionRecallService) func(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	return func(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		authCtx, ok := common.GetAccountAuthContextFromCtx(ctx)
+		if !ok {
+			return mcp.NewToolResultError("authentication required"), nil
+		}
+
+		listReq := &interfaces.KnListActionExecutionsRequest{}
+		if err := bindArguments(req, listReq); err != nil {
+			return mcp.NewToolResultError(err.Error()), nil
+		}
+		if listReq.KnID == "" {
+			listReq.KnID = getKnIDFromHeader(req)
+		}
+		listReq.AccountID = authCtx.AccountID
+		listReq.AccountType = string(authCtx.AccountType)
+
+		if err := validator.New().Struct(listReq); err != nil {
+			return mcp.NewToolResultError(err.Error()), nil
+		}
+
+		resp, err := service.ListActionExecutions(ctx, listReq)
+		if err != nil {
+			return mcp.NewToolResultError(err.Error()), nil
+		}
+		// 执行历史需机器可消费，始终返回 JSON。
+		result, err := BuildMCPToolResult(resp, rest.FormatJSON)
+		if err != nil {
+			return mcp.NewToolResultError(err.Error()), nil
+		}
+		return result, nil
+	}
+}
+
 // handleListKnowledgeNetworks handles list_knowledge_networks tool calls.
 // 用于让外部 Agent 发现可用的 kn_id（其余查询工具的前置）。
 func handleListKnowledgeNetworks(bkn interfaces.BknBackendAccess) func(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {

--- a/adp/context-loader/agent-retrieval/server/driveradapters/mcp/tools.go
+++ b/adp/context-loader/agent-retrieval/server/driveradapters/mcp/tools.go
@@ -293,12 +293,16 @@ func handleGetActionExecution(service interfaces.IKnActionRecallService) func(ct
 			return mcp.NewToolResultError(err.Error()), nil
 		}
 
+		format, err := GetResponseFormatFromRequest(req)
+		if err != nil {
+			return mcp.NewToolResultError(err.Error()), nil
+		}
+
 		resp, err := service.GetActionExecution(ctx, getReq)
 		if err != nil {
 			return mcp.NewToolResultError(err.Error()), nil
 		}
-		// 执行状态/结果需机器可消费，始终返回 JSON。
-		result, err := BuildMCPToolResult(resp, rest.FormatJSON)
+		result, err := BuildMCPToolResult(resp, format)
 		if err != nil {
 			return mcp.NewToolResultError(err.Error()), nil
 		}
@@ -329,12 +333,16 @@ func handleListActionExecutions(service interfaces.IKnActionRecallService) func(
 			return mcp.NewToolResultError(err.Error()), nil
 		}
 
+		format, err := GetResponseFormatFromRequest(req)
+		if err != nil {
+			return mcp.NewToolResultError(err.Error()), nil
+		}
+
 		resp, err := service.ListActionExecutions(ctx, listReq)
 		if err != nil {
 			return mcp.NewToolResultError(err.Error()), nil
 		}
-		// 执行历史需机器可消费，始终返回 JSON。
-		result, err := BuildMCPToolResult(resp, rest.FormatJSON)
+		result, err := BuildMCPToolResult(resp, format)
 		if err != nil {
 			return mcp.NewToolResultError(err.Error()), nil
 		}

--- a/adp/context-loader/agent-retrieval/server/driveradapters/mcp/tools.go
+++ b/adp/context-loader/agent-retrieval/server/driveradapters/mcp/tools.go
@@ -233,6 +233,43 @@ func handleGetActionInfo(service interfaces.IKnActionRecallService) func(ctx con
 	}
 }
 
+// handleExecuteAction handles execute_action tool calls.
+// 与 get_action_info 配对：Agent 先用 get_action_info 拿到 dynamic_params schema，
+// 再用本工具填入真实动态参数值触发执行（异步，返回 execution_id）。
+func handleExecuteAction(service interfaces.IKnActionRecallService) func(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	return func(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		authCtx, ok := common.GetAccountAuthContextFromCtx(ctx)
+		if !ok {
+			return mcp.NewToolResultError("authentication required"), nil
+		}
+
+		execReq := &interfaces.KnActionExecuteRequest{}
+		if err := bindArguments(req, execReq); err != nil {
+			return mcp.NewToolResultError(err.Error()), nil
+		}
+		if execReq.KnID == "" {
+			execReq.KnID = getKnIDFromHeader(req)
+		}
+		execReq.AccountID = authCtx.AccountID
+		execReq.AccountType = string(authCtx.AccountType)
+
+		if err := validator.New().Struct(execReq); err != nil {
+			return mcp.NewToolResultError(err.Error()), nil
+		}
+
+		resp, err := service.ExecuteAction(ctx, execReq)
+		if err != nil {
+			return mcp.NewToolResultError(err.Error()), nil
+		}
+		// execute_action 始终返回 JSON：execution_id 等需机器可消费。
+		result, err := BuildMCPToolResult(resp, rest.FormatJSON)
+		if err != nil {
+			return mcp.NewToolResultError(err.Error()), nil
+		}
+		return result, nil
+	}
+}
+
 // handleListKnowledgeNetworks handles list_knowledge_networks tool calls.
 // 用于让外部 Agent 发现可用的 kn_id（其余查询工具的前置）。
 func handleListKnowledgeNetworks(bkn interfaces.BknBackendAccess) func(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {

--- a/adp/context-loader/agent-retrieval/server/driveradapters/mcp/tools_field_reduction_test.go
+++ b/adp/context-loader/agent-retrieval/server/driveradapters/mcp/tools_field_reduction_test.go
@@ -49,6 +49,10 @@ func (s *stubOntologyQuery) QueryActions(_ context.Context, _ *interfaces.QueryA
 	return nil, nil
 }
 
+func (s *stubOntologyQuery) ExecuteActions(_ context.Context, _ *interfaces.ExecuteActionsRequest) (*interfaces.ExecuteActionsResponse, error) {
+	return nil, nil
+}
+
 func (s *stubOntologyQuery) QueryInstanceSubgraph(_ context.Context, _ *interfaces.QueryInstanceSubgraphReq) (*interfaces.QueryInstanceSubgraphResp, error) {
 	return nil, nil
 }

--- a/adp/context-loader/agent-retrieval/server/driveradapters/mcp/tools_field_reduction_test.go
+++ b/adp/context-loader/agent-retrieval/server/driveradapters/mcp/tools_field_reduction_test.go
@@ -53,6 +53,14 @@ func (s *stubOntologyQuery) ExecuteActions(_ context.Context, _ *interfaces.Exec
 	return nil, nil
 }
 
+func (s *stubOntologyQuery) GetActionExecution(_ context.Context, _ *interfaces.GetActionExecutionRequest) (map[string]any, error) {
+	return nil, nil
+}
+
+func (s *stubOntologyQuery) ListActionExecutions(_ context.Context, _ *interfaces.ListActionExecutionsRequest) (map[string]any, error) {
+	return nil, nil
+}
+
 func (s *stubOntologyQuery) QueryInstanceSubgraph(_ context.Context, _ *interfaces.QueryInstanceSubgraphReq) (*interfaces.QueryInstanceSubgraphResp, error) {
 	return nil, nil
 }

--- a/adp/context-loader/agent-retrieval/server/driveradapters/mcp/tools_get_action_info_test.go
+++ b/adp/context-loader/agent-retrieval/server/driveradapters/mcp/tools_get_action_info_test.go
@@ -26,6 +26,16 @@ func (s *stubActionRecallService) ExecuteAction(_ context.Context, _ *interfaces
 	}, nil
 }
 
+func (s *stubActionRecallService) GetActionExecution(_ context.Context, _ *interfaces.KnGetActionExecutionRequest) (map[string]any, error) {
+	s.called = true
+	return map[string]any{"id": "exec-001", "status": "completed"}, nil
+}
+
+func (s *stubActionRecallService) ListActionExecutions(_ context.Context, _ *interfaces.KnListActionExecutionsRequest) (map[string]any, error) {
+	s.called = true
+	return map[string]any{"total": 0, "executions": []any{}}, nil
+}
+
 func (s *stubActionRecallService) GetActionInfo(_ context.Context, _ *interfaces.KnActionRecallRequest) (*interfaces.KnActionRecallResponse, error) {
 	s.called = true
 	return &interfaces.KnActionRecallResponse{

--- a/adp/context-loader/agent-retrieval/server/driveradapters/mcp/tools_get_action_info_test.go
+++ b/adp/context-loader/agent-retrieval/server/driveradapters/mcp/tools_get_action_info_test.go
@@ -16,6 +16,16 @@ type stubActionRecallService struct {
 	called bool
 }
 
+func (s *stubActionRecallService) ExecuteAction(_ context.Context, _ *interfaces.KnActionExecuteRequest) (*interfaces.KnActionExecuteResponse, error) {
+	s.called = true
+	return &interfaces.KnActionExecuteResponse{
+		ExecutionID: "exec-001",
+		Status:      "pending",
+		Message:     "Action execution started",
+		CreatedAt:   1,
+	}, nil
+}
+
 func (s *stubActionRecallService) GetActionInfo(_ context.Context, _ *interfaces.KnActionRecallRequest) (*interfaces.KnActionRecallResponse, error) {
 	s.called = true
 	return &interfaces.KnActionRecallResponse{

--- a/adp/context-loader/agent-retrieval/server/driveradapters/middleware.go
+++ b/adp/context-loader/agent-retrieval/server/driveradapters/middleware.go
@@ -141,7 +141,7 @@ func middlewareRequestLog(logger interfaces.Logger) gin.HandlerFunc {
 			URI:          c.Request.RequestURI,
 			Method:       c.Request.Method,
 			RemoteAddr:   c.Request.RemoteAddr,
-			RequestBody:  byteToInterface(req),
+			RequestBody:  redactSensitiveFields(byteToInterface(req)),
 			ResponseCode: c.Writer.Status(),
 			Latency:      float64(time.Since(now).Nanoseconds()) / 1e6, //nolint:mnd
 		})
@@ -188,6 +188,39 @@ func byteToInterface(byt []byte) interface{} {
 
 	m["string"] = string(byt)
 	return m
+}
+
+// sensitiveBodyKeys 是请求体中需要在日志里脱敏的字段名。dynamic_params 是任意
+// 工具输入，可能含令牌/密码等敏感值（见 PR #379 review P1）；对其值整体脱敏，
+// 仅保留字段名以维持可观测性。
+var sensitiveBodyKeys = map[string]struct{}{
+	"dynamic_params": {},
+}
+
+// redactSensitiveFields 递归遍历已解析的请求体（map / slice），将 sensitiveBodyKeys
+// 命中的字段值替换为脱敏标记，其余结构原样保留。覆盖 REST 顶层 dynamic_params 与
+// MCP JSON-RPC 嵌套的 params.arguments.dynamic_params 两种形态。
+func redactSensitiveFields(v interface{}) interface{} {
+	switch val := v.(type) {
+	case map[string]interface{}:
+		out := make(map[string]interface{}, len(val))
+		for k, vv := range val {
+			if _, ok := sensitiveBodyKeys[k]; ok {
+				out[k] = "[REDACTED]"
+				continue
+			}
+			out[k] = redactSensitiveFields(vv)
+		}
+		return out
+	case []interface{}:
+		out := make([]interface{}, len(val))
+		for i, vv := range val {
+			out[i] = redactSensitiveFields(vv)
+		}
+		return out
+	default:
+		return v
+	}
 }
 
 // middlewareResponseFormat 解析 Query 参数 response_format（默认 json），非法值返回 400，并写入 context

--- a/adp/context-loader/agent-retrieval/server/driveradapters/middleware_test.go
+++ b/adp/context-loader/agent-retrieval/server/driveradapters/middleware_test.go
@@ -191,6 +191,10 @@ func (stubActionRecallHandler) GetActionInfo(c *gin.Context) {
 	c.Status(http.StatusOK)
 }
 
+func (stubActionRecallHandler) ExecuteAction(c *gin.Context) {
+	c.Status(http.StatusOK)
+}
+
 type stubQueryObjectInstanceHandler struct{}
 
 func (stubQueryObjectInstanceHandler) QueryObjectInstance(c *gin.Context) {

--- a/adp/context-loader/agent-retrieval/server/driveradapters/middleware_test.go
+++ b/adp/context-loader/agent-retrieval/server/driveradapters/middleware_test.go
@@ -195,6 +195,14 @@ func (stubActionRecallHandler) ExecuteAction(c *gin.Context) {
 	c.Status(http.StatusOK)
 }
 
+func (stubActionRecallHandler) GetActionExecution(c *gin.Context) {
+	c.Status(http.StatusOK)
+}
+
+func (stubActionRecallHandler) ListActionExecutions(c *gin.Context) {
+	c.Status(http.StatusOK)
+}
+
 type stubQueryObjectInstanceHandler struct{}
 
 func (stubQueryObjectInstanceHandler) QueryObjectInstance(c *gin.Context) {

--- a/adp/context-loader/agent-retrieval/server/driveradapters/middleware_test.go
+++ b/adp/context-loader/agent-retrieval/server/driveradapters/middleware_test.go
@@ -268,3 +268,44 @@ func TestRestPublicHandler_AppliesResponseFormatMiddleware(t *testing.T) {
 		convey.So(w.Body.String(), convey.ShouldEqual, "ok")
 	})
 }
+
+func TestRedactSensitiveFields(t *testing.T) {
+	convey.Convey("TestRedactSensitiveFields", t, func() {
+		convey.Convey("REST 顶层 dynamic_params 脱敏，其余保留", func() {
+			in := map[string]interface{}{
+				"kn_id":                "kn-1",
+				"at_id":                "at-1",
+				"_instance_identities": []interface{}{map[string]interface{}{"key_id": "14"}},
+				"dynamic_params":       map[string]interface{}{"message": "SECRET", "name": "张三"},
+			}
+			out := redactSensitiveFields(in).(map[string]interface{})
+			convey.So(out["kn_id"], convey.ShouldEqual, "kn-1")
+			convey.So(out["dynamic_params"], convey.ShouldEqual, "[REDACTED]")
+			// 非敏感字段结构原样
+			convey.So(out["_instance_identities"], convey.ShouldNotBeNil)
+		})
+		convey.Convey("MCP JSON-RPC 嵌套 params.arguments.dynamic_params 脱敏", func() {
+			in := map[string]interface{}{
+				"jsonrpc": "2.0",
+				"method":  "tools/call",
+				"params": map[string]interface{}{
+					"name": "execute_action",
+					"arguments": map[string]interface{}{
+						"kn_id":          "kn-1",
+						"dynamic_params": map[string]interface{}{"token": "SECRET"},
+					},
+				},
+			}
+			out := redactSensitiveFields(in).(map[string]interface{})
+			args := out["params"].(map[string]interface{})["arguments"].(map[string]interface{})
+			convey.So(args["kn_id"], convey.ShouldEqual, "kn-1")
+			convey.So(args["dynamic_params"], convey.ShouldEqual, "[REDACTED]")
+		})
+		convey.Convey("无敏感字段时原样返回", func() {
+			in := map[string]interface{}{"kn_id": "kn-1", "limit": float64(10)}
+			out := redactSensitiveFields(in).(map[string]interface{})
+			convey.So(out["kn_id"], convey.ShouldEqual, "kn-1")
+			convey.So(out["limit"], convey.ShouldEqual, float64(10))
+		})
+	})
+}

--- a/adp/context-loader/agent-retrieval/server/driveradapters/rest_private_handler.go
+++ b/adp/context-loader/agent-retrieval/server/driveradapters/rest_private_handler.go
@@ -65,6 +65,7 @@ func (r *restPrivateHandler) RegisterRouter(engine *gin.RouterGroup) {
 	engine.POST("/kn/semantic-search", r.KnRetrievalHandler.SemanticSearch)
 	engine.POST("/kn/logic-property-resolver", r.KnLogicPropertyResolverHandler.ResolveLogicProperties)
 	engine.POST("/kn/get_action_info", r.KnActionRecallHandler.GetActionInfo)
+	engine.POST("/kn/execute_action", r.KnActionRecallHandler.ExecuteAction)
 	engine.POST("/kn/query_object_instance", r.KnQueryObjectInstanceHandler.QueryObjectInstance)
 	engine.POST("/kn/query_instance_subgraph", r.KnQuerySubgraphHandler.QueryInstanceSubgraph)
 	engine.POST("/kn/search_schema", r.KnSearchHandler.SearchSchema)

--- a/adp/context-loader/agent-retrieval/server/driveradapters/rest_private_handler.go
+++ b/adp/context-loader/agent-retrieval/server/driveradapters/rest_private_handler.go
@@ -66,6 +66,8 @@ func (r *restPrivateHandler) RegisterRouter(engine *gin.RouterGroup) {
 	engine.POST("/kn/logic-property-resolver", r.KnLogicPropertyResolverHandler.ResolveLogicProperties)
 	engine.POST("/kn/get_action_info", r.KnActionRecallHandler.GetActionInfo)
 	engine.POST("/kn/execute_action", r.KnActionRecallHandler.ExecuteAction)
+	engine.POST("/kn/get_action_execution", r.KnActionRecallHandler.GetActionExecution)
+	engine.POST("/kn/list_action_executions", r.KnActionRecallHandler.ListActionExecutions)
 	engine.POST("/kn/query_object_instance", r.KnQueryObjectInstanceHandler.QueryObjectInstance)
 	engine.POST("/kn/query_instance_subgraph", r.KnQuerySubgraphHandler.QueryInstanceSubgraph)
 	engine.POST("/kn/search_schema", r.KnSearchHandler.SearchSchema)

--- a/adp/context-loader/agent-retrieval/server/driveradapters/rest_public_handler.go
+++ b/adp/context-loader/agent-retrieval/server/driveradapters/rest_public_handler.go
@@ -68,6 +68,8 @@ func (r *restPublicHandler) RegisterRouter(engine *gin.RouterGroup) {
 	engine.POST("/kn/logic-property-resolver", r.KnLogicPropertyResolverHandler.ResolveLogicProperties)
 	engine.POST("/kn/get_action_info", r.KnActionRecallHandler.GetActionInfo)
 	engine.POST("/kn/execute_action", r.KnActionRecallHandler.ExecuteAction)
+	engine.POST("/kn/get_action_execution", r.KnActionRecallHandler.GetActionExecution)
+	engine.POST("/kn/list_action_executions", r.KnActionRecallHandler.ListActionExecutions)
 	engine.POST("/kn/query_object_instance", r.KnQueryObjectInstanceHandler.QueryObjectInstance)
 	engine.POST("/kn/query_instance_subgraph", r.KnQuerySubgraphHandler.QueryInstanceSubgraph)
 	engine.POST("/kn/search_schema", r.KnSearchHandler.SearchSchema)

--- a/adp/context-loader/agent-retrieval/server/driveradapters/rest_public_handler.go
+++ b/adp/context-loader/agent-retrieval/server/driveradapters/rest_public_handler.go
@@ -67,6 +67,7 @@ func (r *restPublicHandler) RegisterRouter(engine *gin.RouterGroup) {
 	engine.POST("/kn/semantic-search", r.KnRetrievalHandler.SemanticSearch)
 	engine.POST("/kn/logic-property-resolver", r.KnLogicPropertyResolverHandler.ResolveLogicProperties)
 	engine.POST("/kn/get_action_info", r.KnActionRecallHandler.GetActionInfo)
+	engine.POST("/kn/execute_action", r.KnActionRecallHandler.ExecuteAction)
 	engine.POST("/kn/query_object_instance", r.KnQueryObjectInstanceHandler.QueryObjectInstance)
 	engine.POST("/kn/query_instance_subgraph", r.KnQuerySubgraphHandler.QueryInstanceSubgraph)
 	engine.POST("/kn/search_schema", r.KnSearchHandler.SearchSchema)

--- a/adp/context-loader/agent-retrieval/server/interfaces/driven_ontology_query.go
+++ b/adp/context-loader/agent-retrieval/server/interfaces/driven_ontology_query.go
@@ -99,6 +99,10 @@ type DrivenOntologyQuery interface {
 	QueryActions(ctx context.Context, req *QueryActionsRequest) (resp *QueryActionsResponse, err error)
 	// ExecuteActions executes an action type (async), returning an execution id
 	ExecuteActions(ctx context.Context, req *ExecuteActionsRequest) (resp *ExecuteActionsResponse, err error)
+	// GetActionExecution retrieves a single execution's status and results by execution id
+	GetActionExecution(ctx context.Context, req *GetActionExecutionRequest) (resp map[string]any, err error)
+	// ListActionExecutions lists action execution history with optional filters and pagination
+	ListActionExecutions(ctx context.Context, req *ListActionExecutionsRequest) (resp map[string]any, err error)
 	// QueryInstanceSubgraph queries object subgraph
 	QueryInstanceSubgraph(ctx context.Context, req *QueryInstanceSubgraphReq) (resp *QueryInstanceSubgraphResp, err error)
 }

--- a/adp/context-loader/agent-retrieval/server/interfaces/driven_ontology_query.go
+++ b/adp/context-loader/agent-retrieval/server/interfaces/driven_ontology_query.go
@@ -97,6 +97,8 @@ type DrivenOntologyQuery interface {
 	QueryLogicProperties(ctx context.Context, req *QueryLogicPropertiesReq) (resp *QueryLogicPropertiesResp, err error)
 	// QueryActions queries actions
 	QueryActions(ctx context.Context, req *QueryActionsRequest) (resp *QueryActionsResponse, err error)
+	// ExecuteActions executes an action type (async), returning an execution id
+	ExecuteActions(ctx context.Context, req *ExecuteActionsRequest) (resp *ExecuteActionsResponse, err error)
 	// QueryInstanceSubgraph queries object subgraph
 	QueryInstanceSubgraph(ctx context.Context, req *QueryInstanceSubgraphReq) (resp *QueryInstanceSubgraphResp, err error)
 }

--- a/adp/context-loader/agent-retrieval/server/interfaces/kn_action_recall.go
+++ b/adp/context-loader/agent-retrieval/server/interfaces/kn_action_recall.go
@@ -188,6 +188,7 @@ type KnListActionExecutionsRequest struct {
 	StartTimeTo   int64  `json:"start_time_to,omitempty"`   // 起始时间上界（Unix 毫秒，可选）
 	Offset        int    `json:"offset,omitempty"`          // 分页偏移（可选）
 	Limit         int    `json:"limit,omitempty"`           // 分页条数，默认 20，最大 1000（可选）
+	SearchAfter   []any  `json:"search_after,omitempty"`    // 游标分页：上一页响应的 search_after 原样回传（可选）
 
 	AccountID   string `json:"-" header:"x-account-id"`
 	AccountType string `json:"-" header:"x-account-type"`
@@ -209,6 +210,7 @@ type ListActionExecutionsRequest struct {
 	StartTimeTo   int64
 	Offset        int
 	Limit         int
+	SearchAfter   []any
 }
 
 // IKnActionRecallService Knowledge Network Action Recall Service Interface

--- a/adp/context-loader/agent-retrieval/server/interfaces/kn_action_recall.go
+++ b/adp/context-loader/agent-retrieval/server/interfaces/kn_action_recall.go
@@ -169,10 +169,56 @@ type ExecuteActionsResponse struct {
 	CreatedAt   int64  `json:"created_at"`
 }
 
+// KnGetActionExecutionRequest 查询单次行动执行的状态与结果
+type KnGetActionExecutionRequest struct {
+	KnID        string `json:"kn_id" validate:"required"`       // Knowledge Network ID
+	ExecutionID string `json:"execution_id" validate:"required"` // 由 execute_action 返回的执行 ID
+
+	AccountID   string `json:"-" header:"x-account-id"`
+	AccountType string `json:"-" header:"x-account-type"`
+}
+
+// KnListActionExecutionsRequest 列出行动执行历史（可按行动类型/状态/触发方式过滤，分页）
+type KnListActionExecutionsRequest struct {
+	KnID          string `json:"kn_id" validate:"required"` // Knowledge Network ID
+	ActionTypeID  string `json:"action_type_id,omitempty"`  // 按行动类型过滤（可选）
+	Status        string `json:"status,omitempty"`          // 按状态过滤：pending/running/completed/failed/cancelled（可选）
+	TriggerType   string `json:"trigger_type,omitempty"`    // 按触发方式过滤：manual/scheduled（可选）
+	StartTimeFrom int64  `json:"start_time_from,omitempty"` // 起始时间下界（Unix 毫秒，可选）
+	StartTimeTo   int64  `json:"start_time_to,omitempty"`   // 起始时间上界（Unix 毫秒，可选）
+	Offset        int    `json:"offset,omitempty"`          // 分页偏移（可选）
+	Limit         int    `json:"limit,omitempty"`           // 分页条数，默认 20，最大 1000（可选）
+
+	AccountID   string `json:"-" header:"x-account-id"`
+	AccountType string `json:"-" header:"x-account-type"`
+}
+
+// GetActionExecutionRequest 转发到 ontology-query 的单次执行查询请求
+type GetActionExecutionRequest struct {
+	KnID        string `json:"-"`
+	ExecutionID string `json:"-"`
+}
+
+// ListActionExecutionsRequest 转发到 ontology-query 的执行历史查询请求
+type ListActionExecutionsRequest struct {
+	KnID          string
+	ActionTypeID  string
+	Status        string
+	TriggerType   string
+	StartTimeFrom int64
+	StartTimeTo   int64
+	Offset        int
+	Limit         int
+}
+
 // IKnActionRecallService Knowledge Network Action Recall Service Interface
 type IKnActionRecallService interface {
 	// GetActionInfo gets action information (action recall)
 	GetActionInfo(ctx context.Context, req *KnActionRecallRequest) (*KnActionRecallResponse, error)
 	// ExecuteAction executes an action type (async), returning an execution id
 	ExecuteAction(ctx context.Context, req *KnActionExecuteRequest) (*KnActionExecuteResponse, error)
+	// GetActionExecution retrieves a single execution's status and results by execution id
+	GetActionExecution(ctx context.Context, req *KnGetActionExecutionRequest) (map[string]any, error)
+	// ListActionExecutions lists action execution history with optional filters and pagination
+	ListActionExecutions(ctx context.Context, req *KnListActionExecutionsRequest) (map[string]any, error)
 }

--- a/adp/context-loader/agent-retrieval/server/interfaces/kn_action_recall.go
+++ b/adp/context-loader/agent-retrieval/server/interfaces/kn_action_recall.go
@@ -130,8 +130,49 @@ type ActionParams struct {
 
 // ==================== Service Interfaces ====================
 
+// KnActionExecuteRequest Knowledge Network Action Execution Request
+type KnActionExecuteRequest struct {
+	// Query Parameters
+	KnID string `json:"kn_id" validate:"required"` // Knowledge Network ID
+	AtID string `json:"at_id" validate:"required"` // Action Type ID
+
+	// Request Body
+	InstanceIdentities []map[string]any `json:"_instance_identities" validate:"omitempty"` // Target instances; empty means scan-by-condition
+	DynamicParams      map[string]any   `json:"dynamic_params" validate:"omitempty"`       // Dynamic parameter values (value_from=input)
+
+	// Header Fields
+	AccountID   string `json:"-" header:"x-account-id"`
+	AccountType string `json:"-" header:"x-account-type"`
+}
+
+// KnActionExecuteResponse Knowledge Network Action Execution Response (async)
+type KnActionExecuteResponse struct {
+	ExecutionID string `json:"execution_id"`
+	Status      string `json:"status"`
+	Message     string `json:"message"`
+	CreatedAt   int64  `json:"created_at"`
+}
+
+// ExecuteActionsRequest Action Execution Request to ontology-query
+type ExecuteActionsRequest struct {
+	KnID               string           `json:"-"`
+	AtID               string           `json:"-"`
+	InstanceIdentities []map[string]any `json:"_instance_identities"`
+	DynamicParams      map[string]any   `json:"dynamic_params,omitempty"`
+}
+
+// ExecuteActionsResponse Action Execution Response from ontology-query
+type ExecuteActionsResponse struct {
+	ExecutionID string `json:"execution_id"`
+	Status      string `json:"status"`
+	Message     string `json:"message"`
+	CreatedAt   int64  `json:"created_at"`
+}
+
 // IKnActionRecallService Knowledge Network Action Recall Service Interface
 type IKnActionRecallService interface {
 	// GetActionInfo gets action information (action recall)
 	GetActionInfo(ctx context.Context, req *KnActionRecallRequest) (*KnActionRecallResponse, error)
+	// ExecuteAction executes an action type (async), returning an execution id
+	ExecuteAction(ctx context.Context, req *KnActionExecuteRequest) (*KnActionExecuteResponse, error)
 }

--- a/adp/context-loader/agent-retrieval/server/logics/knactionrecall/execute_action.go
+++ b/adp/context-loader/agent-retrieval/server/logics/knactionrecall/execute_action.go
@@ -121,6 +121,7 @@ func (s *knActionRecallServiceImpl) ListActionExecutions(ctx context.Context, re
 		StartTimeTo:   req.StartTimeTo,
 		Offset:        req.Offset,
 		Limit:         req.Limit,
+		SearchAfter:   req.SearchAfter,
 	})
 	if err != nil {
 		s.logger.WithContext(ctx).Errorf("[KnActionRecall#ListActionExecutions] ListActionExecutions failed, err: %v", err)

--- a/adp/context-loader/agent-retrieval/server/logics/knactionrecall/execute_action.go
+++ b/adp/context-loader/agent-retrieval/server/logics/knactionrecall/execute_action.go
@@ -43,6 +43,10 @@ func (s *knActionRecallServiceImpl) ExecuteAction(ctx context.Context, req *inte
 // GetActionExecution 查询单次行动执行的状态与结果。
 // 与 execute_action 配对：Agent 用 execute_action 提交后拿到 execution_id，
 // 再用本接口查询该次执行的 status 与逐对象 results。
+//
+// 返回结果会剔除 Agent 决策用不到的重货（action_type_snapshot、重复的
+// executor/action_source、分页元数据等），仅保留状态、计数与逐对象结果，
+// 以降低 token 占用。
 func (s *knActionRecallServiceImpl) GetActionExecution(ctx context.Context, req *interfaces.KnGetActionExecutionRequest) (map[string]any, error) {
 	resp, err := s.ontologyQuery.GetActionExecution(ctx, &interfaces.GetActionExecutionRequest{
 		KnID:        req.KnID,
@@ -52,7 +56,58 @@ func (s *knActionRecallServiceImpl) GetActionExecution(ctx context.Context, req 
 		s.logger.WithContext(ctx).Errorf("[KnActionRecall#GetActionExecution] GetActionExecution failed, err: %v", err)
 		return nil, err
 	}
-	return resp, nil
+	return slimActionExecution(resp), nil
+}
+
+// actionExecutionKeepKeys 是单次执行详情中对 Agent 有用、需保留的顶层字段。
+var actionExecutionKeepKeys = []string{
+	"id", "kn_id", "action_type_id", "action_type_name",
+	"status", "trigger_type", "total_count", "success_count", "failed_count",
+	"start_time", "end_time", "duration_ms", "dynamic_params", "results",
+}
+
+// slimActionExecution 从后端返回的执行详情中投影出精简结构：
+// 剔除 action_type_snapshot、executor(_id)、action_source、object_type_id、
+// results_limit/offset/total 等冗余，并压缩逐对象结果。
+func slimActionExecution(full map[string]any) map[string]any {
+	if full == nil {
+		return nil
+	}
+	slim := make(map[string]any, len(actionExecutionKeepKeys))
+	for _, k := range actionExecutionKeepKeys {
+		if v, ok := full[k]; ok {
+			slim[k] = v
+		}
+	}
+	if raw, ok := slim["results"].([]any); ok {
+		slim["results"] = slimActionResults(raw)
+	}
+	return slim
+}
+
+// actionResultKeepKeys 是逐对象结果中需保留的字段。
+var actionResultKeepKeys = []string{
+	"_instance_id", "_instance_identity", "_display",
+	"status", "parameters", "duration_ms", "error_message", "result",
+}
+
+func slimActionResults(results []any) []any {
+	slim := make([]any, 0, len(results))
+	for _, item := range results {
+		r, ok := item.(map[string]any)
+		if !ok {
+			slim = append(slim, item)
+			continue
+		}
+		out := make(map[string]any, len(actionResultKeepKeys))
+		for _, k := range actionResultKeepKeys {
+			if v, ok := r[k]; ok {
+				out[k] = v
+			}
+		}
+		slim = append(slim, out)
+	}
+	return slim
 }
 
 // ListActionExecutions 列出行动执行历史（可按行动类型/状态/触发方式过滤，分页）。
@@ -70,6 +125,18 @@ func (s *knActionRecallServiceImpl) ListActionExecutions(ctx context.Context, re
 	if err != nil {
 		s.logger.WithContext(ctx).Errorf("[KnActionRecall#ListActionExecutions] ListActionExecutions failed, err: %v", err)
 		return nil, err
+	}
+	// 列表每条同样剔除重货（action_type_snapshot 等），仅保留概览字段
+	if entries, ok := resp["entries"].([]any); ok {
+		slimmed := make([]any, 0, len(entries))
+		for _, e := range entries {
+			if m, ok := e.(map[string]any); ok {
+				slimmed = append(slimmed, slimActionExecution(m))
+			} else {
+				slimmed = append(slimmed, e)
+			}
+		}
+		resp["entries"] = slimmed
 	}
 	return resp, nil
 }

--- a/adp/context-loader/agent-retrieval/server/logics/knactionrecall/execute_action.go
+++ b/adp/context-loader/agent-retrieval/server/logics/knactionrecall/execute_action.go
@@ -39,3 +39,37 @@ func (s *knActionRecallServiceImpl) ExecuteAction(ctx context.Context, req *inte
 		CreatedAt:   resp.CreatedAt,
 	}, nil
 }
+
+// GetActionExecution 查询单次行动执行的状态与结果。
+// 与 execute_action 配对：Agent 用 execute_action 提交后拿到 execution_id，
+// 再用本接口查询该次执行的 status 与逐对象 results。
+func (s *knActionRecallServiceImpl) GetActionExecution(ctx context.Context, req *interfaces.KnGetActionExecutionRequest) (map[string]any, error) {
+	resp, err := s.ontologyQuery.GetActionExecution(ctx, &interfaces.GetActionExecutionRequest{
+		KnID:        req.KnID,
+		ExecutionID: req.ExecutionID,
+	})
+	if err != nil {
+		s.logger.WithContext(ctx).Errorf("[KnActionRecall#GetActionExecution] GetActionExecution failed, err: %v", err)
+		return nil, err
+	}
+	return resp, nil
+}
+
+// ListActionExecutions 列出行动执行历史（可按行动类型/状态/触发方式过滤，分页）。
+func (s *knActionRecallServiceImpl) ListActionExecutions(ctx context.Context, req *interfaces.KnListActionExecutionsRequest) (map[string]any, error) {
+	resp, err := s.ontologyQuery.ListActionExecutions(ctx, &interfaces.ListActionExecutionsRequest{
+		KnID:          req.KnID,
+		ActionTypeID:  req.ActionTypeID,
+		Status:        req.Status,
+		TriggerType:   req.TriggerType,
+		StartTimeFrom: req.StartTimeFrom,
+		StartTimeTo:   req.StartTimeTo,
+		Offset:        req.Offset,
+		Limit:         req.Limit,
+	})
+	if err != nil {
+		s.logger.WithContext(ctx).Errorf("[KnActionRecall#ListActionExecutions] ListActionExecutions failed, err: %v", err)
+		return nil, err
+	}
+	return resp, nil
+}

--- a/adp/context-loader/agent-retrieval/server/logics/knactionrecall/execute_action.go
+++ b/adp/context-loader/agent-retrieval/server/logics/knactionrecall/execute_action.go
@@ -1,0 +1,41 @@
+// Copyright openbkn.ai
+// Copyright The kweaver.ai Authors.
+//
+// Licensed under the Apache License, Version 2.0.
+// See the LICENSE file in the project root for details.
+
+package knactionrecall
+
+import (
+	"context"
+
+	"github.com/openbkn-ai/adp/context-loader/agent-retrieval/server/interfaces"
+)
+
+// ExecuteAction 执行行动（异步）。
+//
+// 与 GetActionInfo 配对：Agent 先用 get_action_info 拿到行动的可执行定义与
+// dynamic_params schema，再用本接口填入真实动态参数值触发执行，形成
+// 「发现 → 读定义 → 执行」的闭环。真正的执行与动态参数完整性校验在
+// ontology-query 的 execute 端点完成，本层仅做透传。
+func (s *knActionRecallServiceImpl) ExecuteAction(ctx context.Context, req *interfaces.KnActionExecuteRequest) (*interfaces.KnActionExecuteResponse, error) {
+	execReq := &interfaces.ExecuteActionsRequest{
+		KnID:               req.KnID,
+		AtID:               req.AtID,
+		InstanceIdentities: req.InstanceIdentities,
+		DynamicParams:      req.DynamicParams,
+	}
+
+	resp, err := s.ontologyQuery.ExecuteActions(ctx, execReq)
+	if err != nil {
+		s.logger.WithContext(ctx).Errorf("[KnActionRecall#ExecuteAction] ExecuteActions failed, err: %v", err)
+		return nil, err
+	}
+
+	return &interfaces.KnActionExecuteResponse{
+		ExecutionID: resp.ExecutionID,
+		Status:      resp.Status,
+		Message:     resp.Message,
+		CreatedAt:   resp.CreatedAt,
+	}, nil
+}

--- a/adp/context-loader/agent-retrieval/server/logics/knactionrecall/execute_action_test.go
+++ b/adp/context-loader/agent-retrieval/server/logics/knactionrecall/execute_action_test.go
@@ -161,6 +161,10 @@ func TestListActionExecutions_Success(t *testing.T) {
 				convey.So(r.KnID, convey.ShouldEqual, "kn-001")
 				convey.So(r.Status, convey.ShouldEqual, "completed")
 				convey.So(r.Limit, convey.ShouldEqual, 10)
+				// 游标透传：上一页 search_after 原样传到转发结构
+				convey.So(len(r.SearchAfter), convey.ShouldEqual, 2)
+				convey.So(r.SearchAfter[0], convey.ShouldEqual, int64(1784703617885))
+				convey.So(r.SearchAfter[1], convey.ShouldEqual, "d9g6l08acb8s73c6l470")
 				return map[string]any{
 					"total_count": 1,
 					"entries": []any{
@@ -175,6 +179,7 @@ func TestListActionExecutions_Success(t *testing.T) {
 
 		resp, err := service.ListActionExecutions(context.Background(), &interfaces.KnListActionExecutionsRequest{
 			KnID: "kn-001", Status: "completed", Limit: 10,
+			SearchAfter: []any{int64(1784703617885), "d9g6l08acb8s73c6l470"},
 		})
 		convey.So(err, convey.ShouldBeNil)
 		convey.So(resp["total_count"], convey.ShouldEqual, 1)

--- a/adp/context-loader/agent-retrieval/server/logics/knactionrecall/execute_action_test.go
+++ b/adp/context-loader/agent-retrieval/server/logics/knactionrecall/execute_action_test.go
@@ -101,3 +101,72 @@ func TestExecuteAction_Error(t *testing.T) {
 		convey.So(err, convey.ShouldNotBeNil)
 	})
 }
+
+// TestGetActionExecution_Success 透传单次执行查询结果
+func TestGetActionExecution_Success(t *testing.T) {
+	convey.Convey("TestGetActionExecution_Success", t, func() {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		mockLogger := mocks.NewMockLogger(ctrl)
+		mockOntologyQuery := mocks.NewMockDrivenOntologyQuery(ctrl)
+		mockOperatorIntegration := mocks.NewMockDrivenOperatorIntegration(ctrl)
+		mockLogger.EXPECT().WithContext(gomock.Any()).Return(mockLogger).AnyTimes()
+		mockLogger.EXPECT().Errorf(gomock.Any(), gomock.Any()).AnyTimes()
+
+		service := &knActionRecallServiceImpl{
+			logger:              mockLogger,
+			config:              &config.Config{},
+			ontologyQuery:       mockOntologyQuery,
+			operatorIntegration: mockOperatorIntegration,
+		}
+
+		mockOntologyQuery.EXPECT().GetActionExecution(gomock.Any(), gomock.Any()).
+			DoAndReturn(func(_ context.Context, r *interfaces.GetActionExecutionRequest) (map[string]any, error) {
+				convey.So(r.KnID, convey.ShouldEqual, "kn-001")
+				convey.So(r.ExecutionID, convey.ShouldEqual, "exec-001")
+				return map[string]any{"id": "exec-001", "status": "completed"}, nil
+			})
+
+		resp, err := service.GetActionExecution(context.Background(), &interfaces.KnGetActionExecutionRequest{
+			KnID: "kn-001", ExecutionID: "exec-001",
+		})
+		convey.So(err, convey.ShouldBeNil)
+		convey.So(resp["status"], convey.ShouldEqual, "completed")
+	})
+}
+
+// TestListActionExecutions_Success 透传执行历史查询,过滤参数正确传递
+func TestListActionExecutions_Success(t *testing.T) {
+	convey.Convey("TestListActionExecutions_Success", t, func() {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		mockLogger := mocks.NewMockLogger(ctrl)
+		mockOntologyQuery := mocks.NewMockDrivenOntologyQuery(ctrl)
+		mockOperatorIntegration := mocks.NewMockDrivenOperatorIntegration(ctrl)
+		mockLogger.EXPECT().WithContext(gomock.Any()).Return(mockLogger).AnyTimes()
+		mockLogger.EXPECT().Errorf(gomock.Any(), gomock.Any()).AnyTimes()
+
+		service := &knActionRecallServiceImpl{
+			logger:              mockLogger,
+			config:              &config.Config{},
+			ontologyQuery:       mockOntologyQuery,
+			operatorIntegration: mockOperatorIntegration,
+		}
+
+		mockOntologyQuery.EXPECT().ListActionExecutions(gomock.Any(), gomock.Any()).
+			DoAndReturn(func(_ context.Context, r *interfaces.ListActionExecutionsRequest) (map[string]any, error) {
+				convey.So(r.KnID, convey.ShouldEqual, "kn-001")
+				convey.So(r.Status, convey.ShouldEqual, "completed")
+				convey.So(r.Limit, convey.ShouldEqual, 10)
+				return map[string]any{"total": 1, "executions": []any{map[string]any{"id": "exec-001"}}}, nil
+			})
+
+		resp, err := service.ListActionExecutions(context.Background(), &interfaces.KnListActionExecutionsRequest{
+			KnID: "kn-001", Status: "completed", Limit: 10,
+		})
+		convey.So(err, convey.ShouldBeNil)
+		convey.So(resp["total"], convey.ShouldEqual, 1)
+	})
+}

--- a/adp/context-loader/agent-retrieval/server/logics/knactionrecall/execute_action_test.go
+++ b/adp/context-loader/agent-retrieval/server/logics/knactionrecall/execute_action_test.go
@@ -170,3 +170,60 @@ func TestListActionExecutions_Success(t *testing.T) {
 		convey.So(resp["total"], convey.ShouldEqual, 1)
 	})
 }
+
+// TestSlimActionExecution 精简投影剔除重货、保留核心字段
+func TestSlimActionExecution(t *testing.T) {
+	convey.Convey("TestSlimActionExecution", t, func() {
+		full := map[string]any{
+			"id":                  "exec-1",
+			"status":              "failed",
+			"total_count":         1,
+			"success_count":       0,
+			"failed_count":        1,
+			"dynamic_params":      map[string]any{"message": "hi"},
+			"action_type_snapshot": map[string]any{"parameters": []any{"a", "b"}}, // 重货，应剔除
+			"executor":            map[string]any{"id": "u1"},                     // 冗余，应剔除
+			"executor_id":         "u1",                                           // 冗余，应剔除
+			"action_source":       map[string]any{"tool_id": "t1"},               // 冗余，应剔除
+			"results_limit":       1000,                                           // 分页元数据，应剔除
+			"results": []any{
+				map[string]any{
+					"_instance_id":  "obj-14",
+					"_display":      "1990 World Cup",
+					"status":        "failed",
+					"parameters":    map[string]any{"message": "hi", "name": "张三"},
+					"error_message": "503",
+					"duration_ms":   1374,
+					"end_time":      123, // 逐对象里未列入保留集，应剔除
+				},
+			},
+		}
+
+		slim := slimActionExecution(full)
+
+		convey.Convey("保留核心字段", func() {
+			convey.So(slim["id"], convey.ShouldEqual, "exec-1")
+			convey.So(slim["status"], convey.ShouldEqual, "failed")
+			convey.So(slim["failed_count"], convey.ShouldEqual, 1)
+			convey.So(slim["dynamic_params"], convey.ShouldNotBeNil)
+		})
+		convey.Convey("剔除重货字段", func() {
+			convey.So(slim["action_type_snapshot"], convey.ShouldBeNil)
+			convey.So(slim["executor"], convey.ShouldBeNil)
+			convey.So(slim["executor_id"], convey.ShouldBeNil)
+			convey.So(slim["action_source"], convey.ShouldBeNil)
+			convey.So(slim["results_limit"], convey.ShouldBeNil)
+		})
+		convey.Convey("逐对象结果精简", func() {
+			results := slim["results"].([]any)
+			convey.So(len(results), convey.ShouldEqual, 1)
+			r := results[0].(map[string]any)
+			convey.So(r["_instance_id"], convey.ShouldEqual, "obj-14")
+			convey.So(r["status"], convey.ShouldEqual, "failed")
+			convey.So(r["error_message"], convey.ShouldEqual, "503")
+			convey.So(r["parameters"], convey.ShouldNotBeNil)
+			// 未列入保留集的字段被剔除
+			convey.So(r["end_time"], convey.ShouldBeNil)
+		})
+	})
+}

--- a/adp/context-loader/agent-retrieval/server/logics/knactionrecall/execute_action_test.go
+++ b/adp/context-loader/agent-retrieval/server/logics/knactionrecall/execute_action_test.go
@@ -155,19 +155,36 @@ func TestListActionExecutions_Success(t *testing.T) {
 			operatorIntegration: mockOperatorIntegration,
 		}
 
+		// ontology-query 真实响应键名为 total_count / entries / search_after
 		mockOntologyQuery.EXPECT().ListActionExecutions(gomock.Any(), gomock.Any()).
 			DoAndReturn(func(_ context.Context, r *interfaces.ListActionExecutionsRequest) (map[string]any, error) {
 				convey.So(r.KnID, convey.ShouldEqual, "kn-001")
 				convey.So(r.Status, convey.ShouldEqual, "completed")
 				convey.So(r.Limit, convey.ShouldEqual, 10)
-				return map[string]any{"total": 1, "executions": []any{map[string]any{"id": "exec-001"}}}, nil
+				return map[string]any{
+					"total_count": 1,
+					"entries": []any{
+						map[string]any{
+							"id":                   "exec-001",
+							"status":               "completed",
+							"action_type_snapshot": map[string]any{"parameters": []any{"x"}}, // 重货，list 精简后应剔除
+						},
+					},
+				}, nil
 			})
 
 		resp, err := service.ListActionExecutions(context.Background(), &interfaces.KnListActionExecutionsRequest{
 			KnID: "kn-001", Status: "completed", Limit: 10,
 		})
 		convey.So(err, convey.ShouldBeNil)
-		convey.So(resp["total"], convey.ShouldEqual, 1)
+		convey.So(resp["total_count"], convey.ShouldEqual, 1)
+		// 列表每条也应精简：保留 id/status，剔除 action_type_snapshot
+		entries := resp["entries"].([]any)
+		convey.So(len(entries), convey.ShouldEqual, 1)
+		e0 := entries[0].(map[string]any)
+		convey.So(e0["id"], convey.ShouldEqual, "exec-001")
+		convey.So(e0["status"], convey.ShouldEqual, "completed")
+		convey.So(e0["action_type_snapshot"], convey.ShouldBeNil)
 	})
 }
 

--- a/adp/context-loader/agent-retrieval/server/logics/knactionrecall/execute_action_test.go
+++ b/adp/context-loader/agent-retrieval/server/logics/knactionrecall/execute_action_test.go
@@ -1,0 +1,103 @@
+// Copyright openbkn.ai
+// Copyright The kweaver.ai Authors.
+//
+// Licensed under the Apache License, Version 2.0.
+// See the LICENSE file in the project root for details.
+
+package knactionrecall
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/smartystreets/goconvey/convey"
+	"go.uber.org/mock/gomock"
+
+	"github.com/openbkn-ai/adp/context-loader/agent-retrieval/server/infra/config"
+	"github.com/openbkn-ai/adp/context-loader/agent-retrieval/server/interfaces"
+	"github.com/openbkn-ai/adp/context-loader/agent-retrieval/server/mocks"
+)
+
+// TestExecuteAction_Success 透传 ontology-query 的执行响应
+func TestExecuteAction_Success(t *testing.T) {
+	convey.Convey("TestExecuteAction_Success", t, func() {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		mockLogger := mocks.NewMockLogger(ctrl)
+		mockOntologyQuery := mocks.NewMockDrivenOntologyQuery(ctrl)
+		mockOperatorIntegration := mocks.NewMockDrivenOperatorIntegration(ctrl)
+
+		mockLogger.EXPECT().WithContext(gomock.Any()).Return(mockLogger).AnyTimes()
+		mockLogger.EXPECT().Errorf(gomock.Any(), gomock.Any()).AnyTimes()
+
+		service := &knActionRecallServiceImpl{
+			logger:              mockLogger,
+			config:              &config.Config{},
+			ontologyQuery:       mockOntologyQuery,
+			operatorIntegration: mockOperatorIntegration,
+		}
+
+		ctx := context.Background()
+		req := &interfaces.KnActionExecuteRequest{
+			KnID:               "kn-001",
+			AtID:               "at-001",
+			InstanceIdentities: []map[string]any{{"key_id": "14"}},
+			DynamicParams:      map[string]any{"message": "hi", "name": "zhangsan"},
+		}
+
+		// 断言透传的 execReq 携带了动态参数与实例标识
+		mockOntologyQuery.EXPECT().ExecuteActions(gomock.Any(), gomock.Any()).
+			DoAndReturn(func(_ context.Context, r *interfaces.ExecuteActionsRequest) (*interfaces.ExecuteActionsResponse, error) {
+				convey.So(r.KnID, convey.ShouldEqual, "kn-001")
+				convey.So(r.AtID, convey.ShouldEqual, "at-001")
+				convey.So(r.DynamicParams["message"], convey.ShouldEqual, "hi")
+				convey.So(r.DynamicParams["name"], convey.ShouldEqual, "zhangsan")
+				convey.So(len(r.InstanceIdentities), convey.ShouldEqual, 1)
+				return &interfaces.ExecuteActionsResponse{
+					ExecutionID: "exec-xyz",
+					Status:      "pending",
+					Message:     "Action execution started",
+					CreatedAt:   123,
+				}, nil
+			})
+
+		resp, err := service.ExecuteAction(ctx, req)
+		convey.So(err, convey.ShouldBeNil)
+		convey.So(resp.ExecutionID, convey.ShouldEqual, "exec-xyz")
+		convey.So(resp.Status, convey.ShouldEqual, "pending")
+		convey.So(resp.CreatedAt, convey.ShouldEqual, 123)
+	})
+}
+
+// TestExecuteAction_Error ExecuteActions 失败时向上返回错误
+func TestExecuteAction_Error(t *testing.T) {
+	convey.Convey("TestExecuteAction_Error", t, func() {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		mockLogger := mocks.NewMockLogger(ctrl)
+		mockOntologyQuery := mocks.NewMockDrivenOntologyQuery(ctrl)
+		mockOperatorIntegration := mocks.NewMockDrivenOperatorIntegration(ctrl)
+
+		mockLogger.EXPECT().WithContext(gomock.Any()).Return(mockLogger).AnyTimes()
+		mockLogger.EXPECT().Errorf(gomock.Any(), gomock.Any()).AnyTimes()
+
+		service := &knActionRecallServiceImpl{
+			logger:              mockLogger,
+			config:              &config.Config{},
+			ontologyQuery:       mockOntologyQuery,
+			operatorIntegration: mockOperatorIntegration,
+		}
+
+		ctx := context.Background()
+		req := &interfaces.KnActionExecuteRequest{KnID: "kn-001", AtID: "at-001"}
+
+		mockOntologyQuery.EXPECT().ExecuteActions(gomock.Any(), gomock.Any()).
+			Return(nil, errors.New("execute actions failed"))
+
+		_, err := service.ExecuteAction(ctx, req)
+		convey.So(err, convey.ShouldNotBeNil)
+	})
+}

--- a/adp/context-loader/agent-retrieval/server/logics/knfindskills/mock_test.go
+++ b/adp/context-loader/agent-retrieval/server/logics/knfindskills/mock_test.go
@@ -121,6 +121,10 @@ func (m *testOntologyQuery) QueryActions(ctx context.Context, req *interfaces.Qu
 	return nil, nil
 }
 
+func (m *testOntologyQuery) ExecuteActions(ctx context.Context, req *interfaces.ExecuteActionsRequest) (*interfaces.ExecuteActionsResponse, error) {
+	return nil, nil
+}
+
 func makeSkillInstances(count int) []any {
 	data := make([]any, count)
 	for i := 0; i < count; i++ {

--- a/adp/context-loader/agent-retrieval/server/logics/knfindskills/mock_test.go
+++ b/adp/context-loader/agent-retrieval/server/logics/knfindskills/mock_test.go
@@ -125,6 +125,14 @@ func (m *testOntologyQuery) ExecuteActions(ctx context.Context, req *interfaces.
 	return nil, nil
 }
 
+func (m *testOntologyQuery) GetActionExecution(ctx context.Context, req *interfaces.GetActionExecutionRequest) (map[string]any, error) {
+	return nil, nil
+}
+
+func (m *testOntologyQuery) ListActionExecutions(ctx context.Context, req *interfaces.ListActionExecutionsRequest) (map[string]any, error) {
+	return nil, nil
+}
+
 func makeSkillInstances(count int) []any {
 	data := make([]any, count)
 	for i := 0; i < count; i++ {

--- a/adp/context-loader/agent-retrieval/server/logics/knsearch/mock_test.go
+++ b/adp/context-loader/agent-retrieval/server/logics/knsearch/mock_test.go
@@ -141,6 +141,10 @@ func (m *mockOntologyQuery) QueryActions(ctx context.Context, req *interfaces.Qu
 	return nil, nil
 }
 
+func (m *mockOntologyQuery) ExecuteActions(ctx context.Context, req *interfaces.ExecuteActionsRequest) (*interfaces.ExecuteActionsResponse, error) {
+	return nil, nil
+}
+
 func (m *mockOntologyQuery) QueryInstanceSubgraph(ctx context.Context, req *interfaces.QueryInstanceSubgraphReq) (resp *interfaces.QueryInstanceSubgraphResp, err error) {
 	return nil, nil
 }

--- a/adp/context-loader/agent-retrieval/server/logics/knsearch/mock_test.go
+++ b/adp/context-loader/agent-retrieval/server/logics/knsearch/mock_test.go
@@ -145,6 +145,14 @@ func (m *mockOntologyQuery) ExecuteActions(ctx context.Context, req *interfaces.
 	return nil, nil
 }
 
+func (m *mockOntologyQuery) GetActionExecution(ctx context.Context, req *interfaces.GetActionExecutionRequest) (map[string]any, error) {
+	return nil, nil
+}
+
+func (m *mockOntologyQuery) ListActionExecutions(ctx context.Context, req *interfaces.ListActionExecutionsRequest) (map[string]any, error) {
+	return nil, nil
+}
+
 func (m *mockOntologyQuery) QueryInstanceSubgraph(ctx context.Context, req *interfaces.QueryInstanceSubgraphReq) (resp *interfaces.QueryInstanceSubgraphResp, err error) {
 	return nil, nil
 }

--- a/adp/context-loader/agent-retrieval/server/mocks/driven_ontology_query.go
+++ b/adp/context-loader/agent-retrieval/server/mocks/driven_ontology_query.go
@@ -13,9 +13,8 @@ import (
 	context "context"
 	reflect "reflect"
 
-	gomock "go.uber.org/mock/gomock"
-
 	interfaces "github.com/openbkn-ai/adp/context-loader/agent-retrieval/server/interfaces"
+	gomock "go.uber.org/mock/gomock"
 )
 
 // MockDrivenOntologyQuery is a mock of DrivenOntologyQuery interface.
@@ -40,6 +39,21 @@ func NewMockDrivenOntologyQuery(ctrl *gomock.Controller) *MockDrivenOntologyQuer
 // EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockDrivenOntologyQuery) EXPECT() *MockDrivenOntologyQueryMockRecorder {
 	return m.recorder
+}
+
+// ExecuteActions mocks base method.
+func (m *MockDrivenOntologyQuery) ExecuteActions(ctx context.Context, req *interfaces.ExecuteActionsRequest) (*interfaces.ExecuteActionsResponse, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ExecuteActions", ctx, req)
+	ret0, _ := ret[0].(*interfaces.ExecuteActionsResponse)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ExecuteActions indicates an expected call of ExecuteActions.
+func (mr *MockDrivenOntologyQueryMockRecorder) ExecuteActions(ctx, req any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ExecuteActions", reflect.TypeOf((*MockDrivenOntologyQuery)(nil).ExecuteActions), ctx, req)
 }
 
 // QueryActions mocks base method.

--- a/adp/context-loader/agent-retrieval/server/mocks/driven_ontology_query.go
+++ b/adp/context-loader/agent-retrieval/server/mocks/driven_ontology_query.go
@@ -56,6 +56,36 @@ func (mr *MockDrivenOntologyQueryMockRecorder) ExecuteActions(ctx, req any) *gom
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ExecuteActions", reflect.TypeOf((*MockDrivenOntologyQuery)(nil).ExecuteActions), ctx, req)
 }
 
+// GetActionExecution mocks base method.
+func (m *MockDrivenOntologyQuery) GetActionExecution(ctx context.Context, req *interfaces.GetActionExecutionRequest) (map[string]any, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetActionExecution", ctx, req)
+	ret0, _ := ret[0].(map[string]any)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetActionExecution indicates an expected call of GetActionExecution.
+func (mr *MockDrivenOntologyQueryMockRecorder) GetActionExecution(ctx, req any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetActionExecution", reflect.TypeOf((*MockDrivenOntologyQuery)(nil).GetActionExecution), ctx, req)
+}
+
+// ListActionExecutions mocks base method.
+func (m *MockDrivenOntologyQuery) ListActionExecutions(ctx context.Context, req *interfaces.ListActionExecutionsRequest) (map[string]any, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ListActionExecutions", ctx, req)
+	ret0, _ := ret[0].(map[string]any)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ListActionExecutions indicates an expected call of ListActionExecutions.
+func (mr *MockDrivenOntologyQueryMockRecorder) ListActionExecutions(ctx, req any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListActionExecutions", reflect.TypeOf((*MockDrivenOntologyQuery)(nil).ListActionExecutions), ctx, req)
+}
+
 // QueryActions mocks base method.
 func (m *MockDrivenOntologyQuery) QueryActions(ctx context.Context, req *interfaces.QueryActionsRequest) (*interfaces.QueryActionsResponse, error) {
 	m.ctrl.T.Helper()


### PR DESCRIPTION
Closes #371

## 背景

Agent 通过 MCP 工具 `get_action_info` 召回带 `value_from=input` 动态参数的行动类时 100% 返回 400（死锁）：Agent 需先读到参数 schema 才知道要传哪些动态参数，但该接口自身却在召回阶段就强制校验动态参数完整性——鸡生蛋。根因是 #291（`80a8c723`）在修复 execute 缺参静默丢弃时，把动态参数完整性门控**误加到了召回路径**。

修复死锁后，进一步补齐了行动能力的完整链路：`search_schema`（发现）→ `get_action_info`（读定义）→ `execute_action`（执行）→ `get_action_execution` / `list_action_executions`（查结果）。

## 改动

**1. 解除死锁（ontology-query）**
- 移除 `action_type_service.go` 召回路径的动态参数完整性门控（#291 回归）；完整性校验只在执行阶段（`ExecuteAction`）进行，执行侧 `action_scheduler_service.go` 门控原样保留。
- 反转 #291 引入的 3 个「期望 400」召回用例为「成功召回、缺失 input 参数值为空」。
- 缺参报错措辞：新增 `logics.FormatMissingParamNames`，将 `%v` 渲染 `[]string` 得到的 `[message name]`（易被误读为单个参数）改为带引号逗号的 `"message", "name"`。

**2. 新增 execute_action（agent-retrieval）**
- 补齐行动执行出口：原设计依赖 `get_action_info` 返回的 `api_url` 由 agent runtime 直接 HTTP 调用，仅有 MCP 通道的外部 agent 断链。
- MCP 工具 + REST 路由（public/private）+ 服务/driven adapter 透传到 ontology-query 的 execute 端点。

**3. 新增执行查询工具（agent-retrieval）**
- `get_action_execution`：查单次执行的 status 与逐对象 results。
- `list_action_executions`：列执行历史，可按行动类型/状态/触发方式过滤并分页。
- 不含取消（写操作，暂不暴露给 Agent）。

**4. 响应精简 + toon**
- 执行查询响应剔除 Agent 决策用不到的重货（`action_type_snapshot`、重复的 executor/action_source、分页元数据），仅保留状态/计数/结果核心字段，显著降低 token 占用。
- `get_action_execution` / `list_action_executions` 支持 `response_format`（json/toon，默认 toon）；`execute_action` / `get_action_info` 仍固定 JSON（execution_id / 工具定义为结构化契约）。

**5. 三处对齐**
- 新工具在 **MCP tools/list + REST 路由 + toolbox(.adp)** 三处对齐（`.adp` 中 `metadata.version == source_id`，启动 upsert 同步）。

## 兼容性

改动全部属于「放宽」或「纯新增」两类，不改变任何现有接口的行为契约：
- **放宽**：召回门控删除（400 → 成功召回）、报错措辞（仅改 error_details 文案，不动 error_code / HTTP 码）。
- **纯新增**：4 个新工具 + 精简 + toon，均为全新端点，无既有消费方；`DrivenOntologyQuery` 接口扩展的 mock 已重新生成。
- `.adp` 老条目不动，仅 upsert 新增；老工具原样。

## 授权说明

`execute_action` 与既有 `run_sql` 完全同构：均经 public handler 的对外鉴权入口（Hydra 内省 / bak_ AppKey 校验），授权判定押给下游 ontology-query 的 execute `/in` 端点，无新增绕过路径。bak_ AppKey 走 execute_action 按现有设计放行（认证后与普通 token 同构，不额外拦截）。

## 验证

- 单测：agent-retrieval 21 包全绿；ontology-query logics 全绿。含 `FormatMissingParamNames`、slim 投影、execute/get/list 服务层单测。
- VM 端到端（10.211.55.4）：`get_action_info` 免传 dynamic_params 成功返回含参数 schema 的 `_dynamic_tools`；execute_action → get_action_execution 拿到 status/results 闭环；list_action_executions 返回历史；MCP 工具目录 16、toolbox 18（.adp upsert 生效）；响应精简（snapshot 剔除）+ toon 验证通过。

## 后续（另开 PR）

- `search_schema` 的行动类携带参数摘要（需改跨服务上游 bkn-backend）。
- `/kn` 风格的一次性工具清单接口（当前一次性列全工具用 `GET /mcp/info`）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
