### PR TITLE
fix(vega): use build keys for streaming tasks

### DIFF
--- a/adp/vega/vega-backend/server/logics/build_task/build_task_service.go
+++ b/adp/vega/vega-backend/server/logics/build_task/build_task_service.go
@@ -129,11 +129,9 @@ func (bts *buildTaskService) Create(ctx context.Context, req *interfaces.CreateB
 		span.SetStatus(codes.Error, "Invalid execute type")
 		return "", err
 	}
-	if req.Mode == interfaces.BuildTaskModeBatch {
-		if err := validateBatchBuildKeyFields(ctx, resource); err != nil {
-			span.SetStatus(codes.Error, "Invalid batch build key fields")
-			return "", err
-		}
+	if err := validateBuildKeyFields(ctx, resource); err != nil {
+		span.SetStatus(codes.Error, "Invalid build key fields")
+		return "", err
 	}
 
 	cat, err := bts.cs.GetByID(ctx, resource.CatalogID, false)
@@ -157,20 +155,6 @@ func (bts *buildTaskService) Create(ctx context.Context, req *interfaces.CreateB
 		return "", err
 	}
 
-	if req.Mode == interfaces.BuildTaskModeStreaming {
-		primaryKeys := []any{}
-		if resource.SourceMetadata != nil {
-			if v, ok := resource.SourceMetadata["primary_keys"]; ok {
-				primaryKeys = v.([]any)
-			}
-		}
-		if len(primaryKeys) == 0 {
-			span.SetStatus(codes.Error, "Resource has no primary key for build task")
-			return "", rest.NewHTTPError(ctx, http.StatusBadRequest, verrors.VegaBackend_BuildTask_InternalError_CreateFailed).
-				WithErrorDetails("Resource has no primary key")
-		}
-	}
-
 	buildTask, err := bts.newBuildTaskFromCreateRequest(ctx, resource, req)
 	if err != nil {
 		return "", err
@@ -192,10 +176,10 @@ func (bts *buildTaskService) Create(ctx context.Context, req *interfaces.CreateB
 	return buildTask.ID, nil
 }
 
-func validateBatchBuildKeyFields(ctx context.Context, resource *interfaces.Resource) error {
+func validateBuildKeyFields(ctx context.Context, resource *interfaces.Resource) error {
 	if resource.IndexConfig == nil || len(resource.IndexConfig.BuildKeyFields) == 0 {
 		return rest.NewHTTPError(ctx, http.StatusBadRequest, verrors.VegaBackend_BuildTask_InvalidParameter_BuildKeyFields).
-			WithErrorDetails("batch build task requires at least one build_key_fields entry")
+			WithErrorDetails("build task requires at least one build_key_fields entry")
 	}
 	return nil
 }

--- a/adp/vega/vega-backend/server/logics/build_task/build_task_service_test.go
+++ b/adp/vega/vega-backend/server/logics/build_task/build_task_service_test.go
@@ -141,6 +141,24 @@ func TestBuildTaskServiceCreateBuildTask(t *testing.T) {
 		httpErr := requireHTTPError(t, err, verrors.VegaBackend_BuildTask_InvalidParameter_BuildKeyFields)
 		assert.Equal(t, http.StatusBadRequest, httpErr.HTTPCode)
 	})
+	t.Run("rejects streaming task without build key fields", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		mockRS := mock_interfaces.NewMockResourceService(ctrl)
+		service := &buildTaskService{rs: mockRS}
+
+		mockRS.EXPECT().GetByID(gomock.Any(), "resource-1").Return(&interfaces.Resource{
+			ID:        "resource-1",
+			CatalogID: "catalog-1",
+			Category:  interfaces.ResourceCategoryTable,
+		}, nil)
+
+		_, err := service.Create(context.Background(), &interfaces.CreateBuildTaskRequest{
+			ResourceID: "resource-1",
+			Mode:       interfaces.BuildTaskModeStreaming,
+		})
+		httpErr := requireHTTPError(t, err, verrors.VegaBackend_BuildTask_InvalidParameter_BuildKeyFields)
+		assert.Equal(t, http.StatusBadRequest, httpErr.HTTPCode)
+	})
 
 	t.Run("rejects disabled catalog", func(t *testing.T) {
 		ctrl := gomock.NewController(t)
@@ -188,6 +206,40 @@ func TestBuildTaskServiceCreateBuildTask(t *testing.T) {
 		})
 
 		requireHTTPError(t, err, verrors.VegaBackend_BuildTask_Exist)
+	})
+	t.Run("allows streaming task with a build key and no physical primary key", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		mockCS := mock_interfaces.NewMockCatalogService(ctrl)
+		mockRS := mock_interfaces.NewMockResourceService(ctrl)
+		mockBTA := mock_interfaces.NewMockBuildTaskAccess(ctrl)
+		neutralizeEnqueue(t, ctrl)
+		service := &buildTaskService{
+			debugTaskQueue: make(chan *asynq.Task, 10),
+			cs:             mockCS,
+			rs:             mockRS,
+			bta:            mockBTA,
+		}
+
+		mockRS.EXPECT().GetByID(gomock.Any(), "resource-1").Return(&interfaces.Resource{
+			ID:        "resource-1",
+			CatalogID: "catalog-1",
+			Category:  interfaces.ResourceCategoryTable,
+			IndexConfig: &interfaces.ResourceIndexConfig{
+				BuildKeyFields: []string{"supplier_id"},
+			},
+			SchemaDefinition: []*interfaces.Property{{Name: "supplier_id"}},
+		}, nil)
+		mockCS.EXPECT().GetByID(gomock.Any(), "catalog-1", false).
+			Return(&interfaces.Catalog{ID: "catalog-1", Enabled: true}, nil)
+		mockBTA.EXPECT().List(gomock.Any(), gomock.Any()).Return(nil, int64(0), nil)
+		mockBTA.EXPECT().Create(gomock.Any(), gomock.Any()).Return(nil)
+
+		_, err := service.Create(context.Background(), &interfaces.CreateBuildTaskRequest{
+			ResourceID: "resource-1",
+			Mode:       interfaces.BuildTaskModeStreaming,
+		})
+
+		require.NoError(t, err)
 	})
 	t.Run("rejects execute type for streaming", func(t *testing.T) {
 		ctrl := gomock.NewController(t)


### PR DESCRIPTION
# Pull Request

## What Changed

Brief description of changes:

- [x] Vega：创建批量或流式构建任务时，统一校验资源索引配置的 `build_key_fields`。
- [x] Vega：移除流式任务创建阶段对 `source_metadata.primary_keys` 的硬性校验。
- [ ] Docs/doc 1（不适用：未变更对外 API 或配置。）

---

## Why

- Related Issue: studio-255
- Related Feature: N/A
- Background: 对没有数据库物理主键、但已配置构建键的资源，流式任务此前会在创建阶段被 `source_metadata.primary_keys` 校验拒绝。构建键属于资源索引配置，应作为创建任务的前置条件。

---

## How

- Key implementation points:
  - 将原本仅批量任务使用的构建键校验提升为所有构建任务共用的校验。
  - 缺少 `build_key_fields` 时，返回明确的参数错误与错误详情。
  - 新增回归测试：流式任务在无物理主键元数据、但已配置构建键时可进入正常创建流程；流式任务缺少构建键时仍被拒绝。
- Breaking changes (API, config, database, etc.): 无。

---

## Testing

- [x] Unit tests passed locally
- [ ] Integration tests passed locally（不适用：本次为无外部依赖的服务层逻辑与单元测试。）
- [ ] Verified in test environment（未执行。）

Test notes:

- `make ci` 通过（`golangci-lint run ./...`、全部单元测试、覆盖率检查）。

---

## Risk & Rollback

- Potential risks: 本 PR 只调整任务创建条件；流式执行期仍从 CDC 消息 key 计算文档 ID，尚未将其与 `build_key_fields` 绑定。
- Rollback plan: 回滚本 PR 即可恢复创建阶段的物理主键校验。

---

## Additional Notes

- PR 不包含工作区中未提交的 `server/config/vega-backend-config.yaml` 改动。