### PR TITLE
docs(ontology-query): metric query condition merge contract (#596)

### DIFF
--- a/adp/bkn/ontology-query/server/logics/metric/metric_query_service_test.go
+++ b/adp/bkn/ontology-query/server/logics/metric/metric_query_service_test.go
@@ -108,6 +108,73 @@ func Test_metricGroupByDimensions_analysisDimensions(t *testing.T) {
 	})
 }
 
+func Test_mergeConditions(t *testing.T) {
+	Convey("mergeConditions combines non-nil trees with AND\n", t, func() {
+		a := &cond.CondCfg{Operation: cond.OperationEq, Name: "warehouse", ValueOptCfg: cond.ValueOptCfg{Value: "wh-1"}}
+		b := &cond.CondCfg{Operation: cond.OperationEq, Name: "stock_status", ValueOptCfg: cond.ValueOptCfg{Value: "可用"}}
+
+		So(mergeConditions(nil, nil), ShouldBeNil)
+		So(mergeConditions(a, nil), ShouldEqual, a)
+		So(mergeConditions(nil, b), ShouldEqual, b)
+
+		merged := mergeConditions(a, b)
+		So(merged.Operation, ShouldEqual, cond.OperationAnd)
+		So(merged.SubConds, ShouldHaveLength, 2)
+		So(merged.SubConds[0], ShouldEqual, a)
+		So(merged.SubConds[1], ShouldEqual, b)
+	})
+}
+
+func Test_buildResourceDataQueryParams_conditionMerge(t *testing.T) {
+	Convey("buildResourceDataQueryParams merges definition and query-time conditions with AND\n", t, func() {
+		ctx := context.Background()
+		svc := &metricQueryService{appSetting: &common.AppSetting{}}
+		ot := interfaces.ObjectType{
+			ObjectTypeWithKeyField: interfaces.ObjectTypeWithKeyField{
+				DataProperties: []cond.DataProperty{
+					{Name: "warehouse", Type: dtype.DATATYPE_STRING, MappedField: cond.Field{Name: "warehouse_res"}},
+					{Name: "stock_status", Type: dtype.DATATYPE_STRING, MappedField: cond.Field{Name: "stock_status_res"}},
+					{Name: "amount", Type: dtype.DATATYPE_DOUBLE, MappedField: cond.Field{Name: "amount_res"}},
+				},
+			},
+		}
+		def := &interfaces.MetricDefinition{
+			CalculationFormula: &interfaces.MetricCalculationFormula{
+				Condition: &cond.CondCfg{
+					Operation: cond.OperationIn,
+					Name:      "warehouse",
+					ValueOptCfg: cond.ValueOptCfg{Value: []any{"昆山成品仓"}},
+				},
+				Aggregation: interfaces.MetricAggregation{Property: "amount", Aggr: interfaces.MetricAggrSum},
+			},
+		}
+
+		Convey("empty query body uses definition condition only\n", func() {
+			params, _, err := svc.buildResourceDataQueryParams(ctx, def, &interfaces.MetricQueryRequest{}, ot)
+			So(err, ShouldBeNil)
+			So(params.FilterCondition["operation"], ShouldEqual, cond.OperationIn)
+			So(params.FilterCondition["field"], ShouldEqual, "warehouse_res")
+		})
+
+		Convey("query-time condition ANDs with definition condition\n", func() {
+			params, _, err := svc.buildResourceDataQueryParams(ctx, def, &interfaces.MetricQueryRequest{
+				Condition: &cond.CondCfg{
+					Operation: cond.OperationEq,
+					Name:      "stock_status",
+					ValueOptCfg: cond.ValueOptCfg{
+						Value: "可用",
+					},
+				},
+			}, ot)
+			So(err, ShouldBeNil)
+			So(params.FilterCondition["operation"], ShouldEqual, cond.OperationAnd)
+			subs, ok := params.FilterCondition["sub_conditions"].([]any)
+			So(ok, ShouldBeTrue)
+			So(len(subs), ShouldEqual, 2)
+		})
+	})
+}
+
 func Test_metricQueryService_buildResourceDataQueryParams_analysisDimensions(t *testing.T) {
 	Convey("buildResourceDataQueryParams pushes analysis_dimensions to group_by\n", t, func() {
 		ctx := context.Background()

--- a/adp/bkn/ontology-query/server/logics/metric/metric_query_service_test.go
+++ b/adp/bkn/ontology-query/server/logics/metric/metric_query_service_test.go
@@ -172,6 +172,43 @@ func Test_buildResourceDataQueryParams_conditionMerge(t *testing.T) {
 			So(ok, ShouldBeTrue)
 			So(len(subs), ShouldEqual, 2)
 		})
+
+		Convey("definition, query-time, and time conditions nest as two-level AND\n", func() {
+			defTime := *def
+			defTime.TimeDimension = &interfaces.MetricTimeDimension{Property: "evt_time"}
+			otTime := ot
+			otTime.DataProperties = append(otTime.DataProperties,
+				cond.DataProperty{Name: "evt_time", Type: dtype.DATATYPE_DATETIME, MappedField: cond.Field{Name: "evt_time_res"}},
+			)
+			instant := true
+			start := int64(1_000)
+			end := int64(2_000)
+			params, _, err := svc.buildResourceDataQueryParams(ctx, &defTime, &interfaces.MetricQueryRequest{
+				Condition: &cond.CondCfg{
+					Operation:   cond.OperationEq,
+					Name:        "stock_status",
+					ValueOptCfg: cond.ValueOptCfg{Value: "可用"},
+				},
+				Time: &interfaces.MetricTimeWindow{
+					Start: &start, End: &end, Instant: &instant,
+				},
+			}, otTime)
+			So(err, ShouldBeNil)
+			So(params.FilterCondition["operation"], ShouldEqual, cond.OperationAnd)
+			topSubs, ok := params.FilterCondition["sub_conditions"].([]any)
+			So(ok, ShouldBeTrue)
+			So(len(topSubs), ShouldEqual, 2)
+			defQueryAnd, ok := topSubs[0].(map[string]any)
+			So(ok, ShouldBeTrue)
+			So(defQueryAnd["operation"], ShouldEqual, cond.OperationAnd)
+			innerSubs, ok := defQueryAnd["sub_conditions"].([]any)
+			So(ok, ShouldBeTrue)
+			So(len(innerSubs), ShouldEqual, 2)
+			timeLeaf, ok := topSubs[1].(map[string]any)
+			So(ok, ShouldBeTrue)
+			So(timeLeaf["operation"], ShouldEqual, cond.OperationRange)
+			So(timeLeaf["field"], ShouldEqual, "evt_time_res")
+		})
 	})
 }
 

--- a/docs/api/bkn/bkn-metrics.yaml
+++ b/docs/api/bkn/bkn-metrics.yaml
@@ -27,6 +27,8 @@ info:
 
     契约见 [`ontology-query.yaml`](../ontology-query/ontology-query.yaml)
     （paths：`.../metrics/{metric_id}/data`、`.../metrics/dry-run`；schemas：`MetricQueryRequestBody`、`MetricDryRun`）。
+    **condition 合并、analysis_dimensions 与 group_by 关系**见 ontology-query 中
+    `POST .../metrics/{metric_id}/data` 的 description 与 `MetricQueryRequestBody` schema 说明。
 
     产品侧注意：对象**实例**页的「执行」面向逻辑属性；对象类级总量指标应走上述 metric data / dry-run，而非实例执行入口。
 paths:

--- a/docs/api/ontology-query/ontology-query.yaml
+++ b/docs/api/ontology-query/ontology-query.yaml
@@ -2766,6 +2766,26 @@ paths:
   /api/ontology-query/v1/knowledge-networks/{kn_id}/metrics/{metric_id}/data:
     post:
       summary: 查询指标数据（BKN 原生指标）
+      description: |
+        查询已落库的 **object_type 作用域 atomic 指标**（定义见 bkn-backend `MetricDefinition`）。
+
+        ## 定义内过滤 vs 查询时过滤
+
+        执行时将以下条件 **按 AND 合并**（不是覆盖）后下推到 Vega/resource：
+
+        1. `MetricDefinition.calculation_formula.condition`（定义内口径，稳定 KPI）
+        2. 本请求体 `condition`（查询时下钻 / 临时收窄）
+        3. 由 `time` 或 `time_dimension.default_range_policy` 推导的时间范围条件（instant / 趋势查询时）
+
+        合并规则：`merged = AND(definition.condition, request.condition, timeCondition)`；任一侧为空则省略。
+
+        ## analysis_dimensions 与 group_by
+
+        - `calculation_formula.group_by`：定义内的**固定分组基线**，每次查询都会参与 group_by。
+        - `analysis_dimensions`（请求体）：在指标 `analysis_dimensions` 白名单内的**追加下钻维度**，按请求顺序接在 group_by 之后；未知维度名忽略。
+        - 趋势查询（`time.instant=false` 且提供 `time.step`）会额外追加时间分桶维度。
+
+        建模 CRUD 与能力矩阵见 [`bkn-metrics.yaml`](../bkn/bkn-metrics.yaml)；对象类级总量指标应使用本接口，而非对象实例页的 logic-property 执行入口。
       parameters:
         - name: kn_id
           in: path
@@ -2797,6 +2817,31 @@ paths:
           application/json:
             schema:
               $ref: "#/components/schemas/MetricQueryRequestBody"
+            examples:
+              对象类总量（无查询时过滤）:
+                summary: 仅使用定义内 condition；body 可为空对象
+                value: {}
+              查询时单条件过滤:
+                summary: 与定义内 condition AND 合并
+                value:
+                  condition:
+                    operation: eq
+                    field: product_code
+                    value: P-001
+              查询时下钻 analysis_dimensions:
+                summary: 在定义 group_by 基线上追加分组维
+                value:
+                  analysis_dimensions:
+                    - warehouse_id
+                    - stock_status
+              趋势查询（time 窗口）:
+                summary: instant=false 时需提供 start/end/step；与定义 time_dimension 配合
+                value:
+                  time:
+                    start: 1735689600000
+                    end: 1738368000000
+                    instant: false
+                    step: day
       responses:
         "200":
           description: ok
@@ -2804,6 +2849,38 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/MetricData"
+              examples:
+                标量总量:
+                  summary: 无分组时的单序列结果
+                  value:
+                    model:
+                      unit_type: numUnit
+                      unit: none
+                    datas:
+                      - labels: {}
+                        times: []
+                        values: [431]
+                    step: ""
+                    is_variable: false
+                    is_calendar: false
+                分组下钻:
+                  summary: 带 analysis_dimensions 时的多序列
+                  value:
+                    model:
+                      unit_type: numUnit
+                      unit: none
+                    datas:
+                      - labels:
+                          warehouse_id: wh-east
+                        times: []
+                        values: [120]
+                      - labels:
+                          warehouse_id: wh-west
+                        times: []
+                        values: [85]
+                    step: ""
+                    is_variable: false
+                    is_calendar: false
         "400":
           description: bad request
           content:
@@ -5338,7 +5415,13 @@ components:
 
     MetricQueryRequestBody:
       description: |
-        指标查询请求体（metric_id 在路径）。与 uniquery MetricQuery 对齐的时间/分析等 + BKN Condition；含 limit 截断序列条数；不含 scope_context。
+        指标查询请求体（`metric_id` 在路径）。与 uniquery MetricQuery 对齐的时间/分析等 + BKN Condition；含 `limit` 截断序列条数；不含 scope_context。
+
+        **condition 合并**：与 `MetricDefinition.calculation_formula.condition` 及时间推导条件 **AND** 合并，详见
+        `POST .../metrics/{metric_id}/data` 的 operation description。
+
+        **analysis_dimensions**：仅可引用指标定义中 `analysis_dimensions[].name` 已声明的维度；在
+        `calculation_formula.group_by` 之后按请求顺序追加 group_by。
       type: object
       properties:
         time:

--- a/docs/api/ontology-query/ontology-query.yaml
+++ b/docs/api/ontology-query/ontology-query.yaml
@@ -2777,13 +2777,14 @@ paths:
         2. 本请求体 `condition`（查询时下钻 / 临时收窄）
         3. 由 `time` 或 `time_dimension.default_range_policy` 推导的时间范围条件（instant / 趋势查询时）
 
-        合并规则：`merged = AND(definition.condition, request.condition, timeCondition)`；任一侧为空则省略。
+        合并规则：语义上等价于 `AND(definition.condition, request.condition, timeCondition)`，任一侧为空则省略。
+        实现上为**两层嵌套**（先合并 definition 与 request，再与时间条件 AND），下推 filter 可能出现 `sub_conditions` 嵌套，而非扁平三元组。
 
         ## analysis_dimensions 与 group_by
 
         - `calculation_formula.group_by`：定义内的**固定分组基线**，每次查询都会参与 group_by。
         - `analysis_dimensions`（请求体）：在指标 `analysis_dimensions` 白名单内的**追加下钻维度**，按请求顺序接在 group_by 之后；未知维度名忽略。
-        - 趋势查询（`time.instant=false` 且提供 `time.step`）会额外追加时间分桶维度。
+        - 趋势查询（`time.instant` 为 false **或省略**，且提供 `time.step`）会额外追加时间分桶维度。
 
         建模 CRUD 与能力矩阵见 [`bkn-metrics.yaml`](../bkn/bkn-metrics.yaml)；对象类级总量指标应使用本接口，而非对象实例页的 logic-property 执行入口。
       parameters:
@@ -2851,20 +2852,20 @@ paths:
                 $ref: "#/components/schemas/MetricData"
               examples:
                 标量总量:
-                  summary: 无分组时的单序列结果
+                  summary: 无分组时的 instant 单序列（body 为 {} 时 time.end 缺省，times 为 [0]）
                   value:
                     model:
                       unit_type: numUnit
                       unit: none
                     datas:
                       - labels: {}
-                        times: []
+                        times: [0]
                         values: [431]
                     step: ""
                     is_variable: false
                     is_calendar: false
                 分组下钻:
-                  summary: 带 analysis_dimensions 时的多序列
+                  summary: 带 analysis_dimensions 时的多序列（instant 分支 times 恒为单元素数组）
                   value:
                     model:
                       unit_type: numUnit
@@ -2872,11 +2873,11 @@ paths:
                     datas:
                       - labels:
                           warehouse_id: wh-east
-                        times: []
+                        times: [0]
                         values: [120]
                       - labels:
                           warehouse_id: wh-west
-                        times: []
+                        times: [0]
                         values: [85]
                     step: ""
                     is_variable: false
@@ -2897,6 +2898,10 @@ paths:
   /api/ontology-query/v1/knowledge-networks/{kn_id}/metrics/dry-run:
     post:
       summary: 指标试算（不落库）
+      description: |
+        运行时字段（`time` / `condition` / `analysis_dimensions` 等）与
+        `POST .../metrics/{metric_id}/data` 的 `MetricQueryRequestBody` **合并语义完全一致**；
+        区别仅在于 definition 侧取自请求体 `metric_config`（含 `calculation_formula.condition`），而非落库定义。
       parameters:
         - name: kn_id
           in: path
@@ -5435,6 +5440,7 @@ components:
               format: int64
             instant:
               type: boolean
+              description: 是否 instant 查询；省略等同 false（即趋势查询，须提供 step）
             step:
               type: string
         condition:
@@ -5505,7 +5511,10 @@ components:
             type: object
 
     MetricDryRun:
-      description: 指标试算：metric_config 与 MetricDefinition 同构；运行时字段与 MetricQueryRequestBody 对齐
+      description: |
+        指标试算：`metric_config` 与 MetricDefinition 同构；运行时字段与 `MetricQueryRequestBody` 对齐。
+        **condition 合并**与 `POST .../metrics/{metric_id}/data` 相同——definition 侧取
+        `metric_config.calculation_formula.condition`，再与 body 的 `condition`、时间推导条件 AND 合并。
       type: object
       required:
         - metric_config


### PR DESCRIPTION
## Summary

- Document metric query **condition merge** (definition ∩ query ∩ time = **AND**) and **analysis_dimensions** vs `group_by` semantics in `ontology-query.yaml`.
- Add request/response examples for total count, query-time filter, analysis_dimensions drill-down, and trend time window.
- Cross-link from `bkn-metrics.yaml` to the query contract.
- Add unit tests for `mergeConditions` and definition + query-time condition merge in `buildResourceDataQueryParams`.

Closes #596 (backend + docs scope). Product console entry is tracked separately by frontend.

## What Changed

- [x] `docs/api/ontology-query/ontology-query.yaml` — path description, examples, `MetricQueryRequestBody` schema notes
- [x] `docs/api/bkn/bkn-metrics.yaml` — cross-link to merge semantics
- [x] `ontology-query/logics/metric/metric_query_service_test.go` — condition merge tests

## Why

Issue #596: application teams need a clear contract for object_type-level metric query (definition vs query-time filtering) and regression coverage. Query engine already implemented AND merge; this PR documents and tests it.

## Testing

- [x] Unit tests passed locally

```bash
cd adp/bkn/ontology-query/server
I18N_MODE_UT=true go test ./logics/metric/ -run "mergeConditions|conditionMerge|analysisDimensions" -v
```

## Risk & Rollback

- **Risk:** Low — documentation and tests only; no runtime behavior change.
- **Rollback:** Revert commit.

## Additional Notes

- Label: `by-agent`
- Frontend console UX remains out of scope for this PR.
