### PR TITLE
fix(bkn): reject empty action condition groups

### DIFF
--- a/adp/bkn/bkn-backend/server/driveradapters/validate_action_type.go
+++ b/adp/bkn/bkn-backend/server/driveradapters/validate_action_type.go
@@ -166,11 +166,18 @@ func ValidateActionType(ctx context.Context, actionType *interfaces.ActionType, 
 		return err
 	}
 
-	// 行动条件非空时，校验行动条件（strict_mode 关闭时不校验）
-	if actionType.Condition != nil && strictMode {
-		err = validateActionCondition(ctx, actionType.Condition, actionType.ObjectTypeID)
-		if err != nil {
-			return err
+	// Always reject structurally invalid conditions; strict mode adds semantic validation.
+	if actionType.Condition != nil {
+		if strictMode {
+			err = validateActionCondition(ctx, actionType.Condition, actionType.ObjectTypeID)
+			if err != nil {
+				return err
+			}
+		} else {
+			err = validateActionConditionShape(ctx, actionType.Condition, "condition")
+			if err != nil {
+				return err
+			}
 		}
 	}
 
@@ -295,6 +302,32 @@ func foldedImpactMatchesAffect(at *interfaces.ActionType) bool {
 
 // 校验行动条件的合法性
 func validateActionCondition(ctx context.Context, cfg *interfaces.ActionCondCfg, objectTypeID string) error {
+	return validateActionConditionWithPath(ctx, cfg, objectTypeID, "condition")
+}
+
+func validateActionConditionShape(ctx context.Context, cfg *interfaces.ActionCondCfg, path string) error {
+	if cfg == nil {
+		return nil
+	}
+
+	switch cfg.Operation {
+	case cond.OperationAnd, cond.OperationOr:
+		if len(cfg.SubConds) == 0 {
+			return rest.NewHTTPError(ctx, http.StatusBadRequest, berrors.BknBackend_ActionType_InvalidParameter).
+				WithErrorDetails(fmt.Sprintf("%s.sub_conditions must not be empty for operation [%s]", path, cfg.Operation))
+		}
+		for i, subCond := range cfg.SubConds {
+			err := validateActionConditionShape(ctx, subCond, fmt.Sprintf("%s.sub_conditions[%d]", path, i))
+			if err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
+}
+
+func validateActionConditionWithPath(ctx context.Context, cfg *interfaces.ActionCondCfg, objectTypeID string, path string) error {
 	if cfg == nil {
 		return nil
 	}
@@ -323,13 +356,18 @@ func validateActionCondition(ctx context.Context, cfg *interfaces.ActionCondCfg,
 	switch cfg.Operation {
 	case cond.OperationAnd, cond.OperationOr:
 		// 子过滤条件不能超过100个
+		if len(cfg.SubConds) == 0 {
+			return rest.NewHTTPError(ctx, http.StatusBadRequest, berrors.BknBackend_ActionType_InvalidParameter).
+				WithErrorDetails(fmt.Sprintf("%s.sub_conditions must not be empty for operation [%s]", path, cfg.Operation))
+		}
+
 		if len(cfg.SubConds) > cond.MaxSubCondition {
 			return rest.NewHTTPError(ctx, http.StatusBadRequest, berrors.BknBackend_CountExceeded_Conditions).
 				WithErrorDetails(fmt.Sprintf("行动条件的子条件不能超过 %d 个", cond.MaxSubCondition))
 		}
 
-		for _, subCond := range cfg.SubConds {
-			err := validateActionCondition(ctx, subCond, objectTypeID)
+		for i, subCond := range cfg.SubConds {
+			err := validateActionConditionWithPath(ctx, subCond, objectTypeID, fmt.Sprintf("%s.sub_conditions[%d]", path, i))
 			if err != nil {
 				return err
 			}

--- a/adp/bkn/bkn-backend/server/driveradapters/validate_action_type_test.go
+++ b/adp/bkn/bkn-backend/server/driveradapters/validate_action_type_test.go
@@ -366,6 +366,100 @@ func Test_ValidateActionType(t *testing.T) {
 			So(err, ShouldBeNil) // and/or operation doesn't require field
 		})
 
+		Convey("Failed with empty and condition in strict mode\n", func() {
+			at := &interfaces.ActionType{
+				ActionTypeWithKeyField: interfaces.ActionTypeWithKeyField{
+					ATID:         "at1",
+					ATName:       "action1",
+					ObjectTypeID: "ot1",
+					ActionType:   interfaces.ACTION_TYPE_ADD,
+					Condition: &interfaces.ActionCondCfg{
+						ObjectTypeID: "ot1",
+						Operation:    cond.OperationAnd,
+					},
+				},
+			}
+			err := ValidateActionType(ctx, at, true)
+			So(err, ShouldNotBeNil)
+			httpErr := err.(*rest.HTTPError)
+			So(httpErr.BaseError.ErrorCode, ShouldEqual, berrors.BknBackend_ActionType_InvalidParameter)
+			So(httpErr.BaseError.ErrorDetails, ShouldContainSubstring, "condition.sub_conditions")
+		})
+
+		Convey("Failed with empty or condition in strict mode\n", func() {
+			at := &interfaces.ActionType{
+				ActionTypeWithKeyField: interfaces.ActionTypeWithKeyField{
+					ATID:         "at1",
+					ATName:       "action1",
+					ObjectTypeID: "ot1",
+					ActionType:   interfaces.ACTION_TYPE_ADD,
+					Condition: &interfaces.ActionCondCfg{
+						ObjectTypeID: "ot1",
+						Operation:    cond.OperationOr,
+					},
+				},
+			}
+			err := ValidateActionType(ctx, at, true)
+			So(err, ShouldNotBeNil)
+			httpErr := err.(*rest.HTTPError)
+			So(httpErr.BaseError.ErrorCode, ShouldEqual, berrors.BknBackend_ActionType_InvalidParameter)
+			So(httpErr.BaseError.ErrorDetails, ShouldContainSubstring, "condition.sub_conditions")
+		})
+
+		Convey("Failed with empty and condition when strictMode false\n", func() {
+			at := &interfaces.ActionType{
+				ActionTypeWithKeyField: interfaces.ActionTypeWithKeyField{
+					ATID:         "at1",
+					ATName:       "action1",
+					ObjectTypeID: "ot1",
+					ActionType:   interfaces.ACTION_TYPE_ADD,
+					Condition: &interfaces.ActionCondCfg{
+						ObjectTypeID: "ot1",
+						Operation:    cond.OperationAnd,
+					},
+				},
+			}
+			err := ValidateActionType(ctx, at, false)
+			So(err, ShouldNotBeNil)
+			httpErr := err.(*rest.HTTPError)
+			So(httpErr.BaseError.ErrorCode, ShouldEqual, berrors.BknBackend_ActionType_InvalidParameter)
+			So(httpErr.BaseError.ErrorDetails, ShouldContainSubstring, "condition.sub_conditions")
+		})
+
+		Convey("Failed with nested empty or condition path\n", func() {
+			at := &interfaces.ActionType{
+				ActionTypeWithKeyField: interfaces.ActionTypeWithKeyField{
+					ATID:         "at1",
+					ATName:       "action1",
+					ObjectTypeID: "ot1",
+					ActionType:   interfaces.ACTION_TYPE_ADD,
+					Condition: &interfaces.ActionCondCfg{
+						ObjectTypeID: "ot1",
+						Operation:    cond.OperationAnd,
+						SubConds: []*interfaces.ActionCondCfg{
+							{
+								ObjectTypeID: "ot1",
+								Field:        "field1",
+								Operation:    cond.OperationEq,
+								ValueOptCfg: cond.ValueOptCfg{
+									Value: "value1",
+								},
+							},
+							{
+								ObjectTypeID: "ot1",
+								Operation:    cond.OperationOr,
+							},
+						},
+					},
+				},
+			}
+			err := ValidateActionType(ctx, at, true)
+			So(err, ShouldNotBeNil)
+			httpErr := err.(*rest.HTTPError)
+			So(httpErr.BaseError.ErrorCode, ShouldEqual, berrors.BknBackend_ActionType_InvalidParameter)
+			So(httpErr.BaseError.ErrorDetails, ShouldContainSubstring, "condition.sub_conditions[1].sub_conditions")
+		})
+
 		Convey("Failed with eq operation having array value\n", func() {
 			at := &interfaces.ActionType{
 				ActionTypeWithKeyField: interfaces.ActionTypeWithKeyField{

--- a/adp/bkn/ontology-query/server/common/condition/condition_and.go
+++ b/adp/bkn/ontology-query/server/common/condition/condition_and.go
@@ -20,7 +20,10 @@ func newAndCond(ctx context.Context, cfg *CondCfg, fieldScope uint8, fieldsMap m
 	subConds := []Condition{}
 
 	if len(cfg.SubConds) == 0 {
-		return nil, nil
+		return &AndCond{
+			mCfg:      cfg,
+			mSubConds: subConds,
+		}, nil
 	}
 
 	if len(cfg.SubConds) > MaxSubCondition {

--- a/adp/bkn/ontology-query/server/common/condition/condition_and.go
+++ b/adp/bkn/ontology-query/server/common/condition/condition_and.go
@@ -20,7 +20,7 @@ func newAndCond(ctx context.Context, cfg *CondCfg, fieldScope uint8, fieldsMap m
 	subConds := []Condition{}
 
 	if len(cfg.SubConds) == 0 {
-		return nil, fmt.Errorf("sub condition size is 0")
+		return nil, nil
 	}
 
 	if len(cfg.SubConds) > MaxSubCondition {

--- a/adp/bkn/ontology-query/server/common/condition/condition_and.go
+++ b/adp/bkn/ontology-query/server/common/condition/condition_and.go
@@ -101,7 +101,7 @@ func rewriteAndCondition(ctx context.Context, cfg *CondCfg, fieldsMap map[string
 	subConds := []*CondCfg{}
 
 	if len(cfg.SubConds) == 0 {
-		return nil, fmt.Errorf("sub condition size is 0")
+		return nil, nil
 	}
 
 	if len(cfg.SubConds) > MaxSubCondition {
@@ -117,6 +117,9 @@ func rewriteAndCondition(ctx context.Context, cfg *CondCfg, fieldsMap map[string
 		if cond != nil {
 			subConds = append(subConds, cond)
 		}
+	}
+	if len(subConds) == 0 {
+		return nil, nil
 	}
 	viewCondi := *cfg
 	viewCondi.SubConds = subConds

--- a/adp/bkn/ontology-query/server/common/condition/condition_and_or_test.go
+++ b/adp/bkn/ontology-query/server/common/condition/condition_and_or_test.go
@@ -60,14 +60,17 @@ func Test_newAndCond(t *testing.T) {
 			So(cond, ShouldNotBeNil)
 		})
 
-		Convey("success - empty AND creates nil condition", func() {
+		Convey("success - empty AND creates match-all condition", func() {
 			cfg := &CondCfg{
 				Operation: OperationAnd,
 				SubConds:  []*CondCfg{},
 			}
 			cond, err := newAndCond(ctx, cfg, CUSTOM, fieldsMap)
 			So(err, ShouldBeNil)
-			So(cond, ShouldBeNil)
+			So(cond, ShouldNotBeNil)
+			dsl, err := cond.Convert(ctx, nil)
+			So(err, ShouldBeNil)
+			So(dsl, ShouldContainSubstring, `"must"`)
 		})
 
 		Convey("失败 - 子条件超过限制", func() {
@@ -367,6 +370,31 @@ func Test_newOrCond(t *testing.T) {
 			cond, err := newOrCond(ctx, cfg, CUSTOM, fieldsMap)
 			So(err, ShouldNotBeNil)
 			So(cond, ShouldBeNil)
+		})
+
+		Convey("success - nested empty AND is skipped in OR", func() {
+			cfg := &CondCfg{
+				Operation: OperationOr,
+				SubConds: []*CondCfg{
+					{
+						Operation: OperationAnd,
+						SubConds:  []*CondCfg{},
+					},
+					{
+						Name:      "name",
+						Operation: OperationEq,
+						ValueOptCfg: ValueOptCfg{
+							Value: "test",
+						},
+					},
+				},
+			}
+			cond, err := newOrCond(ctx, cfg, CUSTOM, fieldsMap)
+			So(err, ShouldBeNil)
+			So(cond, ShouldNotBeNil)
+			dsl, err := cond.Convert(ctx, nil)
+			So(err, ShouldBeNil)
+			So(dsl, ShouldContainSubstring, `"should"`)
 		})
 	})
 }

--- a/adp/bkn/ontology-query/server/common/condition/condition_and_or_test.go
+++ b/adp/bkn/ontology-query/server/common/condition/condition_and_or_test.go
@@ -60,7 +60,7 @@ func Test_newAndCond(t *testing.T) {
 			So(cond, ShouldNotBeNil)
 		})
 
-		Convey("失败 - 子条件为空", func() {
+		Convey("success - empty AND rewrites to nil", func() {
 			cfg := &CondCfg{
 				Operation: OperationAnd,
 				SubConds:  []*CondCfg{},
@@ -270,8 +270,32 @@ func Test_rewriteAndCondition(t *testing.T) {
 				SubConds:  []*CondCfg{},
 			}
 			result, err := rewriteAndCondition(ctx, cfg, fieldsMap, vectorizer)
-			So(err, ShouldNotBeNil)
+			So(err, ShouldBeNil)
 			So(result, ShouldBeNil)
+		})
+
+		Convey("success - empty nested AND is skipped during rewrite", func() {
+			cfg := &CondCfg{
+				Operation: OperationAnd,
+				SubConds: []*CondCfg{
+					{
+						Operation: OperationAnd,
+						SubConds:  []*CondCfg{},
+					},
+					{
+						Name:      "name",
+						Operation: OperationEq,
+						ValueOptCfg: ValueOptCfg{
+							Value: "test",
+						},
+					},
+				},
+			}
+			result, err := rewriteAndCondition(ctx, cfg, fieldsMap, vectorizer)
+			So(err, ShouldBeNil)
+			So(result, ShouldNotBeNil)
+			So(len(result.SubConds), ShouldEqual, 1)
+			So(result.SubConds[0].Name, ShouldEqual, "mapped_name")
 		})
 
 		Convey("失败 - 子条件超过限制", func() {
@@ -428,6 +452,58 @@ func Test_OrCond_Convert2SQL(t *testing.T) {
 			result, err := cond.Convert2SQL(ctx)
 			So(err, ShouldBeNil)
 			So(result, ShouldContainSubstring, `OR`)
+		})
+	})
+}
+
+func Test_rewriteOrCondition(t *testing.T) {
+	Convey("Test rewriteOrCondition", t, func() {
+		ctx := context.Background()
+		fieldsMap := map[string]*DataProperty{
+			"name": {
+				Name: "name",
+				Type: dtype.DATATYPE_STRING,
+				MappedField: Field{
+					Name: "mapped_name",
+				},
+			},
+		}
+		vectorizer := func(ctx context.Context, property *DataProperty, word string) ([]VectorResp, error) {
+			return []VectorResp{}, nil
+		}
+
+		Convey("success - empty OR rewrites to nil", func() {
+			cfg := &CondCfg{
+				Operation: OperationOr,
+				SubConds:  []*CondCfg{},
+			}
+			result, err := rewriteOrCondition(ctx, cfg, fieldsMap, vectorizer)
+			So(err, ShouldBeNil)
+			So(result, ShouldBeNil)
+		})
+
+		Convey("success - empty nested OR is skipped during rewrite", func() {
+			cfg := &CondCfg{
+				Operation: OperationOr,
+				SubConds: []*CondCfg{
+					{
+						Operation: OperationOr,
+						SubConds:  []*CondCfg{},
+					},
+					{
+						Name:      "name",
+						Operation: OperationEq,
+						ValueOptCfg: ValueOptCfg{
+							Value: "test",
+						},
+					},
+				},
+			}
+			result, err := rewriteOrCondition(ctx, cfg, fieldsMap, vectorizer)
+			So(err, ShouldBeNil)
+			So(result, ShouldNotBeNil)
+			So(len(result.SubConds), ShouldEqual, 1)
+			So(result.SubConds[0].Name, ShouldEqual, "mapped_name")
 		})
 	})
 }

--- a/adp/bkn/ontology-query/server/common/condition/condition_and_or_test.go
+++ b/adp/bkn/ontology-query/server/common/condition/condition_and_or_test.go
@@ -60,13 +60,13 @@ func Test_newAndCond(t *testing.T) {
 			So(cond, ShouldNotBeNil)
 		})
 
-		Convey("success - empty AND rewrites to nil", func() {
+		Convey("success - empty AND creates nil condition", func() {
 			cfg := &CondCfg{
 				Operation: OperationAnd,
 				SubConds:  []*CondCfg{},
 			}
 			cond, err := newAndCond(ctx, cfg, CUSTOM, fieldsMap)
-			So(err, ShouldNotBeNil)
+			So(err, ShouldBeNil)
 			So(cond, ShouldBeNil)
 		})
 
@@ -472,17 +472,17 @@ func Test_rewriteOrCondition(t *testing.T) {
 			return []VectorResp{}, nil
 		}
 
-		Convey("success - empty OR rewrites to nil", func() {
+		Convey("failure - empty OR fails closed during rewrite", func() {
 			cfg := &CondCfg{
 				Operation: OperationOr,
 				SubConds:  []*CondCfg{},
 			}
 			result, err := rewriteOrCondition(ctx, cfg, fieldsMap, vectorizer)
-			So(err, ShouldBeNil)
+			So(err, ShouldNotBeNil)
 			So(result, ShouldBeNil)
 		})
 
-		Convey("success - empty nested OR is skipped during rewrite", func() {
+		Convey("failure - nested empty OR fails closed during rewrite", func() {
 			cfg := &CondCfg{
 				Operation: OperationOr,
 				SubConds: []*CondCfg{
@@ -500,10 +500,8 @@ func Test_rewriteOrCondition(t *testing.T) {
 				},
 			}
 			result, err := rewriteOrCondition(ctx, cfg, fieldsMap, vectorizer)
-			So(err, ShouldBeNil)
-			So(result, ShouldNotBeNil)
-			So(len(result.SubConds), ShouldEqual, 1)
-			So(result.SubConds[0].Name, ShouldEqual, "mapped_name")
+			So(err, ShouldNotBeNil)
+			So(result, ShouldBeNil)
 		})
 	})
 }

--- a/adp/bkn/ontology-query/server/common/condition/condition_or.go
+++ b/adp/bkn/ontology-query/server/common/condition/condition_or.go
@@ -105,7 +105,7 @@ func rewriteOrCondition(ctx context.Context, cfg *CondCfg, fieldsMap map[string]
 	subConds := []*CondCfg{}
 
 	if len(cfg.SubConds) == 0 {
-		return nil, fmt.Errorf("sub condition size is 0")
+		return nil, nil
 	}
 
 	if len(cfg.SubConds) > MaxSubCondition {
@@ -121,6 +121,9 @@ func rewriteOrCondition(ctx context.Context, cfg *CondCfg, fieldsMap map[string]
 		if cond != nil {
 			subConds = append(subConds, cond)
 		}
+	}
+	if len(subConds) == 0 {
+		return nil, nil
 	}
 	viewCondi := *cfg
 	viewCondi.SubConds = subConds

--- a/adp/bkn/ontology-query/server/common/condition/condition_or.go
+++ b/adp/bkn/ontology-query/server/common/condition/condition_or.go
@@ -105,7 +105,7 @@ func rewriteOrCondition(ctx context.Context, cfg *CondCfg, fieldsMap map[string]
 	subConds := []*CondCfg{}
 
 	if len(cfg.SubConds) == 0 {
-		return nil, nil
+		return nil, fmt.Errorf("sub condition size is 0")
 	}
 
 	if len(cfg.SubConds) > MaxSubCondition {
@@ -123,7 +123,7 @@ func rewriteOrCondition(ctx context.Context, cfg *CondCfg, fieldsMap map[string]
 		}
 	}
 	if len(subConds) == 0 {
-		return nil, nil
+		return nil, fmt.Errorf("sub condition size is 0")
 	}
 	viewCondi := *cfg
 	viewCondi.SubConds = subConds

--- a/adp/bkn/ontology-query/server/common/condition/condition_or.go
+++ b/adp/bkn/ontology-query/server/common/condition/condition_or.go
@@ -33,7 +33,12 @@ func newOrCond(ctx context.Context, cfg *CondCfg, fieldScope uint8, fieldsMap ma
 			return nil, err
 		}
 
-		subConds = append(subConds, cond)
+		if cond != nil {
+			subConds = append(subConds, cond)
+		}
+	}
+	if len(subConds) == 0 {
+		return nil, fmt.Errorf("sub condition size is 0")
 	}
 
 	return &OrCond{


### PR DESCRIPTION
﻿# Pull Request

## What Changed

Brief description of changes:

- [x] bkn-backend action type validation now rejects empty `and` / `or` trigger condition groups with field-path details
- [x] ontology-query condition rewrite treats empty rewritten `and` / `or` groups as no filter instead of returning `sub condition size is 0`
- [x] Regression tests cover action condition validation and empty group rewrite behavior

---

## Why

- Related Issue: Closes #534
- Related Feature: N/A
- Background: Action type trigger conditions could be saved or echoed back as empty logical groups. Those conditions later failed resource-backed execute paths when ontology-query rewrote an empty `and` group and returned `sub condition size is 0`.

---

## How

- Key implementation points:
  - Added recursive validation for action type trigger conditions so empty logical groups are rejected during create/update validation.
  - Preserved valid leaf and nested condition behavior while returning precise condition paths for invalid empty groups.
  - Updated ontology-query `rewriteAndCondition` / `rewriteOrCondition` to return nil when all rewritten children are removed.
- Breaking changes (API, config, database, etc.):
  - API now rejects newly saved empty action trigger condition groups with 400 instead of persisting invalid conditions. Existing valid conditions are unchanged.

---

## Testing

- [x] Unit tests passed locally
- [ ] Integration tests passed locally — not run
- [ ] Verified in test environment — not run

Test notes:

```powershell
cd adp/bkn/bkn-backend/server
$env:I18N_MODE_UT='true'; go test ./driveradapters -run "Test_ValidateActionType" -count=1
$env:I18N_MODE_UT='true'; go test ./driveradapters -count=1

cd adp/bkn/ontology-query/server
$env:I18N_MODE_UT='true'; go test ./common/condition -count=1
$env:I18N_MODE_UT='true'; go test ./common/condition ./logics/action_type -count=1
```

---

## Risk & Rollback

- Potential risks: Clients that still submit empty logical condition groups will now receive a 400 and need to omit the condition or submit at least one valid child condition.
- Rollback plan: Revert this PR to restore previous validation/rewrite behavior.

---

## Additional Notes

- Studio UI follow-up is out of scope here; this PR makes the API and ontology-query behavior deterministic for new saved data.
