### PR TITLE
feat(bkn-trace): enforce record-scoped trace authorization

### DIFF
--- a/bkn-trace/agent-observability/charts/agent-observability/templates/deployment.yaml
+++ b/bkn-trace/agent-observability/charts/agent-observability/templates/deployment.yaml
@@ -76,6 +76,10 @@ spec:
               value: {{ ternary "true" "false" .Values.evidence.rawTraceQuery.enabled | quote }}
             - name: BKN_TRACE_ALLOW_UNAUTHENTICATED_QUERY
               value: {{ ternary "true" "false" .Values.evidence.queryAuth.allowUnauthenticated | quote }}
+            - name: BKN_SAFE_BASE_URL
+              value: {{ required "bknSafe.baseURL is required" .Values.bknSafe.baseURL | quote }}
+            - name: BKN_SAFE_ACCESS_TIMEOUT
+              value: {{ .Values.bknSafe.accessTimeout | quote }}
             {{- if .Values.evidence.queryAuth.hydraAdminURL }}
             - name: BKN_TRACE_HYDRA_ADMIN_URL
               value: {{ .Values.evidence.queryAuth.hydraAdminURL | quote }}

--- a/bkn-trace/agent-observability/charts/agent-observability/values.yaml
+++ b/bkn-trace/agent-observability/charts/agent-observability/values.yaml
@@ -59,6 +59,10 @@ evidence:
     hydraAdminURL: http://bkn-safe-hydra-admin:4445
     allowUnauthenticated: false
 
+bknSafe:
+  baseURL: http://bkn-safe:3000
+  accessTimeout: 3s
+
 businessResolver:
   # Opt in only when the deployment can reach the BKN and Vega authorization-aware APIs.
   # When disabled, business refs and operation-business edges are returned as empty arrays

--- a/bkn-trace/agent-observability/docs/swagger/docs.go
+++ b/bkn-trace/agent-observability/docs/swagger/docs.go
@@ -16,6 +16,44 @@ const docTemplate = `{
     "host": "{{.Host}}",
     "basePath": "{{.BasePath}}",
     "paths": {
+        "/access-profile": {
+            "get": {
+                "description": "Returns server-derived page capabilities and a scope fingerprint. Roles and managed resource identifiers are never accepted from or disclosed to the client.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "access"
+                ],
+                "summary": "Get the current BKN Trace access profile",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/rdto.AccessProfileResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/rdto.ErrorResponse"
+                        }
+                    },
+                    "405": {
+                        "description": "Method Not Allowed",
+                        "schema": {
+                            "$ref": "#/definitions/rdto.ErrorResponse"
+                        }
+                    },
+                    "503": {
+                        "description": "Service Unavailable",
+                        "schema": {
+                            "$ref": "#/definitions/rdto.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/conversations": {
             "get": {
                 "produces": [
@@ -2916,6 +2954,9 @@ const docTemplate = `{
                 "agent_or_app": {
                     "type": "string"
                 },
+                "application_principal_id": {
+                    "type": "string"
+                },
                 "artifact_id": {
                     "type": "string"
                 },
@@ -2956,11 +2997,20 @@ const docTemplate = `{
                 "content_type": {
                     "type": "string"
                 },
+                "effective_subject_id": {
+                    "type": "string"
+                },
                 "initiator": {
                     "type": "string"
                 },
                 "interaction_id": {
                     "type": "string"
+                },
+                "knowledge_network_ids": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
                 },
                 "observed_at": {
                     "type": "string"
@@ -3946,6 +3996,32 @@ const docTemplate = `{
                     "type": "string"
                 },
                 "replayed": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "rdto.AccessProfileResponse": {
+            "type": "object",
+            "properties": {
+                "access_scope_fingerprint": {
+                    "type": "string"
+                },
+                "business_provenance_managed_networks": {
+                    "type": "boolean"
+                },
+                "business_provenance_own": {
+                    "type": "boolean"
+                },
+                "global_log_search": {
+                    "type": "boolean"
+                },
+                "management_audit": {
+                    "type": "boolean"
+                },
+                "security_audit": {
+                    "type": "boolean"
+                },
+                "technical_trace": {
                     "type": "boolean"
                 }
             }

--- a/bkn-trace/agent-observability/docs/swagger/swagger.json
+++ b/bkn-trace/agent-observability/docs/swagger/swagger.json
@@ -8,6 +8,44 @@
     },
     "basePath": "/api/agent-observability/v1",
     "paths": {
+        "/access-profile": {
+            "get": {
+                "description": "Returns server-derived page capabilities and a scope fingerprint. Roles and managed resource identifiers are never accepted from or disclosed to the client.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "access"
+                ],
+                "summary": "Get the current BKN Trace access profile",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/rdto.AccessProfileResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/rdto.ErrorResponse"
+                        }
+                    },
+                    "405": {
+                        "description": "Method Not Allowed",
+                        "schema": {
+                            "$ref": "#/definitions/rdto.ErrorResponse"
+                        }
+                    },
+                    "503": {
+                        "description": "Service Unavailable",
+                        "schema": {
+                            "$ref": "#/definitions/rdto.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/conversations": {
             "get": {
                 "produces": [
@@ -2908,6 +2946,9 @@
                 "agent_or_app": {
                     "type": "string"
                 },
+                "application_principal_id": {
+                    "type": "string"
+                },
                 "artifact_id": {
                     "type": "string"
                 },
@@ -2948,11 +2989,20 @@
                 "content_type": {
                     "type": "string"
                 },
+                "effective_subject_id": {
+                    "type": "string"
+                },
                 "initiator": {
                     "type": "string"
                 },
                 "interaction_id": {
                     "type": "string"
+                },
+                "knowledge_network_ids": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
                 },
                 "observed_at": {
                     "type": "string"
@@ -3938,6 +3988,32 @@
                     "type": "string"
                 },
                 "replayed": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "rdto.AccessProfileResponse": {
+            "type": "object",
+            "properties": {
+                "access_scope_fingerprint": {
+                    "type": "string"
+                },
+                "business_provenance_managed_networks": {
+                    "type": "boolean"
+                },
+                "business_provenance_own": {
+                    "type": "boolean"
+                },
+                "global_log_search": {
+                    "type": "boolean"
+                },
+                "management_audit": {
+                    "type": "boolean"
+                },
+                "security_audit": {
+                    "type": "boolean"
+                },
+                "technical_trace": {
                     "type": "boolean"
                 }
             }

--- a/bkn-trace/agent-observability/src/boot/bootstrap.go
+++ b/bkn-trace/agent-observability/src/boot/bootstrap.go
@@ -21,6 +21,7 @@ import (
 	"github.com/openbkn-ai/bkn-foundry/bkn-trace/agent-observability/src/domain/service/sessionsvc"
 	"github.com/openbkn-ai/bkn-foundry/bkn-trace/agent-observability/src/domain/service/tracesvc"
 	mariadbsessionstore "github.com/openbkn-ai/bkn-foundry/bkn-trace/agent-observability/src/drivenadapter/dbaccess/mariadb/sessionstore"
+	"github.com/openbkn-ai/bkn-foundry/bkn-trace/agent-observability/src/drivenadapter/httpaccess/bknsafeaccess"
 	"github.com/openbkn-ai/bkn-foundry/bkn-trace/agent-observability/src/drivenadapter/httpaccess/businessresolver"
 	"github.com/openbkn-ai/bkn-foundry/bkn-trace/agent-observability/src/drivenadapter/httpaccess/opensearchevidencestore"
 	"github.com/openbkn-ai/bkn-foundry/bkn-trace/agent-observability/src/drivenadapter/httpaccess/opensearchprojection"
@@ -81,7 +82,12 @@ func NewApp() (*App, error) {
 		resolver = businessresolver.New(resolverConfig.BKNBaseURL, resolverConfig.VegaBaseURL, &http.Client{Timeout: resolverConfig.Timeout})
 		evidenceService = evidencesvc.NewWithBusinessResolver(evidenceStore, resolver)
 	}
-	evidenceHandler := httphandler.NewEvidenceHandler(evidenceService)
+	accessScopeConfig := conf.NewAccessScopeConfig()
+	accessScopeResolver := bknsafeaccess.New(
+		accessScopeConfig.BKNBaseURL,
+		&http.Client{Timeout: accessScopeConfig.Timeout},
+	)
+	evidenceHandler := httphandler.NewEvidenceHandlerWithAuthorizationScopeResolver(evidenceService, accessScopeResolver)
 	coreConfig := conf.NewCoreConfig()
 	metrics := coremetrics.New()
 	sessionStore, ledgerStore, closeDatabase, err := newCoreStores(coreConfig)
@@ -321,6 +327,7 @@ func newApp(
 	mux.HandleFunc(APIBasePath+"/evidence/artifacts/", readAuth(evidenceHandler.GetEvidenceArtifact))
 	mux.HandleFunc(APIBasePath+"/evidence/by-trace", readAuth(evidenceHandler.SearchEvidenceByTrace))
 	mux.HandleFunc(APIBasePath+"/trace-executions", readAuth(evidenceHandler.ListTraceExecutions))
+	mux.HandleFunc(APIBasePath+"/access-profile", readAuth(evidenceHandler.GetAccessProfile))
 	httphandler.RegisterSessionRoutes(
 		mux, APIBasePath, sessionHandler, evidenceHandler.RequireTrustedLifecycleIdentity,
 	)

--- a/bkn-trace/agent-observability/src/conf/access_scope.go
+++ b/bkn-trace/agent-observability/src/conf/access_scope.go
@@ -1,0 +1,24 @@
+package conf
+
+import (
+	"os"
+	"strings"
+	"time"
+)
+
+type AccessScopeConfig struct {
+	BKNBaseURL string
+	Timeout    time.Duration
+}
+
+func NewAccessScopeConfig() AccessScopeConfig {
+	baseURL := strings.TrimRight(strings.TrimSpace(os.Getenv("BKN_SAFE_BASE_URL")), "/")
+	if baseURL == "" {
+		baseURL = "http://bkn-safe:3000"
+	}
+	timeout := 3 * time.Second
+	if configured, err := time.ParseDuration(strings.TrimSpace(os.Getenv("BKN_SAFE_ACCESS_TIMEOUT"))); err == nil && configured > 0 {
+		timeout = configured
+	}
+	return AccessScopeConfig{BKNBaseURL: baseURL, Timeout: timeout}
+}

--- a/bkn-trace/agent-observability/src/conf/access_scope.go
+++ b/bkn-trace/agent-observability/src/conf/access_scope.go
@@ -1,6 +1,7 @@
 package conf
 
 import (
+	"log/slog"
 	"os"
 	"strings"
 	"time"
@@ -17,8 +18,13 @@ func NewAccessScopeConfig() AccessScopeConfig {
 		baseURL = "http://bkn-safe:3000"
 	}
 	timeout := 3 * time.Second
-	if configured, err := time.ParseDuration(strings.TrimSpace(os.Getenv("BKN_SAFE_ACCESS_TIMEOUT"))); err == nil && configured > 0 {
-		timeout = configured
+	if value := strings.TrimSpace(os.Getenv("BKN_SAFE_ACCESS_TIMEOUT")); value != "" {
+		configured, err := time.ParseDuration(value)
+		if err != nil || configured <= 0 {
+			slog.Warn("invalid BKN Safe access timeout; using default", "value", value, "default", timeout)
+		} else {
+			timeout = configured
+		}
 	}
 	return AccessScopeConfig{BKNBaseURL: baseURL, Timeout: timeout}
 }

--- a/bkn-trace/agent-observability/src/conf/access_scope_test.go
+++ b/bkn-trace/agent-observability/src/conf/access_scope_test.go
@@ -1,0 +1,24 @@
+package conf
+
+import (
+	"testing"
+	"time"
+)
+
+func TestNewAccessScopeConfigUsesFailClosedSafeDefaults(t *testing.T) {
+	t.Setenv("BKN_SAFE_BASE_URL", "")
+	t.Setenv("BKN_SAFE_ACCESS_TIMEOUT", "")
+	config := NewAccessScopeConfig()
+	if config.BKNBaseURL != "http://bkn-safe:3000" || config.Timeout != 3*time.Second {
+		t.Fatalf("unexpected defaults: %+v", config)
+	}
+}
+
+func TestNewAccessScopeConfigReadsSafeEndpointAndTimeout(t *testing.T) {
+	t.Setenv("BKN_SAFE_BASE_URL", "http://safe.internal:3100/")
+	t.Setenv("BKN_SAFE_ACCESS_TIMEOUT", "750ms")
+	config := NewAccessScopeConfig()
+	if config.BKNBaseURL != "http://safe.internal:3100" || config.Timeout != 750*time.Millisecond {
+		t.Fatalf("unexpected configured values: %+v", config)
+	}
+}

--- a/bkn-trace/agent-observability/src/conf/authz.go
+++ b/bkn-trace/agent-observability/src/conf/authz.go
@@ -12,37 +12,21 @@ import (
 // Rollout is staged, per the compatibility rule (default permissive -> shadow
 // log -> flip to enforce):
 //
-//   - Enforce=false (default): a request without a resolvable account identity
+//   - Enforce=false (explicit development override): a request without a resolvable account identity
 //     is allowed but logged; a normal caller's query is NOT actually scoped,
 //     only logged as "would be scoped". This surfaces the access pattern and
 //     confirms the gateway injects account baggage before anything is blocked.
 //   - Enforce=true (TRACE_READ_AUTHZ_ENFORCE=true): a request without identity
 //     is rejected 401; a normal caller's query is scoped to their own account.
-//
-// Admin-class account types (super_admin/admin/audit by default) always see
-// every account's traces — diagnose and audit are cross-account by nature.
 type TraceReadAuthzConfig struct {
-	Enforce    bool
-	AdminTypes map[string]bool
+	Enforce bool
 }
 
 // NewTraceReadAuthzConfig reads the config from the environment.
 //
-//	TRACE_READ_AUTHZ_ENFORCE=true|false   (default false — shadow mode)
-//	TRACE_READ_AUTHZ_ADMIN_TYPES=a,b,c    (default super_admin,admin,audit)
+//	TRACE_READ_AUTHZ_ENFORCE=true|false   (default true)
 func NewTraceReadAuthzConfig() TraceReadAuthzConfig {
-	admin := map[string]bool{}
-	raw := strings.TrimSpace(os.Getenv("TRACE_READ_AUTHZ_ADMIN_TYPES"))
-	if raw == "" {
-		raw = "super_admin,admin,audit"
-	}
-	for _, t := range strings.Split(raw, ",") {
-		if t = strings.TrimSpace(t); t != "" {
-			admin[t] = true
-		}
-	}
 	return TraceReadAuthzConfig{
-		Enforce:    os.Getenv("TRACE_READ_AUTHZ_ENFORCE") == "true",
-		AdminTypes: admin,
+		Enforce: !strings.EqualFold(strings.TrimSpace(os.Getenv("TRACE_READ_AUTHZ_ENFORCE")), "false"),
 	}
 }

--- a/bkn-trace/agent-observability/src/conf/authz.go
+++ b/bkn-trace/agent-observability/src/conf/authz.go
@@ -9,14 +9,14 @@ import (
 // The evidence WRITE endpoint keeps its own ingest-token guard; this only
 // concerns who may read traces.
 //
-// Rollout is staged, per the compatibility rule (default permissive -> shadow
-// log -> flip to enforce):
+// Authorization is enforced by default. Enforce=false is an explicit local
+// development override, not a production rollout mode:
 //
-//   - Enforce=false (explicit development override): a request without a resolvable account identity
+//   - Enforce=false: a request without a resolvable account identity
 //     is allowed but logged; a normal caller's query is NOT actually scoped,
 //     only logged as "would be scoped". This surfaces the access pattern and
-//     confirms the gateway injects account baggage before anything is blocked.
-//   - Enforce=true (TRACE_READ_AUTHZ_ENFORCE=true): a request without identity
+//     can be used for local gateway integration diagnostics.
+//   - Enforce=true (default): a request without identity
 //     is rejected 401; a normal caller's query is scoped to their own account.
 type TraceReadAuthzConfig struct {
 	Enforce bool

--- a/bkn-trace/agent-observability/src/conf/authz_test.go
+++ b/bkn-trace/agent-observability/src/conf/authz_test.go
@@ -1,0 +1,12 @@
+package conf
+
+import "testing"
+
+func TestTraceReadAuthzDefaultsFailClosedWithoutAdminBypass(t *testing.T) {
+	t.Setenv("TRACE_READ_AUTHZ_ENFORCE", "")
+	t.Setenv("TRACE_READ_AUTHZ_ADMIN_TYPES", "super_admin,admin,audit")
+	config := NewTraceReadAuthzConfig()
+	if !config.Enforce {
+		t.Fatal("trace reads must default to enforced identity scoping")
+	}
+}

--- a/bkn-trace/agent-observability/src/domain/service/assemblysvc/query_service.go
+++ b/bkn-trace/agent-observability/src/domain/service/assemblysvc/query_service.go
@@ -85,6 +85,7 @@ func (s *QueryService) GetInteractionAuthorized(
 	scope evidencevo.QueryScope,
 ) (InteractionView, error) {
 	var interaction sessionvo.Interaction
+	var recordOwner sessionvo.Owner
 	var revision *sessionvo.AssemblyRevision
 	var claimIDs []string
 	err := s.sessions.WithinTransaction(ctx, func(tx isessionstore.Transaction) error {
@@ -93,9 +94,13 @@ func (s *QueryService) GetInteractionAuthorized(
 			return ErrNotFound
 		}
 		conversation, found := tx.FindConversation(current.ConversationID)
-		if !found || !conversation.Owner.Equal(owner) {
+		if !found {
 			return ErrNotFound
 		}
+		if scope.AccessProfile == nil && !conversation.Owner.Equal(owner) {
+			return ErrNotFound
+		}
+		recordOwner = conversation.Owner
 		interaction = current
 		if current.ClosureManifest != nil {
 			claimIDs = append([]string(nil), current.ClosureManifest.Claims...)
@@ -110,14 +115,21 @@ func (s *QueryService) GetInteractionAuthorized(
 	if err != nil {
 		return InteractionView{}, err
 	}
-	events, err := s.ledger.ListInteractionEvents(ctx, owner, interactionID)
+	events, err := s.ledger.ListInteractionEvents(ctx, recordOwner, interactionID)
 	if err != nil {
 		return InteractionView{}, err
 	}
 	if revision != nil {
 		events = eventsInRevision(events, revision.IncludedEventIDs)
 	}
-	externalEvidence, err := s.loadPriorEvidence(ctx, owner, interaction, events)
+	if scope.AccessProfile != nil && !evidencevo.CanReadRecord(
+		*scope.AccessProfile,
+		interactionRecordScope(recordOwner, events),
+		evidencevo.AccessViewBusiness,
+	) {
+		return InteractionView{}, ErrNotFound
+	}
+	externalEvidence, err := s.loadPriorEvidence(ctx, recordOwner, interaction, events)
 	if err != nil {
 		return InteractionView{}, err
 	}
@@ -126,6 +138,21 @@ func (s *QueryService) GetInteractionAuthorized(
 		Interaction: interaction, Revision: revision,
 		Assembly: s.projectBusinessRefs(ctx, scope, assembled),
 	}, nil
+}
+
+func interactionRecordScope(owner sessionvo.Owner, events []ledgervo.Event) evidencevo.RecordScope {
+	refs := make([]string, 0)
+	for _, event := range events {
+		for _, ref := range event.BusinessRefs {
+			refs = append(refs, ref.RefID)
+		}
+	}
+	return evidencevo.RecordScope{
+		TenantID: owner.TenantID, BusinessDomain: owner.BusinessDomainID,
+		EffectiveSubjectID:     owner.EffectiveSubjectID,
+		ApplicationPrincipalID: owner.ApplicationPrincipalID,
+		KnowledgeNetworkIDs:    evidencevo.KnowledgeNetworkIDsFromRefs(refs),
+	}
 }
 
 type priorSupportSource struct {
@@ -240,13 +267,18 @@ func (s *QueryService) projectBusinessRefs(ctx context.Context, scope evidencevo
 	viewsByKey := make(map[string]BusinessRefView, len(assembled.BusinessRefs))
 	for _, ref := range assembled.BusinessRefs {
 		resolution, found := resolutions[resolverRefKey(string(ref.RefType), ref.RefID, sourceSystemForBusinessRef(ref))]
-		if !found || (resolution.Visibility != "visible" && resolution.Visibility != "redacted") {
-			if resolveErr == nil && (!found || resolution.Visibility == "unresolved" || resolution.Visibility == "") {
-				disclosureReasons["business_ref_unresolved"] = struct{}{}
+		status := "unresolved"
+		var display *evidencevo.BusinessDisplay
+		if found && resolution.Display != nil {
+			display = resolution.Display
+			status = resolution.Display.ResolutionStatus
+			if status == "" {
+				status = "resolved"
 			}
-			continue
+		} else {
+			disclosureReasons["business_ref_unresolved"] = struct{}{}
 		}
-		view := BusinessRefView{TechnicalRef: ref, DisclosureStatus: resolution.Visibility, Display: resolution.Display}
+		view := BusinessRefView{TechnicalRef: ref, DisclosureStatus: status, Display: display}
 		viewsByKey[businessRefKey(ref)] = view
 		projected.BusinessRefs = append(projected.BusinessRefs, view)
 	}

--- a/bkn-trace/agent-observability/src/domain/service/assemblysvc/query_service.go
+++ b/bkn-trace/agent-observability/src/domain/service/assemblysvc/query_service.go
@@ -141,11 +141,14 @@ func (s *QueryService) GetInteractionAuthorized(
 }
 
 func interactionRecordScope(owner sessionvo.Owner, events []ledgervo.Event) evidencevo.RecordScope {
-	// Ledger BusinessRefs are the validated authorization boundary; the opaque Envelope is not scanned.
+	// The authorization boundary covers every ref assemble can disclose; the opaque Envelope is not scanned.
 	refs := make([]string, 0)
 	for _, event := range events {
 		for _, ref := range event.BusinessRefs {
 			refs = append(refs, ref.RefID)
+		}
+		for _, edge := range event.OperationBusinessEdges {
+			refs = append(refs, edge.BusinessRef.RefID)
 		}
 	}
 	return evidencevo.RecordScope{

--- a/bkn-trace/agent-observability/src/domain/service/assemblysvc/query_service.go
+++ b/bkn-trace/agent-observability/src/domain/service/assemblysvc/query_service.go
@@ -141,6 +141,7 @@ func (s *QueryService) GetInteractionAuthorized(
 }
 
 func interactionRecordScope(owner sessionvo.Owner, events []ledgervo.Event) evidencevo.RecordScope {
+	// Ledger BusinessRefs are the validated authorization boundary; the opaque Envelope is not scanned.
 	refs := make([]string, 0)
 	for _, event := range events {
 		for _, ref := range event.BusinessRefs {

--- a/bkn-trace/agent-observability/src/domain/service/assemblysvc/query_service_test.go
+++ b/bkn-trace/agent-observability/src/domain/service/assemblysvc/query_service_test.go
@@ -102,7 +102,62 @@ func TestQueryUsesLatestImmutableRevisionEventSetAndEnforcesOwner(t *testing.T) 
 	}
 }
 
-func TestQueryProjectsAuthorizedBusinessNamesWithoutChangingAssemblyCompleteness(t *testing.T) {
+func TestQueryAuthorizesManagedKnowledgeNetworkInteraction(t *testing.T) {
+	t.Parallel()
+
+	sessions, ledger, owner, interaction := queryFixture(t)
+	profile := evidencevo.AccessProfile{
+		TenantID: "tenant-1", BusinessDomain: "domain-1", EffectiveSubjectID: "builder-1",
+		Roles: []string{"network_builder"}, ManagedKnowledgeNetworkIDs: []string{"supplychain"},
+		AccountActive: true, TenantActive: true,
+	}
+	requester := owner
+	requester.EffectiveSubjectID = profile.EffectiveSubjectID
+	view, err := assemblysvc.NewQueryService(sessions, ledger).GetInteractionAuthorized(
+		context.Background(), requester, interaction.ID,
+		evidencevo.QueryScope{AccessProfile: &profile, View: evidencevo.AccessViewBusiness},
+	)
+	if err != nil {
+		t.Fatalf("network builder query managed interaction: %v", err)
+	}
+	if view.Interaction.ID != interaction.ID {
+		t.Fatalf("unexpected interaction: %#v", view.Interaction)
+	}
+}
+
+func TestQueryRejectsInteractionOutsideManagedKnowledgeNetworkScope(t *testing.T) {
+	t.Parallel()
+
+	sessions, ledger, owner, interaction := queryFixture(t)
+	tests := map[string]evidencevo.AccessProfile{
+		"partial network scope": {
+			TenantID: "tenant-1", BusinessDomain: "domain-1", EffectiveSubjectID: "builder-1",
+			Roles: []string{"network_builder"}, ManagedKnowledgeNetworkIDs: []string{"other-network"},
+			AccountActive: true, TenantActive: true,
+		},
+		"platform admin cannot read business body": {
+			TenantID: "tenant-1", BusinessDomain: "domain-1", EffectiveSubjectID: "admin-1",
+			Roles: []string{"admin"}, AccountActive: true, TenantActive: true,
+		},
+	}
+	for name, profile := range tests {
+		name, profile := name, profile
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			requester := owner
+			requester.EffectiveSubjectID = profile.EffectiveSubjectID
+			_, err := assemblysvc.NewQueryService(sessions, ledger).GetInteractionAuthorized(
+				context.Background(), requester, interaction.ID,
+				evidencevo.QueryScope{AccessProfile: &profile, View: evidencevo.AccessViewBusiness},
+			)
+			if err != assemblysvc.ErrNotFound {
+				t.Fatalf("out-of-scope interaction must use non-disclosure response, got %v", err)
+			}
+		})
+	}
+}
+
+func TestQueryProjectsResolvedBusinessNamesWithoutChangingRecordAuthorization(t *testing.T) {
 	t.Parallel()
 
 	sessions, ledger, owner, interaction := queryFixture(t)
@@ -127,24 +182,32 @@ func TestQueryProjectsAuthorizedBusinessNamesWithoutChangingAssemblyCompleteness
 	if view.Assembly.Completeness != sessionvo.EvidenceNotApplicable {
 		t.Fatalf("disclosure changed objective assembly completeness: %s", view.Assembly.Completeness)
 	}
-	if len(view.Assembly.BusinessRefs) != 1 {
-		t.Fatalf("unauthorized ref count leaked or visible ref missing: %#v", view.Assembly.BusinessRefs)
+	if len(view.Assembly.BusinessRefs) != 2 {
+		t.Fatalf("resolver visibility must not remove record-authorized technical refs: %#v", view.Assembly.BusinessRefs)
 	}
 	projected := view.Assembly.BusinessRefs[0]
 	if projected.Display == nil || projected.Display.Name != "需求预测单" ||
-		projected.TechnicalRef.Version != "2026.07" || projected.DisclosureStatus != "visible" {
-		t.Fatalf("authorized business display or technical ref missing: %#v", projected)
+		projected.TechnicalRef.Version != "2026.07" || projected.DisclosureStatus != "resolved" {
+		t.Fatalf("resolved business display or technical ref missing: %#v", projected)
 	}
-	if len(view.Assembly.OperationBusinessEdges) != 1 ||
-		view.Assembly.OperationBusinessEdges[0].BusinessRef.TechnicalRef.RefID != "object:supplychain:forecast" {
-		t.Fatalf("operation edge was not projected with its authorized business ref: %#v", view.Assembly.OperationBusinessEdges)
+	if view.Assembly.BusinessRefs[1].TechnicalRef.RefID != "property:supplychain:forecast:qty" ||
+		view.Assembly.BusinessRefs[1].Display != nil || view.Assembly.BusinessRefs[1].DisclosureStatus != "unresolved" {
+		t.Fatalf("unresolved resolver metadata must retain the technical ref without display: %#v", view.Assembly.BusinessRefs[1])
+	}
+	edgeRefs := map[string]bool{}
+	for _, edge := range view.Assembly.OperationBusinessEdges {
+		edgeRefs[edge.BusinessRef.TechnicalRef.RefID] = true
+	}
+	if len(view.Assembly.OperationBusinessEdges) != 2 ||
+		!edgeRefs["object:supplychain:forecast"] || !edgeRefs["property:supplychain:forecast:qty"] {
+		t.Fatalf("operation edges must retain all record-authorized business refs: %#v", view.Assembly.OperationBusinessEdges)
 	}
 	if len(resolver.requests) != 1 || resolver.requests[0].Scope.Authorization != "Bearer current-user-token" {
 		t.Fatalf("resolver did not receive current authorization scope: %#v", resolver.requests)
 	}
 }
 
-func TestQueryBusinessProjectionFailsClosedWhenResolverCannotAuthorizeRefs(t *testing.T) {
+func TestQueryBusinessProjectionKeepsTechnicalRefsWhenResolverCannotEnrichDisplay(t *testing.T) {
 	t.Parallel()
 
 	tests := map[string]func(*sessionstore.Store, *ledgerstore.Store) *assemblysvc.QueryService{
@@ -171,8 +234,8 @@ func TestQueryBusinessProjectionFailsClosedWhenResolverCannotAuthorizeRefs(t *te
 			if err != nil {
 				t.Fatalf("query projected graph: %v", err)
 			}
-			if len(view.Assembly.BusinessRefs) != 0 || len(view.Assembly.OperationBusinessEdges) != 0 {
-				t.Fatalf("unresolved authorization leaked business refs or edges: %#v", view.Assembly)
+			if len(view.Assembly.BusinessRefs) != 2 || len(view.Assembly.OperationBusinessEdges) != 2 {
+				t.Fatalf("resolver degradation must not remove record-authorized refs or edges: %#v", view.Assembly)
 			}
 			if view.Assembly.BusinessRefs == nil || view.Assembly.OperationBusinessEdges == nil {
 				t.Fatalf("empty projected collections must serialize as arrays: %#v", view.Assembly)
@@ -212,8 +275,8 @@ func TestQueryDoesNotReuseAuthorizationAcrossBusinessRefTypes(t *testing.T) {
 	if err != nil {
 		t.Fatalf("query projected graph: %v", err)
 	}
-	if len(view.Assembly.BusinessRefs) != 1 || view.Assembly.BusinessRefs[0].TechnicalRef.RefType != sessionvo.BusinessRefObjectType {
-		t.Fatalf("authorization was reused across ref types: %#v", view.Assembly.BusinessRefs)
+	if len(view.Assembly.BusinessRefs) != 3 {
+		t.Fatalf("resolver display matching must not remove technical refs of another type: %#v", view.Assembly.BusinessRefs)
 	}
 }
 

--- a/bkn-trace/agent-observability/src/domain/service/assemblysvc/query_service_test.go
+++ b/bkn-trace/agent-observability/src/domain/service/assemblysvc/query_service_test.go
@@ -125,6 +125,43 @@ func TestQueryAuthorizesManagedKnowledgeNetworkInteraction(t *testing.T) {
 	}
 }
 
+func TestQueryRejectsManagedInteractionWhenOperationEdgeReferencesUnmanagedNetwork(t *testing.T) {
+	t.Parallel()
+
+	sessions, ledger, owner, interaction := queryFixture(t)
+	edgeOnly := semanticEvent("evt-edge-only", "op-edge-only", 2)
+	edgeOnly.Owner = owner
+	edgeOnly.ConversationID = interaction.ConversationID
+	edgeOnly.InteractionID = interaction.ID
+	edgeOnly.BusinessRefs = nil
+	edgeOnly.OperationBusinessEdges = []sessionvo.OperationBusinessEdge{{
+		OperationID: edgeOnly.OperationID,
+		BusinessRef: sessionvo.BusinessRef{
+			RefType: sessionvo.BusinessRefObjectType, RefID: "object:restricted:salary",
+			BusinessDomainID: owner.BusinessDomainID, Version: "2026.07",
+		},
+		Role: sessionvo.OperationRoleRead, ObservedAt: edgeOnly.ObservedAt,
+	}}
+	if _, err := ledger.Commit(context.Background(), edgeOnly); err != nil {
+		t.Fatalf("commit edge-only business ref: %v", err)
+	}
+
+	profile := evidencevo.AccessProfile{
+		TenantID: "tenant-1", BusinessDomain: "domain-1", EffectiveSubjectID: "builder-1",
+		Roles: []string{"network_builder"}, ManagedKnowledgeNetworkIDs: []string{"supplychain"},
+		AccountActive: true, TenantActive: true,
+	}
+	requester := owner
+	requester.EffectiveSubjectID = profile.EffectiveSubjectID
+	_, err := assemblysvc.NewQueryService(sessions, ledger).GetInteractionAuthorized(
+		context.Background(), requester, interaction.ID,
+		evidencevo.QueryScope{AccessProfile: &profile, View: evidencevo.AccessViewBusiness},
+	)
+	if err != assemblysvc.ErrNotFound {
+		t.Fatalf("operation edge network must be included in all-of authorization, got %v", err)
+	}
+}
+
 func TestQueryRejectsInteractionOutsideManagedKnowledgeNetworkScope(t *testing.T) {
 	t.Parallel()
 

--- a/bkn-trace/agent-observability/src/domain/service/evidencesvc/artifact_service_test.go
+++ b/bkn-trace/agent-observability/src/domain/service/evidencesvc/artifact_service_test.go
@@ -81,7 +81,7 @@ func TestGetArtifactReturnsOwnedContentWhenBusinessResolverIsUnavailable(t *test
 		ArtifactID: "artifact_unresolved_ref_service", ArtifactType: evidencevo.ArtifactTypeDataResult,
 		RequestID: "req_unresolved_ref", TraceID: "4bf92f3577b34da6a3ce929d0e0e4736",
 		BusinessRefs: []string{"object:kn_sales:order"},
-		ContentType: "application/json", SchemaVersion: evidencevo.ArtifactContractVersion,
+		ContentType:  "application/json", SchemaVersion: evidencevo.ArtifactContractVersion,
 		ObservedAt: "2026-07-26T08:00:00Z", Content: map[string]any{"count": 12},
 		TenantID: "tenant_demo", BusinessDomain: "bd_demo", AccountID: "acct_demo", AccountType: "app",
 	})
@@ -107,7 +107,7 @@ func TestGetArtifactReturnsOwnedContentWhenBusinessResolverCannotResolveRef(t *t
 		ArtifactID: "artifact_missing_resolution_service", ArtifactType: evidencevo.ArtifactTypeDataResult,
 		RequestID: "req_missing_resolution", TraceID: "4bf92f3577b34da6a3ce929d0e0e4736",
 		BusinessRefs: []string{"object:kn_sales:order"},
-		ContentType: "application/json", SchemaVersion: evidencevo.ArtifactContractVersion,
+		ContentType:  "application/json", SchemaVersion: evidencevo.ArtifactContractVersion,
 		ObservedAt: "2026-07-26T08:00:00Z", Content: map[string]any{"count": 12},
 		TenantID: "tenant_demo", BusinessDomain: "bd_demo", AccountID: "acct_demo", AccountType: "app",
 	})
@@ -126,12 +126,12 @@ func TestGetArtifactReturnsOwnedContentWhenBusinessResolverCannotResolveRef(t *t
 	if err != nil || !found || got.Content == nil {
 		t.Fatalf("owned artifact content must remain readable when refs are unresolved: artifact=%+v found=%v err=%v", got, found, err)
 	}
-	if len(resolver.requests) != 1 {
-		t.Fatalf("resolver should still be called for audit context: %+v", resolver.requests)
+	if len(resolver.requests) != 0 {
+		t.Fatalf("artifact access must not depend on business ref resolution: %+v", resolver.requests)
 	}
 }
 
-func TestGetArtifactRequiresResolverAuthorizationForSourceAndBusinessRefs(t *testing.T) {
+func TestGetArtifactUsesRecordAuthorizationInsteadOfResolverVisibility(t *testing.T) {
 	store := evidencestore.New()
 	artifact, validationErrors := evidencevo.NormalizeArtifact(evidencevo.EvidenceArtifact{
 		ArtifactID: "artifact_resolver_guard", ArtifactType: evidencevo.ArtifactTypeDataResult,
@@ -155,20 +155,19 @@ func TestGetArtifactRequiresResolverAuthorizationForSourceAndBusinessRefs(t *tes
 		{RefID: "resource:orders", Visibility: "visible"},
 		{RefID: "object:kn_sales:order", Visibility: "unauthorized"},
 	}}
-	_, found, err := NewWithBusinessResolver(store, deniedResolver).GetArtifact(context.Background(), artifact.ArtifactID, scope)
-	if err != nil || found {
-		t.Fatalf("unauthorized business ref must hide artifact content: found=%v err=%v", found, err)
+	got, found, err := NewWithBusinessResolver(store, deniedResolver).GetArtifact(context.Background(), artifact.ArtifactID, scope)
+	if err != nil || !found || got.Content == nil {
+		t.Fatalf("record-authorized artifact must remain readable regardless of resolver visibility: artifact=%+v found=%v err=%v", got, found, err)
 	}
-	if len(deniedResolver.requests) != 1 || deniedResolver.requests[0].Scope.AccountID != "acct_demo" ||
-		deniedResolver.requests[0].Scope.BusinessDomain != "bd_demo" {
-		t.Fatalf("resolver must receive trusted account and requested domain: %+v", deniedResolver.requests)
+	if len(deniedResolver.requests) != 0 {
+		t.Fatalf("resolver must not authorize artifact content: %+v", deniedResolver.requests)
 	}
 
 	visibleResolver := &fakeBusinessResolver{resolutions: []ibusinessresolver.Resolution{
 		{RefID: "resource:orders", Visibility: "visible"},
 		{RefID: "object:kn_sales:order", Visibility: "visible"},
 	}}
-	got, found, err := NewWithBusinessResolver(store, visibleResolver).GetArtifact(context.Background(), artifact.ArtifactID, scope)
+	got, found, err = NewWithBusinessResolver(store, visibleResolver).GetArtifact(context.Background(), artifact.ArtifactID, scope)
 	if err != nil || !found || got.Content == nil {
 		t.Fatalf("fully authorized refs must expose artifact: artifact=%+v found=%v err=%v", got, found, err)
 	}

--- a/bkn-trace/agent-observability/src/domain/service/evidencesvc/service.go
+++ b/bkn-trace/agent-observability/src/domain/service/evidencesvc/service.go
@@ -308,75 +308,7 @@ func (s *Service) GetArtifact(ctx context.Context, artifactID string, scope evid
 	if err != nil || !found {
 		return evidencevo.EvidenceArtifact{}, found, err
 	}
-	authorized, err := s.authorizeArtifactRefs(ctx, artifact, scope)
-	if err != nil {
-		return evidencevo.EvidenceArtifact{}, false, err
-	}
-	if !authorized {
-		return evidencevo.EvidenceArtifact{}, false, nil
-	}
 	return artifact, true, nil
-}
-
-func (s *Service) authorizeArtifactRefs(ctx context.Context, artifact evidencevo.EvidenceArtifact, scope evidencevo.QueryScope) (bool, error) {
-	refs := make([]ibusinessresolver.BusinessRef, 0, len(artifact.BusinessRefs)+1)
-	seen := map[string]struct{}{}
-	appendRef := func(refID string) {
-		refID = strings.TrimSpace(refID)
-		if refID == "" {
-			return
-		}
-		if _, exists := seen[refID]; exists {
-			return
-		}
-		seen[refID] = struct{}{}
-		parts := strings.Split(refID, ":")
-		refType := ""
-		if len(parts) > 0 {
-			refType = parts[0]
-		}
-		refs = append(refs, ibusinessresolver.BusinessRef{RefID: refID, RefType: refType})
-	}
-	if resolverSupportsArtifactRef(artifact.SourceRef) {
-		appendRef(artifact.SourceRef)
-	}
-	for _, refID := range artifact.BusinessRefs {
-		appendRef(refID)
-	}
-	if len(refs) == 0 {
-		return true, nil
-	}
-	if s.businessResolver == nil {
-		return true, nil
-	}
-	resolutions, err := s.businessResolver.ResolveBusinessRefs(ctx, ibusinessresolver.ResolveRequest{Scope: scope, Refs: refs})
-	if err != nil {
-		return false, err
-	}
-	resolved := map[string]ibusinessresolver.Resolution{}
-	for _, resolution := range resolutions {
-		resolved[resolution.RefID] = resolution
-	}
-	for _, ref := range refs {
-		resolution, ok := resolved[ref.RefID]
-		if ok && !visibleResolution(resolution) {
-			return false, nil
-		}
-	}
-	return true, nil
-}
-
-func resolverSupportsArtifactRef(refID string) bool {
-	prefix, _, ok := strings.Cut(strings.TrimSpace(refID), ":")
-	if !ok {
-		return false
-	}
-	switch prefix {
-	case "kn", "object", "relation", "action_type", "metric", "property", "resource", "field":
-		return true
-	default:
-		return false
-	}
 }
 
 func artifactMatchesTrace(artifact evidencevo.EvidenceArtifact, trace evidencevo.NormalizedTrace) bool {
@@ -895,11 +827,6 @@ func (s *Service) buildBusinessGraph(ctx context.Context, traces []evidencevo.No
 						continue
 					}
 					resolution, resolved := resolutions[refID]
-					if resolved && !visibleResolution(resolution) {
-						countResolverVisibility(resolution.Visibility, &response.VisibilitySummary)
-						partialReasons["business_ref_"+resolution.Visibility] = struct{}{}
-						continue
-					}
 					if _, seen := businessRefs[refID]; !seen {
 						businessRefs[refID] = struct{}{}
 						response.VisibilitySummary.AuthorizedRefCount++
@@ -934,11 +861,6 @@ func (s *Service) buildBusinessGraph(ctx context.Context, traces []evidencevo.No
 						continue
 					}
 					resolution, resolved := resolutions[refID]
-					if resolved && !visibleResolution(resolution) {
-						countResolverVisibility(resolution.Visibility, &response.VisibilitySummary)
-						partialReasons["business_ref_"+resolution.Visibility] = struct{}{}
-						continue
-					}
 					if _, seen := businessRefs[refID]; !seen {
 						businessRefs[refID] = struct{}{}
 						response.VisibilitySummary.AuthorizedRefCount++
@@ -987,11 +909,6 @@ func (s *Service) buildBusinessGraph(ctx context.Context, traces []evidencevo.No
 						continue
 					}
 					resolution, resolved := resolutions[refID]
-					if resolved && !visibleResolution(resolution) {
-						countResolverVisibility(resolution.Visibility, &response.VisibilitySummary)
-						partialReasons["business_ref_"+resolution.Visibility] = struct{}{}
-						continue
-					}
 					if _, ok := businessRefs[refID]; !ok {
 						businessRefs[refID] = struct{}{}
 						response.VisibilitySummary.AuthorizedRefCount++
@@ -1159,14 +1076,6 @@ func claimedFactBusinessRefs(event evidencevo.EvidenceEvent) []any {
 func trustedQueryScope(scope evidencevo.QueryScope) bool {
 	return strings.TrimSpace(scope.AccountID) != "" && strings.TrimSpace(scope.AccountType) != "" &&
 		(strings.TrimSpace(scope.TenantID) != "" || strings.TrimSpace(scope.BusinessDomain) != "")
-}
-
-func visibleResolution(resolution ibusinessresolver.Resolution) bool {
-	return resolution.Visibility == "" || resolution.Visibility == "visible" || resolution.Visibility == "redacted"
-}
-
-func countResolverVisibility(visibility string, summary *evidencevo.VisibilitySummary) {
-	countVisibility(map[string]any{"visibility": visibility}, summary)
 }
 
 func hasBusinessExecutionEnvelope(traces []evidencevo.NormalizedTrace) bool {

--- a/bkn-trace/agent-observability/src/domain/service/evidencesvc/service_test.go
+++ b/bkn-trace/agent-observability/src/domain/service/evidencesvc/service_test.go
@@ -392,6 +392,24 @@ func TestDirectKnowledgeReadExposesBusinessRefsWithoutFabricatingClaim(t *testin
 	}
 }
 
+func TestIngestPersistsDerivedKnowledgeNetworkScope(t *testing.T) {
+	store := evidencestore.New()
+	ingested, validationErrors, err := New(store).Ingest(
+		context.Background(),
+		mustJSON(t, twoPointOneBatch(validTwoPointOneEvents())),
+	)
+	if err != nil || len(validationErrors) > 0 {
+		t.Fatalf("ingest failed: errors=%+v err=%v", validationErrors, err)
+	}
+	stored, err := store.GetEvidenceByTraceID(context.Background(), ingested.TraceID, evidencevo.EvidenceQueryOptions{})
+	if err != nil || len(stored.Traces) != 1 {
+		t.Fatalf("load stored trace: result=%+v err=%v", stored, err)
+	}
+	if !reflect.DeepEqual(stored.Traces[0].KnowledgeNetworkIDs, []string{"supplychain"}) {
+		t.Fatalf("stored trace lost knowledge network scope: %v", stored.Traces[0].KnowledgeNetworkIDs)
+	}
+}
+
 func TestIngestIsIdempotentForSameEventIDAndContent(t *testing.T) {
 	store := evidencestore.New()
 	service := New(store)
@@ -1400,7 +1418,7 @@ func TestGetBusinessGraphByTraceIDReturnsClaimAndBusinessNodes(t *testing.T) {
 	}
 }
 
-func TestBusinessGraphAddsDisplayOnlyFromAuthorizedResolver(t *testing.T) {
+func TestBusinessGraphAddsDisplayOnlyFromResolvedResolverMetadata(t *testing.T) {
 	store := &fakeStore{traces: []evidencevo.NormalizedTrace{queryTrace("trace_graph_display", "req_graph_display")}}
 	resolver := &fakeBusinessResolver{resolutions: []ibusinessresolver.Resolution{{
 		RefID: "object:kn_demo:customer", Visibility: "visible", Display: &evidencevo.BusinessDisplay{
@@ -1505,7 +1523,7 @@ func TestBusinessGraphPromotesClaimedRetrievalSourceToResolvedBusinessEvidence(t
 	}
 }
 
-func TestBusinessGraphResolverUnauthorizedDoesNotLeakRefOrDisplay(t *testing.T) {
+func TestBusinessGraphResolverVisibilityDoesNotOverrideRecordAuthorization(t *testing.T) {
 	store := &fakeStore{traces: []evidencevo.NormalizedTrace{queryTrace("trace_graph_resolver_denied", "req_graph_resolver_denied")}}
 	resolver := &fakeBusinessResolver{resolutions: []ibusinessresolver.Resolution{{
 		RefID: "object:kn_demo:customer", Visibility: "unauthorized",
@@ -1518,13 +1536,15 @@ func TestBusinessGraphResolverUnauthorizedDoesNotLeakRefOrDisplay(t *testing.T) 
 	if err != nil || !found {
 		t.Fatalf("query denied graph: found=%v err=%v", found, err)
 	}
-	for _, node := range response.Data.Nodes {
-		if strings.Contains(node.ID, "object:kn_demo:customer") || node.Display != nil {
-			t.Fatalf("unauthorized resolver result leaked node or display: %+v", node)
-		}
+	node := businessNodeByID(t, response.Data.Nodes, "business:object:kn_demo:customer")
+	if node.Display != nil {
+		t.Fatalf("unresolved resolver metadata must not provide a display: %+v", node)
 	}
-	if response.VisibilitySummary.UnauthorizedRefCount != 1 || !contains(response.PartialReasons, "business_ref_unauthorized") {
-		t.Fatalf("expected unauthorized governance result: %+v", response)
+	if response.VisibilitySummary.UnauthorizedRefCount != 0 || contains(response.PartialReasons, "business_ref_unauthorized") {
+		t.Fatalf("resolver visibility must not be treated as record authorization: %+v", response)
+	}
+	if !contains(response.PartialReasons, "resolver_unresolved") {
+		t.Fatalf("missing display metadata must remain explicit: %+v", response.PartialReasons)
 	}
 }
 

--- a/bkn-trace/agent-observability/src/domain/service/evidencesvc/summary.go
+++ b/bkn-trace/agent-observability/src/domain/service/evidencesvc/summary.go
@@ -11,7 +11,6 @@ import (
 
 	"github.com/openbkn-ai/bkn-foundry/bkn-trace/agent-observability/src/domain/valueobject/evidencevo"
 	"github.com/openbkn-ai/bkn-foundry/bkn-trace/agent-observability/src/port/driven/iartifactstore"
-	"github.com/openbkn-ai/bkn-foundry/bkn-trace/agent-observability/src/port/driven/ibusinessresolver"
 	"github.com/openbkn-ai/bkn-foundry/bkn-trace/agent-observability/src/port/driven/iprojectionsource"
 )
 
@@ -286,10 +285,6 @@ func (s *Service) loadTraceExecutionSummaries(ctx context.Context, traceID strin
 			artifacts = append(artifacts, requestArtifacts.Entries...)
 		}
 	}
-	traces, artifacts, resolverUnavailable := s.authorizeSummaryInputs(ctx, traces, artifacts, scope)
-	if resolverUnavailable {
-		metadata.addReason("business_resolver_unavailable")
-	}
 	requestSummaries, traceSummaries := evidencevo.BuildExecutionSummaries(traces, artifacts)
 	return requestSummaries, traceSummaries, metadata, nil
 }
@@ -330,14 +325,7 @@ func (s *Service) loadExecutionSummaries(ctx context.Context, options evidencevo
 	if result.Truncated {
 		metadata.addReason("projection_scan_cap_reached")
 	}
-	traces, artifacts, resolverUnavailable := s.authorizeSummaryInputs(ctx, result.Traces, result.Artifacts, options.Scope)
-	if resolverUnavailable {
-		metadata.addReason("business_resolver_unavailable")
-	}
-	requests, traceSummaries := evidencevo.BuildExecutionSummaries(traces, artifacts)
-	if resolverUnavailable {
-		markRequestSummariesPartial(requests, "business_resolver_unavailable")
-	}
+	requests, traceSummaries := evidencevo.BuildExecutionSummaries(result.Traces, result.Artifacts)
 	return requests, traceSummaries, metadata, nil
 }
 
@@ -373,203 +361,8 @@ func (s *Service) loadRequestExecutionSummaries(ctx context.Context, requestID s
 		}
 		artifacts = artifactResult.Entries
 	}
-	traces, artifacts, resolverUnavailable := s.authorizeSummaryInputs(ctx, traces, artifacts, scope)
-	if resolverUnavailable {
-		metadata.addReason("business_resolver_unavailable")
-	}
 	requests, traceSummaries := evidencevo.BuildExecutionSummaries(traces, artifacts)
 	return requests, traceSummaries, metadata, nil
-}
-
-func (s *Service) authorizeSummaryInputs(
-	ctx context.Context,
-	traces []evidencevo.NormalizedTrace,
-	artifacts []evidencevo.EvidenceArtifact,
-	scope evidencevo.QueryScope,
-) ([]evidencevo.NormalizedTrace, []evidencevo.EvidenceArtifact, bool) {
-	candidates := map[string]ibusinessresolver.BusinessRef{}
-	for _, trace := range traces {
-		for _, event := range trace.Events {
-			if !visible(event.Payload) {
-				continue
-			}
-			collectVisibleSummaryRefCandidates(event.Payload, candidates)
-		}
-	}
-	for _, artifact := range artifacts {
-		if resolverSupportsArtifactRef(artifact.SourceRef) {
-			addSummaryResolverRef(candidates, artifact.SourceRef, "", "", "")
-		}
-		for _, refID := range artifact.BusinessRefs {
-			addSummaryResolverRef(candidates, refID, "", "", "")
-		}
-	}
-
-	authorized := map[string]struct{}{}
-	resolverUnavailable := false
-	if len(candidates) > 0 && s.businessResolver != nil {
-		refs := make([]ibusinessresolver.BusinessRef, 0, len(candidates))
-		for _, ref := range candidates {
-			refs = append(refs, ref)
-		}
-		sort.Slice(refs, func(i, j int) bool { return refs[i].RefID < refs[j].RefID })
-		resolutions, err := s.businessResolver.ResolveBusinessRefs(ctx, ibusinessresolver.ResolveRequest{
-			Scope: scope,
-			Refs:  refs,
-		})
-		if err != nil {
-			resolverUnavailable = true
-		} else {
-			for _, resolution := range resolutions {
-				if visibleResolution(resolution) {
-					authorized[resolution.RefID] = struct{}{}
-				}
-			}
-		}
-	}
-
-	filtered := make([]evidencevo.NormalizedTrace, 0, len(traces))
-	for _, trace := range traces {
-		events := make([]evidencevo.EvidenceEvent, 0, len(trace.Events))
-		for _, event := range trace.Events {
-			payload := cloneSummaryPayloadWithoutUnauthorizedRefs(event.Payload, authorized, visible(event.Payload))
-			event.Payload = payload
-			events = append(events, event)
-		}
-		filtered = append(filtered, evidencevo.WithEvents(trace, events))
-	}
-	filteredArtifacts := make([]evidencevo.EvidenceArtifact, 0, len(artifacts))
-	for _, artifact := range artifacts {
-		if summaryArtifactRefsAuthorized(artifact, authorized) {
-			filteredArtifacts = append(filteredArtifacts, artifact)
-		}
-	}
-	return filtered, filteredArtifacts, resolverUnavailable
-}
-
-func markRequestSummariesPartial(requests []evidencevo.RequestSummary, reason string) {
-	for index := range requests {
-		requests[index].EvidenceCompleteness = "partial"
-		requests[index].PartialReasons = appendUniqueSummaryReason(requests[index].PartialReasons, reason)
-	}
-}
-
-func collectVisibleSummaryRefCandidates(value any, candidates map[string]ibusinessresolver.BusinessRef) {
-	switch item := value.(type) {
-	case map[string]any:
-		if refID, ok := item["ref_id"].(string); ok && strings.TrimSpace(refID) != "" {
-			if visible(item) {
-				addSummaryResolverRef(
-					candidates,
-					refID,
-					stringSummaryField(item, "ref_type"),
-					stringSummaryField(item, "source_system"),
-					stringSummaryField(item, "version_status"),
-				)
-			}
-			return
-		}
-		for _, nested := range item {
-			collectVisibleSummaryRefCandidates(nested, candidates)
-		}
-	case []any:
-		for _, nested := range item {
-			collectVisibleSummaryRefCandidates(nested, candidates)
-		}
-	}
-}
-
-func addSummaryResolverRef(
-	candidates map[string]ibusinessresolver.BusinessRef,
-	refID string,
-	refType string,
-	sourceSystem string,
-	versionStatus string,
-) {
-	refID = strings.TrimSpace(refID)
-	if refID == "" {
-		return
-	}
-	if _, exists := candidates[refID]; exists {
-		return
-	}
-	if refType == "" {
-		refType, _, _ = strings.Cut(refID, ":")
-	}
-	candidates[refID] = ibusinessresolver.BusinessRef{
-		RefID:         refID,
-		RefType:       refType,
-		SourceSystem:  sourceSystem,
-		VersionStatus: versionStatus,
-	}
-}
-
-func summaryArtifactRefsAuthorized(artifact evidencevo.EvidenceArtifact, authorized map[string]struct{}) bool {
-	if len(authorized) == 0 {
-		return true
-	}
-	refs := make([]string, 0, len(artifact.BusinessRefs)+1)
-	if resolverSupportsArtifactRef(artifact.SourceRef) {
-		refs = append(refs, strings.TrimSpace(artifact.SourceRef))
-	}
-	refs = append(refs, artifact.BusinessRefs...)
-	for _, refID := range refs {
-		if _, ok := authorized[strings.TrimSpace(refID)]; !ok {
-			return false
-		}
-	}
-	return true
-}
-
-func cloneSummaryPayloadWithoutUnauthorizedRefs(
-	payload map[string]any,
-	authorized map[string]struct{},
-	allowRefs bool,
-) map[string]any {
-	cloned, _ := cloneSummaryValueWithoutUnauthorizedRefs(payload, authorized, allowRefs)
-	result, _ := cloned.(map[string]any)
-	if result == nil {
-		return map[string]any{}
-	}
-	return result
-}
-
-func cloneSummaryValueWithoutUnauthorizedRefs(value any, authorized map[string]struct{}, allowRefs bool) (any, bool) {
-	switch item := value.(type) {
-	case map[string]any:
-		if refID, ok := item["ref_id"].(string); ok && strings.TrimSpace(refID) != "" {
-			if !allowRefs || !visible(item) {
-				return nil, false
-			}
-			if _, ok := authorized[strings.TrimSpace(refID)]; !ok {
-				return nil, false
-			}
-		}
-		cloned := make(map[string]any, len(item))
-		for key, nested := range item {
-			value, keep := cloneSummaryValueWithoutUnauthorizedRefs(nested, authorized, allowRefs)
-			if keep {
-				cloned[key] = value
-			}
-		}
-		return cloned, true
-	case []any:
-		cloned := make([]any, 0, len(item))
-		for _, nested := range item {
-			value, keep := cloneSummaryValueWithoutUnauthorizedRefs(nested, authorized, allowRefs)
-			if keep {
-				cloned = append(cloned, value)
-			}
-		}
-		return cloned, true
-	default:
-		return value, true
-	}
-}
-
-func stringSummaryField(value map[string]any, key string) string {
-	text, _ := value[key].(string)
-	return text
 }
 
 func appendUniqueSummaryReason(reasons []string, reason string) []string {

--- a/bkn-trace/agent-observability/src/domain/service/evidencesvc/summary_service_test.go
+++ b/bkn-trace/agent-observability/src/domain/service/evidencesvc/summary_service_test.go
@@ -206,7 +206,7 @@ func TestListRequestsDoesNotLeakUnauthorizedPreview(t *testing.T) {
 	}
 }
 
-func TestListRequestsAuthorizesVisibleEventBusinessRefsBeforeProjection(t *testing.T) {
+func TestListRequestsKeepsRecordAuthorizedBusinessRefsWithoutResolverAuthorization(t *testing.T) {
 	store := evidencestore.New()
 	seedSummaryRequest(t, store, "req_refs", "trace_refs", "2026-07-26T09:00:00Z", "查询业务引用", "返回业务结果", "agent-a", "bd_demo", "acct_demo")
 	if err := store.StoreEvidence(context.Background(), evidencevo.NormalizedTrace{
@@ -242,27 +242,22 @@ func TestListRequestsAuthorizesVisibleEventBusinessRefsBeforeProjection(t *testi
 		t.Fatalf("expected one request summary: page=%+v err=%v", page, err)
 	}
 	summary := page.Entries[0]
-	if len(summary.BusinessRefs) != 0 || len(summary.KnowledgeNetworks) != 0 {
-		t.Fatalf("unauthorized and hidden refs must not enter summary: %+v", summary)
+	if !containsSummaryValue(summary.BusinessRefs, "object:kn_secret:item") ||
+		!containsSummaryValue(summary.KnowledgeNetworks, "kn_secret") {
+		t.Fatalf("record-authorized visible refs must remain in summary: %+v", summary)
 	}
-	if summary.EvidenceCompleteness != "partial" ||
-		!containsSummaryReason(summary.PartialReasons, "supporting_evidence_unavailable") {
-		t.Fatalf("unauthorized refs must not satisfy evidence completeness: %+v", summary)
+	if containsSummaryValue(summary.BusinessRefs, "object:kn_hidden:item") {
+		t.Fatalf("producer-hidden refs must remain hidden: %+v", summary)
 	}
-	if len(resolver.requests) != 1 || len(resolver.requests[0].Refs) != 2 ||
-		resolver.requests[0].Refs[0].RefID != "object:kn_demo:item" ||
-		resolver.requests[0].Refs[1].RefID != "object:kn_secret:item" {
-		t.Fatalf("resolver must receive only event-visible refs with trusted scope: %+v", resolver.requests)
-	}
-	if resolver.requests[0].Scope != summaryScope("acct_demo") {
-		t.Fatalf("resolver must use trusted query scope: %+v", resolver.requests[0].Scope)
+	if len(resolver.requests) != 0 {
+		t.Fatalf("summary access must not depend on resolver authorization: %+v", resolver.requests)
 	}
 
 	keywordPage, err := service.ListRequests(context.Background(), evidencevo.SummaryQueryOptions{
 		Scope: summaryScope("acct_demo"), Limit: 20, Keyword: "kn_secret",
 	})
-	if err != nil || len(keywordPage.Entries) != 0 {
-		t.Fatalf("unauthorized ref must not be keyword searchable: page=%+v err=%v", keywordPage, err)
+	if err != nil || len(keywordPage.Entries) != 1 {
+		t.Fatalf("record-authorized ref must remain keyword searchable: page=%+v err=%v", keywordPage, err)
 	}
 }
 
@@ -315,13 +310,8 @@ func TestListRequestsResolvesAllSummaryBusinessRefsOncePerQuery(t *testing.T) {
 	if err != nil || len(page.Entries) != 1 {
 		t.Fatalf("expected authorized summary: page=%+v err=%v", page, err)
 	}
-	if len(resolver.requests) != 1 {
-		t.Fatalf("summary query must batch resolver authorization, got %d calls: %+v", len(resolver.requests), resolver.requests)
-	}
-	if len(resolver.requests[0].Refs) != 2 ||
-		resolver.requests[0].Refs[0].RefID != "object:kn_demo:item" ||
-		resolver.requests[0].Refs[1].RefID != "resource:orders" {
-		t.Fatalf("resolver refs must be deduplicated and stable: %+v", resolver.requests[0].Refs)
+	if len(resolver.requests) != 0 {
+		t.Fatalf("request summary must not invoke resolver as an authorization gate: %+v", resolver.requests)
 	}
 }
 
@@ -366,12 +356,11 @@ func TestListRequestsFailsSoftWhenBusinessResolverIsUnavailable(t *testing.T) {
 	if entry.QuestionPreview != "查询采购履约风险" || entry.ResultPreview != "发现一条逾期采购订单" {
 		t.Fatalf("authorized question and result must remain visible: %+v", entry)
 	}
-	if !page.Partial || !containsSummaryReason(page.PartialReasons, "business_resolver_unavailable") {
-		t.Fatalf("resolver outage must be explicit on the page: %+v", page)
+	if page.Partial && containsSummaryReason(page.PartialReasons, "business_resolver_unavailable") {
+		t.Fatalf("resolver outage must not degrade a summary that does not require display resolution: %+v", page)
 	}
-	if entry.EvidenceCompleteness != "partial" ||
-		!containsSummaryReason(entry.PartialReasons, "business_resolver_unavailable") {
-		t.Fatalf("resolver outage must be explicit on the request: %+v", entry)
+	if containsSummaryReason(entry.PartialReasons, "business_resolver_unavailable") {
+		t.Fatalf("resolver outage must not change objective evidence completeness: %+v", entry)
 	}
 }
 

--- a/bkn-trace/agent-observability/src/domain/valueobject/evidencevo/access_scope.go
+++ b/bkn-trace/agent-observability/src/domain/valueobject/evidencevo/access_scope.go
@@ -13,18 +13,17 @@ const (
 // AccessProfile is derived from trusted gateway identity and current BKN Safe grants.
 // Callers cannot supply roles or managed knowledge networks in request payloads.
 type AccessProfile struct {
-	TenantID                    string
-	BusinessDomain              string
-	ActorID                     string
-	EffectiveSubjectID          string
-	ApplicationPrincipalID      string
-	DelegationID                string
-	Roles                       []string
-	ManagedKnowledgeNetworkIDs  []string
-	ManagesAllKnowledgeNetworks bool
-	AccountActive               bool
-	TenantActive                bool
-	Fingerprint                 string
+	TenantID                   string
+	BusinessDomain             string
+	ActorID                    string
+	EffectiveSubjectID         string
+	ApplicationPrincipalID     string
+	DelegationID               string
+	Roles                      []string
+	ManagedKnowledgeNetworkIDs []string
+	AccountActive              bool
+	TenantActive               bool
+	Fingerprint                string
 }
 
 // RecordScope is the immutable access projection attached to a persisted run.
@@ -65,8 +64,7 @@ func NeedsCrossAccountCandidates(scope QueryScope) bool {
 	profile := *scope.AccessProfile
 	switch defaultAccessView(scope.View) {
 	case AccessViewBusiness:
-		return hasAnyRole(profile, "network_builder") &&
-			(profile.ManagesAllKnowledgeNetworks || len(profile.ManagedKnowledgeNetworkIDs) > 0)
+		return hasAnyRole(profile, "network_builder") && len(profile.ManagedKnowledgeNetworkIDs) > 0
 	case AccessViewTechnical:
 		return hasAnyRole(profile, "admin", "super_admin")
 	case AccessViewSecurity:
@@ -114,9 +112,6 @@ func managesEveryRecordNetwork(profile AccessProfile, record RecordScope) bool {
 		if networkID == "" {
 			return false
 		}
-	}
-	if profile.ManagesAllKnowledgeNetworks {
-		return true
 	}
 	managed := make(map[string]struct{}, len(profile.ManagedKnowledgeNetworkIDs))
 	for _, networkID := range profile.ManagedKnowledgeNetworkIDs {

--- a/bkn-trace/agent-observability/src/domain/valueobject/evidencevo/access_scope.go
+++ b/bkn-trace/agent-observability/src/domain/valueobject/evidencevo/access_scope.go
@@ -1,0 +1,146 @@
+package evidencevo
+
+// AccessView identifies the independently authorized projection requested by a caller.
+type AccessView string
+
+const (
+	AccessViewBusiness  AccessView = "business"
+	AccessViewTechnical AccessView = "technical"
+	AccessViewSecurity  AccessView = "security"
+	AccessViewAudit     AccessView = "audit"
+)
+
+// AccessProfile is derived from trusted gateway identity and current BKN Safe grants.
+// Callers cannot supply roles or managed knowledge networks in request payloads.
+type AccessProfile struct {
+	TenantID                    string
+	BusinessDomain              string
+	ActorID                     string
+	EffectiveSubjectID          string
+	ApplicationPrincipalID      string
+	DelegationID                string
+	Roles                       []string
+	ManagedKnowledgeNetworkIDs  []string
+	ManagesAllKnowledgeNetworks bool
+	AccountActive               bool
+	TenantActive                bool
+	Fingerprint                 string
+}
+
+// RecordScope is the immutable access projection attached to a persisted run.
+type RecordScope struct {
+	TenantID               string
+	BusinessDomain         string
+	EffectiveSubjectID     string
+	ApplicationPrincipalID string
+	KnowledgeNetworkIDs    []string
+}
+
+// CanReadRecord applies the same record-level decision to every read surface.
+func CanReadRecord(profile AccessProfile, record RecordScope, view AccessView) bool {
+	if !validAccessBoundary(profile, record) {
+		return false
+	}
+
+	switch view {
+	case AccessViewBusiness:
+		return ownsRecord(profile, record) || managesEveryRecordNetwork(profile, record)
+	case AccessViewTechnical:
+		return hasAnyRole(profile, "admin", "super_admin")
+	case AccessViewSecurity:
+		return hasAnyRole(profile, "security", "super_admin")
+	case AccessViewAudit:
+		return hasAnyRole(profile, "audit", "super_admin")
+	default:
+		return false
+	}
+}
+
+// NeedsCrossAccountCandidates allows stores to widen only the candidate query;
+// CanReadRecord must still authorize every returned record.
+func NeedsCrossAccountCandidates(scope QueryScope) bool {
+	if scope.AccessProfile == nil {
+		return false
+	}
+	profile := *scope.AccessProfile
+	switch defaultAccessView(scope.View) {
+	case AccessViewBusiness:
+		return hasAnyRole(profile, "network_builder") &&
+			(profile.ManagesAllKnowledgeNetworks || len(profile.ManagedKnowledgeNetworkIDs) > 0)
+	case AccessViewTechnical:
+		return hasAnyRole(profile, "admin", "super_admin")
+	case AccessViewSecurity:
+		return hasAnyRole(profile, "security", "super_admin")
+	case AccessViewAudit:
+		return hasAnyRole(profile, "audit", "super_admin")
+	default:
+		return false
+	}
+}
+
+func defaultAccessView(view AccessView) AccessView {
+	if view == "" {
+		return AccessViewBusiness
+	}
+	return view
+}
+
+func validAccessBoundary(profile AccessProfile, record RecordScope) bool {
+	if !profile.AccountActive || !profile.TenantActive ||
+		profile.TenantID == "" || record.TenantID == "" ||
+		profile.TenantID != record.TenantID {
+		return false
+	}
+	if record.BusinessDomain != "" && profile.BusinessDomain != record.BusinessDomain {
+		return false
+	}
+	return true
+}
+
+func ownsRecord(profile AccessProfile, record RecordScope) bool {
+	if profile.EffectiveSubjectID != "" && record.EffectiveSubjectID != "" &&
+		profile.EffectiveSubjectID == record.EffectiveSubjectID {
+		return true
+	}
+	return profile.ApplicationPrincipalID != "" && record.ApplicationPrincipalID != "" &&
+		profile.ApplicationPrincipalID == record.ApplicationPrincipalID
+}
+
+func managesEveryRecordNetwork(profile AccessProfile, record RecordScope) bool {
+	if !hasAnyRole(profile, "network_builder") || len(record.KnowledgeNetworkIDs) == 0 {
+		return false
+	}
+	for _, networkID := range record.KnowledgeNetworkIDs {
+		if networkID == "" {
+			return false
+		}
+	}
+	if profile.ManagesAllKnowledgeNetworks {
+		return true
+	}
+	managed := make(map[string]struct{}, len(profile.ManagedKnowledgeNetworkIDs))
+	for _, networkID := range profile.ManagedKnowledgeNetworkIDs {
+		if networkID != "" {
+			managed[networkID] = struct{}{}
+		}
+	}
+	for _, networkID := range record.KnowledgeNetworkIDs {
+		if _, ok := managed[networkID]; !ok {
+			return false
+		}
+	}
+	return true
+}
+
+func hasAnyRole(profile AccessProfile, expected ...string) bool {
+	roles := make(map[string]struct{}, len(profile.Roles))
+	for _, role := range profile.Roles {
+		roles[role] = struct{}{}
+	}
+	for _, role := range expected {
+		if _, ok := roles[role]; ok {
+			return true
+		}
+	}
+	return false
+}

--- a/bkn-trace/agent-observability/src/domain/valueobject/evidencevo/access_scope_test.go
+++ b/bkn-trace/agent-observability/src/domain/valueobject/evidencevo/access_scope_test.go
@@ -74,18 +74,17 @@ func TestNetworkBuilderMustManageEveryKnowledgeNetwork(t *testing.T) {
 	}
 }
 
-func TestNetworkBuilderWithTypeWideManagementCanReadAnyScopedNetworkRecord(t *testing.T) {
+func TestNetworkBuilderTypeWideGrantDoesNotImplyBusinessContentAccess(t *testing.T) {
 	profile := AccessProfile{
 		TenantID: "tenant-a", BusinessDomain: "domain-a", AccountActive: true, TenantActive: true,
 		EffectiveSubjectID: "builder-a", Roles: []string{"network_builder"},
-		ManagesAllKnowledgeNetworks: true,
 	}
 	record := RecordScope{
 		TenantID: "tenant-a", BusinessDomain: "domain-a", EffectiveSubjectID: "other-user",
 		KnowledgeNetworkIDs: []string{"kn-a", "kn-b"},
 	}
-	if !CanReadRecord(profile, record, AccessViewBusiness) {
-		t.Fatal("network_builder with a knowledge_network:* management grant must read scoped records")
+	if CanReadRecord(profile, record, AccessViewBusiness) {
+		t.Fatal("type-wide management must not bypass concrete business content authorization")
 	}
 
 	record.KnowledgeNetworkIDs = nil
@@ -148,10 +147,10 @@ func TestCrossAccountCandidatesRequireAnExplicitAuthorizedView(t *testing.T) {
 		t.Fatal("managed-network business lookup needs cross-account candidates before record filtering")
 	}
 	typeWideBuilder := &AccessProfile{
-		Roles: []string{"network_builder"}, ManagesAllKnowledgeNetworks: true,
+		Roles: []string{"network_builder"},
 	}
-	if !NeedsCrossAccountCandidates(QueryScope{AccessProfile: typeWideBuilder, View: AccessViewBusiness}) {
-		t.Fatal("type-wide network management needs cross-account candidates before record filtering")
+	if NeedsCrossAccountCandidates(QueryScope{AccessProfile: typeWideBuilder, View: AccessViewBusiness}) {
+		t.Fatal("type-wide network management must not widen business provenance candidates")
 	}
 	admin := &AccessProfile{Roles: []string{"admin"}}
 	if NeedsCrossAccountCandidates(QueryScope{AccessProfile: admin, View: AccessViewBusiness}) {
@@ -241,11 +240,24 @@ func TestWithEventsDerivesStableKnowledgeNetworkScope(t *testing.T) {
 		{Payload: map[string]any{
 			"business_refs": []any{"relation:kn-a:forecast_product", "logic:kn-c:forecast:sum"},
 			"source_refs":   []any{"object:kn-source:forecast"},
-			"resource_refs": []any{map[string]any{"ref_id": "resource:kn-resource:forecast"}},
+			"resource_refs": []any{map[string]any{"ref_id": "resource:data-view-forecast"}},
 			"field_refs":    []any{"property:kn-field:forecast:qty"},
+			"output": map[string]any{
+				"business_refs": []any{
+					"object:kn-nested:forecast",
+					map[string]any{
+						"ref_id":  "object:kn-parent:forecast",
+						"related": []any{map[string]any{"ref_id": "property:kn-deep:forecast:qty"}},
+					},
+				},
+				"metadata": map[string]any{"kn_id": "kn-structured"},
+			},
 		}},
 	})
-	want := []string{"kn-a", "kn-b", "kn-c", "kn-direct", "kn-explicit", "kn-field", "kn-resource", "kn-source"}
+	want := []string{
+		"kn-a", "kn-b", "kn-c", "kn-deep", "kn-direct", "kn-explicit", "kn-field",
+		"kn-nested", "kn-parent", "kn-source", "kn-structured",
+	}
 	if !reflect.DeepEqual(trace.KnowledgeNetworkIDs, want) {
 		t.Fatalf("unexpected knowledge network scope: got %v want %v", trace.KnowledgeNetworkIDs, want)
 	}

--- a/bkn-trace/agent-observability/src/domain/valueobject/evidencevo/access_scope_test.go
+++ b/bkn-trace/agent-observability/src/domain/valueobject/evidencevo/access_scope_test.go
@@ -238,6 +238,8 @@ func TestWithEventsDerivesStableKnowledgeNetworkScope(t *testing.T) {
 			},
 		}},
 		{Payload: map[string]any{
+			"message":       "diagnostic text mentions object:kn-phantom:forecast but is not a business ref",
+			"model_outputs": []any{"property:kn-phantom:forecast:qty"},
 			"business_refs": []any{"relation:kn-a:forecast_product", "logic:kn-c:forecast:sum"},
 			"source_refs":   []any{"object:kn-source:forecast"},
 			"resource_refs": []any{map[string]any{"ref_id": "resource:data-view-forecast"}},

--- a/bkn-trace/agent-observability/src/domain/valueobject/evidencevo/access_scope_test.go
+++ b/bkn-trace/agent-observability/src/domain/valueobject/evidencevo/access_scope_test.go
@@ -1,0 +1,264 @@
+package evidencevo
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestAccessProfileCanReadOwnAndDelegatedBusinessRecord(t *testing.T) {
+	record := RecordScope{
+		TenantID: "tenant-a", BusinessDomain: "domain-a",
+		EffectiveSubjectID: "user-a", ApplicationPrincipalID: "app-a",
+	}
+
+	for _, profile := range []AccessProfile{
+		{
+			TenantID: "tenant-a", BusinessDomain: "domain-a", AccountActive: true, TenantActive: true,
+			EffectiveSubjectID: "user-a", Roles: []string{"normal_user"},
+		},
+		{
+			TenantID: "tenant-a", BusinessDomain: "domain-a", AccountActive: true, TenantActive: true,
+			EffectiveSubjectID: "user-a", ActorID: "assistant-a", DelegationID: "delegation-a",
+			Roles: []string{"normal_user"},
+		},
+	} {
+		if !CanReadRecord(profile, record, AccessViewBusiness) {
+			t.Fatalf("own or trusted delegated record must be readable: profile=%+v", profile)
+		}
+	}
+}
+
+func TestAccessProfileCanReadOwnApplicationBusinessRecord(t *testing.T) {
+	profile := AccessProfile{
+		TenantID: "tenant-a", BusinessDomain: "domain-a", AccountActive: true, TenantActive: true,
+		ApplicationPrincipalID: "app-a",
+	}
+	record := RecordScope{
+		TenantID: "tenant-a", BusinessDomain: "domain-a",
+		EffectiveSubjectID: "service-a", ApplicationPrincipalID: "app-a",
+	}
+	if !CanReadRecord(profile, record, AccessViewBusiness) {
+		t.Fatal("an application principal must read records produced by the same application")
+	}
+}
+
+func TestNetworkBuilderMustManageEveryKnowledgeNetwork(t *testing.T) {
+	record := RecordScope{
+		TenantID: "tenant-a", BusinessDomain: "domain-a", EffectiveSubjectID: "other-user",
+		KnowledgeNetworkIDs: []string{"kn-a", "kn-b"},
+	}
+	base := AccessProfile{
+		TenantID: "tenant-a", BusinessDomain: "domain-a", AccountActive: true, TenantActive: true,
+		EffectiveSubjectID: "builder-a", Roles: []string{"network_builder"},
+	}
+
+	all := base
+	all.ManagedKnowledgeNetworkIDs = []string{"kn-a", "kn-b", "kn-c"}
+	if !CanReadRecord(all, record, AccessViewBusiness) {
+		t.Fatal("network_builder managing every associated network must read the record")
+	}
+
+	partial := base
+	partial.ManagedKnowledgeNetworkIDs = []string{"kn-a"}
+	if CanReadRecord(partial, record, AccessViewBusiness) {
+		t.Fatal("network_builder managing only part of a multi-network record must be denied")
+	}
+
+	if CanReadRecord(base, record, AccessViewBusiness) {
+		t.Fatal("network_builder without a concrete managed network grant must be denied")
+	}
+
+	record.KnowledgeNetworkIDs = nil
+	if CanReadRecord(all, record, AccessViewBusiness) {
+		t.Fatal("cross-user record without a trusted knowledge network scope must fail closed")
+	}
+}
+
+func TestNetworkBuilderWithTypeWideManagementCanReadAnyScopedNetworkRecord(t *testing.T) {
+	profile := AccessProfile{
+		TenantID: "tenant-a", BusinessDomain: "domain-a", AccountActive: true, TenantActive: true,
+		EffectiveSubjectID: "builder-a", Roles: []string{"network_builder"},
+		ManagesAllKnowledgeNetworks: true,
+	}
+	record := RecordScope{
+		TenantID: "tenant-a", BusinessDomain: "domain-a", EffectiveSubjectID: "other-user",
+		KnowledgeNetworkIDs: []string{"kn-a", "kn-b"},
+	}
+	if !CanReadRecord(profile, record, AccessViewBusiness) {
+		t.Fatal("network_builder with a knowledge_network:* management grant must read scoped records")
+	}
+
+	record.KnowledgeNetworkIDs = nil
+	if CanReadRecord(profile, record, AccessViewBusiness) {
+		t.Fatal("type-wide management must not authorize a record without trusted knowledge network scope")
+	}
+	record.KnowledgeNetworkIDs = []string{""}
+	if CanReadRecord(profile, record, AccessViewBusiness) {
+		t.Fatal("type-wide management must reject an empty knowledge network identifier")
+	}
+}
+
+func TestPlatformRolesDoNotGrantBusinessContent(t *testing.T) {
+	record := RecordScope{
+		TenantID: "tenant-a", BusinessDomain: "domain-a", EffectiveSubjectID: "user-a",
+		KnowledgeNetworkIDs: []string{"kn-a"},
+	}
+	for _, role := range []string{"admin", "security", "audit", "super_admin"} {
+		profile := AccessProfile{
+			TenantID: "tenant-a", BusinessDomain: "domain-a", AccountActive: true, TenantActive: true,
+			EffectiveSubjectID: role + "-account", Roles: []string{role},
+		}
+		if CanReadRecord(profile, record, AccessViewBusiness) {
+			t.Fatalf("platform role %q must not imply access to another subject's business content", role)
+		}
+	}
+}
+
+func TestRoleViewsRemainSeparated(t *testing.T) {
+	record := RecordScope{TenantID: "tenant-a", BusinessDomain: "domain-a", EffectiveSubjectID: "user-a"}
+	tests := []struct {
+		role    string
+		view    AccessView
+		allowed bool
+	}{
+		{role: "admin", view: AccessViewTechnical, allowed: true},
+		{role: "super_admin", view: AccessViewTechnical, allowed: true},
+		{role: "security", view: AccessViewSecurity, allowed: true},
+		{role: "audit", view: AccessViewAudit, allowed: true},
+		{role: "admin", view: AccessViewSecurity, allowed: false},
+		{role: "security", view: AccessViewTechnical, allowed: false},
+		{role: "audit", view: AccessViewTechnical, allowed: false},
+	}
+	for _, test := range tests {
+		profile := AccessProfile{
+			TenantID: "tenant-a", BusinessDomain: "domain-a", AccountActive: true, TenantActive: true,
+			EffectiveSubjectID: test.role + "-account", Roles: []string{test.role},
+		}
+		if got := CanReadRecord(profile, record, test.view); got != test.allowed {
+			t.Fatalf("role=%s view=%s: got %v want %v", test.role, test.view, got, test.allowed)
+		}
+	}
+}
+
+func TestCrossAccountCandidatesRequireAnExplicitAuthorizedView(t *testing.T) {
+	builder := &AccessProfile{
+		Roles: []string{"network_builder"}, ManagedKnowledgeNetworkIDs: []string{"kn-a"},
+	}
+	if !NeedsCrossAccountCandidates(QueryScope{AccessProfile: builder, View: AccessViewBusiness}) {
+		t.Fatal("managed-network business lookup needs cross-account candidates before record filtering")
+	}
+	typeWideBuilder := &AccessProfile{
+		Roles: []string{"network_builder"}, ManagesAllKnowledgeNetworks: true,
+	}
+	if !NeedsCrossAccountCandidates(QueryScope{AccessProfile: typeWideBuilder, View: AccessViewBusiness}) {
+		t.Fatal("type-wide network management needs cross-account candidates before record filtering")
+	}
+	admin := &AccessProfile{Roles: []string{"admin"}}
+	if NeedsCrossAccountCandidates(QueryScope{AccessProfile: admin, View: AccessViewBusiness}) {
+		t.Fatal("admin business lookup must remain owner-scoped")
+	}
+	if !NeedsCrossAccountCandidates(QueryScope{AccessProfile: admin, View: AccessViewTechnical}) {
+		t.Fatal("admin technical lookup needs platform technical candidates")
+	}
+}
+
+func TestAccessProfileFailsClosedForInvalidIdentityBoundary(t *testing.T) {
+	record := RecordScope{
+		TenantID: "tenant-a", BusinessDomain: "domain-a",
+		EffectiveSubjectID: "user-a", ApplicationPrincipalID: "app-a",
+	}
+	valid := AccessProfile{
+		TenantID: "tenant-a", BusinessDomain: "domain-a", AccountActive: true, TenantActive: true,
+		EffectiveSubjectID: "user-a", Roles: []string{"normal_user"},
+	}
+	tests := []AccessProfile{
+		{},
+		func() AccessProfile { value := valid; value.AccountActive = false; return value }(),
+		func() AccessProfile { value := valid; value.TenantActive = false; return value }(),
+		func() AccessProfile { value := valid; value.TenantID = "tenant-b"; return value }(),
+		func() AccessProfile { value := valid; value.BusinessDomain = "domain-b"; return value }(),
+	}
+	for _, profile := range tests {
+		if CanReadRecord(profile, record, AccessViewBusiness) {
+			t.Fatalf("invalid identity boundary must fail closed: profile=%+v", profile)
+		}
+	}
+}
+
+func TestMatchesScopeUsesRecordAccessProfile(t *testing.T) {
+	trace := NormalizedTrace{
+		TraceID: "trace-a", RequestID: "request-a",
+		TenantID: "tenant-a", BusinessDomain: "domain-a",
+		AccountID: "other-user", AccountType: "user", EffectiveSubjectID: "other-user",
+		KnowledgeNetworkIDs: []string{"kn-a", "kn-b"},
+	}
+	scope := QueryScope{
+		View: AccessViewBusiness,
+		AccessProfile: &AccessProfile{
+			TenantID: "tenant-a", BusinessDomain: "domain-a", AccountActive: true, TenantActive: true,
+			EffectiveSubjectID: "builder-a", Roles: []string{"network_builder"},
+			ManagedKnowledgeNetworkIDs: []string{"kn-a", "kn-b"},
+		},
+	}
+	if !MatchesScope(trace, scope) {
+		t.Fatal("trace matching must use the shared record access decision")
+	}
+	scope.AccessProfile.ManagedKnowledgeNetworkIDs = []string{"kn-a"}
+	if MatchesScope(trace, scope) {
+		t.Fatal("trace matching must reject partial knowledge network management")
+	}
+}
+
+func TestMatchesArtifactScopeDoesNotTreatPlatformRoleAsBusinessAccess(t *testing.T) {
+	artifact := EvidenceArtifact{
+		ArtifactID: "artifact-a", RequestID: "request-a",
+		TenantID: "tenant-a", BusinessDomain: "domain-a",
+		AccountID: "user-a", AccountType: "user", EffectiveSubjectID: "user-a",
+		KnowledgeNetworkIDs: []string{"kn-a"},
+	}
+	scope := QueryScope{
+		View: AccessViewBusiness,
+		AccessProfile: &AccessProfile{
+			TenantID: "tenant-a", BusinessDomain: "domain-a", AccountActive: true, TenantActive: true,
+			EffectiveSubjectID: "admin-a", Roles: []string{"super_admin"},
+		},
+	}
+	if MatchesArtifactScope(artifact, scope) {
+		t.Fatal("platform role alone must not expose another subject's evidence artifact")
+	}
+}
+
+func TestWithEventsDerivesStableKnowledgeNetworkScope(t *testing.T) {
+	trace := WithEvents(NormalizedTrace{}, []EvidenceEvent{
+		{Payload: map[string]any{
+			"kn_id": "kn-direct",
+			"business_refs": []any{
+				"kn:kn-explicit",
+				"object:kn-a:forecast",
+				map[string]any{"ref_id": "property:kn-b:forecast:qty"},
+			},
+		}},
+		{Payload: map[string]any{
+			"business_refs": []any{"relation:kn-a:forecast_product", "logic:kn-c:forecast:sum"},
+			"source_refs":   []any{"object:kn-source:forecast"},
+			"resource_refs": []any{map[string]any{"ref_id": "resource:kn-resource:forecast"}},
+			"field_refs":    []any{"property:kn-field:forecast:qty"},
+		}},
+	})
+	want := []string{"kn-a", "kn-b", "kn-c", "kn-direct", "kn-explicit", "kn-field", "kn-resource", "kn-source"}
+	if !reflect.DeepEqual(trace.KnowledgeNetworkIDs, want) {
+		t.Fatalf("unexpected knowledge network scope: got %v want %v", trace.KnowledgeNetworkIDs, want)
+	}
+}
+
+func TestNormalizeArtifactDerivesKnowledgeNetworkScopeFromBusinessRefs(t *testing.T) {
+	artifact, _ := NormalizeArtifact(EvidenceArtifact{
+		SourceRef:           "object:kn-source:forecast",
+		BusinessRefs:        []string{"object:kn-a:forecast", "kn:kn-b"},
+		KnowledgeNetworkIDs: []string{"forged-network"},
+	})
+	want := []string{"kn-a", "kn-b", "kn-source"}
+	if !reflect.DeepEqual(artifact.KnowledgeNetworkIDs, want) {
+		t.Fatalf("artifact scope must be derived from canonical refs, got %v want %v", artifact.KnowledgeNetworkIDs, want)
+	}
+}

--- a/bkn-trace/agent-observability/src/domain/valueobject/evidencevo/artifact.go
+++ b/bkn-trace/agent-observability/src/domain/valueobject/evidencevo/artifact.go
@@ -71,29 +71,32 @@ var artifactLinkRoles = map[string][]ArtifactLinkRole{
 }
 
 type EvidenceArtifact struct {
-	ArtifactID     string       `json:"artifact_id"`
-	ArtifactType   ArtifactType `json:"artifact_type"`
-	RequestID      string       `json:"bkn.request.id"`
-	TraceID        string       `json:"trace_id,omitempty"`
-	InteractionID  string       `json:"interaction_id,omitempty"`
-	OperationID    string       `json:"operation_id,omitempty"`
-	ClaimID        string       `json:"claim_id,omitempty"`
-	SourceRef      string       `json:"source_ref,omitempty"`
-	BusinessRefs   []string     `json:"business_refs,omitempty"`
-	ContentType    string       `json:"content_type"`
-	SchemaVersion  string       `json:"schema_version"`
-	ObservedAt     string       `json:"observed_at"`
-	AsOf           string       `json:"as_of,omitempty"`
-	SourceVersion  string       `json:"source_version,omitempty"`
-	ContentHash    string       `json:"content_hash"`
-	Content        any          `json:"content,omitempty"`
-	SnapshotRef    string       `json:"snapshot_ref,omitempty"`
-	TenantID       string       `json:"bkn.tenant.id,omitempty"`
-	BusinessDomain string       `json:"business_domain,omitempty"`
-	AccountID      string       `json:"bkn.account.id"`
-	AccountType    string       `json:"bkn.account.type"`
-	Initiator      string       `json:"initiator,omitempty"`
-	AgentOrApp     string       `json:"agent_or_app,omitempty"`
+	ArtifactID             string       `json:"artifact_id"`
+	ArtifactType           ArtifactType `json:"artifact_type"`
+	RequestID              string       `json:"bkn.request.id"`
+	TraceID                string       `json:"trace_id,omitempty"`
+	InteractionID          string       `json:"interaction_id,omitempty"`
+	OperationID            string       `json:"operation_id,omitempty"`
+	ClaimID                string       `json:"claim_id,omitempty"`
+	SourceRef              string       `json:"source_ref,omitempty"`
+	BusinessRefs           []string     `json:"business_refs,omitempty"`
+	ContentType            string       `json:"content_type"`
+	SchemaVersion          string       `json:"schema_version"`
+	ObservedAt             string       `json:"observed_at"`
+	AsOf                   string       `json:"as_of,omitempty"`
+	SourceVersion          string       `json:"source_version,omitempty"`
+	ContentHash            string       `json:"content_hash"`
+	Content                any          `json:"content,omitempty"`
+	SnapshotRef            string       `json:"snapshot_ref,omitempty"`
+	TenantID               string       `json:"bkn.tenant.id,omitempty"`
+	BusinessDomain         string       `json:"business_domain,omitempty"`
+	AccountID              string       `json:"bkn.account.id"`
+	AccountType            string       `json:"bkn.account.type"`
+	EffectiveSubjectID     string       `json:"effective_subject_id,omitempty"`
+	ApplicationPrincipalID string       `json:"application_principal_id,omitempty"`
+	KnowledgeNetworkIDs    []string     `json:"knowledge_network_ids,omitempty"`
+	Initiator              string       `json:"initiator,omitempty"`
+	AgentOrApp             string       `json:"agent_or_app,omitempty"`
 }
 
 type ArtifactIngestResponse struct {
@@ -127,6 +130,7 @@ func NormalizeArtifact(artifact EvidenceArtifact) (EvidenceArtifact, ValidationE
 	artifact.AccountType = strings.TrimSpace(artifact.AccountType)
 	artifact.Initiator = strings.TrimSpace(artifact.Initiator)
 	artifact.AgentOrApp = strings.TrimSpace(artifact.AgentOrApp)
+	artifact.KnowledgeNetworkIDs = KnowledgeNetworkIDsFromRefs(append(append([]string(nil), artifact.BusinessRefs...), artifact.SourceRef))
 
 	var validationErrors ValidationErrors
 	requireArtifactValue(artifact.ArtifactID, "artifact_id", &validationErrors)
@@ -257,10 +261,13 @@ func marshalCanonicalArtifactContent(content any) ([]byte, error) {
 }
 
 func MatchesArtifactScope(artifact EvidenceArtifact, scope QueryScope) bool {
+	if scope.AccessProfile != nil {
+		return CanReadRecord(*scope.AccessProfile, artifact.RecordScope(), AccessViewBusiness)
+	}
 	if artifact.AccountID == "" || artifact.AccountType == "" || artifact.TenantID == "" && artifact.BusinessDomain == "" {
 		return false
 	}
-	if !scope.CrossAccountRead && (artifact.AccountID != scope.AccountID || artifact.AccountType != scope.AccountType) {
+	if artifact.AccountID != scope.AccountID || artifact.AccountType != scope.AccountType {
 		return false
 	}
 	if artifact.TenantID != "" && artifact.TenantID != scope.TenantID {
@@ -270,6 +277,22 @@ func MatchesArtifactScope(artifact EvidenceArtifact, scope QueryScope) bool {
 		return false
 	}
 	return true
+}
+
+func (artifact EvidenceArtifact) RecordScope() RecordScope {
+	effectiveSubjectID := artifact.EffectiveSubjectID
+	applicationPrincipalID := artifact.ApplicationPrincipalID
+	if effectiveSubjectID == "" && artifact.AccountType != "app" && artifact.AccountType != "service" {
+		effectiveSubjectID = artifact.AccountID
+	}
+	if applicationPrincipalID == "" && (artifact.AccountType == "app" || artifact.AccountType == "service") {
+		applicationPrincipalID = artifact.AccountID
+	}
+	return RecordScope{
+		TenantID: artifact.TenantID, BusinessDomain: artifact.BusinessDomain,
+		EffectiveSubjectID: effectiveSubjectID, ApplicationPrincipalID: applicationPrincipalID,
+		KnowledgeNetworkIDs: artifact.KnowledgeNetworkIDs,
+	}
 }
 
 func ArtifactFingerprint(artifact EvidenceArtifact) (string, error) {

--- a/bkn-trace/agent-observability/src/domain/valueobject/evidencevo/artifact.go
+++ b/bkn-trace/agent-observability/src/domain/valueobject/evidencevo/artifact.go
@@ -296,6 +296,9 @@ func (artifact EvidenceArtifact) RecordScope() RecordScope {
 }
 
 func ArtifactFingerprint(artifact EvidenceArtifact) (string, error) {
+	artifact.EffectiveSubjectID = ""
+	artifact.ApplicationPrincipalID = ""
+	artifact.KnowledgeNetworkIDs = nil
 	body, err := json.Marshal(artifact)
 	if err != nil {
 		return "", err

--- a/bkn-trace/agent-observability/src/domain/valueobject/evidencevo/artifact_test.go
+++ b/bkn-trace/agent-observability/src/domain/valueobject/evidencevo/artifact_test.go
@@ -5,6 +5,34 @@ import (
 	"testing"
 )
 
+func TestArtifactFingerprintIgnoresServerDerivedRecordScope(t *testing.T) {
+	artifact := validArtifact()
+	artifact.BusinessRefs = []string{"object:kn-a:forecast"}
+	normalized, validationErrors := NormalizeArtifact(artifact)
+	if len(validationErrors) != 0 {
+		t.Fatalf("normalize artifact: %+v", validationErrors)
+	}
+	normalized.EffectiveSubjectID = "user-a"
+	normalized.ApplicationPrincipalID = "app-a"
+
+	legacy := normalized
+	legacy.EffectiveSubjectID = ""
+	legacy.ApplicationPrincipalID = ""
+	legacy.KnowledgeNetworkIDs = nil
+
+	currentFingerprint, err := ArtifactFingerprint(normalized)
+	if err != nil {
+		t.Fatalf("fingerprint current artifact: %v", err)
+	}
+	legacyFingerprint, err := ArtifactFingerprint(legacy)
+	if err != nil {
+		t.Fatalf("fingerprint legacy artifact: %v", err)
+	}
+	if currentFingerprint != legacyFingerprint {
+		t.Fatalf("server-derived record scope must not change artifact idempotency: current=%s legacy=%s", currentFingerprint, legacyFingerprint)
+	}
+}
+
 func TestNormalizeArtifactAcceptsInlineQuestionAndComputesStableHash(t *testing.T) {
 	artifact := validArtifact()
 	artifact.Content = map[string]any{

--- a/bkn-trace/agent-observability/src/domain/valueobject/evidencevo/evidence.go
+++ b/bkn-trace/agent-observability/src/domain/valueobject/evidencevo/evidence.go
@@ -4,6 +4,8 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
+	"sort"
+	"strings"
 )
 
 const (
@@ -211,6 +213,7 @@ func actionEventState(eventType string) string {
 
 func WithEvents(trace NormalizedTrace, events []EvidenceEvent) NormalizedTrace {
 	trace.Events = events
+	trace.KnowledgeNetworkIDs = knowledgeNetworkIDsFromEvents(events)
 	trace.AcceptedEvents = len(events)
 	trace.ClaimIDs = nil
 	trace.ClaimCount = 0
@@ -240,6 +243,79 @@ func WithEvents(trace NormalizedTrace, events []EvidenceEvent) NormalizedTrace {
 	return trace
 }
 
+func knowledgeNetworkIDsFromEvents(events []EvidenceEvent) []string {
+	networks := map[string]struct{}{}
+	for _, event := range events {
+		if networkID, ok := event.Payload["kn_id"].(string); ok {
+			addKnowledgeNetworkID(networkID, networks)
+		}
+		for _, field := range []string{"business_refs", "source_refs", "resource_refs", "field_refs"} {
+			collectKnowledgeNetworkIDs(event.Payload[field], networks)
+		}
+	}
+	return sortedKnowledgeNetworkIDs(networks)
+}
+
+// KnowledgeNetworkIDsFromRefs derives the knowledge-network boundary from trusted canonical refs.
+func KnowledgeNetworkIDsFromRefs(refs []string) []string {
+	networks := map[string]struct{}{}
+	for _, ref := range refs {
+		if networkID := knowledgeNetworkIDFromCanonicalRef(ref); networkID != "" {
+			networks[networkID] = struct{}{}
+		}
+	}
+	return sortedKnowledgeNetworkIDs(networks)
+}
+
+func collectKnowledgeNetworkIDs(value any, networks map[string]struct{}) {
+	switch item := value.(type) {
+	case string:
+		if networkID := knowledgeNetworkIDFromCanonicalRef(item); networkID != "" {
+			networks[networkID] = struct{}{}
+		}
+	case map[string]any:
+		if refID, ok := item["ref_id"].(string); ok {
+			collectKnowledgeNetworkIDs(refID, networks)
+		}
+	case []any:
+		for _, nested := range item {
+			collectKnowledgeNetworkIDs(nested, networks)
+		}
+	}
+}
+
+func knowledgeNetworkIDFromCanonicalRef(ref string) string {
+	parts := strings.Split(strings.TrimSpace(ref), ":")
+	if len(parts) > 0 && parts[0] == "business" {
+		parts = parts[1:]
+	}
+	if len(parts) == 2 && parts[0] == "kn" {
+		return strings.TrimSpace(parts[1])
+	}
+	if len(parts) >= 3 {
+		switch parts[0] {
+		case "object", "object_instance", "property", "relation", "metric", "logic", "function", "action_type", "action_instance", "resource":
+			return strings.TrimSpace(parts[1])
+		}
+	}
+	return ""
+}
+
+func addKnowledgeNetworkID(networkID string, networks map[string]struct{}) {
+	if networkID = strings.TrimSpace(networkID); networkID != "" {
+		networks[networkID] = struct{}{}
+	}
+}
+
+func sortedKnowledgeNetworkIDs(networks map[string]struct{}) []string {
+	values := make([]string, 0, len(networks))
+	for networkID := range networks {
+		values = append(values, networkID)
+	}
+	sort.Strings(values)
+	return values
+}
+
 type ValidationError struct {
 	Code    string `json:"code"`
 	Path    string `json:"path"`
@@ -256,20 +332,23 @@ func (e ValidationErrors) Error() string {
 }
 
 type NormalizedTrace struct {
-	TraceID          string
-	RequestID        string
-	ConversationID   string
-	TenantID         string
-	BusinessDomain   string
-	AccountID        string
-	AccountType      string
-	SchemaVersion    string
-	Events           []EvidenceEvent
-	ClaimIDs         []string
-	AcceptedEvents   int
-	ClaimCount       int
-	EvidenceRefCount int
-	BusinessRefCount int
+	TraceID                string
+	RequestID              string
+	ConversationID         string
+	TenantID               string
+	BusinessDomain         string
+	AccountID              string
+	AccountType            string
+	EffectiveSubjectID     string
+	ApplicationPrincipalID string
+	KnowledgeNetworkIDs    []string
+	SchemaVersion          string
+	Events                 []EvidenceEvent
+	ClaimIDs               []string
+	AcceptedEvents         int
+	ClaimCount             int
+	EvidenceRefCount       int
+	BusinessRefCount       int
 }
 
 type EvidenceQueryOptions struct {
@@ -278,12 +357,13 @@ type EvidenceQueryOptions struct {
 }
 
 type QueryScope struct {
-	TenantID         string
-	BusinessDomain   string
-	AccountID        string
-	AccountType      string
-	CrossAccountRead bool   `json:"-"`
-	Authorization    string `json:"-"`
+	TenantID       string
+	BusinessDomain string
+	AccountID      string
+	AccountType    string
+	Authorization  string         `json:"-"`
+	AccessProfile  *AccessProfile `json:"-"`
+	View           AccessView     `json:"-"`
 }
 
 func SameOwnership(existing NormalizedTrace, incoming NormalizedTrace) bool {
@@ -301,10 +381,13 @@ func compatibleOptionalIdentity(existing, incoming string) bool {
 }
 
 func MatchesScope(trace NormalizedTrace, scope QueryScope) bool {
+	if scope.AccessProfile != nil {
+		return CanReadRecord(*scope.AccessProfile, trace.RecordScope(), defaultAccessView(scope.View))
+	}
 	if trace.AccountID == "" || trace.AccountType == "" || trace.TenantID == "" && trace.BusinessDomain == "" {
 		return false
 	}
-	if !scope.CrossAccountRead && (trace.AccountID != scope.AccountID || trace.AccountType != scope.AccountType) {
+	if trace.AccountID != scope.AccountID || trace.AccountType != scope.AccountType {
 		return false
 	}
 	if trace.TenantID != "" && trace.TenantID != scope.TenantID {
@@ -314,6 +397,22 @@ func MatchesScope(trace NormalizedTrace, scope QueryScope) bool {
 		return false
 	}
 	return true
+}
+
+func (trace NormalizedTrace) RecordScope() RecordScope {
+	effectiveSubjectID := trace.EffectiveSubjectID
+	applicationPrincipalID := trace.ApplicationPrincipalID
+	if effectiveSubjectID == "" && trace.AccountType != "app" && trace.AccountType != "service" {
+		effectiveSubjectID = trace.AccountID
+	}
+	if applicationPrincipalID == "" && (trace.AccountType == "app" || trace.AccountType == "service") {
+		applicationPrincipalID = trace.AccountID
+	}
+	return RecordScope{
+		TenantID: trace.TenantID, BusinessDomain: trace.BusinessDomain,
+		EffectiveSubjectID: effectiveSubjectID, ApplicationPrincipalID: applicationPrincipalID,
+		KnowledgeNetworkIDs: trace.KnowledgeNetworkIDs,
+	}
 }
 
 type EvidenceQueryResult struct {

--- a/bkn-trace/agent-observability/src/domain/valueobject/evidencevo/evidence.go
+++ b/bkn-trace/agent-observability/src/domain/valueobject/evidencevo/evidence.go
@@ -267,7 +267,10 @@ func KnowledgeNetworkIDsFromRefs(refs []string) []string {
 func collectKnowledgeNetworkIDs(value any, networks map[string]struct{}, allowBareRef bool) {
 	switch item := value.(type) {
 	case string:
-		if networkID := knowledgeNetworkIDFromCanonicalRef(item); allowBareRef && networkID != "" {
+		if !allowBareRef {
+			return
+		}
+		if networkID := knowledgeNetworkIDFromCanonicalRef(item); networkID != "" {
 			networks[networkID] = struct{}{}
 		}
 	case map[string]any:

--- a/bkn-trace/agent-observability/src/domain/valueobject/evidencevo/evidence.go
+++ b/bkn-trace/agent-observability/src/domain/valueobject/evidencevo/evidence.go
@@ -248,7 +248,7 @@ func WithEvents(trace NormalizedTrace, events []EvidenceEvent) NormalizedTrace {
 func knowledgeNetworkIDsFromEvents(events []EvidenceEvent) []string {
 	networks := map[string]struct{}{}
 	for _, event := range events {
-		collectKnowledgeNetworkIDs(event.Payload, networks)
+		collectKnowledgeNetworkIDs(event.Payload, networks, false)
 	}
 	return sortedKnowledgeNetworkIDs(networks)
 }
@@ -264,10 +264,10 @@ func KnowledgeNetworkIDsFromRefs(refs []string) []string {
 	return sortedKnowledgeNetworkIDs(networks)
 }
 
-func collectKnowledgeNetworkIDs(value any, networks map[string]struct{}) {
+func collectKnowledgeNetworkIDs(value any, networks map[string]struct{}, allowBareRef bool) {
 	switch item := value.(type) {
 	case string:
-		if networkID := knowledgeNetworkIDFromCanonicalRef(item); networkID != "" {
+		if networkID := knowledgeNetworkIDFromCanonicalRef(item); allowBareRef && networkID != "" {
 			networks[networkID] = struct{}{}
 		}
 	case map[string]any:
@@ -275,16 +275,21 @@ func collectKnowledgeNetworkIDs(value any, networks map[string]struct{}) {
 			addKnowledgeNetworkID(networkID, networks)
 		}
 		if refID, ok := item["ref_id"].(string); ok {
-			collectKnowledgeNetworkIDs(refID, networks)
+			collectKnowledgeNetworkIDs(refID, networks, true)
 		}
-		for _, nested := range item {
-			collectKnowledgeNetworkIDs(nested, networks)
+		for key, nested := range item {
+			collectKnowledgeNetworkIDs(nested, networks, isCanonicalRefContainer(key))
 		}
 	case []any:
 		for _, nested := range item {
-			collectKnowledgeNetworkIDs(nested, networks)
+			collectKnowledgeNetworkIDs(nested, networks, allowBareRef)
 		}
 	}
+}
+
+func isCanonicalRefContainer(key string) bool {
+	key = strings.ToLower(strings.TrimSpace(key))
+	return strings.HasSuffix(key, "_ref") || strings.HasSuffix(key, "_refs")
 }
 
 func knowledgeNetworkIDFromCanonicalRef(ref string) string {

--- a/bkn-trace/agent-observability/src/domain/valueobject/evidencevo/evidence.go
+++ b/bkn-trace/agent-observability/src/domain/valueobject/evidencevo/evidence.go
@@ -289,9 +289,7 @@ func collectKnowledgeNetworkIDs(value any, networks map[string]struct{}) {
 
 func knowledgeNetworkIDFromCanonicalRef(ref string) string {
 	ref = strings.TrimSpace(ref)
-	if strings.HasPrefix(ref, "business:") {
-		ref = strings.TrimPrefix(ref, "business:")
-	}
+	ref = strings.TrimPrefix(ref, "business:")
 	for _, refType := range []sessionvo.BusinessRefType{
 		sessionvo.BusinessRefKnowledgeNetwork,
 		sessionvo.BusinessRefObjectType,

--- a/bkn-trace/agent-observability/src/domain/valueobject/evidencevo/evidence.go
+++ b/bkn-trace/agent-observability/src/domain/valueobject/evidencevo/evidence.go
@@ -6,6 +6,8 @@ import (
 	"encoding/json"
 	"sort"
 	"strings"
+
+	"github.com/openbkn-ai/bkn-foundry/bkn-trace/agent-observability/src/domain/valueobject/sessionvo"
 )
 
 const (
@@ -246,12 +248,7 @@ func WithEvents(trace NormalizedTrace, events []EvidenceEvent) NormalizedTrace {
 func knowledgeNetworkIDsFromEvents(events []EvidenceEvent) []string {
 	networks := map[string]struct{}{}
 	for _, event := range events {
-		if networkID, ok := event.Payload["kn_id"].(string); ok {
-			addKnowledgeNetworkID(networkID, networks)
-		}
-		for _, field := range []string{"business_refs", "source_refs", "resource_refs", "field_refs"} {
-			collectKnowledgeNetworkIDs(event.Payload[field], networks)
-		}
+		collectKnowledgeNetworkIDs(event.Payload, networks)
 	}
 	return sortedKnowledgeNetworkIDs(networks)
 }
@@ -274,8 +271,14 @@ func collectKnowledgeNetworkIDs(value any, networks map[string]struct{}) {
 			networks[networkID] = struct{}{}
 		}
 	case map[string]any:
+		if networkID, ok := item["kn_id"].(string); ok {
+			addKnowledgeNetworkID(networkID, networks)
+		}
 		if refID, ok := item["ref_id"].(string); ok {
 			collectKnowledgeNetworkIDs(refID, networks)
+		}
+		for _, nested := range item {
+			collectKnowledgeNetworkIDs(nested, networks)
 		}
 	case []any:
 		for _, nested := range item {
@@ -285,16 +288,27 @@ func collectKnowledgeNetworkIDs(value any, networks map[string]struct{}) {
 }
 
 func knowledgeNetworkIDFromCanonicalRef(ref string) string {
-	parts := strings.Split(strings.TrimSpace(ref), ":")
-	if len(parts) > 0 && parts[0] == "business" {
-		parts = parts[1:]
+	ref = strings.TrimSpace(ref)
+	if strings.HasPrefix(ref, "business:") {
+		ref = strings.TrimPrefix(ref, "business:")
 	}
-	if len(parts) == 2 && parts[0] == "kn" {
-		return strings.TrimSpace(parts[1])
-	}
-	if len(parts) >= 3 {
-		switch parts[0] {
-		case "object", "object_instance", "property", "relation", "metric", "logic", "function", "action_type", "action_instance", "resource":
+	for _, refType := range []sessionvo.BusinessRefType{
+		sessionvo.BusinessRefKnowledgeNetwork,
+		sessionvo.BusinessRefObjectType,
+		sessionvo.BusinessRefObjectInstance,
+		sessionvo.BusinessRefProperty,
+		sessionvo.BusinessRefRelationType,
+		sessionvo.BusinessRefMetric,
+		sessionvo.BusinessRefLogic,
+		sessionvo.BusinessRefFunction,
+		sessionvo.BusinessRefActionType,
+		sessionvo.BusinessRefActionInstance,
+	} {
+		if !refType.MatchesCanonicalRefID(ref) {
+			continue
+		}
+		parts := strings.SplitN(ref, ":", 3)
+		if len(parts) >= 2 {
 			return strings.TrimSpace(parts[1])
 		}
 	}

--- a/bkn-trace/agent-observability/src/domain/valueobject/evidencevo/evidence_test.go
+++ b/bkn-trace/agent-observability/src/domain/valueobject/evidencevo/evidence_test.go
@@ -36,12 +36,6 @@ func TestMatchesScopeRequiresEveryPersistedOwnershipDimension(t *testing.T) {
 	if !MatchesScope(trace, QueryScope{TenantID: "tenant_a", BusinessDomain: "domain_a", AccountID: "account_a", AccountType: "user"}) {
 		t.Fatal("exact ownership must match")
 	}
-	if !MatchesScope(trace, QueryScope{TenantID: "tenant_a", BusinessDomain: "domain_a", AccountID: "admin_a", AccountType: "super_admin", CrossAccountRead: true}) {
-		t.Fatal("trusted cross-account readers must match within the same ownership boundary")
-	}
-	if MatchesScope(trace, QueryScope{TenantID: "tenant_a", BusinessDomain: "domain_b", AccountID: "admin_a", AccountType: "super_admin", CrossAccountRead: true}) {
-		t.Fatal("cross-account readers must still be constrained by business domain")
-	}
 }
 
 func TestSameOwnershipComparesEveryPersistedDimension(t *testing.T) {

--- a/bkn-trace/agent-observability/src/domain/valueobject/evidencevo/summary.go
+++ b/bkn-trace/agent-observability/src/domain/valueobject/evidencevo/summary.go
@@ -512,7 +512,11 @@ func collectBusinessRefs(value any, refs map[string]struct{}) {
 	switch item := value.(type) {
 	case map[string]any:
 		if refID, ok := item["ref_id"].(string); ok && refID != "" {
-			refs[refID] = struct{}{}
+			visibility, _ := item["visibility"].(string)
+			if visibility == "" || visibility == "visible" {
+				refs[refID] = struct{}{}
+			}
+			return
 		}
 		for _, nested := range item {
 			collectBusinessRefs(nested, refs)

--- a/bkn-trace/agent-observability/src/domain/valueobject/evidencevo/summary.go
+++ b/bkn-trace/agent-observability/src/domain/valueobject/evidencevo/summary.go
@@ -513,10 +513,10 @@ func collectBusinessRefs(value any, refs map[string]struct{}) {
 	case map[string]any:
 		if refID, ok := item["ref_id"].(string); ok && refID != "" {
 			visibility, _ := item["visibility"].(string)
-			if visibility == "" || visibility == "visible" {
-				refs[refID] = struct{}{}
+			if visibility != "" && visibility != "visible" {
+				return
 			}
-			return
+			refs[refID] = struct{}{}
 		}
 		for _, nested := range item {
 			collectBusinessRefs(nested, refs)
@@ -529,17 +529,7 @@ func collectBusinessRefs(value any, refs map[string]struct{}) {
 }
 
 func knowledgeNetworkFromRef(ref string) string {
-	parts := strings.Split(ref, ":")
-	if len(parts) >= 3 && parts[0] == "business" {
-		parts = parts[1:]
-	}
-	if len(parts) >= 3 {
-		switch parts[0] {
-		case "object", "relation", "action", "metric", "logic":
-			return parts[1]
-		}
-	}
-	return ""
+	return knowledgeNetworkIDFromCanonicalRef(ref)
 }
 
 func advanceActionSummary(summary *ActionSummary, eventType string) {

--- a/bkn-trace/agent-observability/src/drivenadapter/httpaccess/bknsafeaccess/client.go
+++ b/bkn-trace/agent-observability/src/drivenadapter/httpaccess/bknsafeaccess/client.go
@@ -121,7 +121,7 @@ func (c *Client) get(ctx context.Context, path, authorization string, target any
 	if err != nil {
 		return err
 	}
-	defer response.Body.Close()
+	defer func() { _ = response.Body.Close() }()
 	if response.StatusCode != http.StatusOK {
 		_, _ = io.Copy(io.Discard, io.LimitReader(response.Body, maxSafeResponseBytes))
 		return fmt.Errorf("BKN Safe returned status %d", response.StatusCode)

--- a/bkn-trace/agent-observability/src/drivenadapter/httpaccess/bknsafeaccess/client.go
+++ b/bkn-trace/agent-observability/src/drivenadapter/httpaccess/bknsafeaccess/client.go
@@ -1,0 +1,220 @@
+package bknsafeaccess
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"sort"
+	"strings"
+
+	"github.com/openbkn-ai/bkn-foundry/bkn-trace/agent-observability/src/domain/valueobject/evidencevo"
+	"github.com/openbkn-ai/bkn-foundry/bkn-trace/agent-observability/src/port/driven/iauthorizationscope"
+)
+
+const maxSafeResponseBytes = 4 << 20
+
+var builtInRoles = map[string]struct{}{
+	"super_admin": {}, "admin": {}, "security": {}, "audit": {},
+	"network_builder": {}, "normal_user": {},
+}
+
+var networkManagementOperations = map[string]struct{}{
+	"modify": {}, "authorize": {}, "task_manage": {},
+}
+
+type Client struct {
+	baseURL string
+	http    *http.Client
+}
+
+type meResponse struct {
+	ID      string   `json:"id"`
+	Enabled bool     `json:"enabled"`
+	Roles   []string `json:"roles"`
+}
+
+type permissionsResponse struct {
+	Permissions []struct {
+		Resource struct {
+			Type string `json:"type"`
+			ID   string `json:"id"`
+		} `json:"resource"`
+		Operations []string `json:"operations"`
+	} `json:"permissions"`
+}
+
+type fingerprintInput struct {
+	TenantID                    string
+	BusinessDomain              string
+	ActorID                     string
+	EffectiveSubjectID          string
+	ApplicationPrincipalID      string
+	DelegationID                string
+	Roles                       []string
+	ManagedKnowledgeNetworkIDs  []string
+	ManagesAllKnowledgeNetworks bool
+}
+
+func New(baseURL string, httpClient *http.Client) *Client {
+	if httpClient == nil {
+		httpClient = http.DefaultClient
+	}
+	return &Client{baseURL: strings.TrimRight(strings.TrimSpace(baseURL), "/"), http: httpClient}
+}
+
+func (c *Client) Resolve(
+	ctx context.Context,
+	authorization string,
+	identity iauthorizationscope.TrustedIdentity,
+) (evidencevo.AccessProfile, error) {
+	if c.baseURL == "" || strings.TrimSpace(authorization) == "" ||
+		identity.TenantID == "" || identity.ActorID == "" || identity.EffectiveSubjectID == "" {
+		return evidencevo.AccessProfile{}, errors.New("trusted authorization identity is incomplete")
+	}
+
+	var me meResponse
+	if err := c.get(ctx, "/api/safe/v1/me", authorization, &me); err != nil {
+		return evidencevo.AccessProfile{}, fmt.Errorf("resolve current BKN Safe identity: %w", err)
+	}
+	if !me.Enabled || strings.TrimSpace(me.ID) == "" || me.ID != identity.ActorID {
+		return evidencevo.AccessProfile{}, errors.New("current BKN Safe identity is disabled or does not match the trusted actor")
+	}
+
+	var permissions permissionsResponse
+	if err := c.get(ctx, "/api/safe/v1/me/permissions", authorization, &permissions); err != nil {
+		return evidencevo.AccessProfile{}, fmt.Errorf("resolve current BKN Safe permissions: %w", err)
+	}
+
+	roles := currentBuiltInRoles(me.Roles)
+	managedNetworks := concreteManagedNetworks(permissions)
+	managesAllNetworks := contains(roles, "network_builder") && hasTypeWideNetworkManagement(permissions)
+	input := fingerprintInput{
+		TenantID: identity.TenantID, BusinessDomain: identity.BusinessDomain,
+		ActorID: identity.ActorID, EffectiveSubjectID: identity.EffectiveSubjectID,
+		ApplicationPrincipalID: identity.ApplicationPrincipalID, DelegationID: identity.DelegationID,
+		Roles: roles, ManagedKnowledgeNetworkIDs: managedNetworks,
+		ManagesAllKnowledgeNetworks: managesAllNetworks,
+	}
+	return evidencevo.AccessProfile{
+		TenantID: identity.TenantID, BusinessDomain: identity.BusinessDomain,
+		ActorID: identity.ActorID, EffectiveSubjectID: identity.EffectiveSubjectID,
+		ApplicationPrincipalID: identity.ApplicationPrincipalID, DelegationID: identity.DelegationID,
+		Roles: roles, ManagedKnowledgeNetworkIDs: managedNetworks,
+		ManagesAllKnowledgeNetworks: managesAllNetworks,
+		AccountActive:               true, TenantActive: true,
+		Fingerprint: accessScopeFingerprint(input),
+	}, nil
+}
+
+func (c *Client) get(ctx context.Context, path, authorization string, target any) error {
+	request, err := http.NewRequestWithContext(ctx, http.MethodGet, c.baseURL+path, nil)
+	if err != nil {
+		return err
+	}
+	request.Header.Set("Authorization", authorization)
+	response, err := c.http.Do(request)
+	if err != nil {
+		return err
+	}
+	defer response.Body.Close()
+	if response.StatusCode != http.StatusOK {
+		_, _ = io.Copy(io.Discard, io.LimitReader(response.Body, maxSafeResponseBytes))
+		return fmt.Errorf("BKN Safe returned status %d", response.StatusCode)
+	}
+	decoder := json.NewDecoder(io.LimitReader(response.Body, maxSafeResponseBytes))
+	if err := decoder.Decode(target); err != nil {
+		return fmt.Errorf("decode BKN Safe response: %w", err)
+	}
+	return nil
+}
+
+func currentBuiltInRoles(values []string) []string {
+	roles := make([]string, 0, len(values))
+	seen := map[string]struct{}{}
+	for _, role := range values {
+		role = strings.TrimSpace(role)
+		if _, known := builtInRoles[role]; !known {
+			continue
+		}
+		if _, duplicate := seen[role]; duplicate {
+			continue
+		}
+		seen[role] = struct{}{}
+		roles = append(roles, role)
+	}
+	sort.Strings(roles)
+	return roles
+}
+
+func concreteManagedNetworks(response permissionsResponse) []string {
+	networks := map[string]struct{}{}
+	for _, permission := range response.Permissions {
+		if permission.Resource.Type != "knowledge_network" || permission.Resource.ID == "" || permission.Resource.ID == "*" {
+			continue
+		}
+		for _, operation := range permission.Operations {
+			if _, allowed := networkManagementOperations[operation]; allowed {
+				networks[permission.Resource.ID] = struct{}{}
+				break
+			}
+		}
+	}
+	values := make([]string, 0, len(networks))
+	for networkID := range networks {
+		values = append(values, networkID)
+	}
+	sort.Strings(values)
+	return values
+}
+
+func hasTypeWideNetworkManagement(response permissionsResponse) bool {
+	for _, permission := range response.Permissions {
+		if permission.Resource.Type != "knowledge_network" || permission.Resource.ID != "*" {
+			continue
+		}
+		for _, operation := range permission.Operations {
+			if _, allowed := networkManagementOperations[operation]; allowed {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func contains(values []string, expected string) bool {
+	for _, value := range values {
+		if value == expected {
+			return true
+		}
+	}
+	return false
+}
+
+func accessScopeFingerprint(input fingerprintInput) string {
+	roles := append([]string(nil), input.Roles...)
+	networks := append([]string(nil), input.ManagedKnowledgeNetworkIDs...)
+	sort.Strings(roles)
+	sort.Strings(networks)
+	body, _ := json.Marshal(struct {
+		TenantID                    string   `json:"tenant_id"`
+		BusinessDomain              string   `json:"business_domain"`
+		ActorID                     string   `json:"actor_id"`
+		EffectiveSubjectID          string   `json:"effective_subject_id"`
+		ApplicationPrincipalID      string   `json:"application_principal_id"`
+		DelegationID                string   `json:"delegation_id"`
+		Roles                       []string `json:"roles"`
+		ManagedKnowledgeNetworkIDs  []string `json:"managed_knowledge_network_ids"`
+		ManagesAllKnowledgeNetworks bool     `json:"manages_all_knowledge_networks"`
+	}{
+		input.TenantID, input.BusinessDomain, input.ActorID, input.EffectiveSubjectID,
+		input.ApplicationPrincipalID, input.DelegationID, roles, networks,
+		input.ManagesAllKnowledgeNetworks,
+	})
+	sum := sha256.Sum256(body)
+	return "sha256:" + hex.EncodeToString(sum[:])
+}

--- a/bkn-trace/agent-observability/src/drivenadapter/httpaccess/bknsafeaccess/client.go
+++ b/bkn-trace/agent-observability/src/drivenadapter/httpaccess/bknsafeaccess/client.go
@@ -49,15 +49,14 @@ type permissionsResponse struct {
 }
 
 type fingerprintInput struct {
-	TenantID                    string
-	BusinessDomain              string
-	ActorID                     string
-	EffectiveSubjectID          string
-	ApplicationPrincipalID      string
-	DelegationID                string
-	Roles                       []string
-	ManagedKnowledgeNetworkIDs  []string
-	ManagesAllKnowledgeNetworks bool
+	TenantID                   string
+	BusinessDomain             string
+	ActorID                    string
+	EffectiveSubjectID         string
+	ApplicationPrincipalID     string
+	DelegationID               string
+	Roles                      []string
+	ManagedKnowledgeNetworkIDs []string
 }
 
 func New(baseURL string, httpClient *http.Client) *Client {
@@ -92,21 +91,18 @@ func (c *Client) Resolve(
 
 	roles := currentBuiltInRoles(me.Roles)
 	managedNetworks := concreteManagedNetworks(permissions)
-	managesAllNetworks := contains(roles, "network_builder") && hasTypeWideNetworkManagement(permissions)
 	input := fingerprintInput{
 		TenantID: identity.TenantID, BusinessDomain: identity.BusinessDomain,
 		ActorID: identity.ActorID, EffectiveSubjectID: identity.EffectiveSubjectID,
 		ApplicationPrincipalID: identity.ApplicationPrincipalID, DelegationID: identity.DelegationID,
 		Roles: roles, ManagedKnowledgeNetworkIDs: managedNetworks,
-		ManagesAllKnowledgeNetworks: managesAllNetworks,
 	}
 	return evidencevo.AccessProfile{
 		TenantID: identity.TenantID, BusinessDomain: identity.BusinessDomain,
 		ActorID: identity.ActorID, EffectiveSubjectID: identity.EffectiveSubjectID,
 		ApplicationPrincipalID: identity.ApplicationPrincipalID, DelegationID: identity.DelegationID,
 		Roles: roles, ManagedKnowledgeNetworkIDs: managedNetworks,
-		ManagesAllKnowledgeNetworks: managesAllNetworks,
-		AccountActive:               true, TenantActive: true,
+		AccountActive: true, TenantActive: true,
 		Fingerprint: accessScopeFingerprint(input),
 	}, nil
 }
@@ -172,48 +168,23 @@ func concreteManagedNetworks(response permissionsResponse) []string {
 	return values
 }
 
-func hasTypeWideNetworkManagement(response permissionsResponse) bool {
-	for _, permission := range response.Permissions {
-		if permission.Resource.Type != "knowledge_network" || permission.Resource.ID != "*" {
-			continue
-		}
-		for _, operation := range permission.Operations {
-			if _, allowed := networkManagementOperations[operation]; allowed {
-				return true
-			}
-		}
-	}
-	return false
-}
-
-func contains(values []string, expected string) bool {
-	for _, value := range values {
-		if value == expected {
-			return true
-		}
-	}
-	return false
-}
-
 func accessScopeFingerprint(input fingerprintInput) string {
 	roles := append([]string(nil), input.Roles...)
 	networks := append([]string(nil), input.ManagedKnowledgeNetworkIDs...)
 	sort.Strings(roles)
 	sort.Strings(networks)
 	body, _ := json.Marshal(struct {
-		TenantID                    string   `json:"tenant_id"`
-		BusinessDomain              string   `json:"business_domain"`
-		ActorID                     string   `json:"actor_id"`
-		EffectiveSubjectID          string   `json:"effective_subject_id"`
-		ApplicationPrincipalID      string   `json:"application_principal_id"`
-		DelegationID                string   `json:"delegation_id"`
-		Roles                       []string `json:"roles"`
-		ManagedKnowledgeNetworkIDs  []string `json:"managed_knowledge_network_ids"`
-		ManagesAllKnowledgeNetworks bool     `json:"manages_all_knowledge_networks"`
+		TenantID                   string   `json:"tenant_id"`
+		BusinessDomain             string   `json:"business_domain"`
+		ActorID                    string   `json:"actor_id"`
+		EffectiveSubjectID         string   `json:"effective_subject_id"`
+		ApplicationPrincipalID     string   `json:"application_principal_id"`
+		DelegationID               string   `json:"delegation_id"`
+		Roles                      []string `json:"roles"`
+		ManagedKnowledgeNetworkIDs []string `json:"managed_knowledge_network_ids"`
 	}{
 		input.TenantID, input.BusinessDomain, input.ActorID, input.EffectiveSubjectID,
 		input.ApplicationPrincipalID, input.DelegationID, roles, networks,
-		input.ManagesAllKnowledgeNetworks,
 	})
 	sum := sha256.Sum256(body)
 	return "sha256:" + hex.EncodeToString(sum[:])

--- a/bkn-trace/agent-observability/src/drivenadapter/httpaccess/bknsafeaccess/client_test.go
+++ b/bkn-trace/agent-observability/src/drivenadapter/httpaccess/bknsafeaccess/client_test.go
@@ -1,0 +1,131 @@
+package bknsafeaccess
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"reflect"
+	"testing"
+
+	"github.com/openbkn-ai/bkn-foundry/bkn-trace/agent-observability/src/port/driven/iauthorizationscope"
+)
+
+func TestResolveBuildsProfileFromCurrentSafeIdentityAndNetworkGrants(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("Authorization") != "Bearer current-token" {
+			t.Fatalf("authorization was not forwarded to BKN Safe")
+		}
+		switch r.URL.Path {
+		case "/api/safe/v1/me":
+			_, _ = w.Write([]byte(`{"id":"actor-a","account_type":"user","enabled":true,"roles":["network_builder","unknown-role"]}`))
+		case "/api/safe/v1/me/permissions":
+			_, _ = w.Write([]byte(`{"is_admin":true,"permissions":[
+				{"resource":{"type":"*","id":"*"},"operations":["*"]},
+				{"resource":{"type":"knowledge_network","id":"*"},"operations":["modify"]},
+				{"resource":{"type":"knowledge_network","id":"kn-b"},"operations":["view_detail","task_manage"]},
+				{"resource":{"type":"knowledge_network","id":"kn-a"},"operations":["authorize"]},
+				{"resource":{"type":"knowledge_network","id":"kn-c"},"operations":["view_detail"]}
+			]}`))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	client := New(server.URL, server.Client())
+	profile, err := client.Resolve(context.Background(), "Bearer current-token", iauthorizationscope.TrustedIdentity{
+		TenantID: "tenant-a", BusinessDomain: "domain-a", ActorID: "actor-a",
+		EffectiveSubjectID: "user-a", ApplicationPrincipalID: "app-a", DelegationID: "delegation-a",
+	})
+	if err != nil {
+		t.Fatalf("resolve profile: %v", err)
+	}
+	if !profile.AccountActive || !profile.TenantActive || profile.ActorID != "actor-a" ||
+		profile.EffectiveSubjectID != "user-a" || profile.ApplicationPrincipalID != "app-a" {
+		t.Fatalf("unexpected trusted identity projection: %+v", profile)
+	}
+	if !reflect.DeepEqual(profile.Roles, []string{"network_builder"}) {
+		t.Fatalf("only current built-in roles may enter the profile: %v", profile.Roles)
+	}
+	if !reflect.DeepEqual(profile.ManagedKnowledgeNetworkIDs, []string{"kn-a", "kn-b"}) {
+		t.Fatalf("only concrete management grants may enter the profile: %v", profile.ManagedKnowledgeNetworkIDs)
+	}
+	if !profile.ManagesAllKnowledgeNetworks {
+		t.Fatal("network_builder knowledge_network:* management grant must enter the profile")
+	}
+	if profile.Fingerprint == "" {
+		t.Fatal("access scope fingerprint is required")
+	}
+}
+
+func TestResolveDoesNotTreatGlobalAdminWildcardAsNetworkManagement(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/safe/v1/me":
+			_, _ = w.Write([]byte(`{"id":"actor-a","enabled":true,"roles":["super_admin"]}`))
+		case "/api/safe/v1/me/permissions":
+			_, _ = w.Write([]byte(`{"permissions":[{"resource":{"type":"*","id":"*"},"operations":["*"]}]}`))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	profile, err := New(server.URL, server.Client()).Resolve(
+		context.Background(), "Bearer current-token", iauthorizationscope.TrustedIdentity{
+			TenantID: "tenant-a", ActorID: "actor-a", EffectiveSubjectID: "actor-a",
+		},
+	)
+	if err != nil {
+		t.Fatalf("resolve profile: %v", err)
+	}
+	if profile.ManagesAllKnowledgeNetworks {
+		t.Fatal("global super_admin wildcard must not imply knowledge network business access")
+	}
+}
+
+func TestResolveFailsClosedForDisabledOrMismatchedIdentity(t *testing.T) {
+	for _, body := range []string{
+		`{"id":"actor-a","account_type":"user","enabled":false,"roles":["normal_user"]}`,
+		`{"id":"different-actor","account_type":"user","enabled":true,"roles":["normal_user"]}`,
+	} {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if r.URL.Path == "/api/safe/v1/me" {
+				_, _ = w.Write([]byte(body))
+				return
+			}
+			_, _ = w.Write([]byte(`{"permissions":[]}`))
+		}))
+		client := New(server.URL, server.Client())
+		_, err := client.Resolve(context.Background(), "Bearer token", iauthorizationscope.TrustedIdentity{
+			TenantID: "tenant-a", BusinessDomain: "domain-a", ActorID: "actor-a", EffectiveSubjectID: "user-a",
+		})
+		server.Close()
+		if err == nil {
+			t.Fatalf("disabled or mismatched current identity must fail closed: %s", body)
+		}
+	}
+}
+
+func TestResolveFingerprintIsStableAndChangesWithManagedScope(t *testing.T) {
+	first := fingerprintInput{
+		TenantID: "tenant-a", BusinessDomain: "domain-a", ActorID: "actor-a",
+		EffectiveSubjectID: "user-a", Roles: []string{"normal_user", "network_builder"},
+		ManagedKnowledgeNetworkIDs: []string{"kn-b", "kn-a"},
+	}
+	second := first
+	second.Roles = []string{"network_builder", "normal_user"}
+	second.ManagedKnowledgeNetworkIDs = []string{"kn-a", "kn-b"}
+	if accessScopeFingerprint(first) != accessScopeFingerprint(second) {
+		t.Fatal("equivalent access scopes must have the same fingerprint")
+	}
+	second.ManagedKnowledgeNetworkIDs = []string{"kn-a"}
+	if accessScopeFingerprint(first) == accessScopeFingerprint(second) {
+		t.Fatal("managed network revocation must change the fingerprint")
+	}
+	second = first
+	second.ManagesAllKnowledgeNetworks = true
+	if accessScopeFingerprint(first) == accessScopeFingerprint(second) {
+		t.Fatal("type-wide network management must change the fingerprint")
+	}
+}

--- a/bkn-trace/agent-observability/src/drivenadapter/httpaccess/bknsafeaccess/client_test.go
+++ b/bkn-trace/agent-observability/src/drivenadapter/httpaccess/bknsafeaccess/client_test.go
@@ -50,9 +50,6 @@ func TestResolveBuildsProfileFromCurrentSafeIdentityAndNetworkGrants(t *testing.
 	if !reflect.DeepEqual(profile.ManagedKnowledgeNetworkIDs, []string{"kn-a", "kn-b"}) {
 		t.Fatalf("only concrete management grants may enter the profile: %v", profile.ManagedKnowledgeNetworkIDs)
 	}
-	if !profile.ManagesAllKnowledgeNetworks {
-		t.Fatal("network_builder knowledge_network:* management grant must enter the profile")
-	}
 	if profile.Fingerprint == "" {
 		t.Fatal("access scope fingerprint is required")
 	}
@@ -79,8 +76,8 @@ func TestResolveDoesNotTreatGlobalAdminWildcardAsNetworkManagement(t *testing.T)
 	if err != nil {
 		t.Fatalf("resolve profile: %v", err)
 	}
-	if profile.ManagesAllKnowledgeNetworks {
-		t.Fatal("global super_admin wildcard must not imply knowledge network business access")
+	if len(profile.ManagedKnowledgeNetworkIDs) != 0 {
+		t.Fatal("global super_admin wildcard must not imply concrete knowledge network business access")
 	}
 }
 
@@ -122,10 +119,5 @@ func TestResolveFingerprintIsStableAndChangesWithManagedScope(t *testing.T) {
 	second.ManagedKnowledgeNetworkIDs = []string{"kn-a"}
 	if accessScopeFingerprint(first) == accessScopeFingerprint(second) {
 		t.Fatal("managed network revocation must change the fingerprint")
-	}
-	second = first
-	second.ManagesAllKnowledgeNetworks = true
-	if accessScopeFingerprint(first) == accessScopeFingerprint(second) {
-		t.Fatal("type-wide network management must change the fingerprint")
 	}
 }

--- a/bkn-trace/agent-observability/src/drivenadapter/httpaccess/opensearchevidencestore/artifact_store.go
+++ b/bkn-trace/agent-observability/src/drivenadapter/httpaccess/opensearchevidencestore/artifact_store.go
@@ -11,32 +11,35 @@ import (
 	"github.com/openbkn-ai/bkn-foundry/bkn-trace/agent-observability/src/port/driven/iartifactstore"
 )
 
-const artifactIndexMapping = `{"settings":{"index.mapping.total_fields.limit":200},"mappings":{"dynamic":false,"properties":{"artifact_id":{"type":"keyword"},"artifact_type":{"type":"keyword"},"trace_id":{"type":"keyword"},"interaction_id":{"type":"keyword"},"operation_id":{"type":"keyword"},"claim_id":{"type":"keyword"},"source_ref":{"type":"keyword"},"business_refs":{"type":"keyword"},"content_type":{"type":"keyword"},"schema_version":{"type":"keyword"},"observed_at":{"type":"date"},"as_of":{"type":"date"},"source_version":{"type":"keyword"},"content_hash":{"type":"keyword"},"content_json":{"type":"keyword","index":false,"doc_values":false},"snapshot_ref":{"type":"keyword"},"business_domain":{"type":"keyword"},"initiator":{"type":"keyword"},"agent_or_app":{"type":"keyword"},"bkn":{"properties":{"tenant":{"properties":{"id":{"type":"keyword"}}},"account":{"properties":{"id":{"type":"keyword"},"type":{"type":"keyword"}}},"request":{"properties":{"id":{"type":"keyword"}}}}}}}}`
+const artifactIndexMapping = `{"settings":{"index.mapping.total_fields.limit":200},"mappings":{"dynamic":false,"properties":{"artifact_id":{"type":"keyword"},"artifact_type":{"type":"keyword"},"trace_id":{"type":"keyword"},"interaction_id":{"type":"keyword"},"operation_id":{"type":"keyword"},"claim_id":{"type":"keyword"},"source_ref":{"type":"keyword"},"business_refs":{"type":"keyword"},"content_type":{"type":"keyword"},"schema_version":{"type":"keyword"},"observed_at":{"type":"date"},"as_of":{"type":"date"},"source_version":{"type":"keyword"},"content_hash":{"type":"keyword"},"content_json":{"type":"keyword","index":false,"doc_values":false},"snapshot_ref":{"type":"keyword"},"business_domain":{"type":"keyword"},"effective_subject_id":{"type":"keyword"},"application_principal_id":{"type":"keyword"},"knowledge_network_ids":{"type":"keyword"},"initiator":{"type":"keyword"},"agent_or_app":{"type":"keyword"},"bkn":{"properties":{"tenant":{"properties":{"id":{"type":"keyword"}}},"account":{"properties":{"id":{"type":"keyword"},"type":{"type":"keyword"}}},"request":{"properties":{"id":{"type":"keyword"}}}}}}}}`
 
 type artifactDocument struct {
-	ArtifactID     string                  `json:"artifact_id"`
-	ArtifactType   evidencevo.ArtifactType `json:"artifact_type"`
-	RequestID      string                  `json:"bkn.request.id"`
-	TraceID        string                  `json:"trace_id,omitempty"`
-	InteractionID  string                  `json:"interaction_id,omitempty"`
-	OperationID    string                  `json:"operation_id,omitempty"`
-	ClaimID        string                  `json:"claim_id,omitempty"`
-	SourceRef      string                  `json:"source_ref,omitempty"`
-	BusinessRefs   []string                `json:"business_refs,omitempty"`
-	ContentType    string                  `json:"content_type"`
-	SchemaVersion  string                  `json:"schema_version"`
-	ObservedAt     string                  `json:"observed_at"`
-	AsOf           string                  `json:"as_of,omitempty"`
-	SourceVersion  string                  `json:"source_version,omitempty"`
-	ContentHash    string                  `json:"content_hash"`
-	ContentJSON    string                  `json:"content_json,omitempty"`
-	SnapshotRef    string                  `json:"snapshot_ref,omitempty"`
-	TenantID       string                  `json:"bkn.tenant.id,omitempty"`
-	BusinessDomain string                  `json:"business_domain,omitempty"`
-	AccountID      string                  `json:"bkn.account.id"`
-	AccountType    string                  `json:"bkn.account.type"`
-	Initiator      string                  `json:"initiator,omitempty"`
-	AgentOrApp     string                  `json:"agent_or_app,omitempty"`
+	ArtifactID             string                  `json:"artifact_id"`
+	ArtifactType           evidencevo.ArtifactType `json:"artifact_type"`
+	RequestID              string                  `json:"bkn.request.id"`
+	TraceID                string                  `json:"trace_id,omitempty"`
+	InteractionID          string                  `json:"interaction_id,omitempty"`
+	OperationID            string                  `json:"operation_id,omitempty"`
+	ClaimID                string                  `json:"claim_id,omitempty"`
+	SourceRef              string                  `json:"source_ref,omitempty"`
+	BusinessRefs           []string                `json:"business_refs,omitempty"`
+	ContentType            string                  `json:"content_type"`
+	SchemaVersion          string                  `json:"schema_version"`
+	ObservedAt             string                  `json:"observed_at"`
+	AsOf                   string                  `json:"as_of,omitempty"`
+	SourceVersion          string                  `json:"source_version,omitempty"`
+	ContentHash            string                  `json:"content_hash"`
+	ContentJSON            string                  `json:"content_json,omitempty"`
+	SnapshotRef            string                  `json:"snapshot_ref,omitempty"`
+	TenantID               string                  `json:"bkn.tenant.id,omitempty"`
+	BusinessDomain         string                  `json:"business_domain,omitempty"`
+	AccountID              string                  `json:"bkn.account.id"`
+	AccountType            string                  `json:"bkn.account.type"`
+	EffectiveSubjectID     string                  `json:"effective_subject_id,omitempty"`
+	ApplicationPrincipalID string                  `json:"application_principal_id,omitempty"`
+	KnowledgeNetworkIDs    []string                `json:"knowledge_network_ids,omitempty"`
+	Initiator              string                  `json:"initiator,omitempty"`
+	AgentOrApp             string                  `json:"agent_or_app,omitempty"`
 }
 
 func (s *Store) StoreArtifact(ctx context.Context, artifact evidencevo.EvidenceArtifact) (bool, error) {
@@ -120,7 +123,7 @@ func (s *Store) ListArtifactsByRequestID(ctx context.Context, requestID string, 
 		{"bkn.account.id", scope.AccountID},
 		{"bkn.account.type", scope.AccountType},
 	} {
-		if scope.CrossAccountRead && (item.field == "bkn.account.id" || item.field == "bkn.account.type") {
+		if evidencevo.NeedsCrossAccountCandidates(scope) && (item.field == "bkn.account.id" || item.field == "bkn.account.type") {
 			continue
 		}
 		if item.value != "" {
@@ -180,7 +183,9 @@ func toArtifactDocument(artifact evidencevo.EvidenceArtifact) (artifactDocument,
 		ContentHash: artifact.ContentHash, SnapshotRef: artifact.SnapshotRef,
 		TenantID: artifact.TenantID, BusinessDomain: artifact.BusinessDomain,
 		AccountID: artifact.AccountID, AccountType: artifact.AccountType,
-		Initiator: artifact.Initiator, AgentOrApp: artifact.AgentOrApp,
+		EffectiveSubjectID: artifact.EffectiveSubjectID, ApplicationPrincipalID: artifact.ApplicationPrincipalID,
+		KnowledgeNetworkIDs: append([]string(nil), artifact.KnowledgeNetworkIDs...),
+		Initiator:           artifact.Initiator, AgentOrApp: artifact.AgentOrApp,
 	}
 	if artifact.Content != nil {
 		content, err := json.Marshal(artifact.Content)
@@ -207,7 +212,9 @@ func decodeArtifactDocument(body []byte) (evidencevo.EvidenceArtifact, error) {
 		ContentHash: document.ContentHash, SnapshotRef: document.SnapshotRef,
 		TenantID: document.TenantID, BusinessDomain: document.BusinessDomain,
 		AccountID: document.AccountID, AccountType: document.AccountType,
-		Initiator: document.Initiator, AgentOrApp: document.AgentOrApp,
+		EffectiveSubjectID: document.EffectiveSubjectID, ApplicationPrincipalID: document.ApplicationPrincipalID,
+		KnowledgeNetworkIDs: append([]string(nil), document.KnowledgeNetworkIDs...),
+		Initiator:           document.Initiator, AgentOrApp: document.AgentOrApp,
 	}
 	if document.ContentJSON != "" {
 		if err := json.Unmarshal([]byte(document.ContentJSON), &artifact.Content); err != nil {

--- a/bkn-trace/agent-observability/src/drivenadapter/httpaccess/opensearchevidencestore/artifact_store.go
+++ b/bkn-trace/agent-observability/src/drivenadapter/httpaccess/opensearchevidencestore/artifact_store.go
@@ -114,22 +114,7 @@ func (s *Store) ListArtifactsByRequestID(ctx context.Context, requestID string, 
 		limit = iartifactstore.MaxArtifactQueryLimit
 	}
 	must := []map[string]any{{"bool": exactTermQuery("bkn.request.id", requestID)}}
-	for _, item := range []struct {
-		field string
-		value string
-	}{
-		{"bkn.tenant.id", scope.TenantID},
-		{"business_domain", scope.BusinessDomain},
-		{"bkn.account.id", scope.AccountID},
-		{"bkn.account.type", scope.AccountType},
-	} {
-		if evidencevo.NeedsCrossAccountCandidates(scope) && (item.field == "bkn.account.id" || item.field == "bkn.account.type") {
-			continue
-		}
-		if item.value != "" {
-			must = append(must, map[string]any{"bool": exactTermQuery(item.field, item.value)})
-		}
-	}
+	must = append(must, scopeCandidateMust(scope)...)
 	query, err := json.Marshal(map[string]any{
 		"size":  limit + 1,
 		"query": map[string]any{"bool": map[string]any{"must": must}},

--- a/bkn-trace/agent-observability/src/drivenadapter/httpaccess/opensearchevidencestore/artifact_store_test.go
+++ b/bkn-trace/agent-observability/src/drivenadapter/httpaccess/opensearchevidencestore/artifact_store_test.go
@@ -141,6 +141,44 @@ func TestOpenSearchArtifactStoreFailsClosedByOwnership(t *testing.T) {
 	}
 }
 
+func TestOpenSearchArtifactStorePersistsRecordScopeForNetworkBuilder(t *testing.T) {
+	backend := newArtifactBackend()
+	store := New(newFakeOpenSearchClient(backend.roundTrip), "bkn-trace-evidence-test")
+	artifact := normalizedOpenSearchArtifact(t)
+	artifact.AccountID = "other-user"
+	artifact.AccountType = "user"
+	artifact.EffectiveSubjectID = "other-user"
+	artifact.ApplicationPrincipalID = "app-a"
+	artifact.BusinessRefs = []string{"object:kn-a:forecast", "property:kn-b:forecast:qty"}
+	artifact, validationErrors := evidencevo.NormalizeArtifact(artifact)
+	if len(validationErrors) != 0 {
+		t.Fatalf("normalize artifact: %+v", validationErrors)
+	}
+	if _, err := store.StoreArtifact(context.Background(), artifact); err != nil {
+		t.Fatal(err)
+	}
+	scope := evidencevo.QueryScope{View: evidencevo.AccessViewBusiness, AccessProfile: &evidencevo.AccessProfile{
+		TenantID: artifact.TenantID, BusinessDomain: artifact.BusinessDomain,
+		EffectiveSubjectID: "builder-a", Roles: []string{"network_builder"},
+		ManagedKnowledgeNetworkIDs: []string{"kn-a", "kn-b"}, AccountActive: true, TenantActive: true,
+	}}
+
+	restored, found, err := store.GetArtifact(context.Background(), artifact.ArtifactID, scope)
+
+	if err != nil || !found {
+		t.Fatalf("network builder must read a fully managed record: found=%v err=%v", found, err)
+	}
+	if restored.EffectiveSubjectID != "other-user" || restored.ApplicationPrincipalID != "app-a" ||
+		!reflect.DeepEqual(restored.KnowledgeNetworkIDs, []string{"kn-a", "kn-b"}) {
+		t.Fatalf("record scope was not preserved: %+v", restored)
+	}
+	for _, field := range []string{"effective_subject_id", "application_principal_id", "knowledge_network_ids"} {
+		if !strings.Contains(backend.mapping, `"`+field+`":{"type":"keyword"}`) {
+			t.Fatalf("artifact index must map %s: %s", field, backend.mapping)
+		}
+	}
+}
+
 func TestOpenSearchArtifactListUsesOwnershipFiltersAndReturnFilter(t *testing.T) {
 	backend := newArtifactBackend()
 	store := New(newFakeOpenSearchClient(backend.roundTrip), "bkn-trace-evidence-test")

--- a/bkn-trace/agent-observability/src/drivenadapter/httpaccess/opensearchevidencestore/projection_source.go
+++ b/bkn-trace/agent-observability/src/drivenadapter/httpaccess/opensearchevidencestore/projection_source.go
@@ -309,7 +309,7 @@ func ownershipMust(scope evidencevo.QueryScope) []map[string]any {
 		{"bkn.account.id", scope.AccountID},
 		{"bkn.account.type", scope.AccountType},
 	} {
-		if scope.CrossAccountRead && (item.field == "bkn.account.id" || item.field == "bkn.account.type") {
+		if evidencevo.NeedsCrossAccountCandidates(scope) && (item.field == "bkn.account.id" || item.field == "bkn.account.type") {
 			continue
 		}
 		if item.value != "" {

--- a/bkn-trace/agent-observability/src/drivenadapter/httpaccess/opensearchevidencestore/projection_source.go
+++ b/bkn-trace/agent-observability/src/drivenadapter/httpaccess/opensearchevidencestore/projection_source.go
@@ -299,24 +299,7 @@ func appendEvidenceTimeFilter(must []map[string]any, query iprojectionsource.Que
 }
 
 func ownershipMust(scope evidencevo.QueryScope) []map[string]any {
-	must := make([]map[string]any, 0, 4)
-	for _, item := range []struct {
-		field string
-		value string
-	}{
-		{"bkn.tenant.id", scope.TenantID},
-		{"business_domain", scope.BusinessDomain},
-		{"bkn.account.id", scope.AccountID},
-		{"bkn.account.type", scope.AccountType},
-	} {
-		if evidencevo.NeedsCrossAccountCandidates(scope) && (item.field == "bkn.account.id" || item.field == "bkn.account.type") {
-			continue
-		}
-		if item.value != "" {
-			must = append(must, map[string]any{"bool": exactTermQuery(item.field, item.value)})
-		}
-	}
-	return must
+	return scopeCandidateMust(scope)
 }
 
 func projectionTracesFromHits(hits []evidenceHit, scope evidencevo.QueryScope) []evidencevo.NormalizedTrace {

--- a/bkn-trace/agent-observability/src/drivenadapter/httpaccess/opensearchevidencestore/projection_source_test.go
+++ b/bkn-trace/agent-observability/src/drivenadapter/httpaccess/opensearchevidencestore/projection_source_test.go
@@ -396,10 +396,15 @@ func TestOpenSearchProjectionSourceStopsAtScanCapAndMarksTruncated(t *testing.T)
 	}
 }
 
-func TestOwnershipMustSkipsAccountFiltersForCrossAccountReaders(t *testing.T) {
+func TestOwnershipMustSkipsAccountFiltersOnlyForExplicitTechnicalView(t *testing.T) {
+	profile := &evidencevo.AccessProfile{
+		TenantID: "tenant_index", BusinessDomain: "bd_index", AccountActive: true, TenantActive: true,
+		EffectiveSubjectID: "admin_index", Roles: []string{"super_admin"},
+	}
 	must := ownershipMust(evidencevo.QueryScope{
 		TenantID: "tenant_index", BusinessDomain: "bd_index",
-		AccountID: "admin_index", AccountType: "super_admin", CrossAccountRead: true,
+		AccountID: "admin_index", AccountType: "super_admin",
+		AccessProfile: profile, View: evidencevo.AccessViewTechnical,
 	})
 	body, err := json.Marshal(must)
 	if err != nil {

--- a/bkn-trace/agent-observability/src/drivenadapter/httpaccess/opensearchevidencestore/scope_query.go
+++ b/bkn-trace/agent-observability/src/drivenadapter/httpaccess/opensearchevidencestore/scope_query.go
@@ -38,7 +38,7 @@ func scopeCandidateMust(scope evidencevo.QueryScope) []map[string]any {
 		ownerMust := appendLegacyOwnerMust(nil, scope)
 		should = append(should, map[string]any{"bool": map[string]any{"must": ownerMust}})
 	}
-	if len(profile.ManagedKnowledgeNetworkIDs) > 0 {
+	if evidencevo.NeedsCrossAccountCandidates(scope) {
 		should = append(should, map[string]any{"terms": map[string]any{
 			"knowledge_network_ids": profile.ManagedKnowledgeNetworkIDs,
 		}})

--- a/bkn-trace/agent-observability/src/drivenadapter/httpaccess/opensearchevidencestore/scope_query.go
+++ b/bkn-trace/agent-observability/src/drivenadapter/httpaccess/opensearchevidencestore/scope_query.go
@@ -1,0 +1,67 @@
+package opensearchevidencestore
+
+import "github.com/openbkn-ai/bkn-foundry/bkn-trace/agent-observability/src/domain/valueobject/evidencevo"
+
+func scopeCandidateMust(scope evidencevo.QueryScope) []map[string]any {
+	must := make([]map[string]any, 0, 3)
+	for _, item := range []struct {
+		field string
+		value string
+	}{
+		{"bkn.tenant.id", scope.TenantID},
+		{"business_domain", scope.BusinessDomain},
+	} {
+		if item.value != "" {
+			must = append(must, map[string]any{"bool": exactTermQuery(item.field, item.value)})
+		}
+	}
+
+	if scope.AccessProfile == nil {
+		return appendLegacyOwnerMust(must, scope)
+	}
+	if scope.View != "" && scope.View != evidencevo.AccessViewBusiness {
+		if evidencevo.NeedsCrossAccountCandidates(scope) {
+			return must
+		}
+		return appendLegacyOwnerMust(must, scope)
+	}
+
+	profile := *scope.AccessProfile
+	should := make([]map[string]any, 0, 4)
+	if profile.EffectiveSubjectID != "" {
+		should = append(should, map[string]any{"bool": exactTermQuery("effective_subject_id", profile.EffectiveSubjectID)})
+	}
+	if profile.ApplicationPrincipalID != "" {
+		should = append(should, map[string]any{"bool": exactTermQuery("application_principal_id", profile.ApplicationPrincipalID)})
+	}
+	if scope.AccountID != "" {
+		ownerMust := appendLegacyOwnerMust(nil, scope)
+		should = append(should, map[string]any{"bool": map[string]any{"must": ownerMust}})
+	}
+	if len(profile.ManagedKnowledgeNetworkIDs) > 0 {
+		should = append(should, map[string]any{"terms": map[string]any{
+			"knowledge_network_ids": profile.ManagedKnowledgeNetworkIDs,
+		}})
+	}
+	if len(should) == 0 {
+		return appendLegacyOwnerMust(must, scope)
+	}
+	return append(must, map[string]any{"bool": map[string]any{
+		"should": should, "minimum_should_match": 1,
+	}})
+}
+
+func appendLegacyOwnerMust(must []map[string]any, scope evidencevo.QueryScope) []map[string]any {
+	for _, item := range []struct {
+		field string
+		value string
+	}{
+		{"bkn.account.id", scope.AccountID},
+		{"bkn.account.type", scope.AccountType},
+	} {
+		if item.value != "" {
+			must = append(must, map[string]any{"bool": exactTermQuery(item.field, item.value)})
+		}
+	}
+	return must
+}

--- a/bkn-trace/agent-observability/src/drivenadapter/httpaccess/opensearchevidencestore/scope_query_test.go
+++ b/bkn-trace/agent-observability/src/drivenadapter/httpaccess/opensearchevidencestore/scope_query_test.go
@@ -1,0 +1,85 @@
+package opensearchevidencestore
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/openbkn-ai/bkn-foundry/bkn-trace/agent-observability/src/domain/valueobject/evidencevo"
+)
+
+func TestScopeCandidateMustPushesDownBusinessRecordScope(t *testing.T) {
+	profile := &evidencevo.AccessProfile{
+		TenantID: "tenant-a", BusinessDomain: "domain-a",
+		EffectiveSubjectID: "builder-a", ApplicationPrincipalID: "app-a",
+		Roles: []string{"network_builder"}, ManagedKnowledgeNetworkIDs: []string{"kn-a", "kn-b"},
+		AccountActive: true, TenantActive: true,
+	}
+	must := scopeCandidateMust(evidencevo.QueryScope{
+		TenantID: "tenant-a", BusinessDomain: "domain-a", AccountID: "builder-a", AccountType: "user",
+		View: evidencevo.AccessViewBusiness, AccessProfile: profile,
+	})
+
+	rendered := mustJSON(t, must)
+	for _, expected := range []string{
+		"bkn.tenant.id", "business_domain", "effective_subject_id", "application_principal_id",
+		"bkn.account.id", "bkn.account.type", "knowledge_network_ids", "kn-a", "kn-b",
+		`"minimum_should_match":1`,
+	} {
+		if !strings.Contains(rendered, expected) {
+			t.Fatalf("candidate query must contain %q: %s", expected, rendered)
+		}
+	}
+}
+
+func TestScopeCandidateMustDoesNotTreatTypeWideNetworkGrantAsBusinessContentAccess(t *testing.T) {
+	profile := &evidencevo.AccessProfile{
+		TenantID: "tenant-a", BusinessDomain: "domain-a", EffectiveSubjectID: "builder-a",
+		Roles:         []string{"network_builder"},
+		AccountActive: true, TenantActive: true,
+	}
+	must := scopeCandidateMust(evidencevo.QueryScope{
+		TenantID: "tenant-a", BusinessDomain: "domain-a", AccountID: "builder-a", AccountType: "user",
+		View: evidencevo.AccessViewBusiness, AccessProfile: profile,
+	})
+
+	rendered := mustJSON(t, must)
+	if strings.Contains(rendered, "knowledge_network_ids") {
+		t.Fatalf("type-wide management grant must not widen business content candidates: %s", rendered)
+	}
+	for _, expected := range []string{"effective_subject_id", "bkn.account.id", "bkn.account.type"} {
+		if !strings.Contains(rendered, expected) {
+			t.Fatalf("own-record candidate condition %q is missing: %s", expected, rendered)
+		}
+	}
+}
+
+func TestScopeCandidateMustAllowsExplicitTechnicalCrossAccountScanInsideTenantDomain(t *testing.T) {
+	profile := &evidencevo.AccessProfile{
+		TenantID: "tenant-a", BusinessDomain: "domain-a", EffectiveSubjectID: "admin-a",
+		Roles: []string{"super_admin"}, AccountActive: true, TenantActive: true,
+	}
+	must := scopeCandidateMust(evidencevo.QueryScope{
+		TenantID: "tenant-a", BusinessDomain: "domain-a", AccountID: "admin-a", AccountType: "user",
+		View: evidencevo.AccessViewTechnical, AccessProfile: profile,
+	})
+
+	rendered := mustJSON(t, must)
+	if strings.Contains(rendered, "bkn.account.id") || strings.Contains(rendered, "effective_subject_id") {
+		t.Fatalf("explicit technical view must not add business owner filters: %s", rendered)
+	}
+	for _, expected := range []string{"bkn.tenant.id", "business_domain"} {
+		if !strings.Contains(rendered, expected) {
+			t.Fatalf("technical candidates must remain tenant/domain bounded: %s", rendered)
+		}
+	}
+}
+
+func mustJSON(t *testing.T, value any) string {
+	t.Helper()
+	body, err := json.Marshal(value)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return string(body)
+}

--- a/bkn-trace/agent-observability/src/drivenadapter/httpaccess/opensearchevidencestore/scope_query_test.go
+++ b/bkn-trace/agent-observability/src/drivenadapter/httpaccess/opensearchevidencestore/scope_query_test.go
@@ -54,6 +54,23 @@ func TestScopeCandidateMustDoesNotTreatTypeWideNetworkGrantAsBusinessContentAcce
 	}
 }
 
+func TestScopeCandidateMustRequiresNetworkBuilderRoleForManagedNetworkCandidates(t *testing.T) {
+	profile := &evidencevo.AccessProfile{
+		TenantID: "tenant-a", BusinessDomain: "domain-a", EffectiveSubjectID: "user-a",
+		Roles: []string{"normal_user"}, ManagedKnowledgeNetworkIDs: []string{"kn-a"},
+		AccountActive: true, TenantActive: true,
+	}
+	must := scopeCandidateMust(evidencevo.QueryScope{
+		TenantID: "tenant-a", BusinessDomain: "domain-a", AccountID: "user-a", AccountType: "user",
+		View: evidencevo.AccessViewBusiness, AccessProfile: profile,
+	})
+
+	rendered := mustJSON(t, must)
+	if strings.Contains(rendered, "knowledge_network_ids") {
+		t.Fatalf("managed network candidates require the network_builder role: %s", rendered)
+	}
+}
+
 func TestScopeCandidateMustAllowsExplicitTechnicalCrossAccountScanInsideTenantDomain(t *testing.T) {
 	profile := &evidencevo.AccessProfile{
 		TenantID: "tenant-a", BusinessDomain: "domain-a", EffectiveSubjectID: "admin-a",

--- a/bkn-trace/agent-observability/src/drivenadapter/httpaccess/opensearchevidencestore/store.go
+++ b/bkn-trace/agent-observability/src/drivenadapter/httpaccess/opensearchevidencestore/store.go
@@ -32,24 +32,27 @@ type Store struct {
 }
 
 type document struct {
-	DocumentID       string                     `json:"document_id"`
-	TraceID          string                     `json:"trace_id"`
-	RequestID        string                     `json:"bkn.request.id"`
-	ConversationID   string                     `json:"bkn.conversation.id,omitempty"`
-	TenantID         string                     `json:"bkn.tenant.id,omitempty"`
-	BusinessDomain   string                     `json:"business_domain,omitempty"`
-	AccountID        string                     `json:"bkn.account.id"`
-	AccountType      string                     `json:"bkn.account.type"`
-	SchemaVersion    string                     `json:"bkn.trace.schema.version"`
-	Events           []evidencevo.EvidenceEvent `json:"events"`
-	ClaimIDs         []string                   `json:"claim_ids,omitempty"`
-	AcceptedEvents   int                        `json:"accepted_event_count"`
-	ClaimCount       int                        `json:"claim_count"`
-	EvidenceRefCount int                        `json:"evidence_ref_count"`
-	BusinessRefCount int                        `json:"business_ref_count"`
-	ObservedStart    string                     `json:"observed_start,omitempty"`
-	IngestedAt       string                     `json:"ingested_at"`
-	Aggregate        bool                       `json:"aggregate,omitempty"`
+	DocumentID             string                     `json:"document_id"`
+	TraceID                string                     `json:"trace_id"`
+	RequestID              string                     `json:"bkn.request.id"`
+	ConversationID         string                     `json:"bkn.conversation.id,omitempty"`
+	TenantID               string                     `json:"bkn.tenant.id,omitempty"`
+	BusinessDomain         string                     `json:"business_domain,omitempty"`
+	AccountID              string                     `json:"bkn.account.id"`
+	AccountType            string                     `json:"bkn.account.type"`
+	EffectiveSubjectID     string                     `json:"effective_subject_id,omitempty"`
+	ApplicationPrincipalID string                     `json:"application_principal_id,omitempty"`
+	KnowledgeNetworkIDs    []string                   `json:"knowledge_network_ids,omitempty"`
+	SchemaVersion          string                     `json:"bkn.trace.schema.version"`
+	Events                 []evidencevo.EvidenceEvent `json:"events"`
+	ClaimIDs               []string                   `json:"claim_ids,omitempty"`
+	AcceptedEvents         int                        `json:"accepted_event_count"`
+	ClaimCount             int                        `json:"claim_count"`
+	EvidenceRefCount       int                        `json:"evidence_ref_count"`
+	BusinessRefCount       int                        `json:"business_ref_count"`
+	ObservedStart          string                     `json:"observed_start,omitempty"`
+	IngestedAt             string                     `json:"ingested_at"`
+	Aggregate              bool                       `json:"aggregate,omitempty"`
 }
 
 type searchResponse struct {
@@ -237,7 +240,7 @@ func (s *Store) searchPage(ctx context.Context, field, value string, scope evide
 		{"bkn.account.id", scope.AccountID},
 		{"bkn.account.type", scope.AccountType},
 	} {
-		if scope.CrossAccountRead && (item.field == "bkn.account.id" || item.field == "bkn.account.type") {
+		if evidencevo.NeedsCrossAccountCandidates(scope) && (item.field == "bkn.account.id" || item.field == "bkn.account.type") {
 			continue
 		}
 		if item.value != "" {
@@ -334,26 +337,29 @@ func (s *Store) ensureIndex(ctx context.Context) error {
 	return nil
 }
 
-const evidenceIndexMapping = `{"settings":{"index.mapping.total_fields.limit":200},"mappings":{"dynamic":false,"properties":{"document_id":{"type":"keyword"},"trace_id":{"type":"keyword"},"business_domain":{"type":"keyword"},"bkn":{"properties":{"conversation":{"properties":{"id":{"type":"keyword"}}},"tenant":{"properties":{"id":{"type":"keyword"}}},"account":{"properties":{"id":{"type":"keyword"},"type":{"type":"keyword"}}},"request":{"properties":{"id":{"type":"keyword"}}},"trace":{"properties":{"schema":{"properties":{"version":{"type":"keyword"}}}}}}},"events":{"type":"object","enabled":false},"claim_ids":{"type":"keyword"},"accepted_event_count":{"type":"integer"},"claim_count":{"type":"integer"},"evidence_ref_count":{"type":"integer"},"business_ref_count":{"type":"integer"},"observed_start":{"type":"date","format":"strict_date_optional_time_nanos||strict_date_optional_time||epoch_millis"},"ingested_at":{"type":"date","format":"strict_date_optional_time_nanos||strict_date_optional_time||epoch_millis"},"aggregate":{"type":"boolean"}}}}`
+const evidenceIndexMapping = `{"settings":{"index.mapping.total_fields.limit":200},"mappings":{"dynamic":false,"properties":{"document_id":{"type":"keyword"},"trace_id":{"type":"keyword"},"business_domain":{"type":"keyword"},"effective_subject_id":{"type":"keyword"},"application_principal_id":{"type":"keyword"},"knowledge_network_ids":{"type":"keyword"},"bkn":{"properties":{"conversation":{"properties":{"id":{"type":"keyword"}}},"tenant":{"properties":{"id":{"type":"keyword"}}},"account":{"properties":{"id":{"type":"keyword"},"type":{"type":"keyword"}}},"request":{"properties":{"id":{"type":"keyword"}}},"trace":{"properties":{"schema":{"properties":{"version":{"type":"keyword"}}}}}}},"events":{"type":"object","enabled":false},"claim_ids":{"type":"keyword"},"accepted_event_count":{"type":"integer"},"claim_count":{"type":"integer"},"evidence_ref_count":{"type":"integer"},"business_ref_count":{"type":"integer"},"observed_start":{"type":"date","format":"strict_date_optional_time_nanos||strict_date_optional_time||epoch_millis"},"ingested_at":{"type":"date","format":"strict_date_optional_time_nanos||strict_date_optional_time||epoch_millis"},"aggregate":{"type":"boolean"}}}}`
 
 func toDocument(trace evidencevo.NormalizedTrace, ingestedAt time.Time) document {
 	doc := document{
-		TraceID:          trace.TraceID,
-		RequestID:        trace.RequestID,
-		ConversationID:   trace.ConversationID,
-		TenantID:         trace.TenantID,
-		BusinessDomain:   trace.BusinessDomain,
-		AccountID:        trace.AccountID,
-		AccountType:      trace.AccountType,
-		SchemaVersion:    trace.SchemaVersion,
-		Events:           trace.Events,
-		ClaimIDs:         trace.ClaimIDs,
-		AcceptedEvents:   trace.AcceptedEvents,
-		ClaimCount:       trace.ClaimCount,
-		EvidenceRefCount: trace.EvidenceRefCount,
-		BusinessRefCount: trace.BusinessRefCount,
-		ObservedStart:    traceObservedStart(trace),
-		IngestedAt:       ingestedAt.Format(time.RFC3339Nano),
+		TraceID:                trace.TraceID,
+		RequestID:              trace.RequestID,
+		ConversationID:         trace.ConversationID,
+		TenantID:               trace.TenantID,
+		BusinessDomain:         trace.BusinessDomain,
+		AccountID:              trace.AccountID,
+		AccountType:            trace.AccountType,
+		EffectiveSubjectID:     trace.EffectiveSubjectID,
+		ApplicationPrincipalID: trace.ApplicationPrincipalID,
+		KnowledgeNetworkIDs:    append([]string(nil), trace.KnowledgeNetworkIDs...),
+		SchemaVersion:          trace.SchemaVersion,
+		Events:                 trace.Events,
+		ClaimIDs:               trace.ClaimIDs,
+		AcceptedEvents:         trace.AcceptedEvents,
+		ClaimCount:             trace.ClaimCount,
+		EvidenceRefCount:       trace.EvidenceRefCount,
+		BusinessRefCount:       trace.BusinessRefCount,
+		ObservedStart:          traceObservedStart(trace),
+		IngestedAt:             ingestedAt.Format(time.RFC3339Nano),
 	}
 	doc.DocumentID = evidenceDocumentID(doc)
 	return doc
@@ -375,20 +381,23 @@ func traceObservedStart(trace evidencevo.NormalizedTrace) string {
 
 func fromDocument(doc document) evidencevo.NormalizedTrace {
 	return evidencevo.NormalizedTrace{
-		TraceID:          doc.TraceID,
-		RequestID:        doc.RequestID,
-		ConversationID:   doc.ConversationID,
-		TenantID:         doc.TenantID,
-		BusinessDomain:   doc.BusinessDomain,
-		AccountID:        doc.AccountID,
-		AccountType:      doc.AccountType,
-		SchemaVersion:    doc.SchemaVersion,
-		Events:           doc.Events,
-		ClaimIDs:         doc.ClaimIDs,
-		AcceptedEvents:   doc.AcceptedEvents,
-		ClaimCount:       doc.ClaimCount,
-		EvidenceRefCount: doc.EvidenceRefCount,
-		BusinessRefCount: doc.BusinessRefCount,
+		TraceID:                doc.TraceID,
+		RequestID:              doc.RequestID,
+		ConversationID:         doc.ConversationID,
+		TenantID:               doc.TenantID,
+		BusinessDomain:         doc.BusinessDomain,
+		AccountID:              doc.AccountID,
+		AccountType:            doc.AccountType,
+		EffectiveSubjectID:     doc.EffectiveSubjectID,
+		ApplicationPrincipalID: doc.ApplicationPrincipalID,
+		KnowledgeNetworkIDs:    append([]string(nil), doc.KnowledgeNetworkIDs...),
+		SchemaVersion:          doc.SchemaVersion,
+		Events:                 doc.Events,
+		ClaimIDs:               doc.ClaimIDs,
+		AcceptedEvents:         doc.AcceptedEvents,
+		ClaimCount:             doc.ClaimCount,
+		EvidenceRefCount:       doc.EvidenceRefCount,
+		BusinessRefCount:       doc.BusinessRefCount,
 	}
 }
 

--- a/bkn-trace/agent-observability/src/drivenadapter/httpaccess/opensearchevidencestore/store.go
+++ b/bkn-trace/agent-observability/src/drivenadapter/httpaccess/opensearchevidencestore/store.go
@@ -231,22 +231,7 @@ type evidenceHit struct {
 
 func (s *Store) searchPage(ctx context.Context, field, value string, scope evidencevo.QueryScope, size int, searchAfter []any) ([]evidenceHit, error) {
 	must := []map[string]any{{"bool": exactTermQuery(field, value)}}
-	for _, item := range []struct {
-		field string
-		value string
-	}{
-		{"bkn.tenant.id", scope.TenantID},
-		{"business_domain", scope.BusinessDomain},
-		{"bkn.account.id", scope.AccountID},
-		{"bkn.account.type", scope.AccountType},
-	} {
-		if evidencevo.NeedsCrossAccountCandidates(scope) && (item.field == "bkn.account.id" || item.field == "bkn.account.type") {
-			continue
-		}
-		if item.value != "" {
-			must = append(must, map[string]any{"bool": exactTermQuery(item.field, item.value)})
-		}
-	}
+	must = append(must, scopeCandidateMust(scope)...)
 	queryBody := map[string]any{
 		"size": size,
 		"query": map[string]any{

--- a/bkn-trace/agent-observability/src/drivenadapter/httpaccess/opensearchevidencestore/store_test.go
+++ b/bkn-trace/agent-observability/src/drivenadapter/httpaccess/opensearchevidencestore/store_test.go
@@ -81,6 +81,22 @@ func TestStoreEvidenceIndexesNormalizedTrace(t *testing.T) {
 	}
 }
 
+func TestDocumentRoundTripPreservesRecordAccessScope(t *testing.T) {
+	trace := normalizedTrace()
+	trace.EffectiveSubjectID = "user-a"
+	trace.ApplicationPrincipalID = "app-a"
+	trace.KnowledgeNetworkIDs = []string{"kn-a", "kn-b"}
+
+	doc := toDocument(trace, time.Date(2026, 8, 1, 1, 2, 3, 0, time.UTC))
+	roundTrip := fromDocument(doc)
+	if roundTrip.EffectiveSubjectID != "user-a" || roundTrip.ApplicationPrincipalID != "app-a" {
+		t.Fatalf("record owner scope was not preserved: %+v", roundTrip)
+	}
+	if len(roundTrip.KnowledgeNetworkIDs) != 2 || roundTrip.KnowledgeNetworkIDs[0] != "kn-a" || roundTrip.KnowledgeNetworkIDs[1] != "kn-b" {
+		t.Fatalf("knowledge network scope was not preserved: %v", roundTrip.KnowledgeNetworkIDs)
+	}
+}
+
 func TestStoreEvidenceTreatsIdenticalEventReplayAsIdempotent(t *testing.T) {
 	indexed := false
 	indexAttempts := 0

--- a/bkn-trace/agent-observability/src/driveradapter/api/httphandler/access_profile_handler.go
+++ b/bkn-trace/agent-observability/src/driveradapter/api/httphandler/access_profile_handler.go
@@ -56,11 +56,11 @@ func accessProfileResponse(profile evidencevo.AccessProfile) rdto.AccessProfileR
 	return rdto.AccessProfileResponse{
 		BusinessProvenanceOwn: active,
 		BusinessProvenanceManagedNetworks: active && hasRole("network_builder") &&
-			(profile.ManagesAllKnowledgeNetworks || len(profile.ManagedKnowledgeNetworkIDs) > 0),
-		TechnicalTrace:         active && hasRole("admin", "super_admin"),
-		SecurityAudit:          active && hasRole("security", "audit", "super_admin"),
-		ManagementAudit:        active && hasRole("audit", "super_admin"),
-		GlobalLogSearch:        active && hasRole("admin", "security", "audit", "super_admin"),
+			len(profile.ManagedKnowledgeNetworkIDs) > 0,
+		TechnicalTrace:         false,
+		SecurityAudit:          false,
+		ManagementAudit:        false,
+		GlobalLogSearch:        false,
 		AccessScopeFingerprint: profile.Fingerprint,
 	}
 }

--- a/bkn-trace/agent-observability/src/driveradapter/api/httphandler/access_profile_handler.go
+++ b/bkn-trace/agent-observability/src/driveradapter/api/httphandler/access_profile_handler.go
@@ -1,0 +1,66 @@
+package httphandler
+
+import (
+	"net/http"
+
+	"github.com/openbkn-ai/bkn-foundry/bkn-trace/agent-observability/src/domain/valueobject/evidencevo"
+	"github.com/openbkn-ai/bkn-foundry/bkn-trace/agent-observability/src/driveradapter/api/rdto"
+)
+
+// GetAccessProfile godoc
+// @Summary Get the current BKN Trace access profile
+// @Description Returns server-derived page capabilities and a scope fingerprint. Roles and managed resource identifiers are never accepted from or disclosed to the client.
+// @Tags access
+// @Produce json
+// @Success 200 {object} rdto.AccessProfileResponse
+// @Failure 401 {object} rdto.ErrorResponse
+// @Failure 405 {object} rdto.ErrorResponse
+// @Failure 503 {object} rdto.ErrorResponse
+// @Router /access-profile [get]
+func (h *EvidenceHandler) GetAccessProfile(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		writeJSON(w, http.StatusMethodNotAllowed, rdto.ErrorResponse{Code: "METHOD_NOT_ALLOWED", Message: "only GET is supported"})
+		return
+	}
+	if !h.authorizeQueryGateway(w, r) {
+		return
+	}
+	if h.authorizationScopeResolver == nil {
+		writeJSON(w, http.StatusServiceUnavailable, rdto.ErrorResponse{
+			Code: "ACCESS_PROFILE_NOT_CONFIGURED", Message: "current access profile resolution is not configured",
+		})
+		return
+	}
+	scope, ok := h.queryScopeFromRequest(w, r)
+	if !ok || scope.AccessProfile == nil {
+		return
+	}
+	profile := *scope.AccessProfile
+	writeJSON(w, http.StatusOK, accessProfileResponse(profile))
+}
+
+func accessProfileResponse(profile evidencevo.AccessProfile) rdto.AccessProfileResponse {
+	roles := make(map[string]struct{}, len(profile.Roles))
+	for _, role := range profile.Roles {
+		roles[role] = struct{}{}
+	}
+	hasRole := func(values ...string) bool {
+		for _, value := range values {
+			if _, ok := roles[value]; ok {
+				return true
+			}
+		}
+		return false
+	}
+	active := profile.AccountActive && profile.TenantActive
+	return rdto.AccessProfileResponse{
+		BusinessProvenanceOwn: active,
+		BusinessProvenanceManagedNetworks: active && hasRole("network_builder") &&
+			(profile.ManagesAllKnowledgeNetworks || len(profile.ManagedKnowledgeNetworkIDs) > 0),
+		TechnicalTrace:         active && hasRole("admin", "super_admin"),
+		SecurityAudit:          active && hasRole("security", "audit", "super_admin"),
+		ManagementAudit:        active && hasRole("audit", "super_admin"),
+		GlobalLogSearch:        active && hasRole("admin", "security", "audit", "super_admin"),
+		AccessScopeFingerprint: profile.Fingerprint,
+	}
+}

--- a/bkn-trace/agent-observability/src/driveradapter/api/httphandler/evidence_handler.go
+++ b/bkn-trace/agent-observability/src/driveradapter/api/httphandler/evidence_handler.go
@@ -981,8 +981,32 @@ func (h *EvidenceHandler) authorizeOAuthQuery(w http.ResponseWriter, r *http.Req
 		writeJSON(w, http.StatusUnauthorized, rdto.ErrorResponse{Code: "QUERY_IDENTITY_MISMATCH", Message: "request identity does not match OAuth token"})
 		return false
 	}
+	expectedApplicationPrincipalID := ""
+	if accountType == "app" || accountType == "service" {
+		expectedApplicationPrincipalID = accountID
+	}
+	for _, identity := range []struct {
+		header   string
+		expected string
+	}{
+		{header: "X-BKN-Effective-Subject-ID", expected: accountID},
+		{header: "X-BKN-Application-Principal-ID", expected: expectedApplicationPrincipalID},
+		{header: "X-BKN-Delegation-ID", expected: ""},
+	} {
+		if supplied := strings.TrimSpace(r.Header.Get(identity.header)); supplied != "" && supplied != identity.expected {
+			writeJSON(w, http.StatusUnauthorized, rdto.ErrorResponse{Code: "QUERY_IDENTITY_MISMATCH", Message: "request delegation identity does not match OAuth token"})
+			return false
+		}
+	}
 	r.Header.Set("x-account-id", accountID)
 	r.Header.Set("x-account-type", accountType)
+	r.Header.Set("X-BKN-Effective-Subject-ID", accountID)
+	if expectedApplicationPrincipalID == "" {
+		r.Header.Del("X-BKN-Application-Principal-ID")
+	} else {
+		r.Header.Set("X-BKN-Application-Principal-ID", expectedApplicationPrincipalID)
+	}
+	r.Header.Del("X-BKN-Delegation-ID")
 	r.Header.Set("X-BKN-Authenticated-Client-ID", strings.TrimSpace(introspection.ClientID))
 	return true
 }

--- a/bkn-trace/agent-observability/src/driveradapter/api/httphandler/evidence_handler.go
+++ b/bkn-trace/agent-observability/src/driveradapter/api/httphandler/evidence_handler.go
@@ -12,10 +12,10 @@ import (
 	"strings"
 	"time"
 
-	"github.com/openbkn-ai/bkn-foundry/bkn-trace/agent-observability/src/conf"
 	"github.com/openbkn-ai/bkn-foundry/bkn-trace/agent-observability/src/domain/service/evidencesvc"
 	"github.com/openbkn-ai/bkn-foundry/bkn-trace/agent-observability/src/domain/valueobject/evidencevo"
 	"github.com/openbkn-ai/bkn-foundry/bkn-trace/agent-observability/src/driveradapter/api/rdto"
+	"github.com/openbkn-ai/bkn-foundry/bkn-trace/agent-observability/src/port/driven/iauthorizationscope"
 )
 
 const maxEvidenceBodyBytes = 1 << 20
@@ -34,7 +34,7 @@ type EvidenceHandlerSecurityConfig struct {
 	QueryHTTPClient            *http.Client
 	AllowUnauthenticatedIngest bool
 	AllowUnauthenticatedQuery  bool
-	QueryAdminTypes            map[string]bool
+	AuthorizationScopeResolver iauthorizationscope.Resolver
 }
 
 type EvidenceHandler struct {
@@ -45,10 +45,17 @@ type EvidenceHandler struct {
 	queryHTTPClient            *http.Client
 	allowUnauthenticatedIngest bool
 	allowUnauthenticatedQuery  bool
-	queryAdminTypes            map[string]bool
+	authorizationScopeResolver iauthorizationscope.Resolver
 }
 
 func NewEvidenceHandler(evidenceService *evidencesvc.Service) *EvidenceHandler {
+	return NewEvidenceHandlerWithAuthorizationScopeResolver(evidenceService, nil)
+}
+
+func NewEvidenceHandlerWithAuthorizationScopeResolver(
+	evidenceService *evidencesvc.Service,
+	resolver iauthorizationscope.Resolver,
+) *EvidenceHandler {
 	allowUnauthenticated := strings.EqualFold(strings.TrimSpace(os.Getenv(evidenceAllowUnauthenticatedIngestEnv)), "true")
 	allowUnauthenticatedQuery := strings.EqualFold(strings.TrimSpace(os.Getenv(evidenceAllowUnauthenticatedQueryEnv)), "true")
 	return NewEvidenceHandlerWithSecurityConfig(evidenceService, EvidenceHandlerSecurityConfig{
@@ -57,6 +64,7 @@ func NewEvidenceHandler(evidenceService *evidencesvc.Service) *EvidenceHandler {
 		HydraAdminURL:              os.Getenv(evidenceHydraAdminURLEnv),
 		AllowUnauthenticatedIngest: allowUnauthenticated,
 		AllowUnauthenticatedQuery:  allowUnauthenticatedQuery,
+		AuthorizationScopeResolver: resolver,
 	})
 }
 
@@ -75,10 +83,6 @@ func NewEvidenceHandlerWithSecurityConfig(evidenceService *evidencesvc.Service, 
 	if queryHTTPClient == nil {
 		queryHTTPClient = &http.Client{Timeout: 3 * time.Second}
 	}
-	queryAdminTypes := config.QueryAdminTypes
-	if queryAdminTypes == nil {
-		queryAdminTypes = conf.NewTraceReadAuthzConfig().AdminTypes
-	}
 	return &EvidenceHandler{
 		evidenceService:            evidenceService,
 		ingestToken:                strings.TrimSpace(config.IngestToken),
@@ -87,7 +91,7 @@ func NewEvidenceHandlerWithSecurityConfig(evidenceService *evidencesvc.Service, 
 		queryHTTPClient:            queryHTTPClient,
 		allowUnauthenticatedIngest: config.AllowUnauthenticatedIngest,
 		allowUnauthenticatedQuery:  config.AllowUnauthenticatedQuery,
-		queryAdminTypes:            queryAdminTypes,
+		authorizationScopeResolver: config.AuthorizationScopeResolver,
 	}
 }
 
@@ -813,9 +817,33 @@ func (h *EvidenceHandler) queryScopeFromRequest(w http.ResponseWriter, r *http.R
 	scope := evidencevo.QueryScope{
 		TenantID: tenantID, BusinessDomain: businessDomain, AccountID: accountID, AccountType: accountType,
 		Authorization: strings.TrimSpace(r.Header.Get("Authorization")),
+		View:          evidencevo.AccessViewBusiness,
 	}
-	if h.queryAdminTypes[accountType] {
-		scope.CrossAccountRead = true
+	if h.authorizationScopeResolver != nil {
+		effectiveSubjectID := strings.TrimSpace(r.Header.Get("X-BKN-Effective-Subject-ID"))
+		if effectiveSubjectID == "" {
+			effectiveSubjectID = accountID
+		}
+		applicationPrincipalID := strings.TrimSpace(r.Header.Get("X-BKN-Application-Principal-ID"))
+		if applicationPrincipalID == "" && (accountType == "app" || accountType == "service") {
+			applicationPrincipalID = accountID
+		}
+		profile, err := h.authorizationScopeResolver.Resolve(r.Context(), scope.Authorization, iauthorizationscope.TrustedIdentity{
+			TenantID: tenantID, BusinessDomain: businessDomain, ActorID: accountID,
+			EffectiveSubjectID:     effectiveSubjectID,
+			ApplicationPrincipalID: applicationPrincipalID,
+			DelegationID:           strings.TrimSpace(r.Header.Get("X-BKN-Delegation-ID")),
+		})
+		if err != nil {
+			writeJSON(w, http.StatusUnauthorized, rdto.ErrorResponse{
+				Code: "QUERY_ACCESS_DENIED", Message: "current account and record scope could not be authorized",
+			})
+			return evidencevo.QueryScope{}, false
+		}
+		scope.AccessProfile = &profile
+		if profile.EffectiveSubjectID != "" {
+			scope.AccountID = profile.EffectiveSubjectID
+		}
 	}
 	return scope, true
 }

--- a/bkn-trace/agent-observability/src/driveradapter/api/httphandler/evidence_handler_test.go
+++ b/bkn-trace/agent-observability/src/driveradapter/api/httphandler/evidence_handler_test.go
@@ -1,6 +1,7 @@
 package httphandler
 
 import (
+	"context"
 	"encoding/json"
 	"io"
 	"net/http"
@@ -9,8 +10,27 @@ import (
 	"testing"
 
 	"github.com/openbkn-ai/bkn-foundry/bkn-trace/agent-observability/src/domain/service/evidencesvc"
+	"github.com/openbkn-ai/bkn-foundry/bkn-trace/agent-observability/src/domain/valueobject/evidencevo"
 	"github.com/openbkn-ai/bkn-foundry/bkn-trace/agent-observability/src/drivenadapter/memoryaccess/evidencestore"
+	"github.com/openbkn-ai/bkn-foundry/bkn-trace/agent-observability/src/port/driven/iauthorizationscope"
 )
+
+type fakeAccessScopeResolver struct {
+	profile         evidencevo.AccessProfile
+	err             error
+	authorization   string
+	trustedIdentity iauthorizationscope.TrustedIdentity
+}
+
+func (f *fakeAccessScopeResolver) Resolve(
+	_ context.Context,
+	authorization string,
+	identity iauthorizationscope.TrustedIdentity,
+) (evidencevo.AccessProfile, error) {
+	f.authorization = authorization
+	f.trustedIdentity = identity
+	return f.profile, f.err
+}
 
 func newDevEvidenceHandler(service *evidencesvc.Service) *EvidenceHandler {
 	return NewEvidenceHandlerWithSecurityConfig(service, EvidenceHandlerSecurityConfig{
@@ -82,6 +102,94 @@ func TestEvidenceHandlerRequiresTrustedQueryIdentity(t *testing.T) {
 
 	if rec.Code != http.StatusUnauthorized || !strings.Contains(rec.Body.String(), "QUERY_IDENTITY_REQUIRED") {
 		t.Fatalf("expected trusted identity rejection, got %d: %s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestEvidenceHandlerBuildsQueryScopeFromCurrentSafeAccessProfile(t *testing.T) {
+	resolver := &fakeAccessScopeResolver{profile: evidencevo.AccessProfile{
+		TenantID: "tenant-a", BusinessDomain: "domain-a", ActorID: "actor-a",
+		EffectiveSubjectID: "user-a", ApplicationPrincipalID: "app-a",
+		Roles: []string{"network_builder"}, ManagedKnowledgeNetworkIDs: []string{"kn-a"},
+		AccountActive: true, TenantActive: true, Fingerprint: "sha256:profile-a",
+	}}
+	handler := NewEvidenceHandlerWithSecurityConfig(evidencesvc.New(evidencestore.New()), EvidenceHandlerSecurityConfig{
+		AllowUnauthenticatedQuery: true, AuthorizationScopeResolver: resolver,
+	})
+	request := authenticatedQueryRequest(http.MethodGet, "/api/agent-observability/v1/requests/request-a/summary", nil)
+	request.Header.Set("Authorization", "Bearer current-token")
+	request.Header.Set("x-account-id", "actor-a")
+	request.Header.Set("x-account-type", "user")
+	request.Header.Set("x-tenant-id", "tenant-a")
+	request.Header.Set("x-business-domain", "domain-a")
+	request.Header.Set("X-BKN-Effective-Subject-ID", "user-a")
+	request.Header.Set("X-BKN-Application-Principal-ID", "app-a")
+	response := httptest.NewRecorder()
+
+	scope, ok := handler.queryScopeFromRequest(response, request)
+	if !ok || scope.AccessProfile == nil || scope.AccessProfile.Fingerprint != "sha256:profile-a" {
+		t.Fatalf("expected current access profile, scope=%+v response=%d %s", scope, response.Code, response.Body.String())
+	}
+	if scope.AccountID != "user-a" {
+		t.Fatalf("candidate owner filter must use the effective subject, got %q", scope.AccountID)
+	}
+	if resolver.authorization != "Bearer current-token" || resolver.trustedIdentity.ActorID != "actor-a" ||
+		resolver.trustedIdentity.EffectiveSubjectID != "user-a" || resolver.trustedIdentity.ApplicationPrincipalID != "app-a" {
+		t.Fatalf("resolver did not receive trusted identity: auth=%q identity=%+v", resolver.authorization, resolver.trustedIdentity)
+	}
+}
+
+func TestEvidenceHandlerReturnsCurrentAccessProfileCapabilities(t *testing.T) {
+	resolver := &fakeAccessScopeResolver{profile: evidencevo.AccessProfile{
+		TenantID: "tenant-a", BusinessDomain: "domain-a", ActorID: "builder-a",
+		EffectiveSubjectID: "builder-a", Roles: []string{"network_builder"},
+		ManagesAllKnowledgeNetworks: true,
+		AccountActive:               true, TenantActive: true, Fingerprint: "sha256:profile-a",
+	}}
+	handler := NewEvidenceHandlerWithSecurityConfig(evidencesvc.New(evidencestore.New()), EvidenceHandlerSecurityConfig{
+		AllowUnauthenticatedQuery: true, AuthorizationScopeResolver: resolver,
+	})
+	request := authenticatedQueryRequest(http.MethodGet, "/api/agent-observability/v1/access-profile", nil)
+	request.Header.Set("Authorization", "Bearer current-token")
+	request.Header.Set("x-account-id", "builder-a")
+	request.Header.Set("x-account-type", "user")
+	request.Header.Set("x-tenant-id", "tenant-a")
+	request.Header.Set("x-business-domain", "domain-a")
+	response := httptest.NewRecorder()
+
+	handler.GetAccessProfile(response, request)
+
+	if response.Code != http.StatusOK {
+		t.Fatalf("expected access profile, got %d: %s", response.Code, response.Body.String())
+	}
+	var body map[string]any
+	if err := json.Unmarshal(response.Body.Bytes(), &body); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if body["business_provenance_own"] != true || body["business_provenance_managed_networks"] != true ||
+		body["technical_trace"] != false || body["security_audit"] != false ||
+		body["management_audit"] != false || body["global_log_search"] != false {
+		t.Fatalf("unexpected capabilities: %#v", body)
+	}
+	if body["access_scope_fingerprint"] != "sha256:profile-a" {
+		t.Fatalf("missing fingerprint: %#v", body)
+	}
+	if _, leaked := body["roles"]; leaked {
+		t.Fatalf("access profile must not expose the complete role table: %#v", body)
+	}
+	if _, leaked := body["managed_knowledge_network_ids"]; leaked {
+		t.Fatalf("access profile must not expose managed network identifiers: %#v", body)
+	}
+}
+
+func TestEvidenceHandlerAccessProfileFailsClosedWithoutScopeResolver(t *testing.T) {
+	handler := newDevEvidenceHandler(evidencesvc.New(evidencestore.New()))
+	request := authenticatedQueryRequest(http.MethodGet, "/api/agent-observability/v1/access-profile", nil)
+	response := httptest.NewRecorder()
+
+	handler.GetAccessProfile(response, request)
+
+	if response.Code != http.StatusServiceUnavailable || !strings.Contains(response.Body.String(), "ACCESS_PROFILE_NOT_CONFIGURED") {
+		t.Fatalf("expected fail-closed access profile response, got %d: %s", response.Code, response.Body.String())
 	}
 }
 
@@ -797,7 +905,7 @@ func TestEvidenceHandlerListsRequestTracesAndTechnicalExecutions(t *testing.T) {
 	}
 }
 
-func TestEvidenceHandlerAdminReadsEvidenceAcrossAccountsWithinBusinessDomain(t *testing.T) {
+func TestEvidenceHandlerPlatformRoleDoesNotReadBusinessEvidenceAcrossAccounts(t *testing.T) {
 	handler := newDevEvidenceHandler(evidencesvc.New(evidencestore.New()))
 	ingestReq := httptest.NewRequest(http.MethodPost, "/api/agent-observability/v1/evidence/events", strings.NewReader(validHandlerBatch()))
 	ingestRec := httptest.NewRecorder()
@@ -820,8 +928,8 @@ func TestEvidenceHandlerAdminReadsEvidenceAcrossAccountsWithinBusinessDomain(t *
 	adminReq.Header.Set("x-account-type", "super_admin")
 	adminRec := httptest.NewRecorder()
 	handler.ListRequests(adminRec, adminReq)
-	if adminRec.Code != http.StatusOK || !strings.Contains(adminRec.Body.String(), `"request_id":"req_handler_001"`) {
-		t.Fatalf("admin must see same-domain evidence, got %d: %s", adminRec.Code, adminRec.Body.String())
+	if adminRec.Code != http.StatusOK || strings.Contains(adminRec.Body.String(), `"request_id":"req_handler_001"`) {
+		t.Fatalf("platform role must not imply cross-account business evidence access, got %d: %s", adminRec.Code, adminRec.Body.String())
 	}
 
 	chainReq := authenticatedQueryRequest(http.MethodGet, "/api/agent-observability/v1/traces/9c0d0000000000000000000000000001/evidence-chain", nil)
@@ -829,8 +937,8 @@ func TestEvidenceHandlerAdminReadsEvidenceAcrossAccountsWithinBusinessDomain(t *
 	chainReq.Header.Set("x-account-type", "super_admin")
 	chainRec := httptest.NewRecorder()
 	handler.GetTraceSubresource(chainRec, chainReq)
-	if chainRec.Code != http.StatusOK || !strings.Contains(chainRec.Body.String(), `"claim_id":"claim_handler"`) {
-		t.Fatalf("admin must read same-domain evidence chain, got %d: %s", chainRec.Code, chainRec.Body.String())
+	if chainRec.Code != http.StatusNotFound || strings.Contains(chainRec.Body.String(), `"claim_id":"claim_handler"`) {
+		t.Fatalf("platform role must not read another account's evidence chain, got %d: %s", chainRec.Code, chainRec.Body.String())
 	}
 
 	otherDomainReq := authenticatedQueryRequest(http.MethodGet, "/api/agent-observability/v1/requests?limit=10", nil)
@@ -840,7 +948,7 @@ func TestEvidenceHandlerAdminReadsEvidenceAcrossAccountsWithinBusinessDomain(t *
 	otherDomainRec := httptest.NewRecorder()
 	handler.ListRequests(otherDomainRec, otherDomainReq)
 	if otherDomainRec.Code != http.StatusOK || strings.Contains(otherDomainRec.Body.String(), `"request_id":"req_handler_001"`) {
-		t.Fatalf("admin cross-account read must stay domain-scoped, got %d: %s", otherDomainRec.Code, otherDomainRec.Body.String())
+		t.Fatalf("platform role must not disclose business evidence in another domain, got %d: %s", otherDomainRec.Code, otherDomainRec.Body.String())
 	}
 }
 

--- a/bkn-trace/agent-observability/src/driveradapter/api/httphandler/evidence_handler_test.go
+++ b/bkn-trace/agent-observability/src/driveradapter/api/httphandler/evidence_handler_test.go
@@ -142,8 +142,8 @@ func TestEvidenceHandlerReturnsCurrentAccessProfileCapabilities(t *testing.T) {
 	resolver := &fakeAccessScopeResolver{profile: evidencevo.AccessProfile{
 		TenantID: "tenant-a", BusinessDomain: "domain-a", ActorID: "builder-a",
 		EffectiveSubjectID: "builder-a", Roles: []string{"network_builder"},
-		ManagesAllKnowledgeNetworks: true,
-		AccountActive:               true, TenantActive: true, Fingerprint: "sha256:profile-a",
+		ManagedKnowledgeNetworkIDs: []string{"kn-a"},
+		AccountActive:              true, TenantActive: true, Fingerprint: "sha256:profile-a",
 	}}
 	handler := NewEvidenceHandlerWithSecurityConfig(evidencesvc.New(evidencestore.New()), EvidenceHandlerSecurityConfig{
 		AllowUnauthenticatedQuery: true, AuthorizationScopeResolver: resolver,
@@ -367,6 +367,40 @@ func TestEvidenceHandlerRejectsOAuthIdentityMismatch(t *testing.T) {
 
 	if rec.Code != http.StatusUnauthorized || !strings.Contains(rec.Body.String(), "QUERY_IDENTITY_MISMATCH") {
 		t.Fatalf("forged OAuth identity must be rejected, got %d: %s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestEvidenceHandlerRejectsForgedOAuthDelegationIdentity(t *testing.T) {
+	hydra := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = io.WriteString(w, `{"active":true,"sub":"acct_demo","client_id":"openbkn-studio","ext":{"visitor_type":"user"}}`)
+	}))
+	defer hydra.Close()
+
+	for _, test := range []struct {
+		name   string
+		header string
+		value  string
+	}{
+		{name: "effective subject", header: "X-BKN-Effective-Subject-ID", value: "victim"},
+		{name: "application principal", header: "X-BKN-Application-Principal-ID", value: "victim-app"},
+		{name: "delegation", header: "X-BKN-Delegation-ID", value: "forged-delegation"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			handler := NewEvidenceHandlerWithSecurityConfig(evidencesvc.New(evidencestore.New()), EvidenceHandlerSecurityConfig{
+				HydraAdminURL: hydra.URL,
+			})
+			req := httptest.NewRequest(http.MethodGet, "/api/agent-observability/v1/traces/missing/evidence-chain", nil)
+			req.Header.Set("Authorization", "Bearer studio-token")
+			req.Header.Set("x-business-domain", "bd_demo")
+			req.Header.Set(test.header, test.value)
+			rec := httptest.NewRecorder()
+
+			handler.GetEvidenceChainByTraceID(rec, req)
+
+			if rec.Code != http.StatusUnauthorized || !strings.Contains(rec.Body.String(), "QUERY_IDENTITY_MISMATCH") {
+				t.Fatalf("forged OAuth delegation identity must be rejected, got %d: %s", rec.Code, rec.Body.String())
+			}
+		})
 	}
 }
 

--- a/bkn-trace/agent-observability/src/driveradapter/api/httphandler/traceauthz.go
+++ b/bkn-trace/agent-observability/src/driveradapter/api/httphandler/traceauthz.go
@@ -70,10 +70,6 @@ func newTraceReadAuthz(cfg conf.TraceReadAuthzConfig) traceReadAuthz {
 	return traceReadAuthz{cfg: cfg}
 }
 
-func (a traceReadAuthz) isAdmin(accountType string) bool {
-	return a.cfg.AdminTypes[accountType]
-}
-
 // authorize decides what query actually runs for a trace read. It returns the
 // (possibly account-scoped) query body, or an HTTP status+message when the
 // request must be refused.
@@ -82,7 +78,6 @@ func (a traceReadAuthz) isAdmin(accountType string) bool {
 //
 //   - no identity + enforce  -> 401
 //   - no identity + shadow   -> log, run the caller's query unchanged
-//   - admin account          -> run unchanged (cross-account by design)
 //   - normal + shadow        -> log "would scope", run unchanged
 //   - normal + enforce       -> inject a term filter on the caller's account
 func (a traceReadAuthz) authorize(id identity, body json.RawMessage) (effective json.RawMessage, status int, message string) {
@@ -91,9 +86,6 @@ func (a traceReadAuthz) authorize(id identity, body json.RawMessage) (effective 
 			return nil, http.StatusUnauthorized, "trace read requires an authenticated account"
 		}
 		slog.Warn("trace read without account identity", "mode", "shadow", "action", "allowed_unscoped")
-		return body, 0, ""
-	}
-	if a.isAdmin(id.accountType) {
 		return body, 0, ""
 	}
 	if !a.cfg.Enforce {

--- a/bkn-trace/agent-observability/src/driveradapter/api/httphandler/traceauthz_test.go
+++ b/bkn-trace/agent-observability/src/driveradapter/api/httphandler/traceauthz_test.go
@@ -37,8 +37,8 @@ func searchReq(body, baggage string) *http.Request {
 	return req
 }
 
-var enforce = conf.TraceReadAuthzConfig{Enforce: true, AdminTypes: map[string]bool{"admin": true, "audit": true, "super_admin": true}}
-var shadow = conf.TraceReadAuthzConfig{Enforce: false, AdminTypes: map[string]bool{"admin": true, "audit": true, "super_admin": true}}
+var enforce = conf.TraceReadAuthzConfig{Enforce: true}
+var shadow = conf.TraceReadAuthzConfig{Enforce: false}
 
 // --- scopeQueryToAccount unit tests ---
 
@@ -112,15 +112,15 @@ func TestEnforceScopesNormalCaller(t *testing.T) {
 	}
 }
 
-func TestEnforceDoesNotScopeAdmin(t *testing.T) {
+func TestEnforceScopesPlatformRoleOnRawQuery(t *testing.T) {
 	h, port := handlerWith(enforce)
 	rec := httptest.NewRecorder()
 	h.SearchTraces(rec, searchReq(`{"query":{"match_all":{}}}`, "bkn.account.type=audit,bkn.account.id=auditor-1"))
 	if rec.Code != http.StatusOK {
 		t.Fatalf("want 200, got %d", rec.Code)
 	}
-	if strings.Contains(string(port.last), accountAttrField) {
-		t.Fatalf("admin/audit must see all accounts, query should be unscoped: %s", port.last)
+	if !strings.Contains(string(port.last), accountAttrField) || !strings.Contains(string(port.last), "auditor-1") {
+		t.Fatalf("raw query must remain account-scoped even for a platform role: %s", port.last)
 	}
 }
 
@@ -162,17 +162,16 @@ func TestEnforceRejectsAggregationsFromScopedCaller(t *testing.T) {
 	}
 }
 
-func TestAdminMayUseAggregations(t *testing.T) {
-	// Admins are not scoped, so aggregations are fine for them.
+func TestPlatformRoleCannotUseRawAggregations(t *testing.T) {
 	h, port := handlerWith(enforce)
 	rec := httptest.NewRecorder()
 	body := `{"aggs":{"by_svc":{"terms":{"field":"x"}}}}`
 	h.SearchTraces(rec, searchReq(body, "bkn.account.type=admin,bkn.account.id=a-1"))
-	if rec.Code != http.StatusOK {
-		t.Fatalf("admin with aggs should pass, got %d: %s", rec.Code, rec.Body.String())
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("platform role raw aggregation must be rejected, got %d: %s", rec.Code, rec.Body.String())
 	}
-	if !strings.Contains(string(port.last), "aggs") {
-		t.Fatalf("admin aggs should reach OpenSearch unchanged: %s", port.last)
+	if port.last != nil {
+		t.Fatalf("rejected raw aggregation must not reach OpenSearch: %s", port.last)
 	}
 }
 

--- a/bkn-trace/agent-observability/src/driveradapter/api/rdto/access_profile.go
+++ b/bkn-trace/agent-observability/src/driveradapter/api/rdto/access_profile.go
@@ -1,0 +1,11 @@
+package rdto
+
+type AccessProfileResponse struct {
+	BusinessProvenanceOwn             bool   `json:"business_provenance_own"`
+	BusinessProvenanceManagedNetworks bool   `json:"business_provenance_managed_networks"`
+	TechnicalTrace                    bool   `json:"technical_trace"`
+	SecurityAudit                     bool   `json:"security_audit"`
+	ManagementAudit                   bool   `json:"management_audit"`
+	GlobalLogSearch                   bool   `json:"global_log_search"`
+	AccessScopeFingerprint            string `json:"access_scope_fingerprint"`
+}

--- a/bkn-trace/agent-observability/src/port/driven/iauthorizationscope/port.go
+++ b/bkn-trace/agent-observability/src/port/driven/iauthorizationscope/port.go
@@ -6,6 +6,9 @@ import (
 	"github.com/openbkn-ai/bkn-foundry/bkn-trace/agent-observability/src/domain/valueobject/evidencevo"
 )
 
+// TrustedIdentity is established by the query gateway or the OAuth handler.
+// DelegationID is currently an audit and fingerprint dimension; Resolver does not
+// independently validate delegation until BKN Safe exposes a verifiable contract.
 type TrustedIdentity struct {
 	TenantID               string
 	BusinessDomain         string

--- a/bkn-trace/agent-observability/src/port/driven/iauthorizationscope/port.go
+++ b/bkn-trace/agent-observability/src/port/driven/iauthorizationscope/port.go
@@ -1,0 +1,20 @@
+package iauthorizationscope
+
+import (
+	"context"
+
+	"github.com/openbkn-ai/bkn-foundry/bkn-trace/agent-observability/src/domain/valueobject/evidencevo"
+)
+
+type TrustedIdentity struct {
+	TenantID               string
+	BusinessDomain         string
+	ActorID                string
+	EffectiveSubjectID     string
+	ApplicationPrincipalID string
+	DelegationID           string
+}
+
+type Resolver interface {
+	Resolve(context.Context, string, TrustedIdentity) (evidencevo.AccessProfile, error)
+}

--- a/docs/api/agent-observability/agent-observability.yaml
+++ b/docs/api/agent-observability/agent-observability.yaml
@@ -286,6 +286,8 @@ definitions:
     properties:
       agent_or_app:
         type: string
+      application_principal_id:
+        type: string
       artifact_id:
         type: string
       artifact_type:
@@ -313,10 +315,16 @@ definitions:
         type: string
       content_type:
         type: string
+      effective_subject_id:
+        type: string
       initiator:
         type: string
       interaction_id:
         type: string
+      knowledge_network_ids:
+        items:
+          type: string
+        type: array
       observed_at:
         type: string
       operation_id:
@@ -983,6 +991,23 @@ definitions:
       replayed:
         type: boolean
     type: object
+  rdto.AccessProfileResponse:
+    properties:
+      access_scope_fingerprint:
+        type: string
+      business_provenance_managed_networks:
+        type: boolean
+      business_provenance_own:
+        type: boolean
+      global_log_search:
+        type: boolean
+      management_audit:
+        type: boolean
+      security_audit:
+        type: boolean
+      technical_trace:
+        type: boolean
+    type: object
   rdto.ErrorResponse:
     properties:
       code:
@@ -1644,6 +1669,33 @@ info:
   title: Agent Observability API
   version: "1.0"
 paths:
+  /access-profile:
+    get:
+      description: Returns server-derived page capabilities and a scope fingerprint.
+        Roles and managed resource identifiers are never accepted from or disclosed
+        to the client.
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/rdto.AccessProfileResponse'
+        "401":
+          description: Unauthorized
+          schema:
+            $ref: '#/definitions/rdto.ErrorResponse'
+        "405":
+          description: Method Not Allowed
+          schema:
+            $ref: '#/definitions/rdto.ErrorResponse'
+        "503":
+          description: Service Unavailable
+          schema:
+            $ref: '#/definitions/rdto.ErrorResponse'
+      summary: Get the current BKN Trace access profile
+      tags:
+      - access
   /conversations:
     get:
       parameters:


### PR DESCRIPTION
## What Changed

- [x] Add a server-derived BKN Trace access profile backed by the current BKN Safe identity and concrete knowledge-network permissions
- [x] Apply one record-level authorization decision across runs, interactions, evidence, business graphs, artifacts, and trace candidates
- [x] Persist trusted subject, application, tenant, business-domain, and knowledge-network scope fields
- [x] Publish `GET /api/agent-observability/v1/access-profile` and update the canonical OpenAPI document
- [x] Push owner, application-principal, and concrete managed-network candidate constraints into OpenSearch

---

## Why

- Related Issue: Closes #542
- Related Feature: [BKN Trace authorization design](https://github.com/openbkn-ai/bkn-docs/pull/27)
- Background: BKN Trace reuses existing OpenBKN roles while separating platform administration from historical business-provenance access. A caller may read records it produced; `network_builder` may additionally read records whose associated knowledge networks are all covered by concrete management grants. Type-wide or platform-wide wildcards never imply business-body access.
- Historical semantics: after a record was produced legally, losing live source-data access does not erase the historical provenance record while the account and BKN Trace access remain active. Resolver calls enrich display metadata and are not a second authorization authority.

---

## How

- Resolve the current actor and concrete knowledge-network grants from BKN Safe and fail closed when the profile cannot be established.
- Reject OAuth callers that try to inject effective-subject, application-principal, or delegation identity headers.
- Recursively derive the complete knowledge-network set from event payloads and enforce all-of managed-network access.
- Keep server-derived record-scope fields outside artifact idempotency fingerprints so legacy replay remains stable.
- Advertise only read capabilities currently implemented by this backend; technical trace and audit capability bits remain false.
- Configure `BKN_SAFE_BASE_URL` and `BKN_SAFE_ACCESS_TIMEOUT` through the Helm chart.

Breaking changes: trace read authorization defaults to enforced unless explicitly disabled for local gateway diagnostics. No database migration.

---

## Testing

- [x] Unit tests passed locally
- [x] Full Go tests, vet, and build passed locally
- [x] Swagger generation matches the canonical API document
- [x] Helm lint and evidence-index governance checks passed
- [ ] Verified in test environment

Commands:

- `GOCACHE=/tmp/bkn-foundry-go-cache go vet ./...`
- `GOCACHE=/tmp/bkn-foundry-go-cache go test ./... -count=1`
- `GOCACHE=/tmp/bkn-foundry-go-cache go build ./...`
- `make check-swag`
- `helm lint charts/agent-observability`
- `bash scripts/test_evidence_index_governance.sh`
- `git diff --check`

Coverage includes forged OAuth delegation headers, own/delegated/application ownership, concrete network management, multi-network all-of semantics, wildcard denial, nested business refs, legacy artifact replay fingerprints, query pushdown, interaction aggregation, artifact access, and fail-closed identity boundaries.

---

## Risk & Rollback

- BKN Safe unavailability fails closed for protected reads.
- Historical records without trusted ownership/network scope remain inaccessible to cross-account network builders but remain readable by their original owner through the legacy account fallback.
- Access-profile resolution currently performs live BKN Safe reads per protected request; cross-request caching is intentionally deferred until revocation and bounded-staleness semantics are specified.
- Rollback: revert this PR and restore the prior trace read configuration; no schema rollback is required.

---

## Additional Notes

- Canonical API document: `docs/api/agent-observability/agent-observability.yaml`
- Studio integration is submitted separately and references #542.