### PR TITLE
fix(deploy): install-status 页面品牌名改为 OpenBKN

### DIFF
--- a/deploy/conf/install-status/index.html
+++ b/deploy/conf/install-status/index.html
@@ -8,7 +8,7 @@
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <title>BKN Foundry — Install Status</title>
+  <title>OpenBKN — Install Status</title>
   <style>
     :root {
       --bg: #0f1419; --panel: #1a212b; --line: #2a3441; --fg: #d8dee9;
@@ -65,7 +65,7 @@
   </style>
 </head>
 <body>
-  <h1>BKN Foundry — Install Status</h1>
+  <h1>OpenBKN — Install Status</h1>
   <div class="sub" id="meta">loading…</div>
   <div class="sub" id="staleHint" style="color:var(--warn)"></div>
   <div id="err"></div>


### PR DESCRIPTION
## 问题

install-status 页面的 `<title>` 和 `<h1>` 硬编码 `BKN Foundry`，与产品对外名称 OpenBKN 不一致（同事在测试服页面上反馈）。

`#555` 已把 `status.sh --product` 从 `bkn-foundry` 改为 `openbkn`，副标题的 `product` 字段随之正确；只剩这两处静态文案没跟上。

## 改动

`deploy/conf/install-status/index.html` 两行文案：`BKN Foundry — Install Status` → `OpenBKN — Install Status`。无逻辑改动。

## 未改（有意）

- `install-status.json` 不是仓库文件，运行时由 `install_status.py` 的 `emit_json` 生成，`product` 取 `--product`（已是 `openbkn`）
- `deploy/release-manifests/0.1.1|0.1.2/bkn-foundry.yaml` 的 `product: bkn-foundry` 是已发布版本的锁文件，不动
- `deploy.sh` / `preflight.sh` / onboard 报告以及 md 文档里的其余 `BKN Foundry` 字样另议，不混在本 PR

## 验证

测试服 14.103.77.23 就地更新 `install-status-nginx` / `install-status-data` 两个 ConfigMap 后实测：

- 页面 `<h1>` 显示 `OpenBKN — Install Status`
- `GET /install-status.json` 的 `product` 返回 `openbkn`

🤖 Generated with [Claude Code](https://claude.com/claude-code)