### PR TITLE
feat(sandbox): 数据模板预装常用依赖 + bwrap arm64 兼容 + workspace 前缀隔离

### DIFF
--- a/.github/workflows/release-infra-sandbox.yml
+++ b/.github/workflows/release-infra-sandbox.yml
@@ -96,6 +96,7 @@ jobs:
       publish: ${{ github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && inputs.publish) }}
       build-args: |
         BASE_IMAGE=ghcr.io/${{ github.repository_owner }}/sandbox-python-executor-base:v1
+        PREINSTALL_COMMON=true
 
   build-template-multi-language:
     needs: [test, build-multi-language-base]

--- a/infra/sandbox/images/build.sh
+++ b/infra/sandbox/images/build.sh
@@ -23,6 +23,10 @@ PYTHON_IMAGE_MIRROR="${PYTHON_IMAGE_MIRROR:-docker.m.daocloud.io/library/python:
 GO_DOWNLOAD_BASE="${GO_DOWNLOAD_BASE:-}"
 GO_DOWNLOAD_MIRROR="${GO_DOWNLOAD_MIRROR:-https://mirrors.ustc.edu.cn/golang}"
 TEMPLATES="${TEMPLATES:-python-basic multi-language}"
+# Space-separated templates that get the common data-science stack pre-installed
+# into /opt/sandbox-common (see templates/executor/common-requirements.txt).
+# Others stay lean. multi-language is intentionally excluded (not Python-data focused).
+PREINSTALL_COMMON_TEMPLATES="${PREINSTALL_COMMON_TEMPLATES:-python-basic}"
 TEMPLATE_IMAGE_TAG="${TEMPLATE_IMAGE_TAG:-${PROJECT_VERSION}}"
 BUILD_PYTHON_BASE="${BUILD_PYTHON_BASE:-false}"
 BUILD_MULTI_BASE="${BUILD_MULTI_BASE:-false}"
@@ -296,12 +300,18 @@ build_templates() {
         base_image="$(get_template_base_image "$template")"
         template_description="$(get_template_description "$template")"
 
+        local preinstall_common="false"
+        case " ${PREINSTALL_COMMON_TEMPLATES} " in
+            *" ${template} "*) preinstall_common="true" ;;
+        esac
+
         docker build \
             -f "$dockerfile" \
             --build-arg "BASE_IMAGE=${base_image}" \
             --build-arg "TEMPLATE_NAME=${template}" \
             --build-arg "TEMPLATE_DESCRIPTION=${template_description}" \
             --build-arg "TEMPLATE_VERSION=${image_tag}" \
+            --build-arg "PREINSTALL_COMMON=${preinstall_common}" \
             $build_args \
             -t "${image_name}:${image_tag}" \
             -t "${image_name}:latest" \

--- a/infra/sandbox/images/templates/executor/Dockerfile
+++ b/infra/sandbox/images/templates/executor/Dockerfile
@@ -51,11 +51,32 @@ COPY runtime/executor/ ./executor/
 # dependency sync.
 COPY runtime/sandbox_sdk/ /opt/sandbox-sdk/sandbox_sdk/
 
-RUN chown -R sandbox:sandbox /app /workspace /opt/sandbox-venv /opt/sandbox-sdk
+# Common packages baked into a dedicated dir, opt-in per template via
+# PREINSTALL_COMMON (build.sh / CI enable it only for data-oriented templates
+# like python-basic; multi-language stays lean). Like the SDK dir this survives
+# dependency syncs (which wipe /opt/sandbox-venv), and it sits after the
+# dependency dir on PYTHONPATH so a function's own declared dependencies still
+# override these baseline versions. The dir is always created so bwrap can bind
+# it even when the template opts out.
+ARG USE_MIRROR=false
+ARG PIP_MIRROR=mirrors.ustc.edu.cn
+ARG PREINSTALL_COMMON=false
+COPY images/templates/executor/common-requirements.txt /tmp/common-requirements.txt
+RUN mkdir -p /opt/sandbox-common && \
+    if [ "$PREINSTALL_COMMON" = "true" ]; then \
+      if [ "$USE_MIRROR" = "true" ]; then \
+        pip install --no-cache-dir -i "https://$PIP_MIRROR/pypi/simple" --target /opt/sandbox-common -r /tmp/common-requirements.txt; \
+      else \
+        pip install --no-cache-dir --target /opt/sandbox-common -r /tmp/common-requirements.txt; \
+      fi; \
+    fi && \
+    rm -f /tmp/common-requirements.txt
+
+RUN chown -R sandbox:sandbox /app /workspace /opt/sandbox-venv /opt/sandbox-sdk /opt/sandbox-common
 
 USER sandbox
 
-ENV PYTHONPATH=/app/.venv/lib/python3.11/site-packages:/app:/opt/sandbox-sdk
+ENV PYTHONPATH=/app/.venv/lib/python3.11/site-packages:/app:/opt/sandbox-sdk:/opt/sandbox-common
 ENV PATH="/app/.venv/bin:${PATH}"
 
 EXPOSE 8080

--- a/infra/sandbox/images/templates/executor/common-requirements.txt
+++ b/infra/sandbox/images/templates/executor/common-requirements.txt
@@ -1,0 +1,36 @@
+# Common packages pre-installed into the user-function venv (/opt/sandbox-venv).
+#
+# Purpose: most sandbox functions need a small, stable data/IO stack. Baking it
+# into the template image avoids per-session pip installs and works in no-egress
+# deployments (runtime pip cannot reach the internet there).
+#
+# These are DIRECT deps only. The image build runs `pip install --target
+# /opt/sandbox-venv -r` on this file; the resolved transitive set is what ends up
+# in the image. Per-session dependency installs (also --target /opt/sandbox-venv)
+# can add packages or override versions on top of this baseline.
+#
+# Pins target Python 3.11 (the base image runtime) and the stable numpy 1.x
+# stack, chosen for maximum compatibility with existing functions (numpy 2.x
+# introduces breaking changes and, at 2.5+, drops Python 3.11). Bump deliberately.
+
+# --- Core: data science (covers most functions) ---
+numpy==1.26.4
+pandas==2.2.3
+scipy==1.13.1
+scikit-learn==1.5.2
+statsmodels==0.14.4
+
+# --- Common: high-frequency, lightweight helpers ---
+python-dateutil==2.9.0.post0
+pytz==2024.2
+pydantic==2.9.2
+PyYAML==6.0.2
+jsonschema==4.23.0
+requests==2.32.3
+httpx==0.27.2
+
+# --- Optional: enable per scenario (uncomment to bake in) ---
+# openpyxl==3.1.5          # Excel read/write
+# lxml==5.3.0              # XML/HTML parsing
+# beautifulsoup4==4.12.3   # HTML scraping
+# tiktoken==0.8.0          # LLM token counting

--- a/infra/sandbox/images/templates/executor/common-requirements.txt
+++ b/infra/sandbox/images/templates/executor/common-requirements.txt
@@ -1,13 +1,15 @@
-# Common packages pre-installed into the user-function venv (/opt/sandbox-venv).
+# Common packages baked into the template image's baseline dir (/opt/sandbox-common).
 #
 # Purpose: most sandbox functions need a small, stable data/IO stack. Baking it
 # into the template image avoids per-session pip installs and works in no-egress
 # deployments (runtime pip cannot reach the internet there).
 #
 # These are DIRECT deps only. The image build runs `pip install --target
-# /opt/sandbox-venv -r` on this file; the resolved transitive set is what ends up
-# in the image. Per-session dependency installs (also --target /opt/sandbox-venv)
-# can add packages or override versions on top of this baseline.
+# /opt/sandbox-common -r` on this file; the resolved transitive set is what ends
+# up in the image. /opt/sandbox-common survives dependency syncs (unlike
+# /opt/sandbox-venv, which is wiped each sync) and sits after it on PYTHONPATH,
+# so per-session dependency installs (--target /opt/sandbox-venv) still override
+# these baseline versions.
 #
 # Pins target Python 3.11 (the base image runtime) and the stable numpy 1.x
 # stack, chosen for maximum compatibility with existing functions (numpy 2.x

--- a/infra/sandbox/runtime/executor/infrastructure/config/config.py
+++ b/infra/sandbox/runtime/executor/infrastructure/config/config.py
@@ -42,6 +42,15 @@ class Settings(BaseModel):
             "directory, which is emptied before every dependency sync."
         ),
     )
+    common_install_path: str = Field(
+        default="/opt/sandbox-common",
+        description=(
+            "Directory holding common packages baked into the image (opt-in per "
+            "template). Like the SDK dir it survives dependency syncs; placed "
+            "after the dependency dir on PYTHONPATH so a function's own declared "
+            "dependencies still override these baseline versions."
+        ),
+    )
     pip_cache_path: str = Field(
         default="/tmp/pip-cache",
         description="Cache directory for pip install operations",

--- a/infra/sandbox/runtime/executor/infrastructure/isolation/bwrap.py
+++ b/infra/sandbox/runtime/executor/infrastructure/isolation/bwrap.py
@@ -102,6 +102,7 @@ class BubblewrapRunner:
         """
         dependency_path = settings.dependency_install_path
         sdk_path = settings.sdk_install_path
+        common_path = settings.common_install_path
         return [
             "bwrap",
             # Filesystem isolation
@@ -115,6 +116,9 @@ class BubblewrapRunner:
             # sandbox_sdk lives outside the dependency directory, which is wiped
             # before every dependency sync, and outside /app, which is not mounted.
             "--ro-bind", sdk_path, sdk_path,
+            # Common baked-in packages (opt-in per template). Empty dir when the
+            # template opted out — harmless on both the mount and PYTHONPATH.
+            "--ro-bind", common_path, common_path,
             # Workspace (writable)
             "--bind", str(self.workspace_path), "/workspace",
             "--chdir", container_working_directory,
@@ -136,7 +140,7 @@ class BubblewrapRunner:
             "--setenv", "TMPDIR", "/tmp",
             # --clearenv drops the image PYTHONPATH, so the interpreter would find
             # neither the session dependencies nor the SDK. Set it explicitly.
-            "--setenv", "PYTHONPATH", f"{sdk_path}:{dependency_path}",
+            "--setenv", "PYTHONPATH", f"{sdk_path}:{dependency_path}:{common_path}",
             # Security (Note: --cap-drop and --no-new-privs not available in bwrap 0.11.0)
             # These are handled by container-level security (non-privileged user, namespaces)
         ]
@@ -421,7 +425,8 @@ console.log('===SANDBOX_RESULT===' + JSON.stringify(result) + '===SANDBOX_RESULT
     def _build_pythonpath(self, existing_pythonpath: str | None) -> str:
         dependency_path = settings.dependency_install_path
         sdk_path = settings.sdk_install_path
-        parts = [sdk_path, dependency_path]
+        common_path = settings.common_install_path
+        parts = [sdk_path, dependency_path, common_path]
         if existing_pythonpath:
             parts.append(existing_pythonpath)
         return ":".join(parts)

--- a/infra/sandbox/runtime/executor/infrastructure/isolation/bwrap.py
+++ b/infra/sandbox/runtime/executor/infrastructure/isolation/bwrap.py
@@ -107,10 +107,14 @@ class BubblewrapRunner:
             "bwrap",
             # Filesystem isolation
             "--ro-bind", "/usr", "/usr",
-            "--ro-bind", "/lib", "/lib",
-            "--ro-bind", "/lib64", "/lib64",
-            "--ro-bind", "/bin", "/bin",
-            "--ro-bind", "/sbin", "/sbin",
+            # /lib, /lib64, /bin, /sbin are usrmerge symlinks or absent on some
+            # base images (arm64 python:3.11-slim has no /lib64; /lib etc. are
+            # symlinks into /usr). Use --ro-bind-try so bwrap skips a missing
+            # source instead of aborting the whole sandbox.
+            "--ro-bind-try", "/lib", "/lib",
+            "--ro-bind-try", "/lib64", "/lib64",
+            "--ro-bind-try", "/bin", "/bin",
+            "--ro-bind-try", "/sbin", "/sbin",
             # Session-installed third-party dependencies remain read-only during execution.
             "--ro-bind", dependency_path, dependency_path,
             # sandbox_sdk lives outside the dependency directory, which is wiped

--- a/infra/sandbox/runtime/executor/infrastructure/isolation/macseatbelt.py
+++ b/infra/sandbox/runtime/executor/infrastructure/isolation/macseatbelt.py
@@ -403,7 +403,8 @@ console.log('===SANDBOX_RESULT===' + JSON.stringify(result) + '===SANDBOX_RESULT
     def _build_pythonpath(self, existing_pythonpath: str | None) -> str:
         dependency_path = settings.dependency_install_path
         sdk_path = settings.sdk_install_path
-        parts = [sdk_path, dependency_path]
+        common_path = settings.common_install_path
+        parts = [sdk_path, dependency_path, common_path]
         if existing_pythonpath:
             parts.append(existing_pythonpath)
         return ":".join(parts)

--- a/infra/sandbox/runtime/executor/infrastructure/isolation/subprocess.py
+++ b/infra/sandbox/runtime/executor/infrastructure/isolation/subprocess.py
@@ -345,7 +345,8 @@ console.log(JSON.stringify(result));
     def _build_pythonpath(self, existing_pythonpath: str | None) -> str:
         dependency_path = settings.dependency_install_path
         sdk_path = settings.sdk_install_path
-        parts = [sdk_path, dependency_path]
+        common_path = settings.common_install_path
+        parts = [sdk_path, dependency_path, common_path]
         if existing_pythonpath:
             parts.append(existing_pythonpath)
         return ":".join(parts)

--- a/infra/sandbox/runtime/executor/tests/unit/isolation/test_bwrap.py
+++ b/infra/sandbox/runtime/executor/tests/unit/isolation/test_bwrap.py
@@ -133,6 +133,25 @@ class TestBubblewrapRunnerInit:
 
         assert (settings.dependency_install_path, settings.dependency_install_path) in ro_bind_pairs
 
+    def test_base_args_bind_common_dir_after_dependency_on_pythonpath(self):
+        """Common baked dir is bound and ordered after the dependency dir so a
+        function's declared dependencies still override the baked baseline."""
+        from pathlib import Path
+        from executor.infrastructure.isolation.bwrap import BubblewrapRunner
+
+        runner = BubblewrapRunner(Path("/tmp/workspace"))
+        args = runner._base_args
+
+        ro_bind_indices = [index for index, value in enumerate(args) if value == "--ro-bind"]
+        ro_bind_pairs = [(args[index + 1], args[index + 2]) for index in ro_bind_indices]
+        assert (settings.common_install_path, settings.common_install_path) in ro_bind_pairs
+
+        pythonpath = args[args.index("PYTHONPATH") + 1]
+        entries = pythonpath.split(":")
+        assert entries.index(settings.dependency_install_path) < entries.index(
+            settings.common_install_path
+        )
+
     def test_inject_env_args_adds_setenv_before_separator(self):
         """Test environment variables are injected into bwrap command."""
         from pathlib import Path

--- a/infra/sandbox/sandbox_control_plane/src/application/commands/create_session.py
+++ b/infra/sandbox/sandbox_control_plane/src/application/commands/create_session.py
@@ -5,6 +5,7 @@
 扩展支持依赖安装，按照 sandbox-design-v2.1.md 章节 5 设计。
 """
 
+import re
 from dataclasses import dataclass, field
 from typing import Dict, List, Optional
 
@@ -37,6 +38,15 @@ class CreateSessionCommand:
         """初始化后验证"""
         if self.timeout <= 0:
             raise ValueError("timeout must be positive")
+
+        # 安全关键：id / template_id 会经 workspace_path 落入以 root 运行的 s3fs
+        # 挂载脚本（k8s/docker scheduler）。严格白名单兜底，防 shell 命令注入与
+        # 前缀逃逸；request schema 已在入口校验，此处覆盖不经 schema 的调用路径。
+        for _name, _val in (("id", self.id), ("template_id", self.template_id)):
+            if _val is not None and not re.match(r"^[A-Za-z0-9_-]+$", _val):
+                raise ValueError(
+                    f"{_name} may only contain letters, digits, '_' and '-'"
+                )
 
         # 设置默认值
         if self.resource_limit is None:

--- a/infra/sandbox/sandbox_control_plane/src/infrastructure/container_scheduler/docker_scheduler.py
+++ b/infra/sandbox/sandbox_control_plane/src/infrastructure/container_scheduler/docker_scheduler.py
@@ -171,29 +171,31 @@ set -e
 echo "{s3_access_key}:{s3_secret_key}" > /tmp/.passwd-s3fs
 chmod 600 /tmp/.passwd-s3fs
 
-# 1. 创建 S3 挂载点（注意：不是直接挂到 /workspace）
-echo "Mounting S3 bucket {s3_bucket}..."
-mkdir -p /mnt/s3-root
-s3fs {s3_bucket} /mnt/s3-root \\
+# 1) 先以 root 临时挂整桶（不 allow_other），创建会话前缀后立即卸载。
+#    s3fs 无法挂载不存在的前缀，需先确保前缀对象存在。用户代码看不到此临时挂载点。
+mkdir -p /mnt/s3-init
+s3fs {s3_bucket} /mnt/s3-init \\
+    -o passwd_file=/tmp/.passwd-s3fs \\
+    -o url={s3_endpoint_url or "https://s3.amazonaws.com"} \\
+    {path_style_option}
+mkdir -p "/mnt/s3-init/{s3_prefix}"
+umount /mnt/s3-init || fusermount -u /mnt/s3-init
+rmdir /mnt/s3-init
+
+# 2) 只把本会话前缀挂到 /workspace，不挂整个 bucket。整桶挂载会让任意会话读写/删除
+#    其它会话的数据，是跨会话数据泄露/破坏面；按前缀挂载后代码只能触及自己的 /workspace。
+echo "Mounting S3 workspace {s3_bucket}:/{s3_prefix} to /workspace..."
+mkdir -p /workspace
+s3fs {s3_bucket}:/{s3_prefix} /workspace \\
     -o passwd_file=/tmp/.passwd-s3fs \\
     -o url={s3_endpoint_url or "https://s3.amazonaws.com"} \\
     {path_style_option} \\
     -o allow_other \\
     -o umask=000
 
-# 2. 创建 session workspace 目录（如果不存在）
-SESSION_PATH="/mnt/s3-root/{s3_prefix}"
-echo "Ensuring session workspace exists: $SESSION_PATH"
-mkdir -p "$SESSION_PATH"
-
-# 3. 确保 /workspace 挂载点存在
-mkdir -p /workspace
-
-# 4. 使用 bind mount 将 session 目录覆盖到 /workspace
-mount --bind "$SESSION_PATH" /workspace
-
-# 5. 验证挂载结果
-echo "Workspace bind mounted: $(ls -la /workspace)"
+# 3) 校验确实挂上了 s3fs，避免静默回落到本地目录。
+mount | grep -q "on /workspace type fuse" || {{ echo "s3fs failed to mount /workspace" >&2; exit 1; }}
+echo "Workspace mounted (scoped to {s3_prefix}): $(ls -la /workspace)"
 
 # ========== ✅ 新增：安装依赖 ==========
 {dependency_install_script}

--- a/infra/sandbox/sandbox_control_plane/src/infrastructure/container_scheduler/k8s_scheduler.py
+++ b/infra/sandbox/sandbox_control_plane/src/infrastructure/container_scheduler/k8s_scheduler.py
@@ -337,41 +337,40 @@ class K8sScheduler(IContainerScheduler):
             )
             bucket = s3_workspace["bucket"]
 
-            # S3 挂载脚本（使用 bucket 挂载 + bind mount 方案）
+            # S3 挂载脚本（先建会话前缀，再只挂本会话前缀到 /workspace，不暴露整个 bucket）
             s3_prefix = s3_workspace["prefix"].rstrip("/")
             mount_script = f"""#!/bin/sh
 set -e
 
-echo "📂 Mounting S3 bucket {bucket} to /mnt/s3-root (session: {session_id})..."
+echo "📂 Preparing S3 workspace {bucket}:/{s3_prefix} (session: {session_id})..."
 
-# 挂载整个 S3 bucket 到临时位置（uid=1000,gid=1000 让挂载点对 sandbox 用户可访问）
-mkdir -p /mnt/s3-root
-s3fs {bucket} /mnt/s3-root \\
+# 1) 先以 root 临时挂整桶（仅 root 可见、不 allow_other），创建会话前缀后立即卸载。
+#    s3fs 无法挂载不存在的前缀，需先确保前缀对象存在。executor 之后才以 sandbox
+#    用户启动，用户代码永远看不到这个临时挂载点。
+mkdir -p /mnt/s3-init
+s3fs {bucket} /mnt/s3-init \\
+    -o url={minio_url} \\
+    -o use_path_request_style \\
+    -o passwd_file=/etc/s3fs-passwd/s3fs-passwd
+mkdir -p "/mnt/s3-init/{s3_prefix}"
+umount /mnt/s3-init || fusermount -u /mnt/s3-init
+rmdir /mnt/s3-init
+
+# 2) 只把本会话前缀挂到 /workspace。不挂整个 bucket —— 整桶挂载（allow_other）会让
+#    任意会话读写/删除其它会话的数据，是跨会话数据泄露/破坏面；按前缀挂载后代码
+#    只能触及自己的 /workspace。
+s3fs {bucket}:/{s3_prefix} /workspace \\
     -o url={minio_url} \\
     -o use_path_request_style \\
     -o allow_other \\
     -o uid=1000 \\
     -o gid=1000 \\
-    -o passwd_file=/etc/s3fs-passwd/s3fs-passwd &
+    -o passwd_file=/etc/s3fs-passwd/s3fs-passwd
 
-S3FS_PID=$!
-echo "s3fs started with PID: $S3FS_PID"
+# 3) 校验确实挂上了 s3fs，避免静默回落到本地 emptyDir 导致数据不落 MinIO。
+mount | grep -q "on /workspace type fuse" || {{ echo "❌ s3fs failed to mount /workspace" >&2; exit 1; }}
 
-# 等待挂载完成
-sleep 2
-
-# 创建 session workspace 目录（使用完整 S3 前缀）
-SESSION_PATH="/mnt/s3-root/{s3_prefix}"
-echo "Ensuring session workspace exists: $SESSION_PATH"
-mkdir -p "$SESSION_PATH"
-
-# 使用 bind mount 将 S3 路径挂载到 /workspace（/workspace 是 emptyDir 挂载点）
-mount --bind "$SESSION_PATH" /workspace
-
-# 验证 bind mount
-echo "Workspace bind mounted: $(ls -la /workspace)"
-
-echo "✅ S3 bucket mounted and workspace linked successfully"
+echo "✅ Session workspace mounted (scoped to {s3_prefix})"
 ls -la /workspace/
 
 """

--- a/infra/sandbox/sandbox_control_plane/src/interfaces/rest/schemas/request.py
+++ b/infra/sandbox/sandbox_control_plane/src/interfaces/rest/schemas/request.py
@@ -112,6 +112,24 @@ class CreateSessionRequest(BaseModel):
         None, max_length=512, description="Python 软件包仓库地址，默认 https://pypi.org/simple/"
     )
 
+    @field_validator("id", "template_id")
+    @classmethod
+    def validate_identifier(cls, v: Optional[str]) -> Optional[str]:
+        """
+        会话 ID / 模板 ID 只允许字母、数字、下划线、连字符。
+
+        安全关键：id 会经 workspace_path 落入以 root 运行的 s3fs 挂载脚本
+        （k8s/docker scheduler）。放行 shell 元字符会造成 root 命令注入，放行
+        '/'、'..' 会造成前缀逃逸、绕过会话间隔离。此处严格白名单从入口拦住。
+        """
+        if v is None:
+            return v
+        if not re.match(r"^[A-Za-z0-9_-]+$", v):
+            raise ValueError(
+                "id and template_id may only contain letters, digits, '_' and '-'"
+            )
+        return v
+
     @field_validator("cpu")
     @classmethod
     def validate_cpu(cls, v: str) -> str:

--- a/infra/sandbox/sandbox_control_plane/tests/unit/application/commands/test_create_session.py
+++ b/infra/sandbox/sandbox_control_plane/tests/unit/application/commands/test_create_session.py
@@ -1,0 +1,40 @@
+"""CreateSessionCommand 校验测试（id / template_id 安全白名单兜底层）。"""
+
+import pytest
+
+from src.application.commands.create_session import CreateSessionCommand
+
+
+class TestCreateSessionCommandValidation:
+    @pytest.mark.parametrize(
+        "bad_id",
+        [
+            "foo; rm -rf /",
+            "$(id)",
+            "a`id`b",
+            "../escape",
+            "sess/../../etc",
+            "a/b",
+            "with space",
+            "a|b",
+            "a&b",
+        ],
+    )
+    def test_rejects_unsafe_id(self, bad_id):
+        # 兜底层：即使不经 request schema，含 shell 元字符 / '..' / '/' 的 id 也必须
+        # 被拒——它会落入以 root 运行的 s3fs 挂载脚本，否则造成命令注入 / 前缀逃逸。
+        with pytest.raises(ValueError):
+            CreateSessionCommand(id=bad_id)
+        with pytest.raises(ValueError):
+            CreateSessionCommand(template_id=bad_id)
+
+    def test_accepts_safe_id_and_template_id(self):
+        cmd = CreateSessionCommand(id="sess_aoi_0", template_id="python-basic")
+        assert cmd.id == "sess_aoi_0"
+        assert cmd.template_id == "python-basic"
+
+    def test_allows_none(self):
+        # id/template_id 可选；None 走自动生成 / 默认模板，不应被校验拦下。
+        cmd = CreateSessionCommand()
+        assert cmd.id is None
+        assert cmd.template_id is None

--- a/infra/sandbox/sandbox_control_plane/tests/unit/interfaces/rest/schemas/test_request_models.py
+++ b/infra/sandbox/sandbox_control_plane/tests/unit/interfaces/rest/schemas/test_request_models.py
@@ -60,6 +60,33 @@ class TestCreateSessionRequest:
         with pytest.raises(ValidationError):
             CreateSessionRequest(cpu=cpu)
 
+    @pytest.mark.parametrize(
+        "bad_id",
+        [
+            "foo; rm -rf /",
+            "$(touch /tmp/x)",
+            "a`id`b",
+            "../other-session",
+            "sess/../../etc",
+            "a/b",
+            "with space",
+            "a|b",
+            "a&b",
+        ],
+    )
+    def test_rejects_unsafe_id(self, bad_id):
+        # id/template_id 会经 workspace_path 落入以 root 运行的 s3fs 挂载脚本：
+        # shell 元字符 -> 命令注入；'/'、'..' -> 前缀逃逸、绕过会话隔离。
+        with pytest.raises(ValidationError):
+            CreateSessionRequest(id=bad_id)
+        with pytest.raises(ValidationError):
+            CreateSessionRequest(template_id=bad_id)
+
+    def test_accepts_safe_id_and_template_id(self):
+        request = CreateSessionRequest(id="sess_aoi_0", template_id="python-basic")
+        assert request.id == "sess_aoi_0"
+        assert request.template_id == "python-basic"
+
     def test_accepts_custom_python_package_index_url(self):
         request = CreateSessionRequest(
             python_package_index_url="https://mirror.example.com/simple/"


### PR DESCRIPTION
沙箱执行器/调度器的三处改动，均已在 VM(arm64/k3s)实测。

## 1. feat: 数据模板预装常用数据栈到 /opt/sandbox-common
为兼容大多数数据处理函数，`python-basic` 等数据向模板预装 numpy/pandas/scipy/scikit-learn/statsmodels 及常用辅助包（见 `common-requirements.txt`）。

- 装入专用 `/opt/sandbox-common`，**不放 `/opt/sandbox-venv`** —— 后者每次依赖同步会被清空；`/opt/sandbox-common` 随镜像常驻，且排在 PYTHONPATH 依赖目录之后，函数自己声明的依赖版本仍可覆盖基线。
- 通过 `PREINSTALL_COMMON` build-arg 按模板开关（`build.sh` / CI 仅对 `python-basic` 开，`multi-language` 保持精简）。
- isolation 三后端（bwrap/macseatbelt/subprocess）PYTHONPATH 追加 `common_install_path`，bwrap 增加 `/opt/sandbox-common` 只读绑定；始终创建该目录以便 bwrap 绑定。
- 版本按 Python 3.11 + numpy 1.x 稳定栈选取（numpy 2.5 需 py3.12，且 1.x 对存量函数更兼容）。

## 2. fix: bwrap 用 --ro-bind-try 挂系统目录，兼容 arm64/usrmerge
arm64 `python:3.11-slim` 无 `/lib64`，且 `/lib /bin /sbin` 是 usrmerge 软链。原 `--ro-bind /lib64` 会让 bwrap 直接 `Can't find source path /lib64` 起不来（`DISABLE_BWRAP=false` 时会话全废）。改 `--ro-bind-try`：源缺就跳过。VM 实测 bwrap 可起、断网生效、依赖可 import。

## 3. fix: 会话 workspace 只挂自己的 S3 前缀，不挂整个 bucket（安全）
原实现把整个 bucket 挂到 `/mnt/s3-root`（allow_other/umask=000）再 bind 会话子目录到 `/workspace` —— 整桶挂载一直敞着，任意会话代码可读写/删除其它会话数据（`rm -rf /mnt/s3-root` 可清空整桶，跨会话）。

改为：先以 root 临时挂整桶建会话前缀后立即卸载（s3fs 挂不了不存在的前缀），再只挂 `{bucket}:/{prefix}` 到 `/workspace`；加挂载校验防静默回落到本地 emptyDir 丢持久化。k8s + docker 两个 scheduler 同步。

**跨会话隔离测试（VM 双会话对抗）**：攻击方看不到、找不到、删不了受害会话数据；受害会话数据完好；`/mnt/s3-root` 不复存在。

## 验证
VM(arm64/k3s)实测：预装数据栈在真实会话可 import 且过依赖同步；用户 `sandbox_sdk` + pandas 函数走执行工厂接口跑通；workspace 前缀隔离双会话对抗通过。

## 已知未覆盖
- bwrap 完整开启仍受阻于 `gosu sandbox`(uid 1000) 跑 bwrap 时配置 netns loopback 无 `CAP_NET_ADMIN`（`Failed RTM_NEWADDR: Operation not permitted`）——属部署模型（privileged+gosu）问题，不在本 PR。
- 手动 PUT 模板 `image_url` 会被 control-plane 启动时 seeder 依据 `DEFAULT_TEMPLATE_IMAGE` 覆盖；正式发布应经 CI 出镜像并对齐默认镜像地址。

🤖 Generated with [Claude Code](https://claude.com/claude-code)