### PR TITLE
feat(bkn-trace): emit context-loader schema evidence events

### DIFF
--- a/adp/context-loader/agent-retrieval/TRACE.md
+++ b/adp/context-loader/agent-retrieval/TRACE.md
@@ -1,7 +1,7 @@
 # context-loader Trace Contract
 
-> 状态：阶段一模块接入合同  
-> 适用版本：`bkn.trace.schema.version=1.0.0`  
+> 状态：阶段二 L2 证据事件局部接入
+> 适用版本：`bkn.trace.schema.version=2.0.0`（阶段一日志/传播 fixture 仍保留 `1.0.0`）
 > 依据：`bkn-docs/docs/foundry/bkn-trace/design/阶段一：OpenBKN 可观测记录规范与 Trace Context 基线.md`
 
 ## Module
@@ -11,13 +11,13 @@
 - service identity: `context-loader`
 - runtime: Go HTTP / MCP / toolbox service
 - repository path: `adp/context-loader/agent-retrieval`
-- contract version: `1.0.0`
+- contract version: `2.0.0`
 
 ## Entry Operations
 
 | operation | trigger | required context | emitted spans | emitted events |
 | --- | --- | --- | --- | --- |
-| `context.search_schema` | schema search HTTP/MCP/tool call | `traceparent`、`bkn-request-id`、account/auth context | `context-loader.request`、`context-loader.search` | `context.refs.resolved` |
+| `context.search_schema` | schema search HTTP/MCP/tool call | `traceparent`、`bkn-request-id`、account/auth context | `context-loader.request`、`context-loader.search` | `claim.created`、`evidence.refs.created`、`context.refs.resolved` |
 | `context.query_object` | object query HTTP/MCP/tool call | `traceparent`、`bkn-request-id`、account/auth context | `context-loader.request`、`context-loader.source.resolve` | `tool.called`、`tool.failed` |
 | `context.load_refs` | source refs load | `traceparent`、`bkn-request-id`、business refs | `context-loader.source.resolve` | `context.refs.resolved` |
 | `context.resolve_source` | source resolver call | `traceparent`、`bkn-request-id`、resource refs | `context-loader.source.resolve` | `context.refs.resolved` |
@@ -74,9 +74,20 @@ Trust policy:
 
 | event type | producer | payload summary | partial reason | retention class |
 | --- | --- | --- | --- | --- |
+| `claim.created` | context-loader | schema search result-set finding hash、kn id、query hash、result counts | schema refs unversioned | evidence event |
+| `evidence.refs.created` | context-loader | object/relation/action/metric schema refs、summary hash、visibility、version status | schema ref unversioned | evidence event |
 | `tool.called` | context-loader | tool id/name、args hash、result count、duration | source unavailable / result truncated | business event |
 | `tool.failed` | context-loader | tool id/name、error code、retryable | dependency timeout / validation failed | forced retention on error |
 | `context.refs.resolved` | context-loader | source ref count、classification、truncated | missing version / unauthorized / truncated | business event |
+
+## Phase 2 Evidence Event Rules
+
+- `context.search_schema` 在成功返回后发射一组局部 L2 事件：`claim.created` 表示“本次 schema 检索产生了一个候选上下文 finding”，`evidence.refs.created` 记录该 finding 使用的 schema/action/metric refs。
+- `claim.created.payload.claim_type` 固定为 `finding`，`claim_hash` 只基于结果数量、`kn_id`、`query_hash` 等摘要字段计算，不包含原始 query、schema 名称、comment、字段说明或完整结果。
+- `evidence.refs.created.payload.evidence_refs` 只包含 `ref_id`、`ref_type`、`source_system`、`summary_hash`、`validity`、`version_status`、`visibility`、`partial_reason`；`summary_hash` 来自安全摘要，不包含原始 schema 内容。
+- `version_status` 当前为 `unversioned`，并必须携带 `partial_reason=["schema_ref_unversioned"]`；后续接入 BKN schema version / snapshot 后才能改为 `versioned`。
+- 证据事件上报由 `BKN_TRACE_EVIDENCE_INGEST_URL` 控制，默认关闭；开启后异步提交，不阻塞 schema 检索主路径。
+- 上报失败只记录 warning，不改变业务响应；BKN Trace 核心服务负责后续 Evidence Graph 汇聚、查询、快照和 Studio 可视化。
 
 ## Business Refs
 
@@ -122,6 +133,8 @@ Trust policy:
 | negative | `fixtures/bkn-trace/negative_baggage.json` | forbidden baggage field | fail |
 | propagation | `fixtures/bkn-trace/propagation.json` | inbound/outbound request context | pass |
 | sampling | `fixtures/bkn-trace/sampling.json` | forced sampled tool error | pass |
+| phase2 positive | `fixtures/bkn-trace/phase2/search_schema_l2_positive.json` | schema search L2 finding and evidence refs | pass |
+| phase2 negative | `fixtures/bkn-trace/phase2/negative_raw_query_payload.json` | raw query/prompt payload rejection | fail |
 
 ## Covered GWT
 
@@ -131,17 +144,22 @@ Trust policy:
 - GWT-08 工具或依赖失败。
 - GWT-10 敏感数据扫描。
 - GWT-13 字段索引分层。
+- GWT-21 Given 合法入站 trace/request/account context，When `search_schema` 成功返回候选对象/关系/行动/指标，Then 模块发射 `claim.created` 和 `evidence.refs.created`，且事件可通过同一 `trace_id`、`span_id`、`bkn.request.id` 关联。
+- GWT-22 Given schema 检索 query 与候选结果含业务名称/comment/字段，When 生成 L2 证据事件，Then payload 只包含 hash/ref/count，不包含原始 query、完整 schema、字段说明或结果行。
+- GWT-23 Given 未配置 `BKN_TRACE_EVIDENCE_INGEST_URL`，When `search_schema` 成功执行，Then 业务响应不受影响且不上报事件。
+- GWT-24 Given Trace 后端暂时不可用，When 异步上报失败，Then 只产生 warning，不改变 `search_schema` 的响应状态。
 
 ## Known Gaps
 
-- full `tool.called/tool.failed/context.refs.resolved` runtime event emitter is not complete in this branch.
+- runtime L2 emitter currently covers `context.search_schema`; `query_object_instance`、`query_instance_subgraph`、`run_sql` and resolver-level source refs remain follow-up.
+- cross-module global Evidence Graph assembly is owned by BKN Trace core service, not by context-loader.
 - full registry validation and indexing policy validation currently rely on `bkn-docs` validator follow-up.
-- partial evidence resolver and audit-grade evidence snapshot belong to later BKN Trace phases.
+- audit-grade evidence snapshot, versioned schema refs, source data snapshot refs, and Studio visualization belong to later BKN Trace phases.
 - S3 health metrics are not implemented yet.
 
 ## Owner Sign-off
 
 - owner: OpenBKN Foundry / context-loader
-- reviewed at: 2026-07-21
+- reviewed at: 2026-07-23
 - reviewer: pending
 - compatibility risk: low; new headers are additive and legacy `x-request-id` remains supported.

--- a/adp/context-loader/agent-retrieval/TRACE.md
+++ b/adp/context-loader/agent-retrieval/TRACE.md
@@ -18,7 +18,7 @@
 | operation | trigger | required context | emitted spans | emitted events |
 | --- | --- | --- | --- | --- |
 | `context.search_schema` | schema search HTTP/MCP/tool call | `traceparent`、`bkn-request-id`、account/auth context | `context-loader.request`、`context-loader.search` | `claim.created`、`evidence.refs.created`、`context.refs.resolved` |
-| `context.query_object` | object query HTTP/MCP/tool call | `traceparent`、`bkn-request-id`、account/auth context | `context-loader.request`、`context-loader.source.resolve` | `tool.called`、`tool.failed` |
+| `context.query_object` | object query HTTP/MCP/tool call | `traceparent`、`bkn-request-id`、account/auth context | `context-loader.request`、`context-loader.source.resolve` | `claim.created`、`evidence.refs.created`、`tool.called`、`tool.failed` |
 | `context.load_refs` | source refs load | `traceparent`、`bkn-request-id`、business refs | `context-loader.source.resolve` | `context.refs.resolved` |
 | `context.resolve_source` | source resolver call | `traceparent`、`bkn-request-id`、resource refs | `context-loader.source.resolve` | `context.refs.resolved` |
 
@@ -85,7 +85,9 @@ Trust policy:
 - `context.search_schema` 在成功返回后发射一组局部 L2 事件：`claim.created` 表示“本次 schema 检索产生了一个候选上下文 finding”，`evidence.refs.created` 记录该 finding 使用的 schema/action/metric refs。
 - `claim.created.payload.claim_type` 固定为 `finding`，`claim_hash` 只基于结果数量、`kn_id`、`query_hash` 等摘要字段计算，不包含原始 query、schema 名称、comment、字段说明或完整结果。
 - `evidence.refs.created.payload.evidence_refs` 只包含 `ref_id`、`ref_type`、`source_system`、`summary_hash`、`validity`、`version_status`、`visibility`、`partial_reason`；`summary_hash` 来自安全摘要，不包含原始 schema 内容。
-- `version_status` 当前为 `unversioned`，并必须携带 `partial_reason=["schema_ref_unversioned"]`；后续接入 BKN schema version / snapshot 后才能改为 `versioned`。
+- `context.query_object` 在 REST/MCP 成功返回后发射局部 L2 事件：`claim.created` 表示“本次对象实例查询产生了一个数据 finding”，`evidence.refs.created` 记录实例级 `row_ref`；`condition`、`filters`、`properties`、实例 identity 和行内容只能进入 hash，不得原样进入 payload。
+- `context.query_object` 的 `truncated=true` 来源包括响应存在 `search_after` 或返回条数达到请求 `limit`；该信号只表示“结果可能仍有后续页”，不表示审计级完整性。
+- `version_status` 当前为 `unversioned`，schema refs 必须携带 `partial_reason=["schema_ref_unversioned"]`，row refs 必须携带 `partial_reason=["row_ref_unversioned"]`；后续接入 BKN schema version / snapshot 后才能改为 `versioned`。
 - 证据事件上报由 `BKN_TRACE_EVIDENCE_INGEST_URL` 控制，默认关闭；开启后异步提交，不阻塞 schema 检索主路径。
 - 上报失败只记录 warning，不改变业务响应；BKN Trace 核心服务负责后续 Evidence Graph 汇聚、查询、快照和 Studio 可视化。
 
@@ -134,6 +136,7 @@ Trust policy:
 | propagation | `fixtures/bkn-trace/propagation.json` | inbound/outbound request context | pass |
 | sampling | `fixtures/bkn-trace/sampling.json` | forced sampled tool error | pass |
 | phase2 positive | `fixtures/bkn-trace/phase2/search_schema_l2_positive.json` | schema search L2 finding and evidence refs | pass |
+| phase2 positive | `fixtures/bkn-trace/phase2/query_object_instance_l2_positive.json` | object query L2 finding and row refs | pass |
 | phase2 negative | `fixtures/bkn-trace/phase2/negative_raw_query_payload.json` | raw query/prompt payload rejection | fail |
 
 ## Covered GWT
@@ -148,10 +151,12 @@ Trust policy:
 - GWT-22 Given schema 检索 query 与候选结果含业务名称/comment/字段，When 生成 L2 证据事件，Then payload 只包含 hash/ref/count，不包含原始 query、完整 schema、字段说明或结果行。
 - GWT-23 Given 未配置 `BKN_TRACE_EVIDENCE_INGEST_URL`，When `search_schema` 成功执行，Then 业务响应不受影响且不上报事件。
 - GWT-24 Given Trace 后端暂时不可用，When 异步上报失败，Then 只产生 warning，不改变 `search_schema` 的响应状态。
+- GWT-25 Given 合法入站 trace/request/account context，When `query_object_instance` 成功返回对象实例，Then 模块发射 `claim.created` 和 `evidence.refs.created`，其中实例证据为 `row_ref`。
+- GWT-26 Given 对象实例查询条件、属性列表、实例 identity 或返回行包含用户数据，When 生成 L2 证据事件，Then payload 只包含 condition/properties/identity/row hash，不包含原始过滤值、属性名、实例名或行级数据。
 
 ## Known Gaps
 
-- runtime L2 emitter currently covers `context.search_schema`; `query_object_instance`、`query_instance_subgraph`、`run_sql` and resolver-level source refs remain follow-up.
+- runtime L2 emitter currently covers `context.search_schema` and `context.query_object` row refs; `query_instance_subgraph`、`run_sql` and resolver-level source refs remain follow-up.
 - cross-module global Evidence Graph assembly is owned by BKN Trace core service, not by context-loader.
 - full registry validation and indexing policy validation currently rely on `bkn-docs` validator follow-up.
 - audit-grade evidence snapshot, versioned schema refs, source data snapshot refs, and Studio visualization belong to later BKN Trace phases.

--- a/adp/context-loader/agent-retrieval/fixtures/bkn-trace/phase2/negative_raw_query_payload.json
+++ b/adp/context-loader/agent-retrieval/fixtures/bkn-trace/phase2/negative_raw_query_payload.json
@@ -1,0 +1,48 @@
+{
+  "bkn.trace.schema.version": "2.0.0",
+  "fixture_id": "context_loader_phase2_negative_raw_query_payload",
+  "expected_result": "fail",
+  "trace": {
+    "trace_id": "71210000000000000000000000000002",
+    "traceparent": "00-71210000000000000000000000000002-7121000000000002-01",
+    "bkn.request.id": "req_context_loader_phase2_negative_0001",
+    "business_domain": "acct_demo",
+    "bkn.account.id": "acct_demo",
+    "bkn.account.type": "service"
+  },
+  "spans": [
+    {
+      "span_id": "7121000000000002",
+      "parent_span_id": null,
+      "name": "context-loader.search",
+      "kind": "internal",
+      "bkn.module.name": "context-loader",
+      "bkn.operation.name": "context.search_schema",
+      "bkn.status": "ok",
+      "bkn.timestamp": "2026-07-23T10:01:00.000000Z"
+    }
+  ],
+  "events": [
+    {
+      "event_id": "evt_context_loader_negative_claim",
+      "event_type": "claim.created",
+      "bkn.trace.schema.version": "2.0.0",
+      "observed_at": "2026-07-23T10:01:00.001000Z",
+      "emitted_at": "2026-07-23T10:01:00.002000Z",
+      "producer_module": "context-loader",
+      "trace_id": "71210000000000000000000000000002",
+      "span_id": "7121000000000002",
+      "bkn.request.id": "req_context_loader_phase2_negative_0001",
+      "bkn.operation.name": "context.search_schema",
+      "payload": {
+        "claim_id": "claim_context_loader_negative_0001",
+        "claim_type": "finding",
+        "claim_hash": "sha256:search_result_summary_hash_only",
+        "visibility": "visible",
+        "version_status": "unversioned",
+        "partial_reason": ["schema_refs_unversioned"],
+        "raw_prompt": "must be rejected"
+      }
+    }
+  ]
+}

--- a/adp/context-loader/agent-retrieval/fixtures/bkn-trace/phase2/query_object_instance_l2_positive.json
+++ b/adp/context-loader/agent-retrieval/fixtures/bkn-trace/phase2/query_object_instance_l2_positive.json
@@ -1,0 +1,94 @@
+{
+  "bkn.trace.schema.version": "2.0.0",
+  "fixture_id": "context_loader_phase2_query_object_instance_l2_positive",
+  "expected_result": "pass",
+  "trace": {
+    "trace_id": "71220000000000000000000000000001",
+    "traceparent": "00-71220000000000000000000000000001-7122000000000001-01",
+    "bkn.request.id": "req_context_loader_phase2_query_object_0001",
+    "business_domain": "acct_demo",
+    "bkn.account.id": "acct_demo",
+    "bkn.account.type": "service"
+  },
+  "spans": [
+    {
+      "span_id": "7122000000000001",
+      "parent_span_id": null,
+      "name": "context-loader.source.resolve",
+      "kind": "internal",
+      "bkn.module.name": "context-loader",
+      "bkn.operation.name": "context.query_object",
+      "bkn.status": "ok",
+      "bkn.timestamp": "2026-07-23T11:00:00.000000Z"
+    }
+  ],
+  "events": [
+    {
+      "event_id": "evt_context_loader_query_object_claim",
+      "event_type": "claim.created",
+      "bkn.trace.schema.version": "2.0.0",
+      "observed_at": "2026-07-23T11:00:00.001000Z",
+      "emitted_at": "2026-07-23T11:00:00.002000Z",
+      "producer_module": "context-loader",
+      "trace_id": "71220000000000000000000000000001",
+      "span_id": "7122000000000001",
+      "bkn.request.id": "req_context_loader_phase2_query_object_0001",
+      "bkn.operation.name": "context.query_object",
+      "payload": {
+        "claim_id": "claim_context_loader_query_object_0001",
+        "claim_type": "finding",
+        "claim_hash": "sha256:query_object_summary_hash_only",
+        "visibility": "visible",
+        "version_status": "unversioned",
+        "partial_reason": ["row_refs_unversioned", "result_truncated"],
+        "subject_refs": {
+          "kn_id": "kn_demo",
+          "object_type_id": "customer",
+          "condition_hash": "sha256:condition_hash_only",
+          "properties_hash": "sha256:properties_hash_only",
+          "limit": 10,
+          "returned_ref_count": 2,
+          "truncated": true,
+          "data.classification": "internal"
+        }
+      }
+    },
+    {
+      "event_id": "evt_context_loader_query_object_refs",
+      "event_type": "evidence.refs.created",
+      "bkn.trace.schema.version": "2.0.0",
+      "observed_at": "2026-07-23T11:00:00.003000Z",
+      "emitted_at": "2026-07-23T11:00:00.004000Z",
+      "producer_module": "context-loader",
+      "trace_id": "71220000000000000000000000000001",
+      "span_id": "7122000000000001",
+      "bkn.request.id": "req_context_loader_phase2_query_object_0001",
+      "bkn.operation.name": "context.query_object",
+      "payload": {
+        "claim_id": "claim_context_loader_query_object_0001",
+        "evidence_refs": [
+          {
+            "ref_id": "object_instance:customer:instance_hash_0001",
+            "ref_type": "row_ref",
+            "source_system": "context-loader",
+            "summary_hash": "sha256:row_ref_summary_hash_only_0001",
+            "validity": "observed",
+            "version_status": "unversioned",
+            "visibility": "visible",
+            "partial_reason": ["row_ref_unversioned"]
+          },
+          {
+            "ref_id": "object_instance:customer:instance_hash_0002",
+            "ref_type": "row_ref",
+            "source_system": "context-loader",
+            "summary_hash": "sha256:row_ref_summary_hash_only_0002",
+            "validity": "observed",
+            "version_status": "unversioned",
+            "visibility": "visible",
+            "partial_reason": ["row_ref_unversioned"]
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/adp/context-loader/agent-retrieval/fixtures/bkn-trace/phase2/search_schema_l2_positive.json
+++ b/adp/context-loader/agent-retrieval/fixtures/bkn-trace/phase2/search_schema_l2_positive.json
@@ -1,0 +1,101 @@
+{
+  "bkn.trace.schema.version": "2.0.0",
+  "fixture_id": "context_loader_phase2_search_schema_l2_positive",
+  "expected_result": "pass",
+  "trace": {
+    "trace_id": "71210000000000000000000000000001",
+    "traceparent": "00-71210000000000000000000000000001-7121000000000001-01",
+    "bkn.request.id": "req_context_loader_phase2_search_0001",
+    "business_domain": "acct_demo",
+    "bkn.account.id": "acct_demo",
+    "bkn.account.type": "service"
+  },
+  "spans": [
+    {
+      "span_id": "7121000000000001",
+      "parent_span_id": null,
+      "name": "context-loader.search",
+      "kind": "internal",
+      "bkn.module.name": "context-loader",
+      "bkn.operation.name": "context.search_schema",
+      "bkn.status": "ok",
+      "bkn.timestamp": "2026-07-23T10:00:00.000000Z"
+    }
+  ],
+  "events": [
+    {
+      "event_id": "evt_context_loader_search_claim",
+      "event_type": "claim.created",
+      "bkn.trace.schema.version": "2.0.0",
+      "observed_at": "2026-07-23T10:00:00.001000Z",
+      "emitted_at": "2026-07-23T10:00:00.002000Z",
+      "producer_module": "context-loader",
+      "trace_id": "71210000000000000000000000000001",
+      "span_id": "7121000000000001",
+      "bkn.request.id": "req_context_loader_phase2_search_0001",
+      "bkn.operation.name": "context.search_schema",
+      "payload": {
+        "claim_id": "claim_context_loader_search_0001",
+        "claim_type": "finding",
+        "claim_hash": "sha256:search_result_summary_hash_only",
+        "visibility": "visible",
+        "version_status": "unversioned",
+        "partial_reason": ["schema_refs_unversioned"],
+        "subject_refs": {
+          "kn_id": "kn_demo",
+          "query_hash": "sha256:query_hash_only",
+          "max_concepts": 5,
+          "returned_ref_count": 3,
+          "data.classification": "internal"
+        }
+      }
+    },
+    {
+      "event_id": "evt_context_loader_search_refs",
+      "event_type": "evidence.refs.created",
+      "bkn.trace.schema.version": "2.0.0",
+      "observed_at": "2026-07-23T10:00:00.003000Z",
+      "emitted_at": "2026-07-23T10:00:00.004000Z",
+      "producer_module": "context-loader",
+      "trace_id": "71210000000000000000000000000001",
+      "span_id": "7121000000000001",
+      "bkn.request.id": "req_context_loader_phase2_search_0001",
+      "bkn.operation.name": "context.search_schema",
+      "payload": {
+        "claim_id": "claim_context_loader_search_0001",
+        "evidence_refs": [
+          {
+            "ref_id": "object_type:customer",
+            "ref_type": "schema_ref",
+            "source_system": "context-loader",
+            "summary_hash": "sha256:object_type_summary_hash_only",
+            "validity": "observed",
+            "version_status": "unversioned",
+            "visibility": "visible",
+            "partial_reason": ["schema_ref_unversioned"]
+          },
+          {
+            "ref_id": "relation_type:customer_has_order",
+            "ref_type": "schema_ref",
+            "source_system": "context-loader",
+            "summary_hash": "sha256:relation_type_summary_hash_only",
+            "validity": "observed",
+            "version_status": "unversioned",
+            "visibility": "visible",
+            "partial_reason": ["schema_ref_unversioned"]
+          },
+          {
+            "ref_id": "action_type:notify_owner",
+            "ref_type": "action_ref",
+            "source_system": "context-loader",
+            "summary_hash": "sha256:action_type_summary_hash_only",
+            "validity": "observed",
+            "version_status": "unversioned",
+            "visibility": "visible",
+            "partial_reason": ["schema_ref_unversioned"]
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/adp/context-loader/agent-retrieval/helm/agent-retrieval/templates/deployment.yaml
+++ b/adp/context-loader/agent-retrieval/helm/agent-retrieval/templates/deployment.yaml
@@ -79,6 +79,14 @@ spec:
               - name: AUTH_ENABLED
                 value: {{ .Values.auth.enabled | quote }}
             {{- end}}
+            {{- if .Values.observability.evidence.ingest_url }}
+              - name: BKN_TRACE_EVIDENCE_INGEST_URL
+                value: {{ .Values.observability.evidence.ingest_url | quote }}
+            {{- end}}
+            {{- if .Values.observability.evidence.timeout_ms }}
+              - name: BKN_TRACE_EVIDENCE_TIMEOUT_MS
+                value: {{ .Values.observability.evidence.timeout_ms | quote }}
+            {{- end}}
 
           ports:
             - name: public-port

--- a/adp/context-loader/agent-retrieval/helm/agent-retrieval/values.yaml
+++ b/adp/context-loader/agent-retrieval/helm/agent-retrieval/values.yaml
@@ -164,6 +164,9 @@ observability:
   trace:
     enabled: false
     sampling_rate: 1.0
+  evidence:
+    ingest_url: ""
+    timeout_ms: 2000
   log:
     enabled: false
     level: info

--- a/adp/context-loader/agent-retrieval/server/driveradapters/knqueryobjectinstance/index.go
+++ b/adp/context-loader/agent-retrieval/server/driveradapters/knqueryobjectinstance/index.go
@@ -98,7 +98,7 @@ func (h *knQueryObjectInstanceHandler) QueryObjectInstance(c *gin.Context) {
 		rest.ReplyError(c, err)
 		return
 	}
-	bkntrace.SubmitEvents(c.Request.Context(), h.Logger, req, bkntrace.BuildQueryObjectInstanceEvents(c.Request.Context(), req, resp))
+	bkntrace.EmitQueryObjectInstanceEvents(c.Request.Context(), h.Logger, req, resp)
 
 	// 返回成功响应
 	rest.ReplyOK(c, http.StatusOK, resp)

--- a/adp/context-loader/agent-retrieval/server/driveradapters/knqueryobjectinstance/index.go
+++ b/adp/context-loader/agent-retrieval/server/driveradapters/knqueryobjectinstance/index.go
@@ -16,6 +16,7 @@ import (
 	validator "github.com/go-playground/validator/v10"
 
 	"github.com/openbkn-ai/adp/context-loader/agent-retrieval/server/drivenadapters"
+	"github.com/openbkn-ai/adp/context-loader/agent-retrieval/server/infra/bkntrace"
 	"github.com/openbkn-ai/adp/context-loader/agent-retrieval/server/infra/config"
 	"github.com/openbkn-ai/adp/context-loader/agent-retrieval/server/infra/errors"
 	"github.com/openbkn-ai/adp/context-loader/agent-retrieval/server/infra/rest"
@@ -97,6 +98,7 @@ func (h *knQueryObjectInstanceHandler) QueryObjectInstance(c *gin.Context) {
 		rest.ReplyError(c, err)
 		return
 	}
+	bkntrace.SubmitEvents(c.Request.Context(), h.Logger, req, bkntrace.BuildQueryObjectInstanceEvents(c.Request.Context(), req, resp))
 
 	// 返回成功响应
 	rest.ReplyOK(c, http.StatusOK, resp)

--- a/adp/context-loader/agent-retrieval/server/driveradapters/mcp/tools.go
+++ b/adp/context-loader/agent-retrieval/server/driveradapters/mcp/tools.go
@@ -109,7 +109,7 @@ func handleQueryObjectInstance(ontologyQuery interfaces.DrivenOntologyQuery) fun
 		if err != nil {
 			return mcp.NewToolResultError(err.Error()), nil
 		}
-		bkntrace.SubmitEvents(ctx, nil, queryReq, bkntrace.BuildQueryObjectInstanceEvents(ctx, queryReq, resp))
+		bkntrace.EmitQueryObjectInstanceEvents(ctx, nil, queryReq, resp)
 		resp.ObjectConcept = nil
 		result, err := BuildMCPToolResult(resp, format)
 		if err != nil {

--- a/adp/context-loader/agent-retrieval/server/driveradapters/mcp/tools.go
+++ b/adp/context-loader/agent-retrieval/server/driveradapters/mcp/tools.go
@@ -14,6 +14,7 @@ import (
 	validator "github.com/go-playground/validator/v10"
 	"github.com/mark3labs/mcp-go/mcp"
 
+	"github.com/openbkn-ai/adp/context-loader/agent-retrieval/server/infra/bkntrace"
 	"github.com/openbkn-ai/adp/context-loader/agent-retrieval/server/infra/common"
 	"github.com/openbkn-ai/adp/context-loader/agent-retrieval/server/infra/rest"
 	"github.com/openbkn-ai/adp/context-loader/agent-retrieval/server/interfaces"
@@ -108,6 +109,7 @@ func handleQueryObjectInstance(ontologyQuery interfaces.DrivenOntologyQuery) fun
 		if err != nil {
 			return mcp.NewToolResultError(err.Error()), nil
 		}
+		bkntrace.SubmitEvents(ctx, nil, queryReq, bkntrace.BuildQueryObjectInstanceEvents(ctx, queryReq, resp))
 		resp.ObjectConcept = nil
 		result, err := BuildMCPToolResult(resp, format)
 		if err != nil {

--- a/adp/context-loader/agent-retrieval/server/infra/bkntrace/evidence.go
+++ b/adp/context-loader/agent-retrieval/server/infra/bkntrace/evidence.go
@@ -34,7 +34,14 @@ const (
 	envEvidenceIngestTimeoutMS = "BKN_TRACE_EVIDENCE_TIMEOUT_MS"
 )
 
+const maxInFlightEvidenceBatches = 64
+
 type Event map[string]any
+
+var (
+	evidenceHTTPClient = &http.Client{}
+	evidenceInFlight   = make(chan struct{}, maxInFlightEvidenceBatches)
+)
 
 type batch struct {
 	ContractVersion string         `json:"bkn.trace.schema.version"`
@@ -67,6 +74,24 @@ func ClaimID(kind, subjectID string, value any) string {
 		"value":      value,
 	})))
 	return "claim_" + hex.EncodeToString(sum[:])[:24]
+}
+
+func EvidenceEnabled() bool {
+	return evidenceIngestURL() != ""
+}
+
+func EmitSearchSchemaEvents(ctx context.Context, logger interfaces.Logger, req *interfaces.SearchSchemaReq, resp *interfaces.SearchSchemaResp) {
+	if !EvidenceEnabled() {
+		return
+	}
+	SubmitEvents(ctx, logger, req, BuildSearchSchemaEvents(ctx, req, resp))
+}
+
+func EmitQueryObjectInstanceEvents(ctx context.Context, logger interfaces.Logger, req *interfaces.QueryObjectInstancesReq, resp *interfaces.QueryObjectInstancesResp) {
+	if !EvidenceEnabled() {
+		return
+	}
+	SubmitEvents(ctx, logger, req, BuildQueryObjectInstanceEvents(ctx, req, resp))
 }
 
 func BuildSearchSchemaEvents(ctx context.Context, req *interfaces.SearchSchemaReq, resp *interfaces.SearchSchemaResp) []Event {
@@ -172,7 +197,7 @@ func SubmitEvents(ctx context.Context, logger interfaces.Logger, req any, events
 	if !ok || ec.accountID == "" || ec.accountType == "" {
 		return
 	}
-	ingestURL := strings.TrimSpace(os.Getenv(envEvidenceIngestURL))
+	ingestURL := evidenceIngestURL()
 	if ingestURL == "" {
 		return
 	}
@@ -190,7 +215,17 @@ func SubmitEvents(ctx context.Context, logger interfaces.Logger, req any, events
 		Events: events,
 	}
 
+	select {
+	case evidenceInFlight <- struct{}{}:
+	default:
+		if logger != nil {
+			logger.WithContext(ctx).Warn("BKN Trace evidence ingestion dropped: in-flight limit reached")
+		}
+		return
+	}
+
 	go func() {
+		defer func() { <-evidenceInFlight }()
 		if err := postBatch(ingestURL, timeout, payload); err != nil && logger != nil {
 			logger.WithContext(ctx).Warnf("BKN Trace evidence ingestion unavailable: %v", err)
 		}
@@ -202,14 +237,16 @@ func postBatch(ingestURL string, timeout time.Duration, payload batch) error {
 	if err != nil {
 		return err
 	}
-	req, err := http.NewRequestWithContext(context.Background(), http.MethodPost, ingestURL, bytes.NewReader(body))
+	postCtx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(postCtx, http.MethodPost, ingestURL, bytes.NewReader(body))
 	if err != nil {
 		return err
 	}
 	req.Header.Set("Content-Type", "application/json")
 
-	client := &http.Client{Timeout: timeout}
-	resp, err := client.Do(req)
+	resp, err := evidenceHTTPClient.Do(req)
 	if err != nil {
 		return err
 	}
@@ -218,6 +255,10 @@ func postBatch(ingestURL string, timeout time.Duration, payload batch) error {
 		return fmt.Errorf("HTTP %d", resp.StatusCode)
 	}
 	return nil
+}
+
+func evidenceIngestURL() string {
+	return strings.TrimSpace(os.Getenv(envEvidenceIngestURL))
 }
 
 func evidenceTimeout() time.Duration {

--- a/adp/context-loader/agent-retrieval/server/infra/bkntrace/evidence.go
+++ b/adp/context-loader/agent-retrieval/server/infra/bkntrace/evidence.go
@@ -114,7 +114,57 @@ func BuildSearchSchemaEvents(ctx context.Context, req *interfaces.SearchSchemaRe
 	}
 }
 
-func SubmitEvents(ctx context.Context, logger interfaces.Logger, req *interfaces.SearchSchemaReq, events []Event) {
+func BuildQueryObjectInstanceEvents(ctx context.Context, req *interfaces.QueryObjectInstancesReq, resp *interfaces.QueryObjectInstancesResp) []Event {
+	ec, ok := contextFromRequest(ctx, nil)
+	if !ok {
+		return nil
+	}
+	refs := objectInstanceEvidenceRefs(req, resp)
+	if len(refs) == 0 {
+		return nil
+	}
+
+	resultSummary := map[string]any{
+		"kn_id":          queryObjectKnID(req),
+		"object_type_id": queryObjectTypeID(req),
+		"condition_hash": queryObjectConditionHash(req),
+		"result_count":   len(resp.Data),
+		"truncated":      queryObjectTruncated(req, resp),
+	}
+	claimID := ClaimID("context_loader.query_object_instance", queryObjectTypeID(req), resultSummary)
+
+	partialReason := []string{"row_refs_unversioned"}
+	if queryObjectTruncated(req, resp) {
+		partialReason = append(partialReason, "result_truncated")
+	}
+
+	return []Event{
+		buildEvent(ec, "claim.created", "context.query_object", map[string]any{
+			"claim_id":       claimID,
+			"claim_type":     "finding",
+			"claim_hash":     HashValue(resultSummary),
+			"visibility":     "visible",
+			"version_status": "unversioned",
+			"partial_reason": partialReason,
+			"subject_refs": map[string]any{
+				"kn_id":               queryObjectKnID(req),
+				"object_type_id":      queryObjectTypeID(req),
+				"condition_hash":      resultSummary["condition_hash"],
+				"properties_hash":     queryObjectPropertiesHash(req),
+				"limit":               queryObjectLimit(req),
+				"returned_ref_count":  len(refs),
+				"truncated":           queryObjectTruncated(req, resp),
+				"data.classification": "internal",
+			},
+		}),
+		buildEvent(ec, "evidence.refs.created", "context.query_object", map[string]any{
+			"claim_id":      claimID,
+			"evidence_refs": refs,
+		}),
+	}
+}
+
+func SubmitEvents(ctx context.Context, logger interfaces.Logger, req any, events []Event) {
 	if len(events) == 0 {
 		return
 	}
@@ -182,7 +232,7 @@ func evidenceTimeout() time.Duration {
 	return time.Duration(ms) * time.Millisecond
 }
 
-func contextFromRequest(ctx context.Context, req *interfaces.SearchSchemaReq) (eventContext, bool) {
+func contextFromRequest(ctx context.Context, req any) (eventContext, bool) {
 	spanContext := trace.SpanContextFromContext(ctx)
 	if !spanContext.IsValid() {
 		return eventContext{}, false
@@ -198,12 +248,12 @@ func contextFromRequest(ctx context.Context, req *interfaces.SearchSchemaReq) (e
 		accountID = strings.TrimSpace(authContext.AccountID)
 		accountType = strings.TrimSpace(string(authContext.AccountType))
 	}
-	if req != nil {
+	if schemaReq, ok := req.(*interfaces.SearchSchemaReq); ok && schemaReq != nil {
 		if accountID == "" {
-			accountID = strings.TrimSpace(req.XAccountID)
+			accountID = strings.TrimSpace(schemaReq.XAccountID)
 		}
 		if accountType == "" {
-			accountType = strings.TrimSpace(req.XAccountType)
+			accountType = strings.TrimSpace(schemaReq.XAccountType)
 		}
 	}
 	flags := "00"
@@ -362,4 +412,103 @@ func maxConcepts(req *interfaces.SearchSchemaReq) int {
 
 func boolValue(value *bool) bool {
 	return value != nil && *value
+}
+
+func objectInstanceEvidenceRefs(req *interfaces.QueryObjectInstancesReq, resp *interfaces.QueryObjectInstancesResp) []map[string]any {
+	if req == nil || resp == nil || len(resp.Data) == 0 {
+		return nil
+	}
+	refs := make([]map[string]any, 0, len(resp.Data))
+	for index, item := range resp.Data {
+		identity, ok := objectInstanceIdentity(item)
+		if !ok {
+			identity = map[string]any{
+				"row_index": index,
+				"row_hash":  HashValue(item),
+			}
+		}
+		refs = append(refs, map[string]any{
+			"ref_id":         "object_instance:" + queryObjectTypeID(req) + ":" + hashSuffix(identity),
+			"ref_type":       "row_ref",
+			"source_system":  ModuleName,
+			"summary_hash":   HashValue(map[string]any{"identity_hash": HashValue(identity), "object_type_id": queryObjectTypeID(req)}),
+			"validity":       "observed",
+			"version_status": "unversioned",
+			"visibility":     "visible",
+			"partial_reason": []string{"row_ref_unversioned"},
+		})
+	}
+	return refs
+}
+
+func objectInstanceIdentity(item any) (map[string]any, bool) {
+	itemMap, ok := asMap(item)
+	if !ok {
+		return nil, false
+	}
+	identity, ok := itemMap["_instance_identity"]
+	if !ok {
+		return nil, false
+	}
+	return asMap(identity)
+}
+
+func queryObjectConditionHash(req *interfaces.QueryObjectInstancesReq) string {
+	if req == nil {
+		return HashValue(nil)
+	}
+	return HashValue(map[string]any{
+		"condition": req.Cond,
+		"filters":   req.Filters,
+		"offset":    req.Offset,
+	})
+}
+
+func queryObjectPropertiesHash(req *interfaces.QueryObjectInstancesReq) string {
+	if req == nil {
+		return HashValue(nil)
+	}
+	return HashValue(req.Properties)
+}
+
+func queryObjectTruncated(req *interfaces.QueryObjectInstancesReq, resp *interfaces.QueryObjectInstancesResp) bool {
+	if resp == nil {
+		return false
+	}
+	if len(resp.SearchAfter) > 0 {
+		return true
+	}
+	if req == nil || req.Limit <= 0 {
+		return false
+	}
+	return len(resp.Data) >= req.Limit
+}
+
+func queryObjectKnID(req *interfaces.QueryObjectInstancesReq) string {
+	if req == nil {
+		return ""
+	}
+	return strings.TrimSpace(req.KnID)
+}
+
+func queryObjectTypeID(req *interfaces.QueryObjectInstancesReq) string {
+	if req == nil {
+		return ""
+	}
+	return strings.TrimSpace(req.OtID)
+}
+
+func queryObjectLimit(req *interfaces.QueryObjectInstancesReq) int {
+	if req == nil {
+		return 0
+	}
+	return req.Limit
+}
+
+func hashSuffix(value any) string {
+	hash := strings.TrimPrefix(HashValue(value), "sha256:")
+	if len(hash) > 24 {
+		return hash[:24]
+	}
+	return hash
 }

--- a/adp/context-loader/agent-retrieval/server/infra/bkntrace/evidence.go
+++ b/adp/context-loader/agent-retrieval/server/infra/bkntrace/evidence.go
@@ -1,0 +1,365 @@
+// Copyright openbkn.ai
+// Copyright The kweaver.ai Authors.
+//
+// Licensed under the Apache License, Version 2.0.
+// See the LICENSE file in the project root for details.
+
+package bkntrace
+
+import (
+	"bytes"
+	"context"
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/openbkn-ai/adp/context-loader/agent-retrieval/server/infra/common"
+	"github.com/openbkn-ai/adp/context-loader/agent-retrieval/server/interfaces"
+	"go.opentelemetry.io/otel/trace"
+)
+
+const (
+	ContractVersion = "2.0.0"
+	ModuleName      = "context-loader"
+)
+
+const (
+	envEvidenceIngestURL       = "BKN_TRACE_EVIDENCE_INGEST_URL"
+	envEvidenceIngestTimeoutMS = "BKN_TRACE_EVIDENCE_TIMEOUT_MS"
+)
+
+type Event map[string]any
+
+type batch struct {
+	ContractVersion string         `json:"bkn.trace.schema.version"`
+	Trace           map[string]any `json:"trace"`
+	Events          []Event        `json:"events"`
+}
+
+type eventContext struct {
+	traceID     string
+	spanID      string
+	traceparent string
+	requestID   string
+	accountID   string
+	accountType string
+}
+
+func HashValue(value any) string {
+	raw, err := json.Marshal(value)
+	if err != nil {
+		raw = []byte(fmt.Sprintf("%v", value))
+	}
+	sum := sha256.Sum256(raw)
+	return "sha256:" + hex.EncodeToString(sum[:])
+}
+
+func ClaimID(kind, subjectID string, value any) string {
+	sum := sha256.Sum256([]byte(HashValue(map[string]any{
+		"kind":       kind,
+		"subject_id": subjectID,
+		"value":      value,
+	})))
+	return "claim_" + hex.EncodeToString(sum[:])[:24]
+}
+
+func BuildSearchSchemaEvents(ctx context.Context, req *interfaces.SearchSchemaReq, resp *interfaces.SearchSchemaResp) []Event {
+	ec, ok := contextFromRequest(ctx, req)
+	if !ok {
+		return nil
+	}
+	refs := schemaEvidenceRefs(resp)
+	if len(refs) == 0 {
+		return nil
+	}
+
+	resultSummary := map[string]any{
+		"kn_id":               resolvedKnID(req),
+		"query_hash":          HashValue(strings.TrimSpace(req.Query)),
+		"object_type_count":   len(resp.ObjectTypes),
+		"relation_type_count": len(resp.RelationTypes),
+		"action_type_count":   len(resp.ActionTypes),
+		"metric_type_count":   len(resp.MetricTypes),
+	}
+	claimID := ClaimID("context_loader.search_schema", resolvedKnID(req), resultSummary)
+
+	return []Event{
+		buildEvent(ec, "claim.created", "context.search_schema", map[string]any{
+			"claim_id":       claimID,
+			"claim_type":     "finding",
+			"claim_hash":     HashValue(resultSummary),
+			"visibility":     "visible",
+			"version_status": "unversioned",
+			"partial_reason": []string{"schema_refs_unversioned"},
+			"subject_refs": map[string]any{
+				"kn_id":               resolvedKnID(req),
+				"query_hash":          resultSummary["query_hash"],
+				"max_concepts":        maxConcepts(req),
+				"include_columns":     boolValue(req.IncludeColumns),
+				"schema_brief":        boolValue(req.SchemaBrief),
+				"returned_ref_count":  len(refs),
+				"data.classification": "internal",
+			},
+		}),
+		buildEvent(ec, "evidence.refs.created", "context.search_schema", map[string]any{
+			"claim_id":      claimID,
+			"evidence_refs": refs,
+		}),
+	}
+}
+
+func SubmitEvents(ctx context.Context, logger interfaces.Logger, req *interfaces.SearchSchemaReq, events []Event) {
+	if len(events) == 0 {
+		return
+	}
+	ec, ok := contextFromRequest(ctx, req)
+	if !ok || ec.accountID == "" || ec.accountType == "" {
+		return
+	}
+	ingestURL := strings.TrimSpace(os.Getenv(envEvidenceIngestURL))
+	if ingestURL == "" {
+		return
+	}
+	timeout := evidenceTimeout()
+	payload := batch{
+		ContractVersion: ContractVersion,
+		Trace: map[string]any{
+			"trace_id":         ec.traceID,
+			"traceparent":      ec.traceparent,
+			"bkn.request.id":   ec.requestID,
+			"business_domain":  ec.accountID,
+			"bkn.account.id":   ec.accountID,
+			"bkn.account.type": ec.accountType,
+		},
+		Events: events,
+	}
+
+	go func() {
+		if err := postBatch(ingestURL, timeout, payload); err != nil && logger != nil {
+			logger.WithContext(ctx).Warnf("BKN Trace evidence ingestion unavailable: %v", err)
+		}
+	}()
+}
+
+func postBatch(ingestURL string, timeout time.Duration, payload batch) error {
+	body, err := json.Marshal(payload)
+	if err != nil {
+		return err
+	}
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodPost, ingestURL, bytes.NewReader(body))
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	client := &http.Client{Timeout: timeout}
+	resp, err := client.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode >= http.StatusBadRequest {
+		return fmt.Errorf("HTTP %d", resp.StatusCode)
+	}
+	return nil
+}
+
+func evidenceTimeout() time.Duration {
+	value := strings.TrimSpace(os.Getenv(envEvidenceIngestTimeoutMS))
+	if value == "" {
+		return 2 * time.Second
+	}
+	var ms int
+	if _, err := fmt.Sscanf(value, "%d", &ms); err != nil || ms <= 0 {
+		return 2 * time.Second
+	}
+	return time.Duration(ms) * time.Millisecond
+}
+
+func contextFromRequest(ctx context.Context, req *interfaces.SearchSchemaReq) (eventContext, bool) {
+	spanContext := trace.SpanContextFromContext(ctx)
+	if !spanContext.IsValid() {
+		return eventContext{}, false
+	}
+	traceContext, ok := common.GetTraceContextFromCtx(ctx)
+	if !ok || !common.IsValidBKNRequestID(traceContext.RequestID) {
+		return eventContext{}, false
+	}
+	authContext, _ := common.GetAccountAuthContextFromCtx(ctx)
+	accountID := ""
+	accountType := ""
+	if authContext != nil {
+		accountID = strings.TrimSpace(authContext.AccountID)
+		accountType = strings.TrimSpace(string(authContext.AccountType))
+	}
+	if req != nil {
+		if accountID == "" {
+			accountID = strings.TrimSpace(req.XAccountID)
+		}
+		if accountType == "" {
+			accountType = strings.TrimSpace(req.XAccountType)
+		}
+	}
+	flags := "00"
+	if spanContext.TraceFlags().IsSampled() {
+		flags = "01"
+	}
+	return eventContext{
+		traceID:     spanContext.TraceID().String(),
+		spanID:      spanContext.SpanID().String(),
+		traceparent: fmt.Sprintf("00-%s-%s-%s", spanContext.TraceID().String(), spanContext.SpanID().String(), flags),
+		requestID:   traceContext.RequestID,
+		accountID:   accountID,
+		accountType: accountType,
+	}, true
+}
+
+func buildEvent(ec eventContext, eventType, operationName string, payload map[string]any) Event {
+	now := time.Now().UTC().Format(time.RFC3339Nano)
+	return Event{
+		"event_id":                 "evt_" + randomHex(16),
+		"event_type":               eventType,
+		"bkn.trace.schema.version": ContractVersion,
+		"observed_at":              now,
+		"emitted_at":               now,
+		"producer_module":          ModuleName,
+		"trace_id":                 ec.traceID,
+		"span_id":                  ec.spanID,
+		"bkn.request.id":           ec.requestID,
+		"bkn.operation.name":       operationName,
+		"payload":                  payload,
+	}
+}
+
+func randomHex(length int) string {
+	if length <= 0 {
+		return ""
+	}
+	buf := make([]byte, (length+1)/2)
+	if _, err := rand.Read(buf); err != nil {
+		sum := sha256.Sum256([]byte(time.Now().UTC().Format(time.RFC3339Nano)))
+		return hex.EncodeToString(sum[:])[:length]
+	}
+	return hex.EncodeToString(buf)[:length]
+}
+
+func schemaEvidenceRefs(resp *interfaces.SearchSchemaResp) []map[string]any {
+	if resp == nil {
+		return nil
+	}
+	refs := make([]map[string]any, 0, len(resp.ObjectTypes)+len(resp.RelationTypes)+len(resp.ActionTypes)+len(resp.MetricTypes))
+	refs = append(refs, conceptRefs("object_type", "schema_ref", resp.ObjectTypes)...)
+	refs = append(refs, conceptRefs("relation_type", "schema_ref", resp.RelationTypes)...)
+	refs = append(refs, conceptRefs("action_type", "action_ref", resp.ActionTypes)...)
+	refs = append(refs, conceptRefs("metric_type", "metric_ref", resp.MetricTypes)...)
+	return refs
+}
+
+func conceptRefs(kind, refType string, items []any) []map[string]any {
+	refs := make([]map[string]any, 0, len(items))
+	for _, item := range items {
+		itemMap, ok := asMap(item)
+		if !ok {
+			continue
+		}
+		id := firstString(itemMap, "concept_id", "id")
+		if id == "" {
+			continue
+		}
+		refs = append(refs, map[string]any{
+			"ref_id":         kind + ":" + id,
+			"ref_type":       refType,
+			"source_system":  ModuleName,
+			"summary_hash":   HashValue(safeConceptSummary(kind, itemMap)),
+			"validity":       "observed",
+			"version_status": "unversioned",
+			"visibility":     "visible",
+			"partial_reason": []string{"schema_ref_unversioned"},
+		})
+	}
+	return refs
+}
+
+func safeConceptSummary(kind string, item map[string]any) map[string]any {
+	return map[string]any{
+		"kind":                  kind,
+		"id":                    firstString(item, "concept_id", "id"),
+		"module_type":           firstString(item, "module_type"),
+		"source_object_type_id": firstString(item, "source_object_type_id"),
+		"target_object_type_id": firstString(item, "target_object_type_id"),
+		"object_type_id":        firstString(item, "object_type_id"),
+		"score_bucket":          scoreBucket(item),
+	}
+}
+
+func asMap(value any) (map[string]any, bool) {
+	if value == nil {
+		return nil, false
+	}
+	if itemMap, ok := value.(map[string]any); ok {
+		return itemMap, true
+	}
+	raw, err := json.Marshal(value)
+	if err != nil {
+		return nil, false
+	}
+	var itemMap map[string]any
+	if err := json.Unmarshal(raw, &itemMap); err != nil {
+		return nil, false
+	}
+	return itemMap, true
+}
+
+func firstString(item map[string]any, keys ...string) string {
+	for _, key := range keys {
+		if value, ok := item[key].(string); ok && strings.TrimSpace(value) != "" {
+			return strings.TrimSpace(value)
+		}
+	}
+	return ""
+}
+
+func scoreBucket(item map[string]any) string {
+	score, ok := item["_score"].(float64)
+	if !ok {
+		score, ok = item["score"].(float64)
+	}
+	if !ok {
+		return "unknown"
+	}
+	switch {
+	case score >= 0.8:
+		return "high"
+	case score >= 0.5:
+		return "medium"
+	default:
+		return "low"
+	}
+}
+
+func resolvedKnID(req *interfaces.SearchSchemaReq) string {
+	if req == nil {
+		return ""
+	}
+	if strings.TrimSpace(req.XKnID) != "" {
+		return strings.TrimSpace(req.XKnID)
+	}
+	return strings.TrimSpace(req.KnID)
+}
+
+func maxConcepts(req *interfaces.SearchSchemaReq) int {
+	if req == nil || req.MaxConcepts == nil {
+		return 0
+	}
+	return *req.MaxConcepts
+}
+
+func boolValue(value *bool) bool {
+	return value != nil && *value
+}

--- a/adp/context-loader/agent-retrieval/server/infra/bkntrace/evidence.go
+++ b/adp/context-loader/agent-retrieval/server/infra/bkntrace/evidence.go
@@ -458,9 +458,10 @@ func queryObjectConditionHash(req *interfaces.QueryObjectInstancesReq) string {
 		return HashValue(nil)
 	}
 	return HashValue(map[string]any{
-		"condition": req.Cond,
-		"filters":   req.Filters,
-		"offset":    req.Offset,
+		"condition":    req.Cond,
+		"filters":      req.Filters,
+		"offset":       req.Offset,
+		"search_after": req.SearchAfter,
 	})
 }
 
@@ -478,10 +479,10 @@ func queryObjectTruncated(req *interfaces.QueryObjectInstancesReq, resp *interfa
 	if len(resp.SearchAfter) > 0 {
 		return true
 	}
-	if req == nil || req.Limit <= 0 {
+	if req == nil || resp.TotalCount <= 0 {
 		return false
 	}
-	return len(resp.Data) >= req.Limit
+	return int64(req.Offset+len(resp.Data)) < resp.TotalCount
 }
 
 func queryObjectKnID(req *interfaces.QueryObjectInstancesReq) string {

--- a/adp/context-loader/agent-retrieval/server/infra/bkntrace/evidence_test.go
+++ b/adp/context-loader/agent-retrieval/server/infra/bkntrace/evidence_test.go
@@ -1,0 +1,120 @@
+// Copyright openbkn.ai
+// Copyright The kweaver.ai Authors.
+//
+// Licensed under the Apache License, Version 2.0.
+// See the LICENSE file in the project root for details.
+
+package bkntrace
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/openbkn-ai/adp/context-loader/agent-retrieval/server/infra/common"
+	"github.com/openbkn-ai/adp/context-loader/agent-retrieval/server/interfaces"
+	"go.opentelemetry.io/otel/trace"
+)
+
+func testTraceContext() context.Context {
+	traceID := trace.TraceID{0x71, 0x21, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1}
+	spanID := trace.SpanID{0x71, 0x21, 0, 0, 0, 0, 0, 1}
+	spanContext := trace.NewSpanContext(trace.SpanContextConfig{
+		TraceID:    traceID,
+		SpanID:     spanID,
+		TraceFlags: trace.FlagsSampled,
+	})
+	ctx := trace.ContextWithSpanContext(context.Background(), spanContext)
+	ctx = common.SetTraceContextToCtx(ctx, common.TraceContext{
+		RequestID: "req_context_loader_phase2_0001",
+	})
+	ctx = common.SetAccountAuthContextToCtx(ctx, &interfaces.AccountAuthContext{
+		AccountID:   "acct_demo",
+		AccountType: interfaces.AccessorType("user"),
+	})
+	return ctx
+}
+
+func TestBuildSearchSchemaEventsUsesHashAndRefsOnly(t *testing.T) {
+	maxConcepts := 5
+	includeColumns := true
+	req := &interfaces.SearchSchemaReq{
+		Query:          "customer phone and complaint risk",
+		KnID:           "kn_demo",
+		MaxConcepts:    &maxConcepts,
+		IncludeColumns: &includeColumns,
+	}
+	resp := &interfaces.SearchSchemaResp{
+		ObjectTypes: []any{
+			map[string]any{
+				"concept_id":  "customer",
+				"name":        "Customer",
+				"comment":     "Contains phone fields and must not be emitted",
+				"module_type": "object_type",
+				"_score":      0.91,
+			},
+		},
+		RelationTypes: []any{
+			map[string]any{
+				"concept_id":            "customer_has_complaint",
+				"source_object_type_id": "customer",
+				"target_object_type_id": "complaint",
+				"_score":                0.73,
+			},
+		},
+		ActionTypes: []any{
+			map[string]any{
+				"id":             "notify_owner",
+				"object_type_id": "customer",
+			},
+		},
+	}
+
+	events := BuildSearchSchemaEvents(testTraceContext(), req, resp)
+	if len(events) != 2 {
+		t.Fatalf("len(events)=%d, want 2", len(events))
+	}
+	raw, err := json.Marshal(events)
+	if err != nil {
+		t.Fatalf("marshal events: %v", err)
+	}
+	text := string(raw)
+	if !strings.Contains(text, `"event_type":"claim.created"`) {
+		t.Fatalf("missing claim.created event: %s", text)
+	}
+	if !strings.Contains(text, `"event_type":"evidence.refs.created"`) {
+		t.Fatalf("missing evidence.refs.created event: %s", text)
+	}
+	for _, leaked := range []string{"customer phone and complaint risk", "Customer", "Contains phone fields"} {
+		if strings.Contains(text, leaked) {
+			t.Fatalf("event leaked raw content %q: %s", leaked, text)
+		}
+	}
+	if !strings.Contains(text, `"query_hash":"sha256:`) {
+		t.Fatalf("missing query hash: %s", text)
+	}
+	if !strings.Contains(text, `"ref_id":"object_type:customer"`) {
+		t.Fatalf("missing object type ref: %s", text)
+	}
+	if !strings.Contains(text, `"ref_id":"relation_type:customer_has_complaint"`) {
+		t.Fatalf("missing relation type ref: %s", text)
+	}
+	if !strings.Contains(text, `"ref_id":"action_type:notify_owner"`) {
+		t.Fatalf("missing action type ref: %s", text)
+	}
+}
+
+func TestBuildSearchSchemaEventsRequiresTraceContext(t *testing.T) {
+	maxConcepts := 5
+	events := BuildSearchSchemaEvents(context.Background(), &interfaces.SearchSchemaReq{
+		Query:       "schema",
+		KnID:        "kn_demo",
+		MaxConcepts: &maxConcepts,
+	}, &interfaces.SearchSchemaResp{
+		ObjectTypes: []any{map[string]any{"concept_id": "customer"}},
+	})
+	if len(events) != 0 {
+		t.Fatalf("len(events)=%d, want 0", len(events))
+	}
+}

--- a/adp/context-loader/agent-retrieval/server/infra/bkntrace/evidence_test.go
+++ b/adp/context-loader/agent-retrieval/server/infra/bkntrace/evidence_test.go
@@ -9,8 +9,12 @@ package bkntrace
 import (
 	"context"
 	"encoding/json"
+	"net/http"
+	"net/http/httptest"
 	"strings"
+	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/openbkn-ai/adp/context-loader/agent-retrieval/server/infra/common"
 	"github.com/openbkn-ai/adp/context-loader/agent-retrieval/server/interfaces"
@@ -221,4 +225,50 @@ func TestQueryObjectTruncatedUsesExplicitNextPageSignals(t *testing.T) {
 	if !queryObjectTruncated(req, hasMoreOffsetResp) {
 		t.Fatalf("truncated should be true when total_count exceeds returned offset range")
 	}
+}
+
+func TestEmitSearchSchemaEventsNoopsWhenIngestDisabled(t *testing.T) {
+	t.Setenv(envEvidenceIngestURL, "")
+	maxConcepts := 5
+
+	EmitSearchSchemaEvents(testTraceContext(), nil, &interfaces.SearchSchemaReq{
+		Query:       "schema",
+		KnID:        "kn_demo",
+		MaxConcepts: &maxConcepts,
+	}, &interfaces.SearchSchemaResp{
+		ObjectTypes: []any{map[string]any{"concept_id": "customer"}},
+	})
+}
+
+func TestSubmitEventsNoopsWhenAccountContextMissing(t *testing.T) {
+	t.Setenv(envEvidenceIngestURL, "http://127.0.0.1:1/ingest")
+	ctx := common.SetTraceContextToCtx(trace.ContextWithSpanContext(context.Background(), trace.NewSpanContext(trace.SpanContextConfig{
+		TraceID: trace.TraceID{0x71, 0x21, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 2},
+		SpanID:  trace.SpanID{0x71, 0x21, 0, 0, 0, 0, 0, 2},
+	})), common.TraceContext{RequestID: "req_context_loader_phase2_no_account"})
+
+	SubmitEvents(ctx, nil, nil, []Event{{"event_type": "claim.created"}})
+}
+
+func TestSubmitEventsHandlesServerFailureWithoutBlocking(t *testing.T) {
+	var calls atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		calls.Add(1)
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer server.Close()
+
+	t.Setenv(envEvidenceIngestURL, server.URL)
+	t.Setenv(envEvidenceIngestTimeoutMS, "500")
+
+	SubmitEvents(testTraceContext(), nil, nil, []Event{{"event_type": "claim.created"}})
+
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if calls.Load() > 0 {
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatalf("expected evidence ingestion request")
 }

--- a/adp/context-loader/agent-retrieval/server/infra/bkntrace/evidence_test.go
+++ b/adp/context-loader/agent-retrieval/server/infra/bkntrace/evidence_test.go
@@ -173,3 +173,52 @@ func TestBuildQueryObjectInstanceEventsUsesRowRefsOnly(t *testing.T) {
 		}
 	}
 }
+
+func TestQueryObjectConditionHashIncludesSearchAfter(t *testing.T) {
+	base := &interfaces.QueryObjectInstancesReq{
+		KnID:        "kn_demo",
+		OtID:        "customer",
+		Limit:       10,
+		SearchAfter: []any{"cursor_page_1"},
+	}
+	next := &interfaces.QueryObjectInstancesReq{
+		KnID:        "kn_demo",
+		OtID:        "customer",
+		Limit:       10,
+		SearchAfter: []any{"cursor_page_2"},
+	}
+
+	if queryObjectConditionHash(base) == queryObjectConditionHash(next) {
+		t.Fatalf("condition hash should differ across search_after pages")
+	}
+}
+
+func TestQueryObjectTruncatedUsesExplicitNextPageSignals(t *testing.T) {
+	req := &interfaces.QueryObjectInstancesReq{
+		Limit:  2,
+		Offset: 0,
+	}
+	lastPageResp := &interfaces.QueryObjectInstancesResp{
+		Data:       []any{map[string]any{"id": "inst_1"}, map[string]any{"id": "inst_2"}},
+		TotalCount: 2,
+	}
+	if queryObjectTruncated(req, lastPageResp) {
+		t.Fatalf("truncated should be false when total_count proves the current page is complete")
+	}
+
+	hasNextCursorResp := &interfaces.QueryObjectInstancesResp{
+		Data:        []any{map[string]any{"id": "inst_1"}},
+		SearchAfter: []any{"cursor_next"},
+	}
+	if !queryObjectTruncated(req, hasNextCursorResp) {
+		t.Fatalf("truncated should be true when search_after indicates a next page")
+	}
+
+	hasMoreOffsetResp := &interfaces.QueryObjectInstancesResp{
+		Data:       []any{map[string]any{"id": "inst_1"}, map[string]any{"id": "inst_2"}},
+		TotalCount: 3,
+	}
+	if !queryObjectTruncated(req, hasMoreOffsetResp) {
+		t.Fatalf("truncated should be true when total_count exceeds returned offset range")
+	}
+}

--- a/adp/context-loader/agent-retrieval/server/infra/bkntrace/evidence_test.go
+++ b/adp/context-loader/agent-retrieval/server/infra/bkntrace/evidence_test.go
@@ -118,3 +118,58 @@ func TestBuildSearchSchemaEventsRequiresTraceContext(t *testing.T) {
 		t.Fatalf("len(events)=%d, want 0", len(events))
 	}
 }
+
+func TestBuildQueryObjectInstanceEventsUsesRowRefsOnly(t *testing.T) {
+	req := &interfaces.QueryObjectInstancesReq{
+		KnID:  "kn_demo",
+		OtID:  "customer",
+		Limit: 10,
+		Filters: []interfaces.FlatFilter{
+			{Field: "phone", Op: interfaces.KnOperationTypeEqual, Value: "18800001111"},
+		},
+		Properties: []string{"customer_name", "phone"},
+	}
+	resp := &interfaces.QueryObjectInstancesResp{
+		Data: []any{
+			map[string]any{
+				"_instance_identity": map[string]any{"customer_id": "cust_001"},
+				"customer_name":      "Alice",
+				"phone":              "18800001111",
+			},
+		},
+		SearchAfter: []any{"cursor_001"},
+	}
+
+	events := BuildQueryObjectInstanceEvents(testTraceContext(), req, resp)
+	if len(events) != 2 {
+		t.Fatalf("len(events)=%d, want 2", len(events))
+	}
+	raw, err := json.Marshal(events)
+	if err != nil {
+		t.Fatalf("marshal events: %v", err)
+	}
+	text := string(raw)
+	if !strings.Contains(text, `"event_type":"claim.created"`) {
+		t.Fatalf("missing claim.created event: %s", text)
+	}
+	if !strings.Contains(text, `"event_type":"evidence.refs.created"`) {
+		t.Fatalf("missing evidence.refs.created event: %s", text)
+	}
+	if !strings.Contains(text, `"ref_type":"row_ref"`) {
+		t.Fatalf("missing row_ref evidence: %s", text)
+	}
+	if !strings.Contains(text, `"condition_hash":"sha256:`) {
+		t.Fatalf("missing condition hash: %s", text)
+	}
+	if !strings.Contains(text, `"properties_hash":"sha256:`) {
+		t.Fatalf("missing properties hash: %s", text)
+	}
+	if !strings.Contains(text, `"truncated":true`) {
+		t.Fatalf("missing truncation signal: %s", text)
+	}
+	for _, leaked := range []string{"18800001111", "Alice", "cust_001", "customer_name"} {
+		if strings.Contains(text, leaked) {
+			t.Fatalf("event leaked raw object query content %q: %s", leaked, text)
+		}
+	}
+}

--- a/adp/context-loader/agent-retrieval/server/logics/knsearch/search_schema.go
+++ b/adp/context-loader/agent-retrieval/server/logics/knsearch/search_schema.go
@@ -16,6 +16,7 @@ import (
 	"github.com/creasty/defaults"
 
 	"github.com/openbkn-ai/adp/context-loader/agent-retrieval/server/drivenadapters"
+	"github.com/openbkn-ai/adp/context-loader/agent-retrieval/server/infra/bkntrace"
 	aerrors "github.com/openbkn-ai/adp/context-loader/agent-retrieval/server/infra/errors"
 	"github.com/openbkn-ai/adp/context-loader/agent-retrieval/server/interfaces"
 )
@@ -42,7 +43,9 @@ func (s *knSearchService) SearchSchema(ctx context.Context, req *interfaces.Sear
 		}
 	}
 
-	return FilterSearchSchemaResp(resp, metricTypes, scope, *req.MaxConcepts), nil
+	filtered := FilterSearchSchemaResp(resp, metricTypes, scope, *req.MaxConcepts)
+	bkntrace.SubmitEvents(ctx, s.Logger, req, bkntrace.BuildSearchSchemaEvents(ctx, req, filtered))
+	return filtered, nil
 }
 
 // SearchSchemaScope holds the resolved boolean flags for output filtering.

--- a/adp/context-loader/agent-retrieval/server/logics/knsearch/search_schema.go
+++ b/adp/context-loader/agent-retrieval/server/logics/knsearch/search_schema.go
@@ -44,7 +44,7 @@ func (s *knSearchService) SearchSchema(ctx context.Context, req *interfaces.Sear
 	}
 
 	filtered := FilterSearchSchemaResp(resp, metricTypes, scope, *req.MaxConcepts)
-	bkntrace.SubmitEvents(ctx, s.Logger, req, bkntrace.BuildSearchSchemaEvents(ctx, req, filtered))
+	bkntrace.EmitSearchSchemaEvents(ctx, s.Logger, req, filtered)
 	return filtered, nil
 }
 


### PR DESCRIPTION
## Summary
- Add context-loader Phase 2 L2 evidence event helper for search_schema.
- Emit claim.created and evidence.refs.created with hash/ref/count-only payloads after successful schema search.
- Add Helm flags for optional async evidence ingestion and Phase 2 positive/negative fixtures.
- Update TRACE.md with runtime scope, safety rules, and Given-When-Then coverage.

## Verification
- env GOCACHE=/Users/leecky/openbkn/bkn-engineering/worktrees/bkn-foundry/feature-bkn-trace-context-loader-phase2/adp/context-loader/agent-retrieval/.gocache go test ./server/infra/bkntrace ./server/infra/common ./server/logics/knsearch
- python3 /Users/leecky/openbkn/bkn-docs/docs/foundry/bkn-trace/validation/validate_phase2_fixture.py fixtures/bkn-trace/phase2 --pretty
- env GOCACHE=/Users/leecky/openbkn/bkn-engineering/worktrees/bkn-foundry/feature-bkn-trace-context-loader-phase2/adp/context-loader/agent-retrieval/.gocache go test ./server/...

Note: ./server/... requires local port binding for httptest; it was rerun with sandbox escalation and passed.