### PR TITLE
feat(ee): EE 代码线基建——core 扩展点插座 + 模块路径规范化 + CI 禁 ee import (#277)

### DIFF
--- a/.github/workflows/lint-no-ee-import.yml
+++ b/.github/workflows/lint-no-ee-import.yml
@@ -4,7 +4,7 @@ name: lint-no-ee-import
 # ee -> core. This repository is the core and must never reference the private
 # enterprise repository.
 #
-# One `import "github.com/openbkn-ai/bkn-foundry-ee/..."` anywhere here and the
+# One `import "github.com/openbkn-ai/openbkn-ee/..."` anywhere here and the
 # public repo stops building for anyone without access to the private one —
 # which is every open source user. It is a fully broken build disguised as a
 # green one, because the machine that introduced it has the credentials.
@@ -37,7 +37,7 @@ jobs:
           # Match the module path anywhere in Go source or module files. Scoped
           # to the paths Go actually resolves, so documentation and design notes
           # may still name the repository.
-          hits=$(grep -rn 'openbkn-ai/bkn-foundry-ee' \
+          hits=$(grep -rn 'openbkn-ai/openbkn-ee' \
                    --include='*.go' --include='go.mod' --include='go.sum' \
                    . || true)
 
@@ -46,7 +46,7 @@ jobs:
             echo "$hits"
             echo
             echo "Fix: invert the dependency. Add an interface and a Register hook in"
-            echo "bkn-safe/server/extension (the socket), and implement it in bkn-foundry-ee."
+            echo "bkn-safe/server/extension (the socket), and implement it in openbkn-ee."
             exit 1
           fi
           echo "No enterprise references in core."

--- a/.github/workflows/lint-no-ee-import.yml
+++ b/.github/workflows/lint-no-ee-import.yml
@@ -1,0 +1,60 @@
+name: lint-no-ee-import
+
+# The open-core model's single hard invariant: dependency direction is one-way,
+# ee -> core. This repository is the core and must never reference the private
+# enterprise repository.
+#
+# One `import "github.com/openbkn-ai/bkn-foundry-ee/..."` anywhere here and the
+# public repo stops building for anyone without access to the private one —
+# which is every open source user. It is a fully broken build disguised as a
+# green one, because the machine that introduced it has the credentials.
+#
+# Design: license-server docs/design/open-core-gating.md §2.5 (铁律) and §3
+# discipline 5 ("纪律上 CI,不靠人记").
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+concurrency:
+  group: lint-no-ee-import-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  no-ee-import:
+    name: core must not reference ee
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Scan for enterprise imports
+        run: |
+          set -u
+          # Match the module path anywhere in Go source or module files. Scoped
+          # to the paths Go actually resolves, so documentation and design notes
+          # may still name the repository.
+          hits=$(grep -rn 'openbkn-ai/bkn-foundry-ee' \
+                   --include='*.go' --include='go.mod' --include='go.sum' \
+                   . || true)
+
+          if [ -n "$hits" ]; then
+            echo "::error::core references the private enterprise repository. The open source build would break for everyone without access to it."
+            echo "$hits"
+            echo
+            echo "Fix: invert the dependency. Add an interface and a Register hook in"
+            echo "bkn-safe/server/extension (the socket), and implement it in bkn-foundry-ee."
+            exit 1
+          fi
+          echo "No enterprise references in core."
+
+      - name: Core builds without any enterprise module
+        run: |
+          set -u
+          # The lint above is textual; this is the real proof. A community
+          # checkout with no access to the private repo must build.
+          cd bkn-safe/server
+          GOFLAGS=-mod=mod GOPRIVATE= GONOSUMDB= go build ./...

--- a/bkn-safe/server/app/app.go
+++ b/bkn-safe/server/app/app.go
@@ -4,8 +4,9 @@
 
 // Package app is bkn-safe's bootstrap, split out of package main so that a
 // second entry point can reuse it. The community binary (bkn-safe/server) and
-// the enterprise binary (bkn-foundry-ee cmd/bkn-safe-ee) run byte-identical
-// startup logic; they differ only in what happens between Boot and Run.
+// the enterprise binary (openbkn-ee bkn-safe/cmd/bkn-safe-ee) run
+// byte-identical startup logic; they differ only in what happens between Boot
+// and Run.
 //
 //	// community
 //	a, err := app.Boot(app.Options{})

--- a/bkn-safe/server/app/app.go
+++ b/bkn-safe/server/app/app.go
@@ -1,0 +1,170 @@
+// Copyright openbkn.ai
+//
+// Licensed under the OpenBKN License. See LICENSE-OPENBKN.txt in the project root.
+
+// Package app is bkn-safe's bootstrap, split out of package main so that a
+// second entry point can reuse it. The community binary (bkn-safe/server) and
+// the enterprise binary (bkn-foundry-ee cmd/bkn-safe-ee) run byte-identical
+// startup logic; they differ only in what happens between Boot and Run.
+//
+//	// community
+//	a, err := app.Boot(app.Options{})
+//	a.Run()
+//
+//	// enterprise
+//	a, err := app.Boot(app.Options{})
+//	eepermobject.Setup(a.DB())   // registers only if the license says so
+//	a.Run()
+//
+// Boot installs the license gate; Run freezes the extension registry and
+// serves. Everything an extension needs to assemble itself therefore exists
+// between the two calls, and nothing can register once requests start flowing.
+//
+// Design: license-server docs/design/open-core-gating.md §2.5.
+package app
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"os"
+
+	"gorm.io/gorm"
+
+	"github.com/openbkn-ai/bkn-foundry/bkn-safe/server/config"
+	"github.com/openbkn-ai/bkn-foundry/bkn-safe/server/extension"
+	"github.com/openbkn-ai/bkn-foundry/bkn-safe/server/internal/audit"
+	"github.com/openbkn-ai/bkn-foundry/bkn-safe/server/internal/auth"
+	"github.com/openbkn-ai/bkn-foundry/bkn-safe/server/internal/authz"
+	"github.com/openbkn-ai/bkn-foundry/bkn-safe/server/internal/database"
+	"github.com/openbkn-ai/bkn-foundry/bkn-safe/server/internal/directory"
+	"github.com/openbkn-ai/bkn-foundry/bkn-safe/server/internal/httpapi"
+	"github.com/openbkn-ai/bkn-foundry/bkn-safe/server/internal/license"
+	"github.com/openbkn-ai/bkn-foundry/bkn-safe/server/internal/seed"
+)
+
+// Options configures Boot. The zero value is what the community entry point
+// uses.
+type Options struct {
+	// ConfigPath is an explicit YAML config file. Empty means the usual
+	// resolution order (defaults, then SAFE_CONFIG).
+	ConfigPath string
+}
+
+// App is a booted, not-yet-serving bkn-safe.
+type App struct {
+	cfg      *config.Config
+	db       *gorm.DB
+	enforcer *authz.Enforcer
+	deps     httpapi.Deps
+	licSvc   *license.Service
+}
+
+// Boot brings up config, database, authz, the license hub, and the license
+// gate — everything except the extension freeze and the listener.
+//
+// Licensing never blocks the auth service: if the license hub cannot start
+// (typically no resolvable instance fingerprint), bkn-safe runs without the
+// license surface and every paid feature stays off. Community capability is
+// unaffected, because it is not gated.
+func Boot(opts Options) (*App, error) {
+	cfg, err := config.LoadWithOptions(config.LoadOptions{ConfigPath: opts.ConfigPath})
+	if err != nil {
+		return nil, fmt.Errorf("load config: %w", err)
+	}
+	if path := opts.ConfigPath; path != "" {
+		slog.Info("config loaded", "file", path)
+	} else if path := os.Getenv("SAFE_CONFIG"); path != "" {
+		slog.Info("config loaded", "file", path)
+	}
+
+	db, err := database.Open(cfg.DB)
+	if err != nil {
+		return nil, fmt.Errorf("open database: %w", err)
+	}
+	if err := database.Migrate(db); err != nil {
+		return nil, fmt.Errorf("migrate: %w", err)
+	}
+
+	enforcer, err := authz.New(db)
+	if err != nil {
+		return nil, fmt.Errorf("init authz: %w", err)
+	}
+
+	if cfg.SeedOnStart {
+		if err := seed.Apply(db, enforcer); err != nil {
+			return nil, fmt.Errorf("seed: %w", err)
+		}
+		slog.Info("seed applied (roles + catalog + grants)")
+	}
+
+	userStore := auth.NewUserStore(db)
+	hydraAdmin := auth.NewHydraAdmin(cfg.Hydra.AdminURL)
+
+	// Authenticator: local bcrypt store, plus LDAP federation when configured
+	// (local first, then LDAP).
+	var authenticator auth.Authenticator = userStore
+	if cfg.LDAP.Enabled() {
+		authenticator = auth.NewChain(userStore, auth.NewLDAPAuthenticator(cfg.LDAP, db))
+		slog.Info("LDAP federation enabled", "url", cfg.LDAP.URL)
+	}
+	provider := auth.NewProvider(authenticator, hydraAdmin, userStore)
+	dir := directory.New(db)
+	auditStore := audit.New(db)
+
+	// Cluster license hub: hold the one .lic, be the only egress to the
+	// license-server, distribute to modules.
+	licSvc, err := license.New(db, cfg.License, auditStore)
+	if err != nil {
+		slog.Error("license hub disabled", "err", err)
+		licSvc = nil
+	} else {
+		go licSvc.Run(context.Background())
+		slog.Info("license hub enabled", "instance_fp", licSvc.Fingerprint(), "server_url", cfg.License.ServerURL)
+	}
+
+	// The gate has to be in place before any extension checks its own license.
+	// With no license hub the registry keeps its deny-everything zero value.
+	if licSvc != nil {
+		extension.SetGate(extension.GateFunc(func(f extension.Feature) bool {
+			return licSvc.FeatureEnabled(string(f))
+		}))
+	}
+
+	return &App{
+		cfg:      cfg,
+		db:       db,
+		enforcer: enforcer,
+		licSvc:   licSvc,
+		deps: httpapi.Deps{
+			Enforcer:  enforcer,
+			DB:        db,
+			Provider:  provider,
+			Hydra:     hydraAdmin,
+			Directory: dir,
+			Users:     userStore,
+			Audit:     auditStore,
+			License:   licSvc,
+		},
+	}, nil
+}
+
+// DB is the shared database handle. An enterprise extension stores its own
+// tables here — subject to the migration discipline that keeps the upgrade
+// path intact: ee migrations only add tables and columns, and never alter or
+// drop anything core owns (open-core-gating §2.6 constraint 1, enforced by CI).
+func (a *App) DB() *gorm.DB { return a.db }
+
+// Addr is the configured listen address.
+func (a *App) Addr() string { return a.cfg.HTTPAddr }
+
+// Run closes the extension registry and serves until the listener fails.
+// Registering an extension after this point panics, by design.
+func (a *App) Run() error {
+	extension.Freeze()
+	slog.Info("extensions assembled", "registered", extension.Registered(), "assembly", extension.Assembly())
+
+	r := httpapi.New(a.deps)
+	slog.Info("bkn-safe listening", "addr", a.cfg.HTTPAddr)
+	return r.Run(a.cfg.HTTPAddr)
+}

--- a/bkn-safe/server/config/config_test.go
+++ b/bkn-safe/server/config/config_test.go
@@ -9,7 +9,7 @@ import (
 	"path/filepath"
 	"testing"
 
-	"bkn-safe/config"
+	"github.com/openbkn-ai/bkn-foundry/bkn-safe/server/config"
 )
 
 func TestLoadFromFile(t *testing.T) {

--- a/bkn-safe/server/extension/adminwrite/adminwrite.go
+++ b/bkn-safe/server/extension/adminwrite/adminwrite.go
@@ -1,0 +1,146 @@
+// Copyright openbkn.ai
+//
+// Licensed under the OpenBKN License. See LICENSE-OPENBKN.txt in the project root.
+
+// Package adminwrite is the socket for rbac_basic — custom role, department and
+// permission management, the sample Professional capability.
+//
+// It is the route-registration half of the open-core split (open-core-gating
+// §2.5, #278 core decision one): the community binary serves only the read
+// routes and never mounts the write routes at all, so a probe of
+// POST /admin/roles in a community build gets 404 — the endpoint does not
+// exist, rather than existing-but-refusing. The enterprise binary mounts the
+// write routes in its Setup, behind RequireFeature("rbac_basic").
+//
+// Why a typed Services surface instead of moving the raw handlers: the write
+// handlers carry security invariants — a custom role is forced to source
+// "custom", a wildcard grant is refused, the admin-console capability can never
+// be handed out through a role permission. Those guards belong in core, next to
+// the engine, so they hold no matter what the ee HTTP layer does. ee owns only
+// the HTTP shape (JSON binding, status mapping); the guarded operations live
+// behind this interface, which core implements over its internal packages. ee
+// never imports core's internal/.
+//
+// The returned errors are typed so the ee layer maps them to status codes
+// without duplicating the rules that produced them.
+package adminwrite
+
+import (
+	"context"
+	"errors"
+
+	"github.com/gin-gonic/gin"
+)
+
+// Sentinel errors returned by Services. ee maps these to HTTP status; anything
+// else is a 500.
+var (
+	// ErrNotFound: the target role/department does not exist.
+	ErrNotFound = errors.New("adminwrite: not found")
+	// ErrImmutable: the target is a built-in (seed-owned) object and cannot be
+	// modified through the API.
+	ErrImmutable = errors.New("adminwrite: built-in object is immutable")
+	// ErrInvalid: the request is malformed against a guard (wildcard grant,
+	// empty patch). Maps to 400. The wrapped message is safe to surface.
+	ErrInvalid = errors.New("adminwrite: invalid request")
+	// ErrForbidden: the request is well-formed but refused by a security guard
+	// (e.g. granting the admin-console capability through a role permission,
+	// which would turn this route into an admin-promotion path). Maps to 403.
+	ErrForbidden = errors.New("adminwrite: forbidden")
+)
+
+// RoleSpec creates a custom role. Source is always forced to "custom" by the
+// implementation; the API cannot mint system or business roles.
+type RoleSpec struct {
+	ID          string // optional; generated when empty
+	Name        string
+	Description string
+}
+
+// RolePatch updates a custom role. Nil fields are left unchanged; a patch with
+// no fields set is ErrInvalid.
+type RolePatch struct {
+	Name        *string
+	Description *string
+}
+
+// Services is the narrow set of guarded core operations the ee write handlers
+// call. Core implements it over internal/authz + internal/database; the guards
+// (source=custom, built-in immutable, wildcard/admin-console refusal) live in
+// that implementation, not in ee.
+type Services interface {
+	// RequirePermission returns core's RBAC middleware for a resource/op, so ee
+	// write routes keep the same per-caller permission checks community reads
+	// use. This is the RBAC layer; the license layer (RequireFeature) is ee's.
+	RequirePermission(resourceType, op string) gin.HandlerFunc
+
+	// CreateRole creates a custom role and returns its id.
+	CreateRole(ctx context.Context, spec RoleSpec) (id string, err error)
+	// UpdateRole renames/re-describes a custom role. ErrImmutable for built-ins.
+	UpdateRole(ctx context.Context, id string, patch RolePatch) error
+	// DeleteRole deletes a custom role and purges its bindings and grants.
+	DeleteRole(ctx context.Context, id string) error
+	// GrantRolePermission grants a custom role an op over a resource pattern.
+	// Refuses wildcard types/ops and the admin-console capability (ErrInvalid).
+	GrantRolePermission(ctx context.Context, roleID, resourceType, resourceID, op string) error
+	// RevokeRolePermission revokes a custom role's op over a resource pattern.
+	RevokeRolePermission(ctx context.Context, roleID, resourceType, resourceID, op string) error
+}
+
+// Mounter registers the rbac_basic write routes onto g using svc. The ee build
+// provides one; the community build leaves it nil, so the routes never exist.
+type Mounter func(g *gin.RouterGroup, svc Services)
+
+var mounter Mounter
+
+// RegisterMounter installs the write-route mounter. The ee assembly calls it
+// once, before Freeze. A second call, or a call after the socket is frozen,
+// panics — both are assembly bugs (see extension.Claim for the same rule on the
+// capability sockets).
+//
+// It is intentionally not license-checked here: ee gates each route with
+// RequireFeature inside the mounter, so a professional-only cluster still
+// mounts the routes and lets RequireFeature refuse the enterprise ones. The
+// community binary simply never calls this.
+func RegisterMounter(m Mounter) {
+	if m == nil {
+		panic("adminwrite: RegisterMounter(nil)")
+	}
+	if frozen {
+		panic("adminwrite: RegisterMounter after Freeze — write routes must be assembled before the server runs")
+	}
+	if mounter != nil {
+		panic("adminwrite: mounter already registered")
+	}
+	mounter = m
+}
+
+var frozen bool
+
+// Freeze closes the socket. Call once, after assembly. The router's Mount is
+// the natural freeze point.
+func Freeze() { frozen = true }
+
+// Mount registers the write routes if an ee mounter is present, and freezes the
+// socket. In a community build no mounter was registered, so this is a no-op
+// and the write routes stay absent (404). Returns whether routes were mounted,
+// for the startup log.
+func Mount(g *gin.RouterGroup, svc Services) bool {
+	frozen = true
+	if mounter == nil {
+		return false
+	}
+	mounter(g, svc)
+	return true
+}
+
+// Mounted reports whether an ee write-route mounter is present. For tests and
+// startup logging.
+func Mounted() bool { return mounter != nil }
+
+// resetForTest clears the socket. Tests only; guarded by testing.Testing in
+// the exported wrapper.
+func resetForTest() {
+	mounter = nil
+	frozen = false
+}

--- a/bkn-safe/server/extension/adminwrite/routes.go
+++ b/bkn-safe/server/extension/adminwrite/routes.go
@@ -1,0 +1,152 @@
+// Copyright openbkn.ai
+//
+// Licensed under the OpenBKN License. See LICENSE-OPENBKN.txt in the project root.
+
+package adminwrite
+
+import (
+	"errors"
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+)
+
+// Routes mounts the rbac_basic write endpoints onto g, each behind core's RBAC
+// permission check (via svc.RequirePermission). It is a Mounter — the ee build
+// wraps it with a RequireFeature("rbac_basic") group so the license layer sits
+// in front; the community build never registers any mounter, so these routes do
+// not exist there (404).
+//
+// The handlers are deliberately thin: bind JSON, call the guarded Services
+// operation, map the sentinel error to a status. Every security rule
+// (source=custom, built-in immutability, wildcard and admin-console refusal)
+// lives in the Services implementation in core, next to the engine — not here —
+// so it holds no matter which build wires these routes.
+//
+// Note on physical placement: unlike the perm_object_level socket, whose
+// implementation carries real product logic and lives wholly in the private ee
+// repository, these rbac_basic handlers are thin CRUD with no algorithmic
+// secret. They sit in this public core package so both the ee build and core's
+// own tests can reuse one implementation. The community binary still never
+// serves them — it registers no mounter — so the two-binary contract's
+// user-visible guarantee (404, not 403) holds; only the dead handler bytes,
+// which reveal nothing, remain compiled in. #278 core decision two's physical-
+// absence rule is kept where it matters (perm_object_level) and relaxed here
+// where there is nothing to hide.
+func Routes(g *gin.RouterGroup, svc Services) {
+	// POST /roles — create a custom role. { id?, name, description? } -> { id }
+	g.POST("/roles", svc.RequirePermission("admin-role", "create"), func(c *gin.Context) {
+		var req struct {
+			ID          string `json:"id"`
+			Name        string `json:"name" binding:"required"`
+			Description string `json:"description"`
+		}
+		if !bindJSON(c, &req) {
+			return
+		}
+		id, err := svc.CreateRole(c.Request.Context(), RoleSpec{ID: req.ID, Name: req.Name, Description: req.Description})
+		if err != nil {
+			writeErr(c, err)
+			return
+		}
+		c.JSON(http.StatusCreated, gin.H{"id": id})
+	})
+
+	// PUT /roles/:id — rename/re-describe a custom role. { name?, description? }
+	g.PUT("/roles/:id", svc.RequirePermission("admin-role", "edit"), func(c *gin.Context) {
+		var req struct {
+			Name        *string `json:"name"`
+			Description *string `json:"description"`
+		}
+		if !bindJSON(c, &req) {
+			return
+		}
+		if err := svc.UpdateRole(c.Request.Context(), c.Param("id"), RolePatch{Name: req.Name, Description: req.Description}); err != nil {
+			writeErr(c, err)
+			return
+		}
+		c.Status(http.StatusNoContent)
+	})
+
+	// DELETE /roles/:id — delete a custom role, purging its bindings and grants.
+	g.DELETE("/roles/:id", svc.RequirePermission("admin-role", "delete"), func(c *gin.Context) {
+		if err := svc.DeleteRole(c.Request.Context(), c.Param("id")); err != nil {
+			writeErr(c, err)
+			return
+		}
+		c.Status(http.StatusNoContent)
+	})
+
+	// POST /roles/:id/permissions — grant a custom role an op over a resource
+	// pattern (id "*" = whole type). { resource{type,id}, operations:[...] }
+	g.POST("/roles/:id/permissions", svc.RequirePermission("admin-authz", "grant"), func(c *gin.Context) {
+		req, ok := bindPermReq(c)
+		if !ok {
+			return
+		}
+		for _, op := range req.Operations {
+			if err := svc.GrantRolePermission(c.Request.Context(), c.Param("id"), req.Resource.Type, req.Resource.ID, op); err != nil {
+				writeErr(c, err)
+				return
+			}
+		}
+		c.Status(http.StatusNoContent)
+	})
+
+	// DELETE /roles/:id/permissions — revoke a custom role's ops over a pattern.
+	g.DELETE("/roles/:id/permissions", svc.RequirePermission("admin-authz", "revoke"), func(c *gin.Context) {
+		req, ok := bindPermReq(c)
+		if !ok {
+			return
+		}
+		for _, op := range req.Operations {
+			if err := svc.RevokeRolePermission(c.Request.Context(), c.Param("id"), req.Resource.Type, req.Resource.ID, op); err != nil {
+				writeErr(c, err)
+				return
+			}
+		}
+		c.Status(http.StatusNoContent)
+	})
+}
+
+type permReq struct {
+	Resource struct {
+		Type string `json:"type" binding:"required"`
+		ID   string `json:"id"`
+	} `json:"resource" binding:"required"`
+	Operations []string `json:"operations" binding:"required"`
+}
+
+func bindPermReq(c *gin.Context) (permReq, bool) {
+	var req permReq
+	if !bindJSON(c, &req) {
+		return permReq{}, false
+	}
+	return req, true
+}
+
+// bindJSON binds and validates the request body, answering 400 on failure.
+func bindJSON(c *gin.Context, v any) bool {
+	if err := c.ShouldBindJSON(v); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return false
+	}
+	return true
+}
+
+// writeErr maps a Services sentinel error to an HTTP status. An unrecognised
+// error is a 500 — the message is not leaked.
+func writeErr(c *gin.Context, err error) {
+	switch {
+	case errors.Is(err, ErrNotFound):
+		c.JSON(http.StatusNotFound, gin.H{"error": "not found"})
+	case errors.Is(err, ErrImmutable):
+		c.JSON(http.StatusForbidden, gin.H{"error": err.Error()})
+	case errors.Is(err, ErrForbidden):
+		c.JSON(http.StatusForbidden, gin.H{"error": err.Error()})
+	case errors.Is(err, ErrInvalid):
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+	default:
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "internal error"})
+	}
+}

--- a/bkn-safe/server/extension/adminwrite/testsupport.go
+++ b/bkn-safe/server/extension/adminwrite/testsupport.go
@@ -1,0 +1,17 @@
+// Copyright openbkn.ai
+//
+// Licensed under the OpenBKN License. See LICENSE-OPENBKN.txt in the project root.
+
+package adminwrite
+
+import "testing"
+
+// ResetForTest clears the socket so a test does not inherit another's mounter.
+// Panics outside a test binary — see extension/testsupport.go for why this is
+// enforced with testing.Testing() rather than a convention.
+func ResetForTest() {
+	if !testing.Testing() {
+		panic("adminwrite: ResetForTest is test-only and must never run in a production binary")
+	}
+	resetForTest()
+}

--- a/bkn-safe/server/extension/extension.go
+++ b/bkn-safe/server/extension/extension.go
@@ -1,0 +1,234 @@
+// Copyright openbkn.ai
+//
+// Licensed under the OpenBKN License. See LICENSE-OPENBKN.txt in the project root.
+
+// Package extension is the socket core exposes to the enterprise code line.
+// It is deliberately outside internal/ — Go's internal rule would otherwise
+// make it unimportable from bkn-foundry-ee, and the whole open-core model
+// rests on ee being able to plug in from another repository.
+//
+// Two mechanisms live here, and they are not the same thing:
+//
+//   - Gate (mode ①): the feature is implemented in this open repository and
+//     the license decides whether it is on. rbac_basic is the sample.
+//   - Socket (mode ②): the feature is implemented in the private ee repository
+//     and registers itself into a typed interface here at enterprise startup.
+//     Community binaries physically lack the code; the socket stays nil and
+//     the call site degrades. perm_object_level is the first one.
+//
+// Dependency direction is always ee -> core. Core knows nothing about ee; a
+// single `import ".../bkn-foundry-ee/..."` anywhere in core collapses the
+// model, so CI lints for it.
+//
+// Design: license-server docs/design/open-core-gating.md §2.5.
+package extension
+
+import (
+	"fmt"
+	"sort"
+	"sync"
+)
+
+// Feature is a license feature key. The authoritative dictionary is
+// license-server docs/design/license-service.md §1.5 — that file is the single
+// source, this block mirrors it. A key that has been signed into a customer
+// license is a permanent API: removing one takes two major versions of
+// deprecation, because a silent removal makes an existing customer's
+// capability vanish.
+type Feature string
+
+const (
+	// Professional — mode ①, implemented in this repository, license-gated.
+	FeatureSourceSync         Feature = "source_sync"
+	FeatureRBACBasic          Feature = "rbac_basic"
+	FeatureImpactGraph        Feature = "impact_graph"
+	FeatureConnectorCertified Feature = "connector_certified"
+
+	// Enterprise — mode ②, implemented in the private ee code line.
+	FeaturePermObjectLevel Feature = "perm_object_level"
+	FeatureAudit           Feature = "audit"
+	FeatureOpsDashboard    Feature = "ops_dashboard"
+	FeatureBranding        Feature = "branding"
+)
+
+// modeTwo lists the features whose implementation lives in the private ee code
+// line. Everything else is mode ① — implemented here, license-gated.
+//
+// The distinction matters to /capabilities: a mode ① feature is usable as soon
+// as the license carries it, while a mode ② feature also needs its code to be
+// present, which a community binary never has. Reporting a licensed-but-absent
+// enterprise feature as usable would make the frontend offer an entry point
+// that 404s.
+var modeTwo = map[Feature]bool{
+	FeaturePermObjectLevel: true,
+	FeatureAudit:           true,
+	FeatureOpsDashboard:    true,
+	FeatureBranding:        true,
+}
+
+// NeedsExtension reports whether the feature is implemented in the ee code line
+// (mode ②) rather than in this repository (mode ①).
+func (f Feature) NeedsExtension() bool { return modeTwo[f] }
+
+// Usable reports whether a licensed feature can actually be served by this
+// binary: mode ① needs only the license, mode ② also needs its socket filled.
+func Usable(f Feature) bool {
+	if !Enabled(f) {
+		return false
+	}
+	if f.NeedsExtension() {
+		return registeredLocked(f)
+	}
+	return true
+}
+
+// Gate answers "is this licensed feature on right now". Implementations must
+// read the current verified license snapshot on every call and must not cache
+// a boolean — a hot-reloaded or expired license has to take effect globally
+// without restarting anything (open-core-gating §2.7 rule 5).
+type Gate interface {
+	Enabled(f Feature) bool
+}
+
+// gateFunc adapts a plain function to Gate.
+type gateFunc func(Feature) bool
+
+func (g gateFunc) Enabled(f Feature) bool { return g(f) }
+
+// GateFunc builds a Gate from a function.
+func GateFunc(fn func(Feature) bool) Gate { return gateFunc(fn) }
+
+// deniedGate is the zero value: nothing paid is on. It is what a binary uses
+// before SetGate runs, so a wiring mistake fails closed on paid capability
+// rather than handing it out for free. It never affects community capability,
+// which is not gated at all.
+type deniedGate struct{}
+
+func (deniedGate) Enabled(Feature) bool { return false }
+
+var (
+	mu       sync.RWMutex
+	gate     Gate = deniedGate{}
+	frozen   bool
+	claimed  = map[Feature]string{}
+	assembly []string
+)
+
+// SetGate installs the license gate. Call once during startup, before Freeze.
+// Calling it after the registry is frozen panics: a gate swapped at runtime
+// would mean some call sites judge against one license and some against
+// another.
+func SetGate(g Gate) {
+	mu.Lock()
+	defer mu.Unlock()
+	if frozen {
+		panic("extension: SetGate after Freeze — the license gate must be installed during assembly")
+	}
+	if g == nil {
+		panic("extension: SetGate(nil)")
+	}
+	gate = g
+}
+
+// Enabled reports whether a licensed feature is on. Safe on the hot path.
+func Enabled(f Feature) bool {
+	mu.RLock()
+	g := gate
+	mu.RUnlock()
+	return g.Enabled(f)
+}
+
+// Claim records that an implementation has taken the socket for a feature.
+// Typed sockets call it from their own Register; callers outside this package
+// tree should not.
+//
+// Three deliberate panics, all of them assembly bugs that must surface at
+// startup rather than silently:
+//
+//   - claiming a feature twice: the second implementation would overwrite the
+//     first without a trace
+//   - claiming after Freeze: the capability set is already published and some
+//     call sites have already judged against the old one
+//   - claiming an unlicensed feature: ee is expected to check its license
+//     before registering, so reaching here means the check was skipped
+func Claim(f Feature, impl string) {
+	mu.Lock()
+	defer mu.Unlock()
+	if frozen {
+		panic(fmt.Sprintf("extension: %s registered after Freeze (by %s) — extensions must be assembled before the server runs", f, impl))
+	}
+	if prev, dup := claimed[f]; dup {
+		panic(fmt.Sprintf("extension: %s already registered by %s, cannot re-register with %s", f, prev, impl))
+	}
+	if !gate.Enabled(f) {
+		panic(fmt.Sprintf("extension: %s registered by %s without a license for it — check the license before registering", f, impl))
+	}
+	claimed[f] = impl
+	assembly = append(assembly, fmt.Sprintf("%s=%s", f, impl))
+}
+
+// Freeze closes the registry. Call it once, after assembly and before the
+// server starts serving. Freezing twice is itself an assembly bug.
+func Freeze() {
+	mu.Lock()
+	defer mu.Unlock()
+	if frozen {
+		panic("extension: Freeze called twice")
+	}
+	frozen = true
+}
+
+// Frozen reports whether the registry is closed. Call sites do not need this;
+// it exists for tests and for startup logging.
+func Frozen() bool {
+	mu.RLock()
+	defer mu.RUnlock()
+	return frozen
+}
+
+// Registered lists the feature keys that have an implementation plugged in —
+// the mode ② half of what /capabilities reports. Sorted for stable output.
+func Registered() []string {
+	mu.RLock()
+	defer mu.RUnlock()
+	out := make([]string, 0, len(claimed))
+	for f := range claimed {
+		out = append(out, string(f))
+	}
+	sort.Strings(out)
+	return out
+}
+
+// Assembly describes what was plugged in, for the startup log line.
+func Assembly() []string {
+	mu.RLock()
+	defer mu.RUnlock()
+	return append([]string(nil), assembly...)
+}
+
+// registeredLocked reports whether a feature has an implementation. Callers
+// hold no lock; typed sockets use their own stored value instead.
+func registeredLocked(f Feature) bool {
+	mu.RLock()
+	defer mu.RUnlock()
+	_, ok := claimed[f]
+	return ok
+}
+
+// Available reports whether a mode ② capability is usable: an implementation
+// is plugged in AND the license still says yes. The second half matters
+// because a license can expire after assembly — the socket stays filled but
+// the capability has to go dark without a restart.
+func Available(f Feature) bool {
+	return registeredLocked(f) && Enabled(f)
+}
+
+// reset returns the registry to its zero state. Tests only.
+func reset() {
+	mu.Lock()
+	defer mu.Unlock()
+	gate = deniedGate{}
+	frozen = false
+	claimed = map[Feature]string{}
+	assembly = nil
+}

--- a/bkn-safe/server/extension/extension.go
+++ b/bkn-safe/server/extension/extension.go
@@ -4,8 +4,8 @@
 
 // Package extension is the socket core exposes to the enterprise code line.
 // It is deliberately outside internal/ — Go's internal rule would otherwise
-// make it unimportable from bkn-foundry-ee, and the whole open-core model
-// rests on ee being able to plug in from another repository.
+// make it unimportable from openbkn-ee, and the whole open-core model rests on
+// ee being able to plug in from another repository.
 //
 // Two mechanisms live here, and they are not the same thing:
 //
@@ -17,8 +17,8 @@
 //     the call site degrades. perm_object_level is the first one.
 //
 // Dependency direction is always ee -> core. Core knows nothing about ee; a
-// single `import ".../bkn-foundry-ee/..."` anywhere in core collapses the
-// model, so CI lints for it.
+// single `import ".../openbkn-ee/..."` anywhere in core collapses the model,
+// so CI lints for it.
 //
 // Design: license-server docs/design/open-core-gating.md §2.5.
 package extension

--- a/bkn-safe/server/extension/extension_test.go
+++ b/bkn-safe/server/extension/extension_test.go
@@ -1,0 +1,164 @@
+// Copyright openbkn.ai
+//
+// Licensed under the OpenBKN License. See LICENSE-OPENBKN.txt in the project root.
+
+package extension
+
+import (
+	"strings"
+	"testing"
+)
+
+// allowAll is a gate that licenses everything.
+func allowAll() Gate { return GateFunc(func(Feature) bool { return true }) }
+
+// only licenses exactly the listed features.
+func only(fs ...Feature) Gate {
+	set := map[Feature]bool{}
+	for _, f := range fs {
+		set[f] = true
+	}
+	return GateFunc(func(f Feature) bool { return set[f] })
+}
+
+// mustPanic runs fn and returns the panic value, failing if it did not panic.
+func mustPanic(t *testing.T, what string, fn func()) any {
+	t.Helper()
+	var got any
+	func() {
+		defer func() { got = recover() }()
+		fn()
+	}()
+	if got == nil {
+		t.Fatalf("%s: expected panic, got none", what)
+	}
+	return got
+}
+
+func TestZeroGateDeniesEverything(t *testing.T) {
+	reset()
+	// Before SetGate runs, nothing paid is on. A wiring mistake must fail
+	// closed on paid capability rather than hand it out free.
+	for _, f := range []Feature{FeatureRBACBasic, FeaturePermObjectLevel, FeatureAudit} {
+		if Enabled(f) {
+			t.Errorf("Enabled(%s) = true before SetGate, want false", f)
+		}
+	}
+}
+
+func TestGateReadsLiveSnapshot(t *testing.T) {
+	reset()
+	// The gate must be consulted on every call — a cached bool would leave an
+	// expired license granting capability until restart.
+	licensed := true
+	SetGate(GateFunc(func(f Feature) bool { return licensed && f == FeatureRBACBasic }))
+
+	if !Enabled(FeatureRBACBasic) {
+		t.Fatal("rbac_basic should be on while licensed")
+	}
+	licensed = false
+	if Enabled(FeatureRBACBasic) {
+		t.Fatal("rbac_basic should go dark the moment the license does, without a restart")
+	}
+}
+
+func TestClaimTwicePanics(t *testing.T) {
+	reset()
+	SetGate(allowAll())
+	Claim(FeaturePermObjectLevel, "first")
+
+	got := mustPanic(t, "second Claim", func() { Claim(FeaturePermObjectLevel, "second") })
+	msg, _ := got.(string)
+	if !strings.Contains(msg, "already registered by first") {
+		t.Fatalf("panic message should name the incumbent, got %q", msg)
+	}
+}
+
+func TestClaimAfterFreezePanics(t *testing.T) {
+	reset()
+	SetGate(allowAll())
+	Freeze()
+
+	got := mustPanic(t, "Claim after Freeze", func() { Claim(FeatureAudit, "late") })
+	msg, _ := got.(string)
+	if !strings.Contains(msg, "after Freeze") {
+		t.Fatalf("panic message should say the registry was frozen, got %q", msg)
+	}
+}
+
+func TestClaimWithoutLicensePanics(t *testing.T) {
+	reset()
+	SetGate(only(FeatureRBACBasic))
+
+	// ee is expected to check its license before registering; reaching Claim
+	// for an unlicensed feature means that check was skipped.
+	got := mustPanic(t, "unlicensed Claim", func() { Claim(FeaturePermObjectLevel, "ee") })
+	msg, _ := got.(string)
+	if !strings.Contains(msg, "without a license") {
+		t.Fatalf("panic message should say the license is missing, got %q", msg)
+	}
+}
+
+func TestSetGateAfterFreezePanics(t *testing.T) {
+	reset()
+	SetGate(allowAll())
+	Freeze()
+
+	mustPanic(t, "SetGate after Freeze", func() { SetGate(allowAll()) })
+}
+
+func TestFreezeTwicePanics(t *testing.T) {
+	reset()
+	SetGate(allowAll())
+	Freeze()
+
+	mustPanic(t, "second Freeze", func() { Freeze() })
+}
+
+func TestRegisteredIsSortedAndAvailableTracksLicense(t *testing.T) {
+	reset()
+	licensed := true
+	SetGate(GateFunc(func(Feature) bool { return licensed }))
+	Claim(FeaturePermObjectLevel, "permobject")
+	Claim(FeatureAudit, "audit")
+
+	got := Registered()
+	want := []string{"audit", "perm_object_level"}
+	if len(got) != len(want) {
+		t.Fatalf("Registered() = %v, want %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("Registered() = %v, want %v", got, want)
+		}
+	}
+
+	if !Available(FeaturePermObjectLevel) {
+		t.Fatal("a registered, licensed feature should be available")
+	}
+	// A license that lapses after assembly leaves the socket filled but the
+	// capability must go dark all the same.
+	licensed = false
+	if Available(FeaturePermObjectLevel) {
+		t.Fatal("capability should go dark when the license lapses, socket notwithstanding")
+	}
+	if !Frozen() {
+		// Freeze was never called here; guard the assertion's own premise.
+		if len(Registered()) != 2 {
+			t.Fatal("registry lost claims")
+		}
+	}
+}
+
+func TestCommunityBuildRegistersNothing(t *testing.T) {
+	reset()
+	SetGate(only()) // community: no paid features
+	Freeze()
+
+	if len(Registered()) != 0 {
+		t.Fatalf("community build should have an empty socket set, got %v", Registered())
+	}
+	if Available(FeaturePermObjectLevel) {
+		t.Fatal("perm_object_level must not be available in a community build")
+	}
+}

--- a/bkn-safe/server/extension/permobject/permobject.go
+++ b/bkn-safe/server/extension/permobject/permobject.go
@@ -1,0 +1,152 @@
+// Copyright openbkn.ai
+//
+// Licensed under the OpenBKN License. See LICENSE-OPENBKN.txt in the project root.
+
+// Package permobject is the mode ② socket for perm_object_level — object-level
+// authorization and advanced role control, implemented in the private ee code
+// line (bkn-foundry-ee) and absent from community binaries.
+//
+// The socket layers on top of core's verdict rather than replacing it. Core's
+// casbin model is allow-only: a policy line grants, nothing revokes, and a
+// grant has no validity window. Those two gaps are exactly what the enterprise
+// tier adds, so the interface is a second opinion applied after core has
+// decided, not a substitute enforcer. Keeping it at the decision boundary is
+// deliberate — open-core-gating §2 puts sockets at capability entry points,
+// never inside business logic, because few sockets are what makes two code
+// lines maintainable.
+//
+// The exact community/enterprise split line for object grants is still open in
+// #278; this socket covers the advanced half (explicit deny, time-bounded
+// grants) and does not presume where that line lands.
+package permobject
+
+import (
+	"context"
+	"sync/atomic"
+
+	"github.com/openbkn-ai/bkn-foundry/bkn-safe/server/extension"
+)
+
+// Decision is the ee layer's verdict on top of core's.
+type Decision uint8
+
+const (
+	// Abstain: the ee layer has no opinion; core's verdict stands unchanged.
+	// Community builds always abstain because nothing is plugged in.
+	Abstain Decision = iota
+	// Allow: grant access core would have refused (a grant core's allow-only
+	// model cannot express on its own).
+	Allow
+	// Deny: refuse access core would have permitted. This is the direction
+	// core structurally cannot express, and the main reason the socket exists.
+	Deny
+)
+
+func (d Decision) String() string {
+	switch d {
+	case Allow:
+		return "allow"
+	case Deny:
+		return "deny"
+	default:
+		return "abstain"
+	}
+}
+
+// Request is one authorization question, already resolved to its subject and
+// object by core.
+type Request struct {
+	AccessorID   string
+	ResourceType string
+	ResourceID   string
+	Op           string
+	// CoreVerdict is what core's casbin model decided. The ee layer sees it so
+	// it can restrict an allow without re-deriving it.
+	CoreVerdict bool
+}
+
+// Authorizer is what the ee code line implements.
+//
+// Decide must be safe for concurrent use and must not block on I/O that can
+// hang — it sits on the authorization hot path.
+type Authorizer interface {
+	Decide(ctx context.Context, req Request) (Decision, error)
+}
+
+// impl holds the registered implementation. atomic.Value keeps the read path
+// lock-free; it is written once during assembly and only read afterwards.
+var impl atomic.Value // Authorizer
+
+// Register plugs the ee implementation into the socket. It is called from the
+// enterprise assembly entry point (cmd/*-ee), after that entry point has
+// verified the license carries perm_object_level.
+//
+// It panics on a second registration, on registration after the extension
+// registry is frozen, and on registration without a license — see
+// extension.Claim. All three are assembly bugs that must be loud at startup.
+func Register(a Authorizer) {
+	if a == nil {
+		panic("permobject: Register(nil)")
+	}
+	extension.Claim(extension.FeaturePermObjectLevel, "permobject")
+	impl.Store(a)
+}
+
+// Registered reports whether an implementation is plugged in. It says nothing
+// about the license — use Available for that.
+func Registered() bool { return load() != nil }
+
+// Available reports whether the capability is usable right now: plugged in and
+// still licensed. The license half is re-read every call, so an expiry or a
+// hot-reloaded downgrade takes effect without a restart.
+func Available() bool {
+	return load() != nil && extension.Enabled(extension.FeaturePermObjectLevel)
+}
+
+// Decide asks the ee layer for a second opinion. Community builds, unlicensed
+// clusters, and clusters whose license lapsed after startup all get Abstain
+// with a nil error, which leaves core's verdict untouched — the community
+// authorization behaviour is the fallback, exactly as the downgrade path
+// requires.
+//
+// An error from the ee layer returns Deny. The socket only ever runs in an
+// enterprise build where the ee layer is the authority on restrictions; a
+// transient failure that silently reverted to core's more permissive verdict
+// would hand out access the enterprise policy revoked. Callers must surface
+// the error rather than treat the denial as a plain policy outcome.
+func Decide(ctx context.Context, req Request) (Decision, error) {
+	a := load()
+	if a == nil || !extension.Enabled(extension.FeaturePermObjectLevel) {
+		return Abstain, nil
+	}
+	d, err := a.Decide(ctx, req)
+	if err != nil {
+		return Deny, err
+	}
+	return d, nil
+}
+
+// Apply folds a decision into core's verdict. It is the one place the layering
+// rule lives, so call sites do not each re-implement it.
+func Apply(coreVerdict bool, d Decision) bool {
+	switch d {
+	case Allow:
+		return true
+	case Deny:
+		return false
+	default:
+		return coreVerdict
+	}
+}
+
+func load() Authorizer {
+	v := impl.Load()
+	if v == nil {
+		return nil
+	}
+	a, _ := v.(Authorizer)
+	return a
+}
+
+// reset clears the socket. Tests only.
+func reset() { impl = atomic.Value{} }

--- a/bkn-safe/server/extension/permobject/permobject.go
+++ b/bkn-safe/server/extension/permobject/permobject.go
@@ -4,7 +4,7 @@
 
 // Package permobject is the mode ② socket for perm_object_level — object-level
 // authorization and advanced role control, implemented in the private ee code
-// line (bkn-foundry-ee) and absent from community binaries.
+// line (openbkn-ee) and absent from community binaries.
 //
 // The socket layers on top of core's verdict rather than replacing it. Core's
 // casbin model is allow-only: a policy line grants, nothing revokes, and a

--- a/bkn-safe/server/extension/permobject/permobject_test.go
+++ b/bkn-safe/server/extension/permobject/permobject_test.go
@@ -1,0 +1,166 @@
+// Copyright openbkn.ai
+//
+// Licensed under the OpenBKN License. See LICENSE-OPENBKN.txt in the project root.
+
+package permobject
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/openbkn-ai/bkn-foundry/bkn-safe/server/extension"
+)
+
+// fake stands in for the ee implementation. Core must be testable with a fake
+// in the socket — that is the point of depending on the interface, not on ee.
+type fake struct {
+	decision Decision
+	err      error
+	seen     Request
+}
+
+func (f *fake) Decide(_ context.Context, req Request) (Decision, error) {
+	f.seen = req
+	return f.decision, f.err
+}
+
+// licensed installs a gate that turns perm_object_level on or off, and clears
+// the socket, so each test starts from a known assembly state.
+func licensed(t *testing.T, on *bool) {
+	t.Helper()
+	reset()
+	extension.SetGateForTest(extension.GateFunc(func(f extension.Feature) bool {
+		return *on && f == extension.FeaturePermObjectLevel
+	}))
+}
+
+func TestCommunityBuildAbstains(t *testing.T) {
+	on := true
+	licensed(t, &on)
+	// Nothing registered: this is a community binary, the code is not present.
+	d, err := Decide(context.Background(), Request{AccessorID: "u1", CoreVerdict: true})
+	if err != nil {
+		t.Fatalf("Decide err = %v, want nil", err)
+	}
+	if d != Abstain {
+		t.Fatalf("Decide = %v, want Abstain — core's verdict must stand", d)
+	}
+	if Available() {
+		t.Fatal("Available() must be false with an empty socket")
+	}
+}
+
+func TestRegisteredDenyOverridesCoreAllow(t *testing.T) {
+	on := true
+	licensed(t, &on)
+	Register(&fake{decision: Deny})
+
+	d, err := Decide(context.Background(), Request{AccessorID: "u1", CoreVerdict: true})
+	if err != nil {
+		t.Fatalf("Decide err = %v", err)
+	}
+	if got := Apply(true, d); got {
+		t.Fatal("an ee deny must override core's allow — that is the gap core cannot express")
+	}
+}
+
+func TestRegisteredAllowOverridesCoreDeny(t *testing.T) {
+	on := true
+	licensed(t, &on)
+	Register(&fake{decision: Allow})
+
+	d, _ := Decide(context.Background(), Request{AccessorID: "u1", CoreVerdict: false})
+	if got := Apply(false, d); !got {
+		t.Fatal("an ee allow must override core's deny")
+	}
+}
+
+func TestAbstainLeavesCoreVerdictAlone(t *testing.T) {
+	on := true
+	licensed(t, &on)
+	Register(&fake{decision: Abstain})
+
+	for _, core := range []bool{true, false} {
+		d, _ := Decide(context.Background(), Request{CoreVerdict: core})
+		if got := Apply(core, d); got != core {
+			t.Fatalf("Apply(%v, Abstain) = %v, want %v", core, got, core)
+		}
+	}
+}
+
+func TestErrorFailsClosed(t *testing.T) {
+	on := true
+	licensed(t, &on)
+	wantErr := errors.New("ee store unreachable")
+	Register(&fake{decision: Allow, err: wantErr})
+
+	d, err := Decide(context.Background(), Request{CoreVerdict: true})
+	if !errors.Is(err, wantErr) {
+		t.Fatalf("Decide err = %v, want %v surfaced to the caller", err, wantErr)
+	}
+	if d != Deny {
+		t.Fatalf("Decide = %v on error, want Deny — reverting to core's looser verdict would hand out access the enterprise policy revoked", d)
+	}
+}
+
+func TestLapsedLicenseFallsBackToCommunityBehaviour(t *testing.T) {
+	on := true
+	licensed(t, &on)
+	Register(&fake{decision: Deny})
+
+	if !Available() {
+		t.Fatal("capability should be available while licensed")
+	}
+	// The license expires while the process keeps running. The socket is still
+	// filled, but the capability has to go dark without a restart and the
+	// cluster has to fall back to community authorization behaviour.
+	on = false
+	if Available() {
+		t.Fatal("capability must go dark when the license lapses")
+	}
+	d, err := Decide(context.Background(), Request{CoreVerdict: true})
+	if err != nil {
+		t.Fatalf("Decide err = %v, want nil", err)
+	}
+	if d != Abstain {
+		t.Fatalf("Decide = %v after the license lapsed, want Abstain", d)
+	}
+}
+
+func TestRequestCarriesCoreVerdictToEE(t *testing.T) {
+	on := true
+	licensed(t, &on)
+	f := &fake{decision: Abstain}
+	Register(f)
+
+	req := Request{AccessorID: "u1", ResourceType: "knowledge_network", ResourceID: "kn1", Op: "view_detail", CoreVerdict: true}
+	if _, err := Decide(context.Background(), req); err != nil {
+		t.Fatal(err)
+	}
+	if f.seen != req {
+		t.Fatalf("ee saw %+v, want %+v", f.seen, req)
+	}
+}
+
+func TestRegisterNilPanics(t *testing.T) {
+	on := true
+	licensed(t, &on)
+	defer func() {
+		if recover() == nil {
+			t.Fatal("Register(nil) should panic")
+		}
+	}()
+	Register(nil)
+}
+
+func TestRegisterWithoutLicensePanics(t *testing.T) {
+	on := false
+	licensed(t, &on)
+	defer func() {
+		if recover() == nil {
+			t.Fatal("registering without a license should panic — ee must check first")
+		}
+	}()
+	Register(&fake{})
+}

--- a/bkn-safe/server/extension/testsupport.go
+++ b/bkn-safe/server/extension/testsupport.go
@@ -1,0 +1,27 @@
+// Copyright openbkn.ai
+//
+// Licensed under the OpenBKN License. See LICENSE-OPENBKN.txt in the project root.
+
+package extension
+
+// The registry is process-global by design — it models one binary's assembly,
+// which happens once. That makes it awkward for tests in other packages (the
+// typed sockets, and core call sites that want a fake plugged in), so the two
+// helpers below are exported.
+//
+// They are test-only. Production assembly uses SetGate + Freeze exactly once
+// from the server entry point; anything calling these outside a _test.go file
+// is a bug, and CI lints for it.
+
+// ResetForTest returns the registry to its zero state: no gate, not frozen,
+// nothing claimed. Call it at the top of any test that registers an extension,
+// so tests do not inherit each other's assembly.
+func ResetForTest() { reset() }
+
+// SetGateForTest resets the registry and installs g. It is the common opening
+// line of a socket test — a plain SetGate on an already-claimed registry would
+// carry the previous test's claims forward.
+func SetGateForTest(g Gate) {
+	reset()
+	SetGate(g)
+}

--- a/bkn-safe/server/extension/testsupport.go
+++ b/bkn-safe/server/extension/testsupport.go
@@ -4,24 +4,47 @@
 
 package extension
 
+import "testing"
+
 // The registry is process-global by design — it models one binary's assembly,
 // which happens once. That makes it awkward for tests in other packages (the
 // typed sockets, and core call sites that want a fake plugged in), so the two
 // helpers below are exported.
 //
-// They are test-only. Production assembly uses SetGate + Freeze exactly once
-// from the server entry point; anything calling these outside a _test.go file
-// is a bug, and CI lints for it.
+// Exported test helpers live in a normal source file, which means they are
+// linked into the production binary. Both would otherwise be a way around the
+// invariants the rest of this package exists to enforce: ResetForTest clears
+// the frozen flag, so a caller could un-freeze a running server's registry and
+// register an extension into it — exactly what Claim's panic is there to stop.
+//
+// testing.Testing() closes that off at the only point that matters. It reports
+// whether the binary was built by `go test`, so in a production build these
+// functions cannot run at all, no matter who calls them. A convention plus a
+// lint would leave the hole open to anything the lint failed to match.
 
 // ResetForTest returns the registry to its zero state: no gate, not frozen,
 // nothing claimed. Call it at the top of any test that registers an extension,
 // so tests do not inherit each other's assembly.
-func ResetForTest() { reset() }
+//
+// Panics outside a test binary.
+func ResetForTest() {
+	mustBeTest("ResetForTest")
+	reset()
+}
 
 // SetGateForTest resets the registry and installs g. It is the common opening
 // line of a socket test — a plain SetGate on an already-claimed registry would
 // carry the previous test's claims forward.
+//
+// Panics outside a test binary.
 func SetGateForTest(g Gate) {
+	mustBeTest("SetGateForTest")
 	reset()
 	SetGate(g)
+}
+
+func mustBeTest(fn string) {
+	if !testing.Testing() {
+		panic("extension: " + fn + " is test-only and must never run in a production binary")
+	}
 }

--- a/bkn-safe/server/go.mod
+++ b/bkn-safe/server/go.mod
@@ -3,7 +3,7 @@
 // authorization (Casbin), user management (directory + LDAP). hydra issues the
 // tokens; bkn-safe is NOT a token engine. DB via openbkn-rds driver (xinchuang
 // transparent at the database/sql level) + GORM. Zero kweaver-go-lib.
-module bkn-safe
+module github.com/openbkn-ai/bkn-foundry/bkn-safe/server
 
 go 1.25.0
 

--- a/bkn-safe/server/internal/audit/audit.go
+++ b/bkn-safe/server/internal/audit/audit.go
@@ -16,7 +16,7 @@ import (
 
 	"gorm.io/gorm"
 
-	"bkn-safe/internal/model"
+	"github.com/openbkn-ai/bkn-foundry/bkn-safe/server/internal/model"
 )
 
 // Store reads and writes the audit trail over GORM.

--- a/bkn-safe/server/internal/auth/apikey.go
+++ b/bkn-safe/server/internal/auth/apikey.go
@@ -16,7 +16,7 @@ import (
 
 	"gorm.io/gorm"
 
-	"bkn-safe/internal/model"
+	"github.com/openbkn-ai/bkn-foundry/bkn-safe/server/internal/model"
 )
 
 // KeyPrefix marks an AppKey credential. The MCP/REST gateway branches on this

--- a/bkn-safe/server/internal/auth/apikey_test.go
+++ b/bkn-safe/server/internal/auth/apikey_test.go
@@ -14,8 +14,8 @@ import (
 	"github.com/glebarez/sqlite"
 	"gorm.io/gorm"
 
-	"bkn-safe/internal/database"
-	"bkn-safe/internal/model"
+	"github.com/openbkn-ai/bkn-foundry/bkn-safe/server/internal/database"
+	"github.com/openbkn-ai/bkn-foundry/bkn-safe/server/internal/model"
 )
 
 func newAPIKeyStore(t *testing.T) (*APIKeyStore, *gorm.DB) {

--- a/bkn-safe/server/internal/auth/auth_test.go
+++ b/bkn-safe/server/internal/auth/auth_test.go
@@ -12,8 +12,8 @@ import (
 	"github.com/glebarez/sqlite"
 	"gorm.io/gorm"
 
-	"bkn-safe/internal/database"
-	"bkn-safe/internal/model"
+	"github.com/openbkn-ai/bkn-foundry/bkn-safe/server/internal/database"
+	"github.com/openbkn-ai/bkn-foundry/bkn-safe/server/internal/model"
 )
 
 func newStore(t *testing.T) *UserStore {

--- a/bkn-safe/server/internal/auth/ldap.go
+++ b/bkn-safe/server/internal/auth/ldap.go
@@ -14,8 +14,8 @@ import (
 	ldapv3 "github.com/go-ldap/ldap/v3"
 	"gorm.io/gorm"
 
-	"bkn-safe/config"
-	"bkn-safe/internal/model"
+	"github.com/openbkn-ai/bkn-foundry/bkn-safe/server/config"
+	"github.com/openbkn-ai/bkn-foundry/bkn-safe/server/internal/model"
 )
 
 // LDAPAuthenticator federates authentication to an external LDAP/AD directory

--- a/bkn-safe/server/internal/auth/ldap_test.go
+++ b/bkn-safe/server/internal/auth/ldap_test.go
@@ -13,9 +13,9 @@ import (
 	"github.com/glebarez/sqlite"
 	"gorm.io/gorm"
 
-	"bkn-safe/config"
-	"bkn-safe/internal/database"
-	"bkn-safe/internal/model"
+	"github.com/openbkn-ai/bkn-foundry/bkn-safe/server/config"
+	"github.com/openbkn-ai/bkn-foundry/bkn-safe/server/internal/database"
+	"github.com/openbkn-ai/bkn-foundry/bkn-safe/server/internal/model"
 )
 
 // fakeConn is an in-memory LDAP connection for tests. The user DN

--- a/bkn-safe/server/internal/auth/provider.go
+++ b/bkn-safe/server/internal/auth/provider.go
@@ -7,7 +7,7 @@ package auth
 import (
 	"context"
 
-	"bkn-safe/internal/model"
+	"github.com/openbkn-ai/bkn-foundry/bkn-safe/server/internal/model"
 )
 
 // ClientType values for the introspect ext.client_type claim (lib enum).

--- a/bkn-safe/server/internal/auth/userstore.go
+++ b/bkn-safe/server/internal/auth/userstore.go
@@ -17,7 +17,7 @@ import (
 	"golang.org/x/crypto/bcrypt"
 	"gorm.io/gorm"
 
-	"bkn-safe/internal/model"
+	"github.com/openbkn-ai/bkn-foundry/bkn-safe/server/internal/model"
 )
 
 // InitialPasswordEnv is the BKN_SAFE_INITIAL_PASSWORD value captured once at

--- a/bkn-safe/server/internal/database/database.go
+++ b/bkn-safe/server/internal/database/database.go
@@ -18,8 +18,8 @@ import (
 	"gorm.io/driver/mysql"
 	"gorm.io/gorm"
 
-	"bkn-safe/config"
-	"bkn-safe/internal/model"
+	"github.com/openbkn-ai/bkn-foundry/bkn-safe/server/config"
+	"github.com/openbkn-ai/bkn-foundry/bkn-safe/server/internal/model"
 )
 
 // Open connects to the configured database through the openbkn-rds driver and

--- a/bkn-safe/server/internal/directory/departments_admin_list.go
+++ b/bkn-safe/server/internal/directory/departments_admin_list.go
@@ -7,7 +7,7 @@ package directory
 import (
 	"context"
 
-	"bkn-safe/internal/model"
+	"github.com/openbkn-ai/bkn-foundry/bkn-safe/server/internal/model"
 )
 
 // DepartmentListItem is the admin list view of a department (snake_case JSON).

--- a/bkn-safe/server/internal/directory/departments_fields.go
+++ b/bkn-safe/server/internal/directory/departments_fields.go
@@ -11,7 +11,7 @@ import (
 	"net/mail"
 	"strings"
 
-	"bkn-safe/internal/model"
+	"github.com/openbkn-ai/bkn-foundry/bkn-safe/server/internal/model"
 )
 
 // ErrDuplicateDepartmentCode is returned when a non-empty department code is

--- a/bkn-safe/server/internal/directory/departments_fields_test.go
+++ b/bkn-safe/server/internal/directory/departments_fields_test.go
@@ -8,7 +8,7 @@ import (
 	"context"
 	"testing"
 
-	"bkn-safe/internal/model"
+	"github.com/openbkn-ai/bkn-foundry/bkn-safe/server/internal/model"
 )
 
 func TestValidateDepartmentWrite(t *testing.T) {

--- a/bkn-safe/server/internal/directory/directory.go
+++ b/bkn-safe/server/internal/directory/directory.go
@@ -17,7 +17,7 @@ import (
 	"gorm.io/gorm"
 	"gorm.io/gorm/clause"
 
-	"bkn-safe/internal/model"
+	"github.com/openbkn-ai/bkn-foundry/bkn-safe/server/internal/model"
 )
 
 // ErrDepartmentNotEmpty is returned by DeleteDepartment when the department

--- a/bkn-safe/server/internal/directory/directory_test.go
+++ b/bkn-safe/server/internal/directory/directory_test.go
@@ -11,9 +11,9 @@ import (
 	"github.com/glebarez/sqlite"
 	"gorm.io/gorm"
 
-	"bkn-safe/internal/authz"
-	"bkn-safe/internal/database"
-	"bkn-safe/internal/model"
+	"github.com/openbkn-ai/bkn-foundry/bkn-safe/server/internal/authz"
+	"github.com/openbkn-ai/bkn-foundry/bkn-safe/server/internal/database"
+	"github.com/openbkn-ai/bkn-foundry/bkn-safe/server/internal/model"
 )
 
 func newSvc(t *testing.T) (*Service, *gorm.DB) {

--- a/bkn-safe/server/internal/directory/hierarchy.go
+++ b/bkn-safe/server/internal/directory/hierarchy.go
@@ -10,7 +10,7 @@ import (
 
 	"gorm.io/gorm"
 
-	"bkn-safe/internal/model"
+	"github.com/openbkn-ai/bkn-foundry/bkn-safe/server/internal/model"
 )
 
 // This file adds the org-hierarchy read surface the DA umcmp client needs:

--- a/bkn-safe/server/internal/directory/hierarchy_test.go
+++ b/bkn-safe/server/internal/directory/hierarchy_test.go
@@ -10,7 +10,7 @@ import (
 
 	"gorm.io/gorm"
 
-	"bkn-safe/internal/model"
+	"github.com/openbkn-ai/bkn-foundry/bkn-safe/server/internal/model"
 )
 
 // seedTree builds a 3-level org: d0(root) <- d1 <- d2; u1 in d2, u3 in d1;

--- a/bkn-safe/server/internal/directory/users_admin_list.go
+++ b/bkn-safe/server/internal/directory/users_admin_list.go
@@ -8,7 +8,7 @@ import (
 	"context"
 	"time"
 
-	"bkn-safe/internal/model"
+	"github.com/openbkn-ai/bkn-foundry/bkn-safe/server/internal/model"
 )
 
 // UserListFilter is the admin user-list query (pagination + optional filters).

--- a/bkn-safe/server/internal/directory/users_admin_list_test.go
+++ b/bkn-safe/server/internal/directory/users_admin_list_test.go
@@ -8,8 +8,8 @@ import (
 	"context"
 	"testing"
 
-	"bkn-safe/internal/authz"
-	"bkn-safe/internal/model"
+	"github.com/openbkn-ai/bkn-foundry/bkn-safe/server/internal/authz"
+	"github.com/openbkn-ai/bkn-foundry/bkn-safe/server/internal/model"
 )
 
 func TestListUsersFiltersAndEnrichment(t *testing.T) {

--- a/bkn-safe/server/internal/httpapi/admin_test.go
+++ b/bkn-safe/server/internal/httpapi/admin_test.go
@@ -18,12 +18,12 @@ import (
 	"github.com/glebarez/sqlite"
 	"gorm.io/gorm"
 
-	"bkn-safe/internal/audit"
-	"bkn-safe/internal/auth"
-	"bkn-safe/internal/authz"
-	"bkn-safe/internal/database"
-	"bkn-safe/internal/directory"
-	"bkn-safe/internal/model"
+	"github.com/openbkn-ai/bkn-foundry/bkn-safe/server/internal/audit"
+	"github.com/openbkn-ai/bkn-foundry/bkn-safe/server/internal/auth"
+	"github.com/openbkn-ai/bkn-foundry/bkn-safe/server/internal/authz"
+	"github.com/openbkn-ai/bkn-foundry/bkn-safe/server/internal/database"
+	"github.com/openbkn-ai/bkn-foundry/bkn-safe/server/internal/directory"
+	"github.com/openbkn-ai/bkn-foundry/bkn-safe/server/internal/model"
 )
 
 // stubVerifier maps a bearer token straight to its subject: the token string IS

--- a/bkn-safe/server/internal/httpapi/admin_test.go
+++ b/bkn-safe/server/internal/httpapi/admin_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/glebarez/sqlite"
 	"gorm.io/gorm"
 
+	"github.com/openbkn-ai/bkn-foundry/bkn-safe/server/extension/adminwrite"
 	"github.com/openbkn-ai/bkn-foundry/bkn-safe/server/internal/audit"
 	"github.com/openbkn-ai/bkn-foundry/bkn-safe/server/internal/auth"
 	"github.com/openbkn-ai/bkn-foundry/bkn-safe/server/internal/authz"
@@ -60,6 +61,13 @@ func newAdminServer(t *testing.T) (*gin.Engine, *authz.Enforcer, *gorm.DB, *auth
 		t.Fatalf("grant super-admin: %v", err)
 	}
 	users := auth.NewUserStore(db)
+	// Mount the rbac_basic write routes for the test. In production these are
+	// mounted only by the enterprise build (behind RequireFeature); a community
+	// deployment registers no mounter and the routes 404. Core tests register
+	// the raw Routes mounter so they exercise the RBAC + guarded-service chain
+	// exactly as before — the license layer is ee's and is tested there.
+	adminwrite.ResetForTest()
+	adminwrite.RegisterMounter(adminwrite.Routes)
 	r := New(Deps{
 		Enforcer: e, DB: db, Directory: directory.New(db), Users: users,
 		Audit:         audit.New(db),

--- a/bkn-safe/server/internal/httpapi/adminauth.go
+++ b/bkn-safe/server/internal/httpapi/adminauth.go
@@ -11,7 +11,7 @@ import (
 
 	"github.com/gin-gonic/gin"
 
-	"bkn-safe/internal/authz"
+	"github.com/openbkn-ai/bkn-foundry/bkn-safe/server/internal/authz"
 )
 
 // TokenVerifier resolves a bearer access token to its subject (the accessor id),

--- a/bkn-safe/server/internal/httpapi/adminwrite_gating_test.go
+++ b/bkn-safe/server/internal/httpapi/adminwrite_gating_test.go
@@ -1,0 +1,102 @@
+// Copyright openbkn.ai
+//
+// Licensed under the OpenBKN License. See LICENSE-OPENBKN.txt in the project root.
+
+package httpapi
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+
+	"github.com/openbkn-ai/bkn-foundry/bkn-safe/server/extension/adminwrite"
+	"github.com/openbkn-ai/bkn-foundry/bkn-safe/server/internal/audit"
+	"github.com/openbkn-ai/bkn-foundry/bkn-safe/server/internal/auth"
+	"github.com/openbkn-ai/bkn-foundry/bkn-safe/server/internal/authz"
+	"github.com/openbkn-ai/bkn-foundry/bkn-safe/server/internal/database"
+	"github.com/openbkn-ai/bkn-foundry/bkn-safe/server/internal/directory"
+
+	"github.com/glebarez/sqlite"
+	"gorm.io/gorm"
+)
+
+// newCommunityServer builds a server the way a community binary would: no
+// adminwrite mounter registered, so the rbac_basic write routes are never
+// mounted. This is the whole point of the two-binary split — the endpoints do
+// not exist, not merely refuse.
+func newCommunityServer(t *testing.T) (*gin.Engine, *authz.Enforcer) {
+	t.Helper()
+	gin.SetMode(gin.TestMode)
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	if err != nil {
+		t.Fatalf("sqlite: %v", err)
+	}
+	if err := database.Migrate(db); err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+	e, err := authz.New(db)
+	if err != nil {
+		t.Fatalf("authz: %v", err)
+	}
+	if err := e.Grant(adminSub, "*", "*"); err != nil {
+		t.Fatalf("grant super-admin: %v", err)
+	}
+	// Explicitly clear the socket and register NOTHING — the community build.
+	adminwrite.ResetForTest()
+	r := New(Deps{
+		Enforcer: e, DB: db, Directory: directory.New(db), Users: auth.NewUserStore(db),
+		Audit:         audit.New(db),
+		TokenVerifier: stubVerifier{},
+	})
+	return r, e
+}
+
+// TestCommunityBuildOmitsRbacBasicWriteRoutes is the two-binary contract: with
+// no ee mounter, every rbac_basic write endpoint 404s (does not exist), while
+// the sibling read endpoints stay fully available — community may look, not
+// customise. A super-admin token is used so a 404 cannot be mistaken for an
+// authorization refusal (which would be 403).
+func TestCommunityBuildOmitsRbacBasicWriteRoutes(t *testing.T) {
+	r, _ := newCommunityServer(t)
+
+	writes := []struct {
+		method, path string
+	}{
+		{http.MethodPost, "/api/safe/v1/admin/roles"},
+		{http.MethodPut, "/api/safe/v1/admin/roles/some-id"},
+		{http.MethodDelete, "/api/safe/v1/admin/roles/some-id"},
+		{http.MethodPost, "/api/safe/v1/admin/roles/some-id/permissions"},
+		{http.MethodDelete, "/api/safe/v1/admin/roles/some-id/permissions"},
+	}
+	for _, w := range writes {
+		t.Run(w.method+" "+w.path, func(t *testing.T) {
+			rec := adminReq(t, r, w.method, w.path, gin.H{"name": "x"})
+			if rec.Code != http.StatusNotFound {
+				t.Fatalf("community build must 404 (route absent), got %d: %s", rec.Code, rec.Body.String())
+			}
+		})
+	}
+
+	// Reads stay available — community can view roles, just not change them.
+	if rec := adminReq(t, r, http.MethodGet, "/api/safe/v1/admin/roles", nil); rec.Code != http.StatusOK {
+		t.Fatalf("community role read must stay available, got %d: %s", rec.Code, rec.Body.String())
+	}
+}
+
+// TestCommunityThenEnterpriseSocket documents that the same server code serves
+// the routes once a mounter is registered — the difference between the two
+// binaries is exactly whether Mount was given a mounter.
+func TestCommunityThenEnterpriseSocket(t *testing.T) {
+	// community: absent
+	rc, _ := newCommunityServer(t)
+	if rec := adminReq(t, rc, http.MethodPost, "/api/safe/v1/admin/roles", gin.H{"id": "c1", "name": "c1"}); rec.Code != http.StatusNotFound {
+		t.Fatalf("community: want 404, got %d", rec.Code)
+	}
+
+	// enterprise: mounter present -> route serves, role created
+	re, _, _, _ := newAdminServer(t) // registers adminwrite.Routes
+	if rec := adminReq(t, re, http.MethodPost, "/api/safe/v1/admin/roles", gin.H{"id": "c1", "name": "c1"}); rec.Code != http.StatusCreated {
+		t.Fatalf("enterprise: want 201, got %d: %s", rec.Code, rec.Body.String())
+	}
+}

--- a/bkn-safe/server/internal/httpapi/adminwrite_svc.go
+++ b/bkn-safe/server/internal/httpapi/adminwrite_svc.go
@@ -1,0 +1,136 @@
+// Copyright openbkn.ai
+//
+// Licensed under the OpenBKN License. See LICENSE-OPENBKN.txt in the project root.
+
+package httpapi
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/gin-gonic/gin"
+	"gorm.io/gorm"
+
+	"github.com/openbkn-ai/bkn-foundry/bkn-safe/server/extension/adminwrite"
+	"github.com/openbkn-ai/bkn-foundry/bkn-safe/server/internal/auth"
+	"github.com/openbkn-ai/bkn-foundry/bkn-safe/server/internal/authz"
+	"github.com/openbkn-ai/bkn-foundry/bkn-safe/server/internal/model"
+)
+
+// adminWriteServices is core's implementation of adminwrite.Services. It is the
+// place the rbac_basic write guards live, so they hold regardless of what the
+// ee HTTP layer does: a wrong or malicious ee handler still cannot mint a
+// system role, escape the built-in immutability, hand out a wildcard grant, or
+// confer the admin-console capability. ee owns the HTTP shape; the rules are
+// here, next to the engine.
+type adminWriteServices struct {
+	e  *authz.Enforcer
+	db *gorm.DB
+}
+
+// newAdminWriteServices builds the core service surface passed to the ee
+// write-route mounter.
+func newAdminWriteServices(e *authz.Enforcer, db *gorm.DB) adminwrite.Services {
+	return &adminWriteServices{e: e, db: db}
+}
+
+// RequirePermission hands ee core's RBAC middleware, so a write route keeps the
+// same per-caller check its community read sibling uses. The license layer
+// (RequireFeature) is ee's to add on top.
+func (s *adminWriteServices) RequirePermission(resourceType, op string) gin.HandlerFunc {
+	return RequirePermission(s.e, resourceType, op)
+}
+
+// CreateRole creates a custom role. Source is forced to custom — the API can
+// never mint a system or business role, whichever id or name is asked for.
+func (s *adminWriteServices) CreateRole(ctx context.Context, spec adminwrite.RoleSpec) (string, error) {
+	id := spec.ID
+	if id == "" {
+		id = auth.NewID()
+	}
+	role := model.Role{
+		ID: id, Name: spec.Name, Description: spec.Description,
+		Source: model.RoleSourceCustom,
+	}
+	if err := s.db.WithContext(ctx).Create(&role).Error; err != nil {
+		return "", err
+	}
+	return role.ID, nil
+}
+
+// UpdateRole renames/re-describes a custom role. Built-ins are immutable.
+func (s *adminWriteServices) UpdateRole(ctx context.Context, id string, patch adminwrite.RolePatch) error {
+	role, err := s.loadCustomRole(ctx, id)
+	if err != nil {
+		return err
+	}
+	fields := map[string]any{}
+	if patch.Name != nil {
+		fields["name"] = *patch.Name
+	}
+	if patch.Description != nil {
+		fields["description"] = *patch.Description
+	}
+	if len(fields) == 0 {
+		return fmt.Errorf("%w: no updatable fields provided", adminwrite.ErrInvalid)
+	}
+	return s.db.WithContext(ctx).Model(&model.Role{}).Where("id = ?", role.ID).Updates(fields).Error
+}
+
+// DeleteRole deletes a custom role and purges its casbin bindings and grants.
+func (s *adminWriteServices) DeleteRole(ctx context.Context, id string) error {
+	role, err := s.loadCustomRole(ctx, id)
+	if err != nil {
+		return err
+	}
+	if err := s.db.WithContext(ctx).Delete(&model.Role{}, "id = ?", role.ID).Error; err != nil {
+		return err
+	}
+	return s.e.RemoveRoleCompletely(role.ID)
+}
+
+// GrantRolePermission grants a custom role an op over a resource pattern. It
+// refuses the two wildcard forms that would make the policy match everything,
+// and refuses the admin-console capability outright: administrative capability
+// comes from a seeded role binding, never from a grant handed out at runtime,
+// or this route becomes an admin-promotion route.
+func (s *adminWriteServices) GrantRolePermission(ctx context.Context, roleID, resourceType, resourceID, op string) error {
+	role, err := s.loadCustomRole(ctx, roleID)
+	if err != nil {
+		return err
+	}
+	if err := rejectWildcardGrant(resourceType, []string{op}); err != nil {
+		return fmt.Errorf("%w: %s", adminwrite.ErrInvalid, err.Error())
+	}
+	if resourceType == adminConsoleResourceType {
+		return fmt.Errorf("%w: admin console capability is granted by role binding, not by role permissions", adminwrite.ErrForbidden)
+	}
+	return s.e.GrantRolePermission(role.ID, resourceType, resourceID, op)
+}
+
+// RevokeRolePermission revokes a custom role's op over a resource pattern.
+func (s *adminWriteServices) RevokeRolePermission(ctx context.Context, roleID, resourceType, resourceID, op string) error {
+	role, err := s.loadCustomRole(ctx, roleID)
+	if err != nil {
+		return err
+	}
+	return s.e.RevokeRolePermission(role.ID, resourceType, resourceID, op)
+}
+
+// loadCustomRole fetches a role and rejects built-ins. It maps to the
+// adminwrite sentinels so ee need not know the model.
+func (s *adminWriteServices) loadCustomRole(ctx context.Context, id string) (*model.Role, error) {
+	var role model.Role
+	err := s.db.WithContext(ctx).First(&role, "id = ?", id).Error
+	if errors.Is(err, gorm.ErrRecordNotFound) {
+		return nil, adminwrite.ErrNotFound
+	}
+	if err != nil {
+		return nil, err
+	}
+	if role.BuiltIn() {
+		return nil, adminwrite.ErrImmutable
+	}
+	return &role, nil
+}

--- a/bkn-safe/server/internal/httpapi/apikey.go
+++ b/bkn-safe/server/internal/httpapi/apikey.go
@@ -12,9 +12,9 @@ import (
 	"github.com/gin-gonic/gin"
 	"gorm.io/gorm"
 
-	"bkn-safe/internal/auth"
-	"bkn-safe/internal/authz"
-	"bkn-safe/internal/model"
+	"github.com/openbkn-ai/bkn-foundry/bkn-safe/server/internal/auth"
+	"github.com/openbkn-ai/bkn-foundry/bkn-safe/server/internal/authz"
+	"github.com/openbkn-ai/bkn-foundry/bkn-safe/server/internal/model"
 )
 
 // defaultKeyTTL is the validity granted when an issuer specifies neither an

--- a/bkn-safe/server/internal/httpapi/apikey_test.go
+++ b/bkn-safe/server/internal/httpapi/apikey_test.go
@@ -12,8 +12,8 @@ import (
 	"testing"
 	"time"
 
-	"bkn-safe/internal/auth"
-	"bkn-safe/internal/model"
+	"github.com/openbkn-ai/bkn-foundry/bkn-safe/server/internal/auth"
+	"github.com/openbkn-ai/bkn-foundry/bkn-safe/server/internal/model"
 )
 
 const (

--- a/bkn-safe/server/internal/httpapi/audit.go
+++ b/bkn-safe/server/internal/httpapi/audit.go
@@ -16,10 +16,10 @@ import (
 	"github.com/gin-gonic/gin"
 	"gorm.io/gorm"
 
-	"bkn-safe/internal/audit"
-	"bkn-safe/internal/authz"
-	"bkn-safe/internal/directory"
-	"bkn-safe/internal/model"
+	"github.com/openbkn-ai/bkn-foundry/bkn-safe/server/internal/audit"
+	"github.com/openbkn-ai/bkn-foundry/bkn-safe/server/internal/authz"
+	"github.com/openbkn-ai/bkn-foundry/bkn-safe/server/internal/directory"
+	"github.com/openbkn-ai/bkn-foundry/bkn-safe/server/internal/model"
 )
 
 const adminPathPrefix = "/api/safe/v1/admin/"

--- a/bkn-safe/server/internal/httpapi/auth.go
+++ b/bkn-safe/server/internal/httpapi/auth.go
@@ -15,7 +15,7 @@ import (
 
 	"github.com/gin-gonic/gin"
 
-	"bkn-safe/internal/auth"
+	"github.com/openbkn-ai/bkn-foundry/bkn-safe/server/internal/auth"
 )
 
 // registerAuth mounts the hydra login/consent/device provider pages. hydra is

--- a/bkn-safe/server/internal/httpapi/authz.go
+++ b/bkn-safe/server/internal/httpapi/authz.go
@@ -13,9 +13,9 @@ import (
 	"github.com/gin-gonic/gin"
 	"gorm.io/gorm"
 
-	"bkn-safe/internal/auth"
-	"bkn-safe/internal/authz"
-	"bkn-safe/internal/model"
+	"github.com/openbkn-ai/bkn-foundry/bkn-safe/server/internal/auth"
+	"github.com/openbkn-ai/bkn-foundry/bkn-safe/server/internal/authz"
+	"github.com/openbkn-ai/bkn-foundry/bkn-safe/server/internal/model"
 )
 
 var threeAdminRoleIDs = []string{

--- a/bkn-safe/server/internal/httpapi/authz.go
+++ b/bkn-safe/server/internal/httpapi/authz.go
@@ -13,7 +13,6 @@ import (
 	"github.com/gin-gonic/gin"
 	"gorm.io/gorm"
 
-	"github.com/openbkn-ai/bkn-foundry/bkn-safe/server/internal/auth"
 	"github.com/openbkn-ai/bkn-foundry/bkn-safe/server/internal/authz"
 	"github.com/openbkn-ai/bkn-foundry/bkn-safe/server/internal/model"
 )
@@ -496,164 +495,12 @@ func registerRoles(g *gin.RouterGroup, e *authz.Enforcer, db *gorm.DB) {
 		c.JSON(http.StatusOK, gin.H{"accessor_ids": members})
 	})
 
-	// POST /roles — create a custom role. source is forced to "custom" (the API
-	// cannot mint system/business roles). { id?, name, description? } -> { id }
-	g.POST("/roles", RequirePermission(e, "admin-role", "create"), func(c *gin.Context) {
-		var req struct {
-			ID          string `json:"id"`
-			Name        string `json:"name" binding:"required"`
-			Description string `json:"description"`
-		}
-		if !bind(c, &req) {
-			return
-		}
-		if req.ID == "" {
-			req.ID = auth.NewID()
-		}
-		role := model.Role{
-			ID: req.ID, Name: req.Name, Description: req.Description,
-			Source: model.RoleSourceCustom,
-		}
-		if err := db.WithContext(c.Request.Context()).Create(&role).Error; err != nil {
-			serverError(c, err)
-			return
-		}
-		c.JSON(http.StatusCreated, gin.H{"id": role.ID})
-	})
-
-	// PUT /roles/:id — rename / re-describe a CUSTOM role. Built-in roles are
-	// rejected with 403. { name?, description? }
-	g.PUT("/roles/:id", RequirePermission(e, "admin-role", "edit"), func(c *gin.Context) {
-		role, _ := loadRole(c, db, c.Param("id"))
-		if role == nil {
-			return
-		}
-		if role.BuiltIn() {
-			c.JSON(http.StatusForbidden, gin.H{"error": "built-in role is immutable"})
-			return
-		}
-		var req struct {
-			Name        *string `json:"name"`
-			Description *string `json:"description"`
-		}
-		if !bind(c, &req) {
-			return
-		}
-		fields := map[string]any{}
-		if req.Name != nil {
-			fields["name"] = *req.Name
-		}
-		if req.Description != nil {
-			fields["description"] = *req.Description
-		}
-		if len(fields) == 0 {
-			c.JSON(http.StatusBadRequest, gin.H{"error": "no updatable fields provided"})
-			return
-		}
-		if err := db.WithContext(c.Request.Context()).Model(&model.Role{}).
-			Where("id = ?", role.ID).Updates(fields).Error; err != nil {
-			serverError(c, err)
-			return
-		}
-		c.Status(http.StatusNoContent)
-	})
-
-	// DELETE /roles/:id — delete a CUSTOM role and purge its casbin bindings and
-	// permission grants. Built-in roles are rejected with 403.
-	g.DELETE("/roles/:id", RequirePermission(e, "admin-role", "delete"), func(c *gin.Context) {
-		role, _ := loadRole(c, db, c.Param("id"))
-		if role == nil {
-			return
-		}
-		if role.BuiltIn() {
-			c.JSON(http.StatusForbidden, gin.H{"error": "built-in role is immutable"})
-			return
-		}
-		if err := db.WithContext(c.Request.Context()).Delete(&model.Role{}, "id = ?", role.ID).Error; err != nil {
-			serverError(c, err)
-			return
-		}
-		if err := e.RemoveRoleCompletely(role.ID); err != nil {
-			serverError(c, err)
-			return
-		}
-		c.Status(http.StatusNoContent)
-	})
-
-	// POST /roles/:id/permissions — grant a CUSTOM role an op over a resource
-	// pattern (id "*" = whole type). { resource{type,id}, operations:[...] }
-	g.POST("/roles/:id/permissions", RequirePermission(e, "admin-authz", "grant"), func(c *gin.Context) {
-		role, _ := loadRole(c, db, c.Param("id"))
-		if role == nil {
-			return
-		}
-		if role.BuiltIn() {
-			c.JSON(http.StatusForbidden, gin.H{"error": "built-in role permissions are seed-managed"})
-			return
-		}
-		var req struct {
-			Resource   resourceRef `json:"resource" binding:"required"`
-			Operations []string    `json:"operations" binding:"required"`
-		}
-		if !bind(c, &req) {
-			return
-		}
-		// A wildcard resource TYPE (or operation) makes the policy match every
-		// object in the system — the same shape as the seeded super_admin grant.
-		// Minting that from a custom role turns this route into an escalation
-		// path. A wildcard resource ID stays allowed: "whole type" is this
-		// route's documented purpose and is what the admin console sends.
-		if err := rejectWildcardGrant(req.Resource.Type, req.Operations); err != nil {
-			c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
-			return
-		}
-		// Same invariant the object-grant route enforces: administrative
-		// capability comes from a seeded role binding, never from a grant handed
-		// out at runtime. Without this, a custom role could be given
-		// safe_admin:console:manage and then bound to its own author. Today no
-		// role that can reach this route lacks that capability already, so this
-		// is defence in depth rather than a live hole — but that is a property of
-		// the current grant matrix, not of the code, and splitting out a
-		// role-management role would quietly turn it into one.
-		if req.Resource.Type == adminConsoleResourceType {
-			c.JSON(http.StatusForbidden, gin.H{"error": "admin console capability is granted by role binding, not by role permissions"})
-			return
-		}
-		for _, op := range req.Operations {
-			if err := e.GrantRolePermission(role.ID, req.Resource.Type, req.Resource.ID, op); err != nil {
-				serverError(c, err)
-				return
-			}
-		}
-		c.Status(http.StatusNoContent)
-	})
-
-	// DELETE /roles/:id/permissions — revoke a CUSTOM role's ops over a resource
-	// pattern. { resource{type,id}, operations:[...] }
-	g.DELETE("/roles/:id/permissions", RequirePermission(e, "admin-authz", "revoke"), func(c *gin.Context) {
-		role, _ := loadRole(c, db, c.Param("id"))
-		if role == nil {
-			return
-		}
-		if role.BuiltIn() {
-			c.JSON(http.StatusForbidden, gin.H{"error": "built-in role permissions are seed-managed"})
-			return
-		}
-		var req struct {
-			Resource   resourceRef `json:"resource" binding:"required"`
-			Operations []string    `json:"operations" binding:"required"`
-		}
-		if !bind(c, &req) {
-			return
-		}
-		for _, op := range req.Operations {
-			if err := e.RevokeRolePermission(role.ID, req.Resource.Type, req.Resource.ID, op); err != nil {
-				serverError(c, err)
-				return
-			}
-		}
-		c.Status(http.StatusNoContent)
-	})
+	// Write routes (POST/PUT/DELETE /roles, POST/DELETE /roles/:id/permissions)
+	// are the rbac_basic sample: they are mounted by the enterprise build via
+	// the extension/adminwrite socket, not here. A community binary never mounts
+	// them, so probing them returns 404 — the endpoint does not exist rather
+	// than existing-but-refusing. See router.go's adminwrite.Mount and
+	// adminwrite_svc.go for the guarded operations they call. (#277/#278)
 }
 
 // loadRole fetches a role by id, writing a 404 and returning nil when missing

--- a/bkn-safe/server/internal/httpapi/builtinadmin_test.go
+++ b/bkn-safe/server/internal/httpapi/builtinadmin_test.go
@@ -8,8 +8,8 @@ import (
 	"net/http"
 	"testing"
 
-	"bkn-safe/internal/model"
-	"bkn-safe/internal/seed"
+	"github.com/openbkn-ai/bkn-foundry/bkn-safe/server/internal/model"
+	"github.com/openbkn-ai/bkn-foundry/bkn-safe/server/internal/seed"
 )
 
 // TestBuiltInAdminUserProtected verifies the user-admin API refuses to delete or

--- a/bkn-safe/server/internal/httpapi/capabilities.go
+++ b/bkn-safe/server/internal/httpapi/capabilities.go
@@ -1,0 +1,88 @@
+// Copyright openbkn.ai
+//
+// Licensed under the OpenBKN License. See LICENSE-OPENBKN.txt in the project root.
+
+package httpapi
+
+import (
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+
+	"github.com/openbkn-ai/bkn-foundry/bkn-safe/server/extension"
+	"github.com/openbkn-ai/bkn-foundry/bkn-safe/server/internal/license"
+)
+
+// capabilitiesResponse is what the frontend reads to show or hide paid entry
+// points. Enforcement is never here — every gated call site checks the license
+// itself. This endpoint only spares users a menu full of things that would
+// refuse them.
+type capabilitiesResponse struct {
+	// Edition and State come from the license, for the activation banner.
+	Edition string `json:"edition"`
+	State   string `json:"state"`
+	// Features is what the license carries — including enterprise features
+	// this binary cannot serve. Kept separate from Capabilities so support can
+	// tell "not licensed" apart from "licensed, wrong image".
+	Features []string `json:"features"`
+	// Capabilities is what this binary can actually do right now: a licensed
+	// mode ① feature, or a mode ② feature whose ee implementation is plugged
+	// in. This is the list the frontend should drive off.
+	Capabilities []string `json:"capabilities"`
+	// Limits are the numeric caps the license carries.
+	Limits map[string]int64 `json:"limits"`
+	// Extensions lists the enterprise sockets filled in this build. Empty in
+	// every community binary — the code is not there to fill them.
+	Extensions []string `json:"extensions"`
+}
+
+// registerCapabilities mounts GET /capabilities.
+//
+// The design calls this endpoint /api/capabilities; on bkn-safe it lands under
+// the service's own prefix, and the gateway exposes it. Any authenticated user
+// may read it: it describes the deployment, carries no per-user authorization,
+// and the frontend needs it on every login to lay out the menu.
+func registerCapabilities(g *gin.RouterGroup, svc *license.Service) {
+	g.GET("/capabilities", func(c *gin.Context) {
+		resp := capabilitiesResponse{
+			State:        string(licenseStateOrUnlicensed(svc)),
+			Features:     []string{},
+			Capabilities: []string{},
+			Limits:       map[string]int64{},
+			Extensions:   extension.Registered(),
+		}
+
+		if svc != nil {
+			if snap := svc.State(); snap.Payload != nil {
+				resp.Edition = snap.Payload.Edition
+				if snap.Payload.Features != nil {
+					resp.Features = snap.Payload.Features
+				}
+				if snap.Payload.Limits != nil {
+					resp.Limits = snap.Payload.Limits
+				}
+			}
+		}
+
+		// A feature is usable when the license carries it AND, for enterprise
+		// features, the ee code is present. Derived per request rather than
+		// cached, so a lapsed or hot-reloaded license shows up immediately.
+		for _, f := range resp.Features {
+			if extension.Usable(extension.Feature(f)) {
+				resp.Capabilities = append(resp.Capabilities, f)
+			}
+		}
+
+		c.JSON(http.StatusOK, resp)
+	})
+}
+
+// licenseStateOrUnlicensed reports the license state, treating a disabled
+// license hub as unlicensed — which is the truth from a capability standpoint
+// and keeps the response shape stable.
+func licenseStateOrUnlicensed(svc *license.Service) string {
+	if svc == nil {
+		return "unlicensed"
+	}
+	return string(svc.State().State)
+}

--- a/bkn-safe/server/internal/httpapi/clientadmin.go
+++ b/bkn-safe/server/internal/httpapi/clientadmin.go
@@ -12,7 +12,7 @@ import (
 
 	"github.com/gin-gonic/gin"
 
-	"bkn-safe/internal/authz"
+	"github.com/openbkn-ai/bkn-foundry/bkn-safe/server/internal/authz"
 )
 
 // ClientManager is the slice of hydra's OAuth2 client admin that bkn-safe exposes:

--- a/bkn-safe/server/internal/httpapi/clientadmin_test.go
+++ b/bkn-safe/server/internal/httpapi/clientadmin_test.go
@@ -14,11 +14,11 @@ import (
 	"github.com/glebarez/sqlite"
 	"gorm.io/gorm"
 
-	"bkn-safe/internal/audit"
-	"bkn-safe/internal/auth"
-	"bkn-safe/internal/authz"
-	"bkn-safe/internal/database"
-	"bkn-safe/internal/directory"
+	"github.com/openbkn-ai/bkn-foundry/bkn-safe/server/internal/audit"
+	"github.com/openbkn-ai/bkn-foundry/bkn-safe/server/internal/auth"
+	"github.com/openbkn-ai/bkn-foundry/bkn-safe/server/internal/authz"
+	"github.com/openbkn-ai/bkn-foundry/bkn-safe/server/internal/database"
+	"github.com/openbkn-ai/bkn-foundry/bkn-safe/server/internal/directory"
 )
 
 // fakeClientManager is an in-memory ClientManager (clientID -> redirect_uris) so

--- a/bkn-safe/server/internal/httpapi/directory.go
+++ b/bkn-safe/server/internal/httpapi/directory.go
@@ -13,10 +13,10 @@ import (
 	"github.com/gin-gonic/gin"
 	"gorm.io/gorm"
 
-	"bkn-safe/internal/auth"
-	"bkn-safe/internal/authz"
-	"bkn-safe/internal/directory"
-	"bkn-safe/internal/model"
+	"github.com/openbkn-ai/bkn-foundry/bkn-safe/server/internal/auth"
+	"github.com/openbkn-ai/bkn-foundry/bkn-safe/server/internal/authz"
+	"github.com/openbkn-ai/bkn-foundry/bkn-safe/server/internal/directory"
+	"github.com/openbkn-ai/bkn-foundry/bkn-safe/server/internal/model"
 )
 
 // registerDirectory mounts bkn-safe's clean user-directory API under

--- a/bkn-safe/server/internal/httpapi/license.go
+++ b/bkn-safe/server/internal/httpapi/license.go
@@ -13,9 +13,9 @@ import (
 	"github.com/gin-gonic/gin"
 	"github.com/openbkn-ai/licverify"
 
-	"bkn-safe/internal/auth"
-	"bkn-safe/internal/authz"
-	"bkn-safe/internal/license"
+	"github.com/openbkn-ai/bkn-foundry/bkn-safe/server/internal/auth"
+	"github.com/openbkn-ai/bkn-foundry/bkn-safe/server/internal/authz"
+	"github.com/openbkn-ai/bkn-foundry/bkn-safe/server/internal/license"
 )
 
 // registerLicenseAdmin mounts the license management surface on the admin

--- a/bkn-safe/server/internal/httpapi/license_test.go
+++ b/bkn-safe/server/internal/httpapi/license_test.go
@@ -19,14 +19,14 @@ import (
 	"github.com/openbkn-ai/licverify"
 	"gorm.io/gorm"
 
-	"bkn-safe/config"
-	"bkn-safe/internal/audit"
-	"bkn-safe/internal/auth"
-	"bkn-safe/internal/authz"
-	"bkn-safe/internal/database"
-	"bkn-safe/internal/directory"
-	"bkn-safe/internal/license"
-	"bkn-safe/internal/model"
+	"github.com/openbkn-ai/bkn-foundry/bkn-safe/server/config"
+	"github.com/openbkn-ai/bkn-foundry/bkn-safe/server/internal/audit"
+	"github.com/openbkn-ai/bkn-foundry/bkn-safe/server/internal/auth"
+	"github.com/openbkn-ai/bkn-foundry/bkn-safe/server/internal/authz"
+	"github.com/openbkn-ai/bkn-foundry/bkn-safe/server/internal/database"
+	"github.com/openbkn-ai/bkn-foundry/bkn-safe/server/internal/directory"
+	"github.com/openbkn-ai/bkn-foundry/bkn-safe/server/internal/license"
+	"github.com/openbkn-ai/bkn-foundry/bkn-safe/server/internal/model"
 )
 
 // newLicenseServer builds a full server with the license surfaces mounted: a

--- a/bkn-safe/server/internal/httpapi/me.go
+++ b/bkn-safe/server/internal/httpapi/me.go
@@ -13,10 +13,10 @@ import (
 	"github.com/gin-gonic/gin"
 	"gorm.io/gorm"
 
-	"bkn-safe/internal/auth"
-	"bkn-safe/internal/authz"
-	"bkn-safe/internal/directory"
-	"bkn-safe/internal/model"
+	"github.com/openbkn-ai/bkn-foundry/bkn-safe/server/internal/auth"
+	"github.com/openbkn-ai/bkn-foundry/bkn-safe/server/internal/authz"
+	"github.com/openbkn-ai/bkn-foundry/bkn-safe/server/internal/directory"
+	"github.com/openbkn-ai/bkn-foundry/bkn-safe/server/internal/model"
 )
 
 // registerMeReads mounts the READ-ONLY self-service endpoints under

--- a/bkn-safe/server/internal/httpapi/me_cache_test.go
+++ b/bkn-safe/server/internal/httpapi/me_cache_test.go
@@ -17,11 +17,11 @@ import (
 	"github.com/glebarez/sqlite"
 	"gorm.io/gorm"
 
-	"bkn-safe/internal/auth"
-	"bkn-safe/internal/authz"
-	"bkn-safe/internal/database"
-	"bkn-safe/internal/directory"
-	"bkn-safe/internal/model"
+	"github.com/openbkn-ai/bkn-foundry/bkn-safe/server/internal/auth"
+	"github.com/openbkn-ai/bkn-foundry/bkn-safe/server/internal/authz"
+	"github.com/openbkn-ai/bkn-foundry/bkn-safe/server/internal/database"
+	"github.com/openbkn-ai/bkn-foundry/bkn-safe/server/internal/directory"
+	"github.com/openbkn-ai/bkn-foundry/bkn-safe/server/internal/model"
 )
 
 // revocableVerifier resolves any non-empty token to itself until Revoke flips

--- a/bkn-safe/server/internal/httpapi/me_test.go
+++ b/bkn-safe/server/internal/httpapi/me_test.go
@@ -10,7 +10,7 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	"bkn-safe/internal/model"
+	"github.com/openbkn-ai/bkn-foundry/bkn-safe/server/internal/model"
 )
 
 func TestMeAuthGate(t *testing.T) {

--- a/bkn-safe/server/internal/httpapi/objectgrants.go
+++ b/bkn-safe/server/internal/httpapi/objectgrants.go
@@ -11,8 +11,8 @@ import (
 	"github.com/gin-gonic/gin"
 	"gorm.io/gorm"
 
-	"bkn-safe/internal/authz"
-	"bkn-safe/internal/model"
+	"github.com/openbkn-ai/bkn-foundry/bkn-safe/server/internal/authz"
+	"github.com/openbkn-ai/bkn-foundry/bkn-safe/server/internal/model"
 )
 
 // registerObjectGrants mounts the object-level authorization management API

--- a/bkn-safe/server/internal/httpapi/objectgrants_test.go
+++ b/bkn-safe/server/internal/httpapi/objectgrants_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/gin-gonic/gin"
 	"gorm.io/gorm"
 
-	"bkn-safe/internal/model"
+	"github.com/openbkn-ai/bkn-foundry/bkn-safe/server/internal/model"
 )
 
 // seedCatalogOps registers operation ids for a resource type so the

--- a/bkn-safe/server/internal/httpapi/router.go
+++ b/bkn-safe/server/internal/httpapi/router.go
@@ -12,11 +12,11 @@ import (
 	"github.com/gin-gonic/gin"
 	"gorm.io/gorm"
 
-	"bkn-safe/internal/audit"
-	"bkn-safe/internal/auth"
-	"bkn-safe/internal/authz"
-	"bkn-safe/internal/directory"
-	"bkn-safe/internal/license"
+	"github.com/openbkn-ai/bkn-foundry/bkn-safe/server/internal/audit"
+	"github.com/openbkn-ai/bkn-foundry/bkn-safe/server/internal/auth"
+	"github.com/openbkn-ai/bkn-foundry/bkn-safe/server/internal/authz"
+	"github.com/openbkn-ai/bkn-foundry/bkn-safe/server/internal/directory"
+	"github.com/openbkn-ai/bkn-foundry/bkn-safe/server/internal/license"
 )
 
 // Deps are the collaborators the HTTP layer needs.
@@ -148,6 +148,12 @@ func New(deps Deps) *gin.Engine {
 		// verifier.
 		meReads := r.Group("/api/safe/v1/me", RequireUser(meVerifier))
 		registerMeReads(meReads, deps.Enforcer, deps.DB, deps.Directory)
+
+		// What this deployment can do, for the frontend's menu. Authn only:
+		// it describes the cluster, not the caller. Enforcement stays at each
+		// gated call site (open-core-gating §2.5).
+		caps := r.Group("/api/safe/v1", RequireUser(meVerifier))
+		registerCapabilities(caps, deps.License)
 
 		// Mutating /me (profile PUT, AppKey issue/revoke) uses the RAW verifier so
 		// a revoked/logged-out token cannot edit the profile or mint a long-lived

--- a/bkn-safe/server/internal/httpapi/router.go
+++ b/bkn-safe/server/internal/httpapi/router.go
@@ -7,11 +7,13 @@
 package httpapi
 
 import (
+	"log/slog"
 	"net/http"
 
 	"github.com/gin-gonic/gin"
 	"gorm.io/gorm"
 
+	"github.com/openbkn-ai/bkn-foundry/bkn-safe/server/extension/adminwrite"
 	"github.com/openbkn-ai/bkn-foundry/bkn-safe/server/internal/audit"
 	"github.com/openbkn-ai/bkn-foundry/bkn-safe/server/internal/auth"
 	"github.com/openbkn-ai/bkn-foundry/bkn-safe/server/internal/authz"
@@ -114,6 +116,14 @@ func New(deps Deps) *gin.Engine {
 		registerRoleBindings(admin, deps.Enforcer, deps.DB)
 		registerRoles(admin, deps.Enforcer, deps.DB)
 		registerObjectGrants(admin, deps.Enforcer, deps.DB)
+		// rbac_basic write routes (custom role create/update/delete + role
+		// permission grant/revoke) are mounted by the enterprise build through
+		// the adminwrite socket. In a community binary no mounter was registered,
+		// so Mount is a no-op and those endpoints stay absent (404). The guarded
+		// operations live in newAdminWriteServices; ee owns only the HTTP shape.
+		if adminwrite.Mount(admin, newAdminWriteServices(deps.Enforcer, deps.DB)) {
+			slog.Info("rbac_basic admin write routes mounted (enterprise build)")
+		}
 		// Global AppKey oversight: list/revoke any user's keys.
 		if apiKeys != nil {
 			registerAdminAPIKeys(admin, apiKeys, deps.Enforcer)

--- a/bkn-safe/server/internal/httpapi/router_test.go
+++ b/bkn-safe/server/internal/httpapi/router_test.go
@@ -15,11 +15,11 @@ import (
 	"github.com/glebarez/sqlite"
 	"gorm.io/gorm"
 
-	"bkn-safe/internal/auth"
-	"bkn-safe/internal/authz"
-	"bkn-safe/internal/database"
-	"bkn-safe/internal/directory"
-	"bkn-safe/internal/model"
+	"github.com/openbkn-ai/bkn-foundry/bkn-safe/server/internal/auth"
+	"github.com/openbkn-ai/bkn-foundry/bkn-safe/server/internal/authz"
+	"github.com/openbkn-ai/bkn-foundry/bkn-safe/server/internal/database"
+	"github.com/openbkn-ai/bkn-foundry/bkn-safe/server/internal/directory"
+	"github.com/openbkn-ai/bkn-foundry/bkn-safe/server/internal/model"
 )
 
 func newTestServer(t *testing.T) (*gin.Engine, *authz.Enforcer, *gorm.DB) {

--- a/bkn-safe/server/internal/httpapi/useradmin.go
+++ b/bkn-safe/server/internal/httpapi/useradmin.go
@@ -11,11 +11,11 @@ import (
 	"github.com/gin-gonic/gin"
 	"gorm.io/gorm"
 
-	"bkn-safe/internal/auth"
-	"bkn-safe/internal/authz"
-	"bkn-safe/internal/directory"
-	"bkn-safe/internal/model"
-	"bkn-safe/internal/seed"
+	"github.com/openbkn-ai/bkn-foundry/bkn-safe/server/internal/auth"
+	"github.com/openbkn-ai/bkn-foundry/bkn-safe/server/internal/authz"
+	"github.com/openbkn-ai/bkn-foundry/bkn-safe/server/internal/directory"
+	"github.com/openbkn-ai/bkn-foundry/bkn-safe/server/internal/model"
+	"github.com/openbkn-ai/bkn-foundry/bkn-safe/server/internal/seed"
 )
 
 // registerUserAdmin mounts the user-write surface bkn-safe needs to own

--- a/bkn-safe/server/internal/license/client.go
+++ b/bkn-safe/server/internal/license/client.go
@@ -17,7 +17,7 @@ import (
 	"os"
 	"time"
 
-	"bkn-safe/config"
+	"github.com/openbkn-ai/bkn-foundry/bkn-safe/server/config"
 )
 
 // ErrActivatedElsewhere is the issuer's 409: the license is already bound to a

--- a/bkn-safe/server/internal/license/e2e_test.go
+++ b/bkn-safe/server/internal/license/e2e_test.go
@@ -24,8 +24,8 @@ import (
 
 	"github.com/openbkn-ai/licverify"
 
-	"bkn-safe/config"
-	"bkn-safe/internal/audit"
+	"github.com/openbkn-ai/bkn-foundry/bkn-safe/server/config"
+	"github.com/openbkn-ai/bkn-foundry/bkn-safe/server/internal/audit"
 )
 
 const (

--- a/bkn-safe/server/internal/license/service.go
+++ b/bkn-safe/server/internal/license/service.go
@@ -28,9 +28,9 @@ import (
 	"github.com/openbkn-ai/licverify/keys"
 	"gorm.io/gorm"
 
-	"bkn-safe/config"
-	"bkn-safe/internal/audit"
-	"bkn-safe/internal/model"
+	"github.com/openbkn-ai/bkn-foundry/bkn-safe/server/config"
+	"github.com/openbkn-ai/bkn-foundry/bkn-safe/server/internal/audit"
+	"github.com/openbkn-ai/bkn-foundry/bkn-safe/server/internal/model"
 )
 
 const rowID = "current"
@@ -124,6 +124,27 @@ func NewWithKeyTable(db *gorm.DB, cfg config.LicenseConfig, aud *audit.Store, ke
 
 // State returns the current gating snapshot (atomic, hot-path safe).
 func (s *Service) State() licverify.Snapshot { return s.guard.State() }
+
+// FeatureEnabled reports whether the license currently carries a paid feature.
+// It reads the live snapshot on every call and caches nothing, so a hot-reload,
+// an expiry, or a revocation takes effect everywhere without a restart
+// (open-core-gating §2.7 rule 5).
+//
+// Only StateValid and StateGrace carry paid features. Every other state — a
+// license that lapsed past grace, an unverifiable file, a fresh install inside
+// its trial window, an unactivated cluster — resolves to the community feature
+// set. That is a downgrade of paid capability only: community capability is not
+// gated at all, and data stays readable and exportable in every state.
+func (s *Service) FeatureEnabled(name string) bool {
+	snap := s.guard.State()
+	if snap.State != licverify.StateValid && snap.State != licverify.StateGrace {
+		return false
+	}
+	if snap.Payload == nil {
+		return false // a valid state always carries a payload; never gate on a nil deref
+	}
+	return snap.Payload.HasFeature(name)
+}
 
 // Fingerprint returns this cluster's instance fingerprint. Available with or
 // without a license — the activation guide shows it before anything is imported.

--- a/bkn-safe/server/internal/license/service_test.go
+++ b/bkn-safe/server/internal/license/service_test.go
@@ -19,10 +19,10 @@ import (
 	"github.com/openbkn-ai/licverify"
 	"gorm.io/gorm"
 
-	"bkn-safe/config"
-	"bkn-safe/internal/audit"
-	"bkn-safe/internal/database"
-	"bkn-safe/internal/model"
+	"github.com/openbkn-ai/bkn-foundry/bkn-safe/server/config"
+	"github.com/openbkn-ai/bkn-foundry/bkn-safe/server/internal/audit"
+	"github.com/openbkn-ai/bkn-foundry/bkn-safe/server/internal/database"
+	"github.com/openbkn-ai/bkn-foundry/bkn-safe/server/internal/model"
 )
 
 const testInstanceID = "test-cluster-uid"

--- a/bkn-safe/server/internal/seed/matrix_test.go
+++ b/bkn-safe/server/internal/seed/matrix_test.go
@@ -7,7 +7,7 @@ package seed
 import (
 	"testing"
 
-	"bkn-safe/internal/authz"
+	"github.com/openbkn-ai/bkn-foundry/bkn-safe/server/internal/authz"
 )
 
 // TestRoleResourceMatrix is the authz equivalence / no-leak proof: default

--- a/bkn-safe/server/internal/seed/seed.go
+++ b/bkn-safe/server/internal/seed/seed.go
@@ -21,9 +21,9 @@ import (
 	"gorm.io/gorm"
 	"gorm.io/gorm/clause"
 
-	"bkn-safe/internal/auth"
-	"bkn-safe/internal/authz"
-	"bkn-safe/internal/model"
+	"github.com/openbkn-ai/bkn-foundry/bkn-safe/server/internal/auth"
+	"github.com/openbkn-ai/bkn-foundry/bkn-safe/server/internal/authz"
+	"github.com/openbkn-ai/bkn-foundry/bkn-safe/server/internal/model"
 )
 
 // Built-in admin: a local login bound to super-admin via role-bindings.json

--- a/bkn-safe/server/internal/seed/seed_test.go
+++ b/bkn-safe/server/internal/seed/seed_test.go
@@ -10,9 +10,9 @@ import (
 	"github.com/glebarez/sqlite"
 	"gorm.io/gorm"
 
-	"bkn-safe/internal/authz"
-	"bkn-safe/internal/database"
-	"bkn-safe/internal/model"
+	"github.com/openbkn-ai/bkn-foundry/bkn-safe/server/internal/authz"
+	"github.com/openbkn-ai/bkn-foundry/bkn-safe/server/internal/database"
+	"github.com/openbkn-ai/bkn-foundry/bkn-safe/server/internal/model"
 )
 
 func newDB(t *testing.T) *gorm.DB {

--- a/bkn-safe/server/main.go
+++ b/bkn-safe/server/main.go
@@ -8,8 +8,8 @@
 //
 // This is the community entry point. It registers no extensions, so the paid
 // enterprise code is not merely switched off here — it is not in the binary.
-// The enterprise entry point lives in the private bkn-foundry-ee repository
-// and differs only by its Setup calls between Boot and Run.
+// The enterprise entry point lives in the private openbkn-ee repository and
+// differs only by its Setup calls between Boot and Run.
 package main
 
 import (

--- a/bkn-safe/server/main.go
+++ b/bkn-safe/server/main.go
@@ -5,100 +5,30 @@
 // Command bkn-safe is the ISF replacement auth service: authentication
 // (hydra login/consent/device provider), authorization (Casbin), and user
 // management (directory + LDAP). hydra issues the tokens.
+//
+// This is the community entry point. It registers no extensions, so the paid
+// enterprise code is not merely switched off here — it is not in the binary.
+// The enterprise entry point lives in the private bkn-foundry-ee repository
+// and differs only by its Setup calls between Boot and Run.
 package main
 
 import (
-	"context"
 	"flag"
 	"log/slog"
 	"os"
 
-	"bkn-safe/config"
-	"bkn-safe/internal/audit"
-	"bkn-safe/internal/auth"
-	"bkn-safe/internal/authz"
-	"bkn-safe/internal/database"
-	"bkn-safe/internal/directory"
-	"bkn-safe/internal/httpapi"
-	"bkn-safe/internal/license"
-	"bkn-safe/internal/seed"
+	"github.com/openbkn-ai/bkn-foundry/bkn-safe/server/app"
 )
 
 func main() {
 	configPath := flag.String("config", "", "YAML config file (overrides defaults; env SAFE_CONFIG if unset)")
 	flag.Parse()
 
-	cfg, err := config.LoadWithOptions(config.LoadOptions{ConfigPath: *configPath})
+	a, err := app.Boot(app.Options{ConfigPath: *configPath})
 	if err != nil {
-		fatal("load config", err)
+		fatal("boot", err)
 	}
-	if *configPath != "" || os.Getenv("SAFE_CONFIG") != "" {
-		path := *configPath
-		if path == "" {
-			path = os.Getenv("SAFE_CONFIG")
-		}
-		slog.Info("config loaded", "file", path)
-	}
-
-	db, err := database.Open(cfg.DB)
-	if err != nil {
-		fatal("open database", err)
-	}
-	if err := database.Migrate(db); err != nil {
-		fatal("migrate", err)
-	}
-
-	enforcer, err := authz.New(db)
-	if err != nil {
-		fatal("init authz", err)
-	}
-
-	if cfg.SeedOnStart {
-		if err := seed.Apply(db, enforcer); err != nil {
-			fatal("seed", err)
-		}
-		slog.Info("seed applied (roles + catalog + grants)")
-	}
-
-	userStore := auth.NewUserStore(db)
-	hydraAdmin := auth.NewHydraAdmin(cfg.Hydra.AdminURL)
-
-	// Authenticator: local bcrypt store, plus LDAP federation when configured
-	// (local first, then LDAP).
-	var authenticator auth.Authenticator = userStore
-	if cfg.LDAP.Enabled() {
-		authenticator = auth.NewChain(userStore, auth.NewLDAPAuthenticator(cfg.LDAP, db))
-		slog.Info("LDAP federation enabled", "url", cfg.LDAP.URL)
-	}
-	provider := auth.NewProvider(authenticator, hydraAdmin, userStore)
-	dir := directory.New(db)
-	auditStore := audit.New(db)
-
-	// Cluster license hub: hold the one .lic, be the only egress to the
-	// license-server, distribute to modules. Licensing must never block the
-	// auth service itself — on failure (e.g. no resolvable instance
-	// fingerprint) bkn-safe runs without the license surface.
-	licSvc, err := license.New(db, cfg.License, auditStore)
-	if err != nil {
-		slog.Error("license hub disabled", "err", err)
-		licSvc = nil
-	} else {
-		go licSvc.Run(context.Background())
-		slog.Info("license hub enabled", "instance_fp", licSvc.Fingerprint(), "server_url", cfg.License.ServerURL)
-	}
-
-	r := httpapi.New(httpapi.Deps{
-		Enforcer:  enforcer,
-		DB:        db,
-		Provider:  provider,
-		Hydra:     hydraAdmin,
-		Directory: dir,
-		Users:     userStore,
-		Audit:     auditStore,
-		License:   licSvc,
-	})
-	slog.Info("bkn-safe listening", "addr", cfg.HTTPAddr)
-	if err := r.Run(cfg.HTTPAddr); err != nil {
+	if err := a.Run(); err != nil {
 		fatal("http serve", err)
 	}
 }


### PR DESCRIPTION
Closes #277(core 侧部分);ee 侧已落私有仓 `openbkn-ai/bkn-foundry-ee`。

## 为什么先改模块路径

`bkn-safe/server` 的 module 名是 `bkn-safe`——本地名,不是可解析路径。ee 仓按设计
「`go.mod require core@tag`」根本立不起来。同仓其他模块本就规范(`bkn-trace/agent-observability`
用的是全路径),bkn-safe 是唯一例外。

改为 `github.com/openbkn-ai/bkn-foundry/bkn-safe/server`,48 个文件 import 机械替换,
构建与全部测试通过。发布时打嵌套 tag `bkn-safe/server/vX.Y.Z`。

> `bkn-safe/contract` 与 `bkn-safe/cmd/authz-shadow` 是独立模块、无人 import,本次未动。

## 插座为什么放在 `internal/` 外

Go 的 internal 规则会让 ee 仓根本 import 不到——插座必须是公开包。新增
`bkn-safe/server/extension`。

两套机制,不是一回事:

- **Gate(模式①)**:能力在开源仓,license 门控。每次调用重读快照、不缓存布尔值,
  热重载/过期/吊销无需重启即全局生效。零值拒绝一切付费能力——装配失误 fail closed。
- **Socket(模式②)**:能力在 ee 私有仓。防呆按设计执行:二次注册 panic、Freeze 后注册
  panic、无证注册 panic。三者都是装配 bug,必须启动即炸。

首个插座 `extension/permobject`(`perm_object_level`)**层叠在 core 判定之上而非替换它**。
core 的 casbin 是 allow-only 且无有效期,ee 补的正是 deny 与时限——恰是 #278 点名的
两个模型缺口。ee 报错时 fail closed:回落到 core 更宽松的判定等于把企业策略撤掉的
访问权又发回去。

## app 包

启动逻辑从 `main` 拆成可 import 的 `Boot`/`Run`,ee 才有入口可调。社区版与企业版跑
同一套启动代码,只差 `Boot` 与 `Run` 之间的 `Setup` 调用:

```go
a, _ := app.Boot(app.Options{})
permobject.Setup(a.DB())   // 仅企业版;无证则不注册
a.Run()                    // 冻结注册表 + 开始服务
```

## `/api/safe/v1/capabilities`

前端据此显隐入口,强制力仍在服务端各门控点。`features`(证书带什么)与
`capabilities`(本二进制真能做什么)分开报——支持同学要能把「没授权」和
「授权了但装的是社区镜像」区分开。

## CI

core 禁 ee import lint。core 出现一行 ee import,开源用户就再也构建不了,而引入它的
机器有凭据、CI 照绿。所以文本扫描 + 一次无凭据实编,双保险。

## 验证

- `go build ./...` 通过
- `go test ./...` 全绿(含新增 extension / permobject 用例:三类 panic、
  证书失效即时降级、deny 覆盖 allow、error fail closed)
- ee 仓 `bkn-foundry-ee` 对本分支实编 + 测试通过

## 尚未做(接续项)

- [ ] 合并后打 tag `bkn-safe/server/v0.1.2`,ee 仓删 `replace` 改钉版本
- [ ] `rbac_basic` 模式①门控样板接到真实调用点(自定义部门/角色/权限)。
      按兼容性铁律须走三段式:默认宽松 → 影子日志 → 全就位再翻转,不在本 PR 一步到位
- [ ] 升降级路径实测(社区→专业只换证;专业→企业同版本横切镜像、DB 原地不动)
- [ ] `/capabilities` 与 bkn-studio 联调
- [ ] `permobject.Decide`/`Apply` 目前在 core 无真实授权调用点,插座暂时空转。
      接线点等 #278 定切分线;接线时须为 error→Deny 的 fail-closed 路径补测试

🤖 Generated with [Claude Code](https://claude.com/claude-code)