### PR TITLE
PR 标题： fix(bkn-safe): 为 admin 角色补充角色查看权限 

### DIFF
--- a/bkn-safe/server/internal/seed/data/grants.json
+++ b/bkn-safe/server/internal/seed/data/grants.json
@@ -31,6 +31,13 @@
       "id_pattern": "*",
       "operations": ["view", "create", "edit", "delete", "members"]
     },
+    {
+      "role_id": "d2bd2082-ad03-11e8-aa06-000c29358ad6",
+      "role_name": "admin",
+      "resource_type": "admin-role",
+      "id_pattern": "*",
+      "operations": ["view"]
+    },
 
     {
       "role_id": "d8998f72-ad03-11e8-aa06-000c29358ad6",

--- a/bkn-safe/server/internal/seed/seed_test.go
+++ b/bkn-safe/server/internal/seed/seed_test.go
@@ -149,11 +149,11 @@ func TestSeededRoleGrants(t *testing.T) {
 	}
 }
 
-// TestOwnerRoleCombinationKeepsMenuAndBackendPermissionsAligned verifies the
-// role combination used by the user-management regression: the admin role
-// supplies the system role-catalog read point while business roles retain
-// model display access. It must not gain role-management write permissions.
-func TestOwnerRoleCombinationKeepsMenuAndBackendPermissionsAligned(t *testing.T) {
+// TestAdminRoleCombinationGrantsRoleCatalogRead verifies the role combination
+// used by the user-management regression: the admin role supplies the system
+// role-catalog read point while business roles retain model display access.
+// It must not gain role-management write permissions.
+func TestAdminRoleCombinationGrantsRoleCatalogRead(t *testing.T) {
 	db := newDB(t)
 	e, err := authz.New(db)
 	if err != nil {

--- a/bkn-safe/server/internal/seed/seed_test.go
+++ b/bkn-safe/server/internal/seed/seed_test.go
@@ -112,6 +112,7 @@ func TestSeededRoleGrants(t *testing.T) {
 		want                    bool
 	}{
 		{"admin manages users", admin, "admin-user", "x", "create", true},
+		{"admin views role catalog for user management", admin, "admin-role", "x", "view", true},
 		{"admin not role grant", admin, "admin-authz", "x", "grant", false},
 		{"security manages roles", security, "admin-role", "x", "create", true},
 		{"security configures role permissions", security, "admin-role", "x", "permissions", true},
@@ -144,6 +145,52 @@ func TestSeededRoleGrants(t *testing.T) {
 		}
 		if got != c.want {
 			t.Errorf("%s: Check(%s, %s:%s, %s) = %v, want %v", c.name, c.role, c.typ, c.id, c.op, got, c.want)
+		}
+	}
+}
+
+// TestOwnerRoleCombinationKeepsMenuAndBackendPermissionsAligned verifies the
+// role combination used by the user-management regression: the admin role
+// supplies the system role-catalog read point while business roles retain
+// model display access. It must not gain role-management write permissions.
+func TestOwnerRoleCombinationKeepsMenuAndBackendPermissionsAligned(t *testing.T) {
+	db := newDB(t)
+	e, err := authz.New(db)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := Apply(db, e); err != nil {
+		t.Fatal(err)
+	}
+
+	const owner = "owner-regression"
+	for _, roleID := range []string{
+		"d2bd2082-ad03-11e8-aa06-000c29358ad6", // admin
+		"1572fb82-526f-11f0-bde6-e674ec8dde71", // network_builder
+		"b5f9ac3e-992c-4bbd-8126-95e87e51c46e", // normal_user
+	} {
+		if err := e.AssignRole(owner, roleID); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	checks := []struct {
+		name, resourceType, operation string
+		want                          bool
+	}{
+		{"role catalog read", "admin-role", "view", true},
+		{"user list read", "admin-user", "view", true},
+		{"large model display", "large_model", "display", true},
+		{"role creation remains restricted", "admin-role", "create", false},
+		{"role permission changes remain restricted", "admin-role", "permissions", false},
+	}
+	for _, tc := range checks {
+		got, err := e.Check(owner, tc.resourceType, "*", tc.operation)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if got != tc.want {
+			t.Errorf("%s: Check(%s, %s:*, %s) = %v, want %v", tc.name, owner, tc.resourceType, tc.operation, got, tc.want)
 		}
 	}
 }


### PR DESCRIPTION
fix(bkn-safe): 为 admin 角色补充角色查看权限

# Pull Request

## What Changed

为 bkn-safe 的 admin 角色增加角色目录查看权限 admin-role:view。

- [x] bkn-safe 角色权限修复
- [ ] 模型统计相关修改
- [ ] 前端菜单相关修改

---

## Why

- Related Issue: 待补充
- Related Feature: 无
- Background:

绑定 admin 角色的用户进入“系统管理 → 用户管理”页面时，接口返回：

not authorized for admin-role:view

原因是 admin 角色虽然具备用户管理和部门管理权限，但缺少角色目录查看权限。用户管理页面需要调用：

GET /api/safe/v1/admin/roles

该接口要求调用者具备 admin-role:view，因此出现页面入口可见但接口鉴权失败的问题。

---

## How

- Key implementation points:

为 admin 角色增加以下权限：

resource_type: admin-role
id_pattern: *
operation: view

即：

admin-role:view

该权限允许 admin 角色查看角色列表、角色详情及角色相关只读信息。

本次不增加以下角色管理权限：

admin-role:create
admin-role:edit
admin-role:delete
admin-role:permissions

- Breaking changes (API, config, database, etc.):

无 API 结构变更。

角色权限种子配置发生变更，部署后需要重新启动 bkn-safe 或执行权限种子同步，使新增权限写入 Casbin/权限数据库。

---

## Testing

- [ ] Unit tests passed locally
- [ ] Integration tests passed locally
- [ ] Verified in test environment

Test notes:

- 验证 admin 角色具备 admin-role:view 后，可以访问 GET /api/safe/v1/admin/roles。
- 验证 admin 角色仍不具备角色创建、编辑、删除和权限配置权限。
- 未修改模型统计、模型管理或模型相关权限逻辑。

本地测试命令：

cd bkn-safe/server
go test ./internal/seed ./internal/httpapi

---

## Risk & Rollback

- Potential risks:

仅扩大 admin 角色的角色目录只读权限，不涉及角色写操作，不会改变普通用户权限。

- Rollback plan:

删除 grants.json 中 admin 角色对应的 admin-role:view 权限配置，并重新执行 bkn-safe 权限种子同步或回滚部署版本。

---

## Additional Notes

- 本 PR 仅修复 admin-role:view 权限缺失问题。
- 模型统计页面数据为空的问题不在本 PR 范围内，未修改相关代码。
- 建议部署后使用具备 admin 角色的用户重新登录，并确认 /api/safe/v1/me/permissions 返回 admin-role:view。