### PR TITLE
fix(vega): finalize build task progress from total

### DIFF
--- a/adp/vega/vega-backend/server/worker/build_worker_embedding.go
+++ b/adp/vega/vega-backend/server/worker/build_worker_embedding.go
@@ -312,25 +312,39 @@ func (ew *embeddingWorker) executeEmbedding(ctx context.Context, resource *inter
 				}
 
 				// 哨兵到达说明同步侧已发完、且组内已消费全部文档消息。
-				// 同任务可能短暂存在两个消费者（asynq 重投的旧实例 + 新一轮入队的实例），
-				// 单分区下旧实例抢走文档、新实例只读到哨兵，内存计数只覆盖自己的切片；
-				// 以最新 synced - 已知失败 为下限、synced 为上限对齐：
-				// 向量数不可能超过同步数，历史重放/恢复续跑造成的虚高一并封顶
+				// total_count 是批量构建的权威完成数量；synced_count 可能因最后一次
+				// 进度写入未落账而滞后，不能用它封顶完成态进度。
+				finalSyncedCount := buildTaskInfo.SyncedCount
 				finalCount := totalProcessed
+				hasFreshProgress := false
 				if fresh, err := ew.bts.InternalGetByID(ctx, buildTaskInfo.ID); err == nil && fresh != nil {
-					if c := fresh.SyncedCount - int64(len(stillFailed)); c > finalCount {
-						logger.Infof("Embedding count for task %s aligned to synced: local=%d, final=%d (split consumers suspected)", buildTaskInfo.ID, totalProcessed, c)
-						finalCount = c
+					hasFreshProgress = true
+					finalSyncedCount = fresh.SyncedCount
+					if fresh.TotalCount > 0 {
+						finalSyncedCount = fresh.TotalCount
 					}
-					if finalCount > fresh.SyncedCount {
-						logger.Infof("Embedding count for task %s capped at synced: local=%d, synced=%d (replayed messages suspected)", buildTaskInfo.ID, finalCount, fresh.SyncedCount)
-						finalCount = fresh.SyncedCount
+				}
+				if hasFreshProgress {
+					targetVectorizedCount := finalSyncedCount - int64(len(stillFailed))
+					if targetVectorizedCount < 0 {
+						targetVectorizedCount = 0
+					}
+					if targetVectorizedCount > finalCount {
+						logger.Infof("Embedding count for task %s aligned to completed total: local=%d, final=%d", buildTaskInfo.ID, totalProcessed, targetVectorizedCount)
+						finalCount = targetVectorizedCount
+					}
+					if finalCount > finalSyncedCount {
+						logger.Infof("Embedding count for task %s capped at completed total: local=%d, total=%d", buildTaskInfo.ID, finalCount, finalSyncedCount)
+						finalCount = finalSyncedCount
 					}
 				}
 
 				update := interfaces.NewBuildTaskUpdate().
 					WithStatus(interfaces.BuildTaskStatusCompleted).
 					WithVectorizedCount(finalCount)
+				if hasFreshProgress {
+					update = update.WithSyncedCount(finalSyncedCount)
+				}
 				// 重试耗尽的文档如实记录到 failure_detail（与 error_msg 区分：completed 但向量不全时，
 				// failure_detail 说明缺了哪些；error_msg 仅留给整任务硬失败）。显式置空以清除上一轮重建的陈旧明细。
 				update = update.WithFailureDetail("")

--- a/adp/vega/vega-backend/server/worker/build_worker_embedding_test.go
+++ b/adp/vega/vega-backend/server/worker/build_worker_embedding_test.go
@@ -154,14 +154,14 @@ func TestEmbeddingWorkerExecuteEmbedding(t *testing.T) {
 		assert.Contains(t, err.Error(), "use of closed network connection")
 	})
 
-	t.Run("end sentinel switches local index and completes task", func(t *testing.T) {
+	t.Run("end sentinel completes progress from total when synced count is stale", func(t *testing.T) {
 		ew, ts, ka := newEmbeddingLoopWorker(t)
 		ctrl := gomock.NewController(t)
 		rs := vmock.NewMockResourceService(ctrl)
 		ew.rs = rs
 		resource, task := embeddingLoopFixtures()
 		resource.LocalIndexName = interfaces.BuildIndexName("r1", "old-task")
-		task.SyncedCount = 7
+		task.SyncedCount = 1330
 		wantIndexName := interfaces.BuildIndexName("r1", "t1")
 
 		expectEmbeddingKafkaSession(ka)
@@ -178,20 +178,52 @@ func TestEmbeddingWorkerExecuteEmbedding(t *testing.T) {
 				return nil
 			})
 		ts.EXPECT().InternalGetByID(gomock.Any(), "t1").
-			Return(&interfaces.BuildTask{ID: "t1", SyncedCount: 7}, nil)
+			Return(&interfaces.BuildTask{ID: "t1", SyncedCount: 1330, TotalCount: 50000}, nil)
 		ts.EXPECT().InternalUpdateStatus(gomock.Any(), nil, "t1", gomock.Any()).
 			DoAndReturn(func(_ context.Context, _ *sql.Tx, _ string, update interfaces.BuildTaskUpdate, _ ...string) (bool, error) {
 				require.NotNil(t, update.Status)
+				require.NotNil(t, update.SyncedCount)
 				require.NotNil(t, update.VectorizedCount)
 				require.NotNil(t, update.FailureDetail)
 				assert.Equal(t, interfaces.BuildTaskStatusCompleted, *update.Status)
-				assert.Equal(t, int64(7), *update.VectorizedCount)
+				assert.Equal(t, int64(50000), *update.SyncedCount)
+				assert.Equal(t, int64(50000), *update.VectorizedCount)
 				assert.Equal(t, "", *update.FailureDetail)
 				return true, nil
 			})
 
 		require.NoError(t, ew.executeEmbedding(context.Background(), resource, task))
 		assert.Equal(t, wantIndexName, resource.LocalIndexName)
+	})
+
+	t.Run("end sentinel keeps synced count unchanged when fresh task lookup fails", func(t *testing.T) {
+		ew, ts, ka := newEmbeddingLoopWorker(t)
+		ctrl := gomock.NewController(t)
+		rs := vmock.NewMockResourceService(ctrl)
+		ew.rs = rs
+		resource, task := embeddingLoopFixtures()
+
+		expectEmbeddingKafkaSession(ka)
+		ts.EXPECT().InternalGetStatus(gomock.Any(), "t1").Return(interfaces.BuildTaskStatusRunning, nil)
+		ka.EXPECT().ReadMessage(gomock.Any(), gomock.Any()).
+			Return(kafka.Message{Value: []byte(`{"document_id":"` + interfaces.EmptyDocumentID + `"}`)}, nil)
+		ka.EXPECT().CommitMessages(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
+		ka.EXPECT().ReadMessage(gomock.Any(), gomock.Any()).
+			Return(kafka.Message{}, context.DeadlineExceeded).
+			Times(embeddingDrainEmptyPolls)
+		rs.EXPECT().InternalUpdate(gomock.Any(), nil, resource).Return(nil)
+		ts.EXPECT().InternalGetByID(gomock.Any(), "t1").Return(nil, errors.New("database unavailable"))
+		ts.EXPECT().InternalUpdateStatus(gomock.Any(), nil, "t1", gomock.Any()).
+			DoAndReturn(func(_ context.Context, _ *sql.Tx, _ string, update interfaces.BuildTaskUpdate, _ ...string) (bool, error) {
+				require.NotNil(t, update.Status)
+				require.Nil(t, update.SyncedCount)
+				require.NotNil(t, update.VectorizedCount)
+				assert.Equal(t, interfaces.BuildTaskStatusCompleted, *update.Status)
+				assert.Equal(t, int64(7), *update.VectorizedCount)
+				return true, nil
+			})
+
+		require.NoError(t, ew.executeEmbedding(context.Background(), resource, task))
 	})
 }
 


### PR DESCRIPTION
## What Changed

- [x] Finalize batch-build synced and vectorized progress from the authoritative total count after the embedding completion sentinel.
- [x] Preserve persisted synced progress if the final task lookup is temporarily unavailable.
- [x] Add regression coverage for stale progress and lookup failure.
- [x] Docs/doc 1 — not required; no public API or configuration changed.

---

## Why

- Related Issue: Closes #467
- Related Feature: N/A
- Background: Completed and effective indexes could still display stale task progress, such as 1,330 / 50,000 and 3%.

---

## How

- Key implementation points: On the completed Kafka sentinel, use the latest task total count to finalize synced/vectorized counts, while preserving partial-vectorization failure details. Do not overwrite synced progress when the final task read fails.
- Breaking changes (API, config, database, etc.): None.

---

## Testing

- [x] Unit tests passed locally
- [ ] Integration tests passed locally — not applicable; tests use mocks.
- [ ] Verified in test environment — not performed; deployment was not requested.

Test notes:

- `make lint`, `make test`, and `make test-race` passed.

---

## Risk & Rollback

- Potential risks: Completed batch tasks now use total count as the final progress authority; partial vectorization failures remain deducted and reported.
- Rollback plan: Revert commit `859f9f8c`.

---

## Additional Notes

- No configuration changes are included.
