### PR TITLE
feat(bkn-trace): persist evidence chain with controlled index

### DIFF
--- a/adp/execution-factory/operator-integration/server/logics/proxy/forwarder.go
+++ b/adp/execution-factory/operator-integration/server/logics/proxy/forwarder.go
@@ -68,7 +68,7 @@ func (f *forwarder) ForwardStream(ctx context.Context, req *interfaces.HTTPReque
 		err = myErr.DefaultHTTPError(ctx, http.StatusInternalServerError, err.Error())
 		return nil, err
 	}
-	httpReq, err := f.buildRequest(req)
+	httpReq, err := f.buildRequest(ctx, req)
 	if err != nil {
 		headerWriter.WriteHeader(http.StatusInternalServerError)
 		f.logger.WithContext(ctx).Warnf("build request failed, err: %v", err)
@@ -152,7 +152,7 @@ func (f *forwarder) Forward(ctx context.Context, req *interfaces.HTTPRequest) (*
 	client := f.pool.GetClient(req.Timeout)
 
 	// 构建HTTP请求
-	httpReq, err := f.buildRequest(req)
+	httpReq, err := f.buildRequest(ctx, req)
 	if err != nil {
 		return nil, fmt.Errorf("failed to build request: %w", err)
 	}
@@ -175,7 +175,7 @@ func (f *forwarder) Forward(ctx context.Context, req *interfaces.HTTPRequest) (*
 }
 
 // buildRequest 根据请求参数构建HTTP请求
-func (f *forwarder) buildRequest(req *interfaces.HTTPRequest) (*http.Request, error) {
+func (f *forwarder) buildRequest(ctx context.Context, req *interfaces.HTTPRequest) (*http.Request, error) {
 	// 处理URL和路径参数
 	requestURL := req.URL
 	if len(req.PathParams) > 0 {
@@ -290,11 +290,13 @@ func (f *forwarder) buildRequest(req *interfaces.HTTPRequest) (*http.Request, er
 		return nil, err
 	}
 
-	// 设置请求头
-	if req.Headers != nil {
-		for key, value := range req.Headers {
-			httpReq.Header.Set(key, fmt.Sprintf("%v", value))
-		}
+	// 设置请求头，并用当前请求上下文补齐 trace/request id，保证代理链路可聚合。
+	headers := map[string]string{}
+	for key, value := range req.Headers {
+		headers[key] = fmt.Sprintf("%v", value)
+	}
+	for key, value := range common.MergeTraceHeaders(ctx, headers) {
+		httpReq.Header.Set(key, value)
 	}
 
 	// 如果Content-Type未在请求头中设置，但我们有确定的类型，则设置它

--- a/adp/execution-factory/operator-integration/server/logics/proxy/forwarder_test.go
+++ b/adp/execution-factory/operator-integration/server/logics/proxy/forwarder_test.go
@@ -2,12 +2,17 @@ package proxy
 
 import (
 	"context"
+	"net/http"
+	"net/http/httptest"
 	"testing"
+	"time"
 
+	"github.com/openbkn-ai/adp/execution-factory/operator-integration/server/infra/common"
 	myErr "github.com/openbkn-ai/adp/execution-factory/operator-integration/server/infra/errors"
 	"github.com/openbkn-ai/adp/execution-factory/operator-integration/server/infra/logger"
 	"github.com/openbkn-ai/adp/execution-factory/operator-integration/server/interfaces"
 	. "github.com/smartystreets/goconvey/convey"
+	"go.opentelemetry.io/otel/trace"
 	"go.uber.org/mock/gomock"
 )
 
@@ -38,5 +43,66 @@ func TestForwardStream_MissingResponseWriterDoesNotPanic(t *testing.T) {
 			So(httpErr.HTTPCode, ShouldEqual, 500)
 			So(httpErr.ErrorDetails, ShouldEqual, "response writer not found in context")
 		}, ShouldNotPanic)
+	})
+}
+
+func TestForward_PropagatesTraceHeadersFromContext(t *testing.T) {
+	Convey("Forward merges trace context headers into downstream HTTP request", t, func() {
+		captured := map[string]string{}
+		target := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			captured[common.HeaderTraceparent] = r.Header.Get(common.HeaderTraceparent)
+			captured[common.HeaderBKNRequestID] = r.Header.Get(common.HeaderBKNRequestID)
+			captured[common.HeaderLegacyRequestID] = r.Header.Get(common.HeaderLegacyRequestID)
+			captured[common.HeaderBaggage] = r.Header.Get(common.HeaderBaggage)
+			captured["x-account-id"] = r.Header.Get("x-account-id")
+			_, _ = w.Write([]byte(`{"ok":true}`))
+		}))
+		defer target.Close()
+
+		traceID := trace.TraceID{0x20, 0x21, 0x22, 0x23, 0x24, 0x25, 0x26, 0x27, 0x28, 0x29, 0x30, 0x31, 0x32, 0x33, 0x34, 0x35}
+		spanID := trace.SpanID{0x40, 0x41, 0x42, 0x43, 0x44, 0x45, 0x46, 0x47}
+		spanCtx := trace.NewSpanContext(trace.SpanContextConfig{
+			TraceID:    traceID,
+			SpanID:     spanID,
+			TraceFlags: trace.FlagsSampled,
+			Remote:     true,
+		})
+		ctx := trace.ContextWithSpanContext(context.Background(), spanCtx)
+		ctx = common.SetTraceContextToCtx(ctx, common.TraceContext{
+			RequestID: "req_01JZVALIDREQUESTID000000215",
+			Baggage: map[string]string{
+				"bkn.account.type": "service",
+				"prompt":           "raw prompt",
+			},
+		})
+
+		forwarder := &forwarder{
+			pool: &clientPool{
+				logger:      logger.DefaultLogger(),
+				clients:     make(map[clientKey]*ProxyClient),
+				config:      PoolConfig{MaxClients: 4, MaxTimeout: 5 * time.Second, DefaultTimeout: 5 * time.Second},
+				stopCleanup: make(chan struct{}),
+			},
+			logger: logger.DefaultLogger(),
+		}
+		resp, err := forwarder.Forward(ctx, &interfaces.HTTPRequest{
+			Timeout: time.Second,
+			HTTPRouter: interfaces.HTTPRouter{
+				Method: http.MethodPost,
+				URL:    target.URL,
+			},
+			HTTPRequestParams: interfaces.HTTPRequestParams{
+				Headers: map[string]any{"x-account-id": "u-9"},
+				Body:    map[string]any{"hello": "world"},
+			},
+		})
+
+		So(err, ShouldBeNil)
+		So(resp.StatusCode, ShouldEqual, http.StatusOK)
+		So(captured["x-account-id"], ShouldEqual, "u-9")
+		So(captured[common.HeaderBKNRequestID], ShouldEqual, "req_01JZVALIDREQUESTID000000215")
+		So(captured[common.HeaderLegacyRequestID], ShouldEqual, "req_01JZVALIDREQUESTID000000215")
+		So(captured[common.HeaderTraceparent], ShouldEqual, "00-20212223242526272829303132333435-4041424344454647-01")
+		So(captured[common.HeaderBaggage], ShouldEqual, "bkn.account.type=service")
 	})
 }

--- a/bkn-trace/agent-observability/README.md
+++ b/bkn-trace/agent-observability/README.md
@@ -269,6 +269,14 @@ business_ref:{ref_id}
 ```
 
 查询必须提供且只能提供一个 scope：`trace_id` 或 `request_id`。当前阶段只返回 `visibility=visible` 的节点；`hidden`、`redacted`、`omitted`、`unresolved`、`unauthorized` 节点不会通过详情接口展开。真实 BKN / Vega / Metric / Action resolver、按账号/租户的实时授权裁决和隐藏节点可审计解释属于后续阶段。
+阶段二 evidence ingestion 接口接受 `bkn.trace.schema.version=2.0.0` 的事件批次，包含 `trace` 与 `events`。当前版本完成 contract 校验、敏感 payload 拒绝、归一化计数，并写入 `OPENSEARCH_EVIDENCE_INDEX`，默认 `bkn-trace-evidence-v2`。索引只对 trace/request/count/时间等检索字段建索引，完整 `events` 保留在 `_source` 中用于证据链详情展示，避免业务 payload 触发动态 mapping 膨胀。
+
+持久化 evidence 可通过以下接口回查：
+
+```text
+GET /api/agent-observability/v1/evidence/by-trace?trace_id=<trace_id>
+GET /api/agent-observability/v1/evidence/by-trace?request_id=<bkn.request.id>
+```
 
 生成 Swagger 文档：
 

--- a/bkn-trace/agent-observability/charts/agent-observability/values.yaml
+++ b/bkn-trace/agent-observability/charts/agent-observability/values.yaml
@@ -65,7 +65,7 @@ affinity: {}
 
 opensearch:
   endpoint:  http://opensearch-cluster-master.resource.svc.cluster.local:9200
-  traceIndex: ss4o_traces-default-namespace
+  traceIndex: ss4o_traces-default-anyshare
   auth:
     enabled: false
     username: ""

--- a/bkn-trace/agent-observability/charts/agent-observability/values.yaml
+++ b/bkn-trace/agent-observability/charts/agent-observability/values.yaml
@@ -34,7 +34,7 @@ ingress:
 
 evidence:
   store: memory
-  index: bkn-trace-evidence-v1
+  index: bkn-trace-evidence-v2
   indexManagement:
     enabled: false
     maxResultWindow: 10000
@@ -65,7 +65,7 @@ affinity: {}
 
 opensearch:
   endpoint:  http://opensearch-cluster-master.resource.svc.cluster.local:9200
-  traceIndex: ss4o_traces-default-anyshare
+  traceIndex: ss4o_traces-default-namespace
   auth:
     enabled: false
     username: ""

--- a/bkn-trace/agent-observability/src/boot/bootstrap.go
+++ b/bkn-trace/agent-observability/src/boot/bootstrap.go
@@ -68,6 +68,7 @@ func newApp(httpServerConfig conf.HTTPServerConfig, traceHandler *httphandler.Tr
 	})
 	mux.HandleFunc(APIBasePath+"/evidence-nodes/", evidenceHandler.GetEvidenceNode)
 	mux.HandleFunc(APIBasePath+"/evidence/events", evidenceHandler.IngestEvidenceEvents)
+	mux.HandleFunc(APIBasePath+"/evidence/by-trace", evidenceHandler.SearchEvidenceByTrace)
 	mux.Handle(APIBasePath+"/swagger/", httpSwagger.Handler(
 		httpSwagger.URL(APIBasePath+"/swagger/doc.json"),
 	))

--- a/bkn-trace/agent-observability/src/conf/opensearch.go
+++ b/bkn-trace/agent-observability/src/conf/opensearch.go
@@ -32,7 +32,7 @@ func NewOpenSearchConfig() OpenSearchConfig {
 
 	evidenceIndex := os.Getenv("OPENSEARCH_EVIDENCE_INDEX")
 	if evidenceIndex == "" {
-		evidenceIndex = "bkn-trace-evidence-v1"
+		evidenceIndex = "bkn-trace-evidence-v2"
 	}
 
 	return OpenSearchConfig{

--- a/bkn-trace/agent-observability/src/domain/service/evidencesvc/service.go
+++ b/bkn-trace/agent-observability/src/domain/service/evidencesvc/service.go
@@ -31,29 +31,35 @@ var sensitivePatterns = []*regexp.Regexp{
 }
 
 var forbiddenRawKeys = map[string]struct{}{
-	"access-token":  {},
-	"access_token":  {},
-	"api-key":       {},
-	"api_key":       {},
-	"authorization": {},
-	"cookie":        {},
-	"id-token":      {},
-	"id_token":      {},
-	"raw-answer":    {},
-	"raw-input":     {},
-	"raw-output":    {},
-	"raw-prompt":    {},
-	"raw-sql":       {},
-	"raw_answer":    {},
-	"raw_input":     {},
-	"raw_output":    {},
-	"raw_prompt":    {},
-	"raw_sql":       {},
-	"refresh-token": {},
-	"refresh_token": {},
-	"row-data":      {},
-	"row_data":      {},
-	"token":         {},
+	"access-token":    {},
+	"access_token":    {},
+	"api-key":         {},
+	"api_key":         {},
+	"authorization":   {},
+	"cookie":          {},
+	"id-token":        {},
+	"id_token":        {},
+	"raw-answer":      {},
+	"raw-input":       {},
+	"raw-output":      {},
+	"raw-prompt":      {},
+	"raw-sql":         {},
+	"raw-tool-args":   {},
+	"raw-tool-io":     {},
+	"raw-tool-result": {},
+	"raw_answer":      {},
+	"raw_input":       {},
+	"raw_output":      {},
+	"raw_prompt":      {},
+	"raw_sql":         {},
+	"raw_tool_args":   {},
+	"raw_tool_io":     {},
+	"raw_tool_result": {},
+	"refresh-token":   {},
+	"refresh_token":   {},
+	"row-data":        {},
+	"row_data":        {},
+	"token":           {},
 }
 
 var eventTypes = map[string]struct{}{
@@ -63,6 +69,8 @@ var eventTypes = map[string]struct{}{
 	"structured_output.validated": {},
 	"agent_as_tool.invoked":       {},
 	"tool.budget.exhausted":       {},
+	"tool.called":                 {},
+	"tool.result.observed":        {},
 	"action.recommended":          {},
 	"action.approval_requested":   {},
 	"action.approved":             {},
@@ -774,6 +782,10 @@ func checkEvent(event evidencevo.EvidenceEvent, i int, knownClaims map[string]st
 	case "business.refs.resolved":
 		checkRefs(event.Payload, base+".payload", "business_refs", knownClaims, errors)
 		normalized.BusinessRefCount += len(arrayField(event.Payload, "business_refs"))
+	case "tool.called":
+		checkToolCalled(event.Payload, base+".payload", errors)
+	case "tool.result.observed":
+		checkToolResultObserved(event.Payload, base+".payload", errors)
 	}
 }
 
@@ -790,6 +802,28 @@ func checkClaim(payload map[string]any, base string, normalized *evidencevo.Norm
 	normalized.ClaimCount++
 	if claimID != "" {
 		normalized.ClaimIDs = append(normalized.ClaimIDs, claimID)
+	}
+}
+
+func checkToolCalled(payload map[string]any, base string, errors *evidencevo.ValidationErrors) {
+	requiredStringField(payload, "tool_id", base, errors)
+	requiredStringField(payload, "tool_name", base, errors)
+	requiredStringField(payload, "args_hash", base, errors)
+	requiredStringField(payload, "visibility", base, errors)
+	requiredStringField(payload, "version_status", base, errors)
+}
+
+func checkToolResultObserved(payload map[string]any, base string, errors *evidencevo.ValidationErrors) {
+	requiredStringField(payload, "tool_id", base, errors)
+	requiredStringField(payload, "tool_name", base, errors)
+	requiredStringField(payload, "status", base, errors)
+	requiredStringField(payload, "visibility", base, errors)
+	requiredStringField(payload, "version_status", base, errors)
+	if status, ok := stringField(payload, "status"); ok && status == "success" {
+		requiredStringField(payload, "result_hash", base, errors)
+	}
+	if status, ok := stringField(payload, "status"); ok && status != "success" {
+		requiredStringField(payload, "error_hash", base, errors)
 	}
 }
 

--- a/bkn-trace/agent-observability/src/domain/service/evidencesvc/service_test.go
+++ b/bkn-trace/agent-observability/src/domain/service/evidencesvc/service_test.go
@@ -70,6 +70,25 @@ func TestIngestAcceptsPhaseTwoEvidenceBatch(t *testing.T) {
 	}
 }
 
+func TestIngestAcceptsHashOnlyToolEvents(t *testing.T) {
+	store := &fakeStore{}
+	service := New(store)
+
+	response, validationErrors, err := service.Ingest(context.Background(), []byte(toolEventsBatch()))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(validationErrors) > 0 {
+		t.Fatalf("unexpected validation errors: %+v", validationErrors)
+	}
+	if store.calls != 1 {
+		t.Fatalf("expected evidence to be stored once, got %d", store.calls)
+	}
+	if response.AcceptedEvents != 2 || response.ClaimCount != 0 || response.EvidenceRefCount != 0 || response.BusinessRefCount != 0 {
+		t.Fatalf("unexpected response counts: %+v", response)
+	}
+}
+
 func TestIngestRejectsMissingClaimID(t *testing.T) {
 	store := &fakeStore{}
 	service := New(store)
@@ -102,6 +121,22 @@ func TestIngestRejectsSensitivePayload(t *testing.T) {
 	}
 	if validationErrors[0].Code != "BKN_TRACE_FORBIDDEN_RAW_PAYLOAD_FIELD" {
 		t.Fatalf("unexpected error code: %+v", validationErrors[0])
+	}
+	if store.calls != 0 {
+		t.Fatalf("invalid batch must not be stored")
+	}
+}
+
+func TestIngestRejectsRawToolPayload(t *testing.T) {
+	store := &fakeStore{}
+	service := New(store)
+
+	_, validationErrors, err := service.Ingest(context.Background(), []byte(rawToolPayloadBatch()))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !hasValidationCode(validationErrors, "BKN_TRACE_FORBIDDEN_RAW_PAYLOAD_FIELD") {
+		t.Fatalf("expected raw tool payload rejection, got %+v", validationErrors)
 	}
 	if store.calls != 0 {
 		t.Fatalf("invalid batch must not be stored")
@@ -795,6 +830,64 @@ func missingClaimIDBatch() string {
 }`
 }
 
+func toolEventsBatch() string {
+	return `{
+  "bkn.trace.schema.version": "2.0.0",
+  "trace": {
+    "trace_id": "8c0d0000000000000000000000000006",
+    "bkn.request.id": "req_phase2_tool_006",
+    "traceparent": "00-8c0d0000000000000000000000000006-1f12000000000006-01",
+    "business_domain": "bd_demo",
+    "bkn.account.id": "acct_demo",
+    "bkn.account.type": "app"
+  },
+  "events": [
+    {
+      "event_id": "evt_tool_called",
+      "event_type": "tool.called",
+      "bkn.trace.schema.version": "2.0.0",
+      "observed_at": "2026-07-22T04:00:00.000000000Z",
+      "emitted_at": "2026-07-22T04:00:00.001000000Z",
+      "producer_module": "bkn-agent",
+      "trace_id": "8c0d0000000000000000000000000006",
+      "span_id": "1f12000000000006",
+      "bkn.request.id": "req_phase2_tool_006",
+      "bkn.operation.name": "bkn.agent.tool.call",
+      "payload": {
+        "tool_id": "tool_query_object",
+        "tool_name": "query_object_instance",
+        "toolbox_id": "box_contextloader",
+        "args_hash": "sha256:args",
+        "visibility": "visible",
+        "version_status": "unversioned"
+      }
+    },
+    {
+      "event_id": "evt_tool_result",
+      "event_type": "tool.result.observed",
+      "bkn.trace.schema.version": "2.0.0",
+      "observed_at": "2026-07-22T04:00:00.002000000Z",
+      "emitted_at": "2026-07-22T04:00:00.003000000Z",
+      "producer_module": "bkn-agent",
+      "trace_id": "8c0d0000000000000000000000000006",
+      "span_id": "1f12000000000006",
+      "bkn.request.id": "req_phase2_tool_006",
+      "bkn.operation.name": "bkn.agent.tool.call",
+      "payload": {
+        "tool_id": "tool_query_object",
+        "tool_name": "query_object_instance",
+        "toolbox_id": "box_contextloader",
+        "result_hash": "sha256:result",
+        "result_length": 123,
+        "status": "success",
+        "visibility": "visible",
+        "version_status": "unversioned"
+      }
+    }
+  ]
+}`
+}
+
 func sensitiveBatch() string {
 	return `{
   "bkn.trace.schema.version": "2.0.0",
@@ -858,6 +951,10 @@ func unknownClaimIDBatch() string {
     }
   ]
 }`
+}
+
+func rawToolPayloadBatch() string {
+	return strings.Replace(toolEventsBatch(), `"result_hash": "sha256:result",`, `"raw_tool_result": "customer email is alice@example.com",`, 1)
 }
 
 func emptyEventsBatch() string {

--- a/bkn-trace/agent-observability/src/drivenadapter/httpaccess/opensearchevidencestore/store.go
+++ b/bkn-trace/agent-observability/src/drivenadapter/httpaccess/opensearchevidencestore/store.go
@@ -16,11 +16,11 @@ import (
 const maxEvidenceSearchResults = 1000
 
 type Store struct {
-	client *opensearch.Client
-	index  string
-	now    func() time.Time
-	once   sync.Once
-	err    error
+	client       *opensearch.Client
+	index        string
+	now          func() time.Time
+	ensureMu     sync.Mutex
+	indexEnsured bool
 }
 
 type document struct {
@@ -122,10 +122,16 @@ func (s *Store) search(ctx context.Context, field string, value string, options 
 }
 
 func (s *Store) ensureIndex(ctx context.Context) error {
-	s.once.Do(func() {
-		s.err = s.client.EnsureIndex(ctx, s.index, []byte(evidenceIndexMapping))
-	})
-	return s.err
+	s.ensureMu.Lock()
+	defer s.ensureMu.Unlock()
+	if s.indexEnsured {
+		return nil
+	}
+	if err := s.client.EnsureIndex(ctx, s.index, []byte(evidenceIndexMapping)); err != nil {
+		return err
+	}
+	s.indexEnsured = true
+	return nil
 }
 
 const evidenceIndexMapping = `{"settings":{"index.mapping.total_fields.limit":200},"mappings":{"dynamic":false,"properties":{"document_id":{"type":"keyword"},"trace_id":{"type":"keyword"},"bkn":{"properties":{"request":{"properties":{"id":{"type":"keyword"}}},"trace":{"properties":{"schema":{"properties":{"version":{"type":"keyword"}}}}}}},"events":{"type":"object","enabled":false},"claim_ids":{"type":"keyword"},"accepted_event_count":{"type":"integer"},"claim_count":{"type":"integer"},"evidence_ref_count":{"type":"integer"},"business_ref_count":{"type":"integer"},"ingested_at":{"type":"date"}}}}`

--- a/bkn-trace/agent-observability/src/drivenadapter/httpaccess/opensearchevidencestore/store.go
+++ b/bkn-trace/agent-observability/src/drivenadapter/httpaccess/opensearchevidencestore/store.go
@@ -6,6 +6,7 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
+	"sync"
 	"time"
 
 	"github.com/openbkn-ai/bkn-foundry/bkn-trace/agent-observability/src/domain/valueobject/evidencevo"
@@ -18,6 +19,8 @@ type Store struct {
 	client *opensearch.Client
 	index  string
 	now    func() time.Time
+	once   sync.Once
+	err    error
 }
 
 type document struct {
@@ -51,6 +54,10 @@ func New(client *opensearch.Client, index string) *Store {
 }
 
 func (s *Store) StoreEvidence(ctx context.Context, trace evidencevo.NormalizedTrace) error {
+	if err := s.ensureIndex(ctx); err != nil {
+		return err
+	}
+
 	doc := toDocument(trace, s.now().UTC())
 	body, err := json.Marshal(doc)
 	if err != nil {
@@ -71,6 +78,10 @@ func (s *Store) GetEvidenceByRequestID(ctx context.Context, requestID string, op
 }
 
 func (s *Store) search(ctx context.Context, field string, value string, options evidencevo.EvidenceQueryOptions) (evidencevo.EvidenceQueryResult, error) {
+	if err := s.ensureIndex(ctx); err != nil {
+		return evidencevo.EvidenceQueryResult{}, err
+	}
+
 	limit := options.Limit
 	if limit <= 0 {
 		limit = maxEvidenceSearchResults
@@ -109,6 +120,15 @@ func (s *Store) search(ctx context.Context, field string, value string, options 
 	}
 	return result, nil
 }
+
+func (s *Store) ensureIndex(ctx context.Context) error {
+	s.once.Do(func() {
+		s.err = s.client.EnsureIndex(ctx, s.index, []byte(evidenceIndexMapping))
+	})
+	return s.err
+}
+
+const evidenceIndexMapping = `{"settings":{"index.mapping.total_fields.limit":200},"mappings":{"dynamic":false,"properties":{"document_id":{"type":"keyword"},"trace_id":{"type":"keyword"},"bkn":{"properties":{"request":{"properties":{"id":{"type":"keyword"}}},"trace":{"properties":{"schema":{"properties":{"version":{"type":"keyword"}}}}}}},"events":{"type":"object","enabled":false},"claim_ids":{"type":"keyword"},"accepted_event_count":{"type":"integer"},"claim_count":{"type":"integer"},"evidence_ref_count":{"type":"integer"},"business_ref_count":{"type":"integer"},"ingested_at":{"type":"date"}}}}`
 
 func toDocument(trace evidencevo.NormalizedTrace, ingestedAt time.Time) document {
 	doc := document{

--- a/bkn-trace/agent-observability/src/drivenadapter/httpaccess/opensearchevidencestore/store_test.go
+++ b/bkn-trace/agent-observability/src/drivenadapter/httpaccess/opensearchevidencestore/store_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"io"
 	"net/http"
 	"strings"
@@ -183,6 +184,41 @@ func TestGetEvidenceByTraceIDFetchesLimitPlusOneAndTruncates(t *testing.T) {
 	}
 	if !result.Truncated || len(result.Traces) != 1 {
 		t.Fatalf("expected truncated single result, got %+v", result)
+	}
+}
+
+func TestStoreEvidenceRetriesEnsureIndexAfterTransientFailure(t *testing.T) {
+	ensureAttempts := 0
+	indexAttempts := 0
+	client := newFakeOpenSearchClient(func(r *http.Request) (*http.Response, error) {
+		if r.Method == http.MethodPut && r.URL.Path == "/bkn-trace-evidence-test" {
+			ensureAttempts++
+			if ensureAttempts == 1 {
+				return nil, errors.New("opensearch temporarily unavailable")
+			}
+			return jsonResponse(`{"acknowledged":true}`), nil
+		}
+		if r.Method == http.MethodPut && strings.HasPrefix(r.URL.Path, "/bkn-trace-evidence-test/_doc/") {
+			indexAttempts++
+			return jsonResponse(`{"result":"created"}`), nil
+		}
+		t.Fatalf("unexpected request %s %s", r.Method, r.URL.Path)
+		return nil, nil
+	})
+
+	store := New(client, "bkn-trace-evidence-test")
+
+	if err := store.StoreEvidence(context.Background(), normalizedTrace()); err == nil {
+		t.Fatal("expected first ensure index attempt to fail")
+	}
+	if err := store.StoreEvidence(context.Background(), normalizedTrace()); err != nil {
+		t.Fatalf("expected second store evidence to retry and pass: %v", err)
+	}
+	if ensureAttempts != 2 {
+		t.Fatalf("expected ensure index to retry after failure, got %d attempts", ensureAttempts)
+	}
+	if indexAttempts != 1 {
+		t.Fatalf("expected document indexed once after successful ensure, got %d", indexAttempts)
 	}
 }
 

--- a/bkn-trace/agent-observability/src/drivenadapter/httpaccess/opensearchevidencestore/store_test.go
+++ b/bkn-trace/agent-observability/src/drivenadapter/httpaccess/opensearchevidencestore/store_test.go
@@ -15,15 +15,22 @@ import (
 )
 
 func TestStoreEvidenceIndexesNormalizedTrace(t *testing.T) {
-	var path string
+	var paths []string
+	var indexMapping map[string]any
 	var body map[string]any
 	client := newFakeOpenSearchClient(func(r *http.Request) (*http.Response, error) {
-		path = r.URL.Path
+		paths = append(paths, r.URL.Path)
 		if r.Method != http.MethodPut {
 			t.Fatalf("expected PUT, got %s", r.Method)
 		}
+		if r.URL.Path == "/bkn-trace-evidence-test" {
+			if err := json.NewDecoder(r.Body).Decode(&indexMapping); err != nil {
+				t.Fatalf("decode index mapping: %v", err)
+			}
+			return jsonResponse(`{"acknowledged":true}`), nil
+		}
 		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
-			t.Fatalf("decode request body: %v", err)
+			t.Fatalf("decode document body: %v", err)
 		}
 		return jsonResponse(`{"result":"created"}`), nil
 	})
@@ -35,8 +42,12 @@ func TestStoreEvidenceIndexesNormalizedTrace(t *testing.T) {
 		t.Fatalf("store evidence: %v", err)
 	}
 
-	if !strings.HasPrefix(path, "/bkn-trace-evidence-test/_doc/") {
-		t.Fatalf("unexpected index path: %s", path)
+	if len(paths) != 2 || paths[0] != "/bkn-trace-evidence-test" || !strings.HasPrefix(paths[1], "/bkn-trace-evidence-test/_doc/") {
+		t.Fatalf("unexpected request paths: %v", paths)
+	}
+	mappingBytes, _ := json.Marshal(indexMapping)
+	if !strings.Contains(string(mappingBytes), `"events":{"enabled":false,"type":"object"}`) {
+		t.Fatalf("events must not create dynamic mappings: %s", string(mappingBytes))
 	}
 	if body["trace_id"] != "trace_index_001" || body["bkn.request.id"] != "req_index_001" {
 		t.Fatalf("unexpected identity fields: %+v", body)
@@ -48,7 +59,12 @@ func TestStoreEvidenceIndexesNormalizedTrace(t *testing.T) {
 
 func TestGetEvidenceByTraceIDParsesSearchHits(t *testing.T) {
 	var query map[string]any
+	var ensured bool
 	client := newFakeOpenSearchClient(func(r *http.Request) (*http.Response, error) {
+		if r.Method == http.MethodPut && r.URL.Path == "/bkn-trace-evidence-test" {
+			ensured = true
+			return jsonResponse(`{"acknowledged":true}`), nil
+		}
 		if r.Method != http.MethodPost {
 			t.Fatalf("expected POST, got %s", r.Method)
 		}
@@ -96,6 +112,9 @@ func TestGetEvidenceByTraceIDParsesSearchHits(t *testing.T) {
 	if err != nil {
 		t.Fatalf("query evidence: %v", err)
 	}
+	if !ensured {
+		t.Fatal("expected evidence index to be ensured before search")
+	}
 	if len(result.Traces) != 1 {
 		t.Fatalf("expected one trace, got %d", len(result.Traces))
 	}
@@ -114,6 +133,9 @@ func TestGetEvidenceByTraceIDParsesSearchHits(t *testing.T) {
 func TestGetEvidenceByRequestIDUsesRequestIDField(t *testing.T) {
 	var query map[string]any
 	client := newFakeOpenSearchClient(func(r *http.Request) (*http.Response, error) {
+		if r.Method == http.MethodPut && r.URL.Path == "/bkn-trace-evidence-test" {
+			return jsonResponse(`{"acknowledged":true}`), nil
+		}
 		if err := json.NewDecoder(r.Body).Decode(&query); err != nil {
 			t.Fatalf("decode query: %v", err)
 		}
@@ -134,6 +156,9 @@ func TestGetEvidenceByRequestIDUsesRequestIDField(t *testing.T) {
 func TestGetEvidenceByTraceIDFetchesLimitPlusOneAndTruncates(t *testing.T) {
 	var query map[string]any
 	client := newFakeOpenSearchClient(func(r *http.Request) (*http.Response, error) {
+		if r.Method == http.MethodPut && r.URL.Path == "/bkn-trace-evidence-test" {
+			return jsonResponse(`{"acknowledged":true}`), nil
+		}
 		if err := json.NewDecoder(r.Body).Decode(&query); err != nil {
 			t.Fatalf("decode query: %v", err)
 		}

--- a/bkn-trace/agent-observability/src/driveradapter/api/httphandler/evidence_handler.go
+++ b/bkn-trace/agent-observability/src/driveradapter/api/httphandler/evidence_handler.go
@@ -149,6 +149,72 @@ func (h *EvidenceHandler) GetEvidenceChainByTraceID(w http.ResponseWriter, r *ht
 	writeJSON(w, http.StatusOK, response)
 }
 
+// SearchEvidenceByTrace godoc
+// @Summary Query evidence chain by trace ID or BKN request ID
+// @Description Backward-compatible endpoint for SDK/Studio callers. Returns the normalized evidence-chain response for trace_id or request_id.
+// @Tags evidence
+// @Produce json
+// @Param trace_id query string false "Trace ID"
+// @Param request_id query string false "BKN request ID"
+// @Param limit query int false "Maximum evidence trace batches to read, 1..1000"
+// @Success 200 {object} map[string]interface{}
+// @Failure 400 {object} rdto.ErrorResponse
+// @Failure 404 {object} rdto.ErrorResponse
+// @Failure 405 {object} rdto.ErrorResponse
+// @Failure 500 {object} rdto.ErrorResponse
+// @Router /api/agent-observability/v1/evidence/by-trace [get]
+func (h *EvidenceHandler) SearchEvidenceByTrace(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		writeJSON(w, http.StatusMethodNotAllowed, rdto.ErrorResponse{
+			Code:    "METHOD_NOT_ALLOWED",
+			Message: "only GET is supported",
+		})
+		return
+	}
+
+	traceID := strings.TrimSpace(r.URL.Query().Get("trace_id"))
+	requestID := strings.TrimSpace(r.URL.Query().Get("request_id"))
+	if (traceID == "") == (requestID == "") {
+		writeJSON(w, http.StatusBadRequest, rdto.ErrorResponse{
+			Code:    "INVALID_ARGUMENT",
+			Message: "exactly one of trace_id or request_id is required",
+		})
+		return
+	}
+
+	options, ok := evidenceQueryOptionsFromRequest(w, r)
+	if !ok {
+		return
+	}
+
+	var (
+		response evidencevo.EvidenceChainResponse
+		found    bool
+		err      error
+	)
+	if traceID != "" {
+		response, found, err = h.evidenceService.GetEvidenceChainByTraceID(r.Context(), traceID, options)
+	} else {
+		response, found, err = h.evidenceService.GetEvidenceChainByRequestID(r.Context(), requestID, options)
+	}
+	if err != nil {
+		writeJSON(w, http.StatusInternalServerError, rdto.ErrorResponse{
+			Code:    "QUERY_FAILED",
+			Message: "failed to query evidence chain",
+		})
+		return
+	}
+	if !found {
+		writeJSON(w, http.StatusNotFound, rdto.ErrorResponse{
+			Code:    "NOT_FOUND",
+			Message: "evidence chain not found",
+		})
+		return
+	}
+
+	writeJSON(w, http.StatusOK, response)
+}
+
 func (h *EvidenceHandler) GetTraceSubresource(w http.ResponseWriter, r *http.Request) {
 	if strings.HasSuffix(r.URL.Path, "/evidence-chain") {
 		h.GetEvidenceChainByTraceID(w, r)

--- a/bkn-trace/agent-observability/src/driveradapter/api/httphandler/evidence_handler_test.go
+++ b/bkn-trace/agent-observability/src/driveradapter/api/httphandler/evidence_handler_test.go
@@ -150,6 +150,25 @@ func TestEvidenceHandlerReturnsEvidenceChainByRequest(t *testing.T) {
 	}
 }
 
+func TestEvidenceHandlerSearchEvidenceByTraceCompatibilityEndpoint(t *testing.T) {
+	store := evidencestore.New()
+	handler := NewEvidenceHandler(evidencesvc.New(store))
+	ingestReq := httptest.NewRequest(http.MethodPost, "/api/agent-observability/v1/evidence/events", strings.NewReader(validHandlerBatch()))
+	ingestRec := httptest.NewRecorder()
+	handler.IngestEvidenceEvents(ingestRec, ingestReq)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/agent-observability/v1/evidence/by-trace?trace_id=9c0d0000000000000000000000000001", nil)
+	rec := httptest.NewRecorder()
+	handler.SearchEvidenceByTrace(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+	if !strings.Contains(rec.Body.String(), `"trace_id":"9c0d0000000000000000000000000001"`) {
+		t.Fatalf("unexpected body: %s", rec.Body.String())
+	}
+}
+
 func TestEvidenceHandlerRejectsInvalidEvidenceQueryLimit(t *testing.T) {
 	handler := NewEvidenceHandler(evidencesvc.New(evidencestore.New()))
 	req := httptest.NewRequest(http.MethodGet, "/api/agent-observability/v1/traces/by-request?request_id=req_handler_001&limit=0", nil)

--- a/bkn-trace/agent-observability/src/infra/opensearch/client.go
+++ b/bkn-trace/agent-observability/src/infra/opensearch/client.go
@@ -104,3 +104,39 @@ func (c *Client) IndexDocument(ctx context.Context, index string, documentID str
 
 	return respBody, nil
 }
+
+func (c *Client) EnsureIndex(ctx context.Context, index string, mapping []byte) error {
+	url := fmt.Sprintf("%s/%s", c.baseURL, strings.TrimLeft(index, "/"))
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPut, url, bytes.NewReader(mapping))
+	if err != nil {
+		return fmt.Errorf("create opensearch create-index request: %w", err)
+	}
+
+	req.Header.Set("Content-Type", "application/json")
+	if c.auth.Enabled {
+		req.SetBasicAuth(c.auth.Username, c.auth.Password)
+	}
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("execute opensearch create-index request: %w", err)
+	}
+	defer func() {
+		_ = resp.Body.Close()
+	}()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return fmt.Errorf("read opensearch create-index response: %w", err)
+	}
+
+	if resp.StatusCode >= http.StatusOK && resp.StatusCode < http.StatusMultipleChoices {
+		return nil
+	}
+	if resp.StatusCode == http.StatusBadRequest && strings.Contains(string(body), "resource_already_exists_exception") {
+		return nil
+	}
+
+	return fmt.Errorf("opensearch create-index failed with status %d: %s", resp.StatusCode, string(body))
+}

--- a/infra/bkn-agent/.dockerignore
+++ b/infra/bkn-agent/.dockerignore
@@ -1,0 +1,5 @@
+.DS_Store
+.pytest_cache/
+.venv*/
+__pycache__/
+*.pyc

--- a/infra/bkn-agent/.gitignore
+++ b/infra/bkn-agent/.gitignore
@@ -1,0 +1,5 @@
+.DS_Store
+.pytest_cache/
+.venv*/
+__pycache__/
+*.pyc

--- a/infra/bkn-agent/TRACE.md
+++ b/infra/bkn-agent/TRACE.md
@@ -19,7 +19,7 @@
 | `bkn-agent.health` | `GET /api/v1/health` | optional upstream `traceparent` / `bkn-request-id` | FastAPI server span | none |
 | `bkn-agent.agent.*` | agent CRUD routes | account identity, request context | FastAPI server span | none in phase one |
 | `bkn-agent.chat` | `POST /api/bkn-agent/v1/chat` | account identity, agent id, optional thread id | FastAPI server span, `agent.chat` business span, LangChain spans when OTel enabled | SSE meta/token/tool/error/done；成功输出 emit `claim.created`，工具引用 emit `evidence.refs.created`，结构化输出 emit `structured_output.validated` |
-| `bkn-agent.task` | `POST /api/bkn-agent/v1/run` / `POST /invoke/{agent_id}` | account identity, agent id, task context | FastAPI server span, `agent.task` business span, LangChain spans when OTel enabled | task status persisted in DB；成功输出 emit `claim.created`；结构化输出 emit `structured_output.validated`；tool result refs emit `evidence.refs.created` |
+| `bkn-agent.task` | `POST /api/bkn-agent/v1/run` / `POST /invoke/{agent_id}` | account identity, agent id, task context | FastAPI server span, `agent.task` business span, LangChain spans when OTel enabled | task status persisted in DB；成功输出 emit `claim.created`；结构化输出 emit `structured_output.validated`；tool result refs emit `evidence.refs.created`；显式业务字段 emit `business.refs.resolved` |
 
 ## Inbound Context
 
@@ -34,8 +34,8 @@
 
 | target | protocol | propagated fields | baggage policy | timeout | retry |
 | --- | --- | --- | --- | --- | --- |
-| toolbox / MCP tools | HTTP / MCP adapter | phase-one propagation pending in toolbox client | baggage not propagated | existing tool timeout policy | existing retry policy |
-| model provider | OpenAI-compatible HTTP through LangChain | OTel instrumentation when enabled | baggage not propagated | model/provider config | provider policy |
+| toolbox / MCP tools | HTTP / MCP adapter | `traceparent`, `bkn.request.id`, `x-request-id`, account identity | baggage not propagated | existing tool timeout policy | existing retry policy |
+| model provider | OpenAI-compatible HTTP through LangChain | OTel instrumentation when enabled; OpenInference input/output/tool/prompt attributes hidden by default | baggage not propagated | model/provider config | provider policy |
 | checkpoint store | MySQL | request context not propagated | baggage not propagated | DB config | DB driver policy |
 | BKN Trace evidence ingest | HTTP POST | `traceparent`, `bkn.request.id`, account identity in event batch | baggage not propagated | `BKN_TRACE_EVIDENCE_TIMEOUT_S` default 3s | no retry; fail-open with warning |
 
@@ -54,6 +54,8 @@
 | FastAPI server span | server | `bkn.request.id`, `trace_id`, route, status when OTel enabled | follows OTel FastAPI instrumentation | HTTP status |
 | `agent.chat` | internal | `bkn.agent.id`, `bkn.thread.id`, `bkn.prompt.source`, `bkn.prompt.version`, `bkn.request.id` | child of request span when active | stream error event in phase one |
 | `agent.task` | internal | `bkn.agent.id`, `task.depth`, `bkn.prompt.source`, `bkn.prompt.version`, `bkn.request.id` | child of request span when active | exception maps to task failure |
+| `bkn.agent.toolbox.list` | internal | `bkn.toolbox.id`, `bkn.request.id` | child of request/task span when active | toolbox list error envelope |
+| `bkn.agent.tool.call` | internal | `bkn.toolbox.id`, `bkn.tool.id`, `bkn.tool.name`, `bkn.tool.args_hash`, `bkn.request.id` | child of request/task span when active | tool call returns sanitized failure text |
 
 ## Events
 
@@ -65,8 +67,10 @@
 | `structured_output.validated` | `bkn-agent` | claim id, response format schema hash, validation result, `validation_path=native|fallback` | none | evidence event |
 | `tool.budget.exhausted` | `bkn-agent` | max tool call cap and sanitized tool name | `tool_budget_exhausted` | evidence event |
 | `agent_as_tool.invoked` | `bkn-agent` | parent thread id, child task id, child agent id, depth, message hash | none | evidence event |
+| `tool.called` | `bkn-agent` | toolbox id, tool id/name, `args_hash`; no raw args | none | evidence event |
+| `tool.result.observed` | `bkn-agent` | toolbox id, tool id/name, result hash/length or error hash; no raw result | `tool_result_failed` on failure | evidence event |
+| `business.refs.resolved` | `bkn-agent` | final task claim linked to explicit refs parsed from structured tool output keys such as `kn_id`, `object_type`, `relation_type`, `action_type`, `resource_id`, `catalog_id`; emitted as registered business dimensions `object/relation/action/data/logic/metric`; no row payload | `business_refs_unversioned` and `resolver_status=unresolved` until downstream resolver supplies versions | evidence event |
 | `task.status.changed` | pending follow-up | task old/new status and failure summary | not implemented in this PR | business event |
-| `tool.called` / `tool.failed` | pending follow-up | tool id/name and hash-only args/result | toolbox client propagation pending | business event |
 
 ## Business Refs
 
@@ -82,13 +86,14 @@
 - never log: authorization, cookie, access token, full prompt, full model output, full tool args/result
 - hash only: prompt/tool/model payload evidence, user message, model answer, structured output
 - controlled reference: future evidence snapshot refs
+- explicit business refs only: bkn-agent may emit business refs from structured identifier fields, but must not infer refs from free text or persist row-level payload
 - redact: HTTP error responses use short error summaries
 - `data.classification`: not emitted by bkn-agent phase-one code yet
 
 ## Evidence Submission
 
-- default mode: disabled when `BKN_TRACE_EVIDENCE_INGEST_URL` is empty; bkn-agent still constructs events in code paths but does not submit.
-- enabled mode: POST phase-two batch to `BKN_TRACE_EVIDENCE_INGEST_URL`.
+- default chart mode: POST phase-two batch to `http://agent-observability:8080/api/agent-observability/v1/evidence/events`.
+- disabled mode: set `BKN_TRACE_EVIDENCE_INGEST_URL` empty; bkn-agent still constructs events in code paths but does not submit.
 - fail behavior: fail-open with warning; bkn-agent response, task execution and tool execution must not depend on BKN Trace availability.
 - account context: event batch includes `bkn.account.id` / `bkn.account.type`; `business_domain` is temporarily set to account id until upstream business domain propagation is available.
 - payload boundary: never submit raw prompt, raw user message, raw answer, raw SQL, row data, token, cookie, authorization, or object storage URL.
@@ -122,9 +127,8 @@
 
 ## Known Gaps
 
-- toolbox/MCP outbound propagation is not fully implemented yet.
 - source refs from context-loader/BKN/Vega/Action are represented only as tool-call refs until downstream modules emit L2/L3 business refs.
 - task status changed events are still DB state transitions, not BKN Trace events.
-- evidence submission requires `BKN_TRACE_EVIDENCE_INGEST_URL`; default deployment keeps it empty until bkn-trace ingestion service address is configured.
+- evidence submission requires `BKN_TRACE_EVIDENCE_INGEST_URL`; local/full OpenBKN chart defaults to agent-observability ingestion, while minimal deployments can explicitly set it empty.
 - forced sampling and dropped counters are not implemented yet.
 - `business_domain` is temporarily derived from account id; dedicated business-domain propagation is a follow-up.

--- a/infra/bkn-agent/app/core/runner.py
+++ b/infra/bkn-agent/app/core/runner.py
@@ -177,6 +177,15 @@ async def _emit_task_evidence(
         for message in result_messages
         if isinstance(message, ToolMessage)
     ]
+    tool_outputs = [
+        {
+            "tool_name": getattr(message, "name", "") or getattr(message, "tool_call_id", ""),
+            "content": getattr(message, "content", None),
+        }
+        for message in result_messages
+        if isinstance(message, ToolMessage)
+    ]
+    business_refs = evidence.extract_business_refs_from_tool_outputs(tool_outputs)
     events = [
         evidence.claim_created(
             claim_id_value=cid,
@@ -223,6 +232,15 @@ async def _emit_task_evidence(
                     for name in dict.fromkeys(tool_names)
                 ],
                 operation_name="bkn.agent.task",
+            )
+        )
+    if business_refs:
+        events.append(
+            evidence.business_refs_resolved(
+                claim_id_value=cid,
+                business_refs=business_refs,
+                operation_name="bkn.agent.task",
+                partial_reason=["business_refs_unversioned"],
             )
         )
     await evidence.submit_events([event for event in events if event], account_id, account_type)

--- a/infra/bkn-agent/app/core/toolbox.py
+++ b/infra/bkn-agent/app/core/toolbox.py
@@ -22,6 +22,7 @@ from fastapi import HTTPException
 from langchain_core.tools import StructuredTool
 from pydantic import ConfigDict, Field, create_model
 
+from app import evidence, observability
 from app.config import config
 from app.errors import bad_request, err
 
@@ -136,6 +137,7 @@ def _args_model(tool_name: str, metadata: dict) -> tuple[Any, list[_Param]]:
 async def _execute(
     box_id: str,
     tool_id: str,
+    tool_name: str,
     method: str,
     args: dict,
     params: list[_Param],
@@ -146,7 +148,8 @@ async def _execute(
     不抛异常击穿整轮对话。参数按元数据声明的位置分发到 body/query/path。"""
     url = f"{config.OPERATOR_INTEGRATION_BASE}/internal-v1/tool-box/{box_id}/proxy/{tool_id}"
     identity = {"x-account-id": account_id, "x-account-type": account_type}
-    payload: dict[str, Any] = {"timeout": 60, "header": identity, "body": {}, "query": {}, "path": {}}
+    headers = {**identity, **observability.outbound_headers()}
+    payload: dict[str, Any] = {"timeout": 60, "header": headers, "body": {}, "query": {}, "path": {}}
     by_field = {p.field: p for p in params}
     fallback = "query" if method.upper() in ("GET", "DELETE") else "body"
     for field, value in args.items():
@@ -158,26 +161,71 @@ async def _execute(
             payload["path"][wire] = str(value)
         else:
             payload[bucket][wire] = value
-    try:
-        async with aiohttp.ClientSession(timeout=aiohttp.ClientTimeout(total=90)) as http:
-            async with http.post(url, json=payload, headers=identity) as resp:
-                text = await resp.text()
-                if not 200 <= resp.status < 300:
-                    return f"tool call failed: HTTP {resp.status} {text[:500]}"
-    except Exception as e:
-        return f"tool call failed: {e}"
-    try:
-        data = json.loads(text)
-    except ValueError:
-        return text
-    if data.get("error"):
-        return f"tool error: {data['error']}"
-    status_code = data.get("status_code") or 0
-    body = data.get("body")
-    body_text = body if isinstance(body, str) else json.dumps(body, ensure_ascii=False)
-    if status_code >= 400:
-        return f"tool target failed: HTTP {status_code} {body_text[:800]}"
-    return body_text
+    operation_name = "bkn.agent.tool.call"
+    args_hash = evidence.hash_value({"body": payload["body"], "query": payload["query"], "path": payload["path"]})
+    start_event = evidence.tool_called(
+        tool_id=tool_id,
+        tool_name=tool_name,
+        toolbox_id=box_id,
+        args_hash=args_hash,
+        operation_name=operation_name,
+    )
+
+    async def _finish(result: str, *, success: bool, status_code: int | None = None, error: str | None = None) -> str:
+        result_event = evidence.tool_result_observed(
+            tool_id=tool_id,
+            tool_name=tool_name,
+            toolbox_id=box_id,
+            result_hash=evidence.hash_value(result) if success else None,
+            result_length=len(result) if success else None,
+            success=success,
+            status_code=status_code,
+            error_hash=evidence.hash_value(error or result) if not success else None,
+            operation_name=operation_name,
+            partial_reason=[] if success else ["tool_result_failed"],
+        )
+        await evidence.submit_events([event for event in [start_event, result_event] if event], account_id, account_type)
+        return result
+
+    with observability.span(
+        operation_name,
+        {
+            "bkn.toolbox.id": box_id,
+            "bkn.tool.id": tool_id,
+            "bkn.tool.name": tool_name,
+            "bkn.tool.args_hash": args_hash,
+        },
+    ):
+        try:
+            async with aiohttp.ClientSession(timeout=aiohttp.ClientTimeout(total=90)) as http:
+                async with http.post(url, json=payload, headers=headers) as resp:
+                    text = await resp.text()
+                    if not 200 <= resp.status < 300:
+                        return await _finish(
+                            f"tool call failed: HTTP {resp.status} {text[:500]}",
+                            success=False,
+                            status_code=resp.status,
+                            error=text,
+                        )
+        except Exception as e:
+            return await _finish(f"tool call failed: {e}", success=False, error=f"{type(e).__name__}: {e}")
+        try:
+            data = json.loads(text)
+        except ValueError:
+            return await _finish(text, success=True, status_code=200)
+        if data.get("error"):
+            return await _finish(f"tool error: {data['error']}", success=False, error=str(data["error"]))
+        status_code = data.get("status_code") or 0
+        body = data.get("body")
+        body_text = body if isinstance(body, str) else json.dumps(body, ensure_ascii=False)
+        if status_code >= 400:
+            return await _finish(
+                f"tool target failed: HTTP {status_code} {body_text[:800]}",
+                success=False,
+                status_code=status_code,
+                error=body_text,
+            )
+        return await _finish(body_text, success=True, status_code=status_code)
 
 
 def _build_tool(box_id: str, info: dict, account_id: str, account_type: str) -> StructuredTool | None:
@@ -203,7 +251,7 @@ def _build_tool(box_id: str, info: dict, account_id: str, account_type: str) -> 
         return None
 
     async def call(**kwargs) -> str:
-        return await _execute(box_id, tool_id, method, kwargs, params, account_id, account_type)
+        return await _execute(box_id, tool_id, name, method, kwargs, params, account_id, account_type)
 
     return StructuredTool.from_function(
         coroutine=call,
@@ -217,35 +265,42 @@ async def _list_tools(box_id: str, account_id: str, account_type: str) -> list[d
     """拉取一个 box 的工具列表。工厂 4xx（box 不存在/无权限）= 调用方配置问题 → 400；
     5xx 与网络故障 = 下游不可用 → 502。都走平台错误封套。"""
     url = f"{config.OPERATOR_INTEGRATION_BASE}/internal-v1/tool-box/{box_id}/tools/list"
-    headers = {"x-account-id": account_id, "x-account-type": account_type}
+    headers = {"x-account-id": account_id, "x-account-type": account_type, **observability.outbound_headers()}
     infos: list[dict] = []
     page = 1
     try:
-        async with aiohttp.ClientSession(timeout=aiohttp.ClientTimeout(total=15)) as http:
-            while True:
-                params = {"page": page, "page_size": 100, "all": "true"}
-                async with http.get(url, params=params, headers=headers) as resp:
-                    body = await resp.text()
-                    if 400 <= resp.status < 500:
-                        raise bad_request(
-                            "ToolRef.BoxUnavailable",
-                            "引用的工具箱不可用",
-                            f"toolbox {box_id}: HTTP {resp.status} {body[:300]}",
-                            "检查 agent.tools 里的 box_id 是否存在、当前账户是否有权访问。",
-                        )
-                    if resp.status != 200:
-                        raise err(
-                            502,
-                            "Toolbox.Upstream",
-                            "算子工厂不可用",
-                            f"toolbox {box_id} list failed: HTTP {resp.status} {body[:300]}",
-                            "稍后重试；持续失败检查 operator-integration。",
-                        )
-                    data = json.loads(body)
-                infos.extend(data.get("tools") or [])
-                if not data.get("has_next"):
-                    return infos
-                page += 1
+        with observability.span(
+            "bkn.agent.toolbox.list",
+            {
+                "bkn.toolbox.id": box_id,
+                "bkn.operation.name": "bkn.agent.toolbox.list",
+            },
+        ):
+            async with aiohttp.ClientSession(timeout=aiohttp.ClientTimeout(total=15)) as http:
+                while True:
+                    params = {"page": page, "page_size": 100, "all": "true"}
+                    async with http.get(url, params=params, headers=headers) as resp:
+                        body = await resp.text()
+                        if 400 <= resp.status < 500:
+                            raise bad_request(
+                                "ToolRef.BoxUnavailable",
+                                "引用的工具箱不可用",
+                                f"toolbox {box_id}: HTTP {resp.status} {body[:300]}",
+                                "检查 agent.tools 里的 box_id 是否存在、当前账户是否有权访问。",
+                            )
+                        if resp.status != 200:
+                            raise err(
+                                502,
+                                "Toolbox.Upstream",
+                                "算子工厂不可用",
+                                f"toolbox {box_id} list failed: HTTP {resp.status} {body[:300]}",
+                                "稍后重试；持续失败检查 operator-integration。",
+                            )
+                        data = json.loads(body)
+                    infos.extend(data.get("tools") or [])
+                    if not data.get("has_next"):
+                        return infos
+                    page += 1
     except HTTPException:
         raise
     except Exception as e:  # 连接失败/超时/响应体畸形

--- a/infra/bkn-agent/app/core/tools.py
+++ b/infra/bkn-agent/app/core/tools.py
@@ -5,7 +5,7 @@ import aiohttp
 from langchain_core.tools import StructuredTool
 from langchain_mcp_adapters.client import MultiServerMCPClient
 
-from app import evidence
+from app import evidence, observability
 from app.config import config
 from app.core.skills import normalize_skill_id
 from app.core.toolbox import load_toolbox_tools
@@ -17,7 +17,7 @@ logger = logging.getLogger("bkn-agent.tools")
 def _mcp_connections(tool_refs: list[dict], account_id: str, account_type: str) -> dict[str, dict]:
     """agent.tools 中 type=mcp 的显式外部 MCP 端点。平台内置工具不走这里
     （统一从执行工厂 toolbox 装载，见 load_tools）。"""
-    headers = {"x-account-id": account_id, "x-account-type": account_type}
+    headers = {"x-account-id": account_id, "x-account-type": account_type, **observability.outbound_headers()}
     conns: dict[str, dict] = {}
     for i, ref in enumerate(tool_refs):
         kind = ref.get("type")
@@ -137,7 +137,7 @@ def _read_skill_file_tool(account_id: str, account_type: str) -> StructuredTool:
         skill_id 与 path 取 system prompt 中该技能条目列出的值。"""
         sid = normalize_skill_id(skill_id)
         url = f"{config.OPERATOR_INTEGRATION_BASE}/internal-v1/skills/{sid}/files/read"
-        headers = {"x-account-id": account_id, "x-account-type": account_type}
+        headers = {"x-account-id": account_id, "x-account-type": account_type, **observability.outbound_headers()}
         async with aiohttp.ClientSession(timeout=aiohttp.ClientTimeout(total=30)) as session:
             # 字段名是 rel_path，执行工厂侧 validate:"required"；发过 path 会 400
             async with session.post(url, json={"rel_path": path}, headers=headers) as resp:

--- a/infra/bkn-agent/app/evidence.py
+++ b/infra/bkn-agent/app/evidence.py
@@ -15,6 +15,30 @@ logger = logging.getLogger("bkn-agent.evidence")
 
 CONTRACT_VERSION = "2.0.0"
 _background: set[asyncio.Task] = set()
+_BUSINESS_REF_FIELDS: dict[str, tuple[str, str]] = {
+    "kn_id": ("object", "bkn"),
+    "knowledge_network_id": ("object", "bkn"),
+    "object_type": ("object", "bkn"),
+    "object_type_id": ("object", "bkn"),
+    "ot_id": ("object", "bkn"),
+    "property": ("property", "bkn"),
+    "property_id": ("property", "bkn"),
+    "property_name": ("property", "bkn"),
+    "relation_type": ("relation", "bkn"),
+    "relation_type_id": ("relation", "bkn"),
+    "rt_id": ("relation", "bkn"),
+    "action_type": ("action", "bkn"),
+    "action_type_id": ("action", "bkn"),
+    "logic_property": ("logic", "bkn"),
+    "logical_property": ("logic", "bkn"),
+    "metric_id": ("metric", "bkn"),
+    "catalog_id": ("data", "vega-data"),
+    "resource_id": ("data", "vega-data"),
+    "data_view_id": ("data", "vega-data"),
+    "table_id": ("data", "vega-data"),
+    "field_id": ("data", "vega-data"),
+    "field_name": ("data", "vega-data"),
+}
 
 
 def hash_value(value: Any) -> str:
@@ -153,6 +177,78 @@ def evidence_refs_created(
     return _event("evidence.refs.created", operation_name, payload)
 
 
+def business_refs_resolved(
+    *,
+    claim_id_value: str,
+    business_refs: list[dict[str, Any]],
+    operation_name: str,
+    partial_reason: list[str] | None = None,
+) -> dict[str, Any] | None:
+    payload: dict[str, Any] = {
+        "claim_id": claim_id_value,
+        "business_refs": business_refs,
+    }
+    if partial_reason:
+        payload["partial_reason"] = partial_reason
+    return _event("business.refs.resolved", operation_name, payload)
+
+
+def extract_business_refs_from_tool_outputs(tool_outputs: list[dict[str, Any]], max_refs: int = 20) -> list[dict[str, Any]]:
+    refs: list[dict[str, Any]] = []
+    seen: set[tuple[str, str, str]] = set()
+
+    def add_ref(key: str, value: Any, tool_name: str) -> None:
+        if len(refs) >= max_refs or not isinstance(value, str) or not value.strip() or len(value) > 200:
+            return
+        ref_type, source_system = _BUSINESS_REF_FIELDS[key]
+        ref_value = value.strip()
+        dedupe_key = (ref_type, source_system, ref_value)
+        if dedupe_key in seen:
+            return
+        seen.add(dedupe_key)
+        ref_hash = hash_value({"type": ref_type, "source": source_system, "value": ref_value})
+        refs.append(
+            {
+                "ref_id": f"{ref_type}:{ref_hash[7:23]}",
+                "ref_type": ref_type,
+                "source_system": source_system,
+                "summary_hash": ref_hash,
+                "label": ref_value,
+                "tool_name": tool_name,
+                "validity": "observed",
+                "visibility": "visible",
+                "version_status": "unversioned",
+                "resolver_status": "unresolved",
+                "partial_reason": ["business_ref_unversioned"],
+            }
+        )
+
+    def walk(value: Any, tool_name: str, depth: int = 0) -> None:
+        if depth > 5 or len(refs) >= max_refs:
+            return
+        if isinstance(value, dict):
+            for key, child in value.items():
+                normalized_key = str(key).lower()
+                if normalized_key in _BUSINESS_REF_FIELDS:
+                    add_ref(normalized_key, child, tool_name)
+                walk(child, tool_name, depth + 1)
+        elif isinstance(value, list):
+            for item in value[:50]:
+                walk(item, tool_name, depth + 1)
+
+    for output in tool_outputs:
+        tool_name = str(output.get("tool_name") or "")
+        content = output.get("content")
+        parsed: Any = content
+        if isinstance(content, str):
+            try:
+                parsed = json.loads(content)
+            except ValueError:
+                continue
+        walk(parsed, tool_name)
+    return refs
+
+
 def structured_output_validated(
     *,
     claim_id_value: str,
@@ -188,6 +284,58 @@ def tool_budget_exhausted(
             "partial_reason": ["tool_budget_exhausted"],
         },
     )
+
+
+def tool_called(
+    *,
+    tool_id: str,
+    tool_name: str,
+    toolbox_id: str | None,
+    args_hash: str,
+    operation_name: str,
+) -> dict[str, Any] | None:
+    return _event(
+        "tool.called",
+        operation_name,
+        {
+            "tool_id": tool_id,
+            "tool_name": tool_name,
+            "toolbox_id": toolbox_id,
+            "args_hash": args_hash,
+            "visibility": "visible",
+            "version_status": "unversioned",
+        },
+    )
+
+
+def tool_result_observed(
+    *,
+    tool_id: str,
+    tool_name: str,
+    toolbox_id: str | None,
+    result_hash: str | None,
+    result_length: int | None,
+    success: bool,
+    operation_name: str,
+    status_code: int | None = None,
+    error_hash: str | None = None,
+    partial_reason: list[str] | None = None,
+) -> dict[str, Any] | None:
+    payload: dict[str, Any] = {
+        "tool_id": tool_id,
+        "tool_name": tool_name,
+        "toolbox_id": toolbox_id,
+        "result_hash": result_hash,
+        "result_length": result_length,
+        "status": "success" if success else "failed",
+        "status_code": status_code,
+        "error_hash": error_hash,
+        "visibility": "visible",
+        "version_status": "unversioned",
+    }
+    if partial_reason:
+        payload["partial_reason"] = partial_reason
+    return _event("tool.result.observed", operation_name, payload)
 
 
 def agent_as_tool_invoked(

--- a/infra/bkn-agent/app/observability.py
+++ b/infra/bkn-agent/app/observability.py
@@ -30,6 +30,25 @@ class TraceContext:
 _current_context: ContextVar[Optional[TraceContext]] = ContextVar("bkn_trace_context", default=None)
 
 
+OPENINFERENCE_REDACTION_DEFAULTS = {
+    "OPENINFERENCE_HIDE_INPUTS": "true",
+    "OPENINFERENCE_HIDE_OUTPUTS": "true",
+    "OPENINFERENCE_HIDE_INPUT_MESSAGES": "true",
+    "OPENINFERENCE_HIDE_OUTPUT_MESSAGES": "true",
+    "OPENINFERENCE_HIDE_INPUT_TEXT": "true",
+    "OPENINFERENCE_HIDE_OUTPUT_TEXT": "true",
+    "OPENINFERENCE_HIDE_LLM_INVOCATION_PARAMETERS": "true",
+    "OPENINFERENCE_HIDE_LLM_TOOLS": "true",
+    "OPENINFERENCE_HIDE_PROMPTS": "true",
+}
+
+
+def configure_openinference_redaction() -> None:
+    """Default LangChain/OpenInference spans to hash-only BKN Trace safety."""
+    for key, value in OPENINFERENCE_REDACTION_DEFAULTS.items():
+        os.environ.setdefault(key, value)
+
+
 def setup_otel(app) -> None:
     """OTel GenAI 链路：openinference LangChain instrumentation（不自研埋点层）
     + FastAPI 入口 span，OTLP HTTP 导出到平台 otelcol-contrib。失败降级为不埋点，不影响服务。"""
@@ -37,6 +56,7 @@ def setup_otel(app) -> None:
     if os.getenv("OTEL_ENABLED", "true").lower() != "true":
         return
     try:
+        configure_openinference_redaction()
         from openinference.instrumentation.langchain import LangChainInstrumentor
         from opentelemetry import trace
         from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter
@@ -145,6 +165,11 @@ def response_headers(ctx: Optional[TraceContext] = None) -> dict[str, str]:
         LEGACY_REQUEST_ID_HEADER: ctx.request_id,
         "traceparent": ctx.traceparent,
     }
+
+
+def outbound_headers(ctx: Optional[TraceContext] = None) -> dict[str, str]:
+    """Trace context headers for downstream HTTP/toolbox/MCP calls."""
+    return response_headers(ctx)
 
 
 def enrich_error(content: dict) -> dict:

--- a/infra/bkn-agent/app/test/test_evidence.py
+++ b/infra/bkn-agent/app/test/test_evidence.py
@@ -1,6 +1,10 @@
 import asyncio
 
+from langchain_core.messages import ToolMessage
+
 from app import evidence, observability
+from app.core import runner
+from app.models import AgentOut
 
 
 def _ctx():
@@ -101,3 +105,82 @@ def test_submit_events_schedules_background_send(monkeypatch):
         asyncio.run(drive())
     finally:
         observability.reset_context(token)
+
+
+def test_extract_business_refs_from_structured_tool_outputs_without_raw_rows():
+    refs = evidence.extract_business_refs_from_tool_outputs(
+        [
+            {
+                "tool_name": "query_object_instance",
+                "content": {
+                    "kn_id": "supplychain_hd0202",
+                    "object_type": "forecast_order",
+                    "rows": [{"customer_name": "客户A", "amount": 100}],
+                    "resource_id": "res_forecast_001",
+                },
+            }
+        ]
+    )
+
+    serialized = str(refs)
+    assert {ref["ref_type"] for ref in refs} >= {"object", "data"}
+    assert "supplychain_hd0202" in serialized
+    assert "forecast_order" in serialized
+    assert "res_forecast_001" in serialized
+    assert "客户A" not in serialized
+    assert "amount" not in serialized
+    assert all(ref["summary_hash"].startswith("sha256:") for ref in refs)
+    assert all(ref["resolver_status"] == "unresolved" for ref in refs)
+
+
+def test_task_evidence_attaches_business_refs_to_claim(monkeypatch):
+    submitted = []
+
+    async def fake_submit(events, account_id, account_type):
+        submitted.extend(events)
+
+    agent = AgentOut(
+        name="agent",
+        mode="task",
+        model="",
+        tools=[],
+        skills=[],
+        status="published",
+        agent_id="agent-1",
+        create_user="u",
+        update_user="u",
+        create_time=0,
+        update_time=0,
+    )
+    token = observability.set_context(_ctx())
+    try:
+        monkeypatch.setattr(runner.evidence, "submit_events", fake_submit)
+        asyncio.run(
+            runner._emit_task_evidence(
+                agent=agent,
+                task_id="task-1",
+                prompt_source="default",
+                prompt_version="1",
+                account_id="acct-1",
+                account_type="user",
+                output="建议查看预测单。",
+                claim_type="answer",
+                response_format=None,
+                structured_validation_path=None,
+                result_messages=[
+                    ToolMessage(
+                        content='{"kn_id":"supplychain_hd0202","object_type":"forecast_order","resource_id":"res_forecast_001"}',
+                        tool_call_id="call-1",
+                        name="query_object_instance",
+                    )
+                ],
+            )
+        )
+    finally:
+        observability.reset_context(token)
+
+    event_types = [event["event_type"] for event in submitted]
+    assert event_types == ["claim.created", "evidence.refs.created", "business.refs.resolved"]
+    business_event = submitted[2]
+    assert business_event["payload"]["claim_id"] == submitted[0]["payload"]["claim_id"]
+    assert {ref["ref_type"] for ref in business_event["payload"]["business_refs"]} >= {"object", "data"}

--- a/infra/bkn-agent/app/test/test_observability_redaction.py
+++ b/infra/bkn-agent/app/test/test_observability_redaction.py
@@ -1,0 +1,27 @@
+from app import observability
+
+
+def test_openinference_redaction_defaults_hide_sensitive_payloads(monkeypatch):
+    for key in observability.OPENINFERENCE_REDACTION_DEFAULTS:
+        monkeypatch.delenv(key, raising=False)
+
+    observability.configure_openinference_redaction()
+
+    for key in (
+        "OPENINFERENCE_HIDE_INPUTS",
+        "OPENINFERENCE_HIDE_OUTPUTS",
+        "OPENINFERENCE_HIDE_INPUT_MESSAGES",
+        "OPENINFERENCE_HIDE_OUTPUT_MESSAGES",
+        "OPENINFERENCE_HIDE_LLM_INVOCATION_PARAMETERS",
+        "OPENINFERENCE_HIDE_LLM_TOOLS",
+        "OPENINFERENCE_HIDE_PROMPTS",
+    ):
+        assert observability.os.environ[key] == "true"
+
+
+def test_openinference_redaction_does_not_override_deployment_policy(monkeypatch):
+    monkeypatch.setenv("OPENINFERENCE_HIDE_INPUTS", "false")
+
+    observability.configure_openinference_redaction()
+
+    assert observability.os.environ["OPENINFERENCE_HIDE_INPUTS"] == "false"

--- a/infra/bkn-agent/app/test/test_toolbox_tools.py
+++ b/infra/bkn-agent/app/test/test_toolbox_tools.py
@@ -3,8 +3,9 @@ import asyncio
 
 import pytest
 
+from app import evidence, observability
 from app.core import toolbox
-from app.core.tools import _toolbox_tools
+from app.core.tools import _mcp_connections, _toolbox_tools
 from app.errors import bad_request  # noqa: F401  (确认导出仍存在)
 
 _TOOL_INFO = {
@@ -118,8 +119,8 @@ def test_execute_payload_routing(monkeypatch):
     """POST 参数进 body、GET 进 query；身份 header 双份（外层请求 + 转发 header）。"""
     captured = {}
 
-    async def fake_execute(box_id, tool_id, method, args, params, account_id, account_type):
-        captured.update(box=box_id, tool=tool_id, method=method, args=args, aid=account_id)
+    async def fake_execute(box_id, tool_id, tool_name, method, args, params, account_id, account_type):
+        captured.update(box=box_id, tool=tool_id, tool_name=tool_name, method=method, args=args, aid=account_id)
         return "ok"
 
     monkeypatch.setattr(toolbox, "_execute", fake_execute)
@@ -127,6 +128,7 @@ def test_execute_payload_routing(monkeypatch):
     out = asyncio.run(tool.coroutine(query="q", limit=None))
     assert out == "ok"
     assert captured["box"] == "b-1" and captured["tool"] == "t-1"
+    assert captured["tool_name"] == "list_knowledge_networks"
     assert captured["aid"] == "u-9"
 
 
@@ -163,12 +165,151 @@ def test_execute_splits_query_and_body_by_declared_location(monkeypatch):
     monkeypatch.setattr(toolbox.aiohttp, "ClientSession", _Session)
     _, params = toolbox._args_model("query_object_instance", _QUERY_TOOL_INFO["metadata"])
     out = asyncio.run(
-        toolbox._execute("b-1", "t-2", "POST", {"kn_id": "kn1", "ot_id": "ot1", "limit": 5}, params, "u-9", "user")
+        toolbox._execute("b-1", "t-2", "query_object_instance", "POST", {"kn_id": "kn1", "ot_id": "ot1", "limit": 5}, params, "u-9", "user")
     )
     assert '"ok": true' in out
     assert sent["payload"]["query"] == {"kn_id": "kn1", "ot_id": "ot1"}
     assert sent["payload"]["body"] == {"limit": 5}
     assert sent["payload"]["header"]["x-account-id"] == "u-9"
+
+
+def test_execute_propagates_trace_context_to_proxy_and_downstream_payload(monkeypatch):
+    """E2E-1 回归：bkn-agent -> toolbox proxy -> 下游 OpenBKN 必须保留 trace/request id。"""
+    sent = {}
+    traceparent = "00-1234567890abcdef1234567890abcdef-abcdef1234567890-01"
+
+    class _Resp:
+        status = 200
+
+        async def text(self):
+            return '{"status_code": 200, "body": {"ok": true}}'
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *a):
+            return False
+
+    class _Session:
+        def __init__(self, *a, **k):
+            pass
+
+        def post(self, url, json=None, headers=None):
+            sent.update(url=url, payload=json, headers=headers)
+            return _Resp()
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *a):
+            return False
+
+    ctx = observability.TraceContext(
+        trace_id="1234567890abcdef1234567890abcdef",
+        request_id="req_toolbox_trace_001",
+        traceparent=traceparent,
+        entry_boundary="external",
+        upstream_span_id="abcdef1234567890",
+    )
+    token = observability.set_context(ctx)
+    try:
+        monkeypatch.setattr(toolbox.aiohttp, "ClientSession", _Session)
+        _, params = toolbox._args_model("query_object_instance", _QUERY_TOOL_INFO["metadata"])
+        out = asyncio.run(
+            toolbox._execute(
+                "b-1",
+                "t-2",
+                "query_object_instance",
+                "POST",
+                {"kn_id": "kn1", "ot_id": "ot1", "limit": 5},
+                params,
+                "u-9",
+                "user",
+            )
+        )
+    finally:
+        observability.reset_context(token)
+
+    assert '"ok": true' in out
+    expected = {
+        "traceparent": traceparent,
+        "bkn-request-id": "req_toolbox_trace_001",
+        "x-request-id": "req_toolbox_trace_001",
+        "x-trace-id": "1234567890abcdef1234567890abcdef",
+    }
+    for key, value in expected.items():
+        assert sent["headers"][key] == value
+        assert sent["payload"]["header"][key] == value
+
+
+def test_execute_emits_hash_only_tool_evidence(monkeypatch):
+    """E2E-1 回归：工具调用要形成证据事件，但不能泄露参数值或结果正文。"""
+    submitted = []
+    traceparent = "00-1234567890abcdef1234567890abcdef-abcdef1234567890-01"
+
+    class _Resp:
+        status = 200
+
+        async def text(self):
+            return '{"status_code": 200, "body": {"answer": "客户A风险升高"}}'
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *a):
+            return False
+
+    class _Session:
+        def __init__(self, *a, **k):
+            pass
+
+        def post(self, url, json=None, headers=None):
+            return _Resp()
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *a):
+            return False
+
+    async def fake_submit(events, account_id, account_type):
+        submitted.extend(events)
+
+    ctx = observability.TraceContext(
+        trace_id="1234567890abcdef1234567890abcdef",
+        request_id="req_toolbox_evidence_001",
+        traceparent=traceparent,
+        entry_boundary="external",
+        upstream_span_id="abcdef1234567890",
+    )
+    token = observability.set_context(ctx)
+    try:
+        monkeypatch.setattr(toolbox.aiohttp, "ClientSession", _Session)
+        monkeypatch.setattr(evidence, "submit_events", fake_submit)
+        _, params = toolbox._args_model("query_object_instance", _QUERY_TOOL_INFO["metadata"])
+        out = asyncio.run(
+            toolbox._execute(
+                "b-1",
+                "t-2",
+                "query_object_instance",
+                "POST",
+                {"kn_id": "kn1", "ot_id": "ot1", "limit": 5},
+                params,
+                "u-9",
+                "user",
+            )
+        )
+    finally:
+        observability.reset_context(token)
+
+    assert "客户A风险升高" in out
+    assert [event["event_type"] for event in submitted] == ["tool.called", "tool.result.observed"]
+    serialized = str(submitted)
+    assert "kn1" not in serialized
+    assert "ot1" not in serialized
+    assert "客户A风险升高" not in serialized
+    assert submitted[0]["payload"]["args_hash"].startswith("sha256:")
+    assert submitted[1]["payload"]["result_hash"].startswith("sha256:")
 
 
 def test_build_tool_survives_bad_args_schema(monkeypatch):
@@ -195,6 +336,34 @@ def test_default_toolbox_degrades_but_explicit_ref_fails(monkeypatch):
 
     with pytest.raises(RuntimeError):
         asyncio.run(_toolbox_tools([{"type": "toolbox", "box_id": "box-x"}], "u", "user"))
+
+
+def test_mcp_connections_propagate_trace_context():
+    """E2E-1 回归：外部 MCP 工具连接也必须保留 bkn-agent 当前 trace context。"""
+    traceparent = "00-fedcba0987654321fedcba0987654321-0123456789abcdef-01"
+    ctx = observability.TraceContext(
+        trace_id="fedcba0987654321fedcba0987654321",
+        request_id="req_mcp_trace_001",
+        traceparent=traceparent,
+        entry_boundary="external",
+        upstream_span_id="0123456789abcdef",
+    )
+    token = observability.set_context(ctx)
+    try:
+        conns = _mcp_connections(
+            [{"type": "mcp", "name": "openbkn-mcp", "url": "http://mcp.example/sse"}],
+            "u-9",
+            "user",
+        )
+    finally:
+        observability.reset_context(token)
+
+    headers = conns["openbkn-mcp"]["headers"]
+    assert headers["x-account-id"] == "u-9"
+    assert headers["traceparent"] == traceparent
+    assert headers["bkn-request-id"] == "req_mcp_trace_001"
+    assert headers["x-request-id"] == "req_mcp_trace_001"
+    assert headers["x-trace-id"] == "fedcba0987654321fedcba0987654321"
 
 
 def test_explicit_box_error_is_classified(monkeypatch):

--- a/infra/bkn-agent/charts/values.yaml
+++ b/infra/bkn-agent/charts/values.yaml
@@ -53,7 +53,7 @@ runtime:
 observability:
   otelEnabled: "true"
   otlpEndpoint: "http://otelcol-contrib:4318"
-  bknTraceEvidenceIngestUrl: ""
+  bknTraceEvidenceIngestUrl: "http://agent-observability:8080/api/agent-observability/v1/evidence/events"
   bknTraceEvidenceTimeoutS: "3"
 
 nodeSelector: {}

--- a/infra/bkn-agent/fixtures/bkn-trace/phase2/chat_l2_positive.json
+++ b/infra/bkn-agent/fixtures/bkn-trace/phase2/chat_l2_positive.json
@@ -75,6 +75,35 @@
           }
         ]
       }
+    },
+    {
+      "event_id": "evt_bkn_agent_chat_business_refs",
+      "event_type": "business.refs.resolved",
+      "bkn.trace.schema.version": "2.0.0",
+      "observed_at": "2026-07-22T10:00:00.004000Z",
+      "emitted_at": "2026-07-22T10:00:00.005000Z",
+      "producer_module": "bkn-agent",
+      "trace_id": "7a210000000000000000000000000001",
+      "span_id": "7a21000000000001",
+      "bkn.request.id": "req_bkn_agent_phase2_chat_0001",
+      "bkn.operation.name": "bkn.agent.chat",
+      "payload": {
+        "claim_id": "claim_bkn_agent_chat_0001",
+        "business_refs": [
+          {
+            "ref_id": "object:forecast_order",
+            "ref_type": "object",
+            "source_system": "bkn",
+            "summary_hash": "sha256:business_ref_summary_hash_only",
+            "label": "forecast_order",
+            "validity": "observed",
+            "visibility": "visible",
+            "version_status": "unversioned",
+            "resolver_status": "unresolved",
+            "partial_reason": ["business_ref_unversioned"]
+          }
+        ]
+      }
     }
   ]
 }


### PR DESCRIPTION
## Summary

- Persist phase-two BKN Trace evidence through agent-observability with OpenSearch-backed query support and a controlled `bkn-trace-evidence-v2` index mapping.
- Keep full evidence `events` in `_source` for API/Studio details, but disable indexing for the event payload to avoid dynamic mapping growth from business refs/tool refs.
- Add backward-compatible `/evidence/by-trace` handling on top of the current evidence-chain service API.
- Extend bkn-agent evidence emission for tool call/result events, trace/request propagation through toolbox/MCP, OpenInference redaction defaults, and explicit business refs from structured tool results.
- Propagate trace/request headers through operator-integration proxy forwarding.

## Verification

- `GOCACHE=/private/tmp/openbkn-go-cache go test ./...` in `bkn-trace/agent-observability`
- `.venv-trace/bin/python -m pytest -q app/test/test_evidence.py app/test/test_toolbox_tools.py app/test/test_structured_output.py app/test/test_observability_redaction.py` in `infra/bkn-agent`
- `python3 /Users/leecky/openbkn/bkn-docs/docs/foundry/bkn-trace/validation/validate_phase2_fixture.py infra/bkn-agent/fixtures/bkn-trace/phase2/chat_l2_positive.json`
- `GOCACHE=/private/tmp/openbkn-go-cache go test ./logics/proxy` in `adp/execution-factory/operator-integration/server`
- Local E2E check: evidence ingest returned `202`; querying trace `7a210000000000000000000000000001` returned `claim.created`, `evidence.refs.created`, and `business.refs.resolved`; OpenSearch mapping confirmed `dynamic=false` and `events.enabled=false`.
