### PR TITLE
fix(mf-model-api): 兼容面上的框架层校验错误也返 OpenAI 错误体

### DIFF
--- a/docs/api/_shared/errors.yaml
+++ b/docs/api/_shared/errors.yaml
@@ -94,6 +94,10 @@ components:
         与 `ErrorCompact` 的关键差异：**顶层只有 `error` 一个字段**，业务码在
         `error.code` 里，没有 `solution` / `link`。判断错误是否来自模型调用链路，
         看顶层有没有 `error` 对象即可。
+
+        覆盖范围包括请求体校验失败（HTTP 400）：`/v1/chat/completions` 上的参数
+        缺失 / 类型错误也是这个形状，原业务码（`ModelFactory.Router.ParamError.*`）
+        在 `error.code` 里。
       type: object
       required:
         - error

--- a/infra/mf-model-api/README.md
+++ b/infra/mf-model-api/README.md
@@ -34,6 +34,11 @@
 - **瞬态错误先重试。** 上游 429/502/503/504 走退避重试（`sleep_before_retry`），
   重试用完才报错；4xx 参数类错误不重试。
 
+兼容面覆盖到**框架层**：请求体在 pydantic 就被打回的那类走 FastAPI 的
+`RequestValidationError` 处理器，同样按路径转成 OpenAI 错误体（`app/routers/__init__.py`
+的 `_is_openai_compat`）。该处理器是全服务共用的——小模型、模型管理等端点不是
+兼容面，继续用 envelope，改这里千万别一刀切。
+
 内部 envelope（参数校验、权限、配额等）经
 `llm_controller.envelope_error_response()` 翻成上述形状后再出门，原 `code`
 落到 OpenAI 的 `code` 字段，机器可读的身份不丢。

--- a/infra/mf-model-api/app/routers/__init__.py
+++ b/infra/mf-model-api/app/routers/__init__.py
@@ -3,9 +3,21 @@ from fastapi.exceptions import RequestValidationError
 from fastapi.responses import JSONResponse
 from fastapi import Request
 
+from app.logs.stand_log import StandLogger
+from app.utils import openai_error
+
 api_version_public_v1 = "/api/mf-model-api/v1"
 api_version_private_v1 = "/api/private/mf-model-api/v1"
 api_version_health = "/api/v1"
+
+# 声明为 OpenAI 兼容的路由。这些路径上的失败必须是 {"error": {...}}，其余端点
+# （小模型、模型管理等）不是兼容面，继续用模型工厂自家的 envelope——别一刀切，
+# 那会连带破掉它们的对外契约（#637）。
+_OPENAI_COMPAT_SUFFIXES = ("/chat/completions",)
+
+
+def _is_openai_compat(path):
+    return any(path.endswith(suffix) for suffix in _OPENAI_COMPAT_SUFFIXES)
 
 
 def router_init(app):
@@ -34,10 +46,14 @@ def router_init(app):
         tags=["Factory"],
         responses={404: {"description": "Not found"}},
     )
+
     @app.exception_handler(RequestValidationError)
     async def exception_handler(request: Request, exc: RequestValidationError):
-        print("errors:")
-        print(exc.errors())
+        # 只投影 loc/type/msg：pydantic v1 的 errors() 不回显入参，但 v2 会带
+        # input，届时整份 errors 落日志就等于把用户请求体写进去了（见 #636）。
+        StandLogger.warn("request validation failed: %s" % [
+            {k: e.get(k) for k in ("loc", "type", "msg")} for e in exc.errors()])
+        # 只报第一条：detail 是字符串不是列表，聚合会改变既有响应契约。
         for error in exc.errors():
             paramName = ' '.join(map(str, error["loc"][1:]))
             if error["type"] == "value_error.missing":
@@ -46,13 +62,18 @@ def router_init(app):
                            "detail": "{0} 参数缺失".format(paramName),
                            "solution": "请检查填写的参数是否正确。",
                            "link": ""}
-                return JSONResponse(status_code=400, content=content)
             else:
                 content = {"code": "ModelFactory.Router.ParamError.FormatError",
                            "description": "参数错误",
                            "detail": f"{error.get('msg', '')}",
                            "solution": "请检查输入内容格式是否符合要求",
                            "link": ""}
-                return JSONResponse(status_code=400, content=content)
+            # 兼容面上换成 OpenAI 错误体：同一端点不能有两种错误契约，否则对接方
+            # 得写两套解析。原业务码挪进 error.code，机器可读的身份不丢。
+            if _is_openai_compat(request.url.path):
+                return JSONResponse(
+                    status_code=400,
+                    content=openai_error.from_envelope(content, 400))
+            return JSONResponse(status_code=400, content=content)
 
     app.add_exception_handler(RequestValidationError, exception_handler)

--- a/infra/mf-model-api/app/test/test_validation_error_shape.py
+++ b/infra/mf-model-api/app/test/test_validation_error_shape.py
@@ -1,0 +1,106 @@
+"""#637：OpenAI 兼容面上的框架层校验错误也要走 OpenAI 错误体。
+
+`/chat/completions` 的控制器错误在 #620 已经统一成 `{"error": {...}}`，但请求体
+在 pydantic 层就被打回的那类走的是 `RequestValidationError` 处理器，之前仍返回
+模型工厂 envelope——同一个端点两种契约，对接方得写两套解析。
+
+同时这个处理器是**全服务共用**的：小模型、模型管理等端点不是兼容面，必须保持
+envelope 不变，一刀切会破掉它们的对外契约。
+"""
+import json
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from app.routers import router_init
+
+
+@pytest.fixture
+def client():
+    app = FastAPI()
+    router_init(app)
+    return TestClient(app)
+
+
+def _body(response):
+    return json.loads(response.content.decode("utf-8"))
+
+
+CHAT_PATHS = [
+    "/api/mf-model-api/v1/chat/completions",
+    "/api/private/mf-model-api/v1/chat/completions",
+]
+
+
+class TestOpenAICompatFace:
+    @pytest.mark.parametrize("path", CHAT_PATHS)
+    def test_type_error_returns_openai_shape(self, client, path):
+        """stream 传字符串：pydantic 打回，公开面与 S2S 面都要是 OpenAI 形状"""
+        response = client.post(path, json={
+            "model": "x", "stream": "yes",
+            "messages": [{"role": "user", "content": "hi"}]})
+
+        assert response.status_code == 400
+        body = _body(response)
+        assert set(body) == {"error"}
+        assert set(body["error"]) == {"message", "type", "param", "code"}
+        assert "Boolean" in body["error"]["message"]
+        assert body["error"]["type"] == "invalid_request_error"
+
+    @pytest.mark.parametrize("path", CHAT_PATHS)
+    def test_missing_field_returns_openai_shape(self, client, path):
+        response = client.post(path, json={"model": "x"})
+
+        assert response.status_code == 400
+        body = _body(response)
+        assert set(body) == {"error"}
+        assert "messages" in body["error"]["message"]
+
+    def test_business_code_survives_in_error_code(self, client):
+        """业务码不能丢，只是从顶层挪进 error.code"""
+        response = client.post(CHAT_PATHS[0], json={"model": "x"})
+        assert _body(response)["error"]["code"] == \
+            "ModelFactory.Router.ParamError.ParamMissing"
+
+    def test_no_envelope_fields_leak(self, client):
+        """solution / link 只对模型工厂控制台有意义，不进兼容面"""
+        raw = client.post(CHAT_PATHS[0], json={
+            "model": "x", "stream": "yes",
+            "messages": [{"role": "user", "content": "hi"}]}).content.decode()
+        for field in ("solution", "link", "description"):
+            assert f'"{field}"' not in raw
+
+
+class TestOtherEndpointsUnchanged:
+    """处理器全服务共用，非兼容面必须原样保留 envelope"""
+
+    OTHER_PATHS = [
+        "/api/mf-model-api/v1/small-model/embeddings",
+        "/api/private/mf-model-api/v1/small-model/embeddings",
+    ]
+
+    @pytest.mark.parametrize("path", OTHER_PATHS)
+    def test_small_model_keeps_envelope(self, client, path):
+        response = client.post(path, json={})
+        if response.status_code == 404:
+            pytest.skip(f"{path} 未注册在本服务")
+        assert response.status_code == 400
+        body = _body(response)
+        assert "error" not in body
+        assert set(body) >= {"code", "description", "detail", "solution", "link"}
+        assert body["code"].startswith("ModelFactory.Router.ParamError")
+
+
+class TestPathDispatch:
+    @pytest.mark.parametrize("path,expected", [
+        ("/api/mf-model-api/v1/chat/completions", True),
+        ("/api/private/mf-model-api/v1/chat/completions", True),
+        ("/api/mf-model-api/v1/small-model/embeddings", False),
+        ("/api/mf-model-api/v1/small-model/rerank", False),
+        ("/api/v1/health/ready", False),
+        ("", False),
+    ])
+    def test_only_chat_completions_is_compat_face(self, path, expected):
+        from app.routers import _is_openai_compat
+        assert _is_openai_compat(path) is expected


### PR DESCRIPTION
Closes #637

## 问题

#620 把 `/v1/chat/completions` 的失败出口统一成了 `{"error": {...}}`，但只覆盖到控制器产生的错误。请求体在 pydantic 层就被打回的那类走 FastAPI 的 `RequestValidationError` 处理器，仍返回模型工厂 envelope。同一个端点两种契约：

```console
# 控制器错误 —— OpenAI 形状
{"error":{"message":"模型名称或者模型id不存在","type":"invalid_request_error",...}}

# 框架校验错误 —— 旧 envelope
{"code":"ModelFactory.Router.ParamError.FormatError","description":"参数错误",...}
```

`docs/api/_shared/errors.yaml` 里新加的「顶层有 `error` 对象即来自模型调用链路」这条判定规则，在这条路径上不成立。

## 改动

**这个处理器是全服务共用的**——小模型、模型管理等端点不是兼容面，一刀切会连带破掉它们的对外契约。所以按路径分流：

```python
_OPENAI_COMPAT_SUFFIXES = ("/chat/completions",)

if _is_openai_compat(request.url.path):
    return JSONResponse(status_code=400,
                        content=openai_error.from_envelope(content, 400))
return JSONResponse(status_code=400, content=content)
```

原业务码经 `from_envelope()` 挪进 `error.code`，机器可读的身份不丢；**状态码仍是 400，不变**。

顺带两处同段代码的问题：

- `print()` 换成 `StandLogger`，原来日志采集收不到
- 只投影 `loc/type/msg` 入日志。pydantic v1 的 `errors()` 不回显入参，但 v2 会带 `input`，届时整份 errors 落日志就等于把用户请求体写进去（同 #636 的问题）

「循环里首次迭代就 return、多个校验错误只报第一条」**保持原样**：`detail` 是字符串不是列表，聚合会改变既有响应契约。已在注释里写明是有意的。

## 测试

`model-factory-base:v2` 内 **389 passed, 3 skipped**。新增 `test_validation_error_shape.py` 用 `TestClient` 打真实路由：

- 公开面与 S2S 面两条路径 × 类型错误 / 缺参，断言四字段齐全、`type` 正确、业务码落在 `error.code`
- 断言 `solution` / `link` / `description` 不外泄
- **专门一组断言小模型端点仍是 envelope**——防止后来者一刀切
- `_is_openai_compat` 的路径分派参数化

文档同步：`README.md` 补了覆盖到框架层的说明与「别一刀切」的提醒，`docs/api/_shared/errors.yaml` 的 `ErrorOpenAI` 补了适用范围（含 400 校验失败）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)