### PR TITLE
feat(observability): 收口业务溯源 Operation 与统一日志采集

### DIFF
--- a/adp/context-loader/agent-retrieval/helm/agent-retrieval/templates/deployment.yaml
+++ b/adp/context-loader/agent-retrieval/helm/agent-retrieval/templates/deployment.yaml
@@ -81,6 +81,17 @@ spec:
             {{- end}}
               - name: BKN_TRACE_CORE_URL
                 value: {{ required "observability.lifecycle.core_url is required" .Values.observability.lifecycle.core_url | quote }}
+            {{- if .Values.observability.lifecycle.default_tenant_id }}
+              - name: BKN_TRACE_DEFAULT_TENANT_ID
+                value: {{ .Values.observability.lifecycle.default_tenant_id | quote }}
+            {{- end}}
+            {{- if .Values.observability.lifecycle.gateway_token_secret_name }}
+              - name: BKN_TRACE_QUERY_GATEWAY_TOKEN
+                valueFrom:
+                  secretKeyRef:
+                    name: {{ .Values.observability.lifecycle.gateway_token_secret_name | quote }}
+                    key: {{ .Values.observability.lifecycle.gateway_token_secret_key | quote }}
+            {{- end}}
             {{- if .Values.observability.evidence.ingest_url }}
               - name: BKN_TRACE_EVIDENCE_INGEST_URL
                 value: {{ .Values.observability.evidence.ingest_url | quote }}

--- a/adp/context-loader/agent-retrieval/helm/agent-retrieval/values.yaml
+++ b/adp/context-loader/agent-retrieval/helm/agent-retrieval/values.yaml
@@ -168,9 +168,9 @@ observability:
     # Mandatory 3.0 business-call dependency. Product deployments install
     # agent-observability before agent-retrieval; standalone releases override this URL.
     core_url: "http://agent-observability:8080"
-    # Trusted deployment scope for installations without tenant claims.
-    # Leave empty in multi-tenant deployments; their gateway supplies x-tenant-id.
-    default_tenant_id: ""
+    # 0.1.3 defaults to the same single-tenant scope as agent-observability.
+    # A trusted inbound x-tenant-id always takes precedence in multi-tenant deployments.
+    default_tenant_id: "openbkn-local"
     gateway_token_secret_name: ""
     gateway_token_secret_key: "token"
   evidence:

--- a/adp/context-loader/agent-retrieval/helm/agent-retrieval/values.yaml
+++ b/adp/context-loader/agent-retrieval/helm/agent-retrieval/values.yaml
@@ -168,6 +168,11 @@ observability:
     # Mandatory 3.0 business-call dependency. Product deployments install
     # agent-observability before agent-retrieval; standalone releases override this URL.
     core_url: "http://agent-observability:8080"
+    # Trusted deployment scope for installations without tenant claims.
+    # Leave empty in multi-tenant deployments; their gateway supplies x-tenant-id.
+    default_tenant_id: ""
+    gateway_token_secret_name: ""
+    gateway_token_secret_key: "token"
   evidence:
     ingest_url: ""
     timeout_ms: 2000

--- a/adp/context-loader/agent-retrieval/server/driveradapters/mcp/lifecycle_adapter.go
+++ b/adp/context-loader/agent-retrieval/server/driveradapters/mcp/lifecycle_adapter.go
@@ -170,6 +170,27 @@ func handleLifecycleTool(
 			target, apiErr, err := client.GetReceipt(ctx, stringValue(args["receipt_id"]))
 			return lifecycleCallResult(target, apiErr, err)
 		}
+		if name == "bkn_complete_interaction" {
+			interactionID := stringValue(args["interaction_id"])
+			var current bkntrace.Interaction
+			apiErr, err := client.Call(
+				ctx, http.MethodGet, "/interactions/"+url.PathEscape(interactionID), nil, &current,
+			)
+			if err != nil {
+				return lifecycleToolError(lifecycleAvailabilityError(err)), nil
+			}
+			if apiErr != nil {
+				return lifecycleToolError(lifecycleError(*apiErr)), nil
+			}
+			artifactRef, err := bkntrace.RecordInteractionArtifact(
+				ctx, current.ConversationID, current.InteractionID,
+				bkntrace.InteractionArtifactResult, args["answer"],
+			)
+			if err != nil {
+				return lifecycleToolError(lifecycleAvailabilityError(err)), nil
+			}
+			args["answer_artifact_ref"] = artifactRef
+		}
 		method, path, body := lifecycleRequest(name, args)
 		var target any
 		switch name {
@@ -184,6 +205,15 @@ func handleLifecycleTool(
 		}
 		if apiErr != nil {
 			return lifecycleToolError(lifecycleError(*apiErr)), nil
+		}
+		interaction, interactionTarget := target.(*bkntrace.Interaction)
+		if name == "bkn_start_interaction" && interactionTarget {
+			if _, err := bkntrace.RecordInteractionArtifact(
+				ctx, interaction.ConversationID, interaction.InteractionID,
+				bkntrace.InteractionArtifactQuestion, args["question"],
+			); err != nil {
+				return lifecycleToolError(lifecycleAvailabilityError(err)), nil
+			}
 		}
 		return mcpsdk.NewToolResultStructured(target, "managed lifecycle state updated"), nil
 	}
@@ -217,10 +247,10 @@ func lifecycleRequest(name string, args map[string]any) (string, string, map[str
 	default:
 		interactionID := url.PathEscape(stringValue(args["interaction_id"]))
 		action := strings.TrimPrefix(strings.TrimSuffix(name, "_interaction"), "bkn_")
-		return http.MethodPost, "/interactions/" + interactionID + "/" + action,
-			copyArgs(args, "terminal_idempotency_key", "lease_token", "lease_epoch",
-				"completion_manifest_version", "answer_artifact_ref", "claims",
-				"expected_operations", "expected_receipts", "assembler_deadline", "completion_reason")
+		body := copyArgs(args, "terminal_idempotency_key", "lease_token", "lease_epoch",
+			"completion_manifest_version", "answer_artifact_ref", "claims",
+			"expected_operations", "expected_receipts", "assembler_deadline", "completion_reason")
+		return http.MethodPost, "/interactions/" + interactionID + "/" + action, body
 	}
 }
 

--- a/adp/context-loader/agent-retrieval/server/driveradapters/mcp/lifecycle_schema_test.go
+++ b/adp/context-loader/agent-retrieval/server/driveradapters/mcp/lifecycle_schema_test.go
@@ -381,8 +381,8 @@ func TestHelmEnforcesInstalledLifecycleCoreByDefault(t *testing.T) {
 	if !strings.Contains(string(values), `gateway_token_secret_key: "token"`) {
 		t.Fatalf("Helm lifecycle values must define the trusted gateway token key: %s", values)
 	}
-	if !strings.Contains(string(values), `default_tenant_id: ""`) {
-		t.Fatalf("Helm lifecycle values must expose the single-tenant trust scope: %s", values)
+	if !strings.Contains(string(values), `default_tenant_id: "openbkn-local"`) {
+		t.Fatalf("Helm lifecycle values must align with the observability single-tenant scope: %s", values)
 	}
 	deploymentPath := filepath.Clean("../../../helm/agent-retrieval/templates/deployment.yaml")
 	deployment, err := os.ReadFile(deploymentPath)

--- a/adp/context-loader/agent-retrieval/server/driveradapters/mcp/lifecycle_schema_test.go
+++ b/adp/context-loader/agent-retrieval/server/driveradapters/mcp/lifecycle_schema_test.go
@@ -347,8 +347,8 @@ func TestLifecycleMCPInputRequiredFieldsMatchCorePathAndBody(t *testing.T) {
 	expected := map[string][]string{
 		"bkn_create_conversation":  {"external_conversation_key"},
 		"bkn_resume_conversation":  {"conversation_id"},
-		"bkn_start_interaction":    {"conversation_id", "idempotency_key"},
-		"bkn_complete_interaction": {"interaction_id", "terminal_idempotency_key", "lease_token", "lease_epoch", "completion_manifest_version", "completion_reason"},
+		"bkn_start_interaction":    {"conversation_id", "idempotency_key", "question"},
+		"bkn_complete_interaction": {"interaction_id", "terminal_idempotency_key", "lease_token", "lease_epoch", "completion_manifest_version", "completion_reason", "answer"},
 		"bkn_fail_interaction":     {"interaction_id", "terminal_idempotency_key", "lease_token", "lease_epoch", "completion_manifest_version", "completion_reason"},
 		"bkn_cancel_interaction":   {"interaction_id", "terminal_idempotency_key", "lease_token", "lease_epoch", "completion_manifest_version", "completion_reason"},
 		"bkn_handoff_interaction":  {"interaction_id", "terminal_idempotency_key", "lease_token", "lease_epoch", "completion_manifest_version", "completion_reason"},
@@ -378,6 +378,12 @@ func TestHelmEnforcesInstalledLifecycleCoreByDefault(t *testing.T) {
 	if !strings.Contains(string(values), `core_url: "http://agent-observability:8080"`) {
 		t.Fatalf("Helm lifecycle default must target the agent-observability service: %s", values)
 	}
+	if !strings.Contains(string(values), `gateway_token_secret_key: "token"`) {
+		t.Fatalf("Helm lifecycle values must define the trusted gateway token key: %s", values)
+	}
+	if !strings.Contains(string(values), `default_tenant_id: ""`) {
+		t.Fatalf("Helm lifecycle values must expose the single-tenant trust scope: %s", values)
+	}
 	deploymentPath := filepath.Clean("../../../helm/agent-retrieval/templates/deployment.yaml")
 	deployment, err := os.ReadFile(deploymentPath)
 	if err != nil {
@@ -389,6 +395,13 @@ func TestHelmEnforcesInstalledLifecycleCoreByDefault(t *testing.T) {
 	}
 	if strings.Contains(rendering, `if .Values.observability.lifecycle.core_url`) {
 		t.Fatal("lifecycle enforcement must not have a long-lived disable switch")
+	}
+	if !strings.Contains(rendering, `name: BKN_TRACE_QUERY_GATEWAY_TOKEN`) ||
+		!strings.Contains(rendering, `.Values.observability.lifecycle.gateway_token_secret_name`) {
+		t.Fatal("Helm must inject the lifecycle gateway token from a Secret")
+	}
+	if !strings.Contains(rendering, `name: BKN_TRACE_DEFAULT_TENANT_ID`) {
+		t.Fatal("Helm must support an explicit single-tenant trust scope")
 	}
 }
 

--- a/adp/context-loader/agent-retrieval/server/driveradapters/mcp/schemas.go
+++ b/adp/context-loader/agent-retrieval/server/driveradapters/mcp/schemas.go
@@ -90,6 +90,7 @@ func lifecycleToolSchemas(toolKey string) (json.RawMessage, json.RawMessage, boo
 	case "bkn_start_interaction":
 		addString("conversation_id", true)
 		addString("idempotency_key", true)
+		addString("question", true)
 		properties["lease_seconds"] = map[string]any{"type": "integer", "minimum": 1}
 	case "bkn_close_conversation":
 		addString("conversation_id", true)
@@ -106,6 +107,9 @@ func lifecycleToolSchemas(toolKey string) (json.RawMessage, json.RawMessage, boo
 		addString("completion_manifest_version", true)
 		addString("completion_reason", true)
 		addString("answer_artifact_ref", false)
+		if toolKey == "bkn_complete_interaction" {
+			addString("answer", true)
+		}
 		properties["claims"] = map[string]any{"type": "array", "items": map[string]any{"type": "string"}}
 		properties["expected_operations"] = expectedResourceSchema("operation_id")
 		properties["expected_receipts"] = expectedResourceSchema("receipt_id")

--- a/adp/context-loader/agent-retrieval/server/driveradapters/middleware.go
+++ b/adp/context-loader/agent-retrieval/server/driveradapters/middleware.go
@@ -14,6 +14,7 @@ import (
 	"errors"
 	"io"
 	"net/http"
+	"sort"
 	"strings"
 	"time"
 
@@ -141,12 +142,52 @@ func middlewareRequestLog(logger interfaces.Logger) gin.HandlerFunc {
 			URI:          c.Request.RequestURI,
 			Method:       c.Request.Method,
 			RemoteAddr:   c.Request.RemoteAddr,
-			RequestBody:  redactSensitiveFields(byteToInterface(req)),
+			RequestBody:  requestBodyForLog(c.Request.URL.Path, req),
 			ResponseCode: c.Writer.Status(),
 			Latency:      float64(time.Since(now).Nanoseconds()) / 1e6, //nolint:mnd
 		})
 		logger.WithContext(c.Request.Context()).Infof("HTTP API Log : %s", logPayload)
 	}
+}
+
+func requestBodyForLog(path string, body []byte) interface{} {
+	if strings.Contains(path, "/mcp/") || strings.HasSuffix(path, "/mcp") {
+		return mcpRequestBodyForLog(body)
+	}
+	return redactSensitiveFields(byteToInterface(body))
+}
+
+func mcpRequestBodyForLog(body []byte) map[string]interface{} {
+	summary := map[string]interface{}{
+		"content_length": len(body),
+		"redacted":       true,
+		"reason":         "MCP arguments are governed evidence, not general log content",
+	}
+	parsed, ok := byteToInterface(body).(map[string]interface{})
+	if !ok {
+		return summary
+	}
+	if method, ok := parsed["method"].(string); ok {
+		summary["jsonrpc_method"] = method
+	}
+	params, ok := parsed["params"].(map[string]interface{})
+	if !ok {
+		return summary
+	}
+	if toolName, ok := params["name"].(string); ok {
+		summary["tool_name"] = toolName
+	}
+	arguments, ok := params["arguments"].(map[string]interface{})
+	if !ok {
+		return summary
+	}
+	argumentKeys := make([]string, 0, len(arguments))
+	for key := range arguments {
+		argumentKeys = append(argumentKeys, key)
+	}
+	sort.Strings(argumentKeys)
+	summary["argument_keys"] = argumentKeys
+	return summary
 }
 
 func middlewareTrace(c *gin.Context) {

--- a/adp/context-loader/agent-retrieval/server/driveradapters/middleware_test.go
+++ b/adp/context-loader/agent-retrieval/server/driveradapters/middleware_test.go
@@ -5,9 +5,11 @@ import (
 	"context"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/gin-gonic/gin"
+	jsoniter "github.com/json-iterator/go"
 	"github.com/smartystreets/goconvey/convey"
 
 	"github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/infra/common"
@@ -317,4 +319,32 @@ func TestRedactSensitiveFields(t *testing.T) {
 			convey.So(out["limit"], convey.ShouldEqual, float64(10))
 		})
 	})
+}
+
+func TestMCPRequestBodyForLogOmitsGovernedBusinessContent(t *testing.T) {
+	body := []byte(`{
+		"jsonrpc":"2.0",
+		"method":"tools/call",
+		"params":{"name":"run_sql","arguments":{
+			"question":"6月份有哪些需求预测单？",
+			"sql":"SELECT * FROM secret_table",
+			"answer":"需求总量为11594"
+		}}
+	}`)
+
+	logged := requestBodyForLog("/api/agent-retrieval/v1/mcp/", body)
+	encoded, err := jsoniter.MarshalToString(logged)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, forbidden := range []string{"6月份", "SELECT *", "11594", "secret_table"} {
+		if strings.Contains(encoded, forbidden) {
+			t.Fatalf("MCP business content leaked into general log: %s", encoded)
+		}
+	}
+	for _, expected := range []string{"tools/call", "run_sql", "argument_keys", "question", "sql", "answer"} {
+		if !strings.Contains(encoded, expected) {
+			t.Fatalf("safe MCP structure missing %q: %s", expected, encoded)
+		}
+	}
 }

--- a/adp/context-loader/agent-retrieval/server/infra/bkntrace/evidence.go
+++ b/adp/context-loader/agent-retrieval/server/infra/bkntrace/evidence.go
@@ -109,6 +109,9 @@ func RecordInteractionArtifact(
 	artifactType InteractionArtifactType,
 	content any,
 ) (string, error) {
+	if !EvidenceEnabled() {
+		return "", nil
+	}
 	ec, ok := baseEventContext(ctx)
 	if !ok {
 		return "", errors.New("current request, trace and trusted account context are required")

--- a/adp/context-loader/agent-retrieval/server/infra/bkntrace/evidence.go
+++ b/adp/context-loader/agent-retrieval/server/infra/bkntrace/evidence.go
@@ -12,11 +12,13 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"log"
 	"net/http"
 	"os"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/infra/common"
@@ -40,6 +42,22 @@ const maxSubgraphEvidenceRefs = 100
 
 type Event map[string]any
 
+type InteractionArtifactType string
+
+const (
+	InteractionArtifactQuestion InteractionArtifactType = "question"
+	InteractionArtifactResult   InteractionArtifactType = "result"
+)
+
+type evidenceOutcomeContextKey struct{}
+
+type evidenceOutcome struct {
+	mu           sync.Mutex
+	durable      bool
+	eventIDs     []string
+	businessRefs []BusinessRef
+}
+
 var (
 	evidenceHTTPClient = &http.Client{}
 	evidenceInFlight   = make(chan struct{}, maxInFlightEvidenceBatches)
@@ -58,6 +76,8 @@ type eventContext struct {
 	requestID        string
 	accountID        string
 	accountType      string
+	applicationID    string
+	subjectType      string
 	tenantID         string
 	businessDomain   string
 	conversationID   string
@@ -80,6 +100,108 @@ func HashValue(value any) string {
 
 func EvidenceEnabled() bool {
 	return evidenceIngestURL() != ""
+}
+
+func RecordInteractionArtifact(
+	ctx context.Context,
+	conversationID string,
+	interactionID string,
+	artifactType InteractionArtifactType,
+	content any,
+) (string, error) {
+	ec, ok := baseEventContext(ctx)
+	if !ok {
+		return "", errors.New("current request, trace and trusted account context are required")
+	}
+	ec.conversationID = strings.TrimSpace(conversationID)
+	ec.interactionID = strings.TrimSpace(interactionID)
+	ec.operationID = ""
+	ec.attempt = 1
+	if ec.conversationID == "" || ec.interactionID == "" {
+		return "", errors.New("conversation_id and interaction_id are required")
+	}
+	eventType := ""
+	artifactField := ""
+	switch artifactType {
+	case InteractionArtifactQuestion:
+		eventType = "agent.interaction.started"
+		artifactField = "question_artifact_ref"
+	case InteractionArtifactResult:
+		eventType = "claim.created"
+		artifactField = "result_artifact_ref"
+	default:
+		return "", fmt.Errorf("unsupported interaction artifact type %q", artifactType)
+	}
+	contentHash := HashValue(content)
+	idHash := sha256.Sum256([]byte(ec.interactionID + "|" + string(artifactType) + "|" + contentHash))
+	artifactID := "art_" + string(artifactType) + "_" + hex.EncodeToString(idHash[:16])
+	artifactRef := "artifact:" + artifactID
+	traceBlock := traceBlockFromEventContext(ec)
+	artifact := map[string]any{
+		"artifact_id": artifactID, "artifact_type": string(artifactType),
+		"bkn.request.id": ec.requestID, "trace_id": ec.traceID,
+		"interaction_id": ec.interactionID, "content_type": "application/json",
+		"schema_version": "2.2.0", "observed_at": ec.observedAt,
+		"content_hash": contentHash, "content": content,
+		"bkn.tenant.id": ec.tenantID, "business_domain": ec.businessDomain,
+		"bkn.account.id": ec.accountID, "bkn.account.type": ec.accountType,
+		"effective_subject_id":     ec.accountID,
+		"application_principal_id": ec.applicationID,
+		"initiator":                "account:" + ec.accountID, "agent_or_app": ec.applicationID,
+	}
+	if err := postArtifactWithRetry(evidenceArtifactURL(), evidenceTimeout(), traceBlock, artifact); err != nil {
+		return "", err
+	}
+	event := buildEvent(
+		ec, eventType, "interaction."+string(artifactType),
+		map[string]any{artifactField: artifactRef, "content_hash": contentHash}, "", "",
+	)
+	event["event_id"] = stableEventID(ec.traceID, ec.interactionID, eventType, 1)
+	if err := postBatchWithRetry(evidenceIngestURL(), evidenceTimeout(), batch{
+		ContractVersion: ContractVersion, Trace: traceBlock, Events: []Event{event},
+	}); err != nil {
+		return "", err
+	}
+	return artifactRef, nil
+}
+
+func postArtifactWithRetry(
+	url string,
+	timeout time.Duration,
+	traceBlock map[string]any,
+	artifact map[string]any,
+) error {
+	if url == "" {
+		return errors.New("BKN Trace artifact URL is not configured")
+	}
+	body, err := json.Marshal(artifact)
+	if err != nil {
+		return err
+	}
+	for attempt := 0; attempt < 3; attempt++ {
+		postCtx, cancel := context.WithTimeout(context.Background(), timeout)
+		req, requestErr := http.NewRequestWithContext(postCtx, http.MethodPost, url, bytes.NewReader(body))
+		if requestErr != nil {
+			cancel()
+			return requestErr
+		}
+		setEvidenceIngestHeaders(req.Header, traceBlock)
+		resp, requestErr := evidenceHTTPClient.Do(req)
+		if requestErr == nil {
+			resp.Body.Close()
+			if resp.StatusCode < http.StatusBadRequest {
+				cancel()
+				return nil
+			}
+			requestErr = fmt.Errorf("HTTP %d", resp.StatusCode)
+		}
+		cancel()
+		err = requestErr
+		if attempt < 2 {
+			time.Sleep(time.Duration(attempt+1) * 20 * time.Millisecond)
+		}
+	}
+	return err
 }
 
 func EmitSearchSchemaEvents(ctx context.Context, logger interfaces.Logger, req *interfaces.SearchSchemaReq, resp *interfaces.SearchSchemaResp) string {
@@ -111,7 +233,7 @@ func EmitRunSQLEvents(ctx context.Context, logger interfaces.Logger, sql string,
 }
 
 func submitAndReturnFirstEventID(ctx context.Context, logger interfaces.Logger, req any, events []Event) string {
-	SubmitEvents(ctx, logger, req, events)
+	_ = SubmitEvents(ctx, logger, req, events)
 	if len(events) == 0 {
 		return ""
 	}
@@ -125,7 +247,11 @@ func BuildSearchSchemaEvents(ctx context.Context, req *interfaces.SearchSchemaRe
 		return nil
 	}
 	refs := schemaEvidenceRefs(resolvedKnID(req), resp)
-	return buildRetrievalEvents(ec, "context.search_schema", HashValue(strings.TrimSpace(req.Query)), len(refs), false, refs)
+	candidateCount := 0
+	if resp != nil {
+		candidateCount = len(resp.ObjectTypes) + len(resp.RelationTypes) + len(resp.ActionTypes) + len(resp.MetricTypes)
+	}
+	return buildRetrievalEvents(ec, "context.search_schema", HashValue(strings.TrimSpace(req.Query)), candidateCount, false, refs)
 }
 
 func BuildQueryObjectInstanceEvents(ctx context.Context, req *interfaces.QueryObjectInstancesReq, resp *interfaces.QueryObjectInstancesResp) []Event {
@@ -205,27 +331,29 @@ func buildRetrievalEvents(ec eventContext, operation, queryHash string, candidat
 	return []Event{fact}
 }
 
-func SubmitEvents(ctx context.Context, logger interfaces.Logger, req any, events []Event) {
+func SubmitEvents(ctx context.Context, logger interfaces.Logger, req any, events []Event) error {
 	if len(events) == 0 {
-		return
+		return nil
 	}
 	ec, ok := contextFromRequest(ctx, req)
 	if !ok || ec.accountID == "" || ec.accountType == "" {
-		return
+		return nil
 	}
 	ingestURL := evidenceIngestURL()
 	if ingestURL == "" {
-		return
+		return nil
 	}
 	timeout := evidenceTimeout()
 	traceBlock := map[string]any{
-		"trace_id":         ec.traceID,
-		"traceparent":      ec.traceparent,
-		"bkn.request.id":   ec.requestID,
-		"bkn.tenant.id":    ec.tenantID,
-		"business_domain":  ec.businessDomain,
-		"bkn.account.id":   ec.accountID,
-		"bkn.account.type": ec.accountType,
+		"trace_id":                     ec.traceID,
+		"traceparent":                  ec.traceparent,
+		"bkn.request.id":               ec.requestID,
+		"bkn.tenant.id":                ec.tenantID,
+		"business_domain":              ec.businessDomain,
+		"bkn.account.id":               ec.accountID,
+		"bkn.account.type":             ec.accountType,
+		"bkn.application.principal.id": ec.applicationID,
+		"bkn.effective.subject.type":   ec.subjectType,
 	}
 	if ec.conversationID != "" {
 		traceBlock["bkn.conversation.id"] = ec.conversationID
@@ -244,19 +372,78 @@ func SubmitEvents(ctx context.Context, logger interfaces.Logger, req any, events
 		} else {
 			log.Printf("BKN Trace evidence ingestion dropped: in-flight limit reached")
 		}
+		return fmt.Errorf("evidence ingestion in-flight limit reached")
+	}
+	defer func() { <-evidenceInFlight }()
+	if err := postBatchWithRetry(ingestURL, timeout, payload); err != nil {
+		if logger != nil {
+			logger.WithContext(ctx).Warnf("BKN Trace evidence ingestion unavailable: %v", err)
+		} else {
+			log.Printf("BKN Trace evidence ingestion unavailable: %v", err)
+		}
+		return err
+	}
+	recordDurableEvidenceOutcome(ctx, payload)
+	return nil
+}
+
+func withEvidenceOutcome(ctx context.Context) context.Context {
+	if evidenceOutcomeFromContext(ctx) != nil {
+		return ctx
+	}
+	return context.WithValue(ctx, evidenceOutcomeContextKey{}, &evidenceOutcome{})
+}
+
+func evidenceOutcomeFromContext(ctx context.Context) *evidenceOutcome {
+	value, _ := ctx.Value(evidenceOutcomeContextKey{}).(*evidenceOutcome)
+	return value
+}
+
+func recordDurableEvidenceOutcome(ctx context.Context, payload batch) {
+	outcome := evidenceOutcomeFromContext(ctx)
+	if outcome == nil {
 		return
 	}
-
-	go func() {
-		defer func() { <-evidenceInFlight }()
-		if err := postBatchWithRetry(ingestURL, timeout, payload); err != nil {
-			if logger != nil {
-				logger.WithContext(ctx).Warnf("BKN Trace evidence ingestion unavailable: %v", err)
-			} else {
-				log.Printf("BKN Trace evidence ingestion unavailable: %v", err)
+	outcome.mu.Lock()
+	defer outcome.mu.Unlock()
+	outcome.durable = true
+	seenEvents := make(map[string]struct{}, len(outcome.eventIDs))
+	for _, eventID := range outcome.eventIDs {
+		seenEvents[eventID] = struct{}{}
+	}
+	seenRefs := make(map[string]struct{}, len(outcome.businessRefs))
+	for _, ref := range outcome.businessRefs {
+		seenRefs[ref.RefType+"\x00"+ref.RefID+"\x00"+ref.Version] = struct{}{}
+	}
+	for _, event := range payload.Events {
+		if eventID := stringValue(event["event_id"]); eventID != "" {
+			if _, exists := seenEvents[eventID]; !exists {
+				outcome.eventIDs = append(outcome.eventIDs, eventID)
+				seenEvents[eventID] = struct{}{}
 			}
 		}
-	}()
+		for _, ref := range trace30BusinessRefs(event, stringValue(payload.Trace["business_domain"])) {
+			key := ref.RefType + "\x00" + ref.RefID + "\x00" + ref.Version
+			if _, exists := seenRefs[key]; exists {
+				continue
+			}
+			outcome.businessRefs = append(outcome.businessRefs, BusinessRef{
+				RefType: ref.RefType, RefID: ref.RefID, BusinessDomainID: ref.BusinessDomainID,
+				Version: ref.Version, DisplayHint: ref.DisplayHint,
+			})
+			seenRefs[key] = struct{}{}
+		}
+	}
+}
+
+func snapshotEvidenceOutcome(ctx context.Context) (bool, []string, []BusinessRef) {
+	outcome := evidenceOutcomeFromContext(ctx)
+	if outcome == nil {
+		return false, nil, nil
+	}
+	outcome.mu.Lock()
+	defer outcome.mu.Unlock()
+	return outcome.durable, append([]string(nil), outcome.eventIDs...), append([]BusinessRef(nil), outcome.businessRefs...)
 }
 
 func postBatchWithRetry(ingestURL string, timeout time.Duration, payload batch) error {
@@ -273,35 +460,210 @@ func postBatchWithRetry(ingestURL string, timeout time.Duration, payload batch) 
 }
 
 func postBatch(ingestURL string, timeout time.Duration, payload batch) error {
-	body, err := json.Marshal(payload)
-	if err != nil {
-		return err
-	}
-	postCtx, cancel := context.WithTimeout(context.Background(), timeout)
-	defer cancel()
+	for _, event := range payload.Events {
+		requestPayload, err := trace30EvidenceEvent(payload.Trace, event)
+		if err != nil {
+			return err
+		}
+		body, err := json.Marshal(requestPayload)
+		if err != nil {
+			return err
+		}
+		postCtx, cancel := context.WithTimeout(context.Background(), timeout)
+		req, err := http.NewRequestWithContext(postCtx, http.MethodPost, ingestURL, bytes.NewReader(body))
+		if err != nil {
+			cancel()
+			return err
+		}
+		setEvidenceIngestHeaders(req.Header, payload.Trace)
 
-	req, err := http.NewRequestWithContext(postCtx, http.MethodPost, ingestURL, bytes.NewReader(body))
-	if err != nil {
-		return err
-	}
-	req.Header.Set("Content-Type", "application/json")
-	if token := strings.TrimSpace(os.Getenv(envEvidenceIngestToken)); token != "" {
-		req.Header.Set("X-BKN-Trace-Ingest-Token", token)
-	}
-
-	resp, err := evidenceHTTPClient.Do(req)
-	if err != nil {
-		return err
-	}
-	defer resp.Body.Close()
-	if resp.StatusCode >= http.StatusBadRequest {
-		return fmt.Errorf("HTTP %d", resp.StatusCode)
+		resp, err := evidenceHTTPClient.Do(req)
+		if err != nil {
+			cancel()
+			return err
+		}
+		resp.Body.Close()
+		cancel()
+		if resp.StatusCode >= http.StatusBadRequest {
+			return fmt.Errorf("HTTP %d", resp.StatusCode)
+		}
 	}
 	return nil
 }
 
+type trace30Event struct {
+	SchemaVersion          string                 `json:"bkn.trace.schema.version"`
+	EventID                string                 `json:"event_id"`
+	EventType              string                 `json:"event_type"`
+	PayloadHash            string                 `json:"payload_hash"`
+	ConversationID         string                 `json:"conversation_id"`
+	InteractionID          string                 `json:"interaction_id"`
+	OperationID            string                 `json:"operation_id,omitempty"`
+	Attempt                uint32                 `json:"attempt,omitempty"`
+	RequestID              string                 `json:"request_id,omitempty"`
+	TraceID                string                 `json:"trace_id,omitempty"`
+	SpanID                 string                 `json:"span_id,omitempty"`
+	ProducerID             string                 `json:"producer_id"`
+	ProducerStreamID       string                 `json:"producer_stream_id"`
+	ProducerEpoch          uint64                 `json:"producer_epoch"`
+	ProducerSequence       uint64                 `json:"producer_sequence"`
+	CausationEventIDs      []string               `json:"causation_event_ids,omitempty"`
+	StartedAt              string                 `json:"started_at"`
+	ObservedAt             string                 `json:"observed_at"`
+	EmittedAt              string                 `json:"emitted_at"`
+	Envelope               Event                  `json:"envelope"`
+	BusinessRefs           []trace30BusinessRef   `json:"business_refs,omitempty"`
+	OperationBusinessEdges []trace30OperationEdge `json:"operation_business_edges,omitempty"`
+}
+
+type trace30BusinessRef struct {
+	RefType          string `json:"ref_type"`
+	RefID            string `json:"ref_id"`
+	BusinessDomainID string `json:"business_domain_id"`
+	Version          string `json:"version"`
+	DisplayHint      string `json:"display_hint,omitempty"`
+}
+
+type trace30OperationEdge struct {
+	OperationID string             `json:"operation_id"`
+	BusinessRef trace30BusinessRef `json:"business_ref"`
+	Role        string             `json:"role"`
+	ObservedAt  string             `json:"observed_at"`
+}
+
+func trace30EvidenceEvent(traceBlock map[string]any, event Event) (trace30Event, error) {
+	envelope, err := json.Marshal(event)
+	if err != nil {
+		return trace30Event{}, err
+	}
+	sum := sha256.Sum256(envelope)
+	operationID := stringValue(event["operation_id"])
+	attempt := uint32(intValue(event["attempt"], 1))
+	observedAt := stringValue(event["observed_at"])
+	emittedAt := stringValue(event["emitted_at"])
+	if emittedAt == "" {
+		emittedAt = observedAt
+	}
+	refs := trace30BusinessRefs(event, stringValue(traceBlock["business_domain"]))
+	edges := make([]trace30OperationEdge, 0, len(refs))
+	for _, ref := range refs {
+		edges = append(edges, trace30OperationEdge{
+			OperationID: operationID, BusinessRef: ref, Role: "read", ObservedAt: observedAt,
+		})
+	}
+	causationIDs := []string{}
+	if value := stringValue(event["causation_event_id"]); value != "" {
+		causationIDs = append(causationIDs, value)
+	}
+	producerStreamKey := operationID
+	if producerStreamKey == "" {
+		producerStreamKey = "interaction:" + stringValue(event["interaction_id"]) + ":" + stringValue(event["event_type"])
+	}
+	return trace30Event{
+		SchemaVersion: CoreSchemaVersion, EventID: stringValue(event["event_id"]),
+		EventType: stringValue(event["event_type"]), PayloadHash: hex.EncodeToString(sum[:]),
+		ConversationID: stringValue(traceBlock["bkn.conversation.id"]),
+		InteractionID:  stringValue(event["interaction_id"]), OperationID: operationID,
+		Attempt: attempt, RequestID: stringValue(traceBlock["bkn.request.id"]),
+		TraceID: stringValue(traceBlock["trace_id"]), SpanID: stringValue(event["span_id"]),
+		ProducerID: ModuleName, ProducerStreamID: ModuleName + ":" + producerStreamKey,
+		ProducerEpoch: 1, ProducerSequence: uint64(attempt), CausationEventIDs: causationIDs,
+		StartedAt: observedAt, ObservedAt: observedAt, EmittedAt: emittedAt,
+		Envelope: event, BusinessRefs: refs, OperationBusinessEdges: edges,
+	}, nil
+}
+
+func trace30BusinessRefs(event Event, businessDomain string) []trace30BusinessRef {
+	payload, _ := event["payload"].(map[string]any)
+	items, _ := payload["source_refs"].([]map[string]any)
+	refs := make([]trace30BusinessRef, 0, len(items))
+	for _, item := range items {
+		refID := stringValue(item["ref_id"])
+		refType := trace30RefType(stringValue(item["ref_type"]))
+		if refID == "" || refType == "" || businessDomain == "" {
+			continue
+		}
+		version := stringValue(item["version_status"])
+		if version == "" {
+			version = "observed"
+		}
+		refs = append(refs, trace30BusinessRef{
+			RefType: refType, RefID: refID, BusinessDomainID: businessDomain,
+			Version: version, DisplayHint: stringValue(item["display_hint"]),
+		})
+	}
+	return refs
+}
+
+func trace30RefType(value string) string {
+	switch value {
+	case "object":
+		return "object_type"
+	case "relation":
+		return "relation_type"
+	case "action":
+		return "action_type"
+	case "knowledge_network", "object_type", "object_instance", "property", "relation_type",
+		"data_resource", "metric", "logic", "function", "action_type", "action_instance":
+		return value
+	default:
+		return ""
+	}
+}
+
+func setEvidenceIngestHeaders(headers http.Header, traceBlock map[string]any) {
+	headers.Set("Content-Type", "application/json")
+	headers.Set("X-BKN-Trace-Ingest-Token", strings.TrimSpace(os.Getenv(envEvidenceIngestToken)))
+	headers.Set(coreGatewayTokenHeader, strings.TrimSpace(os.Getenv(envCoreGatewayToken)))
+	accountID := stringValue(traceBlock["bkn.account.id"])
+	accountType := stringValue(traceBlock["bkn.account.type"])
+	tenantID := stringValue(traceBlock["bkn.tenant.id"])
+	businessDomain := stringValue(traceBlock["business_domain"])
+	applicationID := stringValue(traceBlock["bkn.application.principal.id"])
+	if applicationID == "" {
+		applicationID = ModuleName
+	}
+	subjectType := stringValue(traceBlock["bkn.effective.subject.type"])
+	if subjectType == "" {
+		subjectType = "user"
+	}
+	headers.Set("x-account-id", accountID)
+	headers.Set("x-account-type", accountType)
+	headers.Set("x-tenant-id", tenantID)
+	headers.Set("x-business-domain", businessDomain)
+	headers.Set("X-BKN-Tenant-ID", tenantID)
+	headers.Set("X-Business-Domain-ID", businessDomain)
+	headers.Set("X-BKN-Application-Principal-ID", applicationID)
+	headers.Set("X-BKN-Effective-Subject-Type", subjectType)
+	headers.Set("X-BKN-Effective-Subject-ID", accountID)
+}
+
+func stringValue(value any) string {
+	text, _ := value.(string)
+	return strings.TrimSpace(text)
+}
+
+func intValue(value any, fallback int) int {
+	switch typed := value.(type) {
+	case int:
+		return typed
+	case float64:
+		return int(typed)
+	default:
+		return fallback
+	}
+}
+
 func evidenceIngestURL() string {
 	return strings.TrimSpace(os.Getenv(envEvidenceIngestURL))
+}
+
+func evidenceArtifactURL() string {
+	value := strings.TrimRight(evidenceIngestURL(), "/")
+	if strings.HasSuffix(value, "/events") {
+		return strings.TrimSuffix(value, "/events") + "/artifacts"
+	}
+	return ""
 }
 
 func evidenceTimeout() time.Duration {
@@ -317,6 +679,34 @@ func evidenceTimeout() time.Duration {
 }
 
 func contextFromRequest(ctx context.Context, req any) (eventContext, bool) {
+	ec, ok := baseEventContext(ctx)
+	if !ok {
+		return eventContext{}, false
+	}
+	traceContext, _ := common.GetTraceContextFromCtx(ctx)
+	if schemaReq, ok := req.(*interfaces.SearchSchemaReq); ok && schemaReq != nil {
+		if ec.accountID == "" {
+			ec.accountID = strings.TrimSpace(schemaReq.XAccountID)
+		}
+		if ec.accountType == "" {
+			ec.accountType = strings.TrimSpace(schemaReq.XAccountType)
+		}
+	}
+	ec.interactionID = strings.TrimSpace(traceContext.InteractionID)
+	ec.operationID = strings.TrimSpace(traceContext.OperationID)
+	if ec.interactionID == "" || ec.operationID == "" {
+		return eventContext{}, false
+	}
+	ec.causationEventID = strings.TrimSpace(traceContext.CausationEventID)
+	ec.claimID = strings.TrimSpace(traceContext.ClaimID)
+	ec.attempt = traceContext.Attempt
+	if ec.attempt < 1 || ec.attempt > 1000 {
+		ec.attempt = 1
+	}
+	return ec, true
+}
+
+func baseEventContext(ctx context.Context) (eventContext, bool) {
 	spanContext := trace.SpanContextFromContext(ctx)
 	if !spanContext.IsValid() {
 		return eventContext{}, false
@@ -335,30 +725,25 @@ func contextFromRequest(ctx context.Context, req any) (eventContext, bool) {
 	authContext, _ := common.GetAccountAuthContextFromCtx(ctx)
 	accountID := ""
 	accountType := ""
+	applicationID := ""
+	subjectType := "user"
 	if authContext != nil {
 		accountID = strings.TrimSpace(authContext.AccountID)
 		accountType = strings.TrimSpace(string(authContext.AccountType))
-	}
-	if schemaReq, ok := req.(*interfaces.SearchSchemaReq); ok && schemaReq != nil {
-		if accountID == "" {
-			accountID = strings.TrimSpace(schemaReq.XAccountID)
+		applicationID = accountID
+		if authContext.TokenInfo != nil && strings.TrimSpace(authContext.TokenInfo.ClientID) != "" {
+			applicationID = strings.TrimSpace(authContext.TokenInfo.ClientID)
 		}
-		if accountType == "" {
-			accountType = strings.TrimSpace(schemaReq.XAccountType)
+		if authContext.AccountType == interfaces.AccessorTypeApp {
+			subjectType = "service"
 		}
 	}
-	interactionID := strings.TrimSpace(traceContext.InteractionID)
-	operationID := strings.TrimSpace(traceContext.OperationID)
-	if interactionID == "" || operationID == "" {
+	if accountID == "" || accountType == "" {
 		return eventContext{}, false
 	}
 	flags := "00"
 	if spanContext.TraceFlags().IsSampled() {
 		flags = "01"
-	}
-	attempt := traceContext.Attempt
-	if attempt < 1 || attempt > 1000 {
-		attempt = 1
 	}
 	return eventContext{
 		traceID:          spanContext.TraceID().String(),
@@ -367,16 +752,30 @@ func contextFromRequest(ctx context.Context, req any) (eventContext, bool) {
 		requestID:        traceContext.RequestID,
 		accountID:        accountID,
 		accountType:      accountType,
+		applicationID:    applicationID,
+		subjectType:      subjectType,
 		tenantID:         strings.TrimSpace(traceContext.TenantID),
 		businessDomain:   strings.TrimSpace(traceContext.BusinessDomain),
 		conversationID:   strings.TrimSpace(traceContext.ConversationID),
-		interactionID:    interactionID,
-		operationID:      operationID,
+		interactionID:    strings.TrimSpace(traceContext.InteractionID),
+		operationID:      strings.TrimSpace(traceContext.OperationID),
 		causationEventID: strings.TrimSpace(traceContext.CausationEventID),
 		claimID:          strings.TrimSpace(traceContext.ClaimID),
-		attempt:          attempt,
+		attempt:          traceContext.Attempt,
 		observedAt:       observedAt,
 	}, true
+}
+
+func traceBlockFromEventContext(ec eventContext) map[string]any {
+	return map[string]any{
+		"trace_id": ec.traceID, "traceparent": ec.traceparent,
+		"bkn.request.id": ec.requestID, "bkn.tenant.id": ec.tenantID,
+		"business_domain": ec.businessDomain, "bkn.account.id": ec.accountID,
+		"bkn.account.type":             ec.accountType,
+		"bkn.application.principal.id": ec.applicationID,
+		"bkn.effective.subject.type":   ec.subjectType,
+		"bkn.conversation.id":          ec.conversationID,
+	}
 }
 
 func buildEvent(ec eventContext, eventType, operationName string, payload map[string]any, claimID, causationEventID string) Event {
@@ -415,7 +814,15 @@ func schemaEvidenceRefs(knID string, resp *interfaces.SearchSchemaResp) []map[st
 	if resp == nil || strings.TrimSpace(knID) == "" {
 		return nil
 	}
-	refs := make([]map[string]any, 0, len(resp.ObjectTypes)+len(resp.RelationTypes)+len(resp.ActionTypes)+len(resp.MetricTypes))
+	refs := make([]map[string]any, 0, 1+len(resp.ObjectTypes)+len(resp.RelationTypes)+len(resp.ActionTypes)+len(resp.MetricTypes))
+	refs = append(refs, map[string]any{
+		"ref_id":         "kn:" + knID,
+		"ref_type":       "knowledge_network",
+		"source_system":  "context-loader",
+		"validity":       "observed",
+		"version_status": "unversioned",
+		"visibility":     "visible",
+	})
 	refs = append(refs, conceptRefs("object", "object", knID, resp.ObjectTypes)...)
 	refs = append(refs, conceptRefs("relation", "relation", knID, resp.RelationTypes)...)
 	refs = append(refs, conceptRefs("action_type", "action", knID, resp.ActionTypes)...)

--- a/adp/context-loader/agent-retrieval/server/infra/bkntrace/evidence_test.go
+++ b/adp/context-loader/agent-retrieval/server/infra/bkntrace/evidence_test.go
@@ -100,6 +100,21 @@ func TestRecordInteractionArtifactPersistsGovernedContentAndLedgerLink(t *testin
 	}
 }
 
+func TestRecordInteractionArtifactIsOptionalWhenEvidenceIsDisabled(t *testing.T) {
+	t.Setenv(envEvidenceIngestURL, "")
+
+	ref, err := RecordInteractionArtifact(
+		context.Background(), "conversation-1", "interaction-1", InteractionArtifactQuestion,
+		"6月份有哪些需求预测单？",
+	)
+	if err != nil {
+		t.Fatalf("disabled evidence must not block the managed lifecycle: %v", err)
+	}
+	if ref != "" {
+		t.Fatalf("disabled evidence returned artifact ref %q, want empty", ref)
+	}
+}
+
 func TestBuildSearchSchemaEventsRejectsMissingReplayEnvelope(t *testing.T) {
 	ctx := testTraceContext()
 	traceContext, _ := common.GetTraceContextFromCtx(ctx)

--- a/adp/context-loader/agent-retrieval/server/infra/bkntrace/evidence_test.go
+++ b/adp/context-loader/agent-retrieval/server/infra/bkntrace/evidence_test.go
@@ -54,6 +54,52 @@ func testTraceContext() context.Context {
 	return ctx
 }
 
+func TestRecordInteractionArtifactPersistsGovernedContentAndLedgerLink(t *testing.T) {
+	var artifactBody map[string]any
+	var eventBody map[string]any
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		switch r.URL.Path {
+		case "/api/agent-observability/v1/evidence/artifacts":
+			_ = json.Unmarshal(body, &artifactBody)
+			w.WriteHeader(http.StatusCreated)
+		case "/api/agent-observability/v1/evidence/events":
+			_ = json.Unmarshal(body, &eventBody)
+			w.WriteHeader(http.StatusAccepted)
+		default:
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+	}))
+	t.Cleanup(server.Close)
+	t.Setenv(envEvidenceIngestURL, server.URL+"/api/agent-observability/v1/evidence/events")
+	t.Setenv(envEvidenceIngestToken, "test-ingest-token")
+
+	ref, err := RecordInteractionArtifact(
+		testTraceContext(), "conversation-1", "interaction-1", InteractionArtifactQuestion,
+		"6月份有哪些需求预测单？",
+	)
+	if err != nil {
+		t.Fatalf("record interaction artifact: %v", err)
+	}
+	if !strings.HasPrefix(ref, "artifact:art_question_") {
+		t.Fatalf("unexpected artifact ref: %q", ref)
+	}
+	if artifactBody["content"] != "6月份有哪些需求预测单？" || artifactBody["interaction_id"] != "interaction-1" {
+		t.Fatalf("artifact content or interaction was lost: %#v", artifactBody)
+	}
+	if eventBody["event_type"] != "agent.interaction.started" || eventBody["interaction_id"] != "interaction-1" {
+		t.Fatalf("ledger link was not emitted: %#v", eventBody)
+	}
+	if _, exists := eventBody["operation_id"]; exists {
+		t.Fatalf("interaction-level artifact must not claim a tool operation: %#v", eventBody)
+	}
+	envelope := eventBody["envelope"].(map[string]any)
+	payload := envelope["payload"].(map[string]any)
+	if payload["question_artifact_ref"] != ref {
+		t.Fatalf("ledger event does not link the artifact: %#v", payload)
+	}
+}
+
 func TestBuildSearchSchemaEventsRejectsMissingReplayEnvelope(t *testing.T) {
 	ctx := testTraceContext()
 	traceContext, _ := common.GetTraceContextFromCtx(ctx)
@@ -245,6 +291,9 @@ func TestBuildSearchSchemaEventsUsesHashAndRefsOnly(t *testing.T) {
 	}
 	if !strings.Contains(text, `"query_hash":"sha256:`) {
 		t.Fatalf("missing query hash: %s", text)
+	}
+	if !strings.Contains(text, `"ref_id":"kn:kn_demo"`) {
+		t.Fatalf("missing knowledge network ref: %s", text)
 	}
 	if !strings.Contains(text, `"ref_id":"object:kn_demo:customer"`) {
 		t.Fatalf("missing object type ref: %s", text)
@@ -531,11 +580,11 @@ func TestSubmitEventsPreservesCallerOwnedConversationID(t *testing.T) {
 	t.Setenv(envEvidenceIngestURL, "http://trace.local/ingest")
 	previous := evidenceHTTPClient
 	t.Cleanup(func() { evidenceHTTPClient = previous })
-	payloads := make(chan batch, 1)
+	payloads := make(chan map[string]any, 1)
 	evidenceHTTPClient = &http.Client{Transport: evidenceRoundTripFunc(func(req *http.Request) (*http.Response, error) {
-		var payload batch
+		var payload map[string]any
 		if err := json.NewDecoder(req.Body).Decode(&payload); err != nil {
-			t.Fatalf("decode evidence batch: %v", err)
+			t.Fatalf("decode 3.0 evidence event: %v", err)
 		}
 		payloads <- payload
 		return &http.Response{StatusCode: http.StatusNoContent, Body: io.NopCloser(strings.NewReader(""))}, nil
@@ -565,8 +614,8 @@ func TestSubmitEventsPreservesCallerOwnedConversationID(t *testing.T) {
 	SubmitEvents(ctx, nil, nil, []Event{{"event_type": "retrieval.completed"}})
 	select {
 	case payload := <-payloads:
-		if got := payload.Trace["bkn.conversation.id"]; got != "agent:thread_supply_chain" {
-			t.Fatalf("bkn.conversation.id=%v", got)
+		if got := payload["conversation_id"]; got != "agent:thread_supply_chain" {
+			t.Fatalf("conversation_id=%v", got)
 		}
 	case <-time.After(2 * time.Second):
 		t.Fatal("timed out waiting for evidence batch")
@@ -584,7 +633,7 @@ func TestPostBatchWithRetryTreatsNon2xxAsFailure(t *testing.T) {
 		}
 		return &http.Response{StatusCode: status, Body: io.NopCloser(strings.NewReader(""))}, nil
 	})}
-	if err := postBatchWithRetry("http://trace.local", time.Second, batch{}); err != nil {
+	if err := postBatchWithRetry("http://trace.local", time.Second, batch{Events: []Event{{}}}); err != nil {
 		t.Fatal(err)
 	}
 	if calls.Load() != 3 {
@@ -592,18 +641,105 @@ func TestPostBatchWithRetryTreatsNon2xxAsFailure(t *testing.T) {
 	}
 }
 
-func TestPostBatchSendsDedicatedIngestToken(t *testing.T) {
+func TestPostBatchSendsTrace30EventWithTrustedProducerIdentity(t *testing.T) {
 	t.Setenv("BKN_TRACE_EVIDENCE_INGEST_TOKEN", "producer-token")
+	t.Setenv("BKN_TRACE_QUERY_GATEWAY_TOKEN", "gateway-token")
 	previous := evidenceHTTPClient
 	t.Cleanup(func() { evidenceHTTPClient = previous })
 	evidenceHTTPClient = &http.Client{Transport: evidenceRoundTripFunc(func(req *http.Request) (*http.Response, error) {
 		if got := req.Header.Get("X-BKN-Trace-Ingest-Token"); got != "producer-token" {
 			t.Fatalf("ingest token header=%q", got)
 		}
+		if got := req.Header.Get("X-BKN-Trace-Query-Token"); got != "gateway-token" {
+			t.Fatalf("query gateway token header=%q", got)
+		}
+		for header, want := range map[string]string{
+			"x-account-id":                   "acct_demo",
+			"x-account-type":                 "user",
+			"x-tenant-id":                    "tenant_demo",
+			"x-business-domain":              "domain_demo",
+			"X-BKN-Tenant-ID":                "tenant_demo",
+			"X-Business-Domain-ID":           "domain_demo",
+			"X-BKN-Application-Principal-ID": "context-loader",
+			"X-BKN-Effective-Subject-Type":   "user",
+			"X-BKN-Effective-Subject-ID":     "acct_demo",
+		} {
+			if got := req.Header.Get(header); got != want {
+				t.Fatalf("%s=%q, want %q", header, got, want)
+			}
+		}
+		var event map[string]any
+		if err := json.NewDecoder(req.Body).Decode(&event); err != nil {
+			t.Fatalf("decode 3.0 evidence event: %v", err)
+		}
+		for key, want := range map[string]any{
+			"bkn.trace.schema.version": "3.0.0",
+			"conversation_id":          "conv_demo",
+			"interaction_id":           "int_context_loader_0001",
+			"operation_id":             "op_context_retrieval_0001",
+			"producer_id":              "context-loader",
+		} {
+			if event[key] != want {
+				t.Fatalf("%s=%v, want %v", key, event[key], want)
+			}
+		}
+		if event["payload_hash"] == "" || event["envelope"] == nil {
+			t.Fatalf("3.0 event is missing immutable envelope identity: %#v", event)
+		}
+		refs, ok := event["business_refs"].([]any)
+		if !ok || len(refs) != 1 {
+			t.Fatalf("business_refs=%#v, want one typed ref", event["business_refs"])
+		}
 		return &http.Response{StatusCode: http.StatusNoContent, Body: io.NopCloser(strings.NewReader(""))}, nil
 	})}
-	if err := postBatch("http://trace.local", time.Second, batch{}); err != nil {
+	payload := batch{
+		Trace: map[string]any{
+			"trace_id": "71210000000000000000000000000001", "bkn.request.id": "req_context_loader_phase2_0001",
+			"bkn.tenant.id": "tenant_demo", "business_domain": "domain_demo",
+			"bkn.account.id": "acct_demo", "bkn.account.type": "user",
+			"bkn.conversation.id": "conv_demo",
+		},
+		Events: []Event{{
+			"event_id": "evt_demo", "event_type": "retrieval.completed",
+			"observed_at": "2026-07-25T08:00:00Z", "emitted_at": "2026-07-25T08:00:00Z",
+			"span_id": "7121000000000001", "interaction_id": "int_context_loader_0001",
+			"operation_id": "op_context_retrieval_0001", "attempt": 1,
+			"payload": map[string]any{"source_refs": []map[string]any{{
+				"ref_id": "resource:forecast_resource", "ref_type": "data_resource",
+				"version_status": "unversioned",
+			}}},
+		}},
+	}
+	if err := postBatch("http://trace.local", time.Second, payload); err != nil {
 		t.Fatal(err)
+	}
+}
+
+func TestSubmitEventsRecordsDurableOutcomeForOperationFinish(t *testing.T) {
+	t.Setenv(envEvidenceIngestURL, "http://trace.local/ingest")
+	previous := evidenceHTTPClient
+	t.Cleanup(func() { evidenceHTTPClient = previous })
+	evidenceHTTPClient = &http.Client{Transport: evidenceRoundTripFunc(func(*http.Request) (*http.Response, error) {
+		return &http.Response{
+			StatusCode: http.StatusAccepted,
+			Body: io.NopCloser(strings.NewReader(
+				`{"event_id":"evt_durable","durable_ack":true,"replayed":false,"ingest_sequence":1,"ingested_at":"2026-07-25T08:00:01Z"}`,
+			)),
+		}, nil
+	})}
+	ctx := withEvidenceOutcome(testTraceContext())
+	events := BuildRunSQLEvents(ctx, "SELECT 1", []string{"forecast_resource"}, &interfaces.VegaRawQueryResp{})
+	SubmitEvents(ctx, nil, nil, events)
+
+	outcome := evidenceOutcomeFromContext(ctx)
+	if outcome == nil || !outcome.durable {
+		t.Fatalf("durable evidence outcome was not recorded: %#v", outcome)
+	}
+	if len(outcome.eventIDs) != 1 || outcome.eventIDs[0] != events[0]["event_id"] {
+		t.Fatalf("event IDs=%#v, want emitted event", outcome.eventIDs)
+	}
+	if len(outcome.businessRefs) != 1 || outcome.businessRefs[0].RefID != "resource:forecast_resource" {
+		t.Fatalf("business refs=%#v, want queried resource", outcome.businessRefs)
 	}
 }
 
@@ -615,8 +751,22 @@ func captureIngestedTrace(t *testing.T, ctx context.Context) map[string]any {
 		if _, err := io.ReadFull(r.Body, body); err != nil {
 			t.Errorf("read ingest body: %v", err)
 		}
+		var event map[string]any
+		if err := json.Unmarshal(body, &event); err != nil {
+			t.Errorf("decode 3.0 evidence event: %v", err)
+		}
+		traceBlock := map[string]any{
+			"trace_id":            event["trace_id"],
+			"bkn.request.id":      event["request_id"],
+			"bkn.conversation.id": event["conversation_id"],
+			"bkn.tenant.id":       r.Header.Get("x-tenant-id"),
+			"business_domain":     r.Header.Get("x-business-domain"),
+			"bkn.account.id":      r.Header.Get("x-account-id"),
+			"bkn.account.type":    r.Header.Get("x-account-type"),
+		}
+		encoded, _ := json.Marshal(traceBlock)
 		select {
-		case bodies <- body:
+		case bodies <- encoded:
 		default:
 		}
 		w.WriteHeader(http.StatusOK)
@@ -630,13 +780,14 @@ func captureIngestedTrace(t *testing.T, ctx context.Context) map[string]any {
 
 	select {
 	case body := <-bodies:
-		var payload struct {
-			Trace map[string]any `json:"trace"`
-		}
-		if err := json.Unmarshal(body, &payload); err != nil {
+		var traceBlock map[string]any
+		if err := json.Unmarshal(body, &traceBlock); err != nil {
 			t.Fatalf("decode ingest body: %v", err)
 		}
-		return payload.Trace
+		if traceBlock["bkn.conversation.id"] == "" {
+			delete(traceBlock, "bkn.conversation.id")
+		}
+		return traceBlock
 	case <-time.After(2 * time.Second):
 		t.Fatalf("expected evidence ingestion request")
 		return nil

--- a/adp/context-loader/agent-retrieval/server/infra/bkntrace/guard.go
+++ b/adp/context-loader/agent-retrieval/server/infra/bkntrace/guard.go
@@ -14,6 +14,7 @@ import (
 	"go.opentelemetry.io/otel/trace"
 
 	"github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/infra/common"
+	"github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/infra/telemetry"
 )
 
 const (
@@ -49,11 +50,12 @@ const (
 )
 
 type Guard struct {
-	client *LifecycleClient
+	client               *LifecycleClient
+	emitOperationOutcome func(context.Context, bool)
 }
 
 func NewGuard(client *LifecycleClient) *Guard {
-	return &Guard{client: client}
+	return &Guard{client: client, emitOperationOutcome: telemetry.EmitOperationOutcome}
 }
 
 func (g *Guard) Begin(
@@ -89,8 +91,9 @@ func (g *Guard) Begin(
 	traceContext.ConversationID = intent.Context.ConversationID
 	traceContext.InteractionID = intent.Context.InteractionID
 	traceContext.OperationID = result.Operation.OperationID
+	traceContext.ToolName = intent.ToolName
 	traceContext.Attempt = int(result.Operation.Attempt)
-	return common.SetTraceContextToCtx(ctx, traceContext), state, GuardExecute, nil, nil
+	return withEvidenceOutcome(common.SetTraceContextToCtx(ctx, traceContext)), state, GuardExecute, nil, nil
 }
 
 func ensureFinishCorrelation(ctx context.Context) (context.Context, error) {
@@ -137,6 +140,11 @@ func (g *Guard) Finish(
 		TraceID:     spanContext.TraceID().String(),
 		Retryable:   retryable,
 	}
+	if durable, evidenceRefs, businessRefs := snapshotEvidenceOutcome(ctx); durable {
+		input.EvidenceDurability = "durable"
+		input.ObservedEvidenceRefs = evidenceRefs
+		input.BusinessRefs = businessRefs
+	}
 	finishContext, cancel := context.WithTimeout(context.WithoutCancel(ctx), finishTimeout)
 	defer cancel()
 
@@ -151,6 +159,7 @@ func (g *Guard) Finish(
 			result, apiErr, err = g.client.CompleteAttempt(finishContext, input)
 		}
 		if err == nil && apiErr == nil {
+			g.emitFinalizedOutcome(ctx, failed)
 			return result, nil, nil
 		}
 		if apiErr != nil && !apiErr.Retryable && apiErr.Code != "receipt_pending" {
@@ -173,6 +182,7 @@ func (g *Guard) Finish(
 						return lastResult, conflict, nil
 					}
 					lastResult.Operation = operation
+					g.emitFinalizedOutcome(ctx, failed)
 					return lastResult, nil, nil
 				}
 				if operationErr != nil && !operationErr.Retryable {
@@ -194,6 +204,12 @@ func (g *Guard) Finish(
 		Code: "receipt_pending", Message: "operation receipt finalization is not yet confirmed",
 		Retryable: true, RequiredAction: "poll_receipt",
 	}, nil
+}
+
+func (g *Guard) emitFinalizedOutcome(ctx context.Context, failed bool) {
+	if g.emitOperationOutcome != nil {
+		g.emitOperationOutcome(ctx, failed)
+	}
 }
 
 func validateRecoveredReceipt(

--- a/adp/context-loader/agent-retrieval/server/infra/bkntrace/lifecycle.go
+++ b/adp/context-loader/agent-retrieval/server/infra/bkntrace/lifecycle.go
@@ -25,9 +25,11 @@ import (
 )
 
 const (
-	CoreSchemaVersion = "3.0.0"
-	coreAPIPath       = "/api/agent-observability/v1"
-	envCoreURL        = "BKN_TRACE_CORE_URL"
+	CoreSchemaVersion      = "3.0.0"
+	coreAPIPath            = "/api/agent-observability/v1"
+	envCoreURL             = "BKN_TRACE_CORE_URL"
+	envCoreGatewayToken    = "BKN_TRACE_QUERY_GATEWAY_TOKEN"
+	coreGatewayTokenHeader = "X-BKN-Trace-Query-Token"
 
 	lifecycleClientTimeout      = 10 * time.Second
 	lifecycleMaxIdleConnections = 100
@@ -193,18 +195,26 @@ type FinishAttemptInput struct {
 	EvidenceDurability   string
 	Retryable            bool
 	ObservedEvidenceRefs []string
+	BusinessRefs         []BusinessRef
+	ArtifactRefs         []string
+	PartialReasons       []string
 }
 
 type LifecycleClient struct {
-	baseURL string
-	client  *http.Client
+	baseURL      string
+	gatewayToken string
+	client       *http.Client
 }
 
 func NewLifecycleClient(baseURL string, client *http.Client) *LifecycleClient {
 	if client == nil {
 		client = newLifecycleHTTPClient()
 	}
-	return &LifecycleClient{baseURL: strings.TrimRight(baseURL, "/"), client: client}
+	return &LifecycleClient{
+		baseURL:      strings.TrimRight(baseURL, "/"),
+		gatewayToken: strings.TrimSpace(os.Getenv(envCoreGatewayToken)),
+		client:       client,
+	}
 }
 
 func NewLifecycleClientFromEnv() *LifecycleClient {
@@ -341,6 +351,9 @@ func (c *LifecycleClient) finishAttempt(
 		"evidence_durability": evidenceDurability, "retryable": input.Retryable,
 		"request_id": input.RequestID, "trace_id": input.TraceID,
 		"observed_evidence_refs": input.ObservedEvidenceRefs,
+		"business_refs":          input.BusinessRefs,
+		"artifact_refs":          input.ArtifactRefs,
+		"partial_reasons":        input.PartialReasons,
 	}
 	var result OperationResult
 	path := "/operations/" + url.PathEscape(input.OperationID) + "/attempts/" +
@@ -380,6 +393,9 @@ func (c *LifecycleClient) do(
 		return nil, err
 	}
 	req.Header.Set("Content-Type", "application/json")
+	if c.gatewayToken != "" {
+		req.Header.Set(coreGatewayTokenHeader, c.gatewayToken)
+	}
 	if err := setTrustedLifecycleHeaders(ctx, req.Header); err != nil {
 		return &APIError{
 			Code: "permission_denied", Message: err.Error(),
@@ -424,6 +440,13 @@ func setTrustedLifecycleHeaders(ctx context.Context, headers http.Header) error 
 	if auth.AccountType == interfaces.AccessorTypeApp {
 		subjectType = "service"
 	}
+	// Core first authorizes the trusted query scope, then validates the richer
+	// lifecycle owner tuple. Both header sets come from this authenticated
+	// service boundary, never from the lifecycle request body.
+	headers.Set("x-account-id", auth.AccountID)
+	headers.Set("x-account-type", string(auth.AccountType))
+	headers.Set("x-tenant-id", traceContext.TenantID)
+	headers.Set("x-business-domain", traceContext.BusinessDomain)
 	headers.Set("X-BKN-Tenant-ID", traceContext.TenantID)
 	headers.Set("X-Business-Domain-ID", traceContext.BusinessDomain)
 	headers.Set("X-BKN-Application-Principal-ID", applicationID)

--- a/adp/context-loader/agent-retrieval/server/infra/bkntrace/lifecycle_test.go
+++ b/adp/context-loader/agent-retrieval/server/infra/bkntrace/lifecycle_test.go
@@ -24,10 +24,16 @@ import (
 )
 
 func TestLifecycleClientEnsureOperationUsesTrustedContext(t *testing.T) {
+	t.Setenv("BKN_TRACE_QUERY_GATEWAY_TOKEN", "trusted-context-loader-token")
 	requests := 0
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		requests++
 		for name, expected := range map[string]string{
+			"X-BKN-Trace-Query-Token":        "trusted-context-loader-token",
+			"x-account-id":                   "user-1",
+			"x-account-type":                 "user",
+			"x-tenant-id":                    "tenant-1",
+			"x-business-domain":              "domain-1",
 			"X-BKN-Tenant-ID":                "tenant-1",
 			"X-Business-Domain-ID":           "domain-1",
 			"X-BKN-Application-Principal-ID": "client-1",
@@ -273,6 +279,14 @@ func TestGuardFinishCreatesCorrelationWhenCallerHasNoSpan(t *testing.T) {
 	traceContext, _ := common.GetTraceContextFromCtx(ctx)
 	traceContext.RequestID = "req_finish_without_span_0001"
 	ctx = common.SetTraceContextToCtx(ctx, traceContext)
+	ctx = withEvidenceOutcome(ctx)
+	outcome := evidenceOutcomeFromContext(ctx)
+	outcome.durable = true
+	outcome.eventIDs = []string{"evt_durable"}
+	outcome.businessRefs = []BusinessRef{{
+		RefType: "data_resource", RefID: "resource:forecast_resource",
+		BusinessDomainID: "domain-demo", Version: "unversioned",
+	}}
 
 	_, apiErr, err := NewGuard(client).Finish(
 		ctx, pendingGuardState(), "sha256:result", false, false,
@@ -286,6 +300,17 @@ func TestGuardFinishCreatesCorrelationWhenCallerHasNoSpan(t *testing.T) {
 	traceID, _ := requestBody["trace_id"].(string)
 	if len(traceID) != 32 {
 		t.Fatalf("finish request did not derive a valid trace ID: %#v", requestBody)
+	}
+	if requestBody["evidence_durability"] != "durable" {
+		t.Fatalf("finish request lost durable evidence ACK: %#v", requestBody)
+	}
+	refs, _ := requestBody["observed_evidence_refs"].([]any)
+	if len(refs) != 1 || refs[0] != "evt_durable" {
+		t.Fatalf("finish request lost evidence refs: %#v", requestBody)
+	}
+	businessRefs, _ := requestBody["business_refs"].([]any)
+	if len(businessRefs) != 1 {
+		t.Fatalf("finish request lost business refs: %#v", requestBody)
 	}
 }
 
@@ -385,6 +410,36 @@ func TestGuardFinishRecoversWhenCommittedResponseIsLost(t *testing.T) {
 		receiptCalls != 1 || operationCalls != 1 {
 		t.Fatalf("unexpected lost response recovery: result=%#v finish=%d receipt=%d operation=%d",
 			result, finishCalls, receiptCalls, operationCalls)
+	}
+}
+
+func TestGuardFinishEmitsOneOutcomeOnlyAfterDurableFinalization(t *testing.T) {
+	client := lifecycleClientWithTransport(func(request *http.Request) (*http.Response, error) {
+		return lifecycleJSONResponse(http.StatusOK, OperationResult{
+			Operation: Operation{OperationID: "op-1", Attempt: 1, AttemptStatus: "completed"},
+			Receipt: Receipt{
+				ReceiptID: "receipt-1", OperationID: "op-1", Attempt: 1,
+				ReceiptStatus: "completed",
+			},
+		}), nil
+	})
+	guard := NewGuard(client)
+	emissions := 0
+	guard.emitOperationOutcome = func(_ context.Context, failed bool) {
+		emissions++
+		if failed {
+			t.Fatal("successful finalization emitted a failed outcome")
+		}
+	}
+
+	_, apiErr, err := guard.Finish(
+		finishLifecycleContext(false), pendingGuardState(), "sha256:result", false, false,
+	)
+	if err != nil || apiErr != nil {
+		t.Fatalf("finish failed: api=%#v err=%v", apiErr, err)
+	}
+	if emissions != 1 {
+		t.Fatalf("outcome emissions=%d, want 1", emissions)
 	}
 }
 

--- a/adp/context-loader/agent-retrieval/server/infra/common/context_manage.go
+++ b/adp/context-loader/agent-retrieval/server/infra/common/context_manage.go
@@ -13,6 +13,7 @@ import (
 	"encoding/hex"
 	"fmt"
 	"log"
+	"os"
 	"regexp"
 	"sort"
 	"strconv"
@@ -38,6 +39,7 @@ const (
 	HeaderTenantID            = "x-tenant-id"
 	HeaderBusinessDomain      = "x-business-domain"
 	HeaderBKNEventObservedAt  = "bkn-event-observed-at"
+	envDefaultTenantID        = "BKN_TRACE_DEFAULT_TENANT_ID"
 )
 
 type traceContextKey string
@@ -57,6 +59,7 @@ type TraceContext struct {
 	ConversationID     string
 	InteractionID      string
 	OperationID        string
+	ToolName           string
 	CausationEventID   string
 	ClaimID            string
 	Attempt            int
@@ -170,7 +173,7 @@ func TraceContextFromHeaders(getHeader func(string) string) TraceContext {
 	_, observedAtErr := time.Parse(time.RFC3339Nano, observedAt)
 	return TraceContext{
 		RequestID:          requestID,
-		TenantID:           sanitizeBusinessTraceID(getHeader(HeaderTenantID)),
+		TenantID:           sanitizeBusinessTraceID(firstNonEmpty(getHeader(HeaderTenantID), os.Getenv(envDefaultTenantID))),
 		BusinessDomain:     firstNonEmpty(getHeader(HeaderBusinessDomain), parseBaggage(getHeader(HeaderBaggage))["business_domain"]),
 		Baggage:            parseBaggage(getHeader(HeaderBaggage)),
 		ConversationID:     sanitizeBusinessTraceID(getHeader(HeaderBKNConversationID)),

--- a/adp/context-loader/agent-retrieval/server/infra/common/context_manage_test.go
+++ b/adp/context-loader/agent-retrieval/server/infra/common/context_manage_test.go
@@ -229,6 +229,32 @@ func TestBusinessCausalityHeadersAreValidatedAndPropagated(t *testing.T) {
 	})
 }
 
+func TestTraceContextUsesConfiguredTenantOnlyWhenInboundTenantIsMissing(t *testing.T) {
+	t.Setenv("BKN_TRACE_DEFAULT_TENANT_ID", "openbkn-local")
+	domainOnly := TraceContextFromHeaders(func(key string) string {
+		if key == HeaderBusinessDomain {
+			return "bd_public"
+		}
+		return ""
+	})
+	if domainOnly.TenantID != "openbkn-local" {
+		t.Fatalf("default tenant = %q, want openbkn-local", domainOnly.TenantID)
+	}
+	trustedTenant := TraceContextFromHeaders(func(key string) string {
+		switch key {
+		case HeaderTenantID:
+			return "tenant-from-gateway"
+		case HeaderBusinessDomain:
+			return "bd_public"
+		default:
+			return ""
+		}
+	})
+	if trustedTenant.TenantID != "tenant-from-gateway" {
+		t.Fatalf("inbound tenant was overwritten: %q", trustedTenant.TenantID)
+	}
+}
+
 func TestCallerCorrelationIDsAreValidatedWithoutGeneration(t *testing.T) {
 	convey.Convey("valid caller ids are propagated and invalid ids are dropped", t, func() {
 		headers := map[string]string{

--- a/adp/context-loader/agent-retrieval/server/infra/telemetry/log.go
+++ b/adp/context-loader/agent-retrieval/server/infra/telemetry/log.go
@@ -9,10 +9,15 @@ package telemetry
 
 import (
 	"context"
+	"crypto/rand"
+	"encoding/hex"
 	"fmt"
+	"time"
 
 	"github.com/openbkn-ai/bkn-comm-go/otel/otellog"
+	otellogapi "go.opentelemetry.io/otel/log"
 
+	"github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/infra/common"
 	"github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/interfaces"
 )
 
@@ -22,6 +27,7 @@ type LogExporterType string
 const (
 	LogExporterTypeConsole LogExporterType = "console" // 控制台导出
 	LogExporterTypeOTLP    LogExporterType = "http"    // http导出
+	contextLoaderLogSource                 = "context-loader"
 )
 
 // SamplerLogger 采样logger
@@ -107,87 +113,80 @@ type spanLogger struct {
 }
 
 func (s *spanLogger) Debug(v ...interface{}) {
-	s.maker.DefaultLogger.Debug(v...)
-
-	msg := fmt.Sprint(v...)
+	msg := internalLogMessage(s.ctx, fmt.Sprint(v...))
+	s.maker.DefaultLogger.Debug(msg)
 	if s.ctx != nil {
-		otellog.LogDebug(s.ctx, msg)
+		otellog.LogDebug(s.ctx, msg, contextLogAttributes(s.ctx)...)
 		return
 	}
 	otellog.LogDebug(context.Background(), msg)
 }
 
 func (s *spanLogger) Info(v ...interface{}) {
-	s.maker.DefaultLogger.Info(v...)
-	msg := fmt.Sprint(v...)
+	msg := internalLogMessage(s.ctx, fmt.Sprint(v...))
+	s.maker.DefaultLogger.Info(msg)
 	if s.ctx != nil {
-		otellog.LogInfo(s.ctx, msg)
+		otellog.LogInfo(s.ctx, msg, contextLogAttributes(s.ctx)...)
 		return
 	}
 	otellog.LogInfo(context.Background(), msg)
 }
 
 func (s *spanLogger) Warn(v ...interface{}) {
-	s.maker.DefaultLogger.Warn(v...)
-
-	msg := fmt.Sprint(v...)
+	msg := internalLogMessage(s.ctx, fmt.Sprint(v...))
+	s.maker.DefaultLogger.Warn(msg)
 	if s.ctx != nil {
-		otellog.LogWarn(s.ctx, msg)
+		otellog.LogWarn(s.ctx, msg, contextLogAttributes(s.ctx)...)
 		return
 	}
 	otellog.LogWarn(context.Background(), msg)
 }
 
 func (s *spanLogger) Error(v ...interface{}) {
-	s.maker.DefaultLogger.Error(v...)
-
-	msg := fmt.Sprint(v...)
+	msg := internalLogMessage(s.ctx, fmt.Sprint(v...))
+	s.maker.DefaultLogger.Error(msg)
 	if s.ctx != nil {
-		otellog.LogError(s.ctx, msg, nil)
+		otellog.LogError(s.ctx, msg, nil, contextLogAttributes(s.ctx)...)
 		return
 	}
 	otellog.LogError(context.Background(), msg, nil)
 }
 
 func (s *spanLogger) Debugf(format string, v ...interface{}) {
-	s.maker.DefaultLogger.Debugf(format, v...)
-
-	msg := fmt.Sprintf(format, v...)
+	msg := internalLogMessage(s.ctx, fmt.Sprintf(format, v...))
+	s.maker.DefaultLogger.Debug(msg)
 	if s.ctx != nil {
-		otellog.LogDebug(s.ctx, msg)
+		otellog.LogDebug(s.ctx, msg, contextLogAttributes(s.ctx)...)
 		return
 	}
 	otellog.LogDebug(context.Background(), msg)
 }
 
 func (s *spanLogger) Infof(format string, v ...interface{}) {
-	s.maker.DefaultLogger.Infof(format, v...)
-
-	msg := fmt.Sprintf(format, v...)
+	msg := internalLogMessage(s.ctx, fmt.Sprintf(format, v...))
+	s.maker.DefaultLogger.Info(msg)
 	if s.ctx != nil {
-		otellog.LogInfo(s.ctx, msg)
+		otellog.LogInfo(s.ctx, msg, contextLogAttributes(s.ctx)...)
 		return
 	}
 	otellog.LogInfo(context.Background(), msg)
 }
 
 func (s *spanLogger) Warnf(format string, v ...interface{}) {
-	s.maker.DefaultLogger.Warnf(format, v...)
-
-	msg := fmt.Sprintf(format, v...)
+	msg := internalLogMessage(s.ctx, fmt.Sprintf(format, v...))
+	s.maker.DefaultLogger.Warn(msg)
 	if s.ctx != nil {
-		otellog.LogWarn(s.ctx, msg)
+		otellog.LogWarn(s.ctx, msg, contextLogAttributes(s.ctx)...)
 		return
 	}
 	otellog.LogWarn(context.Background(), msg)
 }
 
 func (s *spanLogger) Errorf(format string, v ...interface{}) {
-	s.maker.DefaultLogger.Errorf(format, v...)
-
-	msg := fmt.Sprintf(format, v...)
+	msg := internalLogMessage(s.ctx, fmt.Sprintf(format, v...))
+	s.maker.DefaultLogger.Error(msg)
 	if s.ctx != nil {
-		otellog.LogError(s.ctx, msg, nil)
+		otellog.LogError(s.ctx, msg, nil, contextLogAttributes(s.ctx)...)
 		return
 	}
 	otellog.LogError(context.Background(), msg, nil)
@@ -196,4 +195,91 @@ func (s *spanLogger) Errorf(format string, v ...interface{}) {
 func (s *spanLogger) WithContext(ctx context.Context) interfaces.Logger {
 	s.ctx = ctx
 	return s
+}
+
+func contextLogAttributes(ctx context.Context) []otellogapi.KeyValue {
+	attrs := []otellogapi.KeyValue{otellogapi.String("schema_version", "1.0.0")}
+	traceContext, hasTraceContext := common.GetTraceContextFromCtx(ctx)
+	if hasTraceContext {
+		attrs = appendNonEmptyLogAttribute(attrs, "tenant_id", traceContext.TenantID)
+		attrs = appendNonEmptyLogAttribute(attrs, "business_domain_id", traceContext.BusinessDomain)
+		attrs = appendNonEmptyLogAttribute(attrs, "request_id", traceContext.RequestID)
+		attrs = appendNonEmptyLogAttribute(attrs, "conversation_id", traceContext.ConversationID)
+		attrs = appendNonEmptyLogAttribute(attrs, "interaction_id", traceContext.InteractionID)
+		attrs = appendNonEmptyLogAttribute(attrs, "operation_id", traceContext.OperationID)
+		attrs = appendNonEmptyLogAttribute(attrs, "tool_name", traceContext.ToolName)
+	}
+	if authContext, ok := common.GetAccountAuthContextFromCtx(ctx); ok && authContext != nil {
+		attrs = appendNonEmptyLogAttribute(attrs, "actor_id", authContext.AccountID)
+		if authContext.AccountType == interfaces.AccessorTypeUser {
+			attrs = appendNonEmptyLogAttribute(attrs, "effective_subject_id", authContext.AccountID)
+		} else {
+			attrs = appendNonEmptyLogAttribute(attrs, "application_id", authContext.AccountID)
+		}
+		if authContext.TokenInfo != nil {
+			attrs = appendNonEmptyLogAttribute(attrs, "application_id", authContext.TokenInfo.ClientID)
+		}
+	}
+	return attrs
+}
+
+func operationLogAttributes(ctx context.Context, failed bool, sourceLogID string) []otellogapi.KeyValue {
+	attrs := contextLogAttributes(ctx)
+	attrs = append(attrs,
+		otellogapi.String("log_id", contextLoaderLogSource+":"+sourceLogID),
+		otellogapi.String("source_id", contextLoaderLogSource),
+		otellogapi.String("source_log_id", sourceLogID),
+		otellogapi.String("trust_level", "trusted"),
+		otellogapi.String("log_category", "runtime.business"),
+		otellogapi.String("ingress_principal", contextLoaderLogSource),
+	)
+	if failed {
+		return append(attrs,
+			otellogapi.String("event_name", "operation.failed"),
+			otellogapi.String("outcome", "failure"),
+			otellogapi.String("safe_summary", "OpenBKN operation failed"),
+		)
+	}
+	return append(attrs,
+		otellogapi.String("event_name", "operation.completed"),
+		otellogapi.String("outcome", "success"),
+		otellogapi.String("safe_summary", "OpenBKN operation completed"),
+	)
+}
+
+// EmitOperationOutcome writes the single governed log record for a durably finalized operation.
+func EmitOperationOutcome(ctx context.Context, failed bool) {
+	sourceLogID := newSourceLogID()
+	attrs := operationLogAttributes(ctx, failed, sourceLogID)
+	if failed {
+		otellog.LogError(ctx, "OpenBKN operation failed", nil, attrs...)
+		return
+	}
+	otellog.LogInfo(ctx, "OpenBKN operation completed", attrs...)
+}
+
+func internalLogMessage(ctx context.Context, original string) string {
+	if ctx == nil {
+		return original
+	}
+	traceContext, ok := common.GetTraceContextFromCtx(ctx)
+	if ok && traceContext.OperationID != "" {
+		return "OpenBKN operation internal detail omitted"
+	}
+	return original
+}
+
+func newSourceLogID() string {
+	var value [16]byte
+	if _, err := rand.Read(value[:]); err == nil {
+		return "log_" + hex.EncodeToString(value[:])
+	}
+	return fmt.Sprintf("log_fallback_%d", time.Now().UnixNano())
+}
+
+func appendNonEmptyLogAttribute(attrs []otellogapi.KeyValue, key, value string) []otellogapi.KeyValue {
+	if value == "" {
+		return attrs
+	}
+	return append(attrs, otellogapi.String(key, value))
 }

--- a/adp/context-loader/agent-retrieval/server/infra/telemetry/log.go
+++ b/adp/context-loader/agent-retrieval/server/infra/telemetry/log.go
@@ -113,8 +113,9 @@ type spanLogger struct {
 }
 
 func (s *spanLogger) Debug(v ...interface{}) {
-	msg := internalLogMessage(s.ctx, fmt.Sprint(v...))
-	s.maker.DefaultLogger.Debug(msg)
+	localMsg := fmt.Sprint(v...)
+	s.maker.DefaultLogger.Debug(localMsg)
+	msg := internalLogMessage(s.ctx, localMsg)
 	if s.ctx != nil {
 		otellog.LogDebug(s.ctx, msg, contextLogAttributes(s.ctx)...)
 		return
@@ -123,8 +124,9 @@ func (s *spanLogger) Debug(v ...interface{}) {
 }
 
 func (s *spanLogger) Info(v ...interface{}) {
-	msg := internalLogMessage(s.ctx, fmt.Sprint(v...))
-	s.maker.DefaultLogger.Info(msg)
+	localMsg := fmt.Sprint(v...)
+	s.maker.DefaultLogger.Info(localMsg)
+	msg := internalLogMessage(s.ctx, localMsg)
 	if s.ctx != nil {
 		otellog.LogInfo(s.ctx, msg, contextLogAttributes(s.ctx)...)
 		return
@@ -133,8 +135,9 @@ func (s *spanLogger) Info(v ...interface{}) {
 }
 
 func (s *spanLogger) Warn(v ...interface{}) {
-	msg := internalLogMessage(s.ctx, fmt.Sprint(v...))
-	s.maker.DefaultLogger.Warn(msg)
+	localMsg := fmt.Sprint(v...)
+	s.maker.DefaultLogger.Warn(localMsg)
+	msg := internalLogMessage(s.ctx, localMsg)
 	if s.ctx != nil {
 		otellog.LogWarn(s.ctx, msg, contextLogAttributes(s.ctx)...)
 		return
@@ -143,8 +146,9 @@ func (s *spanLogger) Warn(v ...interface{}) {
 }
 
 func (s *spanLogger) Error(v ...interface{}) {
-	msg := internalLogMessage(s.ctx, fmt.Sprint(v...))
-	s.maker.DefaultLogger.Error(msg)
+	localMsg := fmt.Sprint(v...)
+	s.maker.DefaultLogger.Error(localMsg)
+	msg := internalLogMessage(s.ctx, localMsg)
 	if s.ctx != nil {
 		otellog.LogError(s.ctx, msg, nil, contextLogAttributes(s.ctx)...)
 		return
@@ -153,8 +157,9 @@ func (s *spanLogger) Error(v ...interface{}) {
 }
 
 func (s *spanLogger) Debugf(format string, v ...interface{}) {
-	msg := internalLogMessage(s.ctx, fmt.Sprintf(format, v...))
-	s.maker.DefaultLogger.Debug(msg)
+	localMsg := fmt.Sprintf(format, v...)
+	s.maker.DefaultLogger.Debug(localMsg)
+	msg := internalLogMessage(s.ctx, localMsg)
 	if s.ctx != nil {
 		otellog.LogDebug(s.ctx, msg, contextLogAttributes(s.ctx)...)
 		return
@@ -163,8 +168,9 @@ func (s *spanLogger) Debugf(format string, v ...interface{}) {
 }
 
 func (s *spanLogger) Infof(format string, v ...interface{}) {
-	msg := internalLogMessage(s.ctx, fmt.Sprintf(format, v...))
-	s.maker.DefaultLogger.Info(msg)
+	localMsg := fmt.Sprintf(format, v...)
+	s.maker.DefaultLogger.Info(localMsg)
+	msg := internalLogMessage(s.ctx, localMsg)
 	if s.ctx != nil {
 		otellog.LogInfo(s.ctx, msg, contextLogAttributes(s.ctx)...)
 		return
@@ -173,8 +179,9 @@ func (s *spanLogger) Infof(format string, v ...interface{}) {
 }
 
 func (s *spanLogger) Warnf(format string, v ...interface{}) {
-	msg := internalLogMessage(s.ctx, fmt.Sprintf(format, v...))
-	s.maker.DefaultLogger.Warn(msg)
+	localMsg := fmt.Sprintf(format, v...)
+	s.maker.DefaultLogger.Warn(localMsg)
+	msg := internalLogMessage(s.ctx, localMsg)
 	if s.ctx != nil {
 		otellog.LogWarn(s.ctx, msg, contextLogAttributes(s.ctx)...)
 		return
@@ -183,8 +190,9 @@ func (s *spanLogger) Warnf(format string, v ...interface{}) {
 }
 
 func (s *spanLogger) Errorf(format string, v ...interface{}) {
-	msg := internalLogMessage(s.ctx, fmt.Sprintf(format, v...))
-	s.maker.DefaultLogger.Error(msg)
+	localMsg := fmt.Sprintf(format, v...)
+	s.maker.DefaultLogger.Error(localMsg)
+	msg := internalLogMessage(s.ctx, localMsg)
 	if s.ctx != nil {
 		otellog.LogError(s.ctx, msg, nil, contextLogAttributes(s.ctx)...)
 		return

--- a/adp/context-loader/agent-retrieval/server/infra/telemetry/log_test.go
+++ b/adp/context-loader/agent-retrieval/server/infra/telemetry/log_test.go
@@ -2,11 +2,26 @@ package telemetry
 
 import (
 	"context"
+	"fmt"
 	"testing"
 
 	"github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/infra/common"
 	"github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/interfaces"
 )
+
+type recordingLogger struct {
+	messages []string
+}
+
+func (l *recordingLogger) Debug(v ...interface{})                        { l.messages = append(l.messages, fmt.Sprint(v...)) }
+func (l *recordingLogger) Info(v ...interface{})                         { l.messages = append(l.messages, fmt.Sprint(v...)) }
+func (l *recordingLogger) Warn(v ...interface{})                         { l.messages = append(l.messages, fmt.Sprint(v...)) }
+func (l *recordingLogger) Error(v ...interface{})                        { l.messages = append(l.messages, fmt.Sprint(v...)) }
+func (l *recordingLogger) Debugf(f string, v ...interface{})             { l.Debug(fmt.Sprintf(f, v...)) }
+func (l *recordingLogger) Infof(f string, v ...interface{})              { l.Info(fmt.Sprintf(f, v...)) }
+func (l *recordingLogger) Warnf(f string, v ...interface{})              { l.Warn(fmt.Sprintf(f, v...)) }
+func (l *recordingLogger) Errorf(f string, v ...interface{})             { l.Error(fmt.Sprintf(f, v...)) }
+func (l *recordingLogger) WithContext(context.Context) interfaces.Logger { return l }
 
 func TestOperationLogAttributesCarryTrustedBusinessOperationScope(t *testing.T) {
 	ctx := common.SetTraceContextToCtx(context.Background(), common.TraceContext{
@@ -78,5 +93,19 @@ func TestInternalLogMessageOmitsGovernedBusinessContent(t *testing.T) {
 	}
 	if got := internalLogMessage(context.Background(), raw); got != raw {
 		t.Fatalf("ungoverned internal message=%q, want original", got)
+	}
+}
+
+func TestSpanLoggerPreservesLocalDiagnosticMessage(t *testing.T) {
+	local := &recordingLogger{}
+	logger := NewSamplerLogger(local).WithContext(common.SetTraceContextToCtx(
+		context.Background(), common.TraceContext{OperationID: "op-1"},
+	))
+	raw := "database query failed: connection refused"
+
+	logger.Error(raw)
+
+	if len(local.messages) != 1 || local.messages[0] != raw {
+		t.Fatalf("local diagnostic message was lost: %#v", local.messages)
 	}
 }

--- a/adp/context-loader/agent-retrieval/server/infra/telemetry/log_test.go
+++ b/adp/context-loader/agent-retrieval/server/infra/telemetry/log_test.go
@@ -1,0 +1,82 @@
+package telemetry
+
+import (
+	"context"
+	"testing"
+
+	"github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/infra/common"
+	"github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/interfaces"
+)
+
+func TestOperationLogAttributesCarryTrustedBusinessOperationScope(t *testing.T) {
+	ctx := common.SetTraceContextToCtx(context.Background(), common.TraceContext{
+		TenantID:       "tenant-local",
+		BusinessDomain: "bd_public",
+		RequestID:      "req_11111111-1111-4111-8111-111111111111",
+		ConversationID: "conv-1",
+		InteractionID:  "int-1",
+		OperationID:    "op-1",
+		ToolName:       "run_sql",
+	})
+	ctx = common.SetAccountAuthContextToCtx(ctx, &interfaces.AccountAuthContext{
+		AccountID:   "user-1",
+		AccountType: interfaces.AccessorTypeUser,
+		TokenInfo:   &interfaces.TokenInfo{ClientID: "third-party-agent"},
+	})
+
+	values := map[string]string{}
+	for _, attr := range operationLogAttributes(ctx, false, "source-log-1") {
+		values[attr.Key] = attr.Value.String()
+	}
+	want := map[string]string{
+		"log_id":               "context-loader:source-log-1",
+		"source_id":            "context-loader",
+		"source_log_id":        "source-log-1",
+		"tenant_id":            "tenant-local",
+		"business_domain_id":   "bd_public",
+		"effective_subject_id": "user-1",
+		"application_id":       "third-party-agent",
+		"request_id":           "req_11111111-1111-4111-8111-111111111111",
+		"conversation_id":      "conv-1",
+		"interaction_id":       "int-1",
+		"operation_id":         "op-1",
+		"tool_name":            "run_sql",
+		"trust_level":          "trusted",
+		"log_category":         "runtime.business",
+		"event_name":           "operation.completed",
+		"outcome":              "success",
+	}
+	for key, expected := range want {
+		if values[key] != expected {
+			t.Fatalf("%s=%q, want %q (all=%v)", key, values[key], expected, values)
+		}
+	}
+}
+
+func TestContextLogAttributesDoNotPretendInternalLinesAreCompletedOperations(t *testing.T) {
+	ctx := common.SetTraceContextToCtx(context.Background(), common.TraceContext{
+		TenantID: "tenant-local", OperationID: "op-1",
+	})
+
+	values := map[string]string{}
+	for _, attr := range contextLogAttributes(ctx) {
+		values[attr.Key] = attr.Value.String()
+	}
+	for _, forbidden := range []string{"log_id", "source_log_id", "trust_level", "log_category", "event_name", "outcome"} {
+		if values[forbidden] != "" {
+			t.Fatalf("internal log unexpectedly carries governed %s=%q", forbidden, values[forbidden])
+		}
+	}
+}
+
+func TestInternalLogMessageOmitsGovernedBusinessContent(t *testing.T) {
+	raw := "[KnSearchLocal] query=6月份有哪些需求预测单？"
+	ctx := common.SetTraceContextToCtx(context.Background(), common.TraceContext{OperationID: "op-1"})
+
+	if got := internalLogMessage(ctx, raw); got != "OpenBKN operation internal detail omitted" {
+		t.Fatalf("governed internal message=%q", got)
+	}
+	if got := internalLogMessage(context.Background(), raw); got != raw {
+		t.Fatalf("ungoverned internal message=%q, want original", got)
+	}
+}

--- a/bkn-trace/agent-observability/charts/agent-observability/templates/deployment.yaml
+++ b/bkn-trace/agent-observability/charts/agent-observability/templates/deployment.yaml
@@ -86,6 +86,8 @@ spec:
             - name: BKN_TRACE_HYDRA_ADMIN_URL
               value: {{ .Values.evidence.queryAuth.hydraAdminURL | quote }}
             {{- end }}
+            - name: BKN_TRACE_DEPLOYMENT_TENANT_ID
+              value: {{ required "evidence.queryAuth.deploymentTenantID is required" .Values.evidence.queryAuth.deploymentTenantID | quote }}
             {{- if .Values.businessResolver.enabled }}
             - name: BKN_TRACE_BKN_RESOLVER_URL
               value: {{ .Values.businessResolver.bknBaseURL | quote }}
@@ -123,6 +125,10 @@ spec:
                   name: {{ .Values.observability.cursorSigning.existingSecret | quote }}
                   key: {{ .Values.observability.cursorSigning.secretKey | quote }}
             {{- end }}
+            - name: BKN_OBSERVABILITY_SOURCE_TIMEOUT
+              value: {{ .Values.observability.sourceTimeout | quote }}
+            - name: BKN_OBSERVABILITY_MAX_CONCURRENT_SOURCES
+              value: {{ .Values.observability.maxConcurrentSources | quote }}
           livenessProbe:
             tcpSocket:
               port: http

--- a/bkn-trace/agent-observability/charts/agent-observability/values.yaml
+++ b/bkn-trace/agent-observability/charts/agent-observability/values.yaml
@@ -58,6 +58,9 @@ evidence:
     existingSecret: ""
     secretKey: token
     hydraAdminURL: http://bkn-safe-hydra-admin:4445
+    # 0.1.3 is deployed as a single tenant. This trusted server-side value is
+    # injected after gateway authentication and never accepted from Studio.
+    deploymentTenantID: openbkn-local
     allowUnauthenticated: false
 
 bknSafe:
@@ -65,12 +68,11 @@ bknSafe:
   accessTimeout: 3s
 
 businessResolver:
-  # Opt in only when the deployment can reach the BKN and Vega authorization-aware APIs.
-  # When disabled, business refs and operation-business edges are returned as empty arrays
-  # and disclosure_partial reports that user-visible business metadata was not resolved.
-  enabled: false
-  bknBaseURL: ""
-  vegaBaseURL: ""
+  # Standard OpenBKN installs resolve technical refs through authorization-aware
+  # internal APIs. Standalone installs may disable this or override the endpoints.
+  enabled: true
+  bknBaseURL: "http://bkn-backend-svc:13014"
+  vegaBaseURL: "http://vega-backend-svc:13014"
   timeout: 3s
 
 observability:
@@ -79,6 +81,8 @@ observability:
   cursorSigning:
     existingSecret: ""
     secretKey: key
+  sourceTimeout: 3s
+  maxConcurrentSources: 4
 
 core:
   # Keep existing trace/evidence reads available after an upgrade. Enable

--- a/bkn-trace/agent-observability/docs/swagger/docs.go
+++ b/bkn-trace/agent-observability/docs/swagger/docs.go
@@ -260,6 +260,295 @@ const docTemplate = `{
                 }
             }
         },
+        "/business-provenance/interactions/{interaction_id}": {
+            "get": {
+                "description": "Aggregates every authorized request and trace in one caller-owned interaction.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "interactions"
+                ],
+                "summary": "Get one observable business interaction",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "BKN interaction ID",
+                        "name": "interaction_id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/evidencevo.InteractionSummary"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/rdto.ErrorResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/rdto.ErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/rdto.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/rdto.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/business-provenance/requests": {
+            "get": {
+                "description": "Returns stable request summaries generated from authorized evidence and artifacts.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "requests"
+                ],
+                "summary": "List observable business requests",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "Page size, 1..200",
+                        "name": "limit",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Opaque pagination cursor",
+                        "name": "cursor",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Caller-owned conversation ID",
+                        "name": "conversation_id",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "One user interaction ID",
+                        "name": "interaction_id",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Started at or after this RFC3339 timestamp",
+                        "name": "from",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Started at or before this RFC3339 timestamp",
+                        "name": "to",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Execution status",
+                        "name": "status",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Agent or application",
+                        "name": "agent_or_app",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Business domain",
+                        "name": "business_domain",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Knowledge network",
+                        "name": "knowledge_network",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Evidence completeness",
+                        "name": "evidence_completeness",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Question, result, ID, business ref, or error keyword",
+                        "name": "keyword",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/evidencevo.RequestSummaryPage"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/rdto.ErrorResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/rdto.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/rdto.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/business-provenance/requests/{request_id}": {
+            "get": {
+                "description": "Returns an authorized request summary and its business-content availability.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "requests"
+                ],
+                "summary": "Get one observable business request",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "BKN request ID",
+                        "name": "request_id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/evidencevo.RequestSummary"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/rdto.ErrorResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/rdto.ErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/rdto.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/rdto.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/business-provenance/requests/{request_id}/traces": {
+            "get": {
+                "description": "Supports one business request to multiple distributed traces and returns request_id on every trace.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "requests"
+                ],
+                "summary": "List technical traces belonging to a business request",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "BKN request ID",
+                        "name": "request_id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "integer",
+                        "description": "Page size, 1..200",
+                        "name": "limit",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Opaque pagination cursor",
+                        "name": "cursor",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Caller-owned conversation ID",
+                        "name": "conversation_id",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "One user interaction ID",
+                        "name": "interaction_id",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/evidencevo.TraceSummaryPage"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/rdto.ErrorResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/rdto.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/rdto.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/conversations": {
             "get": {
                 "produces": [
@@ -2040,77 +2329,6 @@ const docTemplate = `{
                 }
             }
         },
-        "/requests/{request_id}/traces": {
-            "get": {
-                "description": "Supports one business request to multiple distributed traces and returns request_id on every trace.",
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "requests"
-                ],
-                "summary": "List technical traces belonging to a business request",
-                "parameters": [
-                    {
-                        "type": "string",
-                        "description": "BKN request ID",
-                        "name": "request_id",
-                        "in": "path",
-                        "required": true
-                    },
-                    {
-                        "type": "integer",
-                        "description": "Page size, 1..200",
-                        "name": "limit",
-                        "in": "query"
-                    },
-                    {
-                        "type": "string",
-                        "description": "Opaque pagination cursor",
-                        "name": "cursor",
-                        "in": "query"
-                    },
-                    {
-                        "type": "string",
-                        "description": "Caller-owned conversation ID",
-                        "name": "conversation_id",
-                        "in": "query"
-                    },
-                    {
-                        "type": "string",
-                        "description": "One user interaction ID",
-                        "name": "interaction_id",
-                        "in": "query"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "schema": {
-                            "$ref": "#/definitions/evidencevo.TraceSummaryPage"
-                        }
-                    },
-                    "400": {
-                        "description": "Bad Request",
-                        "schema": {
-                            "$ref": "#/definitions/rdto.ErrorResponse"
-                        }
-                    },
-                    "401": {
-                        "description": "Unauthorized",
-                        "schema": {
-                            "$ref": "#/definitions/rdto.ErrorResponse"
-                        }
-                    },
-                    "500": {
-                        "description": "Internal Server Error",
-                        "schema": {
-                            "$ref": "#/definitions/rdto.ErrorResponse"
-                        }
-                    }
-                }
-            }
-        },
         "/trace-executions": {
             "get": {
                 "description": "Returns stable trace summaries with reverse request links, generated from authorized trace evidence.",
@@ -3637,6 +3855,12 @@ const docTemplate = `{
                         "type": "string"
                     }
                 },
+                "operation_id": {
+                    "type": "string"
+                },
+                "operation_key": {
+                    "type": "string"
+                },
                 "partial_reasons": {
                     "type": "array",
                     "items": {
@@ -3656,6 +3880,9 @@ const docTemplate = `{
                     "type": "string"
                 },
                 "status": {
+                    "type": "string"
+                },
+                "tool_name": {
                     "type": "string"
                 },
                 "trace_count": {

--- a/bkn-trace/agent-observability/docs/swagger/swagger.json
+++ b/bkn-trace/agent-observability/docs/swagger/swagger.json
@@ -252,6 +252,295 @@
                 }
             }
         },
+        "/business-provenance/interactions/{interaction_id}": {
+            "get": {
+                "description": "Aggregates every authorized request and trace in one caller-owned interaction.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "interactions"
+                ],
+                "summary": "Get one observable business interaction",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "BKN interaction ID",
+                        "name": "interaction_id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/evidencevo.InteractionSummary"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/rdto.ErrorResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/rdto.ErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/rdto.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/rdto.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/business-provenance/requests": {
+            "get": {
+                "description": "Returns stable request summaries generated from authorized evidence and artifacts.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "requests"
+                ],
+                "summary": "List observable business requests",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "Page size, 1..200",
+                        "name": "limit",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Opaque pagination cursor",
+                        "name": "cursor",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Caller-owned conversation ID",
+                        "name": "conversation_id",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "One user interaction ID",
+                        "name": "interaction_id",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Started at or after this RFC3339 timestamp",
+                        "name": "from",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Started at or before this RFC3339 timestamp",
+                        "name": "to",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Execution status",
+                        "name": "status",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Agent or application",
+                        "name": "agent_or_app",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Business domain",
+                        "name": "business_domain",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Knowledge network",
+                        "name": "knowledge_network",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Evidence completeness",
+                        "name": "evidence_completeness",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Question, result, ID, business ref, or error keyword",
+                        "name": "keyword",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/evidencevo.RequestSummaryPage"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/rdto.ErrorResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/rdto.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/rdto.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/business-provenance/requests/{request_id}": {
+            "get": {
+                "description": "Returns an authorized request summary and its business-content availability.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "requests"
+                ],
+                "summary": "Get one observable business request",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "BKN request ID",
+                        "name": "request_id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/evidencevo.RequestSummary"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/rdto.ErrorResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/rdto.ErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/rdto.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/rdto.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/business-provenance/requests/{request_id}/traces": {
+            "get": {
+                "description": "Supports one business request to multiple distributed traces and returns request_id on every trace.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "requests"
+                ],
+                "summary": "List technical traces belonging to a business request",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "BKN request ID",
+                        "name": "request_id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "integer",
+                        "description": "Page size, 1..200",
+                        "name": "limit",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Opaque pagination cursor",
+                        "name": "cursor",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Caller-owned conversation ID",
+                        "name": "conversation_id",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "One user interaction ID",
+                        "name": "interaction_id",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/evidencevo.TraceSummaryPage"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/rdto.ErrorResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/rdto.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/rdto.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/conversations": {
             "get": {
                 "produces": [
@@ -2032,77 +2321,6 @@
                 }
             }
         },
-        "/requests/{request_id}/traces": {
-            "get": {
-                "description": "Supports one business request to multiple distributed traces and returns request_id on every trace.",
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "requests"
-                ],
-                "summary": "List technical traces belonging to a business request",
-                "parameters": [
-                    {
-                        "type": "string",
-                        "description": "BKN request ID",
-                        "name": "request_id",
-                        "in": "path",
-                        "required": true
-                    },
-                    {
-                        "type": "integer",
-                        "description": "Page size, 1..200",
-                        "name": "limit",
-                        "in": "query"
-                    },
-                    {
-                        "type": "string",
-                        "description": "Opaque pagination cursor",
-                        "name": "cursor",
-                        "in": "query"
-                    },
-                    {
-                        "type": "string",
-                        "description": "Caller-owned conversation ID",
-                        "name": "conversation_id",
-                        "in": "query"
-                    },
-                    {
-                        "type": "string",
-                        "description": "One user interaction ID",
-                        "name": "interaction_id",
-                        "in": "query"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "schema": {
-                            "$ref": "#/definitions/evidencevo.TraceSummaryPage"
-                        }
-                    },
-                    "400": {
-                        "description": "Bad Request",
-                        "schema": {
-                            "$ref": "#/definitions/rdto.ErrorResponse"
-                        }
-                    },
-                    "401": {
-                        "description": "Unauthorized",
-                        "schema": {
-                            "$ref": "#/definitions/rdto.ErrorResponse"
-                        }
-                    },
-                    "500": {
-                        "description": "Internal Server Error",
-                        "schema": {
-                            "$ref": "#/definitions/rdto.ErrorResponse"
-                        }
-                    }
-                }
-            }
-        },
         "/trace-executions": {
             "get": {
                 "description": "Returns stable trace summaries with reverse request links, generated from authorized trace evidence.",
@@ -3629,6 +3847,12 @@
                         "type": "string"
                     }
                 },
+                "operation_id": {
+                    "type": "string"
+                },
+                "operation_key": {
+                    "type": "string"
+                },
                 "partial_reasons": {
                     "type": "array",
                     "items": {
@@ -3648,6 +3872,9 @@
                     "type": "string"
                 },
                 "status": {
+                    "type": "string"
+                },
+                "tool_name": {
                     "type": "string"
                 },
                 "trace_count": {

--- a/bkn-trace/agent-observability/scripts/test_evidence_index_governance.sh
+++ b/bkn-trace/agent-observability/scripts/test_evidence_index_governance.sh
@@ -20,6 +20,21 @@ if grep -Fq "agent-observability-evidence-index-setup" <<<"${default_rendered}";
   echo "evidence index setup job must not render by default" >&2
   exit 1
 fi
+if ! grep -A1 -Fq 'name: BKN_OBSERVABILITY_SOURCE_TIMEOUT
+              value: "3s"' <<<"${default_rendered}"; then
+  echo "observability source timeout must be rendered" >&2
+  exit 1
+fi
+if ! grep -A1 -Fq 'name: BKN_OBSERVABILITY_MAX_CONCURRENT_SOURCES
+              value: "4"' <<<"${default_rendered}"; then
+  echo "observability source concurrency must be rendered" >&2
+  exit 1
+fi
+if ! grep -A1 -Fq 'name: BKN_TRACE_DEPLOYMENT_TENANT_ID
+              value: "openbkn-local"' <<<"${default_rendered}"; then
+  echo "single-tenant deployments must inject the trusted deployment tenant" >&2
+  exit 1
+fi
 
 rendered="$(helm template agent-observability "${chart_dir}" \
   --set evidence.store=opensearch \

--- a/bkn-trace/agent-observability/src/boot/bootstrap.go
+++ b/bkn-trace/agent-observability/src/boot/bootstrap.go
@@ -26,6 +26,7 @@ import (
 	"github.com/openbkn-ai/bkn-foundry/bkn-trace/agent-observability/src/drivenadapter/httpaccess/bknsafeaccess"
 	"github.com/openbkn-ai/bkn-foundry/bkn-trace/agent-observability/src/drivenadapter/httpaccess/bknsafeaudit"
 	"github.com/openbkn-ai/bkn-foundry/bkn-trace/agent-observability/src/drivenadapter/httpaccess/businessresolver"
+	"github.com/openbkn-ai/bkn-foundry/bkn-trace/agent-observability/src/drivenadapter/httpaccess/opensearchcoreprojection"
 	"github.com/openbkn-ai/bkn-foundry/bkn-trace/agent-observability/src/drivenadapter/httpaccess/opensearchevidencestore"
 	"github.com/openbkn-ai/bkn-foundry/bkn-trace/agent-observability/src/drivenadapter/httpaccess/opensearchlogaccess"
 	"github.com/openbkn-ai/bkn-foundry/bkn-trace/agent-observability/src/drivenadapter/httpaccess/opensearchprojection"
@@ -43,6 +44,7 @@ import (
 	"github.com/openbkn-ai/bkn-foundry/bkn-trace/agent-observability/src/port/driven/ievidencestore"
 	"github.com/openbkn-ai/bkn-foundry/bkn-trace/agent-observability/src/port/driven/iprojectionoutbox"
 	"github.com/openbkn-ai/bkn-foundry/bkn-trace/agent-observability/src/port/driven/iprojectionrebuild"
+	"github.com/openbkn-ai/bkn-foundry/bkn-trace/agent-observability/src/port/driven/iprojectionsource"
 	"github.com/openbkn-ai/bkn-foundry/bkn-trace/agent-observability/src/port/driven/isessionstore"
 	httpSwagger "github.com/swaggo/http-swagger/v2"
 )
@@ -82,11 +84,34 @@ func NewApp() (*App, error) {
 	if strings.EqualFold(evidenceConfig.Store, "opensearch") {
 		evidenceStore = opensearchevidencestore.New(openSearchClient, openSearchConfig.EvidenceIndex)
 	}
-	evidenceService := evidencesvc.New(evidenceStore)
 	var resolver ibusinessresolver.BusinessResolverPort
 	if resolverConfig.Enabled {
 		resolver = businessresolver.New(resolverConfig.BKNBaseURL, resolverConfig.VegaBaseURL, &http.Client{Timeout: resolverConfig.Timeout})
+	}
+	coreConfig := conf.NewCoreConfig()
+	metrics := coremetrics.New()
+	sessionStore, ledgerStore, closeDatabase, err := newCoreStores(coreConfig)
+	if err != nil {
+		return nil, err
+	}
+	var summaryProjection iprojectionsource.ProjectionSourcePort
+	if legacyProjection, ok := evidenceStore.(iprojectionsource.ProjectionSourcePort); ok {
+		summaryProjection = legacyProjection
+		if coreConfig.ProjectionEnabled {
+			summaryProjection = opensearchcoreprojection.New(
+				openSearchClient, coreConfig.ProjectionIndex, legacyProjection,
+			)
+		}
+	}
+	var evidenceService *evidencesvc.Service
+	if summaryProjection != nil {
+		evidenceService = evidencesvc.NewWithBusinessResolverAndProjectionSource(
+			evidenceStore, resolver, summaryProjection,
+		)
+	} else if resolver != nil {
 		evidenceService = evidencesvc.NewWithBusinessResolver(evidenceStore, resolver)
+	} else {
+		evidenceService = evidencesvc.New(evidenceStore)
 	}
 	accessScopeConfig := conf.NewAccessScopeConfig()
 	accessScopeResolver := bknsafeaccess.New(
@@ -94,7 +119,7 @@ func NewApp() (*App, error) {
 		&http.Client{Timeout: accessScopeConfig.Timeout},
 	)
 	evidenceHandler := httphandler.NewEvidenceHandlerWithAuthorizationScopeResolver(evidenceService, accessScopeResolver)
-	logHandler := httphandler.NewLogHandler(logsvc.NewWithCursorKey([]logsvc.Source{
+	logHandler := httphandler.NewLogHandler(logsvc.NewWithOptions([]logsvc.Source{
 		opensearchlogaccess.New(openSearchClient, openSearchConfig.LogIndex),
 		bknsafeaudit.New(accessScopeConfig.BKNBaseURL, &http.Client{Timeout: accessScopeConfig.Timeout}),
 		logsvc.NewNotIntegratedSource("bkn-safe-access", []string{
@@ -103,13 +128,11 @@ func NewApp() (*App, error) {
 		logsvc.NewNotIntegratedSource("bkn-safe-security", []string{
 			observabilityvo.CategoryAuditSecurity,
 		}, []string{"BKN Safe Authorization"}),
-	}, observabilityConfig.CursorSigningKey), evidenceHandler)
-	coreConfig := conf.NewCoreConfig()
-	metrics := coremetrics.New()
-	sessionStore, ledgerStore, closeDatabase, err := newCoreStores(coreConfig)
-	if err != nil {
-		return nil, err
-	}
+	}, logsvc.Options{
+		CursorKey:            observabilityConfig.CursorSigningKey,
+		SourceTimeout:        observabilityConfig.SourceTimeout,
+		MaxConcurrentSources: observabilityConfig.MaxConcurrentSources,
+	}), evidenceHandler)
 	sessionService := sessionsvc.New(sessionStore, sessionsvc.Options{
 		EvidenceCollectionState: func() string {
 			if coreConfig.EvidenceCollectionState == "" {
@@ -311,14 +334,11 @@ func newApp(
 		mux.Handle("/metrics", metrics)
 	}
 
-	// readAuth wraps every trace/evidence READ route. In enforce mode it refuses
-	// a caller with no account identity, closing the unauthenticated-read hole
-	// uniformly across all read endpoints — not only the two that additionally
-	// scope by account. In shadow mode it is a pass-through. The evidence WRITE
-	// route (/evidence/events) is excluded: it keeps its own ingest-token guard.
-	readAuthCfg := conf.NewTraceReadAuthzConfig()
+	// Resolve the OAuth or trusted-gateway identity once at the read boundary,
+	// then share the immutable access scope with trace, evidence and log handlers.
+	// The evidence WRITE route keeps its independent ingest-token guard.
 	readAuth := func(h http.HandlerFunc) http.HandlerFunc {
-		return httphandler.RequireReadIdentity(readAuthCfg, h)
+		return evidenceHandler.RequireTrustedQueryIdentity(h)
 	}
 
 	mux.HandleFunc(APIBasePath+"/traces/_search", readAuth(traceHandler.SearchTraces))
@@ -343,8 +363,7 @@ func newApp(
 	mux.HandleFunc(APIBasePath+"/evidence/artifacts", evidenceHandler.IngestEvidenceArtifact)
 	mux.HandleFunc(APIBasePath+"/evidence/artifacts/", readAuth(evidenceHandler.GetEvidenceArtifact))
 	mux.HandleFunc(APIBasePath+"/evidence/by-trace", readAuth(evidenceHandler.SearchEvidenceByTrace))
-	mux.HandleFunc(APIBasePath+"/business-provenance/conversations", readAuth(evidenceHandler.ListBusinessProvenanceConversations))
-	mux.HandleFunc(APIBasePath+"/business-provenance/interactions", readAuth(evidenceHandler.ListBusinessProvenanceInteractions))
+	httphandler.RegisterBusinessProvenanceRoutes(mux, APIBasePath, evidenceHandler, readAuth)
 	mux.HandleFunc(APIBasePath+"/trace-executions", readAuth(evidenceHandler.ListTraceExecutions))
 	mux.HandleFunc(APIBasePath+"/access-profile", readAuth(evidenceHandler.GetAccessProfile))
 	mux.HandleFunc(ObservabilityAPIBasePath+"/logs", readAuth(logHandler.ListLogs))

--- a/bkn-trace/agent-observability/src/conf/observability.go
+++ b/bkn-trace/agent-observability/src/conf/observability.go
@@ -1,13 +1,41 @@
 package conf
 
-import "os"
+import (
+	"log/slog"
+	"os"
+	"strconv"
+	"strings"
+	"time"
+)
 
 type ObservabilityConfig struct {
-	CursorSigningKey []byte
+	CursorSigningKey     []byte
+	SourceTimeout        time.Duration
+	MaxConcurrentSources int
 }
 
 func NewObservabilityConfig() ObservabilityConfig {
+	sourceTimeout := 3 * time.Second
+	if value := strings.TrimSpace(os.Getenv("BKN_OBSERVABILITY_SOURCE_TIMEOUT")); value != "" {
+		configured, err := time.ParseDuration(value)
+		if err != nil || configured <= 0 {
+			slog.Warn("invalid observability source timeout; using default", "value", value, "default", sourceTimeout)
+		} else {
+			sourceTimeout = configured
+		}
+	}
+	maxConcurrentSources := 4
+	if value := strings.TrimSpace(os.Getenv("BKN_OBSERVABILITY_MAX_CONCURRENT_SOURCES")); value != "" {
+		configured, err := strconv.Atoi(value)
+		if err != nil || configured <= 0 {
+			slog.Warn("invalid observability source concurrency; using default", "value", value, "default", maxConcurrentSources)
+		} else {
+			maxConcurrentSources = configured
+		}
+	}
 	return ObservabilityConfig{
-		CursorSigningKey: []byte(os.Getenv("BKN_OBSERVABILITY_CURSOR_SIGNING_KEY")),
+		CursorSigningKey:     []byte(os.Getenv("BKN_OBSERVABILITY_CURSOR_SIGNING_KEY")),
+		SourceTimeout:        sourceTimeout,
+		MaxConcurrentSources: maxConcurrentSources,
 	}
 }

--- a/bkn-trace/agent-observability/src/conf/observability_test.go
+++ b/bkn-trace/agent-observability/src/conf/observability_test.go
@@ -1,11 +1,47 @@
 package conf
 
-import "testing"
+import (
+	"testing"
+	"time"
+)
 
 func TestObservabilityConfigReadsCursorSigningKeyWithoutTransformingIt(t *testing.T) {
 	t.Setenv("BKN_OBSERVABILITY_CURSOR_SIGNING_KEY", "local-test-signing-key")
 	config := NewObservabilityConfig()
 	if string(config.CursorSigningKey) != "local-test-signing-key" {
 		t.Fatalf("unexpected cursor signing key")
+	}
+}
+
+func TestObservabilityConfigUsesBoundedSourceQueryDefaults(t *testing.T) {
+	t.Setenv("BKN_OBSERVABILITY_SOURCE_TIMEOUT", "")
+	t.Setenv("BKN_OBSERVABILITY_MAX_CONCURRENT_SOURCES", "")
+	config := NewObservabilityConfig()
+	if config.SourceTimeout != 3*time.Second {
+		t.Fatalf("unexpected source timeout: %s", config.SourceTimeout)
+	}
+	if config.MaxConcurrentSources != 4 {
+		t.Fatalf("unexpected source concurrency: %d", config.MaxConcurrentSources)
+	}
+}
+
+func TestObservabilityConfigReadsSourceQueryLimits(t *testing.T) {
+	t.Setenv("BKN_OBSERVABILITY_SOURCE_TIMEOUT", "750ms")
+	t.Setenv("BKN_OBSERVABILITY_MAX_CONCURRENT_SOURCES", "2")
+	config := NewObservabilityConfig()
+	if config.SourceTimeout != 750*time.Millisecond {
+		t.Fatalf("unexpected source timeout: %s", config.SourceTimeout)
+	}
+	if config.MaxConcurrentSources != 2 {
+		t.Fatalf("unexpected source concurrency: %d", config.MaxConcurrentSources)
+	}
+}
+
+func TestObservabilityConfigRejectsInvalidSourceQueryLimits(t *testing.T) {
+	t.Setenv("BKN_OBSERVABILITY_SOURCE_TIMEOUT", "forever")
+	t.Setenv("BKN_OBSERVABILITY_MAX_CONCURRENT_SOURCES", "0")
+	config := NewObservabilityConfig()
+	if config.SourceTimeout != 3*time.Second || config.MaxConcurrentSources != 4 {
+		t.Fatalf("invalid values must fall back to defaults: %+v", config)
 	}
 }

--- a/bkn-trace/agent-observability/src/domain/service/evidencesvc/service.go
+++ b/bkn-trace/agent-observability/src/domain/service/evidencesvc/service.go
@@ -248,6 +248,17 @@ func NewWithProjectionSource(store ievidencestore.EvidenceStorePort, projectionS
 	return service
 }
 
+func NewWithBusinessResolverAndProjectionSource(
+	store ievidencestore.EvidenceStorePort,
+	resolver ibusinessresolver.BusinessResolverPort,
+	projectionSource iprojectionsource.ProjectionSourcePort,
+) *Service {
+	service := New(store)
+	service.businessResolver = resolver
+	service.projectionSource = projectionSource
+	return service
+}
+
 func (s *Service) IngestArtifact(ctx context.Context, body []byte) (evidencevo.ArtifactIngestResponse, evidencevo.ValidationErrors, error) {
 	var artifact evidencevo.EvidenceArtifact
 	if err := json.Unmarshal(body, &artifact); err != nil {
@@ -418,7 +429,10 @@ func (s *Service) GetEvidenceChainByRequestID(ctx context.Context, requestID str
 		return evidencevo.EvidenceChainResponse{}, false, err
 	}
 	if len(result.Traces) == 0 {
-		return evidencevo.EvidenceChainResponse{}, false, nil
+		result.Traces, result.Truncated, err = s.projectedRequestTraces(ctx, requestID, options)
+		if err != nil || len(result.Traces) == 0 {
+			return evidencevo.EvidenceChainResponse{}, false, err
+		}
 	}
 	return buildEvidenceChain(result.Traces, result.Truncated), true, nil
 }
@@ -440,7 +454,10 @@ func (s *Service) GetBusinessGraphByRequestID(ctx context.Context, requestID str
 		return evidencevo.BusinessGraphResponse{}, false, err
 	}
 	if len(result.Traces) == 0 {
-		return evidencevo.BusinessGraphResponse{}, false, nil
+		result.Traces, result.Truncated, err = s.projectedRequestTraces(ctx, requestID, options)
+		if err != nil || len(result.Traces) == 0 {
+			return evidencevo.BusinessGraphResponse{}, false, err
+		}
 	}
 	return s.buildBusinessGraph(ctx, result.Traces, result.Truncated, options.Scope), true, nil
 }
@@ -478,9 +495,29 @@ func (s *Service) GetSnapshotPreviewByRequestID(ctx context.Context, requestID s
 		return evidencevo.SnapshotPreviewResponse{}, false, err
 	}
 	if len(result.Traces) == 0 {
-		return evidencevo.SnapshotPreviewResponse{}, false, nil
+		result.Traces, result.Truncated, err = s.projectedRequestTraces(ctx, requestID, options)
+		if err != nil || len(result.Traces) == 0 {
+			return evidencevo.SnapshotPreviewResponse{}, false, err
+		}
 	}
 	return buildSnapshotPreview(result.Traces, result.Truncated), true, nil
+}
+
+func (s *Service) projectedRequestTraces(
+	ctx context.Context,
+	requestID string,
+	options evidencevo.EvidenceQueryOptions,
+) ([]evidencevo.NormalizedTrace, bool, error) {
+	if s.projectionSource == nil {
+		return nil, false, nil
+	}
+	result, err := s.projectionSource.LoadExecutionProjection(ctx, iprojectionsource.Query{
+		Scope: options.Scope, RequestID: strings.TrimSpace(requestID), Limit: MaxEvidenceQueryLimit,
+	})
+	if err != nil {
+		return nil, false, err
+	}
+	return result.Traces, result.Truncated, nil
 }
 
 func buildEvidenceChain(traces []evidencevo.NormalizedTrace, truncated bool) evidencevo.EvidenceChainResponse {
@@ -535,6 +572,8 @@ func buildEvidenceChain(traces []evidencevo.NormalizedTrace, truncated bool) evi
 				}
 				response.Data.BusinessRefs = appendVisibleRefsUnique(response.Data.BusinessRefs, arrayField(event.Payload, "business_refs"), &response.VisibilitySummary, businessRefIDs)
 			case "knowledge.read.observed":
+				response.Data.BusinessRefs = appendVisibleRefsUnique(response.Data.BusinessRefs, arrayField(event.Payload, "business_refs"), &response.VisibilitySummary, businessRefIDs)
+			case "retrieval.completed", "data.query.observed", "logic.execution.observed", "tool.called", "tool.result.observed":
 				response.Data.BusinessRefs = appendVisibleRefsUnique(response.Data.BusinessRefs, arrayField(event.Payload, "business_refs"), &response.VisibilitySummary, businessRefIDs)
 			}
 		}
@@ -806,6 +845,43 @@ func (s *Service) buildBusinessGraph(ctx context.Context, traces []evidencevo.No
 
 	for _, trace := range traces {
 		for _, event := range trace.Events {
+			if isExecutionFact(event.EventType) && event.EventType != "knowledge.read.observed" {
+				refs := arrayField(event.Payload, "business_refs")
+				if len(refs) > 0 {
+					businessRefEvents++
+				}
+				for _, item := range refs {
+					ref, ok := item.(map[string]any)
+					if !ok {
+						partialReasons["business_ref_invalid"] = struct{}{}
+						continue
+					}
+					if !visible(ref) {
+						countVisibility(ref, &response.VisibilitySummary)
+						continue
+					}
+					refID, _ := stringField(ref, "ref_id")
+					if refID == "" {
+						partialReasons["business_ref_id_missing"] = struct{}{}
+						continue
+					}
+					resolution, resolved := resolutions[refID]
+					if _, seen := businessRefs[refID]; !seen {
+						businessRefs[refID] = struct{}{}
+						response.VisibilitySummary.AuthorizedRefCount++
+					}
+					var display *evidencevo.BusinessDisplay
+					if resolved && resolution.Display != nil && resolution.Display.ResolutionStatus == "resolved" {
+						display = resolution.Display
+					} else {
+						partialReasons["resolver_unresolved"] = struct{}{}
+					}
+					addBusinessNode(&response, businessNodes, refID, "", ref, display)
+					if operationNode := eventNodes[event.EventID]; operationNode != "" {
+						appendGraphEdge(&response, edges, &edgeIndex, operationNode, "business:"+refID, "uses_business_ref", visibilityValue(ref))
+					}
+				}
+			}
 			if claimIDs := claimedSourceEvents[event.EventID]; len(claimIDs) > 0 {
 				refs := claimedFactBusinessRefs(event)
 				if len(refs) > 0 {
@@ -987,7 +1063,7 @@ func (s *Service) resolveBusinessRefs(ctx context.Context, traces []evidencevo.N
 	for _, trace := range traces {
 		for _, event := range trace.Events {
 			items := []any{}
-			if event.EventType == "business.refs.resolved" || event.EventType == "knowledge.read.observed" {
+			if event.EventType == "business.refs.resolved" || event.EventType == "knowledge.read.observed" || isExecutionFact(event.EventType) {
 				items = append(items, arrayField(event.Payload, "business_refs")...)
 			}
 			if _, claimed := claimedSourceEvents[event.EventID]; claimed {

--- a/bkn-trace/agent-observability/src/domain/service/evidencesvc/service_test.go
+++ b/bkn-trace/agent-observability/src/domain/service/evidencesvc/service_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/openbkn-ai/bkn-foundry/bkn-trace/agent-observability/src/domain/valueobject/evidencevo"
 	"github.com/openbkn-ai/bkn-foundry/bkn-trace/agent-observability/src/drivenadapter/memoryaccess/evidencestore"
 	"github.com/openbkn-ai/bkn-foundry/bkn-trace/agent-observability/src/port/driven/ibusinessresolver"
+	"github.com/openbkn-ai/bkn-foundry/bkn-trace/agent-observability/src/port/driven/iprojectionsource"
 )
 
 type fakeStore struct {
@@ -1609,6 +1610,75 @@ func TestGetBusinessGraphByRequestIDHandlesHiddenAndUnresolvedRefs(t *testing.T)
 	}
 	if len(response.Data.Nodes) != 2 {
 		t.Fatalf("hidden/unresolved refs must not leak as graph nodes: %+v", response.Data.Nodes)
+	}
+}
+
+func TestGetBusinessGraphByRequestIDFallsBackToAuthorizedProjection(t *testing.T) {
+	trace := businessGraphTraceWithGovernance("trace_graph_projection", "req_graph_projection")
+	source := &capturingProjectionSource{result: iprojectionsource.Result{
+		Traces: []evidencevo.NormalizedTrace{trace},
+	}}
+	service := NewWithProjectionSource(&fakeStore{}, source)
+
+	response, found, err := service.GetBusinessGraphByRequestID(
+		context.Background(),
+		"req_graph_projection",
+		evidencevo.EvidenceQueryOptions{Scope: evidencevo.QueryScope{
+			BusinessDomain: "bd_public", AccountID: "user_1", AccountType: "user",
+		}},
+	)
+
+	if err != nil || !found || len(response.Data.Nodes) == 0 {
+		t.Fatalf("request business graph must recover from the authorized projection: response=%+v found=%v err=%v", response, found, err)
+	}
+	if len(source.queries) != 1 || source.queries[0].RequestID != "req_graph_projection" {
+		t.Fatalf("projection fallback must remain request-scoped: %+v", source.queries)
+	}
+}
+
+func TestReceiptBusinessRefsPopulateEvidenceChainAndBusinessGraph(t *testing.T) {
+	trace := evidencevo.NormalizedTrace{
+		TraceID: "trace_receipt_refs", RequestID: "req_receipt_refs",
+		Events: []evidencevo.EvidenceEvent{{
+			EventID: "receipt:receipt_refs", EventType: "retrieval.completed",
+			InteractionID: "interaction_refs", OperationID: "operation_refs",
+			Payload: map[string]any{
+				"status": "completed",
+				"business_refs": []any{
+					map[string]any{"ref_id": "kn:supplychain_hd0202", "ref_type": "knowledge_network", "visibility": "visible", "version_status": "versioned"},
+					map[string]any{"ref_id": "object:supplychain_hd0202:forecast", "ref_type": "object_type", "visibility": "visible", "version_status": "versioned"},
+				},
+			},
+		}},
+	}
+	source := &capturingProjectionSource{result: iprojectionsource.Result{Traces: []evidencevo.NormalizedTrace{trace}}}
+	resolver := &fakeBusinessResolver{resolutions: []ibusinessresolver.Resolution{
+		{RefID: "kn:supplychain_hd0202", Visibility: "visible", Display: &evidencevo.BusinessDisplay{Name: "HD供应链业务知识网络_v3", ResolutionStatus: "resolved"}},
+		{RefID: "object:supplychain_hd0202:forecast", Visibility: "visible", Display: &evidencevo.BusinessDisplay{Name: "产品需求预测单", ResolutionStatus: "resolved"}},
+	}}
+	service := NewWithBusinessResolverAndProjectionSource(&fakeStore{}, resolver, source)
+	options := evidencevo.EvidenceQueryOptions{Scope: evidencevo.QueryScope{
+		BusinessDomain: "bd_public", AccountID: "user_1", AccountType: "user",
+	}}
+
+	chain, found, err := service.GetEvidenceChainByRequestID(context.Background(), trace.RequestID, options)
+	if err != nil || !found || len(chain.Data.BusinessRefs) != 2 {
+		t.Fatalf("receipt business refs must populate evidence chain: chain=%+v found=%v err=%v", chain, found, err)
+	}
+	graph, found, err := service.GetBusinessGraphByRequestID(context.Background(), trace.RequestID, options)
+	if err != nil || !found {
+		t.Fatalf("query receipt business graph: found=%v err=%v", found, err)
+	}
+	if contains(graph.PartialReasons, "missing_business_refs") {
+		t.Fatalf("governed receipt refs must satisfy business evidence: %+v", graph.PartialReasons)
+	}
+	kn := businessNodeByID(t, graph.Data.Nodes, "business:kn:supplychain_hd0202")
+	if kn.Display == nil || kn.Display.Name != "HD供应链业务知识网络_v3" {
+		t.Fatalf("business resolver display must be used: %+v", kn)
+	}
+	if !graphHasNode(graph.Data.Nodes, "business:object:supplychain_hd0202:forecast") ||
+		!graphHasEdgeType(graph.Data.Edges, "uses_business_ref") {
+		t.Fatalf("receipt refs must be connected to their OpenBKN operation: %+v", graph.Data)
 	}
 }
 

--- a/bkn-trace/agent-observability/src/domain/service/evidencesvc/summary.go
+++ b/bkn-trace/agent-observability/src/domain/service/evidencesvc/summary.go
@@ -346,6 +346,26 @@ func (s *Service) GetRequestSummary(ctx context.Context, requestID string, scope
 	requestID = strings.TrimSpace(requestID)
 	for _, request := range requests {
 		if request.RequestID == requestID {
+			if request.InteractionID != "" &&
+				(request.QuestionPreview == "" || request.ResultPreview == "") &&
+				s.projectionSource != nil {
+				result, projectionErr := s.projectionSource.LoadExecutionProjection(ctx, iprojectionsource.Query{
+					Scope: scope, InteractionID: request.InteractionID, Limit: MaxSummaryScanEntries,
+				})
+				if projectionErr != nil {
+					return evidencevo.RequestSummary{}, false, projectionErr
+				}
+				enrichedRequests, _ := evidencevo.BuildExecutionSummaries(result.Traces, result.Artifacts)
+				for _, enriched := range enrichedRequests {
+					if enriched.RequestID == requestID {
+						request = enrichExactRequestSummary(request, enriched)
+						break
+					}
+				}
+				if result.Truncated {
+					metadata.addReason("projection_scan_cap_reached")
+				}
+			}
 			if metadata.Truncated {
 				request.EvidenceCompleteness = "partial"
 				for _, reason := range metadata.PartialReasons {
@@ -356,6 +376,31 @@ func (s *Service) GetRequestSummary(ctx context.Context, requestID string, scope
 		}
 	}
 	return evidencevo.RequestSummary{}, false, nil
+}
+
+func enrichExactRequestSummary(target, source evidencevo.RequestSummary) evidencevo.RequestSummary {
+	firstNonEmptySummary(&target.QuestionPreview, source.QuestionPreview)
+	firstNonEmptySummary(&target.ResultPreview, source.ResultPreview)
+	firstNonEmptySummary(&target.Initiator, source.Initiator)
+	target.BusinessRefs = sortedSummarySet(summaryStringSet(target.BusinessRefs, source.BusinessRefs))
+	target.KnowledgeNetworks = sortedSummarySet(summaryStringSet(target.KnowledgeNetworks, source.KnowledgeNetworks))
+	if source.EvidenceCompleteness != "" && source.EvidenceCompleteness != "content_unavailable" {
+		target.EvidenceCompleteness = source.EvidenceCompleteness
+		target.PartialReasons = append([]string{}, source.PartialReasons...)
+	}
+	return target
+}
+
+func summaryStringSet(groups ...[]string) map[string]struct{} {
+	result := map[string]struct{}{}
+	for _, group := range groups {
+		for _, value := range group {
+			if value != "" {
+				result[value] = struct{}{}
+			}
+		}
+	}
+	return result
 }
 
 func (s *Service) GetInteractionSummary(
@@ -520,7 +565,9 @@ func (s *Service) loadTraceExecutionSummaries(ctx context.Context, traceID strin
 		metadata.addReason("evidence_query_truncated")
 	}
 	if len(result.Traces) == 0 {
-		return []evidencevo.RequestSummary{}, []evidencevo.TraceSummary{}, metadata, nil
+		return s.loadProjectedExecutionSummaries(ctx, iprojectionsource.Query{
+			Scope: scope, TraceID: traceID, Limit: MaxSummaryScanEntries,
+		}, metadata)
 	}
 	traces := mergeTraceBatches(result.Traces)
 	artifacts := []evidencevo.EvidenceArtifact{}
@@ -602,7 +649,9 @@ func (s *Service) loadRequestExecutionSummaries(ctx context.Context, requestID s
 		metadata.addReason("evidence_query_truncated")
 	}
 	if len(result.Traces) == 0 {
-		return []evidencevo.RequestSummary{}, []evidencevo.TraceSummary{}, metadata, nil
+		return s.loadProjectedExecutionSummaries(ctx, iprojectionsource.Query{
+			Scope: scope, RequestID: requestID, Limit: MaxSummaryScanEntries,
+		}, metadata)
 	}
 	traces := mergeTraceBatches(result.Traces)
 	artifacts := []evidencevo.EvidenceArtifact{}
@@ -621,6 +670,25 @@ func (s *Service) loadRequestExecutionSummaries(ctx context.Context, requestID s
 	}
 	requests, traceSummaries := evidencevo.BuildExecutionSummaries(traces, artifacts)
 	return requests, traceSummaries, metadata, nil
+}
+
+func (s *Service) loadProjectedExecutionSummaries(
+	ctx context.Context,
+	query iprojectionsource.Query,
+	metadata summaryLoadMetadata,
+) ([]evidencevo.RequestSummary, []evidencevo.TraceSummary, summaryLoadMetadata, error) {
+	if s.projectionSource == nil {
+		return []evidencevo.RequestSummary{}, []evidencevo.TraceSummary{}, metadata, nil
+	}
+	result, err := s.projectionSource.LoadExecutionProjection(ctx, query)
+	if err != nil {
+		return nil, nil, summaryLoadMetadata{}, err
+	}
+	if result.Truncated {
+		metadata.addReason("projection_scan_cap_reached")
+	}
+	requests, traces := evidencevo.BuildExecutionSummaries(result.Traces, result.Artifacts)
+	return requests, traces, metadata, nil
 }
 
 func appendUniqueSummaryReason(reasons []string, reason string) []string {

--- a/bkn-trace/agent-observability/src/domain/service/evidencesvc/summary_service_test.go
+++ b/bkn-trace/agent-observability/src/domain/service/evidencesvc/summary_service_test.go
@@ -13,12 +13,16 @@ import (
 )
 
 type capturingProjectionSource struct {
-	result  iprojectionsource.Result
-	queries []iprojectionsource.Query
+	result    iprojectionsource.Result
+	resultFor func(iprojectionsource.Query) iprojectionsource.Result
+	queries   []iprojectionsource.Query
 }
 
 func (s *capturingProjectionSource) LoadExecutionProjection(_ context.Context, query iprojectionsource.Query) (iprojectionsource.Result, error) {
 	s.queries = append(s.queries, query)
+	if s.resultFor != nil {
+		return s.resultFor(query), nil
+	}
 	return s.result, nil
 }
 
@@ -512,6 +516,131 @@ func TestExactRequestSummaryAndTraceLookupDoNotCallListProjection(t *testing.T) 
 	if len(source.queries) != 0 {
 		t.Fatalf("exact request queries must not scan list projection: %+v", source.queries)
 	}
+}
+
+func TestExactRequestSummaryAndTraceLookupFallsBackToReceiptProjection(t *testing.T) {
+	trace := evidencevo.NormalizedTrace{
+		TraceID: "trace_receipt", RequestID: "req_receipt",
+		ConversationID: "conversation_supply_chain",
+		TenantID:       "tenant_demo", BusinessDomain: "bd_demo", AccountID: "acct_demo", AccountType: "app",
+		Events: []evidencevo.EvidenceEvent{{
+			EventID: "receipt:receipt_1", EventType: "retrieval.completed",
+			ObservedAt: "2026-08-02T09:00:00Z", EmittedAt: "2026-08-02T09:00:01Z",
+			RequestID: "req_receipt", TraceID: "trace_receipt", InteractionID: "interaction_july",
+			OperationID: "op_run_sql", OperationName: "run_sql",
+			Payload: map[string]any{
+				"status": "completed", "operation_key": "forecast-data-query",
+			},
+		}},
+	}
+	source := &capturingProjectionSource{result: iprojectionsource.Result{
+		Traces: []evidencevo.NormalizedTrace{trace},
+	}}
+	service := NewWithProjectionSource(evidencestore.New(), source)
+
+	request, found, err := service.GetRequestSummary(context.Background(), "req_receipt", summaryScope("acct_demo"))
+	if err != nil || !found {
+		t.Fatalf("receipt-backed request must support exact lookup: request=%+v found=%v err=%v", request, found, err)
+	}
+	if request.OperationID != "op_run_sql" || request.OperationKey != "forecast-data-query" || request.ToolName != "run_sql" {
+		t.Fatalf("receipt-backed request must preserve operation identity: %+v", request)
+	}
+
+	traces, err := service.ListRequestTraces(context.Background(), "req_receipt", evidencevo.SummaryQueryOptions{
+		Scope: summaryScope("acct_demo"), Limit: 20,
+	})
+	if err != nil || len(traces.Entries) != 1 || traces.Entries[0].TraceID != "trace_receipt" {
+		t.Fatalf("receipt-backed request traces must support exact lookup: traces=%+v err=%v", traces, err)
+	}
+	if len(source.queries) != 3 {
+		t.Fatalf("request detail must query its receipt and interaction context, while trace lookup remains request-scoped: %+v", source.queries)
+	}
+	if source.queries[0].RequestID != "req_receipt" || source.queries[1].InteractionID != "interaction_july" ||
+		source.queries[2].RequestID != "req_receipt" {
+		t.Fatalf("exact fallback must push request or interaction identity: %+v", source.queries)
+	}
+	for _, query := range source.queries {
+		if query.Limit != MaxSummaryScanEntries {
+			t.Fatalf("exact fallback must remain bounded: %+v", query)
+		}
+	}
+}
+
+func TestExactRequestSummaryEnrichesReceiptWithInteractionContent(t *testing.T) {
+	receipt := evidencevo.NormalizedTrace{
+		TraceID: "trace_enriched", RequestID: "req_enriched", ConversationID: "conversation_supply_chain",
+		TenantID: "tenant_demo", BusinessDomain: "bd_demo", AccountID: "acct_demo", AccountType: "app",
+		Events: []evidencevo.EvidenceEvent{{
+			EventID: "receipt:enriched", EventType: "retrieval.completed",
+			ObservedAt: "2026-08-02T09:00:01Z", EmittedAt: "2026-08-02T09:00:02Z",
+			RequestID: "req_enriched", TraceID: "trace_enriched", InteractionID: "interaction_june",
+			OperationID: "op_enriched", OperationName: "run_sql",
+			Payload: map[string]any{"status": "completed", "operation_key": "june-query"},
+		}},
+	}
+	interactionTrace := receipt
+	interactionTrace.Events = append([]evidencevo.EvidenceEvent{
+		{
+			EventID: "question:enriched", EventType: "agent.interaction.started",
+			ObservedAt: "2026-08-02T09:00:00Z", EmittedAt: "2026-08-02T09:00:00Z",
+			RequestID: "req_enriched", TraceID: "trace_enriched", InteractionID: "interaction_june",
+			Payload: map[string]any{"question_artifact_ref": "artifact:question_enriched"},
+		},
+		{
+			EventID: "result:enriched", EventType: "claim.created",
+			ObservedAt: "2026-08-02T09:00:03Z", EmittedAt: "2026-08-02T09:00:03Z",
+			RequestID: "req_enriched", TraceID: "trace_enriched", InteractionID: "interaction_june",
+			Payload: map[string]any{
+				"claim_id": "claim_enriched", "result_artifact_ref": "artifact:result_enriched",
+				"business_refs": []any{map[string]any{"ref_id": "object:kn_demo:forecast"}},
+			},
+		},
+	}, receipt.Events...)
+	question := summaryServiceArtifact(t, "question_enriched", evidencevo.ArtifactTypeQuestion, "req_enriched", "trace_enriched", "interaction_june", "六月预测是多少？")
+	result := summaryServiceArtifact(t, "result_enriched", evidencevo.ArtifactTypeResult, "req_enriched", "trace_enriched", "interaction_june", "合计 11594")
+	source := &capturingProjectionSource{resultFor: func(query iprojectionsource.Query) iprojectionsource.Result {
+		if query.InteractionID == "interaction_june" {
+			return iprojectionsource.Result{Traces: []evidencevo.NormalizedTrace{interactionTrace}, Artifacts: []evidencevo.EvidenceArtifact{question, result}}
+		}
+		return iprojectionsource.Result{Traces: []evidencevo.NormalizedTrace{receipt}}
+	}}
+	service := NewWithProjectionSource(evidencestore.New(), source)
+
+	request, found, err := service.GetRequestSummary(context.Background(), "req_enriched", summaryScope("acct_demo"))
+
+	if err != nil || !found {
+		t.Fatalf("exact request lookup failed: request=%+v found=%v err=%v", request, found, err)
+	}
+	if request.QuestionPreview != "六月预测是多少？" || request.ResultPreview != "合计 11594" ||
+		request.EvidenceCompleteness != "complete" {
+		t.Fatalf("exact request must inherit its interaction content: %+v", request)
+	}
+	if request.StartedAt != "2026-08-02T09:00:01Z" || request.CompletedAt != "2026-08-02T09:00:02Z" || request.DurationMS != 1000 {
+		t.Fatalf("interaction enrichment must not overwrite operation timing: %+v", request)
+	}
+}
+
+func summaryServiceArtifact(
+	t *testing.T,
+	id string,
+	typeName evidencevo.ArtifactType,
+	requestID string,
+	traceID string,
+	interactionID string,
+	text string,
+) evidencevo.EvidenceArtifact {
+	t.Helper()
+	artifact, validationErrors := evidencevo.NormalizeArtifact(evidencevo.EvidenceArtifact{
+		ArtifactID: id, ArtifactType: typeName, RequestID: requestID, TraceID: traceID,
+		InteractionID: interactionID, ContentType: "application/json",
+		SchemaVersion: evidencevo.ArtifactContractVersion, ObservedAt: "2026-08-02T09:00:00Z",
+		Content: map[string]any{"text": text}, BusinessRefs: []string{"object:kn_demo:forecast"},
+		TenantID: "tenant_demo", BusinessDomain: "bd_demo", AccountID: "acct_demo", AccountType: "app",
+	})
+	if len(validationErrors) != 0 {
+		t.Fatalf("normalize summary artifact: %+v", validationErrors)
+	}
+	return artifact
 }
 
 func TestExactTraceExecutionLookupDoesNotCallListProjectionAndReturnsRequest(t *testing.T) {

--- a/bkn-trace/agent-observability/src/domain/service/logsvc/cursor.go
+++ b/bkn-trace/agent-observability/src/domain/service/logsvc/cursor.go
@@ -17,7 +17,7 @@ import (
 
 const (
 	cursorVersion     = "r6.2-v1"
-	cursorSortVersion = "event_timestamp_source_log_desc_v1"
+	cursorSortVersion = "event_timestamp_desc_source_id_source_log_id_asc_v2"
 	cursorTTL         = 15 * time.Minute
 )
 

--- a/bkn-trace/agent-observability/src/domain/service/logsvc/service.go
+++ b/bkn-trace/agent-observability/src/domain/service/logsvc/service.go
@@ -1,10 +1,12 @@
 package logsvc
 
 import (
+	"container/heap"
 	"context"
 	"errors"
 	"sort"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/openbkn-ai/bkn-foundry/bkn-trace/agent-observability/src/domain/valueobject/evidencevo"
@@ -34,21 +36,88 @@ type metadataSource interface {
 }
 
 type Service struct {
-	sources   []Source
-	cursorKey []byte
+	sources              []Source
+	cursorKey            []byte
+	sourceTimeout        time.Duration
+	maxConcurrentSources int
 }
+
+type Options struct {
+	CursorKey            []byte
+	SourceTimeout        time.Duration
+	MaxConcurrentSources int
+}
+
+const (
+	defaultSourceTimeout        = 3 * time.Second
+	defaultMaxConcurrentSources = 4
+)
 
 func New(sources []Source) *Service {
 	return NewWithCursorKey(sources, randomCursorKey())
 }
 
 func NewWithCursorKey(sources []Source, cursorKey []byte) *Service {
-	if len(cursorKey) == 0 {
-		cursorKey = randomCursorKey()
+	return NewWithOptions(sources, Options{CursorKey: cursorKey})
+}
+
+func NewWithOptions(sources []Source, options Options) *Service {
+	if len(options.CursorKey) == 0 {
+		options.CursorKey = randomCursorKey()
+	}
+	if options.SourceTimeout <= 0 {
+		options.SourceTimeout = defaultSourceTimeout
+	}
+	if options.MaxConcurrentSources <= 0 {
+		options.MaxConcurrentSources = defaultMaxConcurrentSources
 	}
 	return &Service{
-		sources: append([]Source(nil), sources...), cursorKey: append([]byte(nil), cursorKey...),
+		sources: append([]Source(nil), sources...), cursorKey: append([]byte(nil), options.CursorKey...),
+		sourceTimeout: options.SourceTimeout, maxConcurrentSources: options.MaxConcurrentSources,
 	}
+}
+
+type sourceSearchResult struct {
+	source Source
+	page   observabilityvo.SourcePage
+	status observabilityvo.SourceStatus
+	err    error
+}
+
+type logCandidate struct {
+	record          observabilityvo.LogRecord
+	adapterSourceID string
+}
+
+type candidateCursor struct {
+	batchIndex  int
+	recordIndex int
+}
+
+type candidateHeap struct {
+	items   []candidateCursor
+	batches [][]logCandidate
+}
+
+func (items candidateHeap) Len() int { return len(items.items) }
+func (items candidateHeap) Less(left, right int) bool {
+	leftCursor, rightCursor := items.items[left], items.items[right]
+	return candidateBefore(
+		items.batches[leftCursor.batchIndex][leftCursor.recordIndex],
+		items.batches[rightCursor.batchIndex][rightCursor.recordIndex],
+	)
+}
+func (items candidateHeap) Swap(left, right int) {
+	items.items[left], items.items[right] = items.items[right], items.items[left]
+}
+func (items *candidateHeap) Push(value any) {
+	items.items = append(items.items, value.(candidateCursor))
+}
+func (items *candidateHeap) Pop() any {
+	last := len(items.items) - 1
+	value := items.items[last]
+	items.items = items.items[:last]
+	return value
 }
 
 func (service *Service) List(
@@ -89,6 +158,13 @@ func (service *Service) List(
 	}
 
 	result := observabilityvo.ListResult{Records: []observabilityvo.LogRecord{}, SourceStatus: []observabilityvo.SourceStatus{}}
+	limit := query.Limit
+	if limit <= 0 {
+		limit = 50
+	}
+	if limit > 200 {
+		limit = 200
+	}
 	sourceQuery := query
 	sourceQuery.Cursor = ""
 	sourceQuery.Limit = 200
@@ -105,39 +181,30 @@ func (service *Service) List(
 	sourceQuery.AuthorizedKnowledgeNetworkIDs = append(
 		[]string(nil), profile.ManagedKnowledgeNetworkIDs...,
 	)
+	sourceQuery.ObservedBefore = &queryWatermark
 	succeeded := 0
 	failed := 0
 	sourcePageSizes := make(map[string]int)
 	sourceCandidates := make(map[string]int)
 	sourceLastRawPosition := make(map[string]observabilityvo.SourcePosition)
-	recordSources := make(map[string]string)
+	candidateBatches := make([][]logCandidate, 0, len(visibleSources))
 	sourceHasMore := false
-	for _, source := range visibleSources {
-		metadata := sourceStatus(source)
-		if metadata.Status == "not_integrated" {
+	for _, sourceResult := range service.searchSources(ctx, visibleSources, sourceQuery, positions) {
+		source := sourceResult.source
+		if sourceResult.status.Status == "not_integrated" {
 			failed++
-			result.SourceStatus = append(result.SourceStatus, metadata)
+			result.SourceStatus = append(result.SourceStatus, sourceResult.status)
 			continue
 		}
 		position, hasPosition := positions[source.ID()]
-		if hasPosition {
-			sourceQuery.PageBefore = &position
-		} else {
-			sourceQuery.PageBefore = nil
-		}
-		page, err := source.Search(ctx, sourceQuery)
-		if err != nil {
+		if sourceResult.err != nil {
 			failed++
-			status := sourceStatus(source)
-			status.Status, status.Reason, status.CountAccuracy = "unavailable", "source_query_failed", "unavailable"
-			result.SourceStatus = append(result.SourceStatus, status)
+			result.SourceStatus = append(result.SourceStatus, sourceResult.status)
 			continue
 		}
 		succeeded++
-		status := sourceStatus(source)
-		status.Status = "healthy"
-		status.CountAccuracy = normalizedAccuracy(page.CountAccuracy)
-		result.SourceStatus = append(result.SourceStatus, status)
+		page := sourceResult.page
+		result.SourceStatus = append(result.SourceStatus, sourceResult.status)
 		sourcePageSizes[source.ID()] = len(page.Records)
 		if len(page.Records) > 0 {
 			sourceLastRawPosition[source.ID()] = positionForRecord(page.Records[len(page.Records)-1])
@@ -145,40 +212,34 @@ func (service *Service) List(
 		if page.NextCursor != "" || page.Count > int64(len(page.Records)) {
 			sourceHasMore = true
 		}
+		candidates := make([]logCandidate, 0, len(page.Records))
 		for _, record := range page.Records {
-			if contains(effectiveCategories, record.Category) && afterSourcePosition(record, sourceQuery.PageBefore) &&
+			var pageBefore *observabilityvo.SourcePosition
+			if hasPosition {
+				pageBefore = &position
+			}
+			if contains(effectiveCategories, record.Category) && afterSourcePosition(record, pageBefore) &&
 				matchesQuery(record, sourceQuery) && canReadLog(profile, capabilities, record, query.IsAssociatedDrilldown()) {
-				result.Records = append(result.Records, record)
-				recordSources[recordKey(record)] = source.ID()
-				sourceCandidates[source.ID()]++
+				candidates = append(candidates, logCandidate{record: record, adapterSourceID: source.ID()})
 			}
 		}
+		sort.SliceStable(candidates, func(left, right int) bool {
+			return candidateBefore(candidates[left], candidates[right])
+		})
+		sourceCandidates[source.ID()] = len(candidates)
+		candidateBatches = append(candidateBatches, candidates)
 	}
 	if succeeded == 0 {
 		return observabilityvo.ListResult{}, ErrSourcesUnavailable
 	}
 
-	sort.SliceStable(result.Records, func(i, j int) bool {
-		if result.Records[i].EventTimestamp.Equal(result.Records[j].EventTimestamp) {
-			leftSource := recordSources[recordKey(result.Records[i])]
-			rightSource := recordSources[recordKey(result.Records[j])]
-			if leftSource == rightSource {
-				return positionID(result.Records[i]) < positionID(result.Records[j])
-			}
-			return leftSource < rightSource
-		}
-		return result.Records[i].EventTimestamp.After(result.Records[j].EventTimestamp)
-	})
-	limit := query.Limit
-	if limit <= 0 {
-		limit = 50
+	merged := mergeCandidates(candidateBatches, limit+1)
+	hasMore := sourceHasMore || len(merged) > limit
+	if len(merged) > limit {
+		merged = merged[:limit]
 	}
-	if limit > 200 {
-		limit = 200
-	}
-	hasMore := sourceHasMore || len(result.Records) > limit
-	if len(result.Records) > limit {
-		result.Records = result.Records[:limit]
+	for _, candidate := range merged {
+		result.Records = append(result.Records, candidate.record)
 	}
 	for _, size := range sourcePageSizes {
 		if size >= sourceQuery.Limit {
@@ -187,10 +248,9 @@ func (service *Service) List(
 	}
 	if hasMore {
 		includedBySource := make(map[string]int)
-		for _, record := range result.Records {
-			sourceID := recordSources[recordKey(record)]
-			positions[sourceID] = positionForRecord(record)
-			includedBySource[sourceID]++
+		for _, candidate := range merged {
+			positions[candidate.adapterSourceID] = positionForRecord(candidate.record)
+			includedBySource[candidate.adapterSourceID]++
 		}
 		for sourceID, rawPosition := range sourceLastRawPosition {
 			if includedBySource[sourceID] == sourceCandidates[sourceID] {
@@ -211,6 +271,102 @@ func (service *Service) List(
 	result.Count = int64(len(result.Records))
 	result.CountExact = !result.Partial && !hasMore
 	return result, nil
+}
+
+func mergeCandidates(batches [][]logCandidate, limit int) []logCandidate {
+	if limit <= 0 {
+		return nil
+	}
+	queue := &candidateHeap{batches: batches, items: make([]candidateCursor, 0, len(batches))}
+	totalCandidates := 0
+	for batchIndex, batch := range batches {
+		if len(batch) > 0 {
+			queue.items = append(queue.items, candidateCursor{batchIndex: batchIndex})
+			totalCandidates += len(batch)
+		}
+	}
+	heap.Init(queue)
+	result := make([]logCandidate, 0, min(limit, totalCandidates))
+	for queue.Len() > 0 && len(result) < limit {
+		cursor := heap.Pop(queue).(candidateCursor)
+		result = append(result, batches[cursor.batchIndex][cursor.recordIndex])
+		cursor.recordIndex++
+		if cursor.recordIndex < len(batches[cursor.batchIndex]) {
+			heap.Push(queue, cursor)
+		}
+	}
+	return result
+}
+
+func candidateBefore(left, right logCandidate) bool {
+	if !left.record.EventTimestamp.Equal(right.record.EventTimestamp) {
+		return left.record.EventTimestamp.After(right.record.EventTimestamp)
+	}
+	if left.record.SourceID != right.record.SourceID {
+		return left.record.SourceID < right.record.SourceID
+	}
+	if positionID(left.record) != positionID(right.record) {
+		return positionID(left.record) < positionID(right.record)
+	}
+	return left.adapterSourceID < right.adapterSourceID
+}
+
+func (service *Service) searchSources(
+	ctx context.Context,
+	sources []Source,
+	query observabilityvo.LogQuery,
+	positions map[string]observabilityvo.SourcePosition,
+) []sourceSearchResult {
+	results := make([]sourceSearchResult, len(sources))
+	semaphore := make(chan struct{}, service.maxConcurrentSources)
+	var waitGroup sync.WaitGroup
+	for index, source := range sources {
+		results[index] = sourceSearchResult{source: source, status: sourceStatus(source)}
+		if results[index].status.Status == "not_integrated" {
+			continue
+		}
+		waitGroup.Add(1)
+		go func(index int, source Source) {
+			defer waitGroup.Done()
+			select {
+			case semaphore <- struct{}{}:
+				defer func() { <-semaphore }()
+			case <-ctx.Done():
+				results[index].err = ctx.Err()
+				results[index].status.Status = "unavailable"
+				results[index].status.Reason = "source_query_failed"
+				results[index].status.CountAccuracy = "unavailable"
+				return
+			}
+			sourceQuery := query
+			if position, ok := positions[source.ID()]; ok {
+				sourceQuery.PageBefore = &position
+			} else {
+				sourceQuery.PageBefore = nil
+			}
+			startedAt := time.Now()
+			sourceContext, cancel := context.WithTimeout(ctx, service.sourceTimeout)
+			defer cancel()
+			page, err := source.Search(sourceContext, sourceQuery)
+			latency := time.Since(startedAt).Milliseconds()
+			results[index].status.LatencyMS = &latency
+			results[index].page = page
+			results[index].err = err
+			if err != nil {
+				results[index].status.Status = "unavailable"
+				results[index].status.Reason = "source_query_failed"
+				if errors.Is(err, context.DeadlineExceeded) && ctx.Err() == nil {
+					results[index].status.Reason = "source_timeout"
+				}
+				results[index].status.CountAccuracy = "unavailable"
+				return
+			}
+			results[index].status.Status = "healthy"
+			results[index].status.CountAccuracy = normalizedAccuracy(page.CountAccuracy)
+		}(index, source)
+	}
+	waitGroup.Wait()
+	return results
 }
 
 func (service *Service) Get(
@@ -289,24 +445,16 @@ func (service *Service) Sources(ctx context.Context, profile evidencevo.AccessPr
 	from := now.Add(-time.Hour)
 	query := observabilityvo.LogQuery{
 		Limit: 1, AuthorizedTenantID: profile.TenantID, AuthorizedBusinessDomain: profile.BusinessDomain,
-		TimeFrom: &from, TimeTo: &now,
+		TimeFrom: &from, TimeTo: &now, ObservedBefore: &now,
 		AuthorizedSubjectID: profile.EffectiveSubjectID, AuthorizedApplicationID: profile.ApplicationPrincipalID,
 		AuthorizedCategories:          append([]string(nil), capabilities.AllowedLogCategories...),
 		AuthorizedKnowledgeNetworkIDs: append([]string(nil), profile.ManagedKnowledgeNetworkIDs...),
 		RequireRecordScope:            hasRole(profile, "network_builder") && !hasRole(profile, "admin", "super_admin"),
 	}
-	for _, source := range visibleSources {
-		status := sourceStatus(source)
-		if status.Status == "not_integrated" {
-			statuses = append(statuses, status)
-			continue
-		}
-		page, err := source.Search(ctx, query)
-		if err != nil {
-			status.Status, status.Reason, status.CountAccuracy = "unavailable", "source_health_check_failed", "unavailable"
-		} else {
-			status.Status = "healthy"
-			status.CountAccuracy = normalizedAccuracy(page.CountAccuracy)
+	for _, result := range service.searchSources(ctx, visibleSources, query, nil) {
+		status := result.status
+		if result.err != nil && status.Reason != "source_timeout" {
+			status.Reason = "source_health_check_failed"
 		}
 		statuses = append(statuses, status)
 	}
@@ -414,7 +562,9 @@ func positionForRecord(record observabilityvo.LogRecord) observabilityvo.SourceP
 		position.SearchAfter = append([]any(nil), record.CursorPosition.SearchAfter...)
 		return position
 	}
-	return observabilityvo.SourcePosition{EventTimestamp: record.EventTimestamp, LogID: positionID(record)}
+	return observabilityvo.SourcePosition{
+		EventTimestamp: record.EventTimestamp, SourceID: record.SourceID, LogID: positionID(record),
+	}
 }
 
 func positionID(record observabilityvo.LogRecord) string {
@@ -422,10 +572,6 @@ func positionID(record observabilityvo.LogRecord) string {
 		return record.SourceLogID
 	}
 	return record.LogID
-}
-
-func recordKey(record observabilityvo.LogRecord) string {
-	return record.SourceID + "\x00" + record.LogID
 }
 
 func applyLogTimeWindow(query *observabilityvo.LogQuery, watermark time.Time) error {
@@ -500,6 +646,7 @@ func validLogProjection(record observabilityvo.LogRecord) bool {
 func matchesQuery(record observabilityvo.LogRecord, query observabilityvo.LogQuery) bool {
 	return (query.TimeFrom == nil || !record.EventTimestamp.Before(*query.TimeFrom)) &&
 		(query.TimeTo == nil || record.EventTimestamp.Before(*query.TimeTo)) &&
+		(query.ObservedBefore == nil || !record.ObservedTimestamp.After(*query.ObservedBefore)) &&
 		matchesOptional(record.TraceID, query.TraceID) && matchesOptional(record.SpanID, query.SpanID) &&
 		matchesOptional(record.RequestID, query.RequestID) && matchesOptional(record.ConversationID, query.ConversationID) &&
 		matchesOptional(record.InteractionID, query.InteractionID) && matchesOptional(record.OperationID, query.OperationID) &&

--- a/bkn-trace/agent-observability/src/domain/service/logsvc/service_test.go
+++ b/bkn-trace/agent-observability/src/domain/service/logsvc/service_test.go
@@ -3,6 +3,7 @@ package logsvc
 import (
 	"context"
 	"errors"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -18,6 +19,45 @@ type fakeSource struct {
 
 type capturingSource struct {
 	query observabilityvo.LogQuery
+}
+
+type blockingSource struct {
+	id      string
+	started chan<- string
+	release <-chan struct{}
+	active  *atomic.Int32
+	peak    *atomic.Int32
+}
+
+func (source *blockingSource) ID() string { return source.id }
+
+func (source *blockingSource) Metadata() observabilityvo.SourceStatus {
+	return observabilityvo.SourceStatus{
+		SourceID: source.id, Status: "healthy", Reliability: "best_effort",
+		Categories: []string{observabilityvo.CategoryRuntimeSystem},
+	}
+}
+
+func (source *blockingSource) Search(ctx context.Context, _ observabilityvo.LogQuery) (observabilityvo.SourcePage, error) {
+	active := source.active.Add(1)
+	defer source.active.Add(-1)
+	for {
+		peak := source.peak.Load()
+		if active <= peak || source.peak.CompareAndSwap(peak, active) {
+			break
+		}
+	}
+	select {
+	case source.started <- source.id:
+	case <-ctx.Done():
+		return observabilityvo.SourcePage{}, ctx.Err()
+	}
+	select {
+	case <-source.release:
+		return observabilityvo.SourcePage{CountAccuracy: "exact"}, nil
+	case <-ctx.Done():
+		return observabilityvo.SourcePage{}, ctx.Err()
+	}
 }
 
 func (source *capturingSource) ID() string { return "capturing" }
@@ -170,6 +210,124 @@ func TestListReportsPartialAndFailsWhenEveryAuthorizedSourceFails(t *testing.T) 
 	}
 }
 
+func TestListQueriesIndependentSourcesConcurrently(t *testing.T) {
+	started := make(chan string, 2)
+	release := make(chan struct{})
+	var active atomic.Int32
+	var peak atomic.Int32
+	service := NewWithOptions([]Source{
+		&blockingSource{id: "source-a", started: started, release: release, active: &active, peak: &peak},
+		&blockingSource{id: "source-b", started: started, release: release, active: &active, peak: &peak},
+	}, Options{CursorKey: []byte("test-cursor-key"), SourceTimeout: time.Second, MaxConcurrentSources: 2})
+
+	done := make(chan error, 1)
+	go func() {
+		_, err := service.List(context.Background(), activeProfile("admin-a", "admin"), observabilityvo.LogQuery{})
+		done <- err
+	}()
+	for index := 0; index < 2; index++ {
+		select {
+		case <-started:
+		case <-time.After(250 * time.Millisecond):
+			close(release)
+			t.Fatal("sources were queried serially")
+		}
+	}
+	close(release)
+	if err := <-done; err != nil {
+		t.Fatalf("concurrent source query failed: %v", err)
+	}
+	if peak.Load() != 2 {
+		t.Fatalf("peak source concurrency = %d, want 2", peak.Load())
+	}
+}
+
+func TestListDoesNotExceedConfiguredSourceConcurrency(t *testing.T) {
+	started := make(chan string, 4)
+	release := make(chan struct{})
+	var active atomic.Int32
+	var peak atomic.Int32
+	sources := make([]Source, 4)
+	for index := range sources {
+		sources[index] = &blockingSource{
+			id: "source-" + time.Duration(index).String(), started: started, release: release,
+			active: &active, peak: &peak,
+		}
+	}
+	service := NewWithOptions(sources, Options{
+		CursorKey: []byte("test-cursor-key"), SourceTimeout: time.Second, MaxConcurrentSources: 2,
+	})
+
+	done := make(chan error, 1)
+	go func() {
+		_, err := service.List(context.Background(), activeProfile("admin-a", "admin"), observabilityvo.LogQuery{})
+		done <- err
+	}()
+	for index := 0; index < 2; index++ {
+		select {
+		case <-started:
+		case <-time.After(250 * time.Millisecond):
+			close(release)
+			t.Fatal("configured source workers did not start")
+		}
+	}
+	select {
+	case sourceID := <-started:
+		close(release)
+		t.Fatalf("source %s exceeded the configured concurrency bound", sourceID)
+	case <-time.After(30 * time.Millisecond):
+	}
+	close(release)
+	if err := <-done; err != nil {
+		t.Fatalf("bounded source query failed: %v", err)
+	}
+	if peak.Load() > 2 {
+		t.Fatalf("peak source concurrency = %d, want at most 2", peak.Load())
+	}
+}
+
+func TestListTimesOutOneSourceAndReturnsTheHealthySource(t *testing.T) {
+	started := make(chan string, 1)
+	release := make(chan struct{})
+	var active atomic.Int32
+	var peak atomic.Int32
+	slow := &blockingSource{id: "slow", started: started, release: release, active: &active, peak: &peak}
+	healthy := categorizedSource{
+		id: "healthy", categories: []string{observabilityvo.CategoryRuntimeSystem},
+		records: []observabilityvo.LogRecord{{
+			LogID: "system-a", Category: observabilityvo.CategoryRuntimeSystem, EventName: "service.started",
+			TenantID: "tenant-a", EventTimestamp: time.Now(), TrustLevel: "trusted", IngressPrincipal: "otel-gateway",
+		}},
+	}
+	service := NewWithOptions([]Source{slow, &healthy}, Options{
+		CursorKey: []byte("test-cursor-key"), SourceTimeout: 20 * time.Millisecond, MaxConcurrentSources: 2,
+	})
+
+	startedAt := time.Now()
+	result, err := service.List(context.Background(), activeProfile("admin-a", "admin"), observabilityvo.LogQuery{})
+	if err != nil {
+		t.Fatalf("healthy source must survive another source timeout: %v", err)
+	}
+	// Keep a coarse wall-clock guard against an unbounded wait. The precise
+	// 20 ms deadline is asserted by the source_timeout status below; a tighter
+	// wall-clock threshold is flaky when the full suite saturates a 4C8G host.
+	if elapsed := time.Since(startedAt); elapsed > time.Second {
+		t.Fatalf("source timeout did not bound request latency: %s", elapsed)
+	}
+	if !result.Partial || len(result.Records) != 1 || len(result.SourceStatus) != 2 {
+		t.Fatalf("timeout partial result is incomplete: %+v", result)
+	}
+	for _, status := range result.SourceStatus {
+		if status.SourceID == "slow" {
+			if status.Status != "unavailable" || status.Reason != "source_timeout" || status.LatencyMS == nil {
+				t.Fatalf("slow source timeout was not disclosed: %+v", status)
+			}
+			return
+		}
+	}
+	t.Fatal("slow source status is missing")
+}
+
 func TestDetailAndFacetsUseTheSameRecordAuthorization(t *testing.T) {
 	owned := ownedBusinessLog("owned", "owner-a", "trace-a")
 	other := ownedBusinessLog("other", "owner-b", "trace-a")
@@ -206,6 +364,30 @@ func TestSourcesAndPoliciesFollowTheAccessProfile(t *testing.T) {
 	}
 	if _, err := service.Policies(activeProfile("user-a", "normal_user")); !errors.Is(err, ErrAccessDenied) {
 		t.Fatalf("normal user policy read must be denied, got %v", err)
+	}
+}
+
+func TestSourcesHealthCheckUsesTheConfiguredSourceTimeout(t *testing.T) {
+	started := make(chan string, 1)
+	release := make(chan struct{})
+	var active atomic.Int32
+	var peak atomic.Int32
+	service := NewWithOptions([]Source{
+		&blockingSource{id: "slow", started: started, release: release, active: &active, peak: &peak},
+		&categorizedSource{id: "healthy", categories: []string{observabilityvo.CategoryRuntimeSystem}},
+	}, Options{CursorKey: []byte("test-cursor-key"), SourceTimeout: 20 * time.Millisecond, MaxConcurrentSources: 2})
+
+	startedAt := time.Now()
+	statuses, err := service.Sources(context.Background(), activeProfile("admin-a", "admin"))
+	if err != nil {
+		t.Fatalf("source health query failed: %v", err)
+	}
+	if elapsed := time.Since(startedAt); elapsed > time.Second {
+		t.Fatalf("source health query was not bounded by its timeout: %s", elapsed)
+	}
+	if len(statuses) != 2 || statuses[0].SourceID != "slow" || statuses[0].Reason != "source_timeout" ||
+		statuses[1].Status != "healthy" {
+		t.Fatalf("source health status is incomplete: %+v", statuses)
 	}
 }
 
@@ -246,6 +428,9 @@ func TestListPushesTrustedAuthorizationScopeToSources(t *testing.T) {
 	}
 	if source.query.TimeFrom == nil || source.query.TimeTo == nil || source.query.TimeTo.Sub(*source.query.TimeFrom) != time.Hour {
 		t.Fatalf("default one-hour window was not frozen: %+v", source.query)
+	}
+	if source.query.ObservedBefore == nil || !source.query.ObservedBefore.Equal(*source.query.TimeTo) {
+		t.Fatalf("query watermark was not pushed to the source: %+v", source.query)
 	}
 }
 
@@ -311,6 +496,28 @@ func TestListExcludesUntrustedUnknownAndCategoryMismatchedRecords(t *testing.T) 
 	}
 	if len(result.Records) != 1 || result.Records[0].LogID != "trusted" {
 		t.Fatalf("quarantined records escaped the query projection: %+v", result.Records)
+	}
+}
+
+func TestListUsesTheContractTieBreakersAcrossSources(t *testing.T) {
+	timestamp := time.Now().UTC().Truncate(time.Second)
+	result, err := New([]Source{
+		fakeSource{id: "adapter-a", records: []observabilityvo.LogRecord{{
+			LogID: "log-z", SourceID: "producer-z", SourceLogID: "log-z",
+			Category: observabilityvo.CategoryRuntimeSystem, EventName: "service.started",
+			TenantID: "tenant-a", EventTimestamp: timestamp, TrustLevel: "trusted", IngressPrincipal: "otel-gateway",
+		}}},
+		fakeSource{id: "adapter-z", records: []observabilityvo.LogRecord{{
+			LogID: "log-a", SourceID: "producer-a", SourceLogID: "log-a",
+			Category: observabilityvo.CategoryRuntimeSystem, EventName: "service.started",
+			TenantID: "tenant-a", EventTimestamp: timestamp, TrustLevel: "trusted", IngressPrincipal: "otel-gateway",
+		}}},
+	}).List(context.Background(), activeProfile("admin-a", "admin"), observabilityvo.LogQuery{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(result.Records) != 2 || result.Records[0].SourceID != "producer-a" || result.Records[1].SourceID != "producer-z" {
+		t.Fatalf("same-timestamp logs must sort by source_id then source_log_id: %+v", result.Records)
 	}
 }
 
@@ -402,6 +609,23 @@ func TestMatchesQueryUsesExclusiveTimeToBoundary(t *testing.T) {
 	}
 }
 
+func TestMatchesQueryExcludesRecordsObservedAfterTheQueryWatermark(t *testing.T) {
+	watermark := time.Date(2026, 8, 1, 11, 0, 0, 0, time.UTC)
+	query := observabilityvo.LogQuery{ObservedBefore: &watermark}
+	if matchesQuery(observabilityvo.LogRecord{
+		EventTimestamp:    watermark.Add(-time.Hour),
+		ObservedTimestamp: watermark.Add(time.Nanosecond),
+	}, query) {
+		t.Fatal("a late-arriving record must not enter a cursor-stable result set")
+	}
+	if !matchesQuery(observabilityvo.LogRecord{
+		EventTimestamp:    watermark.Add(-time.Hour),
+		ObservedTimestamp: watermark,
+	}, query) {
+		t.Fatal("a record observed at the query watermark must remain visible")
+	}
+}
+
 func boolInt(value bool) int {
 	if value {
 		return 1
@@ -466,4 +690,33 @@ func validTestRecord(record observabilityvo.LogRecord) observabilityvo.LogRecord
 		record.Environment = "test"
 	}
 	return record
+}
+
+func BenchmarkListEightSources(b *testing.B) {
+	base := time.Now().UTC().Truncate(time.Second)
+	sources := make([]Source, 8)
+	for sourceIndex := range sources {
+		records := make([]observabilityvo.LogRecord, 200)
+		for recordIndex := range records {
+			records[recordIndex] = validTestRecord(observabilityvo.LogRecord{
+				LogID:    "log-" + time.Duration(sourceIndex*200+recordIndex).String(),
+				SourceID: "source-" + time.Duration(sourceIndex).String(),
+				Category: observabilityvo.CategoryRuntimeSystem, EventName: "service.started",
+				TenantID: "tenant-a", EventTimestamp: base.Add(-time.Duration(recordIndex) * time.Millisecond),
+				TrustLevel: "trusted", IngressPrincipal: "otel-gateway",
+			})
+		}
+		sources[sourceIndex] = fakeSource{id: "source-" + time.Duration(sourceIndex).String(), records: records}
+	}
+	service := NewWithOptions(sources, Options{
+		CursorKey: []byte("benchmark-cursor-key"), SourceTimeout: time.Second, MaxConcurrentSources: 4,
+	})
+	profile := activeProfile("admin-a", "admin")
+	b.ReportAllocs()
+	b.ResetTimer()
+	for index := 0; index < b.N; index++ {
+		if _, err := service.List(context.Background(), profile, observabilityvo.LogQuery{Limit: 200}); err != nil {
+			b.Fatal(err)
+		}
+	}
 }

--- a/bkn-trace/agent-observability/src/domain/valueobject/evidencevo/summary.go
+++ b/bkn-trace/agent-observability/src/domain/valueobject/evidencevo/summary.go
@@ -18,6 +18,9 @@ type ActionSummary struct {
 
 type RequestSummary struct {
 	RequestID            string        `json:"request_id"`
+	OperationID          string        `json:"operation_id,omitempty"`
+	OperationKey         string        `json:"operation_key,omitempty"`
+	ToolName             string        `json:"tool_name,omitempty"`
 	ConversationID       string        `json:"conversation_id,omitempty"`
 	InteractionID        string        `json:"interaction_id,omitempty"`
 	StartedAt            string        `json:"started_at,omitempty"`
@@ -271,6 +274,13 @@ func buildRequestSummary(
 			allTracesTerminal = false
 		}
 		for _, event := range trace.Events {
+			mergeStableIdentity(&summary.OperationID, event.OperationID)
+			if event.OperationID != "" || event.EventType == "retrieval.completed" {
+				mergeStableIdentity(&summary.ToolName, event.OperationName)
+				if operationKey, _ := summaryStringField(event.Payload, "operation_key"); operationKey != "" {
+					mergeStableIdentity(&summary.OperationKey, operationKey)
+				}
+			}
 			collectBusinessRefs(event.Payload, businessRefs)
 			advanceActionSummary(&summary.ActionSummary, event.EventType)
 		}
@@ -289,7 +299,9 @@ func buildRequestSummary(
 		firstNonEmpty(&summary.BusinessDomain, artifact.BusinessDomain)
 		firstNonEmpty(&summary.AgentOrApp, artifact.AgentOrApp)
 		firstNonEmpty(&summary.Initiator, artifact.Initiator)
-		mergeStarted(&started, artifact.ObservedAt)
+		if started.IsZero() {
+			mergeStarted(&started, artifact.ObservedAt)
+		}
 		for _, ref := range artifact.BusinessRefs {
 			if ref != "" {
 				businessRefs[ref] = struct{}{}
@@ -306,7 +318,9 @@ func buildRequestSummary(
 				summary.ResultPreview = preview
 				hasResult = true
 			}
-			mergeCompleted(&completed, artifact.ObservedAt)
+			if completed.IsZero() {
+				mergeCompleted(&completed, artifact.ObservedAt)
+			}
 		default:
 			hasSupportingEvidence = true
 		}
@@ -374,6 +388,15 @@ func buildRequestSummary(
 	if summary.InteractionID == "-" {
 		summary.InteractionID = ""
 	}
+	if summary.OperationID == "-" {
+		summary.OperationID = ""
+	}
+	if summary.OperationKey == "-" {
+		summary.OperationKey = ""
+	}
+	if summary.ToolName == "-" {
+		summary.ToolName = ""
+	}
 	return summary, traceSummaries
 }
 
@@ -395,8 +418,15 @@ func buildTraceSummary(trace NormalizedTrace, artifacts []EvidenceArtifact) Trac
 			}
 			firstNonEmpty(&summary.RootOperation, event.OperationName)
 		}
+		if event.EventType == "retrieval.completed" {
+			firstNonEmpty(&summary.RootOperation, event.OperationName)
+			firstNonEmpty(&summary.AgentOrApp, event.Producer)
+		}
 		if event.SpanID != "" {
 			spans[event.SpanID] = struct{}{}
+		}
+		if strings.HasPrefix(event.EventID, "artifact-link:") {
+			continue
 		}
 		mergeStarted(&started, event.ObservedAt)
 		if eventHasError(event) {
@@ -416,7 +446,9 @@ func buildTraceSummary(trace NormalizedTrace, artifacts []EvidenceArtifact) Trac
 			if summary.Status != "error" {
 				summary.Status = "completed"
 			}
-			mergeCompleted(&completed, artifact.ObservedAt)
+			if completed.IsZero() {
+				mergeCompleted(&completed, artifact.ObservedAt)
+			}
 		}
 	}
 	summary.SpanCount = len(spans)

--- a/bkn-trace/agent-observability/src/domain/valueobject/evidencevo/summary_test.go
+++ b/bkn-trace/agent-observability/src/domain/valueobject/evidencevo/summary_test.go
@@ -240,6 +240,45 @@ func TestBuildExecutionSummariesUsesOnlyArtifactsExplicitlyReferencedByEvents(t 
 	}
 }
 
+func TestBuildExecutionSummariesKeepsOperationTimingSeparateFromInteractionArtifacts(t *testing.T) {
+	trace := NormalizedTrace{
+		TraceID: "trace_operation_timing", RequestID: "req_operation_timing",
+		TenantID: "tenant_demo", BusinessDomain: "bd_demo", AccountID: "acct_demo", AccountType: "app",
+		SchemaVersion: ArtifactContractVersion,
+		Events: []EvidenceEvent{
+			{
+				EventID: "event_question_link", EventType: "agent.interaction.started",
+				ObservedAt: "2026-08-02T09:00:01Z", EmittedAt: "2026-08-02T09:00:01Z",
+				TraceID: "trace_operation_timing", RequestID: "req_operation_timing",
+				Payload: map[string]any{"question_artifact_ref": "artifact:question_operation_timing"},
+			},
+			{
+				EventID: "event_result_link", EventType: "claim.created",
+				ObservedAt: "2026-08-02T09:00:02Z", EmittedAt: "2026-08-02T09:00:02Z",
+				TraceID: "trace_operation_timing", RequestID: "req_operation_timing",
+				Payload: map[string]any{
+					"claim_id":            "claim_operation_timing",
+					"result_artifact_ref": "artifact:result_operation_timing",
+					"business_refs":       []any{map[string]any{"ref_id": "object:kn_demo:forecast"}},
+				},
+			},
+		},
+	}
+	question := summaryArtifact(t, "question_operation_timing", ArtifactTypeQuestion, trace.TraceID, map[string]any{"text": "六月预测是多少？"})
+	question.RequestID = trace.RequestID
+	question.ObservedAt = "2026-08-02T09:00:00Z"
+	result := summaryArtifact(t, "result_operation_timing", ArtifactTypeResult, trace.TraceID, map[string]any{"text": "合计 11594"})
+	result.RequestID = trace.RequestID
+	result.ObservedAt = "2026-08-02T09:00:03Z"
+
+	requests, _ := BuildExecutionSummaries([]NormalizedTrace{trace}, []EvidenceArtifact{question, result})
+
+	if len(requests) != 1 || requests[0].StartedAt != "2026-08-02T09:00:01Z" ||
+		requests[0].CompletedAt != "2026-08-02T09:00:02Z" || requests[0].DurationMS != 1000 {
+		t.Fatalf("operation timing must come from execution events, not interaction artifacts: %+v", requests)
+	}
+}
+
 func TestSummaryCollectionEnvelopeUsesEntriesAndEmptyArray(t *testing.T) {
 	body, err := json.Marshal(RequestSummaryPage{Entries: []RequestSummary{}, Total: 0})
 	if err != nil {

--- a/bkn-trace/agent-observability/src/domain/valueobject/observabilityvo/log.go
+++ b/bkn-trace/agent-observability/src/domain/valueobject/observabilityvo/log.go
@@ -36,6 +36,7 @@ type LogRecord struct {
 	ConversationID      string          `json:"conversation_id,omitempty"`
 	InteractionID       string          `json:"interaction_id,omitempty"`
 	OperationID         string          `json:"operation_id,omitempty"`
+	ToolName            string          `json:"tool_name,omitempty"`
 	ResourceRef         *ResourceRef    `json:"resource_ref,omitempty"`
 	ArtifactRef         string          `json:"artifact_ref,omitempty"`
 	Attributes          map[string]any  `json:"attributes,omitempty"`
@@ -78,6 +79,7 @@ type LogQuery struct {
 	AuthorizedKnowledgeNetworkIDs []string
 	RequireRecordScope            bool
 	PageBefore                    *SourcePosition
+	ObservedBefore                *time.Time
 }
 
 func (query LogQuery) IsAssociatedDrilldown() bool {
@@ -97,6 +99,7 @@ type SourcePage struct {
 // as a strict keyset boundary; it is never accepted directly from callers.
 type SourcePosition struct {
 	EventTimestamp time.Time `json:"event_timestamp"`
+	SourceID       string    `json:"source_id,omitempty"`
 	LogID          string    `json:"log_id"`
 	SearchAfter    []any     `json:"search_after,omitempty"`
 }

--- a/bkn-trace/agent-observability/src/drivenadapter/httpaccess/opensearchcoreprojection/source.go
+++ b/bkn-trace/agent-observability/src/drivenadapter/httpaccess/opensearchcoreprojection/source.go
@@ -104,7 +104,7 @@ func (s *Source) loadReceipts(ctx context.Context, query iprojectionsource.Query
 		"interaction_id":           query.InteractionID,
 	} {
 		if value != "" {
-			must = append(must, map[string]any{"match_phrase": map[string]any{field: value}})
+			must = append(must, exactTermQuery(field, value))
 		}
 	}
 	if !query.From.IsZero() || !query.To.IsZero() {
@@ -146,6 +146,18 @@ func (s *Source) loadReceipts(ctx context.Context, query iprojectionsource.Query
 		}
 	}
 	return result, len(response.Hits.Hits) >= size, nil
+}
+
+func exactTermQuery(field string, value string) map[string]any {
+	return map[string]any{
+		"bool": map[string]any{
+			"should": []map[string]any{
+				{"term": map[string]any{field: map[string]any{"value": value}}},
+				{"term": map[string]any{field + ".keyword": map[string]any{"value": value}}},
+			},
+			"minimum_should_match": 1,
+		},
+	}
 }
 
 func receiptMatchesScope(receipt receiptDocument, scope evidencevo.QueryScope) bool {

--- a/bkn-trace/agent-observability/src/drivenadapter/httpaccess/opensearchcoreprojection/source.go
+++ b/bkn-trace/agent-observability/src/drivenadapter/httpaccess/opensearchcoreprojection/source.go
@@ -1,0 +1,311 @@
+package opensearchcoreprojection
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/openbkn-ai/bkn-foundry/bkn-trace/agent-observability/src/domain/valueobject/evidencevo"
+	"github.com/openbkn-ai/bkn-foundry/bkn-trace/agent-observability/src/domain/valueobject/sessionvo"
+	"github.com/openbkn-ai/bkn-foundry/bkn-trace/agent-observability/src/infra/opensearch"
+	"github.com/openbkn-ai/bkn-foundry/bkn-trace/agent-observability/src/port/driven/iprojectionsource"
+)
+
+const maxProjectionDocuments = 10000
+
+type Source struct {
+	client    *opensearch.Client
+	index     string
+	artifacts iprojectionsource.ProjectionSourcePort
+}
+
+func New(client *opensearch.Client, index string, artifacts iprojectionsource.ProjectionSourcePort) *Source {
+	return &Source{client: client, index: index, artifacts: artifacts}
+}
+
+type receiptDocument struct {
+	ReceiptID          string                  `json:"receipt_id"`
+	SchemaVersion      string                  `json:"schema_version"`
+	Owner              sessionvo.Owner         `json:"owner"`
+	ConversationID     string                  `json:"conversation_id"`
+	InteractionID      string                  `json:"interaction_id"`
+	OperationID        string                  `json:"operation_id"`
+	OperationKey       string                  `json:"operation_key"`
+	ToolName           string                  `json:"tool_name"`
+	Status             string                  `json:"receipt_status"`
+	EvidenceDurability string                  `json:"evidence_durability"`
+	RequestID          string                  `json:"request_id"`
+	TraceID            string                  `json:"trace_id"`
+	BusinessRefs       []sessionvo.BusinessRef `json:"business_refs"`
+	ArtifactRefs       []string                `json:"artifact_refs"`
+	PartialReasons     []string                `json:"partial_reasons"`
+	IssuedAt           string                  `json:"issued_at"`
+	TerminalAt         string                  `json:"terminal_at"`
+}
+
+func (s *Source) LoadExecutionProjection(ctx context.Context, query iprojectionsource.Query) (iprojectionsource.Result, error) {
+	receipts, truncated, err := s.loadReceipts(ctx, query)
+	if err != nil {
+		return iprojectionsource.Result{}, err
+	}
+	artifactResult := iprojectionsource.Result{}
+	if s.artifacts != nil {
+		artifactQuery := query
+		if query.RequestID != "" {
+			if interactionID := stableReceiptInteraction(receipts); interactionID != "" {
+				artifactQuery.RequestID = ""
+				artifactQuery.InteractionID = interactionID
+			}
+		}
+		artifactResult, err = s.artifacts.LoadExecutionProjection(ctx, artifactQuery)
+		if err != nil {
+			return iprojectionsource.Result{}, err
+		}
+	}
+	traces := tracesFromReceipts(receipts)
+	artifacts := artifactsForTraces(artifactResult.Artifacts, traces)
+	attachArtifactEvents(traces, artifacts)
+	return iprojectionsource.Result{
+		Traces: traces, Artifacts: artifacts,
+		Truncated: truncated || artifactResult.Truncated,
+	}, nil
+}
+
+func stableReceiptInteraction(receipts []receiptDocument) string {
+	interactionID := ""
+	for _, receipt := range receipts {
+		if receipt.InteractionID == "" {
+			continue
+		}
+		if interactionID == "" {
+			interactionID = receipt.InteractionID
+			continue
+		}
+		if interactionID != receipt.InteractionID {
+			return ""
+		}
+	}
+	return interactionID
+}
+
+func (s *Source) loadReceipts(ctx context.Context, query iprojectionsource.Query) ([]receiptDocument, bool, error) {
+	size := maxProjectionDocuments
+	if query.Limit > 0 && query.Limit*20+1 < size {
+		size = query.Limit*20 + 1
+	}
+	must := []map[string]any{{"exists": map[string]any{"field": "receipt_id"}}}
+	for field, value := range map[string]string{
+		"owner.tenant_id":          query.Scope.TenantID,
+		"owner.business_domain_id": firstNonEmpty(query.BusinessDomain, query.Scope.BusinessDomain),
+		"request_id":               query.RequestID,
+		"trace_id":                 query.TraceID,
+		"interaction_id":           query.InteractionID,
+	} {
+		if value != "" {
+			must = append(must, map[string]any{"match_phrase": map[string]any{field: value}})
+		}
+	}
+	if !query.From.IsZero() || !query.To.IsZero() {
+		bounds := map[string]any{}
+		if !query.From.IsZero() {
+			bounds["gte"] = query.From
+		}
+		if !query.To.IsZero() {
+			bounds["lte"] = query.To
+		}
+		must = append(must, map[string]any{"range": map[string]any{"issued_at": bounds}})
+	}
+	body, err := json.Marshal(map[string]any{
+		"size":  size,
+		"query": map[string]any{"bool": map[string]any{"must": must}},
+		"sort":  []map[string]any{{"issued_at": map[string]any{"order": "desc"}}, {"_id": map[string]any{"order": "desc"}}},
+	})
+	if err != nil {
+		return nil, false, err
+	}
+	responseBody, err := s.client.Search(ctx, s.index, body)
+	if err != nil {
+		return nil, false, err
+	}
+	var response struct {
+		Hits struct {
+			Hits []struct {
+				Source receiptDocument `json:"_source"`
+			} `json:"hits"`
+		} `json:"hits"`
+	}
+	if err := json.Unmarshal(responseBody, &response); err != nil {
+		return nil, false, fmt.Errorf("decode Core receipt projection: %w", err)
+	}
+	result := make([]receiptDocument, 0, len(response.Hits.Hits))
+	for _, hit := range response.Hits.Hits {
+		if receiptMatchesScope(hit.Source, query.Scope) {
+			result = append(result, hit.Source)
+		}
+	}
+	return result, len(response.Hits.Hits) >= size, nil
+}
+
+func receiptMatchesScope(receipt receiptDocument, scope evidencevo.QueryScope) bool {
+	networks := knowledgeNetworks(receipt.BusinessRefs)
+	record := evidencevo.RecordScope{
+		TenantID: receipt.Owner.TenantID, BusinessDomain: receipt.Owner.BusinessDomainID,
+		EffectiveSubjectID:     receipt.Owner.EffectiveSubjectID,
+		ApplicationPrincipalID: receipt.Owner.ApplicationPrincipalID,
+		KnowledgeNetworkIDs:    networks,
+	}
+	if scope.AccessProfile != nil {
+		return evidencevo.CanReadRecord(*scope.AccessProfile, record, evidencevo.AccessViewBusiness)
+	}
+	return receipt.Owner.TenantID == scope.TenantID &&
+		receipt.Owner.BusinessDomainID == scope.BusinessDomain &&
+		string(receipt.Owner.EffectiveSubjectType) == scope.AccountType &&
+		receipt.Owner.EffectiveSubjectID == scope.AccountID
+}
+
+func tracesFromReceipts(receipts []receiptDocument) []evidencevo.NormalizedTrace {
+	byTrace := map[string]*evidencevo.NormalizedTrace{}
+	for _, receipt := range receipts {
+		if receipt.RequestID == "" || receipt.TraceID == "" {
+			continue
+		}
+		trace := byTrace[receipt.TraceID]
+		if trace == nil {
+			value := evidencevo.NormalizedTrace{
+				TraceID: receipt.TraceID, RequestID: receipt.RequestID,
+				ConversationID: receipt.ConversationID, TenantID: receipt.Owner.TenantID,
+				BusinessDomain:         receipt.Owner.BusinessDomainID,
+				AccountID:              receipt.Owner.EffectiveSubjectID,
+				AccountType:            string(receipt.Owner.EffectiveSubjectType),
+				EffectiveSubjectID:     receipt.Owner.EffectiveSubjectID,
+				ApplicationPrincipalID: receipt.Owner.ApplicationPrincipalID,
+				KnowledgeNetworkIDs:    knowledgeNetworks(receipt.BusinessRefs),
+				SchemaVersion:          receipt.SchemaVersion,
+			}
+			trace = &value
+			byTrace[receipt.TraceID] = trace
+		}
+		businessRefs := make([]any, 0, len(receipt.BusinessRefs))
+		for _, ref := range receipt.BusinessRefs {
+			businessRefs = append(businessRefs, map[string]any{
+				"ref_id": ref.RefID, "ref_type": ref.RefType, "visibility": "visible",
+			})
+		}
+		terminalAt := firstNonEmpty(receipt.TerminalAt, receipt.IssuedAt)
+		trace.Events = append(trace.Events, evidencevo.EvidenceEvent{
+			EventID: "receipt:" + receipt.ReceiptID, EventType: "retrieval.completed",
+			SchemaVersion: receipt.SchemaVersion, ObservedAt: receipt.IssuedAt, EmittedAt: terminalAt,
+			Producer: receipt.Owner.ApplicationPrincipalID, TraceID: receipt.TraceID,
+			RequestID: receipt.RequestID, OperationName: receipt.ToolName,
+			InteractionID: receipt.InteractionID, OperationID: receipt.OperationID,
+			Payload: map[string]any{
+				"status": receipt.Status, "evidence_durability": receipt.EvidenceDurability,
+				"operation_key": receipt.OperationKey,
+				"business_refs": businessRefs, "partial_reasons": receipt.PartialReasons,
+			},
+		})
+	}
+	result := make([]evidencevo.NormalizedTrace, 0, len(byTrace))
+	for _, trace := range byTrace {
+		sort.Slice(trace.Events, func(i, j int) bool { return trace.Events[i].ObservedAt < trace.Events[j].ObservedAt })
+		result = append(result, *trace)
+	}
+	sort.Slice(result, func(i, j int) bool { return result[i].TraceID < result[j].TraceID })
+	return result
+}
+
+func artifactsForTraces(artifacts []evidencevo.EvidenceArtifact, traces []evidencevo.NormalizedTrace) []evidencevo.EvidenceArtifact {
+	requests := map[string]struct{}{}
+	interactions := map[string][]evidencevo.NormalizedTrace{}
+	for _, trace := range traces {
+		requests[trace.RequestID] = struct{}{}
+		for _, event := range trace.Events {
+			if event.InteractionID != "" {
+				interactions[event.InteractionID] = append(interactions[event.InteractionID], trace)
+			}
+		}
+	}
+	result := make([]evidencevo.EvidenceArtifact, 0)
+	for _, artifact := range artifacts {
+		if _, ok := requests[artifact.RequestID]; ok {
+			result = append(result, artifact)
+			continue
+		}
+		for _, trace := range interactions[artifact.InteractionID] {
+			projected := artifact
+			projected.RequestID = trace.RequestID
+			projected.TraceID = trace.TraceID
+			result = append(result, projected)
+		}
+	}
+	return result
+}
+
+func attachArtifactEvents(traces []evidencevo.NormalizedTrace, artifacts []evidencevo.EvidenceArtifact) {
+	byTrace := map[string]*evidencevo.NormalizedTrace{}
+	for index := range traces {
+		byTrace[traces[index].TraceID] = &traces[index]
+	}
+	for _, artifact := range artifacts {
+		trace := byTrace[artifact.TraceID]
+		if trace == nil || artifact.InteractionID == "" {
+			continue
+		}
+		eventType, field := artifactLink(artifact.ArtifactType)
+		if eventType == "" {
+			continue
+		}
+		trace.Events = append(trace.Events, evidencevo.EvidenceEvent{
+			EventID: "artifact-link:" + artifact.ArtifactID, EventType: eventType,
+			SchemaVersion: artifact.SchemaVersion, ObservedAt: artifact.ObservedAt,
+			EmittedAt: artifact.ObservedAt, Producer: artifact.AgentOrApp,
+			TraceID: artifact.TraceID, RequestID: artifact.RequestID,
+			InteractionID: artifact.InteractionID, OperationID: artifact.OperationID,
+			Payload: map[string]any{field: "artifact:" + artifact.ArtifactID},
+		})
+	}
+}
+
+func artifactLink(artifactType evidencevo.ArtifactType) (string, string) {
+	switch artifactType {
+	case evidencevo.ArtifactTypeQuestion:
+		return "agent.interaction.started", "question_artifact_ref"
+	case evidencevo.ArtifactTypeResult:
+		return "claim.created", "result_artifact_ref"
+	case evidencevo.ArtifactTypeDataResult:
+		return "data.query.observed", "result_artifact_ref"
+	case evidencevo.ArtifactTypeLogicExecution:
+		return "logic.execution.observed", "result_artifact_ref"
+	case evidencevo.ArtifactTypeActionResult:
+		return "action.result_recorded", "result_artifact_ref"
+	default:
+		return "", ""
+	}
+}
+
+func knowledgeNetworks(refs []sessionvo.BusinessRef) []string {
+	set := map[string]struct{}{}
+	for _, ref := range refs {
+		parts := strings.Split(ref.RefID, ":")
+		if len(parts) >= 2 && parts[1] != "" && parts[0] != "resource" {
+			set[parts[1]] = struct{}{}
+		}
+	}
+	result := make([]string, 0, len(set))
+	for value := range set {
+		result = append(result, value)
+	}
+	sort.Strings(result)
+	return result
+}
+
+func firstNonEmpty(values ...string) string {
+	for _, value := range values {
+		if value != "" {
+			return value
+		}
+	}
+	return ""
+}

--- a/bkn-trace/agent-observability/src/drivenadapter/httpaccess/opensearchcoreprojection/source_test.go
+++ b/bkn-trace/agent-observability/src/drivenadapter/httpaccess/opensearchcoreprojection/source_test.go
@@ -1,0 +1,177 @@
+package opensearchcoreprojection_test
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/openbkn-ai/bkn-foundry/bkn-trace/agent-observability/src/domain/valueobject/evidencevo"
+	"github.com/openbkn-ai/bkn-foundry/bkn-trace/agent-observability/src/drivenadapter/httpaccess/opensearchcoreprojection"
+	"github.com/openbkn-ai/bkn-foundry/bkn-trace/agent-observability/src/infra/opensearch"
+	"github.com/openbkn-ai/bkn-foundry/bkn-trace/agent-observability/src/port/driven/iprojectionsource"
+)
+
+func TestSourceBuildsAuthorizedExecutionProjectionFromCoreReceiptsAndArtifacts(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/bkn-trace-core/_search" {
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+		body, _ := io.ReadAll(r.Body)
+		if !json.Valid(body) {
+			t.Fatalf("invalid search body: %s", body)
+		}
+		_, _ = io.WriteString(w, `{
+			"hits":{"hits":[{"_source":{
+				"receipt_id":"rcpt-1","schema_version":"3.0.0",
+				"owner":{"tenant_id":"tenant-1","business_domain_id":"domain-1","application_principal_id":"openbkn-sdk","effective_subject_type":"user","effective_subject_id":"user-1"},
+				"conversation_id":"conv-1","interaction_id":"int-1","operation_id":"op-1",
+				"operation_key":"forecast-query","tool_name":"run_sql","receipt_status":"completed","evidence_durability":"durable",
+				"request_id":"req-1","trace_id":"11111111111111111111111111111111",
+				"business_refs":[
+					{"ref_type":"knowledge_network","ref_id":"kn:supplychain_hd0202","business_domain_id":"domain-1","version":"v3"},
+					{"ref_type":"object_type","ref_id":"object:supplychain_hd0202:forecast","business_domain_id":"domain-1","version":"v3"}
+				],
+				"artifact_refs":[],"partial_reasons":[],
+				"issued_at":"2026-08-02T07:35:26Z","terminal_at":"2026-08-02T07:35:27Z"
+			}}, {"_source":{
+				"receipt_id":"rcpt-2","schema_version":"3.0.0",
+				"owner":{"tenant_id":"tenant-1","business_domain_id":"domain-1","application_principal_id":"openbkn-sdk","effective_subject_type":"user","effective_subject_id":"user-1"},
+				"conversation_id":"conv-1","interaction_id":"int-1","operation_id":"op-2",
+				"operation_key":"data-query","tool_name":"run_sql","receipt_status":"completed","evidence_durability":"durable",
+				"request_id":"req-2","trace_id":"44444444444444444444444444444444",
+				"business_refs":[{"ref_type":"data_resource","ref_id":"resource:forecast","business_domain_id":"domain-1","version":"v3"}],
+				"artifact_refs":[],"partial_reasons":[],
+				"issued_at":"2026-08-02T07:35:27Z","terminal_at":"2026-08-02T07:35:28Z"
+			}}]}}
+		`)
+	}))
+	t.Cleanup(server.Close)
+
+	artifacts := artifactProjectionSource{result: iprojectionsource.Result{Artifacts: []evidencevo.EvidenceArtifact{
+		{
+			ArtifactID: "question-1", ArtifactType: evidencevo.ArtifactTypeQuestion,
+			RequestID: "req-lifecycle-start", TraceID: "22222222222222222222222222222222", InteractionID: "int-1",
+			Content: "6月份有哪些需求预测单？", ObservedAt: "2026-08-02T07:35:25Z",
+			TenantID: "tenant-1", BusinessDomain: "domain-1", AccountID: "user-1", AccountType: "user",
+		},
+		{
+			ArtifactID: "answer-1", ArtifactType: evidencevo.ArtifactTypeResult,
+			RequestID: "req-lifecycle-complete", TraceID: "33333333333333333333333333333333", InteractionID: "int-1",
+			Content: map[string]any{"summary": "6月份共有63条，需求总量11594。"}, ObservedAt: "2026-08-02T07:35:28Z",
+			TenantID: "tenant-1", BusinessDomain: "domain-1", AccountID: "user-1", AccountType: "user",
+		},
+	}}}
+	source := opensearchcoreprojection.New(
+		opensearch.New(server.URL, opensearch.AuthConfig{}, time.Second),
+		"bkn-trace-core",
+		artifacts,
+	)
+
+	result, err := source.LoadExecutionProjection(context.Background(), iprojectionsource.Query{
+		Scope: evidencevo.QueryScope{
+			TenantID: "tenant-1", BusinessDomain: "domain-1", AccountID: "user-1", AccountType: "user",
+			AccessProfile: &evidencevo.AccessProfile{
+				TenantID: "tenant-1", BusinessDomain: "domain-1", EffectiveSubjectID: "user-1",
+				ApplicationPrincipalID: "openbkn-studio", AccountActive: true, TenantActive: true,
+			},
+		},
+		Limit: 20,
+	})
+	if err != nil {
+		t.Fatalf("load projection: %v", err)
+	}
+	if len(result.Traces) != 2 {
+		t.Fatalf("expected two traces, got %#v", result.Traces)
+	}
+	for _, trace := range result.Traces {
+		if trace.ConversationID != "conv-1" || len(trace.Events) != 3 {
+			t.Fatalf("each call must inherit the interaction question/result: %#v", trace)
+		}
+	}
+	trace := result.Traces[0]
+	receiptEvent := trace.Events[0]
+	if receiptEvent.OperationID != "op-1" || receiptEvent.OperationName != "run_sql" ||
+		receiptEvent.Payload["operation_key"] != "forecast-query" {
+		t.Fatalf("receipt operation identity was not preserved: %#v", receiptEvent)
+	}
+	if len(trace.KnowledgeNetworkIDs) != 1 || trace.KnowledgeNetworkIDs[0] != "supplychain_hd0202" {
+		t.Fatalf("knowledge network was not derived: %#v", trace.KnowledgeNetworkIDs)
+	}
+	if len(result.Artifacts) != 4 {
+		t.Fatalf("authorized artifacts were not preserved: %#v", result.Artifacts)
+	}
+	requests, _ := evidencevo.BuildExecutionSummaries(result.Traces, result.Artifacts)
+	if len(requests) != 2 {
+		t.Fatalf("expected two request summaries, got %#v", requests)
+	}
+	for _, request := range requests {
+		if request.DurationMS != 1000 {
+			t.Fatalf("interaction context artifacts must not widen operation timing: %#v", requests)
+		}
+	}
+}
+
+func TestRequestProjectionHydratesArtifactsByReceiptInteraction(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = io.WriteString(w, `{"hits":{"hits":[{"_source":{
+			"receipt_id":"rcpt-request","schema_version":"3.0.0",
+			"owner":{"tenant_id":"tenant-1","business_domain_id":"domain-1","application_principal_id":"openbkn-sdk","effective_subject_type":"user","effective_subject_id":"user-1"},
+			"conversation_id":"conv-1","interaction_id":"int-1","operation_id":"op-1",
+			"tool_name":"search_schema","receipt_status":"completed","evidence_durability":"durable",
+			"request_id":"req-1","trace_id":"11111111111111111111111111111111",
+			"issued_at":"2026-08-02T07:35:26Z","terminal_at":"2026-08-02T07:35:27Z"
+		}}]}}`)
+	}))
+	t.Cleanup(server.Close)
+
+	artifacts := &recordingArtifactProjectionSource{result: iprojectionsource.Result{Artifacts: []evidencevo.EvidenceArtifact{{
+		ArtifactID: "question-1", ArtifactType: evidencevo.ArtifactTypeQuestion,
+		RequestID: "req-lifecycle", TraceID: "22222222222222222222222222222222", InteractionID: "int-1",
+		Content: "6月份有哪些需求预测单？", ObservedAt: "2026-08-02T07:35:25Z",
+		TenantID: "tenant-1", BusinessDomain: "domain-1", AccountID: "user-1", AccountType: "user",
+	}}}}
+	source := opensearchcoreprojection.New(
+		opensearch.New(server.URL, opensearch.AuthConfig{}, time.Second), "bkn-trace-core", artifacts,
+	)
+
+	result, err := source.LoadExecutionProjection(context.Background(), iprojectionsource.Query{
+		RequestID: "req-1", Scope: evidencevo.QueryScope{
+			TenantID: "tenant-1", BusinessDomain: "domain-1", AccountID: "user-1", AccountType: "user",
+		},
+	})
+	if err != nil {
+		t.Fatalf("load request projection: %v", err)
+	}
+	if len(artifacts.queries) != 1 || artifacts.queries[0].InteractionID != "int-1" || artifacts.queries[0].RequestID != "" {
+		t.Fatalf("request artifacts must be hydrated from receipt interaction: %+v", artifacts.queries)
+	}
+	if len(result.Traces) != 1 || len(result.Traces[0].Events) != 2 {
+		t.Fatalf("interaction artifact must be attached to exact request trace: %+v", result.Traces)
+	}
+}
+
+type artifactProjectionSource struct {
+	result iprojectionsource.Result
+}
+
+type recordingArtifactProjectionSource struct {
+	result  iprojectionsource.Result
+	queries []iprojectionsource.Query
+}
+
+func (s *recordingArtifactProjectionSource) LoadExecutionProjection(_ context.Context, query iprojectionsource.Query) (iprojectionsource.Result, error) {
+	s.queries = append(s.queries, query)
+	return s.result, nil
+}
+
+func (s artifactProjectionSource) LoadExecutionProjection(context.Context, iprojectionsource.Query) (iprojectionsource.Result, error) {
+	return s.result, nil
+}

--- a/bkn-trace/agent-observability/src/drivenadapter/httpaccess/opensearchcoreprojection/source_test.go
+++ b/bkn-trace/agent-observability/src/drivenadapter/httpaccess/opensearchcoreprojection/source_test.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
 
@@ -25,6 +26,15 @@ func TestSourceBuildsAuthorizedExecutionProjectionFromCoreReceiptsAndArtifacts(t
 		body, _ := io.ReadAll(r.Body)
 		if !json.Valid(body) {
 			t.Fatalf("invalid search body: %s", body)
+		}
+		queryBody := string(body)
+		if strings.Contains(queryBody, "match_phrase") {
+			t.Fatalf("authorization filters must not use analyzed phrase matching: %s", body)
+		}
+		for _, field := range []string{"owner.tenant_id.keyword", "owner.business_domain_id.keyword"} {
+			if !strings.Contains(queryBody, field) {
+				t.Fatalf("authorization filter %q must use exact keyword matching: %s", field, body)
+			}
 		}
 		_, _ = io.WriteString(w, `{
 			"hits":{"hits":[{"_source":{

--- a/bkn-trace/agent-observability/src/drivenadapter/httpaccess/opensearchevidencestore/projection_source.go
+++ b/bkn-trace/agent-observability/src/drivenadapter/httpaccess/opensearchevidencestore/projection_source.go
@@ -159,6 +159,7 @@ func (s *Store) listArtifactProjection(ctx context.Context, query iprojectionsou
 func matchesProjectionTrace(trace evidencevo.NormalizedTrace, query iprojectionsource.Query) bool {
 	if query.RequestID != "" && trace.RequestID != query.RequestID ||
 		query.TraceID != "" && trace.TraceID != query.TraceID ||
+		query.InteractionID != "" && !traceHasInteraction(trace, query.InteractionID) ||
 		query.BusinessDomain != "" && trace.BusinessDomain != query.BusinessDomain {
 		return false
 	}
@@ -177,6 +178,7 @@ func matchesProjectionTrace(trace evidencevo.NormalizedTrace, query iprojections
 func matchesProjectionArtifact(artifact evidencevo.EvidenceArtifact, query iprojectionsource.Query) bool {
 	if query.RequestID != "" && artifact.RequestID != query.RequestID ||
 		query.TraceID != "" && artifact.TraceID != query.TraceID ||
+		query.InteractionID != "" && artifact.InteractionID != query.InteractionID ||
 		query.BusinessDomain != "" && artifact.BusinessDomain != query.BusinessDomain {
 		return false
 	}
@@ -191,6 +193,15 @@ func matchesProjectionArtifact(artifact evidencevo.EvidenceArtifact, query iproj
 		(query.To.IsZero() || !observedAt.After(query.To))
 }
 
+func traceHasInteraction(trace evidencevo.NormalizedTrace, interactionID string) bool {
+	for _, event := range trace.Events {
+		if event.InteractionID == interactionID {
+			return true
+		}
+	}
+	return false
+}
+
 type artifactProjectionHit struct {
 	Source evidencevo.EvidenceArtifact
 	Sort   []any
@@ -198,6 +209,9 @@ type artifactProjectionHit struct {
 
 func (s *Store) listArtifactProjectionPage(ctx context.Context, query iprojectionsource.Query, searchAfter []any, size int) ([]artifactProjectionHit, error) {
 	must := appendProjectionIdentityFilters(ownershipMust(query.Scope), query)
+	if query.InteractionID != "" {
+		must = append(must, map[string]any{"bool": exactTermQuery("interaction_id", query.InteractionID)})
+	}
 	if !query.From.IsZero() || !query.To.IsZero() {
 		bounds := map[string]any{}
 		if !query.From.IsZero() {

--- a/bkn-trace/agent-observability/src/drivenadapter/httpaccess/opensearchlogaccess/client.go
+++ b/bkn-trace/agent-observability/src/drivenadapter/httpaccess/opensearchlogaccess/client.go
@@ -76,7 +76,8 @@ func (client *Client) Search(ctx context.Context, query observabilityvo.LogQuery
 		}
 		if len(hit.Sort) > 0 {
 			record.CursorPosition = &observabilityvo.SourcePosition{
-				EventTimestamp: record.EventTimestamp, LogID: record.SourceLogID, SearchAfter: append([]any(nil), hit.Sort...),
+				EventTimestamp: record.EventTimestamp, SourceID: record.SourceID,
+				LogID: record.SourceLogID, SearchAfter: append([]any(nil), hit.Sort...),
 			}
 		}
 		records = append(records, record)
@@ -206,6 +207,11 @@ func buildQuery(query observabilityvo.LogQuery) map[string]any {
 		}
 		filters = append(filters, map[string]any{"range": map[string]any{"@timestamp": bounds}})
 	}
+	if query.ObservedBefore != nil {
+		filters = append(filters, map[string]any{"range": map[string]any{
+			"observedTimestamp": map[string]any{"lte": query.ObservedBefore.Format(time.RFC3339Nano)},
+		}})
+	}
 	if query.SeverityMinimum > 0 {
 		filters = append(filters, map[string]any{"range": map[string]any{"severity.number": map[string]any{"gte": query.SeverityMinimum}}})
 	}
@@ -220,15 +226,19 @@ func buildQuery(query observabilityvo.LogQuery) map[string]any {
 		"size": limit, "track_total_hits": true,
 		"sort": []any{
 			map[string]any{"@timestamp": map[string]any{"order": "desc"}},
+			map[string]any{"attributes.source_id.keyword": map[string]any{"order": "asc", "unmapped_type": "keyword"}},
 			map[string]any{"attributes.source_log_id.keyword": map[string]any{"order": "asc", "unmapped_type": "keyword"}},
 		},
 		"query": map[string]any{"bool": boolQuery},
 	}
-	if query.PageBefore != nil && !query.PageBefore.EventTimestamp.IsZero() && query.PageBefore.LogID != "" {
+	if query.PageBefore != nil && (len(query.PageBefore.SearchAfter) > 0 ||
+		(!query.PageBefore.EventTimestamp.IsZero() && query.PageBefore.LogID != "")) {
 		if len(query.PageBefore.SearchAfter) > 0 {
 			result["search_after"] = append([]any(nil), query.PageBefore.SearchAfter...)
 		} else {
-			result["search_after"] = []any{query.PageBefore.EventTimestamp.Format(time.RFC3339Nano), query.PageBefore.LogID}
+			result["search_after"] = []any{
+				query.PageBefore.EventTimestamp.Format(time.RFC3339Nano), query.PageBefore.SourceID, query.PageBefore.LogID,
+			}
 		}
 	}
 	return result
@@ -278,6 +288,7 @@ func mapDocument(id string, payload []byte) (observabilityvo.LogRecord, error) {
 		ConversationID:      stringAttribute(document.Attributes, "conversation_id", ""),
 		InteractionID:       stringAttribute(document.Attributes, "interaction_id", ""),
 		OperationID:         stringAttribute(document.Attributes, "operation_id", ""),
+		ToolName:            stringAttribute(document.Attributes, "tool_name", ""),
 		ArtifactRef:         stringAttribute(document.Attributes, "artifact_ref", ""),
 		KnowledgeNetworkIDs: stringSliceAttribute(document.Attributes, "knowledge_network_ids"),
 		Attributes:          projectedAttributes(document.Attributes),

--- a/bkn-trace/agent-observability/src/drivenadapter/httpaccess/opensearchlogaccess/client_test.go
+++ b/bkn-trace/agent-observability/src/drivenadapter/httpaccess/opensearchlogaccess/client_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"strings"
 	"testing"
 	"time"
 
@@ -76,7 +77,7 @@ func TestSearchReplaysNativeSearchAfterValues(t *testing.T) {
 		AuthorizedTenantID: "tenant-a", AuthorizedCategories: []string{observabilityvo.CategoryRuntimeSystem},
 		PageBefore: &observabilityvo.SourcePosition{
 			EventTimestamp: positionTime, LogID: "source-log-a",
-			SearchAfter: []any{"2026-08-01T10:00:00.123456Z", "source-log-a"},
+			SearchAfter: []any{"2026-08-01T10:00:00.123456Z", "context-loader", "source-log-a"},
 		},
 	})
 	if err != nil {
@@ -87,8 +88,49 @@ func TestSearchReplaysNativeSearchAfterValues(t *testing.T) {
 		t.Fatal(err)
 	}
 	searchAfter, _ := query["search_after"].([]any)
-	if len(searchAfter) != 2 || searchAfter[0] != "2026-08-01T10:00:00.123456Z" || searchAfter[1] != "source-log-a" {
+	if len(searchAfter) != 3 || searchAfter[0] != "2026-08-01T10:00:00.123456Z" ||
+		searchAfter[1] != "context-loader" || searchAfter[2] != "source-log-a" {
 		t.Fatalf("native search_after was reconstructed instead of replayed: %#v", searchAfter)
+	}
+}
+
+func TestBuildQueryReplaysNativeSearchAfterWithoutAParsedTimestamp(t *testing.T) {
+	query := buildQuery(observabilityvo.LogQuery{
+		AuthorizedTenantID: "tenant-a", AuthorizedCategories: []string{observabilityvo.CategoryRuntimeSystem},
+		PageBefore: &observabilityvo.SourcePosition{
+			LogID: "source-log-a", SearchAfter: []any{"invalid-legacy-time", "context-loader", "source-log-a"},
+		},
+	})
+	searchAfter, _ := query["search_after"].([]any)
+	if len(searchAfter) != 3 || searchAfter[0] != "invalid-legacy-time" {
+		t.Fatalf("native search_after must be authoritative even when _source time cannot be parsed: %#v", searchAfter)
+	}
+}
+
+func TestBuildQueryUsesTheContractTieBreakers(t *testing.T) {
+	query := buildQuery(observabilityvo.LogQuery{
+		AuthorizedTenantID: "tenant-a", AuthorizedCategories: []string{observabilityvo.CategoryRuntimeSystem},
+	})
+	sorts, _ := query["sort"].([]any)
+	encoded, _ := json.Marshal(sorts)
+	if len(sorts) != 3 || !strings.Contains(string(encoded), `"attributes.source_id.keyword"`) ||
+		!strings.Contains(string(encoded), `"attributes.source_log_id.keyword"`) {
+		t.Fatalf("native sort must be event_timestamp DESC, source_id ASC, source_log_id ASC: %s", encoded)
+	}
+}
+
+func TestBuildQueryFreezesObservedTimestampAtTheGatewayWatermark(t *testing.T) {
+	watermark := time.Date(2026, 8, 1, 12, 0, 0, 123, time.UTC)
+	body, err := json.Marshal(buildQuery(observabilityvo.LogQuery{
+		AuthorizedTenantID:   "tenant-a",
+		AuthorizedCategories: []string{observabilityvo.CategoryRuntimeSystem},
+		ObservedBefore:       &watermark,
+	}))
+	if err != nil {
+		t.Fatalf("marshal query: %v", err)
+	}
+	if !strings.Contains(string(body), `"observedTimestamp":{"lte":"2026-08-01T12:00:00.000000123Z"}`) {
+		t.Fatalf("observed watermark is missing from OpenSearch query: %s", body)
 	}
 }
 
@@ -119,7 +161,7 @@ func TestSearchUsesCandidateScopeInsteadOfRequiringEveryManagedNetwork(t *testin
 func TestListLogIDCanRoundTripThroughGet(t *testing.T) {
 	backend := &fakeSearchClient{response: []byte(`{
 		"hits":{"total":{"value":1,"relation":"eq"},"hits":[{"_id":"source-log-a","_source":{
-			"attributes":{"schema_version":"1.0.0","log_id":"context-loader:source-log-a","source_id":"context-loader","source_log_id":"source-log-a","tenant_id":"tenant-a","business_domain_id":"domain-a","log_category":"runtime.business","event_name":"knowledge.read.completed","outcome":"success","safe_summary":"读取需求预测对象","trust_level":"trusted"},
+			"attributes":{"schema_version":"1.0.0","log_id":"context-loader:source-log-a","source_id":"context-loader","source_log_id":"source-log-a","tenant_id":"tenant-a","business_domain_id":"domain-a","log_category":"runtime.business","event_name":"knowledge.read.completed","outcome":"success","safe_summary":"读取需求预测对象","trust_level":"trusted","tool_name":"run_sql"},
 			"observedTimestamp":"2026-08-01T11:35:47Z","@timestamp":"2026-08-01T11:35:46Z",
 			"resource":{"service.name":"context-loader","deployment.environment":"production"},
 			"severity":{"text":"INFO","number":9}
@@ -133,6 +175,9 @@ func TestListLogIDCanRoundTripThroughGet(t *testing.T) {
 		t.Fatalf("list log: records=%d err=%v", len(page.Records), err)
 	}
 	listedLogID := page.Records[0].LogID
+	if page.Records[0].ToolName != "run_sql" {
+		t.Fatalf("tool identity was not projected into log record: %+v", page.Records[0])
+	}
 	ctx := observabilityvo.WithSourceAccessScope(context.Background(), observabilityvo.SourceAccessScope{
 		TenantID: "tenant-a", BusinessDomain: "domain-a",
 	})

--- a/bkn-trace/agent-observability/src/drivenadapter/memoryaccess/evidencestore/store.go
+++ b/bkn-trace/agent-observability/src/drivenadapter/memoryaccess/evidencestore/store.go
@@ -130,6 +130,7 @@ func (s *Store) LoadExecutionProjection(ctx context.Context, query iprojectionso
 	for _, trace := range traces {
 		if query.RequestID != "" && trace.RequestID != query.RequestID ||
 			query.TraceID != "" && trace.TraceID != query.TraceID ||
+			query.InteractionID != "" && !memoryTraceHasInteraction(trace, query.InteractionID) ||
 			query.BusinessDomain != "" && trace.BusinessDomain != query.BusinessDomain ||
 			!memoryTraceInRange(trace, query.From, query.To) {
 			continue
@@ -140,6 +141,7 @@ func (s *Store) LoadExecutionProjection(ctx context.Context, query iprojectionso
 	for _, artifact := range artifacts {
 		if query.RequestID != "" && artifact.RequestID != query.RequestID ||
 			query.TraceID != "" && artifact.TraceID != query.TraceID ||
+			query.InteractionID != "" && artifact.InteractionID != query.InteractionID ||
 			query.BusinessDomain != "" && artifact.BusinessDomain != query.BusinessDomain ||
 			!memoryTimeInRange(artifact.ObservedAt, query.From, query.To) {
 			continue
@@ -158,6 +160,15 @@ func (s *Store) LoadExecutionProjection(ctx context.Context, query iprojectionso
 		truncated = true
 	}
 	return iprojectionsource.Result{Traces: filteredTraces, Artifacts: filteredArtifacts, Truncated: truncated}, nil
+}
+
+func memoryTraceHasInteraction(trace evidencevo.NormalizedTrace, interactionID string) bool {
+	for _, event := range trace.Events {
+		if event.InteractionID == interactionID {
+			return true
+		}
+	}
+	return false
 }
 
 func memoryTraceInRange(trace evidencevo.NormalizedTrace, from, to time.Time) bool {

--- a/bkn-trace/agent-observability/src/driveradapter/api/httphandler/evidence_handler.go
+++ b/bkn-trace/agent-observability/src/driveradapter/api/httphandler/evidence_handler.go
@@ -2,6 +2,7 @@ package httphandler
 
 import (
 	"bytes"
+	"context"
 	"crypto/subtle"
 	"encoding/json"
 	"io"
@@ -26,11 +27,13 @@ const evidenceQueryGatewayTokenEnv = "BKN_TRACE_QUERY_GATEWAY_TOKEN"
 const evidenceAllowUnauthenticatedQueryEnv = "BKN_TRACE_ALLOW_UNAUTHENTICATED_QUERY"
 const evidenceQueryGatewayTokenHeader = "X-BKN-Trace-Query-Token"
 const evidenceHydraAdminURLEnv = "BKN_TRACE_HYDRA_ADMIN_URL"
+const evidenceDeploymentTenantIDEnv = "BKN_TRACE_DEPLOYMENT_TENANT_ID"
 
 type EvidenceHandlerSecurityConfig struct {
 	IngestToken                string
 	QueryGatewayToken          string
 	HydraAdminURL              string
+	DeploymentTenantID         string
 	QueryHTTPClient            *http.Client
 	AllowUnauthenticatedIngest bool
 	AllowUnauthenticatedQuery  bool
@@ -42,10 +45,18 @@ type EvidenceHandler struct {
 	ingestToken                string
 	queryGatewayToken          string
 	hydraAdminURL              string
+	deploymentTenantID         string
 	queryHTTPClient            *http.Client
 	allowUnauthenticatedIngest bool
 	allowUnauthenticatedQuery  bool
 	authorizationScopeResolver iauthorizationscope.Resolver
+}
+
+type trustedQueryScopeContextKey struct{}
+
+func trustedQueryScopeFromContext(ctx context.Context) (evidencevo.QueryScope, bool) {
+	scope, ok := ctx.Value(trustedQueryScopeContextKey{}).(evidencevo.QueryScope)
+	return scope, ok
 }
 
 func NewEvidenceHandler(evidenceService *evidencesvc.Service) *EvidenceHandler {
@@ -62,6 +73,7 @@ func NewEvidenceHandlerWithAuthorizationScopeResolver(
 		IngestToken:                os.Getenv(evidenceIngestTokenEnv),
 		QueryGatewayToken:          os.Getenv(evidenceQueryGatewayTokenEnv),
 		HydraAdminURL:              os.Getenv(evidenceHydraAdminURLEnv),
+		DeploymentTenantID:         os.Getenv(evidenceDeploymentTenantIDEnv),
 		AllowUnauthenticatedIngest: allowUnauthenticated,
 		AllowUnauthenticatedQuery:  allowUnauthenticatedQuery,
 		AuthorizationScopeResolver: resolver,
@@ -88,6 +100,7 @@ func NewEvidenceHandlerWithSecurityConfig(evidenceService *evidencesvc.Service, 
 		ingestToken:                strings.TrimSpace(config.IngestToken),
 		queryGatewayToken:          strings.TrimSpace(config.QueryGatewayToken),
 		hydraAdminURL:              strings.TrimRight(strings.TrimSpace(config.HydraAdminURL), "/"),
+		deploymentTenantID:         strings.TrimSpace(config.DeploymentTenantID),
 		queryHTTPClient:            queryHTTPClient,
 		allowUnauthenticatedIngest: config.AllowUnauthenticatedIngest,
 		allowUnauthenticatedQuery:  config.AllowUnauthenticatedQuery,
@@ -800,11 +813,21 @@ func (h *EvidenceHandler) evidenceQueryOptionsFromRequest(w http.ResponseWriter,
 }
 
 func (h *EvidenceHandler) queryScopeFromRequest(w http.ResponseWriter, r *http.Request) (evidencevo.QueryScope, bool) {
+	if scope, ok := trustedQueryScopeFromContext(r.Context()); ok {
+		return scope, true
+	}
 	accountID := strings.TrimSpace(r.Header.Get("x-account-id"))
 	accountType := strings.TrimSpace(r.Header.Get("x-account-type"))
 	tenantID := strings.TrimSpace(r.Header.Get("x-tenant-id"))
 	if tenantID == "" {
 		tenantID = strings.TrimSpace(r.Header.Get("x-bkn-tenant-id"))
+	}
+	if h.deploymentTenantID != "" {
+		if tenantID != "" && tenantID != h.deploymentTenantID {
+			writeQueryAuthorizationError(w, r, http.StatusUnauthorized, "QUERY_IDENTITY_MISMATCH", "request tenant does not match the deployment tenant")
+			return evidencevo.QueryScope{}, false
+		}
+		tenantID = h.deploymentTenantID
 	}
 	businessDomain := strings.TrimSpace(r.Header.Get("x-business-domain"))
 	if accountID == "" || accountType == "" || strings.EqualFold(accountType, "anonymous") || tenantID == "" && businessDomain == "" {
@@ -850,10 +873,12 @@ func (h *EvidenceHandler) RequireTrustedQueryIdentity(next http.HandlerFunc) htt
 		if !h.authorizeQueryGateway(w, r) {
 			return
 		}
-		if _, ok := h.queryScopeFromRequest(w, r); !ok {
+		scope, ok := h.queryScopeFromRequest(w, r)
+		if !ok {
 			return
 		}
-		next(w, r)
+		ctx := context.WithValue(r.Context(), trustedQueryScopeContextKey{}, scope)
+		next(w, r.WithContext(ctx))
 	}
 }
 
@@ -868,9 +893,35 @@ func (h *EvidenceHandler) RequireTrustedLifecycleIdentity(next http.HandlerFunc)
 			)
 			return
 		}
-		scope, ok := h.queryScopeFromRequest(w, r)
-		if !ok {
+		accountID := strings.TrimSpace(r.Header.Get("x-account-id"))
+		accountType := strings.TrimSpace(r.Header.Get("x-account-type"))
+		tenantID := strings.TrimSpace(r.Header.Get("x-tenant-id"))
+		if tenantID == "" {
+			tenantID = strings.TrimSpace(r.Header.Get("x-bkn-tenant-id"))
+		}
+		if h.deploymentTenantID != "" {
+			if tenantID != "" && tenantID != h.deploymentTenantID {
+				writeLifecycleError(
+					w, r, http.StatusUnauthorized, "permission_denied",
+					"request tenant does not match the deployment tenant",
+				)
+				return
+			}
+			tenantID = h.deploymentTenantID
+		}
+		businessDomain := strings.TrimSpace(r.Header.Get("x-business-domain"))
+		if accountID == "" || accountType == "" || strings.EqualFold(accountType, "anonymous") ||
+			tenantID == "" || businessDomain == "" {
+			writeLifecycleError(
+				w, r, http.StatusUnauthorized, "permission_denied",
+				"trusted account, tenant and business domain context is required",
+			)
 			return
+		}
+		scope := evidencevo.QueryScope{
+			TenantID: tenantID, BusinessDomain: businessDomain,
+			AccountID: accountID, AccountType: accountType,
+			View: evidencevo.AccessViewBusiness,
 		}
 		if scope.TenantID == "" || scope.BusinessDomain == "" {
 			writeLifecycleError(
@@ -889,11 +940,15 @@ func (h *EvidenceHandler) RequireTrustedLifecycleIdentity(next http.HandlerFunc)
 			return
 		}
 
-		next(w, r)
+		ctx := context.WithValue(r.Context(), trustedQueryScopeContextKey{}, scope)
+		next(w, r.WithContext(ctx))
 	}
 }
 
 func (h *EvidenceHandler) authorizeQueryGateway(w http.ResponseWriter, r *http.Request) bool {
+	if _, ok := trustedQueryScopeFromContext(r.Context()); ok {
+		return true
+	}
 	if h.queryGatewayToken != "" && secureTokenEqual(r.Header.Get(evidenceQueryGatewayTokenHeader), h.queryGatewayToken) {
 		return true
 	}
@@ -1043,6 +1098,18 @@ func (h *EvidenceHandler) AuthorizeTechnicalTraceQuery(w http.ResponseWriter, r 
 	if err != nil {
 		writeJSON(w, http.StatusInternalServerError, rdto.ErrorResponse{Code: "QUERY_FAILED", Message: "failed to authorize trace query"})
 		return false
+	}
+	if !found {
+		page, listErr := h.evidenceService.ListRequests(r.Context(), evidencevo.SummaryQueryOptions{
+			TraceID: traceID,
+			Scope:   options.Scope,
+			Limit:   1,
+		})
+		if listErr != nil {
+			writeJSON(w, http.StatusInternalServerError, rdto.ErrorResponse{Code: "QUERY_FAILED", Message: "failed to authorize trace query"})
+			return false
+		}
+		found = len(page.Entries) > 0
 	}
 	if !found {
 		writeJSON(w, http.StatusNotFound, rdto.ErrorResponse{Code: "NOT_FOUND", Message: "trace not found"})

--- a/bkn-trace/agent-observability/src/driveradapter/api/httphandler/evidence_handler_test.go
+++ b/bkn-trace/agent-observability/src/driveradapter/api/httphandler/evidence_handler_test.go
@@ -13,11 +13,34 @@ import (
 	"github.com/openbkn-ai/bkn-foundry/bkn-trace/agent-observability/src/domain/valueobject/evidencevo"
 	"github.com/openbkn-ai/bkn-foundry/bkn-trace/agent-observability/src/drivenadapter/memoryaccess/evidencestore"
 	"github.com/openbkn-ai/bkn-foundry/bkn-trace/agent-observability/src/port/driven/iauthorizationscope"
+	"github.com/openbkn-ai/bkn-foundry/bkn-trace/agent-observability/src/port/driven/iprojectionsource"
 )
+
+type staticProjectionSource struct {
+	result iprojectionsource.Result
+}
+
+func (s staticProjectionSource) LoadExecutionProjection(
+	_ context.Context,
+	query iprojectionsource.Query,
+) (iprojectionsource.Result, error) {
+	result := iprojectionsource.Result{Artifacts: s.result.Artifacts, Truncated: s.result.Truncated}
+	for _, trace := range s.result.Traces {
+		if query.TraceID != "" && trace.TraceID != query.TraceID {
+			continue
+		}
+		if !evidencevo.MatchesScope(trace, query.Scope) {
+			continue
+		}
+		result.Traces = append(result.Traces, trace)
+	}
+	return result, nil
+}
 
 type fakeAccessScopeResolver struct {
 	profile         evidencevo.AccessProfile
 	err             error
+	calls           int
 	authorization   string
 	trustedIdentity iauthorizationscope.TrustedIdentity
 }
@@ -27,6 +50,7 @@ func (f *fakeAccessScopeResolver) Resolve(
 	authorization string,
 	identity iauthorizationscope.TrustedIdentity,
 ) (evidencevo.AccessProfile, error) {
+	f.calls++
 	f.authorization = authorization
 	f.trustedIdentity = identity
 	return f.profile, f.err
@@ -115,7 +139,7 @@ func TestEvidenceHandlerBuildsQueryScopeFromCurrentSafeAccessProfile(t *testing.
 	handler := NewEvidenceHandlerWithSecurityConfig(evidencesvc.New(evidencestore.New()), EvidenceHandlerSecurityConfig{
 		AllowUnauthenticatedQuery: true, AuthorizationScopeResolver: resolver,
 	})
-	request := authenticatedQueryRequest(http.MethodGet, "/api/agent-observability/v1/requests/request-a/summary", nil)
+	request := authenticatedQueryRequest(http.MethodGet, "/api/agent-observability/v1/business-provenance/requests/request-a", nil)
 	request.Header.Set("Authorization", "Bearer current-token")
 	request.Header.Set("x-account-id", "actor-a")
 	request.Header.Set("x-account-type", "user")
@@ -254,6 +278,118 @@ func TestEvidenceHandlerAuthenticatesStudioQueryWithHydra(t *testing.T) {
 	}
 }
 
+func TestTrustedQueryMiddlewareSharesIdentityAndCachesResolvedScope(t *testing.T) {
+	introspectionCalls := 0
+	hydra := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		introspectionCalls++
+		if r.URL.Path != "/admin/oauth2/introspect" || r.FormValue("token") != "studio-token" {
+			t.Fatalf("unexpected introspection request: %s token=%q", r.URL.Path, r.FormValue("token"))
+		}
+		_, _ = io.WriteString(w, `{"active":true,"sub":"acct_demo","client_id":"openbkn-studio","ext":{"visitor_type":"realname"}}`)
+	}))
+	defer hydra.Close()
+
+	resolver := &fakeAccessScopeResolver{profile: evidencevo.AccessProfile{
+		TenantID: "tenant-demo", BusinessDomain: "bd_demo", ActorID: "acct_demo",
+		EffectiveSubjectID: "acct_demo", Roles: []string{"super_admin"},
+		AccountActive: true, TenantActive: true, Fingerprint: "sha256:scope",
+	}}
+	handler := NewEvidenceHandlerWithSecurityConfig(evidencesvc.New(evidencestore.New()), EvidenceHandlerSecurityConfig{
+		HydraAdminURL: hydra.URL, AuthorizationScopeResolver: resolver,
+	})
+	next := handler.RequireTrustedQueryIdentity(func(w http.ResponseWriter, r *http.Request) {
+		identity := identityFromRequest(r)
+		if !identity.present || identity.accountID != "acct_demo" || identity.accountType != "user" {
+			http.Error(w, "trusted identity was not shared with trace authorization", http.StatusInternalServerError)
+			return
+		}
+		if !handler.authorizeQueryGateway(w, r) {
+			return
+		}
+		scope, ok := handler.queryScopeFromRequest(w, r)
+		if !ok || scope.AccessProfile == nil || scope.AccessProfile.Fingerprint != "sha256:scope" {
+			http.Error(w, "trusted access scope was not cached", http.StatusInternalServerError)
+			return
+		}
+		w.WriteHeader(http.StatusNoContent)
+	})
+	request := httptest.NewRequest(http.MethodGet, "/api/observability/v1/logs", nil)
+	request.Header.Set("Authorization", "Bearer studio-token")
+	request.Header.Set("x-tenant-id", "tenant-demo")
+	request.Header.Set("x-business-domain", "bd_demo")
+	response := httptest.NewRecorder()
+
+	next(response, request)
+
+	if response.Code != http.StatusNoContent {
+		t.Fatalf("trusted OAuth query must reach the protected handler: %d %s", response.Code, response.Body.String())
+	}
+	if introspectionCalls != 1 || resolver.calls != 1 {
+		t.Fatalf("trusted query scope must be resolved once, introspections=%d resolver_calls=%d", introspectionCalls, resolver.calls)
+	}
+}
+
+func TestTrustedQueryMiddlewareInjectsDeploymentTenant(t *testing.T) {
+	hydra := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = io.WriteString(w, `{"active":true,"sub":"acct_demo","client_id":"openbkn-studio","ext":{"visitor_type":"realname"}}`)
+	}))
+	defer hydra.Close()
+
+	resolver := &fakeAccessScopeResolver{profile: evidencevo.AccessProfile{
+		TenantID: "openbkn-local", BusinessDomain: "bd_demo", ActorID: "acct_demo",
+		EffectiveSubjectID: "acct_demo", Roles: []string{"super_admin"},
+		AccountActive: true, TenantActive: true, Fingerprint: "sha256:scope",
+	}}
+	handler := NewEvidenceHandlerWithSecurityConfig(evidencesvc.New(evidencestore.New()), EvidenceHandlerSecurityConfig{
+		HydraAdminURL: hydra.URL, DeploymentTenantID: "openbkn-local", AuthorizationScopeResolver: resolver,
+	})
+	next := handler.RequireTrustedQueryIdentity(func(w http.ResponseWriter, r *http.Request) {
+		scope, ok := trustedQueryScopeFromContext(r.Context())
+		if !ok || scope.TenantID != "openbkn-local" {
+			http.Error(w, "deployment tenant was not injected", http.StatusInternalServerError)
+			return
+		}
+		w.WriteHeader(http.StatusNoContent)
+	})
+	request := httptest.NewRequest(http.MethodGet, "/api/observability/v1/logs", nil)
+	request.Header.Set("Authorization", "Bearer studio-token")
+	request.Header.Set("x-business-domain", "bd_demo")
+	response := httptest.NewRecorder()
+
+	next(response, request)
+
+	if response.Code != http.StatusNoContent {
+		t.Fatalf("deployment tenant must complete the trusted scope: %d %s", response.Code, response.Body.String())
+	}
+	if resolver.trustedIdentity.TenantID != "openbkn-local" {
+		t.Fatalf("resolver must receive the deployment tenant: %+v", resolver.trustedIdentity)
+	}
+}
+
+func TestTrustedQueryMiddlewareRejectsTenantOutsideDeployment(t *testing.T) {
+	hydra := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = io.WriteString(w, `{"active":true,"sub":"acct_demo","client_id":"openbkn-studio","ext":{"visitor_type":"realname"}}`)
+	}))
+	defer hydra.Close()
+
+	handler := NewEvidenceHandlerWithSecurityConfig(evidencesvc.New(evidencestore.New()), EvidenceHandlerSecurityConfig{
+		HydraAdminURL: hydra.URL, DeploymentTenantID: "openbkn-local",
+	})
+	request := httptest.NewRequest(http.MethodGet, "/api/observability/v1/logs", nil)
+	request.Header.Set("Authorization", "Bearer studio-token")
+	request.Header.Set("x-tenant-id", "forged-tenant")
+	request.Header.Set("x-business-domain", "bd_demo")
+	response := httptest.NewRecorder()
+
+	handler.RequireTrustedQueryIdentity(func(http.ResponseWriter, *http.Request) {
+		t.Fatal("tenant mismatch must not reach the protected handler")
+	})(response, request)
+
+	if response.Code != http.StatusUnauthorized || !strings.Contains(response.Body.String(), "query_identity_mismatch") {
+		t.Fatalf("tenant mismatch must fail closed: %d %s", response.Code, response.Body.String())
+	}
+}
+
 func TestLifecycleIdentityRejectsOAuthUntilTenantDomainAuthorizationIsDelegated(t *testing.T) {
 	hydra := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path != "/admin/oauth2/introspect" || r.FormValue("token") != "lifecycle-token" {
@@ -353,6 +489,49 @@ func TestLifecycleIdentityRejectsIncompleteOwnerTupleAtGatewayBoundary(t *testin
 			"incomplete owner tuple must be rejected at the gateway boundary: %d %s",
 			response.Code, response.Body.String(),
 		)
+	}
+}
+
+func TestLifecycleIdentityTrustsGatewayOwnerWithoutReadAuthorizationLookup(t *testing.T) {
+	resolver := &fakeAccessScopeResolver{profile: evidencevo.AccessProfile{
+		TenantID: "tenant-1", BusinessDomain: "domain-1", ActorID: "subject-1",
+		EffectiveSubjectID: "subject-1", AccountActive: true, TenantActive: true,
+	}}
+	handler := NewEvidenceHandlerWithSecurityConfig(
+		evidencesvc.New(evidencestore.New()),
+		EvidenceHandlerSecurityConfig{
+			QueryGatewayToken: "trusted-gateway-token", AuthorizationScopeResolver: resolver,
+		},
+	)
+	nextCalled := false
+	request := httptest.NewRequest(
+		http.MethodPost,
+		"/api/agent-observability/v1/conversations:ensure-current",
+		nil,
+	)
+	request.Header.Set("X-BKN-Trace-Query-Token", "trusted-gateway-token")
+	request.Header.Set("x-account-id", "subject-1")
+	request.Header.Set("x-account-type", "user")
+	request.Header.Set("x-business-domain", "domain-1")
+	request.Header.Set("x-tenant-id", "tenant-1")
+	request.Header.Set("X-BKN-Application-Principal-ID", "context-loader")
+	request.Header.Set("X-BKN-Effective-Subject-Type", "user")
+	request.Header.Set("X-BKN-Effective-Subject-ID", "subject-1")
+	response := httptest.NewRecorder()
+
+	handler.RequireTrustedLifecycleIdentity(func(w http.ResponseWriter, r *http.Request) {
+		nextCalled = true
+		if _, ok := trustedQueryScopeFromContext(r.Context()); !ok {
+			t.Fatal("trusted lifecycle scope was not attached to the request")
+		}
+		w.WriteHeader(http.StatusNoContent)
+	})(response, request)
+
+	if response.Code != http.StatusNoContent || !nextCalled {
+		t.Fatalf("trusted gateway lifecycle write was rejected: %d %s", response.Code, response.Body.String())
+	}
+	if resolver.calls != 0 {
+		t.Fatalf("lifecycle writes must not perform read authorization lookups: %d", resolver.calls)
 	}
 }
 
@@ -468,6 +647,34 @@ func TestEvidenceHandlerAuthorizesTechnicalTraceByEvidenceOwnership(t *testing.T
 	rec := httptest.NewRecorder()
 	if handler.AuthorizeTechnicalTraceQuery(rec, denied) || rec.Code != http.StatusNotFound {
 		t.Fatalf("cross-domain trace access must not reveal existence: %d %s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestEvidenceHandlerAuthorizesTechnicalTraceByCoreProjectionOwnership(t *testing.T) {
+	const traceID = "9c0d0000000000000000000000000099"
+	store := evidencestore.New()
+	service := evidencesvc.NewWithProjectionSource(store, staticProjectionSource{
+		result: iprojectionsource.Result{Traces: []evidencevo.NormalizedTrace{{
+			TraceID: traceID, RequestID: "req-core", ConversationID: "conv-core",
+			BusinessDomain: "bd_demo", AccountID: "acct_demo", AccountType: "app",
+		}}},
+	})
+	handler := newDevEvidenceHandler(service)
+
+	allowed := authenticatedQueryRequest(
+		http.MethodGet,
+		"/api/agent-observability/v1/traces/"+traceID+"/trace-graph",
+		nil,
+	)
+	if rec := httptest.NewRecorder(); !handler.AuthorizeTechnicalTraceQuery(rec, allowed) {
+		t.Fatalf("Core projection owner must access technical trace: %d %s", rec.Code, rec.Body.String())
+	}
+
+	denied := authenticatedQueryRequest(http.MethodGet, allowed.URL.String(), nil)
+	denied.Header.Set("x-account-id", "acct_other")
+	rec := httptest.NewRecorder()
+	if handler.AuthorizeTechnicalTraceQuery(rec, denied) || rec.Code != http.StatusNotFound {
+		t.Fatalf("other account must not discover Core projection trace: %d %s", rec.Code, rec.Body.String())
 	}
 }
 
@@ -903,19 +1110,22 @@ func TestEvidenceHandlerListsBusinessRequestsAndRequestDetail(t *testing.T) {
 		t.Fatalf("seed artifact-linked event: %d %s", eventRec.Code, eventRec.Body.String())
 	}
 
-	listReq := authenticatedQueryRequest(http.MethodGet, "/api/agent-observability/v1/requests?keyword=原始问题&limit=10", nil)
+	mux := http.NewServeMux()
+	RegisterBusinessProvenanceRoutes(mux, "/api/agent-observability/v1", handler)
+
+	listReq := authenticatedQueryRequest(http.MethodGet, "/api/agent-observability/v1/business-provenance/requests?keyword=原始问题&limit=10", nil)
 	listReq.Header.Set("x-tenant-id", "tenant_demo")
 	listRec := httptest.NewRecorder()
-	handler.ListRequests(listRec, listReq)
+	mux.ServeHTTP(listRec, listReq)
 	if listRec.Code != http.StatusOK || !strings.Contains(listRec.Body.String(), `"request_id":"req_artifact_handler"`) ||
 		!strings.Contains(listRec.Body.String(), "用户原始问题") {
 		t.Fatalf("expected business request list, got %d: %s", listRec.Code, listRec.Body.String())
 	}
 
-	detailReq := authenticatedQueryRequest(http.MethodGet, "/api/agent-observability/v1/requests/req_artifact_handler", nil)
+	detailReq := authenticatedQueryRequest(http.MethodGet, "/api/agent-observability/v1/business-provenance/requests/req_artifact_handler", nil)
 	detailReq.Header.Set("x-tenant-id", "tenant_demo")
 	detailRec := httptest.NewRecorder()
-	handler.GetRequestSummary(detailRec, detailReq)
+	mux.ServeHTTP(detailRec, detailReq)
 	if detailRec.Code != http.StatusOK || !strings.Contains(detailRec.Body.String(), "用户原始问题") {
 		t.Fatalf("expected request detail, got %d: %s", detailRec.Code, detailRec.Body.String())
 	}
@@ -935,11 +1145,13 @@ func TestEvidenceHandlerListsBusinessProvenanceConversationsAndInteractions(t *t
 	if eventRec.Code != http.StatusAccepted {
 		t.Fatalf("seed event: %d %s", eventRec.Code, eventRec.Body.String())
 	}
+	mux := http.NewServeMux()
+	RegisterBusinessProvenanceRoutes(mux, "/api/agent-observability/v1", handler)
 
 	conversationReq := authenticatedQueryRequest(http.MethodGet, "/api/agent-observability/v1/business-provenance/conversations?limit=10", nil)
 	conversationReq.Header.Set("x-tenant-id", "tenant_demo")
 	conversationRec := httptest.NewRecorder()
-	handler.ListBusinessProvenanceConversations(conversationRec, conversationReq)
+	mux.ServeHTTP(conversationRec, conversationReq)
 	if conversationRec.Code != http.StatusOK || !strings.Contains(conversationRec.Body.String(), `"conversation_id":"conversation_handler"`) ||
 		!strings.Contains(conversationRec.Body.String(), `"interaction_count":1`) || !strings.Contains(conversationRec.Body.String(), `"request_count":1`) {
 		t.Fatalf("expected conversation projection, got %d: %s", conversationRec.Code, conversationRec.Body.String())
@@ -948,10 +1160,19 @@ func TestEvidenceHandlerListsBusinessProvenanceConversationsAndInteractions(t *t
 	interactionReq := authenticatedQueryRequest(http.MethodGet, "/api/agent-observability/v1/business-provenance/interactions?conversation_id=conversation_handler&limit=10", nil)
 	interactionReq.Header.Set("x-tenant-id", "tenant_demo")
 	interactionRec := httptest.NewRecorder()
-	handler.ListBusinessProvenanceInteractions(interactionRec, interactionReq)
+	mux.ServeHTTP(interactionRec, interactionReq)
 	if interactionRec.Code != http.StatusOK || !strings.Contains(interactionRec.Body.String(), `"interaction_id":"interaction_handler"`) ||
 		!strings.Contains(interactionRec.Body.String(), `"request_count":1`) {
 		t.Fatalf("expected interaction projection, got %d: %s", interactionRec.Code, interactionRec.Body.String())
+	}
+
+	detailReq := authenticatedQueryRequest(http.MethodGet, "/api/agent-observability/v1/business-provenance/interactions/interaction_handler", nil)
+	detailReq.Header.Set("x-tenant-id", "tenant_demo")
+	detailRec := httptest.NewRecorder()
+	mux.ServeHTTP(detailRec, detailReq)
+	if detailRec.Code != http.StatusOK || !strings.Contains(detailRec.Body.String(), `"interaction_id":"interaction_handler"`) ||
+		!strings.Contains(detailRec.Body.String(), `"request_id":"req_artifact_handler"`) {
+		t.Fatalf("expected interaction detail, got %d: %s", detailRec.Code, detailRec.Body.String())
 	}
 }
 
@@ -963,10 +1184,12 @@ func TestEvidenceHandlerListsRequestTracesAndTechnicalExecutions(t *testing.T) {
 	if ingestRec.Code != http.StatusAccepted {
 		t.Fatalf("seed evidence: %d %s", ingestRec.Code, ingestRec.Body.String())
 	}
+	mux := http.NewServeMux()
+	RegisterBusinessProvenanceRoutes(mux, "/api/agent-observability/v1", handler)
 
-	requestTracesReq := authenticatedQueryRequest(http.MethodGet, "/api/agent-observability/v1/requests/req_handler_001/traces", nil)
+	requestTracesReq := authenticatedQueryRequest(http.MethodGet, "/api/agent-observability/v1/business-provenance/requests/req_handler_001/traces", nil)
 	requestTracesRec := httptest.NewRecorder()
-	handler.ListRequestTraces(requestTracesRec, requestTracesReq)
+	mux.ServeHTTP(requestTracesRec, requestTracesReq)
 	if requestTracesRec.Code != http.StatusOK || !strings.Contains(requestTracesRec.Body.String(), `"request_id":"req_handler_001"`) ||
 		!strings.Contains(requestTracesRec.Body.String(), `"trace_id":"9c0d0000000000000000000000000001"`) {
 		t.Fatalf("expected request traces, got %d: %s", requestTracesRec.Code, requestTracesRec.Body.String())
@@ -1072,7 +1295,7 @@ func TestNewAPIErrorResponseIncludesStandardTraceFieldsAndCompatibilityCode(t *t
 func TestNewAPISuccessResponseIncludesPropagatedTraceHeader(t *testing.T) {
 	const traceID = "cccccccccccccccccccccccccccccccc"
 	handler := newDevEvidenceHandler(evidencesvc.New(evidencestore.New()))
-	req := authenticatedQueryRequest(http.MethodGet, "/api/agent-observability/v1/requests", nil)
+	req := authenticatedQueryRequest(http.MethodGet, "/api/agent-observability/v1/business-provenance/requests", nil)
 	req.Header.Set("traceparent", "00-"+traceID+"-dddddddddddddddd-01")
 	rec := httptest.NewRecorder()
 
@@ -1099,12 +1322,12 @@ func TestArtifactIDPathUsesSameSafeFormatAsArtifactIngest(t *testing.T) {
 }
 
 func TestInteractionSummaryPathRejectsNestedOrEmptyIDs(t *testing.T) {
-	if got := interactionIDFromSummaryPath("/api/agent-observability/v1/interactions/int_supply_chain"); got != "int_supply_chain" {
+	if got := interactionIDFromSummaryPath("/api/agent-observability/v1/business-provenance/interactions/int_supply_chain"); got != "int_supply_chain" {
 		t.Fatalf("unexpected interaction id: %q", got)
 	}
 	for _, path := range []string{
-		"/api/agent-observability/v1/interactions/",
-		"/api/agent-observability/v1/interactions/int%2Fchild",
+		"/api/agent-observability/v1/business-provenance/interactions/",
+		"/api/agent-observability/v1/business-provenance/interactions/int%2Fchild",
 	} {
 		if got := interactionIDFromSummaryPath(path); got != "" {
 			t.Fatalf("unsafe interaction path must be rejected: path=%q id=%q", path, got)

--- a/bkn-trace/agent-observability/src/driveradapter/api/httphandler/summary_handler.go
+++ b/bkn-trace/agent-observability/src/driveradapter/api/httphandler/summary_handler.go
@@ -13,6 +13,31 @@ import (
 	"github.com/openbkn-ai/bkn-foundry/bkn-trace/agent-observability/src/driveradapter/api/rdto"
 )
 
+func RegisterBusinessProvenanceRoutes(
+	mux *http.ServeMux,
+	basePath string,
+	handler *EvidenceHandler,
+	middleware ...func(http.HandlerFunc) http.HandlerFunc,
+) {
+	wrap := func(next http.HandlerFunc) http.HandlerFunc {
+		for index := len(middleware) - 1; index >= 0; index-- {
+			next = middleware[index](next)
+		}
+		return next
+	}
+	mux.HandleFunc(basePath+"/business-provenance/conversations", wrap(handler.ListBusinessProvenanceConversations))
+	mux.HandleFunc(basePath+"/business-provenance/interactions", wrap(handler.ListBusinessProvenanceInteractions))
+	mux.HandleFunc(basePath+"/business-provenance/interactions/", wrap(handler.GetInteractionSummary))
+	mux.HandleFunc(basePath+"/business-provenance/requests", wrap(handler.ListRequests))
+	mux.HandleFunc(basePath+"/business-provenance/requests/", wrap(func(w http.ResponseWriter, r *http.Request) {
+		if strings.HasSuffix(strings.TrimSuffix(r.URL.Path, "/"), "/traces") {
+			handler.ListRequestTraces(w, r)
+			return
+		}
+		handler.GetRequestSummary(w, r)
+	}))
+}
+
 // ListBusinessProvenanceConversations godoc
 // @Summary List observable business conversations
 // @Description Returns one authorized business-provenance row per conversation, aggregated from real interactions and requests.
@@ -111,6 +136,7 @@ func (h *EvidenceHandler) ListBusinessProvenanceInteractions(w http.ResponseWrit
 // @Failure 400 {object} rdto.ErrorResponse
 // @Failure 401 {object} rdto.ErrorResponse
 // @Failure 500 {object} rdto.ErrorResponse
+// @Router /business-provenance/requests [get]
 func (h *EvidenceHandler) ListRequests(w http.ResponseWriter, r *http.Request) {
 	ensureResponseTraceID(w, r)
 	if r.Method != http.MethodGet {
@@ -140,6 +166,7 @@ func (h *EvidenceHandler) ListRequests(w http.ResponseWriter, r *http.Request) {
 // @Failure 401 {object} rdto.ErrorResponse
 // @Failure 404 {object} rdto.ErrorResponse
 // @Failure 500 {object} rdto.ErrorResponse
+// @Router /business-provenance/requests/{request_id} [get]
 func (h *EvidenceHandler) GetRequestSummary(w http.ResponseWriter, r *http.Request) {
 	ensureResponseTraceID(w, r)
 	if r.Method != http.MethodGet {
@@ -178,6 +205,7 @@ func (h *EvidenceHandler) GetRequestSummary(w http.ResponseWriter, r *http.Reque
 // @Failure 401 {object} rdto.ErrorResponse
 // @Failure 404 {object} rdto.ErrorResponse
 // @Failure 500 {object} rdto.ErrorResponse
+// @Router /business-provenance/interactions/{interaction_id} [get]
 func (h *EvidenceHandler) GetInteractionSummary(w http.ResponseWriter, r *http.Request) {
 	ensureResponseTraceID(w, r)
 	if r.Method != http.MethodGet {
@@ -219,7 +247,7 @@ func (h *EvidenceHandler) GetInteractionSummary(w http.ResponseWriter, r *http.R
 // @Failure 400 {object} rdto.ErrorResponse
 // @Failure 401 {object} rdto.ErrorResponse
 // @Failure 500 {object} rdto.ErrorResponse
-// @Router /requests/{request_id}/traces [get]
+// @Router /business-provenance/requests/{request_id}/traces [get]
 func (h *EvidenceHandler) ListRequestTraces(w http.ResponseWriter, r *http.Request) {
 	ensureResponseTraceID(w, r)
 	if r.Method != http.MethodGet {
@@ -336,7 +364,7 @@ func (h *EvidenceHandler) summaryQueryOptionsFromRequest(w http.ResponseWriter, 
 }
 
 func requestIDFromSummaryPath(path string, traces bool) string {
-	const prefix = "/api/agent-observability/v1/requests/"
+	const prefix = "/api/agent-observability/v1/business-provenance/requests/"
 	if !strings.HasPrefix(path, prefix) {
 		return ""
 	}
@@ -357,7 +385,7 @@ func requestIDFromSummaryPath(path string, traces bool) string {
 }
 
 func interactionIDFromSummaryPath(path string) string {
-	const prefix = "/api/agent-observability/v1/interactions/"
+	const prefix = "/api/agent-observability/v1/business-provenance/interactions/"
 	if !strings.HasPrefix(path, prefix) {
 		return ""
 	}

--- a/bkn-trace/agent-observability/src/driveradapter/api/httphandler/traceauthz.go
+++ b/bkn-trace/agent-observability/src/driveradapter/api/httphandler/traceauthz.go
@@ -20,10 +20,8 @@ const accountAttrField = "attributes.bkn.account.id.keyword"
 
 const headerBaggage = "baggage"
 
-// identity is the caller resolved from gateway-propagated baggage. Trace
-// services do not verify tokens themselves — the gateway authenticates and
-// forwards bkn.account.id / bkn.account.type, the same trusted-header model the
-// rest of the platform uses.
+// identity is the caller resolved by the trusted query middleware or, for
+// backwards-compatible internal calls, gateway-propagated baggage.
 type identity struct {
 	accountID   string
 	accountType string
@@ -34,6 +32,11 @@ type identity struct {
 // ("bkn.account.type=user,bkn.account.id=u-1,..."). present is false when no
 // account id is carried.
 func identityFromRequest(r *http.Request) identity {
+	if scope, ok := trustedQueryScopeFromContext(r.Context()); ok {
+		id := identity{accountID: scope.AccountID, accountType: scope.AccountType}
+		id.present = id.accountID != ""
+		return id
+	}
 	bag := parseBaggage(r.Header.Get(headerBaggage))
 	id := identity{
 		accountID:   bag["bkn.account.id"],

--- a/bkn-trace/agent-observability/src/port/driven/iprojectionsource/port.go
+++ b/bkn-trace/agent-observability/src/port/driven/iprojectionsource/port.go
@@ -15,6 +15,7 @@ type Query struct {
 	Status         string
 	RequestID      string
 	TraceID        string
+	InteractionID  string
 	Limit          int
 }
 

--- a/bkn-trace/otelcol-contribute-chart/README.md
+++ b/bkn-trace/otelcol-contribute-chart/README.md
@@ -19,7 +19,7 @@ ghcr.io/<github_org_or_user>/charts/otelcol-contrib
 当前版本：
 
 - Chart version: `0.1.0`
-- App version: `0.145.0`
+- App version: `0.148.0`
 
 ---
 
@@ -35,6 +35,8 @@ ghcr.io/<github_org_or_user>/charts/otelcol-contrib
 │           ├── _helpers.tpl
 │           ├── configmap.yaml
 │           ├── deployment.yaml
+│           ├── networkpolicy.yaml
+│           ├── prometheusrule.yaml
 │           ├── service.yaml
 │           ├── serviceaccount.yaml
 │           └── NOTES.txt
@@ -43,7 +45,9 @@ ghcr.io/<github_org_or_user>/charts/otelcol-contrib
 │       ├── chart-ci.yaml
 │       └── chart-release.yaml
 └── scripts/
-    └── create-nodeport-service.sh
+    ├── create-nodeport-service.sh
+    ├── test_4c8g_baseline.sh
+    └── validate_collector_config.sh
 ```
 
 ---
@@ -64,10 +68,10 @@ ghcr.io/<github_org_or_user>/charts/otelcol-contrib
 
 可通过 `values.yaml` 的 `opensearchExporter` 段配置 OpenSearch exporter，也可直接覆盖 `config` 段自定义 collector 配置。
 
-默认 collector 镜像使用国内镜像源：
+默认 collector 镜像：
 
 ```text
-swr.cn-north-4.myhuaweicloud.com/ddn-k8s/ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:0.145.0
+docker.io/otel/opentelemetry-collector-contrib:0.148.0
 ```
 
 默认会渲染以下 exporter 结构：
@@ -82,6 +86,15 @@ exporters:
     dataset: default
     namespace: namespace
     bulk_action: create
+    sending_queue:
+      enabled: true
+      num_consumers: 2
+      queue_size: 2048
+    retry_on_failure:
+      enabled: true
+      initial_interval: 1s
+      max_interval: 30s
+      max_elapsed_time: 5m
     mapping:
       mode: ss4o
 ```
@@ -89,6 +102,18 @@ exporters:
 如果开启 `opensearchExporter.auth.enabled=true`，chart 会自动增加 `basicauth/client` extension，并通过 `opensearch.http.auth.authenticator` 将其绑定到 exporter。
 
 注意：官方 `opensearchexporter` 当前支持 `traces` 和 `logs`，默认不为 `metrics` 创建 OpenSearch 导出 pipeline。
+
+### 4C8G 最小部署基线
+
+默认单副本 Collector 限制为 `500m CPU / 512MiB`，适配 OpenBKN `4C8G` 最小环境：
+
+- `memory_limiter`：`384MiB` 上限、`96MiB` 突发余量，位于 `batch` 之前；
+- `batch`：512 条目标批次、1024 条硬上限、5 秒刷新；
+- OpenSearch 发送队列：2048 批、2 个消费者；
+- OpenSearch 失败重试：指数退避，最长 5 分钟；
+- 健康端点：`:13133/`；Collector 指标：`:8888/metrics`。
+
+`monitoring.prometheusRule.enabled=true` 时渲染队列接近容量、日志导出失败和遥测拒绝告警。`networkPolicy.enabled=true` 时只允许带 `openbkn.ai/otel-producer=true` 标签的同命名空间 Pod 写入 OTLP，并允许指定监控命名空间抓取指标。两项默认关闭，启用前必须核对目标集群的 CRD、命名空间和工作负载标签。
 
 ---
 
@@ -141,7 +166,11 @@ helm pull oci://ghcr.io/<github_org_or_user>/charts/otelcol-contrib --version <v
 ```bash
 helm lint charts/otelcol-contrib
 helm template otelcol-contrib charts/otelcol-contrib
+bash scripts/test_4c8g_baseline.sh charts/otelcol-contrib
+./scripts/validate_collector_config.sh charts/otelcol-contrib
 ```
+
+最后一条命令使用 chart 锁定版本的真实 Collector 二进制执行离线 `validate`，需要本机 Docker 可用。
 
 安装示例：
 

--- a/bkn-trace/otelcol-contribute-chart/charts/otelcol-contrib/Chart.yaml
+++ b/bkn-trace/otelcol-contribute-chart/charts/otelcol-contrib/Chart.yaml
@@ -3,7 +3,7 @@ name: otelcol-contrib
 description: Helm chart for OpenTelemetry Collector Contrib with OCI publishing to GHCR
 type: application
 version: 0.1.0
-appVersion: "0.145.0"
+appVersion: "0.148.0"
 home: https://github.com/openbkn-ai/bkn-foundry/tree/main/bkn-trace/otelcol-contribute-chart
 sources:
   - https://github.com/open-telemetry/opentelemetry-collector-contrib

--- a/bkn-trace/otelcol-contribute-chart/charts/otelcol-contrib/templates/configmap.yaml
+++ b/bkn-trace/otelcol-contribute-chart/charts/otelcol-contrib/templates/configmap.yaml
@@ -11,6 +11,8 @@ metadata:
 {{- $_ := set $config "exporters" (dict) }}
 {{- end }}
 {{- $opensearch := dict "http" (dict "endpoint" .Values.opensearchExporter.http.endpoint) "bulk_action" .Values.opensearchExporter.bulkAction "dataset" .Values.opensearchExporter.dataset "namespace" .Values.opensearchExporter.namespace }}
+{{- $_ := set $opensearch "sending_queue" (dict "enabled" .Values.opensearchExporter.sendingQueue.enabled "num_consumers" .Values.opensearchExporter.sendingQueue.numConsumers "queue_size" .Values.opensearchExporter.sendingQueue.queueSize) }}
+{{- $_ := set $opensearch "retry_on_failure" (dict "enabled" .Values.opensearchExporter.retryOnFailure.enabled "initial_interval" .Values.opensearchExporter.retryOnFailure.initialInterval "max_interval" .Values.opensearchExporter.retryOnFailure.maxInterval "max_elapsed_time" .Values.opensearchExporter.retryOnFailure.maxElapsedTime) }}
 {{- if hasKey .Values.opensearchExporter.http "tls" }}
 {{- $tls := dict }}
 {{- if hasKey .Values.opensearchExporter.http.tls "insecure" }}

--- a/bkn-trace/otelcol-contribute-chart/charts/otelcol-contrib/templates/deployment.yaml
+++ b/bkn-trace/otelcol-contribute-chart/charts/otelcol-contrib/templates/deployment.yaml
@@ -42,6 +42,12 @@ spec:
             - name: otlp-http
               containerPort: {{ .Values.service.ports.http }}
               protocol: TCP
+            - name: health
+              containerPort: {{ .Values.service.ports.health }}
+              protocol: TCP
+            - name: metrics
+              containerPort: {{ .Values.service.ports.metrics }}
+              protocol: TCP
           env:
             {{- with .Values.extraEnvs }}
             {{- toYaml . | nindent 12 }}
@@ -51,6 +57,18 @@ spec:
               mountPath: /conf
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
+          livenessProbe:
+            httpGet:
+              path: /
+              port: health
+            initialDelaySeconds: 10
+            periodSeconds: 10
+          readinessProbe:
+            httpGet:
+              path: /
+              port: health
+            initialDelaySeconds: 5
+            periodSeconds: 10
       volumes:
         - name: config
           configMap:

--- a/bkn-trace/otelcol-contribute-chart/charts/otelcol-contrib/templates/networkpolicy.yaml
+++ b/bkn-trace/otelcol-contribute-chart/charts/otelcol-contrib/templates/networkpolicy.yaml
@@ -1,0 +1,36 @@
+{{- if .Values.networkPolicy.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ include "otelcol-contrib.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: {{ include "otelcol-contrib.name" . }}
+      app.kubernetes.io/instance: {{ .Release.Name }}
+  policyTypes:
+    - Ingress
+  ingress:
+    - from:
+        - podSelector:
+            matchLabels:
+              {{- toYaml .Values.networkPolicy.producerPodLabels | nindent 14 }}
+      ports:
+        - port: otlp-grpc
+          protocol: TCP
+        - port: otlp-http
+          protocol: TCP
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              {{- toYaml .Values.networkPolicy.monitoringNamespaceLabels | nindent 14 }}
+          {{- with .Values.networkPolicy.monitoringPodLabels }}
+          podSelector:
+            matchLabels:
+              {{- toYaml . | nindent 14 }}
+          {{- end }}
+      ports:
+        - port: metrics
+          protocol: TCP
+{{- end }}

--- a/bkn-trace/otelcol-contribute-chart/charts/otelcol-contrib/templates/prometheusrule.yaml
+++ b/bkn-trace/otelcol-contribute-chart/charts/otelcol-contrib/templates/prometheusrule.yaml
@@ -1,0 +1,41 @@
+{{- if .Values.monitoring.prometheusRule.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: {{ include "otelcol-contrib.fullname" . }}
+  namespace: {{ default .Release.Namespace .Values.monitoring.prometheusRule.namespace | quote }}
+  labels:
+    app.kubernetes.io/name: {{ include "otelcol-contrib.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    {{- with .Values.monitoring.prometheusRule.additionalLabels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+spec:
+  groups:
+    - name: {{ include "otelcol-contrib.fullname" . }}.resilience
+      rules:
+        - alert: OpenBKNOtelCollectorQueueNearCapacity
+          expr: max(otelcol_exporter_queue_size) / clamp_min(max(otelcol_exporter_queue_capacity), 1) > {{ .Values.monitoring.prometheusRule.queueUtilizationThreshold }}
+          for: {{ .Values.monitoring.prometheusRule.for }}
+          labels:
+            severity: warning
+          annotations:
+            summary: OpenBKN telemetry export queue is near capacity
+            description: The Collector export queue has remained above the configured utilization threshold.
+        - alert: OpenBKNOtelCollectorLogExportFailure
+          expr: sum(rate(otelcol_exporter_send_failed_log_records_total[5m])) > 0
+          for: {{ .Values.monitoring.prometheusRule.for }}
+          labels:
+            severity: critical
+          annotations:
+            summary: OpenBKN logs are failing to reach the storage backend
+            description: The Collector is reporting failed log record exports.
+        - alert: OpenBKNOtelCollectorRefusedTelemetry
+          expr: sum(rate(otelcol_receiver_refused_log_records_total[5m])) + sum(rate(otelcol_receiver_refused_spans_total[5m])) > 0
+          for: {{ .Values.monitoring.prometheusRule.for }}
+          labels:
+            severity: critical
+          annotations:
+            summary: OpenBKN telemetry is being refused
+            description: The Collector has refused incoming logs or spans, commonly due to memory pressure.
+{{- end }}

--- a/bkn-trace/otelcol-contribute-chart/charts/otelcol-contrib/templates/service.yaml
+++ b/bkn-trace/otelcol-contribute-chart/charts/otelcol-contrib/templates/service.yaml
@@ -23,3 +23,11 @@ spec:
       port: {{ .Values.service.ports.http }}
       targetPort: otlp-http
       protocol: TCP
+    - name: health
+      port: {{ .Values.service.ports.health }}
+      targetPort: health
+      protocol: TCP
+    - name: metrics
+      port: {{ .Values.service.ports.metrics }}
+      targetPort: metrics
+      protocol: TCP

--- a/bkn-trace/otelcol-contribute-chart/charts/otelcol-contrib/values.yaml
+++ b/bkn-trace/otelcol-contribute-chart/charts/otelcol-contrib/values.yaml
@@ -33,10 +33,33 @@ affinity: {}
 
 service:
   type: ClusterIP
-  annotations: {}
+  annotations:
+    prometheus.io/scrape: "true"
+    prometheus.io/port: "8888"
+    prometheus.io/path: /metrics
   ports:
     grpc: 4317
     http: 4318
+    health: 13133
+    metrics: 8888
+
+monitoring:
+  prometheusRule:
+    enabled: false
+    namespace: ""
+    additionalLabels: {}
+    queueUtilizationThreshold: 0.8
+    for: 5m
+
+# Enable only after confirming that producer and monitoring pod labels match
+# the target cluster. The policy protects OTLP ingestion from arbitrary pods.
+networkPolicy:
+  enabled: false
+  producerPodLabels:
+    openbkn.ai/otel-producer: "true"
+  monitoringNamespaceLabels:
+    kubernetes.io/metadata.name: monitoring
+  monitoringPodLabels: {}
 
 opensearchExporter:
   enabled: true
@@ -63,12 +86,25 @@ opensearchExporter:
     dedup: false
     dedot: false
   bulkAction: create
+  sendingQueue:
+    enabled: true
+    numConsumers: 2
+    queueSize: 2048
+  retryOnFailure:
+    enabled: true
+    initialInterval: 1s
+    maxInterval: 30s
+    maxElapsedTime: 5m
 
 debugExporter:
   enabled: false
   verbosity: detailed
 
 config:
+  extensions:
+    health_check:
+      endpoint: 0.0.0.0:13133
+
   receivers:
     otlp:
       protocols:
@@ -78,17 +114,25 @@ config:
           endpoint: 0.0.0.0:4318
 
   processors:
-    batch: {}
+    memory_limiter:
+      check_interval: 1s
+      limit_mib: 384
+      spike_limit_mib: 96
+    batch:
+      timeout: 5s
+      send_batch_size: 512
+      send_batch_max_size: 1024
 
   service:
+    extensions: [health_check]
     pipelines:
       traces:
         receivers: [otlp]
-        processors: [batch]
+        processors: [memory_limiter, batch]
         exporters: [opensearch]
       logs:
         receivers: [otlp]
-        processors: [batch]
+        processors: [memory_limiter, batch]
         exporters: [opensearch]
 
 extraArgs: []

--- a/bkn-trace/otelcol-contribute-chart/charts/otelcol-contrib/values.yaml
+++ b/bkn-trace/otelcol-contribute-chart/charts/otelcol-contrib/values.yaml
@@ -125,6 +125,14 @@ config:
 
   service:
     extensions: [health_check]
+    telemetry:
+      metrics:
+        readers:
+          - pull:
+              exporter:
+                prometheus:
+                  host: 0.0.0.0
+                  port: 8888
     pipelines:
       traces:
         receivers: [otlp]

--- a/bkn-trace/otelcol-contribute-chart/scripts/test_4c8g_baseline.sh
+++ b/bkn-trace/otelcol-contribute-chart/scripts/test_4c8g_baseline.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+chart_dir="${1:-charts/otelcol-contrib}"
+rendered="$(helm template otelcol-contrib "${chart_dir}")"
+
+assert_contains() {
+  local needle="$1"
+  if ! grep -Fq -- "${needle}" <<<"${rendered}"; then
+    echo "expected rendered chart to contain: ${needle}" >&2
+    exit 1
+  fi
+}
+
+assert_contains "memory_limiter:"
+assert_contains "limit_mib: 384"
+assert_contains "spike_limit_mib: 96"
+assert_contains "processors:"
+assert_contains "- memory_limiter"
+assert_contains "send_batch_max_size: 1024"
+assert_contains "sending_queue:"
+assert_contains "queue_size: 2048"
+assert_contains "retry_on_failure:"
+assert_contains "max_elapsed_time: 5m"
+assert_contains "health_check:"
+assert_contains "endpoint: 0.0.0.0:13133"
+assert_contains "path: /"
+assert_contains "port: health"
+assert_contains "name: metrics"
+assert_contains "containerPort: 8888"
+
+if ! grep -Fq "memory: 512Mi" <<<"${rendered}"; then
+  echo "collector memory limit must fit the OpenBKN 4C8G baseline" >&2
+  exit 1
+fi
+
+if grep -Fq "kind: PrometheusRule" <<<"${rendered}" || grep -Fq "kind: NetworkPolicy" <<<"${rendered}"; then
+  echo "cluster-specific monitoring and network policy resources must be opt in" >&2
+  exit 1
+fi
+
+governed_rendered="$(helm template otelcol-contrib "${chart_dir}" \
+  --set monitoring.prometheusRule.enabled=true \
+  --set networkPolicy.enabled=true)"
+if ! grep -Fq "kind: PrometheusRule" <<<"${governed_rendered}"; then
+  echo "enabled collector alerts were not rendered" >&2
+  exit 1
+fi
+if ! grep -Fq "otelcol_exporter_queue_size" <<<"${governed_rendered}" ||
+   ! grep -Fq "otelcol_exporter_send_failed_log_records_total" <<<"${governed_rendered}"; then
+  echo "collector queue and export-failure alerts are incomplete" >&2
+  exit 1
+fi
+if ! grep -Fq "kind: NetworkPolicy" <<<"${governed_rendered}" ||
+   ! grep -Fq "openbkn.ai/otel-producer: \"true\"" <<<"${governed_rendered}"; then
+  echo "collector trusted-ingress policy was not rendered" >&2
+  exit 1
+fi

--- a/bkn-trace/otelcol-contribute-chart/scripts/test_4c8g_baseline.sh
+++ b/bkn-trace/otelcol-contribute-chart/scripts/test_4c8g_baseline.sh
@@ -28,6 +28,8 @@ assert_contains "path: /"
 assert_contains "port: health"
 assert_contains "name: metrics"
 assert_contains "containerPort: 8888"
+assert_contains "host: 0.0.0.0"
+assert_contains "port: 8888"
 
 if ! grep -Fq "memory: 512Mi" <<<"${rendered}"; then
   echo "collector memory limit must fit the OpenBKN 4C8G baseline" >&2

--- a/bkn-trace/otelcol-contribute-chart/scripts/validate_collector_config.sh
+++ b/bkn-trace/otelcol-contribute-chart/scripts/validate_collector_config.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+chart_dir="${1:-charts/otelcol-contrib}"
+image="${OTELCOL_IMAGE:-otel/opentelemetry-collector-contrib:0.148.0}"
+config_file="$(mktemp -t openbkn-otelcol-config.XXXXXX.yaml)"
+trap 'rm -f "${config_file}"' EXIT
+
+helm template otelcol-contrib "${chart_dir}" --show-only templates/configmap.yaml |
+  awk '/collector-config.yaml: \|/{found=1; next} found{sub(/^    /, ""); print}' >"${config_file}"
+
+docker run --rm \
+  -v "${config_file}:/conf/collector-config.yaml:ro" \
+  "${image}" validate --config=/conf/collector-config.yaml

--- a/docs/api/agent-observability/agent-observability.yaml
+++ b/docs/api/agent-observability/agent-observability.yaml
@@ -602,6 +602,10 @@ definitions:
         items:
           type: string
         type: array
+      operation_id:
+        type: string
+      operation_key:
+        type: string
       partial_reasons:
         items:
           type: string
@@ -615,6 +619,8 @@ definitions:
       started_at:
         type: string
       status:
+        type: string
+      tool_name:
         type: string
       trace_count:
         type: integer
@@ -1964,6 +1970,201 @@ paths:
       summary: List observable business interactions
       tags:
       - business-provenance
+  /business-provenance/interactions/{interaction_id}:
+    get:
+      description: Aggregates every authorized request and trace in one caller-owned
+        interaction.
+      parameters:
+      - description: BKN interaction ID
+        in: path
+        name: interaction_id
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/evidencevo.InteractionSummary'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/rdto.ErrorResponse'
+        "401":
+          description: Unauthorized
+          schema:
+            $ref: '#/definitions/rdto.ErrorResponse'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/rdto.ErrorResponse'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/rdto.ErrorResponse'
+      summary: Get one observable business interaction
+      tags:
+      - interactions
+  /business-provenance/requests:
+    get:
+      description: Returns stable request summaries generated from authorized evidence
+        and artifacts.
+      parameters:
+      - description: Page size, 1..200
+        in: query
+        name: limit
+        type: integer
+      - description: Opaque pagination cursor
+        in: query
+        name: cursor
+        type: string
+      - description: Caller-owned conversation ID
+        in: query
+        name: conversation_id
+        type: string
+      - description: One user interaction ID
+        in: query
+        name: interaction_id
+        type: string
+      - description: Started at or after this RFC3339 timestamp
+        in: query
+        name: from
+        type: string
+      - description: Started at or before this RFC3339 timestamp
+        in: query
+        name: to
+        type: string
+      - description: Execution status
+        in: query
+        name: status
+        type: string
+      - description: Agent or application
+        in: query
+        name: agent_or_app
+        type: string
+      - description: Business domain
+        in: query
+        name: business_domain
+        type: string
+      - description: Knowledge network
+        in: query
+        name: knowledge_network
+        type: string
+      - description: Evidence completeness
+        in: query
+        name: evidence_completeness
+        type: string
+      - description: Question, result, ID, business ref, or error keyword
+        in: query
+        name: keyword
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/evidencevo.RequestSummaryPage'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/rdto.ErrorResponse'
+        "401":
+          description: Unauthorized
+          schema:
+            $ref: '#/definitions/rdto.ErrorResponse'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/rdto.ErrorResponse'
+      summary: List observable business requests
+      tags:
+      - requests
+  /business-provenance/requests/{request_id}:
+    get:
+      description: Returns an authorized request summary and its business-content
+        availability.
+      parameters:
+      - description: BKN request ID
+        in: path
+        name: request_id
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/evidencevo.RequestSummary'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/rdto.ErrorResponse'
+        "401":
+          description: Unauthorized
+          schema:
+            $ref: '#/definitions/rdto.ErrorResponse'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/rdto.ErrorResponse'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/rdto.ErrorResponse'
+      summary: Get one observable business request
+      tags:
+      - requests
+  /business-provenance/requests/{request_id}/traces:
+    get:
+      description: Supports one business request to multiple distributed traces and
+        returns request_id on every trace.
+      parameters:
+      - description: BKN request ID
+        in: path
+        name: request_id
+        required: true
+        type: string
+      - description: Page size, 1..200
+        in: query
+        name: limit
+        type: integer
+      - description: Opaque pagination cursor
+        in: query
+        name: cursor
+        type: string
+      - description: Caller-owned conversation ID
+        in: query
+        name: conversation_id
+        type: string
+      - description: One user interaction ID
+        in: query
+        name: interaction_id
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/evidencevo.TraceSummaryPage'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/rdto.ErrorResponse'
+        "401":
+          description: Unauthorized
+          schema:
+            $ref: '#/definitions/rdto.ErrorResponse'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/rdto.ErrorResponse'
+      summary: List technical traces belonging to a business request
+      tags:
+      - requests
   /conversations:
     get:
       parameters:
@@ -3141,54 +3342,6 @@ paths:
       summary: Get one request projection from durable Receipts
       tags:
       - lifecycle
-  /requests/{request_id}/traces:
-    get:
-      description: Supports one business request to multiple distributed traces and
-        returns request_id on every trace.
-      parameters:
-      - description: BKN request ID
-        in: path
-        name: request_id
-        required: true
-        type: string
-      - description: Page size, 1..200
-        in: query
-        name: limit
-        type: integer
-      - description: Opaque pagination cursor
-        in: query
-        name: cursor
-        type: string
-      - description: Caller-owned conversation ID
-        in: query
-        name: conversation_id
-        type: string
-      - description: One user interaction ID
-        in: query
-        name: interaction_id
-        type: string
-      produces:
-      - application/json
-      responses:
-        "200":
-          description: OK
-          schema:
-            $ref: '#/definitions/evidencevo.TraceSummaryPage'
-        "400":
-          description: Bad Request
-          schema:
-            $ref: '#/definitions/rdto.ErrorResponse'
-        "401":
-          description: Unauthorized
-          schema:
-            $ref: '#/definitions/rdto.ErrorResponse'
-        "500":
-          description: Internal Server Error
-          schema:
-            $ref: '#/definitions/rdto.ErrorResponse'
-      summary: List technical traces belonging to a business request
-      tags:
-      - requests
   /trace-executions:
     get:
       description: Returns stable trace summaries with reverse request links, generated


### PR DESCRIPTION
## 概要
- 以 Conversation → Interaction → OpenBKN Operation 建立业务溯源投影，Request/Trace 仅作为技术下钻
- 补齐 Context Loader 受管生命周期、业务证据事件与安全日志关联
- 完善统一日志查询、签名游标、局部失败、OpenSearch 核心投影和 API 合同
- 加固 4C8G Collector 配置、NetworkPolicy、PrometheusRule 与静态校验

## 验证
- Context Loader: GOCACHE=/tmp/openbkn-context-go-cache go test ./...
- agent-observability: GOCACHE=/tmp/openbkn-go-cache go test ./...
- Collector: test_4c8g_baseline.sh + validate_collector_config.sh
- git diff --check origin/main...HEAD

关联：#547、#545
设计文档：openbkn-ai/bkn-docs#29