### PR TITLE
fix(agent-retrieval): query_object_instance 剥除结构化查询无意义的恒定 _score (#236)

### DIFF
--- a/adp/context-loader/agent-retrieval/server/driveradapters/knqueryobjectinstance/index.go
+++ b/adp/context-loader/agent-retrieval/server/driveradapters/knqueryobjectinstance/index.go
@@ -98,6 +98,12 @@ func (h *knQueryObjectInstanceHandler) QueryObjectInstance(c *gin.Context) {
 		return
 	}
 
+	// 纯结构化过滤无相关度评分，剥除恒定的 _score 避免误导调用方；
+	// knn / match 有真实相关度分则保留（#236）。
+	if !req.HasScoringOperator() {
+		resp.StripInstanceScores()
+	}
+
 	// 返回成功响应
 	rest.ReplyOK(c, http.StatusOK, resp)
 }

--- a/adp/context-loader/agent-retrieval/server/driveradapters/mcp/tools.go
+++ b/adp/context-loader/agent-retrieval/server/driveradapters/mcp/tools.go
@@ -109,6 +109,11 @@ func handleQueryObjectInstance(ontologyQuery interfaces.DrivenOntologyQuery) fun
 			return mcp.NewToolResultError(err.Error()), nil
 		}
 		resp.ObjectConcept = nil
+		// 纯结构化过滤无相关度评分，剥除恒定的 _score 避免误导调用方；
+		// knn / match 有真实相关度分则保留（#236）。
+		if !queryReq.HasScoringOperator() {
+			resp.StripInstanceScores()
+		}
 		result, err := BuildMCPToolResult(resp, format)
 		if err != nil {
 			return mcp.NewToolResultError(err.Error()), nil

--- a/adp/context-loader/agent-retrieval/server/interfaces/driven_ontology_query.go
+++ b/adp/context-loader/agent-retrieval/server/interfaces/driven_ontology_query.go
@@ -55,6 +55,63 @@ type QueryObjectInstancesResp struct {
 	SearchAfter []any `json:"search_after,omitempty"`
 }
 
+// StripInstanceScores 删除每条对象实例结果里的 _score 字段。
+//
+// 仅当本次查询是纯结构化过滤（无 knn / match 打分算子）时才应调用：这类查询在
+// OpenSearch 侧落成 term/terms/range/prefix/regexp/exists 等常量打分查询，无过滤时
+// 退化为 match_all，二者都给每条命中赋同一个常量分（通常 1.0），不存在相关度排序语义，
+// 透给调用方只会误导其以为结果按相关度排序（见 #236）。
+// knn / 全文 match 会逐条打真实相关度分，此时不得剥除——由调用方用
+// HasScoringOperator 判定后决定是否调用本方法。
+func (r *QueryObjectInstancesResp) StripInstanceScores() {
+	if r == nil {
+		return
+	}
+	for _, item := range r.Data {
+		if m, ok := item.(map[string]any); ok {
+			delete(m, "_score")
+		}
+	}
+}
+
+// scoringOperators 是会产生真实相关度分（逐条不同）的算子集合；其余结构化算子在
+// OpenSearch 侧是常量打分，_score 无排序语义。
+var scoringOperators = map[KnOperationType]struct{}{
+	KnOperationTypeKnn:   {}, // 向量近邻，按相似度打分
+	KnOperationTypeMatch: {}, // 全文匹配，按相关度打分
+}
+
+// HasScoringOperator 判断本次查询是否使用了会产生相关度评分的算子（knn / match），
+// 用于决定响应是否保留 _score（#236）。会同时检查 filters 语法糖与已展开的
+// condition 树，故调用时机无关（展开前后都正确）。
+func (r *QueryObjectInstancesReq) HasScoringOperator() bool {
+	if r == nil {
+		return false
+	}
+	for _, f := range r.Filters {
+		if _, ok := scoringOperators[f.Op]; ok {
+			return true
+		}
+	}
+	return condHasScoringOperator(r.Cond)
+}
+
+// condHasScoringOperator 递归判断 condition 树里是否含打分算子。
+func condHasScoringOperator(c *KnCondition) bool {
+	if c == nil {
+		return false
+	}
+	if _, ok := scoringOperators[c.Operation]; ok {
+		return true
+	}
+	for _, sub := range c.SubConditions {
+		if condHasScoringOperator(sub) {
+			return true
+		}
+	}
+	return false
+}
+
 // QueryLogicPropertiesReq Request for querying logic properties values
 type QueryLogicPropertiesReq struct {
 	KnID               string                   `json:"kn_id"`

--- a/adp/context-loader/agent-retrieval/server/interfaces/driven_ontology_query_test.go
+++ b/adp/context-loader/agent-retrieval/server/interfaces/driven_ontology_query_test.go
@@ -1,0 +1,147 @@
+// Copyright openbkn.ai
+// Copyright The kweaver.ai Authors.
+//
+// Licensed under the Apache License, Version 2.0.
+// See the LICENSE file in the project root for details.
+
+package interfaces
+
+import "testing"
+
+// TestStripInstanceScores 覆盖 #236：query_object_instance 无相关度评分，
+// 响应中的恒定 _score 必须被剥除；有无过滤条件的结果结构一致。
+func TestStripInstanceScores(t *testing.T) {
+	hasScore := func(item any) bool {
+		m, ok := item.(map[string]any)
+		if !ok {
+			return false
+		}
+		_, ok = m["_score"]
+		return ok
+	}
+
+	t.Run("nil resp 不 panic", func(t *testing.T) {
+		var resp *QueryObjectInstancesResp
+		resp.StripInstanceScores()
+	})
+
+	t.Run("空结果 不 panic", func(t *testing.T) {
+		resp := &QueryObjectInstancesResp{Data: nil}
+		resp.StripInstanceScores()
+		if len(resp.Data) != 0 {
+			t.Fatalf("expected empty data, got %d", len(resp.Data))
+		}
+	})
+
+	t.Run("剥除 _score 保留其余字段", func(t *testing.T) {
+		resp := &QueryObjectInstancesResp{
+			Data: []any{
+				map[string]any{"child_name": "产品A", "_score": 1.0},
+				map[string]any{"child_name": "产品B", "_score": 1.0},
+			},
+		}
+		resp.StripInstanceScores()
+		for i, item := range resp.Data {
+			if hasScore(item) {
+				t.Errorf("item %d 仍含 _score", i)
+			}
+			if m := item.(map[string]any); m["child_name"] == nil {
+				t.Errorf("item %d 丢失业务字段 child_name", i)
+			}
+		}
+	})
+
+	t.Run("无 _score 的结果原样保留", func(t *testing.T) {
+		resp := &QueryObjectInstancesResp{
+			Data: []any{map[string]any{"child_name": "产品A"}},
+		}
+		resp.StripInstanceScores()
+		if m := resp.Data[0].(map[string]any); m["child_name"] != "产品A" {
+			t.Errorf("业务字段被误删")
+		}
+	})
+
+	t.Run("非 map 元素不影响", func(t *testing.T) {
+		resp := &QueryObjectInstancesResp{Data: []any{"raw", 42}}
+		resp.StripInstanceScores() // 不 panic 即可
+		if len(resp.Data) != 2 {
+			t.Fatalf("非 map 元素被改动")
+		}
+	})
+}
+
+// TestHasScoringOperator 覆盖 #236 的意图判定：knn / match 有真实相关度分要保留 _score，
+// 纯结构化过滤无评分语义要剥除。filters 语法糖与 condition 树两条入口都要认。
+func TestHasScoringOperator(t *testing.T) {
+	tests := []struct {
+		name string
+		req  *QueryObjectInstancesReq
+		want bool
+	}{
+		{"nil req", nil, false},
+		{"空 req", &QueryObjectInstancesReq{}, false},
+		{
+			"filters 纯结构化",
+			&QueryObjectInstancesReq{Filters: []FlatFilter{
+				{Field: "child_name", Op: KnOperationTypeLike, Value: "%产品%"},
+				{Field: "qty", Op: KnOperationTypeGreater, Value: 10},
+			}},
+			false,
+		},
+		{
+			"filters 含 knn",
+			&QueryObjectInstancesReq{Filters: []FlatFilter{
+				{Field: "child_name", Op: KnOperationTypeKnn, Value: "产品"},
+			}},
+			true,
+		},
+		{
+			"filters 含 match",
+			&QueryObjectInstancesReq{Filters: []FlatFilter{
+				{Field: "child_name", Op: KnOperationTypeMatch, Value: "产品"},
+			}},
+			true,
+		},
+		{
+			"condition 纯结构化 AND",
+			&QueryObjectInstancesReq{Cond: &KnCondition{
+				Operation: KnOperationTypeAnd,
+				SubConditions: []*KnCondition{
+					{Field: "a", Operation: KnOperationTypeEqual, Value: 1},
+					{Field: "b", Operation: KnOperationTypeIn, Value: []int{1, 2}},
+				},
+			}},
+			false,
+		},
+		{
+			"condition 嵌套里含 knn",
+			&QueryObjectInstancesReq{Cond: &KnCondition{
+				Operation: KnOperationTypeAnd,
+				SubConditions: []*KnCondition{
+					{Field: "a", Operation: KnOperationTypeEqual, Value: 1},
+					{Field: "vec", Operation: KnOperationTypeKnn, Value: "x"},
+				},
+			}},
+			true,
+		},
+		{
+			"condition 深层嵌套含 match",
+			&QueryObjectInstancesReq{Cond: &KnCondition{
+				Operation: KnOperationTypeOr,
+				SubConditions: []*KnCondition{
+					{Operation: KnOperationTypeAnd, SubConditions: []*KnCondition{
+						{Field: "c", Operation: KnOperationTypeMatch, Value: "y"},
+					}},
+				},
+			}},
+			true,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := tc.req.HasScoringOperator(); got != tc.want {
+				t.Errorf("HasScoringOperator() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## 背景

#236：`query_object_instance` 返回结果中所有记录的 `_score` 相同（filters 为空和不为空均如此）。

## 根因

不是评分被覆盖，是**结构化过滤查询本无相关度语义**：

| 查询类型 | OpenSearch `_score` |
|---|---|
| 无 filter（`match_all`）| 每条恒 1.0 |
| 结构化过滤（term/terms/range/prefix/regexp/exists，走 `bool.must`）| Lucene ConstantScoreQuery，每条同一常量 |
| knn / 全文 match | 逐条真实相关度分（有意义） |

`term`/`range`/`in`/`like` 等在 Lucene 里是常量打分（keyword 字段 norms 默认关，term 也无长度归一），bool 组合后每条命中拿同一个和 → 全相同。这个恒定 `_score` 透给调用方会误导其以为结果按相关度排序。

## 改动

按**查询意图**判定，而非无条件剥除：

- 新增 `QueryObjectInstancesReq.HasScoringOperator()`：递归扫 `filters` 语法糖与 `condition` 树，含 `knn` / `match` 打分算子返回 true。
- 新增 `QueryObjectInstancesResp.StripInstanceScores()`：删除每条实例的 `_score`。
- MCP handler 与 REST handler（`/kn/query_object_instance`）在返回前：**纯结构化过滤 → 剥除 `_score`；含 knn / match → 保留逐条真实相关度分**。

两个入口一致处理。knn（#235-B 打通后）/ match 的真实评分不受影响。

## 为什么不是"修好评分"

纯结构化过滤没有相关度可算（行匹配是集合成员，不存在"匹配多好"），无信号可修。要相关度用 knn / match，要稳定顺序用 `sort`。

## 测试

- `TestHasScoringOperator`：filters / condition 两入口、嵌套、纯结构化 vs 含 knn/match。
- `TestStripInstanceScores`：nil / 空 / 剥除保留业务字段 / 无 _score 原样 / 非 map 元素。
- `go test ./interfaces/ ./driveradapters/...` 全绿；`go build` + `go vet` 干净。

## 待办（不在本 PR）

- MCP tool 描述补一句"结构化查询无相关度评分，要排序用 sort、要相关度用 knn/match"（文档指引，可选）。
- 测试环境端到端验证：真机跑 query_object_instance 确认结构化响应无 `_score`、knn/match 保留。

🤖 Generated with [Claude Code](https://claude.com/claude-code)