### PR TITLE
fix(bkn-backend): metrics validate route alias for SDK compat (#593)

### DIFF
--- a/adp/bkn/bkn-backend/server/driveradapters/metric_handler_test.go
+++ b/adp/bkn/bkn-backend/server/driveradapters/metric_handler_test.go
@@ -1,0 +1,95 @@
+// Copyright openbkn.ai
+// Copyright The kweaver.ai Authors.
+//
+// Licensed under the Apache License, Version 2.0.
+// See the LICENSE file in the project root for details.
+
+package driveradapters
+
+import (
+	"bytes"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/bytedance/sonic"
+	"github.com/gin-gonic/gin"
+	"github.com/openbkn-ai/bkn-comm-go/hydra"
+	. "github.com/smartystreets/goconvey/convey"
+	"go.uber.org/mock/gomock"
+
+	"bkn-backend/common"
+	"bkn-backend/interfaces"
+	bmock "bkn-backend/interfaces/mock"
+)
+
+func mockNewMetricRestHandler(
+	appSetting *common.AppSetting,
+	as interfaces.AuthService,
+	ms interfaces.MetricService,
+	kns interfaces.KNService,
+) *restHandler {
+	return &restHandler{
+		appSetting: appSetting,
+		as:         as,
+		ms:         ms,
+		kns:        kns,
+	}
+}
+
+func Test_MetricRestHandler_ValidateMetricsRouteAlias(t *testing.T) {
+	Convey("ValidateMetrics is reachable on /metrics/validate (SDK/CLI alias)\n", t, func() {
+		test := setGinMode()
+		defer test()
+
+		engine := gin.New()
+		engine.Use(gin.Recovery())
+
+		mockCtrl := gomock.NewController(t)
+		defer mockCtrl.Finish()
+
+		appSetting := &common.AppSetting{}
+		as := bmock.NewMockAuthService(mockCtrl)
+		ms := bmock.NewMockMetricService(mockCtrl)
+		kns := bmock.NewMockKNService(mockCtrl)
+
+		handler := mockNewMetricRestHandler(appSetting, as, ms, kns)
+		handler.RegisterPublic(engine)
+
+		as.EXPECT().VerifyToken(gomock.Any(), gomock.Any()).AnyTimes().Return(hydra.Visitor{}, nil)
+
+		knID := "kn1"
+		body, _ := sonic.Marshal(struct {
+			Entries []*interfaces.MetricDefinition `json:"entries"`
+		}{Entries: nil})
+
+		for _, pathSuffix := range []string{"validation", "validate"} {
+			pathSuffix := pathSuffix
+			Convey("external POST .../metrics/"+pathSuffix+" is not 404\n", func() {
+				kns.EXPECT().CheckKNExistByID(gomock.Any(), knID, gomock.Any()).Return(knID, true, nil)
+
+				url := "/api/bkn-backend/v1/knowledge-networks/" + knID + "/metrics/" + pathSuffix
+				req := httptest.NewRequest(http.MethodPost, url, bytes.NewReader(body))
+				req.Header.Set(interfaces.CONTENT_TYPE_NAME, interfaces.CONTENT_TYPE_JSON)
+				w := httptest.NewRecorder()
+				engine.ServeHTTP(w, req)
+
+				So(w.Result().StatusCode, ShouldEqual, http.StatusBadRequest)
+				So(w.Body.String(), ShouldContainSubstring, "No metric was passed in")
+			})
+		}
+
+		Convey("internal POST .../metrics/validate is not 404\n", func() {
+			kns.EXPECT().CheckKNExistByID(gomock.Any(), knID, gomock.Any()).Return(knID, true, nil)
+
+			url := "/api/bkn-backend/in/v1/knowledge-networks/" + knID + "/metrics/validate"
+			req := httptest.NewRequest(http.MethodPost, url, bytes.NewReader(body))
+			req.Header.Set(interfaces.CONTENT_TYPE_NAME, interfaces.CONTENT_TYPE_JSON)
+			w := httptest.NewRecorder()
+			engine.ServeHTTP(w, req)
+
+			So(w.Result().StatusCode, ShouldEqual, http.StatusBadRequest)
+			So(w.Body.String(), ShouldContainSubstring, "No metric was passed in")
+		})
+	})
+}

--- a/adp/bkn/bkn-backend/server/driveradapters/routers.go
+++ b/adp/bkn/bkn-backend/server/driveradapters/routers.go
@@ -135,6 +135,8 @@ func (r *restHandler) RegisterPublic(c *gin.Engine) {
 		// 指标
 		apiV1.POST("/knowledge-networks/:kn_id/metrics", r.verifyJsonContentType(), r.HandleMetricGetOverrideByEx)
 		apiV1.POST("/knowledge-networks/:kn_id/metrics/validation", r.verifyJsonContentType(), r.ValidateMetricsByEx)
+		// SDK/CLI compatibility alias (@openbkn/bkn-sdk uses /metrics/validate)
+		apiV1.POST("/knowledge-networks/:kn_id/metrics/validate", r.verifyJsonContentType(), r.ValidateMetricsByEx)
 		apiV1.DELETE("/knowledge-networks/:kn_id/metrics/:metric_ids", r.DeleteMetricsByIDsByEx)
 		apiV1.PUT("/knowledge-networks/:kn_id/metrics/:metric_ids", r.verifyJsonContentType(), r.UpdateMetricByEx)
 		apiV1.GET("/knowledge-networks/:kn_id/metrics", r.ListMetricsByEx)
@@ -211,6 +213,8 @@ func (r *restHandler) RegisterPublic(c *gin.Engine) {
 		// 指标（内部）
 		apiInV1.POST("/knowledge-networks/:kn_id/metrics", r.verifyJsonContentType(), r.HandleMetricGetOverrideByIn)
 		apiInV1.POST("/knowledge-networks/:kn_id/metrics/validation", r.verifyJsonContentType(), r.ValidateMetricsByIn)
+		// SDK/CLI compatibility alias (@openbkn/bkn-sdk uses /metrics/validate)
+		apiInV1.POST("/knowledge-networks/:kn_id/metrics/validate", r.verifyJsonContentType(), r.ValidateMetricsByIn)
 		apiInV1.DELETE("/knowledge-networks/:kn_id/metrics/:metric_ids", r.DeleteMetricsByIDsByIn)
 		apiInV1.PUT("/knowledge-networks/:kn_id/metrics/:metric_ids", r.verifyJsonContentType(), r.UpdateMetricByIn)
 		apiInV1.GET("/knowledge-networks/:kn_id/metrics", r.ListMetricsByIn)


### PR DESCRIPTION
## Summary

- Register `POST .../metrics/validate` as a compatibility alias on external (`bkn-backend/v1`, `ontology-manager/v1`) and internal (`bkn-backend/in/v1`) API groups, pointing to the same handlers as OpenAPI canonical `.../metrics/validation`.
- Add `metric_handler_test.go` contract tests: both paths return handler semantics (400 + `No metric was passed in` for empty body, not 404).

Companion SDK fix: [openbkn-ai/bkn-sdk#](https://github.com/openbkn-ai/bkn-sdk/pull/new/fix/593-metric-validation-path) — `validateMetric` now calls `/metrics/validation`.

Closes #593

## What Changed

- [x] bkn-backend routers: `/metrics/validate` alias (external + internal)
- [x] bkn-backend driveradapters: route contract unit test

## Why

`@openbkn/bkn-sdk` / `openbkn bkn metric validate` requested `.../metrics/validate` while OpenAPI and backend only exposed `.../metrics/validation`, causing HTTP 404 on POC.

## How

- No handler logic change; alias routes reuse `ValidateMetricsByEx` / `ValidateMetricsByIn`.
- Canonical path remains `validation` per `docs/api/bkn/bkn-metrics.yaml`.

## Testing

- [x] Unit tests passed locally

```bash
cd adp/bkn/bkn-backend/server
I18N_MODE_UT=true go test ./driveradapters/ -run ValidateMetricsRouteAlias -v
```

## Risk & Rollback

- **Risk:** Low — additive route only; existing `validation` path unchanged.
- **Rollback:** Revert commit; remove alias lines from `routers.go`.

## Additional Notes

- Label: `by-agent`
- Deploy backend before or with SDK upgrade; alias supports older SDK until clients update.
