### PR TITLE
fix(ontology-query): preserve metric fixed group by

### DIFF
--- a/adp/bkn/ontology-query/server/logics/metric/metric_query_service.go
+++ b/adp/bkn/ontology-query/server/logics/metric/metric_query_service.go
@@ -425,7 +425,8 @@ type metricGroupByDimension struct {
 }
 
 // metricGroupByDimensions resolves definition and request dimensions to resource fields.
-// When request analysis_dimensions are present, only requested definition dimensions are kept in request order.
+// calculation_formula.group_by is the fixed grouping baseline; request analysis_dimensions append valid drill-down
+// dimensions in request order.
 // excludedResourceField prevents trend queries from grouping the time field twice, including through property aliases.
 func metricGroupByDimensions(def *interfaces.MetricDefinition, query *interfaces.MetricQueryRequest,
 	propMap map[string]*cond.DataProperty, excludedResourceField string) ([]metricGroupByDimension, error) {
@@ -465,11 +466,12 @@ func metricGroupByDimensions(def *interfaces.MetricDefinition, query *interfaces
 		addDefined(ad.Name)
 	}
 
-	var propertyNames []string
-	if query == nil || len(query.AnalysisDimensions) == 0 {
-		propertyNames = defaultOrdered
-	} else {
-		seen := make(map[string]struct{})
+	propertyNames := append([]string(nil), defaultOrdered...)
+	seen := make(map[string]struct{}, len(propertyNames))
+	for _, p := range propertyNames {
+		seen[p] = struct{}{}
+	}
+	if query != nil && len(query.AnalysisDimensions) > 0 {
 		for _, a := range query.AnalysisDimensions {
 			p := strings.TrimSpace(a)
 			if p == "" {
@@ -487,6 +489,7 @@ func metricGroupByDimensions(def *interfaces.MetricDefinition, query *interfaces
 	}
 
 	out := make([]metricGroupByDimension, 0, len(propertyNames))
+	seenResourceFields := make(map[string]struct{}, len(propertyNames))
 	for _, p := range propertyNames {
 		res, err := mapDataPropertyToResourceField(p, propMap)
 		if err != nil {
@@ -495,6 +498,10 @@ func metricGroupByDimensions(def *interfaces.MetricDefinition, query *interfaces
 		if res == excludedResourceField {
 			continue
 		}
+		if _, dup := seenResourceFields[res]; dup {
+			continue
+		}
+		seenResourceFields[res] = struct{}{}
 		out = append(out, metricGroupByDimension{PropertyName: p, ResourceFieldName: res})
 	}
 	return out, nil

--- a/adp/bkn/ontology-query/server/logics/metric/metric_query_service_test.go
+++ b/adp/bkn/ontology-query/server/logics/metric/metric_query_service_test.go
@@ -54,16 +54,18 @@ func Test_metricGroupByDimensions_analysisDimensions(t *testing.T) {
 			So(dims[0].ResourceFieldName, ShouldEqual, "region_res")
 		})
 
-		Convey("Request analysis_dimensions intersects with definition and preserves query order\n", func() {
+		Convey("Request analysis_dimensions appends valid dimensions after fixed group_by and preserves query order\n", func() {
 			dims, err := metricGroupByDimensions(def, &interfaces.MetricQueryRequest{
 				AnalysisDimensions: []string{"item_code", "warehouse_id", "unknown"},
 			}, propMap, "")
 			So(err, ShouldBeNil)
-			So(len(dims), ShouldEqual, 2)
-			So(dims[0].PropertyName, ShouldEqual, "item_code")
-			So(dims[0].ResourceFieldName, ShouldEqual, "item_code_res")
-			So(dims[1].PropertyName, ShouldEqual, "warehouse_id")
-			So(dims[1].ResourceFieldName, ShouldEqual, "warehouse_id_res")
+			So(len(dims), ShouldEqual, 3)
+			So(dims[0].PropertyName, ShouldEqual, "region")
+			So(dims[0].ResourceFieldName, ShouldEqual, "region_res")
+			So(dims[1].PropertyName, ShouldEqual, "item_code")
+			So(dims[1].ResourceFieldName, ShouldEqual, "item_code_res")
+			So(dims[2].PropertyName, ShouldEqual, "warehouse_id")
+			So(dims[2].ResourceFieldName, ShouldEqual, "warehouse_id_res")
 		})
 
 		Convey("Non-trend request keeps time_dimension property as an analysis dimension\n", func() {
@@ -71,11 +73,13 @@ func Test_metricGroupByDimensions_analysisDimensions(t *testing.T) {
 				AnalysisDimensions: []string{"evt_time", "warehouse_id"},
 			}, propMap, "")
 			So(err, ShouldBeNil)
-			So(len(dims), ShouldEqual, 2)
-			So(dims[0].PropertyName, ShouldEqual, "evt_time")
-			So(dims[0].ResourceFieldName, ShouldEqual, "evt_time_res")
-			So(dims[1].PropertyName, ShouldEqual, "warehouse_id")
-			So(dims[1].ResourceFieldName, ShouldEqual, "warehouse_id_res")
+			So(len(dims), ShouldEqual, 3)
+			So(dims[0].PropertyName, ShouldEqual, "region")
+			So(dims[0].ResourceFieldName, ShouldEqual, "region_res")
+			So(dims[1].PropertyName, ShouldEqual, "evt_time")
+			So(dims[1].ResourceFieldName, ShouldEqual, "evt_time_res")
+			So(dims[2].PropertyName, ShouldEqual, "warehouse_id")
+			So(dims[2].ResourceFieldName, ShouldEqual, "warehouse_id_res")
 		})
 
 		Convey("Trend request excludes aliases mapped to the time resource field\n", func() {
@@ -83,9 +87,11 @@ func Test_metricGroupByDimensions_analysisDimensions(t *testing.T) {
 				AnalysisDimensions: []string{"time_alias", "warehouse_id"},
 			}, propMap, "evt_time_res")
 			So(err, ShouldBeNil)
-			So(len(dims), ShouldEqual, 1)
-			So(dims[0].PropertyName, ShouldEqual, "warehouse_id")
-			So(dims[0].ResourceFieldName, ShouldEqual, "warehouse_id_res")
+			So(len(dims), ShouldEqual, 2)
+			So(dims[0].PropertyName, ShouldEqual, "region")
+			So(dims[0].ResourceFieldName, ShouldEqual, "region_res")
+			So(dims[1].PropertyName, ShouldEqual, "warehouse_id")
+			So(dims[1].ResourceFieldName, ShouldEqual, "warehouse_id_res")
 		})
 
 		Convey("Non-trend request keeps aliases mapped to the time resource field\n", func() {
@@ -93,9 +99,11 @@ func Test_metricGroupByDimensions_analysisDimensions(t *testing.T) {
 				AnalysisDimensions: []string{"time_alias"},
 			}, propMap, "")
 			So(err, ShouldBeNil)
-			So(len(dims), ShouldEqual, 1)
-			So(dims[0].PropertyName, ShouldEqual, "time_alias")
-			So(dims[0].ResourceFieldName, ShouldEqual, "evt_time_res")
+			So(len(dims), ShouldEqual, 2)
+			So(dims[0].PropertyName, ShouldEqual, "region")
+			So(dims[0].ResourceFieldName, ShouldEqual, "region_res")
+			So(dims[1].PropertyName, ShouldEqual, "time_alias")
+			So(dims[1].ResourceFieldName, ShouldEqual, "evt_time_res")
 		})
 	})
 }
@@ -125,6 +133,7 @@ func Test_metricQueryService_buildResourceDataQueryParams_analysisDimensions(t *
 					{Name: "time_alias", Type: dtype.DATATYPE_DATETIME, MappedField: cond.Field{Name: "evt_time_res"}},
 					{Name: "warehouse_id", Type: dtype.DATATYPE_STRING, MappedField: cond.Field{Name: "warehouse_id_res"}},
 					{Name: "item_code", Type: dtype.DATATYPE_STRING, MappedField: cond.Field{Name: "item_code_res"}},
+					{Name: "region", Type: dtype.DATATYPE_STRING, MappedField: cond.Field{Name: "region_res"}},
 				},
 			},
 		}
@@ -153,6 +162,24 @@ func Test_metricQueryService_buildResourceDataQueryParams_analysisDimensions(t *
 		So(params.GroupBy[1]["property"], ShouldEqual, "item_code_res")
 		So(params.GroupBy[2]["property"], ShouldEqual, "evt_time_res")
 		So(params.GroupBy[2]["calendar_interval"], ShouldEqual, "year")
+
+		defFixedGroup := *def
+		defFixedGroup.CalculationFormula = &interfaces.MetricCalculationFormula{
+			Aggregation: interfaces.MetricAggregation{Property: "amount", Aggr: "sum"},
+			GroupBy:     []interfaces.MetricGroupBy{{Property: "region"}},
+		}
+		params, trend, err = svc.buildResourceDataQueryParams(ctx, &defFixedGroup, &interfaces.MetricQueryRequest{
+			AnalysisDimensions: []string{"warehouse_id", "item_code"},
+			Time:               &interfaces.MetricTimeWindow{Start: &start, End: &end, Instant: &instant, Step: &step},
+		}, ot)
+		So(err, ShouldBeNil)
+		So(trend, ShouldNotBeNil)
+		So(len(params.GroupBy), ShouldEqual, 4)
+		So(params.GroupBy[0]["property"], ShouldEqual, "region_res")
+		So(params.GroupBy[1]["property"], ShouldEqual, "warehouse_id_res")
+		So(params.GroupBy[2]["property"], ShouldEqual, "item_code_res")
+		So(params.GroupBy[3]["property"], ShouldEqual, "evt_time_res")
+		So(params.GroupBy[3]["calendar_interval"], ShouldEqual, "year")
 
 		params, trend, err = svc.buildResourceDataQueryParams(ctx, def, &interfaces.MetricQueryRequest{
 			AnalysisDimensions: []string{"warehouse_id", "time_alias"},


### PR DESCRIPTION
﻿# Pull Request

## What Changed

Brief description of changes:

- [x] Preserve metric definition `calculation_formula.group_by` as the fixed grouping baseline when request `analysis_dimensions` are provided.
- [x] Append valid requested analysis dimensions as drill-down dimensions in request order, while skipping duplicates and invalid dimensions.
- [x] Avoid duplicate resource-field grouping when different object properties map to the same resource field, including time aliases in trend queries.

---

## Why

- Related Issue: Closes #503
- Related Feature: N/A
- Background: Metric queries previously replaced the metric definition's fixed `group_by` with request `analysis_dimensions`, so required grouping dimensions were lost during drill-down queries.

---

## How

- Key implementation points:
  - `metricGroupByDimensions` now starts from fixed definition group_by properties.
  - Request analysis dimensions are appended only if declared in the metric definition and not already present.
  - Resource field de-duplication prevents duplicate Vega/OpenSearch group_by entries.
  - Focused regression tests cover fixed group_by plus analysis dimensions, trend time bucket behavior, aliases, and invalid dimensions.
- Breaking changes (API, config, database, etc.): None.

---

## Testing

- [x] Unit tests passed locally
- [ ] Integration tests passed locally
- [ ] Verified in test environment

Test notes:

- `I18N_MODE_UT=true go test ./logics/metric -count=1`
- `I18N_MODE_UT=true go test $(go list ./... | exclude /mock) -gcflags=all=-l -count=1`
- `make test` was not runnable in this local Windows shell because `make` is not installed; the Go test command above covers the ontology-query packages excluding mocks.

---

## Risk & Rollback

- Potential risks: Low. The change is scoped to metric query group_by construction. Existing fixed group_by-only behavior is preserved, while drill-down dimensions are appended.
- Rollback plan: Revert commit `50641c1b`.

---

## Additional Notes

- Target branch: `release/0.1.2`.
- Untracked local files were intentionally not included in this PR.
