### PR TITLE
fix(agent-retrieval): query_object_instance 下游参数错误不再包成「依赖服务异常」 (#235)

### DIFF
--- a/adp/context-loader/agent-retrieval/server/drivenadapters/ontology_query.go
+++ b/adp/context-loader/agent-retrieval/server/drivenadapters/ontology_query.go
@@ -121,15 +121,20 @@ func (o *ontologyQueryClient) QueryObjectInstances(ctx context.Context, req *int
 	return
 }
 
-// classifyQueryError re-maps a downstream client error (4xx) from ontology-query
-// into a clean bad-request. The shared HTTP client flattens every non-2xx into
+// classifyQueryError re-classifies a downstream client error (4xx) from
+// ontology-query. The shared HTTP client flattens every non-2xx into
 // CommonExternalServerError ("调用依赖服务异常"), which mislabels a caller mistake
 // — most notably a knn condition on a non-vector string field
 // ("OntologyQuery.InvalidParameter.Condition: left field is not a vector field")
 // — as a dependency outage, so the caller cannot tell "my query is wrong" from
-// "the service is down". A 4xx is the caller's, so surface it as a 400 with the
-// downstream detail intact; a 5xx (or a transport error, which carries no HTTP
-// code) stays as-is.
+// "the service is down".
+//
+// A 4xx is the caller's, so re-map it away from the dependency-error class while
+// PRESERVING the downstream status code: a 400 stays a BadRequest, a 404 stays a
+// NotFound (e.g. an unknown kn_id/ot_id), a 403 a Forbidden — collapsing them all
+// to 400 would lose that distinction. The downstream detail is carried through so
+// the caller sees the actionable cause. A 5xx genuinely IS a dependency fault, so
+// it (and a transport error, which carries no HTTP code) stays as CommonExternalServerError.
 //
 // agent-retrieval deliberately does NOT pre-validate that a field is a vector
 // field before forwarding: a property's condition_operations list is declared
@@ -144,7 +149,7 @@ func classifyQueryError(ctx context.Context, err error) error {
 		if details == nil {
 			details = he.Error()
 		}
-		return infraErr.DefaultHTTPError(ctx, http.StatusBadRequest, details)
+		return infraErr.DefaultHTTPError(ctx, he.HTTPCode, details)
 	}
 	return err
 }

--- a/adp/context-loader/agent-retrieval/server/drivenadapters/ontology_query.go
+++ b/adp/context-loader/agent-retrieval/server/drivenadapters/ontology_query.go
@@ -9,6 +9,7 @@ package drivenadapters
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"net/url"
@@ -106,6 +107,7 @@ func (o *ontologyQueryClient) QueryObjectInstances(ctx context.Context, req *int
 	_, respBody, err := o.httpClient.Post(ctx, url, header, req)
 	if err != nil {
 		o.logger.WithContext(ctx).Warnf("[OntologyQuery#QueryObjectInstances] QueryObjectInstances request failed, err: %v", err)
+		err = classifyQueryError(ctx, err)
 		return
 	}
 	resp = &interfaces.QueryObjectInstancesResp{}
@@ -117,6 +119,34 @@ func (o *ontologyQueryClient) QueryObjectInstances(ctx context.Context, req *int
 		return
 	}
 	return
+}
+
+// classifyQueryError re-maps a downstream client error (4xx) from ontology-query
+// into a clean bad-request. The shared HTTP client flattens every non-2xx into
+// CommonExternalServerError ("调用依赖服务异常"), which mislabels a caller mistake
+// — most notably a knn condition on a non-vector string field
+// ("OntologyQuery.InvalidParameter.Condition: left field is not a vector field")
+// — as a dependency outage, so the caller cannot tell "my query is wrong" from
+// "the service is down". A 4xx is the caller's, so surface it as a 400 with the
+// downstream detail intact; a 5xx (or a transport error, which carries no HTTP
+// code) stays as-is.
+//
+// agent-retrieval deliberately does NOT pre-validate that a field is a vector
+// field before forwarding: a property's condition_operations list is declared
+// by the client at KN-build time and stored as-is (untrusted), so a field
+// marked "knn" may still not be backed by a vector mapping, and vice versa. The
+// downstream ontology-query verdict is the only authoritative signal, so the
+// fix is to surface it clearly rather than guess here.
+func classifyQueryError(ctx context.Context, err error) error {
+	var he *infraErr.HTTPError
+	if errors.As(err, &he) && he.HTTPCode >= http.StatusBadRequest && he.HTTPCode < http.StatusInternalServerError {
+		details := he.ErrorDetails
+		if details == nil {
+			details = he.Error()
+		}
+		return infraErr.DefaultHTTPError(ctx, http.StatusBadRequest, details)
+	}
+	return err
 }
 
 // QueryLogicProperties 查询逻辑属性值

--- a/adp/context-loader/agent-retrieval/server/drivenadapters/ontology_query_test.go
+++ b/adp/context-loader/agent-retrieval/server/drivenadapters/ontology_query_test.go
@@ -9,11 +9,15 @@ package drivenadapters
 import (
 	"context"
 	"errors"
+	"fmt"
+	"net/http"
+	"strings"
 	"testing"
 
 	"github.com/smartystreets/goconvey/convey"
 	"go.uber.org/mock/gomock"
 
+	infraErr "github.com/openbkn-ai/adp/context-loader/agent-retrieval/server/infra/errors"
 	"github.com/openbkn-ai/adp/context-loader/agent-retrieval/server/interfaces"
 	"github.com/openbkn-ai/adp/context-loader/agent-retrieval/server/mocks"
 )
@@ -318,5 +322,76 @@ func TestQueryInstanceSubgraph_HTTPError(t *testing.T) {
 
 		_, err := client.QueryInstanceSubgraph(ctx, req)
 		convey.So(err, convey.ShouldNotBeNil)
+	})
+}
+
+// TestQueryObjectInstances_DownstreamBadRequestRemappedToBadRequest 回归 #235:
+// 下游对非 vector 字段做 knn 时返回 4xx（"left field is not a vector field"）,
+// 共享 http client 把它拍成 CommonExternalServerError「依赖服务异常」。驱动层须
+// 把 4xx 重映射成 BadRequest 并保留下游 detail,让调用方看清是自己参数用错、不是
+// 服务故障。
+func TestQueryObjectInstances_DownstreamBadRequestRemappedToBadRequest(t *testing.T) {
+	convey.Convey("downstream 4xx -> BadRequest, detail preserved", t, func() {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		mockLogger := mocks.NewMockLogger(ctrl)
+		mockHTTPClient := mocks.NewMockHTTPClient(ctrl)
+		mockLogger.EXPECT().WithContext(gomock.Any()).Return(mockLogger).AnyTimes()
+		mockLogger.EXPECT().Warnf(gomock.Any(), gomock.Any()).AnyTimes()
+
+		client := &ontologyQueryClient{
+			logger:     mockLogger,
+			baseURL:    "http://localhost:8080/api/ontology-query",
+			httpClient: mockHTTPClient,
+		}
+		ctx := context.Background()
+		req := &interfaces.QueryObjectInstancesReq{KnID: "kn-001", OtID: "ot-001", Limit: 10}
+
+		// What the shared http client returns for a downstream 400: the raw
+		// ontology-query message flattened into CommonExternalServerError.
+		detail := "OntologyQuery.InvalidParameter.Condition: condition [knn] left field is not a vector field: child_name:string"
+		wrapped := infraErr.NewHTTPError(ctx, http.StatusBadRequest, infraErr.ErrExtCommonExternalServerError, detail)
+		mockHTTPClient.EXPECT().Post(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+			Return(http.StatusBadRequest, nil, wrapped)
+
+		_, err := client.QueryObjectInstances(ctx, req)
+		convey.So(err, convey.ShouldNotBeNil)
+
+		var he *infraErr.HTTPError
+		convey.So(errors.As(err, &he), convey.ShouldBeTrue)
+		convey.So(he.HTTPCode, convey.ShouldEqual, http.StatusBadRequest)
+		// No longer classified as a dependency outage.
+		convey.So(strings.Contains(he.Code, "CommonExternalServerError"), convey.ShouldBeFalse)
+		convey.So(strings.Contains(he.Code, "BadRequest"), convey.ShouldBeTrue)
+		// The actionable downstream cause survives so the caller can fix the query.
+		convey.So(strings.Contains(fmt.Sprintf("%v", he.ErrorDetails), "not a vector field"), convey.ShouldBeTrue)
+	})
+}
+
+// TestQueryObjectInstances_DownstreamServerErrorUntouched 下游 5xx（真服务故障）
+// 与传输错误(无 HTTP 码)保持原样,不误降为 400。
+func TestQueryObjectInstances_DownstreamServerErrorUntouched(t *testing.T) {
+	convey.Convey("downstream 5xx stays as-is", t, func() {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		mockLogger := mocks.NewMockLogger(ctrl)
+		mockHTTPClient := mocks.NewMockHTTPClient(ctrl)
+		mockLogger.EXPECT().WithContext(gomock.Any()).Return(mockLogger).AnyTimes()
+		mockLogger.EXPECT().Warnf(gomock.Any(), gomock.Any()).AnyTimes()
+
+		client := &ontologyQueryClient{logger: mockLogger, baseURL: "http://x", httpClient: mockHTTPClient}
+		ctx := context.Background()
+		req := &interfaces.QueryObjectInstancesReq{KnID: "kn-001", OtID: "ot-001", Limit: 10}
+
+		wrapped := infraErr.NewHTTPError(ctx, http.StatusInternalServerError, infraErr.ErrExtCommonExternalServerError, "boom")
+		mockHTTPClient.EXPECT().Post(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+			Return(http.StatusInternalServerError, nil, wrapped)
+
+		_, err := client.QueryObjectInstances(ctx, req)
+		var he *infraErr.HTTPError
+		convey.So(errors.As(err, &he), convey.ShouldBeTrue)
+		convey.So(he.HTTPCode, convey.ShouldEqual, http.StatusInternalServerError)
 	})
 }

--- a/adp/context-loader/agent-retrieval/server/drivenadapters/ontology_query_test.go
+++ b/adp/context-loader/agent-retrieval/server/drivenadapters/ontology_query_test.go
@@ -369,6 +369,35 @@ func TestQueryObjectInstances_DownstreamBadRequestRemappedToBadRequest(t *testin
 	})
 }
 
+// TestQueryObjectInstances_DownstreamNotFoundKeepsCode 下游 404（如 kn_id/ot_id
+// 不存在）须保留 404 语义,不被压成 400「参数错误」。
+func TestQueryObjectInstances_DownstreamNotFoundKeepsCode(t *testing.T) {
+	convey.Convey("downstream 404 stays NotFound, not collapsed to 400", t, func() {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		mockLogger := mocks.NewMockLogger(ctrl)
+		mockHTTPClient := mocks.NewMockHTTPClient(ctrl)
+		mockLogger.EXPECT().WithContext(gomock.Any()).Return(mockLogger).AnyTimes()
+		mockLogger.EXPECT().Warnf(gomock.Any(), gomock.Any()).AnyTimes()
+
+		client := &ontologyQueryClient{logger: mockLogger, baseURL: "http://x", httpClient: mockHTTPClient}
+		ctx := context.Background()
+		req := &interfaces.QueryObjectInstancesReq{KnID: "missing", OtID: "ot-001", Limit: 10}
+
+		wrapped := infraErr.NewHTTPError(ctx, http.StatusNotFound, infraErr.ErrExtCommonExternalServerError, "knowledge network not found")
+		mockHTTPClient.EXPECT().Post(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+			Return(http.StatusNotFound, nil, wrapped)
+
+		_, err := client.QueryObjectInstances(ctx, req)
+		var he *infraErr.HTTPError
+		convey.So(errors.As(err, &he), convey.ShouldBeTrue)
+		convey.So(he.HTTPCode, convey.ShouldEqual, http.StatusNotFound)
+		convey.So(strings.Contains(he.Code, "NotFound"), convey.ShouldBeTrue)
+		convey.So(strings.Contains(he.Code, "CommonExternalServerError"), convey.ShouldBeFalse)
+	})
+}
+
 // TestQueryObjectInstances_DownstreamServerErrorUntouched 下游 5xx（真服务故障）
 // 与传输错误(无 HTTP 码)保持原样,不误降为 400。
 func TestQueryObjectInstances_DownstreamServerErrorUntouched(t *testing.T) {


### PR DESCRIPTION
Closes #235。

## 问题

对非 vector 的 string 字段做 `knn` 查询,下游 ontology-query 返回 4xx:
```
OntologyQuery.InvalidParameter.Condition: condition [knn] left field is not a vector field: child_name:string
```
但共享 http client 把**所有**非 2xx 一律拍成 `CommonExternalServerError`「调用依赖服务异常」——把调用方参数错误误判成服务故障,真实原因埋没。

## 方案(只做错误分类,不做预校验)

`QueryObjectInstances` 拿到错误后经 `classifyQueryError`:
- 下游 **4xx(客户端错)→ BadRequest** + 保留下游 detail
- **5xx / 传输错误(无 HTTP 码)→ 原样透传**

局部在 query 路径处理,**不动全服务共享的 http client**(改它会波及所有下游调用)。

## 为什么不预校验字段是否 vector

刻意不在 agent-retrieval 侧判「字段是不是 vector」:属性的 `condition_operations` 是**建网时客户端声明、原样落库(不可信)**,标了 `knn` 也可能没有 vector mapping,反之亦然。下游 ontology-query 的裁决才是唯一权威信号——清晰透出即是修法。(见 issue #235 讨论 + `knn 白名单不可信`。)

## 测试

- 下游 400 → `BadRequest`,Code 不含 `CommonExternalServerError`,detail 保留「not a vector field」
- 下游 500 → 保持 500 不误降
- `go build ./...` + `go test ./drivenadapters/` 全绿

## 关联

- #235;#272 A/B 评测框架前置(错误分类不清会污染失败归因)

🤖 Generated with [Claude Code](https://claude.com/claude-code)