### PR TITLE
fix(examples): 绕开 CLI 0.1.1 的 multipart 退化，03/06 恢复可跑

### DIFF
--- a/examples/03-action-lifecycle/run.sh
+++ b/examples/03-action-lifecycle/run.sh
@@ -59,6 +59,45 @@ DB_PASS="${DB_PASS:?Set DB_PASS in .env}"
 DB_HOST_SEED="${DB_HOST_SEED:-$DB_HOST}"
 export NODE_TLS_REJECT_UNAUTHORIZED="${NODE_TLS_REJECT_UNAUTHORIZED:-0}"
 
+# ── openbkn multipart workaround (CLI ≥ 0.1.1) ────────────────────────────────
+# A platform that remembers `-k` (tlsInsecure in ~/.bkn) makes the CLI route
+# every request through undici, which does not recognise the global FormData it
+# builds uploads with: the body degrades to text/plain and `tool upload` fails
+# with 400 "unsupported content type". Setting NODE_TLS_REJECT_UNAUTHORIZED is
+# not enough — the stored flag is what picks the code path. So run against an
+# explicit token and an empty config dir, which keeps the CLI on the plain
+# `fetch` path, and let the env var cover the self-signed certificate.
+# Remove this block once the CLI ships the fix.
+_bkn_multipart_workaround() {
+    command -v openbkn >/dev/null 2>&1 || return 0
+    local cfg="${BKN_CONFIG_DIR:-$HOME/.bkn}" base insecure tok
+    base="$(env -u BKN_TOKEN openbkn --json auth status 2>/dev/null |
+        python3 -c 'import json,sys
+try: print(json.load(sys.stdin).get("baseUrl") or "")
+except Exception: pass' 2>/dev/null)" || true
+    [ -n "$base" ] || return 0
+    insecure="$(python3 -c '
+import base64, glob, json, os, sys
+cfg, base = sys.argv[1], sys.argv[2]
+key = base64.urlsafe_b64encode(base.encode()).decode().rstrip("=")
+for p in glob.glob(os.path.join(cfg, "platforms", key, "users", "*", "token.json")):
+    try:
+        if json.load(open(p)).get("tlsInsecure"):
+            print("1"); break
+    except Exception:
+        pass
+' "$cfg" "$base" 2>/dev/null)" || true
+    [ -n "$insecure" ] || return 0
+    tok="$(env -u BKN_TOKEN openbkn auth token 2>/dev/null | tr -d '[:space:]')" || true
+    [ -n "$tok" ] || return 0
+    export BKN_BASE_URL="${BKN_BASE_URL:-$base}"
+    export BKN_TOKEN="$tok"
+    export BKN_CONFIG_DIR="$SCRIPT_DIR/.tmp/openbkn-config"
+    mkdir -p "$BKN_CONFIG_DIR"
+    echo "  note: platform remembers -k; using an explicit token so uploads stay multipart" >&2
+}
+_bkn_multipart_workaround
+
 MYSQL_BIN="${MYSQL_BIN:-mysql}"
 if ! command -v "$MYSQL_BIN" >/dev/null 2>&1; then
     for _p in "$(brew --prefix mysql-client 2>/dev/null)/bin/mysql" /opt/homebrew/opt/mysql-client/bin/mysql /usr/local/opt/mysql-client/bin/mysql; do

--- a/examples/06-world-cup/run.sh
+++ b/examples/06-world-cup/run.sh
@@ -100,6 +100,54 @@ set -a
 [ -f "$SCRIPT_DIR/.env" ] && source "$SCRIPT_DIR/.env"
 set +a
 
+# ── openbkn multipart workaround (CLI ≥ 0.1.1) ────────────────────────────────
+# A platform that remembers `-k` (tlsInsecure in ~/.bkn) makes the CLI route
+# every request through undici, which does not recognise the global FormData it
+# builds uploads with: the body degrades to text/plain and `bkn push` /
+# `tool upload` fail with 400 "Content-Type isn't multipart/form-data".
+# NODE_TLS_REJECT_UNAUTHORIZED alone does not help — the stored flag is what
+# picks the code path. So run against an explicit token and an empty config
+# dir, which keeps the CLI on the plain `fetch` path, and let the env var cover
+# the self-signed certificate. Remove this block once the CLI ships the fix.
+export NODE_TLS_REJECT_UNAUTHORIZED="${NODE_TLS_REJECT_UNAUTHORIZED:-0}"
+#
+# Re-run before every step: an explicit token is not auto-refreshed, and the
+# CSV import alone can outlive one, so each step mints a fresh one from the
+# real config store (remembered in _BKN_STORE_DIR once the swap has happened).
+_bkn_multipart_workaround() {
+    command -v openbkn >/dev/null 2>&1 || return 0
+    local cfg="${_BKN_STORE_DIR:-${BKN_CONFIG_DIR:-$HOME/.bkn}}" base insecure tok
+    base="$(env -u BKN_TOKEN BKN_CONFIG_DIR="$cfg" openbkn --json auth status 2>/dev/null |
+        python3 -c 'import json,sys
+try: print(json.load(sys.stdin).get("baseUrl") or "")
+except Exception: pass' 2>/dev/null)" || true
+    [ -n "$base" ] || return 0
+    insecure="$(python3 -c '
+import base64, glob, json, os, sys
+cfg, base = sys.argv[1], sys.argv[2]
+key = base64.urlsafe_b64encode(base.encode()).decode().rstrip("=")
+for p in glob.glob(os.path.join(cfg, "platforms", key, "users", "*", "token.json")):
+    try:
+        if json.load(open(p)).get("tlsInsecure"):
+            print("1"); break
+    except Exception:
+        pass
+' "$cfg" "$base" 2>/dev/null)" || true
+    [ -n "$insecure" ] || return 0
+    tok="$(env -u BKN_TOKEN BKN_CONFIG_DIR="$cfg" openbkn auth token 2>/dev/null | tr -d '[:space:]')" || true
+    [ -n "$tok" ] || return 0
+    export _BKN_STORE_DIR="$cfg"
+    export BKN_BASE_URL="${BKN_BASE_URL:-$base}"
+    export BKN_TOKEN="$tok"
+    export BKN_CONFIG_DIR="$SCRIPT_DIR/.tmp/openbkn-config"
+    mkdir -p "$BKN_CONFIG_DIR"
+    [ -n "${_BKN_WORKAROUND_NOTED:-}" ] || {
+        echo "  note: platform remembers -k; using an explicit token so uploads stay multipart" >&2
+        export _BKN_WORKAROUND_NOTED=1
+    }
+}
+_bkn_multipart_workaround
+
 if [ -n "${BKN_BASE_URL:-}" ]; then
     KWEAV=(openbkn --json --base-url "${BKN_BASE_URL}")
 else
@@ -867,6 +915,7 @@ run_step() {
     else
         [ "$n" -ge "$FROM" ] || return 0
     fi
+    _bkn_multipart_workaround
     case "$n" in
         1) step_1_download ;;
         2) step_2_import ;;


### PR DESCRIPTION
# Pull Request

## What Changed

- [x] `examples/03-action-lifecycle/run.sh`：启动时探测平台存储的 `tlsInsecure`，命中则切显式 token + 空 config 目录
- [x] `examples/06-world-cup/run.sh`：同上，且每步之前重新取一次 token

仅改这两个 run.sh，无产品代码改动。

---

## Why

- Related Issue: 无（陈骁 2026-07-23 反馈 examples 03/06 跑不通，未开 issue；需要的话可补一个 `type: bug`）
- 背景：

`@openbkn/bkn-sdk` 自 `0.1.1-alpha.19` 起，把 `-k/--insecure` 从设置 `NODE_TLS_REJECT_UNAUTHORIZED` 改成走 userland undici dispatcher。undici 的 `webidl.is.FormData()` 是 brand check，认不出 CLI 用 Node 全局 `FormData` 构造的上传体 —— 请求体退化成 `"[object FormData]"`、Content-Type 变 `text/plain`，`bkn push` / `tool upload` 一律 400：

```
{"error_code":"BknBackend.KnowledgeNetwork.InvalidParameter",
 "error_details":"Failed to get uploaded file: request Content-Type isn't multipart/form-data"}
```

关键点：**触发开关是平台在 `~/.bkn/platforms/<b64>/users/<uid>/token.json` 里存的 `tlsInsecure`，不是命令行当次有没有带 `-k`**。所以 03 的 run.sh 原本 export 的 `NODE_TLS_REJECT_UNAUTHORIZED=0` 完全不顶用，自签证书环境必中。

影响面不止 examples：`bkn push`、`tool upload`、`toolbox import`、`skill register`、`call --form` 全线。

版本分界实测（npm pack 逐版拆包）：

| 版本 | undici 依赖 | dist 里的 `NODE_TLS_REJECT_UNAUTHORIZED` |
| --- | --- | --- |
| `0.1.0` … `0.1.1-alpha.18` | 无 | 有 |
| `0.1.1-alpha.19`、`0.1.1`（npm latest） | `^8.7.0` | 已删除 |

---

## How

命中 `tlsInsecure` 时改用显式 token + 空 `BKN_CONFIG_DIR` 运行，把 CLI 拉回原生 `fetch` 路径；自签证书交给 `NODE_TLS_REJECT_UNAUTHORIZED` 兜。

06 每步之前重新取 token —— 显式 token 不会自动续期，而 CSV 导入单步就可能超过一个 token 的有效期；用 `_BKN_STORE_DIR` 记住真实 config 目录，避免第二次调用时从已被换掉的空目录里取。

- Breaking changes：无。不命中 `tlsInsecure` 的环境下整块是 no-op。
- 这是**临时绕过**。根因修复在 bkn-sdk 仓的 `fix/insecure-multipart-formdata`（`src/api/tls.ts` 在 insecure 分流点把全局 FormData 重建成 undici FormData）。CLI 发布修复版后，这两块可整段删除 —— 注释里已写明。

---

## Testing

- [ ] Unit tests passed locally（run.sh 无单测；`bash -n` + `shellcheck -S warning` 干净，仅剩一条与本次改动无关的既有 SC2011）
- [ ] Integration tests passed locally
- [x] Verified in test environment

测试环境 14.103.77.23，CLI `0.1.1`（npm latest，非源码构建），平台存 `tlsInsecure: true`：

- **修复前基线**：`openbkn bkn push` → `HTTP 400 ... request Content-Type isn't multipart/form-data`
- **03**：11 步 + cleanup 全绿，日志零 error；Step 4 `tool upload`（原先挂的那步）通过
- **06**：`FORCE_PUSH=1` 下 Step 5 `bkn push` 真推成功（27 objectTypes / 29 relationTypes / 4 conceptGroups），Step 6 `tool upload` 返回 `tool_id`

---

## Risk & Rollback

- 风险：低。改动限于两个示例脚本；探针读不到 `tlsInsecure` 就原样返回，不改变现有行为。
- 回滚：revert 本 PR 即可。

---

## Additional Notes

跑 06 时另外碰到三件**与本 PR 无关**的环境问题，只在测试机上绕过，没动仓库：

1. 测试机 `python3` 是 3.6.8，`scripts/extract_trailing_json.py` 的 `from __future__ import annotations` 直接 SyntaxError（该语法要 3.7+）。装 `python39` 做 PATH shim 后正常。examples 的 Python 版本下限值得单独确认。
2. CSV 源是 `raw.githubusercontent.com`，国内拉 `manager_appearances.csv` 卡死在 24KB 好几分钟；换 `cdn.jsdelivr.net/gh/jfjelstul/worldcup@master/data-csv/` 4 秒到手。27 个文件都走这个源。
3. Step 5 的向量索引仍是 `7 skipped` —— vega 现在要求先在 resource 的 `index_config` 配好 `build_key_fields`，run.sh 还塞在 build-task body 里。
