### PR TITLE
fix(ci): 统一 release 分支版本号格式

### DIFF
--- a/.github/workflows/reusable-test.yml
+++ b/.github/workflows/reusable-test.yml
@@ -59,7 +59,10 @@ jobs:
             # clean, immutable image/chart set across all services.
             VERSION="${REF_NAME#v}"
           elif [[ "$REF_NAME" == release/* ]]; then
-            VERSION="$BASE_VERSION"
+            # Release branches use a stable, Helm-compatible version:
+            # release/0.1.2 -> 0.1.2-release.
+            RELEASE_VERSION="${REF_NAME#release/}"
+            VERSION="${RELEASE_VERSION}-release"
           else
             SANITIZED_BRANCH="$(echo "$REF_NAME" | tr '[:upper:]' '[:lower:]' | sed -E 's#[^0-9a-zA-Z.-]+#-#g; s#-+#-#g; s#^[.-]+##; s#[.-]+$##')"
             # Embed the commit time (Asia/Shanghai, fixed-width YYYYMMDDHHMMSS) so the

--- a/deploy/release-manifests/0.1.2/bkn-foundry.yaml
+++ b/deploy/release-manifests/0.1.2/bkn-foundry.yaml
@@ -12,50 +12,50 @@ source:
 releases:
   core-data-migrator:
     chart: core-data-migrator
-    version: 0.1.2
+    version: 0.1.2-release
     stage: pre
   mf-model-manager:
     chart: mf-model-manager
-    version: 0.1.2
+    version: 0.1.2-release
   mf-model-api:
     chart: mf-model-api
-    version: 0.1.2
+    version: 0.1.2-release
   oss-gateway-backend:
     chart: oss-gateway-backend
-    version: 0.1.2
+    version: 0.1.2-release
   sandbox:
     chart: sandbox
-    version: 0.1.2
+    version: 0.1.2-release
   bkn-backend:
     chart: bkn-backend
-    version: 0.1.2
+    version: 0.1.2-release
   ontology-query:
     chart: ontology-query
-    version: 0.1.2
+    version: 0.1.2-release
   vega-backend:
     chart: vega-backend
-    version: 0.1.2
+    version: 0.1.2-release
   kafka-connect:
     chart: kafka-connect
-    version: 0.1.2
+    version: 0.1.2-release
   agent-operator-integration:
     chart: agent-operator-integration
-    version: 0.1.2
+    version: 0.1.2-release
   agent-retrieval:
     chart: agent-retrieval
-    version: 0.1.2
+    version: 0.1.2-release
   bkn-agent:
     chart: bkn-agent
-    version: 0.1.2
+    version: 0.1.2-release
   agent-observability:
     chart: agent-observability
-    version: 0.1.2
+    version: 0.1.2-release
   otelcol-contrib:
     chart: otelcol-contrib
-    version: 0.1.2
+    version: 0.1.2-release
   bkn-safe:
     chart: bkn-safe
-    version: 0.1.2
+    version: 0.1.2-release
   bkn-studio:
     chart: bkn-studio
-    version: 0.1.2
+    version: 0.1.2-release


### PR DESCRIPTION
# Pull Request

## 变更内容

- [x] CI/CD 版本处理
- [x] Release Manifest
- [ ] 其他模块

统一 release 分支的版本号处理：

- `release/0.1.2` → `0.1.2-release`
- `release/0.1.3` → `0.1.3-release`

同时更新 `deploy/release-manifests/0.1.2/bkn-foundry.yaml`，将所有 Chart 版本统一为 `0.1.2-release`。

---

## 变更原因

之前 release 分支使用的版本格式不符合 Helm SemVer 要求，可能导致 `helm lint` 和 `helm package` 失败。

---

## 实现方式

- 修改 `.github/workflows/reusable-test.yml`。
- 从 `release/*` 分支名中提取版本号。
- 在版本号后追加 `-release`。
- 更新 `0.1.2` release manifest 中所有 Chart 的版本引用。
- 保留 VersionSet 顶层产品版本 `0.1.2` 不变。

---

## 测试

- [ ] 单元测试
- [ ] 集成测试
- [ ] 测试环境验证

验证记录：

- `release/0.1.2` 可解析为 `0.1.2-release`。
- `release/0.1.3` 可解析为 `0.1.3-release`。
- 使用 `helm lint` 验证 Chart 版本格式。
- 使用 `helm package` 验证 Chart 可以成功打包。

---

## 风险与回滚

- 潜在风险：

  使用旧 release 分支版本号的部署配置需要同步更新版本引用。

- 回滚方案：

  回滚本次提交，恢复原有 release 分支版本处理逻辑和 manifest 配置。

---

## 补充说明

- Tag 构建逻辑保持不变：`v0.1.2` → `0.1.2`。
- 普通分支仍使用原有的时间戳和 SHA 预发布版本格式。