### PR TITLE
fix(execution-factory): 公开代理入口以认证账户覆盖身份请求头，GET 空 body 不发下游

### DIFF
--- a/adp/execution-factory/operator-integration/docs/apis/api_public/operator.yaml
+++ b/adp/execution-factory/operator-integration/docs/apis/api_public/operator.yaml
@@ -1399,12 +1399,15 @@ components:
           description: "算子版本"
         header:
           type: object
-          description: "请求头"
+          description: >-
+            下游请求头。传输层请求头（Host、Connection、Transfer-Encoding、Content-Length 等）由平台接管，
+            传入即丢弃；身份请求头（x-account-id、x-account-type、user_id）一律以本次调用的认证账户为准，
+            传入值会被覆盖。
           additionalProperties:
             type: object
         body:
           type: object
-          description: "请求体"
+          description: "请求体。GET/HEAD 传空对象时不会向下游发送请求体"
         query:
           type: object
           description: "查询参数"

--- a/adp/execution-factory/operator-integration/docs/apis/api_public/operator.yaml
+++ b/adp/execution-factory/operator-integration/docs/apis/api_public/operator.yaml
@@ -1401,7 +1401,7 @@ components:
           type: object
           description: >-
             下游请求头。传输层请求头（Host、Connection、Transfer-Encoding、Content-Length 等）由平台接管，
-            传入即丢弃；身份请求头（x-account-id、x-account-type、user_id）一律以本次调用的认证账户为准，
+            传入即丢弃；身份请求头（x-account-id、x-account-type、user_id、x-user-id）一律以本次调用的认证账户为准，
             传入值会被覆盖。
           additionalProperties:
             type: object

--- a/adp/execution-factory/operator-integration/docs/apis/api_public/toolbox.yaml
+++ b/adp/execution-factory/operator-integration/docs/apis/api_public/toolbox.yaml
@@ -1734,12 +1734,15 @@ components:
       properties:
         header:
           type: object
-          description: "请求头"
+          description: >-
+            下游请求头。传输层请求头（Host、Connection、Transfer-Encoding、Content-Length 等）由平台接管，
+            传入即丢弃；身份请求头（x-account-id、x-account-type、user_id）一律以本次调用的认证账户为准，
+            传入值会被覆盖。
           additionalProperties:
             type: object
         body:
           type: object
-          description: "请求体参数"
+          description: "请求体参数。GET/HEAD 传空对象时不会向下游发送请求体"
         query:
           type: object
           description: "查询参数"

--- a/adp/execution-factory/operator-integration/docs/apis/api_public/toolbox.yaml
+++ b/adp/execution-factory/operator-integration/docs/apis/api_public/toolbox.yaml
@@ -1736,7 +1736,7 @@ components:
           type: object
           description: >-
             下游请求头。传输层请求头（Host、Connection、Transfer-Encoding、Content-Length 等）由平台接管，
-            传入即丢弃；身份请求头（x-account-id、x-account-type、user_id）一律以本次调用的认证账户为准，
+            传入即丢弃；身份请求头（x-account-id、x-account-type、user_id、x-user-id）一律以本次调用的认证账户为准，
             传入值会被覆盖。
           additionalProperties:
             type: object

--- a/adp/execution-factory/operator-integration/server/logics/proxy/forwarder.go
+++ b/adp/execution-factory/operator-integration/server/logics/proxy/forwarder.go
@@ -207,7 +207,14 @@ func (f *forwarder) buildRequest(ctx context.Context, req *interfaces.HTTPReques
 	// forceContentType 表示编码过程重算出的 Content-Type 必须覆盖调用方传入的同名请求头
 	var forceContentType bool
 
-	if req.Body != nil {
+	// GET/HEAD 语义上没有请求体，而调试面板对无 body 的接口固定发 "body": {}，
+	// 直接按普通请求体处理会给下游带上空 JSON 体和 Content-Type，部分服务端会直接拒绝。
+	payload := req.Body
+	if isBodylessMethod(req.Method) && isEmptyBody(payload) {
+		payload = nil
+	}
+
+	if payload != nil {
 		// 检查Content-Type头
 		contentType = ""
 		if req.Headers != nil {
@@ -222,7 +229,7 @@ func (f *forwarder) buildRequest(ctx context.Context, req *interfaces.HTTPReques
 		switch {
 		case strings.Contains(contentType, "application/json"):
 			// JSON格式
-			jsonData, err := json.Marshal(req.Body)
+			jsonData, err := json.Marshal(payload)
 			if err != nil {
 				return nil, err
 			}
@@ -232,7 +239,7 @@ func (f *forwarder) buildRequest(ctx context.Context, req *interfaces.HTTPReques
 			formData := url.Values{}
 
 			// 尝试将body转换为map
-			if bodyMap, ok := req.Body.(map[string]interface{}); ok {
+			if bodyMap, ok := payload.(map[string]interface{}); ok {
 				for key, value := range bodyMap {
 					formData.Add(key, fmt.Sprintf("%v", value))
 				}
@@ -244,7 +251,7 @@ func (f *forwarder) buildRequest(ctx context.Context, req *interfaces.HTTPReques
 			writer := multipart.NewWriter(body)
 
 			// 尝试将body转换为map
-			if bodyMap, ok := req.Body.(map[string]interface{}); ok {
+			if bodyMap, ok := payload.(map[string]interface{}); ok {
 				for key, value := range bodyMap {
 					fw, err := writer.CreateFormField(key)
 					if err != nil {
@@ -264,17 +271,17 @@ func (f *forwarder) buildRequest(ctx context.Context, req *interfaces.HTTPReques
 			reqBody = body
 		case strings.Contains(contentType, "text/plain"):
 			// 文本格式
-			reqBody = strings.NewReader(fmt.Sprintf("%v", req.Body))
+			reqBody = strings.NewReader(fmt.Sprintf("%v", payload))
 		case strings.Contains(contentType, "text/event-stream"):
 			// SSE格式
-			reqBody = strings.NewReader(fmt.Sprintf("%v", req.Body))
+			reqBody = strings.NewReader(fmt.Sprintf("%v", payload))
 		case strings.Contains(contentType, "application/stream+json"), // HTTP Streaming格式
 			strings.Contains(contentType, "application/x-ndjson"),      // NDJSON格式
 			strings.Contains(contentType, "application/x-json-stream"): // HTTP Streaming格式
 			// HTTP Streaming格式
-			reqBody = strings.NewReader(fmt.Sprintf("%v", req.Body))
+			reqBody = strings.NewReader(fmt.Sprintf("%v", payload))
 		default:
-			jsonData, err := json.Marshal(req.Body)
+			jsonData, err := json.Marshal(payload)
 			if err != nil {
 				return nil, err
 			}
@@ -295,6 +302,9 @@ func (f *forwarder) buildRequest(ctx context.Context, req *interfaces.HTTPReques
 	}
 
 	// 设置请求头，并用当前请求上下文补齐 trace/request id，保证代理链路可聚合。
+	// 公开接口的 header 由调用方直接填写，身份头必须回填成本次请求的认证账户。
+	isPublic := common.IsPublicAPIFromCtx(ctx)
+	auth, _ := common.GetAccountAuthContextFromCtx(ctx)
 	headers := map[string]string{}
 	for key, value := range req.Headers {
 		// 传输层请求头由转发器与 Go HTTP 客户端接管，调用方手填只会让实际请求与预览对不上
@@ -302,6 +312,20 @@ func (f *forwarder) buildRequest(ctx context.Context, req *interfaces.HTTPReques
 			if f.logger != nil {
 				f.logger.WithContext(ctx).Debugf("drop transport-layer header from caller: %s", key)
 			}
+			continue
+		}
+		if isPublic && isIdentityHeader(key) {
+			resolved, ok := resolveIdentityHeader(key, auth)
+			if !ok {
+				if f.logger != nil {
+					f.logger.WithContext(ctx).Warnf("drop identity header %s: no authenticated account in context", key)
+				}
+				continue
+			}
+			if f.logger != nil && resolved != fmt.Sprintf("%v", value) {
+				f.logger.WithContext(ctx).Warnf("override caller-supplied identity header %s with authenticated account", key)
+			}
+			headers[key] = resolved
 			continue
 		}
 		headers[key] = fmt.Sprintf("%v", value)
@@ -336,6 +360,72 @@ var transportHeaders = map[string]struct{}{
 func isTransportHeader(key string) bool {
 	_, ok := transportHeaders[strings.ToLower(strings.TrimSpace(key))]
 	return ok
+}
+
+// identityHeaders 身份请求头：内置工具箱把它们声明成普通 OpenAPI header 参数，
+// 下游 /in 接口不验 token、直接据此判定调用者身份并做 per-account 授权。
+// 公开接口（调试与执行）的 header 完全由调用方填写，放任透传等于允许冒充任意账户，
+// 因此这里统一回填成本次请求认证出来的账户。内部接口维持透传，运行时按 /in 约定注入身份。
+var identityHeaders = map[string]struct{}{
+	"x-account-id":   {},
+	"x-account-type": {},
+	"user_id":        {},
+	"x-user-id":      {},
+}
+
+// isIdentityHeader 判断请求头是否属于身份请求头（大小写不敏感）。
+func isIdentityHeader(key string) bool {
+	_, ok := identityHeaders[strings.ToLower(strings.TrimSpace(key))]
+	return ok
+}
+
+// resolveIdentityHeader 返回身份请求头应有的值；返回 false 表示拿不到认证账户，该请求头必须丢弃。
+func resolveIdentityHeader(key string, auth *interfaces.AccountAuthContext) (string, bool) {
+	if auth == nil || auth.AccountID == "" {
+		return "", false
+	}
+	if strings.EqualFold(strings.TrimSpace(key), "x-account-type") {
+		if auth.AccountType == "" {
+			return "", false
+		}
+		return string(auth.AccountType), true
+	}
+	return auth.AccountID, true
+}
+
+// bodylessMethods 语义上不带请求体的方法。
+var bodylessMethods = map[string]struct{}{
+	http.MethodGet:  {},
+	http.MethodHead: {},
+}
+
+// isBodylessMethod 判断方法是否语义上不带请求体（大小写不敏感，空方法按 GET 处理）。
+func isBodylessMethod(method string) bool {
+	normalized := strings.ToUpper(strings.TrimSpace(method))
+	if normalized == "" {
+		normalized = http.MethodGet
+	}
+	_, ok := bodylessMethods[normalized]
+	return ok
+}
+
+// isEmptyBody 判断请求体是否为空信封：调试面板对无 body 的接口固定发 "body": {}，
+// 只有空值才当作没有请求体，非空 body 仍按调用方声明的方式编码发出。
+func isEmptyBody(body interface{}) bool {
+	switch value := body.(type) {
+	case nil:
+		return true
+	case map[string]interface{}:
+		return len(value) == 0
+	case map[string]string:
+		return len(value) == 0
+	case []interface{}:
+		return len(value) == 0
+	case string:
+		return value == ""
+	default:
+		return false
+	}
 }
 
 // pathPlaceholderPattern 匹配路径里形如 {name} 的占位符。

--- a/adp/execution-factory/operator-integration/server/logics/proxy/forwarder_identity_test.go
+++ b/adp/execution-factory/operator-integration/server/logics/proxy/forwarder_identity_test.go
@@ -1,0 +1,317 @@
+package proxy
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/openbkn-ai/adp/execution-factory/operator-integration/server/infra/common"
+	"github.com/openbkn-ai/adp/execution-factory/operator-integration/server/interfaces"
+	. "github.com/smartystreets/goconvey/convey"
+)
+
+const (
+	testAuthAccountID = "11111111-1111-4111-8111-111111111111"
+	testSpoofedID     = "22222222-2222-4222-8222-222222222222"
+)
+
+// publicCtx 构造公开接口的请求上下文：认证中间件会同时写入认证账户与公开接口标记。
+func publicCtx() context.Context {
+	ctx := common.SetPublicAPIToCtx(context.Background(), true)
+	return common.SetAccountAuthContextToCtx(ctx, &interfaces.AccountAuthContext{
+		AccountID:   testAuthAccountID,
+		AccountType: interfaces.AccessorTypeUser,
+	})
+}
+
+// internalCtx 构造内部接口的请求上下文：没有公开接口标记，身份由上游运行时按 /in 约定注入。
+func internalCtx() context.Context {
+	return common.SetAccountAuthContextToCtx(context.Background(), &interfaces.AccountAuthContext{
+		AccountID:   testAuthAccountID,
+		AccountType: interfaces.AccessorTypeUser,
+	})
+}
+
+// TestBuildRequest_IdentityHeaders 覆盖公开接口下身份请求头的回填（#216 P1 安全约束）。
+//
+// 内置工具箱把 x-account-id / x-account-type 声明成普通 OpenAPI header 参数，下游 /in
+// 接口不验 token、直接据此判定调用者身份，因此公开的调试与执行入口不能把调用方自填的
+// 身份头原样转发出去。
+func TestBuildRequest_IdentityHeaders(t *testing.T) {
+	f := newTestForwarder()
+
+	Convey("公开接口的身份请求头以认证账户为准", t, func() {
+		Convey("调用方伪造的 x-account-id 被回填成认证账户", func() {
+			req := &interfaces.HTTPRequest{
+				HTTPRouter: interfaces.HTTPRouter{
+					Method: http.MethodPost,
+					URL:    "http://svc/api/agent-retrieval/in/v1/kn/run_sql",
+				},
+				HTTPRequestParams: interfaces.HTTPRequestParams{
+					Headers: map[string]any{
+						"x-account-id":   testSpoofedID,
+						"x-account-type": "app",
+					},
+					Body: map[string]any{"sql": "select 1"},
+				},
+			}
+
+			httpReq, err := f.buildRequest(publicCtx(), req)
+
+			So(err, ShouldBeNil)
+			So(httpReq.Header.Get("x-account-id"), ShouldEqual, testAuthAccountID)
+			So(httpReq.Header.Get("x-account-type"), ShouldEqual, string(interfaces.AccessorTypeUser))
+		})
+
+		Convey("大小写变体同样被回填", func() {
+			req := &interfaces.HTTPRequest{
+				HTTPRouter: interfaces.HTTPRouter{
+					Method: http.MethodGet,
+					URL:    "http://svc/api/v1/resources",
+				},
+				HTTPRequestParams: interfaces.HTTPRequestParams{
+					Headers: map[string]any{
+						"X-Account-Id": testSpoofedID,
+						"USER_ID":      testSpoofedID,
+					},
+				},
+			}
+
+			httpReq, err := f.buildRequest(publicCtx(), req)
+
+			So(err, ShouldBeNil)
+			So(httpReq.Header.Get("X-Account-Id"), ShouldEqual, testAuthAccountID)
+			So(httpReq.Header.Get("user_id"), ShouldEqual, testAuthAccountID)
+		})
+
+		Convey("业务请求头不受影响", func() {
+			req := &interfaces.HTTPRequest{
+				HTTPRouter: interfaces.HTTPRouter{
+					Method: http.MethodGet,
+					URL:    "http://svc/api/v1/resources",
+				},
+				HTTPRequestParams: interfaces.HTTPRequestParams{
+					Headers: map[string]any{
+						"X-Api-Key":         "secret-key",
+						"x-business-domain": "domain-1",
+						"x-account-id":      testSpoofedID,
+					},
+				},
+			}
+
+			httpReq, err := f.buildRequest(publicCtx(), req)
+
+			So(err, ShouldBeNil)
+			So(httpReq.Header.Get("X-Api-Key"), ShouldEqual, "secret-key")
+			So(httpReq.Header.Get("x-business-domain"), ShouldEqual, "domain-1")
+			So(httpReq.Header.Get("x-account-id"), ShouldEqual, testAuthAccountID)
+		})
+
+		Convey("调用方没填身份头时不会凭空注入", func() {
+			req := &interfaces.HTTPRequest{
+				HTTPRouter: interfaces.HTTPRouter{
+					Method: http.MethodGet,
+					URL:    "http://svc/api/v1/resources",
+				},
+				HTTPRequestParams: interfaces.HTTPRequestParams{
+					Headers: map[string]any{"X-Api-Key": "secret-key"},
+				},
+			}
+
+			httpReq, err := f.buildRequest(publicCtx(), req)
+
+			So(err, ShouldBeNil)
+			So(httpReq.Header.Get("x-account-id"), ShouldEqual, "")
+			So(httpReq.Header.Get("x-account-type"), ShouldEqual, "")
+		})
+
+		Convey("拿不到认证账户时身份头被丢弃而不是透传", func() {
+			req := &interfaces.HTTPRequest{
+				HTTPRouter: interfaces.HTTPRouter{
+					Method: http.MethodGet,
+					URL:    "http://svc/api/v1/resources",
+				},
+				HTTPRequestParams: interfaces.HTTPRequestParams{
+					Headers: map[string]any{"x-account-id": testSpoofedID},
+				},
+			}
+
+			httpReq, err := f.buildRequest(common.SetPublicAPIToCtx(context.Background(), true), req)
+
+			So(err, ShouldBeNil)
+			So(httpReq.Header.Get("x-account-id"), ShouldEqual, "")
+		})
+	})
+
+	Convey("内部接口的身份请求头原样透传", t, func() {
+		req := &interfaces.HTTPRequest{
+			HTTPRouter: interfaces.HTTPRouter{
+				Method: http.MethodPost,
+				URL:    "http://svc/api/agent-retrieval/in/v1/kn/search_schema",
+			},
+			HTTPRequestParams: interfaces.HTTPRequestParams{
+				Headers: map[string]any{
+					"x-account-id":   "runtime-injected-account",
+					"x-account-type": "app",
+				},
+				Body: map[string]any{"query": "订单"},
+			},
+		}
+
+		httpReq, err := f.buildRequest(internalCtx(), req)
+
+		So(err, ShouldBeNil)
+		So(httpReq.Header.Get("x-account-id"), ShouldEqual, "runtime-injected-account")
+		So(httpReq.Header.Get("x-account-type"), ShouldEqual, "app")
+	})
+}
+
+// TestBuildRequest_BodylessMethods 覆盖 GET/HEAD 的空 body 信封（#216 验收标准 10）。
+func TestBuildRequest_BodylessMethods(t *testing.T) {
+	f := newTestForwarder()
+
+	Convey("GET/HEAD 的空 body 信封不发给下游", t, func() {
+		Convey("GET 带空 body 时不发送请求体，也不补 Content-Type", func() {
+			req := &interfaces.HTTPRequest{
+				HTTPRouter: interfaces.HTTPRouter{
+					Method: http.MethodGet,
+					URL:    "http://svc/api/v1/resources",
+				},
+				HTTPRequestParams: interfaces.HTTPRequestParams{
+					QueryParams: map[string]any{"page": 1},
+					Body:        map[string]any{},
+				},
+			}
+
+			httpReq, err := f.buildRequest(context.Background(), req)
+
+			So(err, ShouldBeNil)
+			So(httpReq.Header.Get("Content-Type"), ShouldEqual, "")
+			So(readAll(t, httpReq.Body), ShouldEqual, "")
+			So(httpReq.URL.RawQuery, ShouldEqual, "page=1")
+		})
+
+		Convey("HEAD 带空 body 时同样不发送请求体", func() {
+			req := &interfaces.HTTPRequest{
+				HTTPRouter: interfaces.HTTPRouter{
+					Method: http.MethodHead,
+					URL:    "http://svc/api/v1/resources",
+				},
+				HTTPRequestParams: interfaces.HTTPRequestParams{Body: map[string]any{}},
+			}
+
+			httpReq, err := f.buildRequest(context.Background(), req)
+
+			So(err, ShouldBeNil)
+			So(readAll(t, httpReq.Body), ShouldEqual, "")
+		})
+
+		Convey("GET 带非空 body 时仍然发送，不误伤既有用法", func() {
+			req := &interfaces.HTTPRequest{
+				HTTPRouter: interfaces.HTTPRouter{
+					Method: http.MethodGet,
+					URL:    "http://svc/api/v1/resources",
+				},
+				HTTPRequestParams: interfaces.HTTPRequestParams{
+					Body: map[string]any{"filter": "name"},
+				},
+			}
+
+			httpReq, err := f.buildRequest(context.Background(), req)
+
+			So(err, ShouldBeNil)
+			So(httpReq.Header.Get("Content-Type"), ShouldEqual, "application/json")
+			So(readAll(t, httpReq.Body), ShouldEqual, `{"filter":"name"}`)
+		})
+
+		Convey("POST 带空 body 时保持原样发送空 JSON 对象", func() {
+			req := &interfaces.HTTPRequest{
+				HTTPRouter: interfaces.HTTPRouter{
+					Method: http.MethodPost,
+					URL:    "http://svc/api/v1/resources",
+				},
+				HTTPRequestParams: interfaces.HTTPRequestParams{Body: map[string]any{}},
+			}
+
+			httpReq, err := f.buildRequest(context.Background(), req)
+
+			So(err, ShouldBeNil)
+			So(httpReq.Header.Get("Content-Type"), ShouldEqual, "application/json")
+			So(readAll(t, httpReq.Body), ShouldEqual, `{}`)
+		})
+	})
+}
+
+// TestForward_DownstreamReceivesAuthenticatedIdentity 端到端校验下游收到的是认证账户而非调用方自填值。
+func TestForward_DownstreamReceivesAuthenticatedIdentity(t *testing.T) {
+	f := newTestForwarder()
+
+	Convey("公开接口转发后，下游拿到的身份是认证账户", t, func() {
+		type captured struct {
+			accountID   string
+			accountType string
+			contentType string
+			body        string
+		}
+		var got captured
+
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			body, _ := io.ReadAll(r.Body)
+			got = captured{
+				accountID:   r.Header.Get("x-account-id"),
+				accountType: r.Header.Get("x-account-type"),
+				contentType: r.Header.Get("Content-Type"),
+				body:        string(body),
+			}
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"ok":true}`))
+		}))
+		defer server.Close()
+
+		Convey("伪造的身份头在下游被替换", func() {
+			resp, err := f.Forward(publicCtx(), &interfaces.HTTPRequest{
+				HTTPRouter: interfaces.HTTPRouter{
+					Method: http.MethodPost,
+					URL:    server.URL + "/api/agent-retrieval/in/v1/kn/run_sql",
+				},
+				HTTPRequestParams: interfaces.HTTPRequestParams{
+					Headers: map[string]any{
+						"x-account-id":   testSpoofedID,
+						"x-account-type": "app",
+					},
+					Body: map[string]any{"sql": "select 1"},
+				},
+				Timeout: 5 * time.Second,
+			})
+
+			So(err, ShouldBeNil)
+			So(resp.StatusCode, ShouldEqual, http.StatusOK)
+			So(got.accountID, ShouldEqual, testAuthAccountID)
+			So(got.accountType, ShouldEqual, string(interfaces.AccessorTypeUser))
+			So(got.body, ShouldEqual, `{"sql":"select 1"}`)
+		})
+
+		Convey("GET 的空 body 信封不会给下游带上请求体", func() {
+			resp, err := f.Forward(publicCtx(), &interfaces.HTTPRequest{
+				HTTPRouter: interfaces.HTTPRouter{
+					Method: http.MethodGet,
+					URL:    server.URL + "/api/v1/resources",
+				},
+				HTTPRequestParams: interfaces.HTTPRequestParams{
+					QueryParams: map[string]any{"page": 1},
+					Body:        map[string]any{},
+				},
+				Timeout: 5 * time.Second,
+			})
+
+			So(err, ShouldBeNil)
+			So(resp.StatusCode, ShouldEqual, http.StatusOK)
+			So(got.body, ShouldEqual, "")
+			So(got.contentType, ShouldEqual, "")
+		})
+	})
+}


### PR DESCRIPTION
## 背景

| 项 | 值 |
| --- | --- |
| **Issue** | #216 |
| **Branch** | `feature/216-debug-header-authz` |
| **设计文档** | 无（Issue 已给出方案，改动限于代理层，未新增接口面） |

#216 的 P1 安全条款要求「开放 Header 编辑时同步定义安全策略……并由后端最终执行校验」。前端已完成 header/query/path 分区编辑，#483 / #487 已补齐 path 转义、未替换占位符校验、传输层请求头丢弃与参数装配测试。本 PR 收口剩下两项。

## 问题

1. **身份请求头可伪造**。内置工具箱把 `x-account-id` / `x-account-type` 声明成普通 OpenAPI header 参数（`context_loader_toolset.adp`），目标是 `/api/agent-retrieval/in/v1/...`；下游 `/in` 接口不验 token，直接用该头判定调用者身份（`bkn-backend/server/common/visitor/visitor.go`）并做 per-account 授权。代理层原样透传调用方 header，因此任何能调用公开调试/执行入口的账户都可以带上他人的 `x-account-id` 冒充身份访问下游（含 `run_sql`、`list_resources` 等）。

2. **GET 被带上空请求体**。调试面板对无 body 的接口固定发 `"body": {}`，非 nil，代理照常编码成 `{}` 并补 `Content-Type: application/json` 发给下游，部分服务端直接拒绝，与验收清单「调试端点可正确代理 Method 为 GET、POST 等不同类型的下游 API」冲突。

## 改动

- 公开接口（`common.IsPublicAPIFromCtx(ctx) == true`，即经 token 内省中间件的 `/v1` 面）下，调用方传入的 `x-account-id` / `x-account-type` / `user_id` / `x-user-id` 一律回填为本次请求认证出来的账户；拿不到认证账户时丢弃该请求头。调用方未传身份头时不凭空注入，避免改变既有下游行为。
- 内部接口（`internal-v1`）维持透传：身份由运行时按 `/in` 约定注入，bkn-agent 工具调用链路不受影响。
- `GET` / `HEAD` 且 body 为空信封时不再发送请求体与 `Content-Type`；非空 body、以及 `POST` 的空 body 行为不变。
- 新增 `forwarder_identity_test.go`：身份头回填（含大小写变体）、业务头不受影响、无认证上下文时丢弃、内部接口透传、GET/HEAD 空 body、GET 非空 body 与 POST 空 body 不误伤，以及端到端校验下游实际收到的身份与请求体。
- `operator.yaml` / `toolbox.yaml` 说明 header 字段中由平台接管的范围。

## 验证

- `go build ./...` 通过
- `go test ./logics/...` 全绿
- `go test ./...` 中 `server/tests/local` 三个用例失败（缺 `../file/test.json` 等测试数据文件），在合入前的分支上同样失败，与本次改动无关

## 兼容性

- 内部接口零行为变化；bkn-agent 经 `internal-v1/tool-box/{box}/proxy/{tool}` 注入的身份头照常透传。
- 公开接口下，此前依赖自填身份头「以他人身份调用」的用法会被改写成认证账户 —— 这正是要堵的缺口。
- GET 携带非空 body 的既有用法不受影响。

Refs #216

🤖 Generated with [Claude Code](https://claude.com/claude-code)