### PR TITLE
fix(bkn): allow and/or composite conditions in metric validation

### DIFF
--- a/adp/bkn/bkn-backend/server/bkn-specification/bkn/models.go
+++ b/adp/bkn/bkn-backend/server/bkn-specification/bkn/models.go
@@ -139,9 +139,10 @@ type MetricAtomic struct {
 
 // MetricCondition is a row-level filter (no object_type_id).
 type MetricCondition struct {
-	Field     string `yaml:"field"`
-	Operation string `yaml:"operation"`
-	Value     any    `yaml:"value,omitempty"`
+	Field     string             `yaml:"field,omitempty"`
+	Operation string             `yaml:"operation"`
+	SubConds  []*MetricCondition `yaml:"sub_conds,omitempty"`
+	Value     any                `yaml:"value,omitempty"`
 }
 
 // MetricAggregation is required for atomic metrics.

--- a/adp/bkn/bkn-backend/server/bkn-specification/bkn/validator.go
+++ b/adp/bkn/bkn-backend/server/bkn-specification/bkn/validator.go
@@ -566,6 +566,29 @@ func validateMetricConditionField(result *ValidationResult, table, column, field
 	}
 }
 
+func validateMetricCondition(result *ValidationResult, table, column string, c *MetricCondition) {
+	if c == nil {
+		return
+	}
+	op := strings.TrimSpace(strings.ToLower(c.Operation))
+	if op == "" {
+		appendError(result, table, column, "invalid_metric_condition", "operation must not be empty")
+		return
+	}
+	if op == "and" || op == "or" {
+		if len(c.SubConds) == 0 {
+			appendError(result, table, column, "invalid_metric_condition",
+				fmt.Sprintf("[%s] requires at least 1 sub_cond", c.Operation))
+			return
+		}
+		for i, sub := range c.SubConds {
+			validateMetricCondition(result, table, fmt.Sprintf("%s.sub_conds[%d]", column, i), sub)
+		}
+		return
+	}
+	validateMetricConditionField(result, table, column+".field", c.Field)
+}
+
 func validateMetricPropertyRef(result *ValidationResult, table, column, field string) {
 	field = strings.TrimSpace(field)
 	if field == "" {
@@ -619,7 +642,7 @@ func validateMetricDeep(result *ValidationResult, table string, met *BknMetric, 
 		}
 	}
 	if a.Condition != nil {
-		validateMetricConditionField(result, table, "condition.field", a.Condition.Field)
+		validateMetricCondition(result, table, "condition", a.Condition)
 	}
 	for i, g := range a.GroupBy {
 		col := fmt.Sprintf("group_by[%d].property", i)

--- a/adp/bkn/bkn-backend/server/bkn-specification/bkn/validator_test.go
+++ b/adp/bkn/bkn-backend/server/bkn-specification/bkn/validator_test.go
@@ -410,6 +410,37 @@ func TestValidateNetwork_MetricObjectTypeMissingScopeRefRejected(t *testing.T) {
 	assert.True(t, found, "expected invalid_metric_scope_ref (required), got %+v", res.Errors)
 }
 
+func TestValidateNetwork_MetricCompositeConditionOK(t *testing.T) {
+	net := testNetworkWithMetric("object_type", "ot1")
+	net.Metrics[0].Formula.Atomic.Condition = &MetricCondition{
+		Operation: "and",
+		SubConds: []*MetricCondition{
+			{Field: "k", Operation: "eq", Value: "v"},
+			{Field: "status", Operation: "in", Value: []any{"a"}},
+		},
+	}
+	res := ValidateNetwork(net)
+	assert.True(t, res.OK(), "errors: %+v", res.Errors)
+}
+
+func TestValidateNetwork_MetricEmptySubCondsRejected(t *testing.T) {
+	net := testNetworkWithMetric("object_type", "ot1")
+	net.Metrics[0].Formula.Atomic.Condition = &MetricCondition{
+		Operation: "and",
+		SubConds:  []*MetricCondition{},
+	}
+	res := ValidateNetwork(net)
+	assert.False(t, res.OK())
+	var found bool
+	for _, e := range res.Errors {
+		if e.Code == "invalid_metric_condition" && strings.Contains(e.Message, "sub_cond") {
+			found = true
+			break
+		}
+	}
+	assert.True(t, found, "expected invalid_metric_condition for empty sub_conds, got %+v", res.Errors)
+}
+
 func TestValidateNetwork_MockSystem(t *testing.T) {
 	dir := filepath.Join(testExamplesDir(t), "mock_system")
 	net, err := LoadNetwork(dir)

--- a/adp/bkn/bkn-backend/server/driveradapters/validate_metric.go
+++ b/adp/bkn/bkn-backend/server/driveradapters/validate_metric.go
@@ -334,18 +334,17 @@ func validateMetricCond(ctx context.Context, cfg *cond.CondCfg) error {
 	// 指标的过滤条件不支持模糊查询和语义查询操作符
 	switch cfg.Operation {
 	case cond.OperationAnd, cond.OperationOr:
-		// 子过滤条件不能超过10个
 		if len(cfg.SubConds) > cond.MaxSubCondition {
 			return rest.NewHTTPError(ctx, http.StatusBadRequest, berrors.BknBackend_CountExceeded_Conditions).
 				WithErrorDetails(fmt.Sprintf("The number of subConditions exceeds %d", cond.MaxSubCondition))
 		}
 
 		for _, subCond := range cfg.SubConds {
-			err := validateCond(ctx, subCond)
-			if err != nil {
+			if err := validateMetricCond(ctx, subCond); err != nil {
 				return err
 			}
 		}
+		return nil
 	default:
 		// 过滤字段名称不能为空
 		if cfg.Field == "" {

--- a/adp/bkn/bkn-backend/server/driveradapters/validate_metric.go
+++ b/adp/bkn/bkn-backend/server/driveradapters/validate_metric.go
@@ -334,6 +334,10 @@ func validateMetricCond(ctx context.Context, cfg *cond.CondCfg) error {
 	// 指标的过滤条件不支持模糊查询和语义查询操作符
 	switch cfg.Operation {
 	case cond.OperationAnd, cond.OperationOr:
+		if len(cfg.SubConds) == 0 {
+			return rest.NewHTTPError(ctx, http.StatusBadRequest, berrors.BknBackend_InvalidParameter_Condition).
+				WithErrorDetails(fmt.Sprintf("[%s] operation requires at least 1 sub_condition", cfg.Operation))
+		}
 		if len(cfg.SubConds) > cond.MaxSubCondition {
 			return rest.NewHTTPError(ctx, http.StatusBadRequest, berrors.BknBackend_CountExceeded_Conditions).
 				WithErrorDetails(fmt.Sprintf("The number of subConditions exceeds %d", cond.MaxSubCondition))

--- a/adp/bkn/bkn-backend/server/driveradapters/validate_metric_test.go
+++ b/adp/bkn/bkn-backend/server/driveradapters/validate_metric_test.go
@@ -14,6 +14,8 @@ import (
 	"github.com/openbkn-ai/bkn-comm-go/rest"
 	. "github.com/smartystreets/goconvey/convey"
 
+	cond "bkn-backend/common/condition"
+	berrors "bkn-backend/errors"
 	"bkn-backend/interfaces"
 )
 
@@ -96,5 +98,41 @@ func Test_ValidateMetricRequests(t *testing.T) {
 			err := ValidateMetricRequests(ctx, []*interfaces.MetricDefinition{e, e}, true)
 			So(err, ShouldNotBeNil)
 		})
+	})
+}
+
+func Test_validateMetricCond(t *testing.T) {
+	ctx := context.Background()
+
+	Convey("validateMetricCond accepts and/or composite conditions\n", t, func() {
+		err := validateMetricCond(ctx, &cond.CondCfg{
+			Operation: cond.OperationAnd,
+			SubConds: []*cond.CondCfg{
+				{Field: "warehouse", Operation: cond.OperationIn, ValueOptCfg: cond.ValueOptCfg{Value: []any{"昆山成品仓"}}},
+				{Field: "stock_status", Operation: cond.OperationEq, ValueOptCfg: cond.ValueOptCfg{Value: "可用"}},
+			},
+		})
+		So(err, ShouldBeNil)
+	})
+
+	Convey("validateMetricCond accepts single atomic condition\n", t, func() {
+		err := validateMetricCond(ctx, &cond.CondCfg{
+			Field:       "status",
+			Operation:   cond.OperationEq,
+			ValueOptCfg: cond.ValueOptCfg{Value: "Active"},
+		})
+		So(err, ShouldBeNil)
+	})
+
+	Convey("validateMetricCond rejects knn in metric condition tree\n", t, func() {
+		err := validateMetricCond(ctx, &cond.CondCfg{
+			Operation: cond.OperationAnd,
+			SubConds: []*cond.CondCfg{
+				{Field: "warehouse", Operation: cond.OperationKNN, ValueOptCfg: cond.ValueOptCfg{Value: "x"}},
+			},
+		})
+		So(err, ShouldNotBeNil)
+		httpErr := err.(*rest.HTTPError)
+		So(httpErr.BaseError.ErrorCode, ShouldEqual, berrors.BknBackend_UnsupportConditionOperation)
 	})
 }

--- a/adp/bkn/bkn-backend/server/driveradapters/validate_metric_test.go
+++ b/adp/bkn/bkn-backend/server/driveradapters/validate_metric_test.go
@@ -135,4 +135,14 @@ func Test_validateMetricCond(t *testing.T) {
 		httpErr := err.(*rest.HTTPError)
 		So(httpErr.BaseError.ErrorCode, ShouldEqual, berrors.BknBackend_UnsupportConditionOperation)
 	})
+
+	Convey("validateMetricCond rejects empty sub_conditions for and/or\n", t, func() {
+		err := validateMetricCond(ctx, &cond.CondCfg{
+			Operation: cond.OperationAnd,
+			SubConds:  []*cond.CondCfg{},
+		})
+		So(err, ShouldNotBeNil)
+		httpErr := err.(*rest.HTTPError)
+		So(httpErr.BaseError.ErrorCode, ShouldEqual, berrors.BknBackend_InvalidParameter_Condition)
+	})
 }

--- a/adp/bkn/bkn-backend/server/logics/bkn_convert.go
+++ b/adp/bkn/bkn-backend/server/logics/bkn_convert.go
@@ -204,24 +204,32 @@ func metricConditionToCondCfg(c *bknsdk.MetricCondition) *cond.CondCfg {
 	if c == nil {
 		return nil
 	}
-	return &cond.CondCfg{
+	out := &cond.CondCfg{
 		Field:     c.Field,
 		Operation: c.Operation,
 		ValueOptCfg: cond.ValueOptCfg{
 			Value: c.Value,
 		},
 	}
+	for _, subCond := range c.SubConds {
+		out.SubConds = append(out.SubConds, metricConditionToCondCfg(subCond))
+	}
+	return out
 }
 
 func condCfgToMetricCondition(c *cond.CondCfg) *bknsdk.MetricCondition {
 	if c == nil {
 		return nil
 	}
-	return &bknsdk.MetricCondition{
+	out := &bknsdk.MetricCondition{
 		Field:     c.Field,
 		Operation: c.Operation,
 		Value:     c.Value,
 	}
+	for _, subCond := range c.SubConds {
+		out.SubConds = append(out.SubConds, condCfgToMetricCondition(subCond))
+	}
+	return out
 }
 
 func metricHavingToADP(h *bknsdk.MetricHaving) *interfaces.MetricHaving {

--- a/adp/bkn/bkn-backend/server/logics/bkn_convert_test.go
+++ b/adp/bkn/bkn-backend/server/logics/bkn_convert_test.go
@@ -189,6 +189,33 @@ func Test_ToBKNMetricDefinition_RoundTrip_KeyFields(t *testing.T) {
 	})
 }
 
+func Test_MetricCondition_CompositeRoundTrip(t *testing.T) {
+	Convey("metric composite condition round-trips through BKN conversion\n", t, func() {
+		orig := &cond.CondCfg{
+			Operation: cond.OperationAnd,
+			SubConds: []*cond.CondCfg{
+				{Field: "warehouse", Operation: cond.OperationIn, ValueOptCfg: cond.ValueOptCfg{Value: []any{"昆山成品仓"}}},
+				{Field: "stock_status", Operation: cond.OperationEq, ValueOptCfg: cond.ValueOptCfg{Value: "可用"}},
+			},
+		}
+
+		bknCond := condCfgToMetricCondition(orig)
+		So(bknCond, ShouldNotBeNil)
+		So(bknCond.Operation, ShouldEqual, cond.OperationAnd)
+		So(bknCond.SubConds, ShouldHaveLength, 2)
+		So(bknCond.SubConds[0].Field, ShouldEqual, "warehouse")
+		So(bknCond.SubConds[1].Field, ShouldEqual, "stock_status")
+
+		back := metricConditionToCondCfg(bknCond)
+		So(back.Operation, ShouldEqual, orig.Operation)
+		So(back.SubConds, ShouldHaveLength, 2)
+		So(back.SubConds[0].Field, ShouldEqual, "warehouse")
+		So(back.SubConds[0].Operation, ShouldEqual, cond.OperationIn)
+		So(back.SubConds[1].Field, ShouldEqual, "stock_status")
+		So(back.SubConds[1].Operation, ShouldEqual, cond.OperationEq)
+	})
+}
+
 // ── ObjectType ───────────────────────────────────────────────────────────────
 
 func Test_ToADPObjectType(t *testing.T) {

--- a/adp/bkn/ontology-query/server/driveradapters/validate_metric.go
+++ b/adp/bkn/ontology-query/server/driveradapters/validate_metric.go
@@ -236,84 +236,6 @@ func validateMetricHaving(ctx context.Context, h *interfaces.MetricHaving) error
 	}
 }
 
-// validateConditionRecursive 与 bkn-backend validateCond 一致，用于指标公式中 and/or 子条件树。
-func validateConditionRecursive(ctx context.Context, cfg *cond.CondCfg) error {
-	if cfg == nil {
-		return nil
-	}
-	if cfg.Operation == "" {
-		return rest.NewHTTPError(ctx, http.StatusBadRequest, oerrors.OntologyQuery_InvalidParameter_Condition).
-			WithErrorDetails("condition operation is required")
-	}
-	if _, exists := cond.OperationMap[cfg.Operation]; !exists {
-		return rest.NewHTTPError(ctx, http.StatusBadRequest, oerrors.OntologyQuery_InvalidParameter_Condition).
-			WithErrorDetails("unsupported condition operation")
-	}
-
-	switch cfg.Operation {
-	case cond.OperationAnd, cond.OperationOr, cond.OperationKNN:
-		if len(cfg.SubConds) > cond.MaxSubCondition {
-			return rest.NewHTTPError(ctx, http.StatusBadRequest, oerrors.OntologyQuery_InvalidParameter_Condition).
-				WithErrorDetails(fmt.Sprintf("the number of sub_conditions exceeds %d", cond.MaxSubCondition))
-		}
-		for _, subCond := range cfg.SubConds {
-			if err := validateConditionRecursive(ctx, subCond); err != nil {
-				return err
-			}
-		}
-	default:
-		if cfg.Operation != cond.OperationMultiMatch && cfg.Name == "" {
-			return rest.NewHTTPError(ctx, http.StatusBadRequest, oerrors.OntologyQuery_InvalidParameter_Condition).
-				WithErrorDetails("condition field name is required")
-		}
-	}
-
-	switch cfg.Operation {
-	case cond.OperationEq, cond.OperationNotEq, cond.OperationGt, cond.OperationGte, cond.OperationLt, cond.OperationLte,
-		cond.OperationLike, cond.OperationNotLike, cond.OperationPrefix, cond.OperationNotPrefix, cond.OperationRegex,
-		cond.OperationMatch, cond.OperationMatchPhrase, cond.OperationCurrent, cond.OperationMultiMatch:
-		if _, ok := cfg.Value.([]any); ok {
-			return rest.NewHTTPError(ctx, http.StatusBadRequest, oerrors.OntologyQuery_InvalidParameter_Condition).
-				WithErrorDetails(fmt.Sprintf("[%s] operation's value should be a single value", cfg.Operation))
-		}
-		if cfg.Operation == cond.OperationLike || cfg.Operation == cond.OperationNotLike ||
-			cfg.Operation == cond.OperationPrefix || cfg.Operation == cond.OperationNotPrefix {
-			if _, ok := cfg.Value.(string); !ok {
-				return rest.NewHTTPError(ctx, http.StatusBadRequest, oerrors.OntologyQuery_InvalidParameter_Condition).
-					WithErrorDetails("[like not_like prefix not_prefix] operation's value should be a string")
-			}
-		}
-		if cfg.Operation == cond.OperationRegex {
-			_, ok := cfg.Value.(string)
-			if !ok {
-				return rest.NewHTTPError(ctx, http.StatusBadRequest, oerrors.OntologyQuery_InvalidParameter_Condition).
-					WithErrorDetails("[regex] operation's value should be a string")
-			}
-		}
-	case cond.OperationIn, cond.OperationNotIn:
-		arr, ok := cfg.Value.([]any)
-		if !ok {
-			return rest.NewHTTPError(ctx, http.StatusBadRequest, oerrors.OntologyQuery_InvalidParameter_Condition).
-				WithErrorDetails("[in not_in] operation's value must be an array")
-		}
-		if len(arr) <= 0 {
-			return rest.NewHTTPError(ctx, http.StatusBadRequest, oerrors.OntologyQuery_InvalidParameter_Condition).
-				WithErrorDetails("[in not_in] operation's value should contain at least 1 value")
-		}
-	case cond.OperationRange, cond.OperationOutRange, cond.OperationBefore, cond.OperationBetween:
-		v, ok := cfg.Value.([]any)
-		if !ok {
-			return rest.NewHTTPError(ctx, http.StatusBadRequest, oerrors.OntologyQuery_InvalidParameter_Condition).
-				WithErrorDetails("[range, out_range] operation's value must be an array")
-		}
-		if len(v) != 2 {
-			return rest.NewHTTPError(ctx, http.StatusBadRequest, oerrors.OntologyQuery_InvalidParameter_Condition).
-				WithErrorDetails("[range, out_range] operation's value must contain 2 values")
-		}
-	}
-	return nil
-}
-
 func validateMetricCond(ctx context.Context, cfg *cond.CondCfg) error {
 	if cfg == nil {
 		return nil
@@ -334,10 +256,11 @@ func validateMetricCond(ctx context.Context, cfg *cond.CondCfg) error {
 				WithErrorDetails(fmt.Sprintf("the number of sub_conditions exceeds %d", cond.MaxSubCondition))
 		}
 		for _, subCond := range cfg.SubConds {
-			if err := validateConditionRecursive(ctx, subCond); err != nil {
+			if err := validateMetricCond(ctx, subCond); err != nil {
 				return err
 			}
 		}
+		return nil
 	default:
 		if cfg.Name == "" {
 			return rest.NewHTTPError(ctx, http.StatusBadRequest, oerrors.OntologyQuery_InvalidParameter_Condition).

--- a/adp/bkn/ontology-query/server/driveradapters/validate_metric.go
+++ b/adp/bkn/ontology-query/server/driveradapters/validate_metric.go
@@ -251,6 +251,10 @@ func validateMetricCond(ctx context.Context, cfg *cond.CondCfg) error {
 
 	switch cfg.Operation {
 	case cond.OperationAnd, cond.OperationOr:
+		if len(cfg.SubConds) == 0 {
+			return rest.NewHTTPError(ctx, http.StatusBadRequest, oerrors.OntologyQuery_InvalidParameter_Condition).
+				WithErrorDetails(fmt.Sprintf("[%s] operation requires at least 1 sub_condition", cfg.Operation))
+		}
 		if len(cfg.SubConds) > cond.MaxSubCondition {
 			return rest.NewHTTPError(ctx, http.StatusBadRequest, oerrors.OntologyQuery_InvalidParameter_Condition).
 				WithErrorDetails(fmt.Sprintf("the number of sub_conditions exceeds %d", cond.MaxSubCondition))

--- a/adp/bkn/ontology-query/server/driveradapters/validate_metric_test.go
+++ b/adp/bkn/ontology-query/server/driveradapters/validate_metric_test.go
@@ -183,4 +183,27 @@ func Test_validateMetricDryRunForExecution_alignedWithBknSave(t *testing.T) {
 		httpErr := err.(*rest.HTTPError)
 		So(httpErr.BaseError.ErrorCode, ShouldEqual, oerrors.OntologyQuery_InvalidParameter_Condition)
 	})
+
+	Convey("dry-run rejects empty sub_conditions for and/or\n", t, func() {
+		body := &interfaces.MetricDryRunRequest{
+			MetricConfig: &interfaces.MetricDefinition{
+				MetricType: interfaces.MetricTypeAtomic,
+				ScopeType:  interfaces.ScopeTypeObjectType,
+				ScopeRef:   "ot1",
+				UnitType:   "numUnit",
+				Unit:       "none",
+				CalculationFormula: &interfaces.MetricCalculationFormula{
+					Condition: &cond.CondCfg{
+						Operation: cond.OperationOr,
+						SubConds:  []*cond.CondCfg{},
+					},
+					Aggregation: interfaces.MetricAggregation{Property: "amount", Aggr: interfaces.MetricAggrSum},
+				},
+			},
+		}
+		err := validateMetricDryRunForExecution(ctx, body)
+		So(err, ShouldNotBeNil)
+		httpErr := err.(*rest.HTTPError)
+		So(httpErr.BaseError.ErrorCode, ShouldEqual, oerrors.OntologyQuery_InvalidParameter_Condition)
+	})
 }

--- a/adp/bkn/ontology-query/server/driveradapters/validate_metric_test.go
+++ b/adp/bkn/ontology-query/server/driveradapters/validate_metric_test.go
@@ -134,4 +134,53 @@ func Test_validateMetricDryRunForExecution_alignedWithBknSave(t *testing.T) {
 		err := validateMetricDryRunForExecution(ctx, body)
 		So(err, ShouldBeNil)
 	})
+
+	Convey("dry-run accepts and/or composite metric condition\n", t, func() {
+		body := &interfaces.MetricDryRunRequest{
+			MetricConfig: &interfaces.MetricDefinition{
+				MetricType: interfaces.MetricTypeAtomic,
+				ScopeType:  interfaces.ScopeTypeObjectType,
+				ScopeRef:   "ot1",
+				UnitType:   "numUnit",
+				Unit:       "none",
+				CalculationFormula: &interfaces.MetricCalculationFormula{
+					Condition: &cond.CondCfg{
+						Operation: cond.OperationAnd,
+						SubConds: []*cond.CondCfg{
+							{Name: "warehouse", Operation: cond.OperationIn, ValueOptCfg: cond.ValueOptCfg{Value: []any{"昆山成品仓"}}},
+							{Name: "stock_status", Operation: cond.OperationEq, ValueOptCfg: cond.ValueOptCfg{Value: "可用"}},
+						},
+					},
+					Aggregation: interfaces.MetricAggregation{Property: "amount", Aggr: interfaces.MetricAggrSum},
+				},
+			},
+		}
+		err := validateMetricDryRunForExecution(ctx, body)
+		So(err, ShouldBeNil)
+	})
+
+	Convey("dry-run rejects knn in metric condition tree\n", t, func() {
+		body := &interfaces.MetricDryRunRequest{
+			MetricConfig: &interfaces.MetricDefinition{
+				MetricType: interfaces.MetricTypeAtomic,
+				ScopeType:  interfaces.ScopeTypeObjectType,
+				ScopeRef:   "ot1",
+				UnitType:   "numUnit",
+				Unit:       "none",
+				CalculationFormula: &interfaces.MetricCalculationFormula{
+					Condition: &cond.CondCfg{
+						Operation: cond.OperationAnd,
+						SubConds: []*cond.CondCfg{
+							{Name: "warehouse", Operation: cond.OperationKNN, ValueOptCfg: cond.ValueOptCfg{Value: "x"}},
+						},
+					},
+					Aggregation: interfaces.MetricAggregation{Property: "amount", Aggr: interfaces.MetricAggrSum},
+				},
+			},
+		}
+		err := validateMetricDryRunForExecution(ctx, body)
+		So(err, ShouldNotBeNil)
+		httpErr := err.(*rest.HTTPError)
+		So(httpErr.BaseError.ErrorCode, ShouldEqual, oerrors.OntologyQuery_InvalidParameter_Condition)
+	})
 }


### PR DESCRIPTION
## What Changed

Brief description of changes:

- [x] bkn-backend: fix `validateMetricCond` to accept `and`/`or` composite metric conditions
- [x] ontology-query: align dry-run/save validation with bkn-backend and remove redundant helper
- [ ] Docs/doc 1 — not applicable (OpenAPI already references full Condition schema)

---

## Why

- Related Issue: [#594](https://github.com/openbkn-ai/bkn-foundry/issues/594)
- Related Feature: metric calculation formula condition validation
- Background: Metric API documents condition as ontology-query Condition-compatible, but `validateMetricCond` validated `and`/`or` in the first switch and then rejected them in the second switch default branch.

---

## How

- Key implementation points:
  - Return early after recursively validating `and`/`or` sub-conditions in `validateMetricCond`
  - Recurse with `validateMetricCond` instead of broader general-purpose validators
  - Remove ontology-query `validateConditionRecursive` to avoid rule drift
- Breaking changes (API, config, database, etc.): None. This enables documented behavior for composite metric filters.

---

## Testing

- [x] Unit tests passed locally
- [ ] Integration tests passed locally — not run (validation-only change)
- [ ] Verified in test environment — not run

Test notes:

```bash
cd adp/bkn/bkn-backend/server && I18N_MODE_UT=true go test ./driveradapters/ -run ValidateMetric|validateMetricCond -v
cd adp/bkn/ontology-query/server && I18N_MODE_UT=true go test ./driveradapters/ -run validateMetric -v
```

---

## Risk & Rollback

- Potential risks: Low. Execution path already supported composite conditions via `mergeConditions` + `RewriteCondition`; this only fixes pre-save/dry-run validation.
- Rollback plan: Revert this PR if unexpected metric validation regressions appear.

---

## Additional Notes

Closes #594