### PR TITLE
feat(bkn-trace): emit ontology and vega data evidence

### DIFF
--- a/adp/bkn/ontology-query/TRACE.md
+++ b/adp/bkn/ontology-query/TRACE.md
@@ -1,8 +1,8 @@
 # ontology-query Trace Contract
 
-> 状态：阶段一模块接入合同  
-> 适用版本：`bkn.trace.schema.version=1.0.0`  
-> 依据：`bkn-docs/docs/foundry/bkn-trace/design/阶段一：OpenBKN 可观测记录规范与 Trace Context 基线.md`
+> 状态：阶段二数据证据接入合同
+> 适用版本：`bkn.trace.schema.version=2.0.0`
+> 依据：`bkn-docs/docs/foundry/bkn-trace/design/BKN Trace 设计.md`、`bkn-docs/docs/foundry/bkn-trace/design/BKN Trace 三段式实施计划.md`
 
 ## Module
 
@@ -12,16 +12,17 @@
 - service identity: `ontology-query`
 - runtime: Go HTTP service
 - repository path: `adp/bkn/ontology-query`
-- contract version: `1.0.0`
+- contract version: `2.0.0`
 
 ## Entry Operations
 
 | operation | trigger | required context | emitted spans | emitted events |
 | --- | --- | --- | --- | --- |
-| `bkn.object.query` | object instance query | `traceparent`、`bkn-request-id`、account/auth context | `bkn-ontology.request`、`bkn-ontology.instance.query` | `object.query.executed` |
-| `bkn.relation.query` | subgraph/path query | `traceparent`、`bkn-request-id`、account/auth context | `bkn-ontology.request`、`bkn-ontology.instance.query` | `relation.query.executed` |
+| `bkn.object.query` | object instance query | `traceparent`、`bkn-request-id`、account/auth context | `bkn-ontology.request`、`bkn-ontology.instance.query` | `claim.created`、`evidence.refs.created` |
+| `bkn.relation.query` | subgraph/path query | `traceparent`、`bkn-request-id`、account/auth context | `bkn-ontology.request`、`bkn-ontology.instance.query` | `claim.created`、`evidence.refs.created` |
 | `bkn.action_type.get` | action type query | `traceparent`、`bkn-request-id`、account/auth context | `bkn-ontology.request`、`bkn-ontology.schema.lookup` | `schema.read` |
-| `bkn.metric.get` | metric dry-run/data query | `traceparent`、`bkn-request-id`、account/auth context | `bkn-ontology.request`、`bkn-ontology.instance.query` | `object.query.executed` |
+| `bkn.metric.get` | metric data query | `traceparent`、`bkn-request-id`、account/auth context | `bkn-ontology.request`、`bkn-ontology.instance.query` | `claim.created`、`evidence.refs.created` |
+| `bkn.metric.dry_run` | metric dry-run query | `traceparent`、`bkn-request-id`、account/auth context | `bkn-ontology.request`、`bkn-ontology.instance.query` | `claim.created`、`evidence.refs.created` |
 
 ## Inbound Context
 
@@ -72,6 +73,8 @@ bkn.runtime.env
 | `object.query.executed` | ontology-query | object type、result count、truncated、classification | result truncated / data unavailable | business event |
 | `relation.query.executed` | ontology-query | relation path、node count、edge count、truncated | max path exceeded / unauthorized | business event |
 | `schema.change.requested` | BKN backend, not ontology-query | change summary and actor | not emitted by query service | audit event |
+| `claim.created` | ontology-query | kn id、branch、entity kind、subject id、query hash、returned count、evidence refs hash | data refs unversioned | business event |
+| `evidence.refs.created` | ontology-query | `row_ref`、`schema_ref`、`metric_ref` 的受控引用和 summary hash | row/schema/metric refs unversioned | business event |
 
 ## Business Refs
 
@@ -89,6 +92,7 @@ bkn.runtime.env
 
 - never log: token、authorization、cookie、完整 SQL、完整对象实例属性、行级数据、PII、连接串、对象存储裸 URL。
 - hash only: query body、large result summary、operator inputs。
+- runtime evidence event payload only contains safe query shape hash、row hash、counts、type/resource ids and controlled refs; full object instance properties and metric labels/values are not emitted.
 - controlled reference: `bkn.object_instance.ref`、row refs、snapshot refs。
 - redact: unauthorized object/resource detail、PII fields、policy restricted values。
 - `data.classification`: `public|internal|confidential|pii|secret`。
@@ -117,6 +121,7 @@ bkn.runtime.env
 | negative | `fixtures/bkn-trace/negative_missing_request_id.json` | missing request id | fail |
 | propagation | `fixtures/bkn-trace/propagation.json` | object query propagation | pass |
 | sampling | `fixtures/bkn-trace/sampling.json` | forced sampled authz denial | pass |
+| phase2 ontology data evidence | `fixtures/bkn-trace/phase2/ontology_data_evidence_l2_positive.json` | object/subgraph/metric data refs baseline | pass |
 
 ## Covered GWT
 
@@ -129,7 +134,8 @@ bkn.runtime.env
 
 ## Known Gaps
 
-- runtime `schema.read`、`object.query.executed`、`relation.query.executed` event emitters are not complete in this branch.
+- legacy phase-one event names `schema.read`、`object.query.executed`、`relation.query.executed` are superseded by phase-two `claim.created` / `evidence.refs.created` for implemented data evidence paths.
+- evidence refs are currently unversioned row/schema/metric refs; snapshot refs and immutable evidence artifact storage remain a follow-up.
 - current code baseline wires Vega backend outbound trace headers; ontology-manager/model-factory/agent-operator should be migrated to `common.MergeTraceHeaders` in follow-up commits.
 - full registry validation and indexing policy validation currently rely on `bkn-docs` validator follow-up.
 - S3 health metrics are not implemented yet.
@@ -137,6 +143,6 @@ bkn.runtime.env
 ## Owner Sign-off
 
 - owner: OpenBKN Foundry / BKN ontology
-- reviewed at: 2026-07-21
+- reviewed at: 2026-07-23
 - reviewer: pending
 - compatibility risk: low; new headers are additive and legacy `x-request-id` remains supported.

--- a/adp/bkn/ontology-query/fixtures/bkn-trace/phase2/ontology_data_evidence_l2_positive.json
+++ b/adp/bkn/ontology-query/fixtures/bkn-trace/phase2/ontology_data_evidence_l2_positive.json
@@ -1,0 +1,107 @@
+{
+  "bkn.trace.schema.version": "2.0.0",
+  "fixture_id": "ontology_query_phase2_data_evidence_l2_positive",
+  "expected_result": "pass",
+  "trace": {
+    "trace_id": "72220000000000000000000000000001",
+    "traceparent": "00-72220000000000000000000000000001-7222000000000001-01",
+    "bkn.request.id": "req_ontology_phase2_data_evidence_0001",
+    "business_domain": "domain_demo",
+    "bkn.account.id": "acct_demo",
+    "bkn.account.type": "user"
+  },
+  "spans": [
+    {
+      "span_id": "7222000000000001",
+      "parent_span_id": null,
+      "name": "bkn-ontology.instance.query",
+      "kind": "internal",
+      "bkn.module.name": "bkn-ontology",
+      "bkn.operation.name": "bkn.object.query",
+      "bkn.status": "ok",
+      "bkn.timestamp": "2026-07-23T12:00:00.000000Z"
+    }
+  ],
+  "events": [
+    {
+      "event_id": "evt_ontology_data_claim",
+      "event_type": "claim.created",
+      "bkn.trace.schema.version": "2.0.0",
+      "observed_at": "2026-07-23T12:00:00.001000Z",
+      "emitted_at": "2026-07-23T12:00:00.002000Z",
+      "producer_module": "bkn-ontology",
+      "trace_id": "72220000000000000000000000000001",
+      "span_id": "7222000000000001",
+      "bkn.request.id": "req_ontology_phase2_data_evidence_0001",
+      "bkn.operation.name": "bkn.object.query",
+      "payload": {
+        "claim_id": "claim_ontology_data_evidence_0001",
+        "claim_type": "finding",
+        "claim_hash": "sha256:ontology_data_query_claim_hash_only",
+        "visibility": "visible",
+        "version_status": "unversioned",
+        "partial_reason": ["data_refs_unversioned"],
+        "subject_refs": {
+          "kn_id": "kn_demo",
+          "branch": "main",
+          "entity_kind": "object_instance",
+          "subject_id": "customer",
+          "query_hash": "sha256:ontology_query_shape_hash_only",
+          "evidence_refs_hash": "sha256:ontology_data_evidence_refs_hash_only",
+          "returned_ref_count": 3,
+          "returned_count": 2,
+          "total_count": 2,
+          "truncated": false,
+          "data.classification": "internal"
+        }
+      }
+    },
+    {
+      "event_id": "evt_ontology_data_refs",
+      "event_type": "evidence.refs.created",
+      "bkn.trace.schema.version": "2.0.0",
+      "observed_at": "2026-07-23T12:00:00.003000Z",
+      "emitted_at": "2026-07-23T12:00:00.004000Z",
+      "producer_module": "bkn-ontology",
+      "trace_id": "72220000000000000000000000000001",
+      "span_id": "7222000000000001",
+      "bkn.request.id": "req_ontology_phase2_data_evidence_0001",
+      "bkn.operation.name": "bkn.object.query",
+      "payload": {
+        "claim_id": "claim_ontology_data_evidence_0001",
+        "evidence_refs": [
+          {
+            "ref_id": "object_instance:customer:row_hash_0001",
+            "ref_type": "row_ref",
+            "source_system": "bkn-ontology",
+            "summary_hash": "sha256:object_row_summary_hash_only_0001",
+            "validity": "observed",
+            "version_status": "unversioned",
+            "visibility": "visible",
+            "partial_reason": ["row_ref_unversioned"]
+          },
+          {
+            "ref_id": "relation_type:customer_has_order",
+            "ref_type": "schema_ref",
+            "source_system": "bkn-ontology",
+            "summary_hash": "sha256:relation_type_summary_hash_only",
+            "validity": "observed",
+            "version_status": "unversioned",
+            "visibility": "visible",
+            "partial_reason": ["schema_ref_unversioned"]
+          },
+          {
+            "ref_id": "metric:risk_score",
+            "ref_type": "metric_ref",
+            "source_system": "bkn-ontology",
+            "summary_hash": "sha256:metric_summary_hash_only",
+            "validity": "observed",
+            "version_status": "unversioned",
+            "visibility": "visible",
+            "partial_reason": ["metric_ref_unversioned"]
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/adp/bkn/ontology-query/server/common/bkntrace/evidence.go
+++ b/adp/bkn/ontology-query/server/common/bkntrace/evidence.go
@@ -1,0 +1,468 @@
+// Copyright openbkn.ai
+// Copyright The kweaver.ai Authors.
+//
+// Licensed under the Apache License, Version 2.0.
+// See the LICENSE file in the project root for details.
+
+package bkntrace
+
+import (
+	"bytes"
+	"context"
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"os"
+	"sort"
+	"strings"
+	"time"
+
+	"go.opentelemetry.io/otel/trace"
+	"ontology-query/interfaces"
+)
+
+const (
+	ContractVersion = "2.0.0"
+	ModuleName      = "bkn-ontology"
+)
+
+const (
+	envEvidenceIngestURL       = "BKN_TRACE_EVIDENCE_INGEST_URL"
+	envEvidenceIngestTimeoutMS = "BKN_TRACE_EVIDENCE_TIMEOUT_MS"
+)
+
+const maxInFlightEvidenceBatches = 64
+
+const (
+	EntityKindObjectInstance = "object_instance"
+	EntityKindRelationPath   = "relation_path"
+	EntityKindMetric         = "metric"
+)
+
+const (
+	RefTypeRow    = "row_ref"
+	RefTypeSchema = "schema_ref"
+	RefTypeMetric = "metric_ref"
+)
+
+type Event map[string]any
+
+type RequestContext struct {
+	RequestID      string
+	AccountID      string
+	AccountType    string
+	BusinessDomain string
+}
+
+type DataQuerySubject struct {
+	EntityKind    string
+	Operation     string
+	KNID          string
+	Branch        string
+	SubjectID     string
+	QueryHash     string
+	ReturnedCount int
+	TotalCount    int64
+	Truncated     bool
+}
+
+type EvidenceRef struct {
+	RefID          string
+	RefType        string
+	PartialReasons []string
+	Summary        map[string]any
+}
+
+type batch struct {
+	ContractVersion string         `json:"bkn.trace.schema.version"`
+	Trace           map[string]any `json:"trace"`
+	Events          []Event        `json:"events"`
+}
+
+type eventContext struct {
+	traceID        string
+	spanID         string
+	traceparent    string
+	requestID      string
+	accountID      string
+	accountType    string
+	businessDomain string
+}
+
+var (
+	evidenceHTTPClient = &http.Client{}
+	evidenceInFlight   = make(chan struct{}, maxInFlightEvidenceBatches)
+)
+
+func EvidenceEnabled() bool {
+	return evidenceIngestURL() != ""
+}
+
+func HashValue(value any) string {
+	raw, err := json.Marshal(value)
+	if err != nil {
+		raw = []byte(fmt.Sprintf("%v", value))
+	}
+	sum := sha256.Sum256(raw)
+	return "sha256:" + hex.EncodeToString(sum[:])
+}
+
+func ClaimID(kind, subjectID string, value any) string {
+	sum := sha256.Sum256([]byte(HashValue(map[string]any{
+		"kind":       kind,
+		"subject_id": subjectID,
+		"value":      value,
+	})))
+	return "claim_" + hex.EncodeToString(sum[:])[:24]
+}
+
+func BuildDataQueryEvents(ctx context.Context, reqCtx RequestContext, subject DataQuerySubject, refs []EvidenceRef) []Event {
+	ec, ok := contextFromRequest(ctx, reqCtx)
+	if !ok || len(refs) == 0 {
+		return nil
+	}
+	operation := strings.TrimSpace(subject.Operation)
+	if operation == "" {
+		operation = "bkn.data.query"
+	}
+
+	evidenceRefs, evidenceRefsHash := normalizedRefs(refs)
+	if len(evidenceRefs) == 0 {
+		return nil
+	}
+
+	resultSummary := map[string]any{
+		"kn_id":              strings.TrimSpace(subject.KNID),
+		"branch":             strings.TrimSpace(subject.Branch),
+		"entity_kind":        strings.TrimSpace(subject.EntityKind),
+		"subject_id":         strings.TrimSpace(subject.SubjectID),
+		"query_hash":         strings.TrimSpace(subject.QueryHash),
+		"returned_count":     subject.ReturnedCount,
+		"total_count":        subject.TotalCount,
+		"truncated":          subject.Truncated,
+		"evidence_count":     len(evidenceRefs),
+		"evidence_refs_hash": evidenceRefsHash,
+		"operation":          operation,
+		"producer_module":    ModuleName,
+		"contract_version":   ContractVersion,
+	}
+	claimID := ClaimID(operation, subject.KNID+":"+subject.SubjectID, resultSummary)
+
+	return []Event{
+		buildEvent(ec, "claim.created", operation, map[string]any{
+			"claim_id":       claimID,
+			"claim_type":     "finding",
+			"claim_hash":     HashValue(resultSummary),
+			"visibility":     "visible",
+			"version_status": "unversioned",
+			"partial_reason": []string{"data_refs_unversioned"},
+			"subject_refs": map[string]any{
+				"kn_id":               strings.TrimSpace(subject.KNID),
+				"branch":              strings.TrimSpace(subject.Branch),
+				"entity_kind":         strings.TrimSpace(subject.EntityKind),
+				"subject_id":          strings.TrimSpace(subject.SubjectID),
+				"query_hash":          strings.TrimSpace(subject.QueryHash),
+				"evidence_refs_hash":  evidenceRefsHash,
+				"returned_ref_count":  len(evidenceRefs),
+				"returned_count":      subject.ReturnedCount,
+				"total_count":         subject.TotalCount,
+				"truncated":           subject.Truncated,
+				"data.classification": "internal",
+			},
+		}),
+		buildEvent(ec, "evidence.refs.created", operation, map[string]any{
+			"claim_id":      claimID,
+			"evidence_refs": evidenceRefs,
+		}),
+	}
+}
+
+func EmitDataQueryEvents(ctx context.Context, reqCtx RequestContext, subject DataQuerySubject, refs []EvidenceRef) {
+	if !EvidenceEnabled() {
+		return
+	}
+	SubmitEvents(ctx, reqCtx, BuildDataQueryEvents(ctx, reqCtx, subject, refs))
+}
+
+func SubmitEvents(ctx context.Context, reqCtx RequestContext, events []Event) {
+	if len(events) == 0 {
+		return
+	}
+	ec, ok := contextFromRequest(ctx, reqCtx)
+	if !ok {
+		return
+	}
+	ingestURL := evidenceIngestURL()
+	if ingestURL == "" {
+		return
+	}
+
+	payload := batch{
+		ContractVersion: ContractVersion,
+		Trace: map[string]any{
+			"trace_id":         ec.traceID,
+			"traceparent":      ec.traceparent,
+			"bkn.request.id":   ec.requestID,
+			"business_domain":  ec.businessDomain,
+			"bkn.account.id":   ec.accountID,
+			"bkn.account.type": ec.accountType,
+		},
+		Events: events,
+	}
+
+	select {
+	case evidenceInFlight <- struct{}{}:
+	default:
+		return
+	}
+
+	timeout := evidenceTimeout()
+	go func() {
+		defer func() { <-evidenceInFlight }()
+		_ = postBatch(ingestURL, timeout, payload)
+	}()
+}
+
+func ObjectRowRefs(knID, branch, objectTypeID string, rows []map[string]any) []EvidenceRef {
+	refs := make([]EvidenceRef, 0, len(rows))
+	for i, row := range rows {
+		rowHash := HashValue(row)
+		refs = append(refs, EvidenceRef{
+			RefID:          fmt.Sprintf("object_instance:%s:%s", strings.TrimSpace(objectTypeID), shortHash(rowHash)),
+			RefType:        RefTypeRow,
+			PartialReasons: []string{"row_ref_unversioned"},
+			Summary: map[string]any{
+				"kind":            EntityKindObjectInstance,
+				"kn_id":           strings.TrimSpace(knID),
+				"branch":          strings.TrimSpace(branch),
+				"object_type_id":  strings.TrimSpace(objectTypeID),
+				"row_index":       i,
+				"row_hash":        rowHash,
+				"has_instance_id": row[interfaces.SYSTEM_PROPERTY_INSTANCE_ID] != nil,
+			},
+		})
+	}
+	return refs
+}
+
+func SubgraphRefs(knID, branch string, graph *interfaces.ObjectSubGraph) []EvidenceRef {
+	if graph == nil {
+		return nil
+	}
+	refs := make([]EvidenceRef, 0, len(graph.Objects)+len(graph.RelationPaths))
+	for key, object := range graph.Objects {
+		objectHash := HashValue(object)
+		objectTypeID := strings.TrimSpace(object.ObjectTypeId)
+		refs = append(refs, EvidenceRef{
+			RefID:          fmt.Sprintf("object_instance:%s:%s", objectTypeID, shortHash(objectHash)),
+			RefType:        RefTypeRow,
+			PartialReasons: []string{"row_ref_unversioned"},
+			Summary: map[string]any{
+				"kind":            EntityKindObjectInstance,
+				"kn_id":           strings.TrimSpace(knID),
+				"branch":          strings.TrimSpace(branch),
+				"object_type_id":  objectTypeID,
+				"object_key_hash": HashValue(key),
+				"row_hash":        objectHash,
+				"has_instance_id": object.InstanceID != nil,
+			},
+		})
+	}
+	seenRelations := map[string]bool{}
+	for _, path := range graph.RelationPaths {
+		for _, relation := range path.Relations {
+			relationTypeID := strings.TrimSpace(relation.RelationTypeId)
+			if relationTypeID == "" || seenRelations[relationTypeID] {
+				continue
+			}
+			seenRelations[relationTypeID] = true
+			refs = append(refs, EvidenceRef{
+				RefID:          "relation_type:" + relationTypeID,
+				RefType:        RefTypeSchema,
+				PartialReasons: []string{"schema_ref_unversioned"},
+				Summary: map[string]any{
+					"kind":             "relation_type",
+					"kn_id":            strings.TrimSpace(knID),
+					"branch":           strings.TrimSpace(branch),
+					"relation_type_id": relationTypeID,
+				},
+			})
+		}
+	}
+	return refs
+}
+
+func MetricDataRefs(knID, branch, metricID string, rows []interfaces.Data) []EvidenceRef {
+	refs := []EvidenceRef{{
+		RefID:          "metric:" + strings.TrimSpace(metricID),
+		RefType:        RefTypeMetric,
+		PartialReasons: []string{"metric_ref_unversioned"},
+		Summary: map[string]any{
+			"kind":      EntityKindMetric,
+			"kn_id":     strings.TrimSpace(knID),
+			"branch":    strings.TrimSpace(branch),
+			"metric_id": strings.TrimSpace(metricID),
+		},
+	}}
+	for i, row := range rows {
+		rowHash := HashValue(row)
+		refs = append(refs, EvidenceRef{
+			RefID:          fmt.Sprintf("metric_data:%s:%s", strings.TrimSpace(metricID), shortHash(rowHash)),
+			RefType:        RefTypeRow,
+			PartialReasons: []string{"row_ref_unversioned"},
+			Summary: map[string]any{
+				"kind":         "metric_data",
+				"kn_id":        strings.TrimSpace(knID),
+				"branch":       strings.TrimSpace(branch),
+				"metric_id":    strings.TrimSpace(metricID),
+				"series_index": i,
+				"point_count":  len(row.Values),
+				"time_count":   len(row.Times),
+				"row_hash":     rowHash,
+			},
+		})
+	}
+	return refs
+}
+
+func normalizedRefs(refs []EvidenceRef) ([]map[string]any, string) {
+	evidenceRefs := make([]map[string]any, 0, len(refs))
+	refFingerprints := make([]string, 0, len(refs))
+	for _, ref := range refs {
+		refID := strings.TrimSpace(ref.RefID)
+		refType := strings.TrimSpace(ref.RefType)
+		if refID == "" || refType == "" {
+			continue
+		}
+		summaryHash := HashValue(ref.Summary)
+		partialReasons := ref.PartialReasons
+		if len(partialReasons) == 0 {
+			partialReasons = []string{refType + "_unversioned"}
+		}
+		evidenceRefs = append(evidenceRefs, map[string]any{
+			"ref_id":         refID,
+			"ref_type":       refType,
+			"source_system":  ModuleName,
+			"summary":        ref.Summary,
+			"summary_hash":   summaryHash,
+			"validity":       "observed",
+			"version_status": "unversioned",
+			"visibility":     "visible",
+			"partial_reason": partialReasons,
+		})
+		refFingerprints = append(refFingerprints, refType+":"+refID+":"+summaryHash)
+	}
+	sort.Strings(refFingerprints)
+	return evidenceRefs, HashValue(refFingerprints)
+}
+
+func postBatch(ingestURL string, timeout time.Duration, payload batch) error {
+	body, err := json.Marshal(payload)
+	if err != nil {
+		return err
+	}
+	postCtx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(postCtx, http.MethodPost, ingestURL, bytes.NewReader(body))
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := evidenceHTTPClient.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode >= http.StatusBadRequest {
+		return fmt.Errorf("HTTP %d", resp.StatusCode)
+	}
+	return nil
+}
+
+func evidenceIngestURL() string {
+	return strings.TrimSpace(os.Getenv(envEvidenceIngestURL))
+}
+
+func evidenceTimeout() time.Duration {
+	value := strings.TrimSpace(os.Getenv(envEvidenceIngestTimeoutMS))
+	if value == "" {
+		return 2 * time.Second
+	}
+	var ms int
+	if _, err := fmt.Sscanf(value, "%d", &ms); err != nil || ms <= 0 {
+		return 2 * time.Second
+	}
+	return time.Duration(ms) * time.Millisecond
+}
+
+func contextFromRequest(ctx context.Context, reqCtx RequestContext) (eventContext, bool) {
+	spanContext := trace.SpanContextFromContext(ctx)
+	if !spanContext.IsValid() {
+		return eventContext{}, false
+	}
+	requestID := strings.TrimSpace(reqCtx.RequestID)
+	accountID := strings.TrimSpace(reqCtx.AccountID)
+	accountType := strings.TrimSpace(reqCtx.AccountType)
+	if requestID == "" || accountID == "" || accountType == "" {
+		return eventContext{}, false
+	}
+	flags := "00"
+	if spanContext.TraceFlags().IsSampled() {
+		flags = "01"
+	}
+	businessDomain := strings.TrimSpace(reqCtx.BusinessDomain)
+	if businessDomain == "" {
+		businessDomain = accountID
+	}
+	return eventContext{
+		traceID:        spanContext.TraceID().String(),
+		spanID:         spanContext.SpanID().String(),
+		traceparent:    fmt.Sprintf("00-%s-%s-%s", spanContext.TraceID().String(), spanContext.SpanID().String(), flags),
+		requestID:      requestID,
+		accountID:      accountID,
+		accountType:    accountType,
+		businessDomain: businessDomain,
+	}, true
+}
+
+func buildEvent(ec eventContext, eventType, operationName string, payload map[string]any) Event {
+	now := time.Now().UTC().Format(time.RFC3339Nano)
+	return Event{
+		"event_id":                 "evt_" + randomHex(16),
+		"event_type":               eventType,
+		"bkn.trace.schema.version": ContractVersion,
+		"observed_at":              now,
+		"emitted_at":               now,
+		"producer_module":          ModuleName,
+		"trace_id":                 ec.traceID,
+		"span_id":                  ec.spanID,
+		"bkn.request.id":           ec.requestID,
+		"bkn.operation.name":       operationName,
+		"payload":                  payload,
+	}
+}
+
+func randomHex(length int) string {
+	if length <= 0 {
+		return ""
+	}
+	buf := make([]byte, (length+1)/2)
+	if _, err := rand.Read(buf); err != nil {
+		sum := sha256.Sum256([]byte(time.Now().UTC().Format(time.RFC3339Nano)))
+		return hex.EncodeToString(sum[:])[:length]
+	}
+	return hex.EncodeToString(buf)[:length]
+}
+
+func shortHash(hash string) string {
+	hash = strings.TrimPrefix(strings.TrimSpace(hash), "sha256:")
+	if len(hash) < 16 {
+		return hash
+	}
+	return hash[:16]
+}

--- a/adp/bkn/ontology-query/server/common/bkntrace/evidence_test.go
+++ b/adp/bkn/ontology-query/server/common/bkntrace/evidence_test.go
@@ -1,0 +1,221 @@
+// Copyright openbkn.ai
+// Copyright The kweaver.ai Authors.
+//
+// Licensed under the Apache License, Version 2.0.
+// See the LICENSE file in the project root for details.
+
+package bkntrace
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"go.opentelemetry.io/otel/trace"
+	"ontology-query/interfaces"
+)
+
+func testTraceContext() context.Context {
+	traceID := trace.TraceID{0x72, 0x22, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1}
+	spanID := trace.SpanID{0x72, 0x22, 0, 0, 0, 0, 0, 1}
+	spanContext := trace.NewSpanContext(trace.SpanContextConfig{
+		TraceID:    traceID,
+		SpanID:     spanID,
+		TraceFlags: trace.FlagsSampled,
+	})
+	return trace.ContextWithSpanContext(context.Background(), spanContext)
+}
+
+func testRequestContext() RequestContext {
+	return RequestContext{
+		RequestID:      "req_ontology_data_0001",
+		AccountID:      "acct_demo",
+		AccountType:    "user",
+		BusinessDomain: "domain_demo",
+	}
+}
+
+func TestBuildDataQueryEventsUsesRowRefsAndHashesOnly(t *testing.T) {
+	rows := []map[string]any{
+		{
+			"_instance_id":       "obj_customer_001",
+			"_instance_identity": map[string]any{"customer_id": "C-10086"},
+			"name":               "Sensitive Customer",
+			"phone":              "13800000000",
+		},
+	}
+
+	events := BuildDataQueryEvents(testTraceContext(), testRequestContext(), DataQuerySubject{
+		EntityKind:    EntityKindObjectInstance,
+		Operation:     "bkn.object.query",
+		KNID:          "kn_demo",
+		Branch:        "main",
+		SubjectID:     "customer",
+		QueryHash:     HashValue(map[string]any{"condition": "redacted"}),
+		ReturnedCount: len(rows),
+		TotalCount:    1,
+	}, ObjectRowRefs("kn_demo", "main", "customer", rows))
+
+	assertSafeEvents(t, events, []string{
+		`"event_type":"claim.created"`,
+		`"event_type":"evidence.refs.created"`,
+		`"ref_type":"row_ref"`,
+		`"source_system":"bkn-ontology"`,
+		`"row_hash":"sha256:`,
+		`"query_hash":"sha256:`,
+		`"evidence_refs_hash":"sha256:`,
+	}, []string{
+		"C-10086",
+		"Sensitive Customer",
+		"13800000000",
+		"customer_id",
+		"phone",
+	})
+}
+
+func TestBuildDataQueryEventsCoversSubgraphAndMetricRefs(t *testing.T) {
+	graph := &interfaces.ObjectSubGraph{
+		Objects: map[string]interfaces.ObjectInfoInSubgraph{
+			"obj_1": {
+				ObjectSystemInfo: interfaces.ObjectSystemInfo{
+					InstanceID:       "obj_1",
+					InstanceIdentity: map[string]any{"customer_id": "C-10086"},
+					Display:          "Sensitive Customer",
+				},
+				ObjectTypeId:   "customer",
+				ObjectTypeName: "Customer",
+				Properties:     map[string]any{"phone": "13800000000"},
+			},
+		},
+		RelationPaths: []interfaces.RelationPath{
+			{
+				Relations: []interfaces.Relation{
+					{
+						RelationTypeId:   "customer_has_order",
+						RelationTypeName: "Customer Has Order",
+						SourceObjectId:   "obj_1",
+						TargetObjectId:   "obj_2",
+					},
+				},
+				Length: 1,
+			},
+		},
+	}
+	metric := []interfaces.Data{
+		{
+			Labels: map[string]string{"customer_name": "Sensitive Customer"},
+			Times:  []any{1720000000000},
+			Values: []any{99.9},
+		},
+	}
+	refs := append(SubgraphRefs("kn_demo", "main", graph), MetricDataRefs("kn_demo", "main", "risk_score", metric)...)
+
+	events := BuildDataQueryEvents(testTraceContext(), testRequestContext(), DataQuerySubject{
+		EntityKind:    EntityKindMetric,
+		Operation:     "bkn.metric.get",
+		KNID:          "kn_demo",
+		Branch:        "main",
+		SubjectID:     "risk_score",
+		QueryHash:     HashValue("metric-query-redacted"),
+		ReturnedCount: len(metric),
+	}, refs)
+
+	assertSafeEvents(t, events, []string{
+		`"ref_type":"schema_ref"`,
+		`"ref_id":"relation_type:customer_has_order"`,
+		`"ref_type":"metric_ref"`,
+		`"ref_id":"metric:risk_score"`,
+		`"point_count":1`,
+	}, []string{
+		"C-10086",
+		"Sensitive Customer",
+		"13800000000",
+		"customer_name",
+		"Customer Has Order",
+	})
+}
+
+func TestBuildDataQueryEventsDifferentiatesSameCountDifferentRefs(t *testing.T) {
+	subject := DataQuerySubject{
+		EntityKind:    EntityKindObjectInstance,
+		Operation:     "bkn.object.query",
+		KNID:          "kn_demo",
+		Branch:        "main",
+		SubjectID:     "customer",
+		QueryHash:     HashValue("same-query"),
+		ReturnedCount: 1,
+		TotalCount:    1,
+	}
+	first := BuildDataQueryEvents(testTraceContext(), testRequestContext(), subject, ObjectRowRefs("kn_demo", "main", "customer", []map[string]any{{"_instance_id": "obj_1"}}))
+	second := BuildDataQueryEvents(testTraceContext(), testRequestContext(), subject, ObjectRowRefs("kn_demo", "main", "customer", []map[string]any{{"_instance_id": "obj_2"}}))
+
+	if claimPayload(t, first)["claim_id"] == claimPayload(t, second)["claim_id"] {
+		t.Fatalf("claim_id should differ for same-count different row refs")
+	}
+	if claimPayload(t, first)["claim_hash"] == claimPayload(t, second)["claim_hash"] {
+		t.Fatalf("claim_hash should differ for same-count different row refs")
+	}
+}
+
+func TestBuildDataQueryEventsRequiresTraceAndRequestContext(t *testing.T) {
+	events := BuildDataQueryEvents(context.Background(), testRequestContext(), DataQuerySubject{
+		EntityKind:    EntityKindObjectInstance,
+		Operation:     "bkn.object.query",
+		KNID:          "kn_demo",
+		Branch:        "main",
+		SubjectID:     "customer",
+		QueryHash:     HashValue("query"),
+		ReturnedCount: 1,
+	}, []EvidenceRef{{RefID: "row:customer:demo", RefType: RefTypeRow}})
+	if len(events) != 0 {
+		t.Fatalf("len(events)=%d, want 0 without trace context", len(events))
+	}
+
+	events = BuildDataQueryEvents(testTraceContext(), RequestContext{}, DataQuerySubject{
+		EntityKind:    EntityKindObjectInstance,
+		Operation:     "bkn.object.query",
+		KNID:          "kn_demo",
+		Branch:        "main",
+		SubjectID:     "customer",
+		QueryHash:     HashValue("query"),
+		ReturnedCount: 1,
+	}, []EvidenceRef{{RefID: "row:customer:demo", RefType: RefTypeRow}})
+	if len(events) != 0 {
+		t.Fatalf("len(events)=%d, want 0 without request context", len(events))
+	}
+}
+
+func claimPayload(t *testing.T, events []Event) map[string]any {
+	t.Helper()
+	if len(events) == 0 {
+		t.Fatalf("events are empty")
+	}
+	payload, ok := events[0]["payload"].(map[string]any)
+	if !ok {
+		t.Fatalf("claim payload missing or invalid: %#v", events[0]["payload"])
+	}
+	return payload
+}
+
+func assertSafeEvents(t *testing.T, events []Event, want []string, forbidden []string) {
+	t.Helper()
+	if len(events) != 2 {
+		t.Fatalf("len(events)=%d, want 2", len(events))
+	}
+	raw, err := json.Marshal(events)
+	if err != nil {
+		t.Fatalf("marshal events: %v", err)
+	}
+	text := string(raw)
+	for _, item := range want {
+		if !strings.Contains(text, item) {
+			t.Fatalf("missing %q in events: %s", item, text)
+		}
+	}
+	for _, item := range forbidden {
+		if strings.Contains(text, item) {
+			t.Fatalf("event leaked raw content %q: %s", item, text)
+		}
+	}
+}

--- a/adp/bkn/ontology-query/server/driveradapters/bkn_trace_events.go
+++ b/adp/bkn/ontology-query/server/driveradapters/bkn_trace_events.go
@@ -1,0 +1,149 @@
+// Copyright openbkn.ai
+// Copyright The kweaver.ai Authors.
+//
+// Licensed under the Apache License, Version 2.0.
+// See the LICENSE file in the project root for details.
+
+package driveradapters
+
+import (
+	"context"
+	"strings"
+
+	"github.com/gin-gonic/gin"
+	"github.com/openbkn-ai/bkn-comm-go/hydra"
+
+	"ontology-query/common"
+	"ontology-query/common/bkntrace"
+	"ontology-query/interfaces"
+)
+
+func ontologyTraceRequestContext(c *gin.Context, ctx context.Context, visitor hydra.Visitor) bkntrace.RequestContext {
+	traceContext, _ := common.GetTraceContextFromCtx(ctx)
+	businessDomain := strings.TrimSpace(c.GetHeader("x-business-domain"))
+	if businessDomain == "" {
+		businessDomain = strings.TrimSpace(traceContext.Baggage["business_domain"])
+	}
+	return bkntrace.RequestContext{
+		RequestID:      traceContext.RequestID,
+		AccountID:      visitor.ID,
+		AccountType:    string(visitor.Type),
+		BusinessDomain: businessDomain,
+	}
+}
+
+func emitObjectQueryEvidence(c *gin.Context, ctx context.Context, visitor hydra.Visitor, query *interfaces.ObjectQueryBaseOnObjectType, result *interfaces.Objects) {
+	if result == nil {
+		return
+	}
+	subject := bkntrace.DataQuerySubject{
+		EntityKind:    bkntrace.EntityKindObjectInstance,
+		Operation:     "bkn.object.query",
+		KNID:          query.KNID,
+		Branch:        query.Branch,
+		SubjectID:     query.ObjectTypeID,
+		QueryHash:     bkntrace.HashValue(safeObjectQueryShape(query)),
+		ReturnedCount: len(result.Datas),
+		TotalCount:    result.TotalCount,
+		Truncated:     query.Limit > 0 && len(result.Datas) >= query.Limit,
+	}
+	bkntrace.EmitDataQueryEvents(ctx, ontologyTraceRequestContext(c, ctx, visitor), subject,
+		bkntrace.ObjectRowRefs(query.KNID, query.Branch, query.ObjectTypeID, result.Datas))
+}
+
+func emitSubgraphEvidence(c *gin.Context, ctx context.Context, visitor hydra.Visitor, knID, branch, operation string, queryShape any, result *interfaces.ObjectSubGraph) {
+	if result == nil {
+		return
+	}
+	subject := bkntrace.DataQuerySubject{
+		EntityKind:    bkntrace.EntityKindRelationPath,
+		Operation:     operation,
+		KNID:          knID,
+		Branch:        branch,
+		SubjectID:     "subgraph",
+		QueryHash:     bkntrace.HashValue(queryShape),
+		ReturnedCount: len(result.RelationPaths),
+		TotalCount:    result.TotalCount,
+		Truncated:     result.TotalCount > 0 && int64(len(result.RelationPaths)) < result.TotalCount,
+	}
+	bkntrace.EmitDataQueryEvents(ctx, ontologyTraceRequestContext(c, ctx, visitor), subject,
+		bkntrace.SubgraphRefs(knID, branch, result))
+}
+
+func emitMetricEvidence(c *gin.Context, traceCtx context.Context, visitor hydra.Visitor, knID, branch, metricID, operation string, queryShape any, result *interfaces.MetricData) {
+	if result == nil {
+		return
+	}
+	subject := bkntrace.DataQuerySubject{
+		EntityKind:    bkntrace.EntityKindMetric,
+		Operation:     operation,
+		KNID:          knID,
+		Branch:        branch,
+		SubjectID:     metricID,
+		QueryHash:     bkntrace.HashValue(queryShape),
+		ReturnedCount: len(result.Datas),
+	}
+	bkntrace.EmitDataQueryEvents(traceCtx, ontologyTraceRequestContext(c, traceCtx, visitor), subject,
+		bkntrace.MetricDataRefs(knID, branch, metricID, result.Datas))
+}
+
+func safeObjectQueryShape(query *interfaces.ObjectQueryBaseOnObjectType) map[string]any {
+	if query == nil {
+		return nil
+	}
+	return map[string]any{
+		"kn_id":                   query.KNID,
+		"branch":                  query.Branch,
+		"object_type_id":          query.ObjectTypeID,
+		"condition_hash":          bkntrace.HashValue(query.Condition),
+		"properties_hash":         bkntrace.HashValue(query.Properties),
+		"offset":                  query.Offset,
+		"limit":                   query.Limit,
+		"include_type_info":       query.IncludeTypeInfo,
+		"include_logic_params":    query.IncludeLogicParams,
+		"ignoring_store":          query.IgnoringStore,
+		"exclude_props_hash":      bkntrace.HashValue(query.ExcludeSystemProperties),
+		"has_actual_condition":    query.ActualCondition != nil,
+		"has_object_query_info":   query.ObjectQueryInfo != nil,
+		"search_after_value_hash": bkntrace.HashValue(query.SearchAfter),
+	}
+}
+
+func safeSubgraphSourceQueryShape(query *interfaces.SubGraphQueryBaseOnSource) map[string]any {
+	if query == nil {
+		return nil
+	}
+	return map[string]any{
+		"kn_id":                   query.KNID,
+		"branch":                  query.Branch,
+		"source_object_type_id":   query.SourceObjecTypeId,
+		"concept_groups_hash":     bkntrace.HashValue(query.ConceptGroups),
+		"condition_hash":          bkntrace.HashValue(query.Condition),
+		"direction":               query.Direction,
+		"path_length":             query.PathLength,
+		"include_incomplete_path": query.IncludeIncompletePath,
+		"offset":                  query.Offset,
+		"limit":                   query.Limit,
+	}
+}
+
+func safeSubgraphByObjectsQueryShape(query *interfaces.SubGraphQueryBaseOnObjects) map[string]any {
+	if query == nil {
+		return nil
+	}
+	return map[string]any{
+		"kn_id":        query.KNID,
+		"branch":       query.Branch,
+		"entries_hash": bkntrace.HashValue(query.Entries),
+		"entry_count":  len(query.Entries),
+	}
+}
+
+func safeMetricQueryShape(knID, branch, metricID string, query any) map[string]any {
+	return map[string]any{
+		"kn_id":      knID,
+		"branch":     branch,
+		"metric_id":  metricID,
+		"query_hash": bkntrace.HashValue(query),
+	}
+}

--- a/adp/bkn/ontology-query/server/driveradapters/bkn_trace_events.go
+++ b/adp/bkn/ontology-query/server/driveradapters/bkn_trace_events.go
@@ -33,7 +33,7 @@ func ontologyTraceRequestContext(c *gin.Context, ctx context.Context, visitor hy
 }
 
 func emitObjectQueryEvidence(c *gin.Context, ctx context.Context, visitor hydra.Visitor, query *interfaces.ObjectQueryBaseOnObjectType, result *interfaces.Objects) {
-	if result == nil {
+	if !bkntrace.EvidenceEnabled() || result == nil {
 		return
 	}
 	subject := bkntrace.DataQuerySubject{
@@ -52,7 +52,7 @@ func emitObjectQueryEvidence(c *gin.Context, ctx context.Context, visitor hydra.
 }
 
 func emitSubgraphEvidence(c *gin.Context, ctx context.Context, visitor hydra.Visitor, knID, branch, operation string, queryShape any, result *interfaces.ObjectSubGraph) {
-	if result == nil {
+	if !bkntrace.EvidenceEnabled() || result == nil {
 		return
 	}
 	subject := bkntrace.DataQuerySubject{
@@ -70,8 +70,27 @@ func emitSubgraphEvidence(c *gin.Context, ctx context.Context, visitor hydra.Vis
 		bkntrace.SubgraphRefs(knID, branch, result))
 }
 
+func emitSubgraphEntriesEvidence(c *gin.Context, ctx context.Context, visitor hydra.Visitor, knID, branch string, queryShape any, result interfaces.PathsEntries) {
+	if !bkntrace.EvidenceEnabled() {
+		return
+	}
+	refs := make([]bkntrace.EvidenceRef, 0)
+	for i := range result.Entries {
+		refs = append(refs, bkntrace.SubgraphRefs(knID, branch, &result.Entries[i])...)
+	}
+	bkntrace.EmitDataQueryEvents(ctx, ontologyTraceRequestContext(c, ctx, visitor), bkntrace.DataQuerySubject{
+		EntityKind:    bkntrace.EntityKindRelationPath,
+		Operation:     "bkn.relation.query",
+		KNID:          knID,
+		Branch:        branch,
+		SubjectID:     "subgraph_type_path",
+		QueryHash:     bkntrace.HashValue(queryShape),
+		ReturnedCount: len(result.Entries),
+	}, refs)
+}
+
 func emitMetricEvidence(c *gin.Context, traceCtx context.Context, visitor hydra.Visitor, knID, branch, metricID, operation string, queryShape any, result *interfaces.MetricData) {
-	if result == nil {
+	if !bkntrace.EvidenceEnabled() || result == nil {
 		return
 	}
 	subject := bkntrace.DataQuerySubject{

--- a/adp/bkn/ontology-query/server/driveradapters/bkn_trace_events_test.go
+++ b/adp/bkn/ontology-query/server/driveradapters/bkn_trace_events_test.go
@@ -1,0 +1,41 @@
+// Copyright openbkn.ai
+// Copyright The kweaver.ai Authors.
+//
+// Licensed under the Apache License, Version 2.0.
+// See the LICENSE file in the project root for details.
+
+package driveradapters
+
+import (
+	"context"
+	"os"
+	"testing"
+
+	"github.com/openbkn-ai/bkn-comm-go/hydra"
+
+	"ontology-query/interfaces"
+)
+
+func TestOntologyEvidenceEmittersReturnBeforeWorkWhenDisabled(t *testing.T) {
+	t.Setenv("BKN_TRACE_EVIDENCE_INGEST_URL", "")
+	_ = os.Unsetenv("BKN_TRACE_EVIDENCE_INGEST_URL")
+
+	visitor := hydra.Visitor{ID: "acct_demo", Type: hydra.VisitorType_User}
+
+	emitObjectQueryEvidence(nil, context.Background(), visitor, nil, &interfaces.Objects{
+		Datas: []map[string]any{{"_instance_id": "obj_1"}},
+	})
+	emitSubgraphEvidence(nil, context.Background(), visitor, "kn_demo", "main", "bkn.relation.query", map[string]any{"unsafe": "would_hash"}, &interfaces.ObjectSubGraph{
+		Objects: map[string]interfaces.ObjectInfoInSubgraph{
+			"obj_1": {ObjectSystemInfo: interfaces.ObjectSystemInfo{InstanceID: "obj_1"}},
+		},
+	})
+	emitSubgraphEntriesEvidence(nil, context.Background(), visitor, "kn_demo", "main", map[string]any{"unsafe": "would_hash"}, interfaces.PathsEntries{
+		Entries: []interfaces.ObjectSubGraph{
+			{Objects: map[string]interfaces.ObjectInfoInSubgraph{"obj_1": {ObjectSystemInfo: interfaces.ObjectSystemInfo{InstanceID: "obj_1"}}}},
+		},
+	})
+	emitMetricEvidence(nil, context.Background(), visitor, "kn_demo", "main", "metric_demo", "bkn.metric.get", map[string]any{"unsafe": "would_hash"}, &interfaces.MetricData{
+		Datas: []interfaces.Data{{Labels: map[string]string{"pii": "value"}}},
+	})
+}

--- a/adp/bkn/ontology-query/server/driveradapters/knowledge_network_handler.go
+++ b/adp/bkn/ontology-query/server/driveradapters/knowledge_network_handler.go
@@ -20,7 +20,6 @@ import (
 	"github.com/openbkn-ai/bkn-comm-go/rest"
 	attr "go.opentelemetry.io/otel/attribute"
 
-	"ontology-query/common/bkntrace"
 	"ontology-query/common/visitor"
 	oerrors "ontology-query/errors"
 	"ontology-query/interfaces"
@@ -303,19 +302,7 @@ func (r *restHandler) GetObjectsSubgraphByTypePath(c *gin.Context, visitor hydra
 	oteltrace.AddHttpAttrs4Ok(span, http.StatusOK)
 
 	// result.OverallMs = time.Now().UnixMilli() - startTime.UnixMilli()
-	refs := make([]bkntrace.EvidenceRef, 0)
-	for i := range result.Entries {
-		refs = append(refs, bkntrace.SubgraphRefs(knID, branch, &result.Entries[i])...)
-	}
-	bkntrace.EmitDataQueryEvents(ctx, ontologyTraceRequestContext(c, ctx, visitor), bkntrace.DataQuerySubject{
-		EntityKind:    bkntrace.EntityKindRelationPath,
-		Operation:     "bkn.relation.query",
-		KNID:          knID,
-		Branch:        branch,
-		SubjectID:     "subgraph_type_path",
-		QueryHash:     bkntrace.HashValue(paths),
-		ReturnedCount: len(result.Entries),
-	}, refs)
+	emitSubgraphEntriesEvidence(c, ctx, visitor, knID, branch, paths, result)
 	rest.ReplyOK(c, http.StatusOK, result)
 }
 

--- a/adp/bkn/ontology-query/server/driveradapters/knowledge_network_handler.go
+++ b/adp/bkn/ontology-query/server/driveradapters/knowledge_network_handler.go
@@ -20,6 +20,7 @@ import (
 	"github.com/openbkn-ai/bkn-comm-go/rest"
 	attr "go.opentelemetry.io/otel/attribute"
 
+	"ontology-query/common/bkntrace"
 	"ontology-query/common/visitor"
 	oerrors "ontology-query/errors"
 	"ontology-query/interfaces"
@@ -182,6 +183,7 @@ func (r *restHandler) GetObjectsSubgraph(c *gin.Context, visitor hydra.Visitor) 
 	oteltrace.AddHttpAttrs4Ok(span, http.StatusOK)
 
 	result.OverallMs = time.Now().UnixMilli() - startTime.UnixMilli()
+	emitSubgraphEvidence(c, ctx, visitor, knID, branch, "bkn.relation.query", safeSubgraphSourceQueryShape(&query), &result)
 	rest.ReplyOK(c, http.StatusOK, result)
 }
 
@@ -301,6 +303,19 @@ func (r *restHandler) GetObjectsSubgraphByTypePath(c *gin.Context, visitor hydra
 	oteltrace.AddHttpAttrs4Ok(span, http.StatusOK)
 
 	// result.OverallMs = time.Now().UnixMilli() - startTime.UnixMilli()
+	refs := make([]bkntrace.EvidenceRef, 0)
+	for i := range result.Entries {
+		refs = append(refs, bkntrace.SubgraphRefs(knID, branch, &result.Entries[i])...)
+	}
+	bkntrace.EmitDataQueryEvents(ctx, ontologyTraceRequestContext(c, ctx, visitor), bkntrace.DataQuerySubject{
+		EntityKind:    bkntrace.EntityKindRelationPath,
+		Operation:     "bkn.relation.query",
+		KNID:          knID,
+		Branch:        branch,
+		SubjectID:     "subgraph_type_path",
+		QueryHash:     bkntrace.HashValue(paths),
+		ReturnedCount: len(result.Entries),
+	}, refs)
 	rest.ReplyOK(c, http.StatusOK, result)
 }
 
@@ -430,5 +445,6 @@ func (r *restHandler) GetObjectsSubgraphByObjects(c *gin.Context, visitor hydra.
 	oteltrace.AddHttpAttrs4Ok(span, http.StatusOK)
 
 	result.OverallMs = time.Now().UnixMilli() - startTime.UnixMilli()
+	emitSubgraphEvidence(c, ctx, visitor, knID, branch, "bkn.relation.query", safeSubgraphByObjectsQueryShape(&query), &result)
 	rest.ReplyOK(c, http.StatusOK, result)
 }

--- a/adp/bkn/ontology-query/server/driveradapters/metric_handler.go
+++ b/adp/bkn/ontology-query/server/driveradapters/metric_handler.go
@@ -43,6 +43,9 @@ func (r *restHandler) PostMetricDataByIn(c *gin.Context) {
 
 func (r *restHandler) postMetricData(c *gin.Context, vis hydra.Visitor) {
 	start := time.Now()
+	traceCtx, span := oteltrace.StartServerSpan(c)
+	defer span.End()
+
 	ctx := rest.GetLanguageCtx(c)
 	accountInfo := interfaces.AccountInfo{ID: vis.ID, Type: string(vis.Type)}
 	ctx = context.WithValue(ctx, interfaces.ACCOUNT_INFO_KEY, accountInfo)
@@ -90,6 +93,7 @@ func (r *restHandler) postMetricData(c *gin.Context, vis hydra.Visitor) {
 	}
 
 	logger.Infof("PostMetricData done in %dms", time.Since(start).Milliseconds())
+	emitMetricEvidence(c, traceCtx, vis, knID, branch, metricID, "bkn.metric.get", safeMetricQueryShape(knID, branch, metricID, body), &out)
 	rest.ReplyOK(c, http.StatusOK, out)
 }
 
@@ -112,6 +116,9 @@ func (r *restHandler) PostMetricDryRunByIn(c *gin.Context) {
 
 func (r *restHandler) postMetricDryRun(c *gin.Context, vis hydra.Visitor) {
 	start := time.Now()
+	traceCtx, span := oteltrace.StartServerSpan(c)
+	defer span.End()
+
 	ctx := rest.GetLanguageCtx(c)
 	accountInfo := interfaces.AccountInfo{ID: vis.ID, Type: string(vis.Type)}
 	ctx = context.WithValue(ctx, interfaces.ACCOUNT_INFO_KEY, accountInfo)
@@ -159,5 +166,13 @@ func (r *restHandler) postMetricDryRun(c *gin.Context, vis hydra.Visitor) {
 	}
 
 	logger.Infof("PostMetricDryRun done in %dms", time.Since(start).Milliseconds())
+	metricID := ""
+	if body.MetricConfig != nil {
+		metricID = body.MetricConfig.ID
+	}
+	if metricID == "" {
+		metricID = "dry_run"
+	}
+	emitMetricEvidence(c, traceCtx, vis, knID, branch, metricID, "bkn.metric.dry_run", safeMetricQueryShape(knID, branch, metricID, body), &out)
 	rest.ReplyOK(c, http.StatusOK, out)
 }

--- a/adp/bkn/ontology-query/server/driveradapters/object_type_handler.go
+++ b/adp/bkn/ontology-query/server/driveradapters/object_type_handler.go
@@ -173,6 +173,7 @@ func (r *restHandler) GetObjectsInObjectType(c *gin.Context, visitor hydra.Visit
 	oteltrace.AddHttpAttrs4Ok(span, http.StatusOK)
 
 	result.OverallMs = time.Now().UnixMilli() - startTime.UnixMilli()
+	emitObjectQueryEvidence(c, ctx, visitor, &query, &result)
 	rest.ReplyOK(c, http.StatusOK, result)
 
 }

--- a/adp/vega/vega-backend/TRACE.md
+++ b/adp/vega/vega-backend/TRACE.md
@@ -1,8 +1,8 @@
 # vega-backend Trace Contract
 
-> 状态：阶段一模块接入合同  
-> 适用版本：`bkn.trace.schema.version=1.0.0`  
-> 依据：`bkn-docs/docs/foundry/bkn-trace/design/阶段一：OpenBKN 可观测记录规范与 Trace Context 基线.md`
+> 状态：阶段二数据证据接入合同
+> 适用版本：`bkn.trace.schema.version=2.0.0`
+> 依据：`bkn-docs/docs/foundry/bkn-trace/design/BKN Trace 设计.md`、`bkn-docs/docs/foundry/bkn-trace/design/BKN Trace 三段式实施计划.md`
 
 ## Module
 
@@ -12,14 +12,14 @@
 - service identity: `vega-backend`
 - runtime: Go HTTP service
 - repository path: `adp/vega/vega-backend`
-- contract version: `1.0.0`
+- contract version: `2.0.0`
 
 ## Entry Operations
 
 | operation | trigger | required context | emitted spans | emitted events |
 | --- | --- | --- | --- | --- |
-| `data.resource.query` | resource data query | `traceparent`、`bkn-request-id`、account/auth context | `vega-data.request`、`vega-data.query` | `data.query.executed` |
-| `data.catalog.get` | catalog/resource metadata query | `traceparent`、`bkn-request-id`、account/auth context | `vega-data.request` | `schema.read` / metadata read event |
+| `data.resource.query` | resource data query | `traceparent`、`bkn-request-id`、account/auth context | `vega-data.request`、`vega-data.query` | `claim.created`、`evidence.refs.created` |
+| `data.catalog.get` | resource metadata list/get | `traceparent`、`bkn-request-id`、account/auth context | `vega-data.request` | `claim.created`、`evidence.refs.created` |
 | `data.query.execute` | raw SQL / OpenSearch query | `traceparent`、`bkn-request-id`、resource refs | `vega-data.request`、`vega-data.query` | `data.query.executed`、`data.query.failed` |
 | `data.snapshot.create` | snapshot/export follow-up | `traceparent`、`bkn-request-id`、resource refs | `vega-data.snapshot` | `snapshot.created` |
 
@@ -71,6 +71,8 @@ bkn.runtime.env
 | `data.query.executed` | vega-backend | resource id、catalog id、query hash、row count、truncated | result truncated / connector unavailable | business event |
 | `data.query.failed` | vega-backend | resource id、catalog id、query hash、error code、retryable | timeout / dependency / validation | forced retention on error |
 | `snapshot.created` | vega-backend | snapshot ref、hash、format、classification | snapshot unavailable | evidence ref |
+| `claim.created` | vega-backend | resource id、catalog id、query hash、returned count、evidence refs hash | data refs unversioned | business event |
+| `evidence.refs.created` | vega-backend | `resource_ref` and `row_ref` controlled refs with summary hash | resource/row refs unversioned | business event |
 
 ## Business Refs
 
@@ -85,6 +87,7 @@ bkn.runtime.env
 
 - never log: token、authorization、cookie、完整 SQL、完整结果集、行级数据、PII、连接串、对象存储裸 URL。
 - hash only: raw SQL、OpenSearch DSL、query body、large result summary。
+- runtime evidence event payload only contains safe query shape hash、row hash、counts、resource/catalog ids and controlled refs; full SQL、filter values、output field names and row data are not emitted.
 - controlled reference: row refs、snapshot refs、large result artifacts。
 - redact: unauthorized resource detail、PII fields、secret connection metadata。
 - `data.classification`: `public|internal|confidential|pii|secret`。
@@ -114,6 +117,7 @@ bkn.runtime.env
 | negative | `fixtures/bkn-trace/negative_sensitive_sql.json` | full SQL leakage rejection | fail |
 | propagation | `fixtures/bkn-trace/propagation.json` | snapshot/resource propagation | pass |
 | sampling | `fixtures/bkn-trace/sampling.json` | forced sampled timeout | pass |
+| phase2 vega data evidence | `fixtures/bkn-trace/phase2/vega_data_evidence_l2_positive.json` | resource metadata and row refs baseline | pass |
 
 ## Covered GWT
 
@@ -127,7 +131,8 @@ bkn.runtime.env
 
 ## Known Gaps
 
-- runtime `data.query.executed/data.query.failed/snapshot.created` event emitters are not complete in this branch.
+- legacy phase-one event names `data.query.executed/data.query.failed` are superseded by phase-two `claim.created` / `evidence.refs.created` for implemented successful resource metadata and resource data query paths.
+- snapshot refs and immutable evidence artifact storage remain a follow-up; current data evidence emits resource/row refs and summary hashes only.
 - outbound permission/model-factory/bkn-agent clients should be migrated to `common.MergeTraceHeaders` in follow-up commits.
 - full registry validation and indexing policy validation currently rely on `bkn-docs` validator follow-up.
 - S3 health metrics are not implemented yet.
@@ -135,6 +140,6 @@ bkn.runtime.env
 ## Owner Sign-off
 
 - owner: OpenBKN Foundry / Vega data
-- reviewed at: 2026-07-21
+- reviewed at: 2026-07-23
 - reviewer: pending
 - compatibility risk: low; new headers are additive and legacy `x-request-id` remains supported.

--- a/adp/vega/vega-backend/fixtures/bkn-trace/phase2/vega_data_evidence_l2_positive.json
+++ b/adp/vega/vega-backend/fixtures/bkn-trace/phase2/vega_data_evidence_l2_positive.json
@@ -1,0 +1,95 @@
+{
+  "bkn.trace.schema.version": "2.0.0",
+  "fixture_id": "vega_backend_phase2_data_evidence_l2_positive",
+  "expected_result": "pass",
+  "trace": {
+    "trace_id": "73220000000000000000000000000001",
+    "traceparent": "00-73220000000000000000000000000001-7322000000000001-01",
+    "bkn.request.id": "req_vega_phase2_data_evidence_0001",
+    "business_domain": "domain_demo",
+    "bkn.account.id": "acct_demo",
+    "bkn.account.type": "user"
+  },
+  "spans": [
+    {
+      "span_id": "7322000000000001",
+      "parent_span_id": null,
+      "name": "vega-data.query",
+      "kind": "internal",
+      "bkn.module.name": "vega-data",
+      "bkn.operation.name": "data.resource.query",
+      "bkn.status": "ok",
+      "bkn.timestamp": "2026-07-23T12:05:00.000000Z"
+    }
+  ],
+  "events": [
+    {
+      "event_id": "evt_vega_data_claim",
+      "event_type": "claim.created",
+      "bkn.trace.schema.version": "2.0.0",
+      "observed_at": "2026-07-23T12:05:00.001000Z",
+      "emitted_at": "2026-07-23T12:05:00.002000Z",
+      "producer_module": "vega-data",
+      "trace_id": "73220000000000000000000000000001",
+      "span_id": "7322000000000001",
+      "bkn.request.id": "req_vega_phase2_data_evidence_0001",
+      "bkn.operation.name": "data.resource.query",
+      "payload": {
+        "claim_id": "claim_vega_data_evidence_0001",
+        "claim_type": "finding",
+        "claim_hash": "sha256:vega_data_query_claim_hash_only",
+        "visibility": "visible",
+        "version_status": "unversioned",
+        "partial_reason": ["data_refs_unversioned"],
+        "subject_refs": {
+          "resource_id": "res_customer_table",
+          "catalog_id": "cat_prod",
+          "query_hash": "sha256:vega_query_shape_hash_only",
+          "evidence_refs_hash": "sha256:vega_data_evidence_refs_hash_only",
+          "returned_ref_count": 2,
+          "returned_count": 1,
+          "total_count": 1,
+          "truncated": false,
+          "data.classification": "internal"
+        }
+      }
+    },
+    {
+      "event_id": "evt_vega_data_refs",
+      "event_type": "evidence.refs.created",
+      "bkn.trace.schema.version": "2.0.0",
+      "observed_at": "2026-07-23T12:05:00.003000Z",
+      "emitted_at": "2026-07-23T12:05:00.004000Z",
+      "producer_module": "vega-data",
+      "trace_id": "73220000000000000000000000000001",
+      "span_id": "7322000000000001",
+      "bkn.request.id": "req_vega_phase2_data_evidence_0001",
+      "bkn.operation.name": "data.resource.query",
+      "payload": {
+        "claim_id": "claim_vega_data_evidence_0001",
+        "evidence_refs": [
+          {
+            "ref_id": "resource:res_customer_table",
+            "ref_type": "resource_ref",
+            "source_system": "vega-data",
+            "summary_hash": "sha256:resource_summary_hash_only",
+            "validity": "observed",
+            "version_status": "unversioned",
+            "visibility": "visible",
+            "partial_reason": ["resource_ref_unversioned"]
+          },
+          {
+            "ref_id": "resource_row:res_customer_table:row_hash_0001",
+            "ref_type": "row_ref",
+            "source_system": "vega-data",
+            "summary_hash": "sha256:resource_row_summary_hash_only_0001",
+            "validity": "observed",
+            "version_status": "unversioned",
+            "visibility": "visible",
+            "partial_reason": ["row_ref_unversioned"]
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/adp/vega/vega-backend/server/common/bkntrace/evidence.go
+++ b/adp/vega/vega-backend/server/common/bkntrace/evidence.go
@@ -1,0 +1,402 @@
+// Copyright openbkn.ai
+// Copyright The kweaver.ai Authors.
+//
+// Licensed under the Apache License, Version 2.0.
+// See the LICENSE file in the project root for details.
+
+package bkntrace
+
+import (
+	"bytes"
+	"context"
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"os"
+	"sort"
+	"strings"
+	"time"
+
+	"go.opentelemetry.io/otel/trace"
+	"vega-backend/interfaces"
+)
+
+const (
+	ContractVersion = "2.0.0"
+	ModuleName      = "vega-data"
+)
+
+const (
+	envEvidenceIngestURL       = "BKN_TRACE_EVIDENCE_INGEST_URL"
+	envEvidenceIngestTimeoutMS = "BKN_TRACE_EVIDENCE_TIMEOUT_MS"
+)
+
+const maxInFlightEvidenceBatches = 64
+
+const (
+	RefTypeResource = "resource_ref"
+	RefTypeRow      = "row_ref"
+)
+
+type Event map[string]any
+
+type RequestContext struct {
+	RequestID      string
+	AccountID      string
+	AccountType    string
+	BusinessDomain string
+}
+
+type DataQuerySubject struct {
+	Operation     string
+	ResourceID    string
+	CatalogID     string
+	QueryHash     string
+	ReturnedCount int
+	TotalCount    int64
+	Truncated     bool
+}
+
+type EvidenceRef struct {
+	RefID          string
+	RefType        string
+	PartialReasons []string
+	Summary        map[string]any
+}
+
+type batch struct {
+	ContractVersion string         `json:"bkn.trace.schema.version"`
+	Trace           map[string]any `json:"trace"`
+	Events          []Event        `json:"events"`
+}
+
+type eventContext struct {
+	traceID        string
+	spanID         string
+	traceparent    string
+	requestID      string
+	accountID      string
+	accountType    string
+	businessDomain string
+}
+
+var (
+	evidenceHTTPClient = &http.Client{}
+	evidenceInFlight   = make(chan struct{}, maxInFlightEvidenceBatches)
+)
+
+func EvidenceEnabled() bool {
+	return evidenceIngestURL() != ""
+}
+
+func HashValue(value any) string {
+	raw, err := json.Marshal(value)
+	if err != nil {
+		raw = []byte(fmt.Sprintf("%v", value))
+	}
+	sum := sha256.Sum256(raw)
+	return "sha256:" + hex.EncodeToString(sum[:])
+}
+
+func ClaimID(kind, subjectID string, value any) string {
+	sum := sha256.Sum256([]byte(HashValue(map[string]any{
+		"kind":       kind,
+		"subject_id": subjectID,
+		"value":      value,
+	})))
+	return "claim_" + hex.EncodeToString(sum[:])[:24]
+}
+
+func BuildDataQueryEvents(ctx context.Context, reqCtx RequestContext, subject DataQuerySubject, refs []EvidenceRef) []Event {
+	ec, ok := contextFromRequest(ctx, reqCtx)
+	if !ok || len(refs) == 0 {
+		return nil
+	}
+	operation := strings.TrimSpace(subject.Operation)
+	if operation == "" {
+		operation = "data.resource.query"
+	}
+
+	evidenceRefs, evidenceRefsHash := normalizedRefs(refs)
+	if len(evidenceRefs) == 0 {
+		return nil
+	}
+
+	resultSummary := map[string]any{
+		"resource_id":        strings.TrimSpace(subject.ResourceID),
+		"catalog_id":         strings.TrimSpace(subject.CatalogID),
+		"query_hash":         strings.TrimSpace(subject.QueryHash),
+		"returned_count":     subject.ReturnedCount,
+		"total_count":        subject.TotalCount,
+		"truncated":          subject.Truncated,
+		"evidence_count":     len(evidenceRefs),
+		"evidence_refs_hash": evidenceRefsHash,
+		"operation":          operation,
+		"producer_module":    ModuleName,
+		"contract_version":   ContractVersion,
+	}
+	claimID := ClaimID(operation, subject.ResourceID, resultSummary)
+
+	return []Event{
+		buildEvent(ec, "claim.created", operation, map[string]any{
+			"claim_id":       claimID,
+			"claim_type":     "finding",
+			"claim_hash":     HashValue(resultSummary),
+			"visibility":     "visible",
+			"version_status": "unversioned",
+			"partial_reason": []string{"data_refs_unversioned"},
+			"subject_refs": map[string]any{
+				"resource_id":         strings.TrimSpace(subject.ResourceID),
+				"catalog_id":          strings.TrimSpace(subject.CatalogID),
+				"query_hash":          strings.TrimSpace(subject.QueryHash),
+				"evidence_refs_hash":  evidenceRefsHash,
+				"returned_ref_count":  len(evidenceRefs),
+				"returned_count":      subject.ReturnedCount,
+				"total_count":         subject.TotalCount,
+				"truncated":           subject.Truncated,
+				"data.classification": "internal",
+			},
+		}),
+		buildEvent(ec, "evidence.refs.created", operation, map[string]any{
+			"claim_id":      claimID,
+			"evidence_refs": evidenceRefs,
+		}),
+	}
+}
+
+func EmitDataQueryEvents(ctx context.Context, reqCtx RequestContext, subject DataQuerySubject, refs []EvidenceRef) {
+	if !EvidenceEnabled() {
+		return
+	}
+	SubmitEvents(ctx, reqCtx, BuildDataQueryEvents(ctx, reqCtx, subject, refs))
+}
+
+func SubmitEvents(ctx context.Context, reqCtx RequestContext, events []Event) {
+	if len(events) == 0 {
+		return
+	}
+	ec, ok := contextFromRequest(ctx, reqCtx)
+	if !ok {
+		return
+	}
+	ingestURL := evidenceIngestURL()
+	if ingestURL == "" {
+		return
+	}
+
+	payload := batch{
+		ContractVersion: ContractVersion,
+		Trace: map[string]any{
+			"trace_id":         ec.traceID,
+			"traceparent":      ec.traceparent,
+			"bkn.request.id":   ec.requestID,
+			"business_domain":  ec.businessDomain,
+			"bkn.account.id":   ec.accountID,
+			"bkn.account.type": ec.accountType,
+		},
+		Events: events,
+	}
+
+	select {
+	case evidenceInFlight <- struct{}{}:
+	default:
+		return
+	}
+
+	timeout := evidenceTimeout()
+	go func() {
+		defer func() { <-evidenceInFlight }()
+		_ = postBatch(ingestURL, timeout, payload)
+	}()
+}
+
+func ResourceRefs(items []*interfaces.Resource) []EvidenceRef {
+	refs := make([]EvidenceRef, 0, len(items))
+	for _, item := range items {
+		if item == nil || strings.TrimSpace(item.ID) == "" {
+			continue
+		}
+		refs = append(refs, EvidenceRef{
+			RefID:          "resource:" + strings.TrimSpace(item.ID),
+			RefType:        RefTypeResource,
+			PartialReasons: []string{"resource_ref_unversioned"},
+			Summary: map[string]any{
+				"kind":                  "resource",
+				"id":                    strings.TrimSpace(item.ID),
+				"catalog_id":            strings.TrimSpace(item.CatalogID),
+				"category":              strings.TrimSpace(item.Category),
+				"status":                strings.TrimSpace(item.Status),
+				"schema_property_count": len(item.SchemaDefinition),
+				"has_row_count":         item.RowCount != nil,
+				"update_time":           item.UpdateTime,
+			},
+		})
+	}
+	return refs
+}
+
+func ResourceRowRefs(resource *interfaces.Resource, rows []map[string]any) []EvidenceRef {
+	if resource == nil || strings.TrimSpace(resource.ID) == "" {
+		return nil
+	}
+	refs := make([]EvidenceRef, 0, len(rows))
+	for i, row := range rows {
+		rowHash := HashValue(row)
+		refs = append(refs, EvidenceRef{
+			RefID:          fmt.Sprintf("resource_row:%s:%s", strings.TrimSpace(resource.ID), shortHash(rowHash)),
+			RefType:        RefTypeRow,
+			PartialReasons: []string{"row_ref_unversioned"},
+			Summary: map[string]any{
+				"kind":        "resource_row",
+				"resource_id": strings.TrimSpace(resource.ID),
+				"catalog_id":  strings.TrimSpace(resource.CatalogID),
+				"category":    strings.TrimSpace(resource.Category),
+				"row_index":   i,
+				"row_hash":    rowHash,
+			},
+		})
+	}
+	return refs
+}
+
+func normalizedRefs(refs []EvidenceRef) ([]map[string]any, string) {
+	evidenceRefs := make([]map[string]any, 0, len(refs))
+	refFingerprints := make([]string, 0, len(refs))
+	for _, ref := range refs {
+		refID := strings.TrimSpace(ref.RefID)
+		refType := strings.TrimSpace(ref.RefType)
+		if refID == "" || refType == "" {
+			continue
+		}
+		summaryHash := HashValue(ref.Summary)
+		partialReasons := ref.PartialReasons
+		if len(partialReasons) == 0 {
+			partialReasons = []string{refType + "_unversioned"}
+		}
+		evidenceRefs = append(evidenceRefs, map[string]any{
+			"ref_id":         refID,
+			"ref_type":       refType,
+			"source_system":  ModuleName,
+			"summary":        ref.Summary,
+			"summary_hash":   summaryHash,
+			"validity":       "observed",
+			"version_status": "unversioned",
+			"visibility":     "visible",
+			"partial_reason": partialReasons,
+		})
+		refFingerprints = append(refFingerprints, refType+":"+refID+":"+summaryHash)
+	}
+	sort.Strings(refFingerprints)
+	return evidenceRefs, HashValue(refFingerprints)
+}
+
+func postBatch(ingestURL string, timeout time.Duration, payload batch) error {
+	body, err := json.Marshal(payload)
+	if err != nil {
+		return err
+	}
+	postCtx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(postCtx, http.MethodPost, ingestURL, bytes.NewReader(body))
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := evidenceHTTPClient.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode >= http.StatusBadRequest {
+		return fmt.Errorf("HTTP %d", resp.StatusCode)
+	}
+	return nil
+}
+
+func evidenceIngestURL() string {
+	return strings.TrimSpace(os.Getenv(envEvidenceIngestURL))
+}
+
+func evidenceTimeout() time.Duration {
+	value := strings.TrimSpace(os.Getenv(envEvidenceIngestTimeoutMS))
+	if value == "" {
+		return 2 * time.Second
+	}
+	var ms int
+	if _, err := fmt.Sscanf(value, "%d", &ms); err != nil || ms <= 0 {
+		return 2 * time.Second
+	}
+	return time.Duration(ms) * time.Millisecond
+}
+
+func contextFromRequest(ctx context.Context, reqCtx RequestContext) (eventContext, bool) {
+	spanContext := trace.SpanContextFromContext(ctx)
+	if !spanContext.IsValid() {
+		return eventContext{}, false
+	}
+	requestID := strings.TrimSpace(reqCtx.RequestID)
+	accountID := strings.TrimSpace(reqCtx.AccountID)
+	accountType := strings.TrimSpace(reqCtx.AccountType)
+	if requestID == "" || accountID == "" || accountType == "" {
+		return eventContext{}, false
+	}
+	flags := "00"
+	if spanContext.TraceFlags().IsSampled() {
+		flags = "01"
+	}
+	businessDomain := strings.TrimSpace(reqCtx.BusinessDomain)
+	if businessDomain == "" {
+		businessDomain = accountID
+	}
+	return eventContext{
+		traceID:        spanContext.TraceID().String(),
+		spanID:         spanContext.SpanID().String(),
+		traceparent:    fmt.Sprintf("00-%s-%s-%s", spanContext.TraceID().String(), spanContext.SpanID().String(), flags),
+		requestID:      requestID,
+		accountID:      accountID,
+		accountType:    accountType,
+		businessDomain: businessDomain,
+	}, true
+}
+
+func buildEvent(ec eventContext, eventType, operationName string, payload map[string]any) Event {
+	now := time.Now().UTC().Format(time.RFC3339Nano)
+	return Event{
+		"event_id":                 "evt_" + randomHex(16),
+		"event_type":               eventType,
+		"bkn.trace.schema.version": ContractVersion,
+		"observed_at":              now,
+		"emitted_at":               now,
+		"producer_module":          ModuleName,
+		"trace_id":                 ec.traceID,
+		"span_id":                  ec.spanID,
+		"bkn.request.id":           ec.requestID,
+		"bkn.operation.name":       operationName,
+		"payload":                  payload,
+	}
+}
+
+func randomHex(length int) string {
+	if length <= 0 {
+		return ""
+	}
+	buf := make([]byte, (length+1)/2)
+	if _, err := rand.Read(buf); err != nil {
+		sum := sha256.Sum256([]byte(time.Now().UTC().Format(time.RFC3339Nano)))
+		return hex.EncodeToString(sum[:])[:length]
+	}
+	return hex.EncodeToString(buf)[:length]
+}
+
+func shortHash(hash string) string {
+	hash = strings.TrimPrefix(strings.TrimSpace(hash), "sha256:")
+	if len(hash) < 16 {
+		return hash
+	}
+	return hash[:16]
+}

--- a/adp/vega/vega-backend/server/common/bkntrace/evidence_test.go
+++ b/adp/vega/vega-backend/server/common/bkntrace/evidence_test.go
@@ -1,0 +1,168 @@
+// Copyright openbkn.ai
+// Copyright The kweaver.ai Authors.
+//
+// Licensed under the Apache License, Version 2.0.
+// See the LICENSE file in the project root for details.
+
+package bkntrace
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"go.opentelemetry.io/otel/trace"
+	"vega-backend/interfaces"
+)
+
+func testTraceContext() context.Context {
+	traceID := trace.TraceID{0x73, 0x22, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1}
+	spanID := trace.SpanID{0x73, 0x22, 0, 0, 0, 0, 0, 1}
+	spanContext := trace.NewSpanContext(trace.SpanContextConfig{
+		TraceID:    traceID,
+		SpanID:     spanID,
+		TraceFlags: trace.FlagsSampled,
+	})
+	return trace.ContextWithSpanContext(context.Background(), spanContext)
+}
+
+func testRequestContext() RequestContext {
+	return RequestContext{
+		RequestID:      "req_vega_data_0001",
+		AccountID:      "acct_demo",
+		AccountType:    "user",
+		BusinessDomain: "domain_demo",
+	}
+}
+
+func TestBuildDataQueryEventsUsesResourceAndRowRefsOnly(t *testing.T) {
+	resource := &interfaces.Resource{
+		ID:               "res_customer_table",
+		CatalogID:        "cat_prod",
+		Name:             "customer_sensitive_table",
+		Category:         interfaces.ResourceCategoryTable,
+		SourceIdentifier: "prod.customer_phone_table",
+		SchemaDefinition: []*interfaces.Property{
+			{Name: "phone", DisplayName: "Phone Number", Description: "Sensitive"},
+		},
+		UpdateTime: 123,
+	}
+	rows := []map[string]any{
+		{
+			"customer_id": "C-10086",
+			"name":        "Sensitive Customer",
+			"phone":       "13800000000",
+		},
+	}
+
+	refs := append(ResourceRefs([]*interfaces.Resource{resource}), ResourceRowRefs(resource, rows)...)
+	events := BuildDataQueryEvents(testTraceContext(), testRequestContext(), DataQuerySubject{
+		Operation:     "data.resource.query",
+		ResourceID:    resource.ID,
+		CatalogID:     resource.CatalogID,
+		QueryHash:     HashValue(map[string]any{"filter": "redacted"}),
+		ReturnedCount: len(rows),
+		TotalCount:    1,
+	}, refs)
+
+	assertSafeEvents(t, events, []string{
+		`"event_type":"claim.created"`,
+		`"event_type":"evidence.refs.created"`,
+		`"ref_type":"resource_ref"`,
+		`"ref_type":"row_ref"`,
+		`"source_system":"vega-data"`,
+		`"row_hash":"sha256:`,
+		`"query_hash":"sha256:`,
+		`"evidence_refs_hash":"sha256:`,
+	}, []string{
+		"customer_sensitive_table",
+		"prod.customer_phone_table",
+		"C-10086",
+		"Sensitive Customer",
+		"13800000000",
+		"customer_id",
+		"phone",
+		"Phone Number",
+		"Sensitive",
+	})
+}
+
+func TestBuildDataQueryEventsDifferentiatesSameCountDifferentRows(t *testing.T) {
+	resource := &interfaces.Resource{ID: "res_customer_table", CatalogID: "cat_prod"}
+	subject := DataQuerySubject{
+		Operation:     "data.resource.query",
+		ResourceID:    resource.ID,
+		CatalogID:     resource.CatalogID,
+		QueryHash:     HashValue("same-query"),
+		ReturnedCount: 1,
+		TotalCount:    1,
+	}
+	first := BuildDataQueryEvents(testTraceContext(), testRequestContext(), subject, ResourceRowRefs(resource, []map[string]any{{"id": "row_1"}}))
+	second := BuildDataQueryEvents(testTraceContext(), testRequestContext(), subject, ResourceRowRefs(resource, []map[string]any{{"id": "row_2"}}))
+
+	if claimPayload(t, first)["claim_id"] == claimPayload(t, second)["claim_id"] {
+		t.Fatalf("claim_id should differ for same-count different row refs")
+	}
+	if claimPayload(t, first)["claim_hash"] == claimPayload(t, second)["claim_hash"] {
+		t.Fatalf("claim_hash should differ for same-count different row refs")
+	}
+}
+
+func TestBuildDataQueryEventsRequiresTraceAndRequestContext(t *testing.T) {
+	events := BuildDataQueryEvents(context.Background(), testRequestContext(), DataQuerySubject{
+		Operation:     "data.resource.query",
+		ResourceID:    "res_customer_table",
+		CatalogID:     "cat_prod",
+		QueryHash:     HashValue("query"),
+		ReturnedCount: 1,
+	}, []EvidenceRef{{RefID: "row:res:demo", RefType: RefTypeRow}})
+	if len(events) != 0 {
+		t.Fatalf("len(events)=%d, want 0 without trace context", len(events))
+	}
+
+	events = BuildDataQueryEvents(testTraceContext(), RequestContext{}, DataQuerySubject{
+		Operation:     "data.resource.query",
+		ResourceID:    "res_customer_table",
+		CatalogID:     "cat_prod",
+		QueryHash:     HashValue("query"),
+		ReturnedCount: 1,
+	}, []EvidenceRef{{RefID: "row:res:demo", RefType: RefTypeRow}})
+	if len(events) != 0 {
+		t.Fatalf("len(events)=%d, want 0 without request context", len(events))
+	}
+}
+
+func claimPayload(t *testing.T, events []Event) map[string]any {
+	t.Helper()
+	if len(events) == 0 {
+		t.Fatalf("events are empty")
+	}
+	payload, ok := events[0]["payload"].(map[string]any)
+	if !ok {
+		t.Fatalf("claim payload missing or invalid: %#v", events[0]["payload"])
+	}
+	return payload
+}
+
+func assertSafeEvents(t *testing.T, events []Event, want []string, forbidden []string) {
+	t.Helper()
+	if len(events) != 2 {
+		t.Fatalf("len(events)=%d, want 2", len(events))
+	}
+	raw, err := json.Marshal(events)
+	if err != nil {
+		t.Fatalf("marshal events: %v", err)
+	}
+	text := string(raw)
+	for _, item := range want {
+		if !strings.Contains(text, item) {
+			t.Fatalf("missing %q in events: %s", item, text)
+		}
+	}
+	for _, item := range forbidden {
+		if strings.Contains(text, item) {
+			t.Fatalf("event leaked raw content %q: %s", item, text)
+		}
+	}
+}

--- a/adp/vega/vega-backend/server/driveradapters/bkn_trace_disabled_test.go
+++ b/adp/vega/vega-backend/server/driveradapters/bkn_trace_disabled_test.go
@@ -1,0 +1,32 @@
+// Copyright openbkn.ai
+// Copyright The kweaver.ai Authors.
+//
+// Licensed under the Apache License, Version 2.0.
+// See the LICENSE file in the project root for details.
+
+package driveradapters
+
+import (
+	"context"
+	"os"
+	"testing"
+
+	"vega-backend/interfaces"
+)
+
+func TestVegaEvidenceEmittersReturnBeforeWorkWhenDisabled(t *testing.T) {
+	t.Setenv("BKN_TRACE_EVIDENCE_INGEST_URL", "")
+	_ = os.Unsetenv("BKN_TRACE_EVIDENCE_INGEST_URL")
+
+	resource := &interfaces.Resource{
+		ID:        "res_customer_table",
+		CatalogID: "cat_prod",
+		Category:  interfaces.ResourceCategoryTable,
+	}
+
+	emitResourceReadEvidence(nil, context.Background(), "data.catalog.get", []*interfaces.Resource{resource}, 1, map[string]any{"unsafe": "would_hash"})
+	emitResourceDataEvidence(nil, context.Background(), resource, nil, &interfaces.ResourceDataQueryResult{
+		Entries: []map[string]any{{"customer_id": "C-10086"}},
+		Paging:  &interfaces.PagingResponse{},
+	})
+}

--- a/adp/vega/vega-backend/server/driveradapters/bkn_trace_events.go
+++ b/adp/vega/vega-backend/server/driveradapters/bkn_trace_events.go
@@ -61,9 +61,19 @@ func emitResourceDataEvidence(c *gin.Context, ctx context.Context, resource *int
 		QueryHash:     bkntrace.HashValue(safeResourceDataQueryShape(params)),
 		ReturnedCount: len(result.Entries),
 		TotalCount:    result.TotalCount,
-		Truncated:     result.Paging != nil,
+		Truncated:     resourceDataEvidenceTruncated(result),
 	}
 	bkntrace.EmitDataQueryEvents(ctx, vegaTraceRequestContext(c, ctx), subject, refs)
+}
+
+func resourceDataEvidenceTruncated(result *interfaces.ResourceDataQueryResult) bool {
+	if result == nil {
+		return false
+	}
+	if result.Paging != nil && result.Paging.NextCursor != nil {
+		return true
+	}
+	return result.TotalCount > 0 && int64(len(result.Entries)) < result.TotalCount
 }
 
 func safeResourceListQueryShape(params interfaces.ResourcesQueryParams) map[string]any {

--- a/adp/vega/vega-backend/server/driveradapters/bkn_trace_events.go
+++ b/adp/vega/vega-backend/server/driveradapters/bkn_trace_events.go
@@ -1,0 +1,118 @@
+// Copyright openbkn.ai
+// Copyright The kweaver.ai Authors.
+//
+// Licensed under the Apache License, Version 2.0.
+// See the LICENSE file in the project root for details.
+
+package driveradapters
+
+import (
+	"context"
+	"strings"
+
+	"github.com/gin-gonic/gin"
+
+	"vega-backend/common"
+	"vega-backend/common/bkntrace"
+	"vega-backend/interfaces"
+)
+
+func vegaTraceRequestContext(c *gin.Context, ctx context.Context) bkntrace.RequestContext {
+	traceContext, _ := common.GetTraceContextFromCtx(ctx)
+	accountInfo, _ := ctx.Value(interfaces.ACCOUNT_INFO_KEY).(interfaces.AccountInfo)
+	businessDomain := strings.TrimSpace(c.GetHeader("x-business-domain"))
+	if businessDomain == "" {
+		businessDomain = strings.TrimSpace(traceContext.Baggage["business_domain"])
+	}
+	return bkntrace.RequestContext{
+		RequestID:      traceContext.RequestID,
+		AccountID:      accountInfo.ID,
+		AccountType:    accountInfo.Type,
+		BusinessDomain: businessDomain,
+	}
+}
+
+func emitResourceReadEvidence(c *gin.Context, ctx context.Context, operation string, resources []*interfaces.Resource, total int64, queryShape any) {
+	if len(resources) == 0 {
+		return
+	}
+	subject := bkntrace.DataQuerySubject{
+		Operation:     operation,
+		QueryHash:     bkntrace.HashValue(queryShape),
+		ReturnedCount: len(resources),
+		TotalCount:    total,
+	}
+	if len(resources) == 1 && resources[0] != nil {
+		subject.ResourceID = resources[0].ID
+		subject.CatalogID = resources[0].CatalogID
+	}
+	bkntrace.EmitDataQueryEvents(ctx, vegaTraceRequestContext(c, ctx), subject, bkntrace.ResourceRefs(resources))
+}
+
+func emitResourceDataEvidence(c *gin.Context, ctx context.Context, resource *interfaces.Resource, params *interfaces.ResourceDataQueryParams, result *interfaces.ResourceDataQueryResult) {
+	if resource == nil || result == nil {
+		return
+	}
+	refs := append(bkntrace.ResourceRefs([]*interfaces.Resource{resource}), bkntrace.ResourceRowRefs(resource, result.Entries)...)
+	subject := bkntrace.DataQuerySubject{
+		Operation:     "data.resource.query",
+		ResourceID:    resource.ID,
+		CatalogID:     resource.CatalogID,
+		QueryHash:     bkntrace.HashValue(safeResourceDataQueryShape(params)),
+		ReturnedCount: len(result.Entries),
+		TotalCount:    result.TotalCount,
+		Truncated:     result.Paging != nil,
+	}
+	bkntrace.EmitDataQueryEvents(ctx, vegaTraceRequestContext(c, ctx), subject, refs)
+}
+
+func safeResourceListQueryShape(params interfaces.ResourcesQueryParams) map[string]any {
+	return map[string]any{
+		"catalog_id":              params.CatalogID,
+		"category":                params.Category,
+		"status":                  params.Status,
+		"database":                params.Database,
+		"offset":                  params.Offset,
+		"limit":                   params.Limit,
+		"sort":                    params.Sort,
+		"direction":               params.Direction,
+		"extension_keys_hash":     bkntrace.HashValue(params.ExtensionKeys),
+		"extension_values_hash":   bkntrace.HashValue(params.ExtensionValues),
+		"include_extensions":      params.IncludeExtensions,
+		"include_extension_keys":  params.IncludeExtensionKeys,
+		"name_filter_present":     strings.TrimSpace(params.Name) != "",
+		"catalog_filter_present":  strings.TrimSpace(params.CatalogID) != "",
+		"database_filter_present": strings.TrimSpace(params.Database) != "",
+	}
+}
+
+func safeResourceIDsQueryShape(ids []string, ignoreMissing bool) map[string]any {
+	return map[string]any{
+		"ids_hash":       bkntrace.HashValue(ids),
+		"id_count":       len(ids),
+		"ignore_missing": ignoreMissing,
+	}
+}
+
+func safeResourceDataQueryShape(params *interfaces.ResourceDataQueryParams) map[string]any {
+	if params == nil {
+		return nil
+	}
+	return map[string]any{
+		"offset":                params.Offset,
+		"limit":                 params.Limit,
+		"paging_hash":           bkntrace.HashValue(params.Paging),
+		"sort_hash":             bkntrace.HashValue(params.Sort),
+		"filter_hash":           bkntrace.HashValue(params.FilterCondition),
+		"output_fields_hash":    bkntrace.HashValue(params.OutputFields),
+		"need_total":            params.NeedTotal,
+		"format":                params.Format,
+		"search_after_hash":     bkntrace.HashValue(params.SearchAfter),
+		"query_type":            params.QueryType,
+		"aggregation_hash":      bkntrace.HashValue(params.Aggregation),
+		"group_by_hash":         bkntrace.HashValue(params.GroupBy),
+		"having_hash":           bkntrace.HashValue(params.Having),
+		"has_filter_condition":  params.FilterCondition != nil,
+		"has_actual_filter_cfg": params.FilterCondCfg != nil,
+	}
+}

--- a/adp/vega/vega-backend/server/driveradapters/bkn_trace_events.go
+++ b/adp/vega/vega-backend/server/driveradapters/bkn_trace_events.go
@@ -33,7 +33,7 @@ func vegaTraceRequestContext(c *gin.Context, ctx context.Context) bkntrace.Reque
 }
 
 func emitResourceReadEvidence(c *gin.Context, ctx context.Context, operation string, resources []*interfaces.Resource, total int64, queryShape any) {
-	if len(resources) == 0 {
+	if !bkntrace.EvidenceEnabled() || len(resources) == 0 {
 		return
 	}
 	subject := bkntrace.DataQuerySubject{
@@ -50,7 +50,7 @@ func emitResourceReadEvidence(c *gin.Context, ctx context.Context, operation str
 }
 
 func emitResourceDataEvidence(c *gin.Context, ctx context.Context, resource *interfaces.Resource, params *interfaces.ResourceDataQueryParams, result *interfaces.ResourceDataQueryResult) {
-	if resource == nil || result == nil {
+	if !bkntrace.EvidenceEnabled() || resource == nil || result == nil {
 		return
 	}
 	refs := append(bkntrace.ResourceRefs([]*interfaces.Resource{resource}), bkntrace.ResourceRowRefs(resource, result.Entries)...)

--- a/adp/vega/vega-backend/server/driveradapters/bkn_trace_events_test.go
+++ b/adp/vega/vega-backend/server/driveradapters/bkn_trace_events_test.go
@@ -1,0 +1,38 @@
+// Copyright openbkn.ai
+// Copyright The kweaver.ai Authors.
+//
+// Licensed under the Apache License, Version 2.0.
+// See the LICENSE file in the project root for details.
+
+package driveradapters
+
+import (
+	"testing"
+
+	"vega-backend/interfaces"
+)
+
+func TestResourceDataEvidenceTruncatedUsesCursorOrTotal(t *testing.T) {
+	if resourceDataEvidenceTruncated(&interfaces.ResourceDataQueryResult{
+		Entries: []map[string]any{{"id": "row_1"}},
+		Paging:  &interfaces.PagingResponse{},
+	}) {
+		t.Fatalf("empty PagingResponse must not mark evidence as truncated")
+	}
+
+	nextCursor := "cursor_1"
+	if !resourceDataEvidenceTruncated(&interfaces.ResourceDataQueryResult{
+		Entries: []map[string]any{{"id": "row_1"}},
+		Paging:  &interfaces.PagingResponse{NextCursor: &nextCursor},
+	}) {
+		t.Fatalf("non-empty NextCursor must mark evidence as truncated")
+	}
+
+	if !resourceDataEvidenceTruncated(&interfaces.ResourceDataQueryResult{
+		Entries:    []map[string]any{{"id": "row_1"}},
+		TotalCount: 2,
+		Paging:     &interfaces.PagingResponse{},
+	}) {
+		t.Fatalf("returned rows less than total count must mark evidence as truncated")
+	}
+}

--- a/adp/vega/vega-backend/server/driveradapters/resource_data_handler.go
+++ b/adp/vega/vega-backend/server/driveradapters/resource_data_handler.go
@@ -157,6 +157,7 @@ func (r *restHandler) queryResourceData(c *gin.Context, ctx context.Context, spa
 
 	logger.Debug("Handler queryResourceData Success")
 	oteltrace.AddHttpAttrs4Ok(span, http.StatusOK)
+	emitResourceDataEvidence(c, ctx, resource, &params, result)
 	rest.ReplyOkWithHeaders(c, http.StatusOK, resultData, map[string]string{
 		interfaces.X_REQUEST_TOOK: time.Since(start).String(),
 	})

--- a/adp/vega/vega-backend/server/driveradapters/resource_handler.go
+++ b/adp/vega/vega-backend/server/driveradapters/resource_handler.go
@@ -123,6 +123,7 @@ func (r *restHandler) listResources(c *gin.Context, visitor hydra.Visitor) {
 
 	logger.Debug("Handler ListResources Success")
 	oteltrace.AddHttpAttrs4Ok(span, http.StatusOK)
+	emitResourceReadEvidence(c, ctx, "data.catalog.get", entries, total, safeResourceListQueryShape(params))
 	rest.ReplyOK(c, http.StatusOK, result)
 }
 
@@ -309,6 +310,7 @@ func (r *restHandler) getResources(c *gin.Context, visitor hydra.Visitor) {
 
 	logger.Debug("Handler GetResource Success")
 	oteltrace.AddHttpAttrs4Ok(span, http.StatusOK)
+	emitResourceReadEvidence(c, ctx, "data.catalog.get", resources, int64(len(resources)), safeResourceIDsQueryShape(ids, ignoreMissing))
 	rest.ReplyOK(c, http.StatusOK, result)
 }
 


### PR DESCRIPTION
## Summary
- add phase-2 BKN Trace evidence builders for ontology-query and vega-backend
- emit claim.created and evidence.refs.created for ontology object/subgraph/metric data reads
- emit resource_ref and row_ref evidence for Vega resource metadata and resource data queries
- update module TRACE contracts and add phase-2 positive fixtures

## Safety
- evidence payloads use hashes, counts, IDs, and controlled refs only
- raw rows, filter values, output field names, metric labels, SQL, and resource source identifiers are not emitted
- evidence emission is async and fail-open behind BKN_TRACE_EVIDENCE_INGEST_URL

## Verification
- env GOCACHE=/tmp/openbkn-go-cache I18N_MODE_UT=true go test ./common/bkntrace ./driveradapters  # ontology-query/server
- env GOCACHE=/tmp/openbkn-go-cache go test ./common/bkntrace ./driveradapters  # vega-backend/server
- python3 /Users/leecky/openbkn/bkn-docs/docs/foundry/bkn-trace/validation/validate_phase2_fixture.py adp/bkn/ontology-query/fixtures/bkn-trace/phase2 --pretty
- python3 /Users/leecky/openbkn/bkn-docs/docs/foundry/bkn-trace/validation/validate_phase2_fixture.py adp/vega/vega-backend/fixtures/bkn-trace/phase2 --pretty
- git diff --check

## Follow-ups
- snapshot_ref and immutable evidence artifact storage are still follow-up work
- failure-path evidence events and storage/indexing backend are not included in this PR