### PR TITLE
feat(bkn-trace): add evidence index governance chart

### DIFF
--- a/bkn-trace/agent-observability/README.md
+++ b/bkn-trace/agent-observability/README.md
@@ -58,7 +58,21 @@ BKN_TRACE_EVIDENCE_STORE=opensearch
 OPENSEARCH_EVIDENCE_INDEX=bkn-trace-evidence-v1
 ```
 
-当前 PR 不自动创建 index，不要求服务账号具备 OpenSearch index-management 权限；部署方需要提前创建 `OPENSEARCH_EVIDENCE_INDEX`。后续部署治理 PR 会补 index mapping、retention/ILM、权限与迁移脚本。
+默认部署不自动创建 index，不要求服务账号具备 OpenSearch index-management 权限；部署方需要提前创建 `OPENSEARCH_EVIDENCE_INDEX`。
+
+如果部署环境允许 Helm pre-install/pre-upgrade hook 创建 OpenSearch index，可以显式启用最小 index setup：
+
+```bash
+helm upgrade --install agent-observability charts/agent-observability \
+  --set evidence.store=opensearch \
+  --set evidence.index=bkn-trace-evidence-v1 \
+  --set evidence.indexManagement.enabled=true \
+  --set evidence.indexManagement.createJob.enabled=true \
+  --set opensearch.endpoint=http://opensearch-cluster-master:9200 \
+  -n observability --create-namespace
+```
+
+启用后 Chart 会渲染 evidence index mapping ConfigMap，并在 index 不存在时由 hook Job 创建 index。最小 mapping 将 `trace_id`、`bkn.request.id`、`document_id` 等查询字段设为 `keyword`，将 `ingested_at` 设为 `date`，并把 `events` 保留在 `_source` 中但不展开索引，避免 event payload 动态字段膨胀。retention/ILM、细粒度权限、迁移脚本仍属于后续部署治理能力。
 
 Evidence Chain 与 Business Graph 查询支持可选 `limit` 参数，限制本次读取的 evidence trace 批次数：
 

--- a/bkn-trace/agent-observability/charts/agent-observability/templates/evidence-index-configmap.yaml
+++ b/bkn-trace/agent-observability/charts/agent-observability/templates/evidence-index-configmap.yaml
@@ -1,0 +1,44 @@
+{{- if .Values.evidence.indexManagement.enabled }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "agent-observability.fullname" . }}-evidence-index-template
+  labels:
+    {{- include "agent-observability.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": pre-install,pre-upgrade
+    "helm.sh/hook-weight": "-5"
+    "helm.sh/hook-delete-policy": before-hook-creation
+data:
+  evidence-index.json: |
+    {
+      "settings": {
+        "index": {
+          "max_result_window": {{ .Values.evidence.indexManagement.maxResultWindow }},
+          "refresh_interval": {{ .Values.evidence.indexManagement.refreshInterval | quote }}
+        }
+      },
+      "mappings": {
+        "dynamic": false,
+        "properties": {
+          "document_id": { "type": "keyword" },
+          "trace_id": { "type": "keyword" },
+          "bkn.request.id": { "type": "keyword" },
+          "bkn.trace.schema.version": { "type": "keyword" },
+          "claim_ids": { "type": "keyword" },
+          "accepted_event_count": { "type": "integer" },
+          "claim_count": { "type": "integer" },
+          "evidence_ref_count": { "type": "integer" },
+          "business_ref_count": { "type": "integer" },
+          "ingested_at": {
+            "type": "date",
+            "format": "strict_date_optional_time_nanos||strict_date_optional_time||epoch_millis"
+          },
+          "events": {
+            "type": "object",
+            "enabled": false
+          }
+        }
+      }
+    }
+{{- end }}

--- a/bkn-trace/agent-observability/charts/agent-observability/templates/evidence-index-job.yaml
+++ b/bkn-trace/agent-observability/charts/agent-observability/templates/evidence-index-job.yaml
@@ -1,0 +1,71 @@
+{{- if and .Values.evidence.indexManagement.enabled .Values.evidence.indexManagement.createJob.enabled }}
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ include "agent-observability.fullname" . }}-evidence-index-setup
+  labels:
+    {{- include "agent-observability.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": pre-install,pre-upgrade
+    "helm.sh/hook-weight": "0"
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+spec:
+  backoffLimit: {{ .Values.evidence.indexManagement.createJob.backoffLimit }}
+  template:
+    metadata:
+      labels:
+        {{- include "agent-observability.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: evidence-index-setup
+    spec:
+      restartPolicy: Never
+      containers:
+        - name: evidence-index-setup
+          image: {{ printf "%s/%s:%s" .Values.evidence.indexManagement.createJob.image.registry .Values.evidence.indexManagement.createJob.image.repository .Values.evidence.indexManagement.createJob.image.tag | quote }}
+          imagePullPolicy: {{ .Values.evidence.indexManagement.createJob.image.pullPolicy }}
+          env:
+            - name: OPENSEARCH_ENDPOINT
+              value: {{ .Values.opensearch.endpoint | quote }}
+            - name: OPENSEARCH_EVIDENCE_INDEX
+              value: {{ .Values.evidence.index | quote }}
+            - name: OPENSEARCH_AUTH_ENABLED
+              value: {{ ternary "true" "false" .Values.opensearch.auth.enabled | quote }}
+            {{- if .Values.opensearch.auth.enabled }}
+            - name: OPENSEARCH_AUTH_USERNAME
+              value: {{ .Values.opensearch.auth.username | quote }}
+            - name: OPENSEARCH_AUTH_PASSWORD
+              value: {{ .Values.opensearch.auth.password | quote }}
+            {{- end }}
+          command:
+            - /bin/sh
+            - -ec
+            - |
+              curl_opensearch() {
+                if [ "${OPENSEARCH_AUTH_ENABLED}" = "true" ]; then
+                  curl -u "${OPENSEARCH_AUTH_USERNAME}:${OPENSEARCH_AUTH_PASSWORD}" "$@"
+                else
+                  curl "$@"
+                fi
+              }
+              status="$(curl_opensearch -sS -o /tmp/evidence-index-check.out -w "%{http_code}" "${OPENSEARCH_ENDPOINT}/${OPENSEARCH_EVIDENCE_INDEX}")"
+              if [ "${status}" = "200" ]; then
+                echo "evidence index already exists: ${OPENSEARCH_EVIDENCE_INDEX}"
+                exit 0
+              fi
+              if [ "${status}" != "404" ]; then
+                echo "failed to check evidence index, status=${status}" >&2
+                cat /tmp/evidence-index-check.out >&2
+                exit 1
+              fi
+              curl_opensearch -sS -f \
+                -H "Content-Type: application/json" \
+                -X PUT "${OPENSEARCH_ENDPOINT}/${OPENSEARCH_EVIDENCE_INDEX}" \
+                --data-binary @/etc/agent-observability/evidence-index/evidence-index.json
+          volumeMounts:
+            - name: evidence-index-template
+              mountPath: /etc/agent-observability/evidence-index
+              readOnly: true
+      volumes:
+        - name: evidence-index-template
+          configMap:
+            name: {{ include "agent-observability.fullname" . }}-evidence-index-template
+{{- end }}

--- a/bkn-trace/agent-observability/charts/agent-observability/values.yaml
+++ b/bkn-trace/agent-observability/charts/agent-observability/values.yaml
@@ -35,6 +35,18 @@ ingress:
 evidence:
   store: memory
   index: bkn-trace-evidence-v1
+  indexManagement:
+    enabled: false
+    maxResultWindow: 10000
+    refreshInterval: 5s
+    createJob:
+      enabled: false
+      image:
+        registry: docker.io
+        repository: curlimages/curl
+        tag: "8.10.1"
+        pullPolicy: IfNotPresent
+      backoffLimit: 1
   ingestAuth:
     existingSecret: ""
     secretKey: token

--- a/bkn-trace/agent-observability/scripts/test_evidence_index_governance.sh
+++ b/bkn-trace/agent-observability/scripts/test_evidence_index_governance.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+chart_dir="${1:-charts/agent-observability}"
+default_rendered="$(helm template agent-observability "${chart_dir}")"
+if grep -Fq "agent-observability-evidence-index-template" <<<"${default_rendered}"; then
+  echo "evidence index template must not render by default" >&2
+  exit 1
+fi
+if grep -Fq "agent-observability-evidence-index-setup" <<<"${default_rendered}"; then
+  echo "evidence index setup job must not render by default" >&2
+  exit 1
+fi
+
+rendered="$(helm template agent-observability "${chart_dir}" \
+  --set evidence.store=opensearch \
+  --set evidence.index=bkn-trace-evidence-test \
+  --set evidence.indexManagement.enabled=true \
+  --set evidence.indexManagement.createJob.enabled=true)"
+
+assert_contains() {
+  local needle="$1"
+  if ! grep -Fq "$needle" <<<"${rendered}"; then
+    echo "expected rendered chart to contain: ${needle}" >&2
+    exit 1
+  fi
+}
+
+assert_contains "kind: ConfigMap"
+assert_contains "agent-observability-evidence-index-template"
+assert_contains '"helm.sh/hook": pre-install,pre-upgrade'
+assert_contains '"helm.sh/hook-weight": "-5"'
+assert_contains '"helm.sh/hook-delete-policy": before-hook-creation'
+assert_contains '"ingested_at":'
+assert_contains '"type": "date"'
+assert_contains '"max_result_window": 10000'
+assert_contains "kind: Job"
+assert_contains "agent-observability-evidence-index-setup"
+assert_contains '"helm.sh/hook-weight": "0"'
+assert_contains "bkn-trace-evidence-test"


### PR DESCRIPTION
## 背景

#415/#416 已合入 OpenSearch evidence store 与查询截断信号。当前生产启用 `evidence.store=opensearch` 时，部署方仍需要自己准备 evidence index mapping，否则 `ingested_at` 排序、keyword 查询字段和 event payload 动态字段膨胀都容易变成隐式运维风险。

这批 PR 增加默认关闭的 Helm index governance 能力：提供最小 mapping ConfigMap，以及可选的 pre-install/pre-upgrade hook Job，在明确授权的部署环境中创建缺失的 evidence index。

## 主要改动

- 新增 `evidence.indexManagement` Helm values，默认 `enabled=false`。
- 启用 `evidence.indexManagement.enabled=true` 时渲染 evidence index mapping ConfigMap。
- 启用 `evidence.indexManagement.createJob.enabled=true` 时额外渲染 hook Job：
  - 先检查 index 是否存在；
  - 已存在则退出成功；
  - 仅 404 时 PUT 最小 mapping；
  - 默认不要求 agent-observability 主服务账号具备 index-management 权限。
- 最小 mapping：
  - `trace_id`、`bkn.request.id`、`document_id`、schema/version/id 类字段为 `keyword`；
  - `ingested_at` 为 `date`；
  - `events` 保留在 `_source`，但不展开索引，避免动态字段膨胀。
- README 补充启用方式和边界说明。
- 新增 chart governance 测试脚本，覆盖默认不渲染和启用后渲染。

## 验证

- `bash scripts/test_evidence_index_governance.sh`
- `helm lint charts/agent-observability`
- `helm template agent-observability charts/agent-observability`
- `helm template agent-observability charts/agent-observability --set evidence.store=opensearch --set evidence.index=bkn-trace-evidence-test --set evidence.indexManagement.enabled=true --set evidence.indexManagement.createJob.enabled=true --set opensearch.auth.enabled=true --set opensearch.auth.username=demo --set opensearch.auth.password=demo-secret`
- `env GOCACHE=/tmp/openbkn-go-cache go test ./...`
- `git diff --check`

## 边界

- 默认不创建 index，不改变既有部署权限模型。
- 本 PR 不实现 retention/ILM、迁移脚本和细粒度 OpenSearch 权限治理；这些仍作为后续部署治理能力推进。
