### PR TITLE
feat(bkn-trace): expose evidence node query

### DIFF
--- a/bkn-trace/agent-observability/README.md
+++ b/bkn-trace/agent-observability/README.md
@@ -10,6 +10,7 @@
 - Request 维度 Evidence Chain 查询接口：`GET /api/agent-observability/v1/traces/by-request?request_id=...`
 - Business Graph 查询接口：`GET /api/agent-observability/v1/traces/{trace_id}/business-graph`
 - Request 维度 Business Graph 查询接口：`GET /api/agent-observability/v1/traces/by-request/business-graph?request_id=...`
+- Evidence Node 查询接口：`GET /api/agent-observability/v1/evidence-nodes/{node_id}?trace_id=...`
 - OpenSearch 查询客户端
 - 阶段二 Evidence ingestion 校验、归一化和可替换存储接口，支持内存 store 与 OpenSearch evidence index store
 - Swagger 文档生成
@@ -31,7 +32,7 @@ make test
 GOCACHE=/tmp/openbkn-go-build-cache GOMODCACHE=/tmp/openbkn-go-mod-cache go test ./...
 ```
 
-阶段二 evidence ingestion 接口接受 `bkn.trace.schema.version=2.0.0` 的事件批次，包含 `trace` 与 `events`。当前版本先完成 contract 校验、敏感 payload 拒绝、归一化计数、最小 Evidence Chain 查询和 Business Graph 查询；默认使用内存 repository，生产或共享测试环境可切换到 OpenSearch evidence index store。
+阶段二 evidence ingestion 接口接受 `bkn.trace.schema.version=2.0.0` 的事件批次，包含 `trace` 与 `events`。当前版本先完成 contract 校验、敏感 payload 拒绝、归一化计数、最小 Evidence Chain 查询、Business Graph 查询和 Evidence Node 查询；默认使用内存 repository，生产或共享测试环境可切换到 OpenSearch evidence index store。
 
 ### Evidence Store
 
@@ -178,7 +179,24 @@ Business Graph 查询返回从 `business.refs.resolved` 派生的业务语义图
 }
 ```
 
-Business Graph 当前只消费已进入 BKN Trace 的 `business_refs`，并复用 `visibility` 做响应过滤。真实 BKN / Vega / Metric / Action resolver、按账号/租户的授权裁决、节点详情展开和持久化索引属于后续阶段。
+Business Graph 当前只消费已进入 BKN Trace 的 `business_refs`，并复用 `visibility` 做响应过滤。真实 BKN / Vega / Metric / Action resolver、按账号/租户的授权裁决和 resolver-backed 节点详情补全属于后续阶段。
+
+Evidence Node 查询用于打开单个可见节点详情：
+
+```http
+GET /api/agent-observability/v1/evidence-nodes/claim%3Aclaim_handler?trace_id=9c0d...
+GET /api/agent-observability/v1/evidence-nodes/business_ref%3Aobject%3Acustomer?request_id=req_handler_002
+```
+
+首版 node id 格式：
+
+```text
+claim:{claim_id}
+evidence_ref:{ref_id}
+business_ref:{ref_id}
+```
+
+查询必须提供且只能提供一个 scope：`trace_id` 或 `request_id`。当前阶段只返回 `visibility=visible` 的节点；`hidden`、`redacted`、`omitted`、`unresolved` 节点不会通过详情接口展开。真实 BKN / Vega / Metric / Action resolver、按账号/租户的授权裁决和隐藏节点可审计解释属于后续阶段。
 
 生成 Swagger 文档：
 

--- a/bkn-trace/agent-observability/src/boot/bootstrap.go
+++ b/bkn-trace/agent-observability/src/boot/bootstrap.go
@@ -60,6 +60,7 @@ func newApp(httpServerConfig conf.HTTPServerConfig, traceHandler *httphandler.Tr
 	mux.HandleFunc(APIBasePath+"/traces/by-request/business-graph", evidenceHandler.GetBusinessGraphByRequestID)
 	mux.HandleFunc(APIBasePath+"/traces/by-request", evidenceHandler.GetEvidenceChainByRequestID)
 	mux.HandleFunc(APIBasePath+"/traces/", evidenceHandler.GetTraceSubresource)
+	mux.HandleFunc(APIBasePath+"/evidence-nodes/", evidenceHandler.GetEvidenceNode)
 	mux.HandleFunc(APIBasePath+"/evidence/events", evidenceHandler.IngestEvidenceEvents)
 	mux.Handle(APIBasePath+"/swagger/", httpSwagger.Handler(
 		httpSwagger.URL(APIBasePath+"/swagger/doc.json"),

--- a/bkn-trace/agent-observability/src/domain/service/evidencesvc/service.go
+++ b/bkn-trace/agent-observability/src/domain/service/evidencesvc/service.go
@@ -167,6 +167,22 @@ func (s *Service) GetBusinessGraphByRequestID(ctx context.Context, requestID str
 	return buildBusinessGraph(result.Traces, result.Truncated), true, nil
 }
 
+func (s *Service) GetEvidenceNodeByTraceID(ctx context.Context, traceID string, nodeID string, options evidencevo.EvidenceQueryOptions) (evidencevo.EvidenceNodeResponse, bool, error) {
+	result, err := s.store.GetEvidenceByTraceID(ctx, strings.TrimSpace(traceID), normalizeQueryOptions(options))
+	if err != nil {
+		return evidencevo.EvidenceNodeResponse{}, false, err
+	}
+	return findEvidenceNode(result.Traces, strings.TrimSpace(nodeID))
+}
+
+func (s *Service) GetEvidenceNodeByRequestID(ctx context.Context, requestID string, nodeID string, options evidencevo.EvidenceQueryOptions) (evidencevo.EvidenceNodeResponse, bool, error) {
+	result, err := s.store.GetEvidenceByRequestID(ctx, strings.TrimSpace(requestID), normalizeQueryOptions(options))
+	if err != nil {
+		return evidencevo.EvidenceNodeResponse{}, false, err
+	}
+	return findEvidenceNode(result.Traces, strings.TrimSpace(nodeID))
+}
+
 func buildEvidenceChain(traces []evidencevo.NormalizedTrace, truncated bool) evidencevo.EvidenceChainResponse {
 	response := evidencevo.EvidenceChainResponse{
 		TraceID:   traces[0].TraceID,
@@ -227,6 +243,75 @@ func buildEvidenceChain(traces []evidencevo.NormalizedTrace, truncated bool) evi
 	response.Page.EdgeCount = len(response.Data.EvidenceRefs) + len(response.Data.BusinessRefs)
 	response.Page.Truncated = truncated
 	return response
+}
+
+func findEvidenceNode(traces []evidencevo.NormalizedTrace, nodeID string) (evidencevo.EvidenceNodeResponse, bool, error) {
+	if nodeID == "" {
+		return evidencevo.EvidenceNodeResponse{}, false, nil
+	}
+	for _, trace := range traces {
+		for _, event := range trace.Events {
+			switch event.EventType {
+			case "claim.created":
+				if response, ok := claimNodeFromEvent(trace, event, nodeID); ok {
+					return response, true, nil
+				}
+			case "evidence.refs.created":
+				if response, ok := refNodeFromEvent(trace, event, nodeID, "evidence_ref", "evidence_refs"); ok {
+					return response, true, nil
+				}
+			case "business.refs.resolved":
+				if response, ok := refNodeFromEvent(trace, event, nodeID, "business_ref", "business_refs"); ok {
+					return response, true, nil
+				}
+			}
+		}
+	}
+	return evidencevo.EvidenceNodeResponse{}, false, nil
+}
+
+func claimNodeFromEvent(trace evidencevo.NormalizedTrace, event evidencevo.EvidenceEvent, nodeID string) (evidencevo.EvidenceNodeResponse, bool) {
+	claimID, _ := stringField(event.Payload, "claim_id")
+	if claimID == "" || nodeID != "claim:"+claimID || !visible(event.Payload) {
+		return evidencevo.EvidenceNodeResponse{}, false
+	}
+	versionStatus, _ := stringField(event.Payload, "version_status")
+	return evidencevo.EvidenceNodeResponse{
+		TraceID:       trace.TraceID,
+		RequestID:     trace.RequestID,
+		NodeID:        nodeID,
+		NodeType:      "claim",
+		ClaimID:       claimID,
+		Visibility:    visibilityValue(event.Payload),
+		VersionStatus: versionStatus,
+		Data:          cloneMap(event.Payload),
+	}, true
+}
+
+func refNodeFromEvent(trace evidencevo.NormalizedTrace, event evidencevo.EvidenceEvent, nodeID string, nodeType string, payloadKey string) (evidencevo.EvidenceNodeResponse, bool) {
+	claimID, _ := stringField(event.Payload, "claim_id")
+	for _, item := range arrayField(event.Payload, payloadKey) {
+		ref, ok := item.(map[string]any)
+		if !ok {
+			continue
+		}
+		refID, _ := stringField(ref, "ref_id")
+		if refID == "" || nodeID != nodeType+":"+refID || !visible(ref) {
+			continue
+		}
+		versionStatus, _ := stringField(ref, "version_status")
+		return evidencevo.EvidenceNodeResponse{
+			TraceID:       trace.TraceID,
+			RequestID:     trace.RequestID,
+			NodeID:        nodeID,
+			NodeType:      nodeType,
+			ClaimID:       claimID,
+			Visibility:    visibilityValue(ref),
+			VersionStatus: versionStatus,
+			Data:          cloneMap(ref),
+		}, true
+	}
+	return evidencevo.EvidenceNodeResponse{}, false
 }
 
 func buildBusinessGraph(traces []evidencevo.NormalizedTrace, truncated bool) evidencevo.BusinessGraphResponse {

--- a/bkn-trace/agent-observability/src/domain/service/evidencesvc/service_test.go
+++ b/bkn-trace/agent-observability/src/domain/service/evidencesvc/service_test.go
@@ -465,6 +465,38 @@ func TestGetEvidenceChainByTraceIDNotFound(t *testing.T) {
 	}
 }
 
+func TestGetEvidenceNodeByTraceIDReturnsVisibleClaim(t *testing.T) {
+	store := &fakeStore{traces: []evidencevo.NormalizedTrace{queryTrace("trace_node_001", "req_node_001")}}
+	service := New(store)
+
+	response, found, err := service.GetEvidenceNodeByTraceID(context.Background(), "trace_node_001", "claim:claim_visible", evidencevo.EvidenceQueryOptions{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !found {
+		t.Fatal("expected evidence node to be found")
+	}
+	if response.NodeID != "claim:claim_visible" || response.NodeType != "claim" || response.TraceID != "trace_node_001" {
+		t.Fatalf("unexpected node response: %+v", response)
+	}
+	if response.Data["claim_id"] != "claim_visible" || response.Visibility != "visible" {
+		t.Fatalf("unexpected node data: %+v", response)
+	}
+}
+
+func TestGetEvidenceNodeByRequestIDDoesNotReturnHiddenRef(t *testing.T) {
+	store := &fakeStore{traces: []evidencevo.NormalizedTrace{queryTrace("trace_node_002", "req_node_002")}}
+	service := New(store)
+
+	_, found, err := service.GetEvidenceNodeByRequestID(context.Background(), "req_node_002", "evidence_ref:row:hidden", evidencevo.EvidenceQueryOptions{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if found {
+		t.Fatal("hidden evidence ref must not be returned as node detail")
+	}
+}
+
 func hasValidationCode(validationErrors evidencevo.ValidationErrors, code string) bool {
 	for _, validationError := range validationErrors {
 		if validationError.Code == code {

--- a/bkn-trace/agent-observability/src/domain/valueobject/evidencevo/evidence.go
+++ b/bkn-trace/agent-observability/src/domain/valueobject/evidencevo/evidence.go
@@ -109,6 +109,17 @@ type BusinessGraphResponse struct {
 	Data              BusinessGraphData `json:"data"`
 }
 
+type EvidenceNodeResponse struct {
+	TraceID       string         `json:"trace_id"`
+	RequestID     string         `json:"bkn.request.id"`
+	NodeID        string         `json:"node_id"`
+	NodeType      string         `json:"node_type"`
+	ClaimID       string         `json:"claim_id,omitempty"`
+	Visibility    string         `json:"visibility"`
+	VersionStatus string         `json:"version_status,omitempty"`
+	Data          map[string]any `json:"data"`
+}
+
 type BusinessGraphData struct {
 	Nodes []BusinessGraphNode `json:"nodes"`
 	Edges []BusinessGraphEdge `json:"edges"`

--- a/bkn-trace/agent-observability/src/driveradapter/api/httphandler/evidence_handler.go
+++ b/bkn-trace/agent-observability/src/driveradapter/api/httphandler/evidence_handler.go
@@ -4,6 +4,7 @@ import (
 	"crypto/subtle"
 	"io"
 	"net/http"
+	"net/url"
 	"os"
 	"strconv"
 	"strings"
@@ -328,6 +329,82 @@ func (h *EvidenceHandler) GetBusinessGraphByRequestID(w http.ResponseWriter, r *
 	writeJSON(w, http.StatusOK, response)
 }
 
+// GetEvidenceNode godoc
+// @Summary Get evidence node details
+// @Description Returns one visible claim, evidence ref, or business ref node scoped by trace_id or request_id.
+// @Tags evidence
+// @Produce json
+// @Param node_id path string true "Evidence node ID, for example claim:claim_001"
+// @Param trace_id query string false "Trace ID scope"
+// @Param request_id query string false "BKN request ID scope"
+// @Param limit query int false "Maximum evidence trace batches to read, 1..1000"
+// @Success 200 {object} map[string]interface{}
+// @Failure 400 {object} rdto.ErrorResponse
+// @Failure 404 {object} rdto.ErrorResponse
+// @Failure 405 {object} rdto.ErrorResponse
+// @Failure 500 {object} rdto.ErrorResponse
+// @Router /api/agent-observability/v1/evidence-nodes/{node_id} [get]
+func (h *EvidenceHandler) GetEvidenceNode(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		writeJSON(w, http.StatusMethodNotAllowed, rdto.ErrorResponse{
+			Code:    "METHOD_NOT_ALLOWED",
+			Message: "only GET is supported",
+		})
+		return
+	}
+
+	nodeID := evidenceNodeIDFromPath(r.URL.Path)
+	if nodeID == "" {
+		writeJSON(w, http.StatusBadRequest, rdto.ErrorResponse{
+			Code:    "INVALID_ARGUMENT",
+			Message: "node_id is required",
+		})
+		return
+	}
+
+	options, ok := evidenceQueryOptionsFromRequest(w, r)
+	if !ok {
+		return
+	}
+
+	traceID := strings.TrimSpace(r.URL.Query().Get("trace_id"))
+	requestID := strings.TrimSpace(r.URL.Query().Get("request_id"))
+	if (traceID == "" && requestID == "") || (traceID != "" && requestID != "") {
+		writeJSON(w, http.StatusBadRequest, rdto.ErrorResponse{
+			Code:    "INVALID_ARGUMENT",
+			Message: "exactly one of trace_id or request_id is required",
+		})
+		return
+	}
+
+	var (
+		response evidencevo.EvidenceNodeResponse
+		found    bool
+		err      error
+	)
+	if traceID != "" {
+		response, found, err = h.evidenceService.GetEvidenceNodeByTraceID(r.Context(), traceID, nodeID, options)
+	} else {
+		response, found, err = h.evidenceService.GetEvidenceNodeByRequestID(r.Context(), requestID, nodeID, options)
+	}
+	if err != nil {
+		writeJSON(w, http.StatusInternalServerError, rdto.ErrorResponse{
+			Code:    "QUERY_FAILED",
+			Message: "failed to query evidence node",
+		})
+		return
+	}
+	if !found {
+		writeJSON(w, http.StatusNotFound, rdto.ErrorResponse{
+			Code:    "NOT_FOUND",
+			Message: "evidence node not found",
+		})
+		return
+	}
+
+	writeJSON(w, http.StatusOK, response)
+}
+
 func traceIDFromEvidenceChainPath(path string) string {
 	const prefix = "/api/agent-observability/v1/traces/"
 	const suffix = "/evidence-chain"
@@ -340,6 +417,18 @@ func traceIDFromEvidenceChainPath(path string) string {
 		return ""
 	}
 	return strings.TrimSpace(traceID)
+}
+
+func evidenceNodeIDFromPath(path string) string {
+	const prefix = "/api/agent-observability/v1/evidence-nodes/"
+	if !strings.HasPrefix(path, prefix) {
+		return ""
+	}
+	nodeID, err := url.PathUnescape(strings.TrimPrefix(path, prefix))
+	if err != nil {
+		return ""
+	}
+	return strings.TrimSpace(nodeID)
 }
 
 func evidenceQueryOptionsFromRequest(w http.ResponseWriter, r *http.Request) (evidencevo.EvidenceQueryOptions, bool) {

--- a/bkn-trace/agent-observability/src/driveradapter/api/httphandler/evidence_handler_test.go
+++ b/bkn-trace/agent-observability/src/driveradapter/api/httphandler/evidence_handler_test.go
@@ -209,6 +209,40 @@ func TestEvidenceHandlerReturnsBusinessGraphByRequest(t *testing.T) {
 	}
 }
 
+func TestEvidenceHandlerReturnsEvidenceNodeByTrace(t *testing.T) {
+	store := evidencestore.New()
+	handler := NewEvidenceHandler(evidencesvc.New(store))
+	ingestReq := httptest.NewRequest(http.MethodPost, "/api/agent-observability/v1/evidence/events", strings.NewReader(validHandlerBatch()))
+	ingestRec := httptest.NewRecorder()
+	handler.IngestEvidenceEvents(ingestRec, ingestReq)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/agent-observability/v1/evidence-nodes/claim%3Aclaim_handler?trace_id=9c0d0000000000000000000000000001", nil)
+	rec := httptest.NewRecorder()
+	handler.GetEvidenceNode(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+	if !strings.Contains(rec.Body.String(), `"node_id":"claim:claim_handler"`) || !strings.Contains(rec.Body.String(), `"node_type":"claim"`) {
+		t.Fatalf("unexpected body: %s", rec.Body.String())
+	}
+}
+
+func TestEvidenceHandlerRejectsEvidenceNodeWithoutScope(t *testing.T) {
+	handler := NewEvidenceHandler(evidencesvc.New(evidencestore.New()))
+	req := httptest.NewRequest(http.MethodGet, "/api/agent-observability/v1/evidence-nodes/claim%3Aclaim_handler", nil)
+	rec := httptest.NewRecorder()
+
+	handler.GetEvidenceNode(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d: %s", rec.Code, rec.Body.String())
+	}
+	if !strings.Contains(rec.Body.String(), "trace_id or request_id is required") {
+		t.Fatalf("unexpected body: %s", rec.Body.String())
+	}
+}
+
 func TestEvidenceHandlerReturnsNotFoundForUnknownTraceSubresource(t *testing.T) {
 	handler := NewEvidenceHandler(evidencesvc.New(evidencestore.New()))
 	req := httptest.NewRequest(http.MethodGet, "/api/agent-observability/v1/traces/9c0d0000000000000000000000000001/unknown", nil)


### PR DESCRIPTION
## 背景

BKN Trace 已具备 Evidence Chain 与 Business Graph 查询，但 Studio/SDK 打开单个证据节点时仍需要自己从整条 chain 中查找节点。阶段二 PR-2.6 需要稳定的 Evidence Node API，避免前端直接理解 raw event 结构或 OpenSearch 查询细节。

## 主要改动

- 新增 Evidence Node response model。
- 新增 service 查询能力：
  - `GetEvidenceNodeByTraceID`
  - `GetEvidenceNodeByRequestID`
- 新增 HTTP API：
  - `GET /api/agent-observability/v1/evidence-nodes/{node_id}?trace_id=...`
  - `GET /api/agent-observability/v1/evidence-nodes/{node_id}?request_id=...`
- 首版 node id：
  - `claim:{claim_id}`
  - `evidence_ref:{ref_id}`
  - `business_ref:{ref_id}`
- 查询必须且只能提供一个 scope：`trace_id` 或 `request_id`。
- 当前阶段只返回 `visibility=visible` 的节点；hidden/redacted/omitted/unresolved 节点不通过详情接口展开。
- README 补充 API 使用方式和边界。

## 验证

- TDD：先写 service/handler 失败测试，再实现。
- `env GOCACHE=/tmp/openbkn-go-cache go test ./...`
- `env GOCACHE=/tmp/openbkn-go-cache go vet ./...`
- `helm lint charts/agent-observability`
- `git diff --check`

## 边界

- 不做全索引扫，必须通过 `trace_id` 或 `request_id` 限定查询范围。
- 不实现 resolver-backed 详情补全；BKN/Vega/Metric/Action resolver 与账号/租户授权裁决后续继续推进。
