### PR TITLE
feat(bkn-trace): emit context-loader subgraph evidence events

### DIFF
--- a/adp/context-loader/agent-retrieval/TRACE.md
+++ b/adp/context-loader/agent-retrieval/TRACE.md
@@ -89,6 +89,7 @@ Trust policy:
 - `context.query_object` 在 REST/MCP 成功返回后发射局部 L2 事件：`claim.created` 表示“本次对象实例查询产生了一个数据 finding”，`evidence.refs.created` 记录实例级 `row_ref`；`condition`、`filters`、`properties`、实例 identity 和行内容只能进入 hash，不得原样进入 payload。
 - `context.query_object` 的 `truncated=true` 只来自明确下一页信号：响应存在 `search_after`，或 `total_count > offset + returned_count`；不得用 `len(data) >= limit` 猜测截断。
 - `context.query_instance_subgraph` 在 service 成功返回后发射局部 L2 事件：`claim.created` 表示“本次实例子图查询产生了一个关系上下文 finding”，`evidence.refs.created` 记录相关实例 `row_ref` 和关系类型 `schema_ref`；`relation_type_paths`、实例 identity、路径条件和返回行内容只能进入 hash，不得原样进入 payload。
+- `context.query_instance_subgraph` 的 `evidence_refs` 最多保留 100 条，超过后 `subject_refs.refs_truncated=true` 且 `partial_reason` 包含 `refs_truncated`；关系类型只从 `relation`、`relations`、`relation_path(s)`、`relation_type(s)` 等关系容器提取，不从普通实例字段启发式提取。
 - `version_status` 当前为 `unversioned`，schema refs 必须携带 `partial_reason=["schema_ref_unversioned"]`，row refs 必须携带 `partial_reason=["row_ref_unversioned"]`；后续接入 BKN schema version / snapshot 后才能改为 `versioned`。
 - 证据事件上报由 `BKN_TRACE_EVIDENCE_INGEST_URL` 控制，默认关闭；开启后异步提交，不阻塞 schema 检索主路径。
 - 上报失败只记录 warning，不改变业务响应；BKN Trace 核心服务负责后续 Evidence Graph 汇聚、查询、快照和 Studio 可视化。

--- a/adp/context-loader/agent-retrieval/TRACE.md
+++ b/adp/context-loader/agent-retrieval/TRACE.md
@@ -19,6 +19,7 @@
 | --- | --- | --- | --- | --- |
 | `context.search_schema` | schema search HTTP/MCP/tool call | `traceparent`、`bkn-request-id`、account/auth context | `context-loader.request`、`context-loader.search` | `claim.created`、`evidence.refs.created`、`context.refs.resolved` |
 | `context.query_object` | object query HTTP/MCP/tool call | `traceparent`、`bkn-request-id`、account/auth context | `context-loader.request`、`context-loader.source.resolve` | `claim.created`、`evidence.refs.created`、`tool.called`、`tool.failed` |
+| `context.query_instance_subgraph` | instance subgraph HTTP/MCP/tool call | `traceparent`、`bkn-request-id`、account/auth context | `context-loader.request`、`context-loader.source.resolve` | `claim.created`、`evidence.refs.created` |
 | `context.load_refs` | source refs load | `traceparent`、`bkn-request-id`、business refs | `context-loader.source.resolve` | `context.refs.resolved` |
 | `context.resolve_source` | source resolver call | `traceparent`、`bkn-request-id`、resource refs | `context-loader.source.resolve` | `context.refs.resolved` |
 
@@ -86,7 +87,8 @@ Trust policy:
 - `claim.created.payload.claim_type` 固定为 `finding`，`claim_hash` 只基于结果数量、`kn_id`、`query_hash` 等摘要字段计算，不包含原始 query、schema 名称、comment、字段说明或完整结果。
 - `evidence.refs.created.payload.evidence_refs` 只包含 `ref_id`、`ref_type`、`source_system`、`summary_hash`、`validity`、`version_status`、`visibility`、`partial_reason`；`summary_hash` 来自安全摘要，不包含原始 schema 内容。
 - `context.query_object` 在 REST/MCP 成功返回后发射局部 L2 事件：`claim.created` 表示“本次对象实例查询产生了一个数据 finding”，`evidence.refs.created` 记录实例级 `row_ref`；`condition`、`filters`、`properties`、实例 identity 和行内容只能进入 hash，不得原样进入 payload。
-- `context.query_object` 的 `truncated=true` 来源包括响应存在 `search_after` 或返回条数达到请求 `limit`；该信号只表示“结果可能仍有后续页”，不表示审计级完整性。
+- `context.query_object` 的 `truncated=true` 只来自明确下一页信号：响应存在 `search_after`，或 `total_count > offset + returned_count`；不得用 `len(data) >= limit` 猜测截断。
+- `context.query_instance_subgraph` 在 service 成功返回后发射局部 L2 事件：`claim.created` 表示“本次实例子图查询产生了一个关系上下文 finding”，`evidence.refs.created` 记录相关实例 `row_ref` 和关系类型 `schema_ref`；`relation_type_paths`、实例 identity、路径条件和返回行内容只能进入 hash，不得原样进入 payload。
 - `version_status` 当前为 `unversioned`，schema refs 必须携带 `partial_reason=["schema_ref_unversioned"]`，row refs 必须携带 `partial_reason=["row_ref_unversioned"]`；后续接入 BKN schema version / snapshot 后才能改为 `versioned`。
 - 证据事件上报由 `BKN_TRACE_EVIDENCE_INGEST_URL` 控制，默认关闭；开启后异步提交，不阻塞 schema 检索主路径。
 - 上报失败只记录 warning，不改变业务响应；BKN Trace 核心服务负责后续 Evidence Graph 汇聚、查询、快照和 Studio 可视化。
@@ -137,6 +139,7 @@ Trust policy:
 | sampling | `fixtures/bkn-trace/sampling.json` | forced sampled tool error | pass |
 | phase2 positive | `fixtures/bkn-trace/phase2/search_schema_l2_positive.json` | schema search L2 finding and evidence refs | pass |
 | phase2 positive | `fixtures/bkn-trace/phase2/query_object_instance_l2_positive.json` | object query L2 finding and row refs | pass |
+| phase2 positive | `fixtures/bkn-trace/phase2/query_instance_subgraph_l2_positive.json` | instance subgraph L2 finding, row refs and relation schema refs | pass |
 | phase2 negative | `fixtures/bkn-trace/phase2/negative_raw_query_payload.json` | raw query/prompt payload rejection | fail |
 
 ## Covered GWT
@@ -153,10 +156,12 @@ Trust policy:
 - GWT-24 Given Trace 后端暂时不可用，When 异步上报失败，Then 只产生 warning，不改变 `search_schema` 的响应状态。
 - GWT-25 Given 合法入站 trace/request/account context，When `query_object_instance` 成功返回对象实例，Then 模块发射 `claim.created` 和 `evidence.refs.created`，其中实例证据为 `row_ref`。
 - GWT-26 Given 对象实例查询条件、属性列表、实例 identity 或返回行包含用户数据，When 生成 L2 证据事件，Then payload 只包含 condition/properties/identity/row hash，不包含原始过滤值、属性名、实例名或行级数据。
+- GWT-27 Given 合法入站 trace/request/account context，When `query_instance_subgraph` 成功返回关系子图，Then 模块发射 `claim.created` 和 `evidence.refs.created`，其中相关实例为 `row_ref`，关系类型为 `schema_ref`。
+- GWT-28 Given 子图 relation paths、实例 identity 或返回节点/边包含用户数据，When 生成 L2 证据事件，Then payload 只包含 path/identity/entry hash，不包含原始路径条件、实例主键值或行级数据。
 
 ## Known Gaps
 
-- runtime L2 emitter currently covers `context.search_schema` and `context.query_object` row refs; `query_instance_subgraph`、`run_sql` and resolver-level source refs remain follow-up.
+- runtime L2 emitter currently covers `context.search_schema`、`context.query_object` row refs and `context.query_instance_subgraph` row/schema refs; `run_sql` and resolver-level source refs remain follow-up.
 - cross-module global Evidence Graph assembly is owned by BKN Trace core service, not by context-loader.
 - full registry validation and indexing policy validation currently rely on `bkn-docs` validator follow-up.
 - audit-grade evidence snapshot, versioned schema refs, source data snapshot refs, and Studio visualization belong to later BKN Trace phases.

--- a/adp/context-loader/agent-retrieval/fixtures/bkn-trace/phase2/query_instance_subgraph_l2_positive.json
+++ b/adp/context-loader/agent-retrieval/fixtures/bkn-trace/phase2/query_instance_subgraph_l2_positive.json
@@ -1,0 +1,101 @@
+{
+  "bkn.trace.schema.version": "2.0.0",
+  "fixture_id": "context_loader_phase2_query_instance_subgraph_l2_positive",
+  "expected_result": "pass",
+  "trace": {
+    "trace_id": "71220000000000000000000000000003",
+    "traceparent": "00-71220000000000000000000000000003-7122000000000003-01",
+    "bkn.request.id": "req_context_loader_phase2_subgraph_0001",
+    "business_domain": "acct_demo",
+    "bkn.account.id": "acct_demo",
+    "bkn.account.type": "service"
+  },
+  "spans": [
+    {
+      "span_id": "7122000000000003",
+      "parent_span_id": null,
+      "name": "context-loader.source.resolve",
+      "kind": "internal",
+      "bkn.module.name": "context-loader",
+      "bkn.operation.name": "context.query_instance_subgraph",
+      "bkn.status": "ok",
+      "bkn.timestamp": "2026-07-23T12:00:00.000000Z"
+    }
+  ],
+  "events": [
+    {
+      "event_id": "evt_context_loader_subgraph_claim",
+      "event_type": "claim.created",
+      "bkn.trace.schema.version": "2.0.0",
+      "observed_at": "2026-07-23T12:00:00.001000Z",
+      "emitted_at": "2026-07-23T12:00:00.002000Z",
+      "producer_module": "context-loader",
+      "trace_id": "71220000000000000000000000000003",
+      "span_id": "7122000000000003",
+      "bkn.request.id": "req_context_loader_phase2_subgraph_0001",
+      "bkn.operation.name": "context.query_instance_subgraph",
+      "payload": {
+        "claim_id": "claim_context_loader_subgraph_0001",
+        "claim_type": "finding",
+        "claim_hash": "sha256:subgraph_summary_hash_only",
+        "visibility": "visible",
+        "version_status": "unversioned",
+        "partial_reason": ["row_refs_unversioned", "schema_refs_unversioned"],
+        "subject_refs": {
+          "kn_id": "kn_demo",
+          "path_hash": "sha256:relation_path_hash_only",
+          "returned_ref_count": 3,
+          "include_logic_params": false,
+          "data.classification": "internal"
+        }
+      }
+    },
+    {
+      "event_id": "evt_context_loader_subgraph_refs",
+      "event_type": "evidence.refs.created",
+      "bkn.trace.schema.version": "2.0.0",
+      "observed_at": "2026-07-23T12:00:00.003000Z",
+      "emitted_at": "2026-07-23T12:00:00.004000Z",
+      "producer_module": "context-loader",
+      "trace_id": "71220000000000000000000000000003",
+      "span_id": "7122000000000003",
+      "bkn.request.id": "req_context_loader_phase2_subgraph_0001",
+      "bkn.operation.name": "context.query_instance_subgraph",
+      "payload": {
+        "claim_id": "claim_context_loader_subgraph_0001",
+        "evidence_refs": [
+          {
+            "ref_id": "subgraph_instance:instance_hash_0001",
+            "ref_type": "row_ref",
+            "source_system": "context-loader",
+            "summary_hash": "sha256:row_ref_summary_hash_only_0001",
+            "validity": "observed",
+            "version_status": "unversioned",
+            "visibility": "visible",
+            "partial_reason": ["row_ref_unversioned"]
+          },
+          {
+            "ref_id": "subgraph_instance:instance_hash_0002",
+            "ref_type": "row_ref",
+            "source_system": "context-loader",
+            "summary_hash": "sha256:row_ref_summary_hash_only_0002",
+            "validity": "observed",
+            "version_status": "unversioned",
+            "visibility": "visible",
+            "partial_reason": ["row_ref_unversioned"]
+          },
+          {
+            "ref_id": "relation_type:relation_type_hash_0001",
+            "ref_type": "schema_ref",
+            "source_system": "context-loader",
+            "summary_hash": "sha256:relation_schema_summary_hash_only",
+            "validity": "observed",
+            "version_status": "unversioned",
+            "visibility": "visible",
+            "partial_reason": ["schema_ref_unversioned"]
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/adp/context-loader/agent-retrieval/server/infra/bkntrace/evidence.go
+++ b/adp/context-loader/agent-retrieval/server/infra/bkntrace/evidence.go
@@ -94,6 +94,13 @@ func EmitQueryObjectInstanceEvents(ctx context.Context, logger interfaces.Logger
 	SubmitEvents(ctx, logger, req, BuildQueryObjectInstanceEvents(ctx, req, resp))
 }
 
+func EmitQueryInstanceSubgraphEvents(ctx context.Context, logger interfaces.Logger, req *interfaces.QueryInstanceSubgraphReq, resp *interfaces.QueryInstanceSubgraphResp) {
+	if !EvidenceEnabled() {
+		return
+	}
+	SubmitEvents(ctx, logger, req, BuildQueryInstanceSubgraphEvents(ctx, req, resp))
+}
+
 func BuildSearchSchemaEvents(ctx context.Context, req *interfaces.SearchSchemaReq, resp *interfaces.SearchSchemaResp) []Event {
 	ec, ok := contextFromRequest(ctx, req)
 	if !ok {
@@ -183,6 +190,47 @@ func BuildQueryObjectInstanceEvents(ctx context.Context, req *interfaces.QueryOb
 			},
 		}),
 		buildEvent(ec, "evidence.refs.created", "context.query_object", map[string]any{
+			"claim_id":      claimID,
+			"evidence_refs": refs,
+		}),
+	}
+}
+
+func BuildQueryInstanceSubgraphEvents(ctx context.Context, req *interfaces.QueryInstanceSubgraphReq, resp *interfaces.QueryInstanceSubgraphResp) []Event {
+	ec, ok := contextFromRequest(ctx, nil)
+	if !ok {
+		return nil
+	}
+	refs := subgraphEvidenceRefs(resp)
+	if len(refs) == 0 {
+		return nil
+	}
+
+	resultSummary := map[string]any{
+		"kn_id":                querySubgraphKnID(req),
+		"path_hash":            querySubgraphPathHash(req),
+		"entry_count":          subgraphEntryCount(resp),
+		"include_logic_params": querySubgraphIncludeLogicParams(req),
+	}
+	claimID := ClaimID("context_loader.query_instance_subgraph", querySubgraphKnID(req), resultSummary)
+
+	return []Event{
+		buildEvent(ec, "claim.created", "context.query_instance_subgraph", map[string]any{
+			"claim_id":       claimID,
+			"claim_type":     "finding",
+			"claim_hash":     HashValue(resultSummary),
+			"visibility":     "visible",
+			"version_status": "unversioned",
+			"partial_reason": []string{"row_refs_unversioned", "schema_refs_unversioned"},
+			"subject_refs": map[string]any{
+				"kn_id":                querySubgraphKnID(req),
+				"path_hash":            resultSummary["path_hash"],
+				"returned_ref_count":   len(refs),
+				"include_logic_params": querySubgraphIncludeLogicParams(req),
+				"data.classification":  "internal",
+			},
+		}),
+		buildEvent(ec, "evidence.refs.created", "context.query_instance_subgraph", map[string]any{
 			"claim_id":      claimID,
 			"evidence_refs": refs,
 		}),
@@ -545,6 +593,103 @@ func queryObjectLimit(req *interfaces.QueryObjectInstancesReq) int {
 		return 0
 	}
 	return req.Limit
+}
+
+func subgraphEvidenceRefs(resp *interfaces.QueryInstanceSubgraphResp) []map[string]any {
+	if resp == nil || resp.Entries == nil {
+		return nil
+	}
+	refs := make([]map[string]any, 0)
+	seen := make(map[string]struct{})
+	walkSubgraphValue(resp.Entries, func(item map[string]any) {
+		if identity, ok := objectInstanceIdentity(item); ok {
+			ref := map[string]any{
+				"ref_id":         "subgraph_instance:" + hashSuffix(identity),
+				"ref_type":       "row_ref",
+				"source_system":  ModuleName,
+				"summary_hash":   HashValue(map[string]any{"identity_hash": HashValue(identity)}),
+				"validity":       "observed",
+				"version_status": "unversioned",
+				"visibility":     "visible",
+				"partial_reason": []string{"row_ref_unversioned"},
+			}
+			appendEvidenceRef(&refs, seen, ref)
+		}
+		if relationID := firstString(item, "relation_type_id", "relation_type"); relationID != "" {
+			ref := map[string]any{
+				"ref_id":         "relation_type:" + relationID,
+				"ref_type":       "schema_ref",
+				"source_system":  ModuleName,
+				"summary_hash":   HashValue(map[string]any{"relation_id": relationID}),
+				"validity":       "observed",
+				"version_status": "unversioned",
+				"visibility":     "visible",
+				"partial_reason": []string{"schema_ref_unversioned"},
+			}
+			appendEvidenceRef(&refs, seen, ref)
+		}
+	})
+	return refs
+}
+
+func appendEvidenceRef(refs *[]map[string]any, seen map[string]struct{}, ref map[string]any) {
+	key := firstString(ref, "ref_type") + ":" + firstString(ref, "ref_id")
+	if _, ok := seen[key]; ok {
+		return
+	}
+	seen[key] = struct{}{}
+	*refs = append(*refs, ref)
+}
+
+func walkSubgraphValue(value any, visit func(map[string]any)) {
+	switch typed := value.(type) {
+	case []any:
+		for _, item := range typed {
+			walkSubgraphValue(item, visit)
+		}
+	case map[string]any:
+		visit(typed)
+		for _, nested := range typed {
+			walkSubgraphValue(nested, visit)
+		}
+	default:
+		if item, ok := asMap(value); ok {
+			visit(item)
+			for _, nested := range item {
+				walkSubgraphValue(nested, visit)
+			}
+		}
+	}
+}
+
+func querySubgraphKnID(req *interfaces.QueryInstanceSubgraphReq) string {
+	if req == nil {
+		return ""
+	}
+	return strings.TrimSpace(req.KnID)
+}
+
+func querySubgraphPathHash(req *interfaces.QueryInstanceSubgraphReq) string {
+	if req == nil {
+		return HashValue(nil)
+	}
+	return HashValue(req.RelationTypePaths)
+}
+
+func querySubgraphIncludeLogicParams(req *interfaces.QueryInstanceSubgraphReq) bool {
+	return req != nil && req.IncludeLogicParams
+}
+
+func subgraphEntryCount(resp *interfaces.QueryInstanceSubgraphResp) int {
+	if resp == nil || resp.Entries == nil {
+		return 0
+	}
+	switch entries := resp.Entries.(type) {
+	case []any:
+		return len(entries)
+	default:
+		return 1
+	}
 }
 
 func hashSuffix(value any) string {

--- a/adp/context-loader/agent-retrieval/server/infra/bkntrace/evidence.go
+++ b/adp/context-loader/agent-retrieval/server/infra/bkntrace/evidence.go
@@ -35,6 +35,7 @@ const (
 )
 
 const maxInFlightEvidenceBatches = 64
+const maxSubgraphEvidenceRefs = 100
 
 type Event map[string]any
 
@@ -201,7 +202,7 @@ func BuildQueryInstanceSubgraphEvents(ctx context.Context, req *interfaces.Query
 	if !ok {
 		return nil
 	}
-	refs := subgraphEvidenceRefs(resp)
+	refs, refsTruncated := subgraphEvidenceRefs(resp)
 	if len(refs) == 0 {
 		return nil
 	}
@@ -214,6 +215,11 @@ func BuildQueryInstanceSubgraphEvents(ctx context.Context, req *interfaces.Query
 	}
 	claimID := ClaimID("context_loader.query_instance_subgraph", querySubgraphKnID(req), resultSummary)
 
+	partialReason := []string{"row_refs_unversioned", "schema_refs_unversioned"}
+	if refsTruncated {
+		partialReason = append(partialReason, "refs_truncated")
+	}
+
 	return []Event{
 		buildEvent(ec, "claim.created", "context.query_instance_subgraph", map[string]any{
 			"claim_id":       claimID,
@@ -221,12 +227,13 @@ func BuildQueryInstanceSubgraphEvents(ctx context.Context, req *interfaces.Query
 			"claim_hash":     HashValue(resultSummary),
 			"visibility":     "visible",
 			"version_status": "unversioned",
-			"partial_reason": []string{"row_refs_unversioned", "schema_refs_unversioned"},
+			"partial_reason": partialReason,
 			"subject_refs": map[string]any{
 				"kn_id":                querySubgraphKnID(req),
 				"path_hash":            resultSummary["path_hash"],
 				"returned_ref_count":   len(refs),
 				"include_logic_params": querySubgraphIncludeLogicParams(req),
+				"refs_truncated":       refsTruncated,
 				"data.classification":  "internal",
 			},
 		}),
@@ -595,13 +602,14 @@ func queryObjectLimit(req *interfaces.QueryObjectInstancesReq) int {
 	return req.Limit
 }
 
-func subgraphEvidenceRefs(resp *interfaces.QueryInstanceSubgraphResp) []map[string]any {
+func subgraphEvidenceRefs(resp *interfaces.QueryInstanceSubgraphResp) ([]map[string]any, bool) {
 	if resp == nil || resp.Entries == nil {
-		return nil
+		return nil, false
 	}
 	refs := make([]map[string]any, 0)
 	seen := make(map[string]struct{})
-	walkSubgraphValue(resp.Entries, func(item map[string]any) {
+	truncated := false
+	walkSubgraphValue(resp.Entries, func(item map[string]any) bool {
 		if identity, ok := objectInstanceIdentity(item); ok {
 			ref := map[string]any{
 				"ref_id":         "subgraph_instance:" + hashSuffix(identity),
@@ -613,8 +621,17 @@ func subgraphEvidenceRefs(resp *interfaces.QueryInstanceSubgraphResp) []map[stri
 				"visibility":     "visible",
 				"partial_reason": []string{"row_ref_unversioned"},
 			}
-			appendEvidenceRef(&refs, seen, ref)
+			if !appendEvidenceRef(&refs, seen, ref) {
+				truncated = true
+				return false
+			}
 		}
+		return true
+	})
+	if truncated {
+		return refs, true
+	}
+	walkRelationContainers(resp.Entries, func(item map[string]any) bool {
 		if relationID := firstString(item, "relation_type_id", "relation_type"); relationID != "" {
 			ref := map[string]any{
 				"ref_id":         "relation_type:" + relationID,
@@ -626,39 +643,83 @@ func subgraphEvidenceRefs(resp *interfaces.QueryInstanceSubgraphResp) []map[stri
 				"visibility":     "visible",
 				"partial_reason": []string{"schema_ref_unversioned"},
 			}
-			appendEvidenceRef(&refs, seen, ref)
+			if !appendEvidenceRef(&refs, seen, ref) {
+				truncated = true
+				return false
+			}
 		}
+		return true
 	})
-	return refs
+	return refs, truncated
 }
 
-func appendEvidenceRef(refs *[]map[string]any, seen map[string]struct{}, ref map[string]any) {
+func appendEvidenceRef(refs *[]map[string]any, seen map[string]struct{}, ref map[string]any) bool {
 	key := firstString(ref, "ref_type") + ":" + firstString(ref, "ref_id")
 	if _, ok := seen[key]; ok {
-		return
+		return true
+	}
+	if len(*refs) >= maxSubgraphEvidenceRefs {
+		return false
 	}
 	seen[key] = struct{}{}
 	*refs = append(*refs, ref)
+	return true
 }
 
-func walkSubgraphValue(value any, visit func(map[string]any)) {
+func walkSubgraphValue(value any, visit func(map[string]any) bool) bool {
 	switch typed := value.(type) {
+	case nil, string, bool, int, int8, int16, int32, int64, uint, uint8, uint16, uint32, uint64, float32, float64:
+		return true
 	case []any:
 		for _, item := range typed {
-			walkSubgraphValue(item, visit)
+			if !walkSubgraphValue(item, visit) {
+				return false
+			}
 		}
 	case map[string]any:
-		visit(typed)
+		if !visit(typed) {
+			return false
+		}
 		for _, nested := range typed {
-			walkSubgraphValue(nested, visit)
+			if !walkSubgraphValue(nested, visit) {
+				return false
+			}
 		}
 	default:
 		if item, ok := asMap(value); ok {
-			visit(item)
+			if !visit(item) {
+				return false
+			}
 			for _, nested := range item {
-				walkSubgraphValue(nested, visit)
+				if !walkSubgraphValue(nested, visit) {
+					return false
+				}
 			}
 		}
+	}
+	return true
+}
+
+func walkRelationContainers(value any, visit func(map[string]any) bool) bool {
+	return walkSubgraphValue(value, func(item map[string]any) bool {
+		for key, nested := range item {
+			if !isRelationContainerKey(key) {
+				continue
+			}
+			if !walkSubgraphValue(nested, visit) {
+				return false
+			}
+		}
+		return true
+	})
+}
+
+func isRelationContainerKey(key string) bool {
+	switch key {
+	case "relation", "relations", "relation_path", "relation_paths", "relation_type", "relation_types":
+		return true
+	default:
+		return false
 	}
 }
 

--- a/adp/context-loader/agent-retrieval/server/infra/bkntrace/evidence_test.go
+++ b/adp/context-loader/agent-retrieval/server/infra/bkntrace/evidence_test.go
@@ -248,6 +248,7 @@ func TestBuildQueryInstanceSubgraphEventsUsesHashAndRefsOnly(t *testing.T) {
 					"_instance_identity": map[string]any{"customer_id": "cust_001"},
 					"name":               "Alice",
 					"phone":              "18800001111",
+					"relation_type":      "vip_customer_segment",
 				},
 				"relation": map[string]any{
 					"relation_type_id": "has_order",
@@ -292,6 +293,65 @@ func TestBuildQueryInstanceSubgraphEventsUsesHashAndRefsOnly(t *testing.T) {
 		if strings.Contains(text, leaked) {
 			t.Fatalf("event leaked raw subgraph content %q: %s", leaked, text)
 		}
+	}
+	if strings.Contains(text, "vip_customer_segment") {
+		t.Fatalf("event treated data field relation_type as schema ref: %s", text)
+	}
+}
+
+func TestBuildQueryInstanceSubgraphEventsDeduplicatesRefs(t *testing.T) {
+	req := &interfaces.QueryInstanceSubgraphReq{KnID: "kn_demo"}
+	resp := &interfaces.QueryInstanceSubgraphResp{
+		Entries: []any{
+			map[string]any{
+				"source":   map[string]any{"_instance_identity": map[string]any{"customer_id": "cust_001"}},
+				"relation": map[string]any{"relation_type_id": "has_order"},
+				"target":   map[string]any{"_instance_identity": map[string]any{"order_id": "ord_001"}},
+			},
+			map[string]any{
+				"source":   map[string]any{"_instance_identity": map[string]any{"customer_id": "cust_001"}},
+				"relation": map[string]any{"relation_type_id": "has_order"},
+				"target":   map[string]any{"_instance_identity": map[string]any{"order_id": "ord_001"}},
+			},
+		},
+	}
+
+	events := BuildQueryInstanceSubgraphEvents(testTraceContext(), req, resp)
+	raw, err := json.Marshal(events)
+	if err != nil {
+		t.Fatalf("marshal events: %v", err)
+	}
+	text := string(raw)
+	if got := strings.Count(text, `"ref_type":"row_ref"`); got != 2 {
+		t.Fatalf("row_ref count=%d, want 2 unique refs: %s", got, text)
+	}
+	if got := strings.Count(text, `"ref_id":"relation_type:has_order"`); got != 1 {
+		t.Fatalf("relation schema ref count=%d, want 1: %s", got, text)
+	}
+}
+
+func TestBuildQueryInstanceSubgraphEventsCapsEvidenceRefs(t *testing.T) {
+	entries := make([]any, 0, maxSubgraphEvidenceRefs+5)
+	for i := 0; i < maxSubgraphEvidenceRefs+5; i++ {
+		entries = append(entries, map[string]any{
+			"source": map[string]any{
+				"_instance_identity": map[string]any{"customer_id": i},
+			},
+		})
+	}
+	resp := &interfaces.QueryInstanceSubgraphResp{Entries: entries}
+
+	events := BuildQueryInstanceSubgraphEvents(testTraceContext(), &interfaces.QueryInstanceSubgraphReq{KnID: "kn_demo"}, resp)
+	raw, err := json.Marshal(events)
+	if err != nil {
+		t.Fatalf("marshal events: %v", err)
+	}
+	text := string(raw)
+	if got := strings.Count(text, `"ref_type":"row_ref"`); got != maxSubgraphEvidenceRefs {
+		t.Fatalf("row_ref count=%d, want capped %d: %s", got, maxSubgraphEvidenceRefs, text)
+	}
+	if !strings.Contains(text, `"refs_truncated"`) {
+		t.Fatalf("missing refs_truncated partial reason: %s", text)
 	}
 }
 

--- a/adp/context-loader/agent-retrieval/server/infra/bkntrace/evidence_test.go
+++ b/adp/context-loader/agent-retrieval/server/infra/bkntrace/evidence_test.go
@@ -227,6 +227,74 @@ func TestQueryObjectTruncatedUsesExplicitNextPageSignals(t *testing.T) {
 	}
 }
 
+func TestBuildQueryInstanceSubgraphEventsUsesHashAndRefsOnly(t *testing.T) {
+	req := &interfaces.QueryInstanceSubgraphReq{
+		KnID: "kn_demo",
+		RelationTypePaths: []any{
+			map[string]any{
+				"source_ot_id":          "customer",
+				"relation_type_id":      "has_order",
+				"target_ot_id":          "order",
+				"source_instance_id":    "cust_001",
+				"target_instance_phone": "18800001111",
+				"limit":                 20,
+			},
+		},
+	}
+	resp := &interfaces.QueryInstanceSubgraphResp{
+		Entries: []any{
+			map[string]any{
+				"source": map[string]any{
+					"_instance_identity": map[string]any{"customer_id": "cust_001"},
+					"name":               "Alice",
+					"phone":              "18800001111",
+				},
+				"relation": map[string]any{
+					"relation_type_id": "has_order",
+					"amount":           99.5,
+				},
+				"target": map[string]any{
+					"_instance_identity": map[string]any{"order_id": "ord_001"},
+					"address":            "Sensitive Address",
+				},
+			},
+		},
+	}
+
+	events := BuildQueryInstanceSubgraphEvents(testTraceContext(), req, resp)
+	if len(events) != 2 {
+		t.Fatalf("len(events)=%d, want 2", len(events))
+	}
+	raw, err := json.Marshal(events)
+	if err != nil {
+		t.Fatalf("marshal events: %v", err)
+	}
+	text := string(raw)
+	if !strings.Contains(text, `"event_type":"claim.created"`) {
+		t.Fatalf("missing claim.created event: %s", text)
+	}
+	if !strings.Contains(text, `"event_type":"evidence.refs.created"`) {
+		t.Fatalf("missing evidence.refs.created event: %s", text)
+	}
+	if !strings.Contains(text, `"ref_type":"row_ref"`) {
+		t.Fatalf("missing row_ref evidence: %s", text)
+	}
+	if !strings.Contains(text, `"ref_id":"relation_type:has_order"`) {
+		t.Fatalf("missing relation type evidence: %s", text)
+	}
+	if !strings.Contains(text, `"ref_type":"schema_ref"`) {
+		t.Fatalf("missing schema_ref evidence: %s", text)
+	}
+	if !strings.Contains(text, `"path_hash":"sha256:`) {
+		t.Fatalf("missing relation path hash: %s", text)
+	}
+	for _, leaked := range []string{"cust_001", "ord_001", "Alice", "18800001111", "Sensitive Address", "target_instance_phone"} {
+		if strings.Contains(text, leaked) {
+			t.Fatalf("event leaked raw subgraph content %q: %s", leaked, text)
+		}
+	}
+}
+
 func TestEmitSearchSchemaEventsNoopsWhenIngestDisabled(t *testing.T) {
 	t.Setenv(envEvidenceIngestURL, "")
 	maxConcepts := 5

--- a/adp/context-loader/agent-retrieval/server/logics/knquerysubgraph/index.go
+++ b/adp/context-loader/agent-retrieval/server/logics/knquerysubgraph/index.go
@@ -13,6 +13,7 @@ import (
 	"sync"
 
 	"github.com/openbkn-ai/adp/context-loader/agent-retrieval/server/drivenadapters"
+	"github.com/openbkn-ai/adp/context-loader/agent-retrieval/server/infra/bkntrace"
 	"github.com/openbkn-ai/adp/context-loader/agent-retrieval/server/infra/config"
 	"github.com/openbkn-ai/adp/context-loader/agent-retrieval/server/interfaces"
 )
@@ -48,5 +49,8 @@ func NewKnQuerySubgraphService() KnQuerySubgraphService {
 func (s *knQuerySubgraphService) QueryInstanceSubgraph(ctx context.Context, req *interfaces.QueryInstanceSubgraphReq) (resp *interfaces.QueryInstanceSubgraphResp, err error) {
 	// 调用 drivenadapters 层查询子图
 	resp, err = s.OntologyQuery.QueryInstanceSubgraph(ctx, req)
+	if err == nil {
+		bkntrace.EmitQueryInstanceSubgraphEvents(ctx, s.Logger, req, resp)
+	}
 	return
 }


### PR DESCRIPTION
# Pull Request

## What Changed

Brief description of changes:

- [x] Feature/module 1: context-loader `query_instance_subgraph` emits phase-two `claim.created` and `evidence.refs.created` events.
- [x] Feature/module 2: subgraph evidence uses hash-only payloads for relation paths, instance identities, and entries; related instances are emitted as `row_ref`, relation types as `schema_ref`.
- [x] Docs/doc 1: updated context-loader `TRACE.md` and added a phase-two positive fixture for subgraph evidence.

---

## Why

- Related Issue: [openbkn-ai/bkn-foundry#270](https://github.com/openbkn-ai/bkn-foundry/issues/270)
- Related Feature: BKN Trace phase two / PR-2.4 OpenBKN module L2 Evidence integration.
- Background: `search_schema` and `query_object_instance` already emit L2 evidence events. This PR completes the next context-loader path by covering `query_instance_subgraph`, so subgraph-based Agent reasoning can be traced back to relation context without logging raw path conditions or row data.

---

## How

- Key implementation points:
  - Added `BuildQueryInstanceSubgraphEvents` and `EmitQueryInstanceSubgraphEvents`.
  - Emits one `claim.created` plus one `evidence.refs.created` batch when `QueryInstanceSubgraph` succeeds.
  - Keeps payloads limited to `path_hash`, counts, `summary_hash`, `row_ref`, and `schema_ref`.
  - Reuses existing async ingestion behavior controlled by `BKN_TRACE_EVIDENCE_INGEST_URL`; disabled ingestion still avoids event construction on the runtime path.
  - Added fixture coverage and `TRACE.md` GWT entries for subgraph evidence.
- Breaking changes (API, config, database, etc.): none.

---

## Testing

- [x] Unit tests passed locally
- [x] Integration tests passed locally
- [ ] Verified in test environment

Test notes:

```text
python3 /Users/leecky/openbkn/bkn-docs/docs/foundry/bkn-trace/validation/validate_phase2_fixture.py adp/context-loader/agent-retrieval/fixtures/bkn-trace/phase2 --pretty
go test ./server/infra/bkntrace ./server/logics/knquerysubgraph ./server/driveradapters/mcp -count=1
go test ./server/... -count=1
git diff --check
```

---

## Risk & Rollback

- Potential risks:
  - Low runtime risk. Evidence ingestion is feature-flagged by `BKN_TRACE_EVIDENCE_INGEST_URL` and async.
  - Subgraph response shape is semi-structured, so evidence extraction is intentionally conservative: it only extracts `_instance_identity` and explicit `relation_type_id` / `relation_type`.
- Rollback plan:
  - Revert this PR. Main subgraph query behavior remains unchanged because the new emission path is additive.

---

## Additional Notes

- This PR does not implement global Evidence Graph assembly, resolver APIs, snapshot export, or Studio visualization. Those remain later phase-two / phase-three work.
