### PR TITLE
fix(bkn-safe): scope=type 汇总实例操作,别把对象级授权的入口一起丢掉 (#353)

### DIFF
--- a/bkn-safe/server/internal/authz/authz.go
+++ b/bkn-safe/server/internal/authz/authz.go
@@ -180,9 +180,16 @@ func (en *Enforcer) RoleMembers(roleID string) ([]string, error) {
 
 // RoleGrant is one resource-object grant held by a role: the object pattern
 // ("type:id", id may be "*") and the operations allowed on it.
+//
+// InstanceOperations is only ever set by EffectivePermissions under
+// PermQuery.TypeWideOnly: it reports ops the accessor holds on AT LEAST ONE
+// instance of the type without holding them type-wide. It answers "is there any
+// object of this type I may do X to" (menu/entry-point visibility) — never
+// "may I do X to a given object", which still needs a per-instance check.
 type RoleGrant struct {
-	Object     string
-	Operations []string
+	Object             string
+	Operations         []string
+	InstanceOperations []string
 }
 
 // RolePermissions lists the policy grants whose subject is the role, grouped by
@@ -294,6 +301,10 @@ func (en *Enforcer) EffectivePermissions(accessorID string, q PermQuery) (hasWil
 		}
 	}
 
+	if q.TypeWideOnly {
+		return false, typeWideGrants(grouped, typeWide, q.ResourceType), nil
+	}
+
 	idFilter := map[string]bool{}
 	for _, id := range q.ResourceIDs {
 		idFilter[id] = true
@@ -308,9 +319,6 @@ func (en *Enforcer) EffectivePermissions(accessorID string, q PermQuery) (hasWil
 		if rid == "*" {
 			// Type-wide row: always kept within scope; the frontend unions on it.
 			out = append(out, RoleGrant{Object: g.Object, Operations: g.Operations})
-			continue
-		}
-		if q.TypeWideOnly {
 			continue
 		}
 		// Instance row: keep only ops beyond the type-wide set; drop if fully
@@ -339,6 +347,84 @@ func (en *Enforcer) EffectivePermissions(accessorID string, q PermQuery) (hasWil
 		out = append(out, RoleGrant{Object: g.Object, Operations: extra})
 	}
 	return false, out, nil
+}
+
+// typeWideGrants builds the scope=type answer: exactly one row per resource
+// type, carrying the type-wide ops plus (in InstanceOperations) the ops held
+// only on individual instances.
+//
+// Instance ops are SUMMARISED, not dropped. Dropping them would silently strip
+// entry points from anyone whose access is purely object-level — the shape the
+// object-authorization page produces: a menu gated on "may view a toolbox"
+// would vanish even though the accessor was explicitly granted one, and a
+// role-less accessor would end up with an empty permission set. Summarising
+// keeps the payload proportional to #types while preserving the "do I have any
+// access of this kind" answer the caller needs.
+//
+// Types whose only grants are instance-level still get a row (empty Operations,
+// non-empty InstanceOperations) — that is precisely the object-only accessor.
+// Row order follows first appearance in grouped, matching the unscoped path.
+func typeWideGrants(grouped []RoleGrant, typeWide map[string]map[string]bool, resourceType string) []RoleGrant {
+	instanceOps := map[string]map[string]bool{}
+	order := make([]string, 0, len(grouped))
+	seen := map[string]bool{}
+
+	for _, g := range grouped {
+		rtype, rid := splitObjectKey(g.Object)
+		if resourceType != "" && rtype != resourceType {
+			continue
+		}
+		if !seen[rtype] {
+			seen[rtype] = true
+			order = append(order, rtype)
+		}
+		if rid == "*" {
+			continue
+		}
+		// Only ops the accessor lacks type-wide are worth reporting separately;
+		// a type-wide ActAll ("*") covers everything, so nothing is surplus.
+		tw := typeWide[rtype]
+		if tw[ActAll] {
+			continue
+		}
+		for _, op := range g.Operations {
+			if tw[op] {
+				continue
+			}
+			if instanceOps[rtype] == nil {
+				instanceOps[rtype] = map[string]bool{}
+			}
+			instanceOps[rtype][op] = true
+		}
+	}
+
+	out := make([]RoleGrant, 0, len(order))
+	for _, rtype := range order {
+		row := RoleGrant{Object: rtype + ":*"}
+		// Preserve op order from the original type-wide row rather than ranging
+		// over the set (map order is random; callers compare as sets but stable
+		// output keeps responses diffable).
+		for _, g := range grouped {
+			gt, gid := splitObjectKey(g.Object)
+			if gt == rtype && gid == "*" {
+				row.Operations = append(row.Operations, g.Operations...)
+			}
+		}
+		for _, g := range grouped {
+			gt, gid := splitObjectKey(g.Object)
+			if gt != rtype || gid == "*" {
+				continue
+			}
+			for _, op := range g.Operations {
+				if instanceOps[rtype][op] {
+					delete(instanceOps[rtype], op)
+					row.InstanceOperations = append(row.InstanceOperations, op)
+				}
+			}
+		}
+		out = append(out, row)
+	}
+	return out
 }
 
 // hasOp reports whether ops contains want.

--- a/bkn-safe/server/internal/authz/effectiveperms_test.go
+++ b/bkn-safe/server/internal/authz/effectiveperms_test.go
@@ -233,14 +233,16 @@ func TestEffectivePermissionsScope(t *testing.T) {
 	}
 }
 
-// TypeWideOnly drops every instance exception row — including instance-only
-// grants with no type-wide row — and composes with ResourceType.
+// TypeWideOnly collapses to one row per type: no instance rows, but the ops
+// held only on instances are summarised in InstanceOperations rather than lost.
 func TestEffectivePermissionsTypeWideOnly(t *testing.T) {
 	e := newTestEnforcer(t)
 	const user = "u-tw"
 	mustNoErr(t, e.GrantRolePermission("role-tw", "large_model", "*", "view"))
 	mustNoErr(t, e.AssignRole(user, "role-tw"))
 	mustNoErr(t, e.GrantObjectPermission(user, "large_model", "m1", "modify")) // surplus over type-wide
+	mustNoErr(t, e.GrantObjectPermission(user, "large_model", "m2", "modify")) // same op, must not duplicate
+	mustNoErr(t, e.GrantObjectPermission(user, "large_model", "m3", "view"))   // already type-wide, not surplus
 	mustNoErr(t, e.GrantObjectPermission(user, "agent", "a1", "use"))          // instance-only, no type-wide row
 
 	has, grants, err := e.EffectivePermissions(user, PermQuery{TypeWideOnly: true})
@@ -249,21 +251,53 @@ func TestEffectivePermissionsTypeWideOnly(t *testing.T) {
 		t.Fatal("hasWildcard: want false")
 	}
 	idx := byObject(grants)
-	if !eqOps(idx["large_model:*"], "view") {
-		t.Errorf("large_model:* = %v, want [view]", idx["large_model:*"])
+	instIdx := map[string][]string{}
+	for _, g := range grants {
+		ops := append([]string(nil), g.InstanceOperations...)
+		sort.Strings(ops)
+		instIdx[g.Object] = ops
+	}
+	if len(grants) != 2 {
+		t.Fatalf("want exactly one row per type, got %d: %+v", len(grants), grants)
 	}
 	if _, ok := idx["large_model:m1"]; ok {
-		t.Errorf("surplus instance row must be dropped: %+v", grants)
+		t.Errorf("no instance row may survive: %+v", grants)
 	}
-	if _, ok := idx["agent:a1"]; ok {
-		t.Errorf("instance-only grant must be dropped: %+v", grants)
+	if !eqOps(idx["large_model:*"], "view") {
+		t.Errorf("large_model:* ops = %v, want [view]", idx["large_model:*"])
+	}
+	// modify appears once despite two instances holding it; view is type-wide so
+	// it is not repeated as an instance op.
+	if !eqOps(instIdx["large_model:*"], "modify") {
+		t.Errorf("large_model:* instance ops = %v, want [modify]", instIdx["large_model:*"])
+	}
+	// The object-only accessor: no type-wide grant, yet the type must still be
+	// reported or its entry points vanish.
+	if len(idx["agent:*"]) != 0 {
+		t.Errorf("agent:* ops = %v, want none", idx["agent:*"])
+	}
+	if !eqOps(instIdx["agent:*"], "use") {
+		t.Errorf("agent:* instance ops = %v, want [use]", instIdx["agent:*"])
 	}
 
-	// Composes with ResourceType: single type-wide row of the queried type.
+	// Composes with ResourceType: only the queried type's row.
 	_, grants, err = e.EffectivePermissions(user, PermQuery{ResourceType: "large_model", TypeWideOnly: true})
 	mustNoErr(t, err)
-	idx = byObject(grants)
-	if len(idx) != 1 || !eqOps(idx["large_model:*"], "view") {
-		t.Errorf("scoped type-wide = %+v, want only large_model:* [view]", grants)
+	if len(grants) != 1 || grants[0].Object != "large_model:*" {
+		t.Errorf("scoped type-wide = %+v, want only large_model:*", grants)
+	}
+}
+
+// A wildcard holder short-circuits before the type-wide collapse, so scope=type
+// still reports the single all-powerful row (never an empty permission set).
+func TestEffectivePermissionsTypeWideOnlyWildcard(t *testing.T) {
+	e := newTestEnforcer(t)
+	const super = "u-super-tw"
+	mustNoErr(t, e.Grant(super, "*", "*"))
+
+	has, grants, err := e.EffectivePermissions(super, PermQuery{TypeWideOnly: true})
+	mustNoErr(t, err)
+	if !has || len(grants) != 1 || grants[0].Object != "*:*" || !eqOps(grants[0].Operations, "*") {
+		t.Fatalf("wildcard under scope=type = %+v, want single *:* [*]", grants)
 	}
 }

--- a/bkn-safe/server/internal/httpapi/authz.go
+++ b/bkn-safe/server/internal/httpapi/authz.go
@@ -686,10 +686,16 @@ func grantsJSON(grants []authz.RoleGrant) []gin.H {
 	out := make([]gin.H, 0, len(grants))
 	for _, gr := range grants {
 		rtype, rid := splitObject(gr.Object)
-		out = append(out, gin.H{
+		row := gin.H{
 			"resource":   gin.H{"type": rtype, "id": rid},
 			"operations": gr.Operations,
-		})
+		}
+		// Only the scope=type answer carries this; omitted elsewhere so the
+		// existing row shape is untouched.
+		if len(gr.InstanceOperations) > 0 {
+			row["instance_operations"] = gr.InstanceOperations
+		}
+		out = append(out, row)
 	}
 	return out
 }

--- a/bkn-safe/server/internal/httpapi/me_test.go
+++ b/bkn-safe/server/internal/httpapi/me_test.go
@@ -326,16 +326,44 @@ func TestMePermissionsScope(t *testing.T) {
 		t.Errorf("resource_id without resource_type: want 400, got %d", w.Code)
 	}
 
-	// scope=type: only type-wide rows; every instance row (surplus or
-	// instance-only) is dropped.
-	got = decode(tokReq(t, r, http.MethodGet, path+"?scope=type", nil, "u1"))
-	if got["large_model/*"] == nil {
-		t.Errorf("type-wide large_model/* row missing under scope=type: %v", got)
+	// scope=type: one row per type, no instance rows — but the ops held only on
+	// instances survive in instance_operations.
+	w := tokReq(t, r, http.MethodGet, path+"?scope=type", nil, "u1")
+	if w.Code != http.StatusOK {
+		t.Fatalf("scope=type: want 200, got %d (%s)", w.Code, w.Body.String())
+	}
+	var scoped struct {
+		Permissions []struct {
+			Resource struct {
+				Type string `json:"type"`
+				ID   string `json:"id"`
+			} `json:"resource"`
+			Operations         []string `json:"operations"`
+			InstanceOperations []string `json:"instance_operations"`
+		} `json:"permissions"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &scoped); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	rows := map[string][]string{}
+	instRows := map[string][]string{}
+	for _, p := range scoped.Permissions {
+		key := p.Resource.Type + "/" + p.Resource.ID
+		rows[key] = p.Operations
+		instRows[key] = p.InstanceOperations
 	}
 	for _, k := range []string{"large_model/m1", "large_model/m2", "agent/a1"} {
-		if _, ok := got[k]; ok {
-			t.Errorf("%s must be dropped under scope=type: %v", k, got)
+		if _, ok := rows[k]; ok {
+			t.Errorf("%s: no instance row may survive scope=type: %v", k, rows)
 		}
+	}
+	if len(instRows["large_model/*"]) != 1 || instRows["large_model/*"][0] != "modify" {
+		t.Errorf("large_model instance_operations = %v, want [modify]", instRows["large_model/*"])
+	}
+	// agent access is object-only: the row exists solely to keep that access
+	// visible, so instance_operations carries it while operations stays empty.
+	if len(instRows["agent/*"]) != 1 || instRows["agent/*"][0] != "use" {
+		t.Errorf("agent instance_operations = %v, want [use]", instRows["agent/*"])
 	}
 
 	// scope=type composes with resource_type.
@@ -355,7 +383,7 @@ func TestMePermissionsScope(t *testing.T) {
 	// scope=type + resource_id but NO resource_type: both rules would reject, and
 	// the scope conflict must win — telling the caller to add resource_type would
 	// send it into a second 400 on a request that can never be satisfied.
-	w := tokReq(t, r, http.MethodGet, path+"?scope=type&resource_id=m1", nil, "u1")
+	w = tokReq(t, r, http.MethodGet, path+"?scope=type&resource_id=m1", nil, "u1")
 	if w.Code != http.StatusBadRequest {
 		t.Fatalf("scope=type with bare resource_id: want 400, got %d", w.Code)
 	}


### PR DESCRIPTION
## 问题

#419 让 `scope=type` 直接**丢弃**实例例外行。部署后发现这会丢功能:

前端启动权限集(`flattenSafeGrants`)**不区分 `resource.id`** —— 它驱动的是菜单/路由/按钮门禁,问的是「这类东西我有没有一个能看/能改的」。实例行被丢掉后:

- 有类型级 `view`(normal_user 角色自带)的用户:菜单还在,但**对象授权页授给他的那个对象,编辑按钮不见了** —— 后端允许,UI 不给。执行工厂用的是 `PermissionGate permissions="execution-factory:toolbox:edit"`,取的正是这个全局集。
- 无角色、只有对象授权的用户:权限集直接空 —— **连菜单入口都没有**。建用户不自动绑角色,这条路径真实存在。

对象授权页发出的恰好就是这类授权,等于该功能在 UI 上失效。

## 改动

汇总,不丢弃。`scope=type` 仍每类型只回一行,新增 `instance_operations`:该类型下「至少一个实例持有、但未类型级持有」的操作。

```json
{"resource":{"type":"tool_box","id":"*"},"operations":["view"],"instance_operations":["modify"]}
{"resource":{"type":"agent","id":"*"},"operations":[],"instance_operations":["use"]}
```

- 载荷仍是**类型数量级**(#419 的收益不变:实测 500 对象授权 501 行 37KB → 1 行 101B)。
- 入口可见性与折叠前一致,无回归。
- 只有实例级授权的类型也出行,否则无角色纯对象授权账号权限集为空。
- 字段仅在 `scope=type` 下出现,其余路径行数据结构不变。

## 语义边界

`instance_operations` 回答「**有没有一个**」,不回答「**这一个行不行**」。按对象精确显隐仍需 `?resource_type=&resource_id=` 逐对象判权(model-resources `getResourceOperations` 已是此模式)。这一点写进了 `RoleGrant` 与前端 `flattenSafeGrants` 的注释。

## 前端配套

bkn-studio `flattenSafeGrants` 并入 `instance_operations`(老后端无此字段 → 空数组 → 行为不变),两侧可独立上线。

## 验证

- `go test ./internal/authz/ ./internal/httpapi/` 通过;`go vet`、`gofmt` 干净
- 新增用例:同一 op 被多实例持有只出现一次、类型级已有的 op 不重复计入实例、纯对象授权类型出空 `operations` 行、通配持有者短路不受影响
- arm64 镜像已部署 VM(10.211.55.4)实测:`scope=type` 200、`scope=bogus` 400、`scope=type&resource_id` 400

🤖 Generated with [Claude Code](https://claude.com/claude-code)