### PR TITLE
feat(bkn-trace): emit bkn backend schema evidence events

### DIFF
--- a/adp/bkn/bkn-backend/TRACE.md
+++ b/adp/bkn/bkn-backend/TRACE.md
@@ -1,0 +1,78 @@
+# bkn-backend Trace Contract
+
+> 状态：阶段二 L2 schema evidence 局部接入
+> 适用版本：`bkn.trace.schema.version=2.0.0`
+> 依据：`bkn-docs/docs/foundry/bkn-trace/design/BKN Trace 设计.md`
+
+## Module
+
+- module name: `bkn-backend`
+- owner: OpenBKN Foundry / BKN Engine
+- service identity: `bkn-backend`
+- runtime: Go HTTP service
+- repository path: `adp/bkn/bkn-backend`
+- contract version: `2.0.0`
+
+## Entry Operations
+
+| operation | trigger | required context | emitted spans | emitted events |
+| --- | --- | --- | --- | --- |
+| `bkn.schema.object_type.list` | `GET /knowledge-networks/:kn_id/object-types` | `traceparent`、`bkn-request-id`、account/auth context | existing server span | `claim.created`、`evidence.refs.created` |
+| `bkn.schema.object_type.get` | `GET /knowledge-networks/:kn_id/object-types/:ot_ids` | same | existing server span | `claim.created`、`evidence.refs.created` |
+| `bkn.schema.relation_type.list` | `GET /knowledge-networks/:kn_id/relation-types` | same | existing server span | `claim.created`、`evidence.refs.created` |
+| `bkn.schema.relation_type.get` | `GET /knowledge-networks/:kn_id/relation-types/:rt_ids` | same | existing server span | `claim.created`、`evidence.refs.created` |
+| `bkn.schema.action_type.list` | `GET /knowledge-networks/:kn_id/action-types` | same | existing server span | `claim.created`、`evidence.refs.created` |
+| `bkn.schema.action_type.get` | `GET /knowledge-networks/:kn_id/action-types/:at_ids` | same | existing server span | `claim.created`、`evidence.refs.created` |
+| `bkn.schema.metric.list` | `GET /knowledge-networks/:kn_id/metrics` | same | existing server span | `claim.created`、`evidence.refs.created` |
+| `bkn.schema.metric.get` | `GET /knowledge-networks/:kn_id/metrics/:metric_ids` | same | existing server span | `claim.created`、`evidence.refs.created` |
+
+## Inbound Context
+
+- accepted headers: `traceparent`、`bkn-request-id`、legacy `x-request-id`、`x-account-id`、`x-account-type`、`x-business-domain`。
+- `traceparent` parsing: existing global middleware extracts W3C Trace Context into OTel context before handlers create server spans.
+- request id rule: evidence emission uses inbound `bkn-request-id` first, then `x-request-id`; when both are absent it generates `req_<xid>` only for evidence payload completeness.
+- account context source: external APIs use OAuth visitor; internal APIs use account headers through `visitor.GenerateVisitor(c)`; baggage is not an authorization source.
+
+## Phase 2 Evidence Event Rules
+
+- Successful schema read paths emit one `claim.created` event and one `evidence.refs.created` event after the service read succeeds and before the HTTP response is written.
+- Object type and relation type reads emit `schema_ref`; action type reads emit `action_ref`; metric reads emit `metric_ref`.
+- `claim.created.payload.claim_type` is `finding`; `claim_hash` is computed from safe result summary only.
+- `evidence_refs[].summary` may contain IDs, `kn_id`, `branch`, type fields, counts, booleans and timestamps. It must not contain names, comments, property names, mapping rule details, action intent text, metric formula content, SQL, row data, prompt, tool input/output, token, cookie or authorization values.
+- `summary_hash` is always present and computed from the safe summary.
+- `version_status` is currently `unversioned`; refs must include `partial_reason` such as `schema_ref_unversioned`、`action_ref_unversioned`、`metric_ref_unversioned` until schema/snapshot versioning is connected.
+- Evidence event submission is controlled by `BKN_TRACE_EVIDENCE_INGEST_URL`; default is disabled and no business response changes.
+- Submission is asynchronous and fail-open; ingestion failures do not change API status or response body.
+
+## Sensitive Data Rules
+
+- never emit: token、authorization、cookie、完整 SQL、完整 prompt、完整 action intent、完整 metric formula、完整 mapping rules、字段名/字段说明、对象/关系/指标/行动名称、row data、PII、连接串、对象存储裸 URL。
+- hash only: request ID list, result summary, schema/action/metric safe summary.
+- controlled reference: `object_type:<id>`、`relation_type:<id>`、`action_type:<id>`、`metric:<id>`。
+- `data.classification`: current schema evidence events are `internal`.
+
+## Fixtures
+
+| fixture | path | purpose | expected result |
+| --- | --- | --- | --- |
+| phase2 positive | `fixtures/bkn-trace/phase2/bkn_schema_l2_positive.json` | object/relation/action/metric schema read L2 finding and evidence refs | pass |
+
+## Covered GWT
+
+- GWT-BKN-01 Given legal trace/request/account context, When object/relation/action/metric schema read succeeds, Then bkn-backend emits `claim.created` and `evidence.refs.created` tied to the same `trace_id`、`span_id`、`bkn.request.id`.
+- GWT-BKN-02 Given returned schema contains names, comments, property names, mapping rules, action intent or metric formula content, When evidence events are built, Then payload contains only refs/hash/counts/status and no raw schema content.
+- GWT-BKN-03 Given `BKN_TRACE_EVIDENCE_INGEST_URL` is not configured, When schema read succeeds, Then business response remains unchanged and no event submission occurs.
+- GWT-BKN-04 Given evidence ingest is unavailable, When asynchronous event submission fails, Then API status and response body remain unchanged.
+
+## Known Gaps
+
+- This contract covers schema read evidence from bkn-backend only; object instance data-chain evidence remains in ontology-query/context-loader/Vega paths.
+- Schema version and snapshot refs are not available yet, so refs are `unversioned`.
+- Cross-module Evidence Graph assembly, snapshot persistence and Studio visualization are owned by BKN Trace core service.
+
+## Owner Sign-off
+
+- owner: OpenBKN Foundry / BKN Engine
+- reviewed at: 2026-07-23
+- reviewer: pending
+- compatibility risk: low; event emission is disabled by default and fail-open when enabled.

--- a/adp/bkn/bkn-backend/TRACE.md
+++ b/adp/bkn/bkn-backend/TRACE.md
@@ -38,6 +38,7 @@
 - Successful schema read paths emit one `claim.created` event and one `evidence.refs.created` event after the service read succeeds and before the HTTP response is written.
 - Object type and relation type reads emit `schema_ref`; action type reads emit `action_ref`; metric reads emit `metric_ref`.
 - `claim.created.payload.claim_type` is `finding`; `claim_hash` is computed from safe result summary only.
+- `claim_id` / `claim_hash` must include a hash of the sorted `ref_id + ref_type + summary_hash` set so same-count list results with different schema refs remain distinguishable.
 - `evidence_refs[].summary` may contain IDs, `kn_id`, `branch`, type fields, counts, booleans and timestamps. It must not contain names, comments, property names, mapping rule details, action intent text, metric formula content, SQL, row data, prompt, tool input/output, token, cookie or authorization values.
 - `summary_hash` is always present and computed from the safe summary.
 - `version_status` is currently `unversioned`; refs must include `partial_reason` such as `schema_ref_unversioned`、`action_ref_unversioned`、`metric_ref_unversioned` until schema/snapshot versioning is connected.

--- a/adp/bkn/bkn-backend/fixtures/bkn-trace/phase2/bkn_schema_l2_positive.json
+++ b/adp/bkn/bkn-backend/fixtures/bkn-trace/phase2/bkn_schema_l2_positive.json
@@ -46,6 +46,7 @@
           "branch": "main",
           "entity_kind": "object_type",
           "requested_hash": "sha256:requested_ids_hash_only",
+          "evidence_refs_hash": "sha256:sorted_ref_id_and_summary_hashes_only",
           "returned_ref_count": 4,
           "returned_count": 4,
           "total_count": 4,

--- a/adp/bkn/bkn-backend/fixtures/bkn-trace/phase2/bkn_schema_l2_positive.json
+++ b/adp/bkn/bkn-backend/fixtures/bkn-trace/phase2/bkn_schema_l2_positive.json
@@ -1,0 +1,161 @@
+{
+  "bkn.trace.schema.version": "2.0.0",
+  "fixture_id": "bkn_backend_phase2_schema_l2_positive",
+  "expected_result": "pass",
+  "trace": {
+    "trace_id": "71310000000000000000000000000001",
+    "traceparent": "00-71310000000000000000000000000001-7131000000000001-01",
+    "bkn.request.id": "req_bkn_backend_phase2_schema_0001",
+    "business_domain": "domain_demo",
+    "bkn.account.id": "acct_demo",
+    "bkn.account.type": "service"
+  },
+  "spans": [
+    {
+      "span_id": "7131000000000001",
+      "parent_span_id": null,
+      "name": "bkn-backend.request",
+      "kind": "server",
+      "bkn.module.name": "bkn-backend",
+      "bkn.operation.name": "bkn.schema.object_type.list",
+      "bkn.status": "ok",
+      "bkn.timestamp": "2026-07-23T14:30:00.000000Z"
+    }
+  ],
+  "events": [
+    {
+      "event_id": "evt_bkn_backend_schema_claim",
+      "event_type": "claim.created",
+      "bkn.trace.schema.version": "2.0.0",
+      "observed_at": "2026-07-23T14:30:00.001000Z",
+      "emitted_at": "2026-07-23T14:30:00.002000Z",
+      "producer_module": "bkn-backend",
+      "trace_id": "71310000000000000000000000000001",
+      "span_id": "7131000000000001",
+      "bkn.request.id": "req_bkn_backend_phase2_schema_0001",
+      "bkn.operation.name": "bkn.schema.object_type.list",
+      "payload": {
+        "claim_id": "claim_bkn_backend_schema_0001",
+        "claim_type": "finding",
+        "claim_hash": "sha256:bkn_schema_read_summary_hash_only",
+        "visibility": "visible",
+        "version_status": "unversioned",
+        "partial_reason": ["schema_refs_unversioned"],
+        "subject_refs": {
+          "kn_id": "kn_demo",
+          "branch": "main",
+          "entity_kind": "object_type",
+          "requested_hash": "sha256:requested_ids_hash_only",
+          "returned_ref_count": 4,
+          "returned_count": 4,
+          "total_count": 4,
+          "data.classification": "internal"
+        }
+      }
+    },
+    {
+      "event_id": "evt_bkn_backend_schema_refs",
+      "event_type": "evidence.refs.created",
+      "bkn.trace.schema.version": "2.0.0",
+      "observed_at": "2026-07-23T14:30:00.003000Z",
+      "emitted_at": "2026-07-23T14:30:00.004000Z",
+      "producer_module": "bkn-backend",
+      "trace_id": "71310000000000000000000000000001",
+      "span_id": "7131000000000001",
+      "bkn.request.id": "req_bkn_backend_phase2_schema_0001",
+      "bkn.operation.name": "bkn.schema.object_type.list",
+      "payload": {
+        "claim_id": "claim_bkn_backend_schema_0001",
+        "evidence_refs": [
+          {
+            "ref_id": "object_type:customer",
+            "ref_type": "schema_ref",
+            "source_system": "bkn-backend",
+            "summary": {
+              "kind": "object_type",
+              "id": "customer",
+              "kn_id": "kn_demo",
+              "branch": "main",
+              "property_count": 8,
+              "data_property_count": 6,
+              "logic_property_count": 2,
+              "primary_key_count": 1,
+              "has_status": true,
+              "update_time": 1795319400000
+            },
+            "summary_hash": "sha256:object_type_summary_hash_only",
+            "validity": "observed",
+            "version_status": "unversioned",
+            "visibility": "visible",
+            "partial_reason": ["schema_ref_unversioned"]
+          },
+          {
+            "ref_id": "relation_type:customer_has_order",
+            "ref_type": "schema_ref",
+            "source_system": "bkn-backend",
+            "summary": {
+              "kind": "relation_type",
+              "id": "customer_has_order",
+              "kn_id": "kn_demo",
+              "branch": "main",
+              "source_object_type_id": "customer",
+              "target_object_type_id": "order",
+              "relation_type": "direct",
+              "has_mapping_rules": true,
+              "update_time": 1795319400000
+            },
+            "summary_hash": "sha256:relation_type_summary_hash_only",
+            "validity": "observed",
+            "version_status": "unversioned",
+            "visibility": "visible",
+            "partial_reason": ["schema_ref_unversioned"]
+          },
+          {
+            "ref_id": "action_type:notify_owner",
+            "ref_type": "action_ref",
+            "source_system": "bkn-backend",
+            "summary": {
+              "kind": "action_type",
+              "id": "notify_owner",
+              "kn_id": "kn_demo",
+              "branch": "main",
+              "object_type_id": "customer",
+              "action_type": "tool",
+              "parameter_count": 3,
+              "impact_contract_count": 1,
+              "update_time": 1795319400000
+            },
+            "summary_hash": "sha256:action_type_summary_hash_only",
+            "validity": "observed",
+            "version_status": "unversioned",
+            "visibility": "visible",
+            "partial_reason": ["action_ref_unversioned"]
+          },
+          {
+            "ref_id": "metric:customer_risk_score",
+            "ref_type": "metric_ref",
+            "source_system": "bkn-backend",
+            "summary": {
+              "kind": "metric",
+              "id": "customer_risk_score",
+              "kn_id": "kn_demo",
+              "branch": "main",
+              "metric_type": "derived",
+              "scope_type": "object_type",
+              "scope_ref": "customer",
+              "has_time_dimension": false,
+              "has_calculation_formula": true,
+              "analysis_dimension_count": 2,
+              "update_time": 1795319400000
+            },
+            "summary_hash": "sha256:metric_summary_hash_only",
+            "validity": "observed",
+            "version_status": "unversioned",
+            "visibility": "visible",
+            "partial_reason": ["metric_ref_unversioned"]
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/adp/bkn/bkn-backend/server/common/bkntrace/evidence.go
+++ b/adp/bkn/bkn-backend/server/common/bkntrace/evidence.go
@@ -1,0 +1,448 @@
+// Copyright openbkn.ai
+// Copyright The kweaver.ai Authors.
+//
+// Licensed under the Apache License, Version 2.0.
+// See the LICENSE file in the project root for details.
+
+package bkntrace
+
+import (
+	"bytes"
+	"context"
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"os"
+	"strings"
+	"time"
+
+	"bkn-backend/interfaces"
+	"go.opentelemetry.io/otel/trace"
+)
+
+const (
+	ContractVersion = "2.0.0"
+	ModuleName      = "bkn-backend"
+)
+
+const (
+	envEvidenceIngestURL       = "BKN_TRACE_EVIDENCE_INGEST_URL"
+	envEvidenceIngestTimeoutMS = "BKN_TRACE_EVIDENCE_TIMEOUT_MS"
+)
+
+const maxInFlightEvidenceBatches = 64
+
+const (
+	EntityKindObjectType   = "object_type"
+	EntityKindRelationType = "relation_type"
+	EntityKindActionType   = "action_type"
+	EntityKindMetric       = "metric"
+)
+
+const (
+	RefTypeSchema = "schema_ref"
+	RefTypeAction = "action_ref"
+	RefTypeMetric = "metric_ref"
+)
+
+type Event map[string]any
+
+type RequestContext struct {
+	RequestID      string
+	AccountID      string
+	AccountType    string
+	BusinessDomain string
+}
+
+type ReadSubject struct {
+	EntityKind    string
+	Operation     string
+	KNID          string
+	Branch        string
+	RequestedIDs  []string
+	ReturnedCount int
+	TotalCount    int64
+}
+
+type EvidenceRef struct {
+	RefID          string
+	RefType        string
+	PartialReasons []string
+	Summary        map[string]any
+}
+
+type batch struct {
+	ContractVersion string         `json:"bkn.trace.schema.version"`
+	Trace           map[string]any `json:"trace"`
+	Events          []Event        `json:"events"`
+}
+
+type eventContext struct {
+	traceID        string
+	spanID         string
+	traceparent    string
+	requestID      string
+	accountID      string
+	accountType    string
+	businessDomain string
+}
+
+var (
+	evidenceHTTPClient = &http.Client{}
+	evidenceInFlight   = make(chan struct{}, maxInFlightEvidenceBatches)
+)
+
+func EvidenceEnabled() bool {
+	return evidenceIngestURL() != ""
+}
+
+func HashValue(value any) string {
+	raw, err := json.Marshal(value)
+	if err != nil {
+		raw = []byte(fmt.Sprintf("%v", value))
+	}
+	sum := sha256.Sum256(raw)
+	return "sha256:" + hex.EncodeToString(sum[:])
+}
+
+func ClaimID(kind, subjectID string, value any) string {
+	sum := sha256.Sum256([]byte(HashValue(map[string]any{
+		"kind":       kind,
+		"subject_id": subjectID,
+		"value":      value,
+	})))
+	return "claim_" + hex.EncodeToString(sum[:])[:24]
+}
+
+func BuildSchemaReadEvents(ctx context.Context, reqCtx RequestContext, subject ReadSubject, refs []EvidenceRef) []Event {
+	ec, ok := contextFromRequest(ctx, reqCtx)
+	if !ok || len(refs) == 0 {
+		return nil
+	}
+	operation := strings.TrimSpace(subject.Operation)
+	if operation == "" {
+		operation = "bkn.schema.read"
+	}
+
+	evidenceRefs := make([]map[string]any, 0, len(refs))
+	for _, ref := range refs {
+		if strings.TrimSpace(ref.RefID) == "" || strings.TrimSpace(ref.RefType) == "" {
+			continue
+		}
+		partialReasons := ref.PartialReasons
+		if len(partialReasons) == 0 {
+			partialReasons = []string{ref.RefType + "_unversioned"}
+		}
+		evidenceRefs = append(evidenceRefs, map[string]any{
+			"ref_id":         strings.TrimSpace(ref.RefID),
+			"ref_type":       strings.TrimSpace(ref.RefType),
+			"source_system":  ModuleName,
+			"summary":        ref.Summary,
+			"summary_hash":   HashValue(ref.Summary),
+			"validity":       "observed",
+			"version_status": "unversioned",
+			"visibility":     "visible",
+			"partial_reason": partialReasons,
+		})
+	}
+	if len(evidenceRefs) == 0 {
+		return nil
+	}
+
+	resultSummary := map[string]any{
+		"kn_id":            strings.TrimSpace(subject.KNID),
+		"branch":           strings.TrimSpace(subject.Branch),
+		"entity_kind":      strings.TrimSpace(subject.EntityKind),
+		"requested_hash":   HashValue(subject.RequestedIDs),
+		"returned_count":   subject.ReturnedCount,
+		"total_count":      subject.TotalCount,
+		"evidence_count":   len(evidenceRefs),
+		"operation":        operation,
+		"producer_module":  ModuleName,
+		"contract_version": ContractVersion,
+	}
+	claimID := ClaimID(operation, subject.KNID, resultSummary)
+
+	return []Event{
+		buildEvent(ec, "claim.created", operation, map[string]any{
+			"claim_id":       claimID,
+			"claim_type":     "finding",
+			"claim_hash":     HashValue(resultSummary),
+			"visibility":     "visible",
+			"version_status": "unversioned",
+			"partial_reason": []string{"schema_refs_unversioned"},
+			"subject_refs": map[string]any{
+				"kn_id":               strings.TrimSpace(subject.KNID),
+				"branch":              strings.TrimSpace(subject.Branch),
+				"entity_kind":         strings.TrimSpace(subject.EntityKind),
+				"requested_hash":      resultSummary["requested_hash"],
+				"returned_ref_count":  len(evidenceRefs),
+				"returned_count":      subject.ReturnedCount,
+				"total_count":         subject.TotalCount,
+				"data.classification": "internal",
+			},
+		}),
+		buildEvent(ec, "evidence.refs.created", operation, map[string]any{
+			"claim_id":      claimID,
+			"evidence_refs": evidenceRefs,
+		}),
+	}
+}
+
+func EmitSchemaReadEvents(ctx context.Context, reqCtx RequestContext, subject ReadSubject, refs []EvidenceRef) {
+	if !EvidenceEnabled() {
+		return
+	}
+	SubmitEvents(ctx, reqCtx, BuildSchemaReadEvents(ctx, reqCtx, subject, refs))
+}
+
+func SubmitEvents(ctx context.Context, reqCtx RequestContext, events []Event) {
+	if len(events) == 0 {
+		return
+	}
+	ec, ok := contextFromRequest(ctx, reqCtx)
+	if !ok {
+		return
+	}
+	ingestURL := evidenceIngestURL()
+	if ingestURL == "" {
+		return
+	}
+
+	payload := batch{
+		ContractVersion: ContractVersion,
+		Trace: map[string]any{
+			"trace_id":         ec.traceID,
+			"traceparent":      ec.traceparent,
+			"bkn.request.id":   ec.requestID,
+			"business_domain":  ec.businessDomain,
+			"bkn.account.id":   ec.accountID,
+			"bkn.account.type": ec.accountType,
+		},
+		Events: events,
+	}
+
+	select {
+	case evidenceInFlight <- struct{}{}:
+	default:
+		return
+	}
+
+	timeout := evidenceTimeout()
+	go func() {
+		defer func() { <-evidenceInFlight }()
+		_ = postBatch(ingestURL, timeout, payload)
+	}()
+}
+
+func ObjectTypeRefs(items []*interfaces.ObjectType) []EvidenceRef {
+	refs := make([]EvidenceRef, 0, len(items))
+	for _, item := range items {
+		if item == nil || strings.TrimSpace(item.OTID) == "" {
+			continue
+		}
+		refs = append(refs, EvidenceRef{
+			RefID:   "object_type:" + strings.TrimSpace(item.OTID),
+			RefType: RefTypeSchema,
+			Summary: map[string]any{
+				"kind":                 EntityKindObjectType,
+				"id":                   strings.TrimSpace(item.OTID),
+				"kn_id":                strings.TrimSpace(item.KNID),
+				"branch":               strings.TrimSpace(item.Branch),
+				"module_type":          strings.TrimSpace(item.ModuleType),
+				"property_count":       len(item.DataProperties) + len(item.LogicProperties),
+				"data_property_count":  len(item.DataProperties),
+				"logic_property_count": len(item.LogicProperties),
+				"primary_key_count":    len(item.PrimaryKeys),
+				"has_status":           item.Status != nil,
+				"update_time":          item.UpdateTime,
+			},
+		})
+	}
+	return refs
+}
+
+func RelationTypeRefs(items []*interfaces.RelationType) []EvidenceRef {
+	refs := make([]EvidenceRef, 0, len(items))
+	for _, item := range items {
+		if item == nil || strings.TrimSpace(item.RTID) == "" {
+			continue
+		}
+		refs = append(refs, EvidenceRef{
+			RefID:   "relation_type:" + strings.TrimSpace(item.RTID),
+			RefType: RefTypeSchema,
+			Summary: map[string]any{
+				"kind":                  EntityKindRelationType,
+				"id":                    strings.TrimSpace(item.RTID),
+				"kn_id":                 strings.TrimSpace(item.KNID),
+				"branch":                strings.TrimSpace(item.Branch),
+				"module_type":           strings.TrimSpace(item.ModuleType),
+				"source_object_type_id": strings.TrimSpace(item.SourceObjectTypeID),
+				"target_object_type_id": strings.TrimSpace(item.TargetObjectTypeID),
+				"relation_type":         strings.TrimSpace(item.Type),
+				"has_mapping_rules":     item.MappingRules != nil,
+				"update_time":           item.UpdateTime,
+			},
+		})
+	}
+	return refs
+}
+
+func ActionTypeRefs(items []*interfaces.ActionType) []EvidenceRef {
+	refs := make([]EvidenceRef, 0, len(items))
+	for _, item := range items {
+		if item == nil || strings.TrimSpace(item.ATID) == "" {
+			continue
+		}
+		refs = append(refs, EvidenceRef{
+			RefID:          "action_type:" + strings.TrimSpace(item.ATID),
+			RefType:        RefTypeAction,
+			PartialReasons: []string{"action_ref_unversioned"},
+			Summary: map[string]any{
+				"kind":                  EntityKindActionType,
+				"id":                    strings.TrimSpace(item.ATID),
+				"kn_id":                 strings.TrimSpace(item.KNID),
+				"branch":                strings.TrimSpace(item.Branch),
+				"module_type":           strings.TrimSpace(item.ModuleType),
+				"object_type_id":        strings.TrimSpace(item.ObjectTypeID),
+				"action_type":           strings.TrimSpace(item.ActionType),
+				"parameter_count":       len(item.Parameters),
+				"impact_contract_count": len(item.ImpactContracts),
+				"update_time":           item.UpdateTime,
+			},
+		})
+	}
+	return refs
+}
+
+func MetricRefs(items []*interfaces.MetricDefinition) []EvidenceRef {
+	refs := make([]EvidenceRef, 0, len(items))
+	for _, item := range items {
+		if item == nil || strings.TrimSpace(item.ID) == "" {
+			continue
+		}
+		refs = append(refs, EvidenceRef{
+			RefID:          "metric:" + strings.TrimSpace(item.ID),
+			RefType:        RefTypeMetric,
+			PartialReasons: []string{"metric_ref_unversioned"},
+			Summary: map[string]any{
+				"kind":                     EntityKindMetric,
+				"id":                       strings.TrimSpace(item.ID),
+				"kn_id":                    strings.TrimSpace(item.KnID),
+				"branch":                   strings.TrimSpace(item.Branch),
+				"module_type":              strings.TrimSpace(item.ModuleType),
+				"metric_type":              strings.TrimSpace(item.MetricType),
+				"scope_type":               strings.TrimSpace(item.ScopeType),
+				"scope_ref":                strings.TrimSpace(item.ScopeRef),
+				"has_time_dimension":       item.TimeDimension != nil,
+				"has_calculation_formula":  item.CalculationFormula != nil,
+				"analysis_dimension_count": len(item.AnalysisDimensions),
+				"update_time":              item.UpdateTime,
+			},
+		})
+	}
+	return refs
+}
+
+func postBatch(ingestURL string, timeout time.Duration, payload batch) error {
+	body, err := json.Marshal(payload)
+	if err != nil {
+		return err
+	}
+	postCtx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(postCtx, http.MethodPost, ingestURL, bytes.NewReader(body))
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := evidenceHTTPClient.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode >= http.StatusBadRequest {
+		return fmt.Errorf("HTTP %d", resp.StatusCode)
+	}
+	return nil
+}
+
+func evidenceIngestURL() string {
+	return strings.TrimSpace(os.Getenv(envEvidenceIngestURL))
+}
+
+func evidenceTimeout() time.Duration {
+	value := strings.TrimSpace(os.Getenv(envEvidenceIngestTimeoutMS))
+	if value == "" {
+		return 2 * time.Second
+	}
+	var ms int
+	if _, err := fmt.Sscanf(value, "%d", &ms); err != nil || ms <= 0 {
+		return 2 * time.Second
+	}
+	return time.Duration(ms) * time.Millisecond
+}
+
+func contextFromRequest(ctx context.Context, reqCtx RequestContext) (eventContext, bool) {
+	spanContext := trace.SpanContextFromContext(ctx)
+	if !spanContext.IsValid() {
+		return eventContext{}, false
+	}
+	requestID := strings.TrimSpace(reqCtx.RequestID)
+	accountID := strings.TrimSpace(reqCtx.AccountID)
+	accountType := strings.TrimSpace(reqCtx.AccountType)
+	if requestID == "" || accountID == "" || accountType == "" {
+		return eventContext{}, false
+	}
+	flags := "00"
+	if spanContext.TraceFlags().IsSampled() {
+		flags = "01"
+	}
+	businessDomain := strings.TrimSpace(reqCtx.BusinessDomain)
+	if businessDomain == "" {
+		businessDomain = accountID
+	}
+	return eventContext{
+		traceID:        spanContext.TraceID().String(),
+		spanID:         spanContext.SpanID().String(),
+		traceparent:    fmt.Sprintf("00-%s-%s-%s", spanContext.TraceID().String(), spanContext.SpanID().String(), flags),
+		requestID:      requestID,
+		accountID:      accountID,
+		accountType:    accountType,
+		businessDomain: businessDomain,
+	}, true
+}
+
+func buildEvent(ec eventContext, eventType, operationName string, payload map[string]any) Event {
+	now := time.Now().UTC().Format(time.RFC3339Nano)
+	return Event{
+		"event_id":                 "evt_" + randomHex(16),
+		"event_type":               eventType,
+		"bkn.trace.schema.version": ContractVersion,
+		"observed_at":              now,
+		"emitted_at":               now,
+		"producer_module":          ModuleName,
+		"trace_id":                 ec.traceID,
+		"span_id":                  ec.spanID,
+		"bkn.request.id":           ec.requestID,
+		"bkn.operation.name":       operationName,
+		"payload":                  payload,
+	}
+}
+
+func randomHex(length int) string {
+	if length <= 0 {
+		return ""
+	}
+	buf := make([]byte, (length+1)/2)
+	if _, err := rand.Read(buf); err != nil {
+		sum := sha256.Sum256([]byte(time.Now().UTC().Format(time.RFC3339Nano)))
+		return hex.EncodeToString(sum[:])[:length]
+	}
+	return hex.EncodeToString(buf)[:length]
+}

--- a/adp/bkn/bkn-backend/server/common/bkntrace/evidence.go
+++ b/adp/bkn/bkn-backend/server/common/bkntrace/evidence.go
@@ -16,6 +16,7 @@ import (
 	"fmt"
 	"net/http"
 	"os"
+	"sort"
 	"strings"
 	"time"
 
@@ -128,41 +129,49 @@ func BuildSchemaReadEvents(ctx context.Context, reqCtx RequestContext, subject R
 	}
 
 	evidenceRefs := make([]map[string]any, 0, len(refs))
+	refFingerprints := make([]string, 0, len(refs))
 	for _, ref := range refs {
 		if strings.TrimSpace(ref.RefID) == "" || strings.TrimSpace(ref.RefType) == "" {
 			continue
 		}
+		refID := strings.TrimSpace(ref.RefID)
+		refType := strings.TrimSpace(ref.RefType)
+		summaryHash := HashValue(ref.Summary)
 		partialReasons := ref.PartialReasons
 		if len(partialReasons) == 0 {
-			partialReasons = []string{ref.RefType + "_unversioned"}
+			partialReasons = []string{refType + "_unversioned"}
 		}
 		evidenceRefs = append(evidenceRefs, map[string]any{
-			"ref_id":         strings.TrimSpace(ref.RefID),
-			"ref_type":       strings.TrimSpace(ref.RefType),
+			"ref_id":         refID,
+			"ref_type":       refType,
 			"source_system":  ModuleName,
 			"summary":        ref.Summary,
-			"summary_hash":   HashValue(ref.Summary),
+			"summary_hash":   summaryHash,
 			"validity":       "observed",
 			"version_status": "unversioned",
 			"visibility":     "visible",
 			"partial_reason": partialReasons,
 		})
+		refFingerprints = append(refFingerprints, refType+":"+refID+":"+summaryHash)
 	}
 	if len(evidenceRefs) == 0 {
 		return nil
 	}
+	sort.Strings(refFingerprints)
+	evidenceRefsHash := HashValue(refFingerprints)
 
 	resultSummary := map[string]any{
-		"kn_id":            strings.TrimSpace(subject.KNID),
-		"branch":           strings.TrimSpace(subject.Branch),
-		"entity_kind":      strings.TrimSpace(subject.EntityKind),
-		"requested_hash":   HashValue(subject.RequestedIDs),
-		"returned_count":   subject.ReturnedCount,
-		"total_count":      subject.TotalCount,
-		"evidence_count":   len(evidenceRefs),
-		"operation":        operation,
-		"producer_module":  ModuleName,
-		"contract_version": ContractVersion,
+		"kn_id":              strings.TrimSpace(subject.KNID),
+		"branch":             strings.TrimSpace(subject.Branch),
+		"entity_kind":        strings.TrimSpace(subject.EntityKind),
+		"requested_hash":     HashValue(subject.RequestedIDs),
+		"returned_count":     subject.ReturnedCount,
+		"total_count":        subject.TotalCount,
+		"evidence_count":     len(evidenceRefs),
+		"evidence_refs_hash": evidenceRefsHash,
+		"operation":          operation,
+		"producer_module":    ModuleName,
+		"contract_version":   ContractVersion,
 	}
 	claimID := ClaimID(operation, subject.KNID, resultSummary)
 
@@ -179,6 +188,7 @@ func BuildSchemaReadEvents(ctx context.Context, reqCtx RequestContext, subject R
 				"branch":              strings.TrimSpace(subject.Branch),
 				"entity_kind":         strings.TrimSpace(subject.EntityKind),
 				"requested_hash":      resultSummary["requested_hash"],
+				"evidence_refs_hash":  evidenceRefsHash,
 				"returned_ref_count":  len(evidenceRefs),
 				"returned_count":      subject.ReturnedCount,
 				"total_count":         subject.TotalCount,

--- a/adp/bkn/bkn-backend/server/common/bkntrace/evidence_test.go
+++ b/adp/bkn/bkn-backend/server/common/bkntrace/evidence_test.go
@@ -1,0 +1,194 @@
+// Copyright openbkn.ai
+// Copyright The kweaver.ai Authors.
+//
+// Licensed under the Apache License, Version 2.0.
+// See the LICENSE file in the project root for details.
+
+package bkntrace
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"bkn-backend/interfaces"
+	"go.opentelemetry.io/otel/trace"
+)
+
+func testTraceContext() context.Context {
+	traceID := trace.TraceID{0x71, 0x22, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1}
+	spanID := trace.SpanID{0x71, 0x22, 0, 0, 0, 0, 0, 1}
+	spanContext := trace.NewSpanContext(trace.SpanContextConfig{
+		TraceID:    traceID,
+		SpanID:     spanID,
+		TraceFlags: trace.FlagsSampled,
+	})
+	return trace.ContextWithSpanContext(context.Background(), spanContext)
+}
+
+func testRequestContext() RequestContext {
+	return RequestContext{
+		RequestID:      "req_bkn_backend_schema_0001",
+		AccountID:      "acct_demo",
+		AccountType:    "user",
+		BusinessDomain: "domain_demo",
+	}
+}
+
+func TestBuildSchemaReadEventsUsesRefsAndHashesOnly(t *testing.T) {
+	items := []*interfaces.ObjectType{
+		{
+			ObjectTypeWithKeyField: interfaces.ObjectTypeWithKeyField{
+				OTID:   "customer",
+				OTName: "Customer PII",
+				DataProperties: []*interfaces.DataProperty{
+					{Name: "phone", DisplayName: "Phone Number", Comment: "Do not emit this field"},
+				},
+			},
+			CommonInfo: interfaces.CommonInfo{Comment: "Contains sensitive model notes"},
+			KNID:       "kn_demo",
+			Branch:     "main",
+		},
+	}
+
+	events := BuildSchemaReadEvents(testTraceContext(), testRequestContext(), ReadSubject{
+		EntityKind:    EntityKindObjectType,
+		Operation:     "bkn.schema.object_type.list",
+		KNID:          "kn_demo",
+		Branch:        "main",
+		ReturnedCount: len(items),
+	}, ObjectTypeRefs(items))
+
+	assertSafeEvents(t, events, []string{
+		`"event_type":"claim.created"`,
+		`"event_type":"evidence.refs.created"`,
+		`"ref_id":"object_type:customer"`,
+		`"ref_type":"schema_ref"`,
+		`"summary_hash":"sha256:`,
+		`"property_count":1`,
+	}, []string{
+		"Customer PII",
+		"phone",
+		"Phone Number",
+		"Do not emit this field",
+		"Contains sensitive model notes",
+	})
+}
+
+func TestBuildSchemaReadEventsCoversRelationActionAndMetricRefs(t *testing.T) {
+	relationRefs := RelationTypeRefs([]*interfaces.RelationType{
+		{
+			RelationTypeWithKeyField: interfaces.RelationTypeWithKeyField{
+				RTID:               "customer_has_order",
+				RTName:             "Customer Order Relation",
+				SourceObjectTypeID: "customer",
+				TargetObjectTypeID: "order",
+				Type:               interfaces.RELATION_TYPE_DIRECT,
+				MappingRules:       []interfaces.Mapping{{SourceProp: interfaces.SimpleProperty{Name: "customer_id"}}},
+			},
+			CommonInfo: interfaces.CommonInfo{Comment: "Mapping detail must not be emitted"},
+		},
+	})
+	actionRefs := ActionTypeRefs([]*interfaces.ActionType{
+		{
+			ActionTypeWithKeyField: interfaces.ActionTypeWithKeyField{
+				ATID:         "notify_owner",
+				ATName:       "Notify Account Owner",
+				ActionType:   "tool",
+				ActionIntent: "Send customer phone to owner",
+				ObjectTypeID: "customer",
+			},
+		},
+	})
+	metricRefs := MetricRefs([]*interfaces.MetricDefinition{
+		{
+			ID:         "customer_risk_score",
+			Name:       "Customer Risk Score",
+			MetricType: "derived",
+			ScopeType:  "object_type",
+			ScopeRef:   "customer",
+			CommonInfo: interfaces.CommonInfo{Comment: "Sensitive metric commentary"},
+			Branch:     "main",
+			KnID:       "kn_demo",
+			Unit:       "score",
+			UnitType:   "number",
+			UpdateTime: 123,
+			CreateTime: 100,
+			ModuleType: "metric",
+		},
+	})
+	refs := append(append(relationRefs, actionRefs...), metricRefs...)
+
+	events := BuildSchemaReadEvents(testTraceContext(), testRequestContext(), ReadSubject{
+		EntityKind:    EntityKindMetric,
+		Operation:     "bkn.schema.mixed.test",
+		KNID:          "kn_demo",
+		Branch:        "main",
+		ReturnedCount: len(refs),
+	}, refs)
+
+	assertSafeEvents(t, events, []string{
+		`"ref_id":"relation_type:customer_has_order"`,
+		`"ref_type":"schema_ref"`,
+		`"ref_id":"action_type:notify_owner"`,
+		`"ref_type":"action_ref"`,
+		`"ref_id":"metric:customer_risk_score"`,
+		`"ref_type":"metric_ref"`,
+		`"version_status":"unversioned"`,
+	}, []string{
+		"Customer Order Relation",
+		"Mapping detail must not be emitted",
+		"customer_id",
+		"Notify Account Owner",
+		"Send customer phone to owner",
+		"Customer Risk Score",
+		"Sensitive metric commentary",
+	})
+}
+
+func TestBuildSchemaReadEventsRequiresTraceAndRequestContext(t *testing.T) {
+	events := BuildSchemaReadEvents(context.Background(), testRequestContext(), ReadSubject{
+		EntityKind:    EntityKindObjectType,
+		Operation:     "bkn.schema.object_type.list",
+		KNID:          "kn_demo",
+		Branch:        "main",
+		ReturnedCount: 1,
+	}, []EvidenceRef{{RefID: "object_type:customer", RefType: RefTypeSchema}})
+	if len(events) != 0 {
+		t.Fatalf("len(events)=%d, want 0 without trace context", len(events))
+	}
+
+	events = BuildSchemaReadEvents(testTraceContext(), RequestContext{}, ReadSubject{
+		EntityKind:    EntityKindObjectType,
+		Operation:     "bkn.schema.object_type.list",
+		KNID:          "kn_demo",
+		Branch:        "main",
+		ReturnedCount: 1,
+	}, []EvidenceRef{{RefID: "object_type:customer", RefType: RefTypeSchema}})
+	if len(events) != 0 {
+		t.Fatalf("len(events)=%d, want 0 without request context", len(events))
+	}
+}
+
+func assertSafeEvents(t *testing.T, events []Event, want []string, forbidden []string) {
+	t.Helper()
+	if len(events) != 2 {
+		t.Fatalf("len(events)=%d, want 2", len(events))
+	}
+	raw, err := json.Marshal(events)
+	if err != nil {
+		t.Fatalf("marshal events: %v", err)
+	}
+	text := string(raw)
+	for _, item := range want {
+		if !strings.Contains(text, item) {
+			t.Fatalf("missing %q in events: %s", item, text)
+		}
+	}
+	for _, item := range forbidden {
+		if strings.Contains(text, item) {
+			t.Fatalf("event leaked raw content %q: %s", item, text)
+		}
+	}
+}

--- a/adp/bkn/bkn-backend/server/common/bkntrace/evidence_test.go
+++ b/adp/bkn/bkn-backend/server/common/bkntrace/evidence_test.go
@@ -147,6 +147,39 @@ func TestBuildSchemaReadEventsCoversRelationActionAndMetricRefs(t *testing.T) {
 	})
 }
 
+func TestBuildSchemaReadEventsDifferentiatesSameCountDifferentRefs(t *testing.T) {
+	subject := ReadSubject{
+		EntityKind:    EntityKindObjectType,
+		Operation:     "bkn.schema.object_type.list",
+		KNID:          "kn_demo",
+		Branch:        "main",
+		ReturnedCount: 1,
+		TotalCount:    1,
+	}
+	customerEvents := BuildSchemaReadEvents(testTraceContext(), testRequestContext(), subject, ObjectTypeRefs([]*interfaces.ObjectType{
+		{ObjectTypeWithKeyField: interfaces.ObjectTypeWithKeyField{OTID: "customer"}, KNID: "kn_demo", Branch: "main"},
+	}))
+	orderEvents := BuildSchemaReadEvents(testTraceContext(), testRequestContext(), subject, ObjectTypeRefs([]*interfaces.ObjectType{
+		{ObjectTypeWithKeyField: interfaces.ObjectTypeWithKeyField{OTID: "order"}, KNID: "kn_demo", Branch: "main"},
+	}))
+
+	customerClaim := claimPayload(t, customerEvents)
+	orderClaim := claimPayload(t, orderEvents)
+	if customerClaim["claim_id"] == orderClaim["claim_id"] {
+		t.Fatalf("claim_id should differ for same-count different refs: %v", customerClaim["claim_id"])
+	}
+	if customerClaim["claim_hash"] == orderClaim["claim_hash"] {
+		t.Fatalf("claim_hash should differ for same-count different refs: %v", customerClaim["claim_hash"])
+	}
+	customerSubjectRefs, ok := customerClaim["subject_refs"].(map[string]any)
+	if !ok {
+		t.Fatalf("subject_refs missing or invalid: %#v", customerClaim["subject_refs"])
+	}
+	if _, ok := customerSubjectRefs["evidence_refs_hash"].(string); !ok {
+		t.Fatalf("missing evidence_refs_hash in subject_refs: %#v", customerSubjectRefs)
+	}
+}
+
 func TestBuildSchemaReadEventsRequiresTraceAndRequestContext(t *testing.T) {
 	events := BuildSchemaReadEvents(context.Background(), testRequestContext(), ReadSubject{
 		EntityKind:    EntityKindObjectType,
@@ -169,6 +202,18 @@ func TestBuildSchemaReadEventsRequiresTraceAndRequestContext(t *testing.T) {
 	if len(events) != 0 {
 		t.Fatalf("len(events)=%d, want 0 without request context", len(events))
 	}
+}
+
+func claimPayload(t *testing.T, events []Event) map[string]any {
+	t.Helper()
+	if len(events) == 0 {
+		t.Fatalf("events are empty")
+	}
+	payload, ok := events[0]["payload"].(map[string]any)
+	if !ok {
+		t.Fatalf("claim payload missing or invalid: %#v", events[0]["payload"])
+	}
+	return payload
 }
 
 func assertSafeEvents(t *testing.T, events []Event, want []string, forbidden []string) {

--- a/adp/bkn/bkn-backend/server/driveradapters/action_type_handler.go
+++ b/adp/bkn/bkn-backend/server/driveradapters/action_type_handler.go
@@ -718,6 +718,7 @@ func (r *restHandler) ListActionTypes(c *gin.Context, visitor hydra.Visitor) {
 
 	logger.Debug("Handler ListActionTypes Success")
 	oteltrace.AddHttpAttrs4Ok(span, http.StatusOK)
+	emitActionTypeSchemaRead(ctx, c, visitor, "bkn.schema.action_type.list", knID, branch, nil, otList, int64(total))
 	rest.ReplyOK(c, http.StatusOK, result)
 }
 
@@ -804,6 +805,7 @@ func (r *restHandler) GetActionTypes(c *gin.Context, visitor hydra.Visitor) {
 
 	oteltrace.AddHttpAttrs4Ok(span, http.StatusOK)
 	logger.Debug("Handler GetActionTypes Success")
+	emitActionTypeSchemaRead(ctx, c, visitor, "bkn.schema.action_type.get", knID, branch, atIDs, actionTypes, int64(len(actionTypes)))
 	rest.ReplyOK(c, http.StatusOK, httpResult)
 }
 

--- a/adp/bkn/bkn-backend/server/driveradapters/bkn_trace.go
+++ b/adp/bkn/bkn-backend/server/driveradapters/bkn_trace.go
@@ -1,0 +1,103 @@
+// Copyright openbkn.ai
+// Copyright The kweaver.ai Authors.
+//
+// Licensed under the Apache License, Version 2.0.
+// See the LICENSE file in the project root for details.
+
+package driveradapters
+
+import (
+	"context"
+	"strings"
+
+	"github.com/gin-gonic/gin"
+	"github.com/openbkn-ai/bkn-comm-go/hydra"
+	"github.com/rs/xid"
+
+	"bkn-backend/common/bkntrace"
+	"bkn-backend/interfaces"
+)
+
+const (
+	headerBKNRequestID    = "bkn-request-id"
+	headerLegacyRequestID = "x-request-id"
+)
+
+func bknTraceRequestContext(c *gin.Context, vis hydra.Visitor) bkntrace.RequestContext {
+	requestID := firstNonEmptyHeader(c, headerBKNRequestID, headerLegacyRequestID)
+	if requestID == "" {
+		requestID = "req_" + xid.New().String()
+	}
+	accountID := strings.TrimSpace(vis.ID)
+	if accountID == "" {
+		accountID = strings.TrimSpace(c.GetHeader(interfaces.HTTP_HEADER_ACCOUNT_ID))
+	}
+	accountType := strings.TrimSpace(string(vis.Type))
+	if accountType == "" {
+		accountType = strings.TrimSpace(c.GetHeader(interfaces.HTTP_HEADER_ACCOUNT_TYPE))
+	}
+	return bkntrace.RequestContext{
+		RequestID:      requestID,
+		AccountID:      accountID,
+		AccountType:    accountType,
+		BusinessDomain: strings.TrimSpace(c.GetHeader(interfaces.HTTP_HEADER_BUSINESS_DOMAIN)),
+	}
+}
+
+func emitObjectTypeSchemaRead(ctx context.Context, c *gin.Context, vis hydra.Visitor, operation, knID, branch string, requestedIDs []string, items []*interfaces.ObjectType, total int64) {
+	bkntrace.EmitSchemaReadEvents(ctx, bknTraceRequestContext(c, vis), bkntrace.ReadSubject{
+		EntityKind:    bkntrace.EntityKindObjectType,
+		Operation:     operation,
+		KNID:          knID,
+		Branch:        branch,
+		RequestedIDs:  requestedIDs,
+		ReturnedCount: len(items),
+		TotalCount:    total,
+	}, bkntrace.ObjectTypeRefs(items))
+}
+
+func emitRelationTypeSchemaRead(ctx context.Context, c *gin.Context, vis hydra.Visitor, operation, knID, branch string, requestedIDs []string, items []*interfaces.RelationType, total int64) {
+	bkntrace.EmitSchemaReadEvents(ctx, bknTraceRequestContext(c, vis), bkntrace.ReadSubject{
+		EntityKind:    bkntrace.EntityKindRelationType,
+		Operation:     operation,
+		KNID:          knID,
+		Branch:        branch,
+		RequestedIDs:  requestedIDs,
+		ReturnedCount: len(items),
+		TotalCount:    total,
+	}, bkntrace.RelationTypeRefs(items))
+}
+
+func emitActionTypeSchemaRead(ctx context.Context, c *gin.Context, vis hydra.Visitor, operation, knID, branch string, requestedIDs []string, items []*interfaces.ActionType, total int64) {
+	bkntrace.EmitSchemaReadEvents(ctx, bknTraceRequestContext(c, vis), bkntrace.ReadSubject{
+		EntityKind:    bkntrace.EntityKindActionType,
+		Operation:     operation,
+		KNID:          knID,
+		Branch:        branch,
+		RequestedIDs:  requestedIDs,
+		ReturnedCount: len(items),
+		TotalCount:    total,
+	}, bkntrace.ActionTypeRefs(items))
+}
+
+func emitMetricSchemaRead(ctx context.Context, c *gin.Context, vis hydra.Visitor, operation, knID, branch string, requestedIDs []string, items []*interfaces.MetricDefinition, total int64) {
+	bkntrace.EmitSchemaReadEvents(ctx, bknTraceRequestContext(c, vis), bkntrace.ReadSubject{
+		EntityKind:    bkntrace.EntityKindMetric,
+		Operation:     operation,
+		KNID:          knID,
+		Branch:        branch,
+		RequestedIDs:  requestedIDs,
+		ReturnedCount: len(items),
+		TotalCount:    total,
+	}, bkntrace.MetricRefs(items))
+}
+
+func firstNonEmptyHeader(c *gin.Context, names ...string) string {
+	for _, name := range names {
+		value := strings.TrimSpace(c.GetHeader(name))
+		if value != "" {
+			return value
+		}
+	}
+	return ""
+}

--- a/adp/bkn/bkn-backend/server/driveradapters/bkn_trace.go
+++ b/adp/bkn/bkn-backend/server/driveradapters/bkn_trace.go
@@ -45,6 +45,9 @@ func bknTraceRequestContext(c *gin.Context, vis hydra.Visitor) bkntrace.RequestC
 }
 
 func emitObjectTypeSchemaRead(ctx context.Context, c *gin.Context, vis hydra.Visitor, operation, knID, branch string, requestedIDs []string, items []*interfaces.ObjectType, total int64) {
+	if !bkntrace.EvidenceEnabled() {
+		return
+	}
 	bkntrace.EmitSchemaReadEvents(ctx, bknTraceRequestContext(c, vis), bkntrace.ReadSubject{
 		EntityKind:    bkntrace.EntityKindObjectType,
 		Operation:     operation,
@@ -57,6 +60,9 @@ func emitObjectTypeSchemaRead(ctx context.Context, c *gin.Context, vis hydra.Vis
 }
 
 func emitRelationTypeSchemaRead(ctx context.Context, c *gin.Context, vis hydra.Visitor, operation, knID, branch string, requestedIDs []string, items []*interfaces.RelationType, total int64) {
+	if !bkntrace.EvidenceEnabled() {
+		return
+	}
 	bkntrace.EmitSchemaReadEvents(ctx, bknTraceRequestContext(c, vis), bkntrace.ReadSubject{
 		EntityKind:    bkntrace.EntityKindRelationType,
 		Operation:     operation,
@@ -69,6 +75,9 @@ func emitRelationTypeSchemaRead(ctx context.Context, c *gin.Context, vis hydra.V
 }
 
 func emitActionTypeSchemaRead(ctx context.Context, c *gin.Context, vis hydra.Visitor, operation, knID, branch string, requestedIDs []string, items []*interfaces.ActionType, total int64) {
+	if !bkntrace.EvidenceEnabled() {
+		return
+	}
 	bkntrace.EmitSchemaReadEvents(ctx, bknTraceRequestContext(c, vis), bkntrace.ReadSubject{
 		EntityKind:    bkntrace.EntityKindActionType,
 		Operation:     operation,
@@ -81,6 +90,9 @@ func emitActionTypeSchemaRead(ctx context.Context, c *gin.Context, vis hydra.Vis
 }
 
 func emitMetricSchemaRead(ctx context.Context, c *gin.Context, vis hydra.Visitor, operation, knID, branch string, requestedIDs []string, items []*interfaces.MetricDefinition, total int64) {
+	if !bkntrace.EvidenceEnabled() {
+		return
+	}
 	bkntrace.EmitSchemaReadEvents(ctx, bknTraceRequestContext(c, vis), bkntrace.ReadSubject{
 		EntityKind:    bkntrace.EntityKindMetric,
 		Operation:     operation,

--- a/adp/bkn/bkn-backend/server/driveradapters/metric_handler.go
+++ b/adp/bkn/bkn-backend/server/driveradapters/metric_handler.go
@@ -342,6 +342,9 @@ func (r *restHandler) ListMetrics(c *gin.Context, vis hydra.Visitor) {
 		return
 	}
 	oteltrace.AddHttpAttrs4Ok(span, http.StatusOK)
+	if list != nil {
+		emitMetricSchemaRead(ctx, c, vis, "bkn.schema.metric.list", knID, branch, nil, list.Entries, list.TotalCount)
+	}
 	rest.ReplyOK(c, http.StatusOK, list)
 }
 
@@ -409,6 +412,7 @@ func (r *restHandler) GetMetricsByIDs(c *gin.Context, vis hydra.Visitor) {
 		return
 	}
 	oteltrace.AddHttpAttrs4Ok(span, http.StatusOK)
+	emitMetricSchemaRead(ctx, c, vis, "bkn.schema.metric.get", knID, branch, ids, list, int64(len(list)))
 	rest.ReplyOK(c, http.StatusOK, map[string]any{"entries": list})
 }
 

--- a/adp/bkn/bkn-backend/server/driveradapters/object_type_handler.go
+++ b/adp/bkn/bkn-backend/server/driveradapters/object_type_handler.go
@@ -922,6 +922,7 @@ func (r *restHandler) ListObjectTypes(c *gin.Context, visitor hydra.Visitor) {
 
 	logger.Debug("Handler ListObjectTypes Success")
 	oteltrace.AddHttpAttrs4Ok(span, http.StatusOK)
+	emitObjectTypeSchemaRead(ctx, c, visitor, "bkn.schema.object_type.list", knID, branch, nil, otList, int64(total))
 	rest.ReplyOK(c, http.StatusOK, result)
 }
 
@@ -1008,6 +1009,7 @@ func (r *restHandler) GetObjectTypes(c *gin.Context, visitor hydra.Visitor) {
 
 	oteltrace.AddHttpAttrs4Ok(span, http.StatusOK)
 	logger.Debug("Handler GetObjectTypes Success")
+	emitObjectTypeSchemaRead(ctx, c, visitor, "bkn.schema.object_type.get", knID, branch, otIDs, result, int64(len(result)))
 	rest.ReplyOK(c, http.StatusOK, httpResult)
 }
 

--- a/adp/bkn/bkn-backend/server/driveradapters/relation_type_handler.go
+++ b/adp/bkn/bkn-backend/server/driveradapters/relation_type_handler.go
@@ -706,6 +706,7 @@ func (r *restHandler) ListRelationTypes(c *gin.Context, visitor hydra.Visitor) {
 
 	logger.Debug("Handler ListRelationTypes Success")
 	oteltrace.AddHttpAttrs4Ok(span, http.StatusOK)
+	emitRelationTypeSchemaRead(ctx, c, visitor, "bkn.schema.relation_type.list", knID, branch, nil, otList, int64(total))
 	rest.ReplyOK(c, http.StatusOK, result)
 }
 
@@ -792,6 +793,7 @@ func (r *restHandler) GetRelationTypes(c *gin.Context, visitor hydra.Visitor) {
 
 	oteltrace.AddHttpAttrs4Ok(span, http.StatusOK)
 	logger.Debug("Handler GetRelationTypes Success")
+	emitRelationTypeSchemaRead(ctx, c, visitor, "bkn.schema.relation_type.get", knID, branch, rtIDs, result, int64(len(result)))
 	rest.ReplyOK(c, http.StatusOK, httpResult)
 }
 


### PR DESCRIPTION
# Pull Request

## What Changed

Brief description of changes:

- [x] Add bkn-backend phase-2 schema evidence event builder for schema/action/metric refs
- [x] Emit `claim.created` and `evidence.refs.created` on object/relation/action/metric schema read success paths
- [x] Add module trace contract and phase-2 fixture for bkn-backend schema evidence

---

## Why

- Related Issue: openbkn-ai/bkn-foundry#270
- Related Feature: BKN Trace phase 2 evidence chain
- Background:
  - BKN Trace needs schema-level evidence refs from the BKN modeling service so downstream agent/app conclusions can be traced back to BKN object, relation, action and metric definitions.
  - This PR keeps the change limited to bkn-backend schema read paths and emits only refs, hashes, counts and version status. It does not emit raw schema names, comments, property names, mapping rules, metric formulas, SQL, row data or tool content.

---

## How

- Key implementation points:
  - Add `common/bkntrace` package with `BuildSchemaReadEvents`, evidence ref builders and async fail-open submission gated by `BKN_TRACE_EVIDENCE_INGEST_URL`.
  - Add lightweight driver adapter helpers to build request/account context from Gin headers and visitor context.
  - Hook successful list/get paths for object types, relation types, action types and metrics.
  - Add unit tests that assert evidence events contain refs/hashes/counts and reject raw schema content leakage.
- Breaking changes (API, config, database, etc.):
  - None. Event submission is disabled by default and fail-open when enabled.

---

## Testing

- [x] Unit tests passed locally
- [ ] Integration tests passed locally
- [ ] Verified in test environment

Test notes:

- `python3 /Users/leecky/openbkn/bkn-docs/docs/foundry/bkn-trace/validation/validate_phase2_fixture.py adp/bkn/bkn-backend/fixtures/bkn-trace/phase2 --pretty`
- `I18N_MODE_UT=true go test ./common/bkntrace ./driveradapters`
- `I18N_MODE_UT=true go test ./...`
  - Most packages passed.
  - Existing `bkn-specification` tests failed because the current worktree lacks `adp/bkn/bkn-backend/examples/...` fixture directories:
    - `bkn-backend/bkn-specification/bkn`
    - `bkn-backend/bkn-specification/tests`
  - The failure is unrelated to this PR's touched packages.

---

## Risk & Rollback

- Potential risks:
  - Additional event payload construction on schema read success paths.
  - Evidence ingest endpoint outage if enabled.
- Rollback plan:
  - Revert this PR. Since no schema/API/database change is introduced, rollback is code-only.
  - Operationally, unset `BKN_TRACE_EVIDENCE_INGEST_URL` to disable submission.

---

## Additional Notes

- Module contract: `adp/bkn/bkn-backend/TRACE.md`
- Phase-2 fixture: `adp/bkn/bkn-backend/fixtures/bkn-trace/phase2/bkn_schema_l2_positive.json`
