### PR TITLE
fix(vega): make task reference enrichment resilient

### DIFF
--- a/adp/vega/vega-backend/server/logics/build_task/build_task_service.go
+++ b/adp/vega/vega-backend/server/logics/build_task/build_task_service.go
@@ -414,16 +414,12 @@ func (bts *buildTaskService) GetByID(ctx context.Context, id string) (*interface
 		return nil, rest.NewHTTPError(ctx, http.StatusNotFound, verrors.VegaBackend_BuildTask_NotFound)
 	}
 	if err := bts.populateBuildTaskReferences(ctx, []*interfaces.BuildTask{buildTask}); err != nil {
-		span.SetStatus(codes.Error, "Populate build task references failed")
-		return nil, rest.NewHTTPError(ctx, http.StatusInternalServerError, verrors.VegaBackend_BuildTask_InternalError_GetFailed).
-			WithErrorDetails(err.Error())
+		logger.Warnf("Failed to populate build task references: %v", err)
 	}
 
 	accountInfos := []*interfaces.AccountInfo{&buildTask.Creator}
 	if err := bts.ums.GetAccountNames(ctx, accountInfos); err != nil {
-		span.SetStatus(codes.Error, "GetAccountNames error")
-		return nil, rest.NewHTTPError(ctx, http.StatusInternalServerError,
-			verrors.VegaBackend_BuildTask_InternalError_GetAccountNamesFailed).WithErrorDetails(err.Error())
+		logger.Warnf("Failed to populate build task account names: %v", err)
 	}
 
 	buildTask.IndexHealth = computeIndexHealth(buildTask)
@@ -485,22 +481,25 @@ func (bts *buildTaskService) populateBuildTaskReferences(ctx context.Context, bu
 		}
 	}
 
+	var referenceErrors []error
+	resourcesByID := make(map[string]*interfaces.Resource, len(resourceIDs))
 	resources, err := bts.rs.InternalGetByIDs(ctx, resourceIDs)
 	if err != nil {
-		return err
-	}
-	resourcesByID := make(map[string]*interfaces.Resource, len(resources))
-	for _, resource := range resources {
-		resourcesByID[resource.ID] = resource
+		referenceErrors = append(referenceErrors, err)
+	} else {
+		for _, resource := range resources {
+			resourcesByID[resource.ID] = resource
+		}
 	}
 
+	catalogsByID := make(map[string]*interfaces.Catalog, len(catalogIDs))
 	catalogs, err := bts.cs.InternalGetByIDs(ctx, catalogIDs)
 	if err != nil {
-		return err
-	}
-	catalogsByID := make(map[string]*interfaces.Catalog, len(catalogs))
-	for _, catalog := range catalogs {
-		catalogsByID[catalog.ID] = catalog
+		referenceErrors = append(referenceErrors, err)
+	} else {
+		for _, catalog := range catalogs {
+			catalogsByID[catalog.ID] = catalog
+		}
 	}
 
 	for _, buildTask := range buildTasks {
@@ -511,7 +510,7 @@ func (bts *buildTaskService) populateBuildTaskReferences(ctx context.Context, bu
 			buildTask.CatalogName = catalog.Name
 		}
 	}
-	return nil
+	return errors.Join(referenceErrors...)
 }
 
 func (bts *buildTaskService) InternalGetStatus(ctx context.Context, id string) (string, error) {
@@ -587,9 +586,7 @@ func (bts *buildTaskService) GetByResourceID(ctx context.Context, resourceID str
 	if buildTask != nil {
 		accountInfos := []*interfaces.AccountInfo{&buildTask.Creator}
 		if err := bts.ums.GetAccountNames(ctx, accountInfos); err != nil {
-			span.SetStatus(codes.Error, "GetAccountNames error")
-			return nil, rest.NewHTTPError(ctx, http.StatusInternalServerError,
-				verrors.VegaBackend_BuildTask_InternalError_GetAccountNamesFailed).WithErrorDetails(err.Error())
+			logger.Warnf("Failed to populate build task account names: %v", err)
 		}
 		buildTask.IndexHealth = computeIndexHealth(buildTask)
 	}
@@ -610,9 +607,7 @@ func (bts *buildTaskService) List(ctx context.Context, params interfaces.BuildTa
 			WithErrorDetails(err.Error())
 	}
 	if err := bts.populateBuildTaskReferences(ctx, buildTasks); err != nil {
-		span.SetStatus(codes.Error, "Populate build task references failed")
-		return nil, 0, rest.NewHTTPError(ctx, http.StatusInternalServerError, verrors.VegaBackend_BuildTask_InternalError_GetFailed).
-			WithErrorDetails(err.Error())
+		logger.Warnf("Failed to populate build task references: %v", err)
 	}
 
 	accountInfos := make([]*interfaces.AccountInfo, 0, len(buildTasks))
@@ -621,9 +616,7 @@ func (bts *buildTaskService) List(ctx context.Context, params interfaces.BuildTa
 		bt.IndexHealth = computeIndexHealth(bt)
 	}
 	if err := bts.ums.GetAccountNames(ctx, accountInfos); err != nil {
-		span.SetStatus(codes.Error, "GetAccountNames error")
-		return nil, 0, rest.NewHTTPError(ctx, http.StatusInternalServerError,
-			verrors.VegaBackend_BuildTask_InternalError_GetAccountNamesFailed).WithErrorDetails(err.Error())
+		logger.Warnf("Failed to populate build task account names: %v", err)
 	}
 
 	span.SetStatus(codes.Ok, "")

--- a/adp/vega/vega-backend/server/logics/build_task/build_task_service.go
+++ b/adp/vega/vega-backend/server/logics/build_task/build_task_service.go
@@ -414,11 +414,13 @@ func (bts *buildTaskService) GetByID(ctx context.Context, id string) (*interface
 		return nil, rest.NewHTTPError(ctx, http.StatusNotFound, verrors.VegaBackend_BuildTask_NotFound)
 	}
 	if err := bts.populateBuildTaskReferences(ctx, []*interfaces.BuildTask{buildTask}); err != nil {
+		span.RecordError(err)
 		logger.Warnf("Failed to populate build task references: %v", err)
 	}
 
 	accountInfos := []*interfaces.AccountInfo{&buildTask.Creator}
 	if err := bts.ums.GetAccountNames(ctx, accountInfos); err != nil {
+		span.RecordError(err)
 		logger.Warnf("Failed to populate build task account names: %v", err)
 	}
 
@@ -586,6 +588,7 @@ func (bts *buildTaskService) GetByResourceID(ctx context.Context, resourceID str
 	if buildTask != nil {
 		accountInfos := []*interfaces.AccountInfo{&buildTask.Creator}
 		if err := bts.ums.GetAccountNames(ctx, accountInfos); err != nil {
+			span.RecordError(err)
 			logger.Warnf("Failed to populate build task account names: %v", err)
 		}
 		buildTask.IndexHealth = computeIndexHealth(buildTask)
@@ -607,6 +610,7 @@ func (bts *buildTaskService) List(ctx context.Context, params interfaces.BuildTa
 			WithErrorDetails(err.Error())
 	}
 	if err := bts.populateBuildTaskReferences(ctx, buildTasks); err != nil {
+		span.RecordError(err)
 		logger.Warnf("Failed to populate build task references: %v", err)
 	}
 
@@ -616,6 +620,7 @@ func (bts *buildTaskService) List(ctx context.Context, params interfaces.BuildTa
 		bt.IndexHealth = computeIndexHealth(bt)
 	}
 	if err := bts.ums.GetAccountNames(ctx, accountInfos); err != nil {
+		span.RecordError(err)
 		logger.Warnf("Failed to populate build task account names: %v", err)
 	}
 

--- a/adp/vega/vega-backend/server/logics/build_task/build_task_service_test.go
+++ b/adp/vega/vega-backend/server/logics/build_task/build_task_service_test.go
@@ -77,6 +77,49 @@ func TestBuildTaskServicePopulatesTaskReferencesForListAndGet(t *testing.T) {
 		assert.Equal(t, "orders", got.ResourceName)
 		assert.Equal(t, "production", got.CatalogName)
 	})
+
+	t.Run("list keeps tasks when reference lookup fails", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		mockBTA := mock_interfaces.NewMockBuildTaskAccess(ctrl)
+		mockCS := mock_interfaces.NewMockCatalogService(ctrl)
+		mockRS := mock_interfaces.NewMockResourceService(ctrl)
+		mockUMS := mock_interfaces.NewMockUserMgmtService(ctrl)
+		service := &buildTaskService{bta: mockBTA, cs: mockCS, rs: mockRS, ums: mockUMS}
+		tasks := []*interfaces.BuildTask{{ID: "task-1", ResourceID: "resource-1", CatalogID: "catalog-1"}}
+
+		mockBTA.EXPECT().List(gomock.Any(), gomock.Any()).Return(tasks, int64(1), nil)
+		mockRS.EXPECT().InternalGetByIDs(gomock.Any(), []string{"resource-1"}).Return(nil, errors.New("resource service down"))
+		mockCS.EXPECT().InternalGetByIDs(gomock.Any(), []string{"catalog-1"}).Return([]*interfaces.Catalog{{ID: "catalog-1", Name: "production"}}, nil)
+		mockUMS.EXPECT().GetAccountNames(gomock.Any(), gomock.Any()).Return(nil)
+
+		got, total, err := service.List(context.Background(), interfaces.BuildTasksQueryParams{})
+
+		require.NoError(t, err)
+		assert.Equal(t, int64(1), total)
+		assert.Equal(t, "task-1", got[0].ID)
+		assert.Empty(t, got[0].ResourceName)
+		assert.Equal(t, "production", got[0].CatalogName)
+	})
+
+	t.Run("get keeps task when account lookup fails", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		mockBTA := mock_interfaces.NewMockBuildTaskAccess(ctrl)
+		mockCS := mock_interfaces.NewMockCatalogService(ctrl)
+		mockRS := mock_interfaces.NewMockResourceService(ctrl)
+		mockUMS := mock_interfaces.NewMockUserMgmtService(ctrl)
+		service := &buildTaskService{bta: mockBTA, cs: mockCS, rs: mockRS, ums: mockUMS}
+		task := &interfaces.BuildTask{ID: "task-2"}
+
+		mockBTA.EXPECT().GetByID(gomock.Any(), "task-2").Return(task, nil)
+		mockRS.EXPECT().InternalGetByIDs(gomock.Any(), []string{}).Return([]*interfaces.Resource{}, nil)
+		mockCS.EXPECT().InternalGetByIDs(gomock.Any(), []string{}).Return([]*interfaces.Catalog{}, nil)
+		mockUMS.EXPECT().GetAccountNames(gomock.Any(), gomock.Any()).Return(errors.New("user service down"))
+
+		got, err := service.GetByID(context.Background(), "task-2")
+
+		require.NoError(t, err)
+		assert.Equal(t, "task-2", got.ID)
+	})
 }
 
 func TestBuildTaskServiceCreateBuildTask(t *testing.T) {

--- a/adp/vega/vega-backend/server/logics/catalog/catalog_service.go
+++ b/adp/vega/vega-backend/server/logics/catalog/catalog_service.go
@@ -311,10 +311,7 @@ func (cs *catalogService) GetByID(ctx context.Context, id string, withSensitiveF
 	accountInfos := []*interfaces.AccountInfo{&catalog.Creator, &catalog.Updater}
 	err = cs.ums.GetAccountNames(ctx, accountInfos)
 	if err != nil {
-		span.SetStatus(codes.Error, "GetAccountNames error")
-
-		return nil, rest.NewHTTPError(ctx, http.StatusInternalServerError,
-			verrors.VegaBackend_Catalog_InternalError_GetAccountNamesFailed).WithErrorDetails(err.Error())
+		logger.Warnf("Failed to populate catalog account names: %v", err)
 	}
 
 	if !withSensitiveFields {
@@ -444,10 +441,7 @@ func (cs *catalogService) GetByIDs(ctx context.Context, ids []string) ([]*interf
 
 	err = cs.ums.GetAccountNames(ctx, accountInfos)
 	if err != nil {
-		span.SetStatus(codes.Error, "GetAccountNames error")
-
-		return nil, rest.NewHTTPError(ctx, http.StatusInternalServerError,
-			verrors.VegaBackend_Catalog_InternalError_GetAccountNamesFailed).WithErrorDetails(err.Error())
+		logger.Warnf("Failed to populate catalog account names: %v", err)
 	}
 
 	span.SetStatus(codes.Ok, "")
@@ -579,10 +573,7 @@ func (cs *catalogService) List(ctx context.Context, params interfaces.CatalogsQu
 
 	err = cs.ums.GetAccountNames(ctx, accountInfos)
 	if err != nil {
-		span.SetStatus(codes.Error, "GetAccountNames error")
-
-		return []*interfaces.Catalog{}, 0, rest.NewHTTPError(ctx, http.StatusInternalServerError,
-			verrors.VegaBackend_Catalog_InternalError_GetFailed).WithErrorDetails(err.Error())
+		logger.Warnf("Failed to populate catalog account names: %v", err)
 	}
 
 	// 移除敏感字段，不返回给前端

--- a/adp/vega/vega-backend/server/logics/catalog/catalog_service.go
+++ b/adp/vega/vega-backend/server/logics/catalog/catalog_service.go
@@ -311,6 +311,7 @@ func (cs *catalogService) GetByID(ctx context.Context, id string, withSensitiveF
 	accountInfos := []*interfaces.AccountInfo{&catalog.Creator, &catalog.Updater}
 	err = cs.ums.GetAccountNames(ctx, accountInfos)
 	if err != nil {
+		span.RecordError(err)
 		logger.Warnf("Failed to populate catalog account names: %v", err)
 	}
 
@@ -441,6 +442,7 @@ func (cs *catalogService) GetByIDs(ctx context.Context, ids []string) ([]*interf
 
 	err = cs.ums.GetAccountNames(ctx, accountInfos)
 	if err != nil {
+		span.RecordError(err)
 		logger.Warnf("Failed to populate catalog account names: %v", err)
 	}
 
@@ -573,6 +575,7 @@ func (cs *catalogService) List(ctx context.Context, params interfaces.CatalogsQu
 
 	err = cs.ums.GetAccountNames(ctx, accountInfos)
 	if err != nil {
+		span.RecordError(err)
 		logger.Warnf("Failed to populate catalog account names: %v", err)
 	}
 

--- a/adp/vega/vega-backend/server/logics/catalog/catalog_service_test.go
+++ b/adp/vega/vega-backend/server/logics/catalog/catalog_service_test.go
@@ -8,6 +8,7 @@ package catalog
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strings"
 	"testing"
@@ -445,7 +446,7 @@ func TestCatalogServiceSetEnabled(t *testing.T) {
 }
 
 func TestCatalogServiceList(t *testing.T) {
-	t.Run("list return all", func(t *testing.T) {
+	t.Run("keeps catalogs when account name lookup fails", func(t *testing.T) {
 		ctrl := gomock.NewController(t)
 		mockCA := mock_interfaces.NewMockCatalogAccess(ctrl)
 		mockPS := mock_interfaces.NewMockPermissionService(ctrl)
@@ -461,7 +462,7 @@ func TestCatalogServiceList(t *testing.T) {
 			}, nil)
 		mockCA.EXPECT().GetByIDs(gomock.Any(), gomock.Any()).Return(catalogs, nil)
 		mockCA.EXPECT().AttachListExtensions(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
-		mockUMS.EXPECT().GetAccountNames(gomock.Any(), gomock.Any()).Return(nil)
+		mockUMS.EXPECT().GetAccountNames(gomock.Any(), gomock.Any()).Return(errors.New("user management unavailable"))
 
 		cs := &catalogService{ca: mockCA, ps: mockPS, ums: mockUMS}
 		result, total, err := cs.List(context.Background(), interfaces.CatalogsQueryParams{

--- a/adp/vega/vega-backend/server/logics/discover_schedule/discover_schedule_service.go
+++ b/adp/vega/vega-backend/server/logics/discover_schedule/discover_schedule_service.go
@@ -123,9 +123,11 @@ func (dss *discoverScheduleService) GetByID(ctx context.Context, id string) (*in
 	}
 	if schedule != nil {
 		if err := dss.populateDiscoverScheduleReferences(ctx, []*interfaces.DiscoverSchedule{schedule}); err != nil {
+			span.RecordError(err)
 			logger.Warnf("Failed to populate discover schedule references: %v", err)
 		}
 		if err := dss.ums.GetAccountNames(ctx, []*interfaces.AccountInfo{&schedule.Creator, &schedule.Updater}); err != nil {
+			span.RecordError(err)
 			logger.Warnf("Failed to populate discover schedule account names: %v", err)
 		}
 	}
@@ -144,6 +146,7 @@ func (dss *discoverScheduleService) List(ctx context.Context, params interfaces.
 			WithErrorDetails(err.Error())
 	}
 	if err := dss.populateDiscoverScheduleReferences(ctx, schedules); err != nil {
+		span.RecordError(err)
 		logger.Warnf("Failed to populate discover schedule references: %v", err)
 	}
 
@@ -152,6 +155,7 @@ func (dss *discoverScheduleService) List(ctx context.Context, params interfaces.
 		accountInfos = append(accountInfos, &s.Creator, &s.Updater)
 	}
 	if err := dss.ums.GetAccountNames(ctx, accountInfos); err != nil {
+		span.RecordError(err)
 		logger.Warnf("Failed to populate discover schedule account names: %v", err)
 	}
 	return schedules, total, nil

--- a/adp/vega/vega-backend/server/logics/discover_schedule/discover_schedule_service.go
+++ b/adp/vega/vega-backend/server/logics/discover_schedule/discover_schedule_service.go
@@ -117,16 +117,16 @@ func (dss *discoverScheduleService) GetByID(ctx context.Context, id string) (*in
 
 	schedule, err := dss.dsa.GetByID(ctx, id)
 	if err != nil {
-		return nil, err
+		span.SetStatus(codes.Error, "Get discover schedule failed")
+		return nil, rest.NewHTTPError(ctx, http.StatusInternalServerError, verrors.VegaBackend_DiscoverSchedule_InternalError_GetFailed).
+			WithErrorDetails(err.Error())
 	}
 	if schedule != nil {
 		if err := dss.populateDiscoverScheduleReferences(ctx, []*interfaces.DiscoverSchedule{schedule}); err != nil {
-			return nil, err
+			logger.Warnf("Failed to populate discover schedule references: %v", err)
 		}
 		if err := dss.ums.GetAccountNames(ctx, []*interfaces.AccountInfo{&schedule.Creator, &schedule.Updater}); err != nil {
-			span.SetStatus(codes.Error, "GetAccountNames error")
-			return nil, rest.NewHTTPError(ctx, http.StatusInternalServerError,
-				verrors.VegaBackend_DiscoverSchedule_InternalError_GetAccountNamesFailed).WithErrorDetails(err.Error())
+			logger.Warnf("Failed to populate discover schedule account names: %v", err)
 		}
 	}
 	return schedule, nil
@@ -139,10 +139,12 @@ func (dss *discoverScheduleService) List(ctx context.Context, params interfaces.
 
 	schedules, total, err := dss.dsa.List(ctx, params)
 	if err != nil {
-		return nil, 0, err
+		span.SetStatus(codes.Error, "List discover schedules failed")
+		return nil, 0, rest.NewHTTPError(ctx, http.StatusInternalServerError, verrors.VegaBackend_DiscoverSchedule_InternalError_GetFailed).
+			WithErrorDetails(err.Error())
 	}
 	if err := dss.populateDiscoverScheduleReferences(ctx, schedules); err != nil {
-		return nil, 0, err
+		logger.Warnf("Failed to populate discover schedule references: %v", err)
 	}
 
 	accountInfos := make([]*interfaces.AccountInfo, 0, len(schedules)*2)
@@ -150,9 +152,7 @@ func (dss *discoverScheduleService) List(ctx context.Context, params interfaces.
 		accountInfos = append(accountInfos, &s.Creator, &s.Updater)
 	}
 	if err := dss.ums.GetAccountNames(ctx, accountInfos); err != nil {
-		span.SetStatus(codes.Error, "GetAccountNames error")
-		return nil, 0, rest.NewHTTPError(ctx, http.StatusInternalServerError,
-			verrors.VegaBackend_DiscoverSchedule_InternalError_GetAccountNamesFailed).WithErrorDetails(err.Error())
+		logger.Warnf("Failed to populate discover schedule account names: %v", err)
 	}
 	return schedules, total, nil
 }

--- a/adp/vega/vega-backend/server/logics/discover_schedule/discover_schedule_service_test.go
+++ b/adp/vega/vega-backend/server/logics/discover_schedule/discover_schedule_service_test.go
@@ -11,10 +11,12 @@ import (
 	"errors"
 	"testing"
 
+	"github.com/openbkn-ai/bkn-comm-go/rest"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
 
+	verrors "vega-backend/errors"
 	"vega-backend/interfaces"
 	vmock "vega-backend/interfaces/mock"
 )
@@ -143,6 +145,18 @@ func TestDiscoverScheduleServiceGetListAndSimpleDelegates(t *testing.T) {
 		assert.Same(t, schedule, got)
 	})
 
+	t.Run("get wraps access error", func(t *testing.T) {
+		service, dsa, _, _ := newTestDiscoverScheduleService(t)
+		dsa.EXPECT().GetByID(gomock.Any(), "schedule-1").Return(nil, errors.New("database unavailable"))
+
+		got, err := service.GetByID(context.Background(), "schedule-1")
+
+		require.Nil(t, got)
+		httpErr, ok := err.(*rest.HTTPError)
+		require.True(t, ok)
+		assert.Equal(t, verrors.VegaBackend_DiscoverSchedule_InternalError_GetFailed, httpErr.BaseError.ErrorCode)
+	})
+
 	t.Run("list enriches all creator and updater accounts", func(t *testing.T) {
 		service, dsa, _, ums := newTestDiscoverScheduleService(t)
 		params := interfaces.DiscoverScheduleQueryParams{CatalogID: "catalog-1"}
@@ -159,6 +173,19 @@ func TestDiscoverScheduleServiceGetListAndSimpleDelegates(t *testing.T) {
 		require.NoError(t, err)
 		assert.Equal(t, int64(2), total)
 		assert.Equal(t, schedules, got)
+	})
+
+	t.Run("list wraps access error", func(t *testing.T) {
+		service, dsa, _, _ := newTestDiscoverScheduleService(t)
+		dsa.EXPECT().List(gomock.Any(), gomock.Any()).Return(nil, int64(0), errors.New("database unavailable"))
+
+		got, total, err := service.List(context.Background(), interfaces.DiscoverScheduleQueryParams{})
+
+		require.Nil(t, got)
+		assert.Zero(t, total)
+		httpErr, ok := err.(*rest.HTTPError)
+		require.True(t, ok)
+		assert.Equal(t, verrors.VegaBackend_DiscoverSchedule_InternalError_GetFailed, httpErr.BaseError.ErrorCode)
 	})
 
 	t.Run("delegates enable disable delete and last run", func(t *testing.T) {
@@ -209,6 +236,37 @@ func TestDiscoverScheduleServicePopulatesCatalogName(t *testing.T) {
 
 		require.NoError(t, err)
 		assert.Equal(t, "目录二", got.CatalogName)
+	})
+
+	t.Run("list keeps schedules when reference lookup fails", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		dsa := vmock.NewMockDiscoverScheduleAccess(ctrl)
+		cs := vmock.NewMockCatalogService(ctrl)
+		ums := vmock.NewMockUserMgmtService(ctrl)
+		service := &discoverScheduleService{dsa: dsa, cs: cs, ums: ums}
+		schedules := []*interfaces.DiscoverSchedule{{ID: "schedule-4", CatalogID: "catalog-3"}}
+
+		dsa.EXPECT().List(gomock.Any(), gomock.Any()).Return(schedules, int64(1), nil)
+		cs.EXPECT().InternalGetByIDs(gomock.Any(), []string{"catalog-3"}).Return(nil, errors.New("catalog service down"))
+		ums.EXPECT().GetAccountNames(gomock.Any(), gomock.Any()).Return(nil)
+
+		got, total, err := service.List(context.Background(), interfaces.DiscoverScheduleQueryParams{})
+
+		require.NoError(t, err)
+		assert.Equal(t, int64(1), total)
+		assert.Equal(t, "schedule-4", got[0].ID)
+		assert.Empty(t, got[0].CatalogName)
+	})
+
+	t.Run("get keeps schedule when account lookup fails", func(t *testing.T) {
+		schedule := &interfaces.DiscoverSchedule{ID: "schedule-5"}
+		dsa.EXPECT().GetByID(gomock.Any(), "schedule-5").Return(schedule, nil)
+		ums.EXPECT().GetAccountNames(gomock.Any(), gomock.Any()).Return(errors.New("user service down"))
+
+		got, err := service.GetByID(context.Background(), "schedule-5")
+
+		require.NoError(t, err)
+		assert.Equal(t, "schedule-5", got.ID)
 	})
 }
 

--- a/adp/vega/vega-backend/server/logics/discover_task/discover_task_service.go
+++ b/adp/vega/vega-backend/server/logics/discover_task/discover_task_service.go
@@ -161,19 +161,19 @@ func (dts *discoverTaskService) GetByID(ctx context.Context, id string) (*interf
 
 	task, err := dts.dta.GetByID(ctx, id)
 	if err != nil {
-		return nil, err
+		span.SetStatus(codes.Error, "Get discover task failed")
+		return nil, rest.NewHTTPError(ctx, http.StatusInternalServerError, verrors.VegaBackend_DiscoverTask_InternalError_GetFailed).
+			WithErrorDetails(err.Error())
 	}
 	if task == nil {
 		span.SetStatus(codes.Error, "Discover task not found")
 		return nil, rest.NewHTTPError(ctx, http.StatusNotFound, verrors.VegaBackend_DiscoverTask_NotFound)
 	}
 	if err := dts.populateDiscoverTaskReferences(ctx, []*interfaces.DiscoverTask{task}); err != nil {
-		return nil, err
+		logger.Warnf("Failed to populate discover task references: %v", err)
 	}
 	if err := dts.ums.GetAccountNames(ctx, []*interfaces.AccountInfo{&task.Creator}); err != nil {
-		span.SetStatus(codes.Error, "GetAccountNames error")
-		return nil, rest.NewHTTPError(ctx, http.StatusInternalServerError,
-			verrors.VegaBackend_DiscoverTask_InternalError_GetAccountNamesFailed).WithErrorDetails(err.Error())
+		logger.Warnf("Failed to populate discover task account names: %v", err)
 	}
 	return task, nil
 }
@@ -196,10 +196,12 @@ func (dts *discoverTaskService) List(ctx context.Context, params interfaces.Disc
 
 	tasks, total, err := dts.dta.List(ctx, params)
 	if err != nil {
-		return nil, 0, err
+		span.SetStatus(codes.Error, "List discover tasks failed")
+		return nil, 0, rest.NewHTTPError(ctx, http.StatusInternalServerError, verrors.VegaBackend_DiscoverTask_InternalError_GetFailed).
+			WithErrorDetails(err.Error())
 	}
 	if err := dts.populateDiscoverTaskReferences(ctx, tasks); err != nil {
-		return nil, 0, err
+		logger.Warnf("Failed to populate discover task references: %v", err)
 	}
 
 	accountInfos := make([]*interfaces.AccountInfo, 0, len(tasks))
@@ -207,9 +209,7 @@ func (dts *discoverTaskService) List(ctx context.Context, params interfaces.Disc
 		accountInfos = append(accountInfos, &t.Creator)
 	}
 	if err := dts.ums.GetAccountNames(ctx, accountInfos); err != nil {
-		span.SetStatus(codes.Error, "GetAccountNames error")
-		return nil, 0, rest.NewHTTPError(ctx, http.StatusInternalServerError,
-			verrors.VegaBackend_DiscoverTask_InternalError_GetAccountNamesFailed).WithErrorDetails(err.Error())
+		logger.Warnf("Failed to populate discover task account names: %v", err)
 	}
 	return tasks, total, nil
 }

--- a/adp/vega/vega-backend/server/logics/discover_task/discover_task_service.go
+++ b/adp/vega/vega-backend/server/logics/discover_task/discover_task_service.go
@@ -170,9 +170,11 @@ func (dts *discoverTaskService) GetByID(ctx context.Context, id string) (*interf
 		return nil, rest.NewHTTPError(ctx, http.StatusNotFound, verrors.VegaBackend_DiscoverTask_NotFound)
 	}
 	if err := dts.populateDiscoverTaskReferences(ctx, []*interfaces.DiscoverTask{task}); err != nil {
+		span.RecordError(err)
 		logger.Warnf("Failed to populate discover task references: %v", err)
 	}
 	if err := dts.ums.GetAccountNames(ctx, []*interfaces.AccountInfo{&task.Creator}); err != nil {
+		span.RecordError(err)
 		logger.Warnf("Failed to populate discover task account names: %v", err)
 	}
 	return task, nil
@@ -201,6 +203,7 @@ func (dts *discoverTaskService) List(ctx context.Context, params interfaces.Disc
 			WithErrorDetails(err.Error())
 	}
 	if err := dts.populateDiscoverTaskReferences(ctx, tasks); err != nil {
+		span.RecordError(err)
 		logger.Warnf("Failed to populate discover task references: %v", err)
 	}
 
@@ -209,6 +212,7 @@ func (dts *discoverTaskService) List(ctx context.Context, params interfaces.Disc
 		accountInfos = append(accountInfos, &t.Creator)
 	}
 	if err := dts.ums.GetAccountNames(ctx, accountInfos); err != nil {
+		span.RecordError(err)
 		logger.Warnf("Failed to populate discover task account names: %v", err)
 	}
 	return tasks, total, nil

--- a/adp/vega/vega-backend/server/logics/discover_task/discover_task_service_test.go
+++ b/adp/vega/vega-backend/server/logics/discover_task/discover_task_service_test.go
@@ -11,10 +11,12 @@ import (
 	"errors"
 	"testing"
 
+	"github.com/openbkn-ai/bkn-comm-go/rest"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
 
+	verrors "vega-backend/errors"
 	"vega-backend/interfaces"
 	vmock "vega-backend/interfaces/mock"
 )
@@ -66,6 +68,18 @@ func TestDiscoverTaskServiceGetAndList(t *testing.T) {
 		assert.Contains(t, err.Error(), "NotFound")
 	})
 
+	t.Run("get wraps access error", func(t *testing.T) {
+		service, dta, _ := newTestDiscoverTaskService(t)
+		dta.EXPECT().GetByID(gomock.Any(), "task-1").Return(nil, errors.New("database unavailable"))
+
+		got, err := service.GetByID(context.Background(), "task-1")
+
+		require.Nil(t, got)
+		httpErr, ok := err.(*rest.HTTPError)
+		require.True(t, ok)
+		assert.Equal(t, verrors.VegaBackend_DiscoverTask_InternalError_GetFailed, httpErr.BaseError.ErrorCode)
+	})
+
 	t.Run("list enriches creators", func(t *testing.T) {
 		service, dta, ums := newTestDiscoverTaskService(t)
 		params := interfaces.DiscoverTaskQueryParams{CatalogID: "catalog-1"}
@@ -91,7 +105,7 @@ func TestDiscoverTaskServiceGetAndList(t *testing.T) {
 		assert.Equal(t, "Bob", got[1].Creator.Name)
 	})
 
-	t.Run("list wraps account lookup error", func(t *testing.T) {
+	t.Run("list keeps tasks when account lookup fails", func(t *testing.T) {
 		service, dta, ums := newTestDiscoverTaskService(t)
 		dta.EXPECT().List(gomock.Any(), gomock.Any()).
 			Return([]*interfaces.DiscoverTask{{ID: "task-1"}}, int64(1), nil)
@@ -99,10 +113,22 @@ func TestDiscoverTaskServiceGetAndList(t *testing.T) {
 
 		got, total, err := service.List(context.Background(), interfaces.DiscoverTaskQueryParams{})
 
-		require.Error(t, err)
-		assert.Nil(t, got)
+		require.NoError(t, err)
+		assert.Equal(t, int64(1), total)
+		assert.Equal(t, "task-1", got[0].ID)
+	})
+
+	t.Run("list wraps access error", func(t *testing.T) {
+		service, dta, _ := newTestDiscoverTaskService(t)
+		dta.EXPECT().List(gomock.Any(), gomock.Any()).Return(nil, int64(0), errors.New("database unavailable"))
+
+		got, total, err := service.List(context.Background(), interfaces.DiscoverTaskQueryParams{})
+
+		require.Nil(t, got)
 		assert.Zero(t, total)
-		assert.Contains(t, err.Error(), "user service down")
+		httpErr, ok := err.(*rest.HTTPError)
+		require.True(t, ok)
+		assert.Equal(t, verrors.VegaBackend_DiscoverTask_InternalError_GetFailed, httpErr.BaseError.ErrorCode)
 	})
 }
 
@@ -140,6 +166,26 @@ func TestDiscoverTaskServicePopulatesCatalogName(t *testing.T) {
 
 		require.NoError(t, err)
 		assert.Equal(t, "目录二", got.CatalogName)
+	})
+
+	t.Run("list keeps tasks when reference lookup fails", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		dta := vmock.NewMockDiscoverTaskAccess(ctrl)
+		cs := vmock.NewMockCatalogService(ctrl)
+		ums := vmock.NewMockUserMgmtService(ctrl)
+		service := &discoverTaskService{dta: dta, cs: cs, ums: ums}
+		tasks := []*interfaces.DiscoverTask{{ID: "task-4", CatalogID: "catalog-3"}}
+
+		dta.EXPECT().List(gomock.Any(), gomock.Any()).Return(tasks, int64(1), nil)
+		cs.EXPECT().InternalGetByIDs(gomock.Any(), []string{"catalog-3"}).Return(nil, errors.New("catalog service down"))
+		ums.EXPECT().GetAccountNames(gomock.Any(), gomock.Any()).Return(nil)
+
+		got, total, err := service.List(context.Background(), interfaces.DiscoverTaskQueryParams{})
+
+		require.NoError(t, err)
+		assert.Equal(t, int64(1), total)
+		assert.Equal(t, "task-4", got[0].ID)
+		assert.Empty(t, got[0].CatalogName)
 	})
 }
 

--- a/adp/vega/vega-backend/server/logics/resource/resource_service.go
+++ b/adp/vega/vega-backend/server/logics/resource/resource_service.go
@@ -356,10 +356,7 @@ func (rs *resourceService) GetByID(ctx context.Context, id string) (*interfaces.
 	accountInfos := []*interfaces.AccountInfo{&resource.Creator, &resource.Updater}
 	err = rs.ums.GetAccountNames(ctx, accountInfos)
 	if err != nil {
-		span.SetStatus(codes.Error, "GetAccountNames error")
-
-		return nil, rest.NewHTTPError(ctx, http.StatusInternalServerError,
-			verrors.VegaBackend_Resource_InternalError_GetAccountNamesFailed).WithErrorDetails(err.Error())
+		logger.Warnf("Failed to populate resource account names: %v", err)
 	}
 
 	span.SetStatus(codes.Ok, "")
@@ -461,10 +458,7 @@ func (rs *resourceService) GetByIDs(ctx context.Context, ids []string) ([]*inter
 
 	err = rs.ums.GetAccountNames(ctx, accountInfos)
 	if err != nil {
-		span.SetStatus(codes.Error, "GetAccountNames error")
-
-		return nil, rest.NewHTTPError(ctx, http.StatusInternalServerError,
-			verrors.VegaBackend_Resource_InternalError_GetAccountNamesFailed).WithErrorDetails(err.Error())
+		logger.Warnf("Failed to populate resource account names: %v", err)
 	}
 
 	span.SetStatus(codes.Ok, "")
@@ -634,10 +628,7 @@ func (rs *resourceService) List(ctx context.Context, params interfaces.Resources
 
 	err = rs.ums.GetAccountNames(ctx, accountInfos)
 	if err != nil {
-		span.SetStatus(codes.Error, "GetAccountNames error")
-
-		return []*interfaces.Resource{}, 0, rest.NewHTTPError(ctx, http.StatusInternalServerError, verrors.VegaBackend_Resource_InternalError_GetFailed).
-			WithErrorDetails(err.Error())
+		logger.Warnf("Failed to populate resource account names: %v", err)
 	}
 
 	span.SetStatus(codes.Ok, "")

--- a/adp/vega/vega-backend/server/logics/resource/resource_service.go
+++ b/adp/vega/vega-backend/server/logics/resource/resource_service.go
@@ -356,6 +356,7 @@ func (rs *resourceService) GetByID(ctx context.Context, id string) (*interfaces.
 	accountInfos := []*interfaces.AccountInfo{&resource.Creator, &resource.Updater}
 	err = rs.ums.GetAccountNames(ctx, accountInfos)
 	if err != nil {
+		span.RecordError(err)
 		logger.Warnf("Failed to populate resource account names: %v", err)
 	}
 
@@ -458,6 +459,7 @@ func (rs *resourceService) GetByIDs(ctx context.Context, ids []string) ([]*inter
 
 	err = rs.ums.GetAccountNames(ctx, accountInfos)
 	if err != nil {
+		span.RecordError(err)
 		logger.Warnf("Failed to populate resource account names: %v", err)
 	}
 
@@ -628,6 +630,7 @@ func (rs *resourceService) List(ctx context.Context, params interfaces.Resources
 
 	err = rs.ums.GetAccountNames(ctx, accountInfos)
 	if err != nil {
+		span.RecordError(err)
 		logger.Warnf("Failed to populate resource account names: %v", err)
 	}
 

--- a/adp/vega/vega-backend/server/logics/resource/resource_service_test.go
+++ b/adp/vega/vega-backend/server/logics/resource/resource_service_test.go
@@ -9,6 +9,7 @@ package resource
 import (
 	"context"
 	"database/sql"
+	"errors"
 	"fmt"
 	"net/http"
 	"testing"
@@ -147,7 +148,7 @@ func TestResourceServiceCheckExistByName(t *testing.T) {
 }
 
 func TestResourceServiceGetByID(t *testing.T) {
-	t.Run("get by idsuccess", func(t *testing.T) {
+	t.Run("keeps resource when account name lookup fails", func(t *testing.T) {
 		rs, mockRA, mockPS, _, mockUMS, _, _ := newTestService(t)
 		mockRA.EXPECT().GetByID(gomock.Any(), "r1").
 			Return(&interfaces.Resource{ID: "r1", Name: "test"}, nil)
@@ -156,7 +157,7 @@ func TestResourceServiceGetByID(t *testing.T) {
 			Return(map[string]interfaces.PermissionResourceOps{
 				"r1": {ResourceID: "r1", Operations: []string{"view_detail"}},
 			}, nil)
-		mockUMS.EXPECT().GetAccountNames(gomock.Any(), gomock.Any()).Return(nil)
+		mockUMS.EXPECT().GetAccountNames(gomock.Any(), gomock.Any()).Return(errors.New("user management unavailable"))
 
 		resource, err := rs.GetByID(context.Background(), "r1")
 		if err != nil {

--- a/adp/vega/vega-backend/server/logics/semantic_understanding_task/semantic_understanding_task_service.go
+++ b/adp/vega/vega-backend/server/logics/semantic_understanding_task/semantic_understanding_task_service.go
@@ -12,6 +12,7 @@ import (
 	"database/sql"
 	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"math"
 	"net/http"
@@ -223,12 +224,10 @@ func (suts *semanticUnderstandingTaskService) GetByID(ctx context.Context, id st
 		return nil, rest.NewHTTPError(ctx, http.StatusNotFound, verrors.VegaBackend_SemanticUnderstandingTask_NotFound)
 	}
 	if err := suts.populateSemanticUnderstandingTaskReferences(ctx, []*interfaces.SemanticUnderstandingTask{task}); err != nil {
-		return nil, err
+		logger.Warnf("Failed to populate semantic understanding task references: %v", err)
 	}
 	if err := suts.ums.GetAccountNames(ctx, []*interfaces.AccountInfo{&task.Creator}); err != nil {
-		span.SetStatus(codes.Error, "GetAccountNames error")
-		return nil, rest.NewHTTPError(ctx, http.StatusInternalServerError,
-			verrors.VegaBackend_SemanticUnderstandingTask_InternalError_GetAccountNamesFailed).WithErrorDetails(err.Error())
+		logger.Warnf("Failed to populate semantic understanding task account names: %v", err)
 	}
 	return task, nil
 }
@@ -264,7 +263,7 @@ func (suts *semanticUnderstandingTaskService) List(ctx context.Context, params i
 			WithErrorDetails(err.Error())
 	}
 	if err := suts.populateSemanticUnderstandingTaskReferences(ctx, tasks); err != nil {
-		return nil, 0, err
+		logger.Warnf("Failed to populate semantic understanding task references: %v", err)
 	}
 	return tasks, total, nil
 }
@@ -290,24 +289,27 @@ func (suts *semanticUnderstandingTaskService) populateSemanticUnderstandingTaskR
 		}
 	}
 
+	var referenceErrors []error
 	resourcesByID := make(map[string]*interfaces.Resource, len(resourceIDs))
 	if len(resourceIDs) > 0 {
 		resources, err := suts.rs.InternalGetByIDs(ctx, resourceIDs)
 		if err != nil {
-			return err
-		}
-		for _, resource := range resources {
-			resourcesByID[resource.ID] = resource
+			referenceErrors = append(referenceErrors, err)
+		} else {
+			for _, resource := range resources {
+				resourcesByID[resource.ID] = resource
+			}
 		}
 	}
 	catalogsByID := make(map[string]*interfaces.Catalog, len(catalogIDs))
 	if len(catalogIDs) > 0 {
 		catalogs, err := suts.cs.InternalGetByIDs(ctx, catalogIDs)
 		if err != nil {
-			return err
-		}
-		for _, catalog := range catalogs {
-			catalogsByID[catalog.ID] = catalog
+			referenceErrors = append(referenceErrors, err)
+		} else {
+			for _, catalog := range catalogs {
+				catalogsByID[catalog.ID] = catalog
+			}
 		}
 	}
 	for _, task := range tasks {
@@ -318,7 +320,7 @@ func (suts *semanticUnderstandingTaskService) populateSemanticUnderstandingTaskR
 			task.CatalogName = catalog.Name
 		}
 	}
-	return nil
+	return errors.Join(referenceErrors...)
 }
 
 func (suts *semanticUnderstandingTaskService) Delete(ctx context.Context, ids []string, ignoreMissing bool) error {

--- a/adp/vega/vega-backend/server/logics/semantic_understanding_task/semantic_understanding_task_service.go
+++ b/adp/vega/vega-backend/server/logics/semantic_understanding_task/semantic_understanding_task_service.go
@@ -224,9 +224,11 @@ func (suts *semanticUnderstandingTaskService) GetByID(ctx context.Context, id st
 		return nil, rest.NewHTTPError(ctx, http.StatusNotFound, verrors.VegaBackend_SemanticUnderstandingTask_NotFound)
 	}
 	if err := suts.populateSemanticUnderstandingTaskReferences(ctx, []*interfaces.SemanticUnderstandingTask{task}); err != nil {
+		span.RecordError(err)
 		logger.Warnf("Failed to populate semantic understanding task references: %v", err)
 	}
 	if err := suts.ums.GetAccountNames(ctx, []*interfaces.AccountInfo{&task.Creator}); err != nil {
+		span.RecordError(err)
 		logger.Warnf("Failed to populate semantic understanding task account names: %v", err)
 	}
 	return task, nil
@@ -263,6 +265,7 @@ func (suts *semanticUnderstandingTaskService) List(ctx context.Context, params i
 			WithErrorDetails(err.Error())
 	}
 	if err := suts.populateSemanticUnderstandingTaskReferences(ctx, tasks); err != nil {
+		span.RecordError(err)
 		logger.Warnf("Failed to populate semantic understanding task references: %v", err)
 	}
 	return tasks, total, nil

--- a/adp/vega/vega-backend/server/logics/semantic_understanding_task/semantic_understanding_task_service_test.go
+++ b/adp/vega/vega-backend/server/logics/semantic_understanding_task/semantic_understanding_task_service_test.go
@@ -8,6 +8,7 @@ package semantic_understanding_task
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"testing"
 	"time"
 
@@ -278,6 +279,23 @@ func TestSemanticUnderstandingTaskServiceGetByID(t *testing.T) {
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "NotFound")
 	})
+
+	t.Run("keeps task when account lookup fails", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		t.Cleanup(ctrl.Finish)
+		taskAccess := mock_interfaces.NewMockSemanticUnderstandingTaskAccess(ctrl)
+		userMgmtService := mock_interfaces.NewMockUserMgmtService(ctrl)
+		service := &semanticUnderstandingTaskService{suta: taskAccess, ums: userMgmtService}
+		task := &interfaces.SemanticUnderstandingTask{ID: "semantic-task-2"}
+
+		taskAccess.EXPECT().GetByID(gomock.Any(), "semantic-task-2").Return(task, nil)
+		userMgmtService.EXPECT().GetAccountNames(gomock.Any(), gomock.Any()).Return(errors.New("user service down"))
+
+		got, err := service.GetByID(context.Background(), "semantic-task-2")
+
+		require.NoError(t, err)
+		assert.Equal(t, "semantic-task-2", got.ID)
+	})
 }
 
 func TestSemanticUnderstandingTaskServicePopulatesReferenceNames(t *testing.T) {
@@ -322,6 +340,21 @@ func TestSemanticUnderstandingTaskServicePopulatesReferenceNames(t *testing.T) {
 		require.NoError(t, err)
 		assert.Equal(t, "资源二", got.ResourceName)
 		assert.Equal(t, "目录二", got.CatalogName)
+	})
+
+	t.Run("list keeps tasks when reference lookup fails", func(t *testing.T) {
+		tasks := []*interfaces.SemanticUnderstandingTask{{ID: "task-4", CatalogID: "catalog-3", ResourceID: "resource-3"}}
+		taskAccess.EXPECT().List(gomock.Any(), gomock.Any()).Return(tasks, int64(1), nil)
+		resourceService.EXPECT().InternalGetByIDs(gomock.Any(), []string{"resource-3"}).Return(nil, errors.New("resource service down"))
+		catalogService.EXPECT().InternalGetByIDs(gomock.Any(), []string{"catalog-3"}).Return([]*interfaces.Catalog{{ID: "catalog-3", Name: "目录三"}}, nil)
+
+		got, total, err := service.List(context.Background(), interfaces.SemanticUnderstandingTaskQueryParams{})
+
+		require.NoError(t, err)
+		assert.Equal(t, int64(1), total)
+		assert.Equal(t, "task-4", got[0].ID)
+		assert.Empty(t, got[0].ResourceName)
+		assert.Equal(t, "目录三", got[0].CatalogName)
 	})
 }
 


### PR DESCRIPTION
## Summary
- degrade task, catalog, and resource display-name enrichment at the callers so lookup failures do not fail public list/detail APIs
- make Build and Semantic resource/catalog name enrichment independent, preserving available names when one lookup fails
- normalize Discover Task and Discover Schedule public GetByID/List access failures to domain HTTP errors

## Scope
- task permission semantics are intentionally out of scope and will be handled separately

## Validation
- make lint
- make test