### PR TITLE
fix(bkn-safe): 拒绝形态收回插座，注册不再要求先有证

### DIFF
--- a/bkn-safe/server/extension/adminwrite/adminwrite.go
+++ b/bkn-safe/server/extension/adminwrite/adminwrite.go
@@ -10,7 +10,9 @@
 // routes and never mounts the write routes at all, so a probe of
 // POST /admin/roles in a community build gets 404 — the endpoint does not
 // exist, rather than existing-but-refusing. The enterprise binary mounts the
-// write routes in its Setup, behind RequireFeature("rbac_basic").
+// write routes in its Setup and the socket hides them per request when the
+// licence does not carry the feature — so an unlicensed enterprise binary
+// answers a probe exactly as the community one does.
 //
 // Why a typed Services surface instead of moving the raw handlers: the write
 // handlers carry security invariants — a custom role is forced to source
@@ -28,8 +30,12 @@ package adminwrite
 import (
 	"context"
 	"errors"
+	"log/slog"
+	"net/http"
 
 	"github.com/gin-gonic/gin"
+
+	"github.com/openbkn-ai/bkn-foundry/bkn-safe/server/extension"
 )
 
 // Sentinel errors returned by Services. ee maps these to HTTP status; anything
@@ -71,7 +77,9 @@ type RolePatch struct {
 type Services interface {
 	// RequirePermission returns core's RBAC middleware for a resource/op, so ee
 	// write routes keep the same per-caller permission checks community reads
-	// use. This is the RBAC layer; the license layer (RequireFeature) is ee's.
+	// use. This is the RBAC layer; the licence layer is the socket's (see
+// requireFeature), and it runs first — an unlicensed request must never reach
+// an authorization check, or the permission error would disclose the endpoint.
 	RequirePermission(resourceType, op string) gin.HandlerFunc
 
 	// CreateRole creates a custom role and returns its id.
@@ -125,18 +133,42 @@ func requireAnyPermission(svc Services, points ...PermissionPoint) gin.HandlerFu
 // provides one; the community build leaves it nil, so the routes never exist.
 type Mounter func(g *gin.RouterGroup, svc Services)
 
-var mounter Mounter
+var (
+	mounter Mounter
+	// gatedOn is the feature the socket itself enforces per request. Empty
+	// means the caller used the legacy RegisterMounter and is gating inside
+	// its own mounter.
+	gatedOn extension.Feature
+)
 
-// RegisterMounter installs the write-route mounter. The ee assembly calls it
-// once, before Freeze. A second call, or a call after the socket is frozen,
-// panics — both are assembly bugs (see extension.Claim for the same rule on the
-// capability sockets).
+// RegisterMounterGated installs the write-route mounter and tells the socket
+// which feature to enforce. This is the form to use.
 //
-// It is intentionally not license-checked here: ee gates each route with
-// RequireFeature inside the mounter, so a professional-only cluster still
-// mounts the routes and lets RequireFeature refuse the enterprise ones. The
-// community binary simply never calls this.
-func RegisterMounter(m Mounter) {
+// The socket owns the refusal, not the caller. That is the whole point of the
+// signature: an entitlement gap has to be indistinguishable from the route not
+// existing (ee-design.md §4.4/§4.5 — 缺证书 → 装作没有；缺权限 → 明确拒绝),
+// and leaving that decision to each caller means each caller can get it wrong
+// independently. One of them did, and shipped a 403 carrying the feature name.
+//
+// The ee assembly calls this once, before Freeze. A second call, or a call
+// after the socket is frozen, panics — both are assembly bugs.
+func RegisterMounterGated(f extension.Feature, m Mounter) {
+	if f == "" {
+		panic("adminwrite: RegisterMounterGated with an empty feature")
+	}
+	registerMounter(m)
+	gatedOn = f
+}
+
+// RegisterMounter installs a mounter that gates itself.
+//
+// Deprecated: use RegisterMounterGated so the socket enforces the tier and
+// produces the refusal. This form is kept only so the enterprise code line can
+// switch over in its own commit rather than breaking the moment core changes;
+// it will be removed once it has no callers.
+func RegisterMounter(m Mounter) { registerMounter(m) }
+
+func registerMounter(m Mounter) {
 	if m == nil {
 		panic("adminwrite: RegisterMounter(nil)")
 	}
@@ -147,6 +179,30 @@ func RegisterMounter(m Mounter) {
 		panic("adminwrite: mounter already registered")
 	}
 	mounter = m
+}
+
+// requireFeature hides the routes when the licence does not carry the feature.
+//
+// 404 with no body, which is byte-for-byte what an unmounted route answers:
+// gin has no NoRoute handler here, so a community build replies "404 page not
+// found" as text/plain. Anything richer — a JSON body, an error code, the
+// feature name — is a fingerprint that tells a prober the paid surface exists
+// in this binary, which is exactly what the two-binary split is meant to deny.
+//
+// The reason still gets recorded, just not to the caller: the log is where an
+// operator finds out this was an entitlement gap rather than a missing route
+// (ee-design.md §7.5 requires the two to be distinguishable server-side).
+func requireFeature(f extension.Feature) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		if extension.Enabled(f) {
+			c.Next()
+			return
+		}
+		slog.Info("adminwrite: route hidden, feature not licensed",
+			"feature", string(f), "method", c.Request.Method, "path", c.Request.URL.Path)
+		c.Data(http.StatusNotFound, "text/plain; charset=utf-8", []byte("404 page not found"))
+		c.Abort()
+	}
 }
 
 var frozen bool
@@ -163,6 +219,9 @@ func Mount(g *gin.RouterGroup, svc Services) bool {
 	frozen = true
 	if mounter == nil {
 		return false
+	}
+	if gatedOn != "" {
+		g = g.Group("", requireFeature(gatedOn))
 	}
 	mounter(g, svc)
 	return true

--- a/bkn-safe/server/extension/adminwrite/adminwrite.go
+++ b/bkn-safe/server/extension/adminwrite/adminwrite.go
@@ -78,8 +78,8 @@ type Services interface {
 	// RequirePermission returns core's RBAC middleware for a resource/op, so ee
 	// write routes keep the same per-caller permission checks community reads
 	// use. This is the RBAC layer; the licence layer is the socket's (see
-// requireFeature), and it runs first — an unlicensed request must never reach
-// an authorization check, or the permission error would disclose the endpoint.
+	// requireFeature), and it runs first — an unlicensed request must never reach
+	// an authorization check, or the permission error would disclose the endpoint.
 	RequirePermission(resourceType, op string) gin.HandlerFunc
 
 	// CreateRole creates a custom role and returns its id.

--- a/bkn-safe/server/extension/adminwrite/adminwrite.go
+++ b/bkn-safe/server/extension/adminwrite/adminwrite.go
@@ -77,9 +77,10 @@ type RolePatch struct {
 type Services interface {
 	// RequirePermission returns core's RBAC middleware for a resource/op, so ee
 	// write routes keep the same per-caller permission checks community reads
-	// use. This is the RBAC layer; the licence layer is the socket's (see
-	// requireFeature), and it runs first — an unlicensed request must never reach
-	// an authorization check, or the permission error would disclose the endpoint.
+	// use. This is the RBAC layer. The licence layer is the socket's (Gate) and
+	// the caller is responsible for ordering it first — an unlicensed request
+	// must not reach any authorization check, including authentication, or the
+	// 401/403 discloses that the endpoint exists in this binary.
 	RequirePermission(resourceType, op string) gin.HandlerFunc
 
 	// CreateRole creates a custom role and returns its id.
@@ -192,16 +193,39 @@ func registerMounter(m Mounter) {
 // The reason still gets recorded, just not to the caller: the log is where an
 // operator finds out this was an entitlement gap rather than a missing route
 // (ee-design.md §7.5 requires the two to be distinguishable server-side).
-func requireFeature(f extension.Feature) gin.HandlerFunc {
+func Gate() gin.HandlerFunc {
+	f := gatedOn
+	if f == "" {
+		// Legacy RegisterMounter: the caller gates inside its own mounter, so
+		// the socket has nothing to enforce. Never nil — a caller that wires
+		// Gate() unconditionally must not have to branch on it.
+		return func(c *gin.Context) { c.Next() }
+	}
 	return func(c *gin.Context) {
 		if extension.Enabled(f) {
 			c.Next()
 			return
 		}
+		// The reason goes to the log, never to the caller. §7.5 requires an
+		// operator to be able to tell an entitlement gap from a missing route;
+		// the caller must not be able to tell them apart at all.
 		slog.Info("adminwrite: route hidden, feature not licensed",
 			"feature", string(f), "method", c.Request.Method, "path", c.Request.URL.Path)
-		c.Data(http.StatusNotFound, "text/plain; charset=utf-8", []byte("404 page not found"))
+
+		// gin's own answer for an unmounted route, byte for byte: status 404,
+		// Content-Type "text/plain" (gin.MIMEPlain), body "404 page not found"
+		// with no trailing newline and no other header.
+		//
+		// Reproduced here rather than delegated, because there is nothing to
+		// delegate to: gin only runs its not-found handler when no route
+		// matched, and this route did match. Both obvious shortcuts are wrong
+		// and were tried — writing the header by hand yields
+		// "text/plain; charset=utf-8", and net/http's NotFound adds a trailing
+		// newline plus X-Content-Type-Options: nosniff. Each is a fingerprint
+		// even though the status and body look right, which is why the test
+		// compares the whole response rather than the status code.
 		c.Abort()
+		c.Data(http.StatusNotFound, gin.MIMEPlain, []byte("404 page not found"))
 	}
 }
 
@@ -215,13 +239,17 @@ func Freeze() { frozen = true }
 // socket. In a community build no mounter was registered, so this is a no-op
 // and the write routes stay absent (404). Returns whether routes were mounted,
 // for the startup log.
+// Mount does NOT apply Gate() itself. gin appends group middleware to the
+// parent chain, so a gate added here would run after whatever the caller
+// already put on the group — in bkn-safe that is RequireAdmin, and an
+// unauthenticated probe would then get 401 from an enterprise binary where the
+// community one answers 404. Ordering is the caller's to get right, and
+// router.go puts Gate() first; TestGateRunsBeforeAuthentication is what checks
+// that it stays that way.
 func Mount(g *gin.RouterGroup, svc Services) bool {
 	frozen = true
 	if mounter == nil {
 		return false
-	}
-	if gatedOn != "" {
-		g = g.Group("", requireFeature(gatedOn))
 	}
 	mounter(g, svc)
 	return true
@@ -235,5 +263,6 @@ func Mounted() bool { return mounter != nil }
 // the exported wrapper.
 func resetForTest() {
 	mounter = nil
+	gatedOn = ""
 	frozen = false
 }

--- a/bkn-safe/server/extension/adminwrite/adminwrite_socket_test.go
+++ b/bkn-safe/server/extension/adminwrite/adminwrite_socket_test.go
@@ -1,0 +1,87 @@
+// Copyright openbkn.ai
+//
+// Licensed under the OpenBKN License. See LICENSE-OPENBKN.txt in the project root.
+
+package adminwrite
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+
+	"github.com/openbkn-ai/bkn-foundry/bkn-safe/server/extension"
+)
+
+// probe drives POST /x through a router built the way the server builds it, and
+// reports what an outside caller sees.
+func probe(t *testing.T, register func()) (int, string) {
+	t.Helper()
+	gin.SetMode(gin.TestMode)
+	resetForTest()
+	extension.SetGateForTest(extension.GateFunc(func(f extension.Feature) bool { return false }))
+
+	r := gin.New()
+	register()
+	Mount(r.Group("/admin"), nil)
+
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, httptest.NewRequest(http.MethodPost, "/admin/x", nil))
+	return w.Code, w.Body.String()
+}
+
+// The community answer is the reference: nothing registered, so gin's own
+// not-found handler replies. Every other unlicensed answer has to equal it.
+func TestUnlicensedGatedRouteIsByteIdenticalToTheCommunityAnswer(t *testing.T) {
+	communityCode, communityBody := probe(t, func() {})
+
+	gatedCode, gatedBody := probe(t, func() {
+		RegisterMounterGated(extension.FeatureRBACBasic, func(g *gin.RouterGroup, _ Services) {
+			g.POST("/x", func(c *gin.Context) { c.String(http.StatusOK, "served") })
+		})
+	})
+
+	if gatedCode != communityCode || gatedBody != communityBody {
+		t.Fatalf("未授权的付费路由与社区应答不一致——付费面被暴露了\n社区  : %d %q\n未授权: %d %q",
+			communityCode, communityBody, gatedCode, gatedBody)
+	}
+	if gatedCode != http.StatusNotFound {
+		t.Fatalf("状态码 = %d，档位不足必须是 404（ee-design.md §4.5）", gatedCode)
+	}
+}
+
+// The licence is judged per request, so installing one activates routes that
+// were registered while unlicensed — no restart, no re-registration.
+func TestLicenceInstalledAfterAssemblyActivatesTheRoutes(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	resetForTest()
+	on := false
+	extension.SetGateForTest(extension.GateFunc(func(f extension.Feature) bool {
+		return on && f == extension.FeatureRBACBasic
+	}))
+
+	r := gin.New()
+	RegisterMounterGated(extension.FeatureRBACBasic, func(g *gin.RouterGroup, _ Services) {
+		g.POST("/x", func(c *gin.Context) { c.String(http.StatusOK, "served") })
+	})
+	Mount(r.Group("/admin"), nil)
+
+	call := func() int {
+		w := httptest.NewRecorder()
+		r.ServeHTTP(w, httptest.NewRequest(http.MethodPost, "/admin/x", nil))
+		return w.Code
+	}
+
+	if got := call(); got != http.StatusNotFound {
+		t.Fatalf("装证前 = %d，want 404", got)
+	}
+	on = true
+	if got := call(); got != http.StatusOK {
+		t.Fatalf("装证后 = %d，want 200——证书必须无需重启即生效", got)
+	}
+	on = false
+	if got := call(); got != http.StatusNotFound {
+		t.Fatalf("撤证后 = %d，want 404——降档必须同样即时", got)
+	}
+}

--- a/bkn-safe/server/extension/adminwrite/adminwrite_socket_test.go
+++ b/bkn-safe/server/extension/adminwrite/adminwrite_socket_test.go
@@ -5,6 +5,7 @@
 package adminwrite
 
 import (
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -14,40 +15,123 @@ import (
 	"github.com/openbkn-ai/bkn-foundry/bkn-safe/server/extension"
 )
 
-// probe drives POST /x through a router built the way the server builds it, and
-// reports what an outside caller sees.
-func probe(t *testing.T, register func()) (int, string) {
+// requireAuth stands in for RequireAdmin: it refuses anything without a
+// credential, exactly as the real one does. The tests below mount the gate the
+// way router.go does — in FRONT of it — because an earlier version of this file
+// used a bare group with no middleware at all, and so proved a proposition that
+// held only in that simplified wiring.
+func requireAuth() gin.HandlerFunc {
+	return func(c *gin.Context) {
+		if c.GetHeader("Authorization") == "" {
+			c.AbortWithStatusJSON(http.StatusUnauthorized, gin.H{"error": "missing bearer token"})
+			return
+		}
+		c.Next()
+	}
+}
+
+// answer is everything an outside caller can observe.
+type answer struct {
+	code   int
+	body   string
+	header http.Header
+}
+
+func (a answer) equal(b answer) bool {
+	if a.code != b.code || a.body != b.body || len(a.header) != len(b.header) {
+		return false
+	}
+	for k, v := range a.header {
+		if len(b.header[k]) != len(v) {
+			return false
+		}
+		for i := range v {
+			if b.header[k][i] != v[i] {
+				return false
+			}
+		}
+	}
+	return true
+}
+
+// serve builds a router the way router.go does and returns what a probe sees.
+//
+// Over a real listener, not httptest.NewRecorder: the recorder reports the
+// headers the handler happened to set, while a client sees what net/http
+// actually put on the wire — which differs, notably for Content-Length. The
+// property under test is what an outside prober can observe, so measure that.
+func serve(t *testing.T, register func(), authHeader string) answer {
 	t.Helper()
 	gin.SetMode(gin.TestMode)
 	resetForTest()
-	extension.SetGateForTest(extension.GateFunc(func(f extension.Feature) bool { return false }))
+	extension.SetGateForTest(extension.GateFunc(func(extension.Feature) bool { return false }))
 
 	r := gin.New()
 	register()
-	Mount(r.Group("/admin"), nil)
+	Mount(r.Group("/admin", Gate(), requireAuth()), nil)
 
-	w := httptest.NewRecorder()
-	r.ServeHTTP(w, httptest.NewRequest(http.MethodPost, "/admin/x", nil))
-	return w.Code, w.Body.String()
+	srv := httptest.NewServer(r)
+	defer srv.Close()
+
+	req, err := http.NewRequest(http.MethodPost, srv.URL+"/admin/x", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if authHeader != "" {
+		req.Header.Set("Authorization", authHeader)
+	}
+	resp, err := srv.Client().Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Date changes between the two calls by construction; it is set by net/http
+	// for every response and carries nothing about this binary.
+	h := resp.Header.Clone()
+	h.Del("Date")
+	return answer{resp.StatusCode, string(body), h}
 }
 
-// The community answer is the reference: nothing registered, so gin's own
-// not-found handler replies. Every other unlicensed answer has to equal it.
-func TestUnlicensedGatedRouteIsByteIdenticalToTheCommunityAnswer(t *testing.T) {
-	communityCode, communityBody := probe(t, func() {})
-
-	gatedCode, gatedBody := probe(t, func() {
-		RegisterMounterGated(extension.FeatureRBACBasic, func(g *gin.RouterGroup, _ Services) {
-			g.POST("/x", func(c *gin.Context) { c.String(http.StatusOK, "served") })
-		})
+func gatedMounter() {
+	RegisterMounterGated(extension.FeatureRBACBasic, func(g *gin.RouterGroup, _ Services) {
+		g.POST("/x", func(c *gin.Context) { c.String(http.StatusOK, "served") })
 	})
+}
 
-	if gatedCode != communityCode || gatedBody != communityBody {
-		t.Fatalf("未授权的付费路由与社区应答不一致——付费面被暴露了\n社区  : %d %q\n未授权: %d %q",
-			communityCode, communityBody, gatedCode, gatedBody)
+// The community answer is the reference. Compare the WHOLE response — an
+// earlier version compared only status and body, and missed that the hand-built
+// 404 carried "text/plain; charset=utf-8" where gin writes "text/plain".
+func TestUnlicensedRouteIsIndistinguishableFromTheCommunityAnswer(t *testing.T) {
+	for _, tc := range []struct{ name, auth string }{
+		{"无凭据", ""},
+		{"有凭据", "Bearer whatever"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			community := serve(t, func() {}, tc.auth)
+			gated := serve(t, gatedMounter, tc.auth)
+			if !gated.equal(community) {
+				t.Fatalf("未授权的付费路由与社区应答不一致——付费面被暴露了\n社区  : %d %q %v\n未授权: %d %q %v",
+					community.code, community.body, community.header,
+					gated.code, gated.body, gated.header)
+			}
+			if gated.code != http.StatusNotFound {
+				t.Fatalf("状态码 = %d，档位不足必须是 404（ee-design.md §4.5）", gated.code)
+			}
+		})
 	}
-	if gatedCode != http.StatusNotFound {
-		t.Fatalf("状态码 = %d，档位不足必须是 404（ee-design.md §4.5）", gatedCode)
+}
+
+// The unauthenticated case is the one that was broken: the gate sat behind
+// RequireAdmin, so an enterprise binary answered 401 where a community one
+// answers 404 — identifiable with no credential at all.
+func TestGateRunsBeforeAuthentication(t *testing.T) {
+	if got := serve(t, gatedMounter, "").code; got != http.StatusNotFound {
+		t.Fatalf("无凭据探测 = %d，want 404。档位判定排到鉴权之后了", got)
 	}
 }
 
@@ -62,14 +146,14 @@ func TestLicenceInstalledAfterAssemblyActivatesTheRoutes(t *testing.T) {
 	}))
 
 	r := gin.New()
-	RegisterMounterGated(extension.FeatureRBACBasic, func(g *gin.RouterGroup, _ Services) {
-		g.POST("/x", func(c *gin.Context) { c.String(http.StatusOK, "served") })
-	})
-	Mount(r.Group("/admin"), nil)
+	gatedMounter()
+	Mount(r.Group("/admin", Gate(), requireAuth()), nil)
 
 	call := func() int {
+		req := httptest.NewRequest(http.MethodPost, "/admin/x", nil)
+		req.Header.Set("Authorization", "Bearer whatever")
 		w := httptest.NewRecorder()
-		r.ServeHTTP(w, httptest.NewRequest(http.MethodPost, "/admin/x", nil))
+		r.ServeHTTP(w, req)
 		return w.Code
 	}
 
@@ -83,5 +167,40 @@ func TestLicenceInstalledAfterAssemblyActivatesTheRoutes(t *testing.T) {
 	on = false
 	if got := call(); got != http.StatusNotFound {
 		t.Fatalf("撤证后 = %d，want 404——降档必须同样即时", got)
+	}
+}
+
+// The legacy entry point keeps working: Gate() is a no-op, and the caller's own
+// middleware decides. Without this, switching ee over would have to be atomic.
+func TestLegacyRegisterMounterStillMounts(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	resetForTest()
+	extension.SetGateForTest(extension.GateFunc(func(extension.Feature) bool { return false }))
+
+	r := gin.New()
+	RegisterMounter(func(g *gin.RouterGroup, _ Services) {
+		g.POST("/x", func(c *gin.Context) { c.String(http.StatusOK, "served") })
+	})
+	Mount(r.Group("/admin", Gate(), requireAuth()), nil)
+
+	req := httptest.NewRequest(http.MethodPost, "/admin/x", nil)
+	req.Header.Set("Authorization", "Bearer whatever")
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("legacy 入口 = %d，want 200——它自己管门控，插座不该插手", w.Code)
+	}
+}
+
+// resetForTest must not leak assembly state into the next test.
+func TestResetClearsTheGatedFeature(t *testing.T) {
+	resetForTest()
+	gatedMounter()
+	if gatedOn == "" {
+		t.Fatal("前置条件不成立")
+	}
+	resetForTest()
+	if gatedOn != "" {
+		t.Fatal("resetForTest 没清 gatedOn——下一个测试会继承上一个的装配")
 	}
 }

--- a/bkn-safe/server/extension/adminwrite/routes.go
+++ b/bkn-safe/server/extension/adminwrite/routes.go
@@ -12,10 +12,10 @@ import (
 )
 
 // Routes mounts the rbac_basic write endpoints onto g, each behind core's RBAC
-// permission check (via svc.RequirePermission). It is a Mounter — the ee build
-// wraps it with a RequireFeature("rbac_basic") group so the license layer sits
-// in front; the community build never registers any mounter, so these routes do
-// not exist there (404).
+// permission check (via svc.RequirePermission). It is a Mounter — the socket
+// wraps it with its own licence group so that layer sits in front of RBAC; the
+// community build never registers any mounter, so these routes do not exist
+// there (404). Both refusals are the same 404, which is the point.
 //
 // The handlers are deliberately thin: bind JSON, call the guarded Services
 // operation, map the sentinel error to a status. Every security rule

--- a/bkn-safe/server/extension/extension.go
+++ b/bkn-safe/server/extension/extension.go
@@ -142,15 +142,26 @@ func Enabled(f Feature) bool {
 // Typed sockets call it from their own Register; callers outside this package
 // tree should not.
 //
-// Three deliberate panics, all of them assembly bugs that must surface at
-// startup rather than silently:
+// Two deliberate panics, both assembly bugs that must surface at startup
+// rather than silently:
 //
 //   - claiming a feature twice: the second implementation would overwrite the
 //     first without a trace
 //   - claiming after Freeze: the capability set is already published and some
 //     call sites have already judged against the old one
-//   - claiming an unlicensed feature: ee is expected to check its license
-//     before registering, so reaching here means the check was skipped
+//
+// Claiming an UNLICENSED feature used to be the third, on the reasoning that ee
+// should check its licence before registering. That rule turned out to cause
+// the bug it looked like it was preventing: an implementation that only
+// registers when a licence is already present cannot be switched on by a
+// certificate installed afterwards, because the socket is frozen by the time
+// the certificate arrives. The customer then has to restart the service to fix
+// a licensing mistake, on their own site.
+//
+// So registration is unconditional and the licence is judged per request, at
+// the point of use — the same rule comm-go's entitlement/socket states for the
+// sockets built after this one. Callers that still self-check before
+// registering are not wrong, only unable to hot-activate.
 func Claim(f Feature, impl string) {
 	mu.Lock()
 	defer mu.Unlock()
@@ -159,9 +170,6 @@ func Claim(f Feature, impl string) {
 	}
 	if prev, dup := claimed[f]; dup {
 		panic(fmt.Sprintf("extension: %s already registered by %s, cannot re-register with %s", f, prev, impl))
-	}
-	if !gate.Enabled(f) {
-		panic(fmt.Sprintf("extension: %s registered by %s without a license for it — check the license before registering", f, impl))
 	}
 	claimed[f] = impl
 	assembly = append(assembly, fmt.Sprintf("%s=%s", f, impl))

--- a/bkn-safe/server/extension/extension_test.go
+++ b/bkn-safe/server/extension/extension_test.go
@@ -86,16 +86,27 @@ func TestClaimAfterFreezePanics(t *testing.T) {
 	}
 }
 
-func TestClaimWithoutLicensePanics(t *testing.T) {
+func TestClaimWithoutLicenseIsAllowed(t *testing.T) {
 	reset()
 	SetGate(only(FeatureRBACBasic))
 
-	// ee is expected to check its license before registering; reaching Claim
-	// for an unlicensed feature means that check was skipped.
-	got := mustPanic(t, "unlicensed Claim", func() { Claim(FeaturePermObjectLevel, "ee") })
-	msg, _ := got.(string)
-	if !strings.Contains(msg, "without a license") {
-		t.Fatalf("panic message should say the license is missing, got %q", msg)
+	// Registration is unconditional. Refusing to record an unlicensed
+	// implementation is what makes a certificate installed later unable to
+	// switch it on: the socket is frozen before the certificate arrives, so the
+	// only remedy left is a restart. The licence is judged per request instead.
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("Claim must not refuse an unlicensed feature: %v", r)
+		}
+	}()
+	Claim(FeaturePermObjectLevel, "ee")
+
+	if !registeredLocked(FeaturePermObjectLevel) {
+		t.Fatal("the claim should be recorded even though the feature is unlicensed")
+	}
+	// …and recorded is still not usable: that judgement stays with the licence.
+	if Usable(FeaturePermObjectLevel) {
+		t.Fatal("an unlicensed feature must not report as usable just because it is registered")
 	}
 }
 

--- a/bkn-safe/server/extension/permobject/permobject.go
+++ b/bkn-safe/server/extension/permobject/permobject.go
@@ -78,12 +78,19 @@ type Authorizer interface {
 var impl atomic.Value // Authorizer
 
 // Register plugs the ee implementation into the socket. It is called from the
-// enterprise assembly entry point (cmd/*-ee), after that entry point has
-// verified the license carries perm_object_level.
+// enterprise assembly entry point (cmd/*-ee).
 //
-// It panics on a second registration, on registration after the extension
-// registry is frozen, and on registration without a license — see
-// extension.Claim. All three are assembly bugs that must be loud at startup.
+// Registration is UNCONDITIONAL — do not check the licence first. An entry
+// point that registers only when a certificate is already present cannot be
+// switched on by a certificate installed afterwards: the registry is frozen
+// before that certificate arrives, so the only remedy left is restarting the
+// service on the customer's site to fix a licensing mistake. Available() and
+// Decide() re-read the licence on every call, which is where the tier belongs.
+//
+// It panics on a second registration and on registration after the extension
+// registry is frozen — see extension.Claim. Both are assembly bugs that must
+// be loud at startup. Registering while unlicensed used to panic too; that
+// rule is what produced the pattern described above, and it is gone.
 func Register(a Authorizer) {
 	if a == nil {
 		panic("permobject: Register(nil)")

--- a/bkn-safe/server/extension/permobject/permobject_test.go
+++ b/bkn-safe/server/extension/permobject/permobject_test.go
@@ -154,13 +154,27 @@ func TestRegisterNilPanics(t *testing.T) {
 	Register(nil)
 }
 
-func TestRegisterWithoutLicensePanics(t *testing.T) {
+// Registering while unlicensed has to work, or a certificate installed after
+// boot could never switch the capability on without a restart.
+func TestRegisterWithoutLicenseIsAllowedAndStaysInactive(t *testing.T) {
 	on := false
 	licensed(t, &on)
+
 	defer func() {
-		if recover() == nil {
-			t.Fatal("registering without a license should panic — ee must check first")
+		if r := recover(); r != nil {
+			t.Fatalf("Register must not refuse while unlicensed: %v", r)
 		}
 	}()
 	Register(&fake{})
+
+	// Registered, but the licence still decides — Available() is that judgement.
+	// Flipping the licence must take effect
+	// with no further registration — that is the property the panic prevented.
+	if Available() {
+		t.Fatal("an unlicensed registration must not be active")
+	}
+	on = true
+	if !Available() {
+		t.Fatal("installing the licence must activate the already-registered implementation")
+	}
 }

--- a/bkn-safe/server/internal/httpapi/adminwrite_gate_test.go
+++ b/bkn-safe/server/internal/httpapi/adminwrite_gate_test.go
@@ -1,0 +1,83 @@
+// Copyright openbkn.ai
+//
+// Licensed under the OpenBKN License. See LICENSE-OPENBKN.txt in the project root.
+
+package httpapi
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/glebarez/sqlite"
+	"gorm.io/gorm"
+
+	"github.com/openbkn-ai/bkn-foundry/bkn-safe/server/extension"
+	"github.com/openbkn-ai/bkn-foundry/bkn-safe/server/extension/adminwrite"
+	"github.com/openbkn-ai/bkn-foundry/bkn-safe/server/internal/audit"
+	"github.com/openbkn-ai/bkn-foundry/bkn-safe/server/internal/auth"
+	"github.com/openbkn-ai/bkn-foundry/bkn-safe/server/internal/authz"
+	"github.com/openbkn-ai/bkn-foundry/bkn-safe/server/internal/database"
+	"github.com/openbkn-ai/bkn-foundry/bkn-safe/server/internal/directory"
+)
+
+// routerWithMounter builds the REAL router — the one New() assembles, with
+// RequireAdmin and the audit middleware — around whatever mounter is given.
+//
+// The adminwrite package's own tests build a router by hand, so they cannot
+// catch an ordering mistake in New(): they proved the socket refuses correctly
+// when it is wired first, not that anything wires it first. That is precisely
+// how the licence gate ended up behind RequireAdmin. This test uses New().
+func routerWithMounter(t *testing.T, register func()) *gin.Engine {
+	t.Helper()
+	gin.SetMode(gin.TestMode)
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	if err != nil {
+		t.Fatalf("sqlite: %v", err)
+	}
+	if err := database.Migrate(db); err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+	e, err := authz.New(db)
+	if err != nil {
+		t.Fatalf("authz: %v", err)
+	}
+	adminwrite.ResetForTest()
+	register()
+	return New(Deps{
+		Enforcer: e, DB: db, Directory: directory.New(db), Users: auth.NewUserStore(db),
+		Audit: audit.New(db), TokenVerifier: stubVerifier{},
+	})
+}
+
+// An unauthenticated probe must not be able to tell the two binaries apart.
+// This is the case that was broken: with the gate behind RequireAdmin the
+// enterprise build answered 401 where the community build answers 404, so the
+// paid surface was identifiable with no credential at all.
+func TestUnlicensedWriteRouteIsHiddenFromAnUnauthenticatedProbe(t *testing.T) {
+	extension.SetGateForTest(extension.GateFunc(func(extension.Feature) bool { return false }))
+
+	community := routerWithMounter(t, func() {})
+	enterprise := routerWithMounter(t, func() {
+		adminwrite.RegisterMounterGated(extension.FeatureRBACBasic, adminwrite.Routes)
+	})
+
+	probe := func(r *gin.Engine) (int, string) {
+		w := httptest.NewRecorder()
+		r.ServeHTTP(w, httptest.NewRequest(http.MethodPost, "/api/safe/v1/admin/roles", nil))
+		return w.Code, w.Body.String()
+	}
+
+	wantCode, wantBody := probe(community)
+	gotCode, gotBody := probe(enterprise)
+
+	if gotCode != wantCode || gotBody != wantBody {
+		t.Fatalf("无凭据探测能区分社区与无证企业——付费面被暴露了\n社区: %d %q\n企业: %d %q\n"+
+			"多半是 New() 把 adminwrite.Gate() 排到了 RequireAdmin 之后",
+			wantCode, wantBody, gotCode, gotBody)
+	}
+	if gotCode != http.StatusNotFound {
+		t.Fatalf("状态码 = %d，want 404", gotCode)
+	}
+}

--- a/bkn-safe/server/internal/httpapi/router.go
+++ b/bkn-safe/server/internal/httpapi/router.go
@@ -121,7 +121,18 @@ func New(deps Deps) *gin.Engine {
 		// the adminwrite socket. In a community binary no mounter was registered,
 		// so Mount is a no-op and those endpoints stay absent (404). The guarded
 		// operations live in newAdminWriteServices; ee owns only the HTTP shape.
-		if adminwrite.Mount(admin, newAdminWriteServices(deps.Enforcer, deps.DB)) {
+		// The licence gate goes in FRONT of RequireAdmin, on its own group at the
+		// same prefix. Adding it to `admin` would put it behind authentication,
+		// and then an unauthenticated probe would get 401 from an enterprise
+		// binary where a community one answers 404 — the paid surface would be
+		// identifiable without any credential at all. Audit sits after the gate
+		// for the same reason: a hidden route must not produce a record shaped
+		// differently from a route that does not exist.
+		gatedAdmin := r.Group("/api/safe/v1/admin", adminwrite.Gate(), RequireAdmin(verifier, deps.Enforcer))
+		if deps.Audit != nil {
+			gatedAdmin.Use(auditMiddleware(deps.Audit, deps.Directory, deps.DB))
+		}
+		if adminwrite.Mount(gatedAdmin, newAdminWriteServices(deps.Enforcer, deps.DB)) {
 			slog.Info("rbac_basic admin write routes mounted (enterprise build)")
 		}
 		// Global AppKey oversight: list/revoke any user's keys.


### PR DESCRIPTION
两处，同一个根因：**core 把本该自己管的事交了出去**。

## 一、`adminwrite` 把授权判定交给了 ee

`RegisterMounter` 的注释原文：

> It is **intentionally not license-checked here**: ee gates each route with `RequireFeature` inside the mounter

而 `ee-design.md` §5.4 说这一层**「由插座包掉，ee 不写」**。

交出去的结果是每个 ee 能力各写一遍判定，各有一次写错的机会。**已经错了一次** —— ee 侧返 `403 + feature_required`，正是 §4.4 点名否决的替代方案。

新增 `RegisterMounterGated(feature, mounter)`，判定与状态码由插座产生：档位不足返 **404、无 body**，与未挂载路由**逐字节相同**（gin 无 `NoRoute` handler，社区应答就是 text/plain 的 `404 page not found`）。理由不丢 —— 落 `slog`，运维要能分清是档位不足还是路由不存在（§7.5）。

### 为什么不直接改签名

**不改 `RegisterMounter` 的签名是刻意的。** 直接改会让 openbkn-ee 重钉 core 时编不过、`core-main-canary` 变红 —— 那就是影响别人。旧入口保留并标 `Deprecated`，等 ee 切到新入口再摘。

已实测：ee 在本分支的 core 上（`replace` 指向本 worktree）`go build ./...` 通过，三个包测试全绿。

## 二、`Claim` 无证 panic —— 是它逼出了那个反模式

原注释：「ee is expected to check its license before registering」。ee 的 `permobject.Setup` 因此在无证时**直接不注册**：

```go
if !coreext.Enabled(coreext.FeaturePermObjectLevel) {
    slog.Info("ee: perm_object_level not licensed, ...")
    return nil            // ← 什么都没注册
}
```

后果：**开机没证、事后装上证书，该能力永远不生效，直到重启。** 客户为一个授权失误重启服务 —— 这正是 comm-go 的 `entitlement/socket` 明令避免的方向，也是我在 eetools 包注释里写过要避免的那件事。core 在逼着 ee 这么做。

去掉那个 panic，注册无条件，档位在使用点每请求判。另两个 panic（重复注册、`Freeze` 后注册）保留 —— 它们是真的装配 bug。

这条是**放宽**，今天能编过的仍然能编过、能跑的仍然能跑；ee 那边的自查照旧有效，只是从「必须」变成「可以不要」。

## 三、三条注释订正

它们把 403、以及「授权层是 ee 的」说成设计要求，而设计文档说的相反。

## 测试

两条钉旧行为的用例改成**断言相反的不变量**：无证可注册但不可用；装证后无需重启即生效。

新增插座判定用例，判据是**「与社区应答逐字节相同」而不是「等于 404」**。变异验证过：

| 变异 | 结果 |
|---|---|
| 插座不包判定（回到交给 ee） | 两条用例同时 FAIL |
| 拒绝改成带 body 的 JSON 404 | FAIL —— 「未授权的付费路由与社区应答不一致，付费面被暴露了」 |

第二条是关键：状态码对了但仍可指纹，**只断言「是 404」的测试会漏掉**。11 包全绿。

## 后续

ee 侧改 `rbacbasic.Setup` 用 `RegisterMounterGated` 并删掉自己的 `requireFeature`，两条测试反转断言。那之后 core 才能摘掉 `RegisterMounter`。

相关：bkn-docs#31（源头 —— ee 那段 403 是照文档写的）、已合的 #614。