### PR TITLE
feat(bkn-trace): expose trace graph api

### DIFF
--- a/bkn-trace/agent-observability/README.md
+++ b/bkn-trace/agent-observability/README.md
@@ -5,6 +5,7 @@
 当前提供：
 - Trace 原始 DSL 查询接口：`POST /api/agent-observability/v1/traces/_search`
 - Conversation 维度包装查询接口：`GET /api/agent-observability/v1/traces/by-conversation?conversation_id=...`
+- Trace Graph 查询接口：`GET /api/agent-observability/v1/traces/{trace_id}/trace-graph`
 - Evidence 事件接收接口：`POST /api/agent-observability/v1/evidence/events`
 - Evidence Chain 查询接口：`GET /api/agent-observability/v1/traces/{trace_id}/evidence-chain`
 - Request 维度 Evidence Chain 查询接口：`GET /api/agent-observability/v1/traces/by-request?request_id=...`
@@ -83,6 +84,51 @@ GET /api/agent-observability/v1/traces/by-request/business-graph?request_id=req_
 ```
 
 `limit` 取值范围为 `1..1000`，默认 `1000`。命中上限时响应会返回 `partial=true`、`partial_reason=["evidence_query_truncated"]`，并设置 `page.truncated=true`，调用方不得把该结果展示为完整证据链。
+
+Trace Graph 查询把 OTel spans 归一化为 trace tree：
+
+```http
+GET /api/agent-observability/v1/traces/{trace_id}/trace-graph
+```
+
+```json
+{
+  "trace_id": "9c0d...",
+  "status": "error",
+  "duration_nano": 110,
+  "partial": false,
+  "partial_reason": [],
+  "page": {
+    "node_count": 3,
+    "edge_count": 2,
+    "truncated": false
+  },
+  "data": {
+    "nodes": [
+      {
+        "span_id": "root",
+        "name": "POST /chat",
+        "kind": "SERVER",
+        "service_name": "bkn-agent",
+        "status": "ok",
+        "start_nano": 100,
+        "end_nano": 210,
+        "duration_nano": 110
+      }
+    ],
+    "edges": [
+      {
+        "id": "edge:1",
+        "parent_span_id": "root",
+        "child_span_id": "child",
+        "edge_type": "parent_child"
+      }
+    ]
+  }
+}
+```
+
+当 span 指向缺失父节点时，Trace Graph 不生成悬空边，并返回 `partial=true`、`partial_reason=["orphan_span"]`。
 
 ### Evidence 写入安全边界
 

--- a/bkn-trace/agent-observability/README.md
+++ b/bkn-trace/agent-observability/README.md
@@ -128,7 +128,7 @@ GET /api/agent-observability/v1/traces/{trace_id}/trace-graph
 }
 ```
 
-当 span 指向缺失父节点时，Trace Graph 不生成悬空边，并返回 `partial=true`、`partial_reason=["orphan_span"]`。
+Trace Graph 单次最多返回 1000 个 span 节点。命中上限时服务会使用 `limit+1` 查询探测截断，响应返回 `partial=true`、`partial_reason=["trace_query_truncated"]`，并设置 `page.truncated=true`。当 span 指向缺失父节点时，Trace Graph 不生成悬空边，并返回 `partial_reason=["orphan_span"]`。当 span 时间戳缺失、非法或结束时间早于开始时间时，节点耗时会归零，整体耗时不会返回负数，并返回 `partial_reason=["invalid_span_timestamp"]`。
 
 ### Evidence 写入安全边界
 

--- a/bkn-trace/agent-observability/docs/swagger/docs.go
+++ b/bkn-trace/agent-observability/docs/swagger/docs.go
@@ -608,6 +608,66 @@ const docTemplate = `{
                     }
                 }
             }
+        },
+        "/api/agent-observability/v1/traces/{trace_id}/trace-graph": {
+            "get": {
+                "description": "Returns normalized trace tree nodes, parent-child edges, status, duration, and partial reasons for a trace.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "traces"
+                ],
+                "summary": "Get trace graph by trace ID",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Trace ID",
+                        "name": "trace_id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": true
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/rdto.ErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/rdto.ErrorResponse"
+                        }
+                    },
+                    "405": {
+                        "description": "Method Not Allowed",
+                        "schema": {
+                            "$ref": "#/definitions/rdto.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/rdto.ErrorResponse"
+                        }
+                    },
+                    "504": {
+                        "description": "Gateway Timeout",
+                        "schema": {
+                            "$ref": "#/definitions/rdto.ErrorResponse"
+                        }
+                    }
+                }
+            }
         }
     },
     "definitions": {

--- a/bkn-trace/agent-observability/docs/swagger/swagger.json
+++ b/bkn-trace/agent-observability/docs/swagger/swagger.json
@@ -600,6 +600,66 @@
                     }
                 }
             }
+        },
+        "/api/agent-observability/v1/traces/{trace_id}/trace-graph": {
+            "get": {
+                "description": "Returns normalized trace tree nodes, parent-child edges, status, duration, and partial reasons for a trace.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "traces"
+                ],
+                "summary": "Get trace graph by trace ID",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Trace ID",
+                        "name": "trace_id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": true
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/rdto.ErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/rdto.ErrorResponse"
+                        }
+                    },
+                    "405": {
+                        "description": "Method Not Allowed",
+                        "schema": {
+                            "$ref": "#/definitions/rdto.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/rdto.ErrorResponse"
+                        }
+                    },
+                    "504": {
+                        "description": "Gateway Timeout",
+                        "schema": {
+                            "$ref": "#/definitions/rdto.ErrorResponse"
+                        }
+                    }
+                }
+            }
         }
     },
     "definitions": {

--- a/bkn-trace/agent-observability/docs/swagger/swagger.yaml
+++ b/bkn-trace/agent-observability/docs/swagger/swagger.yaml
@@ -257,6 +257,47 @@ paths:
       summary: Get evidence snapshot preview by trace ID
       tags:
       - evidence
+  /api/agent-observability/v1/traces/{trace_id}/trace-graph:
+    get:
+      description: Returns normalized trace tree nodes, parent-child edges, status,
+        duration, and partial reasons for a trace.
+      parameters:
+      - description: Trace ID
+        in: path
+        name: trace_id
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties: true
+            type: object
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/rdto.ErrorResponse'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/rdto.ErrorResponse'
+        "405":
+          description: Method Not Allowed
+          schema:
+            $ref: '#/definitions/rdto.ErrorResponse'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/rdto.ErrorResponse'
+        "504":
+          description: Gateway Timeout
+          schema:
+            $ref: '#/definitions/rdto.ErrorResponse'
+      summary: Get trace graph by trace ID
+      tags:
+      - traces
   /api/agent-observability/v1/traces/by-conversation:
     get:
       consumes:

--- a/bkn-trace/agent-observability/src/boot/bootstrap.go
+++ b/bkn-trace/agent-observability/src/boot/bootstrap.go
@@ -60,7 +60,12 @@ func newApp(httpServerConfig conf.HTTPServerConfig, traceHandler *httphandler.Tr
 	mux.HandleFunc(APIBasePath+"/traces/by-request/business-graph", evidenceHandler.GetBusinessGraphByRequestID)
 	mux.HandleFunc(APIBasePath+"/traces/by-request/snapshot-preview", evidenceHandler.GetSnapshotPreviewByRequestID)
 	mux.HandleFunc(APIBasePath+"/traces/by-request", evidenceHandler.GetEvidenceChainByRequestID)
-	mux.HandleFunc(APIBasePath+"/traces/", evidenceHandler.GetTraceSubresource)
+	mux.HandleFunc(APIBasePath+"/traces/", func(w http.ResponseWriter, r *http.Request) {
+		if traceHandler.GetTraceSubresource(w, r) {
+			return
+		}
+		evidenceHandler.GetTraceSubresource(w, r)
+	})
 	mux.HandleFunc(APIBasePath+"/evidence-nodes/", evidenceHandler.GetEvidenceNode)
 	mux.HandleFunc(APIBasePath+"/evidence/events", evidenceHandler.IngestEvidenceEvents)
 	mux.Handle(APIBasePath+"/swagger/", httpSwagger.Handler(

--- a/bkn-trace/agent-observability/src/domain/service/tracesvc/service.go
+++ b/bkn-trace/agent-observability/src/domain/service/tracesvc/service.go
@@ -53,6 +53,7 @@ func (s *TraceQueryService) GetTraceGraphByTraceID(ctx context.Context, traceID 
 	if len(spans) == 0 {
 		return oteltracevo.TraceGraphResponse{}, false, nil
 	}
+	spans = deduplicateSpanRecords(spans)
 	truncated := false
 	if len(spans) > DefaultTraceGraphSpanLimit {
 		truncated = true
@@ -107,6 +108,23 @@ func spansFromTraceData(traceData oteltracevo.TraceData, traceID string) []spanR
 		}
 	}
 	return records
+}
+
+func deduplicateSpanRecords(records []spanRecord) []spanRecord {
+	seen := map[string]struct{}{}
+	unique := make([]spanRecord, 0, len(records))
+	for _, record := range records {
+		if record.Span.SpanID == "" {
+			unique = append(unique, record)
+			continue
+		}
+		if _, ok := seen[record.Span.SpanID]; ok {
+			continue
+		}
+		seen[record.Span.SpanID] = struct{}{}
+		unique = append(unique, record)
+	}
+	return unique
 }
 
 func buildTraceGraph(traceID string, records []spanRecord, truncated bool) oteltracevo.TraceGraphResponse {

--- a/bkn-trace/agent-observability/src/domain/service/tracesvc/service.go
+++ b/bkn-trace/agent-observability/src/domain/service/tracesvc/service.go
@@ -3,8 +3,12 @@ package tracesvc
 import (
 	"context"
 	"encoding/json"
+	"sort"
+	"strconv"
+	"strings"
 
 	"github.com/openbkn-ai/bkn-foundry/bkn-trace/agent-observability/src/domain/valueobject/opensearchvo"
+	"github.com/openbkn-ai/bkn-foundry/bkn-trace/agent-observability/src/domain/valueobject/oteltracevo"
 	"github.com/openbkn-ai/bkn-foundry/bkn-trace/agent-observability/src/port/driven/ihttpaccess/tracequeryport"
 )
 
@@ -18,4 +22,185 @@ func New(traceQueryPort tracequeryport.TraceQueryPort) *TraceQueryService {
 
 func (s *TraceQueryService) SearchTraces(ctx context.Context, query json.RawMessage) (opensearchvo.SearchResult, error) {
 	return s.traceQueryPort.SearchTraces(ctx, query)
+}
+
+func (s *TraceQueryService) GetTraceGraphByTraceID(ctx context.Context, traceID string) (oteltracevo.TraceGraphResponse, bool, error) {
+	traceID = strings.TrimSpace(traceID)
+	query, err := json.Marshal(map[string]any{
+		"size": 1000,
+		"query": map[string]any{
+			"term": map[string]string{
+				"traceId.keyword": traceID,
+			},
+		},
+		"sort": []map[string]any{
+			{"startTimeUnixNano": map[string]string{"order": "asc"}},
+		},
+	})
+	if err != nil {
+		return oteltracevo.TraceGraphResponse{}, false, err
+	}
+	result, err := s.traceQueryPort.SearchTraces(ctx, query)
+	if err != nil {
+		return oteltracevo.TraceGraphResponse{}, false, err
+	}
+	spans, err := spansFromSearchResult(result, traceID)
+	if err != nil {
+		return oteltracevo.TraceGraphResponse{}, false, err
+	}
+	if len(spans) == 0 {
+		return oteltracevo.TraceGraphResponse{}, false, nil
+	}
+	return buildTraceGraph(traceID, spans), true, nil
+}
+
+type searchResponse struct {
+	Hits struct {
+		Hits []struct {
+			Source json.RawMessage `json:"_source"`
+		} `json:"hits"`
+	} `json:"hits"`
+}
+
+type spanRecord struct {
+	Span        oteltracevo.Span
+	ServiceName string
+}
+
+func spansFromSearchResult(result opensearchvo.SearchResult, traceID string) ([]spanRecord, error) {
+	var response searchResponse
+	if err := json.Unmarshal(result, &response); err != nil {
+		return nil, err
+	}
+	var records []spanRecord
+	for _, hit := range response.Hits.Hits {
+		var traceData oteltracevo.TraceData
+		if err := json.Unmarshal(hit.Source, &traceData); err == nil && len(traceData.ResourceSpans) > 0 {
+			records = append(records, spansFromTraceData(traceData, traceID)...)
+			continue
+		}
+		var span oteltracevo.Span
+		if err := json.Unmarshal(hit.Source, &span); err == nil && span.TraceID == traceID {
+			records = append(records, spanRecord{Span: span})
+		}
+	}
+	return records, nil
+}
+
+func spansFromTraceData(traceData oteltracevo.TraceData, traceID string) []spanRecord {
+	var records []spanRecord
+	for _, resourceSpan := range traceData.ResourceSpans {
+		serviceName := resourceAttribute(resourceSpan.Resource, "service.name")
+		for _, scopeSpan := range resourceSpan.ScopeSpans {
+			for _, span := range scopeSpan.Spans {
+				if span.TraceID == traceID {
+					records = append(records, spanRecord{Span: span, ServiceName: serviceName})
+				}
+			}
+		}
+	}
+	return records
+}
+
+func buildTraceGraph(traceID string, records []spanRecord) oteltracevo.TraceGraphResponse {
+	sort.SliceStable(records, func(i, j int) bool {
+		left := parseNano(records[i].Span.StartTimeUnixNano)
+		right := parseNano(records[j].Span.StartTimeUnixNano)
+		if left == right {
+			return records[i].Span.SpanID < records[j].Span.SpanID
+		}
+		return left < right
+	})
+
+	response := oteltracevo.TraceGraphResponse{
+		TraceID: traceID,
+		Status:  "ok",
+	}
+	seen := map[string]struct{}{}
+	partialReasons := map[string]struct{}{}
+	var minStart, maxEnd int64
+	for i, record := range records {
+		span := record.Span
+		start := parseNano(span.StartTimeUnixNano)
+		end := parseNano(span.EndTimeUnixNano)
+		if i == 0 || start < minStart {
+			minStart = start
+		}
+		if end > maxEnd {
+			maxEnd = end
+		}
+		status := spanStatus(span.Status)
+		if status == "error" {
+			response.Status = "error"
+		}
+		seen[span.SpanID] = struct{}{}
+		response.Data.Nodes = append(response.Data.Nodes, oteltracevo.TraceGraphNode{
+			SpanID:       span.SpanID,
+			ParentSpanID: span.ParentSpanID,
+			Name:         span.Name,
+			Kind:         span.Kind,
+			ServiceName:  record.ServiceName,
+			Status:       status,
+			ErrorMessage: span.Status.Message,
+			StartNano:    start,
+			EndNano:      end,
+			DurationNano: end - start,
+		})
+	}
+	for _, node := range response.Data.Nodes {
+		if node.ParentSpanID == "" {
+			continue
+		}
+		if _, ok := seen[node.ParentSpanID]; !ok {
+			partialReasons["orphan_span"] = struct{}{}
+			continue
+		}
+		response.Data.Edges = append(response.Data.Edges, oteltracevo.TraceGraphEdge{
+			ID:       "edge:" + strconv.Itoa(len(response.Data.Edges)+1),
+			ParentID: node.ParentSpanID,
+			ChildID:  node.SpanID,
+			EdgeType: "parent_child",
+		})
+	}
+	response.DurationNano = maxEnd - minStart
+	response.Page.NodeCount = len(response.Data.Nodes)
+	response.Page.EdgeCount = len(response.Data.Edges)
+	response.PartialReasons = sortedKeys(partialReasons)
+	response.Partial = len(response.PartialReasons) > 0
+	return response
+}
+
+func resourceAttribute(resource oteltracevo.Resource, key string) string {
+	for _, attribute := range resource.Attributes {
+		if attribute.Key == key {
+			return attribute.Value.StringValue
+		}
+	}
+	return ""
+}
+
+func spanStatus(status oteltracevo.Status) string {
+	switch status.Code {
+	case "STATUS_CODE_ERROR", "ERROR":
+		return "error"
+	default:
+		return "ok"
+	}
+}
+
+func parseNano(value string) int64 {
+	parsed, _ := strconv.ParseInt(value, 10, 64)
+	return parsed
+}
+
+func sortedKeys(values map[string]struct{}) []string {
+	if len(values) == 0 {
+		return nil
+	}
+	keys := make([]string, 0, len(values))
+	for key := range values {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	return keys
 }

--- a/bkn-trace/agent-observability/src/domain/service/tracesvc/service.go
+++ b/bkn-trace/agent-observability/src/domain/service/tracesvc/service.go
@@ -16,6 +16,8 @@ type TraceQueryService struct {
 	traceQueryPort tracequeryport.TraceQueryPort
 }
 
+const DefaultTraceGraphSpanLimit = 1000
+
 func New(traceQueryPort tracequeryport.TraceQueryPort) *TraceQueryService {
 	return &TraceQueryService{traceQueryPort: traceQueryPort}
 }
@@ -27,7 +29,7 @@ func (s *TraceQueryService) SearchTraces(ctx context.Context, query json.RawMess
 func (s *TraceQueryService) GetTraceGraphByTraceID(ctx context.Context, traceID string) (oteltracevo.TraceGraphResponse, bool, error) {
 	traceID = strings.TrimSpace(traceID)
 	query, err := json.Marshal(map[string]any{
-		"size": 1000,
+		"size": DefaultTraceGraphSpanLimit + 1,
 		"query": map[string]any{
 			"term": map[string]string{
 				"traceId.keyword": traceID,
@@ -51,7 +53,12 @@ func (s *TraceQueryService) GetTraceGraphByTraceID(ctx context.Context, traceID 
 	if len(spans) == 0 {
 		return oteltracevo.TraceGraphResponse{}, false, nil
 	}
-	return buildTraceGraph(traceID, spans), true, nil
+	truncated := false
+	if len(spans) > DefaultTraceGraphSpanLimit {
+		truncated = true
+		spans = spans[:DefaultTraceGraphSpanLimit]
+	}
+	return buildTraceGraph(traceID, spans, truncated), true, nil
 }
 
 type searchResponse struct {
@@ -102,10 +109,10 @@ func spansFromTraceData(traceData oteltracevo.TraceData, traceID string) []spanR
 	return records
 }
 
-func buildTraceGraph(traceID string, records []spanRecord) oteltracevo.TraceGraphResponse {
+func buildTraceGraph(traceID string, records []spanRecord, truncated bool) oteltracevo.TraceGraphResponse {
 	sort.SliceStable(records, func(i, j int) bool {
-		left := parseNano(records[i].Span.StartTimeUnixNano)
-		right := parseNano(records[j].Span.StartTimeUnixNano)
+		left, _ := parseNano(records[i].Span.StartTimeUnixNano)
+		right, _ := parseNano(records[j].Span.StartTimeUnixNano)
 		if left == right {
 			return records[i].Span.SpanID < records[j].Span.SpanID
 		}
@@ -121,8 +128,15 @@ func buildTraceGraph(traceID string, records []spanRecord) oteltracevo.TraceGrap
 	var minStart, maxEnd int64
 	for i, record := range records {
 		span := record.Span
-		start := parseNano(span.StartTimeUnixNano)
-		end := parseNano(span.EndTimeUnixNano)
+		start, startOK := parseNano(span.StartTimeUnixNano)
+		end, endOK := parseNano(span.EndTimeUnixNano)
+		duration := int64(0)
+		if !startOK || !endOK || end < start {
+			partialReasons["invalid_span_timestamp"] = struct{}{}
+			end = start
+		} else {
+			duration = end - start
+		}
 		if i == 0 || start < minStart {
 			minStart = start
 		}
@@ -144,7 +158,7 @@ func buildTraceGraph(traceID string, records []spanRecord) oteltracevo.TraceGrap
 			ErrorMessage: span.Status.Message,
 			StartNano:    start,
 			EndNano:      end,
-			DurationNano: end - start,
+			DurationNano: duration,
 		})
 	}
 	for _, node := range response.Data.Nodes {
@@ -163,8 +177,15 @@ func buildTraceGraph(traceID string, records []spanRecord) oteltracevo.TraceGrap
 		})
 	}
 	response.DurationNano = maxEnd - minStart
+	if response.DurationNano < 0 {
+		response.DurationNano = 0
+	}
 	response.Page.NodeCount = len(response.Data.Nodes)
 	response.Page.EdgeCount = len(response.Data.Edges)
+	response.Page.Truncated = truncated
+	if truncated {
+		partialReasons["trace_query_truncated"] = struct{}{}
+	}
 	response.PartialReasons = sortedKeys(partialReasons)
 	response.Partial = len(response.PartialReasons) > 0
 	return response
@@ -188,9 +209,9 @@ func spanStatus(status oteltracevo.Status) string {
 	}
 }
 
-func parseNano(value string) int64 {
-	parsed, _ := strconv.ParseInt(value, 10, 64)
-	return parsed
+func parseNano(value string) (int64, bool) {
+	parsed, err := strconv.ParseInt(value, 10, 64)
+	return parsed, err == nil
 }
 
 func sortedKeys(values map[string]struct{}) []string {

--- a/bkn-trace/agent-observability/src/domain/service/tracesvc/service_test.go
+++ b/bkn-trace/agent-observability/src/domain/service/tracesvc/service_test.go
@@ -95,6 +95,25 @@ func TestGetTraceGraphByTraceIDMarksQueryTruncated(t *testing.T) {
 	}
 }
 
+func TestGetTraceGraphByTraceIDDeduplicatesRepeatedSpans(t *testing.T) {
+	port := &fakeTracePort{result: opensearchvo.SearchResult(traceGraphDuplicateSearchResult())}
+	service := New(port)
+
+	response, found, err := service.GetTraceGraphByTraceID(context.Background(), "trace_graph_duplicate")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !found {
+		t.Fatal("expected trace graph to be found")
+	}
+	if response.Page.NodeCount != 1 || len(response.Data.Nodes) != 1 {
+		t.Fatalf("expected duplicate span to be collapsed, got %+v", response)
+	}
+	if response.Data.Nodes[0].SpanID != "duplicate" || response.Data.Nodes[0].ServiceName != "bkn-agent" {
+		t.Fatalf("expected first span record to win, got %+v", response.Data.Nodes[0])
+	}
+}
+
 func TestGetTraceGraphByTraceIDClampsInvalidDurations(t *testing.T) {
 	port := &fakeTracePort{result: opensearchvo.SearchResult(traceGraphInvalidTimeSearchResult())}
 	service := New(port)
@@ -264,6 +283,54 @@ func traceGraphInvalidTimeSearchResult() []byte {
               ]
             }
           ]
+        }
+      }
+    ]
+  }
+}`)
+}
+
+func traceGraphDuplicateSearchResult() []byte {
+	return []byte(`{
+  "hits": {
+    "hits": [
+      {
+        "_source": {
+          "resourceSpans": [
+            {
+              "resource": {
+                "attributes": [
+                  {"key": "service.name", "value": {"stringValue": "bkn-agent"}}
+                ]
+              },
+              "scopeSpans": [
+                {
+                  "spans": [
+                    {
+                      "traceId": "trace_graph_duplicate",
+                      "spanId": "duplicate",
+                      "name": "agent.run",
+                      "kind": "SERVER",
+                      "startTimeUnixNano": "10",
+                      "endTimeUnixNano": "20",
+                      "status": {"code": "STATUS_CODE_OK"}
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      },
+      {
+        "_source": {
+          "traceId": "trace_graph_duplicate",
+          "spanId": "duplicate",
+          "name": "agent.run.duplicate",
+          "kind": "SERVER",
+          "startTimeUnixNano": "10",
+          "endTimeUnixNano": "20",
+          "status": {"code": "STATUS_CODE_OK"}
         }
       }
     ]

--- a/bkn-trace/agent-observability/src/domain/service/tracesvc/service_test.go
+++ b/bkn-trace/agent-observability/src/domain/service/tracesvc/service_test.go
@@ -3,6 +3,7 @@ package tracesvc
 import (
 	"context"
 	"encoding/json"
+	"strconv"
 	"strings"
 	"testing"
 
@@ -69,6 +70,47 @@ func TestGetTraceGraphByTraceIDMarksOrphanSpanPartial(t *testing.T) {
 	}
 	if response.Page.NodeCount != 1 || response.Page.EdgeCount != 0 {
 		t.Fatalf("orphan span must not create dangling edge: %+v", response.Page)
+	}
+}
+
+func TestGetTraceGraphByTraceIDMarksQueryTruncated(t *testing.T) {
+	port := &fakeTracePort{result: opensearchvo.SearchResult(traceGraphTruncatedSearchResult())}
+	service := New(port)
+
+	response, found, err := service.GetTraceGraphByTraceID(context.Background(), "trace_graph_truncated")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !found {
+		t.Fatal("expected trace graph to be found")
+	}
+	if !strings.Contains(string(port.query), `"size":1001`) {
+		t.Fatalf("expected limit+1 query for truncation detection, got %s", string(port.query))
+	}
+	if !response.Partial || !contains(response.PartialReasons, "trace_query_truncated") {
+		t.Fatalf("expected truncation partial reason, got %+v", response)
+	}
+	if !response.Page.Truncated || response.Page.NodeCount != 1000 {
+		t.Fatalf("expected truncated page with capped nodes, got %+v", response.Page)
+	}
+}
+
+func TestGetTraceGraphByTraceIDClampsInvalidDurations(t *testing.T) {
+	port := &fakeTracePort{result: opensearchvo.SearchResult(traceGraphInvalidTimeSearchResult())}
+	service := New(port)
+
+	response, found, err := service.GetTraceGraphByTraceID(context.Background(), "trace_graph_bad_time")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !found {
+		t.Fatal("expected trace graph to be found")
+	}
+	if response.DurationNano < 0 || response.Data.Nodes[0].DurationNano < 0 {
+		t.Fatalf("durations must not be negative: %+v", response)
+	}
+	if !response.Partial || !contains(response.PartialReasons, "invalid_span_timestamp") {
+		t.Fatalf("expected invalid timestamp partial reason, got %+v", response)
 	}
 }
 
@@ -171,6 +213,50 @@ func traceGraphOrphanSearchResult() []byte {
                       "kind": "INTERNAL",
                       "startTimeUnixNano": "10",
                       "endTimeUnixNano": "20",
+                      "status": {"code": "STATUS_CODE_OK"}
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      }
+    ]
+  }
+}`)
+}
+
+func traceGraphTruncatedSearchResult() []byte {
+	spans := make([]string, 0, 1001)
+	for i := 0; i < 1001; i++ {
+		parent := ""
+		if i > 0 {
+			parent = `,"parentSpanId":"span_0"`
+		}
+		spans = append(spans, `{"traceId":"trace_graph_truncated","spanId":"span_`+strconv.Itoa(i)+`"`+parent+`,"name":"step","kind":"INTERNAL","startTimeUnixNano":"`+strconv.Itoa(i)+`","endTimeUnixNano":"`+strconv.Itoa(i+1)+`","status":{"code":"STATUS_CODE_OK"}}`)
+	}
+	return []byte(`{"hits":{"hits":[{"_source":{"resourceSpans":[{"scopeSpans":[{"spans":[` + strings.Join(spans, ",") + `]}]}]}}]}}`)
+}
+
+func traceGraphInvalidTimeSearchResult() []byte {
+	return []byte(`{
+  "hits": {
+    "hits": [
+      {
+        "_source": {
+          "resourceSpans": [
+            {
+              "scopeSpans": [
+                {
+                  "spans": [
+                    {
+                      "traceId": "trace_graph_bad_time",
+                      "spanId": "bad_time",
+                      "name": "bad.time",
+                      "kind": "INTERNAL",
+                      "startTimeUnixNano": "20",
+                      "endTimeUnixNano": "bad",
                       "status": {"code": "STATUS_CODE_OK"}
                     }
                   ]

--- a/bkn-trace/agent-observability/src/domain/service/tracesvc/service_test.go
+++ b/bkn-trace/agent-observability/src/domain/service/tracesvc/service_test.go
@@ -1,0 +1,186 @@
+package tracesvc
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/openbkn-ai/bkn-foundry/bkn-trace/agent-observability/src/domain/valueobject/opensearchvo"
+)
+
+type fakeTracePort struct {
+	query  json.RawMessage
+	result opensearchvo.SearchResult
+}
+
+func (p *fakeTracePort) SearchTraces(_ context.Context, query json.RawMessage) (opensearchvo.SearchResult, error) {
+	p.query = query
+	return p.result, nil
+}
+
+func TestGetTraceGraphByTraceIDBuildsTreeStatusAndDuration(t *testing.T) {
+	port := &fakeTracePort{result: opensearchvo.SearchResult(traceGraphSearchResult())}
+	service := New(port)
+
+	response, found, err := service.GetTraceGraphByTraceID(context.Background(), "trace_graph_001")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !found {
+		t.Fatal("expected trace graph to be found")
+	}
+	if !strings.Contains(string(port.query), `"traceId.keyword":"trace_graph_001"`) {
+		t.Fatalf("expected trace id term query, got %s", string(port.query))
+	}
+	if response.TraceID != "trace_graph_001" || response.Status != "error" || response.DurationNano != 110 {
+		t.Fatalf("unexpected graph summary: %+v", response)
+	}
+	if response.Partial || len(response.PartialReasons) != 0 {
+		t.Fatalf("expected complete graph, got %+v", response.PartialReasons)
+	}
+	if response.Page.NodeCount != 3 || response.Page.EdgeCount != 2 {
+		t.Fatalf("unexpected page: %+v", response.Page)
+	}
+	if len(response.Data.Nodes) != 3 || len(response.Data.Edges) != 2 {
+		t.Fatalf("unexpected graph data: %+v", response.Data)
+	}
+	if response.Data.Nodes[0].SpanID != "root" || response.Data.Nodes[0].ParentSpanID != "" || response.Data.Nodes[0].Status != "ok" {
+		t.Fatalf("root node should be first and ok: %+v", response.Data.Nodes[0])
+	}
+	if response.Data.Nodes[2].Status != "error" || response.Data.Nodes[2].ErrorMessage != "tool failed" {
+		t.Fatalf("expected error node with message: %+v", response.Data.Nodes[2])
+	}
+}
+
+func TestGetTraceGraphByTraceIDMarksOrphanSpanPartial(t *testing.T) {
+	port := &fakeTracePort{result: opensearchvo.SearchResult(traceGraphOrphanSearchResult())}
+	service := New(port)
+
+	response, found, err := service.GetTraceGraphByTraceID(context.Background(), "trace_graph_orphan")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !found {
+		t.Fatal("expected trace graph to be found")
+	}
+	if !response.Partial || !contains(response.PartialReasons, "orphan_span") {
+		t.Fatalf("expected orphan partial reason, got %+v", response)
+	}
+	if response.Page.NodeCount != 1 || response.Page.EdgeCount != 0 {
+		t.Fatalf("orphan span must not create dangling edge: %+v", response.Page)
+	}
+}
+
+func TestGetTraceGraphByTraceIDNotFound(t *testing.T) {
+	port := &fakeTracePort{result: opensearchvo.SearchResult(`{"hits":{"hits":[]}}`)}
+	service := New(port)
+
+	_, found, err := service.GetTraceGraphByTraceID(context.Background(), "missing")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if found {
+		t.Fatal("expected not found")
+	}
+}
+
+func contains(values []string, target string) bool {
+	for _, value := range values {
+		if value == target {
+			return true
+		}
+	}
+	return false
+}
+
+func traceGraphSearchResult() []byte {
+	return []byte(`{
+  "hits": {
+    "hits": [
+      {
+        "_source": {
+          "resourceSpans": [
+            {
+              "resource": {
+                "attributes": [
+                  {"key": "service.name", "value": {"stringValue": "bkn-agent"}}
+                ]
+              },
+              "scopeSpans": [
+                {
+                  "scope": {"name": "bkn-agent"},
+                  "spans": [
+                    {
+                      "traceId": "trace_graph_001",
+                      "spanId": "root",
+                      "name": "POST /chat",
+                      "kind": "SERVER",
+                      "startTimeUnixNano": "100",
+                      "endTimeUnixNano": "210",
+                      "status": {"code": "STATUS_CODE_OK"}
+                    },
+                    {
+                      "traceId": "trace_graph_001",
+                      "spanId": "child",
+                      "parentSpanId": "root",
+                      "name": "tool.search",
+                      "kind": "CLIENT",
+                      "startTimeUnixNano": "120",
+                      "endTimeUnixNano": "180",
+                      "status": {"code": "STATUS_CODE_OK"}
+                    },
+                    {
+                      "traceId": "trace_graph_001",
+                      "spanId": "error",
+                      "parentSpanId": "child",
+                      "name": "tool.invoke",
+                      "kind": "CLIENT",
+                      "startTimeUnixNano": "150",
+                      "endTimeUnixNano": "170",
+                      "status": {"code": "STATUS_CODE_ERROR", "message": "tool failed"}
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      }
+    ]
+  }
+}`)
+}
+
+func traceGraphOrphanSearchResult() []byte {
+	return []byte(`{
+  "hits": {
+    "hits": [
+      {
+        "_source": {
+          "resourceSpans": [
+            {
+              "scopeSpans": [
+                {
+                  "spans": [
+                    {
+                      "traceId": "trace_graph_orphan",
+                      "spanId": "orphan",
+                      "parentSpanId": "missing_parent",
+                      "name": "worker.step",
+                      "kind": "INTERNAL",
+                      "startTimeUnixNano": "10",
+                      "endTimeUnixNano": "20",
+                      "status": {"code": "STATUS_CODE_OK"}
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      }
+    ]
+  }
+}`)
+}

--- a/bkn-trace/agent-observability/src/domain/valueobject/oteltracevo/trace_data.go
+++ b/bkn-trace/agent-observability/src/domain/valueobject/oteltracevo/trace_data.go
@@ -4,6 +4,47 @@ type TraceData struct {
 	ResourceSpans []ResourceSpan `json:"resourceSpans"`
 }
 
+type TraceGraphResponse struct {
+	TraceID        string         `json:"trace_id"`
+	Status         string         `json:"status"`
+	DurationNano   int64          `json:"duration_nano"`
+	Partial        bool           `json:"partial"`
+	PartialReasons []string       `json:"partial_reason"`
+	Page           TraceGraphPage `json:"page"`
+	Data           TraceGraphData `json:"data"`
+}
+
+type TraceGraphPage struct {
+	NodeCount int  `json:"node_count"`
+	EdgeCount int  `json:"edge_count"`
+	Truncated bool `json:"truncated"`
+}
+
+type TraceGraphData struct {
+	Nodes []TraceGraphNode `json:"nodes"`
+	Edges []TraceGraphEdge `json:"edges"`
+}
+
+type TraceGraphNode struct {
+	SpanID       string `json:"span_id"`
+	ParentSpanID string `json:"parent_span_id,omitempty"`
+	Name         string `json:"name"`
+	Kind         string `json:"kind"`
+	ServiceName  string `json:"service_name,omitempty"`
+	Status       string `json:"status"`
+	ErrorMessage string `json:"error_message,omitempty"`
+	StartNano    int64  `json:"start_nano"`
+	EndNano      int64  `json:"end_nano"`
+	DurationNano int64  `json:"duration_nano"`
+}
+
+type TraceGraphEdge struct {
+	ID       string `json:"id"`
+	ParentID string `json:"parent_span_id"`
+	ChildID  string `json:"child_span_id"`
+	EdgeType string `json:"edge_type"`
+}
+
 type ResourceSpan struct {
 	Resource   Resource    `json:"resource"`
 	ScopeSpans []ScopeSpan `json:"scopeSpans"`

--- a/bkn-trace/agent-observability/src/driveradapter/api/httphandler/trace_handler.go
+++ b/bkn-trace/agent-observability/src/driveradapter/api/httphandler/trace_handler.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"io"
 	"net/http"
+	"strings"
 
 	"github.com/openbkn-ai/bkn-foundry/bkn-trace/agent-observability/src/domain/service/tracesvc"
 	"github.com/openbkn-ai/bkn-foundry/bkn-trace/agent-observability/src/driveradapter/api/rdto"
@@ -143,6 +144,78 @@ func (h *TraceHandler) SearchTracesByConversationID(w http.ResponseWriter, r *ht
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusOK)
 	_, _ = w.Write(traceData)
+}
+
+func (h *TraceHandler) GetTraceSubresource(w http.ResponseWriter, r *http.Request) bool {
+	if !strings.HasSuffix(r.URL.Path, "/trace-graph") {
+		return false
+	}
+	h.GetTraceGraphByTraceID(w, r)
+	return true
+}
+
+// GetTraceGraphByTraceID godoc
+// @Summary Get trace graph by trace ID
+// @Description Returns normalized trace tree nodes, parent-child edges, status, duration, and partial reasons for a trace.
+// @Tags traces
+// @Produce json
+// @Param trace_id path string true "Trace ID"
+// @Success 200 {object} map[string]interface{}
+// @Failure 400 {object} rdto.ErrorResponse
+// @Failure 404 {object} rdto.ErrorResponse
+// @Failure 405 {object} rdto.ErrorResponse
+// @Failure 500 {object} rdto.ErrorResponse
+// @Failure 504 {object} rdto.ErrorResponse
+// @Router /api/agent-observability/v1/traces/{trace_id}/trace-graph [get]
+func (h *TraceHandler) GetTraceGraphByTraceID(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		writeJSON(w, http.StatusMethodNotAllowed, rdto.ErrorResponse{
+			Code:    "METHOD_NOT_ALLOWED",
+			Message: "only GET is supported",
+		})
+		return
+	}
+
+	traceID := traceIDFromTraceGraphPath(r.URL.Path)
+	if traceID == "" {
+		writeJSON(w, http.StatusBadRequest, rdto.ErrorResponse{
+			Code:    "INVALID_ARGUMENT",
+			Message: "trace_id is required",
+		})
+		return
+	}
+
+	response, found, err := h.traceQueryService.GetTraceGraphByTraceID(r.Context(), traceID)
+	if err != nil {
+		writeJSON(w, http.StatusGatewayTimeout, rdto.ErrorResponse{
+			Code:    "QUERY_FAILED",
+			Message: "failed to query trace graph",
+		})
+		return
+	}
+	if !found {
+		writeJSON(w, http.StatusNotFound, rdto.ErrorResponse{
+			Code:    "NOT_FOUND",
+			Message: "trace graph not found",
+		})
+		return
+	}
+
+	writeJSON(w, http.StatusOK, response)
+}
+
+func traceIDFromTraceGraphPath(path string) string {
+	const prefix = "/api/agent-observability/v1/traces/"
+	const suffix = "/trace-graph"
+	if !strings.HasPrefix(path, prefix) || !strings.HasSuffix(path, suffix) {
+		return ""
+	}
+	traceID := strings.TrimSuffix(strings.TrimPrefix(path, prefix), suffix)
+	traceID = strings.Trim(traceID, "/")
+	if strings.Contains(traceID, "/") {
+		return ""
+	}
+	return strings.TrimSpace(traceID)
 }
 
 func writeJSON(w http.ResponseWriter, statusCode int, payload any) {

--- a/bkn-trace/agent-observability/src/driveradapter/api/httphandler/trace_handler_test.go
+++ b/bkn-trace/agent-observability/src/driveradapter/api/httphandler/trace_handler_test.go
@@ -1,0 +1,95 @@
+package httphandler
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/openbkn-ai/bkn-foundry/bkn-trace/agent-observability/src/domain/service/tracesvc"
+	"github.com/openbkn-ai/bkn-foundry/bkn-trace/agent-observability/src/domain/valueobject/opensearchvo"
+)
+
+type fakeTraceHandlerPort struct {
+	result opensearchvo.SearchResult
+}
+
+func (p *fakeTraceHandlerPort) SearchTraces(_ context.Context, _ json.RawMessage) (opensearchvo.SearchResult, error) {
+	return p.result, nil
+}
+
+func TestTraceHandlerReturnsTraceGraphByTraceID(t *testing.T) {
+	handler := NewTraceHandler(tracesvc.New(&fakeTraceHandlerPort{result: opensearchvo.SearchResult(handlerTraceGraphSearchResult())}))
+	req := httptest.NewRequest(http.MethodGet, "/api/agent-observability/v1/traces/trace_handler_001/trace-graph", nil)
+	rec := httptest.NewRecorder()
+
+	handler.GetTraceSubresource(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+	body := rec.Body.String()
+	if !strings.Contains(body, `"trace_id":"trace_handler_001"`) || !strings.Contains(body, `"status":"error"`) {
+		t.Fatalf("unexpected trace graph body: %s", body)
+	}
+	if !strings.Contains(body, `"edge_type":"parent_child"`) || !strings.Contains(body, `"duration_nano":90`) {
+		t.Fatalf("expected graph edge and duration: %s", body)
+	}
+}
+
+func TestTraceHandlerReturnsNotFoundForMissingTraceGraph(t *testing.T) {
+	handler := NewTraceHandler(tracesvc.New(&fakeTraceHandlerPort{result: opensearchvo.SearchResult(`{"hits":{"hits":[]}}`)}))
+	req := httptest.NewRequest(http.MethodGet, "/api/agent-observability/v1/traces/missing/trace-graph", nil)
+	rec := httptest.NewRecorder()
+
+	handler.GetTraceSubresource(rec, req)
+
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("expected 404, got %d: %s", rec.Code, rec.Body.String())
+	}
+}
+
+func handlerTraceGraphSearchResult() []byte {
+	return []byte(`{
+  "hits": {
+    "hits": [
+      {
+        "_source": {
+          "resourceSpans": [
+            {
+              "resource": {"attributes": [{"key": "service.name", "value": {"stringValue": "agent-observability"}}]},
+              "scopeSpans": [
+                {
+                  "spans": [
+                    {
+                      "traceId": "trace_handler_001",
+                      "spanId": "root",
+                      "name": "GET /trace",
+                      "kind": "SERVER",
+                      "startTimeUnixNano": "10",
+                      "endTimeUnixNano": "100",
+                      "status": {"code": "STATUS_CODE_OK"}
+                    },
+                    {
+                      "traceId": "trace_handler_001",
+                      "spanId": "child",
+                      "parentSpanId": "root",
+                      "name": "opensearch.search",
+                      "kind": "CLIENT",
+                      "startTimeUnixNano": "20",
+                      "endTimeUnixNano": "80",
+                      "status": {"code": "STATUS_CODE_ERROR", "message": "query failed"}
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      }
+    ]
+  }
+}`)
+}


### PR DESCRIPTION
## Summary

- Add normalized Trace Graph API: `GET /api/agent-observability/v1/traces/{trace_id}/trace-graph`.
- Build trace tree nodes and parent-child edges from OTel `resourceSpans` returned by the trace index.
- Return graph status, duration, error messages, node/edge counts, and `partial_reason=["orphan_span"]` for missing parents.
- Keep existing Evidence Chain / Business Graph / Snapshot Preview trace subresources routed through the same `/traces/` prefix.
- Update README and generated Swagger docs.

## Verification

- `env GOCACHE=/tmp/openbkn-go-cache go test ./...`
- `env GOCACHE=/tmp/openbkn-go-cache go vet ./...`
- `git diff --check`
- `go run github.com/swaggo/swag/cmd/swag init -g main.go -o docs/swagger --parseDependency --parseInternal`

Note: Swagger generation completed and updated docs; `swag` emitted Go 1.26 stdlib constant parsing warnings, but exited successfully.
