### PR TITLE
fix(execution-factory): path 参数按路径段转义并补齐 forwarder 参数装配测试

### DIFF
--- a/adp/execution-factory/operator-integration/server/logics/proxy/forwarder.go
+++ b/adp/execution-factory/operator-integration/server/logics/proxy/forwarder.go
@@ -178,15 +178,7 @@ func (f *forwarder) Forward(ctx context.Context, req *interfaces.HTTPRequest) (*
 // buildRequest 根据请求参数构建HTTP请求
 func (f *forwarder) buildRequest(ctx context.Context, req *interfaces.HTTPRequest) (*http.Request, error) {
 	// 处理URL和路径参数
-	requestURL := req.URL
-	if len(req.PathParams) > 0 {
-		for key, value := range req.PathParams {
-			// ":{key}" 必须先于 "{key}" 替换，否则会先命中 "{key}" 而在 URL 里留下多余的冒号
-			requestURL = strings.ReplaceAll(requestURL, fmt.Sprintf(":{%s}", key), value)
-			requestURL = strings.ReplaceAll(requestURL, fmt.Sprintf("{%s}", key), value)
-			requestURL = strings.ReplaceAll(requestURL, fmt.Sprintf(":%s", key), value)
-		}
-	}
+	requestURL := substitutePathParams(req.URL, req.PathParams)
 	// 路径模板仍有未替换的占位符时直接拒绝，避免把 "/market/{operator_id}" 这类无效 URL 发给下游
 	if unresolved := unresolvedPathPlaceholders(requestURL); len(unresolved) > 0 {
 		missing := strings.Join(unresolved, ", ")
@@ -348,6 +340,36 @@ func isTransportHeader(key string) bool {
 
 // pathPlaceholderPattern 匹配路径里形如 {name} 的占位符。
 var pathPlaceholderPattern = regexp.MustCompile(`\{([^{}/]+)\}`)
+
+// colonParamPattern 匹配 ":name" 形式的占位符，并要求后面是非标识符字符或结尾。
+// 少了这个边界，参数 id 会把 "/users/:identifier" 里的 ":id" 前缀也换掉，剩下半截 "entifier"。
+func colonParamPattern(key string) *regexp.Regexp {
+	return regexp.MustCompile(`:` + regexp.QuoteMeta(key) + `([^A-Za-z0-9_]|$)`)
+}
+
+// substitutePathParams 把 path 参数按 "{name}"、":{name}"、":name" 三种写法替换进 URL。
+//
+// 值一律按路径段转义：path 参数在 OpenAPI 里是单个路径段，未转义的 "/"、"?"、"#"
+// 会改变整条 URL 的结构——调用方本想传 ID，却能把下游请求改写成另一个路径、或凭空
+// 追加 query。目标 URL 由工具元数据决定、调试界面不允许改，这里是最后一道闸。
+func substitutePathParams(rawURL string, params map[string]string) string {
+	if len(params) == 0 {
+		return rawURL
+	}
+
+	for key, value := range params {
+		escaped := url.PathEscape(value)
+		// ":{key}" 必须先于 "{key}" 替换，否则会先命中 "{key}" 而在 URL 里留下多余的冒号
+		rawURL = strings.ReplaceAll(rawURL, ":{"+key+"}", escaped)
+		rawURL = strings.ReplaceAll(rawURL, "{"+key+"}", escaped)
+		// 用 Func 版本替换：转义后的值可能含 "$"，走 ReplaceAllString 会被当成分组引用。
+		rawURL = colonParamPattern(key).ReplaceAllStringFunc(rawURL, func(match string) string {
+			return escaped + match[len(key)+1:]
+		})
+	}
+
+	return rawURL
+}
 
 // unresolvedPathPlaceholders 返回 URL 路径中仍未被 path 参数替换的占位符名称。
 // 只检查路径部分：query 与 fragment 里的花括号可能是业务值，冒号形式无法与端口号区分，都不参与判断。

--- a/adp/execution-factory/operator-integration/server/logics/proxy/forwarder_test.go
+++ b/adp/execution-factory/operator-integration/server/logics/proxy/forwarder_test.go
@@ -2,6 +2,7 @@ package proxy
 
 import (
 	"context"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -104,5 +105,134 @@ func TestForward_PropagatesTraceHeadersFromContext(t *testing.T) {
 		So(captured[common.HeaderLegacyRequestID], ShouldEqual, "req_01JZVALIDREQUESTID000000215")
 		So(captured[common.HeaderTraceparent], ShouldEqual, "00-20212223242526272829303132333435-4041424344454647-01")
 		So(captured[common.HeaderBaggage], ShouldEqual, "bkn.account.type=service")
+	})
+}
+
+func TestBuildRequest_PathQueryHeaderBody(t *testing.T) {
+	Convey("buildRequest 按 OpenAPI 参数位置拼出下游请求（#216）", t, func() {
+		f := &forwarder{logger: logger.DefaultLogger()}
+		ctx := context.Background()
+
+		Convey("path 参数三种写法都会被替换", func() {
+			for _, template := range []string{
+				"http://svc:9000/resources/{resource_id}/detail",
+				"http://svc:9000/resources/:{resource_id}/detail",
+				"http://svc:9000/resources/:resource_id/detail",
+			} {
+				httpReq, err := f.buildRequest(ctx, &interfaces.HTTPRequest{
+					HTTPRouter: interfaces.HTTPRouter{Method: http.MethodGet, URL: template},
+					HTTPRequestParams: interfaces.HTTPRequestParams{
+						PathParams: map[string]string{"resource_id": "res-42"},
+					},
+				})
+
+				So(err, ShouldBeNil)
+				So(httpReq.URL.String(), ShouldEqual, "http://svc:9000/resources/res-42/detail")
+			}
+		})
+
+		Convey("path 值按路径段转义，不能改写 URL 结构", func() {
+			httpReq, err := f.buildRequest(ctx, &interfaces.HTTPRequest{
+				HTTPRouter: interfaces.HTTPRouter{Method: http.MethodGet, URL: "http://svc:9000/files/{name}"},
+				HTTPRequestParams: interfaces.HTTPRequestParams{
+					PathParams: map[string]string{"name": "../admin?x=1"},
+				},
+			})
+
+			So(err, ShouldBeNil)
+			So(httpReq.URL.Path, ShouldEqual, "/files/../admin?x=1")
+			So(httpReq.URL.EscapedPath(), ShouldEqual, "/files/..%2Fadmin%3Fx=1")
+			So(httpReq.URL.RawQuery, ShouldEqual, "")
+		})
+
+		Convey("冒号写法要求名字边界，不能吃掉更长的参数名", func() {
+			httpReq, err := f.buildRequest(ctx, &interfaces.HTTPRequest{
+				HTTPRouter: interfaces.HTTPRouter{Method: http.MethodGet, URL: "http://svc:9000/x/:id/:identifier"},
+				HTTPRequestParams: interfaces.HTTPRequestParams{
+					PathParams: map[string]string{"id": "1", "identifier": "2"},
+				},
+			})
+
+			So(err, ShouldBeNil)
+			So(httpReq.URL.Path, ShouldEqual, "/x/1/2")
+		})
+
+		Convey("占位符没填齐时拒发，不把 {name} 原样发给下游", func() {
+			_, err := f.buildRequest(ctx, &interfaces.HTTPRequest{
+				HTTPRouter: interfaces.HTTPRouter{Method: http.MethodGet, URL: "http://svc:9000/resources/{resource_id}"},
+			})
+
+			So(err, ShouldNotBeNil)
+			httpErr, ok := err.(*myErr.HTTPError)
+			So(ok, ShouldBeTrue)
+			So(httpErr.HTTPCode, ShouldEqual, http.StatusBadRequest)
+			So(httpErr.ErrorDetails, ShouldContainSubstring, "resource_id")
+		})
+
+		Convey("query 参数追加到 URL，且不丢模板里已有的 query", func() {
+			httpReq, err := f.buildRequest(ctx, &interfaces.HTTPRequest{
+				HTTPRouter: interfaces.HTTPRouter{Method: http.MethodGet, URL: "http://svc:9000/search?tenant=t1"},
+				HTTPRequestParams: interfaces.HTTPRequestParams{
+					QueryParams: map[string]any{"limit": 20, "keyword": "a b"},
+				},
+			})
+
+			So(err, ShouldBeNil)
+			query := httpReq.URL.Query()
+			So(query.Get("tenant"), ShouldEqual, "t1")
+			So(query.Get("limit"), ShouldEqual, "20")
+			So(query.Get("keyword"), ShouldEqual, "a b")
+		})
+
+		Convey("header 逐个落到下游请求头上", func() {
+			httpReq, err := f.buildRequest(ctx, &interfaces.HTTPRequest{
+				HTTPRouter: interfaces.HTTPRouter{Method: http.MethodGet, URL: "http://svc:9000/ping"},
+				HTTPRequestParams: interfaces.HTTPRequestParams{
+					Headers: map[string]any{"X-Tenant-Id": "t-1", "X-Api-Key": "ak-live"},
+				},
+			})
+
+			So(err, ShouldBeNil)
+			So(httpReq.Header.Get("X-Tenant-Id"), ShouldEqual, "t-1")
+			So(httpReq.Header.Get("X-Api-Key"), ShouldEqual, "ak-live")
+		})
+
+		Convey("body 默认按 JSON 编码，Content-Type 自动补齐", func() {
+			httpReq, err := f.buildRequest(ctx, &interfaces.HTTPRequest{
+				HTTPRouter: interfaces.HTTPRouter{Method: http.MethodPost, URL: "http://svc:9000/items"},
+				HTTPRequestParams: interfaces.HTTPRequestParams{
+					Body: map[string]any{"name": "demo"},
+				},
+			})
+
+			So(err, ShouldBeNil)
+			So(httpReq.Header.Get("Content-Type"), ShouldEqual, "application/json")
+			payload, readErr := io.ReadAll(httpReq.Body)
+			So(readErr, ShouldBeNil)
+			So(string(payload), ShouldEqual, `{"name":"demo"}`)
+		})
+
+		Convey("四个位置同时给全时互不串位", func() {
+			httpReq, err := f.buildRequest(ctx, &interfaces.HTTPRequest{
+				HTTPRouter: interfaces.HTTPRouter{
+					Method: http.MethodPost,
+					URL:    "http://svc:9000/tenants/{tenant_id}/items",
+				},
+				HTTPRequestParams: interfaces.HTTPRequestParams{
+					PathParams:  map[string]string{"tenant_id": "t-9"},
+					QueryParams: map[string]any{"dry_run": true},
+					Headers:     map[string]any{"X-Account-Id": "u-1"},
+					Body:        map[string]any{"name": "demo"},
+				},
+			})
+
+			So(err, ShouldBeNil)
+			So(httpReq.URL.Path, ShouldEqual, "/tenants/t-9/items")
+			So(httpReq.URL.Query().Get("dry_run"), ShouldEqual, "true")
+			So(httpReq.Header.Get("X-Account-Id"), ShouldEqual, "u-1")
+			payload, readErr := io.ReadAll(httpReq.Body)
+			So(readErr, ShouldBeNil)
+			So(string(payload), ShouldEqual, `{"name":"demo"}`)
+		})
 	})
 }


### PR DESCRIPTION
## 背景

#216 验收标准第 11 条要求「补充 Tool/Operator 调试单测和后端联调测试，覆盖 header/query/path/body」。前端侧已覆盖（bkn-studio #275），后端 `forwarder.buildRequest` —— 真正把 path/query/header/body 装配成下游请求的地方 —— 此前一条测试都没有（`forwarder_test.go` 只测了 ForwardStream 不 panic 和 trace header 透传）。

补测试时暴露两处问题，一并修掉。

## 改动

**1. path 值按路径段转义**

`strings.ReplaceAll(url, "{id}", value)` 把值原样拼进 URL。值里的 `?` / `/` / `#` 会改变整条 URL 的结构：调用方本想传一个 ID，却能把下游请求改写成另一条路径、或凭空追加 query。

实测（未修前）：path 参数 `name = "../admin?x=1"`，模板 `http://svc:9000/files/{name}` → 实际请求 URL 的 Path 变成 `/files/../admin`，`?x=1` 成了真的 query string。

path 参数在 OpenAPI 里就是单个路径段，改为统一 `url.PathEscape`。目标 URL 由工具元数据决定、调试界面不允许改（见 #216 的范围外约定），这里是最后一道闸。

**行为变化**：path 值里的 `/` 现在会编码成 `%2F`，多路径段的值不再穿透。当前平台已注册的 50 个工具，path 参数只有 `operator_id`、`session_id` 这类单段 ID，不受影响。

**2. `:name` 写法加名字边界**

`strings.ReplaceAll(url, ":id", value)` 是前缀匹配：参数 `id` 会把 `/users/:identifier` 里的 `:id` 也换掉，剩下半截 `entifier`。而且当 `id` 和 `identifier` 同时存在时，结果随 map 遍历顺序漂移。改为要求 `:name` 后面是非标识符字符或结尾。

替换逻辑抽成 `substitutePathParams`。

## 测试

新增 `TestBuildRequest_PathQueryHeaderBody`，8 组用例：

- `{name}` / `:{name}` / `:name` 三种占位符写法都替换
- path 值转义，不能改写 URL 结构
- 冒号写法的名字边界，不吃掉更长的参数名
- 占位符没填齐时返回 400，不把 `{name}` 原样发给下游
- query 追加且不丢模板里已有的 query
- header 逐个落到下游请求头
- body 默认 JSON 编码、Content-Type 自动补齐
- 四个位置同时给全时互不串位

`go test -count=1 ./server/logics/proxy/...` 通过；`go vet`、`gofmt`、`go build ./...` 干净。转义那条用例在修复前会失败（实测 `Actual: "/files/../admin"`），不是空跑。

Refs #216

🤖 Generated with [Claude Code](https://claude.com/claude-code)