### PR TITLE
ci(agent-retrieval): 发布产物构建配置断言

### DIFF
--- a/.github/workflows/release-adp-agent-retrieval.yml
+++ b/.github/workflows/release-adp-agent-retrieval.yml
@@ -28,6 +28,51 @@ jobs:
       service-path: adp/context-loader/agent-retrieval
       stack: chart-only
 
+  # 发布产物的构建配置断言。这类偏差不出现在任何 .go 的 diff 里，源码评审覆盖
+  # 不到，所以判据落在产物上。背景与判据依据见内部文档。
+  no-dev-gate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: docker/setup-buildx-action@v3
+
+      # 只造 runner 原生架构这一份：跨架构产物在这条性质上没有差别，qemu 不值。
+      - name: Build the release image (native arch only)
+        uses: docker/build-push-action@v6
+        with:
+          context: adp/context-loader/agent-retrieval
+          file: adp/context-loader/agent-retrieval/docker/Dockerfile
+          platforms: linux/amd64
+          load: true
+          push: false
+          provenance: false
+          sbom: false
+          tags: agent-retrieval:no-dev-gate-check
+          cache-from: type=gha,scope=agent-retrieval-no-dev-gate
+          cache-to: type=gha,mode=max,scope=agent-retrieval-no-dev-gate
+
+      - name: Assert the release build configuration
+        run: |
+          cid=$(docker create agent-retrieval:no-dev-gate-check)
+          docker cp "$cid:/app/agent-retrieval/agent-retrieval" ./agent-retrieval.bin
+          docker rm "$cid" >/dev/null
+
+          # 先自检手法有效：抠错路径或 grep 静默失败会让检查永远"通过"。哨兵取
+          # 两种构型下都在的字符串。
+          if ! grep -aqF 'entitlement: SetGate after Freeze' ./agent-retrieval.bin; then
+            echo "::error::检查手法失效：预期必然存在的符号未命中，产物或判据已不成立。"
+            exit 1
+          fi
+
+          if grep -aqF 'OPENBKN_EDITION' ./agent-retrieval.bin; then
+            echo "::error::发布产物的构建配置不符合预期，检查 Dockerfile 与构建参数。"
+            echo "::error::判据依据见内部文档；不要通过放宽本断言来绕过。"
+            exit 1
+          fi
+
+          echo "OK"
+
   build:
     needs: test
     uses: ./.github/workflows/reusable-build.yml

--- a/.github/workflows/release-adp-agent-retrieval.yml
+++ b/.github/workflows/release-adp-agent-retrieval.yml
@@ -54,17 +54,33 @@ jobs:
 
       - name: Assert the release build configuration
         run: |
+          # 路径来自 docker/Dockerfile 的 WORKDIR 与 COPY。那边改了目录结构这里
+          # 会 docker cp 非零退出（报的是 docker 原话，不是下面的 ::error::）。
           cid=$(docker create agent-retrieval:no-dev-gate-check)
           docker cp "$cid:/app/agent-retrieval/agent-retrieval" ./agent-retrieval.bin
           docker rm "$cid" >/dev/null
 
-          # 先自检手法有效：抠错路径或 grep 静默失败会让检查永远"通过"。哨兵取
-          # 两种构型下都在的字符串。
+          # 三条断言，防的是三件不同的事。
+
+          # 一、手法自检。抠错路径、grep 退出码 2（文件不可读）都会让下面的否定
+          # 断言静默放过。哨兵取两种构型下都在的字符串，所以它只证明「抠到了正确
+          # 的二进制、grep 真的跑了」。放在最前面是有意的。
           if ! grep -aqF 'entitlement: SetGate after Freeze' ./agent-retrieval.bin; then
             echo "::error::检查手法失效：预期必然存在的符号未命中，产物或判据已不成立。"
             exit 1
           fi
 
+          # 二、正向断言。否定断言锁的是「某个符号不在」，而那条判据是外挂约定：
+          # 符号改名、实现换成不读环境变量的形式，否定断言都会一路绿灯。这条改为
+          # 直接要求发布构型独有的符号必须在，判据便不再依赖那个约定。
+          if ! grep -aqF 'entitlement: licence hub is half-configured' ./agent-retrieval.bin; then
+            echo "::error::发布产物里没有发布构型独有的符号，构建配置不符合预期。"
+            echo "::error::检查 Dockerfile 与构建参数；判据依据见内部文档。"
+            exit 1
+          fi
+
+          # 三、否定断言。与上一条互补：正向那条防「该有的没有」，这条防「不该有
+          # 的混进来」。两条同时成立才算构型正确。
           if grep -aqF 'OPENBKN_EDITION' ./agent-retrieval.bin; then
             echo "::error::发布产物的构建配置不符合预期，检查 Dockerfile 与构建参数。"
             echo "::error::判据依据见内部文档；不要通过放宽本断言来绕过。"
@@ -74,7 +90,10 @@ jobs:
           echo "OK"
 
   build:
-    needs: test
+    # no-dev-gate 必须是前置而不是并发：Actions 不会因为一个 job 红就取消并发中
+    # 的其它 job，所以并发意味着推 tag 时镜像已经进了 GHCR 与 SWR，断言才变红。
+    # 那是事后告警，不是闸门。代价是发布路径多串行一次带缓存的编译。
+    needs: [test, no-dev-gate]
     uses: ./.github/workflows/reusable-build.yml
     secrets: inherit
     with:

--- a/comm-go/entitlement/gate_dev.go
+++ b/comm-go/entitlement/gate_dev.go
@@ -22,12 +22,16 @@ import (
 // stub that shipped and merely logged a warning would be a licence bypass with
 // a polite note attached.
 //
-// Each service's release job should assert that its artefact contains no
-// OPENBKN_EDITION string (`! strings <bin> | grep -q OPENBKN_EDITION`). That
-// assertion does not exist yet — it belongs on the pipelines that produce
-// binaries, and this module produces none. Stated as a to-do rather than as
-// fact on purpose: a comment claiming a defence that is not there is worse than
-// no comment, because the next person relaxes on the strength of it.
+// Each service's release job asserts its artefact's build configuration on the
+// artefact itself, because the mistake this guards against lives in build tags
+// and Dockerfiles rather than in any .go file. agent-retrieval's release
+// workflow has the reference implementation; copy it when a service starts
+// linking this package. The assertion belongs on the pipelines that produce
+// binaries — this module produces none, so it cannot carry its own.
+//
+// The wording here tracks reality on purpose, in both directions: a comment
+// claiming a defence that is not there lets the next person relax on the
+// strength of it, and one denying a defence that is there gets it built twice.
 //
 // The environment is re-read on every call rather than resolved once, so the
 // stub has the same shape as the shipped gate: a licence that changes under a


### PR DESCRIPTION
## 为什么

`comm-go/entitlement` 的档位判定有两份实现，由 build tag 二选一编入。发布产物必须是发布版那份。编成另一份时功能一切正常，只是判定依据不对 —— 没有任何可见症状。

这类偏差**不出现在任何 `.go` 的 diff 里**，落在 build tag、Makefile 或 Dockerfile 层，源码评审覆盖不到。所以判据必须落在产物上。

`gate_dev.go` 的注释里本来就写着这条断言应该存在，一直没有。

## 怎么做的

`release-adp-agent-retrieval.yml` 加独立 job `no-dev-gate`：

- 只造 runner 原生架构一份。跨架构产物在这条性质上没有差别，qemu 不值。带 GHA 缓存。
- 从容器 `docker cp` 出二进制，检查符号。
- **带自检**：先确认手法在这个产物上真的能命中，否则一个抠错路径、或 grep 静默失败的检查会永远"通过"。

自检哨兵的选取踩了一个坑：第一版选的符号只存在于其中一种构型，恰好在需要报警的那一侧缺席 —— 自检会先于真正的断言炸掉，把错因指错方向。改用两种构型下都在的字符串。

## 实测

三份产物本地跑同一套判据：

| 产物 | 自检 | 结果 |
|---|---|---|
| 社区（origin/main） | 命中 | PASS |
| 企业发布版 | 命中 | PASS |
| 非发布构型 | 命中 | **FAIL** |

## 范围

只覆盖 agent-retrieval —— 目前只有它链接 `comm-go/entitlement`。后续服务接入时把这个 job 抄过去，或提取到 `reusable-build.yml` 做成可选输入。ee 仓的企业镜像另需一份对称断言。

判据的背景和依据在内部文档，不在本仓展开。