### PR TITLE
fix(vega): validate raw SQL resource placeholders

### DIFF
--- a/adp/vega/vega-backend/server/logics/query/querypolicy/sqlglot_adapter.go
+++ b/adp/vega/vega-backend/server/logics/query/querypolicy/sqlglot_adapter.go
@@ -114,6 +114,117 @@ type validationResult struct {
 	Error string `json:"error"`
 }
 
+type resourceIDExtractionResult struct {
+	ResourceIDs []string `json:"resource_ids"`
+	Error       string   `json:"error"`
+}
+
+// ExtractTableResourceIDs returns Resource IDs only when their placeholders
+// occur in SQL Table nodes. Comments and string literals are intentionally
+// left untouched before parsing, so they can never establish a binding.
+func ExtractTableResourceIDs(ctx context.Context, sql string, inputDialect string) ([]string, error) {
+	cmd := exec.CommandContext(ctx, "python3", "-c", resourceIDExtractionScript, sql, inputDialect)
+
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	if err := cmd.Run(); err != nil {
+		logger.Errorf("ExtractTableResourceIDs policy command failed")
+		if ctxErr := ctx.Err(); ctxErr != nil {
+			return nil, ctxErr
+		}
+		return nil, err
+	}
+
+	var result resourceIDExtractionResult
+	if err := sonic.Unmarshal(out.Bytes(), &result); err != nil {
+		logger.Errorf("ExtractTableResourceIDs policy response decode failed")
+		return nil, err
+	}
+	if result.Error != "" {
+		return nil, errors.New("invalid SQL resource placeholder")
+	}
+	return result.ResourceIDs, nil
+}
+
+const resourceIDExtractionScript = `
+import json
+import re
+import secrets
+import sys
+
+import sqlglot
+from sqlglot import exp
+
+PLACEHOLDER = re.compile(r"\{\{\.?([a-z0-9][a-z0-9_-]{0,39})\}\}")
+
+def replace_code_placeholders(sql):
+    marker_prefix = "__bkn_resource_" + secrets.token_hex(16) + "_"
+    resource_by_marker = {}
+    output = []
+    index = 0
+    marker_index = 0
+    while index < len(sql):
+        if sql.startswith("--", index):
+            end = sql.find("\n", index)
+            if end == -1:
+                output.append(sql[index:])
+                break
+            output.append(sql[index:end + 1])
+            index = end + 1
+            continue
+        if sql.startswith("/*", index):
+            end = sql.find("*/", index + 2)
+            if end == -1:
+                output.append(sql[index:])
+                break
+            output.append(sql[index:end + 2])
+            index = end + 2
+            continue
+        if sql[index] in "'\"" or sql[index] == chr(96):
+            quote = sql[index]
+            end = index + 1
+            while end < len(sql):
+                if sql[end] == quote:
+                    if end + 1 < len(sql) and sql[end + 1] == quote:
+                        end += 2
+                        continue
+                    end += 1
+                    break
+                if sql[end] == "\\\\" and quote == "'" and end + 1 < len(sql):
+                    end += 2
+                    continue
+                end += 1
+            output.append(sql[index:end])
+            index = end
+            continue
+        match = PLACEHOLDER.match(sql, index)
+        if match:
+            marker = marker_prefix + str(marker_index)
+            marker_index += 1
+            resource_by_marker[marker] = match.group(1)
+            output.append(marker)
+            index = match.end()
+            continue
+        output.append(sql[index])
+        index += 1
+    return "".join(output), resource_by_marker
+
+try:
+    sql, dialect = sys.argv[1], sys.argv[2]
+    transformed, resource_by_marker = replace_code_placeholders(sql)
+    statement = sqlglot.parse_one(transformed, read=dialect)
+    resource_ids = []
+    seen = set()
+    for table in statement.find_all(exp.Table):
+        resource_id = resource_by_marker.get(table.name)
+        if resource_id is not None and resource_id not in seen:
+            seen.add(resource_id)
+            resource_ids.append(resource_id)
+    print(json.dumps({"resource_ids": resource_ids, "error": None}))
+except Exception as e:
+    print(json.dumps({"resource_ids": [], "error": "invalid SQL resource placeholder: " + str(e)}))
+`
+
 const validationScript = `
 import json
 import sys

--- a/adp/vega/vega-backend/server/logics/query/querypolicy/sqlglot_adapter.go
+++ b/adp/vega/vega-backend/server/logics/query/querypolicy/sqlglot_adapter.go
@@ -23,6 +23,7 @@ const rejectedPrefix = "READ_ONLY_SQL_REJECTED:"
 
 // Adapter validates a query against the Raw Query policy.
 type Adapter interface {
+	ExtractTableResourceIDs(ctx context.Context, sql string, inputDialect string) ([]string, error)
 	ValidateSQL(ctx context.Context, sql string, inputDialect string) error
 	ValidateTableReferences(ctx context.Context, sql string, inputDialect string, allowedReferences []string) error
 }
@@ -42,6 +43,10 @@ type SQLGlotAdapter struct{}
 
 func NewSQLGlotAdapter() *SQLGlotAdapter {
 	return &SQLGlotAdapter{}
+}
+
+func (a *SQLGlotAdapter) ExtractTableResourceIDs(ctx context.Context, sql string, inputDialect string) ([]string, error) {
+	return ExtractTableResourceIDs(ctx, sql, inputDialect)
 }
 
 func (a *SQLGlotAdapter) ValidateSQL(ctx context.Context, sql string, inputDialect string) error {
@@ -190,7 +195,7 @@ def replace_code_placeholders(sql):
                         continue
                     end += 1
                     break
-                if sql[end] == "\\\\" and quote == "'" and end + 1 < len(sql):
+                if dialect == "mysql" and sql[end] == "\\" and quote == "'" and end + 1 < len(sql):
                     end += 2
                     continue
                 end += 1

--- a/adp/vega/vega-backend/server/logics/query/querypolicy/sqlglot_adapter_test.go
+++ b/adp/vega/vega-backend/server/logics/query/querypolicy/sqlglot_adapter_test.go
@@ -68,6 +68,7 @@ func TestSQLGlotAdapterValidateSQL(t *testing.T) {
 			assert.True(t, errors.As(err, &validationErr))
 		})
 	}
+
 }
 
 func TestSQLGlotAdapterValidateTableReferences(t *testing.T) {
@@ -108,6 +109,11 @@ func TestExtractTableResourceIDs(t *testing.T) {
 			assert.Empty(t, ids)
 		})
 	}
+
+	ids, err = ExtractTableResourceIDs(context.Background(),
+		"SELECT 'it\\'s {{ignored-resource}}' FROM {{orders-2026}}", "mysql")
+	require.NoError(t, err)
+	assert.Equal(t, []string{"orders-2026"}, ids)
 }
 
 func TestSQLGlotAdapterHonorsCanceledContext(t *testing.T) {

--- a/adp/vega/vega-backend/server/logics/query/querypolicy/sqlglot_adapter_test.go
+++ b/adp/vega/vega-backend/server/logics/query/querypolicy/sqlglot_adapter_test.go
@@ -89,6 +89,27 @@ func TestSQLGlotAdapterValidateTableReferences(t *testing.T) {
 	assert.Contains(t, validationErr.Reason, "unbound physical table")
 }
 
+func TestExtractTableResourceIDs(t *testing.T) {
+	requireSQLGlotRuntime(t)
+
+	ids, err := ExtractTableResourceIDs(context.Background(),
+		"SELECT * FROM {{orders-2026}} JOIN {{.customer_data}} ON true", "postgres")
+	require.NoError(t, err)
+	assert.Equal(t, []string{"orders-2026", "customer_data"}, ids)
+
+	for _, sql := range []string{
+		"SELECT * FROM public.orders /* {{orders-2026}} */",
+		"SELECT * FROM public.orders -- {{orders-2026}}\n",
+		"SELECT '{{orders-2026}}' FROM public.orders",
+	} {
+		t.Run(sql, func(t *testing.T) {
+			ids, err := ExtractTableResourceIDs(context.Background(), sql, "postgres")
+			require.NoError(t, err)
+			assert.Empty(t, ids)
+		})
+	}
+}
+
 func TestSQLGlotAdapterHonorsCanceledContext(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()

--- a/adp/vega/vega-backend/server/logics/query/raw_query_service.go
+++ b/adp/vega/vega-backend/server/logics/query/raw_query_service.go
@@ -256,7 +256,7 @@ func (rqs *rawQueryService) prepareSQLQuery(ctx context.Context, req *interfaces
 	if err != nil {
 		return nil, err
 	}
-	replacedSQL, err := rqs.replaceResourceIDWithSchemaTable(ctx, req.Query, resourceIDs, catalog)
+	replacedSQL, err := rqs.replaceResourceIDWithSchemaTable(ctx, req.Query, resourceIDs, catalog, inputDialect)
 	if err != nil {
 		return nil, err
 	}
@@ -739,7 +739,7 @@ func rawQueryTotalCount(result *interfaces.RawQueryResponse) (int64, error) {
 // extractResourceIDs 从 FROM/JOIN 表引用中提取所有 {{.resource_id}} 占位符。
 func (rqs *rawQueryService) extractResourceIDs(ctx context.Context, query any, inputDialect string) ([]string, error) {
 	if queryStr, ok := query.(string); ok {
-		return querypolicy.ExtractTableResourceIDs(ctx, queryStr, inputDialect)
+		return rawQueryPolicy.ExtractTableResourceIDs(ctx, queryStr, inputDialect)
 	}
 
 	// 如果query是map类型（OpenSearch DSL），返回空数组
@@ -819,7 +819,7 @@ func ensureCatalogEnabled(ctx context.Context, catalog *interfaces.Catalog) erro
 }
 
 // replaceResourceIDWithSchemaTable 将resource_id替换为schema.table格式
-func (rqs *rawQueryService) replaceResourceIDWithSchemaTable(ctx context.Context, sql any, resourceIDs []string, catalog *interfaces.Catalog) (string, error) {
+func (rqs *rawQueryService) replaceResourceIDWithSchemaTable(ctx context.Context, sql any, resourceIDs []string, catalog *interfaces.Catalog, inputDialect string) (string, error) {
 	replacedSQL := sql.(string)
 	logger.Infof("Before replace - %s, resource_ids: %v", SafeQuerySummary(replacedSQL), resourceIDs)
 
@@ -840,8 +840,8 @@ func (rqs *rawQueryService) replaceResourceIDWithSchemaTable(ctx context.Context
 		// 替换{{.resource_id}}和{{resource_id}}为schema.table
 		placeholder1 := fmt.Sprintf("{{.%s}}", resourceID)
 		placeholder2 := fmt.Sprintf("{{%s}}", resourceID)
-		replacedSQL = replacePlaceholderInSQLCode(replacedSQL, placeholder1, resource.SourceIdentifier)
-		replacedSQL = replacePlaceholderInSQLCode(replacedSQL, placeholder2, resource.SourceIdentifier)
+		replacedSQL = replacePlaceholderInSQLCode(replacedSQL, placeholder1, resource.SourceIdentifier, inputDialect)
+		replacedSQL = replacePlaceholderInSQLCode(replacedSQL, placeholder2, resource.SourceIdentifier, inputDialect)
 	}
 
 	logger.Infof("After replace - %s", SafeQuerySummary(replacedSQL))
@@ -850,7 +850,7 @@ func (rqs *rawQueryService) replaceResourceIDWithSchemaTable(ctx context.Context
 
 // replacePlaceholderInSQLCode preserves comments and quoted literals. They
 // are not resource bindings and must remain semantically unchanged.
-func replacePlaceholderInSQLCode(sql, placeholder, replacement string) string {
+func replacePlaceholderInSQLCode(sql, placeholder, replacement, inputDialect string) string {
 	var output strings.Builder
 	output.Grow(len(sql))
 	for index := 0; index < len(sql); {
@@ -888,7 +888,7 @@ func replacePlaceholderInSQLCode(sql, placeholder, replacement string) string {
 					end++
 					break
 				}
-				if quote == '\'' && sql[end] == '\\' && end+1 < len(sql) {
+				if inputDialect == "mysql" && quote == '\'' && sql[end] == '\\' && end+1 < len(sql) {
 					end += 2
 					continue
 				}

--- a/adp/vega/vega-backend/server/logics/query/raw_query_service.go
+++ b/adp/vega/vega-backend/server/logics/query/raw_query_service.go
@@ -12,7 +12,6 @@ import (
 	"fmt"
 	"math"
 	"net/http"
-	"regexp"
 	"strconv"
 	"strings"
 	"sync"
@@ -243,7 +242,8 @@ type preparedSQLQuery struct {
 // cursor execution. Policy validation deliberately happens after controlled
 // resource binding and before compilation or connector execution.
 func (rqs *rawQueryService) prepareSQLQuery(ctx context.Context, req *interfaces.RawQueryRequest) (*preparedSQLQuery, error) {
-	resourceIDs, err := rqs.extractResourceIDs(req.Query)
+	inputDialect := req.EffectiveInputDialect()
+	resourceIDs, err := rqs.extractResourceIDs(ctx, req.Query, inputDialect)
 	if err != nil {
 		return nil, rest.NewHTTPError(ctx, http.StatusBadRequest, verrors.VegaBackend_Query_InvalidParameter).
 			WithErrorDetails(fmt.Sprintf("extract resource ids failed: %v", err))
@@ -260,7 +260,6 @@ func (rqs *rawQueryService) prepareSQLQuery(ctx context.Context, req *interfaces
 	if err != nil {
 		return nil, err
 	}
-	inputDialect := req.EffectiveInputDialect()
 	allowedReferences, err := rqs.resourceSourceIdentifiers(ctx, resourceIDs)
 	if err != nil {
 		return nil, err
@@ -737,29 +736,10 @@ func rawQueryTotalCount(result *interfaces.RawQueryResponse) (int64, error) {
 	}
 }
 
-// extractResourceIDs 从SQL中提取所有{{.resource_id}}占位符
-func (rqs *rawQueryService) extractResourceIDs(query any) ([]string, error) {
-	// 如果query是字符串类型，使用正则表达式提取resource_id
+// extractResourceIDs 从 FROM/JOIN 表引用中提取所有 {{.resource_id}} 占位符。
+func (rqs *rawQueryService) extractResourceIDs(ctx context.Context, query any, inputDialect string) ([]string, error) {
 	if queryStr, ok := query.(string); ok {
-		// Keep this grammar aligned with Resource ID validation: lower-case
-		// letters, digits, underscores, and hyphens are all valid IDs.
-		re := regexp.MustCompile(`\{\{\.?([a-z0-9][a-z0-9_-]{0,39})\}\}`)
-		matches := re.FindAllStringSubmatch(queryStr, -1)
-
-		resourceIDs := make([]string, 0, len(matches))
-		seen := make(map[string]bool)
-
-		for _, match := range matches {
-			if len(match) > 1 {
-				resourceID := match[1]
-				if !seen[resourceID] {
-					seen[resourceID] = true
-					resourceIDs = append(resourceIDs, resourceID)
-				}
-			}
-		}
-
-		return resourceIDs, nil
+		return querypolicy.ExtractTableResourceIDs(ctx, queryStr, inputDialect)
 	}
 
 	// 如果query是map类型（OpenSearch DSL），返回空数组
@@ -860,12 +840,73 @@ func (rqs *rawQueryService) replaceResourceIDWithSchemaTable(ctx context.Context
 		// 替换{{.resource_id}}和{{resource_id}}为schema.table
 		placeholder1 := fmt.Sprintf("{{.%s}}", resourceID)
 		placeholder2 := fmt.Sprintf("{{%s}}", resourceID)
-		replacedSQL = regexp.MustCompile(regexp.QuoteMeta(placeholder1)).ReplaceAllString(replacedSQL, resource.SourceIdentifier)
-		replacedSQL = regexp.MustCompile(regexp.QuoteMeta(placeholder2)).ReplaceAllString(replacedSQL, resource.SourceIdentifier)
+		replacedSQL = replacePlaceholderInSQLCode(replacedSQL, placeholder1, resource.SourceIdentifier)
+		replacedSQL = replacePlaceholderInSQLCode(replacedSQL, placeholder2, resource.SourceIdentifier)
 	}
 
 	logger.Infof("After replace - %s", SafeQuerySummary(replacedSQL))
 	return replacedSQL, nil
+}
+
+// replacePlaceholderInSQLCode preserves comments and quoted literals. They
+// are not resource bindings and must remain semantically unchanged.
+func replacePlaceholderInSQLCode(sql, placeholder, replacement string) string {
+	var output strings.Builder
+	output.Grow(len(sql))
+	for index := 0; index < len(sql); {
+		if strings.HasPrefix(sql[index:], "--") {
+			end := strings.IndexByte(sql[index:], '\n')
+			if end < 0 {
+				output.WriteString(sql[index:])
+				break
+			}
+			end += index + 1
+			output.WriteString(sql[index:end])
+			index = end
+			continue
+		}
+		if strings.HasPrefix(sql[index:], "/*") {
+			end := strings.Index(sql[index+2:], "*/")
+			if end < 0 {
+				output.WriteString(sql[index:])
+				break
+			}
+			end += index + 4
+			output.WriteString(sql[index:end])
+			index = end
+			continue
+		}
+		if sql[index] == '\'' || sql[index] == '"' || sql[index] == '`' {
+			quote := sql[index]
+			end := index + 1
+			for end < len(sql) {
+				if sql[end] == quote {
+					if end+1 < len(sql) && sql[end+1] == quote {
+						end += 2
+						continue
+					}
+					end++
+					break
+				}
+				if quote == '\'' && sql[end] == '\\' && end+1 < len(sql) {
+					end += 2
+					continue
+				}
+				end++
+			}
+			output.WriteString(sql[index:end])
+			index = end
+			continue
+		}
+		if strings.HasPrefix(sql[index:], placeholder) {
+			output.WriteString(replacement)
+			index += len(placeholder)
+			continue
+		}
+		output.WriteByte(sql[index])
+		index++
+	}
+	return output.String()
 }
 
 // executeSQL 执行 SQL 查询并记录分页模式。

--- a/adp/vega/vega-backend/server/logics/query/raw_query_service_test.go
+++ b/adp/vega/vega-backend/server/logics/query/raw_query_service_test.go
@@ -47,12 +47,21 @@ type deadlineInspectingPolicy struct {
 }
 
 type recordingPolicy struct {
-	dialects []string
+	dialects    []string
+	resourceIDs []string
+}
+
+func (p *recordingPolicy) ExtractTableResourceIDs(context.Context, string, string) ([]string, error) {
+	return p.resourceIDs, nil
 }
 
 func (p *recordingPolicy) ValidateSQL(_ context.Context, _ string, dialect string) error {
 	p.dialects = append(p.dialects, dialect)
 	return nil
+}
+
+func (p *deadlineInspectingPolicy) ExtractTableResourceIDs(context.Context, string, string) ([]string, error) {
+	return []string{"resource-1"}, nil
 }
 
 func (p *recordingPolicy) ValidateTableReferences(context.Context, string, string, []string) error {
@@ -200,6 +209,10 @@ func TestRawQueryServiceValidateRequestNewContract(t *testing.T) {
 }
 
 func TestExtractResourceIDsSupportsHyphenatedIDs(t *testing.T) {
+	previousPolicy := rawQueryPolicy
+	rawQueryPolicy = &recordingPolicy{resourceIDs: []string{"orders-2026", "customer_data"}}
+	t.Cleanup(func() { rawQueryPolicy = previousPolicy })
+
 	ids, err := (&rawQueryService{}).extractResourceIDs(context.Background(), "SELECT * FROM {{orders-2026}} JOIN {{.customer_data}} ON true", "postgres")
 
 	require.NoError(t, err)
@@ -227,9 +240,17 @@ func TestPrepareSQLQueryRejectsResourcePlaceholderOutsideTableReference(t *testi
 func TestReplacePlaceholderInSQLCodePreservesCommentsAndLiterals(t *testing.T) {
 	got := replacePlaceholderInSQLCode(
 		"SELECT '{{resource-1}}' FROM {{resource-1}} /* {{resource-1}} */ -- {{resource-1}}\n",
-		"{{resource-1}}", "public.orders",
+		"{{resource-1}}", "public.orders", "postgres",
 	)
 	assert.Equal(t, "SELECT '{{resource-1}}' FROM public.orders /* {{resource-1}} */ -- {{resource-1}}\n", got)
+}
+
+func TestReplacePlaceholderInSQLCodeHonorsMySQLBackslashEscapes(t *testing.T) {
+	got := replacePlaceholderInSQLCode(
+		"SELECT 'it\\'s {{resource-1}}' FROM {{resource-1}}",
+		"{{resource-1}}", "public.orders", "mysql",
+	)
+	assert.Equal(t, "SELECT 'it\\'s {{resource-1}}' FROM public.orders", got)
 }
 
 func TestQueryExecutionContextAppliesTimeout(t *testing.T) {
@@ -325,7 +346,7 @@ func TestPrepareSQLQueryRevalidatesTranspiledSQL(t *testing.T) {
 		ID: "catalog-1", Enabled: true, ConnectorType: interfaces.ConnectorTypeMySQL,
 	}, nil)
 
-	policy := &recordingPolicy{}
+	policy := &recordingPolicy{resourceIDs: []string{"resource-1"}}
 	previousPolicy := rawQueryPolicy
 	rawQueryPolicy = policy
 	t.Cleanup(func() { rawQueryPolicy = previousPolicy })
@@ -769,6 +790,9 @@ func TestOpenSearchCursorPageFailureDoesNotRefreshExpiry(t *testing.T) {
 func TestRawQueryServiceExtractResourceIDs(t *testing.T) {
 	t.Run("raw query service extract resource ids", func(t *testing.T) {
 		svc := &rawQueryService{}
+		previousPolicy := rawQueryPolicy
+		rawQueryPolicy = &recordingPolicy{resourceIDs: []string{"r1", "r2"}}
+		t.Cleanup(func() { rawQueryPolicy = previousPolicy })
 
 		got, err := svc.extractResourceIDs(context.Background(), "select * from {{.r1}} join {{r2}} on x where id in (select id from {{.r1}})", "postgres")
 
@@ -806,6 +830,7 @@ func TestRawQueryServiceReplaceResourceIDWithSchemaTable(t *testing.T) {
 			"select * from {{.r1}} join {{r2}} on {{.r1}}.id = {{r2}}.id",
 			[]string{"r1", "r2"},
 			&interfaces.Catalog{Name: "catalog"},
+			"postgres",
 		)
 
 		require.NoError(t, err)

--- a/adp/vega/vega-backend/server/logics/query/raw_query_service_test.go
+++ b/adp/vega/vega-backend/server/logics/query/raw_query_service_test.go
@@ -221,6 +221,10 @@ func TestExtractResourceIDsSupportsHyphenatedIDs(t *testing.T) {
 
 func TestPrepareSQLQueryRejectsResourcePlaceholderOutsideTableReference(t *testing.T) {
 	svc := &rawQueryService{}
+	previousPolicy := rawQueryPolicy
+	rawQueryPolicy = &recordingPolicy{}
+	t.Cleanup(func() { rawQueryPolicy = previousPolicy })
+
 	for _, sql := range []string{
 		"SELECT * FROM public.orders /* {{resource-1}} */",
 		"SELECT * FROM public.orders -- {{resource-1}}\n",
@@ -233,6 +237,9 @@ func TestPrepareSQLQueryRejectsResourcePlaceholderOutsideTableReference(t *testi
 				InputDialect: "postgres",
 			})
 			assertHTTPError(t, err, http.StatusBadRequest)
+			var httpErr *rest.HTTPError
+			require.ErrorAs(t, err, &httpErr)
+			assert.Equal(t, "at least one resource_id is required for SQL queries", httpErr.BaseError.ErrorDetails)
 		})
 	}
 }

--- a/adp/vega/vega-backend/server/logics/query/raw_query_service_test.go
+++ b/adp/vega/vega-backend/server/logics/query/raw_query_service_test.go
@@ -200,10 +200,36 @@ func TestRawQueryServiceValidateRequestNewContract(t *testing.T) {
 }
 
 func TestExtractResourceIDsSupportsHyphenatedIDs(t *testing.T) {
-	ids, err := (&rawQueryService{}).extractResourceIDs("SELECT * FROM {{orders-2026}} JOIN {{.customer_data}} ON true")
+	ids, err := (&rawQueryService{}).extractResourceIDs(context.Background(), "SELECT * FROM {{orders-2026}} JOIN {{.customer_data}} ON true", "postgres")
 
 	require.NoError(t, err)
 	assert.Equal(t, []string{"orders-2026", "customer_data"}, ids)
+}
+
+func TestPrepareSQLQueryRejectsResourcePlaceholderOutsideTableReference(t *testing.T) {
+	svc := &rawQueryService{}
+	for _, sql := range []string{
+		"SELECT * FROM public.orders /* {{resource-1}} */",
+		"SELECT * FROM public.orders -- {{resource-1}}\n",
+		"SELECT '{{resource-1}}' FROM public.orders",
+	} {
+		t.Run(sql, func(t *testing.T) {
+			_, err := svc.prepareSQLQuery(context.Background(), &interfaces.RawQueryRequest{
+				Query:        sql,
+				QueryFormat:  interfaces.QueryFormatSQL,
+				InputDialect: "postgres",
+			})
+			assertHTTPError(t, err, http.StatusBadRequest)
+		})
+	}
+}
+
+func TestReplacePlaceholderInSQLCodePreservesCommentsAndLiterals(t *testing.T) {
+	got := replacePlaceholderInSQLCode(
+		"SELECT '{{resource-1}}' FROM {{resource-1}} /* {{resource-1}} */ -- {{resource-1}}\n",
+		"{{resource-1}}", "public.orders",
+	)
+	assert.Equal(t, "SELECT '{{resource-1}}' FROM public.orders /* {{resource-1}} */ -- {{resource-1}}\n", got)
 }
 
 func TestQueryExecutionContextAppliesTimeout(t *testing.T) {
@@ -744,12 +770,12 @@ func TestRawQueryServiceExtractResourceIDs(t *testing.T) {
 	t.Run("raw query service extract resource ids", func(t *testing.T) {
 		svc := &rawQueryService{}
 
-		got, err := svc.extractResourceIDs("select * from {{.r1}} join {{r2}} on x where id in (select id from {{.r1}})")
+		got, err := svc.extractResourceIDs(context.Background(), "select * from {{.r1}} join {{r2}} on x where id in (select id from {{.r1}})", "postgres")
 
 		require.NoError(t, err)
 		assert.Equal(t, []string{"r1", "r2"}, got)
 
-		got, err = svc.extractResourceIDs(map[string]any{"query": map[string]any{"match_all": map[string]any{}}})
+		got, err = svc.extractResourceIDs(context.Background(), map[string]any{"query": map[string]any{"match_all": map[string]any{}}}, "postgres")
 		require.NoError(t, err)
 		assert.Empty(t, got)
 	})


### PR DESCRIPTION
## What Changed

Brief description of changes:

- [x] Validate SQL Resource placeholders only when they appear in `FROM`/`JOIN` table references.
- [x] Preserve placeholders in comments and string literals during binding.
- [x] Add focused regression coverage for block comments, line comments, string literals, and valid joins.
- [ ] Docs/doc 1 — Not applicable; no public API contract change.

---

## Why

- Related Issue: Closes #400
- Related Feature: Not applicable
- Background: Raw SQL previously accepted a Resource placeholder found only in a comment or string literal when the directly named physical table matched that Resource.

---

## How

- Key implementation points: replace code-region placeholders with unique temporary identifiers, parse with SQLGlot, and collect only `Table` AST nodes; return 400 when no valid table-bound Resource exists.
- Breaking changes (API, config, database, etc.): Queries that use only direct physical table names or placeholders in comments/literals now return HTTP 400, consistent with the documented Resource-binding contract.

---

## Testing

- [x] Unit tests passed locally
- [ ] Integration tests passed locally — Not run; no external dependency is needed for this parser and service-layer change.
- [ ] Verified in test environment — Not run.

Test notes:

- `make test`
- `make lint`
- `go test ./logics/query ./logics/query/querypolicy -count=1`

---

## Risk & Rollback

- Potential risks: SQL dialect edge cases involving quoted identifiers or uncommon literal syntax may require additional compatibility cases.
- Rollback plan: Revert commit `a023e421`.

---

## Additional Notes

- The working-tree change in `server/config/vega-backend-config.yaml` is user-owned and is not included in this PR.