### PR TITLE
fix(bkn-agent): agent-as-tool 派生名过 _safe_name,中文/长名不再 400 (#251)

### DIFF
--- a/infra/bkn-agent/app/core/tools.py
+++ b/infra/bkn-agent/app/core/tools.py
@@ -8,7 +8,7 @@ from langchain_mcp_adapters.client import MultiServerMCPClient
 from app import evidence, observability
 from app.config import config
 from app.core.skills import normalize_skill_id
-from app.core.toolbox import load_toolbox_tools
+from app.core.toolbox import _safe_name, load_toolbox_tools
 from app.errors import bad_request
 
 logger = logging.getLogger("bkn-agent.tools")
@@ -126,9 +126,25 @@ async def _agent_tool(
             await dao.set_task_status(session, task.task_id, "succeeded", output=output)
         return output
 
-    name = ref.get("name") or f"agent_{sub_agent.name}"
+    name = _derive_agent_tool_name(ref, sub_agent.name, sub_agent.agent_id)
     description = ref.get("description") or f"调用子 agent「{sub_agent.name}」完成一次性任务。"
     return StructuredTool.from_function(coroutine=call_sub_agent, name=name, description=description)
+
+
+def _derive_agent_tool_name(ref: dict, agent_name: str, agent_id: str) -> str:
+    """OpenAI-legal tool name for an agent-as-tool.
+
+    AgentSpec.name allows Chinese and up to 100 chars, but an OpenAI function
+    name must be ASCII [a-zA-Z0-9_-] and <=64 — so a raw `agent_{name}` like
+    `agent_语义理解` makes the model 400 on every call before the tool even
+    runs, and agent-as-tool is a core capability with a wide blast radius. Run
+    the explicit (AgentToolRef.name) or derived name through the same sanitizer
+    the toolbox tools use: it strips illegal chars, truncates to 64, and falls
+    back to `tool_{agent_id前缀}` when nothing usable survives. Semantics are
+    carried by the description instead.
+    """
+    raw_name = ref.get("name") or f"agent_{agent_name}"
+    return _safe_name(raw_name, agent_id)
 
 
 def _read_skill_file_tool(account_id: str, account_type: str) -> StructuredTool:

--- a/infra/bkn-agent/app/test/test_toolbox_tools.py
+++ b/infra/bkn-agent/app/test/test_toolbox_tools.py
@@ -5,7 +5,7 @@ import pytest
 
 from app import evidence, observability
 from app.core import toolbox
-from app.core.tools import _mcp_connections, _toolbox_tools
+from app.core.tools import _derive_agent_tool_name, _mcp_connections, _toolbox_tools
 from app.errors import bad_request  # noqa: F401  (确认导出仍存在)
 
 _TOOL_INFO = {
@@ -411,3 +411,27 @@ def test_explicit_box_error_is_classified(monkeypatch):
     with pytest.raises(HTTPException) as e2:
         asyncio.run(toolbox._list_tools("b-1", "u", "user"))
     assert e2.value.status_code == 502 and "Upstream" in e2.value.detail["code"]
+
+
+_OPENAI_NAME_RE = __import__("re").compile(r"^[a-zA-Z0-9_-]{1,64}$")
+
+
+def test_agent_as_tool_name_is_openai_legal():
+    # Chinese agent name: must not leak non-ASCII into the tool name (the bug —
+    # `agent_语义理解` 400s the model every call). The derived form keeps the
+    # ASCII `agent_` prefix, so it stays legal without hitting the id fallback.
+    n = _derive_agent_tool_name({}, "语义理解", "abcdef123456")
+    assert _OPENAI_NAME_RE.match(n), n
+    assert "语" not in n
+
+    # Over-long name is truncated to 64.
+    assert len(_derive_agent_tool_name({}, "a" * 200, "x")) == 64
+
+    # An ASCII agent name stays readable.
+    assert _derive_agent_tool_name({}, "translator", "x") == "agent_translator"
+
+    # An explicit AgentToolRef.name wins but is still sanitized/bounded; an
+    # all-non-ASCII explicit name (no `agent_` prefix) hits the id fallback.
+    assert _derive_agent_tool_name({"name": "我的工具"}, "translator", "abcdef1234") == "tool_abcdef12"
+    assert _derive_agent_tool_name({"name": "my_tool"}, "translator", "x") == "my_tool"
+    assert _OPENAI_NAME_RE.match(_derive_agent_tool_name({"name": "工具" * 40}, "x", "abcdef1234"))


### PR DESCRIPTION
Closes #251。

## 问题

`AgentSpec.name` 允许中文、最长 100 字符,但 OpenAI function name 只许 ASCII `[a-zA-Z0-9_-]` 且 ≤64。`tools.py:_agent_tool` 原样用 `f"agent_{sub_agent.name}"` 作工具名 → 引用「语义理解」的 task agent 生成 `agent_语义理解` → 模型在调用工具前**每次稳定 400**,引用方整个 chat/run 不可用。中文名是一等公民、agent-as-tool 是核心能力,触发面大。

## 修法

派生名(或 `AgentToolRef.name` 显式名)统一过 `toolbox._safe_name`——清洗非法字符、截断 64、全非 ASCII 兜底 `tool_{agent_id前缀}`。

- 派生形态保留 ASCII `agent_` 前缀 → 始终合法(`agent_语义理解` → `agent_____`)
- ASCII 名保留可读(`translator` → `agent_translator`)
- 显式全中文名走 id 兜底(`我的工具` → `tool_abcdef12`)
- 语义靠 description 传达

抽出纯函数 `_derive_agent_tool_name(ref, agent_name, agent_id)` 便于无 DB 单测。

## 测试

新增 `test_agent_as_tool_name_is_openai_legal`:中文名合法且不含非 ASCII、超长截断 64、ASCII 名可读、显式名净化边界。

> bkn-agent 单测需完整依赖环境跑(裸 runner 缺 aiohttp),CI 覆盖;本地 `py_compile` + 派生逻辑独立断言全过。

## 关联

- #251;PR #237 review 来源

🤖 Generated with [Claude Code](https://claude.com/claude-code)