### PR TITLE
fix(sandbox): MinIO 持久化改用 StorageClass 

### DIFF
--- a/infra/sandbox/deploy/helm/sandbox/templates/minio-deployment.yaml
+++ b/infra/sandbox/deploy/helm/sandbox/templates/minio-deployment.yaml
@@ -1,25 +1,6 @@
 {{- if .Values.minio.enabled }}
 ---
 apiVersion: v1
-kind: PersistentVolume
-metadata:
-  name: minio-pv
-  namespace: {{ .Values.namespace }}
-  labels:
-    app: {{ include "sandbox.fullname" . }}
-    component: minio
-spec:
-  capacity:
-    storage: 20Gi
-  accessModes:
-    - ReadWriteOnce
-  persistentVolumeReclaimPolicy: Retain
-  storageClassName: manual
-  hostPath:
-    path: /data/minio
-
----
-apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
   name: minio
@@ -30,8 +11,9 @@ metadata:
 spec:
   accessModes:
     - {{ .Values.minio.persistence.accessMode }}
-  storageClassName: manual
-  volumeName: minio-pv
+  {{- if .Values.minio.persistence.storageClass }}
+  storageClassName: {{ .Values.minio.persistence.storageClass | quote }}
+  {{- end }}
   resources:
     requests:
       storage: {{ .Values.minio.persistence.size }}

--- a/infra/sandbox/deploy/helm/sandbox/values.yaml
+++ b/infra/sandbox/deploy/helm/sandbox/values.yaml
@@ -130,6 +130,8 @@ minio:
 
   persistence:
     enabled: true
+    # PV 由 StorageClass 动态供给，chart 不再创建 hostPath PV。
+    # 留空则使用集群默认 StorageClass；填写名称则使用该 StorageClass。
     storageClass: ""
     accessMode: ReadWriteOnce
     size: 10Gi

--- a/infra/sandbox/deploy/helm/sandbox_standalone/templates/minio-deployment.yaml
+++ b/infra/sandbox/deploy/helm/sandbox_standalone/templates/minio-deployment.yaml
@@ -1,25 +1,6 @@
 {{- if .Values.minio.enabled }}
 ---
 apiVersion: v1
-kind: PersistentVolume
-metadata:
-  name: minio-pv
-  namespace: {{ .Values.namespace }}
-  labels:
-    app: {{ include "sandbox.fullname" . }}
-    component: minio
-spec:
-  capacity:
-    storage: 20Gi
-  accessModes:
-    - ReadWriteOnce
-  persistentVolumeReclaimPolicy: Retain
-  storageClassName: manual
-  hostPath:
-    path: /data/minio
-
----
-apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
   name: minio
@@ -30,8 +11,9 @@ metadata:
 spec:
   accessModes:
     - {{ .Values.minio.persistence.accessMode }}
-  storageClassName: manual
-  volumeName: minio-pv
+  {{- if .Values.minio.persistence.storageClass }}
+  storageClassName: {{ .Values.minio.persistence.storageClass | quote }}
+  {{- end }}
   resources:
     requests:
       storage: {{ .Values.minio.persistence.size }}

--- a/infra/sandbox/deploy/helm/sandbox_standalone/values.yaml
+++ b/infra/sandbox/deploy/helm/sandbox_standalone/values.yaml
@@ -211,6 +211,8 @@ minio:
 
   persistence:
     enabled: true
+    # PV 由 StorageClass 动态供给，chart 不再创建 hostPath PV。
+    # 留空则使用集群默认 StorageClass；填写名称则使用该 StorageClass。
     storageClass: ""
     accessMode: ReadWriteOnce
     size: 10Gi

--- a/infra/sandbox/deploy/manifests/07-minio-deployment.yaml
+++ b/infra/sandbox/deploy/manifests/07-minio-deployment.yaml
@@ -1,23 +1,5 @@
 ---
 apiVersion: v1
-kind: PersistentVolume
-metadata:
-  name: minio-pv
-  namespace: sandbox-system
-  labels:
-    app: minio
-spec:
-  capacity:
-    storage: 20Gi
-  accessModes:
-    - ReadWriteOnce
-  persistentVolumeReclaimPolicy: Retain
-  storageClassName: manual
-  hostPath:
-    path: /data/minio
-
----
-apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
   name: minio-data
@@ -25,8 +7,8 @@ metadata:
 spec:
   accessModes:
     - ReadWriteOnce
-  storageClassName: manual
-  volumeName: minio-pv
+  # 不指定 storageClassName，使用集群默认 StorageClass 动态供给；
+  # 如需指定，请按实际环境填写。
   resources:
     requests:
       storage: 10Gi


### PR DESCRIPTION
## Goal                                                                                                                                                                   
                                                                                                                                                                       
将 sandbox 部署中 MinIO 的 PV/PVC 从预置 hostPath PV 改为由 StorageClass ,与其他服务对齐。                                                                        
                                                                                                                                                                       
**Module**: sandbox                                                                                                                                                       
                                                                                                                                                                       
## Background / Context                                                                                                                                                   
                                                                                                                                                                       
MinIO 是当前部署中唯一使用预置 hostPath PV(`storageClassName: manual`,宿主机路径 `/data/minio`)的组件,其他服务均通过 StorageClass 。hostPath 方式隐含依赖节点上预建目录,多节点环境下 Pod 调度到其他节点会读到空数据。
                                                                                                                                                                       
涉及文件:                                                                                                                                                                 
                                                                                                                                                                       
- `infra/sandbox/deploy/helm/sandbox/templates/minio-deployment.yaml`                                                                                                     
- `infra/sandbox/deploy/helm/sandbox_standalone/templates/minio-deployment.yaml`                                                                                          
- `infra/sandbox/deploy/manifests/07-minio-deployment.yaml`                                                                                                               
- 两个 chart 的 `values.yaml`(`minio.persistence.storageClass`)                                                                                                           
                                                                                                                                                                       
## Acceptance Criteria (Definition of Done)                                                                                                                               
                                                                                                                                                                       
- [ ] chart 不再创建 hostPath PV;PVC 按 `minio.persistence.storageClass` 渲染,留空时使用集群默认 StorageClass                                                             
- [ ] `helm template` 验证:`storageClass` 留空与显式设置两种情况下 PVC 渲染正确                                                                                           
- [ ] 裸 manifests 路径(`07-minio-deployment.yaml`)同步去除 hostPath PV                                                                                                   
- [ ] CI green                                                                                                                                                            
                                                                                                                                                                       
## Boundaries / Risk                                                                                                                                                      
                                                                                                                                                                       
- 存量 PVC 的 `storageClassName`/`volumeName` 为不可变字段,升级前需人工备份 MinIO 数据并删除旧 PVC(`openbkn/minio`)与 PV(`minio-pv`)                                                                                                          
- 旧 hostPath 目录 `/data/minio` 升级后不再挂载,如需保留数据须提前导出 