### PR TITLE
feat(bkn-trace): emit bkn-agent phase2 evidence events

### DIFF
--- a/infra/bkn-agent/TRACE.md
+++ b/infra/bkn-agent/TRACE.md
@@ -1,8 +1,8 @@
 # bkn-agent Trace Contract
 
-> 状态：阶段一模块接入合同
-> 适用版本：`bkn.trace.schema.version=1.0.0`  
-> 依据：`bkn-docs/docs/foundry/bkn-trace/design/阶段一：OpenBKN 可观测记录规范与 Trace Context 基线.md`
+> 状态：阶段二 L2 Evidence 模块接入合同
+> 适用版本：L1 `bkn.trace.schema.version=1.0.0`；L2 evidence event `bkn.trace.schema.version=2.0.0`  
+> 依据：`bkn-docs/docs/foundry/bkn-trace/design/BKN Trace 三段式实施计划.md`、`bkn-docs/docs/foundry/bkn-trace/design/阶段二：证据引用采集与 BKN Trace 核心能力开发计划.md`
 
 ## Module
 
@@ -10,7 +10,7 @@
 - owner: OpenBKN Foundry
 - service identity: platform internal agent runtime
 - runtime: FastAPI / LangChain / LangGraph
-- contract version: `1.0.0`
+- contract version: L1 Trace `1.0.0` + L2 Evidence `2.0.0`
 
 ## Entry Operations
 
@@ -18,8 +18,8 @@
 | --- | --- | --- | --- | --- |
 | `bkn-agent.health` | `GET /api/v1/health` | optional upstream `traceparent` / `bkn-request-id` | FastAPI server span | none |
 | `bkn-agent.agent.*` | agent CRUD routes | account identity, request context | FastAPI server span | none in phase one |
-| `bkn-agent.chat` | `POST /api/bkn-agent/v1/chat` | account identity, agent id, optional thread id | FastAPI server span, `agent.chat` business span, LangChain spans when OTel enabled | SSE meta/token/tool/error/done stream events; BKN Trace event envelope is phase-two work |
-| `bkn-agent.task` | `POST /api/bkn-agent/v1/run` / `POST /invoke/{agent_id}` | account identity, agent id, task context | FastAPI server span, `agent.task` business span, LangChain spans when OTel enabled | task status is persisted in DB; BKN Trace event envelope is phase-two work |
+| `bkn-agent.chat` | `POST /api/bkn-agent/v1/chat` | account identity, agent id, optional thread id | FastAPI server span, `agent.chat` business span, LangChain spans when OTel enabled | SSE meta/token/tool/error/done；成功输出 emit `claim.created`，工具引用 emit `evidence.refs.created`，结构化输出 emit `structured_output.validated` |
+| `bkn-agent.task` | `POST /api/bkn-agent/v1/run` / `POST /invoke/{agent_id}` | account identity, agent id, task context | FastAPI server span, `agent.task` business span, LangChain spans when OTel enabled | task status persisted in DB；成功输出 emit `claim.created`；结构化输出 emit `structured_output.validated`；tool result refs emit `evidence.refs.created` |
 
 ## Inbound Context
 
@@ -37,6 +37,7 @@
 | toolbox / MCP tools | HTTP / MCP adapter | phase-one propagation pending in toolbox client | baggage not propagated | existing tool timeout policy | existing retry policy |
 | model provider | OpenAI-compatible HTTP through LangChain | OTel instrumentation when enabled | baggage not propagated | model/provider config | provider policy |
 | checkpoint store | MySQL | request context not propagated | baggage not propagated | DB config | DB driver policy |
+| BKN Trace evidence ingest | HTTP POST | `traceparent`, `bkn.request.id`, account identity in event batch | baggage not propagated | `BKN_TRACE_EVIDENCE_TIMEOUT_S` default 3s | no retry; fail-open with warning |
 
 ## Logs
 
@@ -59,8 +60,13 @@
 | event type | producer | payload summary | partial reason | retention class |
 | --- | --- | --- | --- | --- |
 | SSE `meta/token/tool_call/structured/done/error` | chat stream | user-visible stream protocol | not BKN Trace event envelope yet | transient stream |
-| `task.status.changed` | pending phase-two emitter | task old/new status and failure summary | emitter not implemented in phase one code | business event |
-| `tool.called` / `tool.failed` | pending toolbox propagation | tool id/name and hash-only args/result | toolbox client propagation pending | business event |
+| `claim.created` | `bkn-agent` | answer or structured output claim; stores `claim_hash`, agent/thread/task/prompt/schema refs; no raw answer | `source_refs_pending` when no tool/source refs observed | evidence event |
+| `evidence.refs.created` | `bkn-agent` | tool call refs by sanitized tool name and hash-derived ref id | omitted when no tool refs observed | evidence event |
+| `structured_output.validated` | `bkn-agent` | claim id, response format schema hash, validation result, `validation_path=native|fallback` | none | evidence event |
+| `tool.budget.exhausted` | `bkn-agent` | max tool call cap and sanitized tool name | `tool_budget_exhausted` | evidence event |
+| `agent_as_tool.invoked` | `bkn-agent` | parent thread id, child task id, child agent id, depth, message hash | none | evidence event |
+| `task.status.changed` | pending follow-up | task old/new status and failure summary | not implemented in this PR | business event |
+| `tool.called` / `tool.failed` | pending follow-up | tool id/name and hash-only args/result | toolbox client propagation pending | business event |
 
 ## Business Refs
 
@@ -74,10 +80,18 @@
 ## Sensitive Data Rules
 
 - never log: authorization, cookie, access token, full prompt, full model output, full tool args/result
-- hash only: future prompt/tool/model payload evidence
+- hash only: prompt/tool/model payload evidence, user message, model answer, structured output
 - controlled reference: future evidence snapshot refs
 - redact: HTTP error responses use short error summaries
 - `data.classification`: not emitted by bkn-agent phase-one code yet
+
+## Evidence Submission
+
+- default mode: disabled when `BKN_TRACE_EVIDENCE_INGEST_URL` is empty; bkn-agent still constructs events in code paths but does not submit.
+- enabled mode: POST phase-two batch to `BKN_TRACE_EVIDENCE_INGEST_URL`.
+- fail behavior: fail-open with warning; bkn-agent response, task execution and tool execution must not depend on BKN Trace availability.
+- account context: event batch includes `bkn.account.id` / `bkn.account.type`; `business_domain` is temporarily set to account id until upstream business domain propagation is available.
+- payload boundary: never submit raw prompt, raw user message, raw answer, raw SQL, row data, token, cookie, authorization, or object storage URL.
 
 ## Sampling
 
@@ -102,10 +116,15 @@
 | propagation | `fixtures/bkn-trace/propagation.json` + `app/test/test_smoke.py::test_trace_context_propagates_request_id_and_traceparent` | inbound `traceparent` and `bkn-request-id` propagation | pass |
 | negative | `fixtures/bkn-trace/negative_invalid_traceparent.json` + `app/test/test_smoke.py::test_invalid_traceparent_is_not_reused` | invalid all-zero traceparent rejected | fail for contract fixture; pass for pytest rejection behavior |
 | sampling | `fixtures/bkn-trace/sampling.json` + `app/test/test_smoke.py::test_auth_fail_closed_without_identity` | forced retained error / error body trace id equals `x-trace-id` | pass |
+| phase2 chat L2 | `fixtures/bkn-trace/phase2/chat_l2_positive.json` + `app/test/test_evidence.py` | answer claim + tool evidence refs | pass |
+| phase2 structured L2 | `fixtures/bkn-trace/phase2/structured_output_l2_positive.json` + `app/test/test_structured_output.py` | structured output claim + schema hash + validation path | pass |
+| phase2 agent-as-tool | `fixtures/bkn-trace/phase2/agent_as_tool_l2_positive.json` + `app/test/test_limits_and_gates.py` | child task invocation + depth relation | pass |
 
 ## Known Gaps
 
 - toolbox/MCP outbound propagation is not fully implemented yet.
-- structured BKN Trace event envelope emission is not implemented yet.
+- source refs from context-loader/BKN/Vega/Action are represented only as tool-call refs until downstream modules emit L2/L3 business refs.
+- task status changed events are still DB state transitions, not BKN Trace events.
+- evidence submission requires `BKN_TRACE_EVIDENCE_INGEST_URL`; default deployment keeps it empty until bkn-trace ingestion service address is configured.
 - forced sampling and dropped counters are not implemented yet.
-- full event emitter fixtures are contract-level until the phase-two BKN Trace event envelope exists.
+- `business_domain` is temporarily derived from account id; dedicated business-domain propagation is a follow-up.

--- a/infra/bkn-agent/app/config.py
+++ b/infra/bkn-agent/app/config.py
@@ -41,6 +41,11 @@ class Config:
     # toolbox 工具回调本服务的地址（box_svc_url）
     SELF_BASE_URL = _env("BKN_AGENT_SELF_BASE_URL", "http://bkn-agent:30800")
 
+    # BKN Trace phase-two evidence ingestion. Empty URL = construct evidence facts
+    # locally but do not submit them, so bkn-agent can deploy before bkn-trace.
+    BKN_TRACE_EVIDENCE_INGEST_URL = _env("BKN_TRACE_EVIDENCE_INGEST_URL", "")
+    BKN_TRACE_EVIDENCE_TIMEOUT_S = float(_env("BKN_TRACE_EVIDENCE_TIMEOUT_S", "3"))
+
     # checkpointer: memory | mysql
     CHECKPOINTER_BACKEND = _env("CHECKPOINTER_BACKEND", "mysql")
     # 建表统一走 migrations/bkn-agent/（core-data-migrator）。仅开发环境

--- a/infra/bkn-agent/app/core/graph.py
+++ b/infra/bkn-agent/app/core/graph.py
@@ -7,11 +7,11 @@ from langchain.agents import create_agent
 from langchain_core.messages import AIMessage, AIMessageChunk, HumanMessage, ToolMessage
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app import dao, observability
+from app import dao, evidence, observability
 from app.config import config
 from app.core.checkpoint import open_checkpointer
 from app.core.llm import build_chat_model
-from app.core.structured import structured_extract
+from app.core.structured import structured_extract_with_path
 from app.core.prompt import resolve_prompt
 from app.core.skills import load_skills
 from app.core.tools import apply_tool_call_cap, load_tools
@@ -76,7 +76,12 @@ async def stream_chat(
         timeout_s = limits.timeout_s if limits and limits.timeout_s else config.DEFAULT_TIMEOUT_S
         max_out = limits.max_output_tokens if limits else None
         model = build_chat_model(agent.model, max_output_tokens=max_out)
-        tools = apply_tool_call_cap(tools, limits.max_tool_calls if limits else None)
+        tools = apply_tool_call_cap(
+            tools,
+            limits.max_tool_calls if limits else None,
+            account_id,
+            account_type,
+        )
     except BaseException:
         _busy_threads.discard(thread_id)  # setup 失败必须放位，否则该 thread 永久 409
         raise
@@ -91,6 +96,8 @@ async def stream_chat(
     span_attrs.update(observability.context_attributes())
 
     async def _events() -> AsyncIterator[str]:
+        answer_parts: list[str] = []
+        tool_names: list[str] = []
         try:
             yield _sse("meta", {"thread_id": thread_id, "agent_id": agent.agent_id})
             with observability.span("agent.chat", span_attrs):
@@ -109,20 +116,49 @@ async def stream_chat(
                             ):
                                 if isinstance(chunk, AIMessageChunk):
                                     if chunk.content:
+                                        answer_parts.append(chunk.content if isinstance(chunk.content, str) else str(chunk.content))
                                         yield _sse("token", {"content": chunk.content})
                                     for tc in chunk.tool_call_chunks or []:
                                         if tc.get("name"):
+                                            tool_names.append(tc["name"])
                                             yield _sse("tool_call", {"name": tc["name"]})
                             if req.response_format:
                                 # 工具循环后单独抽结构化（原生优先→提示词降级），受同一 timeout 约束
                                 state = await graph.aget_state(cfg)
                                 struct_model = build_chat_model(
-                                agent.model, streaming=False, max_output_tokens=max_out
-                            )
-                                obj = await structured_extract(
+                                    agent.model, streaming=False, max_output_tokens=max_out
+                                )
+                                obj, validation_path = await structured_extract_with_path(
                                     struct_model, state.values["messages"], req.response_format
                                 )
                                 yield _sse("structured", {"content": obj})
+                                await _emit_chat_evidence(
+                                    agent=agent,
+                                    thread_id=thread_id,
+                                    prompt_source=prompt_source,
+                                    prompt_version=prompt_version,
+                                    account_id=account_id,
+                                    account_type=account_type,
+                                    output=obj,
+                                    claim_type="structured_output",
+                                    response_format=req.response_format,
+                                    structured_validation_path=validation_path,
+                                    tool_names=tool_names,
+                                )
+                            elif answer_parts:
+                                await _emit_chat_evidence(
+                                    agent=agent,
+                                    thread_id=thread_id,
+                                    prompt_source=prompt_source,
+                                    prompt_version=prompt_version,
+                                    account_id=account_id,
+                                    account_type=account_type,
+                                    output="".join(answer_parts),
+                                    claim_type="answer",
+                                    response_format=None,
+                                    structured_validation_path=None,
+                                    tool_names=tool_names,
+                                )
                         yield _sse("done", {"thread_id": thread_id})
                     except TimeoutError:
                         yield _sse("error", {"code": "BknAgent.Chat.Timeout", "detail": f"超过 {timeout_s}s"})
@@ -134,6 +170,73 @@ async def stream_chat(
             _busy_threads.discard(thread_id)
 
     return _events()
+
+
+async def _emit_chat_evidence(
+    *,
+    agent: AgentOut,
+    thread_id: str,
+    prompt_source: str,
+    prompt_version: str,
+    account_id: str,
+    account_type: str,
+    output,
+    claim_type: str,
+    response_format: dict | None,
+    structured_validation_path: str | None,
+    tool_names: list[str],
+) -> None:
+    cid = evidence.claim_id(claim_type, thread_id, output)
+    events = [
+        evidence.claim_created(
+            claim_id_value=cid,
+            claim_type=claim_type,
+            claim_hash=evidence.hash_value(output),
+            operation_name="bkn.agent.chat",
+            version_status="unversioned",
+            subject_refs={
+                "agent_id": agent.agent_id,
+                "thread_id": thread_id,
+                "prompt_source": prompt_source,
+                "prompt_version": prompt_version,
+                "response_format_schema_hash": evidence.schema_hash(response_format),
+            },
+            partial_reason=["source_refs_pending"] if not tool_names else ["source_refs_unversioned"],
+        )
+    ]
+    if response_format:
+        events.append(
+            evidence.structured_output_validated(
+                claim_id_value=cid,
+                schema_hash_value=evidence.schema_hash(response_format),
+                validation_path=structured_validation_path or "unknown",
+                valid=True,
+                operation_name="bkn.agent.structured_output",
+            )
+        )
+    if tool_names:
+        refs = [
+            {
+                "ref_id": f"tool:{evidence.hash_value(name)[7:23]}",
+                "ref_type": "tool_result_ref",
+                "source_system": "bkn-agent",
+                "summary_hash": evidence.hash_value({"tool_name": name}),
+                "tool_name": name,
+                "validity": "observed",
+                "visibility": "visible",
+                "version_status": "unversioned",
+                "partial_reason": ["tool_result_unversioned"],
+            }
+            for name in dict.fromkeys(tool_names)
+        ]
+        events.append(
+            evidence.evidence_refs_created(
+                claim_id_value=cid,
+                evidence_refs=refs,
+                operation_name="bkn.agent.chat",
+            )
+        )
+    await evidence.submit_events([event for event in events if event], account_id, account_type)
 
 
 def _text(content) -> str:

--- a/infra/bkn-agent/app/core/runner.py
+++ b/infra/bkn-agent/app/core/runner.py
@@ -3,12 +3,12 @@ import json
 from typing import Any, Optional
 
 from langchain.agents import create_agent
-from langchain_core.messages import AIMessage
+from langchain_core.messages import AIMessage, ToolMessage
 
-from app import dao, observability
+from app import dao, evidence, observability
 from app.config import config
 from app.core.llm import build_chat_model
-from app.core.structured import structured_extract
+from app.core.structured import structured_extract_with_path
 from app.core.prompt import resolve_prompt
 from app.core.skills import load_skills
 from app.db import SessionLocal
@@ -31,6 +31,7 @@ async def run_agent_once(
     account_type: str,
     depth: int,
     response_format: Optional[dict[str, Any]] = None,
+    task_id: Optional[str] = None,
 ) -> str:
     """一次性无状态执行：单次 graph run，无 checkpointer。被 /run 与 agent-as-tool 共用。
 
@@ -60,7 +61,12 @@ async def run_agent_once(
     timeout_s = limits.timeout_s if limits and limits.timeout_s else config.DEFAULT_TIMEOUT_S
     max_out = limits.max_output_tokens if limits else None
     model = build_chat_model(agent.model, max_output_tokens=max_out)
-    tools = apply_tool_call_cap(tools, limits.max_tool_calls if limits else None)
+    tools = apply_tool_call_cap(
+        tools,
+        limits.max_tool_calls if limits else None,
+        account_id,
+        account_type,
+    )
 
     with observability.span(
         "agent.task",
@@ -81,11 +87,39 @@ async def run_agent_once(
             if response_format:
                 # 工具循环跑完后单独抽结构化：原生优先，模型不支持则提示词降级
                 struct_model = build_chat_model(agent.model, streaming=False, max_output_tokens=max_out)
-                obj = await structured_extract(struct_model, result["messages"], response_format)
-                return json.dumps(obj, ensure_ascii=False)
+                obj, validation_path = await structured_extract_with_path(struct_model, result["messages"], response_format)
+                output = json.dumps(obj, ensure_ascii=False)
+                await _emit_task_evidence(
+                    agent=agent,
+                    task_id=task_id,
+                    prompt_source=prompt_source,
+                    prompt_version=prompt_version,
+                    account_id=account_id,
+                    account_type=account_type,
+                    output=obj,
+                    claim_type="structured_output",
+                    response_format=response_format,
+                    structured_validation_path=validation_path,
+                    result_messages=result["messages"],
+                )
+                return output
     for msg in reversed(result["messages"]):
         if isinstance(msg, AIMessage) and msg.content:
-            return msg.content if isinstance(msg.content, str) else str(msg.content)
+            output = msg.content if isinstance(msg.content, str) else str(msg.content)
+            await _emit_task_evidence(
+                agent=agent,
+                task_id=task_id,
+                prompt_source=prompt_source,
+                prompt_version=prompt_version,
+                account_id=account_id,
+                account_type=account_type,
+                output=output,
+                claim_type="answer",
+                response_format=None,
+                structured_validation_path=None,
+                result_messages=result["messages"],
+            )
+            return output
     raise RuntimeError("graph 结束但没有产出 AI 回复")
 
 
@@ -104,6 +138,7 @@ async def execute_task(task_id: str, agent: AgentOut, req_input: dict, account_i
             account_type,
             depth=1,
             response_format=req_input.get("response_format"),
+            task_id=task_id,
         )
         async with SessionLocal() as session:
             # succeeded 必须等于结果可用（vega build-task 教训）
@@ -119,3 +154,75 @@ def submit_task(task_id: str, agent: AgentOut, req_input: dict, account_id: str,
     task = asyncio.create_task(execute_task(task_id, agent, req_input, account_id, account_type))
     _background.add(task)
     task.add_done_callback(_background.discard)
+
+
+async def _emit_task_evidence(
+    *,
+    agent: AgentOut,
+    task_id: str | None,
+    prompt_source: str,
+    prompt_version: str,
+    account_id: str,
+    account_type: str,
+    output,
+    claim_type: str,
+    response_format: dict[str, Any] | None,
+    structured_validation_path: str | None,
+    result_messages: list[Any],
+) -> None:
+    subject_id = task_id or agent.agent_id
+    cid = evidence.claim_id(claim_type, subject_id, output)
+    tool_names = [
+        getattr(message, "name", "") or getattr(message, "tool_call_id", "")
+        for message in result_messages
+        if isinstance(message, ToolMessage)
+    ]
+    events = [
+        evidence.claim_created(
+            claim_id_value=cid,
+            claim_type=claim_type,
+            claim_hash=evidence.hash_value(output),
+            operation_name="bkn.agent.task",
+            version_status="unversioned",
+            subject_refs={
+                "agent_id": agent.agent_id,
+                "task_id": task_id,
+                "prompt_source": prompt_source,
+                "prompt_version": prompt_version,
+                "response_format_schema_hash": evidence.schema_hash(response_format),
+            },
+            partial_reason=["source_refs_pending"] if not tool_names else ["source_refs_unversioned"],
+        )
+    ]
+    if response_format:
+        events.append(
+            evidence.structured_output_validated(
+                claim_id_value=cid,
+                schema_hash_value=evidence.schema_hash(response_format),
+                validation_path=structured_validation_path or "unknown",
+                valid=True,
+                operation_name="bkn.agent.structured_output",
+            )
+        )
+    if tool_names:
+        events.append(
+            evidence.evidence_refs_created(
+                claim_id_value=cid,
+                evidence_refs=[
+                    {
+                        "ref_id": f"tool:{evidence.hash_value(name)[7:23]}",
+                        "ref_type": "tool_result_ref",
+                        "source_system": "bkn-agent",
+                        "summary_hash": evidence.hash_value({"tool_name": name}),
+                        "tool_name": name,
+                        "validity": "observed",
+                        "visibility": "visible",
+                        "version_status": "unversioned",
+                        "partial_reason": ["tool_result_unversioned"],
+                    }
+                    for name in dict.fromkeys(tool_names)
+                ],
+                operation_name="bkn.agent.task",
+            )
+        )
+    await evidence.submit_events([event for event in events if event], account_id, account_type)

--- a/infra/bkn-agent/app/core/structured.py
+++ b/infra/bkn-agent/app/core/structured.py
@@ -32,6 +32,12 @@ def _extract_json(text: str) -> Any:
 
 async def structured_extract(model, messages: list, schema: dict) -> dict:
     """从 messages 抽出符合 schema 的对象。model 应为非流式（见 build_chat_model）。"""
+    obj, _ = await structured_extract_with_path(model, messages, schema)
+    return obj
+
+
+async def structured_extract_with_path(model, messages: list, schema: dict) -> tuple[dict, str]:
+    """返回结构化对象及 validation path：native 或 fallback。"""
     # 1. 原生
     try:
         norm = normalize_response_format(schema)
@@ -40,7 +46,7 @@ async def structured_extract(model, messages: list, schema: dict) -> dict:
         # 原生也校验：with_structured_output 未启 strict，可能缺 required/类型不符；
         # 不合法则不当成功返回，落到下面提示词降级重试。
         _jsonschema_validate(obj, schema)
-        return obj
+        return obj, "native"
     except SchemaError:
         # schema 本体非法：请求边界已用 check_schema 拦（models.py ResponseFormat），
         # 这里兜底。降级路径同样必炸，直接抛出，不白费模型调用。
@@ -62,7 +68,7 @@ async def structured_extract(model, messages: list, schema: dict) -> dict:
         try:
             obj = _extract_json(text)
             _jsonschema_validate(obj, schema)
-            return obj
+            return obj, "fallback"
         except (json.JSONDecodeError, ValidationError, ValueError) as e:
             last_err = e
             msgs = msgs + [

--- a/infra/bkn-agent/app/core/tools.py
+++ b/infra/bkn-agent/app/core/tools.py
@@ -198,7 +198,7 @@ def apply_tool_call_cap(
     提示串（模型据此收敛作答），而非静默无视上限。None = 不限。"""
     if max_tool_calls is None:
         return tools
-    budget = {"left": max(max_tool_calls, 0)}
+    budget = {"left": max(max_tool_calls, 0), "exhausted_emitted": False}
     capped: list[Any] = []
     for t in tools:
         inner = getattr(t, "coroutine", None)
@@ -210,12 +210,14 @@ def apply_tool_call_cap(
 
         async def _guarded(__inner=inner, __tool_name=tool_name, **kwargs) -> str:
             if budget["left"] <= 0:
-                event = evidence.tool_budget_exhausted(
-                    max_tool_calls=max_tool_calls,
-                    operation_name="bkn.agent.tool.call",
-                    tool_name=__tool_name,
-                )
-                await evidence.submit_events([event] if event else [], account_id, account_type)
+                if not budget["exhausted_emitted"]:
+                    budget["exhausted_emitted"] = True
+                    event = evidence.tool_budget_exhausted(
+                        max_tool_calls=max_tool_calls,
+                        operation_name="bkn.agent.tool.call",
+                        tool_name=__tool_name,
+                    )
+                    await evidence.submit_events([event] if event else [], account_id, account_type)
                 # 措辞要斩钉截铁：只说「请直接作答」时模型会继续试探性重试，
                 # 白烧若干轮（VM 实测空转 9 轮才收敛）
                 return (

--- a/infra/bkn-agent/app/core/tools.py
+++ b/infra/bkn-agent/app/core/tools.py
@@ -5,6 +5,7 @@ import aiohttp
 from langchain_core.tools import StructuredTool
 from langchain_mcp_adapters.client import MultiServerMCPClient
 
+from app import evidence
 from app.config import config
 from app.core.skills import normalize_skill_id
 from app.core.toolbox import load_toolbox_tools
@@ -96,9 +97,26 @@ async def _agent_tool(
                 session, sub_agent.agent_id, {"message": message}, account_id, parent_thread_id
             )
             await dao.set_task_status(session, task.task_id, "running")
+        event = evidence.agent_as_tool_invoked(
+            parent_thread_id=parent_thread_id,
+            child_task_id=task.task_id,
+            child_agent_id=sub_agent.agent_id,
+            depth=depth + 1,
+            message_hash=evidence.hash_value(message),
+            operation_name="bkn.agent.agent_as_tool",
+        )
+        await evidence.submit_events([event] if event else [], account_id, account_type)
         try:
             output = await runner.run_agent_once(
-                sub_agent, message, {}, [], None, account_id, account_type, depth=depth + 1
+                sub_agent,
+                message,
+                {},
+                [],
+                None,
+                account_id,
+                account_type,
+                depth=depth + 1,
+                task_id=task.task_id,
             )
         except Exception as e:
             async with SessionLocal() as session:
@@ -170,7 +188,12 @@ async def load_tools(
     return deduped
 
 
-def apply_tool_call_cap(tools: list[Any], max_tool_calls: int | None) -> list[Any]:
+def apply_tool_call_cap(
+    tools: list[Any],
+    max_tool_calls: int | None,
+    account_id: str = "",
+    account_type: str = "",
+) -> list[Any]:
     """执行 AgentLimits.max_tool_calls：整轮工具调用次数用尽后，工具改为返回
     提示串（模型据此收敛作答），而非静默无视上限。None = 不限。"""
     if max_tool_calls is None:
@@ -183,8 +206,16 @@ def apply_tool_call_cap(tools: list[Any], max_tool_calls: int | None) -> list[An
             capped.append(t)
             continue
 
-        async def _guarded(__inner=inner, **kwargs) -> str:
+        tool_name = getattr(t, "name", None)
+
+        async def _guarded(__inner=inner, __tool_name=tool_name, **kwargs) -> str:
             if budget["left"] <= 0:
+                event = evidence.tool_budget_exhausted(
+                    max_tool_calls=max_tool_calls,
+                    operation_name="bkn.agent.tool.call",
+                    tool_name=__tool_name,
+                )
+                await evidence.submit_events([event] if event else [], account_id, account_type)
                 # 措辞要斩钉截铁：只说「请直接作答」时模型会继续试探性重试，
                 # 白烧若干轮（VM 实测空转 9 轮才收敛）
                 return (

--- a/infra/bkn-agent/app/evidence.py
+++ b/infra/bkn-agent/app/evidence.py
@@ -1,0 +1,204 @@
+import hashlib
+import json
+import logging
+import uuid
+from datetime import datetime, timezone
+from typing import Any
+
+import aiohttp
+
+from app import observability
+from app.config import config
+
+logger = logging.getLogger("bkn-agent.evidence")
+
+CONTRACT_VERSION = "2.0.0"
+
+
+def hash_value(value: Any) -> str:
+    if isinstance(value, str):
+        raw = value
+    else:
+        raw = json.dumps(value, ensure_ascii=False, sort_keys=True, separators=(",", ":"))
+    return "sha256:" + hashlib.sha256(raw.encode("utf-8")).hexdigest()
+
+
+def schema_hash(schema: dict[str, Any] | None) -> str | None:
+    if not schema:
+        return None
+    return hash_value(schema)
+
+
+def _now() -> str:
+    return datetime.now(timezone.utc).isoformat(timespec="microseconds").replace("+00:00", "Z")
+
+
+def _span_id(ctx: observability.TraceContext) -> str:
+    _, span_id = observability.parse_traceparent(ctx.traceparent)
+    return span_id or uuid.uuid4().hex[:16]
+
+
+def claim_id(kind: str, subject_id: str, value: Any) -> str:
+    digest = hashlib.sha256(
+        json.dumps(
+            {"kind": kind, "subject_id": subject_id, "hash": hash_value(value)},
+            ensure_ascii=False,
+            sort_keys=True,
+            separators=(",", ":"),
+        ).encode("utf-8")
+    ).hexdigest()[:24]
+    return f"claim_{digest}"
+
+
+def _event(event_type: str, operation_name: str, payload: dict[str, Any]) -> dict[str, Any] | None:
+    ctx = observability.current_context()
+    if not ctx:
+        return None
+    ts = _now()
+    return {
+        "event_id": f"evt_{uuid.uuid4().hex}",
+        "event_type": event_type,
+        "bkn.trace.schema.version": CONTRACT_VERSION,
+        "observed_at": ts,
+        "emitted_at": ts,
+        "producer_module": observability.MODULE_NAME,
+        "trace_id": ctx.trace_id,
+        "span_id": _span_id(ctx),
+        "bkn.request.id": ctx.request_id,
+        "bkn.operation.name": operation_name,
+        "payload": {k: v for k, v in payload.items() if v is not None},
+    }
+
+
+def build_batch(events: list[dict[str, Any]], account_id: str, account_type: str) -> dict[str, Any] | None:
+    ctx = observability.current_context()
+    if not ctx or not events:
+        return None
+    return {
+        "bkn.trace.schema.version": CONTRACT_VERSION,
+        "trace": {
+            "trace_id": ctx.trace_id,
+            "traceparent": ctx.traceparent,
+            "bkn.request.id": ctx.request_id,
+            "business_domain": account_id,
+            "bkn.account.id": account_id,
+            "bkn.account.type": account_type,
+        },
+        "events": events,
+    }
+
+
+async def submit_events(events: list[dict[str, Any]], account_id: str, account_type: str) -> None:
+    if not account_id or not account_type:
+        return
+    batch = build_batch(events, account_id, account_type)
+    if not batch or not config.BKN_TRACE_EVIDENCE_INGEST_URL:
+        return
+    try:
+        async with aiohttp.ClientSession(
+            timeout=aiohttp.ClientTimeout(total=config.BKN_TRACE_EVIDENCE_TIMEOUT_S)
+        ) as session:
+            async with session.post(config.BKN_TRACE_EVIDENCE_INGEST_URL, json=batch) as resp:
+                if resp.status >= 400:
+                    logger.warning("BKN Trace evidence ingestion rejected: HTTP %s", resp.status)
+    except Exception as exc:
+        logger.warning("BKN Trace evidence ingestion unavailable: %s", exc)
+
+
+def claim_created(
+    *,
+    claim_id_value: str,
+    claim_type: str,
+    claim_hash: str,
+    operation_name: str,
+    visibility: str = "visible",
+    version_status: str = "unversioned",
+    subject_refs: dict[str, Any] | None = None,
+    partial_reason: list[str] | None = None,
+) -> dict[str, Any] | None:
+    payload: dict[str, Any] = {
+        "claim_id": claim_id_value,
+        "claim_type": claim_type,
+        "claim_hash": claim_hash,
+        "visibility": visibility,
+        "version_status": version_status,
+        "subject_refs": subject_refs or {},
+    }
+    if partial_reason:
+        payload["partial_reason"] = partial_reason
+    return _event("claim.created", operation_name, payload)
+
+
+def evidence_refs_created(
+    *,
+    claim_id_value: str,
+    evidence_refs: list[dict[str, Any]],
+    operation_name: str,
+    partial_reason: list[str] | None = None,
+) -> dict[str, Any] | None:
+    payload: dict[str, Any] = {
+        "claim_id": claim_id_value,
+        "evidence_refs": evidence_refs,
+    }
+    if partial_reason:
+        payload["partial_reason"] = partial_reason
+    return _event("evidence.refs.created", operation_name, payload)
+
+
+def structured_output_validated(
+    *,
+    claim_id_value: str,
+    schema_hash_value: str | None,
+    validation_path: str,
+    valid: bool,
+    operation_name: str,
+) -> dict[str, Any] | None:
+    return _event(
+        "structured_output.validated",
+        operation_name,
+        {
+            "claim_id": claim_id_value,
+            "schema_hash": schema_hash_value,
+            "validation_result": "valid" if valid else "invalid",
+            "validation_path": validation_path,
+        },
+    )
+
+
+def tool_budget_exhausted(
+    *,
+    max_tool_calls: int,
+    operation_name: str,
+    tool_name: str | None = None,
+) -> dict[str, Any] | None:
+    return _event(
+        "tool.budget.exhausted",
+        operation_name,
+        {
+            "max_tool_calls": max_tool_calls,
+            "tool_name": tool_name,
+            "partial_reason": ["tool_budget_exhausted"],
+        },
+    )
+
+
+def agent_as_tool_invoked(
+    *,
+    parent_thread_id: str | None,
+    child_task_id: str,
+    child_agent_id: str,
+    depth: int,
+    message_hash: str,
+    operation_name: str,
+) -> dict[str, Any] | None:
+    return _event(
+        "agent_as_tool.invoked",
+        operation_name,
+        {
+            "parent_thread_id": parent_thread_id,
+            "child_task_id": child_task_id,
+            "child_agent_id": child_agent_id,
+            "depth": depth,
+            "message_hash": message_hash,
+        },
+    )

--- a/infra/bkn-agent/app/evidence.py
+++ b/infra/bkn-agent/app/evidence.py
@@ -1,3 +1,4 @@
+import asyncio
 import hashlib
 import json
 import logging
@@ -13,6 +14,7 @@ from app.config import config
 logger = logging.getLogger("bkn-agent.evidence")
 
 CONTRACT_VERSION = "2.0.0"
+_background: set[asyncio.Task] = set()
 
 
 def hash_value(value: Any) -> str:
@@ -94,6 +96,12 @@ async def submit_events(events: list[dict[str, Any]], account_id: str, account_t
     batch = build_batch(events, account_id, account_type)
     if not batch or not config.BKN_TRACE_EVIDENCE_INGEST_URL:
         return
+    task = asyncio.create_task(_send_batch(batch))
+    _background.add(task)
+    task.add_done_callback(_background.discard)
+
+
+async def _send_batch(batch: dict[str, Any]) -> None:
     try:
         async with aiohttp.ClientSession(
             timeout=aiohttp.ClientTimeout(total=config.BKN_TRACE_EVIDENCE_TIMEOUT_S)

--- a/infra/bkn-agent/app/test/test_evidence.py
+++ b/infra/bkn-agent/app/test/test_evidence.py
@@ -1,0 +1,70 @@
+import asyncio
+
+from app import evidence, observability
+
+
+def _ctx():
+    return observability.TraceContext(
+        trace_id="1234567890abcdef1234567890abcdef",
+        request_id="req_evidence_001",
+        traceparent="00-1234567890abcdef1234567890abcdef-1234567890abcdef-01",
+        entry_boundary="external",
+        upstream_span_id="1234567890abcdef",
+    )
+
+
+def test_claim_batch_uses_phase_two_contract_without_raw_answer():
+    token = observability.set_context(_ctx())
+    try:
+        answer = "客户 A 的风险上升，因为近 7 天投诉增加。"
+        cid = evidence.claim_id("answer", "thread-1", answer)
+        event = evidence.claim_created(
+            claim_id_value=cid,
+            claim_type="answer",
+            claim_hash=evidence.hash_value(answer),
+            operation_name="bkn.agent.chat",
+            subject_refs={"agent_id": "agent-1", "thread_id": "thread-1"},
+            partial_reason=["source_refs_pending"],
+        )
+        batch = evidence.build_batch([event], "acct-1", "user")
+    finally:
+        observability.reset_context(token)
+
+    assert batch["bkn.trace.schema.version"] == "2.0.0"
+    assert batch["trace"]["bkn.request.id"] == "req_evidence_001"
+    assert batch["events"][0]["event_type"] == "claim.created"
+    assert batch["events"][0]["payload"]["claim_id"] == cid
+    assert batch["events"][0]["payload"]["claim_hash"].startswith("sha256:")
+    assert answer not in str(batch)
+
+
+def test_structured_output_event_records_validation_path():
+    token = observability.set_context(_ctx())
+    try:
+        event = evidence.structured_output_validated(
+            claim_id_value="claim_1",
+            schema_hash_value="sha256:schema",
+            validation_path="fallback",
+            valid=True,
+            operation_name="bkn.agent.structured_output",
+        )
+    finally:
+        observability.reset_context(token)
+
+    assert event["event_type"] == "structured_output.validated"
+    assert event["payload"]["validation_path"] == "fallback"
+    assert event["payload"]["validation_result"] == "valid"
+
+
+def test_submit_events_is_noop_when_endpoint_unset(monkeypatch):
+    token = observability.set_context(_ctx())
+    try:
+        event = evidence.tool_budget_exhausted(
+            max_tool_calls=1,
+            operation_name="bkn.agent.tool.call",
+            tool_name="search_schema",
+        )
+        monkeypatch.setattr(evidence.config, "BKN_TRACE_EVIDENCE_INGEST_URL", "")
+        asyncio.run(evidence.submit_events([event], "acct-1", "user"))
+    finally:
+        observability.reset_context(token)

--- a/infra/bkn-agent/app/test/test_evidence.py
+++ b/infra/bkn-agent/app/test/test_evidence.py
@@ -68,3 +68,36 @@ def test_submit_events_is_noop_when_endpoint_unset(monkeypatch):
         asyncio.run(evidence.submit_events([event], "acct-1", "user"))
     finally:
         observability.reset_context(token)
+
+
+def test_submit_events_schedules_background_send(monkeypatch):
+    sent = []
+    release = asyncio.Event()
+
+    async def fake_send(batch):
+        sent.append(batch)
+        await release.wait()
+
+    token = observability.set_context(_ctx())
+    try:
+        event = evidence.claim_created(
+            claim_id_value="claim_1",
+            claim_type="answer",
+            claim_hash="sha256:answer",
+            operation_name="bkn.agent.chat",
+            partial_reason=["source_refs_pending"],
+        )
+        monkeypatch.setattr(evidence.config, "BKN_TRACE_EVIDENCE_INGEST_URL", "http://bkn-trace.local/events")
+        monkeypatch.setattr(evidence, "_send_batch", fake_send)
+
+        async def drive():
+            await evidence.submit_events([event], "acct-1", "user")
+            assert len(evidence._background) == 1
+            await asyncio.sleep(0)
+            assert sent[0]["trace"]["bkn.request.id"] == "req_evidence_001"
+            release.set()
+            await asyncio.sleep(0)
+
+        asyncio.run(drive())
+    finally:
+        observability.reset_context(token)

--- a/infra/bkn-agent/app/test/test_limits_and_gates.py
+++ b/infra/bkn-agent/app/test/test_limits_and_gates.py
@@ -6,6 +6,7 @@ from fastapi import HTTPException
 from langchain_core.tools import StructuredTool
 
 from app.core import graph, tools
+from app import observability
 from app.models import AgentOut
 
 
@@ -33,6 +34,35 @@ def test_max_tool_calls_enforced():
     assert r1 == "t1:ok" and r2 == "t2:ok"
     assert "budget exhausted" in r3  # 返回提示串让模型收敛，而非静默继续
     assert calls == ["t1", "t2"]  # 第 3 次没真打下游
+
+
+def test_max_tool_calls_emits_budget_exhausted_event(monkeypatch):
+    emitted = []
+
+    async def fake_submit(events, account_id, account_type):
+        emitted.extend(events)
+
+    monkeypatch.setattr(tools.evidence, "submit_events", fake_submit)
+    capped = tools.apply_tool_call_cap([_tool("t1", [])], 0, "acct-1", "user")
+    token = observability.set_context(
+        observability.TraceContext(
+            trace_id="1234567890abcdef1234567890abcdef",
+            request_id="req_budget_001",
+            traceparent="00-1234567890abcdef1234567890abcdef-1234567890abcdef-01",
+            entry_boundary="external",
+        )
+    )
+
+    async def drive():
+        return await capped[0].coroutine(x="a")
+
+    try:
+        result = asyncio.run(drive())
+    finally:
+        observability.reset_context(token)
+    assert "budget exhausted" in result
+    assert emitted[0]["event_type"] == "tool.budget.exhausted"
+    assert emitted[0]["payload"]["tool_name"] == "t1"
 
 
 def test_no_cap_when_unset():

--- a/infra/bkn-agent/app/test/test_limits_and_gates.py
+++ b/infra/bkn-agent/app/test/test_limits_and_gates.py
@@ -54,13 +54,15 @@ def test_max_tool_calls_emits_budget_exhausted_event(monkeypatch):
     )
 
     async def drive():
-        return await capped[0].coroutine(x="a")
+        return await capped[0].coroutine(x="a"), await capped[0].coroutine(x="b")
 
     try:
-        result = asyncio.run(drive())
+        result1, result2 = asyncio.run(drive())
     finally:
         observability.reset_context(token)
-    assert "budget exhausted" in result
+    assert "budget exhausted" in result1
+    assert "budget exhausted" in result2
+    assert len(emitted) == 1
     assert emitted[0]["event_type"] == "tool.budget.exhausted"
     assert emitted[0]["payload"]["tool_name"] == "t1"
 

--- a/infra/bkn-agent/app/test/test_structured_output.py
+++ b/infra/bkn-agent/app/test/test_structured_output.py
@@ -10,7 +10,7 @@ from app import observability
 from app.core import runner
 from app.core import structured
 from app.core import tools as tools_mod
-from app.core.structured import structured_extract
+from app.core.structured import structured_extract, structured_extract_with_path
 from app.models import AgentOut
 
 SCHEMA = {"type": "object", "properties": {"greeting": {"type": "string"}}, "required": ["greeting"]}
@@ -53,9 +53,21 @@ def test_native_path():
     assert out == {"greeting": "pong"}
 
 
+def test_native_path_reports_trace_path():
+    out, path = asyncio.run(structured_extract_with_path(_NativeOK({"greeting": "pong"}), [], SCHEMA))
+    assert out == {"greeting": "pong"}
+    assert path == "native"
+
+
 def test_fallback_valid():
     out = asyncio.run(structured_extract(_Fallback(['{"greeting": "hi"}']), [], SCHEMA))
     assert out == {"greeting": "hi"}
+
+
+def test_fallback_reports_trace_path():
+    out, path = asyncio.run(structured_extract_with_path(_Fallback(['{"greeting": "hi"}']), [], SCHEMA))
+    assert out == {"greeting": "hi"}
+    assert path == "fallback"
 
 
 def test_fallback_strips_fence_and_retries():
@@ -108,7 +120,12 @@ def _wire(monkeypatch, captured):
     monkeypatch.setattr(runner, "resolve_prompt", fake_prompt)
     monkeypatch.setattr(runner, "load_skills", fake_skills)
     monkeypatch.setattr(tools_mod, "load_tools", fake_tools)
-    monkeypatch.setattr(tools_mod, "apply_tool_call_cap", lambda t, cap: t)
+    monkeypatch.setattr(tools_mod, "apply_tool_call_cap", lambda t, cap, *a: t)
+    monkeypatch.setattr(runner.evidence, "submit_events", lambda *a, **k: _noop())
+
+
+async def _noop():
+    return None
 
 
 def _agent():
@@ -123,9 +140,9 @@ def test_run_with_response_format_serializes(monkeypatch):
     _wire(monkeypatch, captured)
 
     async def fake_extract(model, messages, schema):
-        return {"greeting": "pong"}
+        return {"greeting": "pong"}, "native"
 
-    monkeypatch.setattr(runner, "structured_extract", fake_extract)
+    monkeypatch.setattr(runner, "structured_extract_with_path", fake_extract)
     out = asyncio.run(runner.run_agent_once(
         _agent(), "hi", {}, [], None, "acc", "user", depth=1, response_format=SCHEMA,
     ))

--- a/infra/bkn-agent/charts/templates/deployment.yaml
+++ b/infra/bkn-agent/charts/templates/deployment.yaml
@@ -88,6 +88,10 @@ spec:
               value: {{ .Values.observability.otelEnabled | quote }}
             - name: OTEL_EXPORTER_OTLP_ENDPOINT
               value: {{ .Values.observability.otlpEndpoint | quote }}
+            - name: BKN_TRACE_EVIDENCE_INGEST_URL
+              value: {{ .Values.observability.bknTraceEvidenceIngestUrl | quote }}
+            - name: BKN_TRACE_EVIDENCE_TIMEOUT_S
+              value: {{ .Values.observability.bknTraceEvidenceTimeoutS | quote }}
           volumeMounts:
             - name: host-time
               mountPath: /etc/localtime

--- a/infra/bkn-agent/charts/values.yaml
+++ b/infra/bkn-agent/charts/values.yaml
@@ -53,6 +53,8 @@ runtime:
 observability:
   otelEnabled: "true"
   otlpEndpoint: "http://otelcol-contrib:4318"
+  bknTraceEvidenceIngestUrl: ""
+  bknTraceEvidenceTimeoutS: "3"
 
 nodeSelector: {}
 

--- a/infra/bkn-agent/fixtures/bkn-trace/phase2/agent_as_tool_l2_positive.json
+++ b/infra/bkn-agent/fixtures/bkn-trace/phase2/agent_as_tool_l2_positive.json
@@ -1,0 +1,45 @@
+{
+  "bkn.trace.schema.version": "2.0.0",
+  "fixture_id": "bkn_agent_phase2_agent_as_tool_l2_positive",
+  "expected_result": "pass",
+  "trace": {
+    "trace_id": "7a230000000000000000000000000003",
+    "traceparent": "00-7a230000000000000000000000000003-7a23000000000001-01",
+    "bkn.request.id": "req_bkn_agent_phase2_agent_tool_0003",
+    "business_domain": "acct_demo",
+    "bkn.account.id": "acct_demo",
+    "bkn.account.type": "user"
+  },
+  "spans": [
+    {
+      "span_id": "7a23000000000001",
+      "parent_span_id": null,
+      "name": "agent.agent_as_tool",
+      "bkn.module.name": "bkn-agent",
+      "bkn.operation.name": "bkn.agent.agent_as_tool",
+      "bkn.status": "ok",
+      "bkn.timestamp": "2026-07-22T10:02:00.000000Z"
+    }
+  ],
+  "events": [
+    {
+      "event_id": "evt_bkn_agent_as_tool_invoked",
+      "event_type": "agent_as_tool.invoked",
+      "bkn.trace.schema.version": "2.0.0",
+      "observed_at": "2026-07-22T10:02:00.000000Z",
+      "emitted_at": "2026-07-22T10:02:00.001000Z",
+      "producer_module": "bkn-agent",
+      "trace_id": "7a230000000000000000000000000003",
+      "span_id": "7a23000000000001",
+      "bkn.request.id": "req_bkn_agent_phase2_agent_tool_0003",
+      "bkn.operation.name": "bkn.agent.agent_as_tool",
+      "payload": {
+        "parent_thread_id": "thread_parent",
+        "child_task_id": "task_child",
+        "child_agent_id": "agent_child",
+        "depth": 2,
+        "message_hash": "sha256:message_hash_only"
+      }
+    }
+  ]
+}

--- a/infra/bkn-agent/fixtures/bkn-trace/phase2/chat_l2_positive.json
+++ b/infra/bkn-agent/fixtures/bkn-trace/phase2/chat_l2_positive.json
@@ -1,0 +1,80 @@
+{
+  "bkn.trace.schema.version": "2.0.0",
+  "fixture_id": "bkn_agent_phase2_chat_l2_positive",
+  "expected_result": "pass",
+  "trace": {
+    "trace_id": "7a210000000000000000000000000001",
+    "traceparent": "00-7a210000000000000000000000000001-7a21000000000001-01",
+    "bkn.request.id": "req_bkn_agent_phase2_chat_0001",
+    "business_domain": "acct_demo",
+    "bkn.account.id": "acct_demo",
+    "bkn.account.type": "user"
+  },
+  "spans": [
+    {
+      "span_id": "7a21000000000001",
+      "parent_span_id": null,
+      "name": "agent.chat",
+      "bkn.module.name": "bkn-agent",
+      "bkn.operation.name": "bkn.agent.chat",
+      "bkn.status": "ok",
+      "bkn.timestamp": "2026-07-22T10:00:00.000000Z"
+    }
+  ],
+  "events": [
+    {
+      "event_id": "evt_bkn_agent_chat_claim",
+      "event_type": "claim.created",
+      "bkn.trace.schema.version": "2.0.0",
+      "observed_at": "2026-07-22T10:00:00.000000Z",
+      "emitted_at": "2026-07-22T10:00:00.001000Z",
+      "producer_module": "bkn-agent",
+      "trace_id": "7a210000000000000000000000000001",
+      "span_id": "7a21000000000001",
+      "bkn.request.id": "req_bkn_agent_phase2_chat_0001",
+      "bkn.operation.name": "bkn.agent.chat",
+      "payload": {
+        "claim_id": "claim_bkn_agent_chat_0001",
+        "claim_type": "answer",
+        "claim_hash": "sha256:answer_hash_only",
+        "visibility": "visible",
+        "version_status": "unversioned",
+        "partial_reason": ["source_refs_unversioned"],
+        "subject_refs": {
+          "agent_id": "agent_demo",
+          "thread_id": "thread_demo",
+          "prompt_source": "default",
+          "prompt_version": 3
+        }
+      }
+    },
+    {
+      "event_id": "evt_bkn_agent_chat_refs",
+      "event_type": "evidence.refs.created",
+      "bkn.trace.schema.version": "2.0.0",
+      "observed_at": "2026-07-22T10:00:00.002000Z",
+      "emitted_at": "2026-07-22T10:00:00.003000Z",
+      "producer_module": "bkn-agent",
+      "trace_id": "7a210000000000000000000000000001",
+      "span_id": "7a21000000000001",
+      "bkn.request.id": "req_bkn_agent_phase2_chat_0001",
+      "bkn.operation.name": "bkn.agent.chat",
+      "payload": {
+        "claim_id": "claim_bkn_agent_chat_0001",
+        "evidence_refs": [
+          {
+            "ref_id": "tool:search_schema",
+            "ref_type": "tool_result_ref",
+            "source_system": "bkn-agent",
+            "summary_hash": "sha256:tool_result_summary_hash_only",
+            "tool_name": "search_schema",
+            "validity": "observed",
+            "visibility": "visible",
+            "version_status": "unversioned",
+            "partial_reason": ["tool_result_unversioned"]
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/infra/bkn-agent/fixtures/bkn-trace/phase2/structured_output_l2_positive.json
+++ b/infra/bkn-agent/fixtures/bkn-trace/phase2/structured_output_l2_positive.json
@@ -1,0 +1,71 @@
+{
+  "bkn.trace.schema.version": "2.0.0",
+  "fixture_id": "bkn_agent_phase2_structured_output_l2_positive",
+  "expected_result": "pass",
+  "trace": {
+    "trace_id": "7a220000000000000000000000000002",
+    "traceparent": "00-7a220000000000000000000000000002-7a22000000000001-01",
+    "bkn.request.id": "req_bkn_agent_phase2_structured_0002",
+    "business_domain": "acct_demo",
+    "bkn.account.id": "acct_demo",
+    "bkn.account.type": "user"
+  },
+  "spans": [
+    {
+      "span_id": "7a22000000000001",
+      "parent_span_id": null,
+      "name": "agent.task",
+      "bkn.module.name": "bkn-agent",
+      "bkn.operation.name": "bkn.agent.task",
+      "bkn.status": "ok",
+      "bkn.timestamp": "2026-07-22T10:01:00.000000Z"
+    }
+  ],
+  "events": [
+    {
+      "event_id": "evt_bkn_agent_structured_claim",
+      "event_type": "claim.created",
+      "bkn.trace.schema.version": "2.0.0",
+      "observed_at": "2026-07-22T10:01:00.000000Z",
+      "emitted_at": "2026-07-22T10:01:00.001000Z",
+      "producer_module": "bkn-agent",
+      "trace_id": "7a220000000000000000000000000002",
+      "span_id": "7a22000000000001",
+      "bkn.request.id": "req_bkn_agent_phase2_structured_0002",
+      "bkn.operation.name": "bkn.agent.task",
+      "payload": {
+        "claim_id": "claim_bkn_agent_structured_0002",
+        "claim_type": "structured_output",
+        "claim_hash": "sha256:structured_output_hash_only",
+        "visibility": "visible",
+        "version_status": "unversioned",
+        "subject_refs": {
+          "agent_id": "agent_demo",
+          "task_id": "task_demo",
+          "prompt_source": "default",
+          "prompt_version": 3,
+          "response_format_schema_hash": "sha256:schema_hash_only"
+        },
+        "partial_reason": ["source_refs_pending"]
+      }
+    },
+    {
+      "event_id": "evt_bkn_agent_structured_validated",
+      "event_type": "structured_output.validated",
+      "bkn.trace.schema.version": "2.0.0",
+      "observed_at": "2026-07-22T10:01:00.002000Z",
+      "emitted_at": "2026-07-22T10:01:00.003000Z",
+      "producer_module": "bkn-agent",
+      "trace_id": "7a220000000000000000000000000002",
+      "span_id": "7a22000000000001",
+      "bkn.request.id": "req_bkn_agent_phase2_structured_0002",
+      "bkn.operation.name": "bkn.agent.structured_output",
+      "payload": {
+        "claim_id": "claim_bkn_agent_structured_0002",
+        "schema_hash": "sha256:schema_hash_only",
+        "validation_result": "valid",
+        "validation_path": "native"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- add bkn-agent phase-two evidence event helper and optional ingestion submission
- emit claim/evidence/structured-output/tool-budget/agent-as-tool events from chat/task/tool paths
- update bkn-agent TRACE contract, Helm config, and phase-two fixtures

## Validation
- .venv-trace/bin/python -m py_compile infra/bkn-agent/app/evidence.py infra/bkn-agent/app/core/graph.py infra/bkn-agent/app/core/runner.py infra/bkn-agent/app/core/tools.py infra/bkn-agent/app/core/structured.py infra/bkn-agent/app/config.py
- OTEL_ENABLED=false .venv-trace/bin/python -m pytest -q infra/bkn-agent/app/test
- python3 bkn-docs/docs/foundry/bkn-trace/validation/validate_phase2_fixture.py /Users/leecky/openbkn/bkn-engineering/worktrees/bkn-foundry/feature-bkn-trace-bkn-agent-phase2/infra/bkn-agent/fixtures/bkn-trace/phase2 --pretty

## Notes
- evidence submission is disabled by default until BKN_TRACE_EVIDENCE_INGEST_URL is configured
- bkn-agent emits L2 tool-result refs first; downstream BKN/context-loader/Vega/Action L3 business refs remain follow-up module PRs