### PR TITLE
feat(bkn-trace): emit context-loader object query evidence

### DIFF
--- a/adp/context-loader/agent-retrieval/TRACE.md
+++ b/adp/context-loader/agent-retrieval/TRACE.md
@@ -18,7 +18,7 @@
 | operation | trigger | required context | emitted spans | emitted events |
 | --- | --- | --- | --- | --- |
 | `context.search_schema` | schema search HTTP/MCP/tool call | `traceparent`、`bkn-request-id`、account/auth context | `context-loader.request`、`context-loader.search` | `claim.created`、`evidence.refs.created`、`context.refs.resolved` |
-| `context.query_object` | object query HTTP/MCP/tool call | `traceparent`、`bkn-request-id`、account/auth context | `context-loader.request`、`context-loader.source.resolve` | `tool.called`、`tool.failed` |
+| `context.query_object` | object query HTTP/MCP/tool call | `traceparent`、`bkn-request-id`、account/auth context | `context-loader.request`、`context-loader.source.resolve` | `claim.created`、`evidence.refs.created`、`tool.called`、`tool.failed` |
 | `context.load_refs` | source refs load | `traceparent`、`bkn-request-id`、business refs | `context-loader.source.resolve` | `context.refs.resolved` |
 | `context.resolve_source` | source resolver call | `traceparent`、`bkn-request-id`、resource refs | `context-loader.source.resolve` | `context.refs.resolved` |
 
@@ -85,7 +85,9 @@ Trust policy:
 - `context.search_schema` 在成功返回后发射一组局部 L2 事件：`claim.created` 表示“本次 schema 检索产生了一个候选上下文 finding”，`evidence.refs.created` 记录该 finding 使用的 schema/action/metric refs。
 - `claim.created.payload.claim_type` 固定为 `finding`，`claim_hash` 只基于结果数量、`kn_id`、`query_hash` 等摘要字段计算，不包含原始 query、schema 名称、comment、字段说明或完整结果。
 - `evidence.refs.created.payload.evidence_refs` 只包含 `ref_id`、`ref_type`、`source_system`、`summary_hash`、`validity`、`version_status`、`visibility`、`partial_reason`；`summary_hash` 来自安全摘要，不包含原始 schema 内容。
-- `version_status` 当前为 `unversioned`，并必须携带 `partial_reason=["schema_ref_unversioned"]`；后续接入 BKN schema version / snapshot 后才能改为 `versioned`。
+- `context.query_object` 在 REST/MCP 成功返回后发射局部 L2 事件：`claim.created` 表示“本次对象实例查询产生了一个数据 finding”，`evidence.refs.created` 记录实例级 `row_ref`；`condition`、`filters`、`properties`、实例 identity 和行内容只能进入 hash，不得原样进入 payload。
+- `context.query_object` 的 `truncated=true` 来源包括响应存在 `search_after` 或返回条数达到请求 `limit`；该信号只表示“结果可能仍有后续页”，不表示审计级完整性。
+- `version_status` 当前为 `unversioned`，schema refs 必须携带 `partial_reason=["schema_ref_unversioned"]`，row refs 必须携带 `partial_reason=["row_ref_unversioned"]`；后续接入 BKN schema version / snapshot 后才能改为 `versioned`。
 - 证据事件上报由 `BKN_TRACE_EVIDENCE_INGEST_URL` 控制，默认关闭；开启后异步提交，不阻塞 schema 检索主路径。
 - 上报失败只记录 warning，不改变业务响应；BKN Trace 核心服务负责后续 Evidence Graph 汇聚、查询、快照和 Studio 可视化。
 
@@ -134,6 +136,7 @@ Trust policy:
 | propagation | `fixtures/bkn-trace/propagation.json` | inbound/outbound request context | pass |
 | sampling | `fixtures/bkn-trace/sampling.json` | forced sampled tool error | pass |
 | phase2 positive | `fixtures/bkn-trace/phase2/search_schema_l2_positive.json` | schema search L2 finding and evidence refs | pass |
+| phase2 positive | `fixtures/bkn-trace/phase2/query_object_instance_l2_positive.json` | object query L2 finding and row refs | pass |
 | phase2 negative | `fixtures/bkn-trace/phase2/negative_raw_query_payload.json` | raw query/prompt payload rejection | fail |
 
 ## Covered GWT
@@ -148,10 +151,12 @@ Trust policy:
 - GWT-22 Given schema 检索 query 与候选结果含业务名称/comment/字段，When 生成 L2 证据事件，Then payload 只包含 hash/ref/count，不包含原始 query、完整 schema、字段说明或结果行。
 - GWT-23 Given 未配置 `BKN_TRACE_EVIDENCE_INGEST_URL`，When `search_schema` 成功执行，Then 业务响应不受影响且不上报事件。
 - GWT-24 Given Trace 后端暂时不可用，When 异步上报失败，Then 只产生 warning，不改变 `search_schema` 的响应状态。
+- GWT-25 Given 合法入站 trace/request/account context，When `query_object_instance` 成功返回对象实例，Then 模块发射 `claim.created` 和 `evidence.refs.created`，其中实例证据为 `row_ref`。
+- GWT-26 Given 对象实例查询条件、属性列表、实例 identity 或返回行包含用户数据，When 生成 L2 证据事件，Then payload 只包含 condition/properties/identity/row hash，不包含原始过滤值、属性名、实例名或行级数据。
 
 ## Known Gaps
 
-- runtime L2 emitter currently covers `context.search_schema`; `query_object_instance`、`query_instance_subgraph`、`run_sql` and resolver-level source refs remain follow-up.
+- runtime L2 emitter currently covers `context.search_schema` and `context.query_object` row refs; `query_instance_subgraph`、`run_sql` and resolver-level source refs remain follow-up.
 - cross-module global Evidence Graph assembly is owned by BKN Trace core service, not by context-loader.
 - full registry validation and indexing policy validation currently rely on `bkn-docs` validator follow-up.
 - audit-grade evidence snapshot, versioned schema refs, source data snapshot refs, and Studio visualization belong to later BKN Trace phases.

--- a/adp/context-loader/agent-retrieval/fixtures/bkn-trace/phase2/query_object_instance_l2_positive.json
+++ b/adp/context-loader/agent-retrieval/fixtures/bkn-trace/phase2/query_object_instance_l2_positive.json
@@ -1,0 +1,94 @@
+{
+  "bkn.trace.schema.version": "2.0.0",
+  "fixture_id": "context_loader_phase2_query_object_instance_l2_positive",
+  "expected_result": "pass",
+  "trace": {
+    "trace_id": "71220000000000000000000000000001",
+    "traceparent": "00-71220000000000000000000000000001-7122000000000001-01",
+    "bkn.request.id": "req_context_loader_phase2_query_object_0001",
+    "business_domain": "acct_demo",
+    "bkn.account.id": "acct_demo",
+    "bkn.account.type": "service"
+  },
+  "spans": [
+    {
+      "span_id": "7122000000000001",
+      "parent_span_id": null,
+      "name": "context-loader.source.resolve",
+      "kind": "internal",
+      "bkn.module.name": "context-loader",
+      "bkn.operation.name": "context.query_object",
+      "bkn.status": "ok",
+      "bkn.timestamp": "2026-07-23T11:00:00.000000Z"
+    }
+  ],
+  "events": [
+    {
+      "event_id": "evt_context_loader_query_object_claim",
+      "event_type": "claim.created",
+      "bkn.trace.schema.version": "2.0.0",
+      "observed_at": "2026-07-23T11:00:00.001000Z",
+      "emitted_at": "2026-07-23T11:00:00.002000Z",
+      "producer_module": "context-loader",
+      "trace_id": "71220000000000000000000000000001",
+      "span_id": "7122000000000001",
+      "bkn.request.id": "req_context_loader_phase2_query_object_0001",
+      "bkn.operation.name": "context.query_object",
+      "payload": {
+        "claim_id": "claim_context_loader_query_object_0001",
+        "claim_type": "finding",
+        "claim_hash": "sha256:query_object_summary_hash_only",
+        "visibility": "visible",
+        "version_status": "unversioned",
+        "partial_reason": ["row_refs_unversioned", "result_truncated"],
+        "subject_refs": {
+          "kn_id": "kn_demo",
+          "object_type_id": "customer",
+          "condition_hash": "sha256:condition_hash_only",
+          "properties_hash": "sha256:properties_hash_only",
+          "limit": 10,
+          "returned_ref_count": 2,
+          "truncated": true,
+          "data.classification": "internal"
+        }
+      }
+    },
+    {
+      "event_id": "evt_context_loader_query_object_refs",
+      "event_type": "evidence.refs.created",
+      "bkn.trace.schema.version": "2.0.0",
+      "observed_at": "2026-07-23T11:00:00.003000Z",
+      "emitted_at": "2026-07-23T11:00:00.004000Z",
+      "producer_module": "context-loader",
+      "trace_id": "71220000000000000000000000000001",
+      "span_id": "7122000000000001",
+      "bkn.request.id": "req_context_loader_phase2_query_object_0001",
+      "bkn.operation.name": "context.query_object",
+      "payload": {
+        "claim_id": "claim_context_loader_query_object_0001",
+        "evidence_refs": [
+          {
+            "ref_id": "object_instance:customer:instance_hash_0001",
+            "ref_type": "row_ref",
+            "source_system": "context-loader",
+            "summary_hash": "sha256:row_ref_summary_hash_only_0001",
+            "validity": "observed",
+            "version_status": "unversioned",
+            "visibility": "visible",
+            "partial_reason": ["row_ref_unversioned"]
+          },
+          {
+            "ref_id": "object_instance:customer:instance_hash_0002",
+            "ref_type": "row_ref",
+            "source_system": "context-loader",
+            "summary_hash": "sha256:row_ref_summary_hash_only_0002",
+            "validity": "observed",
+            "version_status": "unversioned",
+            "visibility": "visible",
+            "partial_reason": ["row_ref_unversioned"]
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/adp/context-loader/agent-retrieval/server/driveradapters/knqueryobjectinstance/index.go
+++ b/adp/context-loader/agent-retrieval/server/driveradapters/knqueryobjectinstance/index.go
@@ -16,6 +16,7 @@ import (
 	validator "github.com/go-playground/validator/v10"
 
 	"github.com/openbkn-ai/adp/context-loader/agent-retrieval/server/drivenadapters"
+	"github.com/openbkn-ai/adp/context-loader/agent-retrieval/server/infra/bkntrace"
 	"github.com/openbkn-ai/adp/context-loader/agent-retrieval/server/infra/config"
 	"github.com/openbkn-ai/adp/context-loader/agent-retrieval/server/infra/errors"
 	"github.com/openbkn-ai/adp/context-loader/agent-retrieval/server/infra/rest"
@@ -97,6 +98,7 @@ func (h *knQueryObjectInstanceHandler) QueryObjectInstance(c *gin.Context) {
 		rest.ReplyError(c, err)
 		return
 	}
+	bkntrace.SubmitEvents(c.Request.Context(), h.Logger, req, bkntrace.BuildQueryObjectInstanceEvents(c.Request.Context(), req, resp))
 
 	// 返回成功响应
 	rest.ReplyOK(c, http.StatusOK, resp)

--- a/adp/context-loader/agent-retrieval/server/driveradapters/mcp/tools.go
+++ b/adp/context-loader/agent-retrieval/server/driveradapters/mcp/tools.go
@@ -14,6 +14,7 @@ import (
 	validator "github.com/go-playground/validator/v10"
 	"github.com/mark3labs/mcp-go/mcp"
 
+	"github.com/openbkn-ai/adp/context-loader/agent-retrieval/server/infra/bkntrace"
 	"github.com/openbkn-ai/adp/context-loader/agent-retrieval/server/infra/common"
 	"github.com/openbkn-ai/adp/context-loader/agent-retrieval/server/infra/rest"
 	"github.com/openbkn-ai/adp/context-loader/agent-retrieval/server/interfaces"
@@ -108,6 +109,7 @@ func handleQueryObjectInstance(ontologyQuery interfaces.DrivenOntologyQuery) fun
 		if err != nil {
 			return mcp.NewToolResultError(err.Error()), nil
 		}
+		bkntrace.SubmitEvents(ctx, nil, queryReq, bkntrace.BuildQueryObjectInstanceEvents(ctx, queryReq, resp))
 		resp.ObjectConcept = nil
 		result, err := BuildMCPToolResult(resp, format)
 		if err != nil {

--- a/adp/context-loader/agent-retrieval/server/infra/bkntrace/evidence.go
+++ b/adp/context-loader/agent-retrieval/server/infra/bkntrace/evidence.go
@@ -114,7 +114,57 @@ func BuildSearchSchemaEvents(ctx context.Context, req *interfaces.SearchSchemaRe
 	}
 }
 
-func SubmitEvents(ctx context.Context, logger interfaces.Logger, req *interfaces.SearchSchemaReq, events []Event) {
+func BuildQueryObjectInstanceEvents(ctx context.Context, req *interfaces.QueryObjectInstancesReq, resp *interfaces.QueryObjectInstancesResp) []Event {
+	ec, ok := contextFromRequest(ctx, nil)
+	if !ok {
+		return nil
+	}
+	refs := objectInstanceEvidenceRefs(req, resp)
+	if len(refs) == 0 {
+		return nil
+	}
+
+	resultSummary := map[string]any{
+		"kn_id":          queryObjectKnID(req),
+		"object_type_id": queryObjectTypeID(req),
+		"condition_hash": queryObjectConditionHash(req),
+		"result_count":   len(resp.Data),
+		"truncated":      queryObjectTruncated(req, resp),
+	}
+	claimID := ClaimID("context_loader.query_object_instance", queryObjectTypeID(req), resultSummary)
+
+	partialReason := []string{"row_refs_unversioned"}
+	if queryObjectTruncated(req, resp) {
+		partialReason = append(partialReason, "result_truncated")
+	}
+
+	return []Event{
+		buildEvent(ec, "claim.created", "context.query_object", map[string]any{
+			"claim_id":       claimID,
+			"claim_type":     "finding",
+			"claim_hash":     HashValue(resultSummary),
+			"visibility":     "visible",
+			"version_status": "unversioned",
+			"partial_reason": partialReason,
+			"subject_refs": map[string]any{
+				"kn_id":               queryObjectKnID(req),
+				"object_type_id":      queryObjectTypeID(req),
+				"condition_hash":      resultSummary["condition_hash"],
+				"properties_hash":     queryObjectPropertiesHash(req),
+				"limit":               queryObjectLimit(req),
+				"returned_ref_count":  len(refs),
+				"truncated":           queryObjectTruncated(req, resp),
+				"data.classification": "internal",
+			},
+		}),
+		buildEvent(ec, "evidence.refs.created", "context.query_object", map[string]any{
+			"claim_id":      claimID,
+			"evidence_refs": refs,
+		}),
+	}
+}
+
+func SubmitEvents(ctx context.Context, logger interfaces.Logger, req any, events []Event) {
 	if len(events) == 0 {
 		return
 	}
@@ -182,7 +232,7 @@ func evidenceTimeout() time.Duration {
 	return time.Duration(ms) * time.Millisecond
 }
 
-func contextFromRequest(ctx context.Context, req *interfaces.SearchSchemaReq) (eventContext, bool) {
+func contextFromRequest(ctx context.Context, req any) (eventContext, bool) {
 	spanContext := trace.SpanContextFromContext(ctx)
 	if !spanContext.IsValid() {
 		return eventContext{}, false
@@ -198,12 +248,12 @@ func contextFromRequest(ctx context.Context, req *interfaces.SearchSchemaReq) (e
 		accountID = strings.TrimSpace(authContext.AccountID)
 		accountType = strings.TrimSpace(string(authContext.AccountType))
 	}
-	if req != nil {
+	if schemaReq, ok := req.(*interfaces.SearchSchemaReq); ok && schemaReq != nil {
 		if accountID == "" {
-			accountID = strings.TrimSpace(req.XAccountID)
+			accountID = strings.TrimSpace(schemaReq.XAccountID)
 		}
 		if accountType == "" {
-			accountType = strings.TrimSpace(req.XAccountType)
+			accountType = strings.TrimSpace(schemaReq.XAccountType)
 		}
 	}
 	flags := "00"
@@ -362,4 +412,103 @@ func maxConcepts(req *interfaces.SearchSchemaReq) int {
 
 func boolValue(value *bool) bool {
 	return value != nil && *value
+}
+
+func objectInstanceEvidenceRefs(req *interfaces.QueryObjectInstancesReq, resp *interfaces.QueryObjectInstancesResp) []map[string]any {
+	if req == nil || resp == nil || len(resp.Data) == 0 {
+		return nil
+	}
+	refs := make([]map[string]any, 0, len(resp.Data))
+	for index, item := range resp.Data {
+		identity, ok := objectInstanceIdentity(item)
+		if !ok {
+			identity = map[string]any{
+				"row_index": index,
+				"row_hash":  HashValue(item),
+			}
+		}
+		refs = append(refs, map[string]any{
+			"ref_id":         "object_instance:" + queryObjectTypeID(req) + ":" + hashSuffix(identity),
+			"ref_type":       "row_ref",
+			"source_system":  ModuleName,
+			"summary_hash":   HashValue(map[string]any{"identity_hash": HashValue(identity), "object_type_id": queryObjectTypeID(req)}),
+			"validity":       "observed",
+			"version_status": "unversioned",
+			"visibility":     "visible",
+			"partial_reason": []string{"row_ref_unversioned"},
+		})
+	}
+	return refs
+}
+
+func objectInstanceIdentity(item any) (map[string]any, bool) {
+	itemMap, ok := asMap(item)
+	if !ok {
+		return nil, false
+	}
+	identity, ok := itemMap["_instance_identity"]
+	if !ok {
+		return nil, false
+	}
+	return asMap(identity)
+}
+
+func queryObjectConditionHash(req *interfaces.QueryObjectInstancesReq) string {
+	if req == nil {
+		return HashValue(nil)
+	}
+	return HashValue(map[string]any{
+		"condition": req.Cond,
+		"filters":   req.Filters,
+		"offset":    req.Offset,
+	})
+}
+
+func queryObjectPropertiesHash(req *interfaces.QueryObjectInstancesReq) string {
+	if req == nil {
+		return HashValue(nil)
+	}
+	return HashValue(req.Properties)
+}
+
+func queryObjectTruncated(req *interfaces.QueryObjectInstancesReq, resp *interfaces.QueryObjectInstancesResp) bool {
+	if resp == nil {
+		return false
+	}
+	if len(resp.SearchAfter) > 0 {
+		return true
+	}
+	if req == nil || req.Limit <= 0 {
+		return false
+	}
+	return len(resp.Data) >= req.Limit
+}
+
+func queryObjectKnID(req *interfaces.QueryObjectInstancesReq) string {
+	if req == nil {
+		return ""
+	}
+	return strings.TrimSpace(req.KnID)
+}
+
+func queryObjectTypeID(req *interfaces.QueryObjectInstancesReq) string {
+	if req == nil {
+		return ""
+	}
+	return strings.TrimSpace(req.OtID)
+}
+
+func queryObjectLimit(req *interfaces.QueryObjectInstancesReq) int {
+	if req == nil {
+		return 0
+	}
+	return req.Limit
+}
+
+func hashSuffix(value any) string {
+	hash := strings.TrimPrefix(HashValue(value), "sha256:")
+	if len(hash) > 24 {
+		return hash[:24]
+	}
+	return hash
 }

--- a/adp/context-loader/agent-retrieval/server/infra/bkntrace/evidence_test.go
+++ b/adp/context-loader/agent-retrieval/server/infra/bkntrace/evidence_test.go
@@ -118,3 +118,58 @@ func TestBuildSearchSchemaEventsRequiresTraceContext(t *testing.T) {
 		t.Fatalf("len(events)=%d, want 0", len(events))
 	}
 }
+
+func TestBuildQueryObjectInstanceEventsUsesRowRefsOnly(t *testing.T) {
+	req := &interfaces.QueryObjectInstancesReq{
+		KnID:  "kn_demo",
+		OtID:  "customer",
+		Limit: 10,
+		Filters: []interfaces.FlatFilter{
+			{Field: "phone", Op: interfaces.KnOperationTypeEqual, Value: "18800001111"},
+		},
+		Properties: []string{"customer_name", "phone"},
+	}
+	resp := &interfaces.QueryObjectInstancesResp{
+		Data: []any{
+			map[string]any{
+				"_instance_identity": map[string]any{"customer_id": "cust_001"},
+				"customer_name":      "Alice",
+				"phone":              "18800001111",
+			},
+		},
+		SearchAfter: []any{"cursor_001"},
+	}
+
+	events := BuildQueryObjectInstanceEvents(testTraceContext(), req, resp)
+	if len(events) != 2 {
+		t.Fatalf("len(events)=%d, want 2", len(events))
+	}
+	raw, err := json.Marshal(events)
+	if err != nil {
+		t.Fatalf("marshal events: %v", err)
+	}
+	text := string(raw)
+	if !strings.Contains(text, `"event_type":"claim.created"`) {
+		t.Fatalf("missing claim.created event: %s", text)
+	}
+	if !strings.Contains(text, `"event_type":"evidence.refs.created"`) {
+		t.Fatalf("missing evidence.refs.created event: %s", text)
+	}
+	if !strings.Contains(text, `"ref_type":"row_ref"`) {
+		t.Fatalf("missing row_ref evidence: %s", text)
+	}
+	if !strings.Contains(text, `"condition_hash":"sha256:`) {
+		t.Fatalf("missing condition hash: %s", text)
+	}
+	if !strings.Contains(text, `"properties_hash":"sha256:`) {
+		t.Fatalf("missing properties hash: %s", text)
+	}
+	if !strings.Contains(text, `"truncated":true`) {
+		t.Fatalf("missing truncation signal: %s", text)
+	}
+	for _, leaked := range []string{"18800001111", "Alice", "cust_001", "customer_name"} {
+		if strings.Contains(text, leaked) {
+			t.Fatalf("event leaked raw object query content %q: %s", leaked, text)
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- Add context-loader Phase 2 L2 evidence events for query_object_instance.
- Emit claim.created and evidence.refs.created with row_ref evidence after successful REST/MCP object instance queries.
- Keep condition, filters, properties, instance identity, and row content hash/ref-only; no raw row or filter values in event payload.
- Add Phase 2 positive fixture and update TRACE.md GWT coverage.

## Stacked PR
- Base is feature/bkn-trace-context-loader-phase2 from openbkn-ai/bkn-foundry#387.
- After #387 merges, this PR can be retargeted to main.

## Verification
- Red test observed first: BuildQueryObjectInstanceEvents was undefined.
- env GOCACHE=/Users/leecky/openbkn/bkn-engineering/worktrees/bkn-foundry/feature-bkn-trace-context-loader-query-object-phase2/adp/context-loader/agent-retrieval/.gocache go test ./server/infra/bkntrace ./server/driveradapters/knqueryobjectinstance ./server/driveradapters/mcp
- python3 /Users/leecky/openbkn/bkn-docs/docs/foundry/bkn-trace/validation/validate_phase2_fixture.py fixtures/bkn-trace/phase2 --pretty
- env GOCACHE=/Users/leecky/openbkn/bkn-engineering/worktrees/bkn-foundry/feature-bkn-trace-context-loader-query-object-phase2/adp/context-loader/agent-retrieval/.gocache go test ./server/...

Note: ./server/... requires local port binding for httptest; it was run with sandbox escalation and passed.