### PR TITLE
fix(execution-factory): 内置 Catalog 去 kweaver 前缀并修复建 dataset 失败 (#372)

### DIFF
--- a/adp/bkn/bkn-backend/server/bkn-specification/examples/mock_system/CHECKSUM
+++ b/adp/bkn/bkn-backend/server/bkn-specification/examples/mock_system/CHECKSUM
@@ -1,5 +1,5 @@
 # BKN Directory Checksum
-# generated: 2026-05-14T15:11:40+08:00
+# generated: 2026-07-23T16:11:49+08:00
 SKILL.md  sha256:08301dfb5f554f2a
 action_type:assess_department  sha256:e47d136512219ee8
 action_type:delete_department  sha256:45549448ff17d0f8
@@ -16,7 +16,7 @@ object_type:department_resource  sha256:913933ca03351f87
 object_type:employee  sha256:c91b6dbcff8a3e0f
 object_type:employee_resource  sha256:7084404af040425e
 object_type:relation  sha256:6a270aa2d5b77714
-object_type:skill  sha256:bf8ec1c95a85bbd2
+object_type:skill  sha256:ae627aad3deb6b8c
 relation_type:emp_dept_resource  sha256:1c9a2007e3f32d8b
 relation_type:emp_skill  sha256:41187a1389b20af5
 relation_type:source_object_type_id  sha256:3517043fa1a34614

--- a/adp/bkn/bkn-backend/server/bkn-specification/examples/mock_system/object_types/skill.bkn
+++ b/adp/bkn/bkn-backend/server/bkn-specification/examples/mock_system/object_types/skill.bkn
@@ -11,7 +11,7 @@ tags: []
 
 | Type | ID | Name |
 |------|----|------|
-| resource | kweaver_execution_factory_skill_dataset | kweaver_execution_factory_skill_dataset |
+| resource | bkn_execution_factory_skill_dataset | bkn_execution_factory_skill_dataset |
 
 ### Data Properties
 

--- a/adp/bkn/bkn-backend/server/logics/ontology_init.go
+++ b/adp/bkn/bkn-backend/server/logics/ontology_init.go
@@ -117,7 +117,8 @@ func bknCatalogRequest() *interfaces.CatalogRequest {
 		ID:          interfaces.BKN_CATALOG_ID,
 		Name:        interfaces.BKN_CATALOG_NAME,
 		Description: "BKN的逻辑命名空间",
-		Tags:        []string{"BKN", "概念索引"},
+		// internal 标签让前端不必靠名称前缀猜内置目录（Studio 暂未读后端 internal 字段）
+		Tags: []string{"BKN", "概念索引", "internal"},
 		Enabled:     true,
 		// 系统内部目录：仅超级管理员可见，业务角色（数据管理员等）的 catalog:* 授权匹配不到
 		Internal: true,

--- a/adp/bkn/bkn-backend/server/logics/ontology_init.go
+++ b/adp/bkn/bkn-backend/server/logics/ontology_init.go
@@ -117,9 +117,8 @@ func bknCatalogRequest() *interfaces.CatalogRequest {
 		ID:          interfaces.BKN_CATALOG_ID,
 		Name:        interfaces.BKN_CATALOG_NAME,
 		Description: "BKN的逻辑命名空间",
-		// internal 标签让前端不必靠名称前缀猜内置目录（Studio 暂未读后端 internal 字段）
-		Tags:    []string{"BKN", "概念索引", "internal"},
-		Enabled: true,
+		Tags:        []string{"BKN", "概念索引"},
+		Enabled:     true,
 		// 系统内部目录：仅超级管理员可见，业务角色（数据管理员等）的 catalog:* 授权匹配不到
 		Internal: true,
 	}

--- a/adp/bkn/bkn-backend/server/logics/ontology_init.go
+++ b/adp/bkn/bkn-backend/server/logics/ontology_init.go
@@ -118,8 +118,8 @@ func bknCatalogRequest() *interfaces.CatalogRequest {
 		Name:        interfaces.BKN_CATALOG_NAME,
 		Description: "BKN的逻辑命名空间",
 		// internal 标签让前端不必靠名称前缀猜内置目录（Studio 暂未读后端 internal 字段）
-		Tags: []string{"BKN", "概念索引", "internal"},
-		Enabled:     true,
+		Tags:    []string{"BKN", "概念索引", "internal"},
+		Enabled: true,
 		// 系统内部目录：仅超级管理员可见，业务角色（数据管理员等）的 catalog:* 授权匹配不到
 		Internal: true,
 	}

--- a/adp/execution-factory/operator-integration/server/drivenadapters/vega_backend.go
+++ b/adp/execution-factory/operator-integration/server/drivenadapters/vega_backend.go
@@ -191,36 +191,6 @@ func (v *vegaBackendClient) GetResourceByID(ctx context.Context, id string) (*in
 	return resource, nil
 }
 
-// RenameResource 只改资源展示名，不动 schema。
-//
-// 请求体刻意不带 category 与 schema_definition：
-//   - vega 的 dataset 分支校验要求 schema_definition 非空，带上就得回填整份 schema；
-//     而本服务的 VegaProperty 是 vega Property 的有损投影(缺 original_type、
-//     attributes、extensions 等)，回填会被判定成 schema 变更，进而清空
-//     resource.LocalIndexName，把已建好的 skill 索引悬空。
-//   - schema_definition 为 nil 时 vega 走「不改 schema」分支，仅套用名称/标签/描述。
-func (v *vegaBackendClient) RenameResource(ctx context.Context, resource *interfaces.VegaResource, name string) error {
-	src := fmt.Sprintf("%s/v1/resources/%s", v.baseURL, url.PathEscape(resource.ID))
-	headers := v.buildHeaders(ctx)
-	payload := map[string]any{
-		"id":          resource.ID,
-		"catalog_id":  resource.CatalogID,
-		"name":        name,
-		"tags":        resource.Tags,
-		"description": resource.Description,
-	}
-	v.logger.WithContext(ctx).Infof("rename vega resource, resource_id=%s, name=%s, url=%s", resource.ID, name, src)
-	respCode, respData, err := v.httpClient.PutNoUnmarshal(ctx, src, headers, payload)
-	if err != nil {
-		v.logger.WithContext(ctx).Errorf("failed to rename vega resource, resource_id=%s, url=%s, err=%v", resource.ID, src, err)
-		return err
-	}
-	if respCode != http.StatusNoContent && respCode != http.StatusOK {
-		return fmt.Errorf("rename resource failed: %s", string(respData))
-	}
-	return nil
-}
-
 func (v *vegaBackendClient) CreateResource(ctx context.Context, req *interfaces.VegaResourceRequest) (*interfaces.VegaResource, error) {
 	src := fmt.Sprintf("%s/v1/resources", v.baseURL)
 	headers := v.buildHeaders(ctx)

--- a/adp/execution-factory/operator-integration/server/drivenadapters/vega_backend.go
+++ b/adp/execution-factory/operator-integration/server/drivenadapters/vega_backend.go
@@ -68,10 +68,23 @@ func (v *vegaBackendClient) GetCatalogByID(ctx context.Context, id string) (*int
 		return nil, fmt.Errorf("get catalog by id failed: %s", string(respData))
 	}
 
+	// vega 的按 ID 查询走的是批量端点，响应是 {"entries":[...]} 包装；
+	// 直接反序列化成 VegaCatalog 只会得到零值(ID 为空)，历史上因为调用方只判
+	// nil 而没暴露出来。
+	var entries struct {
+		Entries []*interfaces.VegaCatalog `json:"entries"`
+	}
+	if err = json.Unmarshal(respData, &entries); err == nil && len(entries.Entries) > 0 {
+		return entries.Entries[0], nil
+	}
+
 	catalog := &interfaces.VegaCatalog{}
 	if err = json.Unmarshal(respData, catalog); err != nil {
 		v.logger.WithContext(ctx).Errorf("failed to unmarshal catalog: %v", err)
 		return nil, err
+	}
+	if catalog.ID == "" {
+		return nil, nil
 	}
 	return catalog, nil
 }
@@ -96,6 +109,40 @@ func (v *vegaBackendClient) CreateCatalog(ctx context.Context, req *interfaces.V
 		return nil, err
 	}
 	return catalog, nil
+}
+
+// UpdateCatalog 更新Vega目录的展示信息(名称/标签/描述)
+// vega 的 PUT /catalogs/{id} 要求 connector_type 与 enabled 与当前值一致，
+// 调用方须从 GetCatalogByID 的返回里原样回填这两个字段。
+func (v *vegaBackendClient) UpdateCatalog(ctx context.Context, req *interfaces.VegaCatalogRequest) error {
+	src := fmt.Sprintf("%s/v1/catalogs/%s", v.baseURL, url.PathEscape(req.ID))
+	headers := v.buildHeaders(ctx)
+	v.logger.WithContext(ctx).Infof("update vega catalog, catalog_id=%s, name=%s, url=%s", req.ID, req.Name, src)
+	respCode, respData, err := v.httpClient.PutNoUnmarshal(ctx, src, headers, req)
+	if err != nil {
+		v.logger.WithContext(ctx).Errorf("failed to update vega catalog, catalog_id=%s, url=%s, err=%v", req.ID, src, err)
+		return err
+	}
+	if respCode != http.StatusNoContent && respCode != http.StatusOK {
+		return fmt.Errorf("update catalog failed: %s", string(respData))
+	}
+	return nil
+}
+
+// EnableCatalog 启用Vega目录
+func (v *vegaBackendClient) EnableCatalog(ctx context.Context, id string) error {
+	src := fmt.Sprintf("%s/v1/catalogs/%s/enable", v.baseURL, url.PathEscape(id))
+	headers := v.buildHeaders(ctx)
+	v.logger.WithContext(ctx).Infof("enable vega catalog, catalog_id=%s, url=%s", id, src)
+	respCode, respData, err := v.httpClient.PostNoUnmarshal(ctx, src, headers, nil)
+	if err != nil {
+		v.logger.WithContext(ctx).Errorf("failed to enable vega catalog, catalog_id=%s, url=%s, err=%v", id, src, err)
+		return err
+	}
+	if respCode != http.StatusNoContent && respCode != http.StatusOK {
+		return fmt.Errorf("enable catalog failed: %s", string(respData))
+	}
+	return nil
 }
 
 func (v *vegaBackendClient) GetResourceByID(ctx context.Context, id string) (*interfaces.VegaResource, error) {
@@ -130,6 +177,36 @@ func (v *vegaBackendClient) GetResourceByID(ctx context.Context, id string) (*in
 		return nil, nil
 	}
 	return resource, nil
+}
+
+// RenameResource 只改资源展示名，不动 schema。
+//
+// 请求体刻意不带 category 与 schema_definition：
+//   - vega 的 dataset 分支校验要求 schema_definition 非空，带上就得回填整份 schema；
+//     而本服务的 VegaProperty 是 vega Property 的有损投影(缺 original_type、
+//     attributes、extensions 等)，回填会被判定成 schema 变更，进而清空
+//     resource.LocalIndexName，把已建好的 skill 索引悬空。
+//   - schema_definition 为 nil 时 vega 走「不改 schema」分支，仅套用名称/标签/描述。
+func (v *vegaBackendClient) RenameResource(ctx context.Context, resource *interfaces.VegaResource, name string) error {
+	src := fmt.Sprintf("%s/v1/resources/%s", v.baseURL, url.PathEscape(resource.ID))
+	headers := v.buildHeaders(ctx)
+	payload := map[string]any{
+		"id":          resource.ID,
+		"catalog_id":  resource.CatalogID,
+		"name":        name,
+		"tags":        resource.Tags,
+		"description": resource.Description,
+	}
+	v.logger.WithContext(ctx).Infof("rename vega resource, resource_id=%s, name=%s, url=%s", resource.ID, name, src)
+	respCode, respData, err := v.httpClient.PutNoUnmarshal(ctx, src, headers, payload)
+	if err != nil {
+		v.logger.WithContext(ctx).Errorf("failed to rename vega resource, resource_id=%s, url=%s, err=%v", resource.ID, src, err)
+		return err
+	}
+	if respCode != http.StatusNoContent && respCode != http.StatusOK {
+		return fmt.Errorf("rename resource failed: %s", string(respData))
+	}
+	return nil
 }
 
 func (v *vegaBackendClient) CreateResource(ctx context.Context, req *interfaces.VegaResourceRequest) (*interfaces.VegaResource, error) {

--- a/adp/execution-factory/operator-integration/server/drivenadapters/vega_backend.go
+++ b/adp/execution-factory/operator-integration/server/drivenadapters/vega_backend.go
@@ -75,7 +75,13 @@ func (v *vegaBackendClient) GetCatalogByID(ctx context.Context, id string) (*int
 		Entries []*interfaces.VegaCatalog `json:"entries"`
 	}
 	if err = json.Unmarshal(respData, &entries); err == nil && len(entries.Entries) > 0 {
-		return entries.Entries[0], nil
+		// 按 id 挑，不认列表顺序：调用方(存量目录收养)强依赖拿到的就是请求的那个目录
+		for _, entry := range entries.Entries {
+			if entry != nil && entry.ID == id {
+				return entry, nil
+			}
+		}
+		return nil, nil
 	}
 
 	catalog := &interfaces.VegaCatalog{}
@@ -165,7 +171,13 @@ func (v *vegaBackendClient) GetResourceByID(ctx context.Context, id string) (*in
 		Entries []*interfaces.VegaResource `json:"entries"`
 	}
 	if err = json.Unmarshal(respData, &entries); err == nil && len(entries.Entries) > 0 {
-		return entries.Entries[0], nil
+		// 同 GetCatalogByID：按 id 挑，收养存量 dataset 时必须确认拿到的就是它
+		for _, entry := range entries.Entries {
+			if entry != nil && entry.ID == id {
+				return entry, nil
+			}
+		}
+		return nil, nil
 	}
 
 	resource := &interfaces.VegaResource{}

--- a/adp/execution-factory/operator-integration/server/drivenadapters/vega_backend_test.go
+++ b/adp/execution-factory/operator-integration/server/drivenadapters/vega_backend_test.go
@@ -101,28 +101,6 @@ func TestVegaBackendClient(t *testing.T) {
 			So(client.EnableCatalog(ctx, "kweaver_execution_factory_catalog"), ShouldBeNil)
 		})
 
-		Convey("renames resource without touching schema", func() {
-			resource := &interfaces.VegaResource{
-				ID:        "kweaver_execution_factory_skill_dataset",
-				CatalogID: "kweaver_execution_factory_catalog",
-				Name:      "kweaver_execution_factory_skill_dataset",
-				Tags:      []string{"execution-factory", "skill"},
-				// schema 不参与请求体：回填有损 schema 会被 vega 判成 schema 变更并清空 LocalIndexName
-				SchemaDefinition: []interfaces.VegaProperty{{Name: "skill_id", Type: "string"}},
-			}
-			expectedPayload := map[string]any{
-				"id":          "kweaver_execution_factory_skill_dataset",
-				"catalog_id":  "kweaver_execution_factory_catalog",
-				"name":        "bkn_execution_factory_skill_dataset",
-				"tags":        []string{"execution-factory", "skill"},
-				"description": "",
-			}
-			httpClient.EXPECT().PutNoUnmarshal(gomock.Any(), "http://vega-backend:9898/api/vega-backend/v1/resources/kweaver_execution_factory_skill_dataset", headers, expectedPayload).
-				Return(http.StatusNoContent, []byte{}, nil)
-
-			So(client.RenameResource(ctx, resource, "bkn_execution_factory_skill_dataset"), ShouldBeNil)
-		})
-
 		Convey("gets resource from entries response", func() {
 			httpClient.EXPECT().GetNoUnmarshal(gomock.Any(), "http://vega-backend:9898/api/vega-backend/v1/resources/bkn_execution_factory_skill_dataset", gomock.Nil(), headers).
 				Return(http.StatusOK, []byte(`{"entries":[{"id":"bkn_execution_factory_skill_dataset","catalog_id":"bkn_execution_factory_catalog"}]}`), nil)

--- a/adp/execution-factory/operator-integration/server/drivenadapters/vega_backend_test.go
+++ b/adp/execution-factory/operator-integration/server/drivenadapters/vega_backend_test.go
@@ -36,28 +36,92 @@ func TestVegaBackendClient(t *testing.T) {
 
 		Convey("creates catalog with fixed fields", func() {
 			req := &interfaces.VegaCatalogRequest{
-				ID:          "kweaver_execution_factory_catalog",
-				Name:        "kweaver_execution_factory_catalog",
+				ID:          "bkn_execution_factory_catalog",
+				Name:        "bkn_execution_factory_catalog",
 				Tags:        []string{"execution-factory", "索引"},
 				Description: "执行工厂的逻辑命名空间",
 			}
 			httpClient.EXPECT().PostNoUnmarshal(gomock.Any(), "http://vega-backend:9898/api/vega-backend/v1/catalogs", headers, req).
-				Return(http.StatusCreated, []byte(`{"id":"kweaver_execution_factory_catalog","name":"kweaver_execution_factory_catalog"}`), nil)
+				Return(http.StatusCreated, []byte(`{"id":"bkn_execution_factory_catalog","name":"bkn_execution_factory_catalog"}`), nil)
 
 			resp, err := client.CreateCatalog(ctx, req)
 			So(err, ShouldBeNil)
 			So(resp, ShouldNotBeNil)
+			So(resp.ID, ShouldEqual, "bkn_execution_factory_catalog")
+		})
+
+		Convey("gets catalog from entries response", func() {
+			httpClient.EXPECT().GetNoUnmarshal(gomock.Any(), "http://vega-backend:9898/api/vega-backend/v1/catalogs/kweaver_execution_factory_catalog", gomock.Nil(), headers).
+				Return(http.StatusOK, []byte(`{"entries":[{"id":"kweaver_execution_factory_catalog","name":"kweaver_execution_factory_catalog","enabled":false}]}`), nil)
+
+			resp, err := client.GetCatalogByID(ctx, "kweaver_execution_factory_catalog")
+			So(err, ShouldBeNil)
+			So(resp, ShouldNotBeNil)
 			So(resp.ID, ShouldEqual, "kweaver_execution_factory_catalog")
+			So(resp.Name, ShouldEqual, "kweaver_execution_factory_catalog")
+			So(resp.Enabled, ShouldBeFalse)
+		})
+
+		Convey("treats an empty catalog payload as not found", func() {
+			httpClient.EXPECT().GetNoUnmarshal(gomock.Any(), "http://vega-backend:9898/api/vega-backend/v1/catalogs/bkn_execution_factory_catalog", gomock.Nil(), headers).
+				Return(http.StatusOK, []byte(`{"entries":[]}`), nil)
+
+			resp, err := client.GetCatalogByID(ctx, "bkn_execution_factory_catalog")
+			So(err, ShouldBeNil)
+			So(resp, ShouldBeNil)
+		})
+
+		Convey("renames catalog in place via PUT", func() {
+			req := &interfaces.VegaCatalogRequest{
+				ID:       "kweaver_execution_factory_catalog",
+				Name:     "bkn_execution_factory_catalog",
+				Tags:     []string{"execution-factory", "索引"},
+				Internal: true,
+				Enabled:  true,
+			}
+			httpClient.EXPECT().PutNoUnmarshal(gomock.Any(), "http://vega-backend:9898/api/vega-backend/v1/catalogs/kweaver_execution_factory_catalog", headers, req).
+				Return(http.StatusNoContent, []byte{}, nil)
+
+			So(client.UpdateCatalog(ctx, req), ShouldBeNil)
+		})
+
+		Convey("enables catalog", func() {
+			httpClient.EXPECT().PostNoUnmarshal(gomock.Any(), "http://vega-backend:9898/api/vega-backend/v1/catalogs/kweaver_execution_factory_catalog/enable", headers, nil).
+				Return(http.StatusNoContent, []byte{}, nil)
+
+			So(client.EnableCatalog(ctx, "kweaver_execution_factory_catalog"), ShouldBeNil)
+		})
+
+		Convey("renames resource without touching schema", func() {
+			resource := &interfaces.VegaResource{
+				ID:        "kweaver_execution_factory_skill_dataset",
+				CatalogID: "kweaver_execution_factory_catalog",
+				Name:      "kweaver_execution_factory_skill_dataset",
+				Tags:      []string{"execution-factory", "skill"},
+				// schema 不参与请求体：回填有损 schema 会被 vega 判成 schema 变更并清空 LocalIndexName
+				SchemaDefinition: []interfaces.VegaProperty{{Name: "skill_id", Type: "string"}},
+			}
+			expectedPayload := map[string]any{
+				"id":          "kweaver_execution_factory_skill_dataset",
+				"catalog_id":  "kweaver_execution_factory_catalog",
+				"name":        "bkn_execution_factory_skill_dataset",
+				"tags":        []string{"execution-factory", "skill"},
+				"description": "",
+			}
+			httpClient.EXPECT().PutNoUnmarshal(gomock.Any(), "http://vega-backend:9898/api/vega-backend/v1/resources/kweaver_execution_factory_skill_dataset", headers, expectedPayload).
+				Return(http.StatusNoContent, []byte{}, nil)
+
+			So(client.RenameResource(ctx, resource, "bkn_execution_factory_skill_dataset"), ShouldBeNil)
 		})
 
 		Convey("gets resource from entries response", func() {
-			httpClient.EXPECT().GetNoUnmarshal(gomock.Any(), "http://vega-backend:9898/api/vega-backend/v1/resources/kweaver_execution_factory_skill_dataset", gomock.Nil(), headers).
-				Return(http.StatusOK, []byte(`{"entries":[{"id":"kweaver_execution_factory_skill_dataset","catalog_id":"kweaver_execution_factory_catalog"}]}`), nil)
+			httpClient.EXPECT().GetNoUnmarshal(gomock.Any(), "http://vega-backend:9898/api/vega-backend/v1/resources/bkn_execution_factory_skill_dataset", gomock.Nil(), headers).
+				Return(http.StatusOK, []byte(`{"entries":[{"id":"bkn_execution_factory_skill_dataset","catalog_id":"bkn_execution_factory_catalog"}]}`), nil)
 
-			resp, err := client.GetResourceByID(ctx, "kweaver_execution_factory_skill_dataset")
+			resp, err := client.GetResourceByID(ctx, "bkn_execution_factory_skill_dataset")
 			So(err, ShouldBeNil)
 			So(resp, ShouldNotBeNil)
-			So(resp.ID, ShouldEqual, "kweaver_execution_factory_skill_dataset")
+			So(resp.ID, ShouldEqual, "bkn_execution_factory_skill_dataset")
 		})
 
 		Convey("writes dataset documents", func() {
@@ -70,10 +134,10 @@ func TestVegaBackendClient(t *testing.T) {
 				"x-account-type":         "user",
 				"X-HTTP-Method-Override": "POST",
 			}
-			httpClient.EXPECT().PostNoUnmarshal(gomock.Any(), "http://vega-backend:9898/api/vega-backend/v1/resources/kweaver_execution_factory_skill_dataset/data", writeHeaders, docs).
+			httpClient.EXPECT().PostNoUnmarshal(gomock.Any(), "http://vega-backend:9898/api/vega-backend/v1/resources/bkn_execution_factory_skill_dataset/data", writeHeaders, docs).
 				Return(http.StatusCreated, []byte(`{}`), nil)
 
-			err := client.WriteDatasetDocuments(ctx, "kweaver_execution_factory_skill_dataset", docs)
+			err := client.WriteDatasetDocuments(ctx, "bkn_execution_factory_skill_dataset", docs)
 			So(err, ShouldBeNil)
 		})
 
@@ -81,18 +145,18 @@ func TestVegaBackendClient(t *testing.T) {
 			docs := []map[string]any{
 				{"_id": "skill-1", "skill_id": "skill-1", "name": "demo-updated"},
 			}
-			httpClient.EXPECT().PutNoUnmarshal(gomock.Any(), "http://vega-backend:9898/api/vega-backend/v1/resources/kweaver_execution_factory_skill_dataset/data", headers, docs).
+			httpClient.EXPECT().PutNoUnmarshal(gomock.Any(), "http://vega-backend:9898/api/vega-backend/v1/resources/bkn_execution_factory_skill_dataset/data", headers, docs).
 				Return(http.StatusOK, []byte(`{}`), nil)
 
-			err := client.UpdateDatasetDocuments(ctx, "kweaver_execution_factory_skill_dataset", docs)
+			err := client.UpdateDatasetDocuments(ctx, "bkn_execution_factory_skill_dataset", docs)
 			So(err, ShouldBeNil)
 		})
 
 		Convey("deletes dataset document by id", func() {
-			httpClient.EXPECT().DeleteNoUnmarshal(gomock.Any(), "http://vega-backend:9898/api/vega-backend/v1/resources/kweaver_execution_factory_skill_dataset/data/skill-1", headers).
+			httpClient.EXPECT().DeleteNoUnmarshal(gomock.Any(), "http://vega-backend:9898/api/vega-backend/v1/resources/bkn_execution_factory_skill_dataset/data/skill-1", headers).
 				Return(http.StatusNoContent, []byte{}, nil)
 
-			err := client.DeleteDatasetDocumentByID(ctx, "kweaver_execution_factory_skill_dataset", "skill-1")
+			err := client.DeleteDatasetDocumentByID(ctx, "bkn_execution_factory_skill_dataset", "skill-1")
 			So(err, ShouldBeNil)
 		})
 	})

--- a/adp/execution-factory/operator-integration/server/drivenadapters/vega_backend_test.go
+++ b/adp/execution-factory/operator-integration/server/drivenadapters/vega_backend_test.go
@@ -62,6 +62,15 @@ func TestVegaBackendClient(t *testing.T) {
 			So(resp.Enabled, ShouldBeFalse)
 		})
 
+		Convey("ignores entries that do not match the requested catalog id", func() {
+			httpClient.EXPECT().GetNoUnmarshal(gomock.Any(), "http://vega-backend:9898/api/vega-backend/v1/catalogs/bkn_execution_factory_catalog", gomock.Nil(), headers).
+				Return(http.StatusOK, []byte(`{"entries":[{"id":"some_other_catalog","name":"other"}]}`), nil)
+
+			resp, err := client.GetCatalogByID(ctx, "bkn_execution_factory_catalog")
+			So(err, ShouldBeNil)
+			So(resp, ShouldBeNil)
+		})
+
 		Convey("treats an empty catalog payload as not found", func() {
 			httpClient.EXPECT().GetNoUnmarshal(gomock.Any(), "http://vega-backend:9898/api/vega-backend/v1/catalogs/bkn_execution_factory_catalog", gomock.Nil(), headers).
 				Return(http.StatusOK, []byte(`{"entries":[]}`), nil)

--- a/adp/execution-factory/operator-integration/server/interfaces/drivenadapters.go
+++ b/adp/execution-factory/operator-integration/server/interfaces/drivenadapters.go
@@ -881,28 +881,38 @@ type VegaCatalog struct {
 	ConnectorType string   `json:"connector_type"`
 }
 
+// VegaResourceIndexConfig 资源级索引配置。DefaultEmbeddingModel 是 vega 解析向量
+// 字段模型的兜底位置，且不会进 OpenSearch mapping —— 模型快照必须落在这里，不能
+// 放进向量属性的 feature config(那会被原样拷进 knn_vector mapping 并被 OpenSearch
+// 以 unknown parameter 拒绝，索引建不出来)。
+type VegaResourceIndexConfig struct {
+	DefaultEmbeddingModel string `json:"default_embedding_model,omitempty"`
+}
+
 type VegaResourceRequest struct {
-	ID               string         `json:"id"`
-	CatalogID        string         `json:"catalog_id"`
-	Name             string         `json:"name"`
-	Tags             []string       `json:"tags"`
-	Description      string         `json:"description"`
-	Category         string         `json:"category"`
-	Status           string         `json:"status"`
-	SourceIdentifier string         `json:"source_identifier"`
-	SchemaDefinition []VegaProperty `json:"schema_definition"`
+	ID               string                   `json:"id"`
+	CatalogID        string                   `json:"catalog_id"`
+	Name             string                   `json:"name"`
+	Tags             []string                 `json:"tags"`
+	Description      string                   `json:"description"`
+	Category         string                   `json:"category"`
+	Status           string                   `json:"status"`
+	SourceIdentifier string                   `json:"source_identifier"`
+	SchemaDefinition []VegaProperty           `json:"schema_definition"`
+	IndexConfig      *VegaResourceIndexConfig `json:"index_config,omitempty"`
 }
 
 type VegaResource struct {
-	ID               string         `json:"id"`
-	CatalogID        string         `json:"catalog_id"`
-	Name             string         `json:"name"`
-	Tags             []string       `json:"tags"`
-	Description      string         `json:"description"`
-	Category         string         `json:"category"`
-	Status           string         `json:"status"`
-	SourceIdentifier string         `json:"source_identifier"`
-	SchemaDefinition []VegaProperty `json:"schema_definition,omitempty"`
+	ID               string                   `json:"id"`
+	CatalogID        string                   `json:"catalog_id"`
+	Name             string                   `json:"name"`
+	Tags             []string                 `json:"tags"`
+	Description      string                   `json:"description"`
+	Category         string                   `json:"category"`
+	Status           string                   `json:"status"`
+	SourceIdentifier string                   `json:"source_identifier"`
+	SchemaDefinition []VegaProperty           `json:"schema_definition,omitempty"`
+	IndexConfig      *VegaResourceIndexConfig `json:"index_config,omitempty"`
 }
 
 type VegaBackendClient interface {

--- a/adp/execution-factory/operator-integration/server/interfaces/drivenadapters.go
+++ b/adp/execution-factory/operator-integration/server/interfaces/drivenadapters.go
@@ -863,14 +863,22 @@ type VegaCatalogRequest struct {
 	Description string   `json:"description"`
 	// Internal 系统内部目录：在权限服务按 internal_catalog 类型注册，仅超级管理员可见
 	Internal bool `json:"internal"`
+	// Enabled 目录启用状态。逻辑目录若为 false，其下 dataset 的读写会被
+	// vega 以 Catalog.IsDisabled(409) 拒绝，因此内置目录必须建成 enabled。
+	Enabled bool `json:"enabled"`
+	// ConnectorType 连接器类型：逻辑目录恒为空。PUT 更新时该字段不可变，
+	// 必须原样回填当前值，否则 vega 返回 400。
+	ConnectorType string `json:"connector_type,omitempty"`
 }
 
 type VegaCatalog struct {
-	ID          string   `json:"id"`
-	Name        string   `json:"name"`
-	Tags        []string `json:"tags"`
-	Description string   `json:"description"`
-	Type        string   `json:"type"`
+	ID            string   `json:"id"`
+	Name          string   `json:"name"`
+	Tags          []string `json:"tags"`
+	Description   string   `json:"description"`
+	Type          string   `json:"type"`
+	Enabled       bool     `json:"enabled"`
+	ConnectorType string   `json:"connector_type"`
 }
 
 type VegaResourceRequest struct {
@@ -900,7 +908,14 @@ type VegaResource struct {
 type VegaBackendClient interface {
 	GetCatalogByID(ctx context.Context, id string) (*VegaCatalog, error)
 	CreateCatalog(ctx context.Context, req *VegaCatalogRequest) (*VegaCatalog, error)
+	// UpdateCatalog 更新目录的展示信息(名称/标签/描述)。enabled 与 connector_type
+	// 不可由该接口改动，调用方须原样回填。
+	UpdateCatalog(ctx context.Context, req *VegaCatalogRequest) error
+	// EnableCatalog 启用目录(vega 的 enabled 只能走该端点，PUT 改会 409)。
+	EnableCatalog(ctx context.Context, id string) error
 	GetResourceByID(ctx context.Context, id string) (*VegaResource, error)
+	// RenameResource 只改资源展示名(及标签/描述)，不触碰 schema。
+	RenameResource(ctx context.Context, resource *VegaResource, name string) error
 	CreateResource(ctx context.Context, req *VegaResourceRequest) (*VegaResource, error)
 	WriteDatasetDocuments(ctx context.Context, datasetID string, documents []map[string]any) error
 	UpdateDatasetDocuments(ctx context.Context, datasetID string, documents []map[string]any) error

--- a/adp/execution-factory/operator-integration/server/interfaces/drivenadapters.go
+++ b/adp/execution-factory/operator-integration/server/interfaces/drivenadapters.go
@@ -914,8 +914,6 @@ type VegaBackendClient interface {
 	// EnableCatalog 启用目录(vega 的 enabled 只能走该端点，PUT 改会 409)。
 	EnableCatalog(ctx context.Context, id string) error
 	GetResourceByID(ctx context.Context, id string) (*VegaResource, error)
-	// RenameResource 只改资源展示名(及标签/描述)，不触碰 schema。
-	RenameResource(ctx context.Context, resource *VegaResource, name string) error
 	CreateResource(ctx context.Context, req *VegaResourceRequest) (*VegaResource, error)
 	WriteDatasetDocuments(ctx context.Context, datasetID string, documents []map[string]any) error
 	UpdateDatasetDocuments(ctx context.Context, datasetID string, documents []map[string]any) error

--- a/adp/execution-factory/operator-integration/server/logics/skill/index_sync.go
+++ b/adp/execution-factory/operator-integration/server/logics/skill/index_sync.go
@@ -45,9 +45,8 @@ type skillIndexSync struct {
 	logger       interfaces.Logger
 	mu           sync.RWMutex
 	initialized  bool
-	// catalogID / datasetID 为本进程实际使用的目录/数据集 ID：新装是 bkn_*，
-	// 存量环境解析到 legacy 的 kweaver_*；空值表示尚未解析，取新装默认值。
-	catalogID string
+	// datasetID 为本进程实际使用的数据集 ID：新装是 bkn_*，存量环境解析到
+	// legacy 的 kweaver_*；空值表示尚未解析，取新装默认值。
 	datasetID string
 	// embeddingModelName 该系统 skill dataset 建时锁定的 embedding 模型名(系统默认快照)，
 	// 受 mu 保护；upsert 读回它生成向量，而非每次重取当前默认。
@@ -102,7 +101,6 @@ func (s *skillIndexSync) Init(ctx context.Context) (err error) {
 	if err != nil {
 		return err
 	}
-	s.setCatalogID(catalogID)
 
 	datasetID, resource, err := s.resolveDataset(ctx)
 	if err != nil {
@@ -335,12 +333,6 @@ func (s *skillIndexSync) setDatasetID(id string) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	s.datasetID = id
-}
-
-func (s *skillIndexSync) setCatalogID(id string) {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-	s.catalogID = id
 }
 
 func (s *skillIndexSync) UpsertSkill(ctx context.Context, skill *model.SkillRepositoryDB) error {

--- a/adp/execution-factory/operator-integration/server/logics/skill/index_sync.go
+++ b/adp/execution-factory/operator-integration/server/logics/skill/index_sync.go
@@ -254,14 +254,11 @@ func (s *skillIndexSync) resolveDataset(ctx context.Context) (string, *interface
 		return "", nil, err
 	}
 	if legacy != nil {
+		// 只收养、不改名：vega 的 Update 无条件对「已存的」schema 跑模型校验，而所有
+		// 存量 dataset 的 _vector 都没有 embedding_model(快照机制之前建的)，vega 回退
+		// 到常量 "embedding" 并因该模型未注册而 400 —— 改名请求对这批 dataset 必然
+		// 失败(VM 实测)。dataset 藏在内置目录下、仅超管可见，旧显示名无碍。
 		s.logger.WithContext(ctx).Infof("adopting legacy skill dataset, resource_id=%s", legacy.ID)
-		if legacy.Name != executionFactorySkillDataset {
-			if err := s.vegaClient.RenameResource(ctx, legacy, executionFactorySkillDataset); err != nil {
-				s.logger.WithContext(ctx).Warnf("rename legacy skill dataset failed, resource_id=%s, err=%v", legacy.ID, err)
-			} else {
-				s.logger.WithContext(ctx).Infof("legacy skill dataset renamed, resource_id=%s, name=%s", legacy.ID, executionFactorySkillDataset)
-			}
-		}
 		return legacy.ID, legacy, nil
 	}
 	return executionFactorySkillDataset, nil, nil

--- a/adp/execution-factory/operator-integration/server/logics/skill/index_sync.go
+++ b/adp/execution-factory/operator-integration/server/logics/skill/index_sync.go
@@ -111,6 +111,10 @@ func (s *skillIndexSync) Init(ctx context.Context) (err error) {
 	}
 	s.setDatasetID(datasetID)
 	if resource != nil {
+		// 收养到的 dataset 可能挂在另一个目录下(混合形态)，写入受它自己的父目录管辖
+		if err := s.ensureDatasetCatalogEnabled(ctx, resource, catalogID); err != nil {
+			return err
+		}
 		// dataset 已存在：读回建时锁定的模型名(建模型==查模型)。
 		// 旧 dataset 两种形态都兜住，都取不到时回退按名 "embedding"，与改造前行为一致。
 		modelName := extractEmbeddingModelFromIndexConfig(resource.IndexConfig)
@@ -179,7 +183,9 @@ func (s *skillIndexSync) ensureCatalog(ctx context.Context) (string, error) {
 		}
 		if legacy != nil {
 			s.logger.WithContext(ctx).Infof("adopting legacy catalog, catalog_id=%s", legacy.ID)
-			s.reconcileCatalog(ctx, legacy)
+			if err := s.reconcileCatalog(ctx, legacy); err != nil {
+				return "", err
+			}
 			return legacy.ID, nil
 		}
 		s.logger.WithContext(ctx).Infof("catalog not found, creating catalog, catalog_id=%s", executionFactoryCatalogID)
@@ -200,14 +206,19 @@ func (s *skillIndexSync) ensureCatalog(ctx context.Context) (string, error) {
 		}
 		return executionFactoryCatalogID, nil
 	}
-	s.reconcileCatalog(ctx, catalog)
+	if err := s.reconcileCatalog(ctx, catalog); err != nil {
+		return "", err
+	}
 	return catalog.ID, nil
 }
 
 // reconcileCatalog 把存量目录对齐到当前预期：展示名迁到新品牌名、补 internal 标签、
-// 目录置为启用。三个动作都是尽力而为——失败只告警不阻断启动，索引读写本身不依赖
-// 它们成功。
-func (s *skillIndexSync) reconcileCatalog(ctx context.Context, catalog *interfaces.VegaCatalog) {
+// 目录置为启用。
+//
+// 改名与补标签是展示项，失败只告警；「启用」是功能项——目录 disabled 时其下 dataset
+// 的读写会被 vega 以 409 拒绝，所以启用失败必须冒泡成 Init 失败，交给重试循环，
+// 否则会带着必然写失败的状态标记成已初始化。
+func (s *skillIndexSync) reconcileCatalog(ctx context.Context, catalog *interfaces.VegaCatalog) error {
 	tags := appendInternalTag(catalog.Tags)
 	// vega 的 tag 数量上限是 5；超限时放弃补标签，保住「改名」这个主目标，
 	// 否则整个 PUT 会 400，改名和补标签一起永久失败。
@@ -231,13 +242,41 @@ func (s *skillIndexSync) reconcileCatalog(ctx context.Context, catalog *interfac
 			s.logger.WithContext(ctx).Infof("catalog reconciled, catalog_id=%s, name=%s, tags=%v", catalog.ID, executionFactoryCatalogID, tags)
 		}
 	}
-	if !catalog.Enabled {
-		if err := s.vegaClient.EnableCatalog(ctx, catalog.ID); err != nil {
-			s.logger.WithContext(ctx).Warnf("enable catalog failed, catalog_id=%s, err=%v", catalog.ID, err)
-		} else {
-			s.logger.WithContext(ctx).Infof("catalog enabled, catalog_id=%s", catalog.ID)
-		}
+	return s.ensureCatalogEnabled(ctx, catalog)
+}
+
+// ensureCatalogEnabled 保证目录处于启用状态。目录 disabled 时其下 dataset 的读写
+// 会被 vega 以 409 Catalog.IsDisabled 拒绝，因此失败要作为错误返回。
+func (s *skillIndexSync) ensureCatalogEnabled(ctx context.Context, catalog *interfaces.VegaCatalog) error {
+	if catalog.Enabled {
+		return nil
 	}
+	if err := s.vegaClient.EnableCatalog(ctx, catalog.ID); err != nil {
+		s.logger.WithContext(ctx).Errorf("enable catalog failed, catalog_id=%s, err=%v", catalog.ID, err)
+		return err
+	}
+	s.logger.WithContext(ctx).Infof("catalog enabled, catalog_id=%s", catalog.ID)
+	return nil
+}
+
+// ensureDatasetCatalogEnabled 保证「收养到的 dataset 自己挂的那个目录」是启用的。
+//
+// 混合形态下两者可能不是同一个目录：ensureCatalog 解析到新 ID 的目录，而 dataset
+// 仍挂在旧目录上。写入受 dataset 的父目录管辖，只启用前者不够。
+func (s *skillIndexSync) ensureDatasetCatalogEnabled(ctx context.Context, resource *interfaces.VegaResource, resolvedCatalogID string) error {
+	if resource == nil || resource.CatalogID == "" || resource.CatalogID == resolvedCatalogID {
+		return nil
+	}
+	parent, err := s.vegaClient.GetCatalogByID(ctx, resource.CatalogID)
+	if err != nil {
+		s.logger.WithContext(ctx).Errorf("get dataset parent catalog failed, resource_id=%s, catalog_id=%s, err=%v", resource.ID, resource.CatalogID, err)
+		return err
+	}
+	if parent == nil {
+		return fmt.Errorf("skill dataset %s points to missing catalog %s", resource.ID, resource.CatalogID)
+	}
+	s.logger.WithContext(ctx).Infof("skill dataset lives in another catalog, resource_id=%s, catalog_id=%s", resource.ID, parent.ID)
+	return s.ensureCatalogEnabled(ctx, parent)
 }
 
 // appendInternalTag 补上 internal 标签；已有(忽略大小写与首尾空格)则原样返回。

--- a/adp/execution-factory/operator-integration/server/logics/skill/index_sync.go
+++ b/adp/execution-factory/operator-integration/server/logics/skill/index_sync.go
@@ -25,6 +25,10 @@ const (
 	// 因此只把「展示名」迁到新品牌名，ID 保持不动、不产生两套目录。
 	legacyExecutionFactoryCatalogID    = "kweaver_execution_factory_catalog"
 	legacyExecutionFactorySkillDataset = "kweaver_execution_factory_skill_dataset"
+	// internalCatalogTag 让内置目录自带「内置」语义标签。Studio 目前不读后端的
+	// internal 字段，靠 metadata/tag/名称前缀启发式判定内置目录，该 tag 命中它的
+	// 内置标签集合 —— 前端零改就能正确显示「内置」并收起管理操作。
+	internalCatalogTag = "internal"
 	// embeddingModelConfigKey 把"建 dataset 时锁定的 embedding 模型名"快照进向量特征
 	// 的 config，重启/实时同步时读回，保证写入向量用的模型与建索引时一致(建模型==查模型)。
 	// 这也是 vega 解析向量字段模型的键。
@@ -177,7 +181,7 @@ func (s *skillIndexSync) ensureCatalog(ctx context.Context) (string, error) {
 		_, err = s.vegaClient.CreateCatalog(ctx, &interfaces.VegaCatalogRequest{
 			ID:          executionFactoryCatalogID,
 			Name:        executionFactoryCatalogID,
-			Tags:        []string{"execution-factory", "索引"},
+			Tags:        []string{"execution-factory", "索引", internalCatalogTag},
 			Description: executionFactoryCatalogDesc,
 			// 系统内部目录：仅超级管理员可见，业务角色（数据管理员等）的 catalog:* 授权匹配不到
 			Internal: true,
@@ -195,23 +199,25 @@ func (s *skillIndexSync) ensureCatalog(ctx context.Context) (string, error) {
 	return catalog.ID, nil
 }
 
-// reconcileCatalog 把存量目录对齐到当前预期：展示名迁到新品牌名、目录置为启用。
-// 两个动作都是尽力而为——失败只告警不阻断启动，索引读写本身不依赖它们成功。
+// reconcileCatalog 把存量目录对齐到当前预期：展示名迁到新品牌名、补 internal 标签、
+// 目录置为启用。三个动作都是尽力而为——失败只告警不阻断启动，索引读写本身不依赖
+// 它们成功。
 func (s *skillIndexSync) reconcileCatalog(ctx context.Context, catalog *interfaces.VegaCatalog) {
-	if catalog.Name != executionFactoryCatalogID {
+	tags := appendInternalTag(catalog.Tags)
+	if catalog.Name != executionFactoryCatalogID || len(tags) != len(catalog.Tags) {
 		req := &interfaces.VegaCatalogRequest{
 			ID:            catalog.ID,
 			Name:          executionFactoryCatalogID,
-			Tags:          catalog.Tags,
+			Tags:          tags,
 			Description:   catalog.Description,
 			Internal:      true,
 			Enabled:       catalog.Enabled,
 			ConnectorType: catalog.ConnectorType,
 		}
 		if err := s.vegaClient.UpdateCatalog(ctx, req); err != nil {
-			s.logger.WithContext(ctx).Warnf("rename catalog failed, catalog_id=%s, name=%s, err=%v", catalog.ID, executionFactoryCatalogID, err)
+			s.logger.WithContext(ctx).Warnf("reconcile catalog failed, catalog_id=%s, name=%s, err=%v", catalog.ID, executionFactoryCatalogID, err)
 		} else {
-			s.logger.WithContext(ctx).Infof("catalog renamed, catalog_id=%s, name=%s", catalog.ID, executionFactoryCatalogID)
+			s.logger.WithContext(ctx).Infof("catalog reconciled, catalog_id=%s, name=%s, tags=%v", catalog.ID, executionFactoryCatalogID, tags)
 		}
 	}
 	if !catalog.Enabled {
@@ -221,6 +227,16 @@ func (s *skillIndexSync) reconcileCatalog(ctx context.Context, catalog *interfac
 			s.logger.WithContext(ctx).Infof("catalog enabled, catalog_id=%s", catalog.ID)
 		}
 	}
+}
+
+// appendInternalTag 补上 internal 标签；已有(忽略大小写与首尾空格)则原样返回。
+func appendInternalTag(tags []string) []string {
+	for _, tag := range tags {
+		if strings.EqualFold(strings.TrimSpace(tag), internalCatalogTag) {
+			return tags
+		}
+	}
+	return append(append([]string{}, tags...), internalCatalogTag)
 }
 
 // resolveDataset 解析本进程使用的 skill dataset：新装取 bkn_*，存量环境沿用

--- a/adp/execution-factory/operator-integration/server/logics/skill/index_sync.go
+++ b/adp/execution-factory/operator-integration/server/logics/skill/index_sync.go
@@ -29,9 +29,12 @@ const (
 	// internal 字段，靠 metadata/tag/名称前缀启发式判定内置目录，该 tag 命中它的
 	// 内置标签集合 —— 前端零改就能正确显示「内置」并收起管理操作。
 	internalCatalogTag = "internal"
-	// embeddingModelConfigKey 把"建 dataset 时锁定的 embedding 模型名"快照进向量特征
-	// 的 config，重启/实时同步时读回，保证写入向量用的模型与建索引时一致(建模型==查模型)。
-	// 这也是 vega 解析向量字段模型的键。
+	// vegaMaxTags 与 vega 的 TAGS_MAX_NUMBER 对齐(超出会 400)
+	vegaMaxTags = 5
+	// embeddingModelConfigKey 是向量特征 config 里的模型键。只用于读：曾经把模型
+	// 快照写在这里，但 vega 会把向量属性的 feature config 原样拷进 OpenSearch
+	// knn_vector mapping，OpenSearch 以 unknown parameter 拒绝，索引建不出来。
+	// 写路径改用资源级 index_config.default_embedding_model。
 	embeddingModelConfigKey = "embedding_model"
 	// embeddingModelTagPrefix 是该快照的旧载体(resource tag)。vega 的 tag 校验禁掉了
 	// ':'，带这种 tag 的建 dataset 请求会 400，因此只保留读路径兼容老 dataset。
@@ -110,7 +113,10 @@ func (s *skillIndexSync) Init(ctx context.Context) (err error) {
 	if resource != nil {
 		// dataset 已存在：读回建时锁定的模型名(建模型==查模型)。
 		// 旧 dataset 两种形态都兜住，都取不到时回退按名 "embedding"，与改造前行为一致。
-		modelName := extractEmbeddingModelFromSchema(resource.SchemaDefinition)
+		modelName := extractEmbeddingModelFromIndexConfig(resource.IndexConfig)
+		if modelName == "" {
+			modelName = extractEmbeddingModelFromSchema(resource.SchemaDefinition)
+		}
 		if modelName == "" {
 			modelName = extractEmbeddingModelFromTags(resource.Tags)
 		}
@@ -131,18 +137,19 @@ func (s *skillIndexSync) Init(ctx context.Context) (err error) {
 	s.logger.WithContext(ctx).Infof("creating skill dataset resource, resource_id=%s, catalog_id=%s, embedding_model=%s, dimension=%d",
 		datasetID, catalogID, embeddingModel.ModelName, embeddingModel.EmbeddingDim)
 	_, err = s.vegaClient.CreateResource(ctx, &interfaces.VegaResourceRequest{
-		ID:        datasetID,
-		CatalogID: catalogID,
+		ID:               datasetID,
+		CatalogID:        catalogID,
 		Name:             datasetID,
 		Tags:             []string{"execution-factory", "skill", "索引"},
 		Description:      executionFactoryDatasetDesc,
 		Category:         "dataset",
 		Status:           executionFactoryDatasetStatus,
 		SourceIdentifier: datasetID,
-		// 建时锁定的模型名快照进向量特征的 config.embedding_model —— 这也是 vega
-		// 自己解析向量模型的位置。不能再放 tag：vega 的 tag 校验禁掉了 ':' '.' 等
-		// 字符，"embedding_model:<name>" 这种 tag 会让整个建 dataset 请求 400。
-		SchemaDefinition: buildSkillIndexSchema(embeddingModel.EmbeddingDim, embeddingModel.ModelName),
+		SchemaDefinition: buildSkillIndexSchema(embeddingModel.EmbeddingDim),
+		// 建时锁定的模型名快照进资源级 index_config：vega 解析向量模型时拿它兜底，
+		// 且它不进 OpenSearch mapping。不能放 tag(vega tag 校验禁 ':' 会 400)，也不能
+		// 放向量属性的 feature config(会被拷进 knn_vector mapping，OpenSearch 拒绝)。
+		IndexConfig: &interfaces.VegaResourceIndexConfig{DefaultEmbeddingModel: embeddingModel.ModelName},
 	})
 	if err != nil {
 		s.logger.WithContext(ctx).Errorf("create skill dataset resource failed, resource_id=%s, err=%v", datasetID, err)
@@ -202,6 +209,12 @@ func (s *skillIndexSync) ensureCatalog(ctx context.Context) (string, error) {
 // 它们成功。
 func (s *skillIndexSync) reconcileCatalog(ctx context.Context, catalog *interfaces.VegaCatalog) {
 	tags := appendInternalTag(catalog.Tags)
+	// vega 的 tag 数量上限是 5；超限时放弃补标签，保住「改名」这个主目标，
+	// 否则整个 PUT 会 400，改名和补标签一起永久失败。
+	if len(tags) > vegaMaxTags {
+		s.logger.WithContext(ctx).Warnf("skip internal tag backfill, tag limit reached, catalog_id=%s, tags=%d", catalog.ID, len(tags))
+		tags = catalog.Tags
+	}
 	if catalog.Name != executionFactoryCatalogID || len(tags) != len(catalog.Tags) {
 		req := &interfaces.VegaCatalogRequest{
 			ID:            catalog.ID,
@@ -275,7 +288,16 @@ func (s *skillIndexSync) resolveBuildEmbeddingModel(ctx context.Context) (*inter
 	return s.modelManager.GetEmbeddingModel(ctx, interfaces.SmallModelTypeEmbedding, interfaces.SmallModelTypeEmbedding)
 }
 
-// extractEmbeddingModelFromSchema 从向量特征的 config.embedding_model 读回建时锁定的模型名
+// extractEmbeddingModelFromIndexConfig 从资源级 index_config 读回建时锁定的模型名(当前写法)
+func extractEmbeddingModelFromIndexConfig(indexConfig *interfaces.VegaResourceIndexConfig) string {
+	if indexConfig == nil {
+		return ""
+	}
+	return indexConfig.DefaultEmbeddingModel
+}
+
+// extractEmbeddingModelFromSchema 从向量特征的 config.embedding_model 读回模型名。
+// 只服务于短暂写过该位置的 dataset，新建 dataset 不再往 schema 里写模型名。
 func extractEmbeddingModelFromSchema(schema []interfaces.VegaProperty) string {
 	for _, property := range schema {
 		for _, feature := range property.Features {
@@ -451,9 +473,9 @@ func buildEmbeddingInput(name string, description string) string {
 	return strings.Join(parts, "\n")
 }
 
-// buildSkillIndexSchema 生成 skill 索引 schema。embeddingModel 会写进向量特征的
-// config.embedding_model，既是 vega 建索引时用的模型，也是本服务重启后读回的快照。
-func buildSkillIndexSchema(dimension int, embeddingModel string) []interfaces.VegaProperty {
+// buildSkillIndexSchema 生成 skill 索引 schema。模型名不进这里 —— 向量属性的
+// feature config 会被 vega 原样拷进 OpenSearch mapping，多余键会让建索引失败。
+func buildSkillIndexSchema(dimension int) []interfaces.VegaProperty {
 	return []interfaces.VegaProperty{
 		{
 			Name:         "skill_id",
@@ -625,8 +647,7 @@ func buildSkillIndexSchema(dimension int, embeddingModel string) []interfaces.Ve
 				IsDefault:   true,
 				IsNative:    false,
 				Config: map[string]any{
-					"dimension":             dimension,
-					embeddingModelConfigKey: embeddingModel,
+					"dimension": dimension,
 					"method": map[string]any{
 						"name":       "hnsw",
 						"space_type": "cosinesimil",

--- a/adp/execution-factory/operator-integration/server/logics/skill/index_sync.go
+++ b/adp/execution-factory/operator-integration/server/logics/skill/index_sync.go
@@ -15,13 +15,22 @@ import (
 )
 
 const (
-	executionFactoryCatalogID     = "kweaver_execution_factory_catalog"
+	executionFactoryCatalogID     = "bkn_execution_factory_catalog"
 	executionFactoryCatalogDesc   = "执行工厂的逻辑命名空间"
-	executionFactorySkillDataset  = "kweaver_execution_factory_skill_dataset"
+	executionFactorySkillDataset  = "bkn_execution_factory_skill_dataset"
 	executionFactoryDatasetDesc   = "执行工厂的Skill索引数据集"
 	executionFactoryDatasetStatus = "active"
-	// embeddingModelTagPrefix 把"建 dataset 时锁定的 embedding 模型名"快照进 resource tag，
-	// 重启/实时同步时读回，保证写入向量用的模型与建索引时一致(建模型==查模型)。
+	// legacy* 是 kweaver 品牌期建的内置目录/数据集 ID(issue #372)。
+	// 存量环境沿用旧 ID：ID 是索引数据的落点，换 ID 等于重建索引，
+	// 因此只把「展示名」迁到新品牌名，ID 保持不动、不产生两套目录。
+	legacyExecutionFactoryCatalogID    = "kweaver_execution_factory_catalog"
+	legacyExecutionFactorySkillDataset = "kweaver_execution_factory_skill_dataset"
+	// embeddingModelConfigKey 把"建 dataset 时锁定的 embedding 模型名"快照进向量特征
+	// 的 config，重启/实时同步时读回，保证写入向量用的模型与建索引时一致(建模型==查模型)。
+	// 这也是 vega 解析向量字段模型的键。
+	embeddingModelConfigKey = "embedding_model"
+	// embeddingModelTagPrefix 是该快照的旧载体(resource tag)。vega 的 tag 校验禁掉了
+	// ':'，带这种 tag 的建 dataset 请求会 400，因此只保留读路径兼容老 dataset。
 	embeddingModelTagPrefix = "embedding_model:"
 )
 
@@ -32,6 +41,10 @@ type skillIndexSync struct {
 	logger       interfaces.Logger
 	mu           sync.RWMutex
 	initialized  bool
+	// catalogID / datasetID 为本进程实际使用的目录/数据集 ID：新装是 bkn_*，
+	// 存量环境解析到 legacy 的 kweaver_*；空值表示尚未解析，取新装默认值。
+	catalogID string
+	datasetID string
 	// embeddingModelName 该系统 skill dataset 建时锁定的 embedding 模型名(系统默认快照)，
 	// 受 mu 保护；upsert 读回它生成向量，而非每次重取当前默认。
 	embeddingModelName string
@@ -81,12 +94,85 @@ func (s *skillIndexSync) Init(ctx context.Context) (err error) {
 		s.setInitialized(initialized)
 	}()
 	s.logger.WithContext(ctx).Infof("init skill index dataset, catalog_id=%s, resource_id=%s", executionFactoryCatalogID, executionFactorySkillDataset)
+	catalogID, err := s.ensureCatalog(ctx)
+	if err != nil {
+		return err
+	}
+	s.setCatalogID(catalogID)
+
+	datasetID, resource, err := s.resolveDataset(ctx)
+	if err != nil {
+		return err
+	}
+	s.setDatasetID(datasetID)
+	if resource != nil {
+		// dataset 已存在：读回建时锁定的模型名(建模型==查模型)。
+		// 旧 dataset 两种形态都兜住，都取不到时回退按名 "embedding"，与改造前行为一致。
+		modelName := extractEmbeddingModelFromSchema(resource.SchemaDefinition)
+		if modelName == "" {
+			modelName = extractEmbeddingModelFromTags(resource.Tags)
+		}
+		if modelName == "" {
+			modelName = interfaces.SmallModelTypeEmbedding
+		}
+		s.setEmbeddingModelName(modelName)
+		initialized = true
+		s.logger.WithContext(ctx).Infof("resource already exists, resource_id=%s, embedding_model=%s", datasetID, modelName)
+		return nil
+	}
+	// 首次创建 dataset：用系统默认 embedding 模型(接口式可配)；未配置默认时回退按名 "embedding"。
+	embeddingModel, err := s.resolveBuildEmbeddingModel(ctx)
+	if err != nil {
+		s.logger.WithContext(ctx).Errorf("resolve embedding model failed, resource_id=%s, err=%v", datasetID, err)
+		return err
+	}
+	s.logger.WithContext(ctx).Infof("creating skill dataset resource, resource_id=%s, catalog_id=%s, embedding_model=%s, dimension=%d",
+		datasetID, catalogID, embeddingModel.ModelName, embeddingModel.EmbeddingDim)
+	_, err = s.vegaClient.CreateResource(ctx, &interfaces.VegaResourceRequest{
+		ID:        datasetID,
+		CatalogID: catalogID,
+		Name:             datasetID,
+		Tags:             []string{"execution-factory", "skill", "索引"},
+		Description:      executionFactoryDatasetDesc,
+		Category:         "dataset",
+		Status:           executionFactoryDatasetStatus,
+		SourceIdentifier: datasetID,
+		// 建时锁定的模型名快照进向量特征的 config.embedding_model —— 这也是 vega
+		// 自己解析向量模型的位置。不能再放 tag：vega 的 tag 校验禁掉了 ':' '.' 等
+		// 字符，"embedding_model:<name>" 这种 tag 会让整个建 dataset 请求 400。
+		SchemaDefinition: buildSkillIndexSchema(embeddingModel.EmbeddingDim, embeddingModel.ModelName),
+	})
+	if err != nil {
+		s.logger.WithContext(ctx).Errorf("create skill dataset resource failed, resource_id=%s, err=%v", datasetID, err)
+		return err
+	}
+	s.setEmbeddingModelName(embeddingModel.ModelName)
+	initialized = true
+	return nil
+}
+
+// ensureCatalog 解析并保证内置目录存在，返回本进程实际使用的目录 ID。
+//
+// 新装取 bkn_execution_factory_catalog；存量环境(kweaver 品牌期建的目录)沿用旧
+// ID，只把展示名迁到新品牌名 —— 换 ID 会新建一套目录并让已建索引失联，
+// 见 issue #372。
+func (s *skillIndexSync) ensureCatalog(ctx context.Context) (string, error) {
 	catalog, err := s.vegaClient.GetCatalogByID(ctx, executionFactoryCatalogID)
 	if err != nil {
 		s.logger.WithContext(ctx).Errorf("get catalog failed during ensure dataset, catalog_id=%s, err=%v", executionFactoryCatalogID, err)
-		return err
+		return "", err
 	}
 	if catalog == nil {
+		legacy, err := s.vegaClient.GetCatalogByID(ctx, legacyExecutionFactoryCatalogID)
+		if err != nil {
+			s.logger.WithContext(ctx).Errorf("get legacy catalog failed, catalog_id=%s, err=%v", legacyExecutionFactoryCatalogID, err)
+			return "", err
+		}
+		if legacy != nil {
+			s.logger.WithContext(ctx).Infof("adopting legacy catalog, catalog_id=%s", legacy.ID)
+			s.reconcileCatalog(ctx, legacy)
+			return legacy.ID, nil
+		}
 		s.logger.WithContext(ctx).Infof("catalog not found, creating catalog, catalog_id=%s", executionFactoryCatalogID)
 		_, err = s.vegaClient.CreateCatalog(ctx, &interfaces.VegaCatalogRequest{
 			ID:          executionFactoryCatalogID,
@@ -95,57 +181,76 @@ func (s *skillIndexSync) Init(ctx context.Context) (err error) {
 			Description: executionFactoryCatalogDesc,
 			// 系统内部目录：仅超级管理员可见，业务角色（数据管理员等）的 catalog:* 授权匹配不到
 			Internal: true,
+			// 逻辑目录若建成 disabled，其下 dataset 的读写会被 vega 以 409
+			// Catalog.IsDisabled 拒绝(bkn-backend 的内置目录同样显式置 true)
+			Enabled: true,
 		})
 		if err != nil {
 			s.logger.WithContext(ctx).Errorf("create catalog failed, catalog_id=%s, err=%v", executionFactoryCatalogID, err)
-			return err
+			return "", err
+		}
+		return executionFactoryCatalogID, nil
+	}
+	s.reconcileCatalog(ctx, catalog)
+	return catalog.ID, nil
+}
+
+// reconcileCatalog 把存量目录对齐到当前预期：展示名迁到新品牌名、目录置为启用。
+// 两个动作都是尽力而为——失败只告警不阻断启动，索引读写本身不依赖它们成功。
+func (s *skillIndexSync) reconcileCatalog(ctx context.Context, catalog *interfaces.VegaCatalog) {
+	if catalog.Name != executionFactoryCatalogID {
+		req := &interfaces.VegaCatalogRequest{
+			ID:            catalog.ID,
+			Name:          executionFactoryCatalogID,
+			Tags:          catalog.Tags,
+			Description:   catalog.Description,
+			Internal:      true,
+			Enabled:       catalog.Enabled,
+			ConnectorType: catalog.ConnectorType,
+		}
+		if err := s.vegaClient.UpdateCatalog(ctx, req); err != nil {
+			s.logger.WithContext(ctx).Warnf("rename catalog failed, catalog_id=%s, name=%s, err=%v", catalog.ID, executionFactoryCatalogID, err)
+		} else {
+			s.logger.WithContext(ctx).Infof("catalog renamed, catalog_id=%s, name=%s", catalog.ID, executionFactoryCatalogID)
 		}
 	}
+	if !catalog.Enabled {
+		if err := s.vegaClient.EnableCatalog(ctx, catalog.ID); err != nil {
+			s.logger.WithContext(ctx).Warnf("enable catalog failed, catalog_id=%s, err=%v", catalog.ID, err)
+		} else {
+			s.logger.WithContext(ctx).Infof("catalog enabled, catalog_id=%s", catalog.ID)
+		}
+	}
+}
 
+// resolveDataset 解析本进程使用的 skill dataset：新装取 bkn_*，存量环境沿用
+// kweaver_* 旧 ID(只迁展示名)。返回的 resource 为 nil 表示两者都不存在，需新建。
+func (s *skillIndexSync) resolveDataset(ctx context.Context) (string, *interfaces.VegaResource, error) {
 	resource, err := s.vegaClient.GetResourceByID(ctx, executionFactorySkillDataset)
 	if err != nil {
 		s.logger.WithContext(ctx).Errorf("get resource failed during ensure dataset, resource_id=%s, err=%v", executionFactorySkillDataset, err)
-		return err
+		return "", nil, err
 	}
 	if resource != nil {
-		// dataset 已存在：从 tag 读回建时锁定的模型名(建模型==查模型)。
-		// 旧 dataset(改造前创建)无该 tag，回退到按名 "embedding"，与改造前行为一致。
-		modelName := extractEmbeddingModelFromTags(resource.Tags)
-		if modelName == "" {
-			modelName = interfaces.SmallModelTypeEmbedding
+		return resource.ID, resource, nil
+	}
+	legacy, err := s.vegaClient.GetResourceByID(ctx, legacyExecutionFactorySkillDataset)
+	if err != nil {
+		s.logger.WithContext(ctx).Errorf("get legacy resource failed, resource_id=%s, err=%v", legacyExecutionFactorySkillDataset, err)
+		return "", nil, err
+	}
+	if legacy != nil {
+		s.logger.WithContext(ctx).Infof("adopting legacy skill dataset, resource_id=%s", legacy.ID)
+		if legacy.Name != executionFactorySkillDataset {
+			if err := s.vegaClient.RenameResource(ctx, legacy, executionFactorySkillDataset); err != nil {
+				s.logger.WithContext(ctx).Warnf("rename legacy skill dataset failed, resource_id=%s, err=%v", legacy.ID, err)
+			} else {
+				s.logger.WithContext(ctx).Infof("legacy skill dataset renamed, resource_id=%s, name=%s", legacy.ID, executionFactorySkillDataset)
+			}
 		}
-		s.setEmbeddingModelName(modelName)
-		initialized = true
-		s.logger.WithContext(ctx).Infof("resource already exists, resource_id=%s, embedding_model=%s", executionFactorySkillDataset, modelName)
-		return nil
+		return legacy.ID, legacy, nil
 	}
-	// 首次创建 dataset：用系统默认 embedding 模型(接口式可配)；未配置默认时回退按名 "embedding"。
-	embeddingModel, err := s.resolveBuildEmbeddingModel(ctx)
-	if err != nil {
-		s.logger.WithContext(ctx).Errorf("resolve embedding model failed, resource_id=%s, err=%v", executionFactorySkillDataset, err)
-		return err
-	}
-	s.logger.WithContext(ctx).Infof("creating skill dataset resource, resource_id=%s, embedding_model=%s, dimension=%d",
-		executionFactorySkillDataset, embeddingModel.ModelName, embeddingModel.EmbeddingDim)
-	_, err = s.vegaClient.CreateResource(ctx, &interfaces.VegaResourceRequest{
-		ID:        executionFactorySkillDataset,
-		CatalogID: executionFactoryCatalogID,
-		Name:      executionFactorySkillDataset,
-		// 把建时锁定的模型名快照进 tag，供重启/实时同步读回
-		Tags:             []string{"execution-factory", "skill", "索引", embeddingModelTagPrefix + embeddingModel.ModelName},
-		Description:      executionFactoryDatasetDesc,
-		Category:         "dataset",
-		Status:           executionFactoryDatasetStatus,
-		SourceIdentifier: executionFactorySkillDataset,
-		SchemaDefinition: buildSkillIndexSchema(embeddingModel.EmbeddingDim),
-	})
-	if err != nil {
-		s.logger.WithContext(ctx).Errorf("create skill dataset resource failed, resource_id=%s, err=%v", executionFactorySkillDataset, err)
-		return err
-	}
-	s.setEmbeddingModelName(embeddingModel.ModelName)
-	initialized = true
-	return nil
+	return executionFactorySkillDataset, nil, nil
 }
 
 // resolveBuildEmbeddingModel 建 dataset 时确定 embedding 模型：优先系统默认(接口式)，未配置则回退按名 "embedding"(改造前行为)。
@@ -159,7 +264,23 @@ func (s *skillIndexSync) resolveBuildEmbeddingModel(ctx context.Context) (*inter
 	return s.modelManager.GetEmbeddingModel(ctx, interfaces.SmallModelTypeEmbedding, interfaces.SmallModelTypeEmbedding)
 }
 
-// extractEmbeddingModelFromTags 从 resource tags 解析建时锁定的 embedding 模型名
+// extractEmbeddingModelFromSchema 从向量特征的 config.embedding_model 读回建时锁定的模型名
+func extractEmbeddingModelFromSchema(schema []interfaces.VegaProperty) string {
+	for _, property := range schema {
+		for _, feature := range property.Features {
+			if feature.FeatureType != "vector" || feature.Config == nil {
+				continue
+			}
+			if name, ok := feature.Config[embeddingModelConfigKey].(string); ok && name != "" {
+				return name
+			}
+		}
+	}
+	return ""
+}
+
+// extractEmbeddingModelFromTags 从 resource tags 解析建时锁定的 embedding 模型名。
+// 只服务于 tag 快照时期建的老 dataset，新建 dataset 不再写这个 tag。
 func extractEmbeddingModelFromTags(tags []string) string {
 	for _, t := range tags {
 		if strings.HasPrefix(t, embeddingModelTagPrefix) {
@@ -184,6 +305,28 @@ func (s *skillIndexSync) setEmbeddingModelName(name string) {
 	s.embeddingModelName = name
 }
 
+// getDatasetID 返回本进程实际使用的 dataset ID；未解析时取新装默认值。
+func (s *skillIndexSync) getDatasetID() string {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	if s.datasetID == "" {
+		return executionFactorySkillDataset
+	}
+	return s.datasetID
+}
+
+func (s *skillIndexSync) setDatasetID(id string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.datasetID = id
+}
+
+func (s *skillIndexSync) setCatalogID(id string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.catalogID = id
+}
+
 func (s *skillIndexSync) UpsertSkill(ctx context.Context, skill *model.SkillRepositoryDB) error {
 	log := s.logger
 	if !s.isInitialized() {
@@ -195,8 +338,9 @@ func (s *skillIndexSync) UpsertSkill(ctx context.Context, skill *model.SkillRepo
 		log.Errorf("build skill index document failed, skill_id=%s, err=%v", skill.SkillID, err)
 		return err
 	}
-	log.Infof("upsert skill index document, skill_id=%s, resource_id=%s", skill.SkillID, executionFactorySkillDataset)
-	if err = s.vegaClient.WriteDatasetDocuments(ctx, executionFactorySkillDataset, []map[string]any{document}); err != nil {
+	datasetID := s.getDatasetID()
+	log.Infof("upsert skill index document, skill_id=%s, resource_id=%s", skill.SkillID, datasetID)
+	if err = s.vegaClient.WriteDatasetDocuments(ctx, datasetID, []map[string]any{document}); err != nil {
 		log.Errorf("write skill index document failed, skill_id=%s, err=%v", skill.SkillID, err)
 		return err
 	}
@@ -214,8 +358,9 @@ func (s *skillIndexSync) UpdateSkill(ctx context.Context, skill *model.SkillRepo
 		log.Errorf("build skill index document failed, skill_id=%s, err=%v", skill.SkillID, err)
 		return err
 	}
-	log.Infof("update skill index document, skill_id=%s, resource_id=%s", skill.SkillID, executionFactorySkillDataset)
-	if err = s.vegaClient.UpdateDatasetDocuments(ctx, executionFactorySkillDataset, []map[string]any{document}); err != nil {
+	datasetID := s.getDatasetID()
+	log.Infof("update skill index document, skill_id=%s, resource_id=%s", skill.SkillID, datasetID)
+	if err = s.vegaClient.UpdateDatasetDocuments(ctx, datasetID, []map[string]any{document}); err != nil {
 		log.Errorf("update skill index document failed, skill_id=%s, err=%v", skill.SkillID, err)
 		return err
 	}
@@ -227,8 +372,9 @@ func (s *skillIndexSync) DeleteSkill(ctx context.Context, skillID string) error 
 		s.logger.WithContext(ctx).Warnf("skip skill index delete because dataset is not initialized, skill_id=%s", skillID)
 		return nil
 	}
-	s.logger.Infof("delete skill index document, skill_id=%s, resource_id=%s", skillID, executionFactorySkillDataset)
-	if err := s.vegaClient.DeleteDatasetDocumentByID(ctx, executionFactorySkillDataset, skillID); err != nil {
+	datasetID := s.getDatasetID()
+	s.logger.Infof("delete skill index document, skill_id=%s, resource_id=%s", skillID, datasetID)
+	if err := s.vegaClient.DeleteDatasetDocumentByID(ctx, datasetID, skillID); err != nil {
 		s.logger.WithContext(ctx).Errorf("delete skill index document failed, skill_id=%s, err=%v", skillID, err)
 		return err
 	}
@@ -300,7 +446,9 @@ func buildEmbeddingInput(name string, description string) string {
 	return strings.Join(parts, "\n")
 }
 
-func buildSkillIndexSchema(dimension int) []interfaces.VegaProperty {
+// buildSkillIndexSchema 生成 skill 索引 schema。embeddingModel 会写进向量特征的
+// config.embedding_model，既是 vega 建索引时用的模型，也是本服务重启后读回的快照。
+func buildSkillIndexSchema(dimension int, embeddingModel string) []interfaces.VegaProperty {
 	return []interfaces.VegaProperty{
 		{
 			Name:         "skill_id",
@@ -472,7 +620,8 @@ func buildSkillIndexSchema(dimension int) []interfaces.VegaProperty {
 				IsDefault:   true,
 				IsNative:    false,
 				Config: map[string]any{
-					"dimension": dimension,
+					"dimension":             dimension,
+					embeddingModelConfigKey: embeddingModel,
 					"method": map[string]any{
 						"name":       "hnsw",
 						"space_type": "cosinesimil",

--- a/adp/execution-factory/operator-integration/server/logics/skill/index_sync_test.go
+++ b/adp/execution-factory/operator-integration/server/logics/skill/index_sync_test.go
@@ -60,11 +60,20 @@ func TestSkillIndexSync(t *testing.T) {
 			So(createdResource, ShouldNotBeNil)
 			So(createdResource.ID, ShouldEqual, executionFactorySkillDataset)
 			So(createdResource.Status, ShouldEqual, executionFactoryDatasetStatus)
-			// 模型名快照进向量特征 config，不再进 tag(vega tag 校验禁 ':'，带上会 400)
+			// 模型快照进资源级 index_config：tag 会被 vega 的 ':' 校验打回，
+			// 向量属性的 feature config 会被拷进 knn_vector mapping 让建索引失败
 			for _, tag := range createdResource.Tags {
 				So(tag, ShouldNotContainSubstring, ":")
 			}
-			So(extractEmbeddingModelFromSchema(createdResource.SchemaDefinition), ShouldEqual, interfaces.SmallModelTypeEmbedding)
+			So(createdResource.IndexConfig, ShouldNotBeNil)
+			So(createdResource.IndexConfig.DefaultEmbeddingModel, ShouldEqual, interfaces.SmallModelTypeEmbedding)
+			So(extractEmbeddingModelFromSchema(createdResource.SchemaDefinition), ShouldBeEmpty)
+			for _, property := range createdResource.SchemaDefinition {
+				for _, feature := range property.Features {
+					_, ok := feature.Config[embeddingModelConfigKey]
+					So(ok, ShouldBeFalse)
+				}
+			}
 			So(len(createdResource.SchemaDefinition), ShouldEqual, 10)
 			var nameProperty interfaces.VegaProperty
 			var descriptionProperty interfaces.VegaProperty
@@ -186,6 +195,83 @@ func TestSkillIndexSync(t *testing.T) {
 			err := syncer.Init(context.Background())
 			So(err, ShouldBeNil)
 			So(syncer.getDatasetID(), ShouldEqual, legacyExecutionFactorySkillDataset)
+		})
+
+		Convey("Init reads the model snapshot from index_config first, then schema, then tag", func() {
+			mockVegaClient := mocks.NewMockVegaBackendClient(ctrl)
+			syncer := &skillIndexSync{vegaClient: mockVegaClient, logger: logger.DefaultLogger()}
+			mockVegaClient.EXPECT().GetCatalogByID(gomock.Any(), executionFactoryCatalogID).
+				Return(&interfaces.VegaCatalog{
+					ID:      executionFactoryCatalogID,
+					Name:    executionFactoryCatalogID,
+					Tags:    []string{internalCatalogTag},
+					Enabled: true,
+				}, nil)
+			mockVegaClient.EXPECT().GetResourceByID(gomock.Any(), executionFactorySkillDataset).
+				Return(&interfaces.VegaResource{
+					ID:          executionFactorySkillDataset,
+					Name:        executionFactorySkillDataset,
+					IndexConfig: &interfaces.VegaResourceIndexConfig{DefaultEmbeddingModel: "text-embedding-v4"},
+					// schema 与 tag 里的旧快照都在，index_config 优先
+					SchemaDefinition: []interfaces.VegaProperty{{
+						Name: "_vector",
+						Type: "vector",
+						Features: []interfaces.VegaPropertyFeature{{
+							FeatureType: "vector",
+							Config:      map[string]any{embeddingModelConfigKey: "stale-from-schema"},
+						}},
+					}},
+					Tags: []string{embeddingModelTagPrefix + "stale-from-tag"},
+				}, nil)
+
+			So(syncer.Init(context.Background()), ShouldBeNil)
+			So(syncer.getEmbeddingModelName(), ShouldEqual, "text-embedding-v4")
+		})
+
+		Convey("Init pairs the new catalog with a legacy dataset when only the dataset is legacy", func() {
+			mockVegaClient := mocks.NewMockVegaBackendClient(ctrl)
+			syncer := &skillIndexSync{vegaClient: mockVegaClient, logger: logger.DefaultLogger()}
+			mockVegaClient.EXPECT().GetCatalogByID(gomock.Any(), executionFactoryCatalogID).
+				Return(&interfaces.VegaCatalog{
+					ID:      executionFactoryCatalogID,
+					Name:    executionFactoryCatalogID,
+					Tags:    []string{internalCatalogTag},
+					Enabled: true,
+				}, nil)
+			mockVegaClient.EXPECT().GetResourceByID(gomock.Any(), executionFactorySkillDataset).Return(nil, nil)
+			mockVegaClient.EXPECT().GetResourceByID(gomock.Any(), legacyExecutionFactorySkillDataset).
+				Return(&interfaces.VegaResource{ID: legacyExecutionFactorySkillDataset, Name: legacyExecutionFactorySkillDataset}, nil)
+
+			So(syncer.Init(context.Background()), ShouldBeNil)
+			So(syncer.getDatasetID(), ShouldEqual, legacyExecutionFactorySkillDataset)
+		})
+
+		Convey("Init skips the internal tag backfill when the catalog already has 5 tags", func() {
+			var reconciled *interfaces.VegaCatalogRequest
+			mockVegaClient := mocks.NewMockVegaBackendClient(ctrl)
+			syncer := &skillIndexSync{vegaClient: mockVegaClient, logger: logger.DefaultLogger()}
+			fullTags := []string{"a", "b", "c", "d", "e"}
+			mockVegaClient.EXPECT().GetCatalogByID(gomock.Any(), executionFactoryCatalogID).Return(nil, nil)
+			mockVegaClient.EXPECT().GetCatalogByID(gomock.Any(), legacyExecutionFactoryCatalogID).
+				Return(&interfaces.VegaCatalog{
+					ID:      legacyExecutionFactoryCatalogID,
+					Name:    legacyExecutionFactoryCatalogID,
+					Tags:    fullTags,
+					Enabled: true,
+				}, nil)
+			mockVegaClient.EXPECT().UpdateCatalog(gomock.Any(), gomock.Any()).DoAndReturn(func(ctx context.Context, req *interfaces.VegaCatalogRequest) error {
+				reconciled = req
+				return nil
+			})
+			mockVegaClient.EXPECT().GetResourceByID(gomock.Any(), executionFactorySkillDataset).Return(nil, nil)
+			mockVegaClient.EXPECT().GetResourceByID(gomock.Any(), legacyExecutionFactorySkillDataset).
+				Return(&interfaces.VegaResource{ID: legacyExecutionFactorySkillDataset}, nil)
+
+			So(syncer.Init(context.Background()), ShouldBeNil)
+			// 标签超限就别塞，改名这个主目标不能被 400 一起带走
+			So(reconciled, ShouldNotBeNil)
+			So(reconciled.Name, ShouldEqual, executionFactoryCatalogID)
+			So(reconciled.Tags, ShouldResemble, fullTags)
 		})
 
 		Convey("Init backfills the internal tag when only the tag is missing", func() {

--- a/adp/execution-factory/operator-integration/server/logics/skill/index_sync_test.go
+++ b/adp/execution-factory/operator-integration/server/logics/skill/index_sync_test.go
@@ -55,6 +55,8 @@ func TestSkillIndexSync(t *testing.T) {
 			// 逻辑目录必须建成 enabled，否则其下 dataset 读写被 vega 409 拒绝
 			So(createdCatalog.Enabled, ShouldBeTrue)
 			So(createdCatalog.Internal, ShouldBeTrue)
+			// internal 标签：Studio 靠它认内置目录（前端不读 internal 字段）
+			So(createdCatalog.Tags, ShouldContain, internalCatalogTag)
 			So(createdResource, ShouldNotBeNil)
 			So(createdResource.ID, ShouldEqual, executionFactorySkillDataset)
 			So(createdResource.Status, ShouldEqual, executionFactoryDatasetStatus)
@@ -101,7 +103,12 @@ func TestSkillIndexSync(t *testing.T) {
 				logger:       logger.DefaultLogger(),
 			}
 			mockVegaClient.EXPECT().GetCatalogByID(gomock.Any(), executionFactoryCatalogID).
-				Return(&interfaces.VegaCatalog{ID: executionFactoryCatalogID, Name: executionFactoryCatalogID, Enabled: true}, nil)
+				Return(&interfaces.VegaCatalog{
+					ID:      executionFactoryCatalogID,
+					Name:    executionFactoryCatalogID,
+					Tags:    []string{internalCatalogTag},
+					Enabled: true,
+				}, nil)
 			mockVegaClient.EXPECT().GetResourceByID(gomock.Any(), executionFactorySkillDataset).
 				Return(&interfaces.VegaResource{ID: executionFactorySkillDataset, Name: executionFactorySkillDataset}, nil)
 
@@ -154,6 +161,9 @@ func TestSkillIndexSync(t *testing.T) {
 			So(renamedCatalog, ShouldNotBeNil)
 			So(renamedCatalog.ID, ShouldEqual, legacyExecutionFactoryCatalogID)
 			So(renamedCatalog.Name, ShouldEqual, executionFactoryCatalogID)
+			// 存量目录补 internal 标签，原有标签保留
+			So(renamedCatalog.Tags, ShouldContain, internalCatalogTag)
+			So(renamedCatalog.Tags, ShouldContain, "execution-factory")
 			So(renamedResourceName, ShouldEqual, executionFactorySkillDataset)
 			So(syncer.getDatasetID(), ShouldEqual, legacyExecutionFactorySkillDataset)
 			// 建时锁定的 embedding 模型从旧 dataset 的 tag 读回
@@ -168,7 +178,12 @@ func TestSkillIndexSync(t *testing.T) {
 			}
 			mockVegaClient.EXPECT().GetCatalogByID(gomock.Any(), executionFactoryCatalogID).Return(nil, nil)
 			mockVegaClient.EXPECT().GetCatalogByID(gomock.Any(), legacyExecutionFactoryCatalogID).
-				Return(&interfaces.VegaCatalog{ID: legacyExecutionFactoryCatalogID, Name: executionFactoryCatalogID, Enabled: true}, nil)
+				Return(&interfaces.VegaCatalog{
+					ID:      legacyExecutionFactoryCatalogID,
+					Name:    executionFactoryCatalogID,
+					Tags:    []string{"execution-factory", internalCatalogTag},
+					Enabled: true,
+				}, nil)
 			mockVegaClient.EXPECT().GetResourceByID(gomock.Any(), executionFactorySkillDataset).Return(nil, nil)
 			mockVegaClient.EXPECT().GetResourceByID(gomock.Any(), legacyExecutionFactorySkillDataset).
 				Return(&interfaces.VegaResource{ID: legacyExecutionFactorySkillDataset, Name: executionFactorySkillDataset}, nil)
@@ -176,6 +191,33 @@ func TestSkillIndexSync(t *testing.T) {
 			err := syncer.Init(context.Background())
 			So(err, ShouldBeNil)
 			So(syncer.getDatasetID(), ShouldEqual, legacyExecutionFactorySkillDataset)
+		})
+
+		Convey("Init backfills the internal tag when only the tag is missing", func() {
+			var reconciled *interfaces.VegaCatalogRequest
+			mockVegaClient := mocks.NewMockVegaBackendClient(ctrl)
+			syncer := &skillIndexSync{
+				vegaClient: mockVegaClient,
+				logger:     logger.DefaultLogger(),
+			}
+			mockVegaClient.EXPECT().GetCatalogByID(gomock.Any(), executionFactoryCatalogID).
+				Return(&interfaces.VegaCatalog{
+					ID:      executionFactoryCatalogID,
+					Name:    executionFactoryCatalogID,
+					Tags:    []string{"execution-factory", "索引"},
+					Enabled: true,
+				}, nil)
+			mockVegaClient.EXPECT().UpdateCatalog(gomock.Any(), gomock.Any()).DoAndReturn(func(ctx context.Context, req *interfaces.VegaCatalogRequest) error {
+				reconciled = req
+				return nil
+			})
+			mockVegaClient.EXPECT().GetResourceByID(gomock.Any(), executionFactorySkillDataset).
+				Return(&interfaces.VegaResource{ID: executionFactorySkillDataset, Name: executionFactorySkillDataset}, nil)
+
+			err := syncer.Init(context.Background())
+			So(err, ShouldBeNil)
+			So(reconciled, ShouldNotBeNil)
+			So(reconciled.Tags, ShouldResemble, []string{"execution-factory", "索引", internalCatalogTag})
 		})
 
 		Convey("Init survives a failed rename and still serves the legacy dataset", func() {

--- a/adp/execution-factory/operator-integration/server/logics/skill/index_sync_test.go
+++ b/adp/execution-factory/operator-integration/server/logics/skill/index_sync_test.go
@@ -240,10 +240,56 @@ func TestSkillIndexSync(t *testing.T) {
 				}, nil)
 			mockVegaClient.EXPECT().GetResourceByID(gomock.Any(), executionFactorySkillDataset).Return(nil, nil)
 			mockVegaClient.EXPECT().GetResourceByID(gomock.Any(), legacyExecutionFactorySkillDataset).
-				Return(&interfaces.VegaResource{ID: legacyExecutionFactorySkillDataset, Name: legacyExecutionFactorySkillDataset}, nil)
+				Return(&interfaces.VegaResource{
+					ID:        legacyExecutionFactorySkillDataset,
+					Name:      legacyExecutionFactorySkillDataset,
+					CatalogID: legacyExecutionFactoryCatalogID,
+				}, nil)
+			// dataset 挂在旧目录下：写入受它自己的父目录管辖，disabled 就得启用
+			mockVegaClient.EXPECT().GetCatalogByID(gomock.Any(), legacyExecutionFactoryCatalogID).
+				Return(&interfaces.VegaCatalog{ID: legacyExecutionFactoryCatalogID, Name: executionFactoryCatalogID, Enabled: false}, nil)
+			mockVegaClient.EXPECT().EnableCatalog(gomock.Any(), legacyExecutionFactoryCatalogID).Return(nil)
 
 			So(syncer.Init(context.Background()), ShouldBeNil)
 			So(syncer.getDatasetID(), ShouldEqual, legacyExecutionFactorySkillDataset)
+		})
+
+		Convey("Init fails when the catalog cannot be enabled, so the retry loop takes over", func() {
+			mockVegaClient := mocks.NewMockVegaBackendClient(ctrl)
+			syncer := &skillIndexSync{vegaClient: mockVegaClient, logger: logger.DefaultLogger()}
+			mockVegaClient.EXPECT().GetCatalogByID(gomock.Any(), executionFactoryCatalogID).
+				Return(&interfaces.VegaCatalog{
+					ID:      executionFactoryCatalogID,
+					Name:    executionFactoryCatalogID,
+					Tags:    []string{internalCatalogTag},
+					Enabled: false,
+				}, nil)
+			mockVegaClient.EXPECT().EnableCatalog(gomock.Any(), executionFactoryCatalogID).Return(errors.New("vega 500"))
+
+			// disabled 目录下的数据读写会被 vega 409 拒绝，不能带着这个状态标记成已初始化
+			So(syncer.Init(context.Background()), ShouldNotBeNil)
+			So(syncer.isInitialized(), ShouldBeFalse)
+		})
+
+		Convey("Init fails when the adopted dataset points to a missing catalog", func() {
+			mockVegaClient := mocks.NewMockVegaBackendClient(ctrl)
+			syncer := &skillIndexSync{vegaClient: mockVegaClient, logger: logger.DefaultLogger()}
+			mockVegaClient.EXPECT().GetCatalogByID(gomock.Any(), executionFactoryCatalogID).
+				Return(&interfaces.VegaCatalog{
+					ID:      executionFactoryCatalogID,
+					Name:    executionFactoryCatalogID,
+					Tags:    []string{internalCatalogTag},
+					Enabled: true,
+				}, nil)
+			mockVegaClient.EXPECT().GetResourceByID(gomock.Any(), executionFactorySkillDataset).Return(nil, nil)
+			mockVegaClient.EXPECT().GetResourceByID(gomock.Any(), legacyExecutionFactorySkillDataset).
+				Return(&interfaces.VegaResource{ID: legacyExecutionFactorySkillDataset, CatalogID: "ghost_catalog"}, nil)
+			mockVegaClient.EXPECT().GetCatalogByID(gomock.Any(), "ghost_catalog").Return(nil, nil)
+
+			err := syncer.Init(context.Background())
+			So(err, ShouldNotBeNil)
+			So(err.Error(), ShouldContainSubstring, "missing catalog")
+			So(syncer.isInitialized(), ShouldBeFalse)
 		})
 
 		Convey("Init skips the internal tag backfill when the catalog already has 5 tags", func() {

--- a/adp/execution-factory/operator-integration/server/logics/skill/index_sync_test.go
+++ b/adp/execution-factory/operator-integration/server/logics/skill/index_sync_test.go
@@ -2,6 +2,7 @@ package skill
 
 import (
 	"context"
+	"errors"
 	"testing"
 
 	"github.com/openbkn-ai/adp/execution-factory/operator-integration/server/infra/logger"
@@ -30,11 +31,13 @@ func TestSkillIndexSync(t *testing.T) {
 				logger:       logger.DefaultLogger(),
 			}
 			mockVegaClient.EXPECT().GetCatalogByID(gomock.Any(), executionFactoryCatalogID).Return(nil, nil)
+			mockVegaClient.EXPECT().GetCatalogByID(gomock.Any(), legacyExecutionFactoryCatalogID).Return(nil, nil)
 			mockVegaClient.EXPECT().CreateCatalog(gomock.Any(), gomock.Any()).DoAndReturn(func(ctx context.Context, req *interfaces.VegaCatalogRequest) (*interfaces.VegaCatalog, error) {
 				createdCatalog = req
 				return &interfaces.VegaCatalog{ID: req.ID}, nil
 			})
 			mockVegaClient.EXPECT().GetResourceByID(gomock.Any(), executionFactorySkillDataset).Return(nil, nil)
+			mockVegaClient.EXPECT().GetResourceByID(gomock.Any(), legacyExecutionFactorySkillDataset).Return(nil, nil)
 			// 系统默认未配置 -> 回退按名 "embedding"
 			mockModelManager.EXPECT().GetDefaultEmbeddingModel(gomock.Any(), interfaces.SmallModelTypeEmbedding).
 				Return(nil, nil)
@@ -49,11 +52,17 @@ func TestSkillIndexSync(t *testing.T) {
 			So(err, ShouldBeNil)
 			So(createdCatalog, ShouldNotBeNil)
 			So(createdCatalog.ID, ShouldEqual, executionFactoryCatalogID)
+			// 逻辑目录必须建成 enabled，否则其下 dataset 读写被 vega 409 拒绝
+			So(createdCatalog.Enabled, ShouldBeTrue)
+			So(createdCatalog.Internal, ShouldBeTrue)
 			So(createdResource, ShouldNotBeNil)
 			So(createdResource.ID, ShouldEqual, executionFactorySkillDataset)
 			So(createdResource.Status, ShouldEqual, executionFactoryDatasetStatus)
-			// 建时锁定的模型名快照进 tag，供重启/实时同步读回
-			So(createdResource.Tags, ShouldContain, embeddingModelTagPrefix+interfaces.SmallModelTypeEmbedding)
+			// 模型名快照进向量特征 config，不再进 tag(vega tag 校验禁 ':'，带上会 400)
+			for _, tag := range createdResource.Tags {
+				So(tag, ShouldNotContainSubstring, ":")
+			}
+			So(extractEmbeddingModelFromSchema(createdResource.SchemaDefinition), ShouldEqual, interfaces.SmallModelTypeEmbedding)
 			So(len(createdResource.SchemaDefinition), ShouldEqual, 10)
 			var nameProperty interfaces.VegaProperty
 			var descriptionProperty interfaces.VegaProperty
@@ -91,12 +100,103 @@ func TestSkillIndexSync(t *testing.T) {
 				vegaClient:   mockVegaClient,
 				logger:       logger.DefaultLogger(),
 			}
-			mockVegaClient.EXPECT().GetCatalogByID(gomock.Any(), executionFactoryCatalogID).Return(&interfaces.VegaCatalog{ID: executionFactoryCatalogID}, nil)
-			mockVegaClient.EXPECT().GetResourceByID(gomock.Any(), executionFactorySkillDataset).Return(&interfaces.VegaResource{ID: executionFactorySkillDataset}, nil)
+			mockVegaClient.EXPECT().GetCatalogByID(gomock.Any(), executionFactoryCatalogID).
+				Return(&interfaces.VegaCatalog{ID: executionFactoryCatalogID, Name: executionFactoryCatalogID, Enabled: true}, nil)
+			mockVegaClient.EXPECT().GetResourceByID(gomock.Any(), executionFactorySkillDataset).
+				Return(&interfaces.VegaResource{ID: executionFactorySkillDataset, Name: executionFactorySkillDataset}, nil)
 
 			err := syncer.Init(context.Background())
 			So(err, ShouldBeNil)
 			So(syncer.isInitialized(), ShouldBeTrue)
+			So(syncer.getDatasetID(), ShouldEqual, executionFactorySkillDataset)
+		})
+
+		Convey("Init adopts the legacy kweaver catalog/dataset and renames them in place", func() {
+			var renamedCatalog *interfaces.VegaCatalogRequest
+			var renamedResourceName string
+			mockVegaClient := mocks.NewMockVegaBackendClient(ctrl)
+			syncer := &skillIndexSync{
+				vegaClient: mockVegaClient,
+				logger:     logger.DefaultLogger(),
+			}
+			legacyCatalog := &interfaces.VegaCatalog{
+				ID:      legacyExecutionFactoryCatalogID,
+				Name:    legacyExecutionFactoryCatalogID,
+				Tags:    []string{"execution-factory", "索引"},
+				Enabled: false,
+			}
+			legacyResource := &interfaces.VegaResource{
+				ID:        legacyExecutionFactorySkillDataset,
+				Name:      legacyExecutionFactorySkillDataset,
+				CatalogID: legacyExecutionFactoryCatalogID,
+				// 老 dataset 的模型快照在 tag 里，读路径仍要兜住
+				Tags: []string{embeddingModelTagPrefix + "text-embedding-v4"},
+			}
+			mockVegaClient.EXPECT().GetCatalogByID(gomock.Any(), executionFactoryCatalogID).Return(nil, nil)
+			mockVegaClient.EXPECT().GetCatalogByID(gomock.Any(), legacyExecutionFactoryCatalogID).Return(legacyCatalog, nil)
+			mockVegaClient.EXPECT().UpdateCatalog(gomock.Any(), gomock.Any()).DoAndReturn(func(ctx context.Context, req *interfaces.VegaCatalogRequest) error {
+				renamedCatalog = req
+				return nil
+			})
+			mockVegaClient.EXPECT().EnableCatalog(gomock.Any(), legacyExecutionFactoryCatalogID).Return(nil)
+			mockVegaClient.EXPECT().GetResourceByID(gomock.Any(), executionFactorySkillDataset).Return(nil, nil)
+			mockVegaClient.EXPECT().GetResourceByID(gomock.Any(), legacyExecutionFactorySkillDataset).Return(legacyResource, nil)
+			mockVegaClient.EXPECT().RenameResource(gomock.Any(), legacyResource, executionFactorySkillDataset).
+				DoAndReturn(func(ctx context.Context, resource *interfaces.VegaResource, name string) error {
+					renamedResourceName = name
+					return nil
+				})
+
+			err := syncer.Init(context.Background())
+			So(err, ShouldBeNil)
+			So(syncer.isInitialized(), ShouldBeTrue)
+			// 只改展示名，ID 保持旧值：索引数据不搬家，也不会多出一套目录
+			So(renamedCatalog, ShouldNotBeNil)
+			So(renamedCatalog.ID, ShouldEqual, legacyExecutionFactoryCatalogID)
+			So(renamedCatalog.Name, ShouldEqual, executionFactoryCatalogID)
+			So(renamedResourceName, ShouldEqual, executionFactorySkillDataset)
+			So(syncer.getDatasetID(), ShouldEqual, legacyExecutionFactorySkillDataset)
+			// 建时锁定的 embedding 模型从旧 dataset 的 tag 读回
+			So(syncer.getEmbeddingModelName(), ShouldEqual, "text-embedding-v4")
+		})
+
+		Convey("Init keeps an already-renamed legacy catalog untouched", func() {
+			mockVegaClient := mocks.NewMockVegaBackendClient(ctrl)
+			syncer := &skillIndexSync{
+				vegaClient: mockVegaClient,
+				logger:     logger.DefaultLogger(),
+			}
+			mockVegaClient.EXPECT().GetCatalogByID(gomock.Any(), executionFactoryCatalogID).Return(nil, nil)
+			mockVegaClient.EXPECT().GetCatalogByID(gomock.Any(), legacyExecutionFactoryCatalogID).
+				Return(&interfaces.VegaCatalog{ID: legacyExecutionFactoryCatalogID, Name: executionFactoryCatalogID, Enabled: true}, nil)
+			mockVegaClient.EXPECT().GetResourceByID(gomock.Any(), executionFactorySkillDataset).Return(nil, nil)
+			mockVegaClient.EXPECT().GetResourceByID(gomock.Any(), legacyExecutionFactorySkillDataset).
+				Return(&interfaces.VegaResource{ID: legacyExecutionFactorySkillDataset, Name: executionFactorySkillDataset}, nil)
+
+			err := syncer.Init(context.Background())
+			So(err, ShouldBeNil)
+			So(syncer.getDatasetID(), ShouldEqual, legacyExecutionFactorySkillDataset)
+		})
+
+		Convey("Init survives a failed rename and still serves the legacy dataset", func() {
+			mockVegaClient := mocks.NewMockVegaBackendClient(ctrl)
+			syncer := &skillIndexSync{
+				vegaClient: mockVegaClient,
+				logger:     logger.DefaultLogger(),
+			}
+			legacyResource := &interfaces.VegaResource{ID: legacyExecutionFactorySkillDataset, Name: legacyExecutionFactorySkillDataset}
+			mockVegaClient.EXPECT().GetCatalogByID(gomock.Any(), executionFactoryCatalogID).Return(nil, nil)
+			mockVegaClient.EXPECT().GetCatalogByID(gomock.Any(), legacyExecutionFactoryCatalogID).
+				Return(&interfaces.VegaCatalog{ID: legacyExecutionFactoryCatalogID, Name: legacyExecutionFactoryCatalogID, Enabled: true}, nil)
+			mockVegaClient.EXPECT().UpdateCatalog(gomock.Any(), gomock.Any()).Return(errors.New("vega 500"))
+			mockVegaClient.EXPECT().GetResourceByID(gomock.Any(), executionFactorySkillDataset).Return(nil, nil)
+			mockVegaClient.EXPECT().GetResourceByID(gomock.Any(), legacyExecutionFactorySkillDataset).Return(legacyResource, nil)
+			mockVegaClient.EXPECT().RenameResource(gomock.Any(), legacyResource, executionFactorySkillDataset).Return(errors.New("vega 500"))
+
+			err := syncer.Init(context.Background())
+			So(err, ShouldBeNil)
+			So(syncer.isInitialized(), ShouldBeTrue)
+			So(syncer.getDatasetID(), ShouldEqual, legacyExecutionFactorySkillDataset)
 		})
 
 		Convey("UpsertSkill writes complete document with _id and vector", func() {

--- a/adp/execution-factory/operator-integration/server/logics/skill/index_sync_test.go
+++ b/adp/execution-factory/operator-integration/server/logics/skill/index_sync_test.go
@@ -118,9 +118,8 @@ func TestSkillIndexSync(t *testing.T) {
 			So(syncer.getDatasetID(), ShouldEqual, executionFactorySkillDataset)
 		})
 
-		Convey("Init adopts the legacy kweaver catalog/dataset and renames them in place", func() {
+		Convey("Init adopts the legacy kweaver catalog/dataset, renaming the catalog in place", func() {
 			var renamedCatalog *interfaces.VegaCatalogRequest
-			var renamedResourceName string
 			mockVegaClient := mocks.NewMockVegaBackendClient(ctrl)
 			syncer := &skillIndexSync{
 				vegaClient: mockVegaClient,
@@ -148,11 +147,6 @@ func TestSkillIndexSync(t *testing.T) {
 			mockVegaClient.EXPECT().EnableCatalog(gomock.Any(), legacyExecutionFactoryCatalogID).Return(nil)
 			mockVegaClient.EXPECT().GetResourceByID(gomock.Any(), executionFactorySkillDataset).Return(nil, nil)
 			mockVegaClient.EXPECT().GetResourceByID(gomock.Any(), legacyExecutionFactorySkillDataset).Return(legacyResource, nil)
-			mockVegaClient.EXPECT().RenameResource(gomock.Any(), legacyResource, executionFactorySkillDataset).
-				DoAndReturn(func(ctx context.Context, resource *interfaces.VegaResource, name string) error {
-					renamedResourceName = name
-					return nil
-				})
 
 			err := syncer.Init(context.Background())
 			So(err, ShouldBeNil)
@@ -164,7 +158,8 @@ func TestSkillIndexSync(t *testing.T) {
 			// 存量目录补 internal 标签，原有标签保留
 			So(renamedCatalog.Tags, ShouldContain, internalCatalogTag)
 			So(renamedCatalog.Tags, ShouldContain, "execution-factory")
-			So(renamedResourceName, ShouldEqual, executionFactorySkillDataset)
+			// dataset 只收养不改名：vega 会对存量 schema 跑模型校验，改名请求必然 400
+			So(syncer.getDatasetID(), ShouldEqual, legacyExecutionFactorySkillDataset)
 			So(syncer.getDatasetID(), ShouldEqual, legacyExecutionFactorySkillDataset)
 			// 建时锁定的 embedding 模型从旧 dataset 的 tag 读回
 			So(syncer.getEmbeddingModelName(), ShouldEqual, "text-embedding-v4")
@@ -220,7 +215,7 @@ func TestSkillIndexSync(t *testing.T) {
 			So(reconciled.Tags, ShouldResemble, []string{"execution-factory", "索引", internalCatalogTag})
 		})
 
-		Convey("Init survives a failed rename and still serves the legacy dataset", func() {
+		Convey("Init survives a failed catalog rename and still serves the legacy dataset", func() {
 			mockVegaClient := mocks.NewMockVegaBackendClient(ctrl)
 			syncer := &skillIndexSync{
 				vegaClient: mockVegaClient,
@@ -233,7 +228,6 @@ func TestSkillIndexSync(t *testing.T) {
 			mockVegaClient.EXPECT().UpdateCatalog(gomock.Any(), gomock.Any()).Return(errors.New("vega 500"))
 			mockVegaClient.EXPECT().GetResourceByID(gomock.Any(), executionFactorySkillDataset).Return(nil, nil)
 			mockVegaClient.EXPECT().GetResourceByID(gomock.Any(), legacyExecutionFactorySkillDataset).Return(legacyResource, nil)
-			mockVegaClient.EXPECT().RenameResource(gomock.Any(), legacyResource, executionFactorySkillDataset).Return(errors.New("vega 500"))
 
 			err := syncer.Init(context.Background())
 			So(err, ShouldBeNil)

--- a/adp/execution-factory/operator-integration/server/mocks/drivenadapters.go
+++ b/adp/execution-factory/operator-integration/server/mocks/drivenadapters.go
@@ -700,21 +700,6 @@ func (m *MockMFModelManager) EXPECT() *MockMFModelManagerMockRecorder {
 	return m.recorder
 }
 
-// GetEmbeddingModel mocks base method.
-func (m *MockMFModelManager) GetEmbeddingModel(ctx context.Context, modelName, modelType string) (*interfaces.EmbeddingModel, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetEmbeddingModel", ctx, modelName, modelType)
-	ret0, _ := ret[0].(*interfaces.EmbeddingModel)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// GetEmbeddingModel indicates an expected call of GetEmbeddingModel.
-func (mr *MockMFModelManagerMockRecorder) GetEmbeddingModel(ctx, modelName, modelType any) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetEmbeddingModel", reflect.TypeOf((*MockMFModelManager)(nil).GetEmbeddingModel), ctx, modelName, modelType)
-}
-
 // GetDefaultEmbeddingModel mocks base method.
 func (m *MockMFModelManager) GetDefaultEmbeddingModel(ctx context.Context, modelType string) (*interfaces.EmbeddingModel, error) {
 	m.ctrl.T.Helper()
@@ -728,6 +713,21 @@ func (m *MockMFModelManager) GetDefaultEmbeddingModel(ctx context.Context, model
 func (mr *MockMFModelManagerMockRecorder) GetDefaultEmbeddingModel(ctx, modelType any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetDefaultEmbeddingModel", reflect.TypeOf((*MockMFModelManager)(nil).GetDefaultEmbeddingModel), ctx, modelType)
+}
+
+// GetEmbeddingModel mocks base method.
+func (m *MockMFModelManager) GetEmbeddingModel(ctx context.Context, modelName, modelType string) (*interfaces.EmbeddingModel, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetEmbeddingModel", ctx, modelName, modelType)
+	ret0, _ := ret[0].(*interfaces.EmbeddingModel)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetEmbeddingModel indicates an expected call of GetEmbeddingModel.
+func (mr *MockMFModelManagerMockRecorder) GetEmbeddingModel(ctx, modelName, modelType any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetEmbeddingModel", reflect.TypeOf((*MockMFModelManager)(nil).GetEmbeddingModel), ctx, modelName, modelType)
 }
 
 // GetPromptByPromptID mocks base method.
@@ -813,6 +813,20 @@ func (mr *MockVegaBackendClientMockRecorder) DeleteDatasetDocumentByID(ctx, data
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteDatasetDocumentByID", reflect.TypeOf((*MockVegaBackendClient)(nil).DeleteDatasetDocumentByID), ctx, datasetID, docID)
 }
 
+// EnableCatalog mocks base method.
+func (m *MockVegaBackendClient) EnableCatalog(ctx context.Context, id string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "EnableCatalog", ctx, id)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// EnableCatalog indicates an expected call of EnableCatalog.
+func (mr *MockVegaBackendClientMockRecorder) EnableCatalog(ctx, id any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EnableCatalog", reflect.TypeOf((*MockVegaBackendClient)(nil).EnableCatalog), ctx, id)
+}
+
 // GetCatalogByID mocks base method.
 func (m *MockVegaBackendClient) GetCatalogByID(ctx context.Context, id string) (*interfaces.VegaCatalog, error) {
 	m.ctrl.T.Helper()
@@ -841,6 +855,34 @@ func (m *MockVegaBackendClient) GetResourceByID(ctx context.Context, id string) 
 func (mr *MockVegaBackendClientMockRecorder) GetResourceByID(ctx, id any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetResourceByID", reflect.TypeOf((*MockVegaBackendClient)(nil).GetResourceByID), ctx, id)
+}
+
+// RenameResource mocks base method.
+func (m *MockVegaBackendClient) RenameResource(ctx context.Context, resource *interfaces.VegaResource, name string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "RenameResource", ctx, resource, name)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// RenameResource indicates an expected call of RenameResource.
+func (mr *MockVegaBackendClientMockRecorder) RenameResource(ctx, resource, name any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RenameResource", reflect.TypeOf((*MockVegaBackendClient)(nil).RenameResource), ctx, resource, name)
+}
+
+// UpdateCatalog mocks base method.
+func (m *MockVegaBackendClient) UpdateCatalog(ctx context.Context, req *interfaces.VegaCatalogRequest) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "UpdateCatalog", ctx, req)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// UpdateCatalog indicates an expected call of UpdateCatalog.
+func (mr *MockVegaBackendClientMockRecorder) UpdateCatalog(ctx, req any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateCatalog", reflect.TypeOf((*MockVegaBackendClient)(nil).UpdateCatalog), ctx, req)
 }
 
 // UpdateDatasetDocuments mocks base method.

--- a/adp/execution-factory/operator-integration/server/mocks/drivenadapters.go
+++ b/adp/execution-factory/operator-integration/server/mocks/drivenadapters.go
@@ -857,20 +857,6 @@ func (mr *MockVegaBackendClientMockRecorder) GetResourceByID(ctx, id any) *gomoc
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetResourceByID", reflect.TypeOf((*MockVegaBackendClient)(nil).GetResourceByID), ctx, id)
 }
 
-// RenameResource mocks base method.
-func (m *MockVegaBackendClient) RenameResource(ctx context.Context, resource *interfaces.VegaResource, name string) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "RenameResource", ctx, resource, name)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// RenameResource indicates an expected call of RenameResource.
-func (mr *MockVegaBackendClientMockRecorder) RenameResource(ctx, resource, name any) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RenameResource", reflect.TypeOf((*MockVegaBackendClient)(nil).RenameResource), ctx, resource, name)
-}
-
 // UpdateCatalog mocks base method.
 func (m *MockVegaBackendClient) UpdateCatalog(ctx context.Context, req *interfaces.VegaCatalogRequest) error {
 	m.ctrl.T.Helper()


### PR DESCRIPTION
Closes #372（后端部分）

## 问题

数据目录里的系统内置逻辑目录仍叫 `kweaver_execution_factory_catalog`。排查过程中带出两个把整条链路打死的缺陷：

1. `GetCatalogByID` 没按 `{"entries":[...]}` 解包，返回的 `VegaCatalog` 是零值（ID/name/enabled 全空）。此前调用方只判 nil，所以一直没暴露。
2. 建 dataset 时把 embedding 模型快照写进 tag（`embedding_model:<name>`），而 vega 的 tag 校验禁掉了 `:`，请求直接 400 —— 测试服上 skill dataset 从来就没建起来。

## 改法

改名不换 ID：ID 是索引落点，换 ID 等于重建索引，并且会多出一套目录（#372 明确要求不产生两套）。

- 新装：建 `bkn_execution_factory_catalog` / `bkn_execution_factory_skill_dataset`
- 存量：沿用旧 ID，启动时把 **catalog** 展示名就地迁到新品牌名（`PUT /catalogs/{id}`，只带展示字段，回填 `enabled`/`connector_type` 当前值满足不可变约束）
- 存量 **dataset 只收养不改名**：vega 的 `Update` 无条件对已存的 schema 跑模型校验，而所有存量 dataset 的 `_vector` 都没有 `embedding_model`（建于快照机制之前），vega 回退到常量 `"embedding"` 并因该模型未注册而 400 —— 改名请求对这批 dataset 必然失败（VM 实测）。收养才是「不产生两套」的关键，改名只是展示项，故去掉
- 改名/启用失败只告警不阻断启动，索引读写本身不依赖它们成功
- 内置目录建成 enabled，并补启用存量的 disabled 目录：逻辑目录 disabled 时其下 dataset 读写会被 vega 以 409 `Catalog.IsDisabled` 拒绝（bkn-backend 的内置目录一直显式置 true，执行工厂漏了）
- embedding 模型快照移到资源级 `index_config.default_embedding_model`（vega 解析向量模型的兜底位置）；读回顺序 `index_config` → schema → tag → `"embedding"`。**不能放 tag**（vega tag 校验禁 `:`，建 dataset 直接 400），**也不能放向量属性的 feature config**（vega 会把它原样拷进 OpenSearch knn_vector mapping，OpenSearch 以 `unknown parameter [embedding_model]` 拒绝，而建索引失败被 `resource_service.go:287-290` 吞掉，表面上 dataset 仍是 active）
- `reconcileCatalog` 补 `internal` 标签前检查 vega 的 5 个 tag 上限，超限放弃补标签保住改名
- 内置目录打 `internal` 标签：Studio 目前不读后端 `internal` 字段，靠 metadata/tag/名称前缀启发式判定内置目录，该标签命中它的内置标签集合 —— **前端零改**即可显示「内置」并收起删除入口。bkn 概念目录同样建时带上（存量靠 `adp_bkn_` 前缀命中，不回填）

## 验证

单测：存量收养+改名、已改名幂等、仅补 tag、改名失败仍可用、entries 按 id 匹配等用例；`go test ./...` 绿。

OpenSearch 侧实证（测试服，删掉早前那个无索引的 dataset 后重建）：

```
_vector: {"type":"knn_vector","dimension":1024,"method":{"name":"hnsw",...}}   ← 索引建成，mapping 无 embedding_model
f_index_config: {"default_embedding_model":"text-embedding-v4"}
重启日志: resource already exists, embedding_model=text-embedding-v4          ← 快照读回闭环
```

**测试服 14.103.77.23**（kweaver 前缀 + disabled + 无 dataset 的形态）：

```
-- 升级前
kweaver_execution_factory_catalog  kweaver_execution_factory_catalog  enabled=0  internal=1  tags=execution-factory,索引
（无 skill dataset）

-- 升级后
kweaver_execution_factory_catalog  bkn_execution_factory_catalog      enabled=1  internal=1  tags=execution-factory,索引,internal
bkn_execution_factory_skill_dataset  status=active
```

**验证 VM 10.211.55.4**（kweaver 前缀 + disabled + **存量 dataset 尚在**的形态）：

```
-- catalog：ID 不变，name/enabled/tags 全部到位
kweaver_execution_factory_catalog  bkn_execution_factory_catalog  enabled=1  internal=1  tags=execution-factory,索引,internal

-- dataset：被收养、零改动（schema md5 与升级前逐字节一致，local_index_name 未被清）
kweaver_execution_factory_skill_dataset  md5=b597aa3cd5d9642f3a3e4ffe4415f733
```

二次重启验证幂等：catalog 已对齐后不再发任何 PUT。

## 升级 / 回滚说明

- 升级：服务启动自动收敛，无 DB 迁移、不依赖 helm hook，`kubectl set image` 也生效
- **回滚**：新装环境回滚到旧镜像后，旧代码找不到 `bkn_*`，会另建一套 `kweaver_*` 目录与空 skill 索引 —— 本次升级后不建议回滚旧镜像（存量环境回滚无此问题，ID 未变）

## 已知取舍 / 遗留

- **存量 dataset 保留旧显示名**（`kweaver_execution_factory_skill_dataset`）：改名请求会被 vega 的模型校验挡死，且它挂在内置目录下仅超管可见，产品上接受现状
- **Studio 未消费后端 `internal` 字段**：当前靠 `internal` 标签命中前端启发式，功能完整且标签由后端每次启动自愈；映射字段属可选优化，不阻塞
- **vega 通用缺陷**：`Update` 对未改动的 schema 也跑模型校验，导致「引用模型未注册就改不了资源名」，本 PR 不处理
- **老环境 `internal=false` 无法回填**：vega 的 `Update` 忽略 `Internal` 字段，早于 #37 的目录若 `internal=false`，Studio 会因 `internal` 标签显示为内置、vega 侧仍按普通目录鉴权。非本 PR 引入，两台验证环境均为 `internal=1`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

