### PR TITLE
fix(bkn-safe): 发证端点改集群内免令牌，取消 BKN_SAFE_APPKEY

### DIFF
--- a/bkn-safe/server/internal/httpapi/license.go
+++ b/bkn-safe/server/internal/httpapi/license.go
@@ -13,7 +13,6 @@ import (
 	"github.com/gin-gonic/gin"
 	"github.com/openbkn-ai/licverify"
 
-	"github.com/openbkn-ai/bkn-foundry/bkn-safe/server/internal/auth"
 	"github.com/openbkn-ai/bkn-foundry/bkn-safe/server/internal/authz"
 	"github.com/openbkn-ai/bkn-foundry/bkn-safe/server/internal/license"
 )
@@ -127,13 +126,21 @@ func importLicense(c *gin.Context, svc *license.Service) {
 	c.JSON(http.StatusOK, licenseDetail(svc))
 }
 
-// registerLicenseInternal mounts the in-cluster distribution surface. It is
-// NOT anonymous (upstream hard rule): callers authenticate with an AppKey —
-// the existing service-identity mechanism. What is distributed is the signed
-// license text; modules verify it locally and never trust these answers for
-// gating.
-func registerLicenseInternal(r *gin.Engine, svc *license.Service, keysStore *auth.APIKeyStore) {
-	g := r.Group("/api/safe/v1/internal/license", RequireAppKey(keysStore))
+// registerLicenseInternal mounts the in-cluster distribution surface: the whole
+// group is tokenless and ClusterIP-only, the same trust face as /authz and
+// /api-keys/introspect.
+//
+// What travels here is the signed license text and two weak views of it.
+// Modules verify the text locally against a key compiled into their own binary
+// and never gate on these answers, so this endpoint hands out evidence, not
+// verdicts — an impersonated hub can withhold a license but cannot manufacture
+// one. Requiring a per-service credential would therefore not protect gating
+// integrity; it would only keep the text from being read anonymously inside the
+// customer's own cluster, at the price of an issuer, a rotation story and a
+// revocation signal nobody had defined. The boundary is the network (see the
+// chart's networkPolicy), not a bearer token.
+func registerLicenseInternal(r *gin.Engine, svc *license.Service) {
+	g := r.Group("/api/safe/v1/internal/license")
 
 	// GET /current — the raw .lic + ETag. Modules poll with If-None-Match
 	// (≤5 min upstream contract); 304 keeps steady-state traffic body-free.
@@ -184,26 +191,6 @@ func registerLicenseInternal(r *gin.Engine, svc *license.Service, keysStore *aut
 		}
 		c.JSON(http.StatusOK, resp)
 	})
-}
-
-// RequireAppKey authenticates service callers by AppKey (Authorization:
-// Bearer bak_...). Any active key passes — this fences the surface off from
-// anonymous traffic, it is not a per-caller authorization scheme.
-func RequireAppKey(keysStore *auth.APIKeyStore) gin.HandlerFunc {
-	return func(c *gin.Context) {
-		tok := bearerToken(c)
-		if tok == "" {
-			c.AbortWithStatusJSON(http.StatusUnauthorized, gin.H{"error": "missing bearer AppKey"})
-			return
-		}
-		v, err := keysStore.Verify(c.Request.Context(), tok)
-		if err != nil {
-			c.AbortWithStatusJSON(http.StatusUnauthorized, gin.H{"error": "invalid AppKey"})
-			return
-		}
-		c.Set(ctxAccessorID, v.OwnerID)
-		c.Next()
-	}
 }
 
 // licenseStatus is the weak-judgement view shared by the internal status

--- a/bkn-safe/server/internal/httpapi/license_test.go
+++ b/bkn-safe/server/internal/httpapi/license_test.go
@@ -26,7 +26,6 @@ import (
 	"github.com/openbkn-ai/bkn-foundry/bkn-safe/server/internal/database"
 	"github.com/openbkn-ai/bkn-foundry/bkn-safe/server/internal/directory"
 	"github.com/openbkn-ai/bkn-foundry/bkn-safe/server/internal/license"
-	"github.com/openbkn-ai/bkn-foundry/bkn-safe/server/internal/model"
 )
 
 // newLicenseServer builds a full server with the license surfaces mounted: a
@@ -210,35 +209,32 @@ func TestLicenseActivateOffline(t *testing.T) {
 
 // internal face ---------------------------------------------------------------
 
-func issueAppKey(t *testing.T, db *gorm.DB) string {
-	t.Helper()
-	// Verification resolves the key to its owner, so the owner must exist.
-	if err := db.Create(&model.User{ID: "svc-module", Account: "svc-module", Name: "module", Enabled: true}).Error; err != nil {
-		t.Fatal(err)
-	}
-	plaintext, _, err := auth.NewAPIKeyStore(db).Issue(t.Context(), "svc-module", "module key", nil)
-	if err != nil {
-		t.Fatal(err)
-	}
-	return plaintext
-}
+// TestLicenseInternalIsTokenless pins the trust face of the whole
+// /internal/license group. It is the inverse of the assertion this test used to
+// make, and it is kept as a test rather than a comment because the failure it
+// guards against is someone re-fencing the surface with a service credential:
+// every module that needs a licence would then be blocked again on an issuer, a
+// rotation story and a revocation signal that do not exist. What travels here is
+// signed text verified locally against a compiled-in key, so reading it confers
+// no power to forge it — see registerLicenseInternal.
+func TestLicenseInternalIsTokenless(t *testing.T) {
+	r, _, priv := newLicenseServer(t)
+	adminReq(t, r, http.MethodPost, licAdminBase+"/import",
+		map[string]string{"license": signTestLic(t, priv, nil)})
 
-func TestLicenseInternalRequiresAppKey(t *testing.T) {
-	r, _, _ := newLicenseServer(t)
-	for _, tok := range []string{"", "bak_bogus_bogus"} {
-		w := tokReq(t, r, http.MethodGet, "/api/safe/v1/internal/license/status", nil, tok)
-		if w.Code != http.StatusUnauthorized {
-			t.Fatalf("token %q = %d, want 401", tok, w.Code)
+	for _, path := range []string{"/current", "/status", "/capabilities"} {
+		w := do(t, r, http.MethodGet, "/api/safe/v1/internal/license"+path, nil)
+		if w.Code != http.StatusOK {
+			t.Fatalf("unauthenticated GET %s = %d, want 200 — the group is tokenless", path, w.Code)
 		}
 	}
 }
 
 func TestLicenseInternalCurrentAndETag(t *testing.T) {
-	r, db, priv := newLicenseServer(t)
-	key := issueAppKey(t, db)
+	r, _, priv := newLicenseServer(t)
 
-	// No license yet: 404.
-	w := tokReq(t, r, http.MethodGet, "/api/safe/v1/internal/license/current", nil, key)
+	// No license yet: 404 — the absence is a definite answer, not a 401.
+	w := do(t, r, http.MethodGet, "/api/safe/v1/internal/license/current", nil)
 	if w.Code != http.StatusNotFound {
 		t.Fatalf("current with no license = %d, want 404", w.Code)
 	}
@@ -246,7 +242,7 @@ func TestLicenseInternalCurrentAndETag(t *testing.T) {
 	adminReq(t, r, http.MethodPost, licAdminBase+"/import",
 		map[string]string{"license": signTestLic(t, priv, nil)})
 
-	w = tokReq(t, r, http.MethodGet, "/api/safe/v1/internal/license/current", nil, key)
+	w = do(t, r, http.MethodGet, "/api/safe/v1/internal/license/current", nil)
 	if w.Code != http.StatusOK {
 		t.Fatalf("current = %d", w.Code)
 	}
@@ -265,7 +261,7 @@ func TestLicenseInternalCurrentAndETag(t *testing.T) {
 	}
 
 	// Conditional poll: 304 without a body.
-	req := tokReq2(t, r, http.MethodGet, "/api/safe/v1/internal/license/current", key, etag)
+	req := condReq(t, r, http.MethodGet, "/api/safe/v1/internal/license/current", etag)
 	if req.Code != http.StatusNotModified {
 		t.Fatalf("If-None-Match = %d, want 304", req.Code)
 	}
@@ -273,7 +269,7 @@ func TestLicenseInternalCurrentAndETag(t *testing.T) {
 	// Re-import (a "renewal"): ETag changes and the poll misses.
 	adminReq(t, r, http.MethodPost, licAdminBase+"/import",
 		map[string]string{"license": signTestLic(t, priv, func(p map[string]any) { p["lic_id"] = "lic-renewed" })})
-	req = tokReq2(t, r, http.MethodGet, "/api/safe/v1/internal/license/current", key, etag)
+	req = condReq(t, r, http.MethodGet, "/api/safe/v1/internal/license/current", etag)
 	if req.Code != http.StatusOK {
 		t.Fatalf("post-renewal poll = %d, want 200", req.Code)
 	}
@@ -283,12 +279,11 @@ func TestLicenseInternalCurrentAndETag(t *testing.T) {
 }
 
 func TestLicenseInternalStatusAndCapabilities(t *testing.T) {
-	r, db, priv := newLicenseServer(t)
-	key := issueAppKey(t, db)
+	r, _, priv := newLicenseServer(t)
 	adminReq(t, r, http.MethodPost, licAdminBase+"/import",
 		map[string]string{"license": signTestLic(t, priv, nil)})
 
-	w := tokReq(t, r, http.MethodGet, "/api/safe/v1/internal/license/status", nil, key)
+	w := do(t, r, http.MethodGet, "/api/safe/v1/internal/license/status", nil)
 	var st struct {
 		State     string `json:"state"`
 		Edition   string `json:"edition"`
@@ -299,7 +294,7 @@ func TestLicenseInternalStatusAndCapabilities(t *testing.T) {
 		t.Fatalf("status = %s", w.Body.String())
 	}
 
-	w = tokReq(t, r, http.MethodGet, "/api/safe/v1/internal/license/capabilities", nil, key)
+	w = do(t, r, http.MethodGet, "/api/safe/v1/internal/license/capabilities", nil)
 	var caps struct {
 		State    string           `json:"state"`
 		Features []string         `json:"features"`
@@ -311,11 +306,11 @@ func TestLicenseInternalStatusAndCapabilities(t *testing.T) {
 	}
 }
 
-// tokReq2 issues an authenticated request with an If-None-Match header.
-func tokReq2(t *testing.T, r *gin.Engine, method, path, token, etag string) *httptest.ResponseRecorder {
+// condReq issues a conditional (If-None-Match) request. No credential: the
+// distribution group is tokenless.
+func condReq(t *testing.T, r *gin.Engine, method, path, etag string) *httptest.ResponseRecorder {
 	t.Helper()
 	req := httptest.NewRequest(method, path, nil)
-	req.Header.Set("Authorization", "Bearer "+token)
 	req.Header.Set("If-None-Match", etag)
 	w := httptest.NewRecorder()
 	r.ServeHTTP(w, req)

--- a/bkn-safe/server/internal/httpapi/router.go
+++ b/bkn-safe/server/internal/httpapi/router.go
@@ -154,11 +154,22 @@ func New(deps Deps) *gin.Engine {
 		}
 	}
 
-	// In-cluster license distribution: modules pull the signed text and verify
-	// locally. AppKey-authenticated (not anonymous, unlike /authz — upstream
-	// hard rule for this surface).
-	if deps.License != nil && apiKeys != nil {
-		registerLicenseInternal(r, deps.License, apiKeys)
+	// In-cluster license distribution. The WHOLE /internal/license group is a
+	// tokenless service surface — /current, /status, /capabilities alike — the
+	// same trust face as /authz and /api-keys/introspect above. Anything added to
+	// this group inherits that: if a route would not be safe to answer for any
+	// pod in the cluster, it does not belong here.
+	//
+	// Tokenless is a property of the surface, not a shortcut. Modules pull the
+	// signed text and verify it locally against a key compiled into their own
+	// binary, so the group hands out evidence, not verdicts — withholding it can
+	// deny a licence, serving it cannot manufacture one, and a leaked certificate
+	// confers no power to forge one. The boundary is ClusterIP plus the chart's
+	// networkPolicy, not a bearer token. The alternative was a per-service
+	// credential with no defined issuer, rotation story, or revocation signal —
+	// an unanswered question that blocked every service needing to read a licence.
+	if deps.License != nil {
+		registerLicenseInternal(r, deps.License)
 	}
 
 	// Self-service reads under /api/safe/v1/me — token-gated (RequireUser:

--- a/comm-go/entitlement/gate_release.go
+++ b/comm-go/entitlement/gate_release.go
@@ -20,15 +20,16 @@ import (
 // Configuration is only ever about where to fetch the certificate — never about
 // which capabilities are on. That distinction is the whole discipline: the
 // moment a deployment can set something like audit.enabled=true, every gate in
-// the product is decorative. So this reads two values and no more:
+// the product is decorative. So this reads one value and no more:
 //
 //	BKN_SAFE_URL        in-cluster address of the licence hub
-//	BKN_SAFE_APPKEY     service credential for the distribution endpoint
 //
-// Either one missing means the process cannot obtain a licence, and a process
-// that cannot obtain one behaves as community. That is a legitimate steady
-// state — community deployments never set these — so it is not an error and
-// must not stop the service from starting.
+// The distribution endpoint is tokenless (ClusterIP-only, see bkn-safe's
+// httpapi/license.go), so there is no second variable to get wrong. Unset means
+// the process cannot obtain a licence, and a process that cannot obtain one
+// behaves as community. That is a legitimate steady state — community
+// deployments never set it — so it is not an error and must not stop the
+// service from starting.
 //
 // The caller is expected to run the returned gate's Run method in a goroutine;
 // GateWithRunner exists so a caller can do that without type-asserting.
@@ -48,25 +49,19 @@ func DefaultGate() Gate {
 // defaultHubGate resolves the hub configuration, or reports that this
 // deployment has none.
 //
-// Every path that ends in "no gate" is logged except the one that is genuinely
-// normal — neither variable set, i.e. a community deployment. The others look
-// identical from the outside (all paid capability off, no certificate fetched),
-// and without a line in the log an operator cannot tell "this is a community
-// install" from "the helm upgrade dropped BKN_SAFE_APPKEY".
+// Unset is the one path that ends in "no gate" without a log line, because it
+// is the genuinely normal one: a community deployment. Everything else that
+// yields no gate is logged — those cases look identical from the outside (all
+// paid capability off, no certificate fetched), and without a line in the log an
+// operator cannot tell "this is a community install" from a broken build.
 func defaultHubGate() (*HubGate, error) {
-	base, appkey := os.Getenv("BKN_SAFE_URL"), os.Getenv("BKN_SAFE_APPKEY")
-	switch {
-	case base == "" && appkey == "":
-		return nil, nil
-	case base == "" || appkey == "":
-		slog.Warn("entitlement: licence hub is half-configured; running as community",
-			"has_url", base != "", "has_appkey", appkey != "")
+	base := os.Getenv("BKN_SAFE_URL")
+	if base == "" {
 		return nil, nil
 	}
 
 	g, err := NewHubGate(HubConfig{
 		BaseURL: base,
-		AppKey:  appkey,
 		Keys:    keys.Official(),
 	})
 	if err != nil {

--- a/comm-go/entitlement/gate_release_test.go
+++ b/comm-go/entitlement/gate_release_test.go
@@ -23,7 +23,6 @@ func TestReleaseGateIgnoresTheEnvironment(t *testing.T) {
 	// Left unset it would fire a real 10s-timeout request at their cluster, and
 	// pass or fail depending on whether that bkn-safe happens to hold a licence.
 	t.Setenv("BKN_SAFE_URL", "")
-	t.Setenv("BKN_SAFE_APPKEY", "")
 
 	snap := DefaultGate().Snapshot()
 	if snap.Licensed || snap.Edition != licverify.EditionCommunity {
@@ -32,11 +31,10 @@ func TestReleaseGateIgnoresTheEnvironment(t *testing.T) {
 }
 
 func TestReleaseGateWithoutAHubIsCommunity(t *testing.T) {
-	// A community deployment sets neither variable. That is a legitimate
+	// A community deployment does not set the variable. That is a legitimate
 	// steady state, not a misconfiguration: the process must start and behave
 	// as community rather than refuse to boot.
 	t.Setenv("BKN_SAFE_URL", "")
-	t.Setenv("BKN_SAFE_APPKEY", "")
 
 	g, run := GateWithRunner()
 	if run != nil {

--- a/comm-go/entitlement/hub.go
+++ b/comm-go/entitlement/hub.go
@@ -27,7 +27,7 @@ import (
 // trusts bkn-safe's judgement, only its delivery — a tampered or impersonated
 // hub can withhold a licence but cannot manufacture one.
 //
-//	GET /api/safe/v1/internal/license/current    (AppKey authenticated)
+//	GET /api/safe/v1/internal/license/current    (tokenless, ClusterIP-only)
 //	200 {"license": "<signed text>", "etag": "..."}   + ETag header
 //	304                                                on If-None-Match
 //	404 {"error": "no license installed"}
@@ -58,9 +58,6 @@ type HubConfig struct {
 	// BaseURL is bkn-safe's in-cluster address, e.g.
 	// http://bkn-safe:8080. Required.
 	BaseURL string
-	// AppKey authenticates this service to the distribution endpoint. The
-	// surface is deliberately not anonymous. Required.
-	AppKey string
 	// Keys are the verification public keys (kid → key), compiled into the
 	// binary. Required — without them nothing can be verified and every fetch
 	// would be pointless.
@@ -101,8 +98,8 @@ type HubGate struct {
 // it serves its first request. A failed first fetch is not an error: the gate
 // starts at community and the background loop keeps trying.
 func NewHubGate(cfg HubConfig) (*HubGate, error) {
-	if cfg.BaseURL == "" || cfg.AppKey == "" {
-		return nil, errors.New("entitlement: hub gate needs BaseURL and AppKey")
+	if cfg.BaseURL == "" {
+		return nil, errors.New("entitlement: hub gate needs BaseURL")
 	}
 	if len(cfg.Keys) == 0 {
 		return nil, errors.New("entitlement: hub gate needs verification keys — a build that cannot verify must not pretend to be licensed")
@@ -237,7 +234,6 @@ func (g *HubGate) fetch() (fetchResult, error) {
 	if err != nil {
 		return fetchResult{}, err
 	}
-	req.Header.Set("Authorization", "Bearer "+g.cfg.AppKey)
 	if et := g.currentETag(); et != "" {
 		req.Header.Set("If-None-Match", `"`+et+`"`)
 	}

--- a/comm-go/entitlement/hub_test.go
+++ b/comm-go/entitlement/hub_test.go
@@ -34,7 +34,12 @@ type fakeHub struct {
 	mu       sync.Mutex
 	licence  string // empty means "none installed" → 404
 	requests int
-	appKeys  []string
+	// authz records the Authorization header of every request. The endpoint is
+	// tokenless, so the assertion on this is that it stays empty — kept as a
+	// test rather than a comment because a credential quietly reappearing here
+	// is exactly the regression that would put every consuming service back to
+	// waiting on an issuer/rotation/revocation story.
+	authz []string
 	// conditional records, per request, whether the client sent a validator.
 	// After the hub reports 404 the client must have dropped its cached ETag,
 	// so the next fetch is unconditional — otherwise recovery depends on text
@@ -71,7 +76,7 @@ func (h *fakeHub) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	h.mu.Lock()
 	defer h.mu.Unlock()
 	h.requests++
-	h.appKeys = append(h.appKeys, r.Header.Get("Authorization"))
+	h.authz = append(h.authz, r.Header.Get("Authorization"))
 	h.conditional = append(h.conditional, r.Header.Get("If-None-Match") != "")
 
 	if h.status != 0 {
@@ -116,7 +121,6 @@ func newTestGate(t *testing.T, hub *fakeHub, keys map[string]ed25519.PublicKey) 
 
 	g, err := NewHubGate(HubConfig{
 		BaseURL: srv.URL,
-		AppKey:  "bak_test",
 		Keys:    keys,
 		Logf:    func(string, ...any) {},
 	})
@@ -137,8 +141,10 @@ func TestHubGateFetchesAndVerifies(t *testing.T) {
 	if !snap.Licensed || snap.Edition != licverify.EditionEnterprise {
 		t.Fatalf("snapshot = %+v, want licensed enterprise", snap)
 	}
-	if hub.appKeys[0] != "Bearer bak_test" {
-		t.Fatalf("Authorization = %q, want a bearer AppKey — the endpoint is not anonymous", hub.appKeys[0])
+	// No credential travels with the fetch: the distribution endpoint is
+	// tokenless by design, and a service needs BKN_SAFE_URL and nothing else.
+	if hub.authz[0] != "" {
+		t.Fatalf("Authorization = %q, want none — the endpoint is tokenless and the client must not require a credential to reach it", hub.authz[0])
 	}
 }
 
@@ -263,7 +269,7 @@ func TestHubGateNeedsVerificationKeys(t *testing.T) {
 	// A build with no key table cannot verify anything, so fetching would be
 	// theatre. Fail loudly at construction instead of running as an
 	// enterprise-looking process that trusts whatever it is handed.
-	_, err := NewHubGate(HubConfig{BaseURL: "http://example.invalid", AppKey: "k"})
+	_, err := NewHubGate(HubConfig{BaseURL: "http://example.invalid"})
 	if err == nil {
 		t.Fatal("expected a refusal when no verification keys are configured")
 	}


### PR DESCRIPTION
## 做了什么

`/api/safe/v1/internal/license` **整组**（`/current`、`/status`、`/capabilities`）由 AppKey 鉴权改为集群内免令牌，`BKN_SAFE_APPKEY` 整个取消——不是改成可选字段。接门控的服务从此只需 `BKN_SAFE_URL` 一个环境变量。

## 为什么免令牌不是"觉得没必要所以去掉"

这组端点分发的是**签名证书文本**。各模块用编译进自身二进制的公钥本地验签，从不把 bkn-safe 的回答当门控依据——`hub.go` 原有注释即写着 "a tampered or impersonated hub can withhold a licence but cannot manufacture one"。所以：

- AppKey **不保护门控完整性**，它只阻止客户自己集群内的匿名读取，而读到的是客户自己的授权信息；
- 代价是一份**没有签发方、没有轮换方案、没有撤销信号**的服务凭据。这三个问题在设计文档里就列为缺口，一个都没定；每个接门控的服务都要先等答案（vega 目前正卡在这里）；
- 先例在同一个文件里：`/authz`（授权判定，比证书敏感得多）与 `/api-keys/introspect` 早已是集群内免令牌，注释写着 "service-to-service, ClusterIP, unauthenticated"。发证端点比它们更严说不通。

边界改由 **ClusterIP + chart 的 networkPolicy** 划定（`bkn-safe/charts/bkn-safe/values.yaml:153`，为免令牌内部接口预留，默认 disabled），不新增暴露面。

**为什么不留成可选字段**：没人设的可选字段仍然要写进文档，每个接门控的服务都要问一句"我要不要配"。取消掉，这个问题就不存在了。真有部署把 bkn-safe 放在要求令牌的网关后面，那是部署层的事（mesh 注入头），届时再加回一个字段也只是几行。

## 兼容性：零存量影响（已逐条核对）

这是"删环境变量"，按惯例会被当破坏性变更卡住。核查过当前不存在任何存量依赖：

1. **没有任何 chart 注入 `BKN_SAFE_APPKEY`** —— 全仓 grep 该字符串，命中只在 `comm-go/entitlement/gate_release.go` 及其测试，没有一个 helm 模板设过它。
2. **门控客户端在 main 上只有一个生产调用点**：`adp/context-loader/agent-retrieval/server/app/app.go:80` 的 `entitlement.GateWithRunner()`。而 agent-retrieval 的 chart **不注入 `BKN_SAFE_URL`**，所以它今天恒为 community，取消 AppKey 对它没有任何行为变化。
3. 其余注入了 `BKN_SAFE_URL` 的服务（vega-backend、bkn-backend、operator-integration、mf-model-*）里，Go 门控客户端**尚未接入**——vega 会是第一个，而它正卡在本 PR 解锁的这个问题上。

副作用值得点名：`BKN_SAFE_URL` 有、`BKN_SAFE_APPKEY` 无的"半配置"状态从此消失。今天这种部署会打一条 warn 然后退回 community；改动后只要有 URL 就会真的去拉证。这正是想要的语义，但它是行为变化，不是纯删除——上面第 2、3 条说明目前没有部署处在这个状态。

故取消而非保留兼容字段。

## 整组而不是单个端点

`/status` 会把 edition、到期时间、宽限剩余暴露给集群内任意 Pod。可接受：这些信息本来就在 `/current` 分发的证书文本里，同一组端点、同一份数据，`/current` 放开而 `/status` 不放没有意义。

router 注释因此写的是**"这一组是免令牌的服务面"**而不是"这个端点"——将来往这组里加路由的人得知道它的信任面是什么，否则会有人往里塞一个不该匿名的东西。

## 改动

| 文件 | 改动 |
|---|---|
| `httpapi/router.go` | 守卫条件由 `License != nil && apiKeys != nil` 改为只判 `License != nil`（否则没有 AppKey store 的部署里发证端点会静默消失）；注释改写为整组信任面说明 |
| `httpapi/license.go` | `registerLicenseInternal` 去掉 `keysStore` 形参与中间件；`RequireAppKey` 函数一并删除（全仓唯一调用点就是这里）；`internal/auth` import 随之移除 |
| `comm-go/entitlement/hub.go` | 删 `HubConfig.AppKey` 字段与 `Authorization` 头；构造校验改为只要求 `BaseURL` |
| `comm-go/entitlement/gate_release.go` | 只读 `BKN_SAFE_URL`；"半配置"分支随之消失——不再有"配了一半"这种状态 |

**测试反转而非删除**（两处）：

- `hub_test.go`：原断言"必须带 bearer AppKey"，改为断言请求**不带** `Authorization` 头；
- `license_test.go`：原 `TestLicenseInternalRequiresAppKey` 断言 401，改为 `TestLicenseInternalIsTokenless` 断言三个端点免令牌可读。

把"这组是免令牌的"变成一条会失败的测试，而不是一句会被读过去的注释——凭据悄悄长回来正是要防的回归。

## 验证

```
comm-go:               go build ./... && go test ./entitlement/...   ok
bkn-safe/server:       go build ./... && go test ./internal/httpapi/... ok
go vet                 两模块均无新增告警
```

集群侧（部署后）：

```bash
kubectl -n openbkn exec deploy/agent-retrieval -- \
  curl -sS -o /dev/null -w '%{http_code}\n' \
  http://bkn-safe:3000/api/safe/v1/internal/license/current
# 有证书 → 200；没装证书 → 404；都不该是 401
```

## 连带

- 上游 `license-server` 文档同步反转：openbkn-ai/license-server 分支 `docs/license-internal-tokenless`（§3.2 标题 + §5.4 "接口面不做匿名暴露"）。只改实现留着注释说反话比不改更糟，下一个人会照注释把 AppKey 加回来。
- `ee-design.md`「缺口一：AppKey 的签发与轮换没有定论」整节可删。
- vega 接门控不用再等身份模型的结论。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
