### PR TITLE
fix(execution-factory): 校验未替换的 path 占位符并补齐 Tool/Operator 调试参数用例

### DIFF
--- a/adp/execution-factory/operator-integration/server/infra/errors/error_code.go
+++ b/adp/execution-factory/operator-integration/server/infra/errors/error_code.go
@@ -112,6 +112,8 @@ const (
 const (
 	// 请求转发失败，请检查是否可用，或稍后重试
 	ErrExtProxyForwardFailed ErrorCode = "ProxyForwardFailed"
+	// 路径参数缺失，URL 模板中仍有未替换的占位符
+	ErrExtProxyPathParamMissing ErrorCode = "ProxyPathParamMissing"
 )
 
 // common拓展错误码定义

--- a/adp/execution-factory/operator-integration/server/infra/localize/locales/en-US.json
+++ b/adp/execution-factory/operator-integration/server/infra/localize/locales/en-US.json
@@ -143,6 +143,7 @@
         "CategoryNotFound": "Category not found",
         "CategoryNameExist": "Category name already exists",
         "ProxyForwardFailed": "Request forwarding failed",
+        "ProxyPathParamMissing": "Path parameter \"%s\" is missing, the URL template is not fully resolved",
         "OpenAPISyntaxInvalid": "OpenAPI syntax is invalid, please check if it conforms to the OpenAPI 3.0 specification",
         "OpenAPIInvalidPath": "OpenAPI path is invalid, please check if it conforms to the OpenAPI 3.0 specification",
         "OpenAPIInvalidParameterRequired": "Parameter \"%s\" is required, please check if there is any missing parameter",
@@ -201,6 +202,7 @@
         "MCPDescLimit": "MCP description exceeds maximum length (%d characters)",
         "OperatorStatusInvalid": "Please refresh the page and try again",
         "ProxyForwardFailed": "Please check if the request is correct, or try again later",
+        "ProxyPathParamMissing": "Please fill in the missing path parameters and try again",
         "CommonImportDataEmpty": "Please check if the import data is correct",
         "SandboxRuntimeExecuteCodeFailed": "Sandbox runtime execute code failed, please check if the code is correct",
         "PypiParserFailed": "Example: Official PyPI source: https://pypi.org/simple/, Tsinghua source: https://pypi.tuna.tsinghua.edu.cn/simple/"

--- a/adp/execution-factory/operator-integration/server/infra/localize/locales/zh-Hans.json
+++ b/adp/execution-factory/operator-integration/server/infra/localize/locales/zh-Hans.json
@@ -143,6 +143,7 @@
         "CategoryNotFound": "算子分类不存在",
         "CategoryNameExist": "算子分类名称已存在",
         "ProxyForwardFailed": "请求转发失败",
+        "ProxyPathParamMissing": "路径参数“%s”缺失，URL 模板未完成替换",
         "OpenAPISyntaxInvalid": "文件格式不正确，请检查是否符合OpenAPI 3.0规范",
         "OpenAPIInvalidPath": "API路径定义缺失或格式错误，请检查路径定义是否正确",
         "OpenAPIInvalidParameterRequired": "参数“%s”缺少必需字段，请检查是否有缺失参数",
@@ -201,6 +202,7 @@
         "MCPDescLimit": "MCP描述长度不能超过%d个字符",
         "OperatorStatusInvalid": "请刷新页面后重试",
         "ProxyForwardFailed": "请检查请求是否正确，或稍后重试",
+        "ProxyPathParamMissing": "请补齐路径参数后重试",
         "CommonImportDataEmpty": "请检查导入数据是否正确",
         "PypiParserFailed": "示例：官方Pypi源地址：https://pypi.org/simple/，清华源地址：https://pypi.tuna.tsinghua.edu.cn/simple/"
     },

--- a/adp/execution-factory/operator-integration/server/logics/operator/debug_params_test.go
+++ b/adp/execution-factory/operator-integration/server/logics/operator/debug_params_test.go
@@ -1,0 +1,190 @@
+package operator
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"testing"
+
+	"github.com/openbkn-ai/adp/execution-factory/operator-integration/server/infra/logger"
+	"github.com/openbkn-ai/adp/execution-factory/operator-integration/server/interfaces"
+	"github.com/openbkn-ai/adp/execution-factory/operator-integration/server/interfaces/model"
+	"github.com/openbkn-ai/adp/execution-factory/operator-integration/server/logics/metric"
+	"github.com/openbkn-ai/adp/execution-factory/operator-integration/server/mocks"
+	. "github.com/smartystreets/goconvey/convey"
+	"go.uber.org/mock/gomock"
+)
+
+const (
+	debugOperatorID      = "5a3d1f6c-2e57-4a2f-95a1-3c1c1f0f9d21"
+	debugMetadataVersion = "9b0d2a44-4f4e-4f2f-8a6f-6a4a4d0d1c33"
+)
+
+// debugOperatorFixture 组装算子调试所需的最小依赖，并回传代理实际收到的请求。
+type debugOperatorFixture struct {
+	manager  *operatorManager
+	captured **interfaces.HTTPRequest
+}
+
+func newDebugOperatorFixture(t *testing.T) *debugOperatorFixture {
+	ctrl := gomock.NewController(t)
+
+	mockDBOperatorManager := mocks.NewMockIOperatorRegisterDB(ctrl)
+	mockOpReleaseDB := mocks.NewMockIOperatorReleaseDB(ctrl)
+	mockAuthService := mocks.NewMockIAuthorizationService(ctrl)
+	mockMetadataService := mocks.NewMockIMetadataService(ctrl)
+	mockMetadata := mocks.NewMockIMetadataDB(ctrl)
+	mockProxy := mocks.NewMockProxyHandler(ctrl)
+	mockAuditLog := mocks.NewMockLogModelOperator[*metric.AuditLogBuilderParams](ctrl)
+
+	mockDBOperatorManager.EXPECT().SelectByOperatorID(gomock.Any(), nil, debugOperatorID).
+		Return(true, &model.OperatorRegisterDB{
+			OperatorID:      debugOperatorID,
+			Name:            "op",
+			MetadataVersion: debugMetadataVersion,
+			MetadataType:    string(interfaces.MetadataTypeAPI),
+			ExecutionMode:   string(interfaces.ExecutionModeSync),
+			ExecuteControl:  `{"timeout":30}`,
+		}, nil).AnyTimes()
+	mockOpReleaseDB.EXPECT().SelectByOpID(gomock.Any(), debugOperatorID).
+		Return(true, &model.OperatorReleaseDB{
+			OpID:            debugOperatorID,
+			Name:            "op",
+			Status:          string(interfaces.BizStatusPublished),
+			MetadataVersion: debugMetadataVersion,
+			MetadataType:    string(interfaces.MetadataTypeAPI),
+			ExecutionMode:   string(interfaces.ExecutionModeSync),
+			ExecuteControl:  `{"timeout":30}`,
+		}, nil).AnyTimes()
+	mockAuthService.EXPECT().GetAccessor(gomock.Any(), "u1").
+		Return(&interfaces.AuthAccessor{ID: "u1"}, nil).AnyTimes()
+	mockAuthService.EXPECT().
+		CheckExecutePermission(gomock.Any(), gomock.Any(), debugOperatorID, interfaces.AuthResourceTypeOperator).
+		Return(nil).AnyTimes()
+	mockMetadataService.EXPECT().
+		CheckMetadataExists(gomock.Any(), interfaces.MetadataTypeAPI, debugMetadataVersion).
+		Return(true, mockMetadata, nil).AnyTimes()
+	mockMetadata.EXPECT().GetServerURL().Return("http://operator-svc").AnyTimes()
+	mockMetadata.EXPECT().GetPath().Return("/api/v1/operator/market/{operator_id}").AnyTimes()
+	mockMetadata.EXPECT().GetMethod().Return(http.MethodGet).AnyTimes()
+
+	var captured *interfaces.HTTPRequest
+	mockProxy.EXPECT().HandlerRequest(gomock.Any(), gomock.Any()).
+		DoAndReturn(func(_ context.Context, req *interfaces.HTTPRequest) (*interfaces.HTTPResponse, error) {
+			captured = req
+			return &interfaces.HTTPResponse{StatusCode: http.StatusOK}, nil
+		}).AnyTimes()
+
+	return &debugOperatorFixture{
+		manager: &operatorManager{
+			Logger:            logger.DefaultLogger(),
+			DBOperatorManager: mockDBOperatorManager,
+			OpReleaseDB:       mockOpReleaseDB,
+			AuthService:       mockAuthService,
+			MetadataService:   mockMetadataService,
+			Proxy:             mockProxy,
+			AuditLog:          mockAuditLog,
+		},
+		captured: &captured,
+	}
+}
+
+// debugOperatorRequestJSON 是 Studio 算子调试面板提交的请求体形态：header/query/path/body 四段并列。
+const debugOperatorRequestJSON = `{
+	"timeout": 5,
+	"header": {"X-Api-Key": "secret-key"},
+	"query": {"version": "v1"},
+	"path": {"operator_id": "op-1"},
+	"body": {"payload": "p1", "query": "业务字段 query"}
+}`
+
+// TestDebugOperator_ForwardsAllRequestParams 校验算子调试的 header/query/path/body 原样抵达代理层（#216 验收标准 5）。
+func TestDebugOperator_ForwardsAllRequestParams(t *testing.T) {
+	Convey("算子调试透传完整请求参数", t, func() {
+		req := &interfaces.DebugOperatorReq{
+			UserID:     "u1",
+			OperatorID: debugOperatorID,
+			Version:    debugMetadataVersion,
+		}
+		So(json.Unmarshal([]byte(debugOperatorRequestJSON), req), ShouldBeNil)
+
+		Convey("四段参数在请求体反序列化时各就各位", func() {
+			So(req.PathParams["operator_id"], ShouldEqual, "op-1")
+			So(req.QueryParams["version"], ShouldEqual, "v1")
+			So(req.Headers["X-Api-Key"], ShouldEqual, "secret-key")
+
+			body, ok := req.Body.(map[string]any)
+			So(ok, ShouldBeTrue)
+			So(body["payload"], ShouldEqual, "p1")
+			// body 里的同名业务字段不会被当作调试信封（#216 验收标准 12）
+			So(body["query"], ShouldEqual, "业务字段 query")
+		})
+
+		Convey("DebugOperator 把四段参数交给代理层", func() {
+			fixture := newDebugOperatorFixture(t)
+
+			resp, err := fixture.manager.DebugOperator(context.Background(), req)
+
+			So(err, ShouldBeNil)
+			So(resp.StatusCode, ShouldEqual, http.StatusOK)
+
+			proxyReq := *fixture.captured
+			So(proxyReq, ShouldNotBeNil)
+			So(proxyReq.Method, ShouldEqual, http.MethodGet)
+			So(proxyReq.URL, ShouldEqual, "http://operator-svc/api/v1/operator/market/{operator_id}")
+			So(proxyReq.PathParams["operator_id"], ShouldEqual, "op-1")
+			So(proxyReq.QueryParams["version"], ShouldEqual, "v1")
+			So(proxyReq.Headers["X-Api-Key"], ShouldEqual, "secret-key")
+
+			body, ok := proxyReq.Body.(map[string]any)
+			So(ok, ShouldBeTrue)
+			So(body["payload"], ShouldEqual, "p1")
+			So(body["query"], ShouldEqual, "业务字段 query")
+		})
+	})
+}
+
+// TestExecuteOperator_ForwardsAllRequestParams 校验算子正式执行走同一条透传链路（#216 验收标准 5）。
+func TestExecuteOperator_ForwardsAllRequestParams(t *testing.T) {
+	Convey("算子执行透传完整请求参数", t, func() {
+		fixture := newDebugOperatorFixture(t)
+		req := &interfaces.ExecuteOperatorReq{UserID: "u1", OperatorID: debugOperatorID}
+		So(json.Unmarshal([]byte(debugOperatorRequestJSON), req), ShouldBeNil)
+
+		resp, err := fixture.manager.ExecuteOperator(context.Background(), req)
+
+		So(err, ShouldBeNil)
+		So(resp.StatusCode, ShouldEqual, http.StatusOK)
+
+		proxyReq := *fixture.captured
+		So(proxyReq, ShouldNotBeNil)
+		So(proxyReq.PathParams["operator_id"], ShouldEqual, "op-1")
+		So(proxyReq.QueryParams["version"], ShouldEqual, "v1")
+		So(proxyReq.Headers["X-Api-Key"], ShouldEqual, "secret-key")
+	})
+}
+
+// TestDebugOperator_NoParamsOperatorSendsEmptyEnvelope 校验无入参算子调试时不会凭空造出 path/query/header（#216 验收标准 8 的后端侧）。
+func TestDebugOperator_NoParamsOperatorSendsEmptyEnvelope(t *testing.T) {
+	Convey("无入参算子调试只发空信封", t, func() {
+		fixture := newDebugOperatorFixture(t)
+		req := &interfaces.DebugOperatorReq{
+			UserID:     "u1",
+			OperatorID: debugOperatorID,
+			Version:    debugMetadataVersion,
+		}
+		So(json.Unmarshal([]byte(`{"timeout":5}`), req), ShouldBeNil)
+
+		resp, err := fixture.manager.DebugOperator(context.Background(), req)
+
+		So(err, ShouldBeNil)
+		So(resp.StatusCode, ShouldEqual, http.StatusOK)
+
+		proxyReq := *fixture.captured
+		So(proxyReq, ShouldNotBeNil)
+		So(proxyReq.PathParams, ShouldBeEmpty)
+		So(proxyReq.QueryParams, ShouldBeEmpty)
+		So(proxyReq.Headers, ShouldBeEmpty)
+		So(proxyReq.Body, ShouldBeNil)
+	})
+}

--- a/adp/execution-factory/operator-integration/server/logics/proxy/forwarder.go
+++ b/adp/execution-factory/operator-integration/server/logics/proxy/forwarder.go
@@ -9,6 +9,7 @@ import (
 	"mime/multipart"
 	"net/http"
 	"net/url"
+	"regexp"
 	"strings"
 	"sync"
 	"time"
@@ -180,10 +181,17 @@ func (f *forwarder) buildRequest(ctx context.Context, req *interfaces.HTTPReques
 	requestURL := req.URL
 	if len(req.PathParams) > 0 {
 		for key, value := range req.PathParams {
-			requestURL = strings.Replace(requestURL, fmt.Sprintf("{%s}", key), value, -1)
-			requestURL = strings.Replace(requestURL, fmt.Sprintf(":{%s}", key), value, -1)
-			requestURL = strings.Replace(requestURL, fmt.Sprintf(":%s", key), value, -1)
+			// ":{key}" 必须先于 "{key}" 替换，否则会先命中 "{key}" 而在 URL 里留下多余的冒号
+			requestURL = strings.ReplaceAll(requestURL, fmt.Sprintf(":{%s}", key), value)
+			requestURL = strings.ReplaceAll(requestURL, fmt.Sprintf("{%s}", key), value)
+			requestURL = strings.ReplaceAll(requestURL, fmt.Sprintf(":%s", key), value)
 		}
+	}
+	// 路径模板仍有未替换的占位符时直接拒绝，避免把 "/market/{operator_id}" 这类无效 URL 发给下游
+	if unresolved := unresolvedPathPlaceholders(requestURL); len(unresolved) > 0 {
+		missing := strings.Join(unresolved, ", ")
+		return nil, myErr.NewHTTPError(ctx, http.StatusBadRequest, myErr.ErrExtProxyPathParamMissing,
+			fmt.Sprintf("unresolved path placeholder(s) [%s] in url %s", missing, requestURL), missing)
 	}
 	// 处理查询参数
 	if len(req.QueryParams) > 0 {
@@ -204,6 +212,8 @@ func (f *forwarder) buildRequest(ctx context.Context, req *interfaces.HTTPReques
 	// 处理请求体
 	var reqBody io.Reader
 	var contentType string
+	// forceContentType 表示编码过程重算出的 Content-Type 必须覆盖调用方传入的同名请求头
+	var forceContentType bool
 
 	if req.Body != nil {
 		// 检查Content-Type头
@@ -255,8 +265,10 @@ func (f *forwarder) buildRequest(ctx context.Context, req *interfaces.HTTPReques
 				}
 			}
 
-			contentType = writer.FormDataContentType()
 			_ = writer.Close()
+			// writer 生成的 Content-Type 带 boundary，必须覆盖调用方自带的 multipart 头，否则下游无法解析
+			contentType = writer.FormDataContentType()
+			forceContentType = true
 			reqBody = body
 		case strings.Contains(contentType, "text/plain"):
 			// 文本格式
@@ -293,6 +305,13 @@ func (f *forwarder) buildRequest(ctx context.Context, req *interfaces.HTTPReques
 	// 设置请求头，并用当前请求上下文补齐 trace/request id，保证代理链路可聚合。
 	headers := map[string]string{}
 	for key, value := range req.Headers {
+		// 传输层请求头由转发器与 Go HTTP 客户端接管，调用方手填只会让实际请求与预览对不上
+		if isTransportHeader(key) {
+			if f.logger != nil {
+				f.logger.WithContext(ctx).Debugf("drop transport-layer header from caller: %s", key)
+			}
+			continue
+		}
 		headers[key] = fmt.Sprintf("%v", value)
 	}
 	for key, value := range common.MergeTraceHeaders(ctx, headers) {
@@ -300,11 +319,52 @@ func (f *forwarder) buildRequest(ctx context.Context, req *interfaces.HTTPReques
 	}
 
 	// 如果Content-Type未在请求头中设置，但我们有确定的类型，则设置它
-	if contentType != "" && httpReq.Header.Get("Content-Type") == "" {
+	if contentType != "" && (forceContentType || httpReq.Header.Get("Content-Type") == "") {
 		httpReq.Header.Set("Content-Type", contentType)
 	}
 
 	return httpReq, nil
+}
+
+// transportHeaders 由转发链路自身接管的传输层请求头，调用方传入时一律丢弃。
+var transportHeaders = map[string]struct{}{
+	"host":              {},
+	"content-length":    {},
+	"transfer-encoding": {},
+	"connection":        {},
+	"keep-alive":        {},
+	"proxy-connection":  {},
+	"te":                {},
+	"trailer":           {},
+	"upgrade":           {},
+	"expect":            {},
+}
+
+// isTransportHeader 判断请求头是否属于传输层请求头（大小写不敏感）。
+func isTransportHeader(key string) bool {
+	_, ok := transportHeaders[strings.ToLower(strings.TrimSpace(key))]
+	return ok
+}
+
+// pathPlaceholderPattern 匹配路径里形如 {name} 的占位符。
+var pathPlaceholderPattern = regexp.MustCompile(`\{([^{}/]+)\}`)
+
+// unresolvedPathPlaceholders 返回 URL 路径中仍未被 path 参数替换的占位符名称。
+// 只检查路径部分：query 与 fragment 里的花括号可能是业务值，冒号形式无法与端口号区分，都不参与判断。
+func unresolvedPathPlaceholders(rawURL string) []string {
+	target := rawURL
+	if parsed, err := url.Parse(rawURL); err == nil {
+		target = parsed.Path
+	}
+	matches := pathPlaceholderPattern.FindAllStringSubmatch(target, -1)
+	if len(matches) == 0 {
+		return nil
+	}
+	names := make([]string, 0, len(matches))
+	for _, match := range matches {
+		names = append(names, match[1])
+	}
+	return names
 }
 
 // processResponse 处理HTTP响应

--- a/adp/execution-factory/operator-integration/server/logics/proxy/forwarder_params_test.go
+++ b/adp/execution-factory/operator-integration/server/logics/proxy/forwarder_params_test.go
@@ -1,0 +1,565 @@
+package proxy
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"mime"
+	"mime/multipart"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	myErr "github.com/openbkn-ai/adp/execution-factory/operator-integration/server/infra/errors"
+	"github.com/openbkn-ai/adp/execution-factory/operator-integration/server/infra/logger"
+	"github.com/openbkn-ai/adp/execution-factory/operator-integration/server/interfaces"
+	. "github.com/smartystreets/goconvey/convey"
+)
+
+// newTestForwarder 手工装配转发器，避免 NewForwarder/NewClientPool 读取配置文件。
+func newTestForwarder() *forwarder {
+	return &forwarder{
+		pool: &clientPool{
+			clients: make(map[clientKey]*ProxyClient),
+			config: PoolConfig{
+				MaxClients:     4,
+				MaxTimeout:     30 * time.Second,
+				DefaultTimeout: 10 * time.Second,
+			},
+			stopCleanup: make(chan struct{}),
+			logger:      logger.DefaultLogger(),
+		},
+		logger: logger.DefaultLogger(),
+	}
+}
+
+func readAll(t *testing.T, body io.ReadCloser) string {
+	t.Helper()
+	if body == nil {
+		return ""
+	}
+	data, err := io.ReadAll(body)
+	if err != nil {
+		t.Fatalf("read body failed: %v", err)
+	}
+	return string(data)
+}
+
+// TestBuildRequest_PathParams 覆盖 path 参数占位符替换（#216 验收标准 1）。
+func TestBuildRequest_PathParams(t *testing.T) {
+	f := newTestForwarder()
+
+	Convey("path 参数替换 URL 占位符", t, func() {
+		Convey("花括号占位符被替换", func() {
+			req := &interfaces.HTTPRequest{
+				HTTPRouter: interfaces.HTTPRouter{
+					Method: http.MethodPost,
+					URL:    "http://svc/api/v1/executions/sessions/{session_id}/execute-sync",
+				},
+				HTTPRequestParams: interfaces.HTTPRequestParams{
+					PathParams: map[string]string{"session_id": "probe-abc"},
+				},
+			}
+
+			httpReq, err := f.buildRequest(context.Background(), req)
+
+			So(err, ShouldBeNil)
+			So(httpReq.URL.Path, ShouldEqual, "/api/v1/executions/sessions/probe-abc/execute-sync")
+		})
+
+		Convey("多个占位符全部被替换", func() {
+			req := &interfaces.HTTPRequest{
+				HTTPRouter: interfaces.HTTPRouter{
+					Method: http.MethodGet,
+					URL:    "http://svc/api/v1/box/{box_id}/tool/{tool_id}",
+				},
+				HTTPRequestParams: interfaces.HTTPRequestParams{
+					PathParams: map[string]string{"box_id": "b1", "tool_id": "t1"},
+				},
+			}
+
+			httpReq, err := f.buildRequest(context.Background(), req)
+
+			So(err, ShouldBeNil)
+			So(httpReq.URL.Path, ShouldEqual, "/api/v1/box/b1/tool/t1")
+		})
+
+		Convey("冒号占位符被替换", func() {
+			req := &interfaces.HTTPRequest{
+				HTTPRouter: interfaces.HTTPRouter{
+					Method: http.MethodGet,
+					URL:    "http://svc/api/v1/operator/market/:operator_id",
+				},
+				HTTPRequestParams: interfaces.HTTPRequestParams{
+					PathParams: map[string]string{"operator_id": "op-1"},
+				},
+			}
+
+			httpReq, err := f.buildRequest(context.Background(), req)
+
+			So(err, ShouldBeNil)
+			So(httpReq.URL.Path, ShouldEqual, "/api/v1/operator/market/op-1")
+		})
+
+		Convey("冒号加花括号的占位符被整体替换，不留多余冒号", func() {
+			req := &interfaces.HTTPRequest{
+				HTTPRouter: interfaces.HTTPRouter{
+					Method: http.MethodGet,
+					URL:    "http://svc/api/v1/operator/market/:{operator_id}",
+				},
+				HTTPRequestParams: interfaces.HTTPRequestParams{
+					PathParams: map[string]string{"operator_id": "op-1"},
+				},
+			}
+
+			httpReq, err := f.buildRequest(context.Background(), req)
+
+			So(err, ShouldBeNil)
+			So(httpReq.URL.Path, ShouldEqual, "/api/v1/operator/market/op-1")
+		})
+
+		Convey("未提供对应 path 参数时拒绝发送并给出明确错误（#216 验收标准 7）", func() {
+			req := &interfaces.HTTPRequest{
+				HTTPRouter: interfaces.HTTPRouter{
+					Method: http.MethodGet,
+					URL:    "http://svc/api/v1/operator/market/{operator_id}",
+				},
+			}
+
+			httpReq, err := f.buildRequest(context.Background(), req)
+
+			So(httpReq, ShouldBeNil)
+			So(err, ShouldNotBeNil)
+			httpErr, ok := err.(*myErr.HTTPError)
+			So(ok, ShouldBeTrue)
+			So(httpErr.HTTPCode, ShouldEqual, http.StatusBadRequest)
+			So(httpErr.Code, ShouldEndWith, string(myErr.ErrExtProxyPathParamMissing))
+			So(httpErr.ErrorDetails, ShouldContainSubstring, "operator_id")
+		})
+
+		Convey("path 参数只给一半时同样被拒绝", func() {
+			req := &interfaces.HTTPRequest{
+				HTTPRouter: interfaces.HTTPRouter{
+					Method: http.MethodGet,
+					URL:    "http://svc/api/v1/box/{box_id}/tool/{tool_id}",
+				},
+				HTTPRequestParams: interfaces.HTTPRequestParams{
+					PathParams: map[string]string{"box_id": "b1"},
+				},
+			}
+
+			httpReq, err := f.buildRequest(context.Background(), req)
+
+			So(httpReq, ShouldBeNil)
+			So(err, ShouldNotBeNil)
+			So(err.(*myErr.HTTPError).ErrorDetails, ShouldContainSubstring, "tool_id")
+		})
+
+		Convey("query 里的花括号是业务值，不触发占位符拦截", func() {
+			req := &interfaces.HTTPRequest{
+				HTTPRouter: interfaces.HTTPRouter{
+					Method: http.MethodGet,
+					URL:    `http://svc/api/v1/resources?filter={"name":"n1"}`,
+				},
+			}
+
+			httpReq, err := f.buildRequest(context.Background(), req)
+
+			So(err, ShouldBeNil)
+			So(httpReq.URL.Query().Get("filter"), ShouldEqual, `{"name":"n1"}`)
+		})
+	})
+}
+
+// TestBuildRequest_QueryParams 覆盖 query 参数拼接（#216 验收标准 3）。
+func TestBuildRequest_QueryParams(t *testing.T) {
+	f := newTestForwarder()
+
+	Convey("query 参数写入请求 URL", t, func() {
+		Convey("追加到无 query 的 URL", func() {
+			req := &interfaces.HTTPRequest{
+				HTTPRouter: interfaces.HTTPRouter{
+					Method: http.MethodGet,
+					URL:    "http://svc/api/v1/resources",
+				},
+				HTTPRequestParams: interfaces.HTTPRequestParams{
+					QueryParams: map[string]any{"page": 1, "size": 20, "active": true},
+				},
+			}
+
+			httpReq, err := f.buildRequest(context.Background(), req)
+
+			So(err, ShouldBeNil)
+			query := httpReq.URL.Query()
+			So(query.Get("page"), ShouldEqual, "1")
+			So(query.Get("size"), ShouldEqual, "20")
+			So(query.Get("active"), ShouldEqual, "true")
+		})
+
+		Convey("与 URL 自带 query 合并而非覆盖", func() {
+			req := &interfaces.HTTPRequest{
+				HTTPRouter: interfaces.HTTPRouter{
+					Method: http.MethodGet,
+					URL:    "http://svc/api/v1/resources?from=metadata",
+				},
+				HTTPRequestParams: interfaces.HTTPRequestParams{
+					QueryParams: map[string]any{"page": 2},
+				},
+			}
+
+			httpReq, err := f.buildRequest(context.Background(), req)
+
+			So(err, ShouldBeNil)
+			query := httpReq.URL.Query()
+			So(query.Get("from"), ShouldEqual, "metadata")
+			So(query.Get("page"), ShouldEqual, "2")
+		})
+
+		Convey("需要转义的值被正确编码", func() {
+			req := &interfaces.HTTPRequest{
+				HTTPRouter: interfaces.HTTPRouter{
+					Method: http.MethodGet,
+					URL:    "http://svc/api/v1/resources",
+				},
+				HTTPRequestParams: interfaces.HTTPRequestParams{
+					QueryParams: map[string]any{"keyword": "a b&c=d"},
+				},
+			}
+
+			httpReq, err := f.buildRequest(context.Background(), req)
+
+			So(err, ShouldBeNil)
+			So(httpReq.URL.RawQuery, ShouldEqual, "keyword=a+b%26c%3Dd")
+			So(httpReq.URL.Query().Get("keyword"), ShouldEqual, "a b&c=d")
+		})
+
+		Convey("query 与 path 同时存在时互不干扰", func() {
+			req := &interfaces.HTTPRequest{
+				HTTPRouter: interfaces.HTTPRouter{
+					Method: http.MethodGet,
+					URL:    "http://svc/api/v1/box/{box_id}/tools",
+				},
+				HTTPRequestParams: interfaces.HTTPRequestParams{
+					PathParams:  map[string]string{"box_id": "b1"},
+					QueryParams: map[string]any{"page": 1},
+				},
+			}
+
+			httpReq, err := f.buildRequest(context.Background(), req)
+
+			So(err, ShouldBeNil)
+			So(httpReq.URL.Path, ShouldEqual, "/api/v1/box/b1/tools")
+			So(httpReq.URL.Query().Get("page"), ShouldEqual, "1")
+		})
+	})
+}
+
+// TestBuildRequest_Headers 覆盖自定义请求头透传（#216 验收标准 4）。
+func TestBuildRequest_Headers(t *testing.T) {
+	f := newTestForwarder()
+
+	Convey("自定义请求头写入下游请求", t, func() {
+		Convey("业务头与鉴权头原样设置", func() {
+			req := &interfaces.HTTPRequest{
+				HTTPRouter: interfaces.HTTPRouter{
+					Method: http.MethodGet,
+					URL:    "http://svc/api/v1/resources",
+				},
+				HTTPRequestParams: interfaces.HTTPRequestParams{
+					Headers: map[string]any{
+						"X-Api-Key":       "secret-key",
+						"X-Tenant-Id":     "tenant-1",
+						"Authorization":   "Bearer token-1",
+						"X-Numeric-Value": 42,
+					},
+				},
+			}
+
+			httpReq, err := f.buildRequest(context.Background(), req)
+
+			So(err, ShouldBeNil)
+			So(httpReq.Header.Get("X-Api-Key"), ShouldEqual, "secret-key")
+			So(httpReq.Header.Get("X-Tenant-Id"), ShouldEqual, "tenant-1")
+			So(httpReq.Header.Get("Authorization"), ShouldEqual, "Bearer token-1")
+			So(httpReq.Header.Get("X-Numeric-Value"), ShouldEqual, "42")
+		})
+
+		Convey("传输层请求头被丢弃，不透传给下游（#216 P1 安全约束）", func() {
+			req := &interfaces.HTTPRequest{
+				HTTPRouter: interfaces.HTTPRouter{
+					Method: http.MethodGet,
+					URL:    "http://svc/api/v1/resources",
+				},
+				HTTPRequestParams: interfaces.HTTPRequestParams{
+					Headers: map[string]any{
+						"Host":              "evil.example.com",
+						"Connection":        "close",
+						"transfer-encoding": "chunked",
+						"Content-Length":    "999",
+						"Upgrade":           "websocket",
+						"X-Company-Token":   "keep-me",
+					},
+				},
+			}
+
+			httpReq, err := f.buildRequest(context.Background(), req)
+
+			So(err, ShouldBeNil)
+			So(httpReq.Host, ShouldEqual, "svc")
+			So(httpReq.Header.Get("Host"), ShouldEqual, "")
+			So(httpReq.Header.Get("Connection"), ShouldEqual, "")
+			So(httpReq.Header.Get("Transfer-Encoding"), ShouldEqual, "")
+			So(httpReq.Header.Get("Content-Length"), ShouldEqual, "")
+			So(httpReq.Header.Get("Upgrade"), ShouldEqual, "")
+			// 自定义鉴权头不在拦截范围内
+			So(httpReq.Header.Get("X-Company-Token"), ShouldEqual, "keep-me")
+		})
+
+		Convey("content-type 识别大小写不敏感，且不被默认值覆盖", func() {
+			req := &interfaces.HTTPRequest{
+				HTTPRouter: interfaces.HTTPRouter{
+					Method: http.MethodPost,
+					URL:    "http://svc/api/v1/resources",
+				},
+				HTTPRequestParams: interfaces.HTTPRequestParams{
+					Headers: map[string]any{"content-type": "application/json; charset=utf-8"},
+					Body:    map[string]any{"name": "n1"},
+				},
+			}
+
+			httpReq, err := f.buildRequest(context.Background(), req)
+
+			So(err, ShouldBeNil)
+			So(httpReq.Header.Get("Content-Type"), ShouldEqual, "application/json; charset=utf-8")
+			So(readAll(t, httpReq.Body), ShouldEqual, `{"name":"n1"}`)
+		})
+	})
+}
+
+// TestBuildRequest_Body 覆盖请求体编码（#216 验收标准 5）。
+func TestBuildRequest_Body(t *testing.T) {
+	f := newTestForwarder()
+
+	Convey("请求体按 Content-Type 编码", t, func() {
+		Convey("未声明 Content-Type 时按 JSON 编码并补默认头", func() {
+			req := &interfaces.HTTPRequest{
+				HTTPRouter: interfaces.HTTPRouter{
+					Method: http.MethodPost,
+					URL:    "http://svc/api/v1/resources",
+				},
+				HTTPRequestParams: interfaces.HTTPRequestParams{
+					Body: map[string]any{"name": "n1"},
+				},
+			}
+
+			httpReq, err := f.buildRequest(context.Background(), req)
+
+			So(err, ShouldBeNil)
+			So(httpReq.Header.Get("Content-Type"), ShouldEqual, "application/json")
+			So(readAll(t, httpReq.Body), ShouldEqual, `{"name":"n1"}`)
+		})
+
+		Convey("表单编码", func() {
+			req := &interfaces.HTTPRequest{
+				HTTPRouter: interfaces.HTTPRouter{
+					Method: http.MethodPost,
+					URL:    "http://svc/api/v1/resources",
+				},
+				HTTPRequestParams: interfaces.HTTPRequestParams{
+					Headers: map[string]any{"Content-Type": "application/x-www-form-urlencoded"},
+					Body:    map[string]interface{}{"name": "n1"},
+				},
+			}
+
+			httpReq, err := f.buildRequest(context.Background(), req)
+
+			So(err, ShouldBeNil)
+			So(httpReq.Header.Get("Content-Type"), ShouldEqual, "application/x-www-form-urlencoded")
+			So(readAll(t, httpReq.Body), ShouldEqual, "name=n1")
+		})
+
+		Convey("multipart 编码时 Content-Type 带 boundary 并可被下游解析", func() {
+			req := &interfaces.HTTPRequest{
+				HTTPRouter: interfaces.HTTPRouter{
+					Method: http.MethodPost,
+					URL:    "http://svc/api/v1/resources",
+				},
+				HTTPRequestParams: interfaces.HTTPRequestParams{
+					Headers: map[string]any{"Content-Type": "multipart/form-data"},
+					Body:    map[string]interface{}{"name": "n1"},
+				},
+			}
+
+			httpReq, err := f.buildRequest(context.Background(), req)
+
+			So(err, ShouldBeNil)
+			mediaType, params, parseErr := mime.ParseMediaType(httpReq.Header.Get("Content-Type"))
+			So(parseErr, ShouldBeNil)
+			So(mediaType, ShouldEqual, "multipart/form-data")
+			So(params["boundary"], ShouldNotBeEmpty)
+
+			reader := multipart.NewReader(httpReq.Body, params["boundary"])
+			form, formErr := reader.ReadForm(1 << 20)
+			So(formErr, ShouldBeNil)
+			// 字段值按 JSON 序列化写入（现状），字符串因此带引号
+			So(form.Value["name"][0], ShouldEqual, `"n1"`)
+		})
+
+		Convey("纯文本编码", func() {
+			req := &interfaces.HTTPRequest{
+				HTTPRouter: interfaces.HTTPRouter{
+					Method: http.MethodPost,
+					URL:    "http://svc/api/v1/resources",
+				},
+				HTTPRequestParams: interfaces.HTTPRequestParams{
+					Headers: map[string]any{"Content-Type": "text/plain"},
+					Body:    "hello",
+				},
+			}
+
+			httpReq, err := f.buildRequest(context.Background(), req)
+
+			So(err, ShouldBeNil)
+			So(readAll(t, httpReq.Body), ShouldEqual, "hello")
+		})
+
+		Convey("无请求体时不发送 body，也不补 Content-Type", func() {
+			req := &interfaces.HTTPRequest{
+				HTTPRouter: interfaces.HTTPRouter{
+					Method: http.MethodGet,
+					URL:    "http://svc/api/v1/resources",
+				},
+				HTTPRequestParams: interfaces.HTTPRequestParams{
+					Headers: map[string]any{"X-Api-Key": "secret-key"},
+				},
+			}
+
+			httpReq, err := f.buildRequest(context.Background(), req)
+
+			So(err, ShouldBeNil)
+			So(httpReq.Header.Get("Content-Type"), ShouldEqual, "")
+			So(readAll(t, httpReq.Body), ShouldEqual, "")
+			So(httpReq.Header.Get("X-Api-Key"), ShouldEqual, "secret-key")
+		})
+	})
+}
+
+// TestBuildRequest_BusinessFieldsNamedLikeEnvelope 覆盖请求体自带 header/query/path/body 同名业务字段的场景（#216 验收标准 12）。
+func TestBuildRequest_BusinessFieldsNamedLikeEnvelope(t *testing.T) {
+	f := newTestForwarder()
+
+	Convey("body 中的 header/query/path/body 同名字段不被当成调试信封", t, func() {
+		req := &interfaces.HTTPRequest{
+			HTTPRouter: interfaces.HTTPRouter{
+				Method: http.MethodPost,
+				URL:    "http://svc/api/v1/records",
+			},
+			HTTPRequestParams: interfaces.HTTPRequestParams{
+				Headers: map[string]any{"X-Api-Key": "secret-key"},
+				Body: map[string]any{
+					"header": "业务字段 header",
+					"query":  "业务字段 query",
+					"path":   "业务字段 path",
+					"body":   "业务字段 body",
+				},
+			},
+		}
+
+		httpReq, err := f.buildRequest(context.Background(), req)
+
+		So(err, ShouldBeNil)
+		// 业务字段留在 body 里，既不会跑到 URL，也不会变成请求头
+		So(httpReq.URL.RawQuery, ShouldEqual, "")
+		So(httpReq.Header.Get("query"), ShouldEqual, "")
+
+		var got map[string]any
+		So(json.Unmarshal([]byte(readAll(t, httpReq.Body)), &got), ShouldBeNil)
+		So(got["header"], ShouldEqual, "业务字段 header")
+		So(got["query"], ShouldEqual, "业务字段 query")
+		So(got["path"], ShouldEqual, "业务字段 path")
+		So(got["body"], ShouldEqual, "业务字段 body")
+	})
+}
+
+// TestForward_DownstreamReceivesAllParams 端到端校验下游实际收到 header + query + path + body（#216 验收标准 1/3/4/5/10）。
+func TestForward_DownstreamReceivesAllParams(t *testing.T) {
+	f := newTestForwarder()
+
+	Convey("下游收到完整的 header/query/path/body", t, func() {
+		type captured struct {
+			method string
+			path   string
+			query  string
+			apiKey string
+			body   string
+		}
+		var got captured
+
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			body, _ := io.ReadAll(r.Body)
+			got = captured{
+				method: r.Method,
+				path:   r.URL.Path,
+				query:  r.URL.RawQuery,
+				apiKey: r.Header.Get("X-Api-Key"),
+				body:   string(body),
+			}
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"ok":true}`))
+		}))
+		defer server.Close()
+
+		Convey("POST 请求带 path/query/header/body", func() {
+			resp, err := f.Forward(t.Context(), &interfaces.HTTPRequest{
+				HTTPRouter: interfaces.HTTPRouter{
+					Method: http.MethodPost,
+					URL:    server.URL + "/api/v1/executions/sessions/{session_id}/execute-sync",
+				},
+				HTTPRequestParams: interfaces.HTTPRequestParams{
+					PathParams:  map[string]string{"session_id": "probe-abc"},
+					QueryParams: map[string]any{"trace": "on"},
+					Headers:     map[string]any{"X-Api-Key": "secret-key"},
+					Body:        map[string]any{"code": "print(1)"},
+				},
+				Timeout: 5 * time.Second,
+			})
+
+			So(err, ShouldBeNil)
+			So(resp.StatusCode, ShouldEqual, http.StatusOK)
+			So(got.method, ShouldEqual, http.MethodPost)
+			So(got.path, ShouldEqual, "/api/v1/executions/sessions/probe-abc/execute-sync")
+			So(got.query, ShouldEqual, "trace=on")
+			So(got.apiKey, ShouldEqual, "secret-key")
+			So(got.body, ShouldEqual, `{"code":"print(1)"}`)
+
+			respBody, ok := resp.Body.(map[string]any)
+			So(ok, ShouldBeTrue)
+			So(respBody["ok"], ShouldEqual, true)
+		})
+
+		Convey("GET 请求同样完成 path 替换与 query 拼接", func() {
+			resp, err := f.Forward(t.Context(), &interfaces.HTTPRequest{
+				HTTPRouter: interfaces.HTTPRouter{
+					Method: http.MethodGet,
+					URL:    server.URL + "/api/v1/operator/market/{operator_id}",
+				},
+				HTTPRequestParams: interfaces.HTTPRequestParams{
+					PathParams:  map[string]string{"operator_id": "op-1"},
+					QueryParams: map[string]any{"version": "v1"},
+					Headers:     map[string]any{"X-Api-Key": "secret-key"},
+				},
+				Timeout: 5 * time.Second,
+			})
+
+			So(err, ShouldBeNil)
+			So(resp.StatusCode, ShouldEqual, http.StatusOK)
+			So(got.method, ShouldEqual, http.MethodGet)
+			So(got.path, ShouldEqual, "/api/v1/operator/market/op-1")
+			So(got.query, ShouldEqual, "version=v1")
+			So(got.apiKey, ShouldEqual, "secret-key")
+			So(got.body, ShouldEqual, "")
+		})
+	})
+}

--- a/adp/execution-factory/operator-integration/server/logics/toolbox/execute_params_test.go
+++ b/adp/execution-factory/operator-integration/server/logics/toolbox/execute_params_test.go
@@ -1,0 +1,163 @@
+package toolbox
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"testing"
+
+	"github.com/openbkn-ai/adp/execution-factory/operator-integration/server/infra/logger"
+	"github.com/openbkn-ai/adp/execution-factory/operator-integration/server/interfaces"
+	"github.com/openbkn-ai/adp/execution-factory/operator-integration/server/interfaces/model"
+	"github.com/openbkn-ai/adp/execution-factory/operator-integration/server/logics/metric"
+	"github.com/openbkn-ai/adp/execution-factory/operator-integration/server/mocks"
+	. "github.com/smartystreets/goconvey/convey"
+	"go.uber.org/mock/gomock"
+)
+
+// debugToolFixture 组装工具调试所需的最小依赖，并回传代理实际收到的请求。
+type debugToolFixture struct {
+	service  *ToolServiceImpl
+	captured **interfaces.HTTPRequest
+}
+
+func newDebugToolFixture(t *testing.T, toolStatus string) *debugToolFixture {
+	ctrl := gomock.NewController(t)
+
+	mockAuthService := mocks.NewMockIAuthorizationService(ctrl)
+	mockToolBoxDB := mocks.NewMockIToolboxDB(ctrl)
+	mockToolDB := mocks.NewMockIToolDB(ctrl)
+	mockMetadataService := mocks.NewMockIMetadataService(ctrl)
+	mockMetadata := mocks.NewMockIMetadataDB(ctrl)
+	mockProxy := mocks.NewMockProxyHandler(ctrl)
+	mockAuditLog := mocks.NewMockLogModelOperator[*metric.AuditLogBuilderParams](ctrl)
+
+	mockAuthService.EXPECT().GetAccessor(gomock.Any(), "u1").
+		Return(&interfaces.AuthAccessor{ID: "u1"}, nil).AnyTimes()
+	mockAuthService.EXPECT().
+		CheckExecutePermission(gomock.Any(), gomock.Any(), "b1", interfaces.AuthResourceTypeToolBox).
+		Return(nil).AnyTimes()
+	mockToolBoxDB.EXPECT().SelectToolBox(gomock.Any(), "b1").
+		Return(true, &model.ToolboxDB{BoxID: "b1", Name: "box", ServerURL: "http://tool-box-svc"}, nil).AnyTimes()
+	mockToolDB.EXPECT().SelectTool(gomock.Any(), "t1").
+		Return(true, &model.ToolDB{
+			ToolID:     "t1",
+			BoxID:      "b1",
+			Name:       "tool",
+			SourceID:   "s1",
+			SourceType: model.SourceTypeOpenAPI,
+			Status:     toolStatus,
+		}, nil).AnyTimes()
+	mockMetadataService.EXPECT().GetMetadataBySource(gomock.Any(), "s1", model.SourceTypeOpenAPI).
+		Return(true, mockMetadata, nil).AnyTimes()
+	mockMetadata.EXPECT().GetServerURL().Return("http://metadata-svc").AnyTimes()
+	mockMetadata.EXPECT().GetPath().Return("/api/v1/executions/sessions/{session_id}/execute-sync").AnyTimes()
+	mockMetadata.EXPECT().GetMethod().Return(http.MethodPost).AnyTimes()
+
+	var captured *interfaces.HTTPRequest
+	mockProxy.EXPECT().HandlerRequest(gomock.Any(), gomock.Any()).
+		DoAndReturn(func(_ context.Context, req *interfaces.HTTPRequest) (*interfaces.HTTPResponse, error) {
+			captured = req
+			return &interfaces.HTTPResponse{StatusCode: http.StatusOK}, nil
+		}).AnyTimes()
+
+	return &debugToolFixture{
+		service: &ToolServiceImpl{
+			Logger:          logger.DefaultLogger(),
+			AuthService:     mockAuthService,
+			ToolBoxDB:       mockToolBoxDB,
+			ToolDB:          mockToolDB,
+			MetadataService: mockMetadataService,
+			Proxy:           mockProxy,
+			AuditLog:        mockAuditLog,
+		},
+		captured: &captured,
+	}
+}
+
+// debugToolRequestJSON 是 Studio 调试面板实际提交的请求体形态：header/query/path/body 四段并列。
+const debugToolRequestJSON = `{
+	"timeout": 5,
+	"header": {"X-Api-Key": "secret-key"},
+	"query": {"page": 1},
+	"path": {"session_id": "probe-abc"},
+	"body": {"code": "print(1)", "header": "业务字段 header"}
+}`
+
+// TestDebugTool_ForwardsAllRequestParams 校验调试请求体的 header/query/path/body 原样抵达代理层（#216 验收标准 1/3/4/5）。
+func TestDebugTool_ForwardsAllRequestParams(t *testing.T) {
+	Convey("工具调试透传完整请求参数", t, func() {
+		req := &interfaces.ExecuteToolReq{UserID: "u1", BoxID: "b1", ToolID: "t1"}
+		So(json.Unmarshal([]byte(debugToolRequestJSON), req), ShouldBeNil)
+
+		Convey("四段参数在请求体反序列化时各就各位", func() {
+			So(req.PathParams["session_id"], ShouldEqual, "probe-abc")
+			So(req.QueryParams["page"], ShouldEqual, float64(1))
+			So(req.Headers["X-Api-Key"], ShouldEqual, "secret-key")
+
+			body, ok := req.Body.(map[string]any)
+			So(ok, ShouldBeTrue)
+			So(body["code"], ShouldEqual, "print(1)")
+			// body 里的同名业务字段不会被当作调试信封（#216 验收标准 12）
+			So(body["header"], ShouldEqual, "业务字段 header")
+		})
+
+		Convey("DebugTool 把四段参数交给代理层", func() {
+			fixture := newDebugToolFixture(t, string(interfaces.ToolStatusTypeEnabled))
+
+			resp, err := fixture.service.DebugTool(context.Background(), req)
+
+			So(err, ShouldBeNil)
+			So(resp.StatusCode, ShouldEqual, http.StatusOK)
+
+			proxyReq := *fixture.captured
+			So(proxyReq, ShouldNotBeNil)
+			So(proxyReq.Method, ShouldEqual, http.MethodPost)
+			So(proxyReq.URL, ShouldEqual, "http://tool-box-svc/api/v1/executions/sessions/{session_id}/execute-sync")
+			So(proxyReq.PathParams["session_id"], ShouldEqual, "probe-abc")
+			So(proxyReq.QueryParams["page"], ShouldEqual, float64(1))
+			So(proxyReq.Headers["X-Api-Key"], ShouldEqual, "secret-key")
+
+			body, ok := proxyReq.Body.(map[string]any)
+			So(ok, ShouldBeTrue)
+			So(body["code"], ShouldEqual, "print(1)")
+			So(body["header"], ShouldEqual, "业务字段 header")
+		})
+
+		Convey("ExecuteTool 走同一条透传链路", func() {
+			fixture := newDebugToolFixture(t, string(interfaces.ToolStatusTypeEnabled))
+
+			resp, err := fixture.service.ExecuteTool(context.Background(), req)
+
+			So(err, ShouldBeNil)
+			So(resp.StatusCode, ShouldEqual, http.StatusOK)
+
+			proxyReq := *fixture.captured
+			So(proxyReq, ShouldNotBeNil)
+			So(proxyReq.PathParams["session_id"], ShouldEqual, "probe-abc")
+			So(proxyReq.QueryParams["page"], ShouldEqual, float64(1))
+			So(proxyReq.Headers["X-Api-Key"], ShouldEqual, "secret-key")
+		})
+	})
+}
+
+// TestDebugTool_NoParamsToolSendsEmptyEnvelope 校验无入参工具调试时不会凭空造出 path/query/header（#216 验收标准 8 的后端侧）。
+func TestDebugTool_NoParamsToolSendsEmptyEnvelope(t *testing.T) {
+	Convey("无入参工具调试只发空信封", t, func() {
+		fixture := newDebugToolFixture(t, string(interfaces.ToolStatusTypeEnabled))
+		req := &interfaces.ExecuteToolReq{UserID: "u1", BoxID: "b1", ToolID: "t1"}
+		So(json.Unmarshal([]byte(`{"timeout":5}`), req), ShouldBeNil)
+
+		resp, err := fixture.service.DebugTool(context.Background(), req)
+
+		So(err, ShouldBeNil)
+		So(resp.StatusCode, ShouldEqual, http.StatusOK)
+
+		proxyReq := *fixture.captured
+		So(proxyReq, ShouldNotBeNil)
+		So(proxyReq.PathParams, ShouldBeEmpty)
+		So(proxyReq.QueryParams, ShouldBeEmpty)
+		So(proxyReq.Headers, ShouldBeEmpty)
+		So(proxyReq.Body, ShouldBeNil)
+	})
+}


### PR DESCRIPTION
# Pull Request

## What Changed

- [x] `logics/proxy/forwarder.go`：未替换的 path 占位符拦截、`:{key}` 替换顺序、multipart boundary、传输层请求头丢弃
- [x] `infra/errors` + `infra/localize`：新增错误码 `ProxyPathParamMissing`（中英文案）
- [x] 新增单测：`logics/proxy/forwarder_params_test.go`、`logics/toolbox/execute_params_test.go`、`logics/operator/debug_params_test.go`

---

## Why

- Related Issue: [Issue #216](https://github.com/openbkn-ai/bkn-foundry/issues/216)（补齐执行工厂 Tool/Operator 调试的 header、query、path 参数支持）
- Background: 前端侧已由 bkn-studio PR #274 / #275 落地，后端侧的验收标准第 11 条（补充 Tool/Operator 调试单测和后端联调测试，覆盖 header/query/path/body）此前完全没有覆盖：`forwarder_test.go` 只有 1 个用例，`buildRequest` 的 path/query/header/body 一个用例都没有，Tool/Operator 调试链路的参数透传也没测。补测过程中暴露三处转发器缺陷，一并修复。

---

## How

- 关键实现点：
  - **未替换占位符拦截（验收标准 7）**：path 参数替换完成后，若 URL **路径部分**仍存在 `{name}` 占位符，直接返回 400 `ProxyPathParamMissing`，不再把 `/market/{operator_id}` 这类无效 URL 发给下游。只检查路径部分——query/fragment 里的花括号可能是业务值（如 `?filter={"a":1}`），冒号形式无法与端口号区分，都不参与判断。
  - **`:{key}` 替换顺序**：原先先替换 `{key}`，导致 `:{id}` 变成 `:1` 留下多余冒号，`:{key}` 分支实际是死代码；现调整为先 `:{key}`、再 `{key}`、最后 `:key`。
  - **multipart boundary**：调用方自带 `Content-Type: multipart/form-data`（无 boundary）时，原实现会因“Content-Type 已存在”而不写入 writer 生成的带 boundary 头，下游无法解析请求体；现由编码过程强制覆盖。
  - **传输层请求头（P1 安全约束）**：丢弃调用方传入的 `Host` / `Content-Length` / `Transfer-Encoding` / `Connection` / `Keep-Alive` / `Proxy-Connection` / `TE` / `Trailer` / `Upgrade` / `Expect`，这些由转发链路与 Go HTTP 客户端接管；自定义鉴权头（如 `X-Company-Token`）不在拦截范围内。
- Breaking changes：
  - 行为变更：路径模板含未提供的 path 参数时，从「原样把 `{name}` 发给下游」改为「400 明确报错」。影响面仅限经代理转发的 Tool/Operator 执行与调试；此类请求此前抵达下游后同样会失败（如 `Session not found: {session_id}`、uuid 校验 400），本次是把失败提前并给出可读原因。
  - 无接口契约、配置或数据库变更。

---

## Testing

- [x] Unit tests passed locally
- [ ] Integration tests passed locally（本模块无 IT）
- [ ] Verified in test environment（纯后端逻辑，用例已覆盖，未另行部署验证）

Test notes：

- `go test ./server/logics/proxy/... ./server/logics/toolbox/... ./server/logics/operator/...` 全绿；`make test` 全模块无 FAIL；`go vet ./server/...` 与改动文件 `gofmt` 干净。
- `make lint` 在本机跑不起来（本地 golangci-lint v1.24.0 解析不了 go1.25 标准库），交由 CI 执行。
- 用例覆盖：
  - `buildRequest`：`{k}` / `:k` / `:{k}` 占位符替换、多占位符、缺参拦截、query 里的花括号不误伤；query 追加 / 与原有 query 合并 / 非字符串值 / 转义；自定义头透传、传输头丢弃、`content-type` 大小写不敏感；JSON / 表单 / multipart（校验 boundary 且能被 `multipart.Reader` 解析）/ 纯文本 / 无 body；body 内 `header`、`query`、`path`、`body` 同名业务字段不被误当调试信封（验收标准 12）。
  - `Forward`：走 `httptest` 真发请求，断言下游实收 method / path / query / header / body，GET 与 POST 各一条（验收标准 1/3/4/5/10）。
  - `DebugTool` / `ExecuteTool` / `DebugOperator` / `ExecuteOperator`：从真实调试请求体 JSON 反序列化后，断言四段参数原样抵达代理层，并覆盖无入参工具/算子只发空信封。

---

## Risk & Rollback

- 潜在风险：若存在「路径模板带占位符、但调用方刻意不填、依赖下游按字面量处理」的用法，会从下游报错变为代理层 400。已排查本仓内经代理转发的路径，仅 `get_operator_schema`（`/operator/market/{operator_id}`）为模板路径，缺参时下游本就会 uuid 校验失败。
- 回滚方案：单 commit，`git revert` 即可；错误码与文案为新增项，回滚无残留依赖。

---

## Additional Notes

- 本 PR 用 `Refs #216` 而非 `Closes`：验收标准第 8 条（无额外参数的纯 body API 不显示空的 path/query/header 区域）与 bkn-studio PR #275 把请求头折叠区改为常显存在冲突，待口径确认后再关闭 issue。
- multipart 字段值目前按 JSON 序列化写入（字符串带引号），属既有行为，本次未改动，用例已按现状钉住。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
