### PR TITLE
fix(context-loader): MCP 零配置接入——业务域默认值、会话级 bkn_context 兜底与契约改可选

### DIFF
--- a/adp/context-loader/agent-retrieval/helm/agent-retrieval/templates/deployment.yaml
+++ b/adp/context-loader/agent-retrieval/helm/agent-retrieval/templates/deployment.yaml
@@ -85,6 +85,10 @@ spec:
               - name: BKN_TRACE_DEFAULT_TENANT_ID
                 value: {{ .Values.observability.lifecycle.default_tenant_id | quote }}
             {{- end}}
+            {{- if .Values.observability.lifecycle.default_business_domain }}
+              - name: BKN_TRACE_DEFAULT_BUSINESS_DOMAIN
+                value: {{ .Values.observability.lifecycle.default_business_domain | quote }}
+            {{- end}}
             {{- if .Values.observability.lifecycle.gateway_token_secret_name }}
               - name: BKN_TRACE_QUERY_GATEWAY_TOKEN
                 valueFrom:

--- a/adp/context-loader/agent-retrieval/helm/agent-retrieval/values.yaml
+++ b/adp/context-loader/agent-retrieval/helm/agent-retrieval/values.yaml
@@ -171,6 +171,11 @@ observability:
     # 0.1.3 defaults to the same single-tenant scope as agent-observability.
     # A trusted inbound x-tenant-id always takes precedence in multi-tenant deployments.
     default_tenant_id: "openbkn-local"
+    # Matches the platform-wide default business domain. MCP clients (Claude Code,
+    # Cursor, Studio) carry no domain header, so without this every lifecycle call
+    # fails closed. A trusted inbound x-business-domain still wins; multi-domain
+    # deployments clear this value to force every caller to declare its domain.
+    default_business_domain: "bd_public"
     gateway_token_secret_name: ""
     gateway_token_secret_key: "token"
   evidence:

--- a/adp/context-loader/agent-retrieval/server/driveradapters/mcp/app.go
+++ b/adp/context-loader/agent-retrieval/server/driveradapters/mcp/app.go
@@ -18,6 +18,7 @@ import (
 	"github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/drivenadapters"
 	"github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/extension/mcptool"
 	"github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/infra/bkntrace"
+	"github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/infra/common"
 	logicsKar "github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/logics/knactionrecall"
 	logicsFs "github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/logics/knfindskills"
 	logicsKlp "github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/logics/knlogicpropertyresolver"
@@ -101,8 +102,12 @@ func NewMCPHandler() http.Handler {
 func NewMCPHandlerWithLifecycle(lifecycleClient *bkntrace.LifecycleClient) http.Handler {
 	srv, _ := newMCPServer(lifecycleClient)
 	return server.NewStreamableHTTPServer(srv,
+		// The incoming ctx already carries the MCP client session; returning
+		// r.Context() outright would drop it, and the session-level lifecycle
+		// fallback would see every call as sessionless. Carry the gin
+		// middleware's values across instead of replacing the whole context.
 		server.WithHTTPContextFunc(func(ctx context.Context, r *http.Request) context.Context {
-			return r.Context()
+			return common.CopyRequestScopedValues(r.Context(), ctx)
 		}),
 		server.WithEndpointPath(endpointPath),
 	)

--- a/adp/context-loader/agent-retrieval/server/driveradapters/mcp/assemble.go
+++ b/adp/context-loader/agent-retrieval/server/driveradapters/mcp/assemble.go
@@ -108,7 +108,7 @@ func (b *toolBuilder) addExtras() {
 		// tool is unusable by anyone following it — the schema comes from ee,
 		// which has no reason to know this service has a lifecycle guard.
 		b.pending = append(b.pending, pendingTool{
-			newToolWithSchemas(t.Name, t.Desc, requireBKNContext(t.Input), t.Output),
+			newToolWithSchemas(t.Name, t.Desc, offerBKNContext(t.Input), t.Output),
 			mcptool.Gated(t),
 		})
 	}

--- a/adp/context-loader/agent-retrieval/server/driveradapters/mcp/info.go
+++ b/adp/context-loader/agent-retrieval/server/driveradapters/mcp/info.go
@@ -48,7 +48,7 @@ func tryLoadToolSchemas(toolKey string) (input, output json.RawMessage) {
 		return nil, nil
 	}
 	if isBusinessTool(toolKey) {
-		wrapper.InputSchema = requireBKNContext(wrapper.InputSchema)
+		wrapper.InputSchema = offerBKNContext(wrapper.InputSchema)
 	}
 	return wrapper.InputSchema, wrapper.OutputSchema
 }
@@ -97,7 +97,7 @@ func BuildMCPInfo(endpoint string) (*MCPInfo, error) {
 			// 自己的定义就是业务工具，生命周期守卫会向它要 bkn_context。这个端点
 			// 存在的理由是「不握手就看清能力面」，广播一份调不通的 schema 比不广播
 			// 更糟——照它集成会直接拿到 conversation_required。
-			InputSchema:  requireBKNContext(t.Input),
+			InputSchema:  offerBKNContext(t.Input),
 			OutputSchema: t.Output,
 		}})
 	}

--- a/adp/context-loader/agent-retrieval/server/driveradapters/mcp/lifecycle_adapter.go
+++ b/adp/context-loader/agent-retrieval/server/driveradapters/mcp/lifecycle_adapter.go
@@ -45,6 +45,7 @@ func lifecycleToolMiddleware(client *bkntrace.LifecycleClient) server.ToolHandle
 			return guardBusinessToolCallWithCompletion(
 				ensureOperationAdapter(client),
 				completeOperationAdapter(client),
+				client,
 				next,
 			)(ctx, req)
 		}

--- a/adp/context-loader/agent-retrieval/server/driveradapters/mcp/lifecycle_schema_test.go
+++ b/adp/context-loader/agent-retrieval/server/driveradapters/mcp/lifecycle_schema_test.go
@@ -384,6 +384,9 @@ func TestHelmEnforcesInstalledLifecycleCoreByDefault(t *testing.T) {
 	if !strings.Contains(string(values), `default_tenant_id: "openbkn-local"`) {
 		t.Fatalf("Helm lifecycle values must align with the observability single-tenant scope: %s", values)
 	}
+	if !strings.Contains(string(values), `default_business_domain: "bd_public"`) {
+		t.Fatalf("Helm lifecycle values must carry the platform default business domain: %s", values)
+	}
 	deploymentPath := filepath.Clean("../../../helm/agent-retrieval/templates/deployment.yaml")
 	deployment, err := os.ReadFile(deploymentPath)
 	if err != nil {

--- a/adp/context-loader/agent-retrieval/server/driveradapters/mcp/lifecycle_schema_test.go
+++ b/adp/context-loader/agent-retrieval/server/driveradapters/mcp/lifecycle_schema_test.go
@@ -18,7 +18,7 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
-func TestBusinessToolSchemasRequireExplicitBKNContext(t *testing.T) {
+func TestBusinessToolSchemasAdvertiseOptionalBKNContext(t *testing.T) {
 	rawMeta, err := schemasFS.ReadFile("schemas/tools_meta.json")
 	if err != nil {
 		t.Fatalf("read registered tool metadata: %v", err)
@@ -40,8 +40,15 @@ func TestBusinessToolSchemasRequireExplicitBKNContext(t *testing.T) {
 			if err := json.Unmarshal(input, &schema); err != nil {
 				t.Fatalf("decode %s input schema: %v", toolKey, err)
 			}
-			if !containsString(schema.Required, "bkn_context") {
-				t.Fatalf("%s must require bkn_context", toolKey)
+			// Advertised on every business tool, demanded on none. A required
+			// field an MCP client cannot legitimately fill just teaches it to
+			// invent IDs that Core rejects; omitting the whole object is the
+			// supported path and falls back to the client's MCP session.
+			if _, ok := schema.Properties["bkn_context"]; !ok {
+				t.Fatalf("%s must advertise bkn_context", toolKey)
+			}
+			if containsString(schema.Required, "bkn_context") {
+				t.Fatalf("%s must not demand bkn_context", toolKey)
 			}
 
 			var contextSchema struct {

--- a/adp/context-loader/agent-retrieval/server/driveradapters/mcp/schemas.go
+++ b/adp/context-loader/agent-retrieval/server/driveradapters/mcp/schemas.go
@@ -63,7 +63,7 @@ func loadToolSchemas(toolKey string) (input, output json.RawMessage) {
 		panic(path + ": missing input_schema")
 	}
 	if isBusinessTool(toolKey) {
-		wrapper.InputSchema = requireBKNContext(wrapper.InputSchema)
+		wrapper.InputSchema = offerBKNContext(wrapper.InputSchema)
 	}
 	return wrapper.InputSchema, wrapper.OutputSchema
 }
@@ -341,7 +341,16 @@ func isBusinessTool(toolKey string) bool {
 	return !lifecycle
 }
 
-func requireBKNContext(input json.RawMessage) json.RawMessage {
+// offerBKNContext advertises the managed lifecycle context on every business
+// tool without demanding it.
+//
+// It used to be required. A required field an MCP client cannot legitimately
+// fill is worse than an absent one: the client is an LLM reading this schema,
+// and its cheapest way to satisfy "required" is to invent three plausible IDs,
+// which Core then rejects as conversation_not_found. Callers that own a real
+// business conversation (bkn-agent) still send it and keep full business-level
+// traceability; callers that have none now fall back to their MCP session.
+func offerBKNContext(input json.RawMessage) json.RawMessage {
 	var schema map[string]any
 	if err := json.Unmarshal(input, &schema); err != nil {
 		panic("invalid business tool input schema: " + err.Error())
@@ -352,8 +361,13 @@ func requireBKNContext(input json.RawMessage) json.RawMessage {
 		schema["properties"] = properties
 	}
 	properties["bkn_context"] = map[string]any{
-		"type":        "object",
-		"description": "BKN Trace 3.0 managed lifecycle context for this logical tool call.",
+		"type": "object",
+		"description": "BKN Trace 业务溯源上下文，声明这次调用属于哪一轮业务对话。" +
+			"conversation_id 来自 bkn_create_conversation，interaction_id 来自 " +
+			"bkn_start_interaction，operation_key 由调用方自取且同一次逻辑调用重试时须保持不变。" +
+			"三者必须同时提供或同时省略：省略时本服务按当前 MCP 连接自动归并会话，" +
+			"调用可直接执行，但证据链只能追溯到连接级而非具体的用户提问；" +
+			"半数提供会被拒绝，因为缺失字段只能凭空生成，会让回执声称一条从未发生的因果关系。",
 		"properties": map[string]any{
 			"conversation_id": map[string]any{"type": "string"},
 			"interaction_id":  map[string]any{"type": "string"},
@@ -369,13 +383,17 @@ func requireBKNContext(input json.RawMessage) json.RawMessage {
 		"additionalProperties": false,
 	}
 	required, _ := schema["required"].([]any)
+	kept := make([]any, 0, len(required))
 	for _, value := range required {
-		if value == "bkn_context" {
-			raw, _ := json.Marshal(schema)
-			return raw
+		if value != "bkn_context" {
+			kept = append(kept, value)
 		}
 	}
-	schema["required"] = append(required, "bkn_context")
+	if len(kept) > 0 {
+		schema["required"] = kept
+	} else {
+		delete(schema, "required")
+	}
 	raw, err := json.Marshal(schema)
 	if err != nil {
 		panic("marshal business tool input schema: " + err.Error())

--- a/adp/context-loader/agent-retrieval/server/driveradapters/mcp/schemas/tools_meta.json
+++ b/adp/context-loader/agent-retrieval/server/driveradapters/mcp/schemas/tools_meta.json
@@ -1,47 +1,47 @@
 {
   "bkn_create_conversation": {
     "name": "bkn_create_conversation",
-    "description": "Create or reuse the current managed BKN Trace 3.0 Conversation."
+    "description": "建立或取回当前的业务对话，返回 conversation_id。业务级溯源的第一步；仅当调用方持有真实业务对话（如 Agent 与用户的一轮完整会话）时才需要调用。通用 MCP 客户端可跳过——省略 bkn_context 时本服务按当前连接自动归并。"
   },
   "bkn_resume_conversation": {
     "name": "bkn_resume_conversation",
-    "description": "Resume an authorized active Conversation by its Core ID."
+    "description": "按 Core 返回的 conversation_id 恢复一个仍然活跃的业务对话。用于进程重启或跨连接续接同一轮业务对话。"
   },
   "bkn_start_interaction": {
     "name": "bkn_start_interaction",
-    "description": "Start one managed Interaction in an active Conversation."
+    "description": "在活跃对话中开启一次交互（一轮问答），返回 interaction_id 与租约。一个对话同时只允许一次活跃交互。租约默认 5 分钟，每次业务调用自动续期。"
   },
   "bkn_complete_interaction": {
     "name": "bkn_complete_interaction",
-    "description": "Explicitly complete an Interaction with its closure manifest."
+    "description": "以收口清单正常完结交互，声明这一轮回答由哪些操作与回执支撑。需要提交上一步拿到的 lease_token 与 lease_epoch。"
   },
   "bkn_fail_interaction": {
     "name": "bkn_fail_interaction",
-    "description": "Explicitly fail an Interaction with its closure manifest."
+    "description": "以收口清单将交互标记为失败。需要提交 lease_token 与 lease_epoch。"
   },
   "bkn_cancel_interaction": {
     "name": "bkn_cancel_interaction",
-    "description": "Explicitly cancel an Interaction with its closure manifest."
+    "description": "以收口清单取消交互。需要提交 lease_token 与 lease_epoch。"
   },
   "bkn_handoff_interaction": {
     "name": "bkn_handoff_interaction",
-    "description": "Explicitly hand off an Interaction with its closure manifest."
+    "description": "以收口清单移交交互（转人工或转其他执行者）。需要提交 lease_token 与 lease_epoch。"
   },
   "bkn_close_conversation": {
     "name": "bkn_close_conversation",
-    "description": "Close an active Conversation when it has no active Interaction."
+    "description": "关闭业务对话。要求其下没有活跃交互，须先完结或取消当前交互。"
   },
   "bkn_get_operation": {
     "name": "bkn_get_operation",
-    "description": "Get the authoritative Operation state and retry eligibility."
+    "description": "查询某次操作的权威状态与是否可重试。用于确认一次业务调用的最终结果。"
   },
   "bkn_retry_operation": {
     "name": "bkn_retry_operation",
-    "description": "Explicitly create the next attempt for a retryable failed Operation."
+    "description": "为可重试的失败操作创建下一次尝试。仅对标记为 retryable 的失败操作有效。"
   },
   "bkn_get_receipt": {
     "name": "bkn_get_receipt",
-    "description": "Poll one authoritative durable Receipt by receipt ID."
+    "description": "按 receipt_id 轮询一张权威的持久化回执。业务调用返回 receipt_pending 时用它确认最终落库结果。"
   },
   "search_schema": {
     "name": "search_schema",

--- a/adp/context-loader/agent-retrieval/server/driveradapters/mcp/session_fallback.go
+++ b/adp/context-loader/agent-retrieval/server/driveradapters/mcp/session_fallback.go
@@ -35,19 +35,41 @@ const (
 	autoSessionOperationNS = "mcp-auto"
 )
 
-// autoSessionEpoch salts the interaction idempotency key. It advances only when
-// a lease has expired, so the retry opens a fresh interaction instead of
-// replaying the dead one.
-type autoSessionRetry struct{ epoch int }
+// autoSessionRetry salts the interaction idempotency key. Core resolves a
+// replayed start key to the interaction it already owns without checking its
+// lease, so reusing the key would hand back the same dead interaction. Only a
+// different key can open a live one.
+//
+// The salt is the id of the interaction that went stale rather than a counter,
+// so concurrent callers that all hit the same dead interaction derive the same
+// replacement key and converge on one new interaction instead of racing.
+type autoSessionRetry struct{ afterInteractionID string }
 
-// resolveAutoSession derives a bkn_context for a client that supplied none, and
-// rebuilds the session once when the previous interaction went stale. Core
-// renews the lease on every operation, so only an idle connection lands here.
+// isStaleAutoSession reports whether an auto session died between calls in a way
+// the client cannot see or repair. Core declares an interaction terminal once
+// its lease lapses, and caps a single interaction at 128 operations; a long-lived
+// MCP connection reaches both in ordinary use.
+func isStaleAutoSession(value *lifecycleError) bool {
+	if value == nil {
+		return false
+	}
+	switch value.Code {
+	case "interaction_terminal", "operation_required", "conversation_closed", "conversation_expired":
+		return true
+	default:
+		return false
+	}
+}
+
+// resolveAutoSession derives a full bkn_context for a client that supplied none.
+// The caller decides when to ask for a rebuild, because the staleness only shows
+// up downstream, when the operation is ensured against Core.
 func resolveAutoSession(
 	ctx context.Context,
 	client *bkntrace.LifecycleClient,
 	req mcpsdk.CallToolRequest,
 	arguments map[string]any,
+	retry autoSessionRetry,
 ) (bknContext, *lifecycleError, error) {
 	if client == nil || !client.Enabled() {
 		return bknContext{}, lifecycleErrorPtr(bkntrace.APIError{
@@ -55,24 +77,6 @@ func resolveAutoSession(
 			RequiredAction: "install_enterprise_implementation",
 		}), nil
 	}
-	resolved, lifecycleErr, err := resolveAutoContext(ctx, client, req, arguments, autoSessionRetry{})
-	if err != nil || !isAutoSessionRecoverable(lifecycleErr) {
-		return resolved, lifecycleErr, err
-	}
-	return resolveAutoContext(ctx, client, req, arguments, autoSessionRetry{epoch: 1})
-}
-
-// resolveAutoContext derives a full bkn_context for a client that supplied none.
-// It returns the zero value untouched when the client did supply one — a partial
-// context stays an error, since splicing a client conversation onto a generated
-// interaction would fabricate a causality edge that never happened.
-func resolveAutoContext(
-	ctx context.Context,
-	client *bkntrace.LifecycleClient,
-	req mcpsdk.CallToolRequest,
-	arguments map[string]any,
-	retry autoSessionRetry,
-) (bknContext, *lifecycleError, error) {
 	sessionID := autoSessionID(ctx)
 	if sessionID == "" {
 		return bknContext{}, &lifecycleError{
@@ -89,7 +93,7 @@ func resolveAutoContext(
 		return bknContext{}, lifecycleErrorPtr(*apiErr), nil
 	}
 	interaction, apiErr, err := client.StartInteraction(
-		ctx, conversation.ConversationID, autoInteractionKey(sessionID, retry.epoch),
+		ctx, conversation.ConversationID, autoInteractionKey(sessionID, retry),
 	)
 	if err != nil {
 		return bknContext{}, nil, err
@@ -115,11 +119,11 @@ func autoSessionID(ctx context.Context) string {
 	return strings.TrimSpace(session.SessionID())
 }
 
-func autoInteractionKey(sessionID string, epoch int) string {
-	if epoch <= 0 {
+func autoInteractionKey(sessionID string, retry autoSessionRetry) string {
+	if retry.afterInteractionID == "" {
 		return autoSessionKeyPrefix + sessionID
 	}
-	return autoSessionKeyPrefix + sessionID + ":" + string(rune('0'+epoch%10))
+	return autoSessionKeyPrefix + sessionID + ":after:" + retry.afterInteractionID
 }
 
 // autoOperationKey makes a replayed identical call idempotent within the
@@ -141,21 +145,6 @@ func autoOperationKey(toolName string, arguments map[string]any) string {
 	raw, _ := json.Marshal(map[string]any{"tool": toolName, "input": normalized})
 	sum := sha256.Sum256(raw)
 	return autoSessionOperationNS + ":" + toolName + ":" + hex.EncodeToString(sum[:8])
-}
-
-// isAutoSessionRecoverable reports whether a stale auto-session can be rebuilt
-// by opening a new interaction. An idle connection loses its lease after five
-// minutes, and the client has no way to know that happened.
-func isAutoSessionRecoverable(value *lifecycleError) bool {
-	if value == nil {
-		return false
-	}
-	switch value.Code {
-	case "interaction_terminal", "interaction_required", "conversation_closed", "conversation_expired":
-		return true
-	default:
-		return false
-	}
 }
 
 func lifecycleErrorPtr(value bkntrace.APIError) *lifecycleError {

--- a/adp/context-loader/agent-retrieval/server/driveradapters/mcp/session_fallback.go
+++ b/adp/context-loader/agent-retrieval/server/driveradapters/mcp/session_fallback.go
@@ -32,7 +32,6 @@ import (
 // closure manifest — an auto-session has no answer to close over.
 const (
 	autoSessionKeyPrefix   = "mcp:"
-	autoSessionQuestion    = "(mcp auto-session)"
 	autoSessionOperationNS = "mcp-auto"
 )
 
@@ -90,8 +89,7 @@ func resolveAutoContext(
 		return bknContext{}, lifecycleErrorPtr(*apiErr), nil
 	}
 	interaction, apiErr, err := client.StartInteraction(
-		ctx, conversation.ConversationID,
-		autoInteractionKey(sessionID, retry.epoch), autoSessionQuestion,
+		ctx, conversation.ConversationID, autoInteractionKey(sessionID, retry.epoch),
 	)
 	if err != nil {
 		return bknContext{}, nil, err

--- a/adp/context-loader/agent-retrieval/server/driveradapters/mcp/session_fallback.go
+++ b/adp/context-loader/agent-retrieval/server/driveradapters/mcp/session_fallback.go
@@ -1,0 +1,166 @@
+// Copyright openbkn.ai
+// Copyright The kweaver.ai Authors.
+//
+// Licensed under the Apache License, Version 2.0.
+// See the LICENSE file in the project root for details.
+
+package mcp
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"sort"
+	"strings"
+
+	mcpsdk "github.com/mark3labs/mcp-go/mcp"
+	mcpserver "github.com/mark3labs/mcp-go/server"
+
+	"github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/infra/bkntrace"
+)
+
+// Managed lifecycle state is caller-owned by design: a client that names its own
+// conversation gets evidence bound to its real business turn. MCP clients such as
+// Claude Code and Cursor have no business conversation to name, so without a
+// fallback every tool call fails closed on conversation_required.
+//
+// The fallback binds one conversation to one MCP connection. Every tool call on
+// that connection becomes an operation under a single interaction, because Core
+// allows only one active interaction per conversation and MCP clients issue tool
+// calls concurrently. The tradeoff is that the interaction never reaches a
+// closure manifest — an auto-session has no answer to close over.
+const (
+	autoSessionKeyPrefix   = "mcp:"
+	autoSessionQuestion    = "(mcp auto-session)"
+	autoSessionOperationNS = "mcp-auto"
+)
+
+// autoSessionEpoch salts the interaction idempotency key. It advances only when
+// a lease has expired, so the retry opens a fresh interaction instead of
+// replaying the dead one.
+type autoSessionRetry struct{ epoch int }
+
+// resolveAutoSession derives a bkn_context for a client that supplied none, and
+// rebuilds the session once when the previous interaction went stale. Core
+// renews the lease on every operation, so only an idle connection lands here.
+func resolveAutoSession(
+	ctx context.Context,
+	client *bkntrace.LifecycleClient,
+	req mcpsdk.CallToolRequest,
+	arguments map[string]any,
+) (bknContext, *lifecycleError, error) {
+	if client == nil || !client.Enabled() {
+		return bknContext{}, lifecycleErrorPtr(bkntrace.APIError{
+			Code: "feature_not_installed", Message: "BKN Trace Core is not configured",
+			RequiredAction: "install_enterprise_implementation",
+		}), nil
+	}
+	resolved, lifecycleErr, err := resolveAutoContext(ctx, client, req, arguments, autoSessionRetry{})
+	if err != nil || !isAutoSessionRecoverable(lifecycleErr) {
+		return resolved, lifecycleErr, err
+	}
+	return resolveAutoContext(ctx, client, req, arguments, autoSessionRetry{epoch: 1})
+}
+
+// resolveAutoContext derives a full bkn_context for a client that supplied none.
+// It returns the zero value untouched when the client did supply one — a partial
+// context stays an error, since splicing a client conversation onto a generated
+// interaction would fabricate a causality edge that never happened.
+func resolveAutoContext(
+	ctx context.Context,
+	client *bkntrace.LifecycleClient,
+	req mcpsdk.CallToolRequest,
+	arguments map[string]any,
+	retry autoSessionRetry,
+) (bknContext, *lifecycleError, error) {
+	sessionID := autoSessionID(ctx)
+	if sessionID == "" {
+		return bknContext{}, &lifecycleError{
+			Code:           "conversation_required",
+			Message:        "conversation_id is required",
+			RequiredAction: "create_conversation",
+		}, nil
+	}
+	conversation, apiErr, err := client.EnsureCurrentConversation(ctx, autoSessionKeyPrefix+sessionID)
+	if err != nil {
+		return bknContext{}, nil, err
+	}
+	if apiErr != nil {
+		return bknContext{}, lifecycleErrorPtr(*apiErr), nil
+	}
+	interaction, apiErr, err := client.StartInteraction(
+		ctx, conversation.ConversationID,
+		autoInteractionKey(sessionID, retry.epoch), autoSessionQuestion,
+	)
+	if err != nil {
+		return bknContext{}, nil, err
+	}
+	if apiErr != nil {
+		return bknContext{}, lifecycleErrorPtr(*apiErr), nil
+	}
+	return bknContext{
+		ConversationID: conversation.ConversationID,
+		InteractionID:  interaction.InteractionID,
+		OperationKey:   autoOperationKey(req.Params.Name, arguments),
+	}, nil, nil
+}
+
+// autoSessionID identifies the MCP connection. Streamable HTTP assigns one per
+// initialize handshake, so a reconnect deliberately starts a new conversation
+// rather than silently extending causality across a gap the client cannot see.
+func autoSessionID(ctx context.Context) string {
+	session := mcpserver.ClientSessionFromContext(ctx)
+	if session == nil {
+		return ""
+	}
+	return strings.TrimSpace(session.SessionID())
+}
+
+func autoInteractionKey(sessionID string, epoch int) string {
+	if epoch <= 0 {
+		return autoSessionKeyPrefix + sessionID
+	}
+	return autoSessionKeyPrefix + sessionID + ":" + string(rune('0'+epoch%10))
+}
+
+// autoOperationKey makes a replayed identical call idempotent within the
+// interaction, and keeps two different calls distinct. Core keys operations by
+// this value, so it must not collide across tools.
+func autoOperationKey(toolName string, arguments map[string]any) string {
+	normalized := map[string]any{}
+	keys := make([]string, 0, len(arguments))
+	for key := range arguments {
+		if key == "bkn_context" {
+			continue
+		}
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	for _, key := range keys {
+		normalized[key] = arguments[key]
+	}
+	raw, _ := json.Marshal(map[string]any{"tool": toolName, "input": normalized})
+	sum := sha256.Sum256(raw)
+	return autoSessionOperationNS + ":" + toolName + ":" + hex.EncodeToString(sum[:8])
+}
+
+// isAutoSessionRecoverable reports whether a stale auto-session can be rebuilt
+// by opening a new interaction. An idle connection loses its lease after five
+// minutes, and the client has no way to know that happened.
+func isAutoSessionRecoverable(value *lifecycleError) bool {
+	if value == nil {
+		return false
+	}
+	switch value.Code {
+	case "interaction_terminal", "interaction_required", "conversation_closed", "conversation_expired":
+		return true
+	default:
+		return false
+	}
+}
+
+func lifecycleErrorPtr(value bkntrace.APIError) *lifecycleError {
+	converted := lifecycleError(value)
+	return &converted
+}

--- a/adp/context-loader/agent-retrieval/server/driveradapters/mcp/session_fallback.go
+++ b/adp/context-loader/agent-retrieval/server/driveradapters/mcp/session_fallback.go
@@ -13,6 +13,7 @@ import (
 	"encoding/json"
 	"sort"
 	"strings"
+	"sync"
 
 	mcpsdk "github.com/mark3labs/mcp-go/mcp"
 	mcpserver "github.com/mark3labs/mcp-go/server"
@@ -44,6 +45,52 @@ const (
 // so concurrent callers that all hit the same dead interaction derive the same
 // replacement key and converge on one new interaction instead of racing.
 type autoSessionRetry struct{ afterInteractionID string }
+
+// autoSessionMaxRebuilds bounds how many dead generations one call will walk
+// past. A connection accumulates one dead interaction per idle gap, and each
+// rebuild costs two Core round trips, so the walk has to end somewhere; the
+// remembered key means a healthy connection never walks at all.
+const autoSessionMaxRebuilds = 3
+
+// autoSessionKeys remembers the start key that last worked for an MCP session.
+// Without it every call after the first rebuild would replay the base key, get
+// the long-dead first interaction back, and pay a failed ensure before
+// rebuilding again — and the walk would grow by one generation per idle gap.
+//
+// Sessions end without telling this service, so entries are aged out by
+// rotation rather than deletion: the live map is retired to previous once it
+// fills, bounding the whole cache at twice the cap.
+var autoSessionKeys = &rotatingKeyCache{cap: 2048}
+
+type rotatingKeyCache struct {
+	mu       sync.Mutex
+	cap      int
+	live     map[string]string
+	previous map[string]string
+}
+
+func (c *rotatingKeyCache) get(sessionID string) (string, bool) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if key, ok := c.live[sessionID]; ok {
+		return key, true
+	}
+	key, ok := c.previous[sessionID]
+	return key, ok
+}
+
+func (c *rotatingKeyCache) put(sessionID, key string) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.live == nil {
+		c.live = make(map[string]string, 64)
+	}
+	if len(c.live) >= c.cap {
+		c.previous = c.live
+		c.live = make(map[string]string, 64)
+	}
+	c.live[sessionID] = key
+}
 
 // isStaleAutoSession reports whether an auto session died between calls in a way
 // the client cannot see or repair. Core declares an interaction terminal once
@@ -92,8 +139,9 @@ func resolveAutoSession(
 	if apiErr != nil {
 		return bknContext{}, lifecycleErrorPtr(*apiErr), nil
 	}
+	startKey := autoInteractionKey(sessionID, retry)
 	interaction, apiErr, err := client.StartInteraction(
-		ctx, conversation.ConversationID, autoInteractionKey(sessionID, retry),
+		ctx, conversation.ConversationID, startKey,
 	)
 	if err != nil {
 		return bknContext{}, nil, err
@@ -101,6 +149,7 @@ func resolveAutoSession(
 	if apiErr != nil {
 		return bknContext{}, lifecycleErrorPtr(*apiErr), nil
 	}
+	autoSessionKeys.put(sessionID, startKey)
 	return bknContext{
 		ConversationID: conversation.ConversationID,
 		InteractionID:  interaction.InteractionID,
@@ -119,11 +168,19 @@ func autoSessionID(ctx context.Context) string {
 	return strings.TrimSpace(session.SessionID())
 }
 
+// autoInteractionKey picks the start key for this attempt: the one that last
+// worked for the session, or a fresh salt derived from the interaction that just
+// died. Walking forward from the dead one matters — the base key resolves to the
+// first interaction ever opened on this connection for as long as the connection
+// lives, so a salt fixed to it would only ever reach the second generation.
 func autoInteractionKey(sessionID string, retry autoSessionRetry) string {
-	if retry.afterInteractionID == "" {
-		return autoSessionKeyPrefix + sessionID
+	if retry.afterInteractionID != "" {
+		return autoSessionKeyPrefix + sessionID + ":after:" + retry.afterInteractionID
 	}
-	return autoSessionKeyPrefix + sessionID + ":after:" + retry.afterInteractionID
+	if remembered, ok := autoSessionKeys.get(sessionID); ok {
+		return remembered
+	}
+	return autoSessionKeyPrefix + sessionID
 }
 
 // autoOperationKey makes a replayed identical call idempotent within the

--- a/adp/context-loader/agent-retrieval/server/driveradapters/mcp/session_fallback_test.go
+++ b/adp/context-loader/agent-retrieval/server/driveradapters/mcp/session_fallback_test.go
@@ -1,0 +1,337 @@
+// Copyright openbkn.ai
+// Copyright The kweaver.ai Authors.
+//
+// Licensed under the Apache License, Version 2.0.
+// See the LICENSE file in the project root for details.
+
+package mcp
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+
+	mcpsdk "github.com/mark3labs/mcp-go/mcp"
+	mcpserver "github.com/mark3labs/mcp-go/server"
+
+	"github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/infra/bkntrace"
+)
+
+type fakeClientSession struct{ id string }
+
+func (s fakeClientSession) Initialize()                                            {}
+func (s fakeClientSession) Initialized() bool                                      { return true }
+func (s fakeClientSession) NotificationChannel() chan<- mcpsdk.JSONRPCNotification { return nil }
+func (s fakeClientSession) SessionID() string                                      { return s.id }
+
+type fakeCore struct {
+	server            *httptest.Server
+	mu                sync.Mutex
+	conversationCalls int
+	interactionKeys   []string
+	// activeInteraction mirrors Core: a second interaction on the same
+	// conversation is rejected unless the start key replays the existing one.
+	activeInteraction string
+	staleOnce         bool
+}
+
+func newFakeCore(t *testing.T) *fakeCore {
+	t.Helper()
+	core := &fakeCore{}
+	core.server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		core.mu.Lock()
+		defer core.mu.Unlock()
+		switch {
+		case strings.HasSuffix(r.URL.Path, "/conversations:ensure-current"):
+			var body struct {
+				ExternalConversationKey string `json:"external_conversation_key"`
+			}
+			_ = json.NewDecoder(r.Body).Decode(&body)
+			core.conversationCalls++
+			_ = json.NewEncoder(w).Encode(bkntrace.Conversation{
+				ConversationID:          "conv-for-" + body.ExternalConversationKey,
+				ExternalConversationKey: body.ExternalConversationKey,
+				Status:                  "active",
+			})
+		case strings.HasSuffix(r.URL.Path, "/interactions"):
+			var body struct {
+				IdempotencyKey string `json:"idempotency_key"`
+				Question       string `json:"question"`
+			}
+			_ = json.NewDecoder(r.Body).Decode(&body)
+			core.interactionKeys = append(core.interactionKeys, body.IdempotencyKey)
+			if core.staleOnce && body.IdempotencyKey == core.activeInteraction {
+				core.staleOnce = false
+				w.WriteHeader(http.StatusConflict)
+				_ = json.NewEncoder(w).Encode(map[string]any{"error": bkntrace.APIError{
+					Code: "interaction_terminal", Message: "lease expired",
+					RequiredAction: "start_interaction",
+				}})
+				return
+			}
+			if core.activeInteraction == "" {
+				core.activeInteraction = body.IdempotencyKey
+			}
+			_ = json.NewEncoder(w).Encode(bkntrace.Interaction{
+				InteractionID: "int-for-" + body.IdempotencyKey,
+				// Core resolves a replayed start key to the interaction it already
+				// owns, which is what lets concurrent callers converge.
+				ConversationID: "conv-active", ExecutionStatus: "active",
+				LeaseToken: "lease-1", LeaseEpoch: 1,
+			})
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	t.Cleanup(core.server.Close)
+	return core
+}
+
+func (c *fakeCore) client() *bkntrace.LifecycleClient {
+	return bkntrace.NewLifecycleClient(c.server.URL, c.server.Client())
+}
+
+func contextWithSession(sessionID string) context.Context {
+	server := mcpserver.NewMCPServer("test", "0")
+	return server.WithContext(trustedSessionGuardContext(), fakeClientSession{id: sessionID})
+}
+
+func contextlessBusinessRequest() mcpsdk.CallToolRequest {
+	return mcpsdk.CallToolRequest{
+		Params: mcpsdk.CallToolParams{
+			Name:      "search_schema",
+			Arguments: map[string]any{"kn_id": "kn-1", "query": "orders"},
+		},
+	}
+}
+
+func TestMissingBusinessContextFallsBackToTheMCPSession(t *testing.T) {
+	core := newFakeCore(t)
+	var seen []bknContext
+	guarded := guardBusinessToolCallWithCompletion(
+		func(_ context.Context, intent operationIntent) (*operationResult, *lifecycleError, error) {
+			seen = append(seen, intent.Context)
+			return &operationResult{Created: true, Execute: true}, nil, nil
+		},
+		nil, core.client(),
+		func(context.Context, mcpsdk.CallToolRequest) (*mcpsdk.CallToolResult, error) {
+			return mcpsdk.NewToolResultStructured(map[string]any{"ok": true}, `{"ok":true}`), nil
+		},
+	)
+
+	result, err := guarded(contextWithSession("session-a"), contextlessBusinessRequest())
+	if err != nil {
+		t.Fatalf("guard returned protocol error: %v", err)
+	}
+	if result.IsError {
+		t.Fatalf("a client with no bkn_context must still be served: %#v", result.StructuredContent)
+	}
+	if len(seen) != 1 {
+		t.Fatalf("expected exactly one ensured operation, got %d", len(seen))
+	}
+	if seen[0].ConversationID != "conv-for-mcp:session-a" {
+		t.Fatalf("conversation is not bound to the MCP session: %#v", seen[0])
+	}
+	if seen[0].InteractionID == "" || seen[0].OperationKey == "" {
+		t.Fatalf("fallback left the lifecycle context incomplete: %#v", seen[0])
+	}
+}
+
+func TestFallbackReusesOneConversationAcrossCallsOnTheSameSession(t *testing.T) {
+	core := newFakeCore(t)
+	var seen []bknContext
+	guarded := guardBusinessToolCallWithCompletion(
+		func(_ context.Context, intent operationIntent) (*operationResult, *lifecycleError, error) {
+			seen = append(seen, intent.Context)
+			return &operationResult{Created: true, Execute: true}, nil, nil
+		},
+		nil, core.client(),
+		func(context.Context, mcpsdk.CallToolRequest) (*mcpsdk.CallToolResult, error) {
+			return mcpsdk.NewToolResultStructured(map[string]any{"ok": true}, `{"ok":true}`), nil
+		},
+	)
+
+	ctx := contextWithSession("session-a")
+	for range 3 {
+		if _, err := guarded(ctx, contextlessBusinessRequest()); err != nil {
+			t.Fatalf("guard returned protocol error: %v", err)
+		}
+	}
+	other := contextWithSession("session-b")
+	if _, err := guarded(other, contextlessBusinessRequest()); err != nil {
+		t.Fatalf("guard returned protocol error: %v", err)
+	}
+
+	if len(seen) != 4 {
+		t.Fatalf("expected four ensured operations, got %d", len(seen))
+	}
+	for _, entry := range seen[:3] {
+		if entry.ConversationID != seen[0].ConversationID || entry.InteractionID != seen[0].InteractionID {
+			t.Fatalf("one session must map to one conversation and interaction: %#v", seen[:3])
+		}
+	}
+	if seen[3].ConversationID == seen[0].ConversationID {
+		t.Fatalf("a different MCP session must not share a conversation: %#v", seen)
+	}
+	// Identical calls on one session share an operation key, which is what makes
+	// a retried call idempotent instead of a second execution.
+	if seen[0].OperationKey != seen[1].OperationKey {
+		t.Fatalf("identical calls produced different operation keys: %q vs %q", seen[0].OperationKey, seen[1].OperationKey)
+	}
+}
+
+func TestFallbackGivesDifferentCallsDistinctOperationKeys(t *testing.T) {
+	core := newFakeCore(t)
+	var seen []bknContext
+	guarded := guardBusinessToolCallWithCompletion(
+		func(_ context.Context, intent operationIntent) (*operationResult, *lifecycleError, error) {
+			seen = append(seen, intent.Context)
+			return &operationResult{Created: true, Execute: true}, nil, nil
+		},
+		nil, core.client(),
+		func(context.Context, mcpsdk.CallToolRequest) (*mcpsdk.CallToolResult, error) {
+			return mcpsdk.NewToolResultStructured(map[string]any{"ok": true}, `{"ok":true}`), nil
+		},
+	)
+
+	ctx := contextWithSession("session-a")
+	first := contextlessBusinessRequest()
+	second := mcpsdk.CallToolRequest{Params: mcpsdk.CallToolParams{
+		Name: "search_schema", Arguments: map[string]any{"kn_id": "kn-1", "query": "shipments"},
+	}}
+	for _, request := range []mcpsdk.CallToolRequest{first, second} {
+		if _, err := guarded(ctx, request); err != nil {
+			t.Fatalf("guard returned protocol error: %v", err)
+		}
+	}
+	if seen[0].OperationKey == seen[1].OperationKey {
+		t.Fatalf("two different calls collapsed onto one operation key: %q", seen[0].OperationKey)
+	}
+}
+
+func TestExplicitBusinessContextIsNeverReplacedByTheSession(t *testing.T) {
+	core := newFakeCore(t)
+	var seen []bknContext
+	guarded := guardBusinessToolCallWithCompletion(
+		func(_ context.Context, intent operationIntent) (*operationResult, *lifecycleError, error) {
+			seen = append(seen, intent.Context)
+			return &operationResult{Created: true, Execute: true}, nil, nil
+		},
+		nil, core.client(),
+		func(context.Context, mcpsdk.CallToolRequest) (*mcpsdk.CallToolResult, error) {
+			return mcpsdk.NewToolResultStructured(map[string]any{"ok": true}, `{"ok":true}`), nil
+		},
+	)
+
+	if _, err := guarded(contextWithSession("session-a"), validBusinessToolRequest()); err != nil {
+		t.Fatalf("guard returned protocol error: %v", err)
+	}
+	if seen[0].ConversationID != "conv_1" || seen[0].OperationKey != "op-key-1" {
+		t.Fatalf("caller-owned context was overwritten by the session: %#v", seen[0])
+	}
+	if core.conversationCalls != 0 {
+		t.Fatalf("an explicit context must not open a fallback conversation")
+	}
+}
+
+func TestPartialBusinessContextStillFailsInsteadOfBeingCompleted(t *testing.T) {
+	core := newFakeCore(t)
+	guarded := guardBusinessToolCallWithCompletion(
+		func(context.Context, operationIntent) (*operationResult, *lifecycleError, error) {
+			t.Fatal("a half-filled context must never reach the lifecycle client")
+			return nil, nil, nil
+		},
+		nil, core.client(),
+		func(context.Context, mcpsdk.CallToolRequest) (*mcpsdk.CallToolResult, error) {
+			return mcpsdk.NewToolResultStructured(map[string]any{"ok": true}, `{"ok":true}`), nil
+		},
+	)
+
+	for _, testCase := range []struct {
+		name      string
+		arguments map[string]any
+		wantCode  string
+	}{
+		{"conversation only", map[string]any{"conversation_id": "conv_1"}, "interaction_required"},
+		{"missing operation key", map[string]any{
+			"conversation_id": "conv_1", "interaction_id": "int_1",
+		}, "operation_required"},
+		{"interaction only", map[string]any{"interaction_id": "int_1"}, "conversation_required"},
+	} {
+		t.Run(testCase.name, func(t *testing.T) {
+			request := mcpsdk.CallToolRequest{Params: mcpsdk.CallToolParams{
+				Name:      "search_schema",
+				Arguments: map[string]any{"bkn_context": testCase.arguments},
+			}}
+			result, err := guarded(contextWithSession("session-a"), request)
+			if err != nil {
+				t.Fatalf("guard returned protocol error: %v", err)
+			}
+			if !result.IsError {
+				t.Fatal("a half-filled context must not be silently completed")
+			}
+			envelope := result.StructuredContent.(map[string]any)["error"].(map[string]any)
+			if envelope["code"] != testCase.wantCode {
+				t.Fatalf("error code = %v, want %s", envelope["code"], testCase.wantCode)
+			}
+		})
+	}
+}
+
+func TestFallbackRebuildsTheSessionWhenTheLeaseExpired(t *testing.T) {
+	core := newFakeCore(t)
+	core.activeInteraction = "mcp:session-a"
+	core.staleOnce = true
+	var seen []bknContext
+	guarded := guardBusinessToolCallWithCompletion(
+		func(_ context.Context, intent operationIntent) (*operationResult, *lifecycleError, error) {
+			seen = append(seen, intent.Context)
+			return &operationResult{Created: true, Execute: true}, nil, nil
+		},
+		nil, core.client(),
+		func(context.Context, mcpsdk.CallToolRequest) (*mcpsdk.CallToolResult, error) {
+			return mcpsdk.NewToolResultStructured(map[string]any{"ok": true}, `{"ok":true}`), nil
+		},
+	)
+
+	result, err := guarded(contextWithSession("session-a"), contextlessBusinessRequest())
+	if err != nil {
+		t.Fatalf("guard returned protocol error: %v", err)
+	}
+	if result.IsError {
+		t.Fatalf("an expired lease must be rebuilt, not surfaced: %#v", result.StructuredContent)
+	}
+	if len(core.interactionKeys) != 2 || core.interactionKeys[0] == core.interactionKeys[1] {
+		t.Fatalf("retry must open a new interaction, keys = %v", core.interactionKeys)
+	}
+	if len(seen) != 1 || seen[0].InteractionID == "" {
+		t.Fatalf("rebuilt session did not produce a usable context: %#v", seen)
+	}
+}
+
+func TestFallbackWithoutAnMCPSessionKeepsTheOriginalError(t *testing.T) {
+	core := newFakeCore(t)
+	guarded := guardBusinessToolCallWithCompletion(
+		func(context.Context, operationIntent) (*operationResult, *lifecycleError, error) {
+			t.Fatal("a sessionless call must not reach the lifecycle client")
+			return nil, nil, nil
+		},
+		nil, core.client(),
+		func(context.Context, mcpsdk.CallToolRequest) (*mcpsdk.CallToolResult, error) {
+			return mcpsdk.NewToolResultStructured(map[string]any{"ok": true}, `{"ok":true}`), nil
+		},
+	)
+
+	result, err := guarded(trustedSessionGuardContext(), contextlessBusinessRequest())
+	if err != nil {
+		t.Fatalf("guard returned protocol error: %v", err)
+	}
+	envelope := result.StructuredContent.(map[string]any)["error"].(map[string]any)
+	if envelope["code"] != "conversation_required" {
+		t.Fatalf("without a session the guard must still demand a conversation, got %v", envelope["code"])
+	}
+}

--- a/adp/context-loader/agent-retrieval/server/driveradapters/mcp/session_fallback_test.go
+++ b/adp/context-loader/agent-retrieval/server/driveradapters/mcp/session_fallback_test.go
@@ -49,8 +49,19 @@ func newFakeCore(t *testing.T) *fakeCore {
 		case strings.HasSuffix(r.URL.Path, "/conversations:ensure-current"):
 			var body struct {
 				ExternalConversationKey string `json:"external_conversation_key"`
+				IdempotencyKey          string `json:"idempotency_key"`
+				OneShot                 bool   `json:"one_shot"`
 			}
-			_ = json.NewDecoder(r.Body).Decode(&body)
+			decoder := json.NewDecoder(r.Body)
+			decoder.DisallowUnknownFields()
+			if err := decoder.Decode(&body); err != nil {
+				w.WriteHeader(http.StatusBadRequest)
+				_ = json.NewEncoder(w).Encode(map[string]any{"error": bkntrace.APIError{
+					Code: "conversation_required", Message: "request body does not match the lifecycle contract",
+					RequiredAction: "create_conversation",
+				}})
+				return
+			}
 			core.conversationCalls++
 			_ = json.NewEncoder(w).Encode(bkntrace.Conversation{
 				ConversationID:          "conv-for-" + body.ExternalConversationKey,
@@ -60,9 +71,21 @@ func newFakeCore(t *testing.T) *fakeCore {
 		case strings.HasSuffix(r.URL.Path, "/interactions"):
 			var body struct {
 				IdempotencyKey string `json:"idempotency_key"`
-				Question       string `json:"question"`
+				LeaseSeconds   int64  `json:"lease_seconds"`
 			}
-			_ = json.NewDecoder(r.Body).Decode(&body)
+			// Core decodes with DisallowUnknownFields and its start contract has
+			// exactly these two fields. A lenient fake here let a body Core would
+			// reject pass every unit test and fail on the first real call.
+			decoder := json.NewDecoder(r.Body)
+			decoder.DisallowUnknownFields()
+			if err := decoder.Decode(&body); err != nil {
+				w.WriteHeader(http.StatusBadRequest)
+				_ = json.NewEncoder(w).Encode(map[string]any{"error": bkntrace.APIError{
+					Code: "interaction_required", Message: "request body does not match the lifecycle contract",
+					RequiredAction: "start_interaction",
+				}})
+				return
+			}
 			core.interactionKeys = append(core.interactionKeys, body.IdempotencyKey)
 			if core.staleOnce && body.IdempotencyKey == core.activeInteraction {
 				core.staleOnce = false

--- a/adp/context-loader/agent-retrieval/server/driveradapters/mcp/session_fallback_test.go
+++ b/adp/context-loader/agent-retrieval/server/driveradapters/mcp/session_fallback_test.go
@@ -19,6 +19,7 @@ import (
 	mcpserver "github.com/mark3labs/mcp-go/server"
 
 	"github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/infra/bkntrace"
+	"github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/infra/common"
 )
 
 type fakeClientSession struct{ id string }
@@ -33,10 +34,6 @@ type fakeCore struct {
 	mu                sync.Mutex
 	conversationCalls int
 	interactionKeys   []string
-	// activeInteraction mirrors Core: a second interaction on the same
-	// conversation is rejected unless the start key replays the existing one.
-	activeInteraction string
-	staleOnce         bool
 }
 
 func newFakeCore(t *testing.T) *fakeCore {
@@ -87,22 +84,12 @@ func newFakeCore(t *testing.T) *fakeCore {
 				return
 			}
 			core.interactionKeys = append(core.interactionKeys, body.IdempotencyKey)
-			if core.staleOnce && body.IdempotencyKey == core.activeInteraction {
-				core.staleOnce = false
-				w.WriteHeader(http.StatusConflict)
-				_ = json.NewEncoder(w).Encode(map[string]any{"error": bkntrace.APIError{
-					Code: "interaction_terminal", Message: "lease expired",
-					RequiredAction: "start_interaction",
-				}})
-				return
-			}
-			if core.activeInteraction == "" {
-				core.activeInteraction = body.IdempotencyKey
-			}
+			// Mirrors Core: a replayed start key resolves to the interaction that
+			// key already owns and answers 200, without consulting its lease. Core
+			// therefore never reports staleness here, and a rebuild that reuses the
+			// key gets the dead interaction straight back.
 			_ = json.NewEncoder(w).Encode(bkntrace.Interaction{
-				InteractionID: "int-for-" + body.IdempotencyKey,
-				// Core resolves a replayed start key to the interaction it already
-				// owns, which is what lets concurrent callers converge.
+				InteractionID:  "int-for-" + body.IdempotencyKey,
 				ConversationID: "conv-active", ExecutionStatus: "active",
 				LeaseToken: "lease-1", LeaseEpoch: 1,
 			})
@@ -305,15 +292,67 @@ func TestPartialBusinessContextStillFailsInsteadOfBeingCompleted(t *testing.T) {
 	}
 }
 
-func TestFallbackRebuildsTheSessionWhenTheLeaseExpired(t *testing.T) {
+func TestFallbackRebuildsTheSessionWhenCoreReportsItStale(t *testing.T) {
+	// Core never reports staleness while starting an interaction: a replayed
+	// start key resolves to the interaction it already owns, lease or no lease,
+	// and answers 200. The death only shows up one step later, when the
+	// operation is ensured — which is why the rebuild has to wrap that call.
+	for _, staleCode := range []string{"interaction_terminal", "operation_required"} {
+		t.Run(staleCode, func(t *testing.T) {
+			core := newFakeCore(t)
+			var seen []bknContext
+			guarded := guardBusinessToolCallWithCompletion(
+				func(_ context.Context, intent operationIntent) (*operationResult, *lifecycleError, error) {
+					seen = append(seen, intent.Context)
+					if len(seen) == 1 {
+						return nil, &lifecycleError{
+							Code: staleCode, Message: "session went stale between calls",
+							RequiredAction: "start_interaction",
+						}, nil
+					}
+					return &operationResult{Created: true, Execute: true}, nil, nil
+				},
+				nil, core.client(),
+				func(context.Context, mcpsdk.CallToolRequest) (*mcpsdk.CallToolResult, error) {
+					return mcpsdk.NewToolResultStructured(map[string]any{"ok": true}, `{"ok":true}`), nil
+				},
+			)
+
+			result, err := guarded(contextWithSession("session-a"), contextlessBusinessRequest())
+			if err != nil {
+				t.Fatalf("guard returned protocol error: %v", err)
+			}
+			if result.IsError {
+				t.Fatalf("a stale auto session must be rebuilt, not surfaced: %#v", result.StructuredContent)
+			}
+			if len(core.interactionKeys) != 2 || core.interactionKeys[0] == core.interactionKeys[1] {
+				t.Fatalf("rebuild must use a different start key, keys = %v", core.interactionKeys)
+			}
+			// Salted with the dead interaction, so concurrent callers that saw the
+			// same death converge on one replacement instead of racing.
+			if !strings.Contains(core.interactionKeys[1], seen[0].InteractionID) {
+				t.Fatalf("replacement key is not derived from the dead interaction: %v", core.interactionKeys)
+			}
+			if len(seen) != 2 || seen[1].InteractionID == seen[0].InteractionID {
+				t.Fatalf("rebuilt session reused the dead interaction: %#v", seen)
+			}
+		})
+	}
+}
+
+func TestExplicitContextIsNeverRebuiltOnStaleErrors(t *testing.T) {
+	// A caller that owns its conversation owns the recovery too. Silently moving
+	// its work onto a service-invented interaction would attribute that work to a
+	// turn the caller never started.
 	core := newFakeCore(t)
-	core.activeInteraction = "mcp:session-a"
-	core.staleOnce = true
-	var seen []bknContext
+	attempts := 0
 	guarded := guardBusinessToolCallWithCompletion(
-		func(_ context.Context, intent operationIntent) (*operationResult, *lifecycleError, error) {
-			seen = append(seen, intent.Context)
-			return &operationResult{Created: true, Execute: true}, nil, nil
+		func(context.Context, operationIntent) (*operationResult, *lifecycleError, error) {
+			attempts++
+			return nil, &lifecycleError{
+				Code: "interaction_terminal", Message: "interaction is not active",
+				RequiredAction: "start_interaction",
+			}, nil
 		},
 		nil, core.client(),
 		func(context.Context, mcpsdk.CallToolRequest) (*mcpsdk.CallToolResult, error) {
@@ -321,18 +360,56 @@ func TestFallbackRebuildsTheSessionWhenTheLeaseExpired(t *testing.T) {
 		},
 	)
 
-	result, err := guarded(contextWithSession("session-a"), contextlessBusinessRequest())
+	result, err := guarded(contextWithSession("session-a"), validBusinessToolRequest())
 	if err != nil {
 		t.Fatalf("guard returned protocol error: %v", err)
 	}
-	if result.IsError {
-		t.Fatalf("an expired lease must be rebuilt, not surfaced: %#v", result.StructuredContent)
+	if !result.IsError {
+		t.Fatal("a caller-owned terminal interaction must surface, not be papered over")
 	}
-	if len(core.interactionKeys) != 2 || core.interactionKeys[0] == core.interactionKeys[1] {
-		t.Fatalf("retry must open a new interaction, keys = %v", core.interactionKeys)
+	if attempts != 1 {
+		t.Fatalf("ensure ran %d times; an explicit context must not be retried", attempts)
 	}
-	if len(seen) != 1 || seen[0].InteractionID == "" {
-		t.Fatalf("rebuilt session did not produce a usable context: %#v", seen)
+	if core.conversationCalls != 0 {
+		t.Fatal("an explicit context must never open a fallback conversation")
+	}
+}
+
+func TestResolvedContextReachesTheDownstreamTraceContext(t *testing.T) {
+	// The guard used to write the caller's raw arguments back onto the trace
+	// context. Under the fallback those are empty, so the evidence events the
+	// business tool emits carried no interaction id — and Core drops such events
+	// in bulk with only a warning, silently emptying the very trail this fallback
+	// exists to produce.
+	core := newFakeCore(t)
+	var resolved bknContext
+	var downstream common.TraceContext
+	guarded := guardBusinessToolCallWithCompletion(
+		func(ctx context.Context, intent operationIntent) (*operationResult, *lifecycleError, error) {
+			resolved = intent.Context
+			return &operationResult{
+				Created: true, Execute: true, LifecycleContext: ctx,
+				Operation: map[string]any{"operation_id": "op-1", "attempt": float64(1)},
+			}, nil, nil
+		},
+		nil, core.client(),
+		func(ctx context.Context, _ mcpsdk.CallToolRequest) (*mcpsdk.CallToolResult, error) {
+			downstream, _ = common.GetTraceContextFromCtx(ctx)
+			return mcpsdk.NewToolResultStructured(map[string]any{"ok": true}, `{"ok":true}`), nil
+		},
+	)
+
+	if _, err := guarded(contextWithSession("session-a"), contextlessBusinessRequest()); err != nil {
+		t.Fatalf("guard returned protocol error: %v", err)
+	}
+	if resolved.ConversationID == "" || resolved.InteractionID == "" {
+		t.Fatalf("fallback did not resolve a usable context: %#v", resolved)
+	}
+	if downstream.ConversationID != resolved.ConversationID {
+		t.Fatalf("downstream conversation = %q, want %q", downstream.ConversationID, resolved.ConversationID)
+	}
+	if downstream.InteractionID != resolved.InteractionID {
+		t.Fatalf("downstream interaction = %q, want %q", downstream.InteractionID, resolved.InteractionID)
 	}
 }
 

--- a/adp/context-loader/agent-retrieval/server/driveradapters/mcp/session_fallback_test.go
+++ b/adp/context-loader/agent-retrieval/server/driveradapters/mcp/session_fallback_test.go
@@ -340,6 +340,91 @@ func TestFallbackRebuildsTheSessionWhenCoreReportsItStale(t *testing.T) {
 	}
 }
 
+func TestFallbackWalksPastSeveralDeadGenerations(t *testing.T) {
+	// One dead interaction accumulates per idle gap. The salt has to advance from
+	// whichever interaction just failed: the base start key keeps resolving to the
+	// connection's first interaction for as long as the connection lives, so a
+	// salt pinned to it would stall at generation two and the connection would be
+	// stuck until the client reconnected.
+	core := newFakeCore(t)
+	dead := map[string]bool{
+		"int-for-mcp:session-walk":                                true,
+		"int-for-mcp:session-walk:after:int-for-mcp:session-walk": true,
+	}
+	var seen []bknContext
+	guarded := guardBusinessToolCallWithCompletion(
+		func(_ context.Context, intent operationIntent) (*operationResult, *lifecycleError, error) {
+			seen = append(seen, intent.Context)
+			if dead[intent.Context.InteractionID] {
+				return nil, &lifecycleError{
+					Code: "interaction_terminal", Message: "lease expired",
+					RequiredAction: "start_interaction",
+				}, nil
+			}
+			return &operationResult{Created: true, Execute: true}, nil, nil
+		},
+		nil, core.client(),
+		func(context.Context, mcpsdk.CallToolRequest) (*mcpsdk.CallToolResult, error) {
+			return mcpsdk.NewToolResultStructured(map[string]any{"ok": true}, `{"ok":true}`), nil
+		},
+	)
+
+	result, err := guarded(contextWithSession("session-walk"), contextlessBusinessRequest())
+	if err != nil {
+		t.Fatalf("guard returned protocol error: %v", err)
+	}
+	if result.IsError {
+		t.Fatalf("two dead generations must still be walked past: %#v", result.StructuredContent)
+	}
+	if len(seen) != 3 {
+		t.Fatalf("expected two rebuilds then success, got %d attempts: %#v", len(seen), seen)
+	}
+	if dead[seen[2].InteractionID] {
+		t.Fatalf("final attempt still landed on a dead interaction: %#v", seen[2])
+	}
+}
+
+func TestFallbackRemembersTheWorkingKeyForTheSession(t *testing.T) {
+	// Without this the call after a rebuild would replay the base key, get the
+	// long-dead first interaction back, and pay a failed ensure before rebuilding
+	// again — every call, forever.
+	core := newFakeCore(t)
+	deadFirst := "int-for-mcp:session-remember"
+	var seen []bknContext
+	guarded := guardBusinessToolCallWithCompletion(
+		func(_ context.Context, intent operationIntent) (*operationResult, *lifecycleError, error) {
+			seen = append(seen, intent.Context)
+			if intent.Context.InteractionID == deadFirst {
+				return nil, &lifecycleError{
+					Code: "interaction_terminal", Message: "lease expired",
+					RequiredAction: "start_interaction",
+				}, nil
+			}
+			return &operationResult{Created: true, Execute: true}, nil, nil
+		},
+		nil, core.client(),
+		func(context.Context, mcpsdk.CallToolRequest) (*mcpsdk.CallToolResult, error) {
+			return mcpsdk.NewToolResultStructured(map[string]any{"ok": true}, `{"ok":true}`), nil
+		},
+	)
+
+	ctx := contextWithSession("session-remember")
+	for range 3 {
+		if _, err := guarded(ctx, contextlessBusinessRequest()); err != nil {
+			t.Fatalf("guard returned protocol error: %v", err)
+		}
+	}
+	// One failed attempt on the first call, then straight to the live interaction.
+	if len(seen) != 4 {
+		t.Fatalf("expected one recovery then two clean calls, got %d: %#v", len(seen), seen)
+	}
+	for _, entry := range seen[1:] {
+		if entry.InteractionID == deadFirst {
+			t.Fatalf("a later call replayed the dead interaction: %#v", seen)
+		}
+	}
+}
+
 func TestExplicitContextIsNeverRebuiltOnStaleErrors(t *testing.T) {
 	// A caller that owns its conversation owns the recovery too. Silently moving
 	// its work onto a service-invented interaction would attribute that work to a

--- a/adp/context-loader/agent-retrieval/server/driveradapters/mcp/session_guard.go
+++ b/adp/context-loader/agent-retrieval/server/driveradapters/mcp/session_guard.go
@@ -65,52 +65,68 @@ func guardBusinessToolCall(
 	ensure ensureOperationFunc,
 	next func(context.Context, mcpsdk.CallToolRequest) (*mcpsdk.CallToolResult, error),
 ) func(context.Context, mcpsdk.CallToolRequest) (*mcpsdk.CallToolResult, error) {
-	return guardBusinessToolCallWithCompletion(ensure, nil, next)
+	return guardBusinessToolCallWithCompletion(ensure, nil, nil, next)
 }
 
 func guardBusinessToolCallWithCompletion(
 	ensure ensureOperationFunc,
 	complete completeOperationFunc,
+	autoClient *bkntrace.LifecycleClient,
 	next func(context.Context, mcpsdk.CallToolRequest) (*mcpsdk.CallToolResult, error),
 ) func(context.Context, mcpsdk.CallToolRequest) (*mcpsdk.CallToolResult, error) {
 	return func(ctx context.Context, req mcpsdk.CallToolRequest) (*mcpsdk.CallToolResult, error) {
 		arguments := req.GetArguments()
 		rawContext, _ := arguments["bkn_context"].(map[string]any)
 		conversationID, _ := rawContext["conversation_id"].(string)
-		if conversationID == "" {
-			return lifecycleToolError(lifecycleError{
-				Code:           "conversation_required",
-				Message:        "conversation_id is required",
-				RequiredAction: "create_conversation",
-			}), nil
-		}
 		interactionID, _ := rawContext["interaction_id"].(string)
-		if interactionID == "" {
-			return lifecycleToolError(lifecycleError{
-				Code:           "interaction_required",
-				Message:        "interaction_id is required",
-				RequiredAction: "start_interaction",
-			}), nil
-		}
 		operationKey, _ := rawContext["operation_key"].(string)
-		if operationKey == "" {
-			return lifecycleToolError(lifecycleError{
-				Code:           "operation_required",
-				Message:        "operation_key is required",
-				RequiredAction: "ensure_operation",
-			}), nil
-		}
 		if ensure == nil {
 			return nil, fmt.Errorf("lifecycle operation client is not configured")
 		}
-		intent := operationIntent{
-			Context: bknContext{
+		var businessContext bknContext
+		if conversationID == "" && interactionID == "" && operationKey == "" {
+			resolved, lifecycleErr, err := resolveAutoSession(ctx, autoClient, req, arguments)
+			if err != nil {
+				return lifecycleToolError(lifecycleAvailabilityError(err)), nil
+			}
+			if lifecycleErr != nil {
+				return lifecycleToolError(*lifecycleErr), nil
+			}
+			businessContext = resolved
+		} else {
+			// A half-filled context is still an error: the missing field would have
+			// to be invented, and an invented parent turns the receipt into a claim
+			// about causality that never happened.
+			switch {
+			case conversationID == "":
+				return lifecycleToolError(lifecycleError{
+					Code:           "conversation_required",
+					Message:        "conversation_id is required",
+					RequiredAction: "create_conversation",
+				}), nil
+			case interactionID == "":
+				return lifecycleToolError(lifecycleError{
+					Code:           "interaction_required",
+					Message:        "interaction_id is required",
+					RequiredAction: "start_interaction",
+				}), nil
+			case operationKey == "":
+				return lifecycleToolError(lifecycleError{
+					Code:           "operation_required",
+					Message:        "operation_key is required",
+					RequiredAction: "ensure_operation",
+				}), nil
+			}
+			businessContext = bknContext{
 				ConversationID:    conversationID,
 				InteractionID:     interactionID,
 				OperationKey:      operationKey,
 				ParentOperationID: stringValue(rawContext["parent_operation_id"]),
 				CausationEventIDs: stringSliceValue(rawContext["causation_event_ids"]),
-			},
+			}
+		}
+		intent := operationIntent{
+			Context:  businessContext,
 			ToolName: req.Params.Name,
 			Input:    arguments,
 		}

--- a/adp/context-loader/agent-retrieval/server/driveradapters/mcp/session_guard.go
+++ b/adp/context-loader/agent-retrieval/server/driveradapters/mcp/session_guard.go
@@ -137,16 +137,27 @@ func guardBusinessToolCallWithCompletion(
 		// interaction terminal once its lease lapses, and caps one interaction at
 		// 128 operations. Both surface here, from operations:ensure — not from
 		// resolving the session — so the rebuild has to wrap this call.
-		if autoSession && err == nil && isStaleAutoSession(lifecycleErr) {
+		// Each idle gap leaves one more dead interaction behind, and the walk has
+		// to start from the one that just failed rather than from a fixed point:
+		// the base start key keeps resolving to the connection's first
+		// interaction, so a salt pinned to it would never reach past generation
+		// two. Bounded, because a walk that never ends is a worse failure than a
+		// call that reports it could not recover.
+		for attempt := 0; autoSession && err == nil && isStaleAutoSession(lifecycleErr) &&
+			attempt < autoSessionMaxRebuilds; attempt++ {
 			rebuilt, rebuildErr, resolveErr := resolveAutoSession(
 				ctx, autoClient, req, arguments,
 				autoSessionRetry{afterInteractionID: businessContext.InteractionID},
 			)
-			if resolveErr == nil && rebuildErr == nil {
-				businessContext = rebuilt
-				intent.Context = rebuilt
-				ensured, lifecycleErr, err = ensure(ctx, intent)
+			if resolveErr != nil || rebuildErr != nil {
+				break
 			}
+			if rebuilt.InteractionID == businessContext.InteractionID {
+				break
+			}
+			businessContext = rebuilt
+			intent.Context = rebuilt
+			ensured, lifecycleErr, err = ensure(ctx, intent)
 		}
 		if err != nil {
 			return lifecycleToolError(lifecycleAvailabilityError(err)), nil

--- a/adp/context-loader/agent-retrieval/server/driveradapters/mcp/session_guard.go
+++ b/adp/context-loader/agent-retrieval/server/driveradapters/mcp/session_guard.go
@@ -84,8 +84,9 @@ func guardBusinessToolCallWithCompletion(
 			return nil, fmt.Errorf("lifecycle operation client is not configured")
 		}
 		var businessContext bknContext
-		if conversationID == "" && interactionID == "" && operationKey == "" {
-			resolved, lifecycleErr, err := resolveAutoSession(ctx, autoClient, req, arguments)
+		autoSession := conversationID == "" && interactionID == "" && operationKey == ""
+		if autoSession {
+			resolved, lifecycleErr, err := resolveAutoSession(ctx, autoClient, req, arguments, autoSessionRetry{})
 			if err != nil {
 				return lifecycleToolError(lifecycleAvailabilityError(err)), nil
 			}
@@ -131,6 +132,22 @@ func guardBusinessToolCallWithCompletion(
 			Input:    arguments,
 		}
 		ensured, lifecycleErr, err := ensure(ctx, intent)
+		// An auto session outlives any single call, so it can go stale between
+		// calls in ways the client cannot see or fix: Core declares the
+		// interaction terminal once its lease lapses, and caps one interaction at
+		// 128 operations. Both surface here, from operations:ensure — not from
+		// resolving the session — so the rebuild has to wrap this call.
+		if autoSession && err == nil && isStaleAutoSession(lifecycleErr) {
+			rebuilt, rebuildErr, resolveErr := resolveAutoSession(
+				ctx, autoClient, req, arguments,
+				autoSessionRetry{afterInteractionID: businessContext.InteractionID},
+			)
+			if resolveErr == nil && rebuildErr == nil {
+				businessContext = rebuilt
+				intent.Context = rebuilt
+				ensured, lifecycleErr, err = ensure(ctx, intent)
+			}
+		}
 		if err != nil {
 			return lifecycleToolError(lifecycleAvailabilityError(err)), nil
 		} else if lifecycleErr != nil {
@@ -155,8 +172,13 @@ func guardBusinessToolCallWithCompletion(
 			}
 			operationID, attempt := operationIdentity(ensured.Operation)
 			traceContext, _ := common.GetTraceContextFromCtx(ctx)
-			traceContext.ConversationID = conversationID
-			traceContext.InteractionID = interactionID
+			// Must come from the resolved context, not the raw arguments: under the
+			// session fallback the arguments carry no ids, and writing them back
+			// would blank out what Guard.Begin just established. Evidence events
+			// with an empty interaction_id are rejected by Core in bulk, and the
+			// rejection only warns — the whole evidence trail would vanish silently.
+			traceContext.ConversationID = businessContext.ConversationID
+			traceContext.InteractionID = businessContext.InteractionID
 			traceContext.OperationID = operationID
 			traceContext.Attempt = attempt
 			ctx = common.SetTraceContextToCtx(ctx, traceContext)

--- a/adp/context-loader/agent-retrieval/server/driveradapters/mcp/session_guard_test.go
+++ b/adp/context-loader/agent-retrieval/server/driveradapters/mcp/session_guard_test.go
@@ -369,6 +369,7 @@ func TestSessionGuardFinishPendingPreservesStableReceipt(t *testing.T) {
 					Retryable: true, RequiredAction: "poll_receipt",
 				}, nil
 		},
+		nil,
 		func(context.Context, mcpsdk.CallToolRequest) (*mcpsdk.CallToolResult, error) {
 			return mcpsdk.NewToolResultStructured(map[string]any{"answer": "ok"}, `{"answer":"ok"}`), nil
 		},
@@ -439,6 +440,7 @@ func TestSessionGuardCompletesAttemptAndReturnsDurableReceipt(t *testing.T) {
 				Receipt:   map[string]any{"receipt_id": "receipt-1", "receipt_status": "completed"},
 			}, nil, nil
 		},
+		nil,
 		func(context.Context, mcpsdk.CallToolRequest) (*mcpsdk.CallToolResult, error) {
 			return mcpsdk.NewToolResultStructured(map[string]any{"answer": "ok"}, `{"answer":"ok"}`), nil
 		},
@@ -479,6 +481,7 @@ func TestSessionGuardPersistsFailedAttemptAndReturnsReceipt(t *testing.T) {
 				Receipt:   map[string]any{"receipt_id": "receipt-1", "receipt_status": "failed"},
 			}, nil, nil
 		},
+		nil,
 		func(context.Context, mcpsdk.CallToolRequest) (*mcpsdk.CallToolResult, error) {
 			result := mcpsdk.NewToolResultStructured(map[string]any{"error": "bad input"}, "bad input")
 			result.IsError = true
@@ -523,6 +526,7 @@ func TestSessionGuardConvertsDownstreamGoErrorToFailedReceipt(t *testing.T) {
 				Receipt:   map[string]any{"receipt_id": "receipt-1", "receipt_status": "failed"},
 			}, nil, nil
 		},
+		nil,
 		func(context.Context, mcpsdk.CallToolRequest) (*mcpsdk.CallToolResult, error) {
 			return nil, errors.New("downstream unavailable")
 		},
@@ -562,6 +566,7 @@ func TestSessionGuardConvertsDownstreamPanicToFailedReceipt(t *testing.T) {
 				Receipt:   map[string]any{"receipt_id": "receipt-1", "receipt_status": "failed"},
 			}, nil, nil
 		},
+		nil,
 		func(context.Context, mcpsdk.CallToolRequest) (*mcpsdk.CallToolResult, error) {
 			panic("sensitive downstream detail")
 		},

--- a/adp/context-loader/agent-retrieval/server/driveradapters/mcp/socket_call_test.go
+++ b/adp/context-loader/agent-retrieval/server/driveradapters/mcp/socket_call_test.go
@@ -85,7 +85,10 @@ func TestLicensedEnterpriseToolCallReachesTheLifecycleGuard(t *testing.T) {
 	if strings.Contains(got, "not found") {
 		t.Fatalf("a licensed tool must not be refused as unknown: %s", got)
 	}
-	if !strings.Contains(got, "conversation") {
+	// A call with no bkn_context now falls back to the MCP session, so the guard
+	// answers about the Core it needs rather than the conversation the client
+	// omitted. Either wording proves the gate handed the call on.
+	if !strings.Contains(got, "conversation") && !strings.Contains(got, "BKN Trace Core") {
 		t.Fatalf("expected the lifecycle guard to answer, got %s", got)
 	}
 }

--- a/adp/context-loader/agent-retrieval/server/driveradapters/mcp/socket_call_test.go
+++ b/adp/context-loader/agent-retrieval/server/driveradapters/mcp/socket_call_test.go
@@ -126,7 +126,7 @@ func TestInfoAndToolsListAgreeOnEnterpriseSchemas(t *testing.T) {
 	mcptool.Register(extraTool("probe_context", "probe_context"))
 
 	// 企业工具那一半与 locale 无关：两侧用的都是 ee 自带的 t.Input，各自过一次
-	// requireBKNContext。这条断言在任何 locale 下都必须成立，所以不钉环境。
+	// offerBKNContext。这条断言在任何 locale 下都必须成立，所以不钉环境。
 	listed := listVisible(t)
 	info, err := BuildMCPInfo("https://example.invalid/mcp")
 	if err != nil {

--- a/adp/context-loader/agent-retrieval/server/infra/bkntrace/lifecycle.go
+++ b/adp/context-loader/agent-retrieval/server/infra/bkntrace/lifecycle.go
@@ -275,6 +275,35 @@ func (c *LifecycleClient) EnsureOperation(
 	return result, apiErr, err
 }
 
+// EnsureCurrentConversation resolves the caller's current conversation for an
+// external key, creating it only when none is active. Core keys this by owner,
+// so two callers never share a conversation even with an identical key.
+func (c *LifecycleClient) EnsureCurrentConversation(
+	ctx context.Context,
+	externalConversationKey string,
+) (Conversation, *APIError, error) {
+	var conversation Conversation
+	apiErr, err := c.do(ctx, http.MethodPost, "/conversations:ensure-current", map[string]any{
+		"external_conversation_key": externalConversationKey,
+	}, &conversation)
+	return conversation, apiErr, err
+}
+
+// StartInteraction opens an interaction, or returns the existing one when the
+// same idempotency key is replayed. Core resolves the key before it rejects a
+// second active interaction, so concurrent callers converge instead of racing.
+func (c *LifecycleClient) StartInteraction(
+	ctx context.Context,
+	conversationID, idempotencyKey, question string,
+) (Interaction, *APIError, error) {
+	var interaction Interaction
+	path := "/conversations/" + url.PathEscape(conversationID) + "/interactions"
+	apiErr, err := c.do(ctx, http.MethodPost, path, map[string]any{
+		"idempotency_key": idempotencyKey, "question": question,
+	}, &interaction)
+	return interaction, apiErr, err
+}
+
 func (c *LifecycleClient) CompleteAttempt(
 	ctx context.Context,
 	input FinishAttemptInput,

--- a/adp/context-loader/agent-retrieval/server/infra/bkntrace/lifecycle.go
+++ b/adp/context-loader/agent-retrieval/server/infra/bkntrace/lifecycle.go
@@ -292,14 +292,18 @@ func (c *LifecycleClient) EnsureCurrentConversation(
 // StartInteraction opens an interaction, or returns the existing one when the
 // same idempotency key is replayed. Core resolves the key before it rejects a
 // second active interaction, so concurrent callers converge instead of racing.
+//
+// Core rejects unknown body fields, and its start contract carries only the
+// idempotency key and lease. The question a caller asked is evidence, recorded
+// separately, never part of this request.
 func (c *LifecycleClient) StartInteraction(
 	ctx context.Context,
-	conversationID, idempotencyKey, question string,
+	conversationID, idempotencyKey string,
 ) (Interaction, *APIError, error) {
 	var interaction Interaction
 	path := "/conversations/" + url.PathEscape(conversationID) + "/interactions"
 	apiErr, err := c.do(ctx, http.MethodPost, path, map[string]any{
-		"idempotency_key": idempotencyKey, "question": question,
+		"idempotency_key": idempotencyKey,
 	}, &interaction)
 	return interaction, apiErr, err
 }

--- a/adp/context-loader/agent-retrieval/server/infra/common/context_manage.go
+++ b/adp/context-loader/agent-retrieval/server/infra/common/context_manage.go
@@ -161,6 +161,35 @@ func GetTraceContextFromCtx(ctx context.Context) (TraceContext, bool) {
 	return traceContext, ok
 }
 
+// CopyRequestScopedValues carries this service's per-request values from the
+// HTTP request context onto another context, keeping that context's own values
+// intact. The MCP transport builds a context holding the client session before
+// it hands control to this service; replacing that context wholesale would drop
+// the session, so the values move in this direction instead.
+func CopyRequestScopedValues(from, onto context.Context) context.Context {
+	if from == nil {
+		return onto
+	}
+	if onto == nil {
+		return from
+	}
+	for _, key := range []any{
+		keyTraceContext,
+		XLangKey,
+		interfaces.KeyAccountAuthContext,
+		interfaces.KeyResponseFormat,
+		interfaces.IsPublic,
+	} {
+		if value := from.Value(key); value != nil {
+			onto = context.WithValue(onto, key, value)
+		}
+	}
+	if spanContext := trace.SpanContextFromContext(from); spanContext.IsValid() {
+		onto = trace.ContextWithSpanContext(onto, spanContext)
+	}
+	return onto
+}
+
 func TraceContextFromHeaders(getHeader func(string) string) TraceContext {
 	requestID := strings.TrimSpace(getHeader(HeaderBKNRequestID))
 	if requestID == "" {

--- a/adp/context-loader/agent-retrieval/server/infra/common/context_manage.go
+++ b/adp/context-loader/agent-retrieval/server/infra/common/context_manage.go
@@ -40,6 +40,7 @@ const (
 	HeaderBusinessDomain      = "x-business-domain"
 	HeaderBKNEventObservedAt  = "bkn-event-observed-at"
 	envDefaultTenantID        = "BKN_TRACE_DEFAULT_TENANT_ID"
+	envDefaultBusinessDomain  = "BKN_TRACE_DEFAULT_BUSINESS_DOMAIN"
 )
 
 type traceContextKey string
@@ -172,9 +173,15 @@ func TraceContextFromHeaders(getHeader func(string) string) TraceContext {
 	observedAt := strings.TrimSpace(getHeader(HeaderBKNEventObservedAt))
 	_, observedAtErr := time.Parse(time.RFC3339Nano, observedAt)
 	return TraceContext{
-		RequestID:          requestID,
-		TenantID:           sanitizeBusinessTraceID(firstNonEmpty(getHeader(HeaderTenantID), os.Getenv(envDefaultTenantID))),
-		BusinessDomain:     firstNonEmpty(getHeader(HeaderBusinessDomain), parseBaggage(getHeader(HeaderBaggage))["business_domain"]),
+		RequestID: requestID,
+		TenantID:  sanitizeBusinessTraceID(firstNonEmpty(getHeader(HeaderTenantID), os.Getenv(envDefaultTenantID))),
+		// A trusted inbound domain always wins; the deployment default only keeps
+		// single-domain installs working for clients that carry no domain at all.
+		BusinessDomain: firstNonEmpty(
+			getHeader(HeaderBusinessDomain),
+			parseBaggage(getHeader(HeaderBaggage))["business_domain"],
+			os.Getenv(envDefaultBusinessDomain),
+		),
 		Baggage:            parseBaggage(getHeader(HeaderBaggage)),
 		ConversationID:     sanitizeBusinessTraceID(getHeader(HeaderBKNConversationID)),
 		InteractionID:      sanitizeBusinessTraceID(getHeader(HeaderBKNInteractionID)),

--- a/adp/context-loader/agent-retrieval/server/infra/common/context_manage_test.go
+++ b/adp/context-loader/agent-retrieval/server/infra/common/context_manage_test.go
@@ -255,6 +255,40 @@ func TestTraceContextUsesConfiguredTenantOnlyWhenInboundTenantIsMissing(t *testi
 	}
 }
 
+func TestTraceContextUsesConfiguredBusinessDomainOnlyWhenInboundDomainIsMissing(t *testing.T) {
+	t.Setenv("BKN_TRACE_DEFAULT_TENANT_ID", "openbkn-local")
+	t.Setenv("BKN_TRACE_DEFAULT_BUSINESS_DOMAIN", "bd_public")
+
+	bare := SetTraceContextToCtx(context.Background(), TraceContextFromHeaders(func(string) string { return "" }))
+	traceContext, ok := GetTraceContextFromCtx(bare)
+	if !ok || traceContext.BusinessDomain != "bd_public" {
+		t.Fatalf("default business domain = %q, want bd_public", traceContext.BusinessDomain)
+	}
+	if traceContext.Baggage["business_domain"] != "bd_public" {
+		t.Fatalf("default business domain must reach outbound baggage: %v", traceContext.Baggage)
+	}
+
+	trusted := TraceContextFromHeaders(func(key string) string {
+		if key == HeaderBusinessDomain {
+			return "bd_from_gateway"
+		}
+		return ""
+	})
+	if trusted.BusinessDomain != "bd_from_gateway" {
+		t.Fatalf("inbound business domain was overwritten: %q", trusted.BusinessDomain)
+	}
+
+	baggageOnly := TraceContextFromHeaders(func(key string) string {
+		if key == HeaderBaggage {
+			return "business_domain=bd_from_baggage"
+		}
+		return ""
+	})
+	if baggageOnly.BusinessDomain != "bd_from_baggage" {
+		t.Fatalf("baggage business domain must outrank the deployment default: %q", baggageOnly.BusinessDomain)
+	}
+}
+
 func TestCallerCorrelationIDsAreValidatedWithoutGeneration(t *testing.T) {
 	convey.Convey("valid caller ids are propagated and invalid ids are dropped", t, func() {
 		headers := map[string]string{

--- a/adp/context-loader/agent-retrieval/server/infra/common/context_manage_test.go
+++ b/adp/context-loader/agent-retrieval/server/infra/common/context_manage_test.go
@@ -289,6 +289,40 @@ func TestTraceContextUsesConfiguredBusinessDomainOnlyWhenInboundDomainIsMissing(
 	}
 }
 
+func TestCopyRequestScopedValuesKeepsTheTargetContextIntact(t *testing.T) {
+	type transportKey struct{}
+	// Stands in for the MCP client session the transport puts on the context
+	// before this service sees it. Replacing that context instead of copying
+	// onto it is what made the session-level fallback see every call as
+	// sessionless while the unit tests stayed green.
+	transport := context.WithValue(context.Background(), transportKey{}, "session-1")
+
+	request := SetTraceContextToCtx(context.Background(), TraceContext{
+		TenantID: "tenant-1", BusinessDomain: "bd_public",
+	})
+	request = SetAccountAuthContextToCtx(request, &interfaces.AccountAuthContext{
+		AccountID: "user-1", AccountType: interfaces.AccessorTypeUser,
+	})
+	request = SetPublicAPIToCtx(request, true)
+
+	merged := CopyRequestScopedValues(request, transport)
+
+	if merged.Value(transportKey{}) != "session-1" {
+		t.Fatal("the transport's own context values were dropped")
+	}
+	traceContext, ok := GetTraceContextFromCtx(merged)
+	if !ok || traceContext.BusinessDomain != "bd_public" {
+		t.Fatalf("request trace context did not survive the copy: %#v", traceContext)
+	}
+	auth, ok := GetAccountAuthContextFromCtx(merged)
+	if !ok || auth.AccountID != "user-1" {
+		t.Fatalf("request auth context did not survive the copy: %#v", auth)
+	}
+	if !IsPublicAPIFromCtx(merged) {
+		t.Fatal("public API marker did not survive the copy")
+	}
+}
+
 func TestCallerCorrelationIDsAreValidatedWithoutGeneration(t *testing.T) {
 	convey.Convey("valid caller ids are propagated and invalid ids are dropped", t, func() {
 		headers := map[string]string{

--- a/docs/api/context-loader/mcp.yaml
+++ b/docs/api/context-loader/mcp.yaml
@@ -6,17 +6,52 @@ info:
     Context Loader 把自己的检索能力同时以 **MCP Server** 形式对外：Cursor、Claude
     Desktop 等 MCP 客户端可以直接接入，不必逐个封装 REST 调用。
 
-    工具集与本模块的 REST 端点一一对应，共 16 个：`search_schema`、
+    工具集共 27 个，分两类。
+
+    **业务工具 16 个**，与本模块的 REST 端点一一对应：`search_schema`、
     `query_object_instance`、`query_instance_subgraph`、`get_logic_properties_values`、
     `get_action_info`、`execute_action`、`get_action_execution`、
     `list_action_executions`、`find_skills`、`run_sql`、`list_knowledge_networks`、
     `get_kn_detail`、`get_object_types`、`get_relation_types`、`list_resources`、
     `describe_resource`。各工具的语义与参数含义见本目录下对应的 REST 文档。
 
+    **业务溯源工具 11 个**，用于管理 BKN Trace 的会话与交互：
+    `bkn_create_conversation`、`bkn_resume_conversation`、`bkn_close_conversation`、
+    `bkn_start_interaction`、`bkn_complete_interaction`、`bkn_fail_interaction`、
+    `bkn_cancel_interaction`、`bkn_handoff_interaction`、`bkn_get_operation`、
+    `bkn_retry_operation`、`bkn_get_receipt`。只有需要业务级溯源的调用方才用得到，
+    见下方「业务溯源上下文」。
+
     **接入方式**：Streamable HTTP，端点 `/api/agent-retrieval/v1/mcp`，
     协议流程 `initialize` → `tools/list` → `tools/call`（JSON-RPC 2.0）。
     鉴权与 REST 一致：`Authorization: Bearer <token>`，OAuth access token 或
     `bak_` 前缀的 AppKey，不需要其他头。
+
+    **业务溯源上下文（`bkn_context`）**
+
+    每个业务工具的入参里都有一个可选的 `bkn_context`，声明这次调用属于哪一轮业务
+    对话。它有三个必填子字段，要么同时提供、要么整体省略，不接受只给一部分——
+    缺失的字段只能凭空生成，会让回执声称一条从未发生的因果关系。
+
+    - `conversation_id`：来自 `bkn_create_conversation` 的返回，不可自拟
+    - `interaction_id`：来自 `bkn_start_interaction` 的返回，不可自拟
+    - `operation_key`：调用方自取的字符串，同一次逻辑调用重试时须保持不变，
+      本服务据此做幂等，重发不会重复执行
+
+    **省略时**（Cursor、Claude Code 等通用 MCP 客户端的默认情形）：本服务按当次
+    MCP 连接自动归并——一条连接对应一个会话，连接内的所有调用归入同一次交互。
+    调用直接可用，无需任何额外配置，但证据链只能追溯到「哪条连接」，
+    追溯不到「哪个用户提问」，且该交互不会收口，拿不到 closure manifest。
+
+    **自带时**（bkn-agent 等持有真实业务会话的调用方）：先用溯源工具建立会话与
+    交互，再把三个字段带进每次业务调用，即可获得完整的业务级溯源。
+
+    注意 REST 面没有连接的概念，因此那 16 个端点的 `bkn_context` 仍为必填，
+    与 MCP 面不同。
+
+    **多业务域部署**：单业务域安装无需任何额外请求头。若部署时清空了
+    `observability.lifecycle.default_business_domain`，则每次请求都须带
+    `x-business-domain`，否则调用会被拒绝。
 
     不想先握手就想知道有哪些工具时，直接 `GET /mcp/info`——它返回完整的工具目录
     （含每个工具的输入输出 schema）与一份可直接粘贴的客户端配置。


### PR DESCRIPTION
## 问题

裸 MCP 客户端（Claude Code、Cursor）接上 Context Loader 后，每次工具调用都被挡死：

```
permission_denied: trusted tenant and business domain context is required
```

排查下来是两个独立缺口叠加，都不是配置问题。

**一、business domain 没有任何默认值。** `TraceContextFromHeaders` 里 tenant 有 `BKN_TRACE_DEFAULT_TENANT_ID` 兜底，business domain 那条链到 baggage 就断了。而平台其他服务一律默认 `bd_public`——execution-factory 写成常量 `DefaultBusinessDomain`、bkn-agent、deploy.sh、onboard 脚本都是。context-loader 是唯一例外，客户端不发 `x-business-domain` 就必挂。

**二、`bkn_context` 三件套要求调用方自带，而通用 MCP 客户端没有业务对话可声明。** 手工路径要求先调 `bkn_create_conversation`、再 `bkn_start_interaction`，然后每次业务调用都带上三个 ID，收尾还要填七个字段（含从上一步接力的 `lease_token`/`lease_epoch`）。LLM 客户端要么漏传要么编 ID，编出来的撞 `conversation_not_found`。

## 修法

**business domain 默认值。** 新增 `BKN_TRACE_DEFAULT_BUSINESS_DOMAIN` 与 chart 默认值 `bd_public`，优先级 header > baggage > 部署默认，可信入站永远压过默认值。与其他服务不同的是这里做成可配而非写死常量——business domain 在 Trace 里是 owner 元组的一部分、参与数据隔离，多业务域部署清空该值即可强制每个调用方显式声明。

**会话级 `bkn_context` 兜底。** 三个字段整体缺失时按 MCP 连接自动归并：一条连接一个 conversation，连接内所有调用挂在同一 interaction 下。之所以不是"一次调用一个交互"，是因为 Core 限制一条会话仅一个 active interaction（`service.go:443`），而 MCP 客户端会并发调用。并发首调靠 `StartInteraction` 自带的幂等收敛（它先按 key 查已有交互再判活跃），不需要额外加锁；租约由每次 `operations:ensure` 自动续期，只有闲置超 5 分钟才过期，此时用新 key 重开一次。

`operation_key` 由工具名加输入哈希推导，保证同一次逻辑调用重放幂等、不同调用互不碰撞。

**半截 `bkn_context` 仍按原样报错。** 缺失字段只能靠编，编出来的父级会让 receipt 声称一条从未发生的因果边。

**`bkn_context` 由必填改为可选。** 必填保护不了溯源质量：客户端是读 schema 决策的 LLM，满足"required"最省力的办法就是编三个 ID；而且只要它填了值，兜底就永远不触发。改为广播但不强制，持有真实业务对话的调用方（bkn-agent）照常自带，仍拿完整业务级溯源。

## 代价

自动交互不会 complete，拿不到 closure manifest，证据链退化为**连接级**而非业务级——能追到「哪条 MCP 连接」，追不到「哪个用户提问」。断线重连开新会话，因果链断在那里。这个退化已写进 schema 描述与对外文档，不是隐含行为。

## 对外文档

`docs/api/context-loader/mcp.yaml` 此前有两处失真：工具数写 16（实为 27，11 个业务溯源工具从未出现在对外文档里），且全文没有 `bkn_context` 与 `x-business-domain` 任何说明。本 PR 补齐工具清单、新增「业务溯源上下文」整节（含省略与自带两种形态、REST 面因无连接概念仍必填的差异）、补多业务域部署要求；11 个溯源工具的描述由英文单句改写为中文并写明适用对象。

## 实机验证（测试服 14.103.77.23）

| 场景 | 修前 | 修后 |
|---|---|---|
| `bkn_create_conversation` 不带任何域头 | `permission_denied` | 返回 `conversation_id`，owner 为 `openbkn-local` / `bd_public` |
| 只带 `x-business-domain` | `permission_denied` | 通过 |
| 带中文业务域（格式非法） | `permission_denied` | 同左（正则拦截，符合预期） |
| 直连 Core 传现编的业务域 | — | 201，坐实该值不做白名单校验 |

排查中一并确认：测试服此前 chart 已注入 `BKN_TRACE_DEFAULT_TENANT_ID` 与 `BKN_TRACE_QUERY_GATEWAY_TOKEN`，但运行的二进制里这两个字符串一个都不存在（镜像构建于 #609 合入之前）。chart 跑到了镜像前面，配置看着齐全实际全部失效，报错还指向误导方向。这是发布流程问题，非本 PR 代码问题，记录备查。

## 两处被实机验证抓出的接线错误

这两条都通过了全部单测却在真实调用中失败，值得记录：

**contextFunc 丢弃传输层 ctx。** mcp-go 先把客户端会话放进 ctx 再调 contextFunc，而本服务的 contextFunc 直接 `return r.Context()`，会话随之丢失，兜底把每次调用都判为无会话。原有兜底单测手工构造 ctx 直接喂给守卫，绕过了这一层。修法是新增 `common.CopyRequestScopedValues` 把请求值搬到传输层 ctx 上而非替换它，并补测试钉住「目标 ctx 自身的值不被抹除」。

**假 Core 比真 Core 宽松。** 自动兜底照搬 MCP 工具入参形状，向 Core 的 start interaction 多发了 `question`，而 Core 只认 `idempotency_key`/`lease_seconds` 且启用 `DisallowUnknownFields`。测试里的假 Core 宽松接受未知字段，因此全绿。现已将假 Core 的两个端点收紧到与 Core 一致的字段集合与解码严格度。

## 测试

`go build ./...` 干净，`./server/...` 全部通过。新增覆盖：不传 / 全传 / 半截三条路径、同会话复用同一 conversation 与 interaction、不同会话不串、相同调用同 `operation_key`、不同调用不同 key、显式上下文永不被覆盖、租约过期自动重开一次、无 MCP 会话时退回原错误、请求值跨 ctx 搬运不丢失。

## 待办

自动兜底端到端（零 `bkn_context` 的业务工具调用直接跑通）尚未在测试服完成实测——最后两个提交的镜像仍在 CI 构建。合并前我会补上这一条并回帖结果。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
