### PR TITLE
fix(vega): enrich task reference names for paginated lists

### DIFF
--- a/adp/vega/vega-backend/server/interfaces/build_task.go
+++ b/adp/vega/vega-backend/server/interfaces/build_task.go
@@ -75,6 +75,9 @@ type BuildTask struct {
 	UpdateTime      int64                 `json:"update_time"`
 	IndexConfig     *BuildTaskIndexConfig `json:"index_config,omitempty"` // 创建 task 时从 resource 派生的索引配置快照
 	CatalogID       string                `json:"catalog_id"`
+	// 以下关联字段仅用于响应展示，不落库；由 service 按当前任务集合批量补齐。
+	ResourceName string `json:"resource_name,omitempty"`
+	CatalogName  string `json:"catalog_name,omitempty"`
 
 	// IndexHealth 为响应时计算的派生状态，**不落库**：让消费方无需自己推断
 	// "completed 其实是失败"。service 层在返回前填充。

--- a/adp/vega/vega-backend/server/interfaces/catalog_service.go
+++ b/adp/vega/vega-backend/server/interfaces/catalog_service.go
@@ -43,4 +43,6 @@ type CatalogService interface {
 
 	// InternalGetByID retrieves a Catalog by ID for internal workers.
 	InternalGetByID(ctx context.Context, id string, withSensitiveFields bool) (*Catalog, error)
+	// InternalGetByIDs retrieves Catalogs for internal callers without permission filtering.
+	InternalGetByIDs(ctx context.Context, ids []string) ([]*Catalog, error)
 }

--- a/adp/vega/vega-backend/server/interfaces/discover_schedule.go
+++ b/adp/vega/vega-backend/server/interfaces/discover_schedule.go
@@ -8,16 +8,17 @@ package interfaces
 
 // DiscoverSchedule represents a scheduled discover task configuration.
 type DiscoverSchedule struct {
-	ID        string `json:"id"`
-	Name      string `json:"name"`
-	CatalogID string `json:"catalog_id"`
-	CronExpr  string `json:"cron_expr"`
-	StartTime int64  `json:"start_time"` // Unix timestamp in milliseconds
-	EndTime   int64  `json:"end_time"`   // Unix timestamp in milliseconds, 0 means no end time
-	Enabled   bool   `json:"enabled"`
-	Strategy  string `json:"strategy"` // Discover strategy: full_sync/create_only/cleanup_only
-	LastRun   int64  `json:"last_run"` // Unix timestamp in milliseconds of last execution
-	NextRun   int64  `json:"next_run"` // Unix timestamp in milliseconds of next scheduled execution
+	ID          string `json:"id"`
+	Name        string `json:"name"`
+	CatalogID   string `json:"catalog_id"`
+	CatalogName string `json:"catalog_name,omitempty"`
+	CronExpr    string `json:"cron_expr"`
+	StartTime   int64  `json:"start_time"` // Unix timestamp in milliseconds
+	EndTime     int64  `json:"end_time"`   // Unix timestamp in milliseconds, 0 means no end time
+	Enabled     bool   `json:"enabled"`
+	Strategy    string `json:"strategy"` // Discover strategy: full_sync/create_only/cleanup_only
+	LastRun     int64  `json:"last_run"` // Unix timestamp in milliseconds of last execution
+	NextRun     int64  `json:"next_run"` // Unix timestamp in milliseconds of next scheduled execution
 
 	Creator    AccountInfo `json:"creator"`
 	CreateTime int64       `json:"create_time"`

--- a/adp/vega/vega-backend/server/interfaces/discover_task.go
+++ b/adp/vega/vega-backend/server/interfaces/discover_task.go
@@ -38,6 +38,7 @@ var (
 type DiscoverTask struct {
 	ID          string `json:"id"`
 	CatalogID   string `json:"catalog_id"`
+	CatalogName string `json:"catalog_name,omitempty"`
 	ScheduleID  string `json:"schedule_id"`
 	Strategy    string `json:"strategy"`     // Discover strategy: full_sync/create_only/cleanup_only
 	TriggerType string `json:"trigger_type"` // manual/scheduled

--- a/adp/vega/vega-backend/server/interfaces/mock/mock_catalog_service.go
+++ b/adp/vega/vega-backend/server/interfaces/mock/mock_catalog_service.go
@@ -145,6 +145,21 @@ func (mr *MockCatalogServiceMockRecorder) InternalGetByID(ctx, id, withSensitive
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "InternalGetByID", reflect.TypeOf((*MockCatalogService)(nil).InternalGetByID), ctx, id, withSensitiveFields)
 }
 
+// InternalGetByIDs mocks base method.
+func (m *MockCatalogService) InternalGetByIDs(ctx context.Context, ids []string) ([]*interfaces.Catalog, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "InternalGetByIDs", ctx, ids)
+	ret0, _ := ret[0].([]*interfaces.Catalog)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// InternalGetByIDs indicates an expected call of InternalGetByIDs.
+func (mr *MockCatalogServiceMockRecorder) InternalGetByIDs(ctx, ids any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "InternalGetByIDs", reflect.TypeOf((*MockCatalogService)(nil).InternalGetByIDs), ctx, ids)
+}
+
 // List mocks base method.
 func (m *MockCatalogService) List(ctx context.Context, params interfaces.CatalogsQueryParams) ([]*interfaces.Catalog, int64, error) {
 	m.ctrl.T.Helper()

--- a/adp/vega/vega-backend/server/interfaces/mock/mock_resource_service.go
+++ b/adp/vega/vega-backend/server/interfaces/mock/mock_resource_service.go
@@ -191,6 +191,21 @@ func (mr *MockResourceServiceMockRecorder) InternalCreate(ctx, tx, req any) *gom
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "InternalCreate", reflect.TypeOf((*MockResourceService)(nil).InternalCreate), ctx, tx, req)
 }
 
+// InternalGetByCatalogID mocks base method.
+func (m *MockResourceService) InternalGetByCatalogID(ctx context.Context, catalogID string) ([]*interfaces.Resource, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "InternalGetByCatalogID", ctx, catalogID)
+	ret0, _ := ret[0].([]*interfaces.Resource)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// InternalGetByCatalogID indicates an expected call of InternalGetByCatalogID.
+func (mr *MockResourceServiceMockRecorder) InternalGetByCatalogID(ctx, catalogID any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "InternalGetByCatalogID", reflect.TypeOf((*MockResourceService)(nil).InternalGetByCatalogID), ctx, catalogID)
+}
+
 // InternalGetByID mocks base method.
 func (m *MockResourceService) InternalGetByID(ctx context.Context, id string) (*interfaces.Resource, error) {
 	m.ctrl.T.Helper()
@@ -204,6 +219,21 @@ func (m *MockResourceService) InternalGetByID(ctx context.Context, id string) (*
 func (mr *MockResourceServiceMockRecorder) InternalGetByID(ctx, id any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "InternalGetByID", reflect.TypeOf((*MockResourceService)(nil).InternalGetByID), ctx, id)
+}
+
+// InternalGetByIDs mocks base method.
+func (m *MockResourceService) InternalGetByIDs(ctx context.Context, ids []string) ([]*interfaces.Resource, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "InternalGetByIDs", ctx, ids)
+	ret0, _ := ret[0].([]*interfaces.Resource)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// InternalGetByIDs indicates an expected call of InternalGetByIDs.
+func (mr *MockResourceServiceMockRecorder) InternalGetByIDs(ctx, ids any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "InternalGetByIDs", reflect.TypeOf((*MockResourceService)(nil).InternalGetByIDs), ctx, ids)
 }
 
 // InternalUpdate mocks base method.

--- a/adp/vega/vega-backend/server/interfaces/resource_service.go
+++ b/adp/vega/vega-backend/server/interfaces/resource_service.go
@@ -51,6 +51,10 @@ type ResourceService interface {
 
 	// InternalGetByID retrieves a Resource by ID for internal workers.
 	InternalGetByID(ctx context.Context, id string) (*Resource, error)
+	// InternalGetByIDs retrieves Resources for internal callers without permission filtering.
+	InternalGetByIDs(ctx context.Context, ids []string) ([]*Resource, error)
+	// InternalGetByCatalogID retrieves all Resources under a Catalog for internal callers.
+	InternalGetByCatalogID(ctx context.Context, catalogID string) ([]*Resource, error)
 	// InternalUpdate updates a Resource for internal workers.
 	InternalUpdate(ctx context.Context, tx *sql.Tx, resource *Resource) error
 	// InternalCreate creates a Resource for internal workers within a transaction.

--- a/adp/vega/vega-backend/server/interfaces/semantic_understanding_task.go
+++ b/adp/vega/vega-backend/server/interfaces/semantic_understanding_task.go
@@ -46,7 +46,9 @@ type SemanticUnderstandingTask struct {
 	ID                   string      `json:"id"`
 	Scope                string      `json:"scope"`
 	CatalogID            string      `json:"catalog_id"`
+	CatalogName          string      `json:"catalog_name,omitempty"`
 	ResourceID           string      `json:"resource_id,omitempty"`
+	ResourceName         string      `json:"resource_name,omitempty"`
 	AgentTaskID          string      `json:"agent_task_id,omitempty"`
 	AgentID              string      `json:"agent_id"`
 	Input                string      `json:"input"`

--- a/adp/vega/vega-backend/server/logics/build_task/build_task_service.go
+++ b/adp/vega/vega-backend/server/logics/build_task/build_task_service.go
@@ -413,6 +413,11 @@ func (bts *buildTaskService) GetByID(ctx context.Context, id string) (*interface
 		span.SetStatus(codes.Error, "Build task not found")
 		return nil, rest.NewHTTPError(ctx, http.StatusNotFound, verrors.VegaBackend_BuildTask_NotFound)
 	}
+	if err := bts.populateBuildTaskReferences(ctx, []*interfaces.BuildTask{buildTask}); err != nil {
+		span.SetStatus(codes.Error, "Populate build task references failed")
+		return nil, rest.NewHTTPError(ctx, http.StatusInternalServerError, verrors.VegaBackend_BuildTask_InternalError_GetFailed).
+			WithErrorDetails(err.Error())
+	}
 
 	accountInfos := []*interfaces.AccountInfo{&buildTask.Creator}
 	if err := bts.ums.GetAccountNames(ctx, accountInfos); err != nil {
@@ -452,6 +457,61 @@ func (bts *buildTaskService) InternalUpdateStatus(ctx context.Context, tx *sql.T
 	defer span.End()
 
 	return bts.bta.UpdateStatus(ctx, tx, id, update, allowedStatuses...)
+}
+
+// populateBuildTaskReferences 批量补齐任务关联的资源与目录展示字段。它只查询当前
+// 返回的任务所引用的实体，避免任务列表由前端触发全量资源/目录加载。
+func (bts *buildTaskService) populateBuildTaskReferences(ctx context.Context, buildTasks []*interfaces.BuildTask) error {
+	if len(buildTasks) == 0 {
+		return nil
+	}
+
+	resourceIDs := make([]string, 0, len(buildTasks))
+	resourceIDSet := make(map[string]struct{}, len(buildTasks))
+	catalogIDs := make([]string, 0, len(buildTasks))
+	catalogIDSet := make(map[string]struct{}, len(buildTasks))
+	for _, buildTask := range buildTasks {
+		if buildTask.ResourceID != "" {
+			if _, exists := resourceIDSet[buildTask.ResourceID]; !exists {
+				resourceIDSet[buildTask.ResourceID] = struct{}{}
+				resourceIDs = append(resourceIDs, buildTask.ResourceID)
+			}
+		}
+		if buildTask.CatalogID != "" {
+			if _, exists := catalogIDSet[buildTask.CatalogID]; !exists {
+				catalogIDSet[buildTask.CatalogID] = struct{}{}
+				catalogIDs = append(catalogIDs, buildTask.CatalogID)
+			}
+		}
+	}
+
+	resources, err := bts.rs.InternalGetByIDs(ctx, resourceIDs)
+	if err != nil {
+		return err
+	}
+	resourcesByID := make(map[string]*interfaces.Resource, len(resources))
+	for _, resource := range resources {
+		resourcesByID[resource.ID] = resource
+	}
+
+	catalogs, err := bts.cs.InternalGetByIDs(ctx, catalogIDs)
+	if err != nil {
+		return err
+	}
+	catalogsByID := make(map[string]*interfaces.Catalog, len(catalogs))
+	for _, catalog := range catalogs {
+		catalogsByID[catalog.ID] = catalog
+	}
+
+	for _, buildTask := range buildTasks {
+		if resource := resourcesByID[buildTask.ResourceID]; resource != nil {
+			buildTask.ResourceName = resource.Name
+		}
+		if catalog := catalogsByID[buildTask.CatalogID]; catalog != nil {
+			buildTask.CatalogName = catalog.Name
+		}
+	}
+	return nil
 }
 
 func (bts *buildTaskService) InternalGetStatus(ctx context.Context, id string) (string, error) {
@@ -546,6 +606,11 @@ func (bts *buildTaskService) List(ctx context.Context, params interfaces.BuildTa
 	buildTasks, total, err := bts.bta.List(ctx, params)
 	if err != nil {
 		span.SetStatus(codes.Error, "List build tasks failed")
+		return nil, 0, rest.NewHTTPError(ctx, http.StatusInternalServerError, verrors.VegaBackend_BuildTask_InternalError_GetFailed).
+			WithErrorDetails(err.Error())
+	}
+	if err := bts.populateBuildTaskReferences(ctx, buildTasks); err != nil {
+		span.SetStatus(codes.Error, "Populate build task references failed")
 		return nil, 0, rest.NewHTTPError(ctx, http.StatusInternalServerError, verrors.VegaBackend_BuildTask_InternalError_GetFailed).
 			WithErrorDetails(err.Error())
 	}

--- a/adp/vega/vega-backend/server/logics/build_task/build_task_service_test.go
+++ b/adp/vega/vega-backend/server/logics/build_task/build_task_service_test.go
@@ -25,6 +25,60 @@ import (
 	"vega-backend/logics"
 )
 
+func TestBuildTaskServicePopulatesTaskReferencesForListAndGet(t *testing.T) {
+	t.Run("list populates only referenced resources and catalogs", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		mockBTA := mock_interfaces.NewMockBuildTaskAccess(ctrl)
+		mockCS := mock_interfaces.NewMockCatalogService(ctrl)
+		mockRS := mock_interfaces.NewMockResourceService(ctrl)
+		mockUMS := mock_interfaces.NewMockUserMgmtService(ctrl)
+		service := &buildTaskService{bta: mockBTA, cs: mockCS, rs: mockRS, ums: mockUMS}
+		tasks := []*interfaces.BuildTask{
+			{ID: "task-1", ResourceID: "resource-1", CatalogID: "catalog-1"},
+			{ID: "task-2", ResourceID: "resource-2", CatalogID: "catalog-1"},
+		}
+
+		mockBTA.EXPECT().List(gomock.Any(), gomock.Any()).Return(tasks, int64(2), nil)
+		mockRS.EXPECT().InternalGetByIDs(gomock.Any(), []string{"resource-1", "resource-2"}).Return([]*interfaces.Resource{
+			{ID: "resource-1", Name: "orders"},
+			{ID: "resource-2", Name: "customers"},
+		}, nil)
+		mockCS.EXPECT().InternalGetByIDs(gomock.Any(), []string{"catalog-1"}).Return([]*interfaces.Catalog{{ID: "catalog-1", Name: "production"}}, nil)
+		mockUMS.EXPECT().GetAccountNames(gomock.Any(), gomock.Any()).Return(nil)
+
+		got, total, err := service.List(context.Background(), interfaces.BuildTasksQueryParams{})
+
+		require.NoError(t, err)
+		assert.Equal(t, int64(2), total)
+		assert.Equal(t, "orders", got[0].ResourceName)
+		assert.Equal(t, "customers", got[1].ResourceName)
+		assert.Equal(t, "production", got[0].CatalogName)
+	})
+
+	t.Run("get by id populates the same reference fields", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		mockBTA := mock_interfaces.NewMockBuildTaskAccess(ctrl)
+		mockCS := mock_interfaces.NewMockCatalogService(ctrl)
+		mockRS := mock_interfaces.NewMockResourceService(ctrl)
+		mockUMS := mock_interfaces.NewMockUserMgmtService(ctrl)
+		service := &buildTaskService{bta: mockBTA, cs: mockCS, rs: mockRS, ums: mockUMS}
+		task := &interfaces.BuildTask{ID: "task-1", ResourceID: "resource-1", CatalogID: "catalog-1"}
+
+		mockBTA.EXPECT().GetByID(gomock.Any(), "task-1").Return(task, nil)
+		mockRS.EXPECT().InternalGetByIDs(gomock.Any(), []string{"resource-1"}).Return([]*interfaces.Resource{
+			{ID: "resource-1", Name: "orders"},
+		}, nil)
+		mockCS.EXPECT().InternalGetByIDs(gomock.Any(), []string{"catalog-1"}).Return([]*interfaces.Catalog{{ID: "catalog-1", Name: "production"}}, nil)
+		mockUMS.EXPECT().GetAccountNames(gomock.Any(), gomock.Any()).Return(nil)
+
+		got, err := service.GetByID(context.Background(), "task-1")
+
+		require.NoError(t, err)
+		assert.Equal(t, "orders", got.ResourceName)
+		assert.Equal(t, "production", got.CatalogName)
+	})
+}
+
 func TestBuildTaskServiceCreateBuildTask(t *testing.T) {
 	t.Run("rejects batch task without build key fields", func(t *testing.T) {
 		ctrl := gomock.NewController(t)

--- a/adp/vega/vega-backend/server/logics/catalog/catalog_service.go
+++ b/adp/vega/vega-backend/server/logics/catalog/catalog_service.go
@@ -370,6 +370,24 @@ func (cs *catalogService) InternalGetByID(ctx context.Context, id string, withSe
 	return catalog, nil
 }
 
+// InternalGetByIDs 供服务端内部批量读取目录信息，不执行权限过滤或加载扩展字段。
+func (cs *catalogService) InternalGetByIDs(ctx context.Context, ids []string) ([]*interfaces.Catalog, error) {
+	ctx, span := oteltrace.StartNamedInternalSpan(ctx, "CatalogService.InternalGetByIDs")
+	defer span.End()
+
+	if len(ids) == 0 {
+		span.SetStatus(codes.Ok, "")
+		return []*interfaces.Catalog{}, nil
+	}
+	catalogs, err := cs.ca.GetByIDs(ctx, ids)
+	if err != nil {
+		span.SetStatus(codes.Error, "Get catalogs failed")
+		return nil, err
+	}
+	span.SetStatus(codes.Ok, "")
+	return catalogs, nil
+}
+
 // GetByIDs retrieves a Catalog by IDs.
 func (cs *catalogService) GetByIDs(ctx context.Context, ids []string) ([]*interfaces.Catalog, error) {
 	ctx, span := oteltrace.StartNamedInternalSpan(ctx, "Get catalogs")

--- a/adp/vega/vega-backend/server/logics/discover_schedule/discover_schedule_service.go
+++ b/adp/vega/vega-backend/server/logics/discover_schedule/discover_schedule_service.go
@@ -24,6 +24,7 @@ import (
 	verrors "vega-backend/errors"
 	"vega-backend/interfaces"
 	"vega-backend/logics"
+	"vega-backend/logics/catalog"
 	"vega-backend/logics/user_mgmt"
 )
 
@@ -34,6 +35,7 @@ var (
 
 type discoverScheduleService struct {
 	appSetting *common.AppSetting
+	cs         interfaces.CatalogService
 	dsa        interfaces.DiscoverScheduleAccess
 	dts        interfaces.DiscoverTaskService
 	ums        interfaces.UserMgmtService
@@ -48,6 +50,7 @@ func NewDiscoverScheduleService(appSetting *common.AppSetting, dts interfaces.Di
 	dsServiceOnce.Do(func() {
 		dsService = &discoverScheduleService{
 			appSetting: appSetting,
+			cs:         catalog.NewCatalogService(appSetting),
 			dsa:        logics.DSA,
 			dts:        dts,
 			ums:        user_mgmt.NewUserMgmtService(appSetting),
@@ -117,6 +120,9 @@ func (dss *discoverScheduleService) GetByID(ctx context.Context, id string) (*in
 		return nil, err
 	}
 	if schedule != nil {
+		if err := dss.populateDiscoverScheduleReferences(ctx, []*interfaces.DiscoverSchedule{schedule}); err != nil {
+			return nil, err
+		}
 		if err := dss.ums.GetAccountNames(ctx, []*interfaces.AccountInfo{&schedule.Creator, &schedule.Updater}); err != nil {
 			span.SetStatus(codes.Error, "GetAccountNames error")
 			return nil, rest.NewHTTPError(ctx, http.StatusInternalServerError,
@@ -135,6 +141,9 @@ func (dss *discoverScheduleService) List(ctx context.Context, params interfaces.
 	if err != nil {
 		return nil, 0, err
 	}
+	if err := dss.populateDiscoverScheduleReferences(ctx, schedules); err != nil {
+		return nil, 0, err
+	}
 
 	accountInfos := make([]*interfaces.AccountInfo, 0, len(schedules)*2)
 	for _, s := range schedules {
@@ -146,6 +155,39 @@ func (dss *discoverScheduleService) List(ctx context.Context, params interfaces.
 			verrors.VegaBackend_DiscoverSchedule_InternalError_GetAccountNamesFailed).WithErrorDetails(err.Error())
 	}
 	return schedules, total, nil
+}
+
+// populateDiscoverScheduleReferences 批量补齐当前页调度关联目录的展示名称。
+func (dss *discoverScheduleService) populateDiscoverScheduleReferences(ctx context.Context, schedules []*interfaces.DiscoverSchedule) error {
+	catalogIDs := make([]string, 0, len(schedules))
+	seen := make(map[string]struct{}, len(schedules))
+	for _, schedule := range schedules {
+		if schedule.CatalogID == "" {
+			continue
+		}
+		if _, exists := seen[schedule.CatalogID]; !exists {
+			seen[schedule.CatalogID] = struct{}{}
+			catalogIDs = append(catalogIDs, schedule.CatalogID)
+		}
+	}
+	if len(catalogIDs) == 0 {
+		return nil
+	}
+
+	catalogs, err := dss.cs.InternalGetByIDs(ctx, catalogIDs)
+	if err != nil {
+		return err
+	}
+	catalogsByID := make(map[string]*interfaces.Catalog, len(catalogs))
+	for _, catalog := range catalogs {
+		catalogsByID[catalog.ID] = catalog
+	}
+	for _, schedule := range schedules {
+		if catalog := catalogsByID[schedule.CatalogID]; catalog != nil {
+			schedule.CatalogName = catalog.Name
+		}
+	}
+	return nil
 }
 
 // Update updates a discover schedule.

--- a/adp/vega/vega-backend/server/logics/discover_schedule/discover_schedule_service_test.go
+++ b/adp/vega/vega-backend/server/logics/discover_schedule/discover_schedule_service_test.go
@@ -175,6 +175,43 @@ func TestDiscoverScheduleServiceGetListAndSimpleDelegates(t *testing.T) {
 	})
 }
 
+func TestDiscoverScheduleServicePopulatesCatalogName(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	t.Cleanup(ctrl.Finish)
+	dsa := vmock.NewMockDiscoverScheduleAccess(ctrl)
+	cs := vmock.NewMockCatalogService(ctrl)
+	ums := vmock.NewMockUserMgmtService(ctrl)
+	service := &discoverScheduleService{dsa: dsa, cs: cs, ums: ums}
+
+	t.Run("list batches current page catalog ids", func(t *testing.T) {
+		schedules := []*interfaces.DiscoverSchedule{
+			{ID: "schedule-1", CatalogID: "catalog-1"},
+			{ID: "schedule-2", CatalogID: "catalog-1"},
+		}
+		dsa.EXPECT().List(gomock.Any(), gomock.Any()).Return(schedules, int64(2), nil)
+		cs.EXPECT().InternalGetByIDs(gomock.Any(), []string{"catalog-1"}).Return([]*interfaces.Catalog{{ID: "catalog-1", Name: "目录一"}}, nil)
+		ums.EXPECT().GetAccountNames(gomock.Any(), gomock.Len(4)).Return(nil)
+
+		got, _, err := service.List(context.Background(), interfaces.DiscoverScheduleQueryParams{})
+
+		require.NoError(t, err)
+		assert.Equal(t, "目录一", got[0].CatalogName)
+		assert.Equal(t, "目录一", got[1].CatalogName)
+	})
+
+	t.Run("get populates catalog name", func(t *testing.T) {
+		schedule := &interfaces.DiscoverSchedule{ID: "schedule-3", CatalogID: "catalog-2"}
+		dsa.EXPECT().GetByID(gomock.Any(), "schedule-3").Return(schedule, nil)
+		cs.EXPECT().InternalGetByIDs(gomock.Any(), []string{"catalog-2"}).Return([]*interfaces.Catalog{{ID: "catalog-2", Name: "目录二"}}, nil)
+		ums.EXPECT().GetAccountNames(gomock.Any(), gomock.Any()).Return(nil)
+
+		got, err := service.GetByID(context.Background(), "schedule-3")
+
+		require.NoError(t, err)
+		assert.Equal(t, "目录二", got.CatalogName)
+	})
+}
+
 func TestDiscoverScheduleServiceExecuteSchedule(t *testing.T) {
 	t.Run("rejects nil discover task service", func(t *testing.T) {
 		service := &discoverScheduleService{}

--- a/adp/vega/vega-backend/server/logics/discover_task/discover_task_service.go
+++ b/adp/vega/vega-backend/server/logics/discover_task/discover_task_service.go
@@ -28,6 +28,7 @@ import (
 	verrors "vega-backend/errors"
 	"vega-backend/interfaces"
 	"vega-backend/logics"
+	"vega-backend/logics/catalog"
 	"vega-backend/logics/user_mgmt"
 )
 
@@ -41,6 +42,7 @@ const debugQueueSize = 100
 type discoverTaskService struct {
 	appSetting *common.AppSetting
 	client     *asynq.Client
+	cs         interfaces.CatalogService
 	dta        interfaces.DiscoverTaskAccess
 	ums        interfaces.UserMgmtService
 
@@ -57,6 +59,7 @@ func NewDiscoverTaskService(appSetting *common.AppSetting) interfaces.DiscoverTa
 		dtService = &discoverTaskService{
 			appSetting: appSetting,
 			client:     client,
+			cs:         catalog.NewCatalogService(appSetting),
 			dta:        logics.DTA,
 			ums:        user_mgmt.NewUserMgmtService(appSetting),
 
@@ -164,6 +167,9 @@ func (dts *discoverTaskService) GetByID(ctx context.Context, id string) (*interf
 		span.SetStatus(codes.Error, "Discover task not found")
 		return nil, rest.NewHTTPError(ctx, http.StatusNotFound, verrors.VegaBackend_DiscoverTask_NotFound)
 	}
+	if err := dts.populateDiscoverTaskReferences(ctx, []*interfaces.DiscoverTask{task}); err != nil {
+		return nil, err
+	}
 	if err := dts.ums.GetAccountNames(ctx, []*interfaces.AccountInfo{&task.Creator}); err != nil {
 		span.SetStatus(codes.Error, "GetAccountNames error")
 		return nil, rest.NewHTTPError(ctx, http.StatusInternalServerError,
@@ -192,6 +198,9 @@ func (dts *discoverTaskService) List(ctx context.Context, params interfaces.Disc
 	if err != nil {
 		return nil, 0, err
 	}
+	if err := dts.populateDiscoverTaskReferences(ctx, tasks); err != nil {
+		return nil, 0, err
+	}
 
 	accountInfos := make([]*interfaces.AccountInfo, 0, len(tasks))
 	for _, t := range tasks {
@@ -203,6 +212,39 @@ func (dts *discoverTaskService) List(ctx context.Context, params interfaces.Disc
 			verrors.VegaBackend_DiscoverTask_InternalError_GetAccountNamesFailed).WithErrorDetails(err.Error())
 	}
 	return tasks, total, nil
+}
+
+// populateDiscoverTaskReferences 批量补齐当前页任务关联目录的展示名称。
+func (dts *discoverTaskService) populateDiscoverTaskReferences(ctx context.Context, tasks []*interfaces.DiscoverTask) error {
+	catalogIDs := make([]string, 0, len(tasks))
+	seen := make(map[string]struct{}, len(tasks))
+	for _, task := range tasks {
+		if task.CatalogID == "" {
+			continue
+		}
+		if _, exists := seen[task.CatalogID]; !exists {
+			seen[task.CatalogID] = struct{}{}
+			catalogIDs = append(catalogIDs, task.CatalogID)
+		}
+	}
+	if len(catalogIDs) == 0 {
+		return nil
+	}
+
+	catalogs, err := dts.cs.InternalGetByIDs(ctx, catalogIDs)
+	if err != nil {
+		return err
+	}
+	catalogsByID := make(map[string]*interfaces.Catalog, len(catalogs))
+	for _, catalog := range catalogs {
+		catalogsByID[catalog.ID] = catalog
+	}
+	for _, task := range tasks {
+		if catalog := catalogsByID[task.CatalogID]; catalog != nil {
+			task.CatalogName = catalog.Name
+		}
+	}
+	return nil
 }
 
 // UpdateStatus updates a DiscoverTask's status.

--- a/adp/vega/vega-backend/server/logics/discover_task/discover_task_service_test.go
+++ b/adp/vega/vega-backend/server/logics/discover_task/discover_task_service_test.go
@@ -106,6 +106,43 @@ func TestDiscoverTaskServiceGetAndList(t *testing.T) {
 	})
 }
 
+func TestDiscoverTaskServicePopulatesCatalogName(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	t.Cleanup(ctrl.Finish)
+	dta := vmock.NewMockDiscoverTaskAccess(ctrl)
+	cs := vmock.NewMockCatalogService(ctrl)
+	ums := vmock.NewMockUserMgmtService(ctrl)
+	service := &discoverTaskService{dta: dta, cs: cs, ums: ums}
+
+	t.Run("list batches current page catalog ids", func(t *testing.T) {
+		tasks := []*interfaces.DiscoverTask{
+			{ID: "task-1", CatalogID: "catalog-1"},
+			{ID: "task-2", CatalogID: "catalog-1"},
+		}
+		dta.EXPECT().List(gomock.Any(), gomock.Any()).Return(tasks, int64(2), nil)
+		cs.EXPECT().InternalGetByIDs(gomock.Any(), []string{"catalog-1"}).Return([]*interfaces.Catalog{{ID: "catalog-1", Name: "目录一"}}, nil)
+		ums.EXPECT().GetAccountNames(gomock.Any(), gomock.Len(2)).Return(nil)
+
+		got, _, err := service.List(context.Background(), interfaces.DiscoverTaskQueryParams{})
+
+		require.NoError(t, err)
+		assert.Equal(t, "目录一", got[0].CatalogName)
+		assert.Equal(t, "目录一", got[1].CatalogName)
+	})
+
+	t.Run("get populates catalog name", func(t *testing.T) {
+		task := &interfaces.DiscoverTask{ID: "task-3", CatalogID: "catalog-2"}
+		dta.EXPECT().GetByID(gomock.Any(), "task-3").Return(task, nil)
+		cs.EXPECT().InternalGetByIDs(gomock.Any(), []string{"catalog-2"}).Return([]*interfaces.Catalog{{ID: "catalog-2", Name: "目录二"}}, nil)
+		ums.EXPECT().GetAccountNames(gomock.Any(), gomock.Any()).Return(nil)
+
+		got, err := service.GetByID(context.Background(), "task-3")
+
+		require.NoError(t, err)
+		assert.Equal(t, "目录二", got.CatalogName)
+	})
+}
+
 func TestDiscoverTaskServiceUpdateAndExistence(t *testing.T) {
 	t.Run("delegates status update", func(t *testing.T) {
 		service, dta, _ := newTestDiscoverTaskService(t)

--- a/adp/vega/vega-backend/server/logics/resource/resource_service.go
+++ b/adp/vega/vega-backend/server/logics/resource/resource_service.go
@@ -373,6 +373,38 @@ func (rs *resourceService) InternalGetByID(ctx context.Context, id string) (*int
 	return rs.ra.GetByID(ctx, id)
 }
 
+// InternalGetByIDs 供服务端内部批量读取资源基础信息，不执行权限过滤或加载扩展字段。
+func (rs *resourceService) InternalGetByIDs(ctx context.Context, ids []string) ([]*interfaces.Resource, error) {
+	ctx, span := oteltrace.StartNamedInternalSpan(ctx, "ResourceService.InternalGetByIDs")
+	defer span.End()
+
+	if len(ids) == 0 {
+		span.SetStatus(codes.Ok, "")
+		return []*interfaces.Resource{}, nil
+	}
+	resources, err := rs.ra.GetByIDsBasic(ctx, ids)
+	if err != nil {
+		span.SetStatus(codes.Error, "Get resources failed")
+		return nil, err
+	}
+	span.SetStatus(codes.Ok, "")
+	return resources, nil
+}
+
+// InternalGetByCatalogID 供服务端内部读取目录下完整资源信息，不执行权限过滤。
+func (rs *resourceService) InternalGetByCatalogID(ctx context.Context, catalogID string) ([]*interfaces.Resource, error) {
+	ctx, span := oteltrace.StartNamedInternalSpan(ctx, "ResourceService.InternalGetByCatalogID")
+	defer span.End()
+
+	resources, err := rs.ra.GetByCatalogID(ctx, catalogID)
+	if err != nil {
+		span.SetStatus(codes.Error, "Get resources failed")
+		return nil, err
+	}
+	span.SetStatus(codes.Ok, "")
+	return resources, nil
+}
+
 // GetByIDs retrieves Resources by IDs.
 func (rs *resourceService) GetByIDs(ctx context.Context, ids []string) ([]*interfaces.Resource, error) {
 	ctx, span := oteltrace.StartNamedInternalSpan(ctx, "Get resources by IDs")

--- a/adp/vega/vega-backend/server/logics/semantic_understanding_task/semantic_understanding_task_service.go
+++ b/adp/vega/vega-backend/server/logics/semantic_understanding_task/semantic_understanding_task_service.go
@@ -31,6 +31,8 @@ import (
 	verrors "vega-backend/errors"
 	"vega-backend/interfaces"
 	"vega-backend/logics"
+	"vega-backend/logics/catalog"
+	"vega-backend/logics/resource"
 	"vega-backend/logics/user_mgmt"
 )
 
@@ -44,8 +46,8 @@ const debugQueueSize = 100
 type semanticUnderstandingTaskService struct {
 	appSetting *common.AppSetting
 	client     *asynq.Client
-	ca         interfaces.CatalogAccess
-	ra         interfaces.ResourceAccess
+	cs         interfaces.CatalogService
+	rs         interfaces.ResourceService
 	suta       interfaces.SemanticUnderstandingTaskAccess
 	ums        interfaces.UserMgmtService
 
@@ -61,8 +63,8 @@ func NewSemanticUnderstandingTaskService(appSetting *common.AppSetting) interfac
 		sutService = &semanticUnderstandingTaskService{
 			appSetting: appSetting,
 			client:     client,
-			ca:         logics.CA,
-			ra:         logics.RA,
+			cs:         catalog.NewCatalogService(appSetting),
+			rs:         resource.NewResourceService(appSetting),
 			suta:       logics.SUTA,
 			ums:        user_mgmt.NewUserMgmtService(appSetting),
 
@@ -86,7 +88,7 @@ func (suts *semanticUnderstandingTaskService) CreateResourceTask(ctx context.Con
 			WithErrorDetails("resource_id is required")
 	}
 
-	resource, err := suts.ra.GetByID(ctx, resourceID)
+	resource, err := suts.rs.InternalGetByID(ctx, resourceID)
 	if err != nil {
 		span.SetStatus(codes.Error, "Get resource failed")
 		return nil, rest.NewHTTPError(ctx, http.StatusInternalServerError, verrors.VegaBackend_InternalError_FilterResourcesFailed).
@@ -116,7 +118,7 @@ func (suts *semanticUnderstandingTaskService) CreateCatalogTask(ctx context.Cont
 			WithErrorDetails("catalog_id is required")
 	}
 
-	catalog, err := suts.ca.GetByID(ctx, catalogID)
+	catalog, err := suts.cs.InternalGetByID(ctx, catalogID, false)
 	if err != nil {
 		span.SetStatus(codes.Error, "Get catalog failed")
 		return nil, rest.NewHTTPError(ctx, http.StatusInternalServerError, verrors.VegaBackend_InternalError_FilterResourcesFailed).
@@ -127,7 +129,7 @@ func (suts *semanticUnderstandingTaskService) CreateCatalogTask(ctx context.Cont
 		return nil, rest.NewHTTPError(ctx, http.StatusNotFound, verrors.VegaBackend_Catalog_NotFound)
 	}
 
-	resources, err := suts.ra.GetByCatalogID(ctx, catalogID)
+	resources, err := suts.rs.InternalGetByCatalogID(ctx, catalogID)
 	if err != nil {
 		span.SetStatus(codes.Error, "Get catalog resources failed")
 		return nil, rest.NewHTTPError(ctx, http.StatusInternalServerError, verrors.VegaBackend_InternalError_FilterResourcesFailed).
@@ -220,6 +222,9 @@ func (suts *semanticUnderstandingTaskService) GetByID(ctx context.Context, id st
 		span.SetStatus(codes.Error, "Semantic understanding task not found")
 		return nil, rest.NewHTTPError(ctx, http.StatusNotFound, verrors.VegaBackend_SemanticUnderstandingTask_NotFound)
 	}
+	if err := suts.populateSemanticUnderstandingTaskReferences(ctx, []*interfaces.SemanticUnderstandingTask{task}); err != nil {
+		return nil, err
+	}
 	if err := suts.ums.GetAccountNames(ctx, []*interfaces.AccountInfo{&task.Creator}); err != nil {
 		span.SetStatus(codes.Error, "GetAccountNames error")
 		return nil, rest.NewHTTPError(ctx, http.StatusInternalServerError,
@@ -258,7 +263,62 @@ func (suts *semanticUnderstandingTaskService) List(ctx context.Context, params i
 		return nil, 0, rest.NewHTTPError(ctx, http.StatusInternalServerError, verrors.VegaBackend_InternalError_FilterResourcesFailed).
 			WithErrorDetails(err.Error())
 	}
+	if err := suts.populateSemanticUnderstandingTaskReferences(ctx, tasks); err != nil {
+		return nil, 0, err
+	}
 	return tasks, total, nil
+}
+
+// populateSemanticUnderstandingTaskReferences 批量补齐当前页任务关联的目录与资源展示名称。
+func (suts *semanticUnderstandingTaskService) populateSemanticUnderstandingTaskReferences(ctx context.Context, tasks []*interfaces.SemanticUnderstandingTask) error {
+	catalogIDs := make([]string, 0, len(tasks))
+	catalogIDSet := make(map[string]struct{}, len(tasks))
+	resourceIDs := make([]string, 0, len(tasks))
+	resourceIDSet := make(map[string]struct{}, len(tasks))
+	for _, task := range tasks {
+		if task.CatalogID != "" {
+			if _, exists := catalogIDSet[task.CatalogID]; !exists {
+				catalogIDSet[task.CatalogID] = struct{}{}
+				catalogIDs = append(catalogIDs, task.CatalogID)
+			}
+		}
+		if task.ResourceID != "" {
+			if _, exists := resourceIDSet[task.ResourceID]; !exists {
+				resourceIDSet[task.ResourceID] = struct{}{}
+				resourceIDs = append(resourceIDs, task.ResourceID)
+			}
+		}
+	}
+
+	resourcesByID := make(map[string]*interfaces.Resource, len(resourceIDs))
+	if len(resourceIDs) > 0 {
+		resources, err := suts.rs.InternalGetByIDs(ctx, resourceIDs)
+		if err != nil {
+			return err
+		}
+		for _, resource := range resources {
+			resourcesByID[resource.ID] = resource
+		}
+	}
+	catalogsByID := make(map[string]*interfaces.Catalog, len(catalogIDs))
+	if len(catalogIDs) > 0 {
+		catalogs, err := suts.cs.InternalGetByIDs(ctx, catalogIDs)
+		if err != nil {
+			return err
+		}
+		for _, catalog := range catalogs {
+			catalogsByID[catalog.ID] = catalog
+		}
+	}
+	for _, task := range tasks {
+		if resource := resourcesByID[task.ResourceID]; resource != nil {
+			task.ResourceName = resource.Name
+		}
+		if catalog := catalogsByID[task.CatalogID]; catalog != nil {
+			task.CatalogName = catalog.Name
+		}
+	}
+	return nil
 }
 
 func (suts *semanticUnderstandingTaskService) Delete(ctx context.Context, ids []string, ignoreMissing bool) error {

--- a/adp/vega/vega-backend/server/logics/semantic_understanding_task/semantic_understanding_task_service_test.go
+++ b/adp/vega/vega-backend/server/logics/semantic_understanding_task/semantic_understanding_task_service_test.go
@@ -98,17 +98,17 @@ func TestSemanticUnderstandingTaskServiceCreate(t *testing.T) {
 		ctrl := gomock.NewController(t)
 		t.Cleanup(ctrl.Finish)
 		taskAccess := mock_interfaces.NewMockSemanticUnderstandingTaskAccess(ctrl)
-		resourceAccess := mock_interfaces.NewMockResourceAccess(ctrl)
+		resourceService := mock_interfaces.NewMockResourceService(ctrl)
 		service := &semanticUnderstandingTaskService{
 			suta:           taskAccess,
-			ra:             resourceAccess,
+			rs:             resourceService,
 			debugTaskQueue: make(chan *asynq.Task, 1),
 		}
 		ctx := context.WithValue(context.Background(), interfaces.ACCOUNT_INFO_KEY, interfaces.AccountInfo{ID: "u1", Type: interfaces.ACCESSOR_TYPE_USER})
 		var createdTask *interfaces.SemanticUnderstandingTask
 		var findHash string
 
-		resourceAccess.EXPECT().GetByID(gomock.Any(), "resource-1").Return(sampleSemanticResource(), nil)
+		resourceService.EXPECT().InternalGetByID(gomock.Any(), "resource-1").Return(sampleSemanticResource(), nil)
 		taskAccess.EXPECT().
 			FindActiveByInputHash(gomock.Any(), interfaces.SemanticUnderstandingTaskScopeResource, gomock.Any()).
 			DoAndReturn(func(_ context.Context, _ string, inputHash string) (*interfaces.SemanticUnderstandingTask, error) {
@@ -190,13 +190,13 @@ func TestSemanticUnderstandingTaskServiceCreate(t *testing.T) {
 		t.Cleanup(ctrl.Finish)
 		active := &interfaces.SemanticUnderstandingTask{ID: "semantic-task-1"}
 		taskAccess := mock_interfaces.NewMockSemanticUnderstandingTaskAccess(ctrl)
-		catalogAccess := mock_interfaces.NewMockCatalogAccess(ctrl)
-		resourceAccess := mock_interfaces.NewMockResourceAccess(ctrl)
-		service := &semanticUnderstandingTaskService{suta: taskAccess, ca: catalogAccess, ra: resourceAccess}
+		catalogService := mock_interfaces.NewMockCatalogService(ctrl)
+		resourceService := mock_interfaces.NewMockResourceService(ctrl)
+		service := &semanticUnderstandingTaskService{suta: taskAccess, cs: catalogService, rs: resourceService}
 		var findScope string
 
-		catalogAccess.EXPECT().GetByID(gomock.Any(), "catalog-1").Return(&interfaces.Catalog{ID: "catalog-1", Name: "sales"}, nil)
-		resourceAccess.EXPECT().GetByCatalogID(gomock.Any(), "catalog-1").Return([]*interfaces.Resource{sampleSemanticResource()}, nil)
+		catalogService.EXPECT().InternalGetByID(gomock.Any(), "catalog-1", false).Return(&interfaces.Catalog{ID: "catalog-1", Name: "sales"}, nil)
+		resourceService.EXPECT().InternalGetByCatalogID(gomock.Any(), "catalog-1").Return([]*interfaces.Resource{sampleSemanticResource()}, nil)
 		taskAccess.EXPECT().
 			FindActiveByInputHash(gomock.Any(), interfaces.SemanticUnderstandingTaskScopeCatalog, gomock.Any()).
 			DoAndReturn(func(_ context.Context, scope string, _ string) (*interfaces.SemanticUnderstandingTask, error) {
@@ -277,6 +277,51 @@ func TestSemanticUnderstandingTaskServiceGetByID(t *testing.T) {
 		assert.Nil(t, got)
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "NotFound")
+	})
+}
+
+func TestSemanticUnderstandingTaskServicePopulatesReferenceNames(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	t.Cleanup(ctrl.Finish)
+	taskAccess := mock_interfaces.NewMockSemanticUnderstandingTaskAccess(ctrl)
+	catalogService := mock_interfaces.NewMockCatalogService(ctrl)
+	resourceService := mock_interfaces.NewMockResourceService(ctrl)
+	userMgmtService := mock_interfaces.NewMockUserMgmtService(ctrl)
+	service := &semanticUnderstandingTaskService{
+		suta: taskAccess,
+		cs:   catalogService,
+		rs:   resourceService,
+		ums:  userMgmtService,
+	}
+
+	t.Run("list batches current page reference ids", func(t *testing.T) {
+		tasks := []*interfaces.SemanticUnderstandingTask{
+			{ID: "task-1", CatalogID: "catalog-1", ResourceID: "resource-1"},
+			{ID: "task-2", CatalogID: "catalog-1", ResourceID: "resource-1"},
+		}
+		taskAccess.EXPECT().List(gomock.Any(), gomock.Any()).Return(tasks, int64(2), nil)
+		resourceService.EXPECT().InternalGetByIDs(gomock.Any(), []string{"resource-1"}).Return([]*interfaces.Resource{{ID: "resource-1", Name: "资源一"}}, nil)
+		catalogService.EXPECT().InternalGetByIDs(gomock.Any(), []string{"catalog-1"}).Return([]*interfaces.Catalog{{ID: "catalog-1", Name: "目录一"}}, nil)
+
+		got, _, err := service.List(context.Background(), interfaces.SemanticUnderstandingTaskQueryParams{})
+
+		require.NoError(t, err)
+		assert.Equal(t, "资源一", got[0].ResourceName)
+		assert.Equal(t, "目录一", got[1].CatalogName)
+	})
+
+	t.Run("get populates reference names", func(t *testing.T) {
+		task := &interfaces.SemanticUnderstandingTask{ID: "task-3", CatalogID: "catalog-2", ResourceID: "resource-2"}
+		taskAccess.EXPECT().GetByID(gomock.Any(), "task-3").Return(task, nil)
+		resourceService.EXPECT().InternalGetByIDs(gomock.Any(), []string{"resource-2"}).Return([]*interfaces.Resource{{ID: "resource-2", Name: "资源二"}}, nil)
+		catalogService.EXPECT().InternalGetByIDs(gomock.Any(), []string{"catalog-2"}).Return([]*interfaces.Catalog{{ID: "catalog-2", Name: "目录二"}}, nil)
+		userMgmtService.EXPECT().GetAccountNames(gomock.Any(), gomock.Any()).Return(nil)
+
+		got, err := service.GetByID(context.Background(), "task-3")
+
+		require.NoError(t, err)
+		assert.Equal(t, "资源二", got.ResourceName)
+		assert.Equal(t, "目录二", got.CatalogName)
 	})
 }
 

--- a/docs/api/vega/build-task.yaml
+++ b/docs/api/vega/build-task.yaml
@@ -378,6 +378,12 @@ components:
         catalog_id:
           description: 关联 Catalog ID（冗余存储以加速过滤）
           type: string
+        resource_name:
+          description: 关联 Resource 的当前名称；响应时按当前任务集合批量补齐，不落库
+          type: string
+        catalog_name:
+          description: 关联 Catalog 的当前名称；响应时按当前任务集合批量补齐，不落库
+          type: string
         status:
           description: 状态
           type: string

--- a/docs/api/vega/discover-schedule.yaml
+++ b/docs/api/vega/discover-schedule.yaml
@@ -349,6 +349,9 @@ components:
         catalog_id:
           description: 关联 catalog；创建后**不可修改**
           type: string
+        catalog_name:
+          description: 关联 catalog 名称
+          type: string
         cron_expr:
           description: 标准 5 字段 cron 表达式
           type: string

--- a/docs/api/vega/discover-task.yaml
+++ b/docs/api/vega/discover-task.yaml
@@ -314,6 +314,9 @@ components:
         catalog_id:
           description: 关联 catalog ID
           type: string
+        catalog_name:
+          description: 关联 catalog 名称
+          type: string
         schedule_id:
           description: |
             关联的 DiscoverSchedule ID。trigger_type=manual 时为空字符串。

--- a/docs/api/vega/semantic-understanding-task.yaml
+++ b/docs/api/vega/semantic-understanding-task.yaml
@@ -181,7 +181,9 @@ components:
         id: { type: string }
         scope: { type: string, enum: [resource, catalog] }
         catalog_id: { type: string }
+        catalog_name: { type: string }
         resource_id: { type: string }
+        resource_name: { type: string }
         agent_task_id: { type: string }
         agent_id: { type: string }
         input: { type: string }


### PR DESCRIPTION
## Summary
- Return catalog/resource display names with build, discover, semantic-understanding, and discover-schedule task list/get responses.
- Hydrate only the IDs in the current response page, using internal CatalogService and ResourceService APIs without permission filtering.
- Add lightweight internal resource lookup APIs and regression coverage.

## Validation
- `make lint`
- `make test`

Related to openbkn-ai/bkn-studio#235