### PR TITLE
docs(api): 补齐文档中心的中文显示名

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -78,11 +78,16 @@ MODTITLE_ontology-query    := Ontology 查询
 MODTITLE_vega              := VEGA 引擎
 
 ## 模块中文描述（index 卡片副标题用）。未列出的模块回落为空。
-MODDESC_bkn            := 业务知识网络：对象类 / 关系类 / 行动类 / 概念组 / 指标 / 导入导出
-MODDESC_ontology-query := 本体查询与语义检索
-MODDESC_vega           := 数据可观测：目录 / 资源 / 连接器 / 构建任务 / 发现任务 / 原生查询
+MODDESC_bkn               := 业务知识网络：对象类 / 关系类 / 行动类 / 概念组 / 指标 / 导入导出
+MODDESC_bkn-agent         := Agent 运行时：Agent 增删改查 / 对话与调用 / 任务 / 提示词版本 / 会话 / 导入导出
+MODDESC_mf-model-manager  := 模型工厂：大模型连通性测试 / 默认模型设置 / 调用监控
+MODDESC_ontology-query    := 本体查询与语义检索
+MODDESC_vega              := 数据可观测：目录 / 资源 / 连接器 / 构建任务 / 发现任务 / 原生查询
 
 # 资源中文名（侧栏显示用；未列出的回落为文件名）
+RESNAME_bkn-agent                 := Agent 运行时
+RESNAME_large-model               := 大模型
+RESNAME_semantic-understanding-task := 语义理解任务
 RESNAME_action-schedules          := 行动调度
 RESNAME_action-type               := 行动类
 RESNAME_bkn-metrics               := 指标

--- a/Makefile
+++ b/Makefile
@@ -71,9 +71,11 @@ api-docs:
 	@echo "done -> $(GEN_DIR)/"
 
 ## 模块显示标题（index 分区标题用）。未列出的模块回落为目录名。
-MODTITLE_bkn            := BKN
-MODTITLE_ontology-query := Ontology 查询
-MODTITLE_vega           := VEGA 引擎
+MODTITLE_bkn               := BKN
+MODTITLE_bkn-agent         := BKN 专属 Agent
+MODTITLE_mf-model-manager  := 模型管理
+MODTITLE_ontology-query    := Ontology 查询
+MODTITLE_vega              := VEGA 引擎
 
 ## 模块中文描述（index 卡片副标题用）。未列出的模块回落为空。
 MODDESC_bkn            := 业务知识网络：对象类 / 关系类 / 行动类 / 概念组 / 指标 / 导入导出


### PR DESCRIPTION
## 问题

https://openbkn-ai.github.io/bkn-foundry/ 的模块分区标题里，`bkn-agent` 和 `mf-model-manager` 是裸目录名，与 `BKN` / `Ontology 查询` / `VEGA 引擎` 中英混排；这两个模块的副标题为空，另有三张资源卡片也是裸英文。原因是 Makefile 的 `MODTITLE_*` / `MODDESC_*` / `RESNAME_*` 表未列出它们，按设计回落为目录名或文件名。

## 改动

模块分区标题（`MODTITLE_*`）：

| 模块 | 显示名 |
| --- | --- |
| `bkn-agent` | BKN 专属 Agent |
| `mf-model-manager` | 模型管理 |

模块副标题（`MODDESC_*`）：

| 模块 | 描述 |
| --- | --- |
| `bkn-agent` | Agent 运行时：Agent 增删改查 / 对话与调用 / 任务 / 提示词版本 / 会话 / 导入导出 |
| `mf-model-manager` | 模型工厂：大模型连通性测试 / 默认模型设置 / 调用监控 |

资源卡片（`RESNAME_*`）：

| 资源 | 显示名 |
| --- | --- |
| `bkn-agent` | Agent 运行时 |
| `large-model` | 大模型 |
| `semantic-understanding-task` | 语义理解任务 |

副标题按各文档实际收录的端点写，不是按服务全量能力写：`mf-model-manager/large-model.yaml` 目前只收了 `/llm/test`、`/llm/default/edit`、`/llm/monitor/overview` 三个端点。

## 验证

本地 `make api-docs-html` 渲染核对：index 五个模块的标题、副标题与 22 张资源卡片全为中文，无裸英文回落。

## 合并后

main push 会自动重发 `versions/main/`。已发布的 v0.1.1 / v0.1.2 是固定归档，要让它们也用新显示名，需重新 dispatch 这两个版本（渲染脚本取自 main，会带上本次修改）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)