### PR TITLE
fix(bkn-agent): 结构化抽取补回系统提示词，修字段业务名原样复制技术名

### DIFF
--- a/infra/bkn-agent/app/core/graph.py
+++ b/infra/bkn-agent/app/core/graph.py
@@ -170,6 +170,7 @@ async def stream_chat(
                                     struct_model,
                                     state.values["messages"],
                                     req.response_format,
+                                    system_prompt,
                                 )
                                 yield _sse("structured", {"content": obj})
                                 await _emit_chat_evidence(

--- a/infra/bkn-agent/app/core/runner.py
+++ b/infra/bkn-agent/app/core/runner.py
@@ -134,7 +134,9 @@ async def _run_agent_once_core(
             if response_format:
                 # 工具循环跑完后单独抽结构化：原生优先，模型不支持则提示词降级
                 struct_model = build_chat_model(agent.model, streaming=False, max_output_tokens=max_out)
-                obj, validation_path = await structured_extract_with_path(struct_model, result["messages"], response_format)
+                obj, validation_path = await structured_extract_with_path(
+                    struct_model, result["messages"], response_format, system_prompt
+                )
                 output = json.dumps(obj, ensure_ascii=False)
                 await _emit_task_evidence(
                     agent=agent,

--- a/infra/bkn-agent/app/core/structured.py
+++ b/infra/bkn-agent/app/core/structured.py
@@ -13,6 +13,7 @@ from typing import Any
 
 from jsonschema import validate as _jsonschema_validate
 from jsonschema.exceptions import SchemaError, ValidationError
+from langchain_core.messages import SystemMessage
 
 from app.core.llm import normalize_response_format
 
@@ -30,14 +31,41 @@ def _extract_json(text: str) -> Any:
     return json.loads(t)
 
 
-async def structured_extract(model, messages: list, schema: dict) -> dict:
+def _with_system_prompt(messages: list, system_prompt: str | None) -> list:
+    """把 agent 的系统提示词补回抽取调用的消息头。
+
+    langchain 1.x 的 create_agent(system_prompt=...) 只在模型请求时注入，不落进
+    graph state——实测 result["messages"] 只有 [HumanMessage, AIMessage]。抽取是
+    另起的一次模型调用，若不补，它看到的就只有「原始输入 + 上一轮回答」，agent
+    的领域约束一条都不在场。对语义理解这类任务，最省力的填法就是把输入里的技术
+    字段名原样抄进 display_name（#556）。
+
+    state 里已带 SystemMessage 时不重复补（未来 langgraph 若改行为，这里自适应）。
+    """
+    if not system_prompt:
+        return list(messages)
+    if messages and isinstance(messages[0], SystemMessage):
+        return list(messages)
+    return [SystemMessage(content=system_prompt), *messages]
+
+
+async def structured_extract(
+    model, messages: list, schema: dict, system_prompt: str | None = None
+) -> dict:
     """从 messages 抽出符合 schema 的对象。model 应为非流式（见 build_chat_model）。"""
-    obj, _ = await structured_extract_with_path(model, messages, schema)
+    obj, _ = await structured_extract_with_path(model, messages, schema, system_prompt)
     return obj
 
 
-async def structured_extract_with_path(model, messages: list, schema: dict) -> tuple[dict, str]:
-    """返回结构化对象及 validation path：native 或 fallback。"""
+async def structured_extract_with_path(
+    model, messages: list, schema: dict, system_prompt: str | None = None
+) -> tuple[dict, str]:
+    """返回结构化对象及 validation path：native 或 fallback。
+
+    system_prompt 为 agent 本轮生效的系统提示词（含技能段），抽取调用必须带上，
+    否则模型在无约束状态下填 schema，见 _with_system_prompt。
+    """
+    messages = _with_system_prompt(messages, system_prompt)
     # 1. 原生
     try:
         norm = normalize_response_format(schema)

--- a/infra/bkn-agent/app/core/structured.py
+++ b/infra/bkn-agent/app/core/structured.py
@@ -74,6 +74,12 @@ async def structured_extract_with_path(
         # 原生也校验：with_structured_output 未启 strict，可能缺 required/类型不符；
         # 不合法则不当成功返回，落到下面提示词降级重试。
         _jsonschema_validate(obj, schema)
+        # path 只进 bkn-trace evidence 的话，trace 摄取一坏（曾遇 503
+        # INGEST_AUTH_NOT_CONFIGURED）就彻底查不到走的哪条路。本地留一行：
+        # 排「结构化结果质量不对」时，先要知道是原生还是降级、提示词在不在场。
+        logger.info(
+            "[Structured] path=native system_prompt=%s", bool(system_prompt)
+        )
         return obj, "native"
     except SchemaError:
         # schema 本体非法：请求边界已用 check_schema 拦（models.py ResponseFormat），
@@ -90,12 +96,17 @@ async def structured_extract_with_path(
     )
     msgs = list(messages) + [("user", instr)]
     last_err: Any = None
-    for _ in range(2):
+    for attempt in range(1, 3):
         resp = await model.ainvoke(msgs)
         text = resp.content if isinstance(resp.content, str) else str(resp.content)
         try:
             obj = _extract_json(text)
             _jsonschema_validate(obj, schema)
+            logger.info(
+                "[Structured] path=fallback attempt=%d system_prompt=%s",
+                attempt,
+                bool(system_prompt),
+            )
             return obj, "fallback"
         except (json.JSONDecodeError, ValidationError, ValueError) as e:
             last_err = e

--- a/infra/bkn-agent/app/test/test_structured_output.py
+++ b/infra/bkn-agent/app/test/test_structured_output.py
@@ -4,7 +4,7 @@ import contextlib
 import json
 
 import pytest
-from langchain_core.messages import AIMessage
+from langchain_core.messages import AIMessage, HumanMessage, SystemMessage
 
 from app import observability
 from app.core import runner
@@ -57,6 +57,66 @@ def test_native_path_reports_trace_path():
     out, path = asyncio.run(structured_extract_with_path(_NativeOK({"greeting": "pong"}), [], SCHEMA))
     assert out == {"greeting": "pong"}
     assert path == "native"
+
+
+class _CaptureMessages:
+    """记录两条路径实际发给模型的消息，用于断言系统提示词到场。"""
+
+    def __init__(self, native_ok: bool):
+        self.native_ok = native_ok
+        self.seen: list = []
+
+    def with_structured_output(self, schema):
+        if not self.native_ok:
+            raise RuntimeError("model unsupported")
+        outer = self
+
+        class _R:
+            async def ainvoke(self, messages):
+                outer.seen = list(messages)
+                return {"greeting": "pong"}
+
+        return _R()
+
+    async def ainvoke(self, messages):
+        self.seen = list(messages)
+        return AIMessage(content='{"greeting": "hi"}')
+
+
+def test_system_prompt_reaches_native_extraction():
+    """#556：抽取是独立的一次模型调用，agent 系统提示词必须在消息头。"""
+    m = _CaptureMessages(native_ok=True)
+    asyncio.run(structured_extract(m, [HumanMessage(content="快照")], SCHEMA, "领域约束X"))
+    assert isinstance(m.seen[0], SystemMessage)
+    assert m.seen[0].content == "领域约束X"
+    assert isinstance(m.seen[1], HumanMessage)
+
+
+def test_system_prompt_reaches_fallback_extraction():
+    m = _CaptureMessages(native_ok=False)
+    asyncio.run(structured_extract(m, [HumanMessage(content="快照")], SCHEMA, "领域约束X"))
+    assert isinstance(m.seen[0], SystemMessage)
+    assert m.seen[0].content == "领域约束X"
+
+
+def test_no_system_prompt_keeps_messages_untouched():
+    """不传（或空）时行为与本改动前一致，不凭空插消息。"""
+    m = _CaptureMessages(native_ok=True)
+    asyncio.run(structured_extract(m, [HumanMessage(content="快照")], SCHEMA))
+    assert not any(isinstance(x, SystemMessage) for x in m.seen)
+
+    m2 = _CaptureMessages(native_ok=True)
+    asyncio.run(structured_extract(m2, [HumanMessage(content="快照")], SCHEMA, ""))
+    assert not any(isinstance(x, SystemMessage) for x in m2.seen)
+
+
+def test_existing_system_message_not_duplicated():
+    """state 里已带 SystemMessage 就不重复补（langgraph 若改行为，这里自适应）。"""
+    m = _CaptureMessages(native_ok=True)
+    msgs = [SystemMessage(content="已有"), HumanMessage(content="快照")]
+    asyncio.run(structured_extract(m, msgs, SCHEMA, "领域约束X"))
+    assert [type(x).__name__ for x in m.seen] == ["SystemMessage", "HumanMessage"]
+    assert m.seen[0].content == "已有"
 
 
 def test_fallback_valid():
@@ -139,7 +199,8 @@ def test_run_with_response_format_serializes(monkeypatch):
     captured: dict = {}
     _wire(monkeypatch, captured)
 
-    async def fake_extract(model, messages, schema):
+    async def fake_extract(model, messages, schema, system_prompt=None):
+        captured["extract_system_prompt"] = system_prompt
         return {"greeting": "pong"}, "native"
 
     monkeypatch.setattr(runner, "structured_extract_with_path", fake_extract)
@@ -148,6 +209,9 @@ def test_run_with_response_format_serializes(monkeypatch):
     ))
     assert json.loads(out) == {"greeting": "pong"}
     assert False in captured["streaming"]  # 抽结构化用非流式模型
+    # #556 回归：抽取是另起的一次模型调用，agent 系统提示词必须一并传下去，
+    # 否则模型在零约束下填 schema（实测表现为把技术字段名原样抄进 display_name）
+    assert captured["extract_system_prompt"] == "sys"
 
 
 def test_run_without_response_format_text_path(monkeypatch):


### PR DESCRIPTION
## 现象

语义理解任务「成功」，但结果是把技术字段名原样抄进业务名。同事在 `supply_chain.warehouse_entity`（资源 `d9kp51ue31bc738mepm0`）上复现：44 个字段 `display_name` 全等于 `name`、置信度 `1`、无 warning。发布 Prompt v2 后无变化。

## 根因

langchain 1.x 的 `create_agent(system_prompt=...)` 把提示词当作 **agent 配置**，只在构造模型请求那一刻拼进消息头（`langchain/agents/factory.py:1417`：`messages = [request.system_message, *messages]`），**不写回 graph state**。

Pod 内实测：

```
HumanMessage | '你好'
AIMessage    | 'ok'
含 SystemMessage: False
```

而我们的结构化输出不走 agent 节点 —— 工具循环之后另起一次裸模型调用：

```python
structured_extract_with_path(struct_model, result["messages"], response_format)
```

它看到的只有「原始输入快照 + 上一轮回答」，agent 的领域约束一条都不在场。输入快照里每个字段的 `display_name` 本来就等于物理名，于是照抄成了阻力最小的填法。

真正回给 vega 的是**抽取那一轮**的产物，所以约束写在提示词里、却作用在一个不产出最终结果的地方。这也解释了为什么改提示词无效：`resolve_prompt` 每次运行现读 DB、无缓存，v2 确实生效了，只是生效在第一轮。

表现为间歇性 —— 第一轮回答里若已写出好名字，抽取照抄就正常；否则退化成复制。此前多数运行被 #447 的 `GraphRecursionError` 挡在抽取之前，问题没机会暴露成规律。

## 改法

`structured_extract` / `structured_extract_with_path` 增加 `system_prompt` 参数，在消息头补一条 `SystemMessage`；`/run`（runner.py）与 `/chat`（graph.py）两条路径都传入本轮解析出的提示词。

保持无状态：`_with_system_prompt` 返回新列表，不改 `state.values["messages"]`，抽取结果不写回 checkpointer —— thread 历史里仍只有 Human/AI/Tool 消息，提示词不会被固化，改 prompt 对存量会话照常生效。

不传或为空时行为与改动前逐字节一致；消息里已有 `SystemMessage` 则不重复补（langgraph 若改行为可自适应）。

## 范围说明

这修的是「模型在零约束下填 schema」，**不是硬保证**。以下三条仍在 vega 应用侧，留在 #556：

- `display_name == name` 应判为无效，不该算有效业务名
- 全字段零增强时不该无警告返回 100% 置信度
- 应用明细该体现实际更新字段与跳过原因（`updated_fields`/`skipped_fields` 现带 omitempty，全空时直接消失）

## 验证

- `infra/bkn-agent`：153 passed（新增 5 条：原生/降级两条路径系统提示词到场、不传时不插消息、已有 SystemMessage 不重复、`/run` 集成断言提示词透传）
- 待办：镜像出来后在 118.196.95.132 复测 `warehouse_entity`

Refs #556

🤖 Generated with [Claude Code](https://claude.com/claude-code)