### PR TITLE
fix(mf-model-api): 供应商 api_key 与用户对话内容不再进错误日志

### DIFF
--- a/infra/mf-model-api/README.md
+++ b/infra/mf-model-api/README.md
@@ -53,6 +53,11 @@
 - `request_digest(params)` —— 请求体压成 model / stream / 消息条数 / 字符数 /
   role 序列 / 采样参数，**不含任何 `content`**
 - `messages_digest(messages)` —— 只有 messages 在手时的简写
+- `safe_url(url)` —— 只留 scheme+host+path，query 一律抹掉（百度 oauth 把
+  `client_secret` 拼在 query 里，`OtherClient.api_url` 又是管理员自由填的）
+
+**成功路径同样适用**：原来 `BaiduTianchenClient` 每次调用都会把完整 `messages`
+以 INFO 落盘一次，比出错才触发的那几处流得更狠，一并换成摘要了。
 
 要复现问题用摘要里的 model 与参数，配合调用方自己的 trace，不要靠日志回放用户
 原文。回归见 `app/test/test_log_redact.py`（含一条断言直接扫源码，防止泄露点

--- a/infra/mf-model-api/README.md
+++ b/infra/mf-model-api/README.md
@@ -39,3 +39,21 @@
 落到 OpenAI 的 `code` 字段，机器可读的身份不丢。
 
 回归测试见 `app/test/test_openai_error.py` 与 `app/test/test_llm_error_contract.py`。
+
+## 日志纪律
+
+调第三方模型时，请求头带的是**供应商 api_key**，请求体带的是**用户的完整对话
+内容**。这两样整体拼进日志就顺着采集链路离开了本服务，而日志的读权限模型跟凭据
+管理、业务数据管理都不是一套（#636）。
+
+往日志里放请求上下文一律经 `app/utils/log_redact.py`：
+
+- `safe_headers(headers)` —— `Authorization` / `api-key` / `Cookie` 等只留掩码
+  （保留 `Bearer` 方案前缀与前 4 位，够认出是哪把 key，不够拿去用），其余原样
+- `request_digest(params)` —— 请求体压成 model / stream / 消息条数 / 字符数 /
+  role 序列 / 采样参数，**不含任何 `content`**
+- `messages_digest(messages)` —— 只有 messages 在手时的简写
+
+要复现问题用摘要里的 model 与参数，配合调用方自己的 trace，不要靠日志回放用户
+原文。回归见 `app/test/test_log_redact.py`（含一条断言直接扫源码，防止泄露点
+被重新写回来）。

--- a/infra/mf-model-api/app/controller/llm_controller.py
+++ b/infra/mf-model-api/app/controller/llm_controller.py
@@ -7,7 +7,7 @@ from app.utils.llm_utils import openai_series_stream, OpenAIClientRequest
 from app.utils.permission_manager import permission_manager
 from app.utils.param_verify_utils import *
 from app.utils.reshape_utils import *
-from app.utils import openai_error
+from app.utils import log_redact, openai_error
 from sse_starlette import EventSourceResponse
 import time
 
@@ -348,6 +348,8 @@ async def used_model_openai(request, user_id, language, func_module, trace_heade
                 else:
                     return JSONResponse(status_code=200, content=res, headers=trace_receipt_headers)
         except Exception as e:
-            StandLogger.error(f"call llmModelError {config['api_model']} error params={messages},error={e}")
+            StandLogger.error(
+                f"call llmModelError {config['api_model']} error "
+                f"request={log_redact.messages_digest(messages)},error={e}")
             return envelope_error_response(
                 ModelFactory_ModelController_Model_ConnectError_Error, 502)

--- a/infra/mf-model-api/app/test/test_log_redact.py
+++ b/infra/mf-model-api/app/test/test_log_redact.py
@@ -1,7 +1,13 @@
 """日志脱敏（#636）：凭据与用户内容不得离开本服务进入日志链路。"""
+import os
+import re
+
 import pytest
 
 from app.utils import log_redact
+
+# 相对测试文件定位源码，不依赖 pytest 的启动目录
+_APP_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 
 REAL_KEY = "sk-abcdef0123456789abcdef0123456789"
 
@@ -103,14 +109,59 @@ class TestRequestDigest:
         assert "身份证" not in str(digest)
 
 
-class TestCallSites:
-    """光有 helper 不算修好——泄露点必须真的换掉了"""
+class TestSafeUrl:
+    def test_query_is_stripped(self):
+        """百度 oauth 把 client_secret 拼在 query 里，OtherClient 的 api_url
+        又是管理员自由填的——不能假设 query 里没有凭据"""
+        url = ("https://aip.baidubce.com/oauth/2.0/token"
+               "?grant_type=client_credentials&client_id=ak&client_secret=sk-xyz")
+        safe = log_redact.safe_url(url)
+        assert safe == "https://aip.baidubce.com/oauth/2.0/token?***"
+        assert "sk-xyz" not in safe
 
-    def test_no_raw_headers_or_payload_in_logs(self):
-        for path in ("app/utils/llm_utils.py",
-                     "app/controller/llm_controller.py"):
-            with open(path, encoding="utf-8") as f:
-                src = f.read()
-            assert "headers={headers}" not in src, path
-            assert "payload={params}" not in src, path
-            assert "params={messages}" not in src, path
+    def test_plain_url_untouched(self):
+        url = "https://api.example.com/v1/chat/completions"
+        assert log_redact.safe_url(url) == url
+
+    @pytest.mark.parametrize("value", ["", None, 123])
+    def test_degenerate(self, value):
+        assert log_redact.safe_url(value) == ""
+
+
+class TestCallSites:
+    """光有 helper 不算修好——泄露点必须真的换掉了。
+
+    按模式匹配而非字面量，`headers={headers!r}` 这类改写也拦得住。
+    """
+
+    SOURCES = ("utils/llm_utils.py", "controller/llm_controller.py")
+
+    # 把「原始变量直接进 f-string」的写法一网打尽
+    RAW_PATTERNS = (
+        r"\{headers[!:}]",
+        r"\{params[!:}]",
+        r"\{messages[!:}]",
+        r"json\.dumps\(messages",
+    )
+
+    @pytest.mark.parametrize("rel", SOURCES)
+    def test_no_raw_context_in_log_calls(self, rel):
+        with open(os.path.join(_APP_ROOT, rel), encoding="utf-8") as f:
+            lines = f.readlines()
+
+        offenders = []
+        for i, line in enumerate(lines, 1):
+            # 只看日志调用所在的行及其续行（f-string 常被折行）
+            window = "".join(lines[max(0, i - 4):i])
+            if not re.search(r"(StandLogger|get_logger\(\))\.[a-z_]+\(", window):
+                continue
+            for pattern in self.RAW_PATTERNS:
+                if re.search(pattern, line):
+                    offenders.append(f"{rel}:{i}: {line.strip()}")
+        assert not offenders, "原始上下文直接进日志：\n" + "\n".join(offenders)
+
+    def test_guard_actually_catches_regressions(self):
+        """守卫本身得有区分度，否则全绿只是错觉"""
+        import re as _re
+        bad = 'StandLogger.error(f"x headers={headers}")'
+        assert any(_re.search(p, bad) for p in self.RAW_PATTERNS)

--- a/infra/mf-model-api/app/test/test_log_redact.py
+++ b/infra/mf-model-api/app/test/test_log_redact.py
@@ -1,0 +1,116 @@
+"""日志脱敏（#636）：凭据与用户内容不得离开本服务进入日志链路。"""
+import pytest
+
+from app.utils import log_redact
+
+REAL_KEY = "sk-abcdef0123456789abcdef0123456789"
+
+
+class TestMaskSecret:
+    def test_keeps_scheme_and_prefix(self):
+        masked = log_redact.mask_secret(f"Bearer {REAL_KEY}")
+        assert masked.startswith("Bearer sk-a")
+        assert REAL_KEY not in masked
+
+    def test_bare_token(self):
+        masked = log_redact.mask_secret(REAL_KEY)
+        assert REAL_KEY not in masked
+        assert masked.startswith("sk-a")
+
+    @pytest.mark.parametrize("value", ["", None, 123, "abc"])
+    def test_degenerate_values_never_pass_through(self, value):
+        assert log_redact.mask_secret(value) == "***"
+
+    def test_length_hint_survives(self):
+        """长度对「是不是配错了半截 key」这类排障有用，本身不敏感"""
+        assert f"({len(REAL_KEY)})" in log_redact.mask_secret(REAL_KEY)
+
+
+class TestSafeHeaders:
+    def test_authorization_masked(self):
+        safe = log_redact.safe_headers({
+            "Authorization": f"Bearer {REAL_KEY}",
+            "Content-Type": "application/json"})
+        assert REAL_KEY not in str(safe)
+        assert safe["Content-Type"] == "application/json"
+
+    @pytest.mark.parametrize("name", [
+        "Authorization", "authorization", "api-key", "API-KEY",
+        "x-api-key", "apikey", "secret-key", "Cookie",
+        "proxy-authorization",
+    ])
+    def test_sensitive_names_case_insensitive(self, name):
+        safe = log_redact.safe_headers({name: REAL_KEY})
+        assert REAL_KEY not in str(safe)
+
+    def test_non_dict_is_safe(self):
+        assert log_redact.safe_headers(None) == {}
+        assert log_redact.safe_headers("Bearer x") == {}
+
+
+class TestRequestDigest:
+    PARAMS = {
+        "messages": [
+            {"role": "system", "content": "你是助手"},
+            {"role": "user", "content": "张伟的身份证号是多少"},
+        ],
+        "model": "qwen3.7-plus",
+        "stream": True,
+        "max_tokens": 1024,
+        "temperature": 0.7,
+        "top_p": 0.9,
+        "tools": [{"type": "function"}],
+    }
+
+    def test_no_user_content_leaks(self):
+        digest = str(log_redact.request_digest(self.PARAMS))
+        assert "身份证" not in digest
+        assert "你是助手" not in digest
+
+    def test_keeps_what_triage_needs(self):
+        digest = log_redact.request_digest(self.PARAMS)
+        assert digest["model"] == "qwen3.7-plus"
+        assert digest["stream"] is True
+        assert digest["message_count"] == 2
+        assert digest["roles"] == ["system", "user"]
+        assert digest["max_tokens"] == 1024
+        assert digest["temperature"] == 0.7
+        assert digest["tool_count"] == 1
+
+    def test_size_without_content(self):
+        """规模能看出「是不是超长导致的」，但看不到内容本身"""
+        expected = len("你是助手") + len("张伟的身份证号是多少")
+        digest = log_redact.request_digest(self.PARAMS)
+        assert digest["message_chars"] == expected
+
+    def test_absent_params_are_omitted(self):
+        digest = log_redact.request_digest({"messages": []})
+        assert "max_tokens" not in digest
+        assert "tool_count" not in digest
+        assert digest["message_count"] == 0
+
+    def test_tolerates_junk(self):
+        assert log_redact.request_digest(None) == {}
+        assert log_redact.request_digest(
+            {"messages": "not a list"})["message_count"] == 0
+        assert log_redact.request_digest(
+            {"messages": [{"role": "user", "content": None}, "junk"]}
+        )["message_chars"] == 0
+
+    def test_messages_digest_shortcut(self):
+        digest = log_redact.messages_digest(self.PARAMS["messages"])
+        assert digest["message_count"] == 2
+        assert "身份证" not in str(digest)
+
+
+class TestCallSites:
+    """光有 helper 不算修好——泄露点必须真的换掉了"""
+
+    def test_no_raw_headers_or_payload_in_logs(self):
+        for path in ("app/utils/llm_utils.py",
+                     "app/controller/llm_controller.py"):
+            with open(path, encoding="utf-8") as f:
+                src = f.read()
+            assert "headers={headers}" not in src, path
+            assert "payload={params}" not in src, path
+            assert "params={messages}" not in src, path

--- a/infra/mf-model-api/app/utils/llm_utils.py
+++ b/infra/mf-model-api/app/utils/llm_utils.py
@@ -631,8 +631,7 @@ class BaiduTianchenClient(BKNTraceModelMixin):
         self.OperationCode = OperationCode
 
     async def chat_completion(self, messages, user_id, cache=False):
-        StandLogger.info_log("messages: " + json.dumps(messages, ensure_ascii=False))
-        messages_json = json.dumps(messages, ensure_ascii=False)
+        StandLogger.info_log(f"request={log_redact.messages_digest(messages)}")
         system = None
         prompt_str = ""
         new_messages = []
@@ -704,9 +703,8 @@ class BaiduTianchenClient(BKNTraceModelMixin):
                         openai_error.retry_after_seconds(resp.status, resp.headers))
 
     async def chat_completion_stream_openai(self, messages, user_id, return_info, cache=False):
-        StandLogger.info_log("messages: " + json.dumps(messages, ensure_ascii=False))
+        StandLogger.info_log(f"request={log_redact.messages_digest(messages)}")
         token_yield = False
-        messages_json = json.dumps(messages, ensure_ascii=False)
         retry_time = 3
         try:
             while retry_time > 0:
@@ -860,7 +858,7 @@ class BaiduTianchenClient(BKNTraceModelMixin):
             raise e
 
     async def chat_completion_stream(self, messages, user_id, return_info, cache=False):
-        StandLogger.info_log("messages: " + json.dumps(messages, ensure_ascii=False))
+        StandLogger.info_log(f"request={log_redact.messages_digest(messages)}")
         retry_time = 3
         while retry_time > 0:
             prompt_str = ""
@@ -974,7 +972,6 @@ class BaiduClient(BKNTraceModelMixin):
         self.top_p = top_p
 
     async def chat_completion(self, messages, user_id, func_module, cache=False):
-        messages_json = json.dumps(messages, ensure_ascii=False)
         headers = {
             'Content-Type': 'application/json',
             'Accept': 'application/json'
@@ -1069,7 +1066,6 @@ class BaiduClient(BKNTraceModelMixin):
 
     async def chat_completion_stream_openai(self, messages, user_id, return_info, func_module, cache=False):
         token_yield = False
-        messages_json = json.dumps(messages, ensure_ascii=False)
         retry_time = 3
         while retry_time > 0:
             retry_time -= 1
@@ -1254,7 +1250,6 @@ class BaiduClient(BKNTraceModelMixin):
                 return
 
     async def chat_completion_stream(self, messages, user_id, return_info, cache=False):
-        messages_json = json.dumps(messages, ensure_ascii=False)
         retry_time = 3
         while retry_time > 0:
             retry_time -= 1
@@ -1549,7 +1544,7 @@ class OtherClient(BKNTraceModelMixin):
                             StandLogger.error(
                                 f"upstream {response.status} error:{info},"
                                 f"headers={log_redact.safe_headers(headers)},"
-                                f"api_url={self.api_url},"
+                                f"api_url={log_redact.safe_url(self.api_url)},"
                                 f"request={log_redact.request_digest(params)}")
                             if openai_error.is_retryable(response.status) and retry_time > 0:
                                 StandLogger.warn(
@@ -1983,7 +1978,6 @@ class ClaudeClient(BKNTraceModelMixin):
             self.tool_choice = {"type": "tool", "name": self.tool_choice["function"]["name"]}
 
     async def chat_completion(self, messages, user_id, func_module, cache=False):
-        messages_json = json.dumps(messages, ensure_ascii=False)
         system = None
         for i in range(0, len(messages)):
 
@@ -2143,7 +2137,6 @@ class ClaudeClient(BKNTraceModelMixin):
 
     async def chat_completion_stream_openai(self, messages, user_id, func_module, cache=False):
         system = None
-        messages_json = json.dumps(messages, ensure_ascii=False)
         for i in range(0, len(messages)):
 
             if messages[i]["role"] == "system":
@@ -2393,7 +2386,6 @@ class ClaudeClient(BKNTraceModelMixin):
                         f'"total_tokens":{prompt_tokens + completion_tokens},"func_module":{func_module},"status":"success"}}')
 
     async def chat_completion_stream(self, messages, user_id, return_info, cache=False):
-        messages_json = json.dumps(messages, ensure_ascii=False)
         start_time = time.time()
         system = None
         new_messages = []

--- a/infra/mf-model-api/app/utils/llm_utils.py
+++ b/infra/mf-model-api/app/utils/llm_utils.py
@@ -22,7 +22,7 @@ from app.interfaces import logics
 from app.logs.stand_log import StandLogger
 from app.utils.bkntrace import evidence as bkntrace_evidence
 from app.utils.observability.observability_log import get_logger
-from app.utils import openai_error
+from app.utils import log_redact, openai_error
 
 from app.utils.str_util import generate_random_string, has_common_substring
 
@@ -1546,7 +1546,11 @@ class OtherClient(BKNTraceModelMixin):
                         response.encoding = 'utf-8'
                         if response.status != 200:
                             info = await response.text()
-                            StandLogger.error(f"error:{info},headers={headers},api_url={self.api_url},payload={params}")
+                            StandLogger.error(
+                                f"upstream {response.status} error:{info},"
+                                f"headers={log_redact.safe_headers(headers)},"
+                                f"api_url={self.api_url},"
+                                f"request={log_redact.request_digest(params)}")
                             if openai_error.is_retryable(response.status) and retry_time > 0:
                                 StandLogger.warn(
                                     f"upstream {response.status} retryable, "
@@ -1753,7 +1757,9 @@ class OtherClient(BKNTraceModelMixin):
                         return
             except aiohttp.ClientError as e:
                 StandLogger.error(
-                    f"call llmModelError {self.api_model} error payload={params},headers={headers},error={e}")
+                    f"call llmModelError {self.api_model} error "
+                    f"request={log_redact.request_digest(params)},"
+                    f"headers={log_redact.safe_headers(headers)},error={e}")
                 if retry_time <= 0:
                     log_info = logics.AddModelUsedAudit(
                         model_id=self.model_id, user_id=user_id, input_tokens=0,
@@ -1776,7 +1782,9 @@ class OtherClient(BKNTraceModelMixin):
                     await asyncio.sleep(1)
             except Exception as e:
                 StandLogger.error(
-                    f"call llmModelError {self.api_model} error payload={params},headers={headers},error={e}")
+                    f"call llmModelError {self.api_model} error "
+                    f"request={log_redact.request_digest(params)},"
+                    f"headers={log_redact.safe_headers(headers)},error={e}")
                 log_info = logics.AddModelUsedAudit(
                     model_id=self.model_id, user_id=user_id, input_tokens=0,
                     output_tokens=0, first_time=0.0, total_time=0.0,

--- a/infra/mf-model-api/app/utils/log_redact.py
+++ b/infra/mf-model-api/app/utils/log_redact.py
@@ -40,6 +40,19 @@ def safe_headers(headers):
     }
 
 
+def safe_url(url):
+    """URL 脱敏：只留 scheme+host+path，query 一律抹掉。
+
+    本服务里 URL 拼凭据是有先例的（百度 oauth 的 `client_id`/`client_secret`、
+    `?access_token=`），而 `OtherClient.api_url` 是管理员在 f_model_config 里自由
+    填的，无法假设里面没有 key。排障要的是「打的哪个 host、哪个 path」。
+    """
+    if not isinstance(url, str) or not url:
+        return ""
+    base, sep, _query = url.partition("?")
+    return f"{base}?***" if sep else base
+
+
 def _message_chars(messages):
     total = 0
     for m in messages:

--- a/infra/mf-model-api/app/utils/log_redact.py
+++ b/infra/mf-model-api/app/utils/log_redact.py
@@ -1,0 +1,83 @@
+"""日志脱敏：排障需要的是「打了哪个 url、哪个模型、多大的请求」，不是凭据本身，
+也不是用户问了什么。
+
+调用第三方模型时，请求头里带的是**供应商 api_key**，请求体里带的是**用户的完整
+对话内容**。这两样一旦整体拼进 error 日志，就顺着日志采集链路离开了本服务——而
+日志的读权限模型跟凭据管理、业务数据管理都不是一套（#636）。
+
+所以往日志里放请求上下文时，一律经这里过一道：
+``safe_headers()`` 给头脱敏，``request_digest()`` 把请求体压成不含内容的摘要。
+"""
+
+_SENSITIVE_HEADERS = (
+    "authorization", "api-key", "x-api-key", "apikey",
+    "secret-key", "x-secret-key", "cookie", "proxy-authorization",
+)
+
+# 掩码保留的前缀长度：够认出「是哪一把 key」，不够拿去用
+_KEEP_PREFIX = 4
+
+
+def mask_secret(value, keep=_KEEP_PREFIX):
+    """凭据掩码。保留可辨识的头部，其余抹掉，并保留 Bearer 之类的方案前缀。"""
+    if not isinstance(value, str) or not value:
+        return "***"
+    scheme, _, rest = value.partition(" ")
+    if rest and scheme.lower() in ("bearer", "basic", "token"):
+        return f"{scheme} {mask_secret(rest, keep)}"
+    if len(value) <= keep:
+        return "***"
+    return f"{value[:keep]}***({len(value)})"
+
+
+def safe_headers(headers):
+    """请求头脱敏副本。敏感项只留掩码，其余原样——排障还得看 Content-Type。"""
+    if not isinstance(headers, dict):
+        return {}
+    return {
+        k: (mask_secret(v) if str(k).lower() in _SENSITIVE_HEADERS else v)
+        for k, v in headers.items()
+    }
+
+
+def _message_chars(messages):
+    total = 0
+    for m in messages:
+        if isinstance(m, dict):
+            content = m.get("content")
+            if isinstance(content, str):
+                total += len(content)
+    return total
+
+
+def request_digest(params):
+    """请求体摘要：够定位问题，不含任何用户内容。
+
+    刻意不收 ``messages`` 里的 ``content``——那是客户的业务数据。要复现问题用
+    这里的 model / 参数 / 规模，配合调用方自己的 trace 即可。
+    """
+    if not isinstance(params, dict):
+        return {}
+    messages = params.get("messages")
+    messages = messages if isinstance(messages, list) else []
+    digest = {
+        "model": params.get("model"),
+        "stream": params.get("stream"),
+        "message_count": len(messages),
+        "message_chars": _message_chars(messages),
+        "roles": [m.get("role") for m in messages if isinstance(m, dict)],
+    }
+    for key in ("max_tokens", "temperature", "top_p", "top_k",
+                "frequency_penalty", "presence_penalty"):
+        if key in params:
+            digest[key] = params[key]
+    if params.get("tools"):
+        digest["tool_count"] = len(params["tools"])
+    if params.get("response_format"):
+        digest["response_format"] = True
+    return digest
+
+
+def messages_digest(messages):
+    """只有 messages 在手时的摘要（controller 侧的异常分支用）。"""
+    return request_digest({"messages": messages})


### PR DESCRIPTION
Closes #636

## 问题

调用第三方模型出错时，四处日志把整个请求头和请求体拼了进去。请求头里是
`Authorization: Bearer <供应商 api_key>`，请求体里是用户的完整 `messages`。

两样都顺着日志采集链路离开了本服务，而日志的读权限模型跟凭据管理、业务数据管理都不是一套——拿到日志读权限就等于拿到所有第三方模型的调用额度，以及客户问过的每一句话。其中「上游非 200」那条在上游繁忙时触发得相当频繁（见 #620）。

## 改动

新增 `app/utils/log_redact.py`：

- `safe_headers()` —— `Authorization` / `api-key` / `x-api-key` / `Cookie` 等脱敏，保留 `Bearer` 方案前缀与前 4 位并附长度。够认出是哪把 key、够看出是不是配了半截，不够拿去用。`Content-Type` 这类非敏感项原样保留，排障还得看。
- `request_digest()` —— 请求体压成 model / stream / 消息条数 / 字符数 / role 序列 / 采样参数 / 工具数，**刻意不收任何 `content`**。要复现问题用这些配合调用方自己的 trace。

四处调用点全部换掉：`llm_utils.py` 的上游非 200、`ClientError`、通用异常三条，以及 `llm_controller.py` 的 `OtherClient` 异常分支。

改完的日志长这样：

```
error:{...},headers={'Authorization': 'Bearer sk-a***(35)', 'Content-Type': 'application/json'},api_url=...,request={'model': 'qwen3.7-plus', 'stream': True, 'message_count': 2, 'message_chars': 47, 'roles': ['system', 'user'], 'max_tokens': 1024, ...}
```

排障要的信息一个没少，凭据和用户原文一个没留。

## 测试

`model-factory-base:v2` 内 **400 passed, 3 skipped**。新增 `test_log_redact.py` 覆盖掩码边界（空值、非字符串、短串）、头名大小写、摘要不含内容但保留规模，另有一条断言**直接扫源码**，防止 `headers={headers}` / `payload={params}` 这类写法日后被重新写回来。

## 未做

`infra/mf-model-manager` 有一份同源 `llm_utils.py` 副本。其 chat 路由虽仍注册，但仓内已确认零调用方（跨服务只用它的模型元数据接口），#620 时按 owner 裁决未动，这里保持一致。若那条路由后续要启用，需一并处理。

🤖 Generated with [Claude Code](https://claude.com/claude-code)