### PR TITLE
feat(vega-backend): 支持统一任务管理的筛选与语义结果回写

### DIFF
--- a/adp/vega/vega-backend/helm/vega-backend/values.yaml
+++ b/adp/vega/vega-backend/helm/vega-backend/values.yaml
@@ -114,7 +114,7 @@ depServices:
     protocol: http
   bkn-agent:
     host: bkn-agent
-    port: 9898
+    port: 30800
     protocol: http
 
 config:

--- a/adp/vega/vega-backend/server/drivenadapters/discover_task/discover_task_access.go
+++ b/adp/vega/vega-backend/server/drivenadapters/discover_task/discover_task_access.go
@@ -11,6 +11,7 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
+	"strings"
 	"sync"
 	"time"
 
@@ -239,6 +240,10 @@ func (dta *discoverTaskAccess) List(ctx context.Context, params interfaces.Disco
 		builder = builder.Where(sq.Eq{"f_status": params.Status})
 		countBuilder = countBuilder.Where(sq.Eq{"f_status": params.Status})
 	}
+	if params.Strategy != "" {
+		builder = builder.Where(sq.Eq{"f_strategy": params.Strategy})
+		countBuilder = countBuilder.Where(sq.Eq{"f_strategy": params.Strategy})
+	}
 	if params.TriggerType != "" {
 		builder = builder.Where(sq.Eq{"f_trigger_type": params.TriggerType})
 		countBuilder = countBuilder.Where(sq.Eq{"f_trigger_type": params.TriggerType})
@@ -257,11 +262,7 @@ func (dta *discoverTaskAccess) List(ctx context.Context, params interfaces.Disco
 	if params.Limit > 0 {
 		builder = builder.Limit(uint64(params.Limit)).Offset(uint64(params.Offset))
 	}
-	if params.Sort != "" && params.Direction != "" {
-		builder = builder.OrderBy(fmt.Sprintf("%s %s", params.Sort, params.Direction))
-	} else {
-		builder = builder.OrderBy("f_create_time DESC")
-	}
+	builder = builder.OrderBy(buildOrderByClause(params.Sort, params.Direction))
 
 	sqlStr, vals, err := builder.ToSql()
 	if err != nil {
@@ -294,6 +295,28 @@ func (dta *discoverTaskAccess) List(ctx context.Context, params interfaces.Disco
 
 	span.SetStatus(codes.Ok, "")
 	return tasks, total, nil
+}
+
+func buildOrderByClause(sort, direction string) string {
+	if sort == "default" {
+		return "CASE f_status WHEN 'running' THEN 1 WHEN 'pending' THEN 2 WHEN 'failed' THEN 3 WHEN 'completed' THEN 4 ELSE 999 END ASC, f_create_time DESC"
+	}
+
+	column := "f_create_time"
+	switch sort {
+	case "start_time":
+		column = "f_start_time"
+	case "finish_time":
+		column = "f_finish_time"
+	case "create_time", "":
+		column = "f_create_time"
+	}
+
+	dir := "DESC"
+	if strings.EqualFold(direction, interfaces.ASC_DIRECTION) {
+		dir = "ASC"
+	}
+	return fmt.Sprintf("%s %s", column, dir)
 }
 
 // UpdateStatus updates a DiscoverTask's status and message.

--- a/adp/vega/vega-backend/server/drivenadapters/discover_task/discover_task_access_test.go
+++ b/adp/vega/vega-backend/server/drivenadapters/discover_task/discover_task_access_test.go
@@ -59,17 +59,18 @@ func TestDiscoverTaskAccessList(t *testing.T) {
 		defer cleanup()
 
 		params := interfaces.DiscoverTaskQueryParams{
-			PaginationQueryParams: interfaces.PaginationQueryParams{Offset: 5, Limit: 10, Sort: "f_create_time", Direction: "ASC"},
+			PaginationQueryParams: interfaces.PaginationQueryParams{Offset: 5, Limit: 10, Sort: "create_time", Direction: "ASC"},
 			CatalogID:             "catalog-1",
 			Status:                interfaces.DiscoverTaskStatusRunning,
+			Strategy:              interfaces.DiscoverStrategyFullSync,
 			TriggerType:           interfaces.DiscoverTaskTriggerScheduled,
 		}
 
-		mock.ExpectQuery("SELECT COUNT(*) FROM t_discover_task WHERE f_catalog_id = ? AND f_status = ? AND f_trigger_type = ?").
-			WithArgs("catalog-1", interfaces.DiscoverTaskStatusRunning, interfaces.DiscoverTaskTriggerScheduled).
+		mock.ExpectQuery("SELECT COUNT(*) FROM t_discover_task WHERE f_catalog_id = ? AND f_status = ? AND f_strategy = ? AND f_trigger_type = ?").
+			WithArgs("catalog-1", interfaces.DiscoverTaskStatusRunning, interfaces.DiscoverStrategyFullSync, interfaces.DiscoverTaskTriggerScheduled).
 			WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(1))
-		mock.ExpectQuery("SELECT f_id, f_catalog_id, f_schedule_id, f_strategy, f_trigger_type, f_status, f_progress, f_message, f_start_time, f_finish_time, f_result, f_creator, f_creator_type, f_create_time FROM t_discover_task WHERE f_catalog_id = ? AND f_status = ? AND f_trigger_type = ? ORDER BY f_create_time ASC LIMIT 10 OFFSET 5").
-			WithArgs("catalog-1", interfaces.DiscoverTaskStatusRunning, interfaces.DiscoverTaskTriggerScheduled).
+		mock.ExpectQuery("SELECT f_id, f_catalog_id, f_schedule_id, f_strategy, f_trigger_type, f_status, f_progress, f_message, f_start_time, f_finish_time, f_result, f_creator, f_creator_type, f_create_time FROM t_discover_task WHERE f_catalog_id = ? AND f_status = ? AND f_strategy = ? AND f_trigger_type = ? ORDER BY f_create_time ASC LIMIT 10 OFFSET 5").
+			WithArgs("catalog-1", interfaces.DiscoverTaskStatusRunning, interfaces.DiscoverStrategyFullSync, interfaces.DiscoverTaskTriggerScheduled).
 			WillReturnRows(discoverTaskRows().AddRow("task-1", "catalog-1", "schedule-1", "full_sync", interfaces.DiscoverTaskTriggerScheduled, interfaces.DiscoverTaskStatusRunning, 10, "", int64(0), int64(0), "", "u1", interfaces.ACCESSOR_TYPE_USER, int64(1)))
 
 		got, total, err := access.List(context.Background(), params)

--- a/adp/vega/vega-backend/server/drivenadapters/semantic_understanding_task/semantic_understanding_task_access.go
+++ b/adp/vega/vega-backend/server/drivenadapters/semantic_understanding_task/semantic_understanding_task_access.go
@@ -275,6 +275,12 @@ func (a *semanticUnderstandingTaskAccess) List(ctx context.Context, params inter
 		if len(params.Statuses) > 0 {
 			b = b.Where(sq.Eq{"f_status": params.Statuses})
 		}
+		if params.ApplyMode != "" {
+			b = b.Where(sq.Eq{"f_apply_mode": params.ApplyMode})
+		}
+		if params.Applied != nil {
+			b = b.Where(sq.Eq{"f_applied": *params.Applied})
+		}
 		return b
 	}
 	builder = applyFilters(builder)
@@ -292,7 +298,7 @@ func (a *semanticUnderstandingTaskAccess) List(ctx context.Context, params inter
 		return nil, 0, err
 	}
 
-	builder = builder.OrderBy(semanticUnderstandingTaskOrderBy(params.Sort, params.Direction))
+	builder = builder.OrderBy(buildOrderByClause(params.Sort, params.Direction))
 	if params.Limit > 0 {
 		builder = builder.Limit(uint64(params.Limit)).Offset(uint64(params.Offset))
 	}
@@ -487,7 +493,10 @@ func (a *semanticUnderstandingTaskAccess) updateWithTx(ctx context.Context, tx *
 	return affected > 0, nil
 }
 
-func semanticUnderstandingTaskOrderBy(sort, direction string) string {
+func buildOrderByClause(sort, direction string) string {
+	if sort == "default" {
+		return "CASE f_status WHEN 'running' THEN 1 WHEN 'pending' THEN 2 WHEN 'failed' THEN 3 WHEN 'succeeded' THEN 4 ELSE 999 END ASC, f_create_time DESC"
+	}
 	column := "f_create_time"
 	switch sort {
 	case "update_time":

--- a/adp/vega/vega-backend/server/drivenadapters/semantic_understanding_task/semantic_understanding_task_access_test.go
+++ b/adp/vega/vega-backend/server/drivenadapters/semantic_understanding_task/semantic_understanding_task_access_test.go
@@ -137,13 +137,15 @@ func TestSemanticUnderstandingTaskAccessList(t *testing.T) {
 				interfaces.SemanticUnderstandingTaskStatusPending,
 				interfaces.SemanticUnderstandingTaskStatusRunning,
 			},
+			ApplyMode: interfaces.SemanticUnderstandingApplyModeFillEmpty,
+			Applied:   boolPtr(true),
 		}
 
-		mock.ExpectQuery(regexp.QuoteMeta("SELECT COUNT(*) FROM t_semantic_understanding_task WHERE f_scope = ? AND f_catalog_id = ? AND f_resource_id = ? AND f_status IN (?,?)")).
-			WithArgs(interfaces.SemanticUnderstandingTaskScopeResource, "catalog-1", "resource-1", interfaces.SemanticUnderstandingTaskStatusPending, interfaces.SemanticUnderstandingTaskStatusRunning).
+		mock.ExpectQuery(regexp.QuoteMeta("SELECT COUNT(*) FROM t_semantic_understanding_task WHERE f_scope = ? AND f_catalog_id = ? AND f_resource_id = ? AND f_status IN (?,?) AND f_apply_mode = ? AND f_applied = ?")).
+			WithArgs(interfaces.SemanticUnderstandingTaskScopeResource, "catalog-1", "resource-1", interfaces.SemanticUnderstandingTaskStatusPending, interfaces.SemanticUnderstandingTaskStatusRunning, interfaces.SemanticUnderstandingApplyModeFillEmpty, true).
 			WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(1))
-		mock.ExpectQuery(regexp.QuoteMeta("SELECT "+joinSemanticUnderstandingTaskColumns()+" FROM t_semantic_understanding_task WHERE f_scope = ? AND f_catalog_id = ? AND f_resource_id = ? AND f_status IN (?,?) ORDER BY f_create_time ASC LIMIT 10 OFFSET 5")).
-			WithArgs(interfaces.SemanticUnderstandingTaskScopeResource, "catalog-1", "resource-1", interfaces.SemanticUnderstandingTaskStatusPending, interfaces.SemanticUnderstandingTaskStatusRunning).
+		mock.ExpectQuery(regexp.QuoteMeta("SELECT "+joinSemanticUnderstandingTaskColumns()+" FROM t_semantic_understanding_task WHERE f_scope = ? AND f_catalog_id = ? AND f_resource_id = ? AND f_status IN (?,?) AND f_apply_mode = ? AND f_applied = ? ORDER BY f_create_time ASC LIMIT 10 OFFSET 5")).
+			WithArgs(interfaces.SemanticUnderstandingTaskScopeResource, "catalog-1", "resource-1", interfaces.SemanticUnderstandingTaskStatusPending, interfaces.SemanticUnderstandingTaskStatusRunning, interfaces.SemanticUnderstandingApplyModeFillEmpty, true).
 			WillReturnRows(sqlmock.NewRows(semanticUnderstandingTaskColumns()).AddRow(semanticUnderstandingTaskRowValues(task)...))
 
 		got, total, err := access.List(context.Background(), params)
@@ -154,6 +156,10 @@ func TestSemanticUnderstandingTaskAccessList(t *testing.T) {
 		assert.Equal(t, task.ID, got[0].ID)
 		require.NoError(t, mock.ExpectationsWereMet())
 	})
+}
+
+func boolPtr(value bool) *bool {
+	return &value
 }
 
 func TestSemanticUnderstandingTaskAccessMarkRunning(t *testing.T) {

--- a/adp/vega/vega-backend/server/driveradapters/auth_resource_handler.go
+++ b/adp/vega/vega-backend/server/driveradapters/auth_resource_handler.go
@@ -142,6 +142,7 @@ func parseAuthResourceQuery(ctx context.Context, span trace.Span, c *gin.Context
 		rest.ReplyError(c, httpErr)
 		return interfaces.AuthResourceQueryParams{}, false
 	}
+	pageParam.Sort = interfaces.AuthResourceSort[sort]
 
 	return interfaces.AuthResourceQueryParams{
 		PaginationQueryParams: pageParam,

--- a/adp/vega/vega-backend/server/driveradapters/catalog_handler.go
+++ b/adp/vega/vega-backend/server/driveradapters/catalog_handler.go
@@ -96,6 +96,7 @@ func (r *restHandler) listCatalogs(c *gin.Context, visitor hydra.Visitor) {
 		rest.ReplyError(c, httpErr)
 		return
 	}
+	pageParam.Sort = interfaces.CATALOG_SORT[sort]
 
 	extKeys := c.QueryArray("extension_key")
 	extVals := c.QueryArray("extension_value")

--- a/adp/vega/vega-backend/server/driveradapters/connector_type_handler.go
+++ b/adp/vega/vega-backend/server/driveradapters/connector_type_handler.go
@@ -82,6 +82,7 @@ func (r *restHandler) ListConnectorTypes(c *gin.Context) {
 		rest.ReplyError(c, httpErr)
 		return
 	}
+	pageParam.Sort = interfaces.CONNECTOR_TYPE_SORT[sort]
 
 	params := interfaces.ConnectorTypesQueryParams{
 		PaginationQueryParams: pageParam,

--- a/adp/vega/vega-backend/server/driveradapters/discover_schedule_handler.go
+++ b/adp/vega/vega-backend/server/driveradapters/discover_schedule_handler.go
@@ -145,6 +145,7 @@ func (r *restHandler) listDiscoverSchedules(c *gin.Context, visitor hydra.Visito
 		rest.ReplyError(c, httpErr)
 		return
 	}
+	pageParam.Sort = interfaces.DISCOVER_SCHEDULE_SORT[sort]
 
 	params := interfaces.DiscoverScheduleQueryParams{
 		PaginationQueryParams: pageParam,

--- a/adp/vega/vega-backend/server/driveradapters/discover_task_handler.go
+++ b/adp/vega/vega-backend/server/driveradapters/discover_task_handler.go
@@ -54,7 +54,7 @@ func (r *restHandler) listDiscoverTasks(c *gin.Context, visitor hydra.Visitor) {
 
 	offset := common.GetQueryOrDefault(c, "offset", interfaces.DEFAULT_OFFSET)
 	limit := common.GetQueryOrDefault(c, "limit", interfaces.DEFAULT_LIMIT)
-	sort := common.GetQueryOrDefault(c, "sort", "create_time")
+	sort := common.GetQueryOrDefault(c, "sort", "default")
 	direction := common.GetQueryOrDefault(c, "direction", interfaces.DESC_DIRECTION)
 
 	pageParam, err := validatePaginationQueryParams(ctx,
@@ -67,12 +67,12 @@ func (r *restHandler) listDiscoverTasks(c *gin.Context, visitor hydra.Visitor) {
 		rest.ReplyError(c, httpErr)
 		return
 	}
-
 	params := interfaces.DiscoverTaskQueryParams{
 		PaginationQueryParams: pageParam,
 		CatalogID:             c.Query("catalog_id"),
 		ScheduleID:            c.Query("schedule_id"),
 		Status:                c.Query("status"),
+		Strategy:              c.Query("strategy"),
 		TriggerType:           c.Query("trigger_type"),
 	}
 

--- a/adp/vega/vega-backend/server/driveradapters/discover_task_handler_test.go
+++ b/adp/vega/vega-backend/server/driveradapters/discover_task_handler_test.go
@@ -53,6 +53,7 @@ func Test_DiscoverTaskRestHandler_ListDiscoverTasks(t *testing.T) {
 		{name: "invalid limit", query: "?limit=99999999", wantStatus: http.StatusBadRequest, wantBody: "VegaBackend.InvalidParameter.Limit"},
 		{name: "invalid sort field", query: "?sort=unknown_field", wantStatus: http.StatusBadRequest, wantBody: "VegaBackend.InvalidParameter.Sort"},
 		{name: "invalid direction", query: "?direction=foo", wantStatus: http.StatusBadRequest, wantBody: "VegaBackend.InvalidParameter.Direction"},
+		{name: "invalid strategy", query: "?strategy=foo", wantStatus: http.StatusBadRequest, wantBody: "invalid strategy"},
 		{name: "invalid trigger type", query: "?trigger_type=foo", wantStatus: http.StatusBadRequest, wantBody: "invalid trigger_type"},
 	}
 
@@ -75,7 +76,7 @@ func Test_DiscoverTaskRestHandler_ListDiscoverTasks(t *testing.T) {
 			DoAndReturn(func(_ context.Context, params interfaces.DiscoverTaskQueryParams) ([]*interfaces.DiscoverTask, int64, error) {
 				assert.Equal(t, 0, params.Offset)
 				assert.Equal(t, 20, params.Limit)
-				assert.Equal(t, "f_create_time", params.Sort)
+				assert.Equal(t, "default", params.Sort)
 				assert.Equal(t, interfaces.DESC_DIRECTION, params.Direction)
 				return []*interfaces.DiscoverTask{}, int64(0), nil
 			})
@@ -95,15 +96,16 @@ func Test_DiscoverTaskRestHandler_ListDiscoverTasks(t *testing.T) {
 				assert.Equal(t, "cat-1", params.CatalogID)
 				assert.Equal(t, "sch-1", params.ScheduleID)
 				assert.Equal(t, interfaces.DiscoverTaskStatusCompleted, params.Status)
+				assert.Equal(t, interfaces.DiscoverStrategyFullSync, params.Strategy)
 				assert.Equal(t, interfaces.DiscoverTaskTriggerScheduled, params.TriggerType)
 				assert.Equal(t, 5, params.Offset)
 				assert.Equal(t, 10, params.Limit)
-				assert.Equal(t, "f_start_time", params.Sort)
+				assert.Equal(t, "start_time", params.Sort)
 				assert.Equal(t, interfaces.ASC_DIRECTION, params.Direction)
 				return []*interfaces.DiscoverTask{}, int64(0), nil
 			})
 
-		req := httptest.NewRequest(http.MethodGet, url+"?catalog_id=cat-1&schedule_id=sch-1&status=completed&trigger_type=scheduled&offset=5&limit=10&sort=start_time&direction=asc", nil)
+		req := httptest.NewRequest(http.MethodGet, url+"?catalog_id=cat-1&schedule_id=sch-1&status=completed&strategy=full_sync&trigger_type=scheduled&offset=5&limit=10&sort=start_time&direction=asc", nil)
 		w := httptest.NewRecorder()
 
 		engine.ServeHTTP(w, req)

--- a/adp/vega/vega-backend/server/driveradapters/resource_handler.go
+++ b/adp/vega/vega-backend/server/driveradapters/resource_handler.go
@@ -80,6 +80,7 @@ func (r *restHandler) listResources(c *gin.Context, visitor hydra.Visitor) {
 		rest.ReplyError(c, httpErr)
 		return
 	}
+	pageParam.Sort = interfaces.RESOURCE_SORT[sort]
 
 	extKeys := c.QueryArray("extension_key")
 	extVals := c.QueryArray("extension_value")

--- a/adp/vega/vega-backend/server/driveradapters/semantic_understanding_task_handler.go
+++ b/adp/vega/vega-backend/server/driveradapters/semantic_understanding_task_handler.go
@@ -252,14 +252,13 @@ func parseSemanticUnderstandingTaskListParams(ctx context.Context, c *gin.Contex
 
 	offset := common.GetQueryOrDefault(c, "offset", interfaces.DEFAULT_OFFSET)
 	limit := common.GetQueryOrDefault(c, "limit", interfaces.DEFAULT_LIMIT)
-	sort := common.GetQueryOrDefault(c, "sort", "create_time")
+	sort := common.GetQueryOrDefault(c, "sort", "default")
 	direction := common.GetQueryOrDefault(c, "direction", interfaces.DESC_DIRECTION)
 
 	pageParam, err := validatePaginationQueryParams(ctx, offset, limit, sort, direction, interfaces.SEMANTIC_UNDERSTANDING_TASK_SORT)
 	if err != nil {
 		return params, err
 	}
-
 	scope := c.Query("scope")
 	if scope != "" && scope != interfaces.SemanticUnderstandingTaskScopeResource && scope != interfaces.SemanticUnderstandingTaskScopeCatalog {
 		return params, rest.NewHTTPError(ctx, http.StatusBadRequest, verrors.VegaBackend_InvalidParameter_Format).
@@ -276,10 +275,27 @@ func parseSemanticUnderstandingTaskListParams(ctx context.Context, c *gin.Contex
 		params.Statuses = statuses
 	}
 
+	applyMode := c.Query("apply_mode")
+	if applyMode != "" && applyMode != interfaces.SemanticUnderstandingApplyModeDryRun &&
+		applyMode != interfaces.SemanticUnderstandingApplyModeFillEmpty &&
+		applyMode != interfaces.SemanticUnderstandingApplyModeForce {
+		return params, rest.NewHTTPError(ctx, http.StatusBadRequest, verrors.VegaBackend_InvalidParameter_Format).
+			WithErrorDetails("invalid apply_mode")
+	}
+	if raw := c.Query("applied"); raw != "" {
+		applied, err := strconv.ParseBool(raw)
+		if err != nil {
+			return params, rest.NewHTTPError(ctx, http.StatusBadRequest, verrors.VegaBackend_InvalidParameter_Format).
+				WithErrorDetails("applied must be true or false")
+		}
+		params.Applied = &applied
+	}
+
 	params.PaginationQueryParams = pageParam
 	params.Scope = scope
 	params.CatalogID = c.Query("catalog_id")
 	params.ResourceID = c.Query("resource_id")
+	params.ApplyMode = applyMode
 	return params, nil
 }
 

--- a/adp/vega/vega-backend/server/driveradapters/semantic_understanding_task_handler_test.go
+++ b/adp/vega/vega-backend/server/driveradapters/semantic_understanding_task_handler_test.go
@@ -159,6 +159,8 @@ func Test_SemanticUnderstandingTaskRestHandler_ListTasks(t *testing.T) {
 		{name: "invalid direction", query: "?direction=foo", wantBody: "VegaBackend.InvalidParameter.Direction"},
 		{name: "invalid scope", query: "?scope=unknown", wantBody: "scope must be resource or catalog"},
 		{name: "invalid status", query: "?status=unknown", wantBody: "invalid status"},
+		{name: "invalid apply mode", query: "?apply_mode=unknown", wantBody: "invalid apply_mode"},
+		{name: "invalid applied", query: "?applied=unknown", wantBody: "applied must be true or false"},
 	}
 
 	for _, tt := range tests {
@@ -185,6 +187,9 @@ func Test_SemanticUnderstandingTaskRestHandler_ListTasks(t *testing.T) {
 					interfaces.SemanticUnderstandingTaskStatusPending,
 					interfaces.SemanticUnderstandingTaskStatusRunning,
 				}, params.Statuses)
+				assert.Equal(t, interfaces.SemanticUnderstandingApplyModeFillEmpty, params.ApplyMode)
+				require.NotNil(t, params.Applied)
+				assert.True(t, *params.Applied)
 				assert.Equal(t, 5, params.Offset)
 				assert.Equal(t, 10, params.Limit)
 				assert.Equal(t, "create_time", params.Sort)
@@ -201,7 +206,7 @@ func Test_SemanticUnderstandingTaskRestHandler_ListTasks(t *testing.T) {
 				}, int64(1), nil
 			})
 
-		req := httptest.NewRequest(http.MethodGet, semanticUnderstandingTaskURL+"?scope=resource&catalog_id=catalog-1&resource_id=res-1&status=pending,running&offset=5&limit=10&sort=create_time&direction=asc", nil)
+		req := httptest.NewRequest(http.MethodGet, semanticUnderstandingTaskURL+"?scope=resource&catalog_id=catalog-1&resource_id=res-1&status=pending,running&apply_mode=fill_empty&applied=true&offset=5&limit=10&sort=create_time&direction=asc", nil)
 		w := httptest.NewRecorder()
 
 		engine.ServeHTTP(w, req)

--- a/adp/vega/vega-backend/server/driveradapters/validate.go
+++ b/adp/vega/vega-backend/server/driveradapters/validate.go
@@ -146,7 +146,7 @@ func validatePaginationQueryParams(ctx context.Context, offset, limit, sort, dir
 	return interfaces.PaginationQueryParams{
 		Offset:    off,
 		Limit:     lim,
-		Sort:      supportedSortTypes[sort],
+		Sort:      sort,
 		Direction: direction,
 	}, nil
 }

--- a/adp/vega/vega-backend/server/driveradapters/validate_build_task.go
+++ b/adp/vega/vega-backend/server/driveradapters/validate_build_task.go
@@ -102,15 +102,8 @@ func parseBuildTaskStatuses(ctx context.Context, raw string) ([]string, error) {
 }
 
 func isValidBuildTaskOrderBy(o string) bool {
-	switch o {
-	case interfaces.BuildTaskOrderByDefault,
-		interfaces.BuildTaskOrderByCreatedAt,
-		interfaces.BuildTaskOrderByUpdatedAt,
-		interfaces.BuildTaskOrderByStatus,
-		interfaces.BuildTaskOrderByMode:
-		return true
-	}
-	return false
+	_, ok := interfaces.BUILD_TASK_SORT[o]
+	return ok
 }
 
 func isValidBuildTaskStatus(s string) bool {

--- a/adp/vega/vega-backend/server/driveradapters/validate_build_task_test.go
+++ b/adp/vega/vega-backend/server/driveradapters/validate_build_task_test.go
@@ -81,8 +81,8 @@ func Test_isValidBuildTaskOrderBy(t *testing.T) {
 		{orderBy: interfaces.BuildTaskOrderByDefault, want: true},
 		{orderBy: interfaces.BuildTaskOrderByCreatedAt, want: true},
 		{orderBy: interfaces.BuildTaskOrderByUpdatedAt, want: true},
-		{orderBy: interfaces.BuildTaskOrderByStatus, want: true},
-		{orderBy: interfaces.BuildTaskOrderByMode, want: true},
+		{orderBy: interfaces.BuildTaskOrderByStatus, want: false},
+		{orderBy: interfaces.BuildTaskOrderByMode, want: false},
 		{orderBy: "progress", want: false},
 		{orderBy: "", want: false},
 	}

--- a/adp/vega/vega-backend/server/driveradapters/validate_discover_task.go
+++ b/adp/vega/vega-backend/server/driveradapters/validate_discover_task.go
@@ -23,6 +23,11 @@ func ValidateDiscoverTaskQueryParams(ctx context.Context, params interfaces.Disc
 			WithErrorDetails(fmt.Sprintf("invalid status: %s", params.Status))
 	}
 
+	if params.Strategy != "" && !interfaces.IsValidDiscoverStrategy(params.Strategy) {
+		return rest.NewHTTPError(ctx, http.StatusBadRequest, verrors.VegaBackend_InvalidParameter_RequestBody).
+			WithErrorDetails(fmt.Sprintf("invalid strategy: %s", params.Strategy))
+	}
+
 	if params.TriggerType != "" && !isValidDiscoverTaskTriggerType(params.TriggerType) {
 		return rest.NewHTTPError(ctx, http.StatusBadRequest, verrors.VegaBackend_InvalidParameter_RequestBody).
 			WithErrorDetails(fmt.Sprintf("invalid trigger_type: %s", params.TriggerType))

--- a/adp/vega/vega-backend/server/driveradapters/validate_discover_task_test.go
+++ b/adp/vega/vega-backend/server/driveradapters/validate_discover_task_test.go
@@ -27,9 +27,10 @@ func Test_ValidateDiscoverTaskQueryParams(t *testing.T) {
 			name: "valid empty params",
 		},
 		{
-			name: "valid status and trigger type",
+			name: "valid status, strategy and trigger type",
 			params: interfaces.DiscoverTaskQueryParams{
 				Status:      interfaces.DiscoverTaskStatusCompleted,
+				Strategy:    interfaces.DiscoverStrategyFullSync,
 				TriggerType: interfaces.DiscoverTaskTriggerScheduled,
 			},
 		},
@@ -37,6 +38,13 @@ func Test_ValidateDiscoverTaskQueryParams(t *testing.T) {
 			name: "invalid status",
 			params: interfaces.DiscoverTaskQueryParams{
 				Status: "unknown",
+			},
+			wantErr: true,
+		},
+		{
+			name: "invalid strategy",
+			params: interfaces.DiscoverTaskQueryParams{
+				Strategy: "unknown",
 			},
 			wantErr: true,
 		},

--- a/adp/vega/vega-backend/server/driveradapters/validate_test.go
+++ b/adp/vega/vega-backend/server/driveradapters/validate_test.go
@@ -408,7 +408,7 @@ func TestValidatePaginationQueryParams(t *testing.T) {
 			assert: func(t *testing.T, got interfaces.PaginationQueryParams) {
 				assert.Equal(t, 0, got.Offset)
 				assert.Equal(t, 10, got.Limit)
-				assert.Equal(t, "f_name", got.Sort)
+				assert.Equal(t, "name", got.Sort)
 				assert.Equal(t, "asc", got.Direction)
 			},
 		},

--- a/adp/vega/vega-backend/server/interfaces/build_task.go
+++ b/adp/vega/vega-backend/server/interfaces/build_task.go
@@ -50,6 +50,14 @@ var BuildTaskStatusOrder = []string{
 	BuildTaskStatusCompleted, // 6 已完成
 }
 
+// BUILD_TASK_SORT is a whitelist of supported order_by values. Values are unused;
+// the data access layer owns the mapping from API fields to database columns.
+var BUILD_TASK_SORT = map[string]string{
+	BuildTaskOrderByDefault:   "",
+	BuildTaskOrderByCreatedAt: "",
+	BuildTaskOrderByUpdatedAt: "",
+}
+
 // BuildTask represents a build task entity.
 type BuildTask struct {
 	ID              string                `json:"id"`

--- a/adp/vega/vega-backend/server/interfaces/discover_task.go
+++ b/adp/vega/vega-backend/server/interfaces/discover_task.go
@@ -27,9 +27,10 @@ const (
 
 var (
 	DISCOVER_TASK_SORT = map[string]string{
-		"create_time": "f_create_time",
-		"start_time":  "f_start_time",
-		"finish_time": "f_finish_time",
+		"default":     "",
+		"create_time": "",
+		"start_time":  "",
+		"finish_time": "",
 	}
 )
 
@@ -61,6 +62,7 @@ type DiscoverTaskQueryParams struct {
 	CatalogID   string `form:"catalog_id" json:"catalog_id"`
 	ScheduleID  string `form:"schedule_id" json:"schedule_id"`
 	Status      string `form:"status" json:"status"`
+	Strategy    string `form:"strategy" json:"strategy"`
 	TriggerType string `form:"trigger_type" json:"trigger_type"`
 }
 

--- a/adp/vega/vega-backend/server/interfaces/semantic_understanding_task.go
+++ b/adp/vega/vega-backend/server/interfaces/semantic_understanding_task.go
@@ -34,10 +34,9 @@ var (
 	}
 
 	SEMANTIC_UNDERSTANDING_TASK_SORT = map[string]string{
-		"create_time": "create_time",
-		"update_time": "update_time",
-		"status":      "status",
-		"scope":       "scope",
+		"default":     "",
+		"create_time": "",
+		"update_time": "",
 	}
 )
 
@@ -92,6 +91,8 @@ type SemanticUnderstandingTaskQueryParams struct {
 	CatalogID  string
 	ResourceID string
 	Statuses   []string
+	ApplyMode  string
+	Applied    *bool
 }
 
 type SemanticUnderstandingTaskMessage struct {

--- a/adp/vega/vega-backend/server/worker/semantic_understanding_task_worker.go
+++ b/adp/vega/vega-backend/server/worker/semantic_understanding_task_worker.go
@@ -431,10 +431,12 @@ func (sutw *SemanticUnderstandingTaskWorker) applyResourceResult(ctx context.Con
 	}
 
 	updatedResource := make([]string, 0, 2)
-	if applyStringByMode(task.ApplyMode, &resourceInfo.Name, result.Resource.DisplayName, false) {
+	if applyStringByMode(task.ApplyMode, &resourceInfo.Name, result.Resource.DisplayName,
+		resourceInfo.Name == resourceInfo.SourceIdentifier) {
 		updatedResource = append(updatedResource, "name")
 	}
-	if applyStringByMode(task.ApplyMode, &resourceInfo.Description, result.Resource.Description, resourceInfo.Description == sourceOriginalDescription(resourceInfo.SourceMetadata)) {
+	if applyStringByMode(task.ApplyMode, &resourceInfo.Description, result.Resource.Description,
+		resourceInfo.Description == sourceOriginalDescription(resourceInfo.SourceMetadata)) {
 		updatedResource = append(updatedResource, "description")
 	}
 	resourceUpdated := len(updatedResource) > 0

--- a/adp/vega/vega-backend/server/worker/semantic_understanding_task_worker.go
+++ b/adp/vega/vega-backend/server/worker/semantic_understanding_task_worker.go
@@ -130,7 +130,12 @@ func (sutw *SemanticUnderstandingTaskWorker) HandleTask(ctx context.Context, tas
 	}
 	taskInfo.ResultJSON = resultJSON
 	taskInfo.Confidence = confidence
-	return sutw.applyAndMark(ctx, taskInfo)
+	if err := sutw.applyAndMark(ctx, taskInfo); err != nil {
+		return err
+	}
+
+	logger.Infof("Semantic understanding completed for task: %s", taskID)
+	return nil
 }
 
 func (sutw *SemanticUnderstandingTaskWorker) applyAndMark(ctx context.Context, task *interfaces.SemanticUnderstandingTask) error {
@@ -414,10 +419,10 @@ func (sutw *SemanticUnderstandingTaskWorker) applyResourceResult(ctx context.Con
 		}
 
 		fieldUpdated := false
-		if applyStringByMode(task.ApplyMode, &property.DisplayName, field.DisplayName) {
+		if applyStringByMode(task.ApplyMode, &property.DisplayName, field.DisplayName, property.DisplayName == property.Name) {
 			fieldUpdated = true
 		}
-		if applyStringByMode(task.ApplyMode, &property.Description, field.Description) {
+		if applyStringByMode(task.ApplyMode, &property.Description, field.Description, property.Description == property.OriginalDescription) {
 			fieldUpdated = true
 		}
 		if fieldUpdated {
@@ -426,10 +431,10 @@ func (sutw *SemanticUnderstandingTaskWorker) applyResourceResult(ctx context.Con
 	}
 
 	updatedResource := make([]string, 0, 2)
-	if applyStringByMode(task.ApplyMode, &resourceInfo.Name, result.Resource.DisplayName) {
+	if applyStringByMode(task.ApplyMode, &resourceInfo.Name, result.Resource.DisplayName, false) {
 		updatedResource = append(updatedResource, "name")
 	}
-	if applyStringByMode(task.ApplyMode, &resourceInfo.Description, result.Resource.Description) {
+	if applyStringByMode(task.ApplyMode, &resourceInfo.Description, result.Resource.Description, resourceInfo.Description == sourceOriginalDescription(resourceInfo.SourceMetadata)) {
 		updatedResource = append(updatedResource, "description")
 	}
 	resourceUpdated := len(updatedResource) > 0
@@ -475,13 +480,13 @@ func (sutw *SemanticUnderstandingTaskWorker) applyResourceResult(ctx context.Con
 	}, nil
 }
 
-func applyStringByMode(mode string, current *string, next string) bool {
+func applyStringByMode(mode string, current *string, next string, treatCurrentAsEmpty bool) bool {
 	if next == "" {
 		return false
 	}
 	switch mode {
 	case interfaces.SemanticUnderstandingApplyModeFillEmpty:
-		if *current != "" {
+		if *current != "" && !treatCurrentAsEmpty {
 			return false
 		}
 	case interfaces.SemanticUnderstandingApplyModeForce:
@@ -493,6 +498,14 @@ func applyStringByMode(mode string, current *string, next string) bool {
 	}
 	*current = next
 	return true
+}
+
+func sourceOriginalDescription(metadata map[string]any) string {
+	if metadata == nil {
+		return ""
+	}
+	description, _ := metadata["original_description"].(string)
+	return description
 }
 
 func validateConfidence(confidence *float64, path string) error {
@@ -599,7 +612,7 @@ func (sutw *SemanticUnderstandingTaskWorker) applyCatalogResult(ctx context.Cont
 		case "update":
 			current := logicViewByID[view.TargetResourceID]
 			nextDescription := current.Description
-			applyStringByMode(task.ApplyMode, &nextDescription, view.Description)
+			applyStringByMode(task.ApplyMode, &nextDescription, view.Description, false)
 			nextLogicDefinition := current.LogicDefinition
 			if task.ApplyMode == interfaces.SemanticUnderstandingApplyModeForce {
 				nextLogicDefinition = view.LogicDefinition

--- a/adp/vega/vega-backend/server/worker/semantic_understanding_task_worker_test.go
+++ b/adp/vega/vega-backend/server/worker/semantic_understanding_task_worker_test.go
@@ -398,6 +398,40 @@ func TestSemanticUnderstandingTaskWorkerApplyResourceResult(t *testing.T) {
 		assert.JSONEq(t, `{"resource_updated":false,"updated_fields":["product_id"]}`, got.DetailJSON)
 	})
 
+	t.Run("fills resource name when it still equals the source identifier", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		t.Cleanup(ctrl.Finish)
+
+		resourceService := vmock.NewMockResourceService(ctrl)
+		worker := &SemanticUnderstandingTaskWorker{rs: resourceService}
+		task := &interfaces.SemanticUnderstandingTask{
+			Scope:               interfaces.SemanticUnderstandingTaskScopeResource,
+			ResourceID:          "resource-1",
+			ApplyMode:           interfaces.SemanticUnderstandingApplyModeFillEmpty,
+			ConfidenceThreshold: 0.75,
+		}
+		resource := &interfaces.Resource{
+			ID:               "resource-1",
+			Name:             "public.v_product_review_summary",
+			SourceIdentifier: "public.v_product_review_summary",
+		}
+		resourceService.EXPECT().
+			GetByID(gomock.Any(), "resource-1").
+			Return(resource, nil)
+		resourceService.EXPECT().
+			UpdateResource(gomock.Any(), resource).
+			DoAndReturn(func(_ context.Context, got *interfaces.Resource) error {
+				assert.Equal(t, "商品评价汇总视图", got.Name)
+				return nil
+			})
+
+		got, err := worker.applyResult(context.Background(), task, `{"confidence":0.9,"resource":{"display_name":"商品评价汇总视图","confidence":0.9}}`, 0.9, nil)
+
+		require.NoError(t, err)
+		assert.True(t, got.Applied)
+		assert.JSONEq(t, `{"resource_updated":true,"updated_resource":["name"]}`, got.DetailJSON)
+	})
+
 	t.Run("fills descriptions that still equal their source descriptions", func(t *testing.T) {
 		ctrl := gomock.NewController(t)
 		t.Cleanup(ctrl.Finish)

--- a/adp/vega/vega-backend/server/worker/semantic_understanding_task_worker_test.go
+++ b/adp/vega/vega-backend/server/worker/semantic_understanding_task_worker_test.go
@@ -363,6 +363,81 @@ func TestSemanticUnderstandingTaskWorkerApplyResourceResult(t *testing.T) {
 		assert.JSONEq(t, `{"resource_updated":false,"skipped_fields":["missing: not found"]}`, got.DetailJSON)
 	})
 
+	t.Run("fills display names that still equal the technical field name", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		t.Cleanup(ctrl.Finish)
+
+		resourceService := vmock.NewMockResourceService(ctrl)
+		worker := &SemanticUnderstandingTaskWorker{rs: resourceService}
+		task := &interfaces.SemanticUnderstandingTask{
+			Scope:               interfaces.SemanticUnderstandingTaskScopeResource,
+			ResourceID:          "resource-1",
+			ApplyMode:           interfaces.SemanticUnderstandingApplyModeFillEmpty,
+			ConfidenceThreshold: 0.75,
+		}
+		resource := &interfaces.Resource{
+			ID: "resource-1",
+			SchemaDefinition: []*interfaces.Property{
+				{Name: "product_id", DisplayName: "product_id", Type: interfaces.DataType_String},
+			},
+		}
+		resourceService.EXPECT().
+			GetByID(gomock.Any(), "resource-1").
+			Return(resource, nil)
+		resourceService.EXPECT().
+			UpdateResource(gomock.Any(), resource).
+			DoAndReturn(func(_ context.Context, got *interfaces.Resource) error {
+				assert.Equal(t, "商品ID", got.SchemaDefinition[0].DisplayName)
+				return nil
+			})
+
+		got, err := worker.applyResult(context.Background(), task, `{"confidence":0.9,"fields":[{"name":"product_id","display_name":"商品ID","confidence":0.9}]}`, 0.9, nil)
+
+		require.NoError(t, err)
+		assert.True(t, got.Applied)
+		assert.JSONEq(t, `{"resource_updated":false,"updated_fields":["product_id"]}`, got.DetailJSON)
+	})
+
+	t.Run("fills descriptions that still equal their source descriptions", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		t.Cleanup(ctrl.Finish)
+
+		resourceService := vmock.NewMockResourceService(ctrl)
+		worker := &SemanticUnderstandingTaskWorker{rs: resourceService}
+		task := &interfaces.SemanticUnderstandingTask{
+			Scope:               interfaces.SemanticUnderstandingTaskScopeResource,
+			ResourceID:          "resource-1",
+			ApplyMode:           interfaces.SemanticUnderstandingApplyModeFillEmpty,
+			ConfidenceThreshold: 0.75,
+		}
+		resource := &interfaces.Resource{
+			ID:          "resource-1",
+			Description: "source resource description",
+			SourceMetadata: map[string]any{
+				"original_description": "source resource description",
+			},
+			SchemaDefinition: []*interfaces.Property{
+				{Name: "product_id", Description: "source field description", OriginalDescription: "source field description", Type: interfaces.DataType_String},
+			},
+		}
+		resourceService.EXPECT().
+			GetByID(gomock.Any(), "resource-1").
+			Return(resource, nil)
+		resourceService.EXPECT().
+			UpdateResource(gomock.Any(), resource).
+			DoAndReturn(func(_ context.Context, got *interfaces.Resource) error {
+				assert.Equal(t, "AI resource description", got.Description)
+				assert.Equal(t, "AI field description", got.SchemaDefinition[0].Description)
+				return nil
+			})
+
+		got, err := worker.applyResult(context.Background(), task, `{"confidence":0.9,"resource":{"description":"AI resource description","confidence":0.9},"fields":[{"name":"product_id","description":"AI field description","confidence":0.9}]}`, 0.9, nil)
+
+		require.NoError(t, err)
+		assert.True(t, got.Applied)
+		assert.JSONEq(t, `{"resource_updated":true,"updated_resource":["description"],"updated_fields":["product_id"]}`, got.DetailJSON)
+	})
+
 	t.Run("skips apply in dry run", func(t *testing.T) {
 		worker := &SemanticUnderstandingTaskWorker{}
 		task := &interfaces.SemanticUnderstandingTask{

--- a/docs/api/vega/build-task.yaml
+++ b/docs/api/vega/build-task.yaml
@@ -84,8 +84,6 @@ paths:
               - default
               - created_at
               - updated_at
-              - status
-              - mode
             default: default
         - name: order
           description: 排序方向，默认 desc；`order_by=default` 时固定使用服务端复合排序

--- a/docs/api/vega/discover-task.yaml
+++ b/docs/api/vega/discover-task.yaml
@@ -25,7 +25,7 @@ paths:
   /discover-tasks:
     get:
       summary: 获取发现任务列表
-      description: 分页获取发现任务；支持按 catalog_id / schedule_id / status / trigger_type 过滤。
+      description: 分页获取发现任务；支持按 catalog_id / schedule_id / status / strategy / trigger_type 过滤。
       parameters:
         - name: catalog_id
           description: 按归属 catalog 过滤
@@ -48,6 +48,15 @@ paths:
               - running
               - completed
               - failed
+        - name: strategy
+          description: 按探查策略过滤
+          in: query
+          schema:
+            type: string
+            enum:
+              - full_sync
+              - create_only
+              - cleanup_only
         - name: trigger_type
           description: 按触发方式过滤
           in: query
@@ -72,10 +81,12 @@ paths:
             format: int64
             default: 20
         - name: sort
-          description: 排序字段（当前数据访问层固定按 create_time 倒序，sort 参数预留）
+          description: 排序字段；默认 `default`（执行中、等待中、失败、已完成，同状态按创建时间倒序）。
           in: query
           schema:
             type: string
+            enum: [default, create_time, start_time, finish_time]
+            default: default
         - name: direction
           description: 排序方向
           in: query

--- a/docs/api/vega/semantic-understanding-task.yaml
+++ b/docs/api/vega/semantic-understanding-task.yaml
@@ -31,6 +31,17 @@ paths:
           in: query
           schema:
             type: string
+        - name: apply_mode
+          description: 应用方式。
+          in: query
+          schema:
+            type: string
+            enum: [dry_run, fill_empty, force]
+        - name: applied
+          description: 是否已应用。
+          in: query
+          schema:
+            type: boolean
         - name: active
           in: query
           schema: { type: boolean }
@@ -44,8 +55,8 @@ paths:
           in: query
           schema:
             type: string
-            enum: [create_time, update_time, status, scope]
-            default: create_time
+            enum: [default, create_time, update_time]
+            default: default
         - name: direction
           in: query
           schema:


### PR DESCRIPTION
## What Changed

- [x] 为 Build、Discover、Semantic Understanding 任务补齐服务端筛选、默认排序与分页契约。
- [x] `fill_empty` 模式下，当 Resource name 与 `source_identifier` 相同时，回写 AI 生成的业务名称。
- [x] 修复 Vega Helm 中 bkn-agent 默认服务端口为 `30800`，并更新相关 OpenAPI 与测试。

---

## Why

- Related Issue: Closes #391
- Related Feature: [bkn-studio#208](https://github.com/openbkn-ai/bkn-studio/issues/208)
- Background: 统一任务管理页需要可靠的任务筛选与排序；技术占位名称应能由语义理解补齐业务名称。

---

## How

- Key implementation points: Discover task 增加 strategy 筛选及状态优先排序；Semantic task 支持 apply_mode/applied 筛选；多个资源列表将 sort 参数映射至底层字段。
- Breaking changes (API, config, database, etc.): 无。新增可选查询条件；Helm 默认 bkn-agent 端口修正为既有服务 targetPort。

---

## Testing

- [x] Unit tests passed locally
- [ ] Integration tests passed locally（不适用：本次未连接外部中间件）
- [ ] Verified in test environment（未执行）

Test notes:

- `go test ./worker -run TestSemanticUnderstandingTaskWorkerApplyResourceResult -count=1`
- `make lint`
- `make test`
- `make api-docs-lint`
- `helm lint adp/vega/vega-backend/helm/vega-backend`

---

## Risk & Rollback

- Potential risks: `fill_empty` 会将与 source_identifier 完全相同的名称视为技术占位名；不同的既有名称不会被覆盖。
- Rollback plan: 回滚本 PR，即可恢复此前端口与回写语义；不涉及数据库迁移或数据回填。

---

## Additional Notes

- OpenAPI 文档已同步更新。
- 未包含本地环境配置文件或任何凭据。
