### PR TITLE
test(ontology-query): cover metric group by field dedupe

### DIFF
--- a/adp/bkn/ontology-query/server/logics/metric/metric_query_service_test.go
+++ b/adp/bkn/ontology-query/server/logics/metric/metric_query_service_test.go
@@ -30,6 +30,7 @@ func Test_metricGroupByDimensions_analysisDimensions(t *testing.T) {
 			"warehouse_id": {Name: "warehouse_id", MappedField: cond.Field{Name: "warehouse_id_res"}},
 			"item_code":    {Name: "item_code", MappedField: cond.Field{Name: "item_code_res"}},
 			"region":       {Name: "region", MappedField: cond.Field{Name: "region_res"}},
+			"region_alias": {Name: "region_alias", MappedField: cond.Field{Name: "region_res"}},
 			"evt_time":     {Name: "evt_time", MappedField: cond.Field{Name: "evt_time_res"}},
 			"time_alias":   {Name: "time_alias", MappedField: cond.Field{Name: "evt_time_res"}},
 		}
@@ -41,6 +42,7 @@ func Test_metricGroupByDimensions_analysisDimensions(t *testing.T) {
 			AnalysisDimensions: []interfaces.MetricAnalysisDimension{
 				{Name: "warehouse_id"},
 				{Name: "item_code"},
+				{Name: "region_alias"},
 				{Name: "evt_time"},
 				{Name: "time_alias"},
 			},
@@ -66,6 +68,18 @@ func Test_metricGroupByDimensions_analysisDimensions(t *testing.T) {
 			So(dims[1].ResourceFieldName, ShouldEqual, "item_code_res")
 			So(dims[2].PropertyName, ShouldEqual, "warehouse_id")
 			So(dims[2].ResourceFieldName, ShouldEqual, "warehouse_id_res")
+		})
+
+		Convey("Request analysis_dimensions skips properties mapped to an existing fixed resource field\n", func() {
+			dims, err := metricGroupByDimensions(def, &interfaces.MetricQueryRequest{
+				AnalysisDimensions: []string{"region_alias", "warehouse_id"},
+			}, propMap, "")
+			So(err, ShouldBeNil)
+			So(len(dims), ShouldEqual, 2)
+			So(dims[0].PropertyName, ShouldEqual, "region")
+			So(dims[0].ResourceFieldName, ShouldEqual, "region_res")
+			So(dims[1].PropertyName, ShouldEqual, "warehouse_id")
+			So(dims[1].ResourceFieldName, ShouldEqual, "warehouse_id_res")
 		})
 
 		Convey("Non-trend request keeps time_dimension property as an analysis dimension\n", func() {


### PR DESCRIPTION
﻿# Pull Request

## What Changed

Brief description of changes:

- [x] Add regression coverage for metric group_by resource-field de-duplication.
- [x] Cover the case where fixed `calculation_formula.group_by` and request `analysis_dimensions` map to the same resource field.
- [ ] Docs/doc 1: N/A, test-only follow-up.

---

## Why

- Related Issue: Refs #503
- Related Feature: N/A
- Background: Follow-up to PR #505 review suggestion. The implementation de-duplicates group_by entries by resource field, but the non-trend fixed-group plus analysis-dimension alias path needed direct regression coverage.

---

## How

- Key implementation points:
  - Add `region_alias -> region_res` to the metric group_by unit test fixture.
  - Assert that fixed `region -> region_res` is retained and requested `region_alias -> region_res` is skipped.
- Breaking changes (API, config, database, etc.): None.

---

## Testing

- [x] Unit tests passed locally
- [ ] Integration tests passed locally
- [ ] Verified in test environment

Test notes:

- `I18N_MODE_UT=true go test ./logics/metric -count=1`
- Earlier on the same fix branch: `I18N_MODE_UT=true go test $(go list ./... | exclude /mock) -gcflags=all=-l -count=1`

---

## Risk & Rollback

- Potential risks: Very low. This PR only adds a focused unit test.
- Rollback plan: Revert commit `2e37980e`.

---

## Additional Notes

- Target branch: `release/0.1.2`.
- This PR is a test-only follow-up because #505 was already merged before the review suggestion was addressed.
