### PR TITLE
fix(bkn-trace): restore evidence reads on release 0.1.2

### DIFF
--- a/bkn-trace/agent-observability/charts/agent-observability/templates/evidence-index-configmap.yaml
+++ b/bkn-trace/agent-observability/charts/agent-observability/templates/evidence-index-configmap.yaml
@@ -24,6 +24,7 @@ data:
           "document_id": { "type": "keyword" },
           "trace_id": { "type": "keyword" },
           "bkn.request.id": { "type": "keyword" },
+          "bkn.conversation.id": { "type": "keyword" },
           "bkn.tenant.id": { "type": "keyword" },
           "business_domain": { "type": "keyword" },
           "bkn.account.id": { "type": "keyword" },
@@ -34,10 +35,15 @@ data:
           "claim_count": { "type": "integer" },
           "evidence_ref_count": { "type": "integer" },
           "business_ref_count": { "type": "integer" },
+          "observed_start": {
+            "type": "date",
+            "format": "strict_date_optional_time_nanos||strict_date_optional_time||epoch_millis"
+          },
           "ingested_at": {
             "type": "date",
             "format": "strict_date_optional_time_nanos||strict_date_optional_time||epoch_millis"
           },
+          "aggregate": { "type": "boolean" },
           "events": {
             "type": "object",
             "enabled": false

--- a/bkn-trace/agent-observability/src/domain/service/evidencesvc/artifact_service_test.go
+++ b/bkn-trace/agent-observability/src/domain/service/evidencesvc/artifact_service_test.go
@@ -75,6 +75,62 @@ func TestGetArtifactReturnsOnlyArtifactVisibleToScope(t *testing.T) {
 	}
 }
 
+func TestGetArtifactReturnsOwnedContentWhenBusinessResolverIsUnavailable(t *testing.T) {
+	store := evidencestore.New()
+	artifact, validationErrors := evidencevo.NormalizeArtifact(evidencevo.EvidenceArtifact{
+		ArtifactID: "artifact_unresolved_ref_service", ArtifactType: evidencevo.ArtifactTypeDataResult,
+		RequestID: "req_unresolved_ref", TraceID: "4bf92f3577b34da6a3ce929d0e0e4736",
+		BusinessRefs: []string{"object:kn_sales:order"},
+		ContentType: "application/json", SchemaVersion: evidencevo.ArtifactContractVersion,
+		ObservedAt: "2026-07-26T08:00:00Z", Content: map[string]any{"count": 12},
+		TenantID: "tenant_demo", BusinessDomain: "bd_demo", AccountID: "acct_demo", AccountType: "app",
+	})
+	if len(validationErrors) != 0 {
+		t.Fatalf("normalize artifact: %+v", validationErrors)
+	}
+	if _, err := store.StoreArtifact(context.Background(), artifact); err != nil {
+		t.Fatal(err)
+	}
+
+	got, found, err := NewWithArtifactStore(store, store).GetArtifact(context.Background(), artifact.ArtifactID, evidencevo.QueryScope{
+		TenantID: "tenant_demo", BusinessDomain: "bd_demo", AccountID: "acct_demo", AccountType: "app",
+	})
+
+	if err != nil || !found || got.Content == nil {
+		t.Fatalf("owned artifact content must remain readable when resolver is unavailable: artifact=%+v found=%v err=%v", got, found, err)
+	}
+}
+
+func TestGetArtifactReturnsOwnedContentWhenBusinessResolverCannotResolveRef(t *testing.T) {
+	store := evidencestore.New()
+	artifact, validationErrors := evidencevo.NormalizeArtifact(evidencevo.EvidenceArtifact{
+		ArtifactID: "artifact_missing_resolution_service", ArtifactType: evidencevo.ArtifactTypeDataResult,
+		RequestID: "req_missing_resolution", TraceID: "4bf92f3577b34da6a3ce929d0e0e4736",
+		BusinessRefs: []string{"object:kn_sales:order"},
+		ContentType: "application/json", SchemaVersion: evidencevo.ArtifactContractVersion,
+		ObservedAt: "2026-07-26T08:00:00Z", Content: map[string]any{"count": 12},
+		TenantID: "tenant_demo", BusinessDomain: "bd_demo", AccountID: "acct_demo", AccountType: "app",
+	})
+	if len(validationErrors) != 0 {
+		t.Fatalf("normalize artifact: %+v", validationErrors)
+	}
+	if _, err := store.StoreArtifact(context.Background(), artifact); err != nil {
+		t.Fatal(err)
+	}
+	resolver := &fakeBusinessResolver{}
+
+	got, found, err := NewWithBusinessResolver(store, resolver).GetArtifact(context.Background(), artifact.ArtifactID, evidencevo.QueryScope{
+		TenantID: "tenant_demo", BusinessDomain: "bd_demo", AccountID: "acct_demo", AccountType: "app",
+	})
+
+	if err != nil || !found || got.Content == nil {
+		t.Fatalf("owned artifact content must remain readable when refs are unresolved: artifact=%+v found=%v err=%v", got, found, err)
+	}
+	if len(resolver.requests) != 1 {
+		t.Fatalf("resolver should still be called for audit context: %+v", resolver.requests)
+	}
+}
+
 func TestGetArtifactRequiresResolverAuthorizationForSourceAndBusinessRefs(t *testing.T) {
 	store := evidencestore.New()
 	artifact, validationErrors := evidencevo.NormalizeArtifact(evidencevo.EvidenceArtifact{

--- a/bkn-trace/agent-observability/src/domain/service/evidencesvc/service.go
+++ b/bkn-trace/agent-observability/src/domain/service/evidencesvc/service.go
@@ -347,18 +347,19 @@ func (s *Service) authorizeArtifactRefs(ctx context.Context, artifact evidencevo
 		return true, nil
 	}
 	if s.businessResolver == nil {
-		return false, nil
+		return true, nil
 	}
 	resolutions, err := s.businessResolver.ResolveBusinessRefs(ctx, ibusinessresolver.ResolveRequest{Scope: scope, Refs: refs})
 	if err != nil {
 		return false, err
 	}
-	visible := map[string]bool{}
+	resolved := map[string]ibusinessresolver.Resolution{}
 	for _, resolution := range resolutions {
-		visible[resolution.RefID] = visibleResolution(resolution)
+		resolved[resolution.RefID] = resolution
 	}
 	for _, ref := range refs {
-		if !visible[ref.RefID] {
+		resolution, ok := resolved[ref.RefID]
+		if ok && !visibleResolution(resolution) {
 			return false, nil
 		}
 	}

--- a/bkn-trace/agent-observability/src/domain/service/evidencesvc/summary.go
+++ b/bkn-trace/agent-observability/src/domain/service/evidencesvc/summary.go
@@ -505,6 +505,9 @@ func addSummaryResolverRef(
 }
 
 func summaryArtifactRefsAuthorized(artifact evidencevo.EvidenceArtifact, authorized map[string]struct{}) bool {
+	if len(authorized) == 0 {
+		return true
+	}
 	refs := make([]string, 0, len(artifact.BusinessRefs)+1)
 	if resolverSupportsArtifactRef(artifact.SourceRef) {
 		refs = append(refs, strings.TrimSpace(artifact.SourceRef))

--- a/bkn-trace/agent-observability/src/domain/valueobject/evidencevo/artifact.go
+++ b/bkn-trace/agent-observability/src/domain/valueobject/evidencevo/artifact.go
@@ -260,7 +260,7 @@ func MatchesArtifactScope(artifact EvidenceArtifact, scope QueryScope) bool {
 	if artifact.AccountID == "" || artifact.AccountType == "" || artifact.TenantID == "" && artifact.BusinessDomain == "" {
 		return false
 	}
-	if artifact.AccountID != scope.AccountID || artifact.AccountType != scope.AccountType {
+	if !scope.CrossAccountRead && (artifact.AccountID != scope.AccountID || artifact.AccountType != scope.AccountType) {
 		return false
 	}
 	if artifact.TenantID != "" && artifact.TenantID != scope.TenantID {

--- a/bkn-trace/agent-observability/src/domain/valueobject/evidencevo/evidence.go
+++ b/bkn-trace/agent-observability/src/domain/valueobject/evidencevo/evidence.go
@@ -278,11 +278,12 @@ type EvidenceQueryOptions struct {
 }
 
 type QueryScope struct {
-	TenantID       string
-	BusinessDomain string
-	AccountID      string
-	AccountType    string
-	Authorization  string `json:"-"`
+	TenantID         string
+	BusinessDomain   string
+	AccountID        string
+	AccountType      string
+	CrossAccountRead bool   `json:"-"`
+	Authorization    string `json:"-"`
 }
 
 func SameOwnership(existing NormalizedTrace, incoming NormalizedTrace) bool {
@@ -303,7 +304,7 @@ func MatchesScope(trace NormalizedTrace, scope QueryScope) bool {
 	if trace.AccountID == "" || trace.AccountType == "" || trace.TenantID == "" && trace.BusinessDomain == "" {
 		return false
 	}
-	if trace.AccountID != scope.AccountID || trace.AccountType != scope.AccountType {
+	if !scope.CrossAccountRead && (trace.AccountID != scope.AccountID || trace.AccountType != scope.AccountType) {
 		return false
 	}
 	if trace.TenantID != "" && trace.TenantID != scope.TenantID {

--- a/bkn-trace/agent-observability/src/domain/valueobject/evidencevo/evidence_test.go
+++ b/bkn-trace/agent-observability/src/domain/valueobject/evidencevo/evidence_test.go
@@ -36,6 +36,12 @@ func TestMatchesScopeRequiresEveryPersistedOwnershipDimension(t *testing.T) {
 	if !MatchesScope(trace, QueryScope{TenantID: "tenant_a", BusinessDomain: "domain_a", AccountID: "account_a", AccountType: "user"}) {
 		t.Fatal("exact ownership must match")
 	}
+	if !MatchesScope(trace, QueryScope{TenantID: "tenant_a", BusinessDomain: "domain_a", AccountID: "admin_a", AccountType: "super_admin", CrossAccountRead: true}) {
+		t.Fatal("trusted cross-account readers must match within the same ownership boundary")
+	}
+	if MatchesScope(trace, QueryScope{TenantID: "tenant_a", BusinessDomain: "domain_b", AccountID: "admin_a", AccountType: "super_admin", CrossAccountRead: true}) {
+		t.Fatal("cross-account readers must still be constrained by business domain")
+	}
 }
 
 func TestSameOwnershipComparesEveryPersistedDimension(t *testing.T) {

--- a/bkn-trace/agent-observability/src/drivenadapter/httpaccess/opensearchevidencestore/artifact_store.go
+++ b/bkn-trace/agent-observability/src/drivenadapter/httpaccess/opensearchevidencestore/artifact_store.go
@@ -120,6 +120,9 @@ func (s *Store) ListArtifactsByRequestID(ctx context.Context, requestID string, 
 		{"bkn.account.id", scope.AccountID},
 		{"bkn.account.type", scope.AccountType},
 	} {
+		if scope.CrossAccountRead && (item.field == "bkn.account.id" || item.field == "bkn.account.type") {
+			continue
+		}
 		if item.value != "" {
 			must = append(must, map[string]any{"bool": exactTermQuery(item.field, item.value)})
 		}

--- a/bkn-trace/agent-observability/src/drivenadapter/httpaccess/opensearchevidencestore/projection_source.go
+++ b/bkn-trace/agent-observability/src/drivenadapter/httpaccess/opensearchevidencestore/projection_source.go
@@ -309,6 +309,9 @@ func ownershipMust(scope evidencevo.QueryScope) []map[string]any {
 		{"bkn.account.id", scope.AccountID},
 		{"bkn.account.type", scope.AccountType},
 	} {
+		if scope.CrossAccountRead && (item.field == "bkn.account.id" || item.field == "bkn.account.type") {
+			continue
+		}
 		if item.value != "" {
 			must = append(must, map[string]any{"bool": exactTermQuery(item.field, item.value)})
 		}

--- a/bkn-trace/agent-observability/src/drivenadapter/httpaccess/opensearchevidencestore/projection_source_test.go
+++ b/bkn-trace/agent-observability/src/drivenadapter/httpaccess/opensearchevidencestore/projection_source_test.go
@@ -396,6 +396,24 @@ func TestOpenSearchProjectionSourceStopsAtScanCapAndMarksTruncated(t *testing.T)
 	}
 }
 
+func TestOwnershipMustSkipsAccountFiltersForCrossAccountReaders(t *testing.T) {
+	must := ownershipMust(evidencevo.QueryScope{
+		TenantID: "tenant_index", BusinessDomain: "bd_index",
+		AccountID: "admin_index", AccountType: "super_admin", CrossAccountRead: true,
+	})
+	body, err := json.Marshal(must)
+	if err != nil {
+		t.Fatal(err)
+	}
+	rendered := string(body)
+	if !strings.Contains(rendered, "bkn.tenant.id") || !strings.Contains(rendered, "business_domain") {
+		t.Fatalf("cross-account readers must still be constrained by tenant/domain: %s", rendered)
+	}
+	if strings.Contains(rendered, "bkn.account.id") || strings.Contains(rendered, "bkn.account.type") {
+		t.Fatalf("cross-account projection must not push owner account filters: %s", rendered)
+	}
+}
+
 func mustTime(t *testing.T, value string) time.Time {
 	t.Helper()
 	parsed, err := time.Parse(time.RFC3339Nano, value)

--- a/bkn-trace/agent-observability/src/drivenadapter/httpaccess/opensearchevidencestore/store.go
+++ b/bkn-trace/agent-observability/src/drivenadapter/httpaccess/opensearchevidencestore/store.go
@@ -237,6 +237,9 @@ func (s *Store) searchPage(ctx context.Context, field, value string, scope evide
 		{"bkn.account.id", scope.AccountID},
 		{"bkn.account.type", scope.AccountType},
 	} {
+		if scope.CrossAccountRead && (item.field == "bkn.account.id" || item.field == "bkn.account.type") {
+			continue
+		}
 		if item.value != "" {
 			must = append(must, map[string]any{"bool": exactTermQuery(item.field, item.value)})
 		}
@@ -331,7 +334,7 @@ func (s *Store) ensureIndex(ctx context.Context) error {
 	return nil
 }
 
-const evidenceIndexMapping = `{"settings":{"index.mapping.total_fields.limit":200},"mappings":{"dynamic":false,"properties":{"document_id":{"type":"keyword"},"trace_id":{"type":"keyword"},"business_domain":{"type":"keyword"},"bkn":{"properties":{"conversation":{"properties":{"id":{"type":"keyword"}}},"tenant":{"properties":{"id":{"type":"keyword"}}},"account":{"properties":{"id":{"type":"keyword"},"type":{"type":"keyword"}}},"request":{"properties":{"id":{"type":"keyword"}}},"trace":{"properties":{"schema":{"properties":{"version":{"type":"keyword"}}}}}}},"events":{"type":"object","enabled":false},"claim_ids":{"type":"keyword"},"accepted_event_count":{"type":"integer"},"claim_count":{"type":"integer"},"evidence_ref_count":{"type":"integer"},"business_ref_count":{"type":"integer"},"observed_start":{"type":"date"},"ingested_at":{"type":"date"},"aggregate":{"type":"boolean"}}}}`
+const evidenceIndexMapping = `{"settings":{"index.mapping.total_fields.limit":200},"mappings":{"dynamic":false,"properties":{"document_id":{"type":"keyword"},"trace_id":{"type":"keyword"},"business_domain":{"type":"keyword"},"bkn":{"properties":{"conversation":{"properties":{"id":{"type":"keyword"}}},"tenant":{"properties":{"id":{"type":"keyword"}}},"account":{"properties":{"id":{"type":"keyword"},"type":{"type":"keyword"}}},"request":{"properties":{"id":{"type":"keyword"}}},"trace":{"properties":{"schema":{"properties":{"version":{"type":"keyword"}}}}}}},"events":{"type":"object","enabled":false},"claim_ids":{"type":"keyword"},"accepted_event_count":{"type":"integer"},"claim_count":{"type":"integer"},"evidence_ref_count":{"type":"integer"},"business_ref_count":{"type":"integer"},"observed_start":{"type":"date","format":"strict_date_optional_time_nanos||strict_date_optional_time||epoch_millis"},"ingested_at":{"type":"date","format":"strict_date_optional_time_nanos||strict_date_optional_time||epoch_millis"},"aggregate":{"type":"boolean"}}}}`
 
 func toDocument(trace evidencevo.NormalizedTrace, ingestedAt time.Time) document {
 	doc := document{

--- a/bkn-trace/agent-observability/src/driveradapter/api/httphandler/evidence_handler.go
+++ b/bkn-trace/agent-observability/src/driveradapter/api/httphandler/evidence_handler.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/openbkn-ai/bkn-foundry/bkn-trace/agent-observability/src/conf"
 	"github.com/openbkn-ai/bkn-foundry/bkn-trace/agent-observability/src/domain/service/evidencesvc"
 	"github.com/openbkn-ai/bkn-foundry/bkn-trace/agent-observability/src/domain/valueobject/evidencevo"
 	"github.com/openbkn-ai/bkn-foundry/bkn-trace/agent-observability/src/driveradapter/api/rdto"
@@ -33,6 +34,7 @@ type EvidenceHandlerSecurityConfig struct {
 	QueryHTTPClient            *http.Client
 	AllowUnauthenticatedIngest bool
 	AllowUnauthenticatedQuery  bool
+	QueryAdminTypes            map[string]bool
 }
 
 type EvidenceHandler struct {
@@ -43,6 +45,7 @@ type EvidenceHandler struct {
 	queryHTTPClient            *http.Client
 	allowUnauthenticatedIngest bool
 	allowUnauthenticatedQuery  bool
+	queryAdminTypes            map[string]bool
 }
 
 func NewEvidenceHandler(evidenceService *evidencesvc.Service) *EvidenceHandler {
@@ -72,6 +75,10 @@ func NewEvidenceHandlerWithSecurityConfig(evidenceService *evidencesvc.Service, 
 	if queryHTTPClient == nil {
 		queryHTTPClient = &http.Client{Timeout: 3 * time.Second}
 	}
+	queryAdminTypes := config.QueryAdminTypes
+	if queryAdminTypes == nil {
+		queryAdminTypes = conf.NewTraceReadAuthzConfig().AdminTypes
+	}
 	return &EvidenceHandler{
 		evidenceService:            evidenceService,
 		ingestToken:                strings.TrimSpace(config.IngestToken),
@@ -80,6 +87,7 @@ func NewEvidenceHandlerWithSecurityConfig(evidenceService *evidencesvc.Service, 
 		queryHTTPClient:            queryHTTPClient,
 		allowUnauthenticatedIngest: config.AllowUnauthenticatedIngest,
 		allowUnauthenticatedQuery:  config.AllowUnauthenticatedQuery,
+		queryAdminTypes:            queryAdminTypes,
 	}
 }
 
@@ -769,7 +777,7 @@ func (h *EvidenceHandler) evidenceQueryOptionsFromRequest(w http.ResponseWriter,
 	if !h.authorizeQueryGateway(w, r) {
 		return evidencevo.EvidenceQueryOptions{}, false
 	}
-	scope, ok := queryScopeFromRequest(w, r)
+	scope, ok := h.queryScopeFromRequest(w, r)
 	if !ok {
 		return evidencevo.EvidenceQueryOptions{}, false
 	}
@@ -788,7 +796,7 @@ func (h *EvidenceHandler) evidenceQueryOptionsFromRequest(w http.ResponseWriter,
 	return evidencevo.EvidenceQueryOptions{Limit: limit, Scope: scope}, true
 }
 
-func queryScopeFromRequest(w http.ResponseWriter, r *http.Request) (evidencevo.QueryScope, bool) {
+func (h *EvidenceHandler) queryScopeFromRequest(w http.ResponseWriter, r *http.Request) (evidencevo.QueryScope, bool) {
 	accountID := strings.TrimSpace(r.Header.Get("x-account-id"))
 	accountType := strings.TrimSpace(r.Header.Get("x-account-type"))
 	tenantID := strings.TrimSpace(r.Header.Get("x-tenant-id"))
@@ -803,10 +811,14 @@ func queryScopeFromRequest(w http.ResponseWriter, r *http.Request) (evidencevo.Q
 		})
 		return evidencevo.QueryScope{}, false
 	}
-	return evidencevo.QueryScope{
+	scope := evidencevo.QueryScope{
 		TenantID: tenantID, BusinessDomain: businessDomain, AccountID: accountID, AccountType: accountType,
 		Authorization: strings.TrimSpace(r.Header.Get("Authorization")),
-	}, true
+	}
+	if h.queryAdminTypes[accountType] {
+		scope.CrossAccountRead = true
+	}
+	return scope, true
 }
 
 func (h *EvidenceHandler) RequireTrustedQueryIdentity(next http.HandlerFunc) http.HandlerFunc {
@@ -814,7 +826,7 @@ func (h *EvidenceHandler) RequireTrustedQueryIdentity(next http.HandlerFunc) htt
 		if !h.authorizeQueryGateway(w, r) {
 			return
 		}
-		if _, ok := queryScopeFromRequest(w, r); !ok {
+		if _, ok := h.queryScopeFromRequest(w, r); !ok {
 			return
 		}
 		next(w, r)
@@ -825,13 +837,16 @@ func (h *EvidenceHandler) authorizeQueryGateway(w http.ResponseWriter, r *http.R
 	if h.queryGatewayToken != "" && secureTokenEqual(r.Header.Get(evidenceQueryGatewayTokenHeader), h.queryGatewayToken) {
 		return true
 	}
+	if h.hydraAdminURL != "" && strings.TrimSpace(r.Header.Get("Authorization")) != "" {
+		return h.authorizeOAuthQuery(w, r)
+	}
+	if h.allowUnauthenticatedQuery {
+		return true
+	}
 	if h.hydraAdminURL != "" {
 		return h.authorizeOAuthQuery(w, r)
 	}
 	if h.queryGatewayToken == "" {
-		if h.allowUnauthenticatedQuery {
-			return true
-		}
 		writeJSON(w, http.StatusServiceUnavailable, rdto.ErrorResponse{
 			Code: "QUERY_AUTH_NOT_CONFIGURED", Message: "query gateway authentication is not configured",
 		})

--- a/bkn-trace/agent-observability/src/driveradapter/api/httphandler/evidence_handler_test.go
+++ b/bkn-trace/agent-observability/src/driveradapter/api/httphandler/evidence_handler_test.go
@@ -695,6 +695,53 @@ func TestEvidenceHandlerListsRequestTracesAndTechnicalExecutions(t *testing.T) {
 	}
 }
 
+func TestEvidenceHandlerAdminReadsEvidenceAcrossAccountsWithinBusinessDomain(t *testing.T) {
+	handler := newDevEvidenceHandler(evidencesvc.New(evidencestore.New()))
+	ingestReq := httptest.NewRequest(http.MethodPost, "/api/agent-observability/v1/evidence/events", strings.NewReader(validHandlerBatch()))
+	ingestRec := httptest.NewRecorder()
+	handler.IngestEvidenceEvents(ingestRec, ingestReq)
+	if ingestRec.Code != http.StatusAccepted {
+		t.Fatalf("seed evidence: %d %s", ingestRec.Code, ingestRec.Body.String())
+	}
+
+	userReq := authenticatedQueryRequest(http.MethodGet, "/api/agent-observability/v1/requests?limit=10", nil)
+	userReq.Header.Set("x-account-id", "other_user")
+	userReq.Header.Set("x-account-type", "user")
+	userRec := httptest.NewRecorder()
+	handler.ListRequests(userRec, userReq)
+	if userRec.Code != http.StatusOK || strings.Contains(userRec.Body.String(), `"request_id":"req_handler_001"`) {
+		t.Fatalf("normal cross-account user must not see evidence, got %d: %s", userRec.Code, userRec.Body.String())
+	}
+
+	adminReq := authenticatedQueryRequest(http.MethodGet, "/api/agent-observability/v1/requests?limit=10", nil)
+	adminReq.Header.Set("x-account-id", "admin_user")
+	adminReq.Header.Set("x-account-type", "super_admin")
+	adminRec := httptest.NewRecorder()
+	handler.ListRequests(adminRec, adminReq)
+	if adminRec.Code != http.StatusOK || !strings.Contains(adminRec.Body.String(), `"request_id":"req_handler_001"`) {
+		t.Fatalf("admin must see same-domain evidence, got %d: %s", adminRec.Code, adminRec.Body.String())
+	}
+
+	chainReq := authenticatedQueryRequest(http.MethodGet, "/api/agent-observability/v1/traces/9c0d0000000000000000000000000001/evidence-chain", nil)
+	chainReq.Header.Set("x-account-id", "admin_user")
+	chainReq.Header.Set("x-account-type", "super_admin")
+	chainRec := httptest.NewRecorder()
+	handler.GetTraceSubresource(chainRec, chainReq)
+	if chainRec.Code != http.StatusOK || !strings.Contains(chainRec.Body.String(), `"claim_id":"claim_handler"`) {
+		t.Fatalf("admin must read same-domain evidence chain, got %d: %s", chainRec.Code, chainRec.Body.String())
+	}
+
+	otherDomainReq := authenticatedQueryRequest(http.MethodGet, "/api/agent-observability/v1/requests?limit=10", nil)
+	otherDomainReq.Header.Set("x-account-id", "admin_user")
+	otherDomainReq.Header.Set("x-account-type", "super_admin")
+	otherDomainReq.Header.Set("x-business-domain", "other_domain")
+	otherDomainRec := httptest.NewRecorder()
+	handler.ListRequests(otherDomainRec, otherDomainReq)
+	if otherDomainRec.Code != http.StatusOK || strings.Contains(otherDomainRec.Body.String(), `"request_id":"req_handler_001"`) {
+		t.Fatalf("admin cross-account read must stay domain-scoped, got %d: %s", otherDomainRec.Code, otherDomainRec.Body.String())
+	}
+}
+
 func TestEvidenceHandlerRejectsInvalidSummaryPaginationAndTime(t *testing.T) {
 	handler := newDevEvidenceHandler(evidencesvc.New(evidencestore.New()))
 	for _, target := range []string{

--- a/bkn-trace/agent-observability/src/driveradapter/api/httphandler/summary_handler.go
+++ b/bkn-trace/agent-observability/src/driveradapter/api/httphandler/summary_handler.go
@@ -212,7 +212,7 @@ func (h *EvidenceHandler) summaryQueryOptionsFromRequest(w http.ResponseWriter, 
 	if !h.authorizeQueryGateway(w, r) {
 		return evidencevo.SummaryQueryOptions{}, false
 	}
-	scope, ok := queryScopeFromRequest(w, r)
+	scope, ok := h.queryScopeFromRequest(w, r)
 	if !ok {
 		return evidencevo.SummaryQueryOptions{}, false
 	}


### PR DESCRIPTION
## Summary
- Allow release/0.1.2 BKN Trace admin/domain reads to resolve owned evidence artifacts correctly.
- Return owned evidence artifacts when refs are unresolved instead of surfacing false not-found errors.
- Supports local Studio BKN Trace detail pages and trace graph drilldown for release validation.

## Test Plan
- go test ./src/... from bkn-trace/agent-observability
- Local OpenBKN deployment validated with updated agent-observability and Studio images
