### PR TITLE
fix(bkn-backend): align action type condition JSON tag with OpenAPI

### DIFF
--- a/adp/bkn/bkn-backend/server/interfaces/action_type.go
+++ b/adp/bkn/bkn-backend/server/interfaces/action_type.go
@@ -97,7 +97,7 @@ type ActionTypeWithKeyField struct {
 	ActionIntent string           `json:"action_intent,omitempty" mapstructure:"action_intent"`
 	ObjectTypeID string           `json:"object_type_id" mapstructure:"object_type_id"`
 	ObjectType   SimpleObjectType `json:"object_type,omitempty" mapstructure:"object_type"` // 翻译绑定的对象类
-	Condition    *ActionCondCfg   `json:"cond,omitempty" mapstructure:"cond"`
+	Condition    *ActionCondCfg   `json:"condition,omitempty" mapstructure:"condition"`
 	Affect       *ActionAffect    `json:"affect" mapstructure:"affect"`
 	// ImpactContracts 与原生请求互斥（不得同时自拟多行又与 affect 混搭）；仅 affect 时在 validate 中补一行，expected_operation 取 action_type，并保留 affect。
 	ImpactContracts []ImpactContractItem `json:"impact_contracts,omitempty" mapstructure:"impact_contracts"`

--- a/adp/bkn/bkn-backend/server/interfaces/action_type_json_test.go
+++ b/adp/bkn/bkn-backend/server/interfaces/action_type_json_test.go
@@ -1,0 +1,52 @@
+// Copyright openbkn.ai
+// Copyright The kweaver.ai Authors.
+//
+// Licensed under the Apache License, Version 2.0.
+// See the LICENSE file in the project root for details.
+
+package interfaces
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+// Regression for openbkn-ai/bkn-studio#219: ActionType trigger condition must
+// serialize/deserialize as "condition" (OpenAPI / Studio), not "cond".
+func TestActionTypeConditionJSONFieldName(t *testing.T) {
+	at := ActionTypeWithKeyField{
+		ATID:         "at1",
+		ATName:       "demo",
+		ActionType:   ACTION_TYPE_MODIFY,
+		ObjectTypeID: "ot1",
+		Condition: &ActionCondCfg{
+			Field:     "status",
+			Operation: "eq",
+		},
+	}
+
+	raw, err := json.Marshal(at)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	s := string(raw)
+	if strings.Contains(s, `"cond"`) {
+		t.Fatalf("marshaled JSON still uses legacy key cond: %s", s)
+	}
+	if !strings.Contains(s, `"condition"`) {
+		t.Fatalf("marshaled JSON missing condition key: %s", s)
+	}
+
+	payload := `{"id":"at1","name":"demo","action_type":"modify","object_type_id":"ot1","condition":{"field":"status","operation":"eq","value":"open","value_from":"const"}}`
+	var decoded ActionTypeWithKeyField
+	if err := json.Unmarshal([]byte(payload), &decoded); err != nil {
+		t.Fatalf("unmarshal condition: %v", err)
+	}
+	if decoded.Condition == nil {
+		t.Fatal("expected Condition to be bound from condition key")
+	}
+	if decoded.Condition.Field != "status" || decoded.Condition.Operation != "eq" {
+		t.Fatalf("unexpected condition: %+v", decoded.Condition)
+	}
+}


### PR DESCRIPTION
## Summary

- Align `ActionTypeWithKeyField.Condition` JSON/mapstructure tag from `cond` to `condition` so create/update/bind matches OpenAPI and Studio.
- Add regression test covering marshal/unmarshal of the `condition` field.

Fixes openbkn-ai/bkn-studio#219
Related to #434

## Test plan

- [ ] Create/update an action type with a trigger condition via Studio; reopen detail/edit and confirm the condition is persisted and rebound
- [ ] GET action type JSON includes `condition` (not `cond`)
- [ ] `go test ./interfaces/ -run TestActionTypeConditionJSONFieldName` in `adp/bkn/bkn-backend/server`
- [ ] (Optional) Re-save previously empty conditions after deploy; rebuild action-type concept index if search path still misses conditions
