### PR TITLE
fix(vega): cast PostgreSQL metric timestamps

### DIFF
--- a/adp/vega/vega-backend/server/logics/connector/local/table/mariadb/mariadb_condition.go
+++ b/adp/vega/vega-backend/server/logics/connector/local/table/mariadb/mariadb_condition.go
@@ -38,11 +38,46 @@ func normalizeTimestampValue(value any) any {
 	}
 }
 
-func mariaDBDateCompareExpr(columnName, op string, value any) sq.Sqlizer {
+func mariaDBDateValueExpr(field *interfaces.Property) string {
+	if field.Type == interfaces.DataType_Time {
+		return "?"
+	}
+	return "FROM_UNIXTIME(?/1000)"
+}
+
+func validateMariaDBDateValue(field *interfaces.Property, value any) error {
+	if field.Type == interfaces.DataType_Time && value != nil {
+		if _, ok := value.(string); !ok {
+			return fmt.Errorf("MariaDB time field %q requires a time string, got %T", field.Name, value)
+		}
+	}
+	return nil
+}
+
+func mariaDBDateCompareExpr(field *interfaces.Property, op string, value any) (sq.Sqlizer, error) {
+	if err := validateMariaDBDateValue(field, value); err != nil {
+		return nil, err
+	}
 	return sq.Expr(
-		quoteColumnName(columnName)+" "+op+" FROM_UNIXTIME(?/1000)",
+		quoteColumnName(field.OriginalName)+" "+op+" "+mariaDBDateValueExpr(field),
 		normalizeTimestampValue(value),
-	)
+	), nil
+}
+
+func mariaDBDateSetExpr(field *interfaces.Property, op string, values []any) (sq.Sqlizer, error) {
+	valueExprs := make([]string, len(values))
+	args := make([]any, len(values))
+	for i, value := range values {
+		if err := validateMariaDBDateValue(field, value); err != nil {
+			return nil, err
+		}
+		valueExprs[i] = mariaDBDateValueExpr(field)
+		args[i] = normalizeTimestampValue(value)
+	}
+	return sq.Expr(
+		quoteColumnName(field.OriginalName)+" "+op+" ("+strings.Join(valueExprs, ", ")+")",
+		args...,
+	), nil
 }
 
 // quoteColumnName 将列名转为 SQL 标识符；支持 "alias.col" -> "`alias`.`col`"
@@ -188,6 +223,9 @@ func (c *MariaDBConnector) ConvertFilterConditionEqual(ctx context.Context, cond
 
 	switch cond.Cfg.ValueFrom {
 	case interfaces.ValueFrom_Const:
+		if interfaces.DataType_IsDate(cond.Lfield.Type) {
+			return mariaDBDateCompareExpr(cond.Lfield, "=", cond.Value)
+		}
 		return sq.Eq{quoteColumnName(cond.Lfield.OriginalName): cond.Value}, nil
 	case interfaces.ValueFrom_Field:
 		return sq.Expr(quoteColumnName(cond.Lfield.OriginalName) + " = " + quoteColumnName(cond.Rfield.OriginalName)), nil
@@ -206,6 +244,9 @@ func (c *MariaDBConnector) ConvertFilterConditionNotEqual(ctx context.Context, c
 
 	switch cond.Cfg.ValueFrom {
 	case interfaces.ValueFrom_Const:
+		if interfaces.DataType_IsDate(cond.Lfield.Type) {
+			return mariaDBDateCompareExpr(cond.Lfield, "<>", cond.Value)
+		}
 		return sq.NotEq{quoteColumnName(cond.Lfield.OriginalName): cond.Value}, nil
 	case interfaces.ValueFrom_Field:
 		return sq.Expr(quoteColumnName(cond.Lfield.OriginalName) + " <> " + quoteColumnName(cond.Rfield.OriginalName)), nil
@@ -225,7 +266,7 @@ func (c *MariaDBConnector) ConvertFilterConditionGt(ctx context.Context, conditi
 	switch cond.Cfg.ValueFrom {
 	case interfaces.ValueFrom_Const:
 		if interfaces.DataType_IsDate(cond.Lfield.Type) {
-			return mariaDBDateCompareExpr(cond.Lfield.OriginalName, ">", cond.Value), nil
+			return mariaDBDateCompareExpr(cond.Lfield, ">", cond.Value)
 		}
 		return sq.Gt{quoteColumnName(cond.Lfield.OriginalName): cond.Value}, nil
 	case interfaces.ValueFrom_Field:
@@ -246,7 +287,7 @@ func (c *MariaDBConnector) ConvertFilterConditionGte(ctx context.Context, condit
 	switch cond.Cfg.ValueFrom {
 	case interfaces.ValueFrom_Const:
 		if interfaces.DataType_IsDate(cond.Lfield.Type) {
-			return mariaDBDateCompareExpr(cond.Lfield.OriginalName, ">=", cond.Value), nil
+			return mariaDBDateCompareExpr(cond.Lfield, ">=", cond.Value)
 		}
 		return sq.GtOrEq{quoteColumnName(cond.Lfield.OriginalName): cond.Value}, nil
 	case interfaces.ValueFrom_Field:
@@ -267,7 +308,7 @@ func (c *MariaDBConnector) ConvertFilterConditionLt(ctx context.Context, conditi
 	switch cond.Cfg.ValueFrom {
 	case interfaces.ValueFrom_Const:
 		if interfaces.DataType_IsDate(cond.Lfield.Type) {
-			return mariaDBDateCompareExpr(cond.Lfield.OriginalName, "<", cond.Value), nil
+			return mariaDBDateCompareExpr(cond.Lfield, "<", cond.Value)
 		}
 		return sq.Lt{quoteColumnName(cond.Lfield.OriginalName): cond.Value}, nil
 	case interfaces.ValueFrom_Field:
@@ -288,7 +329,7 @@ func (c *MariaDBConnector) ConvertFilterConditionLte(ctx context.Context, condit
 	switch cond.Cfg.ValueFrom {
 	case interfaces.ValueFrom_Const:
 		if interfaces.DataType_IsDate(cond.Lfield.Type) {
-			return mariaDBDateCompareExpr(cond.Lfield.OriginalName, "<=", cond.Value), nil
+			return mariaDBDateCompareExpr(cond.Lfield, "<=", cond.Value)
 		}
 		return sq.LtOrEq{quoteColumnName(cond.Lfield.OriginalName): cond.Value}, nil
 	case interfaces.ValueFrom_Field:
@@ -309,6 +350,9 @@ func (c *MariaDBConnector) ConvertFilterConditionIn(ctx context.Context, conditi
 	if cond.Cfg.ValueFrom != interfaces.ValueFrom_Const {
 		return nil, fmt.Errorf("condition [in] only supports ValueFrom_Const, got %s", cond.Cfg.ValueFrom)
 	}
+	if interfaces.DataType_IsDate(cond.Lfield.Type) {
+		return mariaDBDateSetExpr(cond.Lfield, "IN", cond.Value)
+	}
 
 	return sq.Eq{quoteColumnName(cond.Lfield.OriginalName): cond.Value}, nil
 }
@@ -323,6 +367,9 @@ func (c *MariaDBConnector) ConvertFilterConditionNotIn(ctx context.Context, cond
 
 	if cond.Cfg.ValueFrom != interfaces.ValueFrom_Const {
 		return nil, fmt.Errorf("condition [not_in] only supports ValueFrom_Const, got %s", cond.Cfg.ValueFrom)
+	}
+	if interfaces.DataType_IsDate(cond.Lfield.Type) {
+		return mariaDBDateSetExpr(cond.Lfield, "NOT IN", cond.Value)
 	}
 
 	return sq.NotEq{quoteColumnName(cond.Lfield.OriginalName): cond.Value}, nil
@@ -418,10 +465,15 @@ func (c *MariaDBConnector) ConvertFilterConditionRange(ctx context.Context, cond
 	}
 
 	if interfaces.DataType_IsDate(cond.Lfield.Type) {
-		return sq.And{
-			mariaDBDateCompareExpr(cond.Lfield.OriginalName, ">=", values[0]),
-			mariaDBDateCompareExpr(cond.Lfield.OriginalName, "<=", values[1]),
-		}, nil
+		lower, err := mariaDBDateCompareExpr(cond.Lfield, ">=", values[0])
+		if err != nil {
+			return nil, err
+		}
+		upper, err := mariaDBDateCompareExpr(cond.Lfield, "<=", values[1])
+		if err != nil {
+			return nil, err
+		}
+		return sq.And{lower, upper}, nil
 	}
 
 	return sq.And{
@@ -448,10 +500,15 @@ func (c *MariaDBConnector) ConvertFilterConditionOutRange(ctx context.Context, c
 	}
 
 	if interfaces.DataType_IsDate(cond.Lfield.Type) {
-		return sq.Or{
-			mariaDBDateCompareExpr(cond.Lfield.OriginalName, "<", values[0]),
-			mariaDBDateCompareExpr(cond.Lfield.OriginalName, ">", values[1]),
-		}, nil
+		lower, err := mariaDBDateCompareExpr(cond.Lfield, "<", values[0])
+		if err != nil {
+			return nil, err
+		}
+		upper, err := mariaDBDateCompareExpr(cond.Lfield, ">", values[1])
+		if err != nil {
+			return nil, err
+		}
+		return sq.Or{lower, upper}, nil
 	}
 
 	return sq.Or{
@@ -554,10 +611,15 @@ func (c *MariaDBConnector) ConvertFilterConditionBetween(ctx context.Context, co
 	isDateType := interfaces.DataType_IsDate(fieldType)
 
 	if isDateType {
-		return sq.And{
-			mariaDBDateCompareExpr(cond.Lfield.OriginalName, ">=", values[0]),
-			mariaDBDateCompareExpr(cond.Lfield.OriginalName, "<=", values[1]),
-		}, nil
+		lower, err := mariaDBDateCompareExpr(cond.Lfield, ">=", values[0])
+		if err != nil {
+			return nil, err
+		}
+		upper, err := mariaDBDateCompareExpr(cond.Lfield, "<=", values[1])
+		if err != nil {
+			return nil, err
+		}
+		return sq.And{lower, upper}, nil
 	}
 
 	// 非时间类型字段，直接使用参数化查询

--- a/adp/vega/vega-backend/server/logics/connector/local/table/mariadb/mariadb_condition.go
+++ b/adp/vega/vega-backend/server/logics/connector/local/table/mariadb/mariadb_condition.go
@@ -9,6 +9,7 @@ package mariadb
 import (
 	"context"
 	"fmt"
+	"strconv"
 	"strings"
 
 	sq "github.com/Masterminds/squirrel"
@@ -46,10 +47,27 @@ func mariaDBDateValueExpr(field *interfaces.Property) string {
 }
 
 func validateMariaDBDateValue(field *interfaces.Property, value any) error {
-	if field.Type == interfaces.DataType_Time && value != nil {
+	if value == nil {
+		return nil
+	}
+	if field.Type == interfaces.DataType_Time {
 		if _, ok := value.(string); !ok {
 			return fmt.Errorf("MariaDB time field %q requires a time string, got %T", field.Name, value)
 		}
+		return nil
+	}
+
+	switch value := value.(type) {
+	case string:
+		if _, err := strconv.ParseFloat(strings.TrimSpace(value), 64); err != nil {
+			return fmt.Errorf("MariaDB date field %q requires epoch milliseconds, got %q", field.Name, value)
+		}
+	case float32, float64,
+		int, int8, int16, int32, int64,
+		uint, uint8, uint16, uint32, uint64:
+		return nil
+	default:
+		return fmt.Errorf("MariaDB date field %q requires epoch milliseconds, got %T", field.Name, value)
 	}
 	return nil
 }

--- a/adp/vega/vega-backend/server/logics/connector/local/table/mariadb/mariadb_condition.go
+++ b/adp/vega/vega-backend/server/logics/connector/local/table/mariadb/mariadb_condition.go
@@ -11,6 +11,7 @@ import (
 	"fmt"
 	"strconv"
 	"strings"
+	"time"
 
 	sq "github.com/Masterminds/squirrel"
 
@@ -34,6 +35,13 @@ func normalizeTimestampValue(value any) any {
 		return int64(v)
 	case uint32:
 		return int64(v)
+	case time.Time:
+		return v.UnixMilli()
+	case string:
+		if parsed, err := time.Parse(time.RFC3339Nano, strings.TrimSpace(v)); err == nil {
+			return parsed.UnixMilli()
+		}
+		return value
 	default:
 		return value
 	}
@@ -59,9 +67,16 @@ func validateMariaDBDateValue(field *interfaces.Property, value any) error {
 
 	switch value := value.(type) {
 	case string:
-		if _, err := strconv.ParseFloat(strings.TrimSpace(value), 64); err != nil {
-			return fmt.Errorf("MariaDB date field %q requires epoch milliseconds, got %q", field.Name, value)
+		trimmed := strings.TrimSpace(value)
+		if _, err := strconv.ParseFloat(trimmed, 64); err == nil {
+			return nil
 		}
+		if _, err := time.Parse(time.RFC3339Nano, trimmed); err == nil {
+			return nil
+		}
+		return fmt.Errorf("MariaDB date field %q requires epoch milliseconds, got %q", field.Name, value)
+	case time.Time:
+		return nil
 	case float32, float64,
 		int, int8, int16, int32, int64,
 		uint, uint8, uint16, uint32, uint64:

--- a/adp/vega/vega-backend/server/logics/connector/local/table/mariadb/mariadb_condition.go
+++ b/adp/vega/vega-backend/server/logics/connector/local/table/mariadb/mariadb_condition.go
@@ -36,10 +36,10 @@ func normalizeTimestampValue(value any) any {
 	case uint32:
 		return int64(v)
 	case time.Time:
-		return v.UnixMilli()
+		return v
 	case string:
 		if parsed, err := time.Parse(time.RFC3339Nano, strings.TrimSpace(v)); err == nil {
-			return parsed.UnixMilli()
+			return parsed
 		}
 		return value
 	default:
@@ -47,9 +47,17 @@ func normalizeTimestampValue(value any) any {
 	}
 }
 
-func mariaDBDateValueExpr(field *interfaces.Property) string {
+func mariaDBDateValueExpr(field *interfaces.Property, value any) string {
 	if field.Type == interfaces.DataType_Time {
 		return "?"
+	}
+	if _, ok := value.(time.Time); ok {
+		return "?"
+	}
+	if value, ok := value.(string); ok {
+		if _, err := time.Parse(time.RFC3339Nano, strings.TrimSpace(value)); err == nil {
+			return "?"
+		}
 	}
 	return "FROM_UNIXTIME(?/1000)"
 }
@@ -84,7 +92,6 @@ func validateMariaDBDateValue(field *interfaces.Property, value any) error {
 	default:
 		return fmt.Errorf("MariaDB date field %q requires epoch milliseconds, got %T", field.Name, value)
 	}
-	return nil
 }
 
 func mariaDBDateCompareExpr(field *interfaces.Property, op string, value any) (sq.Sqlizer, error) {
@@ -92,7 +99,7 @@ func mariaDBDateCompareExpr(field *interfaces.Property, op string, value any) (s
 		return nil, err
 	}
 	return sq.Expr(
-		quoteColumnName(field.OriginalName)+" "+op+" "+mariaDBDateValueExpr(field),
+		quoteColumnName(field.OriginalName)+" "+op+" "+mariaDBDateValueExpr(field, value),
 		normalizeTimestampValue(value),
 	), nil
 }
@@ -104,7 +111,7 @@ func mariaDBDateSetExpr(field *interfaces.Property, op string, values []any) (sq
 		if err := validateMariaDBDateValue(field, value); err != nil {
 			return nil, err
 		}
-		valueExprs[i] = mariaDBDateValueExpr(field)
+		valueExprs[i] = mariaDBDateValueExpr(field, value)
 		args[i] = normalizeTimestampValue(value)
 	}
 	return sq.Expr(

--- a/adp/vega/vega-backend/server/logics/connector/local/table/mariadb/mariadb_condition_test.go
+++ b/adp/vega/vega-backend/server/logics/connector/local/table/mariadb/mariadb_condition_test.go
@@ -57,6 +57,17 @@ func TestMariaDBConnectorConvertFilterConditionEqual(t *testing.T) {
 			t.Errorf("unexpected args: %v", args)
 		}
 	})
+	t.Run("convert date equal from epoch milliseconds", func(t *testing.T) {
+		c := &MariaDBConnector{}
+		cond := mustNewCond(t, "created_at", "==", float64(1785295334428))
+		sql, args := toSQL(t, c, cond)
+		if sql != "`created_at` = FROM_UNIXTIME(?/1000)" {
+			t.Errorf("unexpected SQL: %s", sql)
+		}
+		if len(args) != 1 || args[0] != int64(1785295334428) {
+			t.Errorf("unexpected args: %v", args)
+		}
+	})
 	t.Run("convert equal field to field", func(t *testing.T) {
 		c := &MariaDBConnector{}
 		cfg := &interfaces.FilterCondCfg{
@@ -106,6 +117,17 @@ func TestMariaDBConnectorConvertFilterConditionNotEqual(t *testing.T) {
 			t.Errorf("unexpected SQL: %s", sql)
 		}
 		if len(args) != 1 || args[0] != "bob" {
+			t.Errorf("unexpected args: %v", args)
+		}
+	})
+	t.Run("convert date not equal from epoch milliseconds", func(t *testing.T) {
+		c := &MariaDBConnector{}
+		cond := mustNewCond(t, "created_at", "!=", float64(1785295334428))
+		sql, args := toSQL(t, c, cond)
+		if sql != "`created_at` <> FROM_UNIXTIME(?/1000)" {
+			t.Errorf("unexpected SQL: %s", sql)
+		}
+		if len(args) != 1 || args[0] != int64(1785295334428) {
 			t.Errorf("unexpected args: %v", args)
 		}
 	})
@@ -176,6 +198,17 @@ func TestMariaDBConnectorConvertFilterConditionIn(t *testing.T) {
 			t.Errorf("expected 2 args, got %d", len(args))
 		}
 	})
+	t.Run("convert date in from epoch milliseconds", func(t *testing.T) {
+		c := &MariaDBConnector{}
+		cond := mustNewCond(t, "created_at", "in", []any{1785295334428, 1785381734428})
+		sql, args := toSQL(t, c, cond)
+		if sql != "`created_at` IN (FROM_UNIXTIME(?/1000), FROM_UNIXTIME(?/1000))" {
+			t.Errorf("unexpected SQL: %s", sql)
+		}
+		if len(args) != 2 || args[0] != int64(1785295334428) || args[1] != int64(1785381734428) {
+			t.Errorf("unexpected args: %v", args)
+		}
+	})
 }
 func TestMariaDBConnectorConvertFilterConditionNotIn(t *testing.T) {
 	t.Run("convert not in", func(t *testing.T) {
@@ -184,6 +217,46 @@ func TestMariaDBConnectorConvertFilterConditionNotIn(t *testing.T) {
 		sql, _ := toSQL(t, c, cond)
 		if sql != "`name` NOT IN (?)" {
 			t.Errorf("unexpected SQL: %s", sql)
+		}
+	})
+	t.Run("convert date not in from epoch milliseconds", func(t *testing.T) {
+		c := &MariaDBConnector{}
+		cond := mustNewCond(t, "created_at", "not_in", []any{1785295334428, 1785381734428})
+		sql, args := toSQL(t, c, cond)
+		if sql != "`created_at` NOT IN (FROM_UNIXTIME(?/1000), FROM_UNIXTIME(?/1000))" {
+			t.Errorf("unexpected SQL: %s", sql)
+		}
+		if len(args) != 2 || args[0] != int64(1785295334428) || args[1] != int64(1785381734428) {
+			t.Errorf("unexpected args: %v", args)
+		}
+	})
+}
+
+func TestMariaDBDateExpressionsKeepTimeValuesRaw(t *testing.T) {
+	t.Run("keeps time strings raw", func(t *testing.T) {
+		c := &MariaDBConnector{}
+		cond := mustNewCond(t, "event_time", ">=", "14:30:00")
+		sql, args := toSQL(t, c, cond)
+		if sql != "`event_time` >= ?" {
+			t.Errorf("unexpected SQL: %s", sql)
+		}
+		if len(args) != 1 || args[0] != "14:30:00" {
+			t.Errorf("unexpected args: %v", args)
+		}
+	})
+
+	t.Run("rejects numeric time values", func(t *testing.T) {
+		c := &MariaDBConnector{}
+		cond := mustNewCond(t, "event_time", ">=", float64(1785295334428))
+		expr, err := c.ConvertFilterCondition(context.Background(), cond, testFieldsMap())
+		if err == nil {
+			t.Fatal("expected numeric time value error")
+		}
+		if expr != nil {
+			t.Fatalf("expected nil expression, got %v", expr)
+		}
+		if !strings.Contains(err.Error(), "requires a time string") {
+			t.Fatalf("unexpected error: %v", err)
 		}
 	})
 }
@@ -417,6 +490,7 @@ func testFieldsMap() map[string]*interfaces.Property {
 		"age":        {Name: "age", OriginalName: "age", Type: interfaces.DataType_Integer},
 		"score":      {Name: "score", OriginalName: "score", Type: interfaces.DataType_Float},
 		"created_at": {Name: "created_at", OriginalName: "created_at", Type: interfaces.DataType_Datetime},
+		"event_time": {Name: "event_time", OriginalName: "event_time", OriginalType: "time", Type: interfaces.DataType_Time},
 		"is_active":  {Name: "is_active", OriginalName: "is_active", Type: interfaces.DataType_Boolean},
 		"tags":       {Name: "tags", OriginalName: "tags", Type: interfaces.DataType_Text},
 		"alias_col":  {Name: "alias_col", OriginalName: "t1.col", Type: interfaces.DataType_String},

--- a/adp/vega/vega-backend/server/logics/connector/local/table/mariadb/mariadb_condition_test.go
+++ b/adp/vega/vega-backend/server/logics/connector/local/table/mariadb/mariadb_condition_test.go
@@ -287,7 +287,7 @@ func TestMariaDBDateExpressionsKeepTimeValuesRaw(t *testing.T) {
 	})
 }
 
-func TestMariaDBDateExpressionsNormalizeCursorTimestamps(t *testing.T) {
+func TestMariaDBDateExpressionsKeepCursorTimestampsNative(t *testing.T) {
 	c := &MariaDBConnector{}
 	wantMillis := int64(1785295334428)
 	wantTime := time.UnixMilli(wantMillis).UTC()
@@ -299,10 +299,10 @@ func TestMariaDBDateExpressionsNormalizeCursorTimestamps(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			cond := mustNewCond(t, "created_at", ">", value)
 			sql, args := toSQL(t, c, cond)
-			if sql != "`created_at` > FROM_UNIXTIME(?/1000)" {
+			if sql != "`created_at` > ?" {
 				t.Errorf("unexpected SQL: %s", sql)
 			}
-			if len(args) != 1 || args[0] != wantMillis {
+			if len(args) != 1 || !args[0].(time.Time).Equal(wantTime) {
 				t.Errorf("unexpected args: %v", args)
 			}
 		})

--- a/adp/vega/vega-backend/server/logics/connector/local/table/mariadb/mariadb_condition_test.go
+++ b/adp/vega/vega-backend/server/logics/connector/local/table/mariadb/mariadb_condition_test.go
@@ -10,6 +10,7 @@ import (
 	"context"
 	"strings"
 	"testing"
+	"time"
 
 	"vega-backend/interfaces"
 	"vega-backend/logics/filter_condition"
@@ -284,6 +285,28 @@ func TestMariaDBDateExpressionsKeepTimeValuesRaw(t *testing.T) {
 			t.Fatalf("unexpected error: %v", err)
 		}
 	})
+}
+
+func TestMariaDBDateExpressionsNormalizeCursorTimestamps(t *testing.T) {
+	c := &MariaDBConnector{}
+	wantMillis := int64(1785295334428)
+	wantTime := time.UnixMilli(wantMillis).UTC()
+
+	for name, value := range map[string]any{
+		"time.Time": wantTime,
+		"RFC3339":   wantTime.Format(time.RFC3339Nano),
+	} {
+		t.Run(name, func(t *testing.T) {
+			cond := mustNewCond(t, "created_at", ">", value)
+			sql, args := toSQL(t, c, cond)
+			if sql != "`created_at` > FROM_UNIXTIME(?/1000)" {
+				t.Errorf("unexpected SQL: %s", sql)
+			}
+			if len(args) != 1 || args[0] != wantMillis {
+				t.Errorf("unexpected args: %v", args)
+			}
+		})
+	}
 }
 func TestMariaDBConnectorConvertFilterConditionLike(t *testing.T) {
 	t.Run("convert like", func(t *testing.T) {

--- a/adp/vega/vega-backend/server/logics/connector/local/table/mariadb/mariadb_condition_test.go
+++ b/adp/vega/vega-backend/server/logics/connector/local/table/mariadb/mariadb_condition_test.go
@@ -68,6 +68,31 @@ func TestMariaDBConnectorConvertFilterConditionEqual(t *testing.T) {
 			t.Errorf("unexpected args: %v", args)
 		}
 	})
+	t.Run("accept numeric string epoch milliseconds", func(t *testing.T) {
+		c := &MariaDBConnector{}
+		cond := mustNewCond(t, "created_at", "==", "1785295334428")
+		sql, args := toSQL(t, c, cond)
+		if sql != "`created_at` = FROM_UNIXTIME(?/1000)" {
+			t.Errorf("unexpected SQL: %s", sql)
+		}
+		if len(args) != 1 || args[0] != "1785295334428" {
+			t.Errorf("unexpected args: %v", args)
+		}
+	})
+	t.Run("reject date literal before mysql numeric coercion", func(t *testing.T) {
+		c := &MariaDBConnector{}
+		cond := mustNewCond(t, "created_at", "==", "2026-01-01 00:00:00")
+		expr, err := c.ConvertFilterCondition(context.Background(), cond, testFieldsMap())
+		if err == nil {
+			t.Fatal("expected non-epoch date value error")
+		}
+		if expr != nil {
+			t.Fatalf("expected nil expression, got %v", expr)
+		}
+		if !strings.Contains(err.Error(), "requires epoch milliseconds") {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
 	t.Run("convert equal field to field", func(t *testing.T) {
 		c := &MariaDBConnector{}
 		cfg := &interfaces.FilterCondCfg{

--- a/adp/vega/vega-backend/server/logics/connector/local/table/postgresql/postgresql_condition.go
+++ b/adp/vega/vega-backend/server/logics/connector/local/table/postgresql/postgresql_condition.go
@@ -40,6 +40,12 @@ func normalizeTimestampValue(value any) any {
 
 // postgresqlDateValueExpr builds a parameter expression compatible with the field's PostgreSQL date type.
 func postgresqlDateValueExpr(field *interfaces.Property) string {
+	// Type is the semantic contract and may be present even when an API-provided schema
+	// omits OriginalType. Keep this check aligned with validatePostgresqlDateValue.
+	if field.Type == interfaces.DataType_Time {
+		return "?"
+	}
+
 	originalType := strings.ToLower(strings.TrimSpace(field.OriginalType))
 	switch originalType {
 	case "time", "timetz", "time without time zone", "time with time zone":
@@ -59,7 +65,6 @@ func postgresqlDateValueExpr(field *interfaces.Property) string {
 	return timestampExpr
 }
 
-// postgresqlDateCompareExpr compares a date column with epoch milliseconds.
 func validatePostgresqlDateValue(field *interfaces.Property, value any) error {
 	if field.Type == interfaces.DataType_Time && value != nil {
 		if _, ok := value.(string); !ok {
@@ -69,6 +74,7 @@ func validatePostgresqlDateValue(field *interfaces.Property, value any) error {
 	return nil
 }
 
+// postgresqlDateCompareExpr compares a date column with epoch milliseconds or a time string.
 func postgresqlDateCompareExpr(field *interfaces.Property, op string, value any) (sq.Sqlizer, error) {
 	if err := validatePostgresqlDateValue(field, value); err != nil {
 		return nil, err

--- a/adp/vega/vega-backend/server/logics/connector/local/table/postgresql/postgresql_condition.go
+++ b/adp/vega/vega-backend/server/logics/connector/local/table/postgresql/postgresql_condition.go
@@ -38,13 +38,37 @@ func normalizeTimestampValue(value any) any {
 	}
 }
 
-// postgresqlDateCompareExpr compares a date column with epoch milliseconds.
+// postgresqlTimestampValueExpr converts epoch milliseconds to the field's PostgreSQL timestamp type.
 // The explicit float8 cast prevents PostgreSQL from inferring the parameter as int4
 // from the 1000 literal, which would overflow or truncate millisecond timestamps.
-func postgresqlDateCompareExpr(columnName, op string, value any) sq.Sqlizer {
+func postgresqlTimestampValueExpr(field *interfaces.Property) string {
+	timestampExpr := "to_timestamp(?::double precision / 1000.0)"
+	switch strings.ToLower(strings.TrimSpace(field.OriginalType)) {
+	case "timestamp", "timestamp without time zone":
+		// Convert the instant to a wall-clock timestamp using the connection session time zone.
+		timestampExpr = "(" + timestampExpr + " AT TIME ZONE current_setting('TimeZone'))"
+	}
+	return timestampExpr
+}
+
+// postgresqlDateCompareExpr compares a date column with epoch milliseconds.
+func postgresqlDateCompareExpr(field *interfaces.Property, op string, value any) sq.Sqlizer {
 	return sq.Expr(
-		quoteColumnName(columnName)+" "+op+" to_timestamp(?::double precision / 1000.0)",
+		quoteColumnName(field.OriginalName)+" "+op+" "+postgresqlTimestampValueExpr(field),
 		normalizeTimestampValue(value),
+	)
+}
+
+func postgresqlDateSetExpr(field *interfaces.Property, op string, values []any) sq.Sqlizer {
+	valueExprs := make([]string, len(values))
+	args := make([]any, len(values))
+	for i, value := range values {
+		valueExprs[i] = postgresqlTimestampValueExpr(field)
+		args[i] = normalizeTimestampValue(value)
+	}
+	return sq.Expr(
+		quoteColumnName(field.OriginalName)+" "+op+" ("+strings.Join(valueExprs, ", ")+")",
+		args...,
 	)
 }
 
@@ -178,6 +202,9 @@ func (c *PostgresqlConnector) ConvertFilterConditionEqual(ctx context.Context, c
 
 	switch cond.Cfg.ValueFrom {
 	case interfaces.ValueFrom_Const:
+		if interfaces.DataType_IsDate(cond.Lfield.Type) {
+			return postgresqlDateCompareExpr(cond.Lfield, "=", cond.Value), nil
+		}
 		return sq.Eq{quoteColumnName(cond.Lfield.OriginalName): cond.Value}, nil
 	case interfaces.ValueFrom_Field:
 		return sq.Expr(quoteColumnName(cond.Lfield.OriginalName) + " = " + quoteColumnName(cond.Rfield.OriginalName)), nil
@@ -196,6 +223,9 @@ func (c *PostgresqlConnector) ConvertFilterConditionNotEqual(ctx context.Context
 
 	switch cond.Cfg.ValueFrom {
 	case interfaces.ValueFrom_Const:
+		if interfaces.DataType_IsDate(cond.Lfield.Type) {
+			return postgresqlDateCompareExpr(cond.Lfield, "<>", cond.Value), nil
+		}
 		return sq.NotEq{quoteColumnName(cond.Lfield.OriginalName): cond.Value}, nil
 	case interfaces.ValueFrom_Field:
 		return sq.Expr(quoteColumnName(cond.Lfield.OriginalName) + " <> " + quoteColumnName(cond.Rfield.OriginalName)), nil
@@ -215,7 +245,7 @@ func (c *PostgresqlConnector) ConvertFilterConditionGt(ctx context.Context, cond
 	switch cond.Cfg.ValueFrom {
 	case interfaces.ValueFrom_Const:
 		if interfaces.DataType_IsDate(cond.Lfield.Type) {
-			return postgresqlDateCompareExpr(cond.Lfield.OriginalName, ">", cond.Value), nil
+			return postgresqlDateCompareExpr(cond.Lfield, ">", cond.Value), nil
 		}
 		return sq.Gt{quoteColumnName(cond.Lfield.OriginalName): cond.Value}, nil
 	case interfaces.ValueFrom_Field:
@@ -236,7 +266,7 @@ func (c *PostgresqlConnector) ConvertFilterConditionGte(ctx context.Context, con
 	switch cond.Cfg.ValueFrom {
 	case interfaces.ValueFrom_Const:
 		if interfaces.DataType_IsDate(cond.Lfield.Type) {
-			return postgresqlDateCompareExpr(cond.Lfield.OriginalName, ">=", cond.Value), nil
+			return postgresqlDateCompareExpr(cond.Lfield, ">=", cond.Value), nil
 		}
 		return sq.GtOrEq{quoteColumnName(cond.Lfield.OriginalName): cond.Value}, nil
 	case interfaces.ValueFrom_Field:
@@ -257,7 +287,7 @@ func (c *PostgresqlConnector) ConvertFilterConditionLt(ctx context.Context, cond
 	switch cond.Cfg.ValueFrom {
 	case interfaces.ValueFrom_Const:
 		if interfaces.DataType_IsDate(cond.Lfield.Type) {
-			return postgresqlDateCompareExpr(cond.Lfield.OriginalName, "<", cond.Value), nil
+			return postgresqlDateCompareExpr(cond.Lfield, "<", cond.Value), nil
 		}
 		return sq.Lt{quoteColumnName(cond.Lfield.OriginalName): cond.Value}, nil
 	case interfaces.ValueFrom_Field:
@@ -278,7 +308,7 @@ func (c *PostgresqlConnector) ConvertFilterConditionLte(ctx context.Context, con
 	switch cond.Cfg.ValueFrom {
 	case interfaces.ValueFrom_Const:
 		if interfaces.DataType_IsDate(cond.Lfield.Type) {
-			return postgresqlDateCompareExpr(cond.Lfield.OriginalName, "<=", cond.Value), nil
+			return postgresqlDateCompareExpr(cond.Lfield, "<=", cond.Value), nil
 		}
 		return sq.LtOrEq{quoteColumnName(cond.Lfield.OriginalName): cond.Value}, nil
 	case interfaces.ValueFrom_Field:
@@ -299,6 +329,9 @@ func (c *PostgresqlConnector) ConvertFilterConditionIn(ctx context.Context, cond
 	if cond.Cfg.ValueFrom != interfaces.ValueFrom_Const {
 		return nil, fmt.Errorf("condition [in] only supports ValueFrom_Const, got %s", cond.Cfg.ValueFrom)
 	}
+	if interfaces.DataType_IsDate(cond.Lfield.Type) {
+		return postgresqlDateSetExpr(cond.Lfield, "IN", cond.Value), nil
+	}
 
 	return sq.Eq{quoteColumnName(cond.Lfield.OriginalName): cond.Value}, nil
 }
@@ -313,6 +346,9 @@ func (c *PostgresqlConnector) ConvertFilterConditionNotIn(ctx context.Context, c
 
 	if cond.Cfg.ValueFrom != interfaces.ValueFrom_Const {
 		return nil, fmt.Errorf("condition [not_in] only supports ValueFrom_Const, got %s", cond.Cfg.ValueFrom)
+	}
+	if interfaces.DataType_IsDate(cond.Lfield.Type) {
+		return postgresqlDateSetExpr(cond.Lfield, "NOT IN", cond.Value), nil
 	}
 
 	return sq.NotEq{quoteColumnName(cond.Lfield.OriginalName): cond.Value}, nil
@@ -411,8 +447,8 @@ func (c *PostgresqlConnector) ConvertFilterConditionRange(ctx context.Context, c
 
 	if interfaces.DataType_IsDate(cond.Lfield.Type) {
 		return sq.And{
-			postgresqlDateCompareExpr(cond.Lfield.OriginalName, ">=", values[0]),
-			postgresqlDateCompareExpr(cond.Lfield.OriginalName, "<=", values[1]),
+			postgresqlDateCompareExpr(cond.Lfield, ">=", values[0]),
+			postgresqlDateCompareExpr(cond.Lfield, "<=", values[1]),
 		}, nil
 	}
 
@@ -441,8 +477,8 @@ func (c *PostgresqlConnector) ConvertFilterConditionOutRange(ctx context.Context
 
 	if interfaces.DataType_IsDate(cond.Lfield.Type) {
 		return sq.Or{
-			postgresqlDateCompareExpr(cond.Lfield.OriginalName, "<", values[0]),
-			postgresqlDateCompareExpr(cond.Lfield.OriginalName, ">", values[1]),
+			postgresqlDateCompareExpr(cond.Lfield, "<", values[0]),
+			postgresqlDateCompareExpr(cond.Lfield, ">", values[1]),
 		}, nil
 	}
 
@@ -547,8 +583,8 @@ func (c *PostgresqlConnector) ConvertFilterConditionBetween(ctx context.Context,
 
 	if isDateType {
 		return sq.And{
-			postgresqlDateCompareExpr(cond.Lfield.OriginalName, ">=", values[0]),
-			postgresqlDateCompareExpr(cond.Lfield.OriginalName, "<=", values[1]),
+			postgresqlDateCompareExpr(cond.Lfield, ">=", values[0]),
+			postgresqlDateCompareExpr(cond.Lfield, "<=", values[1]),
 		}, nil
 	}
 

--- a/adp/vega/vega-backend/server/logics/connector/local/table/postgresql/postgresql_condition.go
+++ b/adp/vega/vega-backend/server/logics/connector/local/table/postgresql/postgresql_condition.go
@@ -35,10 +35,10 @@ func normalizeTimestampValue(value any) any {
 	case uint32:
 		return int64(v)
 	case time.Time:
-		return v.UnixMilli()
+		return v
 	case string:
 		if parsed, err := time.Parse(time.RFC3339Nano, strings.TrimSpace(v)); err == nil {
-			return parsed.UnixMilli()
+			return parsed
 		}
 		return value
 	default:
@@ -47,11 +47,19 @@ func normalizeTimestampValue(value any) any {
 }
 
 // postgresqlDateValueExpr builds a parameter expression compatible with the field's PostgreSQL date type.
-func postgresqlDateValueExpr(field *interfaces.Property) string {
+func postgresqlDateValueExpr(field *interfaces.Property, value any) string {
 	// Type is the semantic contract and may be present even when an API-provided schema
 	// omits OriginalType. Keep this check aligned with validatePostgresqlDateValue.
 	if field.Type == interfaces.DataType_Time {
 		return "?"
+	}
+	if _, ok := value.(time.Time); ok {
+		return "?"
+	}
+	if value, ok := value.(string); ok {
+		if _, err := time.Parse(time.RFC3339Nano, strings.TrimSpace(value)); err == nil {
+			return "?"
+		}
 	}
 
 	originalType := strings.ToLower(strings.TrimSpace(field.OriginalType))
@@ -88,7 +96,7 @@ func postgresqlDateCompareExpr(field *interfaces.Property, op string, value any)
 		return nil, err
 	}
 	return sq.Expr(
-		quoteColumnName(field.OriginalName)+" "+op+" "+postgresqlDateValueExpr(field),
+		quoteColumnName(field.OriginalName)+" "+op+" "+postgresqlDateValueExpr(field, value),
 		normalizeTimestampValue(value),
 	), nil
 }
@@ -100,7 +108,7 @@ func postgresqlDateSetExpr(field *interfaces.Property, op string, values []any) 
 		if err := validatePostgresqlDateValue(field, value); err != nil {
 			return nil, err
 		}
-		valueExprs[i] = postgresqlDateValueExpr(field)
+		valueExprs[i] = postgresqlDateValueExpr(field, value)
 		args[i] = normalizeTimestampValue(value)
 	}
 	return sq.Expr(

--- a/adp/vega/vega-backend/server/logics/connector/local/table/postgresql/postgresql_condition.go
+++ b/adp/vega/vega-backend/server/logics/connector/local/table/postgresql/postgresql_condition.go
@@ -53,16 +53,30 @@ func postgresqlDateValueExpr(field *interfaces.Property, value any) string {
 	if field.Type == interfaces.DataType_Time {
 		return "?"
 	}
+	originalType := strings.ToLower(strings.TrimSpace(field.OriginalType))
+	nativeTimestamp := false
 	if _, ok := value.(time.Time); ok {
-		return "?"
+		nativeTimestamp = true
 	}
 	if value, ok := value.(string); ok {
 		if _, err := time.Parse(time.RFC3339Nano, strings.TrimSpace(value)); err == nil {
-			return "?"
+			nativeTimestamp = true
 		}
 	}
+	if nativeTimestamp {
+		// Without an explicit cast PostgreSQL may infer an unknown parameter as timestamptz
+		// and shift an unzoned column through the session TimeZone. Keep native cursors in
+		// wall-clock space for timestamp-without-time-zone and date columns.
+		switch originalType {
+		case "timestamp", "timestamp without time zone", "date":
+			return "?::timestamp"
+		}
+		if field.Type == interfaces.DataType_Date {
+			return "?::timestamp"
+		}
+		return "?"
+	}
 
-	originalType := strings.ToLower(strings.TrimSpace(field.OriginalType))
 	switch originalType {
 	case "time", "timetz", "time without time zone", "time with time zone":
 		// An epoch instant has no well-defined time-of-day value. Keep time values raw so

--- a/adp/vega/vega-backend/server/logics/connector/local/table/postgresql/postgresql_condition.go
+++ b/adp/vega/vega-backend/server/logics/connector/local/table/postgresql/postgresql_condition.go
@@ -40,7 +40,7 @@ func normalizeTimestampValue(value any) any {
 
 func postgresqlDateCompareExpr(columnName, op string, value any) sq.Sqlizer {
 	return sq.Expr(
-		quoteColumnName(columnName)+" "+op+" to_timestamp(?/1000)",
+		quoteColumnName(columnName)+" "+op+" to_timestamp(?::double precision / 1000.0)",
 		normalizeTimestampValue(value),
 	)
 }

--- a/adp/vega/vega-backend/server/logics/connector/local/table/postgresql/postgresql_condition.go
+++ b/adp/vega/vega-backend/server/logics/connector/local/table/postgresql/postgresql_condition.go
@@ -10,6 +10,7 @@ import (
 	"context"
 	"fmt"
 	"strings"
+	"time"
 
 	sq "github.com/Masterminds/squirrel"
 
@@ -33,6 +34,13 @@ func normalizeTimestampValue(value any) any {
 		return int64(v)
 	case uint32:
 		return int64(v)
+	case time.Time:
+		return v.UnixMilli()
+	case string:
+		if parsed, err := time.Parse(time.RFC3339Nano, strings.TrimSpace(v)); err == nil {
+			return parsed.UnixMilli()
+		}
+		return value
 	default:
 		return value
 	}

--- a/adp/vega/vega-backend/server/logics/connector/local/table/postgresql/postgresql_condition.go
+++ b/adp/vega/vega-backend/server/logics/connector/local/table/postgresql/postgresql_condition.go
@@ -38,12 +38,20 @@ func normalizeTimestampValue(value any) any {
 	}
 }
 
-// postgresqlTimestampValueExpr converts epoch milliseconds to the field's PostgreSQL timestamp type.
-// The explicit float8 cast prevents PostgreSQL from inferring the parameter as int4
-// from the 1000 literal, which would overflow or truncate millisecond timestamps.
-func postgresqlTimestampValueExpr(field *interfaces.Property) string {
+// postgresqlDateValueExpr builds a parameter expression compatible with the field's PostgreSQL date type.
+func postgresqlDateValueExpr(field *interfaces.Property) string {
+	originalType := strings.ToLower(strings.TrimSpace(field.OriginalType))
+	switch originalType {
+	case "time", "timetz", "time without time zone", "time with time zone":
+		// An epoch instant has no well-defined time-of-day value. Keep time values raw so
+		// PostgreSQL can parse them according to the column type instead of comparing with timestamptz.
+		return "?"
+	}
+
+	// The explicit float8 cast prevents PostgreSQL from inferring the parameter as int4
+	// from the 1000 literal, which would overflow or truncate millisecond timestamps.
 	timestampExpr := "to_timestamp(?::double precision / 1000.0)"
-	switch strings.ToLower(strings.TrimSpace(field.OriginalType)) {
+	switch originalType {
 	case "timestamp", "timestamp without time zone":
 		// Convert the instant to a wall-clock timestamp using the connection session time zone.
 		timestampExpr = "(" + timestampExpr + " AT TIME ZONE current_setting('TimeZone'))"
@@ -54,7 +62,7 @@ func postgresqlTimestampValueExpr(field *interfaces.Property) string {
 // postgresqlDateCompareExpr compares a date column with epoch milliseconds.
 func postgresqlDateCompareExpr(field *interfaces.Property, op string, value any) sq.Sqlizer {
 	return sq.Expr(
-		quoteColumnName(field.OriginalName)+" "+op+" "+postgresqlTimestampValueExpr(field),
+		quoteColumnName(field.OriginalName)+" "+op+" "+postgresqlDateValueExpr(field),
 		normalizeTimestampValue(value),
 	)
 }
@@ -63,7 +71,7 @@ func postgresqlDateSetExpr(field *interfaces.Property, op string, values []any) 
 	valueExprs := make([]string, len(values))
 	args := make([]any, len(values))
 	for i, value := range values {
-		valueExprs[i] = postgresqlTimestampValueExpr(field)
+		valueExprs[i] = postgresqlDateValueExpr(field)
 		args[i] = normalizeTimestampValue(value)
 	}
 	return sq.Expr(

--- a/adp/vega/vega-backend/server/logics/connector/local/table/postgresql/postgresql_condition.go
+++ b/adp/vega/vega-backend/server/logics/connector/local/table/postgresql/postgresql_condition.go
@@ -38,6 +38,9 @@ func normalizeTimestampValue(value any) any {
 	}
 }
 
+// postgresqlDateCompareExpr compares a date column with epoch milliseconds.
+// The explicit float8 cast prevents PostgreSQL from inferring the parameter as int4
+// from the 1000 literal, which would overflow or truncate millisecond timestamps.
 func postgresqlDateCompareExpr(columnName, op string, value any) sq.Sqlizer {
 	return sq.Expr(
 		quoteColumnName(columnName)+" "+op+" to_timestamp(?::double precision / 1000.0)",

--- a/adp/vega/vega-backend/server/logics/connector/local/table/postgresql/postgresql_condition.go
+++ b/adp/vega/vega-backend/server/logics/connector/local/table/postgresql/postgresql_condition.go
@@ -60,24 +60,39 @@ func postgresqlDateValueExpr(field *interfaces.Property) string {
 }
 
 // postgresqlDateCompareExpr compares a date column with epoch milliseconds.
-func postgresqlDateCompareExpr(field *interfaces.Property, op string, value any) sq.Sqlizer {
+func validatePostgresqlDateValue(field *interfaces.Property, value any) error {
+	if field.Type == interfaces.DataType_Time && value != nil {
+		if _, ok := value.(string); !ok {
+			return fmt.Errorf("PostgreSQL time field %q requires a time string, got %T", field.Name, value)
+		}
+	}
+	return nil
+}
+
+func postgresqlDateCompareExpr(field *interfaces.Property, op string, value any) (sq.Sqlizer, error) {
+	if err := validatePostgresqlDateValue(field, value); err != nil {
+		return nil, err
+	}
 	return sq.Expr(
 		quoteColumnName(field.OriginalName)+" "+op+" "+postgresqlDateValueExpr(field),
 		normalizeTimestampValue(value),
-	)
+	), nil
 }
 
-func postgresqlDateSetExpr(field *interfaces.Property, op string, values []any) sq.Sqlizer {
+func postgresqlDateSetExpr(field *interfaces.Property, op string, values []any) (sq.Sqlizer, error) {
 	valueExprs := make([]string, len(values))
 	args := make([]any, len(values))
 	for i, value := range values {
+		if err := validatePostgresqlDateValue(field, value); err != nil {
+			return nil, err
+		}
 		valueExprs[i] = postgresqlDateValueExpr(field)
 		args[i] = normalizeTimestampValue(value)
 	}
 	return sq.Expr(
 		quoteColumnName(field.OriginalName)+" "+op+" ("+strings.Join(valueExprs, ", ")+")",
 		args...,
-	)
+	), nil
 }
 
 func (c *PostgresqlConnector) ConvertFilterCondition(ctx context.Context, condition interfaces.FilterCondition,
@@ -211,7 +226,7 @@ func (c *PostgresqlConnector) ConvertFilterConditionEqual(ctx context.Context, c
 	switch cond.Cfg.ValueFrom {
 	case interfaces.ValueFrom_Const:
 		if interfaces.DataType_IsDate(cond.Lfield.Type) {
-			return postgresqlDateCompareExpr(cond.Lfield, "=", cond.Value), nil
+			return postgresqlDateCompareExpr(cond.Lfield, "=", cond.Value)
 		}
 		return sq.Eq{quoteColumnName(cond.Lfield.OriginalName): cond.Value}, nil
 	case interfaces.ValueFrom_Field:
@@ -232,7 +247,7 @@ func (c *PostgresqlConnector) ConvertFilterConditionNotEqual(ctx context.Context
 	switch cond.Cfg.ValueFrom {
 	case interfaces.ValueFrom_Const:
 		if interfaces.DataType_IsDate(cond.Lfield.Type) {
-			return postgresqlDateCompareExpr(cond.Lfield, "<>", cond.Value), nil
+			return postgresqlDateCompareExpr(cond.Lfield, "<>", cond.Value)
 		}
 		return sq.NotEq{quoteColumnName(cond.Lfield.OriginalName): cond.Value}, nil
 	case interfaces.ValueFrom_Field:
@@ -253,7 +268,7 @@ func (c *PostgresqlConnector) ConvertFilterConditionGt(ctx context.Context, cond
 	switch cond.Cfg.ValueFrom {
 	case interfaces.ValueFrom_Const:
 		if interfaces.DataType_IsDate(cond.Lfield.Type) {
-			return postgresqlDateCompareExpr(cond.Lfield, ">", cond.Value), nil
+			return postgresqlDateCompareExpr(cond.Lfield, ">", cond.Value)
 		}
 		return sq.Gt{quoteColumnName(cond.Lfield.OriginalName): cond.Value}, nil
 	case interfaces.ValueFrom_Field:
@@ -274,7 +289,7 @@ func (c *PostgresqlConnector) ConvertFilterConditionGte(ctx context.Context, con
 	switch cond.Cfg.ValueFrom {
 	case interfaces.ValueFrom_Const:
 		if interfaces.DataType_IsDate(cond.Lfield.Type) {
-			return postgresqlDateCompareExpr(cond.Lfield, ">=", cond.Value), nil
+			return postgresqlDateCompareExpr(cond.Lfield, ">=", cond.Value)
 		}
 		return sq.GtOrEq{quoteColumnName(cond.Lfield.OriginalName): cond.Value}, nil
 	case interfaces.ValueFrom_Field:
@@ -295,7 +310,7 @@ func (c *PostgresqlConnector) ConvertFilterConditionLt(ctx context.Context, cond
 	switch cond.Cfg.ValueFrom {
 	case interfaces.ValueFrom_Const:
 		if interfaces.DataType_IsDate(cond.Lfield.Type) {
-			return postgresqlDateCompareExpr(cond.Lfield, "<", cond.Value), nil
+			return postgresqlDateCompareExpr(cond.Lfield, "<", cond.Value)
 		}
 		return sq.Lt{quoteColumnName(cond.Lfield.OriginalName): cond.Value}, nil
 	case interfaces.ValueFrom_Field:
@@ -316,7 +331,7 @@ func (c *PostgresqlConnector) ConvertFilterConditionLte(ctx context.Context, con
 	switch cond.Cfg.ValueFrom {
 	case interfaces.ValueFrom_Const:
 		if interfaces.DataType_IsDate(cond.Lfield.Type) {
-			return postgresqlDateCompareExpr(cond.Lfield, "<=", cond.Value), nil
+			return postgresqlDateCompareExpr(cond.Lfield, "<=", cond.Value)
 		}
 		return sq.LtOrEq{quoteColumnName(cond.Lfield.OriginalName): cond.Value}, nil
 	case interfaces.ValueFrom_Field:
@@ -338,7 +353,7 @@ func (c *PostgresqlConnector) ConvertFilterConditionIn(ctx context.Context, cond
 		return nil, fmt.Errorf("condition [in] only supports ValueFrom_Const, got %s", cond.Cfg.ValueFrom)
 	}
 	if interfaces.DataType_IsDate(cond.Lfield.Type) {
-		return postgresqlDateSetExpr(cond.Lfield, "IN", cond.Value), nil
+		return postgresqlDateSetExpr(cond.Lfield, "IN", cond.Value)
 	}
 
 	return sq.Eq{quoteColumnName(cond.Lfield.OriginalName): cond.Value}, nil
@@ -356,7 +371,7 @@ func (c *PostgresqlConnector) ConvertFilterConditionNotIn(ctx context.Context, c
 		return nil, fmt.Errorf("condition [not_in] only supports ValueFrom_Const, got %s", cond.Cfg.ValueFrom)
 	}
 	if interfaces.DataType_IsDate(cond.Lfield.Type) {
-		return postgresqlDateSetExpr(cond.Lfield, "NOT IN", cond.Value), nil
+		return postgresqlDateSetExpr(cond.Lfield, "NOT IN", cond.Value)
 	}
 
 	return sq.NotEq{quoteColumnName(cond.Lfield.OriginalName): cond.Value}, nil
@@ -454,10 +469,15 @@ func (c *PostgresqlConnector) ConvertFilterConditionRange(ctx context.Context, c
 	}
 
 	if interfaces.DataType_IsDate(cond.Lfield.Type) {
-		return sq.And{
-			postgresqlDateCompareExpr(cond.Lfield, ">=", values[0]),
-			postgresqlDateCompareExpr(cond.Lfield, "<=", values[1]),
-		}, nil
+		lower, err := postgresqlDateCompareExpr(cond.Lfield, ">=", values[0])
+		if err != nil {
+			return nil, err
+		}
+		upper, err := postgresqlDateCompareExpr(cond.Lfield, "<=", values[1])
+		if err != nil {
+			return nil, err
+		}
+		return sq.And{lower, upper}, nil
 	}
 
 	return sq.And{
@@ -484,10 +504,15 @@ func (c *PostgresqlConnector) ConvertFilterConditionOutRange(ctx context.Context
 	}
 
 	if interfaces.DataType_IsDate(cond.Lfield.Type) {
-		return sq.Or{
-			postgresqlDateCompareExpr(cond.Lfield, "<", values[0]),
-			postgresqlDateCompareExpr(cond.Lfield, ">", values[1]),
-		}, nil
+		lower, err := postgresqlDateCompareExpr(cond.Lfield, "<", values[0])
+		if err != nil {
+			return nil, err
+		}
+		upper, err := postgresqlDateCompareExpr(cond.Lfield, ">", values[1])
+		if err != nil {
+			return nil, err
+		}
+		return sq.Or{lower, upper}, nil
 	}
 
 	return sq.Or{
@@ -590,10 +615,15 @@ func (c *PostgresqlConnector) ConvertFilterConditionBetween(ctx context.Context,
 	isDateType := interfaces.DataType_IsDate(fieldType)
 
 	if isDateType {
-		return sq.And{
-			postgresqlDateCompareExpr(cond.Lfield, ">=", values[0]),
-			postgresqlDateCompareExpr(cond.Lfield, "<=", values[1]),
-		}, nil
+		lower, err := postgresqlDateCompareExpr(cond.Lfield, ">=", values[0])
+		if err != nil {
+			return nil, err
+		}
+		upper, err := postgresqlDateCompareExpr(cond.Lfield, "<=", values[1])
+		if err != nil {
+			return nil, err
+		}
+		return sq.And{lower, upper}, nil
 	}
 
 	// 非时间类型字段，直接使用参数化查询

--- a/adp/vega/vega-backend/server/logics/connector/local/table/postgresql/postgresql_condition_test.go
+++ b/adp/vega/vega-backend/server/logics/connector/local/table/postgresql/postgresql_condition_test.go
@@ -65,7 +65,7 @@ func TestConvertDateGteUsesToTimestamp(t *testing.T) {
 		cond := mustNewCond(t, "created_at", ">=", float64(1710000000000))
 		sql, args := toSQL(t, c, cond)
 
-		assert.Equal(t, `"created_at" >= to_timestamp(?/1000)`, sql)
+		assert.Equal(t, `"created_at" >= to_timestamp(?::double precision / 1000.0)`, sql)
 		assert.Equal(t, []interface{}{int64(1710000000000)}, args)
 	})
 }
@@ -76,8 +76,8 @@ func TestConvertDateRangeUsesToTimestamp(t *testing.T) {
 		cond := mustNewCond(t, "created_at", "range", []any{1710000000000, 1710003600000})
 		sql, args := toSQL(t, c, cond)
 
-		assert.Contains(t, sql, `"created_at" >= to_timestamp(?/1000)`)
-		assert.Contains(t, sql, `"created_at" <= to_timestamp(?/1000)`)
+		assert.Contains(t, sql, `"created_at" >= to_timestamp(?::double precision / 1000.0)`)
+		assert.Contains(t, sql, `"created_at" <= to_timestamp(?::double precision / 1000.0)`)
 		assert.Equal(t, []interface{}{int64(1710000000000), int64(1710003600000)}, args)
 	})
 }
@@ -88,8 +88,8 @@ func TestConvertDateOutRangeUsesToTimestamp(t *testing.T) {
 		cond := mustNewCond(t, "created_at", "out_range", []any{1710000000000, 1710003600000})
 		sql, args := toSQL(t, c, cond)
 
-		assert.Contains(t, sql, `"created_at" < to_timestamp(?/1000)`)
-		assert.Contains(t, sql, `"created_at" > to_timestamp(?/1000)`)
+		assert.Contains(t, sql, `"created_at" < to_timestamp(?::double precision / 1000.0)`)
+		assert.Contains(t, sql, `"created_at" > to_timestamp(?::double precision / 1000.0)`)
 		assert.Equal(t, []interface{}{int64(1710000000000), int64(1710003600000)}, args)
 	})
 }
@@ -100,8 +100,8 @@ func TestConvertDateBetweenUsesToTimestamp(t *testing.T) {
 		cond := mustNewCond(t, "created_at", "between", []any{1710000000000, 1710003600000})
 		sql, args := toSQL(t, c, cond)
 
-		assert.Contains(t, sql, `"created_at" >= to_timestamp(?/1000)`)
-		assert.Contains(t, sql, `"created_at" <= to_timestamp(?/1000)`)
+		assert.Contains(t, sql, `"created_at" >= to_timestamp(?::double precision / 1000.0)`)
+		assert.Contains(t, sql, `"created_at" <= to_timestamp(?::double precision / 1000.0)`)
 		assert.Equal(t, []interface{}{int64(1710000000000), int64(1710003600000)}, args)
 	})
 }

--- a/adp/vega/vega-backend/server/logics/connector/local/table/postgresql/postgresql_condition_test.go
+++ b/adp/vega/vega-backend/server/logics/connector/local/table/postgresql/postgresql_condition_test.go
@@ -131,27 +131,30 @@ func TestPostgresqlDateCompareExprUsesSessionTimezoneForTimestampWithoutTimezone
 	}
 }
 
-func TestPostgresqlDateExpressionsNormalizeCursorTimestamps(t *testing.T) {
-	field := &interfaces.Property{
-		Name:         "created_at",
-		OriginalName: "created_at",
-		OriginalType: "timestamptz",
-		Type:         interfaces.DataType_Timestamp,
-	}
+func TestPostgresqlDateExpressionsKeepCursorTimestampsNative(t *testing.T) {
 	wantMillis := int64(1785295334428)
 	wantTime := time.UnixMilli(wantMillis).UTC()
 
-	for name, value := range map[string]any{
-		"time.Time": wantTime,
-		"RFC3339":   wantTime.Format(time.RFC3339Nano),
-	} {
-		t.Run(name, func(t *testing.T) {
-			expr, err := postgresqlDateCompareExpr(field, ">", value)
-			require.NoError(t, err)
-			_, args, err := expr.ToSql()
-			require.NoError(t, err)
-			assert.Equal(t, []interface{}{wantMillis}, args)
-		})
+	for _, originalType := range []string{"timestamp", "timestamptz"} {
+		field := &interfaces.Property{
+			Name:         "created_at",
+			OriginalName: "created_at",
+			OriginalType: originalType,
+			Type:         interfaces.DataType_Timestamp,
+		}
+		for name, value := range map[string]any{
+			"time.Time": wantTime,
+			"RFC3339":   wantTime.Format(time.RFC3339Nano),
+		} {
+			t.Run(originalType+"/"+name, func(t *testing.T) {
+				expr, err := postgresqlDateCompareExpr(field, ">", value)
+				require.NoError(t, err)
+				sql, args, err := expr.ToSql()
+				require.NoError(t, err)
+				assert.Equal(t, `"created_at" > ?`, sql)
+				assert.Equal(t, []interface{}{wantTime}, args)
+			})
+		}
 	}
 }
 

--- a/adp/vega/vega-backend/server/logics/connector/local/table/postgresql/postgresql_condition_test.go
+++ b/adp/vega/vega-backend/server/logics/connector/local/table/postgresql/postgresql_condition_test.go
@@ -131,6 +131,21 @@ func TestPostgresqlDateCompareExprUsesSessionTimezoneForTimestampWithoutTimezone
 }
 
 func TestPostgresqlDateExpressionsKeepTimeOfDayValuesRaw(t *testing.T) {
+	t.Run("uses semantic type when original type is absent", func(t *testing.T) {
+		field := &interfaces.Property{
+			Name:         "event_time",
+			OriginalName: "event_time",
+			Type:         interfaces.DataType_Time,
+		}
+
+		expr, err := postgresqlDateCompareExpr(field, ">=", "14:30:00")
+		require.NoError(t, err)
+		sql, args, err := expr.ToSql()
+		require.NoError(t, err)
+		assert.Equal(t, `"event_time" >= ?`, sql)
+		assert.Equal(t, []interface{}{"14:30:00"}, args)
+	})
+
 	for _, originalType := range []string{"time", "timetz", "time without time zone", "time with time zone"} {
 		t.Run(originalType, func(t *testing.T) {
 			field := &interfaces.Property{

--- a/adp/vega/vega-backend/server/logics/connector/local/table/postgresql/postgresql_condition_test.go
+++ b/adp/vega/vega-backend/server/logics/connector/local/table/postgresql/postgresql_condition_test.go
@@ -120,7 +120,9 @@ func TestPostgresqlDateCompareExprUsesSessionTimezoneForTimestampWithoutTimezone
 				OriginalType: originalType,
 			}
 
-			sql, args, err := postgresqlDateCompareExpr(field, ">=", float64(1785295334428)).ToSql()
+			expr, err := postgresqlDateCompareExpr(field, ">=", float64(1785295334428))
+			require.NoError(t, err)
+			sql, args, err := expr.ToSql()
 			require.NoError(t, err)
 			assert.Equal(t, `"created_at" >= (to_timestamp(?::double precision / 1000.0) AT TIME ZONE current_setting('TimeZone'))`, sql)
 			assert.Equal(t, []interface{}{int64(1785295334428)}, args)
@@ -136,7 +138,9 @@ func TestPostgresqlDateExpressionsKeepTimeOfDayValuesRaw(t *testing.T) {
 				OriginalType: originalType,
 			}
 
-			sql, args, err := postgresqlDateCompareExpr(field, ">=", "14:30:00").ToSql()
+			expr, err := postgresqlDateCompareExpr(field, ">=", "14:30:00")
+			require.NoError(t, err)
+			sql, args, err := expr.ToSql()
 			require.NoError(t, err)
 			assert.Equal(t, `"event_time" >= ?`, sql)
 			assert.Equal(t, []interface{}{"14:30:00"}, args)
@@ -150,6 +154,16 @@ func TestPostgresqlDateExpressionsKeepTimeOfDayValuesRaw(t *testing.T) {
 
 		assert.Equal(t, `"event_time" IN (?, ?)`, sql)
 		assert.Equal(t, []interface{}{"14:30:00", "16:45:00"}, args)
+	})
+
+	t.Run("rejects numeric time values", func(t *testing.T) {
+		c := &PostgresqlConnector{}
+		cond := mustNewCond(t, "event_time", ">=", float64(1785295334428))
+
+		expr, err := c.ConvertFilterCondition(context.Background(), cond, testFieldsMap())
+		require.Error(t, err)
+		assert.Nil(t, expr)
+		assert.Contains(t, err.Error(), "requires a time string")
 	})
 }
 

--- a/adp/vega/vega-backend/server/logics/connector/local/table/postgresql/postgresql_condition_test.go
+++ b/adp/vega/vega-backend/server/logics/connector/local/table/postgresql/postgresql_condition_test.go
@@ -70,6 +70,63 @@ func TestConvertDateGteUsesToTimestamp(t *testing.T) {
 	})
 }
 
+func TestConvertDateEqualityUsesToTimestamp(t *testing.T) {
+	c := &PostgresqlConnector{}
+
+	t.Run("uses to_timestamp for equal", func(t *testing.T) {
+		cond := mustNewCond(t, "created_at", "==", float64(1785295334428))
+		sql, args := toSQL(t, c, cond)
+
+		assert.Equal(t, `"created_at" = to_timestamp(?::double precision / 1000.0)`, sql)
+		assert.Equal(t, []interface{}{int64(1785295334428)}, args)
+	})
+
+	t.Run("uses to_timestamp for not equal", func(t *testing.T) {
+		cond := mustNewCond(t, "created_at", "!=", float64(1785295334428))
+		sql, args := toSQL(t, c, cond)
+
+		assert.Equal(t, `"created_at" <> to_timestamp(?::double precision / 1000.0)`, sql)
+		assert.Equal(t, []interface{}{int64(1785295334428)}, args)
+	})
+}
+
+func TestConvertDateSetMembershipUsesToTimestamp(t *testing.T) {
+	c := &PostgresqlConnector{}
+	values := []any{1785295334428, 1785381734428}
+
+	t.Run("uses to_timestamp for in", func(t *testing.T) {
+		cond := mustNewCond(t, "created_at", "in", values)
+		sql, args := toSQL(t, c, cond)
+
+		assert.Equal(t, `"created_at" IN (to_timestamp(?::double precision / 1000.0), to_timestamp(?::double precision / 1000.0))`, sql)
+		assert.Equal(t, []interface{}{int64(1785295334428), int64(1785381734428)}, args)
+	})
+
+	t.Run("uses to_timestamp for not in", func(t *testing.T) {
+		cond := mustNewCond(t, "created_at", "not_in", values)
+		sql, args := toSQL(t, c, cond)
+
+		assert.Equal(t, `"created_at" NOT IN (to_timestamp(?::double precision / 1000.0), to_timestamp(?::double precision / 1000.0))`, sql)
+		assert.Equal(t, []interface{}{int64(1785295334428), int64(1785381734428)}, args)
+	})
+}
+
+func TestPostgresqlDateCompareExprUsesSessionTimezoneForTimestampWithoutTimezone(t *testing.T) {
+	for _, originalType := range []string{"timestamp", "timestamp without time zone"} {
+		t.Run(originalType, func(t *testing.T) {
+			field := &interfaces.Property{
+				OriginalName: "created_at",
+				OriginalType: originalType,
+			}
+
+			sql, args, err := postgresqlDateCompareExpr(field, ">=", float64(1785295334428)).ToSql()
+			require.NoError(t, err)
+			assert.Equal(t, `"created_at" >= (to_timestamp(?::double precision / 1000.0) AT TIME ZONE current_setting('TimeZone'))`, sql)
+			assert.Equal(t, []interface{}{int64(1785295334428)}, args)
+		})
+	}
+}
+
 func TestConvertDateRangeUsesToTimestamp(t *testing.T) {
 	t.Run("uses to_timestamp for both range bounds", func(t *testing.T) {
 		c := &PostgresqlConnector{}

--- a/adp/vega/vega-backend/server/logics/connector/local/table/postgresql/postgresql_condition_test.go
+++ b/adp/vega/vega-backend/server/logics/connector/local/table/postgresql/postgresql_condition_test.go
@@ -21,6 +21,7 @@ func testFieldsMap() map[string]*interfaces.Property {
 	return map[string]*interfaces.Property{
 		"age":        {Name: "age", OriginalName: "age", Type: interfaces.DataType_Integer},
 		"created_at": {Name: "created_at", OriginalName: "created_at", Type: interfaces.DataType_Datetime},
+		"event_time": {Name: "event_time", OriginalName: "event_time", OriginalType: "time", Type: interfaces.DataType_Time},
 	}
 }
 
@@ -125,6 +126,31 @@ func TestPostgresqlDateCompareExprUsesSessionTimezoneForTimestampWithoutTimezone
 			assert.Equal(t, []interface{}{int64(1785295334428)}, args)
 		})
 	}
+}
+
+func TestPostgresqlDateExpressionsKeepTimeOfDayValuesRaw(t *testing.T) {
+	for _, originalType := range []string{"time", "timetz", "time without time zone", "time with time zone"} {
+		t.Run(originalType, func(t *testing.T) {
+			field := &interfaces.Property{
+				OriginalName: "event_time",
+				OriginalType: originalType,
+			}
+
+			sql, args, err := postgresqlDateCompareExpr(field, ">=", "14:30:00").ToSql()
+			require.NoError(t, err)
+			assert.Equal(t, `"event_time" >= ?`, sql)
+			assert.Equal(t, []interface{}{"14:30:00"}, args)
+		})
+	}
+
+	t.Run("keeps time set values raw", func(t *testing.T) {
+		c := &PostgresqlConnector{}
+		cond := mustNewCond(t, "event_time", "in", []any{"14:30:00", "16:45:00"})
+		sql, args := toSQL(t, c, cond)
+
+		assert.Equal(t, `"event_time" IN (?, ?)`, sql)
+		assert.Equal(t, []interface{}{"14:30:00", "16:45:00"}, args)
+	})
 }
 
 func TestConvertDateRangeUsesToTimestamp(t *testing.T) {

--- a/adp/vega/vega-backend/server/logics/connector/local/table/postgresql/postgresql_condition_test.go
+++ b/adp/vega/vega-backend/server/logics/connector/local/table/postgresql/postgresql_condition_test.go
@@ -135,23 +135,32 @@ func TestPostgresqlDateExpressionsKeepCursorTimestampsNative(t *testing.T) {
 	wantMillis := int64(1785295334428)
 	wantTime := time.UnixMilli(wantMillis).UTC()
 
-	for _, originalType := range []string{"timestamp", "timestamptz"} {
+	tests := []struct {
+		originalType string
+		fieldType    string
+		wantSQL      string
+	}{
+		{originalType: "timestamp", fieldType: interfaces.DataType_Timestamp, wantSQL: `"created_at" > ?::timestamp`},
+		{originalType: "date", fieldType: interfaces.DataType_Date, wantSQL: `"created_at" > ?::timestamp`},
+		{originalType: "timestamptz", fieldType: interfaces.DataType_Timestamp, wantSQL: `"created_at" > ?`},
+	}
+	for _, test := range tests {
 		field := &interfaces.Property{
 			Name:         "created_at",
 			OriginalName: "created_at",
-			OriginalType: originalType,
-			Type:         interfaces.DataType_Timestamp,
+			OriginalType: test.originalType,
+			Type:         test.fieldType,
 		}
 		for name, value := range map[string]any{
 			"time.Time": wantTime,
 			"RFC3339":   wantTime.Format(time.RFC3339Nano),
 		} {
-			t.Run(originalType+"/"+name, func(t *testing.T) {
+			t.Run(test.originalType+"/"+name, func(t *testing.T) {
 				expr, err := postgresqlDateCompareExpr(field, ">", value)
 				require.NoError(t, err)
 				sql, args, err := expr.ToSql()
 				require.NoError(t, err)
-				assert.Equal(t, `"created_at" > ?`, sql)
+				assert.Equal(t, test.wantSQL, sql)
 				assert.Equal(t, []interface{}{wantTime}, args)
 			})
 		}

--- a/adp/vega/vega-backend/server/logics/connector/local/table/postgresql/postgresql_condition_test.go
+++ b/adp/vega/vega-backend/server/logics/connector/local/table/postgresql/postgresql_condition_test.go
@@ -9,6 +9,7 @@ package postgresql
 import (
 	"context"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -126,6 +127,30 @@ func TestPostgresqlDateCompareExprUsesSessionTimezoneForTimestampWithoutTimezone
 			require.NoError(t, err)
 			assert.Equal(t, `"created_at" >= (to_timestamp(?::double precision / 1000.0) AT TIME ZONE current_setting('TimeZone'))`, sql)
 			assert.Equal(t, []interface{}{int64(1785295334428)}, args)
+		})
+	}
+}
+
+func TestPostgresqlDateExpressionsNormalizeCursorTimestamps(t *testing.T) {
+	field := &interfaces.Property{
+		Name:         "created_at",
+		OriginalName: "created_at",
+		OriginalType: "timestamptz",
+		Type:         interfaces.DataType_Timestamp,
+	}
+	wantMillis := int64(1785295334428)
+	wantTime := time.UnixMilli(wantMillis).UTC()
+
+	for name, value := range map[string]any{
+		"time.Time": wantTime,
+		"RFC3339":   wantTime.Format(time.RFC3339Nano),
+	} {
+		t.Run(name, func(t *testing.T) {
+			expr, err := postgresqlDateCompareExpr(field, ">", value)
+			require.NoError(t, err)
+			_, args, err := expr.ToSql()
+			require.NoError(t, err)
+			assert.Equal(t, []interface{}{wantMillis}, args)
 		})
 	}
 }


### PR DESCRIPTION
# Pull Request

## What Changed

Brief description of changes:

- [x] Fix PostgreSQL epoch-millisecond conversion for date and timestamp comparisons
- [x] Cover date-field `eq`, `not_eq`, `in`, and `not_in` filters in PostgreSQL and MariaDB
- [x] Convert PostgreSQL `timestamp without time zone` epoch values using the connection session time zone
- [x] Preserve time-of-day strings and reject numeric values for `time`/`timetz` fields
- [x] Preserve native incremental-build date cursors without epoch/time-zone round trips
- [x] Explicitly type PostgreSQL unzoned native cursors as `timestamp`
- [x] Add unit tests for comparisons, set membership, validation, time zones, and cursor values

---

## Why

- Related Issue: Fixes #550
- Related Feature: N/A
- Background: PostgreSQL inferred `to_timestamp(?/1000)` parameters as `integer`, causing millisecond timestamps to overflow. Date equality and membership filters were inconsistent across SQL connectors. Pure time fields need time-of-day strings, while incremental-build date cursors must retain source wall-clock semantics independently of database session time zones.

---

## How

- Key implementation points:
  - PostgreSQL casts numeric epoch milliseconds to `double precision` and divides by `1000.0`.
  - PostgreSQL and MariaDB convert numeric constant date filters for all comparison, range, and set-membership operations.
  - PostgreSQL unzoned timestamp epoch filters explicitly use `current_setting('TimeZone')`.
  - Pure time fields keep raw string parameters and reject non-string values.
  - MariaDB rejects non-epoch date strings before MySQL can silently coerce them.
  - Both connectors bind `time.Time` and parsed RFC3339/RFC3339Nano cursors natively.
  - PostgreSQL uses `?::timestamp` for native `timestamp without time zone`/`date` cursors and bare `?` for `timestamptz`.
- Breaking changes (API, config, database, etc.): Invalid numeric values for pure time fields and non-epoch MariaDB date strings now return explicit validation errors.

---

## Testing

- [x] Unit tests passed locally
- [ ] Integration tests passed locally
- [ ] Verified in test environment

Test notes:

- `go test ./logics/connector/local/table/postgresql ./logics/connector/local/table/mariadb`
- `go test ./...` from `adp/vega/vega-backend/server`
- `go vet ./logics/connector/local/table/postgresql ./logics/connector/local/table/mariadb`

---

## Risk & Rollback

- Potential risks: Limited to PostgreSQL and MariaDB date/time filters with constant values and incremental-build date cursors.
- Rollback plan: Revert commits `81bf2df6`, `525fd502`, `b4ff091d`, `d2e9b522`, `23382333`, `2d12a75c`, `ab5c85df`, `7f8de54b`, and `4a168b08`.

---

## Additional Notes

- No API, schema, migration, or deployment changes.