### PR TITLE
fix(ontology-query): send resource data paging and promote legacy conditions (#475)

### DIFF
--- a/adp/bkn/ontology-query/server/common/condition/condition.go
+++ b/adp/bkn/ontology-query/server/common/condition/condition.go
@@ -243,6 +243,7 @@ func PromoteLegacyLeafWithSubConds(cfg *CondCfg) *CondCfg {
 		Name:         cfg.Name,
 		Operation:    cfg.Operation,
 		ValueOptCfg:  cfg.ValueOptCfg,
+		RemainCfg:    cfg.RemainCfg,
 		NameField:    cfg.NameField,
 	}
 	subs := make([]*CondCfg, 0, 1+len(cfg.SubConds))

--- a/adp/bkn/ontology-query/server/common/condition/condition.go
+++ b/adp/bkn/ontology-query/server/common/condition/condition.go
@@ -41,6 +41,7 @@ func NewCondition(ctx context.Context, cfg *CondCfg, fieldScope uint8, fieldsMap
 	if cfg == nil {
 		return nil, nil
 	}
+	cfg = PromoteLegacyLeafWithSubConds(cfg)
 	switch cfg.Operation {
 	case OperationAnd:
 		cond, err = newAndCond(ctx, cfg, fieldScope, fieldsMap)
@@ -198,6 +199,7 @@ func RewriteCondition(ctx context.Context, cfg *CondCfg, fieldsMap map[string]*D
 	if cfg == nil {
 		return nil, nil
 	}
+	cfg = PromoteLegacyLeafWithSubConds(cfg)
 	switch cfg.Operation {
 	case OperationAnd:
 		viewCfg, err = rewriteAndCondition(ctx, cfg, fieldsMap, vectorizer)
@@ -211,6 +213,48 @@ func RewriteCondition(ctx context.Context, cfg *CondCfg, fieldsMap map[string]*D
 	}
 
 	return viewCfg, nil
+}
+
+// PromoteLegacyLeafWithSubConds lifts malformed condition trees where a comparison
+// leaf also carries sub_conditions (Studio multi-row before and-normalization)
+// into an explicit and node so rewrite recurses into every leaf.
+func PromoteLegacyLeafWithSubConds(cfg *CondCfg) *CondCfg {
+	if cfg == nil {
+		return nil
+	}
+	if cfg.Operation == OperationAnd || cfg.Operation == OperationOr {
+		if len(cfg.SubConds) == 0 {
+			return cfg
+		}
+		promoted := make([]*CondCfg, 0, len(cfg.SubConds))
+		for _, sub := range cfg.SubConds {
+			promoted = append(promoted, PromoteLegacyLeafWithSubConds(sub))
+		}
+		out := *cfg
+		out.SubConds = promoted
+		return &out
+	}
+	if len(cfg.SubConds) == 0 {
+		return cfg
+	}
+
+	leaf := &CondCfg{
+		ObjectTypeID: cfg.ObjectTypeID,
+		Name:         cfg.Name,
+		Operation:    cfg.Operation,
+		ValueOptCfg:  cfg.ValueOptCfg,
+		NameField:    cfg.NameField,
+	}
+	subs := make([]*CondCfg, 0, 1+len(cfg.SubConds))
+	subs = append(subs, leaf)
+	for _, sub := range cfg.SubConds {
+		subs = append(subs, PromoteLegacyLeafWithSubConds(sub))
+	}
+	return &CondCfg{
+		ObjectTypeID: cfg.ObjectTypeID,
+		Operation:    OperationAnd,
+		SubConds:     subs,
+	}
 }
 
 func rewriteCondWithOpr(ctx context.Context, cfg *CondCfg, fieldsMap map[string]*DataProperty,

--- a/adp/bkn/ontology-query/server/common/condition/condition_promote_test.go
+++ b/adp/bkn/ontology-query/server/common/condition/condition_promote_test.go
@@ -1,0 +1,58 @@
+// Copyright openbkn.ai
+// Copyright The kweaver.ai Authors.
+//
+// Licensed under the Apache License, Version 2.0.
+// See the LICENSE file in the project root for details.
+
+package condition
+
+import (
+	"testing"
+
+	. "github.com/smartystreets/goconvey/convey"
+)
+
+func Test_PromoteLegacyLeafWithSubConds(t *testing.T) {
+	Convey("PromoteLegacyLeafWithSubConds", t, func() {
+		Convey("promotes leaf with nested sub_conditions into and", func() {
+			cfg := &CondCfg{
+				Name:      "product_name",
+				Operation: OperationEq,
+				ValueOptCfg: ValueOptCfg{
+					Value: "UAV-BF-IND-H30",
+				},
+				SubConds: []*CondCfg{
+					{
+						Name:      "customer_name",
+						Operation: OperationEq,
+						ValueOptCfg: ValueOptCfg{
+							Value: "Acme",
+						},
+					},
+				},
+			}
+
+			got := PromoteLegacyLeafWithSubConds(cfg)
+			So(got, ShouldNotBeNil)
+			So(got.Operation, ShouldEqual, OperationAnd)
+			So(len(got.SubConds), ShouldEqual, 2)
+			So(got.SubConds[0].Name, ShouldEqual, "product_name")
+			So(got.SubConds[0].Operation, ShouldEqual, OperationEq)
+			So(got.SubConds[1].Name, ShouldEqual, "customer_name")
+			So(got.SubConds[1].Operation, ShouldEqual, OperationEq)
+		})
+
+		Convey("leaves proper and trees unchanged structurally", func() {
+			cfg := &CondCfg{
+				Operation: OperationAnd,
+				SubConds: []*CondCfg{
+					{Name: "a", Operation: OperationEq, ValueOptCfg: ValueOptCfg{Value: 1}},
+					{Name: "b", Operation: OperationEq, ValueOptCfg: ValueOptCfg{Value: 2}},
+				},
+			}
+			got := PromoteLegacyLeafWithSubConds(cfg)
+			So(got.Operation, ShouldEqual, OperationAnd)
+			So(len(got.SubConds), ShouldEqual, 2)
+		})
+	})
+}

--- a/adp/bkn/ontology-query/server/common/condition/condition_promote_test.go
+++ b/adp/bkn/ontology-query/server/common/condition/condition_promote_test.go
@@ -54,5 +54,39 @@ func Test_PromoteLegacyLeafWithSubConds(t *testing.T) {
 			So(got.Operation, ShouldEqual, OperationAnd)
 			So(len(got.SubConds), ShouldEqual, 2)
 		})
+
+		Convey("preserves RemainCfg when promoting match leaf with sub_conditions", func() {
+			cfg := &CondCfg{
+				Name:      "title",
+				Operation: OperationMatch,
+				ValueOptCfg: ValueOptCfg{
+					Value: "uav",
+				},
+				RemainCfg: map[string]any{
+					"fields":     []any{"title", "desc"},
+					"match_type": "best_fields",
+				},
+				SubConds: []*CondCfg{
+					{
+						Name:      "status",
+						Operation: OperationEq,
+						ValueOptCfg: ValueOptCfg{
+							Value: "active",
+						},
+					},
+				},
+			}
+
+			got := PromoteLegacyLeafWithSubConds(cfg)
+			So(got, ShouldNotBeNil)
+			So(got.Operation, ShouldEqual, OperationAnd)
+			So(len(got.SubConds), ShouldEqual, 2)
+			So(got.SubConds[0].Operation, ShouldEqual, OperationMatch)
+			So(got.SubConds[0].RemainCfg["match_type"], ShouldEqual, "best_fields")
+			fields, ok := got.SubConds[0].RemainCfg["fields"].([]any)
+			So(ok, ShouldBeTrue)
+			So(fields, ShouldResemble, []any{"title", "desc"})
+			So(got.SubConds[1].Name, ShouldEqual, "status")
+		})
 	})
 }

--- a/adp/bkn/ontology-query/server/drivenadapters/vega_backend/vega_backend_access.go
+++ b/adp/bkn/ontology-query/server/drivenadapters/vega_backend/vega_backend_access.go
@@ -67,8 +67,9 @@ func (v *vegaBackendAccess) QueryResourceData(ctx context.Context, resourceID st
 	headers := v.buildHeaders(ctx)
 	headers[interfaces.HTTP_HEADER_METHOD_OVERRIDE] = http.MethodGet
 
-	respCode, respData, err := v.httpClient.PostNoUnmarshal(ctx, httpURL, headers, params)
-	logger.Debugf("QueryResourceData [%s] query_hash [%s] code [%d] err [%v]", httpURL, bkntrace.HashValue(params), respCode, err)
+	request := normalizeResourceDataQueryParams(params)
+	respCode, respData, err := v.httpClient.PostNoUnmarshal(ctx, httpURL, headers, request)
+	logger.Debugf("QueryResourceData [%s] query_hash [%s] code [%d] err [%v]", httpURL, bkntrace.HashValue(request), respCode, err)
 	if err != nil {
 		return nil, fmt.Errorf("QueryResourceData http request failed: %w", err)
 	}
@@ -80,4 +81,28 @@ func (v *vegaBackendAccess) QueryResourceData(ctx context.Context, resourceID st
 		return nil, fmt.Errorf("unmarshal QueryResourceData response: %w", err)
 	}
 	return &response, nil
+}
+
+// normalizeResourceDataQueryParams copies Limit/Offset helpers into paging so the
+// outbound body matches vega-backend's paging contract (DefaultPageLimit otherwise).
+func normalizeResourceDataQueryParams(params *interfaces.ResourceDataQueryParams) *interfaces.ResourceDataQueryParams {
+	if params == nil {
+		return &interfaces.ResourceDataQueryParams{
+			Paging: interfaces.ResourceDataPagingRequest{Mode: "single"},
+		}
+	}
+	request := *params
+	if request.Paging.Cursor == "" && request.Paging.Mode == "" {
+		request.Paging.Mode = "single"
+		if request.Paging.Limit == 0 {
+			request.Paging.Limit = request.Limit
+		}
+		if request.Paging.Offset == 0 {
+			request.Paging.Offset = request.Offset
+		}
+	}
+	// Keep helpers out of the wire payload (json:"-"), paging carries the values.
+	request.Limit = 0
+	request.Offset = 0
+	return &request
 }

--- a/adp/bkn/ontology-query/server/drivenadapters/vega_backend/vega_backend_access_test.go
+++ b/adp/bkn/ontology-query/server/drivenadapters/vega_backend/vega_backend_access_test.go
@@ -108,3 +108,28 @@ func TestVegaBackendAccessQueryResourceDataUsesLocalClientSpan(t *testing.T) {
 		convey.So(strings.Contains(outboundTraceparent, upstreamSpanID.String()), convey.ShouldBeFalse)
 	})
 }
+
+func TestNormalizeResourceDataQueryParams(t *testing.T) {
+	convey.Convey("normalizeResourceDataQueryParams maps Limit into paging", t, func() {
+		got := normalizeResourceDataQueryParams(&interfaces.ResourceDataQueryParams{
+			Limit:  10000,
+			Offset: 5,
+		})
+		convey.So(got.Paging.Mode, convey.ShouldEqual, "single")
+		convey.So(got.Paging.Limit, convey.ShouldEqual, 10000)
+		convey.So(got.Paging.Offset, convey.ShouldEqual, 5)
+		convey.So(got.Limit, convey.ShouldEqual, 0)
+		convey.So(got.Offset, convey.ShouldEqual, 0)
+	})
+
+	convey.Convey("normalizeResourceDataQueryParams keeps explicit paging", t, func() {
+		got := normalizeResourceDataQueryParams(&interfaces.ResourceDataQueryParams{
+			Limit: 1,
+			Paging: interfaces.ResourceDataPagingRequest{
+				Mode:  "single",
+				Limit: 50,
+			},
+		})
+		convey.So(got.Paging.Limit, convey.ShouldEqual, 50)
+	})
+}

--- a/adp/bkn/ontology-query/server/interfaces/vega_backend_access.go
+++ b/adp/bkn/ontology-query/server/interfaces/vega_backend_access.go
@@ -17,16 +17,28 @@ type DatasetQueryResponse struct {
 	SearchAfter []any            `json:"search_after"`
 }
 
+// ResourceDataPagingRequest matches vega-backend paging contract for resource data.
+type ResourceDataPagingRequest struct {
+	Mode         string `json:"mode,omitempty"`
+	Offset       int    `json:"offset,omitempty"`
+	Limit        int    `json:"limit,omitempty"`
+	KeepAliveSec int    `json:"keep_alive_sec,omitempty"`
+	Cursor       string `json:"cursor,omitempty"`
+}
+
 // ResourceDataQueryParams is the JSON body for POST /resources/:id/data.
 // Analytics fields align with resource_data_query_analytics_schema.md (aggregate mode).
+// Pagination must be sent via Paging (vega HTTP contract); Limit/Offset are local helpers
+// that are normalized into Paging before the request is marshaled.
 type ResourceDataQueryParams struct {
-	FilterCondition map[string]any `json:"filter_condition,omitempty"`
-	SearchAfter     []any          `json:"search_after,omitempty"`
-	Offset          int            `json:"offset,omitempty"`
-	Limit           int            `json:"limit,omitempty"`
-	NeedTotal       bool           `json:"need_total,omitempty"`
-	Sort            []*SortParams  `json:"sort,omitempty"`
-	OutputFields    []string       `json:"output_fields,omitempty"`
+	FilterCondition map[string]any            `json:"filter_condition,omitempty"`
+	SearchAfter     []any                     `json:"search_after,omitempty"`
+	Paging          ResourceDataPagingRequest `json:"paging,omitempty"`
+	Offset          int                       `json:"-"`
+	Limit           int                       `json:"-"`
+	NeedTotal       bool                      `json:"need_total,omitempty"`
+	Sort            []*SortParams             `json:"sort,omitempty"`
+	OutputFields    []string                  `json:"output_fields,omitempty"`
 
 	Aggregation map[string]any   `json:"aggregation,omitempty"`
 	GroupBy     []map[string]any `json:"group_by,omitempty"`

--- a/adp/bkn/ontology-query/server/logics/knowledge_network/knowledge_network_service.go
+++ b/adp/bkn/ontology-query/server/logics/knowledge_network/knowledge_network_service.go
@@ -1108,8 +1108,11 @@ func (kns *knowledgeNetworkService) batchGetViewData(ctx context.Context,
 		var backingRows []map[string]any
 		if backingType == interfaces.DATA_SOURCE_TYPE_RESOURCE {
 			params := &interfaces.ResourceDataQueryParams{
-				NeedTotal:       viewQuery.NeedTotal,
-				Limit:           viewQuery.Limit,
+				NeedTotal: viewQuery.NeedTotal,
+				Paging: interfaces.ResourceDataPagingRequest{
+					Mode:  "single",
+					Limit: viewQuery.Limit,
+				},
 				Sort:            viewQuery.Sort,
 				SearchAfter:     viewQuery.SearchAfter,
 				FilterCondition: logics.CondCfgToFilterMap(viewQuery.Filters),

--- a/adp/bkn/ontology-query/server/logics/object_type/object_type_service.go
+++ b/adp/bkn/ontology-query/server/logics/object_type/object_type_service.go
@@ -467,9 +467,12 @@ func (ots *objectTypeService) getObjectsFromResource(ctx context.Context, query 
 		outputFields = append(outputFields, k)
 	}
 	params := &interfaces.ResourceDataQueryParams{
-		NeedTotal:       query.NeedTotal,
-		Limit:           query.Limit,
-		Offset:          query.Offset,
+		NeedTotal: query.NeedTotal,
+		Paging: interfaces.ResourceDataPagingRequest{
+			Mode:   "single",
+			Limit:  query.Limit,
+			Offset: query.Offset,
+		},
 		Sort:            resourceSort,
 		SearchAfter:     query.SearchAfter,
 		FilterCondition: logics.CondCfgToFilterMap(viewQuery.Filters),

--- a/adp/vega/vega-backend/server/driveradapters/validate_resource_data.go
+++ b/adp/vega/vega-backend/server/driveradapters/validate_resource_data.go
@@ -74,6 +74,14 @@ func ValidateResourceDataQueryParams(ctx context.Context, params *interfaces.Res
 
 func validateResourceDataPaging(ctx context.Context, params *interfaces.ResourceDataQueryParams) error {
 	paging := params.Paging
+	// Backward compatibility: map deprecated top-level limit/offset into paging
+	// when the caller has not provided a paging object (foundry#475).
+	if paging.Cursor == "" && paging.Mode == "" && paging.Limit == 0 && paging.Offset == 0 {
+		if params.LegacyLimit != 0 || params.LegacyOffset != 0 {
+			paging.Limit = params.LegacyLimit
+			paging.Offset = params.LegacyOffset
+		}
+	}
 	if paging.Mode == interfaces.PagingModeCursor && paging.Limit == 0 {
 		return rest.NewHTTPError(ctx, http.StatusBadRequest, verrors.VegaBackend_InvalidParameter_Limit).
 			WithErrorDetails("paging.limit is required for cursor paging")
@@ -81,6 +89,8 @@ func validateResourceDataPaging(ctx context.Context, params *interfaces.Resource
 	params.Paging = paging.Normalized()
 	params.Offset = params.Paging.Offset
 	params.Limit = params.Paging.Limit
+	params.LegacyLimit = 0
+	params.LegacyOffset = 0
 	if params.Paging.Mode == interfaces.PagingModeCursor {
 		if params.Offset < 0 {
 			return rest.NewHTTPError(ctx, http.StatusBadRequest, verrors.VegaBackend_InvalidParameter_Offset).

--- a/adp/vega/vega-backend/server/driveradapters/validate_resource_data_test.go
+++ b/adp/vega/vega-backend/server/driveradapters/validate_resource_data_test.go
@@ -30,6 +30,24 @@ func TestValidateResourceDataQueryParams(t *testing.T) {
 		assert.Equal(t, interfaces.DefaultPageLimit, params.Limit)
 	})
 
+	t.Run("maps legacy top-level limit into paging", func(t *testing.T) {
+		params := &interfaces.ResourceDataQueryParams{
+			LegacyLimit:  10000,
+			LegacyOffset: 10,
+		}
+
+		err := ValidateResourceDataQueryParams(ctx, params)
+
+		require.NoError(t, err)
+		assert.Equal(t, 10000, params.Limit)
+		assert.Equal(t, 10, params.Offset)
+		assert.Equal(t, interfaces.PagingModeSingle, params.Paging.Mode)
+		assert.Equal(t, 10000, params.Paging.Limit)
+		assert.Equal(t, 10, params.Paging.Offset)
+		assert.Equal(t, 0, params.LegacyLimit)
+		assert.Equal(t, 0, params.LegacyOffset)
+	})
+
 	t.Run("accepts valid flat query with filter and aggregation", func(t *testing.T) {
 		params := &interfaces.ResourceDataQueryParams{
 			Format: interfaces.Format_Flat,

--- a/adp/vega/vega-backend/server/interfaces/resource_data.go
+++ b/adp/vega/vega-backend/server/interfaces/resource_data.go
@@ -58,8 +58,8 @@ type HavingClause struct {
 type ResourceDataQueryParams struct {
 	// Offset and Limit remain internal connector inputs. The HTTP contract uses
 	// Paging so Raw Query and Resource Data share the same request shape.
-	Offset int           `json:"-"`
-	Limit  int           `json:"-"`
+	Offset int `json:"-"`
+	Limit  int `json:"-"`
 	// LegacyLimit/LegacyOffset accept older callers that still send top-level
 	// limit/offset. ValidateResourceDataQueryParams maps them into Paging when
 	// paging is unset (openbkn-ai/bkn-foundry#475).

--- a/adp/vega/vega-backend/server/interfaces/resource_data.go
+++ b/adp/vega/vega-backend/server/interfaces/resource_data.go
@@ -60,8 +60,13 @@ type ResourceDataQueryParams struct {
 	// Paging so Raw Query and Resource Data share the same request shape.
 	Offset int           `json:"-"`
 	Limit  int           `json:"-"`
-	Paging PagingRequest `json:"paging,omitempty"`
-	Sort   []*SortField  `json:"sort,omitempty"`
+	// LegacyLimit/LegacyOffset accept older callers that still send top-level
+	// limit/offset. ValidateResourceDataQueryParams maps them into Paging when
+	// paging is unset (openbkn-ai/bkn-foundry#475).
+	LegacyLimit  int           `json:"limit,omitempty"`
+	LegacyOffset int           `json:"offset,omitempty"`
+	Paging       PagingRequest `json:"paging,omitempty"`
+	Sort         []*SortField  `json:"sort,omitempty"`
 
 	FilterCondition any `json:"filter_condition,omitempty"`
 


### PR DESCRIPTION
## Summary
- Map ontology-query \Limit\/\Offset\ into Vega \paging\ before \QueryResourceData\, so action scans are not truncated by Vega's default page limit of 20 (#475).
- Accept legacy top-level \limit\/\offset\ in vega-backend for backward compatibility.
- Promote malformed leaf+\sub_conditions\ condition trees to \nd\ in \NewCondition\/\RewriteCondition\ so stock Studio payloads still recurse.

## Test plan
- [ ] Immediate-run an action type whose resource scan should return more than 20 matches; confirm \	otal_count\ is not capped at 20.
- [ ] Confirm resource-backed object/KN queries still honor explicit limits via \paging.limit\.
- [ ] Legacy leaf+\sub_conditions\ filter is rewritten to \nd\ and all leaves participate in the scan.
- [ ] Run ontology-query \condition_promote_test\ and vega \alidate_resource_data\ / \
ormalizeResourceDataQueryParams\ tests when Go toolchain is available.

Fixes #475

Made with [Cursor](https://cursor.com)