### PR TITLE
fix(vega): keep failed build tasks terminal

### DIFF
--- a/adp/vega/vega-backend/server/worker/build_task_common.go
+++ b/adp/vega/vega-backend/server/worker/build_task_common.go
@@ -140,6 +140,13 @@ func isAsynqFinalRetry(ctx context.Context) bool {
 	return retryCount >= maxRetry
 }
 
+// isBuildTaskTerminal reports statuses that background workers must never revive.
+func isBuildTaskTerminal(status string) bool {
+	return status == interfaces.BuildTaskStatusFailed ||
+		status == interfaces.BuildTaskStatusStopped ||
+		status == interfaces.BuildTaskStatusCompleted
+}
+
 // createManagedLocalIndex creates a build-task local index through LocalIndexManager.
 func createManagedLocalIndex(ctx context.Context, lim interfaces.LocalIndexManager, indexName string, buildTask *interfaces.BuildTask, resource *interfaces.Resource) error {
 	schema, err := buildLocalIndexSchema(buildTask, resource)

--- a/adp/vega/vega-backend/server/worker/build_worker_batch.go
+++ b/adp/vega/vega-backend/server/worker/build_worker_batch.go
@@ -158,17 +158,6 @@ func advanceCursor(cursor []interfaces.KeyValue, keys []string, lastItem map[str
 
 // executeBuild executes the build logic
 func (bbw *batchBuildWorker) executeBuild(ctx context.Context, resource *interfaces.Resource, buildTaskInfo *interfaces.BuildTask, executeType string) error {
-	hasEmbedding := buildTaskHasEmbedding(buildTaskInfo)
-	// 两个操作均幂等（embedding 任务靠 asynq TaskID 去重，索引已存在则跳过），
-	// 不能只在 init 时执行：stop→start 重启后老 embedding worker 已退出，
-	// 若不补发，文档 ID 堆积在 Kafka 无消费者，向量化永远停滞
-	if hasEmbedding {
-		err := sendEmbeddingTask(bbw.client, buildTaskInfo.ID)
-		if err != nil {
-			return fmt.Errorf("send embedding task failed: %w", err)
-		}
-		logger.Infof("Embedding task sent for task %s", buildTaskInfo.ID)
-	}
 	indexName := getIndexName(resource.ID, buildTaskInfo.ID)
 	err := createManagedLocalIndex(ctx, bbw.lim, indexName, buildTaskInfo, resource)
 	if err != nil {
@@ -265,6 +254,7 @@ func (bbw *batchBuildWorker) executeBuild(ctx context.Context, resource *interfa
 		}
 	}
 
+	hasEmbedding := buildTaskHasEmbedding(buildTaskInfo)
 	var writer *kafka.Writer
 	if hasEmbedding {
 		topic := getEmbeddingTopic(resource.ID, buildTaskInfo.ID)
@@ -279,6 +269,16 @@ func (bbw *batchBuildWorker) executeBuild(ctx context.Context, resource *interfa
 			return fmt.Errorf("failed to create Kafka topic: %w", err)
 		}
 		defer bbw.kafkaAccess.CloseWriter(writer)
+	}
+	// 索引、数据源连接与 Kafka writer/topic 均是 embedding 的前置条件。
+	// 只有全部准备成功后才投递子任务，避免主任务早期失败时已启动的 worker
+	// 覆写 failed 状态或持续重试。投递使用确定性 TaskID 去重，stop→start
+	// 重启时仍可安全补发。
+	if hasEmbedding {
+		if err := sendEmbeddingTask(bbw.client, buildTaskInfo.ID); err != nil {
+			return fmt.Errorf("send embedding task failed: %w", err)
+		}
+		logger.Infof("Embedding task sent for task %s", buildTaskInfo.ID)
 	}
 
 	syncedCount := buildTaskInfo.SyncedCount

--- a/adp/vega/vega-backend/server/worker/build_worker_batch_test.go
+++ b/adp/vega/vega-backend/server/worker/build_worker_batch_test.go
@@ -9,6 +9,7 @@ import (
 	"errors"
 	"testing"
 
+	"github.com/agiledragon/gomonkey/v2"
 	"github.com/bytedance/sonic"
 	"github.com/hibiken/asynq"
 	"github.com/stretchr/testify/assert"
@@ -109,6 +110,45 @@ func TestBatchBuildWorkerHandleTask(t *testing.T) {
 		task := asynq.NewTask("build:batch", workerBuildTaskPayload(t, interfaces.BatchBuildTaskMessage{TaskID: "t1"}))
 		require.NoError(t, bbw.HandleTask(context.Background(), task))
 		assert.Equal(t, interfaces.BuildIndexName("r1", "old-task"), resource.LocalIndexName)
+	})
+}
+
+func TestBatchBuildWorkerExecuteBuild(t *testing.T) {
+	t.Run("does not dispatch embedding when index creation fails", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		lim := vmock.NewMockLocalIndexManager(ctrl)
+		enqueueCalled := false
+		patches := gomonkey.ApplyFunc(sendEmbeddingTask,
+			func(*asynq.Client, string) error {
+				enqueueCalled = true
+				return nil
+			})
+		defer patches.Reset()
+		bbw := &batchBuildWorker{lim: lim}
+		resource := &interfaces.Resource{
+			ID: "r1",
+			SchemaDefinition: []*interfaces.Property{
+				{
+					Name: "content", Type: interfaces.DataType_String,
+					Features: []interfaces.PropertyFeature{{FeatureType: interfaces.DataType_Vector}},
+				},
+			},
+		}
+		buildTask := &interfaces.BuildTask{
+			ID: "t1",
+			IndexConfig: &interfaces.BuildTaskIndexConfig{Features: map[string]interfaces.BuildTaskFieldIndexFeature{
+				"content": {Vector: &interfaces.BuildTaskEmbeddingConfig{ModelID: "m1", Dimensions: 3}},
+			}},
+		}
+
+		lim.EXPECT().CheckExist(gomock.Any(), interfaces.BuildIndexName("r1", "t1")).Return(false, nil)
+		lim.EXPECT().CreateIndex(gomock.Any(), interfaces.BuildIndexName("r1", "t1"), gomock.Any()).
+			Return(errors.New("opensearch unavailable"))
+
+		err := bbw.executeBuild(context.Background(), resource, buildTask, interfaces.BuildTaskExecuteTypeIncremental)
+		require.Error(t, err)
+		assert.ErrorContains(t, err, "create local index failed: opensearch unavailable")
+		assert.False(t, enqueueCalled)
 	})
 }
 

--- a/adp/vega/vega-backend/server/worker/build_worker_embedding.go
+++ b/adp/vega/vega-backend/server/worker/build_worker_embedding.go
@@ -77,6 +77,10 @@ func (ew *embeddingWorker) HandleTask(ctx context.Context, task *asynq.Task) err
 		// Task not found, return nil
 		return nil
 	}
+	if isBuildTaskTerminal(buildTaskInfo.Status) {
+		logger.Infof("Task %s is %s, skip embedding", taskID, buildTaskInfo.Status)
+		return nil
+	}
 	// 异步任务无原始请求上下文，以任务创建者身份执行下游权限检查
 	ctx = context.WithValue(ctx, interfaces.ACCOUNT_INFO_KEY, buildTaskInfo.Creator)
 	logger.Infof("Starting embedding for task: %s, resource: %s", taskID, buildTaskInfo.ResourceID)
@@ -96,13 +100,6 @@ func (ew *embeddingWorker) HandleTask(ctx context.Context, task *asynq.Task) err
 			return fmt.Errorf("update build task status failed: %w", err)
 		}
 		return nil
-	}
-
-	// Update task status to running
-	update := interfaces.NewBuildTaskUpdate().WithStatus(interfaces.BuildTaskStatusRunning)
-	_, err = ew.bts.InternalUpdateStatus(ctx, nil, taskID, update)
-	if err != nil {
-		return fmt.Errorf("update build task status failed: %w", err)
 	}
 
 	// Execute embedding
@@ -174,6 +171,10 @@ func (ew *embeddingWorker) executeEmbedding(ctx context.Context, resource *inter
 			logger.Errorf("Failed to get task status: %v", err)
 			ew.pause(retryInterval)
 			continue
+		}
+		if isBuildTaskTerminal(taskStatus) {
+			logger.Infof("Task %s is %s, stop embedding", buildTaskInfo.ID, taskStatus)
+			return nil
 		}
 
 		// Handle stopping status

--- a/adp/vega/vega-backend/server/worker/build_worker_embedding_test.go
+++ b/adp/vega/vega-backend/server/worker/build_worker_embedding_test.go
@@ -24,6 +24,27 @@ import (
 )
 
 func TestEmbeddingWorkerHandleTask(t *testing.T) {
+	t.Run("skips terminal task without reviving it", func(t *testing.T) {
+		for _, status := range []string{
+			interfaces.BuildTaskStatusFailed,
+			interfaces.BuildTaskStatusStopped,
+			interfaces.BuildTaskStatusCompleted,
+		} {
+			t.Run(status, func(t *testing.T) {
+				ctrl := gomock.NewController(t)
+				bts := vmock.NewMockBuildTaskService(ctrl)
+				ew := &embeddingWorker{bts: bts}
+
+				bts.EXPECT().InternalGetByID(gomock.Any(), "t1").Return(&interfaces.BuildTask{
+					ID: "t1", ResourceID: "r1", Status: status,
+				}, nil)
+
+				task := asynq.NewTask("build:embedding", workerBuildTaskPayload(t, interfaces.EmbeddingBuildTaskMessage{TaskID: "t1"}))
+				require.NoError(t, ew.HandleTask(context.Background(), task))
+			})
+		}
+	})
+
 	t.Run("injects creator into downstream context", func(t *testing.T) {
 		ctrl := gomock.NewController(t)
 		bts := vmock.NewMockBuildTaskService(ctrl)
@@ -56,6 +77,20 @@ func TestEmbeddingWorkerHandleTask(t *testing.T) {
 }
 
 func TestEmbeddingWorkerExecuteEmbedding(t *testing.T) {
+	t.Run("stops without retry when batch task becomes failed", func(t *testing.T) {
+		ew, ts, ka := newEmbeddingLoopWorker(t)
+		resource, task := embeddingLoopFixtures()
+
+		expectEmbeddingKafkaSession(ka)
+		gomock.InOrder(
+			ts.EXPECT().InternalGetStatus(gomock.Any(), "t1").Return(interfaces.BuildTaskStatusRunning, nil),
+			ka.EXPECT().ReadMessage(gomock.Any(), gomock.Any()).Return(kafka.Message{}, context.DeadlineExceeded),
+			ts.EXPECT().InternalGetStatus(gomock.Any(), "t1").Return(interfaces.BuildTaskStatusFailed, nil),
+		)
+
+		require.NoError(t, ew.executeEmbedding(context.Background(), resource, task))
+	})
+
 	t.Run("ctx canceled returns error for requeue", func(t *testing.T) {
 		ew, ts, ka := newEmbeddingLoopWorker(t)
 		resource, task := embeddingLoopFixtures()


### PR DESCRIPTION
## What Changed

- [x] Delay embedding-task dispatch until the OpenSearch index, source connection, and Kafka writer/topic are ready.
- [x] Prevent embedding workers from reviving terminal build tasks or continuing after the batch task fails.
- [x] Add regression coverage for failed index creation, terminal tasks, and an in-flight worker observing a failed batch task.
- [x] Docs/doc 1 — not required; no public API or configuration changed.

---

## Why

- Related Issue: Closes #455
- Related Feature: N/A
- Background: An embedding worker could overwrite a failed batch-build task as running and retry after index creation failed.

---

## How

- Key implementation points: Dispatch embedding only after its prerequisites succeed; workers exit successfully when the task is failed, stopped, or completed.
- Breaking changes (API, config, database, etc.): None.

---

## Testing

- [x] Unit tests passed locally
- [ ] Integration tests passed locally — not applicable; tests use mocks.
- [ ] Verified in test environment — not performed; deployment was not requested.

Test notes:

- `make lint`, `make test`, and `make test-race` passed.

---

## Risk & Rollback

- Potential risks: Embedding begins only after Kafka writer setup; a prerequisite failure now fails the main task without starting a child worker.
- Rollback plan: Revert commit `c4bdd667`.

---

## Additional Notes

- No configuration changes are included.
