### PR TITLE
ci(claude-review): 把 comm-go 纳入自动评审范围

### DIFF
--- a/.github/workflows/automation-claude-review.yml
+++ b/.github/workflows/automation-claude-review.yml
@@ -28,6 +28,7 @@ on:
       - 'adp/**'
       - 'infra/**'
       - 'bkn-safe/**'
+      - 'comm-go/**'
       - 'deploy/scripts/**'
       - '!**/*.md'
   issue_comment:


### PR DESCRIPTION
一行改动：`paths` 白名单加上 `comm-go/**`。

## 为什么

`comm-go/` 不在名单里，所以公共 Go 库的改动**一次自动评审都不会跑** —— #551（回迁）和 #558（entitlement 包）都是这么过去的，run 记录里是 `skipped`。

这个漏配的方向是反的：comm-go 是九个服务的共同依赖，一个 bug 同时波及全部服务，比任何单个服务更该过审。

## 为什么单独一个 PR

`claude-code-action` 有一条安全校验：**PR 里用的 workflow 文件必须与默认分支上那份逐字节相同**，否则整个 action 跳过（防的是在 PR 里改 workflow 来篡改评审行为）。

```
##[warning]Skipping action due to workflow validation: Workflow validation failed.
The workflow file must exist and have identical content to the version on the
repository's default branch.
```

所以这个补丁只要待在 #558 里，那条分支上的每一次复评都会被这条校验挡掉 —— 实测两次，都是 18 秒空转、不落任何评论。摘出来先合，#558 的文件就和默认分支一致了，复评自动恢复。

往后任何改这个 workflow 的 PR 都会撞同一堵墙，值得知道这条规则的存在，别误判成「评审坏了」。

## 没有一起改的

`bkn-trace/**`、`data-migrator/**`、`migrations/**` 同样不在名单里。与本次无关，单独判断 —— `migrations` 是 SQL，噪声可能盖过收益。

🤖 Generated with [Claude Code](https://claude.com/claude-code)