### PR TITLE
feat(bkn-trace): persist evidence in opensearch

### DIFF
--- a/bkn-trace/agent-observability/README.md
+++ b/bkn-trace/agent-observability/README.md
@@ -11,7 +11,7 @@
 - Business Graph 查询接口：`GET /api/agent-observability/v1/traces/{trace_id}/business-graph`
 - Request 维度 Business Graph 查询接口：`GET /api/agent-observability/v1/traces/by-request/business-graph?request_id=...`
 - OpenSearch 查询客户端
-- 阶段二 Evidence ingestion 校验、归一化和可替换存储接口
+- 阶段二 Evidence ingestion 校验、归一化和可替换存储接口，支持内存 store 与 OpenSearch evidence index store
 - Swagger 文档生成
 - Docker 镜像构建
 - Helm Deployment Chart
@@ -31,7 +31,34 @@ make test
 GOCACHE=/tmp/openbkn-go-build-cache GOMODCACHE=/tmp/openbkn-go-mod-cache go test ./...
 ```
 
-阶段二 evidence ingestion 接口接受 `bkn.trace.schema.version=2.0.0` 的事件批次，包含 `trace` 与 `events`。当前版本先完成 contract 校验、敏感 payload 拒绝、归一化计数、内存 repository 写入、最小 Evidence Chain 查询和 Business Graph 查询；后续 PR 会把 repository 替换为持久化 evidence index。
+阶段二 evidence ingestion 接口接受 `bkn.trace.schema.version=2.0.0` 的事件批次，包含 `trace` 与 `events`。当前版本先完成 contract 校验、敏感 payload 拒绝、归一化计数、最小 Evidence Chain 查询和 Business Graph 查询；默认使用内存 repository，生产或共享测试环境可切换到 OpenSearch evidence index store。
+
+### Evidence Store
+
+默认配置保持兼容：
+
+```text
+BKN_TRACE_EVIDENCE_STORE=memory
+```
+
+启用 OpenSearch 持久化 evidence index：
+
+```bash
+helm upgrade --install agent-observability charts/agent-observability \
+  --set evidence.store=opensearch \
+  --set evidence.index=bkn-trace-evidence-v1 \
+  --set opensearch.endpoint=http://opensearch-cluster-master:9200 \
+  -n observability --create-namespace
+```
+
+对应环境变量：
+
+```text
+BKN_TRACE_EVIDENCE_STORE=opensearch
+OPENSEARCH_EVIDENCE_INDEX=bkn-trace-evidence-v1
+```
+
+当前 PR 不自动创建 index，不要求服务账号具备 OpenSearch index-management 权限；部署方需要提前创建 `OPENSEARCH_EVIDENCE_INDEX`。后续部署治理 PR 会补 index mapping、retention/ILM、权限与迁移脚本。
 
 ### Evidence 写入安全边界
 

--- a/bkn-trace/agent-observability/README.md
+++ b/bkn-trace/agent-observability/README.md
@@ -60,6 +60,15 @@ OPENSEARCH_EVIDENCE_INDEX=bkn-trace-evidence-v1
 
 当前 PR 不自动创建 index，不要求服务账号具备 OpenSearch index-management 权限；部署方需要提前创建 `OPENSEARCH_EVIDENCE_INDEX`。后续部署治理 PR 会补 index mapping、retention/ILM、权限与迁移脚本。
 
+Evidence Chain 与 Business Graph 查询支持可选 `limit` 参数，限制本次读取的 evidence trace 批次数：
+
+```http
+GET /api/agent-observability/v1/traces/{trace_id}/evidence-chain?limit=100
+GET /api/agent-observability/v1/traces/by-request/business-graph?request_id=req_x&limit=100
+```
+
+`limit` 取值范围为 `1..1000`，默认 `1000`。命中上限时响应会返回 `partial=true`、`partial_reason=["evidence_query_truncated"]`，并设置 `page.truncated=true`，调用方不得把该结果展示为完整证据链。
+
 ### Evidence 写入安全边界
 
 `POST /api/agent-observability/v1/evidence/events` 是写接口，生产环境必须通过平台网关鉴权保护，或配置服务内最小 ingest token：

--- a/bkn-trace/agent-observability/charts/agent-observability/templates/deployment.yaml
+++ b/bkn-trace/agent-observability/charts/agent-observability/templates/deployment.yaml
@@ -39,6 +39,10 @@ spec:
               value: {{ .Values.opensearch.endpoint | quote }}
             - name: OPENSEARCH_TRACE_INDEX
               value: {{ .Values.opensearch.traceIndex | quote }}
+            - name: OPENSEARCH_EVIDENCE_INDEX
+              value: {{ .Values.evidence.index | quote }}
+            - name: BKN_TRACE_EVIDENCE_STORE
+              value: {{ .Values.evidence.store | quote }}
             - name: OPENSEARCH_AUTH_ENABLED
               value: {{ ternary "true" "false" .Values.opensearch.auth.enabled | quote }}
             {{- if .Values.opensearch.auth.enabled }}

--- a/bkn-trace/agent-observability/charts/agent-observability/values.yaml
+++ b/bkn-trace/agent-observability/charts/agent-observability/values.yaml
@@ -33,6 +33,8 @@ ingress:
   tls: []
 
 evidence:
+  store: memory
+  index: bkn-trace-evidence-v1
   ingestAuth:
     existingSecret: ""
     secretKey: token

--- a/bkn-trace/agent-observability/src/boot/bootstrap.go
+++ b/bkn-trace/agent-observability/src/boot/bootstrap.go
@@ -3,16 +3,19 @@ package boot
 import (
 	"context"
 	"net/http"
+	"strings"
 
 	docs "github.com/openbkn-ai/bkn-foundry/bkn-trace/agent-observability/docs/swagger"
 	"github.com/openbkn-ai/bkn-foundry/bkn-trace/agent-observability/src/conf"
 	"github.com/openbkn-ai/bkn-foundry/bkn-trace/agent-observability/src/domain/service/evidencesvc"
 	"github.com/openbkn-ai/bkn-foundry/bkn-trace/agent-observability/src/domain/service/tracesvc"
+	"github.com/openbkn-ai/bkn-foundry/bkn-trace/agent-observability/src/drivenadapter/httpaccess/opensearchevidencestore"
 	"github.com/openbkn-ai/bkn-foundry/bkn-trace/agent-observability/src/drivenadapter/httpaccess/opensearchtraceaccess"
 	"github.com/openbkn-ai/bkn-foundry/bkn-trace/agent-observability/src/drivenadapter/memoryaccess/evidencestore"
 	"github.com/openbkn-ai/bkn-foundry/bkn-trace/agent-observability/src/driveradapter/api/httphandler"
 	"github.com/openbkn-ai/bkn-foundry/bkn-trace/agent-observability/src/infra/opensearch"
 	"github.com/openbkn-ai/bkn-foundry/bkn-trace/agent-observability/src/infra/server/httpserver"
+	"github.com/openbkn-ai/bkn-foundry/bkn-trace/agent-observability/src/port/driven/ievidencestore"
 	httpSwagger "github.com/swaggo/http-swagger/v2"
 )
 
@@ -25,6 +28,7 @@ const APIBasePath = "/api/agent-observability/v1"
 func NewApp() *App {
 	httpServerConfig := conf.NewHTTPServerConfig()
 	openSearchConfig := conf.NewOpenSearchConfig()
+	evidenceConfig := conf.NewEvidenceConfig()
 	docs.SwaggerInfo.BasePath = APIBasePath
 
 	openSearchClient := opensearch.New(
@@ -39,9 +43,17 @@ func NewApp() *App {
 	traceDetailClient := opensearchtraceaccess.New(openSearchClient, openSearchConfig.TraceIndex)
 	traceQueryService := tracesvc.New(traceDetailClient)
 	traceHandler := httphandler.NewTraceHandler(traceQueryService)
-	evidenceService := evidencesvc.New(evidencestore.New())
+	var evidenceStore ievidencestore.EvidenceStorePort = evidencestore.New()
+	if strings.EqualFold(evidenceConfig.Store, "opensearch") {
+		evidenceStore = opensearchevidencestore.New(openSearchClient, openSearchConfig.EvidenceIndex)
+	}
+	evidenceService := evidencesvc.New(evidenceStore)
 	evidenceHandler := httphandler.NewEvidenceHandler(evidenceService)
 
+	return newApp(httpServerConfig, traceHandler, evidenceHandler)
+}
+
+func newApp(httpServerConfig conf.HTTPServerConfig, traceHandler *httphandler.TraceHandler, evidenceHandler *httphandler.EvidenceHandler) *App {
 	mux := http.NewServeMux()
 	mux.HandleFunc(APIBasePath+"/traces/_search", traceHandler.SearchTraces)
 	mux.HandleFunc(APIBasePath+"/traces/by-conversation", traceHandler.SearchTracesByConversationID)

--- a/bkn-trace/agent-observability/src/conf/evidence.go
+++ b/bkn-trace/agent-observability/src/conf/evidence.go
@@ -1,0 +1,15 @@
+package conf
+
+import "os"
+
+type EvidenceConfig struct {
+	Store string
+}
+
+func NewEvidenceConfig() EvidenceConfig {
+	store := os.Getenv("BKN_TRACE_EVIDENCE_STORE")
+	if store == "" {
+		store = "memory"
+	}
+	return EvidenceConfig{Store: store}
+}

--- a/bkn-trace/agent-observability/src/conf/opensearch.go
+++ b/bkn-trace/agent-observability/src/conf/opensearch.go
@@ -6,10 +6,11 @@ import (
 )
 
 type OpenSearchConfig struct {
-	Endpoint   string
-	TraceIndex string
-	Timeout    time.Duration
-	Auth       OpenSearchAuthConfig
+	Endpoint      string
+	TraceIndex    string
+	EvidenceIndex string
+	Timeout       time.Duration
+	Auth          OpenSearchAuthConfig
 }
 
 type OpenSearchAuthConfig struct {
@@ -29,10 +30,16 @@ func NewOpenSearchConfig() OpenSearchConfig {
 		traceIndex = "ss4o_traces-default-namespace"
 	}
 
+	evidenceIndex := os.Getenv("OPENSEARCH_EVIDENCE_INDEX")
+	if evidenceIndex == "" {
+		evidenceIndex = "bkn-trace-evidence-v1"
+	}
+
 	return OpenSearchConfig{
-		Endpoint:   endpoint,
-		TraceIndex: traceIndex,
-		Timeout:    3 * time.Second,
+		Endpoint:      endpoint,
+		TraceIndex:    traceIndex,
+		EvidenceIndex: evidenceIndex,
+		Timeout:       3 * time.Second,
 		Auth: OpenSearchAuthConfig{
 			Enabled:  os.Getenv("OPENSEARCH_AUTH_ENABLED") == "true",
 			Username: os.Getenv("OPENSEARCH_AUTH_USERNAME"),

--- a/bkn-trace/agent-observability/src/domain/service/evidencesvc/service.go
+++ b/bkn-trace/agent-observability/src/domain/service/evidencesvc/service.go
@@ -73,6 +73,11 @@ type Service struct {
 	store ievidencestore.EvidenceStorePort
 }
 
+const (
+	DefaultEvidenceQueryLimit = 1000
+	MaxEvidenceQueryLimit     = 1000
+)
+
 func New(store ievidencestore.EvidenceStorePort) *Service {
 	return &Service{store: store}
 }
@@ -118,51 +123,51 @@ func (s *Service) Ingest(ctx context.Context, body []byte) (evidencevo.IngestRes
 	}, nil, nil
 }
 
-func (s *Service) GetEvidenceChainByTraceID(ctx context.Context, traceID string) (evidencevo.EvidenceChainResponse, bool, error) {
-	traces, err := s.store.GetEvidenceByTraceID(ctx, strings.TrimSpace(traceID))
+func (s *Service) GetEvidenceChainByTraceID(ctx context.Context, traceID string, options evidencevo.EvidenceQueryOptions) (evidencevo.EvidenceChainResponse, bool, error) {
+	result, err := s.store.GetEvidenceByTraceID(ctx, strings.TrimSpace(traceID), normalizeQueryOptions(options))
 	if err != nil {
 		return evidencevo.EvidenceChainResponse{}, false, err
 	}
-	if len(traces) == 0 {
+	if len(result.Traces) == 0 {
 		return evidencevo.EvidenceChainResponse{}, false, nil
 	}
-	return buildEvidenceChain(traces), true, nil
+	return buildEvidenceChain(result.Traces, result.Truncated), true, nil
 }
 
-func (s *Service) GetEvidenceChainByRequestID(ctx context.Context, requestID string) (evidencevo.EvidenceChainResponse, bool, error) {
-	traces, err := s.store.GetEvidenceByRequestID(ctx, strings.TrimSpace(requestID))
+func (s *Service) GetEvidenceChainByRequestID(ctx context.Context, requestID string, options evidencevo.EvidenceQueryOptions) (evidencevo.EvidenceChainResponse, bool, error) {
+	result, err := s.store.GetEvidenceByRequestID(ctx, strings.TrimSpace(requestID), normalizeQueryOptions(options))
 	if err != nil {
 		return evidencevo.EvidenceChainResponse{}, false, err
 	}
-	if len(traces) == 0 {
+	if len(result.Traces) == 0 {
 		return evidencevo.EvidenceChainResponse{}, false, nil
 	}
-	return buildEvidenceChain(traces), true, nil
+	return buildEvidenceChain(result.Traces, result.Truncated), true, nil
 }
 
-func (s *Service) GetBusinessGraphByTraceID(ctx context.Context, traceID string) (evidencevo.BusinessGraphResponse, bool, error) {
-	traces, err := s.store.GetEvidenceByTraceID(ctx, strings.TrimSpace(traceID))
+func (s *Service) GetBusinessGraphByTraceID(ctx context.Context, traceID string, options evidencevo.EvidenceQueryOptions) (evidencevo.BusinessGraphResponse, bool, error) {
+	result, err := s.store.GetEvidenceByTraceID(ctx, strings.TrimSpace(traceID), normalizeQueryOptions(options))
 	if err != nil {
 		return evidencevo.BusinessGraphResponse{}, false, err
 	}
-	if len(traces) == 0 {
+	if len(result.Traces) == 0 {
 		return evidencevo.BusinessGraphResponse{}, false, nil
 	}
-	return buildBusinessGraph(traces), true, nil
+	return buildBusinessGraph(result.Traces, result.Truncated), true, nil
 }
 
-func (s *Service) GetBusinessGraphByRequestID(ctx context.Context, requestID string) (evidencevo.BusinessGraphResponse, bool, error) {
-	traces, err := s.store.GetEvidenceByRequestID(ctx, strings.TrimSpace(requestID))
+func (s *Service) GetBusinessGraphByRequestID(ctx context.Context, requestID string, options evidencevo.EvidenceQueryOptions) (evidencevo.BusinessGraphResponse, bool, error) {
+	result, err := s.store.GetEvidenceByRequestID(ctx, strings.TrimSpace(requestID), normalizeQueryOptions(options))
 	if err != nil {
 		return evidencevo.BusinessGraphResponse{}, false, err
 	}
-	if len(traces) == 0 {
+	if len(result.Traces) == 0 {
 		return evidencevo.BusinessGraphResponse{}, false, nil
 	}
-	return buildBusinessGraph(traces), true, nil
+	return buildBusinessGraph(result.Traces, result.Truncated), true, nil
 }
 
-func buildEvidenceChain(traces []evidencevo.NormalizedTrace) evidencevo.EvidenceChainResponse {
+func buildEvidenceChain(traces []evidencevo.NormalizedTrace, truncated bool) evidencevo.EvidenceChainResponse {
 	response := evidencevo.EvidenceChainResponse{
 		TraceID:   traces[0].TraceID,
 		RequestID: traces[0].RequestID,
@@ -212,15 +217,19 @@ func buildEvidenceChain(traces []evidencevo.NormalizedTrace) evidencevo.Evidence
 			partialReasons["version_status_missing"] = struct{}{}
 		}
 	}
+	if truncated {
+		partialReasons["evidence_query_truncated"] = struct{}{}
+	}
 
 	response.PartialReasons = sortedKeys(partialReasons)
 	response.Partial = len(response.PartialReasons) > 0
 	response.Page.NodeCount = len(response.Data.Claims) + len(response.Data.EvidenceRefs) + len(response.Data.BusinessRefs)
 	response.Page.EdgeCount = len(response.Data.EvidenceRefs) + len(response.Data.BusinessRefs)
+	response.Page.Truncated = truncated
 	return response
 }
 
-func buildBusinessGraph(traces []evidencevo.NormalizedTrace) evidencevo.BusinessGraphResponse {
+func buildBusinessGraph(traces []evidencevo.NormalizedTrace, truncated bool) evidencevo.BusinessGraphResponse {
 	response := evidencevo.BusinessGraphResponse{
 		TraceID:   traces[0].TraceID,
 		RequestID: traces[0].RequestID,
@@ -316,12 +325,26 @@ func buildBusinessGraph(traces []evidencevo.NormalizedTrace) evidencevo.Business
 	if len(response.Data.Nodes) == 0 {
 		partialReasons["empty_business_graph"] = struct{}{}
 	}
+	if truncated {
+		partialReasons["evidence_query_truncated"] = struct{}{}
+	}
 
 	response.PartialReasons = sortedKeys(partialReasons)
 	response.Partial = len(response.PartialReasons) > 0
 	response.Page.NodeCount = len(response.Data.Nodes)
 	response.Page.EdgeCount = len(response.Data.Edges)
+	response.Page.Truncated = truncated
 	return response
+}
+
+func normalizeQueryOptions(options evidencevo.EvidenceQueryOptions) evidencevo.EvidenceQueryOptions {
+	if options.Limit <= 0 {
+		options.Limit = DefaultEvidenceQueryLimit
+	}
+	if options.Limit > MaxEvidenceQueryLimit {
+		options.Limit = MaxEvidenceQueryLimit
+	}
+	return options
 }
 
 func appendVisibleRefs(target []map[string]any, refs []any, summary *evidencevo.VisibilitySummary) []map[string]any {

--- a/bkn-trace/agent-observability/src/domain/service/evidencesvc/service_test.go
+++ b/bkn-trace/agent-observability/src/domain/service/evidencesvc/service_test.go
@@ -18,24 +18,34 @@ func (s *fakeStore) StoreEvidence(_ context.Context, _ evidencevo.NormalizedTrac
 	return nil
 }
 
-func (s *fakeStore) GetEvidenceByTraceID(_ context.Context, traceID string) ([]evidencevo.NormalizedTrace, error) {
+func (s *fakeStore) GetEvidenceByTraceID(_ context.Context, traceID string, options evidencevo.EvidenceQueryOptions) (evidencevo.EvidenceQueryResult, error) {
 	var result []evidencevo.NormalizedTrace
 	for _, trace := range s.traces {
 		if trace.TraceID == traceID {
 			result = append(result, trace)
 		}
 	}
-	return result, nil
+	return fakeLimitedResult(result, options.Limit), nil
 }
 
-func (s *fakeStore) GetEvidenceByRequestID(_ context.Context, requestID string) ([]evidencevo.NormalizedTrace, error) {
+func (s *fakeStore) GetEvidenceByRequestID(_ context.Context, requestID string, options evidencevo.EvidenceQueryOptions) (evidencevo.EvidenceQueryResult, error) {
 	var result []evidencevo.NormalizedTrace
 	for _, trace := range s.traces {
 		if trace.RequestID == requestID {
 			result = append(result, trace)
 		}
 	}
-	return result, nil
+	return fakeLimitedResult(result, options.Limit), nil
+}
+
+func fakeLimitedResult(traces []evidencevo.NormalizedTrace, limit int) evidencevo.EvidenceQueryResult {
+	if limit <= 0 || len(traces) <= limit {
+		return evidencevo.EvidenceQueryResult{Traces: traces}
+	}
+	return evidencevo.EvidenceQueryResult{
+		Traces:    traces[:limit],
+		Truncated: true,
+	}
 }
 
 func TestIngestAcceptsPhaseTwoEvidenceBatch(t *testing.T) {
@@ -225,7 +235,7 @@ func TestGetEvidenceChainByTraceIDFiltersHiddenRefsAndReturnsEnvelope(t *testing
 	store := &fakeStore{traces: []evidencevo.NormalizedTrace{queryTrace("trace_query_001", "req_query_001")}}
 	service := New(store)
 
-	response, found, err := service.GetEvidenceChainByTraceID(context.Background(), "trace_query_001")
+	response, found, err := service.GetEvidenceChainByTraceID(context.Background(), "trace_query_001", evidencevo.EvidenceQueryOptions{})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -268,7 +278,7 @@ func TestGetEvidenceChainByRequestIDReturnsMissingClaimPartial(t *testing.T) {
 	}}}
 	service := New(store)
 
-	response, found, err := service.GetEvidenceChainByRequestID(context.Background(), "req_no_claim")
+	response, found, err := service.GetEvidenceChainByRequestID(context.Background(), "req_no_claim", evidencevo.EvidenceQueryOptions{})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -280,11 +290,30 @@ func TestGetEvidenceChainByRequestIDReturnsMissingClaimPartial(t *testing.T) {
 	}
 }
 
+func TestGetEvidenceChainMarksQueryTruncated(t *testing.T) {
+	store := &fakeStore{traces: []evidencevo.NormalizedTrace{
+		queryTrace("trace_query_001", "req_query_truncated"),
+		queryTrace("trace_query_002", "req_query_truncated"),
+	}}
+	service := New(store)
+
+	response, found, err := service.GetEvidenceChainByRequestID(context.Background(), "req_query_truncated", evidencevo.EvidenceQueryOptions{Limit: 1})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !found {
+		t.Fatal("expected evidence chain to be found")
+	}
+	if !response.Partial || !response.Page.Truncated || !contains(response.PartialReasons, "evidence_query_truncated") {
+		t.Fatalf("expected truncated partial response, got: %+v", response)
+	}
+}
+
 func TestGetBusinessGraphByTraceIDReturnsClaimAndBusinessNodes(t *testing.T) {
 	store := &fakeStore{traces: []evidencevo.NormalizedTrace{queryTrace("trace_graph_001", "req_graph_001")}}
 	service := New(store)
 
-	response, found, err := service.GetBusinessGraphByTraceID(context.Background(), "trace_graph_001")
+	response, found, err := service.GetBusinessGraphByTraceID(context.Background(), "trace_graph_001", evidencevo.EvidenceQueryOptions{})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -315,7 +344,7 @@ func TestGetBusinessGraphByRequestIDHandlesHiddenAndUnresolvedRefs(t *testing.T)
 	store := &fakeStore{traces: []evidencevo.NormalizedTrace{businessGraphTraceWithGovernance("trace_graph_002", "req_graph_002")}}
 	service := New(store)
 
-	response, found, err := service.GetBusinessGraphByRequestID(context.Background(), "req_graph_002")
+	response, found, err := service.GetBusinessGraphByRequestID(context.Background(), "req_graph_002", evidencevo.EvidenceQueryOptions{})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -337,7 +366,7 @@ func TestGetBusinessGraphDoesNotDependOnEventOrder(t *testing.T) {
 	store := &fakeStore{traces: []evidencevo.NormalizedTrace{businessGraphTraceWithBusinessBeforeClaim("trace_graph_003", "req_graph_003")}}
 	service := New(store)
 
-	response, found, err := service.GetBusinessGraphByTraceID(context.Background(), "trace_graph_003")
+	response, found, err := service.GetBusinessGraphByTraceID(context.Background(), "trace_graph_003", evidencevo.EvidenceQueryOptions{})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -356,7 +385,7 @@ func TestGetBusinessGraphDeduplicatesEdgesAndAuthorizedRefs(t *testing.T) {
 	store := &fakeStore{traces: []evidencevo.NormalizedTrace{businessGraphTraceWithDuplicateRefs("trace_graph_004", "req_graph_004")}}
 	service := New(store)
 
-	response, found, err := service.GetBusinessGraphByTraceID(context.Background(), "trace_graph_004")
+	response, found, err := service.GetBusinessGraphByTraceID(context.Background(), "trace_graph_004", evidencevo.EvidenceQueryOptions{})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -375,7 +404,7 @@ func TestGetBusinessGraphDoesNotLeakHiddenClaimThroughSyntheticNode(t *testing.T
 	store := &fakeStore{traces: []evidencevo.NormalizedTrace{businessGraphTraceWithHiddenClaim("trace_graph_005", "req_graph_005")}}
 	service := New(store)
 
-	response, found, err := service.GetBusinessGraphByTraceID(context.Background(), "trace_graph_005")
+	response, found, err := service.GetBusinessGraphByTraceID(context.Background(), "trace_graph_005", evidencevo.EvidenceQueryOptions{})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -412,7 +441,7 @@ func TestGetBusinessGraphReturnsMissingBusinessRefsPartial(t *testing.T) {
 	}}}
 	service := New(store)
 
-	response, found, err := service.GetBusinessGraphByTraceID(context.Background(), "trace_no_business_refs")
+	response, found, err := service.GetBusinessGraphByTraceID(context.Background(), "trace_no_business_refs", evidencevo.EvidenceQueryOptions{})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -427,7 +456,7 @@ func TestGetBusinessGraphReturnsMissingBusinessRefsPartial(t *testing.T) {
 func TestGetEvidenceChainByTraceIDNotFound(t *testing.T) {
 	service := New(&fakeStore{})
 
-	_, found, err := service.GetEvidenceChainByTraceID(context.Background(), "missing")
+	_, found, err := service.GetEvidenceChainByTraceID(context.Background(), "missing", evidencevo.EvidenceQueryOptions{})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}

--- a/bkn-trace/agent-observability/src/domain/valueobject/evidencevo/evidence.go
+++ b/bkn-trace/agent-observability/src/domain/valueobject/evidencevo/evidence.go
@@ -59,6 +59,15 @@ type NormalizedTrace struct {
 	BusinessRefCount int
 }
 
+type EvidenceQueryOptions struct {
+	Limit int
+}
+
+type EvidenceQueryResult struct {
+	Traces    []NormalizedTrace
+	Truncated bool
+}
+
 type EvidenceChainResponse struct {
 	TraceID           string            `json:"trace_id"`
 	RequestID         string            `json:"bkn.request.id"`

--- a/bkn-trace/agent-observability/src/drivenadapter/httpaccess/opensearchevidencestore/store.go
+++ b/bkn-trace/agent-observability/src/drivenadapter/httpaccess/opensearchevidencestore/store.go
@@ -62,17 +62,21 @@ func (s *Store) StoreEvidence(ctx context.Context, trace evidencevo.NormalizedTr
 	return nil
 }
 
-func (s *Store) GetEvidenceByTraceID(ctx context.Context, traceID string) ([]evidencevo.NormalizedTrace, error) {
-	return s.search(ctx, "trace_id", traceID)
+func (s *Store) GetEvidenceByTraceID(ctx context.Context, traceID string, options evidencevo.EvidenceQueryOptions) (evidencevo.EvidenceQueryResult, error) {
+	return s.search(ctx, "trace_id", traceID, options)
 }
 
-func (s *Store) GetEvidenceByRequestID(ctx context.Context, requestID string) ([]evidencevo.NormalizedTrace, error) {
-	return s.search(ctx, "bkn.request.id", requestID)
+func (s *Store) GetEvidenceByRequestID(ctx context.Context, requestID string, options evidencevo.EvidenceQueryOptions) (evidencevo.EvidenceQueryResult, error) {
+	return s.search(ctx, "bkn.request.id", requestID, options)
 }
 
-func (s *Store) search(ctx context.Context, field string, value string) ([]evidencevo.NormalizedTrace, error) {
+func (s *Store) search(ctx context.Context, field string, value string, options evidencevo.EvidenceQueryOptions) (evidencevo.EvidenceQueryResult, error) {
+	limit := options.Limit
+	if limit <= 0 {
+		limit = maxEvidenceSearchResults
+	}
 	query, err := json.Marshal(map[string]any{
-		"size": maxEvidenceSearchResults,
+		"size": limit + 1,
 		"query": map[string]any{
 			"bool": exactTermQuery(field, value),
 		},
@@ -81,24 +85,29 @@ func (s *Store) search(ctx context.Context, field string, value string) ([]evide
 		},
 	})
 	if err != nil {
-		return nil, fmt.Errorf("marshal evidence search query: %w", err)
+		return evidencevo.EvidenceQueryResult{}, fmt.Errorf("marshal evidence search query: %w", err)
 	}
 
 	body, err := s.client.Search(ctx, s.index, query)
 	if err != nil {
-		return nil, err
+		return evidencevo.EvidenceQueryResult{}, err
 	}
 
 	var response searchResponse
 	if err := json.Unmarshal(body, &response); err != nil {
-		return nil, fmt.Errorf("decode evidence search response: %w", err)
+		return evidencevo.EvidenceQueryResult{}, fmt.Errorf("decode evidence search response: %w", err)
 	}
 
 	traces := make([]evidencevo.NormalizedTrace, 0, len(response.Hits.Hits))
 	for _, hit := range response.Hits.Hits {
 		traces = append(traces, fromDocument(hit.Source))
 	}
-	return traces, nil
+	result := evidencevo.EvidenceQueryResult{Traces: traces}
+	if len(result.Traces) > limit {
+		result.Truncated = true
+		result.Traces = result.Traces[:limit]
+	}
+	return result, nil
 }
 
 func toDocument(trace evidencevo.NormalizedTrace, ingestedAt time.Time) document {

--- a/bkn-trace/agent-observability/src/drivenadapter/httpaccess/opensearchevidencestore/store.go
+++ b/bkn-trace/agent-observability/src/drivenadapter/httpaccess/opensearchevidencestore/store.go
@@ -1,0 +1,155 @@
+package opensearchevidencestore
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/openbkn-ai/bkn-foundry/bkn-trace/agent-observability/src/domain/valueobject/evidencevo"
+	"github.com/openbkn-ai/bkn-foundry/bkn-trace/agent-observability/src/infra/opensearch"
+)
+
+const maxEvidenceSearchResults = 1000
+
+type Store struct {
+	client *opensearch.Client
+	index  string
+	now    func() time.Time
+}
+
+type document struct {
+	DocumentID       string                     `json:"document_id"`
+	TraceID          string                     `json:"trace_id"`
+	RequestID        string                     `json:"bkn.request.id"`
+	SchemaVersion    string                     `json:"bkn.trace.schema.version"`
+	Events           []evidencevo.EvidenceEvent `json:"events"`
+	ClaimIDs         []string                   `json:"claim_ids,omitempty"`
+	AcceptedEvents   int                        `json:"accepted_event_count"`
+	ClaimCount       int                        `json:"claim_count"`
+	EvidenceRefCount int                        `json:"evidence_ref_count"`
+	BusinessRefCount int                        `json:"business_ref_count"`
+	IngestedAt       string                     `json:"ingested_at"`
+}
+
+type searchResponse struct {
+	Hits struct {
+		Hits []struct {
+			Source document `json:"_source"`
+		} `json:"hits"`
+	} `json:"hits"`
+}
+
+func New(client *opensearch.Client, index string) *Store {
+	return &Store{
+		client: client,
+		index:  index,
+		now:    time.Now,
+	}
+}
+
+func (s *Store) StoreEvidence(ctx context.Context, trace evidencevo.NormalizedTrace) error {
+	doc := toDocument(trace, s.now().UTC())
+	body, err := json.Marshal(doc)
+	if err != nil {
+		return fmt.Errorf("marshal evidence document: %w", err)
+	}
+	if _, err := s.client.IndexDocument(ctx, s.index, doc.DocumentID, body); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (s *Store) GetEvidenceByTraceID(ctx context.Context, traceID string) ([]evidencevo.NormalizedTrace, error) {
+	return s.search(ctx, "trace_id", traceID)
+}
+
+func (s *Store) GetEvidenceByRequestID(ctx context.Context, requestID string) ([]evidencevo.NormalizedTrace, error) {
+	return s.search(ctx, "bkn.request.id", requestID)
+}
+
+func (s *Store) search(ctx context.Context, field string, value string) ([]evidencevo.NormalizedTrace, error) {
+	query, err := json.Marshal(map[string]any{
+		"size": maxEvidenceSearchResults,
+		"query": map[string]any{
+			"bool": exactTermQuery(field, value),
+		},
+		"sort": []map[string]any{
+			{"ingested_at": map[string]any{"order": "asc"}},
+		},
+	})
+	if err != nil {
+		return nil, fmt.Errorf("marshal evidence search query: %w", err)
+	}
+
+	body, err := s.client.Search(ctx, s.index, query)
+	if err != nil {
+		return nil, err
+	}
+
+	var response searchResponse
+	if err := json.Unmarshal(body, &response); err != nil {
+		return nil, fmt.Errorf("decode evidence search response: %w", err)
+	}
+
+	traces := make([]evidencevo.NormalizedTrace, 0, len(response.Hits.Hits))
+	for _, hit := range response.Hits.Hits {
+		traces = append(traces, fromDocument(hit.Source))
+	}
+	return traces, nil
+}
+
+func toDocument(trace evidencevo.NormalizedTrace, ingestedAt time.Time) document {
+	doc := document{
+		TraceID:          trace.TraceID,
+		RequestID:        trace.RequestID,
+		SchemaVersion:    trace.SchemaVersion,
+		Events:           trace.Events,
+		ClaimIDs:         trace.ClaimIDs,
+		AcceptedEvents:   trace.AcceptedEvents,
+		ClaimCount:       trace.ClaimCount,
+		EvidenceRefCount: trace.EvidenceRefCount,
+		BusinessRefCount: trace.BusinessRefCount,
+		IngestedAt:       ingestedAt.Format(time.RFC3339Nano),
+	}
+	doc.DocumentID = evidenceDocumentID(doc)
+	return doc
+}
+
+func fromDocument(doc document) evidencevo.NormalizedTrace {
+	return evidencevo.NormalizedTrace{
+		TraceID:          doc.TraceID,
+		RequestID:        doc.RequestID,
+		SchemaVersion:    doc.SchemaVersion,
+		Events:           doc.Events,
+		ClaimIDs:         doc.ClaimIDs,
+		AcceptedEvents:   doc.AcceptedEvents,
+		ClaimCount:       doc.ClaimCount,
+		EvidenceRefCount: doc.EvidenceRefCount,
+		BusinessRefCount: doc.BusinessRefCount,
+	}
+}
+
+func evidenceDocumentID(doc document) string {
+	hash := sha256.New()
+	_, _ = hash.Write([]byte(doc.TraceID))
+	_, _ = hash.Write([]byte{0})
+	_, _ = hash.Write([]byte(doc.RequestID))
+	for _, event := range doc.Events {
+		_, _ = hash.Write([]byte{0})
+		_, _ = hash.Write([]byte(event.EventID))
+	}
+	return hex.EncodeToString(hash.Sum(nil))
+}
+
+func exactTermQuery(field string, value string) map[string]any {
+	return map[string]any{
+		"should": []map[string]any{
+			{"term": map[string]any{field: map[string]any{"value": value}}},
+			{"term": map[string]any{field + ".keyword": map[string]any{"value": value}}},
+		},
+		"minimum_should_match": 1,
+	}
+}

--- a/bkn-trace/agent-observability/src/drivenadapter/httpaccess/opensearchevidencestore/store_test.go
+++ b/bkn-trace/agent-observability/src/drivenadapter/httpaccess/opensearchevidencestore/store_test.go
@@ -92,15 +92,15 @@ func TestGetEvidenceByTraceIDParsesSearchHits(t *testing.T) {
 
 	store := New(client, "bkn-trace-evidence-test")
 
-	traces, err := store.GetEvidenceByTraceID(context.Background(), "trace_index_001")
+	result, err := store.GetEvidenceByTraceID(context.Background(), "trace_index_001", evidencevo.EvidenceQueryOptions{})
 	if err != nil {
 		t.Fatalf("query evidence: %v", err)
 	}
-	if len(traces) != 1 {
-		t.Fatalf("expected one trace, got %d", len(traces))
+	if len(result.Traces) != 1 {
+		t.Fatalf("expected one trace, got %d", len(result.Traces))
 	}
-	if traces[0].TraceID != "trace_index_001" || traces[0].RequestID != "req_index_001" || traces[0].ClaimCount != 1 {
-		t.Fatalf("unexpected trace: %+v", traces[0])
+	if result.Traces[0].TraceID != "trace_index_001" || result.Traces[0].RequestID != "req_index_001" || result.Traces[0].ClaimCount != 1 {
+		t.Fatalf("unexpected trace: %+v", result.Traces[0])
 	}
 	queryBytes, _ := json.Marshal(query)
 	if !strings.Contains(string(queryBytes), `"trace_id.keyword"`) {
@@ -122,12 +122,42 @@ func TestGetEvidenceByRequestIDUsesRequestIDField(t *testing.T) {
 
 	store := New(client, "bkn-trace-evidence-test")
 
-	if _, err := store.GetEvidenceByRequestID(context.Background(), "req_index_001"); err != nil {
+	if _, err := store.GetEvidenceByRequestID(context.Background(), "req_index_001", evidencevo.EvidenceQueryOptions{}); err != nil {
 		t.Fatalf("query evidence: %v", err)
 	}
 	queryBytes, _ := json.Marshal(query)
 	if !strings.Contains(string(queryBytes), `"bkn.request.id.keyword"`) {
 		t.Fatalf("expected request id keyword term, got %s", string(queryBytes))
+	}
+}
+
+func TestGetEvidenceByTraceIDFetchesLimitPlusOneAndTruncates(t *testing.T) {
+	var query map[string]any
+	client := newFakeOpenSearchClient(func(r *http.Request) (*http.Response, error) {
+		if err := json.NewDecoder(r.Body).Decode(&query); err != nil {
+			t.Fatalf("decode query: %v", err)
+		}
+		return jsonResponse(`{
+		  "hits": {
+		    "hits": [
+		      {"_source": {"trace_id": "trace_index_001", "bkn.request.id": "req_index_001", "events": []}},
+		      {"_source": {"trace_id": "trace_index_002", "bkn.request.id": "req_index_001", "events": []}}
+		    ]
+		  }
+		}`), nil
+	})
+
+	store := New(client, "bkn-trace-evidence-test")
+
+	result, err := store.GetEvidenceByTraceID(context.Background(), "trace_index_001", evidencevo.EvidenceQueryOptions{Limit: 1})
+	if err != nil {
+		t.Fatalf("query evidence: %v", err)
+	}
+	if query["size"] != float64(2) {
+		t.Fatalf("expected size limit+1, got %+v", query["size"])
+	}
+	if !result.Truncated || len(result.Traces) != 1 {
+		t.Fatalf("expected truncated single result, got %+v", result)
 	}
 }
 

--- a/bkn-trace/agent-observability/src/drivenadapter/httpaccess/opensearchevidencestore/store_test.go
+++ b/bkn-trace/agent-observability/src/drivenadapter/httpaccess/opensearchevidencestore/store_test.go
@@ -1,0 +1,176 @@
+package opensearchevidencestore
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/openbkn-ai/bkn-foundry/bkn-trace/agent-observability/src/domain/valueobject/evidencevo"
+	"github.com/openbkn-ai/bkn-foundry/bkn-trace/agent-observability/src/infra/opensearch"
+)
+
+func TestStoreEvidenceIndexesNormalizedTrace(t *testing.T) {
+	var path string
+	var body map[string]any
+	client := newFakeOpenSearchClient(func(r *http.Request) (*http.Response, error) {
+		path = r.URL.Path
+		if r.Method != http.MethodPut {
+			t.Fatalf("expected PUT, got %s", r.Method)
+		}
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Fatalf("decode request body: %v", err)
+		}
+		return jsonResponse(`{"result":"created"}`), nil
+	})
+
+	store := New(client, "bkn-trace-evidence-test")
+	store.now = func() time.Time { return time.Date(2026, 7, 23, 1, 2, 3, 4, time.UTC) }
+
+	if err := store.StoreEvidence(context.Background(), normalizedTrace()); err != nil {
+		t.Fatalf("store evidence: %v", err)
+	}
+
+	if !strings.HasPrefix(path, "/bkn-trace-evidence-test/_doc/") {
+		t.Fatalf("unexpected index path: %s", path)
+	}
+	if body["trace_id"] != "trace_index_001" || body["bkn.request.id"] != "req_index_001" {
+		t.Fatalf("unexpected identity fields: %+v", body)
+	}
+	if body["ingested_at"] != "2026-07-23T01:02:03.000000004Z" {
+		t.Fatalf("unexpected ingested_at: %+v", body["ingested_at"])
+	}
+}
+
+func TestGetEvidenceByTraceIDParsesSearchHits(t *testing.T) {
+	var query map[string]any
+	client := newFakeOpenSearchClient(func(r *http.Request) (*http.Response, error) {
+		if r.Method != http.MethodPost {
+			t.Fatalf("expected POST, got %s", r.Method)
+		}
+		if r.URL.Path != "/bkn-trace-evidence-test/_search" {
+			t.Fatalf("unexpected search path: %s", r.URL.Path)
+		}
+		if err := json.NewDecoder(r.Body).Decode(&query); err != nil {
+			t.Fatalf("decode query: %v", err)
+		}
+		return jsonResponse(`{
+		  "hits": {
+		    "hits": [
+		      {
+		        "_source": {
+		          "document_id": "doc-1",
+		          "trace_id": "trace_index_001",
+		          "bkn.request.id": "req_index_001",
+		          "bkn.trace.schema.version": "2.0.0",
+		          "events": [
+		            {
+		              "event_id": "evt_claim",
+		              "event_type": "claim.created",
+		              "bkn.trace.schema.version": "2.0.0",
+		              "trace_id": "trace_index_001",
+		              "bkn.request.id": "req_index_001",
+		              "payload": {"claim_id": "claim_index", "visibility": "visible"}
+		            }
+		          ],
+		          "claim_ids": ["claim_index"],
+		          "accepted_event_count": 1,
+		          "claim_count": 1,
+		          "evidence_ref_count": 0,
+		          "business_ref_count": 0,
+		          "ingested_at": "2026-07-23T01:02:03Z"
+		        }
+		      }
+		    ]
+		  }
+		}`), nil
+	})
+
+	store := New(client, "bkn-trace-evidence-test")
+
+	traces, err := store.GetEvidenceByTraceID(context.Background(), "trace_index_001")
+	if err != nil {
+		t.Fatalf("query evidence: %v", err)
+	}
+	if len(traces) != 1 {
+		t.Fatalf("expected one trace, got %d", len(traces))
+	}
+	if traces[0].TraceID != "trace_index_001" || traces[0].RequestID != "req_index_001" || traces[0].ClaimCount != 1 {
+		t.Fatalf("unexpected trace: %+v", traces[0])
+	}
+	queryBytes, _ := json.Marshal(query)
+	if !strings.Contains(string(queryBytes), `"trace_id.keyword"`) {
+		t.Fatalf("expected keyword exact term fallback, got %s", string(queryBytes))
+	}
+	if strings.Contains(string(queryBytes), `"document_id"`) {
+		t.Fatalf("document_id sort requires explicit mapping and must not be emitted, got %s", string(queryBytes))
+	}
+}
+
+func TestGetEvidenceByRequestIDUsesRequestIDField(t *testing.T) {
+	var query map[string]any
+	client := newFakeOpenSearchClient(func(r *http.Request) (*http.Response, error) {
+		if err := json.NewDecoder(r.Body).Decode(&query); err != nil {
+			t.Fatalf("decode query: %v", err)
+		}
+		return jsonResponse(`{"hits":{"hits":[]}}`), nil
+	})
+
+	store := New(client, "bkn-trace-evidence-test")
+
+	if _, err := store.GetEvidenceByRequestID(context.Background(), "req_index_001"); err != nil {
+		t.Fatalf("query evidence: %v", err)
+	}
+	queryBytes, _ := json.Marshal(query)
+	if !strings.Contains(string(queryBytes), `"bkn.request.id.keyword"`) {
+		t.Fatalf("expected request id keyword term, got %s", string(queryBytes))
+	}
+}
+
+func normalizedTrace() evidencevo.NormalizedTrace {
+	return evidencevo.NormalizedTrace{
+		TraceID:       "trace_index_001",
+		RequestID:     "req_index_001",
+		SchemaVersion: evidencevo.ContractVersion,
+		Events: []evidencevo.EvidenceEvent{
+			{
+				EventID:       "evt_claim",
+				EventType:     "claim.created",
+				SchemaVersion: evidencevo.ContractVersion,
+				TraceID:       "trace_index_001",
+				RequestID:     "req_index_001",
+				Payload: map[string]any{
+					"claim_id":   "claim_index",
+					"visibility": "visible",
+				},
+			},
+		},
+		ClaimIDs:       []string{"claim_index"},
+		AcceptedEvents: 1,
+		ClaimCount:     1,
+	}
+}
+
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripFunc) RoundTrip(r *http.Request) (*http.Response, error) {
+	return f(r)
+}
+
+func newFakeOpenSearchClient(fn roundTripFunc) *opensearch.Client {
+	return opensearch.NewWithHTTPClient("http://opensearch.test", opensearch.AuthConfig{}, &http.Client{
+		Transport: fn,
+	})
+}
+
+func jsonResponse(body string) *http.Response {
+	return &http.Response{
+		StatusCode: http.StatusOK,
+		Header:     http.Header{"Content-Type": []string{"application/json"}},
+		Body:       io.NopCloser(bytes.NewBufferString(body)),
+	}
+}

--- a/bkn-trace/agent-observability/src/drivenadapter/memoryaccess/evidencestore/store.go
+++ b/bkn-trace/agent-observability/src/drivenadapter/memoryaccess/evidencestore/store.go
@@ -28,20 +28,32 @@ func (s *Store) StoreEvidence(_ context.Context, trace evidencevo.NormalizedTrac
 	return nil
 }
 
-func (s *Store) GetEvidenceByTraceID(_ context.Context, traceID string) ([]evidencevo.NormalizedTrace, error) {
+func (s *Store) GetEvidenceByTraceID(_ context.Context, traceID string, options evidencevo.EvidenceQueryOptions) (evidencevo.EvidenceQueryResult, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	return append([]evidencevo.NormalizedTrace(nil), s.traces[traceID]...), nil
+	return limitedResult(s.traces[traceID], options.Limit), nil
 }
 
-func (s *Store) GetEvidenceByRequestID(_ context.Context, requestID string) ([]evidencevo.NormalizedTrace, error) {
+func (s *Store) GetEvidenceByRequestID(_ context.Context, requestID string, options evidencevo.EvidenceQueryOptions) (evidencevo.EvidenceQueryResult, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	return append([]evidencevo.NormalizedTrace(nil), s.requests[requestID]...), nil
+	return limitedResult(s.requests[requestID], options.Limit), nil
 }
 
 func (s *Store) TraceCount(traceID string) int {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	return len(s.traces[traceID])
+}
+
+func limitedResult(traces []evidencevo.NormalizedTrace, limit int) evidencevo.EvidenceQueryResult {
+	if limit <= 0 || len(traces) <= limit {
+		return evidencevo.EvidenceQueryResult{
+			Traces: append([]evidencevo.NormalizedTrace(nil), traces...),
+		}
+	}
+	return evidencevo.EvidenceQueryResult{
+		Traces:    append([]evidencevo.NormalizedTrace(nil), traces[:limit]...),
+		Truncated: true,
+	}
 }

--- a/bkn-trace/agent-observability/src/driveradapter/api/httphandler/evidence_handler.go
+++ b/bkn-trace/agent-observability/src/driveradapter/api/httphandler/evidence_handler.go
@@ -5,9 +5,11 @@ import (
 	"io"
 	"net/http"
 	"os"
+	"strconv"
 	"strings"
 
 	"github.com/openbkn-ai/bkn-foundry/bkn-trace/agent-observability/src/domain/service/evidencesvc"
+	"github.com/openbkn-ai/bkn-foundry/bkn-trace/agent-observability/src/domain/valueobject/evidencevo"
 	"github.com/openbkn-ai/bkn-foundry/bkn-trace/agent-observability/src/driveradapter/api/rdto"
 )
 
@@ -97,6 +99,7 @@ func (h *EvidenceHandler) IngestEvidenceEvents(w http.ResponseWriter, r *http.Re
 // @Tags evidence
 // @Produce json
 // @Param trace_id path string true "Trace ID"
+// @Param limit query int false "Maximum evidence trace batches to read, 1..1000"
 // @Success 200 {object} map[string]interface{}
 // @Failure 400 {object} rdto.ErrorResponse
 // @Failure 404 {object} rdto.ErrorResponse
@@ -121,7 +124,12 @@ func (h *EvidenceHandler) GetEvidenceChainByTraceID(w http.ResponseWriter, r *ht
 		return
 	}
 
-	response, found, err := h.evidenceService.GetEvidenceChainByTraceID(r.Context(), traceID)
+	options, ok := evidenceQueryOptionsFromRequest(w, r)
+	if !ok {
+		return
+	}
+
+	response, found, err := h.evidenceService.GetEvidenceChainByTraceID(r.Context(), traceID, options)
 	if err != nil {
 		writeJSON(w, http.StatusInternalServerError, rdto.ErrorResponse{
 			Code:    "QUERY_FAILED",
@@ -161,6 +169,7 @@ func (h *EvidenceHandler) GetTraceSubresource(w http.ResponseWriter, r *http.Req
 // @Tags evidence
 // @Produce json
 // @Param trace_id path string true "Trace ID"
+// @Param limit query int false "Maximum evidence trace batches to read, 1..1000"
 // @Success 200 {object} map[string]interface{}
 // @Failure 400 {object} rdto.ErrorResponse
 // @Failure 404 {object} rdto.ErrorResponse
@@ -185,7 +194,12 @@ func (h *EvidenceHandler) GetBusinessGraphByTraceID(w http.ResponseWriter, r *ht
 		return
 	}
 
-	response, found, err := h.evidenceService.GetBusinessGraphByTraceID(r.Context(), traceID)
+	options, ok := evidenceQueryOptionsFromRequest(w, r)
+	if !ok {
+		return
+	}
+
+	response, found, err := h.evidenceService.GetBusinessGraphByTraceID(r.Context(), traceID, options)
 	if err != nil {
 		writeJSON(w, http.StatusInternalServerError, rdto.ErrorResponse{
 			Code:    "QUERY_FAILED",
@@ -210,6 +224,7 @@ func (h *EvidenceHandler) GetBusinessGraphByTraceID(w http.ResponseWriter, r *ht
 // @Tags evidence
 // @Produce json
 // @Param request_id query string true "BKN request ID"
+// @Param limit query int false "Maximum evidence trace batches to read, 1..1000"
 // @Success 200 {object} map[string]interface{}
 // @Failure 400 {object} rdto.ErrorResponse
 // @Failure 404 {object} rdto.ErrorResponse
@@ -234,7 +249,12 @@ func (h *EvidenceHandler) GetEvidenceChainByRequestID(w http.ResponseWriter, r *
 		return
 	}
 
-	response, found, err := h.evidenceService.GetEvidenceChainByRequestID(r.Context(), requestID)
+	options, ok := evidenceQueryOptionsFromRequest(w, r)
+	if !ok {
+		return
+	}
+
+	response, found, err := h.evidenceService.GetEvidenceChainByRequestID(r.Context(), requestID, options)
 	if err != nil {
 		writeJSON(w, http.StatusInternalServerError, rdto.ErrorResponse{
 			Code:    "QUERY_FAILED",
@@ -259,6 +279,7 @@ func (h *EvidenceHandler) GetEvidenceChainByRequestID(w http.ResponseWriter, r *
 // @Tags evidence
 // @Produce json
 // @Param request_id query string true "BKN request ID"
+// @Param limit query int false "Maximum evidence trace batches to read, 1..1000"
 // @Success 200 {object} map[string]interface{}
 // @Failure 400 {object} rdto.ErrorResponse
 // @Failure 404 {object} rdto.ErrorResponse
@@ -283,7 +304,12 @@ func (h *EvidenceHandler) GetBusinessGraphByRequestID(w http.ResponseWriter, r *
 		return
 	}
 
-	response, found, err := h.evidenceService.GetBusinessGraphByRequestID(r.Context(), requestID)
+	options, ok := evidenceQueryOptionsFromRequest(w, r)
+	if !ok {
+		return
+	}
+
+	response, found, err := h.evidenceService.GetBusinessGraphByRequestID(r.Context(), requestID, options)
 	if err != nil {
 		writeJSON(w, http.StatusInternalServerError, rdto.ErrorResponse{
 			Code:    "QUERY_FAILED",
@@ -314,6 +340,22 @@ func traceIDFromEvidenceChainPath(path string) string {
 		return ""
 	}
 	return strings.TrimSpace(traceID)
+}
+
+func evidenceQueryOptionsFromRequest(w http.ResponseWriter, r *http.Request) (evidencevo.EvidenceQueryOptions, bool) {
+	rawLimit := strings.TrimSpace(r.URL.Query().Get("limit"))
+	if rawLimit == "" {
+		return evidencevo.EvidenceQueryOptions{}, true
+	}
+	limit, err := strconv.Atoi(rawLimit)
+	if err != nil || limit <= 0 || limit > evidencesvc.MaxEvidenceQueryLimit {
+		writeJSON(w, http.StatusBadRequest, rdto.ErrorResponse{
+			Code:    "INVALID_ARGUMENT",
+			Message: "limit must be an integer between 1 and 1000",
+		})
+		return evidencevo.EvidenceQueryOptions{}, false
+	}
+	return evidencevo.EvidenceQueryOptions{Limit: limit}, true
 }
 
 func traceIDFromBusinessGraphPath(path string) string {

--- a/bkn-trace/agent-observability/src/driveradapter/api/httphandler/evidence_handler_test.go
+++ b/bkn-trace/agent-observability/src/driveradapter/api/httphandler/evidence_handler_test.go
@@ -150,6 +150,21 @@ func TestEvidenceHandlerReturnsEvidenceChainByRequest(t *testing.T) {
 	}
 }
 
+func TestEvidenceHandlerRejectsInvalidEvidenceQueryLimit(t *testing.T) {
+	handler := NewEvidenceHandler(evidencesvc.New(evidencestore.New()))
+	req := httptest.NewRequest(http.MethodGet, "/api/agent-observability/v1/traces/by-request?request_id=req_handler_001&limit=0", nil)
+	rec := httptest.NewRecorder()
+
+	handler.GetEvidenceChainByRequestID(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d: %s", rec.Code, rec.Body.String())
+	}
+	if !strings.Contains(rec.Body.String(), `"limit must be an integer between 1 and 1000"`) {
+		t.Fatalf("unexpected body: %s", rec.Body.String())
+	}
+}
+
 func TestEvidenceHandlerReturnsBusinessGraphByTrace(t *testing.T) {
 	store := evidencestore.New()
 	handler := NewEvidenceHandler(evidencesvc.New(store))

--- a/bkn-trace/agent-observability/src/infra/opensearch/client.go
+++ b/bkn-trace/agent-observability/src/infra/opensearch/client.go
@@ -23,12 +23,19 @@ type AuthConfig struct {
 }
 
 func New(baseURL string, auth AuthConfig, timeout time.Duration) *Client {
+	return NewWithHTTPClient(baseURL, auth, &http.Client{
+		Timeout: timeout,
+	})
+}
+
+func NewWithHTTPClient(baseURL string, auth AuthConfig, httpClient *http.Client) *Client {
+	if httpClient == nil {
+		httpClient = http.DefaultClient
+	}
 	return &Client{
-		baseURL: strings.TrimRight(baseURL, "/"),
-		auth:    auth,
-		httpClient: &http.Client{
-			Timeout: timeout,
-		},
+		baseURL:    strings.TrimRight(baseURL, "/"),
+		auth:       auth,
+		httpClient: httpClient,
 	}
 }
 
@@ -63,4 +70,37 @@ func (c *Client) Search(ctx context.Context, index string, query []byte) ([]byte
 	}
 
 	return body, nil
+}
+
+func (c *Client) IndexDocument(ctx context.Context, index string, documentID string, body []byte) ([]byte, error) {
+	url := fmt.Sprintf("%s/%s/_doc/%s", c.baseURL, strings.TrimLeft(index, "/"), strings.TrimLeft(documentID, "/"))
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPut, url, bytes.NewReader(body))
+	if err != nil {
+		return nil, fmt.Errorf("create opensearch index request: %w", err)
+	}
+
+	req.Header.Set("Content-Type", "application/json")
+	if c.auth.Enabled {
+		req.SetBasicAuth(c.auth.Username, c.auth.Password)
+	}
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("execute opensearch index request: %w", err)
+	}
+	defer func() {
+		_ = resp.Body.Close()
+	}()
+
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("read opensearch index response: %w", err)
+	}
+
+	if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
+		return nil, fmt.Errorf("opensearch index failed with status %d: %s", resp.StatusCode, string(respBody))
+	}
+
+	return respBody, nil
 }

--- a/bkn-trace/agent-observability/src/port/driven/ievidencestore/port.go
+++ b/bkn-trace/agent-observability/src/port/driven/ievidencestore/port.go
@@ -8,6 +8,6 @@ import (
 
 type EvidenceStorePort interface {
 	StoreEvidence(ctx context.Context, trace evidencevo.NormalizedTrace) error
-	GetEvidenceByTraceID(ctx context.Context, traceID string) ([]evidencevo.NormalizedTrace, error)
-	GetEvidenceByRequestID(ctx context.Context, requestID string) ([]evidencevo.NormalizedTrace, error)
+	GetEvidenceByTraceID(ctx context.Context, traceID string, options evidencevo.EvidenceQueryOptions) (evidencevo.EvidenceQueryResult, error)
+	GetEvidenceByRequestID(ctx context.Context, requestID string, options evidencevo.EvidenceQueryOptions) (evidencevo.EvidenceQueryResult, error)
 }


### PR DESCRIPTION
## 背景

BKN Trace 阶段二已经具备 evidence ingestion、Evidence Chain 查询和 Business Graph 查询，但 evidence repository 默认仍是进程内内存，服务重启或多副本部署时不可复查、不可共享。

这批 PR 把 agent-observability 的 evidence repository 扩展为可配置的 OpenSearch evidence index store，同时保持默认内存 store 兼容。

## 主要改动

- 新增 OpenSearch evidence store，实现 `StoreEvidence`、按 `trace_id` 查询、按 `bkn.request.id` 查询。
- 新增 `BKN_TRACE_EVIDENCE_STORE` 配置，默认 `memory`，可切换为 `opensearch`。
- 新增 `OPENSEARCH_EVIDENCE_INDEX` 配置，默认 `bkn-trace-evidence-v1`。
- OpenSearch client 增加 document indexing 能力，并支持注入 HTTP client 便于单测。
- Helm Chart 增加 evidence store/index 配置与环境变量。
- README 补充 evidence store 启用方式、安全边界和当前不自动创建 index 的部署约束。

## 设计边界

- 本 PR 不自动创建 OpenSearch index，不要求 agent-observability 服务账号具备 index-management 权限。
- 部署方需要提前创建 `OPENSEARCH_EVIDENCE_INDEX`。
- index mapping、retention/ILM、权限收敛与迁移脚本会在后续部署治理 PR 中补齐。
- document id 基于 trace/request/event ids 生成，重复写入同一批事件会覆盖同一文档，避免重试造成重复 evidence 批次。

## 验证

- `env GOCACHE=/tmp/openbkn-go-cache go test ./...`
- `env GOCACHE=/tmp/openbkn-go-cache go vet ./...`
- `helm lint charts/agent-observability`
- `helm template agent-observability charts/agent-observability --set evidence.store=opensearch --set evidence.index=bkn-trace-evidence-v1`
- `git diff --check`
