### PR TITLE
chore(ci): 镜像 tag 使用上海时间

### DIFF
--- a/.github/workflows/release-deploy-redis.yml
+++ b/.github/workflows/release-deploy-redis.yml
@@ -44,8 +44,8 @@ jobs:
           REF_NAME="${{ github.ref_name }}"
           SHORT_SHA="$(git rev-parse --short=7 HEAD)"
           SANITIZED_BRANCH="$(echo "$REF_NAME" | tr '[:upper:]' '[:lower:]' | sed -E 's#[^0-9a-zA-Z.-]+#-#g; s#-+#-#g; s#^[.-]+##; s#[.-]+$##')"
-          # Commit time (UTC), not build time — monotonic and re-run reproducible.
-          COMMIT_DATE="$(TZ=UTC git show -s --format=%cd --date=format-local:%Y%m%d%H%M%S HEAD)"
+          # Commit time (Asia/Shanghai), not build time — monotonic and re-run reproducible.
+          COMMIT_DATE="$(TZ=Asia/Shanghai git show -s --format=%cd --date=format-local:%Y%m%d%H%M%S HEAD)"
           VERSION="$BASE_VERSION-$SANITIZED_BRANCH.$COMMIT_DATE.sha$SHORT_SHA"
 
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/reusable-test.yml
+++ b/.github/workflows/reusable-test.yml
@@ -62,12 +62,12 @@ jobs:
             VERSION="$BASE_VERSION"
           else
             SANITIZED_BRANCH="$(echo "$REF_NAME" | tr '[:upper:]' '[:lower:]' | sed -E 's#[^0-9a-zA-Z.-]+#-#g; s#-+#-#g; s#^[.-]+##; s#[.-]+$##')"
-            # Embed the commit time (UTC, fixed-width YYYYMMDDHHMMSS) so the
+            # Embed the commit time (Asia/Shanghai, fixed-width YYYYMMDDHHMMSS) so the
             # prerelease is monotonically sortable as a plain string — picking
             # "newest" needs no resolving the sha against a local git history
             # (the old scheme silently mis-ordered on shallow/foreign checkouts).
             # Commit time, not build time, so CI re-runs stay reproducible.
-            COMMIT_DATE="$(TZ=UTC git show -s --format=%cd --date=format-local:%Y%m%d%H%M%S HEAD)"
+            COMMIT_DATE="$(TZ=Asia/Shanghai git show -s --format=%cd --date=format-local:%Y%m%d%H%M%S HEAD)"
             VERSION="$BASE_VERSION-$SANITIZED_BRANCH.$COMMIT_DATE.sha$SHORT_SHA"
           fi
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -35,3 +35,4 @@ Read this first, then load the rules under [`rules/`](rules/). Before working in
 
 - Conventional Commits: `type(scope): subject` (`feat` / `fix` / `chore` / `refactor` / `docs` / `test`; scope = service name).
 - Branch from the Issue's "Create a branch"; one PR per Issue, kept small.
+- Branch names must use a valid type prefix and at most two path segments after it: `<type>/<description>`, `<type>/<issue-number>-<description>`, or `<type>/<module>/<description>`; segments start with lowercase letters or digits and may contain `-`, `.`, or `_`.


### PR DESCRIPTION
# Pull Request

## What Changed

Brief description of changes:

- [x] 将通用镜像版本解析中的提交时间时区从 UTC 改为 `Asia/Shanghai`。
- [x] 将 Redis 镜像版本解析中的提交时间时区从 UTC 改为 `Asia/Shanghai`。
- [x] 更新 `AGENTS.md` 中的分支命名规则说明。

---

## Why

- Related Issue: Closes #382
- Related Feature: N/A
- Background: 镜像 tag 的提交时间此前按 UTC 格式化，需要改为东八区显示。

---

## How

- Key implementation points: 两处 `git show --date=format-local` 均通过 `TZ=Asia/Shanghai` 显式指定时区，并同步更新注释。
- Breaking changes (API, config, database, etc.): 无；仅改变新生成非发布分支镜像 tag 中时间字段的显示时区。

---

## Testing

- [x] Unit tests passed locally: 不适用（仅修改 GitHub Actions YAML）。
- [x] Integration tests passed locally: 不适用（仅修改 GitHub Actions YAML）。
- [ ] Verified in test environment: 未执行；将由 PR CI 验证 workflow 配置。

Test notes:

- `git diff --check` 通过。
- 本地使用 `TZ=Asia/Shanghai git show -s --format=%cd --date=format-local:%Y%m%d%H%M%S HEAD` 验证可正确生成上海时区格式的时间。

---

## Risk & Rollback

- Potential risks: 新构建的分支镜像 tag 时间字段相对旧 UTC 值增加 8 小时；tag 的其余结构与提交时间语义不变。
- Rollback plan: 将两处 `TZ=Asia/Shanghai` 恢复为 `TZ=UTC` 即可。

---

## Additional Notes

- Screenshots, logs, documentation links, etc.: 无。