### PR TITLE
perf(bkn-safe): 登录时 /me/permissions 响应过大——加「只要类型级权限」开关 (#353)

### DIFF
--- a/bkn-safe/server/internal/authz/authz.go
+++ b/bkn-safe/server/internal/authz/authz.go
@@ -227,10 +227,14 @@ func groupGrantsByObject(rows [][]string) []RoleGrant {
 // PermQuery narrows an EffectivePermissions read. The zero value returns the
 // full effective set; ResourceType scopes to one type and ResourceIDs further
 // narrows the instance exception rows (ResourceIDs is only meaningful with a
-// ResourceType set).
+// ResourceType set). TypeWideOnly drops instance exception rows entirely —
+// for callers that only render type-level UI (menus/navigation) and would
+// discard per-instance rows anyway; with per-object grants those rows dominate
+// the payload (#353).
 type PermQuery struct {
 	ResourceType string   // "" = all types
 	ResourceIDs  []string // empty = all instances of the type
+	TypeWideOnly bool     // true = only id:"*" rows (and the wildcard row)
 }
 
 // EffectivePermissions returns the accessor's authorization as a COLLAPSED,
@@ -304,6 +308,9 @@ func (en *Enforcer) EffectivePermissions(accessorID string, q PermQuery) (hasWil
 		if rid == "*" {
 			// Type-wide row: always kept within scope; the frontend unions on it.
 			out = append(out, RoleGrant{Object: g.Object, Operations: g.Operations})
+			continue
+		}
+		if q.TypeWideOnly {
 			continue
 		}
 		// Instance row: keep only ops beyond the type-wide set; drop if fully

--- a/bkn-safe/server/internal/authz/effectiveperms_test.go
+++ b/bkn-safe/server/internal/authz/effectiveperms_test.go
@@ -232,3 +232,38 @@ func TestEffectivePermissionsScope(t *testing.T) {
 		t.Fatalf("resource:r1 = %v", idx["resource:r1"])
 	}
 }
+
+// TypeWideOnly drops every instance exception row — including instance-only
+// grants with no type-wide row — and composes with ResourceType.
+func TestEffectivePermissionsTypeWideOnly(t *testing.T) {
+	e := newTestEnforcer(t)
+	const user = "u-tw"
+	mustNoErr(t, e.GrantRolePermission("role-tw", "large_model", "*", "view"))
+	mustNoErr(t, e.AssignRole(user, "role-tw"))
+	mustNoErr(t, e.GrantObjectPermission(user, "large_model", "m1", "modify")) // surplus over type-wide
+	mustNoErr(t, e.GrantObjectPermission(user, "agent", "a1", "use"))          // instance-only, no type-wide row
+
+	has, grants, err := e.EffectivePermissions(user, PermQuery{TypeWideOnly: true})
+	mustNoErr(t, err)
+	if has {
+		t.Fatal("hasWildcard: want false")
+	}
+	idx := byObject(grants)
+	if !eqOps(idx["large_model:*"], "view") {
+		t.Errorf("large_model:* = %v, want [view]", idx["large_model:*"])
+	}
+	if _, ok := idx["large_model:m1"]; ok {
+		t.Errorf("surplus instance row must be dropped: %+v", grants)
+	}
+	if _, ok := idx["agent:a1"]; ok {
+		t.Errorf("instance-only grant must be dropped: %+v", grants)
+	}
+
+	// Composes with ResourceType: single type-wide row of the queried type.
+	_, grants, err = e.EffectivePermissions(user, PermQuery{ResourceType: "large_model", TypeWideOnly: true})
+	mustNoErr(t, err)
+	idx = byObject(grants)
+	if len(idx) != 1 || !eqOps(idx["large_model:*"], "view") {
+		t.Errorf("scoped type-wide = %+v, want only large_model:* [view]", grants)
+	}
+}

--- a/bkn-safe/server/internal/httpapi/me.go
+++ b/bkn-safe/server/internal/httpapi/me.go
@@ -102,6 +102,11 @@ func registerMeReads(g *gin.RouterGroup, e *authz.Enforcer, db *gorm.DB, dir *di
 	// Optional scope filters: ?resource_type=<T> narrows to one type;
 	// &resource_id=<id1,id2,...> (comma-separated) narrows the instance rows,
 	// keeping the type-wide id:"*" row. resource_id requires resource_type.
+	// ?scope=type drops instance exception rows entirely (only id:"*" rows and
+	// the wildcard row) — for the login/boot call that renders menus from
+	// type-level grants and discards instance rows anyway; with per-object
+	// grants those rows dominate the payload (#353). Conflicts with
+	// resource_id (asking for instance rows while dropping them) -> 400.
 	g.GET("/permissions", func(c *gin.Context) {
 		accessorID := c.GetString(ctxAccessorID)
 		isAdmin, err := e.CanAdmin(accessorID)
@@ -122,9 +127,19 @@ func registerMeReads(g *gin.RouterGroup, e *authz.Enforcer, db *gorm.DB, dir *di
 			c.JSON(http.StatusBadRequest, gin.H{"error": "resource_id requires resource_type"})
 			return
 		}
+		scope := c.Query("scope")
+		if scope != "" && scope != "type" {
+			c.JSON(http.StatusBadRequest, gin.H{"error": `unknown scope: only "type" is supported`})
+			return
+		}
+		if scope == "type" && len(resourceIDs) > 0 {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "resource_id conflicts with scope=type"})
+			return
+		}
 		_, grants, err := e.EffectivePermissions(accessorID, authz.PermQuery{
 			ResourceType: resourceType,
 			ResourceIDs:  resourceIDs,
+			TypeWideOnly: scope == "type",
 		})
 		if err != nil {
 			serverError(c, err)

--- a/bkn-safe/server/internal/httpapi/me.go
+++ b/bkn-safe/server/internal/httpapi/me.go
@@ -123,17 +123,21 @@ func registerMeReads(g *gin.RouterGroup, e *authz.Enforcer, db *gorm.DB, dir *di
 				}
 			}
 		}
-		if len(resourceIDs) > 0 && resourceType == "" {
-			c.JSON(http.StatusBadRequest, gin.H{"error": "resource_id requires resource_type"})
-			return
-		}
 		scope := c.Query("scope")
 		if scope != "" && scope != "type" {
 			c.JSON(http.StatusBadRequest, gin.H{"error": `unknown scope: only "type" is supported`})
 			return
 		}
+		// scope 校验先于 resource_type 缺失校验:?scope=type&resource_id=m1 的真正
+		// 毛病是「要实例行又丢实例行」,补个 resource_type 也救不回来。若让
+		// "resource_id requires resource_type" 先命中,调用方会照文案加上
+		// resource_type 再撞一次 400,把真矛盾藏了一层。
 		if scope == "type" && len(resourceIDs) > 0 {
 			c.JSON(http.StatusBadRequest, gin.H{"error": "resource_id conflicts with scope=type"})
+			return
+		}
+		if len(resourceIDs) > 0 && resourceType == "" {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "resource_id requires resource_type"})
 			return
 		}
 		_, grants, err := e.EffectivePermissions(accessorID, authz.PermQuery{

--- a/bkn-safe/server/internal/httpapi/me_test.go
+++ b/bkn-safe/server/internal/httpapi/me_test.go
@@ -324,4 +324,30 @@ func TestMePermissionsScope(t *testing.T) {
 	if w := tokReq(t, r, http.MethodGet, path+"?resource_id=m1", nil, "u1"); w.Code != http.StatusBadRequest {
 		t.Errorf("resource_id without resource_type: want 400, got %d", w.Code)
 	}
+
+	// scope=type: only type-wide rows; every instance row (surplus or
+	// instance-only) is dropped.
+	got = decode(tokReq(t, r, http.MethodGet, path+"?scope=type", nil, "u1"))
+	if got["large_model/*"] == nil {
+		t.Errorf("type-wide large_model/* row missing under scope=type: %v", got)
+	}
+	for _, k := range []string{"large_model/m1", "large_model/m2", "agent/a1"} {
+		if _, ok := got[k]; ok {
+			t.Errorf("%s must be dropped under scope=type: %v", k, got)
+		}
+	}
+
+	// scope=type composes with resource_type.
+	got = decode(tokReq(t, r, http.MethodGet, path+"?scope=type&resource_type=large_model", nil, "u1"))
+	if len(got) != 1 || got["large_model/*"] == nil {
+		t.Errorf("scope=type&resource_type: want only large_model/*, got %v", got)
+	}
+
+	// Unknown scope value -> 400; scope=type with resource_id -> 400.
+	if w := tokReq(t, r, http.MethodGet, path+"?scope=instance", nil, "u1"); w.Code != http.StatusBadRequest {
+		t.Errorf("unknown scope: want 400, got %d", w.Code)
+	}
+	if w := tokReq(t, r, http.MethodGet, path+"?scope=type&resource_type=large_model&resource_id=m1", nil, "u1"); w.Code != http.StatusBadRequest {
+		t.Errorf("scope=type with resource_id: want 400, got %d", w.Code)
+	}
 }

--- a/bkn-safe/server/internal/httpapi/me_test.go
+++ b/bkn-safe/server/internal/httpapi/me_test.go
@@ -8,6 +8,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"bkn-safe/internal/model"
@@ -349,5 +350,16 @@ func TestMePermissionsScope(t *testing.T) {
 	}
 	if w := tokReq(t, r, http.MethodGet, path+"?scope=type&resource_type=large_model&resource_id=m1", nil, "u1"); w.Code != http.StatusBadRequest {
 		t.Errorf("scope=type with resource_id: want 400, got %d", w.Code)
+	}
+
+	// scope=type + resource_id but NO resource_type: both rules would reject, and
+	// the scope conflict must win — telling the caller to add resource_type would
+	// send it into a second 400 on a request that can never be satisfied.
+	w := tokReq(t, r, http.MethodGet, path+"?scope=type&resource_id=m1", nil, "u1")
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("scope=type with bare resource_id: want 400, got %d", w.Code)
+	}
+	if !strings.Contains(w.Body.String(), "conflicts with scope=type") {
+		t.Errorf("want the scope-conflict error, got %s", w.Body.String())
 	}
 }


### PR DESCRIPTION
## 背景

#356 折叠后,实例行只在权限超出类型级时出现且只带增量——这部分是**真实例外**,折叠压不掉。授权页面按对象授权一多,启动那次全量 `/me/permissions` 又涨回 1000+ 行。

启动调用只为渲染导航/菜单,只消费类型级行(前端 `flattenSafeGrants` 折叠时就丢弃 `resource.id`,已确认无首屏实例级消费方;唯一要实例判权的模型列表走独立 scoped 查询)。缺的只是接口层面表达「只要类型级」。

## 改动

- `PermQuery.TypeWideOnly`:实例例外行直接跳过,保留类型级行与通配行;与 `ResourceType` 可组合。
- `GET /me/permissions?scope=type`:映射到 `TypeWideOnly`。非法 scope 值 400;`scope=type` + `resource_id` 自相矛盾(要实例行又丢实例行),400。
- 测试:`TestEffectivePermissionsTypeWideOnly`(含实例仅授权无类型级行的情形)+ `TestMePermissionsScope` 补 scope=type 四例。

## 兼容

纯增量参数,零破坏。前端 bkn-studio 启动调用已带 `scope=type`(老后端忽略未知参数),本 PR 合并部署后启动响应自动收敛到类型数量级。

## 验证

- `go test ./internal/authz/ ./internal/httpapi/` 通过
- `go vet` 干净;gofmt 仅 pre-existing 的 ldap_test.go 未动

🤖 Generated with [Claude Code](https://claude.com/claude-code)