### PR TITLE
fix(mf-model-api): large_model execute 补对象授权,对齐 small_model (#460)

### DIFF
--- a/infra/mf-model-api/app/controller/llm_controller.py
+++ b/infra/mf-model-api/app/controller/llm_controller.py
@@ -4,6 +4,7 @@ from app.mydb.ConnectUtil import redis_util, get_redis_util
 from app.utils import llm_utils
 from app.utils.bkntrace import evidence as bkntrace_evidence
 from app.utils.llm_utils import openai_series_stream, OpenAIClientRequest
+from app.utils.permission_manager import permission_manager
 from app.utils.param_verify_utils import *
 from app.utils.reshape_utils import *
 from sse_starlette import EventSourceResponse
@@ -15,7 +16,7 @@ eng_dict = {
 }
 
 
-async def used_model_openai(request, user_id, language, func_module, trace_headers=None):
+async def used_model_openai(request, user_id, language, func_module, trace_headers=None, role=None, private=True):
     if "stream" not in request.keys():
         stream = True
     else:
@@ -89,6 +90,17 @@ async def used_model_openai(request, user_id, language, func_module, trace_heade
     context_size = model_data["f_max_model_len"]
     model_id = model_data["f_model_id"]
     quota = model_data["f_quota"]
+    # Object-level authorization on the execute face, mirroring small_model
+    # (small_model_controller.py). Only the public route enforces (private=False);
+    # the S2S private route skips, by the same convention. resource_type is
+    # large_model so a caller must hold large_model:execute on this model.
+    # AUTH_ENABLED=false short-circuits inside check_single_permission.
+    if not private:
+        permission = await permission_manager.check_single_permission(
+            user_id=user_id, resource_id=model_id, operations="execute",
+            resource_type="large_model", role=role)
+        if not permission:
+            return JSONResponse(status_code=403, content=NotPermissionError)
     trace_context = bkntrace_evidence.build_request_context(trace_headers, account_id=user_id, account_type="user")
     if quota:
         quota_cache_key = f"{user_id}:dip:model-api:llm-quota:{model_name}:list"

--- a/infra/mf-model-api/app/routers/llm_router.py
+++ b/infra/mf-model-api/app/routers/llm_router.py
@@ -96,4 +96,7 @@ async def llm_used_openai2(request: LLMUsedOpenAI, head_request: Request):
     userId, language, role = await get_user_info(head_request)
     headers = head_request.headers
     func_module = headers.get('x-func-module', "")
-    return await used_model_openai(request.dict(), userId, language, func_module, dict(headers))
+    # Public route enforces large_model:execute (private=False); the S2S
+    # private_route keeps the default (private=True) and skips, matching
+    # small_model.
+    return await used_model_openai(request.dict(), userId, language, func_module, dict(headers), role=role, private=False)


### PR DESCRIPTION
Closes #460。

## 问题

`large_model` 的 execute 面(chat/completions)零对象授权,只查配额(`llm_controller.used_model_openai`)。词表定义了 `large_model:execute` 但从未校验 → 任意认证用户可用任意大模型对话。对照:`small_model` 的 embedding/rerank execute 早已校验。

## 方案(镜像 small_model 现有实现)

- `used_model_openai` 加 `role`/`private` 参(默认 `private=True`)
- `model_id` 解析后、配额检查前:`private=False` 时 `check_single_permission(operations="execute", resource_type="large_model")`,失败 403
- 公开路由 `llm_router` 传 `role` + `private=False`(校验);S2S `private_route` 保持默认跳过(与 small_model 同惯例)
- `AUTH_ENABLED=false` 短路放行;bkn-safe/ISF/shadow 由 `AUTHZ_PROVIDER` 选择

## 兼容性(请 owner 裁决)

与 small_model 一致的**硬 403**(非 shadow)。潜在风险:存量若通过**未含 `large_model:execute`** 的路径授权,启用后合法用户可能 403。

缓解:
1. small_model 已强制同类 execute,模型通常同批授权 → 同一 grant 群体
2. `AUTH_ENABLED=false` 全关
3. `AUTHZ_PROVIDER=shadow` 可先影子观察分歧再翻 bkn-safe 权威

若判断需要,可先 shadow 或做 `large_model:execute` grant 回填。倾向与 small_model 保持一致(硬 403),请 owner 确认。

## 测试

改动是 `small_model_controller.py:388` 的忠实镜像。mf-model 单测需 `model-factory-base` 镜像内跑(裸 runner 缺依赖,CI 为 chart-only),本地做了 `py_compile` + import 链核对。建议在镜像内补一条 large_model execute 授权用例(参照 small_model 现有)。

## 关联

- #460;覆盖审计定位「model execute 面裸露」
- 样板:`small_model_controller.py:388`

🤖 Generated with [Claude Code](https://claude.com/claude-code)