### PR TITLE
feat(bkn-trace): query normalized evidence chains

### DIFF
--- a/bkn-trace/agent-observability/README.md
+++ b/bkn-trace/agent-observability/README.md
@@ -6,6 +6,8 @@
 - Trace 原始 DSL 查询接口：`POST /api/agent-observability/v1/traces/_search`
 - Conversation 维度包装查询接口：`GET /api/agent-observability/v1/traces/by-conversation?conversation_id=...`
 - Evidence 事件接收接口：`POST /api/agent-observability/v1/evidence/events`
+- Evidence Chain 查询接口：`GET /api/agent-observability/v1/traces/{trace_id}/evidence-chain`
+- Request 维度 Evidence Chain 查询接口：`GET /api/agent-observability/v1/traces/by-request?request_id=...`
 - OpenSearch 查询客户端
 - 阶段二 Evidence ingestion 校验、归一化和可替换存储接口
 - Swagger 文档生成
@@ -27,7 +29,36 @@ make test
 GOCACHE=/tmp/openbkn-go-build-cache GOMODCACHE=/tmp/openbkn-go-mod-cache go test ./...
 ```
 
-阶段二 evidence ingestion 接口接受 `bkn.trace.schema.version=2.0.0` 的事件批次，包含 `trace` 与 `events`。当前版本先完成 contract 校验、敏感 payload 拒绝、归一化计数和内存 repository 写入；后续 PR 会把 repository 替换为持久化 evidence index。
+阶段二 evidence ingestion 接口接受 `bkn.trace.schema.version=2.0.0` 的事件批次，包含 `trace` 与 `events`。当前版本先完成 contract 校验、敏感 payload 拒绝、归一化计数、内存 repository 写入和最小 Evidence Chain 查询；后续 PR 会把 repository 替换为持久化 evidence index。
+
+Evidence Chain 查询返回稳定 envelope：
+
+```json
+{
+  "trace_id": "9c0d...",
+  "bkn.request.id": "req_handler_001",
+  "partial": false,
+  "partial_reason": [],
+  "visibility_summary": {
+    "authorized_ref_count": 2,
+    "redacted_ref_count": 0,
+    "hidden_ref_count": 0,
+    "omitted_ref_count": 0,
+    "unresolved_ref_count": 0
+  },
+  "page": {
+    "next_cursor": null,
+    "node_count": 3,
+    "edge_count": 2,
+    "truncated": false
+  },
+  "data": {
+    "claims": [],
+    "evidence_refs": [],
+    "business_refs": []
+  }
+}
+```
 
 生成 Swagger 文档：
 

--- a/bkn-trace/agent-observability/README.md
+++ b/bkn-trace/agent-observability/README.md
@@ -31,6 +31,26 @@ GOCACHE=/tmp/openbkn-go-build-cache GOMODCACHE=/tmp/openbkn-go-mod-cache go test
 
 阶段二 evidence ingestion 接口接受 `bkn.trace.schema.version=2.0.0` 的事件批次，包含 `trace` 与 `events`。当前版本先完成 contract 校验、敏感 payload 拒绝、归一化计数、内存 repository 写入和最小 Evidence Chain 查询；后续 PR 会把 repository 替换为持久化 evidence index。
 
+### Evidence 写入安全边界
+
+`POST /api/agent-observability/v1/evidence/events` 是写接口，生产环境必须通过平台网关鉴权保护，或配置服务内最小 ingest token：
+
+```bash
+kubectl create secret generic bkn-trace-evidence-ingest \
+  --from-literal=token='<strong-token>' \
+  -n observability
+```
+
+```bash
+helm upgrade --install agent-observability charts/agent-observability \
+  --set evidence.ingestAuth.existingSecret=bkn-trace-evidence-ingest \
+  -n observability
+```
+
+启用后，写入方需要携带 `Authorization: Bearer <strong-token>` 或 `X-BKN-Trace-Ingest-Token: <strong-token>`。未配置 `BKN_TRACE_EVIDENCE_INGEST_TOKEN` 时保持当前兼容行为，依赖平台网关/网络边界保护。
+
+当前阶段的 Evidence Chain 查询只依据事件生产方声明的 `visibility` 做响应过滤，不按调用者身份做细粒度可见性裁决。resolver-backed authorization、按账号/租户的 evidence ref 授权与审计将在后续持久化 evidence index 阶段接入。
+
 Evidence Chain 查询返回稳定 envelope：
 
 ```json

--- a/bkn-trace/agent-observability/charts/agent-observability/templates/deployment.yaml
+++ b/bkn-trace/agent-observability/charts/agent-observability/templates/deployment.yaml
@@ -47,6 +47,13 @@ spec:
             - name: OPENSEARCH_AUTH_PASSWORD
               value: {{ .Values.opensearch.auth.password | quote }}
             {{- end }}
+            {{- if .Values.evidence.ingestAuth.existingSecret }}
+            - name: BKN_TRACE_EVIDENCE_INGEST_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.evidence.ingestAuth.existingSecret | quote }}
+                  key: {{ .Values.evidence.ingestAuth.secretKey | quote }}
+            {{- end }}
           livenessProbe:
             tcpSocket:
               port: http

--- a/bkn-trace/agent-observability/charts/agent-observability/values.yaml
+++ b/bkn-trace/agent-observability/charts/agent-observability/values.yaml
@@ -32,6 +32,11 @@ ingress:
     - /api/agent-observability/v1
   tls: []
 
+evidence:
+  ingestAuth:
+    existingSecret: ""
+    secretKey: token
+
 resources:
   limits:
     cpu: 500m

--- a/bkn-trace/agent-observability/src/boot/bootstrap.go
+++ b/bkn-trace/agent-observability/src/boot/bootstrap.go
@@ -45,6 +45,8 @@ func NewApp() *App {
 	mux := http.NewServeMux()
 	mux.HandleFunc(APIBasePath+"/traces/_search", traceHandler.SearchTraces)
 	mux.HandleFunc(APIBasePath+"/traces/by-conversation", traceHandler.SearchTracesByConversationID)
+	mux.HandleFunc(APIBasePath+"/traces/by-request", evidenceHandler.GetEvidenceChainByRequestID)
+	mux.HandleFunc(APIBasePath+"/traces/", evidenceHandler.GetEvidenceChainByTraceID)
 	mux.HandleFunc(APIBasePath+"/evidence/events", evidenceHandler.IngestEvidenceEvents)
 	mux.Handle(APIBasePath+"/swagger/", httpSwagger.Handler(
 		httpSwagger.URL(APIBasePath+"/swagger/doc.json"),

--- a/bkn-trace/agent-observability/src/domain/service/evidencesvc/service.go
+++ b/bkn-trace/agent-observability/src/domain/service/evidencesvc/service.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"regexp"
+	"sort"
 	"strconv"
 	"strings"
 
@@ -115,6 +116,143 @@ func (s *Service) Ingest(ctx context.Context, body []byte) (evidencevo.IngestRes
 		EvidenceRefCount: normalized.EvidenceRefCount,
 		BusinessRefCount: normalized.BusinessRefCount,
 	}, nil, nil
+}
+
+func (s *Service) GetEvidenceChainByTraceID(ctx context.Context, traceID string) (evidencevo.EvidenceChainResponse, bool, error) {
+	traces, err := s.store.GetEvidenceByTraceID(ctx, strings.TrimSpace(traceID))
+	if err != nil {
+		return evidencevo.EvidenceChainResponse{}, false, err
+	}
+	if len(traces) == 0 {
+		return evidencevo.EvidenceChainResponse{}, false, nil
+	}
+	return buildEvidenceChain(traces), true, nil
+}
+
+func (s *Service) GetEvidenceChainByRequestID(ctx context.Context, requestID string) (evidencevo.EvidenceChainResponse, bool, error) {
+	traces, err := s.store.GetEvidenceByRequestID(ctx, strings.TrimSpace(requestID))
+	if err != nil {
+		return evidencevo.EvidenceChainResponse{}, false, err
+	}
+	if len(traces) == 0 {
+		return evidencevo.EvidenceChainResponse{}, false, nil
+	}
+	return buildEvidenceChain(traces), true, nil
+}
+
+func buildEvidenceChain(traces []evidencevo.NormalizedTrace) evidencevo.EvidenceChainResponse {
+	response := evidencevo.EvidenceChainResponse{
+		TraceID:   traces[0].TraceID,
+		RequestID: traces[0].RequestID,
+	}
+	knownClaims := map[string]struct{}{}
+	claimRefs := map[string]struct{}{}
+	partialReasons := map[string]struct{}{}
+
+	for _, trace := range traces {
+		for _, event := range trace.Events {
+			switch event.EventType {
+			case "claim.created":
+				if visible(event.Payload) {
+					response.Data.Claims = append(response.Data.Claims, cloneMap(event.Payload))
+				} else {
+					countVisibility(event.Payload, &response.VisibilitySummary)
+				}
+				if claimID, ok := stringField(event.Payload, "claim_id"); ok && claimID != "" {
+					knownClaims[claimID] = struct{}{}
+				}
+			case "evidence.refs.created":
+				claimID, _ := stringField(event.Payload, "claim_id")
+				if claimID != "" {
+					claimRefs[claimID] = struct{}{}
+				}
+				response.Data.EvidenceRefs = appendVisibleRefs(response.Data.EvidenceRefs, arrayField(event.Payload, "evidence_refs"), &response.VisibilitySummary)
+			case "business.refs.resolved":
+				claimID, _ := stringField(event.Payload, "claim_id")
+				if claimID != "" {
+					claimRefs[claimID] = struct{}{}
+				}
+				response.Data.BusinessRefs = appendVisibleRefs(response.Data.BusinessRefs, arrayField(event.Payload, "business_refs"), &response.VisibilitySummary)
+			}
+		}
+	}
+
+	if len(knownClaims) == 0 {
+		partialReasons["missing_claim"] = struct{}{}
+	}
+	for claimID := range claimRefs {
+		if _, ok := knownClaims[claimID]; !ok {
+			partialReasons["missing_claim"] = struct{}{}
+		}
+	}
+	for _, claim := range response.Data.Claims {
+		if _, ok := claim["version_status"].(string); !ok {
+			partialReasons["version_status_missing"] = struct{}{}
+		}
+	}
+
+	response.PartialReasons = sortedKeys(partialReasons)
+	response.Partial = len(response.PartialReasons) > 0
+	response.Page.NodeCount = len(response.Data.Claims) + len(response.Data.EvidenceRefs) + len(response.Data.BusinessRefs)
+	response.Page.EdgeCount = len(response.Data.EvidenceRefs) + len(response.Data.BusinessRefs)
+	return response
+}
+
+func appendVisibleRefs(target []map[string]any, refs []any, summary *evidencevo.VisibilitySummary) []map[string]any {
+	for _, item := range refs {
+		ref, ok := item.(map[string]any)
+		if !ok {
+			continue
+		}
+		if visible(ref) {
+			target = append(target, cloneMap(ref))
+			summary.AuthorizedRefCount++
+			continue
+		}
+		countVisibility(ref, summary)
+	}
+	return target
+}
+
+func visible(item map[string]any) bool {
+	visibility, _ := item["visibility"].(string)
+	return visibility == "" || visibility == "visible"
+}
+
+func countVisibility(item map[string]any, summary *evidencevo.VisibilitySummary) {
+	visibility, _ := item["visibility"].(string)
+	switch visibility {
+	case "redacted":
+		summary.RedactedRefCount++
+	case "hidden":
+		summary.HiddenRefCount++
+	case "omitted":
+		summary.OmittedRefCount++
+	case "unresolved":
+		summary.UnresolvedRefCount++
+	default:
+		summary.OmittedRefCount++
+	}
+}
+
+func cloneMap(value map[string]any) map[string]any {
+	clone := make(map[string]any, len(value))
+	for key, item := range value {
+		clone[key] = item
+	}
+	return clone
+}
+
+func sortedKeys(values map[string]struct{}) []string {
+	if len(values) == 0 {
+		return nil
+	}
+	keys := make([]string, 0, len(values))
+	for key := range values {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	return keys
 }
 
 func normalize(req evidencevo.IngestRequest, errors *evidencevo.ValidationErrors) evidencevo.NormalizedTrace {

--- a/bkn-trace/agent-observability/src/domain/service/evidencesvc/service_test.go
+++ b/bkn-trace/agent-observability/src/domain/service/evidencesvc/service_test.go
@@ -9,12 +9,33 @@ import (
 )
 
 type fakeStore struct {
-	calls int
+	calls  int
+	traces []evidencevo.NormalizedTrace
 }
 
 func (s *fakeStore) StoreEvidence(_ context.Context, _ evidencevo.NormalizedTrace) error {
 	s.calls++
 	return nil
+}
+
+func (s *fakeStore) GetEvidenceByTraceID(_ context.Context, traceID string) ([]evidencevo.NormalizedTrace, error) {
+	var result []evidencevo.NormalizedTrace
+	for _, trace := range s.traces {
+		if trace.TraceID == traceID {
+			result = append(result, trace)
+		}
+	}
+	return result, nil
+}
+
+func (s *fakeStore) GetEvidenceByRequestID(_ context.Context, requestID string) ([]evidencevo.NormalizedTrace, error) {
+	var result []evidencevo.NormalizedTrace
+	for _, trace := range s.traces {
+		if trace.RequestID == requestID {
+			result = append(result, trace)
+		}
+	}
+	return result, nil
 }
 
 func TestIngestAcceptsPhaseTwoEvidenceBatch(t *testing.T) {
@@ -200,6 +221,77 @@ func TestIngestAllowsReferenceLikeStringsAndNonSensitiveKeySubstrings(t *testing
 	}
 }
 
+func TestGetEvidenceChainByTraceIDFiltersHiddenRefsAndReturnsEnvelope(t *testing.T) {
+	store := &fakeStore{traces: []evidencevo.NormalizedTrace{queryTrace("trace_query_001", "req_query_001")}}
+	service := New(store)
+
+	response, found, err := service.GetEvidenceChainByTraceID(context.Background(), "trace_query_001")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !found {
+		t.Fatal("expected evidence chain to be found")
+	}
+	if response.TraceID != "trace_query_001" || response.RequestID != "req_query_001" {
+		t.Fatalf("unexpected identity: %+v", response)
+	}
+	if response.Partial {
+		t.Fatalf("expected complete visible response, got partial: %+v", response.PartialReasons)
+	}
+	if response.VisibilitySummary.HiddenRefCount != 1 || response.VisibilitySummary.AuthorizedRefCount != 2 {
+		t.Fatalf("unexpected visibility summary: %+v", response.VisibilitySummary)
+	}
+	if response.Page.NodeCount != 3 || response.Page.EdgeCount != 2 || response.Page.Truncated {
+		t.Fatalf("unexpected page: %+v", response.Page)
+	}
+	if len(response.Data.Claims) != 1 || len(response.Data.EvidenceRefs) != 1 || len(response.Data.BusinessRefs) != 1 {
+		t.Fatalf("unexpected data counts: %+v", response.Data)
+	}
+	if response.Data.EvidenceRefs[0]["ref_id"] != "row:visible" {
+		t.Fatalf("hidden evidence ref leaked or visible ref missing: %+v", response.Data.EvidenceRefs)
+	}
+}
+
+func TestGetEvidenceChainByRequestIDReturnsMissingClaimPartial(t *testing.T) {
+	store := &fakeStore{traces: []evidencevo.NormalizedTrace{{
+		TraceID:   "trace_no_claim",
+		RequestID: "req_no_claim",
+		Events: []evidencevo.EvidenceEvent{
+			{
+				EventType: "evidence.refs.created",
+				Payload: map[string]any{
+					"claim_id":      "missing_claim",
+					"evidence_refs": []any{map[string]any{"ref_id": "row:visible", "visibility": "visible"}},
+				},
+			},
+		},
+	}}}
+	service := New(store)
+
+	response, found, err := service.GetEvidenceChainByRequestID(context.Background(), "req_no_claim")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !found {
+		t.Fatal("expected evidence chain to be found")
+	}
+	if !response.Partial || !contains(response.PartialReasons, "missing_claim") {
+		t.Fatalf("expected missing claim partial, got: %+v", response)
+	}
+}
+
+func TestGetEvidenceChainByTraceIDNotFound(t *testing.T) {
+	service := New(&fakeStore{})
+
+	_, found, err := service.GetEvidenceChainByTraceID(context.Background(), "missing")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if found {
+		t.Fatal("expected not found")
+	}
+}
+
 func hasValidationCode(validationErrors evidencevo.ValidationErrors, code string) bool {
 	for _, validationError := range validationErrors {
 		if validationError.Code == code {
@@ -207,6 +299,51 @@ func hasValidationCode(validationErrors evidencevo.ValidationErrors, code string
 		}
 	}
 	return false
+}
+
+func contains(values []string, target string) bool {
+	for _, value := range values {
+		if value == target {
+			return true
+		}
+	}
+	return false
+}
+
+func queryTrace(traceID, requestID string) evidencevo.NormalizedTrace {
+	return evidencevo.NormalizedTrace{
+		TraceID:   traceID,
+		RequestID: requestID,
+		Events: []evidencevo.EvidenceEvent{
+			{
+				EventType: "claim.created",
+				Payload: map[string]any{
+					"claim_id":       "claim_visible",
+					"claim_type":     "finding",
+					"claim_hash":     "sha256:claim",
+					"visibility":     "visible",
+					"version_status": "versioned",
+				},
+			},
+			{
+				EventType: "evidence.refs.created",
+				Payload: map[string]any{
+					"claim_id": "claim_visible",
+					"evidence_refs": []any{
+						map[string]any{"ref_id": "row:visible", "ref_type": "row_ref", "visibility": "visible"},
+						map[string]any{"ref_id": "row:hidden", "ref_type": "row_ref", "visibility": "hidden"},
+					},
+				},
+			},
+			{
+				EventType: "business.refs.resolved",
+				Payload: map[string]any{
+					"claim_id":      "claim_visible",
+					"business_refs": []any{map[string]any{"ref_id": "object:customer", "ref_type": "object", "visibility": "visible"}},
+				},
+			},
+		},
+	}
 }
 
 func validBatch() string {

--- a/bkn-trace/agent-observability/src/domain/valueobject/evidencevo/evidence.go
+++ b/bkn-trace/agent-observability/src/domain/valueobject/evidencevo/evidence.go
@@ -62,6 +62,37 @@ type NormalizedTrace struct {
 	BusinessRefCount int
 }
 
+type EvidenceChainResponse struct {
+	TraceID           string            `json:"trace_id"`
+	RequestID         string            `json:"bkn.request.id"`
+	Partial           bool              `json:"partial"`
+	PartialReasons    []string          `json:"partial_reason"`
+	VisibilitySummary VisibilitySummary `json:"visibility_summary"`
+	Page              EvidencePage      `json:"page"`
+	Data              EvidenceChainData `json:"data"`
+}
+
+type VisibilitySummary struct {
+	AuthorizedRefCount int `json:"authorized_ref_count"`
+	RedactedRefCount   int `json:"redacted_ref_count"`
+	HiddenRefCount     int `json:"hidden_ref_count"`
+	OmittedRefCount    int `json:"omitted_ref_count"`
+	UnresolvedRefCount int `json:"unresolved_ref_count"`
+}
+
+type EvidencePage struct {
+	NextCursor *string `json:"next_cursor"`
+	NodeCount  int     `json:"node_count"`
+	EdgeCount  int     `json:"edge_count"`
+	Truncated  bool    `json:"truncated"`
+}
+
+type EvidenceChainData struct {
+	Claims       []map[string]any `json:"claims"`
+	EvidenceRefs []map[string]any `json:"evidence_refs"`
+	BusinessRefs []map[string]any `json:"business_refs"`
+}
+
 type IngestResponse struct {
 	TraceID          string `json:"trace_id"`
 	RequestID        string `json:"bkn.request.id"`

--- a/bkn-trace/agent-observability/src/domain/valueobject/evidencevo/evidence.go
+++ b/bkn-trace/agent-observability/src/domain/valueobject/evidencevo/evidence.go
@@ -1,7 +1,5 @@
 package evidencevo
 
-import "encoding/json"
-
 const ContractVersion = "2.0.0"
 
 type IngestRequest struct {
@@ -21,18 +19,17 @@ type TraceContext struct {
 }
 
 type EvidenceEvent struct {
-	EventID       string          `json:"event_id"`
-	EventType     string          `json:"event_type"`
-	SchemaVersion string          `json:"bkn.trace.schema.version"`
-	ObservedAt    string          `json:"observed_at"`
-	EmittedAt     string          `json:"emitted_at"`
-	Producer      string          `json:"producer_module"`
-	TraceID       string          `json:"trace_id"`
-	SpanID        string          `json:"span_id"`
-	RequestID     string          `json:"bkn.request.id"`
-	OperationName string          `json:"bkn.operation.name"`
-	Payload       map[string]any  `json:"payload"`
-	RawPayload    json.RawMessage `json:"-"`
+	EventID       string         `json:"event_id"`
+	EventType     string         `json:"event_type"`
+	SchemaVersion string         `json:"bkn.trace.schema.version"`
+	ObservedAt    string         `json:"observed_at"`
+	EmittedAt     string         `json:"emitted_at"`
+	Producer      string         `json:"producer_module"`
+	TraceID       string         `json:"trace_id"`
+	SpanID        string         `json:"span_id"`
+	RequestID     string         `json:"bkn.request.id"`
+	OperationName string         `json:"bkn.operation.name"`
+	Payload       map[string]any `json:"payload"`
 }
 
 type ValidationError struct {

--- a/bkn-trace/agent-observability/src/drivenadapter/memoryaccess/evidencestore/store.go
+++ b/bkn-trace/agent-observability/src/drivenadapter/memoryaccess/evidencestore/store.go
@@ -8,19 +8,36 @@ import (
 )
 
 type Store struct {
-	mu     sync.Mutex
-	traces map[string][]evidencevo.NormalizedTrace
+	mu       sync.Mutex
+	traces   map[string][]evidencevo.NormalizedTrace
+	requests map[string][]evidencevo.NormalizedTrace
 }
 
 func New() *Store {
-	return &Store{traces: map[string][]evidencevo.NormalizedTrace{}}
+	return &Store{
+		traces:   map[string][]evidencevo.NormalizedTrace{},
+		requests: map[string][]evidencevo.NormalizedTrace{},
+	}
 }
 
 func (s *Store) StoreEvidence(_ context.Context, trace evidencevo.NormalizedTrace) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	s.traces[trace.TraceID] = append(s.traces[trace.TraceID], trace)
+	s.requests[trace.RequestID] = append(s.requests[trace.RequestID], trace)
 	return nil
+}
+
+func (s *Store) GetEvidenceByTraceID(_ context.Context, traceID string) ([]evidencevo.NormalizedTrace, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return append([]evidencevo.NormalizedTrace(nil), s.traces[traceID]...), nil
+}
+
+func (s *Store) GetEvidenceByRequestID(_ context.Context, requestID string) ([]evidencevo.NormalizedTrace, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return append([]evidencevo.NormalizedTrace(nil), s.requests[requestID]...), nil
 }
 
 func (s *Store) TraceCount(traceID string) int {

--- a/bkn-trace/agent-observability/src/driveradapter/api/httphandler/evidence_handler.go
+++ b/bkn-trace/agent-observability/src/driveradapter/api/httphandler/evidence_handler.go
@@ -1,8 +1,10 @@
 package httphandler
 
 import (
+	"crypto/subtle"
 	"io"
 	"net/http"
+	"os"
 	"strings"
 
 	"github.com/openbkn-ai/bkn-foundry/bkn-trace/agent-observability/src/domain/service/evidencesvc"
@@ -10,13 +12,23 @@ import (
 )
 
 const maxEvidenceBodyBytes = 1 << 20
+const evidenceIngestTokenEnv = "BKN_TRACE_EVIDENCE_INGEST_TOKEN"
+const evidenceIngestTokenHeader = "X-BKN-Trace-Ingest-Token"
 
 type EvidenceHandler struct {
 	evidenceService *evidencesvc.Service
+	ingestToken     string
 }
 
 func NewEvidenceHandler(evidenceService *evidencesvc.Service) *EvidenceHandler {
-	return &EvidenceHandler{evidenceService: evidenceService}
+	return NewEvidenceHandlerWithIngestToken(evidenceService, os.Getenv(evidenceIngestTokenEnv))
+}
+
+func NewEvidenceHandlerWithIngestToken(evidenceService *evidencesvc.Service, ingestToken string) *EvidenceHandler {
+	return &EvidenceHandler{
+		evidenceService: evidenceService,
+		ingestToken:     strings.TrimSpace(ingestToken),
+	}
 }
 
 // IngestEvidenceEvents godoc
@@ -37,6 +49,9 @@ func (h *EvidenceHandler) IngestEvidenceEvents(w http.ResponseWriter, r *http.Re
 			Code:    "METHOD_NOT_ALLOWED",
 			Message: "only POST is supported",
 		})
+		return
+	}
+	if !h.authorizeEvidenceIngest(w, r) {
 		return
 	}
 
@@ -186,4 +201,35 @@ func traceIDFromEvidenceChainPath(path string) string {
 		return ""
 	}
 	return strings.TrimSpace(traceID)
+}
+
+func (h *EvidenceHandler) authorizeEvidenceIngest(w http.ResponseWriter, r *http.Request) bool {
+	if h.ingestToken == "" {
+		return true
+	}
+	if secureTokenEqual(r.Header.Get(evidenceIngestTokenHeader), h.ingestToken) {
+		return true
+	}
+
+	authHeader := strings.TrimSpace(r.Header.Get("Authorization"))
+	if len(authHeader) > len("Bearer ") && strings.EqualFold(authHeader[:len("Bearer ")], "Bearer ") {
+		if secureTokenEqual(strings.TrimSpace(authHeader[len("Bearer "):]), h.ingestToken) {
+			return true
+		}
+	}
+
+	writeJSON(w, http.StatusUnauthorized, rdto.ErrorResponse{
+		Code:    "UNAUTHORIZED",
+		Message: "evidence ingest authentication is required",
+	})
+	return false
+}
+
+func secureTokenEqual(actual, expected string) bool {
+	actual = strings.TrimSpace(actual)
+	expected = strings.TrimSpace(expected)
+	if actual == "" || expected == "" {
+		return false
+	}
+	return subtle.ConstantTimeCompare([]byte(actual), []byte(expected)) == 1
 }

--- a/bkn-trace/agent-observability/src/driveradapter/api/httphandler/evidence_handler.go
+++ b/bkn-trace/agent-observability/src/driveradapter/api/httphandler/evidence_handler.go
@@ -3,6 +3,7 @@ package httphandler
 import (
 	"io"
 	"net/http"
+	"strings"
 
 	"github.com/openbkn-ai/bkn-foundry/bkn-trace/agent-observability/src/domain/service/evidencesvc"
 	"github.com/openbkn-ai/bkn-foundry/bkn-trace/agent-observability/src/driveradapter/api/rdto"
@@ -73,4 +74,116 @@ func (h *EvidenceHandler) IngestEvidenceEvents(w http.ResponseWriter, r *http.Re
 	}
 
 	writeJSON(w, http.StatusAccepted, response)
+}
+
+// GetEvidenceChainByTraceID godoc
+// @Summary Get evidence chain by trace ID
+// @Description Returns normalized claim, evidence refs, business refs, pagination, partial reasons, and visibility summary for a trace.
+// @Tags evidence
+// @Produce json
+// @Param trace_id path string true "Trace ID"
+// @Success 200 {object} map[string]interface{}
+// @Failure 400 {object} rdto.ErrorResponse
+// @Failure 404 {object} rdto.ErrorResponse
+// @Failure 405 {object} rdto.ErrorResponse
+// @Failure 500 {object} rdto.ErrorResponse
+// @Router /api/agent-observability/v1/traces/{trace_id}/evidence-chain [get]
+func (h *EvidenceHandler) GetEvidenceChainByTraceID(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		writeJSON(w, http.StatusMethodNotAllowed, rdto.ErrorResponse{
+			Code:    "METHOD_NOT_ALLOWED",
+			Message: "only GET is supported",
+		})
+		return
+	}
+
+	traceID := traceIDFromEvidenceChainPath(r.URL.Path)
+	if traceID == "" {
+		writeJSON(w, http.StatusBadRequest, rdto.ErrorResponse{
+			Code:    "INVALID_ARGUMENT",
+			Message: "trace_id is required",
+		})
+		return
+	}
+
+	response, found, err := h.evidenceService.GetEvidenceChainByTraceID(r.Context(), traceID)
+	if err != nil {
+		writeJSON(w, http.StatusInternalServerError, rdto.ErrorResponse{
+			Code:    "QUERY_FAILED",
+			Message: "failed to query evidence chain",
+		})
+		return
+	}
+	if !found {
+		writeJSON(w, http.StatusNotFound, rdto.ErrorResponse{
+			Code:    "NOT_FOUND",
+			Message: "evidence chain not found",
+		})
+		return
+	}
+
+	writeJSON(w, http.StatusOK, response)
+}
+
+// GetEvidenceChainByRequestID godoc
+// @Summary Get evidence chain by BKN request ID
+// @Description Returns normalized claim, evidence refs, business refs, pagination, partial reasons, and visibility summary for a request.
+// @Tags evidence
+// @Produce json
+// @Param request_id query string true "BKN request ID"
+// @Success 200 {object} map[string]interface{}
+// @Failure 400 {object} rdto.ErrorResponse
+// @Failure 404 {object} rdto.ErrorResponse
+// @Failure 405 {object} rdto.ErrorResponse
+// @Failure 500 {object} rdto.ErrorResponse
+// @Router /api/agent-observability/v1/traces/by-request [get]
+func (h *EvidenceHandler) GetEvidenceChainByRequestID(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		writeJSON(w, http.StatusMethodNotAllowed, rdto.ErrorResponse{
+			Code:    "METHOD_NOT_ALLOWED",
+			Message: "only GET is supported",
+		})
+		return
+	}
+
+	requestID := strings.TrimSpace(r.URL.Query().Get("request_id"))
+	if requestID == "" {
+		writeJSON(w, http.StatusBadRequest, rdto.ErrorResponse{
+			Code:    "INVALID_ARGUMENT",
+			Message: "request_id is required",
+		})
+		return
+	}
+
+	response, found, err := h.evidenceService.GetEvidenceChainByRequestID(r.Context(), requestID)
+	if err != nil {
+		writeJSON(w, http.StatusInternalServerError, rdto.ErrorResponse{
+			Code:    "QUERY_FAILED",
+			Message: "failed to query evidence chain",
+		})
+		return
+	}
+	if !found {
+		writeJSON(w, http.StatusNotFound, rdto.ErrorResponse{
+			Code:    "NOT_FOUND",
+			Message: "evidence chain not found",
+		})
+		return
+	}
+
+	writeJSON(w, http.StatusOK, response)
+}
+
+func traceIDFromEvidenceChainPath(path string) string {
+	const prefix = "/api/agent-observability/v1/traces/"
+	const suffix = "/evidence-chain"
+	if !strings.HasPrefix(path, prefix) || !strings.HasSuffix(path, suffix) {
+		return ""
+	}
+	traceID := strings.TrimSuffix(strings.TrimPrefix(path, prefix), suffix)
+	traceID = strings.Trim(traceID, "/")
+	if strings.Contains(traceID, "/") {
+		return ""
+	}
+	return strings.TrimSpace(traceID)
 }

--- a/bkn-trace/agent-observability/src/driveradapter/api/httphandler/evidence_handler_test.go
+++ b/bkn-trace/agent-observability/src/driveradapter/api/httphandler/evidence_handler_test.go
@@ -25,6 +25,52 @@ func TestEvidenceHandlerAcceptsValidBatch(t *testing.T) {
 	}
 }
 
+func TestEvidenceHandlerRejectsIngestWithoutConfiguredToken(t *testing.T) {
+	store := evidencestore.New()
+	handler := NewEvidenceHandlerWithIngestToken(evidencesvc.New(store), "secret-token")
+	req := httptest.NewRequest(http.MethodPost, "/api/agent-observability/v1/evidence/events", strings.NewReader(validHandlerBatch()))
+	rec := httptest.NewRecorder()
+
+	handler.IngestEvidenceEvents(rec, req)
+
+	if rec.Code != http.StatusUnauthorized {
+		t.Fatalf("expected 401, got %d: %s", rec.Code, rec.Body.String())
+	}
+
+	queryReq := httptest.NewRequest(http.MethodGet, "/api/agent-observability/v1/traces/9c0d0000000000000000000000000001/evidence-chain", nil)
+	queryRec := httptest.NewRecorder()
+	handler.GetEvidenceChainByTraceID(queryRec, queryReq)
+	if queryRec.Code != http.StatusNotFound {
+		t.Fatalf("expected rejected event to stay unstored, got %d: %s", queryRec.Code, queryRec.Body.String())
+	}
+}
+
+func TestEvidenceHandlerAcceptsBearerIngestToken(t *testing.T) {
+	handler := NewEvidenceHandlerWithIngestToken(evidencesvc.New(evidencestore.New()), "secret-token")
+	req := httptest.NewRequest(http.MethodPost, "/api/agent-observability/v1/evidence/events", strings.NewReader(validHandlerBatch()))
+	req.Header.Set("Authorization", "Bearer secret-token")
+	rec := httptest.NewRecorder()
+
+	handler.IngestEvidenceEvents(rec, req)
+
+	if rec.Code != http.StatusAccepted {
+		t.Fatalf("expected 202, got %d: %s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestEvidenceHandlerAcceptsIngestTokenHeader(t *testing.T) {
+	handler := NewEvidenceHandlerWithIngestToken(evidencesvc.New(evidencestore.New()), "secret-token")
+	req := httptest.NewRequest(http.MethodPost, "/api/agent-observability/v1/evidence/events", strings.NewReader(validHandlerBatch()))
+	req.Header.Set("X-BKN-Trace-Ingest-Token", "secret-token")
+	rec := httptest.NewRecorder()
+
+	handler.IngestEvidenceEvents(rec, req)
+
+	if rec.Code != http.StatusAccepted {
+		t.Fatalf("expected 202, got %d: %s", rec.Code, rec.Body.String())
+	}
+}
+
 func TestEvidenceHandlerRejectsSensitivePayload(t *testing.T) {
 	handler := NewEvidenceHandler(evidencesvc.New(evidencestore.New()))
 	req := httptest.NewRequest(http.MethodPost, "/api/agent-observability/v1/evidence/events", strings.NewReader(strings.Replace(validHandlerBatch(), `"claim_hash": "sha256:claim"`, `"raw_sql": "select email from customer"`, 1)))

--- a/bkn-trace/agent-observability/src/driveradapter/api/httphandler/evidence_handler_test.go
+++ b/bkn-trace/agent-observability/src/driveradapter/api/httphandler/evidence_handler_test.go
@@ -60,6 +60,62 @@ func TestEvidenceHandlerReturnsValidationErrorDetails(t *testing.T) {
 	}
 }
 
+func TestEvidenceHandlerReturnsEvidenceChainByTrace(t *testing.T) {
+	store := evidencestore.New()
+	handler := NewEvidenceHandler(evidencesvc.New(store))
+	ingestReq := httptest.NewRequest(http.MethodPost, "/api/agent-observability/v1/evidence/events", strings.NewReader(validHandlerBatch()))
+	ingestRec := httptest.NewRecorder()
+	handler.IngestEvidenceEvents(ingestRec, ingestReq)
+	if ingestRec.Code != http.StatusAccepted {
+		t.Fatalf("expected ingest 202, got %d: %s", ingestRec.Code, ingestRec.Body.String())
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/api/agent-observability/v1/traces/9c0d0000000000000000000000000001/evidence-chain", nil)
+	rec := httptest.NewRecorder()
+	handler.GetEvidenceChainByTraceID(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+	if !strings.Contains(rec.Body.String(), `"trace_id":"9c0d0000000000000000000000000001"`) {
+		t.Fatalf("unexpected body: %s", rec.Body.String())
+	}
+	if !strings.Contains(rec.Body.String(), `"claims"`) {
+		t.Fatalf("expected claims in body: %s", rec.Body.String())
+	}
+}
+
+func TestEvidenceHandlerReturnsEvidenceChainByRequest(t *testing.T) {
+	store := evidencestore.New()
+	handler := NewEvidenceHandler(evidencesvc.New(store))
+	ingestReq := httptest.NewRequest(http.MethodPost, "/api/agent-observability/v1/evidence/events", strings.NewReader(validHandlerBatch()))
+	ingestRec := httptest.NewRecorder()
+	handler.IngestEvidenceEvents(ingestRec, ingestReq)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/agent-observability/v1/traces/by-request?request_id=req_handler_001", nil)
+	rec := httptest.NewRecorder()
+	handler.GetEvidenceChainByRequestID(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+	if !strings.Contains(rec.Body.String(), `"bkn.request.id":"req_handler_001"`) {
+		t.Fatalf("unexpected body: %s", rec.Body.String())
+	}
+}
+
+func TestEvidenceHandlerReturnsNotFoundForMissingEvidenceChain(t *testing.T) {
+	handler := NewEvidenceHandler(evidencesvc.New(evidencestore.New()))
+	req := httptest.NewRequest(http.MethodGet, "/api/agent-observability/v1/traces/missing/evidence-chain", nil)
+	rec := httptest.NewRecorder()
+
+	handler.GetEvidenceChainByTraceID(rec, req)
+
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("expected 404, got %d: %s", rec.Code, rec.Body.String())
+	}
+}
+
 func validHandlerBatch() string {
 	return `{
   "bkn.trace.schema.version": "2.0.0",

--- a/bkn-trace/agent-observability/src/port/driven/ievidencestore/port.go
+++ b/bkn-trace/agent-observability/src/port/driven/ievidencestore/port.go
@@ -8,4 +8,6 @@ import (
 
 type EvidenceStorePort interface {
 	StoreEvidence(ctx context.Context, trace evidencevo.NormalizedTrace) error
+	GetEvidenceByTraceID(ctx context.Context, traceID string) ([]evidencevo.NormalizedTrace, error)
+	GetEvidenceByRequestID(ctx context.Context, requestID string) ([]evidencevo.NormalizedTrace, error)
 }


### PR DESCRIPTION
# Pull Request

## What Changed

Brief description of changes:

- [x] Add normalized Evidence Chain response model for BKN Trace phase two
- [x] Add in-memory evidence query repository methods by trace_id and bkn.request.id
- [x] Add Evidence Chain query APIs in agent-observability
- [x] Update agent-observability README with ingestion/query API notes

---

## Why

- Related Issue: BKN Trace phase-two implementation plan / PR-2.6 backend API baseline
- Related Feature: BKN Trace Evidence Graph query API
- Background: Modules now emit phase-two claim/evidence refs. The trace service needs a stable normalized query envelope before Studio and SDK consume Evidence Chain data.

---

## How

- Key implementation points:
  - Adds GET /api/agent-observability/v1/traces/{trace_id}/evidence-chain
  - Adds GET /api/agent-observability/v1/traces/by-request?request_id=...
  - Returns stable envelope with partial, partial_reason, visibility_summary, page, and data claims/evidence_refs/business_refs
  - Filters non-visible refs from response details and exposes only visibility counts
  - Marks missing claim evidence chains as partial with missing_claim
- Breaking changes (API, config, database, etc.):
  - None. New APIs are additive.
  - Repository remains in-memory and replaceable; persistent evidence index is follow-up.

---

## Testing

- [x] Unit tests passed locally
- [ ] Integration tests passed locally
- [ ] Verified in test environment

Test notes:

- bkn-trace/agent-observability: env GOCACHE=/tmp/openbkn-go-cache go test ./...
- git diff --check

---

## Risk & Rollback

- Potential risks:
  - Query API currently reads only the in-memory evidence repository, so data disappears on service restart until persistent evidence index lands.
  - This is a minimal Evidence Chain envelope, not the final resolver-backed Business Semantic Graph.
- Rollback plan:
  - Revert this additive PR; existing trace search and evidence ingestion APIs continue to work without schema/database migration.

---

## Additional Notes

- Does not expose raw rows, SQL, prompt, or hidden refs.
- Non-visible refs are represented via visibility_summary counts only.
- Follow-up work: persistent evidence repository, resolver-backed business graph, pagination cursor, Studio consumption.