### PR TITLE
feat(bkn-trace): expose business graph query

### DIFF
--- a/bkn-trace/agent-observability/README.md
+++ b/bkn-trace/agent-observability/README.md
@@ -8,6 +8,8 @@
 - Evidence 事件接收接口：`POST /api/agent-observability/v1/evidence/events`
 - Evidence Chain 查询接口：`GET /api/agent-observability/v1/traces/{trace_id}/evidence-chain`
 - Request 维度 Evidence Chain 查询接口：`GET /api/agent-observability/v1/traces/by-request?request_id=...`
+- Business Graph 查询接口：`GET /api/agent-observability/v1/traces/{trace_id}/business-graph`
+- Request 维度 Business Graph 查询接口：`GET /api/agent-observability/v1/traces/by-request/business-graph?request_id=...`
 - OpenSearch 查询客户端
 - 阶段二 Evidence ingestion 校验、归一化和可替换存储接口
 - Swagger 文档生成
@@ -29,7 +31,7 @@ make test
 GOCACHE=/tmp/openbkn-go-build-cache GOMODCACHE=/tmp/openbkn-go-mod-cache go test ./...
 ```
 
-阶段二 evidence ingestion 接口接受 `bkn.trace.schema.version=2.0.0` 的事件批次，包含 `trace` 与 `events`。当前版本先完成 contract 校验、敏感 payload 拒绝、归一化计数、内存 repository 写入和最小 Evidence Chain 查询；后续 PR 会把 repository 替换为持久化 evidence index。
+阶段二 evidence ingestion 接口接受 `bkn.trace.schema.version=2.0.0` 的事件批次，包含 `trace` 与 `events`。当前版本先完成 contract 校验、敏感 payload 拒绝、归一化计数、内存 repository 写入、最小 Evidence Chain 查询和 Business Graph 查询；后续 PR 会把 repository 替换为持久化 evidence index。
 
 ### Evidence 写入安全边界
 
@@ -79,6 +81,54 @@ Evidence Chain 查询返回稳定 envelope：
   }
 }
 ```
+
+Business Graph 查询返回从 `business.refs.resolved` 派生的业务语义图：
+
+```json
+{
+  "trace_id": "9c0d...",
+  "bkn.request.id": "req_handler_002",
+  "partial": false,
+  "partial_reason": [],
+  "visibility_summary": {
+    "authorized_ref_count": 0,
+    "redacted_ref_count": 0,
+    "hidden_ref_count": 0,
+    "omitted_ref_count": 0,
+    "unresolved_ref_count": 0
+  },
+  "page": {
+    "next_cursor": null,
+    "node_count": 2,
+    "edge_count": 1,
+    "truncated": false
+  },
+  "data": {
+    "nodes": [
+      {
+        "id": "claim:claim_handler_business",
+        "node_type": "claim",
+        "claim_id": "claim_handler_business"
+      },
+      {
+        "id": "business:object:customer",
+        "node_type": "object",
+        "label": "Customer"
+      }
+    ],
+    "edges": [
+      {
+        "id": "edge:1",
+        "source_id": "claim:claim_handler_business",
+        "target_id": "business:object:customer",
+        "edge_type": "claim_to_object"
+      }
+    ]
+  }
+}
+```
+
+Business Graph 当前只消费已进入 BKN Trace 的 `business_refs`，并复用 `visibility` 做响应过滤。真实 BKN / Vega / Metric / Action resolver、按账号/租户的授权裁决、节点详情展开和持久化索引属于后续阶段。
 
 生成 Swagger 文档：
 

--- a/bkn-trace/agent-observability/docs/swagger/docs.go
+++ b/bkn-trace/agent-observability/docs/swagger/docs.go
@@ -16,6 +16,59 @@ const docTemplate = `{
     "host": "{{.Host}}",
     "basePath": "{{.BasePath}}",
     "paths": {
+        "/api/agent-observability/v1/evidence/events": {
+            "post": {
+                "description": "Accepts claim.created, evidence.refs.created, and business.refs.resolved events and stores the normalized evidence model.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "evidence"
+                ],
+                "summary": "Ingest BKN Trace phase-two evidence events",
+                "parameters": [
+                    {
+                        "description": "BKN Trace phase-two evidence event batch",
+                        "name": "request",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "202": {
+                        "description": "Accepted",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": true
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/rdto.ErrorResponse"
+                        }
+                    },
+                    "405": {
+                        "description": "Method Not Allowed",
+                        "schema": {
+                            "$ref": "#/definitions/rdto.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/rdto.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/api/agent-observability/v1/traces/_search": {
             "post": {
                 "description": "Proxy raw OpenSearch DSL to the configured trace index and return the original OpenSearch response body.",
@@ -123,6 +176,222 @@ const docTemplate = `{
                     }
                 }
             }
+        },
+        "/api/agent-observability/v1/traces/by-request": {
+            "get": {
+                "description": "Returns normalized claim, evidence refs, business refs, pagination, partial reasons, and visibility summary for a request.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "evidence"
+                ],
+                "summary": "Get evidence chain by BKN request ID",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "BKN request ID",
+                        "name": "request_id",
+                        "in": "query",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": true
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/rdto.ErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/rdto.ErrorResponse"
+                        }
+                    },
+                    "405": {
+                        "description": "Method Not Allowed",
+                        "schema": {
+                            "$ref": "#/definitions/rdto.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/rdto.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/api/agent-observability/v1/traces/by-request/business-graph": {
+            "get": {
+                "description": "Returns claim and business semantic nodes/edges derived from business.refs.resolved events.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "evidence"
+                ],
+                "summary": "Get business semantic graph by BKN request ID",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "BKN request ID",
+                        "name": "request_id",
+                        "in": "query",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": true
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/rdto.ErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/rdto.ErrorResponse"
+                        }
+                    },
+                    "405": {
+                        "description": "Method Not Allowed",
+                        "schema": {
+                            "$ref": "#/definitions/rdto.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/rdto.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/api/agent-observability/v1/traces/{trace_id}/business-graph": {
+            "get": {
+                "description": "Returns claim and business semantic nodes/edges derived from business.refs.resolved events.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "evidence"
+                ],
+                "summary": "Get business semantic graph by trace ID",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Trace ID",
+                        "name": "trace_id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": true
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/rdto.ErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/rdto.ErrorResponse"
+                        }
+                    },
+                    "405": {
+                        "description": "Method Not Allowed",
+                        "schema": {
+                            "$ref": "#/definitions/rdto.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/rdto.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/api/agent-observability/v1/traces/{trace_id}/evidence-chain": {
+            "get": {
+                "description": "Returns normalized claim, evidence refs, business refs, pagination, partial reasons, and visibility summary for a trace.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "evidence"
+                ],
+                "summary": "Get evidence chain by trace ID",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Trace ID",
+                        "name": "trace_id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": true
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/rdto.ErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/rdto.ErrorResponse"
+                        }
+                    },
+                    "405": {
+                        "description": "Method Not Allowed",
+                        "schema": {
+                            "$ref": "#/definitions/rdto.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/rdto.ErrorResponse"
+                        }
+                    }
+                }
+            }
         }
     },
     "definitions": {
@@ -132,6 +401,7 @@ const docTemplate = `{
                 "code": {
                     "type": "string"
                 },
+                "details": {},
                 "message": {
                     "type": "string"
                 }

--- a/bkn-trace/agent-observability/docs/swagger/swagger.json
+++ b/bkn-trace/agent-observability/docs/swagger/swagger.json
@@ -8,6 +8,59 @@
     },
     "basePath": "/api/agent-observability/v1",
     "paths": {
+        "/api/agent-observability/v1/evidence/events": {
+            "post": {
+                "description": "Accepts claim.created, evidence.refs.created, and business.refs.resolved events and stores the normalized evidence model.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "evidence"
+                ],
+                "summary": "Ingest BKN Trace phase-two evidence events",
+                "parameters": [
+                    {
+                        "description": "BKN Trace phase-two evidence event batch",
+                        "name": "request",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "202": {
+                        "description": "Accepted",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": true
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/rdto.ErrorResponse"
+                        }
+                    },
+                    "405": {
+                        "description": "Method Not Allowed",
+                        "schema": {
+                            "$ref": "#/definitions/rdto.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/rdto.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/api/agent-observability/v1/traces/_search": {
             "post": {
                 "description": "Proxy raw OpenSearch DSL to the configured trace index and return the original OpenSearch response body.",
@@ -115,6 +168,222 @@
                     }
                 }
             }
+        },
+        "/api/agent-observability/v1/traces/by-request": {
+            "get": {
+                "description": "Returns normalized claim, evidence refs, business refs, pagination, partial reasons, and visibility summary for a request.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "evidence"
+                ],
+                "summary": "Get evidence chain by BKN request ID",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "BKN request ID",
+                        "name": "request_id",
+                        "in": "query",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": true
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/rdto.ErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/rdto.ErrorResponse"
+                        }
+                    },
+                    "405": {
+                        "description": "Method Not Allowed",
+                        "schema": {
+                            "$ref": "#/definitions/rdto.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/rdto.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/api/agent-observability/v1/traces/by-request/business-graph": {
+            "get": {
+                "description": "Returns claim and business semantic nodes/edges derived from business.refs.resolved events.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "evidence"
+                ],
+                "summary": "Get business semantic graph by BKN request ID",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "BKN request ID",
+                        "name": "request_id",
+                        "in": "query",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": true
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/rdto.ErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/rdto.ErrorResponse"
+                        }
+                    },
+                    "405": {
+                        "description": "Method Not Allowed",
+                        "schema": {
+                            "$ref": "#/definitions/rdto.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/rdto.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/api/agent-observability/v1/traces/{trace_id}/business-graph": {
+            "get": {
+                "description": "Returns claim and business semantic nodes/edges derived from business.refs.resolved events.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "evidence"
+                ],
+                "summary": "Get business semantic graph by trace ID",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Trace ID",
+                        "name": "trace_id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": true
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/rdto.ErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/rdto.ErrorResponse"
+                        }
+                    },
+                    "405": {
+                        "description": "Method Not Allowed",
+                        "schema": {
+                            "$ref": "#/definitions/rdto.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/rdto.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/api/agent-observability/v1/traces/{trace_id}/evidence-chain": {
+            "get": {
+                "description": "Returns normalized claim, evidence refs, business refs, pagination, partial reasons, and visibility summary for a trace.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "evidence"
+                ],
+                "summary": "Get evidence chain by trace ID",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Trace ID",
+                        "name": "trace_id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": true
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/rdto.ErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/rdto.ErrorResponse"
+                        }
+                    },
+                    "405": {
+                        "description": "Method Not Allowed",
+                        "schema": {
+                            "$ref": "#/definitions/rdto.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/rdto.ErrorResponse"
+                        }
+                    }
+                }
+            }
         }
     },
     "definitions": {
@@ -124,6 +393,7 @@
                 "code": {
                     "type": "string"
                 },
+                "details": {},
                 "message": {
                     "type": "string"
                 }

--- a/bkn-trace/agent-observability/docs/swagger/swagger.yaml
+++ b/bkn-trace/agent-observability/docs/swagger/swagger.yaml
@@ -4,6 +4,7 @@ definitions:
     properties:
       code:
         type: string
+      details: {}
       message:
         type: string
     type: object
@@ -13,6 +14,42 @@ info:
   title: Agent Observability API
   version: "1.0"
 paths:
+  /api/agent-observability/v1/evidence/events:
+    post:
+      consumes:
+      - application/json
+      description: Accepts claim.created, evidence.refs.created, and business.refs.resolved
+        events and stores the normalized evidence model.
+      parameters:
+      - description: BKN Trace phase-two evidence event batch
+        in: body
+        name: request
+        required: true
+        schema:
+          type: string
+      produces:
+      - application/json
+      responses:
+        "202":
+          description: Accepted
+          schema:
+            additionalProperties: true
+            type: object
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/rdto.ErrorResponse'
+        "405":
+          description: Method Not Allowed
+          schema:
+            $ref: '#/definitions/rdto.ErrorResponse'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/rdto.ErrorResponse'
+      summary: Ingest BKN Trace phase-two evidence events
+      tags:
+      - evidence
   /api/agent-observability/v1/traces/_search:
     post:
       consumes:
@@ -48,6 +85,80 @@ paths:
       summary: Search traces with raw OpenSearch DSL
       tags:
       - traces
+  /api/agent-observability/v1/traces/{trace_id}/business-graph:
+    get:
+      description: Returns claim and business semantic nodes/edges derived from business.refs.resolved
+        events.
+      parameters:
+      - description: Trace ID
+        in: path
+        name: trace_id
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties: true
+            type: object
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/rdto.ErrorResponse'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/rdto.ErrorResponse'
+        "405":
+          description: Method Not Allowed
+          schema:
+            $ref: '#/definitions/rdto.ErrorResponse'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/rdto.ErrorResponse'
+      summary: Get business semantic graph by trace ID
+      tags:
+      - evidence
+  /api/agent-observability/v1/traces/{trace_id}/evidence-chain:
+    get:
+      description: Returns normalized claim, evidence refs, business refs, pagination,
+        partial reasons, and visibility summary for a trace.
+      parameters:
+      - description: Trace ID
+        in: path
+        name: trace_id
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties: true
+            type: object
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/rdto.ErrorResponse'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/rdto.ErrorResponse'
+        "405":
+          description: Method Not Allowed
+          schema:
+            $ref: '#/definitions/rdto.ErrorResponse'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/rdto.ErrorResponse'
+      summary: Get evidence chain by trace ID
+      tags:
+      - evidence
   /api/agent-observability/v1/traces/by-conversation:
     get:
       consumes:
@@ -86,4 +197,78 @@ paths:
       summary: Search traces by conversation ID
       tags:
       - traces
+  /api/agent-observability/v1/traces/by-request:
+    get:
+      description: Returns normalized claim, evidence refs, business refs, pagination,
+        partial reasons, and visibility summary for a request.
+      parameters:
+      - description: BKN request ID
+        in: query
+        name: request_id
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties: true
+            type: object
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/rdto.ErrorResponse'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/rdto.ErrorResponse'
+        "405":
+          description: Method Not Allowed
+          schema:
+            $ref: '#/definitions/rdto.ErrorResponse'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/rdto.ErrorResponse'
+      summary: Get evidence chain by BKN request ID
+      tags:
+      - evidence
+  /api/agent-observability/v1/traces/by-request/business-graph:
+    get:
+      description: Returns claim and business semantic nodes/edges derived from business.refs.resolved
+        events.
+      parameters:
+      - description: BKN request ID
+        in: query
+        name: request_id
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties: true
+            type: object
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/rdto.ErrorResponse'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/rdto.ErrorResponse'
+        "405":
+          description: Method Not Allowed
+          schema:
+            $ref: '#/definitions/rdto.ErrorResponse'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/rdto.ErrorResponse'
+      summary: Get business semantic graph by BKN request ID
+      tags:
+      - evidence
 swagger: "2.0"

--- a/bkn-trace/agent-observability/src/boot/bootstrap.go
+++ b/bkn-trace/agent-observability/src/boot/bootstrap.go
@@ -45,8 +45,9 @@ func NewApp() *App {
 	mux := http.NewServeMux()
 	mux.HandleFunc(APIBasePath+"/traces/_search", traceHandler.SearchTraces)
 	mux.HandleFunc(APIBasePath+"/traces/by-conversation", traceHandler.SearchTracesByConversationID)
+	mux.HandleFunc(APIBasePath+"/traces/by-request/business-graph", evidenceHandler.GetBusinessGraphByRequestID)
 	mux.HandleFunc(APIBasePath+"/traces/by-request", evidenceHandler.GetEvidenceChainByRequestID)
-	mux.HandleFunc(APIBasePath+"/traces/", evidenceHandler.GetEvidenceChainByTraceID)
+	mux.HandleFunc(APIBasePath+"/traces/", evidenceHandler.GetTraceSubresource)
 	mux.HandleFunc(APIBasePath+"/evidence/events", evidenceHandler.IngestEvidenceEvents)
 	mux.Handle(APIBasePath+"/swagger/", httpSwagger.Handler(
 		httpSwagger.URL(APIBasePath+"/swagger/doc.json"),

--- a/bkn-trace/agent-observability/src/domain/service/evidencesvc/service.go
+++ b/bkn-trace/agent-observability/src/domain/service/evidencesvc/service.go
@@ -226,8 +226,11 @@ func buildBusinessGraph(traces []evidencevo.NormalizedTrace) evidencevo.Business
 		RequestID: traces[0].RequestID,
 	}
 	knownClaims := map[string]struct{}{}
+	visibleClaims := map[string]struct{}{}
 	claimNodes := map[string]struct{}{}
 	businessNodes := map[string]struct{}{}
+	businessRefs := map[string]struct{}{}
+	edges := map[string]struct{}{}
 	partialReasons := map[string]struct{}{}
 	edgeIndex := 0
 	businessRefEvents := 0
@@ -242,9 +245,11 @@ func buildBusinessGraph(traces []evidencevo.NormalizedTrace) evidencevo.Business
 				knownClaims[claimID] = struct{}{}
 			}
 			if claimID != "" && visible(event.Payload) {
+				visibleClaims[claimID] = struct{}{}
 				addClaimNode(&response, claimNodes, event.Payload, claimID)
 			} else if !visible(event.Payload) {
 				countVisibility(event.Payload, &response.VisibilitySummary)
+				partialReasons["hidden_claim"] = struct{}{}
 			}
 		}
 	}
@@ -259,9 +264,11 @@ func buildBusinessGraph(traces []evidencevo.NormalizedTrace) evidencevo.Business
 				} else if _, ok := knownClaims[claimID]; !ok {
 					partialReasons["missing_claim"] = struct{}{}
 				}
-				if claimID != "" {
-					ensureSyntheticClaimNode(&response, claimNodes, claimID)
+				if _, ok := visibleClaims[claimID]; !ok {
+					countVisibleBusinessRefsAsOmitted(event.Payload, &response.VisibilitySummary)
+					continue
 				}
+				ensureSyntheticClaimNode(&response, claimNodes, claimID)
 				for _, item := range arrayField(event.Payload, "business_refs") {
 					ref, ok := item.(map[string]any)
 					if !ok {
@@ -277,9 +284,12 @@ func buildBusinessGraph(traces []evidencevo.NormalizedTrace) evidencevo.Business
 						partialReasons["business_ref_id_missing"] = struct{}{}
 						continue
 					}
-					response.VisibilitySummary.AuthorizedRefCount++
+					if _, ok := businessRefs[refID]; !ok {
+						businessRefs[refID] = struct{}{}
+						response.VisibilitySummary.AuthorizedRefCount++
+					}
 					addBusinessNode(&response, businessNodes, refID, claimID, ref)
-					if claimID != "" {
+					if claimID != "" && !edgeSeen(edges, "claim:"+claimID, "business:"+refID, businessEdgeType(ref)) {
 						edgeIndex++
 						response.Data.Edges = append(response.Data.Edges, evidencevo.BusinessGraphEdge{
 							ID:         "edge:" + strconv.Itoa(edgeIndex),
@@ -351,6 +361,20 @@ func countVisibility(item map[string]any, summary *evidencevo.VisibilitySummary)
 	}
 }
 
+func countVisibleBusinessRefsAsOmitted(payload map[string]any, summary *evidencevo.VisibilitySummary) {
+	for _, item := range arrayField(payload, "business_refs") {
+		ref, ok := item.(map[string]any)
+		if !ok {
+			continue
+		}
+		if visible(ref) {
+			summary.OmittedRefCount++
+			continue
+		}
+		countVisibility(ref, summary)
+	}
+}
+
 func cloneMap(value map[string]any) map[string]any {
 	clone := make(map[string]any, len(value))
 	for key, item := range value {
@@ -417,6 +441,15 @@ func businessEdgeType(ref map[string]any) string {
 		return "claim_to_business_ref"
 	}
 	return "claim_to_" + refType
+}
+
+func edgeSeen(edges map[string]struct{}, sourceID, targetID, edgeType string) bool {
+	key := sourceID + "|" + targetID + "|" + edgeType
+	if _, ok := edges[key]; ok {
+		return true
+	}
+	edges[key] = struct{}{}
+	return false
 }
 
 func visibilityValue(item map[string]any) string {

--- a/bkn-trace/agent-observability/src/domain/service/evidencesvc/service.go
+++ b/bkn-trace/agent-observability/src/domain/service/evidencesvc/service.go
@@ -140,6 +140,28 @@ func (s *Service) GetEvidenceChainByRequestID(ctx context.Context, requestID str
 	return buildEvidenceChain(traces), true, nil
 }
 
+func (s *Service) GetBusinessGraphByTraceID(ctx context.Context, traceID string) (evidencevo.BusinessGraphResponse, bool, error) {
+	traces, err := s.store.GetEvidenceByTraceID(ctx, strings.TrimSpace(traceID))
+	if err != nil {
+		return evidencevo.BusinessGraphResponse{}, false, err
+	}
+	if len(traces) == 0 {
+		return evidencevo.BusinessGraphResponse{}, false, nil
+	}
+	return buildBusinessGraph(traces), true, nil
+}
+
+func (s *Service) GetBusinessGraphByRequestID(ctx context.Context, requestID string) (evidencevo.BusinessGraphResponse, bool, error) {
+	traces, err := s.store.GetEvidenceByRequestID(ctx, strings.TrimSpace(requestID))
+	if err != nil {
+		return evidencevo.BusinessGraphResponse{}, false, err
+	}
+	if len(traces) == 0 {
+		return evidencevo.BusinessGraphResponse{}, false, nil
+	}
+	return buildBusinessGraph(traces), true, nil
+}
+
 func buildEvidenceChain(traces []evidencevo.NormalizedTrace) evidencevo.EvidenceChainResponse {
 	response := evidencevo.EvidenceChainResponse{
 		TraceID:   traces[0].TraceID,
@@ -198,6 +220,100 @@ func buildEvidenceChain(traces []evidencevo.NormalizedTrace) evidencevo.Evidence
 	return response
 }
 
+func buildBusinessGraph(traces []evidencevo.NormalizedTrace) evidencevo.BusinessGraphResponse {
+	response := evidencevo.BusinessGraphResponse{
+		TraceID:   traces[0].TraceID,
+		RequestID: traces[0].RequestID,
+	}
+	knownClaims := map[string]struct{}{}
+	claimNodes := map[string]struct{}{}
+	businessNodes := map[string]struct{}{}
+	partialReasons := map[string]struct{}{}
+	edgeIndex := 0
+	businessRefEvents := 0
+
+	for _, trace := range traces {
+		for _, event := range trace.Events {
+			if event.EventType != "claim.created" {
+				continue
+			}
+			claimID, _ := stringField(event.Payload, "claim_id")
+			if claimID != "" {
+				knownClaims[claimID] = struct{}{}
+			}
+			if claimID != "" && visible(event.Payload) {
+				addClaimNode(&response, claimNodes, event.Payload, claimID)
+			} else if !visible(event.Payload) {
+				countVisibility(event.Payload, &response.VisibilitySummary)
+			}
+		}
+	}
+
+	for _, trace := range traces {
+		for _, event := range trace.Events {
+			if event.EventType == "business.refs.resolved" {
+				businessRefEvents++
+				claimID, _ := stringField(event.Payload, "claim_id")
+				if claimID == "" {
+					partialReasons["missing_claim"] = struct{}{}
+				} else if _, ok := knownClaims[claimID]; !ok {
+					partialReasons["missing_claim"] = struct{}{}
+				}
+				if claimID != "" {
+					ensureSyntheticClaimNode(&response, claimNodes, claimID)
+				}
+				for _, item := range arrayField(event.Payload, "business_refs") {
+					ref, ok := item.(map[string]any)
+					if !ok {
+						partialReasons["business_ref_invalid"] = struct{}{}
+						continue
+					}
+					if !visible(ref) {
+						countVisibility(ref, &response.VisibilitySummary)
+						continue
+					}
+					refID, _ := stringField(ref, "ref_id")
+					if refID == "" {
+						partialReasons["business_ref_id_missing"] = struct{}{}
+						continue
+					}
+					response.VisibilitySummary.AuthorizedRefCount++
+					addBusinessNode(&response, businessNodes, refID, claimID, ref)
+					if claimID != "" {
+						edgeIndex++
+						response.Data.Edges = append(response.Data.Edges, evidencevo.BusinessGraphEdge{
+							ID:         "edge:" + strconv.Itoa(edgeIndex),
+							SourceID:   "claim:" + claimID,
+							TargetID:   "business:" + refID,
+							EdgeType:   businessEdgeType(ref),
+							Visibility: visibilityValue(ref),
+						})
+					}
+				}
+			}
+		}
+	}
+
+	if len(knownClaims) == 0 {
+		partialReasons["missing_claim"] = struct{}{}
+	}
+	if businessRefEvents == 0 {
+		partialReasons["missing_business_refs"] = struct{}{}
+	}
+	if response.VisibilitySummary.UnresolvedRefCount > 0 {
+		partialReasons["business_ref_unresolved"] = struct{}{}
+	}
+	if len(response.Data.Nodes) == 0 {
+		partialReasons["empty_business_graph"] = struct{}{}
+	}
+
+	response.PartialReasons = sortedKeys(partialReasons)
+	response.Partial = len(response.PartialReasons) > 0
+	response.Page.NodeCount = len(response.Data.Nodes)
+	response.Page.EdgeCount = len(response.Data.Edges)
+	return response
+}
+
 func appendVisibleRefs(target []map[string]any, refs []any, summary *evidencevo.VisibilitySummary) []map[string]any {
 	for _, item := range refs {
 		ref, ok := item.(map[string]any)
@@ -241,6 +357,74 @@ func cloneMap(value map[string]any) map[string]any {
 		clone[key] = item
 	}
 	return clone
+}
+
+func addClaimNode(response *evidencevo.BusinessGraphResponse, seen map[string]struct{}, payload map[string]any, claimID string) {
+	if _, ok := seen[claimID]; ok {
+		return
+	}
+	seen[claimID] = struct{}{}
+	label, _ := stringField(payload, "claim_type")
+	versionStatus, _ := stringField(payload, "version_status")
+	response.Data.Nodes = append(response.Data.Nodes, evidencevo.BusinessGraphNode{
+		ID:            "claim:" + claimID,
+		NodeType:      "claim",
+		Label:         label,
+		ClaimID:       claimID,
+		VersionStatus: versionStatus,
+		Visibility:    visibilityValue(payload),
+		Properties:    cloneMap(payload),
+	})
+}
+
+func ensureSyntheticClaimNode(response *evidencevo.BusinessGraphResponse, seen map[string]struct{}, claimID string) {
+	if _, ok := seen[claimID]; ok {
+		return
+	}
+	seen[claimID] = struct{}{}
+	response.Data.Nodes = append(response.Data.Nodes, evidencevo.BusinessGraphNode{
+		ID:       "claim:" + claimID,
+		NodeType: "claim",
+		ClaimID:  claimID,
+	})
+}
+
+func addBusinessNode(response *evidencevo.BusinessGraphResponse, seen map[string]struct{}, refID string, claimID string, ref map[string]any) {
+	if _, ok := seen[refID]; ok {
+		return
+	}
+	seen[refID] = struct{}{}
+	nodeType, _ := stringField(ref, "ref_type")
+	if nodeType == "" {
+		nodeType = "business_ref"
+	}
+	label, _ := stringField(ref, "label")
+	versionStatus, _ := stringField(ref, "version_status")
+	response.Data.Nodes = append(response.Data.Nodes, evidencevo.BusinessGraphNode{
+		ID:            "business:" + refID,
+		NodeType:      nodeType,
+		Label:         label,
+		ClaimID:       claimID,
+		VersionStatus: versionStatus,
+		Visibility:    visibilityValue(ref),
+		Properties:    cloneMap(ref),
+	})
+}
+
+func businessEdgeType(ref map[string]any) string {
+	refType, _ := stringField(ref, "ref_type")
+	if refType == "" {
+		return "claim_to_business_ref"
+	}
+	return "claim_to_" + refType
+}
+
+func visibilityValue(item map[string]any) string {
+	visibility, _ := item["visibility"].(string)
+	if visibility == "" {
+		return "visible"
+	}
+	return visibility
 }
 
 func sortedKeys(values map[string]struct{}) []string {

--- a/bkn-trace/agent-observability/src/domain/service/evidencesvc/service_test.go
+++ b/bkn-trace/agent-observability/src/domain/service/evidencesvc/service_test.go
@@ -280,6 +280,109 @@ func TestGetEvidenceChainByRequestIDReturnsMissingClaimPartial(t *testing.T) {
 	}
 }
 
+func TestGetBusinessGraphByTraceIDReturnsClaimAndBusinessNodes(t *testing.T) {
+	store := &fakeStore{traces: []evidencevo.NormalizedTrace{queryTrace("trace_graph_001", "req_graph_001")}}
+	service := New(store)
+
+	response, found, err := service.GetBusinessGraphByTraceID(context.Background(), "trace_graph_001")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !found {
+		t.Fatal("expected business graph to be found")
+	}
+	if response.TraceID != "trace_graph_001" || response.RequestID != "req_graph_001" {
+		t.Fatalf("unexpected identity: %+v", response)
+	}
+	if response.Partial {
+		t.Fatalf("expected complete graph, got partial: %+v", response.PartialReasons)
+	}
+	if response.Page.NodeCount != 2 || response.Page.EdgeCount != 1 {
+		t.Fatalf("unexpected page: %+v", response.Page)
+	}
+	if response.VisibilitySummary.AuthorizedRefCount != 1 {
+		t.Fatalf("unexpected visibility summary: %+v", response.VisibilitySummary)
+	}
+	if len(response.Data.Nodes) != 2 || len(response.Data.Edges) != 1 {
+		t.Fatalf("unexpected graph size: %+v", response.Data)
+	}
+	if response.Data.Edges[0].SourceID != "claim:claim_visible" || response.Data.Edges[0].TargetID != "business:object:customer" {
+		t.Fatalf("unexpected edge: %+v", response.Data.Edges[0])
+	}
+}
+
+func TestGetBusinessGraphByRequestIDHandlesHiddenAndUnresolvedRefs(t *testing.T) {
+	store := &fakeStore{traces: []evidencevo.NormalizedTrace{businessGraphTraceWithGovernance("trace_graph_002", "req_graph_002")}}
+	service := New(store)
+
+	response, found, err := service.GetBusinessGraphByRequestID(context.Background(), "req_graph_002")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !found {
+		t.Fatal("expected business graph to be found")
+	}
+	if !response.Partial || !contains(response.PartialReasons, "business_ref_unresolved") {
+		t.Fatalf("expected unresolved partial reason, got: %+v", response)
+	}
+	if response.VisibilitySummary.HiddenRefCount != 1 || response.VisibilitySummary.UnresolvedRefCount != 1 {
+		t.Fatalf("unexpected visibility summary: %+v", response.VisibilitySummary)
+	}
+	if len(response.Data.Nodes) != 2 {
+		t.Fatalf("hidden/unresolved refs must not leak as graph nodes: %+v", response.Data.Nodes)
+	}
+}
+
+func TestGetBusinessGraphDoesNotDependOnEventOrder(t *testing.T) {
+	store := &fakeStore{traces: []evidencevo.NormalizedTrace{businessGraphTraceWithBusinessBeforeClaim("trace_graph_003", "req_graph_003")}}
+	service := New(store)
+
+	response, found, err := service.GetBusinessGraphByTraceID(context.Background(), "trace_graph_003")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !found {
+		t.Fatal("expected business graph to be found")
+	}
+	if contains(response.PartialReasons, "missing_claim") {
+		t.Fatalf("business graph must collect claims before linking refs: %+v", response)
+	}
+	if response.Page.NodeCount != 2 || response.Page.EdgeCount != 1 {
+		t.Fatalf("unexpected page: %+v", response.Page)
+	}
+}
+
+func TestGetBusinessGraphReturnsMissingBusinessRefsPartial(t *testing.T) {
+	store := &fakeStore{traces: []evidencevo.NormalizedTrace{{
+		TraceID:   "trace_no_business_refs",
+		RequestID: "req_no_business_refs",
+		Events: []evidencevo.EvidenceEvent{
+			{
+				EventType: "claim.created",
+				Payload: map[string]any{
+					"claim_id":       "claim_no_business_refs",
+					"claim_type":     "answer",
+					"claim_hash":     "sha256:claim",
+					"visibility":     "visible",
+					"version_status": "versioned",
+				},
+			},
+		},
+	}}}
+	service := New(store)
+
+	response, found, err := service.GetBusinessGraphByTraceID(context.Background(), "trace_no_business_refs")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !found {
+		t.Fatal("expected business graph to be found")
+	}
+	if !response.Partial || !contains(response.PartialReasons, "missing_business_refs") {
+		t.Fatalf("expected missing business refs partial, got: %+v", response)
+	}
+}
+
 func TestGetEvidenceChainByTraceIDNotFound(t *testing.T) {
 	service := New(&fakeStore{})
 
@@ -339,11 +442,27 @@ func queryTrace(traceID, requestID string) evidencevo.NormalizedTrace {
 				EventType: "business.refs.resolved",
 				Payload: map[string]any{
 					"claim_id":      "claim_visible",
-					"business_refs": []any{map[string]any{"ref_id": "object:customer", "ref_type": "object", "visibility": "visible"}},
+					"business_refs": []any{map[string]any{"ref_id": "object:customer", "ref_type": "object", "label": "Customer", "visibility": "visible", "version_status": "versioned"}},
 				},
 			},
 		},
 	}
+}
+
+func businessGraphTraceWithGovernance(traceID, requestID string) evidencevo.NormalizedTrace {
+	trace := queryTrace(traceID, requestID)
+	trace.Events[2].Payload["business_refs"] = []any{
+		map[string]any{"ref_id": "object:customer", "ref_type": "object", "visibility": "visible", "version_status": "versioned"},
+		map[string]any{"ref_id": "object:hidden", "ref_type": "object", "visibility": "hidden"},
+		map[string]any{"ref_id": "object:deleted", "ref_type": "object", "visibility": "unresolved"},
+	}
+	return trace
+}
+
+func businessGraphTraceWithBusinessBeforeClaim(traceID, requestID string) evidencevo.NormalizedTrace {
+	trace := queryTrace(traceID, requestID)
+	trace.Events[0], trace.Events[2] = trace.Events[2], trace.Events[0]
+	return trace
 }
 
 func validBatch() string {

--- a/bkn-trace/agent-observability/src/domain/service/evidencesvc/service_test.go
+++ b/bkn-trace/agent-observability/src/domain/service/evidencesvc/service_test.go
@@ -352,6 +352,47 @@ func TestGetBusinessGraphDoesNotDependOnEventOrder(t *testing.T) {
 	}
 }
 
+func TestGetBusinessGraphDeduplicatesEdgesAndAuthorizedRefs(t *testing.T) {
+	store := &fakeStore{traces: []evidencevo.NormalizedTrace{businessGraphTraceWithDuplicateRefs("trace_graph_004", "req_graph_004")}}
+	service := New(store)
+
+	response, found, err := service.GetBusinessGraphByTraceID(context.Background(), "trace_graph_004")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !found {
+		t.Fatal("expected business graph to be found")
+	}
+	if response.Page.EdgeCount != 1 || len(response.Data.Edges) != 1 {
+		t.Fatalf("expected duplicate edges to be collapsed, got page=%+v edges=%+v", response.Page, response.Data.Edges)
+	}
+	if response.VisibilitySummary.AuthorizedRefCount != 1 {
+		t.Fatalf("expected duplicate refs to count once, got %+v", response.VisibilitySummary)
+	}
+}
+
+func TestGetBusinessGraphDoesNotLeakHiddenClaimThroughSyntheticNode(t *testing.T) {
+	store := &fakeStore{traces: []evidencevo.NormalizedTrace{businessGraphTraceWithHiddenClaim("trace_graph_005", "req_graph_005")}}
+	service := New(store)
+
+	response, found, err := service.GetBusinessGraphByTraceID(context.Background(), "trace_graph_005")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !found {
+		t.Fatal("expected business graph to be found")
+	}
+	if !response.Partial || !contains(response.PartialReasons, "hidden_claim") {
+		t.Fatalf("expected hidden claim partial, got %+v", response)
+	}
+	if response.Page.NodeCount != 0 || response.Page.EdgeCount != 0 {
+		t.Fatalf("hidden claim must not leak through nodes or edges: %+v", response)
+	}
+	if response.VisibilitySummary.HiddenRefCount != 1 || response.VisibilitySummary.OmittedRefCount != 1 {
+		t.Fatalf("expected hidden claim and omitted business ref counts, got %+v", response.VisibilitySummary)
+	}
+}
+
 func TestGetBusinessGraphReturnsMissingBusinessRefsPartial(t *testing.T) {
 	store := &fakeStore{traces: []evidencevo.NormalizedTrace{{
 		TraceID:   "trace_no_business_refs",
@@ -462,6 +503,22 @@ func businessGraphTraceWithGovernance(traceID, requestID string) evidencevo.Norm
 func businessGraphTraceWithBusinessBeforeClaim(traceID, requestID string) evidencevo.NormalizedTrace {
 	trace := queryTrace(traceID, requestID)
 	trace.Events[0], trace.Events[2] = trace.Events[2], trace.Events[0]
+	return trace
+}
+
+func businessGraphTraceWithDuplicateRefs(traceID, requestID string) evidencevo.NormalizedTrace {
+	trace := queryTrace(traceID, requestID)
+	trace.Events[2].Payload["business_refs"] = []any{
+		map[string]any{"ref_id": "object:customer", "ref_type": "object", "visibility": "visible", "version_status": "versioned"},
+		map[string]any{"ref_id": "object:customer", "ref_type": "object", "visibility": "visible", "version_status": "versioned"},
+	}
+	trace.Events = append(trace.Events, trace.Events[2])
+	return trace
+}
+
+func businessGraphTraceWithHiddenClaim(traceID, requestID string) evidencevo.NormalizedTrace {
+	trace := queryTrace(traceID, requestID)
+	trace.Events[0].Payload["visibility"] = "hidden"
 	return trace
 }
 

--- a/bkn-trace/agent-observability/src/domain/valueobject/evidencevo/evidence.go
+++ b/bkn-trace/agent-observability/src/domain/valueobject/evidencevo/evidence.go
@@ -90,6 +90,39 @@ type EvidenceChainData struct {
 	BusinessRefs []map[string]any `json:"business_refs"`
 }
 
+type BusinessGraphResponse struct {
+	TraceID           string            `json:"trace_id"`
+	RequestID         string            `json:"bkn.request.id"`
+	Partial           bool              `json:"partial"`
+	PartialReasons    []string          `json:"partial_reason"`
+	VisibilitySummary VisibilitySummary `json:"visibility_summary"`
+	Page              EvidencePage      `json:"page"`
+	Data              BusinessGraphData `json:"data"`
+}
+
+type BusinessGraphData struct {
+	Nodes []BusinessGraphNode `json:"nodes"`
+	Edges []BusinessGraphEdge `json:"edges"`
+}
+
+type BusinessGraphNode struct {
+	ID            string         `json:"id"`
+	NodeType      string         `json:"node_type"`
+	Label         string         `json:"label,omitempty"`
+	ClaimID       string         `json:"claim_id,omitempty"`
+	VersionStatus string         `json:"version_status,omitempty"`
+	Visibility    string         `json:"visibility,omitempty"`
+	Properties    map[string]any `json:"properties,omitempty"`
+}
+
+type BusinessGraphEdge struct {
+	ID         string `json:"id"`
+	SourceID   string `json:"source_id"`
+	TargetID   string `json:"target_id"`
+	EdgeType   string `json:"edge_type"`
+	Visibility string `json:"visibility,omitempty"`
+}
+
 type IngestResponse struct {
 	TraceID          string `json:"trace_id"`
 	RequestID        string `json:"bkn.request.id"`

--- a/bkn-trace/agent-observability/src/driveradapter/api/httphandler/evidence_handler.go
+++ b/bkn-trace/agent-observability/src/driveradapter/api/httphandler/evidence_handler.go
@@ -140,6 +140,70 @@ func (h *EvidenceHandler) GetEvidenceChainByTraceID(w http.ResponseWriter, r *ht
 	writeJSON(w, http.StatusOK, response)
 }
 
+func (h *EvidenceHandler) GetTraceSubresource(w http.ResponseWriter, r *http.Request) {
+	if strings.HasSuffix(r.URL.Path, "/evidence-chain") {
+		h.GetEvidenceChainByTraceID(w, r)
+		return
+	}
+	if strings.HasSuffix(r.URL.Path, "/business-graph") {
+		h.GetBusinessGraphByTraceID(w, r)
+		return
+	}
+	writeJSON(w, http.StatusNotFound, rdto.ErrorResponse{
+		Code:    "NOT_FOUND",
+		Message: "trace subresource not found",
+	})
+}
+
+// GetBusinessGraphByTraceID godoc
+// @Summary Get business semantic graph by trace ID
+// @Description Returns claim and business semantic nodes/edges derived from business.refs.resolved events.
+// @Tags evidence
+// @Produce json
+// @Param trace_id path string true "Trace ID"
+// @Success 200 {object} map[string]interface{}
+// @Failure 400 {object} rdto.ErrorResponse
+// @Failure 404 {object} rdto.ErrorResponse
+// @Failure 405 {object} rdto.ErrorResponse
+// @Failure 500 {object} rdto.ErrorResponse
+// @Router /api/agent-observability/v1/traces/{trace_id}/business-graph [get]
+func (h *EvidenceHandler) GetBusinessGraphByTraceID(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		writeJSON(w, http.StatusMethodNotAllowed, rdto.ErrorResponse{
+			Code:    "METHOD_NOT_ALLOWED",
+			Message: "only GET is supported",
+		})
+		return
+	}
+
+	traceID := traceIDFromBusinessGraphPath(r.URL.Path)
+	if traceID == "" {
+		writeJSON(w, http.StatusBadRequest, rdto.ErrorResponse{
+			Code:    "INVALID_ARGUMENT",
+			Message: "trace_id is required",
+		})
+		return
+	}
+
+	response, found, err := h.evidenceService.GetBusinessGraphByTraceID(r.Context(), traceID)
+	if err != nil {
+		writeJSON(w, http.StatusInternalServerError, rdto.ErrorResponse{
+			Code:    "QUERY_FAILED",
+			Message: "failed to query business graph",
+		})
+		return
+	}
+	if !found {
+		writeJSON(w, http.StatusNotFound, rdto.ErrorResponse{
+			Code:    "NOT_FOUND",
+			Message: "business graph not found",
+		})
+		return
+	}
+
+	writeJSON(w, http.StatusOK, response)
+}
+
 // GetEvidenceChainByRequestID godoc
 // @Summary Get evidence chain by BKN request ID
 // @Description Returns normalized claim, evidence refs, business refs, pagination, partial reasons, and visibility summary for a request.
@@ -189,9 +253,72 @@ func (h *EvidenceHandler) GetEvidenceChainByRequestID(w http.ResponseWriter, r *
 	writeJSON(w, http.StatusOK, response)
 }
 
+// GetBusinessGraphByRequestID godoc
+// @Summary Get business semantic graph by BKN request ID
+// @Description Returns claim and business semantic nodes/edges derived from business.refs.resolved events.
+// @Tags evidence
+// @Produce json
+// @Param request_id query string true "BKN request ID"
+// @Success 200 {object} map[string]interface{}
+// @Failure 400 {object} rdto.ErrorResponse
+// @Failure 404 {object} rdto.ErrorResponse
+// @Failure 405 {object} rdto.ErrorResponse
+// @Failure 500 {object} rdto.ErrorResponse
+// @Router /api/agent-observability/v1/traces/by-request/business-graph [get]
+func (h *EvidenceHandler) GetBusinessGraphByRequestID(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		writeJSON(w, http.StatusMethodNotAllowed, rdto.ErrorResponse{
+			Code:    "METHOD_NOT_ALLOWED",
+			Message: "only GET is supported",
+		})
+		return
+	}
+
+	requestID := strings.TrimSpace(r.URL.Query().Get("request_id"))
+	if requestID == "" {
+		writeJSON(w, http.StatusBadRequest, rdto.ErrorResponse{
+			Code:    "INVALID_ARGUMENT",
+			Message: "request_id is required",
+		})
+		return
+	}
+
+	response, found, err := h.evidenceService.GetBusinessGraphByRequestID(r.Context(), requestID)
+	if err != nil {
+		writeJSON(w, http.StatusInternalServerError, rdto.ErrorResponse{
+			Code:    "QUERY_FAILED",
+			Message: "failed to query business graph",
+		})
+		return
+	}
+	if !found {
+		writeJSON(w, http.StatusNotFound, rdto.ErrorResponse{
+			Code:    "NOT_FOUND",
+			Message: "business graph not found",
+		})
+		return
+	}
+
+	writeJSON(w, http.StatusOK, response)
+}
+
 func traceIDFromEvidenceChainPath(path string) string {
 	const prefix = "/api/agent-observability/v1/traces/"
 	const suffix = "/evidence-chain"
+	if !strings.HasPrefix(path, prefix) || !strings.HasSuffix(path, suffix) {
+		return ""
+	}
+	traceID := strings.TrimSuffix(strings.TrimPrefix(path, prefix), suffix)
+	traceID = strings.Trim(traceID, "/")
+	if strings.Contains(traceID, "/") {
+		return ""
+	}
+	return strings.TrimSpace(traceID)
+}
+
+func traceIDFromBusinessGraphPath(path string) string {
+	const prefix = "/api/agent-observability/v1/traces/"
+	const suffix = "/business-graph"
 	if !strings.HasPrefix(path, prefix) || !strings.HasSuffix(path, suffix) {
 		return ""
 	}

--- a/bkn-trace/agent-observability/src/driveradapter/api/httphandler/evidence_handler_test.go
+++ b/bkn-trace/agent-observability/src/driveradapter/api/httphandler/evidence_handler_test.go
@@ -150,6 +150,62 @@ func TestEvidenceHandlerReturnsEvidenceChainByRequest(t *testing.T) {
 	}
 }
 
+func TestEvidenceHandlerReturnsBusinessGraphByTrace(t *testing.T) {
+	store := evidencestore.New()
+	handler := NewEvidenceHandler(evidencesvc.New(store))
+	ingestReq := httptest.NewRequest(http.MethodPost, "/api/agent-observability/v1/evidence/events", strings.NewReader(validHandlerBusinessBatch()))
+	ingestRec := httptest.NewRecorder()
+	handler.IngestEvidenceEvents(ingestRec, ingestReq)
+	if ingestRec.Code != http.StatusAccepted {
+		t.Fatalf("expected ingest 202, got %d: %s", ingestRec.Code, ingestRec.Body.String())
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/api/agent-observability/v1/traces/9c0d0000000000000000000000000002/business-graph", nil)
+	rec := httptest.NewRecorder()
+	handler.GetTraceSubresource(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+	if !strings.Contains(rec.Body.String(), `"nodes"`) || !strings.Contains(rec.Body.String(), `"edges"`) {
+		t.Fatalf("expected graph data in body: %s", rec.Body.String())
+	}
+	if !strings.Contains(rec.Body.String(), `"target_id":"business:object:customer"`) {
+		t.Fatalf("expected business node edge in body: %s", rec.Body.String())
+	}
+}
+
+func TestEvidenceHandlerReturnsBusinessGraphByRequest(t *testing.T) {
+	store := evidencestore.New()
+	handler := NewEvidenceHandler(evidencesvc.New(store))
+	ingestReq := httptest.NewRequest(http.MethodPost, "/api/agent-observability/v1/evidence/events", strings.NewReader(validHandlerBusinessBatch()))
+	ingestRec := httptest.NewRecorder()
+	handler.IngestEvidenceEvents(ingestRec, ingestReq)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/agent-observability/v1/traces/by-request/business-graph?request_id=req_handler_002", nil)
+	rec := httptest.NewRecorder()
+	handler.GetBusinessGraphByRequestID(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+	if !strings.Contains(rec.Body.String(), `"bkn.request.id":"req_handler_002"`) {
+		t.Fatalf("unexpected body: %s", rec.Body.String())
+	}
+}
+
+func TestEvidenceHandlerReturnsNotFoundForUnknownTraceSubresource(t *testing.T) {
+	handler := NewEvidenceHandler(evidencesvc.New(evidencestore.New()))
+	req := httptest.NewRequest(http.MethodGet, "/api/agent-observability/v1/traces/9c0d0000000000000000000000000001/unknown", nil)
+	rec := httptest.NewRecorder()
+
+	handler.GetTraceSubresource(rec, req)
+
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("expected 404, got %d: %s", rec.Code, rec.Body.String())
+	}
+}
+
 func TestEvidenceHandlerReturnsNotFoundForMissingEvidenceChain(t *testing.T) {
 	handler := NewEvidenceHandler(evidencesvc.New(evidencestore.New()))
 	req := httptest.NewRequest(http.MethodGet, "/api/agent-observability/v1/traces/missing/evidence-chain", nil)
@@ -191,6 +247,65 @@ func validHandlerBatch() string {
         "claim_hash": "sha256:claim",
         "visibility": "visible",
         "version_status": "versioned"
+      }
+    }
+  ]
+}`
+}
+
+func validHandlerBusinessBatch() string {
+	return `{
+  "bkn.trace.schema.version": "2.0.0",
+  "trace": {
+    "trace_id": "9c0d0000000000000000000000000002",
+    "bkn.request.id": "req_handler_002",
+    "traceparent": "00-9c0d0000000000000000000000000002-2f12000000000002-01",
+    "business_domain": "bd_demo",
+    "bkn.account.id": "acct_demo",
+    "bkn.account.type": "app"
+  },
+  "events": [
+    {
+      "event_id": "evt_claim_business",
+      "event_type": "claim.created",
+      "bkn.trace.schema.version": "2.0.0",
+      "observed_at": "2026-07-22T04:00:00.000000000Z",
+      "emitted_at": "2026-07-22T04:00:00.001000000Z",
+      "producer_module": "third-party-agent",
+      "trace_id": "9c0d0000000000000000000000000002",
+      "span_id": "2f12000000000002",
+      "bkn.request.id": "req_handler_002",
+      "bkn.operation.name": "agent.answer",
+      "payload": {
+        "claim_id": "claim_handler_business",
+        "claim_type": "answer",
+        "claim_hash": "sha256:claim",
+        "visibility": "visible",
+        "version_status": "versioned"
+      }
+    },
+    {
+      "event_id": "evt_business",
+      "event_type": "business.refs.resolved",
+      "bkn.trace.schema.version": "2.0.0",
+      "observed_at": "2026-07-22T04:00:00.002000000Z",
+      "emitted_at": "2026-07-22T04:00:00.003000000Z",
+      "producer_module": "bkn-trace",
+      "trace_id": "9c0d0000000000000000000000000002",
+      "span_id": "2f12000000000002",
+      "bkn.request.id": "req_handler_002",
+      "bkn.operation.name": "bkn_trace.resolve_business_refs",
+      "payload": {
+        "claim_id": "claim_handler_business",
+        "business_refs": [
+          {
+            "ref_id": "object:customer",
+            "ref_type": "object",
+            "label": "Customer",
+            "visibility": "visible",
+            "version_status": "versioned"
+          }
+        ]
       }
     }
   ]


### PR DESCRIPTION
# Pull Request

## What Changed

Brief description of changes:

- [x] Add Business Graph response model for BKN Trace phase two
- [x] Add trace/request query APIs for Business Graph
- [x] Add service and handler tests plus generated Swagger docs

---

## Why

- Related Issue: https://github.com/openbkn-ai/bkn-foundry/issues/270
- Related Feature: BKN Trace phase two Evidence / Business Semantic Graph
- Background: after normalized evidence-chain query landed, Studio and SDK need a stable business semantic graph envelope that does not depend on raw span attributes or module-private event shapes.

---

## How

- Key implementation points:
  - Adds `GET /api/agent-observability/v1/traces/{trace_id}/business-graph`.
  - Adds `GET /api/agent-observability/v1/traces/by-request/business-graph?request_id=...`.
  - Builds claim and business nodes/edges from normalized `business.refs.resolved` events.
  - Filters hidden/redacted/omitted/unresolved refs from node detail and exposes counts through `visibility_summary`.
  - Emits partial reasons for missing claims, missing business refs, unresolved refs, invalid refs, and empty graph.
- Breaking changes (API, config, database, etc.): none. Existing evidence-chain and trace query routes remain compatible.

---

## Testing

- [x] Unit tests passed locally
- [ ] Integration tests passed locally
- [ ] Verified in test environment

Test notes:

- `env GOCACHE=/tmp/openbkn-go-cache go test ./...`
- `env GOCACHE=/tmp/openbkn-go-cache go vet ./...`
- `helm lint charts/agent-observability`
- `git diff --check`
- Swagger regenerated with `go run github.com/swaggo/swag/cmd/swag init -g main.go -o docs/swagger --parseDependency --parseInternal`; swag emitted Go 1.26 stdlib constant warnings but generated docs successfully.

---

## Risk & Rollback

- Potential risks: current Business Graph only consumes already-ingested `business_refs`; it is not yet resolver-backed per-account authorization or full node detail expansion.
- Rollback plan: revert this commit to remove the additive Business Graph endpoints and restore the previous evidence-chain-only surface.

---

## Additional Notes

- This is the next phase-two step after normalized Evidence Chain query.
- Resolver-backed BKN / Vega / Metric / Action expansion remains a follow-up.
