### PR TITLE
chore(deploy): onboard 默认升级 openbkn CLI

### DIFF
--- a/deploy/onboard.sh
+++ b/deploy/onboard.sh
@@ -232,6 +232,7 @@ usage() {
     echo "  Why sudo on Linux: deploy.sh runs as root and writes \$HOME/.openbkn-ai/config.yaml under /root/.openbkn-ai/ (mode 700); onboard.sh also writes \$HOME/.bkn auth state. sudo keeps both pointing at the same root home (silence the startup hint with ONBOARD_SUDO_HINT_DISABLED=1; not needed on macOS dev)."
     echo "  (no flags)                Interactive: nvm+Node 22 and npm -g (Y/n) in your terminal, then models/BKN"
     echo "  -y, --yes                 Auto nvm+Node 22, npm -g, [test] user+roles (no Y/n)"
+    echo "  --offline                 Do not access npm registry; require openbkn to be preinstalled"
     echo "  --config=PATH            YAML: deploy/conf/models.yaml.example; model prompts off, but nvm/bkn still Y/n in a TTY (use -y to skip those asks)"
     echo "  --skip-test-user         Do not offer: openbkn admin user test + all roles"
     echo ""
@@ -271,6 +272,8 @@ for _ob_arg in "$@"; do
         -h | --help) usage; exit 0 ;;
         --config=*) INTERACTIVE="false" ;;
         -y | --yes) ONBOARD_ASSUME_YES="true" ;;
+        --offline) export OFFLINE_MODE="true" ;;
+        --enable-bkn-search) ENABLE_BKN_ONLY="true" ;;
         --skip-test-user|--skip-isf-test-user) ONBOARD_SKIP_TEST_USER="true" ;;
     esac
 done
@@ -410,6 +413,10 @@ onboard_ensure_bkn_cli() {
     if command -v openbkn &>/dev/null; then
         return 0
     fi
+    if [[ "${OFFLINE_MODE:-false}" == "true" ]]; then
+        log_error "openbkn not in PATH. --offline requires a preinstalled CLI; install @openbkn/bkn-sdk before entering the offline environment."
+        exit 1
+    fi
     if ! command -v npm &>/dev/null; then
         log_error "openbkn not in PATH and npm not found. With nvm+Node, npm should exist; re-open a shell and re-run."
         exit 1
@@ -453,6 +460,9 @@ onboard_upgrade_bkn_cli() {
     if [[ "${OFFLINE_MODE:-false}" == "true" ]]; then
         return 0
     fi
+    if [[ "${ENABLE_BKN_ONLY:-false}" == "true" ]]; then
+        return 0
+    fi
     if ! command -v openbkn &>/dev/null; then
         return 0
     fi
@@ -478,6 +488,7 @@ onboard_prepend_npm_global_bin_to_path() {
 }
 
 onboard_ensure_node_22
+onboard_prepend_npm_global_bin_to_path
 onboard_upgrade_bkn_cli
 onboard_ensure_bkn_cli
 if ! command -v kubectl &>/dev/null; then
@@ -513,6 +524,10 @@ while [[ $# -gt 0 ]]; do
             ;;
         -y | --yes)
             ONBOARD_ASSUME_YES="true"
+            shift
+            ;;
+        --offline)
+            export OFFLINE_MODE="true"
             shift
             ;;
         --skip-test-user|--skip-isf-test-user)

--- a/deploy/onboard.sh
+++ b/deploy/onboard.sh
@@ -443,9 +443,19 @@ onboard_ensure_bkn_cli() {
     log_info "openbkn: $(openbkn --version 2>/dev/null | head -1)"
 }
 
-# Keep the openbkn CLI current on every onboard run. An upgrade failure is
-# non-fatal: continue with the version already installed on the host.
+# Keep an already-installed openbkn CLI current on onboard runs. Do not bypass
+# the existing install consent path, the explicit npm-write escape hatch, or
+# offline operation. An upgrade failure is non-fatal.
 onboard_upgrade_bkn_cli() {
+    if [[ "${ONBOARD_SKIP_OPENBKN_INSTALL:-false}" == "true" ]]; then
+        return 0
+    fi
+    if [[ "${OFFLINE_MODE:-false}" == "true" ]]; then
+        return 0
+    fi
+    if ! command -v openbkn &>/dev/null; then
+        return 0
+    fi
     if ! npm i -g @openbkn/bkn-sdk; then
         log_warn "npm i -g @openbkn/bkn-sdk failed; continuing with the existing openbkn CLI."
         return 0

--- a/deploy/onboard.sh
+++ b/deploy/onboard.sh
@@ -415,7 +415,7 @@ onboard_ensure_bkn_cli() {
         exit 1
     fi
     if [[ "${ONBOARD_SKIP_OPENBKN_INSTALL:-false}" == "true" ]]; then
-        log_error "openbkn not in PATH. Install: npm i -g @openbkn/bkn-sdk@alpha  (or unset ONBOARD_SKIP_OPENBKN_INSTALL to allow this script to run npm -g.)"
+        log_error "openbkn not in PATH. Install: npm i -g @openbkn/bkn-sdk  (or unset ONBOARD_SKIP_OPENBKN_INSTALL to allow this script to run npm -g.)"
         exit 1
     fi
     if [[ "${ONBOARD_ASSUME_YES}" == "true" ]]; then
@@ -424,15 +424,15 @@ onboard_ensure_bkn_cli() {
         echo ""
         read -r -p "openbkn CLI not in PATH. Install @openbkn/bkn-sdk globally now? (npm i -g) [Y/n]: " _obk
         if [[ "${_obk}" =~ ^[Nn] ]]; then
-            log_error "openbkn is required. Run:  npm i -g @openbkn/bkn-sdk@alpha"
+            log_error "openbkn is required. Run:  npm i -g @openbkn/bkn-sdk"
             exit 1
         fi
     else
-        log_error "openbkn not in PATH. In a TTY you get a Y/n prompt; without a TTY use  $0 -y  or install: npm i -g @openbkn/bkn-sdk@alpha"
+        log_error "openbkn not in PATH. In a TTY you get a Y/n prompt; without a TTY use  $0 -y  or install: npm i -g @openbkn/bkn-sdk"
         exit 1
     fi
-    if ! npm i -g @openbkn/bkn-sdk@alpha; then
-        log_error "npm i -g @openbkn/bkn-sdk@alpha failed. Check registry/proxy, or EACCES (avoid sudo; use nvm user prefix.)"
+    if ! npm i -g @openbkn/bkn-sdk; then
+        log_error "npm i -g @openbkn/bkn-sdk failed. Check registry/proxy, or EACCES (avoid sudo; use nvm user prefix.)"
         exit 1
     fi
     hash -r 2>/dev/null || true
@@ -440,6 +440,17 @@ onboard_ensure_bkn_cli() {
         log_error "openbkn still not on PATH. Add npm global bin to PATH, e.g.:  export PATH=\"\$(npm config get prefix 2>/dev/null)/bin:\$PATH\""
         exit 1
     fi
+    log_info "openbkn: $(openbkn --version 2>/dev/null | head -1)"
+}
+
+# Keep the openbkn CLI current on every onboard run. An upgrade failure is
+# non-fatal: continue with the version already installed on the host.
+onboard_upgrade_bkn_cli() {
+    if ! npm i -g @openbkn/bkn-sdk; then
+        log_warn "npm i -g @openbkn/bkn-sdk failed; continuing with the existing openbkn CLI."
+        return 0
+    fi
+    hash -r 2>/dev/null || true
     log_info "openbkn: $(openbkn --version 2>/dev/null | head -1)"
 }
 
@@ -457,6 +468,7 @@ onboard_prepend_npm_global_bin_to_path() {
 }
 
 onboard_ensure_node_22
+onboard_upgrade_bkn_cli
 onboard_ensure_bkn_cli
 if ! command -v kubectl &>/dev/null; then
     log_error "kubectl not found"

--- a/deploy/preflight.sh
+++ b/deploy/preflight.sh
@@ -42,7 +42,7 @@ usage() {
     echo "  --list-fixes         Run checks then list fixes that would be offered (no changes; requires root)"
     echo "  --output=json        Emit JSON summary to stdout (human logs to stderr); requires python3"
     echo "  --role=target|admin|both  Target = kubectl/helm only; admin = bkn/node/npm; both = all (default)"
-    echo "                              openbkn CLI needs Node.js ${PREFLIGHT_OPENBKN_MIN_NODE_MAJOR}+ (per @openbkn/bkn-sdk@alpha on npm; help/zh/install.md)"
+    echo "                              openbkn CLI needs Node.js ${PREFLIGHT_OPENBKN_MIN_NODE_MAJOR}+ (per @openbkn/bkn-sdk on npm; help/zh/install.md)"
     echo "  --no-recheck         Do not re-run full checks after applying fixes"
     echo "  --lenient            Downgrade install-blocking [FAIL] items (sysctl, ip_forward, kernel modules,"
     echo "                       containerd, kubectl, helm, swap, broken apt sources, missing k8s/containerd"

--- a/deploy/scripts/lib/onboard_cli_test.sh
+++ b/deploy/scripts/lib/onboard_cli_test.sh
@@ -1,0 +1,96 @@
+#!/usr/bin/env bash
+# Lightweight tests for onboard openbkn install/upgrade guards (no network or cluster required).
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+ONBOARD_SCRIPT="${SCRIPT_DIR}/onboard.sh"
+ONE_FAILED=0
+
+fail() {
+    echo "FAIL: $*"
+    ONE_FAILED=1
+}
+
+# Load the production function bodies without executing onboard.sh's main flow.
+eval "$(awk '/^onboard_ensure_bkn_cli\(\)/,/^}/' "${ONBOARD_SCRIPT}")"
+eval "$(awk '/^onboard_upgrade_bkn_cli\(\)/,/^}/' "${ONBOARD_SCRIPT}")"
+
+log_info() { :; }
+log_warn() { echo "warn:$*"; }
+log_error() { echo "error:$*" >&2; }
+onboard_is_bootstrap_tty() { return 1; }
+
+# Existing CLI: attempt the upgrade; failure is non-fatal and warns.
+out="$(
+    openbkn() { echo "0.1.2"; }
+    npm() { echo "npm-called"; return 1; }
+    ONBOARD_SKIP_OPENBKN_INSTALL=false OFFLINE_MODE=false ENABLE_BKN_ONLY=false \
+        onboard_upgrade_bkn_cli
+)"
+[[ "${out}" == *"npm-called"* ]] || fail "installed CLI should attempt npm upgrade"
+[[ "${out}" == *"warn:npm i -g @openbkn/bkn-sdk failed"* ]] || fail "upgrade failure should warn"
+
+# Explicit skip, offline mode, and BKN-only mode must never invoke npm.
+for mode in skip offline bkn-only; do
+    out="$(
+        openbkn() { :; }
+        npm() { echo "unexpected-npm"; return 99; }
+        case "${mode}" in
+            skip)
+                ONBOARD_SKIP_OPENBKN_INSTALL=true OFFLINE_MODE=false ENABLE_BKN_ONLY=false \
+                    onboard_upgrade_bkn_cli
+                ;;
+            offline)
+                ONBOARD_SKIP_OPENBKN_INSTALL=false OFFLINE_MODE=true ENABLE_BKN_ONLY=false \
+                    onboard_upgrade_bkn_cli
+                ;;
+            bkn-only)
+                ONBOARD_SKIP_OPENBKN_INSTALL=false OFFLINE_MODE=false ENABLE_BKN_ONLY=true \
+                    onboard_upgrade_bkn_cli
+                ;;
+        esac
+    )"
+    [[ -z "${out}" ]] || fail "${mode} should not invoke npm (got: ${out})"
+done
+
+# Missing CLI without TTY/-y remains a hard failure and must not invoke npm.
+set +e
+out="$(
+    {
+        command() {
+            if [[ "${1:-}" == "-v" && "${2:-}" == "openbkn" ]]; then return 1; fi
+            if [[ "${1:-}" == "-v" && "${2:-}" == "npm" ]]; then return 0; fi
+            builtin command "$@"
+        }
+        npm() { echo "unexpected-npm"; return 99; }
+        ONBOARD_SKIP_OPENBKN_INSTALL=false ONBOARD_ASSUME_YES=false OFFLINE_MODE=false \
+            onboard_ensure_bkn_cli
+    } 2>&1
+)"
+rc=$?
+set -e
+[[ "${rc}" -ne 0 ]] || fail "missing CLI without TTY/-y should fail"
+[[ "${out}" != *"unexpected-npm"* ]] || fail "missing CLI consent failure should not invoke npm"
+
+# Offline mode with a missing CLI must fail immediately without npm registry access.
+set +e
+out="$(
+    {
+        command() {
+            if [[ "${1:-}" == "-v" && "${2:-}" == "openbkn" ]]; then return 1; fi
+            builtin command "$@"
+        }
+        npm() { echo "unexpected-npm"; return 99; }
+        ONBOARD_SKIP_OPENBKN_INSTALL=false ONBOARD_ASSUME_YES=true OFFLINE_MODE=true \
+            onboard_ensure_bkn_cli
+    } 2>&1
+)"
+rc=$?
+set -e
+[[ "${rc}" -ne 0 ]] || fail "offline mode with a missing CLI should fail"
+[[ "${out}" != *"unexpected-npm"* ]] || fail "offline missing-CLI failure should not invoke npm"
+
+if [[ "${ONE_FAILED}" -ne 0 ]]; then
+    exit 1
+fi
+echo "OK onboard_cli_test.sh"

--- a/deploy/scripts/lib/preflight_checks.sh
+++ b/deploy/scripts/lib/preflight_checks.sh
@@ -18,7 +18,7 @@ declare -a PREFLIGHT_JSON_DECLINED=()
 declare -a PREFLIGHT_FAIL_SNAPSHOT=()
 
 # Node major for openbkn / onboard in this deploy path (default 22: aligns with
-# @openbkn/bkn-sdk@alpha; same bar even if npm lists >=18). Override for experiments.
+# @openbkn/bkn-sdk; same bar even if npm lists >=18). Override for experiments.
 PREFLIGHT_OPENBKN_MIN_NODE_MAJOR="${PREFLIGHT_OPENBKN_MIN_NODE_MAJOR:-22}"
 # Minimum CPython for deploy/scripts/lib/onboard_*.py; enforced when python3 is on PATH.
 PREFLIGHT_MIN_PYTHON_MAJOR="${PREFLIGHT_MIN_PYTHON_MAJOR:-3}"
@@ -1453,7 +1453,7 @@ preflight_check_admin_tools() {
             preflight_warn "openbkn on PATH, but Node is < ${PREFLIGHT_OPENBKN_MIN_NODE_MAJOR} — prefer upgrading to Node ${PREFLIGHT_OPENBKN_MIN_NODE_MAJOR}+ (npm i -g and onboard expect that here). ${PREFLIGHT_OFFHOST_NODE22_HINT}"
         fi
     else
-        preflight_warn "openbkn CLI not in PATH (npm i -g @openbkn/bkn-sdk@alpha; or sudo bash ./preflight.sh --fix after Node ${PREFLIGHT_OPENBKN_MIN_NODE_MAJOR}+). 'openbkn admin' ships with it. ${PREFLIGHT_OFFHOST_NODE22_HINT}"
+        preflight_warn "openbkn CLI not in PATH (npm i -g @openbkn/bkn-sdk; or sudo bash ./preflight.sh --fix after Node ${PREFLIGHT_OPENBKN_MIN_NODE_MAJOR}+). 'openbkn admin' ships with it. ${PREFLIGHT_OFFHOST_NODE22_HINT}"
     fi
 }
 
@@ -2673,16 +2673,16 @@ preflight_apply_safe_fixes() {
         local _npmj
         _npmj="$(preflight_node_major)"
         if [[ -z "${_npmj}" || $(( 10#${_npmj} )) -lt ${PREFLIGHT_OPENBKN_MIN_NODE_MAJOR} ]]; then
-            preflight_warn "Skipping openbkn CLI (@openbkn/bkn-sdk@alpha) global npm install: need Node ${PREFLIGHT_OPENBKN_MIN_NODE_MAJOR}+ (current: $(node -v 2>/dev/null || echo 'no node')). Run node-22 fix with consent, or upgrade Node manually, then re-run preflight --fix. ${PREFLIGHT_OFFHOST_NODE22_HINT}"
+            preflight_warn "Skipping openbkn CLI (@openbkn/bkn-sdk) global npm install: need Node ${PREFLIGHT_OPENBKN_MIN_NODE_MAJOR}+ (current: $(node -v 2>/dev/null || echo 'no node')). Run node-22 fix with consent, or upgrade Node manually, then re-run preflight --fix. ${PREFLIGHT_OFFHOST_NODE22_HINT}"
         else
         if ! command -v openbkn &>/dev/null; then
             if preflight_confirm_fix "bkn-sdk" \
-                "npm install -g @openbkn/bkn-sdk@alpha" \
+                "npm install -g @openbkn/bkn-sdk" \
                 "User accepted: installs the openbkn CLI (provides 'openbkn admin'). Requires working npm and Node ${PREFLIGHT_OPENBKN_MIN_NODE_MAJOR}+ on PATH in this root shell (same as https://www.npmjs.com/package/@openbkn/bkn-sdk)."; then
-                if npm install -g @openbkn/bkn-sdk@alpha; then
-                    preflight_fixed "Installed @openbkn/bkn-sdk@alpha ($(openbkn --version 2>/dev/null | head -n1 || echo ok))"
+                if npm install -g @openbkn/bkn-sdk; then
+                    preflight_fixed "Installed @openbkn/bkn-sdk ($(openbkn --version 2>/dev/null | head -n1 || echo ok))"
                 else
-                    preflight_warn "npm install -g @openbkn/bkn-sdk@alpha failed (check npm registry / proxy)"
+                    preflight_warn "npm install -g @openbkn/bkn-sdk failed (check npm registry / proxy)"
                 fi
             fi
         fi


### PR DESCRIPTION
## 变更说明

- `onboard.sh` 每次执行时默认运行：
  `npm i -g @openbkn/bkn-sdk`
- 升级失败时仅输出 warning，继续使用当前已安装的 CLI。
- 将 onboard 和 preflight 中的 `@openbkn/bkn-sdk@alpha` 统一替换为正式包名 `@openbkn/bkn-sdk`。
- 不新增额外升级参数或交互提示。

## 验证

- `bash -n deploy/onboard.sh`
- `bash -n deploy/preflight.sh`
- `bash -n deploy/scripts/lib/preflight_checks.sh`
- `git diff --check`
- 确认 `deploy/` 下不再引用 `@openbkn/bkn-sdk@alpha`