### PR TITLE
chore(bkn-agent): 暂时下线内置 agent 工具箱

### DIFF
--- a/infra/bkn-agent/charts/values.yaml
+++ b/infra/bkn-agent/charts/values.yaml
@@ -40,7 +40,9 @@ runtime:
   defaultToolboxes: "e521d454-4a0b-4dc9-8a28-d0986de1cef9"
   # published agent 注册进算子工厂 toolbox（#212）；工具面与技能面统一走这里（#322）
   operatorIntegrationBase: "http://agent-operator-integration:9000/api/agent-operator-integration"
-  toolboxSync: "true"
+  # 暂时下线内置「bkn_agent内置agent」工具箱：关掉后启动同步与变更 resync 均 no-op，
+  # 不再注册/复活该 box（存量 box 需手动删；恢复=改回 "true" 重新部署，box 会幂等重建）
+  toolboxSync: "false"
   # toolbox 工具回调本服务的地址（box_svc_url）
   selfBaseUrl: "http://bkn-agent:30800"
   defaultModel: ""


### PR DESCRIPTION
## 背景

从系统中暂时去掉内置的「bkn_agent内置agent」工具箱（published agent 自动注册进执行工厂那个 box）。

## 改动

`infra/bkn-agent/charts/values.yaml`：`runtime.toolboxSync` 由 `"true"` 置为 `"false"`（单行 + 注释）。

代码侧已就绪，flag 关掉后：
- 启动同步 `start_startup_sync`、agent 增删改触发的 `schedule_resync` 全部 early-return（no-op，不报错）。
- 不再向执行工厂注册/复活 box `9a5abc35-3a01-5959-b4e1-070b1ab8918e`。

## 影响范围（已核实，隔离）

不受影响：
- Agent 增删改照常，resync 只是跳过。
- published agent 运行时直调 `/invoke/{agent_id}` 与该 box 无关，照跑。
- 其他工具箱（默认 box `e521d454` contextloader + agent 自己 `ToolRef` 的 box）照常加载。
- box ID `9a5abc35` 除 sync 模块外无处引用。

唯一副作用（即目的）：其他 agent 不能再把 published agent 当工具挂；若存量某 agent 的 `tools` 明写了该 box_id，box 删除后该引用会 `BoxUnavailable`。

## 存量清理（本 PR 不含）

存量已注册的 box 需手动删除：Studio UI 删除该工具箱，或 admin `DELETE /api/agent-operator-integration/v1/tool-box/9a5abc35-3a01-5959-b4e1-070b1ab8918e`。flag 已关，不会复活。

## 恢复

`toolboxSync` 改回 `"true"` 重新部署 → box + 工具幂等重建（确定性 ID）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)