### PR TITLE
fix(bkn-safe): 钉到 licverify v0.5.1，取回指纹漂移修复

### DIFF
--- a/bkn-safe/server/go.mod
+++ b/bkn-safe/server/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/glebarez/sqlite v1.7.0
 	github.com/go-ldap/ldap/v3 v3.4.13
 	github.com/openbkn-ai/bkn-comm-go v0.0.4
-	github.com/openbkn-ai/licverify v0.5.0
+	github.com/openbkn-ai/licverify v0.5.1
 	github.com/ory/hydra-client-go/v2 v2.2.0
 	golang.org/x/crypto v0.53.0
 	golang.org/x/sync v0.21.0

--- a/bkn-safe/server/go.sum
+++ b/bkn-safe/server/go.sum
@@ -169,6 +169,8 @@ github.com/openbkn-ai/licverify v0.2.0 h1:pUFRK5kpbVyeH3dMaqVlh19cCAHVq65NOy9Jrl
 github.com/openbkn-ai/licverify v0.2.0/go.mod h1:9Cnmt/tl7JN48+EjsGCjQERs1mNjuaBHdM+oVx0gvS4=
 github.com/openbkn-ai/licverify v0.5.0 h1:79aXlMYBDIzSLBXLhbrM3xOIDmMxhgCxG7PtZbPMNnE=
 github.com/openbkn-ai/licverify v0.5.0/go.mod h1:9Cnmt/tl7JN48+EjsGCjQERs1mNjuaBHdM+oVx0gvS4=
+github.com/openbkn-ai/licverify v0.5.1 h1:mQVlRKvFNLDyjG41lti+MNt0BRmyrAxKdQDHSX3MPPs=
+github.com/openbkn-ai/licverify v0.5.1/go.mod h1:9Cnmt/tl7JN48+EjsGCjQERs1mNjuaBHdM+oVx0gvS4=
 github.com/ory/hydra-client-go/v2 v2.2.0 h1:g8hw0YQD5Us1aAgZj7OyBmBGSDwlnY9/2Pb/pQQq8YE=
 github.com/ory/hydra-client-go/v2 v2.2.0/go.mod h1:h0DSI2kQA3S2fN7HyD8DNWcvbgDmYRSxfhwu/mSBhH8=
 github.com/pelletier/go-toml/v2 v2.2.4 h1:mye9XuhQ6gvn5h28+VilKrrPoQVanw5PMw/TB0t5Ec4=


### PR DESCRIPTION
#605 合并的时机比这个提交早了几分钟，所以它没跟上去。内容与我在 #605 评论里说明的一致。

## 为什么需要

`v0.5.0` 打在 licverify 的 `fix/508-ephemeral-mac-fingerprint` 合并**之前**，所以按 tag 钉依赖的一方拿不到那个修复，尽管它在 licverify main 上已经躺了几天。`v0.5.1` 补打在同一个 main tip 上，**没有新增代码**。

## 它修的是什么

容器的 `eth0`、veth peer、网桥、hypervisor tap 带的都是 pod/VM 启动时才生成的**本地管理地址**。旧逻辑按网卡名前缀过滤虚拟接口，但**pod 里的接口就叫 `eth0`** —— 前缀过滤抓不到，于是该地址被哈希进指纹，**每次 pod 重建身份就变，已激活的证书随之失效**（#508）。现在只有 OUI 烧录地址算数；什么都不剩时返回 `ErrNoFingerprint`。

不是理论问题：VM 上实测过那个漂移指纹 `fp_f15e2fa282512f73`，正好等于 `sha256("openbkn-license-fp-v1\x00mac:9a:d6:a2:aa:87:c6")` —— pod 的 eth0 MAC。

## VM 活体验证（隔离库，未碰生产数据）

scratch deployment 复用 bkn-safe 的 configmap/secret，`SAFE_DB_NAME` 指向 `safe` 库的克隆；现网 deployment 未动，验完 scratch 对象与克隆库都已删除。

| 场景 | 观察到 |
|---|---|
| 注入 `OPENBKN_INSTANCE_ID` | `license state from="" to=unlicensed`，`hub enabled instance_fp=fp_1d37b06cef344af7` |
| **不注入**（模拟旧 chart） | `ERROR license hub disabled err="license: resolve instance fingerprint: licverify: no stable instance identity found; set OPENBKN_INSTANCE_ID"`，**pod 正常起来没崩** |

第二行是这次升级唯一的行为变化：拿不到指纹时 `app.go:118-125` 走 `license hub disabled`、`licSvc` 置 nil、档位门保持 deny-everything。响亮失败但不致命 —— 这正是设计意图，静默漂移的值修不好。

chart 侧这条链已经接好（`templates/instance-id.yaml` + `_helpers.tpl` 的 `bkn-safe.instanceID`，带 `resource-policy: keep`，`deploy.sh` 先读集群已有值再从 `nodeInfo.systemUUID` 推导），**走 chart 的部署不受影响**。绕过 chart 手工部署的环境需要自己注入 —— VM 上那台正是这种（deployment 里没有 `bkn-safe-instance-id` 的 `configMapRef`，跑的是旧 chart）。

## 覆盖缺口

10 包全绿，但所有测试都用 `t.Setenv(licverify.EnvInstanceID, ...)` 注入了 instance id，所以**取指纹失败 → hub disabled 这条路径在 bkn-safe 侧没有用例**。licverify 自己的 `fingerprint_test.go` 覆盖了拒绝逻辑本身。要不要在这边补一条，听评审的。