### PR TITLE
fix(execution-factory): 修复工具箱编辑报错与遗留 timeout 参数

### DIFF
--- a/adp/execution-factory/operator-integration/server/interfaces/logics_toolbox.go
+++ b/adp/execution-factory/operator-integration/server/interfaces/logics_toolbox.go
@@ -53,7 +53,9 @@ type UpdateToolBoxReq struct {
 	BoxDesc       string       `json:"box_desc" form:"box_desc" validate:"required"`                                  // 工具箱描述
 	BoxSvcURL     string       `json:"box_svc_url" form:"box_svc_url"`                                                // 工具箱服务地址(当metadata_type为openapi时必填)
 	Category      BizCategory  `json:"box_category" form:"box_category" default:"other_category" validate:"required"` // 分类
-	MetadataType  MetadataType `json:"metadata_type" form:"metadata_type" validate:"oneof=openapi function"`          // 元数据类型(可选参数)
+	// 元数据类型(可选参数)。工具箱建成后类型不会变,编辑请求可以不带;
+	// 带了才校验取值,否则「可选」的注释与 oneof 冲突,不传就被判成非法值。
+	MetadataType  MetadataType `json:"metadata_type" form:"metadata_type" validate:"omitempty,oneof=openapi function"`
 	*OpenAPIInput `json:",inline"`
 }
 

--- a/adp/execution-factory/operator-integration/server/logics/metadata/legacy_timeout_test.go
+++ b/adp/execution-factory/operator-integration/server/logics/metadata/legacy_timeout_test.go
@@ -1,0 +1,51 @@
+package metadata
+
+import (
+	"testing"
+
+	. "github.com/smartystreets/goconvey/convey"
+
+	"github.com/openbkn-ai/adp/execution-factory/operator-integration/server/interfaces"
+)
+
+func TestStripLegacyTimeoutParameter(t *testing.T) {
+	timeoutParam := func() *interfaces.Parameter {
+		return &interfaces.Parameter{Name: "timeout", In: "query", Description: "函数执行超时时间，单位毫秒"}
+	}
+
+	Convey("剥掉遗留的 timeout 查询参数", t, func() {
+		spec := &interfaces.APISpec{Parameters: []*interfaces.Parameter{timeoutParam()}}
+		stripLegacyTimeoutParameter(spec)
+		So(len(spec.Parameters), ShouldEqual, 0)
+	})
+
+	Convey("同名但不在 query 的业务参数保留", t, func() {
+		spec := &interfaces.APISpec{Parameters: []*interfaces.Parameter{
+			{Name: "timeout", In: "header"},
+		}}
+		stripLegacyTimeoutParameter(spec)
+		So(len(spec.Parameters), ShouldEqual, 1)
+	})
+
+	Convey("其余参数不受影响", t, func() {
+		spec := &interfaces.APISpec{Parameters: []*interfaces.Parameter{
+			{Name: "page", In: "query"},
+			timeoutParam(),
+			{Name: "token", In: "header"},
+		}}
+		stripLegacyTimeoutParameter(spec)
+		names := []string{}
+		for _, p := range spec.Parameters {
+			names = append(names, p.Name)
+		}
+		So(names, ShouldResemble, []string{"page", "token"})
+	})
+
+	Convey("空值不 panic", t, func() {
+		So(func() { stripLegacyTimeoutParameter(nil) }, ShouldNotPanic)
+		So(func() { stripLegacyTimeoutParameter(&interfaces.APISpec{}) }, ShouldNotPanic)
+		So(func() {
+			stripLegacyTimeoutParameter(&interfaces.APISpec{Parameters: []*interfaces.Parameter{nil}})
+		}, ShouldNotPanic)
+	})
+}

--- a/adp/execution-factory/operator-integration/server/logics/metadata/struct_convert.go
+++ b/adp/execution-factory/operator-integration/server/logics/metadata/struct_convert.go
@@ -7,6 +7,33 @@ import (
 	"github.com/openbkn-ai/adp/execution-factory/operator-integration/server/utils"
 )
 
+const (
+	legacyTimeoutParamName = "timeout"
+	legacyTimeoutParamIn   = "query"
+)
+
+// stripLegacyTimeoutParameter 去掉函数元数据里遗留的 timeout 查询参数。
+//
+// 执行超时曾被当成契约参数写进 api_spec，导致它和业务入参并列出现在
+// 工具 schema 里：Agent 会把它当成可传的参数去猜，按 schema 渲染的界面
+// 也会要求使用者为它选固定值或动态输入。生成侧已经不再写入，但升级前
+// 建的函数工具库里仍有这个字段，这里在读取时剥掉，免去一次数据迁移。
+//
+// 执行侧仍从请求的 query 读取 timeout，存量调用方不受影响。
+func stripLegacyTimeoutParameter(spec *interfaces.APISpec) {
+	if spec == nil || len(spec.Parameters) == 0 {
+		return
+	}
+	kept := make([]*interfaces.Parameter, 0, len(spec.Parameters))
+	for _, param := range spec.Parameters {
+		if param != nil && param.Name == legacyTimeoutParamName && param.In == legacyTimeoutParamIn {
+			continue
+		}
+		kept = append(kept, param)
+	}
+	spec.Parameters = kept
+}
+
 // MetadataDBToStruct 将数据库模型转换为元数据接口
 func MetadataDBToStruct(metadataDB interfaces.IMetadataDB) *interfaces.MetadataInfo {
 	switch v := metadataDB.(type) {
@@ -25,6 +52,7 @@ func MetadataDBToStruct(metadataDB interfaces.IMetadataDB) *interfaces.MetadataI
 			APISpec:     v.APISpec,
 		}
 		metadata := apimetadataDBToAPIMetadata(apiMetadataDB)
+		stripLegacyTimeoutParameter(metadata.APISpec)
 		dependencies := []interfaces.DependencyInfo{}
 		if v.GetDependencies() != "" {
 			dependencies = utils.JSONToObject[[]interfaces.DependencyInfo](v.GetDependencies())

--- a/adp/execution-factory/operator-integration/server/logics/toolbox/toolbox_edit.go
+++ b/adp/execution-factory/operator-integration/server/logics/toolbox/toolbox_edit.go
@@ -37,13 +37,6 @@ func (s *ToolServiceImpl) UpdateToolBox(ctx context.Context, req *interfaces.Upd
 	if err != nil {
 		return
 	}
-	// 检查openapi类型的工具箱是否填写了服务地址
-	if req.MetadataType == interfaces.MetadataTypeAPI {
-		err = s.Validator.ValidatorURL(ctx, req.BoxSvcURL)
-		if err != nil {
-			return
-		}
-	}
 	// 检查分类是否存在
 	if !s.CategoryManager.CheckCategory(req.Category) {
 		err = errors.NewHTTPError(ctx, http.StatusBadRequest, errors.ErrExtToolBoxCategoryTypeInvalid,
@@ -60,6 +53,18 @@ func (s *ToolServiceImpl) UpdateToolBox(ctx context.Context, req *interfaces.Upd
 	if !exist {
 		err = errors.NewHTTPError(ctx, http.StatusBadRequest, errors.ErrExtToolBoxNotFound, "toolbox not found")
 		return
+	}
+	// 元数据类型建成后不再变化,编辑请求可以不带。不带时沿用已存值 ——
+	// 下面按类型分支,留空会让两个分支都不命中,元数据被静默跳过。
+	if req.MetadataType == "" {
+		req.MetadataType = interfaces.MetadataType(toolBox.MetadataType)
+	}
+	// 检查openapi类型的工具箱是否填写了服务地址
+	if req.MetadataType == interfaces.MetadataTypeAPI {
+		err = s.Validator.ValidatorURL(ctx, req.BoxSvcURL)
+		if err != nil {
+			return
+		}
 	}
 	// 检查工具箱名称是否存在
 	isNameChanged := toolBox.Name != req.BoxName

--- a/adp/execution-factory/operator-integration/server/logics/toolbox/toolbox_edit_test.go
+++ b/adp/execution-factory/operator-integration/server/logics/toolbox/toolbox_edit_test.go
@@ -1,0 +1,130 @@
+package toolbox
+
+import (
+	"context"
+	"database/sql"
+	"net/http"
+	"testing"
+
+	"github.com/agiledragon/gomonkey/v2"
+	myErr "github.com/openbkn-ai/adp/execution-factory/operator-integration/server/infra/errors"
+	"github.com/openbkn-ai/adp/execution-factory/operator-integration/server/infra/logger"
+	"github.com/openbkn-ai/adp/execution-factory/operator-integration/server/interfaces"
+	"github.com/openbkn-ai/adp/execution-factory/operator-integration/server/interfaces/model"
+	"github.com/openbkn-ai/adp/execution-factory/operator-integration/server/mocks"
+	. "github.com/smartystreets/goconvey/convey"
+	"go.uber.org/mock/gomock"
+)
+
+// TestUpdateToolBoxMetadataTypeFallback 覆盖编辑请求省略 metadata_type 时回填已存类型的行为。
+func TestUpdateToolBoxMetadataTypeFallback(t *testing.T) {
+	Convey("TestUpdateToolBox:编辑请求省略 metadata_type", t, func() {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		mockDBTx := mocks.NewMockDBTx(ctrl)
+		mockToolBoxDB := mocks.NewMockIToolboxDB(ctrl)
+		mockCategoryManager := mocks.NewMockCategoryManager(ctrl)
+		mockAuthService := mocks.NewMockIAuthorizationService(ctrl)
+		mockValidator := mocks.NewMockValidator(ctrl)
+		toolbox := &ToolServiceImpl{
+			DBTx:            mockDBTx,
+			ToolBoxDB:       mockToolBoxDB,
+			CategoryManager: mockCategoryManager,
+			Logger:          logger.DefaultLogger(),
+			Validator:       mockValidator,
+			AuthService:     mockAuthService,
+		}
+
+		tx := &sql.Tx{}
+		rollbackPatch := gomonkey.ApplyFunc((*sql.Tx).Rollback, func(*sql.Tx) error { return nil })
+		defer rollbackPatch.Reset()
+		commitPatch := gomonkey.ApplyFunc((*sql.Tx).Commit, func(*sql.Tx) error { return nil })
+		defer commitPatch.Reset()
+
+		const boxID = "box_id_1"
+		// 名称不变,避免走重名校验与权限资源变更通知
+		const boxName = "box_name_1"
+		newToolBox := func(metadataType interfaces.MetadataType, serverURL string) *model.ToolboxDB {
+			return &model.ToolboxDB{
+				BoxID:        boxID,
+				Name:         boxName,
+				Description:  "old_desc",
+				ServerURL:    serverURL,
+				Category:     "other_category",
+				MetadataType: string(metadataType),
+			}
+		}
+		newReq := func() *interfaces.UpdateToolBoxReq {
+			return &interfaces.UpdateToolBoxReq{
+				UserID:   "user_1",
+				BoxID:    boxID,
+				BoxName:  boxName,
+				BoxDesc:  "new_desc",
+				Category: interfaces.BizCategory("other_category"),
+			}
+		}
+		expectPreflight := func(stored *model.ToolboxDB) {
+			mockAuthService.EXPECT().GetAccessor(gomock.Any(), "user_1").Return(&interfaces.AuthAccessor{ID: "user_1"}, nil)
+			mockAuthService.EXPECT().CheckModifyPermission(gomock.Any(), gomock.Any(), boxID, interfaces.AuthResourceTypeToolBox).Return(nil)
+			mockCategoryManager.EXPECT().CheckCategory(gomock.Any()).Return(true)
+			mockToolBoxDB.EXPECT().SelectToolBox(gomock.Any(), boxID).Return(true, stored, nil)
+		}
+
+		Convey("已存 openapi 工具箱,请求带合法 box_svc_url 应更新成功", func() {
+			stored := newToolBox(interfaces.MetadataTypeAPI, "http://old.example.com")
+			expectPreflight(stored)
+			// 回填后按 openapi 分支走,服务地址仍需校验
+			mockValidator.EXPECT().ValidatorURL(gomock.Any(), "http://new.example.com").Return(nil)
+			mockDBTx.EXPECT().GetTx(gomock.Any()).Return(tx, nil)
+			mockToolBoxDB.EXPECT().UpdateToolBox(gomock.Any(), tx, stored).DoAndReturn(
+				func(_ context.Context, _ *sql.Tx, box *model.ToolboxDB) error {
+					So(box.ServerURL, ShouldEqual, "http://new.example.com")
+					So(box.Description, ShouldEqual, "new_desc")
+					So(box.UpdateUser, ShouldEqual, "user_1")
+					return nil
+				})
+
+			req := newReq()
+			req.BoxSvcURL = "http://new.example.com"
+			resp, err := toolbox.UpdateToolBox(context.TODO(), req)
+			So(err, ShouldBeNil)
+			So(resp.BoxID, ShouldEqual, boxID)
+			// 回填生效:后续分支拿到的是已存类型
+			So(req.MetadataType, ShouldEqual, interfaces.MetadataTypeAPI)
+		})
+
+		Convey("已存 openapi 工具箱,请求不带 box_svc_url 应报错(契约:openapi 编辑必须带 URL)", func() {
+			expectPreflight(newToolBox(interfaces.MetadataTypeAPI, "http://old.example.com"))
+			mockValidator.EXPECT().ValidatorURL(gomock.Any(), "").Return(
+				myErr.NewHTTPError(context.TODO(), http.StatusBadRequest, myErr.ErrExtOpenAPIInvalidURLFormat, "URL cannot be empty"))
+
+			resp, err := toolbox.UpdateToolBox(context.TODO(), newReq())
+			So(err, ShouldNotBeNil)
+			So(resp, ShouldBeNil)
+			httpErr, ok := err.(*myErr.HTTPError)
+			So(ok, ShouldBeTrue)
+			So(httpErr.HTTPCode, ShouldEqual, http.StatusBadRequest)
+		})
+
+		Convey("已存 function 工具箱,请求不带 metadata_type 不应校验服务地址", func() {
+			stored := newToolBox(interfaces.MetadataTypeFunc, "http://function.example.com")
+			expectPreflight(stored)
+			// 未声明 ValidatorURL 期望:一旦被调用 gomock 直接判失败
+			mockDBTx.EXPECT().GetTx(gomock.Any()).Return(tx, nil)
+			mockToolBoxDB.EXPECT().UpdateToolBox(gomock.Any(), tx, stored).DoAndReturn(
+				func(_ context.Context, _ *sql.Tx, box *model.ToolboxDB) error {
+					// function 分支不碰服务地址,保留原值
+					So(box.ServerURL, ShouldEqual, "http://function.example.com")
+					So(box.Description, ShouldEqual, "new_desc")
+					return nil
+				})
+
+			req := newReq()
+			resp, err := toolbox.UpdateToolBox(context.TODO(), req)
+			So(err, ShouldBeNil)
+			So(resp.BoxID, ShouldEqual, boxID)
+			So(req.MetadataType, ShouldEqual, interfaces.MetadataTypeFunc)
+		})
+	})
+}


### PR DESCRIPTION
接 #413 之后在测试环境发现的两个问题。

## 1. 编辑工具箱返回 400

```
Key: 'UpdateToolBoxReq.MetadataType' Error:Field validation for 'MetadataType' failed on the 'oneof' tag
```

`UpdateToolBoxReq.MetadataType` 的校验标签是 `oneof=openapi function`，没有 `omitempty`，因此请求不带这个字段时空值被判成非法取值——与该字段自己「可选参数」的注释矛盾。工具箱建成后元数据类型不会变，编辑时本就不必重复携带。

改成 `omitempty` 后还有一处要补：更新逻辑按 `req.MetadataType` 分支处理元数据，留空会让两个分支都不命中、元数据被静默跳过。因此在加载到工具箱之后回填已存类型，并把只对 openapi 生效的服务地址校验移到回填之后。

## 2. `timeout` 混在业务参数里

执行超时曾被写进 `api_spec.parameters`，于是它和真正的业务入参并列出现在工具 schema 中：Agent 会把它当成一个可传参数去猜是否要传、传多少；按 schema 渲染的界面（例如知识网络配置对象类行动）也会要求使用者为它选择固定值或动态输入。

生成侧已在 #413 移除，但此前建的函数工具库里仍存着这个字段。这里在读取元数据时剥掉，避免一次数据迁移。执行侧仍从请求 query 读取 timeout，存量调用方不受影响。

## 验证

新增 `stripLegacyTimeoutParameter` 单测：剥离遗留参数、保留同名但位置不同的业务参数、不影响其余参数、空值与 nil 元素不 panic。

`logics/...` 与 `driveradapters/...` 全部通过。

🤖 Generated with [Claude Code](https://claude.com/claude-code)