### PR TITLE
fix(ontology-query): push metric analysis_dimensions to Vega group_by

### DIFF
--- a/adp/bkn/ontology-query/server/logics/metric/metric_query_service.go
+++ b/adp/bkn/ontology-query/server/logics/metric/metric_query_service.go
@@ -313,8 +313,12 @@ func (s *metricQueryService) buildResourceDataQueryParams(ctx context.Context, d
 		"alias":    "__value",
 	}
 
-	// 处理分组字段（calculation_formula.group_by + 请求 analysis_dimensions，与 metricGroupByDimensions 一致）
-	groupDims, err := metricGroupByDimensions(def, metricQuery, propMap)
+	// Keep the pushed group-by fields aligned with the dimensions used by result conversion.
+	excludedGroupByResourceField := ""
+	if trend != nil {
+		excludedGroupByResourceField = trend.timeResField
+	}
+	groupDims, err := metricGroupByDimensions(def, metricQuery, propMap, excludedGroupByResourceField)
 	if err != nil {
 		return nil, nil, rest.NewHTTPError(ctx, http.StatusBadRequest, oerrors.OntologyQuery_Metric_InvalidParameter).
 			WithErrorDetails(err.Error())
@@ -420,31 +424,30 @@ type metricGroupByDimension struct {
 	ResourceFieldName string
 }
 
-// metricGroupByDimensions 从 def 与 query 收集维度顺序（与下推时 group 维度一致，顺序：先 group_by 后 analysis_dimensions 去重），
-// 并对每一项解析出 resource 列名。当 query 带 analysis_dimensions 时，只保留在定义与请求的交集中，顺序与 query 一致；交集为空则返回空 slice。
-func metricGroupByDimensions(def *interfaces.MetricDefinition, query *interfaces.MetricQueryRequest, propMap map[string]*cond.DataProperty) ([]metricGroupByDimension, error) {
+// metricGroupByDimensions resolves definition and request dimensions to resource fields.
+// When request analysis_dimensions are present, only requested definition dimensions are kept in request order.
+// excludedResourceField prevents trend queries from grouping the time field twice, including through property aliases.
+func metricGroupByDimensions(def *interfaces.MetricDefinition, query *interfaces.MetricQueryRequest,
+	propMap map[string]*cond.DataProperty, excludedResourceField string) ([]metricGroupByDimension, error) {
 	if def == nil {
 		return nil, nil
 	}
 	if propMap == nil {
 		return nil, fmt.Errorf("propMap is required for group by dimension mapping")
 	}
-	timeProperty := ""
-	if def.TimeDimension != nil {
-		timeProperty = strings.TrimSpace(def.TimeDimension.Property)
-	}
+	excludedResourceField = strings.TrimSpace(excludedResourceField)
 	defined := make(map[string]struct{})
 	var defaultOrdered []string
 	addDefined := func(s string) {
 		s = strings.TrimSpace(s)
-		if s == "" || s == timeProperty {
+		if s == "" {
 			return
 		}
 		defined[s] = struct{}{}
 	}
 	addDefault := func(s string) {
 		s = strings.TrimSpace(s)
-		if s == "" || s == timeProperty {
+		if s == "" {
 			return
 		}
 		if _, ok := defined[s]; ok {
@@ -488,6 +491,9 @@ func metricGroupByDimensions(def *interfaces.MetricDefinition, query *interfaces
 		res, err := mapDataPropertyToResourceField(p, propMap)
 		if err != nil {
 			return nil, err
+		}
+		if res == excludedResourceField {
+			continue
 		}
 		out = append(out, metricGroupByDimension{PropertyName: p, ResourceFieldName: res})
 	}
@@ -590,13 +596,13 @@ func vegaEntriesToMetricData(ctx context.Context, def interfaces.MetricDefinitio
 	samePeriodDatas *interfaces.DatasetQueryResponse, query *interfaces.MetricQueryRequest,
 	trend *trendMeta, vegaFetchDur int64, propMap map[string]*cond.DataProperty) (interfaces.MetricResponse, error) {
 
-	groupDims, err := metricGroupByDimensions(&def, query, propMap)
-	if err != nil {
-		return interfaces.MetricResponse{}, err
-	}
-
 	if trend != nil {
 		return convertVegaDatas2TimeSeries(ctx, def, datas, samePeriodDatas, query, trend, vegaFetchDur, propMap)
+	}
+
+	groupDims, err := metricGroupByDimensions(&def, query, propMap, "")
+	if err != nil {
+		return interfaces.MetricResponse{}, err
 	}
 
 	entries := []map[string]any(nil)
@@ -991,7 +997,7 @@ func convert2TimeSeries(ctx context.Context, def interfaces.MetricDefinition, da
 		return seriesMap, nil
 	}
 	fillNull := query != nil && query.FillNull
-	groupDims, err := metricGroupByDimensions(&def, query, propMap)
+	groupDims, err := metricGroupByDimensions(&def, query, propMap, trend.timeResField)
 	if err != nil {
 		return nil, err
 	}

--- a/adp/bkn/ontology-query/server/logics/metric/metric_query_service.go
+++ b/adp/bkn/ontology-query/server/logics/metric/metric_query_service.go
@@ -313,18 +313,18 @@ func (s *metricQueryService) buildResourceDataQueryParams(ctx context.Context, d
 		"alias":    "__value",
 	}
 
-	// 处理分组字段
+	// 处理分组字段（calculation_formula.group_by + 请求 analysis_dimensions，与 metricGroupByDimensions 一致）
+	groupDims, err := metricGroupByDimensions(def, metricQuery, propMap)
+	if err != nil {
+		return nil, nil, rest.NewHTTPError(ctx, http.StatusBadRequest, oerrors.OntologyQuery_Metric_InvalidParameter).
+			WithErrorDetails(err.Error())
+	}
 	var gb []map[string]any
-	if len(metricFormula.GroupBy) > 0 {
-		gb = make([]map[string]any, 0, len(metricFormula.GroupBy))
-		for _, g := range metricFormula.GroupBy {
-			resProp, err := mapDataPropertyToResourceField(g.Property, propMap)
-			if err != nil {
-				return nil, nil, rest.NewHTTPError(ctx, http.StatusBadRequest, oerrors.OntologyQuery_Metric_InvalidParameter).
-					WithErrorDetails(err.Error())
-			}
+	if len(groupDims) > 0 {
+		gb = make([]map[string]any, 0, len(groupDims)+1)
+		for _, d := range groupDims {
 			gb = append(gb, map[string]any{
-				"property": resProp,
+				"property": d.ResourceFieldName,
 			})
 		}
 	}
@@ -430,8 +430,15 @@ func metricGroupByDimensions(def *interfaces.MetricDefinition, query *interfaces
 		return nil, fmt.Errorf("propMap is required for group by dimension mapping")
 	}
 	defined := make(map[string]struct{})
-	var ordered []string
-	add := func(s string) {
+	var defaultOrdered []string
+	addDefined := func(s string) {
+		s = strings.TrimSpace(s)
+		if s == "" {
+			return
+		}
+		defined[s] = struct{}{}
+	}
+	addDefault := func(s string) {
 		s = strings.TrimSpace(s)
 		if s == "" {
 			return
@@ -440,17 +447,20 @@ func metricGroupByDimensions(def *interfaces.MetricDefinition, query *interfaces
 			return
 		}
 		defined[s] = struct{}{}
-		ordered = append(ordered, s)
+		defaultOrdered = append(defaultOrdered, s)
 	}
 	if def.CalculationFormula != nil {
 		for _, g := range def.CalculationFormula.GroupBy {
-			add(g.Property)
+			addDefault(g.Property)
 		}
+	}
+	for _, ad := range def.AnalysisDimensions {
+		addDefined(ad.Name)
 	}
 
 	var propertyNames []string
 	if query == nil || len(query.AnalysisDimensions) == 0 {
-		propertyNames = ordered
+		propertyNames = defaultOrdered
 	} else {
 		seen := make(map[string]struct{})
 		for _, a := range query.AnalysisDimensions {

--- a/adp/bkn/ontology-query/server/logics/metric/metric_query_service.go
+++ b/adp/bkn/ontology-query/server/logics/metric/metric_query_service.go
@@ -429,18 +429,22 @@ func metricGroupByDimensions(def *interfaces.MetricDefinition, query *interfaces
 	if propMap == nil {
 		return nil, fmt.Errorf("propMap is required for group by dimension mapping")
 	}
+	timeProperty := ""
+	if def.TimeDimension != nil {
+		timeProperty = strings.TrimSpace(def.TimeDimension.Property)
+	}
 	defined := make(map[string]struct{})
 	var defaultOrdered []string
 	addDefined := func(s string) {
 		s = strings.TrimSpace(s)
-		if s == "" {
+		if s == "" || s == timeProperty {
 			return
 		}
 		defined[s] = struct{}{}
 	}
 	addDefault := func(s string) {
 		s = strings.TrimSpace(s)
-		if s == "" {
+		if s == "" || s == timeProperty {
 			return
 		}
 		if _, ok := defined[s]; ok {

--- a/adp/bkn/ontology-query/server/logics/metric/metric_query_service_test.go
+++ b/adp/bkn/ontology-query/server/logics/metric/metric_query_service_test.go
@@ -24,6 +24,88 @@ import (
 	omock "ontology-query/interfaces/mock"
 )
 
+func Test_metricGroupByDimensions_analysisDimensions(t *testing.T) {
+	Convey("metricGroupByDimensions respects analysis_dimensions\n", t, func() {
+		propMap := map[string]*cond.DataProperty{
+			"warehouse_id": {Name: "warehouse_id", MappedField: cond.Field{Name: "warehouse_id_res"}},
+			"item_code":    {Name: "item_code", MappedField: cond.Field{Name: "item_code_res"}},
+			"region":       {Name: "region", MappedField: cond.Field{Name: "region_res"}},
+		}
+		def := &interfaces.MetricDefinition{
+			CalculationFormula: &interfaces.MetricCalculationFormula{
+				GroupBy: []interfaces.MetricGroupBy{{Property: "region"}},
+			},
+			AnalysisDimensions: []interfaces.MetricAnalysisDimension{
+				{Name: "warehouse_id"},
+				{Name: "item_code"},
+			},
+		}
+
+		Convey("Without request analysis_dimensions uses calculation_formula.group_by only\n", func() {
+			dims, err := metricGroupByDimensions(def, &interfaces.MetricQueryRequest{}, propMap)
+			So(err, ShouldBeNil)
+			So(len(dims), ShouldEqual, 1)
+			So(dims[0].PropertyName, ShouldEqual, "region")
+			So(dims[0].ResourceFieldName, ShouldEqual, "region_res")
+		})
+
+		Convey("Request analysis_dimensions intersects with definition and preserves query order\n", func() {
+			dims, err := metricGroupByDimensions(def, &interfaces.MetricQueryRequest{
+				AnalysisDimensions: []string{"item_code", "warehouse_id", "unknown"},
+			}, propMap)
+			So(err, ShouldBeNil)
+			So(len(dims), ShouldEqual, 2)
+			So(dims[0].PropertyName, ShouldEqual, "item_code")
+			So(dims[0].ResourceFieldName, ShouldEqual, "item_code_res")
+			So(dims[1].PropertyName, ShouldEqual, "warehouse_id")
+			So(dims[1].ResourceFieldName, ShouldEqual, "warehouse_id_res")
+		})
+	})
+}
+
+func Test_metricQueryService_buildResourceDataQueryParams_analysisDimensions(t *testing.T) {
+	Convey("buildResourceDataQueryParams pushes analysis_dimensions to group_by\n", t, func() {
+		ctx := context.Background()
+		svc := &metricQueryService{appSetting: &common.AppSetting{}}
+		def := &interfaces.MetricDefinition{
+			TimeDimension: &interfaces.MetricTimeDimension{Property: "evt_time"},
+			CalculationFormula: &interfaces.MetricCalculationFormula{
+				Aggregation: interfaces.MetricAggregation{Property: "amount", Aggr: "sum"},
+			},
+			AnalysisDimensions: []interfaces.MetricAnalysisDimension{
+				{Name: "warehouse_id"},
+				{Name: "item_code"},
+			},
+		}
+		ot := interfaces.ObjectType{
+			ObjectTypeWithKeyField: interfaces.ObjectTypeWithKeyField{
+				DataProperties: []cond.DataProperty{
+					{Name: "amount", Type: dtype.DATATYPE_DOUBLE, MappedField: cond.Field{Name: "amount_res"}},
+					{Name: "evt_time", Type: dtype.DATATYPE_DATETIME, MappedField: cond.Field{Name: "evt_time_res"}},
+					{Name: "warehouse_id", Type: dtype.DATATYPE_STRING, MappedField: cond.Field{Name: "warehouse_id_res"}},
+					{Name: "item_code", Type: dtype.DATATYPE_STRING, MappedField: cond.Field{Name: "item_code_res"}},
+				},
+			},
+		}
+		instant := false
+		step := "year"
+		start := int64(1_000)
+		end := int64(2_000)
+
+		params, trend, err := svc.buildResourceDataQueryParams(ctx, def, &interfaces.MetricQueryRequest{
+			AnalysisDimensions: []string{"warehouse_id", "item_code"},
+			Time:               &interfaces.MetricTimeWindow{Start: &start, End: &end, Instant: &instant, Step: &step},
+		}, ot)
+		So(err, ShouldBeNil)
+		So(trend, ShouldNotBeNil)
+		So(len(params.GroupBy), ShouldEqual, 3)
+		So(params.GroupBy[0]["property"], ShouldEqual, "warehouse_id_res")
+		So(params.GroupBy[1]["property"], ShouldEqual, "item_code_res")
+		So(params.GroupBy[2]["property"], ShouldEqual, "evt_time_res")
+		So(params.GroupBy[2]["calendar_interval"], ShouldEqual, "year")
+	})
+}
+
 func Test_metricQueryService_QueryMetricData(t *testing.T) {
 	Convey("QueryMetricData\n", t, func() {
 		ctx := context.Background()

--- a/adp/bkn/ontology-query/server/logics/metric/metric_query_service_test.go
+++ b/adp/bkn/ontology-query/server/logics/metric/metric_query_service_test.go
@@ -31,6 +31,7 @@ func Test_metricGroupByDimensions_analysisDimensions(t *testing.T) {
 			"item_code":    {Name: "item_code", MappedField: cond.Field{Name: "item_code_res"}},
 			"region":       {Name: "region", MappedField: cond.Field{Name: "region_res"}},
 			"evt_time":     {Name: "evt_time", MappedField: cond.Field{Name: "evt_time_res"}},
+			"time_alias":   {Name: "time_alias", MappedField: cond.Field{Name: "evt_time_res"}},
 		}
 		def := &interfaces.MetricDefinition{
 			TimeDimension: &interfaces.MetricTimeDimension{Property: "evt_time"},
@@ -41,11 +42,12 @@ func Test_metricGroupByDimensions_analysisDimensions(t *testing.T) {
 				{Name: "warehouse_id"},
 				{Name: "item_code"},
 				{Name: "evt_time"},
+				{Name: "time_alias"},
 			},
 		}
 
 		Convey("Without request analysis_dimensions uses calculation_formula.group_by only\n", func() {
-			dims, err := metricGroupByDimensions(def, &interfaces.MetricQueryRequest{}, propMap)
+			dims, err := metricGroupByDimensions(def, &interfaces.MetricQueryRequest{}, propMap, "")
 			So(err, ShouldBeNil)
 			So(len(dims), ShouldEqual, 1)
 			So(dims[0].PropertyName, ShouldEqual, "region")
@@ -55,7 +57,7 @@ func Test_metricGroupByDimensions_analysisDimensions(t *testing.T) {
 		Convey("Request analysis_dimensions intersects with definition and preserves query order\n", func() {
 			dims, err := metricGroupByDimensions(def, &interfaces.MetricQueryRequest{
 				AnalysisDimensions: []string{"item_code", "warehouse_id", "unknown"},
-			}, propMap)
+			}, propMap, "")
 			So(err, ShouldBeNil)
 			So(len(dims), ShouldEqual, 2)
 			So(dims[0].PropertyName, ShouldEqual, "item_code")
@@ -64,14 +66,36 @@ func Test_metricGroupByDimensions_analysisDimensions(t *testing.T) {
 			So(dims[1].ResourceFieldName, ShouldEqual, "warehouse_id_res")
 		})
 
-		Convey("Request time_dimension property is ignored even when listed as analysis dimension\n", func() {
+		Convey("Non-trend request keeps time_dimension property as an analysis dimension\n", func() {
 			dims, err := metricGroupByDimensions(def, &interfaces.MetricQueryRequest{
 				AnalysisDimensions: []string{"evt_time", "warehouse_id"},
-			}, propMap)
+			}, propMap, "")
+			So(err, ShouldBeNil)
+			So(len(dims), ShouldEqual, 2)
+			So(dims[0].PropertyName, ShouldEqual, "evt_time")
+			So(dims[0].ResourceFieldName, ShouldEqual, "evt_time_res")
+			So(dims[1].PropertyName, ShouldEqual, "warehouse_id")
+			So(dims[1].ResourceFieldName, ShouldEqual, "warehouse_id_res")
+		})
+
+		Convey("Trend request excludes aliases mapped to the time resource field\n", func() {
+			dims, err := metricGroupByDimensions(def, &interfaces.MetricQueryRequest{
+				AnalysisDimensions: []string{"time_alias", "warehouse_id"},
+			}, propMap, "evt_time_res")
 			So(err, ShouldBeNil)
 			So(len(dims), ShouldEqual, 1)
 			So(dims[0].PropertyName, ShouldEqual, "warehouse_id")
 			So(dims[0].ResourceFieldName, ShouldEqual, "warehouse_id_res")
+		})
+
+		Convey("Non-trend request keeps aliases mapped to the time resource field\n", func() {
+			dims, err := metricGroupByDimensions(def, &interfaces.MetricQueryRequest{
+				AnalysisDimensions: []string{"time_alias"},
+			}, propMap, "")
+			So(err, ShouldBeNil)
+			So(len(dims), ShouldEqual, 1)
+			So(dims[0].PropertyName, ShouldEqual, "time_alias")
+			So(dims[0].ResourceFieldName, ShouldEqual, "evt_time_res")
 		})
 	})
 }
@@ -84,10 +108,13 @@ func Test_metricQueryService_buildResourceDataQueryParams_analysisDimensions(t *
 			TimeDimension: &interfaces.MetricTimeDimension{Property: "evt_time"},
 			CalculationFormula: &interfaces.MetricCalculationFormula{
 				Aggregation: interfaces.MetricAggregation{Property: "amount", Aggr: "sum"},
+				GroupBy:     []interfaces.MetricGroupBy{{Property: "evt_time"}},
 			},
 			AnalysisDimensions: []interfaces.MetricAnalysisDimension{
 				{Name: "warehouse_id"},
 				{Name: "item_code"},
+				{Name: "evt_time"},
+				{Name: "time_alias"},
 			},
 		}
 		ot := interfaces.ObjectType{
@@ -95,6 +122,7 @@ func Test_metricQueryService_buildResourceDataQueryParams_analysisDimensions(t *
 				DataProperties: []cond.DataProperty{
 					{Name: "amount", Type: dtype.DATATYPE_DOUBLE, MappedField: cond.Field{Name: "amount_res"}},
 					{Name: "evt_time", Type: dtype.DATATYPE_DATETIME, MappedField: cond.Field{Name: "evt_time_res"}},
+					{Name: "time_alias", Type: dtype.DATATYPE_DATETIME, MappedField: cond.Field{Name: "evt_time_res"}},
 					{Name: "warehouse_id", Type: dtype.DATATYPE_STRING, MappedField: cond.Field{Name: "warehouse_id_res"}},
 					{Name: "item_code", Type: dtype.DATATYPE_STRING, MappedField: cond.Field{Name: "item_code_res"}},
 				},
@@ -106,6 +134,15 @@ func Test_metricQueryService_buildResourceDataQueryParams_analysisDimensions(t *
 		end := int64(2_000)
 
 		params, trend, err := svc.buildResourceDataQueryParams(ctx, def, &interfaces.MetricQueryRequest{
+			Time: &interfaces.MetricTimeWindow{Start: &start, End: &end, Instant: &instant, Step: &step},
+		}, ot)
+		So(err, ShouldBeNil)
+		So(trend, ShouldNotBeNil)
+		So(len(params.GroupBy), ShouldEqual, 1)
+		So(params.GroupBy[0]["property"], ShouldEqual, "evt_time_res")
+		So(params.GroupBy[0]["calendar_interval"], ShouldEqual, "year")
+
+		params, trend, err = svc.buildResourceDataQueryParams(ctx, def, &interfaces.MetricQueryRequest{
 			AnalysisDimensions: []string{"warehouse_id", "item_code"},
 			Time:               &interfaces.MetricTimeWindow{Start: &start, End: &end, Instant: &instant, Step: &step},
 		}, ot)
@@ -118,7 +155,7 @@ func Test_metricQueryService_buildResourceDataQueryParams_analysisDimensions(t *
 		So(params.GroupBy[2]["calendar_interval"], ShouldEqual, "year")
 
 		params, trend, err = svc.buildResourceDataQueryParams(ctx, def, &interfaces.MetricQueryRequest{
-			AnalysisDimensions: []string{"warehouse_id", "evt_time"},
+			AnalysisDimensions: []string{"warehouse_id", "time_alias"},
 			Time:               &interfaces.MetricTimeWindow{Start: &start, End: &end, Instant: &instant, Step: &step},
 		}, ot)
 		So(err, ShouldBeNil)
@@ -127,6 +164,28 @@ func Test_metricQueryService_buildResourceDataQueryParams_analysisDimensions(t *
 		So(params.GroupBy[0]["property"], ShouldEqual, "warehouse_id_res")
 		So(params.GroupBy[1]["property"], ShouldEqual, "evt_time_res")
 		So(params.GroupBy[1]["calendar_interval"], ShouldEqual, "year")
+
+		instant = true
+		params, trend, err = svc.buildResourceDataQueryParams(ctx, def, &interfaces.MetricQueryRequest{
+			Time: &interfaces.MetricTimeWindow{Start: &start, End: &end, Instant: &instant},
+		}, ot)
+		So(err, ShouldBeNil)
+		So(trend, ShouldBeNil)
+		So(len(params.GroupBy), ShouldEqual, 1)
+		So(params.GroupBy[0]["property"], ShouldEqual, "evt_time_res")
+		_, hasCalendarInterval := params.GroupBy[0]["calendar_interval"]
+		So(hasCalendarInterval, ShouldBeFalse)
+
+		params, trend, err = svc.buildResourceDataQueryParams(ctx, def, &interfaces.MetricQueryRequest{
+			AnalysisDimensions: []string{"time_alias"},
+			Time:               &interfaces.MetricTimeWindow{Start: &start, End: &end, Instant: &instant},
+		}, ot)
+		So(err, ShouldBeNil)
+		So(trend, ShouldBeNil)
+		So(len(params.GroupBy), ShouldEqual, 1)
+		So(params.GroupBy[0]["property"], ShouldEqual, "evt_time_res")
+		_, hasCalendarInterval = params.GroupBy[0]["calendar_interval"]
+		So(hasCalendarInterval, ShouldBeFalse)
 	})
 }
 
@@ -137,16 +196,17 @@ func Test_convert2TimeSeries_excludesTrendTimeFromDimensions(t *testing.T) {
 			TimeDimension: &interfaces.MetricTimeDimension{Property: "evt_time"},
 			AnalysisDimensions: []interfaces.MetricAnalysisDimension{
 				{Name: "warehouse_id"},
-				{Name: "evt_time"},
+				{Name: "time_alias"},
 			},
 		}
 		propMap := map[string]*cond.DataProperty{
 			"warehouse_id": {Name: "warehouse_id", MappedField: cond.Field{Name: "warehouse_id_res"}},
 			"evt_time":     {Name: "evt_time", MappedField: cond.Field{Name: "evt_time_res"}},
+			"time_alias":   {Name: "time_alias", MappedField: cond.Field{Name: "evt_time_res"}},
 		}
 		step := "day"
 		query := &interfaces.MetricQueryRequest{
-			AnalysisDimensions: []string{"warehouse_id", "evt_time"},
+			AnalysisDimensions: []string{"warehouse_id", "time_alias"},
 			Time:               &interfaces.MetricTimeWindow{Step: &step},
 		}
 		trend := &trendMeta{

--- a/adp/bkn/ontology-query/server/logics/metric/metric_query_service_test.go
+++ b/adp/bkn/ontology-query/server/logics/metric/metric_query_service_test.go
@@ -30,14 +30,17 @@ func Test_metricGroupByDimensions_analysisDimensions(t *testing.T) {
 			"warehouse_id": {Name: "warehouse_id", MappedField: cond.Field{Name: "warehouse_id_res"}},
 			"item_code":    {Name: "item_code", MappedField: cond.Field{Name: "item_code_res"}},
 			"region":       {Name: "region", MappedField: cond.Field{Name: "region_res"}},
+			"evt_time":     {Name: "evt_time", MappedField: cond.Field{Name: "evt_time_res"}},
 		}
 		def := &interfaces.MetricDefinition{
+			TimeDimension: &interfaces.MetricTimeDimension{Property: "evt_time"},
 			CalculationFormula: &interfaces.MetricCalculationFormula{
 				GroupBy: []interfaces.MetricGroupBy{{Property: "region"}},
 			},
 			AnalysisDimensions: []interfaces.MetricAnalysisDimension{
 				{Name: "warehouse_id"},
 				{Name: "item_code"},
+				{Name: "evt_time"},
 			},
 		}
 
@@ -59,6 +62,16 @@ func Test_metricGroupByDimensions_analysisDimensions(t *testing.T) {
 			So(dims[0].ResourceFieldName, ShouldEqual, "item_code_res")
 			So(dims[1].PropertyName, ShouldEqual, "warehouse_id")
 			So(dims[1].ResourceFieldName, ShouldEqual, "warehouse_id_res")
+		})
+
+		Convey("Request time_dimension property is ignored even when listed as analysis dimension\n", func() {
+			dims, err := metricGroupByDimensions(def, &interfaces.MetricQueryRequest{
+				AnalysisDimensions: []string{"evt_time", "warehouse_id"},
+			}, propMap)
+			So(err, ShouldBeNil)
+			So(len(dims), ShouldEqual, 1)
+			So(dims[0].PropertyName, ShouldEqual, "warehouse_id")
+			So(dims[0].ResourceFieldName, ShouldEqual, "warehouse_id_res")
 		})
 	})
 }
@@ -103,6 +116,59 @@ func Test_metricQueryService_buildResourceDataQueryParams_analysisDimensions(t *
 		So(params.GroupBy[1]["property"], ShouldEqual, "item_code_res")
 		So(params.GroupBy[2]["property"], ShouldEqual, "evt_time_res")
 		So(params.GroupBy[2]["calendar_interval"], ShouldEqual, "year")
+
+		params, trend, err = svc.buildResourceDataQueryParams(ctx, def, &interfaces.MetricQueryRequest{
+			AnalysisDimensions: []string{"warehouse_id", "evt_time"},
+			Time:               &interfaces.MetricTimeWindow{Start: &start, End: &end, Instant: &instant, Step: &step},
+		}, ot)
+		So(err, ShouldBeNil)
+		So(trend, ShouldNotBeNil)
+		So(len(params.GroupBy), ShouldEqual, 2)
+		So(params.GroupBy[0]["property"], ShouldEqual, "warehouse_id_res")
+		So(params.GroupBy[1]["property"], ShouldEqual, "evt_time_res")
+		So(params.GroupBy[1]["calendar_interval"], ShouldEqual, "year")
+	})
+}
+
+func Test_convert2TimeSeries_excludesTrendTimeFromDimensions(t *testing.T) {
+	Convey("convert2TimeSeries excludes trend time_dimension from analysis dimension series key\n", t, func() {
+		ctx := context.Background()
+		def := interfaces.MetricDefinition{
+			TimeDimension: &interfaces.MetricTimeDimension{Property: "evt_time"},
+			AnalysisDimensions: []interfaces.MetricAnalysisDimension{
+				{Name: "warehouse_id"},
+				{Name: "evt_time"},
+			},
+		}
+		propMap := map[string]*cond.DataProperty{
+			"warehouse_id": {Name: "warehouse_id", MappedField: cond.Field{Name: "warehouse_id_res"}},
+			"evt_time":     {Name: "evt_time", MappedField: cond.Field{Name: "evt_time_res"}},
+		}
+		step := "day"
+		query := &interfaces.MetricQueryRequest{
+			AnalysisDimensions: []string{"warehouse_id", "evt_time"},
+			Time:               &interfaces.MetricTimeWindow{Step: &step},
+		}
+		trend := &trendMeta{
+			step:         step,
+			timeProperty: "evt_time",
+			timeResField: "evt_time_res",
+		}
+		datas := &interfaces.DatasetQueryResponse{
+			Entries: []map[string]any{
+				{"warehouse_id_res": "wh-1", "evt_time_res": int64(1_700_000_000_000), "__value": 1.0},
+				{"warehouse_id_res": "wh-1", "evt_time_res": int64(1_700_086_400_000), "__value": 2.0},
+			},
+		}
+
+		series, err := convert2TimeSeries(ctx, def, datas, query, trend, propMap, false)
+		So(err, ShouldBeNil)
+		So(len(series), ShouldEqual, 1)
+		for _, item := range series {
+			So(item.Labels, ShouldResemble, map[string]string{"warehouse_id": "wh-1"})
+			So(len(item.Times), ShouldEqual, 2)
+			So(item.Values, ShouldResemble, []any{1.0, 2.0})
+		}
 	})
 }
 


### PR DESCRIPTION
## What Changed

- [x] ontology-query metric query: push request `analysis_dimensions` to Vega `group_by`
- [x] `metricGroupByDimensions`: include metric definition `analysis_dimensions` in allowed dimension set
- [x] Unit tests for group_by push-down and dimension intersection

---

## Why

- Related Issue: Closes #436
- Background: Metric data queries accepted `analysis_dimensions` in the API contract but never pushed them to Vega `group_by`, so drill-down results were identical to queries without dimensions.

---

## How

- `buildResourceDataQueryParams` now reuses `metricGroupByDimensions` when assembling Vega `group_by` (plus existing trend calendar bucket).
- `metricGroupByDimensions` registers definition-side `analysis_dimensions` in `defined`; when the request omits them, behavior stays limited to `calculation_formula.group_by` + time bucket.
- Breaking changes: none.

---

## Testing

- [x] Unit tests passed locally
- [ ] Integration tests passed locally
- [ ] Verified in test environment

Test notes:
- `I18N_MODE_UT=true go test ./logics/metric -run Test_metricGroupByDimensions_analysisDimensions|Test_metricQueryService_buildResourceDataQueryParams_analysisDimensions`

---

## Risk & Rollback

- Potential risks: queries that previously ignored request dimensions may now return multi-row/multi-series results when valid dimensions are supplied.
- Rollback plan: revert this PR; no schema or config migration required.

---

## Additional Notes

- Companion Studio PR will expose analysis dimension selection in the metric query UI once this backend fix is deployed.

Made with [Cursor](https://cursor.com)