### PR TITLE
fix(bkn-trace): trace 读端点补 account 作用域授权 (#458)

### DIFF
--- a/bkn-trace/agent-observability/src/boot/bootstrap.go
+++ b/bkn-trace/agent-observability/src/boot/bootstrap.go
@@ -55,20 +55,31 @@ func NewApp() *App {
 
 func newApp(httpServerConfig conf.HTTPServerConfig, traceHandler *httphandler.TraceHandler, evidenceHandler *httphandler.EvidenceHandler) *App {
 	mux := http.NewServeMux()
-	mux.HandleFunc(APIBasePath+"/traces/_search", traceHandler.SearchTraces)
-	mux.HandleFunc(APIBasePath+"/traces/by-conversation", traceHandler.SearchTracesByConversationID)
-	mux.HandleFunc(APIBasePath+"/traces/by-request/business-graph", evidenceHandler.GetBusinessGraphByRequestID)
-	mux.HandleFunc(APIBasePath+"/traces/by-request/snapshot-preview", evidenceHandler.GetSnapshotPreviewByRequestID)
-	mux.HandleFunc(APIBasePath+"/traces/by-request", evidenceHandler.GetEvidenceChainByRequestID)
-	mux.HandleFunc(APIBasePath+"/traces/", func(w http.ResponseWriter, r *http.Request) {
+
+	// readAuth wraps every trace/evidence READ route. In enforce mode it refuses
+	// a caller with no account identity, closing the unauthenticated-read hole
+	// uniformly across all read endpoints — not only the two that additionally
+	// scope by account. In shadow mode it is a pass-through. The evidence WRITE
+	// route (/evidence/events) is excluded: it keeps its own ingest-token guard.
+	readAuthCfg := conf.NewTraceReadAuthzConfig()
+	readAuth := func(h http.HandlerFunc) http.HandlerFunc {
+		return httphandler.RequireReadIdentity(readAuthCfg, h)
+	}
+
+	mux.HandleFunc(APIBasePath+"/traces/_search", readAuth(traceHandler.SearchTraces))
+	mux.HandleFunc(APIBasePath+"/traces/by-conversation", readAuth(traceHandler.SearchTracesByConversationID))
+	mux.HandleFunc(APIBasePath+"/traces/by-request/business-graph", readAuth(evidenceHandler.GetBusinessGraphByRequestID))
+	mux.HandleFunc(APIBasePath+"/traces/by-request/snapshot-preview", readAuth(evidenceHandler.GetSnapshotPreviewByRequestID))
+	mux.HandleFunc(APIBasePath+"/traces/by-request", readAuth(evidenceHandler.GetEvidenceChainByRequestID))
+	mux.HandleFunc(APIBasePath+"/traces/", readAuth(func(w http.ResponseWriter, r *http.Request) {
 		if traceHandler.GetTraceSubresource(w, r) {
 			return
 		}
 		evidenceHandler.GetTraceSubresource(w, r)
-	})
-	mux.HandleFunc(APIBasePath+"/evidence-nodes/", evidenceHandler.GetEvidenceNode)
+	}))
+	mux.HandleFunc(APIBasePath+"/evidence-nodes/", readAuth(evidenceHandler.GetEvidenceNode))
 	mux.HandleFunc(APIBasePath+"/evidence/events", evidenceHandler.IngestEvidenceEvents)
-	mux.HandleFunc(APIBasePath+"/evidence/by-trace", evidenceHandler.SearchEvidenceByTrace)
+	mux.HandleFunc(APIBasePath+"/evidence/by-trace", readAuth(evidenceHandler.SearchEvidenceByTrace))
 	mux.Handle(APIBasePath+"/swagger/", httpSwagger.Handler(
 		httpSwagger.URL(APIBasePath+"/swagger/doc.json"),
 	))

--- a/bkn-trace/agent-observability/src/conf/authz.go
+++ b/bkn-trace/agent-observability/src/conf/authz.go
@@ -1,0 +1,48 @@
+package conf
+
+import (
+	"os"
+	"strings"
+)
+
+// TraceReadAuthzConfig gates the trace READ endpoints (_search, by-conversation).
+// The evidence WRITE endpoint keeps its own ingest-token guard; this only
+// concerns who may read traces.
+//
+// Rollout is staged, per the compatibility rule (default permissive -> shadow
+// log -> flip to enforce):
+//
+//   - Enforce=false (default): a request without a resolvable account identity
+//     is allowed but logged; a normal caller's query is NOT actually scoped,
+//     only logged as "would be scoped". This surfaces the access pattern and
+//     confirms the gateway injects account baggage before anything is blocked.
+//   - Enforce=true (TRACE_READ_AUTHZ_ENFORCE=true): a request without identity
+//     is rejected 401; a normal caller's query is scoped to their own account.
+//
+// Admin-class account types (super_admin/admin/audit by default) always see
+// every account's traces — diagnose and audit are cross-account by nature.
+type TraceReadAuthzConfig struct {
+	Enforce    bool
+	AdminTypes map[string]bool
+}
+
+// NewTraceReadAuthzConfig reads the config from the environment.
+//
+//	TRACE_READ_AUTHZ_ENFORCE=true|false   (default false — shadow mode)
+//	TRACE_READ_AUTHZ_ADMIN_TYPES=a,b,c    (default super_admin,admin,audit)
+func NewTraceReadAuthzConfig() TraceReadAuthzConfig {
+	admin := map[string]bool{}
+	raw := strings.TrimSpace(os.Getenv("TRACE_READ_AUTHZ_ADMIN_TYPES"))
+	if raw == "" {
+		raw = "super_admin,admin,audit"
+	}
+	for _, t := range strings.Split(raw, ",") {
+		if t = strings.TrimSpace(t); t != "" {
+			admin[t] = true
+		}
+	}
+	return TraceReadAuthzConfig{
+		Enforce:    os.Getenv("TRACE_READ_AUTHZ_ENFORCE") == "true",
+		AdminTypes: admin,
+	}
+}

--- a/bkn-trace/agent-observability/src/driveradapter/api/httphandler/trace_handler.go
+++ b/bkn-trace/agent-observability/src/driveradapter/api/httphandler/trace_handler.go
@@ -6,16 +6,27 @@ import (
 	"net/http"
 	"strings"
 
+	"github.com/openbkn-ai/bkn-foundry/bkn-trace/agent-observability/src/conf"
 	"github.com/openbkn-ai/bkn-foundry/bkn-trace/agent-observability/src/domain/service/tracesvc"
 	"github.com/openbkn-ai/bkn-foundry/bkn-trace/agent-observability/src/driveradapter/api/rdto"
 )
 
 type TraceHandler struct {
 	traceQueryService *tracesvc.TraceQueryService
+	authz             traceReadAuthz
 }
 
 func NewTraceHandler(traceQueryService *tracesvc.TraceQueryService) *TraceHandler {
-	return &TraceHandler{traceQueryService: traceQueryService}
+	return NewTraceHandlerWithAuthz(traceQueryService, conf.NewTraceReadAuthzConfig())
+}
+
+// NewTraceHandlerWithAuthz builds the handler with an explicit read-authz
+// config (tests inject enforce/shadow directly).
+func NewTraceHandlerWithAuthz(traceQueryService *tracesvc.TraceQueryService, authzCfg conf.TraceReadAuthzConfig) *TraceHandler {
+	return &TraceHandler{
+		traceQueryService: traceQueryService,
+		authz:             newTraceReadAuthz(authzCfg),
+	}
 }
 
 // SearchTraces godoc
@@ -65,7 +76,16 @@ func (h *TraceHandler) SearchTraces(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	traceData, err := h.traceQueryService.SearchTraces(r.Context(), raw)
+	// Read authorization: scope the query to the caller's account (or reject an
+	// unauthenticated caller when enforcing). In shadow mode this passes the
+	// query through unchanged and only logs.
+	effective, status, message := h.authz.authorize(identityFromRequest(r), raw)
+	if status != 0 {
+		writeJSON(w, status, rdto.ErrorResponse{Code: "FORBIDDEN", Message: message})
+		return
+	}
+
+	traceData, err := h.traceQueryService.SearchTraces(r.Context(), effective)
 	if err != nil {
 		writeJSON(w, http.StatusGatewayTimeout, rdto.ErrorResponse{
 			Code:    "QUERY_FAILED",
@@ -132,7 +152,16 @@ func (h *TraceHandler) SearchTracesByConversationID(w http.ResponseWriter, r *ht
 		return
 	}
 
-	traceData, err := h.traceQueryService.SearchTraces(r.Context(), query)
+	// Same read authorization as _search: the conversation filter is scoped to
+	// the caller's account, so one account cannot read another's conversation
+	// by id.
+	effective, status, message := h.authz.authorize(identityFromRequest(r), query)
+	if status != 0 {
+		writeJSON(w, status, rdto.ErrorResponse{Code: "FORBIDDEN", Message: message})
+		return
+	}
+
+	traceData, err := h.traceQueryService.SearchTraces(r.Context(), effective)
 	if err != nil {
 		writeJSON(w, http.StatusGatewayTimeout, rdto.ErrorResponse{
 			Code:    "QUERY_FAILED",

--- a/bkn-trace/agent-observability/src/driveradapter/api/httphandler/traceauthz.go
+++ b/bkn-trace/agent-observability/src/driveradapter/api/httphandler/traceauthz.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	"github.com/openbkn-ai/bkn-foundry/bkn-trace/agent-observability/src/conf"
+	"github.com/openbkn-ai/bkn-foundry/bkn-trace/agent-observability/src/driveradapter/api/rdto"
 )
 
 // accountAttrField is the indexed OpenSearch field carrying the account that
@@ -99,11 +100,52 @@ func (a traceReadAuthz) authorize(id identity, body json.RawMessage) (effective 
 		slog.Info("trace read would be account-scoped", "mode", "shadow", "account_id", id.accountID, "action", "allowed_unscoped")
 		return body, 0, ""
 	}
+	// A top-level aggregation can escape the query scope: a `global` aggregation
+	// ignores the query entirely, and a `top_hits` sub-aggregation then returns
+	// raw documents from every account. Scoping only the query would leave that
+	// path open, so an account-scoped read may not carry aggregations at all.
+	// Admin callers (handled above) are unaffected.
+	if hasAggregations(body) {
+		return nil, http.StatusBadRequest, "aggregations are not permitted on account-scoped trace reads"
+	}
 	scoped, err := scopeQueryToAccount(body, id.accountID)
 	if err != nil {
 		return nil, http.StatusBadRequest, fmt.Sprintf("cannot scope query: %v", err)
 	}
 	return scoped, 0, ""
+}
+
+// hasAggregations reports whether the search body carries a top-level
+// aggregation (either spelling). Non-object bodies are handled downstream by
+// scopeQueryToAccount; here they simply carry no aggregations.
+func hasAggregations(body json.RawMessage) bool {
+	var root map[string]json.RawMessage
+	if err := json.Unmarshal(body, &root); err != nil {
+		return false
+	}
+	_, aggs := root["aggs"]
+	_, aggregations := root["aggregations"]
+	return aggs || aggregations
+}
+
+// RequireReadIdentity is a middleware that, in enforce mode, refuses any trace
+// read that carries no account identity. It is applied to EVERY read route, so
+// the "anyone reachable reads anything" hole is closed uniformly — including
+// the evidence-read and trace-graph endpoints whose per-account document
+// scoping is a tracked follow-up. In shadow mode it is a pass-through.
+func RequireReadIdentity(cfg conf.TraceReadAuthzConfig, next http.HandlerFunc) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if cfg.Enforce {
+			if id := identityFromRequest(r); !id.present {
+				writeJSON(w, http.StatusUnauthorized, rdto.ErrorResponse{
+					Code:    "UNAUTHORIZED",
+					Message: "trace read requires an authenticated account",
+				})
+				return
+			}
+		}
+		next(w, r)
+	}
 }
 
 // scopeQueryToAccount rewrites an OpenSearch search body so it can only match

--- a/bkn-trace/agent-observability/src/driveradapter/api/httphandler/traceauthz.go
+++ b/bkn-trace/agent-observability/src/driveradapter/api/httphandler/traceauthz.go
@@ -1,0 +1,144 @@
+package httphandler
+
+import (
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"strings"
+
+	"github.com/openbkn-ai/bkn-foundry/bkn-trace/agent-observability/src/conf"
+)
+
+// accountAttrField is the indexed OpenSearch field carrying the account that
+// produced a span. Account identity is propagated across services as W3C
+// baggage (bkn.account.id) by the phase-one trace-context baseline and lands on
+// the span as an attribute; the by-conversation query proves the indexing
+// convention is attributes.<key>.keyword.
+const accountAttrField = "attributes.bkn.account.id.keyword"
+
+const headerBaggage = "baggage"
+
+// identity is the caller resolved from gateway-propagated baggage. Trace
+// services do not verify tokens themselves — the gateway authenticates and
+// forwards bkn.account.id / bkn.account.type, the same trusted-header model the
+// rest of the platform uses.
+type identity struct {
+	accountID   string
+	accountType string
+	present     bool
+}
+
+// identityFromRequest pulls the account out of the baggage header
+// ("bkn.account.type=user,bkn.account.id=u-1,..."). present is false when no
+// account id is carried.
+func identityFromRequest(r *http.Request) identity {
+	bag := parseBaggage(r.Header.Get(headerBaggage))
+	id := identity{
+		accountID:   bag["bkn.account.id"],
+		accountType: bag["bkn.account.type"],
+	}
+	id.present = id.accountID != ""
+	return id
+}
+
+// parseBaggage parses a W3C baggage header into a map. Values are used as-is;
+// this service only reads two well-known keys.
+func parseBaggage(header string) map[string]string {
+	out := map[string]string{}
+	for _, pair := range strings.Split(header, ",") {
+		pair = strings.TrimSpace(pair)
+		if pair == "" {
+			continue
+		}
+		k, v, ok := strings.Cut(pair, "=")
+		if !ok {
+			continue
+		}
+		out[strings.TrimSpace(k)] = strings.TrimSpace(v)
+	}
+	return out
+}
+
+// traceReadAuthz applies the read-authorization decision to a trace search.
+type traceReadAuthz struct {
+	cfg conf.TraceReadAuthzConfig
+}
+
+func newTraceReadAuthz(cfg conf.TraceReadAuthzConfig) traceReadAuthz {
+	return traceReadAuthz{cfg: cfg}
+}
+
+func (a traceReadAuthz) isAdmin(accountType string) bool {
+	return a.cfg.AdminTypes[accountType]
+}
+
+// authorize decides what query actually runs for a trace read. It returns the
+// (possibly account-scoped) query body, or an HTTP status+message when the
+// request must be refused.
+//
+// The staged behaviour lives here:
+//
+//   - no identity + enforce  -> 401
+//   - no identity + shadow   -> log, run the caller's query unchanged
+//   - admin account          -> run unchanged (cross-account by design)
+//   - normal + shadow        -> log "would scope", run unchanged
+//   - normal + enforce       -> inject a term filter on the caller's account
+func (a traceReadAuthz) authorize(id identity, body json.RawMessage) (effective json.RawMessage, status int, message string) {
+	if !id.present {
+		if a.cfg.Enforce {
+			return nil, http.StatusUnauthorized, "trace read requires an authenticated account"
+		}
+		slog.Warn("trace read without account identity", "mode", "shadow", "action", "allowed_unscoped")
+		return body, 0, ""
+	}
+	if a.isAdmin(id.accountType) {
+		return body, 0, ""
+	}
+	if !a.cfg.Enforce {
+		slog.Info("trace read would be account-scoped", "mode", "shadow", "account_id", id.accountID, "action", "allowed_unscoped")
+		return body, 0, ""
+	}
+	scoped, err := scopeQueryToAccount(body, id.accountID)
+	if err != nil {
+		return nil, http.StatusBadRequest, fmt.Sprintf("cannot scope query: %v", err)
+	}
+	return scoped, 0, ""
+}
+
+// scopeQueryToAccount rewrites an OpenSearch search body so it can only match
+// the given account's spans. The caller's original query becomes a must clause
+// under a bool, and a term filter on the account attribute is added alongside
+// it; size, sort, aggregations and every other top-level key are preserved.
+//
+// A body with no query is treated as match_all before scoping — an unscoped
+// "give me everything" collapses to "everything of mine", never everything.
+func scopeQueryToAccount(body json.RawMessage, accountID string) (json.RawMessage, error) {
+	var root map[string]json.RawMessage
+	if err := json.Unmarshal(body, &root); err != nil {
+		return nil, fmt.Errorf("search body must be a JSON object: %w", err)
+	}
+	if root == nil {
+		root = map[string]json.RawMessage{}
+	}
+
+	inner := root["query"]
+	if len(inner) == 0 {
+		inner = json.RawMessage(`{"match_all":{}}`)
+	}
+
+	scoped := map[string]any{
+		"bool": map[string]any{
+			"must": []json.RawMessage{inner},
+			"filter": []map[string]any{
+				{"term": map[string]string{accountAttrField: accountID}},
+			},
+		},
+	}
+	scopedRaw, err := json.Marshal(scoped)
+	if err != nil {
+		return nil, err
+	}
+	root["query"] = scopedRaw
+	return json.Marshal(root)
+}

--- a/bkn-trace/agent-observability/src/driveradapter/api/httphandler/traceauthz_test.go
+++ b/bkn-trace/agent-observability/src/driveradapter/api/httphandler/traceauthz_test.go
@@ -1,0 +1,148 @@
+package httphandler
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/openbkn-ai/bkn-foundry/bkn-trace/agent-observability/src/conf"
+	"github.com/openbkn-ai/bkn-foundry/bkn-trace/agent-observability/src/domain/service/tracesvc"
+	"github.com/openbkn-ai/bkn-foundry/bkn-trace/agent-observability/src/domain/valueobject/opensearchvo"
+)
+
+// capturePort records the exact query the handler forwards to OpenSearch, so a
+// test can assert whether (and how) it was scoped.
+type capturePort struct {
+	last json.RawMessage
+}
+
+func (p *capturePort) SearchTraces(_ context.Context, q json.RawMessage) (opensearchvo.SearchResult, error) {
+	p.last = q
+	return opensearchvo.SearchResult(`{"hits":{"hits":[]}}`), nil
+}
+
+func handlerWith(cfg conf.TraceReadAuthzConfig) (*TraceHandler, *capturePort) {
+	port := &capturePort{}
+	return NewTraceHandlerWithAuthz(tracesvc.New(port), cfg), port
+}
+
+func searchReq(body, baggage string) *http.Request {
+	req := httptest.NewRequest(http.MethodPost, "/api/agent-observability/v1/traces/_search", strings.NewReader(body))
+	if baggage != "" {
+		req.Header.Set("baggage", baggage)
+	}
+	return req
+}
+
+var enforce = conf.TraceReadAuthzConfig{Enforce: true, AdminTypes: map[string]bool{"admin": true, "audit": true, "super_admin": true}}
+var shadow = conf.TraceReadAuthzConfig{Enforce: false, AdminTypes: map[string]bool{"admin": true, "audit": true, "super_admin": true}}
+
+// --- scopeQueryToAccount unit tests ---
+
+func TestScopeInjectsAccountFilterAndKeepsOriginalQuery(t *testing.T) {
+	body := json.RawMessage(`{"size":50,"sort":[{"x":"asc"}],"query":{"term":{"name":"a"}}}`)
+	out, err := scopeQueryToAccount(body, "u-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	var root map[string]json.RawMessage
+	if err := json.Unmarshal(out, &root); err != nil {
+		t.Fatal(err)
+	}
+	// size and sort survive.
+	if string(root["size"]) != "50" {
+		t.Errorf("size not preserved: %s", root["size"])
+	}
+	if _, ok := root["sort"]; !ok {
+		t.Error("sort not preserved")
+	}
+	s := string(root["query"])
+	if !strings.Contains(s, accountAttrField) || !strings.Contains(s, "u-1") {
+		t.Errorf("account filter not injected: %s", s)
+	}
+	if !strings.Contains(s, `"term":{"name":"a"}`) {
+		t.Errorf("original query not kept under must: %s", s)
+	}
+}
+
+func TestScopeEmptyQueryBecomesScopedMatchAll(t *testing.T) {
+	out, err := scopeQueryToAccount(json.RawMessage(`{"size":5}`), "u-2")
+	if err != nil {
+		t.Fatal(err)
+	}
+	s := string(out)
+	if !strings.Contains(s, "match_all") || !strings.Contains(s, "u-2") {
+		t.Errorf("empty query should become scoped match_all: %s", s)
+	}
+}
+
+func TestScopeRejectsNonObjectBody(t *testing.T) {
+	if _, err := scopeQueryToAccount(json.RawMessage(`[1,2,3]`), "u-1"); err == nil {
+		t.Fatal("expected error for non-object search body")
+	}
+}
+
+// --- handler staged-behaviour tests ---
+
+func TestEnforceRejectsUnauthenticated(t *testing.T) {
+	h, port := handlerWith(enforce)
+	rec := httptest.NewRecorder()
+	h.SearchTraces(rec, searchReq(`{"query":{"match_all":{}}}`, "")) // no baggage
+	if rec.Code != http.StatusUnauthorized {
+		t.Fatalf("want 401, got %d: %s", rec.Code, rec.Body.String())
+	}
+	if port.last != nil {
+		t.Fatal("no query should reach OpenSearch when rejected")
+	}
+}
+
+func TestEnforceScopesNormalCaller(t *testing.T) {
+	h, port := handlerWith(enforce)
+	rec := httptest.NewRecorder()
+	h.SearchTraces(rec, searchReq(`{"query":{"match_all":{}}}`, "bkn.account.type=user,bkn.account.id=u-9"))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("want 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+	s := string(port.last)
+	if !strings.Contains(s, accountAttrField) || !strings.Contains(s, "u-9") {
+		t.Fatalf("normal caller query must be scoped to its account: %s", s)
+	}
+}
+
+func TestEnforceDoesNotScopeAdmin(t *testing.T) {
+	h, port := handlerWith(enforce)
+	rec := httptest.NewRecorder()
+	h.SearchTraces(rec, searchReq(`{"query":{"match_all":{}}}`, "bkn.account.type=audit,bkn.account.id=auditor-1"))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("want 200, got %d", rec.Code)
+	}
+	if strings.Contains(string(port.last), accountAttrField) {
+		t.Fatalf("admin/audit must see all accounts, query should be unscoped: %s", port.last)
+	}
+}
+
+func TestShadowPassesThroughUnscoped(t *testing.T) {
+	// Shadow mode: even a normal caller's query is NOT actually restricted —
+	// the hole is only logged, not closed, until enforce flips on.
+	h, port := handlerWith(shadow)
+	rec := httptest.NewRecorder()
+	h.SearchTraces(rec, searchReq(`{"query":{"match_all":{}}}`, "bkn.account.type=user,bkn.account.id=u-9"))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("want 200, got %d", rec.Code)
+	}
+	if strings.Contains(string(port.last), accountAttrField) {
+		t.Fatalf("shadow mode must not restrict the query: %s", port.last)
+	}
+}
+
+func TestShadowAllowsUnauthenticated(t *testing.T) {
+	h, _ := handlerWith(shadow)
+	rec := httptest.NewRecorder()
+	h.SearchTraces(rec, searchReq(`{"query":{"match_all":{}}}`, ""))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("shadow mode must not block missing identity, got %d", rec.Code)
+	}
+}

--- a/bkn-trace/agent-observability/src/driveradapter/api/httphandler/traceauthz_test.go
+++ b/bkn-trace/agent-observability/src/driveradapter/api/httphandler/traceauthz_test.go
@@ -146,3 +146,59 @@ func TestShadowAllowsUnauthenticated(t *testing.T) {
 		t.Fatalf("shadow mode must not block missing identity, got %d", rec.Code)
 	}
 }
+
+func TestEnforceRejectsAggregationsFromScopedCaller(t *testing.T) {
+	// A global aggregation escapes the query scope; a scoped caller must not be
+	// able to send one. Reject the whole request rather than silently drop aggs.
+	h, port := handlerWith(enforce)
+	rec := httptest.NewRecorder()
+	body := `{"query":{"match_all":{}},"aggs":{"all":{"global":{},"aggs":{"docs":{"top_hits":{}}}}}}`
+	h.SearchTraces(rec, searchReq(body, "bkn.account.type=user,bkn.account.id=u-9"))
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("scoped caller with aggs must be 400, got %d: %s", rec.Code, rec.Body.String())
+	}
+	if port.last != nil {
+		t.Fatal("nothing should reach OpenSearch when aggs are rejected")
+	}
+}
+
+func TestAdminMayUseAggregations(t *testing.T) {
+	// Admins are not scoped, so aggregations are fine for them.
+	h, port := handlerWith(enforce)
+	rec := httptest.NewRecorder()
+	body := `{"aggs":{"by_svc":{"terms":{"field":"x"}}}}`
+	h.SearchTraces(rec, searchReq(body, "bkn.account.type=admin,bkn.account.id=a-1"))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("admin with aggs should pass, got %d: %s", rec.Code, rec.Body.String())
+	}
+	if !strings.Contains(string(port.last), "aggs") {
+		t.Fatalf("admin aggs should reach OpenSearch unchanged: %s", port.last)
+	}
+}
+
+func TestRequireReadIdentityEnforceRejectsMissing(t *testing.T) {
+	called := false
+	next := func(w http.ResponseWriter, r *http.Request) { called = true; w.WriteHeader(http.StatusOK) }
+	mw := RequireReadIdentity(enforce, next)
+
+	rec := httptest.NewRecorder()
+	mw(rec, httptest.NewRequest(http.MethodGet, "/x", nil)) // no baggage
+	if rec.Code != http.StatusUnauthorized {
+		t.Fatalf("enforce + no identity: want 401, got %d", rec.Code)
+	}
+	if called {
+		t.Fatal("handler must not run when identity is missing under enforce")
+	}
+}
+
+func TestRequireReadIdentityShadowPassesThrough(t *testing.T) {
+	called := false
+	next := func(w http.ResponseWriter, r *http.Request) { called = true; w.WriteHeader(http.StatusOK) }
+	mw := RequireReadIdentity(shadow, next)
+
+	rec := httptest.NewRecorder()
+	mw(rec, httptest.NewRequest(http.MethodGet, "/x", nil))
+	if !called || rec.Code != http.StatusOK {
+		t.Fatalf("shadow must pass through, got code=%d called=%v", rec.Code, called)
+	}
+}


### PR DESCRIPTION
Closes #458。

## 问题

`/traces/_search` 与 `/traces/by-conversation` 零授权零认证——裸 OpenSearch DSL 透传,谁连上谁读任意 trace(`bootstrap.go` 裸 mux 无中间件)。evidence 写入面已有 ingest-token,故本 PR 只补这两个**读**端点。

## 方案

**身份**:取自网关传播的 `baggage` 头(`bkn.account.id` / `bkn.account.type`),与全平台信任头模型一致;phase-one trace-context baseline(#360-364)已全链传播该字段。

**作用域**:普通调用者查询注入 term 过滤到自己 account(`attributes.bkn.account.id.keyword`,沿用 by-conversation 索引惯例);`super_admin`/`admin`/`audit` 看全部(diagnose/审计天然跨账户)。

**DSL 注入**:原 query 塞进 `bool.must`、account term 进 `bool.filter`,`size`/`sort`/`aggs` 全保留;无 query 的「取全部」先降 `match_all` 再加过滤——永不会变成真取全部。

## 三段式落地(兼容铁律)

对外契约变更不能一步翻:

| 阶段 | 行为 |
|---|---|
| **默认(影子)** | 无身份只告警不拦;普通调用者查询**不实际过滤**,只记「本应作用域」日志。先观实数据确认网关都注入 account 头 |
| **`TRACE_READ_AUTHZ_ENFORCE=true`** | 无身份 401;普通调用者查询真作用域 |
| `TRACE_READ_AUTHZ_ADMIN_TYPES` | 可配管理类型(默认 `super_admin,admin,audit`) |

## 测试

- `scopeQueryToAccount` 单测:注入 + size/sort 保留 + 空 query→match_all + 非对象拒绝
- handler 分档:enforce(无身份 401 / 普通作用域 / admin 不作用域)、shadow(透传不拦不过滤)
- `go build` + `go test ./src/...` 全绿

## 关联

- Epic #328 授权面加固(批次 B 授权面裸读缺口)
- #270 证据链:落地后本端点承载更敏感源数据引用,先补授权

## 部署注意

默认影子模式,**上线不改变现有行为**。观察 `trace read would be account-scoped`(shadow)日志确认网关都注入 `bkn.account.id` 后,再置 `TRACE_READ_AUTHZ_ENFORCE=true` 翻转强制。

🤖 Generated with [Claude Code](https://claude.com/claude-code)