### PR TITLE
fix(ci): pass release version to Go service image builds

### DIFF
--- a/.github/workflows/release-adp-bkn-backend.yml
+++ b/.github/workflows/release-adp-bkn-backend.yml
@@ -36,6 +36,8 @@ jobs:
       context: '.'
       image-name: bkn-backend
       version: ${{ needs.test.outputs.version }}
+      build-args: |
+        SERVER_VERSION=${{ needs.test.outputs.version }}
       publish: ${{ github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && inputs.publish) }}
 
   chart:

--- a/.github/workflows/release-adp-ontology-query.yml
+++ b/.github/workflows/release-adp-ontology-query.yml
@@ -36,6 +36,8 @@ jobs:
       context: '.'
       image-name: ontology-query
       version: ${{ needs.test.outputs.version }}
+      build-args: |
+        SERVER_VERSION=${{ needs.test.outputs.version }}
       publish: ${{ github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && inputs.publish) }}
 
   chart:

--- a/.github/workflows/release-adp-vega-backend.yml
+++ b/.github/workflows/release-adp-vega-backend.yml
@@ -38,6 +38,8 @@ jobs:
       context: '.'
       image-name: vega-backend
       version: ${{ needs.test.outputs.version }}
+      build-args: |
+        SERVER_VERSION=${{ needs.test.outputs.version }}
       publish: ${{ github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && inputs.publish) }}
 
   build-kafka-connect:


### PR DESCRIPTION
# Pull Request

## What Changed

Brief description of changes:

- [x] Pass the release version as `SERVER_VERSION` when building bkn-backend, ontology-query, and vega-backend images.
- [ ] Feature/module 2 — N/A.
- [ ] Docs/doc 1 — N/A; the behavior is self-contained in the release workflows.

---

## Why

- Related Issue: Closes #406
- Related Feature: N/A
- Background: The three Go service Dockerfiles inject `SERVER_VERSION` into the compiled binary, but their release workflows previously left it at the Dockerfile default (`0.1.0`) rather than the release/image-tag version.

---

## How

- Key implementation points: Add `build-args` with `SERVER_VERSION=${{ needs.test.outputs.version }}` to each affected service build job. The kafka-connect build is unchanged.
- Breaking changes (API, config, database, etc.): None.

---

## Testing

- [ ] Unit tests passed locally — N/A; CI workflow configuration only.
- [ ] Integration tests passed locally — N/A; CI workflow configuration only.
- [ ] Verified in test environment — N/A; no deployment was performed.

Test notes:

- Parsed the three modified workflow YAML files successfully with PyYAML.
- Confirmed each affected image job passes the same version source used for its image tag.
- Ran `git diff --check` successfully.
- `actionlint` is not installed in the local environment, so it was not run.

---

## Risk & Rollback

- Potential risks: A malformed GitHub Actions expression could fail the release build before image publication; the change is limited to build arguments for the three intended service images.
- Rollback plan: Revert commit `428638ee` to restore the prior workflow configuration.

---

## Additional Notes

- Screenshots, logs, documentation links, etc.: No application code, Dockerfiles, image publication, deployment, registry credentials, or secrets were changed.
