### PR TITLE
feat(bkn-trace): implement managed lifecycle core

### DIFF
--- a/.github/workflows/ci-bkn-trace.yml
+++ b/.github/workflows/ci-bkn-trace.yml
@@ -1,8 +1,5 @@
 name: ci-bkn-trace
 
-# Compile gate for PRs touching bkn-trace. Build-only for now; add `go test`
-# once the test harness is CI-ready.
-
 on:
   pull_request:
     paths:
@@ -14,8 +11,34 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  build:
+  test:
     runs-on: ubuntu-latest
+    services:
+      mariadb:
+        image: mariadb:11.4
+        env:
+          MARIADB_ROOT_PASSWORD: trace-ci-password
+          MARIADB_DATABASE: bkn_trace_ci
+        ports:
+          - 3306:3306
+        options: >-
+          --health-cmd "healthcheck.sh --connect --innodb_initialized"
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 20
+      opensearch:
+        image: opensearchproject/opensearch:2.19.4
+        env:
+          discovery.type: single-node
+          DISABLE_SECURITY_PLUGIN: "true"
+          OPENSEARCH_JAVA_OPTS: -Xms512m -Xmx512m
+        ports:
+          - 9200:9200
+        options: >-
+          --health-cmd "curl --fail http://localhost:9200/_cluster/health || exit 1"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 30
     defaults:
       run:
         working-directory: bkn-trace/agent-observability
@@ -24,4 +47,25 @@ jobs:
       - uses: actions/setup-go@v5
         with:
           go-version-file: bkn-trace/agent-observability/go.mod
-      - run: go build ./...
+      - name: Unit tests
+        run: make test
+      - name: Race tests
+        run: make test-race
+      - name: MariaDB lifecycle, fault and rebuild integration tests
+        env:
+          BKN_TRACE_TEST_MARIADB_DSN: root:trace-ci-password@tcp(127.0.0.1:3306)/bkn_trace_ci?parseTime=true&multiStatements=true
+          BKN_TRACE_TEST_OPENSEARCH_ENDPOINT: http://127.0.0.1:9200
+        run: make test-integration
+      - name: MariaDB capacity smoke
+        env:
+          BKN_TRACE_TEST_MARIADB_DSN: root:trace-ci-password@tcp(127.0.0.1:3306)/bkn_trace_ci?parseTime=true&multiStatements=true
+        run: make test-performance
+      - name: OpenSearch projection and alias integration test
+        env:
+          BKN_TRACE_TEST_OPENSEARCH_ENDPOINT: http://127.0.0.1:9200
+        run: make test-opensearch-integration
+      - name: Build
+        run: make build
+      - uses: azure/setup-helm@v4
+      - name: Helm lint
+        run: make helm-lint

--- a/bkn-trace/agent-observability/.gitignore
+++ b/bkn-trace/agent-observability/.gitignore
@@ -16,6 +16,7 @@
 coverage.*
 *.coverprofile
 profile.cov
+/test-result/
 
 # Dependency directories (remove the comment below to include it)
 # vendor/

--- a/bkn-trace/agent-observability/Makefile
+++ b/bkn-trace/agent-observability/Makefile
@@ -5,9 +5,48 @@ SWAG_OUT := docs/swagger
 IMAGE ?= swr.cn-east-3.myhuaweicloud.com/kweaver-ai/agent-observability:local
 CHART_PATH := charts/agent-observability
 GOCACHE ?= /tmp/go-build
+TEST_RESULT := test-result
+UNIT_PACKAGES := ./...
+RACE_PACKAGES := ./src/domain/service/... ./src/drivenadapter/memoryaccess/...
+INTEGRATION_PACKAGE := ./src/drivenadapter/dbaccess/mariadb/sessionstore
+OPENSEARCH_INTEGRATION_PACKAGE := ./src/drivenadapter/httpaccess/opensearchprojection
+
+.PHONY: lint test test-cover test-race test-integration test-opensearch-integration test-performance ci build \
+	docker-build helm-lint helm-package gen-swag view-swag clean-swag
+
+lint:
+	GOCACHE=$(GOCACHE) go vet ./...
 
 test:
-	GOCACHE=$(GOCACHE) go test ./...
+	GOCACHE=$(GOCACHE) go test $(UNIT_PACKAGES) -count=1
+
+test-cover:
+	@mkdir -p $(TEST_RESULT)
+	GOCACHE=$(GOCACHE) go test $(UNIT_PACKAGES) -count=1 -covermode=atomic \
+		-coverprofile=$(TEST_RESULT)/coverage.out
+	go tool cover -func=$(TEST_RESULT)/coverage.out
+	go tool cover -html=$(TEST_RESULT)/coverage.out -o $(TEST_RESULT)/coverage.html
+	@command -v gocover-cobertura >/dev/null 2>&1 && \
+		gocover-cobertura < $(TEST_RESULT)/coverage.out > $(TEST_RESULT)/coverage.xml || \
+		echo "WARN: gocover-cobertura not found; coverage.xml was not generated"
+
+test-race:
+	GOCACHE=$(GOCACHE) go test -race $(RACE_PACKAGES) -count=1
+
+test-integration:
+	GOCACHE=$(GOCACHE) go test -tags=integration $(INTEGRATION_PACKAGE) -count=1 -v
+
+test-opensearch-integration:
+	GOCACHE=$(GOCACHE) go test -tags=integration $(OPENSEARCH_INTEGRATION_PACKAGE) -count=1 -v
+
+test-performance:
+	GOCACHE=$(GOCACHE) go test -tags=integration $(INTEGRATION_PACKAGE) -run '^$$' \
+		-bench 'BenchmarkMariaDB(EnsureCurrent|EvidenceIngest)' -benchtime=200x -count=1
+
+ci: lint test-cover
+
+build:
+	GOCACHE=$(GOCACHE) go build ./...
 
 docker-build:
 	docker build -t $(IMAGE) .

--- a/bkn-trace/agent-observability/Makefile
+++ b/bkn-trace/agent-observability/Makefile
@@ -53,6 +53,7 @@ docker-build:
 
 helm-lint:
 	helm lint $(CHART_PATH)
+	bash scripts/test_evidence_index_governance.sh $(CHART_PATH)
 
 helm-package:
 	mkdir -p dist

--- a/bkn-trace/agent-observability/README.md
+++ b/bkn-trace/agent-observability/README.md
@@ -157,21 +157,35 @@ Trace Graph 单次最多返回 1000 个 span 节点。命中上限时服务会�
 
 ### Evidence 写入安全边界
 
-`POST /api/agent-observability/v1/evidence/events` 是写接口，生产环境必须通过平台网关鉴权保护，或配置服务内最小 ingest token：
+`POST /api/agent-observability/v1/evidence/events` 是权威 Ledger 写接口，生产环境必须同时经过平台可信网关身份校验和服务内 ingest token 校验。网关必须剥离外部调用方提交的 owner header，并从认证上下文重新注入完整 owner tuple；服务不接受请求 body 自报 owner。
 
 ```bash
 kubectl create secret generic bkn-trace-evidence-ingest \
   --from-literal=token='<strong-token>' \
+  -n observability
+
+kubectl create secret generic bkn-trace-query-gateway \
+  --from-literal=token='<different-strong-token>' \
+  -n observability
+
+kubectl create secret generic bkn-trace-core-mariadb \
+  --from-literal=dsn='<user>:<password>@tcp(<host>:3306)/<database>?parseTime=true' \
   -n observability
 ```
 
 ```bash
 helm upgrade --install agent-observability charts/agent-observability \
   --set evidence.ingestAuth.existingSecret=bkn-trace-evidence-ingest \
+  --set evidence.queryAuth.existingSecret=bkn-trace-query-gateway \
+  --set core.store=mariadb \
+  --set core.mariadb.existingSecret=bkn-trace-core-mariadb \
+  --set core.projection.enabled=true \
   -n observability
 ```
 
-写入方需要携带 `Authorization: Bearer <strong-token>` 或 `X-BKN-Trace-Ingest-Token: <strong-token>`。生产环境未配置 `BKN_TRACE_EVIDENCE_INGEST_TOKEN` 时接口返回 `503 INGEST_AUTH_NOT_CONFIGURED`，不得 fail-open。仅本地开发和测试可显式设置 `BKN_TRACE_ALLOW_UNAUTHENTICATED_INGEST=true`；Helm 默认值为 `false`。
+内部写入方需要携带 `X-BKN-Trace-Ingest-Token` 和由网关注入的 `X-BKN-Trace-Query-Token`，以及 tenant、business domain、application principal、effective subject type/id 和可选 delegation 构成的 owner tuple。生产环境未配置相应凭据时接口拒绝写入，不得 fail-open。仅本地开发和测试可显式设置 `BKN_TRACE_ALLOW_UNAUTHENTICATED_INGEST=true`；该开关只绕过 ingest token，不能绕过可信网关身份边界，Helm 默认值为 `false`。
+
+Chart 默认使用 memory store 且关闭 Core projection，以保证存量 trace/evidence 读取在普通 chart 升级时不会因缺少新 Secret 而中断。该默认值不代表具备 durable lifecycle；生产启用受管 Conversation / Interaction 时必须显式采用上面的 MariaDB 与 projection 配置。
 
 Studio 查询使用用户 OAuth access token。核心服务通过 `BKN_TRACE_HYDRA_ADMIN_URL` 调用 Hydra introspection，从 token 派生可信 `account_id/account_type`，拒绝客户端自报身份与 token 不一致的请求；当前业务域由 Studio 发送。解析 BKN/Vega 业务名称时只在内存中向授权下游转发该 Bearer，不能写入日志、事件、索引或响应。服务到服务查询仍可配置独立的 `BKN_TRACE_QUERY_GATEWAY_TOKEN`，不得把该 token 放入浏览器。
 

--- a/bkn-trace/agent-observability/charts/agent-observability/templates/deployment.yaml
+++ b/bkn-trace/agent-observability/charts/agent-observability/templates/deployment.yaml
@@ -43,6 +43,33 @@ spec:
               value: {{ .Values.evidence.index | quote }}
             - name: BKN_TRACE_EVIDENCE_STORE
               value: {{ .Values.evidence.store | quote }}
+            - name: BKN_TRACE_CORE_STORE
+              value: {{ .Values.core.store | quote }}
+            - name: BKN_TRACE_CORE_AUTO_MIGRATE
+              value: {{ ternary "true" "false" .Values.core.autoMigrate | quote }}
+            - name: BKN_TRACE_CORE_ABANDON_INTERVAL
+              value: {{ .Values.core.abandonInterval | quote }}
+            - name: BKN_TRACE_CORE_ONE_SHOT_IDLE_TTL
+              value: {{ .Values.core.oneShotIdleTTL | quote }}
+            - name: BKN_TRACE_EVIDENCE_COLLECTION_STATE
+              value: {{ .Values.core.evidenceCollectionState | quote }}
+            - name: BKN_TRACE_PROJECTION_ENABLED
+              value: {{ ternary "true" "false" .Values.core.projection.enabled | quote }}
+            - name: BKN_TRACE_PROJECTION_INDEX
+              value: {{ .Values.core.projection.index | quote }}
+            - name: BKN_TRACE_PROJECTION_INTERVAL
+              value: {{ .Values.core.projection.interval | quote }}
+            {{- with .Values.core.projection.rebuildVersion }}
+            - name: BKN_TRACE_PROJECTION_REBUILD_VERSION
+              value: {{ . | quote }}
+            {{- end }}
+            {{- if eq .Values.core.store "mariadb" }}
+            - name: BKN_TRACE_CORE_MARIADB_DSN
+              valueFrom:
+                secretKeyRef:
+                  name: {{ required "core.mariadb.existingSecret is required for the MariaDB Core store" .Values.core.mariadb.existingSecret | quote }}
+                  key: {{ .Values.core.mariadb.dsnKey | quote }}
+            {{- end }}
             - name: BKN_TRACE_ALLOW_UNAUTHENTICATED_INGEST
               value: {{ ternary "true" "false" .Values.evidence.ingestAuth.allowUnauthenticated | quote }}
             - name: BKN_TRACE_ALLOW_RAW_TRACE_QUERY

--- a/bkn-trace/agent-observability/charts/agent-observability/values.yaml
+++ b/bkn-trace/agent-observability/charts/agent-observability/values.yaml
@@ -66,15 +66,15 @@ businessResolver:
   timeout: 3s
 
 core:
-  # MariaDB is the authoritative store in deployed environments. Use memory
-  # only for isolated local tests that do not claim durable lifecycle support.
-  store: mariadb
+  # Keep existing trace/evidence reads available after an upgrade. Enable
+  # MariaDB explicitly only after its Secret and database are ready.
+  store: memory
   autoMigrate: true
   abandonInterval: 30s
   oneShotIdleTTL: 15m
   evidenceCollectionState: enabled
   projection:
-    enabled: true
+    enabled: false
     index: bkn-trace-core
     interval: 1s
     rebuildVersion: bkn-trace-core-v013

--- a/bkn-trace/agent-observability/charts/agent-observability/values.yaml
+++ b/bkn-trace/agent-observability/charts/agent-observability/values.yaml
@@ -65,6 +65,23 @@ businessResolver:
   vegaBaseURL: ""
   timeout: 3s
 
+core:
+  # MariaDB is the authoritative store in deployed environments. Use memory
+  # only for isolated local tests that do not claim durable lifecycle support.
+  store: mariadb
+  autoMigrate: true
+  abandonInterval: 30s
+  oneShotIdleTTL: 15m
+  evidenceCollectionState: enabled
+  projection:
+    enabled: true
+    index: bkn-trace-core
+    interval: 1s
+    rebuildVersion: bkn-trace-core-v013
+  mariadb:
+    existingSecret: bkn-trace-core-mariadb
+    dsnKey: dsn
+
 resources:
   limits:
     cpu: 500m

--- a/bkn-trace/agent-observability/docs/swagger/core_contract_test.go
+++ b/bkn-trace/agent-observability/docs/swagger/core_contract_test.go
@@ -1,0 +1,43 @@
+package swagger_test
+
+import (
+	"os"
+	"strings"
+	"testing"
+)
+
+func TestGeneratedSwaggerContainsManagedLifecycleContract(t *testing.T) {
+	t.Parallel()
+
+	content, err := os.ReadFile("swagger.yaml")
+	if err != nil {
+		t.Fatalf("read generated Swagger: %v", err)
+	}
+	swagger := string(content)
+	requiredPaths := []string{
+		"/conversations:",
+		"/conversations:ensure-current:",
+		"/conversations:create-new-generation:",
+		"/conversations:resume-by-id:",
+		"/conversations/{conversation_id}:",
+		"/conversations/{conversation_id}/close:",
+		"/conversations/{conversation_id}/interactions:",
+		"/conversations/{conversation_id}/interactions/{interaction_id}/operations:ensure:",
+		"/interactions/{interaction_id}:",
+		"/interactions/{interaction_id}/complete:",
+		"/interactions/{interaction_id}/fail:",
+		"/interactions/{interaction_id}/cancel:",
+		"/interactions/{interaction_id}/handoff:",
+		"/operations/{operation_id}:",
+		"/operations/{operation_id}/attempts:",
+		"/operations/{operation_id}/attempts/{attempt}:complete:",
+		"/operations/{operation_id}/attempts/{attempt}:fail:",
+		"/receipts/{receipt_id}:",
+		"/evidence/events:",
+	}
+	for _, path := range requiredPaths {
+		if !strings.Contains(swagger, "  "+path) {
+			t.Errorf("generated Swagger is missing %s", path)
+		}
+	}
+}

--- a/bkn-trace/agent-observability/docs/swagger/docs.go
+++ b/bkn-trace/agent-observability/docs/swagger/docs.go
@@ -16,6 +16,762 @@ const docTemplate = `{
     "host": "{{.Host}}",
     "basePath": "{{.BasePath}}",
     "paths": {
+        "/api/agent-observability/v1/traces/_search": {
+            "post": {
+                "description": "Proxy raw OpenSearch DSL to the configured trace index and return the original OpenSearch response body.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "traces"
+                ],
+                "summary": "Search traces with raw OpenSearch DSL",
+                "parameters": [
+                    {
+                        "description": "OpenSearch DSL JSON body",
+                        "name": "request",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Raw OpenSearch search response",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/rdto.ErrorResponse"
+                        }
+                    },
+                    "405": {
+                        "description": "Method Not Allowed",
+                        "schema": {
+                            "$ref": "#/definitions/rdto.ErrorResponse"
+                        }
+                    },
+                    "504": {
+                        "description": "Gateway Timeout",
+                        "schema": {
+                            "$ref": "#/definitions/rdto.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/api/agent-observability/v1/traces/by-conversation": {
+            "get": {
+                "description": "Build a term filter automatically using attributes.gen_ai.conversation.id.keyword and return the original OpenSearch response body.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "traces"
+                ],
+                "summary": "Search traces by conversation ID",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Conversation ID",
+                        "name": "conversation_id",
+                        "in": "query",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Raw OpenSearch search response",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/rdto.ErrorResponse"
+                        }
+                    },
+                    "405": {
+                        "description": "Method Not Allowed",
+                        "schema": {
+                            "$ref": "#/definitions/rdto.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/rdto.ErrorResponse"
+                        }
+                    },
+                    "504": {
+                        "description": "Gateway Timeout",
+                        "schema": {
+                            "$ref": "#/definitions/rdto.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/api/agent-observability/v1/traces/{trace_id}/trace-graph": {
+            "get": {
+                "description": "Returns normalized trace tree nodes, parent-child edges, status, duration, and partial reasons for a trace.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "traces"
+                ],
+                "summary": "Get trace graph by trace ID",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Trace ID",
+                        "name": "trace_id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": true
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/rdto.ErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/rdto.ErrorResponse"
+                        }
+                    },
+                    "405": {
+                        "description": "Method Not Allowed",
+                        "schema": {
+                            "$ref": "#/definitions/rdto.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/rdto.ErrorResponse"
+                        }
+                    },
+                    "504": {
+                        "description": "Gateway Timeout",
+                        "schema": {
+                            "$ref": "#/definitions/rdto.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/conversations": {
+            "get": {
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "lifecycle"
+                ],
+                "summary": "List managed Conversations in the authorized owner scope",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "Page size, 1..100",
+                        "name": "limit",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/httphandler.conversationPage"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/httphandler.lifecycleErrorEnvelope"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "$ref": "#/definitions/httphandler.lifecycleErrorEnvelope"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/httphandler.lifecycleErrorEnvelope"
+                        }
+                    }
+                }
+            },
+            "post": {
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "lifecycle"
+                ],
+                "summary": "Create or return the current managed Conversation",
+                "parameters": [
+                    {
+                        "description": "Managed Conversation request",
+                        "name": "request",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/httphandler.ensureConversationRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "description": "Created",
+                        "schema": {
+                            "$ref": "#/definitions/sessionvo.Conversation"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/httphandler.lifecycleErrorEnvelope"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/httphandler.lifecycleErrorEnvelope"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "$ref": "#/definitions/httphandler.lifecycleErrorEnvelope"
+                        }
+                    },
+                    "409": {
+                        "description": "Conflict",
+                        "schema": {
+                            "$ref": "#/definitions/httphandler.lifecycleErrorEnvelope"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/httphandler.lifecycleErrorEnvelope"
+                        }
+                    }
+                }
+            }
+        },
+        "/conversations/{conversation_id}": {
+            "get": {
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "lifecycle"
+                ],
+                "summary": "Get one managed Conversation",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Conversation ID",
+                        "name": "conversation_id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/sessionvo.Conversation"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/httphandler.lifecycleErrorEnvelope"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "$ref": "#/definitions/httphandler.lifecycleErrorEnvelope"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/httphandler.lifecycleErrorEnvelope"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/httphandler.lifecycleErrorEnvelope"
+                        }
+                    }
+                }
+            }
+        },
+        "/conversations/{conversation_id}/close": {
+            "post": {
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "lifecycle"
+                ],
+                "summary": "Close one managed Conversation",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Conversation ID",
+                        "name": "conversation_id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Idempotent close request",
+                        "name": "request",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/httphandler.closeConversationRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/sessionvo.Conversation"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/httphandler.lifecycleErrorEnvelope"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/httphandler.lifecycleErrorEnvelope"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "$ref": "#/definitions/httphandler.lifecycleErrorEnvelope"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/httphandler.lifecycleErrorEnvelope"
+                        }
+                    },
+                    "409": {
+                        "description": "Conflict",
+                        "schema": {
+                            "$ref": "#/definitions/httphandler.lifecycleErrorEnvelope"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/httphandler.lifecycleErrorEnvelope"
+                        }
+                    }
+                }
+            }
+        },
+        "/conversations/{conversation_id}/interactions": {
+            "post": {
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "lifecycle"
+                ],
+                "summary": "Start one managed Interaction",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Conversation ID",
+                        "name": "conversation_id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Interaction start request",
+                        "name": "request",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/httphandler.startInteractionRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "description": "Created",
+                        "schema": {
+                            "$ref": "#/definitions/sessionvo.Interaction"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/httphandler.lifecycleErrorEnvelope"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/httphandler.lifecycleErrorEnvelope"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "$ref": "#/definitions/httphandler.lifecycleErrorEnvelope"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/httphandler.lifecycleErrorEnvelope"
+                        }
+                    },
+                    "409": {
+                        "description": "Conflict",
+                        "schema": {
+                            "$ref": "#/definitions/httphandler.lifecycleErrorEnvelope"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/httphandler.lifecycleErrorEnvelope"
+                        }
+                    }
+                }
+            }
+        },
+        "/conversations/{conversation_id}/interactions/{interaction_id}/operations:ensure": {
+            "post": {
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "lifecycle"
+                ],
+                "summary": "Ensure an idempotent Operation intent and durable Receipt",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Conversation ID",
+                        "name": "conversation_id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Interaction ID",
+                        "name": "interaction_id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Operation intent",
+                        "name": "request",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/httphandler.ensureOperationRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "description": "Created",
+                        "schema": {
+                            "$ref": "#/definitions/httphandler.operationResult"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/httphandler.lifecycleErrorEnvelope"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/httphandler.lifecycleErrorEnvelope"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "$ref": "#/definitions/httphandler.lifecycleErrorEnvelope"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/httphandler.lifecycleErrorEnvelope"
+                        }
+                    },
+                    "409": {
+                        "description": "Conflict",
+                        "schema": {
+                            "$ref": "#/definitions/httphandler.lifecycleErrorEnvelope"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/httphandler.lifecycleErrorEnvelope"
+                        }
+                    }
+                }
+            }
+        },
+        "/conversations:create-new-generation": {
+            "post": {
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "lifecycle"
+                ],
+                "summary": "Create a new managed Conversation generation",
+                "parameters": [
+                    {
+                        "description": "New generation request",
+                        "name": "request",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/httphandler.ensureConversationRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "description": "Created",
+                        "schema": {
+                            "$ref": "#/definitions/sessionvo.Conversation"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/httphandler.lifecycleErrorEnvelope"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/httphandler.lifecycleErrorEnvelope"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "$ref": "#/definitions/httphandler.lifecycleErrorEnvelope"
+                        }
+                    },
+                    "409": {
+                        "description": "Conflict",
+                        "schema": {
+                            "$ref": "#/definitions/httphandler.lifecycleErrorEnvelope"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/httphandler.lifecycleErrorEnvelope"
+                        }
+                    }
+                }
+            }
+        },
+        "/conversations:ensure-current": {
+            "post": {
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "lifecycle"
+                ],
+                "summary": "Ensure the current managed Conversation",
+                "parameters": [
+                    {
+                        "description": "Managed Conversation request",
+                        "name": "request",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/httphandler.ensureConversationRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "description": "Created",
+                        "schema": {
+                            "$ref": "#/definitions/sessionvo.Conversation"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/httphandler.lifecycleErrorEnvelope"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/httphandler.lifecycleErrorEnvelope"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "$ref": "#/definitions/httphandler.lifecycleErrorEnvelope"
+                        }
+                    },
+                    "409": {
+                        "description": "Conflict",
+                        "schema": {
+                            "$ref": "#/definitions/httphandler.lifecycleErrorEnvelope"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/httphandler.lifecycleErrorEnvelope"
+                        }
+                    }
+                }
+            }
+        },
+        "/conversations:resume-by-id": {
+            "post": {
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "lifecycle"
+                ],
+                "summary": "Resume an active managed Conversation by Core ID",
+                "parameters": [
+                    {
+                        "description": "Conversation resume request",
+                        "name": "request",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/httphandler.resumeConversationRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/sessionvo.Conversation"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/httphandler.lifecycleErrorEnvelope"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/httphandler.lifecycleErrorEnvelope"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "$ref": "#/definitions/httphandler.lifecycleErrorEnvelope"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/httphandler.lifecycleErrorEnvelope"
+                        }
+                    },
+                    "409": {
+                        "description": "Conflict",
+                        "schema": {
+                            "$ref": "#/definitions/httphandler.lifecycleErrorEnvelope"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/httphandler.lifecycleErrorEnvelope"
+                        }
+                    }
+                }
+            }
+        },
         "/evidence-nodes/{node_id}": {
             "get": {
                 "description": "Returns one visible claim, evidence ref, or business ref node scoped by trace_id or request_id.",
@@ -270,7 +1026,7 @@ const docTemplate = `{
         },
         "/evidence/events": {
             "post": {
-                "description": "Accepts claim.created, evidence.refs.created, and business.refs.resolved events and stores the normalized evidence model.",
+                "description": "Commits the immutable Evidence Ledger record and Projection Outbox in one transaction before returning durable_ack.",
                 "consumes": [
                     "application/json"
                 ],
@@ -280,15 +1036,15 @@ const docTemplate = `{
                 "tags": [
                     "evidence"
                 ],
-                "summary": "Ingest BKN Trace phase-two evidence events",
+                "summary": "Durably ingest one BKN Trace 3.0 evidence event",
                 "parameters": [
                     {
-                        "description": "BKN Trace phase-two evidence event batch",
+                        "description": "BKN Trace 3.0 evidence event",
                         "name": "request",
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "type": "string"
+                            "$ref": "#/definitions/httphandler.evidenceEventRequest"
                         }
                     }
                 ],
@@ -296,25 +1052,769 @@ const docTemplate = `{
                     "202": {
                         "description": "Accepted",
                         "schema": {
-                            "$ref": "#/definitions/evidencevo.IngestResponse"
+                            "$ref": "#/definitions/ledgervo.DurableAck"
                         }
                     },
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/rdto.ErrorResponse"
+                            "$ref": "#/definitions/httphandler.lifecycleErrorEnvelope"
                         }
                     },
-                    "405": {
-                        "description": "Method Not Allowed",
+                    "401": {
+                        "description": "Unauthorized",
                         "schema": {
-                            "$ref": "#/definitions/rdto.ErrorResponse"
+                            "$ref": "#/definitions/httphandler.lifecycleErrorEnvelope"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "$ref": "#/definitions/httphandler.lifecycleErrorEnvelope"
+                        }
+                    },
+                    "409": {
+                        "description": "Conflict",
+                        "schema": {
+                            "$ref": "#/definitions/httphandler.lifecycleErrorEnvelope"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/rdto.ErrorResponse"
+                            "$ref": "#/definitions/httphandler.lifecycleErrorEnvelope"
+                        }
+                    }
+                }
+            }
+        },
+        "/interactions/{interaction_id}": {
+            "get": {
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "lifecycle"
+                ],
+                "summary": "Get one managed Interaction",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Interaction ID",
+                        "name": "interaction_id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/sessionvo.Interaction"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/httphandler.lifecycleErrorEnvelope"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "$ref": "#/definitions/httphandler.lifecycleErrorEnvelope"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/httphandler.lifecycleErrorEnvelope"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/httphandler.lifecycleErrorEnvelope"
+                        }
+                    }
+                }
+            }
+        },
+        "/interactions/{interaction_id}/cancel": {
+            "post": {
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "lifecycle"
+                ],
+                "summary": "Cancel one managed Interaction",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Interaction ID",
+                        "name": "interaction_id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Terminal closure manifest",
+                        "name": "request",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/httphandler.terminalInteractionRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/sessionvo.Interaction"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/httphandler.lifecycleErrorEnvelope"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/httphandler.lifecycleErrorEnvelope"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "$ref": "#/definitions/httphandler.lifecycleErrorEnvelope"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/httphandler.lifecycleErrorEnvelope"
+                        }
+                    },
+                    "409": {
+                        "description": "Conflict",
+                        "schema": {
+                            "$ref": "#/definitions/httphandler.lifecycleErrorEnvelope"
+                        }
+                    },
+                    "422": {
+                        "description": "Unprocessable Entity",
+                        "schema": {
+                            "$ref": "#/definitions/httphandler.lifecycleErrorEnvelope"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/httphandler.lifecycleErrorEnvelope"
+                        }
+                    }
+                }
+            }
+        },
+        "/interactions/{interaction_id}/complete": {
+            "post": {
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "lifecycle"
+                ],
+                "summary": "Complete one managed Interaction",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Interaction ID",
+                        "name": "interaction_id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Terminal closure manifest",
+                        "name": "request",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/httphandler.terminalInteractionRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/sessionvo.Interaction"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/httphandler.lifecycleErrorEnvelope"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/httphandler.lifecycleErrorEnvelope"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "$ref": "#/definitions/httphandler.lifecycleErrorEnvelope"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/httphandler.lifecycleErrorEnvelope"
+                        }
+                    },
+                    "409": {
+                        "description": "Conflict",
+                        "schema": {
+                            "$ref": "#/definitions/httphandler.lifecycleErrorEnvelope"
+                        }
+                    },
+                    "422": {
+                        "description": "Unprocessable Entity",
+                        "schema": {
+                            "$ref": "#/definitions/httphandler.lifecycleErrorEnvelope"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/httphandler.lifecycleErrorEnvelope"
+                        }
+                    }
+                }
+            }
+        },
+        "/interactions/{interaction_id}/fail": {
+            "post": {
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "lifecycle"
+                ],
+                "summary": "Fail one managed Interaction",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Interaction ID",
+                        "name": "interaction_id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Terminal closure manifest",
+                        "name": "request",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/httphandler.terminalInteractionRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/sessionvo.Interaction"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/httphandler.lifecycleErrorEnvelope"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/httphandler.lifecycleErrorEnvelope"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "$ref": "#/definitions/httphandler.lifecycleErrorEnvelope"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/httphandler.lifecycleErrorEnvelope"
+                        }
+                    },
+                    "409": {
+                        "description": "Conflict",
+                        "schema": {
+                            "$ref": "#/definitions/httphandler.lifecycleErrorEnvelope"
+                        }
+                    },
+                    "422": {
+                        "description": "Unprocessable Entity",
+                        "schema": {
+                            "$ref": "#/definitions/httphandler.lifecycleErrorEnvelope"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/httphandler.lifecycleErrorEnvelope"
+                        }
+                    }
+                }
+            }
+        },
+        "/interactions/{interaction_id}/handoff": {
+            "post": {
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "lifecycle"
+                ],
+                "summary": "Hand off one managed Interaction",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Interaction ID",
+                        "name": "interaction_id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Terminal closure manifest",
+                        "name": "request",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/httphandler.terminalInteractionRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/sessionvo.Interaction"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/httphandler.lifecycleErrorEnvelope"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/httphandler.lifecycleErrorEnvelope"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "$ref": "#/definitions/httphandler.lifecycleErrorEnvelope"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/httphandler.lifecycleErrorEnvelope"
+                        }
+                    },
+                    "409": {
+                        "description": "Conflict",
+                        "schema": {
+                            "$ref": "#/definitions/httphandler.lifecycleErrorEnvelope"
+                        }
+                    },
+                    "422": {
+                        "description": "Unprocessable Entity",
+                        "schema": {
+                            "$ref": "#/definitions/httphandler.lifecycleErrorEnvelope"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/httphandler.lifecycleErrorEnvelope"
+                        }
+                    }
+                }
+            }
+        },
+        "/operations/{operation_id}": {
+            "get": {
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "lifecycle"
+                ],
+                "summary": "Get one Operation",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Operation ID",
+                        "name": "operation_id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/sessionvo.Operation"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/httphandler.lifecycleErrorEnvelope"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "$ref": "#/definitions/httphandler.lifecycleErrorEnvelope"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/httphandler.lifecycleErrorEnvelope"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/httphandler.lifecycleErrorEnvelope"
+                        }
+                    }
+                }
+            }
+        },
+        "/operations/{operation_id}/attempts": {
+            "post": {
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "lifecycle"
+                ],
+                "summary": "Start the next retry attempt for an Operation",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Operation ID",
+                        "name": "operation_id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Current Interaction lease",
+                        "name": "request",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/httphandler.interactionLeaseRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "description": "Created",
+                        "schema": {
+                            "$ref": "#/definitions/httphandler.operationResult"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/httphandler.lifecycleErrorEnvelope"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/httphandler.lifecycleErrorEnvelope"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "$ref": "#/definitions/httphandler.lifecycleErrorEnvelope"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/httphandler.lifecycleErrorEnvelope"
+                        }
+                    },
+                    "409": {
+                        "description": "Conflict",
+                        "schema": {
+                            "$ref": "#/definitions/httphandler.lifecycleErrorEnvelope"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/httphandler.lifecycleErrorEnvelope"
+                        }
+                    }
+                }
+            }
+        },
+        "/operations/{operation_id}/attempts/{attempt}:complete": {
+            "post": {
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "lifecycle"
+                ],
+                "summary": "Complete one Operation attempt",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Operation ID",
+                        "name": "operation_id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "integer",
+                        "description": "Attempt number",
+                        "name": "attempt",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Durable operation result",
+                        "name": "request",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/httphandler.finishAttemptRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/httphandler.operationResult"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/httphandler.lifecycleErrorEnvelope"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/httphandler.lifecycleErrorEnvelope"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "$ref": "#/definitions/httphandler.lifecycleErrorEnvelope"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/httphandler.lifecycleErrorEnvelope"
+                        }
+                    },
+                    "409": {
+                        "description": "Conflict",
+                        "schema": {
+                            "$ref": "#/definitions/httphandler.lifecycleErrorEnvelope"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/httphandler.lifecycleErrorEnvelope"
+                        }
+                    }
+                }
+            }
+        },
+        "/operations/{operation_id}/attempts/{attempt}:fail": {
+            "post": {
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "lifecycle"
+                ],
+                "summary": "Fail one Operation attempt",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Operation ID",
+                        "name": "operation_id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "integer",
+                        "description": "Attempt number",
+                        "name": "attempt",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Durable operation failure",
+                        "name": "request",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/httphandler.finishAttemptRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/httphandler.operationResult"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/httphandler.lifecycleErrorEnvelope"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/httphandler.lifecycleErrorEnvelope"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "$ref": "#/definitions/httphandler.lifecycleErrorEnvelope"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/httphandler.lifecycleErrorEnvelope"
+                        }
+                    },
+                    "409": {
+                        "description": "Conflict",
+                        "schema": {
+                            "$ref": "#/definitions/httphandler.lifecycleErrorEnvelope"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/httphandler.lifecycleErrorEnvelope"
+                        }
+                    }
+                }
+            }
+        },
+        "/receipts/{receipt_id}": {
+            "get": {
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "lifecycle"
+                ],
+                "summary": "Get one durable Receipt",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Receipt ID",
+                        "name": "receipt_id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/sessionvo.Receipt"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/httphandler.lifecycleErrorEnvelope"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "$ref": "#/definitions/httphandler.lifecycleErrorEnvelope"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/httphandler.lifecycleErrorEnvelope"
+                        }
+                    },
+                    "409": {
+                        "description": "Conflict",
+                        "schema": {
+                            "$ref": "#/definitions/httphandler.lifecycleErrorEnvelope"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/httphandler.lifecycleErrorEnvelope"
                         }
                     }
                 }
@@ -322,85 +1822,18 @@ const docTemplate = `{
         },
         "/requests": {
             "get": {
-                "description": "Returns stable request summaries generated from authorized evidence and artifacts.",
                 "produces": [
                     "application/json"
                 ],
                 "tags": [
-                    "requests"
+                    "lifecycle"
                 ],
-                "summary": "List observable business requests",
+                "summary": "List request projections from durable Receipts",
                 "parameters": [
                     {
                         "type": "integer",
-                        "description": "Page size, 1..200",
+                        "description": "Page size, 1..100",
                         "name": "limit",
-                        "in": "query"
-                    },
-                    {
-                        "type": "string",
-                        "description": "Opaque pagination cursor",
-                        "name": "cursor",
-                        "in": "query"
-                    },
-                    {
-                        "type": "string",
-                        "description": "One user interaction ID",
-                        "name": "interaction_id",
-                        "in": "query"
-                    },
-                    {
-                        "type": "string",
-                        "description": "Caller-owned conversation ID",
-                        "name": "conversation_id",
-                        "in": "query"
-                    },
-                    {
-                        "type": "string",
-                        "description": "Started at or after this RFC3339 timestamp",
-                        "name": "from",
-                        "in": "query"
-                    },
-                    {
-                        "type": "string",
-                        "description": "Started at or before this RFC3339 timestamp",
-                        "name": "to",
-                        "in": "query"
-                    },
-                    {
-                        "type": "string",
-                        "description": "Execution status",
-                        "name": "status",
-                        "in": "query"
-                    },
-                    {
-                        "type": "string",
-                        "description": "Agent or application",
-                        "name": "agent_or_app",
-                        "in": "query"
-                    },
-                    {
-                        "type": "string",
-                        "description": "Business domain",
-                        "name": "business_domain",
-                        "in": "query"
-                    },
-                    {
-                        "type": "string",
-                        "description": "Knowledge network",
-                        "name": "knowledge_network",
-                        "in": "query"
-                    },
-                    {
-                        "type": "string",
-                        "description": "Evidence completeness",
-                        "name": "evidence_completeness",
-                        "in": "query"
-                    },
-                    {
-                        "type": "string",
-                        "description": "Question, result, ID, business ref, or error keyword",
-                        "name": "keyword",
                         "in": "query"
                     }
                 ],
@@ -408,25 +1841,25 @@ const docTemplate = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/evidencevo.RequestSummaryPage"
-                        }
-                    },
-                    "400": {
-                        "description": "Bad Request",
-                        "schema": {
-                            "$ref": "#/definitions/rdto.ErrorResponse"
+                            "$ref": "#/definitions/httphandler.requestPage"
                         }
                     },
                     "401": {
                         "description": "Unauthorized",
                         "schema": {
-                            "$ref": "#/definitions/rdto.ErrorResponse"
+                            "$ref": "#/definitions/httphandler.lifecycleErrorEnvelope"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "$ref": "#/definitions/httphandler.lifecycleErrorEnvelope"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/rdto.ErrorResponse"
+                            "$ref": "#/definitions/httphandler.lifecycleErrorEnvelope"
                         }
                     }
                 }
@@ -434,18 +1867,17 @@ const docTemplate = `{
         },
         "/requests/{request_id}": {
             "get": {
-                "description": "Returns an authorized request summary and its business-content availability.",
                 "produces": [
                     "application/json"
                 ],
                 "tags": [
-                    "requests"
+                    "lifecycle"
                 ],
-                "summary": "Get one observable business request",
+                "summary": "Get one request projection from durable Receipts",
                 "parameters": [
                     {
                         "type": "string",
-                        "description": "BKN request ID",
+                        "description": "Request ID",
                         "name": "request_id",
                         "in": "path",
                         "required": true
@@ -455,31 +1887,31 @@ const docTemplate = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/evidencevo.RequestSummary"
-                        }
-                    },
-                    "400": {
-                        "description": "Bad Request",
-                        "schema": {
-                            "$ref": "#/definitions/rdto.ErrorResponse"
+                            "$ref": "#/definitions/sessionvo.RequestSummary"
                         }
                     },
                     "401": {
                         "description": "Unauthorized",
                         "schema": {
-                            "$ref": "#/definitions/rdto.ErrorResponse"
+                            "$ref": "#/definitions/httphandler.lifecycleErrorEnvelope"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "$ref": "#/definitions/httphandler.lifecycleErrorEnvelope"
                         }
                     },
                     "404": {
                         "description": "Not Found",
                         "schema": {
-                            "$ref": "#/definitions/rdto.ErrorResponse"
+                            "$ref": "#/definitions/httphandler.lifecycleErrorEnvelope"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/rdto.ErrorResponse"
+                            "$ref": "#/definitions/httphandler.lifecycleErrorEnvelope"
                         }
                     }
                 }
@@ -517,14 +1949,14 @@ const docTemplate = `{
                     },
                     {
                         "type": "string",
-                        "description": "One user interaction ID",
-                        "name": "interaction_id",
+                        "description": "Caller-owned conversation ID",
+                        "name": "conversation_id",
                         "in": "query"
                     },
                     {
                         "type": "string",
-                        "description": "Caller-owned conversation ID",
-                        "name": "conversation_id",
+                        "description": "One user interaction ID",
+                        "name": "interaction_id",
                         "in": "query"
                     }
                 ],
@@ -581,8 +2013,8 @@ const docTemplate = `{
                     },
                     {
                         "type": "string",
-                        "description": "One user interaction ID",
-                        "name": "interaction_id",
+                        "description": "Exact trace ID; bypasses list projection scan",
+                        "name": "trace_id",
                         "in": "query"
                     },
                     {
@@ -593,8 +2025,8 @@ const docTemplate = `{
                     },
                     {
                         "type": "string",
-                        "description": "Exact trace ID; bypasses list projection scan",
-                        "name": "trace_id",
+                        "description": "One user interaction ID",
+                        "name": "interaction_id",
                         "in": "query"
                     },
                     {
@@ -655,114 +2087,6 @@ const docTemplate = `{
                     },
                     "500": {
                         "description": "Internal Server Error",
-                        "schema": {
-                            "$ref": "#/definitions/rdto.ErrorResponse"
-                        }
-                    }
-                }
-            }
-        },
-        "/traces/_search": {
-            "post": {
-                "description": "Proxy raw OpenSearch DSL to the configured trace index and return the original OpenSearch response body.",
-                "consumes": [
-                    "application/json"
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "traces"
-                ],
-                "summary": "Search traces with raw OpenSearch DSL",
-                "parameters": [
-                    {
-                        "description": "OpenSearch DSL JSON body",
-                        "name": "request",
-                        "in": "body",
-                        "required": true,
-                        "schema": {
-                            "type": "string"
-                        }
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Raw OpenSearch search response",
-                        "schema": {
-                            "type": "string"
-                        }
-                    },
-                    "400": {
-                        "description": "Bad Request",
-                        "schema": {
-                            "$ref": "#/definitions/rdto.ErrorResponse"
-                        }
-                    },
-                    "405": {
-                        "description": "Method Not Allowed",
-                        "schema": {
-                            "$ref": "#/definitions/rdto.ErrorResponse"
-                        }
-                    },
-                    "504": {
-                        "description": "Gateway Timeout",
-                        "schema": {
-                            "$ref": "#/definitions/rdto.ErrorResponse"
-                        }
-                    }
-                }
-            }
-        },
-        "/traces/by-conversation": {
-            "get": {
-                "description": "Build a term filter automatically using attributes.gen_ai.conversation.id.keyword and return the original OpenSearch response body.",
-                "consumes": [
-                    "application/json"
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "traces"
-                ],
-                "summary": "Search traces by conversation ID",
-                "parameters": [
-                    {
-                        "type": "string",
-                        "description": "Conversation ID",
-                        "name": "conversation_id",
-                        "in": "query",
-                        "required": true
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Raw OpenSearch search response",
-                        "schema": {
-                            "type": "string"
-                        }
-                    },
-                    "400": {
-                        "description": "Bad Request",
-                        "schema": {
-                            "$ref": "#/definitions/rdto.ErrorResponse"
-                        }
-                    },
-                    "405": {
-                        "description": "Method Not Allowed",
-                        "schema": {
-                            "$ref": "#/definitions/rdto.ErrorResponse"
-                        }
-                    },
-                    "500": {
-                        "description": "Internal Server Error",
-                        "schema": {
-                            "$ref": "#/definitions/rdto.ErrorResponse"
-                        }
-                    },
-                    "504": {
-                        "description": "Gateway Timeout",
                         "schema": {
                             "$ref": "#/definitions/rdto.ErrorResponse"
                         }
@@ -1111,119 +2435,6 @@ const docTemplate = `{
                     },
                     "405": {
                         "description": "Method Not Allowed",
-                        "schema": {
-                            "$ref": "#/definitions/rdto.ErrorResponse"
-                        }
-                    },
-                    "500": {
-                        "description": "Internal Server Error",
-                        "schema": {
-                            "$ref": "#/definitions/rdto.ErrorResponse"
-                        }
-                    }
-                }
-            }
-        },
-        "/traces/{trace_id}/trace-graph": {
-            "get": {
-                "description": "Returns normalized trace tree nodes, parent-child edges, status, duration, and partial reasons for a trace.",
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "traces"
-                ],
-                "summary": "Get trace graph by trace ID",
-                "parameters": [
-                    {
-                        "type": "string",
-                        "description": "Trace ID",
-                        "name": "trace_id",
-                        "in": "path",
-                        "required": true
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "schema": {
-                            "type": "object",
-                            "additionalProperties": true
-                        }
-                    },
-                    "400": {
-                        "description": "Bad Request",
-                        "schema": {
-                            "$ref": "#/definitions/rdto.ErrorResponse"
-                        }
-                    },
-                    "404": {
-                        "description": "Not Found",
-                        "schema": {
-                            "$ref": "#/definitions/rdto.ErrorResponse"
-                        }
-                    },
-                    "405": {
-                        "description": "Method Not Allowed",
-                        "schema": {
-                            "$ref": "#/definitions/rdto.ErrorResponse"
-                        }
-                    },
-                    "500": {
-                        "description": "Internal Server Error",
-                        "schema": {
-                            "$ref": "#/definitions/rdto.ErrorResponse"
-                        }
-                    },
-                    "504": {
-                        "description": "Gateway Timeout",
-                        "schema": {
-                            "$ref": "#/definitions/rdto.ErrorResponse"
-                        }
-                    }
-                }
-            }
-        },
-        "/interactions/{interaction_id}": {
-            "get": {
-                "description": "Aggregates every authorized request and trace in one caller-owned interaction.",
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "interactions"
-                ],
-                "summary": "Get one observable business interaction",
-                "parameters": [
-                    {
-                        "type": "string",
-                        "description": "BKN interaction ID",
-                        "name": "interaction_id",
-                        "in": "path",
-                        "required": true
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "schema": {
-                            "$ref": "#/definitions/evidencevo.InteractionSummary"
-                        }
-                    },
-                    "400": {
-                        "description": "Bad Request",
-                        "schema": {
-                            "$ref": "#/definitions/rdto.ErrorResponse"
-                        }
-                    },
-                    "401": {
-                        "description": "Unauthorized",
-                        "schema": {
-                            "$ref": "#/definitions/rdto.ErrorResponse"
-                        }
-                    },
-                    "404": {
-                        "description": "Not Found",
                         "schema": {
                             "$ref": "#/definitions/rdto.ErrorResponse"
                         }
@@ -1672,6 +2883,41 @@ const docTemplate = `{
                 }
             }
         },
+        "evidencevo.InteractionSummary": {
+            "type": "object",
+            "properties": {
+                "completed_at": {
+                    "type": "string"
+                },
+                "conversation_id": {
+                    "type": "string"
+                },
+                "duration_ms": {
+                    "type": "integer"
+                },
+                "interaction_id": {
+                    "type": "string"
+                },
+                "requests": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/evidencevo.RequestSummary"
+                    }
+                },
+                "started_at": {
+                    "type": "string"
+                },
+                "status": {
+                    "type": "string"
+                },
+                "traces": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/evidencevo.TraceSummary"
+                    }
+                }
+            }
+        },
         "evidencevo.RequestSummary": {
             "type": "object",
             "properties": {
@@ -1702,13 +2948,13 @@ const docTemplate = `{
                 "error_summary": {
                     "type": "string"
                 },
-                "interaction_id": {
-                    "type": "string"
-                },
                 "evidence_completeness": {
                     "type": "string"
                 },
                 "initiator": {
+                    "type": "string"
+                },
+                "interaction_id": {
                     "type": "string"
                 },
                 "knowledge_networks": {
@@ -1964,6 +3210,404 @@ const docTemplate = `{
                 }
             }
         },
+        "httphandler.closeConversationRequest": {
+            "type": "object",
+            "properties": {
+                "idempotency_key": {
+                    "type": "string"
+                }
+            }
+        },
+        "httphandler.conversationPage": {
+            "type": "object",
+            "properties": {
+                "entries": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/sessionvo.Conversation"
+                    }
+                },
+                "next_cursor": {
+                    "type": "string"
+                }
+            }
+        },
+        "httphandler.ensureConversationRequest": {
+            "type": "object",
+            "properties": {
+                "application_principal_id": {
+                    "type": "string"
+                },
+                "business_domain_id": {
+                    "type": "string"
+                },
+                "delegation_id": {
+                    "type": "string"
+                },
+                "effective_subject_id": {
+                    "type": "string"
+                },
+                "effective_subject_type": {
+                    "type": "string"
+                },
+                "external_conversation_key": {
+                    "type": "string"
+                },
+                "idempotency_key": {
+                    "type": "string"
+                },
+                "one_shot": {
+                    "type": "boolean"
+                },
+                "tenant_id": {
+                    "type": "string"
+                }
+            }
+        },
+        "httphandler.ensureOperationRequest": {
+            "type": "object",
+            "properties": {
+                "causation_event_ids": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "lease_epoch": {
+                    "type": "integer"
+                },
+                "lease_token": {
+                    "type": "string"
+                },
+                "normalized_input_hash": {
+                    "type": "string"
+                },
+                "operation_key": {
+                    "type": "string"
+                },
+                "parent_operation_id": {
+                    "type": "string"
+                },
+                "required": {
+                    "type": "boolean"
+                },
+                "tool_name": {
+                    "type": "string"
+                }
+            }
+        },
+        "httphandler.evidenceEventRequest": {
+            "type": "object",
+            "properties": {
+                "artifact_refs": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "attempt": {
+                    "type": "integer"
+                },
+                "business_domain_id": {
+                    "type": "string"
+                },
+                "business_refs": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/sessionvo.BusinessRef"
+                    }
+                },
+                "causation_event_ids": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "conversation_id": {
+                    "type": "string"
+                },
+                "emitted_at": {
+                    "type": "string"
+                },
+                "envelope": {
+                    "type": "array",
+                    "items": {
+                        "type": "integer"
+                    }
+                },
+                "event_id": {
+                    "type": "string"
+                },
+                "event_type": {
+                    "type": "string"
+                },
+                "interaction_id": {
+                    "type": "string"
+                },
+                "observed_at": {
+                    "type": "string"
+                },
+                "operation_id": {
+                    "type": "string"
+                },
+                "payload_hash": {
+                    "type": "string"
+                },
+                "producer_epoch": {
+                    "type": "integer"
+                },
+                "producer_id": {
+                    "type": "string"
+                },
+                "producer_sequence": {
+                    "type": "integer"
+                },
+                "producer_stream_id": {
+                    "type": "string"
+                },
+                "request_id": {
+                    "type": "string"
+                },
+                "schema_version": {
+                    "type": "string"
+                },
+                "span_id": {
+                    "type": "string"
+                },
+                "started_at": {
+                    "type": "string"
+                },
+                "tenant_id": {
+                    "type": "string"
+                },
+                "trace_id": {
+                    "type": "string"
+                }
+            }
+        },
+        "httphandler.finishAttemptRequest": {
+            "type": "object",
+            "properties": {
+                "artifact_refs": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "business_refs": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/sessionvo.BusinessRef"
+                    }
+                },
+                "evidence_durability": {
+                    "$ref": "#/definitions/sessionvo.EvidenceDurability"
+                },
+                "observed_evidence_refs": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "partial_reasons": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "payload_hash": {
+                    "type": "string"
+                },
+                "receipt_id": {
+                    "type": "string"
+                },
+                "request_id": {
+                    "type": "string"
+                },
+                "retryable": {
+                    "type": "boolean"
+                },
+                "trace_id": {
+                    "type": "string"
+                }
+            }
+        },
+        "httphandler.interactionLeaseRequest": {
+            "type": "object",
+            "properties": {
+                "lease_epoch": {
+                    "type": "integer"
+                },
+                "lease_token": {
+                    "type": "string"
+                }
+            }
+        },
+        "httphandler.lifecycleError": {
+            "type": "object",
+            "properties": {
+                "code": {
+                    "type": "string",
+                    "enum": [
+                        "conversation_required",
+                        "conversation_not_found",
+                        "conversation_closed",
+                        "conversation_expired",
+                        "conversation_owner_mismatch",
+                        "interaction_required",
+                        "interaction_in_progress",
+                        "interaction_terminal",
+                        "operation_required",
+                        "idempotency_conflict",
+                        "event_payload_conflict",
+                        "producer_sequence_conflict",
+                        "invalid_evidence_event",
+                        "receipt_pending",
+                        "terminal_conflict",
+                        "closure_manifest_invalid",
+                        "feature_not_installed",
+                        "capability_not_licensed",
+                        "permission_denied",
+                        "resource_not_disclosed",
+                        "internal_error"
+                    ]
+                },
+                "current_status": {
+                    "type": "string"
+                },
+                "message": {
+                    "type": "string"
+                },
+                "request_id": {
+                    "type": "string"
+                },
+                "required_action": {
+                    "type": "string"
+                },
+                "retry_after_ms": {
+                    "type": "integer"
+                },
+                "retryable": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "httphandler.lifecycleErrorEnvelope": {
+            "type": "object",
+            "properties": {
+                "error": {
+                    "$ref": "#/definitions/httphandler.lifecycleError"
+                }
+            }
+        },
+        "httphandler.operationResult": {
+            "type": "object",
+            "properties": {
+                "operation": {
+                    "$ref": "#/definitions/sessionvo.Operation"
+                },
+                "receipt": {
+                    "$ref": "#/definitions/sessionvo.Receipt"
+                }
+            }
+        },
+        "httphandler.requestPage": {
+            "type": "object",
+            "properties": {
+                "entries": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/sessionvo.RequestSummary"
+                    }
+                },
+                "next_cursor": {
+                    "type": "string"
+                }
+            }
+        },
+        "httphandler.resumeConversationRequest": {
+            "type": "object",
+            "properties": {
+                "conversation_id": {
+                    "type": "string"
+                }
+            }
+        },
+        "httphandler.startInteractionRequest": {
+            "type": "object",
+            "properties": {
+                "idempotency_key": {
+                    "type": "string"
+                },
+                "lease_seconds": {
+                    "type": "integer"
+                }
+            }
+        },
+        "httphandler.terminalInteractionRequest": {
+            "type": "object",
+            "properties": {
+                "answer_artifact_ref": {
+                    "type": "string"
+                },
+                "assembler_deadline": {
+                    "type": "string"
+                },
+                "claims": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "completion_manifest_version": {
+                    "type": "string"
+                },
+                "completion_reason": {
+                    "type": "string"
+                },
+                "expected_operations": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/sessionvo.ExpectedOperation"
+                    }
+                },
+                "expected_receipts": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/sessionvo.ExpectedReceipt"
+                    }
+                },
+                "lease_epoch": {
+                    "type": "integer"
+                },
+                "lease_token": {
+                    "type": "string"
+                },
+                "terminal_idempotency_key": {
+                    "type": "string"
+                }
+            }
+        },
+        "ledgervo.DurableAck": {
+            "type": "object",
+            "properties": {
+                "durable_ack": {
+                    "type": "boolean"
+                },
+                "event_id": {
+                    "type": "string"
+                },
+                "ingest_sequence": {
+                    "type": "integer"
+                },
+                "ingested_at": {
+                    "type": "string"
+                },
+                "replayed": {
+                    "type": "boolean"
+                }
+            }
+        },
         "rdto.ErrorResponse": {
             "type": "object",
             "properties": {
@@ -1982,40 +3626,466 @@ const docTemplate = `{
                 }
             }
         },
-        "evidencevo.InteractionSummary": {
+        "sessionvo.AttemptStatus": {
+            "type": "string",
+            "enum": [
+                "pending",
+                "completed",
+                "failed"
+            ],
+            "x-enum-varnames": [
+                "AttemptPending",
+                "AttemptCompleted",
+                "AttemptFailed"
+            ]
+        },
+        "sessionvo.BusinessRef": {
             "type": "object",
             "properties": {
-                "completed_at": {
+                "as_of": {
+                    "type": "string"
+                },
+                "business_domain_id": {
+                    "type": "string"
+                },
+                "display_hint": {
+                    "type": "string"
+                },
+                "ref_id": {
+                    "type": "string"
+                },
+                "ref_type": {
+                    "type": "string"
+                },
+                "version": {
+                    "type": "string"
+                }
+            }
+        },
+        "sessionvo.ClosureManifest": {
+            "type": "object",
+            "properties": {
+                "answer_artifact_ref": {
+                    "type": "string"
+                },
+                "assembler_deadline": {
+                    "type": "string"
+                },
+                "claims": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "completion_manifest_version": {
+                    "type": "string"
+                },
+                "completion_reason": {
+                    "type": "string"
+                },
+                "expected_operations": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/sessionvo.ExpectedOperation"
+                    }
+                },
+                "expected_receipts": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/sessionvo.ExpectedReceipt"
+                    }
+                },
+                "system_partial_reasons": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            }
+        },
+        "sessionvo.Conversation": {
+            "type": "object",
+            "properties": {
+                "closed_at": {
                     "type": "string"
                 },
                 "conversation_id": {
                     "type": "string"
                 },
-                "duration_ms": {
+                "created_at": {
+                    "type": "string"
+                },
+                "external_conversation_key": {
+                    "type": "string"
+                },
+                "generation": {
                     "type": "integer"
+                },
+                "one_shot": {
+                    "type": "boolean"
+                },
+                "owner": {
+                    "$ref": "#/definitions/sessionvo.Owner"
+                },
+                "row_version": {
+                    "type": "integer"
+                },
+                "status": {
+                    "$ref": "#/definitions/sessionvo.ConversationStatus"
+                },
+                "updated_at": {
+                    "type": "string"
+                }
+            }
+        },
+        "sessionvo.ConversationStatus": {
+            "type": "string",
+            "enum": [
+                "active",
+                "closed",
+                "expired"
+            ],
+            "x-enum-varnames": [
+                "ConversationActive",
+                "ConversationClosed",
+                "ConversationExpired"
+            ]
+        },
+        "sessionvo.EvidenceDurability": {
+            "type": "string",
+            "enum": [
+                "pending",
+                "durable",
+                "failed"
+            ],
+            "x-enum-varnames": [
+                "DurabilityPending",
+                "DurabilityDurable",
+                "DurabilityFailed"
+            ]
+        },
+        "sessionvo.EvidenceStatus": {
+            "type": "string",
+            "enum": [
+                "not_applicable",
+                "assembling",
+                "complete",
+                "partial",
+                "failed"
+            ],
+            "x-enum-varnames": [
+                "EvidenceNotApplicable",
+                "EvidenceAssembling",
+                "EvidenceComplete",
+                "EvidencePartial",
+                "EvidenceFailed"
+            ]
+        },
+        "sessionvo.ExpectedOperation": {
+            "type": "object",
+            "properties": {
+                "operation_id": {
+                    "type": "string"
+                },
+                "required": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "sessionvo.ExpectedReceipt": {
+            "type": "object",
+            "properties": {
+                "receipt_id": {
+                    "type": "string"
+                },
+                "required": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "sessionvo.Interaction": {
+            "type": "object",
+            "properties": {
+                "closure_manifest": {
+                    "$ref": "#/definitions/sessionvo.ClosureManifest"
+                },
+                "conversation_id": {
+                    "type": "string"
+                },
+                "created_at": {
+                    "type": "string"
+                },
+                "evidence_status": {
+                    "$ref": "#/definitions/sessionvo.EvidenceStatus"
+                },
+                "execution_status": {
+                    "$ref": "#/definitions/sessionvo.InteractionStatus"
                 },
                 "interaction_id": {
                     "type": "string"
                 },
-                "requests": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/evidencevo.RequestSummary"
-                    }
+                "lease_epoch": {
+                    "type": "integer"
                 },
-                "started_at": {
+                "lease_expires_at": {
                     "type": "string"
                 },
-                "status": {
+                "lease_token": {
                     "type": "string"
                 },
-                "traces": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/evidencevo.TraceSummary"
-                    }
+                "lease_version": {
+                    "type": "integer"
+                },
+                "ordinal": {
+                    "type": "integer"
+                },
+                "row_version": {
+                    "type": "integer"
+                },
+                "terminal_at": {
+                    "type": "string"
+                },
+                "updated_at": {
+                    "type": "string"
                 }
             }
+        },
+        "sessionvo.InteractionStatus": {
+            "type": "string",
+            "enum": [
+                "active",
+                "completed",
+                "failed",
+                "canceled",
+                "handed_off",
+                "abandoned"
+            ],
+            "x-enum-varnames": [
+                "InteractionActive",
+                "InteractionCompleted",
+                "InteractionFailed",
+                "InteractionCanceled",
+                "InteractionHandedOff",
+                "InteractionAbandoned"
+            ]
+        },
+        "sessionvo.Operation": {
+            "type": "object",
+            "properties": {
+                "attempt": {
+                    "type": "integer"
+                },
+                "attempt_status": {
+                    "$ref": "#/definitions/sessionvo.AttemptStatus"
+                },
+                "causation_event_ids": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "conversation_id": {
+                    "type": "string"
+                },
+                "created_at": {
+                    "type": "string"
+                },
+                "interaction_id": {
+                    "type": "string"
+                },
+                "normalized_input_hash": {
+                    "type": "string"
+                },
+                "operation_id": {
+                    "type": "string"
+                },
+                "operation_key": {
+                    "type": "string"
+                },
+                "parent_operation_id": {
+                    "type": "string"
+                },
+                "retryable": {
+                    "type": "boolean"
+                },
+                "row_version": {
+                    "type": "integer"
+                },
+                "tool_name": {
+                    "type": "string"
+                },
+                "updated_at": {
+                    "type": "string"
+                }
+            }
+        },
+        "sessionvo.Owner": {
+            "type": "object",
+            "properties": {
+                "application_principal_id": {
+                    "type": "string"
+                },
+                "business_domain_id": {
+                    "type": "string"
+                },
+                "delegation_id": {
+                    "type": "string"
+                },
+                "effective_subject_id": {
+                    "type": "string"
+                },
+                "effective_subject_type": {
+                    "$ref": "#/definitions/sessionvo.SubjectType"
+                },
+                "tenant_id": {
+                    "type": "string"
+                }
+            }
+        },
+        "sessionvo.Receipt": {
+            "type": "object",
+            "properties": {
+                "artifact_refs": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "attempt": {
+                    "type": "integer"
+                },
+                "business_refs": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/sessionvo.BusinessRef"
+                    }
+                },
+                "causation_event_ids": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "conversation_id": {
+                    "type": "string"
+                },
+                "evidence_durability": {
+                    "$ref": "#/definitions/sessionvo.EvidenceDurability"
+                },
+                "interaction_id": {
+                    "type": "string"
+                },
+                "issued_at": {
+                    "type": "string"
+                },
+                "normalized_input_hash": {
+                    "type": "string"
+                },
+                "observed_evidence_refs": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "operation_id": {
+                    "type": "string"
+                },
+                "operation_key": {
+                    "type": "string"
+                },
+                "owner": {
+                    "$ref": "#/definitions/sessionvo.Owner"
+                },
+                "partial_reasons": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "payload_hash": {
+                    "type": "string"
+                },
+                "receipt_id": {
+                    "type": "string"
+                },
+                "receipt_status": {
+                    "$ref": "#/definitions/sessionvo.ReceiptStatus"
+                },
+                "request_id": {
+                    "type": "string"
+                },
+                "required": {
+                    "type": "boolean"
+                },
+                "row_version": {
+                    "type": "integer"
+                },
+                "schema_version": {
+                    "type": "string"
+                },
+                "terminal_at": {
+                    "type": "string"
+                },
+                "tool_name": {
+                    "type": "string"
+                },
+                "trace_id": {
+                    "type": "string"
+                }
+            }
+        },
+        "sessionvo.ReceiptStatus": {
+            "type": "string",
+            "enum": [
+                "pending",
+                "completed",
+                "failed"
+            ],
+            "x-enum-varnames": [
+                "ReceiptPending",
+                "ReceiptCompleted",
+                "ReceiptFailed"
+            ]
+        },
+        "sessionvo.RequestSummary": {
+            "type": "object",
+            "properties": {
+                "conversation_id": {
+                    "type": "string"
+                },
+                "interaction_id": {
+                    "type": "string"
+                },
+                "operation_count": {
+                    "type": "integer"
+                },
+                "receipt_count": {
+                    "type": "integer"
+                },
+                "request_id": {
+                    "type": "string"
+                },
+                "trace_ids": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "updated_at": {
+                    "type": "string"
+                }
+            }
+        },
+        "sessionvo.SubjectType": {
+            "type": "string",
+            "enum": [
+                "user",
+                "service"
+            ],
+            "x-enum-varnames": [
+                "SubjectUser",
+                "SubjectService"
+            ]
         }
     }
 }`

--- a/bkn-trace/agent-observability/docs/swagger/swagger.json
+++ b/bkn-trace/agent-observability/docs/swagger/swagger.json
@@ -8,6 +8,762 @@
     },
     "basePath": "/api/agent-observability/v1",
     "paths": {
+        "/api/agent-observability/v1/traces/_search": {
+            "post": {
+                "description": "Proxy raw OpenSearch DSL to the configured trace index and return the original OpenSearch response body.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "traces"
+                ],
+                "summary": "Search traces with raw OpenSearch DSL",
+                "parameters": [
+                    {
+                        "description": "OpenSearch DSL JSON body",
+                        "name": "request",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Raw OpenSearch search response",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/rdto.ErrorResponse"
+                        }
+                    },
+                    "405": {
+                        "description": "Method Not Allowed",
+                        "schema": {
+                            "$ref": "#/definitions/rdto.ErrorResponse"
+                        }
+                    },
+                    "504": {
+                        "description": "Gateway Timeout",
+                        "schema": {
+                            "$ref": "#/definitions/rdto.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/api/agent-observability/v1/traces/by-conversation": {
+            "get": {
+                "description": "Build a term filter automatically using attributes.gen_ai.conversation.id.keyword and return the original OpenSearch response body.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "traces"
+                ],
+                "summary": "Search traces by conversation ID",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Conversation ID",
+                        "name": "conversation_id",
+                        "in": "query",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Raw OpenSearch search response",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/rdto.ErrorResponse"
+                        }
+                    },
+                    "405": {
+                        "description": "Method Not Allowed",
+                        "schema": {
+                            "$ref": "#/definitions/rdto.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/rdto.ErrorResponse"
+                        }
+                    },
+                    "504": {
+                        "description": "Gateway Timeout",
+                        "schema": {
+                            "$ref": "#/definitions/rdto.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/api/agent-observability/v1/traces/{trace_id}/trace-graph": {
+            "get": {
+                "description": "Returns normalized trace tree nodes, parent-child edges, status, duration, and partial reasons for a trace.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "traces"
+                ],
+                "summary": "Get trace graph by trace ID",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Trace ID",
+                        "name": "trace_id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": true
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/rdto.ErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/rdto.ErrorResponse"
+                        }
+                    },
+                    "405": {
+                        "description": "Method Not Allowed",
+                        "schema": {
+                            "$ref": "#/definitions/rdto.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/rdto.ErrorResponse"
+                        }
+                    },
+                    "504": {
+                        "description": "Gateway Timeout",
+                        "schema": {
+                            "$ref": "#/definitions/rdto.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/conversations": {
+            "get": {
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "lifecycle"
+                ],
+                "summary": "List managed Conversations in the authorized owner scope",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "Page size, 1..100",
+                        "name": "limit",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/httphandler.conversationPage"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/httphandler.lifecycleErrorEnvelope"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "$ref": "#/definitions/httphandler.lifecycleErrorEnvelope"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/httphandler.lifecycleErrorEnvelope"
+                        }
+                    }
+                }
+            },
+            "post": {
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "lifecycle"
+                ],
+                "summary": "Create or return the current managed Conversation",
+                "parameters": [
+                    {
+                        "description": "Managed Conversation request",
+                        "name": "request",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/httphandler.ensureConversationRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "description": "Created",
+                        "schema": {
+                            "$ref": "#/definitions/sessionvo.Conversation"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/httphandler.lifecycleErrorEnvelope"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/httphandler.lifecycleErrorEnvelope"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "$ref": "#/definitions/httphandler.lifecycleErrorEnvelope"
+                        }
+                    },
+                    "409": {
+                        "description": "Conflict",
+                        "schema": {
+                            "$ref": "#/definitions/httphandler.lifecycleErrorEnvelope"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/httphandler.lifecycleErrorEnvelope"
+                        }
+                    }
+                }
+            }
+        },
+        "/conversations/{conversation_id}": {
+            "get": {
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "lifecycle"
+                ],
+                "summary": "Get one managed Conversation",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Conversation ID",
+                        "name": "conversation_id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/sessionvo.Conversation"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/httphandler.lifecycleErrorEnvelope"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "$ref": "#/definitions/httphandler.lifecycleErrorEnvelope"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/httphandler.lifecycleErrorEnvelope"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/httphandler.lifecycleErrorEnvelope"
+                        }
+                    }
+                }
+            }
+        },
+        "/conversations/{conversation_id}/close": {
+            "post": {
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "lifecycle"
+                ],
+                "summary": "Close one managed Conversation",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Conversation ID",
+                        "name": "conversation_id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Idempotent close request",
+                        "name": "request",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/httphandler.closeConversationRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/sessionvo.Conversation"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/httphandler.lifecycleErrorEnvelope"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/httphandler.lifecycleErrorEnvelope"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "$ref": "#/definitions/httphandler.lifecycleErrorEnvelope"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/httphandler.lifecycleErrorEnvelope"
+                        }
+                    },
+                    "409": {
+                        "description": "Conflict",
+                        "schema": {
+                            "$ref": "#/definitions/httphandler.lifecycleErrorEnvelope"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/httphandler.lifecycleErrorEnvelope"
+                        }
+                    }
+                }
+            }
+        },
+        "/conversations/{conversation_id}/interactions": {
+            "post": {
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "lifecycle"
+                ],
+                "summary": "Start one managed Interaction",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Conversation ID",
+                        "name": "conversation_id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Interaction start request",
+                        "name": "request",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/httphandler.startInteractionRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "description": "Created",
+                        "schema": {
+                            "$ref": "#/definitions/sessionvo.Interaction"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/httphandler.lifecycleErrorEnvelope"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/httphandler.lifecycleErrorEnvelope"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "$ref": "#/definitions/httphandler.lifecycleErrorEnvelope"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/httphandler.lifecycleErrorEnvelope"
+                        }
+                    },
+                    "409": {
+                        "description": "Conflict",
+                        "schema": {
+                            "$ref": "#/definitions/httphandler.lifecycleErrorEnvelope"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/httphandler.lifecycleErrorEnvelope"
+                        }
+                    }
+                }
+            }
+        },
+        "/conversations/{conversation_id}/interactions/{interaction_id}/operations:ensure": {
+            "post": {
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "lifecycle"
+                ],
+                "summary": "Ensure an idempotent Operation intent and durable Receipt",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Conversation ID",
+                        "name": "conversation_id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Interaction ID",
+                        "name": "interaction_id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Operation intent",
+                        "name": "request",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/httphandler.ensureOperationRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "description": "Created",
+                        "schema": {
+                            "$ref": "#/definitions/httphandler.operationResult"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/httphandler.lifecycleErrorEnvelope"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/httphandler.lifecycleErrorEnvelope"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "$ref": "#/definitions/httphandler.lifecycleErrorEnvelope"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/httphandler.lifecycleErrorEnvelope"
+                        }
+                    },
+                    "409": {
+                        "description": "Conflict",
+                        "schema": {
+                            "$ref": "#/definitions/httphandler.lifecycleErrorEnvelope"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/httphandler.lifecycleErrorEnvelope"
+                        }
+                    }
+                }
+            }
+        },
+        "/conversations:create-new-generation": {
+            "post": {
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "lifecycle"
+                ],
+                "summary": "Create a new managed Conversation generation",
+                "parameters": [
+                    {
+                        "description": "New generation request",
+                        "name": "request",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/httphandler.ensureConversationRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "description": "Created",
+                        "schema": {
+                            "$ref": "#/definitions/sessionvo.Conversation"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/httphandler.lifecycleErrorEnvelope"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/httphandler.lifecycleErrorEnvelope"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "$ref": "#/definitions/httphandler.lifecycleErrorEnvelope"
+                        }
+                    },
+                    "409": {
+                        "description": "Conflict",
+                        "schema": {
+                            "$ref": "#/definitions/httphandler.lifecycleErrorEnvelope"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/httphandler.lifecycleErrorEnvelope"
+                        }
+                    }
+                }
+            }
+        },
+        "/conversations:ensure-current": {
+            "post": {
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "lifecycle"
+                ],
+                "summary": "Ensure the current managed Conversation",
+                "parameters": [
+                    {
+                        "description": "Managed Conversation request",
+                        "name": "request",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/httphandler.ensureConversationRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "description": "Created",
+                        "schema": {
+                            "$ref": "#/definitions/sessionvo.Conversation"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/httphandler.lifecycleErrorEnvelope"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/httphandler.lifecycleErrorEnvelope"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "$ref": "#/definitions/httphandler.lifecycleErrorEnvelope"
+                        }
+                    },
+                    "409": {
+                        "description": "Conflict",
+                        "schema": {
+                            "$ref": "#/definitions/httphandler.lifecycleErrorEnvelope"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/httphandler.lifecycleErrorEnvelope"
+                        }
+                    }
+                }
+            }
+        },
+        "/conversations:resume-by-id": {
+            "post": {
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "lifecycle"
+                ],
+                "summary": "Resume an active managed Conversation by Core ID",
+                "parameters": [
+                    {
+                        "description": "Conversation resume request",
+                        "name": "request",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/httphandler.resumeConversationRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/sessionvo.Conversation"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/httphandler.lifecycleErrorEnvelope"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/httphandler.lifecycleErrorEnvelope"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "$ref": "#/definitions/httphandler.lifecycleErrorEnvelope"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/httphandler.lifecycleErrorEnvelope"
+                        }
+                    },
+                    "409": {
+                        "description": "Conflict",
+                        "schema": {
+                            "$ref": "#/definitions/httphandler.lifecycleErrorEnvelope"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/httphandler.lifecycleErrorEnvelope"
+                        }
+                    }
+                }
+            }
+        },
         "/evidence-nodes/{node_id}": {
             "get": {
                 "description": "Returns one visible claim, evidence ref, or business ref node scoped by trace_id or request_id.",
@@ -262,7 +1018,7 @@
         },
         "/evidence/events": {
             "post": {
-                "description": "Accepts claim.created, evidence.refs.created, and business.refs.resolved events and stores the normalized evidence model.",
+                "description": "Commits the immutable Evidence Ledger record and Projection Outbox in one transaction before returning durable_ack.",
                 "consumes": [
                     "application/json"
                 ],
@@ -272,15 +1028,15 @@
                 "tags": [
                     "evidence"
                 ],
-                "summary": "Ingest BKN Trace phase-two evidence events",
+                "summary": "Durably ingest one BKN Trace 3.0 evidence event",
                 "parameters": [
                     {
-                        "description": "BKN Trace phase-two evidence event batch",
+                        "description": "BKN Trace 3.0 evidence event",
                         "name": "request",
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "type": "string"
+                            "$ref": "#/definitions/httphandler.evidenceEventRequest"
                         }
                     }
                 ],
@@ -288,25 +1044,769 @@
                     "202": {
                         "description": "Accepted",
                         "schema": {
-                            "$ref": "#/definitions/evidencevo.IngestResponse"
+                            "$ref": "#/definitions/ledgervo.DurableAck"
                         }
                     },
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/rdto.ErrorResponse"
+                            "$ref": "#/definitions/httphandler.lifecycleErrorEnvelope"
                         }
                     },
-                    "405": {
-                        "description": "Method Not Allowed",
+                    "401": {
+                        "description": "Unauthorized",
                         "schema": {
-                            "$ref": "#/definitions/rdto.ErrorResponse"
+                            "$ref": "#/definitions/httphandler.lifecycleErrorEnvelope"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "$ref": "#/definitions/httphandler.lifecycleErrorEnvelope"
+                        }
+                    },
+                    "409": {
+                        "description": "Conflict",
+                        "schema": {
+                            "$ref": "#/definitions/httphandler.lifecycleErrorEnvelope"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/rdto.ErrorResponse"
+                            "$ref": "#/definitions/httphandler.lifecycleErrorEnvelope"
+                        }
+                    }
+                }
+            }
+        },
+        "/interactions/{interaction_id}": {
+            "get": {
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "lifecycle"
+                ],
+                "summary": "Get one managed Interaction",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Interaction ID",
+                        "name": "interaction_id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/sessionvo.Interaction"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/httphandler.lifecycleErrorEnvelope"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "$ref": "#/definitions/httphandler.lifecycleErrorEnvelope"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/httphandler.lifecycleErrorEnvelope"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/httphandler.lifecycleErrorEnvelope"
+                        }
+                    }
+                }
+            }
+        },
+        "/interactions/{interaction_id}/cancel": {
+            "post": {
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "lifecycle"
+                ],
+                "summary": "Cancel one managed Interaction",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Interaction ID",
+                        "name": "interaction_id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Terminal closure manifest",
+                        "name": "request",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/httphandler.terminalInteractionRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/sessionvo.Interaction"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/httphandler.lifecycleErrorEnvelope"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/httphandler.lifecycleErrorEnvelope"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "$ref": "#/definitions/httphandler.lifecycleErrorEnvelope"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/httphandler.lifecycleErrorEnvelope"
+                        }
+                    },
+                    "409": {
+                        "description": "Conflict",
+                        "schema": {
+                            "$ref": "#/definitions/httphandler.lifecycleErrorEnvelope"
+                        }
+                    },
+                    "422": {
+                        "description": "Unprocessable Entity",
+                        "schema": {
+                            "$ref": "#/definitions/httphandler.lifecycleErrorEnvelope"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/httphandler.lifecycleErrorEnvelope"
+                        }
+                    }
+                }
+            }
+        },
+        "/interactions/{interaction_id}/complete": {
+            "post": {
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "lifecycle"
+                ],
+                "summary": "Complete one managed Interaction",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Interaction ID",
+                        "name": "interaction_id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Terminal closure manifest",
+                        "name": "request",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/httphandler.terminalInteractionRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/sessionvo.Interaction"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/httphandler.lifecycleErrorEnvelope"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/httphandler.lifecycleErrorEnvelope"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "$ref": "#/definitions/httphandler.lifecycleErrorEnvelope"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/httphandler.lifecycleErrorEnvelope"
+                        }
+                    },
+                    "409": {
+                        "description": "Conflict",
+                        "schema": {
+                            "$ref": "#/definitions/httphandler.lifecycleErrorEnvelope"
+                        }
+                    },
+                    "422": {
+                        "description": "Unprocessable Entity",
+                        "schema": {
+                            "$ref": "#/definitions/httphandler.lifecycleErrorEnvelope"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/httphandler.lifecycleErrorEnvelope"
+                        }
+                    }
+                }
+            }
+        },
+        "/interactions/{interaction_id}/fail": {
+            "post": {
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "lifecycle"
+                ],
+                "summary": "Fail one managed Interaction",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Interaction ID",
+                        "name": "interaction_id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Terminal closure manifest",
+                        "name": "request",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/httphandler.terminalInteractionRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/sessionvo.Interaction"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/httphandler.lifecycleErrorEnvelope"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/httphandler.lifecycleErrorEnvelope"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "$ref": "#/definitions/httphandler.lifecycleErrorEnvelope"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/httphandler.lifecycleErrorEnvelope"
+                        }
+                    },
+                    "409": {
+                        "description": "Conflict",
+                        "schema": {
+                            "$ref": "#/definitions/httphandler.lifecycleErrorEnvelope"
+                        }
+                    },
+                    "422": {
+                        "description": "Unprocessable Entity",
+                        "schema": {
+                            "$ref": "#/definitions/httphandler.lifecycleErrorEnvelope"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/httphandler.lifecycleErrorEnvelope"
+                        }
+                    }
+                }
+            }
+        },
+        "/interactions/{interaction_id}/handoff": {
+            "post": {
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "lifecycle"
+                ],
+                "summary": "Hand off one managed Interaction",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Interaction ID",
+                        "name": "interaction_id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Terminal closure manifest",
+                        "name": "request",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/httphandler.terminalInteractionRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/sessionvo.Interaction"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/httphandler.lifecycleErrorEnvelope"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/httphandler.lifecycleErrorEnvelope"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "$ref": "#/definitions/httphandler.lifecycleErrorEnvelope"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/httphandler.lifecycleErrorEnvelope"
+                        }
+                    },
+                    "409": {
+                        "description": "Conflict",
+                        "schema": {
+                            "$ref": "#/definitions/httphandler.lifecycleErrorEnvelope"
+                        }
+                    },
+                    "422": {
+                        "description": "Unprocessable Entity",
+                        "schema": {
+                            "$ref": "#/definitions/httphandler.lifecycleErrorEnvelope"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/httphandler.lifecycleErrorEnvelope"
+                        }
+                    }
+                }
+            }
+        },
+        "/operations/{operation_id}": {
+            "get": {
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "lifecycle"
+                ],
+                "summary": "Get one Operation",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Operation ID",
+                        "name": "operation_id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/sessionvo.Operation"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/httphandler.lifecycleErrorEnvelope"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "$ref": "#/definitions/httphandler.lifecycleErrorEnvelope"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/httphandler.lifecycleErrorEnvelope"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/httphandler.lifecycleErrorEnvelope"
+                        }
+                    }
+                }
+            }
+        },
+        "/operations/{operation_id}/attempts": {
+            "post": {
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "lifecycle"
+                ],
+                "summary": "Start the next retry attempt for an Operation",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Operation ID",
+                        "name": "operation_id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Current Interaction lease",
+                        "name": "request",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/httphandler.interactionLeaseRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "description": "Created",
+                        "schema": {
+                            "$ref": "#/definitions/httphandler.operationResult"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/httphandler.lifecycleErrorEnvelope"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/httphandler.lifecycleErrorEnvelope"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "$ref": "#/definitions/httphandler.lifecycleErrorEnvelope"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/httphandler.lifecycleErrorEnvelope"
+                        }
+                    },
+                    "409": {
+                        "description": "Conflict",
+                        "schema": {
+                            "$ref": "#/definitions/httphandler.lifecycleErrorEnvelope"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/httphandler.lifecycleErrorEnvelope"
+                        }
+                    }
+                }
+            }
+        },
+        "/operations/{operation_id}/attempts/{attempt}:complete": {
+            "post": {
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "lifecycle"
+                ],
+                "summary": "Complete one Operation attempt",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Operation ID",
+                        "name": "operation_id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "integer",
+                        "description": "Attempt number",
+                        "name": "attempt",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Durable operation result",
+                        "name": "request",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/httphandler.finishAttemptRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/httphandler.operationResult"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/httphandler.lifecycleErrorEnvelope"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/httphandler.lifecycleErrorEnvelope"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "$ref": "#/definitions/httphandler.lifecycleErrorEnvelope"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/httphandler.lifecycleErrorEnvelope"
+                        }
+                    },
+                    "409": {
+                        "description": "Conflict",
+                        "schema": {
+                            "$ref": "#/definitions/httphandler.lifecycleErrorEnvelope"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/httphandler.lifecycleErrorEnvelope"
+                        }
+                    }
+                }
+            }
+        },
+        "/operations/{operation_id}/attempts/{attempt}:fail": {
+            "post": {
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "lifecycle"
+                ],
+                "summary": "Fail one Operation attempt",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Operation ID",
+                        "name": "operation_id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "integer",
+                        "description": "Attempt number",
+                        "name": "attempt",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Durable operation failure",
+                        "name": "request",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/httphandler.finishAttemptRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/httphandler.operationResult"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/httphandler.lifecycleErrorEnvelope"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/httphandler.lifecycleErrorEnvelope"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "$ref": "#/definitions/httphandler.lifecycleErrorEnvelope"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/httphandler.lifecycleErrorEnvelope"
+                        }
+                    },
+                    "409": {
+                        "description": "Conflict",
+                        "schema": {
+                            "$ref": "#/definitions/httphandler.lifecycleErrorEnvelope"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/httphandler.lifecycleErrorEnvelope"
+                        }
+                    }
+                }
+            }
+        },
+        "/receipts/{receipt_id}": {
+            "get": {
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "lifecycle"
+                ],
+                "summary": "Get one durable Receipt",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Receipt ID",
+                        "name": "receipt_id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/sessionvo.Receipt"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/httphandler.lifecycleErrorEnvelope"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "$ref": "#/definitions/httphandler.lifecycleErrorEnvelope"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/httphandler.lifecycleErrorEnvelope"
+                        }
+                    },
+                    "409": {
+                        "description": "Conflict",
+                        "schema": {
+                            "$ref": "#/definitions/httphandler.lifecycleErrorEnvelope"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/httphandler.lifecycleErrorEnvelope"
                         }
                     }
                 }
@@ -314,85 +1814,18 @@
         },
         "/requests": {
             "get": {
-                "description": "Returns stable request summaries generated from authorized evidence and artifacts.",
                 "produces": [
                     "application/json"
                 ],
                 "tags": [
-                    "requests"
+                    "lifecycle"
                 ],
-                "summary": "List observable business requests",
+                "summary": "List request projections from durable Receipts",
                 "parameters": [
                     {
                         "type": "integer",
-                        "description": "Page size, 1..200",
+                        "description": "Page size, 1..100",
                         "name": "limit",
-                        "in": "query"
-                    },
-                    {
-                        "type": "string",
-                        "description": "Opaque pagination cursor",
-                        "name": "cursor",
-                        "in": "query"
-                    },
-                    {
-                        "type": "string",
-                        "description": "One user interaction ID",
-                        "name": "interaction_id",
-                        "in": "query"
-                    },
-                    {
-                        "type": "string",
-                        "description": "Caller-owned conversation ID",
-                        "name": "conversation_id",
-                        "in": "query"
-                    },
-                    {
-                        "type": "string",
-                        "description": "Started at or after this RFC3339 timestamp",
-                        "name": "from",
-                        "in": "query"
-                    },
-                    {
-                        "type": "string",
-                        "description": "Started at or before this RFC3339 timestamp",
-                        "name": "to",
-                        "in": "query"
-                    },
-                    {
-                        "type": "string",
-                        "description": "Execution status",
-                        "name": "status",
-                        "in": "query"
-                    },
-                    {
-                        "type": "string",
-                        "description": "Agent or application",
-                        "name": "agent_or_app",
-                        "in": "query"
-                    },
-                    {
-                        "type": "string",
-                        "description": "Business domain",
-                        "name": "business_domain",
-                        "in": "query"
-                    },
-                    {
-                        "type": "string",
-                        "description": "Knowledge network",
-                        "name": "knowledge_network",
-                        "in": "query"
-                    },
-                    {
-                        "type": "string",
-                        "description": "Evidence completeness",
-                        "name": "evidence_completeness",
-                        "in": "query"
-                    },
-                    {
-                        "type": "string",
-                        "description": "Question, result, ID, business ref, or error keyword",
-                        "name": "keyword",
                         "in": "query"
                     }
                 ],
@@ -400,25 +1833,25 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/evidencevo.RequestSummaryPage"
-                        }
-                    },
-                    "400": {
-                        "description": "Bad Request",
-                        "schema": {
-                            "$ref": "#/definitions/rdto.ErrorResponse"
+                            "$ref": "#/definitions/httphandler.requestPage"
                         }
                     },
                     "401": {
                         "description": "Unauthorized",
                         "schema": {
-                            "$ref": "#/definitions/rdto.ErrorResponse"
+                            "$ref": "#/definitions/httphandler.lifecycleErrorEnvelope"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "$ref": "#/definitions/httphandler.lifecycleErrorEnvelope"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/rdto.ErrorResponse"
+                            "$ref": "#/definitions/httphandler.lifecycleErrorEnvelope"
                         }
                     }
                 }
@@ -426,18 +1859,17 @@
         },
         "/requests/{request_id}": {
             "get": {
-                "description": "Returns an authorized request summary and its business-content availability.",
                 "produces": [
                     "application/json"
                 ],
                 "tags": [
-                    "requests"
+                    "lifecycle"
                 ],
-                "summary": "Get one observable business request",
+                "summary": "Get one request projection from durable Receipts",
                 "parameters": [
                     {
                         "type": "string",
-                        "description": "BKN request ID",
+                        "description": "Request ID",
                         "name": "request_id",
                         "in": "path",
                         "required": true
@@ -447,31 +1879,31 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/evidencevo.RequestSummary"
-                        }
-                    },
-                    "400": {
-                        "description": "Bad Request",
-                        "schema": {
-                            "$ref": "#/definitions/rdto.ErrorResponse"
+                            "$ref": "#/definitions/sessionvo.RequestSummary"
                         }
                     },
                     "401": {
                         "description": "Unauthorized",
                         "schema": {
-                            "$ref": "#/definitions/rdto.ErrorResponse"
+                            "$ref": "#/definitions/httphandler.lifecycleErrorEnvelope"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "$ref": "#/definitions/httphandler.lifecycleErrorEnvelope"
                         }
                     },
                     "404": {
                         "description": "Not Found",
                         "schema": {
-                            "$ref": "#/definitions/rdto.ErrorResponse"
+                            "$ref": "#/definitions/httphandler.lifecycleErrorEnvelope"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/rdto.ErrorResponse"
+                            "$ref": "#/definitions/httphandler.lifecycleErrorEnvelope"
                         }
                     }
                 }
@@ -509,14 +1941,14 @@
                     },
                     {
                         "type": "string",
-                        "description": "One user interaction ID",
-                        "name": "interaction_id",
+                        "description": "Caller-owned conversation ID",
+                        "name": "conversation_id",
                         "in": "query"
                     },
                     {
                         "type": "string",
-                        "description": "Caller-owned conversation ID",
-                        "name": "conversation_id",
+                        "description": "One user interaction ID",
+                        "name": "interaction_id",
                         "in": "query"
                     }
                 ],
@@ -573,8 +2005,8 @@
                     },
                     {
                         "type": "string",
-                        "description": "One user interaction ID",
-                        "name": "interaction_id",
+                        "description": "Exact trace ID; bypasses list projection scan",
+                        "name": "trace_id",
                         "in": "query"
                     },
                     {
@@ -585,8 +2017,8 @@
                     },
                     {
                         "type": "string",
-                        "description": "Exact trace ID; bypasses list projection scan",
-                        "name": "trace_id",
+                        "description": "One user interaction ID",
+                        "name": "interaction_id",
                         "in": "query"
                     },
                     {
@@ -647,114 +2079,6 @@
                     },
                     "500": {
                         "description": "Internal Server Error",
-                        "schema": {
-                            "$ref": "#/definitions/rdto.ErrorResponse"
-                        }
-                    }
-                }
-            }
-        },
-        "/traces/_search": {
-            "post": {
-                "description": "Proxy raw OpenSearch DSL to the configured trace index and return the original OpenSearch response body.",
-                "consumes": [
-                    "application/json"
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "traces"
-                ],
-                "summary": "Search traces with raw OpenSearch DSL",
-                "parameters": [
-                    {
-                        "description": "OpenSearch DSL JSON body",
-                        "name": "request",
-                        "in": "body",
-                        "required": true,
-                        "schema": {
-                            "type": "string"
-                        }
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Raw OpenSearch search response",
-                        "schema": {
-                            "type": "string"
-                        }
-                    },
-                    "400": {
-                        "description": "Bad Request",
-                        "schema": {
-                            "$ref": "#/definitions/rdto.ErrorResponse"
-                        }
-                    },
-                    "405": {
-                        "description": "Method Not Allowed",
-                        "schema": {
-                            "$ref": "#/definitions/rdto.ErrorResponse"
-                        }
-                    },
-                    "504": {
-                        "description": "Gateway Timeout",
-                        "schema": {
-                            "$ref": "#/definitions/rdto.ErrorResponse"
-                        }
-                    }
-                }
-            }
-        },
-        "/traces/by-conversation": {
-            "get": {
-                "description": "Build a term filter automatically using attributes.gen_ai.conversation.id.keyword and return the original OpenSearch response body.",
-                "consumes": [
-                    "application/json"
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "traces"
-                ],
-                "summary": "Search traces by conversation ID",
-                "parameters": [
-                    {
-                        "type": "string",
-                        "description": "Conversation ID",
-                        "name": "conversation_id",
-                        "in": "query",
-                        "required": true
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Raw OpenSearch search response",
-                        "schema": {
-                            "type": "string"
-                        }
-                    },
-                    "400": {
-                        "description": "Bad Request",
-                        "schema": {
-                            "$ref": "#/definitions/rdto.ErrorResponse"
-                        }
-                    },
-                    "405": {
-                        "description": "Method Not Allowed",
-                        "schema": {
-                            "$ref": "#/definitions/rdto.ErrorResponse"
-                        }
-                    },
-                    "500": {
-                        "description": "Internal Server Error",
-                        "schema": {
-                            "$ref": "#/definitions/rdto.ErrorResponse"
-                        }
-                    },
-                    "504": {
-                        "description": "Gateway Timeout",
                         "schema": {
                             "$ref": "#/definitions/rdto.ErrorResponse"
                         }
@@ -1103,119 +2427,6 @@
                     },
                     "405": {
                         "description": "Method Not Allowed",
-                        "schema": {
-                            "$ref": "#/definitions/rdto.ErrorResponse"
-                        }
-                    },
-                    "500": {
-                        "description": "Internal Server Error",
-                        "schema": {
-                            "$ref": "#/definitions/rdto.ErrorResponse"
-                        }
-                    }
-                }
-            }
-        },
-        "/traces/{trace_id}/trace-graph": {
-            "get": {
-                "description": "Returns normalized trace tree nodes, parent-child edges, status, duration, and partial reasons for a trace.",
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "traces"
-                ],
-                "summary": "Get trace graph by trace ID",
-                "parameters": [
-                    {
-                        "type": "string",
-                        "description": "Trace ID",
-                        "name": "trace_id",
-                        "in": "path",
-                        "required": true
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "schema": {
-                            "type": "object",
-                            "additionalProperties": true
-                        }
-                    },
-                    "400": {
-                        "description": "Bad Request",
-                        "schema": {
-                            "$ref": "#/definitions/rdto.ErrorResponse"
-                        }
-                    },
-                    "404": {
-                        "description": "Not Found",
-                        "schema": {
-                            "$ref": "#/definitions/rdto.ErrorResponse"
-                        }
-                    },
-                    "405": {
-                        "description": "Method Not Allowed",
-                        "schema": {
-                            "$ref": "#/definitions/rdto.ErrorResponse"
-                        }
-                    },
-                    "500": {
-                        "description": "Internal Server Error",
-                        "schema": {
-                            "$ref": "#/definitions/rdto.ErrorResponse"
-                        }
-                    },
-                    "504": {
-                        "description": "Gateway Timeout",
-                        "schema": {
-                            "$ref": "#/definitions/rdto.ErrorResponse"
-                        }
-                    }
-                }
-            }
-        },
-        "/interactions/{interaction_id}": {
-            "get": {
-                "description": "Aggregates every authorized request and trace in one caller-owned interaction.",
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "interactions"
-                ],
-                "summary": "Get one observable business interaction",
-                "parameters": [
-                    {
-                        "type": "string",
-                        "description": "BKN interaction ID",
-                        "name": "interaction_id",
-                        "in": "path",
-                        "required": true
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "schema": {
-                            "$ref": "#/definitions/evidencevo.InteractionSummary"
-                        }
-                    },
-                    "400": {
-                        "description": "Bad Request",
-                        "schema": {
-                            "$ref": "#/definitions/rdto.ErrorResponse"
-                        }
-                    },
-                    "401": {
-                        "description": "Unauthorized",
-                        "schema": {
-                            "$ref": "#/definitions/rdto.ErrorResponse"
-                        }
-                    },
-                    "404": {
-                        "description": "Not Found",
                         "schema": {
                             "$ref": "#/definitions/rdto.ErrorResponse"
                         }
@@ -1664,6 +2875,41 @@
                 }
             }
         },
+        "evidencevo.InteractionSummary": {
+            "type": "object",
+            "properties": {
+                "completed_at": {
+                    "type": "string"
+                },
+                "conversation_id": {
+                    "type": "string"
+                },
+                "duration_ms": {
+                    "type": "integer"
+                },
+                "interaction_id": {
+                    "type": "string"
+                },
+                "requests": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/evidencevo.RequestSummary"
+                    }
+                },
+                "started_at": {
+                    "type": "string"
+                },
+                "status": {
+                    "type": "string"
+                },
+                "traces": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/evidencevo.TraceSummary"
+                    }
+                }
+            }
+        },
         "evidencevo.RequestSummary": {
             "type": "object",
             "properties": {
@@ -1694,13 +2940,13 @@
                 "error_summary": {
                     "type": "string"
                 },
-                "interaction_id": {
-                    "type": "string"
-                },
                 "evidence_completeness": {
                     "type": "string"
                 },
                 "initiator": {
+                    "type": "string"
+                },
+                "interaction_id": {
                     "type": "string"
                 },
                 "knowledge_networks": {
@@ -1956,6 +3202,404 @@
                 }
             }
         },
+        "httphandler.closeConversationRequest": {
+            "type": "object",
+            "properties": {
+                "idempotency_key": {
+                    "type": "string"
+                }
+            }
+        },
+        "httphandler.conversationPage": {
+            "type": "object",
+            "properties": {
+                "entries": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/sessionvo.Conversation"
+                    }
+                },
+                "next_cursor": {
+                    "type": "string"
+                }
+            }
+        },
+        "httphandler.ensureConversationRequest": {
+            "type": "object",
+            "properties": {
+                "application_principal_id": {
+                    "type": "string"
+                },
+                "business_domain_id": {
+                    "type": "string"
+                },
+                "delegation_id": {
+                    "type": "string"
+                },
+                "effective_subject_id": {
+                    "type": "string"
+                },
+                "effective_subject_type": {
+                    "type": "string"
+                },
+                "external_conversation_key": {
+                    "type": "string"
+                },
+                "idempotency_key": {
+                    "type": "string"
+                },
+                "one_shot": {
+                    "type": "boolean"
+                },
+                "tenant_id": {
+                    "type": "string"
+                }
+            }
+        },
+        "httphandler.ensureOperationRequest": {
+            "type": "object",
+            "properties": {
+                "causation_event_ids": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "lease_epoch": {
+                    "type": "integer"
+                },
+                "lease_token": {
+                    "type": "string"
+                },
+                "normalized_input_hash": {
+                    "type": "string"
+                },
+                "operation_key": {
+                    "type": "string"
+                },
+                "parent_operation_id": {
+                    "type": "string"
+                },
+                "required": {
+                    "type": "boolean"
+                },
+                "tool_name": {
+                    "type": "string"
+                }
+            }
+        },
+        "httphandler.evidenceEventRequest": {
+            "type": "object",
+            "properties": {
+                "artifact_refs": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "attempt": {
+                    "type": "integer"
+                },
+                "business_domain_id": {
+                    "type": "string"
+                },
+                "business_refs": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/sessionvo.BusinessRef"
+                    }
+                },
+                "causation_event_ids": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "conversation_id": {
+                    "type": "string"
+                },
+                "emitted_at": {
+                    "type": "string"
+                },
+                "envelope": {
+                    "type": "array",
+                    "items": {
+                        "type": "integer"
+                    }
+                },
+                "event_id": {
+                    "type": "string"
+                },
+                "event_type": {
+                    "type": "string"
+                },
+                "interaction_id": {
+                    "type": "string"
+                },
+                "observed_at": {
+                    "type": "string"
+                },
+                "operation_id": {
+                    "type": "string"
+                },
+                "payload_hash": {
+                    "type": "string"
+                },
+                "producer_epoch": {
+                    "type": "integer"
+                },
+                "producer_id": {
+                    "type": "string"
+                },
+                "producer_sequence": {
+                    "type": "integer"
+                },
+                "producer_stream_id": {
+                    "type": "string"
+                },
+                "request_id": {
+                    "type": "string"
+                },
+                "schema_version": {
+                    "type": "string"
+                },
+                "span_id": {
+                    "type": "string"
+                },
+                "started_at": {
+                    "type": "string"
+                },
+                "tenant_id": {
+                    "type": "string"
+                },
+                "trace_id": {
+                    "type": "string"
+                }
+            }
+        },
+        "httphandler.finishAttemptRequest": {
+            "type": "object",
+            "properties": {
+                "artifact_refs": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "business_refs": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/sessionvo.BusinessRef"
+                    }
+                },
+                "evidence_durability": {
+                    "$ref": "#/definitions/sessionvo.EvidenceDurability"
+                },
+                "observed_evidence_refs": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "partial_reasons": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "payload_hash": {
+                    "type": "string"
+                },
+                "receipt_id": {
+                    "type": "string"
+                },
+                "request_id": {
+                    "type": "string"
+                },
+                "retryable": {
+                    "type": "boolean"
+                },
+                "trace_id": {
+                    "type": "string"
+                }
+            }
+        },
+        "httphandler.interactionLeaseRequest": {
+            "type": "object",
+            "properties": {
+                "lease_epoch": {
+                    "type": "integer"
+                },
+                "lease_token": {
+                    "type": "string"
+                }
+            }
+        },
+        "httphandler.lifecycleError": {
+            "type": "object",
+            "properties": {
+                "code": {
+                    "type": "string",
+                    "enum": [
+                        "conversation_required",
+                        "conversation_not_found",
+                        "conversation_closed",
+                        "conversation_expired",
+                        "conversation_owner_mismatch",
+                        "interaction_required",
+                        "interaction_in_progress",
+                        "interaction_terminal",
+                        "operation_required",
+                        "idempotency_conflict",
+                        "event_payload_conflict",
+                        "producer_sequence_conflict",
+                        "invalid_evidence_event",
+                        "receipt_pending",
+                        "terminal_conflict",
+                        "closure_manifest_invalid",
+                        "feature_not_installed",
+                        "capability_not_licensed",
+                        "permission_denied",
+                        "resource_not_disclosed",
+                        "internal_error"
+                    ]
+                },
+                "current_status": {
+                    "type": "string"
+                },
+                "message": {
+                    "type": "string"
+                },
+                "request_id": {
+                    "type": "string"
+                },
+                "required_action": {
+                    "type": "string"
+                },
+                "retry_after_ms": {
+                    "type": "integer"
+                },
+                "retryable": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "httphandler.lifecycleErrorEnvelope": {
+            "type": "object",
+            "properties": {
+                "error": {
+                    "$ref": "#/definitions/httphandler.lifecycleError"
+                }
+            }
+        },
+        "httphandler.operationResult": {
+            "type": "object",
+            "properties": {
+                "operation": {
+                    "$ref": "#/definitions/sessionvo.Operation"
+                },
+                "receipt": {
+                    "$ref": "#/definitions/sessionvo.Receipt"
+                }
+            }
+        },
+        "httphandler.requestPage": {
+            "type": "object",
+            "properties": {
+                "entries": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/sessionvo.RequestSummary"
+                    }
+                },
+                "next_cursor": {
+                    "type": "string"
+                }
+            }
+        },
+        "httphandler.resumeConversationRequest": {
+            "type": "object",
+            "properties": {
+                "conversation_id": {
+                    "type": "string"
+                }
+            }
+        },
+        "httphandler.startInteractionRequest": {
+            "type": "object",
+            "properties": {
+                "idempotency_key": {
+                    "type": "string"
+                },
+                "lease_seconds": {
+                    "type": "integer"
+                }
+            }
+        },
+        "httphandler.terminalInteractionRequest": {
+            "type": "object",
+            "properties": {
+                "answer_artifact_ref": {
+                    "type": "string"
+                },
+                "assembler_deadline": {
+                    "type": "string"
+                },
+                "claims": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "completion_manifest_version": {
+                    "type": "string"
+                },
+                "completion_reason": {
+                    "type": "string"
+                },
+                "expected_operations": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/sessionvo.ExpectedOperation"
+                    }
+                },
+                "expected_receipts": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/sessionvo.ExpectedReceipt"
+                    }
+                },
+                "lease_epoch": {
+                    "type": "integer"
+                },
+                "lease_token": {
+                    "type": "string"
+                },
+                "terminal_idempotency_key": {
+                    "type": "string"
+                }
+            }
+        },
+        "ledgervo.DurableAck": {
+            "type": "object",
+            "properties": {
+                "durable_ack": {
+                    "type": "boolean"
+                },
+                "event_id": {
+                    "type": "string"
+                },
+                "ingest_sequence": {
+                    "type": "integer"
+                },
+                "ingested_at": {
+                    "type": "string"
+                },
+                "replayed": {
+                    "type": "boolean"
+                }
+            }
+        },
         "rdto.ErrorResponse": {
             "type": "object",
             "properties": {
@@ -1974,40 +3618,466 @@
                 }
             }
         },
-        "evidencevo.InteractionSummary": {
+        "sessionvo.AttemptStatus": {
+            "type": "string",
+            "enum": [
+                "pending",
+                "completed",
+                "failed"
+            ],
+            "x-enum-varnames": [
+                "AttemptPending",
+                "AttemptCompleted",
+                "AttemptFailed"
+            ]
+        },
+        "sessionvo.BusinessRef": {
             "type": "object",
             "properties": {
-                "completed_at": {
+                "as_of": {
+                    "type": "string"
+                },
+                "business_domain_id": {
+                    "type": "string"
+                },
+                "display_hint": {
+                    "type": "string"
+                },
+                "ref_id": {
+                    "type": "string"
+                },
+                "ref_type": {
+                    "type": "string"
+                },
+                "version": {
+                    "type": "string"
+                }
+            }
+        },
+        "sessionvo.ClosureManifest": {
+            "type": "object",
+            "properties": {
+                "answer_artifact_ref": {
+                    "type": "string"
+                },
+                "assembler_deadline": {
+                    "type": "string"
+                },
+                "claims": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "completion_manifest_version": {
+                    "type": "string"
+                },
+                "completion_reason": {
+                    "type": "string"
+                },
+                "expected_operations": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/sessionvo.ExpectedOperation"
+                    }
+                },
+                "expected_receipts": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/sessionvo.ExpectedReceipt"
+                    }
+                },
+                "system_partial_reasons": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            }
+        },
+        "sessionvo.Conversation": {
+            "type": "object",
+            "properties": {
+                "closed_at": {
                     "type": "string"
                 },
                 "conversation_id": {
                     "type": "string"
                 },
-                "duration_ms": {
+                "created_at": {
+                    "type": "string"
+                },
+                "external_conversation_key": {
+                    "type": "string"
+                },
+                "generation": {
                     "type": "integer"
+                },
+                "one_shot": {
+                    "type": "boolean"
+                },
+                "owner": {
+                    "$ref": "#/definitions/sessionvo.Owner"
+                },
+                "row_version": {
+                    "type": "integer"
+                },
+                "status": {
+                    "$ref": "#/definitions/sessionvo.ConversationStatus"
+                },
+                "updated_at": {
+                    "type": "string"
+                }
+            }
+        },
+        "sessionvo.ConversationStatus": {
+            "type": "string",
+            "enum": [
+                "active",
+                "closed",
+                "expired"
+            ],
+            "x-enum-varnames": [
+                "ConversationActive",
+                "ConversationClosed",
+                "ConversationExpired"
+            ]
+        },
+        "sessionvo.EvidenceDurability": {
+            "type": "string",
+            "enum": [
+                "pending",
+                "durable",
+                "failed"
+            ],
+            "x-enum-varnames": [
+                "DurabilityPending",
+                "DurabilityDurable",
+                "DurabilityFailed"
+            ]
+        },
+        "sessionvo.EvidenceStatus": {
+            "type": "string",
+            "enum": [
+                "not_applicable",
+                "assembling",
+                "complete",
+                "partial",
+                "failed"
+            ],
+            "x-enum-varnames": [
+                "EvidenceNotApplicable",
+                "EvidenceAssembling",
+                "EvidenceComplete",
+                "EvidencePartial",
+                "EvidenceFailed"
+            ]
+        },
+        "sessionvo.ExpectedOperation": {
+            "type": "object",
+            "properties": {
+                "operation_id": {
+                    "type": "string"
+                },
+                "required": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "sessionvo.ExpectedReceipt": {
+            "type": "object",
+            "properties": {
+                "receipt_id": {
+                    "type": "string"
+                },
+                "required": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "sessionvo.Interaction": {
+            "type": "object",
+            "properties": {
+                "closure_manifest": {
+                    "$ref": "#/definitions/sessionvo.ClosureManifest"
+                },
+                "conversation_id": {
+                    "type": "string"
+                },
+                "created_at": {
+                    "type": "string"
+                },
+                "evidence_status": {
+                    "$ref": "#/definitions/sessionvo.EvidenceStatus"
+                },
+                "execution_status": {
+                    "$ref": "#/definitions/sessionvo.InteractionStatus"
                 },
                 "interaction_id": {
                     "type": "string"
                 },
-                "requests": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/evidencevo.RequestSummary"
-                    }
+                "lease_epoch": {
+                    "type": "integer"
                 },
-                "started_at": {
+                "lease_expires_at": {
                     "type": "string"
                 },
-                "status": {
+                "lease_token": {
                     "type": "string"
                 },
-                "traces": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/evidencevo.TraceSummary"
-                    }
+                "lease_version": {
+                    "type": "integer"
+                },
+                "ordinal": {
+                    "type": "integer"
+                },
+                "row_version": {
+                    "type": "integer"
+                },
+                "terminal_at": {
+                    "type": "string"
+                },
+                "updated_at": {
+                    "type": "string"
                 }
             }
+        },
+        "sessionvo.InteractionStatus": {
+            "type": "string",
+            "enum": [
+                "active",
+                "completed",
+                "failed",
+                "canceled",
+                "handed_off",
+                "abandoned"
+            ],
+            "x-enum-varnames": [
+                "InteractionActive",
+                "InteractionCompleted",
+                "InteractionFailed",
+                "InteractionCanceled",
+                "InteractionHandedOff",
+                "InteractionAbandoned"
+            ]
+        },
+        "sessionvo.Operation": {
+            "type": "object",
+            "properties": {
+                "attempt": {
+                    "type": "integer"
+                },
+                "attempt_status": {
+                    "$ref": "#/definitions/sessionvo.AttemptStatus"
+                },
+                "causation_event_ids": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "conversation_id": {
+                    "type": "string"
+                },
+                "created_at": {
+                    "type": "string"
+                },
+                "interaction_id": {
+                    "type": "string"
+                },
+                "normalized_input_hash": {
+                    "type": "string"
+                },
+                "operation_id": {
+                    "type": "string"
+                },
+                "operation_key": {
+                    "type": "string"
+                },
+                "parent_operation_id": {
+                    "type": "string"
+                },
+                "retryable": {
+                    "type": "boolean"
+                },
+                "row_version": {
+                    "type": "integer"
+                },
+                "tool_name": {
+                    "type": "string"
+                },
+                "updated_at": {
+                    "type": "string"
+                }
+            }
+        },
+        "sessionvo.Owner": {
+            "type": "object",
+            "properties": {
+                "application_principal_id": {
+                    "type": "string"
+                },
+                "business_domain_id": {
+                    "type": "string"
+                },
+                "delegation_id": {
+                    "type": "string"
+                },
+                "effective_subject_id": {
+                    "type": "string"
+                },
+                "effective_subject_type": {
+                    "$ref": "#/definitions/sessionvo.SubjectType"
+                },
+                "tenant_id": {
+                    "type": "string"
+                }
+            }
+        },
+        "sessionvo.Receipt": {
+            "type": "object",
+            "properties": {
+                "artifact_refs": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "attempt": {
+                    "type": "integer"
+                },
+                "business_refs": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/sessionvo.BusinessRef"
+                    }
+                },
+                "causation_event_ids": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "conversation_id": {
+                    "type": "string"
+                },
+                "evidence_durability": {
+                    "$ref": "#/definitions/sessionvo.EvidenceDurability"
+                },
+                "interaction_id": {
+                    "type": "string"
+                },
+                "issued_at": {
+                    "type": "string"
+                },
+                "normalized_input_hash": {
+                    "type": "string"
+                },
+                "observed_evidence_refs": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "operation_id": {
+                    "type": "string"
+                },
+                "operation_key": {
+                    "type": "string"
+                },
+                "owner": {
+                    "$ref": "#/definitions/sessionvo.Owner"
+                },
+                "partial_reasons": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "payload_hash": {
+                    "type": "string"
+                },
+                "receipt_id": {
+                    "type": "string"
+                },
+                "receipt_status": {
+                    "$ref": "#/definitions/sessionvo.ReceiptStatus"
+                },
+                "request_id": {
+                    "type": "string"
+                },
+                "required": {
+                    "type": "boolean"
+                },
+                "row_version": {
+                    "type": "integer"
+                },
+                "schema_version": {
+                    "type": "string"
+                },
+                "terminal_at": {
+                    "type": "string"
+                },
+                "tool_name": {
+                    "type": "string"
+                },
+                "trace_id": {
+                    "type": "string"
+                }
+            }
+        },
+        "sessionvo.ReceiptStatus": {
+            "type": "string",
+            "enum": [
+                "pending",
+                "completed",
+                "failed"
+            ],
+            "x-enum-varnames": [
+                "ReceiptPending",
+                "ReceiptCompleted",
+                "ReceiptFailed"
+            ]
+        },
+        "sessionvo.RequestSummary": {
+            "type": "object",
+            "properties": {
+                "conversation_id": {
+                    "type": "string"
+                },
+                "interaction_id": {
+                    "type": "string"
+                },
+                "operation_count": {
+                    "type": "integer"
+                },
+                "receipt_count": {
+                    "type": "integer"
+                },
+                "request_id": {
+                    "type": "string"
+                },
+                "trace_ids": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "updated_at": {
+                    "type": "string"
+                }
+            }
+        },
+        "sessionvo.SubjectType": {
+            "type": "string",
+            "enum": [
+                "user",
+                "service"
+            ],
+            "x-enum-varnames": [
+                "SubjectUser",
+                "SubjectService"
+            ]
         }
     }
 }

--- a/bkn-trace/agent-observability/docs/swagger/swagger.yaml
+++ b/bkn-trace/agent-observability/docs/swagger/swagger.yaml
@@ -1,820 +1,6 @@
-swagger: '2.0'
-info:
-  description: APIs for querying agent traces from OpenSearch.
-  title: Agent Observability API
-  contact: {}
-  version: '1.0'
 basePath: /api/agent-observability/v1
-paths:
-  /evidence-nodes/{node_id}:
-    get:
-      description: Returns one visible claim, evidence ref, or business ref node scoped by trace_id or request_id.
-      produces:
-      - application/json
-      tags:
-      - evidence
-      summary: Get evidence node details
-      parameters:
-      - type: string
-        description: Evidence node ID, for example claim:claim_001
-        name: node_id
-        in: path
-        required: true
-      - type: string
-        description: Trace ID scope
-        name: trace_id
-        in: query
-      - type: string
-        description: BKN request ID scope
-        name: request_id
-        in: query
-      - type: integer
-        description: Maximum evidence trace batches to read, 1..1000
-        name: limit
-        in: query
-      responses:
-        '200':
-          description: OK
-          schema:
-            $ref: '#/definitions/evidencevo.EvidenceNodeResponse'
-        '400':
-          description: Bad Request
-          schema:
-            $ref: '#/definitions/rdto.ErrorResponse'
-        '404':
-          description: Not Found
-          schema:
-            $ref: '#/definitions/rdto.ErrorResponse'
-        '405':
-          description: Method Not Allowed
-          schema:
-            $ref: '#/definitions/rdto.ErrorResponse'
-        '500':
-          description: Internal Server Error
-          schema:
-            $ref: '#/definitions/rdto.ErrorResponse'
-  /evidence/artifacts:
-    post:
-      description: Stores authorized business content separately from evidence events. Inline content and snapshot_ref are mutually exclusive.
-      consumes:
-      - application/json
-      produces:
-      - application/json
-      tags:
-      - evidence
-      summary: Ingest a BKN Trace 2.2 evidence artifact
-      parameters:
-      - description: BKN Trace 2.2 evidence artifact
-        name: request
-        in: body
-        required: true
-        schema:
-          $ref: '#/definitions/evidencevo.EvidenceArtifact'
-      responses:
-        '200':
-          description: OK
-          schema:
-            $ref: '#/definitions/evidencevo.ArtifactIngestResponse'
-        '201':
-          description: Created
-          schema:
-            $ref: '#/definitions/evidencevo.ArtifactIngestResponse'
-        '400':
-          description: Bad Request
-          schema:
-            $ref: '#/definitions/rdto.ErrorResponse'
-        '401':
-          description: Unauthorized
-          schema:
-            $ref: '#/definitions/rdto.ErrorResponse'
-        '409':
-          description: Conflict
-          schema:
-            $ref: '#/definitions/rdto.ErrorResponse'
-        '500':
-          description: Internal Server Error
-          schema:
-            $ref: '#/definitions/rdto.ErrorResponse'
-  /evidence/artifacts/{artifact_id}:
-    get:
-      description: Returns artifact content only when all persisted ownership dimensions match the trusted query identity.
-      produces:
-      - application/json
-      tags:
-      - evidence
-      summary: Get an authorized evidence artifact by ID
-      parameters:
-      - type: string
-        description: Artifact ID
-        name: artifact_id
-        in: path
-        required: true
-      responses:
-        '200':
-          description: OK
-          schema:
-            $ref: '#/definitions/evidencevo.EvidenceArtifact'
-        '400':
-          description: Bad Request
-          schema:
-            $ref: '#/definitions/rdto.ErrorResponse'
-        '401':
-          description: Unauthorized
-          schema:
-            $ref: '#/definitions/rdto.ErrorResponse'
-        '404':
-          description: Not Found
-          schema:
-            $ref: '#/definitions/rdto.ErrorResponse'
-        '500':
-          description: Internal Server Error
-          schema:
-            $ref: '#/definitions/rdto.ErrorResponse'
-  /evidence/by-trace:
-    get:
-      description: Backward-compatible endpoint for SDK/Studio callers. Returns the normalized evidence-chain response for trace_id or request_id.
-      produces:
-      - application/json
-      tags:
-      - evidence
-      summary: Query evidence chain by trace ID or BKN request ID
-      parameters:
-      - type: string
-        description: Trace ID
-        name: trace_id
-        in: query
-      - type: string
-        description: BKN request ID
-        name: request_id
-        in: query
-      - type: integer
-        description: Maximum evidence trace batches to read, 1..1000
-        name: limit
-        in: query
-      responses:
-        '200':
-          description: OK
-          schema:
-            $ref: '#/definitions/evidencevo.EvidenceChainResponse'
-        '400':
-          description: Bad Request
-          schema:
-            $ref: '#/definitions/rdto.ErrorResponse'
-        '404':
-          description: Not Found
-          schema:
-            $ref: '#/definitions/rdto.ErrorResponse'
-        '405':
-          description: Method Not Allowed
-          schema:
-            $ref: '#/definitions/rdto.ErrorResponse'
-        '500':
-          description: Internal Server Error
-          schema:
-            $ref: '#/definitions/rdto.ErrorResponse'
-  /evidence/events:
-    post:
-      description: Accepts claim.created, evidence.refs.created, and business.refs.resolved events and stores the normalized evidence model.
-      consumes:
-      - application/json
-      produces:
-      - application/json
-      tags:
-      - evidence
-      summary: Ingest BKN Trace phase-two evidence events
-      parameters:
-      - description: BKN Trace phase-two evidence event batch
-        name: request
-        in: body
-        required: true
-        schema:
-          type: string
-      responses:
-        '202':
-          description: Accepted
-          schema:
-            $ref: '#/definitions/evidencevo.IngestResponse'
-        '400':
-          description: Bad Request
-          schema:
-            $ref: '#/definitions/rdto.ErrorResponse'
-        '405':
-          description: Method Not Allowed
-          schema:
-            $ref: '#/definitions/rdto.ErrorResponse'
-        '500':
-          description: Internal Server Error
-          schema:
-            $ref: '#/definitions/rdto.ErrorResponse'
-  /requests:
-    get:
-      description: Returns stable request summaries generated from authorized evidence and artifacts.
-      produces:
-      - application/json
-      tags:
-      - requests
-      summary: List observable business requests
-      parameters:
-      - type: integer
-        description: Page size, 1..200
-        name: limit
-        in: query
-      - type: string
-        description: Opaque pagination cursor
-        name: cursor
-        in: query
-      - type: string
-        description: One user interaction ID
-        name: interaction_id
-        in: query
-      - type: string
-        description: Caller-owned conversation ID
-        name: conversation_id
-        in: query
-      - type: string
-        description: Started at or after this RFC3339 timestamp
-        name: from
-        in: query
-      - type: string
-        description: Started at or before this RFC3339 timestamp
-        name: to
-        in: query
-      - type: string
-        description: Execution status
-        name: status
-        in: query
-      - type: string
-        description: Agent or application
-        name: agent_or_app
-        in: query
-      - type: string
-        description: Business domain
-        name: business_domain
-        in: query
-      - type: string
-        description: Knowledge network
-        name: knowledge_network
-        in: query
-      - type: string
-        description: Evidence completeness
-        name: evidence_completeness
-        in: query
-      - type: string
-        description: Question, result, ID, business ref, or error keyword
-        name: keyword
-        in: query
-      responses:
-        '200':
-          description: OK
-          schema:
-            $ref: '#/definitions/evidencevo.RequestSummaryPage'
-        '400':
-          description: Bad Request
-          schema:
-            $ref: '#/definitions/rdto.ErrorResponse'
-        '401':
-          description: Unauthorized
-          schema:
-            $ref: '#/definitions/rdto.ErrorResponse'
-        '500':
-          description: Internal Server Error
-          schema:
-            $ref: '#/definitions/rdto.ErrorResponse'
-  /requests/{request_id}:
-    get:
-      description: Returns an authorized request summary and its business-content availability.
-      produces:
-      - application/json
-      tags:
-      - requests
-      summary: Get one observable business request
-      parameters:
-      - type: string
-        description: BKN request ID
-        name: request_id
-        in: path
-        required: true
-      responses:
-        '200':
-          description: OK
-          schema:
-            $ref: '#/definitions/evidencevo.RequestSummary'
-        '400':
-          description: Bad Request
-          schema:
-            $ref: '#/definitions/rdto.ErrorResponse'
-        '401':
-          description: Unauthorized
-          schema:
-            $ref: '#/definitions/rdto.ErrorResponse'
-        '404':
-          description: Not Found
-          schema:
-            $ref: '#/definitions/rdto.ErrorResponse'
-        '500':
-          description: Internal Server Error
-          schema:
-            $ref: '#/definitions/rdto.ErrorResponse'
-  /requests/{request_id}/traces:
-    get:
-      description: Supports one business request to multiple distributed traces and returns request_id on every trace.
-      produces:
-      - application/json
-      tags:
-      - requests
-      summary: List technical traces belonging to a business request
-      parameters:
-      - type: string
-        description: BKN request ID
-        name: request_id
-        in: path
-        required: true
-      - type: integer
-        description: Page size, 1..200
-        name: limit
-        in: query
-      - type: string
-        description: Opaque pagination cursor
-        name: cursor
-        in: query
-      - type: string
-        description: One user interaction ID
-        name: interaction_id
-        in: query
-      - type: string
-        description: Caller-owned conversation ID
-        name: conversation_id
-        in: query
-      responses:
-        '200':
-          description: OK
-          schema:
-            $ref: '#/definitions/evidencevo.TraceSummaryPage'
-        '400':
-          description: Bad Request
-          schema:
-            $ref: '#/definitions/rdto.ErrorResponse'
-        '401':
-          description: Unauthorized
-          schema:
-            $ref: '#/definitions/rdto.ErrorResponse'
-        '500':
-          description: Internal Server Error
-          schema:
-            $ref: '#/definitions/rdto.ErrorResponse'
-  /trace-executions:
-    get:
-      description: Returns stable trace summaries with reverse request links, generated from authorized trace evidence.
-      produces:
-      - application/json
-      tags:
-      - traces
-      summary: List technical trace executions
-      parameters:
-      - type: integer
-        description: Page size, 1..200
-        name: limit
-        in: query
-      - type: string
-        description: Opaque pagination cursor
-        name: cursor
-        in: query
-      - type: string
-        description: One user interaction ID
-        name: interaction_id
-        in: query
-      - type: string
-        description: Caller-owned conversation ID
-        name: conversation_id
-        in: query
-      - type: string
-        description: Exact trace ID; bypasses list projection scan
-        name: trace_id
-        in: query
-      - type: string
-        description: Started at or after this RFC3339 timestamp
-        name: from
-        in: query
-      - type: string
-        description: Started at or before this RFC3339 timestamp
-        name: to
-        in: query
-      - type: string
-        description: Execution status
-        name: status
-        in: query
-      - type: string
-        description: Agent or application
-        name: agent_or_app
-        in: query
-      - type: string
-        description: Business domain
-        name: business_domain
-        in: query
-      - type: string
-        description: Trace, request, operation, or error keyword
-        name: keyword
-        in: query
-      responses:
-        '200':
-          description: OK
-          schema:
-            $ref: '#/definitions/evidencevo.TraceSummaryPage'
-        '400':
-          description: Bad Request
-          schema:
-            $ref: '#/definitions/rdto.ErrorResponse'
-        '401':
-          description: Unauthorized
-          schema:
-            $ref: '#/definitions/rdto.ErrorResponse'
-        '500':
-          description: Internal Server Error
-          schema:
-            $ref: '#/definitions/rdto.ErrorResponse'
-  /traces/_search:
-    post:
-      description: Proxy raw OpenSearch DSL to the configured trace index and return the original OpenSearch response body.
-      consumes:
-      - application/json
-      produces:
-      - application/json
-      tags:
-      - traces
-      summary: Search traces with raw OpenSearch DSL
-      parameters:
-      - description: OpenSearch DSL JSON body
-        name: request
-        in: body
-        required: true
-        schema:
-          type: string
-      responses:
-        '200':
-          description: Raw OpenSearch search response
-          schema:
-            type: string
-        '400':
-          description: Bad Request
-          schema:
-            $ref: '#/definitions/rdto.ErrorResponse'
-        '405':
-          description: Method Not Allowed
-          schema:
-            $ref: '#/definitions/rdto.ErrorResponse'
-        '504':
-          description: Gateway Timeout
-          schema:
-            $ref: '#/definitions/rdto.ErrorResponse'
-  /traces/by-conversation:
-    get:
-      description: Build a term filter automatically using attributes.gen_ai.conversation.id.keyword and return the original OpenSearch response body.
-      consumes:
-      - application/json
-      produces:
-      - application/json
-      tags:
-      - traces
-      summary: Search traces by conversation ID
-      parameters:
-      - type: string
-        description: Conversation ID
-        name: conversation_id
-        in: query
-        required: true
-      responses:
-        '200':
-          description: Raw OpenSearch search response
-          schema:
-            type: string
-        '400':
-          description: Bad Request
-          schema:
-            $ref: '#/definitions/rdto.ErrorResponse'
-        '405':
-          description: Method Not Allowed
-          schema:
-            $ref: '#/definitions/rdto.ErrorResponse'
-        '500':
-          description: Internal Server Error
-          schema:
-            $ref: '#/definitions/rdto.ErrorResponse'
-        '504':
-          description: Gateway Timeout
-          schema:
-            $ref: '#/definitions/rdto.ErrorResponse'
-  /traces/by-request:
-    get:
-      description: Returns normalized claim, evidence refs, business refs, pagination, partial reasons, and visibility summary for a request.
-      produces:
-      - application/json
-      tags:
-      - evidence
-      summary: Get evidence chain by BKN request ID
-      parameters:
-      - type: string
-        description: BKN request ID
-        name: request_id
-        in: query
-        required: true
-      - type: integer
-        description: Maximum evidence trace batches to read, 1..1000
-        name: limit
-        in: query
-      responses:
-        '200':
-          description: OK
-          schema:
-            $ref: '#/definitions/evidencevo.EvidenceChainResponse'
-        '400':
-          description: Bad Request
-          schema:
-            $ref: '#/definitions/rdto.ErrorResponse'
-        '404':
-          description: Not Found
-          schema:
-            $ref: '#/definitions/rdto.ErrorResponse'
-        '405':
-          description: Method Not Allowed
-          schema:
-            $ref: '#/definitions/rdto.ErrorResponse'
-        '500':
-          description: Internal Server Error
-          schema:
-            $ref: '#/definitions/rdto.ErrorResponse'
-  /traces/by-request/business-graph:
-    get:
-      description: Returns claim and business semantic nodes/edges derived from business.refs.resolved events.
-      produces:
-      - application/json
-      tags:
-      - evidence
-      summary: Get business semantic graph by BKN request ID
-      parameters:
-      - type: string
-        description: BKN request ID
-        name: request_id
-        in: query
-        required: true
-      - type: integer
-        description: Maximum evidence trace batches to read, 1..1000
-        name: limit
-        in: query
-      responses:
-        '200':
-          description: OK
-          schema:
-            $ref: '#/definitions/evidencevo.BusinessGraphResponse'
-        '400':
-          description: Bad Request
-          schema:
-            $ref: '#/definitions/rdto.ErrorResponse'
-        '404':
-          description: Not Found
-          schema:
-            $ref: '#/definitions/rdto.ErrorResponse'
-        '405':
-          description: Method Not Allowed
-          schema:
-            $ref: '#/definitions/rdto.ErrorResponse'
-        '500':
-          description: Internal Server Error
-          schema:
-            $ref: '#/definitions/rdto.ErrorResponse'
-  /traces/by-request/snapshot-preview:
-    get:
-      description: Returns a metadata-only governed snapshot manifest preview without creating or exposing object storage locations.
-      produces:
-      - application/json
-      tags:
-      - evidence
-      summary: Get evidence snapshot preview by BKN request ID
-      parameters:
-      - type: string
-        description: BKN request ID
-        name: request_id
-        in: query
-        required: true
-      - type: integer
-        description: Maximum evidence trace batches to read, 1..1000
-        name: limit
-        in: query
-      responses:
-        '200':
-          description: OK
-          schema:
-            $ref: '#/definitions/evidencevo.SnapshotPreviewResponse'
-        '400':
-          description: Bad Request
-          schema:
-            $ref: '#/definitions/rdto.ErrorResponse'
-        '404':
-          description: Not Found
-          schema:
-            $ref: '#/definitions/rdto.ErrorResponse'
-        '405':
-          description: Method Not Allowed
-          schema:
-            $ref: '#/definitions/rdto.ErrorResponse'
-        '500':
-          description: Internal Server Error
-          schema:
-            $ref: '#/definitions/rdto.ErrorResponse'
-  /traces/{trace_id}/business-graph:
-    get:
-      description: Returns claim and business semantic nodes/edges derived from business.refs.resolved events.
-      produces:
-      - application/json
-      tags:
-      - evidence
-      summary: Get business semantic graph by trace ID
-      parameters:
-      - type: string
-        description: Trace ID
-        name: trace_id
-        in: path
-        required: true
-      - type: integer
-        description: Maximum evidence trace batches to read, 1..1000
-        name: limit
-        in: query
-      responses:
-        '200':
-          description: OK
-          schema:
-            $ref: '#/definitions/evidencevo.BusinessGraphResponse'
-        '400':
-          description: Bad Request
-          schema:
-            $ref: '#/definitions/rdto.ErrorResponse'
-        '404':
-          description: Not Found
-          schema:
-            $ref: '#/definitions/rdto.ErrorResponse'
-        '405':
-          description: Method Not Allowed
-          schema:
-            $ref: '#/definitions/rdto.ErrorResponse'
-        '500':
-          description: Internal Server Error
-          schema:
-            $ref: '#/definitions/rdto.ErrorResponse'
-  /traces/{trace_id}/evidence-chain:
-    get:
-      description: Returns normalized claim, evidence refs, business refs, pagination, partial reasons, and visibility summary for a trace.
-      produces:
-      - application/json
-      tags:
-      - evidence
-      summary: Get evidence chain by trace ID
-      parameters:
-      - type: string
-        description: Trace ID
-        name: trace_id
-        in: path
-        required: true
-      - type: integer
-        description: Maximum evidence trace batches to read, 1..1000
-        name: limit
-        in: query
-      responses:
-        '200':
-          description: OK
-          schema:
-            $ref: '#/definitions/evidencevo.EvidenceChainResponse'
-        '400':
-          description: Bad Request
-          schema:
-            $ref: '#/definitions/rdto.ErrorResponse'
-        '404':
-          description: Not Found
-          schema:
-            $ref: '#/definitions/rdto.ErrorResponse'
-        '405':
-          description: Method Not Allowed
-          schema:
-            $ref: '#/definitions/rdto.ErrorResponse'
-        '500':
-          description: Internal Server Error
-          schema:
-            $ref: '#/definitions/rdto.ErrorResponse'
-  /traces/{trace_id}/snapshot-preview:
-    get:
-      description: Returns a metadata-only governed snapshot manifest preview without creating or exposing object storage locations.
-      produces:
-      - application/json
-      tags:
-      - evidence
-      summary: Get evidence snapshot preview by trace ID
-      parameters:
-      - type: string
-        description: Trace ID
-        name: trace_id
-        in: path
-        required: true
-      - type: integer
-        description: Maximum evidence trace batches to read, 1..1000
-        name: limit
-        in: query
-      responses:
-        '200':
-          description: OK
-          schema:
-            $ref: '#/definitions/evidencevo.SnapshotPreviewResponse'
-        '400':
-          description: Bad Request
-          schema:
-            $ref: '#/definitions/rdto.ErrorResponse'
-        '404':
-          description: Not Found
-          schema:
-            $ref: '#/definitions/rdto.ErrorResponse'
-        '405':
-          description: Method Not Allowed
-          schema:
-            $ref: '#/definitions/rdto.ErrorResponse'
-        '500':
-          description: Internal Server Error
-          schema:
-            $ref: '#/definitions/rdto.ErrorResponse'
-  /traces/{trace_id}/trace-graph:
-    get:
-      description: Returns normalized trace tree nodes, parent-child edges, status, duration, and partial reasons for a trace.
-      produces:
-      - application/json
-      tags:
-      - traces
-      summary: Get trace graph by trace ID
-      parameters:
-      - type: string
-        description: Trace ID
-        name: trace_id
-        in: path
-        required: true
-      responses:
-        '200':
-          description: OK
-          schema:
-            type: object
-            additionalProperties: true
-        '400':
-          description: Bad Request
-          schema:
-            $ref: '#/definitions/rdto.ErrorResponse'
-        '404':
-          description: Not Found
-          schema:
-            $ref: '#/definitions/rdto.ErrorResponse'
-        '405':
-          description: Method Not Allowed
-          schema:
-            $ref: '#/definitions/rdto.ErrorResponse'
-        '500':
-          description: Internal Server Error
-          schema:
-            $ref: '#/definitions/rdto.ErrorResponse'
-        '504':
-          description: Gateway Timeout
-          schema:
-            $ref: '#/definitions/rdto.ErrorResponse'
-  /interactions/{interaction_id}:
-    get:
-      description: Aggregates every authorized request and trace in one caller-owned interaction.
-      produces:
-      - application/json
-      tags:
-      - interactions
-      summary: Get one observable business interaction
-      parameters:
-      - type: string
-        description: BKN interaction ID
-        name: interaction_id
-        in: path
-        required: true
-      responses:
-        '200':
-          description: OK
-          schema:
-            $ref: '#/definitions/evidencevo.InteractionSummary'
-        '400':
-          description: Bad Request
-          schema:
-            $ref: '#/definitions/rdto.ErrorResponse'
-        '401':
-          description: Unauthorized
-          schema:
-            $ref: '#/definitions/rdto.ErrorResponse'
-        '404':
-          description: Not Found
-          schema:
-            $ref: '#/definitions/rdto.ErrorResponse'
-        '500':
-          description: Internal Server Error
-          schema:
-            $ref: '#/definitions/rdto.ErrorResponse'
 definitions:
   evidencevo.ActionSummary:
-    type: object
     properties:
       approved:
         type: integer
@@ -826,8 +12,8 @@ definitions:
         type: string
       recommended:
         type: integer
-  evidencevo.ArtifactIngestResponse:
     type: object
+  evidencevo.ArtifactIngestResponse:
     properties:
       artifact_id:
         type: string
@@ -841,8 +27,8 @@ definitions:
         type: boolean
       trace_id:
         type: string
-  evidencevo.ArtifactLink:
     type: object
+  evidencevo.ArtifactLink:
     properties:
       artifact_ref:
         type: string
@@ -858,8 +44,8 @@ definitions:
         type: string
       role:
         type: string
+    type: object
   evidencevo.ArtifactType:
-    type: string
     enum:
     - question
     - result
@@ -868,6 +54,7 @@ definitions:
     - logic_execution
     - action_input
     - action_result
+    type: string
     x-enum-varnames:
     - ArtifactTypeQuestion
     - ArtifactTypeResult
@@ -877,12 +64,11 @@ definitions:
     - ArtifactTypeActionInput
     - ArtifactTypeActionResult
   evidencevo.BusinessDisplay:
-    type: object
     properties:
       business_path:
-        type: array
         items:
           type: string
+        type: array
       controlled_summary:
         type: string
       name:
@@ -891,19 +77,19 @@ definitions:
         type: string
       source_version:
         type: string
-  evidencevo.BusinessGraphData:
     type: object
+  evidencevo.BusinessGraphData:
     properties:
       edges:
-        type: array
         items:
           $ref: '#/definitions/evidencevo.BusinessGraphEdge'
-      nodes:
         type: array
+      nodes:
         items:
           $ref: '#/definitions/evidencevo.BusinessGraphNode'
-  evidencevo.BusinessGraphEdge:
+        type: array
     type: object
+  evidencevo.BusinessGraphEdge:
     properties:
       edge_type:
         type: string
@@ -915,8 +101,8 @@ definitions:
         type: string
       visibility:
         type: string
-  evidencevo.BusinessGraphNode:
     type: object
+  evidencevo.BusinessGraphNode:
     properties:
       action_instance_id:
         type: string
@@ -937,16 +123,16 @@ definitions:
       operation_id:
         type: string
       properties:
-        type: object
         additionalProperties: {}
+        type: object
       stage:
         type: string
       version_status:
         type: string
       visibility:
         type: string
-  evidencevo.BusinessGraphResponse:
     type: object
+  evidencevo.BusinessGraphResponse:
     properties:
       bkn.request.id:
         type: string
@@ -957,15 +143,15 @@ definitions:
       partial:
         type: boolean
       partial_reason:
-        type: array
         items:
           type: string
+        type: array
       trace_id:
         type: string
       visibility_summary:
         $ref: '#/definitions/evidencevo.VisibilitySummary'
-  evidencevo.EvidenceArtifact:
     type: object
+  evidencevo.EvidenceArtifact:
     properties:
       agent_or_app:
         type: string
@@ -986,9 +172,9 @@ definitions:
       business_domain:
         type: string
       business_refs:
-        type: array
         items:
           type: string
+        type: array
       claim_id:
         type: string
       content: {}
@@ -1014,30 +200,30 @@ definitions:
         type: string
       trace_id:
         type: string
-  evidencevo.EvidenceChainData:
     type: object
+  evidencevo.EvidenceChainData:
     properties:
       artifact_links:
-        type: array
         items:
           $ref: '#/definitions/evidencevo.ArtifactLink'
+        type: array
       business_refs:
-        type: array
         items:
-          type: object
           additionalProperties: {}
+          type: object
+        type: array
       claims:
-        type: array
         items:
-          type: object
           additionalProperties: {}
+          type: object
+        type: array
       evidence_refs:
-        type: array
         items:
-          type: object
           additionalProperties: {}
-  evidencevo.EvidenceChainResponse:
+          type: object
+        type: array
     type: object
+  evidencevo.EvidenceChainResponse:
     properties:
       bkn.request.id:
         type: string
@@ -1048,23 +234,23 @@ definitions:
       partial:
         type: boolean
       partial_reason:
-        type: array
         items:
           type: string
+        type: array
       trace_id:
         type: string
       visibility_summary:
         $ref: '#/definitions/evidencevo.VisibilitySummary'
-  evidencevo.EvidenceNodeResponse:
     type: object
+  evidencevo.EvidenceNodeResponse:
     properties:
       bkn.request.id:
         type: string
       claim_id:
         type: string
       data:
-        type: object
         additionalProperties: {}
+        type: object
       node_id:
         type: string
       node_type:
@@ -1075,8 +261,8 @@ definitions:
         type: string
       visibility:
         type: string
-  evidencevo.EvidencePage:
     type: object
+  evidencevo.EvidencePage:
     properties:
       edge_count:
         type: integer
@@ -1086,8 +272,8 @@ definitions:
         type: integer
       truncated:
         type: boolean
-  evidencevo.IngestResponse:
     type: object
+  evidencevo.IngestResponse:
     properties:
       accepted_event_count:
         type: integer
@@ -1103,8 +289,31 @@ definitions:
         type: integer
       trace_id:
         type: string
-  evidencevo.RequestSummary:
     type: object
+  evidencevo.InteractionSummary:
+    properties:
+      completed_at:
+        type: string
+      conversation_id:
+        type: string
+      duration_ms:
+        type: integer
+      interaction_id:
+        type: string
+      requests:
+        items:
+          $ref: '#/definitions/evidencevo.RequestSummary'
+        type: array
+      started_at:
+        type: string
+      status:
+        type: string
+      traces:
+        items:
+          $ref: '#/definitions/evidencevo.TraceSummary'
+        type: array
+    type: object
+  evidencevo.RequestSummary:
     properties:
       action_summary:
         $ref: '#/definitions/evidencevo.ActionSummary'
@@ -1113,9 +322,9 @@ definitions:
       business_domain:
         type: string
       business_refs:
-        type: array
         items:
           type: string
+        type: array
       completed_at:
         type: string
       conversation_id:
@@ -1124,20 +333,20 @@ definitions:
         type: integer
       error_summary:
         type: string
-      interaction_id:
-        type: string
       evidence_completeness:
         type: string
       initiator:
         type: string
+      interaction_id:
+        type: string
       knowledge_networks:
-        type: array
         items:
           type: string
+        type: array
       partial_reasons:
-        type: array
         items:
           type: string
+        type: array
       question_preview:
         type: string
       request_id:
@@ -1150,27 +359,27 @@ definitions:
         type: string
       trace_count:
         type: integer
-  evidencevo.RequestSummaryPage:
     type: object
+  evidencevo.RequestSummaryPage:
     properties:
       entries:
-        type: array
         items:
           $ref: '#/definitions/evidencevo.RequestSummary'
+        type: array
       next_cursor:
         type: string
       partial:
         type: boolean
       partial_reasons:
-        type: array
         items:
           type: string
+        type: array
       total:
         type: integer
       truncated:
         type: boolean
-  evidencevo.SnapshotManifest:
     type: object
+  evidencevo.SnapshotManifest:
     properties:
       artifact_count:
         type: integer
@@ -1204,8 +413,8 @@ definitions:
         type: string
       visibility_summary:
         $ref: '#/definitions/evidencevo.VisibilitySummary'
-  evidencevo.SnapshotPreviewResponse:
     type: object
+  evidencevo.SnapshotPreviewResponse:
     properties:
       bkn.request.id:
         type: string
@@ -1214,17 +423,17 @@ definitions:
       partial:
         type: boolean
       partial_reason:
-        type: array
         items:
           type: string
+        type: array
       snapshot_ref:
         $ref: '#/definitions/evidencevo.SnapshotRef'
       trace_id:
         type: string
       visibility_summary:
         $ref: '#/definitions/evidencevo.VisibilitySummary'
-  evidencevo.SnapshotRef:
     type: object
+  evidencevo.SnapshotRef:
     properties:
       mode:
         type: string
@@ -1232,8 +441,8 @@ definitions:
         type: string
       uri:
         type: string
-  evidencevo.TraceSummary:
     type: object
+  evidencevo.TraceSummary:
     properties:
       agent_or_app:
         type: string
@@ -1261,27 +470,27 @@ definitions:
         type: string
       trace_id:
         type: string
-  evidencevo.TraceSummaryPage:
     type: object
+  evidencevo.TraceSummaryPage:
     properties:
       entries:
-        type: array
         items:
           $ref: '#/definitions/evidencevo.TraceSummary'
+        type: array
       next_cursor:
         type: string
       partial:
         type: boolean
       partial_reasons:
-        type: array
         items:
           type: string
+        type: array
       total:
         type: integer
       truncated:
         type: boolean
-  evidencevo.VisibilitySummary:
     type: object
+  evidencevo.VisibilitySummary:
     properties:
       authorized_ref_count:
         type: integer
@@ -1295,8 +504,275 @@ definitions:
         type: integer
       unresolved_ref_count:
         type: integer
-  rdto.ErrorResponse:
     type: object
+  httphandler.closeConversationRequest:
+    properties:
+      idempotency_key:
+        type: string
+    type: object
+  httphandler.conversationPage:
+    properties:
+      entries:
+        items:
+          $ref: '#/definitions/sessionvo.Conversation'
+        type: array
+      next_cursor:
+        type: string
+    type: object
+  httphandler.ensureConversationRequest:
+    properties:
+      application_principal_id:
+        type: string
+      business_domain_id:
+        type: string
+      delegation_id:
+        type: string
+      effective_subject_id:
+        type: string
+      effective_subject_type:
+        type: string
+      external_conversation_key:
+        type: string
+      idempotency_key:
+        type: string
+      one_shot:
+        type: boolean
+      tenant_id:
+        type: string
+    type: object
+  httphandler.ensureOperationRequest:
+    properties:
+      causation_event_ids:
+        items:
+          type: string
+        type: array
+      lease_epoch:
+        type: integer
+      lease_token:
+        type: string
+      normalized_input_hash:
+        type: string
+      operation_key:
+        type: string
+      parent_operation_id:
+        type: string
+      required:
+        type: boolean
+      tool_name:
+        type: string
+    type: object
+  httphandler.evidenceEventRequest:
+    properties:
+      artifact_refs:
+        items:
+          type: string
+        type: array
+      attempt:
+        type: integer
+      business_domain_id:
+        type: string
+      business_refs:
+        items:
+          $ref: '#/definitions/sessionvo.BusinessRef'
+        type: array
+      causation_event_ids:
+        items:
+          type: string
+        type: array
+      conversation_id:
+        type: string
+      emitted_at:
+        type: string
+      envelope:
+        items:
+          type: integer
+        type: array
+      event_id:
+        type: string
+      event_type:
+        type: string
+      interaction_id:
+        type: string
+      observed_at:
+        type: string
+      operation_id:
+        type: string
+      payload_hash:
+        type: string
+      producer_epoch:
+        type: integer
+      producer_id:
+        type: string
+      producer_sequence:
+        type: integer
+      producer_stream_id:
+        type: string
+      request_id:
+        type: string
+      schema_version:
+        type: string
+      span_id:
+        type: string
+      started_at:
+        type: string
+      tenant_id:
+        type: string
+      trace_id:
+        type: string
+    type: object
+  httphandler.finishAttemptRequest:
+    properties:
+      artifact_refs:
+        items:
+          type: string
+        type: array
+      business_refs:
+        items:
+          $ref: '#/definitions/sessionvo.BusinessRef'
+        type: array
+      evidence_durability:
+        $ref: '#/definitions/sessionvo.EvidenceDurability'
+      observed_evidence_refs:
+        items:
+          type: string
+        type: array
+      partial_reasons:
+        items:
+          type: string
+        type: array
+      payload_hash:
+        type: string
+      receipt_id:
+        type: string
+      request_id:
+        type: string
+      retryable:
+        type: boolean
+      trace_id:
+        type: string
+    type: object
+  httphandler.interactionLeaseRequest:
+    properties:
+      lease_epoch:
+        type: integer
+      lease_token:
+        type: string
+    type: object
+  httphandler.lifecycleError:
+    properties:
+      code:
+        enum:
+        - conversation_required
+        - conversation_not_found
+        - conversation_closed
+        - conversation_expired
+        - conversation_owner_mismatch
+        - interaction_required
+        - interaction_in_progress
+        - interaction_terminal
+        - operation_required
+        - idempotency_conflict
+        - event_payload_conflict
+        - producer_sequence_conflict
+        - invalid_evidence_event
+        - receipt_pending
+        - terminal_conflict
+        - closure_manifest_invalid
+        - feature_not_installed
+        - capability_not_licensed
+        - permission_denied
+        - resource_not_disclosed
+        - internal_error
+        type: string
+      current_status:
+        type: string
+      message:
+        type: string
+      request_id:
+        type: string
+      required_action:
+        type: string
+      retry_after_ms:
+        type: integer
+      retryable:
+        type: boolean
+    type: object
+  httphandler.lifecycleErrorEnvelope:
+    properties:
+      error:
+        $ref: '#/definitions/httphandler.lifecycleError'
+    type: object
+  httphandler.operationResult:
+    properties:
+      operation:
+        $ref: '#/definitions/sessionvo.Operation'
+      receipt:
+        $ref: '#/definitions/sessionvo.Receipt'
+    type: object
+  httphandler.requestPage:
+    properties:
+      entries:
+        items:
+          $ref: '#/definitions/sessionvo.RequestSummary'
+        type: array
+      next_cursor:
+        type: string
+    type: object
+  httphandler.resumeConversationRequest:
+    properties:
+      conversation_id:
+        type: string
+    type: object
+  httphandler.startInteractionRequest:
+    properties:
+      idempotency_key:
+        type: string
+      lease_seconds:
+        type: integer
+    type: object
+  httphandler.terminalInteractionRequest:
+    properties:
+      answer_artifact_ref:
+        type: string
+      assembler_deadline:
+        type: string
+      claims:
+        items:
+          type: string
+        type: array
+      completion_manifest_version:
+        type: string
+      completion_reason:
+        type: string
+      expected_operations:
+        items:
+          $ref: '#/definitions/sessionvo.ExpectedOperation'
+        type: array
+      expected_receipts:
+        items:
+          $ref: '#/definitions/sessionvo.ExpectedReceipt'
+        type: array
+      lease_epoch:
+        type: integer
+      lease_token:
+        type: string
+      terminal_idempotency_key:
+        type: string
+    type: object
+  ledgervo.DurableAck:
+    properties:
+      durable_ack:
+        type: boolean
+      event_id:
+        type: string
+      ingest_sequence:
+        type: integer
+      ingested_at:
+        type: string
+      replayed:
+        type: boolean
+    type: object
+  rdto.ErrorResponse:
     properties:
       code:
         type: string
@@ -1307,26 +783,1943 @@ definitions:
         type: string
       trace_id:
         type: string
-  evidencevo.InteractionSummary:
     type: object
+  sessionvo.AttemptStatus:
+    enum:
+    - pending
+    - completed
+    - failed
+    type: string
+    x-enum-varnames:
+    - AttemptPending
+    - AttemptCompleted
+    - AttemptFailed
+  sessionvo.BusinessRef:
     properties:
-      completed_at:
+      as_of:
+        type: string
+      business_domain_id:
+        type: string
+      display_hint:
+        type: string
+      ref_id:
+        type: string
+      ref_type:
+        type: string
+      version:
+        type: string
+    type: object
+  sessionvo.ClosureManifest:
+    properties:
+      answer_artifact_ref:
+        type: string
+      assembler_deadline:
+        type: string
+      claims:
+        items:
+          type: string
+        type: array
+      completion_manifest_version:
+        type: string
+      completion_reason:
+        type: string
+      expected_operations:
+        items:
+          $ref: '#/definitions/sessionvo.ExpectedOperation'
+        type: array
+      expected_receipts:
+        items:
+          $ref: '#/definitions/sessionvo.ExpectedReceipt'
+        type: array
+      system_partial_reasons:
+        items:
+          type: string
+        type: array
+    type: object
+  sessionvo.Conversation:
+    properties:
+      closed_at:
         type: string
       conversation_id:
         type: string
-      duration_ms:
+      created_at:
+        type: string
+      external_conversation_key:
+        type: string
+      generation:
         type: integer
+      one_shot:
+        type: boolean
+      owner:
+        $ref: '#/definitions/sessionvo.Owner'
+      row_version:
+        type: integer
+      status:
+        $ref: '#/definitions/sessionvo.ConversationStatus'
+      updated_at:
+        type: string
+    type: object
+  sessionvo.ConversationStatus:
+    enum:
+    - active
+    - closed
+    - expired
+    type: string
+    x-enum-varnames:
+    - ConversationActive
+    - ConversationClosed
+    - ConversationExpired
+  sessionvo.EvidenceDurability:
+    enum:
+    - pending
+    - durable
+    - failed
+    type: string
+    x-enum-varnames:
+    - DurabilityPending
+    - DurabilityDurable
+    - DurabilityFailed
+  sessionvo.EvidenceStatus:
+    enum:
+    - not_applicable
+    - assembling
+    - complete
+    - partial
+    - failed
+    type: string
+    x-enum-varnames:
+    - EvidenceNotApplicable
+    - EvidenceAssembling
+    - EvidenceComplete
+    - EvidencePartial
+    - EvidenceFailed
+  sessionvo.ExpectedOperation:
+    properties:
+      operation_id:
+        type: string
+      required:
+        type: boolean
+    type: object
+  sessionvo.ExpectedReceipt:
+    properties:
+      receipt_id:
+        type: string
+      required:
+        type: boolean
+    type: object
+  sessionvo.Interaction:
+    properties:
+      closure_manifest:
+        $ref: '#/definitions/sessionvo.ClosureManifest'
+      conversation_id:
+        type: string
+      created_at:
+        type: string
+      evidence_status:
+        $ref: '#/definitions/sessionvo.EvidenceStatus'
+      execution_status:
+        $ref: '#/definitions/sessionvo.InteractionStatus'
       interaction_id:
         type: string
-      requests:
-        type: array
-        items:
-          $ref: '#/definitions/evidencevo.RequestSummary'
-      started_at:
+      lease_epoch:
+        type: integer
+      lease_expires_at:
         type: string
-      status:
+      lease_token:
         type: string
-      traces:
-        type: array
+      lease_version:
+        type: integer
+      ordinal:
+        type: integer
+      row_version:
+        type: integer
+      terminal_at:
+        type: string
+      updated_at:
+        type: string
+    type: object
+  sessionvo.InteractionStatus:
+    enum:
+    - active
+    - completed
+    - failed
+    - canceled
+    - handed_off
+    - abandoned
+    type: string
+    x-enum-varnames:
+    - InteractionActive
+    - InteractionCompleted
+    - InteractionFailed
+    - InteractionCanceled
+    - InteractionHandedOff
+    - InteractionAbandoned
+  sessionvo.Operation:
+    properties:
+      attempt:
+        type: integer
+      attempt_status:
+        $ref: '#/definitions/sessionvo.AttemptStatus'
+      causation_event_ids:
         items:
-          $ref: '#/definitions/evidencevo.TraceSummary'
+          type: string
+        type: array
+      conversation_id:
+        type: string
+      created_at:
+        type: string
+      interaction_id:
+        type: string
+      normalized_input_hash:
+        type: string
+      operation_id:
+        type: string
+      operation_key:
+        type: string
+      parent_operation_id:
+        type: string
+      retryable:
+        type: boolean
+      row_version:
+        type: integer
+      tool_name:
+        type: string
+      updated_at:
+        type: string
+    type: object
+  sessionvo.Owner:
+    properties:
+      application_principal_id:
+        type: string
+      business_domain_id:
+        type: string
+      delegation_id:
+        type: string
+      effective_subject_id:
+        type: string
+      effective_subject_type:
+        $ref: '#/definitions/sessionvo.SubjectType'
+      tenant_id:
+        type: string
+    type: object
+  sessionvo.Receipt:
+    properties:
+      artifact_refs:
+        items:
+          type: string
+        type: array
+      attempt:
+        type: integer
+      business_refs:
+        items:
+          $ref: '#/definitions/sessionvo.BusinessRef'
+        type: array
+      causation_event_ids:
+        items:
+          type: string
+        type: array
+      conversation_id:
+        type: string
+      evidence_durability:
+        $ref: '#/definitions/sessionvo.EvidenceDurability'
+      interaction_id:
+        type: string
+      issued_at:
+        type: string
+      normalized_input_hash:
+        type: string
+      observed_evidence_refs:
+        items:
+          type: string
+        type: array
+      operation_id:
+        type: string
+      operation_key:
+        type: string
+      owner:
+        $ref: '#/definitions/sessionvo.Owner'
+      partial_reasons:
+        items:
+          type: string
+        type: array
+      payload_hash:
+        type: string
+      receipt_id:
+        type: string
+      receipt_status:
+        $ref: '#/definitions/sessionvo.ReceiptStatus'
+      request_id:
+        type: string
+      required:
+        type: boolean
+      row_version:
+        type: integer
+      schema_version:
+        type: string
+      terminal_at:
+        type: string
+      tool_name:
+        type: string
+      trace_id:
+        type: string
+    type: object
+  sessionvo.ReceiptStatus:
+    enum:
+    - pending
+    - completed
+    - failed
+    type: string
+    x-enum-varnames:
+    - ReceiptPending
+    - ReceiptCompleted
+    - ReceiptFailed
+  sessionvo.RequestSummary:
+    properties:
+      conversation_id:
+        type: string
+      interaction_id:
+        type: string
+      operation_count:
+        type: integer
+      receipt_count:
+        type: integer
+      request_id:
+        type: string
+      trace_ids:
+        items:
+          type: string
+        type: array
+      updated_at:
+        type: string
+    type: object
+  sessionvo.SubjectType:
+    enum:
+    - user
+    - service
+    type: string
+    x-enum-varnames:
+    - SubjectUser
+    - SubjectService
+info:
+  contact: {}
+  description: APIs for querying agent traces from OpenSearch.
+  title: Agent Observability API
+  version: "1.0"
+paths:
+  /api/agent-observability/v1/traces/_search:
+    post:
+      consumes:
+      - application/json
+      description: Proxy raw OpenSearch DSL to the configured trace index and return
+        the original OpenSearch response body.
+      parameters:
+      - description: OpenSearch DSL JSON body
+        in: body
+        name: request
+        required: true
+        schema:
+          type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: Raw OpenSearch search response
+          schema:
+            type: string
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/rdto.ErrorResponse'
+        "405":
+          description: Method Not Allowed
+          schema:
+            $ref: '#/definitions/rdto.ErrorResponse'
+        "504":
+          description: Gateway Timeout
+          schema:
+            $ref: '#/definitions/rdto.ErrorResponse'
+      summary: Search traces with raw OpenSearch DSL
+      tags:
+      - traces
+  /api/agent-observability/v1/traces/{trace_id}/trace-graph:
+    get:
+      description: Returns normalized trace tree nodes, parent-child edges, status,
+        duration, and partial reasons for a trace.
+      parameters:
+      - description: Trace ID
+        in: path
+        name: trace_id
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties: true
+            type: object
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/rdto.ErrorResponse'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/rdto.ErrorResponse'
+        "405":
+          description: Method Not Allowed
+          schema:
+            $ref: '#/definitions/rdto.ErrorResponse'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/rdto.ErrorResponse'
+        "504":
+          description: Gateway Timeout
+          schema:
+            $ref: '#/definitions/rdto.ErrorResponse'
+      summary: Get trace graph by trace ID
+      tags:
+      - traces
+  /api/agent-observability/v1/traces/by-conversation:
+    get:
+      consumes:
+      - application/json
+      description: Build a term filter automatically using attributes.gen_ai.conversation.id.keyword
+        and return the original OpenSearch response body.
+      parameters:
+      - description: Conversation ID
+        in: query
+        name: conversation_id
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: Raw OpenSearch search response
+          schema:
+            type: string
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/rdto.ErrorResponse'
+        "405":
+          description: Method Not Allowed
+          schema:
+            $ref: '#/definitions/rdto.ErrorResponse'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/rdto.ErrorResponse'
+        "504":
+          description: Gateway Timeout
+          schema:
+            $ref: '#/definitions/rdto.ErrorResponse'
+      summary: Search traces by conversation ID
+      tags:
+      - traces
+  /conversations:
+    get:
+      parameters:
+      - description: Page size, 1..100
+        in: query
+        name: limit
+        type: integer
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/httphandler.conversationPage'
+        "401":
+          description: Unauthorized
+          schema:
+            $ref: '#/definitions/httphandler.lifecycleErrorEnvelope'
+        "403":
+          description: Forbidden
+          schema:
+            $ref: '#/definitions/httphandler.lifecycleErrorEnvelope'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/httphandler.lifecycleErrorEnvelope'
+      summary: List managed Conversations in the authorized owner scope
+      tags:
+      - lifecycle
+    post:
+      consumes:
+      - application/json
+      parameters:
+      - description: Managed Conversation request
+        in: body
+        name: request
+        required: true
+        schema:
+          $ref: '#/definitions/httphandler.ensureConversationRequest'
+      produces:
+      - application/json
+      responses:
+        "201":
+          description: Created
+          schema:
+            $ref: '#/definitions/sessionvo.Conversation'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/httphandler.lifecycleErrorEnvelope'
+        "401":
+          description: Unauthorized
+          schema:
+            $ref: '#/definitions/httphandler.lifecycleErrorEnvelope'
+        "403":
+          description: Forbidden
+          schema:
+            $ref: '#/definitions/httphandler.lifecycleErrorEnvelope'
+        "409":
+          description: Conflict
+          schema:
+            $ref: '#/definitions/httphandler.lifecycleErrorEnvelope'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/httphandler.lifecycleErrorEnvelope'
+      summary: Create or return the current managed Conversation
+      tags:
+      - lifecycle
+  /conversations/{conversation_id}:
+    get:
+      parameters:
+      - description: Conversation ID
+        in: path
+        name: conversation_id
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/sessionvo.Conversation'
+        "401":
+          description: Unauthorized
+          schema:
+            $ref: '#/definitions/httphandler.lifecycleErrorEnvelope'
+        "403":
+          description: Forbidden
+          schema:
+            $ref: '#/definitions/httphandler.lifecycleErrorEnvelope'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/httphandler.lifecycleErrorEnvelope'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/httphandler.lifecycleErrorEnvelope'
+      summary: Get one managed Conversation
+      tags:
+      - lifecycle
+  /conversations/{conversation_id}/close:
+    post:
+      consumes:
+      - application/json
+      parameters:
+      - description: Conversation ID
+        in: path
+        name: conversation_id
+        required: true
+        type: string
+      - description: Idempotent close request
+        in: body
+        name: request
+        required: true
+        schema:
+          $ref: '#/definitions/httphandler.closeConversationRequest'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/sessionvo.Conversation'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/httphandler.lifecycleErrorEnvelope'
+        "401":
+          description: Unauthorized
+          schema:
+            $ref: '#/definitions/httphandler.lifecycleErrorEnvelope'
+        "403":
+          description: Forbidden
+          schema:
+            $ref: '#/definitions/httphandler.lifecycleErrorEnvelope'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/httphandler.lifecycleErrorEnvelope'
+        "409":
+          description: Conflict
+          schema:
+            $ref: '#/definitions/httphandler.lifecycleErrorEnvelope'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/httphandler.lifecycleErrorEnvelope'
+      summary: Close one managed Conversation
+      tags:
+      - lifecycle
+  /conversations/{conversation_id}/interactions:
+    post:
+      consumes:
+      - application/json
+      parameters:
+      - description: Conversation ID
+        in: path
+        name: conversation_id
+        required: true
+        type: string
+      - description: Interaction start request
+        in: body
+        name: request
+        required: true
+        schema:
+          $ref: '#/definitions/httphandler.startInteractionRequest'
+      produces:
+      - application/json
+      responses:
+        "201":
+          description: Created
+          schema:
+            $ref: '#/definitions/sessionvo.Interaction'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/httphandler.lifecycleErrorEnvelope'
+        "401":
+          description: Unauthorized
+          schema:
+            $ref: '#/definitions/httphandler.lifecycleErrorEnvelope'
+        "403":
+          description: Forbidden
+          schema:
+            $ref: '#/definitions/httphandler.lifecycleErrorEnvelope'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/httphandler.lifecycleErrorEnvelope'
+        "409":
+          description: Conflict
+          schema:
+            $ref: '#/definitions/httphandler.lifecycleErrorEnvelope'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/httphandler.lifecycleErrorEnvelope'
+      summary: Start one managed Interaction
+      tags:
+      - lifecycle
+  /conversations/{conversation_id}/interactions/{interaction_id}/operations:ensure:
+    post:
+      consumes:
+      - application/json
+      parameters:
+      - description: Conversation ID
+        in: path
+        name: conversation_id
+        required: true
+        type: string
+      - description: Interaction ID
+        in: path
+        name: interaction_id
+        required: true
+        type: string
+      - description: Operation intent
+        in: body
+        name: request
+        required: true
+        schema:
+          $ref: '#/definitions/httphandler.ensureOperationRequest'
+      produces:
+      - application/json
+      responses:
+        "201":
+          description: Created
+          schema:
+            $ref: '#/definitions/httphandler.operationResult'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/httphandler.lifecycleErrorEnvelope'
+        "401":
+          description: Unauthorized
+          schema:
+            $ref: '#/definitions/httphandler.lifecycleErrorEnvelope'
+        "403":
+          description: Forbidden
+          schema:
+            $ref: '#/definitions/httphandler.lifecycleErrorEnvelope'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/httphandler.lifecycleErrorEnvelope'
+        "409":
+          description: Conflict
+          schema:
+            $ref: '#/definitions/httphandler.lifecycleErrorEnvelope'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/httphandler.lifecycleErrorEnvelope'
+      summary: Ensure an idempotent Operation intent and durable Receipt
+      tags:
+      - lifecycle
+  /conversations:create-new-generation:
+    post:
+      consumes:
+      - application/json
+      parameters:
+      - description: New generation request
+        in: body
+        name: request
+        required: true
+        schema:
+          $ref: '#/definitions/httphandler.ensureConversationRequest'
+      produces:
+      - application/json
+      responses:
+        "201":
+          description: Created
+          schema:
+            $ref: '#/definitions/sessionvo.Conversation'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/httphandler.lifecycleErrorEnvelope'
+        "401":
+          description: Unauthorized
+          schema:
+            $ref: '#/definitions/httphandler.lifecycleErrorEnvelope'
+        "403":
+          description: Forbidden
+          schema:
+            $ref: '#/definitions/httphandler.lifecycleErrorEnvelope'
+        "409":
+          description: Conflict
+          schema:
+            $ref: '#/definitions/httphandler.lifecycleErrorEnvelope'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/httphandler.lifecycleErrorEnvelope'
+      summary: Create a new managed Conversation generation
+      tags:
+      - lifecycle
+  /conversations:ensure-current:
+    post:
+      consumes:
+      - application/json
+      parameters:
+      - description: Managed Conversation request
+        in: body
+        name: request
+        required: true
+        schema:
+          $ref: '#/definitions/httphandler.ensureConversationRequest'
+      produces:
+      - application/json
+      responses:
+        "201":
+          description: Created
+          schema:
+            $ref: '#/definitions/sessionvo.Conversation'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/httphandler.lifecycleErrorEnvelope'
+        "401":
+          description: Unauthorized
+          schema:
+            $ref: '#/definitions/httphandler.lifecycleErrorEnvelope'
+        "403":
+          description: Forbidden
+          schema:
+            $ref: '#/definitions/httphandler.lifecycleErrorEnvelope'
+        "409":
+          description: Conflict
+          schema:
+            $ref: '#/definitions/httphandler.lifecycleErrorEnvelope'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/httphandler.lifecycleErrorEnvelope'
+      summary: Ensure the current managed Conversation
+      tags:
+      - lifecycle
+  /conversations:resume-by-id:
+    post:
+      consumes:
+      - application/json
+      parameters:
+      - description: Conversation resume request
+        in: body
+        name: request
+        required: true
+        schema:
+          $ref: '#/definitions/httphandler.resumeConversationRequest'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/sessionvo.Conversation'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/httphandler.lifecycleErrorEnvelope'
+        "401":
+          description: Unauthorized
+          schema:
+            $ref: '#/definitions/httphandler.lifecycleErrorEnvelope'
+        "403":
+          description: Forbidden
+          schema:
+            $ref: '#/definitions/httphandler.lifecycleErrorEnvelope'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/httphandler.lifecycleErrorEnvelope'
+        "409":
+          description: Conflict
+          schema:
+            $ref: '#/definitions/httphandler.lifecycleErrorEnvelope'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/httphandler.lifecycleErrorEnvelope'
+      summary: Resume an active managed Conversation by Core ID
+      tags:
+      - lifecycle
+  /evidence-nodes/{node_id}:
+    get:
+      description: Returns one visible claim, evidence ref, or business ref node scoped
+        by trace_id or request_id.
+      parameters:
+      - description: Evidence node ID, for example claim:claim_001
+        in: path
+        name: node_id
+        required: true
+        type: string
+      - description: Trace ID scope
+        in: query
+        name: trace_id
+        type: string
+      - description: BKN request ID scope
+        in: query
+        name: request_id
+        type: string
+      - description: Maximum evidence trace batches to read, 1..1000
+        in: query
+        name: limit
+        type: integer
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/evidencevo.EvidenceNodeResponse'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/rdto.ErrorResponse'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/rdto.ErrorResponse'
+        "405":
+          description: Method Not Allowed
+          schema:
+            $ref: '#/definitions/rdto.ErrorResponse'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/rdto.ErrorResponse'
+      summary: Get evidence node details
+      tags:
+      - evidence
+  /evidence/artifacts:
+    post:
+      consumes:
+      - application/json
+      description: Stores authorized business content separately from evidence events.
+        Inline content and snapshot_ref are mutually exclusive.
+      parameters:
+      - description: BKN Trace 2.2 evidence artifact
+        in: body
+        name: request
+        required: true
+        schema:
+          $ref: '#/definitions/evidencevo.EvidenceArtifact'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/evidencevo.ArtifactIngestResponse'
+        "201":
+          description: Created
+          schema:
+            $ref: '#/definitions/evidencevo.ArtifactIngestResponse'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/rdto.ErrorResponse'
+        "401":
+          description: Unauthorized
+          schema:
+            $ref: '#/definitions/rdto.ErrorResponse'
+        "409":
+          description: Conflict
+          schema:
+            $ref: '#/definitions/rdto.ErrorResponse'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/rdto.ErrorResponse'
+      summary: Ingest a BKN Trace 2.2 evidence artifact
+      tags:
+      - evidence
+  /evidence/artifacts/{artifact_id}:
+    get:
+      description: Returns artifact content only when all persisted ownership dimensions
+        match the trusted query identity.
+      parameters:
+      - description: Artifact ID
+        in: path
+        name: artifact_id
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/evidencevo.EvidenceArtifact'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/rdto.ErrorResponse'
+        "401":
+          description: Unauthorized
+          schema:
+            $ref: '#/definitions/rdto.ErrorResponse'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/rdto.ErrorResponse'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/rdto.ErrorResponse'
+      summary: Get an authorized evidence artifact by ID
+      tags:
+      - evidence
+  /evidence/by-trace:
+    get:
+      description: Backward-compatible endpoint for SDK/Studio callers. Returns the
+        normalized evidence-chain response for trace_id or request_id.
+      parameters:
+      - description: Trace ID
+        in: query
+        name: trace_id
+        type: string
+      - description: BKN request ID
+        in: query
+        name: request_id
+        type: string
+      - description: Maximum evidence trace batches to read, 1..1000
+        in: query
+        name: limit
+        type: integer
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/evidencevo.EvidenceChainResponse'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/rdto.ErrorResponse'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/rdto.ErrorResponse'
+        "405":
+          description: Method Not Allowed
+          schema:
+            $ref: '#/definitions/rdto.ErrorResponse'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/rdto.ErrorResponse'
+      summary: Query evidence chain by trace ID or BKN request ID
+      tags:
+      - evidence
+  /evidence/events:
+    post:
+      consumes:
+      - application/json
+      description: Commits the immutable Evidence Ledger record and Projection Outbox
+        in one transaction before returning durable_ack.
+      parameters:
+      - description: BKN Trace 3.0 evidence event
+        in: body
+        name: request
+        required: true
+        schema:
+          $ref: '#/definitions/httphandler.evidenceEventRequest'
+      produces:
+      - application/json
+      responses:
+        "202":
+          description: Accepted
+          schema:
+            $ref: '#/definitions/ledgervo.DurableAck'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/httphandler.lifecycleErrorEnvelope'
+        "401":
+          description: Unauthorized
+          schema:
+            $ref: '#/definitions/httphandler.lifecycleErrorEnvelope'
+        "403":
+          description: Forbidden
+          schema:
+            $ref: '#/definitions/httphandler.lifecycleErrorEnvelope'
+        "409":
+          description: Conflict
+          schema:
+            $ref: '#/definitions/httphandler.lifecycleErrorEnvelope'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/httphandler.lifecycleErrorEnvelope'
+      summary: Durably ingest one BKN Trace 3.0 evidence event
+      tags:
+      - evidence
+  /interactions/{interaction_id}:
+    get:
+      parameters:
+      - description: Interaction ID
+        in: path
+        name: interaction_id
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/sessionvo.Interaction'
+        "401":
+          description: Unauthorized
+          schema:
+            $ref: '#/definitions/httphandler.lifecycleErrorEnvelope'
+        "403":
+          description: Forbidden
+          schema:
+            $ref: '#/definitions/httphandler.lifecycleErrorEnvelope'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/httphandler.lifecycleErrorEnvelope'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/httphandler.lifecycleErrorEnvelope'
+      summary: Get one managed Interaction
+      tags:
+      - lifecycle
+  /interactions/{interaction_id}/cancel:
+    post:
+      consumes:
+      - application/json
+      parameters:
+      - description: Interaction ID
+        in: path
+        name: interaction_id
+        required: true
+        type: string
+      - description: Terminal closure manifest
+        in: body
+        name: request
+        required: true
+        schema:
+          $ref: '#/definitions/httphandler.terminalInteractionRequest'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/sessionvo.Interaction'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/httphandler.lifecycleErrorEnvelope'
+        "401":
+          description: Unauthorized
+          schema:
+            $ref: '#/definitions/httphandler.lifecycleErrorEnvelope'
+        "403":
+          description: Forbidden
+          schema:
+            $ref: '#/definitions/httphandler.lifecycleErrorEnvelope'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/httphandler.lifecycleErrorEnvelope'
+        "409":
+          description: Conflict
+          schema:
+            $ref: '#/definitions/httphandler.lifecycleErrorEnvelope'
+        "422":
+          description: Unprocessable Entity
+          schema:
+            $ref: '#/definitions/httphandler.lifecycleErrorEnvelope'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/httphandler.lifecycleErrorEnvelope'
+      summary: Cancel one managed Interaction
+      tags:
+      - lifecycle
+  /interactions/{interaction_id}/complete:
+    post:
+      consumes:
+      - application/json
+      parameters:
+      - description: Interaction ID
+        in: path
+        name: interaction_id
+        required: true
+        type: string
+      - description: Terminal closure manifest
+        in: body
+        name: request
+        required: true
+        schema:
+          $ref: '#/definitions/httphandler.terminalInteractionRequest'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/sessionvo.Interaction'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/httphandler.lifecycleErrorEnvelope'
+        "401":
+          description: Unauthorized
+          schema:
+            $ref: '#/definitions/httphandler.lifecycleErrorEnvelope'
+        "403":
+          description: Forbidden
+          schema:
+            $ref: '#/definitions/httphandler.lifecycleErrorEnvelope'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/httphandler.lifecycleErrorEnvelope'
+        "409":
+          description: Conflict
+          schema:
+            $ref: '#/definitions/httphandler.lifecycleErrorEnvelope'
+        "422":
+          description: Unprocessable Entity
+          schema:
+            $ref: '#/definitions/httphandler.lifecycleErrorEnvelope'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/httphandler.lifecycleErrorEnvelope'
+      summary: Complete one managed Interaction
+      tags:
+      - lifecycle
+  /interactions/{interaction_id}/fail:
+    post:
+      consumes:
+      - application/json
+      parameters:
+      - description: Interaction ID
+        in: path
+        name: interaction_id
+        required: true
+        type: string
+      - description: Terminal closure manifest
+        in: body
+        name: request
+        required: true
+        schema:
+          $ref: '#/definitions/httphandler.terminalInteractionRequest'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/sessionvo.Interaction'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/httphandler.lifecycleErrorEnvelope'
+        "401":
+          description: Unauthorized
+          schema:
+            $ref: '#/definitions/httphandler.lifecycleErrorEnvelope'
+        "403":
+          description: Forbidden
+          schema:
+            $ref: '#/definitions/httphandler.lifecycleErrorEnvelope'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/httphandler.lifecycleErrorEnvelope'
+        "409":
+          description: Conflict
+          schema:
+            $ref: '#/definitions/httphandler.lifecycleErrorEnvelope'
+        "422":
+          description: Unprocessable Entity
+          schema:
+            $ref: '#/definitions/httphandler.lifecycleErrorEnvelope'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/httphandler.lifecycleErrorEnvelope'
+      summary: Fail one managed Interaction
+      tags:
+      - lifecycle
+  /interactions/{interaction_id}/handoff:
+    post:
+      consumes:
+      - application/json
+      parameters:
+      - description: Interaction ID
+        in: path
+        name: interaction_id
+        required: true
+        type: string
+      - description: Terminal closure manifest
+        in: body
+        name: request
+        required: true
+        schema:
+          $ref: '#/definitions/httphandler.terminalInteractionRequest'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/sessionvo.Interaction'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/httphandler.lifecycleErrorEnvelope'
+        "401":
+          description: Unauthorized
+          schema:
+            $ref: '#/definitions/httphandler.lifecycleErrorEnvelope'
+        "403":
+          description: Forbidden
+          schema:
+            $ref: '#/definitions/httphandler.lifecycleErrorEnvelope'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/httphandler.lifecycleErrorEnvelope'
+        "409":
+          description: Conflict
+          schema:
+            $ref: '#/definitions/httphandler.lifecycleErrorEnvelope'
+        "422":
+          description: Unprocessable Entity
+          schema:
+            $ref: '#/definitions/httphandler.lifecycleErrorEnvelope'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/httphandler.lifecycleErrorEnvelope'
+      summary: Hand off one managed Interaction
+      tags:
+      - lifecycle
+  /operations/{operation_id}:
+    get:
+      parameters:
+      - description: Operation ID
+        in: path
+        name: operation_id
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/sessionvo.Operation'
+        "401":
+          description: Unauthorized
+          schema:
+            $ref: '#/definitions/httphandler.lifecycleErrorEnvelope'
+        "403":
+          description: Forbidden
+          schema:
+            $ref: '#/definitions/httphandler.lifecycleErrorEnvelope'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/httphandler.lifecycleErrorEnvelope'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/httphandler.lifecycleErrorEnvelope'
+      summary: Get one Operation
+      tags:
+      - lifecycle
+  /operations/{operation_id}/attempts:
+    post:
+      consumes:
+      - application/json
+      parameters:
+      - description: Operation ID
+        in: path
+        name: operation_id
+        required: true
+        type: string
+      - description: Current Interaction lease
+        in: body
+        name: request
+        required: true
+        schema:
+          $ref: '#/definitions/httphandler.interactionLeaseRequest'
+      produces:
+      - application/json
+      responses:
+        "201":
+          description: Created
+          schema:
+            $ref: '#/definitions/httphandler.operationResult'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/httphandler.lifecycleErrorEnvelope'
+        "401":
+          description: Unauthorized
+          schema:
+            $ref: '#/definitions/httphandler.lifecycleErrorEnvelope'
+        "403":
+          description: Forbidden
+          schema:
+            $ref: '#/definitions/httphandler.lifecycleErrorEnvelope'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/httphandler.lifecycleErrorEnvelope'
+        "409":
+          description: Conflict
+          schema:
+            $ref: '#/definitions/httphandler.lifecycleErrorEnvelope'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/httphandler.lifecycleErrorEnvelope'
+      summary: Start the next retry attempt for an Operation
+      tags:
+      - lifecycle
+  /operations/{operation_id}/attempts/{attempt}:complete:
+    post:
+      consumes:
+      - application/json
+      parameters:
+      - description: Operation ID
+        in: path
+        name: operation_id
+        required: true
+        type: string
+      - description: Attempt number
+        in: path
+        name: attempt
+        required: true
+        type: integer
+      - description: Durable operation result
+        in: body
+        name: request
+        required: true
+        schema:
+          $ref: '#/definitions/httphandler.finishAttemptRequest'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/httphandler.operationResult'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/httphandler.lifecycleErrorEnvelope'
+        "401":
+          description: Unauthorized
+          schema:
+            $ref: '#/definitions/httphandler.lifecycleErrorEnvelope'
+        "403":
+          description: Forbidden
+          schema:
+            $ref: '#/definitions/httphandler.lifecycleErrorEnvelope'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/httphandler.lifecycleErrorEnvelope'
+        "409":
+          description: Conflict
+          schema:
+            $ref: '#/definitions/httphandler.lifecycleErrorEnvelope'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/httphandler.lifecycleErrorEnvelope'
+      summary: Complete one Operation attempt
+      tags:
+      - lifecycle
+  /operations/{operation_id}/attempts/{attempt}:fail:
+    post:
+      consumes:
+      - application/json
+      parameters:
+      - description: Operation ID
+        in: path
+        name: operation_id
+        required: true
+        type: string
+      - description: Attempt number
+        in: path
+        name: attempt
+        required: true
+        type: integer
+      - description: Durable operation failure
+        in: body
+        name: request
+        required: true
+        schema:
+          $ref: '#/definitions/httphandler.finishAttemptRequest'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/httphandler.operationResult'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/httphandler.lifecycleErrorEnvelope'
+        "401":
+          description: Unauthorized
+          schema:
+            $ref: '#/definitions/httphandler.lifecycleErrorEnvelope'
+        "403":
+          description: Forbidden
+          schema:
+            $ref: '#/definitions/httphandler.lifecycleErrorEnvelope'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/httphandler.lifecycleErrorEnvelope'
+        "409":
+          description: Conflict
+          schema:
+            $ref: '#/definitions/httphandler.lifecycleErrorEnvelope'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/httphandler.lifecycleErrorEnvelope'
+      summary: Fail one Operation attempt
+      tags:
+      - lifecycle
+  /receipts/{receipt_id}:
+    get:
+      parameters:
+      - description: Receipt ID
+        in: path
+        name: receipt_id
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/sessionvo.Receipt'
+        "401":
+          description: Unauthorized
+          schema:
+            $ref: '#/definitions/httphandler.lifecycleErrorEnvelope'
+        "403":
+          description: Forbidden
+          schema:
+            $ref: '#/definitions/httphandler.lifecycleErrorEnvelope'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/httphandler.lifecycleErrorEnvelope'
+        "409":
+          description: Conflict
+          schema:
+            $ref: '#/definitions/httphandler.lifecycleErrorEnvelope'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/httphandler.lifecycleErrorEnvelope'
+      summary: Get one durable Receipt
+      tags:
+      - lifecycle
+  /requests:
+    get:
+      parameters:
+      - description: Page size, 1..100
+        in: query
+        name: limit
+        type: integer
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/httphandler.requestPage'
+        "401":
+          description: Unauthorized
+          schema:
+            $ref: '#/definitions/httphandler.lifecycleErrorEnvelope'
+        "403":
+          description: Forbidden
+          schema:
+            $ref: '#/definitions/httphandler.lifecycleErrorEnvelope'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/httphandler.lifecycleErrorEnvelope'
+      summary: List request projections from durable Receipts
+      tags:
+      - lifecycle
+  /requests/{request_id}:
+    get:
+      parameters:
+      - description: Request ID
+        in: path
+        name: request_id
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/sessionvo.RequestSummary'
+        "401":
+          description: Unauthorized
+          schema:
+            $ref: '#/definitions/httphandler.lifecycleErrorEnvelope'
+        "403":
+          description: Forbidden
+          schema:
+            $ref: '#/definitions/httphandler.lifecycleErrorEnvelope'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/httphandler.lifecycleErrorEnvelope'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/httphandler.lifecycleErrorEnvelope'
+      summary: Get one request projection from durable Receipts
+      tags:
+      - lifecycle
+  /requests/{request_id}/traces:
+    get:
+      description: Supports one business request to multiple distributed traces and
+        returns request_id on every trace.
+      parameters:
+      - description: BKN request ID
+        in: path
+        name: request_id
+        required: true
+        type: string
+      - description: Page size, 1..200
+        in: query
+        name: limit
+        type: integer
+      - description: Opaque pagination cursor
+        in: query
+        name: cursor
+        type: string
+      - description: Caller-owned conversation ID
+        in: query
+        name: conversation_id
+        type: string
+      - description: One user interaction ID
+        in: query
+        name: interaction_id
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/evidencevo.TraceSummaryPage'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/rdto.ErrorResponse'
+        "401":
+          description: Unauthorized
+          schema:
+            $ref: '#/definitions/rdto.ErrorResponse'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/rdto.ErrorResponse'
+      summary: List technical traces belonging to a business request
+      tags:
+      - requests
+  /trace-executions:
+    get:
+      description: Returns stable trace summaries with reverse request links, generated
+        from authorized trace evidence.
+      parameters:
+      - description: Page size, 1..200
+        in: query
+        name: limit
+        type: integer
+      - description: Opaque pagination cursor
+        in: query
+        name: cursor
+        type: string
+      - description: Exact trace ID; bypasses list projection scan
+        in: query
+        name: trace_id
+        type: string
+      - description: Caller-owned conversation ID
+        in: query
+        name: conversation_id
+        type: string
+      - description: One user interaction ID
+        in: query
+        name: interaction_id
+        type: string
+      - description: Started at or after this RFC3339 timestamp
+        in: query
+        name: from
+        type: string
+      - description: Started at or before this RFC3339 timestamp
+        in: query
+        name: to
+        type: string
+      - description: Execution status
+        in: query
+        name: status
+        type: string
+      - description: Agent or application
+        in: query
+        name: agent_or_app
+        type: string
+      - description: Business domain
+        in: query
+        name: business_domain
+        type: string
+      - description: Trace, request, operation, or error keyword
+        in: query
+        name: keyword
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/evidencevo.TraceSummaryPage'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/rdto.ErrorResponse'
+        "401":
+          description: Unauthorized
+          schema:
+            $ref: '#/definitions/rdto.ErrorResponse'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/rdto.ErrorResponse'
+      summary: List technical trace executions
+      tags:
+      - traces
+  /traces/{trace_id}/business-graph:
+    get:
+      description: Returns claim and business semantic nodes/edges derived from business.refs.resolved
+        events.
+      parameters:
+      - description: Trace ID
+        in: path
+        name: trace_id
+        required: true
+        type: string
+      - description: Maximum evidence trace batches to read, 1..1000
+        in: query
+        name: limit
+        type: integer
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/evidencevo.BusinessGraphResponse'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/rdto.ErrorResponse'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/rdto.ErrorResponse'
+        "405":
+          description: Method Not Allowed
+          schema:
+            $ref: '#/definitions/rdto.ErrorResponse'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/rdto.ErrorResponse'
+      summary: Get business semantic graph by trace ID
+      tags:
+      - evidence
+  /traces/{trace_id}/evidence-chain:
+    get:
+      description: Returns normalized claim, evidence refs, business refs, pagination,
+        partial reasons, and visibility summary for a trace.
+      parameters:
+      - description: Trace ID
+        in: path
+        name: trace_id
+        required: true
+        type: string
+      - description: Maximum evidence trace batches to read, 1..1000
+        in: query
+        name: limit
+        type: integer
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/evidencevo.EvidenceChainResponse'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/rdto.ErrorResponse'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/rdto.ErrorResponse'
+        "405":
+          description: Method Not Allowed
+          schema:
+            $ref: '#/definitions/rdto.ErrorResponse'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/rdto.ErrorResponse'
+      summary: Get evidence chain by trace ID
+      tags:
+      - evidence
+  /traces/{trace_id}/snapshot-preview:
+    get:
+      description: Returns a metadata-only governed snapshot manifest preview without
+        creating or exposing object storage locations.
+      parameters:
+      - description: Trace ID
+        in: path
+        name: trace_id
+        required: true
+        type: string
+      - description: Maximum evidence trace batches to read, 1..1000
+        in: query
+        name: limit
+        type: integer
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/evidencevo.SnapshotPreviewResponse'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/rdto.ErrorResponse'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/rdto.ErrorResponse'
+        "405":
+          description: Method Not Allowed
+          schema:
+            $ref: '#/definitions/rdto.ErrorResponse'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/rdto.ErrorResponse'
+      summary: Get evidence snapshot preview by trace ID
+      tags:
+      - evidence
+  /traces/by-request:
+    get:
+      description: Returns normalized claim, evidence refs, business refs, pagination,
+        partial reasons, and visibility summary for a request.
+      parameters:
+      - description: BKN request ID
+        in: query
+        name: request_id
+        required: true
+        type: string
+      - description: Maximum evidence trace batches to read, 1..1000
+        in: query
+        name: limit
+        type: integer
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/evidencevo.EvidenceChainResponse'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/rdto.ErrorResponse'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/rdto.ErrorResponse'
+        "405":
+          description: Method Not Allowed
+          schema:
+            $ref: '#/definitions/rdto.ErrorResponse'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/rdto.ErrorResponse'
+      summary: Get evidence chain by BKN request ID
+      tags:
+      - evidence
+  /traces/by-request/business-graph:
+    get:
+      description: Returns claim and business semantic nodes/edges derived from business.refs.resolved
+        events.
+      parameters:
+      - description: BKN request ID
+        in: query
+        name: request_id
+        required: true
+        type: string
+      - description: Maximum evidence trace batches to read, 1..1000
+        in: query
+        name: limit
+        type: integer
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/evidencevo.BusinessGraphResponse'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/rdto.ErrorResponse'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/rdto.ErrorResponse'
+        "405":
+          description: Method Not Allowed
+          schema:
+            $ref: '#/definitions/rdto.ErrorResponse'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/rdto.ErrorResponse'
+      summary: Get business semantic graph by BKN request ID
+      tags:
+      - evidence
+  /traces/by-request/snapshot-preview:
+    get:
+      description: Returns a metadata-only governed snapshot manifest preview without
+        creating or exposing object storage locations.
+      parameters:
+      - description: BKN request ID
+        in: query
+        name: request_id
+        required: true
+        type: string
+      - description: Maximum evidence trace batches to read, 1..1000
+        in: query
+        name: limit
+        type: integer
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/evidencevo.SnapshotPreviewResponse'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/rdto.ErrorResponse'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/rdto.ErrorResponse'
+        "405":
+          description: Method Not Allowed
+          schema:
+            $ref: '#/definitions/rdto.ErrorResponse'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/rdto.ErrorResponse'
+      summary: Get evidence snapshot preview by BKN request ID
+      tags:
+      - evidence
+swagger: "2.0"

--- a/bkn-trace/agent-observability/go.mod
+++ b/bkn-trace/agent-observability/go.mod
@@ -8,11 +8,13 @@ require (
 )
 
 require (
+	filippo.io/edwards25519 v1.2.0 // indirect
 	github.com/KyleBanks/depth v1.2.1 // indirect
 	github.com/go-openapi/jsonpointer v0.19.5 // indirect
 	github.com/go-openapi/jsonreference v0.20.0 // indirect
 	github.com/go-openapi/spec v0.20.6 // indirect
 	github.com/go-openapi/swag v0.19.15 // indirect
+	github.com/go-sql-driver/mysql v1.10.0 // indirect
 	github.com/josharian/intern v1.0.0 // indirect
 	github.com/mailru/easyjson v0.7.6 // indirect
 	github.com/swaggo/files/v2 v2.0.0 // indirect

--- a/bkn-trace/agent-observability/go.sum
+++ b/bkn-trace/agent-observability/go.sum
@@ -1,3 +1,5 @@
+filippo.io/edwards25519 v1.2.0 h1:crnVqOiS4jqYleHd9vaKZ+HKtHfllngJIiOpNpoJsjo=
+filippo.io/edwards25519 v1.2.0/go.mod h1:xzAOLCNug/yB62zG1bQ8uziwrIqIuxhctzJT18Q77mc=
 github.com/KyleBanks/depth v1.2.1 h1:5h8fQADFrWtarTdtDudMmGsC7GPbOAu6RVB3ffsVFHc=
 github.com/KyleBanks/depth v1.2.1/go.mod h1:jzSb9d0L43HxTQfT+oSA1EEp2q+ne2uh6XgeJcm8brE=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
@@ -14,6 +16,8 @@ github.com/go-openapi/spec v0.20.6/go.mod h1:2OpW+JddWPrpXSCIX8eOx7lZ5iyuWj3RYR6
 github.com/go-openapi/swag v0.19.5/go.mod h1:POnQmlKehdgb5mhVOsnJFsivZCEZ/vjK9gh66Z9tfKk=
 github.com/go-openapi/swag v0.19.15 h1:D2NRCBzS9/pEY3gP9Nl8aDqGUcPFrwG2p+CNFrLyrCM=
 github.com/go-openapi/swag v0.19.15/go.mod h1:QYRuS/SOXUCsnplDa677K7+DxSOj6IPNl/eQntq43wQ=
+github.com/go-sql-driver/mysql v1.10.0 h1:Q+1LV8DkHJvSYAdR83XzuhDaTykuDx0l6fkXxoWCWfw=
+github.com/go-sql-driver/mysql v1.10.0/go.mod h1:M+cqaI7+xxXGG9swrdeUIoPG3Y3KCkF0pZej+SK+nWk=
 github.com/josharian/intern v1.0.0 h1:vlS4z54oSdjm0bgjRigI+G1HpF+tI+9rE5LLzOg8HmY=
 github.com/josharian/intern v1.0.0/go.mod h1:5DoeVV0s6jJacbCEi61lwdGj/aVlrQvzHFFd8Hwg//Y=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=

--- a/bkn-trace/agent-observability/main.go
+++ b/bkn-trace/agent-observability/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"errors"
 	"log"
 	"os/signal"
 	"syscall"
@@ -15,24 +16,40 @@ import (
 // @description APIs for querying agent traces from OpenSearch.
 // @BasePath /api/agent-observability/v1
 func main() {
-	app := boot.NewApp()
+	app, err := boot.NewApp()
+	if err != nil {
+		log.Fatal(err)
+	}
 
 	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
 	defer stop()
 
-	go func() {
-		<-ctx.Done()
-
-		shutdownCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-		defer cancel()
-
-		if err := app.Shutdown(shutdownCtx); err != nil {
-			log.Printf("shutdown app: %v", err)
-		}
-	}()
-
 	log.Printf("agent-observability listening on :8080")
-	if err := app.Start(); err != nil {
+	if err := run(ctx, app); err != nil {
 		log.Fatal(err)
 	}
+}
+
+type application interface {
+	Start() error
+	Shutdown(context.Context) error
+}
+
+func run(ctx context.Context, app application) error {
+	startResult := make(chan error, 1)
+	go func() {
+		startResult <- app.Start()
+	}()
+
+	select {
+	case err := <-startResult:
+		return err
+	case <-ctx.Done():
+	}
+
+	shutdownCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	shutdownErr := app.Shutdown(shutdownCtx)
+	startErr := <-startResult
+	return errors.Join(shutdownErr, startErr)
 }

--- a/bkn-trace/agent-observability/main_test.go
+++ b/bkn-trace/agent-observability/main_test.go
@@ -1,0 +1,58 @@
+package main
+
+import (
+	"context"
+	"sync"
+	"testing"
+)
+
+func TestRunWaitsForShutdownToComplete(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	app := &testApplication{
+		started:      make(chan struct{}),
+		stopServer:   make(chan struct{}),
+		shutdownDone: make(chan struct{}),
+	}
+	result := make(chan error, 1)
+	go func() {
+		result <- run(ctx, app)
+	}()
+	<-app.started
+	cancel()
+
+	select {
+	case <-result:
+		t.Fatal("run returned before shutdown completed")
+	default:
+	}
+	close(app.shutdownDone)
+	if err := <-result; err != nil {
+		t.Fatalf("run application: %v", err)
+	}
+	if !app.shutdownCalled {
+		t.Fatal("application shutdown was not called")
+	}
+}
+
+type testApplication struct {
+	started        chan struct{}
+	stopServer     chan struct{}
+	shutdownDone   chan struct{}
+	startOnce      sync.Once
+	shutdownCalled bool
+}
+
+func (a *testApplication) Start() error {
+	a.startOnce.Do(func() { close(a.started) })
+	<-a.stopServer
+	return nil
+}
+
+func (a *testApplication) Shutdown(context.Context) error {
+	a.shutdownCalled = true
+	<-a.shutdownDone
+	close(a.stopServer)
+	return nil
+}

--- a/bkn-trace/agent-observability/migrations/mariadb/v013/init.sql
+++ b/bkn-trace/agent-observability/migrations/mariadb/v013/init.sql
@@ -1,0 +1,285 @@
+CREATE TABLE IF NOT EXISTS bkn_trace_conversations (
+    conversation_id VARCHAR(64) CHARACTER SET ascii COLLATE ascii_bin NOT NULL,
+    tenant_id VARCHAR(64) CHARACTER SET ascii COLLATE ascii_bin NOT NULL,
+    business_domain_id VARCHAR(64) CHARACTER SET ascii COLLATE ascii_bin NOT NULL,
+    application_principal_id VARCHAR(128) CHARACTER SET ascii COLLATE ascii_bin NOT NULL,
+    effective_subject_type VARCHAR(16) CHARACTER SET ascii COLLATE ascii_bin NOT NULL,
+    effective_subject_id VARCHAR(128) CHARACTER SET ascii COLLATE ascii_bin NOT NULL,
+    delegation_id VARCHAR(128) CHARACTER SET ascii COLLATE ascii_bin NOT NULL DEFAULT '',
+    external_conversation_key VARCHAR(255) CHARACTER SET ascii COLLATE ascii_bin NOT NULL,
+    generation BIGINT UNSIGNED NOT NULL,
+    status VARCHAR(16) CHARACTER SET ascii COLLATE ascii_bin NOT NULL,
+    one_shot BOOLEAN NOT NULL DEFAULT FALSE,
+    current_slot TINYINT AS (CASE WHEN status = 'active' THEN 1 ELSE NULL END) PERSISTENT,
+    row_version BIGINT UNSIGNED NOT NULL DEFAULT 1,
+    created_at DATETIME(6) NOT NULL,
+    updated_at DATETIME(6) NOT NULL,
+    closed_at DATETIME(6) NULL,
+    PRIMARY KEY (conversation_id),
+    CONSTRAINT uq_bkn_trace_conversation_generation UNIQUE (
+        tenant_id, business_domain_id, application_principal_id,
+        effective_subject_type, effective_subject_id, delegation_id,
+        external_conversation_key, generation
+    ),
+    CONSTRAINT uq_bkn_trace_conversation_current UNIQUE (
+        tenant_id, business_domain_id, application_principal_id,
+        effective_subject_type, effective_subject_id, delegation_id,
+        external_conversation_key, current_slot
+    ),
+    INDEX idx_bkn_trace_conversation_list (
+        tenant_id, business_domain_id, updated_at, conversation_id
+    )
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin;
+
+CREATE TABLE IF NOT EXISTS bkn_trace_idempotency_records (
+    idempotency_record_id BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
+    scope VARCHAR(64) CHARACTER SET ascii COLLATE ascii_bin NOT NULL,
+    tenant_id VARCHAR(64) CHARACTER SET ascii COLLATE ascii_bin NOT NULL,
+    business_domain_id VARCHAR(64) CHARACTER SET ascii COLLATE ascii_bin NOT NULL,
+    application_principal_id VARCHAR(128) CHARACTER SET ascii COLLATE ascii_bin NOT NULL,
+    effective_subject_type VARCHAR(16) CHARACTER SET ascii COLLATE ascii_bin NOT NULL,
+    effective_subject_id VARCHAR(128) CHARACTER SET ascii COLLATE ascii_bin NOT NULL,
+    delegation_id VARCHAR(128) CHARACTER SET ascii COLLATE ascii_bin NOT NULL DEFAULT '',
+    external_conversation_key VARCHAR(255) CHARACTER SET ascii COLLATE ascii_bin NOT NULL,
+    idempotency_key VARCHAR(128) CHARACTER SET ascii COLLATE ascii_bin NOT NULL,
+    request_hash CHAR(64) CHARACTER SET ascii COLLATE ascii_bin NOT NULL,
+    resource_type VARCHAR(32) CHARACTER SET ascii COLLATE ascii_bin NOT NULL,
+    resource_id VARCHAR(64) CHARACTER SET ascii COLLATE ascii_bin NOT NULL,
+    created_at DATETIME(6) NOT NULL,
+    PRIMARY KEY (idempotency_record_id),
+    CONSTRAINT uq_bkn_trace_idempotency UNIQUE (
+        scope, tenant_id, business_domain_id, application_principal_id,
+        effective_subject_type, effective_subject_id, delegation_id,
+        external_conversation_key, idempotency_key
+    )
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin;
+
+CREATE TABLE IF NOT EXISTS bkn_trace_interactions (
+    interaction_id VARCHAR(64) CHARACTER SET ascii COLLATE ascii_bin NOT NULL,
+    conversation_id VARCHAR(64) CHARACTER SET ascii COLLATE ascii_bin NOT NULL,
+    ordinal_no BIGINT UNSIGNED NOT NULL,
+    execution_status VARCHAR(16) CHARACTER SET ascii COLLATE ascii_bin NOT NULL,
+    evidence_status VARCHAR(20) CHARACTER SET ascii COLLATE ascii_bin NOT NULL,
+    active_slot TINYINT AS (CASE WHEN execution_status = 'active' THEN 1 ELSE NULL END) PERSISTENT,
+    start_idempotency_key VARCHAR(128) CHARACTER SET ascii COLLATE ascii_bin NOT NULL,
+    terminal_idempotency_key VARCHAR(128) CHARACTER SET ascii COLLATE ascii_bin NULL,
+    terminal_payload_hash CHAR(64) CHARACTER SET ascii COLLATE ascii_bin NULL,
+    closure_manifest LONGTEXT NULL,
+    assembler_deadline DATETIME(6) NULL,
+    lease_token VARCHAR(64) CHARACTER SET ascii COLLATE ascii_bin NOT NULL,
+    lease_epoch BIGINT UNSIGNED NOT NULL,
+    lease_version BIGINT UNSIGNED NOT NULL,
+    lease_expires_at DATETIME(6) NOT NULL,
+    row_version BIGINT UNSIGNED NOT NULL DEFAULT 1,
+    created_at DATETIME(6) NOT NULL,
+    updated_at DATETIME(6) NOT NULL,
+    terminal_at DATETIME(6) NULL,
+    PRIMARY KEY (interaction_id),
+    CONSTRAINT fk_bkn_trace_interaction_conversation
+        FOREIGN KEY (conversation_id) REFERENCES bkn_trace_conversations (conversation_id),
+    CONSTRAINT uq_bkn_trace_interaction_ordinal UNIQUE (conversation_id, ordinal_no),
+    CONSTRAINT uq_bkn_trace_interaction_active UNIQUE (conversation_id, active_slot),
+    CONSTRAINT uq_bkn_trace_interaction_start_idempotency UNIQUE (conversation_id, start_idempotency_key),
+    INDEX idx_bkn_trace_interaction_lease (execution_status, lease_expires_at, lease_version),
+    INDEX idx_bkn_trace_interaction_assembly (evidence_status, assembler_deadline, interaction_id)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin;
+
+CREATE TABLE IF NOT EXISTS bkn_trace_operations (
+    operation_id VARCHAR(64) CHARACTER SET ascii COLLATE ascii_bin NOT NULL,
+    conversation_id VARCHAR(64) CHARACTER SET ascii COLLATE ascii_bin NOT NULL,
+    interaction_id VARCHAR(64) CHARACTER SET ascii COLLATE ascii_bin NOT NULL,
+    operation_key VARCHAR(255) CHARACTER SET ascii COLLATE ascii_bin NOT NULL,
+    tool_name VARCHAR(255) NOT NULL,
+    normalized_input_hash VARCHAR(80) CHARACTER SET ascii COLLATE ascii_bin NOT NULL,
+    parent_operation_id VARCHAR(64) CHARACTER SET ascii COLLATE ascii_bin NULL,
+    causation_event_ids LONGTEXT NULL,
+    attempt_no INT UNSIGNED NOT NULL,
+    attempt_status VARCHAR(16) CHARACTER SET ascii COLLATE ascii_bin NOT NULL,
+    retryable BOOLEAN NOT NULL DEFAULT FALSE,
+    row_version BIGINT UNSIGNED NOT NULL DEFAULT 1,
+    created_at DATETIME(6) NOT NULL,
+    updated_at DATETIME(6) NOT NULL,
+    PRIMARY KEY (operation_id),
+    CONSTRAINT fk_bkn_trace_operation_interaction
+        FOREIGN KEY (interaction_id) REFERENCES bkn_trace_interactions (interaction_id),
+    CONSTRAINT uq_bkn_trace_operation_key UNIQUE (interaction_id, operation_key),
+    INDEX idx_bkn_trace_operation_conversation (conversation_id, interaction_id, created_at)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin;
+
+CREATE TABLE IF NOT EXISTS bkn_trace_receipts (
+    receipt_id VARCHAR(64) CHARACTER SET ascii COLLATE ascii_bin NOT NULL,
+    schema_version VARCHAR(16) CHARACTER SET ascii COLLATE ascii_bin NOT NULL,
+    tenant_id VARCHAR(64) CHARACTER SET ascii COLLATE ascii_bin NOT NULL,
+    business_domain_id VARCHAR(64) CHARACTER SET ascii COLLATE ascii_bin NOT NULL,
+    application_principal_id VARCHAR(128) CHARACTER SET ascii COLLATE ascii_bin NOT NULL,
+    effective_subject_type VARCHAR(16) CHARACTER SET ascii COLLATE ascii_bin NOT NULL,
+    effective_subject_id VARCHAR(128) CHARACTER SET ascii COLLATE ascii_bin NOT NULL,
+    delegation_id VARCHAR(128) CHARACTER SET ascii COLLATE ascii_bin NOT NULL DEFAULT '',
+    conversation_id VARCHAR(64) CHARACTER SET ascii COLLATE ascii_bin NOT NULL,
+    interaction_id VARCHAR(64) CHARACTER SET ascii COLLATE ascii_bin NOT NULL,
+    operation_id VARCHAR(64) CHARACTER SET ascii COLLATE ascii_bin NOT NULL,
+    attempt_no INT UNSIGNED NOT NULL,
+    operation_key VARCHAR(255) CHARACTER SET ascii COLLATE ascii_bin NOT NULL,
+    tool_name VARCHAR(255) NOT NULL,
+    normalized_input_hash VARCHAR(80) CHARACTER SET ascii COLLATE ascii_bin NOT NULL,
+    receipt_status VARCHAR(16) CHARACTER SET ascii COLLATE ascii_bin NOT NULL,
+    evidence_durability VARCHAR(16) CHARACTER SET ascii COLLATE ascii_bin NOT NULL,
+    required_receipt BOOLEAN NOT NULL,
+    request_id VARCHAR(128) CHARACTER SET ascii COLLATE ascii_bin NULL,
+    trace_id VARCHAR(64) CHARACTER SET ascii COLLATE ascii_bin NULL,
+    causation_event_ids LONGTEXT NULL,
+    observed_evidence_refs LONGTEXT NULL,
+    business_refs LONGTEXT NULL,
+    artifact_refs LONGTEXT NULL,
+    partial_reasons LONGTEXT NULL,
+    row_version BIGINT UNSIGNED NOT NULL DEFAULT 1,
+    issued_at DATETIME(6) NOT NULL,
+    terminal_at DATETIME(6) NULL,
+    payload_hash VARCHAR(80) CHARACTER SET ascii COLLATE ascii_bin NULL,
+    PRIMARY KEY (receipt_id),
+    CONSTRAINT fk_bkn_trace_receipt_operation
+        FOREIGN KEY (operation_id) REFERENCES bkn_trace_operations (operation_id),
+    CONSTRAINT uq_bkn_trace_receipt_attempt UNIQUE (operation_id, attempt_no),
+    INDEX idx_bkn_trace_receipt_interaction (interaction_id, issued_at)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin;
+
+CREATE TABLE IF NOT EXISTS bkn_trace_evidence_event_ledger (
+    ingest_sequence BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
+    event_id VARCHAR(128) CHARACTER SET ascii COLLATE ascii_bin NOT NULL,
+    payload_hash CHAR(64) CHARACTER SET ascii COLLATE ascii_bin NOT NULL,
+    immutable_record_hash CHAR(64) CHARACTER SET ascii COLLATE ascii_bin NOT NULL,
+    schema_version VARCHAR(16) CHARACTER SET ascii COLLATE ascii_bin NOT NULL,
+    event_type VARCHAR(128) CHARACTER SET ascii COLLATE ascii_bin NOT NULL,
+    tenant_id VARCHAR(64) CHARACTER SET ascii COLLATE ascii_bin NOT NULL,
+    business_domain_id VARCHAR(64) CHARACTER SET ascii COLLATE ascii_bin NOT NULL,
+    conversation_id VARCHAR(64) CHARACTER SET ascii COLLATE ascii_bin NOT NULL,
+    interaction_id VARCHAR(64) CHARACTER SET ascii COLLATE ascii_bin NOT NULL,
+    operation_id VARCHAR(64) CHARACTER SET ascii COLLATE ascii_bin NULL,
+    attempt_no INT UNSIGNED NULL,
+    request_id VARCHAR(128) CHARACTER SET ascii COLLATE ascii_bin NULL,
+    trace_id VARCHAR(64) CHARACTER SET ascii COLLATE ascii_bin NULL,
+    span_id VARCHAR(32) CHARACTER SET ascii COLLATE ascii_bin NULL,
+    producer_id VARCHAR(128) CHARACTER SET ascii COLLATE ascii_bin NOT NULL,
+    producer_stream_id VARCHAR(128) CHARACTER SET ascii COLLATE ascii_bin NOT NULL,
+    producer_epoch BIGINT UNSIGNED NOT NULL,
+    producer_sequence BIGINT UNSIGNED NOT NULL,
+    causality_status VARCHAR(20) CHARACTER SET ascii COLLATE ascii_bin NOT NULL,
+    missing_causation_event_ids LONGTEXT NULL,
+    started_at DATETIME(6) NOT NULL,
+    observed_at DATETIME(6) NOT NULL,
+    emitted_at DATETIME(6) NOT NULL,
+    ingested_at DATETIME(6) NOT NULL,
+    envelope LONGTEXT NOT NULL,
+    PRIMARY KEY (ingest_sequence),
+    CONSTRAINT uq_bkn_trace_event_id UNIQUE (event_id),
+    CONSTRAINT uq_bkn_trace_event_stream_sequence UNIQUE (
+        tenant_id, producer_stream_id, producer_epoch, producer_sequence
+    ),
+    INDEX idx_bkn_trace_ledger_interaction (tenant_id, business_domain_id, interaction_id, ingest_sequence)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin;
+
+CREATE TABLE IF NOT EXISTS bkn_trace_projection_outbox (
+    outbox_id BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
+    aggregate_type VARCHAR(64) CHARACTER SET ascii COLLATE ascii_bin NOT NULL,
+    aggregate_id VARCHAR(128) CHARACTER SET ascii COLLATE ascii_bin NOT NULL,
+    aggregate_version BIGINT UNSIGNED NOT NULL DEFAULT 1,
+    event_type VARCHAR(128) CHARACTER SET ascii COLLATE ascii_bin NOT NULL,
+    event_id VARCHAR(128) CHARACTER SET ascii COLLATE ascii_bin NOT NULL,
+    payload LONGTEXT NOT NULL,
+    status VARCHAR(16) CHARACTER SET ascii COLLATE ascii_bin NOT NULL DEFAULT 'pending',
+    attempts INT UNSIGNED NOT NULL DEFAULT 0,
+    available_at DATETIME(6) NOT NULL,
+    locked_until DATETIME(6) NULL,
+    lease_token VARCHAR(64) CHARACTER SET ascii COLLATE ascii_bin NULL,
+    last_error_code VARCHAR(64) CHARACTER SET ascii COLLATE ascii_bin NULL,
+    created_at DATETIME(6) NOT NULL,
+    delivered_at DATETIME(6) NULL,
+    PRIMARY KEY (outbox_id),
+    CONSTRAINT uq_bkn_trace_projection_event UNIQUE (event_id, event_type),
+    INDEX idx_bkn_trace_projection_pending (status, available_at, outbox_id)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin;
+
+ALTER TABLE bkn_trace_receipts
+    ADD COLUMN IF NOT EXISTS row_version BIGINT UNSIGNED NOT NULL DEFAULT 1
+    AFTER partial_reasons;
+
+ALTER TABLE bkn_trace_projection_outbox
+    ADD COLUMN IF NOT EXISTS aggregate_version BIGINT UNSIGNED NOT NULL DEFAULT 1
+    AFTER aggregate_id;
+
+CREATE TABLE IF NOT EXISTS bkn_trace_assembly_revisions (
+    revision_id VARCHAR(64) CHARACTER SET ascii COLLATE ascii_bin NOT NULL,
+    interaction_id VARCHAR(64) CHARACTER SET ascii COLLATE ascii_bin NOT NULL,
+    revision_no BIGINT UNSIGNED NOT NULL,
+    parent_revision_id VARCHAR(64) CHARACTER SET ascii COLLATE ascii_bin NULL,
+    completion_manifest_version VARCHAR(32) CHARACTER SET ascii COLLATE ascii_bin NOT NULL,
+    included_receipt_ids LONGTEXT NOT NULL,
+    included_event_ids LONGTEXT NOT NULL,
+    artifact_manifest_hash CHAR(64) CHARACTER SET ascii COLLATE ascii_bin NOT NULL,
+    assembly_completeness VARCHAR(16) CHARACTER SET ascii COLLATE ascii_bin NOT NULL,
+    partial_reasons LONGTEXT NULL,
+    trigger_type VARCHAR(32) CHARACTER SET ascii COLLATE ascii_bin NOT NULL,
+    created_at DATETIME(6) NOT NULL,
+    PRIMARY KEY (revision_id),
+    CONSTRAINT uq_bkn_trace_assembly_revision UNIQUE (interaction_id, revision_no)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin;
+
+CREATE TABLE IF NOT EXISTS bkn_trace_event_conflicts (
+    conflict_id BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
+    event_id VARCHAR(128) CHARACTER SET ascii COLLATE ascii_bin NOT NULL,
+    existing_payload_hash CHAR(64) CHARACTER SET ascii COLLATE ascii_bin NOT NULL,
+    conflicting_payload_hash CHAR(64) CHARACTER SET ascii COLLATE ascii_bin NOT NULL,
+    tenant_id VARCHAR(64) CHARACTER SET ascii COLLATE ascii_bin NOT NULL,
+    business_domain_id VARCHAR(64) CHARACTER SET ascii COLLATE ascii_bin NOT NULL,
+    envelope LONGTEXT NOT NULL,
+    detected_at DATETIME(6) NOT NULL,
+    PRIMARY KEY (conflict_id),
+    INDEX idx_bkn_trace_event_conflict (event_id, detected_at)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin;
+
+CREATE TABLE IF NOT EXISTS bkn_trace_projection_checkpoints (
+    projector_id VARCHAR(128) CHARACTER SET ascii COLLATE ascii_bin NOT NULL,
+    index_version VARCHAR(64) CHARACTER SET ascii COLLATE ascii_bin NOT NULL,
+    last_outbox_id BIGINT UNSIGNED NOT NULL,
+    updated_at DATETIME(6) NOT NULL,
+    PRIMARY KEY (projector_id, index_version)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin;
+
+CREATE TABLE IF NOT EXISTS bkn_trace_dlq (
+    dlq_id BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
+    source_kind VARCHAR(32) CHARACTER SET ascii COLLATE ascii_bin NOT NULL,
+    source_id VARCHAR(128) CHARACTER SET ascii COLLATE ascii_bin NOT NULL,
+    failure_class VARCHAR(64) CHARACTER SET ascii COLLATE ascii_bin NOT NULL,
+    attempts INT UNSIGNED NOT NULL,
+    last_error_code VARCHAR(64) CHARACTER SET ascii COLLATE ascii_bin NOT NULL,
+    payload LONGTEXT NOT NULL,
+    failed_at DATETIME(6) NOT NULL,
+    replayed_at DATETIME(6) NULL,
+    replayed_by VARCHAR(128) CHARACTER SET ascii COLLATE ascii_bin NULL,
+    PRIMARY KEY (dlq_id),
+    CONSTRAINT uq_bkn_trace_dlq_source UNIQUE (source_kind, source_id),
+    INDEX idx_bkn_trace_dlq_pending (replayed_at, failed_at)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin;
+
+CREATE TABLE IF NOT EXISTS bkn_trace_dlq_replay_audit (
+    replay_id BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
+    dlq_id BIGINT UNSIGNED NOT NULL,
+    source_kind VARCHAR(32) CHARACTER SET ascii COLLATE ascii_bin NOT NULL,
+    source_id VARCHAR(128) CHARACTER SET ascii COLLATE ascii_bin NOT NULL,
+    replayed_by VARCHAR(128) CHARACTER SET ascii COLLATE ascii_bin NOT NULL,
+    reason VARCHAR(512) NOT NULL,
+    repair_version VARCHAR(128) CHARACTER SET ascii COLLATE ascii_bin NOT NULL,
+    replayed_at DATETIME(6) NOT NULL,
+    PRIMARY KEY (replay_id),
+    INDEX idx_bkn_trace_dlq_replay (dlq_id, replayed_at)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin;
+
+ALTER TABLE bkn_trace_evidence_event_ledger
+    ADD COLUMN IF NOT EXISTS started_at DATETIME(6) NULL AFTER missing_causation_event_ids;
+
+UPDATE bkn_trace_evidence_event_ledger
+SET started_at = observed_at
+WHERE started_at IS NULL;
+
+ALTER TABLE bkn_trace_evidence_event_ledger
+    MODIFY COLUMN started_at DATETIME(6) NOT NULL;

--- a/bkn-trace/agent-observability/migrations/mariadb/v013/schema.go
+++ b/bkn-trace/agent-observability/migrations/mariadb/v013/schema.go
@@ -1,0 +1,10 @@
+package v013
+
+import _ "embed"
+
+//go:embed init.sql
+var schemaSQL string
+
+func SchemaSQL() string {
+	return schemaSQL
+}

--- a/bkn-trace/agent-observability/scripts/test_evidence_index_governance.sh
+++ b/bkn-trace/agent-observability/scripts/test_evidence_index_governance.sh
@@ -3,6 +3,15 @@ set -euo pipefail
 
 chart_dir="${1:-charts/agent-observability}"
 default_rendered="$(helm template agent-observability "${chart_dir}")"
+if grep -Fq "BKN_TRACE_CORE_MARIADB_DSN" <<<"${default_rendered}"; then
+  echo "default chart must not require the MariaDB Core secret" >&2
+  exit 1
+fi
+if ! grep -A1 -Fq "name: BKN_TRACE_PROJECTION_ENABLED
+              value: \"false\"" <<<"${default_rendered}"; then
+  echo "Core projection must be disabled by default" >&2
+  exit 1
+fi
 if grep -Fq "agent-observability-evidence-index-template" <<<"${default_rendered}"; then
   echo "evidence index template must not render by default" >&2
   exit 1

--- a/bkn-trace/agent-observability/src/boot/bootstrap.go
+++ b/bkn-trace/agent-observability/src/boot/bootstrap.go
@@ -2,31 +2,55 @@ package boot
 
 import (
 	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"log"
 	"net/http"
 	"strings"
+	"sync"
+	"time"
 
 	docs "github.com/openbkn-ai/bkn-foundry/bkn-trace/agent-observability/docs/swagger"
 	"github.com/openbkn-ai/bkn-foundry/bkn-trace/agent-observability/src/conf"
 	"github.com/openbkn-ai/bkn-foundry/bkn-trace/agent-observability/src/domain/service/evidencesvc"
+	"github.com/openbkn-ai/bkn-foundry/bkn-trace/agent-observability/src/domain/service/ledgersvc"
+	"github.com/openbkn-ai/bkn-foundry/bkn-trace/agent-observability/src/domain/service/projectionrebuildsvc"
+	"github.com/openbkn-ai/bkn-foundry/bkn-trace/agent-observability/src/domain/service/projectorsvc"
+	"github.com/openbkn-ai/bkn-foundry/bkn-trace/agent-observability/src/domain/service/sessionsvc"
 	"github.com/openbkn-ai/bkn-foundry/bkn-trace/agent-observability/src/domain/service/tracesvc"
+	mariadbsessionstore "github.com/openbkn-ai/bkn-foundry/bkn-trace/agent-observability/src/drivenadapter/dbaccess/mariadb/sessionstore"
 	"github.com/openbkn-ai/bkn-foundry/bkn-trace/agent-observability/src/drivenadapter/httpaccess/businessresolver"
 	"github.com/openbkn-ai/bkn-foundry/bkn-trace/agent-observability/src/drivenadapter/httpaccess/opensearchevidencestore"
+	"github.com/openbkn-ai/bkn-foundry/bkn-trace/agent-observability/src/drivenadapter/httpaccess/opensearchprojection"
 	"github.com/openbkn-ai/bkn-foundry/bkn-trace/agent-observability/src/drivenadapter/httpaccess/opensearchtraceaccess"
 	"github.com/openbkn-ai/bkn-foundry/bkn-trace/agent-observability/src/drivenadapter/memoryaccess/evidencestore"
+	"github.com/openbkn-ai/bkn-foundry/bkn-trace/agent-observability/src/drivenadapter/memoryaccess/ledgerstore"
+	memorysessionstore "github.com/openbkn-ai/bkn-foundry/bkn-trace/agent-observability/src/drivenadapter/memoryaccess/sessionstore"
 	"github.com/openbkn-ai/bkn-foundry/bkn-trace/agent-observability/src/driveradapter/api/httphandler"
+	"github.com/openbkn-ai/bkn-foundry/bkn-trace/agent-observability/src/infra/coremetrics"
 	"github.com/openbkn-ai/bkn-foundry/bkn-trace/agent-observability/src/infra/opensearch"
 	"github.com/openbkn-ai/bkn-foundry/bkn-trace/agent-observability/src/infra/server/httpserver"
+	"github.com/openbkn-ai/bkn-foundry/bkn-trace/agent-observability/src/port/driven/icoremetrics"
+	"github.com/openbkn-ai/bkn-foundry/bkn-trace/agent-observability/src/port/driven/ievidenceledger"
 	"github.com/openbkn-ai/bkn-foundry/bkn-trace/agent-observability/src/port/driven/ievidencestore"
+	"github.com/openbkn-ai/bkn-foundry/bkn-trace/agent-observability/src/port/driven/iprojectionoutbox"
+	"github.com/openbkn-ai/bkn-foundry/bkn-trace/agent-observability/src/port/driven/iprojectionrebuild"
+	"github.com/openbkn-ai/bkn-foundry/bkn-trace/agent-observability/src/port/driven/isessionstore"
 	httpSwagger "github.com/swaggo/http-swagger/v2"
 )
 
 type App struct {
-	server *httpserver.Server
+	server        *httpserver.Server
+	closeDatabase func() error
+	stopWorkers   context.CancelFunc
+	workers       sync.WaitGroup
+	projection    *projectorsvc.Worker
 }
 
 const APIBasePath = "/api/agent-observability/v1"
 
-func NewApp() *App {
+func NewApp() (*App, error) {
 	httpServerConfig := conf.NewHTTPServerConfig()
 	openSearchConfig := conf.NewOpenSearchConfig()
 	evidenceConfig := conf.NewEvidenceConfig()
@@ -55,12 +79,208 @@ func NewApp() *App {
 		evidenceService = evidencesvc.NewWithBusinessResolver(evidenceStore, resolver)
 	}
 	evidenceHandler := httphandler.NewEvidenceHandler(evidenceService)
+	coreConfig := conf.NewCoreConfig()
+	metrics := coremetrics.New()
+	sessionStore, ledgerStore, closeDatabase, err := newCoreStores(coreConfig)
+	if err != nil {
+		return nil, err
+	}
+	sessionService := sessionsvc.New(sessionStore, sessionsvc.Options{
+		EvidenceCollectionState: func() string {
+			if coreConfig.EvidenceCollectionState == "" {
+				return "enabled"
+			}
+			return coreConfig.EvidenceCollectionState
+		},
+		Metrics: metrics,
+	})
+	sessionHandler := httphandler.NewSessionHandler(sessionService)
+	ledgerHandler := httphandler.NewConfiguredLedgerHandler(ledgersvc.NewWithMetrics(ledgerStore, metrics))
 
-	return newApp(httpServerConfig, traceHandler, evidenceHandler)
+	app := newApp(httpServerConfig, traceHandler, evidenceHandler, sessionHandler, ledgerHandler, metrics)
+	app.closeDatabase = closeDatabase
+	workerContext, stopWorkers := context.WithCancel(context.Background())
+	app.stopWorkers = stopWorkers
+	app.workers.Add(1)
+	go func() {
+		defer app.workers.Done()
+		runLeaseReaper(
+			workerContext,
+			coreConfig.AbandonInterval,
+			coreConfig.OneShotIdleTTL,
+			sessionService,
+		)
+	}()
+	if coreConfig.ProjectionEnabled {
+		outboxStore, supported := sessionStore.(iprojectionoutbox.Store)
+		if !supported {
+			stopWorkers()
+			app.workers.Wait()
+			if closeDatabase != nil {
+				_ = closeDatabase()
+			}
+			return nil, errors.New("configured Core store does not support projection outbox")
+		}
+		sink := opensearchprojection.New(openSearchClient, coreConfig.ProjectionIndex)
+		var rebuildProjection func(context.Context) error
+		if coreConfig.ProjectionRebuildVersion != "" {
+			source, rebuildSupported := sessionStore.(iprojectionrebuild.Source)
+			if !rebuildSupported {
+				stopWorkers()
+				app.workers.Wait()
+				if closeDatabase != nil {
+					_ = closeDatabase()
+				}
+				return nil, errors.New("configured Core store does not support projection rebuild")
+			}
+			rebuild := projectionrebuildsvc.New(source, sink, projectionrebuildsvc.Options{})
+			rebuildProjection = func(ctx context.Context) error {
+				_, err := rebuild.Rebuild(
+					ctx, "core", coreConfig.ProjectionIndex,
+					coreConfig.ProjectionRebuildVersion,
+				)
+				return err
+			}
+		}
+		worker := projectorsvc.NewWorker(
+			outboxStore, sink, projectorsvc.WorkerOptions{Metrics: metrics},
+		)
+		app.projection = worker
+		app.workers.Add(1)
+		go func() {
+			defer app.workers.Done()
+			runProjectionSupervisor(
+				workerContext,
+				coreConfig.ProjectionInterval,
+				rebuildProjection,
+				func(ctx context.Context) {
+					runProjectionWorker(
+						ctx, coreConfig.ProjectionInterval, worker, metrics,
+					)
+				},
+				metrics,
+			)
+		}()
+	}
+	return app, nil
 }
 
-func newApp(httpServerConfig conf.HTTPServerConfig, traceHandler *httphandler.TraceHandler, evidenceHandler *httphandler.EvidenceHandler) *App {
+func newCoreStores(config conf.CoreConfig) (isessionstore.Store, ievidenceledger.Store, func() error, error) {
+	if !strings.EqualFold(config.Store, "mariadb") {
+		return memorysessionstore.New(), ledgerstore.New(), nil, nil
+	}
+	if config.MariaDBDSN == "" {
+		return nil, nil, nil, errors.New("BKN_TRACE_CORE_MARIADB_DSN is required when BKN_TRACE_CORE_STORE=mariadb")
+	}
+	db, err := sql.Open("mysql", config.MariaDBDSN)
+	if err != nil {
+		return nil, nil, nil, fmt.Errorf("open BKN Trace MariaDB: %w", err)
+	}
+	db.SetMaxOpenConns(16)
+	db.SetMaxIdleConns(4)
+	db.SetConnMaxLifetime(30 * time.Minute)
+	if err := db.PingContext(context.Background()); err != nil {
+		_ = db.Close()
+		return nil, nil, nil, fmt.Errorf("connect BKN Trace MariaDB: %w", err)
+	}
+	store := mariadbsessionstore.New(db)
+	if config.AutoMigrate {
+		if err := store.Migrate(context.Background()); err != nil {
+			_ = db.Close()
+			return nil, nil, nil, err
+		}
+	}
+	return store, store, db.Close, nil
+}
+
+func runLeaseReaper(
+	ctx context.Context,
+	interval time.Duration,
+	oneShotIdleTTL time.Duration,
+	service *sessionsvc.Service,
+) {
+	timer := time.NewTicker(interval)
+	defer timer.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-timer.C:
+			_, _ = service.AbandonExpiredInteractions(ctx, 100)
+			_, _ = service.ExpireIdleOneShotConversations(ctx, oneShotIdleTTL, 100)
+			_, _ = service.AssembleDueInteractions(ctx, 100)
+		}
+	}
+}
+
+func runProjectionWorker(
+	ctx context.Context,
+	interval time.Duration,
+	worker *projectorsvc.Worker,
+	metrics icoremetrics.Recorder,
+) {
+	timer := time.NewTicker(interval)
+	defer timer.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-timer.C:
+			if _, err := worker.RunOnce(ctx); err != nil {
+				metrics.Increment(icoremetrics.ProjectionErrorsTotal)
+				log.Printf("BKN Trace projection worker failed: %v", err)
+			}
+		}
+	}
+}
+
+func runProjectionSupervisor(
+	ctx context.Context,
+	retryInterval time.Duration,
+	rebuild func(context.Context) error,
+	runWorker func(context.Context),
+	metrics icoremetrics.Recorder,
+) {
+	if metrics == nil {
+		metrics = icoremetrics.Noop{}
+	}
+	metrics.Set(icoremetrics.ProjectionReady, 0)
+	if retryInterval <= 0 {
+		retryInterval = time.Second
+	}
+	for rebuild != nil {
+		if err := rebuild(ctx); err == nil {
+			break
+		} else {
+			metrics.Increment(icoremetrics.ProjectionErrorsTotal)
+			log.Printf("BKN Trace projection rebuild failed; retrying: %v", err)
+		}
+		timer := time.NewTimer(retryInterval)
+		select {
+		case <-ctx.Done():
+			if !timer.Stop() {
+				<-timer.C
+			}
+			return
+		case <-timer.C:
+		}
+	}
+	metrics.Set(icoremetrics.ProjectionReady, 1)
+	runWorker(ctx)
+}
+
+func newApp(
+	httpServerConfig conf.HTTPServerConfig,
+	traceHandler *httphandler.TraceHandler,
+	evidenceHandler *httphandler.EvidenceHandler,
+	sessionHandler *httphandler.SessionHandler,
+	ledgerHandler *httphandler.LedgerHandler,
+	metrics http.Handler,
+) *App {
 	mux := http.NewServeMux()
+	if metrics != nil {
+		mux.Handle("/metrics", metrics)
+	}
 
 	// readAuth wraps every trace/evidence READ route. In enforce mode it refuses
 	// a caller with no account identity, closing the unauthenticated-read hole
@@ -87,20 +307,14 @@ func newApp(httpServerConfig conf.HTTPServerConfig, traceHandler *httphandler.Tr
 		evidenceHandler.GetTraceSubresource(w, r)
 	}))
 	mux.HandleFunc(APIBasePath+"/evidence-nodes/", readAuth(evidenceHandler.GetEvidenceNode))
-	mux.HandleFunc(APIBasePath+"/evidence/events", evidenceHandler.IngestEvidenceEvents)
+	mux.HandleFunc(APIBasePath+"/evidence/events", ledgerHandler.Ingest)
 	mux.HandleFunc(APIBasePath+"/evidence/artifacts", evidenceHandler.IngestEvidenceArtifact)
 	mux.HandleFunc(APIBasePath+"/evidence/artifacts/", readAuth(evidenceHandler.GetEvidenceArtifact))
 	mux.HandleFunc(APIBasePath+"/evidence/by-trace", readAuth(evidenceHandler.SearchEvidenceByTrace))
-	mux.HandleFunc(APIBasePath+"/requests", readAuth(evidenceHandler.ListRequests))
-	mux.HandleFunc(APIBasePath+"/interactions/", readAuth(evidenceHandler.GetInteractionSummary))
-	mux.HandleFunc(APIBasePath+"/requests/", readAuth(func(w http.ResponseWriter, r *http.Request) {
-		if strings.HasSuffix(r.URL.Path, "/traces") {
-			evidenceHandler.ListRequestTraces(w, r)
-			return
-		}
-		evidenceHandler.GetRequestSummary(w, r)
-	}))
 	mux.HandleFunc(APIBasePath+"/trace-executions", readAuth(evidenceHandler.ListTraceExecutions))
+	httphandler.RegisterSessionRoutes(
+		mux, APIBasePath, sessionHandler, evidenceHandler.RequireTrustedLifecycleIdentity,
+	)
 	mux.Handle(APIBasePath+"/swagger/", httpSwagger.Handler(
 		httpSwagger.URL(APIBasePath+"/swagger/doc.json"),
 	))
@@ -115,9 +329,38 @@ func (a *App) Start() error {
 }
 
 func (a *App) Shutdown(ctx context.Context) error {
+	var shutdownErr error
 	if a.server != nil {
-		return a.server.Shutdown(ctx)
+		shutdownErr = a.server.Shutdown(ctx)
 	}
+	shutdownErr = errors.Join(
+		shutdownErr,
+		stopAndDrainProjectionWorker(ctx, a.stopWorkers, &a.workers, a.projection),
+	)
+	if a.closeDatabase != nil {
+		shutdownErr = errors.Join(shutdownErr, a.closeDatabase())
+	}
+	return shutdownErr
+}
 
-	return nil
+func stopAndDrainProjectionWorker(
+	ctx context.Context,
+	stopWorkers context.CancelFunc,
+	workers *sync.WaitGroup,
+	projection *projectorsvc.Worker,
+) error {
+	if stopWorkers != nil {
+		stopWorkers()
+	}
+	if workers != nil {
+		workers.Wait()
+	}
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	if projection == nil {
+		return nil
+	}
+	_, err := projection.Drain(ctx)
+	return err
 }

--- a/bkn-trace/agent-observability/src/boot/bootstrap.go
+++ b/bkn-trace/agent-observability/src/boot/bootstrap.go
@@ -307,7 +307,10 @@ func newApp(
 		evidenceHandler.GetTraceSubresource(w, r)
 	}))
 	mux.HandleFunc(APIBasePath+"/evidence-nodes/", readAuth(evidenceHandler.GetEvidenceNode))
-	mux.HandleFunc(APIBasePath+"/evidence/events", ledgerHandler.Ingest)
+	mux.HandleFunc(
+		APIBasePath+"/evidence/events",
+		evidenceHandler.RequireTrustedLifecycleIdentity(ledgerHandler.Ingest),
+	)
 	mux.HandleFunc(APIBasePath+"/evidence/artifacts", evidenceHandler.IngestEvidenceArtifact)
 	mux.HandleFunc(APIBasePath+"/evidence/artifacts/", readAuth(evidenceHandler.GetEvidenceArtifact))
 	mux.HandleFunc(APIBasePath+"/evidence/by-trace", readAuth(evidenceHandler.SearchEvidenceByTrace))

--- a/bkn-trace/agent-observability/src/boot/projection_shutdown_test.go
+++ b/bkn-trace/agent-observability/src/boot/projection_shutdown_test.go
@@ -1,0 +1,78 @@
+package boot
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/openbkn-ai/bkn-foundry/bkn-trace/agent-observability/src/domain/service/projectorsvc"
+	"github.com/openbkn-ai/bkn-foundry/bkn-trace/agent-observability/src/port/driven/iprojectionoutbox"
+)
+
+func TestStopAndDrainProjectionWorker(t *testing.T) {
+	t.Parallel()
+
+	store := &shutdownOutboxStore{
+		items: []iprojectionoutbox.Item{{ID: 1, EventID: "evt-1"}},
+	}
+	worker := projectorsvc.NewWorker(
+		store, shutdownProjectionSink{}, projectorsvc.WorkerOptions{},
+	)
+	workerContext, stopWorker := context.WithCancel(context.Background())
+	var workers sync.WaitGroup
+	workers.Add(1)
+	go func() {
+		defer workers.Done()
+		<-workerContext.Done()
+	}()
+
+	if err := stopAndDrainProjectionWorker(
+		context.Background(), stopWorker, &workers, worker,
+	); err != nil {
+		t.Fatalf("stop and drain: %v", err)
+	}
+	if len(store.delivered) != 1 || store.delivered[0] != 1 {
+		t.Fatalf("durable outbox was not drained: %#v", store.delivered)
+	}
+}
+
+type shutdownOutboxStore struct {
+	items     []iprojectionoutbox.Item
+	delivered []uint64
+}
+
+func (s *shutdownOutboxStore) Lease(
+	context.Context, int, time.Duration,
+) ([]iprojectionoutbox.Item, error) {
+	items := append([]iprojectionoutbox.Item(nil), s.items...)
+	s.items = nil
+	return items, nil
+}
+
+func (s *shutdownOutboxStore) MarkDelivered(
+	_ context.Context, item iprojectionoutbox.Item,
+) error {
+	s.delivered = append(s.delivered, item.ID)
+	return nil
+}
+
+func (*shutdownOutboxStore) MarkRetry(
+	context.Context, iprojectionoutbox.Item, string, time.Time,
+) error {
+	return nil
+}
+
+func (*shutdownOutboxStore) MoveToDLQ(
+	context.Context, iprojectionoutbox.Item, string,
+) error {
+	return nil
+}
+
+type shutdownProjectionSink struct{}
+
+func (shutdownProjectionSink) Project(
+	context.Context, iprojectionoutbox.Item,
+) error {
+	return nil
+}

--- a/bkn-trace/agent-observability/src/boot/projection_supervisor_test.go
+++ b/bkn-trace/agent-observability/src/boot/projection_supervisor_test.go
@@ -1,0 +1,80 @@
+package boot
+
+import (
+	"context"
+	"errors"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+func TestProjectionSupervisorRetriesRebuildBeforeStartingWorker(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	var attempts atomic.Int32
+	workerStarted := make(chan struct{})
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		runProjectionSupervisor(
+			ctx,
+			time.Millisecond,
+			func(context.Context) error {
+				if attempts.Add(1) == 1 {
+					return errors.New("OpenSearch unavailable")
+				}
+				return nil
+			},
+			func(context.Context) {
+				close(workerStarted)
+			},
+			nil,
+		)
+	}()
+
+	select {
+	case <-workerStarted:
+	case <-time.After(time.Second):
+		t.Fatal("projection worker did not start after rebuild recovered")
+	}
+	<-done
+	if attempts.Load() != 2 {
+		t.Fatalf("unexpected rebuild attempts: %d", attempts.Load())
+	}
+}
+
+func TestProjectionSupervisorStopsWhileRebuildIsUnavailable(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	workerStarted := make(chan struct{}, 1)
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		runProjectionSupervisor(
+			ctx,
+			time.Hour,
+			func(context.Context) error {
+				return errors.New("OpenSearch unavailable")
+			},
+			func(context.Context) {
+				workerStarted <- struct{}{}
+			},
+			nil,
+		)
+	}()
+	cancel()
+
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("projection supervisor did not stop after cancellation")
+	}
+	select {
+	case <-workerStarted:
+		t.Fatal("projection worker started before a successful rebuild")
+	default:
+	}
+}

--- a/bkn-trace/agent-observability/src/conf/core.go
+++ b/bkn-trace/agent-observability/src/conf/core.go
@@ -1,0 +1,64 @@
+package conf
+
+import (
+	"os"
+	"strconv"
+	"strings"
+	"time"
+)
+
+type CoreConfig struct {
+	Store                    string
+	MariaDBDSN               string
+	AutoMigrate              bool
+	AbandonInterval          time.Duration
+	OneShotIdleTTL           time.Duration
+	ProjectionEnabled        bool
+	ProjectionIndex          string
+	ProjectionInterval       time.Duration
+	ProjectionRebuildVersion string
+	EvidenceCollectionState  string
+}
+
+func NewCoreConfig() CoreConfig {
+	store := strings.ToLower(strings.TrimSpace(os.Getenv("BKN_TRACE_CORE_STORE")))
+	if store == "" {
+		store = "memory"
+	}
+	interval := 30 * time.Second
+	if configured := strings.TrimSpace(os.Getenv("BKN_TRACE_CORE_ABANDON_INTERVAL")); configured != "" {
+		if parsed, err := time.ParseDuration(configured); err == nil && parsed > 0 {
+			interval = parsed
+		}
+	}
+	oneShotIdleTTL := 15 * time.Minute
+	if configured := strings.TrimSpace(os.Getenv("BKN_TRACE_CORE_ONE_SHOT_IDLE_TTL")); configured != "" {
+		if parsed, err := time.ParseDuration(configured); err == nil && parsed > 0 {
+			oneShotIdleTTL = parsed
+		}
+	}
+	autoMigrate, _ := strconv.ParseBool(strings.TrimSpace(os.Getenv("BKN_TRACE_CORE_AUTO_MIGRATE")))
+	projectionEnabled, _ := strconv.ParseBool(strings.TrimSpace(os.Getenv("BKN_TRACE_PROJECTION_ENABLED")))
+	projectionInterval := time.Second
+	if configured := strings.TrimSpace(os.Getenv("BKN_TRACE_PROJECTION_INTERVAL")); configured != "" {
+		if parsed, err := time.ParseDuration(configured); err == nil && parsed > 0 {
+			projectionInterval = parsed
+		}
+	}
+	projectionIndex := strings.TrimSpace(os.Getenv("BKN_TRACE_PROJECTION_INDEX"))
+	if projectionIndex == "" {
+		projectionIndex = "bkn-trace-core"
+	}
+	projectionRebuildVersion := strings.TrimSpace(os.Getenv("BKN_TRACE_PROJECTION_REBUILD_VERSION"))
+	if projectionEnabled && projectionRebuildVersion == "" {
+		projectionRebuildVersion = projectionIndex + "-v013"
+	}
+	return CoreConfig{
+		Store: store, MariaDBDSN: strings.TrimSpace(os.Getenv("BKN_TRACE_CORE_MARIADB_DSN")),
+		AutoMigrate: autoMigrate, AbandonInterval: interval, OneShotIdleTTL: oneShotIdleTTL,
+		ProjectionEnabled: projectionEnabled, ProjectionIndex: projectionIndex,
+		ProjectionInterval:       projectionInterval,
+		ProjectionRebuildVersion: projectionRebuildVersion,
+		EvidenceCollectionState:  strings.TrimSpace(os.Getenv("BKN_TRACE_EVIDENCE_COLLECTION_STATE")),
+	}
+}

--- a/bkn-trace/agent-observability/src/conf/core_test.go
+++ b/bkn-trace/agent-observability/src/conf/core_test.go
@@ -1,0 +1,41 @@
+package conf
+
+import (
+	"testing"
+	"time"
+)
+
+func TestCoreConfigRequiresExplicitMariaDBDSN(t *testing.T) {
+	t.Setenv("BKN_TRACE_CORE_STORE", "mariadb")
+	t.Setenv("BKN_TRACE_CORE_MARIADB_DSN", "trace:secret@tcp(mariadb:3306)/trace?parseTime=true")
+	t.Setenv("BKN_TRACE_CORE_AUTO_MIGRATE", "true")
+	t.Setenv("BKN_TRACE_CORE_ABANDON_INTERVAL", "45s")
+
+	config := NewCoreConfig()
+	if config.Store != "mariadb" || config.MariaDBDSN == "" || !config.AutoMigrate {
+		t.Fatalf("unexpected core config: %#v", config)
+	}
+	if config.AbandonInterval != 45*time.Second {
+		t.Fatalf("unexpected abandon interval: %s", config.AbandonInterval)
+	}
+}
+
+func TestProjectionUsesVersionedIndexBehindAliasByDefault(t *testing.T) {
+	t.Setenv("BKN_TRACE_PROJECTION_ENABLED", "true")
+	t.Setenv("BKN_TRACE_PROJECTION_INDEX", "bkn-trace-core")
+	t.Setenv("BKN_TRACE_PROJECTION_REBUILD_VERSION", "")
+
+	config := NewCoreConfig()
+	if config.ProjectionRebuildVersion != "bkn-trace-core-v013" {
+		t.Fatalf("projection could create a concrete alias index: %#v", config)
+	}
+}
+
+func TestCoreConfigParsesOneShotIdleTTL(t *testing.T) {
+	t.Setenv("BKN_TRACE_CORE_ONE_SHOT_IDLE_TTL", "20m")
+
+	config := NewCoreConfig()
+	if config.OneShotIdleTTL != 20*time.Minute {
+		t.Fatalf("unexpected one-shot idle TTL: %s", config.OneShotIdleTTL)
+	}
+}

--- a/bkn-trace/agent-observability/src/domain/service/ledgersvc/service.go
+++ b/bkn-trace/agent-observability/src/domain/service/ledgersvc/service.go
@@ -1,0 +1,101 @@
+package ledgersvc
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+
+	"github.com/openbkn-ai/bkn-foundry/bkn-trace/agent-observability/src/domain/valueobject/ledgervo"
+	"github.com/openbkn-ai/bkn-foundry/bkn-trace/agent-observability/src/port/driven/icoremetrics"
+	"github.com/openbkn-ai/bkn-foundry/bkn-trace/agent-observability/src/port/driven/ievidenceledger"
+)
+
+type ErrorCode string
+
+const (
+	CodeEventPayloadConflict  ErrorCode = "event_payload_conflict"
+	CodeEventSequenceConflict ErrorCode = "producer_sequence_conflict"
+	CodeInvalidEvent          ErrorCode = "invalid_evidence_event"
+)
+
+type DomainError struct {
+	Code    ErrorCode
+	Message string
+}
+
+func (e *DomainError) Error() string { return e.Message }
+
+func IsCode(err error, code ErrorCode) bool {
+	var domainErr *DomainError
+	return errors.As(err, &domainErr) && domainErr.Code == code
+}
+
+type Service struct {
+	store   ievidenceledger.Store
+	metrics icoremetrics.Recorder
+}
+
+func New(store ievidenceledger.Store) *Service {
+	return NewWithMetrics(store, icoremetrics.Noop{})
+}
+
+func NewWithMetrics(store ievidenceledger.Store, metrics icoremetrics.Recorder) *Service {
+	if metrics == nil {
+		metrics = icoremetrics.Noop{}
+	}
+	return &Service{store: store, metrics: metrics}
+}
+
+func (s *Service) Ingest(ctx context.Context, event ledgervo.Event) (ledgervo.DurableAck, error) {
+	if err := validateEvent(event); err != nil {
+		return ledgervo.DurableAck{}, err
+	}
+	ack, err := s.store.Commit(ctx, event)
+	switch {
+	case errors.Is(err, ievidenceledger.ErrPayloadConflict):
+		s.metrics.Increment(icoremetrics.EvidenceHashConflictsTotal)
+		return ledgervo.DurableAck{}, &DomainError{
+			Code: CodeEventPayloadConflict, Message: "event ID already exists with a different payload hash",
+		}
+	case errors.Is(err, ievidenceledger.ErrSequenceConflict):
+		return ledgervo.DurableAck{}, &DomainError{
+			Code: CodeEventSequenceConflict, Message: "producer stream sequence is already occupied",
+		}
+	case errors.Is(err, ievidenceledger.ErrCausalityConflict):
+		return ledgervo.DurableAck{}, &DomainError{
+			Code: CodeInvalidEvent, Message: "event causality is cyclic or crosses its trusted interaction scope",
+		}
+	case err != nil:
+		return ledgervo.DurableAck{}, err
+	default:
+		s.metrics.Increment(icoremetrics.EvidenceIngestTotal)
+		return ack, nil
+	}
+}
+
+func validateEvent(event ledgervo.Event) error {
+	if event.SchemaVersion != "3.0.0" {
+		return &DomainError{Code: CodeInvalidEvent, Message: "schema_version must be 3.0.0"}
+	}
+	if event.EventID == "" || event.EventType == "" || event.ConversationID == "" ||
+		event.InteractionID == "" || event.ProducerID == "" || event.ProducerStreamID == "" ||
+		event.ProducerEpoch == 0 || event.ProducerSequence == 0 ||
+		event.Owner.TenantID == "" || event.Owner.BusinessDomainID == "" {
+		return &DomainError{Code: CodeInvalidEvent, Message: "required evidence event fields are missing"}
+	}
+	if event.PayloadHash != ledgervo.CanonicalPayloadHash(event.Envelope) {
+		return &DomainError{Code: CodeInvalidEvent, Message: "payload_hash does not match canonical envelope"}
+	}
+	for _, cause := range event.CausationEventIDs {
+		if cause == event.EventID {
+			return &DomainError{Code: CodeInvalidEvent, Message: "event cannot cause itself"}
+		}
+	}
+	if event.StartedAt.IsZero() || event.ObservedAt.IsZero() || event.EmittedAt.IsZero() {
+		return &DomainError{Code: CodeInvalidEvent, Message: "started_at, observed_at and emitted_at are required"}
+	}
+	if !json.Valid(event.Envelope) {
+		return &DomainError{Code: CodeInvalidEvent, Message: "event envelope is not valid JSON"}
+	}
+	return nil
+}

--- a/bkn-trace/agent-observability/src/domain/service/ledgersvc/service_test.go
+++ b/bkn-trace/agent-observability/src/domain/service/ledgersvc/service_test.go
@@ -1,0 +1,241 @@
+package ledgersvc_test
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/openbkn-ai/bkn-foundry/bkn-trace/agent-observability/src/domain/service/ledgersvc"
+	"github.com/openbkn-ai/bkn-foundry/bkn-trace/agent-observability/src/domain/valueobject/ledgervo"
+	"github.com/openbkn-ai/bkn-foundry/bkn-trace/agent-observability/src/domain/valueobject/sessionvo"
+	"github.com/openbkn-ai/bkn-foundry/bkn-trace/agent-observability/src/drivenadapter/memoryaccess/ledgerstore"
+	"github.com/openbkn-ai/bkn-foundry/bkn-trace/agent-observability/src/port/driven/icoremetrics"
+)
+
+func TestEvidenceLedgerReturnsDurableAckOnlyAfterOutboxCommit(t *testing.T) {
+	t.Parallel()
+
+	store := ledgerstore.New()
+	service := ledgersvc.New(store)
+	event := testEvent()
+	ack, err := service.Ingest(context.Background(), event)
+	if err != nil {
+		t.Fatalf("ingest event: %v", err)
+	}
+	if !ack.Durable || ack.IngestSequence != 1 || ack.Replayed {
+		t.Fatalf("unexpected durable ack: %#v", ack)
+	}
+	if store.LedgerCount() != 1 || store.PendingProjectionCount() != 1 {
+		t.Fatalf("ledger and outbox must commit together: ledger=%d outbox=%d",
+			store.LedgerCount(), store.PendingProjectionCount())
+	}
+
+	replayed, err := service.Ingest(context.Background(), event)
+	if err != nil {
+		t.Fatalf("replay event: %v", err)
+	}
+	if !replayed.Durable || !replayed.Replayed || replayed.IngestSequence != ack.IngestSequence {
+		t.Fatalf("unexpected replay ack: %#v", replayed)
+	}
+	if store.LedgerCount() != 1 || store.PendingProjectionCount() != 1 {
+		t.Fatal("idempotent replay duplicated durable records")
+	}
+}
+
+func TestEvidenceLedgerRecordsAcceptedAndHashConflictMetrics(t *testing.T) {
+	t.Parallel()
+
+	store := ledgerstore.New()
+	metrics := &ledgerTestMetrics{counts: make(map[string]uint64)}
+	service := ledgersvc.NewWithMetrics(store, metrics)
+	event := testEvent()
+	if _, err := service.Ingest(context.Background(), event); err != nil {
+		t.Fatalf("ingest event: %v", err)
+	}
+	event.Owner.TenantID = "tenant-2"
+	if _, err := service.Ingest(context.Background(), event); !ledgersvc.IsCode(err, ledgersvc.CodeEventPayloadConflict) {
+		t.Fatalf("expected immutable event conflict, got %v", err)
+	}
+	if metrics.counts[icoremetrics.EvidenceIngestTotal] != 1 ||
+		metrics.counts[icoremetrics.EvidenceHashConflictsTotal] != 1 {
+		t.Fatalf("unexpected evidence metrics: %#v", metrics.counts)
+	}
+}
+
+func TestEvidenceEventPayloadConflictIsQuarantined(t *testing.T) {
+	t.Parallel()
+
+	store := ledgerstore.New()
+	service := ledgersvc.New(store)
+	event := testEvent()
+	if _, err := service.Ingest(context.Background(), event); err != nil {
+		t.Fatalf("ingest event: %v", err)
+	}
+	event.Envelope = json.RawMessage(`{"answer":"different"}`)
+	event.PayloadHash = ledgervo.CanonicalPayloadHash(event.Envelope)
+	if _, err := service.Ingest(context.Background(), event); !ledgersvc.IsCode(err, ledgersvc.CodeEventPayloadConflict) {
+		t.Fatalf("expected event_payload_conflict, got %v", err)
+	}
+	if store.ConflictCount() != 1 || store.LedgerCount() != 1 {
+		t.Fatalf("conflict must be quarantined without overwriting ledger")
+	}
+}
+
+func TestEvidenceReplayCannotChangeImmutableOwnershipMetadata(t *testing.T) {
+	t.Parallel()
+
+	store := ledgerstore.New()
+	service := ledgersvc.New(store)
+	event := testEvent()
+	if _, err := service.Ingest(context.Background(), event); err != nil {
+		t.Fatalf("ingest event: %v", err)
+	}
+	event.Owner.TenantID = "tenant-2"
+	if _, err := service.Ingest(context.Background(), event); !ledgersvc.IsCode(err, ledgersvc.CodeEventPayloadConflict) {
+		t.Fatalf("expected immutable event conflict, got %v", err)
+	}
+}
+
+func TestProjectionWriteFailureDoesNotReturnDurableAck(t *testing.T) {
+	t.Parallel()
+
+	store := ledgerstore.New()
+	store.FailProjectionWrites(true)
+	service := ledgersvc.New(store)
+	ack, err := service.Ingest(context.Background(), testEvent())
+	if err == nil || ack.Durable {
+		t.Fatalf("expected failed ingest without durable ack, got %#v, %v", ack, err)
+	}
+	if store.LedgerCount() != 0 || store.PendingProjectionCount() != 0 {
+		t.Fatal("failed transaction left a partial ledger or outbox record")
+	}
+}
+
+func TestProducerSequenceAndEpochRollbackAreRejected(t *testing.T) {
+	t.Parallel()
+
+	store := ledgerstore.New()
+	service := ledgersvc.New(store)
+	first := testEvent()
+	first.ProducerSequence = 10
+	if _, err := service.Ingest(context.Background(), first); err != nil {
+		t.Fatalf("ingest stream head: %v", err)
+	}
+
+	sequenceRollback := testEvent()
+	sequenceRollback.EventID = "evt-sequence-rollback"
+	sequenceRollback.ProducerSequence = 9
+	sequenceRollback.Envelope = json.RawMessage(`{"answer":"sequence rollback"}`)
+	sequenceRollback.PayloadHash = ledgervo.CanonicalPayloadHash(sequenceRollback.Envelope)
+	if _, err := service.Ingest(context.Background(), sequenceRollback); !ledgersvc.IsCode(err, ledgersvc.CodeEventSequenceConflict) {
+		t.Fatalf("expected sequence rollback conflict, got %v", err)
+	}
+
+	nextEpoch := testEvent()
+	nextEpoch.EventID = "evt-next-epoch"
+	nextEpoch.ProducerEpoch = 2
+	nextEpoch.ProducerSequence = 1
+	nextEpoch.Envelope = json.RawMessage(`{"answer":"new epoch"}`)
+	nextEpoch.PayloadHash = ledgervo.CanonicalPayloadHash(nextEpoch.Envelope)
+	if _, err := service.Ingest(context.Background(), nextEpoch); err != nil {
+		t.Fatalf("ingest next epoch: %v", err)
+	}
+
+	epochRollback := testEvent()
+	epochRollback.EventID = "evt-epoch-rollback"
+	epochRollback.ProducerEpoch = 1
+	epochRollback.ProducerSequence = 11
+	epochRollback.Envelope = json.RawMessage(`{"answer":"epoch rollback"}`)
+	epochRollback.PayloadHash = ledgervo.CanonicalPayloadHash(epochRollback.Envelope)
+	if _, err := service.Ingest(context.Background(), epochRollback); !ledgersvc.IsCode(err, ledgersvc.CodeEventSequenceConflict) {
+		t.Fatalf("expected epoch rollback conflict, got %v", err)
+	}
+}
+
+func TestMissingCausationIsPersistedAsExplicitState(t *testing.T) {
+	t.Parallel()
+
+	store := ledgerstore.New()
+	service := ledgersvc.New(store)
+	event := testEvent()
+	event.CausationEventIDs = []string{"evt-parent-late"}
+	if _, err := service.Ingest(context.Background(), event); err != nil {
+		t.Fatalf("ingest event with late parent: %v", err)
+	}
+	stored, found := store.StoredEvent(event.EventID)
+	if !found || stored.CausalityStatus != "causality_missing" ||
+		len(stored.MissingCauseIDs) != 1 || stored.MissingCauseIDs[0] != "evt-parent-late" {
+		t.Fatalf("missing causation was not explicit: %#v", stored)
+	}
+}
+
+func TestEvidenceEventRequiresStartedObservedAndEmittedTimes(t *testing.T) {
+	t.Parallel()
+
+	store := ledgerstore.New()
+	service := ledgersvc.New(store)
+	event := testEvent()
+	event.StartedAt = time.Time{}
+	if _, err := service.Ingest(context.Background(), event); !ledgersvc.IsCode(err, ledgersvc.CodeInvalidEvent) {
+		t.Fatalf("expected missing started_at to be rejected, got %v", err)
+	}
+}
+
+func TestLateCausationThatClosesCycleIsRejected(t *testing.T) {
+	t.Parallel()
+
+	store := ledgerstore.New()
+	service := ledgersvc.New(store)
+	first := testEvent()
+	first.CausationEventIDs = []string{"evt-2"}
+	if _, err := service.Ingest(context.Background(), first); err != nil {
+		t.Fatalf("ingest event with late parent: %v", err)
+	}
+
+	second := testEvent()
+	second.EventID = "evt-2"
+	second.ProducerSequence = 2
+	second.CausationEventIDs = []string{"evt-1"}
+	second.Envelope = json.RawMessage(`{"answer":"cycle"}`)
+	second.PayloadHash = ledgervo.CanonicalPayloadHash(second.Envelope)
+	if _, err := service.Ingest(context.Background(), second); !ledgersvc.IsCode(err, ledgersvc.CodeInvalidEvent) {
+		t.Fatalf("causation cycle was not rejected: %v", err)
+	}
+	if store.LedgerCount() != 1 {
+		t.Fatalf("cyclic event was written to ledger, count=%d", store.LedgerCount())
+	}
+}
+
+func testEvent() ledgervo.Event {
+	envelope := json.RawMessage(`{"answer":"15991"}`)
+	return ledgervo.Event{
+		EventID: "evt-1", EventType: "operation.output.observed", SchemaVersion: "3.0.0",
+		PayloadHash: ledgervo.CanonicalPayloadHash(envelope),
+		Owner: sessionvo.Owner{
+			TenantID: "tenant-1", BusinessDomainID: "domain-1",
+			ApplicationPrincipalID: "app-1", EffectiveSubjectType: sessionvo.SubjectService,
+			EffectiveSubjectID: "agent-1",
+		},
+		ConversationID: "conv-1", InteractionID: "int-1", OperationID: "op-1", Attempt: 1,
+		ProducerID: "context-loader", ProducerStreamID: "stream-1", ProducerEpoch: 1, ProducerSequence: 1,
+		StartedAt:  time.Date(2026, 7, 30, 9, 59, 59, 0, time.UTC),
+		ObservedAt: time.Date(2026, 7, 30, 10, 0, 0, 0, time.UTC),
+		EmittedAt:  time.Date(2026, 7, 30, 10, 0, 1, 0, time.UTC),
+		Envelope:   envelope,
+	}
+}
+
+type ledgerTestMetrics struct {
+	counts map[string]uint64
+}
+
+func (m *ledgerTestMetrics) Increment(name string) {
+	m.Add(name, 1)
+}
+
+func (m *ledgerTestMetrics) Add(name string, delta uint64) {
+	m.counts[name] += delta
+}
+
+func (m *ledgerTestMetrics) Set(string, float64) {}

--- a/bkn-trace/agent-observability/src/domain/service/projectionrebuildsvc/service.go
+++ b/bkn-trace/agent-observability/src/domain/service/projectionrebuildsvc/service.go
@@ -3,6 +3,7 @@ package projectionrebuildsvc
 import (
 	"context"
 	"errors"
+	"fmt"
 
 	"github.com/openbkn-ai/bkn-foundry/bkn-trace/agent-observability/src/port/driven/iprojectionrebuild"
 )
@@ -60,7 +61,7 @@ func (s *Service) Rebuild(ctx context.Context, projectorID, alias, indexVersion 
 			}
 		}
 		if err := s.target.ValidateVersion(ctx, indexVersion, items); err != nil {
-			return Result{}, ErrProjectionValidation
+			return Result{}, fmt.Errorf("validate authoritative projection: %w", err)
 		}
 		last := items[len(items)-1]
 		afterType, afterID = last.AggregateType, last.AggregateID
@@ -90,7 +91,7 @@ func (s *Service) Rebuild(ctx context.Context, projectorID, alias, indexVersion 
 				checkpoint = item.ID
 			}
 			if err := s.target.ValidateVersion(ctx, indexVersion, items); err != nil {
-				return Result{}, ErrProjectionValidation
+				return Result{}, fmt.Errorf("validate projection history: %w", err)
 			}
 			if err := s.source.SaveProjectionCheckpoint(
 				ctx, projectorID, indexVersion, checkpoint,

--- a/bkn-trace/agent-observability/src/domain/service/projectionrebuildsvc/service.go
+++ b/bkn-trace/agent-observability/src/domain/service/projectionrebuildsvc/service.go
@@ -1,0 +1,139 @@
+package projectionrebuildsvc
+
+import (
+	"context"
+	"errors"
+
+	"github.com/openbkn-ai/bkn-foundry/bkn-trace/agent-observability/src/port/driven/iprojectionrebuild"
+)
+
+var ErrProjectionValidation = errors.New("rebuilt projection does not match authoritative state")
+
+type Options struct {
+	BatchSize int
+}
+
+type Service struct {
+	source  iprojectionrebuild.Source
+	target  iprojectionrebuild.Target
+	options Options
+}
+
+type Result struct {
+	IndexVersion   string
+	LastOutboxID   uint64
+	ProjectedCount uint64
+}
+
+func New(source iprojectionrebuild.Source, target iprojectionrebuild.Target, options Options) *Service {
+	if options.BatchSize <= 0 {
+		options.BatchSize = 500
+	}
+	return &Service{source: source, target: target, options: options}
+}
+
+func (s *Service) Rebuild(ctx context.Context, projectorID, alias, indexVersion string) (Result, error) {
+	if projectorID == "" || alias == "" || indexVersion == "" {
+		return Result{}, errors.New("projector ID, alias and index version are required")
+	}
+	if err := s.target.PrepareVersion(ctx, indexVersion); err != nil {
+		return Result{}, err
+	}
+	rebuildStart, err := s.source.ProjectionHighWatermark(ctx)
+	if err != nil {
+		return Result{}, err
+	}
+	afterType, afterID := "", ""
+	for {
+		items, err := s.source.ScanAuthoritativeProjection(
+			ctx, afterType, afterID, s.options.BatchSize,
+		)
+		if err != nil {
+			return Result{}, err
+		}
+		if len(items) == 0 {
+			break
+		}
+		for _, item := range items {
+			if err := s.target.ProjectVersion(ctx, indexVersion, item); err != nil {
+				return Result{}, err
+			}
+		}
+		if err := s.target.ValidateVersion(ctx, indexVersion, items); err != nil {
+			return Result{}, ErrProjectionValidation
+		}
+		last := items[len(items)-1]
+		afterType, afterID = last.AggregateType, last.AggregateID
+	}
+	checkpoint := rebuildStart
+	if err := s.source.SaveProjectionCheckpoint(
+		ctx, projectorID, indexVersion, checkpoint,
+	); err != nil {
+		return Result{}, err
+	}
+	highWatermark := rebuildStart
+	for {
+		for checkpoint < highWatermark {
+			items, err := s.source.ScanProjectionHistory(
+				ctx, checkpoint, highWatermark, s.options.BatchSize,
+			)
+			if err != nil {
+				return Result{}, err
+			}
+			if len(items) == 0 {
+				return Result{}, ErrProjectionValidation
+			}
+			for _, item := range items {
+				if err := s.target.ProjectVersion(ctx, indexVersion, item); err != nil {
+					return Result{}, err
+				}
+				checkpoint = item.ID
+			}
+			if err := s.target.ValidateVersion(ctx, indexVersion, items); err != nil {
+				return Result{}, ErrProjectionValidation
+			}
+			if err := s.source.SaveProjectionCheckpoint(
+				ctx, projectorID, indexVersion, checkpoint,
+			); err != nil {
+				return Result{}, err
+			}
+		}
+
+		latestHighWatermark, err := s.source.ProjectionHighWatermark(ctx)
+		if err != nil {
+			return Result{}, err
+		}
+		if latestHighWatermark > highWatermark {
+			highWatermark = latestHighWatermark
+			continue
+		}
+
+		expected, err := s.source.CountAuthoritativeProjection(ctx)
+		if err != nil {
+			return Result{}, err
+		}
+		actual, err := s.target.CountVersion(ctx, indexVersion)
+		if err != nil {
+			return Result{}, err
+		}
+		if actual != expected {
+			return Result{}, ErrProjectionValidation
+		}
+
+		latestHighWatermark, err = s.source.ProjectionHighWatermark(ctx)
+		if err != nil {
+			return Result{}, err
+		}
+		if latestHighWatermark > highWatermark {
+			highWatermark = latestHighWatermark
+			continue
+		}
+		if err := s.target.SwitchAlias(ctx, alias, indexVersion); err != nil {
+			return Result{}, err
+		}
+		return Result{
+			IndexVersion: indexVersion, LastOutboxID: highWatermark,
+			ProjectedCount: actual,
+		}, nil
+	}
+}

--- a/bkn-trace/agent-observability/src/domain/service/projectionrebuildsvc/service_test.go
+++ b/bkn-trace/agent-observability/src/domain/service/projectionrebuildsvc/service_test.go
@@ -1,0 +1,229 @@
+package projectionrebuildsvc_test
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"sort"
+	"testing"
+
+	"github.com/openbkn-ai/bkn-foundry/bkn-trace/agent-observability/src/domain/service/projectionrebuildsvc"
+	"github.com/openbkn-ai/bkn-foundry/bkn-trace/agent-observability/src/port/driven/iprojectionoutbox"
+)
+
+func TestRebuildUsesAuthoritativeStateAfterDeliveredOutboxWasCleared(t *testing.T) {
+	t.Parallel()
+
+	source := &fakeSource{authoritative: []iprojectionoutbox.Item{
+		projectionItem("conversation", "conv-1", `{"status":"active"}`),
+		projectionItem("interaction", "int-1", `{"status":"completed"}`),
+		projectionItem("receipt", "rcpt-1", `{"status":"completed"}`),
+	}}
+	target := newFakeTarget()
+	service := projectionrebuildsvc.New(source, target, projectionrebuildsvc.Options{BatchSize: 2})
+
+	result, err := service.Rebuild(
+		context.Background(), "core", "bkn-trace-core", "bkn-trace-core-v20260730",
+	)
+	if err != nil {
+		t.Fatalf("rebuild: %v", err)
+	}
+	if result.LastOutboxID != 0 || result.ProjectedCount != 3 ||
+		target.alias != "bkn-trace-core" || target.version != result.IndexVersion {
+		t.Fatalf("unexpected rebuild result: %#v target=%#v", result, target)
+	}
+	if len(source.checkpoints) != 1 || source.checkpoints[0] != 0 {
+		t.Fatalf("rebuild start checkpoint was not recorded: %#v", source.checkpoints)
+	}
+}
+
+func TestRebuildDoesNotSwitchAliasWhenDocumentContentValidationFails(t *testing.T) {
+	t.Parallel()
+
+	source := &fakeSource{authoritative: []iprojectionoutbox.Item{
+		projectionItem("conversation", "conv-1", `{"status":"active"}`),
+	}}
+	target := newFakeTarget()
+	target.corrupt = true
+	service := projectionrebuildsvc.New(source, target, projectionrebuildsvc.Options{})
+
+	_, err := service.Rebuild(context.Background(), "core", "alias", "version")
+	if !errors.Is(err, projectionrebuildsvc.ErrProjectionValidation) || target.alias != "" {
+		t.Fatalf("invalid rebuild switched alias: alias=%q err=%v", target.alias, err)
+	}
+}
+
+func TestRebuildCatchesUpEventsCommittedDuringSnapshotBeforeAliasSwitch(t *testing.T) {
+	t.Parallel()
+
+	source := &fakeSource{
+		authoritative: []iprojectionoutbox.Item{
+			projectionItem("conversation", "conv-1", `{"status":"active"}`),
+			projectionItem("interaction", "int-1", `{"status":"active"}`),
+		},
+		outbox: []iprojectionoutbox.Item{
+			{
+				ID: 3, AggregateType: "receipt", AggregateID: "rcpt-1",
+				EventID: "evt-3", Payload: []byte(`{"status":"completed"}`),
+			},
+		},
+		authoritativeCount: 3,
+		highWatermarks:     []uint64{2, 3, 3},
+	}
+	target := newFakeTarget()
+	service := projectionrebuildsvc.New(source, target, projectionrebuildsvc.Options{BatchSize: 1})
+
+	result, err := service.Rebuild(
+		context.Background(), "core", "bkn-trace-core", "bkn-trace-core-v20260730",
+	)
+	if err != nil {
+		t.Fatalf("rebuild: %v", err)
+	}
+	if result.LastOutboxID != 3 || result.ProjectedCount != 3 {
+		t.Fatalf("rebuild did not catch up: %#v", result)
+	}
+	if target.alias == "" {
+		t.Fatal("validated caught-up projection did not switch alias")
+	}
+}
+
+func projectionItem(aggregateType, aggregateID, payload string) iprojectionoutbox.Item {
+	return iprojectionoutbox.Item{
+		AggregateType: aggregateType, AggregateID: aggregateID,
+		AggregateVersion: 1,
+		EventType:        aggregateType + ".snapshot", EventID: aggregateType + ":" + aggregateID,
+		Payload: []byte(payload),
+	}
+}
+
+type fakeSource struct {
+	authoritative      []iprojectionoutbox.Item
+	outbox             []iprojectionoutbox.Item
+	authoritativeCount uint64
+	checkpoints        []uint64
+	highWatermarks     []uint64
+	highWatermark      int
+}
+
+func (s *fakeSource) ProjectionHighWatermark(context.Context) (uint64, error) {
+	if len(s.highWatermarks) > 0 {
+		index := s.highWatermark
+		if index >= len(s.highWatermarks) {
+			index = len(s.highWatermarks) - 1
+		}
+		s.highWatermark++
+		return s.highWatermarks[index], nil
+	}
+	if len(s.outbox) == 0 {
+		return 0, nil
+	}
+	return s.outbox[len(s.outbox)-1].ID, nil
+}
+
+func (s *fakeSource) ScanAuthoritativeProjection(
+	_ context.Context,
+	afterType string,
+	afterID string,
+	limit int,
+) ([]iprojectionoutbox.Item, error) {
+	items := append([]iprojectionoutbox.Item(nil), s.authoritative...)
+	sort.Slice(items, func(i, j int) bool {
+		if items[i].AggregateType == items[j].AggregateType {
+			return items[i].AggregateID < items[j].AggregateID
+		}
+		return items[i].AggregateType < items[j].AggregateType
+	})
+	var result []iprojectionoutbox.Item
+	for _, item := range items {
+		if item.AggregateType < afterType ||
+			item.AggregateType == afterType && item.AggregateID <= afterID {
+			continue
+		}
+		result = append(result, item)
+		if len(result) == limit {
+			break
+		}
+	}
+	return result, nil
+}
+
+func (s *fakeSource) CountAuthoritativeProjection(context.Context) (uint64, error) {
+	if s.authoritativeCount > 0 {
+		return s.authoritativeCount, nil
+	}
+	return uint64(len(s.authoritative)), nil
+}
+
+func (s *fakeSource) ScanProjectionHistory(
+	_ context.Context,
+	after uint64,
+	through uint64,
+	limit int,
+) ([]iprojectionoutbox.Item, error) {
+	var result []iprojectionoutbox.Item
+	for _, item := range s.outbox {
+		if item.ID > after && item.ID <= through {
+			result = append(result, item)
+			if len(result) == limit {
+				break
+			}
+		}
+	}
+	return result, nil
+}
+
+func (s *fakeSource) LoadProjectionCheckpoint(context.Context, string, string) (uint64, error) {
+	if len(s.checkpoints) == 0 {
+		return 0, nil
+	}
+	return s.checkpoints[len(s.checkpoints)-1], nil
+}
+
+func (s *fakeSource) SaveProjectionCheckpoint(_ context.Context, _, _ string, value uint64) error {
+	s.checkpoints = append(s.checkpoints, value)
+	return nil
+}
+
+type fakeTarget struct {
+	documents map[string][]byte
+	corrupt   bool
+	alias     string
+	version   string
+}
+
+func newFakeTarget() *fakeTarget {
+	return &fakeTarget{documents: make(map[string][]byte)}
+}
+
+func (t *fakeTarget) PrepareVersion(context.Context, string) error { return nil }
+
+func (t *fakeTarget) ProjectVersion(_ context.Context, _ string, item iprojectionoutbox.Item) error {
+	payload := append([]byte(nil), item.Payload...)
+	if t.corrupt {
+		payload = []byte(`{"corrupt":true}`)
+	}
+	t.documents[iprojectionoutbox.DocumentID(item)] = payload
+	return nil
+}
+
+func (t *fakeTarget) ValidateVersion(
+	_ context.Context,
+	_ string,
+	items []iprojectionoutbox.Item,
+) error {
+	for _, item := range items {
+		if !bytes.Equal(t.documents[iprojectionoutbox.DocumentID(item)], item.Payload) {
+			return projectionrebuildsvc.ErrProjectionValidation
+		}
+	}
+	return nil
+}
+
+func (t *fakeTarget) CountVersion(context.Context, string) (uint64, error) {
+	return uint64(len(t.documents)), nil
+}
+
+func (t *fakeTarget) SwitchAlias(_ context.Context, alias, version string) error {
+	t.alias, t.version = alias, version
+	return nil
+}

--- a/bkn-trace/agent-observability/src/domain/service/projectionrebuildsvc/service_test.go
+++ b/bkn-trace/agent-observability/src/domain/service/projectionrebuildsvc/service_test.go
@@ -53,6 +53,26 @@ func TestRebuildDoesNotSwitchAliasWhenDocumentContentValidationFails(t *testing.
 	}
 }
 
+func TestRebuildPreservesProjectionInfrastructureFailure(t *testing.T) {
+	t.Parallel()
+
+	infrastructureErr := errors.New("OpenSearch timeout")
+	source := &fakeSource{authoritative: []iprojectionoutbox.Item{
+		projectionItem("conversation", "conv-1", `{"status":"active"}`),
+	}}
+	target := newFakeTarget()
+	target.validateErr = infrastructureErr
+	service := projectionrebuildsvc.New(source, target, projectionrebuildsvc.Options{})
+
+	_, err := service.Rebuild(context.Background(), "core", "alias", "version")
+	if !errors.Is(err, infrastructureErr) {
+		t.Fatalf("projection infrastructure failure was replaced: %v", err)
+	}
+	if errors.Is(err, projectionrebuildsvc.ErrProjectionValidation) {
+		t.Fatalf("infrastructure failure was misclassified as data divergence: %v", err)
+	}
+}
+
 func TestRebuildCatchesUpEventsCommittedDuringSnapshotBeforeAliasSwitch(t *testing.T) {
 	t.Parallel()
 
@@ -185,10 +205,11 @@ func (s *fakeSource) SaveProjectionCheckpoint(_ context.Context, _, _ string, va
 }
 
 type fakeTarget struct {
-	documents map[string][]byte
-	corrupt   bool
-	alias     string
-	version   string
+	documents   map[string][]byte
+	corrupt     bool
+	validateErr error
+	alias       string
+	version     string
 }
 
 func newFakeTarget() *fakeTarget {
@@ -211,6 +232,9 @@ func (t *fakeTarget) ValidateVersion(
 	_ string,
 	items []iprojectionoutbox.Item,
 ) error {
+	if t.validateErr != nil {
+		return t.validateErr
+	}
 	for _, item := range items {
 		if !bytes.Equal(t.documents[iprojectionoutbox.DocumentID(item)], item.Payload) {
 			return projectionrebuildsvc.ErrProjectionValidation

--- a/bkn-trace/agent-observability/src/domain/service/projectorsvc/worker.go
+++ b/bkn-trace/agent-observability/src/domain/service/projectorsvc/worker.go
@@ -3,6 +3,7 @@ package projectorsvc
 import (
 	"context"
 	"crypto/rand"
+	"errors"
 	"math/big"
 	"time"
 
@@ -72,6 +73,9 @@ func (w *Worker) RunOnce(ctx context.Context) (RunResult, error) {
 		projectionErr := w.sink.Project(ctx, item)
 		if projectionErr == nil {
 			if err := w.store.MarkDelivered(ctx, item); err != nil {
+				if errors.Is(err, iprojectionoutbox.ErrLeaseLost) {
+					continue
+				}
 				return result, err
 			}
 			result.Delivered++
@@ -89,6 +93,9 @@ func (w *Worker) RunOnce(ctx context.Context) (RunResult, error) {
 				failureClass = "retry_window_expired"
 			}
 			if err := w.store.MoveToDLQ(ctx, item, failureClass); err != nil {
+				if errors.Is(err, iprojectionoutbox.ErrLeaseLost) {
+					continue
+				}
 				return result, err
 			}
 			result.Dead++
@@ -96,6 +103,9 @@ func (w *Worker) RunOnce(ctx context.Context) (RunResult, error) {
 		}
 		delay := w.options.FullJitter(retryDelay(item.Attempts + 1))
 		if err := w.store.MarkRetry(ctx, item, "projection_failed", w.options.Now().UTC().Add(delay)); err != nil {
+			if errors.Is(err, iprojectionoutbox.ErrLeaseLost) {
+				continue
+			}
 			return result, err
 		}
 		result.Retried++

--- a/bkn-trace/agent-observability/src/domain/service/projectorsvc/worker.go
+++ b/bkn-trace/agent-observability/src/domain/service/projectorsvc/worker.go
@@ -1,0 +1,148 @@
+package projectorsvc
+
+import (
+	"context"
+	"crypto/rand"
+	"math/big"
+	"time"
+
+	"github.com/openbkn-ai/bkn-foundry/bkn-trace/agent-observability/src/port/driven/icoremetrics"
+	"github.com/openbkn-ai/bkn-foundry/bkn-trace/agent-observability/src/port/driven/iprojectionoutbox"
+)
+
+type WorkerOptions struct {
+	Now          func() time.Time
+	BatchSize    int
+	LockDuration time.Duration
+	MaxAttempts  uint32
+	MaxRetryAge  time.Duration
+	FullJitter   func(max time.Duration) time.Duration
+	Metrics      icoremetrics.Recorder
+}
+
+type Worker struct {
+	store   iprojectionoutbox.Store
+	sink    iprojectionoutbox.Sink
+	options WorkerOptions
+}
+
+type RunResult struct {
+	Leased    int
+	Delivered int
+	Retried   int
+	Dead      int
+}
+
+func NewWorker(store iprojectionoutbox.Store, sink iprojectionoutbox.Sink, options WorkerOptions) *Worker {
+	if options.Now == nil {
+		options.Now = time.Now
+	}
+	if options.BatchSize <= 0 {
+		options.BatchSize = 100
+	}
+	if options.LockDuration <= 0 {
+		options.LockDuration = 30 * time.Second
+	}
+	if options.MaxAttempts == 0 {
+		options.MaxAttempts = 10
+	}
+	if options.MaxRetryAge <= 0 {
+		options.MaxRetryAge = 24 * time.Hour
+	}
+	if options.FullJitter == nil {
+		options.FullJitter = fullJitter
+	}
+	if options.Metrics == nil {
+		options.Metrics = icoremetrics.Noop{}
+	}
+	return &Worker{store: store, sink: sink, options: options}
+}
+
+func (w *Worker) RunOnce(ctx context.Context) (RunResult, error) {
+	items, err := w.store.Lease(ctx, w.options.BatchSize, w.options.LockDuration)
+	if err != nil {
+		return RunResult{}, err
+	}
+	result := RunResult{Leased: len(items)}
+	var oldest time.Time
+	for _, item := range items {
+		if !item.CreatedAt.IsZero() && (oldest.IsZero() || item.CreatedAt.Before(oldest)) {
+			oldest = item.CreatedAt
+		}
+		projectionErr := w.sink.Project(ctx, item)
+		if projectionErr == nil {
+			if err := w.store.MarkDelivered(ctx, item); err != nil {
+				return result, err
+			}
+			result.Delivered++
+			continue
+		}
+		retryWindowExpired := !item.CreatedAt.IsZero() &&
+			!item.CreatedAt.Add(w.options.MaxRetryAge).After(w.options.Now().UTC())
+		permanent := iprojectionoutbox.IsPermanent(projectionErr)
+		attemptsExhausted := item.Attempts+1 >= w.options.MaxAttempts
+		if permanent || attemptsExhausted || retryWindowExpired {
+			failureClass := "retry_attempts_exhausted"
+			if permanent {
+				failureClass = "permanent_projection_error"
+			} else if retryWindowExpired {
+				failureClass = "retry_window_expired"
+			}
+			if err := w.store.MoveToDLQ(ctx, item, failureClass); err != nil {
+				return result, err
+			}
+			result.Dead++
+			continue
+		}
+		delay := w.options.FullJitter(retryDelay(item.Attempts + 1))
+		if err := w.store.MarkRetry(ctx, item, "projection_failed", w.options.Now().UTC().Add(delay)); err != nil {
+			return result, err
+		}
+		result.Retried++
+	}
+	if !oldest.IsZero() {
+		lag := w.options.Now().UTC().Sub(oldest).Seconds()
+		if lag < 0 {
+			lag = 0
+		}
+		w.options.Metrics.Set(icoremetrics.ProjectionLagSeconds, lag)
+	} else {
+		w.options.Metrics.Set(icoremetrics.ProjectionLagSeconds, 0)
+	}
+	return result, nil
+}
+
+func (w *Worker) Drain(ctx context.Context) (RunResult, error) {
+	var total RunResult
+	for {
+		result, err := w.RunOnce(ctx)
+		total.Leased += result.Leased
+		total.Delivered += result.Delivered
+		total.Retried += result.Retried
+		total.Dead += result.Dead
+		if err != nil {
+			return total, err
+		}
+		if result.Leased == 0 {
+			return total, nil
+		}
+	}
+}
+
+func fullJitter(max time.Duration) time.Duration {
+	if max <= 0 {
+		return 0
+	}
+	value, err := rand.Int(rand.Reader, big.NewInt(int64(max)))
+	if err != nil {
+		return max / 2
+	}
+	return time.Duration(value.Int64())
+}
+
+func retryDelay(attempt uint32) time.Duration {
+	if attempt > 8 {
+		attempt = 8
+	}
+	return time.Second * time.Duration(1<<attempt)
+}

--- a/bkn-trace/agent-observability/src/domain/service/projectorsvc/worker_test.go
+++ b/bkn-trace/agent-observability/src/domain/service/projectorsvc/worker_test.go
@@ -136,13 +136,39 @@ func TestRetryWindowExpiryMovesEventToDLQ(t *testing.T) {
 	}
 }
 
+func TestProjectionWorkerContinuesAfterLeaseIsLost(t *testing.T) {
+	t.Parallel()
+
+	store := &fakeOutboxStore{
+		items: []iprojectionoutbox.Item{
+			{ID: 1, EventID: "evt-lost"},
+			{ID: 2, EventID: "evt-current"},
+		},
+		markDeliveredErrors: map[uint64]error{
+			1: iprojectionoutbox.ErrLeaseLost,
+		},
+	}
+	worker := projectorsvc.NewWorker(
+		store, &fakeProjectionSink{}, projectorsvc.WorkerOptions{},
+	)
+
+	result, err := worker.RunOnce(context.Background())
+	if err != nil {
+		t.Fatalf("lease loss must not abort the batch: %v", err)
+	}
+	if result.Delivered != 1 || len(store.delivered) != 1 || store.delivered[0] != 2 {
+		t.Fatalf("worker did not continue after lease loss: result=%#v store=%#v", result, store)
+	}
+}
+
 type fakeOutboxStore struct {
-	items     []iprojectionoutbox.Item
-	retried   []iprojectionoutbox.Item
-	delivered []uint64
-	dead      []uint64
-	deadCode  string
-	retryAt   time.Time
+	items               []iprojectionoutbox.Item
+	retried             []iprojectionoutbox.Item
+	delivered           []uint64
+	dead                []uint64
+	deadCode            string
+	retryAt             time.Time
+	markDeliveredErrors map[uint64]error
 }
 
 func (s *fakeOutboxStore) Lease(_ context.Context, _ int, _ time.Duration) ([]iprojectionoutbox.Item, error) {
@@ -151,6 +177,9 @@ func (s *fakeOutboxStore) Lease(_ context.Context, _ int, _ time.Duration) ([]ip
 	return items, nil
 }
 func (s *fakeOutboxStore) MarkDelivered(_ context.Context, item iprojectionoutbox.Item) error {
+	if err := s.markDeliveredErrors[item.ID]; err != nil {
+		return err
+	}
 	s.delivered = append(s.delivered, item.ID)
 	return nil
 }

--- a/bkn-trace/agent-observability/src/domain/service/projectorsvc/worker_test.go
+++ b/bkn-trace/agent-observability/src/domain/service/projectorsvc/worker_test.go
@@ -1,0 +1,182 @@
+package projectorsvc_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/openbkn-ai/bkn-foundry/bkn-trace/agent-observability/src/domain/service/projectorsvc"
+	"github.com/openbkn-ai/bkn-foundry/bkn-trace/agent-observability/src/port/driven/icoremetrics"
+	"github.com/openbkn-ai/bkn-foundry/bkn-trace/agent-observability/src/port/driven/iprojectionoutbox"
+)
+
+func TestProjectionFailureIsRetriedWithoutChangingDurableEvent(t *testing.T) {
+	t.Parallel()
+
+	store := &fakeOutboxStore{items: []iprojectionoutbox.Item{{
+		ID: 1, EventID: "evt-1", Payload: []byte(`{"event_id":"evt-1"}`), Attempts: 0,
+		CreatedAt: time.Date(2026, 7, 30, 10, 0, 0, 0, time.UTC),
+	}}}
+	sink := &fakeProjectionSink{err: errors.New("OpenSearch unavailable")}
+	worker := projectorsvc.NewWorker(store, sink, projectorsvc.WorkerOptions{
+		Now:         func() time.Time { return time.Date(2026, 7, 30, 10, 1, 0, 0, time.UTC) },
+		MaxAttempts: 3,
+		FullJitter: func(max time.Duration) time.Duration {
+			return max / 4
+		},
+	})
+
+	result, err := worker.RunOnce(context.Background())
+	if err != nil {
+		t.Fatalf("run worker: %v", err)
+	}
+	if result.Retried != 1 || result.Delivered != 0 || len(store.retried) != 1 {
+		t.Fatalf("unexpected projection result: %#v", result)
+	}
+	if store.retried[0].EventID != "evt-1" || store.retried[0].Attempts != 0 {
+		t.Fatal("worker changed the durable projection payload")
+	}
+	expectedRetryAt := time.Date(2026, 7, 30, 10, 1, 0, 0, time.UTC).
+		Add(500 * time.Millisecond)
+	if !store.retryAt.Equal(expectedRetryAt) {
+		t.Fatalf("retry did not use full-jitter delay: %s", store.retryAt)
+	}
+}
+
+func TestProjectionWorkerRecordsOldestLeasedEventLag(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 7, 30, 10, 1, 0, 0, time.UTC)
+	store := &fakeOutboxStore{items: []iprojectionoutbox.Item{{
+		ID: 1, EventID: "evt-lag", Payload: []byte(`{}`), CreatedAt: now.Add(-45 * time.Second),
+	}}}
+	metrics := &projectionTestMetrics{gauges: make(map[string]float64)}
+	worker := projectorsvc.NewWorker(store, &fakeProjectionSink{}, projectorsvc.WorkerOptions{
+		Now: func() time.Time { return now }, Metrics: metrics,
+	})
+	if _, err := worker.RunOnce(context.Background()); err != nil {
+		t.Fatalf("run projection worker: %v", err)
+	}
+	if metrics.gauges[icoremetrics.ProjectionLagSeconds] != 45 {
+		t.Fatalf("unexpected projection lag: %#v", metrics.gauges)
+	}
+}
+
+func TestPermanentProjectionFailureMovesDirectlyToDLQ(t *testing.T) {
+	t.Parallel()
+
+	store := &fakeOutboxStore{items: []iprojectionoutbox.Item{{ID: 1, EventID: "evt-1"}}}
+	sink := &fakeProjectionSink{
+		err: iprojectionoutbox.Permanent(errors.New("invalid projection document")),
+	}
+	worker := projectorsvc.NewWorker(store, sink, projectorsvc.WorkerOptions{MaxAttempts: 10})
+
+	result, err := worker.RunOnce(context.Background())
+	if err != nil {
+		t.Fatalf("run worker: %v", err)
+	}
+	if result.Dead != 1 || result.Retried != 0 || len(store.dead) != 1 {
+		t.Fatalf("permanent failure was not moved directly to DLQ: %#v", result)
+	}
+	if store.deadCode != "permanent_projection_error" {
+		t.Fatalf("permanent failure classification was lost: %q", store.deadCode)
+	}
+}
+
+func TestDrainProjectsAllCurrentlyAvailableItems(t *testing.T) {
+	t.Parallel()
+
+	store := &fakeOutboxStore{
+		items: []iprojectionoutbox.Item{
+			{ID: 1, EventID: "evt-1"},
+			{ID: 2, EventID: "evt-2"},
+			{ID: 3, EventID: "evt-3"},
+		},
+	}
+	worker := projectorsvc.NewWorker(
+		store, &fakeProjectionSink{}, projectorsvc.WorkerOptions{BatchSize: 2},
+	)
+
+	result, err := worker.Drain(context.Background())
+	if err != nil {
+		t.Fatalf("drain: %v", err)
+	}
+	if result.Delivered != 3 || len(store.delivered) != 3 || result.Leased != 3 {
+		t.Fatalf("drain did not project all available items: %#v", result)
+	}
+}
+
+func TestRetryWindowExpiryMovesEventToDLQ(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 7, 30, 10, 0, 0, 0, time.UTC)
+	store := &fakeOutboxStore{items: []iprojectionoutbox.Item{{
+		ID: 1, EventID: "evt-expired", CreatedAt: now.Add(-24 * time.Hour),
+	}}}
+	worker := projectorsvc.NewWorker(
+		store,
+		&fakeProjectionSink{err: errors.New("OpenSearch unavailable")},
+		projectorsvc.WorkerOptions{
+			Now:         func() time.Time { return now },
+			MaxAttempts: 100,
+			MaxRetryAge: 24 * time.Hour,
+		},
+	)
+
+	result, err := worker.RunOnce(context.Background())
+	if err != nil {
+		t.Fatalf("run worker: %v", err)
+	}
+	if result.Dead != 1 || result.Retried != 0 {
+		t.Fatalf("expired retry window did not move event to DLQ: %#v", result)
+	}
+	if store.deadCode != "retry_window_expired" {
+		t.Fatalf("retry-window failure classification was lost: %q", store.deadCode)
+	}
+}
+
+type fakeOutboxStore struct {
+	items     []iprojectionoutbox.Item
+	retried   []iprojectionoutbox.Item
+	delivered []uint64
+	dead      []uint64
+	deadCode  string
+	retryAt   time.Time
+}
+
+func (s *fakeOutboxStore) Lease(_ context.Context, _ int, _ time.Duration) ([]iprojectionoutbox.Item, error) {
+	items := append([]iprojectionoutbox.Item(nil), s.items...)
+	s.items = nil
+	return items, nil
+}
+func (s *fakeOutboxStore) MarkDelivered(_ context.Context, item iprojectionoutbox.Item) error {
+	s.delivered = append(s.delivered, item.ID)
+	return nil
+}
+func (s *fakeOutboxStore) MarkRetry(_ context.Context, item iprojectionoutbox.Item, _ string, retryAt time.Time) error {
+	s.retried = append(s.retried, item)
+	s.retryAt = retryAt
+	return nil
+}
+func (s *fakeOutboxStore) MoveToDLQ(_ context.Context, item iprojectionoutbox.Item, code string) error {
+	s.dead = append(s.dead, item.ID)
+	s.deadCode = code
+	return nil
+}
+
+type fakeProjectionSink struct{ err error }
+
+func (s *fakeProjectionSink) Project(context.Context, iprojectionoutbox.Item) error {
+	return s.err
+}
+
+type projectionTestMetrics struct {
+	gauges map[string]float64
+}
+
+func (*projectionTestMetrics) Increment(string)   {}
+func (*projectionTestMetrics) Add(string, uint64) {}
+func (m *projectionTestMetrics) Set(name string, value float64) {
+	m.gauges[name] = value
+}

--- a/bkn-trace/agent-observability/src/domain/service/sessionsvc/errors.go
+++ b/bkn-trace/agent-observability/src/domain/service/sessionsvc/errors.go
@@ -1,0 +1,41 @@
+package sessionsvc
+
+import "errors"
+
+type ErrorCode string
+
+const (
+	CodeConversationRequired      ErrorCode = "conversation_required"
+	CodeConversationNotFound      ErrorCode = "conversation_not_found"
+	CodeConversationClosed        ErrorCode = "conversation_closed"
+	CodeConversationExpired       ErrorCode = "conversation_expired"
+	CodeConversationOwnerMismatch ErrorCode = "conversation_owner_mismatch"
+	CodeInteractionInProgress     ErrorCode = "interaction_in_progress"
+	CodeInteractionRequired       ErrorCode = "interaction_required"
+	CodeInteractionTerminal       ErrorCode = "interaction_terminal"
+	CodeOperationRequired         ErrorCode = "operation_required"
+	CodeIdempotencyConflict       ErrorCode = "idempotency_conflict"
+	CodeReceiptPending            ErrorCode = "receipt_pending"
+	CodeTerminalConflict          ErrorCode = "terminal_conflict"
+	CodeClosureManifestInvalid    ErrorCode = "closure_manifest_invalid"
+	CodeResourceNotDisclosed      ErrorCode = "resource_not_disclosed"
+)
+
+type DomainError struct {
+	Code          ErrorCode
+	Message       string
+	CurrentStatus string
+}
+
+func (e *DomainError) Error() string {
+	return e.Message
+}
+
+func IsCode(err error, code ErrorCode) bool {
+	var domainErr *DomainError
+	return errors.As(err, &domainErr) && domainErr.Code == code
+}
+
+func domainError(code ErrorCode, message string) error {
+	return &DomainError{Code: code, Message: message}
+}

--- a/bkn-trace/agent-observability/src/domain/service/sessionsvc/service.go
+++ b/bkn-trace/agent-observability/src/domain/service/sessionsvc/service.go
@@ -1,0 +1,1291 @@
+package sessionsvc
+
+import (
+	"context"
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"slices"
+	"time"
+
+	"github.com/openbkn-ai/bkn-foundry/bkn-trace/agent-observability/src/domain/valueobject/sessionvo"
+	"github.com/openbkn-ai/bkn-foundry/bkn-trace/agent-observability/src/port/driven/icoremetrics"
+	"github.com/openbkn-ai/bkn-foundry/bkn-trace/agent-observability/src/port/driven/isessionstore"
+)
+
+var ErrInvalidOwner = errors.New("trusted conversation owner is incomplete")
+
+const (
+	maxOperationsPerInteraction   = 128
+	maxClaimsPerInteraction       = 32
+	maxEvidenceRefsPerInteraction = 2048
+)
+
+type Options struct {
+	Now                     func() time.Time
+	NewID                   func(prefix string) string
+	EvidenceCollectionState func() string
+	Metrics                 icoremetrics.Recorder
+}
+
+type Service struct {
+	store                   isessionstore.Store
+	now                     func() time.Time
+	newID                   func(string) string
+	evidenceCollectionState func() string
+	metrics                 icoremetrics.Recorder
+}
+
+func New(store isessionstore.Store, options Options) *Service {
+	now := options.Now
+	if now == nil {
+		now = time.Now
+	}
+	newID := options.NewID
+	if newID == nil {
+		newID = randomID
+	}
+	evidenceCollectionState := options.EvidenceCollectionState
+	if evidenceCollectionState == nil {
+		evidenceCollectionState = func() string { return "enabled" }
+	}
+	metrics := options.Metrics
+	if metrics == nil {
+		metrics = icoremetrics.Noop{}
+	}
+	return &Service{
+		store: store, now: now, newID: newID,
+		evidenceCollectionState: evidenceCollectionState,
+		metrics:                 metrics,
+	}
+}
+
+type EnsureConversationCommand struct {
+	Owner                   sessionvo.Owner
+	ExternalConversationKey string
+	IdempotencyKey          string
+	OneShot                 bool
+}
+
+type CloseConversationCommand struct {
+	Owner          sessionvo.Owner
+	ConversationID string
+	IdempotencyKey string
+}
+
+type ResumeConversationCommand struct {
+	Owner          sessionvo.Owner
+	ConversationID string
+}
+
+type StartInteractionCommand struct {
+	Owner          sessionvo.Owner
+	ConversationID string
+	IdempotencyKey string
+	LeaseDuration  time.Duration
+}
+
+type TerminateInteractionCommand struct {
+	Owner                  sessionvo.Owner
+	InteractionID          string
+	Status                 sessionvo.InteractionStatus
+	TerminalIdempotencyKey string
+	LeaseToken             string
+	LeaseEpoch             uint64
+	Manifest               sessionvo.ClosureManifest
+}
+
+type EnsureOperationCommand struct {
+	Owner               sessionvo.Owner
+	ConversationID      string
+	InteractionID       string
+	OperationKey        string
+	ToolName            string
+	NormalizedInputHash string
+	ParentOperationID   string
+	CausationEventIDs   []string
+	Required            bool
+	LeaseToken          string
+	LeaseEpoch          uint64
+}
+
+type StartAttemptCommand struct {
+	Owner       sessionvo.Owner
+	OperationID string
+	LeaseToken  string
+	LeaseEpoch  uint64
+}
+
+type FinishAttemptCommand struct {
+	Owner                sessionvo.Owner
+	OperationID          string
+	Attempt              uint32
+	ReceiptID            string
+	PayloadHash          string
+	EvidenceDurability   sessionvo.EvidenceDurability
+	Retryable            bool
+	RequestID            string
+	TraceID              string
+	ObservedEvidenceRefs []string
+	BusinessRefs         []sessionvo.BusinessRef
+	ArtifactRefs         []string
+	PartialReasons       []string
+}
+
+func (s *Service) EnsureCurrentConversation(ctx context.Context, command EnsureConversationCommand) (sessionvo.Conversation, error) {
+	if err := validateOwner(command.Owner); err != nil {
+		return sessionvo.Conversation{}, err
+	}
+	if command.ExternalConversationKey == "" {
+		return sessionvo.Conversation{}, domainError(CodeConversationRequired, "external conversation key is required")
+	}
+
+	var result sessionvo.Conversation
+	created := false
+	err := s.store.WithinTransaction(ctx, func(tx isessionstore.Transaction) error {
+		current, found := tx.FindCurrentConversation(command.Owner, command.ExternalConversationKey)
+		if found && current.Status == sessionvo.ConversationActive {
+			result = current
+			return nil
+		}
+
+		generation := uint64(1)
+		if found {
+			generation = current.Generation + 1
+		}
+		now := tx.Now()
+		result = sessionvo.Conversation{
+			ID:                      s.newID("conv"),
+			Owner:                   command.Owner,
+			ExternalConversationKey: command.ExternalConversationKey,
+			Generation:              generation,
+			Status:                  sessionvo.ConversationActive,
+			OneShot:                 command.OneShot,
+			RowVersion:              1,
+			CreatedAt:               now,
+			UpdatedAt:               now,
+		}
+		created = true
+		tx.SaveConversation(result)
+		return s.appendProjection(tx, "conversation", result.ID, "conversation.created", result)
+	})
+	s.observeLifecycleError(err)
+	if err == nil && created {
+		s.metrics.Increment(icoremetrics.ConversationsTotal)
+	}
+	return result, err
+}
+
+func (s *Service) CreateNewGeneration(ctx context.Context, command EnsureConversationCommand) (sessionvo.Conversation, error) {
+	if err := validateOwner(command.Owner); err != nil {
+		return sessionvo.Conversation{}, err
+	}
+	if command.ExternalConversationKey == "" {
+		return sessionvo.Conversation{}, domainError(CodeConversationRequired, "external conversation key is required")
+	}
+	if command.IdempotencyKey == "" {
+		return sessionvo.Conversation{}, domainError(CodeConversationRequired, "idempotency key is required")
+	}
+	const idempotencyScope = "conversation.create_new_generation"
+	requestHash := hashValue(struct {
+		ExternalConversationKey string `json:"external_conversation_key"`
+		OneShot                 bool   `json:"one_shot"`
+	}{
+		ExternalConversationKey: command.ExternalConversationKey,
+		OneShot:                 command.OneShot,
+	})
+	var result sessionvo.Conversation
+	created := false
+	err := s.store.WithinTransaction(ctx, func(tx isessionstore.Transaction) error {
+		if record, found := tx.FindIdempotency(
+			idempotencyScope, command.Owner, command.ExternalConversationKey, command.IdempotencyKey,
+		); found {
+			if record.RequestHash != requestHash || record.ResourceType != "conversation" {
+				return domainError(CodeIdempotencyConflict, "idempotency key was already used with a different request")
+			}
+			conversation, found := tx.FindConversation(record.ResourceID)
+			if !found {
+				return domainError(CodeConversationNotFound, "idempotency result conversation was not found")
+			}
+			result = conversation
+			return nil
+		}
+		current, found := tx.FindCurrentConversation(command.Owner, command.ExternalConversationKey)
+		generation := uint64(1)
+		now := tx.Now()
+		if found {
+			if current.Status == sessionvo.ConversationActive {
+				if _, active := tx.FindActiveInteraction(current.ID); active {
+					return domainError(CodeInteractionInProgress, "complete or cancel the active interaction before creating a new generation")
+				}
+				current.Status = sessionvo.ConversationClosed
+				current.RowVersion++
+				current.UpdatedAt = now
+				current.ClosedAt = &now
+				tx.SaveConversation(current)
+				if err := s.appendProjection(tx, "conversation", current.ID, "conversation.closed", current); err != nil {
+					return err
+				}
+			}
+			generation = current.Generation + 1
+		}
+		result = sessionvo.Conversation{
+			ID: s.newID("conv"), Owner: command.Owner,
+			ExternalConversationKey: command.ExternalConversationKey,
+			Generation:              generation, Status: sessionvo.ConversationActive,
+			OneShot: command.OneShot, RowVersion: 1, CreatedAt: now, UpdatedAt: now,
+		}
+		created = true
+		tx.SaveConversation(result)
+		tx.SaveIdempotency(sessionvo.IdempotencyRecord{
+			Scope: idempotencyScope, Owner: command.Owner,
+			ExternalConversationKey: command.ExternalConversationKey,
+			IdempotencyKey:          command.IdempotencyKey, RequestHash: requestHash,
+			ResourceType: "conversation", ResourceID: result.ID, CreatedAt: now,
+		})
+		return s.appendProjection(tx, "conversation", result.ID, "conversation.created", result)
+	})
+	s.observeLifecycleError(err)
+	if err == nil && created {
+		s.metrics.Increment(icoremetrics.ConversationsTotal)
+	}
+	return result, err
+}
+
+func (s *Service) GetConversation(ctx context.Context, owner sessionvo.Owner, conversationID string) (sessionvo.Conversation, error) {
+	var result sessionvo.Conversation
+	err := s.store.WithinTransaction(ctx, func(tx isessionstore.Transaction) error {
+		conversation, err := ownedConversation(tx, owner, conversationID)
+		if err != nil {
+			return err
+		}
+		result = conversation
+		return nil
+	})
+	s.observeLifecycleError(err)
+	return result, err
+}
+
+func (s *Service) ResumeConversation(ctx context.Context, command ResumeConversationCommand) (sessionvo.Conversation, error) {
+	var result sessionvo.Conversation
+	err := s.store.WithinTransaction(ctx, func(tx isessionstore.Transaction) error {
+		conversation, err := ownedConversation(tx, command.Owner, command.ConversationID)
+		if err != nil {
+			return err
+		}
+		switch conversation.Status {
+		case sessionvo.ConversationActive:
+			result = conversation
+			return nil
+		case sessionvo.ConversationExpired:
+			return domainError(CodeConversationExpired, "conversation expired; create or resume another conversation")
+		default:
+			return domainError(CodeConversationClosed, "conversation is closed; create a new generation")
+		}
+	})
+	return result, err
+}
+
+func (s *Service) ListConversations(ctx context.Context, owner sessionvo.Owner, limit int) ([]sessionvo.Conversation, error) {
+	if err := validateOwner(owner); err != nil {
+		return nil, err
+	}
+	if limit <= 0 || limit > 100 {
+		limit = 50
+	}
+	var result []sessionvo.Conversation
+	err := s.store.WithinTransaction(ctx, func(tx isessionstore.Transaction) error {
+		result = tx.ListConversations(owner, limit)
+		return nil
+	})
+	return result, err
+}
+
+func (s *Service) ListRequests(ctx context.Context, owner sessionvo.Owner, limit int) ([]sessionvo.RequestSummary, error) {
+	if err := validateOwner(owner); err != nil {
+		return nil, err
+	}
+	if limit <= 0 || limit > 100 {
+		limit = 50
+	}
+	var result []sessionvo.RequestSummary
+	err := s.store.WithinTransaction(ctx, func(tx isessionstore.Transaction) error {
+		result = tx.ListRequests(owner, limit)
+		return nil
+	})
+	return result, err
+}
+
+func (s *Service) GetRequest(ctx context.Context, owner sessionvo.Owner, requestID string) (sessionvo.RequestSummary, error) {
+	if err := validateOwner(owner); err != nil {
+		return sessionvo.RequestSummary{}, err
+	}
+	var result sessionvo.RequestSummary
+	err := s.store.WithinTransaction(ctx, func(tx isessionstore.Transaction) error {
+		value, found := tx.FindRequest(owner, requestID)
+		if !found {
+			return domainError(CodeResourceNotDisclosed, "request was not found in the authorized scope")
+		}
+		result = value
+		return nil
+	})
+	return result, err
+}
+
+func (s *Service) GetInteraction(ctx context.Context, owner sessionvo.Owner, interactionID string) (sessionvo.Interaction, error) {
+	var result sessionvo.Interaction
+	err := s.store.WithinTransaction(ctx, func(tx isessionstore.Transaction) error {
+		interaction, found := tx.PeekInteraction(interactionID)
+		if !found {
+			return domainError(CodeInteractionRequired, "interaction was not found")
+		}
+		if _, err := ownedConversation(tx, owner, interaction.ConversationID); err != nil {
+			return err
+		}
+		result = interaction
+		return nil
+	})
+	return result, err
+}
+
+func (s *Service) GetOperation(ctx context.Context, owner sessionvo.Owner, operationID string) (sessionvo.Operation, error) {
+	var result sessionvo.Operation
+	err := s.store.WithinTransaction(ctx, func(tx isessionstore.Transaction) error {
+		operation, found := tx.PeekOperation(operationID)
+		if !found {
+			return domainError(CodeInteractionRequired, "operation was not found")
+		}
+		if _, err := ownedConversation(tx, owner, operation.ConversationID); err != nil {
+			return err
+		}
+		result = operation
+		return nil
+	})
+	return result, err
+}
+
+func (s *Service) GetReceipt(ctx context.Context, owner sessionvo.Owner, receiptID string) (sessionvo.Receipt, error) {
+	var result sessionvo.Receipt
+	err := s.store.WithinTransaction(ctx, func(tx isessionstore.Transaction) error {
+		receipt, found := tx.PeekReceipt(receiptID)
+		if !found {
+			return domainError(CodeInteractionRequired, "receipt was not found")
+		}
+		if _, err := ownedConversation(tx, owner, receipt.ConversationID); err != nil {
+			return err
+		}
+		result = receipt
+		return nil
+	})
+	return result, err
+}
+
+func (s *Service) CloseConversation(ctx context.Context, command CloseConversationCommand) (sessionvo.Conversation, error) {
+	var result sessionvo.Conversation
+	err := s.store.WithinTransaction(ctx, func(tx isessionstore.Transaction) error {
+		conversation, err := ownedConversation(tx, command.Owner, command.ConversationID)
+		if err != nil {
+			return err
+		}
+		if conversation.Status == sessionvo.ConversationClosed {
+			result = conversation
+			return nil
+		}
+		if conversation.Status == sessionvo.ConversationExpired {
+			return domainError(CodeConversationExpired, "expired conversation cannot be closed")
+		}
+		if _, found := tx.FindActiveInteraction(conversation.ID); found {
+			return domainError(CodeInteractionInProgress, "complete or cancel the active interaction before closing the conversation")
+		}
+		now := tx.Now()
+		conversation.Status = sessionvo.ConversationClosed
+		conversation.RowVersion++
+		conversation.UpdatedAt = now
+		conversation.ClosedAt = &now
+		tx.SaveConversation(conversation)
+		if err := s.appendProjection(tx, "conversation", conversation.ID, "conversation.closed", conversation); err != nil {
+			return err
+		}
+		result = conversation
+		return nil
+	})
+	s.observeLifecycleError(err)
+	return result, err
+}
+
+func (s *Service) StartInteraction(ctx context.Context, command StartInteractionCommand) (sessionvo.Interaction, error) {
+	if command.IdempotencyKey == "" {
+		return sessionvo.Interaction{}, domainError(CodeInteractionRequired, "idempotency key is required")
+	}
+	var result sessionvo.Interaction
+	created := false
+	err := s.store.WithinTransaction(ctx, func(tx isessionstore.Transaction) error {
+		conversation, err := ownedConversation(tx, command.Owner, command.ConversationID)
+		if err != nil {
+			return err
+		}
+		if err := requireActiveConversation(conversation); err != nil {
+			return err
+		}
+		if existing, found := tx.FindInteractionByStartKey(conversation.ID, command.IdempotencyKey); found {
+			result = existing
+			return nil
+		}
+		if _, found := tx.FindActiveInteraction(conversation.ID); found {
+			return domainError(CodeInteractionInProgress, "the conversation already has an active interaction")
+		}
+		leaseDuration := command.LeaseDuration
+		if leaseDuration <= 0 {
+			leaseDuration = 5 * time.Minute
+		}
+		now := tx.Now()
+		result = sessionvo.Interaction{
+			ID:                  s.newID("int"),
+			ConversationID:      conversation.ID,
+			Ordinal:             tx.NextInteractionOrdinal(conversation.ID),
+			ExecutionStatus:     sessionvo.InteractionActive,
+			EvidenceStatus:      sessionvo.EvidenceNotApplicable,
+			StartIdempotencyKey: command.IdempotencyKey,
+			LeaseToken:          s.newID("lease"),
+			LeaseEpoch:          1,
+			LeaseVersion:        1,
+			LeaseExpiresAt:      now.Add(leaseDuration),
+			RowVersion:          1,
+			CreatedAt:           now,
+			UpdatedAt:           now,
+		}
+		created = true
+		tx.SaveInteraction(result)
+		return s.appendProjection(tx, "interaction", result.ID, "interaction.started", result)
+	})
+	s.observeLifecycleError(err)
+	if err == nil && created {
+		s.metrics.Increment(icoremetrics.InteractionsTotal)
+	}
+	return result, err
+}
+
+func (s *Service) TerminateInteraction(ctx context.Context, command TerminateInteractionCommand) (sessionvo.Interaction, error) {
+	if !validTerminalStatus(command.Status) {
+		return sessionvo.Interaction{}, domainError(CodeInteractionTerminal, "requested status is not terminal")
+	}
+	if command.LeaseToken == "" || command.LeaseEpoch == 0 {
+		return sessionvo.Interaction{}, domainError(CodeTerminalConflict, "interaction lease token and epoch are required")
+	}
+	if command.TerminalIdempotencyKey == "" {
+		return sessionvo.Interaction{}, domainError(CodeIdempotencyConflict, "terminal idempotency key is required")
+	}
+	if s.evidenceCollectionState() == "not_collected_due_to_license" {
+		command.Manifest.SystemPartialReasons = appendUnique(
+			command.Manifest.SystemPartialReasons, "not_collected_due_to_license",
+		)
+	}
+	payloadHash := hashValue(struct {
+		Status   sessionvo.InteractionStatus
+		Manifest sessionvo.ClosureManifest
+	}{command.Status, command.Manifest})
+
+	var result sessionvo.Interaction
+	err := s.store.WithinTransaction(ctx, func(tx isessionstore.Transaction) error {
+		interactionRef, found := tx.PeekInteraction(command.InteractionID)
+		if !found {
+			return domainError(CodeInteractionRequired, "interaction was not found")
+		}
+		conversation, err := ownedConversation(tx, command.Owner, interactionRef.ConversationID)
+		if err != nil {
+			return err
+		}
+		interaction, found := tx.FindInteraction(command.InteractionID)
+		if !found || interaction.ConversationID != conversation.ID {
+			return domainError(CodeInteractionRequired, "interaction was not found")
+		}
+		if interaction.IsTerminal() {
+			if interaction.TerminalIdempotencyKey == command.TerminalIdempotencyKey &&
+				interaction.TerminalPayloadHash == payloadHash {
+				result = interaction
+				return nil
+			}
+			return &DomainError{
+				Code: CodeTerminalConflict, Message: "another terminal transition already won",
+				CurrentStatus: string(interaction.ExecutionStatus),
+			}
+		}
+		if !interaction.LeaseExpiresAt.After(tx.Now()) {
+			return &DomainError{
+				Code: CodeTerminalConflict, Message: "interaction lease has expired",
+				CurrentStatus: string(interaction.ExecutionStatus),
+			}
+		}
+		if command.LeaseToken != interaction.LeaseToken || command.LeaseEpoch != interaction.LeaseEpoch {
+			return &DomainError{
+				Code: CodeTerminalConflict, Message: "stale interaction lease was fenced",
+				CurrentStatus: string(interaction.ExecutionStatus),
+			}
+		}
+		if err := validateClosureManifest(tx, interaction, command.Manifest); err != nil {
+			return err
+		}
+		now := tx.Now()
+		interaction.ExecutionStatus = command.Status
+		interaction.EvidenceStatus = evidenceStatusAtTermination(tx, command.Manifest)
+		interaction.TerminalIdempotencyKey = command.TerminalIdempotencyKey
+		interaction.TerminalPayloadHash = payloadHash
+		interaction.ClosureManifest = &command.Manifest
+		interaction.RowVersion++
+		interaction.LeaseVersion++
+		interaction.UpdatedAt = now
+		interaction.TerminalAt = &now
+		tx.SaveInteraction(interaction)
+		if interaction.EvidenceStatus == sessionvo.EvidenceComplete ||
+			interaction.EvidenceStatus == sessionvo.EvidencePartial ||
+			interaction.EvidenceStatus == sessionvo.EvidenceFailed {
+			trigger := "completion"
+			if command.Manifest.AssemblerDeadline != nil && !command.Manifest.AssemblerDeadline.After(tx.Now()) {
+				trigger = "deadline"
+			}
+			if err := s.freezeAssemblyRevision(tx, interaction, command.Manifest, trigger); err != nil {
+				return err
+			}
+		}
+		if err := s.appendProjection(tx, "interaction", interaction.ID, "interaction."+string(command.Status), interaction); err != nil {
+			return err
+		}
+		if conversation.OneShot {
+			conversation.Status = sessionvo.ConversationClosed
+			conversation.RowVersion++
+			conversation.UpdatedAt = now
+			conversation.ClosedAt = &now
+			tx.SaveConversation(conversation)
+			if err := s.appendProjection(tx, "conversation", conversation.ID, "conversation.closed", conversation); err != nil {
+				return err
+			}
+		}
+		result = interaction
+		return nil
+	})
+	s.observeLifecycleError(err)
+	return result, err
+}
+
+func (s *Service) EnsureOperation(ctx context.Context, command EnsureOperationCommand) (sessionvo.Operation, sessionvo.Receipt, error) {
+	if command.OperationKey == "" || command.NormalizedInputHash == "" || command.ToolName == "" {
+		return sessionvo.Operation{}, sessionvo.Receipt{}, domainError(
+			CodeOperationRequired,
+			"operation key, tool name and normalized input hash are required",
+		)
+	}
+	var operation sessionvo.Operation
+	var receipt sessionvo.Receipt
+	err := s.store.WithinTransaction(ctx, func(tx isessionstore.Transaction) error {
+		conversation, err := ownedConversation(tx, command.Owner, command.ConversationID)
+		if err != nil {
+			return err
+		}
+		if err := requireActiveConversation(conversation); err != nil {
+			return err
+		}
+		interaction, found := tx.FindInteraction(command.InteractionID)
+		if !found || interaction.ConversationID != conversation.ID {
+			return domainError(CodeInteractionRequired, "interaction does not belong to the conversation")
+		}
+		if interaction.ExecutionStatus != sessionvo.InteractionActive ||
+			!interaction.LeaseExpiresAt.After(tx.Now()) {
+			return domainError(CodeInteractionTerminal, "interaction is already terminal")
+		}
+		if command.LeaseToken == "" || command.LeaseEpoch == 0 ||
+			command.LeaseToken != interaction.LeaseToken ||
+			command.LeaseEpoch != interaction.LeaseEpoch {
+			return domainError(CodeTerminalConflict, "stale interaction lease was fenced")
+		}
+		if command.ParentOperationID != "" {
+			parent, found := tx.FindOperation(command.ParentOperationID)
+			if !found || parent.InteractionID != interaction.ID {
+				return domainError(
+					CodeOperationRequired,
+					"parent operation must belong to the same interaction",
+				)
+			}
+		}
+		renewInteractionLease(tx, &interaction)
+		if existing, found := tx.FindOperationByKey(interaction.ID, command.OperationKey); found {
+			if existing.NormalizedInputHash != command.NormalizedInputHash || existing.ToolName != command.ToolName {
+				return domainError(CodeIdempotencyConflict, "operation key was already used with different input")
+			}
+			existingReceipt, receiptFound := tx.FindReceiptByOperationAttempt(existing.ID, existing.Attempt)
+			if !receiptFound {
+				return errors.New("operation receipt invariant violated")
+			}
+			operation, receipt = existing, existingReceipt
+			return nil
+		}
+		if len(tx.ListOperations(interaction.ID)) >= maxOperationsPerInteraction {
+			return domainError(CodeOperationRequired, "interaction operation limit of 128 was reached")
+		}
+		now := tx.Now()
+		operation = sessionvo.Operation{
+			ID: s.newID("op"), ConversationID: conversation.ID, InteractionID: interaction.ID,
+			OperationKey: command.OperationKey, ToolName: command.ToolName,
+			NormalizedInputHash: command.NormalizedInputHash,
+			ParentOperationID:   command.ParentOperationID,
+			CausationEventIDs:   append([]string(nil), command.CausationEventIDs...),
+			Attempt:             1, AttemptStatus: sessionvo.AttemptPending, RowVersion: 1,
+			CreatedAt: now, UpdatedAt: now,
+		}
+		receipt = sessionvo.Receipt{
+			ID: s.newID("rcpt"), SchemaVersion: "3.0.0", Owner: command.Owner,
+			ConversationID: conversation.ID, InteractionID: interaction.ID,
+			OperationID: operation.ID, Attempt: 1, OperationKey: command.OperationKey,
+			ToolName: command.ToolName, NormalizedInputHash: command.NormalizedInputHash,
+			Status: sessionvo.ReceiptPending, EvidenceDurability: sessionvo.DurabilityPending,
+			Required:             command.Required,
+			CausationEventIDs:    cloneStrings(command.CausationEventIDs),
+			ObservedEvidenceRefs: []string{},
+			BusinessRefs:         []sessionvo.BusinessRef{},
+			ArtifactRefs:         []string{},
+			PartialReasons:       []string{},
+			RowVersion:           1,
+			IssuedAt:             now,
+		}
+		tx.SaveOperation(operation)
+		tx.SaveReceipt(receipt)
+		if err := s.appendProjection(tx, "operation", operation.ID, "operation.started", operation); err != nil {
+			return err
+		}
+		if err := s.appendProjection(tx, "receipt", receipt.ID, "receipt.started", receipt); err != nil {
+			return err
+		}
+		interaction.EvidenceStatus = sessionvo.EvidenceAssembling
+		interaction.RowVersion++
+		interaction.UpdatedAt = now
+		tx.SaveInteraction(interaction)
+		return s.appendProjection(
+			tx, "interaction", interaction.ID, "interaction.evidence.assembling",
+			interaction,
+		)
+	})
+	s.observeLifecycleError(err)
+	return operation, receipt, err
+}
+
+func (s *Service) StartOperationAttempt(ctx context.Context, command StartAttemptCommand) (sessionvo.Operation, sessionvo.Receipt, error) {
+	var operation sessionvo.Operation
+	var receipt sessionvo.Receipt
+	err := s.store.WithinTransaction(ctx, func(tx isessionstore.Transaction) error {
+		operationRef, found := tx.PeekOperation(command.OperationID)
+		if !found {
+			return domainError(CodeInteractionRequired, "operation was not found")
+		}
+		conversation, err := ownedConversation(tx, command.Owner, operationRef.ConversationID)
+		if err != nil {
+			return err
+		}
+		if err := requireActiveConversation(conversation); err != nil {
+			return err
+		}
+		interaction, found := tx.FindInteraction(operationRef.InteractionID)
+		if !found {
+			return domainError(CodeInteractionRequired, "interaction was not found")
+		}
+		current, found := tx.FindOperation(command.OperationID)
+		if !found || current.ConversationID != conversation.ID ||
+			current.InteractionID != interaction.ID {
+			return domainError(CodeInteractionRequired, "operation was not found")
+		}
+		if interaction.ExecutionStatus != sessionvo.InteractionActive ||
+			!interaction.LeaseExpiresAt.After(tx.Now()) {
+			return domainError(CodeInteractionTerminal, "interaction is already terminal or its lease expired")
+		}
+		if command.LeaseToken == "" || command.LeaseEpoch == 0 ||
+			command.LeaseToken != interaction.LeaseToken ||
+			command.LeaseEpoch != interaction.LeaseEpoch {
+			return domainError(CodeTerminalConflict, "stale interaction lease was fenced")
+		}
+		renewInteractionLease(tx, &interaction)
+		previousReceipt, found := tx.FindReceiptByOperationAttempt(current.ID, current.Attempt)
+		if !found || previousReceipt.Status != sessionvo.ReceiptFailed || !current.Retryable {
+			return domainError(CodeReceiptPending, "the current attempt has not failed retryably")
+		}
+		now := tx.Now()
+		current.Attempt++
+		current.AttemptStatus = sessionvo.AttemptPending
+		current.Retryable = false
+		current.RowVersion++
+		current.UpdatedAt = now
+		receipt = sessionvo.Receipt{
+			ID: s.newID("rcpt"), SchemaVersion: "3.0.0", Owner: command.Owner,
+			ConversationID: current.ConversationID, InteractionID: current.InteractionID,
+			OperationID: current.ID, Attempt: current.Attempt, OperationKey: current.OperationKey,
+			ToolName: current.ToolName, NormalizedInputHash: current.NormalizedInputHash,
+			Status: sessionvo.ReceiptPending, EvidenceDurability: sessionvo.DurabilityPending,
+			Required:             previousReceipt.Required,
+			CausationEventIDs:    cloneStrings(previousReceipt.CausationEventIDs),
+			ObservedEvidenceRefs: []string{},
+			BusinessRefs:         []sessionvo.BusinessRef{},
+			ArtifactRefs:         []string{},
+			PartialReasons:       []string{},
+			RowVersion:           1,
+			IssuedAt:             now,
+		}
+		tx.SaveOperation(current)
+		tx.SaveReceipt(receipt)
+		if err := s.appendProjection(tx, "operation", current.ID, "operation.attempt.started", current); err != nil {
+			return err
+		}
+		if err := s.appendProjection(tx, "receipt", receipt.ID, "receipt.started", receipt); err != nil {
+			return err
+		}
+		operation = current
+		return nil
+	})
+	s.observeLifecycleError(err)
+	return operation, receipt, err
+}
+
+func renewInteractionLease(tx isessionstore.Transaction, interaction *sessionvo.Interaction) {
+	interaction.LeaseExpiresAt = tx.Now().Add(5 * time.Minute)
+	interaction.LeaseVersion++
+	interaction.RowVersion++
+	interaction.UpdatedAt = tx.Now()
+	tx.SaveInteraction(*interaction)
+}
+
+func (s *Service) CompleteOperationAttempt(ctx context.Context, command FinishAttemptCommand) (sessionvo.Operation, sessionvo.Receipt, error) {
+	if command.EvidenceDurability == "" {
+		command.EvidenceDurability = sessionvo.DurabilityDurable
+	}
+	return s.finishOperationAttempt(ctx, command, sessionvo.ReceiptCompleted)
+}
+
+func (s *Service) FailOperationAttempt(ctx context.Context, command FinishAttemptCommand) (sessionvo.Operation, sessionvo.Receipt, error) {
+	if command.EvidenceDurability == "" {
+		command.EvidenceDurability = sessionvo.DurabilityFailed
+	}
+	return s.finishOperationAttempt(ctx, command, sessionvo.ReceiptFailed)
+}
+
+func (s *Service) finishOperationAttempt(ctx context.Context, command FinishAttemptCommand, status sessionvo.ReceiptStatus) (sessionvo.Operation, sessionvo.Receipt, error) {
+	if command.PayloadHash == "" {
+		return sessionvo.Operation{}, sessionvo.Receipt{}, domainError(CodeOperationRequired, "receipt payload hash is required")
+	}
+	if command.RequestID == "" || command.TraceID == "" {
+		return sessionvo.Operation{}, sessionvo.Receipt{}, domainError(
+			CodeOperationRequired,
+			"receipt request ID and trace ID are required",
+		)
+	}
+	if !validEvidenceDurability(command.EvidenceDurability) {
+		return sessionvo.Operation{}, sessionvo.Receipt{}, domainError(
+			CodeOperationRequired,
+			"receipt evidence durability is invalid",
+		)
+	}
+	var operation sessionvo.Operation
+	var receipt sessionvo.Receipt
+	err := s.store.WithinTransaction(ctx, func(tx isessionstore.Transaction) error {
+		operationRef, found := tx.PeekOperation(command.OperationID)
+		if !found {
+			return domainError(CodeInteractionRequired, "operation was not found")
+		}
+		conversation, err := ownedConversation(tx, command.Owner, operationRef.ConversationID)
+		if err != nil {
+			return err
+		}
+		interaction, found := tx.FindInteraction(operationRef.InteractionID)
+		if !found {
+			return domainError(CodeInteractionRequired, "interaction was not found")
+		}
+		current, found := tx.FindOperation(command.OperationID)
+		if !found || current.ConversationID != conversation.ID ||
+			current.InteractionID != interaction.ID {
+			return domainError(CodeInteractionRequired, "operation was not found")
+		}
+		if interaction.ExecutionStatus == sessionvo.InteractionActive &&
+			!interaction.LeaseExpiresAt.After(tx.Now()) {
+			return domainError(CodeInteractionTerminal, "interaction lease has expired")
+		}
+		currentReceipt, found := tx.FindReceiptByOperationAttempt(current.ID, command.Attempt)
+		if !found || currentReceipt.ID != command.ReceiptID || current.Attempt != command.Attempt {
+			return domainError(CodeIdempotencyConflict, "operation attempt or receipt does not match")
+		}
+		if currentReceipt.Status != sessionvo.ReceiptPending {
+			if receiptTerminalMatches(currentReceipt, current, command, status) {
+				operation, receipt = current, currentReceipt
+				return nil
+			}
+			return domainError(CodeIdempotencyConflict, "receipt terminal payload conflicts with the durable result")
+		}
+		if evidenceReferenceCount(tx.ListReceipts(interaction.ID), currentReceipt.ID, command.ObservedEvidenceRefs) >
+			maxEvidenceRefsPerInteraction {
+			return domainError(CodeOperationRequired, "interaction evidence reference limit of 2048 was exceeded")
+		}
+		now := tx.Now()
+		currentReceipt.Status = status
+		currentReceipt.EvidenceDurability = command.EvidenceDurability
+		currentReceipt.PayloadHash = command.PayloadHash
+		currentReceipt.RequestID = command.RequestID
+		currentReceipt.TraceID = command.TraceID
+		currentReceipt.ObservedEvidenceRefs = cloneStrings(command.ObservedEvidenceRefs)
+		currentReceipt.BusinessRefs = cloneBusinessRefs(command.BusinessRefs)
+		currentReceipt.ArtifactRefs = cloneStrings(command.ArtifactRefs)
+		currentReceipt.PartialReasons = cloneStrings(command.PartialReasons)
+		currentReceipt.TerminalAt = &now
+		currentReceipt.RowVersion++
+		current.AttemptStatus = sessionvo.AttemptCompleted
+		if status == sessionvo.ReceiptFailed {
+			current.AttemptStatus = sessionvo.AttemptFailed
+			current.Retryable = command.Retryable
+		}
+		current.RowVersion++
+		current.UpdatedAt = now
+		tx.SaveOperation(current)
+		tx.SaveReceipt(currentReceipt)
+		if err := s.appendProjection(tx, "operation", current.ID, "operation.attempt."+string(status), current); err != nil {
+			return err
+		}
+		if err := s.appendProjection(
+			tx, "receipt", currentReceipt.ID, "receipt."+string(status), currentReceipt,
+		); err != nil {
+			return err
+		}
+		if found && interaction.IsTerminal() && interaction.ClosureManifest != nil &&
+			manifestContainsReceipt(*interaction.ClosureManifest, currentReceipt.ID) {
+			nextEvidenceStatus := evidenceStatusAtTermination(tx, *interaction.ClosureManifest)
+			if nextEvidenceStatus != sessionvo.EvidenceAssembling {
+				interaction.EvidenceStatus = nextEvidenceStatus
+				interaction.RowVersion++
+				interaction.UpdatedAt = now
+				tx.SaveInteraction(interaction)
+				if err := s.freezeAssemblyRevision(tx, interaction, *interaction.ClosureManifest, "late_receipt"); err != nil {
+					return err
+				}
+				if err := s.appendProjection(tx, "interaction", interaction.ID, "interaction.evidence.revised", interaction); err != nil {
+					return err
+				}
+			}
+		}
+		operation, receipt = current, currentReceipt
+		return nil
+	})
+	s.observeLifecycleError(err)
+	return operation, receipt, err
+}
+
+func receiptTerminalMatches(
+	receipt sessionvo.Receipt,
+	operation sessionvo.Operation,
+	command FinishAttemptCommand,
+	status sessionvo.ReceiptStatus,
+) bool {
+	return receipt.Status == status &&
+		receipt.PayloadHash == command.PayloadHash &&
+		receipt.EvidenceDurability == command.EvidenceDurability &&
+		receipt.RequestID == command.RequestID &&
+		receipt.TraceID == command.TraceID &&
+		slices.Equal(receipt.ObservedEvidenceRefs, command.ObservedEvidenceRefs) &&
+		slices.Equal(receipt.BusinessRefs, command.BusinessRefs) &&
+		slices.Equal(receipt.ArtifactRefs, command.ArtifactRefs) &&
+		slices.Equal(receipt.PartialReasons, command.PartialReasons) &&
+		(status != sessionvo.ReceiptFailed || operation.Retryable == command.Retryable)
+}
+
+func validEvidenceDurability(value sessionvo.EvidenceDurability) bool {
+	switch value {
+	case sessionvo.DurabilityPending, sessionvo.DurabilityDurable, sessionvo.DurabilityFailed:
+		return true
+	default:
+		return false
+	}
+}
+
+func manifestContainsReceipt(manifest sessionvo.ClosureManifest, receiptID string) bool {
+	for _, expected := range manifest.ExpectedReceipts {
+		if expected.ReceiptID == receiptID {
+			return true
+		}
+	}
+	return false
+}
+
+func (s *Service) AbandonExpiredInteractions(ctx context.Context, limit int) ([]sessionvo.Interaction, error) {
+	var abandoned []sessionvo.Interaction
+	err := s.store.WithinTransaction(ctx, func(tx isessionstore.Transaction) error {
+		for _, interaction := range tx.ListExpiredActiveInteractions(limit) {
+			conversation, found := tx.FindConversation(interaction.ConversationID)
+			if !found {
+				continue
+			}
+			current, found := tx.FindInteraction(interaction.ID)
+			if !found || current.ExecutionStatus != sessionvo.InteractionActive ||
+				current.LeaseVersion != interaction.LeaseVersion || current.LeaseExpiresAt.After(tx.Now()) {
+				continue
+			}
+			now := tx.Now()
+			current.ExecutionStatus = sessionvo.InteractionAbandoned
+			current.EvidenceStatus = evidenceStatusAtTermination(tx, sessionvo.ClosureManifest{})
+			current.TerminalIdempotencyKey = "lease-expired:" + current.LeaseToken
+			current.TerminalPayloadHash = hashValue(current.LeaseVersion)
+			current.RowVersion++
+			current.LeaseVersion++
+			current.UpdatedAt = now
+			current.TerminalAt = &now
+			tx.SaveInteraction(current)
+			if err := s.appendProjection(tx, "interaction", current.ID, "interaction.abandoned", current); err != nil {
+				return err
+			}
+			if conversation.OneShot && conversation.Status == sessionvo.ConversationActive {
+				conversation.Status = sessionvo.ConversationClosed
+				conversation.RowVersion++
+				conversation.UpdatedAt = now
+				conversation.ClosedAt = &now
+				tx.SaveConversation(conversation)
+				if err := s.appendProjection(
+					tx, "conversation", conversation.ID, "conversation.closed", conversation,
+				); err != nil {
+					return err
+				}
+			}
+			abandoned = append(abandoned, current)
+		}
+		return nil
+	})
+	s.observeLifecycleError(err)
+	if err == nil {
+		s.metrics.Add(icoremetrics.InteractionsAbandonedTotal, uint64(len(abandoned)))
+	}
+	return abandoned, err
+}
+
+func (s *Service) ExpireIdleOneShotConversations(
+	ctx context.Context,
+	idleTTL time.Duration,
+	limit int,
+) ([]sessionvo.Conversation, error) {
+	if idleTTL <= 0 {
+		idleTTL = 15 * time.Minute
+	}
+	var expired []sessionvo.Conversation
+	err := s.store.WithinTransaction(ctx, func(tx isessionstore.Transaction) error {
+		cutoff := tx.Now().Add(-idleTTL)
+		for _, candidate := range tx.ListIdleOneShotConversations(cutoff, limit) {
+			current, found := tx.FindConversation(candidate.ID)
+			if !found || !current.OneShot || current.Status != sessionvo.ConversationActive ||
+				current.UpdatedAt.After(cutoff) {
+				continue
+			}
+			if _, active := tx.FindActiveInteraction(current.ID); active {
+				continue
+			}
+			now := tx.Now()
+			current.Status = sessionvo.ConversationExpired
+			current.RowVersion++
+			current.UpdatedAt = now
+			current.ClosedAt = &now
+			tx.SaveConversation(current)
+			if err := s.appendProjection(
+				tx, "conversation", current.ID, "conversation.expired", current,
+			); err != nil {
+				return err
+			}
+			expired = append(expired, current)
+		}
+		return nil
+	})
+	s.observeLifecycleError(err)
+	return expired, err
+}
+
+func (s *Service) ListAssemblyRevisions(ctx context.Context, owner sessionvo.Owner, interactionID string) ([]sessionvo.AssemblyRevision, error) {
+	var result []sessionvo.AssemblyRevision
+	err := s.store.WithinTransaction(ctx, func(tx isessionstore.Transaction) error {
+		interaction, found := tx.PeekInteraction(interactionID)
+		if !found {
+			return domainError(CodeInteractionRequired, "interaction was not found")
+		}
+		if _, err := ownedConversation(tx, owner, interaction.ConversationID); err != nil {
+			return err
+		}
+		result = tx.ListAssemblyRevisions(interactionID)
+		return nil
+	})
+	return result, err
+}
+
+func (s *Service) AssembleDueInteractions(ctx context.Context, limit int) ([]sessionvo.Interaction, error) {
+	var assembled []sessionvo.Interaction
+	err := s.store.WithinTransaction(ctx, func(tx isessionstore.Transaction) error {
+		for _, interaction := range tx.ListAssemblyDueInteractions(limit) {
+			if _, found := tx.FindConversation(interaction.ConversationID); !found {
+				continue
+			}
+			current, found := tx.FindInteraction(interaction.ID)
+			if !found || current.EvidenceStatus != sessionvo.EvidenceAssembling ||
+				current.ClosureManifest == nil || current.ClosureManifest.AssemblerDeadline == nil ||
+				current.ClosureManifest.AssemblerDeadline.After(tx.Now()) {
+				continue
+			}
+			current.EvidenceStatus = sessionvo.EvidencePartial
+			if deadline := current.ClosureManifest.AssemblerDeadline; deadline != nil {
+				lag := tx.Now().Sub(*deadline).Seconds()
+				if lag < 0 {
+					lag = 0
+				}
+				s.metrics.Set(icoremetrics.AssemblyLagSeconds, lag)
+			}
+			current.RowVersion++
+			current.UpdatedAt = tx.Now()
+			tx.SaveInteraction(current)
+			if err := s.freezeAssemblyRevision(tx, current, *current.ClosureManifest, "deadline"); err != nil {
+				return err
+			}
+			if err := s.appendProjection(tx, "interaction", current.ID, "interaction.evidence.partial", current); err != nil {
+				return err
+			}
+			assembled = append(assembled, current)
+		}
+		return nil
+	})
+	s.observeLifecycleError(err)
+	return assembled, err
+}
+
+func (s *Service) freezeAssemblyRevision(tx isessionstore.Transaction, interaction sessionvo.Interaction, manifest sessionvo.ClosureManifest, trigger string) error {
+	existing := tx.ListAssemblyRevisions(interaction.ID)
+	revisionNo := uint64(len(existing) + 1)
+	parentID := ""
+	if len(existing) > 0 {
+		parentID = existing[len(existing)-1].ID
+	}
+	receiptIDs := make([]string, 0, len(manifest.ExpectedReceipts))
+	eventIDs := make([]string, 0)
+	artifactRefs := make([]string, 0)
+	partialReasons := cloneStrings(manifest.SystemPartialReasons)
+	for _, expected := range manifest.ExpectedReceipts {
+		receiptIDs = append(receiptIDs, expected.ReceiptID)
+		receipt, found := tx.FindReceipt(expected.ReceiptID)
+		if !found {
+			partialReasons = append(partialReasons, "receipt_missing:"+expected.ReceiptID)
+			continue
+		}
+		for _, eventID := range receipt.ObservedEvidenceRefs {
+			eventIDs = appendUnique(eventIDs, eventID)
+		}
+		artifactRefs = append(artifactRefs, receipt.ArtifactRefs...)
+		partialReasons = append(partialReasons, receipt.PartialReasons...)
+		if expected.Required && receipt.EvidenceDurability != sessionvo.DurabilityDurable {
+			partialReasons = append(partialReasons, "receipt_not_durable:"+expected.ReceiptID)
+		}
+	}
+	revision := sessionvo.AssemblyRevision{
+		ID: s.newID("rev"), RevisionNo: revisionNo, ParentRevisionID: parentID,
+		InteractionID: interaction.ID, CompletionManifestVersion: manifest.Version,
+		IncludedReceiptIDs: receiptIDs, IncludedEventIDs: eventIDs,
+		ArtifactManifestHash: hashValue(struct {
+			Claims       []string
+			ArtifactRefs []string
+		}{manifest.Claims, artifactRefs}),
+		Completeness: interaction.EvidenceStatus, PartialReasons: partialReasons,
+		Trigger: trigger, CreatedAt: tx.Now(),
+	}
+	tx.SaveAssemblyRevision(revision)
+	return s.appendProjection(tx, "assembly_revision", revision.ID, "assembly.revision.created", revision)
+}
+
+func validateClosureManifest(tx isessionstore.Transaction, interaction sessionvo.Interaction, manifest sessionvo.ClosureManifest) error {
+	if len(manifest.Claims) > maxClaimsPerInteraction {
+		return domainError(CodeClosureManifestInvalid, "closure manifest claim limit of 32 was exceeded")
+	}
+	registeredOperations := tx.ListOperations(interaction.ID)
+	registeredReceipts := tx.ListReceipts(interaction.ID)
+	if len(manifest.ExpectedOperations) != len(registeredOperations) ||
+		len(manifest.ExpectedReceipts) != len(registeredReceipts) {
+		return domainError(CodeClosureManifestInvalid, "closure manifest must list every registered operation and receipt")
+	}
+	operationRequired := make(map[string]bool, len(registeredReceipts))
+	for _, receipt := range registeredReceipts {
+		operationRequired[receipt.OperationID] = receipt.Required
+	}
+	seenOperations := make(map[string]bool, len(manifest.ExpectedOperations))
+	for _, expected := range manifest.ExpectedOperations {
+		if expected.OperationID == "" || seenOperations[expected.OperationID] {
+			return domainError(CodeClosureManifestInvalid, "closure manifest contains a duplicate or empty operation")
+		}
+		seenOperations[expected.OperationID] = true
+		operation, found := tx.FindOperation(expected.OperationID)
+		if !found || operation.InteractionID != interaction.ID ||
+			operationRequired[operation.ID] != expected.Required {
+			return domainError(CodeClosureManifestInvalid, "closure manifest operation does not belong to the interaction")
+		}
+	}
+	seenReceipts := make(map[string]bool, len(manifest.ExpectedReceipts))
+	for _, expected := range manifest.ExpectedReceipts {
+		if expected.ReceiptID == "" || seenReceipts[expected.ReceiptID] {
+			return domainError(CodeClosureManifestInvalid, "closure manifest contains a duplicate or empty receipt")
+		}
+		seenReceipts[expected.ReceiptID] = true
+		receipt, found := tx.FindReceipt(expected.ReceiptID)
+		if !found || receipt.InteractionID != interaction.ID || receipt.Required != expected.Required {
+			return domainError(CodeClosureManifestInvalid, "closure manifest receipt is unknown, foreign, or changes required semantics")
+		}
+	}
+	return nil
+}
+
+func evidenceReferenceCount(receipts []sessionvo.Receipt, replacingReceiptID string, replacement []string) int {
+	unique := make(map[string]struct{})
+	for _, receipt := range receipts {
+		references := receipt.ObservedEvidenceRefs
+		if receipt.ID == replacingReceiptID {
+			references = replacement
+		}
+		for _, reference := range references {
+			if reference != "" {
+				unique[reference] = struct{}{}
+			}
+		}
+	}
+	return len(unique)
+}
+
+func ownedConversation(tx isessionstore.Transaction, owner sessionvo.Owner, conversationID string) (sessionvo.Conversation, error) {
+	conversation, found := tx.FindConversation(conversationID)
+	if !found {
+		return sessionvo.Conversation{}, domainError(CodeConversationNotFound, "conversation was not found")
+	}
+	if !conversation.Owner.Equal(owner) {
+		return sessionvo.Conversation{}, domainError(CodeConversationOwnerMismatch, "conversation belongs to another trusted owner")
+	}
+	return conversation, nil
+}
+
+func requireActiveConversation(conversation sessionvo.Conversation) error {
+	switch conversation.Status {
+	case sessionvo.ConversationActive:
+		return nil
+	case sessionvo.ConversationExpired:
+		return domainError(CodeConversationExpired, "conversation expired; create or resume another conversation")
+	default:
+		return domainError(CodeConversationClosed, "conversation is closed; create a new generation")
+	}
+}
+
+func validTerminalStatus(status sessionvo.InteractionStatus) bool {
+	switch status {
+	case sessionvo.InteractionCompleted, sessionvo.InteractionFailed, sessionvo.InteractionCanceled,
+		sessionvo.InteractionHandedOff, sessionvo.InteractionAbandoned:
+		return true
+	default:
+		return false
+	}
+}
+
+func evidenceStatusAtTermination(tx isessionstore.Transaction, manifest sessionvo.ClosureManifest) sessionvo.EvidenceStatus {
+	if len(manifest.SystemPartialReasons) > 0 {
+		return sessionvo.EvidencePartial
+	}
+	if len(manifest.ExpectedReceipts) == 0 && len(manifest.Claims) == 0 {
+		return sessionvo.EvidenceNotApplicable
+	}
+	for _, expected := range manifest.ExpectedReceipts {
+		receipt, found := tx.FindReceipt(expected.ReceiptID)
+		if !found || (expected.Required && receipt.EvidenceDurability == sessionvo.DurabilityPending) {
+			if manifest.AssemblerDeadline != nil && !manifest.AssemblerDeadline.After(tx.Now()) {
+				return sessionvo.EvidencePartial
+			}
+			return sessionvo.EvidenceAssembling
+		}
+		if expected.Required && receipt.EvidenceDurability == sessionvo.DurabilityFailed {
+			return sessionvo.EvidencePartial
+		}
+		if expected.Required && len(receipt.PartialReasons) > 0 {
+			return sessionvo.EvidencePartial
+		}
+	}
+	return sessionvo.EvidenceComplete
+}
+
+func appendUnique(values []string, value string) []string {
+	for _, existing := range values {
+		if existing == value {
+			return values
+		}
+	}
+	return append(values, value)
+}
+
+func cloneStrings(values []string) []string {
+	return append(make([]string, 0, len(values)), values...)
+}
+
+func cloneBusinessRefs(values []sessionvo.BusinessRef) []sessionvo.BusinessRef {
+	return append(make([]sessionvo.BusinessRef, 0, len(values)), values...)
+}
+
+func hashValue(value any) string {
+	data, _ := json.Marshal(value)
+	sum := sha256.Sum256(data)
+	return hex.EncodeToString(sum[:])
+}
+
+func (s *Service) appendProjection(tx isessionstore.Transaction, aggregateType, aggregateID, eventType string, value any) error {
+	payload, err := json.Marshal(value)
+	if err != nil {
+		return err
+	}
+	var aggregateVersion uint64
+	switch typed := value.(type) {
+	case sessionvo.Conversation:
+		aggregateVersion = typed.RowVersion
+	case sessionvo.Interaction:
+		aggregateVersion = typed.RowVersion
+	case sessionvo.Operation:
+		aggregateVersion = typed.RowVersion
+	case sessionvo.Receipt:
+		aggregateVersion = typed.RowVersion
+	case sessionvo.AssemblyRevision:
+		aggregateVersion = typed.RevisionNo
+	}
+	if aggregateVersion == 0 {
+		return errors.New("projection aggregate version is required")
+	}
+	tx.AppendProjection(sessionvo.ProjectionMutation{
+		EventID: s.newID("evt"), AggregateType: aggregateType,
+		AggregateID: aggregateID, AggregateVersion: aggregateVersion,
+		EventType: eventType, Payload: payload,
+	})
+	return nil
+}
+
+func validateOwner(owner sessionvo.Owner) error {
+	if owner.TenantID == "" || owner.BusinessDomainID == "" ||
+		owner.ApplicationPrincipalID == "" || owner.EffectiveSubjectID == "" ||
+		(owner.EffectiveSubjectType != sessionvo.SubjectUser && owner.EffectiveSubjectType != sessionvo.SubjectService) {
+		return ErrInvalidOwner
+	}
+	return nil
+}
+
+func (s *Service) observeLifecycleError(err error) {
+	if err == nil {
+		return
+	}
+	var domainErr *DomainError
+	if errors.As(err, &domainErr) {
+		s.metrics.Increment(icoremetrics.SessionRejectionsTotal)
+		switch domainErr.Code {
+		case CodeInteractionInProgress, CodeIdempotencyConflict, CodeTerminalConflict:
+			s.metrics.Increment(icoremetrics.SessionTransitionConflictsTotal)
+		}
+		return
+	}
+	s.metrics.Increment(icoremetrics.SessionStoreErrorsTotal)
+}
+
+func randomID(prefix string) string {
+	var value [16]byte
+	if _, err := rand.Read(value[:]); err != nil {
+		panic("crypto/rand failed: " + err.Error())
+	}
+	return prefix + "_" + hex.EncodeToString(value[:])
+}

--- a/bkn-trace/agent-observability/src/domain/service/sessionsvc/service_test.go
+++ b/bkn-trace/agent-observability/src/domain/service/sessionsvc/service_test.go
@@ -1,0 +1,1295 @@
+package sessionsvc_test
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/openbkn-ai/bkn-foundry/bkn-trace/agent-observability/src/domain/service/sessionsvc"
+	"github.com/openbkn-ai/bkn-foundry/bkn-trace/agent-observability/src/domain/valueobject/sessionvo"
+	"github.com/openbkn-ai/bkn-foundry/bkn-trace/agent-observability/src/drivenadapter/memoryaccess/sessionstore"
+	"github.com/openbkn-ai/bkn-foundry/bkn-trace/agent-observability/src/port/driven/icoremetrics"
+)
+
+func TestEnsureCurrentConversationIsIdempotent(t *testing.T) {
+	t.Parallel()
+
+	store := sessionstore.New()
+	service := sessionsvc.New(store, sessionsvc.Options{
+		Now: func() time.Time { return time.Date(2026, 7, 30, 10, 0, 0, 0, time.UTC) },
+	})
+	owner := sessionvo.Owner{
+		TenantID:               "tenant-1",
+		BusinessDomainID:       "domain-1",
+		ApplicationPrincipalID: "app-1",
+		EffectiveSubjectType:   sessionvo.SubjectUser,
+		EffectiveSubjectID:     "user-1",
+	}
+
+	first, err := service.EnsureCurrentConversation(context.Background(), sessionsvc.EnsureConversationCommand{
+		Owner:                   owner,
+		ExternalConversationKey: "cursor-thread-1",
+		IdempotencyKey:          "idem-1",
+	})
+	if err != nil {
+		t.Fatalf("ensure first conversation: %v", err)
+	}
+	second, err := service.EnsureCurrentConversation(context.Background(), sessionsvc.EnsureConversationCommand{
+		Owner:                   owner,
+		ExternalConversationKey: "cursor-thread-1",
+		IdempotencyKey:          "idem-2",
+	})
+	if err != nil {
+		t.Fatalf("ensure second conversation: %v", err)
+	}
+
+	if first.ID != second.ID {
+		t.Fatalf("expected the current conversation to be reused, got %q and %q", first.ID, second.ID)
+	}
+	if first.Generation != 1 || second.Generation != 1 {
+		t.Fatalf("expected generation 1, got %d and %d", first.Generation, second.Generation)
+	}
+	if first.Status != sessionvo.ConversationActive {
+		t.Fatalf("expected active conversation, got %q", first.Status)
+	}
+}
+
+func TestManagedLifecycleRecordsCoreOperationalMetrics(t *testing.T) {
+	t.Parallel()
+
+	metrics := newTestMetrics()
+	service := sessionsvc.New(sessionstore.New(), sessionsvc.Options{Metrics: metrics})
+	owner := testOwner()
+	conversation := mustEnsureConversation(t, service, owner, "metrics")
+	if _, err := service.EnsureCurrentConversation(context.Background(), sessionsvc.EnsureConversationCommand{
+		Owner: owner, ExternalConversationKey: "metrics",
+	}); err != nil {
+		t.Fatalf("idempotent ensure: %v", err)
+	}
+	if _, err := service.StartInteraction(context.Background(), sessionsvc.StartInteractionCommand{
+		Owner: owner, ConversationID: conversation.ID, IdempotencyKey: "metrics-1",
+	}); err != nil {
+		t.Fatalf("start interaction: %v", err)
+	}
+	if _, err := service.StartInteraction(context.Background(), sessionsvc.StartInteractionCommand{
+		Owner: owner, ConversationID: conversation.ID, IdempotencyKey: "metrics-2",
+	}); !sessionsvc.IsCode(err, sessionsvc.CodeInteractionInProgress) {
+		t.Fatalf("expected interaction conflict, got %v", err)
+	}
+
+	if metrics.count(icoremetrics.ConversationsTotal) != 1 ||
+		metrics.count(icoremetrics.InteractionsTotal) != 1 ||
+		metrics.count(icoremetrics.SessionRejectionsTotal) != 1 ||
+		metrics.count(icoremetrics.SessionTransitionConflictsTotal) != 1 {
+		t.Fatalf("unexpected lifecycle metrics: %#v", metrics.counters)
+	}
+}
+
+func TestLifecycleMutationAppendsProjectionOutboxOnce(t *testing.T) {
+	t.Parallel()
+
+	store := sessionstore.New()
+	service := sessionsvc.New(store, sessionsvc.Options{})
+	owner := testOwner()
+	if _, err := service.EnsureCurrentConversation(context.Background(), sessionsvc.EnsureConversationCommand{
+		Owner: owner, ExternalConversationKey: "projected", IdempotencyKey: "projected-1",
+	}); err != nil {
+		t.Fatalf("ensure conversation: %v", err)
+	}
+	if _, err := service.EnsureCurrentConversation(context.Background(), sessionsvc.EnsureConversationCommand{
+		Owner: owner, ExternalConversationKey: "projected", IdempotencyKey: "projected-2",
+	}); err != nil {
+		t.Fatalf("replay conversation: %v", err)
+	}
+	if store.PendingProjectionCount() != 1 {
+		t.Fatalf("expected one lifecycle projection event, got %d", store.PendingProjectionCount())
+	}
+}
+
+func TestOperationAndReceiptUseIndependentVersionedProjectionDocuments(t *testing.T) {
+	t.Parallel()
+
+	store := sessionstore.New()
+	service := sessionsvc.New(store, sessionsvc.Options{})
+	owner := testOwner()
+	conversation := mustEnsureConversation(t, service, owner, "projection-model")
+	interaction, err := service.StartInteraction(
+		context.Background(),
+		sessionsvc.StartInteractionCommand{
+			Owner: owner, ConversationID: conversation.ID, IdempotencyKey: "start",
+		},
+	)
+	if err != nil {
+		t.Fatalf("start interaction: %v", err)
+	}
+	operation, receipt, err := service.EnsureOperation(
+		context.Background(),
+		sessionsvc.EnsureOperationCommand{
+			Owner: owner, ConversationID: conversation.ID, InteractionID: interaction.ID,
+			OperationKey: "query", ToolName: "ontology-query",
+			NormalizedInputHash: "sha256:input", Required: true,
+			LeaseToken: interaction.LeaseToken, LeaseEpoch: interaction.LeaseEpoch,
+		},
+	)
+	if err != nil {
+		t.Fatalf("ensure operation: %v", err)
+	}
+	items, err := store.Lease(context.Background(), 100, time.Minute)
+	if err != nil {
+		t.Fatalf("lease projections: %v", err)
+	}
+	var operationFound, receiptFound bool
+	for _, item := range items {
+		switch {
+		case item.AggregateType == "operation" && item.AggregateID == operation.ID:
+			operationFound = true
+			if item.AggregateVersion != operation.RowVersion {
+				t.Fatalf("operation projection version: %#v", item)
+			}
+			var payload map[string]any
+			if json.Unmarshal(item.Payload, &payload) != nil ||
+				payload["operation_id"] != operation.ID || payload["operation"] != nil {
+				t.Fatalf("operation projection is not a canonical operation snapshot: %s", item.Payload)
+			}
+		case item.AggregateType == "receipt" && item.AggregateID == receipt.ID:
+			receiptFound = true
+			if item.AggregateVersion != receipt.RowVersion {
+				t.Fatalf("receipt projection version: %#v", item)
+			}
+		}
+	}
+	if !operationFound || !receiptFound {
+		t.Fatalf("independent operation/receipt projections missing: %#v", items)
+	}
+}
+
+func TestConversationGenerationAndOwnerIsolation(t *testing.T) {
+	t.Parallel()
+
+	service := newTestService()
+	owner := testOwner()
+	first := mustEnsureConversation(t, service, owner, "thread-1")
+	if _, err := service.CloseConversation(context.Background(), sessionsvc.CloseConversationCommand{
+		Owner: owner, ConversationID: first.ID, IdempotencyKey: "close-1",
+	}); err != nil {
+		t.Fatalf("close conversation: %v", err)
+	}
+	second := mustEnsureConversation(t, service, owner, "thread-1")
+	if second.Generation != 2 || second.ID == first.ID {
+		t.Fatalf("expected a new generation, got id=%q generation=%d", second.ID, second.Generation)
+	}
+
+	otherOwner := owner
+	otherOwner.EffectiveSubjectID = "user-2"
+	isolated := mustEnsureConversation(t, service, otherOwner, "thread-1")
+	if isolated.ID == second.ID || isolated.Generation != 1 {
+		t.Fatalf("expected an isolated generation 1 conversation, got %#v", isolated)
+	}
+	if _, err := service.GetConversation(context.Background(), otherOwner, second.ID); !sessionsvc.IsCode(err, sessionsvc.CodeConversationOwnerMismatch) {
+		t.Fatalf("expected owner mismatch, got %v", err)
+	}
+}
+
+func TestConversationAndRequestIsolationIncludesDelegation(t *testing.T) {
+	t.Parallel()
+
+	service := newTestService()
+	firstOwner := testOwner()
+	firstOwner.DelegationID = "delegation-a"
+	secondOwner := firstOwner
+	secondOwner.DelegationID = "delegation-b"
+
+	first := mustEnsureConversation(t, service, firstOwner, "shared-delegated-thread")
+	second := mustEnsureConversation(t, service, secondOwner, "shared-delegated-thread")
+	if first.ID == second.ID {
+		t.Fatal("different delegations reused the same conversation")
+	}
+	firstList, err := service.ListConversations(context.Background(), firstOwner, 10)
+	if err != nil || len(firstList) != 1 || firstList[0].ID != first.ID {
+		t.Fatalf("delegation-a list leaked another delegation: %#v, %v", firstList, err)
+	}
+	secondList, err := service.ListConversations(context.Background(), secondOwner, 10)
+	if err != nil || len(secondList) != 1 || secondList[0].ID != second.ID {
+		t.Fatalf("delegation-b list leaked another delegation: %#v, %v", secondList, err)
+	}
+}
+
+func TestResumeByIDReturnsOnlyOwnedActiveConversation(t *testing.T) {
+	t.Parallel()
+
+	service := newTestService()
+	owner := testOwner()
+	conversation := mustEnsureConversation(t, service, owner, "resume-by-id")
+	resumed, err := service.ResumeConversation(context.Background(), sessionsvc.ResumeConversationCommand{
+		Owner: owner, ConversationID: conversation.ID,
+	})
+	if err != nil || resumed.ID != conversation.ID {
+		t.Fatalf("resume active conversation: %#v, %v", resumed, err)
+	}
+	otherOwner := owner
+	otherOwner.EffectiveSubjectID = "other-user"
+	if _, err := service.ResumeConversation(context.Background(), sessionsvc.ResumeConversationCommand{
+		Owner: otherOwner, ConversationID: conversation.ID,
+	}); !sessionsvc.IsCode(err, sessionsvc.CodeConversationOwnerMismatch) {
+		t.Fatalf("expected owner mismatch, got %v", err)
+	}
+	if _, err := service.CloseConversation(context.Background(), sessionsvc.CloseConversationCommand{
+		Owner: owner, ConversationID: conversation.ID, IdempotencyKey: "close-resume",
+	}); err != nil {
+		t.Fatalf("close conversation: %v", err)
+	}
+	if _, err := service.ResumeConversation(context.Background(), sessionsvc.ResumeConversationCommand{
+		Owner: owner, ConversationID: conversation.ID,
+	}); !sessionsvc.IsCode(err, sessionsvc.CodeConversationClosed) {
+		t.Fatalf("expected closed conversation conflict, got %v", err)
+	}
+}
+
+func TestCreateNewGenerationRejectsActiveInteraction(t *testing.T) {
+	t.Parallel()
+
+	service := newTestService()
+	owner := testOwner()
+	current := mustEnsureConversation(t, service, owner, "thread-generation")
+	if _, err := service.StartInteraction(context.Background(), sessionsvc.StartInteractionCommand{
+		Owner: owner, ConversationID: current.ID, IdempotencyKey: "active",
+	}); err != nil {
+		t.Fatalf("start interaction: %v", err)
+	}
+	if _, err := service.CreateNewGeneration(context.Background(), sessionsvc.EnsureConversationCommand{
+		Owner: owner, ExternalConversationKey: "thread-generation", IdempotencyKey: "new-generation",
+	}); !sessionsvc.IsCode(err, sessionsvc.CodeInteractionInProgress) {
+		t.Fatalf("expected interaction_in_progress, got %v", err)
+	}
+}
+
+func TestCreateNewGenerationReplayReturnsSameConversation(t *testing.T) {
+	t.Parallel()
+
+	service := newTestService()
+	owner := testOwner()
+	mustEnsureConversation(t, service, owner, "thread-generation-replay")
+	command := sessionsvc.EnsureConversationCommand{
+		Owner: owner, ExternalConversationKey: "thread-generation-replay",
+		IdempotencyKey: "new-generation-replay", OneShot: false,
+	}
+	first, err := service.CreateNewGeneration(context.Background(), command)
+	if err != nil {
+		t.Fatalf("create generation: %v", err)
+	}
+	replayed, err := service.CreateNewGeneration(context.Background(), command)
+	if err != nil {
+		t.Fatalf("replay generation: %v", err)
+	}
+	if replayed.ID != first.ID || replayed.Generation != first.Generation {
+		t.Fatalf("replay created another generation: first=%#v replay=%#v", first, replayed)
+	}
+	command.OneShot = true
+	if _, err := service.CreateNewGeneration(context.Background(), command); !sessionsvc.IsCode(err, sessionsvc.CodeIdempotencyConflict) {
+		t.Fatalf("expected changed replay to conflict, got %v", err)
+	}
+}
+
+func TestOnlyOneActiveInteractionAndTerminalIsFenced(t *testing.T) {
+	t.Parallel()
+
+	service := newTestService()
+	owner := testOwner()
+	conversation := mustEnsureConversation(t, service, owner, "thread-2")
+	first, err := service.StartInteraction(context.Background(), sessionsvc.StartInteractionCommand{
+		Owner: owner, ConversationID: conversation.ID, IdempotencyKey: "start-1",
+		LeaseDuration: time.Minute,
+	})
+	if err != nil {
+		t.Fatalf("start interaction: %v", err)
+	}
+	if first.Ordinal != 1 || first.ExecutionStatus != sessionvo.InteractionActive {
+		t.Fatalf("unexpected interaction: %#v", first)
+	}
+	if _, err := service.StartInteraction(context.Background(), sessionsvc.StartInteractionCommand{
+		Owner: owner, ConversationID: conversation.ID, IdempotencyKey: "start-2",
+	}); !sessionsvc.IsCode(err, sessionsvc.CodeInteractionInProgress) {
+		t.Fatalf("expected interaction_in_progress, got %v", err)
+	}
+	if _, err := service.TerminateInteraction(context.Background(), sessionsvc.TerminateInteractionCommand{
+		Owner: owner, InteractionID: first.ID, Status: sessionvo.InteractionCompleted,
+		TerminalIdempotencyKey: "stale-terminal", LeaseToken: "stale-token", LeaseEpoch: first.LeaseEpoch,
+	}); !sessionsvc.IsCode(err, sessionsvc.CodeTerminalConflict) {
+		t.Fatalf("expected stale lease fencing conflict, got %v", err)
+	}
+
+	completed, err := service.TerminateInteraction(context.Background(), sessionsvc.TerminateInteractionCommand{
+		Owner: owner, InteractionID: first.ID, Status: sessionvo.InteractionCompleted,
+		TerminalIdempotencyKey: "terminal-1", LeaseToken: first.LeaseToken, LeaseEpoch: first.LeaseEpoch,
+		Manifest: sessionvo.ClosureManifest{Version: "1", CompletionReason: "answer_returned"},
+	})
+	if err != nil {
+		t.Fatalf("complete interaction: %v", err)
+	}
+	if completed.ExecutionStatus != sessionvo.InteractionCompleted {
+		t.Fatalf("expected completed, got %q", completed.ExecutionStatus)
+	}
+	replayed, err := service.TerminateInteraction(context.Background(), sessionsvc.TerminateInteractionCommand{
+		Owner: owner, InteractionID: first.ID, Status: sessionvo.InteractionCompleted,
+		TerminalIdempotencyKey: "terminal-1", LeaseToken: first.LeaseToken, LeaseEpoch: first.LeaseEpoch,
+		Manifest: sessionvo.ClosureManifest{Version: "1", CompletionReason: "answer_returned"},
+	})
+	if err != nil || replayed.ExecutionStatus != sessionvo.InteractionCompleted {
+		t.Fatalf("expected idempotent terminal replay, got %#v, %v", replayed, err)
+	}
+	if _, err := service.TerminateInteraction(context.Background(), sessionsvc.TerminateInteractionCommand{
+		Owner: owner, InteractionID: first.ID, Status: sessionvo.InteractionCanceled,
+		TerminalIdempotencyKey: "terminal-2", LeaseToken: first.LeaseToken, LeaseEpoch: first.LeaseEpoch,
+	}); !sessionsvc.IsCode(err, sessionsvc.CodeTerminalConflict) {
+		t.Fatalf("expected terminal_conflict, got %v", err)
+	}
+}
+
+func TestStartInteractionReplayReturnsOriginalAfterTerminal(t *testing.T) {
+	t.Parallel()
+
+	service := newTestService()
+	owner := testOwner()
+	conversation := mustEnsureConversation(t, service, owner, "thread-start-replay")
+	command := sessionsvc.StartInteractionCommand{
+		Owner: owner, ConversationID: conversation.ID,
+		IdempotencyKey: "start-replay", LeaseDuration: time.Minute,
+	}
+	started, err := service.StartInteraction(context.Background(), command)
+	if err != nil {
+		t.Fatalf("start interaction: %v", err)
+	}
+	if _, err := service.TerminateInteraction(context.Background(), sessionsvc.TerminateInteractionCommand{
+		Owner: owner, InteractionID: started.ID, Status: sessionvo.InteractionCanceled,
+		TerminalIdempotencyKey: "cancel-replay", LeaseToken: started.LeaseToken,
+		LeaseEpoch: started.LeaseEpoch,
+		Manifest: sessionvo.ClosureManifest{
+			Version: "1", CompletionReason: "caller_canceled",
+		},
+	}); err != nil {
+		t.Fatalf("cancel interaction: %v", err)
+	}
+
+	replayed, err := service.StartInteraction(context.Background(), command)
+	if err != nil {
+		t.Fatalf("replay start interaction: %v", err)
+	}
+	if replayed.ID != started.ID {
+		t.Fatalf("replay created another interaction: first=%s replay=%s", started.ID, replayed.ID)
+	}
+}
+
+func TestConversationPersistsThreeSequentialInteractionRounds(t *testing.T) {
+	t.Parallel()
+
+	store := sessionstore.New()
+	service := sessionsvc.New(store, sessionsvc.Options{})
+	owner := testOwner()
+	conversation := mustEnsureConversation(t, service, owner, "three-rounds")
+
+	for round := 1; round <= 3; round++ {
+		interaction, err := service.StartInteraction(
+			context.Background(),
+			sessionsvc.StartInteractionCommand{
+				Owner: owner, ConversationID: conversation.ID,
+				IdempotencyKey: fmt.Sprintf("round-%d", round),
+			},
+		)
+		if err != nil {
+			t.Fatalf("start round %d: %v", round, err)
+		}
+		if interaction.Ordinal != uint64(round) {
+			t.Fatalf("round ordinal = %d, want %d", interaction.Ordinal, round)
+		}
+		completed, err := service.TerminateInteraction(
+			context.Background(),
+			sessionsvc.TerminateInteractionCommand{
+				Owner: owner, InteractionID: interaction.ID,
+				Status:                 sessionvo.InteractionCompleted,
+				TerminalIdempotencyKey: fmt.Sprintf("complete-%d", round),
+				LeaseToken:             interaction.LeaseToken, LeaseEpoch: interaction.LeaseEpoch,
+				Manifest: sessionvo.ClosureManifest{
+					Version: "1", CompletionReason: "answer_returned",
+				},
+			},
+		)
+		if err != nil || completed.ExecutionStatus != sessionvo.InteractionCompleted {
+			t.Fatalf("complete round %d: %#v, %v", round, completed, err)
+		}
+	}
+}
+
+func TestEnsureOperationUsesStableLogicalKeyAndInputHash(t *testing.T) {
+	t.Parallel()
+
+	service := newTestService()
+	owner := testOwner()
+	conversation := mustEnsureConversation(t, service, owner, "thread-3")
+	interaction, err := service.StartInteraction(context.Background(), sessionsvc.StartInteractionCommand{
+		Owner: owner, ConversationID: conversation.ID, IdempotencyKey: "start-op",
+	})
+	if err != nil {
+		t.Fatalf("start interaction: %v", err)
+	}
+	first, receipt, err := service.EnsureOperation(context.Background(), sessionsvc.EnsureOperationCommand{
+		Owner: owner, ConversationID: conversation.ID, InteractionID: interaction.ID,
+		OperationKey: "query-sales-orders", ToolName: "ontology-query",
+		NormalizedInputHash: "sha256:input-a", Required: true,
+		LeaseToken: interaction.LeaseToken, LeaseEpoch: interaction.LeaseEpoch,
+	})
+	if err != nil {
+		t.Fatalf("ensure operation: %v", err)
+	}
+	if receipt.CausationEventIDs == nil || receipt.ObservedEvidenceRefs == nil ||
+		receipt.BusinessRefs == nil || receipt.ArtifactRefs == nil || receipt.PartialReasons == nil {
+		t.Fatalf("pending receipt must expose required collection fields as empty arrays: %#v", receipt)
+	}
+	replayed, replayedReceipt, err := service.EnsureOperation(context.Background(), sessionsvc.EnsureOperationCommand{
+		Owner: owner, ConversationID: conversation.ID, InteractionID: interaction.ID,
+		OperationKey: "query-sales-orders", ToolName: "ontology-query",
+		NormalizedInputHash: "sha256:input-a", Required: true,
+		LeaseToken: interaction.LeaseToken, LeaseEpoch: interaction.LeaseEpoch,
+	})
+	if err != nil {
+		t.Fatalf("replay operation: %v", err)
+	}
+	if first.ID != replayed.ID || receipt.ID != replayedReceipt.ID || first.Attempt != 1 {
+		t.Fatalf("expected the same operation and receipt, got %#v / %#v", replayed, replayedReceipt)
+	}
+	if _, _, err := service.EnsureOperation(context.Background(), sessionsvc.EnsureOperationCommand{
+		Owner: owner, ConversationID: conversation.ID, InteractionID: interaction.ID,
+		OperationKey: "query-sales-orders", ToolName: "ontology-query",
+		NormalizedInputHash: "sha256:input-b", Required: true,
+		LeaseToken: interaction.LeaseToken, LeaseEpoch: interaction.LeaseEpoch,
+	}); !sessionsvc.IsCode(err, sessionsvc.CodeIdempotencyConflict) {
+		t.Fatalf("expected idempotency_conflict, got %v", err)
+	}
+	if _, _, err := service.EnsureOperation(context.Background(), sessionsvc.EnsureOperationCommand{
+		Owner: owner, ConversationID: conversation.ID, InteractionID: interaction.ID,
+		OperationKey: "child-with-unknown-parent", ToolName: "ontology-query",
+		NormalizedInputHash: "sha256:child", Required: true,
+		ParentOperationID: "op-from-another-interaction",
+		LeaseToken:        interaction.LeaseToken, LeaseEpoch: interaction.LeaseEpoch,
+	}); !sessionsvc.IsCode(err, sessionsvc.CodeOperationRequired) {
+		t.Fatalf("unknown parent operation was accepted: %v", err)
+	}
+}
+
+func TestOperationIntentRequiresCurrentInteractionLeaseAndRenewsIt(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 7, 30, 12, 0, 0, 0, time.UTC)
+	store := sessionstore.NewWithClock(func() time.Time { return now })
+	service := sessionsvc.New(store, sessionsvc.Options{})
+	owner := testOwner()
+	conversation := mustEnsureConversation(t, service, owner, "operation-lease")
+	interaction, err := service.StartInteraction(
+		context.Background(),
+		sessionsvc.StartInteractionCommand{
+			Owner: owner, ConversationID: conversation.ID,
+			IdempotencyKey: "start", LeaseDuration: time.Minute,
+		},
+	)
+	if err != nil {
+		t.Fatalf("start interaction: %v", err)
+	}
+	if _, _, err := service.EnsureOperation(
+		context.Background(),
+		sessionsvc.EnsureOperationCommand{
+			Owner: owner, ConversationID: conversation.ID,
+			InteractionID: interaction.ID, OperationKey: "query",
+			ToolName: "ontology-query", NormalizedInputHash: "sha256:query",
+			LeaseToken: "stale-token", LeaseEpoch: interaction.LeaseEpoch,
+		},
+	); !sessionsvc.IsCode(err, sessionsvc.CodeTerminalConflict) {
+		t.Fatalf("stale operation lease was not fenced: %v", err)
+	}
+
+	now = now.Add(30 * time.Second)
+	if _, _, err := service.EnsureOperation(
+		context.Background(),
+		sessionsvc.EnsureOperationCommand{
+			Owner: owner, ConversationID: conversation.ID,
+			InteractionID: interaction.ID, OperationKey: "query",
+			ToolName: "ontology-query", NormalizedInputHash: "sha256:query",
+			LeaseToken: interaction.LeaseToken, LeaseEpoch: interaction.LeaseEpoch,
+		},
+	); err != nil {
+		t.Fatalf("ensure operation with current lease: %v", err)
+	}
+	renewed, err := service.GetInteraction(context.Background(), owner, interaction.ID)
+	if err != nil {
+		t.Fatalf("get renewed interaction: %v", err)
+	}
+	if !renewed.LeaseExpiresAt.Equal(now.Add(5*time.Minute)) ||
+		renewed.LeaseVersion != interaction.LeaseVersion+1 {
+		t.Fatalf("operation intent did not renew interaction lease: %#v", renewed)
+	}
+}
+
+func TestRetryAttemptRequiresRetryableFailure(t *testing.T) {
+	t.Parallel()
+
+	service, owner, _, interaction, operation, receipt := mustCreateOperation(t)
+	if _, _, err := service.StartOperationAttempt(context.Background(), sessionsvc.StartAttemptCommand{
+		Owner: owner, OperationID: operation.ID,
+		LeaseToken: interaction.LeaseToken, LeaseEpoch: interaction.LeaseEpoch,
+	}); !sessionsvc.IsCode(err, sessionsvc.CodeReceiptPending) {
+		t.Fatalf("expected receipt_pending before a retryable failure, got %v", err)
+	}
+	if _, _, err := service.FailOperationAttempt(context.Background(), sessionsvc.FinishAttemptCommand{
+		Owner: owner, OperationID: operation.ID, Attempt: 1,
+		ReceiptID: receipt.ID, PayloadHash: "sha256:failed", Retryable: true,
+		RequestID: "req-retry", TraceID: "trace-retry",
+	}); err != nil {
+		t.Fatalf("fail operation attempt: %v", err)
+	}
+	retry, retryReceipt, err := service.StartOperationAttempt(context.Background(), sessionsvc.StartAttemptCommand{
+		Owner: owner, OperationID: operation.ID,
+		LeaseToken: interaction.LeaseToken, LeaseEpoch: interaction.LeaseEpoch,
+	})
+	if err != nil {
+		t.Fatalf("start retry: %v", err)
+	}
+	if retry.Attempt != 2 || retryReceipt.Attempt != 2 || retryReceipt.ID == receipt.ID {
+		t.Fatalf("expected a new attempt and receipt, got %#v / %#v", retry, retryReceipt)
+	}
+}
+
+func TestCompletionManifestRejectsUnknownReceipt(t *testing.T) {
+	t.Parallel()
+
+	service, owner, _, interaction, _, _ := mustCreateOperation(t)
+	if _, err := service.TerminateInteraction(context.Background(), sessionsvc.TerminateInteractionCommand{
+		Owner: owner, InteractionID: interaction.ID, Status: sessionvo.InteractionCompleted,
+		TerminalIdempotencyKey: "terminal-invalid", LeaseToken: interaction.LeaseToken, LeaseEpoch: interaction.LeaseEpoch,
+		Manifest: sessionvo.ClosureManifest{
+			Version: "1", CompletionReason: "answer_returned",
+			ExpectedReceipts: []sessionvo.ExpectedReceipt{{ReceiptID: "rcpt_unknown", Required: true}},
+		},
+	}); !sessionsvc.IsCode(err, sessionsvc.CodeClosureManifestInvalid) {
+		t.Fatalf("expected closure_manifest_invalid, got %v", err)
+	}
+}
+
+func TestCompletionManifestRejectsOmittedRegisteredOperationAndReceipt(t *testing.T) {
+	t.Parallel()
+
+	service, owner, _, interaction, _, _ := mustCreateOperation(t)
+	if _, err := service.TerminateInteraction(context.Background(), sessionsvc.TerminateInteractionCommand{
+		Owner: owner, InteractionID: interaction.ID, Status: sessionvo.InteractionCompleted,
+		TerminalIdempotencyKey: "terminal-omitted", LeaseToken: interaction.LeaseToken,
+		LeaseEpoch: interaction.LeaseEpoch,
+		Manifest: sessionvo.ClosureManifest{
+			Version: "1", CompletionReason: "answer_returned",
+		},
+	}); !sessionsvc.IsCode(err, sessionsvc.CodeClosureManifestInvalid) {
+		t.Fatalf("expected closure_manifest_invalid, got %v", err)
+	}
+}
+
+func TestExpiredAssemblerDeadlineFreezesPartialRevision(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 7, 30, 13, 0, 0, 0, time.UTC)
+	store := sessionstore.NewWithClock(func() time.Time { return now })
+	service := sessionsvc.New(store, sessionsvc.Options{})
+	owner := testOwner()
+	conversation := mustEnsureConversation(t, service, owner, "deadline")
+	interaction, err := service.StartInteraction(context.Background(), sessionsvc.StartInteractionCommand{
+		Owner: owner, ConversationID: conversation.ID, IdempotencyKey: "deadline-start",
+	})
+	if err != nil {
+		t.Fatalf("start interaction: %v", err)
+	}
+	operation, receipt, err := service.EnsureOperation(context.Background(), sessionsvc.EnsureOperationCommand{
+		Owner: owner, ConversationID: conversation.ID, InteractionID: interaction.ID,
+		OperationKey: "pending", ToolName: "ontology-query",
+		NormalizedInputHash: "sha256:pending", Required: true,
+		LeaseToken: interaction.LeaseToken, LeaseEpoch: interaction.LeaseEpoch,
+	})
+	if err != nil {
+		t.Fatalf("ensure operation: %v", err)
+	}
+	deadline := now.Add(-time.Second)
+	completed, err := service.TerminateInteraction(context.Background(), sessionsvc.TerminateInteractionCommand{
+		Owner: owner, InteractionID: interaction.ID, Status: sessionvo.InteractionCompleted,
+		TerminalIdempotencyKey: "deadline-terminal", LeaseToken: interaction.LeaseToken, LeaseEpoch: interaction.LeaseEpoch,
+		Manifest: sessionvo.ClosureManifest{
+			Version: "1", CompletionReason: "answer_returned", AssemblerDeadline: &deadline,
+			ExpectedOperations: []sessionvo.ExpectedOperation{{OperationID: operation.ID, Required: true}},
+			ExpectedReceipts:   []sessionvo.ExpectedReceipt{{ReceiptID: receipt.ID, Required: true}},
+		},
+	})
+	if err != nil {
+		t.Fatalf("complete interaction: %v", err)
+	}
+	if completed.EvidenceStatus != sessionvo.EvidencePartial {
+		t.Fatalf("expected partial after deadline, got %q", completed.EvidenceStatus)
+	}
+	revisions, err := service.ListAssemblyRevisions(context.Background(), owner, interaction.ID)
+	if err != nil || len(revisions) != 1 || revisions[0].Trigger != "deadline" {
+		t.Fatalf("unexpected deadline revision: %#v, %v", revisions, err)
+	}
+}
+
+func TestAssemblerFreezesPendingInteractionWhenDeadlineLaterExpires(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 7, 30, 14, 0, 0, 0, time.UTC)
+	store := sessionstore.NewWithClock(func() time.Time { return now })
+	service := sessionsvc.New(store, sessionsvc.Options{})
+	owner := testOwner()
+	conversation := mustEnsureConversation(t, service, owner, "future-deadline")
+	interaction, _ := service.StartInteraction(context.Background(), sessionsvc.StartInteractionCommand{
+		Owner: owner, ConversationID: conversation.ID, IdempotencyKey: "future-start",
+	})
+	operation, receipt, _ := service.EnsureOperation(context.Background(), sessionsvc.EnsureOperationCommand{
+		Owner: owner, ConversationID: conversation.ID, InteractionID: interaction.ID,
+		OperationKey: "future", ToolName: "query", NormalizedInputHash: "sha256:future", Required: true,
+		LeaseToken: interaction.LeaseToken, LeaseEpoch: interaction.LeaseEpoch,
+	})
+	deadline := now.Add(time.Minute)
+	completed, err := service.TerminateInteraction(context.Background(), sessionsvc.TerminateInteractionCommand{
+		Owner: owner, InteractionID: interaction.ID, Status: sessionvo.InteractionCompleted,
+		TerminalIdempotencyKey: "future-terminal", LeaseToken: interaction.LeaseToken, LeaseEpoch: interaction.LeaseEpoch,
+		Manifest: sessionvo.ClosureManifest{
+			Version: "1", CompletionReason: "answer_returned", AssemblerDeadline: &deadline,
+			ExpectedOperations: []sessionvo.ExpectedOperation{{OperationID: operation.ID, Required: true}},
+			ExpectedReceipts:   []sessionvo.ExpectedReceipt{{ReceiptID: receipt.ID, Required: true}},
+		},
+	})
+	if err != nil || completed.EvidenceStatus != sessionvo.EvidenceAssembling {
+		t.Fatalf("expected assembling before deadline, got %#v, %v", completed, err)
+	}
+	now = now.Add(2 * time.Minute)
+	assembled, err := service.AssembleDueInteractions(context.Background(), 10)
+	if err != nil || len(assembled) != 1 || assembled[0].EvidenceStatus != sessionvo.EvidencePartial {
+		t.Fatalf("unexpected deadline assembly: %#v, %v", assembled, err)
+	}
+}
+
+func TestLateDurableReceiptCreatesNewImmutableAssemblyRevision(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 7, 30, 15, 0, 0, 0, time.UTC)
+	store := sessionstore.NewWithClock(func() time.Time { return now })
+	service := sessionsvc.New(store, sessionsvc.Options{})
+	owner := testOwner()
+	conversation := mustEnsureConversation(t, service, owner, "late-receipt")
+	interaction, _ := service.StartInteraction(context.Background(), sessionsvc.StartInteractionCommand{
+		Owner: owner, ConversationID: conversation.ID, IdempotencyKey: "late-start",
+	})
+	operation, receipt, _ := service.EnsureOperation(context.Background(), sessionsvc.EnsureOperationCommand{
+		Owner: owner, ConversationID: conversation.ID, InteractionID: interaction.ID,
+		OperationKey: "late", ToolName: "query", NormalizedInputHash: "sha256:late", Required: true,
+		LeaseToken: interaction.LeaseToken, LeaseEpoch: interaction.LeaseEpoch,
+	})
+	deadline := now.Add(-time.Second)
+	completed, err := service.TerminateInteraction(context.Background(), sessionsvc.TerminateInteractionCommand{
+		Owner: owner, InteractionID: interaction.ID, Status: sessionvo.InteractionCompleted,
+		TerminalIdempotencyKey: "late-terminal", LeaseToken: interaction.LeaseToken,
+		LeaseEpoch: interaction.LeaseEpoch,
+		Manifest: sessionvo.ClosureManifest{
+			Version: "1", CompletionReason: "answer_returned", AssemblerDeadline: &deadline,
+			ExpectedOperations: []sessionvo.ExpectedOperation{{OperationID: operation.ID, Required: true}},
+			ExpectedReceipts:   []sessionvo.ExpectedReceipt{{ReceiptID: receipt.ID, Required: true}},
+		},
+	})
+	if err != nil || completed.EvidenceStatus != sessionvo.EvidencePartial {
+		t.Fatalf("freeze partial revision: %#v, %v", completed, err)
+	}
+
+	_, _, err = service.CompleteOperationAttempt(context.Background(), sessionsvc.FinishAttemptCommand{
+		Owner: owner, OperationID: operation.ID, Attempt: receipt.Attempt,
+		ReceiptID: receipt.ID, PayloadHash: "sha256:late-result",
+		EvidenceDurability: sessionvo.DurabilityDurable,
+		RequestID:          "req-late", TraceID: "trace-late",
+	})
+	if err != nil {
+		t.Fatalf("complete late receipt: %v", err)
+	}
+	revisions, err := service.ListAssemblyRevisions(context.Background(), owner, interaction.ID)
+	if err != nil {
+		t.Fatalf("list revisions: %v", err)
+	}
+	if len(revisions) != 2 || revisions[0].Completeness != sessionvo.EvidencePartial ||
+		revisions[1].Completeness != sessionvo.EvidenceComplete ||
+		revisions[1].ParentRevisionID != revisions[0].ID || revisions[1].Trigger != "late_receipt" {
+		t.Fatalf("unexpected immutable revision chain: %#v", revisions)
+	}
+}
+
+func TestPendingReceiptCompletedBeforeDeadlineCreatesFirstAssemblyRevision(t *testing.T) {
+	t.Parallel()
+
+	service, owner, _, interaction, operation, receipt := mustCreateOperation(t)
+	deadline := time.Now().Add(time.Hour)
+	completed, err := service.TerminateInteraction(context.Background(), sessionsvc.TerminateInteractionCommand{
+		Owner: owner, InteractionID: interaction.ID, Status: sessionvo.InteractionCompleted,
+		TerminalIdempotencyKey: "terminal-before-deadline",
+		LeaseToken:             interaction.LeaseToken, LeaseEpoch: interaction.LeaseEpoch,
+		Manifest: sessionvo.ClosureManifest{
+			Version: "1", CompletionReason: "answer_returned", AssemblerDeadline: &deadline,
+			ExpectedOperations: []sessionvo.ExpectedOperation{{OperationID: operation.ID, Required: true}},
+			ExpectedReceipts:   []sessionvo.ExpectedReceipt{{ReceiptID: receipt.ID, Required: true}},
+		},
+	})
+	if err != nil || completed.EvidenceStatus != sessionvo.EvidenceAssembling {
+		t.Fatalf("expected assembling interaction: %#v, %v", completed, err)
+	}
+
+	_, _, err = service.CompleteOperationAttempt(context.Background(), sessionsvc.FinishAttemptCommand{
+		Owner: owner, OperationID: operation.ID, Attempt: receipt.Attempt,
+		ReceiptID: receipt.ID, PayloadHash: "sha256:before-deadline",
+		EvidenceDurability: sessionvo.DurabilityDurable,
+		RequestID:          "req-before-deadline", TraceID: "trace-before-deadline",
+	})
+	if err != nil {
+		t.Fatalf("complete receipt before deadline: %v", err)
+	}
+
+	current, err := service.GetInteraction(context.Background(), owner, interaction.ID)
+	if err != nil || current.EvidenceStatus != sessionvo.EvidenceComplete {
+		t.Fatalf("expected complete evidence after receipt: %#v, %v", current, err)
+	}
+	revisions, err := service.ListAssemblyRevisions(context.Background(), owner, interaction.ID)
+	if err != nil || len(revisions) != 1 ||
+		revisions[0].RevisionNo != 1 || revisions[0].Trigger != "late_receipt" ||
+		revisions[0].Completeness != sessionvo.EvidenceComplete {
+		t.Fatalf("expected first immutable completion revision: %#v, %v", revisions, err)
+	}
+}
+
+func TestDurableReceiptMakesCompletedInteractionEvidenceComplete(t *testing.T) {
+	t.Parallel()
+
+	service, owner, _, interaction, operation, receipt := mustCreateOperation(t)
+	_, durableReceipt, err := service.CompleteOperationAttempt(context.Background(), sessionsvc.FinishAttemptCommand{
+		Owner: owner, OperationID: operation.ID, Attempt: 1,
+		ReceiptID: receipt.ID, PayloadHash: "sha256:complete",
+		EvidenceDurability: sessionvo.DurabilityDurable,
+		RequestID:          "req-complete", TraceID: "trace-complete",
+	})
+	if err != nil {
+		t.Fatalf("complete operation attempt: %v", err)
+	}
+	completed, err := service.TerminateInteraction(context.Background(), sessionsvc.TerminateInteractionCommand{
+		Owner: owner, InteractionID: interaction.ID, Status: sessionvo.InteractionCompleted,
+		TerminalIdempotencyKey: "terminal-complete", LeaseToken: interaction.LeaseToken, LeaseEpoch: interaction.LeaseEpoch,
+		Manifest: sessionvo.ClosureManifest{
+			Version: "1", CompletionReason: "answer_returned",
+			ExpectedOperations: []sessionvo.ExpectedOperation{{OperationID: operation.ID, Required: true}},
+			ExpectedReceipts:   []sessionvo.ExpectedReceipt{{ReceiptID: durableReceipt.ID, Required: true}},
+		},
+	})
+	if err != nil {
+		t.Fatalf("complete interaction: %v", err)
+	}
+	if completed.EvidenceStatus != sessionvo.EvidenceComplete {
+		t.Fatalf("expected complete evidence, got %q", completed.EvidenceStatus)
+	}
+	revisions, err := service.ListAssemblyRevisions(context.Background(), owner, interaction.ID)
+	if err != nil {
+		t.Fatalf("list assembly revisions: %v", err)
+	}
+	if len(revisions) != 1 || revisions[0].RevisionNo != 1 ||
+		revisions[0].Completeness != sessionvo.EvidenceComplete ||
+		len(revisions[0].IncludedReceiptIDs) != 1 {
+		t.Fatalf("unexpected frozen revision: %#v", revisions)
+	}
+}
+
+func TestDurableReceiptFreezesEvidenceBusinessAndArtifactReferences(t *testing.T) {
+	t.Parallel()
+
+	service, owner, _, interaction, operation, receipt := mustCreateOperation(t)
+	businessRef := sessionvo.BusinessRef{
+		RefType: "object_type", RefID: "supplychain_hd0202_forecast",
+		BusinessDomainID: owner.BusinessDomainID, Version: "v3",
+		DisplayHint: "需求预测单",
+	}
+	_, durableReceipt, err := service.CompleteOperationAttempt(
+		context.Background(),
+		sessionsvc.FinishAttemptCommand{
+			Owner: owner, OperationID: operation.ID, Attempt: 1,
+			ReceiptID: receipt.ID, PayloadHash: "sha256:complete-with-evidence",
+			EvidenceDurability:   sessionvo.DurabilityDurable,
+			RequestID:            "req-complete-with-evidence",
+			TraceID:              "trace-complete-with-evidence",
+			ObservedEvidenceRefs: []string{"evt-data-query-1"},
+			BusinessRefs:         []sessionvo.BusinessRef{businessRef},
+			ArtifactRefs:         []string{"artifact://answer/fragment-1"},
+		},
+	)
+	if err != nil {
+		t.Fatalf("complete operation attempt: %v", err)
+	}
+	if len(durableReceipt.ObservedEvidenceRefs) != 1 ||
+		len(durableReceipt.BusinessRefs) != 1 ||
+		len(durableReceipt.ArtifactRefs) != 1 {
+		t.Fatalf("receipt omitted evidence metadata: %#v", durableReceipt)
+	}
+	_, err = service.TerminateInteraction(
+		context.Background(),
+		sessionsvc.TerminateInteractionCommand{
+			Owner: owner, InteractionID: interaction.ID,
+			Status:                 sessionvo.InteractionCompleted,
+			TerminalIdempotencyKey: "terminal-complete-with-evidence",
+			LeaseToken:             interaction.LeaseToken, LeaseEpoch: interaction.LeaseEpoch,
+			Manifest: sessionvo.ClosureManifest{
+				Version: "1", CompletionReason: "answer_returned",
+				ExpectedOperations: []sessionvo.ExpectedOperation{{
+					OperationID: operation.ID, Required: true,
+				}},
+				ExpectedReceipts: []sessionvo.ExpectedReceipt{{
+					ReceiptID: durableReceipt.ID, Required: true,
+				}},
+			},
+		},
+	)
+	if err != nil {
+		t.Fatalf("complete interaction: %v", err)
+	}
+	revisions, err := service.ListAssemblyRevisions(context.Background(), owner, interaction.ID)
+	if err != nil {
+		t.Fatalf("list assembly revisions: %v", err)
+	}
+	if len(revisions) != 1 ||
+		len(revisions[0].IncludedEventIDs) != 1 ||
+		revisions[0].IncludedEventIDs[0] != "evt-data-query-1" {
+		t.Fatalf("assembly omitted evidence event references: %#v", revisions)
+	}
+
+	_, _, err = service.CompleteOperationAttempt(
+		context.Background(),
+		sessionsvc.FinishAttemptCommand{
+			Owner: owner, OperationID: operation.ID, Attempt: 1,
+			ReceiptID: receipt.ID, PayloadHash: "sha256:complete-with-evidence",
+			EvidenceDurability:   sessionvo.DurabilityDurable,
+			RequestID:            "req-complete-with-evidence",
+			TraceID:              "trace-complete-with-evidence",
+			ObservedEvidenceRefs: []string{"evt-rewritten"},
+			BusinessRefs:         []sessionvo.BusinessRef{businessRef},
+			ArtifactRefs:         []string{"artifact://answer/fragment-1"},
+		},
+	)
+	if !sessionsvc.IsCode(err, sessionsvc.CodeIdempotencyConflict) {
+		t.Fatalf("receipt replay changed immutable evidence refs: %v", err)
+	}
+}
+
+func TestOptionalPendingReceiptDoesNotBlockEvidenceCompletion(t *testing.T) {
+	t.Parallel()
+
+	service, owner, _, interaction, operation, receipt := mustCreateOptionalOperation(t)
+	completed, err := service.TerminateInteraction(context.Background(), sessionsvc.TerminateInteractionCommand{
+		Owner: owner, InteractionID: interaction.ID, Status: sessionvo.InteractionCompleted,
+		TerminalIdempotencyKey: "terminal-optional", LeaseToken: interaction.LeaseToken,
+		LeaseEpoch: interaction.LeaseEpoch,
+		Manifest: sessionvo.ClosureManifest{
+			Version: "1", CompletionReason: "answer_returned",
+			ExpectedOperations: []sessionvo.ExpectedOperation{{OperationID: operation.ID, Required: false}},
+			ExpectedReceipts:   []sessionvo.ExpectedReceipt{{ReceiptID: receipt.ID, Required: false}},
+		},
+	})
+	if err != nil {
+		t.Fatalf("complete interaction: %v", err)
+	}
+	if completed.EvidenceStatus != sessionvo.EvidenceComplete {
+		t.Fatalf("optional pending receipt blocked completion: %s", completed.EvidenceStatus)
+	}
+}
+
+func TestLicenseLossStillTerminatesAndRecordsEvidenceOmission(t *testing.T) {
+	t.Parallel()
+
+	store := sessionstore.New()
+	service := sessionsvc.New(store, sessionsvc.Options{
+		EvidenceCollectionState: func() string { return "not_collected_due_to_license" },
+	})
+	owner := testOwner()
+	conversation := mustEnsureConversation(t, service, owner, "license-loss")
+	interaction, err := service.StartInteraction(context.Background(), sessionsvc.StartInteractionCommand{
+		Owner: owner, ConversationID: conversation.ID, IdempotencyKey: "license-start",
+	})
+	if err != nil {
+		t.Fatalf("start interaction: %v", err)
+	}
+	completed, err := service.TerminateInteraction(context.Background(), sessionsvc.TerminateInteractionCommand{
+		Owner: owner, InteractionID: interaction.ID, Status: sessionvo.InteractionCompleted,
+		TerminalIdempotencyKey: "license-terminal", LeaseToken: interaction.LeaseToken,
+		LeaseEpoch: interaction.LeaseEpoch,
+		Manifest: sessionvo.ClosureManifest{
+			Version: "1", CompletionReason: "answer_returned",
+		},
+	})
+	if err != nil || completed.ExecutionStatus != sessionvo.InteractionCompleted ||
+		completed.EvidenceStatus != sessionvo.EvidencePartial {
+		t.Fatalf("license loss blocked lifecycle completion: %#v, %v", completed, err)
+	}
+	revisions, err := service.ListAssemblyRevisions(context.Background(), owner, interaction.ID)
+	if err != nil || len(revisions) != 1 ||
+		len(revisions[0].PartialReasons) != 1 ||
+		revisions[0].PartialReasons[0] != "not_collected_due_to_license" {
+		t.Fatalf("license omission was not preserved: %#v, %v", revisions, err)
+	}
+}
+
+func TestAbandonExpiredOnlyTransitionsMatchingActiveLease(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 7, 30, 12, 0, 0, 0, time.UTC)
+	store := sessionstore.NewWithClock(func() time.Time { return now })
+	service := sessionsvc.New(store, sessionsvc.Options{})
+	owner := testOwner()
+	conversation := mustEnsureConversation(t, service, owner, "thread-expired")
+	expired, err := service.StartInteraction(context.Background(), sessionsvc.StartInteractionCommand{
+		Owner: owner, ConversationID: conversation.ID, IdempotencyKey: "expired",
+		LeaseDuration: time.Minute,
+	})
+	if err != nil {
+		t.Fatalf("start expired interaction: %v", err)
+	}
+	now = now.Add(2 * time.Minute)
+	abandoned, err := service.AbandonExpiredInteractions(context.Background(), 10)
+	if err != nil {
+		t.Fatalf("abandon expired interactions: %v", err)
+	}
+	if len(abandoned) != 1 || abandoned[0].ID != expired.ID ||
+		abandoned[0].ExecutionStatus != sessionvo.InteractionAbandoned {
+		t.Fatalf("unexpected abandoned interactions: %#v", abandoned)
+	}
+}
+
+func TestIdleOneShotConversationExpiresAndEnsureCreatesNextGeneration(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 7, 30, 12, 0, 0, 0, time.UTC)
+	store := sessionstore.NewWithClock(func() time.Time { return now })
+	service := sessionsvc.New(store, sessionsvc.Options{})
+	owner := testOwner()
+	oneShot, err := service.EnsureCurrentConversation(context.Background(), sessionsvc.EnsureConversationCommand{
+		Owner: owner, ExternalConversationKey: "idle-one-shot", OneShot: true,
+	})
+	if err != nil {
+		t.Fatalf("ensure one-shot conversation: %v", err)
+	}
+	regular := mustEnsureConversation(t, service, owner, "idle-regular")
+
+	now = now.Add(16 * time.Minute)
+	expired, err := service.ExpireIdleOneShotConversations(context.Background(), 15*time.Minute, 10)
+	if err != nil {
+		t.Fatalf("expire idle one-shot conversations: %v", err)
+	}
+	if len(expired) != 1 || expired[0].ID != oneShot.ID ||
+		expired[0].Status != sessionvo.ConversationExpired {
+		t.Fatalf("unexpected expired conversations: %#v", expired)
+	}
+	if _, err := service.StartInteraction(context.Background(), sessionsvc.StartInteractionCommand{
+		Owner: owner, ConversationID: oneShot.ID, IdempotencyKey: "expired-start",
+	}); !sessionsvc.IsCode(err, sessionsvc.CodeConversationExpired) {
+		t.Fatalf("expected conversation_expired when starting an expired one-shot, got %v", err)
+	}
+	if _, err := service.CloseConversation(context.Background(), sessionsvc.CloseConversationCommand{
+		Owner: owner, ConversationID: oneShot.ID, IdempotencyKey: "expired-close",
+	}); !sessionsvc.IsCode(err, sessionsvc.CodeConversationExpired) {
+		t.Fatalf("expected closing an expired conversation to preserve expiry, got %v", err)
+	}
+	preserved, err := service.GetConversation(context.Background(), owner, oneShot.ID)
+	if err != nil || preserved.Status != sessionvo.ConversationExpired {
+		t.Fatalf("expired status was rewritten: %#v, %v", preserved, err)
+	}
+	stillActive, err := service.GetConversation(context.Background(), owner, regular.ID)
+	if err != nil || stillActive.Status != sessionvo.ConversationActive {
+		t.Fatalf("regular conversation was expired: %#v, %v", stillActive, err)
+	}
+	next, err := service.EnsureCurrentConversation(context.Background(), sessionsvc.EnsureConversationCommand{
+		Owner: owner, ExternalConversationKey: "idle-one-shot", OneShot: true,
+	})
+	if err != nil {
+		t.Fatalf("ensure next one-shot generation: %v", err)
+	}
+	if next.Generation != 2 || next.ID == oneShot.ID {
+		t.Fatalf("expected generation 2 after expiry: %#v", next)
+	}
+}
+
+func TestAbandonExpiredOneShotInteractionClosesConversation(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 7, 30, 12, 0, 0, 0, time.UTC)
+	store := sessionstore.NewWithClock(func() time.Time { return now })
+	service := sessionsvc.New(store, sessionsvc.Options{})
+	owner := testOwner()
+	conversation, err := service.EnsureCurrentConversation(context.Background(), sessionsvc.EnsureConversationCommand{
+		Owner: owner, ExternalConversationKey: "abandoned-one-shot", OneShot: true,
+	})
+	if err != nil {
+		t.Fatalf("ensure one-shot conversation: %v", err)
+	}
+	if _, err := service.StartInteraction(context.Background(), sessionsvc.StartInteractionCommand{
+		Owner: owner, ConversationID: conversation.ID, IdempotencyKey: "abandoned-one-shot",
+		LeaseDuration: time.Minute,
+	}); err != nil {
+		t.Fatalf("start one-shot interaction: %v", err)
+	}
+
+	now = now.Add(2 * time.Minute)
+	if _, err := service.AbandonExpiredInteractions(context.Background(), 10); err != nil {
+		t.Fatalf("abandon expired interaction: %v", err)
+	}
+	closed, err := service.GetConversation(context.Background(), owner, conversation.ID)
+	if err != nil {
+		t.Fatalf("get one-shot conversation: %v", err)
+	}
+	if closed.Status != sessionvo.ConversationClosed || closed.ClosedAt == nil {
+		t.Fatalf("abandoned one-shot conversation was not closed: %#v", closed)
+	}
+}
+
+func TestExpiredLeaseCannotTerminateOrCreateOperationBeforeReaper(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 7, 30, 12, 0, 0, 0, time.UTC)
+	store := sessionstore.NewWithClock(func() time.Time { return now })
+	service := sessionsvc.New(store, sessionsvc.Options{})
+	owner := testOwner()
+	conversation := mustEnsureConversation(t, service, owner, "thread-expired-write")
+	interaction, err := service.StartInteraction(context.Background(), sessionsvc.StartInteractionCommand{
+		Owner: owner, ConversationID: conversation.ID, IdempotencyKey: "expired-write",
+		LeaseDuration: time.Minute,
+	})
+	if err != nil {
+		t.Fatalf("start interaction: %v", err)
+	}
+	now = now.Add(2 * time.Minute)
+	if _, _, err := service.EnsureOperation(context.Background(), sessionsvc.EnsureOperationCommand{
+		Owner: owner, ConversationID: conversation.ID, InteractionID: interaction.ID,
+		OperationKey: "expired-op", ToolName: "query",
+		NormalizedInputHash: "sha256:expired", Required: true,
+		LeaseToken: interaction.LeaseToken, LeaseEpoch: interaction.LeaseEpoch,
+	}); !sessionsvc.IsCode(err, sessionsvc.CodeInteractionTerminal) {
+		t.Fatalf("expected expired lease to reject operation, got %v", err)
+	}
+	if _, err := service.TerminateInteraction(context.Background(), sessionsvc.TerminateInteractionCommand{
+		Owner: owner, InteractionID: interaction.ID, Status: sessionvo.InteractionCanceled,
+		TerminalIdempotencyKey: "expired-terminal", LeaseToken: interaction.LeaseToken,
+		LeaseEpoch: interaction.LeaseEpoch,
+	}); !sessionsvc.IsCode(err, sessionsvc.CodeTerminalConflict) {
+		t.Fatalf("expected expired lease to reject terminal write, got %v", err)
+	}
+}
+
+func TestRequestProjectionHasRequestRatherThanReceiptCardinality(t *testing.T) {
+	t.Parallel()
+
+	service, owner, conversation, interaction, operation, receipt := mustCreateOperation(t)
+	if _, _, err := service.CompleteOperationAttempt(context.Background(), sessionsvc.FinishAttemptCommand{
+		Owner: owner, OperationID: operation.ID, Attempt: 1, ReceiptID: receipt.ID,
+		PayloadHash: "sha256:request-result", EvidenceDurability: sessionvo.DurabilityDurable,
+		RequestID: "req-shared", TraceID: "trace-one",
+	}); err != nil {
+		t.Fatalf("complete first operation: %v", err)
+	}
+	secondOperation, secondReceipt, err := service.EnsureOperation(context.Background(), sessionsvc.EnsureOperationCommand{
+		Owner: owner, ConversationID: conversation.ID, InteractionID: interaction.ID,
+		OperationKey: "logical-call-2", ToolName: "metric-query",
+		NormalizedInputHash: "sha256:input-2", Required: true,
+		LeaseToken: interaction.LeaseToken, LeaseEpoch: interaction.LeaseEpoch,
+	})
+	if err != nil {
+		t.Fatalf("ensure second operation: %v", err)
+	}
+	if _, _, err := service.CompleteOperationAttempt(context.Background(), sessionsvc.FinishAttemptCommand{
+		Owner: owner, OperationID: secondOperation.ID, Attempt: 1, ReceiptID: secondReceipt.ID,
+		PayloadHash: "sha256:request-result-2", EvidenceDurability: sessionvo.DurabilityDurable,
+		RequestID: "req-shared", TraceID: "trace-two",
+	}); err != nil {
+		t.Fatalf("complete second operation: %v", err)
+	}
+
+	requests, err := service.ListRequests(context.Background(), owner, 20)
+	if err != nil {
+		t.Fatalf("list requests: %v", err)
+	}
+	if len(requests) != 1 || requests[0].RequestID != "req-shared" ||
+		requests[0].ReceiptCount != 2 || requests[0].OperationCount != 2 {
+		t.Fatalf("unexpected request projection: %#v", requests)
+	}
+}
+
+func TestInteractionRejectsOperationBeyondCapacityLimit(t *testing.T) {
+	t.Parallel()
+
+	service := newTestService()
+	owner := testOwner()
+	conversation := mustEnsureConversation(t, service, owner, "operation-capacity")
+	interaction, err := service.StartInteraction(context.Background(), sessionsvc.StartInteractionCommand{
+		Owner: owner, ConversationID: conversation.ID, IdempotencyKey: "operation-capacity",
+	})
+	if err != nil {
+		t.Fatalf("start interaction: %v", err)
+	}
+	for index := 0; index < 128; index++ {
+		if _, _, err := service.EnsureOperation(context.Background(), sessionsvc.EnsureOperationCommand{
+			Owner: owner, ConversationID: conversation.ID, InteractionID: interaction.ID,
+			OperationKey: fmt.Sprintf("operation-%03d", index), ToolName: "query",
+			NormalizedInputHash: fmt.Sprintf("sha256:%03d", index),
+			LeaseToken:          interaction.LeaseToken, LeaseEpoch: interaction.LeaseEpoch,
+		}); err != nil {
+			t.Fatalf("ensure operation %d: %v", index, err)
+		}
+	}
+	if _, _, err := service.EnsureOperation(context.Background(), sessionsvc.EnsureOperationCommand{
+		Owner: owner, ConversationID: conversation.ID, InteractionID: interaction.ID,
+		OperationKey: "operation-over-limit", ToolName: "query",
+		NormalizedInputHash: "sha256:over-limit",
+		LeaseToken:          interaction.LeaseToken, LeaseEpoch: interaction.LeaseEpoch,
+	}); !sessionsvc.IsCode(err, sessionsvc.CodeOperationRequired) {
+		t.Fatalf("expected operation capacity rejection, got %v", err)
+	}
+}
+
+func TestClosureManifestRejectsClaimsBeyondCapacityLimit(t *testing.T) {
+	t.Parallel()
+
+	service := newTestService()
+	owner := testOwner()
+	conversation := mustEnsureConversation(t, service, owner, "claim-capacity")
+	interaction, err := service.StartInteraction(context.Background(), sessionsvc.StartInteractionCommand{
+		Owner: owner, ConversationID: conversation.ID, IdempotencyKey: "claim-capacity",
+	})
+	if err != nil {
+		t.Fatalf("start interaction: %v", err)
+	}
+	claims := make([]string, 33)
+	for index := range claims {
+		claims[index] = fmt.Sprintf("claim-%02d", index)
+	}
+	if _, err := service.TerminateInteraction(context.Background(), sessionsvc.TerminateInteractionCommand{
+		Owner: owner, InteractionID: interaction.ID, Status: sessionvo.InteractionCompleted,
+		TerminalIdempotencyKey: "claim-capacity", LeaseToken: interaction.LeaseToken,
+		LeaseEpoch: interaction.LeaseEpoch,
+		Manifest: sessionvo.ClosureManifest{
+			Version: "1", CompletionReason: "answer_returned", Claims: claims,
+		},
+	}); !sessionsvc.IsCode(err, sessionsvc.CodeClosureManifestInvalid) {
+		t.Fatalf("expected claim capacity rejection, got %v", err)
+	}
+}
+
+func TestReceiptRejectsEvidenceReferencesBeyondCapacityLimit(t *testing.T) {
+	t.Parallel()
+
+	service, owner, _, _, operation, receipt := mustCreateOperation(t)
+	references := make([]string, 2049)
+	for index := range references {
+		references[index] = fmt.Sprintf("event-%04d", index)
+	}
+	if _, _, err := service.CompleteOperationAttempt(context.Background(), sessionsvc.FinishAttemptCommand{
+		Owner: owner, OperationID: operation.ID, Attempt: 1, ReceiptID: receipt.ID,
+		PayloadHash: "sha256:too-many-evidence-refs", EvidenceDurability: sessionvo.DurabilityDurable,
+		RequestID: "req-capacity", TraceID: "trace-capacity", ObservedEvidenceRefs: references,
+	}); !sessionsvc.IsCode(err, sessionsvc.CodeOperationRequired) {
+		t.Fatalf("expected evidence reference capacity rejection, got %v", err)
+	}
+}
+
+func newTestService() *sessionsvc.Service {
+	return sessionsvc.New(sessionstore.New(), sessionsvc.Options{})
+}
+
+func testOwner() sessionvo.Owner {
+	return sessionvo.Owner{
+		TenantID:               "tenant-1",
+		BusinessDomainID:       "domain-1",
+		ApplicationPrincipalID: "app-1",
+		EffectiveSubjectType:   sessionvo.SubjectUser,
+		EffectiveSubjectID:     "user-1",
+	}
+}
+
+type testMetrics struct {
+	counters map[string]uint64
+	gauges   map[string]float64
+}
+
+func newTestMetrics() *testMetrics {
+	return &testMetrics{counters: make(map[string]uint64), gauges: make(map[string]float64)}
+}
+
+func (m *testMetrics) Increment(name string) {
+	m.Add(name, 1)
+}
+
+func (m *testMetrics) Add(name string, delta uint64) {
+	m.counters[name] += delta
+}
+
+func (m *testMetrics) Set(name string, value float64) {
+	m.gauges[name] = value
+}
+
+func (m *testMetrics) count(name string) uint64 {
+	return m.counters[name]
+}
+
+func mustEnsureConversation(t *testing.T, service *sessionsvc.Service, owner sessionvo.Owner, externalKey string) sessionvo.Conversation {
+	t.Helper()
+	conversation, err := service.EnsureCurrentConversation(context.Background(), sessionsvc.EnsureConversationCommand{
+		Owner: owner, ExternalConversationKey: externalKey, IdempotencyKey: "ensure-" + externalKey,
+	})
+	if err != nil {
+		t.Fatalf("ensure conversation: %v", err)
+	}
+	return conversation
+}
+
+func mustCreateOperation(t *testing.T) (*sessionsvc.Service, sessionvo.Owner, sessionvo.Conversation, sessionvo.Interaction, sessionvo.Operation, sessionvo.Receipt) {
+	t.Helper()
+	service := newTestService()
+	owner := testOwner()
+	conversation := mustEnsureConversation(t, service, owner, "thread-operation")
+	interaction, err := service.StartInteraction(context.Background(), sessionsvc.StartInteractionCommand{
+		Owner: owner, ConversationID: conversation.ID, IdempotencyKey: "start-operation",
+	})
+	if err != nil {
+		t.Fatalf("start interaction: %v", err)
+	}
+	operation, receipt, err := service.EnsureOperation(context.Background(), sessionsvc.EnsureOperationCommand{
+		Owner: owner, ConversationID: conversation.ID, InteractionID: interaction.ID,
+		OperationKey: "logical-call", ToolName: "ontology-query",
+		NormalizedInputHash: "sha256:input", Required: true,
+		LeaseToken: interaction.LeaseToken, LeaseEpoch: interaction.LeaseEpoch,
+	})
+	if err != nil {
+		t.Fatalf("ensure operation: %v", err)
+	}
+	return service, owner, conversation, interaction, operation, receipt
+}
+
+func mustCreateOptionalOperation(t *testing.T) (*sessionsvc.Service, sessionvo.Owner, sessionvo.Conversation, sessionvo.Interaction, sessionvo.Operation, sessionvo.Receipt) {
+	t.Helper()
+	service := newTestService()
+	owner := testOwner()
+	conversation := mustEnsureConversation(t, service, owner, "thread-optional-operation")
+	interaction, err := service.StartInteraction(context.Background(), sessionsvc.StartInteractionCommand{
+		Owner: owner, ConversationID: conversation.ID, IdempotencyKey: "start-optional-operation",
+	})
+	if err != nil {
+		t.Fatalf("start interaction: %v", err)
+	}
+	operation, receipt, err := service.EnsureOperation(context.Background(), sessionsvc.EnsureOperationCommand{
+		Owner: owner, ConversationID: conversation.ID, InteractionID: interaction.ID,
+		OperationKey: "optional-call", ToolName: "optional-query",
+		NormalizedInputHash: "sha256:optional-input", Required: false,
+		LeaseToken: interaction.LeaseToken, LeaseEpoch: interaction.LeaseEpoch,
+	})
+	if err != nil {
+		t.Fatalf("ensure optional operation: %v", err)
+	}
+	return service, owner, conversation, interaction, operation, receipt
+}

--- a/bkn-trace/agent-observability/src/domain/valueobject/ledgervo/causality.go
+++ b/bkn-trace/agent-observability/src/domain/valueobject/ledgervo/causality.go
@@ -1,0 +1,38 @@
+package ledgervo
+
+func HasCausationCycle(events []Event) bool {
+	graph := make(map[string][]string, len(events))
+	for _, event := range events {
+		graph[event.EventID] = append([]string(nil), event.CausationEventIDs...)
+	}
+	visiting := make(map[string]bool, len(graph))
+	visited := make(map[string]bool, len(graph))
+	var visit func(string) bool
+	visit = func(eventID string) bool {
+		if visiting[eventID] {
+			return true
+		}
+		if visited[eventID] {
+			return false
+		}
+		causes, exists := graph[eventID]
+		if !exists {
+			return false
+		}
+		visiting[eventID] = true
+		for _, causeID := range causes {
+			if visit(causeID) {
+				return true
+			}
+		}
+		visiting[eventID] = false
+		visited[eventID] = true
+		return false
+	}
+	for eventID := range graph {
+		if visit(eventID) {
+			return true
+		}
+	}
+	return false
+}

--- a/bkn-trace/agent-observability/src/domain/valueobject/ledgervo/event.go
+++ b/bkn-trace/agent-observability/src/domain/valueobject/ledgervo/event.go
@@ -1,0 +1,69 @@
+package ledgervo
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"time"
+
+	"github.com/openbkn-ai/bkn-foundry/bkn-trace/agent-observability/src/domain/valueobject/sessionvo"
+)
+
+type Event struct {
+	EventID           string                  `json:"event_id"`
+	EventType         string                  `json:"event_type"`
+	SchemaVersion     string                  `json:"schema_version"`
+	PayloadHash       string                  `json:"payload_hash"`
+	Owner             sessionvo.Owner         `json:"owner"`
+	ConversationID    string                  `json:"conversation_id"`
+	InteractionID     string                  `json:"interaction_id"`
+	OperationID       string                  `json:"operation_id,omitempty"`
+	Attempt           uint32                  `json:"attempt,omitempty"`
+	RequestID         string                  `json:"request_id,omitempty"`
+	TraceID           string                  `json:"trace_id,omitempty"`
+	SpanID            string                  `json:"span_id,omitempty"`
+	ProducerID        string                  `json:"producer_id"`
+	ProducerStreamID  string                  `json:"producer_stream_id"`
+	ProducerEpoch     uint64                  `json:"producer_epoch"`
+	ProducerSequence  uint64                  `json:"producer_sequence"`
+	CausationEventIDs []string                `json:"causation_event_ids,omitempty"`
+	CausalityStatus   string                  `json:"causality_status,omitempty"`
+	MissingCauseIDs   []string                `json:"missing_causation_event_ids,omitempty"`
+	StartedAt         time.Time               `json:"started_at"`
+	ObservedAt        time.Time               `json:"observed_at"`
+	EmittedAt         time.Time               `json:"emitted_at"`
+	Envelope          json.RawMessage         `json:"envelope"`
+	BusinessRefs      []sessionvo.BusinessRef `json:"business_refs,omitempty"`
+	ArtifactRefs      []string                `json:"artifact_refs,omitempty"`
+}
+
+type DurableAck struct {
+	EventID        string    `json:"event_id"`
+	Durable        bool      `json:"durable_ack"`
+	Replayed       bool      `json:"replayed"`
+	IngestSequence uint64    `json:"ingest_sequence"`
+	IngestedAt     time.Time `json:"ingested_at"`
+}
+
+func CanonicalPayloadHash(payload json.RawMessage) string {
+	var decoded any
+	if err := json.Unmarshal(payload, &decoded); err == nil {
+		if canonical, err := json.Marshal(decoded); err == nil {
+			payload = canonical
+		}
+	}
+	sum := sha256.Sum256(payload)
+	return hex.EncodeToString(sum[:])
+}
+
+func ImmutableRecordHash(event Event) string {
+	event.CausalityStatus = ""
+	event.MissingCauseIDs = nil
+	var decoded any
+	if json.Unmarshal(event.Envelope, &decoded) == nil {
+		event.Envelope, _ = json.Marshal(decoded)
+	}
+	data, _ := json.Marshal(event)
+	sum := sha256.Sum256(data)
+	return hex.EncodeToString(sum[:])
+}

--- a/bkn-trace/agent-observability/src/domain/valueobject/sessionvo/assembly.go
+++ b/bkn-trace/agent-observability/src/domain/valueobject/sessionvo/assembly.go
@@ -1,0 +1,18 @@
+package sessionvo
+
+import "time"
+
+type AssemblyRevision struct {
+	ID                        string         `json:"revision_id"`
+	RevisionNo                uint64         `json:"revision_no"`
+	ParentRevisionID          string         `json:"parent_revision_id,omitempty"`
+	InteractionID             string         `json:"interaction_id"`
+	CompletionManifestVersion string         `json:"completion_manifest_version"`
+	IncludedReceiptIDs        []string       `json:"included_receipt_ids"`
+	IncludedEventIDs          []string       `json:"included_event_ids"`
+	ArtifactManifestHash      string         `json:"artifact_manifest_hash"`
+	Completeness              EvidenceStatus `json:"assembly_completeness"`
+	PartialReasons            []string       `json:"partial_reasons,omitempty"`
+	Trigger                   string         `json:"trigger"`
+	CreatedAt                 time.Time      `json:"created_at"`
+}

--- a/bkn-trace/agent-observability/src/domain/valueobject/sessionvo/conversation.go
+++ b/bkn-trace/agent-observability/src/domain/valueobject/sessionvo/conversation.go
@@ -1,0 +1,50 @@
+package sessionvo
+
+import "time"
+
+type SubjectType string
+
+const (
+	SubjectUser    SubjectType = "user"
+	SubjectService SubjectType = "service"
+)
+
+type ConversationStatus string
+
+const (
+	ConversationActive  ConversationStatus = "active"
+	ConversationClosed  ConversationStatus = "closed"
+	ConversationExpired ConversationStatus = "expired"
+)
+
+type Owner struct {
+	TenantID               string      `json:"tenant_id"`
+	BusinessDomainID       string      `json:"business_domain_id"`
+	ApplicationPrincipalID string      `json:"application_principal_id"`
+	EffectiveSubjectType   SubjectType `json:"effective_subject_type"`
+	EffectiveSubjectID     string      `json:"effective_subject_id"`
+	DelegationID           string      `json:"delegation_id,omitempty"`
+}
+
+func (o Owner) Equal(other Owner) bool {
+	return o == other
+}
+
+func (o Owner) Key() string {
+	return o.TenantID + "\x00" + o.BusinessDomainID + "\x00" +
+		o.ApplicationPrincipalID + "\x00" + string(o.EffectiveSubjectType) +
+		"\x00" + o.EffectiveSubjectID + "\x00" + o.DelegationID
+}
+
+type Conversation struct {
+	ID                      string             `json:"conversation_id"`
+	Owner                   Owner              `json:"owner"`
+	ExternalConversationKey string             `json:"external_conversation_key"`
+	Generation              uint64             `json:"generation"`
+	Status                  ConversationStatus `json:"status"`
+	OneShot                 bool               `json:"one_shot"`
+	RowVersion              uint64             `json:"row_version"`
+	CreatedAt               time.Time          `json:"created_at"`
+	UpdatedAt               time.Time          `json:"updated_at"`
+	ClosedAt                *time.Time         `json:"closed_at,omitempty"`
+}

--- a/bkn-trace/agent-observability/src/domain/valueobject/sessionvo/idempotency.go
+++ b/bkn-trace/agent-observability/src/domain/valueobject/sessionvo/idempotency.go
@@ -1,0 +1,14 @@
+package sessionvo
+
+import "time"
+
+type IdempotencyRecord struct {
+	Scope                   string
+	Owner                   Owner
+	ExternalConversationKey string
+	IdempotencyKey          string
+	RequestHash             string
+	ResourceType            string
+	ResourceID              string
+	CreatedAt               time.Time
+}

--- a/bkn-trace/agent-observability/src/domain/valueobject/sessionvo/interaction.go
+++ b/bkn-trace/agent-observability/src/domain/valueobject/sessionvo/interaction.go
@@ -1,0 +1,69 @@
+package sessionvo
+
+import "time"
+
+type InteractionStatus string
+
+const (
+	InteractionActive    InteractionStatus = "active"
+	InteractionCompleted InteractionStatus = "completed"
+	InteractionFailed    InteractionStatus = "failed"
+	InteractionCanceled  InteractionStatus = "canceled"
+	InteractionHandedOff InteractionStatus = "handed_off"
+	InteractionAbandoned InteractionStatus = "abandoned"
+)
+
+type EvidenceStatus string
+
+const (
+	EvidenceNotApplicable EvidenceStatus = "not_applicable"
+	EvidenceAssembling    EvidenceStatus = "assembling"
+	EvidenceComplete      EvidenceStatus = "complete"
+	EvidencePartial       EvidenceStatus = "partial"
+	EvidenceFailed        EvidenceStatus = "failed"
+)
+
+type ClosureManifest struct {
+	Version              string              `json:"completion_manifest_version"`
+	AnswerArtifactRef    string              `json:"answer_artifact_ref,omitempty"`
+	Claims               []string            `json:"claims,omitempty"`
+	ExpectedOperations   []ExpectedOperation `json:"expected_operations,omitempty"`
+	ExpectedReceipts     []ExpectedReceipt   `json:"expected_receipts,omitempty"`
+	AssemblerDeadline    *time.Time          `json:"assembler_deadline,omitempty"`
+	CompletionReason     string              `json:"completion_reason"`
+	SystemPartialReasons []string            `json:"system_partial_reasons,omitempty"`
+}
+
+type ExpectedOperation struct {
+	OperationID string `json:"operation_id"`
+	Required    bool   `json:"required"`
+}
+
+type ExpectedReceipt struct {
+	ReceiptID string `json:"receipt_id"`
+	Required  bool   `json:"required"`
+}
+
+type Interaction struct {
+	ID                     string            `json:"interaction_id"`
+	ConversationID         string            `json:"conversation_id"`
+	Ordinal                uint64            `json:"ordinal"`
+	ExecutionStatus        InteractionStatus `json:"execution_status"`
+	EvidenceStatus         EvidenceStatus    `json:"evidence_status"`
+	StartIdempotencyKey    string            `json:"-"`
+	TerminalIdempotencyKey string            `json:"-"`
+	TerminalPayloadHash    string            `json:"-"`
+	ClosureManifest        *ClosureManifest  `json:"closure_manifest,omitempty"`
+	LeaseToken             string            `json:"lease_token"`
+	LeaseEpoch             uint64            `json:"lease_epoch"`
+	LeaseVersion           uint64            `json:"lease_version"`
+	LeaseExpiresAt         time.Time         `json:"lease_expires_at"`
+	RowVersion             uint64            `json:"row_version"`
+	CreatedAt              time.Time         `json:"created_at"`
+	UpdatedAt              time.Time         `json:"updated_at"`
+	TerminalAt             *time.Time        `json:"terminal_at,omitempty"`
+}
+
+func (i Interaction) IsTerminal() bool {
+	return i.ExecutionStatus != InteractionActive
+}

--- a/bkn-trace/agent-observability/src/domain/valueobject/sessionvo/operation.go
+++ b/bkn-trace/agent-observability/src/domain/valueobject/sessionvo/operation.go
@@ -1,0 +1,77 @@
+package sessionvo
+
+import "time"
+
+type AttemptStatus string
+
+const (
+	AttemptPending   AttemptStatus = "pending"
+	AttemptCompleted AttemptStatus = "completed"
+	AttemptFailed    AttemptStatus = "failed"
+)
+
+type ReceiptStatus string
+type EvidenceDurability string
+
+const (
+	ReceiptPending   ReceiptStatus = "pending"
+	ReceiptCompleted ReceiptStatus = "completed"
+	ReceiptFailed    ReceiptStatus = "failed"
+
+	DurabilityPending EvidenceDurability = "pending"
+	DurabilityDurable EvidenceDurability = "durable"
+	DurabilityFailed  EvidenceDurability = "failed"
+)
+
+type Operation struct {
+	ID                  string        `json:"operation_id"`
+	ConversationID      string        `json:"conversation_id"`
+	InteractionID       string        `json:"interaction_id"`
+	OperationKey        string        `json:"operation_key"`
+	ToolName            string        `json:"tool_name"`
+	NormalizedInputHash string        `json:"normalized_input_hash"`
+	ParentOperationID   string        `json:"parent_operation_id,omitempty"`
+	CausationEventIDs   []string      `json:"causation_event_ids,omitempty"`
+	Attempt             uint32        `json:"attempt"`
+	AttemptStatus       AttemptStatus `json:"attempt_status"`
+	Retryable           bool          `json:"retryable"`
+	RowVersion          uint64        `json:"row_version"`
+	CreatedAt           time.Time     `json:"created_at"`
+	UpdatedAt           time.Time     `json:"updated_at"`
+}
+
+type Receipt struct {
+	ID                   string             `json:"receipt_id"`
+	SchemaVersion        string             `json:"schema_version"`
+	Owner                Owner              `json:"owner"`
+	ConversationID       string             `json:"conversation_id"`
+	InteractionID        string             `json:"interaction_id"`
+	OperationID          string             `json:"operation_id"`
+	Attempt              uint32             `json:"attempt"`
+	OperationKey         string             `json:"operation_key"`
+	ToolName             string             `json:"tool_name"`
+	NormalizedInputHash  string             `json:"normalized_input_hash"`
+	Status               ReceiptStatus      `json:"receipt_status"`
+	EvidenceDurability   EvidenceDurability `json:"evidence_durability"`
+	Required             bool               `json:"required"`
+	RequestID            string             `json:"request_id"`
+	TraceID              string             `json:"trace_id"`
+	CausationEventIDs    []string           `json:"causation_event_ids"`
+	ObservedEvidenceRefs []string           `json:"observed_evidence_refs"`
+	BusinessRefs         []BusinessRef      `json:"business_refs"`
+	ArtifactRefs         []string           `json:"artifact_refs"`
+	PartialReasons       []string           `json:"partial_reasons"`
+	RowVersion           uint64             `json:"row_version"`
+	IssuedAt             time.Time          `json:"issued_at"`
+	TerminalAt           *time.Time         `json:"terminal_at,omitempty"`
+	PayloadHash          string             `json:"payload_hash"`
+}
+
+type BusinessRef struct {
+	RefType          string     `json:"ref_type"`
+	RefID            string     `json:"ref_id"`
+	BusinessDomainID string     `json:"business_domain_id"`
+	Version          string     `json:"version"`
+	AsOf             *time.Time `json:"as_of,omitempty"`
+	DisplayHint      string     `json:"display_hint,omitempty"`
+}

--- a/bkn-trace/agent-observability/src/domain/valueobject/sessionvo/projection.go
+++ b/bkn-trace/agent-observability/src/domain/valueobject/sessionvo/projection.go
@@ -1,0 +1,10 @@
+package sessionvo
+
+type ProjectionMutation struct {
+	EventID          string
+	AggregateType    string
+	AggregateID      string
+	AggregateVersion uint64
+	EventType        string
+	Payload          []byte
+}

--- a/bkn-trace/agent-observability/src/domain/valueobject/sessionvo/request.go
+++ b/bkn-trace/agent-observability/src/domain/valueobject/sessionvo/request.go
@@ -1,0 +1,13 @@
+package sessionvo
+
+import "time"
+
+type RequestSummary struct {
+	RequestID      string    `json:"request_id"`
+	ConversationID string    `json:"conversation_id"`
+	InteractionID  string    `json:"interaction_id"`
+	OperationCount int       `json:"operation_count"`
+	ReceiptCount   int       `json:"receipt_count"`
+	TraceIDs       []string  `json:"trace_ids,omitempty"`
+	UpdatedAt      time.Time `json:"updated_at"`
+}

--- a/bkn-trace/agent-observability/src/drivenadapter/dbaccess/mariadb/sessionstore/ledger.go
+++ b/bkn-trace/agent-observability/src/drivenadapter/dbaccess/mariadb/sessionstore/ledger.go
@@ -265,7 +265,7 @@ func verifyCausationAcyclic(ctx context.Context, tx *sql.Tx, event ledgervo.Even
 	if err != nil {
 		return err
 	}
-	defer rows.Close()
+	defer func() { _ = rows.Close() }()
 	events := []ledgervo.Event{event}
 	for rows.Next() {
 		var envelope []byte

--- a/bkn-trace/agent-observability/src/drivenadapter/dbaccess/mariadb/sessionstore/ledger.go
+++ b/bkn-trace/agent-observability/src/drivenadapter/dbaccess/mariadb/sessionstore/ledger.go
@@ -1,0 +1,304 @@
+package sessionstore
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/openbkn-ai/bkn-foundry/bkn-trace/agent-observability/src/domain/valueobject/ledgervo"
+	"github.com/openbkn-ai/bkn-foundry/bkn-trace/agent-observability/src/port/driven/ievidenceledger"
+)
+
+func (s *Store) Commit(ctx context.Context, event ledgervo.Event) (ledgervo.DurableAck, error) {
+	for attempt := 0; attempt < transactionRetries; attempt++ {
+		ack, retry, err := s.commitEvidenceOnce(ctx, event)
+		if !retry {
+			return ack, err
+		}
+	}
+	return ledgervo.DurableAck{}, errors.New("evidence transaction retry budget exhausted")
+}
+
+func (s *Store) commitEvidenceOnce(ctx context.Context, event ledgervo.Event) (ledgervo.DurableAck, bool, error) {
+	tx, err := s.db.BeginTx(ctx, &sql.TxOptions{Isolation: sql.LevelSerializable})
+	if err != nil {
+		return ledgervo.DurableAck{}, false, err
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	if err := verifyEvidenceOwnership(ctx, tx, event); err != nil {
+		return ledgervo.DurableAck{}, false, err
+	}
+
+	var existingHash string
+	var existingSequence uint64
+	var ingestedAt time.Time
+	err = tx.QueryRowContext(ctx, `
+		SELECT immutable_record_hash, ingest_sequence, ingested_at
+		FROM bkn_trace_evidence_event_ledger WHERE event_id=? FOR UPDATE`,
+		event.EventID,
+	).Scan(&existingHash, &existingSequence, &ingestedAt)
+	recordHash := ledgervo.ImmutableRecordHash(event)
+	switch {
+	case err == nil && existingHash == recordHash:
+		if err := tx.Commit(); err != nil {
+			return ledgervo.DurableAck{}, retryableTransactionError(err), err
+		}
+		return ledgervo.DurableAck{
+			EventID: event.EventID, Durable: true, Replayed: true,
+			IngestSequence: existingSequence, IngestedAt: ingestedAt.UTC(),
+		}, false, nil
+	case err == nil:
+		if err := insertEvidenceConflict(ctx, tx, event, existingHash); err != nil {
+			return ledgervo.DurableAck{}, retryableTransactionError(err), err
+		}
+		if err := tx.Commit(); err != nil {
+			return ledgervo.DurableAck{}, retryableTransactionError(err), err
+		}
+		return ledgervo.DurableAck{}, false, ievidenceledger.ErrPayloadConflict
+	case !errors.Is(err, sql.ErrNoRows):
+		return ledgervo.DurableAck{}, retryableTransactionError(err), err
+	}
+
+	missingCauses, err := verifyCausationScope(ctx, tx, event)
+	if err != nil {
+		if conflictErr := insertEvidenceConflict(ctx, tx, event, event.PayloadHash); conflictErr != nil {
+			return ledgervo.DurableAck{}, retryableTransactionError(conflictErr), conflictErr
+		}
+		if commitErr := tx.Commit(); commitErr != nil {
+			return ledgervo.DurableAck{}, retryableTransactionError(commitErr), commitErr
+		}
+		return ledgervo.DurableAck{}, false, err
+	}
+	if err := verifyCausationAcyclic(ctx, tx, event); err != nil {
+		if conflictErr := insertEvidenceConflict(ctx, tx, event, event.PayloadHash); conflictErr != nil {
+			return ledgervo.DurableAck{}, retryableTransactionError(conflictErr), conflictErr
+		}
+		if commitErr := tx.Commit(); commitErr != nil {
+			return ledgervo.DurableAck{}, retryableTransactionError(commitErr), commitErr
+		}
+		return ledgervo.DurableAck{}, false, err
+	}
+	event.CausalityStatus = "complete"
+	if len(missingCauses) > 0 {
+		event.CausalityStatus = "causality_missing"
+		event.MissingCauseIDs = missingCauses
+	}
+
+	var streamEventID, streamHash string
+	err = tx.QueryRowContext(ctx, `
+		SELECT event_id, payload_hash FROM bkn_trace_evidence_event_ledger
+		WHERE tenant_id=? AND producer_stream_id=? AND producer_epoch=? AND producer_sequence=?
+		FOR UPDATE`,
+		event.Owner.TenantID, event.ProducerStreamID, event.ProducerEpoch, event.ProducerSequence,
+	).Scan(&streamEventID, &streamHash)
+	if err == nil && streamEventID != event.EventID {
+		if err := insertEvidenceConflict(ctx, tx, event, streamHash); err != nil {
+			return ledgervo.DurableAck{}, retryableTransactionError(err), err
+		}
+		if err := tx.Commit(); err != nil {
+			return ledgervo.DurableAck{}, retryableTransactionError(err), err
+		}
+		return ledgervo.DurableAck{}, false, ievidenceledger.ErrSequenceConflict
+	}
+	if err != nil && !errors.Is(err, sql.ErrNoRows) {
+		return ledgervo.DurableAck{}, retryableTransactionError(err), err
+	}
+	var maxEpoch sql.NullInt64
+	if err := tx.QueryRowContext(ctx, `
+		SELECT MAX(producer_epoch) FROM bkn_trace_evidence_event_ledger
+		WHERE tenant_id=? AND producer_stream_id=? FOR UPDATE`,
+		event.Owner.TenantID, event.ProducerStreamID,
+	).Scan(&maxEpoch); err != nil {
+		return ledgervo.DurableAck{}, retryableTransactionError(err), err
+	}
+	if maxEpoch.Valid && event.ProducerEpoch < uint64(maxEpoch.Int64) {
+		if err := insertEvidenceConflict(ctx, tx, event, event.PayloadHash); err != nil {
+			return ledgervo.DurableAck{}, retryableTransactionError(err), err
+		}
+		if err := tx.Commit(); err != nil {
+			return ledgervo.DurableAck{}, retryableTransactionError(err), err
+		}
+		return ledgervo.DurableAck{}, false, ievidenceledger.ErrSequenceConflict
+	}
+	var maxSequence sql.NullInt64
+	if err := tx.QueryRowContext(ctx, `
+		SELECT MAX(producer_sequence) FROM bkn_trace_evidence_event_ledger
+		WHERE tenant_id=? AND producer_stream_id=? AND producer_epoch=? FOR UPDATE`,
+		event.Owner.TenantID, event.ProducerStreamID, event.ProducerEpoch,
+	).Scan(&maxSequence); err != nil {
+		return ledgervo.DurableAck{}, retryableTransactionError(err), err
+	}
+	if maxSequence.Valid && event.ProducerSequence <= uint64(maxSequence.Int64) {
+		if err := insertEvidenceConflict(ctx, tx, event, event.PayloadHash); err != nil {
+			return ledgervo.DurableAck{}, retryableTransactionError(err), err
+		}
+		if err := tx.Commit(); err != nil {
+			return ledgervo.DurableAck{}, retryableTransactionError(err), err
+		}
+		return ledgervo.DurableAck{}, false, ievidenceledger.ErrSequenceConflict
+	}
+
+	envelope, err := json.Marshal(event)
+	if err != nil {
+		return ledgervo.DurableAck{}, false, err
+	}
+	var now time.Time
+	if err := tx.QueryRowContext(ctx, "SELECT UTC_TIMESTAMP(6)").Scan(&now); err != nil {
+		return ledgervo.DurableAck{}, retryableTransactionError(err), err
+	}
+	result, err := tx.ExecContext(ctx, `
+		INSERT INTO bkn_trace_evidence_event_ledger (
+			event_id, payload_hash, immutable_record_hash, schema_version, event_type,
+			tenant_id, business_domain_id,
+			conversation_id, interaction_id, operation_id, attempt_no, request_id, trace_id,
+			span_id, producer_id, producer_stream_id, producer_epoch, producer_sequence,
+			causality_status, missing_causation_event_ids,
+				started_at, observed_at, emitted_at, ingested_at, envelope
+			) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, NULLIF(?, ''), NULLIF(?, 0), NULLIF(?, ''),
+				NULLIF(?, ''), NULLIF(?, ''), ?, ?, ?, ?, ?, NULLIF(?, ''), ?, ?, ?, ?, ?)`,
+		event.EventID, event.PayloadHash, recordHash, event.SchemaVersion, event.EventType,
+		event.Owner.TenantID, event.Owner.BusinessDomainID, event.ConversationID,
+		event.InteractionID, event.OperationID, event.Attempt, event.RequestID, event.TraceID,
+		event.SpanID, event.ProducerID, event.ProducerStreamID, event.ProducerEpoch,
+		event.ProducerSequence, event.CausalityStatus, marshalJSON(event.MissingCauseIDs),
+		event.StartedAt, event.ObservedAt, event.EmittedAt, now, envelope,
+	)
+	if err != nil {
+		return ledgervo.DurableAck{}, retryableTransactionError(err), err
+	}
+	sequence, err := result.LastInsertId()
+	if err != nil {
+		return ledgervo.DurableAck{}, false, err
+	}
+	_, err = tx.ExecContext(ctx, `
+		INSERT INTO bkn_trace_projection_outbox (
+			aggregate_type, aggregate_id, aggregate_version, event_type, event_id, payload,
+			status, attempts, available_at, created_at
+		) VALUES ('evidence_event', ?, ?, 'evidence.project', ?, ?, 'pending', 0, ?, ?)`,
+		event.EventID, sequence, event.EventID, envelope, now, now,
+	)
+	if err != nil {
+		return ledgervo.DurableAck{}, retryableTransactionError(err), err
+	}
+	if err := tx.Commit(); err != nil {
+		return ledgervo.DurableAck{}, retryableTransactionError(err), err
+	}
+	return ledgervo.DurableAck{
+		EventID: event.EventID, Durable: true, IngestSequence: uint64(sequence), IngestedAt: now.UTC(),
+	}, false, nil
+}
+
+func verifyEvidenceOwnership(ctx context.Context, tx *sql.Tx, event ledgervo.Event) error {
+	var tenantID, domainID, applicationID, subjectType, subjectID, delegationID string
+	err := tx.QueryRowContext(ctx, `
+		SELECT c.tenant_id, c.business_domain_id, c.application_principal_id,
+			c.effective_subject_type, c.effective_subject_id, c.delegation_id
+		FROM bkn_trace_conversations c
+		JOIN bkn_trace_interactions i ON i.conversation_id=c.conversation_id
+		WHERE c.conversation_id=? AND i.interaction_id=? FOR UPDATE`,
+		event.ConversationID, event.InteractionID,
+	).Scan(&tenantID, &domainID, &applicationID, &subjectType, &subjectID, &delegationID)
+	if errors.Is(err, sql.ErrNoRows) {
+		return errors.New("evidence interaction does not exist")
+	}
+	if err != nil {
+		return err
+	}
+	if tenantID != event.Owner.TenantID || domainID != event.Owner.BusinessDomainID ||
+		applicationID != event.Owner.ApplicationPrincipalID ||
+		subjectType != string(event.Owner.EffectiveSubjectType) ||
+		subjectID != event.Owner.EffectiveSubjectID ||
+		delegationID != event.Owner.DelegationID {
+		return errors.New("evidence owner does not match trusted conversation owner")
+	}
+	if event.OperationID != "" {
+		var count int
+		if err := tx.QueryRowContext(ctx, `
+			SELECT COUNT(*) FROM bkn_trace_operations
+			WHERE operation_id=? AND interaction_id=?`,
+			event.OperationID, event.InteractionID,
+		).Scan(&count); err != nil {
+			return err
+		}
+		if count != 1 {
+			return errors.New("evidence operation does not belong to interaction")
+		}
+	}
+	return nil
+}
+
+func verifyCausationScope(ctx context.Context, tx *sql.Tx, event ledgervo.Event) ([]string, error) {
+	var missing []string
+	for _, causeID := range event.CausationEventIDs {
+		var tenantID, domainID, interactionID string
+		err := tx.QueryRowContext(ctx, `
+			SELECT tenant_id, business_domain_id, interaction_id
+			FROM bkn_trace_evidence_event_ledger WHERE event_id=?`,
+			causeID,
+		).Scan(&tenantID, &domainID, &interactionID)
+		if errors.Is(err, sql.ErrNoRows) {
+			missing = append(missing, causeID)
+			continue
+		}
+		if err != nil {
+			return nil, err
+		}
+		if tenantID != event.Owner.TenantID || domainID != event.Owner.BusinessDomainID ||
+			interactionID != event.InteractionID {
+			return nil, fmt.Errorf("causation event %s crosses trusted interaction scope", causeID)
+		}
+	}
+	return missing, nil
+}
+
+func verifyCausationAcyclic(ctx context.Context, tx *sql.Tx, event ledgervo.Event) error {
+	rows, err := tx.QueryContext(ctx, `
+		SELECT envelope FROM bkn_trace_evidence_event_ledger
+		WHERE tenant_id=? AND business_domain_id=? AND interaction_id=?
+		FOR UPDATE`,
+		event.Owner.TenantID, event.Owner.BusinessDomainID, event.InteractionID,
+	)
+	if err != nil {
+		return err
+	}
+	defer rows.Close()
+	events := []ledgervo.Event{event}
+	for rows.Next() {
+		var envelope []byte
+		if err := rows.Scan(&envelope); err != nil {
+			return err
+		}
+		var existing ledgervo.Event
+		if err := json.Unmarshal(envelope, &existing); err != nil {
+			return err
+		}
+		events = append(events, existing)
+	}
+	if err := rows.Err(); err != nil {
+		return err
+	}
+	if ledgervo.HasCausationCycle(events) {
+		return ievidenceledger.ErrCausalityConflict
+	}
+	return nil
+}
+
+func insertEvidenceConflict(ctx context.Context, tx *sql.Tx, event ledgervo.Event, existingHash string) error {
+	envelope, err := json.Marshal(event)
+	if err != nil {
+		return err
+	}
+	_, err = tx.ExecContext(ctx, `
+		INSERT INTO bkn_trace_event_conflicts (
+			event_id, existing_payload_hash, conflicting_payload_hash,
+			tenant_id, business_domain_id, envelope, detected_at
+		) VALUES (?, ?, ?, ?, ?, ?, UTC_TIMESTAMP(6))`,
+		event.EventID, existingHash, event.PayloadHash,
+		event.Owner.TenantID, event.Owner.BusinessDomainID, envelope,
+	)
+	return err
+}

--- a/bkn-trace/agent-observability/src/drivenadapter/dbaccess/mariadb/sessionstore/outbox.go
+++ b/bkn-trace/agent-observability/src/drivenadapter/dbaccess/mariadb/sessionstore/outbox.go
@@ -1,0 +1,233 @@
+package sessionstore
+
+import (
+	"context"
+	"crypto/rand"
+	"database/sql"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/openbkn-ai/bkn-foundry/bkn-trace/agent-observability/src/port/driven/iprojectionoutbox"
+)
+
+func (s *Store) Lease(ctx context.Context, limit int, lockDuration time.Duration) ([]iprojectionoutbox.Item, error) {
+	if limit <= 0 {
+		limit = 100
+	}
+	tx, err := s.db.BeginTx(ctx, &sql.TxOptions{Isolation: sql.LevelReadCommitted})
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = tx.Rollback() }()
+	rows, err := tx.QueryContext(ctx, `
+		SELECT outbox_id, aggregate_type, aggregate_id, aggregate_version, event_type, event_id,
+			payload, attempts, created_at
+		FROM bkn_trace_projection_outbox
+		WHERE status IN ('pending', 'processing') AND available_at<=UTC_TIMESTAMP(6)
+		  AND (locked_until IS NULL OR locked_until<=UTC_TIMESTAMP(6))
+		ORDER BY outbox_id LIMIT ? FOR UPDATE SKIP LOCKED`, limit)
+	if err != nil {
+		return nil, err
+	}
+	var result []iprojectionoutbox.Item
+	for rows.Next() {
+		var item iprojectionoutbox.Item
+		if err := rows.Scan(
+			&item.ID, &item.AggregateType, &item.AggregateID, &item.AggregateVersion,
+			&item.EventType,
+			&item.EventID, &item.Payload, &item.Attempts, &item.CreatedAt,
+		); err != nil {
+			_ = rows.Close()
+			return nil, err
+		}
+		result = append(result, item)
+	}
+	if err := rows.Close(); err != nil {
+		return nil, err
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	for index := range result {
+		result[index].LeaseToken = newOutboxLeaseToken()
+		update, err := tx.ExecContext(ctx, `
+			UPDATE bkn_trace_projection_outbox
+			SET status='processing',
+				lease_token=?,
+				locked_until=DATE_ADD(UTC_TIMESTAMP(6), INTERVAL ? MICROSECOND)
+			WHERE outbox_id=? AND (locked_until IS NULL OR locked_until<=UTC_TIMESTAMP(6))`,
+			result[index].LeaseToken, lockDuration.Microseconds(), result[index].ID)
+		if err != nil {
+			return nil, err
+		}
+		if err := requireOutboxLease(update); err != nil {
+			return nil, err
+		}
+	}
+	if err := tx.Commit(); err != nil {
+		return nil, err
+	}
+	return result, nil
+}
+
+func (s *Store) MarkDelivered(ctx context.Context, item iprojectionoutbox.Item) error {
+	result, err := s.db.ExecContext(ctx, `
+		UPDATE bkn_trace_projection_outbox
+		SET status='delivered', delivered_at=UTC_TIMESTAMP(6), locked_until=NULL,
+			lease_token=NULL, last_error_code=NULL
+		WHERE outbox_id=? AND status='processing' AND lease_token=?`,
+		item.ID, item.LeaseToken)
+	if err != nil {
+		return err
+	}
+	return requireOutboxLease(result)
+}
+
+func (s *Store) MarkRetry(ctx context.Context, item iprojectionoutbox.Item, errorCode string, availableAt time.Time) error {
+	result, err := s.db.ExecContext(ctx, `
+		UPDATE bkn_trace_projection_outbox
+		SET status='pending', attempts=attempts+1, available_at=?, locked_until=NULL,
+			lease_token=NULL, last_error_code=?
+		WHERE outbox_id=? AND status='processing' AND lease_token=?`,
+		availableAt, errorCode, item.ID, item.LeaseToken,
+	)
+	if err != nil {
+		return err
+	}
+	return requireOutboxLease(result)
+}
+
+func (s *Store) MoveToDLQ(ctx context.Context, item iprojectionoutbox.Item, errorCode string) error {
+	tx, err := s.db.BeginTx(ctx, &sql.TxOptions{Isolation: sql.LevelReadCommitted})
+	if err != nil {
+		return err
+	}
+	defer func() { _ = tx.Rollback() }()
+	result, err := tx.ExecContext(ctx, `
+		UPDATE bkn_trace_projection_outbox
+		SET status='dead', attempts=attempts+1, locked_until=NULL,
+			lease_token=NULL, last_error_code=?
+		WHERE outbox_id=? AND status='processing' AND lease_token=?`,
+		errorCode, item.ID, item.LeaseToken,
+	)
+	if err != nil {
+		return err
+	}
+	if err := requireOutboxLease(result); err != nil {
+		return err
+	}
+	if _, err := tx.ExecContext(ctx, `
+		INSERT INTO bkn_trace_dlq (
+			source_kind, source_id, failure_class, attempts,
+			last_error_code, payload, failed_at
+		) VALUES ('projection', ?, ?, ?, ?, ?, UTC_TIMESTAMP(6))
+		ON DUPLICATE KEY UPDATE
+			failure_class=VALUES(failure_class),
+			attempts=VALUES(attempts),
+			last_error_code=VALUES(last_error_code),
+			payload=VALUES(payload),
+			failed_at=VALUES(failed_at),
+			replayed_at=NULL,
+			replayed_by=NULL`,
+		item.EventID, errorCode, item.Attempts+1, errorCode, item.Payload,
+	); err != nil {
+		return err
+	}
+	return tx.Commit()
+}
+
+func (s *Store) ReplayProjectionDLQ(
+	ctx context.Context,
+	request iprojectionoutbox.ReplayRequest,
+) error {
+	if request.DLQID == 0 ||
+		strings.TrimSpace(request.Operator) == "" ||
+		strings.TrimSpace(request.Reason) == "" ||
+		strings.TrimSpace(request.RepairVersion) == "" {
+		return errors.New("DLQ ID, operator, reason and repair version are required")
+	}
+	tx, err := s.db.BeginTx(ctx, &sql.TxOptions{Isolation: sql.LevelSerializable})
+	if err != nil {
+		return err
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	var sourceKind, sourceID string
+	var replayedAt sql.NullTime
+	err = tx.QueryRowContext(ctx, `
+		SELECT source_kind, source_id, replayed_at
+		FROM bkn_trace_dlq WHERE dlq_id=? FOR UPDATE`,
+		request.DLQID,
+	).Scan(&sourceKind, &sourceID, &replayedAt)
+	if errors.Is(err, sql.ErrNoRows) {
+		return fmt.Errorf("projection DLQ entry %d not found", request.DLQID)
+	}
+	if err != nil {
+		return err
+	}
+	if sourceKind != "projection" {
+		return fmt.Errorf("DLQ entry %d is not a projection failure", request.DLQID)
+	}
+	if replayedAt.Valid {
+		return fmt.Errorf("projection DLQ entry %d was already replayed", request.DLQID)
+	}
+
+	result, err := tx.ExecContext(ctx, `
+		UPDATE bkn_trace_projection_outbox
+		SET status='pending', attempts=0, available_at=UTC_TIMESTAMP(6),
+			locked_until=NULL, lease_token=NULL, last_error_code=NULL,
+			delivered_at=NULL
+		WHERE event_id=? AND status='dead'`,
+		sourceID,
+	)
+	if err != nil {
+		return err
+	}
+	if affected, err := result.RowsAffected(); err != nil {
+		return err
+	} else if affected != 1 {
+		return fmt.Errorf("projection outbox for DLQ entry %d is not dead", request.DLQID)
+	}
+
+	if _, err := tx.ExecContext(ctx, `
+		INSERT INTO bkn_trace_dlq_replay_audit (
+			dlq_id, source_kind, source_id, replayed_by,
+			reason, repair_version, replayed_at
+		) VALUES (?, ?, ?, ?, ?, ?, UTC_TIMESTAMP(6))`,
+		request.DLQID, sourceKind, sourceID, request.Operator,
+		request.Reason, request.RepairVersion,
+	); err != nil {
+		return err
+	}
+	if _, err := tx.ExecContext(ctx, `
+		UPDATE bkn_trace_dlq
+		SET replayed_at=UTC_TIMESTAMP(6), replayed_by=?
+		WHERE dlq_id=?`,
+		request.Operator, request.DLQID,
+	); err != nil {
+		return err
+	}
+	return tx.Commit()
+}
+
+func requireOutboxLease(result sql.Result) error {
+	affected, err := result.RowsAffected()
+	if err != nil {
+		return err
+	}
+	if affected != 1 {
+		return iprojectionoutbox.ErrLeaseLost
+	}
+	return nil
+}
+
+func newOutboxLeaseToken() string {
+	var value [16]byte
+	if _, err := rand.Read(value[:]); err != nil {
+		panic("crypto/rand failed: " + err.Error())
+	}
+	return hex.EncodeToString(value[:])
+}

--- a/bkn-trace/agent-observability/src/drivenadapter/dbaccess/mariadb/sessionstore/rebuild.go
+++ b/bkn-trace/agent-observability/src/drivenadapter/dbaccess/mariadb/sessionstore/rebuild.go
@@ -35,7 +35,7 @@ func (s *Store) ScanProjectionHistory(
 	if err != nil {
 		return nil, err
 	}
-	defer rows.Close()
+	defer func() { _ = rows.Close() }()
 	var result []iprojectionoutbox.Item
 	for rows.Next() {
 		var item iprojectionoutbox.Item
@@ -120,7 +120,7 @@ func (s *Store) scanConversationProjection(
 	if err != nil {
 		return nil, err
 	}
-	defer rows.Close()
+	defer func() { _ = rows.Close() }()
 	var result []iprojectionoutbox.Item
 	for rows.Next() {
 		value, err := scanConversationRows(rows)
@@ -146,7 +146,7 @@ func (s *Store) scanInteractionProjection(
 	if err != nil {
 		return nil, err
 	}
-	defer rows.Close()
+	defer func() { _ = rows.Close() }()
 	var result []iprojectionoutbox.Item
 	for rows.Next() {
 		value, err := scanInteractionRows(rows)
@@ -172,7 +172,7 @@ func (s *Store) scanOperationProjection(
 	if err != nil {
 		return nil, err
 	}
-	defer rows.Close()
+	defer func() { _ = rows.Close() }()
 	var result []iprojectionoutbox.Item
 	for rows.Next() {
 		value, err := scanOperationRows(rows)
@@ -198,7 +198,7 @@ func (s *Store) scanReceiptProjection(
 	if err != nil {
 		return nil, err
 	}
-	defer rows.Close()
+	defer func() { _ = rows.Close() }()
 	var result []iprojectionoutbox.Item
 	for rows.Next() {
 		value, err := scanReceiptRows(rows)
@@ -224,7 +224,7 @@ func (s *Store) scanEvidenceEventProjection(
 	if err != nil {
 		return nil, err
 	}
-	defer rows.Close()
+	defer func() { _ = rows.Close() }()
 	var result []iprojectionoutbox.Item
 	for rows.Next() {
 		var item iprojectionoutbox.Item
@@ -252,7 +252,7 @@ func (s *Store) scanAssemblyRevisionProjection(
 	if err != nil {
 		return nil, err
 	}
-	defer rows.Close()
+	defer func() { _ = rows.Close() }()
 	var result []iprojectionoutbox.Item
 	for rows.Next() {
 		var value sessionvo.AssemblyRevision

--- a/bkn-trace/agent-observability/src/drivenadapter/dbaccess/mariadb/sessionstore/rebuild.go
+++ b/bkn-trace/agent-observability/src/drivenadapter/dbaccess/mariadb/sessionstore/rebuild.go
@@ -1,0 +1,330 @@
+package sessionstore
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/openbkn-ai/bkn-foundry/bkn-trace/agent-observability/src/domain/valueobject/sessionvo"
+	"github.com/openbkn-ai/bkn-foundry/bkn-trace/agent-observability/src/port/driven/iprojectionoutbox"
+)
+
+func (s *Store) ProjectionHighWatermark(ctx context.Context) (uint64, error) {
+	var value uint64
+	err := s.db.QueryRowContext(ctx,
+		"SELECT COALESCE(MAX(outbox_id), 0) FROM bkn_trace_projection_outbox",
+	).Scan(&value)
+	return value, err
+}
+
+func (s *Store) ScanProjectionHistory(
+	ctx context.Context,
+	after uint64,
+	through uint64,
+	limit int,
+) ([]iprojectionoutbox.Item, error) {
+	if limit <= 0 {
+		limit = 500
+	}
+	rows, err := s.db.QueryContext(ctx, `
+		SELECT outbox_id, aggregate_type, aggregate_id, aggregate_version, event_type, event_id,
+			payload, attempts, created_at
+		FROM bkn_trace_projection_outbox
+		WHERE outbox_id>? AND outbox_id<=?
+		ORDER BY outbox_id LIMIT ?`, after, through, limit)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var result []iprojectionoutbox.Item
+	for rows.Next() {
+		var item iprojectionoutbox.Item
+		if err := rows.Scan(
+			&item.ID, &item.AggregateType, &item.AggregateID, &item.AggregateVersion,
+			&item.EventType,
+			&item.EventID, &item.Payload, &item.Attempts, &item.CreatedAt,
+		); err != nil {
+			return nil, err
+		}
+		result = append(result, item)
+	}
+	return result, rows.Err()
+}
+
+func (s *Store) ScanAuthoritativeProjection(
+	ctx context.Context,
+	afterAggregateType string,
+	afterAggregateID string,
+	limit int,
+) ([]iprojectionoutbox.Item, error) {
+	if limit <= 0 {
+		limit = 500
+	}
+	var result []iprojectionoutbox.Item
+	scanners := []struct {
+		aggregateType string
+		scan          func(context.Context, string, int) ([]iprojectionoutbox.Item, error)
+	}{
+		{"assembly_revision", s.scanAssemblyRevisionProjection},
+		{"conversation", s.scanConversationProjection},
+		{"evidence_event", s.scanEvidenceEventProjection},
+		{"interaction", s.scanInteractionProjection},
+		{"operation", s.scanOperationProjection},
+		{"receipt", s.scanReceiptProjection},
+	}
+	for _, scanner := range scanners {
+		if scanner.aggregateType < afterAggregateType {
+			continue
+		}
+		afterID := ""
+		if scanner.aggregateType == afterAggregateType {
+			afterID = afterAggregateID
+		}
+		items, err := scanner.scan(ctx, afterID, limit-len(result))
+		if err != nil {
+			return nil, err
+		}
+		result = append(result, items...)
+		if len(result) == limit {
+			break
+		}
+	}
+	return result, nil
+}
+
+func projectionItem(
+	aggregateType, aggregateID string,
+	aggregateVersion uint64,
+	value any,
+) (iprojectionoutbox.Item, error) {
+	payload, err := json.Marshal(value)
+	if err != nil {
+		return iprojectionoutbox.Item{}, err
+	}
+	return iprojectionoutbox.Item{
+		AggregateType: aggregateType, AggregateID: aggregateID,
+		AggregateVersion: aggregateVersion,
+		EventType:        aggregateType + ".snapshot",
+		EventID:          aggregateType + ":" + aggregateID,
+		Payload:          payload,
+	}, nil
+}
+
+func (s *Store) scanConversationProjection(
+	ctx context.Context, afterID string, limit int,
+) ([]iprojectionoutbox.Item, error) {
+	rows, err := s.db.QueryContext(
+		ctx, conversationSelect+` WHERE conversation_id>? ORDER BY conversation_id LIMIT ?`,
+		afterID, limit,
+	)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var result []iprojectionoutbox.Item
+	for rows.Next() {
+		value, err := scanConversationRows(rows)
+		if err != nil {
+			return nil, err
+		}
+		item, err := projectionItem("conversation", value.ID, value.RowVersion, value)
+		if err != nil {
+			return nil, err
+		}
+		result = append(result, item)
+	}
+	return result, rows.Err()
+}
+
+func (s *Store) scanInteractionProjection(
+	ctx context.Context, afterID string, limit int,
+) ([]iprojectionoutbox.Item, error) {
+	rows, err := s.db.QueryContext(
+		ctx, interactionSelect+` WHERE interaction_id>? ORDER BY interaction_id LIMIT ?`,
+		afterID, limit,
+	)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var result []iprojectionoutbox.Item
+	for rows.Next() {
+		value, err := scanInteractionRows(rows)
+		if err != nil {
+			return nil, err
+		}
+		item, err := projectionItem("interaction", value.ID, value.RowVersion, value)
+		if err != nil {
+			return nil, err
+		}
+		result = append(result, item)
+	}
+	return result, rows.Err()
+}
+
+func (s *Store) scanOperationProjection(
+	ctx context.Context, afterID string, limit int,
+) ([]iprojectionoutbox.Item, error) {
+	rows, err := s.db.QueryContext(
+		ctx, operationSelect+` WHERE operation_id>? ORDER BY operation_id LIMIT ?`,
+		afterID, limit,
+	)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var result []iprojectionoutbox.Item
+	for rows.Next() {
+		value, err := scanOperationRows(rows)
+		if err != nil {
+			return nil, err
+		}
+		item, err := projectionItem("operation", value.ID, value.RowVersion, value)
+		if err != nil {
+			return nil, err
+		}
+		result = append(result, item)
+	}
+	return result, rows.Err()
+}
+
+func (s *Store) scanReceiptProjection(
+	ctx context.Context, afterID string, limit int,
+) ([]iprojectionoutbox.Item, error) {
+	rows, err := s.db.QueryContext(
+		ctx, receiptSelect+` WHERE receipt_id>? ORDER BY receipt_id LIMIT ?`,
+		afterID, limit,
+	)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var result []iprojectionoutbox.Item
+	for rows.Next() {
+		value, err := scanReceiptRows(rows)
+		if err != nil {
+			return nil, err
+		}
+		item, err := projectionItem("receipt", value.ID, value.RowVersion, value)
+		if err != nil {
+			return nil, err
+		}
+		result = append(result, item)
+	}
+	return result, rows.Err()
+}
+
+func (s *Store) scanEvidenceEventProjection(
+	ctx context.Context, afterID string, limit int,
+) ([]iprojectionoutbox.Item, error) {
+	rows, err := s.db.QueryContext(ctx, `
+		SELECT event_id, ingest_sequence, envelope
+		FROM bkn_trace_evidence_event_ledger
+		WHERE event_id>? ORDER BY event_id LIMIT ?`, afterID, limit)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var result []iprojectionoutbox.Item
+	for rows.Next() {
+		var item iprojectionoutbox.Item
+		if err := rows.Scan(&item.AggregateID, &item.AggregateVersion, &item.Payload); err != nil {
+			return nil, err
+		}
+		item.AggregateType = "evidence_event"
+		item.EventType = "evidence_event.snapshot"
+		item.EventID = "evidence_event:" + item.AggregateID
+		result = append(result, item)
+	}
+	return result, rows.Err()
+}
+
+func (s *Store) scanAssemblyRevisionProjection(
+	ctx context.Context, afterID string, limit int,
+) ([]iprojectionoutbox.Item, error) {
+	rows, err := s.db.QueryContext(ctx, `
+		SELECT revision_id, revision_no, COALESCE(parent_revision_id, ''), interaction_id,
+			completion_manifest_version, included_receipt_ids, included_event_ids,
+			artifact_manifest_hash, assembly_completeness, COALESCE(partial_reasons, ''),
+			trigger_type, created_at
+		FROM bkn_trace_assembly_revisions
+		WHERE revision_id>? ORDER BY revision_id LIMIT ?`, afterID, limit)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var result []iprojectionoutbox.Item
+	for rows.Next() {
+		var value sessionvo.AssemblyRevision
+		var receipts, events, reasons string
+		if err := rows.Scan(
+			&value.ID, &value.RevisionNo, &value.ParentRevisionID, &value.InteractionID,
+			&value.CompletionManifestVersion, &receipts, &events,
+			&value.ArtifactManifestHash, &value.Completeness, &reasons,
+			&value.Trigger, &value.CreatedAt,
+		); err != nil {
+			return nil, err
+		}
+		unmarshalJSON(receipts, &value.IncludedReceiptIDs)
+		unmarshalJSON(events, &value.IncludedEventIDs)
+		unmarshalJSON(reasons, &value.PartialReasons)
+		item, err := projectionItem(
+			"assembly_revision", value.ID, value.RevisionNo, value,
+		)
+		if err != nil {
+			return nil, err
+		}
+		result = append(result, item)
+	}
+	return result, rows.Err()
+}
+
+func (s *Store) CountAuthoritativeProjection(ctx context.Context) (uint64, error) {
+	var value uint64
+	err := s.db.QueryRowContext(ctx, `
+		SELECT
+			(SELECT COUNT(*) FROM bkn_trace_conversations) +
+			(SELECT COUNT(*) FROM bkn_trace_interactions) +
+			(SELECT COUNT(*) FROM bkn_trace_operations) +
+			(SELECT COUNT(*) FROM bkn_trace_receipts) +
+			(SELECT COUNT(*) FROM bkn_trace_evidence_event_ledger) +
+			(SELECT COUNT(*) FROM bkn_trace_assembly_revisions)`,
+	).Scan(&value)
+	if err != nil {
+		return 0, fmt.Errorf("count authoritative BKN Trace projection: %w", err)
+	}
+	return value, err
+}
+
+func (s *Store) LoadProjectionCheckpoint(
+	ctx context.Context,
+	projectorID string,
+	indexVersion string,
+) (uint64, error) {
+	var value uint64
+	err := s.db.QueryRowContext(ctx, `
+		SELECT COALESCE(MAX(last_outbox_id), 0)
+		FROM bkn_trace_projection_checkpoints
+		WHERE projector_id=? AND index_version=?`,
+		projectorID, indexVersion,
+	).Scan(&value)
+	return value, err
+}
+
+func (s *Store) SaveProjectionCheckpoint(
+	ctx context.Context,
+	projectorID string,
+	indexVersion string,
+	lastOutboxID uint64,
+) error {
+	_, err := s.db.ExecContext(ctx, `
+		INSERT INTO bkn_trace_projection_checkpoints (
+			projector_id, index_version, last_outbox_id, updated_at
+		) VALUES (?, ?, ?, UTC_TIMESTAMP(6))
+		ON DUPLICATE KEY UPDATE
+			last_outbox_id=GREATEST(last_outbox_id, VALUES(last_outbox_id)),
+			updated_at=UTC_TIMESTAMP(6)`,
+		projectorID, indexVersion, lastOutboxID,
+	)
+	return err
+}

--- a/bkn-trace/agent-observability/src/drivenadapter/dbaccess/mariadb/sessionstore/schema.go
+++ b/bkn-trace/agent-observability/src/drivenadapter/dbaccess/mariadb/sessionstore/schema.go
@@ -1,0 +1,5 @@
+package sessionstore
+
+import v013 "github.com/openbkn-ai/bkn-foundry/bkn-trace/agent-observability/migrations/mariadb/v013"
+
+func SchemaSQL() string { return v013.SchemaSQL() }

--- a/bkn-trace/agent-observability/src/drivenadapter/dbaccess/mariadb/sessionstore/schema_test.go
+++ b/bkn-trace/agent-observability/src/drivenadapter/dbaccess/mariadb/sessionstore/schema_test.go
@@ -1,0 +1,39 @@
+package sessionstore_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/openbkn-ai/bkn-foundry/bkn-trace/agent-observability/src/drivenadapter/dbaccess/mariadb/sessionstore"
+)
+
+func TestSchemaFreezesLifecycleAndDurableEvidenceConstraints(t *testing.T) {
+	t.Parallel()
+
+	schema := sessionstore.SchemaSQL()
+	required := []string{
+		"bkn_trace_conversations",
+		"uq_bkn_trace_conversation_generation",
+		"uq_bkn_trace_conversation_current",
+		"bkn_trace_interactions",
+		"uq_bkn_trace_interaction_active",
+		"bkn_trace_operations",
+		"uq_bkn_trace_operation_key",
+		"bkn_trace_receipts",
+		"uq_bkn_trace_receipt_attempt",
+		"bkn_trace_evidence_event_ledger",
+		"uq_bkn_trace_event_stream_sequence",
+		"started_at DATETIME(6) NOT NULL",
+		"bkn_trace_projection_outbox",
+		"bkn_trace_assembly_revisions",
+		"bkn_trace_event_conflicts",
+		"bkn_trace_projection_checkpoints",
+		"bkn_trace_dlq",
+		"bkn_trace_dlq_replay_audit",
+	}
+	for _, fragment := range required {
+		if !strings.Contains(schema, fragment) {
+			t.Errorf("schema is missing %q", fragment)
+		}
+	}
+}

--- a/bkn-trace/agent-observability/src/drivenadapter/dbaccess/mariadb/sessionstore/store.go
+++ b/bkn-trace/agent-observability/src/drivenadapter/dbaccess/mariadb/sessionstore/store.go
@@ -1,0 +1,1028 @@
+package sessionstore
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"math/rand/v2"
+	"strings"
+	"time"
+
+	"github.com/go-sql-driver/mysql"
+	"github.com/openbkn-ai/bkn-foundry/bkn-trace/agent-observability/src/domain/valueobject/sessionvo"
+	"github.com/openbkn-ai/bkn-foundry/bkn-trace/agent-observability/src/port/driven/isessionstore"
+)
+
+const transactionRetries = 4
+
+type Store struct {
+	db *sql.DB
+}
+
+func New(db *sql.DB) *Store {
+	return &Store{db: db}
+}
+
+func (s *Store) Migrate(ctx context.Context) error {
+	for _, statement := range strings.Split(SchemaSQL(), ";") {
+		statement = strings.TrimSpace(statement)
+		if statement == "" {
+			continue
+		}
+		if _, err := s.db.ExecContext(ctx, statement); err != nil {
+			return fmt.Errorf("apply BKN Trace migration: %w", err)
+		}
+	}
+	return nil
+}
+
+func (s *Store) WithinTransaction(ctx context.Context, fn func(isessionstore.Transaction) error) error {
+	var lastErr error
+	for attempt := 0; attempt < transactionRetries; attempt++ {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		tx, err := s.db.BeginTx(ctx, &sql.TxOptions{Isolation: sql.LevelReadCommitted})
+		if err != nil {
+			return err
+		}
+		adapter := &transaction{ctx: ctx, tx: tx}
+		if err := adapter.loadServerTime(); err != nil {
+			_ = tx.Rollback()
+			return err
+		}
+		callbackErr := fn(adapter)
+		if callbackErr == nil {
+			callbackErr = adapter.err
+		}
+		if callbackErr != nil {
+			_ = tx.Rollback()
+			if retryableTransactionError(callbackErr) {
+				lastErr = callbackErr
+				if err := waitForTransactionRetry(ctx, attempt); err != nil {
+					return err
+				}
+				continue
+			}
+			return callbackErr
+		}
+		if err := tx.Commit(); err != nil {
+			if retryableTransactionError(err) {
+				lastErr = err
+				if waitErr := waitForTransactionRetry(ctx, attempt); waitErr != nil {
+					return waitErr
+				}
+				continue
+			}
+			return err
+		}
+		return nil
+	}
+	return fmt.Errorf("transaction retry budget exhausted: %w", lastErr)
+}
+
+func waitForTransactionRetry(ctx context.Context, attempt int) error {
+	timer := time.NewTimer(transactionRetryDelay(attempt))
+	defer timer.Stop()
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-timer.C:
+		return nil
+	}
+}
+
+func transactionRetryDelay(attempt int) time.Duration {
+	if attempt < 0 {
+		attempt = 0
+	}
+	if attempt >= transactionRetries {
+		attempt = transactionRetries - 1
+	}
+	maximum := 5 * time.Millisecond * time.Duration(1<<attempt)
+	return time.Duration(rand.Int64N(int64(maximum) + 1))
+}
+
+func retryableTransactionError(err error) bool {
+	var mysqlErr *mysql.MySQLError
+	if !errors.As(err, &mysqlErr) {
+		return false
+	}
+	switch mysqlErr.Number {
+	case 1062, 1205, 1213:
+		return true
+	default:
+		return false
+	}
+}
+
+type transaction struct {
+	ctx context.Context
+	tx  *sql.Tx
+	now time.Time
+	err error
+}
+
+func (t *transaction) loadServerTime() error {
+	if err := t.tx.QueryRowContext(t.ctx, "SELECT UTC_TIMESTAMP(6)").Scan(&t.now); err != nil {
+		return fmt.Errorf("read MariaDB server time: %w", err)
+	}
+	t.now = t.now.UTC()
+	return nil
+}
+
+func (t *transaction) Now() time.Time {
+	return t.now
+}
+
+func (t *transaction) FindCurrentConversation(owner sessionvo.Owner, externalKey string) (sessionvo.Conversation, bool) {
+	if t.err != nil {
+		return sessionvo.Conversation{}, false
+	}
+	row := t.tx.QueryRowContext(t.ctx, conversationSelect+`
+		WHERE tenant_id=? AND business_domain_id=? AND application_principal_id=?
+		  AND effective_subject_type=? AND effective_subject_id=? AND delegation_id=?
+		  AND external_conversation_key=?
+		ORDER BY generation DESC LIMIT 1 FOR UPDATE`,
+		owner.TenantID, owner.BusinessDomainID, owner.ApplicationPrincipalID,
+		owner.EffectiveSubjectType, owner.EffectiveSubjectID, owner.DelegationID, externalKey,
+	)
+	return t.scanConversation(row)
+}
+
+func (t *transaction) FindConversation(conversationID string) (sessionvo.Conversation, bool) {
+	if t.err != nil {
+		return sessionvo.Conversation{}, false
+	}
+	return t.scanConversation(t.tx.QueryRowContext(t.ctx, conversationSelect+`
+		WHERE conversation_id=? FOR UPDATE`, conversationID))
+}
+
+func (t *transaction) FindIdempotency(
+	scope string,
+	owner sessionvo.Owner,
+	externalKey string,
+	idempotencyKey string,
+) (sessionvo.IdempotencyRecord, bool) {
+	if t.err != nil {
+		return sessionvo.IdempotencyRecord{}, false
+	}
+	var record sessionvo.IdempotencyRecord
+	record.Scope = scope
+	record.Owner = owner
+	record.ExternalConversationKey = externalKey
+	record.IdempotencyKey = idempotencyKey
+	err := t.tx.QueryRowContext(t.ctx, `
+		SELECT request_hash, resource_type, resource_id, created_at
+		FROM bkn_trace_idempotency_records
+		WHERE scope=? AND tenant_id=? AND business_domain_id=?
+		  AND application_principal_id=? AND effective_subject_type=?
+		  AND effective_subject_id=? AND delegation_id=? AND external_conversation_key=?
+		  AND idempotency_key=? FOR UPDATE`,
+		scope, owner.TenantID, owner.BusinessDomainID, owner.ApplicationPrincipalID,
+		owner.EffectiveSubjectType, owner.EffectiveSubjectID, owner.DelegationID,
+		externalKey, idempotencyKey,
+	).Scan(&record.RequestHash, &record.ResourceType, &record.ResourceID, &record.CreatedAt)
+	if errors.Is(err, sql.ErrNoRows) {
+		return sessionvo.IdempotencyRecord{}, false
+	}
+	if err != nil {
+		t.err = err
+		return sessionvo.IdempotencyRecord{}, false
+	}
+	return record, true
+}
+
+func (t *transaction) SaveIdempotency(record sessionvo.IdempotencyRecord) {
+	if t.err != nil {
+		return
+	}
+	_, t.err = t.tx.ExecContext(t.ctx, `
+		INSERT INTO bkn_trace_idempotency_records (
+			scope, tenant_id, business_domain_id, application_principal_id,
+			effective_subject_type, effective_subject_id, delegation_id, external_conversation_key,
+			idempotency_key, request_hash, resource_type, resource_id, created_at
+		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		record.Scope, record.Owner.TenantID, record.Owner.BusinessDomainID,
+		record.Owner.ApplicationPrincipalID, record.Owner.EffectiveSubjectType,
+		record.Owner.EffectiveSubjectID, record.Owner.DelegationID, record.ExternalConversationKey,
+		record.IdempotencyKey, record.RequestHash, record.ResourceType,
+		record.ResourceID, record.CreatedAt,
+	)
+}
+
+func (t *transaction) ListConversations(owner sessionvo.Owner, limit int) []sessionvo.Conversation {
+	if t.err != nil {
+		return nil
+	}
+	rows, err := t.tx.QueryContext(t.ctx, conversationSelect+`
+		WHERE tenant_id=? AND business_domain_id=? AND application_principal_id=?
+		  AND effective_subject_type=? AND effective_subject_id=? AND delegation_id=?
+		ORDER BY updated_at DESC, conversation_id DESC LIMIT ?`,
+		owner.TenantID, owner.BusinessDomainID, owner.ApplicationPrincipalID,
+		owner.EffectiveSubjectType, owner.EffectiveSubjectID, owner.DelegationID, limit,
+	)
+	if err != nil {
+		t.err = err
+		return nil
+	}
+	defer rows.Close()
+	var result []sessionvo.Conversation
+	for rows.Next() {
+		value, scanErr := scanConversationRows(rows)
+		if scanErr != nil {
+			t.err = scanErr
+			return nil
+		}
+		result = append(result, value)
+	}
+	t.err = rows.Err()
+	return result
+}
+
+func (t *transaction) SaveConversation(conversation sessionvo.Conversation) {
+	if t.err != nil {
+		return
+	}
+	var exists int
+	err := t.tx.QueryRowContext(t.ctx,
+		"SELECT 1 FROM bkn_trace_conversations WHERE conversation_id=?",
+		conversation.ID,
+	).Scan(&exists)
+	switch {
+	case errors.Is(err, sql.ErrNoRows):
+		_, t.err = t.tx.ExecContext(t.ctx, `
+			INSERT INTO bkn_trace_conversations (
+				conversation_id, tenant_id, business_domain_id, application_principal_id,
+				effective_subject_type, effective_subject_id, delegation_id,
+				external_conversation_key, generation, status, one_shot, row_version,
+				created_at, updated_at, closed_at
+			) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+			conversation.ID, conversation.Owner.TenantID, conversation.Owner.BusinessDomainID,
+			conversation.Owner.ApplicationPrincipalID, conversation.Owner.EffectiveSubjectType,
+			conversation.Owner.EffectiveSubjectID, conversation.Owner.DelegationID,
+			conversation.ExternalConversationKey, conversation.Generation, conversation.Status,
+			conversation.OneShot, conversation.RowVersion, conversation.CreatedAt,
+			conversation.UpdatedAt, nullableTime(conversation.ClosedAt),
+		)
+	case err != nil:
+		t.err = err
+	default:
+		_, t.err = t.tx.ExecContext(t.ctx, `
+			UPDATE bkn_trace_conversations SET status=?, one_shot=?, row_version=?,
+				updated_at=?, closed_at=? WHERE conversation_id=?`,
+			conversation.Status, conversation.OneShot, conversation.RowVersion,
+			conversation.UpdatedAt, nullableTime(conversation.ClosedAt), conversation.ID,
+		)
+	}
+}
+
+func (t *transaction) FindActiveInteraction(conversationID string) (sessionvo.Interaction, bool) {
+	if t.err != nil {
+		return sessionvo.Interaction{}, false
+	}
+	return t.scanInteraction(t.tx.QueryRowContext(t.ctx, interactionSelect+`
+		WHERE conversation_id=? AND execution_status='active' LIMIT 1 FOR UPDATE`, conversationID))
+}
+
+func (t *transaction) FindInteractionByStartKey(
+	conversationID string,
+	idempotencyKey string,
+) (sessionvo.Interaction, bool) {
+	if t.err != nil {
+		return sessionvo.Interaction{}, false
+	}
+	return t.scanInteraction(t.tx.QueryRowContext(t.ctx, interactionSelect+`
+		WHERE conversation_id=? AND start_idempotency_key=? FOR UPDATE`,
+		conversationID, idempotencyKey,
+	))
+}
+
+func (t *transaction) FindInteraction(interactionID string) (sessionvo.Interaction, bool) {
+	if t.err != nil {
+		return sessionvo.Interaction{}, false
+	}
+	return t.scanInteraction(t.tx.QueryRowContext(t.ctx, interactionSelect+`
+		WHERE interaction_id=? FOR UPDATE`, interactionID))
+}
+
+func (t *transaction) PeekInteraction(interactionID string) (sessionvo.Interaction, bool) {
+	if t.err != nil {
+		return sessionvo.Interaction{}, false
+	}
+	return t.scanInteraction(t.tx.QueryRowContext(t.ctx, interactionSelect+`
+		WHERE interaction_id=?`, interactionID))
+}
+
+func (t *transaction) NextInteractionOrdinal(conversationID string) uint64 {
+	if t.err != nil {
+		return 0
+	}
+	var ordinal uint64
+	t.err = t.tx.QueryRowContext(t.ctx,
+		"SELECT COALESCE(MAX(ordinal_no), 0) + 1 FROM bkn_trace_interactions WHERE conversation_id=? FOR UPDATE",
+		conversationID,
+	).Scan(&ordinal)
+	return ordinal
+}
+
+func (t *transaction) SaveInteraction(interaction sessionvo.Interaction) {
+	if t.err != nil {
+		return
+	}
+	manifest := marshalJSON(interaction.ClosureManifest)
+	var assemblerDeadline any
+	if interaction.ClosureManifest != nil {
+		assemblerDeadline = nullableTime(interaction.ClosureManifest.AssemblerDeadline)
+	}
+	var exists int
+	err := t.tx.QueryRowContext(t.ctx,
+		"SELECT 1 FROM bkn_trace_interactions WHERE interaction_id=?",
+		interaction.ID,
+	).Scan(&exists)
+	switch {
+	case errors.Is(err, sql.ErrNoRows):
+		_, t.err = t.tx.ExecContext(t.ctx, `
+			INSERT INTO bkn_trace_interactions (
+				interaction_id, conversation_id, ordinal_no, execution_status, evidence_status,
+				start_idempotency_key, terminal_idempotency_key, terminal_payload_hash,
+				closure_manifest, assembler_deadline, lease_token, lease_epoch, lease_version, lease_expires_at,
+				row_version, created_at, updated_at, terminal_at
+			) VALUES (?, ?, ?, ?, ?, ?, NULLIF(?, ''), NULLIF(?, ''), NULLIF(?, ''), ?,
+				?, ?, ?, ?, ?, ?, ?, ?)`,
+			interaction.ID, interaction.ConversationID, interaction.Ordinal,
+			interaction.ExecutionStatus, interaction.EvidenceStatus, interaction.StartIdempotencyKey,
+			interaction.TerminalIdempotencyKey, interaction.TerminalPayloadHash, manifest,
+			assemblerDeadline, interaction.LeaseToken, interaction.LeaseEpoch, interaction.LeaseVersion,
+			interaction.LeaseExpiresAt, interaction.RowVersion, interaction.CreatedAt,
+			interaction.UpdatedAt, nullableTime(interaction.TerminalAt),
+		)
+	case err != nil:
+		t.err = err
+	default:
+		_, t.err = t.tx.ExecContext(t.ctx, `
+			UPDATE bkn_trace_interactions SET execution_status=?, evidence_status=?,
+				terminal_idempotency_key=NULLIF(?, ''), terminal_payload_hash=NULLIF(?, ''),
+				closure_manifest=NULLIF(?, ''), assembler_deadline=?, lease_token=?, lease_epoch=?, lease_version=?,
+				lease_expires_at=?, row_version=?, updated_at=?, terminal_at=?
+			WHERE interaction_id=?`,
+			interaction.ExecutionStatus, interaction.EvidenceStatus,
+			interaction.TerminalIdempotencyKey, interaction.TerminalPayloadHash, manifest,
+			assemblerDeadline, interaction.LeaseToken, interaction.LeaseEpoch, interaction.LeaseVersion,
+			interaction.LeaseExpiresAt, interaction.RowVersion, interaction.UpdatedAt,
+			nullableTime(interaction.TerminalAt), interaction.ID,
+		)
+	}
+}
+
+func (t *transaction) FindOperationByKey(interactionID, operationKey string) (sessionvo.Operation, bool) {
+	if t.err != nil {
+		return sessionvo.Operation{}, false
+	}
+	return t.scanOperation(t.tx.QueryRowContext(t.ctx, operationSelect+`
+		WHERE interaction_id=? AND operation_key=? FOR UPDATE`, interactionID, operationKey))
+}
+
+func (t *transaction) FindOperation(operationID string) (sessionvo.Operation, bool) {
+	if t.err != nil {
+		return sessionvo.Operation{}, false
+	}
+	return t.scanOperation(t.tx.QueryRowContext(t.ctx, operationSelect+`
+		WHERE operation_id=? FOR UPDATE`, operationID))
+}
+
+func (t *transaction) PeekOperation(operationID string) (sessionvo.Operation, bool) {
+	if t.err != nil {
+		return sessionvo.Operation{}, false
+	}
+	return t.scanOperation(t.tx.QueryRowContext(t.ctx, operationSelect+`
+		WHERE operation_id=?`, operationID))
+}
+
+func (t *transaction) ListOperations(interactionID string) []sessionvo.Operation {
+	if t.err != nil {
+		return nil
+	}
+	rows, err := t.tx.QueryContext(t.ctx, operationSelect+`
+		WHERE interaction_id=? ORDER BY operation_id`, interactionID)
+	if err != nil {
+		t.err = err
+		return nil
+	}
+	defer rows.Close()
+	var result []sessionvo.Operation
+	for rows.Next() {
+		value, scanErr := scanOperationRows(rows)
+		if scanErr != nil {
+			t.err = scanErr
+			return nil
+		}
+		result = append(result, value)
+	}
+	t.err = rows.Err()
+	return result
+}
+
+func (t *transaction) SaveOperation(operation sessionvo.Operation) {
+	if t.err != nil {
+		return
+	}
+	causation := marshalJSON(operation.CausationEventIDs)
+	var exists int
+	err := t.tx.QueryRowContext(t.ctx,
+		"SELECT 1 FROM bkn_trace_operations WHERE operation_id=?",
+		operation.ID,
+	).Scan(&exists)
+	switch {
+	case errors.Is(err, sql.ErrNoRows):
+		_, t.err = t.tx.ExecContext(t.ctx, `
+			INSERT INTO bkn_trace_operations (
+				operation_id, conversation_id, interaction_id, operation_key, tool_name,
+				normalized_input_hash, parent_operation_id, causation_event_ids,
+				attempt_no, attempt_status, retryable, row_version, created_at, updated_at
+			) VALUES (?, ?, ?, ?, ?, ?, NULLIF(?, ''), NULLIF(?, ''), ?, ?, ?, ?, ?, ?)`,
+			operation.ID, operation.ConversationID, operation.InteractionID, operation.OperationKey,
+			operation.ToolName, operation.NormalizedInputHash, operation.ParentOperationID,
+			causation, operation.Attempt, operation.AttemptStatus, operation.Retryable,
+			operation.RowVersion, operation.CreatedAt, operation.UpdatedAt,
+		)
+	case err != nil:
+		t.err = err
+	default:
+		_, t.err = t.tx.ExecContext(t.ctx, `
+			UPDATE bkn_trace_operations SET attempt_no=?, attempt_status=?, retryable=?,
+				row_version=?, updated_at=? WHERE operation_id=?`,
+			operation.Attempt, operation.AttemptStatus, operation.Retryable,
+			operation.RowVersion, operation.UpdatedAt, operation.ID,
+		)
+	}
+}
+
+func (t *transaction) FindReceipt(receiptID string) (sessionvo.Receipt, bool) {
+	if t.err != nil {
+		return sessionvo.Receipt{}, false
+	}
+	return t.scanReceipt(t.tx.QueryRowContext(t.ctx, receiptSelect+`
+		WHERE receipt_id=? FOR UPDATE`, receiptID))
+}
+
+func (t *transaction) PeekReceipt(receiptID string) (sessionvo.Receipt, bool) {
+	if t.err != nil {
+		return sessionvo.Receipt{}, false
+	}
+	return t.scanReceipt(t.tx.QueryRowContext(t.ctx, receiptSelect+`
+		WHERE receipt_id=?`, receiptID))
+}
+
+func (t *transaction) FindReceiptByOperationAttempt(operationID string, attempt uint32) (sessionvo.Receipt, bool) {
+	if t.err != nil {
+		return sessionvo.Receipt{}, false
+	}
+	return t.scanReceipt(t.tx.QueryRowContext(t.ctx, receiptSelect+`
+		WHERE operation_id=? AND attempt_no=? FOR UPDATE`, operationID, attempt))
+}
+
+func (t *transaction) ListReceipts(interactionID string) []sessionvo.Receipt {
+	if t.err != nil {
+		return nil
+	}
+	rows, err := t.tx.QueryContext(t.ctx, receiptSelect+`
+		WHERE interaction_id=? ORDER BY receipt_id`, interactionID)
+	if err != nil {
+		t.err = err
+		return nil
+	}
+	defer rows.Close()
+	var result []sessionvo.Receipt
+	for rows.Next() {
+		value, scanErr := scanReceiptRows(rows)
+		if scanErr != nil {
+			t.err = scanErr
+			return nil
+		}
+		result = append(result, value)
+	}
+	t.err = rows.Err()
+	return result
+}
+
+func (t *transaction) SaveReceipt(receipt sessionvo.Receipt) {
+	if t.err != nil {
+		return
+	}
+	var exists int
+	err := t.tx.QueryRowContext(t.ctx,
+		"SELECT 1 FROM bkn_trace_receipts WHERE receipt_id=?",
+		receipt.ID,
+	).Scan(&exists)
+	switch {
+	case errors.Is(err, sql.ErrNoRows):
+		_, t.err = t.tx.ExecContext(t.ctx, `
+			INSERT INTO bkn_trace_receipts (
+				receipt_id, schema_version, tenant_id, business_domain_id,
+				application_principal_id, effective_subject_type, effective_subject_id,
+				delegation_id, conversation_id, interaction_id, operation_id, attempt_no,
+				operation_key, tool_name, normalized_input_hash, receipt_status,
+				evidence_durability, required_receipt, request_id, trace_id,
+				causation_event_ids, observed_evidence_refs, business_refs, artifact_refs,
+				partial_reasons, row_version, issued_at, terminal_at, payload_hash
+			) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?,
+				NULLIF(?, ''), NULLIF(?, ''), NULLIF(?, ''), NULLIF(?, ''), NULLIF(?, ''),
+				NULLIF(?, ''), NULLIF(?, ''), ?, ?, ?, NULLIF(?, ''))`,
+			receipt.ID, receipt.SchemaVersion, receipt.Owner.TenantID, receipt.Owner.BusinessDomainID,
+			receipt.Owner.ApplicationPrincipalID, receipt.Owner.EffectiveSubjectType,
+			receipt.Owner.EffectiveSubjectID, receipt.Owner.DelegationID,
+			receipt.ConversationID, receipt.InteractionID, receipt.OperationID, receipt.Attempt,
+			receipt.OperationKey, receipt.ToolName, receipt.NormalizedInputHash,
+			receipt.Status, receipt.EvidenceDurability, receipt.Required, receipt.RequestID,
+			receipt.TraceID, marshalJSON(receipt.CausationEventIDs),
+			marshalJSON(receipt.ObservedEvidenceRefs), marshalJSON(receipt.BusinessRefs),
+			marshalJSON(receipt.ArtifactRefs), marshalJSON(receipt.PartialReasons),
+			receipt.RowVersion, receipt.IssuedAt, nullableTime(receipt.TerminalAt), receipt.PayloadHash,
+		)
+	case err != nil:
+		t.err = err
+	default:
+		_, t.err = t.tx.ExecContext(t.ctx, `
+			UPDATE bkn_trace_receipts SET receipt_status=?, evidence_durability=?,
+				request_id=NULLIF(?, ''), trace_id=NULLIF(?, ''), observed_evidence_refs=NULLIF(?, ''),
+				business_refs=NULLIF(?, ''), artifact_refs=NULLIF(?, ''),
+				partial_reasons=NULLIF(?, ''), row_version=?, terminal_at=?,
+				payload_hash=NULLIF(?, '')
+			WHERE receipt_id=?`,
+			receipt.Status, receipt.EvidenceDurability, receipt.RequestID, receipt.TraceID,
+			marshalJSON(receipt.ObservedEvidenceRefs), marshalJSON(receipt.BusinessRefs),
+			marshalJSON(receipt.ArtifactRefs), marshalJSON(receipt.PartialReasons),
+			receipt.RowVersion, nullableTime(receipt.TerminalAt), receipt.PayloadHash, receipt.ID,
+		)
+	}
+}
+
+func (t *transaction) ListRequests(owner sessionvo.Owner, limit int) []sessionvo.RequestSummary {
+	if t.err != nil {
+		return nil
+	}
+	rows, err := t.tx.QueryContext(t.ctx, `
+		SELECT request_id, MIN(conversation_id), MIN(interaction_id),
+			COUNT(DISTINCT operation_id), COUNT(*),
+			MAX(COALESCE(terminal_at, issued_at))
+		FROM bkn_trace_receipts
+		WHERE tenant_id=? AND business_domain_id=? AND application_principal_id=?
+		  AND effective_subject_type=? AND effective_subject_id=? AND delegation_id=?
+		  AND request_id IS NOT NULL AND request_id<>''
+		GROUP BY request_id
+		ORDER BY MAX(COALESCE(terminal_at, issued_at)) DESC, request_id DESC
+		LIMIT ?`,
+		owner.TenantID, owner.BusinessDomainID, owner.ApplicationPrincipalID,
+		owner.EffectiveSubjectType, owner.EffectiveSubjectID, owner.DelegationID, limit,
+	)
+	if err != nil {
+		t.err = err
+		return nil
+	}
+	defer rows.Close()
+	var result []sessionvo.RequestSummary
+	for rows.Next() {
+		var value sessionvo.RequestSummary
+		if err := rows.Scan(
+			&value.RequestID, &value.ConversationID, &value.InteractionID,
+			&value.OperationCount, &value.ReceiptCount, &value.UpdatedAt,
+		); err != nil {
+			t.err = err
+			return nil
+		}
+		result = append(result, value)
+	}
+	if err := rows.Err(); err != nil {
+		t.err = err
+		return nil
+	}
+	if err := rows.Close(); err != nil {
+		t.err = err
+		return nil
+	}
+	for index := range result {
+		result[index].TraceIDs = t.listRequestTraceIDs(owner, result[index].RequestID)
+	}
+	return result
+}
+
+func (t *transaction) FindRequest(owner sessionvo.Owner, requestID string) (sessionvo.RequestSummary, bool) {
+	if t.err != nil {
+		return sessionvo.RequestSummary{}, false
+	}
+	var value sessionvo.RequestSummary
+	err := t.tx.QueryRowContext(t.ctx, `
+		SELECT request_id, MIN(conversation_id), MIN(interaction_id),
+			COUNT(DISTINCT operation_id), COUNT(*),
+			MAX(COALESCE(terminal_at, issued_at))
+		FROM bkn_trace_receipts
+		WHERE tenant_id=? AND business_domain_id=? AND application_principal_id=?
+		  AND effective_subject_type=? AND effective_subject_id=? AND delegation_id=?
+		  AND request_id=?
+		GROUP BY request_id`,
+		owner.TenantID, owner.BusinessDomainID, owner.ApplicationPrincipalID,
+		owner.EffectiveSubjectType, owner.EffectiveSubjectID, owner.DelegationID, requestID,
+	).Scan(
+		&value.RequestID, &value.ConversationID, &value.InteractionID,
+		&value.OperationCount, &value.ReceiptCount, &value.UpdatedAt,
+	)
+	if errors.Is(err, sql.ErrNoRows) {
+		return sessionvo.RequestSummary{}, false
+	}
+	if err != nil {
+		t.err = err
+		return sessionvo.RequestSummary{}, false
+	}
+	value.TraceIDs = t.listRequestTraceIDs(owner, requestID)
+	return value, true
+}
+
+func (t *transaction) listRequestTraceIDs(owner sessionvo.Owner, requestID string) []string {
+	if t.err != nil {
+		return nil
+	}
+	rows, err := t.tx.QueryContext(t.ctx, `
+		SELECT DISTINCT trace_id
+		FROM bkn_trace_receipts
+		WHERE tenant_id=? AND business_domain_id=? AND application_principal_id=?
+		  AND effective_subject_type=? AND effective_subject_id=? AND delegation_id=?
+		  AND request_id=? AND trace_id IS NOT NULL AND trace_id<>''
+		ORDER BY trace_id`,
+		owner.TenantID, owner.BusinessDomainID, owner.ApplicationPrincipalID,
+		owner.EffectiveSubjectType, owner.EffectiveSubjectID, owner.DelegationID, requestID,
+	)
+	if err != nil {
+		t.err = err
+		return nil
+	}
+	defer rows.Close()
+	var result []string
+	for rows.Next() {
+		var traceID string
+		if err := rows.Scan(&traceID); err != nil {
+			t.err = err
+			return nil
+		}
+		result = append(result, traceID)
+	}
+	t.err = rows.Err()
+	return result
+}
+
+func (t *transaction) ListExpiredActiveInteractions(limit int) []sessionvo.Interaction {
+	if t.err != nil {
+		return nil
+	}
+	if limit <= 0 {
+		limit = 100
+	}
+	rows, err := t.tx.QueryContext(t.ctx, interactionSelect+`
+		WHERE execution_status='active' AND lease_expires_at<=UTC_TIMESTAMP(6)
+		ORDER BY lease_expires_at, interaction_id LIMIT ?`, limit)
+	if err != nil {
+		t.err = err
+		return nil
+	}
+	defer rows.Close()
+	var result []sessionvo.Interaction
+	for rows.Next() {
+		interaction, scanErr := scanInteractionRows(rows)
+		if scanErr != nil {
+			t.err = scanErr
+			return nil
+		}
+		result = append(result, interaction)
+	}
+	t.err = rows.Err()
+	return result
+}
+
+func (t *transaction) ListIdleOneShotConversations(
+	cutoff time.Time,
+	limit int,
+) []sessionvo.Conversation {
+	if t.err != nil {
+		return nil
+	}
+	if limit <= 0 {
+		limit = 100
+	}
+	rows, err := t.tx.QueryContext(t.ctx, conversationSelect+`
+		WHERE one_shot=TRUE AND status='active' AND updated_at<=?
+		  AND NOT EXISTS (
+			SELECT 1 FROM bkn_trace_interactions
+			WHERE bkn_trace_interactions.conversation_id=bkn_trace_conversations.conversation_id
+		  )
+		ORDER BY updated_at, conversation_id LIMIT ? FOR UPDATE`, cutoff, limit)
+	if err != nil {
+		t.err = err
+		return nil
+	}
+	defer rows.Close()
+	var result []sessionvo.Conversation
+	for rows.Next() {
+		conversation, scanErr := scanConversationRows(rows)
+		if scanErr != nil {
+			t.err = scanErr
+			return nil
+		}
+		result = append(result, conversation)
+	}
+	t.err = rows.Err()
+	return result
+}
+
+func (t *transaction) ListAssemblyDueInteractions(limit int) []sessionvo.Interaction {
+	if t.err != nil {
+		return nil
+	}
+	if limit <= 0 {
+		limit = 100
+	}
+	rows, err := t.tx.QueryContext(t.ctx, interactionSelect+`
+		WHERE evidence_status='assembling' AND assembler_deadline<=UTC_TIMESTAMP(6)
+		ORDER BY assembler_deadline, interaction_id LIMIT ?`, limit)
+	if err != nil {
+		t.err = err
+		return nil
+	}
+	defer rows.Close()
+	var result []sessionvo.Interaction
+	for rows.Next() {
+		interaction, scanErr := scanInteractionRows(rows)
+		if scanErr != nil {
+			t.err = scanErr
+			return nil
+		}
+		result = append(result, interaction)
+	}
+	t.err = rows.Err()
+	return result
+}
+
+func (t *transaction) AppendProjection(mutation sessionvo.ProjectionMutation) {
+	if t.err != nil {
+		return
+	}
+	_, t.err = t.tx.ExecContext(t.ctx, `
+		INSERT INTO bkn_trace_projection_outbox (
+			aggregate_type, aggregate_id, aggregate_version, event_type, event_id, payload,
+			status, attempts, available_at, created_at
+		) VALUES (?, ?, ?, ?, ?, ?, 'pending', 0, ?, ?)`,
+		mutation.AggregateType, mutation.AggregateID, mutation.AggregateVersion,
+		mutation.EventType,
+		mutation.EventID, mutation.Payload, t.now, t.now,
+	)
+}
+
+func (t *transaction) ListAssemblyRevisions(interactionID string) []sessionvo.AssemblyRevision {
+	if t.err != nil {
+		return nil
+	}
+	rows, err := t.tx.QueryContext(t.ctx, `
+		SELECT revision_id, revision_no, COALESCE(parent_revision_id, ''), interaction_id,
+			completion_manifest_version, included_receipt_ids, included_event_ids,
+			artifact_manifest_hash, assembly_completeness, COALESCE(partial_reasons, ''),
+			trigger_type, created_at
+		FROM bkn_trace_assembly_revisions
+		WHERE interaction_id=? ORDER BY revision_no`, interactionID)
+	if err != nil {
+		t.err = err
+		return nil
+	}
+	defer rows.Close()
+	var result []sessionvo.AssemblyRevision
+	for rows.Next() {
+		var value sessionvo.AssemblyRevision
+		var receipts, events, reasons string
+		if err := rows.Scan(
+			&value.ID, &value.RevisionNo, &value.ParentRevisionID, &value.InteractionID,
+			&value.CompletionManifestVersion, &receipts, &events, &value.ArtifactManifestHash,
+			&value.Completeness, &reasons, &value.Trigger, &value.CreatedAt,
+		); err != nil {
+			t.err = err
+			return nil
+		}
+		unmarshalJSON(receipts, &value.IncludedReceiptIDs)
+		unmarshalJSON(events, &value.IncludedEventIDs)
+		unmarshalJSON(reasons, &value.PartialReasons)
+		result = append(result, value)
+	}
+	t.err = rows.Err()
+	return result
+}
+
+func (t *transaction) SaveAssemblyRevision(revision sessionvo.AssemblyRevision) {
+	if t.err != nil {
+		return
+	}
+	_, t.err = t.tx.ExecContext(t.ctx, `
+		INSERT INTO bkn_trace_assembly_revisions (
+			revision_id, interaction_id, revision_no, parent_revision_id,
+			completion_manifest_version, included_receipt_ids, included_event_ids,
+			artifact_manifest_hash, assembly_completeness, partial_reasons,
+			trigger_type, created_at
+		) VALUES (?, ?, ?, NULLIF(?, ''), ?, ?, ?, ?, ?, NULLIF(?, ''), ?, ?)`,
+		revision.ID, revision.InteractionID, revision.RevisionNo, revision.ParentRevisionID,
+		revision.CompletionManifestVersion, marshalJSON(revision.IncludedReceiptIDs),
+		marshalJSON(revision.IncludedEventIDs), revision.ArtifactManifestHash,
+		revision.Completeness, marshalJSON(revision.PartialReasons),
+		revision.Trigger, revision.CreatedAt,
+	)
+}
+
+const conversationSelect = `SELECT conversation_id, tenant_id, business_domain_id,
+	application_principal_id, effective_subject_type, effective_subject_id,
+	COALESCE(delegation_id, ''), external_conversation_key, generation, status,
+	one_shot, row_version, created_at, updated_at, closed_at
+	FROM bkn_trace_conversations`
+
+type rowScanner interface {
+	Scan(dest ...any) error
+}
+
+func (t *transaction) scanConversation(row rowScanner) (sessionvo.Conversation, bool) {
+	value, err := scanConversationRows(row)
+	if errors.Is(err, sql.ErrNoRows) {
+		return sessionvo.Conversation{}, false
+	}
+	if err != nil {
+		t.err = err
+		return sessionvo.Conversation{}, false
+	}
+	return value, true
+}
+
+func scanConversationRows(row rowScanner) (sessionvo.Conversation, error) {
+	var value sessionvo.Conversation
+	var closedAt sql.NullTime
+	err := row.Scan(
+		&value.ID, &value.Owner.TenantID, &value.Owner.BusinessDomainID,
+		&value.Owner.ApplicationPrincipalID, &value.Owner.EffectiveSubjectType,
+		&value.Owner.EffectiveSubjectID, &value.Owner.DelegationID,
+		&value.ExternalConversationKey, &value.Generation, &value.Status,
+		&value.OneShot, &value.RowVersion, &value.CreatedAt, &value.UpdatedAt, &closedAt,
+	)
+	if err != nil {
+		return sessionvo.Conversation{}, err
+	}
+	if closedAt.Valid {
+		value.ClosedAt = &closedAt.Time
+	}
+	return value, nil
+}
+
+const interactionSelect = `SELECT interaction_id, conversation_id, ordinal_no,
+	execution_status, evidence_status, start_idempotency_key,
+	COALESCE(terminal_idempotency_key, ''), COALESCE(terminal_payload_hash, ''),
+	COALESCE(closure_manifest, ''), lease_token, lease_epoch, lease_version,
+	lease_expires_at, row_version, created_at, updated_at, terminal_at
+	FROM bkn_trace_interactions`
+
+func (t *transaction) scanInteraction(row rowScanner) (sessionvo.Interaction, bool) {
+	value, err := scanInteractionRows(row)
+	if errors.Is(err, sql.ErrNoRows) {
+		return sessionvo.Interaction{}, false
+	}
+	if err != nil {
+		t.err = err
+		return sessionvo.Interaction{}, false
+	}
+	return value, true
+}
+
+func scanInteractionRows(row rowScanner) (sessionvo.Interaction, error) {
+	var value sessionvo.Interaction
+	var manifest string
+	var terminalAt sql.NullTime
+	err := row.Scan(
+		&value.ID, &value.ConversationID, &value.Ordinal, &value.ExecutionStatus,
+		&value.EvidenceStatus, &value.StartIdempotencyKey,
+		&value.TerminalIdempotencyKey, &value.TerminalPayloadHash, &manifest,
+		&value.LeaseToken, &value.LeaseEpoch, &value.LeaseVersion,
+		&value.LeaseExpiresAt, &value.RowVersion, &value.CreatedAt, &value.UpdatedAt, &terminalAt,
+	)
+	if err != nil {
+		return sessionvo.Interaction{}, err
+	}
+	if manifest != "" {
+		var decoded sessionvo.ClosureManifest
+		if err := json.Unmarshal([]byte(manifest), &decoded); err != nil {
+			return sessionvo.Interaction{}, err
+		}
+		value.ClosureManifest = &decoded
+	}
+	if terminalAt.Valid {
+		value.TerminalAt = &terminalAt.Time
+	}
+	return value, nil
+}
+
+const operationSelect = `SELECT operation_id, conversation_id, interaction_id,
+	operation_key, tool_name, normalized_input_hash, COALESCE(parent_operation_id, ''),
+	COALESCE(causation_event_ids, ''), attempt_no, attempt_status, retryable,
+	row_version, created_at, updated_at FROM bkn_trace_operations`
+
+func (t *transaction) scanOperation(row rowScanner) (sessionvo.Operation, bool) {
+	value, err := scanOperationRows(row)
+	if errors.Is(err, sql.ErrNoRows) {
+		return sessionvo.Operation{}, false
+	}
+	if err != nil {
+		t.err = err
+		return sessionvo.Operation{}, false
+	}
+	return value, true
+}
+
+func scanOperationRows(row rowScanner) (sessionvo.Operation, error) {
+	var value sessionvo.Operation
+	var causation string
+	err := row.Scan(
+		&value.ID, &value.ConversationID, &value.InteractionID, &value.OperationKey,
+		&value.ToolName, &value.NormalizedInputHash, &value.ParentOperationID, &causation,
+		&value.Attempt, &value.AttemptStatus, &value.Retryable, &value.RowVersion,
+		&value.CreatedAt, &value.UpdatedAt,
+	)
+	if err != nil {
+		return sessionvo.Operation{}, err
+	}
+	unmarshalJSON(causation, &value.CausationEventIDs)
+	return value, nil
+}
+
+const receiptSelect = `SELECT receipt_id, schema_version, tenant_id, business_domain_id,
+	application_principal_id, effective_subject_type, effective_subject_id,
+	COALESCE(delegation_id, ''), conversation_id, interaction_id, operation_id,
+	attempt_no, operation_key, tool_name, normalized_input_hash, receipt_status,
+	evidence_durability, required_receipt, COALESCE(request_id, ''), COALESCE(trace_id, ''),
+	COALESCE(causation_event_ids, ''), COALESCE(observed_evidence_refs, ''),
+	COALESCE(business_refs, ''), COALESCE(artifact_refs, ''), COALESCE(partial_reasons, ''),
+	row_version, issued_at, terminal_at, COALESCE(payload_hash, '') FROM bkn_trace_receipts`
+
+func (t *transaction) scanReceipt(row rowScanner) (sessionvo.Receipt, bool) {
+	value, err := scanReceiptRows(row)
+	if errors.Is(err, sql.ErrNoRows) {
+		return sessionvo.Receipt{}, false
+	}
+	if err != nil {
+		t.err = err
+		return sessionvo.Receipt{}, false
+	}
+	return value, true
+}
+
+func scanReceiptRows(row rowScanner) (sessionvo.Receipt, error) {
+	var value sessionvo.Receipt
+	var causation, evidence, business, artifacts, reasons string
+	var terminalAt sql.NullTime
+	err := row.Scan(
+		&value.ID, &value.SchemaVersion, &value.Owner.TenantID, &value.Owner.BusinessDomainID,
+		&value.Owner.ApplicationPrincipalID, &value.Owner.EffectiveSubjectType,
+		&value.Owner.EffectiveSubjectID, &value.Owner.DelegationID,
+		&value.ConversationID, &value.InteractionID, &value.OperationID, &value.Attempt,
+		&value.OperationKey, &value.ToolName, &value.NormalizedInputHash,
+		&value.Status, &value.EvidenceDurability, &value.Required,
+		&value.RequestID, &value.TraceID, &causation, &evidence, &business, &artifacts,
+		&reasons, &value.RowVersion, &value.IssuedAt, &terminalAt, &value.PayloadHash,
+	)
+	if err != nil {
+		return sessionvo.Receipt{}, err
+	}
+	unmarshalJSON(causation, &value.CausationEventIDs)
+	unmarshalJSON(evidence, &value.ObservedEvidenceRefs)
+	unmarshalJSON(business, &value.BusinessRefs)
+	unmarshalJSON(artifacts, &value.ArtifactRefs)
+	unmarshalJSON(reasons, &value.PartialReasons)
+	if terminalAt.Valid {
+		value.TerminalAt = &terminalAt.Time
+	}
+	return value, nil
+}
+
+func marshalJSON(value any) string {
+	if value == nil {
+		return ""
+	}
+	data, err := json.Marshal(value)
+	if err != nil || string(data) == "null" {
+		return ""
+	}
+	return string(data)
+}
+
+func unmarshalJSON(data string, target any) {
+	if data != "" {
+		_ = json.Unmarshal([]byte(data), target)
+	}
+}
+
+func nullableTime(value *time.Time) any {
+	if value == nil {
+		return nil
+	}
+	return *value
+}

--- a/bkn-trace/agent-observability/src/drivenadapter/dbaccess/mariadb/sessionstore/store.go
+++ b/bkn-trace/agent-observability/src/drivenadapter/dbaccess/mariadb/sessionstore/store.go
@@ -228,7 +228,7 @@ func (t *transaction) ListConversations(owner sessionvo.Owner, limit int) []sess
 		t.err = err
 		return nil
 	}
-	defer rows.Close()
+	defer func() { _ = rows.Close() }()
 	var result []sessionvo.Conversation
 	for rows.Next() {
 		value, scanErr := scanConversationRows(rows)
@@ -411,7 +411,7 @@ func (t *transaction) ListOperations(interactionID string) []sessionvo.Operation
 		t.err = err
 		return nil
 	}
-	defer rows.Close()
+	defer func() { _ = rows.Close() }()
 	var result []sessionvo.Operation
 	for rows.Next() {
 		value, scanErr := scanOperationRows(rows)
@@ -494,7 +494,7 @@ func (t *transaction) ListReceipts(interactionID string) []sessionvo.Receipt {
 		t.err = err
 		return nil
 	}
-	defer rows.Close()
+	defer func() { _ = rows.Close() }()
 	var result []sessionvo.Receipt
 	for rows.Next() {
 		value, scanErr := scanReceiptRows(rows)
@@ -582,7 +582,7 @@ func (t *transaction) ListRequests(owner sessionvo.Owner, limit int) []sessionvo
 		t.err = err
 		return nil
 	}
-	defer rows.Close()
+	defer func() { _ = rows.Close() }()
 	var result []sessionvo.RequestSummary
 	for rows.Next() {
 		var value sessionvo.RequestSummary
@@ -658,7 +658,7 @@ func (t *transaction) listRequestTraceIDs(owner sessionvo.Owner, requestID strin
 		t.err = err
 		return nil
 	}
-	defer rows.Close()
+	defer func() { _ = rows.Close() }()
 	var result []string
 	for rows.Next() {
 		var traceID string
@@ -686,7 +686,7 @@ func (t *transaction) ListExpiredActiveInteractions(limit int) []sessionvo.Inter
 		t.err = err
 		return nil
 	}
-	defer rows.Close()
+	defer func() { _ = rows.Close() }()
 	var result []sessionvo.Interaction
 	for rows.Next() {
 		interaction, scanErr := scanInteractionRows(rows)
@@ -721,7 +721,7 @@ func (t *transaction) ListIdleOneShotConversations(
 		t.err = err
 		return nil
 	}
-	defer rows.Close()
+	defer func() { _ = rows.Close() }()
 	var result []sessionvo.Conversation
 	for rows.Next() {
 		conversation, scanErr := scanConversationRows(rows)
@@ -749,7 +749,7 @@ func (t *transaction) ListAssemblyDueInteractions(limit int) []sessionvo.Interac
 		t.err = err
 		return nil
 	}
-	defer rows.Close()
+	defer func() { _ = rows.Close() }()
 	var result []sessionvo.Interaction
 	for rows.Next() {
 		interaction, scanErr := scanInteractionRows(rows)
@@ -793,7 +793,7 @@ func (t *transaction) ListAssemblyRevisions(interactionID string) []sessionvo.As
 		t.err = err
 		return nil
 	}
-	defer rows.Close()
+	defer func() { _ = rows.Close() }()
 	var result []sessionvo.AssemblyRevision
 	for rows.Next() {
 		var value sessionvo.AssemblyRevision

--- a/bkn-trace/agent-observability/src/drivenadapter/dbaccess/mariadb/sessionstore/store_integration_test.go
+++ b/bkn-trace/agent-observability/src/drivenadapter/dbaccess/mariadb/sessionstore/store_integration_test.go
@@ -1,0 +1,983 @@
+//go:build integration
+
+package sessionstore_test
+
+import (
+	"bytes"
+	"context"
+	"database/sql"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"reflect"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	_ "github.com/go-sql-driver/mysql"
+	"github.com/openbkn-ai/bkn-foundry/bkn-trace/agent-observability/src/domain/service/ledgersvc"
+	"github.com/openbkn-ai/bkn-foundry/bkn-trace/agent-observability/src/domain/service/projectionrebuildsvc"
+	"github.com/openbkn-ai/bkn-foundry/bkn-trace/agent-observability/src/domain/service/sessionsvc"
+	"github.com/openbkn-ai/bkn-foundry/bkn-trace/agent-observability/src/domain/valueobject/ledgervo"
+	"github.com/openbkn-ai/bkn-foundry/bkn-trace/agent-observability/src/domain/valueobject/sessionvo"
+	"github.com/openbkn-ai/bkn-foundry/bkn-trace/agent-observability/src/drivenadapter/dbaccess/mariadb/sessionstore"
+	"github.com/openbkn-ai/bkn-foundry/bkn-trace/agent-observability/src/drivenadapter/httpaccess/opensearchprojection"
+	"github.com/openbkn-ai/bkn-foundry/bkn-trace/agent-observability/src/infra/opensearch"
+	"github.com/openbkn-ai/bkn-foundry/bkn-trace/agent-observability/src/port/driven/iprojectionoutbox"
+)
+
+func TestConcurrentEnsureCurrentHasOneGeneration(t *testing.T) {
+	dsn := os.Getenv("BKN_TRACE_TEST_MARIADB_DSN")
+	if dsn == "" {
+		t.Skip("BKN_TRACE_TEST_MARIADB_DSN is not set")
+	}
+	db, err := sql.Open("mysql", dsn)
+	if err != nil {
+		t.Fatalf("open MariaDB: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	store := sessionstore.New(db)
+	if err := store.Migrate(context.Background()); err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+	service := sessionsvc.New(store, sessionsvc.Options{})
+	owner := sessionvo.Owner{
+		TenantID: "tenant-race", BusinessDomainID: "domain-race",
+		ApplicationPrincipalID: "app-race", EffectiveSubjectType: sessionvo.SubjectService,
+		EffectiveSubjectID: "subject-race",
+	}
+
+	const workers = 12
+	results := make(chan sessionvo.Conversation, workers)
+	errs := make(chan error, workers)
+	var wg sync.WaitGroup
+	for i := 0; i < workers; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			conversation, ensureErr := service.EnsureCurrentConversation(context.Background(), sessionsvc.EnsureConversationCommand{
+				Owner: owner, ExternalConversationKey: "concurrent-key", IdempotencyKey: "ensure",
+			})
+			results <- conversation
+			errs <- ensureErr
+		}()
+	}
+	wg.Wait()
+	close(results)
+	close(errs)
+	for ensureErr := range errs {
+		if ensureErr != nil {
+			t.Fatalf("concurrent ensure: %v", ensureErr)
+		}
+	}
+	var expected string
+	for conversation := range results {
+		if expected == "" {
+			expected = conversation.ID
+		}
+		if conversation.ID != expected || conversation.Generation != 1 {
+			t.Fatalf("expected one generation, got %#v", conversation)
+		}
+	}
+}
+
+func TestIdleOneShotExpirationAndInteractionStartCommitOneWinner(t *testing.T) {
+	dsn := os.Getenv("BKN_TRACE_TEST_MARIADB_DSN")
+	if dsn == "" {
+		t.Skip("BKN_TRACE_TEST_MARIADB_DSN is not set")
+	}
+	db, err := sql.Open("mysql", dsn)
+	if err != nil {
+		t.Fatalf("open MariaDB: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	store := sessionstore.New(db)
+	if err := store.Migrate(context.Background()); err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+	service := sessionsvc.New(store, sessionsvc.Options{})
+	owner := sessionvo.Owner{
+		TenantID: "tenant-one-shot", BusinessDomainID: "domain-one-shot",
+		ApplicationPrincipalID: "app-one-shot", EffectiveSubjectType: sessionvo.SubjectService,
+		EffectiveSubjectID: "subject-one-shot",
+	}
+
+	for iteration := 0; iteration < 10; iteration++ {
+		suffix := fmt.Sprintf("%d-%d", time.Now().UnixNano(), iteration)
+		conversation, ensureErr := service.EnsureCurrentConversation(
+			context.Background(),
+			sessionsvc.EnsureConversationCommand{
+				Owner: owner, ExternalConversationKey: "idle-race-" + suffix, OneShot: true,
+			},
+		)
+		if ensureErr != nil {
+			t.Fatalf("ensure one-shot conversation: %v", ensureErr)
+		}
+
+		started := make(chan struct{})
+		var startErr, expireErr error
+		var expired []sessionvo.Conversation
+		var wg sync.WaitGroup
+		wg.Add(2)
+		go func() {
+			defer wg.Done()
+			<-started
+			_, startErr = service.StartInteraction(context.Background(), sessionsvc.StartInteractionCommand{
+				Owner: owner, ConversationID: conversation.ID, IdempotencyKey: "start-" + suffix,
+			})
+		}()
+		go func() {
+			defer wg.Done()
+			<-started
+			expired, expireErr = service.ExpireIdleOneShotConversations(
+				context.Background(), time.Nanosecond, 1000,
+			)
+		}()
+		close(started)
+		wg.Wait()
+		if expireErr != nil {
+			t.Fatalf("expire one-shot conversation: %v", expireErr)
+		}
+
+		current, getErr := service.GetConversation(context.Background(), owner, conversation.ID)
+		if getErr != nil {
+			t.Fatalf("get one-shot conversation: %v", getErr)
+		}
+		targetExpired := false
+		for _, item := range expired {
+			if item.ID == conversation.ID {
+				targetExpired = true
+				break
+			}
+		}
+		switch current.Status {
+		case sessionvo.ConversationActive:
+			if startErr != nil || targetExpired {
+				t.Fatalf("active winner was inconsistent: start=%v expired=%t", startErr, targetExpired)
+			}
+		case sessionvo.ConversationExpired:
+			if !sessionsvc.IsCode(startErr, sessionsvc.CodeConversationExpired) || !targetExpired {
+				t.Fatalf("expiry winner was inconsistent: start=%v expired=%t", startErr, targetExpired)
+			}
+		default:
+			t.Fatalf("unexpected conversation status after race: %s", current.Status)
+		}
+	}
+}
+
+func TestEvidenceLedgerAndProjectionOutboxCommitAtomically(t *testing.T) {
+	dsn := os.Getenv("BKN_TRACE_TEST_MARIADB_DSN")
+	if dsn == "" {
+		t.Skip("BKN_TRACE_TEST_MARIADB_DSN is not set")
+	}
+	db, err := sql.Open("mysql", dsn)
+	if err != nil {
+		t.Fatalf("open MariaDB: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	store := sessionstore.New(db)
+	if err := store.Migrate(context.Background()); err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+	sessions := sessionsvc.New(store, sessionsvc.Options{})
+	suffix := fmt.Sprintf("%d", time.Now().UnixNano())
+	owner := sessionvo.Owner{
+		TenantID: "tenant-ledger", BusinessDomainID: "domain-ledger",
+		ApplicationPrincipalID: "app-ledger", EffectiveSubjectType: sessionvo.SubjectService,
+		EffectiveSubjectID: "subject-ledger",
+	}
+	conversation, err := sessions.EnsureCurrentConversation(context.Background(), sessionsvc.EnsureConversationCommand{
+		Owner: owner, ExternalConversationKey: "ledger-" + suffix, IdempotencyKey: "ensure",
+	})
+	if err != nil {
+		t.Fatalf("ensure conversation: %v", err)
+	}
+	interaction, err := sessions.StartInteraction(context.Background(), sessionsvc.StartInteractionCommand{
+		Owner: owner, ConversationID: conversation.ID, IdempotencyKey: "start",
+	})
+	if err != nil {
+		t.Fatalf("start interaction: %v", err)
+	}
+	operation, _, err := sessions.EnsureOperation(context.Background(), sessionsvc.EnsureOperationCommand{
+		Owner: owner, ConversationID: conversation.ID, InteractionID: interaction.ID,
+		OperationKey: "query", ToolName: "ontology-query",
+		NormalizedInputHash: "sha256:input", Required: true,
+		LeaseToken: interaction.LeaseToken, LeaseEpoch: interaction.LeaseEpoch,
+	})
+	if err != nil {
+		t.Fatalf("ensure operation: %v", err)
+	}
+	envelope := json.RawMessage(`{"result":"durable"}`)
+	event := ledgervo.Event{
+		EventID: "evt-" + suffix, EventType: "operation.output.observed", SchemaVersion: "3.0.0",
+		PayloadHash: ledgervo.CanonicalPayloadHash(envelope), Owner: owner,
+		ConversationID: conversation.ID, InteractionID: interaction.ID,
+		OperationID: operation.ID, Attempt: 1, ProducerID: "integration-test",
+		ProducerStreamID: "stream-" + suffix, ProducerEpoch: 1, ProducerSequence: 1,
+		StartedAt: time.Now().UTC(), ObservedAt: time.Now().UTC(),
+		EmittedAt: time.Now().UTC(), Envelope: envelope,
+	}
+	ledger := ledgersvc.New(store)
+	ack, err := ledger.Ingest(context.Background(), event)
+	if err != nil || !ack.Durable {
+		t.Fatalf("ingest durable event: %#v, %v", ack, err)
+	}
+	replay, err := ledger.Ingest(context.Background(), event)
+	if err != nil || !replay.Replayed || replay.IngestSequence != ack.IngestSequence {
+		t.Fatalf("replay durable event: %#v, %v", replay, err)
+	}
+	var ledgerCount, outboxCount int
+	if err := db.QueryRow("SELECT COUNT(*) FROM bkn_trace_evidence_event_ledger WHERE event_id=?", event.EventID).Scan(&ledgerCount); err != nil {
+		t.Fatalf("count ledger: %v", err)
+	}
+	if err := db.QueryRow("SELECT COUNT(*) FROM bkn_trace_projection_outbox WHERE event_id=? AND event_type='evidence.project'", event.EventID).Scan(&outboxCount); err != nil {
+		t.Fatalf("count outbox: %v", err)
+	}
+	if ledgerCount != 1 || outboxCount != 1 {
+		t.Fatalf("expected one ledger and outbox row, got %d and %d", ledgerCount, outboxCount)
+	}
+
+	firstCycleEvent := event
+	firstCycleEvent.EventID = "evt-cycle-a-" + suffix
+	firstCycleEvent.ProducerSequence = 2
+	firstCycleEvent.CausationEventIDs = []string{"evt-cycle-b-" + suffix}
+	firstCycleEvent.Envelope = json.RawMessage(`{"result":"cycle-a"}`)
+	firstCycleEvent.PayloadHash = ledgervo.CanonicalPayloadHash(firstCycleEvent.Envelope)
+	if _, err := ledger.Ingest(context.Background(), firstCycleEvent); err != nil {
+		t.Fatalf("ingest event with late cause: %v", err)
+	}
+	secondCycleEvent := event
+	secondCycleEvent.EventID = "evt-cycle-b-" + suffix
+	secondCycleEvent.ProducerSequence = 3
+	secondCycleEvent.CausationEventIDs = []string{firstCycleEvent.EventID}
+	secondCycleEvent.Envelope = json.RawMessage(`{"result":"cycle-b"}`)
+	secondCycleEvent.PayloadHash = ledgervo.CanonicalPayloadHash(secondCycleEvent.Envelope)
+	if _, err := ledger.Ingest(context.Background(), secondCycleEvent); !ledgersvc.IsCode(err, ledgersvc.CodeInvalidEvent) {
+		t.Fatalf("MariaDB ledger accepted a causation cycle: %v", err)
+	}
+}
+
+func TestTerminalRaceCommitsOneWinner(t *testing.T) {
+	dsn := os.Getenv("BKN_TRACE_TEST_MARIADB_DSN")
+	if dsn == "" {
+		t.Skip("BKN_TRACE_TEST_MARIADB_DSN is not set")
+	}
+	db, err := sql.Open("mysql", dsn)
+	if err != nil {
+		t.Fatalf("open MariaDB: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	store := sessionstore.New(db)
+	if err := store.Migrate(context.Background()); err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+	service := sessionsvc.New(store, sessionsvc.Options{})
+	suffix := fmt.Sprintf("%d", time.Now().UnixNano())
+	owner := sessionvo.Owner{
+		TenantID: "tenant-terminal", BusinessDomainID: "domain-terminal",
+		ApplicationPrincipalID: "app-terminal", EffectiveSubjectType: sessionvo.SubjectService,
+		EffectiveSubjectID: "subject-terminal",
+	}
+	conversation, err := service.EnsureCurrentConversation(context.Background(), sessionsvc.EnsureConversationCommand{
+		Owner: owner, ExternalConversationKey: "terminal-" + suffix, IdempotencyKey: "ensure",
+	})
+	if err != nil {
+		t.Fatalf("ensure conversation: %v", err)
+	}
+	interaction, err := service.StartInteraction(context.Background(), sessionsvc.StartInteractionCommand{
+		Owner: owner, ConversationID: conversation.ID, IdempotencyKey: "start",
+	})
+	if err != nil {
+		t.Fatalf("start interaction: %v", err)
+	}
+	statuses := []sessionvo.InteractionStatus{
+		sessionvo.InteractionCompleted, sessionvo.InteractionFailed,
+		sessionvo.InteractionCanceled, sessionvo.InteractionHandedOff,
+	}
+	errs := make(chan error, len(statuses))
+	var wg sync.WaitGroup
+	for index, status := range statuses {
+		wg.Add(1)
+		go func(index int, status sessionvo.InteractionStatus) {
+			defer wg.Done()
+			_, terminateErr := service.TerminateInteraction(context.Background(), sessionsvc.TerminateInteractionCommand{
+				Owner: owner, InteractionID: interaction.ID, Status: status,
+				TerminalIdempotencyKey: fmt.Sprintf("terminal-%d", index),
+				LeaseToken:             interaction.LeaseToken, LeaseEpoch: interaction.LeaseEpoch,
+				Manifest: sessionvo.ClosureManifest{
+					Version: "1", CompletionReason: "race",
+				},
+			})
+			errs <- terminateErr
+		}(index, status)
+	}
+	wg.Wait()
+	close(errs)
+	var successes, conflicts int
+	for terminateErr := range errs {
+		switch {
+		case terminateErr == nil:
+			successes++
+		case sessionsvc.IsCode(terminateErr, sessionsvc.CodeTerminalConflict):
+			conflicts++
+		default:
+			t.Fatalf("unexpected terminal race error: %v", terminateErr)
+		}
+	}
+	if successes != 1 || conflicts != len(statuses)-1 {
+		t.Fatalf("expected one terminal winner, successes=%d conflicts=%d", successes, conflicts)
+	}
+}
+
+func TestTerminalAndLeaseReaperRaceCommitsOneWinner(t *testing.T) {
+	dsn := os.Getenv("BKN_TRACE_TEST_MARIADB_DSN")
+	if dsn == "" {
+		t.Skip("BKN_TRACE_TEST_MARIADB_DSN is not set")
+	}
+	db, err := sql.Open("mysql", dsn)
+	if err != nil {
+		t.Fatalf("open MariaDB: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	store := sessionstore.New(db)
+	if err := store.Migrate(context.Background()); err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+	service := sessionsvc.New(store, sessionsvc.Options{})
+	suffix := fmt.Sprintf("%d", time.Now().UnixNano())
+	owner := sessionvo.Owner{
+		TenantID: "tenant-reaper", BusinessDomainID: "domain-reaper",
+		ApplicationPrincipalID: "app-reaper", EffectiveSubjectType: sessionvo.SubjectService,
+		EffectiveSubjectID: "subject-reaper",
+	}
+	conversation, err := service.EnsureCurrentConversation(
+		context.Background(),
+		sessionsvc.EnsureConversationCommand{
+			Owner: owner, ExternalConversationKey: "reaper-" + suffix,
+			IdempotencyKey: "ensure",
+		},
+	)
+	if err != nil {
+		t.Fatalf("ensure conversation: %v", err)
+	}
+	interaction, err := service.StartInteraction(
+		context.Background(),
+		sessionsvc.StartInteractionCommand{
+			Owner: owner, ConversationID: conversation.ID,
+			IdempotencyKey: "start", LeaseDuration: 20 * time.Millisecond,
+		},
+	)
+	if err != nil {
+		t.Fatalf("start interaction: %v", err)
+	}
+	time.Sleep(15 * time.Millisecond)
+
+	var wg sync.WaitGroup
+	terminalErr := make(chan error, 1)
+	reaperErr := make(chan error, 1)
+	wg.Add(2)
+	go func() {
+		defer wg.Done()
+		_, err := service.TerminateInteraction(
+			context.Background(),
+			sessionsvc.TerminateInteractionCommand{
+				Owner: owner, InteractionID: interaction.ID,
+				Status:                 sessionvo.InteractionCompleted,
+				TerminalIdempotencyKey: "terminal",
+				LeaseToken:             interaction.LeaseToken, LeaseEpoch: interaction.LeaseEpoch,
+				Manifest: sessionvo.ClosureManifest{
+					Version: "1", CompletionReason: "race",
+				},
+			},
+		)
+		terminalErr <- err
+	}()
+	go func() {
+		defer wg.Done()
+		_, err := service.AbandonExpiredInteractions(context.Background(), 100)
+		reaperErr <- err
+	}()
+	wg.Wait()
+	if err := <-reaperErr; err != nil {
+		t.Fatalf("lease reaper: %v", err)
+	}
+	if err := <-terminalErr; err != nil &&
+		!sessionsvc.IsCode(err, sessionsvc.CodeTerminalConflict) {
+		t.Fatalf("unexpected terminal result: %v", err)
+	}
+
+	current, err := service.GetInteraction(context.Background(), owner, interaction.ID)
+	if err != nil {
+		t.Fatalf("get interaction: %v", err)
+	}
+	if current.ExecutionStatus != sessionvo.InteractionCompleted &&
+		current.ExecutionStatus != sessionvo.InteractionAbandoned {
+		t.Fatalf("race did not commit one terminal status: %#v", current)
+	}
+	var terminalProjectionCount int
+	if err := db.QueryRow(`
+		SELECT COUNT(*) FROM bkn_trace_projection_outbox
+		WHERE aggregate_type='interaction' AND aggregate_id=?
+		  AND event_type IN ('interaction.completed', 'interaction.abandoned')`,
+		interaction.ID,
+	).Scan(&terminalProjectionCount); err != nil {
+		t.Fatalf("count terminal projection: %v", err)
+	}
+	if terminalProjectionCount != 1 {
+		t.Fatalf("expected one terminal projection, got %d", terminalProjectionCount)
+	}
+}
+
+func TestProjectionOutboxRejectsStaleLeaseCompletion(t *testing.T) {
+	dsn := os.Getenv("BKN_TRACE_TEST_MARIADB_DSN")
+	if dsn == "" {
+		t.Skip("BKN_TRACE_TEST_MARIADB_DSN is not set")
+	}
+	db, err := sql.Open("mysql", dsn)
+	if err != nil {
+		t.Fatalf("open MariaDB: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	store := sessionstore.New(db)
+	if err := store.Migrate(context.Background()); err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+	service := sessionsvc.New(store, sessionsvc.Options{})
+	suffix := fmt.Sprintf("%d", time.Now().UnixNano())
+	owner := sessionvo.Owner{
+		TenantID: "tenant-outbox", BusinessDomainID: "domain-outbox",
+		ApplicationPrincipalID: "app-outbox", EffectiveSubjectType: sessionvo.SubjectService,
+		EffectiveSubjectID: "subject-outbox",
+	}
+	if _, err := service.EnsureCurrentConversation(context.Background(), sessionsvc.EnsureConversationCommand{
+		Owner: owner, ExternalConversationKey: "outbox-" + suffix, IdempotencyKey: "ensure",
+	}); err != nil {
+		t.Fatalf("ensure conversation: %v", err)
+	}
+	firstLease, err := store.Lease(context.Background(), 1, time.Millisecond)
+	if err != nil || len(firstLease) != 1 {
+		t.Fatalf("first lease: %#v, %v", firstLease, err)
+	}
+	time.Sleep(5 * time.Millisecond)
+	secondLease, err := store.Lease(context.Background(), 1, time.Minute)
+	if err != nil || len(secondLease) != 1 || firstLease[0].ID != secondLease[0].ID {
+		t.Fatalf("second lease: %#v, %v", secondLease, err)
+	}
+	if err := store.MarkDelivered(context.Background(), firstLease[0]); !errors.Is(err, iprojectionoutbox.ErrLeaseLost) {
+		t.Fatalf("stale lease unexpectedly completed outbox: %v", err)
+	}
+	if err := store.MarkDelivered(context.Background(), secondLease[0]); err != nil {
+		t.Fatalf("current lease could not complete outbox: %v", err)
+	}
+	if err := store.MoveToDLQ(context.Background(), firstLease[0], "late_failure"); !errors.Is(err, iprojectionoutbox.ErrLeaseLost) {
+		t.Fatalf("stale lease unexpectedly created DLQ: %v", err)
+	}
+	var dlqCount int
+	if err := db.QueryRow(
+		"SELECT COUNT(*) FROM bkn_trace_dlq WHERE source_kind='projection' AND source_id=?",
+		firstLease[0].EventID,
+	).Scan(&dlqCount); err != nil {
+		t.Fatalf("count DLQ: %v", err)
+	}
+	if dlqCount != 0 {
+		t.Fatalf("stale lease created %d false DLQ rows", dlqCount)
+	}
+}
+
+func TestProjectionDLQReplayIsAuditedAndReturnsEventToOutbox(t *testing.T) {
+	dsn := os.Getenv("BKN_TRACE_TEST_MARIADB_DSN")
+	if dsn == "" {
+		t.Skip("BKN_TRACE_TEST_MARIADB_DSN is not set")
+	}
+	db, err := sql.Open("mysql", dsn)
+	if err != nil {
+		t.Fatalf("open MariaDB: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	store := sessionstore.New(db)
+	if err := store.Migrate(context.Background()); err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+
+	suffix := fmt.Sprintf("%d", time.Now().UnixNano())
+	eventID := "evt-dlq-" + suffix
+	result, err := db.Exec(`
+		INSERT INTO bkn_trace_projection_outbox (
+			aggregate_type, aggregate_id, event_type, event_id, payload,
+			status, attempts, available_at, created_at
+		) VALUES ('evidence', ?, 'evidence.project', ?, '{}',
+			'pending', 0, UTC_TIMESTAMP(6), UTC_TIMESTAMP(6))`,
+		eventID, eventID,
+	)
+	if err != nil {
+		t.Fatalf("insert outbox: %v", err)
+	}
+	outboxID, err := result.LastInsertId()
+	if err != nil {
+		t.Fatalf("outbox ID: %v", err)
+	}
+	leaseToken := "lease-" + suffix
+	if _, err := db.Exec(`
+		UPDATE bkn_trace_projection_outbox
+		SET status='processing', lease_token=?,
+			locked_until=DATE_ADD(UTC_TIMESTAMP(6), INTERVAL 1 MINUTE)
+		WHERE outbox_id=?`,
+		leaseToken, outboxID,
+	); err != nil {
+		t.Fatalf("lease inserted outbox: %v", err)
+	}
+	item := iprojectionoutbox.Item{
+		ID: uint64(outboxID), EventID: eventID, Payload: []byte(`{}`),
+		LeaseToken: leaseToken,
+	}
+	if err := store.MoveToDLQ(context.Background(), item, "mapping_invalid"); err != nil {
+		t.Fatalf("move to DLQ: %v", err)
+	}
+
+	var dlqID uint64
+	if err := db.QueryRow(`
+		SELECT dlq_id FROM bkn_trace_dlq
+		WHERE source_kind='projection' AND source_id=?`, eventID,
+	).Scan(&dlqID); err != nil {
+		t.Fatalf("find DLQ row: %v", err)
+	}
+	if err := store.ReplayProjectionDLQ(
+		context.Background(),
+		iprojectionoutbox.ReplayRequest{
+			DLQID: dlqID, Operator: "sre@example.com",
+			Reason: "mapping fixed", RepairVersion: "bkn-trace-core-v20260730.2",
+		},
+	); err != nil {
+		t.Fatalf("replay DLQ: %v", err)
+	}
+
+	var status string
+	var attempts uint32
+	if err := db.QueryRow(`
+		SELECT status, attempts FROM bkn_trace_projection_outbox
+		WHERE outbox_id=?`, outboxID,
+	).Scan(&status, &attempts); err != nil {
+		t.Fatalf("query replayed outbox: %v", err)
+	}
+	if status != "pending" || attempts != 0 {
+		t.Fatalf("replayed outbox state = %q attempts=%d", status, attempts)
+	}
+	var auditCount int
+	if err := db.QueryRow(`
+		SELECT COUNT(*) FROM bkn_trace_dlq_replay_audit
+		WHERE dlq_id=? AND replayed_by='sre@example.com'
+		  AND reason='mapping fixed'
+		  AND repair_version='bkn-trace-core-v20260730.2'`, dlqID,
+	).Scan(&auditCount); err != nil {
+		t.Fatalf("query replay audit: %v", err)
+	}
+	if auditCount != 1 {
+		t.Fatalf("expected one DLQ replay audit row, got %d", auditCount)
+	}
+}
+
+func TestProjectionRebuildFromMariaDBAuthorityAfterOutboxCleanup(t *testing.T) {
+	dsn := os.Getenv("BKN_TRACE_TEST_MARIADB_DSN")
+	if dsn == "" {
+		t.Skip("BKN_TRACE_TEST_MARIADB_DSN is not set")
+	}
+	db, err := sql.Open("mysql", dsn)
+	if err != nil {
+		t.Fatalf("open MariaDB: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	store := sessionstore.New(db)
+	if err := store.Migrate(context.Background()); err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+	suffix := fmt.Sprintf("%d", time.Now().UnixNano())
+	owner := sessionvo.Owner{
+		TenantID: "tenant-rebuild-" + suffix, BusinessDomainID: "domain-rebuild",
+		ApplicationPrincipalID: "app-rebuild",
+		EffectiveSubjectType:   sessionvo.SubjectService,
+		EffectiveSubjectID:     "subject-rebuild",
+	}
+	conversation, err := sessionsvc.New(store, sessionsvc.Options{}).
+		EnsureCurrentConversation(
+			context.Background(),
+			sessionsvc.EnsureConversationCommand{
+				Owner: owner, ExternalConversationKey: "external-" + suffix,
+				IdempotencyKey: "ensure-" + suffix,
+			},
+		)
+	if err != nil {
+		t.Fatalf("create authoritative conversation: %v", err)
+	}
+	if _, err := db.Exec(
+		"DELETE FROM bkn_trace_projection_outbox WHERE aggregate_type='conversation' AND aggregate_id=?",
+		conversation.ID,
+	); err != nil {
+		t.Fatalf("simulate delivered Outbox retention cleanup: %v", err)
+	}
+
+	target := &integrationRebuildTarget{documents: make(map[string][]byte)}
+	version := "bkn-trace-core-" + suffix
+	result, err := projectionrebuildsvc.New(
+		store, target, projectionrebuildsvc.Options{BatchSize: 7},
+	).Rebuild(context.Background(), "core", "bkn-trace-core", version)
+	if err != nil {
+		t.Fatalf("rebuild projection: %v", err)
+	}
+	if result.LastOutboxID == 0 || result.ProjectedCount == 0 ||
+		target.alias != "bkn-trace-core" || target.version != version {
+		t.Fatalf("unexpected rebuild result: %#v target=%#v", result, target)
+	}
+	documentID := "conversation:" + conversation.ID
+	if _, found := target.documents[documentID]; !found {
+		t.Fatalf("rebuild omitted authority after Outbox cleanup: %s", documentID)
+	}
+}
+
+func TestAuthorityRebuildMatchesLiveOperationAndReceiptProjectionModels(t *testing.T) {
+	dsn := os.Getenv("BKN_TRACE_TEST_MARIADB_DSN")
+	if dsn == "" {
+		t.Skip("BKN_TRACE_TEST_MARIADB_DSN is not set")
+	}
+	db, err := sql.Open("mysql", dsn)
+	if err != nil {
+		t.Fatalf("open MariaDB: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	store := sessionstore.New(db)
+	if err := store.Migrate(context.Background()); err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+	suffix := fmt.Sprintf("%d", time.Now().UnixNano())
+	owner := sessionvo.Owner{
+		TenantID: "tenant-model-" + suffix, BusinessDomainID: "domain-model",
+		ApplicationPrincipalID: "app-model",
+		EffectiveSubjectType:   sessionvo.SubjectService, EffectiveSubjectID: "subject-model",
+	}
+	service := sessionsvc.New(store, sessionsvc.Options{})
+	conversation, err := service.EnsureCurrentConversation(
+		context.Background(),
+		sessionsvc.EnsureConversationCommand{
+			Owner: owner, ExternalConversationKey: "model-" + suffix,
+			IdempotencyKey: "ensure",
+		},
+	)
+	if err != nil {
+		t.Fatalf("create conversation: %v", err)
+	}
+	interaction, err := service.StartInteraction(
+		context.Background(),
+		sessionsvc.StartInteractionCommand{
+			Owner: owner, ConversationID: conversation.ID, IdempotencyKey: "start",
+		},
+	)
+	if err != nil {
+		t.Fatalf("start interaction: %v", err)
+	}
+	operation, receipt, err := service.EnsureOperation(
+		context.Background(),
+		sessionsvc.EnsureOperationCommand{
+			Owner: owner, ConversationID: conversation.ID, InteractionID: interaction.ID,
+			OperationKey: "query", ToolName: "ontology-query",
+			NormalizedInputHash: "sha256:model", Required: true,
+			LeaseToken: interaction.LeaseToken, LeaseEpoch: interaction.LeaseEpoch,
+		},
+	)
+	if err != nil {
+		t.Fatalf("ensure operation: %v", err)
+	}
+	live := make(map[string]iprojectionoutbox.Item)
+	through, err := store.ProjectionHighWatermark(context.Background())
+	if err != nil {
+		t.Fatalf("read projection watermark: %v", err)
+	}
+	history, err := store.ScanProjectionHistory(context.Background(), 0, through, 10000)
+	if err != nil {
+		t.Fatalf("scan live projection history: %v", err)
+	}
+	for _, item := range history {
+		if item.AggregateID == operation.ID || item.AggregateID == receipt.ID {
+			live[iprojectionoutbox.DocumentID(item)] = item
+		}
+	}
+	authority := make(map[string]iprojectionoutbox.Item)
+	afterType, afterID := "", ""
+	for {
+		items, scanErr := store.ScanAuthoritativeProjection(
+			context.Background(), afterType, afterID, 100,
+		)
+		if scanErr != nil {
+			t.Fatalf("scan authoritative projection: %v", scanErr)
+		}
+		if len(items) == 0 {
+			break
+		}
+		for _, item := range items {
+			if item.AggregateID == operation.ID || item.AggregateID == receipt.ID {
+				authority[iprojectionoutbox.DocumentID(item)] = item
+			}
+		}
+		last := items[len(items)-1]
+		afterType, afterID = last.AggregateType, last.AggregateID
+	}
+	for _, documentID := range []string{
+		"operation:" + operation.ID,
+		"receipt:" + receipt.ID,
+	} {
+		liveItem, liveFound := live[documentID]
+		authorityItem, authorityFound := authority[documentID]
+		if !liveFound || !authorityFound {
+			t.Fatalf(
+				"projection model missing for %s: live=%t authority=%t",
+				documentID, liveFound, authorityFound,
+			)
+		}
+		if liveItem.AggregateVersion != authorityItem.AggregateVersion ||
+			!equivalentJSON(liveItem.Payload, authorityItem.Payload) {
+			t.Fatalf(
+				"live/rebuild projection mismatch for %s:\nlive=%s\nauthority=%s",
+				documentID, liveItem.Payload, authorityItem.Payload,
+			)
+		}
+	}
+}
+
+func TestMariaDBAuthorityRebuildsIntoOpenSearchAlias(t *testing.T) {
+	dsn := os.Getenv("BKN_TRACE_TEST_MARIADB_DSN")
+	endpoint := os.Getenv("BKN_TRACE_TEST_OPENSEARCH_ENDPOINT")
+	if dsn == "" || endpoint == "" {
+		t.Skip("MariaDB DSN and OpenSearch endpoint are required")
+	}
+	db, err := sql.Open("mysql", dsn)
+	if err != nil {
+		t.Fatalf("open MariaDB: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	store := sessionstore.New(db)
+	if err := store.Migrate(context.Background()); err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+	suffix := fmt.Sprintf("%d", time.Now().UnixNano())
+	owner := sessionvo.Owner{
+		TenantID: "tenant-combined-" + suffix, BusinessDomainID: "domain-combined",
+		ApplicationPrincipalID: "app-combined",
+		EffectiveSubjectType:   sessionvo.SubjectService, EffectiveSubjectID: "subject-combined",
+	}
+	service := sessionsvc.New(store, sessionsvc.Options{})
+	conversation, err := service.EnsureCurrentConversation(
+		context.Background(),
+		sessionsvc.EnsureConversationCommand{
+			Owner: owner, ExternalConversationKey: "combined-" + suffix,
+			IdempotencyKey: "ensure",
+		},
+	)
+	if err != nil {
+		t.Fatalf("create conversation: %v", err)
+	}
+	interaction, err := service.StartInteraction(
+		context.Background(),
+		sessionsvc.StartInteractionCommand{
+			Owner: owner, ConversationID: conversation.ID, IdempotencyKey: "start",
+		},
+	)
+	if err != nil {
+		t.Fatalf("start interaction: %v", err)
+	}
+	operation, receipt, err := service.EnsureOperation(
+		context.Background(),
+		sessionsvc.EnsureOperationCommand{
+			Owner: owner, ConversationID: conversation.ID, InteractionID: interaction.ID,
+			OperationKey: "combined-query", ToolName: "ontology-query",
+			NormalizedInputHash: "sha256:combined", Required: true,
+			LeaseToken: interaction.LeaseToken, LeaseEpoch: interaction.LeaseEpoch,
+		},
+	)
+	if err != nil {
+		t.Fatalf("ensure operation: %v", err)
+	}
+	username := os.Getenv("BKN_TRACE_TEST_OPENSEARCH_USERNAME")
+	client := opensearch.New(endpoint, opensearch.AuthConfig{
+		Enabled: username != "", Username: username,
+		Password: os.Getenv("BKN_TRACE_TEST_OPENSEARCH_PASSWORD"),
+	}, 10*time.Second)
+	alias := "bkn-trace-combined-" + suffix
+	version := alias + "-v1"
+	target := opensearchprojection.New(client, alias)
+	if _, err := projectionrebuildsvc.New(
+		store, target, projectionrebuildsvc.Options{BatchSize: 100},
+	).Rebuild(context.Background(), "combined", alias, version); err != nil {
+		t.Fatalf("rebuild MariaDB authority into OpenSearch: %v", err)
+	}
+	for documentID, expected := range map[string]any{
+		"operation:" + operation.ID: operation,
+		"receipt:" + receipt.ID:     receipt,
+	} {
+		document, err := client.GetDocument(context.Background(), alias, documentID)
+		if err != nil {
+			t.Fatalf("read %s through alias: %v", documentID, err)
+		}
+		expectedJSON, _ := json.Marshal(expected)
+		if !equivalentJSON(document.Source, expectedJSON) {
+			t.Fatalf(
+				"combined rebuild changed %s contract:\nexpected=%s\nactual=%s",
+				documentID, expectedJSON, document.Source,
+			)
+		}
+	}
+}
+
+func equivalentJSON(left, right []byte) bool {
+	var leftValue, rightValue any
+	if json.Unmarshal(left, &leftValue) != nil || json.Unmarshal(right, &rightValue) != nil {
+		return false
+	}
+	return reflect.DeepEqual(leftValue, rightValue)
+}
+
+type integrationRebuildTarget struct {
+	documents map[string][]byte
+	alias     string
+	version   string
+}
+
+func (t *integrationRebuildTarget) PrepareVersion(context.Context, string) error {
+	return nil
+}
+
+func BenchmarkMariaDBEnsureCurrent(b *testing.B) {
+	dsn := os.Getenv("BKN_TRACE_TEST_MARIADB_DSN")
+	if dsn == "" {
+		b.Skip("BKN_TRACE_TEST_MARIADB_DSN is not set")
+	}
+	db, err := sql.Open("mysql", dsn)
+	if err != nil {
+		b.Fatalf("open MariaDB: %v", err)
+	}
+	b.Cleanup(func() { _ = db.Close() })
+	store := sessionstore.New(db)
+	if err := store.Migrate(context.Background()); err != nil {
+		b.Fatalf("migrate: %v", err)
+	}
+	service := sessionsvc.New(store, sessionsvc.Options{})
+	owner := sessionvo.Owner{
+		TenantID: "tenant-capacity", BusinessDomainID: "domain-capacity",
+		ApplicationPrincipalID: "app-capacity", EffectiveSubjectType: sessionvo.SubjectService,
+		EffectiveSubjectID: "subject-capacity",
+	}
+	prefix := fmt.Sprintf("capacity-%d-", time.Now().UnixNano())
+	var sequence atomic.Uint64
+
+	b.ResetTimer()
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			index := sequence.Add(1)
+			if _, err := service.EnsureCurrentConversation(
+				context.Background(),
+				sessionsvc.EnsureConversationCommand{
+					Owner:                   owner,
+					ExternalConversationKey: fmt.Sprintf("%s%d", prefix, index),
+					IdempotencyKey:          "ensure",
+				},
+			); err != nil {
+				b.Errorf("ensure current: %v", err)
+				return
+			}
+		}
+	})
+}
+
+func BenchmarkMariaDBEvidenceIngest(b *testing.B) {
+	dsn := os.Getenv("BKN_TRACE_TEST_MARIADB_DSN")
+	if dsn == "" {
+		b.Skip("BKN_TRACE_TEST_MARIADB_DSN is not set")
+	}
+	db, err := sql.Open("mysql", dsn)
+	if err != nil {
+		b.Fatalf("open MariaDB: %v", err)
+	}
+	b.Cleanup(func() { _ = db.Close() })
+	store := sessionstore.New(db)
+	if err := store.Migrate(context.Background()); err != nil {
+		b.Fatalf("migrate: %v", err)
+	}
+	sessions := sessionsvc.New(store, sessionsvc.Options{})
+	owner := sessionvo.Owner{
+		TenantID: "tenant-evidence-capacity", BusinessDomainID: "domain-evidence-capacity",
+		ApplicationPrincipalID: "app-evidence-capacity", EffectiveSubjectType: sessionvo.SubjectService,
+		EffectiveSubjectID: "subject-evidence-capacity",
+	}
+	prefix := fmt.Sprintf("evidence-capacity-%d-", time.Now().UnixNano())
+	conversation, err := sessions.EnsureCurrentConversation(context.Background(), sessionsvc.EnsureConversationCommand{
+		Owner: owner, ExternalConversationKey: prefix, IdempotencyKey: "ensure",
+	})
+	if err != nil {
+		b.Fatalf("ensure conversation: %v", err)
+	}
+	interaction, err := sessions.StartInteraction(context.Background(), sessionsvc.StartInteractionCommand{
+		Owner: owner, ConversationID: conversation.ID, IdempotencyKey: "start",
+	})
+	if err != nil {
+		b.Fatalf("start interaction: %v", err)
+	}
+	ledger := ledgersvc.New(store)
+	var sequence atomic.Uint64
+
+	b.ResetTimer()
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			index := sequence.Add(1)
+			envelope := json.RawMessage(fmt.Sprintf(`{"sequence":%d}`, index))
+			now := time.Now().UTC()
+			if _, err := ledger.Ingest(context.Background(), ledgervo.Event{
+				EventID:   fmt.Sprintf("%sevent-%d", prefix, index),
+				EventType: "data.query.observed", SchemaVersion: "3.0.0",
+				PayloadHash: ledgervo.CanonicalPayloadHash(envelope), Owner: owner,
+				ConversationID: conversation.ID, InteractionID: interaction.ID,
+				ProducerID: "capacity", ProducerStreamID: fmt.Sprintf("%sstream-%d", prefix, index),
+				ProducerEpoch: 1, ProducerSequence: 1,
+				StartedAt: now, ObservedAt: now, EmittedAt: now, Envelope: envelope,
+			}); err != nil {
+				b.Errorf("ingest evidence: %v", err)
+				return
+			}
+		}
+	})
+}
+
+func (t *integrationRebuildTarget) ProjectVersion(
+	_ context.Context,
+	_ string,
+	item iprojectionoutbox.Item,
+) error {
+	t.documents[iprojectionoutbox.DocumentID(item)] = append([]byte(nil), item.Payload...)
+	return nil
+}
+
+func (t *integrationRebuildTarget) ValidateVersion(
+	_ context.Context,
+	_ string,
+	items []iprojectionoutbox.Item,
+) error {
+	for _, item := range items {
+		documentID := iprojectionoutbox.DocumentID(item)
+		if !bytes.Equal(t.documents[documentID], item.Payload) {
+			return fmt.Errorf("projection document %s does not match", documentID)
+		}
+	}
+	return nil
+}
+
+func (t *integrationRebuildTarget) CountVersion(context.Context, string) (uint64, error) {
+	return uint64(len(t.documents)), nil
+}
+
+func (t *integrationRebuildTarget) SwitchAlias(
+	_ context.Context,
+	alias string,
+	version string,
+) error {
+	t.alias = alias
+	t.version = version
+	return nil
+}

--- a/bkn-trace/agent-observability/src/drivenadapter/dbaccess/mariadb/sessionstore/store_test.go
+++ b/bkn-trace/agent-observability/src/drivenadapter/dbaccess/mariadb/sessionstore/store_test.go
@@ -1,0 +1,20 @@
+package sessionstore
+
+import (
+	"testing"
+	"time"
+)
+
+func TestTransactionRetryDelayUsesBoundedExponentialJitter(t *testing.T) {
+	t.Parallel()
+
+	for attempt := 0; attempt < transactionRetries; attempt++ {
+		maximum := 5 * time.Millisecond * time.Duration(1<<attempt)
+		for sample := 0; sample < 100; sample++ {
+			delay := transactionRetryDelay(attempt)
+			if delay < 0 || delay > maximum {
+				t.Fatalf("attempt %d delay %s exceeds [0,%s]", attempt, delay, maximum)
+			}
+		}
+	}
+}

--- a/bkn-trace/agent-observability/src/drivenadapter/httpaccess/opensearchprojection/sink.go
+++ b/bkn-trace/agent-observability/src/drivenadapter/httpaccess/opensearchprojection/sink.go
@@ -1,0 +1,163 @@
+package opensearchprojection
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"sort"
+
+	"github.com/openbkn-ai/bkn-foundry/bkn-trace/agent-observability/src/infra/opensearch"
+	"github.com/openbkn-ai/bkn-foundry/bkn-trace/agent-observability/src/port/driven/iprojectionoutbox"
+)
+
+type Sink struct {
+	client *opensearch.Client
+	index  string
+}
+
+func New(client *opensearch.Client, index string) *Sink {
+	return &Sink{client: client, index: index}
+}
+
+func (s *Sink) Project(ctx context.Context, item iprojectionoutbox.Item) error {
+	if item.AggregateVersion == 0 {
+		return iprojectionoutbox.Permanent(errors.New("projection aggregate version is required"))
+	}
+	_, err := s.client.IndexDocumentVersion(
+		ctx, s.index, iprojectionoutbox.DocumentID(item),
+		item.AggregateVersion, item.Payload,
+	)
+	if errors.Is(err, opensearch.ErrVersionConflict) {
+		return nil
+	}
+	if opensearch.IsPermanentStatusError(err) {
+		return iprojectionoutbox.Permanent(err)
+	}
+	return err
+}
+
+func (s *Sink) PrepareVersion(ctx context.Context, indexVersion string) error {
+	return s.client.EnsureIndex(ctx, indexVersion, []byte(`{"mappings":{"dynamic":true}}`))
+}
+
+func (s *Sink) ProjectVersion(ctx context.Context, indexVersion string, item iprojectionoutbox.Item) error {
+	if item.AggregateVersion == 0 {
+		return iprojectionoutbox.Permanent(errors.New("projection aggregate version is required"))
+	}
+	_, err := s.client.IndexDocumentVersion(
+		ctx, indexVersion, iprojectionoutbox.DocumentID(item),
+		item.AggregateVersion, item.Payload,
+	)
+	if errors.Is(err, opensearch.ErrVersionConflict) {
+		return nil
+	}
+	if opensearch.IsPermanentStatusError(err) {
+		return iprojectionoutbox.Permanent(err)
+	}
+	return err
+}
+
+func (s *Sink) ValidateVersion(
+	ctx context.Context,
+	indexVersion string,
+	items []iprojectionoutbox.Item,
+) error {
+	type expectedDocument struct {
+		version uint64
+		body    []byte
+	}
+	expected := make(map[string]expectedDocument, len(items))
+	versionPayloads := make(map[string]map[uint64][]byte, len(items))
+	for _, item := range items {
+		id := iprojectionoutbox.DocumentID(item)
+		canonical, err := canonicalJSON(item.Payload)
+		if err != nil {
+			return fmt.Errorf("canonicalize expected projection %q: %w", id, err)
+		}
+		payloads, exists := versionPayloads[id]
+		if !exists {
+			payloads = make(map[uint64][]byte)
+			versionPayloads[id] = payloads
+		}
+		if known, versionSeen := payloads[item.AggregateVersion]; versionSeen {
+			if !bytes.Equal(canonical, known) {
+				return fmt.Errorf(
+					"projection contract conflict for document %q at aggregate version %d",
+					id,
+					item.AggregateVersion,
+				)
+			}
+		} else {
+			payloads[item.AggregateVersion] = canonical
+		}
+		current, exists := expected[id]
+		if !exists || item.AggregateVersion > current.version {
+			expected[id] = expectedDocument{
+				version: item.AggregateVersion,
+				body:    canonical,
+			}
+		}
+	}
+	ids := make([]string, 0, len(expected))
+	for id := range expected {
+		ids = append(ids, id)
+	}
+	sort.Strings(ids)
+	documents, err := s.client.MultiGetDocuments(ctx, indexVersion, ids)
+	if err != nil {
+		return err
+	}
+	if len(documents) != len(expected) {
+		return fmt.Errorf(
+			"projection validation returned %d documents for %d aggregates",
+			len(documents), len(expected),
+		)
+	}
+	seen := make(map[string]struct{}, len(documents))
+	for _, document := range documents {
+		if _, duplicate := seen[document.ID]; duplicate {
+			return fmt.Errorf("projection returned duplicate document %q", document.ID)
+		}
+		seen[document.ID] = struct{}{}
+		if !document.Found {
+			return fmt.Errorf("projection document %q was not found", document.ID)
+		}
+		canonical, err := canonicalJSON(document.Source)
+		if err != nil {
+			return fmt.Errorf("canonicalize projected document %q: %w", document.ID, err)
+		}
+		expectedDocument, ok := expected[document.ID]
+		if !ok {
+			return fmt.Errorf("projection returned unexpected document %q", document.ID)
+		}
+		if !bytes.Equal(canonical, expectedDocument.body) {
+			return fmt.Errorf("projection document %q content does not match", document.ID)
+		}
+		delete(expected, document.ID)
+	}
+	if len(expected) != 0 {
+		return fmt.Errorf("projection validation omitted %d documents", len(expected))
+	}
+	return nil
+}
+
+func canonicalJSON(body []byte) ([]byte, error) {
+	var value any
+	if err := json.Unmarshal(body, &value); err != nil {
+		return nil, err
+	}
+	return json.Marshal(value)
+}
+
+func (s *Sink) CountVersion(ctx context.Context, indexVersion string) (uint64, error) {
+	if err := s.client.RefreshIndex(ctx, indexVersion); err != nil {
+		return 0, err
+	}
+	return s.client.CountDocuments(ctx, indexVersion)
+}
+
+func (s *Sink) SwitchAlias(ctx context.Context, alias, indexVersion string) error {
+	return s.client.SwitchAlias(ctx, alias, indexVersion)
+}

--- a/bkn-trace/agent-observability/src/drivenadapter/httpaccess/opensearchprojection/sink_integration_test.go
+++ b/bkn-trace/agent-observability/src/drivenadapter/httpaccess/opensearchprojection/sink_integration_test.go
@@ -1,0 +1,91 @@
+//go:build integration
+
+package opensearchprojection_test
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/openbkn-ai/bkn-foundry/bkn-trace/agent-observability/src/drivenadapter/httpaccess/opensearchprojection"
+	"github.com/openbkn-ai/bkn-foundry/bkn-trace/agent-observability/src/infra/opensearch"
+	"github.com/openbkn-ai/bkn-foundry/bkn-trace/agent-observability/src/port/driven/iprojectionoutbox"
+)
+
+func TestOpenSearchProjectionVersionValidationAndAliasSwitch(t *testing.T) {
+	endpoint := os.Getenv("BKN_TRACE_TEST_OPENSEARCH_ENDPOINT")
+	if endpoint == "" {
+		t.Skip("BKN_TRACE_TEST_OPENSEARCH_ENDPOINT is not set")
+	}
+	suffix := fmt.Sprintf("%d", time.Now().UnixNano())
+	alias := "bkn-trace-core-integration-" + suffix
+	version := alias + "-v1"
+	username := os.Getenv("BKN_TRACE_TEST_OPENSEARCH_USERNAME")
+	client := opensearch.New(endpoint, opensearch.AuthConfig{
+		Enabled:  username != "",
+		Username: username,
+		Password: os.Getenv("BKN_TRACE_TEST_OPENSEARCH_PASSWORD"),
+	}, 10*time.Second)
+	sink := opensearchprojection.New(client, alias)
+	item := iprojectionoutbox.Item{
+		AggregateType:    "interaction",
+		AggregateID:      "interaction-" + suffix,
+		AggregateVersion: 2,
+		EventType:        "interaction.snapshot",
+		EventID:          "interaction:" + suffix,
+		Payload:          []byte(`{"state":"completed","evidence_status":"complete"}`),
+	}
+
+	if err := sink.PrepareVersion(context.Background(), version); err != nil {
+		t.Fatalf("prepare OpenSearch version: %v", err)
+	}
+	if err := sink.ProjectVersion(context.Background(), version, item); err != nil {
+		t.Fatalf("project OpenSearch version: %v", err)
+	}
+	stale := item
+	stale.AggregateVersion = 1
+	stale.Payload = []byte(`{"state":"active","evidence_status":"assembling"}`)
+	if err := sink.ProjectVersion(context.Background(), version, stale); err != nil {
+		t.Fatalf("stale projection must be acknowledged without overwrite: %v", err)
+	}
+	divergent := item
+	divergent.Payload = []byte(`{"state":"failed","evidence_status":"incomplete"}`)
+	if err := sink.ProjectVersion(context.Background(), version, divergent); err != nil {
+		t.Fatalf("same-version projection must be acknowledged without overwrite: %v", err)
+	}
+	if err := sink.ValidateVersion(
+		context.Background(), version, []iprojectionoutbox.Item{item},
+	); err != nil {
+		t.Fatalf("validate OpenSearch version: %v", err)
+	}
+	count, err := sink.CountVersion(context.Background(), version)
+	if err != nil || count != 1 {
+		t.Fatalf("count OpenSearch version: count=%d err=%v", count, err)
+	}
+	if err := sink.SwitchAlias(context.Background(), alias, version); err != nil {
+		t.Fatalf("switch OpenSearch alias: %v", err)
+	}
+	document, err := client.GetDocument(
+		context.Background(), alias, iprojectionoutbox.DocumentID(item),
+	)
+	if err != nil {
+		t.Fatalf("read projection through alias: %v", err)
+	}
+	if !canonicalEqual(document.Source, item.Payload) {
+		t.Fatalf("stale projection regressed alias document: %s", document.Source)
+	}
+}
+
+func canonicalEqual(left, right []byte) bool {
+	var leftValue, rightValue any
+	if json.Unmarshal(left, &leftValue) != nil || json.Unmarshal(right, &rightValue) != nil {
+		return false
+	}
+	leftCanonical, _ := json.Marshal(leftValue)
+	rightCanonical, _ := json.Marshal(rightValue)
+	return bytes.Equal(leftCanonical, rightCanonical)
+}

--- a/bkn-trace/agent-observability/src/drivenadapter/httpaccess/opensearchprojection/sink_test.go
+++ b/bkn-trace/agent-observability/src/drivenadapter/httpaccess/opensearchprojection/sink_test.go
@@ -1,0 +1,340 @@
+package opensearchprojection_test
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/openbkn-ai/bkn-foundry/bkn-trace/agent-observability/src/drivenadapter/httpaccess/opensearchprojection"
+	"github.com/openbkn-ai/bkn-foundry/bkn-trace/agent-observability/src/infra/opensearch"
+	"github.com/openbkn-ai/bkn-foundry/bkn-trace/agent-observability/src/port/driven/iprojectionoutbox"
+)
+
+func TestSinkIndexesByStableAggregateID(t *testing.T) {
+	t.Parallel()
+
+	var path string
+	var query string
+	var body []byte
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		path = r.URL.Path
+		query = r.URL.RawQuery
+		body, _ = io.ReadAll(r.Body)
+		w.WriteHeader(http.StatusCreated)
+	}))
+	t.Cleanup(server.Close)
+	client := opensearch.New(server.URL, opensearch.AuthConfig{}, time.Second)
+	sink := opensearchprojection.New(client, "bkn-trace-core-v3")
+	item := iprojectionoutbox.Item{
+		ID: 1, AggregateType: "interaction", AggregateID: "int-1",
+		AggregateVersion: 7,
+		EventID:          "evt-1", EventType: "interaction.completed",
+		Payload: []byte(`{"interaction_id":"int-1"}`),
+	}
+
+	if err := sink.Project(context.Background(), item); err != nil {
+		t.Fatalf("project: %v", err)
+	}
+	if path != "/bkn-trace-core-v3/_doc/interaction:int-1" || string(body) != string(item.Payload) {
+		t.Fatalf("unexpected projection request: path=%q body=%s", path, body)
+	}
+	if query != "version=7&version_type=external" {
+		t.Fatalf("projection did not enforce aggregate version: %q", query)
+	}
+}
+
+func TestSinkAcknowledgesStaleAggregateVersionWithoutRetry(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		http.Error(w, "version_conflict_engine_exception", http.StatusConflict)
+	}))
+	t.Cleanup(server.Close)
+	sink := opensearchprojection.New(
+		opensearch.New(server.URL, opensearch.AuthConfig{}, time.Second),
+		"bkn-trace-core",
+	)
+	err := sink.Project(context.Background(), iprojectionoutbox.Item{
+		AggregateType: "interaction", AggregateID: "int-1",
+		AggregateVersion: 1, Payload: []byte(`{"row_version":1}`),
+	})
+	if err != nil {
+		t.Fatalf("stale aggregate version must be safely superseded: %v", err)
+	}
+}
+
+func TestValidateVersionRejectsCorruptedDocumentContent(t *testing.T) {
+	t.Parallel()
+
+	client := opensearch.NewWithHTTPClient(
+		"http://opensearch.test",
+		opensearch.AuthConfig{},
+		&http.Client{Transport: roundTripFunc(func(request *http.Request) (*http.Response, error) {
+			if request.URL.Path != "/bkn-trace-core-v4/_mget" {
+				t.Fatalf("unexpected validation path: %s", request.URL.Path)
+			}
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Body: io.NopCloser(bytes.NewBufferString(
+					`{"docs":[{"_id":"interaction:int-1","found":true,"_source":{"state":"failed"}}]}`,
+				)),
+				Header: make(http.Header),
+			}, nil
+		})},
+	)
+	sink := opensearchprojection.New(client, "bkn-trace-core")
+	err := sink.ValidateVersion(context.Background(), "bkn-trace-core-v4", []iprojectionoutbox.Item{{
+		AggregateType: "interaction",
+		AggregateID:   "int-1",
+		Payload:       []byte(`{"state":"completed"}`),
+	}})
+	if err == nil {
+		t.Fatal("corrupted projection content must fail validation")
+	}
+}
+
+func TestValidateVersionAcceptsCanonicalEquivalentJSON(t *testing.T) {
+	t.Parallel()
+
+	client := opensearch.NewWithHTTPClient(
+		"http://opensearch.test",
+		opensearch.AuthConfig{},
+		&http.Client{Transport: roundTripFunc(func(*http.Request) (*http.Response, error) {
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Body: io.NopCloser(bytes.NewBufferString(
+					`{"docs":[{"_id":"interaction:int-1","found":true,"_source":{"state":"completed","count":1}}]}`,
+				)),
+				Header: make(http.Header),
+			}, nil
+		})},
+	)
+	sink := opensearchprojection.New(client, "bkn-trace-core")
+	err := sink.ValidateVersion(context.Background(), "bkn-trace-core-v4", []iprojectionoutbox.Item{{
+		AggregateType: "interaction",
+		AggregateID:   "int-1",
+		Payload:       []byte(`{"count":1,"state":"completed"}`),
+	}})
+	if err != nil {
+		t.Fatalf("canonical equivalent projection content: %v", err)
+	}
+}
+
+func TestValidateVersionUsesHighestAggregateVersionPerDocument(t *testing.T) {
+	t.Parallel()
+
+	var requestedIDs []string
+	client := opensearch.NewWithHTTPClient(
+		"http://opensearch.test",
+		opensearch.AuthConfig{},
+		&http.Client{Transport: roundTripFunc(func(request *http.Request) (*http.Response, error) {
+			var body struct {
+				IDs []string `json:"ids"`
+			}
+			if err := json.NewDecoder(request.Body).Decode(&body); err != nil {
+				t.Fatalf("decode multi-get request: %v", err)
+			}
+			requestedIDs = body.IDs
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Body: io.NopCloser(bytes.NewBufferString(
+					`{"docs":[{"_id":"interaction:int-1","found":true,"_source":{"row_version":3}}]}`,
+				)),
+				Header: make(http.Header),
+			}, nil
+		})},
+	)
+	sink := opensearchprojection.New(client, "bkn-trace-core")
+	err := sink.ValidateVersion(
+		context.Background(),
+		"bkn-trace-core-v4",
+		[]iprojectionoutbox.Item{
+			{
+				AggregateType: "interaction", AggregateID: "int-1",
+				AggregateVersion: 2, Payload: []byte(`{"row_version":2}`),
+			},
+			{
+				AggregateType: "interaction", AggregateID: "int-1",
+				AggregateVersion: 3, Payload: []byte(`{"row_version":3}`),
+			},
+		},
+	)
+	if err != nil {
+		t.Fatalf("validate highest aggregate version: %v", err)
+	}
+	if len(requestedIDs) != 1 || requestedIDs[0] != "interaction:int-1" {
+		t.Fatalf("multi-get request was not deduplicated: %#v", requestedIDs)
+	}
+}
+
+func TestValidateVersionRejectsSameVersionDifferentPayload(t *testing.T) {
+	t.Parallel()
+
+	requested := false
+	client := opensearch.NewWithHTTPClient(
+		"http://opensearch.test",
+		opensearch.AuthConfig{},
+		&http.Client{Transport: roundTripFunc(func(*http.Request) (*http.Response, error) {
+			requested = true
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Body: io.NopCloser(bytes.NewBufferString(
+					`{"docs":[{"_id":"interaction:int-1","found":true,"_source":{"state":"failed"}}]}`,
+				)),
+				Header: make(http.Header),
+			}, nil
+		})},
+	)
+	sink := opensearchprojection.New(client, "bkn-trace-core")
+	err := sink.ValidateVersion(
+		context.Background(),
+		"bkn-trace-core-v4",
+		[]iprojectionoutbox.Item{
+			{
+				AggregateType: "interaction", AggregateID: "int-1",
+				AggregateVersion: 3, Payload: []byte(`{"state":"completed"}`),
+			},
+			{
+				AggregateType: "interaction", AggregateID: "int-1",
+				AggregateVersion: 3, Payload: []byte(`{"state":"failed"}`),
+			},
+		},
+	)
+	if err == nil {
+		t.Fatal("same aggregate version with different payload must fail validation")
+	}
+	if requested {
+		t.Fatal("contract conflict must be rejected before querying OpenSearch")
+	}
+}
+
+func TestValidateVersionRejectsOlderVersionPayloadConflictAfterNewerVersion(t *testing.T) {
+	t.Parallel()
+
+	requested := false
+	client := opensearch.NewWithHTTPClient(
+		"http://opensearch.test",
+		opensearch.AuthConfig{},
+		&http.Client{Transport: roundTripFunc(func(*http.Request) (*http.Response, error) {
+			requested = true
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Body: io.NopCloser(bytes.NewBufferString(
+					`{"docs":[{"_id":"interaction:int-1","found":true,"_source":{"state":"completed"}}]}`,
+				)),
+				Header: make(http.Header),
+			}, nil
+		})},
+	)
+	sink := opensearchprojection.New(client, "bkn-trace-core")
+	err := sink.ValidateVersion(
+		context.Background(),
+		"bkn-trace-core-v4",
+		[]iprojectionoutbox.Item{
+			{
+				AggregateType: "interaction", AggregateID: "int-1",
+				AggregateVersion: 2, Payload: []byte(`{"state":"active"}`),
+			},
+			{
+				AggregateType: "interaction", AggregateID: "int-1",
+				AggregateVersion: 3, Payload: []byte(`{"state":"completed"}`),
+			},
+			{
+				AggregateType: "interaction", AggregateID: "int-1",
+				AggregateVersion: 2, Payload: []byte(`{"state":"failed"}`),
+			},
+		},
+	)
+	if err == nil {
+		t.Fatal("older aggregate version with conflicting payload must fail validation")
+	}
+	if requested {
+		t.Fatal("contract conflict must be rejected before querying OpenSearch")
+	}
+}
+
+func TestSinkClassifiesInvalidDocumentAsPermanent(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		http.Error(w, "mapper_parsing_exception", http.StatusBadRequest)
+	}))
+	t.Cleanup(server.Close)
+	sink := opensearchprojection.New(
+		opensearch.New(server.URL, opensearch.AuthConfig{}, time.Second),
+		"bkn-trace-core",
+	)
+
+	err := sink.Project(context.Background(), iprojectionoutbox.Item{
+		AggregateType: "evidence_event", AggregateID: "evt-invalid",
+		AggregateVersion: 1, EventID: "evt-invalid", Payload: []byte(`{"broken":true}`),
+	})
+	if !iprojectionoutbox.IsPermanent(err) {
+		t.Fatalf("invalid document error was not classified as permanent: %v", err)
+	}
+}
+
+func TestSinkLeavesOpenSearchOutageRetryable(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		http.Error(w, "unavailable", http.StatusServiceUnavailable)
+	}))
+	t.Cleanup(server.Close)
+	sink := opensearchprojection.New(
+		opensearch.New(server.URL, opensearch.AuthConfig{}, time.Second),
+		"bkn-trace-core",
+	)
+
+	err := sink.Project(context.Background(), iprojectionoutbox.Item{
+		AggregateType: "evidence_event", AggregateID: "evt-retry",
+		AggregateVersion: 1, EventID: "evt-retry", Payload: []byte(`{"valid":true}`),
+	})
+	if err == nil || iprojectionoutbox.IsPermanent(err) {
+		t.Fatalf("OpenSearch outage must remain retryable: %v", err)
+	}
+}
+
+func TestCountVersionRefreshesIndexBeforeValidation(t *testing.T) {
+	t.Parallel()
+
+	var paths []string
+	client := opensearch.NewWithHTTPClient(
+		"http://opensearch.test",
+		opensearch.AuthConfig{},
+		&http.Client{Transport: roundTripFunc(func(request *http.Request) (*http.Response, error) {
+			paths = append(paths, request.URL.Path)
+			body := `{}`
+			if request.URL.Path == "/bkn-trace-core-v4/_search" {
+				body = `{"hits":{"total":{"value":1}}}`
+			}
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Body:       io.NopCloser(bytes.NewBufferString(body)),
+				Header:     make(http.Header),
+			}, nil
+		})},
+	)
+	sink := opensearchprojection.New(client, "bkn-trace-core")
+
+	count, err := sink.CountVersion(context.Background(), "bkn-trace-core-v4")
+	if err != nil || count != 1 {
+		t.Fatalf("count rebuilt version: count=%d err=%v", count, err)
+	}
+	if len(paths) != 2 ||
+		paths[0] != "/bkn-trace-core-v4/_refresh" ||
+		paths[1] != "/bkn-trace-core-v4/_search" {
+		t.Fatalf("version was not refreshed before validation: %#v", paths)
+	}
+}
+
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripFunc) RoundTrip(request *http.Request) (*http.Response, error) {
+	return f(request)
+}

--- a/bkn-trace/agent-observability/src/drivenadapter/memoryaccess/ledgerstore/store.go
+++ b/bkn-trace/agent-observability/src/drivenadapter/memoryaccess/ledgerstore/store.go
@@ -1,0 +1,149 @@
+package ledgerstore
+
+import (
+	"context"
+	"errors"
+	"strconv"
+	"sync"
+	"time"
+
+	"github.com/openbkn-ai/bkn-foundry/bkn-trace/agent-observability/src/domain/valueobject/ledgervo"
+	"github.com/openbkn-ai/bkn-foundry/bkn-trace/agent-observability/src/port/driven/ievidenceledger"
+)
+
+type ledgerRecord struct {
+	event ledgervo.Event
+	ack   ledgervo.DurableAck
+}
+
+type Store struct {
+	mu                  sync.Mutex
+	ledger              map[string]ledgerRecord
+	streamSequences     map[string]string
+	streamEpochs        map[string]uint64
+	streamHeads         map[string]uint64
+	projectionOutbox    map[string]ledgervo.Event
+	conflicts           int
+	nextSequence        uint64
+	failProjectionWrite bool
+}
+
+func New() *Store {
+	return &Store{
+		ledger:           make(map[string]ledgerRecord),
+		streamSequences:  make(map[string]string),
+		streamEpochs:     make(map[string]uint64),
+		streamHeads:      make(map[string]uint64),
+		projectionOutbox: make(map[string]ledgervo.Event),
+	}
+}
+
+func (s *Store) Commit(ctx context.Context, event ledgervo.Event) (ledgervo.DurableAck, error) {
+	if err := ctx.Err(); err != nil {
+		return ledgervo.DurableAck{}, err
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if existing, found := s.ledger[event.EventID]; found {
+		if ledgervo.ImmutableRecordHash(existing.event) != ledgervo.ImmutableRecordHash(event) {
+			s.conflicts++
+			return ledgervo.DurableAck{}, ievidenceledger.ErrPayloadConflict
+		}
+		ack := existing.ack
+		ack.Replayed = true
+		return ack, nil
+	}
+	events := make([]ledgervo.Event, 0, len(s.ledger)+1)
+	for _, record := range s.ledger {
+		if record.event.Owner.TenantID == event.Owner.TenantID &&
+			record.event.Owner.BusinessDomainID == event.Owner.BusinessDomainID &&
+			record.event.InteractionID == event.InteractionID {
+			events = append(events, record.event)
+		}
+	}
+	for _, causeID := range event.CausationEventIDs {
+		if cause, found := s.ledger[causeID]; found &&
+			(cause.event.Owner.TenantID != event.Owner.TenantID ||
+				cause.event.Owner.BusinessDomainID != event.Owner.BusinessDomainID ||
+				cause.event.InteractionID != event.InteractionID) {
+			s.conflicts++
+			return ledgervo.DurableAck{}, ievidenceledger.ErrCausalityConflict
+		}
+	}
+	events = append(events, event)
+	if ledgervo.HasCausationCycle(events) {
+		s.conflicts++
+		return ledgervo.DurableAck{}, ievidenceledger.ErrCausalityConflict
+	}
+	streamKey := event.Owner.TenantID + "\x00" + event.ProducerStreamID + "\x00" +
+		strconv.FormatUint(event.ProducerEpoch, 10) + "\x00" + strconv.FormatUint(event.ProducerSequence, 10)
+	producerKey := event.Owner.TenantID + "\x00" + event.ProducerStreamID
+	if currentEpoch, found := s.streamEpochs[producerKey]; found && event.ProducerEpoch < currentEpoch {
+		s.conflicts++
+		return ledgervo.DurableAck{}, ievidenceledger.ErrSequenceConflict
+	}
+	epochKey := producerKey + "\x00" + strconv.FormatUint(event.ProducerEpoch, 10)
+	if lastSequence, found := s.streamHeads[epochKey]; found && event.ProducerSequence <= lastSequence {
+		s.conflicts++
+		return ledgervo.DurableAck{}, ievidenceledger.ErrSequenceConflict
+	}
+	if existingEventID, found := s.streamSequences[streamKey]; found && existingEventID != event.EventID {
+		s.conflicts++
+		return ledgervo.DurableAck{}, ievidenceledger.ErrSequenceConflict
+	}
+	event.CausalityStatus = "complete"
+	for _, causeID := range event.CausationEventIDs {
+		if _, found := s.ledger[causeID]; !found {
+			event.MissingCauseIDs = append(event.MissingCauseIDs, causeID)
+		}
+	}
+	if len(event.MissingCauseIDs) > 0 {
+		event.CausalityStatus = "causality_missing"
+	}
+	if s.failProjectionWrite {
+		return ledgervo.DurableAck{}, errors.New("projection outbox write failed")
+	}
+	s.nextSequence++
+	ack := ledgervo.DurableAck{
+		EventID: event.EventID, Durable: true, IngestSequence: s.nextSequence, IngestedAt: time.Now().UTC(),
+	}
+	s.ledger[event.EventID] = ledgerRecord{event: event, ack: ack}
+	s.streamSequences[streamKey] = event.EventID
+	if event.ProducerEpoch > s.streamEpochs[producerKey] {
+		s.streamEpochs[producerKey] = event.ProducerEpoch
+	}
+	s.streamHeads[epochKey] = event.ProducerSequence
+	s.projectionOutbox[event.EventID] = event
+	return ack, nil
+}
+
+func (s *Store) StoredEvent(eventID string) (ledgervo.Event, bool) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	record, found := s.ledger[eventID]
+	return record.event, found
+}
+
+func (s *Store) FailProjectionWrites(fail bool) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.failProjectionWrite = fail
+}
+
+func (s *Store) LedgerCount() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return len(s.ledger)
+}
+
+func (s *Store) PendingProjectionCount() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return len(s.projectionOutbox)
+}
+
+func (s *Store) ConflictCount() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.conflicts
+}

--- a/bkn-trace/agent-observability/src/drivenadapter/memoryaccess/sessionstore/store.go
+++ b/bkn-trace/agent-observability/src/drivenadapter/memoryaccess/sessionstore/store.go
@@ -1,0 +1,422 @@
+package sessionstore
+
+import (
+	"context"
+	"sort"
+	"sync"
+	"time"
+
+	"github.com/openbkn-ai/bkn-foundry/bkn-trace/agent-observability/src/domain/valueobject/sessionvo"
+	"github.com/openbkn-ai/bkn-foundry/bkn-trace/agent-observability/src/port/driven/iprojectionoutbox"
+	"github.com/openbkn-ai/bkn-foundry/bkn-trace/agent-observability/src/port/driven/isessionstore"
+)
+
+type Store struct {
+	mu             sync.Mutex
+	now            func() time.Time
+	conversations  map[string]sessionvo.Conversation
+	interactions   map[string]sessionvo.Interaction
+	operations     map[string]sessionvo.Operation
+	receipts       map[string]sessionvo.Receipt
+	idempotencies  map[string]sessionvo.IdempotencyRecord
+	projections    map[uint64]sessionvo.ProjectionMutation
+	nextProjection uint64
+	revisions      map[string]sessionvo.AssemblyRevision
+}
+
+func New() *Store {
+	return NewWithClock(time.Now)
+}
+
+func NewWithClock(now func() time.Time) *Store {
+	return &Store{
+		now:           now,
+		conversations: make(map[string]sessionvo.Conversation),
+		interactions:  make(map[string]sessionvo.Interaction),
+		operations:    make(map[string]sessionvo.Operation),
+		receipts:      make(map[string]sessionvo.Receipt),
+		idempotencies: make(map[string]sessionvo.IdempotencyRecord),
+		projections:   make(map[uint64]sessionvo.ProjectionMutation),
+		revisions:     make(map[string]sessionvo.AssemblyRevision),
+	}
+}
+
+func (s *Store) WithinTransaction(ctx context.Context, fn func(isessionstore.Transaction) error) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return fn(memoryTransaction{s: s, now: s.now().UTC()})
+}
+
+type memoryTransaction struct {
+	s   *Store
+	now time.Time
+}
+
+func (tx memoryTransaction) Now() time.Time {
+	return tx.now
+}
+
+func (tx memoryTransaction) FindCurrentConversation(owner sessionvo.Owner, externalKey string) (sessionvo.Conversation, bool) {
+	var current sessionvo.Conversation
+	found := false
+	for _, conversation := range tx.s.conversations {
+		if !conversation.Owner.Equal(owner) || conversation.ExternalConversationKey != externalKey {
+			continue
+		}
+		if !found || conversation.Generation > current.Generation {
+			current = conversation
+			found = true
+		}
+	}
+	return current, found
+}
+
+func (tx memoryTransaction) SaveConversation(conversation sessionvo.Conversation) {
+	tx.s.conversations[conversation.ID] = conversation
+}
+
+func (tx memoryTransaction) FindConversation(conversationID string) (sessionvo.Conversation, bool) {
+	conversation, found := tx.s.conversations[conversationID]
+	return conversation, found
+}
+
+func (tx memoryTransaction) FindIdempotency(
+	scope string,
+	owner sessionvo.Owner,
+	externalKey string,
+	idempotencyKey string,
+) (sessionvo.IdempotencyRecord, bool) {
+	record, found := tx.s.idempotencies[idempotencyRecordKey(scope, owner, externalKey, idempotencyKey)]
+	return record, found
+}
+
+func (tx memoryTransaction) SaveIdempotency(record sessionvo.IdempotencyRecord) {
+	tx.s.idempotencies[idempotencyRecordKey(
+		record.Scope, record.Owner, record.ExternalConversationKey, record.IdempotencyKey,
+	)] = record
+}
+
+func idempotencyRecordKey(scope string, owner sessionvo.Owner, externalKey, idempotencyKey string) string {
+	return scope + "\x00" + owner.Key() + "\x00" + externalKey + "\x00" + idempotencyKey
+}
+
+func (tx memoryTransaction) ListConversations(owner sessionvo.Owner, limit int) []sessionvo.Conversation {
+	result := make([]sessionvo.Conversation, 0)
+	for _, conversation := range tx.s.conversations {
+		if conversation.Owner.Equal(owner) {
+			result = append(result, conversation)
+		}
+	}
+	sort.Slice(result, func(i, j int) bool {
+		if result[i].UpdatedAt.Equal(result[j].UpdatedAt) {
+			return result[i].ID > result[j].ID
+		}
+		return result[i].UpdatedAt.After(result[j].UpdatedAt)
+	})
+	if limit > 0 && len(result) > limit {
+		result = result[:limit]
+	}
+	return result
+}
+
+func (tx memoryTransaction) FindActiveInteraction(conversationID string) (sessionvo.Interaction, bool) {
+	for _, interaction := range tx.s.interactions {
+		if interaction.ConversationID == conversationID && interaction.ExecutionStatus == sessionvo.InteractionActive {
+			return interaction, true
+		}
+	}
+	return sessionvo.Interaction{}, false
+}
+
+func (tx memoryTransaction) FindInteractionByStartKey(
+	conversationID string,
+	idempotencyKey string,
+) (sessionvo.Interaction, bool) {
+	for _, interaction := range tx.s.interactions {
+		if interaction.ConversationID == conversationID &&
+			interaction.StartIdempotencyKey == idempotencyKey {
+			return interaction, true
+		}
+	}
+	return sessionvo.Interaction{}, false
+}
+
+func (tx memoryTransaction) FindInteraction(interactionID string) (sessionvo.Interaction, bool) {
+	interaction, found := tx.s.interactions[interactionID]
+	return interaction, found
+}
+
+func (tx memoryTransaction) PeekInteraction(interactionID string) (sessionvo.Interaction, bool) {
+	return tx.FindInteraction(interactionID)
+}
+
+func (tx memoryTransaction) NextInteractionOrdinal(conversationID string) uint64 {
+	var max uint64
+	for _, interaction := range tx.s.interactions {
+		if interaction.ConversationID == conversationID && interaction.Ordinal > max {
+			max = interaction.Ordinal
+		}
+	}
+	return max + 1
+}
+
+func (tx memoryTransaction) SaveInteraction(interaction sessionvo.Interaction) {
+	tx.s.interactions[interaction.ID] = interaction
+}
+
+func (tx memoryTransaction) FindOperationByKey(interactionID, operationKey string) (sessionvo.Operation, bool) {
+	for _, operation := range tx.s.operations {
+		if operation.InteractionID == interactionID && operation.OperationKey == operationKey {
+			return operation, true
+		}
+	}
+	return sessionvo.Operation{}, false
+}
+
+func (tx memoryTransaction) SaveOperation(operation sessionvo.Operation) {
+	tx.s.operations[operation.ID] = operation
+}
+
+func (tx memoryTransaction) FindOperation(operationID string) (sessionvo.Operation, bool) {
+	operation, found := tx.s.operations[operationID]
+	return operation, found
+}
+
+func (tx memoryTransaction) PeekOperation(operationID string) (sessionvo.Operation, bool) {
+	return tx.FindOperation(operationID)
+}
+
+func (tx memoryTransaction) ListOperations(interactionID string) []sessionvo.Operation {
+	var result []sessionvo.Operation
+	for _, operation := range tx.s.operations {
+		if operation.InteractionID == interactionID {
+			result = append(result, operation)
+		}
+	}
+	sort.Slice(result, func(i, j int) bool { return result[i].ID < result[j].ID })
+	return result
+}
+
+func (tx memoryTransaction) FindReceipt(receiptID string) (sessionvo.Receipt, bool) {
+	receipt, found := tx.s.receipts[receiptID]
+	return receipt, found
+}
+
+func (tx memoryTransaction) PeekReceipt(receiptID string) (sessionvo.Receipt, bool) {
+	return tx.FindReceipt(receiptID)
+}
+
+func (tx memoryTransaction) FindReceiptByOperationAttempt(operationID string, attempt uint32) (sessionvo.Receipt, bool) {
+	for _, receipt := range tx.s.receipts {
+		if receipt.OperationID == operationID && receipt.Attempt == attempt {
+			return receipt, true
+		}
+	}
+	return sessionvo.Receipt{}, false
+}
+
+func (tx memoryTransaction) ListReceipts(interactionID string) []sessionvo.Receipt {
+	var result []sessionvo.Receipt
+	for _, receipt := range tx.s.receipts {
+		if receipt.InteractionID == interactionID {
+			result = append(result, receipt)
+		}
+	}
+	sort.Slice(result, func(i, j int) bool { return result[i].ID < result[j].ID })
+	return result
+}
+
+func (tx memoryTransaction) SaveReceipt(receipt sessionvo.Receipt) {
+	tx.s.receipts[receipt.ID] = receipt
+}
+
+func (tx memoryTransaction) ListRequests(owner sessionvo.Owner, limit int) []sessionvo.RequestSummary {
+	type accumulator struct {
+		summary    sessionvo.RequestSummary
+		operations map[string]bool
+		traces     map[string]bool
+	}
+	grouped := make(map[string]*accumulator)
+	for _, receipt := range tx.s.receipts {
+		if receipt.RequestID == "" || !receipt.Owner.Equal(owner) {
+			continue
+		}
+		item := grouped[receipt.RequestID]
+		if item == nil {
+			item = &accumulator{
+				summary: sessionvo.RequestSummary{
+					RequestID: receipt.RequestID, ConversationID: receipt.ConversationID,
+					InteractionID: receipt.InteractionID, UpdatedAt: receipt.IssuedAt,
+				},
+				operations: make(map[string]bool), traces: make(map[string]bool),
+			}
+			grouped[receipt.RequestID] = item
+		}
+		item.summary.ReceiptCount++
+		item.operations[receipt.OperationID] = true
+		if receipt.TraceID != "" {
+			item.traces[receipt.TraceID] = true
+		}
+		if receipt.TerminalAt != nil && receipt.TerminalAt.After(item.summary.UpdatedAt) {
+			item.summary.UpdatedAt = *receipt.TerminalAt
+		}
+	}
+	result := make([]sessionvo.RequestSummary, 0, len(grouped))
+	for _, item := range grouped {
+		item.summary.OperationCount = len(item.operations)
+		for traceID := range item.traces {
+			item.summary.TraceIDs = append(item.summary.TraceIDs, traceID)
+		}
+		sort.Strings(item.summary.TraceIDs)
+		result = append(result, item.summary)
+	}
+	sort.Slice(result, func(i, j int) bool {
+		if result[i].UpdatedAt.Equal(result[j].UpdatedAt) {
+			return result[i].RequestID > result[j].RequestID
+		}
+		return result[i].UpdatedAt.After(result[j].UpdatedAt)
+	})
+	if limit > 0 && len(result) > limit {
+		result = result[:limit]
+	}
+	return result
+}
+
+func (tx memoryTransaction) FindRequest(owner sessionvo.Owner, requestID string) (sessionvo.RequestSummary, bool) {
+	for _, item := range tx.ListRequests(owner, 0) {
+		if item.RequestID == requestID {
+			return item, true
+		}
+	}
+	return sessionvo.RequestSummary{}, false
+}
+
+func (tx memoryTransaction) ListIdleOneShotConversations(
+	cutoff time.Time,
+	limit int,
+) []sessionvo.Conversation {
+	result := make([]sessionvo.Conversation, 0)
+	for _, conversation := range tx.s.conversations {
+		if !conversation.OneShot || conversation.Status != sessionvo.ConversationActive ||
+			conversation.UpdatedAt.After(cutoff) || tx.hasInteraction(conversation.ID) {
+			continue
+		}
+		result = append(result, conversation)
+	}
+	sort.Slice(result, func(i, j int) bool {
+		if result[i].UpdatedAt.Equal(result[j].UpdatedAt) {
+			return result[i].ID < result[j].ID
+		}
+		return result[i].UpdatedAt.Before(result[j].UpdatedAt)
+	})
+	if limit > 0 && len(result) > limit {
+		result = result[:limit]
+	}
+	return result
+}
+
+func (tx memoryTransaction) hasInteraction(conversationID string) bool {
+	for _, interaction := range tx.s.interactions {
+		if interaction.ConversationID == conversationID {
+			return true
+		}
+	}
+	return false
+}
+
+func (tx memoryTransaction) ListExpiredActiveInteractions(limit int) []sessionvo.Interaction {
+	result := make([]sessionvo.Interaction, 0)
+	for _, interaction := range tx.s.interactions {
+		if interaction.ExecutionStatus != sessionvo.InteractionActive || interaction.LeaseExpiresAt.After(tx.now) {
+			continue
+		}
+		result = append(result, interaction)
+		if limit > 0 && len(result) >= limit {
+			break
+		}
+	}
+	return result
+}
+
+func (tx memoryTransaction) ListAssemblyDueInteractions(limit int) []sessionvo.Interaction {
+	var result []sessionvo.Interaction
+	for _, interaction := range tx.s.interactions {
+		if interaction.EvidenceStatus != sessionvo.EvidenceAssembling ||
+			interaction.ClosureManifest == nil || interaction.ClosureManifest.AssemblerDeadline == nil ||
+			interaction.ClosureManifest.AssemblerDeadline.After(tx.now) {
+			continue
+		}
+		result = append(result, interaction)
+		if limit > 0 && len(result) >= limit {
+			break
+		}
+	}
+	return result
+}
+
+func (tx memoryTransaction) AppendProjection(mutation sessionvo.ProjectionMutation) {
+	tx.s.nextProjection++
+	tx.s.projections[tx.s.nextProjection] = mutation
+}
+
+func (tx memoryTransaction) ListAssemblyRevisions(interactionID string) []sessionvo.AssemblyRevision {
+	var result []sessionvo.AssemblyRevision
+	for _, revision := range tx.s.revisions {
+		if revision.InteractionID == interactionID {
+			result = append(result, revision)
+		}
+	}
+	sort.Slice(result, func(i, j int) bool { return result[i].RevisionNo < result[j].RevisionNo })
+	return result
+}
+
+func (tx memoryTransaction) SaveAssemblyRevision(revision sessionvo.AssemblyRevision) {
+	tx.s.revisions[revision.ID] = revision
+}
+
+func (s *Store) Lease(ctx context.Context, limit int, _ time.Duration) ([]iprojectionoutbox.Item, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	var result []iprojectionoutbox.Item
+	for id, mutation := range s.projections {
+		result = append(result, iprojectionoutbox.Item{
+			ID: id, AggregateType: mutation.AggregateType, AggregateID: mutation.AggregateID,
+			AggregateVersion: mutation.AggregateVersion,
+			EventType:        mutation.EventType, EventID: mutation.EventID, Payload: mutation.Payload,
+		})
+		if limit > 0 && len(result) >= limit {
+			break
+		}
+	}
+	return result, nil
+}
+
+func (s *Store) MarkDelivered(_ context.Context, item iprojectionoutbox.Item) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	delete(s.projections, item.ID)
+	return nil
+}
+
+func (s *Store) MarkRetry(_ context.Context, _ iprojectionoutbox.Item, _ string, _ time.Time) error {
+	return nil
+}
+
+func (s *Store) MoveToDLQ(_ context.Context, item iprojectionoutbox.Item, _ string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	delete(s.projections, item.ID)
+	return nil
+}
+
+func (s *Store) PendingProjectionCount() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return len(s.projections)
+}

--- a/bkn-trace/agent-observability/src/driveradapter/api/httphandler/core_openapi.go
+++ b/bkn-trace/agent-observability/src/driveradapter/api/httphandler/core_openapi.go
@@ -1,0 +1,237 @@
+package httphandler
+
+import "github.com/openbkn-ai/bkn-foundry/bkn-trace/agent-observability/src/domain/valueobject/sessionvo"
+
+type conversationPage struct {
+	Entries    []sessionvo.Conversation `json:"entries"`
+	NextCursor string                   `json:"next_cursor,omitempty"`
+}
+
+type requestPage struct {
+	Entries    []sessionvo.RequestSummary `json:"entries"`
+	NextCursor string                     `json:"next_cursor,omitempty"`
+}
+
+// @Summary Create or return the current managed Conversation
+// @Tags lifecycle
+// @Accept json
+// @Produce json
+// @Param request body ensureConversationRequest true "Managed Conversation request"
+// @Success 201 {object} sessionvo.Conversation
+// @Failure 400,401,403,409,500 {object} lifecycleErrorEnvelope
+// @Router /conversations [post]
+func documentCreateConversation() {}
+
+// @Summary List managed Conversations in the authorized owner scope
+// @Tags lifecycle
+// @Produce json
+// @Param limit query int false "Page size, 1..100"
+// @Success 200 {object} conversationPage
+// @Failure 401,403,500 {object} lifecycleErrorEnvelope
+// @Router /conversations [get]
+func documentListConversations() {}
+
+// @Summary Ensure the current managed Conversation
+// @Tags lifecycle
+// @Accept json
+// @Produce json
+// @Param request body ensureConversationRequest true "Managed Conversation request"
+// @Success 201 {object} sessionvo.Conversation
+// @Failure 400,401,403,409,500 {object} lifecycleErrorEnvelope
+// @Router /conversations:ensure-current [post]
+func documentEnsureCurrentConversation() {}
+
+// @Summary Create a new managed Conversation generation
+// @Tags lifecycle
+// @Accept json
+// @Produce json
+// @Param request body ensureConversationRequest true "New generation request"
+// @Success 201 {object} sessionvo.Conversation
+// @Failure 400,401,403,409,500 {object} lifecycleErrorEnvelope
+// @Router /conversations:create-new-generation [post]
+func documentCreateConversationGeneration() {}
+
+// @Summary Resume an active managed Conversation by Core ID
+// @Tags lifecycle
+// @Accept json
+// @Produce json
+// @Param request body resumeConversationRequest true "Conversation resume request"
+// @Success 200 {object} sessionvo.Conversation
+// @Failure 400,401,403,404,409,500 {object} lifecycleErrorEnvelope
+// @Router /conversations:resume-by-id [post]
+func documentResumeConversation() {}
+
+// @Summary Get one managed Conversation
+// @Tags lifecycle
+// @Produce json
+// @Param conversation_id path string true "Conversation ID"
+// @Success 200 {object} sessionvo.Conversation
+// @Failure 401,403,404,500 {object} lifecycleErrorEnvelope
+// @Router /conversations/{conversation_id} [get]
+func documentGetConversation() {}
+
+// @Summary Close one managed Conversation
+// @Tags lifecycle
+// @Accept json
+// @Produce json
+// @Param conversation_id path string true "Conversation ID"
+// @Param request body closeConversationRequest true "Idempotent close request"
+// @Success 200 {object} sessionvo.Conversation
+// @Failure 400,401,403,404,409,500 {object} lifecycleErrorEnvelope
+// @Router /conversations/{conversation_id}/close [post]
+func documentCloseConversation() {}
+
+// @Summary Start one managed Interaction
+// @Tags lifecycle
+// @Accept json
+// @Produce json
+// @Param conversation_id path string true "Conversation ID"
+// @Param request body startInteractionRequest true "Interaction start request"
+// @Success 201 {object} sessionvo.Interaction
+// @Failure 400,401,403,404,409,500 {object} lifecycleErrorEnvelope
+// @Router /conversations/{conversation_id}/interactions [post]
+func documentStartInteraction() {}
+
+// @Summary Ensure an idempotent Operation intent and durable Receipt
+// @Tags lifecycle
+// @Accept json
+// @Produce json
+// @Param conversation_id path string true "Conversation ID"
+// @Param interaction_id path string true "Interaction ID"
+// @Param request body ensureOperationRequest true "Operation intent"
+// @Success 201 {object} operationResult
+// @Failure 400,401,403,404,409,500 {object} lifecycleErrorEnvelope
+// @Router /conversations/{conversation_id}/interactions/{interaction_id}/operations:ensure [post]
+func documentEnsureOperation() {}
+
+// @Summary Get one managed Interaction
+// @Tags lifecycle
+// @Produce json
+// @Param interaction_id path string true "Interaction ID"
+// @Success 200 {object} sessionvo.Interaction
+// @Failure 401,403,404,500 {object} lifecycleErrorEnvelope
+// @Router /interactions/{interaction_id} [get]
+func documentGetInteraction() {}
+
+// @Summary Complete one managed Interaction
+// @Tags lifecycle
+// @Accept json
+// @Produce json
+// @Param interaction_id path string true "Interaction ID"
+// @Param request body terminalInteractionRequest true "Terminal closure manifest"
+// @Success 200 {object} sessionvo.Interaction
+// @Failure 400,401,403,404,409,422,500 {object} lifecycleErrorEnvelope
+// @Router /interactions/{interaction_id}/complete [post]
+func documentCompleteInteraction() {}
+
+// @Summary Fail one managed Interaction
+// @Tags lifecycle
+// @Accept json
+// @Produce json
+// @Param interaction_id path string true "Interaction ID"
+// @Param request body terminalInteractionRequest true "Terminal closure manifest"
+// @Success 200 {object} sessionvo.Interaction
+// @Failure 400,401,403,404,409,422,500 {object} lifecycleErrorEnvelope
+// @Router /interactions/{interaction_id}/fail [post]
+func documentFailInteraction() {}
+
+// @Summary Cancel one managed Interaction
+// @Tags lifecycle
+// @Accept json
+// @Produce json
+// @Param interaction_id path string true "Interaction ID"
+// @Param request body terminalInteractionRequest true "Terminal closure manifest"
+// @Success 200 {object} sessionvo.Interaction
+// @Failure 400,401,403,404,409,422,500 {object} lifecycleErrorEnvelope
+// @Router /interactions/{interaction_id}/cancel [post]
+func documentCancelInteraction() {}
+
+// @Summary Hand off one managed Interaction
+// @Tags lifecycle
+// @Accept json
+// @Produce json
+// @Param interaction_id path string true "Interaction ID"
+// @Param request body terminalInteractionRequest true "Terminal closure manifest"
+// @Success 200 {object} sessionvo.Interaction
+// @Failure 400,401,403,404,409,422,500 {object} lifecycleErrorEnvelope
+// @Router /interactions/{interaction_id}/handoff [post]
+func documentHandoffInteraction() {}
+
+// @Summary Get one Operation
+// @Tags lifecycle
+// @Produce json
+// @Param operation_id path string true "Operation ID"
+// @Success 200 {object} sessionvo.Operation
+// @Failure 401,403,404,500 {object} lifecycleErrorEnvelope
+// @Router /operations/{operation_id} [get]
+func documentGetOperation() {}
+
+// @Summary Start the next retry attempt for an Operation
+// @Tags lifecycle
+// @Accept json
+// @Produce json
+// @Param operation_id path string true "Operation ID"
+// @Param request body interactionLeaseRequest true "Current Interaction lease"
+// @Success 201 {object} operationResult
+// @Failure 400,401,403,404,409,500 {object} lifecycleErrorEnvelope
+// @Router /operations/{operation_id}/attempts [post]
+func documentStartOperationAttempt() {}
+
+// @Summary Complete one Operation attempt
+// @Tags lifecycle
+// @Accept json
+// @Produce json
+// @Param operation_id path string true "Operation ID"
+// @Param attempt path int true "Attempt number"
+// @Param request body finishAttemptRequest true "Durable operation result"
+// @Success 200 {object} operationResult
+// @Failure 400,401,403,404,409,500 {object} lifecycleErrorEnvelope
+// @Router /operations/{operation_id}/attempts/{attempt}:complete [post]
+func documentCompleteOperationAttempt() {}
+
+// @Summary Fail one Operation attempt
+// @Tags lifecycle
+// @Accept json
+// @Produce json
+// @Param operation_id path string true "Operation ID"
+// @Param attempt path int true "Attempt number"
+// @Param request body finishAttemptRequest true "Durable operation failure"
+// @Success 200 {object} operationResult
+// @Failure 400,401,403,404,409,500 {object} lifecycleErrorEnvelope
+// @Router /operations/{operation_id}/attempts/{attempt}:fail [post]
+func documentFailOperationAttempt() {}
+
+// @Summary Get one durable Receipt
+// @Tags lifecycle
+// @Produce json
+// @Param receipt_id path string true "Receipt ID"
+// @Success 200 {object} sessionvo.Receipt
+// @Failure 401,403,404,409,500 {object} lifecycleErrorEnvelope
+// @Router /receipts/{receipt_id} [get]
+func documentGetReceipt() {}
+
+// @Summary List request projections from durable Receipts
+// @Tags lifecycle
+// @Produce json
+// @Param limit query int false "Page size, 1..100"
+// @Success 200 {object} requestPage
+// @Failure 401,403,500 {object} lifecycleErrorEnvelope
+// @Router /requests [get]
+func documentListCoreRequests() {}
+
+// @Summary Get one request projection from durable Receipts
+// @Tags lifecycle
+// @Produce json
+// @Param request_id path string true "Request ID"
+// @Success 200 {object} sessionvo.RequestSummary
+// @Failure 401,403,404,500 {object} lifecycleErrorEnvelope
+// @Router /requests/{request_id} [get]
+func documentGetCoreRequest() {}
+
+type resumeConversationRequest struct {
+	ConversationID string `json:"conversation_id"`
+}
+
+type closeConversationRequest struct {
+	IdempotencyKey string `json:"idempotency_key"`
+}

--- a/bkn-trace/agent-observability/src/driveradapter/api/httphandler/core_openapi.go
+++ b/bkn-trace/agent-observability/src/driveradapter/api/httphandler/core_openapi.go
@@ -20,6 +20,8 @@ type requestPage struct {
 // @Success 201 {object} sessionvo.Conversation
 // @Failure 400,401,403,409,500 {object} lifecycleErrorEnvelope
 // @Router /conversations [post]
+//
+//nolint:unused // Swag parses this annotation carrier during documentation generation.
 func documentCreateConversation() {}
 
 // @Summary List managed Conversations in the authorized owner scope
@@ -29,6 +31,8 @@ func documentCreateConversation() {}
 // @Success 200 {object} conversationPage
 // @Failure 401,403,500 {object} lifecycleErrorEnvelope
 // @Router /conversations [get]
+//
+//nolint:unused // Swag parses this annotation carrier during documentation generation.
 func documentListConversations() {}
 
 // @Summary Ensure the current managed Conversation
@@ -39,6 +43,8 @@ func documentListConversations() {}
 // @Success 201 {object} sessionvo.Conversation
 // @Failure 400,401,403,409,500 {object} lifecycleErrorEnvelope
 // @Router /conversations:ensure-current [post]
+//
+//nolint:unused // Swag parses this annotation carrier during documentation generation.
 func documentEnsureCurrentConversation() {}
 
 // @Summary Create a new managed Conversation generation
@@ -49,6 +55,8 @@ func documentEnsureCurrentConversation() {}
 // @Success 201 {object} sessionvo.Conversation
 // @Failure 400,401,403,409,500 {object} lifecycleErrorEnvelope
 // @Router /conversations:create-new-generation [post]
+//
+//nolint:unused // Swag parses this annotation carrier during documentation generation.
 func documentCreateConversationGeneration() {}
 
 // @Summary Resume an active managed Conversation by Core ID
@@ -59,6 +67,8 @@ func documentCreateConversationGeneration() {}
 // @Success 200 {object} sessionvo.Conversation
 // @Failure 400,401,403,404,409,500 {object} lifecycleErrorEnvelope
 // @Router /conversations:resume-by-id [post]
+//
+//nolint:unused // Swag parses this annotation carrier during documentation generation.
 func documentResumeConversation() {}
 
 // @Summary Get one managed Conversation
@@ -68,6 +78,8 @@ func documentResumeConversation() {}
 // @Success 200 {object} sessionvo.Conversation
 // @Failure 401,403,404,500 {object} lifecycleErrorEnvelope
 // @Router /conversations/{conversation_id} [get]
+//
+//nolint:unused // Swag parses this annotation carrier during documentation generation.
 func documentGetConversation() {}
 
 // @Summary Close one managed Conversation
@@ -79,6 +91,8 @@ func documentGetConversation() {}
 // @Success 200 {object} sessionvo.Conversation
 // @Failure 400,401,403,404,409,500 {object} lifecycleErrorEnvelope
 // @Router /conversations/{conversation_id}/close [post]
+//
+//nolint:unused // Swag parses this annotation carrier during documentation generation.
 func documentCloseConversation() {}
 
 // @Summary Start one managed Interaction
@@ -90,6 +104,8 @@ func documentCloseConversation() {}
 // @Success 201 {object} sessionvo.Interaction
 // @Failure 400,401,403,404,409,500 {object} lifecycleErrorEnvelope
 // @Router /conversations/{conversation_id}/interactions [post]
+//
+//nolint:unused // Swag parses this annotation carrier during documentation generation.
 func documentStartInteraction() {}
 
 // @Summary Ensure an idempotent Operation intent and durable Receipt
@@ -102,6 +118,8 @@ func documentStartInteraction() {}
 // @Success 201 {object} operationResult
 // @Failure 400,401,403,404,409,500 {object} lifecycleErrorEnvelope
 // @Router /conversations/{conversation_id}/interactions/{interaction_id}/operations:ensure [post]
+//
+//nolint:unused // Swag parses this annotation carrier during documentation generation.
 func documentEnsureOperation() {}
 
 // @Summary Get one managed Interaction
@@ -111,6 +129,8 @@ func documentEnsureOperation() {}
 // @Success 200 {object} sessionvo.Interaction
 // @Failure 401,403,404,500 {object} lifecycleErrorEnvelope
 // @Router /interactions/{interaction_id} [get]
+//
+//nolint:unused // Swag parses this annotation carrier during documentation generation.
 func documentGetInteraction() {}
 
 // @Summary Complete one managed Interaction
@@ -122,6 +142,8 @@ func documentGetInteraction() {}
 // @Success 200 {object} sessionvo.Interaction
 // @Failure 400,401,403,404,409,422,500 {object} lifecycleErrorEnvelope
 // @Router /interactions/{interaction_id}/complete [post]
+//
+//nolint:unused // Swag parses this annotation carrier during documentation generation.
 func documentCompleteInteraction() {}
 
 // @Summary Fail one managed Interaction
@@ -133,6 +155,8 @@ func documentCompleteInteraction() {}
 // @Success 200 {object} sessionvo.Interaction
 // @Failure 400,401,403,404,409,422,500 {object} lifecycleErrorEnvelope
 // @Router /interactions/{interaction_id}/fail [post]
+//
+//nolint:unused // Swag parses this annotation carrier during documentation generation.
 func documentFailInteraction() {}
 
 // @Summary Cancel one managed Interaction
@@ -144,6 +168,8 @@ func documentFailInteraction() {}
 // @Success 200 {object} sessionvo.Interaction
 // @Failure 400,401,403,404,409,422,500 {object} lifecycleErrorEnvelope
 // @Router /interactions/{interaction_id}/cancel [post]
+//
+//nolint:unused // Swag parses this annotation carrier during documentation generation.
 func documentCancelInteraction() {}
 
 // @Summary Hand off one managed Interaction
@@ -155,6 +181,8 @@ func documentCancelInteraction() {}
 // @Success 200 {object} sessionvo.Interaction
 // @Failure 400,401,403,404,409,422,500 {object} lifecycleErrorEnvelope
 // @Router /interactions/{interaction_id}/handoff [post]
+//
+//nolint:unused // Swag parses this annotation carrier during documentation generation.
 func documentHandoffInteraction() {}
 
 // @Summary Get one Operation
@@ -164,6 +192,8 @@ func documentHandoffInteraction() {}
 // @Success 200 {object} sessionvo.Operation
 // @Failure 401,403,404,500 {object} lifecycleErrorEnvelope
 // @Router /operations/{operation_id} [get]
+//
+//nolint:unused // Swag parses this annotation carrier during documentation generation.
 func documentGetOperation() {}
 
 // @Summary Start the next retry attempt for an Operation
@@ -175,6 +205,8 @@ func documentGetOperation() {}
 // @Success 201 {object} operationResult
 // @Failure 400,401,403,404,409,500 {object} lifecycleErrorEnvelope
 // @Router /operations/{operation_id}/attempts [post]
+//
+//nolint:unused // Swag parses this annotation carrier during documentation generation.
 func documentStartOperationAttempt() {}
 
 // @Summary Complete one Operation attempt
@@ -187,6 +219,8 @@ func documentStartOperationAttempt() {}
 // @Success 200 {object} operationResult
 // @Failure 400,401,403,404,409,500 {object} lifecycleErrorEnvelope
 // @Router /operations/{operation_id}/attempts/{attempt}:complete [post]
+//
+//nolint:unused // Swag parses this annotation carrier during documentation generation.
 func documentCompleteOperationAttempt() {}
 
 // @Summary Fail one Operation attempt
@@ -199,6 +233,8 @@ func documentCompleteOperationAttempt() {}
 // @Success 200 {object} operationResult
 // @Failure 400,401,403,404,409,500 {object} lifecycleErrorEnvelope
 // @Router /operations/{operation_id}/attempts/{attempt}:fail [post]
+//
+//nolint:unused // Swag parses this annotation carrier during documentation generation.
 func documentFailOperationAttempt() {}
 
 // @Summary Get one durable Receipt
@@ -208,6 +244,8 @@ func documentFailOperationAttempt() {}
 // @Success 200 {object} sessionvo.Receipt
 // @Failure 401,403,404,409,500 {object} lifecycleErrorEnvelope
 // @Router /receipts/{receipt_id} [get]
+//
+//nolint:unused // Swag parses this annotation carrier during documentation generation.
 func documentGetReceipt() {}
 
 // @Summary List request projections from durable Receipts
@@ -217,6 +255,8 @@ func documentGetReceipt() {}
 // @Success 200 {object} requestPage
 // @Failure 401,403,500 {object} lifecycleErrorEnvelope
 // @Router /requests [get]
+//
+//nolint:unused // Swag parses this annotation carrier during documentation generation.
 func documentListCoreRequests() {}
 
 // @Summary Get one request projection from durable Receipts
@@ -226,12 +266,16 @@ func documentListCoreRequests() {}
 // @Success 200 {object} sessionvo.RequestSummary
 // @Failure 401,403,404,500 {object} lifecycleErrorEnvelope
 // @Router /requests/{request_id} [get]
+//
+//nolint:unused // Swag parses this annotation carrier during documentation generation.
 func documentGetCoreRequest() {}
 
+//nolint:unused // Swag resolves this request schema from annotation references.
 type resumeConversationRequest struct {
 	ConversationID string `json:"conversation_id"`
 }
 
+//nolint:unused // Swag resolves this request schema from annotation references.
 type closeConversationRequest struct {
 	IdempotencyKey string `json:"idempotency_key"`
 }

--- a/bkn-trace/agent-observability/src/driveradapter/api/httphandler/evidence_handler.go
+++ b/bkn-trace/agent-observability/src/driveradapter/api/httphandler/evidence_handler.go
@@ -856,6 +856,13 @@ func (h *EvidenceHandler) RequireTrustedLifecycleIdentity(next http.HandlerFunc)
 		}
 		r.Header.Set("X-BKN-Tenant-ID", scope.TenantID)
 		r.Header.Set("X-Business-Domain-ID", scope.BusinessDomain)
+		if _, ok := trustedOwnerFromRequest(r); !ok {
+			writeLifecycleError(
+				w, r, http.StatusUnauthorized, "permission_denied",
+				"trusted gateway must provide the complete lifecycle owner identity",
+			)
+			return
+		}
 
 		next(w, r)
 	}

--- a/bkn-trace/agent-observability/src/driveradapter/api/httphandler/evidence_handler.go
+++ b/bkn-trace/agent-observability/src/driveradapter/api/httphandler/evidence_handler.go
@@ -102,7 +102,6 @@ func NewEvidenceHandlerWithSecurityConfig(evidenceService *evidencesvc.Service, 
 // @Failure 400 {object} rdto.ErrorResponse
 // @Failure 405 {object} rdto.ErrorResponse
 // @Failure 500 {object} rdto.ErrorResponse
-// @Router /evidence/events [post]
 func (h *EvidenceHandler) IngestEvidenceEvents(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodPost {
 		writeJSON(w, http.StatusMethodNotAllowed, rdto.ErrorResponse{
@@ -833,6 +832,35 @@ func (h *EvidenceHandler) RequireTrustedQueryIdentity(next http.HandlerFunc) htt
 	}
 }
 
+func (h *EvidenceHandler) RequireTrustedLifecycleIdentity(next http.HandlerFunc) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		gatewayTrusted := h.queryGatewayToken != "" &&
+			secureTokenEqual(r.Header.Get(evidenceQueryGatewayTokenHeader), h.queryGatewayToken)
+		if !gatewayTrusted {
+			writeLifecycleError(
+				w, r, http.StatusUnauthorized, "permission_denied",
+				"trusted gateway identity with authorized tenant and business domain is required",
+			)
+			return
+		}
+		scope, ok := h.queryScopeFromRequest(w, r)
+		if !ok {
+			return
+		}
+		if scope.TenantID == "" || scope.BusinessDomain == "" {
+			writeLifecycleError(
+				w, r, http.StatusUnauthorized, "permission_denied",
+				"trusted tenant and business domain context is required",
+			)
+			return
+		}
+		r.Header.Set("X-BKN-Tenant-ID", scope.TenantID)
+		r.Header.Set("X-Business-Domain-ID", scope.BusinessDomain)
+
+		next(w, r)
+	}
+}
+
 func (h *EvidenceHandler) authorizeQueryGateway(w http.ResponseWriter, r *http.Request) bool {
 	if h.queryGatewayToken != "" && secureTokenEqual(r.Header.Get(evidenceQueryGatewayTokenHeader), h.queryGatewayToken) {
 		return true
@@ -920,6 +948,7 @@ func (h *EvidenceHandler) authorizeOAuthQuery(w http.ResponseWriter, r *http.Req
 	}
 	r.Header.Set("x-account-id", accountID)
 	r.Header.Set("x-account-type", accountType)
+	r.Header.Set("X-BKN-Authenticated-Client-ID", strings.TrimSpace(introspection.ClientID))
 	return true
 }
 

--- a/bkn-trace/agent-observability/src/driveradapter/api/httphandler/evidence_handler_test.go
+++ b/bkn-trace/agent-observability/src/driveradapter/api/httphandler/evidence_handler_test.go
@@ -139,6 +139,75 @@ func TestEvidenceHandlerAuthenticatesStudioQueryWithHydra(t *testing.T) {
 	}
 }
 
+func TestLifecycleIdentityRejectsOAuthUntilTenantDomainAuthorizationIsDelegated(t *testing.T) {
+	hydra := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/admin/oauth2/introspect" || r.FormValue("token") != "lifecycle-token" {
+			t.Fatalf("unexpected introspection request: %s token=%q", r.URL.Path, r.FormValue("token"))
+		}
+		_, _ = io.WriteString(w, `{"active":true,"sub":"user-authenticated","client_id":"agent-authenticated","ext":{"visitor_type":"user"}}`)
+	}))
+	defer hydra.Close()
+
+	handler := NewEvidenceHandlerWithSecurityConfig(evidencesvc.New(evidencestore.New()), EvidenceHandlerSecurityConfig{
+		HydraAdminURL: hydra.URL,
+	})
+	nextCalled := false
+	next := handler.RequireTrustedLifecycleIdentity(func(w http.ResponseWriter, r *http.Request) {
+		nextCalled = true
+		w.WriteHeader(http.StatusNoContent)
+	})
+	request := httptest.NewRequest(http.MethodPost, "/api/agent-observability/v1/conversations:ensure-current", nil)
+	request.Header.Set("Authorization", "Bearer lifecycle-token")
+	request.Header.Set("X-BKN-Tenant-ID", "tenant-1")
+	request.Header.Set("X-Business-Domain", "domain-1")
+	request.Header.Set("X-BKN-Application-Principal-ID", "forged-app")
+	request.Header.Set("X-BKN-Effective-Subject-Type", "service")
+	request.Header.Set("X-BKN-Effective-Subject-ID", "forged-subject")
+	request.Header.Set("X-BKN-Delegation-ID", "forged-delegation")
+	response := httptest.NewRecorder()
+
+	next(response, request)
+
+	if response.Code != http.StatusUnauthorized || nextCalled {
+		t.Fatalf(
+			"OAuth without authorized tenant/domain context must be rejected: %d %s",
+			response.Code, response.Body.String(),
+		)
+	}
+}
+
+func TestLifecycleIdentityRejectsAnonymousQueryCompatibilityMode(t *testing.T) {
+	handler := NewEvidenceHandlerWithSecurityConfig(
+		evidencesvc.New(evidencestore.New()),
+		EvidenceHandlerSecurityConfig{AllowUnauthenticatedQuery: true},
+	)
+	nextCalled := false
+	next := handler.RequireTrustedLifecycleIdentity(func(
+		http.ResponseWriter, *http.Request,
+	) {
+		nextCalled = true
+	})
+	request := httptest.NewRequest(
+		http.MethodPost,
+		"/api/agent-observability/v1/conversations:ensure-current",
+		nil,
+	)
+	request.Header.Set("X-BKN-Tenant-ID", "forged-tenant")
+	request.Header.Set("X-Business-Domain", "forged-domain")
+	request.Header.Set("X-BKN-Application-Principal-ID", "forged-app")
+	request.Header.Set("X-BKN-Effective-Subject-ID", "forged-subject")
+	response := httptest.NewRecorder()
+
+	next(response, request)
+
+	if response.Code != http.StatusUnauthorized || nextCalled {
+		t.Fatalf(
+			"anonymous query compatibility must not authorize lifecycle writes: %d %s",
+			response.Code, response.Body.String(),
+		)
+	}
+}
+
 func TestEvidenceHandlerRejectsOAuthIdentityMismatch(t *testing.T) {
 	hydra := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		_, _ = io.WriteString(w, `{"active":true,"sub":"acct_demo","client_id":"openbkn-studio","ext":{"visitor_type":"user"}}`)

--- a/bkn-trace/agent-observability/src/driveradapter/api/httphandler/evidence_handler_test.go
+++ b/bkn-trace/agent-observability/src/driveradapter/api/httphandler/evidence_handler_test.go
@@ -208,6 +208,39 @@ func TestLifecycleIdentityRejectsAnonymousQueryCompatibilityMode(t *testing.T) {
 	}
 }
 
+func TestLifecycleIdentityRejectsIncompleteOwnerTupleAtGatewayBoundary(t *testing.T) {
+	handler := NewEvidenceHandlerWithSecurityConfig(
+		evidencesvc.New(evidencestore.New()),
+		EvidenceHandlerSecurityConfig{QueryGatewayToken: "trusted-gateway-token"},
+	)
+	nextCalled := false
+	next := handler.RequireTrustedLifecycleIdentity(func(
+		http.ResponseWriter, *http.Request,
+	) {
+		nextCalled = true
+	})
+	request := httptest.NewRequest(
+		http.MethodPost,
+		"/api/agent-observability/v1/conversations:ensure-current",
+		nil,
+	)
+	request.Header.Set("X-BKN-Trace-Query-Token", "trusted-gateway-token")
+	request.Header.Set("x-account-id", "subject-1")
+	request.Header.Set("x-account-type", "service")
+	request.Header.Set("x-business-domain", "domain-1")
+	request.Header.Set("x-tenant-id", "tenant-1")
+	response := httptest.NewRecorder()
+
+	next(response, request)
+
+	if response.Code != http.StatusUnauthorized || nextCalled {
+		t.Fatalf(
+			"incomplete owner tuple must be rejected at the gateway boundary: %d %s",
+			response.Code, response.Body.String(),
+		)
+	}
+}
+
 func TestEvidenceHandlerRejectsOAuthIdentityMismatch(t *testing.T) {
 	hydra := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		_, _ = io.WriteString(w, `{"active":true,"sub":"acct_demo","client_id":"openbkn-studio","ext":{"visitor_type":"user"}}`)

--- a/bkn-trace/agent-observability/src/driveradapter/api/httphandler/ledger_handler.go
+++ b/bkn-trace/agent-observability/src/driveradapter/api/httphandler/ledger_handler.go
@@ -1,0 +1,142 @@
+package httphandler
+
+import (
+	"crypto/subtle"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/openbkn-ai/bkn-foundry/bkn-trace/agent-observability/src/domain/service/ledgersvc"
+	"github.com/openbkn-ai/bkn-foundry/bkn-trace/agent-observability/src/domain/valueobject/ledgervo"
+	"github.com/openbkn-ai/bkn-foundry/bkn-trace/agent-observability/src/domain/valueobject/sessionvo"
+)
+
+type LedgerSecurityConfig struct {
+	IngestToken                string
+	AllowUnauthenticatedIngest bool
+}
+
+type LedgerHandler struct {
+	service                    *ledgersvc.Service
+	ingestToken                string
+	allowUnauthenticatedIngest bool
+}
+
+func NewLedgerHandler(service *ledgersvc.Service, security LedgerSecurityConfig) *LedgerHandler {
+	return &LedgerHandler{
+		service: service, ingestToken: strings.TrimSpace(security.IngestToken),
+		allowUnauthenticatedIngest: security.AllowUnauthenticatedIngest,
+	}
+}
+
+func NewConfiguredLedgerHandler(service *ledgersvc.Service) *LedgerHandler {
+	return NewLedgerHandler(service, LedgerSecurityConfig{
+		IngestToken: os.Getenv(evidenceIngestTokenEnv),
+		AllowUnauthenticatedIngest: strings.EqualFold(
+			strings.TrimSpace(os.Getenv(evidenceAllowUnauthenticatedIngestEnv)), "true",
+		),
+	})
+}
+
+type evidenceEventRequest struct {
+	EventID           string                  `json:"event_id"`
+	EventType         string                  `json:"event_type"`
+	SchemaVersion     string                  `json:"schema_version"`
+	PayloadHash       string                  `json:"payload_hash"`
+	TenantID          string                  `json:"tenant_id,omitempty"`
+	BusinessDomainID  string                  `json:"business_domain_id,omitempty"`
+	ConversationID    string                  `json:"conversation_id"`
+	InteractionID     string                  `json:"interaction_id"`
+	OperationID       string                  `json:"operation_id,omitempty"`
+	Attempt           uint32                  `json:"attempt,omitempty"`
+	RequestID         string                  `json:"request_id,omitempty"`
+	TraceID           string                  `json:"trace_id,omitempty"`
+	SpanID            string                  `json:"span_id,omitempty"`
+	ProducerID        string                  `json:"producer_id"`
+	ProducerStreamID  string                  `json:"producer_stream_id"`
+	ProducerEpoch     uint64                  `json:"producer_epoch"`
+	ProducerSequence  uint64                  `json:"producer_sequence"`
+	CausationEventIDs []string                `json:"causation_event_ids,omitempty"`
+	StartedAt         time.Time               `json:"started_at"`
+	ObservedAt        time.Time               `json:"observed_at"`
+	EmittedAt         time.Time               `json:"emitted_at"`
+	Envelope          json.RawMessage         `json:"envelope"`
+	BusinessRefs      []sessionvo.BusinessRef `json:"business_refs,omitempty"`
+	ArtifactRefs      []string                `json:"artifact_refs,omitempty"`
+}
+
+// Ingest accepts one immutable BKN Trace 3.0 evidence event.
+// @Summary Durably ingest one BKN Trace 3.0 evidence event
+// @Description Commits the immutable Evidence Ledger record and Projection Outbox in one transaction before returning durable_ack.
+// @Tags evidence
+// @Accept json
+// @Produce json
+// @Param request body evidenceEventRequest true "BKN Trace 3.0 evidence event"
+// @Success 202 {object} ledgervo.DurableAck
+// @Failure 400,401,403,409,500 {object} lifecycleErrorEnvelope
+// @Router /evidence/events [post]
+func (h *LedgerHandler) Ingest(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		writeLifecycleError(w, r, http.StatusMethodNotAllowed, "permission_denied", "only POST is supported")
+		return
+	}
+	if !h.authorize(w, r) {
+		return
+	}
+	owner, ok := trustedOwnerFromRequest(r)
+	if !ok {
+		writeLifecycleError(w, r, http.StatusUnauthorized, "permission_denied", "trusted evidence identity is required")
+		return
+	}
+	var request evidenceEventRequest
+	if err := decodeLifecycleBody(w, r, &request); err != nil {
+		writeLifecycleError(w, r, http.StatusBadRequest, "invalid_evidence_event", err.Error())
+		return
+	}
+	ack, err := h.service.Ingest(r.Context(), ledgervo.Event{
+		EventID: request.EventID, EventType: request.EventType, SchemaVersion: request.SchemaVersion,
+		PayloadHash: request.PayloadHash, Owner: owner, ConversationID: request.ConversationID,
+		InteractionID: request.InteractionID, OperationID: request.OperationID, Attempt: request.Attempt,
+		RequestID: request.RequestID, TraceID: request.TraceID, SpanID: request.SpanID,
+		ProducerID: request.ProducerID, ProducerStreamID: request.ProducerStreamID,
+		ProducerEpoch: request.ProducerEpoch, ProducerSequence: request.ProducerSequence,
+		CausationEventIDs: request.CausationEventIDs, StartedAt: request.StartedAt,
+		ObservedAt: request.ObservedAt, EmittedAt: request.EmittedAt, Envelope: request.Envelope,
+		BusinessRefs: request.BusinessRefs, ArtifactRefs: request.ArtifactRefs,
+	})
+	if err != nil {
+		var domainErr *ledgersvc.DomainError
+		if errors.As(err, &domainErr) {
+			status := http.StatusBadRequest
+			action := "fix_evidence_event"
+			if domainErr.Code == ledgersvc.CodeEventPayloadConflict || domainErr.Code == ledgersvc.CodeEventSequenceConflict {
+				status = http.StatusConflict
+				action = "inspect_event_conflict"
+			}
+			writeJSON(w, status, lifecycleErrorEnvelope{Error: lifecycleError{
+				Code: string(domainErr.Code), Message: domainErr.Message,
+				RequiredAction: action, RequestID: requestIDFromRequest(r),
+			}})
+			return
+		}
+		writeLifecycleError(w, r, http.StatusInternalServerError, "internal_error", "evidence event was not durably committed")
+		return
+	}
+	writeJSON(w, http.StatusAccepted, ack)
+}
+
+func (h *LedgerHandler) authorize(w http.ResponseWriter, r *http.Request) bool {
+	if h.allowUnauthenticatedIngest {
+		return true
+	}
+	provided := strings.TrimSpace(r.Header.Get(evidenceIngestTokenHeader))
+	if h.ingestToken == "" || provided == "" ||
+		subtle.ConstantTimeCompare([]byte(provided), []byte(h.ingestToken)) != 1 {
+		writeLifecycleError(w, r, http.StatusUnauthorized, "permission_denied", "evidence ingest authorization is required")
+		return false
+	}
+	return true
+}

--- a/bkn-trace/agent-observability/src/driveradapter/api/httphandler/ledger_handler_test.go
+++ b/bkn-trace/agent-observability/src/driveradapter/api/httphandler/ledger_handler_test.go
@@ -1,0 +1,52 @@
+package httphandler_test
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/openbkn-ai/bkn-foundry/bkn-trace/agent-observability/src/domain/service/ledgersvc"
+	"github.com/openbkn-ai/bkn-foundry/bkn-trace/agent-observability/src/domain/valueobject/ledgervo"
+	"github.com/openbkn-ai/bkn-foundry/bkn-trace/agent-observability/src/drivenadapter/memoryaccess/ledgerstore"
+	"github.com/openbkn-ai/bkn-foundry/bkn-trace/agent-observability/src/driveradapter/api/httphandler"
+)
+
+func TestLedgerHandlerReturnsDurableAckAndUsesTrustedOwner(t *testing.T) {
+	t.Parallel()
+
+	store := ledgerstore.New()
+	handler := httphandler.NewLedgerHandler(ledgersvc.New(store), httphandler.LedgerSecurityConfig{
+		AllowUnauthenticatedIngest: true,
+	})
+	envelope := json.RawMessage(`{"result":"15991"}`)
+	payload := map[string]any{
+		"event_id": "evt-http-1", "event_type": "operation.output.observed",
+		"schema_version": "3.0.0", "payload_hash": ledgervo.CanonicalPayloadHash(envelope),
+		"tenant_id": "forged", "business_domain_id": "forged",
+		"conversation_id": "conv-1", "interaction_id": "int-1", "operation_id": "op-1",
+		"attempt": 1, "producer_id": "context-loader", "producer_stream_id": "stream-1",
+		"producer_epoch": 1, "producer_sequence": 1,
+		"started_at":  time.Date(2026, 7, 30, 9, 59, 59, 0, time.UTC),
+		"observed_at": time.Date(2026, 7, 30, 10, 0, 0, 0, time.UTC),
+		"emitted_at":  time.Date(2026, 7, 30, 10, 0, 1, 0, time.UTC),
+		"envelope":    envelope,
+	}
+	body, _ := json.Marshal(payload)
+	request := httptest.NewRequest(http.MethodPost, "/api/agent-observability/v1/evidence/events", bytes.NewReader(body))
+	setTrustedOwnerHeaders(request)
+	response := httptest.NewRecorder()
+
+	handler.Ingest(response, request)
+
+	if response.Code != http.StatusAccepted {
+		t.Fatalf("expected 202, got %d: %s", response.Code, response.Body.String())
+	}
+	var ack ledgervo.DurableAck
+	decodeLifecycleResponse(t, response, &ack)
+	if !ack.Durable || ack.EventID != "evt-http-1" || store.LedgerCount() != 1 {
+		t.Fatalf("unexpected durable ingest: %#v", ack)
+	}
+}

--- a/bkn-trace/agent-observability/src/driveradapter/api/httphandler/session_handler.go
+++ b/bkn-trace/agent-observability/src/driveradapter/api/httphandler/session_handler.go
@@ -400,11 +400,12 @@ func (h *SessionHandler) handleOperationSubresource(w http.ResponseWriter, r *ht
 	}
 	var operation sessionvo.Operation
 	var receipt sessionvo.Receipt
-	if action == "complete" {
+	switch action {
+	case "complete":
 		operation, receipt, err = h.service.CompleteOperationAttempt(r.Context(), command)
-	} else if action == "fail" {
+	case "fail":
 		operation, receipt, err = h.service.FailOperationAttempt(r.Context(), command)
-	} else {
+	default:
 		writeLifecycleError(w, r, http.StatusNotFound, "operation_required", "attempt action was not found")
 		return
 	}

--- a/bkn-trace/agent-observability/src/driveradapter/api/httphandler/session_handler.go
+++ b/bkn-trace/agent-observability/src/driveradapter/api/httphandler/session_handler.go
@@ -1,0 +1,564 @@
+package httphandler
+
+import (
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/openbkn-ai/bkn-foundry/bkn-trace/agent-observability/src/domain/service/sessionsvc"
+	"github.com/openbkn-ai/bkn-foundry/bkn-trace/agent-observability/src/domain/valueobject/sessionvo"
+)
+
+const maxLifecycleBodyBytes = 1 << 20
+
+type SessionHandler struct {
+	service *sessionsvc.Service
+}
+
+func NewSessionHandler(service *sessionsvc.Service) *SessionHandler {
+	return &SessionHandler{service: service}
+}
+
+type lifecycleErrorEnvelope struct {
+	Error lifecycleError `json:"error"`
+}
+
+type lifecycleError struct {
+	Code           string `json:"code" enums:"conversation_required,conversation_not_found,conversation_closed,conversation_expired,conversation_owner_mismatch,interaction_required,interaction_in_progress,interaction_terminal,operation_required,idempotency_conflict,event_payload_conflict,producer_sequence_conflict,invalid_evidence_event,receipt_pending,terminal_conflict,closure_manifest_invalid,feature_not_installed,capability_not_licensed,permission_denied,resource_not_disclosed,internal_error"`
+	Message        string `json:"message"`
+	CurrentStatus  string `json:"current_status,omitempty"`
+	Retryable      bool   `json:"retryable"`
+	RequiredAction string `json:"required_action,omitempty"`
+	RequestID      string `json:"request_id,omitempty"`
+	RetryAfterMS   int    `json:"retry_after_ms"`
+}
+
+type ensureConversationRequest struct {
+	ExternalConversationKey string `json:"external_conversation_key"`
+	IdempotencyKey          string `json:"idempotency_key"`
+	OneShot                 bool   `json:"one_shot"`
+	TenantID                string `json:"tenant_id,omitempty"`
+	BusinessDomainID        string `json:"business_domain_id,omitempty"`
+	ApplicationPrincipalID  string `json:"application_principal_id,omitempty"`
+	EffectiveSubjectType    string `json:"effective_subject_type,omitempty"`
+	EffectiveSubjectID      string `json:"effective_subject_id,omitempty"`
+	DelegationID            string `json:"delegation_id,omitempty"`
+}
+
+type startInteractionRequest struct {
+	IdempotencyKey string `json:"idempotency_key"`
+	LeaseSeconds   int64  `json:"lease_seconds"`
+}
+
+type ensureOperationRequest struct {
+	OperationKey        string   `json:"operation_key"`
+	ToolName            string   `json:"tool_name"`
+	NormalizedInputHash string   `json:"normalized_input_hash"`
+	ParentOperationID   string   `json:"parent_operation_id,omitempty"`
+	CausationEventIDs   []string `json:"causation_event_ids,omitempty"`
+	Required            bool     `json:"required"`
+	LeaseToken          string   `json:"lease_token"`
+	LeaseEpoch          uint64   `json:"lease_epoch"`
+}
+
+type interactionLeaseRequest struct {
+	LeaseToken string `json:"lease_token"`
+	LeaseEpoch uint64 `json:"lease_epoch"`
+}
+
+type finishAttemptRequest struct {
+	ReceiptID            string                       `json:"receipt_id"`
+	PayloadHash          string                       `json:"payload_hash"`
+	EvidenceDurability   sessionvo.EvidenceDurability `json:"evidence_durability"`
+	Retryable            bool                         `json:"retryable"`
+	RequestID            string                       `json:"request_id,omitempty"`
+	TraceID              string                       `json:"trace_id,omitempty"`
+	ObservedEvidenceRefs []string                     `json:"observed_evidence_refs,omitempty"`
+	BusinessRefs         []sessionvo.BusinessRef      `json:"business_refs,omitempty"`
+	ArtifactRefs         []string                     `json:"artifact_refs,omitempty"`
+	PartialReasons       []string                     `json:"partial_reasons,omitempty"`
+}
+
+type terminalInteractionRequest struct {
+	TerminalIdempotencyKey string                        `json:"terminal_idempotency_key"`
+	LeaseToken             string                        `json:"lease_token"`
+	LeaseEpoch             uint64                        `json:"lease_epoch"`
+	ManifestVersion        string                        `json:"completion_manifest_version"`
+	AnswerArtifactRef      string                        `json:"answer_artifact_ref,omitempty"`
+	Claims                 []string                      `json:"claims,omitempty"`
+	ExpectedOperations     []sessionvo.ExpectedOperation `json:"expected_operations,omitempty"`
+	ExpectedReceipts       []sessionvo.ExpectedReceipt   `json:"expected_receipts,omitempty"`
+	AssemblerDeadline      *time.Time                    `json:"assembler_deadline,omitempty"`
+	CompletionReason       string                        `json:"completion_reason"`
+}
+
+type operationResult struct {
+	Operation sessionvo.Operation `json:"operation"`
+	Receipt   sessionvo.Receipt   `json:"receipt"`
+}
+
+func RegisterSessionRoutes(
+	mux *http.ServeMux,
+	basePath string,
+	handler *SessionHandler,
+	middleware ...func(http.HandlerFunc) http.HandlerFunc,
+) {
+	wrap := func(next http.HandlerFunc) http.HandlerFunc {
+		for index := len(middleware) - 1; index >= 0; index-- {
+			next = middleware[index](next)
+		}
+		return next
+	}
+	mux.HandleFunc(basePath+"/conversations", wrap(handler.CreateConversation))
+	mux.HandleFunc(basePath+"/conversations:ensure-current", wrap(handler.EnsureCurrentConversation))
+	mux.HandleFunc(basePath+"/conversations:create-new-generation", wrap(handler.CreateNewGeneration))
+	mux.HandleFunc(basePath+"/conversations:resume-by-id", wrap(handler.ResumeConversation))
+	mux.HandleFunc(basePath+"/conversations/", wrap(handler.handleConversationSubresource))
+	mux.HandleFunc(basePath+"/interactions/", wrap(handler.handleInteractionSubresource))
+	mux.HandleFunc(basePath+"/operations/", wrap(handler.handleOperationSubresource))
+	mux.HandleFunc(basePath+"/receipts/", wrap(handler.handleReceiptSubresource))
+	mux.HandleFunc(basePath+"/requests", wrap(handler.ListRequests))
+	mux.HandleFunc(basePath+"/requests/", wrap(handler.GetRequest))
+}
+
+func (h *SessionHandler) ResumeConversation(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		writeLifecycleError(w, r, http.StatusMethodNotAllowed, "permission_denied", "only POST is supported")
+		return
+	}
+	owner, ok := trustedOwnerFromRequest(r)
+	if !ok {
+		writeLifecycleError(w, r, http.StatusUnauthorized, "permission_denied", "trusted lifecycle identity is required")
+		return
+	}
+	var request struct {
+		ConversationID string `json:"conversation_id"`
+	}
+	if err := decodeLifecycleBody(w, r, &request); err != nil || request.ConversationID == "" {
+		writeLifecycleError(w, r, http.StatusBadRequest, "conversation_required", "conversation_id is required")
+		return
+	}
+	value, err := h.service.ResumeConversation(r.Context(), sessionsvc.ResumeConversationCommand{
+		Owner: owner, ConversationID: request.ConversationID,
+	})
+	h.writeLifecycleResult(w, r, value, err, http.StatusOK)
+}
+
+func (h *SessionHandler) ListRequests(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		writeLifecycleError(w, r, http.StatusMethodNotAllowed, "permission_denied", "only GET is supported")
+		return
+	}
+	owner, ok := trustedOwnerFromRequest(r)
+	if !ok {
+		writeLifecycleError(w, r, http.StatusUnauthorized, "permission_denied", "trusted lifecycle identity is required")
+		return
+	}
+	limit, _ := strconv.Atoi(r.URL.Query().Get("limit"))
+	items, err := h.service.ListRequests(r.Context(), owner, limit)
+	h.writeLifecycleResult(w, r, requestPage{Entries: items}, err, http.StatusOK)
+}
+
+func (h *SessionHandler) GetRequest(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		writeLifecycleError(w, r, http.StatusMethodNotAllowed, "permission_denied", "only GET is supported")
+		return
+	}
+	owner, ok := trustedOwnerFromRequest(r)
+	if !ok {
+		writeLifecycleError(w, r, http.StatusUnauthorized, "permission_denied", "trusted lifecycle identity is required")
+		return
+	}
+	requestID := pathAfterResource(r.URL.Path, "requests")
+	value, err := h.service.GetRequest(r.Context(), owner, requestID)
+	h.writeLifecycleResult(w, r, value, err, http.StatusOK)
+}
+
+func (h *SessionHandler) CreateConversation(w http.ResponseWriter, r *http.Request) {
+	if r.Method == http.MethodPost {
+		h.EnsureCurrentConversation(w, r)
+		return
+	}
+	if r.Method != http.MethodGet {
+		writeLifecycleError(w, r, http.StatusMethodNotAllowed, "permission_denied", "only GET and POST are supported")
+		return
+	}
+	owner, ok := trustedOwnerFromRequest(r)
+	if !ok {
+		writeLifecycleError(w, r, http.StatusUnauthorized, "permission_denied", "trusted lifecycle identity is required")
+		return
+	}
+	limit, _ := strconv.Atoi(r.URL.Query().Get("limit"))
+	items, err := h.service.ListConversations(r.Context(), owner, limit)
+	h.writeLifecycleResult(w, r, conversationPage{Entries: items}, err, http.StatusOK)
+}
+
+func (h *SessionHandler) CreateNewGeneration(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		writeLifecycleError(w, r, http.StatusMethodNotAllowed, "permission_denied", "only POST is supported")
+		return
+	}
+	owner, ok := trustedOwnerFromRequest(r)
+	if !ok {
+		writeLifecycleError(w, r, http.StatusUnauthorized, "permission_denied", "trusted lifecycle identity is required")
+		return
+	}
+	var request ensureConversationRequest
+	if err := decodeLifecycleBody(w, r, &request); err != nil {
+		writeLifecycleError(w, r, http.StatusBadRequest, "conversation_required", err.Error())
+		return
+	}
+	conversation, err := h.service.CreateNewGeneration(r.Context(), sessionsvc.EnsureConversationCommand{
+		Owner: owner, ExternalConversationKey: request.ExternalConversationKey,
+		IdempotencyKey: request.IdempotencyKey, OneShot: request.OneShot,
+	})
+	h.writeLifecycleResult(w, r, conversation, err, http.StatusCreated)
+}
+
+func (h *SessionHandler) EnsureCurrentConversation(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		writeLifecycleError(w, r, http.StatusMethodNotAllowed, "permission_denied", "only POST is supported")
+		return
+	}
+	owner, ok := trustedOwnerFromRequest(r)
+	if !ok {
+		writeLifecycleError(w, r, http.StatusUnauthorized, "permission_denied", "trusted lifecycle identity is required")
+		return
+	}
+	var request ensureConversationRequest
+	if err := decodeLifecycleBody(w, r, &request); err != nil {
+		writeLifecycleError(w, r, http.StatusBadRequest, "conversation_required", err.Error())
+		return
+	}
+	conversation, err := h.service.EnsureCurrentConversation(r.Context(), sessionsvc.EnsureConversationCommand{
+		Owner: owner, ExternalConversationKey: request.ExternalConversationKey,
+		IdempotencyKey: request.IdempotencyKey, OneShot: request.OneShot,
+	})
+	if err != nil {
+		writeSessionDomainError(w, r, err)
+		return
+	}
+	writeJSON(w, http.StatusCreated, conversation)
+}
+
+func (h *SessionHandler) handleConversationSubresource(w http.ResponseWriter, r *http.Request) {
+	owner, ok := trustedOwnerFromRequest(r)
+	if !ok {
+		writeLifecycleError(w, r, http.StatusUnauthorized, "permission_denied", "trusted lifecycle identity is required")
+		return
+	}
+	path := pathAfterResource(r.URL.Path, "conversations")
+	parts := splitLifecyclePath(path)
+	switch {
+	case len(parts) == 1 && r.Method == http.MethodGet:
+		value, err := h.service.GetConversation(r.Context(), owner, parts[0])
+		h.writeLifecycleResult(w, r, value, err, http.StatusOK)
+	case len(parts) == 1 && r.Method == http.MethodPost && strings.HasSuffix(r.URL.Path, "/close"):
+		writeLifecycleError(w, r, http.StatusNotFound, "conversation_not_found", "invalid conversation path")
+	case len(parts) == 2 && parts[1] == "close" && r.Method == http.MethodPost:
+		var request struct {
+			IdempotencyKey string `json:"idempotency_key"`
+		}
+		if err := decodeLifecycleBody(w, r, &request); err != nil {
+			writeLifecycleError(w, r, http.StatusBadRequest, "conversation_required", err.Error())
+			return
+		}
+		value, err := h.service.CloseConversation(r.Context(), sessionsvc.CloseConversationCommand{
+			Owner: owner, ConversationID: parts[0], IdempotencyKey: request.IdempotencyKey,
+		})
+		h.writeLifecycleResult(w, r, value, err, http.StatusOK)
+	case len(parts) == 2 && parts[1] == "interactions" && r.Method == http.MethodPost:
+		var request startInteractionRequest
+		if err := decodeLifecycleBody(w, r, &request); err != nil {
+			writeLifecycleError(w, r, http.StatusBadRequest, "interaction_required", err.Error())
+			return
+		}
+		value, err := h.service.StartInteraction(r.Context(), sessionsvc.StartInteractionCommand{
+			Owner: owner, ConversationID: parts[0], IdempotencyKey: request.IdempotencyKey,
+			LeaseDuration: time.Duration(request.LeaseSeconds) * time.Second,
+		})
+		h.writeLifecycleResult(w, r, value, err, http.StatusCreated)
+	case len(parts) == 4 && parts[1] == "interactions" && parts[3] == "operations:ensure" && r.Method == http.MethodPost:
+		var request ensureOperationRequest
+		if err := decodeLifecycleBody(w, r, &request); err != nil {
+			writeLifecycleError(w, r, http.StatusBadRequest, "operation_required", err.Error())
+			return
+		}
+		operation, receipt, err := h.service.EnsureOperation(r.Context(), sessionsvc.EnsureOperationCommand{
+			Owner: owner, ConversationID: parts[0], InteractionID: parts[2],
+			OperationKey: request.OperationKey, ToolName: request.ToolName,
+			NormalizedInputHash: request.NormalizedInputHash,
+			ParentOperationID:   request.ParentOperationID,
+			CausationEventIDs:   request.CausationEventIDs, Required: request.Required,
+			LeaseToken: request.LeaseToken, LeaseEpoch: request.LeaseEpoch,
+		})
+		h.writeLifecycleResult(w, r, operationResult{Operation: operation, Receipt: receipt}, err, http.StatusCreated)
+	default:
+		writeLifecycleError(w, r, http.StatusNotFound, "conversation_not_found", "lifecycle route was not found")
+	}
+}
+
+func (h *SessionHandler) handleInteractionSubresource(w http.ResponseWriter, r *http.Request) {
+	owner, ok := trustedOwnerFromRequest(r)
+	if !ok {
+		writeLifecycleError(w, r, http.StatusUnauthorized, "permission_denied", "trusted lifecycle identity is required")
+		return
+	}
+	path := pathAfterResource(r.URL.Path, "interactions")
+	parts := splitLifecyclePath(path)
+	if len(parts) == 1 && r.Method == http.MethodGet {
+		value, err := h.service.GetInteraction(r.Context(), owner, parts[0])
+		h.writeLifecycleResult(w, r, value, err, http.StatusOK)
+		return
+	}
+	if len(parts) != 2 || r.Method != http.MethodPost {
+		writeLifecycleError(w, r, http.StatusNotFound, "interaction_required", "interaction route was not found")
+		return
+	}
+	var request terminalInteractionRequest
+	if err := decodeLifecycleBody(w, r, &request); err != nil {
+		writeLifecycleError(w, r, http.StatusBadRequest, "interaction_required", err.Error())
+		return
+	}
+	status, valid := terminalStatusForAction(parts[1])
+	if !valid {
+		writeLifecycleError(w, r, http.StatusNotFound, "interaction_required", "terminal action was not found")
+		return
+	}
+	value, err := h.service.TerminateInteraction(r.Context(), sessionsvc.TerminateInteractionCommand{
+		Owner: owner, InteractionID: parts[0], Status: status,
+		TerminalIdempotencyKey: request.TerminalIdempotencyKey,
+		LeaseToken:             request.LeaseToken, LeaseEpoch: request.LeaseEpoch,
+		Manifest: sessionvo.ClosureManifest{
+			Version: request.ManifestVersion, AnswerArtifactRef: request.AnswerArtifactRef,
+			Claims: request.Claims, ExpectedOperations: request.ExpectedOperations,
+			ExpectedReceipts: request.ExpectedReceipts, AssemblerDeadline: request.AssemblerDeadline,
+			CompletionReason: request.CompletionReason,
+		},
+	})
+	h.writeLifecycleResult(w, r, value, err, http.StatusOK)
+}
+
+func (h *SessionHandler) handleOperationSubresource(w http.ResponseWriter, r *http.Request) {
+	owner, ok := trustedOwnerFromRequest(r)
+	if !ok {
+		writeLifecycleError(w, r, http.StatusUnauthorized, "permission_denied", "trusted lifecycle identity is required")
+		return
+	}
+	path := pathAfterResource(r.URL.Path, "operations")
+	parts := splitLifecyclePath(path)
+	if len(parts) == 1 && r.Method == http.MethodGet {
+		value, err := h.service.GetOperation(r.Context(), owner, parts[0])
+		h.writeLifecycleResult(w, r, value, err, http.StatusOK)
+		return
+	}
+	if len(parts) == 2 && parts[1] == "attempts" && r.Method == http.MethodPost {
+		var request interactionLeaseRequest
+		if err := decodeLifecycleBody(w, r, &request); err != nil {
+			writeLifecycleError(w, r, http.StatusBadRequest, "operation_required", err.Error())
+			return
+		}
+		operation, receipt, err := h.service.StartOperationAttempt(r.Context(), sessionsvc.StartAttemptCommand{
+			Owner: owner, OperationID: parts[0],
+			LeaseToken: request.LeaseToken, LeaseEpoch: request.LeaseEpoch,
+		})
+		h.writeLifecycleResult(w, r, operationResult{Operation: operation, Receipt: receipt}, err, http.StatusCreated)
+		return
+	}
+	if len(parts) != 3 || parts[1] != "attempts" || r.Method != http.MethodPost {
+		writeLifecycleError(w, r, http.StatusNotFound, "operation_required", "operation route was not found")
+		return
+	}
+	attemptText, action, found := strings.Cut(parts[2], ":")
+	if !found {
+		writeLifecycleError(w, r, http.StatusNotFound, "operation_required", "attempt action was not found")
+		return
+	}
+	attempt, err := strconv.ParseUint(attemptText, 10, 32)
+	if err != nil {
+		writeLifecycleError(w, r, http.StatusBadRequest, "operation_required", "attempt must be a positive integer")
+		return
+	}
+	var request finishAttemptRequest
+	if err := decodeLifecycleBody(w, r, &request); err != nil {
+		writeLifecycleError(w, r, http.StatusBadRequest, "operation_required", err.Error())
+		return
+	}
+	command := sessionsvc.FinishAttemptCommand{
+		Owner: owner, OperationID: parts[0], Attempt: uint32(attempt),
+		ReceiptID: request.ReceiptID, PayloadHash: request.PayloadHash,
+		EvidenceDurability: request.EvidenceDurability, Retryable: request.Retryable,
+		RequestID: request.RequestID, TraceID: request.TraceID,
+		ObservedEvidenceRefs: request.ObservedEvidenceRefs,
+		BusinessRefs:         request.BusinessRefs,
+		ArtifactRefs:         request.ArtifactRefs,
+		PartialReasons:       request.PartialReasons,
+	}
+	var operation sessionvo.Operation
+	var receipt sessionvo.Receipt
+	if action == "complete" {
+		operation, receipt, err = h.service.CompleteOperationAttempt(r.Context(), command)
+	} else if action == "fail" {
+		operation, receipt, err = h.service.FailOperationAttempt(r.Context(), command)
+	} else {
+		writeLifecycleError(w, r, http.StatusNotFound, "operation_required", "attempt action was not found")
+		return
+	}
+	h.writeLifecycleResult(w, r, operationResult{Operation: operation, Receipt: receipt}, err, http.StatusOK)
+}
+
+func (h *SessionHandler) handleReceiptSubresource(w http.ResponseWriter, r *http.Request) {
+	owner, ok := trustedOwnerFromRequest(r)
+	if !ok {
+		writeLifecycleError(w, r, http.StatusUnauthorized, "permission_denied", "trusted lifecycle identity is required")
+		return
+	}
+	path := pathAfterResource(r.URL.Path, "receipts")
+	parts := splitLifecyclePath(path)
+	if len(parts) != 1 || r.Method != http.MethodGet {
+		writeLifecycleError(w, r, http.StatusNotFound, "operation_required", "receipt route was not found")
+		return
+	}
+	value, err := h.service.GetReceipt(r.Context(), owner, parts[0])
+	h.writeLifecycleResult(w, r, value, err, http.StatusOK)
+}
+
+func (h *SessionHandler) writeLifecycleResult(w http.ResponseWriter, r *http.Request, value any, err error, status int) {
+	if err != nil {
+		writeSessionDomainError(w, r, err)
+		return
+	}
+	writeJSON(w, status, value)
+}
+
+func splitLifecyclePath(path string) []string {
+	raw := strings.Split(strings.Trim(path, "/"), "/")
+	result := make([]string, 0, len(raw))
+	for _, item := range raw {
+		if item != "" {
+			result = append(result, item)
+		}
+	}
+	return result
+}
+
+func pathAfterResource(path, resource string) string {
+	marker := "/" + resource + "/"
+	index := strings.Index(path, marker)
+	if index < 0 {
+		return ""
+	}
+	return path[index+len(marker):]
+}
+
+func terminalStatusForAction(action string) (sessionvo.InteractionStatus, bool) {
+	switch action {
+	case "complete":
+		return sessionvo.InteractionCompleted, true
+	case "fail":
+		return sessionvo.InteractionFailed, true
+	case "cancel":
+		return sessionvo.InteractionCanceled, true
+	case "handoff":
+		return sessionvo.InteractionHandedOff, true
+	default:
+		return "", false
+	}
+}
+
+func trustedOwnerFromRequest(r *http.Request) (sessionvo.Owner, bool) {
+	owner := sessionvo.Owner{
+		TenantID:               strings.TrimSpace(r.Header.Get("X-BKN-Tenant-ID")),
+		BusinessDomainID:       strings.TrimSpace(r.Header.Get("X-Business-Domain-ID")),
+		ApplicationPrincipalID: strings.TrimSpace(r.Header.Get("X-BKN-Application-Principal-ID")),
+		EffectiveSubjectType:   sessionvo.SubjectType(strings.TrimSpace(r.Header.Get("X-BKN-Effective-Subject-Type"))),
+		EffectiveSubjectID:     strings.TrimSpace(r.Header.Get("X-BKN-Effective-Subject-ID")),
+		DelegationID:           strings.TrimSpace(r.Header.Get("X-BKN-Delegation-ID")),
+	}
+	valid := owner.TenantID != "" && owner.BusinessDomainID != "" &&
+		owner.ApplicationPrincipalID != "" && owner.EffectiveSubjectID != "" &&
+		(owner.EffectiveSubjectType == sessionvo.SubjectUser || owner.EffectiveSubjectType == sessionvo.SubjectService)
+	return owner, valid
+}
+
+func decodeLifecycleBody(w http.ResponseWriter, r *http.Request, target any) error {
+	decoder := json.NewDecoder(http.MaxBytesReader(w, r.Body, maxLifecycleBodyBytes))
+	decoder.DisallowUnknownFields()
+	if err := decoder.Decode(target); err != nil {
+		return errors.New("request body does not match the lifecycle contract")
+	}
+	if err := decoder.Decode(&struct{}{}); !errors.Is(err, io.EOF) {
+		return errors.New("request body must contain one JSON object")
+	}
+	return nil
+}
+
+func writeSessionDomainError(w http.ResponseWriter, r *http.Request, err error) {
+	var domainErr *sessionsvc.DomainError
+	if !errors.As(err, &domainErr) {
+		writeLifecycleError(w, r, http.StatusInternalServerError, "internal_error", "lifecycle request failed")
+		return
+	}
+	status, action, retryable := lifecycleErrorContract(domainErr.Code)
+	writeJSON(w, status, lifecycleErrorEnvelope{Error: lifecycleError{
+		Code: string(domainErr.Code), Message: domainErr.Message,
+		CurrentStatus: domainErr.CurrentStatus, Retryable: retryable,
+		RequiredAction: action, RequestID: requestIDFromRequest(r),
+	}})
+}
+
+func writeLifecycleError(w http.ResponseWriter, r *http.Request, status int, code, message string) {
+	_, action, retryable := lifecycleErrorContract(sessionsvc.ErrorCode(code))
+	writeJSON(w, status, lifecycleErrorEnvelope{Error: lifecycleError{
+		Code: code, Message: message, Retryable: retryable,
+		RequiredAction: action, RequestID: requestIDFromRequest(r),
+	}})
+}
+
+func lifecycleErrorContract(code sessionsvc.ErrorCode) (int, string, bool) {
+	switch code {
+	case sessionsvc.CodeConversationRequired:
+		return http.StatusBadRequest, "create_conversation", false
+	case sessionsvc.CodeConversationNotFound:
+		return http.StatusNotFound, "create_or_resume_conversation", false
+	case sessionsvc.CodeConversationClosed:
+		return http.StatusConflict, "create_conversation", false
+	case sessionsvc.CodeConversationExpired:
+		return http.StatusConflict, "create_or_resume_conversation", false
+	case sessionsvc.CodeConversationOwnerMismatch:
+		return http.StatusForbidden, "use_authorized_conversation", false
+	case sessionsvc.CodeInteractionRequired:
+		return http.StatusBadRequest, "start_interaction", false
+	case sessionsvc.CodeInteractionInProgress:
+		return http.StatusConflict, "complete_or_cancel_interaction", false
+	case sessionsvc.CodeInteractionTerminal:
+		return http.StatusConflict, "start_interaction", false
+	case sessionsvc.CodeOperationRequired:
+		return http.StatusBadRequest, "ensure_operation", false
+	case sessionsvc.CodeIdempotencyConflict:
+		return http.StatusConflict, "use_new_idempotency_key", false
+	case sessionsvc.CodeReceiptPending:
+		return http.StatusConflict, "poll_receipt", true
+	case sessionsvc.CodeTerminalConflict:
+		return http.StatusConflict, "get_interaction", false
+	case sessionsvc.CodeClosureManifestInvalid:
+		return http.StatusUnprocessableEntity, "fix_closure_manifest", false
+	case sessionsvc.CodeResourceNotDisclosed:
+		return http.StatusNotFound, "verify_scope_or_identifier", false
+	case "permission_denied":
+		return http.StatusForbidden, "request_authorization", false
+	default:
+		return http.StatusInternalServerError, "", false
+	}
+}
+
+func requestIDFromRequest(r *http.Request) string {
+	if value := strings.TrimSpace(r.Header.Get("X-Request-ID")); value != "" {
+		return value
+	}
+	return strings.TrimSpace(r.Header.Get("x-bkn-request-id"))
+}

--- a/bkn-trace/agent-observability/src/driveradapter/api/httphandler/session_handler.go
+++ b/bkn-trace/agent-observability/src/driveradapter/api/httphandler/session_handler.go
@@ -41,12 +41,6 @@ type ensureConversationRequest struct {
 	ExternalConversationKey string `json:"external_conversation_key"`
 	IdempotencyKey          string `json:"idempotency_key"`
 	OneShot                 bool   `json:"one_shot"`
-	TenantID                string `json:"tenant_id,omitempty"`
-	BusinessDomainID        string `json:"business_domain_id,omitempty"`
-	ApplicationPrincipalID  string `json:"application_principal_id,omitempty"`
-	EffectiveSubjectType    string `json:"effective_subject_type,omitempty"`
-	EffectiveSubjectID      string `json:"effective_subject_id,omitempty"`
-	DelegationID            string `json:"delegation_id,omitempty"`
 }
 
 type startInteractionRequest struct {

--- a/bkn-trace/agent-observability/src/driveradapter/api/httphandler/session_handler_test.go
+++ b/bkn-trace/agent-observability/src/driveradapter/api/httphandler/session_handler_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/openbkn-ai/bkn-foundry/bkn-trace/agent-observability/src/driveradapter/api/httphandler"
 )
 
-func TestEnsureConversationUsesTrustedHeadersAndIgnoresBodyIdentity(t *testing.T) {
+func TestEnsureConversationRejectsBodyIdentityFields(t *testing.T) {
 	t.Parallel()
 
 	handler := httphandler.NewSessionHandler(sessionsvc.New(sessionstore.New(), sessionsvc.Options{}))
@@ -29,15 +29,13 @@ func TestEnsureConversationUsesTrustedHeadersAndIgnoresBodyIdentity(t *testing.T
 
 	handler.EnsureCurrentConversation(response, request)
 
-	if response.Code != http.StatusCreated {
-		t.Fatalf("expected 201, got %d: %s", response.Code, response.Body.String())
+	if response.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d: %s", response.Code, response.Body.String())
 	}
-	var conversation sessionvo.Conversation
-	if err := json.Unmarshal(response.Body.Bytes(), &conversation); err != nil {
-		t.Fatalf("decode response: %v", err)
-	}
-	if conversation.Owner.TenantID != "tenant-1" || conversation.Owner.EffectiveSubjectID != "user-1" {
-		t.Fatalf("body identity overrode trusted headers: %#v", conversation.Owner)
+	var envelope lifecycleTestErrorEnvelope
+	decodeLifecycleResponse(t, response, &envelope)
+	if envelope.Error.Code != "conversation_required" {
+		t.Fatalf("unexpected identity-field rejection: %#v", envelope.Error)
 	}
 }
 

--- a/bkn-trace/agent-observability/src/driveradapter/api/httphandler/session_handler_test.go
+++ b/bkn-trace/agent-observability/src/driveradapter/api/httphandler/session_handler_test.go
@@ -1,0 +1,219 @@
+package httphandler_test
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/openbkn-ai/bkn-foundry/bkn-trace/agent-observability/src/domain/service/sessionsvc"
+	"github.com/openbkn-ai/bkn-foundry/bkn-trace/agent-observability/src/domain/valueobject/sessionvo"
+	"github.com/openbkn-ai/bkn-foundry/bkn-trace/agent-observability/src/drivenadapter/memoryaccess/sessionstore"
+	"github.com/openbkn-ai/bkn-foundry/bkn-trace/agent-observability/src/driveradapter/api/httphandler"
+)
+
+func TestEnsureConversationUsesTrustedHeadersAndIgnoresBodyIdentity(t *testing.T) {
+	t.Parallel()
+
+	handler := httphandler.NewSessionHandler(sessionsvc.New(sessionstore.New(), sessionsvc.Options{}))
+	body := []byte(`{
+		"external_conversation_key":"cursor-thread-42",
+		"idempotency_key":"ensure-42",
+		"tenant_id":"forged-tenant",
+		"effective_subject_id":"forged-user"
+	}`)
+	request := httptest.NewRequest(http.MethodPost, "/api/agent-observability/v1/conversations:ensure-current", bytes.NewReader(body))
+	setTrustedOwnerHeaders(request)
+	response := httptest.NewRecorder()
+
+	handler.EnsureCurrentConversation(response, request)
+
+	if response.Code != http.StatusCreated {
+		t.Fatalf("expected 201, got %d: %s", response.Code, response.Body.String())
+	}
+	var conversation sessionvo.Conversation
+	if err := json.Unmarshal(response.Body.Bytes(), &conversation); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if conversation.Owner.TenantID != "tenant-1" || conversation.Owner.EffectiveSubjectID != "user-1" {
+		t.Fatalf("body identity overrode trusted headers: %#v", conversation.Owner)
+	}
+}
+
+func TestLifecycleRequestWithoutTrustedOwnerIsRejectedWithGuidance(t *testing.T) {
+	t.Parallel()
+
+	handler := httphandler.NewSessionHandler(sessionsvc.New(sessionstore.New(), sessionsvc.Options{}))
+	request := httptest.NewRequest(http.MethodPost, "/api/agent-observability/v1/conversations:ensure-current",
+		bytes.NewReader([]byte(`{"external_conversation_key":"thread"}`)))
+	response := httptest.NewRecorder()
+
+	handler.EnsureCurrentConversation(response, request)
+
+	if response.Code != http.StatusUnauthorized {
+		t.Fatalf("expected 401, got %d: %s", response.Code, response.Body.String())
+	}
+	var envelope struct {
+		Error struct {
+			Code           string `json:"code"`
+			RequiredAction string `json:"required_action"`
+		} `json:"error"`
+	}
+	if err := json.Unmarshal(response.Body.Bytes(), &envelope); err != nil {
+		t.Fatalf("decode error: %v", err)
+	}
+	if envelope.Error.Code != "permission_denied" || envelope.Error.RequiredAction != "request_authorization" {
+		t.Fatalf("unexpected guided error: %#v", envelope.Error)
+	}
+}
+
+func TestLifecycleValueValidationReturnsRegisteredGuidedError(t *testing.T) {
+	t.Parallel()
+
+	handler := httphandler.NewSessionHandler(sessionsvc.New(sessionstore.New(), sessionsvc.Options{}))
+	request := httptest.NewRequest(
+		http.MethodPost,
+		"/api/agent-observability/v1/conversations:ensure-current",
+		bytes.NewReader([]byte(`{"external_conversation_key":""}`)),
+	)
+	setTrustedOwnerHeaders(request)
+	response := httptest.NewRecorder()
+
+	handler.EnsureCurrentConversation(response, request)
+
+	if response.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d: %s", response.Code, response.Body.String())
+	}
+	var envelope lifecycleTestErrorEnvelope
+	decodeLifecycleResponse(t, response, &envelope)
+	if envelope.Error.Code != "conversation_required" ||
+		envelope.Error.RequiredAction != "create_conversation" {
+		t.Fatalf("unexpected guided error: %#v", envelope.Error)
+	}
+}
+
+func TestManagedLifecycleHTTPWorkflow(t *testing.T) {
+	t.Parallel()
+
+	handler := httphandler.NewSessionHandler(sessionsvc.New(sessionstore.New(), sessionsvc.Options{}))
+	mux := http.NewServeMux()
+	httphandler.RegisterSessionRoutes(mux, "/api/agent-observability/v1", handler)
+
+	conversationResponse := performLifecycleRequest(t, mux, http.MethodPost,
+		"/api/agent-observability/v1/conversations:ensure-current",
+		`{"external_conversation_key":"agent-thread-1","idempotency_key":"ensure-1"}`)
+	if conversationResponse.Code != http.StatusCreated {
+		t.Fatalf("ensure conversation: %d %s", conversationResponse.Code, conversationResponse.Body.String())
+	}
+	var conversation sessionvo.Conversation
+	decodeLifecycleResponse(t, conversationResponse, &conversation)
+
+	interactionResponse := performLifecycleRequest(t, mux, http.MethodPost,
+		"/api/agent-observability/v1/conversations/"+conversation.ID+"/interactions",
+		`{"idempotency_key":"interaction-1","lease_seconds":300}`)
+	if interactionResponse.Code != http.StatusCreated {
+		t.Fatalf("start interaction: %d %s", interactionResponse.Code, interactionResponse.Body.String())
+	}
+	var interaction sessionvo.Interaction
+	decodeLifecycleResponse(t, interactionResponse, &interaction)
+
+	operationResponse := performLifecycleRequest(t, mux, http.MethodPost,
+		"/api/agent-observability/v1/conversations/"+conversation.ID+"/interactions/"+interaction.ID+"/operations:ensure",
+		`{"operation_key":"query-orders","tool_name":"ontology-query","normalized_input_hash":"sha256:input","required":true,"lease_token":"`+
+			interaction.LeaseToken+`","lease_epoch":1}`)
+	if operationResponse.Code != http.StatusCreated {
+		t.Fatalf("ensure operation: %d %s", operationResponse.Code, operationResponse.Body.String())
+	}
+	var operationResult struct {
+		Operation sessionvo.Operation `json:"operation"`
+		Receipt   sessionvo.Receipt   `json:"receipt"`
+	}
+	decodeLifecycleResponse(t, operationResponse, &operationResult)
+
+	receiptResponse := performLifecycleRequest(t, mux, http.MethodPost,
+		"/api/agent-observability/v1/operations/"+operationResult.Operation.ID+"/attempts/1:complete",
+		`{"receipt_id":"`+operationResult.Receipt.ID+`","payload_hash":"sha256:result","evidence_durability":"durable","request_id":"req-1","trace_id":"4b3d59daeff5bfbb23d46c47a5051ec9"}`)
+	if receiptResponse.Code != http.StatusOK {
+		t.Fatalf("complete receipt: %d %s", receiptResponse.Code, receiptResponse.Body.String())
+	}
+
+	completeResponse := performLifecycleRequest(t, mux, http.MethodPost,
+		"/api/agent-observability/v1/interactions/"+interaction.ID+"/complete",
+		`{"terminal_idempotency_key":"terminal-1","lease_token":"`+interaction.LeaseToken+`","lease_epoch":1,"completion_manifest_version":"1","completion_reason":"answer_returned","expected_operations":[{"operation_id":"`+
+			operationResult.Operation.ID+`","required":true}],"expected_receipts":[{"receipt_id":"`+
+			operationResult.Receipt.ID+`","required":true}]}`)
+	if completeResponse.Code != http.StatusOK {
+		t.Fatalf("complete interaction: %d %s", completeResponse.Code, completeResponse.Body.String())
+	}
+	var completed sessionvo.Interaction
+	decodeLifecycleResponse(t, completeResponse, &completed)
+	if completed.ExecutionStatus != sessionvo.InteractionCompleted || completed.EvidenceStatus != sessionvo.EvidenceComplete {
+		t.Fatalf("unexpected completed interaction: %#v", completed)
+	}
+
+	getResponse := performLifecycleRequest(t, mux, http.MethodGet,
+		"/api/agent-observability/v1/interactions/"+interaction.ID, "")
+	if getResponse.Code != http.StatusOK {
+		t.Fatalf("get interaction: %d %s", getResponse.Code, getResponse.Body.String())
+	}
+}
+
+func TestConversationListUsesOwnerTupleAsRealQueryScope(t *testing.T) {
+	t.Parallel()
+
+	service := sessionsvc.New(sessionstore.New(), sessionsvc.Options{})
+	handler := httphandler.NewSessionHandler(service)
+	mux := http.NewServeMux()
+	httphandler.RegisterSessionRoutes(mux, "/api/agent-observability/v1", handler)
+	performLifecycleRequest(t, mux, http.MethodPost,
+		"/api/agent-observability/v1/conversations:ensure-current",
+		`{"external_conversation_key":"visible","idempotency_key":"one"}`)
+
+	request := httptest.NewRequest(http.MethodGet, "/api/agent-observability/v1/conversations?limit=20", nil)
+	setTrustedOwnerHeaders(request)
+	response := httptest.NewRecorder()
+	mux.ServeHTTP(response, request)
+	if response.Code != http.StatusOK {
+		t.Fatalf("list conversations: %d %s", response.Code, response.Body.String())
+	}
+	var result struct {
+		Entries []sessionvo.Conversation `json:"entries"`
+	}
+	decodeLifecycleResponse(t, response, &result)
+	if len(result.Entries) != 1 || result.Entries[0].ExternalConversationKey != "visible" {
+		t.Fatalf("unexpected owner-scoped list: %#v", result.Entries)
+	}
+}
+
+type lifecycleTestErrorEnvelope struct {
+	Error struct {
+		Code           string `json:"code"`
+		RequiredAction string `json:"required_action"`
+	} `json:"error"`
+}
+
+func setTrustedOwnerHeaders(request *http.Request) {
+	request.Header.Set("X-BKN-Tenant-ID", "tenant-1")
+	request.Header.Set("X-Business-Domain-ID", "domain-1")
+	request.Header.Set("X-BKN-Application-Principal-ID", "app-1")
+	request.Header.Set("X-BKN-Effective-Subject-Type", "user")
+	request.Header.Set("X-BKN-Effective-Subject-ID", "user-1")
+}
+
+func performLifecycleRequest(t *testing.T, handler http.Handler, method, path, body string) *httptest.ResponseRecorder {
+	t.Helper()
+	request := httptest.NewRequest(method, path, bytes.NewBufferString(body))
+	setTrustedOwnerHeaders(request)
+	request.Header.Set("Content-Type", "application/json")
+	response := httptest.NewRecorder()
+	handler.ServeHTTP(response, request)
+	return response
+}
+
+func decodeLifecycleResponse(t *testing.T, response *httptest.ResponseRecorder, target any) {
+	t.Helper()
+	if err := json.Unmarshal(response.Body.Bytes(), target); err != nil {
+		t.Fatalf("decode response %q: %v", response.Body.String(), err)
+	}
+}

--- a/bkn-trace/agent-observability/src/driveradapter/api/httphandler/summary_handler.go
+++ b/bkn-trace/agent-observability/src/driveradapter/api/httphandler/summary_handler.go
@@ -34,7 +34,6 @@ import (
 // @Failure 400 {object} rdto.ErrorResponse
 // @Failure 401 {object} rdto.ErrorResponse
 // @Failure 500 {object} rdto.ErrorResponse
-// @Router /requests [get]
 func (h *EvidenceHandler) ListRequests(w http.ResponseWriter, r *http.Request) {
 	ensureResponseTraceID(w, r)
 	if r.Method != http.MethodGet {
@@ -64,7 +63,6 @@ func (h *EvidenceHandler) ListRequests(w http.ResponseWriter, r *http.Request) {
 // @Failure 401 {object} rdto.ErrorResponse
 // @Failure 404 {object} rdto.ErrorResponse
 // @Failure 500 {object} rdto.ErrorResponse
-// @Router /requests/{request_id} [get]
 func (h *EvidenceHandler) GetRequestSummary(w http.ResponseWriter, r *http.Request) {
 	ensureResponseTraceID(w, r)
 	if r.Method != http.MethodGet {
@@ -103,7 +101,6 @@ func (h *EvidenceHandler) GetRequestSummary(w http.ResponseWriter, r *http.Reque
 // @Failure 401 {object} rdto.ErrorResponse
 // @Failure 404 {object} rdto.ErrorResponse
 // @Failure 500 {object} rdto.ErrorResponse
-// @Router /interactions/{interaction_id} [get]
 func (h *EvidenceHandler) GetInteractionSummary(w http.ResponseWriter, r *http.Request) {
 	ensureResponseTraceID(w, r)
 	if r.Method != http.MethodGet {

--- a/bkn-trace/agent-observability/src/infra/coremetrics/registry.go
+++ b/bkn-trace/agent-observability/src/infra/coremetrics/registry.go
@@ -1,0 +1,83 @@
+package coremetrics
+
+import (
+	"fmt"
+	"math"
+	"net/http"
+	"sort"
+	"sync"
+	"sync/atomic"
+
+	"github.com/openbkn-ai/bkn-foundry/bkn-trace/agent-observability/src/port/driven/icoremetrics"
+)
+
+var metricKinds = map[string]string{
+	icoremetrics.ConversationsTotal:              "counter",
+	icoremetrics.InteractionsTotal:               "counter",
+	icoremetrics.SessionRejectionsTotal:          "counter",
+	icoremetrics.InteractionsAbandonedTotal:      "counter",
+	icoremetrics.SessionStoreErrorsTotal:         "counter",
+	icoremetrics.SessionTransitionConflictsTotal: "counter",
+	icoremetrics.EvidenceIngestTotal:             "counter",
+	icoremetrics.EvidenceHashConflictsTotal:      "counter",
+	icoremetrics.ProjectionErrorsTotal:           "counter",
+	icoremetrics.ProjectionLagSeconds:            "gauge",
+	icoremetrics.ProjectionReady:                 "gauge",
+	icoremetrics.AssemblyLagSeconds:              "gauge",
+}
+
+type Registry struct {
+	counters sync.Map
+	gauges   sync.Map
+}
+
+func New() *Registry {
+	return &Registry{}
+}
+
+func (r *Registry) Increment(name string) {
+	r.Add(name, 1)
+}
+
+func (r *Registry) Add(name string, delta uint64) {
+	if metricKinds[name] != "counter" {
+		return
+	}
+	value, _ := r.counters.LoadOrStore(name, &atomic.Uint64{})
+	value.(*atomic.Uint64).Add(delta)
+}
+
+func (r *Registry) Set(name string, value float64) {
+	if metricKinds[name] != "gauge" {
+		return
+	}
+	stored, _ := r.gauges.LoadOrStore(name, &atomic.Uint64{})
+	stored.(*atomic.Uint64).Store(math.Float64bits(value))
+}
+
+func (r *Registry) ServeHTTP(w http.ResponseWriter, _ *http.Request) {
+	w.Header().Set("Content-Type", "text/plain; version=0.0.4; charset=utf-8")
+	names := make([]string, 0, len(metricKinds))
+	for name := range metricKinds {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	for _, name := range names {
+		_, _ = fmt.Fprintf(w, "# TYPE %s %s\n%s %s\n", name, metricKinds[name], name, r.value(name))
+	}
+}
+
+func (r *Registry) value(name string) string {
+	if metricKinds[name] == "counter" {
+		if value, ok := r.counters.Load(name); ok {
+			return fmt.Sprintf("%d", value.(*atomic.Uint64).Load())
+		}
+		return "0"
+	}
+	if value, ok := r.gauges.Load(name); ok {
+		return fmt.Sprintf("%g", math.Float64frombits(value.(*atomic.Uint64).Load()))
+	}
+	return "0"
+}
+
+var _ http.Handler = (*Registry)(nil)

--- a/bkn-trace/agent-observability/src/infra/coremetrics/registry_test.go
+++ b/bkn-trace/agent-observability/src/infra/coremetrics/registry_test.go
@@ -1,0 +1,31 @@
+package coremetrics_test
+
+import (
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/openbkn-ai/bkn-foundry/bkn-trace/agent-observability/src/infra/coremetrics"
+	"github.com/openbkn-ai/bkn-foundry/bkn-trace/agent-observability/src/port/driven/icoremetrics"
+)
+
+func TestRegistryExportsFrozenCoreMetricNames(t *testing.T) {
+	t.Parallel()
+
+	registry := coremetrics.New()
+	registry.Increment(icoremetrics.ConversationsTotal)
+	registry.Set(icoremetrics.ProjectionLagSeconds, 2.5)
+	response := httptest.NewRecorder()
+	registry.ServeHTTP(response, httptest.NewRequest("GET", "/metrics", nil))
+
+	body := response.Body.String()
+	for _, expected := range []string{
+		"bkn_trace_conversations_total 1",
+		"bkn_trace_projection_lag_seconds 2.5",
+		"bkn_trace_assembly_lag_seconds 0",
+	} {
+		if !strings.Contains(body, expected) {
+			t.Fatalf("metrics response is missing %q:\n%s", expected, body)
+		}
+	}
+}

--- a/bkn-trace/agent-observability/src/infra/opensearch/client.go
+++ b/bkn-trace/agent-observability/src/infra/opensearch/client.go
@@ -25,6 +25,40 @@ type Document struct {
 	PrimaryTerm int64
 }
 
+type MultiGetDocument struct {
+	ID     string
+	Found  bool
+	Source []byte
+}
+
+type StatusError struct {
+	Operation  string
+	StatusCode int
+	Body       string
+}
+
+func (e *StatusError) Error() string {
+	return fmt.Sprintf(
+		"opensearch %s failed with status %d: %s",
+		e.Operation, e.StatusCode, e.Body,
+	)
+}
+
+func IsPermanentStatusError(err error) bool {
+	var statusError *StatusError
+	if !errors.As(err, &statusError) {
+		return false
+	}
+	switch statusError.StatusCode {
+	case http.StatusRequestTimeout, http.StatusConflict, http.StatusTooEarly,
+		http.StatusTooManyRequests:
+		return false
+	default:
+		return statusError.StatusCode >= http.StatusBadRequest &&
+			statusError.StatusCode < http.StatusInternalServerError
+	}
+}
+
 type Client struct {
 	baseURL    string
 	auth       AuthConfig
@@ -88,8 +122,81 @@ func (c *Client) Search(ctx context.Context, index string, query []byte) ([]byte
 }
 
 func (c *Client) IndexDocument(ctx context.Context, index string, documentID string, body []byte) ([]byte, error) {
-	requestURL := fmt.Sprintf("%s/%s/_doc/%s", c.baseURL, strings.TrimLeft(index, "/"), strings.TrimLeft(documentID, "/"))
+	requestURL := fmt.Sprintf("%s/%s/_doc/%s", c.baseURL, strings.TrimLeft(index, "/"), url.PathEscape(strings.TrimLeft(documentID, "/")))
 	return c.putDocument(ctx, requestURL, body)
+}
+
+func (c *Client) IndexDocumentVersion(
+	ctx context.Context,
+	index string,
+	documentID string,
+	version uint64,
+	body []byte,
+) ([]byte, error) {
+	requestURL := fmt.Sprintf(
+		"%s/%s/_doc/%s?version=%d&version_type=external",
+		c.baseURL,
+		strings.TrimLeft(index, "/"),
+		url.PathEscape(strings.TrimLeft(documentID, "/")),
+		version,
+	)
+	return c.putDocument(ctx, requestURL, body)
+}
+
+func (c *Client) MultiGetDocuments(
+	ctx context.Context,
+	index string,
+	documentIDs []string,
+) ([]MultiGetDocument, error) {
+	body, err := json.Marshal(map[string]any{"ids": documentIDs})
+	if err != nil {
+		return nil, fmt.Errorf("encode opensearch multi-get request: %w", err)
+	}
+	requestURL := fmt.Sprintf(
+		"%s/%s/_mget", c.baseURL, strings.TrimLeft(index, "/"),
+	)
+	req, err := http.NewRequestWithContext(
+		ctx, http.MethodPost, requestURL, bytes.NewReader(body),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("create opensearch multi-get request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	if c.auth.Enabled {
+		req.SetBasicAuth(c.auth.Username, c.auth.Password)
+	}
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("execute opensearch multi-get request: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	responseBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("read opensearch multi-get response: %w", err)
+	}
+	if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
+		return nil, fmt.Errorf(
+			"opensearch multi-get failed with status %d: %s",
+			resp.StatusCode, string(responseBody),
+		)
+	}
+	var response struct {
+		Documents []struct {
+			ID     string          `json:"_id"`
+			Found  bool            `json:"found"`
+			Source json.RawMessage `json:"_source"`
+		} `json:"docs"`
+	}
+	if err := json.Unmarshal(responseBody, &response); err != nil {
+		return nil, fmt.Errorf("decode opensearch multi-get response: %w", err)
+	}
+	documents := make([]MultiGetDocument, 0, len(response.Documents))
+	for _, document := range response.Documents {
+		documents = append(documents, MultiGetDocument{
+			ID: document.ID, Found: document.Found, Source: document.Source,
+		})
+	}
+	return documents, nil
 }
 
 func (c *Client) CreateDocument(ctx context.Context, index string, documentID string, body []byte) ([]byte, error) {
@@ -166,7 +273,9 @@ func (c *Client) putDocument(ctx context.Context, requestURL string, body []byte
 		return nil, ErrVersionConflict
 	}
 	if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
-		return nil, fmt.Errorf("opensearch index failed with status %d: %s", resp.StatusCode, string(respBody))
+		return nil, &StatusError{
+			Operation: "index", StatusCode: resp.StatusCode, Body: string(respBody),
+		}
 	}
 
 	return respBody, nil
@@ -206,6 +315,87 @@ func (c *Client) EnsureIndex(ctx context.Context, index string, mapping []byte) 
 	}
 
 	return fmt.Errorf("opensearch create-index failed with status %d: %s", resp.StatusCode, string(body))
+}
+
+func (c *Client) CountDocuments(ctx context.Context, index string) (uint64, error) {
+	body, err := c.Search(ctx, index, []byte(`{"size":0,"track_total_hits":true}`))
+	if err != nil {
+		return 0, err
+	}
+	var response struct {
+		Hits struct {
+			Total struct {
+				Value uint64 `json:"value"`
+			} `json:"total"`
+		} `json:"hits"`
+	}
+	if err := json.Unmarshal(body, &response); err != nil {
+		return 0, fmt.Errorf("decode opensearch count response: %w", err)
+	}
+	return response.Hits.Total.Value, nil
+}
+
+func (c *Client) RefreshIndex(ctx context.Context, index string) error {
+	requestURL := fmt.Sprintf(
+		"%s/%s/_refresh", c.baseURL, strings.TrimLeft(index, "/"),
+	)
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, requestURL, nil)
+	if err != nil {
+		return fmt.Errorf("create opensearch refresh request: %w", err)
+	}
+	if c.auth.Enabled {
+		req.SetBasicAuth(c.auth.Username, c.auth.Password)
+	}
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("execute opensearch refresh request: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return fmt.Errorf("read opensearch refresh response: %w", err)
+	}
+	if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
+		return fmt.Errorf(
+			"opensearch refresh failed with status %d: %s",
+			resp.StatusCode, string(body),
+		)
+	}
+	return nil
+}
+
+func (c *Client) SwitchAlias(ctx context.Context, alias, index string) error {
+	body, err := json.Marshal(map[string]any{
+		"actions": []map[string]any{
+			{"remove": map[string]any{"index": "*", "alias": alias, "must_exist": false}},
+			{"add": map[string]any{"index": index, "alias": alias}},
+		},
+	})
+	if err != nil {
+		return err
+	}
+	requestURL := c.baseURL + "/_aliases"
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, requestURL, bytes.NewReader(body))
+	if err != nil {
+		return fmt.Errorf("create opensearch alias request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	if c.auth.Enabled {
+		req.SetBasicAuth(c.auth.Username, c.auth.Password)
+	}
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("execute opensearch alias request: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	responseBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return fmt.Errorf("read opensearch alias response: %w", err)
+	}
+	if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
+		return fmt.Errorf("opensearch alias switch failed with status %d: %s", resp.StatusCode, string(responseBody))
+	}
+	return nil
 }
 
 func (c *Client) ensureMapping(ctx context.Context, index string, indexDefinition []byte) error {

--- a/bkn-trace/agent-observability/src/port/driven/icoremetrics/port.go
+++ b/bkn-trace/agent-observability/src/port/driven/icoremetrics/port.go
@@ -1,0 +1,28 @@
+package icoremetrics
+
+const (
+	ConversationsTotal              = "bkn_trace_conversations_total"
+	InteractionsTotal               = "bkn_trace_interactions_total"
+	SessionRejectionsTotal          = "bkn_trace_session_rejections_total"
+	InteractionsAbandonedTotal      = "bkn_trace_interactions_abandoned_total"
+	SessionStoreErrorsTotal         = "bkn_trace_session_store_errors_total"
+	SessionTransitionConflictsTotal = "bkn_trace_session_transition_conflicts_total"
+	EvidenceIngestTotal             = "bkn_trace_evidence_ingest_total"
+	EvidenceHashConflictsTotal      = "bkn_trace_evidence_hash_conflicts_total"
+	ProjectionErrorsTotal           = "bkn_trace_projection_errors_total"
+	ProjectionLagSeconds            = "bkn_trace_projection_lag_seconds"
+	ProjectionReady                 = "bkn_trace_projection_ready"
+	AssemblyLagSeconds              = "bkn_trace_assembly_lag_seconds"
+)
+
+type Recorder interface {
+	Increment(name string)
+	Add(name string, delta uint64)
+	Set(name string, value float64)
+}
+
+type Noop struct{}
+
+func (Noop) Increment(string)    {}
+func (Noop) Add(string, uint64)  {}
+func (Noop) Set(string, float64) {}

--- a/bkn-trace/agent-observability/src/port/driven/ievidenceledger/port.go
+++ b/bkn-trace/agent-observability/src/port/driven/ievidenceledger/port.go
@@ -1,0 +1,18 @@
+package ievidenceledger
+
+import (
+	"context"
+	"errors"
+
+	"github.com/openbkn-ai/bkn-foundry/bkn-trace/agent-observability/src/domain/valueobject/ledgervo"
+)
+
+var (
+	ErrPayloadConflict   = errors.New("event payload conflicts with durable ledger")
+	ErrSequenceConflict  = errors.New("producer sequence conflicts with durable ledger")
+	ErrCausalityConflict = errors.New("event causality conflicts with durable ledger")
+)
+
+type Store interface {
+	Commit(ctx context.Context, event ledgervo.Event) (ledgervo.DurableAck, error)
+}

--- a/bkn-trace/agent-observability/src/port/driven/iprojectionoutbox/port.go
+++ b/bkn-trace/agent-observability/src/port/driven/iprojectionoutbox/port.go
@@ -1,0 +1,76 @@
+package iprojectionoutbox
+
+import (
+	"context"
+	"errors"
+	"time"
+)
+
+var ErrLeaseLost = errors.New("projection outbox lease was lost")
+
+type permanentError struct {
+	err error
+}
+
+func (e permanentError) Error() string {
+	return e.err.Error()
+}
+
+func (e permanentError) Unwrap() error {
+	return e.err
+}
+
+func (e permanentError) Permanent() bool {
+	return true
+}
+
+func Permanent(err error) error {
+	if err == nil {
+		return nil
+	}
+	return permanentError{err: err}
+}
+
+func IsPermanent(err error) bool {
+	var classified interface{ Permanent() bool }
+	return errors.As(err, &classified) && classified.Permanent()
+}
+
+type Item struct {
+	ID               uint64    `json:"outbox_id"`
+	AggregateType    string    `json:"aggregate_type"`
+	AggregateID      string    `json:"aggregate_id"`
+	AggregateVersion uint64    `json:"aggregate_version"`
+	EventType        string    `json:"event_type"`
+	EventID          string    `json:"event_id"`
+	Payload          []byte    `json:"payload"`
+	Attempts         uint32    `json:"attempts"`
+	LeaseToken       string    `json:"-"`
+	CreatedAt        time.Time `json:"created_at"`
+}
+
+func DocumentID(item Item) string {
+	return item.AggregateType + ":" + item.AggregateID
+}
+
+type Store interface {
+	Lease(ctx context.Context, limit int, lockDuration time.Duration) ([]Item, error)
+	MarkDelivered(ctx context.Context, item Item) error
+	MarkRetry(ctx context.Context, item Item, errorCode string, availableAt time.Time) error
+	MoveToDLQ(ctx context.Context, item Item, errorCode string) error
+}
+
+type ReplayRequest struct {
+	DLQID         uint64
+	Operator      string
+	Reason        string
+	RepairVersion string
+}
+
+type DLQAdmin interface {
+	ReplayProjectionDLQ(ctx context.Context, request ReplayRequest) error
+}
+
+type Sink interface {
+	Project(ctx context.Context, item Item) error
+}

--- a/bkn-trace/agent-observability/src/port/driven/iprojectionrebuild/port.go
+++ b/bkn-trace/agent-observability/src/port/driven/iprojectionrebuild/port.go
@@ -1,0 +1,33 @@
+package iprojectionrebuild
+
+import (
+	"context"
+
+	"github.com/openbkn-ai/bkn-foundry/bkn-trace/agent-observability/src/port/driven/iprojectionoutbox"
+)
+
+type Source interface {
+	ProjectionHighWatermark(ctx context.Context) (uint64, error)
+	ScanAuthoritativeProjection(
+		ctx context.Context,
+		afterAggregateType string,
+		afterAggregateID string,
+		limit int,
+	) ([]iprojectionoutbox.Item, error)
+	CountAuthoritativeProjection(ctx context.Context) (uint64, error)
+	ScanProjectionHistory(ctx context.Context, after, through uint64, limit int) ([]iprojectionoutbox.Item, error)
+	LoadProjectionCheckpoint(ctx context.Context, projectorID, indexVersion string) (uint64, error)
+	SaveProjectionCheckpoint(ctx context.Context, projectorID, indexVersion string, lastOutboxID uint64) error
+}
+
+type Target interface {
+	PrepareVersion(ctx context.Context, indexVersion string) error
+	ProjectVersion(ctx context.Context, indexVersion string, item iprojectionoutbox.Item) error
+	ValidateVersion(
+		ctx context.Context,
+		indexVersion string,
+		items []iprojectionoutbox.Item,
+	) error
+	CountVersion(ctx context.Context, indexVersion string) (uint64, error)
+	SwitchAlias(ctx context.Context, alias, indexVersion string) error
+}

--- a/bkn-trace/agent-observability/src/port/driven/isessionstore/port.go
+++ b/bkn-trace/agent-observability/src/port/driven/isessionstore/port.go
@@ -1,0 +1,46 @@
+package isessionstore
+
+import (
+	"context"
+	"time"
+
+	"github.com/openbkn-ai/bkn-foundry/bkn-trace/agent-observability/src/domain/valueobject/sessionvo"
+)
+
+type Transaction interface {
+	Now() time.Time
+	FindCurrentConversation(owner sessionvo.Owner, externalKey string) (sessionvo.Conversation, bool)
+	FindConversation(conversationID string) (sessionvo.Conversation, bool)
+	FindIdempotency(scope string, owner sessionvo.Owner, externalKey, idempotencyKey string) (sessionvo.IdempotencyRecord, bool)
+	ListConversations(owner sessionvo.Owner, limit int) []sessionvo.Conversation
+	SaveConversation(conversation sessionvo.Conversation)
+	SaveIdempotency(record sessionvo.IdempotencyRecord)
+	FindActiveInteraction(conversationID string) (sessionvo.Interaction, bool)
+	FindInteractionByStartKey(conversationID, idempotencyKey string) (sessionvo.Interaction, bool)
+	PeekInteraction(interactionID string) (sessionvo.Interaction, bool)
+	FindInteraction(interactionID string) (sessionvo.Interaction, bool)
+	NextInteractionOrdinal(conversationID string) uint64
+	SaveInteraction(interaction sessionvo.Interaction)
+	FindOperationByKey(interactionID, operationKey string) (sessionvo.Operation, bool)
+	PeekOperation(operationID string) (sessionvo.Operation, bool)
+	FindOperation(operationID string) (sessionvo.Operation, bool)
+	ListOperations(interactionID string) []sessionvo.Operation
+	SaveOperation(operation sessionvo.Operation)
+	PeekReceipt(receiptID string) (sessionvo.Receipt, bool)
+	FindReceipt(receiptID string) (sessionvo.Receipt, bool)
+	FindReceiptByOperationAttempt(operationID string, attempt uint32) (sessionvo.Receipt, bool)
+	ListReceipts(interactionID string) []sessionvo.Receipt
+	SaveReceipt(receipt sessionvo.Receipt)
+	ListRequests(owner sessionvo.Owner, limit int) []sessionvo.RequestSummary
+	FindRequest(owner sessionvo.Owner, requestID string) (sessionvo.RequestSummary, bool)
+	ListIdleOneShotConversations(cutoff time.Time, limit int) []sessionvo.Conversation
+	ListExpiredActiveInteractions(limit int) []sessionvo.Interaction
+	ListAssemblyDueInteractions(limit int) []sessionvo.Interaction
+	ListAssemblyRevisions(interactionID string) []sessionvo.AssemblyRevision
+	SaveAssemblyRevision(revision sessionvo.AssemblyRevision)
+	AppendProjection(mutation sessionvo.ProjectionMutation)
+}
+
+type Store interface {
+	WithinTransaction(ctx context.Context, fn func(Transaction) error) error
+}


### PR DESCRIPTION
# Pull Request

## What Changed

Brief description of changes:

- [x] 实现受管 Conversation、Interaction、Operation、Receipt 生命周期、幂等、租约、fencing 与五种终态
- [x] 实现 MariaDB 权威存储、Evidence Event Ledger、Projection Outbox、DLQ、重放与不可变 Assembly Revision
- [x] 实现 OpenSearch 可重建投影、checkpoint、内容校验、严格外部版本和 alias 原子切换
- [x] 补齐 19 个核心 HTTP API、Swagger 合同、指标、Helm 配置和真实 MariaDB/OpenSearch CI

---

## Why

- Related Issue: [Issue #540](https://github.com/openbkn-ai/bkn-foundry/issues/540)
- Related Feature: [BKN Trace 0.1.3 设计与实施计划](https://github.com/openbkn-ai/bkn-docs/tree/main/docs/foundry/bkn-trace)
- Background: BKN Trace 需要为第三方 Agent、SDK 和 Context Loader 提供耐久、可恢复的统一会话生命周期与证据接收核心。此前缺少 MariaDB 权威状态、Receipt、Ledger/Outbox 原子 ACK 和可重建搜索投影，无法支撑 0.1.3 的业务溯源主链。

---

## How

- Key implementation points:
  - MariaDB 事务内维护生命周期状态、Receipt、Evidence Ledger 和 Projection Outbox；只有 Ledger 与 Outbox 同时提交后才返回 durable ACK。
  - 使用 owner tuple、generation、幂等记录、lease epoch/token 和 canonical lock order 处理并发创建、终态竞争、重试及失效写入。
  - OpenSearch 仅作为可重建投影，使用稳定 document ID 和 `version_type=external`；同聚合版本不同 payload 直接判定合同冲突。
  - 启动时可从 MariaDB 权威表与 outbox watermark 重建版本化索引，追平后校验内容与数量并切换 alias；OpenSearch 故障不阻塞 Core 权威写入。
  - 生命周期写入仅接受可信 gateway identity；#542 完成 OAuth 授权前保持 fail-closed。
- Breaking changes (API, config, database, etc.):
  - 新增 0.1.3 生命周期 API、MariaDB v013 表结构和 Core 配置项；这是新能力，无既有 0.1.3 生产兼容负担。
  - 部署启用 MariaDB Core store 时必须配置 `BKN_TRACE_CORE_MARIADB_DSN`；OpenSearch 投影可独立启停。

---

## Testing

- [x] Unit tests passed locally
- [x] Integration tests passed locally
- [x] Verified in test environment

Test notes:

- `make lint test test-race build`
- `helm lint charts/agent-observability`
- `helm template bkn-trace-core charts/agent-observability`
- 真实 MariaDB：并发 generation、one-shot expiry、终态竞争、Ledger+Outbox 原子性、DLQ 重放、权威重建
- 真实 OpenSearch：严格版本、同版本不可覆盖、内容校验、MariaDB -> OpenSearch 重建与 alias 查询
- 容量 smoke：生命周期约 3.05 ms/op，Evidence ingest 约 14.31 ms/op（本地 Apple M2 + Kubernetes 中间件）
- 独立代码审查确认无剩余 P0/P1

---

## Risk & Rollback

- Potential risks:
  - 新增 MariaDB schema 和后台投影 worker，错误配置可能导致 Core 启动失败或投影积压。
  - OpenSearch 投影不可作为权威来源；恢复流程必须从 MariaDB/Ledger 重建。
  - 正式 PITR/RPO/RTO 演练仍由 #545 的 SRE/DBA 发布门完成，本 PR 不宣称该发布门已通过。
- Rollback plan:
  - 回滚服务镜像并关闭 `BKN_TRACE_CORE_PROJECTION_ENABLED`；新表为增量创建，不覆盖旧 evidence/trace 数据。
  - 保留 MariaDB 权威数据和未投递 Outbox，不执行破坏性降级；恢复版本修复后可重放或重建 OpenSearch。

---

## Additional Notes

- 本 PR 只包含 bkn-foundry Core 实现；设计、需求和实施计划继续以 bkn-docs 为中心。
- 后续依赖汇合：#541 SDK/Context Loader、#542 授权、#544 业务语义图、#545 真实多轮 E2E 与恢复演练。
- Closes #540
