### PR TITLE
fix(execution-factory): 公开面剩余端点补授权门禁（#345 中危项）

### DIFF
--- a/adp/execution-factory/operator-integration/server/logics/auth/filter.go
+++ b/adp/execution-factory/operator-integration/server/logics/auth/filter.go
@@ -15,6 +15,12 @@ import (
 //
 // 判定复用 ResourceListIDs：类型级授权（含超管）会直接返回 ResourceIDAll，一次调用即可覆盖
 // 通配场景，无需按 ID 逐个回源。
+//
+// 刻意只按 view 判定，不含 execute/public_access：names 服务于管理态（对象级授权页的名称
+// 回显），口径与管理态列表一致——skill 列表、工具箱列表、算子列表都只按 view 过滤
+// （见 logics/skill/registry.go:945、logics/toolbox/toolbox.go:199、logics/operator/query.go:294）。
+// 市场态列表走的是另一套口径（只按 public_access，见 logics/operator/market.go:266），
+// 因此若将来市场页要复用批量取名，应另开按 public_access 过滤的入口，而不是放宽这里。
 func FilterViewableIDs(ctx context.Context, authService interfaces.IAuthorizationService, userID string,
 	ids []string, resourceType interfaces.AuthResourceType) ([]string, error) {
 	if !common.IsPublicAPIFromCtx(ctx) || len(ids) == 0 {

--- a/adp/execution-factory/operator-integration/server/logics/auth/filter.go
+++ b/adp/execution-factory/operator-integration/server/logics/auth/filter.go
@@ -1,0 +1,45 @@
+package auth
+
+import (
+	"context"
+
+	"github.com/openbkn-ai/adp/execution-factory/operator-integration/server/infra/common"
+	"github.com/openbkn-ai/adp/execution-factory/operator-integration/server/interfaces"
+)
+
+// FilterViewableIDs 在公开面按查看权限过滤资源ID，内部面原样返回。
+//
+// 用于 /operator/names、/tool-box/names、/skills/names 这类批量取名接口：它们本就对不存在的
+// ID 静默略过，因此无权限的 ID 同样略过而不是整体 403——否则 403 与 200 的差异本身就成了
+// 存在性探测信道。
+//
+// 判定复用 ResourceListIDs：类型级授权（含超管）会直接返回 ResourceIDAll，一次调用即可覆盖
+// 通配场景，无需按 ID 逐个回源。
+func FilterViewableIDs(ctx context.Context, authService interfaces.IAuthorizationService, userID string,
+	ids []string, resourceType interfaces.AuthResourceType) ([]string, error) {
+	if !common.IsPublicAPIFromCtx(ctx) || len(ids) == 0 {
+		return ids, nil
+	}
+	accessor, err := authService.GetAccessor(ctx, userID)
+	if err != nil {
+		return nil, err
+	}
+	authorizedIDs, err := authService.ResourceListIDs(ctx, accessor, resourceType, interfaces.AuthOperationTypeView)
+	if err != nil {
+		return nil, err
+	}
+	allowed := make(map[string]struct{}, len(authorizedIDs))
+	for _, id := range authorizedIDs {
+		if id == interfaces.ResourceIDAll {
+			return ids, nil
+		}
+		allowed[id] = struct{}{}
+	}
+	filtered := make([]string, 0, len(ids))
+	for _, id := range ids {
+		if _, ok := allowed[id]; ok {
+			filtered = append(filtered, id)
+		}
+	}
+	return filtered, nil
+}

--- a/adp/execution-factory/operator-integration/server/logics/auth/filter_test.go
+++ b/adp/execution-factory/operator-integration/server/logics/auth/filter_test.go
@@ -1,0 +1,83 @@
+package auth
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/openbkn-ai/adp/execution-factory/operator-integration/server/infra/common"
+	"github.com/openbkn-ai/adp/execution-factory/operator-integration/server/interfaces"
+	"github.com/openbkn-ai/adp/execution-factory/operator-integration/server/mocks"
+	. "github.com/smartystreets/goconvey/convey"
+	"go.uber.org/mock/gomock"
+)
+
+func publicCtx() context.Context {
+	ctx := common.SetPublicAPIToCtx(context.Background(), true)
+	return common.SetAccountAuthContextToCtx(ctx, &interfaces.AccountAuthContext{
+		AccountID:   "user-1",
+		AccountType: interfaces.AccessorTypeUser,
+	})
+}
+
+func TestFilterViewableIDs(t *testing.T) {
+	Convey("FilterViewableIDs", t, func() {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+		ids := []string{"a", "b", "c"}
+
+		Convey("内部面原样返回，不触发判定", func() {
+			authService := mocks.NewMockIAuthorizationService(ctrl)
+			got, err := FilterViewableIDs(context.Background(), authService, "", ids, interfaces.AuthResourceTypeOperator)
+			So(err, ShouldBeNil)
+			So(got, ShouldResemble, ids)
+		})
+
+		Convey("空ID列表直接返回", func() {
+			authService := mocks.NewMockIAuthorizationService(ctrl)
+			got, err := FilterViewableIDs(publicCtx(), authService, "", nil, interfaces.AuthResourceTypeOperator)
+			So(err, ShouldBeNil)
+			So(got, ShouldBeEmpty)
+		})
+
+		Convey("类型级授权(ResourceIDAll)全量放行", func() {
+			authService := mocks.NewMockIAuthorizationService(ctrl)
+			authService.EXPECT().GetAccessor(gomock.Any(), "").Return(&interfaces.AuthAccessor{ID: "user-1"}, nil)
+			authService.EXPECT().ResourceListIDs(gomock.Any(), gomock.Any(), interfaces.AuthResourceTypeOperator,
+				interfaces.AuthOperationTypeView).Return([]string{interfaces.ResourceIDAll}, nil)
+			got, err := FilterViewableIDs(publicCtx(), authService, "", ids, interfaces.AuthResourceTypeOperator)
+			So(err, ShouldBeNil)
+			So(got, ShouldResemble, ids)
+		})
+
+		Convey("只保留有查看权限的ID", func() {
+			authService := mocks.NewMockIAuthorizationService(ctrl)
+			authService.EXPECT().GetAccessor(gomock.Any(), "").Return(&interfaces.AuthAccessor{ID: "user-1"}, nil)
+			authService.EXPECT().ResourceListIDs(gomock.Any(), gomock.Any(), interfaces.AuthResourceTypeSkill,
+				interfaces.AuthOperationTypeView).Return([]string{"b", "z"}, nil)
+			got, err := FilterViewableIDs(publicCtx(), authService, "", ids, interfaces.AuthResourceTypeSkill)
+			So(err, ShouldBeNil)
+			So(got, ShouldResemble, []string{"b"})
+		})
+
+		Convey("权限集为空则全部过滤掉", func() {
+			authService := mocks.NewMockIAuthorizationService(ctrl)
+			authService.EXPECT().GetAccessor(gomock.Any(), "").Return(&interfaces.AuthAccessor{ID: "user-1"}, nil)
+			authService.EXPECT().ResourceListIDs(gomock.Any(), gomock.Any(), interfaces.AuthResourceTypeToolBox,
+				interfaces.AuthOperationTypeView).Return([]string{}, nil)
+			got, err := FilterViewableIDs(publicCtx(), authService, "", ids, interfaces.AuthResourceTypeToolBox)
+			So(err, ShouldBeNil)
+			So(got, ShouldBeEmpty)
+		})
+
+		Convey("授权服务报错向上传递，不降级放行", func() {
+			authService := mocks.NewMockIAuthorizationService(ctrl)
+			authService.EXPECT().GetAccessor(gomock.Any(), "").Return(&interfaces.AuthAccessor{ID: "user-1"}, nil)
+			authService.EXPECT().ResourceListIDs(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+				Return(nil, errors.New("authz down"))
+			got, err := FilterViewableIDs(publicCtx(), authService, "", ids, interfaces.AuthResourceTypeOperator)
+			So(err, ShouldNotBeNil)
+			So(got, ShouldBeNil)
+		})
+	})
+}

--- a/adp/execution-factory/operator-integration/server/logics/category/authz_test.go
+++ b/adp/execution-factory/operator-integration/server/logics/category/authz_test.go
@@ -1,0 +1,91 @@
+package category
+
+import (
+	"context"
+	"testing"
+
+	"github.com/openbkn-ai/adp/execution-factory/operator-integration/server/infra/common"
+	"github.com/openbkn-ai/adp/execution-factory/operator-integration/server/infra/logger"
+	"github.com/openbkn-ai/adp/execution-factory/operator-integration/server/interfaces"
+	"github.com/openbkn-ai/adp/execution-factory/operator-integration/server/mocks"
+	. "github.com/smartystreets/goconvey/convey"
+	"go.uber.org/mock/gomock"
+)
+
+// TestCategoryWriteAuthz 覆盖 #345：公开面分类写操作的类型级门禁。
+// 各用例都不给 DBCategory/Validator 设 EXPECT——门禁一旦失效走到业务逻辑，
+// gomock 会因非预期调用直接失败。
+func TestCategoryWriteAuthz(t *testing.T) {
+	Convey("算子分类写操作授权", t, func() {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+		publicCtx := common.SetPublicAPIToCtx(context.Background(), true)
+
+		newManager := func(authService interfaces.IAuthorizationService) *categoryManager {
+			return &categoryManager{
+				logger:      logger.DefaultLogger(),
+				DBTx:        mocks.NewMockDBTx(ctrl),
+				DBCategory:  mocks.NewMockDBCategory(ctrl),
+				Validator:   mocks.NewMockValidator(ctrl),
+				Cache:       mocks.NewMockCache(ctrl),
+				AuthService: authService,
+			}
+		}
+		expectDenied := func(authService *mocks.MockIAuthorizationService, operation interfaces.AuthOperationType) {
+			authService.EXPECT().GetAccessor(gomock.Any(), "user-1").Return(&interfaces.AuthAccessor{ID: "user-1"}, nil)
+			authService.EXPECT().OperationCheckAll(gomock.Any(), gomock.Any(), interfaces.ResourceIDAll,
+				interfaces.AuthResourceTypeOperator, operation).Return(false, nil)
+		}
+
+		Convey("CreateCategory 无新建权限时拒绝", func() {
+			authService := mocks.NewMockIAuthorizationService(ctrl)
+			expectDenied(authService, interfaces.AuthOperationTypeCreate)
+			resp, err := newManager(authService).CreateCategory(publicCtx, &interfaces.CreateCategoryReq{
+				UserID: "user-1", CategoryType: "cat-1", CategoryName: "分类一",
+			})
+			So(resp, ShouldBeNil)
+			So(err, ShouldNotBeNil)
+		})
+
+		Convey("UpdateCategory 无编辑权限时拒绝", func() {
+			authService := mocks.NewMockIAuthorizationService(ctrl)
+			expectDenied(authService, interfaces.AuthOperationTypeModify)
+			resp, err := newManager(authService).UpdateCategory(publicCtx, &interfaces.UpdateCategoryReq{
+				UserID: "user-1", CategoryType: "cat-1", CategoryName: "分类一",
+			})
+			So(resp, ShouldBeNil)
+			So(err, ShouldNotBeNil)
+		})
+
+		Convey("DeleteCategory 无删除权限时拒绝", func() {
+			authService := mocks.NewMockIAuthorizationService(ctrl)
+			expectDenied(authService, interfaces.AuthOperationTypeDelete)
+			err := newManager(authService).DeleteCategory(publicCtx, &interfaces.DeleteCategoryReq{
+				UserID: "user-1", CategoryType: "cat-1",
+			})
+			So(err, ShouldNotBeNil)
+		})
+
+		Convey("内部面不判定（启动期内置分类灌入走此路）", func() {
+			// authService 不设 EXPECT：内部面若发起判定，gomock 会因非预期调用失败
+			manager := newManager(mocks.NewMockIAuthorizationService(ctrl))
+			manager.DBCategory.(*mocks.MockDBCategory).EXPECT().
+				SelectListByCategoryID(gomock.Any(), gomock.Nil(), "cat-1").Return(nil, nil)
+			err := manager.DeleteCategory(context.Background(), &interfaces.DeleteCategoryReq{
+				UserID: "user-1", CategoryType: "cat-1",
+			})
+			// 分类不存在 → 404，说明已越过门禁进入业务逻辑
+			So(err, ShouldNotBeNil)
+			So(err.Error(), ShouldContainSubstring, "not found")
+		})
+
+		Convey("读接口保持开放，不做判定", func() {
+			manager := newManager(mocks.NewMockIAuthorizationService(ctrl))
+			manager.DBCategory.(*mocks.MockDBCategory).EXPECT().
+				SelectList(gomock.Any(), gomock.Nil()).Return(nil, nil)
+			list, err := manager.GetCategoryList(publicCtx)
+			So(err, ShouldBeNil)
+			So(len(list), ShouldEqual, 2) // 两个内置分类：未分类、系统工具
+		})
+	})
+}

--- a/adp/execution-factory/operator-integration/server/logics/category/category.go
+++ b/adp/execution-factory/operator-integration/server/logics/category/category.go
@@ -15,6 +15,34 @@ import (
 	"github.com/openbkn-ai/bkn-comm-go/otel/oteltrace"
 )
 
+// requireOperatorTypePermission 校验调用方在算子类型上持有指定操作权限。
+//
+// 分类是全局分类法，不隶属于任何单个算子，没有资源 ID 可判，因此按类型级（ResourceIDAll）
+// 判定，口径与 logics/auth/decision.go 中 CheckCreatePermission 一致。
+//
+// 仅在公开面生效：内部面（internal-v1）由服务间调用，启动期的内置分类灌入走的也是这条路
+// （见 driveradapters/category/init_data.go），沿用服务内既有惯用法跳过判定。
+// 读接口（GetCategoryList）不判：分类法只是名称字典，不含租户数据，收紧会打断非超管前端。
+func (c *categoryManager) requireOperatorTypePermission(ctx context.Context, userID string,
+	operation interfaces.AuthOperationType) error {
+	if !common.IsPublicAPIFromCtx(ctx) {
+		return nil
+	}
+	accessor, err := c.AuthService.GetAccessor(ctx, userID)
+	if err != nil {
+		return err
+	}
+	authorized, err := c.AuthService.OperationCheckAll(ctx, accessor,
+		interfaces.ResourceIDAll, interfaces.AuthResourceTypeOperator, operation)
+	if err != nil {
+		return err
+	}
+	if !authorized {
+		return errors.NewHTTPError(ctx, http.StatusForbidden, errors.ErrExtCommonOperationForbidden, nil)
+	}
+	return nil
+}
+
 // GetCategoryName 获取分类名称
 func (c *categoryManager) GetCategoryName(ctx context.Context, category interfaces.BizCategory) (categoryName string) {
 	ctx, _ = oteltrace.StartInternalSpan(ctx)
@@ -111,6 +139,9 @@ func (c *categoryManager) getCategorySystem(ctx context.Context) *interfaces.Cat
 func (c *categoryManager) UpdateCategory(ctx context.Context, req *interfaces.UpdateCategoryReq) (resp *interfaces.UpdateCategoryResp, err error) {
 	ctx, _ = oteltrace.StartInternalSpan(ctx)
 	defer oteltrace.EndSpan(ctx, err)
+	if err = c.requireOperatorTypePermission(ctx, req.UserID, interfaces.AuthOperationTypeModify); err != nil {
+		return
+	}
 	// 校验分类名称
 	err = c.Validator.ValidatorCategoryName(ctx, req.CategoryName)
 	if err != nil {
@@ -161,6 +192,9 @@ func (c *categoryManager) UpdateCategory(ctx context.Context, req *interfaces.Up
 func (c *categoryManager) CreateCategory(ctx context.Context, req *interfaces.CreateCategoryReq) (resp *interfaces.CreateCategoryResp, err error) {
 	ctx, _ = oteltrace.StartInternalSpan(ctx)
 	defer oteltrace.EndSpan(ctx, err)
+	if err = c.requireOperatorTypePermission(ctx, req.UserID, interfaces.AuthOperationTypeCreate); err != nil {
+		return
+	}
 	// 校验分类名称
 	err = c.Validator.ValidatorCategoryName(ctx, req.CategoryName)
 	if err != nil {
@@ -225,6 +259,9 @@ func (c *categoryManager) BatchCreateCategory(ctx context.Context, req []*interf
 func (c *categoryManager) DeleteCategory(ctx context.Context, req *interfaces.DeleteCategoryReq) (err error) {
 	ctx, _ = oteltrace.StartInternalSpan(ctx)
 	defer oteltrace.EndSpan(ctx, err)
+	if err = c.requireOperatorTypePermission(ctx, req.UserID, interfaces.AuthOperationTypeDelete); err != nil {
+		return
+	}
 	if string(req.CategoryType) == interfaces.CategoryTypeOther.String() {
 		return errors.DefaultHTTPError(ctx, http.StatusForbidden, "category_type: "+interfaces.CategoryTypeOther.String()+" is a built-in system category and cannot be deleted")
 	}

--- a/adp/execution-factory/operator-integration/server/logics/category/index.go
+++ b/adp/execution-factory/operator-integration/server/logics/category/index.go
@@ -9,25 +9,28 @@ import (
 	"github.com/openbkn-ai/adp/execution-factory/operator-integration/server/infra/validator"
 	"github.com/openbkn-ai/adp/execution-factory/operator-integration/server/interfaces"
 	"github.com/openbkn-ai/adp/execution-factory/operator-integration/server/interfaces/model"
+	"github.com/openbkn-ai/adp/execution-factory/operator-integration/server/logics/auth"
 )
 
 // categoryManager 分类管理器
 type categoryManager struct {
-	logger     interfaces.Logger
-	DBTx       model.DBTx
-	DBCategory model.DBCategory
-	Validator  interfaces.Validator
-	Cache      interfaces.Cache
+	logger      interfaces.Logger
+	DBTx        model.DBTx
+	DBCategory  model.DBCategory
+	Validator   interfaces.Validator
+	Cache       interfaces.Cache
+	AuthService interfaces.IAuthorizationService
 }
 
 // NewCategoryManager 创建分类管理器
 func NewCategoryManager() interfaces.CategoryManager {
 	c := &categoryManager{
-		logger:     config.NewConfigLoader().GetLogger(),
-		DBTx:       dbaccess.NewBaseTx(),
-		DBCategory: dbaccess.NewCategoryDBSingleton(),
-		Validator:  validator.NewValidator(),
-		Cache:      cache.NewInMemoryCache(),
+		logger:      config.NewConfigLoader().GetLogger(),
+		DBTx:        dbaccess.NewBaseTx(),
+		DBCategory:  dbaccess.NewCategoryDBSingleton(),
+		Validator:   validator.NewValidator(),
+		Cache:       cache.NewInMemoryCache(),
+		AuthService: auth.NewAuthServiceImpl(),
 	}
 	// 从数据库中加载分类信息到缓存中
 	categoryDBList, err := c.DBCategory.SelectList(context.Background(), nil)

--- a/adp/execution-factory/operator-integration/server/logics/mcp/authz_test.go
+++ b/adp/execution-factory/operator-integration/server/logics/mcp/authz_test.go
@@ -1,0 +1,44 @@
+package mcp
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/openbkn-ai/adp/execution-factory/operator-integration/server/infra/common"
+	"github.com/openbkn-ai/adp/execution-factory/operator-integration/server/infra/logger"
+	"github.com/openbkn-ai/adp/execution-factory/operator-integration/server/interfaces"
+	"github.com/openbkn-ai/adp/execution-factory/operator-integration/server/mocks"
+	. "github.com/smartystreets/goconvey/convey"
+	"go.uber.org/mock/gomock"
+)
+
+// TestParseSSEAuthz 覆盖 #345：解析接口会驱动服务端向调用方给定的 URL 发起出站请求，
+// 公开面必须先过 MCP 类型级新建权限。
+func TestParseSSEAuthz(t *testing.T) {
+	Convey("ParseSSE 授权", t, func() {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+		publicCtx := common.SetPublicAPIToCtx(context.Background(), true)
+		req := &interfaces.MCPParseSSERequest{
+			Mode: interfaces.MCPModeSSE,
+			URL:  "http://127.0.0.1:1/sse",
+		}
+
+		Convey("无新建权限时拒绝，不发起出站请求", func() {
+			authService := mocks.NewMockIAuthorizationService(ctrl)
+			svc := &mcpServiceImpl{logger: logger.DefaultLogger(), AuthService: authService}
+			authService.EXPECT().GetAccessor(gomock.Any(), "").Return(&interfaces.AuthAccessor{ID: "user-1"}, nil)
+			authService.EXPECT().CheckCreatePermission(gomock.Any(), gomock.Any(), interfaces.AuthResourceTypeMCP).
+				Return(errors.New("create forbidden"))
+
+			resp, err := svc.ParseSSE(publicCtx, req)
+			So(resp, ShouldBeNil)
+			So(err, ShouldNotBeNil)
+			So(err.Error(), ShouldContainSubstring, "create forbidden")
+		})
+
+		// 内部面（internal-v1）未注册该端点，且解析逻辑必须建 MCP 客户端、加载运行时配置，
+		// 单测环境无法进入，因此内部面放行只由 IsPublicAPIFromCtx 判定本身保证，不在此断言。
+	})
+}

--- a/adp/execution-factory/operator-integration/server/logics/mcp/manage.go
+++ b/adp/execution-factory/operator-integration/server/logics/mcp/manage.go
@@ -41,6 +41,18 @@ func (s *mcpServiceImpl) ParseSSE(ctx context.Context, req *interfaces.MCPParseS
 	// 记录可观测
 	ctx, _ = oteltrace.StartInternalSpan(ctx)
 	defer oteltrace.EndSpan(ctx, err)
+	// 解析动作会驱动服务端向调用方给定的 URL 发起出站请求，是新建 MCP Server 的前置步骤，
+	// 因此按与 AddMCPServer 相同的类型级新建权限判定；内部面不受影响。
+	if icommon.IsPublicAPIFromCtx(ctx) {
+		var accessor *interfaces.AuthAccessor
+		accessor, err = s.AuthService.GetAccessor(ctx, "")
+		if err != nil {
+			return
+		}
+		if err = s.AuthService.CheckCreatePermission(ctx, accessor, interfaces.AuthResourceTypeMCP); err != nil {
+			return
+		}
+	}
 	mcpCoreInfo := interfaces.MCPCoreConfigInfo{
 		Mode:    req.Mode,
 		URL:     req.URL,

--- a/adp/execution-factory/operator-integration/server/logics/operator/names_authz_test.go
+++ b/adp/execution-factory/operator-integration/server/logics/operator/names_authz_test.go
@@ -1,0 +1,75 @@
+package operator
+
+import (
+	"context"
+	"testing"
+
+	"github.com/openbkn-ai/adp/execution-factory/operator-integration/server/infra/common"
+	"github.com/openbkn-ai/adp/execution-factory/operator-integration/server/infra/logger"
+	"github.com/openbkn-ai/adp/execution-factory/operator-integration/server/interfaces"
+	"github.com/openbkn-ai/adp/execution-factory/operator-integration/server/interfaces/model"
+	"github.com/openbkn-ai/adp/execution-factory/operator-integration/server/mocks"
+	. "github.com/smartystreets/goconvey/convey"
+	"go.uber.org/mock/gomock"
+)
+
+// TestGetOperatorNamesByIDsAuthz 覆盖 #345：批量取名按查看权限过滤，避免枚举全量算子名
+func TestGetOperatorNamesByIDsAuthz(t *testing.T) {
+	Convey("算子批量取名授权过滤", t, func() {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+		publicCtx := common.SetPublicAPIToCtx(context.Background(), true)
+
+		Convey("只返回有查看权限的算子", func() {
+			authService := mocks.NewMockIAuthorizationService(ctrl)
+			operatorDB := mocks.NewMockIOperatorRegisterDB(ctrl)
+			manager := &operatorManager{
+				Logger:            logger.DefaultLogger(),
+				DBOperatorManager: operatorDB,
+				AuthService:       authService,
+			}
+			authService.EXPECT().GetAccessor(gomock.Any(), "").Return(&interfaces.AuthAccessor{ID: "user-1"}, nil)
+			authService.EXPECT().ResourceListIDs(gomock.Any(), gomock.Any(), interfaces.AuthResourceTypeOperator,
+				interfaces.AuthOperationTypeView).Return([]string{"op-1"}, nil)
+			operatorDB.EXPECT().SelectByOperatorIDs(gomock.Any(), []string{"op-1"}).
+				Return([]*model.OperatorRegisterDB{{OperatorID: "op-1", Name: "算子一"}}, nil)
+
+			resp, err := manager.GetOperatorNamesByIDs(publicCtx, []string{"op-1", "op-2"})
+			So(err, ShouldBeNil)
+			So(len(resp.Entries), ShouldEqual, 1)
+			So(resp.Entries[0].ID, ShouldEqual, "op-1")
+		})
+
+		Convey("权限集为空时返回空列表且不查库", func() {
+			authService := mocks.NewMockIAuthorizationService(ctrl)
+			manager := &operatorManager{
+				Logger:            logger.DefaultLogger(),
+				DBOperatorManager: mocks.NewMockIOperatorRegisterDB(ctrl),
+				AuthService:       authService,
+			}
+			authService.EXPECT().GetAccessor(gomock.Any(), "").Return(&interfaces.AuthAccessor{ID: "user-1"}, nil)
+			authService.EXPECT().ResourceListIDs(gomock.Any(), gomock.Any(), interfaces.AuthResourceTypeOperator,
+				interfaces.AuthOperationTypeView).Return(nil, nil)
+
+			resp, err := manager.GetOperatorNamesByIDs(publicCtx, []string{"op-1"})
+			So(err, ShouldBeNil)
+			So(resp.Entries, ShouldBeEmpty)
+		})
+
+		Convey("内部面不过滤", func() {
+			// authService 不设 EXPECT：内部面若发起判定，gomock 会因非预期调用失败
+			operatorDB := mocks.NewMockIOperatorRegisterDB(ctrl)
+			manager := &operatorManager{
+				Logger:            logger.DefaultLogger(),
+				DBOperatorManager: operatorDB,
+				AuthService:       mocks.NewMockIAuthorizationService(ctrl),
+			}
+			operatorDB.EXPECT().SelectByOperatorIDs(gomock.Any(), []string{"op-1"}).
+				Return([]*model.OperatorRegisterDB{{OperatorID: "op-1", Name: "算子一"}}, nil)
+
+			resp, err := manager.GetOperatorNamesByIDs(context.Background(), []string{"op-1"})
+			So(err, ShouldBeNil)
+			So(len(resp.Entries), ShouldEqual, 1)
+		})
+	})
+}

--- a/adp/execution-factory/operator-integration/server/logics/operator/query.go
+++ b/adp/execution-factory/operator-integration/server/logics/operator/query.go
@@ -80,11 +80,19 @@ func (m *operatorManager) getOperatorRegisterInfo(ctx context.Context, operatorI
 }
 
 // GetOperatorNamesByIDs 按算子ID批量取名(轻量只读，复用 SelectByOperatorIDs；不存在的ID略过)
+// 公开面按查看权限过滤：无权限的ID与不存在的ID一样静默略过。
 func (m *operatorManager) GetOperatorNamesByIDs(ctx context.Context, ids []string) (resp *interfaces.BatchNamesResp, err error) {
 	ctx, _ = oteltrace.StartInternalSpan(ctx)
 	defer oteltrace.EndSpan(ctx, err)
 	resp = &interfaces.BatchNamesResp{Entries: []*interfaces.NameEntry{}}
 	ids = utils.UniqueStrings(ids)
+	if len(ids) == 0 {
+		return
+	}
+	ids, err = auth.FilterViewableIDs(ctx, m.AuthService, "", ids, interfaces.AuthResourceTypeOperator)
+	if err != nil {
+		return nil, err
+	}
 	if len(ids) == 0 {
 		return
 	}

--- a/adp/execution-factory/operator-integration/server/logics/skill/authz_test.go
+++ b/adp/execution-factory/operator-integration/server/logics/skill/authz_test.go
@@ -1,0 +1,231 @@
+package skill
+
+import (
+	"context"
+	"testing"
+
+	"github.com/openbkn-ai/adp/execution-factory/operator-integration/server/infra/common"
+	"github.com/openbkn-ai/adp/execution-factory/operator-integration/server/infra/logger"
+	"github.com/openbkn-ai/adp/execution-factory/operator-integration/server/interfaces"
+	"github.com/openbkn-ai/adp/execution-factory/operator-integration/server/interfaces/model"
+	"github.com/openbkn-ai/adp/execution-factory/operator-integration/server/mocks"
+	. "github.com/smartystreets/goconvey/convey"
+	"go.uber.org/mock/gomock"
+)
+
+// skillPublicCtx 构造公开面上下文，公开面才做授权判定
+func skillPublicCtx() context.Context {
+	return common.SetPublicAPIToCtx(context.Background(), true)
+}
+
+// TestSkillIndexBuildAuthz 覆盖 #345：公开面索引构建写接口的类型级门禁
+func TestSkillIndexBuildAuthz(t *testing.T) {
+	Convey("Skill 索引构建写接口授权", t, func() {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		// expectDenied 断言类型级 skill:modify 判定为不通过；taskRepo 不设任何 EXPECT，
+		// 一旦门禁失效走到仓储层，gomock 会因非预期调用直接失败。
+		expectDenied := func(authService *mocks.MockIAuthorizationService) {
+			authService.EXPECT().GetAccessor(gomock.Any(), "user-1").Return(&interfaces.AuthAccessor{ID: "user-1"}, nil)
+			authService.EXPECT().OperationCheckAll(gomock.Any(), gomock.Any(), interfaces.ResourceIDAll,
+				interfaces.AuthResourceTypeSkill, interfaces.AuthOperationTypeModify).Return(false, nil)
+		}
+
+		Convey("CreateTask 无权限时拒绝且不落库", func() {
+			authService := mocks.NewMockIAuthorizationService(ctrl)
+			svc := &skillIndexBuildService{
+				logger:      logger.DefaultLogger(),
+				taskRepo:    mocks.NewMockISkillIndexBuildTaskDB(ctrl),
+				authService: authService,
+			}
+			expectDenied(authService)
+			resp, err := svc.CreateTask(skillPublicCtx(), &interfaces.CreateSkillIndexBuildTaskReq{
+				BusinessDomainID: "bd-1", UserID: "user-1",
+				ExecuteType: interfaces.SkillIndexBuildExecuteTypeFull,
+			})
+			So(resp, ShouldBeNil)
+			So(err, ShouldNotBeNil)
+		})
+
+		Convey("CancelTask 无权限时拒绝且不读任务", func() {
+			authService := mocks.NewMockIAuthorizationService(ctrl)
+			svc := &skillIndexBuildService{
+				logger:      logger.DefaultLogger(),
+				taskRepo:    mocks.NewMockISkillIndexBuildTaskDB(ctrl),
+				authService: authService,
+			}
+			expectDenied(authService)
+			resp, err := svc.CancelTask(skillPublicCtx(), &interfaces.CancelSkillIndexBuildTaskReq{
+				BusinessDomainID: "bd-1", UserID: "user-1", TaskID: "task-1",
+			})
+			So(resp, ShouldBeNil)
+			So(err, ShouldNotBeNil)
+		})
+
+		Convey("RetryTask 无权限时拒绝且不读任务", func() {
+			authService := mocks.NewMockIAuthorizationService(ctrl)
+			svc := &skillIndexBuildService{
+				logger:      logger.DefaultLogger(),
+				taskRepo:    mocks.NewMockISkillIndexBuildTaskDB(ctrl),
+				authService: authService,
+			}
+			expectDenied(authService)
+			resp, err := svc.RetryTask(skillPublicCtx(), &interfaces.RetrySkillIndexBuildTaskReq{
+				BusinessDomainID: "bd-1", UserID: "user-1", TaskID: "task-1",
+			})
+			So(resp, ShouldBeNil)
+			So(err, ShouldNotBeNil)
+		})
+
+		Convey("有权限时放行到业务逻辑", func() {
+			authService := mocks.NewMockIAuthorizationService(ctrl)
+			taskRepo := mocks.NewMockISkillIndexBuildTaskDB(ctrl)
+			svc := &skillIndexBuildService{
+				logger:      logger.DefaultLogger(),
+				taskRepo:    taskRepo,
+				authService: authService,
+			}
+			authService.EXPECT().GetAccessor(gomock.Any(), "user-1").Return(&interfaces.AuthAccessor{ID: "user-1"}, nil)
+			authService.EXPECT().OperationCheckAll(gomock.Any(), gomock.Any(), interfaces.ResourceIDAll,
+				interfaces.AuthResourceTypeSkill, interfaces.AuthOperationTypeModify).Return(true, nil)
+			taskRepo.EXPECT().SelectRunningTask(gomock.Any(), gomock.Nil()).Return(nil, nil)
+			taskRepo.EXPECT().Insert(gomock.Any(), gomock.Nil(), gomock.Any()).Return(nil)
+
+			resp, err := svc.CreateTask(skillPublicCtx(), &interfaces.CreateSkillIndexBuildTaskReq{
+				BusinessDomainID: "bd-1", UserID: "user-1",
+				ExecuteType: interfaces.SkillIndexBuildExecuteTypeFull,
+			})
+			So(err, ShouldBeNil)
+			So(resp.Status, ShouldEqual, interfaces.SkillIndexBuildStatusPending)
+		})
+
+		Convey("内部面不判定（调度器与服务间调用）", func() {
+			// authService 不设 EXPECT：内部面若发起判定，gomock 会因非预期调用失败
+			taskRepo := mocks.NewMockISkillIndexBuildTaskDB(ctrl)
+			svc := &skillIndexBuildService{
+				logger:      logger.DefaultLogger(),
+				taskRepo:    taskRepo,
+				authService: mocks.NewMockIAuthorizationService(ctrl),
+			}
+			taskRepo.EXPECT().SelectRunningTask(gomock.Any(), gomock.Nil()).Return(nil, nil)
+			taskRepo.EXPECT().Insert(gomock.Any(), gomock.Nil(), gomock.Any()).Return(nil)
+
+			resp, err := svc.CreateTask(context.Background(), &interfaces.CreateSkillIndexBuildTaskReq{
+				BusinessDomainID: "bd-1", UserID: "user-1",
+				ExecuteType: interfaces.SkillIndexBuildExecuteTypeFull,
+			})
+			So(err, ShouldBeNil)
+			So(resp, ShouldNotBeNil)
+		})
+	})
+}
+
+// TestGetSkillReleaseHistoryAuthz 覆盖 #345：发布历史读接口按 skill_id 的对象级门禁
+func TestGetSkillReleaseHistoryAuthz(t *testing.T) {
+	Convey("Skill 发布历史授权", t, func() {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		Convey("无权限时拒绝且不读历史", func() {
+			authService := mocks.NewMockIAuthorizationService(ctrl)
+			reader := &skillReader{
+				releaseHistoryRepo: mocks.NewMockISkillReleaseHistoryDB(ctrl),
+				AuthService:        authService,
+				Logger:             logger.DefaultLogger(),
+			}
+			authService.EXPECT().GetAccessor(gomock.Any(), "user-1").Return(&interfaces.AuthAccessor{ID: "user-1"}, nil)
+			authService.EXPECT().OperationCheckAny(gomock.Any(), gomock.Any(), "skill-1", interfaces.AuthResourceTypeSkill,
+				interfaces.AuthOperationTypeExecute, interfaces.AuthOperationTypePublicAccess,
+				interfaces.AuthOperationTypeView).Return(false, nil)
+
+			resp, err := reader.GetSkillReleaseHistory(skillPublicCtx(), &interfaces.GetSkillReleaseHistoryReq{
+				BusinessDomainID: "bd-1", UserID: "user-1", SkillID: "skill-1",
+			})
+			So(resp, ShouldBeNil)
+			So(err, ShouldNotBeNil)
+		})
+
+		Convey("有权限时返回历史", func() {
+			authService := mocks.NewMockIAuthorizationService(ctrl)
+			historyRepo := mocks.NewMockISkillReleaseHistoryDB(ctrl)
+			reader := &skillReader{
+				releaseHistoryRepo: historyRepo,
+				AuthService:        authService,
+				Logger:             logger.DefaultLogger(),
+			}
+			authService.EXPECT().GetAccessor(gomock.Any(), "user-1").Return(&interfaces.AuthAccessor{ID: "user-1"}, nil)
+			authService.EXPECT().OperationCheckAny(gomock.Any(), gomock.Any(), "skill-1", interfaces.AuthResourceTypeSkill,
+				gomock.Any(), gomock.Any(), gomock.Any()).Return(true, nil)
+			historyRepo.EXPECT().SelectBySkillID(gomock.Any(), gomock.Nil(), "skill-1").
+				Return([]*model.SkillReleaseHistoryDB{{SkillID: "skill-1", Version: "v1"}}, nil)
+
+			resp, err := reader.GetSkillReleaseHistory(skillPublicCtx(), &interfaces.GetSkillReleaseHistoryReq{
+				BusinessDomainID: "bd-1", UserID: "user-1", SkillID: "skill-1",
+			})
+			So(err, ShouldBeNil)
+			So(len(resp), ShouldEqual, 1)
+		})
+
+		Convey("内部面不判定", func() {
+			historyRepo := mocks.NewMockISkillReleaseHistoryDB(ctrl)
+			reader := &skillReader{
+				releaseHistoryRepo: historyRepo,
+				AuthService:        mocks.NewMockIAuthorizationService(ctrl),
+				Logger:             logger.DefaultLogger(),
+			}
+			historyRepo.EXPECT().SelectBySkillID(gomock.Any(), gomock.Nil(), "skill-1").
+				Return([]*model.SkillReleaseHistoryDB{}, nil)
+
+			resp, err := reader.GetSkillReleaseHistory(context.Background(), &interfaces.GetSkillReleaseHistoryReq{
+				BusinessDomainID: "bd-1", UserID: "user-1", SkillID: "skill-1",
+			})
+			So(err, ShouldBeNil)
+			So(resp, ShouldBeEmpty)
+		})
+	})
+}
+
+// TestGetSkillNamesByIDsAuthz 覆盖 #345：批量取名按查看权限过滤，避免枚举全量技能名
+func TestGetSkillNamesByIDsAuthz(t *testing.T) {
+	Convey("Skill 批量取名授权过滤", t, func() {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		Convey("只返回有查看权限的技能", func() {
+			authService := mocks.NewMockIAuthorizationService(ctrl)
+			skillRepo := mocks.NewMockISkillRepository(ctrl)
+			registry := &skillRegistry{
+				skillRepo:   skillRepo,
+				AuthService: authService,
+				Logger:      logger.DefaultLogger(),
+			}
+			authService.EXPECT().GetAccessor(gomock.Any(), "").Return(&interfaces.AuthAccessor{ID: "user-1"}, nil)
+			authService.EXPECT().ResourceListIDs(gomock.Any(), gomock.Any(), interfaces.AuthResourceTypeSkill,
+				interfaces.AuthOperationTypeView).Return([]string{"skill-1"}, nil)
+			skillRepo.EXPECT().SelectSkillListByIDs(gomock.Any(), []string{"skill-1"}).
+				Return([]*model.SkillRepositoryDB{{SkillID: "skill-1", Name: "skill one"}}, nil)
+
+			resp, err := registry.GetSkillNamesByIDs(skillPublicCtx(), []string{"skill-1", "skill-2"})
+			So(err, ShouldBeNil)
+			So(len(resp.Entries), ShouldEqual, 1)
+			So(resp.Entries[0].ID, ShouldEqual, "skill-1")
+		})
+
+		Convey("权限集为空时返回空列表且不查库", func() {
+			authService := mocks.NewMockIAuthorizationService(ctrl)
+			registry := &skillRegistry{
+				skillRepo:   mocks.NewMockISkillRepository(ctrl),
+				AuthService: authService,
+				Logger:      logger.DefaultLogger(),
+			}
+			authService.EXPECT().GetAccessor(gomock.Any(), "").Return(&interfaces.AuthAccessor{ID: "user-1"}, nil)
+			authService.EXPECT().ResourceListIDs(gomock.Any(), gomock.Any(), interfaces.AuthResourceTypeSkill,
+				interfaces.AuthOperationTypeView).Return(nil, nil)
+
+			resp, err := registry.GetSkillNamesByIDs(skillPublicCtx(), []string{"skill-1"})
+			So(err, ShouldBeNil)
+			So(resp.Entries, ShouldBeEmpty)
+		})
+	})
+}

--- a/adp/execution-factory/operator-integration/server/logics/skill/index_build.go
+++ b/adp/execution-factory/operator-integration/server/logics/skill/index_build.go
@@ -9,12 +9,14 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/openbkn-ai/adp/execution-factory/operator-integration/server/dbaccess"
+	infracommon "github.com/openbkn-ai/adp/execution-factory/operator-integration/server/infra/common"
 	"github.com/openbkn-ai/adp/execution-factory/operator-integration/server/infra/common/ormhelper"
 	"github.com/openbkn-ai/adp/execution-factory/operator-integration/server/infra/config"
 	oerrors "github.com/openbkn-ai/adp/execution-factory/operator-integration/server/infra/errors"
 	infralock "github.com/openbkn-ai/adp/execution-factory/operator-integration/server/infra/lock"
 	"github.com/openbkn-ai/adp/execution-factory/operator-integration/server/interfaces"
 	"github.com/openbkn-ai/adp/execution-factory/operator-integration/server/interfaces/model"
+	"github.com/openbkn-ai/adp/execution-factory/operator-integration/server/logics/auth"
 	"github.com/redis/go-redis/v9"
 )
 
@@ -33,6 +35,7 @@ type skillIndexBuildService struct {
 	skillRepo           model.ISkillRepository
 	releaseRepo         model.ISkillReleaseDB
 	indexSync           interfaces.SkillIndexSyncService
+	authService         interfaces.IAuthorizationService
 	assignLockerFactory func(taskID string) skillIndexBuildAssignLocker
 	enablePeriodicFull  bool
 	periodicFullEvery   time.Duration
@@ -63,6 +66,7 @@ func NewSkillIndexBuildService() interfaces.SkillIndexBuildService {
 			skillRepo:           dbaccess.NewSkillRepositoryDB(),
 			releaseRepo:         dbaccess.NewSkillReleaseDB(),
 			indexSync:           NewSkillIndexSyncService(),
+			authService:         auth.NewAuthServiceImpl(),
 			assignLockerFactory: newSkillIndexBuildAssignLockerFactory(),
 			enablePeriodicFull:  conf.SkillIndexBuildConfig.EnablePeriodicFullScan,
 			periodicFullEvery:   periodicEvery,
@@ -73,7 +77,37 @@ func NewSkillIndexBuildService() interfaces.SkillIndexBuildService {
 	return skillIndexBuildInst
 }
 
+// requireSkillTypePermission 校验调用方在 Skill 类型上持有指定操作权限。
+//
+// 索引构建任务面向全量 Skill，不隶属于任何单个 Skill，没有资源 ID 可判，因此按类型级
+// （ResourceIDAll）判定，口径与 logics/auth/decision.go 中 CheckCreatePermission 一致。
+//
+// 仅在公开面生效。内部面（internal-v1）由服务间调用、周期调度器与重试 worker 触发，
+// 沿用服务内既有惯用法（见 logics/skill/reader.go:70）跳过判定，避免打断现有调用方。
+func (s *skillIndexBuildService) requireSkillTypePermission(ctx context.Context, userID string,
+	operation interfaces.AuthOperationType) error {
+	if !infracommon.IsPublicAPIFromCtx(ctx) {
+		return nil
+	}
+	accessor, err := s.authService.GetAccessor(ctx, userID)
+	if err != nil {
+		return err
+	}
+	authorized, err := s.authService.OperationCheckAll(ctx, accessor,
+		interfaces.ResourceIDAll, interfaces.AuthResourceTypeSkill, operation)
+	if err != nil {
+		return err
+	}
+	if !authorized {
+		return oerrors.NewHTTPError(ctx, http.StatusForbidden, oerrors.ErrExtCommonOperationForbidden, nil)
+	}
+	return nil
+}
+
 func (s *skillIndexBuildService) CreateTask(ctx context.Context, req *interfaces.CreateSkillIndexBuildTaskReq) (*interfaces.CreateSkillIndexBuildTaskResp, error) {
+	if err := s.requireSkillTypePermission(ctx, req.UserID, interfaces.AuthOperationTypeModify); err != nil {
+		return nil, err
+	}
 	resp, err := s.createTask(ctx, req.UserID, req.ExecuteType)
 	if err != nil {
 		return nil, err
@@ -180,6 +214,9 @@ func (s *skillIndexBuildService) QueryTaskList(ctx context.Context, req *interfa
 }
 
 func (s *skillIndexBuildService) CancelTask(ctx context.Context, req *interfaces.CancelSkillIndexBuildTaskReq) (*interfaces.CancelSkillIndexBuildTaskResp, error) {
+	if err := s.requireSkillTypePermission(ctx, req.UserID, interfaces.AuthOperationTypeModify); err != nil {
+		return nil, err
+	}
 	task, err := s.taskRepo.SelectByTaskID(ctx, nil, req.TaskID)
 	if err != nil {
 		return nil, oerrors.DefaultHTTPError(ctx, http.StatusInternalServerError, err.Error())
@@ -208,6 +245,9 @@ func (s *skillIndexBuildService) CancelTask(ctx context.Context, req *interfaces
 }
 
 func (s *skillIndexBuildService) RetryTask(ctx context.Context, req *interfaces.RetrySkillIndexBuildTaskReq) (*interfaces.RetrySkillIndexBuildTaskResp, error) {
+	if err := s.requireSkillTypePermission(ctx, req.UserID, interfaces.AuthOperationTypeModify); err != nil {
+		return nil, err
+	}
 	task, err := s.taskRepo.SelectByTaskID(ctx, nil, req.TaskID)
 	if err != nil {
 		return nil, oerrors.DefaultHTTPError(ctx, http.StatusInternalServerError, err.Error())

--- a/adp/execution-factory/operator-integration/server/logics/skill/reader.go
+++ b/adp/execution-factory/operator-integration/server/logics/skill/reader.go
@@ -185,6 +185,27 @@ func (r *skillReader) GetSkillReleaseHistory(ctx context.Context, req *interface
 		"skill_id": req.SkillID,
 	})
 
+	// 如果是外部接口，口径与同文件其余只读接口一致：执行、公共访问、查看三者有其一即可
+	if common.IsPublicAPIFromCtx(ctx) {
+		var accessor *interfaces.AuthAccessor
+		accessor, err = r.AuthService.GetAccessor(ctx, req.UserID)
+		if err != nil {
+			return nil, err
+		}
+		var authorized bool
+		authorized, err = r.AuthService.OperationCheckAny(ctx, accessor, req.SkillID, interfaces.AuthResourceTypeSkill,
+			interfaces.AuthOperationTypeExecute, interfaces.AuthOperationTypePublicAccess, interfaces.AuthOperationTypeView)
+		if err != nil {
+			return nil, err
+		}
+		if !authorized {
+			r.Logger.WithContext(ctx).Errorf("user has no permission to view release history of skill %s", req.SkillID)
+			err = errors.NewHTTPError(ctx, http.StatusForbidden, errors.ErrExtCommonOperationForbidden,
+				fmt.Sprintf("user has no permission to view release history of skill %s", req.SkillID))
+			return nil, err
+		}
+	}
+
 	histories, err := r.releaseHistoryRepo.SelectBySkillID(ctx, nil, req.SkillID)
 	if err != nil {
 		return nil, errors.DefaultHTTPError(ctx, http.StatusInternalServerError, err.Error())

--- a/adp/execution-factory/operator-integration/server/logics/skill/registry.go
+++ b/adp/execution-factory/operator-integration/server/logics/skill/registry.go
@@ -1323,12 +1323,20 @@ func (r *skillRegistry) GetSkillDetail(ctx context.Context, req *interfaces.GetS
 	return skillInfo, nil
 }
 
-// GetSkillNamesByIDs 按技能ID批量取名(轻量只读，不存在的ID略过；不做对象级授权校验)
+// GetSkillNamesByIDs 按技能ID批量取名(轻量只读，不存在的ID略过)
+// 公开面按查看权限过滤：无权限的ID与不存在的ID一样静默略过。
 func (r *skillRegistry) GetSkillNamesByIDs(ctx context.Context, ids []string) (resp *interfaces.BatchNamesResp, err error) {
 	ctx, _ = oteltrace.StartInternalSpan(ctx)
 	defer oteltrace.EndSpan(ctx, err)
 	resp = &interfaces.BatchNamesResp{Entries: []*interfaces.NameEntry{}}
 	ids = utils.UniqueStrings(ids)
+	if len(ids) == 0 {
+		return
+	}
+	ids, err = auth.FilterViewableIDs(ctx, r.AuthService, "", ids, interfaces.AuthResourceTypeSkill)
+	if err != nil {
+		return nil, err
+	}
 	if len(ids) == 0 {
 		return
 	}

--- a/adp/execution-factory/operator-integration/server/logics/toolbox/names_authz_test.go
+++ b/adp/execution-factory/operator-integration/server/logics/toolbox/names_authz_test.go
@@ -1,0 +1,75 @@
+package toolbox
+
+import (
+	"context"
+	"testing"
+
+	"github.com/openbkn-ai/adp/execution-factory/operator-integration/server/infra/common"
+	"github.com/openbkn-ai/adp/execution-factory/operator-integration/server/infra/logger"
+	"github.com/openbkn-ai/adp/execution-factory/operator-integration/server/interfaces"
+	"github.com/openbkn-ai/adp/execution-factory/operator-integration/server/interfaces/model"
+	"github.com/openbkn-ai/adp/execution-factory/operator-integration/server/mocks"
+	. "github.com/smartystreets/goconvey/convey"
+	"go.uber.org/mock/gomock"
+)
+
+// TestGetToolBoxNamesByIDsAuthz 覆盖 #345：批量取名按查看权限过滤，避免枚举全量工具箱名
+func TestGetToolBoxNamesByIDsAuthz(t *testing.T) {
+	Convey("工具箱批量取名授权过滤", t, func() {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+		publicCtx := common.SetPublicAPIToCtx(context.Background(), true)
+
+		Convey("只返回有查看权限的工具箱", func() {
+			authService := mocks.NewMockIAuthorizationService(ctrl)
+			toolBoxDB := mocks.NewMockIToolboxDB(ctrl)
+			svc := &ToolServiceImpl{
+				Logger:      logger.DefaultLogger(),
+				ToolBoxDB:   toolBoxDB,
+				AuthService: authService,
+			}
+			authService.EXPECT().GetAccessor(gomock.Any(), "").Return(&interfaces.AuthAccessor{ID: "user-1"}, nil)
+			authService.EXPECT().ResourceListIDs(gomock.Any(), gomock.Any(), interfaces.AuthResourceTypeToolBox,
+				interfaces.AuthOperationTypeView).Return([]string{"box-1"}, nil)
+			toolBoxDB.EXPECT().SelectListByBoxIDs(gomock.Any(), []string{"box-1"}).
+				Return([]*model.ToolboxDB{{BoxID: "box-1", Name: "工具箱一"}}, nil)
+
+			resp, err := svc.GetToolBoxNamesByIDs(publicCtx, []string{"box-1", "box-2"})
+			So(err, ShouldBeNil)
+			So(len(resp.Entries), ShouldEqual, 1)
+			So(resp.Entries[0].ID, ShouldEqual, "box-1")
+		})
+
+		Convey("权限集为空时返回空列表且不查库", func() {
+			authService := mocks.NewMockIAuthorizationService(ctrl)
+			svc := &ToolServiceImpl{
+				Logger:      logger.DefaultLogger(),
+				ToolBoxDB:   mocks.NewMockIToolboxDB(ctrl),
+				AuthService: authService,
+			}
+			authService.EXPECT().GetAccessor(gomock.Any(), "").Return(&interfaces.AuthAccessor{ID: "user-1"}, nil)
+			authService.EXPECT().ResourceListIDs(gomock.Any(), gomock.Any(), interfaces.AuthResourceTypeToolBox,
+				interfaces.AuthOperationTypeView).Return(nil, nil)
+
+			resp, err := svc.GetToolBoxNamesByIDs(publicCtx, []string{"box-1"})
+			So(err, ShouldBeNil)
+			So(resp.Entries, ShouldBeEmpty)
+		})
+
+		Convey("内部面不过滤", func() {
+			// authService 不设 EXPECT：内部面若发起判定，gomock 会因非预期调用失败
+			toolBoxDB := mocks.NewMockIToolboxDB(ctrl)
+			svc := &ToolServiceImpl{
+				Logger:      logger.DefaultLogger(),
+				ToolBoxDB:   toolBoxDB,
+				AuthService: mocks.NewMockIAuthorizationService(ctrl),
+			}
+			toolBoxDB.EXPECT().SelectListByBoxIDs(gomock.Any(), []string{"box-1"}).
+				Return([]*model.ToolboxDB{{BoxID: "box-1", Name: "工具箱一"}}, nil)
+
+			resp, err := svc.GetToolBoxNamesByIDs(context.Background(), []string{"box-1"})
+			So(err, ShouldBeNil)
+			So(len(resp.Entries), ShouldEqual, 1)
+		})
+	})
+}

--- a/adp/execution-factory/operator-integration/server/logics/toolbox/query.go
+++ b/adp/execution-factory/operator-integration/server/logics/toolbox/query.go
@@ -8,16 +8,25 @@ import (
 	"github.com/openbkn-ai/adp/execution-factory/operator-integration/server/infra/errors"
 	"github.com/openbkn-ai/adp/execution-factory/operator-integration/server/interfaces"
 	"github.com/openbkn-ai/adp/execution-factory/operator-integration/server/interfaces/model"
+	"github.com/openbkn-ai/adp/execution-factory/operator-integration/server/logics/auth"
 	"github.com/openbkn-ai/adp/execution-factory/operator-integration/server/utils"
 	"github.com/openbkn-ai/bkn-comm-go/otel/oteltrace"
 )
 
 // GetToolBoxNamesByIDs 按工具箱ID批量取名(轻量只读，复用 SelectListByBoxIDs；不存在的ID略过)
+// 公开面按查看权限过滤：无权限的ID与不存在的ID一样静默略过。
 func (s *ToolServiceImpl) GetToolBoxNamesByIDs(ctx context.Context, ids []string) (resp *interfaces.BatchNamesResp, err error) {
 	ctx, _ = oteltrace.StartInternalSpan(ctx)
 	defer oteltrace.EndSpan(ctx, err)
 	resp = &interfaces.BatchNamesResp{Entries: []*interfaces.NameEntry{}}
 	ids = utils.UniqueStrings(ids)
+	if len(ids) == 0 {
+		return
+	}
+	ids, err = auth.FilterViewableIDs(ctx, s.AuthService, "", ids, interfaces.AuthResourceTypeToolBox)
+	if err != nil {
+		return nil, err
+	}
 	if len(ids) == 0 {
 		return
 	}


### PR DESCRIPTION
# Pull Request

## What Changed

补齐执行工厂公开面剩余的授权门禁（#345 清单中 #348 未覆盖的部分）：

- Skill 索引构建的建/取消/重试三条写接口 —— 类型级 `skill:modify`
- Skill 发布历史读接口 —— 按 `skill_id` 判 `execute`/`public_access`/`view` 三取一
- `POST /mcp/parse/sse` —— 类型级 `mcp:create`
- `/operator/names`、`/tool-box/names`、`/skills/names` —— 按查看权限过滤
- 算子分类新建/编辑/删除 —— 类型级 `operator:create`/`modify`/`delete`（见下方说明，当前为兜底）

---

## Why

- Related Issue: [Issue #345](https://github.com/openbkn-ai/bkn-foundry/issues/345)
- Background: 公开面经 introspect 中间件只校验「令牌有效」，此后不再判定调用方对资源的权限。#348 已处理其中高危三条（`/function/execute`、`/ai_generate/*`），本 PR 处理清单剩余部分。

---

## How

- 关键实现点：
  - 全部判定挂在 `IsPublicAPIFromCtx(ctx)` 之后，沿用服务内既有惯用法，内部面（`internal-v1`、周期调度器、启动期内置分类灌入）行为不变。
  - 索引构建、分类这类没有资源 ID 的端点按类型级（`ResourceIDAll`）判定，口径与 `logics/auth/decision.go` 的 `CheckCreatePermission` 一致。
  - 批量取名新增 `auth.FilterViewableIDs`：无权限的 ID 与不存在的 ID 一样静默略过，而不是整体 403 —— 否则 403 与 200 的差异本身会成为存在性探测信道。判定复用 `ResourceListIDs`，类型级授权（含超管）一次通配即返回 `ResourceIDAll`，不按 ID 逐个回源。
  - 对 issue 清单的一处更正：`POST/PUT/DELETE /operator/category` 实际只注册在 `internal-v1`（`driveradapters/operator_handler.go:78-82` 位于私有块，公开块只有第 125 行的 GET），公开面前缀返回 404，外部访问 `internal-v1` 前缀被 nginx 拦在 404。因此这三条并非公开面缺口，本 PR 的门禁在当前接线下为空转，仅作为将来接到公开面时的兜底。

- Breaking changes：
  - 属收紧行为。零权限账号调用上述写接口将得到 403，`names` 接口返回空列表。issue 已记录「非超管在执行工厂前端权限集恒为空」，故对象级授权页的名称回显在前端权限串对齐前可能为空，需前端侧同步跟进。
  - 按裁决保留开放：`GET /operator/category`（名称字典）与索引构建任务列表/详情（运维计数），二者均不含租户数据，收紧会直接打断非超管前端。

---

## Testing

- [x] Unit tests passed locally
- [ ] Integration tests passed locally
- [x] Verified in test environment

Test notes:

- 单测：新增 7 个测试文件；`go test ./logics/... ./driveradapters/...` 全绿。门禁用例均不给仓储 mock 设 EXPECT，门禁被删即因非预期调用失败。（`tests/local` 的两条失败为预存 fixture 缺失，自 #111 起即如此，与本 PR 无关。）
- 测试服 14.103.77.23 实测（overlay 镜像换二进制热替，pod 正常、零 panic）：

  | 用例 | 零权限账号 | 超管 |
  |---|---|---|
  | `POST /skills/index/build` | 403 `CommonOperationForbidden` | 200，任务 `completed` 1/1 |
  | `GET /skills/index/build`（保持开放） | 200 | — |
  | `POST /mcp/parse/sse` | 403 `CommonAddForbidden` | 504 `MCPServerNotAccessible`（已过门禁） |
  | `GET /skills/:id/history` | 403 | 200 |
  | `POST /skills/names` | `{"entries":[]}` | 返回名称 |
  | `POST /tool-box/names` | `{"entries":[]}` | 返回名称 |
  | `GET /operator/category`（保持开放） | 200 | 200 |

- 内部面回归：集群内直连 `internal-v1/operator/category` 写操作，无 token 仍 200，服务间调用未被打断。

---

## Risk & Rollback

- 潜在风险：前端权限串与 bkn-safe 资源类型未对齐前，非超管在相关页面会看到 403 或空列表。
- 回滚方案：改动集中在 logics 层的判定分支，`git revert` 即可；无数据库迁移、无配置变更。

---

## Additional Notes

- 关联：#326（沙箱观测接口同类问题，已由 #339 修复四条）、#348（本 issue 高危三条）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
