### PR TITLE
refactor(deploy): 统一 OpenBKN 部署入口并移除过时别名

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,10 +60,7 @@ sudo bash ./preflight.sh --help         # all flags (--role, --skip, --report, -
 ```bash
 # (Same deploy/ directory as step 2)
 
-# Equivalent to:
-# ./deploy.sh core install --set auth.enabled=false --set businessDomain.enabled=false
-
-# Full installation (includes auth & business-domain modules)
+# Install the full BKN Foundry stack
 ./deploy.sh bkn-foundry install
 
 # Or specify addresses explicitly (skips interactive prompts):
@@ -106,9 +103,7 @@ sudo bash ./onboard.sh --help # all flags (--config=models.yaml, --enable-bkn-se
    BKN Foundry is backend-only and does not provide a web console. On the machine you use to reach the cluster (laptop, bastion, etc.), use the BKN CLI from [**bkn-sdk**](https://github.com/openbkn-ai/bkn-sdk): either `npm install -g @openbkn/bkn-sdk` or `npx openbkn` (no global install; see [OpenBKN SDK](#toc-bkn-sdk) below). Then run:
 
 ```bash
-# Minimum install (no auth):
-openbkn auth login https://<node-ip> -k
-# Full install: sign in as the user onboard.sh created (default password 111111 unless you overrode it):
+# Sign in as the user onboard.sh created (default password 111111 unless you overrode it):
 openbkn auth login https://<node-ip> -u test -p '<password>' -k
 
 openbkn bkn list
@@ -126,7 +121,7 @@ openbkn <command> --help         # help for a specific command, e.g. openbkn bkn
 
 For full product documentation, see the [Documentation](help/README.md) ([EN](help/en/README.md) / [中文](help/zh/README.md)).
 
-> **Did a full install (without `--minimum`)?** Use the `openbkn admin` subcommands to manage users, organizations, roles, models, and audit logs — see [Administration](#toc-kweaver-admin) below.
+> **After a full install**, use the `openbkn admin` subcommands to manage users, organizations, roles, models, and audit logs — see [Administration](#toc-kweaver-admin) below.
 
 <a id="toc-kweaver-core"></a>
 
@@ -327,7 +322,7 @@ For streaming and the full resource API (`bkn.kn`, `bkn.context`, `bkn.models`, 
 
 ## 🛡️ Administration
 
-Platform administration (users, organizations, roles, models, audit) is **built into the same `openbkn` CLI** under the `openbkn admin` subcommands — there is no separate admin tool. Most `admin` commands target services that come with a **full install** (`auth.enabled=true`, `businessDomain.enabled=true`); on a `--minimum` install they return 401 / 404 (expected).
+Platform administration (users, organizations, roles, models, audit) is **built into the same `openbkn` CLI** under the `openbkn admin` subcommands — there is no separate admin tool. These commands target services included in the **full install** (`auth.enabled=true`, `businessDomain.enabled=true`).
 
 ```bash
 openbkn admin org tree                          # list departments

--- a/README.zh.md
+++ b/README.zh.md
@@ -124,7 +124,7 @@ openbkn <command> --help         # 查看某命令的帮助，例如 openbkn bkn
 
 完整产品文档参见[文档中心](help/README.md)（[中文](help/zh/README.md) / [EN](help/en/README.md)）。
 
-> **完整安装（未加 `--minimum`）？** 用 `openbkn admin` 子命令进行用户、组织、角色、模型与审计管理 — 详见下文 [平台管理](#toc-kweaver-admin)。
+> **完成全量安装后**，使用 `openbkn admin` 子命令进行用户、组织、角色、模型与审计管理 — 详见下文 [平台管理](#toc-kweaver-admin)。
 
 <a id="toc-kweaver-core"></a>
 
@@ -325,7 +325,7 @@ const results  = await bkn.kn.search("<kn-id>", "供应链有哪些风险？");
 
 ## 🛡️ 平台管理
 
-平台管理（用户、组织、角色、模型、审计）**已内置在同一个 `openbkn` CLI** 的 `openbkn admin` 子命令下——无需独立的管理工具。`admin` 命令主要操作**完整安装**（`auth.enabled=true`、`businessDomain.enabled=true`）带的服务；`--minimum` 安装下大多返回 401 / 404（正常裁剪）。
+平台管理（用户、组织、角色、模型、审计）**已内置在同一个 `openbkn` CLI** 的 `openbkn admin` 子命令下——无需独立的管理工具。`admin` 命令操作**完整安装**（`auth.enabled=true`、`businessDomain.enabled=true`）提供的服务。
 
 ```bash
 openbkn admin org tree                          # 列出部门

--- a/deploy/deploy.sh
+++ b/deploy/deploy.sh
@@ -60,12 +60,12 @@ usage() {
     echo "  opensearch uninstall          Uninstall OpenSearch (optionally purge PVC)"
     echo "  ingress-nginx install         Install ingress-nginx-controller"
     echo "  ingress-nginx uninstall       Uninstall ingress-nginx-controller"
-    echo "  bkn-foundry install          Install BKN Foundry services; auto-installs K8s/data services if missing"
-    echo "  bkn-foundry download         Download/update BKN Foundry charts into deploy/.tmp/charts"
-    echo "  bkn-foundry uninstall        Uninstall BKN Foundry services"
-    echo "  bkn-foundry status           Show BKN Foundry services status"
+    echo "  openbkn install              Install BKN Foundry services; auto-installs K8s/data services if missing"
+    echo "  openbkn download             Download/update BKN Foundry charts into deploy/.tmp/charts"
+    echo "  openbkn uninstall            Uninstall BKN Foundry services"
+    echo "  openbkn status               Show BKN Foundry services status"
     echo "                                Use --set to pass custom values to all charts"
-    echo "  all install                   Run full initialization (k8s + mariadb + redis + ingress-nginx)"
+    echo "  infra install                Install Kubernetes and platform data services"
     echo ""
     echo "Examples:"
     echo "  $0 k8s install                # Initialize K8s master node with default settings"
@@ -95,7 +95,7 @@ usage() {
     echo "  $0 config generate            # Generate/update ~/.openbkn-ai/config.yaml"
     echo "                                Console admin initial password: prompted on first generation (Enter = random);"
     echo "                                preset with BKN_SAFE_INITIAL_PASSWORD=...; recorded as bknSafe.initialPassword."
-    echo "  $0 all install                # Full initialization with all components"
+    echo "  $0 infra install             # Install infrastructure only"
     echo ""
     echo "Global Options (must appear BEFORE <module> <action>, e.g. $0 --distro=k8s bkn-foundry install):"
     echo "                                Trailing flags like ... install --distro=k8s are NOT parsed here;"
@@ -617,6 +617,26 @@ main() {
         return 0
     fi
     
+    # Handle ingress-nginx module
+    if [[ "${module}" == "ingress-nginx" ]]; then
+        case "${action}" in
+            install|init)
+                check_root
+                install_ingress_nginx
+                ;;
+            uninstall)
+                check_root
+                uninstall_ingress_nginx
+                ;;
+            *)
+                log_error "Unknown ingress-nginx action: ${action}"
+                usage
+                exit 1
+                ;;
+        esac
+        return 0
+    fi
+
     # Handle mariadb module
     if [[ "${module}" == "mariadb" ]]; then
         case "${action}" in
@@ -719,63 +739,8 @@ main() {
         return 0
     fi
     
-    # Handle ingress-nginx module
-    if [[ "${module}" == "ingress-nginx" ]]; then
-        case "${action}" in
-            install|init)
-                check_root
-                install_ingress_nginx
-                ;;
-            uninstall)
-                check_root
-                uninstall_ingress_nginx
-                ;;
-            *)
-                log_error "Unknown ingress-nginx action: ${action}"
-                usage
-                exit 1
-                ;;
-        esac
-        return 0
-    fi
-    
-    # Handle bkn-foundry module
-    if [[ "${module}" == "bkn-foundry" ]] || [[ "${module}" == "foundry" ]] || [[ "${module}" == "core" ]]; then
-        case "${action}" in
-            install|init)
-                parse_openbkn_args "install" "$@"
-                confirm_access_address_before_install
-                install_openbkn
-                ;;
-            download)
-                parse_openbkn_args "download" "$@"
-                download_openbkn
-                ;;
-            uninstall)
-                parse_openbkn_args "uninstall" "$@"
-                uninstall_openbkn
-                ;;
-            status)
-                parse_openbkn_args "status" "$@"
-                show_install_status
-                ;;
-            publish-status)
-                parse_openbkn_args "status" "$@"
-                gen_install_status_json
-                ;;
-            *)
-                log_error "Unknown bkn-foundry action: ${action}"
-                usage
-                exit 1
-                ;;
-        esac
-        return 0
-    fi
-    
-
-    # Handle all/infra module (infrastructure: k8s + data services)
-    # 'all' is an alias for 'infra' for backward compatibility
-    if [[ "${module}" == "all" ]] || [[ "${module}" == "infra" ]]; then
+    # Handle infra module (infrastructure: k8s + data services)
+    if [[ "${module}" == "infra" ]]; then
         case "${action}" in
             install|init)
                 log_info "=========================================="
@@ -803,57 +768,35 @@ main() {
         return 0
     fi
     
-    # Handle bkn module (application services)
-    if [[ "${module}" == "bkn" ]]; then
+    # Handle OpenBKN application module. bkn-foundry/foundry/bkn remain compatibility aliases.
+    if [[ "${module}" == "openbkn" ]] \
+        || [[ "${module}" == "bkn-foundry" ]] \
+        || [[ "${module}" == "foundry" ]] \
+        || [[ "${module}" == "bkn" ]]; then
         case "${action}" in
-            init)
-                check_root
-                log_info "=========================================="
-                log_info "  Deploying BKN Foundry Application Services"
-                log_info "=========================================="
-                
-                # Parse common args for all bkn services
-                while [[ $# -gt 0 ]]; do
-                    case "$1" in
-                        --version=*)
-                            HELM_CHART_VERSION="${1#*=}"
-                            shift
-                            ;;
-                        --version)
-                            HELM_CHART_VERSION="$2"
-                            shift 2
-                            ;;
-                        --helm_repo=*)
-                            HELM_CHART_REPO_URL="${1#*=}"
-                            shift
-                            ;;
-                        --helm_repo)
-                            HELM_CHART_REPO_URL="$2"
-                            shift 2
-                            ;;
-                        *)
-                            shift
-                            ;;
-                    esac
-                done
-                
-                # Install all BKN Foundry services in order
+            install|init)
+                parse_openbkn_args "install" "$@"
+                confirm_access_address_before_install
                 install_openbkn
-
-                log_info "BKN Foundry application services deployment completed!"
+                ;;
+            download)
+                parse_openbkn_args "download" "$@"
+                download_openbkn
                 ;;
             uninstall)
-                check_root
-                log_info "Uninstalling BKN Foundry application services..."
-                uninstall_openbkn || true
-                log_info "BKN Foundry application services uninstalled!"
+                parse_openbkn_args "uninstall" "$@"
+                uninstall_openbkn
                 ;;
             status)
-                log_info "BKN Foundry application services status:"
-                show_openbkn_status
+                parse_openbkn_args "status" "$@"
+                show_install_status
+                ;;
+            publish-status)
+                parse_openbkn_args "status" "$@"
+                gen_install_status_json
                 ;;
             *)
-                log_error "Unknown bkn action: ${action}"
+                log_error "Unknown openbkn action: ${action}"
                 usage
                 exit 1
                 ;;

--- a/deploy/dev/README.md
+++ b/deploy/dev/README.md
@@ -30,7 +30,7 @@ On **Apple Silicon** Macs, kind nodes are **linux/arm64** by default. Charts pul
 
 ## Order of operations
 
-Run from the **`deploy/`** directory (`cd deploy` in this repo). Invoke **`mac.sh` with bash** (e.g. `bash ./dev/mac.sh ...`). **`bkn-foundry` / `core`:** the wrapper installs the **full stack including bkn-safe** (auth is mandatory now).
+Run from the **`deploy/`** directory (`cd deploy` in this repo). Invoke **`mac.sh` with bash** (e.g. `bash ./dev/mac.sh ...`). **`openbkn` / `bkn-foundry`:** the wrapper installs the **full stack including bkn-safe** (auth is mandatory now).
 
 | Step | Command | Required? |
 |------|---------|-----------|

--- a/deploy/dev/README.zh.md
+++ b/deploy/dev/README.zh.md
@@ -30,7 +30,7 @@ cd bkn-foundry/deploy   # 在此目录执行 bash ./dev/mac.sh ...（与 deploy.
 
 ### 操作流程
 
-在 **`deploy/`** 下执行；用 **bash** 调用（如 `bash ./dev/mac.sh ...`）。**`bkn-foundry` / `core`** 封装默认装**全量（含必选的 bkn-safe）。
+在 **`deploy/`** 下执行；用 **bash** 调用（如 `bash ./dev/mac.sh ...`）。**`openbkn` / `bkn-foundry`** 封装默认装**全量（含必选的 bkn-safe）。
 
 | 步骤 | 命令 | 是否必需？ |
 |------|------|------------|

--- a/deploy/dev/mac.sh
+++ b/deploy/dev/mac.sh
@@ -72,7 +72,7 @@ Commands:
   doctor [--fix] [-y|--yes]        Check toolchain; --fix runs brew after confirm (use -y to skip prompt)
   cluster up|down|status           kind cluster + ingress-nginx (kind manifest)
   data-services install|uninstall  Platform data layer (optional before Core: bkn-foundry install runs it automatically on mac); uninstall tears down bundled charts
-  bkn-foundry <action> ...         Delegates to deploy.sh (aliases: foundry, bkn-core, core)
+  openbkn <action> ...             Delegates to deploy.sh (aliases: bkn-foundry, foundry, bkn)
   onboard [args ...]               Runs deploy/onboard.sh
 
 Examples:
@@ -89,7 +89,7 @@ Examples:
 
 Environment:
   KIND_CLUSTER_NAME       Default: bkn-dev
-  CONFIG_YAML_PATH        Default: ${mac_cfg} when unset (bkn-foundry|core|data-services)
+  CONFIG_YAML_PATH        Default: ${mac_cfg} when unset (openbkn|data-services)
 
 Note: data-services install runs deploy.sh data-services (Helm charts into the current kube context). Other deploy.sh modules on mac still skip host k3s bootstrap unless you install infra yourself. See ${readme}.
 
@@ -217,7 +217,7 @@ main() {
             fi
             exec bash "${DEPLOY_ROOT}/deploy.sh" data-services "$@"
             ;;
-        bkn-foundry | foundry | bkn-core | core)
+        openbkn | bkn-foundry | foundry | bkn)
             mac_require_darwin
             if ! mac_doctor; then
                 exit 1
@@ -246,7 +246,7 @@ main() {
                 esac
             done
             if [[ ${#_kw_pos[@]} -eq 0 ]]; then
-                mac_log_error "bkn-foundry|core needs an action (e.g. download, install, status)."
+                mac_log_error "openbkn needs an action (e.g. download, install, status)."
                 exit 1
             fi
             local -a _kw_final=("${_kw_pos[@]}")

--- a/deploy/scripts/services/openbkn.sh
+++ b/deploy/scripts/services/openbkn.sh
@@ -903,27 +903,3 @@ uninstall_openbkn() {
 
     log_info "BKN Foundry services uninstallation completed."
 }
-
-# Show BKN Foundry services status
-show_openbkn_status() {
-    log_info "BKN Foundry services status:"
-
-    local namespace
-    namespace="$(_openbkn_resolve_target_namespace)"
-
-    log_info "Namespace: ${namespace}"
-    log_info ""
-
-    local -a release_names=()
-    bkn_mapfile_compat release_names _openbkn_release_names_or_installed "${namespace}"
-    for release_name in "${release_names[@]}"; do
-        if helm status "${release_name}" -n "${namespace}" >/dev/null 2>&1; then
-            local status
-            status=$(helm status "${release_name}" -n "${namespace}" -o json 2>/dev/null \
-                | grep -o '"status":"[^"]*"' | head -1 | cut -d'"' -f4)
-            log_info "  ✓ ${release_name}: ${status}"
-        else
-            log_info "  ✗ ${release_name}: not installed"
-        fi
-    done
-}

--- a/deploy/scripts/services/status.sh
+++ b/deploy/scripts/services/status.sh
@@ -5,7 +5,7 @@
 # BKN Foundry install-status — two views over one collector
 # (scripts/lib/install_status.py):
 #   show_install_status()      — Layer 1: live, detailed table for operators on
-#                                the server (`deploy.sh core status`).
+#                                the server (`deploy.sh openbkn status`).
 #   gen_install_status_json()  — Layer 2: regenerate the non-sensitive JSON
 #                                snapshot + publish the static /install-status
 #                                ingress endpoint. Called at the end of
@@ -128,7 +128,7 @@ _status_apply_endpoint() {
 # --set auth.enabled=false. That is a SUPPORTED, normal state: bkn-safe is
 # optional. Detect it so install-status reports an absent bkn-safe as
 # "skipped", not "missing". Signals: the install-time --set (CORE_SET_VALUES,
-# present right after install) or, for a standalone status run, a deployed core
+# present right after install) or, for a standalone status run, a deployed OpenBKN
 # service running AUTH_ENABLED=false.
 _status_auth_disabled() {
     local ns="$1" v

--- a/rules/CONTRIBUTING.md
+++ b/rules/CONTRIBUTING.md
@@ -72,7 +72,7 @@ When reporting a bug, please provide the following information:
   - Module affected (e.g. `adp/bkn`, `adp/vega/vega-backend`, `infra/sandbox`)
   - Runtime (Java / Go / Python / Node — and version, e.g. JDK 17, Go 1.23, Python 3.11)
   - OS (Linux distro + kernel, macOS, Windows)
-  - Cluster (single-node K3s / kubeadm / managed K8s) and how it was installed (`deploy.sh core install [--minimum]`)
+  - Cluster (single-node K3s / kubeadm / managed K8s) and how it was installed (`deploy.sh bkn-foundry install`)
   - Storage backends as relevant (MariaDB / DM8, OpenSearch, Redis, Kafka)
 
 - **Reproduction Steps**: Clear, step-by-step instructions to reproduce the issue
@@ -91,7 +91,7 @@ When reporting a bug, please provide the following information:
 - Module: adp/bkn
 - Runtime: JDK 17
 - OS: Linux Ubuntu 22.04
-- Cluster: single-node K3s (deploy.sh core install)
+- Cluster: single-node K3s (deploy.sh bkn-foundry install)
 - Database: MariaDB 11.4
 
 **Steps to Reproduce:**
@@ -566,8 +566,7 @@ Each module's `README.md` / `AGENTS.md` lists the exact prerequisites, build com
 
    ```bash
    cd deploy
-   ./deploy.sh core install --minimum    # quick try
-   # or full install: ./deploy.sh core install
+   ./deploy.sh bkn-foundry install
    ```
 
 ---

--- a/rules/CONTRIBUTING.zh.md
+++ b/rules/CONTRIBUTING.zh.md
@@ -72,7 +72,7 @@ BKN Foundry 是一个 **monorepo**（[`openbkn-ai/bkn-foundry`](https://github.c
   - 受影响的模块（如 `adp/bkn`、`adp/vega/vega-backend`、`infra/sandbox`）
   - 运行时（Java / Go / Python / Node 及版本，如 JDK 17、Go 1.23、Python 3.11）
   - 操作系统（Linux 发行版与内核 / macOS / Windows）
-  - 集群形态（单机 K3s / kubeadm / 托管 K8s）以及安装方式（`deploy.sh core install [--minimum]`）
+  - 集群形态（单机 K3s / kubeadm / 托管 K8s）以及安装方式（`deploy.sh bkn-foundry install`）
   - 涉及的存储/中间件（MariaDB / DM8、OpenSearch、Redis、Kafka）
 
 - **复现步骤**: 清晰、逐步的复现说明
@@ -91,7 +91,7 @@ BKN Foundry 是一个 **monorepo**（[`openbkn-ai/bkn-foundry`](https://github.c
 - 模块: adp/bkn
 - 运行时: JDK 17
 - 操作系统: Linux Ubuntu 22.04
-- 集群: 单机 K3s（deploy.sh core install）
+- 集群: 单机 K3s（deploy.sh bkn-foundry install）
 - 数据库: MariaDB 11.4
 
 **复现步骤:**
@@ -561,8 +561,7 @@ BKN Foundry 是多语言项目，**只需安装你要修改的模块所需的工
 
    ```bash
    cd deploy
-   ./deploy.sh core install --minimum    # 快速体验
-   # 完整安装：./deploy.sh core install
+   ./deploy.sh bkn-foundry install
    ```
 
 ---


### PR DESCRIPTION
# Pull Request

## What Changed

- [x] 新增 `openbkn` 作为规范部署模块名
- [x] 合并 `bkn-foundry`、`foundry`、`bkn` 的处理逻辑
- [x] 删除 `core`、`bkn-core` 过时入口
- [x] 删除容易引起误解的 `all` 入口，仅保留 `infra`
- [x] 更新 macOS 部署包装器、帮助信息和状态提示

## Why

- 当前产品已不再使用 `core` 作为部署模块名。
- `all` 实际只部署 Kubernetes 和基础设施，不包含 OpenBKN 业务服务，容易误导用户。
- `bkn` 与 `bkn-foundry` 存在重复的部署、卸载和状态处理逻辑，维护成本较高。

## How

- 使用统一条件分支处理 `openbkn`、`bkn-foundry`、`foundry`、`bkn`。
- 将 `init` 统一映射到 OpenBKN 安装流程。
- `infra` 仅负责 Kubernetes 和平台数据服务。
- 同步移除 `core`、`bkn-core`、`all` 的帮助和包装器入口。

## Breaking Changes

- 不再支持：
  - `deploy.sh core ...`
  - `deploy.sh bkn-core ...`
  - `deploy.sh all ...`
- 推荐使用：
  - `deploy.sh openbkn install`
  - `deploy.sh infra install`

## Testing

- [x] Bash 语法检查通过
- [x] OpenBKN release retire 测试通过
- [x] `git diff --check` 通过
- [x] 已验证 `core`、`all` 入口会拒绝执行并显示帮助
- [ ] 未执行实际 Kubernetes 集群部署验证

## Risk & Rollback

- Potential risks:
  - 依赖旧 `core` 或 `all` 命令的外部脚本需要迁移。
- Rollback plan:
  - 回滚本次提交即可恢复旧入口。
  - 不涉及数据库、Helm values 或集群数据迁移。

## Additional Notes

- Related Issue: Closes #[请填写 Issue 编号]
- 建议合并后统一使用 `openbkn` 和 `infra` 入口。