### PR TITLE
fix(context-loader): 社区镜像不再向调用方报出企业动作，档位缺口改判 404

### DIFF
--- a/adp/context-loader/agent-retrieval/server/driveradapters/lifecycle_middleware.go
+++ b/adp/context-loader/agent-retrieval/server/driveradapters/lifecycle_middleware.go
@@ -204,19 +204,28 @@ func lifecycleUnavailableError(client *bkntrace.LifecycleClient) bkntrace.APIErr
 	if client == nil || !client.Enabled() {
 		message = "BKN Trace Core is not configured"
 	}
-	return bkntrace.APIError{
-		Code: "feature_not_installed", Message: message,
-		RequiredAction: "install_enterprise_implementation",
-	}
+	// No required_action. It used to say "install_enterprise_implementation",
+	// which a community deployment shipped to every caller whose trace core was
+	// simply unconfigured — a paid surface announcing itself from the image that
+	// is supposed to prove it is not there (ee-design.md §4.4). What the caller
+	// needs is that the dependency is unavailable; which product answers it is
+	// the operator's business, and the operator reads logs.
+	return bkntrace.APIError{Code: "feature_not_installed", Message: message}
 }
 
 func lifecycleHTTPStatus(code string) int {
 	switch code {
 	case "conversation_required", "interaction_required", "operation_required":
 		return http.StatusBadRequest
-	case "conversation_not_found", "resource_not_disclosed":
+	// capability_not_licensed belongs with these, not with permission_denied:
+	// a licence gap must be indistinguishable from the resource not existing,
+	// while a permission gap is told plainly (ee-design.md §4.5 — 缺证书 →
+	// 装作没有；缺权限 → 明确拒绝). Sharing an arm with permission_denied made
+	// an entitlement boundary answer like an authorization one, which is the
+	// one distinction the two-binary contract depends on.
+	case "conversation_not_found", "resource_not_disclosed", "capability_not_licensed":
 		return http.StatusNotFound
-	case "conversation_owner_mismatch", "permission_denied", "capability_not_licensed":
+	case "conversation_owner_mismatch", "permission_denied":
 		return http.StatusForbidden
 	case "feature_not_installed":
 		return http.StatusNotImplemented

--- a/adp/context-loader/agent-retrieval/server/driveradapters/lifecycle_middleware_test.go
+++ b/adp/context-loader/agent-retrieval/server/driveradapters/lifecycle_middleware_test.go
@@ -378,11 +378,22 @@ func TestLifecycleHTTPStatusPreservesProtocolSemantics(t *testing.T) {
 		"permission_denied":           http.StatusForbidden,
 		"feature_not_installed":       http.StatusNotImplemented,
 		"receipt_pending":             http.StatusConflict,
+		// A licence gap is hidden, not refused. This code was never covered
+		// here, which is how it sat in the same arm as permission_denied.
+		"capability_not_licensed": http.StatusNotFound,
 	}
 	for code, want := range tests {
 		if got := lifecycleHTTPStatus(code); got != want {
 			t.Errorf("lifecycleHTTPStatus(%q) = %d, want %d", code, got, want)
 		}
+	}
+
+	// The distinction the two-binary contract rests on: an entitlement gap must
+	// not be reported the way an authorization gap is. Asserting the two codes
+	// separately above would still pass if someone merged the arms again, so
+	// assert the inequality itself.
+	if lifecycleHTTPStatus("capability_not_licensed") == lifecycleHTTPStatus("permission_denied") {
+		t.Error("缺证书与缺权限返回了同一个状态码——档位边界会被当成授权边界识别出来")
 	}
 }
 

--- a/adp/context-loader/agent-retrieval/server/driveradapters/mcp/session_guard.go
+++ b/adp/context-loader/agent-retrieval/server/driveradapters/mcp/session_guard.go
@@ -203,10 +203,9 @@ func lifecycleAvailabilityError(err error) lifecycleError {
 	if errors.Is(err, bkntrace.ErrFeatureNotInstalled) {
 		message = "BKN Trace Core is not configured"
 	}
-	return lifecycleError{
-		Code: "feature_not_installed", Message: message,
-		RequiredAction: "install_enterprise_implementation",
-	}
+	// See the HTTP twin in driveradapters/lifecycle_middleware.go: the caller is
+	// told the dependency is unavailable, not which product to buy.
+	return lifecycleError{Code: "feature_not_installed", Message: message}
 }
 
 func operationIdentity(operation any) (string, int) {

--- a/adp/context-loader/agent-retrieval/server/driveradapters/mcp/session_guard_test.go
+++ b/adp/context-loader/agent-retrieval/server/driveradapters/mcp/session_guard_test.go
@@ -146,14 +146,14 @@ func TestSessionGuardDistinguishesUninstalledAndUnavailableCore(t *testing.T) {
 		{
 			name:     "not configured",
 			ensure:   ensureOperationAdapter(bkntrace.NewLifecycleClient("", nil)),
-			wantCode: "feature_not_installed", wantAction: "install_enterprise_implementation",
+			wantCode: "feature_not_installed", wantAction: "",
 		},
 		{
 			name: "runtime unavailable",
 			ensure: func(context.Context, operationIntent) (*operationResult, *lifecycleError, error) {
 				return nil, nil, errors.New("connection refused")
 			},
-			wantCode: "feature_not_installed", wantAction: "install_enterprise_implementation",
+			wantCode: "feature_not_installed", wantAction: "",
 		},
 	}
 	for _, test := range tests {


### PR DESCRIPTION
两处都违反 `ee-design.md` §4.4/§4.5 —— 那两节标着**「已定」**。是审计扫出来的，不是新设计。

## 一、社区镜像每天在向调用方报出企业动作

Trace Core 未配置时，`lifecycleUnavailableError` 与它的 MCP 孪生 `lifecycleAvailabilityError` 都合成：

```go
Code: "feature_not_installed", Message: "BKN Trace Core is not configured",
RequiredAction: "install_enterprise_implementation",
```

**这是社区镜像发出的**，而社区镜像的全部意义就是证明付费面不在这里。§4.4 原话：

> 返回 403 等于告诉任何探测者「这里有个付费端点」，付费面就不再不可见了。

我在 VM 上做验证时看了几十遍 `feature_not_installed: BKN Trace Core is not configured`，一次都没起疑 —— 因为它读起来像个普通的依赖缺失。带着 `install_enterprise_implementation` 就不是了。

**改法**：去掉 `required_action`。调用方需要知道的是依赖不可用；该装哪个产品是运维的事，运维看日志。

`code` 与 `message` 不动 —— `feature_not_installed` 是 **bkn-trace 已发布的契约枚举**（`session_handler.go` 的 `enums:` tag + swagger.json），改它会破坏契约。`required_action` 这一项是 context-loader 自己合成的，不来自 bkn-trace，是我们的。

## 二、`capability_not_licensed` 被当成授权失败

```go
case "conversation_owner_mismatch", "permission_denied", "capability_not_licensed":
    return http.StatusForbidden
```

档位码和真正的 RBAC 码 `permission_denied` 共用一个 arm。§4.5：

> 缺证书 → 装作没有；缺权限 → 明确拒绝。

挪到 404，与 `conversation_not_found` / `resource_not_disclosed` 并列。

## 为什么这条能长期存在

**状态映射的测试从来没覆盖过这个码。** `TestLifecycleHTTPStatusPreservesProtocolSemantics` 列了 7 个码，恰好没有它 —— 所以我改完映射，测试一开始是绿的。

补上覆盖，并额外加一条断言：

```go
if lifecycleHTTPStatus("capability_not_licensed") == lifecycleHTTPStatus("permission_denied") {
    t.Error("缺证书与缺权限返回了同一个状态码——档位边界会被当成授权边界识别出来")
}
```

只逐个断言的话，日后有人把 arm 合回去仍然全绿。这条断言的是**不变量本身**。

## 验证

两个变异都跑过：

| 变异 | 结果 |
|---|---|
| 把 `install_enterprise_implementation` 加回去 | MCP 用例 FAIL |
| 把 `capability_not_licensed` 挪回 403 | HTTP 用例 FAIL，并打印那句诊断 |

23 个包在 `go build` / `go build -tags ee_dev` / `go test` 下全绿。

## 连带

同一轮审计还发现 `bkn-safe/server/extension/extension.go:163` 的 `Claim()` 在无证时 panic（装配期门控，与 §5.4「注册无条件」和 comm-go `socket.Add` 相矛盾 —— core 里并存两套注册规则），以及 `adminwrite` 把拒绝形态的编写权交给了 ee（`RegisterMounter` 注释写着 "intentionally not license-checked here"），而 ee 据此写出了 403。那两条与本 PR 无关，另开。

bkn-docs 的 `issue-278` / `issue-277` 目前把 403 写成已定决策并给了代码样例 —— ee 那段代码是照文档写的。文档不改，代码改了也会退回去。也另开。