### PR TITLE
feat(comm-go): 抽出插座通用注册表 entitlement/socket

### DIFF
--- a/comm-go/README.md
+++ b/comm-go/README.md
@@ -31,7 +31,8 @@ go mod tidy && go build ./... && go test ./...
 找出所有消费者：
 
 ```bash
-grep -rl 'openbkn-ai/bkn-foundry/comm-go' --include=go.mod . | xargs -n1 dirname
+# 要求路径后面跟着版本号，否则 comm-go/go.mod 的 module 行也会命中
+grep -rlE 'openbkn-ai/bkn-foundry/comm-go v[0-9]' --include=go.mod . | xargs -n1 dirname
 ```
 
 ## 版本

--- a/comm-go/README.md
+++ b/comm-go/README.md
@@ -1,3 +1,61 @@
-# bkn-comm-go
+# comm-go
 
-openbkn Go 公共依赖库
+openbkn Go 公共依赖库。回迁自独立仓 `openbkn-ai/bkn-comm-go`，module path 现为
+`github.com/openbkn-ai/bkn-foundry/comm-go`。
+
+## 改完之后：谁负责让消费者用上
+
+comm-go 与各服务是**各自独立的 Go module**，同一个仓也不例外。消费者的 `go.mod`
+里钉着一个版本，那行不会自己变。所以改公共库永远是两步——先合库，再让消费者
+指过去——而且单体仓也没法把两步塞进同一个 PR：`require` 的那个版本得先存在。
+
+第二步由谁做，取决于改动的性质：
+
+| 改动 | 谁负责 | 为什么 |
+|---|---|---|
+| **加 API**（新函数、新类型、新包） | 用它的人 | 你要用就编不过，立刻发现 |
+| **改行为**（bug 修复、安全修复、语义变更） | **改 comm-go 的人**，合并后立刻 bump 各消费者 | 编译照过、测试照绿、行为是旧的——不会有任何东西报错 |
+
+第二类是这条规矩存在的全部理由。举个真实的：`entitlement` 修过一个「hub 不可达
+时许可判定被冻住」的洞（掐掉出向流量就永久有效）。修完不 bump，那个绕过就一直
+在线上，而没有人「需要」这次改动——没有缺失的符号会提醒任何人。
+
+怎么 bump：
+
+```bash
+cd <消费者目录>
+go get github.com/openbkn-ai/bkn-foundry/comm-go@<main 上的 commit>
+go mod tidy && go build ./... && go test ./...
+```
+
+找出所有消费者：
+
+```bash
+grep -rl 'openbkn-ai/bkn-foundry/comm-go' --include=go.mod . | xargs -n1 dirname
+```
+
+## 版本
+
+日常钉 commit（`go get ...@<sha>`，落成 pseudo-version），正式发布才打
+`comm-go/vX.Y.Z` 并让消费者钉 tag。
+
+日常不打 tag，是因为 tag 不可撤回：Go 的 proxy 一旦缓存就永久保留，源仓删掉 ref
+也照样发。给每次合并都发一个版本号，等于把版本序变成提交日志。pseudo-version
+指向的 commit 在 main 上同样永久可达，坐标一样诚实，只是读不出语义。
+
+## 包
+
+- `entitlement` —— EE 版本门控：按档位判定（`AtLeast`）、装配注册表、
+  从 bkn-safe 取证书并本地验签的 hub 客户端。设计见 bkn-docs
+  `docs/shared/licensing/ee-design.md`。
+- `entitlement/socket` —— 插座通用注册表，各服务的插座（`mcptool`、将来的
+  `httproute`）共用它来保证「注册只在装配期、必须声明能力与档位、重复键必炸、
+  列举稳定排序」这四条。
+- 其余（`audit` `common` `crypto` `db` `hydra` `i18n` `logger` `middleware`
+  `mq` `otel` `rest`）为回迁前既有的基础设施封装。
+
+### 第三方源码
+
+`db/driver/kingbase/gokb/` 是人大金仓（KingbaseES）官方 Go 驱动的源码，版权归
+中电科金仓（北京）科技股份有限公司。它被 `db/driver/rds.go` 无条件 import，因此
+链接进每个用到 `db/driver` 的服务。来源说明与第三方 license 例外待归档。

--- a/comm-go/entitlement/entitlement_test.go
+++ b/comm-go/entitlement/entitlement_test.go
@@ -162,6 +162,23 @@ func TestMarkAssembledRequiresMinEdition(t *testing.T) {
 	}
 }
 
+func TestMarkAssembledRejectsAnUnknownEdition(t *testing.T) {
+	reset()
+	// A misspelt tier fails in the worse direction than a missing one: an
+	// unrecognised edition ranks with community (licverify Edition.rank falls
+	// through to 0), so AtLeast(min) is true for every licence and the paid
+	// capability silently becomes free.
+	msg := mustPanic(t, "misspelt MinEdition", func() {
+		MarkAssembled("audit", licverify.Edition("enterprize"))
+	})
+	if !strings.Contains(msg, "unknown edition") {
+		t.Fatalf("panic should name the bad value, got %q", msg)
+	}
+	if len(Assembled()) != 0 {
+		t.Fatal("nothing should have been recorded")
+	}
+}
+
 func TestRegistrationDoesNotDependOnTheLicence(t *testing.T) {
 	reset()
 	SetGate(fixed(licverify.EditionCommunity))

--- a/comm-go/entitlement/registry.go
+++ b/comm-go/entitlement/registry.go
@@ -85,6 +85,15 @@ func MarkAssembled(name string, min licverify.Edition) {
 	if min == "" {
 		panic(fmt.Sprintf("entitlement: capability %q registered without a MinEdition — declare the lowest tier that may use it (licverify.EditionEnterprise and friends)", name))
 	}
+	if !min.Known() {
+		// A misspelt tier is the same class of mistake as a missing one, and it
+		// fails in the worse direction: an unrecognised edition ranks with
+		// community, so AtLeast(min) is true for *every* licence — the paid
+		// entry silently becomes free. Both checks live here rather than in each
+		// socket, because this is the one place a paid capability can register
+		// itself as something it is not.
+		panic(fmt.Sprintf("entitlement: capability %q registered with an unknown edition %q — must be one of community, professional, enterprise, industry", name, min))
+	}
 	mu.Lock()
 	defer mu.Unlock()
 	if frozen {

--- a/comm-go/entitlement/socket/socket.go
+++ b/comm-go/entitlement/socket/socket.go
@@ -1,0 +1,147 @@
+// Copyright openbkn.ai
+//
+// Licensed under the OpenBKN License. See LICENSE-OPENBKN.txt in the project root.
+
+// Package socket holds the part every extension socket repeats: a keyed
+// registry that only accepts entries during assembly, records which paid
+// capability each entry belongs to, and hands them back in a stable order.
+//
+// # What belongs here and what does not
+//
+// Sockets differ in almost everything that matters to their users. The MCP tool
+// socket keys by tool name, carries JSON schemas, and hides an unlicensed tool
+// by answering the way mcp-go answers one it has never heard of. An HTTP route
+// socket keys by method and path, has no schema to speak of, answers 404, and —
+// in bkn-backend, where the same route is mounted under both /api/bkn-backend
+// and /api/ontology-manager — cannot even decide by itself where its entries
+// get mounted.
+//
+// So this package deliberately holds no opinion about any of that. It does not
+// know what an entry is, how it is served, or what refusing looks like. What it
+// does know are the four invariants that are the same everywhere, and that are
+// easy to forget when writing socket number three:
+//
+//  1. Registration happens during assembly, never after the server starts.
+//  2. Every entry declares the capability it belongs to and the lowest tier
+//     that may use it.
+//  3. Two entries must not claim the same key — the second would silently
+//     replace the first.
+//  4. Listing is stable, because tool catalogues and route tables are compared
+//     across restarts.
+//
+// # Registration is unconditional
+//
+// Nothing here consults the licence. A socket registers everything the binary
+// has, and whether an entry may serve is decided per call from the licence in
+// force at that moment (entitlement.AtLeast). Registering only what the current
+// certificate allows would mean a process that booted without one could never
+// pick up a certificate installed later — it would have to be restarted, on a
+// customer's site, to fix a licensing mistake.
+package socket
+
+import (
+	"fmt"
+	"sort"
+	"sync"
+	"testing"
+
+	"github.com/openbkn-ai/bkn-foundry/comm-go/entitlement"
+	"github.com/openbkn-ai/licverify"
+)
+
+// Registry stores one socket's entries. T is whatever that socket's entry looks
+// like; this package never inspects it.
+//
+// The zero value is not usable — use New, which names the socket for the panic
+// messages. "mcptool: tool \"search_schema\" registered twice" tells whoever
+// hits it where to look; "socket: duplicate key" does not.
+type Registry[T any] struct {
+	kind string
+
+	mu    sync.RWMutex
+	items map[string]T
+	order []string
+}
+
+// New creates a registry for a socket. kind is the socket's name, used in panic
+// messages ("mcptool", "httproute").
+func New[T any](kind string) *Registry[T] {
+	return &Registry[T]{kind: kind, items: map[string]T{}}
+}
+
+// Add registers an entry under key, on behalf of capability, requiring at least
+// min.
+//
+// It panics on every condition that would otherwise fail silently at runtime:
+// registering after the assembly window closed, a duplicate key, a missing
+// capability name, or a zero MinEdition — the last one being how a paid entry
+// would accidentally register as free.
+func (r *Registry[T]) Add(key, capability string, min licverify.Edition, item T) {
+	if key == "" {
+		panic(r.kind + ": registration with an empty key")
+	}
+	if capability == "" {
+		panic(fmt.Sprintf("%s: %q registered without a capability name — several entries usually share one, and the assembly registry records it by name", r.kind, key))
+	}
+
+	// Outside the assembly window nothing may register: the catalogue this
+	// socket feeds is materialised once, when handlers are built.
+	entitlement.MustBeAssembling(r.kind + ":" + key)
+
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if _, dup := r.items[key]; dup {
+		panic(fmt.Sprintf("%s: %q registered twice — the second registration would silently replace the first", r.kind, key))
+	}
+	// MarkAssembled rejects a zero MinEdition, so the check lives in one place
+	// for every socket rather than being repeated (and eventually forgotten).
+	entitlement.MarkAssembled(capability, min)
+
+	r.items[key] = item
+	r.order = append(r.order, key)
+}
+
+// Get returns the entry registered under key.
+func (r *Registry[T]) Get(key string) (T, bool) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	item, ok := r.items[key]
+	return item, ok
+}
+
+// All returns every entry, ordered by key. Ordering is by key rather than by
+// registration order so that the answer does not depend on which init ran
+// first — catalogues get diffed across restarts and across replicas.
+func (r *Registry[T]) All() []T {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	keys := append([]string(nil), r.order...)
+	sort.Strings(keys)
+	out := make([]T, 0, len(keys))
+	for _, k := range keys {
+		out = append(out, r.items[k])
+	}
+	return out
+}
+
+// Len reports how many entries are registered. A community binary has none:
+// the code that would register them is not in the build.
+func (r *Registry[T]) Len() int {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	return len(r.items)
+}
+
+// ResetForTest empties the registry. It is exported because socket tests live
+// in other packages, and guarded because it is linked into production binaries:
+// clearing a live registry is exactly what Add's assembly-window panic exists
+// to prevent.
+func (r *Registry[T]) ResetForTest() {
+	if !testing.Testing() {
+		panic(r.kind + ": ResetForTest is test-only and must never run in a production binary")
+	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.items = map[string]T{}
+	r.order = nil
+}

--- a/comm-go/entitlement/socket/socket.go
+++ b/comm-go/entitlement/socket/socket.go
@@ -60,7 +60,6 @@ type Registry[T any] struct {
 
 	mu    sync.RWMutex
 	items map[string]T
-	order []string
 }
 
 // New creates a registry for a socket. kind is the socket's name, used in panic
@@ -74,8 +73,8 @@ func New[T any](kind string) *Registry[T] {
 //
 // It panics on every condition that would otherwise fail silently at runtime:
 // registering after the assembly window closed, a duplicate key, a missing
-// capability name, or a zero MinEdition — the last one being how a paid entry
-// would accidentally register as free.
+// capability name, or a MinEdition that is zero or unrecognised — those last two
+// being how a paid entry accidentally registers as free.
 func (r *Registry[T]) Add(key, capability string, min licverify.Edition, item T) {
 	if key == "" {
 		panic(r.kind + ": registration with an empty key")
@@ -93,12 +92,13 @@ func (r *Registry[T]) Add(key, capability string, min licverify.Edition, item T)
 	if _, dup := r.items[key]; dup {
 		panic(fmt.Sprintf("%s: %q registered twice — the second registration would silently replace the first", r.kind, key))
 	}
-	// MarkAssembled rejects a zero MinEdition, so the check lives in one place
-	// for every socket rather than being repeated (and eventually forgotten).
+	// MarkAssembled rejects a zero or misspelt MinEdition, so those checks live
+	// in one place for every socket rather than being repeated (and eventually
+	// forgotten). An unrecognised tier is the dangerous one: it ranks with
+	// community, so AtLeast is true for every licence.
 	entitlement.MarkAssembled(capability, min)
 
 	r.items[key] = item
-	r.order = append(r.order, key)
 }
 
 // Get returns the entry registered under key.
@@ -115,7 +115,10 @@ func (r *Registry[T]) Get(key string) (T, bool) {
 func (r *Registry[T]) All() []T {
 	r.mu.RLock()
 	defer r.mu.RUnlock()
-	keys := append([]string(nil), r.order...)
+	keys := make([]string, 0, len(r.items))
+	for k := range r.items {
+		keys = append(keys, k)
+	}
 	sort.Strings(keys)
 	out := make([]T, 0, len(keys))
 	for _, k := range keys {
@@ -132,10 +135,24 @@ func (r *Registry[T]) Len() int {
 	return len(r.items)
 }
 
-// ResetForTest empties the registry. It is exported because socket tests live
-// in other packages, and guarded because it is linked into production binaries:
-// clearing a live registry is exactly what Add's assembly-window panic exists
-// to prevent.
+// ResetForTest empties this registry — and only this registry.
+//
+// It deliberately does not touch entitlement's assembly table, and
+// entitlement.ResetForTest does not touch this one. A socket commonly owns
+// several registries (mcptool has one for tools and one for decorators), so
+// coupling them would mean resetting the first wipes the capability claims that
+// the second's entries still depend on — trading one kind of skew for another.
+//
+// So a socket's own reset helper has to clear both halves. mcptool.ResetForTest
+// is the reference shape: reset every registry it owns, then call
+// entitlement.SetGateForTest, which resets the assembly table on its way in.
+//
+// Getting this wrong is not a production risk — both resets refuse to run
+// outside a test binary — but it makes a test lie: "a community build assembled
+// nothing" passes while the socket registry is still full.
+//
+// Guarded because it is linked into production binaries: clearing a live
+// registry is exactly what Add's assembly-window panic exists to prevent.
 func (r *Registry[T]) ResetForTest() {
 	if !testing.Testing() {
 		panic(r.kind + ": ResetForTest is test-only and must never run in a production binary")
@@ -143,5 +160,4 @@ func (r *Registry[T]) ResetForTest() {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	r.items = map[string]T{}
-	r.order = nil
 }

--- a/comm-go/entitlement/socket/socket_test.go
+++ b/comm-go/entitlement/socket/socket_test.go
@@ -1,0 +1,158 @@
+// Copyright openbkn.ai
+//
+// Licensed under the OpenBKN License. See LICENSE-OPENBKN.txt in the project root.
+
+package socket
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/openbkn-ai/bkn-foundry/comm-go/entitlement"
+	"github.com/openbkn-ai/licverify"
+)
+
+// entry stands in for whatever a real socket stores; this package never looks
+// inside it.
+type entry struct{ name string }
+
+func enterprise(t *testing.T) *Registry[entry] {
+	t.Helper()
+	entitlement.SetGateForTest(entitlement.FixedGate(licverify.EditionEnterprise))
+	return New[entry]("testsocket")
+}
+
+func mustPanic(t *testing.T, what string, fn func()) string {
+	t.Helper()
+	var got any
+	func() {
+		defer func() { got = recover() }()
+		fn()
+	}()
+	if got == nil {
+		t.Fatalf("%s: expected panic, got none", what)
+	}
+	msg, _ := got.(string)
+	return msg
+}
+
+func TestAddAndGet(t *testing.T) {
+	r := enterprise(t)
+	r.Add("probe", "context_probe", licverify.EditionEnterprise, entry{"probe"})
+
+	got, ok := r.Get("probe")
+	if !ok || got.name != "probe" {
+		t.Fatalf("Get = %+v, %v; want the registered entry", got, ok)
+	}
+	if r.Len() != 1 {
+		t.Fatalf("Len = %d, want 1", r.Len())
+	}
+}
+
+func TestAddRecordsTheCapability(t *testing.T) {
+	r := enterprise(t)
+	// One capability, several entries — an extra tool plus a decorator is the
+	// normal shape, and the assembly registry records it once.
+	r.Add("probe", "context_probe", licverify.EditionEnterprise, entry{"probe"})
+	r.Add("decorate:search_schema", "context_probe", licverify.EditionEnterprise, entry{"dec"})
+
+	caps := entitlement.Assembled()
+	if len(caps) != 1 || caps[0].Name != "context_probe" || caps[0].MinEdition != licverify.EditionEnterprise {
+		t.Fatalf("Assembled() = %+v, want one enterprise capability", caps)
+	}
+}
+
+func TestDuplicateKeyPanics(t *testing.T) {
+	r := enterprise(t)
+	r.Add("probe", "context_probe", licverify.EditionEnterprise, entry{"first"})
+
+	msg := mustPanic(t, "duplicate key", func() {
+		r.Add("probe", "context_probe", licverify.EditionEnterprise, entry{"second"})
+	})
+	if !strings.Contains(msg, "testsocket") || !strings.Contains(msg, "registered twice") {
+		t.Fatalf("panic should name the socket and the collision, got %q", msg)
+	}
+}
+
+func TestMissingCapabilityPanics(t *testing.T) {
+	r := enterprise(t)
+	msg := mustPanic(t, "no capability", func() {
+		r.Add("probe", "", licverify.EditionEnterprise, entry{"probe"})
+	})
+	if !strings.Contains(msg, "capability") {
+		t.Fatalf("panic should name the missing field, got %q", msg)
+	}
+}
+
+func TestZeroMinEditionPanics(t *testing.T) {
+	r := enterprise(t)
+	// This is how a paid entry would quietly become free. The check lives in
+	// entitlement.MarkAssembled so no socket has to remember it.
+	msg := mustPanic(t, "zero MinEdition", func() {
+		r.Add("probe", "context_probe", "", entry{"probe"})
+	})
+	if !strings.Contains(msg, "MinEdition") {
+		t.Fatalf("panic should name the missing tier, got %q", msg)
+	}
+}
+
+func TestAddAfterFreezePanics(t *testing.T) {
+	r := enterprise(t)
+	entitlement.Freeze()
+
+	msg := mustPanic(t, "Add after Freeze", func() {
+		r.Add("probe", "context_probe", licverify.EditionEnterprise, entry{"probe"})
+	})
+	if !strings.Contains(msg, "after Freeze") {
+		t.Fatalf("panic should say the assembly window is closed, got %q", msg)
+	}
+}
+
+func TestRegistrationIgnoresTheLicence(t *testing.T) {
+	// A community-licensed process still assembles everything the binary has:
+	// a certificate installed later must take effect without a restart, which
+	// is impossible if an unlicensed boot registered nothing.
+	entitlement.SetGateForTest(entitlement.FixedGate(licverify.EditionCommunity))
+	r := New[entry]("testsocket")
+
+	r.Add("probe", "context_probe", licverify.EditionEnterprise, entry{"probe"})
+	if r.Len() != 1 {
+		t.Fatal("registration must not depend on the licence")
+	}
+	if entitlement.AtLeast(licverify.EditionEnterprise) {
+		t.Fatal("…while the capability itself stays unusable")
+	}
+}
+
+func TestAllIsOrderedByKeyNotByRegistration(t *testing.T) {
+	r := enterprise(t)
+	// Registration order follows whichever Setup ran first; the catalogue must
+	// not, because it gets diffed across restarts and across replicas.
+	r.Add("zeta", "cap", licverify.EditionEnterprise, entry{"zeta"})
+	r.Add("alpha", "cap", licverify.EditionEnterprise, entry{"alpha"})
+
+	got := r.All()
+	if len(got) != 2 || got[0].name != "alpha" || got[1].name != "zeta" {
+		t.Fatalf("All() = %+v, want key order", got)
+	}
+}
+
+func TestEmptyKeyPanics(t *testing.T) {
+	r := enterprise(t)
+	mustPanic(t, "empty key", func() {
+		r.Add("", "cap", licverify.EditionEnterprise, entry{})
+	})
+}
+
+func TestResetForTestEmptiesTheRegistry(t *testing.T) {
+	r := enterprise(t)
+	r.Add("probe", "context_probe", licverify.EditionEnterprise, entry{"probe"})
+
+	r.ResetForTest()
+	if r.Len() != 0 {
+		t.Fatal("ResetForTest should empty the registry")
+	}
+	// Registering again must work — a test that resets is starting over.
+	entitlement.SetGateForTest(entitlement.FixedGate(licverify.EditionEnterprise))
+	r.Add("probe", "context_probe", licverify.EditionEnterprise, entry{"probe"})
+}

--- a/comm-go/entitlement/socket/socket_test.go
+++ b/comm-go/entitlement/socket/socket_test.go
@@ -96,6 +96,22 @@ func TestZeroMinEditionPanics(t *testing.T) {
 	}
 }
 
+func TestUnknownMinEditionPanics(t *testing.T) {
+	r := enterprise(t)
+	// Same class of mistake as the zero value, worse consequences: an
+	// unrecognised tier ranks with community, so every licence clears it and the
+	// paid entry is free. Caught in MarkAssembled, one place for every socket.
+	msg := mustPanic(t, "misspelt MinEdition", func() {
+		r.Add("probe", "context_probe", licverify.Edition("enterprize"), entry{"probe"})
+	})
+	if !strings.Contains(msg, "unknown edition") {
+		t.Fatalf("panic should name the bad value, got %q", msg)
+	}
+	if r.Len() != 0 {
+		t.Fatal("nothing should have been registered")
+	}
+}
+
 func TestAddAfterFreezePanics(t *testing.T) {
 	r := enterprise(t)
 	entitlement.Freeze()


### PR DESCRIPTION
mcptool 那 123 行代码里约一半是「换个插座还要再抄一遍」的东西。抽出来，让四条不变量想忘也忘不掉。

## 抽的边界是照两个真实样本划的

不是猜的 —— 一个是已经写完的 `mcptool`，一个是 bkn-backend 里 httproute 将来的样子：

| | mcptool | httproute（bkn-backend） |
|---|---|---|
| 键 | 工具名 | method + path |
| schema | 有，`PatchInput` 要打补丁 | 没有 |
| 拒绝形态 | 伪装成 mcp-go 的未知工具 | 404 |
| 装饰 | 改结果对象 | 改响应字节 |
| 挂载 | 一个 MCP server | **同一路由挂两个 group**（`/api/bkn-backend` 与 `/api/ontology-manager`） |

差异全在「entry 是什么、怎么服务、拒绝长什么样、挂到哪儿」。最后一条尤其说明问题：**挂载位置根本不该由插座决定**。

重合的只有四条，而且全是不变量：

1. 注册必须在装配窗口内，服务开始之后不行
2. 每个 entry 必须声明所属能力与最低档位
3. 重复键必须炸 —— 第二个会静默替换第一个
4. 列举必须稳定排序 —— 工具目录和路由表要跨重启、跨副本比对

第三个插座上来时最容易漏的恰恰是这几条。

## API

```go
func New[T any](kind string) *Registry[T]
func (r *Registry[T]) Add(key, capability string, min licverify.Edition, item T)
func (r *Registry[T]) Get(key string) (T, bool)
func (r *Registry[T]) All() []T        // 按 key 排序
func (r *Registry[T]) Len() int
func (r *Registry[T]) ResetForTest()   // testing.Testing() 硬拦
```

**它对 T 一无所知** —— 不检视、不过滤、不知道什么叫拒绝。`kind` 只用于 panic 文案：`mcptool: tool "search_schema" registered twice` 能指明去哪儿看，`socket: duplicate key` 不能。

## 两个刻意的决定

**注册不看证书。** 与 `entitlement` 一致：社区档进程也要把二进制里有的全装上，否则之后装的证书永远等不到生效，只能重启 —— 而补证多发生在客户现场。

**零 MinEdition 的检查留在 `entitlement.MarkAssembled`**，不在这里重复。那是「付费 entry 悄悄变免费」的唯一入口，检查点只该有一个。

## 效果

`mcptool.go` 123 行代码 → **87 行**，少的 36 行全是机制。（那部分改动在 #566 里，本 PR 只加包。）

## 验证

`go build` / `go vet` / `go test` 全过，10 条测试覆盖：重复键、缺能力名、零 MinEdition、Freeze 后注册、注册不看证书、`All()` 按 key 排而非按注册顺序、空键、`ResetForTest` 后可重新注册。

🤖 Generated with [Claude Code](https://claude.com/claude-code)