### PR TITLE
fix(ontology-query): prevent action execution from stalling

### DIFF
--- a/adp/bkn/ontology-query/server/driveradapters/action_execution_handler.go
+++ b/adp/bkn/ontology-query/server/driveradapters/action_execution_handler.go
@@ -92,6 +92,7 @@ func (r *restHandler) ExecuteAction(c *gin.Context, visitor hydra.Visitor) {
 	req.KNID = knID
 	req.Branch = branch
 	req.ActionTypeID = atID
+	req.BusinessDomain = businessDomain
 
 	// Note: _instance_identities is optional
 	// If not provided, the action will apply to all entities matching the action type's conditions

--- a/adp/bkn/ontology-query/server/interfaces/action_execution.go
+++ b/adp/bkn/ontology-query/server/interfaces/action_execution.go
@@ -43,6 +43,7 @@ type ActionExecutionRequest struct {
 	TriggerType        string           `json:"trigger_type,omitempty"` // "manual" or "scheduled", defaults to "manual"
 	InstanceIdentities []map[string]any `json:"_instance_identities"`
 	DynamicParams      map[string]any   `json:"dynamic_params,omitempty"`
+	BusinessDomain     string           `json:"-"`
 
 	Instances []ObjectSystemInfo `json:"-"`
 	ObjDatas  []map[string]any   `json:"-"`

--- a/adp/bkn/ontology-query/server/logics/action_scheduler/action_scheduler_service.go
+++ b/adp/bkn/ontology-query/server/logics/action_scheduler/action_scheduler_service.go
@@ -139,6 +139,9 @@ func (s *actionSchedulerService) ExecuteAction(ctx context.Context, req *interfa
 	if accountInfo := ctx.Value(interfaces.ACCOUNT_INFO_KEY); accountInfo != nil {
 		executor = accountInfo.(interfaces.AccountInfo)
 	}
+	if businessDomain := ctx.Value(interfaces.BUSINESS_DOMAIN_KEY); businessDomain != nil && req.BusinessDomain == "" {
+		req.BusinessDomain = businessDomain.(string)
+	}
 
 	// Reserved: Permission check hook
 	if s.permissionCheckHook != nil {
@@ -246,6 +249,9 @@ func (s *actionSchedulerService) executeAsync(execution *interfaces.ActionExecut
 	ctx := context.Background()
 	// Restore account info from execution record for downstream API calls (user_id header)
 	ctx = context.WithValue(ctx, interfaces.ACCOUNT_INFO_KEY, execution.Executor)
+	if req.BusinessDomain != "" {
+		ctx = context.WithValue(ctx, interfaces.BUSINESS_DOMAIN_KEY, req.BusinessDomain)
+	}
 
 	logger.Infof("Starting async execution: %s, total objects: %d", execution.ID, len(req.Instances))
 
@@ -264,9 +270,7 @@ func (s *actionSchedulerService) executeAsync(execution *interfaces.ActionExecut
 	cancelled := false
 
 	for i, objData := range req.ObjDatas {
-		// Check cancellation status at the start of each batch
-		if i%batchSize == 0 && i > 0 {
-			// Check if execution has been cancelled
+		if shouldCheckExecutionCancellation(i, len(req.ObjDatas)) {
 			if s.isExecutionCancelled(ctx, execution.KNID, execution.ID) {
 				logger.Infof("Execution %s cancelled, stopping at object %d/%d", execution.ID, i, len(req.ObjDatas))
 				cancelled = true
@@ -281,10 +285,6 @@ func (s *actionSchedulerService) executeAsync(execution *interfaces.ActionExecut
 				}
 				break
 			}
-
-			// Batch update: save current progress
-			s.updateExecutionProgress(ctx, execution, successCount, failedCount, allResults)
-			logger.Debugf("Execution %s progress: %d/%d completed", execution.ID, i, len(req.ObjDatas))
 		}
 
 		startTime := time.Now().UnixMilli()
@@ -342,6 +342,12 @@ func (s *actionSchedulerService) executeAsync(execution *interfaces.ActionExecut
 			})
 			successCount++
 		}
+
+		completedCount := i + 1
+		if shouldUpdateExecutionProgress(completedCount, len(req.ObjDatas)) {
+			s.updateExecutionProgress(ctx, execution, successCount, failedCount, allResults)
+			logger.Debugf("Execution %s progress: %d/%d completed", execution.ID, completedCount, len(req.ObjDatas))
+		}
 	}
 
 	// Determine final status
@@ -372,6 +378,14 @@ func (s *actionSchedulerService) executeAsync(execution *interfaces.ActionExecut
 
 	logger.Infof("Completed async execution: %s, success: %d, failed: %d, cancelled: %d",
 		execution.ID, successCount, failedCount, cancelledCount)
+}
+
+func shouldCheckExecutionCancellation(index, total int) bool {
+	return index == 0 || total <= batchSize || index%batchSize == 0
+}
+
+func shouldUpdateExecutionProgress(completed, total int) bool {
+	return total <= batchSize || completed%batchSize == 0
 }
 
 // isExecutionCancelled checks if the execution has been cancelled

--- a/adp/bkn/ontology-query/server/logics/action_scheduler/action_scheduler_service_test.go
+++ b/adp/bkn/ontology-query/server/logics/action_scheduler/action_scheduler_service_test.go
@@ -500,6 +500,81 @@ func Test_ActionExecution_Snapshot(t *testing.T) {
 	})
 }
 
+func Test_executeAsync_ContextAndProgress(t *testing.T) {
+	Convey("executeAsync should restore business domain and flush small-run progress", t, func() {
+		mockCtrl := gomock.NewController(t)
+		defer mockCtrl.Finish()
+
+		aoAccess := omock.NewMockAgentOperatorAccess(mockCtrl)
+		logsService := omock.NewMockActionLogsService(mockCtrl)
+		service := &actionSchedulerService{
+			aoAccess:    aoAccess,
+			logsService: logsService,
+		}
+
+		execution := &interfaces.ActionExecution{
+			ID:           "exec_001",
+			KNID:         "kn_001",
+			Status:       interfaces.ExecutionStatusPending,
+			TotalCount:   1,
+			StartTime:    1700000000000,
+			SuccessCount: 0,
+			FailedCount:  0,
+			Executor: interfaces.AccountInfo{
+				ID:   "user_001",
+				Type: "user",
+			},
+		}
+		actionType := &interfaces.ActionType{
+			ActionSource: interfaces.ActionSource{
+				Type:   interfaces.ActionSourceTypeTool,
+				BoxID:  "box_001",
+				ToolID: "tool_001",
+			},
+			Parameters: []interfaces.Parameter{},
+		}
+		req := &interfaces.ActionExecutionRequest{
+			BusinessDomain: "domain_001",
+			Instances: []interfaces.ObjectSystemInfo{
+				{InstanceIdentity: map[string]any{"id": "1"}},
+			},
+			ObjDatas: []map[string]any{
+				{"id": "1"},
+			},
+		}
+
+		var progressUpdates []map[string]any
+		logsService.EXPECT().UpdateExecution(gomock.Any(), "kn_001", "exec_001", gomock.Any()).DoAndReturn(
+			func(ctx context.Context, knID, execID string, updates map[string]any) error {
+				if _, ok := updates["success_count"]; ok {
+					progressUpdates = append(progressUpdates, updates)
+				}
+				return nil
+			}).AnyTimes()
+		logsService.EXPECT().GetExecution(gomock.Any(), gomock.Any()).Return(&interfaces.ActionExecution{
+			Status: interfaces.ExecutionStatusRunning,
+		}, nil).AnyTimes()
+		aoAccess.EXPECT().ExecuteTool(gomock.Any(), "box_001", "tool_001", gomock.Any()).DoAndReturn(
+			func(ctx context.Context, boxID, toolID string, execRequest interfaces.ToolExecutionRequest) (any, error) {
+				So(ctx.Value(interfaces.ACCOUNT_INFO_KEY), ShouldResemble, execution.Executor)
+				So(ctx.Value(interfaces.BUSINESS_DOMAIN_KEY), ShouldEqual, "domain_001")
+				_, ok := ctx.Deadline()
+				So(ok, ShouldBeTrue)
+				return map[string]any{"checked": true}, nil
+			})
+
+		service.executeAsync(execution, actionType, req)
+
+		So(len(progressUpdates), ShouldBeGreaterThanOrEqualTo, 1)
+		So(progressUpdates[0]["success_count"], ShouldEqual, 1)
+		So(progressUpdates[0]["failed_count"], ShouldEqual, 0)
+		results, ok := progressUpdates[0]["results"].([]interfaces.ObjectExecutionResult)
+		So(ok, ShouldBeTrue)
+		So(len(results), ShouldEqual, 1)
+		So(results[0].Status, ShouldEqual, interfaces.ObjectStatusSuccess)
+	})
+}
+
 func Test_ExecuteAction_InputDynamicParamsValidation(t *testing.T) {
 	Convey("行动执行：行动类含 input 参数时，dynamic_params 未给齐则返回 400", t, func() {
 		mockCtrl := gomock.NewController(t)

--- a/adp/bkn/ontology-query/server/logics/action_scheduler/executor_test.go
+++ b/adp/bkn/ontology-query/server/logics/action_scheduler/executor_test.go
@@ -7,11 +7,15 @@
 package action_scheduler
 
 import (
+	"context"
 	"testing"
+	"time"
 
 	. "github.com/smartystreets/goconvey/convey"
+	"go.uber.org/mock/gomock"
 
 	"ontology-query/interfaces"
+	omock "ontology-query/interfaces/mock"
 )
 
 func Test_ExecuteTool_Validation(t *testing.T) {
@@ -47,6 +51,36 @@ func Test_ExecuteTool_Validation(t *testing.T) {
 			So(actionType.ActionSource.ToolID, ShouldEqual, "tool_001")
 			So(params["target_ip"], ShouldEqual, "192.168.1.1")
 		})
+	})
+}
+
+func Test_ExecuteTool_UsesContextDeadline(t *testing.T) {
+	Convey("ExecuteTool should bound downstream tool-box calls with a context deadline", t, func() {
+		mockCtrl := gomock.NewController(t)
+		defer mockCtrl.Finish()
+
+		aoAccess := omock.NewMockAgentOperatorAccess(mockCtrl)
+		actionType := &interfaces.ActionType{
+			ActionSource: interfaces.ActionSource{
+				Type:   interfaces.ActionSourceTypeTool,
+				BoxID:  "box_001",
+				ToolID: "tool_001",
+			},
+		}
+
+		aoAccess.EXPECT().ExecuteTool(gomock.Any(), "box_001", "tool_001", gomock.Any()).DoAndReturn(
+			func(ctx context.Context, boxID, toolID string, req interfaces.ToolExecutionRequest) (any, error) {
+				deadline, ok := ctx.Deadline()
+				So(ok, ShouldBeTrue)
+				So(time.Until(deadline), ShouldBeGreaterThan, 0)
+				So(req.Timeout, ShouldEqual, toolExecutionTimeoutSeconds)
+				return map[string]any{"ok": true}, nil
+			})
+
+		result, err := ExecuteTool(context.Background(), aoAccess, actionType, map[string]any{"id": "1"})
+
+		So(err, ShouldBeNil)
+		So(result, ShouldResemble, map[string]any{"ok": true})
 	})
 }
 

--- a/adp/bkn/ontology-query/server/logics/action_scheduler/mcp_executor.go
+++ b/adp/bkn/ontology-query/server/logics/action_scheduler/mcp_executor.go
@@ -9,11 +9,14 @@ package action_scheduler
 import (
 	"context"
 	"fmt"
+	"time"
 
 	"github.com/openbkn-ai/bkn-comm-go/logger"
 
 	"ontology-query/interfaces"
 )
+
+const mcpExecutionTimeoutSeconds int64 = 60
 
 // ExecuteMCP executes an MCP-based action through agent-operator-integration
 // API: POST /mcp/proxy/{mcp_id}/tool/call
@@ -37,7 +40,7 @@ func ExecuteMCP(ctx context.Context, aoAccess interfaces.AgentOperatorAccess, ac
 		McpID:      source.McpID,
 		ToolName:   toolName,
 		Parameters: mcpParams,
-		Timeout:    60, // Default 60 seconds timeout
+		Timeout:    mcpExecutionTimeoutSeconds,
 	}
 
 	mcpID := source.McpID
@@ -45,7 +48,10 @@ func ExecuteMCP(ctx context.Context, aoAccess interfaces.AgentOperatorAccess, ac
 	logger.Debugf("Executing MCP: mcp_id=%s, tool_name=%s, params=%+v", mcpID, toolName, mcpParams)
 
 	// Execute through agent-operator-integration MCP endpoint
-	result, err := aoAccess.ExecuteMCP(ctx, mcpID, toolName, mcpRequest)
+	execCtx, cancel := context.WithTimeout(ctx, time.Duration(mcpRequest.Timeout)*time.Second)
+	defer cancel()
+
+	result, err := aoAccess.ExecuteMCP(execCtx, mcpID, toolName, mcpRequest)
 	if err != nil {
 		logger.Errorf("MCP execution failed: %v", err)
 		return nil, fmt.Errorf("MCP execution failed: %w", err)

--- a/adp/bkn/ontology-query/server/logics/action_scheduler/tool_executor.go
+++ b/adp/bkn/ontology-query/server/logics/action_scheduler/tool_executor.go
@@ -10,11 +10,14 @@ import (
 	"context"
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/openbkn-ai/bkn-comm-go/logger"
 
 	"ontology-query/interfaces"
 )
+
+const toolExecutionTimeoutSeconds int64 = 300
 
 // ExecuteTool executes a tool-based action through tool-box API
 // API: POST /tool-box/{box_id}/proxy/{tool_id}
@@ -28,12 +31,15 @@ func ExecuteTool(ctx context.Context, aoAccess interfaces.AgentOperatorAccess, a
 
 	// Build tool execution request using ActionType.Parameters configuration
 	execRequest := buildToolExecutionRequest(actionType.Parameters, params)
-	execRequest.Timeout = 300 // 5 minutes timeout
+	execRequest.Timeout = toolExecutionTimeoutSeconds
 
 	logger.Debugf("Executing tool: box_id=%s, tool_id=%s, request=%+v", source.BoxID, source.ToolID, execRequest)
 
 	// Execute through tool-box API
-	result, err := aoAccess.ExecuteTool(ctx, source.BoxID, source.ToolID, execRequest)
+	execCtx, cancel := context.WithTimeout(ctx, time.Duration(execRequest.Timeout)*time.Second)
+	defer cancel()
+
+	result, err := aoAccess.ExecuteTool(execCtx, source.BoxID, source.ToolID, execRequest)
 	if err != nil {
 		logger.Errorf("Tool execution failed: %v", err)
 		return nil, fmt.Errorf("tool execution failed: %w", err)


### PR DESCRIPTION
﻿# Pull Request

## What Changed

Brief description of changes:

- [x] Preserve business domain context for async action execution in ontology-query
- [x] Flush progress for small action batches so execution logs no longer stay at zero until finalization
- [x] Apply real context deadlines to tool and MCP downstream calls
- [x] Add focused regression tests for async context/progress and tool deadlines

---

## Why

- Related Issue: Closes #446
- Related Feature: N/A
- Background: Action executions could remain visible as `running` with `success_count=0`, `failed_count=0`, and empty `results` even when the underlying tool call should complete quickly. The async worker rebuilt context from `context.Background()` and did not preserve `x-business-domain`; progress was also only persisted every 100 objects, which hid progress for small executions such as the reported 20-object run. The timeout field sent downstream was not backed by a Go context deadline.

---

## How

- Key implementation points:
  - Store the request business domain on `ActionExecutionRequest` after HTTP binding.
  - Restore `BUSINESS_DOMAIN_KEY` in async execution alongside account info.
  - Check cancellation and persist progress per item for executions whose total size is within the scheduler batch size; larger executions keep batch-boundary checks/writes.
  - Wrap tool-box calls with a 300s context timeout and MCP calls with a 60s context timeout, preserving the existing timeout values while making them effective.
  - Add regression coverage for context restoration, progress persistence, and tool call deadlines.
- Breaking changes (API, config, database, etc.): None. `BusinessDomain` is internal-only with `json:"-"`; no external API payload changes.

---

## Testing

- [x] Unit tests passed locally
- [x] Integration tests passed locally
- [ ] Verified in test environment

Test notes:

- `I18N_MODE_UT=true go test ./logics/action_scheduler -gcflags=all=-l -v -count=1` passed.
- `I18N_MODE_UT=true go test $(go list ./... | exclude /mock) -gcflags=all=-l -v -count=1` passed for ontology-query server non-mock packages.
- `git diff --check` passed.
- `make test` was not run because `make` is not installed in the local PowerShell environment.
- `golangci-lint run ./... --exclude-dirs=interfaces/mock` was not run because `golangci-lint` is not installed locally.

---

## Risk & Rollback

- Potential risks: Small executions now perform cancellation checks and progress writes more frequently, capped at the scheduler batch size. Timeout behavior now actively cancels long downstream calls instead of only passing timeout metadata.
- Rollback plan: Revert this PR to restore previous async context, progress batching, and downstream timeout behavior.

---

## Additional Notes

- The existing timeout values were preserved intentionally: tool executor remains 300s and MCP executor remains 60s. This PR only makes those existing limits effective via context deadlines.
