### PR TITLE
fix(bkn-agent): agent 修改与删除限定为创建者本人

### DIFF
--- a/infra/bkn-agent/app/dao.py
+++ b/infra/bkn-agent/app/dao.py
@@ -418,13 +418,25 @@ async def check_import_conflict(
     agent_name: str,
     prompt_id: Optional[str],
     prompt_name: Optional[str],
+    account_id: str = "",
 ) -> Optional[str]:
     """只读预检：返回冲突原因，无冲突返回 None。
 
     导入必须先检后写：prompt 与 agent 分别 commit，若写到一半才发现 agent 名撞车，
     rollback 已经回不了 prompt 的提交——那条 agent 报 failed，但 prompt 新版本已
     对线上生效。预检把两个名字冲突一次查完。
+
+    归属也在这里检：导入按 agent_id upsert，命中他人已有的 agent 会覆盖其定义
+    （工具、提示词、模型全部改写），与直接 PUT 是同一类越权，只是换了入口。放在
+    预检里而不是抛 403，是为了保持导入的按条语义——一条归属不符只让该条 failed，
+    不中断整批。创建者未知的存量数据放行，与写接口的取舍一致。
     """
+    if account_id:
+        existing = await session.get(AgentRow, agent_id)
+        if existing:
+            owner = (existing.f_create_user or "").strip()
+            if owner and owner != account_id:
+                return f"agent {agent_id} 属于 {owner}，不能通过导入覆盖他人 agent"
     dup_agent = (
         await session.execute(
             select(AgentRow).where(AgentRow.f_name == agent_name, AgentRow.f_agent_id != agent_id)

--- a/infra/bkn-agent/app/errors.py
+++ b/infra/bkn-agent/app/errors.py
@@ -20,3 +20,7 @@ def not_found(what: str, ident: str) -> HTTPException:
 
 def bad_request(code: str, description: str, detail: str = "", solution: str = "") -> HTTPException:
     return err(400, f"ParamError.{code}", description, detail, solution)
+
+
+def forbidden(description: str, detail: str = "", solution: str = "") -> HTTPException:
+    return err(403, "Forbidden", description, detail, solution)

--- a/infra/bkn-agent/app/routers/agents.py
+++ b/infra/bkn-agent/app/routers/agents.py
@@ -6,10 +6,35 @@ from app import dao
 from app.auth import Account, get_account
 from app.bootstrap import toolbox_sync
 from app.db import get_session
-from app.errors import bad_request, not_found
+from app.errors import bad_request, forbidden, not_found
 from app.models import AgentDeleted, AgentList, AgentOut, AgentSpec
 
 router = APIRouter()
+
+
+async def _load_owned_agent(session: AsyncSession, agent_id: str, account: Account) -> AgentOut:
+    """Fetch an agent and assert the caller may mutate it. Mutation is
+    restricted to the creator: without this, any authenticated account could
+    edit or delete every agent on the platform (the account dependency used to
+    be resolved and then ignored).
+
+    A legacy row whose creator is unknown (empty f_create_user — agents created
+    before ownership was recorded, or while AUTH_ENABLED was off) is left
+    editable rather than locked to nobody; tightening that is deferred to the
+    ownership model (#332). Read paths (list/get) are intentionally NOT gated
+    here so existing agents stay visible to their current users.
+    """
+    agent = await dao.get_agent(session, agent_id)
+    if not agent:
+        raise not_found("agent", agent_id)
+    owner = (agent.create_user or "").strip()
+    if owner and owner != account.account_id:
+        raise forbidden(
+            "无权操作他人 agent",
+            f"agent {agent_id} 属于 {owner}，调用方为 {account.account_id}",
+            "只有创建者可修改或删除该 agent。",
+        )
+    return agent
 
 
 @router.post("/agents", response_model=AgentOut)
@@ -59,6 +84,7 @@ async def update_agent(
     account: Account = Depends(get_account),
     session: AsyncSession = Depends(get_session),
 ):
+    await _load_owned_agent(session, agent_id, account)
     try:
         agent = await dao.update_agent(session, agent_id, spec, account.account_id)
     except IntegrityError:
@@ -75,6 +101,7 @@ async def delete_agent(
     account: Account = Depends(get_account),
     session: AsyncSession = Depends(get_session),
 ):
+    await _load_owned_agent(session, agent_id, account)
     if not await dao.delete_agent(session, agent_id):
         raise not_found("agent", agent_id)
     toolbox_sync.schedule_resync()

--- a/infra/bkn-agent/app/routers/impex.py
+++ b/infra/bkn-agent/app/routers/impex.py
@@ -87,6 +87,7 @@ async def import_agents(
             item.spec.name,
             item.prompt.prompt_id if item.prompt else None,
             item.prompt.name if item.prompt else None,
+            account.account_id,
         )
         if conflict:
             results.append(

--- a/infra/bkn-agent/app/test/test_impex.py
+++ b/infra/bkn-agent/app/test/test_impex.py
@@ -77,7 +77,7 @@ def test_export_then_import_roundtrip(monkeypatch):
     async def fake_upsert_prompt(session, prompt_id, name, content, vars_schema, account_id, commit=True):
         return "version_published"
 
-    async def no_conflict(session, agent_id, agent_name, prompt_id, prompt_name):
+    async def no_conflict(session, agent_id, agent_name, prompt_id, prompt_name, account_id=""):
         return None
 
     resynced = []
@@ -106,7 +106,7 @@ def test_import_conflict_precheck_writes_nothing_and_isolates_item(monkeypatch):
     app.dependency_overrides[get_session] = _fake_session
     written = {"prompts": [], "agents": []}
 
-    async def fake_conflict(session, agent_id, agent_name, prompt_id, prompt_name):
+    async def fake_conflict(session, agent_id, agent_name, prompt_id, prompt_name, account_id=""):
         return f"agent 名「{agent_name}」已被 a-x 占用" if agent_name == "taken" else None
 
     async def fake_upsert_agent(session, agent_id, spec, account_id, commit=True):
@@ -156,3 +156,46 @@ def test_import_conflict_precheck_writes_nothing_and_isolates_item(monkeypatch):
 def test_impex_requires_identity():
     r = client.post("/api/bkn-agent/v1/export", json={"agent_ids": ["a-1"]})
     assert r.status_code == 401
+
+
+def test_import_cannot_overwrite_foreign_agent():
+    """越权回归：导入按 agent_id upsert，命中他人 agent 会整份覆盖其定义
+    （工具/提示词/模型全改写）——与直接 PUT 是同一类越权，只是换了入口。
+    预检必须拦住，且按条 failed（不中断整批）。
+    """
+    import asyncio
+
+    from app.models import AgentRow
+
+    class _Result:
+        def scalar_one_or_none(self):
+            return None  # 无重名冲突，确保命中的是归属分支
+
+    class _Session:
+        def __init__(self, owner):
+            self._owner = owner
+
+        async def get(self, model, agent_id):
+            if self._owner is None:
+                return None
+            return AgentRow(f_agent_id=agent_id, f_create_user=self._owner)
+
+        async def execute(self, stmt):
+            return _Result()
+
+    async def reason_for(owner, caller):
+        return await dao.check_import_conflict(
+            _Session(owner), "a-1", "some-name", None, None, caller
+        )
+
+    foreign = asyncio.run(reason_for("someone-else", "u-1"))
+    assert foreign and "属于" in foreign
+
+    own = asyncio.run(reason_for("u-1", "u-1"))
+    assert own is None  # 覆盖自己的 agent 仍然允许（导入幂等）
+
+    legacy = asyncio.run(reason_for("", "u-1"))
+    assert legacy is None  # 创建者未知的存量数据放行，与写接口取舍一致
+
+    fresh = asyncio.run(reason_for(None, "u-1"))
+    assert fresh is None  # 新建（目标环境不存在该 id）不受影响

--- a/infra/bkn-agent/app/test/test_review_fixes.py
+++ b/infra/bkn-agent/app/test/test_review_fixes.py
@@ -42,13 +42,24 @@ def test_put_agent_name_conflict_not_500(monkeypatch):
     from app import dao
     from app.db import get_session
 
+    from app.models import AgentOut
+
     async def fake_session():
         yield object()
+
+    async def fake_get_agent(session, agent_id):
+        # Owned by the caller (u-1) so the ownership guard passes and the flow
+        # reaches update_agent, where the conflict is raised.
+        return AgentOut(
+            agent_id=agent_id, name="orig", mode="chat", model="", tools=[], skills=[],
+            status="draft", create_user="u-1", update_user="u-1", create_time=1, update_time=2,
+        )
 
     async def fake_update(session, agent_id, spec, account_id):
         raise IntegrityError("UPDATE ...", {}, Exception("Duplicate entry for key f_name"))
 
     app.dependency_overrides[get_session] = fake_session
+    monkeypatch.setattr(dao, "get_agent", fake_get_agent)
     monkeypatch.setattr(dao, "update_agent", fake_update)
     monkeypatch.setattr("app.routers.agents.toolbox_sync.schedule_resync", lambda: None)
     try:

--- a/infra/bkn-agent/app/test/test_review_fixes2.py
+++ b/infra/bkn-agent/app/test/test_review_fixes2.py
@@ -117,7 +117,7 @@ def test_import_single_transaction_rolls_back(monkeypatch):
     async def fake_session():
         yield _S()
 
-    async def fake_conflict(session, agent_id, agent_name, prompt_id, prompt_name):
+    async def fake_conflict(session, agent_id, agent_name, prompt_id, prompt_name, account_id=""):
         return None  # 预检放过，让写入阶段的 IntegrityError 兜底
 
     async def fake_prompt(session, prompt_id, name, content, vars_schema, account_id, commit=True):

--- a/infra/bkn-agent/app/test/test_smoke.py
+++ b/infra/bkn-agent/app/test/test_smoke.py
@@ -203,6 +203,72 @@ def test_thread_owner_reads_history(monkeypatch):
     assert [m["role"] for m in body["messages"]] == ["user", "assistant"]
 
 
+def _agent_out(agent_id, owner):
+    from app.models import AgentOut
+
+    return AgentOut(
+        agent_id=agent_id, name="a", mode="chat", model="", tools=[], skills=[],
+        status="draft", create_user=owner, update_user=owner, create_time=1, update_time=2,
+    )
+
+
+def _override_get_agent(monkeypatch, returns):
+    from app import dao
+    from app.db import get_session
+
+    async def fake_session():
+        class _S:
+            pass
+
+        yield _S()
+
+    async def fake_get_agent(session, agent_id):
+        return returns
+
+    app.dependency_overrides[get_session] = fake_session
+    monkeypatch.setattr(dao, "get_agent", fake_get_agent)
+
+
+def test_update_agent_rejects_non_owner(monkeypatch):
+    """写操作止血：非创建者不得修改他人 agent（此前 account 被解析后忽略）。"""
+    _override_get_agent(monkeypatch, _agent_out("a-1", owner="owner"))
+    body = {"name": "renamed"}
+    r = client.put(
+        "/api/bkn-agent/v1/agents/a-1", json=body,
+        headers={"x-account-id": "intruder", "x-account-type": "user"},
+    )
+    assert r.status_code == 403, r.text
+    app.dependency_overrides.clear()
+
+
+def test_delete_agent_rejects_non_owner(monkeypatch):
+    _override_get_agent(monkeypatch, _agent_out("a-1", owner="owner"))
+    r = client.delete(
+        "/api/bkn-agent/v1/agents/a-1",
+        headers={"x-account-id": "intruder", "x-account-type": "user"},
+    )
+    assert r.status_code == 403, r.text
+    app.dependency_overrides.clear()
+
+
+def test_update_agent_allows_legacy_unowned(monkeypatch):
+    """兼容：f_create_user 为空的存量 agent 不因归属校验被锁死。"""
+    from app import dao
+
+    _override_get_agent(monkeypatch, _agent_out("a-1", owner=""))
+
+    async def fake_update(session, agent_id, spec, account_id):
+        return _agent_out(agent_id, owner="")
+
+    monkeypatch.setattr(dao, "update_agent", fake_update)
+    r = client.put(
+        "/api/bkn-agent/v1/agents/a-1", json={"name": "renamed"},
+        headers={"x-account-id": "anyone", "x-account-type": "user"},
+    )
+    assert r.status_code == 200, r.text
+    app.dependency_overrides.clear()
+
+
 def test_task_read_is_owner_scoped(monkeypatch):
     """P0 回归：GET /tasks/{id} 必须按 account 过滤，越权与不存在同响应（404）。"""
     from app import dao


### PR DESCRIPTION
Closes #331。父 Epic：#328（止血批次 A-3）。

## 这个 PR 解决什么问题

bkn-agent 的 agent 接口不校验调用者身份。`PUT /agents/{id}` 与 `DELETE /agents/{id}` 通过依赖注入拿到了调用方账号，随后**从未使用**，因此任何通过认证的账户都可以修改或删除平台上的**任意** agent，而不只是自己创建的那些。

同类问题在 thread 与 task 上已经做了归属隔离，agent 是唯一遗漏的一类。

## 改动

新增 `_load_owned_agent()`：先取出 agent，不存在返回 404；若该 agent 有创建者且不是当前调用方，返回 403。两个写接口在进入业务逻辑前各调用一次。

`errors.py` 补充 `forbidden()` 助手——此前只有 404 与 400 两种。

## 两处刻意的取舍

**其一，创建者未知的存量数据放行。** `f_create_user` 为空的 agent（在归属信息开始记录之前创建的，或在 `AUTH_ENABLED` 关闭期间创建的）不做拦截。若一律按"无创建者即无人可改"处理，这些 agent 会被永久锁死。收紧这一点需要先有完整的归属模型，归入 #332。

**其二，读取路径不做收窄。** list 与 get 不按归属过滤。直接加过滤会让存量 agent 从当前正在使用它们的用户视野中消失，属于破坏性变更；读面的处理同样等归属模型落地后再定。

因此本 PR 的边界是：**写操作按创建者收敛，读操作保持现状。** 与 #331 的验收标准一致。

## 兼容性

- 未改动创建、列表、查看接口，既有调用方行为不变
- 存量 agent 对其原有使用者仍然可见可用
- 无数据库结构变更，无配置项变更，不涉及部署面

## 测试

`app/test/` 共 93 项全部通过。新增三项：非创建者修改被拒、非创建者删除被拒、创建者未知的存量 agent 仍可修改。

另有一项既有测试需要同步调整：`test_put_agent_name_conflict_not_500` 走的是修改路径，加入归属校验后需要先让调用方通过该校验，才能继续验证它原本要覆盖的重名冲突分支。

## 未包含

- 读取面的归属过滤（依赖 #332 归属模型）
- 管理员越权管理他人 agent 的能力：bkn-agent 目前没有角色概念，仅按创建者判定。若后续需要平台管理员统一管理，需接入 bkn-safe 的授权判定，属 B 批次范围
