### PR TITLE
chore(deploy): 更新 bkn-foundry 版本号至 0.1.2

### DIFF
--- a/deploy/release-manifests/0.1.2/bkn-foundry.yaml
+++ b/deploy/release-manifests/0.1.2/bkn-foundry.yaml
@@ -12,50 +12,50 @@ source:
 releases:
   core-data-migrator:
     chart: core-data-migrator
-    version: 0.1.2-release
+    version: 0.1.2
     stage: pre
   mf-model-manager:
     chart: mf-model-manager
-    version: 0.1.2-release
+    version: 0.1.2
   mf-model-api:
     chart: mf-model-api
-    version: 0.1.2-release
+    version: 0.1.2
   oss-gateway-backend:
     chart: oss-gateway-backend
-    version: 0.1.2-release
+    version: 0.1.2
   sandbox:
     chart: sandbox
-    version: 0.1.2-release
+    version: 0.1.2
   bkn-backend:
     chart: bkn-backend
-    version: 0.1.2-release
+    version: 0.1.2
   ontology-query:
     chart: ontology-query
-    version: 0.1.2-release
+    version: 0.1.2
   vega-backend:
     chart: vega-backend
-    version: 0.1.2-release
+    version: 0.1.2
   kafka-connect:
     chart: kafka-connect
-    version: 0.1.2-release
+    version: 0.1.2
   agent-operator-integration:
     chart: agent-operator-integration
-    version: 0.1.2-release
+    version: 0.1.2
   agent-retrieval:
     chart: agent-retrieval
-    version: 0.1.2-release
+    version: 0.1.2
   bkn-agent:
     chart: bkn-agent
-    version: 0.1.2-release
+    version: 0.1.2
   agent-observability:
     chart: agent-observability
-    version: 0.1.2-release
+    version: 0.1.2
   otelcol-contrib:
     chart: otelcol-contrib
-    version: 0.1.2-release
+    version: 0.1.2
   bkn-safe:
     chart: bkn-safe
-    version: 0.1.2-release
+    version: 0.1.2
   bkn-studio:
     chart: bkn-studio
-    version: 0.1.2-release
+    version: 0.1.2


### PR DESCRIPTION
## What Changed

- 更新 `deploy/release-manifests/0.1.2/bkn-foundry.yaml`
- 将所有组件版本从 `0.1.2-release` 更新为 `0.1.2`

## Why

统一 bkn-foundry 0.1.2 发布清单中的组件版本号。

## How

- 修改发布清单中的 16 个组件版本字段
- 无代码逻辑变更
- 无 API、数据库或配置兼容性变更

## Testing

- [x] 已执行 `git diff --check`
- [x] 已确认不存在 `version: 0.1.2-release`
- [ ] 单元测试：不适用
- [ ] 集成测试：不适用

## Risk & Rollback

- 潜在风险：发布时组件版本解析错误
- 回滚方案：将版本字段恢复为 `0.1.2-release`

## Additional Notes

- 相关文件：`deploy/release-manifests/0.1.2/bkn-foundry.yaml`