### PR TITLE
test(bkn-trace): add e2e lite readiness probe

### DIFF
--- a/bkn-trace/agent-observability/README.md
+++ b/bkn-trace/agent-observability/README.md
@@ -33,6 +33,31 @@ make test
 GOCACHE=/tmp/openbkn-go-build-cache GOMODCACHE=/tmp/openbkn-go-mod-cache go test ./...
 ```
 
+本地 E2E Lite 就绪性探测：
+
+```bash
+python3 scripts/test_bkn_trace_e2e_lite_probe.py
+python3 scripts/bkn_trace_e2e_lite_probe.py \
+  --base-url http://localhost \
+  --trace-id <trace_id> \
+  --request-id <bkn.request.id>
+```
+
+默认模式只探测真实 OpenBKN Gateway / BKN Trace API 是否可用，不写入集群、不创建索引、不使用 mock 数据。常见失败原因包括：Studio dev proxy 未启用、认证失败、BKN Trace API 未部署、trace/evidence OpenSearch index 缺失或 trace id 不存在。
+
+如果本地已经有 OTLP HTTP collector 和 BKN Trace API，可显式启用写入模式，生成一条最小真实 trace 和最小 evidence batch 后再查询：
+
+```bash
+python3 scripts/bkn_trace_e2e_lite_probe.py \
+  --base-url http://127.0.0.1:8080 \
+  --trace-id 33333333333333333333333333333333 \
+  --request-id req_bkn_trace_e2e_lite_probe_003 \
+  --emit-otlp-url http://127.0.0.1:4318/v1/traces \
+  --ingest-evidence
+```
+
+本地自签 HTTPS 网关可以加 `--insecure`。写入模式仍只写最小诊断 span、claim、evidence ref 和 business ref，不包含 prompt、完整 SQL、行级数据、token 或裸对象存储 URL。由于 collector 到 OpenSearch 可能存在短暂可见性延迟，查询类 endpoint 默认重试 3 次，可用 `--retries` 和 `--retry-delay` 调整。
+
 阶段二 evidence ingestion 接口接受 `bkn.trace.schema.version=2.0.0` 的事件批次，包含 `trace` 与 `events`。当前版本先完成 contract 校验、敏感 payload 拒绝、归一化计数、最小 Evidence Chain 查询、Business Graph 查询和 Evidence Node 查询；默认使用内存 repository，生产或共享测试环境可切换到 OpenSearch evidence index store。
 
 ### Evidence Store

--- a/bkn-trace/agent-observability/scripts/bkn_trace_e2e_lite_probe.py
+++ b/bkn-trace/agent-observability/scripts/bkn_trace_e2e_lite_probe.py
@@ -1,0 +1,477 @@
+#!/usr/bin/env python3
+import argparse
+import json
+import re
+import ssl
+import sys
+import time
+import urllib.error
+import urllib.parse
+import urllib.request
+from dataclasses import dataclass
+
+
+TRACEPARENT_RE = re.compile(
+    r"^[0-9a-f]{2}-([0-9a-f]{32})-[0-9a-f]{16}-[0-9a-f]{2}$"
+)
+
+
+@dataclass(frozen=True)
+class ProbeResult:
+    name: str
+    status: str
+    reason: str
+    detail: str = ""
+
+
+def extract_trace_id(traceparent: str) -> str:
+    match = TRACEPARENT_RE.match(traceparent.strip().lower())
+    if not match:
+        raise ValueError("invalid traceparent")
+    trace_id = match.group(1)
+    if trace_id == "0" * 32:
+        raise ValueError("invalid traceparent: zero trace id")
+    return trace_id
+
+
+def classify_http_result(status_code: int, body: str) -> ProbeResult:
+    if 200 <= status_code < 300:
+        return ProbeResult("http", "pass", "ok")
+
+    lowered = body.lower()
+    if status_code == 0 and ("ssl" in lowered or "certificate" in lowered):
+        return ProbeResult("http", "fail", "tls_failed")
+    if status_code == 0:
+        return ProbeResult("http", "fail", "connection_failed")
+    if "public base url of /studio/" in lowered:
+        return ProbeResult("http", "fail", "studio_proxy_not_enabled")
+    if status_code in (401, 403):
+        return ProbeResult("http", "fail", "auth_failed")
+    if "index_not_found_exception" in lowered:
+        return ProbeResult("http", "fail", "trace_index_missing")
+    if status_code == 502:
+        return ProbeResult("http", "fail", "bad_gateway")
+    if status_code == 404:
+        return ProbeResult("http", "fail", "not_found")
+    return ProbeResult("http", "fail", f"http_{status_code}")
+
+
+def request_json(
+    url: str,
+    token: str = "",
+    timeout: float = 10.0,
+    insecure: bool = False,
+) -> tuple[int, str]:
+    request = urllib.request.Request(url, headers={"Accept": "application/json"})
+    if token:
+        request.add_header("Authorization", f"Bearer {token}")
+    context = ssl._create_unverified_context() if insecure else None
+    handlers = [urllib.request.ProxyHandler({})]
+    if context:
+        handlers.append(urllib.request.HTTPSHandler(context=context))
+    opener = urllib.request.build_opener(*handlers)
+    try:
+        with opener.open(request, timeout=timeout) as response:
+            return response.status, response.read().decode("utf-8", errors="replace")
+    except urllib.error.HTTPError as error:
+        return error.code, error.read().decode("utf-8", errors="replace")
+    except urllib.error.URLError as error:
+        return 0, str(error.reason)
+
+
+def post_json(
+    url: str,
+    payload: dict,
+    token: str = "",
+    timeout: float = 10.0,
+    insecure: bool = False,
+) -> tuple[int, str]:
+    body = json.dumps(payload).encode("utf-8")
+    request = urllib.request.Request(
+        url,
+        data=body,
+        headers={"Accept": "application/json", "Content-Type": "application/json"},
+        method="POST",
+    )
+    if token:
+        request.add_header("Authorization", f"Bearer {token}")
+    context = ssl._create_unverified_context() if insecure else None
+    handlers = [urllib.request.ProxyHandler({})]
+    if context:
+        handlers.append(urllib.request.HTTPSHandler(context=context))
+    opener = urllib.request.build_opener(*handlers)
+    try:
+        with opener.open(request, timeout=timeout) as response:
+            return response.status, response.read().decode("utf-8", errors="replace")
+    except urllib.error.HTTPError as error:
+        return error.code, error.read().decode("utf-8", errors="replace")
+    except urllib.error.URLError as error:
+        return 0, str(error.reason)
+
+
+def join_url(base_url: str, path: str, params: dict[str, str] | None = None) -> str:
+    base = base_url.rstrip("/")
+    url = f"{base}{path}"
+    if params:
+        url = f"{url}?{urllib.parse.urlencode(params)}"
+    return url
+
+
+def parse_json(body: str) -> dict | None:
+    try:
+        parsed = json.loads(body)
+    except json.JSONDecodeError:
+        return None
+    return parsed if isinstance(parsed, dict) else None
+
+
+def probe_endpoint(
+    name: str,
+    url: str,
+    token: str,
+    timeout: float,
+    insecure: bool,
+    retries: int,
+    retry_delay: float,
+) -> ProbeResult:
+    attempts = max(0, retries) + 1
+    retryable = {"not_found", "trace_index_missing", "connection_failed", "bad_gateway"}
+    for attempt in range(attempts):
+        status_code, body = request_json(url, token=token, timeout=timeout, insecure=insecure)
+        result = classify_http_result(status_code, body)
+        if result.status == "pass":
+            break
+        if result.reason not in retryable or attempt == attempts - 1:
+            return ProbeResult(name, result.status, result.reason, body[:300])
+        if retry_delay > 0:
+            time.sleep(retry_delay)
+
+    payload = parse_json(body)
+    if payload is None:
+        return ProbeResult(name, "fail", "invalid_json", body[:300])
+    if payload.get("partial") is True:
+        reasons = payload.get("partial_reason") or []
+        return ProbeResult(name, "warn", "partial", ",".join(map(str, reasons)))
+    return ProbeResult(name, "pass", "ok")
+
+
+def post_endpoint(
+    name: str,
+    url: str,
+    payload: dict,
+    token: str,
+    timeout: float,
+    insecure: bool,
+) -> ProbeResult:
+    status_code, body = post_json(url, payload, token=token, timeout=timeout, insecure=insecure)
+    result = classify_http_result(status_code, body)
+    if result.status != "pass":
+        return ProbeResult(name, result.status, result.reason, body[:300])
+    return ProbeResult(name, "pass", "ok")
+
+
+def build_otlp_trace_payload(trace_id: str, span_id: str, request_id: str) -> dict:
+    return {
+        "resourceSpans": [
+            {
+                "resource": {
+                    "attributes": [
+                        {"key": "service.name", "value": {"stringValue": "bkn-trace-e2e-lite-probe"}}
+                    ]
+                },
+                "scopeSpans": [
+                    {
+                        "scope": {"name": "bkn-trace-e2e-lite-probe"},
+                        "spans": [
+                            {
+                                "traceId": trace_id,
+                                "spanId": span_id,
+                                "name": "bkn-trace.e2e_lite_probe",
+                                "kind": 2,
+                                "startTimeUnixNano": "1784894250000000000",
+                                "endTimeUnixNano": "1784894251000000000",
+                                "attributes": [
+                                    {"key": "bkn.request.id", "value": {"stringValue": request_id}},
+                                    {"key": "bkn.module.name", "value": {"stringValue": "bkn-trace"}},
+                                ],
+                                "status": {"code": 1},
+                            }
+                        ],
+                    }
+                ],
+            }
+        ]
+    }
+
+
+def build_evidence_payload(trace_id: str, span_id: str, request_id: str) -> dict:
+    base_event = {
+        "bkn.trace.schema.version": "2.0.0",
+        "observed_at": "2026-07-24T11:57:30.100000000Z",
+        "emitted_at": "2026-07-24T11:57:30.101000000Z",
+        "producer_module": "bkn-trace-e2e-lite-probe",
+        "trace_id": trace_id,
+        "span_id": span_id,
+        "bkn.request.id": request_id,
+        "bkn.operation.name": "bkn_trace.e2e_lite_probe",
+    }
+    return {
+        "bkn.trace.schema.version": "2.0.0",
+        "trace": {
+            "trace_id": trace_id,
+            "bkn.request.id": request_id,
+            "traceparent": f"00-{trace_id}-{span_id}-01",
+            "bkn.tenant.id": "tenant_e2e_lite",
+            "bkn.account.id": "acct_e2e_lite",
+            "bkn.account.type": "app",
+        },
+        "events": [
+            {
+                **base_event,
+                "event_id": "evt_e2e_lite_claim",
+                "event_type": "claim.created",
+                "payload": {
+                    "claim_id": "claim_e2e_lite",
+                    "claim_type": "diagnostic",
+                    "claim_hash": "sha256:e2e-lite-claim",
+                    "visibility": "visible",
+                    "version_status": "versioned",
+                },
+            },
+            {
+                **base_event,
+                "event_id": "evt_e2e_lite_evidence",
+                "event_type": "evidence.refs.created",
+                "payload": {
+                    "claim_id": "claim_e2e_lite",
+                    "evidence_refs": [
+                        {
+                            "ref_id": "row:e2e_lite_visible",
+                            "ref_type": "row_ref",
+                            "visibility": "visible",
+                            "version_status": "versioned",
+                        }
+                    ],
+                },
+            },
+            {
+                **base_event,
+                "event_id": "evt_e2e_lite_business",
+                "event_type": "business.refs.resolved",
+                "payload": {
+                    "claim_id": "claim_e2e_lite",
+                    "business_refs": [
+                        {
+                            "ref_id": "object:e2e_customer",
+                            "ref_type": "object",
+                            "label": "E2E Customer",
+                            "visibility": "visible",
+                            "version_status": "versioned",
+                        }
+                    ],
+                },
+            },
+        ],
+    }
+
+
+def run_probe(args: argparse.Namespace) -> list[ProbeResult]:
+    trace_id = args.trace_id
+    if not trace_id and args.traceparent:
+        trace_id = extract_trace_id(args.traceparent)
+    span_id = args.span_id
+    request_id = args.request_id
+
+    results: list[ProbeResult] = []
+    if trace_id and request_id and args.emit_otlp_url:
+        results.append(
+            post_endpoint(
+                "emit_otlp_trace",
+                args.emit_otlp_url,
+                build_otlp_trace_payload(trace_id, span_id, request_id),
+                args.token,
+                args.timeout,
+                args.insecure,
+            )
+        )
+    if trace_id and request_id and args.ingest_evidence:
+        results.append(
+            post_endpoint(
+                "ingest_evidence",
+                join_url(args.base_url, "/api/agent-observability/v1/evidence/events"),
+                build_evidence_payload(trace_id, span_id, request_id),
+                args.token,
+                args.timeout,
+                args.insecure,
+            )
+        )
+    if trace_id:
+        results.append(
+            probe_endpoint(
+                "trace_graph",
+                join_url(args.base_url, f"/api/agent-observability/v1/traces/{trace_id}/trace-graph"),
+                args.token,
+                args.timeout,
+                args.insecure,
+                args.retries,
+                args.retry_delay,
+            )
+        )
+        results.append(
+            probe_endpoint(
+                "evidence_chain_by_trace",
+                join_url(
+                    args.base_url,
+                    f"/api/agent-observability/v1/traces/{trace_id}/evidence-chain",
+                    {"limit": str(args.limit)},
+                ),
+                args.token,
+                args.timeout,
+                args.insecure,
+                args.retries,
+                args.retry_delay,
+            )
+        )
+        results.append(
+            probe_endpoint(
+                "business_graph_by_trace",
+                join_url(
+                    args.base_url,
+                    f"/api/agent-observability/v1/traces/{trace_id}/business-graph",
+                    {"limit": str(args.limit)},
+                ),
+                args.token,
+                args.timeout,
+                args.insecure,
+                args.retries,
+                args.retry_delay,
+            )
+        )
+        results.append(
+            probe_endpoint(
+                "snapshot_preview_by_trace",
+                join_url(
+                    args.base_url,
+                    f"/api/agent-observability/v1/traces/{trace_id}/snapshot-preview",
+                    {"limit": str(args.limit)},
+                ),
+                args.token,
+                args.timeout,
+                args.insecure,
+                args.retries,
+                args.retry_delay,
+            )
+        )
+
+    if args.request_id:
+        results.append(
+            probe_endpoint(
+                "evidence_chain_by_request",
+                join_url(
+                    args.base_url,
+                    "/api/agent-observability/v1/traces/by-request",
+                    {"request_id": args.request_id, "limit": str(args.limit)},
+                ),
+                args.token,
+                args.timeout,
+                args.insecure,
+                args.retries,
+                args.retry_delay,
+            )
+        )
+        results.append(
+            probe_endpoint(
+                "business_graph_by_request",
+                join_url(
+                    args.base_url,
+                    "/api/agent-observability/v1/traces/by-request/business-graph",
+                    {"request_id": args.request_id, "limit": str(args.limit)},
+                ),
+                args.token,
+                args.timeout,
+                args.insecure,
+                args.retries,
+                args.retry_delay,
+            )
+        )
+        results.append(
+            probe_endpoint(
+                "snapshot_preview_by_request",
+                join_url(
+                    args.base_url,
+                    "/api/agent-observability/v1/traces/by-request/snapshot-preview",
+                    {"request_id": args.request_id, "limit": str(args.limit)},
+                ),
+                args.token,
+                args.timeout,
+                args.insecure,
+                args.retries,
+                args.retry_delay,
+            )
+        )
+
+    if not results:
+        results.append(
+            ProbeResult(
+                "input",
+                "fail",
+                "missing_trace_or_request_id",
+                "provide --trace-id, --traceparent, or --request-id",
+            )
+        )
+    return results
+
+
+def print_results(results: list[ProbeResult]) -> None:
+    for result in results:
+        line = f"{result.status.upper():4} {result.name}: {result.reason}"
+        if result.detail:
+            line = f"{line} - {result.detail}"
+        print(line)
+
+
+def parse_args(argv: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Probe BKN Trace E2E Lite readiness against a real OpenBKN API endpoint."
+    )
+    parser.add_argument("--base-url", default="https://localhost", help="OpenBKN gateway base URL")
+    parser.add_argument("--trace-id", default="", help="Trace id to query")
+    parser.add_argument("--traceparent", default="", help="W3C traceparent; trace id is extracted")
+    parser.add_argument("--request-id", default="", help="bkn.request.id to query")
+    parser.add_argument(
+        "--span-id",
+        default="2222222222222222",
+        help="Span id used when --emit-otlp-url or --ingest-evidence is enabled",
+    )
+    parser.add_argument(
+        "--emit-otlp-url",
+        default="",
+        help="Optional OTLP HTTP traces endpoint; when set, emits one minimal real span before queries",
+    )
+    parser.add_argument(
+        "--ingest-evidence",
+        action="store_true",
+        help="Post one minimal evidence event batch to the BKN Trace API before queries",
+    )
+    parser.add_argument("--token", default="", help="Bearer token for authenticated gateways")
+    parser.add_argument("--limit", type=int, default=100, help="Query limit for graph endpoints")
+    parser.add_argument("--timeout", type=float, default=10.0, help="HTTP timeout in seconds")
+    parser.add_argument("--retries", type=int, default=3, help="Retry count for query endpoints")
+    parser.add_argument("--retry-delay", type=float, default=1.0, help="Delay between query retries")
+    parser.add_argument(
+        "--insecure",
+        action="store_true",
+        help="Skip TLS certificate verification for local self-signed gateways",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str]) -> int:
+    args = parse_args(argv)
+    results = run_probe(args)
+    print_results(results)
+    return 1 if any(result.status == "fail" for result in results) else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/bkn-trace/agent-observability/scripts/test_bkn_trace_e2e_lite_probe.py
+++ b/bkn-trace/agent-observability/scripts/test_bkn_trace_e2e_lite_probe.py
@@ -1,0 +1,194 @@
+import json
+import unittest
+from unittest import mock
+
+import bkn_trace_e2e_lite_probe as probe
+
+
+class BknTraceE2ELiteProbeTest(unittest.TestCase):
+    def test_extracts_trace_id_from_traceparent(self):
+        traceparent = "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01"
+
+        self.assertEqual(
+            probe.extract_trace_id(traceparent),
+            "4bf92f3577b34da6a3ce929d0e0e4736",
+        )
+
+    def test_rejects_invalid_traceparent(self):
+        with self.assertRaises(ValueError):
+            probe.extract_trace_id("00-invalid-span-01")
+
+    def test_classifies_vite_base_url_404(self):
+        result = probe.classify_http_result(
+            404,
+            "The server is configured with a public base URL of /studio/",
+        )
+
+        self.assertEqual(result.status, "fail")
+        self.assertEqual(result.reason, "studio_proxy_not_enabled")
+
+    def test_classifies_backend_index_missing(self):
+        body = json.dumps(
+            {
+                "error": {
+                    "type": "index_not_found_exception",
+                    "reason": "no such index [ss4o_traces-default-anyshare]",
+                },
+                "status": 404,
+            }
+        )
+
+        result = probe.classify_http_result(404, body)
+
+        self.assertEqual(result.status, "fail")
+        self.assertEqual(result.reason, "trace_index_missing")
+
+    def test_classifies_auth_failure(self):
+        result = probe.classify_http_result(401, '{"message":"unauthorized"}')
+
+        self.assertEqual(result.status, "fail")
+        self.assertEqual(result.reason, "auth_failed")
+
+    def test_classifies_bad_gateway(self):
+        result = probe.classify_http_result(502, "Bad Gateway")
+
+        self.assertEqual(result.status, "fail")
+        self.assertEqual(result.reason, "bad_gateway")
+
+    def test_classifies_tls_failure(self):
+        result = probe.classify_http_result(
+            0,
+            "[SSL: UNEXPECTED_EOF_WHILE_READING] EOF occurred in violation of protocol",
+        )
+
+        self.assertEqual(result.status, "fail")
+        self.assertEqual(result.reason, "tls_failed")
+
+    def test_classifies_ok_json(self):
+        result = probe.classify_http_result(200, '{"trace_id":"trace_001"}')
+
+        self.assertEqual(result.status, "pass")
+        self.assertEqual(result.reason, "ok")
+
+    def test_probe_endpoint_maps_partial_to_warn(self):
+        with mock.patch.object(
+            probe,
+            "request_json",
+            return_value=(200, '{"partial":true,"partial_reason":["evidence_query_truncated"]}'),
+        ):
+            result = probe.probe_endpoint(
+                "evidence_chain",
+                "http://127.0.0.1:8080/evidence-chain",
+                token="",
+                timeout=1,
+                insecure=False,
+                retries=0,
+                retry_delay=0,
+            )
+
+        self.assertEqual(result.status, "warn")
+        self.assertEqual(result.reason, "partial")
+        self.assertEqual(result.detail, "evidence_query_truncated")
+
+    def test_probe_endpoint_distinguishes_empty_object_from_invalid_json(self):
+        with mock.patch.object(probe, "request_json", return_value=(200, "{}")):
+            empty_result = probe.probe_endpoint(
+                "empty",
+                "http://127.0.0.1:8080/empty",
+                token="",
+                timeout=1,
+                insecure=False,
+                retries=0,
+                retry_delay=0,
+            )
+        with mock.patch.object(probe, "request_json", return_value=(200, "not-json")):
+            invalid_result = probe.probe_endpoint(
+                "invalid",
+                "http://127.0.0.1:8080/invalid",
+                token="",
+                timeout=1,
+                insecure=False,
+                retries=0,
+                retry_delay=0,
+            )
+
+        self.assertEqual(empty_result.status, "pass")
+        self.assertEqual(invalid_result.status, "fail")
+        self.assertEqual(invalid_result.reason, "invalid_json")
+
+    def test_parse_args_supports_insecure_tls(self):
+        args = probe.parse_args(["--insecure"])
+
+        self.assertTrue(args.insecure)
+
+    def test_builds_minimal_otlp_payload(self):
+        payload = probe.build_otlp_trace_payload(
+            trace_id="11111111111111111111111111111111",
+            span_id="2222222222222222",
+            request_id="req_e2e",
+        )
+
+        span = payload["resourceSpans"][0]["scopeSpans"][0]["spans"][0]
+        self.assertEqual(span["traceId"], "11111111111111111111111111111111")
+        self.assertEqual(span["spanId"], "2222222222222222")
+        self.assertEqual(span["attributes"][0]["key"], "bkn.request.id")
+
+    def test_builds_minimal_evidence_payload(self):
+        payload = probe.build_evidence_payload(
+            trace_id="11111111111111111111111111111111",
+            span_id="2222222222222222",
+            request_id="req_e2e",
+        )
+
+        self.assertEqual(payload["trace"]["trace_id"], "11111111111111111111111111111111")
+        self.assertEqual(len(payload["events"]), 3)
+        self.assertEqual(payload["events"][0]["event_type"], "claim.created")
+
+    def test_run_probe_emits_before_querying(self):
+        args = probe.parse_args(
+            [
+                "--base-url",
+                "http://127.0.0.1:8080",
+                "--trace-id",
+                "11111111111111111111111111111111",
+                "--request-id",
+                "req_e2e",
+                "--emit-otlp-url",
+                "http://127.0.0.1:4318/v1/traces",
+                "--ingest-evidence",
+            ]
+        )
+
+        with mock.patch.object(probe, "post_json", return_value=(200, "{}")) as post_json:
+            with mock.patch.object(probe, "request_json", return_value=(200, '{"trace_id":"ok"}')):
+                results = probe.run_probe(args)
+
+        self.assertEqual(post_json.call_count, 2)
+        self.assertEqual(results[0].name, "emit_otlp_trace")
+        self.assertEqual(results[1].name, "ingest_evidence")
+        self.assertTrue(all(result.status == "pass" for result in results))
+
+    def test_probe_endpoint_retries_eventual_trace_visibility(self):
+        with mock.patch.object(
+            probe,
+            "request_json",
+            side_effect=[
+                (404, '{"code":"NOT_FOUND"}'),
+                (200, '{"trace_id":"ok"}'),
+            ],
+        ):
+            result = probe.probe_endpoint(
+                "trace_graph",
+                "http://127.0.0.1:8080/trace-graph",
+                token="",
+                timeout=1,
+                insecure=False,
+                retries=1,
+                retry_delay=0,
+            )
+
+        self.assertEqual(result.status, "pass")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/bkn-trace/agent-observability/src/domain/service/tracesvc/service.go
+++ b/bkn-trace/agent-observability/src/domain/service/tracesvc/service.go
@@ -6,6 +6,7 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/openbkn-ai/bkn-foundry/bkn-trace/agent-observability/src/domain/valueobject/opensearchvo"
 	"github.com/openbkn-ai/bkn-foundry/bkn-trace/agent-observability/src/domain/valueobject/oteltracevo"
@@ -32,11 +33,16 @@ func (s *TraceQueryService) GetTraceGraphByTraceID(ctx context.Context, traceID 
 		"size": DefaultTraceGraphSpanLimit + 1,
 		"query": map[string]any{
 			"term": map[string]string{
-				"traceId.keyword": traceID,
+				"traceId": traceID,
 			},
 		},
 		"sort": []map[string]any{
-			{"startTimeUnixNano": map[string]string{"order": "asc"}},
+			{
+				"startTime": map[string]string{
+					"order":         "asc",
+					"unmapped_type": "date",
+				},
+			},
 		},
 	})
 	if err != nil {
@@ -75,6 +81,18 @@ type spanRecord struct {
 	ServiceName string
 }
 
+type ss4oFlatSpan struct {
+	TraceID      string             `json:"traceId"`
+	SpanID       string             `json:"spanId"`
+	ParentSpanID string             `json:"parentSpanId"`
+	Name         string             `json:"name"`
+	Kind         string             `json:"kind"`
+	StartTime    string             `json:"startTime"`
+	EndTime      string             `json:"endTime"`
+	Resource     map[string]string  `json:"resource"`
+	Status       oteltracevo.Status `json:"status"`
+}
+
 func spansFromSearchResult(result opensearchvo.SearchResult, traceID string) ([]spanRecord, error) {
 	var response searchResponse
 	if err := json.Unmarshal(result, &response); err != nil {
@@ -87,12 +105,37 @@ func spansFromSearchResult(result opensearchvo.SearchResult, traceID string) ([]
 			records = append(records, spansFromTraceData(traceData, traceID)...)
 			continue
 		}
+		var flatSpan ss4oFlatSpan
+		if err := json.Unmarshal(hit.Source, &flatSpan); err == nil && isSS4OFlatSpan(flatSpan, traceID) {
+			records = append(records, spanRecord{
+				Span: oteltracevo.Span{
+					TraceID:           flatSpan.TraceID,
+					SpanID:            flatSpan.SpanID,
+					ParentSpanID:      flatSpan.ParentSpanID,
+					Name:              flatSpan.Name,
+					Kind:              flatSpan.Kind,
+					StartTimeUnixNano: rfc3339ToNanoString(flatSpan.StartTime),
+					EndTimeUnixNano:   rfc3339ToNanoString(flatSpan.EndTime),
+					Status:            flatSpan.Status,
+				},
+				ServiceName: flatSpan.Resource["service.name"],
+			})
+			continue
+		}
 		var span oteltracevo.Span
-		if err := json.Unmarshal(hit.Source, &span); err == nil && span.TraceID == traceID {
+		if err := json.Unmarshal(hit.Source, &span); err == nil && isOTLPSpan(span, traceID) {
 			records = append(records, spanRecord{Span: span})
 		}
 	}
 	return records, nil
+}
+
+func isSS4OFlatSpan(span ss4oFlatSpan, traceID string) bool {
+	return span.TraceID == traceID && span.SpanID != "" && (span.StartTime != "" || span.EndTime != "")
+}
+
+func isOTLPSpan(span oteltracevo.Span, traceID string) bool {
+	return span.TraceID == traceID && span.SpanID != "" && (span.StartTimeUnixNano != "" || span.EndTimeUnixNano != "")
 }
 
 func spansFromTraceData(traceData oteltracevo.TraceData, traceID string) []spanRecord {
@@ -219,7 +262,7 @@ func resourceAttribute(resource oteltracevo.Resource, key string) string {
 }
 
 func spanStatus(status oteltracevo.Status) string {
-	switch status.Code {
+	switch strings.ToUpper(status.Code) {
 	case "STATUS_CODE_ERROR", "ERROR":
 		return "error"
 	default:
@@ -230,6 +273,14 @@ func spanStatus(status oteltracevo.Status) string {
 func parseNano(value string) (int64, bool) {
 	parsed, err := strconv.ParseInt(value, 10, 64)
 	return parsed, err == nil
+}
+
+func rfc3339ToNanoString(value string) string {
+	parsed, err := time.Parse(time.RFC3339Nano, value)
+	if err != nil {
+		return ""
+	}
+	return strconv.FormatInt(parsed.UnixNano(), 10)
 }
 
 func sortedKeys(values map[string]struct{}) []string {

--- a/bkn-trace/agent-observability/src/domain/service/tracesvc/service_test.go
+++ b/bkn-trace/agent-observability/src/domain/service/tracesvc/service_test.go
@@ -31,7 +31,7 @@ func TestGetTraceGraphByTraceIDBuildsTreeStatusAndDuration(t *testing.T) {
 	if !found {
 		t.Fatal("expected trace graph to be found")
 	}
-	if !strings.Contains(string(port.query), `"traceId.keyword":"trace_graph_001"`) {
+	if !strings.Contains(string(port.query), `"traceId":"trace_graph_001"`) {
 		t.Fatalf("expected trace id term query, got %s", string(port.query))
 	}
 	if response.TraceID != "trace_graph_001" || response.Status != "error" || response.DurationNano != 110 {
@@ -51,6 +51,65 @@ func TestGetTraceGraphByTraceIDBuildsTreeStatusAndDuration(t *testing.T) {
 	}
 	if response.Data.Nodes[2].Status != "error" || response.Data.Nodes[2].ErrorMessage != "tool failed" {
 		t.Fatalf("expected error node with message: %+v", response.Data.Nodes[2])
+	}
+}
+
+func TestGetTraceGraphByTraceIDSupportsSS4OFlatSpanDocuments(t *testing.T) {
+	port := &fakeTracePort{result: opensearchvo.SearchResult(traceGraphSS4OFlatSearchResult())}
+	service := New(port)
+
+	response, found, err := service.GetTraceGraphByTraceID(context.Background(), "trace_graph_ss4o")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !found {
+		t.Fatal("expected trace graph to be found")
+	}
+	if strings.Contains(string(port.query), "startTimeUnixNano") {
+		t.Fatalf("query must not sort on missing SS4O field startTimeUnixNano: %s", string(port.query))
+	}
+	if response.Page.NodeCount != 1 || len(response.Data.Nodes) != 1 {
+		t.Fatalf("expected one SS4O span node, got %+v", response)
+	}
+	node := response.Data.Nodes[0]
+	if node.SpanID != "ss4o_span" || node.ServiceName != "bkn-trace-e2e-lite-probe" {
+		t.Fatalf("unexpected SS4O node mapping: %+v", node)
+	}
+	if node.StartNano == 0 || node.EndNano == 0 || node.DurationNano != int64(1000000000) {
+		t.Fatalf("expected RFC3339 timestamps to map to nanos, got %+v", node)
+	}
+}
+
+func TestGetTraceGraphByTraceIDSupportsSS4OFlatSpanWithoutAttributes(t *testing.T) {
+	port := &fakeTracePort{result: opensearchvo.SearchResult(traceGraphSS4OFlatWithoutAttributesSearchResult())}
+	service := New(port)
+
+	response, found, err := service.GetTraceGraphByTraceID(context.Background(), "trace_graph_ss4o_no_attrs")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !found {
+		t.Fatal("expected trace graph to be found")
+	}
+	node := response.Data.Nodes[0]
+	if node.StartNano == 0 || node.ServiceName != "bkn-trace-e2e-lite-probe" {
+		t.Fatalf("expected SS4O flat span mapping without attributes, got %+v", node)
+	}
+}
+
+func TestGetTraceGraphByTraceIDRecognizesSS4OErrorStatus(t *testing.T) {
+	port := &fakeTracePort{result: opensearchvo.SearchResult(traceGraphSS4OErrorSearchResult())}
+	service := New(port)
+
+	response, found, err := service.GetTraceGraphByTraceID(context.Background(), "trace_graph_ss4o_error")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !found {
+		t.Fatal("expected trace graph to be found")
+	}
+	if response.Status != "error" || response.Data.Nodes[0].Status != "error" {
+		t.Fatalf("expected SS4O Error status to map to error, got %+v", response)
 	}
 }
 
@@ -239,6 +298,91 @@ func traceGraphOrphanSearchResult() []byte {
               ]
             }
           ]
+        }
+      }
+    ]
+  }
+}`)
+}
+
+func traceGraphSS4OFlatSearchResult() []byte {
+	return []byte(`{
+  "hits": {
+    "hits": [
+      {
+        "_source": {
+          "attributes": {
+            "bkn.module.name": "bkn-trace",
+            "bkn.request.id": "req_bkn_trace_e2e_lite_probe_001"
+          },
+          "endTime": "2026-07-24T11:57:31Z",
+          "kind": "Server",
+          "name": "bkn-trace.e2e_lite_probe",
+          "parentSpanId": "",
+          "resource": {
+            "service.name": "bkn-trace-e2e-lite-probe"
+          },
+          "spanId": "ss4o_span",
+          "startTime": "2026-07-24T11:57:30Z",
+          "status": {
+            "code": "Ok",
+            "message": ""
+          },
+          "traceId": "trace_graph_ss4o"
+        }
+      }
+    ]
+  }
+}`)
+}
+
+func traceGraphSS4OFlatWithoutAttributesSearchResult() []byte {
+	return []byte(`{
+  "hits": {
+    "hits": [
+      {
+        "_source": {
+          "endTime": "2026-07-24T11:57:31Z",
+          "kind": "Server",
+          "name": "bkn-trace.e2e_lite_probe",
+          "parentSpanId": "",
+          "resource": {
+            "service.name": "bkn-trace-e2e-lite-probe"
+          },
+          "spanId": "ss4o_span_no_attrs",
+          "startTime": "2026-07-24T11:57:30Z",
+          "status": {
+            "code": "Ok",
+            "message": ""
+          },
+          "traceId": "trace_graph_ss4o_no_attrs"
+        }
+      }
+    ]
+  }
+}`)
+}
+
+func traceGraphSS4OErrorSearchResult() []byte {
+	return []byte(`{
+  "hits": {
+    "hits": [
+      {
+        "_source": {
+          "endTime": "2026-07-24T11:57:31Z",
+          "kind": "Server",
+          "name": "bkn-trace.e2e_lite_probe",
+          "parentSpanId": "",
+          "resource": {
+            "service.name": "bkn-trace-e2e-lite-probe"
+          },
+          "spanId": "ss4o_span_error",
+          "startTime": "2026-07-24T11:57:30Z",
+          "status": {
+            "code": "Error",
+            "message": "failed"
+          },
+          "traceId": "trace_graph_ss4o_error"
         }
       }
     ]


### PR DESCRIPTION
## What

Adds a lightweight BKN Trace E2E Lite readiness probe for `agent-observability`.

The probe checks real OpenBKN / BKN Trace endpoints and classifies common failure modes:

- Studio dev proxy not enabled
- auth failure
- BKN Trace API not deployed / trace not found
- trace/evidence OpenSearch index missing
- partial graph responses

It also supports extracting `trace_id` from W3C `traceparent`.

## Why

BKN Trace should not rely on mock Studio data for validation. Before running the full local OpenBKN E2E, developers need a low-risk probe that says whether the current environment can actually query BKN Trace APIs.

Local inspection found that the existing kind OpenBKN environment already occupies `https://localhost/studio/`, but it does not require stopping for this step. The blocking issue is BKN Trace readiness: the deployed `agent-observability` is older and the expected trace/evidence indexes are absent.

## Validation

```bash
python3 scripts/test_bkn_trace_e2e_lite_probe.py
git diff origin/main...HEAD --check
```

Both passed locally.

## Notes

The probe is read-only. It does not write to the cluster, create OpenSearch indexes, or seed mock data.
