### PR TITLE
chore(context-loader): module path 改到 bkn-foundry 下

### DIFF
--- a/adp/context-loader/agent-retrieval/go.mod
+++ b/adp/context-loader/agent-retrieval/go.mod
@@ -1,4 +1,4 @@
-module github.com/openbkn-ai/adp/context-loader/agent-retrieval
+module github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval
 
 go 1.25.0
 

--- a/adp/context-loader/agent-retrieval/server/bootstrap/tool_dependency_sync.go
+++ b/adp/context-loader/agent-retrieval/server/bootstrap/tool_dependency_sync.go
@@ -6,9 +6,9 @@ import (
 	"sync"
 	"time"
 
-	"github.com/openbkn-ai/adp/context-loader/agent-retrieval/server/drivenadapters"
-	"github.com/openbkn-ai/adp/context-loader/agent-retrieval/server/infra/config"
-	"github.com/openbkn-ai/adp/context-loader/agent-retrieval/server/interfaces"
+	"github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/drivenadapters"
+	"github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/infra/config"
+	"github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/interfaces"
 )
 
 type embeddedToolDependencyPackage struct {

--- a/adp/context-loader/agent-retrieval/server/bootstrap/tool_dependency_sync_test.go
+++ b/adp/context-loader/agent-retrieval/server/bootstrap/tool_dependency_sync_test.go
@@ -7,9 +7,9 @@ import (
 	"testing"
 	"time"
 
-	"github.com/openbkn-ai/adp/context-loader/agent-retrieval/server/infra/config"
-	"github.com/openbkn-ai/adp/context-loader/agent-retrieval/server/interfaces"
-	"github.com/openbkn-ai/adp/context-loader/agent-retrieval/server/mocks"
+	"github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/infra/config"
+	"github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/interfaces"
+	"github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/mocks"
 	. "github.com/smartystreets/goconvey/convey"
 	"go.uber.org/mock/gomock"
 )

--- a/adp/context-loader/agent-retrieval/server/drivenadapters/appkey.go
+++ b/adp/context-loader/agent-retrieval/server/drivenadapters/appkey.go
@@ -11,11 +11,11 @@ import (
 
 	jsoniter "github.com/json-iterator/go"
 
-	"github.com/openbkn-ai/adp/context-loader/agent-retrieval/server/infra/config"
-	"github.com/openbkn-ai/adp/context-loader/agent-retrieval/server/infra/errors"
-	"github.com/openbkn-ai/adp/context-loader/agent-retrieval/server/infra/rest"
-	"github.com/openbkn-ai/adp/context-loader/agent-retrieval/server/interfaces"
-	"github.com/openbkn-ai/adp/context-loader/agent-retrieval/server/utils"
+	"github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/infra/config"
+	"github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/infra/errors"
+	"github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/infra/rest"
+	"github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/interfaces"
+	"github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/utils"
 )
 
 // appKeyIntrospectURI is bkn-safe's internal AppKey verification endpoint

--- a/adp/context-loader/agent-retrieval/server/drivenadapters/appkey_test.go
+++ b/adp/context-loader/agent-retrieval/server/drivenadapters/appkey_test.go
@@ -12,8 +12,8 @@ import (
 	"github.com/smartystreets/goconvey/convey"
 	"go.uber.org/mock/gomock"
 
-	"github.com/openbkn-ai/adp/context-loader/agent-retrieval/server/interfaces"
-	"github.com/openbkn-ai/adp/context-loader/agent-retrieval/server/mocks"
+	"github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/interfaces"
+	"github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/mocks"
 )
 
 func TestAppKeyVerify(t *testing.T) {

--- a/adp/context-loader/agent-retrieval/server/drivenadapters/bkn_backend.go
+++ b/adp/context-loader/agent-retrieval/server/drivenadapters/bkn_backend.go
@@ -17,11 +17,11 @@ import (
 
 	"github.com/bytedance/sonic"
 
-	"github.com/openbkn-ai/adp/context-loader/agent-retrieval/server/infra/common"
-	"github.com/openbkn-ai/adp/context-loader/agent-retrieval/server/infra/config"
-	infraErr "github.com/openbkn-ai/adp/context-loader/agent-retrieval/server/infra/errors"
-	"github.com/openbkn-ai/adp/context-loader/agent-retrieval/server/infra/rest"
-	"github.com/openbkn-ai/adp/context-loader/agent-retrieval/server/interfaces"
+	"github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/infra/common"
+	"github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/infra/config"
+	infraErr "github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/infra/errors"
+	"github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/infra/rest"
+	"github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/interfaces"
 )
 
 type bknBackendAccess struct {

--- a/adp/context-loader/agent-retrieval/server/drivenadapters/bkn_backend_test.go
+++ b/adp/context-loader/agent-retrieval/server/drivenadapters/bkn_backend_test.go
@@ -15,9 +15,9 @@ import (
 	"github.com/smartystreets/goconvey/convey"
 	"go.uber.org/mock/gomock"
 
-	infraErr "github.com/openbkn-ai/adp/context-loader/agent-retrieval/server/infra/errors"
-	"github.com/openbkn-ai/adp/context-loader/agent-retrieval/server/interfaces"
-	"github.com/openbkn-ai/adp/context-loader/agent-retrieval/server/mocks"
+	infraErr "github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/infra/errors"
+	"github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/interfaces"
+	"github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/mocks"
 )
 
 // TestSearchObjectTypes_Success 测试 SearchObjectTypes 成功场景

--- a/adp/context-loader/agent-retrieval/server/drivenadapters/clients_test.go
+++ b/adp/context-loader/agent-retrieval/server/drivenadapters/clients_test.go
@@ -15,8 +15,8 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/openbkn-ai/adp/context-loader/agent-retrieval/server/infra/common"
-	"github.com/openbkn-ai/adp/context-loader/agent-retrieval/server/interfaces"
+	"github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/infra/common"
+	"github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/interfaces"
 )
 
 // mockLogger 测试用的mock logger

--- a/adp/context-loader/agent-retrieval/server/drivenadapters/expand_filters_test.go
+++ b/adp/context-loader/agent-retrieval/server/drivenadapters/expand_filters_test.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/smartystreets/goconvey/convey"
 
-	"github.com/openbkn-ai/adp/context-loader/agent-retrieval/server/interfaces"
+	"github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/interfaces"
 )
 
 // TestExpandFilters locks the equivalence between the flat `filters` shortcut

--- a/adp/context-loader/agent-retrieval/server/drivenadapters/hydra.go
+++ b/adp/context-loader/agent-retrieval/server/drivenadapters/hydra.go
@@ -14,11 +14,11 @@ import (
 
 	jsoniter "github.com/json-iterator/go"
 
-	"github.com/openbkn-ai/adp/context-loader/agent-retrieval/server/infra/config"
-	"github.com/openbkn-ai/adp/context-loader/agent-retrieval/server/infra/errors"
-	"github.com/openbkn-ai/adp/context-loader/agent-retrieval/server/infra/rest"
-	"github.com/openbkn-ai/adp/context-loader/agent-retrieval/server/interfaces"
-	"github.com/openbkn-ai/adp/context-loader/agent-retrieval/server/utils"
+	"github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/infra/config"
+	"github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/infra/errors"
+	"github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/infra/rest"
+	"github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/interfaces"
+	"github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/utils"
 )
 
 type hydra struct {

--- a/adp/context-loader/agent-retrieval/server/drivenadapters/hydra_test.go
+++ b/adp/context-loader/agent-retrieval/server/drivenadapters/hydra_test.go
@@ -14,8 +14,8 @@ import (
 	"github.com/smartystreets/goconvey/convey"
 	"go.uber.org/mock/gomock"
 
-	"github.com/openbkn-ai/adp/context-loader/agent-retrieval/server/interfaces"
-	"github.com/openbkn-ai/adp/context-loader/agent-retrieval/server/mocks"
+	"github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/interfaces"
+	"github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/mocks"
 )
 
 func TestNoopHydraIntrospect(t *testing.T) {

--- a/adp/context-loader/agent-retrieval/server/drivenadapters/mf_model_api_client.go
+++ b/adp/context-loader/agent-retrieval/server/drivenadapters/mf_model_api_client.go
@@ -13,12 +13,12 @@ import (
 	"net/http"
 	"sync"
 
-	"github.com/openbkn-ai/adp/context-loader/agent-retrieval/server/infra/common"
-	"github.com/openbkn-ai/adp/context-loader/agent-retrieval/server/infra/config"
-	infraErr "github.com/openbkn-ai/adp/context-loader/agent-retrieval/server/infra/errors"
-	"github.com/openbkn-ai/adp/context-loader/agent-retrieval/server/infra/rest"
-	"github.com/openbkn-ai/adp/context-loader/agent-retrieval/server/interfaces"
-	"github.com/openbkn-ai/adp/context-loader/agent-retrieval/server/utils"
+	"github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/infra/common"
+	"github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/infra/config"
+	infraErr "github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/infra/errors"
+	"github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/infra/rest"
+	"github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/interfaces"
+	"github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/utils"
 )
 
 // API路径常量

--- a/adp/context-loader/agent-retrieval/server/drivenadapters/mf_model_api_client_test.go
+++ b/adp/context-loader/agent-retrieval/server/drivenadapters/mf_model_api_client_test.go
@@ -10,7 +10,7 @@ import (
 	"context"
 	"testing"
 
-	"github.com/openbkn-ai/adp/context-loader/agent-retrieval/server/interfaces"
+	"github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/interfaces"
 )
 
 // chatOKResp 构造一个能被 chatCompletionsResp 解析的成功响应

--- a/adp/context-loader/agent-retrieval/server/drivenadapters/ontology_query.go
+++ b/adp/context-loader/agent-retrieval/server/drivenadapters/ontology_query.go
@@ -17,12 +17,12 @@ import (
 	"strings"
 	"sync"
 
-	"github.com/openbkn-ai/adp/context-loader/agent-retrieval/server/infra/common"
-	"github.com/openbkn-ai/adp/context-loader/agent-retrieval/server/infra/config"
-	infraErr "github.com/openbkn-ai/adp/context-loader/agent-retrieval/server/infra/errors"
-	"github.com/openbkn-ai/adp/context-loader/agent-retrieval/server/infra/rest"
-	"github.com/openbkn-ai/adp/context-loader/agent-retrieval/server/interfaces"
-	"github.com/openbkn-ai/adp/context-loader/agent-retrieval/server/utils"
+	"github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/infra/common"
+	"github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/infra/config"
+	infraErr "github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/infra/errors"
+	"github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/infra/rest"
+	"github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/interfaces"
+	"github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/utils"
 )
 
 type ontologyQueryClient struct {

--- a/adp/context-loader/agent-retrieval/server/drivenadapters/ontology_query_test.go
+++ b/adp/context-loader/agent-retrieval/server/drivenadapters/ontology_query_test.go
@@ -17,9 +17,9 @@ import (
 	"github.com/smartystreets/goconvey/convey"
 	"go.uber.org/mock/gomock"
 
-	infraErr "github.com/openbkn-ai/adp/context-loader/agent-retrieval/server/infra/errors"
-	"github.com/openbkn-ai/adp/context-loader/agent-retrieval/server/interfaces"
-	"github.com/openbkn-ai/adp/context-loader/agent-retrieval/server/mocks"
+	infraErr "github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/infra/errors"
+	"github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/interfaces"
+	"github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/mocks"
 )
 
 // TestQueryObjectInstances_Success 测试 QueryObjectInstances 成功场景

--- a/adp/context-loader/agent-retrieval/server/drivenadapters/operator_integration.go
+++ b/adp/context-loader/agent-retrieval/server/drivenadapters/operator_integration.go
@@ -15,12 +15,12 @@ import (
 	"net/http"
 	"sync"
 
-	"github.com/openbkn-ai/adp/context-loader/agent-retrieval/server/infra/common"
-	"github.com/openbkn-ai/adp/context-loader/agent-retrieval/server/infra/config"
-	infraErr "github.com/openbkn-ai/adp/context-loader/agent-retrieval/server/infra/errors"
-	"github.com/openbkn-ai/adp/context-loader/agent-retrieval/server/infra/rest"
-	"github.com/openbkn-ai/adp/context-loader/agent-retrieval/server/interfaces"
-	"github.com/openbkn-ai/adp/context-loader/agent-retrieval/server/utils"
+	"github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/infra/common"
+	"github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/infra/config"
+	infraErr "github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/infra/errors"
+	"github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/infra/rest"
+	"github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/interfaces"
+	"github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/utils"
 )
 
 type operatorIntegrationClient struct {

--- a/adp/context-loader/agent-retrieval/server/drivenadapters/operator_integration_test.go
+++ b/adp/context-loader/agent-retrieval/server/drivenadapters/operator_integration_test.go
@@ -18,8 +18,8 @@ import (
 	"github.com/smartystreets/goconvey/convey"
 	"go.uber.org/mock/gomock"
 
-	"github.com/openbkn-ai/adp/context-loader/agent-retrieval/server/interfaces"
-	"github.com/openbkn-ai/adp/context-loader/agent-retrieval/server/mocks"
+	"github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/interfaces"
+	"github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/mocks"
 )
 
 // TestGetToolDetail_Success 测试 GetToolDetail 成功场景

--- a/adp/context-loader/agent-retrieval/server/drivenadapters/vega.go
+++ b/adp/context-loader/agent-retrieval/server/drivenadapters/vega.go
@@ -14,11 +14,11 @@ import (
 
 	"github.com/bytedance/sonic"
 
-	"github.com/openbkn-ai/adp/context-loader/agent-retrieval/server/infra/common"
-	"github.com/openbkn-ai/adp/context-loader/agent-retrieval/server/infra/config"
-	infraErr "github.com/openbkn-ai/adp/context-loader/agent-retrieval/server/infra/errors"
-	"github.com/openbkn-ai/adp/context-loader/agent-retrieval/server/infra/rest"
-	"github.com/openbkn-ai/adp/context-loader/agent-retrieval/server/interfaces"
+	"github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/infra/common"
+	"github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/infra/config"
+	infraErr "github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/infra/errors"
+	"github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/infra/rest"
+	"github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/interfaces"
 )
 
 type vegaAccess struct {

--- a/adp/context-loader/agent-retrieval/server/driveradapters/appkey_middleware_test.go
+++ b/adp/context-loader/agent-retrieval/server/driveradapters/appkey_middleware_test.go
@@ -13,8 +13,8 @@ import (
 	"github.com/gin-gonic/gin"
 	"github.com/smartystreets/goconvey/convey"
 
-	"github.com/openbkn-ai/adp/context-loader/agent-retrieval/server/infra/common"
-	"github.com/openbkn-ai/adp/context-loader/agent-retrieval/server/interfaces"
+	"github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/infra/common"
+	"github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/interfaces"
 )
 
 // stubAppKeys records whether Verify ran and resolves to a fixed AppKey owner so

--- a/adp/context-loader/agent-retrieval/server/driveradapters/http_health_handler.go
+++ b/adp/context-loader/agent-retrieval/server/driveradapters/http_health_handler.go
@@ -12,7 +12,7 @@ import (
 
 	"github.com/gin-gonic/gin"
 
-	"github.com/openbkn-ai/adp/context-loader/agent-retrieval/server/interfaces"
+	"github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/interfaces"
 )
 
 // 健康检查

--- a/adp/context-loader/agent-retrieval/server/driveradapters/knactionrecall/index.go
+++ b/adp/context-loader/agent-retrieval/server/driveradapters/knactionrecall/index.go
@@ -15,11 +15,11 @@ import (
 	"github.com/gin-gonic/gin"
 	validator "github.com/go-playground/validator/v10"
 
-	"github.com/openbkn-ai/adp/context-loader/agent-retrieval/server/infra/config"
-	"github.com/openbkn-ai/adp/context-loader/agent-retrieval/server/infra/errors"
-	"github.com/openbkn-ai/adp/context-loader/agent-retrieval/server/infra/rest"
-	"github.com/openbkn-ai/adp/context-loader/agent-retrieval/server/interfaces"
-	logicsKAR "github.com/openbkn-ai/adp/context-loader/agent-retrieval/server/logics/knactionrecall"
+	"github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/infra/config"
+	"github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/infra/errors"
+	"github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/infra/rest"
+	"github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/interfaces"
+	logicsKAR "github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/logics/knactionrecall"
 )
 
 // KnActionRecallHandler 业务知识网络行动召回处理器

--- a/adp/context-loader/agent-retrieval/server/driveradapters/knfindskills/index.go
+++ b/adp/context-loader/agent-retrieval/server/driveradapters/knfindskills/index.go
@@ -15,11 +15,11 @@ import (
 	"github.com/gin-gonic/gin"
 	validator "github.com/go-playground/validator/v10"
 
-	"github.com/openbkn-ai/adp/context-loader/agent-retrieval/server/infra/config"
-	"github.com/openbkn-ai/adp/context-loader/agent-retrieval/server/infra/errors"
-	"github.com/openbkn-ai/adp/context-loader/agent-retrieval/server/infra/rest"
-	"github.com/openbkn-ai/adp/context-loader/agent-retrieval/server/interfaces"
-	logicsFS "github.com/openbkn-ai/adp/context-loader/agent-retrieval/server/logics/knfindskills"
+	"github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/infra/config"
+	"github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/infra/errors"
+	"github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/infra/rest"
+	"github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/interfaces"
+	logicsFS "github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/logics/knfindskills"
 )
 
 // KnFindSkillsHandler HTTP handler interface for find_skills

--- a/adp/context-loader/agent-retrieval/server/driveradapters/knlogicpropertyresolver/index.go
+++ b/adp/context-loader/agent-retrieval/server/driveradapters/knlogicpropertyresolver/index.go
@@ -17,11 +17,11 @@ import (
 	"github.com/gin-gonic/gin"
 	validator "github.com/go-playground/validator/v10"
 
-	"github.com/openbkn-ai/adp/context-loader/agent-retrieval/server/infra/config"
-	"github.com/openbkn-ai/adp/context-loader/agent-retrieval/server/infra/errors"
-	"github.com/openbkn-ai/adp/context-loader/agent-retrieval/server/infra/rest"
-	"github.com/openbkn-ai/adp/context-loader/agent-retrieval/server/interfaces"
-	logicskn "github.com/openbkn-ai/adp/context-loader/agent-retrieval/server/logics/knlogicpropertyresolver"
+	"github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/infra/config"
+	"github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/infra/errors"
+	"github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/infra/rest"
+	"github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/interfaces"
+	logicskn "github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/logics/knlogicpropertyresolver"
 )
 
 // KnLogicPropertyResolverHandler 逻辑属性解析 Handler

--- a/adp/context-loader/agent-retrieval/server/driveradapters/knqueryobjectinstance/index.go
+++ b/adp/context-loader/agent-retrieval/server/driveradapters/knqueryobjectinstance/index.go
@@ -15,12 +15,12 @@ import (
 	"github.com/gin-gonic/gin"
 	validator "github.com/go-playground/validator/v10"
 
-	"github.com/openbkn-ai/adp/context-loader/agent-retrieval/server/drivenadapters"
-	"github.com/openbkn-ai/adp/context-loader/agent-retrieval/server/infra/bkntrace"
-	"github.com/openbkn-ai/adp/context-loader/agent-retrieval/server/infra/config"
-	"github.com/openbkn-ai/adp/context-loader/agent-retrieval/server/infra/errors"
-	"github.com/openbkn-ai/adp/context-loader/agent-retrieval/server/infra/rest"
-	"github.com/openbkn-ai/adp/context-loader/agent-retrieval/server/interfaces"
+	"github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/drivenadapters"
+	"github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/infra/bkntrace"
+	"github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/infra/config"
+	"github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/infra/errors"
+	"github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/infra/rest"
+	"github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/interfaces"
 )
 
 // KnQueryObjectInstanceHandler 查询对象实例处理器

--- a/adp/context-loader/agent-retrieval/server/driveradapters/knquerysubgraph/index.go
+++ b/adp/context-loader/agent-retrieval/server/driveradapters/knquerysubgraph/index.go
@@ -15,11 +15,11 @@ import (
 	"github.com/gin-gonic/gin"
 	validator "github.com/go-playground/validator/v10"
 
-	"github.com/openbkn-ai/adp/context-loader/agent-retrieval/server/infra/config"
-	"github.com/openbkn-ai/adp/context-loader/agent-retrieval/server/infra/errors"
-	"github.com/openbkn-ai/adp/context-loader/agent-retrieval/server/infra/rest"
-	"github.com/openbkn-ai/adp/context-loader/agent-retrieval/server/interfaces"
-	logicskn "github.com/openbkn-ai/adp/context-loader/agent-retrieval/server/logics/knquerysubgraph"
+	"github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/infra/config"
+	"github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/infra/errors"
+	"github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/infra/rest"
+	"github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/interfaces"
+	logicskn "github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/logics/knquerysubgraph"
 )
 
 // KnQuerySubgraphHandler 子图查询处理器

--- a/adp/context-loader/agent-retrieval/server/driveradapters/knquerytools/index.go
+++ b/adp/context-loader/agent-retrieval/server/driveradapters/knquerytools/index.go
@@ -14,13 +14,13 @@ import (
 
 	"github.com/gin-gonic/gin"
 
-	"github.com/openbkn-ai/adp/context-loader/agent-retrieval/server/drivenadapters"
-	"github.com/openbkn-ai/adp/context-loader/agent-retrieval/server/infra/config"
-	"github.com/openbkn-ai/adp/context-loader/agent-retrieval/server/infra/errors"
-	"github.com/openbkn-ai/adp/context-loader/agent-retrieval/server/infra/rest"
-	"github.com/openbkn-ai/adp/context-loader/agent-retrieval/server/interfaces"
-	"github.com/openbkn-ai/adp/context-loader/agent-retrieval/server/logics/knresources"
-	"github.com/openbkn-ai/adp/context-loader/agent-retrieval/server/logics/knrunsql"
+	"github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/drivenadapters"
+	"github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/infra/config"
+	"github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/infra/errors"
+	"github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/infra/rest"
+	"github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/interfaces"
+	"github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/logics/knresources"
+	"github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/logics/knrunsql"
 )
 
 // KnQueryToolsHandler 处理 run_sql / list_knowledge_networks / get_kn_detail /

--- a/adp/context-loader/agent-retrieval/server/driveradapters/knretrieval/index.go
+++ b/adp/context-loader/agent-retrieval/server/driveradapters/knretrieval/index.go
@@ -15,11 +15,11 @@ import (
 	"github.com/gin-gonic/gin"
 	validator "github.com/go-playground/validator/v10"
 
-	"github.com/openbkn-ai/adp/context-loader/agent-retrieval/server/infra/config"
-	"github.com/openbkn-ai/adp/context-loader/agent-retrieval/server/infra/errors"
-	"github.com/openbkn-ai/adp/context-loader/agent-retrieval/server/infra/rest"
-	"github.com/openbkn-ai/adp/context-loader/agent-retrieval/server/interfaces"
-	logicskn "github.com/openbkn-ai/adp/context-loader/agent-retrieval/server/logics/knretrieval"
+	"github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/infra/config"
+	"github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/infra/errors"
+	"github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/infra/rest"
+	"github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/interfaces"
+	logicskn "github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/logics/knretrieval"
 )
 
 // KnRetrievalHandler 基于业务知识网络实现统一Retrieval

--- a/adp/context-loader/agent-retrieval/server/driveradapters/knsearch/index.go
+++ b/adp/context-loader/agent-retrieval/server/driveradapters/knsearch/index.go
@@ -15,11 +15,11 @@ import (
 	"github.com/gin-gonic/gin"
 	validator "github.com/go-playground/validator/v10"
 
-	"github.com/openbkn-ai/adp/context-loader/agent-retrieval/server/infra/config"
-	"github.com/openbkn-ai/adp/context-loader/agent-retrieval/server/infra/errors"
-	"github.com/openbkn-ai/adp/context-loader/agent-retrieval/server/infra/rest"
-	"github.com/openbkn-ai/adp/context-loader/agent-retrieval/server/interfaces"
-	logicskn "github.com/openbkn-ai/adp/context-loader/agent-retrieval/server/logics/knsearch"
+	"github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/infra/config"
+	"github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/infra/errors"
+	"github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/infra/rest"
+	"github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/interfaces"
+	logicskn "github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/logics/knsearch"
 )
 
 // KnSearchHandler kn_search 处理器

--- a/adp/context-loader/agent-retrieval/server/driveradapters/knsearch/index_test.go
+++ b/adp/context-loader/agent-retrieval/server/driveradapters/knsearch/index_test.go
@@ -11,8 +11,8 @@ import (
 
 	"github.com/gin-gonic/gin"
 
-	"github.com/openbkn-ai/adp/context-loader/agent-retrieval/server/infra/logger"
-	"github.com/openbkn-ai/adp/context-loader/agent-retrieval/server/interfaces"
+	"github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/infra/logger"
+	"github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/interfaces"
 )
 
 type stubKnSearchService struct {

--- a/adp/context-loader/agent-retrieval/server/driveradapters/mcp/app.go
+++ b/adp/context-loader/agent-retrieval/server/driveradapters/mcp/app.go
@@ -15,14 +15,14 @@ import (
 	"github.com/mark3labs/mcp-go/mcp"
 	"github.com/mark3labs/mcp-go/server"
 
-	"github.com/openbkn-ai/adp/context-loader/agent-retrieval/server/drivenadapters"
-	logicsKar "github.com/openbkn-ai/adp/context-loader/agent-retrieval/server/logics/knactionrecall"
-	logicsFs "github.com/openbkn-ai/adp/context-loader/agent-retrieval/server/logics/knfindskills"
-	logicsKlp "github.com/openbkn-ai/adp/context-loader/agent-retrieval/server/logics/knlogicpropertyresolver"
-	logicsKqs "github.com/openbkn-ai/adp/context-loader/agent-retrieval/server/logics/knquerysubgraph"
-	"github.com/openbkn-ai/adp/context-loader/agent-retrieval/server/logics/knresources"
-	"github.com/openbkn-ai/adp/context-loader/agent-retrieval/server/logics/knrunsql"
-	"github.com/openbkn-ai/adp/context-loader/agent-retrieval/server/logics/knsearch"
+	"github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/drivenadapters"
+	logicsKar "github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/logics/knactionrecall"
+	logicsFs "github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/logics/knfindskills"
+	logicsKlp "github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/logics/knlogicpropertyresolver"
+	logicsKqs "github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/logics/knquerysubgraph"
+	"github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/logics/knresources"
+	"github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/logics/knrunsql"
+	"github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/logics/knsearch"
 )
 
 const (

--- a/adp/context-loader/agent-retrieval/server/driveradapters/mcp/response_format.go
+++ b/adp/context-loader/agent-retrieval/server/driveradapters/mcp/response_format.go
@@ -9,8 +9,8 @@ package mcp
 import (
 	"github.com/mark3labs/mcp-go/mcp"
 
-	"github.com/openbkn-ai/adp/context-loader/agent-retrieval/server/infra/rest"
-	"github.com/openbkn-ai/adp/context-loader/agent-retrieval/server/utils"
+	"github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/infra/rest"
+	"github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/utils"
 )
 
 // GetResponseFormatFromRequest 从 MCP CallToolRequest 的 arguments 中解析 response_format，未传时默认 toon

--- a/adp/context-loader/agent-retrieval/server/driveradapters/mcp/response_format_test.go
+++ b/adp/context-loader/agent-retrieval/server/driveradapters/mcp/response_format_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/mark3labs/mcp-go/mcp"
 	"github.com/smartystreets/goconvey/convey"
 
-	"github.com/openbkn-ai/adp/context-loader/agent-retrieval/server/infra/rest"
+	"github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/infra/rest"
 )
 
 // helper to build a CallToolRequest with simple arguments

--- a/adp/context-loader/agent-retrieval/server/driveradapters/mcp/tools.go
+++ b/adp/context-loader/agent-retrieval/server/driveradapters/mcp/tools.go
@@ -14,14 +14,14 @@ import (
 	validator "github.com/go-playground/validator/v10"
 	"github.com/mark3labs/mcp-go/mcp"
 
-	"github.com/openbkn-ai/adp/context-loader/agent-retrieval/server/infra/bkntrace"
-	"github.com/openbkn-ai/adp/context-loader/agent-retrieval/server/infra/common"
-	"github.com/openbkn-ai/adp/context-loader/agent-retrieval/server/infra/rest"
-	"github.com/openbkn-ai/adp/context-loader/agent-retrieval/server/interfaces"
-	logicsKqs "github.com/openbkn-ai/adp/context-loader/agent-retrieval/server/logics/knquerysubgraph"
-	"github.com/openbkn-ai/adp/context-loader/agent-retrieval/server/logics/knresources"
-	"github.com/openbkn-ai/adp/context-loader/agent-retrieval/server/logics/knrunsql"
-	"github.com/openbkn-ai/adp/context-loader/agent-retrieval/server/logics/knsearch"
+	"github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/infra/bkntrace"
+	"github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/infra/common"
+	"github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/infra/rest"
+	"github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/interfaces"
+	logicsKqs "github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/logics/knquerysubgraph"
+	"github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/logics/knresources"
+	"github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/logics/knrunsql"
+	"github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/logics/knsearch"
 )
 
 const (

--- a/adp/context-loader/agent-retrieval/server/driveradapters/mcp/tools_field_reduction_test.go
+++ b/adp/context-loader/agent-retrieval/server/driveradapters/mcp/tools_field_reduction_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/mark3labs/mcp-go/mcp"
 	"github.com/smartystreets/goconvey/convey"
 
-	"github.com/openbkn-ai/adp/context-loader/agent-retrieval/server/interfaces"
+	"github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/interfaces"
 )
 
 // ==================== Stub Implementations ====================

--- a/adp/context-loader/agent-retrieval/server/driveradapters/mcp/tools_get_action_info_test.go
+++ b/adp/context-loader/agent-retrieval/server/driveradapters/mcp/tools_get_action_info_test.go
@@ -7,9 +7,9 @@ import (
 
 	"github.com/smartystreets/goconvey/convey"
 
-	"github.com/openbkn-ai/adp/context-loader/agent-retrieval/server/infra/common"
-	"github.com/openbkn-ai/adp/context-loader/agent-retrieval/server/interfaces"
-	"github.com/openbkn-ai/adp/context-loader/agent-retrieval/server/utils"
+	"github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/infra/common"
+	"github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/interfaces"
+	"github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/utils"
 )
 
 type stubActionRecallService struct {

--- a/adp/context-loader/agent-retrieval/server/driveradapters/mcp/toon_tabular_test.go
+++ b/adp/context-loader/agent-retrieval/server/driveradapters/mcp/toon_tabular_test.go
@@ -10,8 +10,8 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/openbkn-ai/adp/context-loader/agent-retrieval/server/infra/rest"
-	"github.com/openbkn-ai/adp/context-loader/agent-retrieval/server/interfaces"
+	"github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/infra/rest"
+	"github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/interfaces"
 )
 
 // After Slim(summary), each data_property is a flat {name,type} object, so TOON

--- a/adp/context-loader/agent-retrieval/server/driveradapters/mcpproxy/index.go
+++ b/adp/context-loader/agent-retrieval/server/driveradapters/mcpproxy/index.go
@@ -12,10 +12,10 @@ import (
 
 	"github.com/gin-gonic/gin"
 
-	"github.com/openbkn-ai/adp/context-loader/agent-retrieval/server/drivenadapters"
-	infraErr "github.com/openbkn-ai/adp/context-loader/agent-retrieval/server/infra/errors"
-	"github.com/openbkn-ai/adp/context-loader/agent-retrieval/server/infra/rest"
-	"github.com/openbkn-ai/adp/context-loader/agent-retrieval/server/interfaces"
+	"github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/drivenadapters"
+	infraErr "github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/infra/errors"
+	"github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/infra/rest"
+	"github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/interfaces"
 )
 
 type MCPProxyHandler interface {

--- a/adp/context-loader/agent-retrieval/server/driveradapters/middleware.go
+++ b/adp/context-loader/agent-retrieval/server/driveradapters/middleware.go
@@ -22,10 +22,10 @@ import (
 	"github.com/openbkn-ai/bkn-comm-go/otel/oteltrace"
 	"go.opentelemetry.io/otel/attribute"
 
-	"github.com/openbkn-ai/adp/context-loader/agent-retrieval/server/infra/common"
-	aerrors "github.com/openbkn-ai/adp/context-loader/agent-retrieval/server/infra/errors"
-	"github.com/openbkn-ai/adp/context-loader/agent-retrieval/server/infra/rest"
-	"github.com/openbkn-ai/adp/context-loader/agent-retrieval/server/interfaces"
+	"github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/infra/common"
+	aerrors "github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/infra/errors"
+	"github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/infra/rest"
+	"github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/interfaces"
 )
 
 type apiLogModel struct {

--- a/adp/context-loader/agent-retrieval/server/driveradapters/middleware_test.go
+++ b/adp/context-loader/agent-retrieval/server/driveradapters/middleware_test.go
@@ -9,10 +9,10 @@ import (
 	"github.com/gin-gonic/gin"
 	"github.com/smartystreets/goconvey/convey"
 
-	"github.com/openbkn-ai/adp/context-loader/agent-retrieval/server/infra/common"
-	"github.com/openbkn-ai/adp/context-loader/agent-retrieval/server/infra/logger"
-	"github.com/openbkn-ai/adp/context-loader/agent-retrieval/server/infra/rest"
-	"github.com/openbkn-ai/adp/context-loader/agent-retrieval/server/interfaces"
+	"github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/infra/common"
+	"github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/infra/logger"
+	"github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/infra/rest"
+	"github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/interfaces"
 )
 
 func TestMiddlewareResponseFormat_DefaultAndValid(t *testing.T) {

--- a/adp/context-loader/agent-retrieval/server/driveradapters/rest_private_handler.go
+++ b/adp/context-loader/agent-retrieval/server/driveradapters/rest_private_handler.go
@@ -12,16 +12,16 @@ package driveradapters
 import (
 	"github.com/gin-gonic/gin"
 
-	"github.com/openbkn-ai/adp/context-loader/agent-retrieval/server/driveradapters/knactionrecall"
-	"github.com/openbkn-ai/adp/context-loader/agent-retrieval/server/driveradapters/knfindskills"
-	"github.com/openbkn-ai/adp/context-loader/agent-retrieval/server/driveradapters/knlogicpropertyresolver"
-	"github.com/openbkn-ai/adp/context-loader/agent-retrieval/server/driveradapters/knqueryobjectinstance"
-	"github.com/openbkn-ai/adp/context-loader/agent-retrieval/server/driveradapters/knquerysubgraph"
-	"github.com/openbkn-ai/adp/context-loader/agent-retrieval/server/driveradapters/knquerytools"
-	"github.com/openbkn-ai/adp/context-loader/agent-retrieval/server/driveradapters/knretrieval"
-	"github.com/openbkn-ai/adp/context-loader/agent-retrieval/server/driveradapters/knsearch"
-	"github.com/openbkn-ai/adp/context-loader/agent-retrieval/server/driveradapters/mcpproxy"
-	"github.com/openbkn-ai/adp/context-loader/agent-retrieval/server/interfaces"
+	"github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/driveradapters/knactionrecall"
+	"github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/driveradapters/knfindskills"
+	"github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/driveradapters/knlogicpropertyresolver"
+	"github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/driveradapters/knqueryobjectinstance"
+	"github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/driveradapters/knquerysubgraph"
+	"github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/driveradapters/knquerytools"
+	"github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/driveradapters/knretrieval"
+	"github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/driveradapters/knsearch"
+	"github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/driveradapters/mcpproxy"
+	"github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/interfaces"
 )
 
 type restPrivateHandler struct {

--- a/adp/context-loader/agent-retrieval/server/driveradapters/rest_public_handler.go
+++ b/adp/context-loader/agent-retrieval/server/driveradapters/rest_public_handler.go
@@ -12,17 +12,17 @@ import (
 
 	"github.com/gin-gonic/gin"
 
-	"github.com/openbkn-ai/adp/context-loader/agent-retrieval/server/drivenadapters"
-	"github.com/openbkn-ai/adp/context-loader/agent-retrieval/server/driveradapters/knactionrecall"
-	"github.com/openbkn-ai/adp/context-loader/agent-retrieval/server/driveradapters/knfindskills"
-	"github.com/openbkn-ai/adp/context-loader/agent-retrieval/server/driveradapters/knlogicpropertyresolver"
-	"github.com/openbkn-ai/adp/context-loader/agent-retrieval/server/driveradapters/knqueryobjectinstance"
-	"github.com/openbkn-ai/adp/context-loader/agent-retrieval/server/driveradapters/knquerysubgraph"
-	"github.com/openbkn-ai/adp/context-loader/agent-retrieval/server/driveradapters/knquerytools"
-	"github.com/openbkn-ai/adp/context-loader/agent-retrieval/server/driveradapters/knretrieval"
-	"github.com/openbkn-ai/adp/context-loader/agent-retrieval/server/driveradapters/knsearch"
-	"github.com/openbkn-ai/adp/context-loader/agent-retrieval/server/driveradapters/mcp"
-	"github.com/openbkn-ai/adp/context-loader/agent-retrieval/server/interfaces"
+	"github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/drivenadapters"
+	"github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/driveradapters/knactionrecall"
+	"github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/driveradapters/knfindskills"
+	"github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/driveradapters/knlogicpropertyresolver"
+	"github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/driveradapters/knqueryobjectinstance"
+	"github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/driveradapters/knquerysubgraph"
+	"github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/driveradapters/knquerytools"
+	"github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/driveradapters/knretrieval"
+	"github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/driveradapters/knsearch"
+	"github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/driveradapters/mcp"
+	"github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/interfaces"
 )
 
 type restPublicHandler struct {

--- a/adp/context-loader/agent-retrieval/server/driveradapters/search_schema_route_test.go
+++ b/adp/context-loader/agent-retrieval/server/driveradapters/search_schema_route_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/gin-gonic/gin"
 	"github.com/smartystreets/goconvey/convey"
 
-	"github.com/openbkn-ai/adp/context-loader/agent-retrieval/server/infra/logger"
+	"github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/infra/logger"
 )
 
 func (stubKnSearchHandler) SearchSchema(c *gin.Context) {

--- a/adp/context-loader/agent-retrieval/server/infra/bkntrace/evidence.go
+++ b/adp/context-loader/agent-retrieval/server/infra/bkntrace/evidence.go
@@ -19,8 +19,8 @@ import (
 	"strings"
 	"time"
 
-	"github.com/openbkn-ai/adp/context-loader/agent-retrieval/server/infra/common"
-	"github.com/openbkn-ai/adp/context-loader/agent-retrieval/server/interfaces"
+	"github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/infra/common"
+	"github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/interfaces"
 	"go.opentelemetry.io/otel/trace"
 )
 

--- a/adp/context-loader/agent-retrieval/server/infra/bkntrace/evidence_test.go
+++ b/adp/context-loader/agent-retrieval/server/infra/bkntrace/evidence_test.go
@@ -17,8 +17,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/openbkn-ai/adp/context-loader/agent-retrieval/server/infra/common"
-	"github.com/openbkn-ai/adp/context-loader/agent-retrieval/server/interfaces"
+	"github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/infra/common"
+	"github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/interfaces"
 	"go.opentelemetry.io/otel/trace"
 )
 

--- a/adp/context-loader/agent-retrieval/server/infra/common/context_manage.go
+++ b/adp/context-loader/agent-retrieval/server/infra/common/context_manage.go
@@ -19,7 +19,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/openbkn-ai/adp/context-loader/agent-retrieval/server/interfaces"
+	"github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/interfaces"
 	"go.opentelemetry.io/otel/trace"
 )
 

--- a/adp/context-loader/agent-retrieval/server/infra/common/context_manage_test.go
+++ b/adp/context-loader/agent-retrieval/server/infra/common/context_manage_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/smartystreets/goconvey/convey"
 	"go.opentelemetry.io/otel/trace"
 
-	"github.com/openbkn-ai/adp/context-loader/agent-retrieval/server/interfaces"
+	"github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/interfaces"
 )
 
 func TestResponseFormatContextHelpers(t *testing.T) {

--- a/adp/context-loader/agent-retrieval/server/infra/config/config.go
+++ b/adp/context-loader/agent-retrieval/server/infra/config/config.go
@@ -24,10 +24,10 @@ import (
 	"github.com/spf13/viper"
 	yaml "gopkg.in/yaml.v3"
 
-	"github.com/openbkn-ai/adp/context-loader/agent-retrieval/server/infra/logger"
-	"github.com/openbkn-ai/adp/context-loader/agent-retrieval/server/infra/telemetry"
-	"github.com/openbkn-ai/adp/context-loader/agent-retrieval/server/interfaces"
-	"github.com/openbkn-ai/adp/context-loader/agent-retrieval/server/utils"
+	"github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/infra/logger"
+	"github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/infra/telemetry"
+	"github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/interfaces"
+	"github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/utils"
 )
 
 // Config configuration

--- a/adp/context-loader/agent-retrieval/server/infra/errors/error.go
+++ b/adp/context-loader/agent-retrieval/server/infra/errors/error.go
@@ -16,8 +16,8 @@ import (
 
 	jsoniter "github.com/json-iterator/go"
 
-	"github.com/openbkn-ai/adp/context-loader/agent-retrieval/server/infra/common"
-	"github.com/openbkn-ai/adp/context-loader/agent-retrieval/server/infra/localize"
+	"github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/infra/common"
+	"github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/infra/localize"
 )
 
 // HTTPError HTTP错误

--- a/adp/context-loader/agent-retrieval/server/infra/logger/logger.go
+++ b/adp/context-loader/agent-retrieval/server/infra/logger/logger.go
@@ -16,7 +16,7 @@ import (
 	"log"
 	"os"
 
-	"github.com/openbkn-ai/adp/context-loader/agent-retrieval/server/interfaces"
+	"github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/interfaces"
 )
 
 // Level 日志level

--- a/adp/context-loader/agent-retrieval/server/infra/rest/http_client.go
+++ b/adp/context-loader/agent-retrieval/server/infra/rest/http_client.go
@@ -19,11 +19,11 @@ import (
 
 	"github.com/bytedance/sonic"
 
-	infraErr "github.com/openbkn-ai/adp/context-loader/agent-retrieval/server/infra/errors"
-	"github.com/openbkn-ai/adp/context-loader/agent-retrieval/server/infra/logger"
-	"github.com/openbkn-ai/adp/context-loader/agent-retrieval/server/infra/telemetry"
-	"github.com/openbkn-ai/adp/context-loader/agent-retrieval/server/interfaces"
-	"github.com/openbkn-ai/adp/context-loader/agent-retrieval/server/utils"
+	infraErr "github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/infra/errors"
+	"github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/infra/logger"
+	"github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/infra/telemetry"
+	"github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/interfaces"
+	"github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/utils"
 )
 
 // httpClient HTTP客户端结构

--- a/adp/context-loader/agent-retrieval/server/infra/rest/reply.go
+++ b/adp/context-loader/agent-retrieval/server/infra/rest/reply.go
@@ -20,11 +20,11 @@ import (
 	validator "github.com/go-playground/validator/v10"
 	errorwrap "github.com/pkg/errors"
 
-	"github.com/openbkn-ai/adp/context-loader/agent-retrieval/server/infra/common"
-	myErr "github.com/openbkn-ai/adp/context-loader/agent-retrieval/server/infra/errors"
-	"github.com/openbkn-ai/adp/context-loader/agent-retrieval/server/infra/localize"
-	"github.com/openbkn-ai/adp/context-loader/agent-retrieval/server/infra/logger"
-	validatorv "github.com/openbkn-ai/adp/context-loader/agent-retrieval/server/infra/validator"
+	"github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/infra/common"
+	myErr "github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/infra/errors"
+	"github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/infra/localize"
+	"github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/infra/logger"
+	validatorv "github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/infra/validator"
 )
 
 const (

--- a/adp/context-loader/agent-retrieval/server/infra/rest/reply_response_format_test.go
+++ b/adp/context-loader/agent-retrieval/server/infra/rest/reply_response_format_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/smartystreets/goconvey/convey"
 	"github.com/toon-format/toon-go"
 
-	"github.com/openbkn-ai/adp/context-loader/agent-retrieval/server/infra/common"
+	"github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/infra/common"
 )
 
 func TestReplyOK_WithTOONResponseFormatFromContext(t *testing.T) {

--- a/adp/context-loader/agent-retrieval/server/infra/telemetry/log.go
+++ b/adp/context-loader/agent-retrieval/server/infra/telemetry/log.go
@@ -13,7 +13,7 @@ import (
 
 	"github.com/openbkn-ai/bkn-comm-go/otel/otellog"
 
-	"github.com/openbkn-ai/adp/context-loader/agent-retrieval/server/interfaces"
+	"github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/interfaces"
 )
 
 // LogExporterType 日志导出类型

--- a/adp/context-loader/agent-retrieval/server/infra/validator/validator10.go
+++ b/adp/context-loader/agent-retrieval/server/infra/validator/validator10.go
@@ -8,7 +8,7 @@
 package validator
 
 import (
-	myErr "github.com/openbkn-ai/adp/context-loader/agent-retrieval/server/infra/errors"
+	myErr "github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/infra/errors"
 )
 
 // TagToErrorType Validate tag 映射到错误分类

--- a/adp/context-loader/agent-retrieval/server/logics/knactionrecall/execute_action.go
+++ b/adp/context-loader/agent-retrieval/server/logics/knactionrecall/execute_action.go
@@ -9,7 +9,7 @@ package knactionrecall
 import (
 	"context"
 
-	"github.com/openbkn-ai/adp/context-loader/agent-retrieval/server/interfaces"
+	"github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/interfaces"
 )
 
 // ExecuteAction 执行行动（异步）。

--- a/adp/context-loader/agent-retrieval/server/logics/knactionrecall/execute_action_test.go
+++ b/adp/context-loader/agent-retrieval/server/logics/knactionrecall/execute_action_test.go
@@ -14,9 +14,9 @@ import (
 	"github.com/smartystreets/goconvey/convey"
 	"go.uber.org/mock/gomock"
 
-	"github.com/openbkn-ai/adp/context-loader/agent-retrieval/server/infra/config"
-	"github.com/openbkn-ai/adp/context-loader/agent-retrieval/server/interfaces"
-	"github.com/openbkn-ai/adp/context-loader/agent-retrieval/server/mocks"
+	"github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/infra/config"
+	"github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/interfaces"
+	"github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/mocks"
 )
 
 // TestExecuteAction_Success 透传 ontology-query 的执行响应

--- a/adp/context-loader/agent-retrieval/server/logics/knactionrecall/get_action_info.go
+++ b/adp/context-loader/agent-retrieval/server/logics/knactionrecall/get_action_info.go
@@ -11,9 +11,9 @@ import (
 	"fmt"
 	"net/http"
 
-	"github.com/openbkn-ai/adp/context-loader/agent-retrieval/server/infra/common"
-	infraErr "github.com/openbkn-ai/adp/context-loader/agent-retrieval/server/infra/errors"
-	"github.com/openbkn-ai/adp/context-loader/agent-retrieval/server/interfaces"
+	"github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/infra/common"
+	infraErr "github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/infra/errors"
+	"github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/interfaces"
 )
 
 // GetActionInfo 获取行动信息（行动召回）

--- a/adp/context-loader/agent-retrieval/server/logics/knactionrecall/get_action_info_test.go
+++ b/adp/context-loader/agent-retrieval/server/logics/knactionrecall/get_action_info_test.go
@@ -14,9 +14,9 @@ import (
 	"github.com/smartystreets/goconvey/convey"
 	"go.uber.org/mock/gomock"
 
-	"github.com/openbkn-ai/adp/context-loader/agent-retrieval/server/infra/config"
-	"github.com/openbkn-ai/adp/context-loader/agent-retrieval/server/interfaces"
-	"github.com/openbkn-ai/adp/context-loader/agent-retrieval/server/mocks"
+	"github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/infra/config"
+	"github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/interfaces"
+	"github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/mocks"
 )
 
 // TestGetActionInfo_QueryActionsError 测试 QueryActions 调用失败的场景

--- a/adp/context-loader/agent-retrieval/server/logics/knactionrecall/index.go
+++ b/adp/context-loader/agent-retrieval/server/logics/knactionrecall/index.go
@@ -11,9 +11,9 @@ package knactionrecall
 import (
 	"sync"
 
-	"github.com/openbkn-ai/adp/context-loader/agent-retrieval/server/drivenadapters"
-	"github.com/openbkn-ai/adp/context-loader/agent-retrieval/server/infra/config"
-	"github.com/openbkn-ai/adp/context-loader/agent-retrieval/server/interfaces"
+	"github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/drivenadapters"
+	"github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/infra/config"
+	"github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/interfaces"
 )
 
 type knActionRecallServiceImpl struct {

--- a/adp/context-loader/agent-retrieval/server/logics/knactionrecall/schema_converter.go
+++ b/adp/context-loader/agent-retrieval/server/logics/knactionrecall/schema_converter.go
@@ -11,7 +11,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/openbkn-ai/adp/context-loader/agent-retrieval/server/interfaces"
+	"github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/interfaces"
 )
 
 const (

--- a/adp/context-loader/agent-retrieval/server/logics/knactionrecall/schema_converter_test.go
+++ b/adp/context-loader/agent-retrieval/server/logics/knactionrecall/schema_converter_test.go
@@ -5,8 +5,8 @@ import (
 	"encoding/json"
 	"testing"
 
-	"github.com/openbkn-ai/adp/context-loader/agent-retrieval/server/infra/config"
-	"github.com/openbkn-ai/adp/context-loader/agent-retrieval/server/interfaces"
+	"github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/infra/config"
+	"github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/interfaces"
 )
 
 type mockLogger struct{}

--- a/adp/context-loader/agent-retrieval/server/logics/knfindskills/context_normalizer.go
+++ b/adp/context-loader/agent-retrieval/server/logics/knfindskills/context_normalizer.go
@@ -10,8 +10,8 @@ import (
 	"fmt"
 	"net/http"
 
-	"github.com/openbkn-ai/adp/context-loader/agent-retrieval/server/infra/config"
-	"github.com/openbkn-ai/adp/context-loader/agent-retrieval/server/interfaces"
+	"github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/infra/config"
+	"github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/interfaces"
 )
 
 // NormalizeAndDetectMode validates the request and determines the recall mode.

--- a/adp/context-loader/agent-retrieval/server/logics/knfindskills/context_normalizer_test.go
+++ b/adp/context-loader/agent-retrieval/server/logics/knfindskills/context_normalizer_test.go
@@ -11,8 +11,8 @@ import (
 
 	validator "github.com/go-playground/validator/v10"
 
-	"github.com/openbkn-ai/adp/context-loader/agent-retrieval/server/infra/config"
-	"github.com/openbkn-ai/adp/context-loader/agent-retrieval/server/interfaces"
+	"github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/infra/config"
+	"github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/interfaces"
 )
 
 func defaultFSConfig() *config.FindSkillsConfig {

--- a/adp/context-loader/agent-retrieval/server/logics/knfindskills/find_skills_service_test.go
+++ b/adp/context-loader/agent-retrieval/server/logics/knfindskills/find_skills_service_test.go
@@ -12,10 +12,10 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/openbkn-ai/adp/context-loader/agent-retrieval/server/infra/common"
-	"github.com/openbkn-ai/adp/context-loader/agent-retrieval/server/infra/config"
-	infraErr "github.com/openbkn-ai/adp/context-loader/agent-retrieval/server/infra/errors"
-	"github.com/openbkn-ai/adp/context-loader/agent-retrieval/server/interfaces"
+	"github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/infra/common"
+	"github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/infra/config"
+	infraErr "github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/infra/errors"
+	"github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/interfaces"
 )
 
 func newTestConfig() *config.Config {

--- a/adp/context-loader/agent-retrieval/server/logics/knfindskills/index.go
+++ b/adp/context-loader/agent-retrieval/server/logics/knfindskills/index.go
@@ -17,12 +17,12 @@ import (
 
 	"github.com/openbkn-ai/bkn-comm-go/otel/oteltrace"
 
-	"github.com/openbkn-ai/adp/context-loader/agent-retrieval/server/drivenadapters"
-	"github.com/openbkn-ai/adp/context-loader/agent-retrieval/server/infra/common"
-	"github.com/openbkn-ai/adp/context-loader/agent-retrieval/server/infra/config"
-	infraErr "github.com/openbkn-ai/adp/context-loader/agent-retrieval/server/infra/errors"
-	"github.com/openbkn-ai/adp/context-loader/agent-retrieval/server/infra/localize"
-	"github.com/openbkn-ai/adp/context-loader/agent-retrieval/server/interfaces"
+	"github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/drivenadapters"
+	"github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/infra/common"
+	"github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/infra/config"
+	infraErr "github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/infra/errors"
+	"github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/infra/localize"
+	"github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/interfaces"
 )
 
 var requiredSkillsDataProperties = []string{"skill_id", "name"}

--- a/adp/context-loader/agent-retrieval/server/logics/knfindskills/mock_test.go
+++ b/adp/context-loader/agent-retrieval/server/logics/knfindskills/mock_test.go
@@ -10,7 +10,7 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/openbkn-ai/adp/context-loader/agent-retrieval/server/interfaces"
+	"github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/interfaces"
 )
 
 // testLogger is a minimal logger for tests

--- a/adp/context-loader/agent-retrieval/server/logics/knfindskills/recall_coordinator.go
+++ b/adp/context-loader/agent-retrieval/server/logics/knfindskills/recall_coordinator.go
@@ -12,8 +12,8 @@ import (
 
 	"github.com/openbkn-ai/bkn-comm-go/otel/oteltrace"
 
-	"github.com/openbkn-ai/adp/context-loader/agent-retrieval/server/infra/config"
-	"github.com/openbkn-ai/adp/context-loader/agent-retrieval/server/interfaces"
+	"github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/infra/config"
+	"github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/interfaces"
 )
 
 // recallCoordinator orchestrates multi-path skill recall

--- a/adp/context-loader/agent-retrieval/server/logics/knfindskills/recall_coordinator_test.go
+++ b/adp/context-loader/agent-retrieval/server/logics/knfindskills/recall_coordinator_test.go
@@ -12,9 +12,9 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/openbkn-ai/adp/context-loader/agent-retrieval/server/infra/common"
-	"github.com/openbkn-ai/adp/context-loader/agent-retrieval/server/infra/config"
-	"github.com/openbkn-ai/adp/context-loader/agent-retrieval/server/interfaces"
+	"github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/infra/common"
+	"github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/infra/config"
+	"github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/interfaces"
 )
 
 func newTestCoordinator(bkn *testBknBackend, oq *testOntologyQuery) *recallCoordinator {

--- a/adp/context-loader/agent-retrieval/server/logics/knfindskills/result_assembler.go
+++ b/adp/context-loader/agent-retrieval/server/logics/knfindskills/result_assembler.go
@@ -9,7 +9,7 @@ package knfindskills
 import (
 	"sort"
 
-	"github.com/openbkn-ai/adp/context-loader/agent-retrieval/server/interfaces"
+	"github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/interfaces"
 )
 
 // Assemble deduplicates by skill_id (keeping the highest priority),

--- a/adp/context-loader/agent-retrieval/server/logics/knfindskills/result_assembler_test.go
+++ b/adp/context-loader/agent-retrieval/server/logics/knfindskills/result_assembler_test.go
@@ -9,7 +9,7 @@ package knfindskills
 import (
 	"testing"
 
-	"github.com/openbkn-ai/adp/context-loader/agent-retrieval/server/interfaces"
+	"github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/interfaces"
 )
 
 func TestAssemble_Empty(t *testing.T) {

--- a/adp/context-loader/agent-retrieval/server/logics/knfindskills/skill_query_condition_builder.go
+++ b/adp/context-loader/agent-retrieval/server/logics/knfindskills/skill_query_condition_builder.go
@@ -9,7 +9,7 @@ package knfindskills
 import (
 	"strings"
 
-	"github.com/openbkn-ai/adp/context-loader/agent-retrieval/server/interfaces"
+	"github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/interfaces"
 )
 
 var skillQueryTargetFields = map[string]struct{}{

--- a/adp/context-loader/agent-retrieval/server/logics/knfindskills/skill_query_condition_builder_test.go
+++ b/adp/context-loader/agent-retrieval/server/logics/knfindskills/skill_query_condition_builder_test.go
@@ -9,7 +9,7 @@ package knfindskills
 import (
 	"testing"
 
-	"github.com/openbkn-ai/adp/context-loader/agent-retrieval/server/interfaces"
+	"github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/interfaces"
 )
 
 func makeSkillsObjType(nameOps, descOps []interfaces.KnOperationType) *interfaces.ObjectType {

--- a/adp/context-loader/agent-retrieval/server/logics/knfindskills/subgraph_request_builder.go
+++ b/adp/context-loader/agent-retrieval/server/logics/knfindskills/subgraph_request_builder.go
@@ -7,7 +7,7 @@
 package knfindskills
 
 import (
-	"github.com/openbkn-ai/adp/context-loader/agent-retrieval/server/interfaces"
+	"github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/interfaces"
 )
 
 const skillsObjectTypeIDDefault = "skills"

--- a/adp/context-loader/agent-retrieval/server/logics/knfindskills/subgraph_request_builder_test.go
+++ b/adp/context-loader/agent-retrieval/server/logics/knfindskills/subgraph_request_builder_test.go
@@ -9,7 +9,7 @@ package knfindskills
 import (
 	"testing"
 
-	"github.com/openbkn-ai/adp/context-loader/agent-retrieval/server/interfaces"
+	"github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/interfaces"
 )
 
 func TestBuildSubgraphRequest_ForwardDirection(t *testing.T) {

--- a/adp/context-loader/agent-retrieval/server/logics/knlogicpropertyresolver/debug_collector.go
+++ b/adp/context-loader/agent-retrieval/server/logics/knlogicpropertyresolver/debug_collector.go
@@ -8,7 +8,7 @@
 package knlogicpropertyresolver
 
 import (
-	"github.com/openbkn-ai/adp/context-loader/agent-retrieval/server/interfaces"
+	"github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/interfaces"
 )
 
 // DebugCollector Debug 信息收集器

--- a/adp/context-loader/agent-retrieval/server/logics/knlogicpropertyresolver/dynamic_params_llm.go
+++ b/adp/context-loader/agent-retrieval/server/logics/knlogicpropertyresolver/dynamic_params_llm.go
@@ -17,8 +17,8 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/openbkn-ai/adp/context-loader/agent-retrieval/server/interfaces"
-	"github.com/openbkn-ai/adp/context-loader/agent-retrieval/server/utils"
+	"github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/interfaces"
+	"github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/utils"
 )
 
 //go:embed prompts/metric_dynamic_params.md

--- a/adp/context-loader/agent-retrieval/server/logics/knlogicpropertyresolver/dynamic_params_llm_test.go
+++ b/adp/context-loader/agent-retrieval/server/logics/knlogicpropertyresolver/dynamic_params_llm_test.go
@@ -10,8 +10,8 @@ import (
 
 	"go.uber.org/mock/gomock"
 
-	"github.com/openbkn-ai/adp/context-loader/agent-retrieval/server/interfaces"
-	"github.com/openbkn-ai/adp/context-loader/agent-retrieval/server/mocks"
+	"github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/interfaces"
+	"github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/mocks"
 )
 
 // noopLogger 空实现，避免为每条日志写 gomock 期望

--- a/adp/context-loader/agent-retrieval/server/logics/knlogicpropertyresolver/index.go
+++ b/adp/context-loader/agent-retrieval/server/logics/knlogicpropertyresolver/index.go
@@ -13,10 +13,10 @@ import (
 	"sync"
 	"time"
 
-	"github.com/openbkn-ai/adp/context-loader/agent-retrieval/server/drivenadapters"
-	"github.com/openbkn-ai/adp/context-loader/agent-retrieval/server/infra/config"
-	"github.com/openbkn-ai/adp/context-loader/agent-retrieval/server/infra/errors"
-	"github.com/openbkn-ai/adp/context-loader/agent-retrieval/server/interfaces"
+	"github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/drivenadapters"
+	"github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/infra/config"
+	"github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/infra/errors"
+	"github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/interfaces"
 )
 
 const (

--- a/adp/context-loader/agent-retrieval/server/logics/knlogicpropertyresolver/index_test.go
+++ b/adp/context-loader/agent-retrieval/server/logics/knlogicpropertyresolver/index_test.go
@@ -13,8 +13,8 @@ import (
 	"github.com/smartystreets/goconvey/convey"
 	"go.uber.org/mock/gomock"
 
-	"github.com/openbkn-ai/adp/context-loader/agent-retrieval/server/interfaces"
-	"github.com/openbkn-ai/adp/context-loader/agent-retrieval/server/mocks"
+	"github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/interfaces"
+	"github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/mocks"
 )
 
 // TestValidateRequest_Success 测试 validateRequest 成功场景

--- a/adp/context-loader/agent-retrieval/server/logics/knquerysubgraph/index.go
+++ b/adp/context-loader/agent-retrieval/server/logics/knquerysubgraph/index.go
@@ -12,10 +12,10 @@ import (
 	"context"
 	"sync"
 
-	"github.com/openbkn-ai/adp/context-loader/agent-retrieval/server/drivenadapters"
-	"github.com/openbkn-ai/adp/context-loader/agent-retrieval/server/infra/bkntrace"
-	"github.com/openbkn-ai/adp/context-loader/agent-retrieval/server/infra/config"
-	"github.com/openbkn-ai/adp/context-loader/agent-retrieval/server/interfaces"
+	"github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/drivenadapters"
+	"github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/infra/bkntrace"
+	"github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/infra/config"
+	"github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/interfaces"
 )
 
 // KnQuerySubgraphService 子图查询服务

--- a/adp/context-loader/agent-retrieval/server/logics/knquerysubgraph/index_test.go
+++ b/adp/context-loader/agent-retrieval/server/logics/knquerysubgraph/index_test.go
@@ -14,8 +14,8 @@ import (
 	"github.com/smartystreets/goconvey/convey"
 	"go.uber.org/mock/gomock"
 
-	"github.com/openbkn-ai/adp/context-loader/agent-retrieval/server/interfaces"
-	"github.com/openbkn-ai/adp/context-loader/agent-retrieval/server/mocks"
+	"github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/interfaces"
+	"github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/mocks"
 )
 
 // TestQueryInstanceSubgraph_Success 测试 QueryInstanceSubgraph 成功场景

--- a/adp/context-loader/agent-retrieval/server/logics/knrerank/knowledge_rerank.go
+++ b/adp/context-loader/agent-retrieval/server/logics/knrerank/knowledge_rerank.go
@@ -19,8 +19,8 @@ import (
 	"sync"
 	"text/template"
 
-	"github.com/openbkn-ai/adp/context-loader/agent-retrieval/server/infra/config"
-	"github.com/openbkn-ai/adp/context-loader/agent-retrieval/server/interfaces"
+	"github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/infra/config"
+	"github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/interfaces"
 )
 
 // rerankPromptTemplate 重排序提示词模板

--- a/adp/context-loader/agent-retrieval/server/logics/knrerank/knowledge_rerank_test.go
+++ b/adp/context-loader/agent-retrieval/server/logics/knrerank/knowledge_rerank_test.go
@@ -10,7 +10,7 @@ import (
 	"context"
 	"testing"
 
-	"github.com/openbkn-ai/adp/context-loader/agent-retrieval/server/interfaces"
+	"github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/interfaces"
 )
 
 // mockLogger 测试用的mock logger

--- a/adp/context-loader/agent-retrieval/server/logics/knresources/index.go
+++ b/adp/context-loader/agent-retrieval/server/logics/knresources/index.go
@@ -13,8 +13,8 @@ import (
 	"strings"
 	"sync"
 
-	"github.com/openbkn-ai/adp/context-loader/agent-retrieval/server/drivenadapters"
-	"github.com/openbkn-ai/adp/context-loader/agent-retrieval/server/interfaces"
+	"github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/drivenadapters"
+	"github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/interfaces"
 )
 
 // ErrResourceIDRequired describe_resource 的 resource_id 入参为空。

--- a/adp/context-loader/agent-retrieval/server/logics/knresources/index_test.go
+++ b/adp/context-loader/agent-retrieval/server/logics/knresources/index_test.go
@@ -9,7 +9,7 @@ import (
 	"errors"
 	"testing"
 
-	"github.com/openbkn-ai/adp/context-loader/agent-retrieval/server/interfaces"
+	"github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/interfaces"
 )
 
 // fakeVega 实现 interfaces.DrivenVega，仅供本包测试。

--- a/adp/context-loader/agent-retrieval/server/logics/knretrieval/agent_intent_planning.go
+++ b/adp/context-loader/agent-retrieval/server/logics/knretrieval/agent_intent_planning.go
@@ -12,7 +12,7 @@ import (
 
 	"github.com/openbkn-ai/bkn-comm-go/otel/oteltrace"
 
-	"github.com/openbkn-ai/adp/context-loader/agent-retrieval/server/interfaces"
+	"github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/interfaces"
 )
 
 // AgentIntentPlanning 语义搜索: 基于意图分析智能体+规划策略

--- a/adp/context-loader/agent-retrieval/server/logics/knretrieval/agent_intent_planning_test.go
+++ b/adp/context-loader/agent-retrieval/server/logics/knretrieval/agent_intent_planning_test.go
@@ -11,7 +11,7 @@ import (
 
 	"github.com/smartystreets/goconvey/convey"
 
-	"github.com/openbkn-ai/adp/context-loader/agent-retrieval/server/interfaces"
+	"github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/interfaces"
 )
 
 // TestDeduplicateConcepts 测试 deduplicateConcepts 函数

--- a/adp/context-loader/agent-retrieval/server/logics/knretrieval/agent_intent_retrieval.go
+++ b/adp/context-loader/agent-retrieval/server/logics/knretrieval/agent_intent_retrieval.go
@@ -11,7 +11,7 @@ import (
 
 	"github.com/openbkn-ai/bkn-comm-go/otel/oteltrace"
 
-	"github.com/openbkn-ai/adp/context-loader/agent-retrieval/server/interfaces"
+	"github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/interfaces"
 )
 
 // AgentIntentRetrieval 语义检索。

--- a/adp/context-loader/agent-retrieval/server/logics/knretrieval/convert.go
+++ b/adp/context-loader/agent-retrieval/server/logics/knretrieval/convert.go
@@ -9,7 +9,7 @@ package knretrieval
 import (
 	"fmt"
 
-	"github.com/openbkn-ai/adp/context-loader/agent-retrieval/server/interfaces"
+	"github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/interfaces"
 )
 
 var knOperationTypeMap = map[string]interfaces.KnOperationType{

--- a/adp/context-loader/agent-retrieval/server/logics/knretrieval/convert_test.go
+++ b/adp/context-loader/agent-retrieval/server/logics/knretrieval/convert_test.go
@@ -11,7 +11,7 @@ import (
 
 	"github.com/smartystreets/goconvey/convey"
 
-	"github.com/openbkn-ai/adp/context-loader/agent-retrieval/server/interfaces"
+	"github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/interfaces"
 )
 
 // TestParseKnOperationType_Success 测试 ParseKnOperationType 成功场景

--- a/adp/context-loader/agent-retrieval/server/logics/knretrieval/index.go
+++ b/adp/context-loader/agent-retrieval/server/logics/knretrieval/index.go
@@ -11,10 +11,10 @@ package knretrieval
 import (
 	"sync"
 
-	"github.com/openbkn-ai/adp/context-loader/agent-retrieval/server/drivenadapters"
-	"github.com/openbkn-ai/adp/context-loader/agent-retrieval/server/infra/config"
-	"github.com/openbkn-ai/adp/context-loader/agent-retrieval/server/interfaces"
-	"github.com/openbkn-ai/adp/context-loader/agent-retrieval/server/logics/knrerank"
+	"github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/drivenadapters"
+	"github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/infra/config"
+	"github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/interfaces"
+	"github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/logics/knrerank"
 )
 
 type knRetrievalServiceImpl struct {

--- a/adp/context-loader/agent-retrieval/server/logics/knretrieval/keyword_vector_retrieval.go
+++ b/adp/context-loader/agent-retrieval/server/logics/knretrieval/keyword_vector_retrieval.go
@@ -11,7 +11,7 @@ import (
 
 	"github.com/openbkn-ai/bkn-comm-go/otel/oteltrace"
 
-	"github.com/openbkn-ai/adp/context-loader/agent-retrieval/server/interfaces"
+	"github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/interfaces"
 )
 
 // KeywordVectorRetrieval 基于关键词+向量召回

--- a/adp/context-loader/agent-retrieval/server/logics/knretrieval/query_strategy.go
+++ b/adp/context-loader/agent-retrieval/server/logics/knretrieval/query_strategy.go
@@ -10,8 +10,8 @@ import (
 	"context"
 	"sync"
 
-	"github.com/openbkn-ai/adp/context-loader/agent-retrieval/server/infra/config"
-	"github.com/openbkn-ai/adp/context-loader/agent-retrieval/server/interfaces"
+	"github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/infra/config"
+	"github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/interfaces"
 )
 
 const (

--- a/adp/context-loader/agent-retrieval/server/logics/knretrieval/rerank.go
+++ b/adp/context-loader/agent-retrieval/server/logics/knretrieval/rerank.go
@@ -10,7 +10,7 @@ import (
 	"context"
 	"sort"
 
-	"github.com/openbkn-ai/adp/context-loader/agent-retrieval/server/interfaces"
+	"github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/interfaces"
 )
 
 // rerankByConceptType 收集不同概念类集合，并进行排序，每个概念集取前limit个

--- a/adp/context-loader/agent-retrieval/server/logics/knretrieval/rerank_test.go
+++ b/adp/context-loader/agent-retrieval/server/logics/knretrieval/rerank_test.go
@@ -13,8 +13,8 @@ import (
 
 	"github.com/smartystreets/goconvey/convey"
 
-	"github.com/openbkn-ai/adp/context-loader/agent-retrieval/server/interfaces"
-	"github.com/openbkn-ai/adp/context-loader/agent-retrieval/server/logics/knrerank"
+	"github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/interfaces"
+	"github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/logics/knrerank"
 )
 
 type testLogger struct{}

--- a/adp/context-loader/agent-retrieval/server/logics/knrunsql/index.go
+++ b/adp/context-loader/agent-retrieval/server/logics/knrunsql/index.go
@@ -10,9 +10,9 @@ import (
 	"strings"
 	"sync"
 
-	"github.com/openbkn-ai/adp/context-loader/agent-retrieval/server/drivenadapters"
-	"github.com/openbkn-ai/adp/context-loader/agent-retrieval/server/infra/bkntrace"
-	"github.com/openbkn-ai/adp/context-loader/agent-retrieval/server/interfaces"
+	"github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/drivenadapters"
+	"github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/infra/bkntrace"
+	"github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/interfaces"
 )
 
 var (

--- a/adp/context-loader/agent-retrieval/server/logics/knrunsql/index_test.go
+++ b/adp/context-loader/agent-retrieval/server/logics/knrunsql/index_test.go
@@ -8,7 +8,7 @@ import (
 	"context"
 	"testing"
 
-	"github.com/openbkn-ai/adp/context-loader/agent-retrieval/server/interfaces"
+	"github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/interfaces"
 )
 
 type recordingVega struct {

--- a/adp/context-loader/agent-retrieval/server/logics/knsearch/concept_retrieval.go
+++ b/adp/context-loader/agent-retrieval/server/logics/knsearch/concept_retrieval.go
@@ -15,7 +15,7 @@ import (
 
 	"github.com/openbkn-ai/bkn-comm-go/otel/oteltrace"
 
-	"github.com/openbkn-ai/adp/context-loader/agent-retrieval/server/interfaces"
+	"github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/interfaces"
 )
 
 // objectTypeRelationMultiplier 无关系/按关系过滤时对象类型数量相对 topK 的倍数

--- a/adp/context-loader/agent-retrieval/server/logics/knsearch/concept_retrieval_test.go
+++ b/adp/context-loader/agent-retrieval/server/logics/knsearch/concept_retrieval_test.go
@@ -5,7 +5,7 @@ import (
 	"errors"
 	"testing"
 
-	"github.com/openbkn-ai/adp/context-loader/agent-retrieval/server/interfaces"
+	"github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/interfaces"
 )
 
 func sameStringSet(got, want []string) bool {

--- a/adp/context-loader/agent-retrieval/server/logics/knsearch/config.go
+++ b/adp/context-loader/agent-retrieval/server/logics/knsearch/config.go
@@ -8,7 +8,7 @@
 // file: config.go
 package knsearch
 
-import "github.com/openbkn-ai/adp/context-loader/agent-retrieval/server/interfaces"
+import "github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/interfaces"
 
 // DefaultConceptRetrievalConfig 返回概念召回默认配置
 func DefaultConceptRetrievalConfig() *interfaces.KnSearchConceptRetrievalConfig {

--- a/adp/context-loader/agent-retrieval/server/logics/knsearch/config_test.go
+++ b/adp/context-loader/agent-retrieval/server/logics/knsearch/config_test.go
@@ -4,7 +4,7 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/openbkn-ai/adp/context-loader/agent-retrieval/server/interfaces"
+	"github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/interfaces"
 )
 
 func TestDefaultConceptRetrievalConfig(t *testing.T) {

--- a/adp/context-loader/agent-retrieval/server/logics/knsearch/convert.go
+++ b/adp/context-loader/agent-retrieval/server/logics/knsearch/convert.go
@@ -12,7 +12,7 @@ package knsearch
 import (
 	"encoding/json"
 
-	"github.com/openbkn-ai/adp/context-loader/agent-retrieval/server/interfaces"
+	"github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/interfaces"
 )
 
 // KnSearchReqToLocal 将 KnSearchReq 转为 KnSearchLocalRequest

--- a/adp/context-loader/agent-retrieval/server/logics/knsearch/convert_brief_datasource_test.go
+++ b/adp/context-loader/agent-retrieval/server/logics/knsearch/convert_brief_datasource_test.go
@@ -11,7 +11,7 @@ import (
 
 	"github.com/smartystreets/goconvey/convey"
 
-	"github.com/openbkn-ai/adp/context-loader/agent-retrieval/server/interfaces"
+	"github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/interfaces"
 )
 
 func TestConvertObjectTypesToLocal_BriefKeepsDataSource(t *testing.T) {

--- a/adp/context-loader/agent-retrieval/server/logics/knsearch/convert_test.go
+++ b/adp/context-loader/agent-retrieval/server/logics/knsearch/convert_test.go
@@ -9,7 +9,7 @@ package knsearch
 import (
 	"testing"
 
-	"github.com/openbkn-ai/adp/context-loader/agent-retrieval/server/interfaces"
+	"github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/interfaces"
 )
 
 func TestRetrievalConfigToLocal_PreservesSchemaBriefFalse(t *testing.T) {

--- a/adp/context-loader/agent-retrieval/server/logics/knsearch/index.go
+++ b/adp/context-loader/agent-retrieval/server/logics/knsearch/index.go
@@ -11,9 +11,9 @@ import (
 	"context"
 	"sync"
 
-	"github.com/openbkn-ai/adp/context-loader/agent-retrieval/server/drivenadapters"
-	"github.com/openbkn-ai/adp/context-loader/agent-retrieval/server/infra/config"
-	"github.com/openbkn-ai/adp/context-loader/agent-retrieval/server/interfaces"
+	"github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/drivenadapters"
+	"github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/infra/config"
+	"github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/interfaces"
 )
 
 // localSearchImpl 本地检索实现体

--- a/adp/context-loader/agent-retrieval/server/logics/knsearch/index_legacy_contract_test.go
+++ b/adp/context-loader/agent-retrieval/server/logics/knsearch/index_legacy_contract_test.go
@@ -13,8 +13,8 @@ import (
 	"github.com/smartystreets/goconvey/convey"
 	"go.uber.org/mock/gomock"
 
-	"github.com/openbkn-ai/adp/context-loader/agent-retrieval/server/interfaces"
-	"github.com/openbkn-ai/adp/context-loader/agent-retrieval/server/mocks"
+	"github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/interfaces"
+	"github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/mocks"
 )
 
 func TestKnSearch_StripsLegacyNodesAndMessage(t *testing.T) {

--- a/adp/context-loader/agent-retrieval/server/logics/knsearch/index_test.go
+++ b/adp/context-loader/agent-retrieval/server/logics/knsearch/index_test.go
@@ -14,8 +14,8 @@ import (
 	"github.com/smartystreets/goconvey/convey"
 	"go.uber.org/mock/gomock"
 
-	"github.com/openbkn-ai/adp/context-loader/agent-retrieval/server/interfaces"
-	"github.com/openbkn-ai/adp/context-loader/agent-retrieval/server/mocks"
+	"github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/interfaces"
+	"github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/mocks"
 )
 
 // TestKnSearch_Success 测试 KnSearch 固定走本地检索成功

--- a/adp/context-loader/agent-retrieval/server/logics/knsearch/mock_test.go
+++ b/adp/context-loader/agent-retrieval/server/logics/knsearch/mock_test.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/openbkn-ai/adp/context-loader/agent-retrieval/server/interfaces"
+	"github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/interfaces"
 )
 
 // mockLogger 模拟 Logger 接口

--- a/adp/context-loader/agent-retrieval/server/logics/knsearch/search_schema.go
+++ b/adp/context-loader/agent-retrieval/server/logics/knsearch/search_schema.go
@@ -15,10 +15,10 @@ import (
 
 	"github.com/creasty/defaults"
 
-	"github.com/openbkn-ai/adp/context-loader/agent-retrieval/server/drivenadapters"
-	"github.com/openbkn-ai/adp/context-loader/agent-retrieval/server/infra/bkntrace"
-	aerrors "github.com/openbkn-ai/adp/context-loader/agent-retrieval/server/infra/errors"
-	"github.com/openbkn-ai/adp/context-loader/agent-retrieval/server/interfaces"
+	"github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/drivenadapters"
+	"github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/infra/bkntrace"
+	aerrors "github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/infra/errors"
+	"github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/interfaces"
 )
 
 var newBknBackendAccess = drivenadapters.NewBknBackendAccess

--- a/adp/context-loader/agent-retrieval/server/logics/knsearch/search_schema_test.go
+++ b/adp/context-loader/agent-retrieval/server/logics/knsearch/search_schema_test.go
@@ -5,8 +5,8 @@ import (
 	"errors"
 	"testing"
 
-	infraLogger "github.com/openbkn-ai/adp/context-loader/agent-retrieval/server/infra/logger"
-	"github.com/openbkn-ai/adp/context-loader/agent-retrieval/server/interfaces"
+	infraLogger "github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/infra/logger"
+	"github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/interfaces"
 )
 
 type stubSearchSchemaLocalService struct {

--- a/adp/context-loader/agent-retrieval/server/logics/knsearch/semantic_instance_retrieval.go
+++ b/adp/context-loader/agent-retrieval/server/logics/knsearch/semantic_instance_retrieval.go
@@ -16,7 +16,7 @@ import (
 
 	"github.com/openbkn-ai/bkn-comm-go/otel/oteltrace"
 
-	"github.com/openbkn-ai/adp/context-loader/agent-retrieval/server/interfaces"
+	"github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/interfaces"
 )
 
 // semanticInstanceRetrieval 语义实例召回主逻辑

--- a/adp/context-loader/agent-retrieval/server/logics/knsearch/semantic_instance_retrieval_test.go
+++ b/adp/context-loader/agent-retrieval/server/logics/knsearch/semantic_instance_retrieval_test.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"testing"
 
-	"github.com/openbkn-ai/adp/context-loader/agent-retrieval/server/interfaces"
+	"github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/interfaces"
 )
 
 func TestSemanticInstanceRetrieval_MainFlow(t *testing.T) {

--- a/adp/context-loader/agent-retrieval/server/logics/knsearch/semantic_searchable_fields.go
+++ b/adp/context-loader/agent-retrieval/server/logics/knsearch/semantic_searchable_fields.go
@@ -11,7 +11,7 @@ package knsearch
 import (
 	"strings"
 
-	"github.com/openbkn-ai/adp/context-loader/agent-retrieval/server/interfaces"
+	"github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/interfaces"
 )
 
 // searchableField 可参与语义检索的字段信息

--- a/adp/context-loader/agent-retrieval/server/logics/knsearch/semantic_searchable_fields_test.go
+++ b/adp/context-loader/agent-retrieval/server/logics/knsearch/semantic_searchable_fields_test.go
@@ -9,7 +9,7 @@ package knsearch
 import (
 	"testing"
 
-	"github.com/openbkn-ai/adp/context-loader/agent-retrieval/server/interfaces"
+	"github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/interfaces"
 )
 
 func TestFindSemanticSearchableFields_Empty(t *testing.T) {

--- a/adp/context-loader/agent-retrieval/server/logics/knsearch/service.go
+++ b/adp/context-loader/agent-retrieval/server/logics/knsearch/service.go
@@ -13,7 +13,7 @@ import (
 
 	"github.com/openbkn-ai/bkn-comm-go/otel/oteltrace"
 
-	"github.com/openbkn-ai/adp/context-loader/agent-retrieval/server/interfaces"
+	"github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/interfaces"
 )
 
 // Search 知识网络检索本地主入口

--- a/adp/context-loader/agent-retrieval/server/logics/knsearch/service_test.go
+++ b/adp/context-loader/agent-retrieval/server/logics/knsearch/service_test.go
@@ -5,7 +5,7 @@ import (
 	"errors"
 	"testing"
 
-	"github.com/openbkn-ai/adp/context-loader/agent-retrieval/server/interfaces"
+	"github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/interfaces"
 )
 
 func TestLocalSearch_Service(t *testing.T) {

--- a/adp/context-loader/agent-retrieval/server/main.go
+++ b/adp/context-loader/agent-retrieval/server/main.go
@@ -10,11 +10,11 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/openbkn-ai/adp/context-loader/agent-retrieval/server/bootstrap"
-	"github.com/openbkn-ai/adp/context-loader/agent-retrieval/server/driveradapters"
-	"github.com/openbkn-ai/adp/context-loader/agent-retrieval/server/infra/common"
-	"github.com/openbkn-ai/adp/context-loader/agent-retrieval/server/infra/config"
-	"github.com/openbkn-ai/adp/context-loader/agent-retrieval/server/interfaces"
+	"github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/bootstrap"
+	"github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/driveradapters"
+	"github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/infra/common"
+	"github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/infra/config"
+	"github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/interfaces"
 
 	"github.com/gin-gonic/gin"
 )

--- a/adp/context-loader/agent-retrieval/server/mocks/driven_ontology_query.go
+++ b/adp/context-loader/agent-retrieval/server/mocks/driven_ontology_query.go
@@ -13,7 +13,7 @@ import (
 	context "context"
 	reflect "reflect"
 
-	interfaces "github.com/openbkn-ai/adp/context-loader/agent-retrieval/server/interfaces"
+	interfaces "github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/interfaces"
 	gomock "go.uber.org/mock/gomock"
 )
 

--- a/adp/context-loader/agent-retrieval/server/mocks/driven_operator_integration.go
+++ b/adp/context-loader/agent-retrieval/server/mocks/driven_operator_integration.go
@@ -15,7 +15,7 @@ import (
 
 	gomock "go.uber.org/mock/gomock"
 
-	interfaces "github.com/openbkn-ai/adp/context-loader/agent-retrieval/server/interfaces"
+	interfaces "github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/interfaces"
 )
 
 // MockDrivenOperatorIntegration is a mock of DrivenOperatorIntegration interface.

--- a/adp/context-loader/agent-retrieval/server/mocks/drivenadapters.go
+++ b/adp/context-loader/agent-retrieval/server/mocks/drivenadapters.go
@@ -13,7 +13,7 @@ import (
 	context "context"
 	reflect "reflect"
 
-	interfaces "github.com/openbkn-ai/adp/context-loader/agent-retrieval/server/interfaces"
+	interfaces "github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/interfaces"
 	gomock "go.uber.org/mock/gomock"
 )
 

--- a/adp/context-loader/agent-retrieval/server/mocks/infra.go
+++ b/adp/context-loader/agent-retrieval/server/mocks/infra.go
@@ -14,7 +14,7 @@ import (
 	url "net/url"
 	reflect "reflect"
 
-	interfaces "github.com/openbkn-ai/adp/context-loader/agent-retrieval/server/interfaces"
+	interfaces "github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/interfaces"
 	gomock "go.uber.org/mock/gomock"
 )
 

--- a/adp/context-loader/agent-retrieval/server/mocks/interface.go
+++ b/adp/context-loader/agent-retrieval/server/mocks/interface.go
@@ -13,7 +13,7 @@ import (
 	context "context"
 	reflect "reflect"
 
-	interfaces "github.com/openbkn-ai/adp/context-loader/agent-retrieval/server/interfaces"
+	interfaces "github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/interfaces"
 	gomock "go.uber.org/mock/gomock"
 )
 


### PR DESCRIPTION
## 为什么

`github.com/openbkn-ai/adp/context-loader/agent-retrieval` 长得完全合规，go 也会照着解析 —— 主机 `github.com`、仓 `openbkn-ai/adp`、子目录 `context-loader/agent-retrieval`。但 **`openbkn-ai/adp` 这个仓不存在**（真仓是 `openbkn-ai/bkn-foundry`，`adp` 只是仓内一级目录），拉取必然 404。

execution-factory 已在 #548 改过，这是同一批债的最后一处 `adp` 假 URL。

直接动机：**这是 openbkn-ee 能 `require` 它的前提**。不改名，ee 只能 `replace` 指本地目录，版本就变成「本机上那份」。EE 插座改造随后单独提，不混在这个 PR 里。

## 改了什么

`go.mod` 首行 + 121 个 go 文件的 import 前缀。纯逐行替换：**315 加 / 315 删**，加删相等。

无跨模块引用，Makefile / Dockerfile / helm / CI 均未写死旧路径。

**gofmt 零改动** —— 这次不像 #548 那样需要重排 64 个文件：本模块的 `bkn-comm-go` import 与自引用分处不同 import 组，组内字典序不跨组重排。改名前后 `gofmt -l` 都是同样的 4 个既有文件。

## 怎么审

不用逐文件看，这条证明每一条改动行都只碰 module path：

```bash
git diff origin/main..HEAD -U0 | grep '^[+-]' | grep -v '^[+-][+-]' \
  | grep -v 'openbkn-ai/adp/context-loader\|openbkn-ai/bkn-foundry/adp/context-loader'
# 输出为空
```

## 验证

- `go build ./...` 通过
- `go test ./...` 21 个包通过；唯一失败的 `server/infra/bkntrace` 的 `TestSubmitEventsCarriesCorrelationIDs` 在改名前的 origin/main 上以完全相同方式失败，与本次无关

🤖 Generated with [Claude Code](https://claude.com/claude-code)