### PR TITLE
fix(vega-backend): filter resources by schema

### DIFF
--- a/adp/vega/vega-backend/server/drivenadapters/resource/resource_access.go
+++ b/adp/vega/vega-backend/server/drivenadapters/resource/resource_access.go
@@ -102,7 +102,7 @@ func (ra *resourceAccess) create(ctx context.Context, tx *sql.Tx, resource *inte
 			"f_status",
 			"f_status_message",
 			"f_last_discover_status",
-			"f_database",
+			"f_schema",
 			"f_source_identifier",
 			"f_source_metadata",
 			"f_schema_definition",
@@ -139,7 +139,7 @@ func (ra *resourceAccess) create(ctx context.Context, tx *sql.Tx, resource *inte
 			resource.Status,
 			resource.StatusMessage,
 			resource.LastDiscoverStatus,
-			resource.Database,
+			resource.Schema,
 			resource.SourceIdentifier,
 			string(sourceMetadataBytes),
 			string(schemaDefinitionBytes),
@@ -204,7 +204,7 @@ func (ra *resourceAccess) GetByID(ctx context.Context, id string) (*interfaces.R
 		"f_status",
 		"f_status_message",
 		"f_last_discover_status",
-		"f_database",
+		"f_schema",
 		"f_source_identifier",
 		"f_source_metadata",
 		"f_schema_definition",
@@ -229,7 +229,7 @@ func (ra *resourceAccess) GetByID(ctx context.Context, id string) (*interfaces.R
 
 	resource := &interfaces.Resource{}
 	var tagsStr string
-	var database, sourceIdentifier, sourceMetadata, schemaDefinition, indexConfig, logicDefinition sql.NullString
+	var sourceMetadata, schemaDefinition, indexConfig, logicDefinition sql.NullString
 
 	row := ra.db.QueryRowContext(ctx, sqlStr, vals...)
 	err = row.Scan(
@@ -242,8 +242,8 @@ func (ra *resourceAccess) GetByID(ctx context.Context, id string) (*interfaces.R
 		&resource.Status,
 		&resource.StatusMessage,
 		&resource.LastDiscoverStatus,
-		&database,
-		&sourceIdentifier,
+		&resource.Schema,
+		&resource.SourceIdentifier,
 		&sourceMetadata,
 		&schemaDefinition,
 		&indexConfig,
@@ -269,8 +269,6 @@ func (ra *resourceAccess) GetByID(ctx context.Context, id string) (*interfaces.R
 
 	// tags string 转成数组的格式
 	resource.Tags = libCommon.TagString2TagSlice(tagsStr)
-	resource.Database = database.String
-	resource.SourceIdentifier = sourceIdentifier.String
 	if sourceMetadata.Valid && sourceMetadata.String != "" {
 		_ = sonic.Unmarshal([]byte(sourceMetadata.String), &resource.SourceMetadata)
 	}
@@ -310,7 +308,7 @@ func (ra *resourceAccess) GetByIDs(ctx context.Context, ids []string) ([]*interf
 		"f_status",
 		"f_status_message",
 		"f_last_discover_status",
-		"f_database",
+		"f_schema",
 		"f_source_identifier",
 		"f_source_metadata",
 		"f_schema_definition",
@@ -345,7 +343,7 @@ func (ra *resourceAccess) GetByIDs(ctx context.Context, ids []string) ([]*interf
 	for rows.Next() {
 		resource := &interfaces.Resource{}
 		var tagsStr string
-		var database, sourceIdentifier, sourceMetadata, schemaDefinition, indexConfig, logicDefinition sql.NullString
+		var sourceMetadata, schemaDefinition, indexConfig, logicDefinition sql.NullString
 
 		err := rows.Scan(
 			&resource.ID,
@@ -357,8 +355,8 @@ func (ra *resourceAccess) GetByIDs(ctx context.Context, ids []string) ([]*interf
 			&resource.Status,
 			&resource.StatusMessage,
 			&resource.LastDiscoverStatus,
-			&database,
-			&sourceIdentifier,
+			&resource.Schema,
+			&resource.SourceIdentifier,
 			&sourceMetadata,
 			&schemaDefinition,
 			&indexConfig,
@@ -381,8 +379,6 @@ func (ra *resourceAccess) GetByIDs(ctx context.Context, ids []string) ([]*interf
 
 		// tags string 转成数组的格式
 		resource.Tags = libCommon.TagString2TagSlice(tagsStr)
-		resource.Database = database.String
-		resource.SourceIdentifier = sourceIdentifier.String
 		if sourceMetadata.Valid && sourceMetadata.String != "" {
 			_ = sonic.Unmarshal([]byte(sourceMetadata.String), &resource.SourceMetadata)
 		}
@@ -438,7 +434,7 @@ func (ra *resourceAccess) GetByIDsBasic(ctx context.Context, ids []string) ([]*i
 		"f_status",
 		"f_status_message",
 		"f_last_discover_status",
-		"f_database",
+		"f_schema",
 		"f_source_identifier",
 		"f_source_metadata",
 		"f_schema_definition",
@@ -470,7 +466,7 @@ func (ra *resourceAccess) GetByIDsBasic(ctx context.Context, ids []string) ([]*i
 	for rows.Next() {
 		resource := &interfaces.Resource{}
 		var tagsStr string
-		var database, sourceIdentifier, sourceMetadata, schemaDefinition sql.NullString
+		var sourceMetadata, schemaDefinition sql.NullString
 
 		err := rows.Scan(
 			&resource.ID,
@@ -482,8 +478,8 @@ func (ra *resourceAccess) GetByIDsBasic(ctx context.Context, ids []string) ([]*i
 			&resource.Status,
 			&resource.StatusMessage,
 			&resource.LastDiscoverStatus,
-			&database,
-			&sourceIdentifier,
+			&resource.Schema,
+			&resource.SourceIdentifier,
 			&sourceMetadata,
 			&schemaDefinition,
 			&resource.LogicType,
@@ -503,8 +499,6 @@ func (ra *resourceAccess) GetByIDsBasic(ctx context.Context, ids []string) ([]*i
 
 		// tags string 转成数组的格式
 		resource.Tags = libCommon.TagString2TagSlice(tagsStr)
-		resource.Database = database.String
-		resource.SourceIdentifier = sourceIdentifier.String
 		// 不反序列化sourceMetadata、schemaDefinition和logicDefinition的完整结构，以减少内存占用
 		// 仅惰性提取规模信息：列数（schema 顶层元素数）与源端行数估算（properties.row_count）
 		if schemaDefinition.Valid && schemaDefinition.String != "" {
@@ -551,7 +545,7 @@ func (ra *resourceAccess) GetByName(ctx context.Context, catalogID string, name 
 		"f_status",
 		"f_status_message",
 		"f_last_discover_status",
-		"f_database",
+		"f_schema",
 		"f_source_identifier",
 		"f_source_metadata",
 		"f_schema_definition",
@@ -574,7 +568,7 @@ func (ra *resourceAccess) GetByName(ctx context.Context, catalogID string, name 
 
 	resource := &interfaces.Resource{}
 	var tagsStr string
-	var database, sourceIdentifier, sourceMetadata, schemaDefinition, indexConfig sql.NullString
+	var sourceMetadata, schemaDefinition, indexConfig sql.NullString
 
 	row := ra.db.QueryRowContext(ctx, sqlStr, vals...)
 	err = row.Scan(
@@ -587,8 +581,8 @@ func (ra *resourceAccess) GetByName(ctx context.Context, catalogID string, name 
 		&resource.Status,
 		&resource.StatusMessage,
 		&resource.LastDiscoverStatus,
-		&database,
-		&sourceIdentifier,
+		&resource.Schema,
+		&resource.SourceIdentifier,
 		&sourceMetadata,
 		&schemaDefinition,
 		&indexConfig,
@@ -611,8 +605,6 @@ func (ra *resourceAccess) GetByName(ctx context.Context, catalogID string, name 
 
 	// tags string 转成数组的格式
 	resource.Tags = libCommon.TagString2TagSlice(tagsStr)
-	resource.Database = database.String
-	resource.SourceIdentifier = sourceIdentifier.String
 	if sourceMetadata.Valid && sourceMetadata.String != "" {
 		_ = sonic.Unmarshal([]byte(sourceMetadata.String), &resource.SourceMetadata)
 	}
@@ -647,8 +639,8 @@ func (ra *resourceAccess) ListIDs(ctx context.Context, params interfaces.Resourc
 	if params.Status != "" {
 		builder = builder.Where(sq.Eq{resourceExtCol(params, "f_status"): params.Status})
 	}
-	if params.Database != "" {
-		builder = builder.Where(sq.Eq{resourceExtCol(params, "f_database"): params.Database})
+	if params.Schema != "" {
+		builder = builder.Where(sq.Eq{resourceExtCol(params, "f_schema"): params.Schema})
 	}
 
 	builder = applyResourceExtensionJoins(builder, params)
@@ -711,7 +703,7 @@ func (ra *resourceAccess) List(ctx context.Context, params interfaces.ResourcesQ
 		resourceExtCol(params, "f_status"),
 		resourceExtCol(params, "f_status_message"),
 		resourceExtCol(params, "f_last_discover_status"),
-		resourceExtCol(params, "f_database"),
+		resourceExtCol(params, "f_schema"),
 		resourceExtCol(params, "f_source_identifier"),
 		resourceExtCol(params, "f_source_metadata"),
 		resourceExtCol(params, "f_schema_definition"),
@@ -743,9 +735,9 @@ func (ra *resourceAccess) List(ctx context.Context, params interfaces.ResourcesQ
 		builder = builder.Where(sq.Eq{resourceExtCol(params, "f_status"): params.Status})
 		countBuilder = countBuilder.Where(sq.Eq{resourceExtCol(params, "f_status"): params.Status})
 	}
-	if params.Database != "" {
-		builder = builder.Where(sq.Eq{resourceExtCol(params, "f_database"): params.Database})
-		countBuilder = countBuilder.Where(sq.Eq{resourceExtCol(params, "f_database"): params.Database})
+	if params.Schema != "" {
+		builder = builder.Where(sq.Eq{resourceExtCol(params, "f_schema"): params.Schema})
+		countBuilder = countBuilder.Where(sq.Eq{resourceExtCol(params, "f_schema"): params.Schema})
 	}
 
 	builder = applyResourceExtensionJoins(builder, params)
@@ -789,7 +781,7 @@ func (ra *resourceAccess) List(ctx context.Context, params interfaces.ResourcesQ
 	for rows.Next() {
 		resource := &interfaces.Resource{}
 		var tagsStr string
-		var database, sourceIdentifier, sourceMetadata, schemaDefinition, indexConfig sql.NullString
+		var sourceMetadata, schemaDefinition, indexConfig sql.NullString
 
 		err := rows.Scan(
 			&resource.ID,
@@ -801,8 +793,8 @@ func (ra *resourceAccess) List(ctx context.Context, params interfaces.ResourcesQ
 			&resource.Status,
 			&resource.StatusMessage,
 			&resource.LastDiscoverStatus,
-			&database,
-			&sourceIdentifier,
+			&resource.Schema,
+			&resource.SourceIdentifier,
 			&sourceMetadata,
 			&schemaDefinition,
 			&indexConfig,
@@ -820,8 +812,6 @@ func (ra *resourceAccess) List(ctx context.Context, params interfaces.ResourcesQ
 
 		// tags string 转成数组的格式
 		resource.Tags = libCommon.TagString2TagSlice(tagsStr)
-		resource.Database = database.String
-		resource.SourceIdentifier = sourceIdentifier.String
 		if sourceMetadata.Valid && sourceMetadata.String != "" {
 			_ = sonic.Unmarshal([]byte(sourceMetadata.String), &resource.SourceMetadata)
 		}
@@ -933,7 +923,7 @@ func (ra *resourceAccess) GetByCatalogID(ctx context.Context, catalogID string) 
 		"f_status",
 		"f_status_message",
 		"f_last_discover_status",
-		"f_database",
+		"f_schema",
 		"f_source_identifier",
 		"f_source_metadata",
 		"f_schema_definition",
@@ -965,7 +955,7 @@ func (ra *resourceAccess) GetByCatalogID(ctx context.Context, catalogID string) 
 	for rows.Next() {
 		resource := &interfaces.Resource{}
 		var tagsStr string
-		var database, sourceIdentifier, sourceMetadata, schemaDefinition, indexConfig sql.NullString
+		var sourceMetadata, schemaDefinition, indexConfig sql.NullString
 
 		err := rows.Scan(
 			&resource.ID,
@@ -977,8 +967,8 @@ func (ra *resourceAccess) GetByCatalogID(ctx context.Context, catalogID string) 
 			&resource.Status,
 			&resource.StatusMessage,
 			&resource.LastDiscoverStatus,
-			&database,
-			&sourceIdentifier,
+			&resource.Schema,
+			&resource.SourceIdentifier,
 			&sourceMetadata,
 			&schemaDefinition,
 			&indexConfig,
@@ -996,8 +986,6 @@ func (ra *resourceAccess) GetByCatalogID(ctx context.Context, catalogID string) 
 		}
 
 		resource.Tags = libCommon.TagString2TagSlice(tagsStr)
-		resource.Database = database.String
-		resource.SourceIdentifier = sourceIdentifier.String
 		if sourceMetadata.Valid && sourceMetadata.String != "" {
 			_ = sonic.Unmarshal([]byte(sourceMetadata.String), &resource.SourceMetadata)
 		}

--- a/adp/vega/vega-backend/server/drivenadapters/resource/resource_access_test.go
+++ b/adp/vega/vega-backend/server/drivenadapters/resource/resource_access_test.go
@@ -30,7 +30,7 @@ func TestResourceAccessCreate(t *testing.T) {
 		access, mock, cleanup := newResourceAccessMock(t)
 		defer cleanup()
 
-		mock.ExpectExec(regexp.QuoteMeta("INSERT INTO t_resource (f_id,f_catalog_id,f_name,f_tags,f_description,f_category,f_status,f_status_message,f_last_discover_status,f_database,f_source_identifier,f_source_metadata,f_schema_definition,f_index_config,f_logic_type,f_logic_definition,f_local_enabled,f_local_storage_engine,f_local_storage_config,f_local_index_name,f_sync_strategy,f_sync_config,f_sync_status,f_last_sync_time,f_sync_error_message,f_creator,f_creator_type,f_create_time,f_updater,f_updater_type,f_update_time) VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)")).
+		mock.ExpectExec(regexp.QuoteMeta("INSERT INTO t_resource (f_id,f_catalog_id,f_name,f_tags,f_description,f_category,f_status,f_status_message,f_last_discover_status,f_schema,f_source_identifier,f_source_metadata,f_schema_definition,f_index_config,f_logic_type,f_logic_definition,f_local_enabled,f_local_storage_engine,f_local_storage_config,f_local_index_name,f_sync_strategy,f_sync_config,f_sync_status,f_last_sync_time,f_sync_error_message,f_creator,f_creator_type,f_create_time,f_updater,f_updater_type,f_update_time) VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)")).
 			WithArgs(
 				"resource-1",
 				"catalog-1",
@@ -189,11 +189,11 @@ func TestResourceAccessGetByIDsBasic(t *testing.T) {
 		access, mock, cleanup := newResourceAccessMock(t)
 		defer cleanup()
 
-		mock.ExpectQuery(regexp.QuoteMeta("SELECT f_id, f_catalog_id, f_name, f_tags, f_description, f_category, f_status, f_status_message, f_last_discover_status, f_database, f_source_identifier, f_source_metadata, f_schema_definition, f_logic_type, f_creator, f_creator_type, f_create_time, f_updater, f_updater_type, f_update_time FROM t_resource WHERE f_id IN (?,?)")).
+		mock.ExpectQuery(regexp.QuoteMeta("SELECT f_id, f_catalog_id, f_name, f_tags, f_description, f_category, f_status, f_status_message, f_last_discover_status, f_schema, f_source_identifier, f_source_metadata, f_schema_definition, f_logic_type, f_creator, f_creator_type, f_create_time, f_updater, f_updater_type, f_update_time FROM t_resource WHERE f_id IN (?,?)")).
 			WithArgs("resource-1", "resource-2").
 			WillReturnRows(sqlmock.NewRows([]string{
 				"f_id", "f_catalog_id", "f_name", "f_tags", "f_description", "f_category", "f_status", "f_status_message", "f_last_discover_status",
-				"f_database", "f_source_identifier", "f_source_metadata", "f_schema_definition", "f_logic_type",
+				"f_schema", "f_source_identifier", "f_source_metadata", "f_schema_definition", "f_logic_type",
 				"f_creator", "f_creator_type", "f_create_time", "f_updater", "f_updater_type", "f_update_time",
 			}).AddRow(
 				"resource-1", "catalog-1", "orders", "pii,core", "desc", interfaces.ResourceCategoryTable, interfaces.ResourceStatusActive, "ready", interfaces.DiscoverStatusNew,
@@ -219,7 +219,7 @@ func TestResourceAccessGetByName(t *testing.T) {
 		access, mock, cleanup := newResourceAccessMock(t)
 		defer cleanup()
 
-		mock.ExpectQuery(regexp.QuoteMeta("SELECT f_id, f_catalog_id, f_name, f_tags, f_description, f_category, f_status, f_status_message, f_last_discover_status, f_database, f_source_identifier, f_source_metadata, f_schema_definition, f_index_config, f_creator, f_creator_type, f_create_time, f_updater, f_updater_type, f_update_time FROM t_resource WHERE f_catalog_id = ? AND f_name = ?")).
+		mock.ExpectQuery(regexp.QuoteMeta("SELECT f_id, f_catalog_id, f_name, f_tags, f_description, f_category, f_status, f_status_message, f_last_discover_status, f_schema, f_source_identifier, f_source_metadata, f_schema_definition, f_index_config, f_creator, f_creator_type, f_create_time, f_updater, f_updater_type, f_update_time FROM t_resource WHERE f_catalog_id = ? AND f_name = ?")).
 			WithArgs("catalog-1", "orders").
 			WillReturnRows(resourceNameRows().AddRow(resourceNameRowValues(sampleResource())...))
 
@@ -229,7 +229,7 @@ func TestResourceAccessGetByName(t *testing.T) {
 		require.NotNil(t, got)
 		assert.Equal(t, "resource-1", got.ID)
 		assert.Equal(t, []string{"pii", "core"}, got.Tags)
-		assert.Equal(t, "db1", got.Database)
+		assert.Equal(t, "db1", got.Schema)
 		assert.Equal(t, "public.orders", got.SourceIdentifier)
 		require.Len(t, got.SchemaDefinition, 1)
 		require.NoError(t, mock.ExpectationsWereMet())
@@ -239,7 +239,7 @@ func TestResourceAccessGetByName(t *testing.T) {
 		access, mock, cleanup := newResourceAccessMock(t)
 		defer cleanup()
 
-		mock.ExpectQuery(regexp.QuoteMeta("SELECT f_id, f_catalog_id, f_name, f_tags, f_description, f_category, f_status, f_status_message, f_last_discover_status, f_database, f_source_identifier, f_source_metadata, f_schema_definition, f_index_config, f_creator, f_creator_type, f_create_time, f_updater, f_updater_type, f_update_time FROM t_resource WHERE f_catalog_id = ? AND f_name = ?")).
+		mock.ExpectQuery(regexp.QuoteMeta("SELECT f_id, f_catalog_id, f_name, f_tags, f_description, f_category, f_status, f_status_message, f_last_discover_status, f_schema, f_source_identifier, f_source_metadata, f_schema_definition, f_index_config, f_creator, f_creator_type, f_create_time, f_updater, f_updater_type, f_update_time FROM t_resource WHERE f_catalog_id = ? AND f_name = ?")).
 			WithArgs("catalog-1", "missing").
 			WillReturnError(sql.ErrNoRows)
 
@@ -256,7 +256,7 @@ func TestResourceAccessGetByCatalogID(t *testing.T) {
 		access, mock, cleanup := newResourceAccessMock(t)
 		defer cleanup()
 
-		mock.ExpectQuery(regexp.QuoteMeta("SELECT f_id, f_catalog_id, f_name, f_tags, f_description, f_category, f_status, f_status_message, f_last_discover_status, f_database, f_source_identifier, f_source_metadata, f_schema_definition, f_index_config, f_creator, f_creator_type, f_create_time, f_updater, f_updater_type, f_update_time FROM t_resource WHERE f_catalog_id = ?")).
+		mock.ExpectQuery(regexp.QuoteMeta("SELECT f_id, f_catalog_id, f_name, f_tags, f_description, f_category, f_status, f_status_message, f_last_discover_status, f_schema, f_source_identifier, f_source_metadata, f_schema_definition, f_index_config, f_creator, f_creator_type, f_create_time, f_updater, f_updater_type, f_update_time FROM t_resource WHERE f_catalog_id = ?")).
 			WithArgs("catalog-1").
 			WillReturnRows(resourceNameRows().
 				AddRow(resourceNameRowValues(sampleResource())...).
@@ -282,13 +282,13 @@ func TestResourceAccessList(t *testing.T) {
 			CatalogID:             "catalog-1",
 			Category:              interfaces.ResourceCategoryTable,
 			Status:                interfaces.ResourceStatusActive,
-			Database:              "db1",
+			Schema:                "db1",
 		}
 
-		mock.ExpectQuery(regexp.QuoteMeta("SELECT COUNT(*) FROM t_resource WHERE f_name LIKE ? AND f_catalog_id = ? AND f_category = ? AND f_status = ? AND f_database = ?")).
+		mock.ExpectQuery(regexp.QuoteMeta("SELECT COUNT(*) FROM t_resource WHERE f_name LIKE ? AND f_catalog_id = ? AND f_category = ? AND f_status = ? AND f_schema = ?")).
 			WithArgs("%order%", "catalog-1", interfaces.ResourceCategoryTable, interfaces.ResourceStatusActive, "db1").
 			WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(int64(1)))
-		mock.ExpectQuery(regexp.QuoteMeta("SELECT f_id, f_catalog_id, f_name, f_tags, f_description, f_category, f_status, f_status_message, f_last_discover_status, f_database, f_source_identifier, f_source_metadata, f_schema_definition, f_index_config, f_creator, f_creator_type, f_create_time, f_updater, f_updater_type, f_update_time FROM t_resource WHERE f_name LIKE ? AND f_catalog_id = ? AND f_category = ? AND f_status = ? AND f_database = ? ORDER BY f_name ASC")).
+		mock.ExpectQuery(regexp.QuoteMeta("SELECT f_id, f_catalog_id, f_name, f_tags, f_description, f_category, f_status, f_status_message, f_last_discover_status, f_schema, f_source_identifier, f_source_metadata, f_schema_definition, f_index_config, f_creator, f_creator_type, f_create_time, f_updater, f_updater_type, f_update_time FROM t_resource WHERE f_name LIKE ? AND f_catalog_id = ? AND f_category = ? AND f_status = ? AND f_schema = ? ORDER BY f_name ASC")).
 			WithArgs("%order%", "catalog-1", interfaces.ResourceCategoryTable, interfaces.ResourceStatusActive, "db1").
 			WillReturnRows(resourceNameRows().AddRow(resourceNameRowValues(sampleResource())...))
 
@@ -745,7 +745,7 @@ func sampleResource() *interfaces.Resource {
 		Status:             interfaces.ResourceStatusActive,
 		StatusMessage:      "ready",
 		LastDiscoverStatus: interfaces.DiscoverStatusNew,
-		Database:           "db1",
+		Schema:             "db1",
 		SourceIdentifier:   "public.orders",
 		SourceMetadata:     map[string]any{"properties": map[string]any{"row_count": 42}},
 		SchemaDefinition:   []*interfaces.Property{{Name: "id", Type: "integer"}},
@@ -778,7 +778,7 @@ func resourceNameRows() *sqlmock.Rows {
 		"f_status",
 		"f_status_message",
 		"f_last_discover_status",
-		"f_database",
+		"f_schema",
 		"f_source_identifier",
 		"f_source_metadata",
 		"f_schema_definition",
@@ -803,7 +803,7 @@ func resourceNameRowValues(resource *interfaces.Resource) []driver.Value {
 		resource.Status,
 		resource.StatusMessage,
 		resource.LastDiscoverStatus,
-		resource.Database,
+		resource.Schema,
 		resource.SourceIdentifier,
 		`{"properties":{"row_count":42}}`,
 		`[{"name":"id","type":"integer"}]`,
@@ -818,7 +818,7 @@ func resourceNameRowValues(resource *interfaces.Resource) []driver.Value {
 }
 
 func resourceSelectSQL(where string) string {
-	return "SELECT f_id, f_catalog_id, f_name, f_tags, f_description, f_category, f_status, f_status_message, f_last_discover_status, f_database, f_source_identifier, f_source_metadata, f_schema_definition, f_index_config, f_logic_type, f_logic_definition, f_creator, f_creator_type, f_create_time, f_updater, f_updater_type, f_update_time, f_local_index_name FROM t_resource WHERE " + where
+	return "SELECT f_id, f_catalog_id, f_name, f_tags, f_description, f_category, f_status, f_status_message, f_last_discover_status, f_schema, f_source_identifier, f_source_metadata, f_schema_definition, f_index_config, f_logic_type, f_logic_definition, f_creator, f_creator_type, f_create_time, f_updater, f_updater_type, f_update_time, f_local_index_name FROM t_resource WHERE " + where
 }
 
 func resourceRows() *sqlmock.Rows {
@@ -832,7 +832,7 @@ func resourceRows() *sqlmock.Rows {
 		"f_status",
 		"f_status_message",
 		"f_last_discover_status",
-		"f_database",
+		"f_schema",
 		"f_source_identifier",
 		"f_source_metadata",
 		"f_schema_definition",
@@ -860,7 +860,7 @@ func resourceRowValues(resource *interfaces.Resource) []driver.Value {
 		resource.Status,
 		resource.StatusMessage,
 		resource.LastDiscoverStatus,
-		resource.Database,
+		resource.Schema,
 		resource.SourceIdentifier,
 		`{"properties":{"row_count":42}}`,
 		`[{"name":"id","type":"integer"}]`,

--- a/adp/vega/vega-backend/server/driveradapters/bkn_trace_events.go
+++ b/adp/vega/vega-backend/server/driveradapters/bkn_trace_events.go
@@ -195,21 +195,21 @@ func resourceDataEvidenceTruncated(result *interfaces.ResourceDataQueryResult) b
 
 func safeResourceListQueryShape(params interfaces.ResourcesQueryParams) map[string]any {
 	return map[string]any{
-		"catalog_id":              params.CatalogID,
-		"category":                params.Category,
-		"status":                  params.Status,
-		"database":                params.Database,
-		"offset":                  params.Offset,
-		"limit":                   params.Limit,
-		"sort":                    params.Sort,
-		"direction":               params.Direction,
-		"extension_keys_hash":     bkntrace.HashValue(params.ExtensionKeys),
-		"extension_values_hash":   bkntrace.HashValue(params.ExtensionValues),
-		"include_extensions":      params.IncludeExtensions,
-		"include_extension_keys":  params.IncludeExtensionKeys,
-		"name_filter_present":     strings.TrimSpace(params.Name) != "",
-		"catalog_filter_present":  strings.TrimSpace(params.CatalogID) != "",
-		"database_filter_present": strings.TrimSpace(params.Database) != "",
+		"catalog_id":             params.CatalogID,
+		"category":               params.Category,
+		"status":                 params.Status,
+		"schema":                 params.Schema,
+		"offset":                 params.Offset,
+		"limit":                  params.Limit,
+		"sort":                   params.Sort,
+		"direction":              params.Direction,
+		"extension_keys_hash":    bkntrace.HashValue(params.ExtensionKeys),
+		"extension_values_hash":  bkntrace.HashValue(params.ExtensionValues),
+		"include_extensions":     params.IncludeExtensions,
+		"include_extension_keys": params.IncludeExtensionKeys,
+		"name_filter_present":    strings.TrimSpace(params.Name) != "",
+		"catalog_filter_present": strings.TrimSpace(params.CatalogID) != "",
+		"schema_filter_present":  strings.TrimSpace(params.Schema) != "",
 	}
 }
 

--- a/adp/vega/vega-backend/server/driveradapters/resource_handler.go
+++ b/adp/vega/vega-backend/server/driveradapters/resource_handler.go
@@ -63,7 +63,7 @@ func (r *restHandler) listResources(c *gin.Context, visitor hydra.Visitor) {
 	catalogID := c.Query("catalog_id")
 	category := c.Query("category")
 	status := c.Query("status")
-	database := c.Query("database")
+	schema := c.Query("schema")
 	offset := common.GetQueryOrDefault(c, "offset", interfaces.DEFAULT_OFFSET)
 	limit := common.GetQueryOrDefault(c, "limit", interfaces.DEFAULT_LIMIT)
 	sort := common.GetQueryOrDefault(c, "sort", "update_time")
@@ -93,7 +93,7 @@ func (r *restHandler) listResources(c *gin.Context, visitor hydra.Visitor) {
 		CatalogID:             catalogID,
 		Category:              category,
 		Status:                status,
-		Database:              database,
+		Schema:                schema,
 		ExtensionKeys:         extKeys,
 		ExtensionValues:       extVals,
 		IncludeExtensions:     includeExt,

--- a/adp/vega/vega-backend/server/driveradapters/resource_handler_test.go
+++ b/adp/vega/vega-backend/server/driveradapters/resource_handler_test.go
@@ -84,17 +84,18 @@ func Test_ResourceRestHandler_ListResources(t *testing.T) {
 		assert.Contains(t, w.Body.String(), "invalid status: unknown")
 	})
 
-	t.Run("success list resources with name category and status", func(t *testing.T) {
+	t.Run("success list resources with schema", func(t *testing.T) {
 		engine, rs := setup(t)
 		rs.EXPECT().List(gomock.Any(), gomock.Any()).
 			DoAndReturn(func(_ context.Context, params interfaces.ResourcesQueryParams) ([]*interfaces.Resource, int64, error) {
 				assert.Equal(t, "orders", params.Name)
 				assert.Equal(t, interfaces.ResourceCategoryDataset, params.Category)
 				assert.Equal(t, interfaces.ResourceStatusActive, params.Status)
+				assert.Equal(t, "external_data", params.Schema)
 				return []*interfaces.Resource{}, int64(0), nil
 			})
 
-		req := httptest.NewRequest(http.MethodGet, url+"?name=orders&category=dataset&status=active", nil)
+		req := httptest.NewRequest(http.MethodGet, url+"?name=orders&category=dataset&status=active&schema=external_data", nil)
 		w := httptest.NewRecorder()
 
 		engine.ServeHTTP(w, req)

--- a/adp/vega/vega-backend/server/interfaces/resource.go
+++ b/adp/vega/vega-backend/server/interfaces/resource.go
@@ -57,7 +57,7 @@ type Resource struct {
 	LastDiscoverStatus string `json:"last_discover_status"` // 最近一次扫描观察状态
 
 	// 新增字段：支持自动发现
-	Database         string         `json:"database,omitempty"`          // 所属数据库（实例级 Catalog 时填充）
+	Schema           string         `json:"schema,omitempty"`            // 所属 schema，由发现流程写入
 	SourceIdentifier string         `json:"source_identifier"`           // 源端标识（原始表名/路径）
 	SourceMetadata   map[string]any `json:"source_metadata,omitempty"`   // 源端配置（JSON）
 	SchemaDefinition []*Property    `json:"schema_definition,omitempty"` // Schema定义
@@ -135,7 +135,7 @@ type ResourcesQueryParams struct {
 	CatalogID            string
 	Category             string
 	Status               string
-	Database             string
+	Schema               string
 	ExtensionKeys        []string
 	ExtensionValues      []string
 	IncludeExtensions    bool
@@ -154,7 +154,7 @@ type ResourceRequest struct {
 
 	Status string `json:"status"`
 
-	Database         string         `json:"database,omitempty"`          // 所属数据库（实例级 Catalog 时填充）
+	Schema           string         `json:"schema,omitempty"`            // 所属 schema，由发现流程写入
 	SourceIdentifier string         `json:"source_identifier"`           // 源端标识（原始表名/路径）
 	SourceMetadata   map[string]any `json:"source_metadata,omitempty"`   // 源端配置（JSON）
 	SchemaDefinition []*Property    `json:"schema_definition,omitempty"` // Schema定义

--- a/adp/vega/vega-backend/server/logics/connector/local/table/mariadb/mariadb_discover.go
+++ b/adp/vega/vega-backend/server/logics/connector/local/table/mariadb/mariadb_discover.go
@@ -519,6 +519,12 @@ func (c *MariaDBConnector) GetMetadata(ctx context.Context) (map[string]any, err
 		return nil, err
 	}
 
+	schemas, err := c.listSchemas(ctx)
+	if err != nil {
+		return nil, err
+	}
+	metadata["schemas"] = schemas
+
 	// 3. Infer Cluster Mode
 	metadata["cluster_mode"] = "standalone" // Default
 	if val, ok := metadata["wsrep_on"]; ok && strings.EqualFold(fmt.Sprint(val), "ON") {
@@ -528,4 +534,35 @@ func (c *MariaDBConnector) GetMetadata(ctx context.Context) (map[string]any, err
 	}
 
 	return metadata, nil
+}
+
+func (c *MariaDBConnector) listSchemas(ctx context.Context) ([]string, error) {
+	schemaBuilder := sq.Select("SCHEMA_NAME").From("information_schema.SCHEMATA")
+	if len(c.config.Databases) > 0 {
+		schemaBuilder = schemaBuilder.Where(sq.Eq{"SCHEMA_NAME": c.config.Databases})
+	} else {
+		schemaBuilder = schemaBuilder.Where(sq.NotEq{"SCHEMA_NAME": SYSTEM_DBS})
+	}
+	schemaQuery, schemaArgs, err := schemaBuilder.OrderBy("SCHEMA_NAME").ToSql()
+	if err != nil {
+		return nil, fmt.Errorf("build list schemas query: %w", err)
+	}
+	schemaRows, err := c.db.QueryContext(ctx, schemaQuery, schemaArgs...)
+	if err != nil {
+		return nil, fmt.Errorf("list schemas: %w", err)
+	}
+	defer func() { _ = schemaRows.Close() }()
+
+	schemas := make([]string, 0)
+	for schemaRows.Next() {
+		var schema string
+		if err := schemaRows.Scan(&schema); err != nil {
+			return nil, fmt.Errorf("scan schema: %w", err)
+		}
+		schemas = append(schemas, schema)
+	}
+	if err := schemaRows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate schemas: %w", err)
+	}
+	return schemas, nil
 }

--- a/adp/vega/vega-backend/server/logics/connector/local/table/postgresql/postgresql_discover.go
+++ b/adp/vega/vega-backend/server/logics/connector/local/table/postgresql/postgresql_discover.go
@@ -434,6 +434,43 @@ WHERE name IN ('server_version','server_version_num','TimeZone','max_connections
 		return nil, err
 	}
 
+	schemas, err := c.listSchemas(ctx)
+	if err != nil {
+		return nil, err
+	}
+	meta["schemas"] = schemas
+
 	meta["cluster_mode"] = "standalone"
 	return meta, nil
+}
+
+func (c *PostgresqlConnector) listSchemas(ctx context.Context) ([]string, error) {
+	schemaBuilder := pgSq.Select("n.nspname").From("pg_catalog.pg_namespace n").
+		Where(sq.NotEq{"n.nspname": SYSTEM_SCHEMAS}).
+		Where(sq.Expr("NOT pg_is_other_temp_schema(n.oid)"))
+	if len(c.config.Schemas) > 0 {
+		schemaBuilder = schemaBuilder.Where(sq.Eq{"n.nspname": c.config.Schemas})
+	}
+	schemaQuery, schemaArgs, err := schemaBuilder.OrderBy("n.nspname").ToSql()
+	if err != nil {
+		return nil, fmt.Errorf("build list schemas query: %w", err)
+	}
+	schemaRows, err := c.db.QueryContext(ctx, schemaQuery, schemaArgs...)
+	if err != nil {
+		return nil, fmt.Errorf("list schemas: %w", err)
+	}
+	defer func() { _ = schemaRows.Close() }()
+
+	schemas := make([]string, 0)
+	for schemaRows.Next() {
+		var schema string
+		if err := schemaRows.Scan(&schema); err != nil {
+			return nil, fmt.Errorf("scan schema: %w", err)
+		}
+		schemas = append(schemas, schema)
+	}
+	if err := schemaRows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate schemas: %w", err)
+	}
+	return schemas, nil
 }

--- a/adp/vega/vega-backend/server/logics/resource/resource_service.go
+++ b/adp/vega/vega-backend/server/logics/resource/resource_service.go
@@ -251,7 +251,7 @@ func (rs *resourceService) Create(ctx context.Context, req *interfaces.ResourceR
 		Description:      req.Description,
 		Category:         req.Category,
 		Status:           req.Status,
-		Database:         req.Database,
+		Schema:           req.Schema,
 		SourceIdentifier: req.SourceIdentifier,
 		SourceMetadata:   req.SourceMetadata,
 		SchemaDefinition: req.SchemaDefinition,
@@ -954,7 +954,7 @@ func (rs *resourceService) InternalCreate(ctx context.Context, tx *sql.Tx, req *
 		Description:      req.Description,
 		Category:         req.Category,
 		Status:           req.Status,
-		Database:         req.Database,
+		Schema:           req.Schema,
 		SourceIdentifier: req.SourceIdentifier,
 		SourceMetadata:   req.SourceMetadata,
 		SchemaDefinition: req.SchemaDefinition,
@@ -1001,8 +1001,8 @@ func (rs *resourceService) validateResourceUpdateScope(ctx context.Context, reso
 	if resource.Category == interfaces.ResourceCategoryLogicView {
 		return req.LogicDefinition != nil && !reflect.DeepEqual(resource.LogicDefinition, req.LogicDefinition), nil
 	}
-	if req.Database != "" && resource.Database != req.Database {
-		return false, unsupportedResourceUpdateError(ctx, "database is managed by discover and cannot be updated directly")
+	if req.Schema != "" && resource.Schema != req.Schema {
+		return false, unsupportedResourceUpdateError(ctx, "schema is managed by discover and cannot be updated directly")
 	}
 	if req.SourceIdentifier != "" && resource.SourceIdentifier != req.SourceIdentifier {
 		return false, unsupportedResourceUpdateError(ctx, "source_identifier is managed by discover and cannot be updated directly")

--- a/adp/vega/vega-backend/server/logics/semantic_understanding_task/semantic_understanding_task_service.go
+++ b/adp/vega/vega-backend/server/logics/semantic_understanding_task/semantic_understanding_task_service.go
@@ -590,7 +590,7 @@ type catalogAgentInputResource struct {
 	ID               string                         `json:"id"`
 	Name             string                         `json:"name"`
 	Description      string                         `json:"description,omitempty"`
-	Database         string                         `json:"database,omitempty"`
+	Schema           string                         `json:"schema,omitempty"`
 	SourceIdentifier string                         `json:"source_identifier"`
 	Keys             *catalogAgentInputResourceKeys `json:"keys,omitempty"`
 	Fields           []catalogAgentInputProperty    `json:"fields"`
@@ -688,7 +688,7 @@ func buildCatalogAgentInputResource(resource *interfaces.Resource) catalogAgentI
 		ID:               resource.ID,
 		Name:             resource.Name,
 		Description:      resource.Description,
-		Database:         resource.Schema,
+		Schema:           resource.Schema,
 		SourceIdentifier: resource.SourceIdentifier,
 		Keys:             buildCatalogAgentInputResourceKeys(resource.SourceMetadata),
 		Fields:           buildCatalogAgentInputProperties(resource.SchemaDefinition),

--- a/adp/vega/vega-backend/server/logics/semantic_understanding_task/semantic_understanding_task_service.go
+++ b/adp/vega/vega-backend/server/logics/semantic_understanding_task/semantic_understanding_task_service.go
@@ -548,7 +548,7 @@ type resourceAgentInputResource struct {
 	ID                string                       `json:"id"`
 	Name              string                       `json:"name"`
 	Category          string                       `json:"category"`
-	Database          string                       `json:"database,omitempty"`
+	Schema            string                       `json:"schema,omitempty"`
 	SourceIdentifier  string                       `json:"source_identifier"`
 	SourceDescription string                       `json:"source_description,omitempty"`
 	Description       string                       `json:"description,omitempty"`
@@ -676,7 +676,7 @@ func buildResourceAgentInputResource(resource *interfaces.Resource) resourceAgen
 		ID:               resource.ID,
 		Name:             resource.Name,
 		Category:         resource.Category,
-		Database:         resource.Database,
+		Schema:           resource.Schema,
 		SourceIdentifier: resource.SourceIdentifier,
 		Description:      resource.Description,
 		SchemaDefinition: buildResourceAgentInputProperties(resource.SchemaDefinition),
@@ -688,7 +688,7 @@ func buildCatalogAgentInputResource(resource *interfaces.Resource) catalogAgentI
 		ID:               resource.ID,
 		Name:             resource.Name,
 		Description:      resource.Description,
-		Database:         resource.Database,
+		Database:         resource.Schema,
 		SourceIdentifier: resource.SourceIdentifier,
 		Keys:             buildCatalogAgentInputResourceKeys(resource.SourceMetadata),
 		Fields:           buildCatalogAgentInputProperties(resource.SchemaDefinition),

--- a/adp/vega/vega-backend/server/logics/semantic_understanding_task/semantic_understanding_task_service_test.go
+++ b/adp/vega/vega-backend/server/logics/semantic_understanding_task/semantic_understanding_task_service_test.go
@@ -74,6 +74,8 @@ func TestBuildCatalogSemanticUnderstandingInput(t *testing.T) {
 	resources := got["resources"].([]any)
 	require.Len(t, resources, 1)
 	resource := resources[0].(map[string]any)
+	assert.Equal(t, "ecommerce", resource["schema"])
+	assert.NotContains(t, resource, "database")
 	assert.NotContains(t, resource, "schema_definition")
 	fields := resource["fields"].([]any)
 	require.Len(t, fields, 1)

--- a/adp/vega/vega-backend/server/logics/semantic_understanding_task/semantic_understanding_task_service_test.go
+++ b/adp/vega/vega-backend/server/logics/semantic_understanding_task/semantic_understanding_task_service_test.go
@@ -41,7 +41,7 @@ func TestBuildCatalogSemanticUnderstandingInput(t *testing.T) {
 				SourceIdentifier: "public.orders",
 				Description:      "销售订单资源",
 				Category:         interfaces.ResourceCategoryTable,
-				Database:         "ecommerce",
+				Schema:           "ecommerce",
 				SourceMetadata: map[string]any{
 					"primary_keys": []any{"order_id"},
 					"indices": []any{
@@ -450,7 +450,7 @@ func sampleSemanticResource() *interfaces.Resource {
 		CatalogID:        "catalog-1",
 		Name:             "orders",
 		Category:         interfaces.ResourceCategoryTable,
-		Database:         "sales",
+		Schema:           "sales",
 		SourceIdentifier: "orders",
 		Description:      "order table",
 		SchemaDefinition: []*interfaces.Property{

--- a/adp/vega/vega-backend/server/worker/build_worker_streaming.go
+++ b/adp/vega/vega-backend/server/worker/build_worker_streaming.go
@@ -13,6 +13,7 @@ import (
 	"hash/fnv"
 	"net/http"
 	"sort"
+	"strings"
 	"time"
 
 	"github.com/bytedance/sonic"
@@ -182,7 +183,17 @@ func (sbw *streamingBuildWorker) HandleTask(ctx context.Context, task *asynq.Tas
 	}
 
 	sourceIdentifier := resource.SourceIdentifier
-	database := catalog.ConnectorCfg["database"]
+	database, err := streamingDatabase(catalog)
+	if err != nil {
+		logger.Errorf("Invalid streaming connector configuration for task %s: %v", taskID, err)
+		update := interfaces.NewBuildTaskUpdate().
+			WithStatus(interfaces.BuildTaskStatusFailed).
+			WithErrorMsg(err.Error())
+		if _, updateErr := sbw.bts.InternalUpdateStatus(ctx, nil, taskID, update); updateErr != nil {
+			return fmt.Errorf("update build task status failed: %w", updateErr)
+		}
+		return nil
+	}
 
 	indexName := getIndexName(resource.ID, buildTaskInfo.ID)
 	err = createManagedLocalIndex(ctx, sbw.lim, indexName, buildTaskInfo, resource)
@@ -213,7 +224,7 @@ func (sbw *streamingBuildWorker) HandleTask(ctx context.Context, task *asynq.Tas
 }
 
 // executeBuild executes the build logic
-func (sbw *streamingBuildWorker) executeBuild(ctx context.Context, catalog *interfaces.Catalog, resource *interfaces.Resource, buildTaskInfo *interfaces.BuildTask, indexName string, database any, sourceIdentifier string) error {
+func (sbw *streamingBuildWorker) executeBuild(ctx context.Context, catalog *interfaces.Catalog, resource *interfaces.Resource, buildTaskInfo *interfaces.BuildTask, indexName string, database string, sourceIdentifier string) error {
 	// Use the connector name as the Kafka topic prefix
 	topic := fmt.Sprintf("%s-%s.%s", interfaces.BUILD_PREFIX, catalog.ID, sourceIdentifier)
 	groupID := fmt.Sprintf("%s-%s", interfaces.BUILD_PREFIX, resource.ID)
@@ -422,7 +433,7 @@ func (sbw *streamingBuildWorker) executeBuild(ctx context.Context, catalog *inte
 }
 
 // createKafkaConnector creates a Kafka connector for the build task
-func (sbw *streamingBuildWorker) createKafkaConnector(ctx context.Context, catalog *interfaces.Catalog, _ *interfaces.Resource, database any, sourceIdentifier string) error {
+func (sbw *streamingBuildWorker) createKafkaConnector(ctx context.Context, catalog *interfaces.Catalog, _ *interfaces.Resource, database string, sourceIdentifier string) error {
 	// get connector
 	kafkaConnectSetting := sbw.appSetting.KafkaConnectSetting
 	// connector name 和 catalog 绑定，catalog 下多个 resource 公有一个 connector，各自订阅自己的表的 topic
@@ -499,7 +510,7 @@ func (sbw *streamingBuildWorker) createKafkaConnector(ctx context.Context, catal
 }
 
 // buildConnectorConfig builds the connector configuration
-func (sbw *streamingBuildWorker) buildConnectorConfig(connectorName string, catalog *interfaces.Catalog, database any, _ string) map[string]any {
+func (sbw *streamingBuildWorker) buildConnectorConfig(connectorName string, catalog *interfaces.Catalog, database string, _ string) map[string]any {
 	// Connector not found, create connector
 	mqSetting := sbw.appSetting.MQSetting
 	connectorBody := map[string]any{
@@ -544,6 +555,52 @@ func (sbw *streamingBuildWorker) buildConnectorConfig(connectorName string, cata
 	}
 
 	return connectorBody
+}
+
+// streamingDatabase returns the Debezium capture database configuration for a catalog.
+func streamingDatabase(catalog *interfaces.Catalog) (string, error) {
+	switch catalog.ConnectorType {
+	case interfaces.ConnectorTypePostgreSQL:
+		database, ok := catalog.ConnectorCfg["database"].(string)
+		if !ok || strings.TrimSpace(database) == "" {
+			return "", fmt.Errorf("PostgreSQL streaming build requires connector_config.database")
+		}
+		return database, nil
+	case interfaces.ConnectorTypeMySQL:
+		value, ok := catalog.ConnectorCfg["databases"]
+		if !ok {
+			return "", fmt.Errorf("MySQL streaming build requires a non-empty connector_config.databases")
+		}
+
+		var databases []string
+		switch configuredDatabases := value.(type) {
+		case []string:
+			databases = configuredDatabases
+		case []any:
+			databases = make([]string, 0, len(configuredDatabases))
+			for _, configuredDatabase := range configuredDatabases {
+				database, ok := configuredDatabase.(string)
+				if !ok {
+					return "", fmt.Errorf("MySQL streaming build requires connector_config.databases to contain only strings")
+				}
+				databases = append(databases, database)
+			}
+		default:
+			return "", fmt.Errorf("MySQL streaming build requires connector_config.databases to be an array")
+		}
+
+		if len(databases) == 0 {
+			return "", fmt.Errorf("MySQL streaming build requires a non-empty connector_config.databases")
+		}
+		for _, database := range databases {
+			if strings.TrimSpace(database) == "" {
+				return "", fmt.Errorf("MySQL streaming build requires connector_config.databases without empty values")
+			}
+		}
+		return strings.Join(databases, ","), nil
+	default:
+		return "", fmt.Errorf("unsupported streaming connector type: %s", catalog.ConnectorType)
+	}
 }
 
 // handleUpdateOperation 处理更新操作

--- a/adp/vega/vega-backend/server/worker/build_worker_streaming.go
+++ b/adp/vega/vega-backend/server/worker/build_worker_streaming.go
@@ -13,7 +13,6 @@ import (
 	"hash/fnv"
 	"net/http"
 	"sort"
-	"strings"
 	"time"
 
 	"github.com/bytedance/sonic"
@@ -182,22 +181,8 @@ func (sbw *streamingBuildWorker) HandleTask(ctx context.Context, task *asynq.Tas
 		return nil
 	}
 
+	sourceIdentifier := resource.SourceIdentifier
 	database := catalog.ConnectorCfg["database"]
-	if database == nil || database == "" {
-		database = resource.Database
-	}
-	sourceId, err := sbw.formatTableName(resource.SourceIdentifier, catalog.ConnectorType, database)
-	if err != nil {
-		logger.Errorf("Failed to format table name: %v", err)
-		update := interfaces.NewBuildTaskUpdate().
-			WithStatus(interfaces.BuildTaskStatusFailed).
-			WithErrorMsg(err.Error())
-		_, err = sbw.bts.InternalUpdateStatus(ctx, nil, buildTaskInfo.ID, update)
-		if err != nil {
-			return fmt.Errorf("update build task status failed: %w", err)
-		}
-		return nil
-	}
 
 	indexName := getIndexName(resource.ID, buildTaskInfo.ID)
 	err = createManagedLocalIndex(ctx, sbw.lim, indexName, buildTaskInfo, resource)
@@ -213,7 +198,7 @@ func (sbw *streamingBuildWorker) HandleTask(ctx context.Context, task *asynq.Tas
 	}
 
 	// Execute build
-	err = sbw.executeBuild(ctx, catalog, resource, buildTaskInfo, indexName, database, sourceId)
+	err = sbw.executeBuild(ctx, catalog, resource, buildTaskInfo, indexName, database, sourceIdentifier)
 	if err != nil {
 		update := interfaces.NewBuildTaskUpdate().WithErrorMsg(err.Error())
 		if isAsynqFinalRetry(ctx) {
@@ -228,9 +213,9 @@ func (sbw *streamingBuildWorker) HandleTask(ctx context.Context, task *asynq.Tas
 }
 
 // executeBuild executes the build logic
-func (sbw *streamingBuildWorker) executeBuild(ctx context.Context, catalog *interfaces.Catalog, resource *interfaces.Resource, buildTaskInfo *interfaces.BuildTask, indexName string, database any, sourceId string) error {
+func (sbw *streamingBuildWorker) executeBuild(ctx context.Context, catalog *interfaces.Catalog, resource *interfaces.Resource, buildTaskInfo *interfaces.BuildTask, indexName string, database any, sourceIdentifier string) error {
 	// Use the connector name as the Kafka topic prefix
-	topic := fmt.Sprintf("%s-%s.%s", interfaces.BUILD_PREFIX, catalog.ID, sourceId)
+	topic := fmt.Sprintf("%s-%s.%s", interfaces.BUILD_PREFIX, catalog.ID, sourceIdentifier)
 	groupID := fmt.Sprintf("%s-%s", interfaces.BUILD_PREFIX, resource.ID)
 
 	// Create Kafka topic if it doesn't exist
@@ -268,7 +253,7 @@ func (sbw *streamingBuildWorker) executeBuild(ctx context.Context, catalog *inte
 		defer sbw.kafkaAccess.CloseWriter(writer)
 	}
 
-	err = sbw.createKafkaConnector(ctx, catalog, resource, database, sourceId)
+	err = sbw.createKafkaConnector(ctx, catalog, resource, database, sourceIdentifier)
 	if err != nil {
 		return fmt.Errorf("create kafka connector failed: %w", err)
 	}
@@ -437,7 +422,7 @@ func (sbw *streamingBuildWorker) executeBuild(ctx context.Context, catalog *inte
 }
 
 // createKafkaConnector creates a Kafka connector for the build task
-func (sbw *streamingBuildWorker) createKafkaConnector(ctx context.Context, catalog *interfaces.Catalog, _ *interfaces.Resource, database any, sourceId string) error {
+func (sbw *streamingBuildWorker) createKafkaConnector(ctx context.Context, catalog *interfaces.Catalog, _ *interfaces.Resource, database any, sourceIdentifier string) error {
 	// get connector
 	kafkaConnectSetting := sbw.appSetting.KafkaConnectSetting
 	// connector name 和 catalog 绑定，catalog 下多个 resource 公有一个 connector，各自订阅自己的表的 topic
@@ -453,7 +438,7 @@ func (sbw *streamingBuildWorker) createKafkaConnector(ctx context.Context, catal
 	}
 	switch respCode {
 	case http.StatusNotFound:
-		connectorBody := sbw.buildConnectorConfig(connectorName, catalog, database, sourceId)
+		connectorBody := sbw.buildConnectorConfig(connectorName, catalog, database, sourceIdentifier)
 		respCode, respBody, err := sbw.httpClient.Post(ctx, connectorUrl, headers, connectorBody)
 		if err != nil {
 			return fmt.Errorf("failed to create kafka connector: %w", err)
@@ -473,7 +458,7 @@ func (sbw *streamingBuildWorker) createKafkaConnector(ctx context.Context, catal
 		table_lists := strings.Split(tableIncludeList, ",")
 		tableExist := false
 		for _, table := range table_lists {
-			if strings.TrimSpace(table) == sourceId {
+			if strings.TrimSpace(table) == sourceIdentifier {
 				tableExist = true
 				break
 			}
@@ -484,13 +469,13 @@ func (sbw *streamingBuildWorker) createKafkaConnector(ctx context.Context, catal
 			if newTableList != "" {
 				newTableList += ","
 			}
-			newTableList += sourceId
+			newTableList += sourceIdentifier
 			config["table.include.list"] = newTableList
 			_, _, err = sbw.httpClient.Put(ctx, fmt.Sprintf("%s/%s/config", connectorUrl, connectorName), headers, config)
 			if err != nil {
 				return fmt.Errorf("Failed to update kafka connector config: %w", err)
 			}
-			logger.Infof("Updated kafka connector config to include table: %s", sourceId)
+			logger.Infof("Updated kafka connector config to include table: %s", sourceIdentifier)
 		}*/
 		// check kafka connector status
 		_, respBody, err := sbw.httpClient.Get(ctx, fmt.Sprintf("%s/%s/status", connectorUrl, connectorName), nil, headers)
@@ -531,7 +516,7 @@ func (sbw *streamingBuildWorker) buildConnectorConfig(connectorName string, cata
 			"schema.history.internal.kafka.topic":             fmt.Sprintf("%s-schema-changes", interfaces.BUILD_PREFIX),
 			"include.schema.changes":                          "true",
 			"topic.prefix":                                    fmt.Sprintf("%s-%s", interfaces.BUILD_PREFIX, catalog.ID),
-			//"table.include.list":                              sourceId, // 同-catalog下多resource构建，公用一个connector，但是如果加了table.include.list，其他resource就没有全量快照，除非一开始就设置到table.include.list中
+			//"table.include.list":                              sourceIdentifier, // 同-catalog下多resource构建，公用一个connector，但是如果加了table.include.list，其他resource就没有全量快照，除非一开始就设置到table.include.list中
 			//"snapshot.mode":                                   "when_needed",
 		},
 	}
@@ -611,32 +596,6 @@ func (sbw *streamingBuildWorker) handleDeleteOperation(ctx context.Context, keyM
 	}
 
 	return nil
-}
-
-// 格式化table名称
-func (sbw *streamingBuildWorker) formatTableName(sourceIdentifier string, connectorType string, database any) (string, error) {
-	if database == nil || database == "" {
-		return "", fmt.Errorf("database is empty or nil")
-	}
-	sourceId := sourceIdentifier
-	switch connectorType {
-	case interfaces.ConnectorTypeMySQL:
-		// 如果不是 db.table 格式，前面加上 dbname.
-		if !strings.Contains(sourceIdentifier, ".") {
-			sourceId = fmt.Sprintf("%v", database) + "." + sourceIdentifier
-		}
-	case interfaces.ConnectorTypePostgreSQL:
-		// 如果是 db.schema.table 格式，去掉 db.
-		if strings.Count(sourceIdentifier, ".") >= 2 {
-			parts := strings.Split(sourceIdentifier, ".")
-			sourceId = strings.Join(parts[1:], ".")
-		} else if !strings.Contains(sourceIdentifier, ".") {
-			return "", fmt.Errorf("sourceIdentifier %s is not contain database name or schema name", sourceIdentifier)
-		}
-	default:
-		return "", fmt.Errorf("connector type %s is not supported", connectorType)
-	}
-	return sourceId, nil
 }
 
 // check connector need to be stop

--- a/adp/vega/vega-backend/server/worker/build_worker_streaming_test.go
+++ b/adp/vega/vega-backend/server/worker/build_worker_streaming_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
 
+	"vega-backend/common"
 	"vega-backend/interfaces"
 	vmock "vega-backend/interfaces/mock"
 )
@@ -73,5 +74,102 @@ func TestStreamingBuildWorkerHandleTask(t *testing.T) {
 
 		task := asynq.NewTask("build:streaming", workerBuildTaskPayload(t, interfaces.StreamingBuildTaskMessage{TaskID: "t1"}))
 		require.NoError(t, sh.HandleTask(context.Background(), task))
+	})
+
+	t.Run("marks task failed for invalid streaming connector configuration", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		bts := vmock.NewMockBuildTaskService(ctrl)
+		rs := vmock.NewMockResourceService(ctrl)
+		cs := vmock.NewMockCatalogService(ctrl)
+		sh := &streamingBuildWorker{bts: bts, rs: rs, cs: cs}
+
+		bts.EXPECT().InternalGetByID(gomock.Any(), "t1").Return(&interfaces.BuildTask{
+			ID: "t1", ResourceID: "r1", Status: interfaces.BuildTaskStatusInit,
+		}, nil)
+		bts.EXPECT().InternalUpdateStatus(gomock.Any(), nil, "t1",
+			interfaces.NewBuildTaskUpdate().
+				WithStatus(interfaces.BuildTaskStatusRunning).
+				WithErrorMsg(""),
+			interfaces.BuildTaskStatusInit).
+			Return(true, nil)
+		rs.EXPECT().InternalGetByID(gomock.Any(), "r1").Return(&interfaces.Resource{ID: "r1", CatalogID: "c1"}, nil)
+		cs.EXPECT().InternalGetByID(gomock.Any(), "c1", true).Return(&interfaces.Catalog{
+			ID:            "c1",
+			Enabled:       true,
+			ConnectorType: interfaces.ConnectorTypePostgreSQL,
+			ConnectorCfg:  interfaces.ConnectorConfig{},
+		}, nil)
+		bts.EXPECT().InternalUpdateStatus(gomock.Any(), nil, "t1",
+			interfaces.NewBuildTaskUpdate().
+				WithStatus(interfaces.BuildTaskStatusFailed).
+				WithErrorMsg("PostgreSQL streaming build requires connector_config.database")).
+			Return(true, nil)
+
+		task := asynq.NewTask("build:streaming", workerBuildTaskPayload(t, interfaces.StreamingBuildTaskMessage{TaskID: "t1"}))
+		require.NoError(t, sh.HandleTask(context.Background(), task))
+	})
+}
+
+func TestStreamingDatabase(t *testing.T) {
+	t.Run("returns PostgreSQL connection database", func(t *testing.T) {
+		database, err := streamingDatabase(&interfaces.Catalog{
+			ConnectorType: interfaces.ConnectorTypePostgreSQL,
+			ConnectorCfg:  interfaces.ConnectorConfig{"database": "app"},
+		})
+
+		require.NoError(t, err)
+		assert.Equal(t, "app", database)
+	})
+
+	t.Run("rejects PostgreSQL without connection database", func(t *testing.T) {
+		_, err := streamingDatabase(&interfaces.Catalog{
+			ConnectorType: interfaces.ConnectorTypePostgreSQL,
+			ConnectorCfg:  interfaces.ConnectorConfig{},
+		})
+
+		require.ErrorContains(t, err, "connector_config.database")
+	})
+
+	t.Run("returns MySQL database include list from databases", func(t *testing.T) {
+		database, err := streamingDatabase(&interfaces.Catalog{
+			ConnectorType: interfaces.ConnectorTypeMySQL,
+			ConnectorCfg:  interfaces.ConnectorConfig{"databases": []any{"app", "analytics"}},
+		})
+
+		require.NoError(t, err)
+		assert.Equal(t, "app,analytics", database)
+	})
+
+	t.Run("rejects MySQL instance-level catalog", func(t *testing.T) {
+		_, err := streamingDatabase(&interfaces.Catalog{
+			ConnectorType: interfaces.ConnectorTypeMySQL,
+			ConnectorCfg:  interfaces.ConnectorConfig{"databases": []any{}},
+		})
+
+		require.ErrorContains(t, err, "non-empty connector_config.databases")
+	})
+}
+
+func TestBuildConnectorConfigUsesCaptureDatabase(t *testing.T) {
+	worker := &streamingBuildWorker{appSetting: &common.AppSetting{}}
+
+	t.Run("uses database include list for MySQL", func(t *testing.T) {
+		config := worker.buildConnectorConfig("build-c1", &interfaces.Catalog{
+			ID:            "c1",
+			ConnectorType: interfaces.ConnectorTypeMySQL,
+			ConnectorCfg:  interfaces.ConnectorConfig{},
+		}, "app,analytics", "")
+
+		assert.Equal(t, "app,analytics", config["config"].(map[string]any)["database.include.list"])
+	})
+
+	t.Run("uses connection database for PostgreSQL", func(t *testing.T) {
+		config := worker.buildConnectorConfig("build-c1", &interfaces.Catalog{
+			ID:            "c1",
+			ConnectorType: interfaces.ConnectorTypePostgreSQL,
+			ConnectorCfg:  interfaces.ConnectorConfig{},
+		}, "app", "")
+
+		assert.Equal(t, "app", config["config"].(map[string]any)["database.dbname"])
 	})
 }

--- a/adp/vega/vega-backend/server/worker/discover_fileset.go
+++ b/adp/vega/vega-backend/server/worker/discover_fileset.go
@@ -147,7 +147,7 @@ func (dtw *DiscoverTaskWorker) createFilesetResource(ctx context.Context, catalo
 		Name:             fs.Name,
 		Category:         interfaces.ResourceCategoryFileset,
 		Status:           interfaces.ResourceStatusActive,
-		Database:         "",
+		Schema:           "",
 		SourceIdentifier: sourceIdentifier,
 		SourceMetadata:   meta,
 	}

--- a/adp/vega/vega-backend/server/worker/discover_table.go
+++ b/adp/vega/vega-backend/server/worker/discover_table.go
@@ -93,7 +93,7 @@ func (dtw *DiscoverTaskWorker) enrichTableMetadata(ctx context.Context, tableCon
 		}
 
 		// 填充 Resource 元数据 ：schema_definition 字段
-		resource.Database = table.Database
+		resource.Schema = table.Schema
 		resource.SchemaDefinition = []*interfaces.Property{}
 		for _, column := range table.Columns {
 			resource.SchemaDefinition = append(resource.SchemaDefinition, &interfaces.Property{
@@ -260,7 +260,7 @@ func (dtw *DiscoverTaskWorker) createResource(ctx context.Context, catalog *inte
 		Description:      table.Description,
 		Category:         interfaces.ResourceCategoryTable,
 		Status:           interfaces.ResourceStatusActive,
-		Database:         table.Database,
+		Schema:           table.Schema,
 		SourceIdentifier: sourceIdentifier,
 		SourceMetadata: map[string]any{
 			"original_name":        sourceIdentifier,

--- a/adp/vega/vega-backend/server/worker/discover_task_worker.go
+++ b/adp/vega/vega-backend/server/worker/discover_task_worker.go
@@ -127,8 +127,8 @@ func (dtw *DiscoverTaskWorker) discoverCatalog(ctx context.Context, catalog *int
 	}
 	defer func() { _ = connector.Close(ctx) }()
 
-	// Update catalog metadata
 	if meta, err := connector.GetMetadata(ctx); err == nil {
+		catalog.Metadata = meta
 		if err := dtw.cs.UpdateMetadata(ctx, catalog.ID, meta); err != nil {
 			logger.Errorf("Failed to update catalog metadata: %v", err)
 		}

--- a/adp/vega/vega-backend/server/worker/semantic_understanding_task_worker.go
+++ b/adp/vega/vega-backend/server/worker/semantic_understanding_task_worker.go
@@ -627,7 +627,7 @@ func (sutw *SemanticUnderstandingTaskWorker) applyCatalogResult(ctx context.Cont
 				Description:     nextDescription,
 				Category:        current.Category,
 				Status:          current.Status,
-				Database:        current.Database,
+				Schema:          current.Schema,
 				SourceMetadata:  current.SourceMetadata,
 				IndexConfig:     current.IndexConfig,
 				LogicDefinition: nextLogicDefinition,

--- a/docs/api/vega/catalog.yaml
+++ b/docs/api/vega/catalog.yaml
@@ -532,8 +532,14 @@ components:
           type: object
           additionalProperties: true
         metadata:
-          description: 扩展元信息
+          description: 扩展元信息；关系型 Catalog 探查后可包含 schemas 快照
           type: object
+          properties:
+            schemas:
+              description: 探查发现的 schema 名称列表
+              type: array
+              items:
+                type: string
           additionalProperties: true
         extensions:
           $ref: "#/components/schemas/EntityExtensions"

--- a/docs/api/vega/resource.yaml
+++ b/docs/api/vega/resource.yaml
@@ -98,8 +98,8 @@ paths:
               - disabled
               - deprecated
               - stale
-        - name: database
-          description: 按所属 database 过滤（实例级 catalog 时有意义）
+        - name: schema
+          description: 按所属 schema 过滤；过滤在服务端计数和分页之前完成
           in: query
           schema:
             type: string
@@ -600,8 +600,8 @@ components:
         last_discover_status:
           description: 最近一次资源发现的观察状态
           type: string
-        database:
-          description: 所属数据库（实例级 Catalog 时填充）
+        schema:
+          description: 所属 schema，由发现流程写入
           type: string
         source_identifier:
           description: 源端标识（原始表名 / 路径 / topic 名等）
@@ -714,7 +714,8 @@ components:
             - disabled
             - deprecated
             - stale
-        database:
+        schema:
+          description: 所属 schema，由发现流程写入
           type: string
         source_identifier:
           type: string

--- a/migrations/vega-backend/mariadb/0.1.3/01-catalog-schema.sql
+++ b/migrations/vega-backend/mariadb/0.1.3/01-catalog-schema.sql
@@ -10,5 +10,17 @@ USE openbkn;
 ALTER TABLE t_resource
     CHANGE COLUMN f_database f_schema VARCHAR(128) NOT NULL DEFAULT '' COMMENT '所属 schema 名称，由发现流程写入';
 
+-- 旧 Resource 的 source_identifier 使用 schema.table。rename 后 f_schema 暂存旧 database 值，
+-- 必须由 source_identifier 回填；无法可靠识别的记录置空，等待下一次 discover 写入权威值。
+UPDATE t_resource r
+JOIN t_catalog c ON c.f_id = r.f_catalog_id
+SET r.f_schema = CASE
+    WHEN r.f_source_identifier LIKE '%.%'
+        THEN SUBSTRING_INDEX(r.f_source_identifier, '.', 1)
+    ELSE ''
+END
+WHERE c.f_connector_type IN ('postgresql', 'mariadb', 'mysql')
+  AND r.f_category = 'table';
+
 ALTER TABLE t_resource
     ADD INDEX idx_catalog_schema (f_catalog_id, f_schema);

--- a/migrations/vega-backend/mariadb/0.1.3/01-catalog-schema.sql
+++ b/migrations/vega-backend/mariadb/0.1.3/01-catalog-schema.sql
@@ -1,0 +1,14 @@
+-- Copyright 2026 openbkn.ai
+-- Copyright The kweaver.ai Authors.
+--
+-- Licensed under the Apache License, Version 2.0.
+-- See the LICENSE file in the project root for details.
+
+-- Issue #240：Catalog 将发现得到的 schema 快照保存到 f_metadata.schemas；Resource 以 schema 作为筛选维度。
+USE openbkn;
+
+ALTER TABLE t_resource
+    CHANGE COLUMN f_database f_schema VARCHAR(128) NOT NULL DEFAULT '' COMMENT '所属 schema 名称，由发现流程写入';
+
+ALTER TABLE t_resource
+    ADD INDEX idx_catalog_schema (f_catalog_id, f_schema);

--- a/migrations/vega-backend/mariadb/0.1.3/init.sql
+++ b/migrations/vega-backend/mariadb/0.1.3/init.sql
@@ -1,0 +1,497 @@
+-- Copyright 2026 openbkn.ai
+-- Copyright The kweaver.ai Authors.
+--
+-- Licensed under the Apache License, Version 2.0.
+-- See the LICENSE file in the project root for details.
+
+-- ==========================================
+-- VEGA Catalog 表结构定义
+-- ==========================================
+
+-- ==========================================
+-- Schema定义说明（f_schema_definition字段JSON格式）
+-- ==========================================
+-- f_schema_definition 字段使用JSON数组格式存储所有字段信息，每个字段包含以下属性：
+--
+-- 基础属性：
+--   - name: 字段名称
+--   - type: VEGA统一类型 (integer, unsigned_integer, float, decimal, string, text, date, datetime, time, boolean, binary, json, vector)
+--   - description: 字段描述
+--   - type_config: 类型配置对象 (如 {"max_length": 128}, {"dimension": 768})
+--
+-- 源端映射：
+--   - source_name: 源端字段名（可能与name不同）
+--   - source_type: 源端字段类型
+--   - is_native: 是否为系统自动同步的字段
+--
+-- 字段属性：
+--   - is_primary: 是否为主键
+--   - is_nullable: 是否可为空
+--   - default_value: 默认值
+--   - ordinal_position: 字段顺序位置
+--
+-- 字段特征（features数组，可选，用于扩展字段能力）：
+--   - feature_type: 特征类型 (keyword, fulltext, vector)
+--   - feature_config: 特征配置对象 (如分词器、向量空间类型等)
+--   - ref_field_name: 引用的字段名称（用于借用其他字段的能力）
+--   - enabled: 是否启用
+--
+-- 示例：
+-- [
+--   {
+--     "name": "id",
+--     "type": "integer",
+--     "description": "主键ID",
+--     "type_config": {"length": 11},
+--     "source_name": "id",
+--     "source_type": "int(11)",
+--     "is_native": true,
+--     "is_primary": true,
+--     "is_nullable": false,
+--     "default_value": "",
+--     "ordinal_position": 1
+--   },
+--   {
+--     "name": "content",
+--     "type": "text",
+--     "description": "文章内容",
+--     "type_config": {},
+--     "source_name": "content",
+--     "source_type": "text",
+--     "is_native": true,
+--     "is_primary": false,
+--     "is_nullable": true,
+--     "default_value": "",
+--     "ordinal_position": 2,
+--     "features": [
+--       {
+--         "feature_type": "fulltext",
+--         "feature_config": {"analyzer": "ik_max_word"},
+--         "ref_field_name": "",
+--         "is_default": true
+--       }
+--     ]
+--   },
+--   {
+--     "name": "embedding",
+--     "type": "vector",
+--     "description": "向量嵌入",
+--     "type_config": {"dimension": 768},
+--     "source_name": "",
+--     "source_type": "",
+--     "is_native": false,
+--     "is_primary": false,
+--     "is_nullable": true,
+--     "default_value": "",
+--     "ordinal_position": 3,
+--     "features": [
+--       {
+--         "feature_type": "vector",
+--         "feature_config": {"space_type": "cosinesimil", "m": 16, "ef_construction": 200},
+--         "ref_field_name": "",
+--         "is_default": true
+--       }
+--     ]
+--   }
+-- ]
+-- ==========================================
+USE openbkn;
+-- ==========================================
+-- 1. t_catalog 主表
+-- ==========================================
+CREATE TABLE IF NOT EXISTS t_catalog (
+    -- 主键与基础信息
+    f_id                      VARCHAR(40) NOT NULL DEFAULT '' COMMENT 'catalog唯一标识',
+    f_name                    VARCHAR(255) NOT NULL DEFAULT '' COMMENT '目录名称，系统一级命名空间',
+    f_tags                    VARCHAR(255) NOT NULL DEFAULT '[]' COMMENT '标签，逗号分隔，用于分类和检索',
+    f_description             VARCHAR(1000) NOT NULL DEFAULT '' COMMENT '目录描述',
+
+    f_type                    VARCHAR(20) NOT NULL DEFAULT '' COMMENT '目录类型: physical, logical',
+    f_enabled                 BOOLEAN NOT NULL DEFAULT TRUE COMMENT '是否启用',
+    f_internal                BOOLEAN NOT NULL DEFAULT FALSE COMMENT '是否系统内部目录：内部目录在权限服务按 internal_catalog 类型注册，业务角色的 catalog:* 通配授权匹配不到，仅超级管理员可见',
+
+    -- Physical Catalog 专属字段
+    f_connector_type          VARCHAR(50) NOT NULL DEFAULT '' COMMENT '数据源类型: mysql, postgresql, s3, kafka, elasticsearch, api, prometheus, etc.',
+    f_connector_config        MEDIUMTEXT NOT NULL COMMENT '加密存储的连接配置（JSON格式）',
+    f_metadata                MEDIUMTEXT NOT NULL COMMENT '自动发现的元数据（JSON格式），如数据库版本、schema快照等',
+
+    -- 状态管理
+    f_health_check_enabled    BOOLEAN NOT NULL DEFAULT TRUE COMMENT '是否启用健康检查',
+    f_health_check_status     VARCHAR(20) NOT NULL DEFAULT 'unchecked' COMMENT '连接状态: unchecked, healthy, degraded, unhealthy, offline',
+    f_last_check_time         BIGINT(20) NOT NULL DEFAULT 0 COMMENT '最后健康检查时间',
+    f_health_check_result     TEXT NOT NULL COMMENT '健康检查结果',
+
+    -- 审计字段
+    f_creator                 VARCHAR(40) NOT NULL DEFAULT '' COMMENT '创建者id',
+    f_creator_type            VARCHAR(20) NOT NULL DEFAULT '' COMMENT '创建者类型',
+    f_create_time             BIGINT(20) NOT NULL DEFAULT 0 COMMENT '创建时间',
+    f_updater                 VARCHAR(40) NOT NULL DEFAULT '' COMMENT '更新者id',
+    f_updater_type            VARCHAR(20) NOT NULL DEFAULT '' COMMENT '更新者类型',
+    f_update_time             BIGINT(20) NOT NULL DEFAULT 0 COMMENT '更新时间',
+
+    -- 索引
+    PRIMARY KEY (f_id),
+    UNIQUE INDEX uk_name (f_name),
+    INDEX idx_type (f_type),
+    INDEX idx_connector_type (f_connector_type),
+    INDEX idx_health_check_status (f_health_check_status)
+)  ENGINE = InnoDB DEFAULT CHARSET = utf8mb4 COLLATE = utf8mb4_bin COMMENT='目录表，管理数据源连接和命名空间';
+
+
+-- ==========================================
+-- 2. t_resource 数据资源主表
+-- ==========================================
+CREATE TABLE IF NOT EXISTS t_resource (
+    -- 主键与基础信息
+    f_id                      VARCHAR(40) NOT NULL DEFAULT '' COMMENT 'resource唯一标识',
+    f_catalog_id              VARCHAR(40) NOT NULL DEFAULT '' COMMENT '所属catalog ID',
+    f_name                    VARCHAR(255) NOT NULL DEFAULT '' COMMENT '数据资源名称，catalog下唯一',
+    f_tags                    VARCHAR(255) NOT NULL DEFAULT '[]' COMMENT '标签，JSON数组格式',
+    f_description             VARCHAR(1000) NOT NULL DEFAULT '' COMMENT '数据资源描述',
+
+    f_category                VARCHAR(20) NOT NULL DEFAULT '' COMMENT '数据资源类型: table, file, fileset, api, metric, topic, index, logicview, dataset',
+
+    -- 状态管理
+    f_status                  VARCHAR(20) NOT NULL DEFAULT 'active' COMMENT '数据资源状态: active, disabled, deprecated, stale',
+    f_status_message          VARCHAR(500) NOT NULL DEFAULT '' COMMENT '状态说明',
+    f_last_discover_status    VARCHAR(32) NOT NULL DEFAULT '' COMMENT '最近一次扫描观察状态',
+
+    -- 物理数据资源专属字段
+    f_schema                  VARCHAR(128) NOT NULL DEFAULT '' COMMENT '所属 schema 名称，由发现流程写入',
+    f_source_identifier       VARCHAR(500) NOT NULL DEFAULT '' COMMENT '源端标识(表名/文件路径/索引名等)',
+    f_source_metadata         MEDIUMTEXT NOT NULL COMMENT '源端元数据（JSON格式）',
+
+    -- Schema相关
+    f_schema_definition       MEDIUMTEXT NOT NULL COMMENT 'Schema定义（JSON数组格式，包含所有字段信息）',
+
+    -- LogicView 专属字段
+    f_logic_type              VARCHAR(20) NOT NULL DEFAULT '' COMMENT '逻辑类型: derived(衍生), composite(复合), 仅LogicView使用',
+    f_logic_definition        MEDIUMTEXT NOT NULL COMMENT '逻辑定义（JSON格式），仅LogicView使用',
+
+    -- Local查询配置（物化）
+    f_local_enabled           BOOLEAN NOT NULL DEFAULT FALSE COMMENT '是否启用Local查询（物化）',
+    f_local_storage_engine    VARCHAR(50) NOT NULL DEFAULT '' COMMENT '物化存储引擎: elasticsearch, opensearch, lancedb, pgvector',
+    f_local_storage_config    MEDIUMTEXT NOT NULL COMMENT '物化存储配置（JSON格式）',
+    f_local_index_name        VARCHAR(255) NOT NULL DEFAULT '' COMMENT '物化后的索引名称',
+
+    -- 同步配置
+    f_sync_strategy           VARCHAR(20) NOT NULL DEFAULT '' COMMENT '同步策略: cdc, bulk_load, etl_pipeline, polling, micro_batch, reindex, snapshot',
+    f_sync_config             MEDIUMTEXT NOT NULL COMMENT '同步配置（JSON格式：调度周期、批次大小等）',
+    f_sync_status             VARCHAR(20) NOT NULL DEFAULT 'not_synced' COMMENT '同步状态: not_synced, syncing, synced, failed',
+    f_last_sync_time          BIGINT(20) NOT NULL DEFAULT 0 COMMENT '最后同步时间',
+    f_sync_error_message      TEXT NOT NULL COMMENT '同步错误信息',
+
+    -- 审计字段
+    f_creator                 VARCHAR(40) NOT NULL DEFAULT '' COMMENT '创建者id',
+    f_creator_type            VARCHAR(20) NOT NULL DEFAULT '' COMMENT '创建者类型',
+    f_create_time             BIGINT(20) NOT NULL DEFAULT 0 COMMENT '创建时间',
+    f_updater                 VARCHAR(40) NOT NULL DEFAULT '' COMMENT '更新者id',
+    f_updater_type            VARCHAR(20) NOT NULL DEFAULT '' COMMENT '更新者类型',
+    f_update_time             BIGINT(20) NOT NULL DEFAULT 0 COMMENT '更新时间',
+
+    -- 索引
+    PRIMARY KEY (f_id),
+    INDEX idx_category (f_category),
+    INDEX idx_status (f_status),
+    INDEX idx_catalog_schema (f_catalog_id, f_schema)
+)  ENGINE = InnoDB DEFAULT CHARSET = utf8mb4 COLLATE = utf8mb4_bin COMMENT='数据资源主表，管理所有类型的数据资源';
+
+
+-- ==========================================
+-- 3. t_entity_extension Catalog/Resource 可检索业务 KV（extensions）副表
+-- Issue #382 方案 B
+-- ==========================================
+CREATE TABLE IF NOT EXISTS t_entity_extension (
+    f_entity_kind VARCHAR(20) NOT NULL COMMENT '实体类型: catalog / resource，与 f_entity_id 共同标识扩展所属实体',
+    f_entity_id VARCHAR(40) NOT NULL COMMENT '等于 t_catalog.f_id 或 t_resource.f_id',
+    f_key       VARCHAR(128) NOT NULL COMMENT '扩展键，建议 dip: 等业务前缀',
+    f_value     VARCHAR(512) NOT NULL COMMENT '扩展值，可为 JSON 文本',
+    f_create_time BIGINT(20) NOT NULL DEFAULT 0 COMMENT '创建时间（毫秒）',
+    f_update_time BIGINT(20) NOT NULL DEFAULT 0 COMMENT '更新时间（毫秒）',
+    PRIMARY KEY (f_entity_kind, f_entity_id, f_key),
+    KEY idx_entity (f_entity_kind, f_entity_id),
+    KEY idx_entity_key_value (f_entity_kind, f_entity_id, f_key, f_value(191))
+) ENGINE = InnoDB DEFAULT CHARSET = utf8mb4 COLLATE = utf8mb4_bin COMMENT='实体级 extensions 行存储（与 schema_definition 内 Property.extensions 分离）';
+
+
+-- ==========================================
+-- 4. t_resource_schema_history Schema历史表
+-- ==========================================
+CREATE TABLE IF NOT EXISTS t_resource_schema_history (
+    f_id                      VARCHAR(40) NOT NULL DEFAULT '' COMMENT '历史记录唯一标识',
+    f_resource_id             VARCHAR(40) NOT NULL DEFAULT '' COMMENT '所属resource ID',
+    f_schema_version          VARCHAR(40) NOT NULL DEFAULT '' COMMENT 'Schema版本号',
+    f_schema_definition       MEDIUMTEXT NOT NULL COMMENT 'Schema定义快照（JSON数组格式）',
+
+    -- 变更信息
+    f_change_type             VARCHAR(20) NOT NULL DEFAULT '' COMMENT '变更类型: created, field_added, field_removed, field_modified, type_changed',
+    f_change_summary          VARCHAR(1000) NOT NULL DEFAULT '' COMMENT '变更摘要',
+    f_schema_inferred         BOOLEAN NOT NULL DEFAULT FALSE COMMENT 'Schema是否为自动推导',
+    f_change_time             BIGINT(20) NOT NULL DEFAULT 0 COMMENT '变更时间',
+
+    -- 索引
+    PRIMARY KEY (f_id),
+    INDEX idx_resource_id (f_resource_id)
+)  ENGINE = InnoDB DEFAULT CHARSET = utf8mb4 COLLATE = utf8mb4_bin COMMENT='数据资源Schema历史表，记录Schema变更历史';
+
+
+-- ==========================================
+-- 5. t_connector_type Connector 类型注册表
+-- ==========================================
+CREATE TABLE IF NOT EXISTS t_connector_type (
+    -- 主键与基础信息
+    f_type                    VARCHAR(40) NOT NULL DEFAULT '' COMMENT 'connector类型,唯一标识',
+    f_name                    VARCHAR(255) NOT NULL DEFAULT '' COMMENT '类型名称: mysql, postgresql, kafka...',
+    f_tags                    VARCHAR(255) NOT NULL DEFAULT '[]' COMMENT '标签，JSON数组格式',
+    f_description             VARCHAR(1000) NOT NULL DEFAULT '' COMMENT '类型描述',
+
+    -- 类型分类
+    f_mode                    VARCHAR(20) NOT NULL DEFAULT '' COMMENT '模式: local, remote',
+    f_category                VARCHAR(32) NOT NULL DEFAULT '' COMMENT '分类: table, index, topic, file, api',
+
+    -- Remote 模式专用字段
+    f_endpoint                VARCHAR(512) NOT NULL DEFAULT '' COMMENT '远程服务地址 (仅remote模式)',
+
+    -- 字段配置列表（JSON数组格式）
+    f_field_config            MEDIUMTEXT NOT NULL COMMENT '字段配置列表（JSON数组格式，定义连接配置的结构）',
+
+    -- 状态
+    f_enabled                 BOOLEAN NOT NULL DEFAULT TRUE COMMENT '是否启用',
+
+    -- 索引
+    PRIMARY KEY (f_type),
+    UNIQUE INDEX uk_name (f_name),
+    INDEX idx_mode (f_mode),
+    INDEX idx_category (f_category),
+    INDEX idx_enabled (f_enabled)
+) ENGINE = InnoDB DEFAULT CHARSET = utf8mb4 COLLATE = utf8mb4_bin COMMENT='Connector类型注册表';
+
+
+-- ==========================================
+-- 6. 初始化内置 Local Connector
+-- ==========================================
+INSERT INTO t_connector_type (f_type, f_name, f_description, f_mode, f_category, f_field_config, f_enabled)
+SELECT 'mariadb', 'mariadb', 'MariaDB 关系型数据库连接器', 'local', 'table',
+    '{
+        "host":      {"name":"主机地址","type":"string","description":"数据库服务器主机地址","required":true,"encrypted":false},
+        "port":      {"name":"端口号","type":"integer","description":"数据库服务器端口","required":true,"encrypted":false},
+        "username":  {"name":"用户名","type":"string","description":"数据库用户名","required":true,"encrypted":false},
+        "password":  {"name":"密码","type":"string","description":"数据库密码","required":true,"encrypted":true},
+        "databases": {"name":"数据库列表","type":"array","description":"数据库名称列表（可选，为空则连接实例级别）","required":false,"encrypted":false},
+        "options":   {"name":"连接参数","type":"object","description":"连接参数（如 charset, timeout 等）","required":false,"encrypted":false}
+    }',
+    TRUE
+FROM DUAL WHERE NOT EXISTS ( SELECT f_type FROM t_connector_type WHERE f_type = 'mariadb' );
+
+INSERT INTO t_connector_type (f_type, f_name, f_description, f_mode, f_category, f_field_config, f_enabled)
+SELECT 'mysql', 'mysql', 'MySQL 关系型数据库连接器', 'local', 'table',
+       '{
+           "host":      {"name":"主机地址","type":"string","description":"数据库服务器主机地址","required":true,"encrypted":false},
+           "port":      {"name":"端口号","type":"integer","description":"数据库服务器端口","required":true,"encrypted":false},
+           "username":  {"name":"用户名","type":"string","description":"数据库用户名","required":true,"encrypted":false},
+           "password":  {"name":"密码","type":"string","description":"数据库密码","required":true,"encrypted":true},
+           "databases": {"name":"数据库列表","type":"array","description":"数据库名称列表（可选，为空则连接实例级别）","required":false,"encrypted":false},
+           "options":   {"name":"连接参数","type":"object","description":"连接参数（如 charset, timeout 等）","required":false,"encrypted":false}
+       }',
+       TRUE
+FROM DUAL WHERE NOT EXISTS ( SELECT f_type FROM t_connector_type WHERE f_type = 'mysql' );
+
+INSERT INTO t_connector_type (f_type, f_name, f_description, f_mode, f_category, f_field_config, f_enabled)
+SELECT 'opensearch', 'opensearch', 'OpenSearch 搜索引擎连接器', 'local', 'index',
+    '{
+        "host":          {"name":"主机地址","type":"string","description":"OpenSearch 服务器主机地址","required":true,"encrypted":false},
+        "port":          {"name":"端口号","type":"integer","description":"OpenSearch 服务器端口","required":true,"encrypted":false},
+        "username":      {"name":"用户名","type":"string","description":"认证用户名","required":false,"encrypted":false},
+        "password":      {"name":"密码","type":"string","description":"认证密码","required":false,"encrypted":true},
+        "index_pattern": {"name":"索引模式","type":"string","description":"索引匹配模式（可选，如 log-*）","required":false,"encrypted":false}
+    }',
+    TRUE
+FROM DUAL WHERE NOT EXISTS ( SELECT f_type FROM t_connector_type WHERE f_type = 'opensearch' );
+
+INSERT INTO t_connector_type (f_type, f_name, f_description, f_mode, f_category, f_field_config, f_enabled)
+SELECT 'postgresql', 'postgresql', 'PostgreSQL 关系型数据库连接器', 'local', 'table',
+       '{
+           "host":      {"name":"主机地址","type":"string","description":"数据库服务器主机地址","required":true,"encrypted":false},
+           "port":      {"name":"端口号","type":"integer","description":"数据库服务器端口","required":true,"encrypted":false},
+           "username":  {"name":"用户名","type":"string","description":"数据库用户名","required":true,"encrypted":false},
+           "password":  {"name":"密码","type":"string","description":"数据库密码","required":true,"encrypted":true},
+           "database":  {"name":"数据库名","type":"string","description":"PostgreSQL 连接目标 database","required":true,"encrypted":false},
+           "schemas":   {"name":"Schema 列表","type":"array","description":"可选；为空则扫描当前库下除系统 schema 外的用户 schema；非空则仅扫描列出的 schema","required":false,"encrypted":false},
+           "options":   {"name":"连接参数","type":"object","description":"连接参数（如 sslmode、connect_timeout 等）","required":false,"encrypted":false}
+       }',
+       TRUE
+FROM DUAL WHERE NOT EXISTS ( SELECT f_type FROM t_connector_type WHERE f_type = 'postgresql' );
+
+INSERT INTO t_connector_type (f_type, f_name, f_description, f_mode, f_category, f_field_config, f_enabled)
+SELECT 'anyshare', 'anyshare', 'AnyShare 连接器', 'local', 'fileset',
+    '{
+        "protocol":     {"name":"协议","type":"string","description":"http 或 https","required":true,"encrypted":false},
+        "host":         {"name":"主机地址","type":"string","description":"AnyShare 服务主机","required":true,"encrypted":false},
+        "port":         {"name":"端口","type":"integer","description":"服务端口","required":true,"encrypted":false},
+        "auth_type":    {"name":"认证方式","type":"integer","description":"1=访问令牌 Token，2=AppID/AppSecret","required":true,"encrypted":false},
+        "token":        {"name":"访问令牌","type":"string","description":"auth_type=1 时必填","required":false,"encrypted":true},
+        "app_id":       {"name":"应用账户 ID","type":"string","description":"auth_type=2 时必填","required":false,"encrypted":false},
+        "app_secret":   {"name":"应用密钥","type":"string","description":"auth_type=2 时必填","required":false,"encrypted":true},
+        "doc_lib_type": {"name":"文档库类型","type":"integer","description":"1=知识库，2=文档库","required":true,"encrypted":false},
+        "paths":        {"name":"路径列表","type":"array","description":"可选；按文档库名称路径解析起点，空则按文档库类型枚举","required":false,"encrypted":false}
+    }',
+    TRUE
+FROM DUAL WHERE NOT EXISTS ( SELECT f_type FROM t_connector_type WHERE f_type = 'anyshare' );
+
+-- ==========================================
+-- 7. t_discover_task 发现任务表
+-- ==========================================
+CREATE TABLE IF NOT EXISTS t_discover_task (
+    -- 主键与关联信息
+    f_id                      VARCHAR(40) NOT NULL DEFAULT '' COMMENT '任务唯一标识',
+    f_catalog_id              VARCHAR(40) NOT NULL DEFAULT '' COMMENT '所属catalog ID',
+    f_schedule_id             VARCHAR(40) NOT NULL DEFAULT '' COMMENT '关联的 DiscoverSchedule ID',
+    f_strategy                VARCHAR(32) NOT NULL DEFAULT 'full_sync' COMMENT '发现策略: full_sync, create_only, cleanup_only',
+    f_strategies              VARCHAR(100) NOT NULL DEFAULT '' COMMENT '历史策略数组字段',
+    f_trigger_type            VARCHAR(20) NOT NULL DEFAULT 'manual' COMMENT '触发类型: manual(立即执行), scheduled(定时驱动)',
+
+    -- 任务状态
+    f_status                  VARCHAR(20) NOT NULL DEFAULT 'pending' COMMENT '任务状态: pending, running, completed, failed',
+    f_progress                INT NOT NULL DEFAULT 0 COMMENT '任务进度: 0-100',
+    f_message                 VARCHAR(1000) NOT NULL DEFAULT '' COMMENT '任务消息/错误信息',
+
+    -- 时间信息
+    f_start_time              BIGINT(20) NOT NULL DEFAULT 0 COMMENT '开始执行时间',
+    f_finish_time             BIGINT(20) NOT NULL DEFAULT 0 COMMENT '完成时间',
+
+    -- 执行结果
+    f_result                  MEDIUMTEXT NOT NULL COMMENT '发现结果（JSON格式，包含发现的资源统计等）',
+
+    -- 审计字段
+    f_creator                 VARCHAR(40) NOT NULL DEFAULT '' COMMENT '创建者id',
+    f_creator_type            VARCHAR(20) NOT NULL DEFAULT '' COMMENT '创建者类型',
+    f_create_time             BIGINT(20) NOT NULL DEFAULT 0 COMMENT '创建时间',
+
+    -- 索引
+    PRIMARY KEY (f_id),
+    INDEX idx_catalog_id (f_catalog_id),
+    INDEX idx_status (f_status),
+    INDEX idx_schedule_id (f_schedule_id)
+) ENGINE = InnoDB DEFAULT CHARSET = utf8mb4 COLLATE = utf8mb4_bin COMMENT='发现任务表，记录异步资源发现任务的状态和结果';
+
+-- ==========================================
+-- 8. t_build_task 构建任务表
+-- ==========================================
+CREATE TABLE IF NOT EXISTS t_build_task (
+    -- 主键与关联信息
+    f_id                      VARCHAR(40) NOT NULL COMMENT '任务ID',
+    f_resource_id             VARCHAR(40) NOT NULL COMMENT '资源ID',
+
+    -- 任务状态
+    f_status                  VARCHAR(20) NOT NULL COMMENT '任务状态: pending, running, completed, failed',
+    f_mode                    VARCHAR(20) NOT NULL COMMENT '任务模式: full, incremental, realtime',
+    f_total_count             BIGINT NOT NULL DEFAULT 0 COMMENT '总数',
+    f_synced_count            BIGINT NOT NULL DEFAULT 0 COMMENT '已同步数',
+    f_vectorized_count        BIGINT NOT NULL DEFAULT 0 COMMENT '已做向量数',
+    f_synced_mark             VARCHAR(100) NOT NULL COMMENT '同步标记',
+    f_error_msg               TEXT NOT NULL COMMENT '错误信息',
+    f_failure_detail          TEXT NOT NULL COMMENT '构建完成但部分文档向量化失败的明细（区别于 f_error_msg 的整任务硬失败）',
+
+    -- 审计字段
+    f_creator                 VARCHAR(40) NOT NULL DEFAULT '' COMMENT '创建者id',
+    f_creator_type            VARCHAR(20) NOT NULL DEFAULT '' COMMENT '创建者类型',
+    f_create_time             BIGINT(20) NOT NULL DEFAULT 0 COMMENT '创建时间',
+    f_updater                 VARCHAR(40) NOT NULL DEFAULT '' COMMENT '更新者id',
+    f_updater_type            VARCHAR(20) NOT NULL DEFAULT '' COMMENT '更新者类型',
+    f_update_time             BIGINT(20) NOT NULL DEFAULT 0 COMMENT '更新时间',
+
+    f_embedding_fields        VARCHAR(255) NOT NULL DEFAULT '' COMMENT '需要向量化嵌入字段',
+    f_build_key_fields        VARCHAR(255) NOT NULL DEFAULT '' COMMENT '构建中依赖的特殊键字段',
+    f_embedding_model         VARCHAR(40) NOT NULL DEFAULT '' COMMENT '嵌入模型',
+    f_model_dimensions        INT NOT NULL DEFAULT 0 COMMENT '模型维度',
+    f_fulltext_fields         VARCHAR(255) NOT NULL DEFAULT '' COMMENT '需建全文索引的字段',
+    f_fulltext_analyzer       VARCHAR(40) NOT NULL DEFAULT '' COMMENT '全文分词器，空为默认 standard',
+    f_catalog_id              VARCHAR(40) NOT NULL DEFAULT '' COMMENT '所属catalog ID',
+
+    -- 索引
+    PRIMARY KEY (f_id),
+    INDEX idx_resource_id (f_resource_id),
+    INDEX idx_status (f_status),
+    INDEX idx_catalog_id (f_catalog_id)
+) ENGINE = InnoDB DEFAULT CHARSET = utf8mb4 COLLATE = utf8mb4_bin COMMENT='构建任务表';
+
+-- ==========================================
+-- 9. t_semantic_understanding_task 语义理解任务表
+-- ==========================================
+CREATE TABLE IF NOT EXISTS t_semantic_understanding_task (
+    -- 主键与关联信息
+    f_id                         VARCHAR(40) NOT NULL DEFAULT '' COMMENT 'Vega 语义理解任务唯一标识',
+    f_scope                      VARCHAR(20) NOT NULL DEFAULT '' COMMENT '任务范围: resource, catalog',
+    f_catalog_id                 VARCHAR(40) NOT NULL DEFAULT '' COMMENT '所属 catalog ID',
+    f_resource_id                VARCHAR(40) NOT NULL DEFAULT '' COMMENT 'resource 级任务关联 resource ID，catalog 级为空',
+    f_agent_task_id              VARCHAR(80) NOT NULL DEFAULT '' COMMENT 'bkn-agent 任务 ID',
+    f_agent_id                   VARCHAR(80) NOT NULL DEFAULT '' COMMENT '执行语义理解的 agent ID',
+
+    -- 输入快照与状态
+    f_input                      MEDIUMTEXT NOT NULL COMMENT '发送给 bkn-agent 的完整结构化输入(JSON)',
+    f_input_hash                 VARCHAR(128) NOT NULL DEFAULT '' COMMENT '基于 agent 输入生成的哈希，用于去重和快照匹配',
+    f_status                     VARCHAR(20) NOT NULL DEFAULT 'pending' COMMENT '任务状态: pending, running, succeeded, failed',
+    f_apply_mode                 VARCHAR(20) NOT NULL DEFAULT 'fill_empty' COMMENT '应用模式: dry_run, fill_empty, force',
+
+    -- agent 结果与应用详情
+    f_result_json                MEDIUMTEXT NOT NULL COMMENT 'agent 原始结构化输出(JSON)',
+    f_confidence_threshold       DECIMAL(5,4) NOT NULL DEFAULT 0.7500 COMMENT '本次任务要求的最低置信分',
+    f_confidence                 DECIMAL(5,4) NOT NULL DEFAULT 0.0000 COMMENT '任务级语义置信度',
+    f_confidence_detail_json     MEDIUMTEXT NOT NULL COMMENT '字段、逻辑视图、stale 建议等细粒度置信分(JSON)',
+    f_catalog_apply_detail_json  MEDIUMTEXT NOT NULL COMMENT 'catalog 级应用明细(JSON)，resource 级为空',
+    f_applied                    TINYINT(1) NOT NULL DEFAULT 0 COMMENT 'agent 结果是否已应用: 0-否, 1-是',
+    f_applied_time               BIGINT(20) NOT NULL DEFAULT 0 COMMENT '应用时间',
+    f_failure_detail             TEXT NOT NULL COMMENT '失败详情',
+
+    -- 审计字段
+    f_creator                    VARCHAR(40) NOT NULL DEFAULT '' COMMENT '创建者id',
+    f_creator_type               VARCHAR(20) NOT NULL DEFAULT '' COMMENT '创建者类型',
+    f_create_time                BIGINT(20) NOT NULL DEFAULT 0 COMMENT '创建时间',
+    f_update_time                BIGINT(20) NOT NULL DEFAULT 0 COMMENT '更新时间',
+
+    -- 索引
+    PRIMARY KEY (f_id),
+    INDEX idx_scope_input_hash_status (f_scope, f_input_hash, f_status),
+    INDEX idx_catalog_id (f_catalog_id),
+    INDEX idx_resource_id (f_resource_id),
+    INDEX idx_agent_task_id (f_agent_task_id),
+    INDEX idx_status (f_status)
+) ENGINE = InnoDB DEFAULT CHARSET = utf8mb4 COLLATE = utf8mb4_bin COMMENT='语义理解任务表，记录 resource/catalog 语义理解异步任务、agent 输出和应用状态';
+
+
+-- ==========================================
+-- 10. t_discover_schedule 资源发现调度表
+-- ==========================================
+CREATE TABLE IF NOT EXISTS t_discover_schedule (
+    -- 主键与关联信息
+    f_id                      VARCHAR(40) NOT NULL DEFAULT '' COMMENT '调度唯一标识',
+    f_name                    VARCHAR(255) NOT NULL DEFAULT '' COMMENT '调度名称',
+    f_catalog_id              VARCHAR(40) NOT NULL DEFAULT '' COMMENT '所属catalog ID',
+    f_cron_expr               VARCHAR(100) NOT NULL DEFAULT '' COMMENT 'Cron表达式',
+
+    -- 时间配置
+    f_start_time              BIGINT(20) NOT NULL DEFAULT 0 COMMENT '开始时间（Unix毫秒时间戳）',
+    f_end_time                BIGINT(20) NOT NULL DEFAULT 0 COMMENT '结束时间（Unix毫秒时间戳），0表示无结束时间',
+
+    -- 调度状态
+    f_enabled                 TINYINT(1) NOT NULL DEFAULT 0 COMMENT '是否启用: 0-禁用, 1-启用',
+    f_strategy                VARCHAR(32) NOT NULL DEFAULT 'full_sync' COMMENT '发现策略: full_sync, create_only, cleanup_only',
+
+    f_last_run                BIGINT(20) NOT NULL DEFAULT 0 COMMENT '最后执行时间（Unix毫秒时间戳）',
+    f_next_run                BIGINT(20) NOT NULL DEFAULT 0 COMMENT '下次执行时间（Unix毫秒时间戳）',
+
+    -- 审计字段
+    f_creator                 VARCHAR(40) NOT NULL DEFAULT '' COMMENT '创建者id',
+    f_creator_type            VARCHAR(20) NOT NULL DEFAULT '' COMMENT '创建者类型',
+    f_create_time             BIGINT(20) NOT NULL DEFAULT 0 COMMENT '创建时间',
+    f_updater                 VARCHAR(40) NOT NULL DEFAULT '' COMMENT '更新者id',
+    f_updater_type            VARCHAR(20) NOT NULL DEFAULT '' COMMENT '更新者类型',
+    f_update_time             BIGINT(20) NOT NULL DEFAULT 0 COMMENT '更新时间',
+
+    -- 索引
+    PRIMARY KEY (f_id),
+    INDEX idx_catalog_id (f_catalog_id),
+    INDEX idx_enabled (f_enabled),
+    INDEX idx_next_run (f_next_run),
+    INDEX idx_name (f_name)
+) ENGINE = InnoDB DEFAULT CHARSET = utf8mb4 COLLATE = utf8mb4_bin COMMENT='资源发现调度表，记录定时资源发现的配置和执行状态';

--- a/migrations/vega-backend/mariadb/0.1.3/init.sql
+++ b/migrations/vega-backend/mariadb/0.1.3/init.sql
@@ -163,6 +163,7 @@ CREATE TABLE IF NOT EXISTS t_resource (
 
     -- Schema相关
     f_schema_definition       MEDIUMTEXT NOT NULL COMMENT 'Schema定义（JSON数组格式，包含所有字段信息）',
+    f_index_config            MEDIUMTEXT NOT NULL DEFAULT '' COMMENT '本地索引配置（JSON格式）',
 
     -- LogicView 专属字段
     f_logic_type              VARCHAR(20) NOT NULL DEFAULT '' COMMENT '逻辑类型: derived(衍生), composite(复合), 仅LogicView使用',
@@ -381,10 +382,15 @@ CREATE TABLE IF NOT EXISTS t_build_task (
     -- 主键与关联信息
     f_id                      VARCHAR(40) NOT NULL COMMENT '任务ID',
     f_resource_id             VARCHAR(40) NOT NULL COMMENT '资源ID',
+    f_catalog_id              VARCHAR(40) NOT NULL DEFAULT '' COMMENT '所属catalog ID',
+
+    f_mode                    VARCHAR(20) NOT NULL COMMENT '任务模式: full, incremental, realtime',
+
+    -- 任务索引配置
+    f_index_config            TEXT NOT NULL DEFAULT '' COMMENT '索引配置快照(JSON)',
 
     -- 任务状态
     f_status                  VARCHAR(20) NOT NULL COMMENT '任务状态: pending, running, completed, failed',
-    f_mode                    VARCHAR(20) NOT NULL COMMENT '任务模式: full, incremental, realtime',
     f_total_count             BIGINT NOT NULL DEFAULT 0 COMMENT '总数',
     f_synced_count            BIGINT NOT NULL DEFAULT 0 COMMENT '已同步数',
     f_vectorized_count        BIGINT NOT NULL DEFAULT 0 COMMENT '已做向量数',
@@ -396,23 +402,13 @@ CREATE TABLE IF NOT EXISTS t_build_task (
     f_creator                 VARCHAR(40) NOT NULL DEFAULT '' COMMENT '创建者id',
     f_creator_type            VARCHAR(20) NOT NULL DEFAULT '' COMMENT '创建者类型',
     f_create_time             BIGINT(20) NOT NULL DEFAULT 0 COMMENT '创建时间',
-    f_updater                 VARCHAR(40) NOT NULL DEFAULT '' COMMENT '更新者id',
-    f_updater_type            VARCHAR(20) NOT NULL DEFAULT '' COMMENT '更新者类型',
     f_update_time             BIGINT(20) NOT NULL DEFAULT 0 COMMENT '更新时间',
-
-    f_embedding_fields        VARCHAR(255) NOT NULL DEFAULT '' COMMENT '需要向量化嵌入字段',
-    f_build_key_fields        VARCHAR(255) NOT NULL DEFAULT '' COMMENT '构建中依赖的特殊键字段',
-    f_embedding_model         VARCHAR(40) NOT NULL DEFAULT '' COMMENT '嵌入模型',
-    f_model_dimensions        INT NOT NULL DEFAULT 0 COMMENT '模型维度',
-    f_fulltext_fields         VARCHAR(255) NOT NULL DEFAULT '' COMMENT '需建全文索引的字段',
-    f_fulltext_analyzer       VARCHAR(40) NOT NULL DEFAULT '' COMMENT '全文分词器，空为默认 standard',
-    f_catalog_id              VARCHAR(40) NOT NULL DEFAULT '' COMMENT '所属catalog ID',
 
     -- 索引
     PRIMARY KEY (f_id),
     INDEX idx_resource_id (f_resource_id),
-    INDEX idx_status (f_status),
-    INDEX idx_catalog_id (f_catalog_id)
+    INDEX idx_catalog_id (f_catalog_id),
+    INDEX idx_status (f_status)
 ) ENGINE = InnoDB DEFAULT CHARSET = utf8mb4 COLLATE = utf8mb4_bin COMMENT='构建任务表';
 
 -- ==========================================
@@ -438,7 +434,7 @@ CREATE TABLE IF NOT EXISTS t_semantic_understanding_task (
     f_confidence_threshold       DECIMAL(5,4) NOT NULL DEFAULT 0.7500 COMMENT '本次任务要求的最低置信分',
     f_confidence                 DECIMAL(5,4) NOT NULL DEFAULT 0.0000 COMMENT '任务级语义置信度',
     f_confidence_detail_json     MEDIUMTEXT NOT NULL COMMENT '字段、逻辑视图、stale 建议等细粒度置信分(JSON)',
-    f_catalog_apply_detail_json  MEDIUMTEXT NOT NULL COMMENT 'catalog 级应用明细(JSON)，resource 级为空',
+    f_apply_detail_json          MEDIUMTEXT NOT NULL COMMENT '应用明细(JSON)',
     f_applied                    TINYINT(1) NOT NULL DEFAULT 0 COMMENT 'agent 结果是否已应用: 0-否, 1-是',
     f_applied_time               BIGINT(20) NOT NULL DEFAULT 0 COMMENT '应用时间',
     f_failure_detail             TEXT NOT NULL COMMENT '失败详情',


### PR DESCRIPTION
## What Changed

Brief description of changes:

- [x] Vega Resource 使用 schema 过滤、计数和分页，移除 Resource 层 database。
- [x] PostgreSQL 与 MariaDB 将发现的 schema 写入 Catalog metadata.schemas。
- [x] 更新资源 API 文档与数据库迁移。

---

## Why

- Related Issue: [openbkn-ai/bkn-studio#240](https://github.com/openbkn-ai/bkn-studio/issues/240)
- Background: schema 节点选择后，前端不能再对当前页资源做本地过滤；后端需按 schema 在分页前完成过滤。

---

## How

- Key implementation points: 资源 f_schema 持久化；列表及 count 使用同一 schema 条件；连接器 metadata 返回 schemas；Studio 从 Catalog metadata 读取。
- Breaking changes (API, config, database, etc.): Resource 的 database 查询参数移除，改为可选 schema 参数；包含 0.1.3 数据库迁移。

---

## Testing

- [x] Unit tests passed locally
- [x] Integration tests passed locally
- [ ] Verified in test environment (not run)

Test notes: `make ci` 与 `make api-docs-lint` 均已通过。

---

## Risk & Rollback

- Potential risks: 尚未完成 discover 的历史资源 schema 为空，不会被指定 schema 的筛选结果命中。
- Rollback plan: 回滚本 PR 和对应迁移；未传 schema 的资源列表行为保持不变。

---

## Additional Notes

- Documentation: [#240 design](https://github.com/openbkn-ai/bkn-docs/blob/main/docs/foundry/vega/design/issue-240-Catalog-Schema-%E5%BF%AB%E7%85%A7%E4%B8%8E%E8%B5%84%E6%BA%90%E5%88%86%E9%A1%B5%E8%BF%87%E6%BB%A4%E5%AE%9E%E7%8E%B0%E8%AE%A1%E5%88%92.md)
- Closes openbkn-ai/bkn-studio#240.