### PR TITLE
fix(observability): 收紧核心投影精确查询

### DIFF
--- a/bkn-trace/agent-observability/src/drivenadapter/httpaccess/opensearchcoreprojection/source.go
+++ b/bkn-trace/agent-observability/src/drivenadapter/httpaccess/opensearchcoreprojection/source.go
@@ -104,7 +104,7 @@ func (s *Source) loadReceipts(ctx context.Context, query iprojectionsource.Query
 		"interaction_id":           query.InteractionID,
 	} {
 		if value != "" {
-			must = append(must, exactTermQuery(field, value))
+			must = append(must, exactKeywordQuery(field, value))
 		}
 	}
 	if !query.From.IsZero() || !query.To.IsZero() {
@@ -148,16 +148,8 @@ func (s *Source) loadReceipts(ctx context.Context, query iprojectionsource.Query
 	return result, len(response.Hits.Hits) >= size, nil
 }
 
-func exactTermQuery(field string, value string) map[string]any {
-	return map[string]any{
-		"bool": map[string]any{
-			"should": []map[string]any{
-				{"term": map[string]any{field: map[string]any{"value": value}}},
-				{"term": map[string]any{field + ".keyword": map[string]any{"value": value}}},
-			},
-			"minimum_should_match": 1,
-		},
-	}
+func exactKeywordQuery(field string, value string) map[string]any {
+	return map[string]any{"term": map[string]any{field + ".keyword": map[string]any{"value": value}}}
 }
 
 func receiptMatchesScope(receipt receiptDocument, scope evidencevo.QueryScope) bool {

--- a/bkn-trace/agent-observability/src/drivenadapter/httpaccess/opensearchcoreprojection/source_test.go
+++ b/bkn-trace/agent-observability/src/drivenadapter/httpaccess/opensearchcoreprojection/source_test.go
@@ -36,6 +36,11 @@ func TestSourceBuildsAuthorizedExecutionProjectionFromCoreReceiptsAndArtifacts(t
 				t.Fatalf("authorization filter %q must use exact keyword matching: %s", field, body)
 			}
 		}
+		for _, field := range []string{"owner.tenant_id", "owner.business_domain_id"} {
+			if strings.Contains(queryBody, `"`+field+`":{"value"`) {
+				t.Fatalf("identifier filter %q must not query the analyzed text field: %s", field, body)
+			}
+		}
 		_, _ = io.WriteString(w, `{
 			"hits":{"hits":[{"_source":{
 				"receipt_id":"rcpt-1","schema_version":"3.0.0",

--- a/bkn-trace/agent-observability/src/drivenadapter/httpaccess/opensearchcoreprojection/source_test.go
+++ b/bkn-trace/agent-observability/src/drivenadapter/httpaccess/opensearchcoreprojection/source_test.go
@@ -31,12 +31,18 @@ func TestSourceBuildsAuthorizedExecutionProjectionFromCoreReceiptsAndArtifacts(t
 		if strings.Contains(queryBody, "match_phrase") {
 			t.Fatalf("authorization filters must not use analyzed phrase matching: %s", body)
 		}
-		for _, field := range []string{"owner.tenant_id.keyword", "owner.business_domain_id.keyword"} {
+		for _, field := range []string{
+			"owner.tenant_id.keyword", "owner.business_domain_id.keyword",
+			"request_id.keyword", "trace_id.keyword", "interaction_id.keyword",
+		} {
 			if !strings.Contains(queryBody, field) {
-				t.Fatalf("authorization filter %q must use exact keyword matching: %s", field, body)
+				t.Fatalf("identifier filter %q must use exact keyword matching: %s", field, body)
 			}
 		}
-		for _, field := range []string{"owner.tenant_id", "owner.business_domain_id"} {
+		for _, field := range []string{
+			"owner.tenant_id", "owner.business_domain_id",
+			"request_id", "trace_id", "interaction_id",
+		} {
 			if strings.Contains(queryBody, `"`+field+`":{"value"`) {
 				t.Fatalf("identifier filter %q must not query the analyzed text field: %s", field, body)
 			}
@@ -89,6 +95,9 @@ func TestSourceBuildsAuthorizedExecutionProjectionFromCoreReceiptsAndArtifacts(t
 	)
 
 	result, err := source.LoadExecutionProjection(context.Background(), iprojectionsource.Query{
+		RequestID:     "req-1",
+		TraceID:       "11111111111111111111111111111111",
+		InteractionID: "int-1",
 		Scope: evidencevo.QueryScope{
 			TenantID: "tenant-1", BusinessDomain: "domain-1", AccountID: "user-1", AccountType: "user",
 			AccessProfile: &evidencevo.AccessProfile{


### PR DESCRIPTION
## 变更

- 核心 Receipt 投影的租户、业务域、Request、Trace 和 Interaction 标识统一只查询 `.keyword` 字段。
- 移除对 analyzed text 原字段的 fallback，避免单词型 ID 产生大量宽候选并挤占 10k 查询窗口。
- 增加回归测试，禁止标识过滤回退到 analyzed text。

## 背景

这是已合并 PR #609 评审遗留项的后续收口。Go 侧逐条授权原本可以阻止越权返回，但宽候选仍可能造成查询完整性和性能问题。

## 验证

- `go test ./src/drivenadapter/httpaccess/opensearchcoreprojection`
- agent-observability `go test ./...`
- `git diff --check`
