### PR TITLE
feat(bkn-trace): separate unauthorized evidence refs

### DIFF
--- a/bkn-trace/agent-observability/README.md
+++ b/bkn-trace/agent-observability/README.md
@@ -102,7 +102,7 @@ helm upgrade --install agent-observability charts/agent-observability \
 
 启用后，写入方需要携带 `Authorization: Bearer <strong-token>` 或 `X-BKN-Trace-Ingest-Token: <strong-token>`。未配置 `BKN_TRACE_EVIDENCE_INGEST_TOKEN` 时保持当前兼容行为，依赖平台网关/网络边界保护。
 
-当前阶段的 Evidence Chain 查询只依据事件生产方声明的 `visibility` 做响应过滤，不按调用者身份做细粒度可见性裁决。resolver-backed authorization、按账号/租户的 evidence ref 授权与审计将在后续持久化 evidence index 阶段接入。
+当前阶段的 Evidence Chain 查询依据事件生产方或 resolver 声明的 `visibility` 做响应过滤，并区分 `redacted`、`hidden`、`omitted`、`unresolved`、`unauthorized` 统计。`unauthorized` 引用只进入汇总和 `partial_reason[]`，不会展开 `ref_id`、`policy_decision_ref` 或其他节点详情。按调用者身份实时裁决、授权审计和 resolver-backed 节点详情补全仍属于后续阶段。
 
 Evidence Chain 查询返回稳定 envelope：
 
@@ -117,7 +117,8 @@ Evidence Chain 查询返回稳定 envelope：
     "redacted_ref_count": 0,
     "hidden_ref_count": 0,
     "omitted_ref_count": 0,
-    "unresolved_ref_count": 0
+    "unresolved_ref_count": 0,
+    "unauthorized_ref_count": 0
   },
   "page": {
     "next_cursor": null,
@@ -179,7 +180,7 @@ Business Graph 查询返回从 `business.refs.resolved` 派生的业务语义图
 }
 ```
 
-Business Graph 当前只消费已进入 BKN Trace 的 `business_refs`，并复用 `visibility` 做响应过滤。真实 BKN / Vega / Metric / Action resolver、按账号/租户的授权裁决和 resolver-backed 节点详情补全属于后续阶段。
+Business Graph 当前只消费已进入 BKN Trace 的 `business_refs`，并复用 `visibility` 做响应过滤。`unresolved` 与 `unauthorized` 会分别进入 `visibility_summary` 和 `partial_reason[]`，不会生成业务节点或边。真实 BKN / Vega / Metric / Action resolver、按账号/租户的实时授权裁决和 resolver-backed 节点详情补全属于后续阶段。
 
 Evidence Node 查询用于打开单个可见节点详情：
 
@@ -196,7 +197,7 @@ evidence_ref:{ref_id}
 business_ref:{ref_id}
 ```
 
-查询必须提供且只能提供一个 scope：`trace_id` 或 `request_id`。当前阶段只返回 `visibility=visible` 的节点；`hidden`、`redacted`、`omitted`、`unresolved` 节点不会通过详情接口展开。真实 BKN / Vega / Metric / Action resolver、按账号/租户的授权裁决和隐藏节点可审计解释属于后续阶段。
+查询必须提供且只能提供一个 scope：`trace_id` 或 `request_id`。当前阶段只返回 `visibility=visible` 的节点；`hidden`、`redacted`、`omitted`、`unresolved`、`unauthorized` 节点不会通过详情接口展开。真实 BKN / Vega / Metric / Action resolver、按账号/租户的实时授权裁决和隐藏节点可审计解释属于后续阶段。
 
 生成 Swagger 文档：
 

--- a/bkn-trace/agent-observability/src/domain/service/evidencesvc/service.go
+++ b/bkn-trace/agent-observability/src/domain/service/evidencesvc/service.go
@@ -71,6 +71,16 @@ var eventTypes = map[string]struct{}{
 	"action.result_recorded":      {},
 }
 
+var visibilityStates = map[string]struct{}{
+	"":             {},
+	"visible":      {},
+	"redacted":     {},
+	"hidden":       {},
+	"omitted":      {},
+	"unresolved":   {},
+	"unauthorized": {},
+}
+
 type Service struct {
 	store ievidencestore.EvidenceStorePort
 }
@@ -259,6 +269,12 @@ func buildEvidenceChain(traces []evidencevo.NormalizedTrace, truncated bool) evi
 	}
 	if truncated {
 		partialReasons["evidence_query_truncated"] = struct{}{}
+	}
+	if response.VisibilitySummary.UnauthorizedRefCount > 0 {
+		partialReasons["evidence_ref_unauthorized"] = struct{}{}
+	}
+	if response.VisibilitySummary.UnresolvedRefCount > 0 {
+		partialReasons["evidence_ref_unresolved"] = struct{}{}
 	}
 
 	response.PartialReasons = sortedKeys(partialReasons)
@@ -486,6 +502,9 @@ func buildBusinessGraph(traces []evidencevo.NormalizedTrace, truncated bool) evi
 	if response.VisibilitySummary.UnresolvedRefCount > 0 {
 		partialReasons["business_ref_unresolved"] = struct{}{}
 	}
+	if response.VisibilitySummary.UnauthorizedRefCount > 0 {
+		partialReasons["business_ref_unauthorized"] = struct{}{}
+	}
 	if len(response.Data.Nodes) == 0 {
 		partialReasons["empty_business_graph"] = struct{}{}
 	}
@@ -543,6 +562,8 @@ func countVisibility(item map[string]any, summary *evidencevo.VisibilitySummary)
 		summary.OmittedRefCount++
 	case "unresolved":
 		summary.UnresolvedRefCount++
+	case "unauthorized":
+		summary.UnauthorizedRefCount++
 	default:
 		summary.OmittedRefCount++
 	}
@@ -765,6 +786,7 @@ func checkClaim(payload map[string]any, base string, normalized *evidencevo.Norm
 	requiredStringField(payload, "claim_hash", base, errors)
 	requiredStringField(payload, "visibility", base, errors)
 	requiredStringField(payload, "version_status", base, errors)
+	checkVisibility(payload, base+".visibility", errors)
 	normalized.ClaimCount++
 	if claimID != "" {
 		normalized.ClaimIDs = append(normalized.ClaimIDs, claimID)
@@ -781,6 +803,13 @@ func checkRefs(payload map[string]any, base string, key string, knownClaims map[
 	refs := arrayField(payload, key)
 	if len(refs) == 0 {
 		add(errors, "BKN_TRACE_REQUIRED_FIELD_MISSING", base+"."+key, key+" must be a non-empty array")
+	}
+	for i, item := range refs {
+		ref, ok := item.(map[string]any)
+		if !ok {
+			continue
+		}
+		checkVisibility(ref, base+"."+key+"["+strconv.Itoa(i)+"].visibility", errors)
 	}
 }
 
@@ -811,6 +840,14 @@ func checkSensitive(value any, path string, errors *evidencevo.ValidationErrors)
 func forbiddenRawKey(key string) bool {
 	_, ok := forbiddenRawKeys[strings.ToLower(key)]
 	return ok
+}
+
+func checkVisibility(payload map[string]any, path string, errors *evidencevo.ValidationErrors) {
+	visibility, _ := stringField(payload, "visibility")
+	if _, ok := visibilityStates[visibility]; ok {
+		return
+	}
+	add(errors, "BKN_TRACE_VISIBILITY_UNSUPPORTED", path, "unsupported visibility state")
 }
 
 func validTraceparent(value string) bool {

--- a/bkn-trace/agent-observability/src/domain/service/evidencesvc/service_test.go
+++ b/bkn-trace/agent-observability/src/domain/service/evidencesvc/service_test.go
@@ -192,6 +192,23 @@ func TestIngestRejectsInvalidTimestamp(t *testing.T) {
 	}
 }
 
+func TestIngestRejectsUnsupportedVisibilityState(t *testing.T) {
+	store := &fakeStore{}
+	service := New(store)
+	body := strings.Replace(validBatch(), `"visibility": "visible"`, `"visibility": "tenant_denied"`, 1)
+
+	_, validationErrors, err := service.Ingest(context.Background(), []byte(body))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !hasValidationCode(validationErrors, "BKN_TRACE_VISIBILITY_UNSUPPORTED") {
+		t.Fatalf("expected unsupported visibility error, got %+v", validationErrors)
+	}
+	if store.calls != 0 {
+		t.Fatalf("invalid batch must not be stored")
+	}
+}
+
 func TestIngestRejectsEmptyEvents(t *testing.T) {
 	store := &fakeStore{}
 	service := New(store)
@@ -309,6 +326,28 @@ func TestGetEvidenceChainMarksQueryTruncated(t *testing.T) {
 	}
 }
 
+func TestGetEvidenceChainSeparatesUnauthorizedRefsWithoutLeakingDetails(t *testing.T) {
+	store := &fakeStore{traces: []evidencevo.NormalizedTrace{evidenceChainTraceWithUnauthorizedRef("trace_chain_authz", "req_chain_authz")}}
+	service := New(store)
+
+	response, found, err := service.GetEvidenceChainByTraceID(context.Background(), "trace_chain_authz", evidencevo.EvidenceQueryOptions{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !found {
+		t.Fatal("expected evidence chain to be found")
+	}
+	if !response.Partial || !contains(response.PartialReasons, "evidence_ref_unauthorized") {
+		t.Fatalf("expected unauthorized partial reason, got: %+v", response)
+	}
+	if response.VisibilitySummary.UnauthorizedRefCount != 1 || response.VisibilitySummary.AuthorizedRefCount != 2 {
+		t.Fatalf("expected distinct authorized/unauthorized counts, got %+v", response.VisibilitySummary)
+	}
+	if len(response.Data.EvidenceRefs) != 1 || response.Data.EvidenceRefs[0]["ref_id"] != "row:visible" {
+		t.Fatalf("unauthorized evidence ref details must not leak: %+v", response.Data.EvidenceRefs)
+	}
+}
+
 func TestGetBusinessGraphByTraceIDReturnsClaimAndBusinessNodes(t *testing.T) {
 	store := &fakeStore{traces: []evidencevo.NormalizedTrace{queryTrace("trace_graph_001", "req_graph_001")}}
 	service := New(store)
@@ -359,6 +398,28 @@ func TestGetBusinessGraphByRequestIDHandlesHiddenAndUnresolvedRefs(t *testing.T)
 	}
 	if len(response.Data.Nodes) != 2 {
 		t.Fatalf("hidden/unresolved refs must not leak as graph nodes: %+v", response.Data.Nodes)
+	}
+}
+
+func TestGetBusinessGraphSeparatesUnauthorizedAndUnresolvedRefs(t *testing.T) {
+	store := &fakeStore{traces: []evidencevo.NormalizedTrace{businessGraphTraceWithUnauthorizedAndUnresolvedRefs("trace_graph_authz", "req_graph_authz")}}
+	service := New(store)
+
+	response, found, err := service.GetBusinessGraphByTraceID(context.Background(), "trace_graph_authz", evidencevo.EvidenceQueryOptions{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !found {
+		t.Fatal("expected business graph to be found")
+	}
+	if !response.Partial || !contains(response.PartialReasons, "business_ref_unauthorized") || !contains(response.PartialReasons, "business_ref_unresolved") {
+		t.Fatalf("expected unauthorized and unresolved partial reasons, got: %+v", response)
+	}
+	if response.VisibilitySummary.UnauthorizedRefCount != 1 || response.VisibilitySummary.UnresolvedRefCount != 1 {
+		t.Fatalf("expected distinct unauthorized/unresolved counts, got %+v", response.VisibilitySummary)
+	}
+	if response.Page.NodeCount != 2 || response.Page.EdgeCount != 1 {
+		t.Fatalf("unauthorized/unresolved refs must not leak as graph nodes or edges: page=%+v data=%+v", response.Page, response.Data)
 	}
 }
 
@@ -582,12 +643,31 @@ func queryTrace(traceID, requestID string) evidencevo.NormalizedTrace {
 	}
 }
 
+func evidenceChainTraceWithUnauthorizedRef(traceID, requestID string) evidencevo.NormalizedTrace {
+	trace := queryTrace(traceID, requestID)
+	trace.Events[1].Payload["evidence_refs"] = []any{
+		map[string]any{"ref_id": "row:visible", "ref_type": "row_ref", "visibility": "visible"},
+		map[string]any{"ref_id": "row:unauthorized", "ref_type": "row_ref", "visibility": "unauthorized", "policy_decision_ref": "policy:deny:2", "redaction_reason": "row_scope_denied"},
+	}
+	return trace
+}
+
 func businessGraphTraceWithGovernance(traceID, requestID string) evidencevo.NormalizedTrace {
 	trace := queryTrace(traceID, requestID)
 	trace.Events[2].Payload["business_refs"] = []any{
 		map[string]any{"ref_id": "object:customer", "ref_type": "object", "visibility": "visible", "version_status": "versioned"},
 		map[string]any{"ref_id": "object:hidden", "ref_type": "object", "visibility": "hidden"},
 		map[string]any{"ref_id": "object:deleted", "ref_type": "object", "visibility": "unresolved"},
+	}
+	return trace
+}
+
+func businessGraphTraceWithUnauthorizedAndUnresolvedRefs(traceID, requestID string) evidencevo.NormalizedTrace {
+	trace := queryTrace(traceID, requestID)
+	trace.Events[2].Payload["business_refs"] = []any{
+		map[string]any{"ref_id": "object:customer", "ref_type": "object", "visibility": "visible", "version_status": "versioned"},
+		map[string]any{"ref_id": "object:unauthorized", "ref_type": "object", "visibility": "unauthorized", "policy_decision_ref": "policy:deny:1", "redaction_reason": "tenant_scope_denied"},
+		map[string]any{"ref_id": "object:unresolved", "ref_type": "object", "visibility": "unresolved", "failure_status": "resolver_not_found"},
 	}
 	return trace
 }

--- a/bkn-trace/agent-observability/src/domain/valueobject/evidencevo/evidence.go
+++ b/bkn-trace/agent-observability/src/domain/valueobject/evidencevo/evidence.go
@@ -79,11 +79,12 @@ type EvidenceChainResponse struct {
 }
 
 type VisibilitySummary struct {
-	AuthorizedRefCount int `json:"authorized_ref_count"`
-	RedactedRefCount   int `json:"redacted_ref_count"`
-	HiddenRefCount     int `json:"hidden_ref_count"`
-	OmittedRefCount    int `json:"omitted_ref_count"`
-	UnresolvedRefCount int `json:"unresolved_ref_count"`
+	AuthorizedRefCount   int `json:"authorized_ref_count"`
+	RedactedRefCount     int `json:"redacted_ref_count"`
+	HiddenRefCount       int `json:"hidden_ref_count"`
+	OmittedRefCount      int `json:"omitted_ref_count"`
+	UnresolvedRefCount   int `json:"unresolved_ref_count"`
+	UnauthorizedRefCount int `json:"unauthorized_ref_count"`
 }
 
 type EvidencePage struct {

--- a/bkn-trace/agent-observability/src/driveradapter/api/httphandler/evidence_handler_test.go
+++ b/bkn-trace/agent-observability/src/driveradapter/api/httphandler/evidence_handler_test.go
@@ -254,6 +254,32 @@ func TestEvidenceHandlerReturnsSnapshotPreviewByRequest(t *testing.T) {
 	}
 }
 
+func TestEvidenceHandlerReportsUnauthorizedRefsWithoutLeakingDetails(t *testing.T) {
+	store := evidencestore.New()
+	handler := NewEvidenceHandler(evidencesvc.New(store))
+	ingestReq := httptest.NewRequest(http.MethodPost, "/api/agent-observability/v1/evidence/events", strings.NewReader(unauthorizedHandlerBatch()))
+	ingestRec := httptest.NewRecorder()
+	handler.IngestEvidenceEvents(ingestRec, ingestReq)
+	if ingestRec.Code != http.StatusAccepted {
+		t.Fatalf("expected ingest 202, got %d: %s", ingestRec.Code, ingestRec.Body.String())
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/api/agent-observability/v1/traces/9c0d0000000000000000000000000003/evidence-chain", nil)
+	rec := httptest.NewRecorder()
+	handler.GetTraceSubresource(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+	body := rec.Body.String()
+	if !strings.Contains(body, `"unauthorized_ref_count":1`) || !strings.Contains(body, `"evidence_ref_unauthorized"`) {
+		t.Fatalf("expected unauthorized summary and partial reason: %s", body)
+	}
+	if strings.Contains(body, "row:unauthorized") || strings.Contains(body, "policy:deny:handler") {
+		t.Fatalf("unauthorized ref detail must not leak: %s", body)
+	}
+}
+
 func TestEvidenceHandlerReturnsEvidenceNodeByTrace(t *testing.T) {
 	store := evidencestore.New()
 	handler := NewEvidenceHandler(evidencesvc.New(store))
@@ -398,6 +424,70 @@ func validHandlerBusinessBatch() string {
             "label": "Customer",
             "visibility": "visible",
             "version_status": "versioned"
+          }
+        ]
+      }
+    }
+  ]
+}`
+}
+
+func unauthorizedHandlerBatch() string {
+	return `{
+  "bkn.trace.schema.version": "2.0.0",
+  "trace": {
+    "trace_id": "9c0d0000000000000000000000000003",
+    "bkn.request.id": "req_handler_003",
+    "traceparent": "00-9c0d0000000000000000000000000003-2f12000000000003-01",
+    "business_domain": "bd_demo",
+    "bkn.account.id": "acct_demo",
+    "bkn.account.type": "app"
+  },
+  "events": [
+    {
+      "event_id": "evt_claim_authz",
+      "event_type": "claim.created",
+      "bkn.trace.schema.version": "2.0.0",
+      "observed_at": "2026-07-22T04:00:00.000000000Z",
+      "emitted_at": "2026-07-22T04:00:00.001000000Z",
+      "producer_module": "third-party-agent",
+      "trace_id": "9c0d0000000000000000000000000003",
+      "span_id": "2f12000000000003",
+      "bkn.request.id": "req_handler_003",
+      "bkn.operation.name": "agent.answer",
+      "payload": {
+        "claim_id": "claim_handler_authz",
+        "claim_type": "answer",
+        "claim_hash": "sha256:claim-authz",
+        "visibility": "visible",
+        "version_status": "versioned"
+      }
+    },
+    {
+      "event_id": "evt_evidence_authz",
+      "event_type": "evidence.refs.created",
+      "bkn.trace.schema.version": "2.0.0",
+      "observed_at": "2026-07-22T04:00:00.002000000Z",
+      "emitted_at": "2026-07-22T04:00:00.003000000Z",
+      "producer_module": "bkn-trace",
+      "trace_id": "9c0d0000000000000000000000000003",
+      "span_id": "2f12000000000003",
+      "bkn.request.id": "req_handler_003",
+      "bkn.operation.name": "bkn_trace.resolve_evidence_refs",
+      "payload": {
+        "claim_id": "claim_handler_authz",
+        "evidence_refs": [
+          {
+            "ref_id": "row:visible",
+            "ref_type": "row_ref",
+            "visibility": "visible"
+          },
+          {
+            "ref_id": "row:unauthorized",
+            "ref_type": "row_ref",
+            "visibility": "unauthorized",
+            "policy_decision_ref": "policy:deny:handler",
+            "redaction_reason": "row_scope_denied"
           }
         ]
       }


### PR DESCRIPTION
## Summary

- Add `unauthorized_ref_count` to BKN Trace visibility summaries.
- Keep `visibility=unauthorized` refs out of evidence-chain details, business graph nodes/edges, and evidence-node expansion.
- Add explicit `evidence_ref_unauthorized`, `evidence_ref_unresolved`, and `business_ref_unauthorized` partial reasons.
- Validate BKN Trace evidence visibility states so unsupported resolver/governance states fail fast.
- Update agent-observability README with current governance-state behavior.

## Verification

- `env GOCACHE=/tmp/openbkn-go-cache go test ./...`
- `env GOCACHE=/tmp/openbkn-go-cache go vet ./...`
- `git diff --check`

## Notes

- Swagger generation was checked, but this branch does not change route annotations. The local generator still requires additional `swag` CLI go.sum entries (`github.com/ghodss/yaml`, `github.com/urfave/cli/v2`), so no generated Swagger files are included.
