### PR TITLE
fix(agent-retrieval): 修复 get_logic_properties_values 因 top_p=0 恒定失败并被误报为缺参

### DIFF
--- a/adp/context-loader/agent-retrieval/server/drivenadapters/mf_model_api_client.go
+++ b/adp/context-loader/agent-retrieval/server/drivenadapters/mf_model_api_client.go
@@ -75,17 +75,28 @@ type chatCompletionsResp struct {
 func (c *mfModelAPIClient) Chat(ctx context.Context, req *interfaces.LLMChatReq) (string, error) {
 	url := fmt.Sprintf("%s%s", c.baseURL, chatCompletionsURI)
 
-	// 构建请求体
+	// 构建请求体。
+	// temperature / frequency_penalty / presence_penalty 的 0 是合法业务取值（区间分别为
+	// [0,2] 与 [-2,2]），恒发；top_p / top_k / max_tokens 的合法区间不含 0
+	// （0 < top_p ≤ 1、top_k ≥ 1、max_tokens ≥ 10），调用方未设置时的 Go 零值不能当成业务
+	// 参数发出去，否则 mf-model-api 直接 400（issue #450）。此处用 map 组装，struct 上的
+	// omitempty 不生效，必须显式判零。
 	reqBody := map[string]interface{}{
 		"model":             req.Model,
 		"messages":          req.Messages,
 		"stream":            false, // 非流式
 		"temperature":       req.Temperature,
-		"top_k":             req.TopK,
-		"top_p":             req.TopP,
 		"frequency_penalty": req.FrequencyPenalty,
 		"presence_penalty":  req.PresencePenalty,
-		"max_tokens":        req.MaxTokens,
+	}
+	if req.TopP > 0 {
+		reqBody["top_p"] = req.TopP
+	}
+	if req.TopK > 0 {
+		reqBody["top_k"] = req.TopK
+	}
+	if req.MaxTokens > 0 {
+		reqBody["max_tokens"] = req.MaxTokens
 	}
 
 	// 获取Header（统一方式）

--- a/adp/context-loader/agent-retrieval/server/drivenadapters/mf_model_api_client_test.go
+++ b/adp/context-loader/agent-retrieval/server/drivenadapters/mf_model_api_client_test.go
@@ -1,0 +1,120 @@
+// Copyright openbkn.ai
+// Copyright The kweaver.ai Authors.
+//
+// Licensed under the Apache License, Version 2.0.
+// See the LICENSE file in the project root for details.
+
+package drivenadapters
+
+import (
+	"context"
+	"testing"
+
+	"github.com/openbkn-ai/adp/context-loader/agent-retrieval/server/interfaces"
+)
+
+// chatOKResp 构造一个能被 chatCompletionsResp 解析的成功响应
+func chatOKResp(content string) map[string]interface{} {
+	return map[string]interface{}{
+		"choices": []interface{}{
+			map[string]interface{}{
+				"message": map[string]interface{}{"content": content},
+			},
+		},
+	}
+}
+
+// newTestMFModelAPIClient 直接构造客户端，绕开读配置的单例构造器
+func newTestMFModelAPIClient(capture *map[string]interface{}) *mfModelAPIClient {
+	return &mfModelAPIClient{
+		logger:  &mockLogger{},
+		baseURL: "http://mf-model-api",
+		httpClient: &mockHTTPClient{
+			handlerFunc: func(_ context.Context, _, _ string, _ map[string]string, body interface{}) (int, interface{}, error) {
+				if m, ok := body.(map[string]interface{}); ok {
+					*capture = m
+				}
+				return 200, chatOKResp("ok"), nil
+			},
+		},
+	}
+}
+
+// TestChat_ZeroSamplingParamsOmitted 复现 issue #450：调用方未设置 TopP/TopK 时，
+// Go 零值不得作为业务参数发给 mf-model-api（其校验为 0 < top_p ≤ 1、top_k ≥ 1，
+// 收到 0 直接 400，错误在上层被误包装成「缺参」）。
+func TestChat_ZeroSamplingParamsOmitted(t *testing.T) {
+	var got map[string]interface{}
+	client := newTestMFModelAPIClient(&got)
+
+	// 仅设置 MaxTokens，与 dynamic_params_llm.chatJSON 的调用方式一致
+	_, err := client.Chat(context.Background(), &interfaces.LLMChatReq{
+		Messages:  []interfaces.LLMMessage{{Role: "user", Content: "hi"}},
+		MaxTokens: 2000,
+	})
+	if err != nil {
+		t.Fatalf("Chat failed: %v", err)
+	}
+
+	for _, key := range []string{"top_p", "top_k"} {
+		if v, ok := got[key]; ok {
+			t.Errorf("zero-valued %s must be omitted from request body, got %v", key, v)
+		}
+	}
+	if got["max_tokens"] != 2000 {
+		t.Errorf("max_tokens = %v, want 2000", got["max_tokens"])
+	}
+	// temperature / penalty 的 0 是合法业务取值，必须原样发送
+	if v, ok := got["temperature"]; !ok || v != float64(0) {
+		t.Errorf("temperature = %v (present=%v), want 0", v, ok)
+	}
+}
+
+// TestChat_ExplicitSamplingParamsKept 显式设置的采样参数必须原样透传
+func TestChat_ExplicitSamplingParamsKept(t *testing.T) {
+	var got map[string]interface{}
+	client := newTestMFModelAPIClient(&got)
+
+	_, err := client.Chat(context.Background(), &interfaces.LLMChatReq{
+		Messages:         []interfaces.LLMMessage{{Role: "user", Content: "hi"}},
+		Temperature:      0.7,
+		TopK:             2,
+		TopP:             0.5,
+		FrequencyPenalty: 0.5,
+		PresencePenalty:  0.5,
+		MaxTokens:        5000,
+	})
+	if err != nil {
+		t.Fatalf("Chat failed: %v", err)
+	}
+
+	want := map[string]interface{}{
+		"temperature":       0.7,
+		"top_k":             2,
+		"top_p":             0.5,
+		"frequency_penalty": 0.5,
+		"presence_penalty":  0.5,
+		"max_tokens":        5000,
+	}
+	for key, expected := range want {
+		if got[key] != expected {
+			t.Errorf("%s = %v, want %v", key, got[key], expected)
+		}
+	}
+}
+
+// TestChat_ZeroMaxTokensOmitted mf-model-api 要求 max_tokens ≥ 10，零值同样不得发送
+func TestChat_ZeroMaxTokensOmitted(t *testing.T) {
+	var got map[string]interface{}
+	client := newTestMFModelAPIClient(&got)
+
+	_, err := client.Chat(context.Background(), &interfaces.LLMChatReq{
+		Messages: []interfaces.LLMMessage{{Role: "user", Content: "hi"}},
+	})
+	if err != nil {
+		t.Fatalf("Chat failed: %v", err)
+	}
+	if v, ok := got["max_tokens"]; ok {
+		t.Errorf("zero-valued max_tokens must be omitted, got %v", v)
+	}
+}

--- a/adp/context-loader/agent-retrieval/server/logics/knlogicpropertyresolver/dynamic_params_llm.go
+++ b/adp/context-loader/agent-retrieval/server/logics/knlogicpropertyresolver/dynamic_params_llm.go
@@ -27,8 +27,16 @@ var metricDynamicParamsPrompt string
 //go:embed prompts/tool_dynamic_params.md
 var toolDynamicParamsPrompt string
 
-// dynamicParamsMaxTokens is sufficient for dynamic parameter generation.
-const dynamicParamsMaxTokens = 2000
+// 动态参数生成的采样参数，取值与 rerank_llm 配置默认一致（temperature=0 / top_k=2 / top_p=0.5）：
+// 这里要的是结构化 JSON 的确定性输出，不是发散。top_p / top_k 必须显式设置——留空走 Go 零值，
+// 而 mf-model-api 要求 0 < top_p ≤ 1、top_k ≥ 1，零值直接 400（issue #450）。
+const (
+	// dynamicParamsMaxTokens is sufficient for dynamic parameter generation.
+	dynamicParamsMaxTokens   = 2000
+	dynamicParamsTemperature = 0.0
+	dynamicParamsTopK        = 2
+	dynamicParamsTopP        = 0.5
+)
 
 // dynamicParamsLLM generates metric and ToolBox-tool dynamic parameters.
 // 不指定模型：mf-model-api 在 model 为空时解析系统默认大模型（t_llm_model.f_default=1，
@@ -135,7 +143,10 @@ func (d *dynamicParamsLLM) chatJSON(ctx context.Context, systemPrompt, userJSON,
 			{Role: "system", Content: systemPrompt},
 			{Role: "user", Content: userJSON},
 		},
-		MaxTokens: dynamicParamsMaxTokens,
+		Temperature: dynamicParamsTemperature,
+		TopK:        dynamicParamsTopK,
+		TopP:        dynamicParamsTopP,
+		MaxTokens:   dynamicParamsMaxTokens,
 	}
 	content, err := d.mfModelClient.Chat(ctx, req)
 	if err != nil {

--- a/adp/context-loader/agent-retrieval/server/logics/knlogicpropertyresolver/dynamic_params_llm_test.go
+++ b/adp/context-loader/agent-retrieval/server/logics/knlogicpropertyresolver/dynamic_params_llm_test.go
@@ -1,0 +1,65 @@
+// Copyright openbkn.ai
+//
+// Licensed under the OpenBKN License. See LICENSE-OPENBKN.txt in the project root.
+
+package knlogicpropertyresolver
+
+import (
+	"context"
+	"testing"
+
+	"go.uber.org/mock/gomock"
+
+	"github.com/openbkn-ai/adp/context-loader/agent-retrieval/server/interfaces"
+	"github.com/openbkn-ai/adp/context-loader/agent-retrieval/server/mocks"
+)
+
+// noopLogger 空实现，避免为每条日志写 gomock 期望
+type noopLogger struct{}
+
+func (l *noopLogger) Debug(...interface{})                                {}
+func (l *noopLogger) Debugf(string, ...interface{})                       {}
+func (l *noopLogger) Info(...interface{})                                 {}
+func (l *noopLogger) Infof(string, ...interface{})                        {}
+func (l *noopLogger) Warn(...interface{})                                 {}
+func (l *noopLogger) Warnf(string, ...interface{})                        {}
+func (l *noopLogger) Error(...interface{})                                {}
+func (l *noopLogger) Errorf(string, ...interface{})                       {}
+func (l *noopLogger) WithContext(context.Context) interfaces.Logger       { return l }
+func (l *noopLogger) WithField(string, interface{}) interfaces.Logger     { return l }
+func (l *noopLogger) WithFields(map[string]interface{}) interfaces.Logger { return l }
+
+// TestChatJSON_SamplingParamsWithinGatewayRange 复现 issue #450：动态参数生成必须显式设置
+// 采样参数。留空走 Go 零值时 mf-model-api 直接 400（要求 0 < top_p ≤ 1、top_k ≥ 1），
+// 失败又被上层包装成「缺参」，根因被掩盖。
+func TestChatJSON_SamplingParamsWithinGatewayRange(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mfClient := mocks.NewMockDrivenMFModelAPIClient(ctrl)
+
+	var got *interfaces.LLMChatReq
+	mfClient.EXPECT().Chat(gomock.Any(), gomock.Any()).
+		DoAndReturn(func(_ context.Context, req *interfaces.LLMChatReq) (string, error) {
+			got = req
+			return `{"ok": true}`, nil
+		})
+
+	d := newDynamicParamsLLM(&noopLogger{}, mfClient, nil)
+	if _, err := d.chatJSON(context.Background(), "system", "{}", ""); err != nil {
+		t.Fatalf("chatJSON failed: %v", err)
+	}
+
+	if got.TopP <= 0 || got.TopP > 1 {
+		t.Errorf("TopP = %v, want 0 < top_p <= 1 (mf-model-api 校验区间)", got.TopP)
+	}
+	if got.TopK < 1 {
+		t.Errorf("TopK = %v, want >= 1 (mf-model-api 校验区间)", got.TopK)
+	}
+	if got.MaxTokens < 10 {
+		t.Errorf("MaxTokens = %v, want >= 10 (mf-model-api 校验区间)", got.MaxTokens)
+	}
+	if got.Temperature < 0 || got.Temperature > 2 {
+		t.Errorf("Temperature = %v, want 0 <= temperature <= 2", got.Temperature)
+	}
+}

--- a/adp/context-loader/agent-retrieval/server/logics/knlogicpropertyresolver/index.go
+++ b/adp/context-loader/agent-retrieval/server/logics/knlogicpropertyresolver/index.go
@@ -99,11 +99,24 @@ func (s *knLogicPropertyResolverService) ResolveLogicProperties(
 	// Step 4: 生成 dynamic_params
 	s.logger.WithContext(ctx).Debugf("[Step 2] 生成 dynamic_params（Agent 并发调用）")
 	startTime := time.Now()
-	dynamicParams, missingParams, err := s.generateDynamicParams(ctx, req, logicPropertiesDef, debugCollector)
+	dynamicParams, missingParams, genFailures, err := s.generateDynamicParams(ctx, req, logicPropertiesDef, debugCollector)
 	generateParamsDuration := time.Since(startTime)
 	if err != nil {
 		s.logger.WithContext(ctx).Errorf("[Step 2] ❌ 失败: %v", err)
 		return nil, err
+	}
+
+	// 参数生成失败（LLM / 依赖服务异常）优先于缺参上报：这不是调用方少传参数，
+	// 而是服务端链路故障，必须原样透出上游 code/detail，不能伪装成 MISSING_INPUT_PARAMS。
+	if len(genFailures) > 0 {
+		s.logger.WithContext(ctx).Errorf("[Step 2] ❌ 参数生成失败: %d 个属性", len(genFailures))
+		if req.Options.ReturnDebug {
+			return &interfaces.ResolveLogicPropertiesResponse{
+				Datas: []map[string]any{},
+				Debug: debugCollector.BuildDebugInfo(),
+			}, nil
+		}
+		return nil, s.buildGenerationFailedError(ctx, genFailures)
 	}
 
 	// 如果有缺参，根据是否开启 debug 决定处理方式
@@ -262,7 +275,8 @@ func (s *knLogicPropertyResolverService) generateDynamicParams(
 	req *interfaces.ResolveLogicPropertiesRequest,
 	logicPropertiesDef map[string]*interfaces.LogicPropertyDef,
 	debugCollector *DebugCollector,
-) (dynamicParams map[string]interface{}, missingParams []interfaces.MissingPropertyParams, err error) {
+) (dynamicParams map[string]interface{}, missingParams []interfaces.MissingPropertyParams,
+	genFailures []interfaces.MissingPropertyParams, err error) {
 	s.logger.WithContext(ctx).Debugf("[KnLogicPropertyResolver] Generating dynamic params for %d properties", len(logicPropertiesDef))
 
 	// 获取并发配置
@@ -320,6 +334,7 @@ func (s *knLogicPropertyResolverService) generateDynamicParams(
 	// Step 3: 收集结果
 	dynamicParams = make(map[string]interface{})
 	missingParams = []interfaces.MissingPropertyParams{}
+	genFailures = []interfaces.MissingPropertyParams{}
 
 	for range len(tasks) {
 		result := <-results
@@ -332,8 +347,10 @@ func (s *knLogicPropertyResolverService) generateDynamicParams(
 			if debugCollector != nil {
 				debugCollector.RecordAgentResponseError(result.Name, result.Error.Error())
 			}
-			// 将错误转换为缺参（让上游知道哪个 property 失败了）
-			missingParams = append(missingParams, interfaces.MissingPropertyParams{
+			// 生成失败（LLM / 依赖服务异常）与「模型判定缺参」是两回事，单独归集：
+			// 混进 missingParams 会让依赖服务的 4xx/5xx 被包装成 MISSING_INPUT_PARAMS，
+			// 掩盖真实根因（issue #450）。
+			genFailures = append(genFailures, interfaces.MissingPropertyParams{
 				Property: result.Name,
 				ErrorMsg: fmt.Sprintf("generate params failed: %v", result.Error),
 			})
@@ -356,10 +373,10 @@ func (s *knLogicPropertyResolverService) generateDynamicParams(
 		}
 	}
 
-	s.logger.WithContext(ctx).Debugf("[KnLogicPropertyResolver] Generated dynamic params for %d properties, %d missing",
-		len(dynamicParams), len(missingParams))
+	s.logger.WithContext(ctx).Debugf("[KnLogicPropertyResolver] Generated dynamic params for %d properties, %d missing, %d failed",
+		len(dynamicParams), len(missingParams), len(genFailures))
 
-	return dynamicParams, missingParams, nil
+	return dynamicParams, missingParams, genFailures, nil
 }
 
 // generateSinglePropertyParams 生成单个 property 的 dynamic_params
@@ -722,4 +739,22 @@ func (s *knLogicPropertyResolverService) buildMissingParamsError(
 
 	// 返回为 HTTPError
 	return errors.DefaultHTTPError(ctx, http.StatusBadRequest, fmt.Sprintf("%+v", missingError))
+}
+
+// buildGenerationFailedError 构建参数生成失败错误。与缺参区分开：这里是 LLM 或依赖服务
+// 故障，属服务端问题（500），错误消息保留上游 code/detail 便于定位。
+func (s *knLogicPropertyResolverService) buildGenerationFailedError(
+	ctx context.Context,
+	failures []interfaces.MissingPropertyParams,
+) error {
+	errorMsg := ""
+	for i, f := range failures {
+		if i > 0 {
+			errorMsg += "; "
+		}
+		errorMsg += fmt.Sprintf("%s: %s", f.Property, f.ErrorMsg)
+	}
+
+	return errors.DefaultHTTPError(ctx, http.StatusInternalServerError,
+		fmt.Sprintf("DYNAMIC_PARAMS_GENERATION_FAILED: 动态参数生成失败（LLM 或依赖服务异常，非缺少入参）: %s", errorMsg))
 }


### PR DESCRIPTION
Closes #450

## 问题

`get_logic_properties_values` 100% 失败,返回 `MISSING_INPUT_PARAMS`「dynamic_params 缺少必需的 input 参数」,真实根因埋在嵌套 `details` 里:调用 mf-model-api `/v1/chat/completions` 返回 400 `top_p must be an float and the range of values is 0 < top_p ≤ 1`。

两个独立缺陷叠加:

1. `dynamic_params_llm.chatJSON` 只设 `MaxTokens`,其余采样参数走 Go 零值。
2. `mf_model_api_client.Chat` 用 `map[string]interface{}` 组装请求体,`LLMChatReq` 上的 `omitempty` 在这条路径不生效,`top_p: 0`、`top_k: 0` 原样发出。mf-model-api 校验区间为 `0 < top_p ≤ 1`、`top_k ≥ 1`、`max_tokens ≥ 10`,直接 400。
3. `generateDynamicParams` 把任何生成错误都塞进 `missingParams`,依赖服务故障因此被报成调用方少传参数。

工单只提到 `top_p`;实测 `top_k` 同样非法,pydantic 按字段声明顺序校验,`top_p` 先报错盖住了它。只修 `top_p` 会紧接着撞 `top_k` 400。

## 改动

**commit 1 — 采样参数零值不再外发**

- `Chat` 只在 `top_p` / `top_k` / `max_tokens` 大于 0 时写入请求体;`temperature` 与两个 penalty 的 0 是合法业务取值(区间 `[0,2]` 与 `[-2,2]`),保持恒发。
- `chatJSON` 显式设 `temperature=0` / `top_k=2` / `top_p=0.5`,与 `rerank_llm` 配置默认一致——动态参数生成要的是确定性 JSON 输出。
- 单测覆盖:零值不外发、显式值原样透传、`chatJSON` 产出的参数落在网关校验区间内。

**commit 2 — 生成失败不再伪装成缺参**

生成失败单独归集为 `genFailures`,优先于缺参上报,返回 500 `DYNAMIC_PARAMS_GENERATION_FAILED` 并保留上游 `code`/`detail`。debug 模式行为不变。这一 commit 是错误语义调整,可单独摘除。

## 验证(测试服 14.103.77.23)

修复前,基线镜像 `0.1.1-main.20260727104211.sha910f041`,MCP 原样复现工单请求:

| 请求体 | 结果 |
|---|---|
| `top_p:0, top_k:0` | 400 `top_p must be an float and the range of values is 0 < top_p ≤ 1` |
| `top_p:0.5, top_k:0` | 400 `top_k must be an integer and greater than or equal to 1` |
| 两者均不传 | 200 |

修复后(overlay 镜像 `agent-retrieval:fix450-1`),同一 MCP 调用返回 `datas`,日志显示动态参数生成耗时 3681ms、查询 126ms,无报错。

单测 `go test ./...` 全绿,`go vet` 无告警。

## 遗留(不属本 PR)

用真实实例 id 调用后 `is_correct` 值为 `null`,ontology-query 日志:

```
extract tool result with path "$.data.is_correct" failed for logic property is_correct: unknown key data
```

该 KN 里 `is_correct` 配置的结果提取路径与工具实际返回结构不匹配,与本 issue 无关,另行处理。

🤖 Generated with [Claude Code](https://claude.com/claude-code)