### PR TITLE
feat(context-loader): 透传调用方的 conversation/interaction 关联 id (#481)

### DIFF
--- a/adp/context-loader/agent-retrieval/TRACE.md
+++ b/adp/context-loader/agent-retrieval/TRACE.md
@@ -25,21 +25,32 @@
 
 ## Inbound Context
 
-- accepted headers / metadata: `traceparent`、`bkn-request-id`、legacy `x-request-id`、`baggage`、`x-account-id`、`x-account-type`、`user_id`。
+- accepted headers / metadata: `traceparent`、`bkn-request-id`、legacy `x-request-id`、`baggage`、`bkn-conversation-id`、`bkn-interaction-id`、`x-account-id`、`x-account-type`、`user_id`。
 - `traceparent` parsing: HTTP trace middleware extracts W3C Trace Context into OTel context; invalid external trace must not be propagated as an internal parent.
 - external trace trust policy: external trace can be linked or used as parent only after format validation and boundary classification.
 - invalid context handling: invalid or missing request id is replaced by a generated `req_<uuid>` value.
 - request id generation: `SetTraceContextToCtx` generates a request id when inbound `bkn-request-id` and `x-request-id` are missing or invalid.
 - tenant/account/auth context source: auth middleware reads account headers or public token introspection result; request id is independent of account id and must not be placed in baggage.
 
+### Conversation And Interaction Correlation
+
+- `bkn-conversation-id` groups one business conversation; `bkn-interaction-id` groups one user question and the multiple context calls it triggers. Both are caller-owned correlation labels only.
+- caller ownership: only the caller (third-party agent, AI application, bkn-agent, SDK/CLI user) knows where a conversation or one round of analysis starts and ends, so only the caller may mint these ids. context-loader never generates, infers, or reuses them; it never derives them from time proximity, SQL text, or natural language.
+- accepted format: `^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$`; an issuer prefix such as `agent:thread_x` is allowed so a caller-side id keeps its origin. Blank or malformed values are dropped, never rejected with an error.
+- degraded mode: with no inbound conversation/interaction id the request stays a single-request trace, exactly as before; BKN Trace query side may present such a request as a derived single-request interaction, but nothing is written as if the caller had supplied an id.
+- authorization boundary: these ids are correlation labels only. They must never take part in authorization, tenant/business-domain resolution, rate limiting, or cache keys, and they must never be placed in baggage.
+- MCP boundary: `Mcp-Session-Id` is a transport session and is not a business conversation; it is not read as a conversation id by this module.
+
 ## Outbound Calls
 
 | target | protocol | propagated fields | baggage policy | timeout | retry |
 | --- | --- | --- | --- | --- | --- |
-| BKN backend / ontology | HTTP | `traceparent`、`bkn-request-id`、`x-request-id`、account headers | allowlist only | existing client timeout | existing retry policy |
-| Vega/data | HTTP | `traceparent`、`bkn-request-id`、`x-request-id`、account headers | allowlist only | existing client timeout | existing retry policy |
-| Operator integration / toolbox | HTTP | `traceparent`、`bkn-request-id`、`x-request-id`、account headers | allowlist only | existing client timeout | existing retry policy |
-| MCP tools | MCP metadata / returned headers | `bkn-request-id`、account headers、allowed baggage | allowlist only | caller controlled | caller controlled |
+| BKN backend / ontology | HTTP | `traceparent`、`bkn-request-id`、`x-request-id`、`bkn-conversation-id`、`bkn-interaction-id`、account headers | allowlist only | existing client timeout | existing retry policy |
+| Vega/data | HTTP | `traceparent`、`bkn-request-id`、`x-request-id`、`bkn-conversation-id`、`bkn-interaction-id`、account headers | allowlist only | existing client timeout | existing retry policy |
+| Operator integration / toolbox | HTTP | `traceparent`、`bkn-request-id`、`x-request-id`、`bkn-conversation-id`、`bkn-interaction-id`、account headers | allowlist only | existing client timeout | existing retry policy |
+| MCP tools | MCP metadata / returned headers | `bkn-request-id`、`bkn-conversation-id`、`bkn-interaction-id`、account headers、allowed baggage | allowlist only | caller controlled | caller controlled |
+
+Conversation and interaction ids are only emitted when the caller supplied them; an absent id is omitted from the outbound request rather than replaced by a generated value.
 
 Allowed baggage fields:
 
@@ -92,6 +103,7 @@ Trust policy:
 - `context.query_instance_subgraph` 的 `evidence_refs` 最多保留 100 条，超过后 `subject_refs.refs_truncated=true` 且 `partial_reason` 包含 `refs_truncated`；关系类型只从 `relation`、`relations`、`relation_path(s)`、`relation_type(s)` 等关系容器提取，不从普通实例字段启发式提取。
 - `version_status` 当前为 `unversioned`，schema refs 必须携带 `partial_reason=["schema_ref_unversioned"]`，row refs 必须携带 `partial_reason=["row_ref_unversioned"]`；后续接入 BKN schema version / snapshot 后才能改为 `versioned`。
 - 证据事件上报由 `BKN_TRACE_EVIDENCE_INGEST_URL` 控制，默认关闭；开启后异步提交，不阻塞 schema 检索主路径。
+- 上报批次的 `trace` 块在调用方传入时携带 `bkn.conversation.id` 与 `bkn.interaction.id`，缺失时整个字段不出现；这两个字段只用于把同一轮分析的多次调用归到一起，不改变 claim/evidence payload 的哈希与引用规则。
 - 上报失败只记录 warning，不改变业务响应；BKN Trace 核心服务负责后续 Evidence Graph 汇聚、查询、快照和 Studio 可视化。
 
 ## Business Refs
@@ -164,6 +176,7 @@ Trust policy:
 
 - runtime L2 emitter currently covers `context.search_schema`、`context.query_object` row refs and `context.query_instance_subgraph` row/schema refs; `run_sql` and resolver-level source refs remain follow-up.
 - cross-module global Evidence Graph assembly is owned by BKN Trace core service, not by context-loader.
+- BKN Trace ingestion does not yet persist or index `bkn.conversation.id` / `bkn.interaction.id`, and no query endpoint groups traces by interaction; until that lands the ids propagate and are submitted but cannot be queried back.
 - full registry validation and indexing policy validation currently rely on `bkn-docs` validator follow-up.
 - audit-grade evidence snapshot, versioned schema refs, source data snapshot refs, and Studio visualization belong to later BKN Trace phases.
 - S3 health metrics are not implemented yet.

--- a/adp/context-loader/agent-retrieval/server/infra/bkntrace/evidence.go
+++ b/adp/context-loader/agent-retrieval/server/infra/bkntrace/evidence.go
@@ -51,12 +51,14 @@ type batch struct {
 }
 
 type eventContext struct {
-	traceID     string
-	spanID      string
-	traceparent string
-	requestID   string
-	accountID   string
-	accountType string
+	traceID        string
+	spanID         string
+	traceparent    string
+	requestID      string
+	conversationID string
+	interactionID  string
+	accountID      string
+	accountType    string
 }
 
 func HashValue(value any) string {
@@ -257,17 +259,25 @@ func SubmitEvents(ctx context.Context, logger interfaces.Logger, req any, events
 		return
 	}
 	timeout := evidenceTimeout()
+	traceBlock := map[string]any{
+		"trace_id":         ec.traceID,
+		"traceparent":      ec.traceparent,
+		"bkn.request.id":   ec.requestID,
+		"business_domain":  ec.accountID,
+		"bkn.account.id":   ec.accountID,
+		"bkn.account.type": ec.accountType,
+	}
+	// 只有调用方真的传了才带上；缺失时不补造，由 BKN Trace 查询侧按 request id 降级成单请求交互。
+	if ec.conversationID != "" {
+		traceBlock["bkn.conversation.id"] = ec.conversationID
+	}
+	if ec.interactionID != "" {
+		traceBlock["bkn.interaction.id"] = ec.interactionID
+	}
 	payload := batch{
 		ContractVersion: ContractVersion,
-		Trace: map[string]any{
-			"trace_id":         ec.traceID,
-			"traceparent":      ec.traceparent,
-			"bkn.request.id":   ec.requestID,
-			"business_domain":  ec.accountID,
-			"bkn.account.id":   ec.accountID,
-			"bkn.account.type": ec.accountType,
-		},
-		Events: events,
+		Trace:           traceBlock,
+		Events:          events,
 	}
 
 	select {
@@ -357,12 +367,14 @@ func contextFromRequest(ctx context.Context, req any) (eventContext, bool) {
 		flags = "01"
 	}
 	return eventContext{
-		traceID:     spanContext.TraceID().String(),
-		spanID:      spanContext.SpanID().String(),
-		traceparent: fmt.Sprintf("00-%s-%s-%s", spanContext.TraceID().String(), spanContext.SpanID().String(), flags),
-		requestID:   traceContext.RequestID,
-		accountID:   accountID,
-		accountType: accountType,
+		traceID:        spanContext.TraceID().String(),
+		spanID:         spanContext.SpanID().String(),
+		traceparent:    fmt.Sprintf("00-%s-%s-%s", spanContext.TraceID().String(), spanContext.SpanID().String(), flags),
+		requestID:      traceContext.RequestID,
+		conversationID: traceContext.ConversationID,
+		interactionID:  traceContext.InteractionID,
+		accountID:      accountID,
+		accountType:    accountType,
 	}, true
 }
 

--- a/adp/context-loader/agent-retrieval/server/infra/bkntrace/evidence_test.go
+++ b/adp/context-loader/agent-retrieval/server/infra/bkntrace/evidence_test.go
@@ -9,6 +9,7 @@ package bkntrace
 import (
 	"context"
 	"encoding/json"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -399,4 +400,67 @@ func TestSubmitEventsHandlesServerFailureWithoutBlocking(t *testing.T) {
 		time.Sleep(10 * time.Millisecond)
 	}
 	t.Fatalf("expected evidence ingestion request")
+}
+
+func captureIngestedTrace(t *testing.T, ctx context.Context) map[string]any {
+	t.Helper()
+	bodies := make(chan []byte, 1)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body := make([]byte, r.ContentLength)
+		if _, err := io.ReadFull(r.Body, body); err != nil {
+			t.Errorf("read ingest body: %v", err)
+		}
+		select {
+		case bodies <- body:
+		default:
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	t.Setenv(envEvidenceIngestURL, server.URL)
+	t.Setenv(envEvidenceIngestTimeoutMS, "500")
+
+	SubmitEvents(ctx, nil, nil, []Event{{"event_type": "claim.created"}})
+
+	select {
+	case body := <-bodies:
+		var payload struct {
+			Trace map[string]any `json:"trace"`
+		}
+		if err := json.Unmarshal(body, &payload); err != nil {
+			t.Fatalf("decode ingest body: %v", err)
+		}
+		return payload.Trace
+	case <-time.After(2 * time.Second):
+		t.Fatalf("expected evidence ingestion request")
+		return nil
+	}
+}
+
+func TestSubmitEventsCarriesCorrelationIDs(t *testing.T) {
+	ctx := common.SetTraceContextToCtx(testTraceContext(), common.TraceContext{
+		RequestID:      "req_context_loader_phase2_0002",
+		ConversationID: "agent:thread_abc",
+		InteractionID:  "itr_2026072701",
+	})
+
+	traceBlock := captureIngestedTrace(t, ctx)
+	if got := traceBlock["bkn.conversation.id"]; got != "agent:thread_abc" {
+		t.Fatalf("expected conversation id in trace block, got %v", got)
+	}
+	if got := traceBlock["bkn.interaction.id"]; got != "itr_2026072701" {
+		t.Fatalf("expected interaction id in trace block, got %v", got)
+	}
+}
+
+func TestSubmitEventsOmitsCorrelationIDsWhenAbsent(t *testing.T) {
+	traceBlock := captureIngestedTrace(t, testTraceContext())
+
+	if _, ok := traceBlock["bkn.conversation.id"]; ok {
+		t.Fatalf("expected no conversation id when the caller sent none")
+	}
+	if _, ok := traceBlock["bkn.interaction.id"]; ok {
+		t.Fatalf("expected no interaction id when the caller sent none")
+	}
 }

--- a/adp/context-loader/agent-retrieval/server/infra/common/context_manage.go
+++ b/adp/context-loader/agent-retrieval/server/infra/common/context_manage.go
@@ -20,10 +20,12 @@ import (
 )
 
 const (
-	HeaderTraceparent     = "traceparent"
-	HeaderBKNRequestID    = "bkn-request-id"
-	HeaderLegacyRequestID = "x-request-id"
-	HeaderBaggage         = "baggage"
+	HeaderTraceparent       = "traceparent"
+	HeaderBKNRequestID      = "bkn-request-id"
+	HeaderLegacyRequestID   = "x-request-id"
+	HeaderBaggage           = "baggage"
+	HeaderBKNConversationID = "bkn-conversation-id"
+	HeaderBKNInteractionID  = "bkn-interaction-id"
 )
 
 type traceContextKey string
@@ -32,10 +34,19 @@ const keyTraceContext traceContextKey = "bkn_trace_context"
 
 var bknRequestIDRe = regexp.MustCompile(`^req_[A-Za-z0-9_-]{8,128}$`)
 
+// correlationIDRe 约束会话/交互 id 的字符集：允许调用方带 issuer 前缀（如 `agent:thread_x`），
+// 拒绝空白、控制字符和超长值，避免非法值污染 header 与证据事件。
+var correlationIDRe = regexp.MustCompile(`^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$`)
+
 // TraceContext carries the OpenBKN phase-one correlation context.
+//
+// ConversationID/InteractionID 只做关联标签：由调用方生成并传入，本服务只透传，
+// 不生成、不推断，也不参与任何鉴权、限流或缓存判定。
 type TraceContext struct {
-	RequestID string
-	Baggage   map[string]string
+	RequestID      string
+	ConversationID string
+	InteractionID  string
+	Baggage        map[string]string
 }
 
 // GetLanguageFromCtx 从context中获取语言设置
@@ -97,6 +108,10 @@ func SetTraceContextToCtx(ctx context.Context, traceContext TraceContext) contex
 	if !IsValidBKNRequestID(traceContext.RequestID) {
 		traceContext.RequestID = NewBKNRequestID()
 	}
+	// 会话/交互 id 缺失或非法时直接丢弃：本轮降级为单请求 trace，绝不在服务端补造，
+	// 否则每次调用都会生成一个与 request id 一一对应的假分组。
+	traceContext.ConversationID = sanitizeCorrelationID(traceContext.ConversationID)
+	traceContext.InteractionID = sanitizeCorrelationID(traceContext.InteractionID)
 	traceContext.Baggage = sanitizeBaggage(traceContext.Baggage)
 	return context.WithValue(ctx, keyTraceContext, traceContext)
 }
@@ -112,13 +127,28 @@ func TraceContextFromHeaders(getHeader func(string) string) TraceContext {
 		requestID = strings.TrimSpace(getHeader(HeaderLegacyRequestID))
 	}
 	return TraceContext{
-		RequestID: requestID,
-		Baggage:   parseBaggage(getHeader(HeaderBaggage)),
+		RequestID:      requestID,
+		ConversationID: strings.TrimSpace(getHeader(HeaderBKNConversationID)),
+		InteractionID:  strings.TrimSpace(getHeader(HeaderBKNInteractionID)),
+		Baggage:        parseBaggage(getHeader(HeaderBaggage)),
 	}
 }
 
 func IsValidBKNRequestID(requestID string) bool {
 	return bknRequestIDRe.MatchString(requestID)
+}
+
+// IsValidCorrelationID 判断调用方传入的会话/交互 id 是否可透传。
+func IsValidCorrelationID(id string) bool {
+	return correlationIDRe.MatchString(id)
+}
+
+func sanitizeCorrelationID(id string) string {
+	id = strings.TrimSpace(id)
+	if !IsValidCorrelationID(id) {
+		return ""
+	}
+	return id
 }
 
 func NewBKNRequestID() string {
@@ -144,6 +174,13 @@ func GetHeaderFromCtx(ctx context.Context) (header map[string]string) {
 	if ok {
 		header[HeaderBKNRequestID] = traceContext.RequestID
 		header[HeaderLegacyRequestID] = traceContext.RequestID
+		// 缺失即不下发，保持下游「无上游会话则降级为单请求」的语义。
+		if traceContext.ConversationID != "" {
+			header[HeaderBKNConversationID] = traceContext.ConversationID
+		}
+		if traceContext.InteractionID != "" {
+			header[HeaderBKNInteractionID] = traceContext.InteractionID
+		}
 		if baggage := formatBaggage(outboundBaggage(traceContext.Baggage, authContext)); baggage != "" {
 			header[HeaderBaggage] = baggage
 		}

--- a/adp/context-loader/agent-retrieval/server/infra/common/context_manage_test.go
+++ b/adp/context-loader/agent-retrieval/server/infra/common/context_manage_test.go
@@ -2,6 +2,7 @@ package common
 
 import (
 	"context"
+	"strings"
 	"testing"
 
 	"github.com/smartystreets/goconvey/convey"
@@ -123,5 +124,89 @@ func TestGetHeaderFromCtxPropagatesTraceContext(t *testing.T) {
 
 		header := GetHeaderFromCtx(ctx)
 		convey.So(header[HeaderBaggage], convey.ShouldEqual, "bkn.account.type=service,bkn.runtime.env=test")
+	})
+}
+
+func TestTraceContextCorrelationIDs(t *testing.T) {
+	convey.Convey("TraceContextFromHeaders reads conversation and interaction ids", t, func() {
+		headers := map[string]string{
+			HeaderBKNRequestID:      "req_01JZVALIDREQUESTID000000010",
+			HeaderBKNConversationID: " agent:thread_abc ",
+			HeaderBKNInteractionID:  "itr_2026072701",
+		}
+		traceCtx := TraceContextFromHeaders(func(key string) string { return headers[key] })
+
+		convey.So(traceCtx.ConversationID, convey.ShouldEqual, "agent:thread_abc")
+		convey.So(traceCtx.InteractionID, convey.ShouldEqual, "itr_2026072701")
+	})
+
+	convey.Convey("SetTraceContextToCtx keeps valid correlation ids and never generates them", t, func() {
+		ctx := SetTraceContextToCtx(context.Background(), TraceContext{
+			RequestID:      "req_01JZVALIDREQUESTID000000011",
+			ConversationID: "agent:thread_abc",
+			InteractionID:  "itr_2026072701",
+		})
+		traceCtx, ok := GetTraceContextFromCtx(ctx)
+		convey.So(ok, convey.ShouldBeTrue)
+		convey.So(traceCtx.ConversationID, convey.ShouldEqual, "agent:thread_abc")
+		convey.So(traceCtx.InteractionID, convey.ShouldEqual, "itr_2026072701")
+
+		degraded := SetTraceContextToCtx(context.Background(), TraceContext{
+			RequestID: "req_01JZVALIDREQUESTID000000012",
+		})
+		degradedCtx, ok := GetTraceContextFromCtx(degraded)
+		convey.So(ok, convey.ShouldBeTrue)
+		convey.So(degradedCtx.ConversationID, convey.ShouldBeEmpty)
+		convey.So(degradedCtx.InteractionID, convey.ShouldBeEmpty)
+	})
+
+	convey.Convey("SetTraceContextToCtx drops malformed correlation ids", t, func() {
+		ctx := SetTraceContextToCtx(context.Background(), TraceContext{
+			RequestID:      "req_01JZVALIDREQUESTID000000013",
+			ConversationID: "bad id with spaces",
+			InteractionID:  strings.Repeat("a", 129),
+		})
+		traceCtx, ok := GetTraceContextFromCtx(ctx)
+		convey.So(ok, convey.ShouldBeTrue)
+		convey.So(traceCtx.ConversationID, convey.ShouldBeEmpty)
+		convey.So(traceCtx.InteractionID, convey.ShouldBeEmpty)
+	})
+}
+
+func TestGetHeaderFromCtxPropagatesCorrelationIDs(t *testing.T) {
+	convey.Convey("GetHeaderFromCtx forwards conversation and interaction ids when present", t, func() {
+		ctx := SetTraceContextToCtx(context.Background(), TraceContext{
+			RequestID:      "req_01JZVALIDREQUESTID000000014",
+			ConversationID: "agent:thread_abc",
+			InteractionID:  "itr_2026072701",
+		})
+
+		header := GetHeaderFromCtx(ctx)
+		convey.So(header[HeaderBKNConversationID], convey.ShouldEqual, "agent:thread_abc")
+		convey.So(header[HeaderBKNInteractionID], convey.ShouldEqual, "itr_2026072701")
+	})
+
+	convey.Convey("GetHeaderFromCtx omits correlation headers when the caller sent none", t, func() {
+		ctx := SetTraceContextToCtx(context.Background(), TraceContext{
+			RequestID: "req_01JZVALIDREQUESTID000000015",
+		})
+
+		header := GetHeaderFromCtx(ctx)
+		_, hasConversation := header[HeaderBKNConversationID]
+		_, hasInteraction := header[HeaderBKNInteractionID]
+		convey.So(hasConversation, convey.ShouldBeFalse)
+		convey.So(hasInteraction, convey.ShouldBeFalse)
+	})
+
+	convey.Convey("correlation ids never leak into baggage", t, func() {
+		ctx := SetTraceContextToCtx(context.Background(), TraceContext{
+			RequestID:      "req_01JZVALIDREQUESTID000000016",
+			ConversationID: "agent:thread_abc",
+			InteractionID:  "itr_2026072701",
+			Baggage:        map[string]string{"bkn.runtime.env": "test"},
+		})
+
+		header := GetHeaderFromCtx(ctx)
+		convey.So(header[HeaderBaggage], convey.ShouldEqual, "bkn.runtime.env=test")
 	})
 }


### PR DESCRIPTION
# Pull Request

## What Changed

- [x] context-loader：接受并透传调用方提供的 `bkn-conversation-id` / `bkn-interaction-id`
- [x] context-loader：证据事件批次的 `trace` 块在调用方传入时携带 `bkn.conversation.id` / `bkn.interaction.id`
- [x] 文档：更新 `adp/context-loader/agent-retrieval/TRACE.md` 契约（入站、出站、Phase 2 规则、Known Gaps）

---

## Why

- Related Issue: [Issue #481](https://github.com/openbkn-ai/bkn-foundry/issues/481)
- Background：同一轮业务分析里的多次 Context 调用（`search_schema` → 多次 `run_sql`）目前只有各自的 `trace_id` / `bkn.request.id`，没有任何共享字段可 join，BKN Trace 无法把它们呈现为一轮交互。
- 本 PR 只做 #481 的 context-loader 切片：**传播**。发起方（Agent / SDK / CLI）与查询方（BKN Trace 核心）另开 PR，见下方「Additional Notes」。

---

## How

- 关键实现点：
  - `TraceContext` 增加 `ConversationID` / `InteractionID`，入站从 header 解析，出站经 `GetHeaderFromCtx` 注入到 BKN/ontology、Vega、operator-integration、MCP 等受信下游。
  - 格式约束 `^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$`，允许 issuer 前缀（如 `agent:thread_x`）。空值或非法值直接丢弃，不报错、不阻断请求。
  - **服务端不生成这两个 id。** 只有调用方知道一轮问题的起止；服务端生成的 id 与 request id 一一对应，零信息量，且落库后无法与真实分组区分。缺失即本轮降级为单请求 trace，与现状行为完全一致。
  - 这两个 id 只是关联标签：不参与鉴权、租户/业务域判定、限流与缓存键，也不进 baggage（baggage 白名单保持 `bkn.account.type` / `bkn.runtime.env` 两项）。
  - `Mcp-Session-Id` 是传输会话，不被当作业务会话读取。
- Breaking changes：无。新增 header 为可选项，老客户端不传即保持原有单请求 trace 行为；无接口签名变更、无配置变更、无数据迁移。

---

## Testing

- [x] Unit tests passed locally
- [ ] Integration tests passed locally（本 PR 无跨服务集成路径，端到端贯通依赖 BKN Trace 侧后续 PR）
- [ ] Verified in test environment（等 BKN Trace 侧落地后一起做贯通验证）

Test notes：

- 新增用例覆盖：header 解析与 trim、合法 id 保留、非法/超长 id 丢弃、缺失时不生成、出站头在缺失时不下发、id 不进 baggage、证据批次 trace 块在有值/无值两种情况下的字段存在性。
- `go test ./...`（context-loader 全模块）本地全绿；`gofmt` 无新增未格式化文件。

---

## Risk & Rollback

- 潜在风险：低。改动集中在 trace context 的读写与出站 header 注入，缺参路径保持原行为；证据上报默认关闭（`BKN_TRACE_EVIDENCE_INGEST_URL` 为空）。
- 已知限制：BKN Trace ingest 目前不持久化、不索引这两个字段，也没有按 interaction 聚合的查询端点，因此本 PR 之后 id 会传播和提交、但暂时查不回来。已写入 TRACE.md 的 Known Gaps。
- 回滚方案：`git revert` 本 PR 即可，无状态、无迁移、无配置依赖。

---

## Additional Notes

- 后续依赖（另开 PR / issue）：
  1. **BKN Trace 核心**：ingest 接受并索引 `bkn.conversation.id` / `bkn.interaction.id`，事件白名单加 `interaction.started` / `interaction.completed`，新增按 interaction 聚合的查询端点；无 interaction 的请求在查询侧按 `req:<request_id>` 虚拟成单请求交互并标 `derived`，不写库。
  2. **bkn-sdk / CLI**：支持传入这两个 id，已提 [openbkn-ai/bkn-sdk#PR](https://github.com/openbkn-ai/bkn-sdk/pulls)。
  3. **bkn-agent**：`thread_id` 映射为 `conversation_id` 并出站传播。
  4. **context-loader 后续**：`run_sql` 目前没有证据 emitter（现有 emitter 只覆盖 `search_schema`、`query_object_instance`、`query_instance_subgraph`），另开 PR 补 hash-only 事件；部署侧 `observability.trace.enabled` 与 `evidence.ingest_url` 默认关闭，需要在部署 profile 打开。
