### PR TITLE
fix(ontology-query): 修复 MCP 行动类执行必失败与参数丢失

### DIFF
--- a/adp/bkn/ontology-query/server/drivenadapters/agent_operator/agent_operator_access.go
+++ b/adp/bkn/ontology-query/server/drivenadapters/agent_operator/agent_operator_access.go
@@ -11,6 +11,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"strings"
 	"sync"
 	"time"
 
@@ -179,7 +180,7 @@ func (aoa *agentOperatorAccess) ExecuteMCP(ctx context.Context, mcpID string,
 	logger.Debugf("post [%s] with headers[%v] finished, request is [%v] response code is [%d], error is [%v], 耗时: %dms",
 		url, headers, execRequest, respCode, err, time.Now().UnixMilli()-start)
 
-	mcpResult := executionResult{}
+	mcpResult := mcpCallToolResult{}
 
 	if err != nil {
 		logger.Errorf("MCP execution request failed: %v", err)
@@ -211,16 +212,55 @@ func (aoa *agentOperatorAccess) ExecuteMCP(ctx context.Context, mcpID string,
 		return mcpResult, err
 	}
 
-	// status_code 在100-300间才算成功
-	if http.StatusContinue <= mcpResult.StatusCode &&
-		mcpResult.StatusCode < http.StatusMultipleChoices {
-		return mcpResult.Body, nil
-	} else {
-		resByte, err := json.Marshal(mcpResult)
-		if err != nil {
-			logger.Errorf("marshal MCP result failed: %v\n", err)
-			return mcpResult, err
-		}
-		return nil, fmt.Errorf("execute MCP failed: %v", string(resByte))
+	// MCP 协议以 is_error 表达工具自身的失败，不存在 HTTP status_code
+	if mcpResult.IsError {
+		return nil, fmt.Errorf("execute MCP failed: %v", mcpResult.normalize())
 	}
+
+	return mcpResult.normalize(), nil
+}
+
+// mcpCallToolResult 对应执行工厂 MCP 代理的返回结构（POST /mcp/proxy/{mcp_id}/tool/call）：
+// {"content":[{"type":"text","text":"..."}],"is_error":false}
+// 与 tool-box 代理的 executionResult{status_code,body} 不同，不可混用。
+type mcpCallToolResult struct {
+	Content []map[string]any `json:"content"`
+	IsError bool             `json:"is_error"`
+}
+
+// normalize 把 MCP content 块压成便于下游消费的结果。
+//
+// 结果恒为 JSON 对象：执行记录落在 OpenSearch 的 results.result 字段上，该字段已按 object
+// 映射（tool 类型返回的是 HTTP body 对象），返回裸标量会触发 mapper_parsing_exception 导致
+// 整条执行记录写不进去。同理，同一字段名在不同执行间必须保持同一类型，故按内容形态分键：
+//   - 全 text 块且拼接后是 JSON 对象：直接返回该对象
+//   - 全 text 块且拼接后是 JSON 数组：{"items": [...]}
+//   - 其余全 text 块（纯文本或 JSON 标量）：{"text": "..."}
+//   - 含非 text 块（图片、资源等）：{"content": [...]}
+func (r mcpCallToolResult) normalize() map[string]any {
+	texts := make([]string, 0, len(r.Content))
+	for _, item := range r.Content {
+		text, ok := item["text"].(string)
+		if !ok || item["type"] != "text" {
+			return map[string]any{"content": r.Content}
+		}
+		texts = append(texts, text)
+	}
+
+	if len(texts) == 0 {
+		return map[string]any{"content": r.Content}
+	}
+
+	joined := strings.Join(texts, "\n")
+	var parsed any
+	if err := json.Unmarshal([]byte(joined), &parsed); err == nil {
+		switch v := parsed.(type) {
+		case map[string]any:
+			return v
+		case []any:
+			return map[string]any{"items": v}
+		}
+	}
+
+	return map[string]any{"text": joined}
 }

--- a/adp/bkn/ontology-query/server/drivenadapters/agent_operator/mcp_result_test.go
+++ b/adp/bkn/ontology-query/server/drivenadapters/agent_operator/mcp_result_test.go
@@ -1,0 +1,78 @@
+// Copyright openbkn.ai
+// Copyright The kweaver.ai Authors.
+//
+// Licensed under the Apache License, Version 2.0.
+// See the LICENSE file in the project root for details.
+
+package agent_operator
+
+import (
+	"testing"
+
+	. "github.com/smartystreets/goconvey/convey"
+)
+
+func Test_mcpCallToolResult_normalize(t *testing.T) {
+	Convey("Test mcpCallToolResult normalize", t, func() {
+		Convey("单个 text 块内容为 JSON 对象时直接返回该对象", func() {
+			r := mcpCallToolResult{
+				Content: []map[string]any{
+					{"type": "text", "text": `{"name":"tester","ok":true}`},
+				},
+			}
+
+			parsed := r.normalize()
+			So(parsed["name"], ShouldEqual, "tester")
+			So(parsed["ok"], ShouldEqual, true)
+		})
+
+		Convey("text 块非 JSON 时拼接文本落在 text 字段", func() {
+			r := mcpCallToolResult{
+				Content: []map[string]any{
+					{"type": "text", "text": "line1"},
+					{"type": "text", "text": "line2"},
+				},
+			}
+
+			So(r.normalize()["text"], ShouldEqual, "line1\nline2")
+		})
+
+		Convey("text 块内容为 JSON 数组时落在 items 字段", func() {
+			r := mcpCallToolResult{
+				Content: []map[string]any{
+					{"type": "text", "text": `[{"id":1},{"id":2}]`},
+				},
+			}
+
+			items, ok := r.normalize()["items"].([]any)
+			So(ok, ShouldBeTrue)
+			So(len(items), ShouldEqual, 2)
+		})
+
+		Convey("text 块内容为 JSON 标量时落在 text 字段", func() {
+			r := mcpCallToolResult{
+				Content: []map[string]any{
+					{"type": "text", "text": "42"},
+				},
+			}
+
+			So(r.normalize()["text"], ShouldEqual, "42")
+		})
+
+		Convey("含非 text 块时原样挂在 content 字段", func() {
+			r := mcpCallToolResult{
+				Content: []map[string]any{
+					{"type": "image", "data": "base64..."},
+				},
+			}
+
+			So(r.normalize()["content"], ShouldResemble, r.Content)
+		})
+
+		Convey("content 为空时结果仍是对象", func() {
+			r := mcpCallToolResult{}
+
+			So(r.normalize()["content"], ShouldResemble, r.Content)
+		})
+	})
+}

--- a/adp/bkn/ontology-query/server/logics/action_scheduler/action_scheduler_service.go
+++ b/adp/bkn/ontology-query/server/logics/action_scheduler/action_scheduler_service.go
@@ -313,6 +313,8 @@ func (s *actionSchedulerService) executeAsync(execution *interfaces.ActionExecut
 		case interfaces.ActionSourceTypeTool:
 			result, execErr = ExecuteTool(ctx, s.aoAccess, actionType, params)
 		case interfaces.ActionSourceTypeMCP:
+			// MCP 工具自带入参 schema，未在行动类声明的 dynamic_params 也要透传
+			params = buildMCPParameters(params, req.DynamicParams)
 			result, execErr = ExecuteMCP(ctx, s.aoAccess, actionType, params)
 		default:
 			execErr = fmt.Errorf("unsupported action source type: %s", actionType.ActionSource.Type)

--- a/adp/bkn/ontology-query/server/logics/action_scheduler/executor_test.go
+++ b/adp/bkn/ontology-query/server/logics/action_scheduler/executor_test.go
@@ -427,3 +427,35 @@ func Test_MCPExecutionRequest(t *testing.T) {
 		})
 	})
 }
+
+func Test_buildMCPParameters(t *testing.T) {
+	Convey("Test buildMCPParameters", t, func() {
+		Convey("行动类未声明参数时 dynamic_params 直通", func() {
+			merged := buildMCPParameters(map[string]any{}, map[string]any{
+				"resource_id": "res_001",
+				"limit":       10,
+			})
+
+			So(len(merged), ShouldEqual, 2)
+			So(merged["resource_id"], ShouldEqual, "res_001")
+			So(merged["limit"], ShouldEqual, 10)
+		})
+
+		Convey("行动类声明的参数覆盖同名 dynamic_params", func() {
+			merged := buildMCPParameters(
+				map[string]any{"city": "上海"},
+				map[string]any{"city": "北京", "limit": 5},
+			)
+
+			So(merged["city"], ShouldEqual, "上海")
+			So(merged["limit"], ShouldEqual, 5)
+		})
+
+		Convey("两侧均为空时返回空 map 而非 nil", func() {
+			merged := buildMCPParameters(nil, nil)
+
+			So(merged, ShouldNotBeNil)
+			So(len(merged), ShouldEqual, 0)
+		})
+	})
+}

--- a/adp/bkn/ontology-query/server/logics/action_scheduler/mcp_executor.go
+++ b/adp/bkn/ontology-query/server/logics/action_scheduler/mcp_executor.go
@@ -33,19 +33,17 @@ func ExecuteMCP(ctx context.Context, aoAccess interfaces.AgentOperatorAccess, ac
 		toolName = source.ToolID
 	}
 
-	// Build MCP execution request using ActionType.Parameters configuration
-	mcpParams := buildMCPParameters(actionType.Parameters, params)
-
+	// params 由调用方经 buildExecutionParams + buildMCPParameters 组装好，此处直接使用
 	mcpRequest := interfaces.MCPExecutionRequest{
 		McpID:      source.McpID,
 		ToolName:   toolName,
-		Parameters: mcpParams,
+		Parameters: params,
 		Timeout:    mcpExecutionTimeoutSeconds,
 	}
 
 	mcpID := source.McpID
 
-	logger.Debugf("Executing MCP: mcp_id=%s, tool_name=%s, params=%+v", mcpID, toolName, mcpParams)
+	logger.Debugf("Executing MCP: mcp_id=%s, tool_name=%s, params=%+v", mcpID, toolName, params)
 
 	// Execute through agent-operator-integration MCP endpoint
 	execCtx, cancel := context.WithTimeout(ctx, time.Duration(mcpRequest.Timeout)*time.Second)
@@ -61,15 +59,19 @@ func ExecuteMCP(ctx context.Context, aoAccess interfaces.AgentOperatorAccess, ac
 	return result, nil
 }
 
-// buildMCPParameters builds parameters for MCP execution based on ActionType.Parameters configuration
-// Note: params already contains processed values from buildExecutionParams
-func buildMCPParameters(configParams []interfaces.Parameter, params map[string]any) map[string]any {
-	// If no parameters configured, use params directly (backward compatible)
-	if len(configParams) == 0 {
-		return params
+// buildMCPParameters 合并 MCP 工具的调用参数。
+//
+// MCP 工具的入参 schema 由工具自身声明（get_action_info 直接把 input_schema 暴露为
+// dynamic_params），行动类不必逐项声明 parameters；因此未声明的 dynamic_params 也要透传，
+// 否则 MCP 工具会收到空参数。行动类声明过的参数（const/property/input 映射结果）优先级更高，
+// 同名时覆盖直通值。MCP 不区分 header/query/path/body，全部平铺。
+func buildMCPParameters(params map[string]any, dynamicParams map[string]any) map[string]any {
+	merged := make(map[string]any, len(params)+len(dynamicParams))
+	for k, v := range dynamicParams {
+		merged[k] = v
 	}
-
-	// For MCP, params already contains the processed values from buildExecutionParams
-	// Just return params directly since MCP doesn't distinguish between header/body/query/path
-	return params
+	for k, v := range params {
+		merged[k] = v
+	}
+	return merged
 }


### PR DESCRIPTION
Closes #497

## 问题

行动类 `action_source.type = mcp` 时执行必定失败，且 MCP 工具收到空参数。VM 实测：MCP 调用在执行工厂侧全部 200 成功，ontology-query 却把结果判成失败。

## 改动

**1. 响应结构（[agent_operator_access.go](../blob/fix/497-mcp-action-execution/adp/bkn/ontology-query/server/drivenadapters/agent_operator/agent_operator_access.go)）**

`ExecuteMCP` 原先把 MCP 代理响应塞进 `executionResult{status_code, body}` —— 那是 tool-box 代理的结构。MCP 代理返回 `{content, is_error}`，`status_code` 恒为 0，永远落进失败分支。

新增 `mcpCallToolResult`，以 `is_error` 判成败；`normalize()` 把 content 块收敛为结果，**恒返回 map**：JSON 对象原样返回、JSON 数组进 `items`、纯文本/JSON 标量进 `text`、含非 text 块进 `content`。

恒返回 map 是必要的：执行记录的 `results.result` 在 OpenSearch 中已按 object 映射（tool 类型返回的是 HTTP body 对象），写入裸标量会触发 `mapper_parsing_exception`，整条执行记录写不进去、状态停在 running。分键则是避免同名字段在不同执行间类型冲突。

**2. 参数合并（[mcp_executor.go](../blob/fix/497-mcp-action-execution/adp/bkn/ontology-query/server/logics/action_scheduler/mcp_executor.go) / [action_scheduler_service.go](../blob/fix/497-mcp-action-execution/adp/bkn/ontology-query/server/logics/action_scheduler/action_scheduler_service.go)）**

`buildMCPParameters` 原先是空壳，无论是否声明都原样返回 `params`，于是行动类未声明 `parameters` 时 MCP 收到 `{}`。改为两路合并：`dynamic_params` 铺底直通，行动类声明的参数（const/property/input 映射结果）覆盖同名键。

合并点放在调度器 switch 的 MCP 分支内并回写 `params`，使执行记录里的 `results[].parameters` 等于真正发出去的那份。tool 分支不变。

## 测试

- 新增 `Test_buildMCPParameters`（直通 / 覆盖 / 双空）
- 新增 `Test_mcpCallToolResult_normalize`（对象 / 数组 / 文本 / 标量 / 非 text 块 / 空）
- ontology-query 全量单测通过

## 环境验证

两台均已部署实测。

VM 10.211.55.4（`get_kn_detail`，行动类 `parameters` 留空，仅传 `dynamic_params`）：

```
completed  success 1  failed 0
params sent: {"kn_id":"worldcup_vega_catalog_bkn","detail_level":"summary","response_format":"json"}
result: {"object_types":[{"data_properties":[{"name":"key_id","type":"integer"},...
```

测试服 14.103.77.23（既有行动类「接入MCP」/ `describe_resource`，参数声明为 `value_from=input`）：

```
completed  success 1  failed 0
params sent: {"resource_id":"d9jnkgj2gev65o6dgjj0","response_format":"json"}
result: {"columns":[{"name":"id","type":"integer"},...],"connector_type":"mysql",...
```

验证用的临时行动类已从 MariaDB 与 OpenSearch 双边清理。

## 影响范围

仅 MCP 行动执行路径。tool 类型执行、MCP 超时控制、执行工厂侧代理实现均未改动。

🤖 Generated with [Claude Code](https://claude.com/claude-code)