### PR TITLE
fix(deploy): 仅在首次安装时显示 bkn-safe 初始密码

### DIFF
--- a/deploy/scripts/services/core.sh
+++ b/deploy/scripts/services/core.sh
@@ -742,6 +742,11 @@ install_core() {
 
     log_info "Target namespace: ${namespace}"
 
+    local bkn_safe_existed_before_install="false"
+    if _core_release_exists "bkn-safe" "${namespace}"; then
+        bkn_safe_existed_before_install="true"
+    fi
+
     if ! init_core_databases; then
         log_error "Failed to initialize BKN Foundry databases"
         return 1
@@ -792,10 +797,10 @@ install_core() {
     # Platform account credentials (NOT database passwords): the console admin
     # initial password, which is also the initial password handed to users
     # created without an explicit one. Highlighted — it is the one thing the
-    # operator must take away from this summary.
+    # operator must take away from this summary, but only on the first install.
     local _initial_pwd
     _initial_pwd="$(config_yaml_top_field bknSafe initialPassword)"
-    if [[ -n "${_initial_pwd}" ]]; then
+    if _core_should_show_bkn_safe_initial_password "${bkn_safe_existed_before_install}" "${_initial_pwd}"; then
         echo ""
         echo "  Console sign-in (a password change is forced on first login):"
         echo ""
@@ -834,6 +839,15 @@ _core_release_exists() {
     local release="$1"
     local ns="$2"
     helm status "${release}" -n "${ns}" >/dev/null 2>&1
+}
+
+# Decide whether the bkn-safe initial password should be shown in the install
+# summary. Only a fresh install should reveal it; upgrades/retries stay quiet
+# even if config.yaml still carries bknSafe.initialPassword.
+_core_should_show_bkn_safe_initial_password() {
+    local release_existed_before_install="$1"
+    local initial_password="$2"
+    [[ "${release_existed_before_install}" != "true" && -n "${initial_password}" ]]
 }
 
 # 逐条退役 _CORE_RETIRED_RELEASES 中仍存在的 release。

--- a/deploy/scripts/services/core_initial_password_test.sh
+++ b/deploy/scripts/services/core_initial_password_test.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+# _core_should_show_bkn_safe_initial_password 的行为测试（无需集群）。
+set -uo pipefail
+
+ONE_FAILED=0
+PASS=0
+fail() { echo "FAIL: $*"; ONE_FAILED=1; }
+ok() { PASS=$((PASS + 1)); }
+check() {
+    if [[ "$2" == "$3" ]]; then ok; else fail "$1: got[$2] want[$3]"; fi
+}
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+
+# shellcheck source=../services/core.sh
+source "${SCRIPT_DIR}/scripts/services/core.sh"
+
+run_case() {
+    local name="$1"
+    local existed_before="$2"
+    local initial_pwd="$3"
+    local want_rc="$4"
+
+    if _core_should_show_bkn_safe_initial_password "${existed_before}" "${initial_pwd}"; then
+        check "${name}" "0" "${want_rc}"
+    else
+        check "${name}" "1" "${want_rc}"
+    fi
+}
+
+# fresh install + password recorded => show it once
+run_case "fresh-install-shows" "false" "abc123" "0"
+
+# upgrade + password recorded => never show
+run_case "upgrade-hides" "true" "abc123" "1"
+
+# fresh install + empty password => nothing to show
+run_case "fresh-install-empty-hides" "false" "" "1"
+
+# upgrade + empty password => nothing to show
+run_case "upgrade-empty-hides" "true" "" "1"
+
+if [[ "${ONE_FAILED}" -eq 0 ]]; then
+    echo "core_initial_password_test: all ${PASS} checks passed"
+    exit 0
+fi
+echo "core_initial_password_test: FAILED"
+exit 1


### PR DESCRIPTION
# Pull Request

## What Changed

变更说明：

- [x] `deploy/scripts/services/core.sh`：增加“仅首次安装展示 bkn-safe 初始密码”的判断逻辑
- [x] `deploy/scripts/services/core.sh`：在安装完成摘要中，仅当 `bkn-safe` 在安装前不存在时才输出初始密码
- [x] `deploy/scripts/services/core_initial_password_test.sh`：新增 shell 测试，覆盖首次安装/升级下的展示行为
- [ ] 文档更新

---

## Why

- Related Issue: 无
- Related Feature: 无
- Background:
  之前 `bkn-safe` 的初始密码只要存在于 `config.yaml`，安装完成摘要就可能再次打印。这样在升级场景下会重复暴露一次性初始密码，不符合预期。
  现在按“首次安装展示一次，后续升级不再显示”的规则收敛输出行为，避免重复回显敏感信息。

---

## How

- Key implementation points:
  - 在 `install_core` 开始时先检测 `bkn-safe` release 是否已经存在
  - 新增 `_core_should_show_bkn_safe_initial_password` helper，统一判断是否允许展示初始密码
  - 安装完成摘要只在 fresh install 场景输出 `admin` 初始密码
  - 新增脚本级测试，覆盖：
    - 首次安装 + 有密码 => 显示
    - 升级 + 有密码 => 不显示
    - 首次安装 + 空密码 => 不显示
    - 升级 + 空密码 => 不显示
- Breaking changes (API, config, database, etc.):
  - 无
  - 仅调整部署摘要的输出行为，不改变密码生成、存储或认证逻辑

---

## Testing

- [x] Unit tests passed locally
- [ ] Integration tests passed locally
- [ ] Verified in test environment

Test notes:

- `bash -n deploy/scripts/services/core.sh deploy/scripts/services/core_initial_password_test.sh`
- `bash deploy/scripts/services/core_initial_password_test.sh`

---

## Risk & Rollback

- Potential risks:
  - 安装摘要不再在升级场景中回显初始密码，可能让依赖旧行为的人工流程需要调整
- Rollback plan:
  - 回退 `deploy/scripts/services/core.sh` 中的摘要判断逻辑即可恢复原行为
  - 测试脚本可一并移除或保留，不影响运行时逻辑

---

## Additional Notes

- Screenshots, logs, documentation links, etc.:
  - 本次修改仅影响 `deploy` 安装摘要的输出，不影响 `bkn-safe` 的初始化、升级或用户认证流程