### PR TITLE
chore(deploy): 清掉 capabilities-lab 退役后的清单与文档残留 (#324)

### DIFF
--- a/deploy/release-manifests/0.1.1/bkn-foundry.yaml
+++ b/deploy/release-manifests/0.1.1/bkn-foundry.yaml
@@ -41,9 +41,6 @@ releases:
   agent-operator-integration:
     chart: agent-operator-integration
     version: 0.1.1
-  capabilities-lab:
-    chart: capabilities-lab
-    version: 0.1.1
   agent-retrieval:
     chart: agent-retrieval
     version: 0.1.1

--- a/infra/bkn-agent/README.md
+++ b/infra/bkn-agent/README.md
@@ -9,7 +9,7 @@
 - 工具：执行工厂 toolbox 统一工具平面（默认挂 contextloader 内置工具集，
   执行走 operator-integration 执行代理，身份 header 透传）；外部 MCP 端点经
   `type: "mcp"` 显式挂载
-- 技能：capabilities-lab（`/skill/content` 注入 + `/skill/files/read` 渐进读取）
+- 技能：执行工厂 internal-v1（`/skill/content` 注入 + `/skill/files/read` 渐进读取）
 - 存储：共享 `openbkn` 库，`agent_` 前缀表，迁移见 `migrations/bkn-agent/`
 
 ## 本地运行
@@ -19,7 +19,7 @@ pip install -r requirements.txt
 uvicorn main:app --port 30800
 ```
 
-关键环境变量见 `app/config.py`（RDS*、MF_MODEL_API_PRIVATE_BASE、BKN_AGENT_DEFAULT_TOOLBOXES、CAPABILITIES_LAB_BASE、CHECKPOINTER_BACKEND）。默认 toolbox 拉取失败降级告警不击穿对话；`type: "toolbox"` 显式引用失败报错。
+关键环境变量见 `app/config.py`（RDS*、MF_MODEL_API_PRIVATE_BASE、BKN_AGENT_DEFAULT_TOOLBOXES、OPERATOR_INTEGRATION_BASE、CHECKPOINTER_BACKEND）。默认 toolbox 拉取失败降级告警不击穿对话；`type: "toolbox"` 显式引用失败报错。
 
 ## API
 


### PR DESCRIPTION
Refs #324。收尾两条验收项，不改任何运行逻辑。

## 改动

**`deploy/release-manifests/0.1.1/bkn-foundry.yaml`** —— 删掉 `capabilities-lab` release 条目。#350 把服务并入 operator-integration 后，chart 目录与 `release-adp-capabilities-lab.yml` 都已删除，版本集却仍列着 `chart: capabilities-lab, version: 0.1.1`，指向一个仓库里不再存在的 chart（源为 `oci://ghcr.io/openbkn-ai/charts`，按此清单装会拉到已退役服务的旧镜像）。

**`infra/bkn-agent/README.md`** —— 「技能：capabilities-lab」改为「技能：执行工厂 internal-v1」；关键环境变量里的 `CAPABILITIES_LAB_BASE` 换成实际存在的 `OPERATOR_INTEGRATION_BASE`。技能面在 #323 已收敛到执行工厂，`app/config.py:37` 只剩后者。

## 不动的部分

`deploy/scripts/services/openbkn.sh:832` 的退役清单条目保留 —— 它负责在升级时卸载存量 `capabilities-lab` release，删掉会让老环境残留一个跑不动的 Deployment。

## 与 #324 的关系

Epic 主体（PR #350）已完成：目录删除、chart 删除、`bak_` AppKey（#325 / PR #327）、bkn-agent 技能面收敛（#323）、并入的包已进 `go test` 门禁（CI 跑 `go list ./...`，仅排除 `/server/tests`、`/server/mocks`）。

本 PR 合并后，#324 验收清单剩下的只有批次 0-A —— 即仍处于 OPEN 的 #326（internal-v1 收回集群内），建议由它单独跟踪，Epic 可以关闭。

🤖 Generated with [Claude Code](https://claude.com/claude-code)