### PR TITLE
fix(context-loader): 订正 mcp-go 下限版本，并清掉一处已失效的注释

### DIFF
--- a/adp/context-loader/agent-retrieval/server/driveradapters/mcp/app.go
+++ b/adp/context-loader/agent-retrieval/server/driveradapters/mcp/app.go
@@ -175,7 +175,7 @@ func newMCPServer(lifecycleClient *bkntrace.LifecycleClient) (*server.MCPServer,
 		// announces itself to anyone probing.
 		server.WithToolHandlerMiddleware(mcptool.GateMiddleware()),
 		server.WithToolHandlerMiddleware(lifecycleToolMiddleware(lifecycleClient)),
-		// Not just a listing filter. Since mcp-go v0.55.1 the filter also runs
+		// Not just a listing filter. Since mcp-go v0.55.0 the filter also runs
 		// on tools/call, and a tool it drops is refused by mcp-go itself with
 		// the same error code and text an unknown tool gets. That is what makes
 		// an unlicensed enterprise tool indistinguishable from one that was

--- a/adp/context-loader/agent-retrieval/server/driveradapters/mcp/socket_call_test.go
+++ b/adp/context-loader/agent-retrieval/server/driveradapters/mcp/socket_call_test.go
@@ -198,7 +198,7 @@ func TestRefusalIsIndistinguishableFromAnUnknownTool(t *testing.T) {
 
 	// 错误码曾经不一致：未知工具走 handleToolCall 内部的 INVALID_PARAMS
 	// (-32602)，而中间件返回的 error 一律被包成 INTERNAL_ERROR(-32603)。
-	// mcp-go v0.55.1 起 ToolFilterFunc 在 tools/call 时也执行，被过滤掉的工具
+	// mcp-go v0.55.0 起 ToolFilterFunc 在 tools/call 时也执行，被过滤掉的工具
 	// 由 handleToolCall 用同一条 format string、同一个 sentinel 直接拒掉，两侧
 	// 因此对齐。
 	//

--- a/adp/context-loader/agent-retrieval/server/extension/mcptool/mcptool.go
+++ b/adp/context-loader/agent-retrieval/server/extension/mcptool/mcptool.go
@@ -242,13 +242,12 @@ func Gated(t ExtraTool) Handler {
 // way for the difference to leak. Wrapping the sentinel rather than hard-coding
 // its text means mcp-go changing it takes us along.
 //
-// One difference remains and cannot be closed here: mcp-go answers an unknown
-// tool with INVALID_PARAMS (-32602) from inside handleToolCall, while an error
-// returned by a handler or middleware becomes INTERNAL_ERROR (-32603). Closing
-// that would mean not registering under-licensed tools at all — which is the
-// startup-time decision this design deliberately rejects (a certificate
-// installed later has to take effect without a restart). Recorded in
-// bkn-docs docs/shared/licensing/extension-points.md §6.
+// The error code is not this function's to set — mcp-go assigns it, and what
+// it assigns depends on where the refusal happens. The tool filter registered
+// in driveradapters/mcp/app.go is what puts the refusal in the same place an
+// unknown tool lands, so the two answers agree; see the note there. This
+// wrapper covers the case where the filter is bypassed, and is deliberately
+// kept even though that path should not occur.
 func notFound(name string) error {
 	return fmt.Errorf("tool '%s' not found: %w", name, server.ErrToolNotFound)
 }


### PR DESCRIPTION
#606 合并的时机比这个提交早，所以它没跟上去。两处都是复核挖出来的。

## 一、下限是 v0.55.0，不是 v0.55.1

我在 #606 里写的下限是 v0.55.1，判据是 `grep -c passesToolFilters`。而 **v0.55.0 是内联 `filteredTools` 实现、没有这个 helper 名** —— 判据本身漏判。

逐版本核对 `handleToolCall` 内的过滤引用数：

| 版本 | 引用数 | 守卫用例 |
|---|---|---|
| v0.54.1 | 0 | FAIL（未知 -32602，未授权 -32603） |
| **v0.55.0** | 5（内联 `filteredTools`） | PASS |
| v0.55.1 | 1（改成 `passesToolFilters` helper） | PASS |

写 v0.55.1 会让「低于此版本即失效」这句话本身不成立 —— v0.55.0 是有效的。代码里两处注释订正。

## 二、`mcptool.go` 里一段已失效的注释

#606 的 diff 只碰了 `go.mod`/`go.sum`/`app.go`/`socket_call_test.go`，这段没改到：

```go
// One difference remains and cannot be closed here: mcp-go answers an unknown
// tool with INVALID_PARAMS (-32602) from inside handleToolCall, while an error
// returned by a handler or middleware becomes INTERNAL_ERROR (-32603). ...
```

两个问题：

1. **它现在与实际不符** —— 那个差异已经关掉了，VM 上实测两侧都是 `-32602`。
2. **foundry 是公开仓**，而这是全树里唯一读起来像探测配方的文字。我们前几轮刚花力气把 PR 说明和工作流注释里的同类表述收掉，这段是漏网的。

改成陈述不变量：错误码不由这个函数决定，由**拒绝发生的位置**决定；filter 把拒绝放到了未知工具落地的同一处，所以两者一致。wrapper 保留作 filter 被绕过时的兜底 —— 那条路径不应发生，但保留是有意的。

## 验证

23 个包在 `go build` / `go build -tags ee_dev` / `go test` 下全绿。改动是注释与两个版本号字符串，无行为变更。