### PR TITLE
fix(mf-model): 大模型列表与统计补授权,空权限用户不再看到模型/误导性0 (#213)

### DIFF
--- a/infra/mf-model-manager/app/controller/llm_controller.py
+++ b/infra/mf-model-manager/app/controller/llm_controller.py
@@ -308,7 +308,7 @@ async def edit_model(model_para, userId, language, role=""):
 
 
 # 获取大模型列表函数
-async def source_model(userId, language, page, size, name, order, series, rule, api_model, model_type, quota):
+async def source_model(userId, language, page, size, name, order, series, rule, api_model, model_type, quota, role=""):
     name = name.strip()
     error = llm_source_verify(order, page, size, rule, series, name, model_type)
     if error:
@@ -326,8 +326,17 @@ async def source_model(userId, language, page, size, name, order, series, rule, 
                 result = await reshape_source(result, total)
                 return JSONResponse(status_code=200, content=result)
             else:
+                # 授权过滤（#213）：普通用户只看有 large_model:display 授权的模型。
+                # 未授权任何模型 → 空列表；否则把授权 id 集下推进配额查询（查询层过滤，分页正确）。
+                candidate_ids = [m['f_model_id'] for m in llm_model_dao.get_all_model_list()]
+                permission_ids = await permission_manager.filter_authorized_ids(
+                    user_id=userId, role=role, candidate_ids=candidate_ids,
+                    resource_type="large_model", resource_name="大模型", operation="display")
+                if not permission_ids:
+                    return JSONResponse(status_code=200, content={"count": 0, "data": []})
                 datas = await model_quota_controller.get_user_quote_model_list(userId, page, size, name, api_model,
-                                                                               order, rule, quota, model_type)
+                                                                               order, rule, quota, model_type,
+                                                                               permission_ids=permission_ids)
                 result = {
                     "count": datas["total"],
                     "data": datas["res"]
@@ -947,12 +956,17 @@ async def encode_endpoint(params_json, userId, language):
     #     return JSONResponse(status_code=500, content=UnknownError)
 
 
-async def get_monitor_data(userId, language, model_id):
+async def get_monitor_data(userId, language, model_id, role=""):
     try:
         if not model_id:
             error_dict = ModelFactory_Router_ParamError_ParamMissing_Error.copy()
             error_dict["deatil"] = "Param model_id is required"
             return JSONResponse(status_code=400, content=error_dict)
+        # 授权（#213）：无该模型 display 权限的用户不得看统计（此前返全 0，误导为「没被调用」）。
+        # admin 用户与 AUTH 关闭在 check_display 内部短路放行。
+        if userId != "266c6a42-6131-4d62-8f39-853e7093701c" and \
+                not await permission_manager.check_display(userId, role, "large_model", model_id):
+            return JSONResponse(status_code=403, content=NotPermissionError)
         result = llm_model_dao.get_monitor_data(model_id)
         output_token_speed_list = []
         total_token_speed_list = []
@@ -1043,8 +1057,22 @@ async def edit_default_model(model_para, userId, language):
         return JSONResponse(status_code=500, content=DataBaseError)
 
 
-async def get_overview_data(userId, language, model_id, start_time, end_time):
+async def get_overview_data(userId, language, model_id, start_time, end_time, role=""):
     try:
+        # 授权（#213）：指定 model_id 时校验其 display 权限；未指定（聚合全部）时要求
+        # 至少对一个大模型有 display 权限,否则空权限用户会看到全 0 的误导性总览。
+        # admin 与 AUTH 关闭在内部短路放行。
+        if base_config.AUTH_ENABLED and userId != "266c6a42-6131-4d62-8f39-853e7093701c":
+            if model_id:
+                if not await permission_manager.check_display(userId, role, "large_model", model_id):
+                    return JSONResponse(status_code=403, content=NotPermissionError)
+            else:
+                candidate_ids = [m['f_model_id'] for m in llm_model_dao.get_all_model_list()]
+                authorized = await permission_manager.filter_authorized_ids(
+                    user_id=userId, role=role, candidate_ids=candidate_ids,
+                    resource_type="large_model", resource_name="大模型", operation="display")
+                if not authorized:
+                    return JSONResponse(status_code=403, content=NotPermissionError)
         if not start_time:
             error_dict = ModelFactory_Router_ParamError_ParamMissing_Error.copy()
             error_dict["detail"] = "Param start_time is required"

--- a/infra/mf-model-manager/app/controller/llm_controller.py
+++ b/infra/mf-model-manager/app/controller/llm_controller.py
@@ -1067,6 +1067,11 @@ async def get_overview_data(userId, language, model_id, start_time, end_time, ro
                 if not await permission_manager.check_display(userId, role, "large_model", model_id):
                     return JSONResponse(status_code=403, content=NotPermissionError)
             else:
+                # 口径说明:此处 authorized 仅作准入门禁(有无任一授权模型),用于消除
+                # 空权限用户的误导性全 0 总览。聚合本身不再按 authorized 集收窄——DAO 侧
+                # 对非 admin 已附加 and d.f_user_id='{userId}'(llm_model_dao 435/459),
+                # 总览统计的是调用者自身跨模型的用量,不构成越权;列表按授权收窄、总览按
+                # 自身用量,两处口径不同,勿误读为总览也已逐模型过滤。
                 candidate_ids = [m['f_model_id'] for m in llm_model_dao.get_all_model_list()]
                 authorized = await permission_manager.filter_authorized_ids(
                     user_id=userId, role=role, candidate_ids=candidate_ids,

--- a/infra/mf-model-manager/app/controller/model_quota_controller.py
+++ b/infra/mf-model-manager/app/controller/model_quota_controller.py
@@ -591,15 +591,15 @@ async def delete_user_model_quota_config(conf_id_list, user_id: str):
                             content=error_dict)
 
 
-async def get_user_quote_model_list(userId, page, size, name, api_model, order, rule, quota, model_type):
+async def get_user_quote_model_list(userId, page, size, name, api_model, order, rule, quota, model_type, permission_ids=None):
     try:
         if name is None or name == "":
             user_quote_list, total_list, total, user_quota_token_used_list = model_quota_dao.get_user_quota_model_by_user_id(
-                userId, page, size, api_model, order, rule, quota,model_type)
+                userId, page, size, api_model, order, rule, quota, model_type, permission_ids=permission_ids)
         else:
             user_quote_list, total_list, total, user_quota_token_used_list = model_quota_dao.get_user_quota_model_by_user_id_name_fuzzy(
                 userId, page, size, name,
-                api_model, order, rule, quota, model_type)
+                api_model, order, rule, quota, model_type, permission_ids=permission_ids)
         model_list = []
         for item in total_list:
             if item["f_model"] not in model_list:

--- a/infra/mf-model-manager/app/dao/model_quota_dao.py
+++ b/infra/mf-model-manager/app/dao/model_quota_dao.py
@@ -284,8 +284,19 @@ class ModelQuotaDao():
         return res
 
     @connect_execute_close_db
-    def get_user_quota_model_by_user_id(self, userId, page, size, api_model, order, rule, quota, model_type, connection,
-                                        cursor):
+    def get_user_quota_model_by_user_id(self, userId, page, size, api_model, order, rule, quota, model_type,
+                                        permission_ids=None, connection=None, cursor=None):
+        # Authorization filter (#213): when permission_ids is passed, restrict
+        # every query to those model ids so an unauthorized model never appears —
+        # applied at the query level so pagination/count stay correct. None means
+        # no filtering (auth disabled / admin); an empty list means "authorized
+        # for nothing" and short-circuits to an empty result.
+        id_filter = ""
+        if permission_ids is not None:
+            if not permission_ids:
+                return [], [], 0, []
+            _quoted = ",".join("'" + str(_i).replace("'", "").replace(";", "") + "'" for _i in permission_ids)
+            id_filter = f" and t_llm_model.f_model_id in ({_quoted})"
         # 构建基础WHERE条件
         if model_type:
             where_clause = f"""where (t_llm_model.f_model_type = '{model_type}' and t_llm_model.f_quota = 0 and (t_user_quota_config.f_user_id is null or t_user_quota_config.f_user_id = '{userId}'))
@@ -305,7 +316,7 @@ class ModelQuotaDao():
                 from t_model_quota_config 
                 left join t_user_quota_config on t_user_quota_config.f_model_conf = t_model_quota_config.f_id 
                 right join t_llm_model on t_llm_model.f_model_id = t_model_quota_config.f_model_id
-                {where_clause}"""
+                where ({where_clause[6:]}) {id_filter}"""
         if api_model is not None and api_model != "":
             sql += " and BINARY t_llm_model.f_model = %s " % api_model
         if quota is not None:
@@ -339,7 +350,7 @@ class ModelQuotaDao():
                         from t_model_quota_config 
                         left join t_user_quota_config on t_user_quota_config.f_model_conf = t_model_quota_config.f_id 
                         right join t_llm_model on t_llm_model.f_model_id = t_model_quota_config.f_model_id
-                        {where_clause2}"""
+                        where ({where_clause2[6:]}) {id_filter}"""
         if api_model is not None and api_model != "":
             sql += "and BINARY t_llm_model.f_model = '%s' " % api_model
         if quota is not None:
@@ -371,7 +382,7 @@ class ModelQuotaDao():
                                         from t_model_quota_config 
                                         left join t_user_quota_config on t_user_quota_config.f_model_conf = t_model_quota_config.f_id 
                                         right join t_llm_model on t_llm_model.f_model_id = t_model_quota_config.f_model_id
-                                        {where_clause3}"""
+                                        where ({where_clause3[6:]}) {id_filter}"""
         if rule != "":
             sql += " order by t_llm_model.f_" + rule
         if order == "desc":
@@ -399,8 +410,15 @@ class ModelQuotaDao():
     @connect_execute_close_db
     def get_user_quota_model_by_user_id_name_fuzzy(self, userId, page, size, name, api_model, order, rule, quota,
                                                    model_type,
-                                                   connection, cursor):
+                                                   permission_ids=None, connection=None, cursor=None):
         admin_id = "266c6a42-6131-4d62-8f39-853e7093701c"
+        # Authorization filter (#213), same contract as get_user_quota_model_by_user_id.
+        id_filter = ""
+        if permission_ids is not None:
+            if not permission_ids:
+                return [], [], 0, []
+            _quoted = ",".join("'" + str(_i).replace("'", "").replace(";", "") + "'" for _i in permission_ids)
+            id_filter = f" and t_llm_model.f_model_id in ({_quoted})"
         
         # 构建基础WHERE条件
         if model_type:
@@ -424,7 +442,7 @@ class ModelQuotaDao():
                         from t_model_quota_config 
                         left join t_user_quota_config on t_user_quota_config.f_model_conf = t_model_quota_config.f_id 
                         right join t_llm_model on t_llm_model.f_model_id = t_model_quota_config.f_model_id 
-                        {where_clause}"""
+                        where ({where_clause[6:]}) {id_filter}"""
         if api_model is not None and api_model != "":
             sql += " and BINARY t_llm_model.f_model = '%s' " % api_model
         if rule != "":
@@ -453,7 +471,7 @@ class ModelQuotaDao():
                                 from t_model_quota_config 
                                 left join t_user_quota_config on t_user_quota_config.f_model_conf = t_model_quota_config.f_id 
                                 right join t_llm_model on t_llm_model.f_model_id = t_model_quota_config.f_model_id 
-                                {where_clause2}"""
+                                where ({where_clause2[6:]}) {id_filter}"""
         if api_model is not None and api_model != "":
             sql += "and BINARY t_llm_model.f_model = '%s' " % api_model
         if rule != "":
@@ -479,7 +497,7 @@ class ModelQuotaDao():
                                 from t_model_quota_config 
                                 left join t_user_quota_config on t_user_quota_config.f_model_conf = t_model_quota_config.f_id 
                                 right join t_llm_model on t_llm_model.f_model_id = t_model_quota_config.f_model_id 
-                                {where_clause3}"""
+                                where ({where_clause3[6:]}) {id_filter}"""
         if rule != "":
             sql += " order by t_llm_model.f_" + rule
         if order == "desc":

--- a/infra/mf-model-manager/app/dao/model_quota_dao.py
+++ b/infra/mf-model-manager/app/dao/model_quota_dao.py
@@ -318,7 +318,9 @@ class ModelQuotaDao():
                 right join t_llm_model on t_llm_model.f_model_id = t_model_quota_config.f_model_id
                 where ({where_clause[6:]}) {id_filter}"""
         if api_model is not None and api_model != "":
-            sql += " and BINARY t_llm_model.f_model = %s " % api_model
+            # 存量缺陷(#213 顺修):裸 %s 未加引号,api_model 非空时拼出语法错误的 SQL;
+            # 对齐同方法第二段的 '%s' 写法。恰在本 PR 收窄的非 admin 授权查询路径上。
+            sql += " and BINARY t_llm_model.f_model = '%s' " % api_model
         if quota is not None:
             if quota:
                 sql += " and t_llm_model.f_quota = 1 "

--- a/infra/mf-model-manager/app/routers/llm_router.py
+++ b/infra/mf-model-manager/app/routers/llm_router.py
@@ -57,7 +57,7 @@ async def edit_llm(request: Request, model_para: dict = Body(...)):
 async def source_llm(request: Request, page, size, order='desc', rule='update_time', series='all', name='',
                      api_model='', model_type='', quota: bool = Query(default=None)):
     userId, language, role = await get_user_info(request)
-    return await source_model(userId, language, page, size, name, order, series, rule, api_model, model_type, quota)
+    return await source_model(userId, language, page, size, name, order, series, rule, api_model, model_type, quota, role)
 
 
 # 大模型按 id 批量取名接口
@@ -164,7 +164,7 @@ async def llm_used_openai2(request: LLMUsedOpenAI, head_request: Request):
 @llm_route.get("/llm/monitor/list")
 async def monitor_llm(request: Request, model_id):
     userId, language, role = await get_user_info(request)
-    return await get_monitor_data(userId, language, model_id)
+    return await get_monitor_data(userId, language, model_id, role)
 
 
 @llm_route.post("/llm/default/edit")
@@ -176,4 +176,4 @@ async def edit_default_llm(request: Request, model_para: dict = Body(...)):
 @llm_route.get("/llm/monitor/overview")
 async def get_performance_analysis(request: Request, start_time="", end_time="", model_id=""):
     userId, language, role = await get_user_info(request)
-    return await get_overview_data(userId, language, model_id, start_time, end_time)
+    return await get_overview_data(userId, language, model_id, start_time, end_time, role)

--- a/infra/mf-model-manager/app/utils/permission_manager.py
+++ b/infra/mf-model-manager/app/utils/permission_manager.py
@@ -285,6 +285,61 @@ class PermissionManager:
             StandLogger.error(e.args)
         return operation_ids
 
+    async def filter_authorized_ids(self, user_id: str, role: str, candidate_ids: list,
+                                    resource_type: str, resource_name: str,
+                                    operation: str = "display") -> list:
+        """Generic per-caller resource filter: keep only the candidate ids the
+        user is authorized for. Unlike get_permission_ids (which is coupled to
+        small_model_dao), the candidate id set is passed in, so it works for any
+        resource type — large_model list uses it, and it does not disturb the
+        existing small_model path.
+
+        AUTH disabled -> everything passes. A "*" operation yields none (matches
+        the ISF filter dropping them). bkn-safe authoritative checks each id;
+        otherwise the ISF resource-filter endpoint decides in one batch.
+        """
+        if not base_config.AUTH_ENABLED:
+            return list(candidate_ids)
+        if operation == "*":
+            return []
+        if self._bkn_safe_authoritative():
+            allowed = []
+            for mid in candidate_ids:
+                try:
+                    if await self._bkn_safe_check(user_id, resource_type, mid, operation):
+                        allowed.append(mid)
+                except Exception as e:
+                    StandLogger.error(e.args)
+            return allowed
+        # ISF legacy: batch resource-filter.
+        resources = [{"id": mid, "type": resource_type, "name": resource_name} for mid in candidate_ids]
+        payload = {
+            "method": "GET",
+            "accessor": {"id": user_id, "type": role},
+            "resources": resources,
+            "operation": [operation],
+        }
+        try:
+            session = await self.get_session()
+            async with session.post(
+                    self.resource_filter_url,
+                    json=payload,
+                    headers={'Content-Type': 'application/json'}
+            ) as response:
+                if response.status == 200:
+                    result = await response.json()
+                    return [item['id'] for item in result]
+        except Exception as e:
+            StandLogger.error(e.args)
+        return []
+
+    async def check_display(self, user_id: str, role: str, resource_type: str, resource_id: str) -> bool:
+        """Single-resource display check, for endpoints keyed by one model id
+        (e.g. model statistics). AUTH disabled -> allowed."""
+        return await self.check_single_permission(
+            user_id=user_id, resource_id=resource_id, operations="display",
+            resource_type=resource_type, role=role)
+
     async def delete_permission(self, resource_type: str, resource_ids: list) -> bool:
         if not base_config.AUTH_ENABLED:
             return True

--- a/infra/mf-model-manager/app/utils/permission_manager.py
+++ b/infra/mf-model-manager/app/utils/permission_manager.py
@@ -1,3 +1,4 @@
+import asyncio
 import os
 
 import aiohttp
@@ -295,22 +296,27 @@ class PermissionManager:
         existing small_model path.
 
         AUTH disabled -> everything passes. A "*" operation yields none (matches
-        the ISF filter dropping them). bkn-safe authoritative checks each id;
-        otherwise the ISF resource-filter endpoint decides in one batch.
+        the ISF filter dropping them). bkn-safe authoritative checks each id
+        concurrently; otherwise the ISF resource-filter endpoint decides in one
+        batch.
+
+        Fail-closed on error: a per-id check that raises is NOT swallowed into
+        "not authorized" — that would silently drop models from the list on a
+        transient blip and show the user an incomplete set with no error. The
+        exception propagates so the caller returns 500 instead of a plausible
+        short list.
         """
         if not base_config.AUTH_ENABLED:
             return list(candidate_ids)
         if operation == "*":
             return []
         if self._bkn_safe_authoritative():
-            allowed = []
-            for mid in candidate_ids:
-                try:
-                    if await self._bkn_safe_check(user_id, resource_type, mid, operation):
-                        allowed.append(mid)
-                except Exception as e:
-                    StandLogger.error(e.args)
-            return allowed
+            # Concurrent per-id checks (serial N round-trips is the #357 timeout
+            # shape). gather propagates the first exception -> fail-closed.
+            results = await asyncio.gather(
+                *[self._bkn_safe_check(user_id, resource_type, mid, operation) for mid in candidate_ids]
+            )
+            return [mid for mid, ok in zip(candidate_ids, results) if ok]
         # ISF legacy: batch resource-filter.
         resources = [{"id": mid, "type": resource_type, "name": resource_name} for mid in candidate_ids]
         payload = {


### PR DESCRIPTION
bkn-studio#213 的**后端半**(mf-model)。前端菜单/路由门禁 + vega index-builds 另做。

## 问题

mf-model-manager 大模型「读」面漏授权:create/edit/delete/execute 都校验,但 **list 与 statistics 没有** → 空权限用户看到全部大模型、统计页返全 0 误导成「系统没被调用」。小模型列表早已按 `display` 过滤,本次补齐大模型对齐。

## 改动

**大模型列表**(`source_model` 普通用户路径):
- 候选 id 经 `permission_manager.filter_authorized_ids` 过滤到有 `large_model:display` 授权的集合;零授权 → 空列表
- 授权 id 集**下推进配额查询**(`model_quota_dao` 两方法 6 处 where 子句),查询层过滤 → **分页/总数正确**
- AUTH 关 / admin 走全量,行为不变

**统计**(`get_monitor_data` / `get_overview_data`):
- 指定 model_id 校验 `display`;overview 未指定时要求至少一个授权模型,否则 403
- 无权 **403 而非全 0**,消除误导

**新增** `permission_manager.filter_authorized_ids`(candidate_ids 显式传入、按 resource_type 通用、不耦合 small_model_dao)+ `check_display`。

## DAO 安全改法

`where` 子句一律 **slice-wrap**:`where (<原条件>) and f_model_id in (...)`,外包一层括号再 AND → 优先级永远正确(已验证括号平衡)。`permission_ids` 空短路返空、None(AUTH关/admin)不过滤。装饰器以 kwargs 注入 connection/cursor,新增参数不冲突。

## 范围 / 兼容

- 小模型列表已护(不动);vega index-builds 归 **#269**;前端菜单/路由门禁另做(studio)
- 按裁决**硬强制**:普通用户只见有 `display` 授权的大模型,与小模型一致

## 测试

mf-model 单测须在 `model-factory-base` 镜像内跑(裸 runner 缺依赖)。本地做了 `py_compile` + DAO wrap 出的 SQL 括号平衡/优先级验证。**DAO SQL 改动需镜像/环境实测**——建议在测试服拿空权限用户实调 `/llm/list`、`/llm/monitor/*` 确认列表过滤 + 统计 403。

## 关联

- bkn-studio#213(后端半);#269(vega index-builds);审计定位「授权只护写不护读」
- 样板:`small_model_controller.get_info_list`

🤖 Generated with [Claude Code](https://claude.com/claude-code)