### PR TITLE
fix(bkn): optimize knowledge network list pagination (#427)

### DIFF
--- a/adp/bkn/bkn-backend/server/drivenadapters/action_type/action_type_access.go
+++ b/adp/bkn/bkn-backend/server/drivenadapters/action_type/action_type_access.go
@@ -303,6 +303,12 @@ func (ata *actionTypeAccess) ListActionTypes(ctx context.Context, query interfac
 	if query.Sort != "" {
 		builder = builder.OrderBy(fmt.Sprintf("%s %s", query.Sort, query.Direction))
 	}
+	if query.Limit > 0 {
+		builder = builder.Limit(uint64(query.Limit))
+		if query.Offset > 0 {
+			builder = builder.Offset(uint64(query.Offset))
+		}
+	}
 
 	sqlStr, vals, err := builder.ToSql()
 	if err != nil {

--- a/adp/bkn/bkn-backend/server/drivenadapters/action_type/action_type_access_test.go
+++ b/adp/bkn/bkn-backend/server/drivenadapters/action_type/action_type_access_test.go
@@ -466,7 +466,7 @@ func Test_ActionTypeAccess_ListActionTypes(t *testing.T) {
 			sqlStr := fmt.Sprintf("SELECT f_id, f_name, f_tags, f_comment, f_icon, f_color, f_bkn_raw_content, "+
 				"f_kn_id, f_branch, f_action_type, f_action_intent, f_impact_contracts, f_object_type_id, f_condition, f_affect, f_action_source, "+
 				"f_parameters, f_schedule, f_creator, f_creator_type, f_create_time, f_updater, f_updater_type, f_update_time "+
-				"FROM %s WHERE f_kn_id = ? AND f_branch = ? ORDER BY f_name ASC", AT_TABLE_NAME)
+				"FROM %s WHERE f_kn_id = ? AND f_branch = ? ORDER BY f_name ASC LIMIT 20 OFFSET 10", AT_TABLE_NAME)
 
 			rows := sqlmock.NewRows([]string{
 				"f_id", "f_name", "f_tags", "f_comment", "f_icon", "f_color", "f_bkn_raw_content",
@@ -484,6 +484,8 @@ func Test_ActionTypeAccess_ListActionTypes(t *testing.T) {
 
 			queryWithSort := interfaces.ActionTypesQueryParams{
 				PaginationQueryParameters: interfaces.PaginationQueryParameters{
+					Limit:     20,
+					Offset:    10,
 					Sort:      "f_name",
 					Direction: "ASC",
 				},

--- a/adp/bkn/bkn-backend/server/drivenadapters/concept_group/concept_group_access.go
+++ b/adp/bkn/bkn-backend/server/drivenadapters/concept_group/concept_group_access.go
@@ -236,6 +236,12 @@ func (cga *conceptGroupAccess) ListConceptGroups(ctx context.Context, query inte
 	if query.Sort != "" {
 		builder = builder.OrderBy(fmt.Sprintf("%s %s", query.Sort, query.Direction))
 	}
+	if query.Limit > 0 {
+		builder = builder.Limit(uint64(query.Limit))
+		if query.Offset > 0 {
+			builder = builder.Offset(uint64(query.Offset))
+		}
+	}
 
 	sqlStr, vals, err := builder.ToSql()
 	if err != nil {

--- a/adp/bkn/bkn-backend/server/drivenadapters/concept_group/concept_group_access_test.go
+++ b/adp/bkn/bkn-backend/server/drivenadapters/concept_group/concept_group_access_test.go
@@ -274,7 +274,7 @@ func Test_conceptGroupAccess_ListConceptGroups(t *testing.T) {
 		Convey("ListConceptGroups with Sort ASC\n", func() {
 			sqlStr := fmt.Sprintf("SELECT f_id, f_name, f_tags, f_comment, f_icon, f_color, f_bkn_raw_content, "+
 				"f_kn_id, f_branch, f_creator, f_creator_type, f_create_time, f_updater, f_updater_type, f_update_time "+
-				"FROM %s WHERE f_kn_id = ? AND f_branch = ? ORDER BY f_name ASC", CONCEPT_GROUP_TABLE_NAME)
+				"FROM %s WHERE f_kn_id = ? AND f_branch = ? ORDER BY f_name ASC LIMIT 20 OFFSET 10", CONCEPT_GROUP_TABLE_NAME)
 
 			rows := sqlmock.NewRows([]string{
 				"f_id", "f_name", "f_tags", "f_comment", "f_icon", "f_color", "f_bkn_raw_content",
@@ -288,6 +288,8 @@ func Test_conceptGroupAccess_ListConceptGroups(t *testing.T) {
 
 			queryWithSort := interfaces.ConceptGroupsQueryParams{
 				PaginationQueryParameters: interfaces.PaginationQueryParameters{
+					Limit:     20,
+					Offset:    10,
 					Sort:      "f_name",
 					Direction: "ASC",
 				},

--- a/adp/bkn/bkn-backend/server/drivenadapters/knowledge_network/knowledge_network_access.go
+++ b/adp/bkn/bkn-backend/server/drivenadapters/knowledge_network/knowledge_network_access.go
@@ -210,7 +210,7 @@ func (kna *knowledgeNetworkAccess) ListKNs(ctx context.Context, query interfaces
 		attr.Key("db_url").String(libdb.GetDBUrl()),
 		attr.Key("db_type").String(libdb.GetDBType()))
 
-	subBuilder := sq.Select(
+	columns := []string{
 		"f_id",
 		"f_name",
 		"f_tags",
@@ -226,14 +226,24 @@ func (kna *knowledgeNetworkAccess) ListKNs(ctx context.Context, query interfaces
 		"f_create_time",
 		"f_updater",
 		"f_updater_type",
-		"f_update_time").
-		From(KN_TABLE_NAME)
+		"f_update_time",
+	}
+	if query.OnlyIDs {
+		columns = []string{"f_id"}
+	}
+	subBuilder := sq.Select(columns...).From(KN_TABLE_NAME)
 
 	builder := processQueryCondition(query, subBuilder)
 
 	//排序
 	if query.Sort != "" {
 		builder = builder.OrderBy(fmt.Sprintf("%s %s", query.Sort, query.Direction))
+	}
+	if query.Limit > 0 {
+		builder = builder.Limit(uint64(query.Limit))
+		if query.Offset > 0 {
+			builder = builder.Offset(uint64(query.Offset))
+		}
 	}
 
 	sqlStr, vals, err := builder.ToSql()
@@ -256,6 +266,14 @@ func (kna *knowledgeNetworkAccess) ListKNs(ctx context.Context, query interfaces
 	for rows.Next() {
 		KN := interfaces.KN{
 			ModuleType: interfaces.MODULE_TYPE_KN,
+		}
+		if query.OnlyIDs {
+			if err := rows.Scan(&KN.KNID); err != nil {
+				otellog.LogError(ctx, "Row scan error", err)
+				return []*interfaces.KN{}, err
+			}
+			KNs = append(KNs, &KN)
+			continue
 		}
 		tagsStr := ""
 		err := rows.Scan(
@@ -562,6 +580,10 @@ func processQueryCondition(query interfaces.KNsQueryParams, subBuilder sq.Select
 
 	if query.BusinessDomain != "" {
 		subBuilder = subBuilder.Where(sq.Eq{"f_business_domain": query.BusinessDomain})
+	}
+
+	if len(query.CandidateIDs) > 0 {
+		subBuilder = subBuilder.Where(sq.Eq{"f_id": query.CandidateIDs})
 	}
 
 	return subBuilder

--- a/adp/bkn/bkn-backend/server/drivenadapters/knowledge_network/knowledge_network_access_test.go
+++ b/adp/bkn/bkn-backend/server/drivenadapters/knowledge_network/knowledge_network_access_test.go
@@ -327,7 +327,7 @@ func Test_knowledgeNetworkAccess_ListKNs(t *testing.T) {
 			}
 			sqlStrWithAll := fmt.Sprintf("SELECT f_id, f_name, f_tags, f_comment, f_icon, f_color, f_bkn_raw_content, f_skill_content, "+
 				"f_branch, f_business_domain, f_creator, f_creator_type, f_create_time, f_updater, f_updater_type, f_update_time "+
-				"FROM %s WHERE (instr(f_name, ?) > 0 OR instr(f_id, ?) > 0) AND instr(f_tags, ?) > 0 AND f_business_domain = ? ORDER BY f_name ASC",
+				"FROM %s WHERE (instr(f_name, ?) > 0 OR instr(f_id, ?) > 0) AND instr(f_tags, ?) > 0 AND f_business_domain = ? ORDER BY f_name ASC LIMIT 20 OFFSET 10",
 				KN_TABLE_NAME)
 
 			rows := sqlmock.NewRows([]string{
@@ -336,7 +336,7 @@ func Test_knowledgeNetworkAccess_ListKNs(t *testing.T) {
 				"f_updater", "f_updater_type", "f_update_time",
 			})
 
-			smock.ExpectQuery(sqlStrWithAll).WithArgs().WillReturnRows(rows)
+			smock.ExpectQuery(sqlStrWithAll).WithArgs("test", "test", `"tag1"`, "domain1").WillReturnRows(rows)
 
 			kns, err := kna.ListKNs(testCtx, queryWithAll)
 			So(err, ShouldBeNil)

--- a/adp/bkn/bkn-backend/server/drivenadapters/object_type/object_type_access.go
+++ b/adp/bkn/bkn-backend/server/drivenadapters/object_type/object_type_access.go
@@ -340,6 +340,12 @@ func (ota *objectTypeAccess) ListObjectTypes(ctx context.Context, tx *sql.Tx, qu
 	if query.Sort != "" {
 		builder = builder.OrderBy(fmt.Sprintf("ot.%s %s", query.Sort, query.Direction))
 	}
+	if query.Limit > 0 {
+		builder = builder.Limit(uint64(query.Limit))
+		if query.Offset > 0 {
+			builder = builder.Offset(uint64(query.Offset))
+		}
+	}
 
 	sqlStr, vals, err := builder.ToSql()
 	if err != nil {

--- a/adp/bkn/bkn-backend/server/drivenadapters/object_type/object_type_access_test.go
+++ b/adp/bkn/bkn-backend/server/drivenadapters/object_type/object_type_access_test.go
@@ -716,7 +716,7 @@ func Test_objectTypeAccess_ListObjectTypes(t *testing.T) {
 			   FROM t_object_type AS ot JOIN t_object_type_status AS ots ON ot.f_id = ots.f_id 
 			   AND ot.f_kn_id = ots.f_kn_id AND ot.f_branch = ots.f_branch 
 			   WHERE (instr(ot.f_name, ?) > 0 OR instr(ot.f_id, ?) > 0) AND instr(ot.f_tags, ?) > 0 AND ot.f_branch = ? 
-			   AND ot.f_id IN (?,?) ORDER BY ot.ot.f_name ASC`
+			   AND ot.f_id IN (?,?) ORDER BY ot.ot.f_name ASC LIMIT 20 OFFSET 10`
 
 			rows := sqlmock.NewRows([]string{
 				"ot.f_id", "ot.f_name", "ot.f_tags", "ot.f_comment", "ot.f_icon", "ot.f_color", "ot.f_bkn_raw_content",

--- a/adp/bkn/bkn-backend/server/drivenadapters/relation_type/relation_type_access.go
+++ b/adp/bkn/bkn-backend/server/drivenadapters/relation_type/relation_type_access.go
@@ -211,6 +211,12 @@ func (rta *relationTypeAccess) ListRelationTypes(ctx context.Context, query inte
 	if query.Sort != "" {
 		builder = builder.OrderBy(fmt.Sprintf("%s %s", query.Sort, query.Direction))
 	}
+	if query.Limit > 0 {
+		builder = builder.Limit(uint64(query.Limit))
+		if query.Offset > 0 {
+			builder = builder.Offset(uint64(query.Offset))
+		}
+	}
 
 	sqlStr, vals, err := builder.ToSql()
 	if err != nil {

--- a/adp/bkn/bkn-backend/server/drivenadapters/relation_type/relation_type_access_test.go
+++ b/adp/bkn/bkn-backend/server/drivenadapters/relation_type/relation_type_access_test.go
@@ -331,7 +331,7 @@ func Test_relationTypeAccess_ListRelationTypes(t *testing.T) {
 			 f_kn_id, f_branch, f_source_object_type_id, f_target_object_type_id, f_type, f_mapping_rules, 
 			 f_creator, f_creator_type, f_create_time, f_updater, f_updater_type, f_update_time 
 			 FROM t_relation_type WHERE (instr(f_name, ?) > 0 OR instr(f_id, ?) > 0) AND instr(f_tags, ?) > 0 AND f_branch = ? 
-			 AND f_source_object_type_id IN (?) AND f_target_object_type_id IN (?) ORDER BY f_name ASC`
+			 AND f_source_object_type_id IN (?) AND f_target_object_type_id IN (?) ORDER BY f_name ASC LIMIT 20 OFFSET 10`
 
 			rows := sqlmock.NewRows([]string{
 				"f_id", "f_name", "f_tags", "f_comment", "f_icon", "f_color", "f_bkn_raw_content",
@@ -339,7 +339,9 @@ func Test_relationTypeAccess_ListRelationTypes(t *testing.T) {
 				"f_creator", "f_creator_type", "f_create_time", "f_updater", "f_updater_type", "f_update_time",
 			})
 
-			smock.ExpectQuery(sqlStrWithAll).WithArgs().WillReturnRows(rows)
+			smock.ExpectQuery(sqlStrWithAll).
+				WithArgs("test", "test", `"tag1"`, interfaces.MAIN_BRANCH, "ot1", "ot2").
+				WillReturnRows(rows)
 
 			relationTypes, err := rta.ListRelationTypes(testCtx, queryWithAll)
 			So(err, ShouldBeNil)

--- a/adp/bkn/bkn-backend/server/driveradapters/knowledge_network_handler.go
+++ b/adp/bkn/bkn-backend/server/driveradapters/knowledge_network_handler.go
@@ -865,18 +865,28 @@ func (r *restHandler) GetRelationTypePaths(c *gin.Context, visitor hydra.Visitor
 
 // QueryKNNamesByIDs 按 ID 批量取知识网络名称(对象级授权页回显，统一契约)。
 // 请求 {"ids":[...]}，响应 {"entries":[{"id","name"}]}；缺失 id 略过、空 ids 返回空 entries。
-// 绕过授权过滤：授权页需为用户无权但被引用的 KN 回显名称，故不做 token/权限校验，与
-// operator-integration 的 /skills/names、/operator/names、/tool-box/names 契约一致。
+// 授权页需为用户无权但被引用的 KN 回显名称，故不做知识网络权限过滤；调用方仍必须完成 OAuth 认证。
 func (r *restHandler) QueryKNNamesByIDs(c *gin.Context) {
 	logger.Debug("Handler QueryKNNamesByIDs Start")
 	ctx, span := oteltrace.StartServerSpan(c)
 	defer span.End()
 	oteltrace.AddHttpAttrs4API(span, oteltrace.GetAttrsByGinCtx(c))
 
+	if _, err := r.verifyOAuth(ctx, c); err != nil {
+		return
+	}
+
 	req := interfaces.KNBatchNamesReq{}
 	if err := c.ShouldBindJSON(&req); err != nil {
 		httpErr := rest.NewHTTPError(ctx, http.StatusBadRequest, berrors.BknBackend_KnowledgeNetwork_InvalidParameter).
 			WithErrorDetails("Binding Parameter Failed: " + err.Error())
+		oteltrace.AddHttpAttrs4HttpError(span, httpErr)
+		rest.ReplyError(c, httpErr)
+		return
+	}
+	if len(req.IDs) > interfaces.KN_BATCH_NAMES_MAX_IDS {
+		httpErr := rest.NewHTTPError(ctx, http.StatusBadRequest, berrors.BknBackend_KnowledgeNetwork_InvalidParameter).
+			WithErrorDetails(fmt.Sprintf("ids exceeds the maximum size of %d", interfaces.KN_BATCH_NAMES_MAX_IDS))
 		oteltrace.AddHttpAttrs4HttpError(span, httpErr)
 		rest.ReplyError(c, httpErr)
 		return

--- a/adp/bkn/bkn-backend/server/driveradapters/knowledge_network_handler_test.go
+++ b/adp/bkn/bkn-backend/server/driveradapters/knowledge_network_handler_test.go
@@ -8,6 +8,7 @@ package driveradapters
 
 import (
 	"bytes"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -249,6 +250,31 @@ func Test_KnowledgeNetworkRestHandler_DeleteKN(t *testing.T) {
 			engine.ServeHTTP(w, req)
 
 			So(w.Result().StatusCode, ShouldEqual, http.StatusNotFound)
+		})
+	})
+}
+
+func Test_KnowledgeNetworkRestHandler_QueryKNNamesByIDs(t *testing.T) {
+	Convey("Test QueryKNNamesByIDs", t, func() {
+		test := setGinMode()
+		defer test()
+
+		mockCtrl := gomock.NewController(t)
+		defer mockCtrl.Finish()
+		as := bmock.NewMockAuthService(mockCtrl)
+		kns := bmock.NewMockKNService(mockCtrl)
+		handler := MockNewKnowledgeNetworkRestHandler(&common.AppSetting{}, as, kns)
+		engine := gin.New()
+		handler.RegisterPublic(engine)
+
+		Convey("Rejects an unauthenticated request", func() {
+			as.EXPECT().VerifyToken(gomock.Any(), gomock.Any()).Return(hydra.Visitor{}, errors.New("invalid token"))
+			req := httptest.NewRequest(http.MethodPost, "/api/bkn-backend/v1/knowledge-networks/names",
+				bytes.NewBufferString(`{"ids":["kn1"]}`))
+			req.Header.Set("Content-Type", "application/json")
+			w := httptest.NewRecorder()
+			engine.ServeHTTP(w, req)
+			So(w.Code, ShouldEqual, http.StatusUnauthorized)
 		})
 	})
 }

--- a/adp/bkn/bkn-backend/server/interfaces/knowledge_network.go
+++ b/adp/bkn/bkn-backend/server/interfaces/knowledge_network.go
@@ -193,6 +193,8 @@ func slimObjectTypeForSummary(ot *ObjectType) {
 	}
 }
 
+const KN_BATCH_NAMES_MAX_IDS = 100
+
 // KNBatchNamesReq 按 ID 批量取知识网络名称请求(对象级授权页回显，统一契约)
 type KNBatchNamesReq struct {
 	IDs []string `json:"ids"` // 待取名的知识网络 ID 列表，空列表返回空 entries

--- a/adp/bkn/bkn-backend/server/interfaces/knowledge_network.go
+++ b/adp/bkn/bkn-backend/server/interfaces/knowledge_network.go
@@ -228,6 +228,10 @@ type KNsQueryParams struct {
 	Tag            string
 	BusinessDomain string
 	Branch         string
+	// CandidateIDs restricts an internal detail query to permission-filtered IDs.
+	CandidateIDs []string `json:"-" form:"-"`
+	// OnlyIDs avoids loading list detail before permission filtering.
+	OnlyIDs bool `json:"-" form:"-"`
 }
 
 // 概念搜索

--- a/adp/bkn/bkn-backend/server/logics/action_type/action_type_service.go
+++ b/adp/bkn/bkn-backend/server/logics/action_type/action_type_service.go
@@ -362,19 +362,32 @@ func (ats *actionTypeService) ListActionTypes(ctx context.Context, query interfa
 		return []*interfaces.ActionType{}, 0, rest.NewHTTPError(ctx, http.StatusInternalServerError,
 			berrors.BknBackend_ActionType_InternalError).WithErrorDetails(err.Error())
 	}
+
+	total, err := ats.ata.GetActionTypesTotal(ctx, query)
+	if err != nil {
+		logger.Errorf("GetActionTypesTotal error: %s", err.Error())
+		span.SetStatus(codes.Error, "Get action types total error")
+		return []*interfaces.ActionType{}, 0, rest.NewHTTPError(ctx, http.StatusInternalServerError,
+			berrors.BknBackend_ActionType_InternalError).WithErrorDetails(err.Error())
+	}
 	if len(actionTypes) == 0 {
 		span.SetStatus(codes.Ok, "")
-		return actionTypes, 0, nil
+		return actionTypes, total, nil
 	}
 
-	// 获取绑定对象类的名称拿到
+	objectTypeIDs := make([]string, 0, len(actionTypes))
 	for _, actionType := range actionTypes {
-		objectTypeMap, err := ats.ots.GetObjectTypesMapByIDs(ctx, query.KNID,
-			query.Branch, []string{actionType.ObjectTypeID}, false)
-		if err != nil {
-			return []*interfaces.ActionType{}, 0, err
-		}
+		objectTypeIDs = append(objectTypeIDs, actionType.ObjectTypeID)
+	}
 
+	objectTypeMap, err := ats.ots.GetObjectTypesMapByIDs(ctx, query.KNID,
+		query.Branch, common.DuplicateSlice(objectTypeIDs), false)
+	if err != nil {
+		return []*interfaces.ActionType{}, 0, err
+	}
+
+	// 补充当前页行动类绑定对象类的名称。
+	for _, actionType := range actionTypes {
 		if objectTypeMap[actionType.ObjectTypeID] != nil {
 			actionType.ObjectType = interfaces.SimpleObjectType{
 				OTID:   objectTypeMap[actionType.ObjectTypeID].OTID,
@@ -383,24 +396,6 @@ func (ats *actionTypeService) ListActionTypes(ctx context.Context, query interfa
 				Color:  objectTypeMap[actionType.ObjectTypeID].Color,
 			}
 		}
-	}
-	total := len(actionTypes)
-
-	// limit = -1,则返回所有
-	if query.Limit != -1 {
-		// 分页
-		// 检查起始位置是否越界
-		if query.Offset < 0 || query.Offset >= len(actionTypes) {
-			span.SetStatus(codes.Ok, "")
-			return []*interfaces.ActionType{}, total, nil
-		}
-		// 计算结束位置
-		end := query.Offset + query.Limit
-		if end > len(actionTypes) {
-			end = len(actionTypes)
-		}
-
-		actionTypes = actionTypes[query.Offset:end]
 	}
 
 	accountInfos := make([]*interfaces.AccountInfo, 0, len(actionTypes)*2)

--- a/adp/bkn/bkn-backend/server/logics/action_type/action_type_service_test.go
+++ b/adp/bkn/bkn-backend/server/logics/action_type/action_type_service_test.go
@@ -406,6 +406,7 @@ func Test_actionTypeService_ListActionTypes(t *testing.T) {
 
 			ps.EXPECT().CheckPermission(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
 			ata.EXPECT().ListActionTypes(gomock.Any(), gomock.Any()).Return(atArr, nil)
+			ata.EXPECT().GetActionTypesTotal(gomock.Any(), gomock.Any()).Return(1, nil)
 			ots.EXPECT().GetObjectTypesMapByIDs(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(map[string]*interfaces.ObjectType{}, nil)
 			ums.EXPECT().GetAccountNames(gomock.Any(), gomock.Any()).Return(nil)
 
@@ -427,6 +428,7 @@ func Test_actionTypeService_ListActionTypes(t *testing.T) {
 
 			ps.EXPECT().CheckPermission(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
 			ata.EXPECT().ListActionTypes(gomock.Any(), gomock.Any()).Return([]*interfaces.ActionType{}, nil)
+			ata.EXPECT().GetActionTypesTotal(gomock.Any(), gomock.Any()).Return(0, nil)
 
 			ats, total, err := service.ListActionTypes(ctx, query)
 			So(err, ShouldBeNil)
@@ -480,6 +482,7 @@ func Test_actionTypeService_ListActionTypes(t *testing.T) {
 
 			ps.EXPECT().CheckPermission(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
 			ata.EXPECT().ListActionTypes(gomock.Any(), gomock.Any()).Return(atArr, nil)
+			ata.EXPECT().GetActionTypesTotal(gomock.Any(), gomock.Any()).Return(1, nil)
 			ots.EXPECT().GetObjectTypesMapByIDs(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, rest.NewHTTPError(ctx, 500, berrors.BknBackend_ActionType_InternalError))
 
 			ats, total, err := service.ListActionTypes(ctx, query)
@@ -509,6 +512,7 @@ func Test_actionTypeService_ListActionTypes(t *testing.T) {
 
 			ps.EXPECT().CheckPermission(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
 			ata.EXPECT().ListActionTypes(gomock.Any(), gomock.Any()).Return(atArr, nil)
+			ata.EXPECT().GetActionTypesTotal(gomock.Any(), gomock.Any()).Return(1, nil)
 			ots.EXPECT().GetObjectTypesMapByIDs(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(map[string]*interfaces.ObjectType{}, nil)
 			ums.EXPECT().GetAccountNames(gomock.Any(), gomock.Any()).Return(rest.NewHTTPError(ctx, 500, berrors.BknBackend_ActionType_InternalError))
 
@@ -539,6 +543,7 @@ func Test_actionTypeService_ListActionTypes(t *testing.T) {
 
 			ps.EXPECT().CheckPermission(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
 			ata.EXPECT().ListActionTypes(gomock.Any(), gomock.Any()).Return(atArr, nil)
+			ata.EXPECT().GetActionTypesTotal(gomock.Any(), gomock.Any()).Return(1, nil)
 			ots.EXPECT().GetObjectTypesMapByIDs(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(map[string]*interfaces.ObjectType{}, nil)
 			ums.EXPECT().GetAccountNames(gomock.Any(), gomock.Any()).Return(nil)
 
@@ -557,19 +562,9 @@ func Test_actionTypeService_ListActionTypes(t *testing.T) {
 					Offset: 100,
 				},
 			}
-			atArr := []*interfaces.ActionType{
-				{
-					ActionTypeWithKeyField: interfaces.ActionTypeWithKeyField{
-						ATID:         "at1",
-						ATName:       "at1",
-						ObjectTypeID: "ot1",
-					},
-				},
-			}
-
 			ps.EXPECT().CheckPermission(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
-			ata.EXPECT().ListActionTypes(gomock.Any(), gomock.Any()).Return(atArr, nil)
-			ots.EXPECT().GetObjectTypesMapByIDs(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(map[string]*interfaces.ObjectType{}, nil)
+			ata.EXPECT().ListActionTypes(gomock.Any(), gomock.Any()).Return([]*interfaces.ActionType{}, nil)
+			ata.EXPECT().GetActionTypesTotal(gomock.Any(), gomock.Any()).Return(1, nil)
 
 			ats, total, err := service.ListActionTypes(ctx, query)
 			So(err, ShouldBeNil)
@@ -611,8 +606,10 @@ func Test_actionTypeService_ListActionTypes(t *testing.T) {
 			}
 
 			ps.EXPECT().CheckPermission(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
-			ata.EXPECT().ListActionTypes(gomock.Any(), gomock.Any()).Return(atArr, nil)
-			ots.EXPECT().GetObjectTypesMapByIDs(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(map[string]*interfaces.ObjectType{}, nil).AnyTimes()
+			ata.EXPECT().ListActionTypes(gomock.Any(), gomock.Any()).Return(atArr[1:], nil)
+			ata.EXPECT().GetActionTypesTotal(gomock.Any(), gomock.Any()).Return(3, nil)
+			ots.EXPECT().GetObjectTypesMapByIDs(gomock.Any(), "kn1", interfaces.MAIN_BRANCH,
+				[]string{"ot1"}, false).Return(map[string]*interfaces.ObjectType{}, nil)
 			ums.EXPECT().GetAccountNames(gomock.Any(), gomock.Any()).Return(nil)
 
 			ats, total, err := service.ListActionTypes(ctx, query)

--- a/adp/bkn/bkn-backend/server/logics/concept_group/concept_group_service.go
+++ b/adp/bkn/bkn-backend/server/logics/concept_group/concept_group_service.go
@@ -413,27 +413,18 @@ func (cgs *conceptGroupService) ListConceptGroups(ctx context.Context,
 		return []*interfaces.ConceptGroup{}, 0, rest.NewHTTPError(ctx, http.StatusInternalServerError,
 			berrors.BknBackend_ConceptGroup_InternalError).WithErrorDetails(err.Error())
 	}
+
+	total, err := cgs.cga.GetConceptGroupsTotal(ctx, query)
+	if err != nil {
+		logger.Errorf("GetConceptGroupsTotal error: %s", err.Error())
+		span.SetStatus(codes.Error, "Get concept groups total error")
+
+		return []*interfaces.ConceptGroup{}, 0, rest.NewHTTPError(ctx, http.StatusInternalServerError,
+			berrors.BknBackend_ConceptGroup_InternalError).WithErrorDetails(err.Error())
+	}
 	if len(conceptGroups) == 0 {
 		span.SetStatus(codes.Ok, "")
-		return []*interfaces.ConceptGroup{}, 0, nil
-	}
-
-	total := len(conceptGroups)
-
-	// limit = -1,则返回所有
-	if query.Limit != -1 {
-		// 分页
-		// 检查起始位置是否越界
-		if query.Offset < 0 || query.Offset >= len(conceptGroups) {
-			span.SetStatus(codes.Ok, "")
-			return []*interfaces.ConceptGroup{}, total, nil
-		}
-		// 计算结束位置
-		end := query.Offset + query.Limit
-		if end > len(conceptGroups) {
-			end = len(conceptGroups)
-		}
-		conceptGroups = conceptGroups[query.Offset:end]
+		return []*interfaces.ConceptGroup{}, total, nil
 	}
 
 	accountInfos := make([]*interfaces.AccountInfo, 0, len(conceptGroups)*2)
@@ -451,12 +442,6 @@ func (cgs *conceptGroupService) ListConceptGroups(ctx context.Context,
 
 	// 分组列表为每个组生成本体对象统计信息
 	for _, conceptGroup := range conceptGroups {
-		stats, err := cgs.GetStatByConceptGroup(ctx, conceptGroup)
-		if err != nil {
-			return []*interfaces.ConceptGroup{}, 0, err
-		}
-		conceptGroup.Statistics = stats
-
 		otIDs, err := cgs.cga.GetConceptIDsByConceptGroupIDs(ctx, conceptGroup.KNID,
 			conceptGroup.Branch, []string{conceptGroup.CGID}, interfaces.MODULE_TYPE_OBJECT_TYPE)
 		if err != nil {
@@ -469,6 +454,12 @@ func (cgs *conceptGroupService) ListConceptGroups(ctx context.Context,
 				berrors.BknBackend_ConceptGroup_InternalError).WithErrorDetails(err.Error())
 		}
 		conceptGroup.ObjectTypeIDs = otIDs
+
+		stats, err := cgs.getStatByObjectTypeIDs(ctx, conceptGroup, otIDs)
+		if err != nil {
+			return []*interfaces.ConceptGroup{}, 0, err
+		}
+		conceptGroup.Statistics = stats
 	}
 
 	span.SetStatus(codes.Ok, "")
@@ -613,6 +604,15 @@ func (cgs *conceptGroupService) GetStatByConceptGroup(ctx context.Context, conce
 		return nil, rest.NewHTTPError(ctx, http.StatusInternalServerError,
 			berrors.BknBackend_ConceptGroup_InternalError_GetConceptIDsByConceptGroupIDsFailed).WithErrorDetails(err.Error())
 	}
+
+	return cgs.getStatByObjectTypeIDs(ctx, conceptGroup, otIDs)
+}
+
+func (cgs *conceptGroupService) getStatByObjectTypeIDs(ctx context.Context,
+	conceptGroup *interfaces.ConceptGroup, otIDs []string) (*interfaces.Statistics, error) {
+
+	ctx, span := oteltrace.StartNamedInternalSpan(ctx, fmt.Sprintf("查询概念分组[%s]统计信息", conceptGroup.KNID))
+	defer span.End()
 
 	if len(otIDs) == 0 {
 		return &interfaces.Statistics{

--- a/adp/bkn/bkn-backend/server/logics/concept_group/concept_group_service_test.go
+++ b/adp/bkn/bkn-backend/server/logics/concept_group/concept_group_service_test.go
@@ -325,8 +325,9 @@ func Test_conceptGroupService_ListConceptGroups(t *testing.T) {
 
 			ps.EXPECT().CheckPermission(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
 			cga.EXPECT().ListConceptGroups(gomock.Any(), gomock.Any()).Return(cgArr, nil)
+			cga.EXPECT().GetConceptGroupsTotal(gomock.Any(), gomock.Any()).Return(1, nil)
 			ums.EXPECT().GetAccountNames(gomock.Any(), gomock.Any()).Return(nil)
-			cga.EXPECT().GetConceptIDsByConceptGroupIDs(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return([]string{}, nil).AnyTimes()
+			cga.EXPECT().GetConceptIDsByConceptGroupIDs(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return([]string{}, nil)
 
 			cgs, total, err := service.ListConceptGroups(ctx, query)
 			So(err, ShouldBeNil)
@@ -346,6 +347,7 @@ func Test_conceptGroupService_ListConceptGroups(t *testing.T) {
 
 			ps.EXPECT().CheckPermission(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
 			cga.EXPECT().ListConceptGroups(gomock.Any(), gomock.Any()).Return([]*interfaces.ConceptGroup{}, nil)
+			cga.EXPECT().GetConceptGroupsTotal(gomock.Any(), gomock.Any()).Return(0, nil)
 
 			cgs, total, err := service.ListConceptGroups(ctx, query)
 			So(err, ShouldBeNil)
@@ -400,6 +402,7 @@ func Test_conceptGroupService_ListConceptGroups(t *testing.T) {
 
 			ps.EXPECT().CheckPermission(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
 			cga.EXPECT().ListConceptGroups(gomock.Any(), gomock.Any()).Return(cgArr, nil)
+			cga.EXPECT().GetConceptGroupsTotal(gomock.Any(), gomock.Any()).Return(1, nil)
 			ums.EXPECT().GetAccountNames(gomock.Any(), gomock.Any()).Return(rest.NewHTTPError(ctx, 500, berrors.BknBackend_ConceptGroup_InternalError))
 
 			cgs, total, err := service.ListConceptGroups(ctx, query)
@@ -437,6 +440,7 @@ func Test_conceptGroupService_ListConceptGroups(t *testing.T) {
 
 			ps.EXPECT().CheckPermission(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
 			cga.EXPECT().ListConceptGroups(gomock.Any(), gomock.Any()).Return(cgArr, nil)
+			cga.EXPECT().GetConceptGroupsTotal(gomock.Any(), gomock.Any()).Return(1, nil)
 			ums.EXPECT().GetAccountNames(gomock.Any(), gomock.Any()).Return(nil)
 			cga.EXPECT().GetConceptIDsByConceptGroupIDs(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, rest.NewHTTPError(ctx, 500, berrors.BknBackend_ConceptGroup_InternalError))
 
@@ -464,6 +468,7 @@ func Test_conceptGroupService_ListConceptGroups(t *testing.T) {
 
 			ps.EXPECT().CheckPermission(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
 			cga.EXPECT().ListConceptGroups(gomock.Any(), gomock.Any()).Return(cgArr, nil)
+			cga.EXPECT().GetConceptGroupsTotal(gomock.Any(), gomock.Any()).Return(1, nil)
 			ums.EXPECT().GetAccountNames(gomock.Any(), gomock.Any()).Return(nil)
 			cga.EXPECT().GetConceptIDsByConceptGroupIDs(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes().Return([]string{}, nil)
 
@@ -482,15 +487,9 @@ func Test_conceptGroupService_ListConceptGroups(t *testing.T) {
 					Offset: 100,
 				},
 			}
-			cgArr := []*interfaces.ConceptGroup{
-				{
-					CGID:   "cg1",
-					CGName: "cg1",
-				},
-			}
-
 			ps.EXPECT().CheckPermission(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
-			cga.EXPECT().ListConceptGroups(gomock.Any(), gomock.Any()).Return(cgArr, nil)
+			cga.EXPECT().ListConceptGroups(gomock.Any(), gomock.Any()).Return([]*interfaces.ConceptGroup{}, nil)
+			cga.EXPECT().GetConceptGroupsTotal(gomock.Any(), gomock.Any()).Return(1, nil)
 
 			cgs, total, err := service.ListConceptGroups(ctx, query)
 			So(err, ShouldBeNil)
@@ -514,7 +513,8 @@ func Test_conceptGroupService_ListConceptGroups(t *testing.T) {
 			}
 
 			ps.EXPECT().CheckPermission(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
-			cga.EXPECT().ListConceptGroups(gomock.Any(), gomock.Any()).Return(cgArr, nil)
+			cga.EXPECT().ListConceptGroups(gomock.Any(), gomock.Any()).Return(cgArr[1:], nil)
+			cga.EXPECT().GetConceptGroupsTotal(gomock.Any(), gomock.Any()).Return(3, nil)
 			ums.EXPECT().GetAccountNames(gomock.Any(), gomock.Any()).Return(nil)
 			cga.EXPECT().GetConceptIDsByConceptGroupIDs(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return([]string{}, nil).AnyTimes()
 

--- a/adp/bkn/bkn-backend/server/logics/knowledge_network/knowledge_network_service.go
+++ b/adp/bkn/bkn-backend/server/logics/knowledge_network/knowledge_network_service.go
@@ -490,8 +490,11 @@ func (kns *knowledgeNetworkService) ListKNs(ctx context.Context, parameter inter
 	ctx, span := oteltrace.StartNamedInternalSpan(ctx, "查询业务知识网络列表")
 	defer span.End()
 
-	//获取业务知识网络列表
-	KNArr, err := kns.kna.ListKNs(ctx, parameter)
+	candidateQuery := parameter
+	candidateQuery.OnlyIDs = true
+	candidateQuery.Limit = -1
+	candidateQuery.Offset = 0
+	KNArr, err := kns.kna.ListKNs(ctx, candidateQuery)
 	if err != nil {
 		logger.Errorf("ListKNs error: %s", err.Error())
 		span.SetStatus(codes.Error, "List knowledge networks error")
@@ -518,31 +521,46 @@ func (kns *knowledgeNetworkService) ListKNs(ctx context.Context, parameter inter
 		return []*interfaces.KN{}, 0, err
 	}
 
-	KNs := make([]*interfaces.KN, 0)
+	visibleKNIDs := make([]string, 0, len(KNArr))
 	for _, kn := range KNArr {
-		// 只留下有权限的模型
-		if resrc, exist := matchResoucesMap[kn.KNID]; exist {
-			kn.Operations = resrc.Operations // 用户当前有权限的操作
-			KNs = append(KNs, kn)
+		if _, exist := matchResoucesMap[kn.KNID]; exist {
+			visibleKNIDs = append(visibleKNIDs, kn.KNID)
 		}
 	}
-	total := len(KNs)
+	total := len(visibleKNIDs)
 
-	// limit = -1,则返回所有
+	if parameter.Limit == 0 {
+		span.SetStatus(codes.Ok, "")
+		return []*interfaces.KN{}, total, nil
+	}
 	if parameter.Limit != -1 {
-		// 分页
-		// 检查起始位置是否越界
-		if parameter.Offset < 0 || parameter.Offset >= len(KNs) {
+		if parameter.Offset < 0 || parameter.Offset >= total {
 			span.SetStatus(codes.Ok, "")
 			return []*interfaces.KN{}, total, nil
 		}
-		// 计算结束位置
 		end := parameter.Offset + parameter.Limit
-		if end > len(KNs) {
-			end = len(KNs)
+		if end > total {
+			end = total
 		}
+		visibleKNIDs = visibleKNIDs[parameter.Offset:end]
+	}
 
-		KNs = KNs[parameter.Offset:end]
+	detailQuery := parameter
+	detailQuery.CandidateIDs = visibleKNIDs
+	detailQuery.Limit = -1
+	detailQuery.Offset = 0
+	if parameter.Limit > 0 {
+		detailQuery.Limit = len(visibleKNIDs)
+	}
+	KNs, err := kns.kna.ListKNs(ctx, detailQuery)
+	if err != nil {
+		logger.Errorf("ListKNs detail error: %s", err.Error())
+		span.SetStatus(codes.Error, "List knowledge network details error")
+		return []*interfaces.KN{}, 0, rest.NewHTTPError(ctx, http.StatusInternalServerError,
+			berrors.BknBackend_KnowledgeNetwork_InternalError).WithErrorDetails(err.Error())
+	}
+	for _, kn := range KNs {
+		kn.Operations = matchResoucesMap[kn.KNID].Operations
 	}
 
 	accountInfos := make([]*interfaces.AccountInfo, 0, len(KNs)*2)

--- a/adp/bkn/bkn-backend/server/logics/knowledge_network/knowledge_network_service.go
+++ b/adp/bkn/bkn-backend/server/logics/knowledge_network/knowledge_network_service.go
@@ -529,6 +529,11 @@ func (kns *knowledgeNetworkService) ListKNs(ctx context.Context, parameter inter
 	}
 	total := len(visibleKNIDs)
 
+	if total == 0 {
+		span.SetStatus(codes.Ok, "")
+		return []*interfaces.KN{}, 0, nil
+	}
+
 	if parameter.Limit == 0 {
 		span.SetStatus(codes.Ok, "")
 		return []*interfaces.KN{}, total, nil

--- a/adp/bkn/bkn-backend/server/logics/knowledge_network/knowledge_network_service_test.go
+++ b/adp/bkn/bkn-backend/server/logics/knowledge_network/knowledge_network_service_test.go
@@ -363,7 +363,7 @@ func Test_knowledgeNetworkService_ListKNs(t *testing.T) {
 				},
 			}
 
-			kna.EXPECT().ListKNs(gomock.Any(), gomock.Any()).Return(knArr, nil)
+			kna.EXPECT().ListKNs(gomock.Any(), gomock.Any()).Return(knArr, nil).AnyTimes()
 			ps.EXPECT().FilterResources(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
 				Return(map[string]interfaces.PermissionResourceOps{
 					"kn1": {
@@ -424,7 +424,7 @@ func Test_knowledgeNetworkService_ListKNs(t *testing.T) {
 				},
 			}
 
-			kna.EXPECT().ListKNs(gomock.Any(), gomock.Any()).Return(knArr, nil)
+			kna.EXPECT().ListKNs(gomock.Any(), gomock.Any()).Return(knArr, nil).AnyTimes()
 			ps.EXPECT().FilterResources(gomock.Any(), gomock.Any(), gomock.Any(),
 				gomock.Any(), gomock.Any(), gomock.Any()).
 				Return(nil, rest.NewHTTPError(ctx, 500, berrors.BknBackend_KnowledgeNetwork_InternalError))
@@ -449,7 +449,7 @@ func Test_knowledgeNetworkService_ListKNs(t *testing.T) {
 				},
 			}
 
-			kna.EXPECT().ListKNs(gomock.Any(), gomock.Any()).Return(knArr, nil)
+			kna.EXPECT().ListKNs(gomock.Any(), gomock.Any()).Return(knArr, nil).AnyTimes()
 			ps.EXPECT().FilterResources(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
 				Return(map[string]interfaces.PermissionResourceOps{
 					"kn1": {
@@ -478,7 +478,7 @@ func Test_knowledgeNetworkService_ListKNs(t *testing.T) {
 				},
 			}
 
-			kna.EXPECT().ListKNs(gomock.Any(), gomock.Any()).Return(knArr, nil)
+			kna.EXPECT().ListKNs(gomock.Any(), gomock.Any()).Return(knArr, nil).AnyTimes()
 			ps.EXPECT().FilterResources(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
 				Return(map[string]interfaces.PermissionResourceOps{
 					"kn1": {
@@ -543,7 +543,15 @@ func Test_knowledgeNetworkService_ListKNs(t *testing.T) {
 				},
 			}
 
-			kna.EXPECT().ListKNs(gomock.Any(), gomock.Any()).Return(knArr, nil)
+			candidateQuery := parameter
+			candidateQuery.OnlyIDs = true
+			candidateQuery.Limit = -1
+			candidateQuery.Offset = 0
+			detailQuery := parameter
+			detailQuery.CandidateIDs = []string{"kn2", "kn3"}
+			detailQuery.Offset = 0
+			kna.EXPECT().ListKNs(gomock.Any(), candidateQuery).Return(knArr, nil)
+			kna.EXPECT().ListKNs(gomock.Any(), detailQuery).Return(knArr[1:], nil)
 			ps.EXPECT().FilterResources(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
 				Return(map[string]interfaces.PermissionResourceOps{
 					"kn1": {Operations: []string{interfaces.OPERATION_TYPE_VIEW_DETAIL}},

--- a/adp/bkn/bkn-backend/server/logics/knowledge_network/knowledge_network_service_test.go
+++ b/adp/bkn/bkn-backend/server/logics/knowledge_network/knowledge_network_service_test.go
@@ -493,6 +493,27 @@ func Test_knowledgeNetworkService_ListKNs(t *testing.T) {
 			So(len(kns), ShouldEqual, 1)
 		})
 
+		Convey("Returns empty result when no knowledge networks are visible", func() {
+			parameter := interfaces.KNsQueryParams{
+				PaginationQueryParameters: interfaces.PaginationQueryParameters{
+					Limit:  -1,
+					Offset: 0,
+				},
+			}
+			knArr := []*interfaces.KN{{KNID: "kn1", KNName: "kn1"}}
+			candidateQuery := parameter
+			candidateQuery.OnlyIDs = true
+
+			kna.EXPECT().ListKNs(gomock.Any(), candidateQuery).Return(knArr, nil)
+			ps.EXPECT().FilterResources(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+				Return(map[string]interfaces.PermissionResourceOps{}, nil)
+
+			kns, total, err := service.ListKNs(ctx, parameter)
+			So(err, ShouldBeNil)
+			So(total, ShouldEqual, 0)
+			So(kns, ShouldResemble, []*interfaces.KN{})
+		})
+
 		Convey("Success with Offset out of bounds\n", func() {
 			parameter := interfaces.KNsQueryParams{
 				PaginationQueryParameters: interfaces.PaginationQueryParameters{

--- a/adp/bkn/bkn-backend/server/logics/object_type/object_type_service.go
+++ b/adp/bkn/bkn-backend/server/logics/object_type/object_type_service.go
@@ -467,27 +467,18 @@ func (ots *objectTypeService) ListObjectTypes(ctx context.Context, tx *sql.Tx,
 		return []*interfaces.ObjectType{}, 0, rest.NewHTTPError(ctx, http.StatusInternalServerError,
 			berrors.BknBackend_ObjectType_InternalError).WithErrorDetails(err.Error())
 	}
+
+	total, err := ots.ota.GetObjectTypesTotal(ctx, query)
+	if err != nil {
+		logger.Errorf("GetObjectTypesTotal error: %s", err.Error())
+		span.SetStatus(codes.Error, "Get object types total error")
+
+		return []*interfaces.ObjectType{}, 0, rest.NewHTTPError(ctx, http.StatusInternalServerError,
+			berrors.BknBackend_ObjectType_InternalError).WithErrorDetails(err.Error())
+	}
 	if len(objectTypes) == 0 {
 		span.SetStatus(codes.Ok, "")
-		return objectTypes, 0, nil
-	}
-
-	total := len(objectTypes)
-	// limit = -1,则返回所有
-	if query.Limit != -1 {
-
-		// 分页
-		// 检查起始位置是否越界
-		if query.Offset < 0 || query.Offset >= len(objectTypes) {
-			span.SetStatus(codes.Ok, "")
-			return []*interfaces.ObjectType{}, total, nil
-		}
-		// 计算结束位置
-		end := query.Offset + query.Limit
-		if end > len(objectTypes) {
-			end = len(objectTypes)
-		}
-		objectTypes = objectTypes[query.Offset:end]
+		return objectTypes, total, nil
 	}
 
 	accountInfos := make([]*interfaces.AccountInfo, 0, len(objectTypes)*2)

--- a/adp/bkn/bkn-backend/server/logics/object_type/object_type_service_test.go
+++ b/adp/bkn/bkn-backend/server/logics/object_type/object_type_service_test.go
@@ -1392,6 +1392,7 @@ func Test_objectTypeService_ListObjectTypes(t *testing.T) {
 			smock.ExpectBegin()
 			ps.EXPECT().CheckPermission(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
 			ota.EXPECT().ListObjectTypes(gomock.Any(), gomock.Any(), gomock.Any()).Return(objectTypes, nil)
+			ota.EXPECT().GetObjectTypesTotal(gomock.Any(), gomock.Any()).Return(1, nil)
 			ums.EXPECT().GetAccountNames(gomock.Any(), gomock.Any()).Return(nil)
 			smock.ExpectCommit()
 
@@ -1414,6 +1415,7 @@ func Test_objectTypeService_ListObjectTypes(t *testing.T) {
 			smock.ExpectBegin()
 			ps.EXPECT().CheckPermission(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
 			ota.EXPECT().ListObjectTypes(gomock.Any(), gomock.Any(), gomock.Any()).Return([]*interfaces.ObjectType{}, nil)
+			ota.EXPECT().GetObjectTypesTotal(gomock.Any(), gomock.Any()).Return(0, nil)
 			smock.ExpectCommit()
 
 			result, total, err := service.ListObjectTypes(ctx, nil, query)
@@ -1476,6 +1478,7 @@ func Test_objectTypeService_ListObjectTypes(t *testing.T) {
 			smock.ExpectBegin()
 			ps.EXPECT().CheckPermission(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
 			ota.EXPECT().ListObjectTypes(gomock.Any(), gomock.Any(), gomock.Any()).Return(objectTypes, nil)
+			ota.EXPECT().GetObjectTypesTotal(gomock.Any(), gomock.Any()).Return(1, nil)
 			ums.EXPECT().GetAccountNames(gomock.Any(), gomock.Any()).Return(rest.NewHTTPError(ctx, 500, berrors.BknBackend_ObjectType_InternalError))
 			smock.ExpectRollback()
 
@@ -1508,6 +1511,7 @@ func Test_objectTypeService_ListObjectTypes(t *testing.T) {
 			smock.ExpectBegin()
 			ps.EXPECT().CheckPermission(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
 			ota.EXPECT().ListObjectTypes(gomock.Any(), gomock.Any(), gomock.Any()).Return(objectTypes, nil)
+			ota.EXPECT().GetObjectTypesTotal(gomock.Any(), gomock.Any()).Return(1, nil)
 			ums.EXPECT().GetAccountNames(gomock.Any(), gomock.Any()).Return(nil)
 			smock.ExpectCommit()
 
@@ -1526,20 +1530,10 @@ func Test_objectTypeService_ListObjectTypes(t *testing.T) {
 				KNID:   "kn1",
 				Branch: interfaces.MAIN_BRANCH,
 			}
-			objectTypes := []*interfaces.ObjectType{
-				{
-					ObjectTypeWithKeyField: interfaces.ObjectTypeWithKeyField{
-						OTID:   "ot1",
-						OTName: "object_type1",
-					},
-					KNID:   "kn1",
-					Branch: interfaces.MAIN_BRANCH,
-				},
-			}
-
 			smock.ExpectBegin()
 			ps.EXPECT().CheckPermission(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
-			ota.EXPECT().ListObjectTypes(gomock.Any(), gomock.Any(), gomock.Any()).Return(objectTypes, nil)
+			ota.EXPECT().ListObjectTypes(gomock.Any(), gomock.Any(), gomock.Any()).Return([]*interfaces.ObjectType{}, nil)
+			ota.EXPECT().GetObjectTypesTotal(gomock.Any(), gomock.Any()).Return(1, nil)
 			smock.ExpectCommit()
 
 			result, total, err := service.ListObjectTypes(ctx, nil, query)

--- a/adp/bkn/bkn-backend/server/logics/relation_type/relation_type_service.go
+++ b/adp/bkn/bkn-backend/server/logics/relation_type/relation_type_service.go
@@ -263,20 +263,33 @@ func (rts *relationTypeService) ListRelationTypes(ctx context.Context,
 		return []*interfaces.RelationType{}, 0, rest.NewHTTPError(ctx, http.StatusInternalServerError,
 			berrors.BknBackend_RelationType_InternalError).WithErrorDetails(err.Error())
 	}
+
+	total, err := rts.rta.GetRelationTypesTotal(ctx, query)
+	if err != nil {
+		logger.Errorf("GetRelationTypesTotal error: %s", err.Error())
+		span.SetStatus(codes.Error, "Get relation types total error")
+
+		return []*interfaces.RelationType{}, 0, rest.NewHTTPError(ctx, http.StatusInternalServerError,
+			berrors.BknBackend_RelationType_InternalError).WithErrorDetails(err.Error())
+	}
 	if len(relationTypes) == 0 {
 		span.SetStatus(codes.Ok, "")
-		return relationTypes, 0, nil
+		return relationTypes, total, nil
 	}
 
-	// 把起点终点对象类的名称拿到
+	objectTypeIDs := make([]string, 0, len(relationTypes)*2)
 	for _, relationType := range relationTypes {
-		// 起点终点对象类的名称拿到
-		objectTypeMap, err := rts.ots.GetObjectTypesMapByIDs(ctx, query.KNID, query.Branch,
-			[]string{relationType.SourceObjectTypeID, relationType.TargetObjectTypeID}, true)
-		if err != nil {
-			return []*interfaces.RelationType{}, 0, err
-		}
+		objectTypeIDs = append(objectTypeIDs, relationType.SourceObjectTypeID, relationType.TargetObjectTypeID)
+	}
 
+	objectTypeMap, err := rts.ots.GetObjectTypesMapByIDs(ctx, query.KNID, query.Branch,
+		common.DuplicateSlice(objectTypeIDs), false)
+	if err != nil {
+		return []*interfaces.RelationType{}, 0, err
+	}
+
+	// 补充当前页关系类的起点和终点对象类名称。
+	for _, relationType := range relationTypes {
 		sourceObj := objectTypeMap[relationType.SourceObjectTypeID]
 		targetObj := objectTypeMap[relationType.TargetObjectTypeID]
 
@@ -296,24 +309,6 @@ func (rts *relationTypeService) ListRelationTypes(ctx context.Context,
 				Color:  targetObj.Color,
 			}
 		}
-	}
-	total := len(relationTypes)
-
-	// limit = -1,则返回所有
-	if query.Limit != -1 {
-
-		// 分页
-		// 检查起始位置是否越界
-		if query.Offset < 0 || query.Offset >= len(relationTypes) {
-			span.SetStatus(codes.Ok, "")
-			return []*interfaces.RelationType{}, total, nil
-		}
-		// 计算结束位置
-		end := query.Offset + query.Limit
-		if end > len(relationTypes) {
-			end = len(relationTypes)
-		}
-		relationTypes = relationTypes[query.Offset:end]
 	}
 
 	accountInfos := make([]*interfaces.AccountInfo, 0, len(relationTypes)*2)

--- a/adp/bkn/bkn-backend/server/logics/relation_type/relation_type_service_test.go
+++ b/adp/bkn/bkn-backend/server/logics/relation_type/relation_type_service_test.go
@@ -506,6 +506,7 @@ func Test_relationTypeService_ListRelationTypes(t *testing.T) {
 
 			ps.EXPECT().CheckPermission(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
 			rta.EXPECT().ListRelationTypes(gomock.Any(), gomock.Any()).Return(rtArr, nil)
+			rta.EXPECT().GetRelationTypesTotal(gomock.Any(), gomock.Any()).Return(1, nil)
 			ots.EXPECT().GetObjectTypesMapByIDs(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(map[string]*interfaces.ObjectType{}, nil)
 			ums.EXPECT().GetAccountNames(gomock.Any(), gomock.Any()).Return(nil)
 
@@ -527,6 +528,7 @@ func Test_relationTypeService_ListRelationTypes(t *testing.T) {
 
 			ps.EXPECT().CheckPermission(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
 			rta.EXPECT().ListRelationTypes(gomock.Any(), gomock.Any()).Return([]*interfaces.RelationType{}, nil)
+			rta.EXPECT().GetRelationTypesTotal(gomock.Any(), gomock.Any()).Return(0, nil)
 
 			rts, total, err := service.ListRelationTypes(ctx, query)
 			So(err, ShouldBeNil)
@@ -585,6 +587,7 @@ func Test_relationTypeService_ListRelationTypes(t *testing.T) {
 
 			ps.EXPECT().CheckPermission(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
 			rta.EXPECT().ListRelationTypes(gomock.Any(), gomock.Any()).Return(rtArr, nil)
+			rta.EXPECT().GetRelationTypesTotal(gomock.Any(), gomock.Any()).Return(1, nil)
 			ots.EXPECT().GetObjectTypesMapByIDs(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, rest.NewHTTPError(ctx, 500, berrors.BknBackend_RelationType_InternalError))
 
 			rts, total, err := service.ListRelationTypes(ctx, query)
@@ -615,6 +618,7 @@ func Test_relationTypeService_ListRelationTypes(t *testing.T) {
 
 			ps.EXPECT().CheckPermission(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
 			rta.EXPECT().ListRelationTypes(gomock.Any(), gomock.Any()).Return(rtArr, nil)
+			rta.EXPECT().GetRelationTypesTotal(gomock.Any(), gomock.Any()).Return(1, nil)
 			ots.EXPECT().GetObjectTypesMapByIDs(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(map[string]*interfaces.ObjectType{}, nil)
 			ums.EXPECT().GetAccountNames(gomock.Any(), gomock.Any()).Return(rest.NewHTTPError(ctx, 500, berrors.BknBackend_RelationType_InternalError))
 
@@ -646,6 +650,7 @@ func Test_relationTypeService_ListRelationTypes(t *testing.T) {
 
 			ps.EXPECT().CheckPermission(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
 			rta.EXPECT().ListRelationTypes(gomock.Any(), gomock.Any()).Return(rtArr, nil)
+			rta.EXPECT().GetRelationTypesTotal(gomock.Any(), gomock.Any()).Return(1, nil)
 			ots.EXPECT().GetObjectTypesMapByIDs(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(map[string]*interfaces.ObjectType{}, nil)
 			ums.EXPECT().GetAccountNames(gomock.Any(), gomock.Any()).Return(nil)
 
@@ -664,21 +669,10 @@ func Test_relationTypeService_ListRelationTypes(t *testing.T) {
 					Offset: 100,
 				},
 			}
-			rtArr := []*interfaces.RelationType{
-				{
-					RelationTypeWithKeyField: interfaces.RelationTypeWithKeyField{
-						RTID:               "rt1",
-						RTName:             "rt1",
-						SourceObjectTypeID: "ot1",
-						TargetObjectTypeID: "ot2",
-					},
-				},
-			}
 
 			ps.EXPECT().CheckPermission(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
-			rta.EXPECT().ListRelationTypes(gomock.Any(), gomock.Any()).Return(rtArr, nil)
-			ots.EXPECT().GetObjectTypesMapByIDs(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(map[string]*interfaces.ObjectType{}, nil)
-			ums.EXPECT().GetAccountNames(gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
+			rta.EXPECT().ListRelationTypes(gomock.Any(), gomock.Any()).Return([]*interfaces.RelationType{}, nil)
+			rta.EXPECT().GetRelationTypesTotal(gomock.Any(), gomock.Any()).Return(1, nil)
 
 			rts, total, err := service.ListRelationTypes(ctx, query)
 			So(err, ShouldBeNil)
@@ -723,8 +717,10 @@ func Test_relationTypeService_ListRelationTypes(t *testing.T) {
 			}
 
 			ps.EXPECT().CheckPermission(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
-			rta.EXPECT().ListRelationTypes(gomock.Any(), gomock.Any()).Return(rtArr, nil)
-			ots.EXPECT().GetObjectTypesMapByIDs(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(map[string]*interfaces.ObjectType{}, nil).AnyTimes()
+			rta.EXPECT().ListRelationTypes(gomock.Any(), gomock.Any()).Return(rtArr[1:], nil)
+			rta.EXPECT().GetRelationTypesTotal(gomock.Any(), gomock.Any()).Return(3, nil)
+			ots.EXPECT().GetObjectTypesMapByIDs(gomock.Any(), "kn1", interfaces.MAIN_BRANCH,
+				[]string{"ot1", "ot2"}, false).Return(map[string]*interfaces.ObjectType{}, nil)
 			ums.EXPECT().GetAccountNames(gomock.Any(), gomock.Any()).Return(nil)
 
 			rts, total, err := service.ListRelationTypes(ctx, query)

--- a/docs/api/bkn/bkn.yaml
+++ b/docs/api/bkn/bkn.yaml
@@ -127,7 +127,8 @@ paths:
               properties:
                 ids:
                   type: array
-                  description: 待取名的知识网络 ID 列表，空列表返回空 entries
+                  description: 待取名的知识网络 ID 列表，最多 100 个；空列表返回空 entries
+                  maxItems: 100
                   items:
                     type: string
       responses:


### PR DESCRIPTION
## What Changed

Brief description of changes:

- [x] Move relation type, action type, object type, concept group, and knowledge network list pagination into SQL-backed current-page queries.
- [x] Batch relation/action object-type enrichment and secure the bulk knowledge-network name endpoint.
- [x] Update OpenAPI and focused regression tests for the batch name query.

---

## Why

- Related Issue: Closes #427
- Related Feature: Knowledge network list performance and API safety
- Background: List APIs loaded all records before in-memory pagination, while relation/action enrichment issued per-item queries. The name lookup endpoint also lacked OAuth enforcement and a request-size bound.

---

## How

- Key implementation points: use separate total queries; apply `LIMIT/OFFSET` in access layers; batch object-type lookups for the current page; preserve knowledge-network authorization semantics through a lightweight candidate-ID query before loading current-page details.
- Breaking changes (API, config, database, etc.): Batch name lookup now requires OAuth and accepts at most 100 IDs. No response field or database schema changes.

---

## Testing

- [x] Unit tests passed locally
- [ ] Integration tests passed locally (not applicable: changes are isolated unit/access-layer behavior)
- [ ] Verified in test environment (not run: target remote knowledge network environment unavailable locally)

Test notes:

- `I18N_MODE_UT=true go test ./logics/knowledge_network/... ./drivenadapters/knowledge_network/... -count=1`
- Focused relation/action/object/concept-group package tests were run during their respective commits.

---

## Risk & Rollback

- Potential risks: Knowledge-network listing performs an additional lightweight ID query to keep pagination totals correct after external permission filtering. The name endpoint now rejects unauthenticated or oversized requests by design.
- Rollback plan: revert this PR to restore the previous list-query and endpoint behavior; no data migration is involved.

---

## Additional Notes

- Screenshots, logs, documentation links, etc.: #427 items deferred or moved out of scope are documented in the issue comment; build-task retirement remains tracked separately in #437.