### PR TITLE
feat(bkn-trace): add snapshot preview api

### DIFF
--- a/bkn-trace/agent-observability/docs/swagger/docs.go
+++ b/bkn-trace/agent-observability/docs/swagger/docs.go
@@ -16,6 +16,78 @@ const docTemplate = `{
     "host": "{{.Host}}",
     "basePath": "{{.BasePath}}",
     "paths": {
+        "/api/agent-observability/v1/evidence-nodes/{node_id}": {
+            "get": {
+                "description": "Returns one visible claim, evidence ref, or business ref node scoped by trace_id or request_id.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "evidence"
+                ],
+                "summary": "Get evidence node details",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Evidence node ID, for example claim:claim_001",
+                        "name": "node_id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Trace ID scope",
+                        "name": "trace_id",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "BKN request ID scope",
+                        "name": "request_id",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "description": "Maximum evidence trace batches to read, 1..1000",
+                        "name": "limit",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": true
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/rdto.ErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/rdto.ErrorResponse"
+                        }
+                    },
+                    "405": {
+                        "description": "Method Not Allowed",
+                        "schema": {
+                            "$ref": "#/definitions/rdto.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/rdto.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/api/agent-observability/v1/evidence/events": {
             "post": {
                 "description": "Accepts claim.created, evidence.refs.created, and business.refs.resolved events and stores the normalized evidence model.",
@@ -194,6 +266,12 @@ const docTemplate = `{
                         "name": "request_id",
                         "in": "query",
                         "required": true
+                    },
+                    {
+                        "type": "integer",
+                        "description": "Maximum evidence trace batches to read, 1..1000",
+                        "name": "limit",
+                        "in": "query"
                     }
                 ],
                 "responses": {
@@ -248,6 +326,72 @@ const docTemplate = `{
                         "name": "request_id",
                         "in": "query",
                         "required": true
+                    },
+                    {
+                        "type": "integer",
+                        "description": "Maximum evidence trace batches to read, 1..1000",
+                        "name": "limit",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": true
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/rdto.ErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/rdto.ErrorResponse"
+                        }
+                    },
+                    "405": {
+                        "description": "Method Not Allowed",
+                        "schema": {
+                            "$ref": "#/definitions/rdto.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/rdto.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/api/agent-observability/v1/traces/by-request/snapshot-preview": {
+            "get": {
+                "description": "Returns a metadata-only governed snapshot manifest preview without creating or exposing object storage locations.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "evidence"
+                ],
+                "summary": "Get evidence snapshot preview by BKN request ID",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "BKN request ID",
+                        "name": "request_id",
+                        "in": "query",
+                        "required": true
+                    },
+                    {
+                        "type": "integer",
+                        "description": "Maximum evidence trace batches to read, 1..1000",
+                        "name": "limit",
+                        "in": "query"
                     }
                 ],
                 "responses": {
@@ -302,6 +446,12 @@ const docTemplate = `{
                         "name": "trace_id",
                         "in": "path",
                         "required": true
+                    },
+                    {
+                        "type": "integer",
+                        "description": "Maximum evidence trace batches to read, 1..1000",
+                        "name": "limit",
+                        "in": "query"
                     }
                 ],
                 "responses": {
@@ -356,6 +506,72 @@ const docTemplate = `{
                         "name": "trace_id",
                         "in": "path",
                         "required": true
+                    },
+                    {
+                        "type": "integer",
+                        "description": "Maximum evidence trace batches to read, 1..1000",
+                        "name": "limit",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": true
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/rdto.ErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/rdto.ErrorResponse"
+                        }
+                    },
+                    "405": {
+                        "description": "Method Not Allowed",
+                        "schema": {
+                            "$ref": "#/definitions/rdto.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/rdto.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/api/agent-observability/v1/traces/{trace_id}/snapshot-preview": {
+            "get": {
+                "description": "Returns a metadata-only governed snapshot manifest preview without creating or exposing object storage locations.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "evidence"
+                ],
+                "summary": "Get evidence snapshot preview by trace ID",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Trace ID",
+                        "name": "trace_id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "integer",
+                        "description": "Maximum evidence trace batches to read, 1..1000",
+                        "name": "limit",
+                        "in": "query"
                     }
                 ],
                 "responses": {

--- a/bkn-trace/agent-observability/docs/swagger/swagger.json
+++ b/bkn-trace/agent-observability/docs/swagger/swagger.json
@@ -8,6 +8,78 @@
     },
     "basePath": "/api/agent-observability/v1",
     "paths": {
+        "/api/agent-observability/v1/evidence-nodes/{node_id}": {
+            "get": {
+                "description": "Returns one visible claim, evidence ref, or business ref node scoped by trace_id or request_id.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "evidence"
+                ],
+                "summary": "Get evidence node details",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Evidence node ID, for example claim:claim_001",
+                        "name": "node_id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Trace ID scope",
+                        "name": "trace_id",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "BKN request ID scope",
+                        "name": "request_id",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "description": "Maximum evidence trace batches to read, 1..1000",
+                        "name": "limit",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": true
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/rdto.ErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/rdto.ErrorResponse"
+                        }
+                    },
+                    "405": {
+                        "description": "Method Not Allowed",
+                        "schema": {
+                            "$ref": "#/definitions/rdto.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/rdto.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/api/agent-observability/v1/evidence/events": {
             "post": {
                 "description": "Accepts claim.created, evidence.refs.created, and business.refs.resolved events and stores the normalized evidence model.",
@@ -186,6 +258,12 @@
                         "name": "request_id",
                         "in": "query",
                         "required": true
+                    },
+                    {
+                        "type": "integer",
+                        "description": "Maximum evidence trace batches to read, 1..1000",
+                        "name": "limit",
+                        "in": "query"
                     }
                 ],
                 "responses": {
@@ -240,6 +318,72 @@
                         "name": "request_id",
                         "in": "query",
                         "required": true
+                    },
+                    {
+                        "type": "integer",
+                        "description": "Maximum evidence trace batches to read, 1..1000",
+                        "name": "limit",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": true
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/rdto.ErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/rdto.ErrorResponse"
+                        }
+                    },
+                    "405": {
+                        "description": "Method Not Allowed",
+                        "schema": {
+                            "$ref": "#/definitions/rdto.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/rdto.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/api/agent-observability/v1/traces/by-request/snapshot-preview": {
+            "get": {
+                "description": "Returns a metadata-only governed snapshot manifest preview without creating or exposing object storage locations.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "evidence"
+                ],
+                "summary": "Get evidence snapshot preview by BKN request ID",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "BKN request ID",
+                        "name": "request_id",
+                        "in": "query",
+                        "required": true
+                    },
+                    {
+                        "type": "integer",
+                        "description": "Maximum evidence trace batches to read, 1..1000",
+                        "name": "limit",
+                        "in": "query"
                     }
                 ],
                 "responses": {
@@ -294,6 +438,12 @@
                         "name": "trace_id",
                         "in": "path",
                         "required": true
+                    },
+                    {
+                        "type": "integer",
+                        "description": "Maximum evidence trace batches to read, 1..1000",
+                        "name": "limit",
+                        "in": "query"
                     }
                 ],
                 "responses": {
@@ -348,6 +498,72 @@
                         "name": "trace_id",
                         "in": "path",
                         "required": true
+                    },
+                    {
+                        "type": "integer",
+                        "description": "Maximum evidence trace batches to read, 1..1000",
+                        "name": "limit",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": true
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/rdto.ErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/rdto.ErrorResponse"
+                        }
+                    },
+                    "405": {
+                        "description": "Method Not Allowed",
+                        "schema": {
+                            "$ref": "#/definitions/rdto.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/rdto.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/api/agent-observability/v1/traces/{trace_id}/snapshot-preview": {
+            "get": {
+                "description": "Returns a metadata-only governed snapshot manifest preview without creating or exposing object storage locations.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "evidence"
+                ],
+                "summary": "Get evidence snapshot preview by trace ID",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Trace ID",
+                        "name": "trace_id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "integer",
+                        "description": "Maximum evidence trace batches to read, 1..1000",
+                        "name": "limit",
+                        "in": "query"
                     }
                 ],
                 "responses": {

--- a/bkn-trace/agent-observability/docs/swagger/swagger.yaml
+++ b/bkn-trace/agent-observability/docs/swagger/swagger.yaml
@@ -14,6 +14,55 @@ info:
   title: Agent Observability API
   version: "1.0"
 paths:
+  /api/agent-observability/v1/evidence-nodes/{node_id}:
+    get:
+      description: Returns one visible claim, evidence ref, or business ref node scoped
+        by trace_id or request_id.
+      parameters:
+      - description: Evidence node ID, for example claim:claim_001
+        in: path
+        name: node_id
+        required: true
+        type: string
+      - description: Trace ID scope
+        in: query
+        name: trace_id
+        type: string
+      - description: BKN request ID scope
+        in: query
+        name: request_id
+        type: string
+      - description: Maximum evidence trace batches to read, 1..1000
+        in: query
+        name: limit
+        type: integer
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties: true
+            type: object
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/rdto.ErrorResponse'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/rdto.ErrorResponse'
+        "405":
+          description: Method Not Allowed
+          schema:
+            $ref: '#/definitions/rdto.ErrorResponse'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/rdto.ErrorResponse'
+      summary: Get evidence node details
+      tags:
+      - evidence
   /api/agent-observability/v1/evidence/events:
     post:
       consumes:
@@ -95,6 +144,10 @@ paths:
         name: trace_id
         required: true
         type: string
+      - description: Maximum evidence trace batches to read, 1..1000
+        in: query
+        name: limit
+        type: integer
       produces:
       - application/json
       responses:
@@ -132,6 +185,10 @@ paths:
         name: trace_id
         required: true
         type: string
+      - description: Maximum evidence trace batches to read, 1..1000
+        in: query
+        name: limit
+        type: integer
       produces:
       - application/json
       responses:
@@ -157,6 +214,47 @@ paths:
           schema:
             $ref: '#/definitions/rdto.ErrorResponse'
       summary: Get evidence chain by trace ID
+      tags:
+      - evidence
+  /api/agent-observability/v1/traces/{trace_id}/snapshot-preview:
+    get:
+      description: Returns a metadata-only governed snapshot manifest preview without
+        creating or exposing object storage locations.
+      parameters:
+      - description: Trace ID
+        in: path
+        name: trace_id
+        required: true
+        type: string
+      - description: Maximum evidence trace batches to read, 1..1000
+        in: query
+        name: limit
+        type: integer
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties: true
+            type: object
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/rdto.ErrorResponse'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/rdto.ErrorResponse'
+        "405":
+          description: Method Not Allowed
+          schema:
+            $ref: '#/definitions/rdto.ErrorResponse'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/rdto.ErrorResponse'
+      summary: Get evidence snapshot preview by trace ID
       tags:
       - evidence
   /api/agent-observability/v1/traces/by-conversation:
@@ -207,6 +305,10 @@ paths:
         name: request_id
         required: true
         type: string
+      - description: Maximum evidence trace batches to read, 1..1000
+        in: query
+        name: limit
+        type: integer
       produces:
       - application/json
       responses:
@@ -244,6 +346,10 @@ paths:
         name: request_id
         required: true
         type: string
+      - description: Maximum evidence trace batches to read, 1..1000
+        in: query
+        name: limit
+        type: integer
       produces:
       - application/json
       responses:
@@ -269,6 +375,47 @@ paths:
           schema:
             $ref: '#/definitions/rdto.ErrorResponse'
       summary: Get business semantic graph by BKN request ID
+      tags:
+      - evidence
+  /api/agent-observability/v1/traces/by-request/snapshot-preview:
+    get:
+      description: Returns a metadata-only governed snapshot manifest preview without
+        creating or exposing object storage locations.
+      parameters:
+      - description: BKN request ID
+        in: query
+        name: request_id
+        required: true
+        type: string
+      - description: Maximum evidence trace batches to read, 1..1000
+        in: query
+        name: limit
+        type: integer
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties: true
+            type: object
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/rdto.ErrorResponse'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/rdto.ErrorResponse'
+        "405":
+          description: Method Not Allowed
+          schema:
+            $ref: '#/definitions/rdto.ErrorResponse'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/rdto.ErrorResponse'
+      summary: Get evidence snapshot preview by BKN request ID
       tags:
       - evidence
 swagger: "2.0"

--- a/bkn-trace/agent-observability/src/boot/bootstrap.go
+++ b/bkn-trace/agent-observability/src/boot/bootstrap.go
@@ -58,6 +58,7 @@ func newApp(httpServerConfig conf.HTTPServerConfig, traceHandler *httphandler.Tr
 	mux.HandleFunc(APIBasePath+"/traces/_search", traceHandler.SearchTraces)
 	mux.HandleFunc(APIBasePath+"/traces/by-conversation", traceHandler.SearchTracesByConversationID)
 	mux.HandleFunc(APIBasePath+"/traces/by-request/business-graph", evidenceHandler.GetBusinessGraphByRequestID)
+	mux.HandleFunc(APIBasePath+"/traces/by-request/snapshot-preview", evidenceHandler.GetSnapshotPreviewByRequestID)
 	mux.HandleFunc(APIBasePath+"/traces/by-request", evidenceHandler.GetEvidenceChainByRequestID)
 	mux.HandleFunc(APIBasePath+"/traces/", evidenceHandler.GetTraceSubresource)
 	mux.HandleFunc(APIBasePath+"/evidence-nodes/", evidenceHandler.GetEvidenceNode)

--- a/bkn-trace/agent-observability/src/domain/service/evidencesvc/service.go
+++ b/bkn-trace/agent-observability/src/domain/service/evidencesvc/service.go
@@ -2,6 +2,8 @@ package evidencesvc
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
 	"regexp"
 	"sort"
@@ -183,6 +185,28 @@ func (s *Service) GetEvidenceNodeByRequestID(ctx context.Context, requestID stri
 	return findEvidenceNode(result.Traces, strings.TrimSpace(nodeID))
 }
 
+func (s *Service) GetSnapshotPreviewByTraceID(ctx context.Context, traceID string, options evidencevo.EvidenceQueryOptions) (evidencevo.SnapshotPreviewResponse, bool, error) {
+	result, err := s.store.GetEvidenceByTraceID(ctx, strings.TrimSpace(traceID), normalizeQueryOptions(options))
+	if err != nil {
+		return evidencevo.SnapshotPreviewResponse{}, false, err
+	}
+	if len(result.Traces) == 0 {
+		return evidencevo.SnapshotPreviewResponse{}, false, nil
+	}
+	return buildSnapshotPreview(result.Traces, result.Truncated), true, nil
+}
+
+func (s *Service) GetSnapshotPreviewByRequestID(ctx context.Context, requestID string, options evidencevo.EvidenceQueryOptions) (evidencevo.SnapshotPreviewResponse, bool, error) {
+	result, err := s.store.GetEvidenceByRequestID(ctx, strings.TrimSpace(requestID), normalizeQueryOptions(options))
+	if err != nil {
+		return evidencevo.SnapshotPreviewResponse{}, false, err
+	}
+	if len(result.Traces) == 0 {
+		return evidencevo.SnapshotPreviewResponse{}, false, nil
+	}
+	return buildSnapshotPreview(result.Traces, result.Truncated), true, nil
+}
+
 func buildEvidenceChain(traces []evidencevo.NormalizedTrace, truncated bool) evidencevo.EvidenceChainResponse {
 	response := evidencevo.EvidenceChainResponse{
 		TraceID:   traces[0].TraceID,
@@ -243,6 +267,61 @@ func buildEvidenceChain(traces []evidencevo.NormalizedTrace, truncated bool) evi
 	response.Page.EdgeCount = len(response.Data.EvidenceRefs) + len(response.Data.BusinessRefs)
 	response.Page.Truncated = truncated
 	return response
+}
+
+func buildSnapshotPreview(traces []evidencevo.NormalizedTrace, truncated bool) evidencevo.SnapshotPreviewResponse {
+	chain := buildEvidenceChain(traces, truncated)
+	artifactSummary := map[string]any{
+		"trace_id":           chain.TraceID,
+		"bkn.request.id":     chain.RequestID,
+		"claims":             chain.Data.Claims,
+		"evidence_refs":      chain.Data.EvidenceRefs,
+		"business_refs":      chain.Data.BusinessRefs,
+		"visibility_summary": chain.VisibilitySummary,
+		"partial":            chain.Partial,
+		"partial_reason":     chain.PartialReasons,
+	}
+	artifactHash := hashValue(artifactSummary)
+	manifest := evidencevo.SnapshotManifest{
+		SchemaVersion:     "bkn-trace-snapshot-preview/v1",
+		Producer:          "bkn-trace.agent-observability",
+		TraceID:           chain.TraceID,
+		RequestID:         chain.RequestID,
+		ArtifactCount:     chain.Page.NodeCount,
+		ClaimCount:        len(chain.Data.Claims),
+		EvidenceRefCount:  len(chain.Data.EvidenceRefs),
+		BusinessRefCount:  len(chain.Data.BusinessRefs),
+		VisibilitySummary: chain.VisibilitySummary,
+		ComplianceStatus:  "preview/non-production compliance",
+		DLPClassification: "metadata-only",
+		RetentionPolicy:   "policy-managed",
+		LegalHold:         "not_requested",
+		SignatureStatus:   "unsigned-preview",
+		ArtifactHash:      artifactHash,
+	}
+	manifest.ManifestHash = hashValue(manifest)
+	return evidencevo.SnapshotPreviewResponse{
+		TraceID:           chain.TraceID,
+		RequestID:         chain.RequestID,
+		Partial:           chain.Partial,
+		PartialReasons:    chain.PartialReasons,
+		VisibilitySummary: chain.VisibilitySummary,
+		SnapshotRef: evidencevo.SnapshotRef{
+			SnapshotID: "preview:" + strings.TrimPrefix(hashValue(map[string]string{
+				"trace_id":       chain.TraceID,
+				"bkn.request.id": chain.RequestID,
+				"artifact_hash":  artifactHash,
+			}), "sha256:")[:16],
+			Mode: "preview",
+		},
+		Manifest: manifest,
+	}
+}
+
+func hashValue(value any) string {
+	body, _ := json.Marshal(value)
+	sum := sha256.Sum256(body)
+	return "sha256:" + hex.EncodeToString(sum[:])
 }
 
 func findEvidenceNode(traces []evidencevo.NormalizedTrace, nodeID string) (evidencevo.EvidenceNodeResponse, bool, error) {

--- a/bkn-trace/agent-observability/src/domain/service/evidencesvc/service_test.go
+++ b/bkn-trace/agent-observability/src/domain/service/evidencesvc/service_test.go
@@ -453,6 +453,37 @@ func TestGetBusinessGraphReturnsMissingBusinessRefsPartial(t *testing.T) {
 	}
 }
 
+func TestGetSnapshotPreviewByTraceIDReturnsGovernedManifest(t *testing.T) {
+	store := &fakeStore{traces: []evidencevo.NormalizedTrace{queryTrace("trace_snapshot_001", "req_snapshot_001")}}
+	service := New(store)
+
+	response, found, err := service.GetSnapshotPreviewByTraceID(context.Background(), "trace_snapshot_001", evidencevo.EvidenceQueryOptions{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !found {
+		t.Fatal("expected snapshot preview to be found")
+	}
+	if response.TraceID != "trace_snapshot_001" || response.RequestID != "req_snapshot_001" {
+		t.Fatalf("unexpected identity: %+v", response)
+	}
+	if response.SnapshotRef.Mode != "preview" || response.SnapshotRef.URI != "" {
+		t.Fatalf("preview must not expose a persisted object storage uri: %+v", response.SnapshotRef)
+	}
+	if response.Manifest.ArtifactCount != 3 || response.Manifest.ClaimCount != 1 || response.Manifest.EvidenceRefCount != 1 || response.Manifest.BusinessRefCount != 1 {
+		t.Fatalf("unexpected manifest counts: %+v", response.Manifest)
+	}
+	if response.Manifest.ComplianceStatus != "preview/non-production compliance" || response.Manifest.DLPClassification != "metadata-only" {
+		t.Fatalf("unexpected governance fields: %+v", response.Manifest)
+	}
+	if !strings.HasPrefix(response.Manifest.ArtifactHash, "sha256:") || !strings.HasPrefix(response.Manifest.ManifestHash, "sha256:") {
+		t.Fatalf("expected sha256 hashes in manifest: %+v", response.Manifest)
+	}
+	if response.VisibilitySummary.HiddenRefCount != 1 || response.VisibilitySummary.AuthorizedRefCount != 2 {
+		t.Fatalf("unexpected visibility summary: %+v", response.VisibilitySummary)
+	}
+}
+
 func TestGetEvidenceChainByTraceIDNotFound(t *testing.T) {
 	service := New(&fakeStore{})
 

--- a/bkn-trace/agent-observability/src/domain/valueobject/evidencevo/evidence.go
+++ b/bkn-trace/agent-observability/src/domain/valueobject/evidencevo/evidence.go
@@ -120,6 +120,41 @@ type EvidenceNodeResponse struct {
 	Data          map[string]any `json:"data"`
 }
 
+type SnapshotPreviewResponse struct {
+	TraceID           string            `json:"trace_id"`
+	RequestID         string            `json:"bkn.request.id"`
+	Partial           bool              `json:"partial"`
+	PartialReasons    []string          `json:"partial_reason"`
+	VisibilitySummary VisibilitySummary `json:"visibility_summary"`
+	SnapshotRef       SnapshotRef       `json:"snapshot_ref"`
+	Manifest          SnapshotManifest  `json:"manifest"`
+}
+
+type SnapshotRef struct {
+	SnapshotID string `json:"snapshot_id"`
+	Mode       string `json:"mode"`
+	URI        string `json:"uri,omitempty"`
+}
+
+type SnapshotManifest struct {
+	SchemaVersion     string            `json:"schema_version"`
+	Producer          string            `json:"producer"`
+	TraceID           string            `json:"trace_id"`
+	RequestID         string            `json:"bkn.request.id"`
+	ArtifactCount     int               `json:"artifact_count"`
+	ClaimCount        int               `json:"claim_count"`
+	EvidenceRefCount  int               `json:"evidence_ref_count"`
+	BusinessRefCount  int               `json:"business_ref_count"`
+	VisibilitySummary VisibilitySummary `json:"visibility_summary"`
+	ComplianceStatus  string            `json:"compliance_status"`
+	DLPClassification string            `json:"dlp_classification"`
+	RetentionPolicy   string            `json:"retention_policy"`
+	LegalHold         string            `json:"legal_hold"`
+	SignatureStatus   string            `json:"signature_status"`
+	ArtifactHash      string            `json:"artifact_hash"`
+	ManifestHash      string            `json:"manifest_hash"`
+}
+
 type BusinessGraphData struct {
 	Nodes []BusinessGraphNode `json:"nodes"`
 	Edges []BusinessGraphEdge `json:"edges"`

--- a/bkn-trace/agent-observability/src/driveradapter/api/httphandler/evidence_handler.go
+++ b/bkn-trace/agent-observability/src/driveradapter/api/httphandler/evidence_handler.go
@@ -158,6 +158,10 @@ func (h *EvidenceHandler) GetTraceSubresource(w http.ResponseWriter, r *http.Req
 		h.GetBusinessGraphByTraceID(w, r)
 		return
 	}
+	if strings.HasSuffix(r.URL.Path, "/snapshot-preview") {
+		h.GetSnapshotPreviewByTraceID(w, r)
+		return
+	}
 	writeJSON(w, http.StatusNotFound, rdto.ErrorResponse{
 		Code:    "NOT_FOUND",
 		Message: "trace subresource not found",
@@ -267,6 +271,116 @@ func (h *EvidenceHandler) GetEvidenceChainByRequestID(w http.ResponseWriter, r *
 		writeJSON(w, http.StatusNotFound, rdto.ErrorResponse{
 			Code:    "NOT_FOUND",
 			Message: "evidence chain not found",
+		})
+		return
+	}
+
+	writeJSON(w, http.StatusOK, response)
+}
+
+// GetSnapshotPreviewByTraceID godoc
+// @Summary Get evidence snapshot preview by trace ID
+// @Description Returns a metadata-only governed snapshot manifest preview without creating or exposing object storage locations.
+// @Tags evidence
+// @Produce json
+// @Param trace_id path string true "Trace ID"
+// @Param limit query int false "Maximum evidence trace batches to read, 1..1000"
+// @Success 200 {object} map[string]interface{}
+// @Failure 400 {object} rdto.ErrorResponse
+// @Failure 404 {object} rdto.ErrorResponse
+// @Failure 405 {object} rdto.ErrorResponse
+// @Failure 500 {object} rdto.ErrorResponse
+// @Router /api/agent-observability/v1/traces/{trace_id}/snapshot-preview [get]
+func (h *EvidenceHandler) GetSnapshotPreviewByTraceID(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		writeJSON(w, http.StatusMethodNotAllowed, rdto.ErrorResponse{
+			Code:    "METHOD_NOT_ALLOWED",
+			Message: "only GET is supported",
+		})
+		return
+	}
+
+	traceID := traceIDFromSnapshotPreviewPath(r.URL.Path)
+	if traceID == "" {
+		writeJSON(w, http.StatusBadRequest, rdto.ErrorResponse{
+			Code:    "INVALID_ARGUMENT",
+			Message: "trace_id is required",
+		})
+		return
+	}
+
+	options, ok := evidenceQueryOptionsFromRequest(w, r)
+	if !ok {
+		return
+	}
+
+	response, found, err := h.evidenceService.GetSnapshotPreviewByTraceID(r.Context(), traceID, options)
+	if err != nil {
+		writeJSON(w, http.StatusInternalServerError, rdto.ErrorResponse{
+			Code:    "QUERY_FAILED",
+			Message: "failed to query snapshot preview",
+		})
+		return
+	}
+	if !found {
+		writeJSON(w, http.StatusNotFound, rdto.ErrorResponse{
+			Code:    "NOT_FOUND",
+			Message: "snapshot preview not found",
+		})
+		return
+	}
+
+	writeJSON(w, http.StatusOK, response)
+}
+
+// GetSnapshotPreviewByRequestID godoc
+// @Summary Get evidence snapshot preview by BKN request ID
+// @Description Returns a metadata-only governed snapshot manifest preview without creating or exposing object storage locations.
+// @Tags evidence
+// @Produce json
+// @Param request_id query string true "BKN request ID"
+// @Param limit query int false "Maximum evidence trace batches to read, 1..1000"
+// @Success 200 {object} map[string]interface{}
+// @Failure 400 {object} rdto.ErrorResponse
+// @Failure 404 {object} rdto.ErrorResponse
+// @Failure 405 {object} rdto.ErrorResponse
+// @Failure 500 {object} rdto.ErrorResponse
+// @Router /api/agent-observability/v1/traces/by-request/snapshot-preview [get]
+func (h *EvidenceHandler) GetSnapshotPreviewByRequestID(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		writeJSON(w, http.StatusMethodNotAllowed, rdto.ErrorResponse{
+			Code:    "METHOD_NOT_ALLOWED",
+			Message: "only GET is supported",
+		})
+		return
+	}
+
+	requestID := strings.TrimSpace(r.URL.Query().Get("request_id"))
+	if requestID == "" {
+		writeJSON(w, http.StatusBadRequest, rdto.ErrorResponse{
+			Code:    "INVALID_ARGUMENT",
+			Message: "request_id is required",
+		})
+		return
+	}
+
+	options, ok := evidenceQueryOptionsFromRequest(w, r)
+	if !ok {
+		return
+	}
+
+	response, found, err := h.evidenceService.GetSnapshotPreviewByRequestID(r.Context(), requestID, options)
+	if err != nil {
+		writeJSON(w, http.StatusInternalServerError, rdto.ErrorResponse{
+			Code:    "QUERY_FAILED",
+			Message: "failed to query snapshot preview",
+		})
+		return
+	}
+	if !found {
+		writeJSON(w, http.StatusNotFound, rdto.ErrorResponse{
+			Code:    "NOT_FOUND",
+			Message: "snapshot preview not found",
 		})
 		return
 	}
@@ -450,6 +564,20 @@ func evidenceQueryOptionsFromRequest(w http.ResponseWriter, r *http.Request) (ev
 func traceIDFromBusinessGraphPath(path string) string {
 	const prefix = "/api/agent-observability/v1/traces/"
 	const suffix = "/business-graph"
+	if !strings.HasPrefix(path, prefix) || !strings.HasSuffix(path, suffix) {
+		return ""
+	}
+	traceID := strings.TrimSuffix(strings.TrimPrefix(path, prefix), suffix)
+	traceID = strings.Trim(traceID, "/")
+	if strings.Contains(traceID, "/") {
+		return ""
+	}
+	return strings.TrimSpace(traceID)
+}
+
+func traceIDFromSnapshotPreviewPath(path string) string {
+	const prefix = "/api/agent-observability/v1/traces/"
+	const suffix = "/snapshot-preview"
 	if !strings.HasPrefix(path, prefix) || !strings.HasSuffix(path, suffix) {
 		return ""
 	}

--- a/bkn-trace/agent-observability/src/driveradapter/api/httphandler/evidence_handler_test.go
+++ b/bkn-trace/agent-observability/src/driveradapter/api/httphandler/evidence_handler_test.go
@@ -209,6 +209,51 @@ func TestEvidenceHandlerReturnsBusinessGraphByRequest(t *testing.T) {
 	}
 }
 
+func TestEvidenceHandlerReturnsSnapshotPreviewByTraceWithoutStorageURI(t *testing.T) {
+	store := evidencestore.New()
+	handler := NewEvidenceHandler(evidencesvc.New(store))
+	ingestReq := httptest.NewRequest(http.MethodPost, "/api/agent-observability/v1/evidence/events", strings.NewReader(validHandlerBusinessBatch()))
+	ingestRec := httptest.NewRecorder()
+	handler.IngestEvidenceEvents(ingestRec, ingestReq)
+	if ingestRec.Code != http.StatusAccepted {
+		t.Fatalf("expected ingest 202, got %d: %s", ingestRec.Code, ingestRec.Body.String())
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/api/agent-observability/v1/traces/9c0d0000000000000000000000000002/snapshot-preview", nil)
+	rec := httptest.NewRecorder()
+	handler.GetTraceSubresource(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+	body := rec.Body.String()
+	if !strings.Contains(body, `"mode":"preview"`) || !strings.Contains(body, `"manifest_hash":"sha256:`) {
+		t.Fatalf("expected snapshot preview manifest in body: %s", body)
+	}
+	if strings.Contains(body, `"uri"`) || strings.Contains(body, "s3://") || strings.Contains(body, "http://") || strings.Contains(body, "https://") {
+		t.Fatalf("snapshot preview must not expose object storage uri or bare urls: %s", body)
+	}
+}
+
+func TestEvidenceHandlerReturnsSnapshotPreviewByRequest(t *testing.T) {
+	store := evidencestore.New()
+	handler := NewEvidenceHandler(evidencesvc.New(store))
+	ingestReq := httptest.NewRequest(http.MethodPost, "/api/agent-observability/v1/evidence/events", strings.NewReader(validHandlerBusinessBatch()))
+	ingestRec := httptest.NewRecorder()
+	handler.IngestEvidenceEvents(ingestRec, ingestReq)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/agent-observability/v1/traces/by-request/snapshot-preview?request_id=req_handler_002", nil)
+	rec := httptest.NewRecorder()
+	handler.GetSnapshotPreviewByRequestID(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+	if !strings.Contains(rec.Body.String(), `"bkn.request.id":"req_handler_002"`) || !strings.Contains(rec.Body.String(), `"snapshot_ref"`) {
+		t.Fatalf("unexpected body: %s", rec.Body.String())
+	}
+}
+
 func TestEvidenceHandlerReturnsEvidenceNodeByTrace(t *testing.T) {
 	store := evidencestore.New()
 	handler := NewEvidenceHandler(evidencesvc.New(store))


### PR DESCRIPTION
## Summary

- Add metadata-only BKN Trace snapshot preview responses for trace and request scopes.
- Expose `GET /api/agent-observability/v1/traces/{trace_id}/snapshot-preview` and `GET /api/agent-observability/v1/traces/by-request/snapshot-preview`.
- Return governed manifest hashes/counts/visibility summary without creating or exposing object storage URIs.
- Regenerate Swagger docs for the new endpoints.

## Verification

- `env GOCACHE=/tmp/openbkn-go-cache go test ./...`
- `env GOCACHE=/tmp/openbkn-go-cache go vet ./...`
- `git diff --check`
- `go run github.com/swaggo/swag/cmd/swag init -g main.go -o docs/swagger --parseDependency --parseInternal`

Note: Swagger generation completed and updated docs; `swag` emitted Go 1.26 stdlib constant parsing warnings, but exited successfully.
