### PR TITLE
fix(bkn-safe): 升 licverify v0.5.0，清掉已退休的申请码

### DIFF
--- a/bkn-safe/server/go.mod
+++ b/bkn-safe/server/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/glebarez/sqlite v1.7.0
 	github.com/go-ldap/ldap/v3 v3.4.13
 	github.com/openbkn-ai/bkn-comm-go v0.0.4
-	github.com/openbkn-ai/licverify v0.2.0
+	github.com/openbkn-ai/licverify v0.5.0
 	github.com/ory/hydra-client-go/v2 v2.2.0
 	golang.org/x/crypto v0.53.0
 	golang.org/x/sync v0.21.0

--- a/bkn-safe/server/go.sum
+++ b/bkn-safe/server/go.sum
@@ -167,6 +167,8 @@ github.com/openbkn-ai/bkn-comm-go v0.0.4 h1:oYmrMuayyTrDn3fZ+La7PXTuJV4wjHcKr5HT
 github.com/openbkn-ai/bkn-comm-go v0.0.4/go.mod h1:pyx5ux3IT4zZrUoqni6DVzLaFe1fY8dwAl6wL8PAf7I=
 github.com/openbkn-ai/licverify v0.2.0 h1:pUFRK5kpbVyeH3dMaqVlh19cCAHVq65NOy9Jrl/5e+Y=
 github.com/openbkn-ai/licverify v0.2.0/go.mod h1:9Cnmt/tl7JN48+EjsGCjQERs1mNjuaBHdM+oVx0gvS4=
+github.com/openbkn-ai/licverify v0.5.0 h1:79aXlMYBDIzSLBXLhbrM3xOIDmMxhgCxG7PtZbPMNnE=
+github.com/openbkn-ai/licverify v0.5.0/go.mod h1:9Cnmt/tl7JN48+EjsGCjQERs1mNjuaBHdM+oVx0gvS4=
 github.com/ory/hydra-client-go/v2 v2.2.0 h1:g8hw0YQD5Us1aAgZj7OyBmBGSDwlnY9/2Pb/pQQq8YE=
 github.com/ory/hydra-client-go/v2 v2.2.0/go.mod h1:h0DSI2kQA3S2fN7HyD8DNWcvbgDmYRSxfhwu/mSBhH8=
 github.com/pelletier/go-toml/v2 v2.2.4 h1:mye9XuhQ6gvn5h28+VilKrrPoQVanw5PMw/TB0t5Ec4=

--- a/bkn-safe/server/internal/httpapi/capabilities.go
+++ b/bkn-safe/server/internal/httpapi/capabilities.go
@@ -54,7 +54,7 @@ func registerCapabilities(g *gin.RouterGroup, svc *license.Service) {
 
 		if svc != nil {
 			if snap := svc.State(); snap.Payload != nil {
-				resp.Edition = snap.Payload.Edition
+				resp.Edition = string(snap.Payload.Edition)
 				if snap.Payload.Features != nil {
 					resp.Features = snap.Payload.Features
 				}

--- a/bkn-safe/server/internal/httpapi/license.go
+++ b/bkn-safe/server/internal/httpapi/license.go
@@ -69,12 +69,20 @@ func registerLicenseAdmin(g *gin.RouterGroup, svc *license.Service, e *authz.Enf
 		c.JSON(http.StatusOK, gin.H{"instance_fp": svc.Fingerprint()})
 	})
 
-	// GET /license/activation-code — the offline activation request code the
-	// customer pastes into the license portal (shown next to the fingerprint,
-	// both copyable).
+	// GET /license/activation-code — what the customer submits to the license
+	// portal for offline activation.
+	//
+	// The activation_code field is gone. It used to carry base64({lic_id,
+	// instance_fp}), and the issuer stopped accepting it in 2026-07: the portal
+	// now validates ^fp_[0-9a-f]{16}$ and answers 400 to anything else. Keeping
+	// the field would not have been compatibility, it would have been shipping a
+	// value whose only remaining use is to make an admin's paste fail. Studio
+	// dropped its copy button the same week, and no other client ever read it.
+	//
+	// The route keeps its name so existing links and scripts do not 404.
 	g.GET("/license/activation-code", RequirePermission(e, "admin-license", "view"), func(c *gin.Context) {
-		fp, code, licID := svc.ActivationCode()
-		c.JSON(http.StatusOK, gin.H{"instance_fp": fp, "activation_code": code, "lic_id": licID})
+		fp, licID := svc.ActivationRequest()
+		c.JSON(http.StatusOK, gin.H{"instance_fp": fp, "lic_id": licID})
 	})
 
 	// DELETE /license — drop the installed license (back to unactivated).
@@ -172,7 +180,7 @@ func registerLicenseInternal(r *gin.Engine, svc *license.Service, keysStore *aut
 			if snap.Payload.Limits != nil {
 				resp["limits"] = snap.Payload.Limits
 			}
-			resp["edition"] = snap.Payload.Edition
+			resp["edition"] = string(snap.Payload.Edition)
 		}
 		c.JSON(http.StatusOK, resp)
 	})
@@ -213,7 +221,7 @@ func licenseStatus(svc *license.Service) gin.H {
 		h["renew_error"] = snap.RenewErr.Error()
 	}
 	if p := snap.Payload; p != nil {
-		h["edition"] = p.Edition
+		h["edition"] = string(p.Edition)
 		h["expires_at"] = p.ExpiresAt
 		h["contract_expires_at"] = p.ContractExpiresAt
 		if snap.State == licverify.StateGrace && p.ExpiresAt != 0 {

--- a/bkn-safe/server/internal/httpapi/license.go
+++ b/bkn-safe/server/internal/httpapi/license.go
@@ -169,7 +169,7 @@ func registerLicenseInternal(r *gin.Engine, svc *license.Service, keysStore *aut
 	g.GET("/capabilities", func(c *gin.Context) {
 		snap := svc.State()
 		resp := gin.H{
-			"state":    snap.State,
+			"state":    string(snap.State),
 			"features": []string{},
 			"limits":   map[string]int64{},
 		}
@@ -211,7 +211,7 @@ func RequireAppKey(keysStore *auth.APIKeyStore) gin.HandlerFunc {
 func licenseStatus(svc *license.Service) gin.H {
 	snap := svc.State()
 	h := gin.H{
-		"state":     snap.State,
+		"state":     string(snap.State),
 		"activated": svc.Activated(),
 	}
 	if snap.Err != nil {
@@ -237,8 +237,8 @@ func licenseStatus(svc *license.Service) gin.H {
 }
 
 // licenseDetail is the admin view: status plus identity/customer/features and
-// the instance fingerprint (the activation guide needs fingerprint + code
-// visible side by side).
+// the instance fingerprint (the activation guide shows the fingerprint — it is
+// what the portal asks for).
 func licenseDetail(svc *license.Service) gin.H {
 	h := licenseStatus(svc)
 	h["instance_fp"] = svc.Fingerprint()

--- a/bkn-safe/server/internal/httpapi/license_test.go
+++ b/bkn-safe/server/internal/httpapi/license_test.go
@@ -114,19 +114,28 @@ func TestLicenseFingerprintWithoutLicense(t *testing.T) {
 	}
 }
 
-func TestLicenseActivationCodeWithoutLicense(t *testing.T) {
+func TestLicenseActivationRequestWithoutLicense(t *testing.T) {
 	r, _, _ := newLicenseServer(t)
 	w := adminReq(t, r, http.MethodGet, licAdminBase+"/activation-code", nil)
 	if w.Code != http.StatusOK {
 		t.Fatalf("activation-code = %d", w.Code)
 	}
-	var resp struct {
-		InstanceFP     string `json:"instance_fp"`
-		ActivationCode string `json:"activation_code"`
-	}
+	var resp map[string]any
 	_ = json.Unmarshal(w.Body.Bytes(), &resp)
-	if resp.InstanceFP == "" || resp.ActivationCode == "" {
-		t.Fatalf("both fingerprint and code must be present: %s", w.Body.String())
+
+	fp, _ := resp["instance_fp"].(string)
+	if fp == "" {
+		t.Fatalf("the fingerprint is what the portal wants; it must be present: %s", w.Body.String())
+	}
+	if _, ok := resp["lic_id"]; !ok {
+		t.Fatalf("lic_id must be present (empty with no license): %s", w.Body.String())
+	}
+
+	// The retired field must stay gone. The issuer validates ^fp_[0-9a-f]{16}$
+	// and answers 400 to the old base64 blob, so re-adding it would hand an
+	// admin a value that only fails.
+	if _, ok := resp["activation_code"]; ok {
+		t.Fatalf("activation_code came back; the portal no longer accepts it: %s", w.Body.String())
 	}
 }
 
@@ -170,7 +179,10 @@ func TestLicenseImportDetailAndRemove(t *testing.T) {
 	}
 	w = adminReq(t, r, http.MethodGet, licAdminBase, nil)
 	_ = json.Unmarshal(w.Body.Bytes(), &detail)
-	if detail.State != string(licverify.StateInvalid) {
+	// See TestRemove: a freshly created deployment with no license reads
+	// "trial", not "invalid" — "invalid" now means a license that failed to
+	// verify, which is a different thing to tell an admin.
+	if detail.State != string(licverify.StateTrial) {
 		t.Fatalf("state after remove = %s", detail.State)
 	}
 }

--- a/bkn-safe/server/internal/license/service.go
+++ b/bkn-safe/server/internal/license/service.go
@@ -15,6 +15,7 @@ import (
 	"context"
 	"crypto/ed25519"
 	"crypto/sha256"
+	"database/sql"
 	"encoding/hex"
 	"errors"
 	"fmt"
@@ -68,6 +69,11 @@ type Service struct {
 	// guard snapshot and need no lock.
 	mu           sync.Mutex
 	lastRenewErr string
+
+	// firstRunAt is resolved once and never changes: the guard asks for it on
+	// every state evaluation, and that must not become a query per call.
+	firstRunOnce sync.Once
+	firstRunAt   int64
 }
 
 // New builds the service with the official compiled-in key table. The
@@ -110,6 +116,7 @@ func NewWithKeyTable(db *gorm.DB, cfg config.LicenseConfig, aud *audit.Store, ke
 		RenewURL:   renewURL,
 		InstanceFP: fp,
 		HTTPClient: hc,
+		FirstRun:   s.firstRun,
 		Logf: func(format string, args ...any) {
 			slog.Info("license: " + fmt.Sprintf(format, args...))
 		},
@@ -156,14 +163,21 @@ func (s *Service) Activated() bool {
 	return snap.Payload != nil && snap.Payload.HWFingerprint != ""
 }
 
-// ActivationCode returns the offline activation request code the customer
-// pastes into the license portal. With no license installed the lic_id half is
-// empty; the portal then binds whichever license the code is submitted against.
-func (s *Service) ActivationCode() (fp, code, licID string) {
+// ActivationRequest returns what the customer pastes into the license portal
+// for offline activation: this instance's fingerprint, plus the id of the
+// license already installed, if any. With no license the lic_id half is empty
+// and the portal binds whichever license the fingerprint is submitted against.
+//
+// It used to also return an "activation code" — a base64 of exactly these two
+// fields, and nothing else. licverify retired that helper (dd891e6, "offline
+// activation pastes the fingerprint") because the issuer only ever read
+// instance_fp back out of it, so the encoding bought nothing and cost the
+// customer a step that could go wrong in a copy-paste.
+func (s *Service) ActivationRequest() (fp, licID string) {
 	if snap := s.guard.State(); snap.Payload != nil {
 		licID = snap.Payload.LicID
 	}
-	return s.fp, licverify.ActivationCode(licID, s.fp), licID
+	return s.fp, licID
 }
 
 // Current returns the raw license text and its ETag for module distribution.
@@ -282,6 +296,37 @@ func (s *Service) Run(ctx context.Context) {
 }
 
 // loadText is the Guard's Load hook: the license text, "" when none installed.
+// firstRun is when this deployment first started, in unix seconds. licverify
+// uses it to tell a fresh install (trial: quiet, nothing to do yet) apart from
+// one whose trial window has elapsed (unlicensed: standing prompt to activate).
+// Neither state carries paid capability — FeatureEnabled only honours valid and
+// grace — so this only decides which of the two an admin screen shows.
+//
+// The timestamp is the oldest user row. bkn-safe seeds the built-in admin at
+// install and there is no path that deletes every user, so the minimum is the
+// moment this deployment came up, it survives restarts and replicas agree on
+// it. A dedicated install-metadata row would be more direct but would cost a
+// migration for a value that is already sitting in the database.
+//
+// Answering 0 (empty table, or a database that will not answer) reads as
+// "brand new", i.e. trial. That is the quiet state and it grants nothing, so
+// the failure mode is a missing activation prompt rather than a false one.
+func (s *Service) firstRun() int64 {
+	s.firstRunOnce.Do(func() {
+		var at sql.NullTime
+		if err := s.db.Model(&model.User{}).
+			Select("MIN(created_at)").Scan(&at).Error; err != nil {
+			slog.Warn("license: cannot resolve first-run time; treating this deployment as new",
+				"err", err)
+			return
+		}
+		if at.Valid {
+			s.firstRunAt = at.Time.Unix()
+		}
+	})
+	return s.firstRunAt
+}
+
 func (s *Service) loadText() (string, error) {
 	var row model.License
 	err := s.db.First(&row, "id = ?", rowID).Error

--- a/bkn-safe/server/internal/license/service.go
+++ b/bkn-safe/server/internal/license/service.go
@@ -15,7 +15,6 @@ import (
 	"context"
 	"crypto/ed25519"
 	"crypto/sha256"
-	"database/sql"
 	"encoding/hex"
 	"errors"
 	"fmt"
@@ -23,6 +22,7 @@ import (
 	"net/http"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/openbkn-ai/licverify"
@@ -70,10 +70,10 @@ type Service struct {
 	mu           sync.Mutex
 	lastRenewErr string
 
-	// firstRunAt is resolved once and never changes: the guard asks for it on
-	// every state evaluation, and that must not become a query per call.
-	firstRunOnce sync.Once
-	firstRunAt   int64
+	// firstRunAt caches the resolved first-run time: the guard asks for it on
+	// every state evaluation, and that must not become a query per call. Zero
+	// means "not resolved yet" — see firstRun for why a failure is not cached.
+	firstRunAt atomic.Int64
 }
 
 // New builds the service with the official compiled-in key table. The
@@ -295,7 +295,6 @@ func (s *Service) Run(ctx context.Context) {
 	}
 }
 
-// loadText is the Guard's Load hook: the license text, "" when none installed.
 // firstRun is when this deployment first started, in unix seconds. licverify
 // uses it to tell a fresh install (trial: quiet, nothing to do yet) apart from
 // one whose trial window has elapsed (unlicensed: standing prompt to activate).
@@ -308,25 +307,38 @@ func (s *Service) Run(ctx context.Context) {
 // it. A dedicated install-metadata row would be more direct but would cost a
 // migration for a value that is already sitting in the database.
 //
+// Read it as ORDER BY ... LIMIT 1 into the model, not as SELECT MIN(...) into a
+// sql.NullTime: scanning an expression column bypasses GORM's field decoding
+// and lands on the driver's raw value, which for SQLite is a string and fails
+// to scan into a time. That failure is silent — it degrades to 0, i.e. "brand
+// new" — so the whole distinction would quietly never happen. TestFirstRun is
+// what keeps this honest.
+//
 // Answering 0 (empty table, or a database that will not answer) reads as
 // "brand new", i.e. trial. That is the quiet state and it grants nothing, so
-// the failure mode is a missing activation prompt rather than a false one.
+// the failure mode is a missing activation prompt rather than a false one. A
+// failed read is not memoised: the value is cached only once it is real, so a
+// database that was briefly unreachable does not pin this replica to trial for
+// the rest of its life.
 func (s *Service) firstRun() int64 {
-	s.firstRunOnce.Do(func() {
-		var at sql.NullTime
-		if err := s.db.Model(&model.User{}).
-			Select("MIN(created_at)").Scan(&at).Error; err != nil {
-			slog.Warn("license: cannot resolve first-run time; treating this deployment as new",
-				"err", err)
-			return
-		}
-		if at.Valid {
-			s.firstRunAt = at.Time.Unix()
-		}
-	})
-	return s.firstRunAt
+	if at := s.firstRunAt.Load(); at != 0 {
+		return at
+	}
+	var first model.User
+	if err := s.db.Order("created_at ASC").Limit(1).Find(&first).Error; err != nil {
+		slog.Warn("license: cannot resolve first-run time; treating this deployment as new",
+			"err", err)
+		return 0
+	}
+	if first.CreatedAt.IsZero() {
+		return 0
+	}
+	at := first.CreatedAt.Unix()
+	s.firstRunAt.Store(at)
+	return at
 }
 
+// loadText is the Guard's Load hook: the license text, "" when none installed.
 func (s *Service) loadText() (string, error) {
 	var row model.License
 	err := s.db.First(&row, "id = ?", rowID).Error

--- a/bkn-safe/server/internal/license/service_test.go
+++ b/bkn-safe/server/internal/license/service_test.go
@@ -397,6 +397,59 @@ func TestRemove(t *testing.T) {
 	}
 }
 
+// TestFirstRun is the用例 that makes the trial/unlicensed distinction real.
+// Without it the whole thing degrades silently: an unresolved first-run time
+// reads as 0, which reads as "brand new", which is trial — the same answer a
+// correct implementation gives for a fresh install, so nothing looks wrong.
+// The first version of firstRun did exactly that on SQLite and every existing
+// test still passed.
+func TestFirstRun(t *testing.T) {
+	keyTable, _ := testKeys(t)
+
+	for name, tc := range map[string]struct {
+		age   time.Duration
+		state licverify.State
+	}{
+		"fresh install is inside the trial window": {age: 24 * time.Hour, state: licverify.StateTrial},
+		"trial elapsed": {age: licverify.TrialPeriod + 24*time.Hour, state: licverify.StateUnlicensed},
+	} {
+		t.Run(name, func(t *testing.T) {
+			db := testDB(t)
+			born := time.Now().Add(-tc.age)
+			if err := db.Create(&model.User{ID: "u-admin", Account: "admin", CreatedAt: born}).Error; err != nil {
+				t.Fatal(err)
+			}
+			svc := newTestService(t, db, config.LicenseConfig{}, keyTable)
+
+			if got := svc.firstRun(); got != born.Unix() {
+				t.Fatalf("firstRun = %d, want %d — the timestamp did not survive the round trip", got, born.Unix())
+			}
+			if got := svc.State().State; got != tc.state {
+				t.Fatalf("state = %s, want %s", got, tc.state)
+			}
+		})
+	}
+}
+
+// A database that will not answer must not pin this replica to trial forever.
+func TestFirstRunDoesNotCacheAFailure(t *testing.T) {
+	keyTable, _ := testKeys(t)
+	db := testDB(t)
+	svc := newTestService(t, db, config.LicenseConfig{}, keyTable)
+
+	if got := svc.firstRun(); got != 0 {
+		t.Fatalf("firstRun on an empty table = %d, want 0", got)
+	}
+
+	born := time.Now().Add(-licverify.TrialPeriod - 24*time.Hour)
+	if err := db.Create(&model.User{ID: "u-admin", Account: "admin", CreatedAt: born}).Error; err != nil {
+		t.Fatal(err)
+	}
+	if got := svc.firstRun(); got != born.Unix() {
+		t.Fatalf("firstRun = %d after the row appeared, want %d — an unresolved read was cached", got, born.Unix())
+	}
+}
+
 func TestActivationRequestWithoutLicense(t *testing.T) {
 	keyTable, _ := testKeys(t)
 	db := testDB(t)

--- a/bkn-safe/server/internal/license/service_test.go
+++ b/bkn-safe/server/internal/license/service_test.go
@@ -385,7 +385,11 @@ func TestRemove(t *testing.T) {
 	if err := svc.Remove(t.Context()); err != nil {
 		t.Fatal(err)
 	}
-	if snap := svc.State(); snap.State != licverify.StateInvalid {
+	// Not "invalid": licverify separates "no license" from "broken license".
+	// This test database is minutes old, so removing the license lands back in
+	// the trial window. Neither state carries paid capability — only valid and
+	// grace do — so what changes here is the label an admin screen shows.
+	if snap := svc.State(); snap.State != licverify.StateTrial {
 		t.Fatalf("state after remove = %s", snap.State)
 	}
 	if _, _, err := svc.Current(); !errors.Is(err, ErrNoLicense) {
@@ -393,28 +397,17 @@ func TestRemove(t *testing.T) {
 	}
 }
 
-func TestActivationCodeWithoutLicense(t *testing.T) {
+func TestActivationRequestWithoutLicense(t *testing.T) {
 	keyTable, _ := testKeys(t)
 	db := testDB(t)
 	svc := newTestService(t, db, config.LicenseConfig{}, keyTable)
 
-	fp, code, licID := svc.ActivationCode()
+	fp, licID := svc.ActivationRequest()
 	if fp != localFP() {
 		t.Fatalf("fp = %s", fp)
 	}
 	if licID != "" {
 		t.Fatalf("licID with no license = %q", licID)
-	}
-	raw, err := base64.RawURLEncoding.DecodeString(code)
-	if err != nil {
-		t.Fatal(err)
-	}
-	var decoded map[string]string
-	if err := json.Unmarshal(raw, &decoded); err != nil {
-		t.Fatal(err)
-	}
-	if decoded["instance_fp"] != localFP() {
-		t.Fatalf("code fp = %s", decoded["instance_fp"])
 	}
 }
 


### PR DESCRIPTION
## 为什么

bkn-safe 一直钉着 licverify **v0.2.0**，因为它还在调 v0.3.0 就删掉的 `licverify.ActivationCode`。单独编能过，所以一直没暴露。

但 openbkn-ee 是**一个 module 同时依赖 bkn-safe 和 comm-go**，而 comm-go 要 v0.5.0 才有 `Edition` 类型。MVS 统一到 v0.5.0，于是：

```
bkn-safe/server@.../internal/license/service.go:166:25: undefined: licverify.ActivationCode
```

ee 侧 `go build ./...` 直接挂。

## 申请码：删，不是复刻

我一开始打算本地复刻那三行 base64 保住字段，查证后发现方向反了：

- **签发侧 2026-07 起用 `^fp_[0-9a-f]{16}$` 硬校验**（license-server `api.go:910`），把旧的 `base64({lic_id, instance_fp})` 贴过去必然 400
- **Studio 同期已删**：`a4399e8`（2026-07-16，与 licverify 退役同日）移掉了 `activationCode` 字段、i18n 文案和复制按钮
- **bkn-sdk 注释写明**：`safe.ts:448` "activation request codes are retired — the raw fingerprint is what's pasted"
- **bkn-docs 接口表已移除该端点**，并注明「2026-07-15 起申请码机制退役」

留着它不是兼容，是发一个只会让管理员粘贴失败的值。路由名保留，避免既有链接和脚本 404。

## 升级带出的两处

**一、`Payload.Edition` 从 `string` 变成具名类型**，`capabilities.go:57` 赋值断裂。三个出口一律显式转 `string`，把线上格式钉在边界上 —— 不随 licverify 后续给该类型加 `MarshalJSON` 而变。

**二、无证状态的语义变了。** v0.2.0 把「没装证」和「证书坏了」都算 `invalid`；v0.5.0 拆成 `trial`（首次启动 30 天内）和 `unlicensed`（过了），`invalid` 只留给验签失败。

但 `GuardConfig.FirstRun` 不接就恒为 0，`TrialAt` 走 `firstRun <= 0` 分支 —— **永远停在 trial，进不到 unlicensed**。所以接上：取 `users` 表最早的 `created_at`。bkn-safe 装机时会建内置 admin，且没有删光所有用户的路径，这个最小值就是本部署起来的时刻，重启不变、多副本一致。专门加一张安装元信息表更直接，但为一个已经躺在库里的值付一次迁移不值。查不到就当作全新（trial）—— 那是安静的一档，且不给任何能力，失败方向是少提示一次激活而不是错报一次。

**三档都不带付费能力**（`FeatureEnabled` 只认 valid/grace），所以这次改的只是管理面显示哪个标签。

## 测试

`bkn-safe/server` 全量 10 包绿。两条断言按新语义更新（都带了原因注释）：删证后从 `invalid` 改为 `trial`。`TestLicenseActivationCodeWithoutLicense` 重写为 `TestLicenseActivationRequestWithoutLicense`，反向断言 `activation_code` **必须不存在** —— 防止有人日后"为了兼容"把它加回来。

## 已知外溢，需另开

BKN Studio 的 `LicenseState` 联合类型（`types/license.ts`）只有 `fallback_community | grace | invalid | valid`，i18n 词条同理，而 `LicenseManagementScene.tsx:131` 直接 `t(\`...status.${detail.state}\`)`。无证集群的状态徽标会渲染成**裸 i18n key**。另外 `LicenseManagementScene.tsx:331` 的删除按钮判据是 `state === "invalid"`，无证时会从禁用变成可点。

两处都在 bkn-studio 仓，需要同步改。合这个 PR 前请确认 Studio 侧的节奏。