### PR TITLE
feat(bkn-trace): mark truncated evidence queries

### DIFF
--- a/bkn-trace/agent-observability/README.md
+++ b/bkn-trace/agent-observability/README.md
@@ -60,6 +60,15 @@ OPENSEARCH_EVIDENCE_INDEX=bkn-trace-evidence-v1
 
 当前 PR 不自动创建 index，不要求服务账号具备 OpenSearch index-management 权限；部署方需要提前创建 `OPENSEARCH_EVIDENCE_INDEX`。后续部署治理 PR 会补 index mapping、retention/ILM、权限与迁移脚本。
 
+Evidence Chain 与 Business Graph 查询支持可选 `limit` 参数，限制本次读取的 evidence trace 批次数：
+
+```http
+GET /api/agent-observability/v1/traces/{trace_id}/evidence-chain?limit=100
+GET /api/agent-observability/v1/traces/by-request/business-graph?request_id=req_x&limit=100
+```
+
+`limit` 取值范围为 `1..1000`，默认 `1000`。命中上限时响应会返回 `partial=true`、`partial_reason=["evidence_query_truncated"]`，并设置 `page.truncated=true`，调用方不得把该结果展示为完整证据链。
+
 ### Evidence 写入安全边界
 
 `POST /api/agent-observability/v1/evidence/events` 是写接口，生产环境必须通过平台网关鉴权保护，或配置服务内最小 ingest token：

--- a/bkn-trace/agent-observability/src/domain/service/evidencesvc/service.go
+++ b/bkn-trace/agent-observability/src/domain/service/evidencesvc/service.go
@@ -73,6 +73,11 @@ type Service struct {
 	store ievidencestore.EvidenceStorePort
 }
 
+const (
+	DefaultEvidenceQueryLimit = 1000
+	MaxEvidenceQueryLimit     = 1000
+)
+
 func New(store ievidencestore.EvidenceStorePort) *Service {
 	return &Service{store: store}
 }
@@ -118,51 +123,51 @@ func (s *Service) Ingest(ctx context.Context, body []byte) (evidencevo.IngestRes
 	}, nil, nil
 }
 
-func (s *Service) GetEvidenceChainByTraceID(ctx context.Context, traceID string) (evidencevo.EvidenceChainResponse, bool, error) {
-	traces, err := s.store.GetEvidenceByTraceID(ctx, strings.TrimSpace(traceID))
+func (s *Service) GetEvidenceChainByTraceID(ctx context.Context, traceID string, options evidencevo.EvidenceQueryOptions) (evidencevo.EvidenceChainResponse, bool, error) {
+	result, err := s.store.GetEvidenceByTraceID(ctx, strings.TrimSpace(traceID), normalizeQueryOptions(options))
 	if err != nil {
 		return evidencevo.EvidenceChainResponse{}, false, err
 	}
-	if len(traces) == 0 {
+	if len(result.Traces) == 0 {
 		return evidencevo.EvidenceChainResponse{}, false, nil
 	}
-	return buildEvidenceChain(traces), true, nil
+	return buildEvidenceChain(result.Traces, result.Truncated), true, nil
 }
 
-func (s *Service) GetEvidenceChainByRequestID(ctx context.Context, requestID string) (evidencevo.EvidenceChainResponse, bool, error) {
-	traces, err := s.store.GetEvidenceByRequestID(ctx, strings.TrimSpace(requestID))
+func (s *Service) GetEvidenceChainByRequestID(ctx context.Context, requestID string, options evidencevo.EvidenceQueryOptions) (evidencevo.EvidenceChainResponse, bool, error) {
+	result, err := s.store.GetEvidenceByRequestID(ctx, strings.TrimSpace(requestID), normalizeQueryOptions(options))
 	if err != nil {
 		return evidencevo.EvidenceChainResponse{}, false, err
 	}
-	if len(traces) == 0 {
+	if len(result.Traces) == 0 {
 		return evidencevo.EvidenceChainResponse{}, false, nil
 	}
-	return buildEvidenceChain(traces), true, nil
+	return buildEvidenceChain(result.Traces, result.Truncated), true, nil
 }
 
-func (s *Service) GetBusinessGraphByTraceID(ctx context.Context, traceID string) (evidencevo.BusinessGraphResponse, bool, error) {
-	traces, err := s.store.GetEvidenceByTraceID(ctx, strings.TrimSpace(traceID))
+func (s *Service) GetBusinessGraphByTraceID(ctx context.Context, traceID string, options evidencevo.EvidenceQueryOptions) (evidencevo.BusinessGraphResponse, bool, error) {
+	result, err := s.store.GetEvidenceByTraceID(ctx, strings.TrimSpace(traceID), normalizeQueryOptions(options))
 	if err != nil {
 		return evidencevo.BusinessGraphResponse{}, false, err
 	}
-	if len(traces) == 0 {
+	if len(result.Traces) == 0 {
 		return evidencevo.BusinessGraphResponse{}, false, nil
 	}
-	return buildBusinessGraph(traces), true, nil
+	return buildBusinessGraph(result.Traces, result.Truncated), true, nil
 }
 
-func (s *Service) GetBusinessGraphByRequestID(ctx context.Context, requestID string) (evidencevo.BusinessGraphResponse, bool, error) {
-	traces, err := s.store.GetEvidenceByRequestID(ctx, strings.TrimSpace(requestID))
+func (s *Service) GetBusinessGraphByRequestID(ctx context.Context, requestID string, options evidencevo.EvidenceQueryOptions) (evidencevo.BusinessGraphResponse, bool, error) {
+	result, err := s.store.GetEvidenceByRequestID(ctx, strings.TrimSpace(requestID), normalizeQueryOptions(options))
 	if err != nil {
 		return evidencevo.BusinessGraphResponse{}, false, err
 	}
-	if len(traces) == 0 {
+	if len(result.Traces) == 0 {
 		return evidencevo.BusinessGraphResponse{}, false, nil
 	}
-	return buildBusinessGraph(traces), true, nil
+	return buildBusinessGraph(result.Traces, result.Truncated), true, nil
 }
 
-func buildEvidenceChain(traces []evidencevo.NormalizedTrace) evidencevo.EvidenceChainResponse {
+func buildEvidenceChain(traces []evidencevo.NormalizedTrace, truncated bool) evidencevo.EvidenceChainResponse {
 	response := evidencevo.EvidenceChainResponse{
 		TraceID:   traces[0].TraceID,
 		RequestID: traces[0].RequestID,
@@ -212,15 +217,19 @@ func buildEvidenceChain(traces []evidencevo.NormalizedTrace) evidencevo.Evidence
 			partialReasons["version_status_missing"] = struct{}{}
 		}
 	}
+	if truncated {
+		partialReasons["evidence_query_truncated"] = struct{}{}
+	}
 
 	response.PartialReasons = sortedKeys(partialReasons)
 	response.Partial = len(response.PartialReasons) > 0
 	response.Page.NodeCount = len(response.Data.Claims) + len(response.Data.EvidenceRefs) + len(response.Data.BusinessRefs)
 	response.Page.EdgeCount = len(response.Data.EvidenceRefs) + len(response.Data.BusinessRefs)
+	response.Page.Truncated = truncated
 	return response
 }
 
-func buildBusinessGraph(traces []evidencevo.NormalizedTrace) evidencevo.BusinessGraphResponse {
+func buildBusinessGraph(traces []evidencevo.NormalizedTrace, truncated bool) evidencevo.BusinessGraphResponse {
 	response := evidencevo.BusinessGraphResponse{
 		TraceID:   traces[0].TraceID,
 		RequestID: traces[0].RequestID,
@@ -316,12 +325,26 @@ func buildBusinessGraph(traces []evidencevo.NormalizedTrace) evidencevo.Business
 	if len(response.Data.Nodes) == 0 {
 		partialReasons["empty_business_graph"] = struct{}{}
 	}
+	if truncated {
+		partialReasons["evidence_query_truncated"] = struct{}{}
+	}
 
 	response.PartialReasons = sortedKeys(partialReasons)
 	response.Partial = len(response.PartialReasons) > 0
 	response.Page.NodeCount = len(response.Data.Nodes)
 	response.Page.EdgeCount = len(response.Data.Edges)
+	response.Page.Truncated = truncated
 	return response
+}
+
+func normalizeQueryOptions(options evidencevo.EvidenceQueryOptions) evidencevo.EvidenceQueryOptions {
+	if options.Limit <= 0 {
+		options.Limit = DefaultEvidenceQueryLimit
+	}
+	if options.Limit > MaxEvidenceQueryLimit {
+		options.Limit = MaxEvidenceQueryLimit
+	}
+	return options
 }
 
 func appendVisibleRefs(target []map[string]any, refs []any, summary *evidencevo.VisibilitySummary) []map[string]any {

--- a/bkn-trace/agent-observability/src/domain/service/evidencesvc/service_test.go
+++ b/bkn-trace/agent-observability/src/domain/service/evidencesvc/service_test.go
@@ -18,24 +18,34 @@ func (s *fakeStore) StoreEvidence(_ context.Context, _ evidencevo.NormalizedTrac
 	return nil
 }
 
-func (s *fakeStore) GetEvidenceByTraceID(_ context.Context, traceID string) ([]evidencevo.NormalizedTrace, error) {
+func (s *fakeStore) GetEvidenceByTraceID(_ context.Context, traceID string, options evidencevo.EvidenceQueryOptions) (evidencevo.EvidenceQueryResult, error) {
 	var result []evidencevo.NormalizedTrace
 	for _, trace := range s.traces {
 		if trace.TraceID == traceID {
 			result = append(result, trace)
 		}
 	}
-	return result, nil
+	return fakeLimitedResult(result, options.Limit), nil
 }
 
-func (s *fakeStore) GetEvidenceByRequestID(_ context.Context, requestID string) ([]evidencevo.NormalizedTrace, error) {
+func (s *fakeStore) GetEvidenceByRequestID(_ context.Context, requestID string, options evidencevo.EvidenceQueryOptions) (evidencevo.EvidenceQueryResult, error) {
 	var result []evidencevo.NormalizedTrace
 	for _, trace := range s.traces {
 		if trace.RequestID == requestID {
 			result = append(result, trace)
 		}
 	}
-	return result, nil
+	return fakeLimitedResult(result, options.Limit), nil
+}
+
+func fakeLimitedResult(traces []evidencevo.NormalizedTrace, limit int) evidencevo.EvidenceQueryResult {
+	if limit <= 0 || len(traces) <= limit {
+		return evidencevo.EvidenceQueryResult{Traces: traces}
+	}
+	return evidencevo.EvidenceQueryResult{
+		Traces:    traces[:limit],
+		Truncated: true,
+	}
 }
 
 func TestIngestAcceptsPhaseTwoEvidenceBatch(t *testing.T) {
@@ -225,7 +235,7 @@ func TestGetEvidenceChainByTraceIDFiltersHiddenRefsAndReturnsEnvelope(t *testing
 	store := &fakeStore{traces: []evidencevo.NormalizedTrace{queryTrace("trace_query_001", "req_query_001")}}
 	service := New(store)
 
-	response, found, err := service.GetEvidenceChainByTraceID(context.Background(), "trace_query_001")
+	response, found, err := service.GetEvidenceChainByTraceID(context.Background(), "trace_query_001", evidencevo.EvidenceQueryOptions{})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -268,7 +278,7 @@ func TestGetEvidenceChainByRequestIDReturnsMissingClaimPartial(t *testing.T) {
 	}}}
 	service := New(store)
 
-	response, found, err := service.GetEvidenceChainByRequestID(context.Background(), "req_no_claim")
+	response, found, err := service.GetEvidenceChainByRequestID(context.Background(), "req_no_claim", evidencevo.EvidenceQueryOptions{})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -280,11 +290,30 @@ func TestGetEvidenceChainByRequestIDReturnsMissingClaimPartial(t *testing.T) {
 	}
 }
 
+func TestGetEvidenceChainMarksQueryTruncated(t *testing.T) {
+	store := &fakeStore{traces: []evidencevo.NormalizedTrace{
+		queryTrace("trace_query_001", "req_query_truncated"),
+		queryTrace("trace_query_002", "req_query_truncated"),
+	}}
+	service := New(store)
+
+	response, found, err := service.GetEvidenceChainByRequestID(context.Background(), "req_query_truncated", evidencevo.EvidenceQueryOptions{Limit: 1})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !found {
+		t.Fatal("expected evidence chain to be found")
+	}
+	if !response.Partial || !response.Page.Truncated || !contains(response.PartialReasons, "evidence_query_truncated") {
+		t.Fatalf("expected truncated partial response, got: %+v", response)
+	}
+}
+
 func TestGetBusinessGraphByTraceIDReturnsClaimAndBusinessNodes(t *testing.T) {
 	store := &fakeStore{traces: []evidencevo.NormalizedTrace{queryTrace("trace_graph_001", "req_graph_001")}}
 	service := New(store)
 
-	response, found, err := service.GetBusinessGraphByTraceID(context.Background(), "trace_graph_001")
+	response, found, err := service.GetBusinessGraphByTraceID(context.Background(), "trace_graph_001", evidencevo.EvidenceQueryOptions{})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -315,7 +344,7 @@ func TestGetBusinessGraphByRequestIDHandlesHiddenAndUnresolvedRefs(t *testing.T)
 	store := &fakeStore{traces: []evidencevo.NormalizedTrace{businessGraphTraceWithGovernance("trace_graph_002", "req_graph_002")}}
 	service := New(store)
 
-	response, found, err := service.GetBusinessGraphByRequestID(context.Background(), "req_graph_002")
+	response, found, err := service.GetBusinessGraphByRequestID(context.Background(), "req_graph_002", evidencevo.EvidenceQueryOptions{})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -337,7 +366,7 @@ func TestGetBusinessGraphDoesNotDependOnEventOrder(t *testing.T) {
 	store := &fakeStore{traces: []evidencevo.NormalizedTrace{businessGraphTraceWithBusinessBeforeClaim("trace_graph_003", "req_graph_003")}}
 	service := New(store)
 
-	response, found, err := service.GetBusinessGraphByTraceID(context.Background(), "trace_graph_003")
+	response, found, err := service.GetBusinessGraphByTraceID(context.Background(), "trace_graph_003", evidencevo.EvidenceQueryOptions{})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -356,7 +385,7 @@ func TestGetBusinessGraphDeduplicatesEdgesAndAuthorizedRefs(t *testing.T) {
 	store := &fakeStore{traces: []evidencevo.NormalizedTrace{businessGraphTraceWithDuplicateRefs("trace_graph_004", "req_graph_004")}}
 	service := New(store)
 
-	response, found, err := service.GetBusinessGraphByTraceID(context.Background(), "trace_graph_004")
+	response, found, err := service.GetBusinessGraphByTraceID(context.Background(), "trace_graph_004", evidencevo.EvidenceQueryOptions{})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -375,7 +404,7 @@ func TestGetBusinessGraphDoesNotLeakHiddenClaimThroughSyntheticNode(t *testing.T
 	store := &fakeStore{traces: []evidencevo.NormalizedTrace{businessGraphTraceWithHiddenClaim("trace_graph_005", "req_graph_005")}}
 	service := New(store)
 
-	response, found, err := service.GetBusinessGraphByTraceID(context.Background(), "trace_graph_005")
+	response, found, err := service.GetBusinessGraphByTraceID(context.Background(), "trace_graph_005", evidencevo.EvidenceQueryOptions{})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -412,7 +441,7 @@ func TestGetBusinessGraphReturnsMissingBusinessRefsPartial(t *testing.T) {
 	}}}
 	service := New(store)
 
-	response, found, err := service.GetBusinessGraphByTraceID(context.Background(), "trace_no_business_refs")
+	response, found, err := service.GetBusinessGraphByTraceID(context.Background(), "trace_no_business_refs", evidencevo.EvidenceQueryOptions{})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -427,7 +456,7 @@ func TestGetBusinessGraphReturnsMissingBusinessRefsPartial(t *testing.T) {
 func TestGetEvidenceChainByTraceIDNotFound(t *testing.T) {
 	service := New(&fakeStore{})
 
-	_, found, err := service.GetEvidenceChainByTraceID(context.Background(), "missing")
+	_, found, err := service.GetEvidenceChainByTraceID(context.Background(), "missing", evidencevo.EvidenceQueryOptions{})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}

--- a/bkn-trace/agent-observability/src/domain/valueobject/evidencevo/evidence.go
+++ b/bkn-trace/agent-observability/src/domain/valueobject/evidencevo/evidence.go
@@ -59,6 +59,15 @@ type NormalizedTrace struct {
 	BusinessRefCount int
 }
 
+type EvidenceQueryOptions struct {
+	Limit int
+}
+
+type EvidenceQueryResult struct {
+	Traces    []NormalizedTrace
+	Truncated bool
+}
+
 type EvidenceChainResponse struct {
 	TraceID           string            `json:"trace_id"`
 	RequestID         string            `json:"bkn.request.id"`

--- a/bkn-trace/agent-observability/src/drivenadapter/httpaccess/opensearchevidencestore/store.go
+++ b/bkn-trace/agent-observability/src/drivenadapter/httpaccess/opensearchevidencestore/store.go
@@ -62,17 +62,21 @@ func (s *Store) StoreEvidence(ctx context.Context, trace evidencevo.NormalizedTr
 	return nil
 }
 
-func (s *Store) GetEvidenceByTraceID(ctx context.Context, traceID string) ([]evidencevo.NormalizedTrace, error) {
-	return s.search(ctx, "trace_id", traceID)
+func (s *Store) GetEvidenceByTraceID(ctx context.Context, traceID string, options evidencevo.EvidenceQueryOptions) (evidencevo.EvidenceQueryResult, error) {
+	return s.search(ctx, "trace_id", traceID, options)
 }
 
-func (s *Store) GetEvidenceByRequestID(ctx context.Context, requestID string) ([]evidencevo.NormalizedTrace, error) {
-	return s.search(ctx, "bkn.request.id", requestID)
+func (s *Store) GetEvidenceByRequestID(ctx context.Context, requestID string, options evidencevo.EvidenceQueryOptions) (evidencevo.EvidenceQueryResult, error) {
+	return s.search(ctx, "bkn.request.id", requestID, options)
 }
 
-func (s *Store) search(ctx context.Context, field string, value string) ([]evidencevo.NormalizedTrace, error) {
+func (s *Store) search(ctx context.Context, field string, value string, options evidencevo.EvidenceQueryOptions) (evidencevo.EvidenceQueryResult, error) {
+	limit := options.Limit
+	if limit <= 0 {
+		limit = maxEvidenceSearchResults
+	}
 	query, err := json.Marshal(map[string]any{
-		"size": maxEvidenceSearchResults,
+		"size": limit + 1,
 		"query": map[string]any{
 			"bool": exactTermQuery(field, value),
 		},
@@ -81,24 +85,29 @@ func (s *Store) search(ctx context.Context, field string, value string) ([]evide
 		},
 	})
 	if err != nil {
-		return nil, fmt.Errorf("marshal evidence search query: %w", err)
+		return evidencevo.EvidenceQueryResult{}, fmt.Errorf("marshal evidence search query: %w", err)
 	}
 
 	body, err := s.client.Search(ctx, s.index, query)
 	if err != nil {
-		return nil, err
+		return evidencevo.EvidenceQueryResult{}, err
 	}
 
 	var response searchResponse
 	if err := json.Unmarshal(body, &response); err != nil {
-		return nil, fmt.Errorf("decode evidence search response: %w", err)
+		return evidencevo.EvidenceQueryResult{}, fmt.Errorf("decode evidence search response: %w", err)
 	}
 
 	traces := make([]evidencevo.NormalizedTrace, 0, len(response.Hits.Hits))
 	for _, hit := range response.Hits.Hits {
 		traces = append(traces, fromDocument(hit.Source))
 	}
-	return traces, nil
+	result := evidencevo.EvidenceQueryResult{Traces: traces}
+	if len(result.Traces) > limit {
+		result.Truncated = true
+		result.Traces = result.Traces[:limit]
+	}
+	return result, nil
 }
 
 func toDocument(trace evidencevo.NormalizedTrace, ingestedAt time.Time) document {

--- a/bkn-trace/agent-observability/src/drivenadapter/httpaccess/opensearchevidencestore/store_test.go
+++ b/bkn-trace/agent-observability/src/drivenadapter/httpaccess/opensearchevidencestore/store_test.go
@@ -92,15 +92,15 @@ func TestGetEvidenceByTraceIDParsesSearchHits(t *testing.T) {
 
 	store := New(client, "bkn-trace-evidence-test")
 
-	traces, err := store.GetEvidenceByTraceID(context.Background(), "trace_index_001")
+	result, err := store.GetEvidenceByTraceID(context.Background(), "trace_index_001", evidencevo.EvidenceQueryOptions{})
 	if err != nil {
 		t.Fatalf("query evidence: %v", err)
 	}
-	if len(traces) != 1 {
-		t.Fatalf("expected one trace, got %d", len(traces))
+	if len(result.Traces) != 1 {
+		t.Fatalf("expected one trace, got %d", len(result.Traces))
 	}
-	if traces[0].TraceID != "trace_index_001" || traces[0].RequestID != "req_index_001" || traces[0].ClaimCount != 1 {
-		t.Fatalf("unexpected trace: %+v", traces[0])
+	if result.Traces[0].TraceID != "trace_index_001" || result.Traces[0].RequestID != "req_index_001" || result.Traces[0].ClaimCount != 1 {
+		t.Fatalf("unexpected trace: %+v", result.Traces[0])
 	}
 	queryBytes, _ := json.Marshal(query)
 	if !strings.Contains(string(queryBytes), `"trace_id.keyword"`) {
@@ -122,12 +122,42 @@ func TestGetEvidenceByRequestIDUsesRequestIDField(t *testing.T) {
 
 	store := New(client, "bkn-trace-evidence-test")
 
-	if _, err := store.GetEvidenceByRequestID(context.Background(), "req_index_001"); err != nil {
+	if _, err := store.GetEvidenceByRequestID(context.Background(), "req_index_001", evidencevo.EvidenceQueryOptions{}); err != nil {
 		t.Fatalf("query evidence: %v", err)
 	}
 	queryBytes, _ := json.Marshal(query)
 	if !strings.Contains(string(queryBytes), `"bkn.request.id.keyword"`) {
 		t.Fatalf("expected request id keyword term, got %s", string(queryBytes))
+	}
+}
+
+func TestGetEvidenceByTraceIDFetchesLimitPlusOneAndTruncates(t *testing.T) {
+	var query map[string]any
+	client := newFakeOpenSearchClient(func(r *http.Request) (*http.Response, error) {
+		if err := json.NewDecoder(r.Body).Decode(&query); err != nil {
+			t.Fatalf("decode query: %v", err)
+		}
+		return jsonResponse(`{
+		  "hits": {
+		    "hits": [
+		      {"_source": {"trace_id": "trace_index_001", "bkn.request.id": "req_index_001", "events": []}},
+		      {"_source": {"trace_id": "trace_index_002", "bkn.request.id": "req_index_001", "events": []}}
+		    ]
+		  }
+		}`), nil
+	})
+
+	store := New(client, "bkn-trace-evidence-test")
+
+	result, err := store.GetEvidenceByTraceID(context.Background(), "trace_index_001", evidencevo.EvidenceQueryOptions{Limit: 1})
+	if err != nil {
+		t.Fatalf("query evidence: %v", err)
+	}
+	if query["size"] != float64(2) {
+		t.Fatalf("expected size limit+1, got %+v", query["size"])
+	}
+	if !result.Truncated || len(result.Traces) != 1 {
+		t.Fatalf("expected truncated single result, got %+v", result)
 	}
 }
 

--- a/bkn-trace/agent-observability/src/drivenadapter/memoryaccess/evidencestore/store.go
+++ b/bkn-trace/agent-observability/src/drivenadapter/memoryaccess/evidencestore/store.go
@@ -28,20 +28,32 @@ func (s *Store) StoreEvidence(_ context.Context, trace evidencevo.NormalizedTrac
 	return nil
 }
 
-func (s *Store) GetEvidenceByTraceID(_ context.Context, traceID string) ([]evidencevo.NormalizedTrace, error) {
+func (s *Store) GetEvidenceByTraceID(_ context.Context, traceID string, options evidencevo.EvidenceQueryOptions) (evidencevo.EvidenceQueryResult, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	return append([]evidencevo.NormalizedTrace(nil), s.traces[traceID]...), nil
+	return limitedResult(s.traces[traceID], options.Limit), nil
 }
 
-func (s *Store) GetEvidenceByRequestID(_ context.Context, requestID string) ([]evidencevo.NormalizedTrace, error) {
+func (s *Store) GetEvidenceByRequestID(_ context.Context, requestID string, options evidencevo.EvidenceQueryOptions) (evidencevo.EvidenceQueryResult, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	return append([]evidencevo.NormalizedTrace(nil), s.requests[requestID]...), nil
+	return limitedResult(s.requests[requestID], options.Limit), nil
 }
 
 func (s *Store) TraceCount(traceID string) int {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	return len(s.traces[traceID])
+}
+
+func limitedResult(traces []evidencevo.NormalizedTrace, limit int) evidencevo.EvidenceQueryResult {
+	if limit <= 0 || len(traces) <= limit {
+		return evidencevo.EvidenceQueryResult{
+			Traces: append([]evidencevo.NormalizedTrace(nil), traces...),
+		}
+	}
+	return evidencevo.EvidenceQueryResult{
+		Traces:    append([]evidencevo.NormalizedTrace(nil), traces[:limit]...),
+		Truncated: true,
+	}
 }

--- a/bkn-trace/agent-observability/src/driveradapter/api/httphandler/evidence_handler.go
+++ b/bkn-trace/agent-observability/src/driveradapter/api/httphandler/evidence_handler.go
@@ -5,9 +5,11 @@ import (
 	"io"
 	"net/http"
 	"os"
+	"strconv"
 	"strings"
 
 	"github.com/openbkn-ai/bkn-foundry/bkn-trace/agent-observability/src/domain/service/evidencesvc"
+	"github.com/openbkn-ai/bkn-foundry/bkn-trace/agent-observability/src/domain/valueobject/evidencevo"
 	"github.com/openbkn-ai/bkn-foundry/bkn-trace/agent-observability/src/driveradapter/api/rdto"
 )
 
@@ -97,6 +99,7 @@ func (h *EvidenceHandler) IngestEvidenceEvents(w http.ResponseWriter, r *http.Re
 // @Tags evidence
 // @Produce json
 // @Param trace_id path string true "Trace ID"
+// @Param limit query int false "Maximum evidence trace batches to read, 1..1000"
 // @Success 200 {object} map[string]interface{}
 // @Failure 400 {object} rdto.ErrorResponse
 // @Failure 404 {object} rdto.ErrorResponse
@@ -121,7 +124,12 @@ func (h *EvidenceHandler) GetEvidenceChainByTraceID(w http.ResponseWriter, r *ht
 		return
 	}
 
-	response, found, err := h.evidenceService.GetEvidenceChainByTraceID(r.Context(), traceID)
+	options, ok := evidenceQueryOptionsFromRequest(w, r)
+	if !ok {
+		return
+	}
+
+	response, found, err := h.evidenceService.GetEvidenceChainByTraceID(r.Context(), traceID, options)
 	if err != nil {
 		writeJSON(w, http.StatusInternalServerError, rdto.ErrorResponse{
 			Code:    "QUERY_FAILED",
@@ -161,6 +169,7 @@ func (h *EvidenceHandler) GetTraceSubresource(w http.ResponseWriter, r *http.Req
 // @Tags evidence
 // @Produce json
 // @Param trace_id path string true "Trace ID"
+// @Param limit query int false "Maximum evidence trace batches to read, 1..1000"
 // @Success 200 {object} map[string]interface{}
 // @Failure 400 {object} rdto.ErrorResponse
 // @Failure 404 {object} rdto.ErrorResponse
@@ -185,7 +194,12 @@ func (h *EvidenceHandler) GetBusinessGraphByTraceID(w http.ResponseWriter, r *ht
 		return
 	}
 
-	response, found, err := h.evidenceService.GetBusinessGraphByTraceID(r.Context(), traceID)
+	options, ok := evidenceQueryOptionsFromRequest(w, r)
+	if !ok {
+		return
+	}
+
+	response, found, err := h.evidenceService.GetBusinessGraphByTraceID(r.Context(), traceID, options)
 	if err != nil {
 		writeJSON(w, http.StatusInternalServerError, rdto.ErrorResponse{
 			Code:    "QUERY_FAILED",
@@ -210,6 +224,7 @@ func (h *EvidenceHandler) GetBusinessGraphByTraceID(w http.ResponseWriter, r *ht
 // @Tags evidence
 // @Produce json
 // @Param request_id query string true "BKN request ID"
+// @Param limit query int false "Maximum evidence trace batches to read, 1..1000"
 // @Success 200 {object} map[string]interface{}
 // @Failure 400 {object} rdto.ErrorResponse
 // @Failure 404 {object} rdto.ErrorResponse
@@ -234,7 +249,12 @@ func (h *EvidenceHandler) GetEvidenceChainByRequestID(w http.ResponseWriter, r *
 		return
 	}
 
-	response, found, err := h.evidenceService.GetEvidenceChainByRequestID(r.Context(), requestID)
+	options, ok := evidenceQueryOptionsFromRequest(w, r)
+	if !ok {
+		return
+	}
+
+	response, found, err := h.evidenceService.GetEvidenceChainByRequestID(r.Context(), requestID, options)
 	if err != nil {
 		writeJSON(w, http.StatusInternalServerError, rdto.ErrorResponse{
 			Code:    "QUERY_FAILED",
@@ -259,6 +279,7 @@ func (h *EvidenceHandler) GetEvidenceChainByRequestID(w http.ResponseWriter, r *
 // @Tags evidence
 // @Produce json
 // @Param request_id query string true "BKN request ID"
+// @Param limit query int false "Maximum evidence trace batches to read, 1..1000"
 // @Success 200 {object} map[string]interface{}
 // @Failure 400 {object} rdto.ErrorResponse
 // @Failure 404 {object} rdto.ErrorResponse
@@ -283,7 +304,12 @@ func (h *EvidenceHandler) GetBusinessGraphByRequestID(w http.ResponseWriter, r *
 		return
 	}
 
-	response, found, err := h.evidenceService.GetBusinessGraphByRequestID(r.Context(), requestID)
+	options, ok := evidenceQueryOptionsFromRequest(w, r)
+	if !ok {
+		return
+	}
+
+	response, found, err := h.evidenceService.GetBusinessGraphByRequestID(r.Context(), requestID, options)
 	if err != nil {
 		writeJSON(w, http.StatusInternalServerError, rdto.ErrorResponse{
 			Code:    "QUERY_FAILED",
@@ -314,6 +340,22 @@ func traceIDFromEvidenceChainPath(path string) string {
 		return ""
 	}
 	return strings.TrimSpace(traceID)
+}
+
+func evidenceQueryOptionsFromRequest(w http.ResponseWriter, r *http.Request) (evidencevo.EvidenceQueryOptions, bool) {
+	rawLimit := strings.TrimSpace(r.URL.Query().Get("limit"))
+	if rawLimit == "" {
+		return evidencevo.EvidenceQueryOptions{}, true
+	}
+	limit, err := strconv.Atoi(rawLimit)
+	if err != nil || limit <= 0 || limit > evidencesvc.MaxEvidenceQueryLimit {
+		writeJSON(w, http.StatusBadRequest, rdto.ErrorResponse{
+			Code:    "INVALID_ARGUMENT",
+			Message: "limit must be an integer between 1 and 1000",
+		})
+		return evidencevo.EvidenceQueryOptions{}, false
+	}
+	return evidencevo.EvidenceQueryOptions{Limit: limit}, true
 }
 
 func traceIDFromBusinessGraphPath(path string) string {

--- a/bkn-trace/agent-observability/src/driveradapter/api/httphandler/evidence_handler_test.go
+++ b/bkn-trace/agent-observability/src/driveradapter/api/httphandler/evidence_handler_test.go
@@ -150,6 +150,21 @@ func TestEvidenceHandlerReturnsEvidenceChainByRequest(t *testing.T) {
 	}
 }
 
+func TestEvidenceHandlerRejectsInvalidEvidenceQueryLimit(t *testing.T) {
+	handler := NewEvidenceHandler(evidencesvc.New(evidencestore.New()))
+	req := httptest.NewRequest(http.MethodGet, "/api/agent-observability/v1/traces/by-request?request_id=req_handler_001&limit=0", nil)
+	rec := httptest.NewRecorder()
+
+	handler.GetEvidenceChainByRequestID(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d: %s", rec.Code, rec.Body.String())
+	}
+	if !strings.Contains(rec.Body.String(), `"limit must be an integer between 1 and 1000"`) {
+		t.Fatalf("unexpected body: %s", rec.Body.String())
+	}
+}
+
 func TestEvidenceHandlerReturnsBusinessGraphByTrace(t *testing.T) {
 	store := evidencestore.New()
 	handler := NewEvidenceHandler(evidencesvc.New(store))

--- a/bkn-trace/agent-observability/src/port/driven/ievidencestore/port.go
+++ b/bkn-trace/agent-observability/src/port/driven/ievidencestore/port.go
@@ -8,6 +8,6 @@ import (
 
 type EvidenceStorePort interface {
 	StoreEvidence(ctx context.Context, trace evidencevo.NormalizedTrace) error
-	GetEvidenceByTraceID(ctx context.Context, traceID string) ([]evidencevo.NormalizedTrace, error)
-	GetEvidenceByRequestID(ctx context.Context, requestID string) ([]evidencevo.NormalizedTrace, error)
+	GetEvidenceByTraceID(ctx context.Context, traceID string, options evidencevo.EvidenceQueryOptions) (evidencevo.EvidenceQueryResult, error)
+	GetEvidenceByRequestID(ctx context.Context, requestID string, options evidencevo.EvidenceQueryOptions) (evidencevo.EvidenceQueryResult, error)
 }


### PR DESCRIPTION
## 背景

#415 已把 evidence store 扩展为 OpenSearch 持久化，但查询侧仍有固定读取上限。如果 request 维度聚合超过上限，Evidence Chain / Business Graph 可能静默少返回数据。

这批 PR 在 #415 之上补上查询 limit 与截断信号，避免把 partial 结果展示为完整证据链。

## 主要改动

- Evidence store port 返回 `EvidenceQueryResult`，包含 `Traces` 与 `Truncated`。
- Evidence Chain / Business Graph 查询支持可选 `limit` 参数，范围 `1..1000`，默认 `1000`。
- OpenSearch store 使用 `size=limit+1` 多取一条判断截断，并裁剪回 `limit`。
- memory store 同步支持 limit/truncated，保证本地和测试行为一致。
- 查询命中上限时返回：
  - `partial=true`
  - `partial_reason` 包含 `evidence_query_truncated`
  - `page.truncated=true`
- README 补充 limit 与截断语义。

## 验证

- `env GOCACHE=/tmp/openbkn-go-cache go test ./...`
- `env GOCACHE=/tmp/openbkn-go-cache go vet ./...`
- `git diff --check`

## 依赖

Stacked on #415. #415 合并后，本 PR 可 retarget 到 `main`。
