### PR TITLE
feat(bkn-trace): add business provenance query projections

### DIFF
--- a/bkn-trace/agent-observability/docs/swagger/docs.go
+++ b/bkn-trace/agent-observability/docs/swagger/docs.go
@@ -54,6 +54,212 @@ const docTemplate = `{
                 }
             }
         },
+        "/business-provenance/conversations": {
+            "get": {
+                "description": "Returns one authorized business-provenance row per conversation, aggregated from real interactions and requests.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "business-provenance"
+                ],
+                "summary": "List observable business conversations",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "Page size, 1..200",
+                        "name": "limit",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Opaque pagination cursor",
+                        "name": "cursor",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Started at or after this RFC3339 timestamp",
+                        "name": "from",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Started at or before this RFC3339 timestamp",
+                        "name": "to",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Execution status",
+                        "name": "status",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Agent or application",
+                        "name": "agent_or_app",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Business domain",
+                        "name": "business_domain",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Knowledge network",
+                        "name": "knowledge_network",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Evidence completeness",
+                        "name": "evidence_completeness",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Question, result, ID, business ref, or error keyword",
+                        "name": "keyword",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/evidencevo.ConversationSummaryPage"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/rdto.ErrorResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/rdto.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/rdto.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/business-provenance/interactions": {
+            "get": {
+                "description": "Returns one authorized business-provenance row per interaction, aggregated from real requests.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "business-provenance"
+                ],
+                "summary": "List observable business interactions",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "Page size, 1..200",
+                        "name": "limit",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Opaque pagination cursor",
+                        "name": "cursor",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Conversation ID",
+                        "name": "conversation_id",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Started at or after this RFC3339 timestamp",
+                        "name": "from",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Started at or before this RFC3339 timestamp",
+                        "name": "to",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Execution status",
+                        "name": "status",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Agent or application",
+                        "name": "agent_or_app",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Business domain",
+                        "name": "business_domain",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Knowledge network",
+                        "name": "knowledge_network",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Evidence completeness",
+                        "name": "evidence_completeness",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Question, result, ID, business ref, or error keyword",
+                        "name": "keyword",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/evidencevo.InteractionSummaryPage"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/rdto.ErrorResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/rdto.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/rdto.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/conversations": {
             "get": {
                 "produces": [
@@ -2948,6 +3154,97 @@ const docTemplate = `{
                 }
             }
         },
+        "evidencevo.ConversationSummary": {
+            "type": "object",
+            "properties": {
+                "agent_or_app": {
+                    "type": "string"
+                },
+                "business_domain": {
+                    "type": "string"
+                },
+                "completed_at": {
+                    "type": "string"
+                },
+                "conversation_id": {
+                    "type": "string"
+                },
+                "duration_ms": {
+                    "type": "integer"
+                },
+                "error_summary": {
+                    "type": "string"
+                },
+                "evidence_completeness": {
+                    "type": "string"
+                },
+                "initiator": {
+                    "type": "string"
+                },
+                "interaction_count": {
+                    "type": "integer"
+                },
+                "knowledge_networks": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "partial_reasons": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "question_preview": {
+                    "type": "string"
+                },
+                "request_count": {
+                    "type": "integer"
+                },
+                "result_preview": {
+                    "type": "string"
+                },
+                "started_at": {
+                    "type": "string"
+                },
+                "status": {
+                    "type": "string"
+                },
+                "trace_count": {
+                    "type": "integer"
+                }
+            }
+        },
+        "evidencevo.ConversationSummaryPage": {
+            "type": "object",
+            "properties": {
+                "entries": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/evidencevo.ConversationSummary"
+                    }
+                },
+                "next_cursor": {
+                    "type": "string"
+                },
+                "partial": {
+                    "type": "boolean"
+                },
+                "partial_reasons": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "total": {
+                    "type": "integer"
+                },
+                "truncated": {
+                    "type": "boolean"
+                }
+            }
+        },
         "evidencevo.EvidenceArtifact": {
             "type": "object",
             "properties": {
@@ -3169,6 +3466,68 @@ const docTemplate = `{
                 }
             }
         },
+        "evidencevo.InteractionListSummary": {
+            "type": "object",
+            "properties": {
+                "agent_or_app": {
+                    "type": "string"
+                },
+                "business_domain": {
+                    "type": "string"
+                },
+                "completed_at": {
+                    "type": "string"
+                },
+                "conversation_id": {
+                    "type": "string"
+                },
+                "duration_ms": {
+                    "type": "integer"
+                },
+                "error_summary": {
+                    "type": "string"
+                },
+                "evidence_completeness": {
+                    "type": "string"
+                },
+                "initiator": {
+                    "type": "string"
+                },
+                "interaction_id": {
+                    "type": "string"
+                },
+                "knowledge_networks": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "partial_reasons": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "question_preview": {
+                    "type": "string"
+                },
+                "request_count": {
+                    "type": "integer"
+                },
+                "result_preview": {
+                    "type": "string"
+                },
+                "started_at": {
+                    "type": "string"
+                },
+                "status": {
+                    "type": "string"
+                },
+                "trace_count": {
+                    "type": "integer"
+                }
+            }
+        },
         "evidencevo.InteractionSummary": {
             "type": "object",
             "properties": {
@@ -3201,6 +3560,35 @@ const docTemplate = `{
                     "items": {
                         "$ref": "#/definitions/evidencevo.TraceSummary"
                     }
+                }
+            }
+        },
+        "evidencevo.InteractionSummaryPage": {
+            "type": "object",
+            "properties": {
+                "entries": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/evidencevo.InteractionListSummary"
+                    }
+                },
+                "next_cursor": {
+                    "type": "string"
+                },
+                "partial": {
+                    "type": "boolean"
+                },
+                "partial_reasons": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "total": {
+                    "type": "integer"
+                },
+                "truncated": {
+                    "type": "boolean"
                 }
             }
         },

--- a/bkn-trace/agent-observability/docs/swagger/swagger.json
+++ b/bkn-trace/agent-observability/docs/swagger/swagger.json
@@ -46,6 +46,212 @@
                 }
             }
         },
+        "/business-provenance/conversations": {
+            "get": {
+                "description": "Returns one authorized business-provenance row per conversation, aggregated from real interactions and requests.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "business-provenance"
+                ],
+                "summary": "List observable business conversations",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "Page size, 1..200",
+                        "name": "limit",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Opaque pagination cursor",
+                        "name": "cursor",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Started at or after this RFC3339 timestamp",
+                        "name": "from",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Started at or before this RFC3339 timestamp",
+                        "name": "to",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Execution status",
+                        "name": "status",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Agent or application",
+                        "name": "agent_or_app",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Business domain",
+                        "name": "business_domain",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Knowledge network",
+                        "name": "knowledge_network",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Evidence completeness",
+                        "name": "evidence_completeness",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Question, result, ID, business ref, or error keyword",
+                        "name": "keyword",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/evidencevo.ConversationSummaryPage"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/rdto.ErrorResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/rdto.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/rdto.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/business-provenance/interactions": {
+            "get": {
+                "description": "Returns one authorized business-provenance row per interaction, aggregated from real requests.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "business-provenance"
+                ],
+                "summary": "List observable business interactions",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "Page size, 1..200",
+                        "name": "limit",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Opaque pagination cursor",
+                        "name": "cursor",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Conversation ID",
+                        "name": "conversation_id",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Started at or after this RFC3339 timestamp",
+                        "name": "from",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Started at or before this RFC3339 timestamp",
+                        "name": "to",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Execution status",
+                        "name": "status",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Agent or application",
+                        "name": "agent_or_app",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Business domain",
+                        "name": "business_domain",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Knowledge network",
+                        "name": "knowledge_network",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Evidence completeness",
+                        "name": "evidence_completeness",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Question, result, ID, business ref, or error keyword",
+                        "name": "keyword",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/evidencevo.InteractionSummaryPage"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/rdto.ErrorResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/rdto.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/rdto.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/conversations": {
             "get": {
                 "produces": [
@@ -2940,6 +3146,97 @@
                 }
             }
         },
+        "evidencevo.ConversationSummary": {
+            "type": "object",
+            "properties": {
+                "agent_or_app": {
+                    "type": "string"
+                },
+                "business_domain": {
+                    "type": "string"
+                },
+                "completed_at": {
+                    "type": "string"
+                },
+                "conversation_id": {
+                    "type": "string"
+                },
+                "duration_ms": {
+                    "type": "integer"
+                },
+                "error_summary": {
+                    "type": "string"
+                },
+                "evidence_completeness": {
+                    "type": "string"
+                },
+                "initiator": {
+                    "type": "string"
+                },
+                "interaction_count": {
+                    "type": "integer"
+                },
+                "knowledge_networks": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "partial_reasons": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "question_preview": {
+                    "type": "string"
+                },
+                "request_count": {
+                    "type": "integer"
+                },
+                "result_preview": {
+                    "type": "string"
+                },
+                "started_at": {
+                    "type": "string"
+                },
+                "status": {
+                    "type": "string"
+                },
+                "trace_count": {
+                    "type": "integer"
+                }
+            }
+        },
+        "evidencevo.ConversationSummaryPage": {
+            "type": "object",
+            "properties": {
+                "entries": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/evidencevo.ConversationSummary"
+                    }
+                },
+                "next_cursor": {
+                    "type": "string"
+                },
+                "partial": {
+                    "type": "boolean"
+                },
+                "partial_reasons": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "total": {
+                    "type": "integer"
+                },
+                "truncated": {
+                    "type": "boolean"
+                }
+            }
+        },
         "evidencevo.EvidenceArtifact": {
             "type": "object",
             "properties": {
@@ -3161,6 +3458,68 @@
                 }
             }
         },
+        "evidencevo.InteractionListSummary": {
+            "type": "object",
+            "properties": {
+                "agent_or_app": {
+                    "type": "string"
+                },
+                "business_domain": {
+                    "type": "string"
+                },
+                "completed_at": {
+                    "type": "string"
+                },
+                "conversation_id": {
+                    "type": "string"
+                },
+                "duration_ms": {
+                    "type": "integer"
+                },
+                "error_summary": {
+                    "type": "string"
+                },
+                "evidence_completeness": {
+                    "type": "string"
+                },
+                "initiator": {
+                    "type": "string"
+                },
+                "interaction_id": {
+                    "type": "string"
+                },
+                "knowledge_networks": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "partial_reasons": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "question_preview": {
+                    "type": "string"
+                },
+                "request_count": {
+                    "type": "integer"
+                },
+                "result_preview": {
+                    "type": "string"
+                },
+                "started_at": {
+                    "type": "string"
+                },
+                "status": {
+                    "type": "string"
+                },
+                "trace_count": {
+                    "type": "integer"
+                }
+            }
+        },
         "evidencevo.InteractionSummary": {
             "type": "object",
             "properties": {
@@ -3193,6 +3552,35 @@
                     "items": {
                         "$ref": "#/definitions/evidencevo.TraceSummary"
                     }
+                }
+            }
+        },
+        "evidencevo.InteractionSummaryPage": {
+            "type": "object",
+            "properties": {
+                "entries": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/evidencevo.InteractionListSummary"
+                    }
+                },
+                "next_cursor": {
+                    "type": "string"
+                },
+                "partial": {
+                    "type": "boolean"
+                },
+                "partial_reasons": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "total": {
+                    "type": "integer"
+                },
+                "truncated": {
+                    "type": "boolean"
                 }
             }
         },

--- a/bkn-trace/agent-observability/src/boot/bootstrap.go
+++ b/bkn-trace/agent-observability/src/boot/bootstrap.go
@@ -326,6 +326,8 @@ func newApp(
 	mux.HandleFunc(APIBasePath+"/evidence/artifacts", evidenceHandler.IngestEvidenceArtifact)
 	mux.HandleFunc(APIBasePath+"/evidence/artifacts/", readAuth(evidenceHandler.GetEvidenceArtifact))
 	mux.HandleFunc(APIBasePath+"/evidence/by-trace", readAuth(evidenceHandler.SearchEvidenceByTrace))
+	mux.HandleFunc(APIBasePath+"/business-provenance/conversations", readAuth(evidenceHandler.ListBusinessProvenanceConversations))
+	mux.HandleFunc(APIBasePath+"/business-provenance/interactions", readAuth(evidenceHandler.ListBusinessProvenanceInteractions))
 	mux.HandleFunc(APIBasePath+"/trace-executions", readAuth(evidenceHandler.ListTraceExecutions))
 	mux.HandleFunc(APIBasePath+"/access-profile", readAuth(evidenceHandler.GetAccessProfile))
 	httphandler.RegisterSessionRoutes(

--- a/bkn-trace/agent-observability/src/domain/service/evidencesvc/summary.go
+++ b/bkn-trace/agent-observability/src/domain/service/evidencesvc/summary.go
@@ -80,6 +80,264 @@ func (s *Service) ListRequests(ctx context.Context, options evidencevo.SummaryQu
 	return page, nil
 }
 
+func (s *Service) ListConversations(ctx context.Context, options evidencevo.SummaryQueryOptions) (evidencevo.ConversationSummaryPage, error) {
+	requests, _, metadata, err := s.loadExecutionSummaries(ctx, options)
+	if err != nil {
+		return evidencevo.ConversationSummaryPage{}, err
+	}
+	grouped := map[string][]evidencevo.RequestSummary{}
+	for _, request := range requests {
+		if request.ConversationID != "" && matchesRequestFilters(request, options) {
+			grouped[request.ConversationID] = append(grouped[request.ConversationID], request)
+		}
+	}
+	entries := make([]evidencevo.ConversationSummary, 0, len(grouped))
+	for conversationID, group := range grouped {
+		entries = append(entries, buildConversationSummary(conversationID, group))
+	}
+	sort.Slice(entries, func(i, j int) bool {
+		if entries[i].StartedAt == entries[j].StartedAt {
+			return entries[i].ConversationID < entries[j].ConversationID
+		}
+		return entries[i].StartedAt > entries[j].StartedAt
+	})
+	cursor, hasCursor, err := decodeSummaryCursor(options.Cursor)
+	if err != nil {
+		return evidencevo.ConversationSummaryPage{}, err
+	}
+	start := summaryPageStart(len(entries), hasCursor, func(index int) bool {
+		return afterSummaryCursor(entries[index].StartedAt, entries[index].ConversationID, cursor)
+	})
+	end := summaryPageEnd(start, len(entries), options.Limit)
+	page := evidencevo.ConversationSummaryPage{
+		Entries: append([]evidencevo.ConversationSummary{}, entries[start:end]...),
+		Total:   len(entries), Truncated: metadata.Truncated, Partial: metadata.Truncated,
+		PartialReasons: append([]string{}, metadata.PartialReasons...),
+	}
+	if end < len(entries) && len(page.Entries) > 0 {
+		last := page.Entries[len(page.Entries)-1]
+		next := encodeSummaryCursor(summaryCursor{StartedAt: last.StartedAt, ID: last.ConversationID})
+		page.NextCursor = &next
+	}
+	return page, nil
+}
+
+func (s *Service) ListInteractions(ctx context.Context, options evidencevo.SummaryQueryOptions) (evidencevo.InteractionSummaryPage, error) {
+	requests, _, metadata, err := s.loadExecutionSummaries(ctx, options)
+	if err != nil {
+		return evidencevo.InteractionSummaryPage{}, err
+	}
+	grouped := map[string][]evidencevo.RequestSummary{}
+	for _, request := range requests {
+		if request.InteractionID != "" && matchesRequestFilters(request, options) {
+			grouped[request.InteractionID] = append(grouped[request.InteractionID], request)
+		}
+	}
+	entries := make([]evidencevo.InteractionListSummary, 0, len(grouped))
+	for interactionID, group := range grouped {
+		entries = append(entries, buildInteractionListSummary(interactionID, group))
+	}
+	sort.Slice(entries, func(i, j int) bool {
+		if entries[i].StartedAt == entries[j].StartedAt {
+			return entries[i].InteractionID < entries[j].InteractionID
+		}
+		return entries[i].StartedAt > entries[j].StartedAt
+	})
+	cursor, hasCursor, err := decodeSummaryCursor(options.Cursor)
+	if err != nil {
+		return evidencevo.InteractionSummaryPage{}, err
+	}
+	start := summaryPageStart(len(entries), hasCursor, func(index int) bool {
+		return afterSummaryCursor(entries[index].StartedAt, entries[index].InteractionID, cursor)
+	})
+	end := summaryPageEnd(start, len(entries), options.Limit)
+	page := evidencevo.InteractionSummaryPage{
+		Entries: append([]evidencevo.InteractionListSummary{}, entries[start:end]...),
+		Total:   len(entries), Truncated: metadata.Truncated, Partial: metadata.Truncated,
+		PartialReasons: append([]string{}, metadata.PartialReasons...),
+	}
+	if end < len(entries) && len(page.Entries) > 0 {
+		last := page.Entries[len(page.Entries)-1]
+		next := encodeSummaryCursor(summaryCursor{StartedAt: last.StartedAt, ID: last.InteractionID})
+		page.NextCursor = &next
+	}
+	return page, nil
+}
+
+func buildConversationSummary(conversationID string, requests []evidencevo.RequestSummary) evidencevo.ConversationSummary {
+	base, interactionCount := aggregateRequestGroup(requests)
+	return evidencevo.ConversationSummary{
+		ConversationID: conversationID,
+		StartedAt:      base.StartedAt, CompletedAt: base.CompletedAt,
+		Initiator: base.Initiator, AgentOrApp: base.AgentOrApp, BusinessDomain: base.BusinessDomain,
+		KnowledgeNetworks: base.KnowledgeNetworks, QuestionPreview: base.QuestionPreview, ResultPreview: base.ResultPreview,
+		Status: base.Status, EvidenceCompleteness: base.EvidenceCompleteness, PartialReasons: base.PartialReasons,
+		InteractionCount: interactionCount, RequestCount: len(requests), TraceCount: base.TraceCount,
+		DurationMS: base.DurationMS, ErrorSummary: base.ErrorSummary,
+	}
+}
+
+func buildInteractionListSummary(interactionID string, requests []evidencevo.RequestSummary) evidencevo.InteractionListSummary {
+	base, _ := aggregateRequestGroup(requests)
+	conversationID := ""
+	conversationConflict := false
+	for _, request := range requests {
+		if request.ConversationID == "" {
+			continue
+		}
+		if conversationID == "" && !conversationConflict {
+			conversationID = request.ConversationID
+		} else if conversationID != request.ConversationID {
+			conversationID = ""
+			conversationConflict = true
+		}
+	}
+	return evidencevo.InteractionListSummary{
+		InteractionID: interactionID, ConversationID: conversationID,
+		StartedAt: base.StartedAt, CompletedAt: base.CompletedAt,
+		Initiator: base.Initiator, AgentOrApp: base.AgentOrApp, BusinessDomain: base.BusinessDomain,
+		KnowledgeNetworks: base.KnowledgeNetworks, QuestionPreview: base.QuestionPreview, ResultPreview: base.ResultPreview,
+		Status: base.Status, EvidenceCompleteness: base.EvidenceCompleteness, PartialReasons: base.PartialReasons,
+		RequestCount: len(requests), TraceCount: base.TraceCount, DurationMS: base.DurationMS, ErrorSummary: base.ErrorSummary,
+	}
+}
+
+func aggregateRequestGroup(requests []evidencevo.RequestSummary) (evidencevo.RequestSummary, int) {
+	result := evidencevo.RequestSummary{Status: "unknown"}
+	interactions := map[string]struct{}{}
+	knowledgeNetworks := map[string]struct{}{}
+	partialReasons := map[string]struct{}{}
+	var started, completed time.Time
+	questionAt := ""
+	resultAt := ""
+	allCompleted := len(requests) > 0
+	hasError := false
+	hasRunning := false
+	for _, request := range requests {
+		mergeSummaryTime(&started, request.StartedAt, true)
+		mergeSummaryTime(&completed, request.CompletedAt, false)
+		if request.QuestionPreview != "" && (result.QuestionPreview == "" || summaryTimeBefore(request.StartedAt, questionAt)) {
+			result.QuestionPreview = request.QuestionPreview
+			questionAt = request.StartedAt
+		}
+		if request.ResultPreview != "" && (result.ResultPreview == "" || summaryTimeAfter(request.CompletedAt, resultAt)) {
+			result.ResultPreview = request.ResultPreview
+			resultAt = request.CompletedAt
+		}
+		firstNonEmptySummary(&result.Initiator, request.Initiator)
+		firstNonEmptySummary(&result.AgentOrApp, request.AgentOrApp)
+		firstNonEmptySummary(&result.BusinessDomain, request.BusinessDomain)
+		firstNonEmptySummary(&result.ErrorSummary, request.ErrorSummary)
+		result.TraceCount += request.TraceCount
+		if request.InteractionID != "" {
+			interactions[request.InteractionID] = struct{}{}
+		}
+		for _, network := range request.KnowledgeNetworks {
+			knowledgeNetworks[network] = struct{}{}
+		}
+		for _, reason := range request.PartialReasons {
+			partialReasons[reason] = struct{}{}
+		}
+		if evidenceCompletenessRank(request.EvidenceCompleteness) > evidenceCompletenessRank(result.EvidenceCompleteness) {
+			result.EvidenceCompleteness = request.EvidenceCompleteness
+		}
+		switch request.Status {
+		case "error":
+			hasError = true
+			allCompleted = false
+		case "running":
+			hasRunning = true
+			allCompleted = false
+		case "completed":
+		default:
+			allCompleted = false
+		}
+	}
+	switch {
+	case hasError:
+		result.Status = "error"
+	case hasRunning:
+		result.Status = "running"
+	case allCompleted:
+		result.Status = "completed"
+	}
+	if !started.IsZero() {
+		result.StartedAt = started.Format(time.RFC3339Nano)
+	}
+	if !completed.IsZero() {
+		result.CompletedAt = completed.Format(time.RFC3339Nano)
+	}
+	if !started.IsZero() && !completed.IsZero() && !completed.Before(started) {
+		result.DurationMS = completed.Sub(started).Milliseconds()
+	}
+	result.KnowledgeNetworks = sortedSummarySet(knowledgeNetworks)
+	result.PartialReasons = sortedSummarySet(partialReasons)
+	if result.EvidenceCompleteness == "" {
+		result.EvidenceCompleteness = "content_unavailable"
+	}
+	return result, len(interactions)
+}
+
+func evidenceCompletenessRank(value string) int {
+	switch value {
+	case "partial":
+		return 3
+	case "content_unavailable":
+		return 2
+	case "complete":
+		return 1
+	default:
+		return 0
+	}
+}
+
+func sortedSummarySet(values map[string]struct{}) []string {
+	result := make([]string, 0, len(values))
+	for value := range values {
+		result = append(result, value)
+	}
+	sort.Strings(result)
+	return result
+}
+
+func firstNonEmptySummary(target *string, value string) {
+	if *target == "" && value != "" {
+		*target = value
+	}
+}
+
+func summaryTimeBefore(value, other string) bool {
+	if other == "" {
+		return true
+	}
+	return value != "" && value < other
+}
+
+func summaryTimeAfter(value, other string) bool {
+	if other == "" {
+		return true
+	}
+	return value != "" && value > other
+}
+
+func summaryPageStart(length int, hasCursor bool, after func(int) bool) int {
+	start := 0
+	if hasCursor {
+		for start < length && !after(start) {
+			start++
+		}
+	}
+	return start
+}
+
+func summaryPageEnd(start, length, limit int) int {
+	end := start + normalizeSummaryLimit(limit)
+	if end > length {
+		return length
+	}
+	return end
+}
+
 func (s *Service) GetRequestSummary(ctx context.Context, requestID string, scope evidencevo.QueryScope) (evidencevo.RequestSummary, bool, error) {
 	requests, _, metadata, err := s.loadRequestExecutionSummaries(ctx, strings.TrimSpace(requestID), scope)
 	if err != nil {

--- a/bkn-trace/agent-observability/src/domain/service/evidencesvc/summary_service_test.go
+++ b/bkn-trace/agent-observability/src/domain/service/evidencesvc/summary_service_test.go
@@ -170,6 +170,73 @@ func TestGetInteractionSummaryAggregatesMultipleRequestsAndTraces(t *testing.T) 
 	}
 }
 
+func TestBusinessProvenanceListsUseTrueConversationInteractionAndRequestCardinality(t *testing.T) {
+	store := evidencestore.New()
+	seedBusinessProvenanceRequest(t, store, "req_plan", "trace_plan", "conversation_supply", "interaction_june", "2026-07-27T08:00:00Z", "查询六月预测", "六月共 63 条", "acct_demo")
+	seedBusinessProvenanceRequest(t, store, "req_data", "trace_data", "conversation_supply", "interaction_june", "2026-07-27T08:00:01Z", "读取预测数据", "合计 11594", "acct_demo")
+	seedBusinessProvenanceRequest(t, store, "req_compare", "trace_compare", "conversation_supply", "interaction_july", "2026-07-27T09:00:00Z", "对比七月预测", "七月下降 60%", "acct_demo")
+	seedBusinessProvenanceRequest(t, store, "req_secret", "trace_secret", "conversation_secret", "interaction_secret", "2026-07-27T10:00:00Z", "不可见问题", "不可见结果", "other-account")
+	service := NewWithProjectionSource(store, store)
+	options := evidencevo.SummaryQueryOptions{Scope: summaryScope("acct_demo"), Limit: 20}
+
+	conversations, err := service.ListConversations(context.Background(), options)
+	if err != nil {
+		t.Fatalf("list conversations: %v", err)
+	}
+	interactions, err := service.ListInteractions(context.Background(), options)
+	if err != nil {
+		t.Fatalf("list interactions: %v", err)
+	}
+	requests, err := service.ListRequests(context.Background(), options)
+	if err != nil {
+		t.Fatalf("list requests: %v", err)
+	}
+
+	if conversations.Total != 1 || len(conversations.Entries) != 1 {
+		t.Fatalf("expected one authorized conversation, got %+v", conversations)
+	}
+	conversation := conversations.Entries[0]
+	if conversation.ConversationID != "conversation_supply" || conversation.InteractionCount != 2 || conversation.RequestCount != 3 ||
+		conversation.QuestionPreview == "不可见问题" || conversation.ResultPreview == "不可见结果" {
+		t.Fatalf("unexpected conversation projection: %+v", conversation)
+	}
+	if interactions.Total != 2 || len(interactions.Entries) != 2 {
+		t.Fatalf("expected two authorized interactions, got %+v", interactions)
+	}
+	if requests.Total != 3 || len(requests.Entries) != 3 {
+		t.Fatalf("expected three authorized requests, got %+v", requests)
+	}
+}
+
+func TestBusinessProvenanceConversationAndInteractionListsUseStablePagination(t *testing.T) {
+	store := evidencestore.New()
+	seedBusinessProvenanceRequest(t, store, "req_old", "trace_old", "conversation_old", "interaction_old", "2026-07-27T08:00:00Z", "旧问题", "旧结果", "acct_demo")
+	seedBusinessProvenanceRequest(t, store, "req_new", "trace_new", "conversation_new", "interaction_new", "2026-07-27T09:00:00Z", "新问题", "新结果", "acct_demo")
+	service := NewWithProjectionSource(store, store)
+	options := evidencevo.SummaryQueryOptions{Scope: summaryScope("acct_demo"), Limit: 1}
+
+	firstConversations, err := service.ListConversations(context.Background(), options)
+	if err != nil || len(firstConversations.Entries) != 1 || firstConversations.Entries[0].ConversationID != "conversation_new" || firstConversations.NextCursor == nil {
+		t.Fatalf("unexpected first conversation page: %+v err=%v", firstConversations, err)
+	}
+	options.Cursor = *firstConversations.NextCursor
+	secondConversations, err := service.ListConversations(context.Background(), options)
+	if err != nil || len(secondConversations.Entries) != 1 || secondConversations.Entries[0].ConversationID != "conversation_old" || secondConversations.NextCursor != nil {
+		t.Fatalf("unexpected second conversation page: %+v err=%v", secondConversations, err)
+	}
+
+	options.Cursor = ""
+	firstInteractions, err := service.ListInteractions(context.Background(), options)
+	if err != nil || len(firstInteractions.Entries) != 1 || firstInteractions.Entries[0].InteractionID != "interaction_new" || firstInteractions.NextCursor == nil {
+		t.Fatalf("unexpected first interaction page: %+v err=%v", firstInteractions, err)
+	}
+	options.Cursor = *firstInteractions.NextCursor
+	secondInteractions, err := service.ListInteractions(context.Background(), options)
+	if err != nil || len(secondInteractions.Entries) != 1 || secondInteractions.Entries[0].InteractionID != "interaction_old" || secondInteractions.NextCursor != nil {
+		t.Fatalf("unexpected second interaction page: %+v err=%v", secondInteractions, err)
+	}
+}
+
 func TestRequestAndTraceSummarySupportMultipleTracesAndReverseLookup(t *testing.T) {
 	store := evidencestore.New()
 	seedSummaryRequest(t, store, "req_multi", "trace_multi_a", "2026-07-26T08:00:00Z", "多阶段问题", "最终结果", "agent-a", "bd_demo", "acct_demo")
@@ -570,6 +637,64 @@ func seedSummaryTrace(t *testing.T, store *evidencestore.Store, requestID, trace
 	}
 	if err := store.StoreEvidence(context.Background(), evidencevo.WithEvents(trace, trace.Events)); err != nil {
 		t.Fatal(err)
+	}
+}
+
+func seedBusinessProvenanceRequest(
+	t *testing.T,
+	store *evidencestore.Store,
+	requestID, traceID, conversationID, interactionID, at, question, result, account string,
+) {
+	t.Helper()
+	trace := evidencevo.NormalizedTrace{
+		TraceID: traceID, RequestID: requestID, ConversationID: conversationID,
+		TenantID: "tenant_demo", BusinessDomain: "bd_demo", AccountID: account, AccountType: "app",
+		SchemaVersion: evidencevo.ArtifactContractVersion,
+		Events: []evidencevo.EvidenceEvent{
+			{
+				EventID: "question_event_" + traceID, EventType: "agent.interaction.started",
+				SchemaVersion: evidencevo.ArtifactContractVersion,
+				ObservedAt:    at, EmittedAt: at, Producer: "third-party-agent", TraceID: traceID,
+				SpanID: "span_" + traceID, RequestID: requestID, InteractionID: interactionID, OperationName: "agent.run",
+				Payload: map[string]any{"app_ref": "supply-chain-agent", "question_artifact_ref": "artifact:question_" + requestID},
+			},
+			{
+				EventID: "result_event_" + traceID, EventType: "claim.created",
+				SchemaVersion: evidencevo.ArtifactContractVersion,
+				ObservedAt:    at, EmittedAt: at, Producer: "third-party-agent", TraceID: traceID,
+				SpanID: "span_" + traceID, RequestID: requestID, InteractionID: interactionID, OperationName: "claim.create",
+				Payload: map[string]any{
+					"claim_id": "claim_" + traceID, "visibility": "visible",
+					"result_artifact_ref": "artifact:result_" + requestID,
+					"business_refs":       []any{map[string]any{"ref_id": "object:kn_demo:item", "visibility": "visible"}},
+				},
+			},
+		},
+	}
+	if err := store.StoreEvidence(context.Background(), evidencevo.WithEvents(trace, trace.Events)); err != nil {
+		t.Fatal(err)
+	}
+	for _, item := range []struct {
+		id           string
+		artifactType evidencevo.ArtifactType
+		text         string
+	}{
+		{"question_" + requestID, evidencevo.ArtifactTypeQuestion, question},
+		{"result_" + requestID, evidencevo.ArtifactTypeResult, result},
+	} {
+		artifact, validationErrors := evidencevo.NormalizeArtifact(evidencevo.EvidenceArtifact{
+			ArtifactID: item.id, ArtifactType: item.artifactType,
+			RequestID: requestID, TraceID: traceID, InteractionID: interactionID,
+			ContentType: "application/json", SchemaVersion: evidencevo.ArtifactContractVersion, ObservedAt: at,
+			Content: map[string]any{"text": item.text}, AgentOrApp: "supply-chain-agent",
+			TenantID: "tenant_demo", BusinessDomain: "bd_demo", AccountID: account, AccountType: "app",
+		})
+		if len(validationErrors) != 0 {
+			t.Fatalf("normalize artifact: %+v", validationErrors)
+		}
+		if _, err := store.StoreArtifact(context.Background(), artifact); err != nil {
+			t.Fatal(err)
+		}
 	}
 }
 

--- a/bkn-trace/agent-observability/src/domain/valueobject/evidencevo/summary.go
+++ b/bkn-trace/agent-observability/src/domain/valueobject/evidencevo/summary.go
@@ -89,6 +89,64 @@ type TraceSummaryPage struct {
 	PartialReasons []string       `json:"partial_reasons,omitempty"`
 }
 
+type ConversationSummary struct {
+	ConversationID       string   `json:"conversation_id"`
+	StartedAt            string   `json:"started_at,omitempty"`
+	CompletedAt          string   `json:"completed_at,omitempty"`
+	Initiator            string   `json:"initiator,omitempty"`
+	AgentOrApp           string   `json:"agent_or_app,omitempty"`
+	BusinessDomain       string   `json:"business_domain,omitempty"`
+	KnowledgeNetworks    []string `json:"knowledge_networks,omitempty"`
+	QuestionPreview      string   `json:"question_preview,omitempty"`
+	ResultPreview        string   `json:"result_preview,omitempty"`
+	Status               string   `json:"status"`
+	EvidenceCompleteness string   `json:"evidence_completeness"`
+	PartialReasons       []string `json:"partial_reasons,omitempty"`
+	InteractionCount     int      `json:"interaction_count"`
+	RequestCount         int      `json:"request_count"`
+	TraceCount           int      `json:"trace_count"`
+	DurationMS           int64    `json:"duration_ms,omitempty"`
+	ErrorSummary         string   `json:"error_summary,omitempty"`
+}
+
+type InteractionListSummary struct {
+	InteractionID        string   `json:"interaction_id"`
+	ConversationID       string   `json:"conversation_id,omitempty"`
+	StartedAt            string   `json:"started_at,omitempty"`
+	CompletedAt          string   `json:"completed_at,omitempty"`
+	Initiator            string   `json:"initiator,omitempty"`
+	AgentOrApp           string   `json:"agent_or_app,omitempty"`
+	BusinessDomain       string   `json:"business_domain,omitempty"`
+	KnowledgeNetworks    []string `json:"knowledge_networks,omitempty"`
+	QuestionPreview      string   `json:"question_preview,omitempty"`
+	ResultPreview        string   `json:"result_preview,omitempty"`
+	Status               string   `json:"status"`
+	EvidenceCompleteness string   `json:"evidence_completeness"`
+	PartialReasons       []string `json:"partial_reasons,omitempty"`
+	RequestCount         int      `json:"request_count"`
+	TraceCount           int      `json:"trace_count"`
+	DurationMS           int64    `json:"duration_ms,omitempty"`
+	ErrorSummary         string   `json:"error_summary,omitempty"`
+}
+
+type ConversationSummaryPage struct {
+	Entries        []ConversationSummary `json:"entries"`
+	Total          int                   `json:"total"`
+	NextCursor     *string               `json:"next_cursor"`
+	Truncated      bool                  `json:"truncated"`
+	Partial        bool                  `json:"partial"`
+	PartialReasons []string              `json:"partial_reasons,omitempty"`
+}
+
+type InteractionSummaryPage struct {
+	Entries        []InteractionListSummary `json:"entries"`
+	Total          int                      `json:"total"`
+	NextCursor     *string                  `json:"next_cursor"`
+	Truncated      bool                     `json:"truncated"`
+	Partial        bool                     `json:"partial"`
+	PartialReasons []string                 `json:"partial_reasons,omitempty"`
+}
+
 type InteractionSummary struct {
 	InteractionID  string           `json:"interaction_id"`
 	ConversationID string           `json:"conversation_id,omitempty"`

--- a/bkn-trace/agent-observability/src/driveradapter/api/httphandler/evidence_handler_test.go
+++ b/bkn-trace/agent-observability/src/driveradapter/api/httphandler/evidence_handler_test.go
@@ -914,6 +914,40 @@ func TestEvidenceHandlerListsBusinessRequestsAndRequestDetail(t *testing.T) {
 	}
 }
 
+func TestEvidenceHandlerListsBusinessProvenanceConversationsAndInteractions(t *testing.T) {
+	handler := newDevEvidenceHandler(evidencesvc.New(evidencestore.New()))
+	artifactReq := httptest.NewRequest(http.MethodPost, "/api/agent-observability/v1/evidence/artifacts", strings.NewReader(validHandlerArtifact()))
+	artifactRec := httptest.NewRecorder()
+	handler.IngestEvidenceArtifact(artifactRec, artifactReq)
+	if artifactRec.Code != http.StatusCreated {
+		t.Fatalf("seed artifact: %d %s", artifactRec.Code, artifactRec.Body.String())
+	}
+	eventReq := httptest.NewRequest(http.MethodPost, "/api/agent-observability/v1/evidence/events", strings.NewReader(validHandlerArtifactEventBatch()))
+	eventRec := httptest.NewRecorder()
+	handler.IngestEvidenceEvents(eventRec, eventReq)
+	if eventRec.Code != http.StatusAccepted {
+		t.Fatalf("seed event: %d %s", eventRec.Code, eventRec.Body.String())
+	}
+
+	conversationReq := authenticatedQueryRequest(http.MethodGet, "/api/agent-observability/v1/business-provenance/conversations?limit=10", nil)
+	conversationReq.Header.Set("x-tenant-id", "tenant_demo")
+	conversationRec := httptest.NewRecorder()
+	handler.ListBusinessProvenanceConversations(conversationRec, conversationReq)
+	if conversationRec.Code != http.StatusOK || !strings.Contains(conversationRec.Body.String(), `"conversation_id":"conversation_handler"`) ||
+		!strings.Contains(conversationRec.Body.String(), `"interaction_count":1`) || !strings.Contains(conversationRec.Body.String(), `"request_count":1`) {
+		t.Fatalf("expected conversation projection, got %d: %s", conversationRec.Code, conversationRec.Body.String())
+	}
+
+	interactionReq := authenticatedQueryRequest(http.MethodGet, "/api/agent-observability/v1/business-provenance/interactions?conversation_id=conversation_handler&limit=10", nil)
+	interactionReq.Header.Set("x-tenant-id", "tenant_demo")
+	interactionRec := httptest.NewRecorder()
+	handler.ListBusinessProvenanceInteractions(interactionRec, interactionReq)
+	if interactionRec.Code != http.StatusOK || !strings.Contains(interactionRec.Body.String(), `"interaction_id":"interaction_handler"`) ||
+		!strings.Contains(interactionRec.Body.String(), `"request_count":1`) {
+		t.Fatalf("expected interaction projection, got %d: %s", interactionRec.Code, interactionRec.Body.String())
+	}
+}
+
 func TestEvidenceHandlerListsRequestTracesAndTechnicalExecutions(t *testing.T) {
 	handler := newDevEvidenceHandler(evidencesvc.New(evidencestore.New()))
 	ingestReq := httptest.NewRequest(http.MethodPost, "/api/agent-observability/v1/evidence/events", strings.NewReader(validHandlerBatch()))
@@ -1098,6 +1132,7 @@ func validHandlerArtifactEventBatch() string {
 	    "trace_id": "4bf92f3577b34da6a3ce929d0e0e4736",
 	    "traceparent": "00-4bf92f3577b34da6a3ce929d0e0e4736-2f12000000000003-01",
 	    "bkn.request.id": "req_artifact_handler",
+	    "bkn.conversation.id": "conversation_handler",
 	    "bkn.tenant.id": "tenant_demo",
 	    "business_domain": "bd_demo",
 	    "bkn.account.id": "acct_demo",

--- a/bkn-trace/agent-observability/src/driveradapter/api/httphandler/summary_handler.go
+++ b/bkn-trace/agent-observability/src/driveradapter/api/httphandler/summary_handler.go
@@ -13,6 +13,83 @@ import (
 	"github.com/openbkn-ai/bkn-foundry/bkn-trace/agent-observability/src/driveradapter/api/rdto"
 )
 
+// ListBusinessProvenanceConversations godoc
+// @Summary List observable business conversations
+// @Description Returns one authorized business-provenance row per conversation, aggregated from real interactions and requests.
+// @Tags business-provenance
+// @Produce json
+// @Param limit query int false "Page size, 1..200"
+// @Param cursor query string false "Opaque pagination cursor"
+// @Param from query string false "Started at or after this RFC3339 timestamp"
+// @Param to query string false "Started at or before this RFC3339 timestamp"
+// @Param status query string false "Execution status"
+// @Param agent_or_app query string false "Agent or application"
+// @Param business_domain query string false "Business domain"
+// @Param knowledge_network query string false "Knowledge network"
+// @Param evidence_completeness query string false "Evidence completeness"
+// @Param keyword query string false "Question, result, ID, business ref, or error keyword"
+// @Success 200 {object} evidencevo.ConversationSummaryPage
+// @Failure 400 {object} rdto.ErrorResponse
+// @Failure 401 {object} rdto.ErrorResponse
+// @Failure 500 {object} rdto.ErrorResponse
+// @Router /business-provenance/conversations [get]
+func (h *EvidenceHandler) ListBusinessProvenanceConversations(w http.ResponseWriter, r *http.Request) {
+	ensureResponseTraceID(w, r)
+	if r.Method != http.MethodGet {
+		writeJSON(w, http.StatusMethodNotAllowed, rdto.ErrorResponse{Code: "METHOD_NOT_ALLOWED", Message: "only GET is supported"})
+		return
+	}
+	options, ok := h.summaryQueryOptionsFromRequest(w, r)
+	if !ok {
+		return
+	}
+	page, err := h.evidenceService.ListConversations(r.Context(), options)
+	if err != nil {
+		writeSummaryQueryError(w, err)
+		return
+	}
+	writeJSON(w, http.StatusOK, page)
+}
+
+// ListBusinessProvenanceInteractions godoc
+// @Summary List observable business interactions
+// @Description Returns one authorized business-provenance row per interaction, aggregated from real requests.
+// @Tags business-provenance
+// @Produce json
+// @Param limit query int false "Page size, 1..200"
+// @Param cursor query string false "Opaque pagination cursor"
+// @Param conversation_id query string false "Conversation ID"
+// @Param from query string false "Started at or after this RFC3339 timestamp"
+// @Param to query string false "Started at or before this RFC3339 timestamp"
+// @Param status query string false "Execution status"
+// @Param agent_or_app query string false "Agent or application"
+// @Param business_domain query string false "Business domain"
+// @Param knowledge_network query string false "Knowledge network"
+// @Param evidence_completeness query string false "Evidence completeness"
+// @Param keyword query string false "Question, result, ID, business ref, or error keyword"
+// @Success 200 {object} evidencevo.InteractionSummaryPage
+// @Failure 400 {object} rdto.ErrorResponse
+// @Failure 401 {object} rdto.ErrorResponse
+// @Failure 500 {object} rdto.ErrorResponse
+// @Router /business-provenance/interactions [get]
+func (h *EvidenceHandler) ListBusinessProvenanceInteractions(w http.ResponseWriter, r *http.Request) {
+	ensureResponseTraceID(w, r)
+	if r.Method != http.MethodGet {
+		writeJSON(w, http.StatusMethodNotAllowed, rdto.ErrorResponse{Code: "METHOD_NOT_ALLOWED", Message: "only GET is supported"})
+		return
+	}
+	options, ok := h.summaryQueryOptionsFromRequest(w, r)
+	if !ok {
+		return
+	}
+	page, err := h.evidenceService.ListInteractions(r.Context(), options)
+	if err != nil {
+		writeSummaryQueryError(w, err)
+		return
+	}
+	writeJSON(w, http.StatusOK, page)
+}
+
 // ListRequests godoc
 // @Summary List observable business requests
 // @Description Returns stable request summaries generated from authorized evidence and artifacts.

--- a/docs/api/agent-observability/agent-observability.yaml
+++ b/docs/api/agent-observability/agent-observability.yaml
@@ -282,6 +282,66 @@ definitions:
       visibility_summary:
         $ref: '#/definitions/evidencevo.VisibilitySummary'
     type: object
+  evidencevo.ConversationSummary:
+    properties:
+      agent_or_app:
+        type: string
+      business_domain:
+        type: string
+      completed_at:
+        type: string
+      conversation_id:
+        type: string
+      duration_ms:
+        type: integer
+      error_summary:
+        type: string
+      evidence_completeness:
+        type: string
+      initiator:
+        type: string
+      interaction_count:
+        type: integer
+      knowledge_networks:
+        items:
+          type: string
+        type: array
+      partial_reasons:
+        items:
+          type: string
+        type: array
+      question_preview:
+        type: string
+      request_count:
+        type: integer
+      result_preview:
+        type: string
+      started_at:
+        type: string
+      status:
+        type: string
+      trace_count:
+        type: integer
+    type: object
+  evidencevo.ConversationSummaryPage:
+    properties:
+      entries:
+        items:
+          $ref: '#/definitions/evidencevo.ConversationSummary'
+        type: array
+      next_cursor:
+        type: string
+      partial:
+        type: boolean
+      partial_reasons:
+        items:
+          type: string
+        type: array
+      total:
+        type: integer
+      truncated:
+        type: boolean
+    type: object
   evidencevo.EvidenceArtifact:
     properties:
       agent_or_app:
@@ -429,6 +489,47 @@ definitions:
       trace_id:
         type: string
     type: object
+  evidencevo.InteractionListSummary:
+    properties:
+      agent_or_app:
+        type: string
+      business_domain:
+        type: string
+      completed_at:
+        type: string
+      conversation_id:
+        type: string
+      duration_ms:
+        type: integer
+      error_summary:
+        type: string
+      evidence_completeness:
+        type: string
+      initiator:
+        type: string
+      interaction_id:
+        type: string
+      knowledge_networks:
+        items:
+          type: string
+        type: array
+      partial_reasons:
+        items:
+          type: string
+        type: array
+      question_preview:
+        type: string
+      request_count:
+        type: integer
+      result_preview:
+        type: string
+      started_at:
+        type: string
+      status:
+        type: string
+      trace_count:
+        type: integer
+    type: object
   evidencevo.InteractionSummary:
     properties:
       completed_at:
@@ -451,6 +552,25 @@ definitions:
         items:
           $ref: '#/definitions/evidencevo.TraceSummary'
         type: array
+    type: object
+  evidencevo.InteractionSummaryPage:
+    properties:
+      entries:
+        items:
+          $ref: '#/definitions/evidencevo.InteractionListSummary'
+        type: array
+      next_cursor:
+        type: string
+      partial:
+        type: boolean
+      partial_reasons:
+        items:
+          type: string
+        type: array
+      total:
+        type: integer
+      truncated:
+        type: boolean
     type: object
   evidencevo.RequestSummary:
     properties:
@@ -1696,6 +1816,144 @@ paths:
       summary: Get the current BKN Trace access profile
       tags:
       - access
+  /business-provenance/conversations:
+    get:
+      description: Returns one authorized business-provenance row per conversation,
+        aggregated from real interactions and requests.
+      parameters:
+      - description: Page size, 1..200
+        in: query
+        name: limit
+        type: integer
+      - description: Opaque pagination cursor
+        in: query
+        name: cursor
+        type: string
+      - description: Started at or after this RFC3339 timestamp
+        in: query
+        name: from
+        type: string
+      - description: Started at or before this RFC3339 timestamp
+        in: query
+        name: to
+        type: string
+      - description: Execution status
+        in: query
+        name: status
+        type: string
+      - description: Agent or application
+        in: query
+        name: agent_or_app
+        type: string
+      - description: Business domain
+        in: query
+        name: business_domain
+        type: string
+      - description: Knowledge network
+        in: query
+        name: knowledge_network
+        type: string
+      - description: Evidence completeness
+        in: query
+        name: evidence_completeness
+        type: string
+      - description: Question, result, ID, business ref, or error keyword
+        in: query
+        name: keyword
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/evidencevo.ConversationSummaryPage'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/rdto.ErrorResponse'
+        "401":
+          description: Unauthorized
+          schema:
+            $ref: '#/definitions/rdto.ErrorResponse'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/rdto.ErrorResponse'
+      summary: List observable business conversations
+      tags:
+      - business-provenance
+  /business-provenance/interactions:
+    get:
+      description: Returns one authorized business-provenance row per interaction,
+        aggregated from real requests.
+      parameters:
+      - description: Page size, 1..200
+        in: query
+        name: limit
+        type: integer
+      - description: Opaque pagination cursor
+        in: query
+        name: cursor
+        type: string
+      - description: Conversation ID
+        in: query
+        name: conversation_id
+        type: string
+      - description: Started at or after this RFC3339 timestamp
+        in: query
+        name: from
+        type: string
+      - description: Started at or before this RFC3339 timestamp
+        in: query
+        name: to
+        type: string
+      - description: Execution status
+        in: query
+        name: status
+        type: string
+      - description: Agent or application
+        in: query
+        name: agent_or_app
+        type: string
+      - description: Business domain
+        in: query
+        name: business_domain
+        type: string
+      - description: Knowledge network
+        in: query
+        name: knowledge_network
+        type: string
+      - description: Evidence completeness
+        in: query
+        name: evidence_completeness
+        type: string
+      - description: Question, result, ID, business ref, or error keyword
+        in: query
+        name: keyword
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/evidencevo.InteractionSummaryPage'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/rdto.ErrorResponse'
+        "401":
+          description: Unauthorized
+          schema:
+            $ref: '#/definitions/rdto.ErrorResponse'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/rdto.ErrorResponse'
+      summary: List observable business interactions
+      tags:
+      - business-provenance
   /conversations:
     get:
       parameters:


### PR DESCRIPTION
## 目标

补齐 #540 在业务溯源查询侧缺失的真实三级投影，使 Studio 不再以 Request 数量模拟会话和交互轮次。

## 变更

- 新增受权 `ConversationSummary` 与 `InteractionListSummary` 投影
- 新增 `/business-provenance/conversations` 与 `/business-provenance/interactions` 查询接口
- 在分组、计数和预览前应用既有 QueryScope / Access Profile，避免越权侧信道
- 使用稳定游标分页，并同步正式 OpenAPI 与生成 Swagger
- 增加 1 Conversation / 2 Interactions / 3 Requests 真实基数、越权隔离和分页合同测试

## 验证

- `GOCACHE=/tmp/openbkn-go-cache go test ./... -count=1`
- `make gen-swag`
- Swagger/OpenAPI 路径合同校验
- `git diff --check`

Closes #540

关联 Studio：openbkn-ai/bkn-studio#173
设计基线：openbkn-ai/bkn-docs#28