### PR TITLE
fix(bkn-safe): 无证部署的 capabilities 返回 community，并放行网关路径

### DIFF
--- a/bkn-safe/charts/bkn-safe/values.yaml
+++ b/bkn-safe/charts/bkn-safe/values.yaml
@@ -18,8 +18,12 @@ service:
 
 # Only the hydra provider pages (login/consent/device) and the self-service
 # change-password endpoint are browser/CLI-facing and go through the ingress.
-# The internal authz/directory APIs (/api/safe/v1/authz, /api/safe/v1/directory)
-# stay ClusterIP, called service-to-service — do NOT expose those at the gateway.
+# The internal APIs (/api/safe/v1/authz, /api/safe/v1/directory,
+# /api/safe/v1/internal/license) stay ClusterIP, called service-to-service — do
+# NOT expose those at the gateway. The licence group is tokenless by design (its
+# boundary is the network, see networkPolicy below), so putting it behind the
+# ingress would publish the certificate and its expiry to anyone who can reach
+# the host.
 # The admin API (/api/safe/v1/admin) IS exposed below, but it is token-gated
 # (RequireAdmin: bearer-token introspection + casbin super-admin check), so it is
 # safe to widen — unlike the raw internal routes, which are unauthenticated.
@@ -50,6 +54,12 @@ ingress:
     # in-service by RequireUser (introspect); the accessor id comes from the
     # token, so a caller can only read its own grants.
     - /api/safe/v1/me
+    # Deployment capability discovery, read on every login to lay out the menu.
+    # Token-gated in-service by RequireUser (introspect only — it describes the
+    # deployment, not the caller) and it decides nothing: enforcement stays at
+    # each gated call site. Without this path the frontend gets the gateway's
+    # own 404 and has to guess what the deployment can do.
+    - /api/safe/v1/capabilities
   # hydra public OAuth2/OIDC endpoints exposed at the gateway, routed to the
   # paired hydra public service (port 4444): token, device authorization,
   # discovery, jwks, userinfo. Replaces the retired ISF ingress's /oauth2/* rules.

--- a/bkn-safe/server/internal/httpapi/capabilities.go
+++ b/bkn-safe/server/internal/httpapi/capabilities.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 
 	"github.com/gin-gonic/gin"
+	"github.com/openbkn-ai/licverify"
 
 	"github.com/openbkn-ai/bkn-foundry/bkn-safe/server/extension"
 	"github.com/openbkn-ai/bkn-foundry/bkn-safe/server/internal/license"
@@ -19,15 +20,23 @@ import (
 // refuse them.
 type capabilitiesResponse struct {
 	// Licensed reports whether a valid licence is in force right now. False
-	// covers "never installed", "expired past grace" and "failed verification"
-	// alike, because the product behaves identically in all three. It exists so
-	// a frontend does not have to enumerate State values to work that out — one
-	// that does will get it wrong the day a new State appears.
+	// covers "never installed", "expired past grace" (State fallback_community)
+	// and "failed verification" alike, because the product behaves identically
+	// in all three. It exists so a frontend does not have to enumerate State
+	// values to work that out — one that does will get it wrong the day a new
+	// State appears.
+	//
+	// It is derived from the same predicate the gate uses (State ∈ {valid,
+	// grace}, see license.Service.FeatureEnabled), not from the presence of a
+	// payload: an expired certificate still has one, and reporting that as
+	// licensed would put the frontend back in exactly the state this field was
+	// added to prevent — a full menu where every call refuses.
 	Licensed bool `json:"licensed"`
 	// Edition is the tier in force, and "community" whenever Licensed is false:
 	// a deployment without a valid certificate behaves as community, and there
 	// is deliberately no separate "unlicensed" tier. State carries the detail
-	// (valid, grace, expired, trial, unlicensed) for the activation banner.
+	// (valid, grace, fallback_community, trial, unlicensed, invalid) for the
+	// activation banner.
 	Edition string `json:"edition"`
 	State   string `json:"state"`
 	// Features is what the license carries — including enterprise features
@@ -68,10 +77,19 @@ func registerCapabilities(g *gin.RouterGroup, svc *license.Service) {
 			Extensions:   extension.Registered(),
 		}
 
+		// Same predicate as the gate: a licence is in force only while the
+		// certificate verifies and has not run past its grace window. Features
+		// and limits are read from the payload regardless — support needs to see
+		// what the installed certificate carries even when it no longer grants
+		// anything, and Licensed already says it grants nothing.
 		if svc != nil {
-			if snap := svc.State(); snap.Payload != nil {
-				resp.Licensed = true
-				resp.Edition = string(snap.Payload.Edition)
+			snap := svc.State()
+			inForce := snap.State == licverify.StateValid || snap.State == licverify.StateGrace
+			if snap.Payload != nil {
+				if inForce {
+					resp.Licensed = true
+					resp.Edition = string(snap.Payload.Edition)
+				}
 				if snap.Payload.Features != nil {
 					resp.Features = snap.Payload.Features
 				}

--- a/bkn-safe/server/internal/httpapi/capabilities.go
+++ b/bkn-safe/server/internal/httpapi/capabilities.go
@@ -18,7 +18,16 @@ import (
 // itself. This endpoint only spares users a menu full of things that would
 // refuse them.
 type capabilitiesResponse struct {
-	// Edition and State come from the license, for the activation banner.
+	// Licensed reports whether a valid licence is in force right now. False
+	// covers "never installed", "expired past grace" and "failed verification"
+	// alike, because the product behaves identically in all three. It exists so
+	// a frontend does not have to enumerate State values to work that out — one
+	// that does will get it wrong the day a new State appears.
+	Licensed bool `json:"licensed"`
+	// Edition is the tier in force, and "community" whenever Licensed is false:
+	// a deployment without a valid certificate behaves as community, and there
+	// is deliberately no separate "unlicensed" tier. State carries the detail
+	// (valid, grace, expired, trial, unlicensed) for the activation banner.
 	Edition string `json:"edition"`
 	State   string `json:"state"`
 	// Features is what the license carries — including enterprise features
@@ -45,6 +54,13 @@ type capabilitiesResponse struct {
 func registerCapabilities(g *gin.RouterGroup, svc *license.Service) {
 	g.GET("/capabilities", func(c *gin.Context) {
 		resp := capabilitiesResponse{
+			// Defaults describe a deployment with no valid certificate, which is
+			// what a community install and an unlicensed enterprise one both are.
+			// Written here rather than left to the zero value: an empty edition
+			// pushes the "does empty mean community?" question onto every caller,
+			// and the callers are frontends that will each answer it differently.
+			Licensed:     false,
+			Edition:      "community",
 			State:        string(licenseStateOrUnlicensed(svc)),
 			Features:     []string{},
 			Capabilities: []string{},
@@ -54,6 +70,7 @@ func registerCapabilities(g *gin.RouterGroup, svc *license.Service) {
 
 		if svc != nil {
 			if snap := svc.State(); snap.Payload != nil {
+				resp.Licensed = true
 				resp.Edition = string(snap.Payload.Edition)
 				if snap.Payload.Features != nil {
 					resp.Features = snap.Payload.Features

--- a/bkn-safe/server/internal/httpapi/capabilities_test.go
+++ b/bkn-safe/server/internal/httpapi/capabilities_test.go
@@ -10,8 +10,10 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/gin-gonic/gin"
+	"github.com/openbkn-ai/licverify"
 )
 
 // A deployment with no licence service at all — a community install, or an
@@ -55,5 +57,64 @@ func TestCapabilitiesWithoutLicenceReportsCommunity(t *testing.T) {
 		if !strings.Contains(body, want) {
 			t.Errorf("body missing %s: %s", want, body)
 		}
+	}
+}
+
+// The licence hub is running but nothing has been imported yet — the shape the
+// VM reproduced, and the branch the nil-service test above skips entirely
+// (licenseStateOrUnlicensed returns early on nil).
+func TestCapabilitiesWithHubButNoLicenceReportsCommunity(t *testing.T) {
+	r, _, _ := newLicenseServer(t)
+
+	w := adminReq(t, r, http.MethodGet, "/api/safe/v1/capabilities", nil)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status: got %d, want 200 (body %s)", w.Code, w.Body.String())
+	}
+	var resp capabilitiesResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if resp.Licensed || resp.Edition != "community" {
+		t.Errorf("hub up, no certificate: got licensed=%v edition=%q, want false/community",
+			resp.Licensed, resp.Edition)
+	}
+}
+
+// An expired certificate past its grace window keeps its payload, so a check
+// written as "payload != nil" reports the deployment as licensed while every
+// gated call refuses — a full menu where nothing works, which is the state this
+// field exists to prevent. The predicate must be the gate's own: State ∈
+// {valid, grace}.
+func TestCapabilitiesPastGraceIsNotLicensed(t *testing.T) {
+	r, _, priv := newLicenseServer(t)
+
+	// Expired well beyond licverify.GracePeriod, so Eval lands on
+	// fallback_community with the payload still attached.
+	past := time.Now().Add(-2 * licverify.GracePeriod).Unix()
+	lic := signTestLic(t, priv, func(p map[string]any) {
+		p["issued_at"] = past - 86400
+		p["expires_at"] = past
+		p["contract_expires_at"] = past
+	})
+	adminReq(t, r, http.MethodPost, "/api/safe/v1/admin/license/import",
+		map[string]string{"license": lic})
+
+	w := adminReq(t, r, http.MethodGet, "/api/safe/v1/capabilities", nil)
+
+	var resp capabilitiesResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode: %v (body %s)", err, w.Body.String())
+	}
+	if resp.Licensed {
+		t.Error("licensed: got true past the grace window — the gate refuses everything in this state")
+	}
+	if resp.Edition != "community" {
+		t.Errorf("edition: got %q, want \"community\" — an expired certificate grants nothing", resp.Edition)
+	}
+	// Features stay visible on purpose: support needs to see what the installed
+	// certificate carries even when it no longer grants anything.
+	if len(resp.Features) == 0 {
+		t.Error("features: emptied — the installed certificate still lists them, and support reads this")
 	}
 }

--- a/bkn-safe/server/internal/httpapi/capabilities_test.go
+++ b/bkn-safe/server/internal/httpapi/capabilities_test.go
@@ -1,0 +1,59 @@
+// Copyright openbkn.ai
+//
+// Licensed under the OpenBKN License. See LICENSE-OPENBKN.txt in the project root.
+
+package httpapi
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+)
+
+// A deployment with no licence service at all — a community install, or an
+// enterprise one whose licence hub failed to start — must still answer with a
+// complete, unambiguous shape.
+//
+// The regression this guards against is an empty edition. It used to be the
+// zero value, which left every frontend to decide for itself whether "" meant
+// community, and they would not all have decided the same way.
+func TestCapabilitiesWithoutLicenceReportsCommunity(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	registerCapabilities(r.Group("/api/safe/v1"), nil)
+
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/api/safe/v1/capabilities", nil))
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status: got %d, want 200", w.Code)
+	}
+
+	var resp capabilitiesResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode: %v (body %s)", err, w.Body.String())
+	}
+	if resp.Licensed {
+		t.Error("licensed: got true, want false — no licence service is present")
+	}
+	if resp.Edition != "community" {
+		t.Errorf("edition: got %q, want \"community\" — a deployment without a valid certificate behaves as community", resp.Edition)
+	}
+	if resp.State != "unlicensed" {
+		t.Errorf("state: got %q, want \"unlicensed\"", resp.State)
+	}
+
+	// Collections must serialise as [] and {}, never null: a frontend that does
+	// resp.capabilities.includes(...) breaks on null, and the difference is
+	// invisible until an unlicensed deployment hits it.
+	body := w.Body.String()
+	for _, want := range []string{`"features":[]`, `"capabilities":[]`, `"limits":{}`, `"extensions":[]`} {
+		if !strings.Contains(body, want) {
+			t.Errorf("body missing %s: %s", want, body)
+		}
+	}
+}


### PR DESCRIPTION
三处，都来自 VM 实测（企业镜像 + license hub 已启用、未装证书）：

```json
{"edition":"","state":"unlicensed","features":[],"capabilities":[],"limits":{},"extensions":[]}
```

## 一、`edition` 空串 → `community`

没装证书时 `snap.Payload == nil`，那段赋值整个跳过，`Edition` 保持零值。**这把"空是不是等于社区版"的判断推给了每个调用方**——而调用方是若干个前端，它们不会都答得一样。

语义早就定了：没有有效证书就是社区版，不存在独立的 unlicensed 档位；`State` 才承载 valid / grace / expired / trial 的细节。

## 二、新增 `licensed` 字段

让前端不必枚举 `State` 取值反推"现在算不算有授权"——**那种写法在新增一个 State 的当天就会错**。

`false` 覆盖"从未安装""过期超宽限""验签失败"三种，因为产品在这三种情况下行为完全一致。

## 三、ingress 放行 `/api/safe/v1/capabilities`

它的注释写着前端每次登录都要读它来铺菜单，而白名单里没有这条——**VM 实测浏览器拿到的是网关自己的 404，请求根本没到 bkn-safe**。要么前端还没用上，要么一直在吃 404 走降级。

顺带在 `values.yaml` 顶部那段"哪些不能暴露"里补上 `/api/safe/v1/internal/license`：那组端点刚改成集群内免令牌（#631），边界是网络而不是令牌，被误放进 ingress 等于把证书内容和到期时间挂到公网。原注释只点名了 `authz` 与 `directory`。

## VM 实测

```text
改动前  {"edition":"","state":"unlicensed",…}
改动后  {"licensed":false,"edition":"community","state":"unlicensed",…}
```

## 测试

覆盖无证部署的完整形状，包括**集合字段必须序列化成 `[]` / `{}` 而非 `null`**——前端做 `capabilities.includes(...)` 时 null 会直接抛，而这个差异要等到一个无证部署才暴露。

## 不在本 PR 的第四条

`extensions` 与 `capabilities` 的派生要等 bkn-safe 的档位迁移：

- `extensions` 取 `extension.Registered()`，而 bkn-safe 无证时不注册，导致**社区镜像与无证企业镜像都返回 `[]`，分不出来**
- `capabilities` 按证书 `features[]` 逐个问 `Usable(f)` 派生，而 `features[]` 在档位化后只读不判，该循环已失效、恒空

两个字段各管一头才有意义：`extensions` 回答"装了什么"（编译期事实），`capabilities` 回答"现在能用什么"（运行期判定）。"装了但开不了"正是客户买了企业镜像而证书没生效的状态。

🤖 Generated with [Claude Code](https://claude.com/claude-code)