### PR TITLE
fix(bkn-safe): 授权指纹改用宿主派生的实例身份，不再随 Pod 重建漂移

### DIFF
--- a/bkn-safe/charts/bkn-safe/templates/_helpers.tpl
+++ b/bkn-safe/charts/bkn-safe/templates/_helpers.tpl
@@ -6,12 +6,19 @@ Stability is the whole point: the fingerprint must survive Pod rebuilds and
 Helm upgrades, because a changed fingerprint invalidates an activated license
 (openbkn-ai/bkn-foundry#508). Resolution order:
 
-  1. an explicit config.license.instanceId wins — deploy.sh passes the value it
-     derived from the node's hardware (status.nodeInfo.systemUUID, falling back
-     to nodeInfo.machineID);
+  1. an explicit config.license.instanceId wins. Note this is the OVERRIDE, not
+     the sticky path: a bare `helm upgrade --set config.license.instanceId=…`
+     moves the identity, and moving it invalidates the activated license. That
+     is deliberate — it is the escape hatch for pinning an identity by hand —
+     but it means the chart alone cannot protect an operator from typing it.
+     deploy.sh is what makes the normal path sticky: it reads the value already
+     in the cluster FIRST and passes that back here, and only derives from the
+     node (status.nodeInfo.systemUUID, falling back to nodeInfo.machineID) when
+     the cluster has none;
   2. otherwise reuse the value already stored in the release's instance-id
-     ConfigMap, so a `helm upgrade` that forgets the --set does not silently
-     drop the identity;
+     ConfigMap, so a `helm upgrade` that passes no value at all — the plain
+     `helm upgrade` an operator runs by hand — does not silently drop the
+     identity;
   3. otherwise empty — no key is rendered, and licverify falls back to its own
      host-identity chain. Inside a Pod that chain finds nothing durable and
      fails loudly rather than inventing a value that drifts.

--- a/bkn-safe/charts/bkn-safe/templates/_helpers.tpl
+++ b/bkn-safe/charts/bkn-safe/templates/_helpers.tpl
@@ -1,4 +1,37 @@
 {{/*
+bkn-safe.instanceID resolves OPENBKN_INSTANCE_ID — the instance identity a
+license activation is bound to (licverify hashes it into the fingerprint).
+
+Stability is the whole point: the fingerprint must survive Pod rebuilds and
+Helm upgrades, because a changed fingerprint invalidates an activated license
+(openbkn-ai/bkn-foundry#508). Resolution order:
+
+  1. an explicit config.license.instanceId wins — deploy.sh passes the value it
+     derived from the node's hardware (status.nodeInfo.systemUUID, falling back
+     to nodeInfo.machineID);
+  2. otherwise reuse the value already stored in the release's instance-id
+     ConfigMap, so a `helm upgrade` that forgets the --set does not silently
+     drop the identity;
+  3. otherwise empty — no key is rendered, and licverify falls back to its own
+     host-identity chain. Inside a Pod that chain finds nothing durable and
+     fails loudly rather than inventing a value that drifts.
+
+Deliberately NOT randAlphaNum like bkn-safe.hydraSecret: a generated identity
+would be stable in this cluster yet meaningless as a machine identity, and it
+would travel with any copy of the config. Derive from the host or render nothing.
+*/}}
+{{- define "bkn-safe.instanceID" -}}
+{{- if .Values.config.license.instanceId -}}
+{{- .Values.config.license.instanceId -}}
+{{- else -}}
+{{- $existing := lookup "v1" "ConfigMap" .Release.Namespace (printf "%s-instance-id" .Release.Name) -}}
+{{- if and $existing $existing.data -}}
+{{- index $existing.data "OPENBKN_INSTANCE_ID" | default "" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
 bkn-safe.hydraSecret resolves the hydra SECRETS_SYSTEM value.
 
 hydra uses this key to sign/encrypt session and token material, so it must be a

--- a/bkn-safe/charts/bkn-safe/templates/configmap.yaml
+++ b/bkn-safe/charts/bkn-safe/templates/configmap.yaml
@@ -36,4 +36,7 @@ data:
   SAFE_LICENSE_SERVER_URL: {{ .Values.config.license.serverURL | quote }}
   SAFE_LICENSE_CA_FILE: {{ .Values.config.license.caFile | quote }}
   SAFE_LICENSE_INSECURE_SKIP_VERIFY: {{ .Values.config.license.insecureSkipVerify | quote }}
+  {{- /* OPENBKN_INSTANCE_ID is NOT here — the instance identity lives in its
+         own ConfigMap (templates/instance-id.yaml) so that it survives
+         `helm uninstall`. Both are pulled in via envFrom. */}}
   GIN_MODE: "release"

--- a/bkn-safe/charts/bkn-safe/templates/deployment.yaml
+++ b/bkn-safe/charts/bkn-safe/templates/deployment.yaml
@@ -19,6 +19,10 @@ spec:
         app: {{ .Values.image.name }}
         checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum | trunc 10 | quote }}
         checksum/secret: {{ include (print $.Template.BasePath "/secret.yaml") . | sha256sum | trunc 10 | quote }}
+        {{- /* A changed instance identity changes the license fingerprint, and
+               the fingerprint is resolved once at startup — the Pod has to be
+               replaced for it to take effect. */}}
+        checksum/instance-id: {{ include (print $.Template.BasePath "/instance-id.yaml") . | sha256sum | trunc 10 | quote }}
     spec:
       {{- with .Values.nodeSelector }}
       nodeSelector:
@@ -31,6 +35,8 @@ spec:
           envFrom:
             - configMapRef:
                 name: {{ .Release.Name }}-config
+            - configMapRef:
+                name: {{ .Release.Name }}-instance-id
             - secretRef:
                 name: {{ .Release.Name }}-secrets
           ports:

--- a/bkn-safe/charts/bkn-safe/templates/instance-id.yaml
+++ b/bkn-safe/charts/bkn-safe/templates/instance-id.yaml
@@ -1,0 +1,27 @@
+{{- /*
+The instance identity a license activation is bound to, kept in its own object
+for one reason: it must outlive everything else in the release.
+
+helm.sh/resource-policy: keep means `helm uninstall` leaves it behind, so a
+reinstall onto the same cluster keeps the activated license valid. Re-deriving
+from the node would usually produce the same value anyway (that is the real
+guarantee — see bkn-safe.instanceID), but the derivation depends on a node
+still being readable; this object does not.
+
+Reinstalling under a DIFFERENT release name cannot adopt this ConfigMap (its
+Helm ownership metadata names the old release). Delete it by hand in that case,
+and expect a one-time unbind + reactivate if the node it was derived from is
+also gone.
+*/ -}}
+{{- $id := include "bkn-safe.instanceID" . -}}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ .Release.Name }}-instance-id
+  namespace: {{ .Release.Namespace }}
+  annotations:
+    helm.sh/resource-policy: keep
+data: {{ if not $id }}{}{{ end }}
+{{- if $id }}
+  OPENBKN_INSTANCE_ID: {{ $id | quote }}
+{{- end }}

--- a/bkn-safe/charts/bkn-safe/values.yaml
+++ b/bkn-safe/charts/bkn-safe/values.yaml
@@ -118,6 +118,23 @@ config:
     serverURL: "https://license.openbkn.ai"
     caFile: ""
     insecureSkipVerify: false
+    # Instance identity the license activation binds to (OPENBKN_INSTANCE_ID,
+    # read by licverify). Empty = resolved per install by the chart
+    # (bkn-safe.instanceID): deploy.sh derives it from the node's hardware
+    # (status.nodeInfo.systemUUID, i.e. the host's DMI product_uuid, falling
+    # back to nodeInfo.machineID where kubelet cannot read DMI) and an existing
+    # value is carried forward unchanged on every upgrade. The resolved value
+    # lives in its own ConfigMap (templates/instance-id.yaml), annotated
+    # helm.sh/resource-policy: keep so `helm uninstall` cannot take the
+    # activated license down with it.
+    #
+    # It MUST be host-derived and re-derivable, NEVER randomly generated: an
+    # invented identity drifts the moment its storage is lost and travels along
+    # when this file is copied to another machine. Nothing inside the Pod is
+    # stable enough to fall back to — a Pod's eth0 MAC is minted per Pod, which
+    # is what made every Helm upgrade invalidate an activated license
+    # (openbkn-ai/bkn-foundry#508).
+    instanceId: ""
 
 resources:
   requests:

--- a/deploy/scripts/services/openbkn.sh
+++ b/deploy/scripts/services/openbkn.sh
@@ -326,14 +326,92 @@ _openbkn_find_local_chart() {
     find_cached_chart_tgz "${charts_dir}" "${chart_name}"
 }
 
+# Resolve OPENBKN_INSTANCE_ID for bkn-safe: the instance identity a license
+# activation binds to. It must stay identical across Pod rebuilds and upgrades —
+# a changed identity changes the fingerprint and invalidates an activated
+# license (openbkn-ai/bkn-foundry#508).
+#
+# An identity already recorded in the cluster always wins, so re-running the
+# installer can never move it. Otherwise it is DERIVED from the node the license
+# is meant to be bound to:
+#
+#   status.nodeInfo.systemUUID — the host's DMI product_uuid as reported by
+#     kubelet. Lives in firmware, so it survives an OS reinstall and changes
+#     only when the machine does: exactly the licensing boundary.
+#   status.nodeInfo.machineID — the host's /etc/machine-id, for hosts whose DMI
+#     kubelet cannot read (restricted or containerised kubelets). Weaker (a host
+#     OS reinstall regenerates it) but still host-scoped and durable.
+#
+# Reading them through the API server means no hostPath mount, no root in the
+# container, and it works from wherever the installer runs.
+#
+# Never generate a value here: a random UUID would be stable in this cluster but
+# meaningless as a machine identity and would travel with any copy of config.yaml.
+# When nothing can be derived, emit nothing and warn — bkn-safe then reports an
+# unlicensed instance instead of activating against an identity that will drift.
+_bkn_safe_instance_id() {
+    local namespace="$1"
+    local existing derived
+
+    existing="$(kubectl get configmap bkn-safe-instance-id -n "${namespace}" \
+        -o jsonpath='{.data.OPENBKN_INSTANCE_ID}' 2>/dev/null || true)"
+    derived="$(_bkn_safe_derive_instance_id)"
+
+    if [[ -n "${existing}" ]]; then
+        # Sticky by design, but say so when the host stopped matching: someone
+        # replaced the node, and the license is still bound to the old one.
+        # The warning goes to stderr — this function's stdout IS the identity.
+        if [[ -n "${derived}" && "${derived}" != "${existing}" ]]; then
+            log_warn "bkn-safe instance identity ${existing} is kept, but this cluster now derives ${derived} — the node it was bound to was replaced. The activated license stays on the old identity; unbind and reactivate to move it." >&2
+        fi
+        printf '%s' "${existing}"
+        return 0
+    fi
+
+    printf '%s' "${derived}"
+}
+
+# Derive a host-scoped instance identity from the cluster's nodes. Deterministic
+# node choice (lowest name among control-plane nodes, else any node): a
+# multi-node cluster must resolve the same identity on every run. Prints nothing
+# when no node reports a usable value.
+_bkn_safe_derive_instance_id() {
+    local selector field value lowered
+    for field in systemUUID machineID; do
+        for selector in "-l node-role.kubernetes.io/control-plane" ""; do
+            # shellcheck disable=SC2086
+            value="$(kubectl get nodes ${selector} --sort-by=.metadata.name \
+                -o jsonpath="{.items[0].status.nodeInfo.${field}}" 2>/dev/null || true)"
+            # tr, not ${value,,}: deploy.sh also runs on macOS, whose /bin/bash
+            # is 3.2 and has no case-conversion expansion.
+            lowered="$(printf '%s' "${value}" | tr 'A-Z' 'a-z')"
+            # Firmware placeholders that several vendors ship identically on
+            # every unit — using one would give unrelated hosts one identity.
+            case "${lowered}" in
+                ""|none|"not specified"|"default string"|\
+                00000000-0000-0000-0000-000000000000|\
+                ffffffff-ffff-ffff-ffff-ffffffffffff|\
+                03000200-0400-0500-0006-000700080009)
+                    continue
+                    ;;
+            esac
+            printf '%s' "${value}"
+            return 0
+        done
+    done
+    return 0
+}
+
 # Per-release extra --set values, filled into CORE_RELEASE_EXTRA_SETS.
 # bkn-safe: pass the per-install platform initial password recorded in
 # config.yaml by generate_config_yaml (seeded admin + users created without an
-# explicit password — no baked-in default). Applied BEFORE CORE_SET_VALUES so an
-# explicit --set config.initialPassword=... still wins.
+# explicit password — no baked-in default), plus the license instance identity.
+# Applied BEFORE CORE_SET_VALUES so an explicit --set config.initialPassword=...
+# still wins.
 CORE_RELEASE_EXTRA_SETS=()
 _openbkn_release_extra_sets() {
     local release_name="$1"
+    local namespace="${2:-${CORE_NAMESPACE}}"
     CORE_RELEASE_EXTRA_SETS=()
     if [[ "${release_name}" == "bkn-safe" ]]; then
         local initial_pwd
@@ -342,6 +420,14 @@ _openbkn_release_extra_sets() {
             CORE_RELEASE_EXTRA_SETS+=("config.initialPassword=${initial_pwd}")
         else
             log_warn "bknSafe.initialPassword not recorded in ${CONFIG_YAML_PATH} — bkn-safe will generate an admin password and log it once (re-run 'deploy.sh config generate' to record one)."
+        fi
+
+        local instance_id
+        instance_id="$(_bkn_safe_instance_id "${namespace}")"
+        if [[ -n "${instance_id}" ]]; then
+            CORE_RELEASE_EXTRA_SETS+=("config.license.instanceId=${instance_id}")
+        else
+            log_warn "Could not derive a hardware instance identity from any node (status.nodeInfo.systemUUID) — commercial licenses cannot be activated on this cluster until config.license.instanceId is set to a host-derived, stable value."
         fi
     fi
 }
@@ -390,7 +476,7 @@ _install_openbkn_release_local() {
 
     # Per-release values first, then all --set values (so explicit --set wins)
     local set_value
-    _openbkn_release_extra_sets "${release_name}"
+    _openbkn_release_extra_sets "${release_name}" "${namespace}"
     for set_value in "${CORE_RELEASE_EXTRA_SETS[@]}"; do
         helm_args+=("--set" "${set_value}")
     done
@@ -460,7 +546,7 @@ _install_openbkn_release_repo() {
 
     # Per-release values first, then all --set values (so explicit --set wins)
     local set_value
-    _openbkn_release_extra_sets "${release_name}"
+    _openbkn_release_extra_sets "${release_name}" "${namespace}"
     for set_value in "${CORE_RELEASE_EXTRA_SETS[@]}"; do
         helm_args+=("--set" "${set_value}")
     done

--- a/deploy/scripts/services/openbkn.sh
+++ b/deploy/scripts/services/openbkn.sh
@@ -376,43 +376,68 @@ _bkn_safe_instance_id() {
 # multi-node cluster must resolve the same identity on every run. Prints nothing
 # when no node reports a usable value.
 _bkn_safe_derive_instance_id() {
-    local selector field value lowered
+    local selector field candidate
     for field in systemUUID machineID; do
         for selector in "-l node-role.kubernetes.io/control-plane" ""; do
-            # shellcheck disable=SC2086
-            value="$(kubectl get nodes ${selector} --sort-by=.metadata.name \
-                -o jsonpath="{.items[0].status.nodeInfo.${field}}" 2>/dev/null || true)"
-            # tr, not ${value,,}: deploy.sh also runs on macOS, whose /bin/bash
-            # is 3.2 and has no case-conversion expansion.
-            lowered="$(printf '%s' "${value}" | tr 'A-Z' 'a-z')"
-            # Firmware placeholders that several vendors ship identically on
-            # every unit — using one would give unrelated hosts one identity.
-            case "${lowered}" in
-                ""|none|"not specified"|"default string"|\
-                00000000-0000-0000-0000-000000000000|\
-                ffffffff-ffff-ffff-ffff-ffffffffffff|\
-                03000200-0400-0500-0006-000700080009)
-                    continue
-                    ;;
-            esac
-            printf '%s' "${value}"
-            return 0
+            # Sorted here rather than with `kubectl --sort-by`: there sorting is
+            # a printer concern, and the identity of a whole install should not
+            # rest on how it composes with -o jsonpath across kubectl versions.
+            # One "<node-name> <value>" line per node; nodes that report nothing
+            # yield a name-only line and are skipped.
+            while read -r _ candidate; do
+                if _bkn_safe_usable_instance_id "${candidate}"; then
+                    printf '%s' "${candidate}"
+                    return 0
+                fi
+            done <<EOF
+$(_bkn_safe_node_field "${selector}" "${field}" | sort)
+EOF
         done
     done
     return 0
 }
 
-# Per-release extra --set values, filled into CORE_RELEASE_EXTRA_SETS.
+# One "<node-name> <field-value>" line per node, unsorted.
+_bkn_safe_node_field() {
+    local selector="$1" field="$2"
+    # shellcheck disable=SC2086
+    kubectl get nodes ${selector} -o \
+        jsonpath="{range .items[*]}{.metadata.name}{' '}{.status.nodeInfo.${field}}{'\n'}{end}" \
+        2>/dev/null || true
+}
+
+# Reject firmware placeholders that several vendors ship identically on every
+# unit — using one would hand unrelated hosts a single identity.
+_bkn_safe_usable_instance_id() {
+    local lowered
+    # tr, not ${1,,}: deploy.sh also runs on macOS, whose /bin/bash is 3.2 and
+    # has no case-conversion expansion.
+    lowered="$(printf '%s' "${1:-}" | tr 'A-Z' 'a-z')"
+    case "${lowered}" in
+        ""|none|"not specified"|"default string"|\
+        00000000-0000-0000-0000-000000000000|\
+        ffffffff-ffff-ffff-ffff-ffffffffffff|\
+        03000200-0400-0500-0006-000700080009)
+            return 1
+            ;;
+    esac
+    return 0
+}
+
+# Per-release extra values, filled into CORE_RELEASE_EXTRA_SETS (--set) and
+# CORE_RELEASE_EXTRA_SET_STRINGS (--set-string).
 # bkn-safe: pass the per-install platform initial password recorded in
 # config.yaml by generate_config_yaml (seeded admin + users created without an
 # explicit password — no baked-in default), plus the license instance identity.
 # Applied BEFORE CORE_SET_VALUES so an explicit --set config.initialPassword=...
 # still wins.
 CORE_RELEASE_EXTRA_SETS=()
+CORE_RELEASE_EXTRA_SET_STRINGS=()
 _openbkn_release_extra_sets() {
     local release_name="$1"
     local namespace="${2:-${CORE_NAMESPACE}}"
     CORE_RELEASE_EXTRA_SETS=()
+    CORE_RELEASE_EXTRA_SET_STRINGS=()
     if [[ "${release_name}" == "bkn-safe" ]]; then
         local initial_pwd
         initial_pwd="$(config_yaml_top_field bknSafe initialPassword)"
@@ -425,9 +450,11 @@ _openbkn_release_extra_sets() {
         local instance_id
         instance_id="$(_bkn_safe_instance_id "${namespace}")"
         if [[ -n "${instance_id}" ]]; then
-            CORE_RELEASE_EXTRA_SETS+=("config.license.instanceId=${instance_id}")
+            # --set-string: an all-digit machineID would otherwise be coerced to
+            # a number and come back out reformatted, changing the fingerprint.
+            CORE_RELEASE_EXTRA_SET_STRINGS+=("config.license.instanceId=${instance_id}")
         else
-            log_warn "Could not derive a hardware instance identity from any node (status.nodeInfo.systemUUID) — commercial licenses cannot be activated on this cluster until config.license.instanceId is set to a host-derived, stable value."
+            log_warn "Could not derive a hardware instance identity from any node (status.nodeInfo.systemUUID / machineID) — commercial licenses cannot be activated on this cluster until config.license.instanceId is set to a host-derived, stable value."
         fi
     fi
 }
@@ -479,6 +506,9 @@ _install_openbkn_release_local() {
     _openbkn_release_extra_sets "${release_name}" "${namespace}"
     for set_value in "${CORE_RELEASE_EXTRA_SETS[@]}"; do
         helm_args+=("--set" "${set_value}")
+    done
+    for set_value in "${CORE_RELEASE_EXTRA_SET_STRINGS[@]}"; do
+        helm_args+=("--set-string" "${set_value}")
     done
     for set_value in "${CORE_SET_VALUES[@]}"; do
         helm_args+=("--set" "${set_value}")
@@ -549,6 +579,9 @@ _install_openbkn_release_repo() {
     _openbkn_release_extra_sets "${release_name}" "${namespace}"
     for set_value in "${CORE_RELEASE_EXTRA_SETS[@]}"; do
         helm_args+=("--set" "${set_value}")
+    done
+    for set_value in "${CORE_RELEASE_EXTRA_SET_STRINGS[@]}"; do
+        helm_args+=("--set-string" "${set_value}")
     done
     for set_value in "${CORE_SET_VALUES[@]}"; do
         helm_args+=("--set" "${set_value}")

--- a/deploy/scripts/services/openbkn_instance_id_test.sh
+++ b/deploy/scripts/services/openbkn_instance_id_test.sh
@@ -1,0 +1,115 @@
+#!/usr/bin/env bash
+# _bkn_safe_instance_id / _bkn_safe_derive_instance_id 的行为测试（无需集群）。
+#
+# 这个身份决定授权指纹：算错一次，已激活的证就失效（#508）。所以四件事必须钉住：
+# 现值粘性、DMI 占位值降级到 machineID、多节点确定性、以及"函数的 stdout 就是
+# 身份值"——告警混进 stdout 会被命令替换吞进 helm --set。
+set -uo pipefail
+
+ONE_FAILED=0
+PASS=0
+fail() { echo "FAIL: $*"; ONE_FAILED=1; }
+ok() { PASS=$((PASS + 1)); }
+check() {
+    if [[ "$2" == "$3" ]]; then ok; else fail "$1: got[$2] want[$3]"; fi
+}
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+
+# shellcheck source=../services/openbkn.sh
+source "${SCRIPT_DIR}/scripts/services/openbkn.sh"
+
+log_warn() { echo "[WARN] $*"; }
+
+# common.sh 不在测试里 source：补齐 _openbkn_release_extra_sets 走到的另一半
+# （初始密码分支）所需的最小依赖。
+CONFIG_YAML_PATH="${CONFIG_YAML_PATH:-/dev/null}"
+config_yaml_top_field() { printf ''; }
+
+# 桩 kubectl：SCENARIO 决定 configmap 现值与各 node 字段的返回。
+# 节点行故意乱序给出，用来验证排序发生在我们这边而不是靠 kubectl --sort-by。
+kubectl() {
+    local args="$*"
+    case "${SCENARIO}" in
+        normal)
+            [[ "${args}" == *configmap* ]] && return 1
+            [[ "${args}" == *systemUUID* ]] && {
+                printf 'node-b 22222222-2222-2222-2222-222222222222\n'
+                printf 'node-a 11111111-1111-1111-1111-111111111111\n'
+                return 0
+            }
+            ;;
+        dmi_placeholder)
+            [[ "${args}" == *configmap* ]] && return 1
+            [[ "${args}" == *systemUUID* ]] && {
+                printf 'node-a 03000200-0400-0500-0006-000700080009\n'
+                return 0
+            }
+            [[ "${args}" == *machineID* ]] && {
+                printf 'node-a 9f2c1d3ea4b64e2f8c7d5a1b0e6f3c9d\n'
+                return 0
+            }
+            ;;
+        partial_report)
+            # 名字最小的节点没上报字段（只有 name 一列），要跳过而不是判空。
+            [[ "${args}" == *configmap* ]] && return 1
+            [[ "${args}" == *systemUUID* ]] && {
+                printf 'node-a \n'
+                printf 'node-b 22222222-2222-2222-2222-222222222222\n'
+                return 0
+            }
+            ;;
+        sticky)
+            [[ "${args}" == *configmap* ]] && { printf 'OLD-IDENTITY-1111'; return 0; }
+            [[ "${args}" == *systemUUID* ]] && { printf 'node-a NEW-NODE-2222\n'; return 0; }
+            ;;
+        nothing)
+            return 1
+            ;;
+    esac
+    return 1
+}
+
+# 取值：只收 stdout，告警必须走 stderr
+resolve() { SCENARIO="$1" _bkn_safe_instance_id openbkn 2>/dev/null; }
+
+# 正常集群：取 systemUUID，多节点按节点名排序取最小者（node-a），与桩的返回顺序无关
+check "normal-picks-lowest-node" "$(resolve normal)" "11111111-1111-1111-1111-111111111111"
+
+# DMI 是厂商占位值：跳过，降级取 machineID
+check "dmi-placeholder-falls-back" "$(resolve dmi_placeholder)" "9f2c1d3ea4b64e2f8c7d5a1b0e6f3c9d"
+
+# 排序最靠前的节点没上报：跳过它，取下一个真有值的
+check "skips-node-without-value" "$(resolve partial_report)" "22222222-2222-2222-2222-222222222222"
+
+# 集群里已有身份：粘住不动，哪怕现在能推导出别的值
+check "existing-wins" "$(resolve sticky)" "OLD-IDENTITY-1111"
+
+# 什么都取不到：输出空（调用方据此告警并跳过 --set，绝不编一个值）
+check "nothing-derivable-is-empty" "$(resolve nothing)" ""
+
+# 换节点的告警走 stderr —— 若写到 stdout 就会被命令替换吞进身份值
+stdout_only="$(SCENARIO=sticky _bkn_safe_instance_id openbkn 2>/dev/null)"
+stderr_only="$(SCENARIO=sticky _bkn_safe_instance_id openbkn 2>&1 >/dev/null)"
+check "warning-not-on-stdout" "${stdout_only}" "OLD-IDENTITY-1111"
+if [[ "${stderr_only}" == *"NEW-NODE-2222"* ]]; then ok; else
+    fail "warning-on-stderr: got[${stderr_only}]"
+fi
+
+# 身份走 --set-string：全数字的 machineID 被 helm 当数字重排就会改掉指纹
+SCENARIO=normal _openbkn_release_extra_sets bkn-safe openbkn >/dev/null 2>&1
+check "identity-uses-set-string" \
+    "${CORE_RELEASE_EXTRA_SET_STRINGS[*]:-}" \
+    "config.license.instanceId=11111111-1111-1111-1111-111111111111"
+if [[ "${CORE_RELEASE_EXTRA_SETS[*]:-}" == *"instanceId"* ]]; then
+    fail "identity-must-not-use-plain-set: got[${CORE_RELEASE_EXTRA_SETS[*]:-}]"
+else
+    ok
+fi
+
+if [[ "${ONE_FAILED}" -eq 0 ]]; then
+    echo "openbkn_instance_id_test: all ${PASS} checks passed"
+    exit 0
+fi
+echo "openbkn_instance_id_test: FAILED"
+exit 1


### PR DESCRIPTION
Fixes #508

## 根因

bkn-safe 容器里没有 `/etc/machine-id`，chart 也没注入 `OPENBKN_INSTANCE_ID`，licverify 的取值链 `OPENBKN_INSTANCE_ID → machine-id → MAC` 退化到第三条，拿 Pod 的 `eth0` MAC 算指纹。那是每次 Pod 启动重新分配的地址，Helm 升级重建 Pod 后指纹就变，已激活的企业版证被判 `invalid`。

指纹算式核对无误：`sha256("openbkn-license-fp-v1\0mac:c2:2f:a3:86:52:c4")[:8]` = `fp_7369c5f7e64650b1`，正是 issue 里贴的升级后指纹。

## 改法

安装器从 node 推导实例身份，注入 `OPENBKN_INSTANCE_ID`：

- `status.nodeInfo.systemUUID` —— kubelet 上报的宿主 DMI `product_uuid`，在固件里，重装宿主 OS 都不变，只有换机器才变
- DMI 读不到时（受限或容器化 kubelet）降级取 `nodeInfo.machineID`
- 多节点按「control-plane 节点名排序取第一个」确定性选取，厂商占位值跳过

经 API server 读取，不需要 hostPath、不需要容器内 root、不需要把 pod pin 在节点上。

## 不变性怎么保证

**来自「值能算回来」，不是「值别丢」。** 派生幂等——同一台机器算多少次都是同一个值，所以 ConfigMap 被误删、集群重建、`helm uninstall` 后重装，只要机器没换都会算回同值。这与「生成随机 UUID 再持久化」有本质区别：后者存储一丢就永久漂移，救不回来。

在此之上两道保险：

1. 身份单独放 `{{ .Release.Name }}-instance-id` ConfigMap，标注 `helm.sh/resource-policy: keep`，`helm uninstall` 带不走
2. 已有值永远优先（chart helper 与安装器都先读集群现值），与新推导值不一致时**告警但不覆盖**——换节点是人的决定，不该由一次 upgrade 悄悄做掉

推导不出来时不渲染该 key 并告警，让 bkn-safe 报未授权，而不是拿一个会漂的值去激活。deployment 加了身份 ConfigMap 的 checksum：指纹只在启动时解析一次，身份变了必须重建 Pod 才生效。

## 验证

`helm lint` 过；渲染出的 14 个对象 YAML 全部解析通过；空身份时 `data: {}` 合法；`envFrom` 顺序与三个 checksum 标签核对无误。桩 `kubectl` 覆盖四个场景：正常取 systemUUID、占位值降级 machineID、现值粘性 + 告警、全部取不到则不注入。

容器里端到端复现（无 machine-id，只有运行时分配的 eth0）：旧行为三次重建给出三个不同指纹；注入宿主 UUID 后三次一致。

顺带修掉两个会真出事的 bug：`log_warn` 打 stdout 会被命令替换吞进 `--set` 值里（已定向 stderr）；`${var,,}` 在 macOS 的 bash 3.2 下 `bad substitution` 导致推导静默返回空（改用 `tr`）。

## 存量影响

锚点切换会让每个已激活实例的指纹变化，已确认存量激活全部作废重发。操作步骤见 license-server 仓库 `docs/bkn-safe-license-integration.md` §2.1（解绑必须先于激活，first-wins 会 409 拒新指纹）。

## 相关 PR

- openbkn-ai/licverify — 兜底：软件分配的 MAC 一律不收，取不到就报错不猜
- openbkn-ai/license-server — 文档：原 §2 明写「不要设 `OPENBKN_INSTANCE_ID`」，是实施踩坑的源头

🤖 Generated with [Claude Code](https://claude.com/claude-code)