### PR TITLE
ci(release): 版本冻结提交触发全量构建，并加分支/VERSION 一致性护栏

### DIFF
--- a/.github/workflows/release-adp-agent-retrieval.yml
+++ b/.github/workflows/release-adp-agent-retrieval.yml
@@ -9,6 +9,8 @@ on:
       - 'adp/context-loader/agent-retrieval/**'
       - '.github/workflows/release-adp-agent-retrieval.yml'
       - '.github/workflows/reusable-*.yml'
+      # 版本冻结提交（release/<x.y.z> 分支）触发全量重建
+      - 'VERSION'
   workflow_dispatch:
     inputs:
       publish:

--- a/.github/workflows/release-adp-bkn-backend.yml
+++ b/.github/workflows/release-adp-bkn-backend.yml
@@ -9,6 +9,8 @@ on:
       - 'adp/bkn/bkn-backend/**'
       - '.github/workflows/release-adp-bkn-backend.yml'
       - '.github/workflows/reusable-*.yml'
+      # 版本冻结提交（release/<x.y.z> 分支）触发全量重建
+      - 'VERSION'
   workflow_dispatch:
     inputs:
       publish:

--- a/.github/workflows/release-adp-bkn-safe.yml
+++ b/.github/workflows/release-adp-bkn-safe.yml
@@ -12,6 +12,8 @@ on:
       - 'bkn-safe/**'
       - '.github/workflows/release-adp-bkn-safe.yml'
       - '.github/workflows/reusable-*.yml'
+      # 版本冻结提交（release/<x.y.z> 分支）触发全量重建
+      - 'VERSION'
   workflow_dispatch:
     inputs:
       publish:

--- a/.github/workflows/release-adp-ontology-query.yml
+++ b/.github/workflows/release-adp-ontology-query.yml
@@ -9,6 +9,8 @@ on:
       - 'adp/bkn/ontology-query/**'
       - '.github/workflows/release-adp-ontology-query.yml'
       - '.github/workflows/reusable-*.yml'
+      # 版本冻结提交（release/<x.y.z> 分支）触发全量重建
+      - 'VERSION'
   workflow_dispatch:
     inputs:
       publish:

--- a/.github/workflows/release-adp-operator-integration.yml
+++ b/.github/workflows/release-adp-operator-integration.yml
@@ -9,6 +9,8 @@ on:
       - 'adp/execution-factory/operator-integration/**'
       - '.github/workflows/release-adp-operator-integration.yml'
       - '.github/workflows/reusable-*.yml'
+      # 版本冻结提交（release/<x.y.z> 分支）触发全量重建
+      - 'VERSION'
   workflow_dispatch:
     inputs:
       publish:

--- a/.github/workflows/release-adp-vega-backend.yml
+++ b/.github/workflows/release-adp-vega-backend.yml
@@ -11,6 +11,8 @@ on:
       - 'adp/vega/vega-backend/**'
       - '.github/workflows/release-adp-vega-backend.yml'
       - '.github/workflows/reusable-*.yml'
+      # 版本冻结提交（release/<x.y.z> 分支）触发全量重建
+      - 'VERSION'
   workflow_dispatch:
     inputs:
       publish:

--- a/.github/workflows/release-bkn-trace-agent-observability.yml
+++ b/.github/workflows/release-bkn-trace-agent-observability.yml
@@ -9,6 +9,8 @@ on:
       - 'bkn-trace/agent-observability/**'
       - '.github/workflows/release-bkn-trace-agent-observability.yml'
       - '.github/workflows/reusable-*.yml'
+      # 版本冻结提交（release/<x.y.z> 分支）触发全量重建
+      - 'VERSION'
   workflow_dispatch:
     inputs:
       publish:

--- a/.github/workflows/release-bkn-trace-otelcol.yml
+++ b/.github/workflows/release-bkn-trace-otelcol.yml
@@ -12,6 +12,8 @@ on:
       - 'bkn-trace/otelcol-contribute-chart/**'
       - '.github/workflows/release-bkn-trace-otelcol.yml'
       - '.github/workflows/reusable-*.yml'
+      # 版本冻结提交（release/<x.y.z> 分支）触发全量重建
+      - 'VERSION'
   workflow_dispatch:
     inputs:
       publish:

--- a/.github/workflows/release-data-migrator.yml
+++ b/.github/workflows/release-data-migrator.yml
@@ -10,6 +10,8 @@ on:
       - '**/migrations/**'                          # rebuild when any service's SQL changes
       - '.github/workflows/release-data-migrator.yml'
       - '.github/workflows/reusable-*.yml'
+      # 版本冻结提交（release/<x.y.z> 分支）触发全量重建
+      - 'VERSION'
   workflow_dispatch:
     inputs:
       publish:

--- a/.github/workflows/release-infra-bkn-agent.yml
+++ b/.github/workflows/release-infra-bkn-agent.yml
@@ -14,6 +14,8 @@ on:
       - 'infra/bkn-agent/**'
       - '.github/workflows/release-infra-bkn-agent.yml'
       - '.github/workflows/reusable-*.yml'
+      # 版本冻结提交（release/<x.y.z> 分支）触发全量重建
+      - 'VERSION'
   workflow_dispatch:
     inputs:
       publish:

--- a/.github/workflows/release-infra-mf-model-api.yml
+++ b/.github/workflows/release-infra-mf-model-api.yml
@@ -15,6 +15,8 @@ on:
       - 'infra/mf-model-api/**'
       - '.github/workflows/release-infra-mf-model-api.yml'
       - '.github/workflows/reusable-*.yml'
+      # 版本冻结提交（release/<x.y.z> 分支）触发全量重建
+      - 'VERSION'
   workflow_dispatch:
     inputs:
       publish:

--- a/.github/workflows/release-infra-mf-model-manager.yml
+++ b/.github/workflows/release-infra-mf-model-manager.yml
@@ -13,6 +13,8 @@ on:
       - 'infra/mf-model-manager/**'
       - '.github/workflows/release-infra-mf-model-manager.yml'
       - '.github/workflows/reusable-*.yml'
+      # 版本冻结提交（release/<x.y.z> 分支）触发全量重建
+      - 'VERSION'
   workflow_dispatch:
     inputs:
       publish:

--- a/.github/workflows/release-infra-oss-gateway.yml
+++ b/.github/workflows/release-infra-oss-gateway.yml
@@ -9,6 +9,8 @@ on:
       - 'infra/oss-gateway-backend/**'
       - '.github/workflows/release-infra-oss-gateway.yml'
       - '.github/workflows/reusable-*.yml'
+      # 版本冻结提交（release/<x.y.z> 分支）触发全量重建
+      - 'VERSION'
   workflow_dispatch:
     inputs:
       publish:

--- a/.github/workflows/release-infra-sandbox.yml
+++ b/.github/workflows/release-infra-sandbox.yml
@@ -14,6 +14,8 @@ on:
       - 'infra/sandbox/**'
       - '.github/workflows/release-infra-sandbox.yml'
       - '.github/workflows/reusable-*.yml'
+      # 版本冻结提交（release/<x.y.z> 分支）触发全量重建
+      - 'VERSION'
   workflow_dispatch:
     inputs:
       publish:

--- a/.github/workflows/release-mariadb.yml
+++ b/.github/workflows/release-mariadb.yml
@@ -12,6 +12,8 @@ on:
       - 'deploy/charts/mariadb/**'
       - '.github/workflows/release-mariadb.yml'
       - '.github/workflows/reusable-*.yml'
+      # 版本冻结提交（release/<x.y.z> 分支）触发全量重建
+      - 'VERSION'
   workflow_dispatch:
     inputs:
       publish:

--- a/.github/workflows/reusable-test.yml
+++ b/.github/workflows/reusable-test.yml
@@ -59,6 +59,15 @@ jobs:
             # clean, immutable image/chart set across all services.
             VERSION="${REF_NAME#v}"
           elif [[ "$REF_NAME" == release/* ]]; then
+            # release/<x.y.z> 分支发布裸版本号（无分支后缀），会覆盖同名制品。
+            # 因此分支名必须与根 VERSION 一致：分支刚从 main 拉出、版本冻结提交
+            # 尚未落地时，VERSION 还是上一个版本，此时构建会覆盖已发布的制品。
+            BRANCH_VERSION="${REF_NAME#release/}"
+            if [[ "$BRANCH_VERSION" != "$BASE_VERSION" ]]; then
+              echo "::error::分支 $REF_NAME 与根 VERSION($BASE_VERSION) 不一致，拒绝构建：" \
+                   "裸版本号会覆盖已发布的 $BASE_VERSION 制品。请先提交版本冻结（VERSION -> $BRANCH_VERSION）。"
+              exit 1
+            fi
             VERSION="$BASE_VERSION"
           else
             SANITIZED_BRANCH="$(echo "$REF_NAME" | tr '[:upper:]' '[:lower:]' | sed -E 's#[^0-9a-zA-Z.-]+#-#g; s#-+#-#g; s#^[.-]+##; s#[.-]+$##')"


### PR DESCRIPTION
## 问题

`release/<x.y.z>` 分支拉出来后，版本冻结提交只改根 `VERSION`（+ 发布锁文件），而各 release workflow 的 `push.paths` 只匹配自己的服务目录、自身文件和 `reusable-*.yml`，两者都不在里面 —— 结果一个构建都不触发。

0.1.2 就是这么漏的：`release/0.1.2` 分支上零 workflow run，GHCR 里没有任何 `0.1.2` 制品（已手工 `workflow_dispatch` 补出）。

## 改动

1. **15 个参与版本化发布的 release workflow**：`push.paths` 增加 `'VERSION'`，由版本冻结提交触发全量重建。
   - 不参与的两个：`release-deploy-redis`（第三方镜像搬运，本来就没有 tag 触发）、`release-infra-model-factory-base`（版本固定 `v2`，与产品版本无关）。
2. **`reusable-test.yml` 加一致性护栏**：`release/<x.y.z>` 分支解析出的是**裸版本号**，推上去会覆盖同名制品。现在校验分支名后缀与根 `VERSION` 必须一致，否则直接失败。

## 为什么不用 `create` 事件触发

分支刚从 main 拉出来的那一刻，`VERSION` 还是**上一个版本**（`release/0.1.2` 创建时 VERSION 仍为 `0.1.1`）。此时触发会以裸 `0.1.1` 构建并**覆盖已发布的 0.1.1 镜像和 chart** —— 静默的制品污染。正确的触发点是版本冻结提交落地那一刻。

附带：`create` 事件也不满足现有发布判断 `github.event_name == 'push'`，走这条路还得再改 15 处 publish 条件。

## 护栏挡住的场景

分支建好但冻结提交没落地时，若有人手工 dispatch 或误触发，构建会失败并提示 `请先提交版本冻结`，而不是覆盖上一个已发布版本。

## 副作用

任何分支改动 `VERSION` 都会点着全部 15 个 release workflow。非 release 分支产出的是带分支后缀的预发布版本，不覆盖任何正式制品；`VERSION` 极少改动，可接受。

本 PR 自身改了 `reusable-test.yml`，按现有 paths 规则会触发全部 15 个 release workflow 跑一轮预发布构建 —— 这是改动 `reusable-*.yml` 的既有行为，非本次引入。

## 验证

- 全部 workflow YAML 解析通过
- 未新增文件，工作流命名规范不受影响

🤖 Generated with [Claude Code](https://claude.com/claude-code)