### PR TITLE
ci(claude-review): paths 过滤补上 bkn-trace/**

### DIFF
--- a/.github/workflows/automation-claude-review.yml
+++ b/.github/workflows/automation-claude-review.yml
@@ -20,6 +20,7 @@ on:
       - 'adp/**'
       - 'infra/**'
       - 'bkn-safe/**'
+      - 'bkn-trace/**'
       - 'deploy/scripts/**'
       - '!**/*.md'
   workflow_dispatch:


### PR DESCRIPTION
## 背景

trace-ai 改名 bkn-trace（#214）后，`automation-claude-review.yml` 的 `paths` include 列表没有跟上，纯 `bkn-trace/**` 改动的 PR 不会触发自动评审。#405 就是这样漏掉的（该 PR 已手动补审）。

## 改动

`on.pull_request.paths` 补一行 `'bkn-trace/**'`。`!**/*.md` 排除规则不变，README 类改动仍不触发。

🤖 Generated with [Claude Code](https://claude.com/claude-code)