### PR TITLE
fix(mf-model): support Doubao vision embedding batches

### DIFF
--- a/infra/mf-model-api/app/controller/small_model_controller.py
+++ b/infra/mf-model-api/app/controller/small_model_controller.py
@@ -76,6 +76,7 @@ async def test_model(request, userId, language, role):
             model_type = model_info[0]["f_model_type"]
             adapter = model_info[0]["f_adapter"]
             adapter_code = model_info[0]["f_adapter_code"]
+            embedding_dim = model_info[0].get("f_embedding_dim")
             api_model = config_info.get("api_model", "")
         else:
             resource_id = "*"
@@ -84,6 +85,7 @@ async def test_model(request, userId, language, role):
             api_model = config_info.get("api_model", "")
             adapter = request.adapter
             adapter_code = request.adapter_code
+            embedding_dim = None
         try:
             # permission = await permission_manager.check_single_permission(user_id=userId, resource_id=resource_id,
             #                                                               operations="execute",
@@ -92,7 +94,8 @@ async def test_model(request, userId, language, role):
             #     return JSONResponse(status_code=403, content=NotPermissionError)
             client = InnerClient(url=config_info.get("api_url", ""), model_name=api_model,
                                  api_key=config_info.get("api_key", ""),
-                                 adapter=adapter, adapter_code=adapter_code)
+                                 adapter=adapter, adapter_code=adapter_code,
+                                 embedding_dim=embedding_dim)
             if model_type == "embedding":
                 texts = ["hello"]
                 await client.test_embedding(texts=texts)
@@ -380,6 +383,13 @@ async def embedding_model_used(request, userId, language, role, func_module, pri
                 return JSONResponse(status_code=400, content=ModelFactory_ExternalSmallModel_Used_NameNotExist)
             # 设置缓存
             await redis_util.set_str(key=cache_key, value=str(model_info), expire=3600 * 24)
+        # Refresh records written by older mf-model-api instances, whose query did
+        # not include f_embedding_dim. This keeps rolling upgrades dimension-safe.
+        if model_info and "f_embedding_dim" not in model_info[0]:
+            model_info = small_model_dao.get_model_info_by_name_id(model_name, model_id)
+            if len(model_info) == 0:
+                return JSONResponse(status_code=400, content=ModelFactory_ExternalSmallModel_Used_NameNotExist)
+            await redis_util.set_str(key=cache_key, value=str(model_info), expire=3600 * 24)
         model_info = model_info[0]
         config_info = json.loads(model_info["f_model_config"])
         adapter = model_info["f_adapter"]
@@ -393,7 +403,8 @@ async def embedding_model_used(request, userId, language, role, func_module, pri
             if not permission:
                 return JSONResponse(status_code=403, content=NotPermissionError)
         client = InnerClient(url=config_info.get("api_url", ""), model_name=config_info.get("api_model", ""),
-                             api_key=config_info.get("api_key", ""), adapter=adapter, adapter_code=adapter_code)
+                             api_key=config_info.get("api_key", ""), adapter=adapter, adapter_code=adapter_code,
+                             embedding_dim=model_info.get("f_embedding_dim"))
         res_dict = await client.embedding(texts)
         prompt_tokens = res_dict.get("usage", {}).get("prompt_tokens")
         total_tokens = res_dict.get("usage", {}).get("total_tokens")
@@ -406,7 +417,10 @@ async def embedding_model_used(request, userId, language, role, func_module, pri
     except UpstreamModelError as e:
         status_code = e.status if e.status in (400, 401, 403, 404, 422, 429) else 502
         error_dict = ModelFactory_ExternalSmallModel_Used_ConnectError.copy()
-        error_dict["detail"] = f"模型服务调用失败（HTTP {e.status}）"
+        error_dict["detail"] = e.detail
+        StandLogger.error(
+            f"call embeddingError,model_name={model_name},model_id={model_id},"
+            f"status={e.status},error_detail={e.detail}")
         if get_logger():
             get_logger().info(
                 f'{{"model_name":{model_name},"resourece_type":"embeddings","user_id":{userId},'
@@ -414,7 +428,7 @@ async def embedding_model_used(request, userId, language, role, func_module, pri
         return JSONResponse(status_code=status_code, content=error_dict)
     except Exception as e:
         StandLogger.error(
-            f"call embeddingError,model_name={model_name},model_id={model_id},error_detail={e},body={texts}")
+            f"call embeddingError,model_name={model_name},model_id={model_id},error_detail={e}")
         error_dict = ModelFactory_ExternalSmallModel_UnknownError.copy()
         error_dict["detail"] = str(e)
         if get_logger():

--- a/infra/mf-model-api/app/controller/small_model_controller.py
+++ b/infra/mf-model-api/app/controller/small_model_controller.py
@@ -7,7 +7,7 @@ from app.core.config import base_config
 from app.dao.small_model_dao import small_model_dao
 from app.interfaces import dbaccess, logics
 from app.logs.stand_log import StandLogger
-from app.utils.external_small_model_utils import BaiduClient, BaishengClient, InnerClient, BaiduTianchenClient
+from app.utils.external_small_model_utils import BaiduClient, BaishengClient, InnerClient, BaiduTianchenClient, UpstreamModelError
 from app.utils.observability.observability_log import get_logger
 from app.utils.param_verify_utils import *
 from app.utils.reshape_utils import *
@@ -82,7 +82,7 @@ async def test_model(request, userId, language, role):
             config_info = request.model_config
             model_type = request.model_type
             api_model = config_info.get("api_model", "")
-            adapter = request.adapter,
+            adapter = request.adapter
             adapter_code = request.adapter_code
         try:
             # permission = await permission_manager.check_single_permission(user_id=userId, resource_id=resource_id,
@@ -403,6 +403,15 @@ async def embedding_model_used(request, userId, language, role, func_module, pri
                 f'"prompt_tokens":{prompt_tokens},"total_tokens":{total_tokens},"func_module":{func_module},"status":"success"}}')
         return res_dict
 
+    except UpstreamModelError as e:
+        status_code = e.status if e.status in (400, 401, 403, 404, 422, 429) else 502
+        error_dict = ModelFactory_ExternalSmallModel_Used_ConnectError.copy()
+        error_dict["detail"] = f"模型服务调用失败（HTTP {e.status}）"
+        if get_logger():
+            get_logger().info(
+                f'{{"model_name":{model_name},"resourece_type":"embeddings","user_id":{userId},'
+                f'"prompt_tokens":0,"total_tokens":0,"func_module":{func_module},"status":"failed"}}')
+        return JSONResponse(status_code=status_code, content=error_dict)
     except Exception as e:
         StandLogger.error(
             f"call embeddingError,model_name={model_name},model_id={model_id},error_detail={e},body={texts}")

--- a/infra/mf-model-api/app/dao/small_model_dao.py
+++ b/infra/mf-model-api/app/dao/small_model_dao.py
@@ -16,7 +16,7 @@ class SmallModelDao:
 
     @connect_execute_close_db
     def get_model_info_by_id(self, model_id, connection, cursor):
-        sql = """select f_model_id, f_model_name, f_model_type, f_model_config, f_create_time, f_update_time,f_adapter, f_adapter_code 
+        sql = """select f_model_id, f_model_name, f_model_type, f_model_config, f_create_time, f_update_time,f_adapter, f_adapter_code, f_embedding_dim
                     from t_small_model where f_model_id = %s"""
 
         cursor.execute(sql, model_id)
@@ -41,7 +41,7 @@ class SmallModelDao:
 
     @connect_execute_close_db
     def get_model_info_by_name_id(self, model_name, model_id, connection, cursor):
-        sql = """select f_model_id, f_model_name, f_model_type, f_model_config,f_adapter,f_adapter_code
+        sql = """select f_model_id, f_model_name, f_model_type, f_model_config,f_adapter,f_adapter_code,f_embedding_dim
                             from t_small_model"""
         if model_name:
             sql += f" where f_model_name = '{model_name}'"

--- a/infra/mf-model-api/app/test/test_volcengine_embedding.py
+++ b/infra/mf-model-api/app/test/test_volcengine_embedding.py
@@ -15,11 +15,17 @@ class _Response:
         return False
 
     async def text(self):
+        if self.status != 200:
+            return json.dumps({"error": {"message": "rate limit exceeded"}})
         return json.dumps({
             "object": "list",
             "data": {"object": "embedding", "embedding": [0.1] * 1024},
             "model": "doubao-embedding-vision-251215",
-            "usage": {"prompt_tokens": 1, "total_tokens": 1},
+            "usage": {
+                "prompt_tokens": 1,
+                "total_tokens": 1,
+                "prompt_tokens_details": {"text_tokens": 1},
+            },
         })
 
 
@@ -48,6 +54,7 @@ def test_volcengine_embedding_uses_multimodal_request_and_normalizes_response(mo
         url="https://ark.cn-beijing.volces.com/api/v3/embeddings/multimodal",
         model_name="doubao-embedding-vision-251215",
         api_key="test-key",
+        embedding_dim=1024,
     )
 
     result = asyncio.run(client.embedding(["Hi, who are you?"]))
@@ -69,6 +76,7 @@ def test_volcengine_embedding_batches_texts_as_single_item_requests(monkeypatch)
         url="https://ark.cn-beijing.volces.com/api/v3/embeddings/multimodal",
         model_name="doubao-embedding-vision-251215",
         api_key="test-key",
+        embedding_dim=1024,
     )
 
     result = asyncio.run(client.embedding(["first", "second"]))
@@ -78,6 +86,9 @@ def test_volcengine_embedding_batches_texts_as_single_item_requests(monkeypatch)
         [{"type": "text", "text": "second"}],
     ]
     assert [item["index"] for item in result["data"]] == [0, 1]
+    assert result["usage"]["prompt_tokens"] == 2
+    assert result["usage"]["total_tokens"] == 2
+    assert result["usage"]["prompt_tokens_details"]["text_tokens"] == 2
 
 
 def test_volcengine_embedding_preserves_upstream_error_status(monkeypatch):
@@ -94,6 +105,30 @@ def test_volcengine_embedding_preserves_upstream_error_status(monkeypatch):
         assert False, "expected an upstream error"
     except external_small_model_utils.UpstreamModelError as error:
         assert error.status == 429
+        assert error.detail == "rate limit exceeded"
+
+
+def test_volcengine_embedding_uses_configured_dimension():
+    client = external_small_model_utils.InnerClient(
+        url="https://ark.cn-beijing.volces.com/api/v3/embeddings/multimodal",
+        model_name="doubao-embedding-vision-250615",
+        api_key="test-key",
+        embedding_dim=2048,
+    )
+
+    assert client._embedding_params(["hello"])["dimensions"] == 2048
+
+
+def test_volcengine_embedding_omits_unspecified_dimension():
+    client = external_small_model_utils.InnerClient(
+        url="https://ark.cn-beijing.volces.com/api/v3/embeddings/multimodal",
+        model_name="ep-20240604000000-abcde",
+        api_key="test-key",
+    )
+
+    params = client._embedding_params(["hello"])
+    assert "dimensions" not in params
+    assert params["input"] == [{"type": "text", "text": "hello"}]
 
 
 def test_non_vision_doubao_embedding_preserves_openai_text_request(monkeypatch):

--- a/infra/mf-model-api/app/test/test_volcengine_embedding.py
+++ b/infra/mf-model-api/app/test/test_volcengine_embedding.py
@@ -1,0 +1,113 @@
+import asyncio
+import json
+
+from app.utils import external_small_model_utils
+
+
+class _Response:
+    def __init__(self, status=200):
+        self.status = status
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return False
+
+    async def text(self):
+        return json.dumps({
+            "object": "list",
+            "data": {"object": "embedding", "embedding": [0.1] * 1024},
+            "model": "doubao-embedding-vision-251215",
+            "usage": {"prompt_tokens": 1, "total_tokens": 1},
+        })
+
+
+class _Session:
+    def __init__(self, status=200):
+        self.status = status
+        self.post_kwargs = None
+        self.post_kwargs_list = []
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return False
+
+    def post(self, *args, **kwargs):
+        self.post_kwargs = kwargs
+        self.post_kwargs_list.append(kwargs)
+        return _Response(self.status)
+
+
+def test_volcengine_embedding_uses_multimodal_request_and_normalizes_response(monkeypatch):
+    session = _Session()
+    monkeypatch.setattr(external_small_model_utils.aiohttp, "ClientSession", lambda **kwargs: session)
+    client = external_small_model_utils.InnerClient(
+        url="https://ark.cn-beijing.volces.com/api/v3/embeddings/multimodal",
+        model_name="doubao-embedding-vision-251215",
+        api_key="test-key",
+    )
+
+    result = asyncio.run(client.embedding(["Hi, who are you?"]))
+
+    assert session.post_kwargs["json"] == {
+        "model": "doubao-embedding-vision-251215",
+        "input": [{"type": "text", "text": "Hi, who are you?"}],
+        "dimensions": 1024,
+    }
+    assert isinstance(result["data"], list)
+    assert len(result["data"][0]["embedding"]) == 1024
+    assert result["data"][0]["index"] == 0
+
+
+def test_volcengine_embedding_batches_texts_as_single_item_requests(monkeypatch):
+    session = _Session()
+    monkeypatch.setattr(external_small_model_utils.aiohttp, "ClientSession", lambda **kwargs: session)
+    client = external_small_model_utils.InnerClient(
+        url="https://ark.cn-beijing.volces.com/api/v3/embeddings/multimodal",
+        model_name="doubao-embedding-vision-251215",
+        api_key="test-key",
+    )
+
+    result = asyncio.run(client.embedding(["first", "second"]))
+
+    assert [request["json"]["input"] for request in session.post_kwargs_list] == [
+        [{"type": "text", "text": "first"}],
+        [{"type": "text", "text": "second"}],
+    ]
+    assert [item["index"] for item in result["data"]] == [0, 1]
+
+
+def test_volcengine_embedding_preserves_upstream_error_status(monkeypatch):
+    session = _Session(status=429)
+    monkeypatch.setattr(external_small_model_utils.aiohttp, "ClientSession", lambda **kwargs: session)
+    client = external_small_model_utils.InnerClient(
+        url="https://ark.cn-beijing.volces.com/api/v3/embeddings/multimodal",
+        model_name="doubao-embedding-vision-251215",
+        api_key="test-key",
+    )
+
+    try:
+        asyncio.run(client.embedding(["rate limited"]))
+        assert False, "expected an upstream error"
+    except external_small_model_utils.UpstreamModelError as error:
+        assert error.status == 429
+
+
+def test_non_vision_doubao_embedding_preserves_openai_text_request(monkeypatch):
+    session = _Session()
+    monkeypatch.setattr(external_small_model_utils.aiohttp, "ClientSession", lambda **kwargs: session)
+    client = external_small_model_utils.InnerClient(
+        url="https://ark.cn-beijing.volces.com/api/v3/embeddings",
+        model_name="doubao-embedding-250615",
+        api_key="test-key",
+    )
+
+    asyncio.run(client.embedding(["Hi, who are you?"]))
+
+    assert session.post_kwargs["json"] == {
+        "model": "doubao-embedding-250615",
+        "input": ["Hi, who are you?"],
+    }

--- a/infra/mf-model-api/app/utils/external_small_model_utils.py
+++ b/infra/mf-model-api/app/utils/external_small_model_utils.py
@@ -1,3 +1,4 @@
+import asyncio
 import json
 
 import aiohttp
@@ -13,9 +14,23 @@ class UpstreamModelError(Exception):
     """Provider error with an HTTP status suitable for gateway mapping."""
 
     def __init__(self, status, detail):
-        super().__init__(detail)
+        raw_detail = str(detail)
+        message = raw_detail
+        try:
+            payload = json.loads(raw_detail)
+            error = payload.get("error") if isinstance(payload, dict) else None
+            if isinstance(error, dict):
+                message = error.get("message") or error.get("code") or raw_detail
+            elif isinstance(error, str):
+                message = error
+            elif isinstance(payload, dict):
+                message = payload.get("message") or payload.get("error_msg") or raw_detail
+        except (TypeError, ValueError):
+            pass
+        message = str(message)[:2000]
+        super().__init__(message)
         self.status = status
-        self.detail = detail
+        self.detail = message
 
 
 class BaiduTianchenClient:
@@ -247,7 +262,10 @@ class BaishengClient:
 
 
 class InnerClient:
-    def __init__(self, url, model_name, api_key="", adapter=False, adapter_code=None):
+    VOLCENGINE_MAX_CONCURRENCY = 10
+
+    def __init__(self, url, model_name, api_key="", adapter=False, adapter_code=None,
+                 embedding_dim=None):
         if not url.startswith(('http://', 'https://')):
             url = f"http://{url}"
         self.url = url
@@ -258,23 +276,27 @@ class InnerClient:
         }
         self.adapter = adapter
         self.adapter_code = adapter_code
+        self.embedding_dim = int(embedding_dim) if embedding_dim is not None else None
 
     def _is_volcengine_embedding(self):
         # Only the vision family uses Ark's multimodal embeddings endpoint.
         # Other Doubao embedding models retain the OpenAI-compatible text body.
-        return self.model_name.startswith("doubao-embedding-vision-")
+        return (self.model_name.startswith("doubao-embedding-vision-") or
+                "/embeddings/multimodal" in self.url)
 
     def _embedding_params(self, texts):
         """Build the provider-specific embedding request body."""
         if self._is_volcengine_embedding():
-            return {
+            params = {
                 "model": self.model_name,
                 "input": [
                     text if isinstance(text, dict) else {"type": "text", "text": text}
                     for text in texts
                 ],
-                "dimensions": 1024,
             }
+            if self.embedding_dim is not None:
+                params["dimensions"] = self.embedding_dim
+            return params
         return {
             "model": self.model_name,
             "input": texts,
@@ -282,13 +304,17 @@ class InnerClient:
 
     def _normalize_volcengine_embedding_response(self, result):
         """Normalize Ark's single-object data field to the OpenAI-style list."""
-        if self._is_volcengine_embedding() and isinstance(result.get("data"), dict):
+        if (self._is_volcengine_embedding() and isinstance(result, dict) and
+                isinstance(result.get("data"), dict)):
             result["data"] = [result["data"]]
         return result
 
     def _validate_volcengine_embedding_response(self, result, expected_count=1):
         """Validate the response shape consumed by mf-model-api callers."""
         result = self._normalize_volcengine_embedding_response(result)
+        required_keys = ("object", "data", "model", "usage")
+        if not isinstance(result, dict) or not all(key in result for key in required_keys):
+            raise ValueError("Invalid Volcengine embedding response: missing required fields")
         data = result.get("data") if isinstance(result, dict) else None
         if not isinstance(data, list) or len(data) != expected_count:
             raise ValueError(
@@ -298,7 +324,26 @@ class InnerClient:
                 len(item["embedding"]) > 0
                 for item in data):
             raise ValueError("Invalid Volcengine embedding response: invalid embedding data")
+        for index, item in enumerate(data):
+            if self.embedding_dim is not None and len(item["embedding"]) != self.embedding_dim:
+                raise ValueError(
+                    "Invalid Volcengine embedding response: "
+                    f"expected dimension {self.embedding_dim}, got {len(item['embedding'])}")
+            item["index"] = index
         return result
+
+    @classmethod
+    def _merge_usage_values(cls, values):
+        if values and all(isinstance(value, (int, float)) for value in values):
+            return sum(values)
+        if values and all(isinstance(value, dict) for value in values):
+            keys = dict.fromkeys(key for value in values for key in value)
+            return {
+                key: cls._merge_usage_values(
+                    [value[key] for value in values if key in value])
+                for key in keys
+            }
+        return values[0] if values else None
 
     async def _post_embedding(self, session, texts):
         async with session.post(
@@ -306,9 +351,11 @@ class InnerClient:
                 json=self._embedding_params(texts), headers=self.headers, ssl=False) as resp:
             res = await resp.text()
             if resp.status != 200:
+                error = UpstreamModelError(resp.status, res)
                 StandLogger.error(
-                    f"call embeddingError,model_name={self.model_name},status={resp.status}")
-                raise UpstreamModelError(resp.status, res)
+                    f"call embeddingError,model_name={self.model_name},status={resp.status},"
+                    f"error_detail={error.detail}")
+                raise error
             return json.loads(res)
 
     async def _volcengine_text_embeddings(self, texts):
@@ -316,28 +363,24 @@ class InnerClient:
         if not texts:
             raise ValueError("Volcengine embedding input must not be empty")
 
+        semaphore = asyncio.Semaphore(self.VOLCENGINE_MAX_CONCURRENCY)
         async with aiohttp.ClientSession(timeout=base_config.aiohttp_timeout) as session:
-            results = []
-            for index, text in enumerate(texts):
-                result = self._validate_volcengine_embedding_response(
-                    await self._post_embedding(session, [text]))
+            async def embed_one(index, text):
+                async with semaphore:
+                    result = self._validate_volcengine_embedding_response(
+                        await self._post_embedding(session, [text]))
                 item = result["data"][0]
                 item["index"] = index
-                results.append((result, item))
+                return result, item
+
+            results = await asyncio.gather(*(
+                embed_one(index, text) for index, text in enumerate(texts)))
 
         response = results[0][0]
         response["data"] = [item for _, item in results]
-        usage = response.get("usage")
-        if isinstance(usage, dict):
-            response["usage"] = {
-                key: sum(
-                    result.get("usage", {}).get(key, 0)
-                    for result, _ in results
-                    if isinstance(result.get("usage"), dict) and
-                    isinstance(result["usage"].get(key, 0), (int, float))
-                ) if isinstance(value, (int, float)) else value
-                for key, value in usage.items()
-            }
+        usage_values = [result.get("usage") for result, _ in results]
+        if all(isinstance(usage, dict) for usage in usage_values):
+            response["usage"] = self._merge_usage_values(usage_values)
         return response
 
     async def embedding(self, texts):
@@ -411,17 +454,10 @@ class InnerClient:
                 raise Exception(f"Adapter execution failed: {str(e)}")
 
         else:
-            params = self._embedding_params(texts)
             async with aiohttp.ClientSession(timeout=base_config.aiohttp_timeout) as session:
-                async with session.post(
-                        self.url,
-                        json=params, headers=self.headers, ssl=False) as resp:
-                    if resp.status == 422:
-                        raise Exception("string_too_long,String should have at most 122880 characters")
-                    if resp.status != 200:
-                        raise Exception(resp.content)
-                    res = await resp.text()
-                    result = self._normalize_volcengine_embedding_response(json.loads(res))
+                result = await self._post_embedding(session, texts)
+            if self._is_volcengine_embedding():
+                result = self._validate_volcengine_embedding_response(result)
         required_keys = ["object", "data", "model", "usage"]
         if not all(key in result for key in required_keys):
             raise ValueError(f"Invalid adapter response format, missing one of: {required_keys}")

--- a/infra/mf-model-api/app/utils/external_small_model_utils.py
+++ b/infra/mf-model-api/app/utils/external_small_model_utils.py
@@ -9,6 +9,15 @@ from app.core.config import base_config
 from app.logs.stand_log import StandLogger
 
 
+class UpstreamModelError(Exception):
+    """Provider error with an HTTP status suitable for gateway mapping."""
+
+    def __init__(self, status, detail):
+        super().__init__(detail)
+        self.status = status
+        self.detail = detail
+
+
 class BaiduTianchenClient:
     def __init__(self, url, ClientId, OperationCode):
         self.url = url
@@ -250,6 +259,87 @@ class InnerClient:
         self.adapter = adapter
         self.adapter_code = adapter_code
 
+    def _is_volcengine_embedding(self):
+        # Only the vision family uses Ark's multimodal embeddings endpoint.
+        # Other Doubao embedding models retain the OpenAI-compatible text body.
+        return self.model_name.startswith("doubao-embedding-vision-")
+
+    def _embedding_params(self, texts):
+        """Build the provider-specific embedding request body."""
+        if self._is_volcengine_embedding():
+            return {
+                "model": self.model_name,
+                "input": [
+                    text if isinstance(text, dict) else {"type": "text", "text": text}
+                    for text in texts
+                ],
+                "dimensions": 1024,
+            }
+        return {
+            "model": self.model_name,
+            "input": texts,
+        }
+
+    def _normalize_volcengine_embedding_response(self, result):
+        """Normalize Ark's single-object data field to the OpenAI-style list."""
+        if self._is_volcengine_embedding() and isinstance(result.get("data"), dict):
+            result["data"] = [result["data"]]
+        return result
+
+    def _validate_volcengine_embedding_response(self, result, expected_count=1):
+        """Validate the response shape consumed by mf-model-api callers."""
+        result = self._normalize_volcengine_embedding_response(result)
+        data = result.get("data") if isinstance(result, dict) else None
+        if not isinstance(data, list) or len(data) != expected_count:
+            raise ValueError(
+                f"Invalid Volcengine embedding response: expected {expected_count} vectors")
+        if not all(
+                isinstance(item, dict) and isinstance(item.get("embedding"), list) and
+                len(item["embedding"]) > 0
+                for item in data):
+            raise ValueError("Invalid Volcengine embedding response: invalid embedding data")
+        return result
+
+    async def _post_embedding(self, session, texts):
+        async with session.post(
+                self.url,
+                json=self._embedding_params(texts), headers=self.headers, ssl=False) as resp:
+            res = await resp.text()
+            if resp.status != 200:
+                StandLogger.error(
+                    f"call embeddingError,model_name={self.model_name},status={resp.status}")
+                raise UpstreamModelError(resp.status, res)
+            return json.loads(res)
+
+    async def _volcengine_text_embeddings(self, texts):
+        """Ark permits one text item per multimodal request; preserve batch semantics locally."""
+        if not texts:
+            raise ValueError("Volcengine embedding input must not be empty")
+
+        async with aiohttp.ClientSession(timeout=base_config.aiohttp_timeout) as session:
+            results = []
+            for index, text in enumerate(texts):
+                result = self._validate_volcengine_embedding_response(
+                    await self._post_embedding(session, [text]))
+                item = result["data"][0]
+                item["index"] = index
+                results.append((result, item))
+
+        response = results[0][0]
+        response["data"] = [item for _, item in results]
+        usage = response.get("usage")
+        if isinstance(usage, dict):
+            response["usage"] = {
+                key: sum(
+                    result.get("usage", {}).get(key, 0)
+                    for result, _ in results
+                    if isinstance(result.get("usage"), dict) and
+                    isinstance(result["usage"].get(key, 0), (int, float))
+                ) if isinstance(value, (int, float)) else value
+                for key, value in usage.items()
+            }
+        return response
+
     async def embedding(self, texts):
         if self.adapter and self.adapter_code:
             try:
@@ -264,22 +354,13 @@ class InnerClient:
             except Exception as e:
                 raise Exception(f"Adapter execution failed: {str(e)}")
 
-        # 原有逻辑
-        params = {
-            "model": self.model_name,
-            "input": texts
-        }
+        if self._is_volcengine_embedding() and all(isinstance(text, str) for text in texts):
+            return await self._volcengine_text_embeddings(texts)
+
         async with aiohttp.ClientSession(timeout=base_config.aiohttp_timeout) as session:
-            async with session.post(
-                    self.url,
-                    json=params, headers=self.headers, ssl=False) as resp:
-                if resp.status != 200:
-                    error_msg = await resp.text()
-                    StandLogger.error(
-                        f"call embeddingError,model_name={self.model_name},error_detail={error_msg},body={texts},status={resp.status}")
-                    raise Exception(error_msg)
-                res = await resp.text()
-                result = json.loads(res)
+            result = await self._post_embedding(session, texts)
+        if self._is_volcengine_embedding():
+            return self._validate_volcengine_embedding_response(result)
         return result
 
     async def reranker(self, query, documents):
@@ -330,10 +411,7 @@ class InnerClient:
                 raise Exception(f"Adapter execution failed: {str(e)}")
 
         else:
-            params = {
-                "model": self.model_name,
-                "input": texts
-            }
+            params = self._embedding_params(texts)
             async with aiohttp.ClientSession(timeout=base_config.aiohttp_timeout) as session:
                 async with session.post(
                         self.url,
@@ -343,7 +421,7 @@ class InnerClient:
                     if resp.status != 200:
                         raise Exception(resp.content)
                     res = await resp.text()
-                    result = json.loads(res)
+                    result = self._normalize_volcengine_embedding_response(json.loads(res))
         required_keys = ["object", "data", "model", "usage"]
         if not all(key in result for key in required_keys):
             raise ValueError(f"Invalid adapter response format, missing one of: {required_keys}")

--- a/infra/mf-model-manager/app/controller/small_model_controller.py
+++ b/infra/mf-model-manager/app/controller/small_model_controller.py
@@ -120,7 +120,8 @@ async def test_model(request, userId, language, role):
             #     return JSONResponse(status_code=403, content=NotPermissionError)
             client = InnerClient(url=config_info.get("api_url", ""), model_name=api_model,
                                  api_key=config_info.get("api_key", ""),
-                                 adapter=adapter, adapter_code=adapter_code)
+                                 adapter=adapter, adapter_code=adapter_code,
+                                 embedding_dim=embedding_dim)
             if model_type == "embedding":
                 texts = ["hello"]
                 result = await client.test_embedding(texts=texts)
@@ -562,7 +563,8 @@ async def embedding_model_used(request, userId, language, role, func_module, pri
             if not permission:
                 return JSONResponse(status_code=403, content=NotPermissionError)
         client = InnerClient(url=config_info.get("api_url", ""), model_name=config_info.get("api_model", ""),
-                             api_key=config_info.get("api_key", ""), adapter=adapter, adapter_code=adapter_code)
+                             api_key=config_info.get("api_key", ""), adapter=adapter, adapter_code=adapter_code,
+                             embedding_dim=model_info.get("f_embedding_dim"))
         res_dict = await client.embedding(texts)
         prompt_tokens = res_dict.get("usage", {}).get("prompt_tokens")
         total_tokens = res_dict.get("usage", {}).get("total_tokens")
@@ -575,7 +577,10 @@ async def embedding_model_used(request, userId, language, role, func_module, pri
     except UpstreamModelError as e:
         status_code = e.status if e.status in (400, 401, 403, 404, 422, 429) else 502
         error_dict = ModelFactory_ExternalSmallModel_Used_ConnectError.copy()
-        error_dict["detail"] = f"模型服务调用失败（HTTP {e.status}）"
+        error_dict["detail"] = e.detail
+        StandLogger.error(
+            f"call embeddingError,model_name={model_name},status={e.status},"
+            f"error_detail={e.detail}")
         if get_logger():
             get_logger().info(
                 f'{{"model_name":{model_name},"resourece_type":"embeddings","user_id":{userId},'
@@ -583,7 +588,7 @@ async def embedding_model_used(request, userId, language, role, func_module, pri
         return JSONResponse(status_code=status_code, content=error_dict)
     except Exception as e:
         StandLogger.error(
-            f"call embeddingError,model_name={model_name},error_detail={e},body={texts}")
+            f"call embeddingError,model_name={model_name},error_detail={e}")
         error_dict = ModelFactory_ExternalSmallModel_UnknownError.copy()
         error_dict["detail"] = str(e)
         if get_logger():

--- a/infra/mf-model-manager/app/controller/small_model_controller.py
+++ b/infra/mf-model-manager/app/controller/small_model_controller.py
@@ -7,7 +7,7 @@ from app.core.config import base_config
 from app.dao.small_model_dao import small_model_dao
 from app.interfaces import dbaccess, logics
 from app.logs.stand_log import StandLogger
-from app.utils.external_small_model_utils import BaiduClient, BaishengClient, InnerClient, BaiduTianchenClient
+from app.utils.external_small_model_utils import BaiduClient, BaishengClient, InnerClient, BaiduTianchenClient, UpstreamModelError
 from app.utils.observability.observability_log import get_logger
 from app.utils.param_verify_utils import *
 from app.utils.reshape_utils import *
@@ -102,14 +102,14 @@ async def test_model(request, userId, language, role):
                     config_info['api_key'] = config_info_old.get("api_key", "")
                 model_type = request.model_type
                 api_model = config_info.get("api_model", "")
-                adapter = request.adapter,
+                adapter = request.adapter
                 adapter_code = request.adapter_code
                 embedding_dim = request.embedding_dim
         else:
             config_info = request.model_config
             model_type = request.model_type
             api_model = config_info.get("api_model", "")
-            adapter = request.adapter,
+            adapter = request.adapter
             adapter_code = request.adapter_code
             embedding_dim = request.embedding_dim
         try:
@@ -572,6 +572,15 @@ async def embedding_model_used(request, userId, language, role, func_module, pri
                 f'"prompt_tokens":{prompt_tokens},"total_tokens":{total_tokens},"func_module":{func_module},"status":"success"}}')
         return res_dict
 
+    except UpstreamModelError as e:
+        status_code = e.status if e.status in (400, 401, 403, 404, 422, 429) else 502
+        error_dict = ModelFactory_ExternalSmallModel_Used_ConnectError.copy()
+        error_dict["detail"] = f"模型服务调用失败（HTTP {e.status}）"
+        if get_logger():
+            get_logger().info(
+                f'{{"model_name":{model_name},"resourece_type":"embeddings","user_id":{userId},'
+                f'"prompt_tokens":0,"total_tokens":0,"func_module":{func_module},"status":"failed"}}')
+        return JSONResponse(status_code=status_code, content=error_dict)
     except Exception as e:
         StandLogger.error(
             f"call embeddingError,model_name={model_name},error_detail={e},body={texts}")

--- a/infra/mf-model-manager/app/test/test_external_small_model_controller.py
+++ b/infra/mf-model-manager/app/test/test_external_small_model_controller.py
@@ -5,6 +5,7 @@ from app.controller import small_model_controller
 from app.dao.small_model_dao import small_model_dao
 from app.interfaces import logics
 from app.logs.stand_log import StandLogger
+from app.utils import external_small_model_utils
 import asyncio
 import json
 
@@ -25,16 +26,108 @@ class TestAddModel(TestCase):
         small_model_dao.name_check = mock.Mock(return_value=[])
         small_model_dao.add_model_info = mock.Mock(return_value=None)
         para = logics.AddExternalSmallModel(
-            model_name="1",
+            model_name="doubao-embedding-vision-251215",
             model_type="embedding",
-            model_config={"api_url": "http://x", "api_model": "m"},
-            batch_size=16,
-            max_tokens=512,
-            embedding_dim=768,
+            model_config={
+                "api_url": "https://ark.cn-beijing.volces.com/api/v3/embeddings/multimodal",
+                "api_model": "doubao-embedding-vision-251215",
+            },
+            batch_size=10,
+            max_tokens=4096,
+            embedding_dim=1024,
         )
         res = loop.run_until_complete(
             small_model_controller.add_model(para, "1", "zh", "user"))
         self.assertEqual(isinstance(json.loads(res.body)["id"], str), True)
+
+
+class TestVolcengineMultimodalEmbeddingRequest(TestCase):
+    class _Response:
+        status = 200
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb):
+            return False
+
+        async def text(self):
+            return json.dumps({
+                "object": "list",
+                "data": {"embedding": [0.1] * 1024, "object": "embedding"},
+                "model": "doubao-embedding-vision-251215",
+                "usage": {"prompt_tokens": 1, "total_tokens": 1},
+            })
+
+    class _Session:
+        def __init__(self):
+            self.post_args = None
+            self.post_kwargs = None
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb):
+            return False
+
+        def post(self, *args, **kwargs):
+            self.post_args = args
+            self.post_kwargs = kwargs
+            return TestVolcengineMultimodalEmbeddingRequest._Response()
+
+    def setUp(self) -> None:
+        self.ClientSession = external_small_model_utils.aiohttp.ClientSession
+
+    def tearDown(self) -> None:
+        external_small_model_utils.aiohttp.ClientSession = self.ClientSession
+        StandLogger.stand_log_shutdown()
+
+    def test_model_test_uses_ark_multimodal_text_input(self):
+        loop = asyncio.new_event_loop()
+        asyncio.set_event_loop(loop)
+        session = self._Session()
+        external_small_model_utils.aiohttp.ClientSession = mock.Mock(return_value=session)
+        request = logics.TestSmallModel(
+            model_name="doubao-embedding-vision-251215",
+            model_type="embedding",
+            model_config={
+                "api_url": "https://ark.cn-beijing.volces.com/api/v3/embeddings/multimodal",
+                "api_model": "doubao-embedding-vision-251215",
+                "api_key": "test-key",
+            },
+            batch_size=10,
+            max_tokens=4096,
+            embedding_dim=1024,
+            change=True,
+        )
+
+        result = loop.run_until_complete(
+            small_model_controller.test_model(request, "1", "zh", "user"))
+
+        self.assertEqual(json.loads(result.body)["status"], "ok")
+        self.assertEqual(session.post_kwargs["json"], {
+            "model": "doubao-embedding-vision-251215",
+            "input": [{"type": "text", "text": "hello"}],
+            "dimensions": 1024,
+        })
+
+    def test_non_vision_doubao_embedding_uses_text_request(self):
+        loop = asyncio.new_event_loop()
+        asyncio.set_event_loop(loop)
+        session = self._Session()
+        external_small_model_utils.aiohttp.ClientSession = mock.Mock(return_value=session)
+        client = external_small_model_utils.InnerClient(
+            url="https://ark.cn-beijing.volces.com/api/v3/embeddings",
+            model_name="doubao-embedding-250615",
+            api_key="test-key",
+        )
+
+        loop.run_until_complete(client.embedding(["hello"]))
+
+        self.assertEqual(session.post_kwargs["json"], {
+            "model": "doubao-embedding-250615",
+            "input": ["hello"],
+        })
 
 
 class TestEditModel(TestCase):

--- a/infra/mf-model-manager/app/test/test_external_small_model_controller.py
+++ b/infra/mf-model-manager/app/test/test_external_small_model_controller.py
@@ -26,15 +26,12 @@ class TestAddModel(TestCase):
         small_model_dao.name_check = mock.Mock(return_value=[])
         small_model_dao.add_model_info = mock.Mock(return_value=None)
         para = logics.AddExternalSmallModel(
-            model_name="doubao-embedding-vision-251215",
+            model_name="1",
             model_type="embedding",
-            model_config={
-                "api_url": "https://ark.cn-beijing.volces.com/api/v3/embeddings/multimodal",
-                "api_model": "doubao-embedding-vision-251215",
-            },
-            batch_size=10,
-            max_tokens=4096,
-            embedding_dim=1024,
+            model_config={"api_url": "http://x", "api_model": "m"},
+            batch_size=16,
+            max_tokens=512,
+            embedding_dim=768,
         )
         res = loop.run_until_complete(
             small_model_controller.add_model(para, "1", "zh", "user"))
@@ -128,6 +125,44 @@ class TestVolcengineMultimodalEmbeddingRequest(TestCase):
             "model": "doubao-embedding-250615",
             "input": ["hello"],
         })
+
+    def test_model_test_passes_adapter_as_boolean(self):
+        captured = {}
+
+        class _Client:
+            def __init__(self, **kwargs):
+                captured.update(kwargs)
+
+            async def test_embedding(self, texts):
+                return {
+                    "object": "list",
+                    "data": [{"embedding": [0.1] * 1024}],
+                    "model": "doubao-embedding-vision-251215",
+                    "usage": {"prompt_tokens": 1, "total_tokens": 1},
+                }
+
+        request = logics.TestSmallModel(
+            model_name="doubao-embedding-vision-251215",
+            model_type="embedding",
+            model_config={
+                "api_url": "https://ark.cn-beijing.volces.com/api/v3/embeddings/multimodal",
+                "api_model": "doubao-embedding-vision-251215",
+                "api_key": "test-key",
+            },
+            adapter=False,
+            batch_size=10,
+            max_tokens=4096,
+            embedding_dim=1024,
+            change=True,
+        )
+
+        with mock.patch.object(small_model_controller, "InnerClient", _Client):
+            result = asyncio.run(
+                small_model_controller.test_model(request, "1", "zh", "user"))
+
+        self.assertEqual(json.loads(result.body)["status"], "ok")
+        self.assertIs(captured["adapter"], False)
+        self.assertEqual(captured["embedding_dim"], 1024)
 
 
 class TestEditModel(TestCase):

--- a/infra/mf-model-manager/app/utils/external_small_model_utils.py
+++ b/infra/mf-model-manager/app/utils/external_small_model_utils.py
@@ -1,3 +1,4 @@
+import asyncio
 import json
 
 import aiohttp
@@ -13,9 +14,23 @@ class UpstreamModelError(Exception):
     """Provider error with an HTTP status suitable for gateway mapping."""
 
     def __init__(self, status, detail):
-        super().__init__(detail)
+        raw_detail = str(detail)
+        message = raw_detail
+        try:
+            payload = json.loads(raw_detail)
+            error = payload.get("error") if isinstance(payload, dict) else None
+            if isinstance(error, dict):
+                message = error.get("message") or error.get("code") or raw_detail
+            elif isinstance(error, str):
+                message = error
+            elif isinstance(payload, dict):
+                message = payload.get("message") or payload.get("error_msg") or raw_detail
+        except (TypeError, ValueError):
+            pass
+        message = str(message)[:2000]
+        super().__init__(message)
         self.status = status
-        self.detail = detail
+        self.detail = message
 
 
 class BaiduTianchenClient:
@@ -247,7 +262,10 @@ class BaishengClient:
 
 
 class InnerClient:
-    def __init__(self, url, model_name, api_key="", adapter=False, adapter_code=None):
+    VOLCENGINE_MAX_CONCURRENCY = 10
+
+    def __init__(self, url, model_name, api_key="", adapter=False, adapter_code=None,
+                 embedding_dim=None):
         if not url.startswith(('http://', 'https://')):
             url = f"http://{url}"
         self.url = url
@@ -258,15 +276,17 @@ class InnerClient:
         }
         self.adapter = adapter
         self.adapter_code = adapter_code
+        self.embedding_dim = int(embedding_dim) if embedding_dim is not None else None
 
     def _is_volcengine_embedding(self):
         # Only the vision family uses Ark's multimodal embeddings endpoint.
         # Other Doubao embedding models retain the OpenAI-compatible text body.
-        return self.model_name.startswith("doubao-embedding-vision-")
+        return (self.model_name.startswith("doubao-embedding-vision-") or
+                "/embeddings/multimodal" in self.url)
 
     def _normalize_volcengine_embedding_response(self, result):
         """Normalize Ark's single-object data field to the OpenAI-style list."""
-        if not self._is_volcengine_embedding():
+        if not self._is_volcengine_embedding() or not isinstance(result, dict):
             return result
 
         data = result.get("data")
@@ -279,18 +299,20 @@ class InnerClient:
 
         Ark's ``embeddings/multimodal`` endpoint is not OpenAI text-embedding
         compatible: even text must be represented as a typed input object.  The
-        model name is the stable discriminator requested by the model-manager
-        API, so no public API parameter is needed for this provider.
+        model family or the configured multimodal endpoint identifies this
+        provider without adding a new public API parameter.
         """
         if self._is_volcengine_embedding():
-            return {
+            params = {
                 "model": self.model_name,
                 "input": [
                     text if isinstance(text, dict) else {"type": "text", "text": text}
                     for text in texts
                 ],
-                "dimensions": 1024,
             }
+            if self.embedding_dim is not None:
+                params["dimensions"] = self.embedding_dim
+            return params
         return {
             "model": self.model_name,
             "input": texts,
@@ -299,6 +321,9 @@ class InnerClient:
     def _validate_volcengine_embedding_response(self, result, expected_count=1):
         """Validate the response shape consumed by mf-model-api callers."""
         result = self._normalize_volcengine_embedding_response(result)
+        required_keys = ("object", "data", "model", "usage")
+        if not isinstance(result, dict) or not all(key in result for key in required_keys):
+            raise ValueError("Invalid Volcengine embedding response: missing required fields")
         data = result.get("data") if isinstance(result, dict) else None
         if not isinstance(data, list) or len(data) != expected_count:
             raise ValueError(
@@ -308,7 +333,26 @@ class InnerClient:
                 len(item["embedding"]) > 0
                 for item in data):
             raise ValueError("Invalid Volcengine embedding response: invalid embedding data")
+        for index, item in enumerate(data):
+            if self.embedding_dim is not None and len(item["embedding"]) != self.embedding_dim:
+                raise ValueError(
+                    "Invalid Volcengine embedding response: "
+                    f"expected dimension {self.embedding_dim}, got {len(item['embedding'])}")
+            item["index"] = index
         return result
+
+    @classmethod
+    def _merge_usage_values(cls, values):
+        if values and all(isinstance(value, (int, float)) for value in values):
+            return sum(values)
+        if values and all(isinstance(value, dict) for value in values):
+            keys = dict.fromkeys(key for value in values for key in value)
+            return {
+                key: cls._merge_usage_values(
+                    [value[key] for value in values if key in value])
+                for key in keys
+            }
+        return values[0] if values else None
 
     async def _post_embedding(self, session, texts):
         async with session.post(
@@ -316,9 +360,11 @@ class InnerClient:
                 json=self._embedding_params(texts), headers=self.headers, ssl=False) as resp:
             res = await resp.text()
             if resp.status != 200:
+                error = UpstreamModelError(resp.status, res)
                 StandLogger.error(
-                    f"call embeddingError,model_name={self.model_name},status={resp.status}")
-                raise UpstreamModelError(resp.status, res)
+                    f"call embeddingError,model_name={self.model_name},status={resp.status},"
+                    f"error_detail={error.detail}")
+                raise error
             return json.loads(res)
 
     async def _volcengine_text_embeddings(self, texts):
@@ -326,28 +372,24 @@ class InnerClient:
         if not texts:
             raise ValueError("Volcengine embedding input must not be empty")
 
+        semaphore = asyncio.Semaphore(self.VOLCENGINE_MAX_CONCURRENCY)
         async with aiohttp.ClientSession(timeout=base_config.aiohttp_timeout) as session:
-            results = []
-            for index, text in enumerate(texts):
-                result = self._validate_volcengine_embedding_response(
-                    await self._post_embedding(session, [text]))
+            async def embed_one(index, text):
+                async with semaphore:
+                    result = self._validate_volcengine_embedding_response(
+                        await self._post_embedding(session, [text]))
                 item = result["data"][0]
                 item["index"] = index
-                results.append((result, item))
+                return result, item
+
+            results = await asyncio.gather(*(
+                embed_one(index, text) for index, text in enumerate(texts)))
 
         response = results[0][0]
         response["data"] = [item for _, item in results]
-        usage = response.get("usage")
-        if isinstance(usage, dict):
-            response["usage"] = {
-                key: sum(
-                    result.get("usage", {}).get(key, 0)
-                    for result, _ in results
-                    if isinstance(result.get("usage"), dict) and
-                    isinstance(result["usage"].get(key, 0), (int, float))
-                ) if isinstance(value, (int, float)) else value
-                for key, value in usage.items()
-            }
+        usage_values = [result.get("usage") for result, _ in results]
+        if all(isinstance(usage, dict) for usage in usage_values):
+            response["usage"] = self._merge_usage_values(usage_values)
         return response
 
     async def embedding(self, texts):
@@ -421,15 +463,10 @@ class InnerClient:
                 raise Exception(f"Adapter execution failed: {str(e)}")
 
         else:
-            params = self._embedding_params(texts)
             async with aiohttp.ClientSession(timeout=base_config.aiohttp_timeout) as session:
-                async with session.post(
-                        self.url,
-                        json=params, headers=self.headers, ssl=False) as resp:
-                    res = await resp.text()
-                    if resp.status != 200:
-                        raise Exception(res)
-                    result = self._normalize_volcengine_embedding_response(json.loads(res))
+                result = await self._post_embedding(session, texts)
+            if self._is_volcengine_embedding():
+                result = self._validate_volcengine_embedding_response(result)
         required_keys = ["object", "data", "model", "usage"]
         if not all(key in result for key in required_keys):
             raise ValueError(f"Invalid adapter response format, missing one of: {required_keys}")

--- a/infra/mf-model-manager/app/utils/external_small_model_utils.py
+++ b/infra/mf-model-manager/app/utils/external_small_model_utils.py
@@ -9,6 +9,15 @@ from app.core.config import base_config
 from app.logs.stand_log import StandLogger
 
 
+class UpstreamModelError(Exception):
+    """Provider error with an HTTP status suitable for gateway mapping."""
+
+    def __init__(self, status, detail):
+        super().__init__(detail)
+        self.status = status
+        self.detail = detail
+
+
 class BaiduTianchenClient:
     def __init__(self, url, ClientId, OperationCode):
         self.url = url
@@ -250,6 +259,97 @@ class InnerClient:
         self.adapter = adapter
         self.adapter_code = adapter_code
 
+    def _is_volcengine_embedding(self):
+        # Only the vision family uses Ark's multimodal embeddings endpoint.
+        # Other Doubao embedding models retain the OpenAI-compatible text body.
+        return self.model_name.startswith("doubao-embedding-vision-")
+
+    def _normalize_volcengine_embedding_response(self, result):
+        """Normalize Ark's single-object data field to the OpenAI-style list."""
+        if not self._is_volcengine_embedding():
+            return result
+
+        data = result.get("data")
+        if isinstance(data, dict):
+            result["data"] = [data]
+        return result
+
+    def _embedding_params(self, texts):
+        """Build the provider-specific embedding request body.
+
+        Ark's ``embeddings/multimodal`` endpoint is not OpenAI text-embedding
+        compatible: even text must be represented as a typed input object.  The
+        model name is the stable discriminator requested by the model-manager
+        API, so no public API parameter is needed for this provider.
+        """
+        if self._is_volcengine_embedding():
+            return {
+                "model": self.model_name,
+                "input": [
+                    text if isinstance(text, dict) else {"type": "text", "text": text}
+                    for text in texts
+                ],
+                "dimensions": 1024,
+            }
+        return {
+            "model": self.model_name,
+            "input": texts,
+        }
+
+    def _validate_volcengine_embedding_response(self, result, expected_count=1):
+        """Validate the response shape consumed by mf-model-api callers."""
+        result = self._normalize_volcengine_embedding_response(result)
+        data = result.get("data") if isinstance(result, dict) else None
+        if not isinstance(data, list) or len(data) != expected_count:
+            raise ValueError(
+                f"Invalid Volcengine embedding response: expected {expected_count} vectors")
+        if not all(
+                isinstance(item, dict) and isinstance(item.get("embedding"), list) and
+                len(item["embedding"]) > 0
+                for item in data):
+            raise ValueError("Invalid Volcengine embedding response: invalid embedding data")
+        return result
+
+    async def _post_embedding(self, session, texts):
+        async with session.post(
+                self.url,
+                json=self._embedding_params(texts), headers=self.headers, ssl=False) as resp:
+            res = await resp.text()
+            if resp.status != 200:
+                StandLogger.error(
+                    f"call embeddingError,model_name={self.model_name},status={resp.status}")
+                raise UpstreamModelError(resp.status, res)
+            return json.loads(res)
+
+    async def _volcengine_text_embeddings(self, texts):
+        """Ark permits one text item per multimodal request; preserve batch semantics locally."""
+        if not texts:
+            raise ValueError("Volcengine embedding input must not be empty")
+
+        async with aiohttp.ClientSession(timeout=base_config.aiohttp_timeout) as session:
+            results = []
+            for index, text in enumerate(texts):
+                result = self._validate_volcengine_embedding_response(
+                    await self._post_embedding(session, [text]))
+                item = result["data"][0]
+                item["index"] = index
+                results.append((result, item))
+
+        response = results[0][0]
+        response["data"] = [item for _, item in results]
+        usage = response.get("usage")
+        if isinstance(usage, dict):
+            response["usage"] = {
+                key: sum(
+                    result.get("usage", {}).get(key, 0)
+                    for result, _ in results
+                    if isinstance(result.get("usage"), dict) and
+                    isinstance(result["usage"].get(key, 0), (int, float))
+                ) if isinstance(value, (int, float)) else value
+                for key, value in usage.items()
+            }
+        return response
+
     async def embedding(self, texts):
         if self.adapter and self.adapter_code:
             try:
@@ -264,22 +364,13 @@ class InnerClient:
             except Exception as e:
                 raise Exception(f"Adapter execution failed: {str(e)}")
 
-        # 原有逻辑
-        params = {
-            "model": self.model_name,
-            "input": texts
-        }
+        if self._is_volcengine_embedding() and all(isinstance(text, str) for text in texts):
+            return await self._volcengine_text_embeddings(texts)
+
         async with aiohttp.ClientSession(timeout=base_config.aiohttp_timeout) as session:
-            async with session.post(
-                    self.url,
-                    json=params, headers=self.headers, ssl=False) as resp:
-                if resp.status != 200:
-                    error_msg = await resp.text()
-                    StandLogger.error(
-                        f"call embeddingError,model_name={self.model_name},error_detail={error_msg},body={texts},status={resp.status}")
-                    raise Exception(error_msg)
-                res = await resp.text()
-                result = json.loads(res)
+            result = await self._post_embedding(session, texts)
+        if self._is_volcengine_embedding():
+            return self._validate_volcengine_embedding_response(result)
         return result
 
     async def reranker(self, query, documents):
@@ -330,10 +421,7 @@ class InnerClient:
                 raise Exception(f"Adapter execution failed: {str(e)}")
 
         else:
-            params = {
-                "model": self.model_name,
-                "input": texts
-            }
+            params = self._embedding_params(texts)
             async with aiohttp.ClientSession(timeout=base_config.aiohttp_timeout) as session:
                 async with session.post(
                         self.url,
@@ -341,7 +429,7 @@ class InnerClient:
                     res = await resp.text()
                     if resp.status != 200:
                         raise Exception(res)
-                    result = json.loads(res)
+                    result = self._normalize_volcengine_embedding_response(json.loads(res))
         required_keys = ["object", "data", "model", "usage"]
         if not all(key in result for key in required_keys):
             raise ValueError(f"Invalid adapter response format, missing one of: {required_keys}")


### PR DESCRIPTION
# Pull Request

## What Changed

Brief description of changes:

- [x] Added a Volcengine-specific adapter for `doubao-embedding-vision-*`.
- [x] Split batched text inputs into valid single-item multimodal embedding requests and aggregate results into the existing `data[]` response contract.
- [x] Normalized and validated embedding responses before returning them through mf-model-api.
- [x] Preserved provider error semantics for authentication, rate-limit, and upstream failures.
- [x] Added regression coverage for multimodal request construction, text batching, response indexes, upstream status handling, and non-vision Doubao compatibility.

---

## Why

- Related Issue: N/A
- Related Feature: Doubao Vision Embedding compatibility
- Background: The Ark multimodal embedding API requires typed multimodal input and does not accept multiple text items in one multimodal request. The previous adapter could produce an invalid request body for batched callers and mapped all provider failures to HTTP 400.

---

## How

- Key implementation points:
  - Apply the multimodal request format only to `doubao-embedding-vision-*` models.
  - Send one Ark request per text item and rebuild `data[]` with deterministic indexes.
  - Validate the returned embedding payload before forwarding it to BKN, Ontology Query, and VEGA consumers.
  - Map upstream 401/403/404/422/429 responses directly and map upstream 5xx failures to 502.
  - Keep existing non-vision Doubao text embedding requests unchanged.
- Breaking changes (API, config, database, etc.): None.

---

## Testing

- [ ] Unit tests passed locally
- [ ] Integration tests passed locally
- [ ] Verified in test environment

Test notes:

- `git diff --check` passed.
- `python3 -m compileall` passed for the changed mf-model-api and mf-model-manager files.
- Pytest could not run because the local environment does not have `pytest` or `aiohttp` installed.

---

## Risk & Rollback

- Potential risks:
  - Text batches now issue one upstream request per item, which may increase request count and latency.
  - Provider response variations beyond the validated contract may be rejected earlier than before.
- Rollback plan:
  - Revert this commit to restore the previous generic embedding request behavior.

---

## Additional Notes

- No API, database schema, or configuration migration is required.
- The PR should be opened as a draft until unit tests run in an environment with the Python test dependencies installed.