### PR TITLE
fix(vega): validate analyzers before build

### DIFF
--- a/adp/vega/vega-backend/server/errors/build_task.go
+++ b/adp/vega/vega-backend/server/errors/build_task.go
@@ -17,6 +17,7 @@ const (
 	VegaBackend_BuildTask_InvalidParameter_ResourceID     = "VegaBackend.BuildTask.InvalidParameter.ResourceID"
 	VegaBackend_BuildTask_InvalidParameter_Mode           = "VegaBackend.BuildTask.InvalidParameter.Mode"
 	VegaBackend_BuildTask_InvalidParameter_BuildKeyFields = "VegaBackend.BuildTask.InvalidParameter.BuildKeyFields"
+	VegaBackend_BuildTask_InvalidParameter_Analyzer       = "VegaBackend.BuildTask.InvalidParameter.Analyzer"
 
 	// 404 Not Found
 	VegaBackend_BuildTask_NotFound = "VegaBackend.BuildTask.NotFound"
@@ -43,6 +44,7 @@ var BuildTaskErrCodeList = []string{
 	VegaBackend_BuildTask_InvalidParameter_ResourceID,
 	VegaBackend_BuildTask_InvalidParameter_Mode,
 	VegaBackend_BuildTask_InvalidParameter_BuildKeyFields,
+	VegaBackend_BuildTask_InvalidParameter_Analyzer,
 
 	// 404 Not Found
 	VegaBackend_BuildTask_NotFound,

--- a/adp/vega/vega-backend/server/errors/build_task.go
+++ b/adp/vega/vega-backend/server/errors/build_task.go
@@ -28,11 +28,12 @@ const (
 	VegaBackend_BuildTask_ActiveIndexInUse       = "VegaBackend.BuildTask.ActiveIndexInUse"
 
 	// 500 Internal Server Error
-	VegaBackend_BuildTask_InternalError_CreateFailed          = "VegaBackend.BuildTask.InternalError.CreateFailed"
-	VegaBackend_BuildTask_InternalError_GetFailed             = "VegaBackend.BuildTask.InternalError.GetFailed"
-	VegaBackend_BuildTask_InternalError_UpdateFailed          = "VegaBackend.BuildTask.InternalError.UpdateFailed"
-	VegaBackend_BuildTask_InternalError_DeleteFailed          = "VegaBackend.BuildTask.InternalError.DeleteFailed"
-	VegaBackend_BuildTask_InternalError_GetAccountNamesFailed = "VegaBackend.BuildTask.InternalError.GetAccountNamesFailed"
+	VegaBackend_BuildTask_InternalError_CreateFailed           = "VegaBackend.BuildTask.InternalError.CreateFailed"
+	VegaBackend_BuildTask_InternalError_GetFailed              = "VegaBackend.BuildTask.InternalError.GetFailed"
+	VegaBackend_BuildTask_InternalError_UpdateFailed           = "VegaBackend.BuildTask.InternalError.UpdateFailed"
+	VegaBackend_BuildTask_InternalError_DeleteFailed           = "VegaBackend.BuildTask.InternalError.DeleteFailed"
+	VegaBackend_BuildTask_InternalError_GetAccountNamesFailed  = "VegaBackend.BuildTask.InternalError.GetAccountNamesFailed"
+	VegaBackend_BuildTask_InternalError_ValidateAnalyzerFailed = "VegaBackend.BuildTask.InternalError.ValidateAnalyzerFailed"
 )
 
 var BuildTaskErrCodeList = []string{
@@ -60,4 +61,5 @@ var BuildTaskErrCodeList = []string{
 	VegaBackend_BuildTask_InternalError_UpdateFailed,
 	VegaBackend_BuildTask_InternalError_DeleteFailed,
 	VegaBackend_BuildTask_InternalError_GetAccountNamesFailed,
+	VegaBackend_BuildTask_InternalError_ValidateAnalyzerFailed,
 }

--- a/adp/vega/vega-backend/server/interfaces/connector_interface.go
+++ b/adp/vega/vega-backend/server/interfaces/connector_interface.go
@@ -103,6 +103,7 @@ type IndexConnector interface {
 	Update(ctx context.Context, name string, schemaDefinition []*Property) error
 	Delete(ctx context.Context, name string) error
 	CheckExist(ctx context.Context, name string) (bool, error)
+	ValidateAnalyzers(ctx context.Context, analyzers map[string]string) error
 	CreateDocuments(ctx context.Context, name string, documents []map[string]any) ([]string, error)
 	GetDocument(ctx context.Context, name string, docID string) (map[string]any, error)
 	DeleteDocument(ctx context.Context, name string, docID string) error

--- a/adp/vega/vega-backend/server/interfaces/connector_interface.go
+++ b/adp/vega/vega-backend/server/interfaces/connector_interface.go
@@ -6,7 +6,23 @@
 
 package interfaces
 
-import "context"
+import (
+	"context"
+	"fmt"
+	"strings"
+)
+
+// AnalyzerUnavailableError indicates that OpenSearch accepted the validation
+// request but could not resolve the configured analyzer.
+type AnalyzerUnavailableError struct {
+	Analyzer string
+	Fields   []string
+	Detail   string
+}
+
+func (e *AnalyzerUnavailableError) Error() string {
+	return fmt.Sprintf("analyzer %q for fields %q is unavailable: %s", e.Analyzer, strings.Join(e.Fields, ", "), e.Detail)
+}
 
 //go:generate mockgen -source ../interfaces/connector_interface.go -destination ../interfaces/mock/mock_connector_interface.go
 

--- a/adp/vega/vega-backend/server/interfaces/local_index_manager.go
+++ b/adp/vega/vega-backend/server/interfaces/local_index_manager.go
@@ -16,6 +16,7 @@ type LocalIndexManager interface {
 	UpdateIndex(ctx context.Context, indexName string, schema []*Property) error
 	DeleteIndex(ctx context.Context, indexName string) error
 	CheckExist(ctx context.Context, indexName string) (bool, error)
+	ValidateAnalyzers(ctx context.Context, analyzers map[string]string) error
 
 	ListDocuments(ctx context.Context, indexName string, res *Resource, params *ResourceDataQueryParams) ([]map[string]any, int64, error)
 	GetDocument(ctx context.Context, indexName string, docID string) (map[string]any, error)

--- a/adp/vega/vega-backend/server/interfaces/mock/mock_connector_interface.go
+++ b/adp/vega/vega-backend/server/interfaces/mock/mock_connector_interface.go
@@ -1877,6 +1877,20 @@ func (mr *MockIndexConnectorMockRecorder) UpsertDocuments(ctx, name, updateReque
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpsertDocuments", reflect.TypeOf((*MockIndexConnector)(nil).UpsertDocuments), ctx, name, updateRequests)
 }
 
+// ValidateAnalyzers mocks base method.
+func (m *MockIndexConnector) ValidateAnalyzers(ctx context.Context, analyzers map[string]string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ValidateAnalyzers", ctx, analyzers)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// ValidateAnalyzers indicates an expected call of ValidateAnalyzers.
+func (mr *MockIndexConnectorMockRecorder) ValidateAnalyzers(ctx, analyzers any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ValidateAnalyzers", reflect.TypeOf((*MockIndexConnector)(nil).ValidateAnalyzers), ctx, analyzers)
+}
+
 // MockAPIConnector is a mock of APIConnector interface.
 type MockAPIConnector struct {
 	ctrl     *gomock.Controller

--- a/adp/vega/vega-backend/server/interfaces/mock/mock_local_index_manager.go
+++ b/adp/vega/vega-backend/server/interfaces/mock/mock_local_index_manager.go
@@ -200,3 +200,17 @@ func (mr *MockLocalIndexManagerMockRecorder) UpsertDocuments(ctx, indexName, upd
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpsertDocuments", reflect.TypeOf((*MockLocalIndexManager)(nil).UpsertDocuments), ctx, indexName, updateRequests)
 }
+
+// ValidateAnalyzers mocks base method.
+func (m *MockLocalIndexManager) ValidateAnalyzers(ctx context.Context, analyzers map[string]string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ValidateAnalyzers", ctx, analyzers)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// ValidateAnalyzers indicates an expected call of ValidateAnalyzers.
+func (mr *MockLocalIndexManagerMockRecorder) ValidateAnalyzers(ctx, analyzers any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ValidateAnalyzers", reflect.TypeOf((*MockLocalIndexManager)(nil).ValidateAnalyzers), ctx, analyzers)
+}

--- a/adp/vega/vega-backend/server/locale/build_task.en-US.toml
+++ b/adp/vega/vega-backend/server/locale/build_task.en-US.toml
@@ -43,6 +43,11 @@ Description = "Failed to create build task"
 Solution = "Please contact the administrator"
 ErrorLink = "No solution"
 
+[VegaBackend.BuildTask.InternalError.ValidateAnalyzerFailed]
+Description = "Failed to validate full-text analyzer"
+Solution = "Check the OpenSearch connection and try again"
+ErrorLink = "No solution"
+
 [VegaBackend.BuildTask.InternalError.GetFailed]
 Description = "Failed to get build task"
 Solution = "Please contact the administrator"

--- a/adp/vega/vega-backend/server/locale/build_task.en-US.toml
+++ b/adp/vega/vega-backend/server/locale/build_task.en-US.toml
@@ -18,6 +18,11 @@ Description = "Invalid batch build key fields"
 Solution = "Configure at least one build_key_fields field from the resource schema in index_config"
 ErrorLink = "No solution"
 
+[VegaBackend.BuildTask.InvalidParameter.Analyzer]
+Description = "Unavailable full-text analyzer"
+Solution = "Choose an analyzer installed in OpenSearch, or update the affected field to use the resource default"
+ErrorLink = "No solution"
+
 [VegaBackend.BuildTask.InvalidStateTransition]
 Description = "Invalid build task state transition"
 Solution = "Check current task status; start requires status in {init, stopped}; stop requires status == running"

--- a/adp/vega/vega-backend/server/locale/build_task.zh-CN.toml
+++ b/adp/vega/vega-backend/server/locale/build_task.zh-CN.toml
@@ -18,6 +18,11 @@ Description = "批量构建键无效"
 Solution = "请在资源 index_config 中配置至少一个存在于 schema 的 build_key_fields 字段"
 ErrorLink = "暂无"
 
+[VegaBackend.BuildTask.InvalidParameter.Analyzer]
+Description = "全文分词器不可用"
+Solution = "请选择 OpenSearch 已安装的分词器，或将受影响字段改为使用资源默认分词器"
+ErrorLink = "暂无"
+
 [VegaBackend.BuildTask.InvalidStateTransition]
 Description = "构建任务状态转移非法"
 Solution = "检查当前状态；start 要求 status 为 init 或 stopped；stop 要求 status 为 running"

--- a/adp/vega/vega-backend/server/locale/build_task.zh-CN.toml
+++ b/adp/vega/vega-backend/server/locale/build_task.zh-CN.toml
@@ -43,6 +43,11 @@ Description = "创建构建任务失败"
 Solution = "请联系管理员"
 ErrorLink = "暂无"
 
+[VegaBackend.BuildTask.InternalError.ValidateAnalyzerFailed]
+Description = "校验全文分词器失败"
+Solution = "请检查 OpenSearch 连接后重试"
+ErrorLink = "暂无"
+
 [VegaBackend.BuildTask.InternalError.GetFailed]
 Description = "获取构建任务失败"
 Solution = "请联系管理员"

--- a/adp/vega/vega-backend/server/logics/build_task/build_task_service.go
+++ b/adp/vega/vega-backend/server/logics/build_task/build_task_service.go
@@ -197,7 +197,12 @@ func validateBuildTaskAnalyzers(ctx context.Context, indexManager interfaces.Loc
 		return nil
 	}
 	if err := indexManager.ValidateAnalyzers(ctx, analyzers); err != nil {
-		return rest.NewHTTPError(ctx, http.StatusBadRequest, verrors.VegaBackend_BuildTask_InvalidParameter_Analyzer).
+		var unavailableErr *interfaces.AnalyzerUnavailableError
+		if errors.As(err, &unavailableErr) {
+			return rest.NewHTTPError(ctx, http.StatusBadRequest, verrors.VegaBackend_BuildTask_InvalidParameter_Analyzer).
+				WithErrorDetails(unavailableErr.Error())
+		}
+		return rest.NewHTTPError(ctx, http.StatusInternalServerError, verrors.VegaBackend_BuildTask_InternalError_ValidateAnalyzerFailed).
 			WithErrorDetails(err.Error())
 	}
 	return nil

--- a/adp/vega/vega-backend/server/logics/build_task/build_task_service.go
+++ b/adp/vega/vega-backend/server/logics/build_task/build_task_service.go
@@ -159,6 +159,10 @@ func (bts *buildTaskService) Create(ctx context.Context, req *interfaces.CreateB
 	if err != nil {
 		return "", err
 	}
+	if err := validateBuildTaskAnalyzers(ctx, bts.lim, buildTask); err != nil {
+		span.SetStatus(codes.Error, "Invalid fulltext analyzer")
+		return "", err
+	}
 
 	if err := bts.bta.Create(ctx, buildTask); err != nil {
 		otellog.LogError(ctx, "Create build task failed", err)
@@ -174,6 +178,29 @@ func (bts *buildTaskService) Create(ctx context.Context, req *interfaces.CreateB
 
 	span.SetStatus(codes.Ok, "")
 	return buildTask.ID, nil
+}
+
+func validateBuildTaskAnalyzers(ctx context.Context, indexManager interfaces.LocalIndexManager, buildTask *interfaces.BuildTask) error {
+	if indexManager == nil {
+		return nil
+	}
+	analyzers := map[string]string{}
+	if buildTask == nil || buildTask.IndexConfig == nil {
+		return nil
+	}
+	for field, feature := range buildTask.IndexConfig.Features {
+		if feature.Fulltext != nil && strings.TrimSpace(feature.Fulltext.Analyzer) != "" {
+			analyzers[field] = feature.Fulltext.Analyzer
+		}
+	}
+	if len(analyzers) == 0 {
+		return nil
+	}
+	if err := indexManager.ValidateAnalyzers(ctx, analyzers); err != nil {
+		return rest.NewHTTPError(ctx, http.StatusBadRequest, verrors.VegaBackend_BuildTask_InvalidParameter_Analyzer).
+			WithErrorDetails(err.Error())
+	}
+	return nil
 }
 
 func validateBuildKeyFields(ctx context.Context, resource *interfaces.Resource) error {

--- a/adp/vega/vega-backend/server/logics/build_task/build_task_service.go
+++ b/adp/vega/vega-backend/server/logics/build_task/build_task_service.go
@@ -694,6 +694,10 @@ func (bts *buildTaskService) Start(ctx context.Context, taskID string, reset boo
 		span.SetStatus(codes.Error, "Build task is no longer current")
 		return err
 	}
+	if err := validateBuildTaskAnalyzers(ctx, bts.lim, buildTask); err != nil {
+		span.SetStatus(codes.Error, "Invalid fulltext analyzer")
+		return err
+	}
 
 	// 入队前先置回 init：worker 出队时会跳过 stopped/stopping 的任务
 	// （防止排队中被停止的任务复活），stopped 状态直接入队会被误跳过。

--- a/adp/vega/vega-backend/server/logics/build_task/build_task_service_test.go
+++ b/adp/vega/vega-backend/server/logics/build_task/build_task_service_test.go
@@ -25,6 +25,54 @@ import (
 	"vega-backend/logics"
 )
 
+type analyzerValidatingIndexManager struct {
+	interfaces.LocalIndexManager
+	err      error
+	captured map[string]string
+}
+
+func (m *analyzerValidatingIndexManager) ValidateAnalyzers(_ context.Context, analyzers map[string]string) error {
+	m.captured = analyzers
+	return m.err
+}
+
+func TestBuildTaskServiceRejectsUnavailableFieldAnalyzerBeforePersistence(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	mockCS := mock_interfaces.NewMockCatalogService(ctrl)
+	mockRS := mock_interfaces.NewMockResourceService(ctrl)
+	mockBTA := mock_interfaces.NewMockBuildTaskAccess(ctrl)
+	validator := &analyzerValidatingIndexManager{err: errors.New("analyzer \"hanlp_index\" for field \"status\" is unavailable")}
+	service := &buildTaskService{
+		bta:            mockBTA,
+		cs:             mockCS,
+		debugTaskQueue: make(chan *asynq.Task, 1),
+		lim:            validator,
+		rs:             mockRS,
+	}
+
+	mockRS.EXPECT().GetByID(gomock.Any(), "resource-1").Return(&interfaces.Resource{
+		ID:        "resource-1",
+		CatalogID: "catalog-1",
+		Category:  interfaces.ResourceCategoryTable,
+		IndexConfig: &interfaces.ResourceIndexConfig{
+			BuildKeyFields:          []string{"id"},
+			DefaultFulltextAnalyzer: "standard",
+		},
+		SchemaDefinition: []*interfaces.Property{
+			{Name: "id"},
+			{Name: "coupon_code", Features: []interfaces.PropertyFeature{{FeatureType: interfaces.PropertyFeatureType_Fulltext, Config: map[string]any{"analyzer": "standard"}}}},
+			{Name: "status", Features: []interfaces.PropertyFeature{{FeatureType: interfaces.PropertyFeatureType_Fulltext, Config: map[string]any{"analyzer": "hanlp_index"}}}},
+		},
+	}, nil)
+	mockCS.EXPECT().GetByID(gomock.Any(), "catalog-1", false).Return(&interfaces.Catalog{ID: "catalog-1", Enabled: true}, nil)
+	mockBTA.EXPECT().List(gomock.Any(), gomock.Any()).Return(nil, int64(0), nil)
+
+	_, err := service.Create(context.Background(), &interfaces.CreateBuildTaskRequest{ResourceID: "resource-1", Mode: interfaces.BuildTaskModeBatch})
+	httpErr := requireHTTPError(t, err, verrors.VegaBackend_BuildTask_InvalidParameter_Analyzer)
+	assert.Contains(t, httpErr.BaseError.ErrorDetails, "status")
+	assert.Equal(t, map[string]string{"coupon_code": "standard", "status": "hanlp_index"}, validator.captured)
+}
+
 func TestBuildTaskServicePopulatesTaskReferencesForListAndGet(t *testing.T) {
 	t.Run("list populates only referenced resources and catalogs", func(t *testing.T) {
 		ctrl := gomock.NewController(t)

--- a/adp/vega/vega-backend/server/logics/build_task/build_task_service_test.go
+++ b/adp/vega/vega-backend/server/logics/build_task/build_task_service_test.go
@@ -41,7 +41,11 @@ func TestBuildTaskServiceRejectsUnavailableFieldAnalyzerBeforePersistence(t *tes
 	mockCS := mock_interfaces.NewMockCatalogService(ctrl)
 	mockRS := mock_interfaces.NewMockResourceService(ctrl)
 	mockBTA := mock_interfaces.NewMockBuildTaskAccess(ctrl)
-	validator := &analyzerValidatingIndexManager{err: errors.New("analyzer \"hanlp_index\" for field \"status\" is unavailable")}
+	validator := &analyzerValidatingIndexManager{err: &interfaces.AnalyzerUnavailableError{
+		Analyzer: "hanlp_index",
+		Fields:   []string{"status"},
+		Detail:   "analyzer not found",
+	}}
 	service := &buildTaskService{
 		bta:            mockBTA,
 		cs:             mockCS,
@@ -71,6 +75,19 @@ func TestBuildTaskServiceRejectsUnavailableFieldAnalyzerBeforePersistence(t *tes
 	httpErr := requireHTTPError(t, err, verrors.VegaBackend_BuildTask_InvalidParameter_Analyzer)
 	assert.Contains(t, httpErr.BaseError.ErrorDetails, "status")
 	assert.Equal(t, map[string]string{"coupon_code": "standard", "status": "hanlp_index"}, validator.captured)
+}
+
+func TestValidateBuildTaskAnalyzersReturnsInternalErrorForTransportFailure(t *testing.T) {
+	validator := &analyzerValidatingIndexManager{err: errors.New("connect OpenSearch: connection refused")}
+	buildTask := &interfaces.BuildTask{IndexConfig: &interfaces.BuildTaskIndexConfig{
+		Features: map[string]interfaces.BuildTaskFieldIndexFeature{
+			"status": {Fulltext: &interfaces.BuildTaskFulltextConfig{Analyzer: "hanlp_index"}},
+		},
+	}}
+
+	err := validateBuildTaskAnalyzers(context.Background(), validator, buildTask)
+	httpErr := requireHTTPError(t, err, verrors.VegaBackend_BuildTask_InternalError_ValidateAnalyzerFailed)
+	assert.Equal(t, http.StatusInternalServerError, httpErr.HTTPCode)
 }
 
 func TestBuildTaskServicePopulatesTaskReferencesForListAndGet(t *testing.T) {

--- a/adp/vega/vega-backend/server/logics/build_task/build_task_service_test.go
+++ b/adp/vega/vega-backend/server/logics/build_task/build_task_service_test.go
@@ -882,6 +882,65 @@ func TestBuildTaskServiceStartBuildTask(t *testing.T) {
 
 		require.NoError(t, service.Start(context.Background(), "task-1", false))
 	})
+	t.Run("rejects unavailable analyzer before updating status or enqueueing", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		mockCS := mock_interfaces.NewMockCatalogService(ctrl)
+		mockRS := mock_interfaces.NewMockResourceService(ctrl)
+		mockBTA := mock_interfaces.NewMockBuildTaskAccess(ctrl)
+		validator := &analyzerValidatingIndexManager{err: &interfaces.AnalyzerUnavailableError{
+			Analyzer: "hanlp_index",
+			Fields:   []string{"status"},
+			Detail:   "analyzer not found",
+		}}
+		service := &buildTaskService{
+			debugTaskQueue: make(chan *asynq.Task, 10),
+			bta:            mockBTA,
+			cs:             mockCS,
+			lim:            validator,
+			rs:             mockRS,
+		}
+		task := &interfaces.BuildTask{
+			ID:         "task-1",
+			ResourceID: "resource-1",
+			CatalogID:  "catalog-1",
+			Status:     interfaces.BuildTaskStatusStopped,
+			IndexConfig: &interfaces.BuildTaskIndexConfig{Features: map[string]interfaces.BuildTaskFieldIndexFeature{
+				"status": {Fulltext: &interfaces.BuildTaskFulltextConfig{Analyzer: "hanlp_index"}},
+			}},
+		}
+		mockBTA.EXPECT().GetByID(gomock.Any(), "task-1").Return(task, nil)
+		mockCS.EXPECT().GetByID(gomock.Any(), "catalog-1", false).
+			Return(&interfaces.Catalog{ID: "catalog-1", Enabled: true}, nil)
+		mockBTA.EXPECT().List(gomock.Any(), gomock.Any()).
+			DoAndReturn(func(_ context.Context, params interfaces.BuildTasksQueryParams) ([]*interfaces.BuildTask, int64, error) {
+				if len(params.Statuses) == 1 && params.Statuses[0] == interfaces.BuildTaskStatusCompleted {
+					return nil, int64(0), nil
+				}
+				return nil, int64(0), nil
+			}).Times(2)
+		mockRS.EXPECT().GetByID(gomock.Any(), "resource-1").Return(&interfaces.Resource{
+			ID:        "resource-1",
+			CatalogID: "catalog-1",
+			SchemaDefinition: []*interfaces.Property{{
+				Name: "status",
+				Features: []interfaces.PropertyFeature{{
+					FeatureType: interfaces.PropertyFeatureType_Fulltext,
+					Config:      map[string]any{"analyzer": "hanlp_index"},
+				}},
+			}},
+		}, nil)
+
+		err := service.Start(context.Background(), "task-1", false)
+		httpErr := requireHTTPError(t, err, verrors.VegaBackend_BuildTask_InvalidParameter_Analyzer)
+		assert.Equal(t, http.StatusBadRequest, httpErr.HTTPCode)
+		assert.Contains(t, httpErr.BaseError.ErrorDetails, "status")
+		assert.Equal(t, map[string]string{"status": "hanlp_index"}, validator.captured)
+		select {
+		case queued := <-service.DebugTaskQueue():
+			t.Fatalf("expected no queued task, got %s", queued.Type())
+		default:
+		}
+	})
 }
 
 func assertCatalogDisabledError(t *testing.T, err error) {

--- a/adp/vega/vega-backend/server/logics/connector/local/index/opensearch/opensearch.go
+++ b/adp/vega/vega-backend/server/logics/connector/local/index/opensearch/opensearch.go
@@ -11,6 +11,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"sort"
 	"strings"
 
 	"github.com/bytedance/sonic"
@@ -34,6 +35,49 @@ type OpenSearchConnector struct {
 	enabled bool
 	Config  *opensearchConfig
 	client  *opensearch.Client
+}
+
+// ValidateAnalyzers verifies that each field's configured analyzer is available
+// in the connected OpenSearch cluster before a build task is persisted.
+func (c *OpenSearchConnector) ValidateAnalyzers(ctx context.Context, analyzers map[string]string) error {
+	if err := c.Connect(ctx); err != nil {
+		return err
+	}
+
+	analyzerFields := map[string][]string{}
+	for field, configuredAnalyzer := range analyzers {
+		analyzer := strings.TrimSpace(configuredAnalyzer)
+		if analyzer != "" {
+			analyzerFields[analyzer] = append(analyzerFields[analyzer], field)
+		}
+	}
+	analyzerNames := make([]string, 0, len(analyzerFields))
+	for analyzer := range analyzerFields {
+		analyzerNames = append(analyzerNames, analyzer)
+	}
+	sort.Strings(analyzerNames)
+	for _, analyzer := range analyzerNames {
+		fields := analyzerFields[analyzer]
+		sort.Strings(fields)
+		body, err := sonic.Marshal(map[string]any{"analyzer": analyzer, "text": "bkn"})
+		if err != nil {
+			return fmt.Errorf("marshal analyzer validation request: %w", err)
+		}
+		resp, err := c.client.Indices.Analyze(
+			c.client.Indices.Analyze.WithContext(ctx),
+			c.client.Indices.Analyze.WithBody(bytes.NewReader(body)),
+		)
+		if err != nil {
+			return fmt.Errorf("validate analyzer %q for fields %q: %w", analyzer, strings.Join(fields, ", "), err)
+		}
+		if resp.IsError() {
+			detail := resp.String()
+			_ = resp.Body.Close()
+			return fmt.Errorf("analyzer %q for fields %q is unavailable: %s", analyzer, strings.Join(fields, ", "), detail)
+		}
+		_ = resp.Body.Close()
+	}
+	return nil
 }
 
 // NewOpenSearchConnector 创建 OpenSearch connector 构建器

--- a/adp/vega/vega-backend/server/logics/connector/local/index/opensearch/opensearch.go
+++ b/adp/vega/vega-backend/server/logics/connector/local/index/opensearch/opensearch.go
@@ -73,7 +73,11 @@ func (c *OpenSearchConnector) ValidateAnalyzers(ctx context.Context, analyzers m
 		if resp.IsError() {
 			detail := resp.String()
 			_ = resp.Body.Close()
-			return fmt.Errorf("analyzer %q for fields %q is unavailable: %s", analyzer, strings.Join(fields, ", "), detail)
+			return &interfaces.AnalyzerUnavailableError{
+				Analyzer: analyzer,
+				Fields:   fields,
+				Detail:   detail,
+			}
 		}
 		_ = resp.Body.Close()
 	}

--- a/adp/vega/vega-backend/server/logics/connector/local/index/opensearch/opensearch.go
+++ b/adp/vega/vega-backend/server/logics/connector/local/index/opensearch/opensearch.go
@@ -11,6 +11,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"net/http"
 	"sort"
 	"strings"
 
@@ -70,7 +71,7 @@ func (c *OpenSearchConnector) ValidateAnalyzers(ctx context.Context, analyzers m
 		if err != nil {
 			return fmt.Errorf("validate analyzer %q for fields %q: %w", analyzer, strings.Join(fields, ", "), err)
 		}
-		if resp.IsError() {
+		if resp.StatusCode == http.StatusBadRequest {
 			detail := resp.String()
 			_ = resp.Body.Close()
 			return &interfaces.AnalyzerUnavailableError{
@@ -78,6 +79,11 @@ func (c *OpenSearchConnector) ValidateAnalyzers(ctx context.Context, analyzers m
 				Fields:   fields,
 				Detail:   detail,
 			}
+		}
+		if resp.IsError() {
+			detail := resp.String()
+			_ = resp.Body.Close()
+			return fmt.Errorf("validate analyzer %q for fields %q: OpenSearch returned %s: %s", analyzer, strings.Join(fields, ", "), resp.Status(), detail)
 		}
 		_ = resp.Body.Close()
 	}

--- a/adp/vega/vega-backend/server/logics/connector/local/index/opensearch/opensearch_query_test.go
+++ b/adp/vega/vega-backend/server/logics/connector/local/index/opensearch/opensearch_query_test.go
@@ -90,6 +90,33 @@ func TestValidateAnalyzersChecksEachDistinctAnalyzerOnce(t *testing.T) {
 	assert.Equal(t, 2, requests)
 }
 
+func TestValidateAnalyzersReturnsUnavailableErrorForOpenSearchResponse(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, "/_analyze", r.URL.Path)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusBadRequest)
+		_, err := w.Write([]byte(`{"error":"analyzer not found"}`))
+		require.NoError(t, err)
+	}))
+	t.Cleanup(server.Close)
+
+	serverURL, err := url.Parse(server.URL)
+	require.NoError(t, err)
+	host, portText, err := net.SplitHostPort(serverURL.Host)
+	require.NoError(t, err)
+	port, err := strconv.Atoi(portText)
+	require.NoError(t, err)
+	connector := &OpenSearchConnector{Config: &opensearchConfig{Host: host, Port: port}}
+
+	err = connector.ValidateAnalyzers(context.Background(), map[string]string{
+		"status": "hanlp_index",
+	})
+	var unavailableErr *interfaces.AnalyzerUnavailableError
+	require.ErrorAs(t, err, &unavailableErr)
+	assert.Equal(t, "hanlp_index", unavailableErr.Analyzer)
+	assert.Equal(t, []string{"status"}, unavailableErr.Fields)
+}
+
 func TestExecuteRawQueryFlattensAggregationsIntoEntries(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.Header().Set("Content-Type", "application/json")

--- a/adp/vega/vega-backend/server/logics/connector/local/index/opensearch/opensearch_query_test.go
+++ b/adp/vega/vega-backend/server/logics/connector/local/index/opensearch/opensearch_query_test.go
@@ -62,6 +62,34 @@ func TestOpenSearchQueryTracksTotalOnlyWhenRequested(t *testing.T) {
 	assert.Equal(t, true, (<-queries)["track_total_hits"])
 }
 
+func TestValidateAnalyzersChecksEachDistinctAnalyzerOnce(t *testing.T) {
+	requests := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, "/_analyze", r.URL.Path)
+		requests++
+		w.Header().Set("Content-Type", "application/json")
+		_, err := w.Write([]byte(`{"tokens":[]}`))
+		require.NoError(t, err)
+	}))
+	t.Cleanup(server.Close)
+
+	serverURL, err := url.Parse(server.URL)
+	require.NoError(t, err)
+	host, portText, err := net.SplitHostPort(serverURL.Host)
+	require.NoError(t, err)
+	port, err := strconv.Atoi(portText)
+	require.NoError(t, err)
+	connector := &OpenSearchConnector{Config: &opensearchConfig{Host: host, Port: port}}
+
+	err = connector.ValidateAnalyzers(context.Background(), map[string]string{
+		"coupon_code": "standard",
+		"name":        "standard",
+		"status":      "ik_max_word",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, 2, requests)
+}
+
 func TestExecuteRawQueryFlattensAggregationsIntoEntries(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.Header().Set("Content-Type", "application/json")

--- a/adp/vega/vega-backend/server/logics/connector/local/index/opensearch/opensearch_query_test.go
+++ b/adp/vega/vega-backend/server/logics/connector/local/index/opensearch/opensearch_query_test.go
@@ -8,6 +8,7 @@ package opensearch
 
 import (
 	"context"
+	"errors"
 	"io"
 	"net"
 	"net/http"
@@ -115,6 +116,34 @@ func TestValidateAnalyzersReturnsUnavailableErrorForOpenSearchResponse(t *testin
 	require.ErrorAs(t, err, &unavailableErr)
 	assert.Equal(t, "hanlp_index", unavailableErr.Analyzer)
 	assert.Equal(t, []string{"status"}, unavailableErr.Fields)
+}
+
+func TestValidateAnalyzersReturnsDependencyErrorForNonBadRequestResponse(t *testing.T) {
+	for _, statusCode := range []int{http.StatusUnauthorized, http.StatusInternalServerError} {
+		t.Run(http.StatusText(statusCode), func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				require.Equal(t, "/_analyze", r.URL.Path)
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(statusCode)
+				_, err := w.Write([]byte(`{"error":"dependency failure"}`))
+				require.NoError(t, err)
+			}))
+			t.Cleanup(server.Close)
+
+			serverURL, err := url.Parse(server.URL)
+			require.NoError(t, err)
+			host, portText, err := net.SplitHostPort(serverURL.Host)
+			require.NoError(t, err)
+			port, err := strconv.Atoi(portText)
+			require.NoError(t, err)
+			connector := &OpenSearchConnector{Config: &opensearchConfig{Host: host, Port: port}}
+
+			err = connector.ValidateAnalyzers(context.Background(), map[string]string{"status": "hanlp_index"})
+			require.Error(t, err)
+			var unavailableErr *interfaces.AnalyzerUnavailableError
+			assert.False(t, errors.As(err, &unavailableErr))
+		})
+	}
 }
 
 func TestExecuteRawQueryFlattensAggregationsIntoEntries(t *testing.T) {

--- a/adp/vega/vega-backend/server/logics/local_index/local_index_manager.go
+++ b/adp/vega/vega-backend/server/logics/local_index/local_index_manager.go
@@ -71,6 +71,11 @@ func (lim *localIndexManager) CheckExist(ctx context.Context, indexName string) 
 	return lim.c.CheckExist(ctx, indexName)
 }
 
+// ValidateAnalyzers delegates analyzer availability checks to the local index connector.
+func (lim *localIndexManager) ValidateAnalyzers(ctx context.Context, analyzers map[string]string) error {
+	return lim.c.ValidateAnalyzers(ctx, analyzers)
+}
+
 func (lim *localIndexManager) ListDocuments(ctx context.Context, indexName string, res *interfaces.Resource, params *interfaces.ResourceDataQueryParams) ([]map[string]any, int64, error) {
 	queryResult, err := lim.c.ExecuteQuery(ctx, indexName, res, params)
 	if err != nil {


### PR DESCRIPTION
## What Changed

Brief description of changes:

- [x] Add mandatory analyzer validation to IndexConnector and LocalIndexManager.
- [x] Validate unique OpenSearch analyzers before persisting or enqueueing a build task.
- [x] Add backend regression tests and regenerate GoMock interfaces.
- [ ] Docs/doc 1 — not required; no externally documented API endpoint changed.

---

## Why

- Related Issue: [bkn-studio#247](https://github.com/openbkn-ai/bkn-studio/issues/247)
- Related Feature: N/A
- Background: A resource field-level `hanlp_index` override could be hidden by a displayed `standard` default and caused asynchronous OpenSearch index-creation failure when HanLP was unavailable.

---

## How

- Key implementation points: OpenSearch validates each distinct analyzer through `_analyze`; failures identify every affected field. The build-task service returns HTTP 400 before task persistence or queueing.
- Breaking changes (API, config, database, etc.): `ValidateAnalyzers` is now required on the internal IndexConnector and LocalIndexManager interfaces. No API, configuration, database, or resource-data migration is required.

---

## Testing

- [x] Unit tests passed locally
- [ ] Integration tests passed locally — not applicable; tests use an in-process HTTP server and no external middleware.
- [ ] Verified in test environment — not performed; no deployment requested.

Test notes:

- `make ci` passed (golangci-lint, full unit suite, coverage).
- Regression coverage verifies unavailable field analyzer rejection before persistence and duplicate analyzer validation runs once.

---

## Risk & Rollback

- Potential risks: Build-task creation now depends on OpenSearch analyzer validation availability; an unavailable OpenSearch cluster causes a fast, actionable rejection instead of an asynchronous build failure.
- Rollback plan: Revert commit `95824fce` to restore the prior asynchronous behavior.

---

## Additional Notes

- This PR intentionally does not use `Closes #247`, because that issue is in the separate `bkn-studio` repository.
- Existing uncommitted change to `server/config/vega-backend-config.yaml` is not part of this PR.