### PR TITLE
docs(help): BKN / 快速开始 / cookbook / 安装文档对齐 CLI 0.1.2

### DIFF
--- a/help/en/cookbook/cookbook_example.md
+++ b/help/en/cookbook/cookbook_example.md
@@ -20,28 +20,31 @@
 
 ## 3. Steps
 
-### 3.1 Pick or create a datasource
+### 3.1 Pick or create a catalog
 
-List existing datasources first:
-
-```bash
-openbkn ds list
-```
-
-Connect a new one if none fits (MySQL example):
+List existing catalogs first:
 
 ```bash
-openbkn ds connect mysql db.example.com 3306 erp \
-  --account root --password pass123
-# → returns ds_id
+openbkn vega catalog list
 ```
 
-> Record **`<ds_id>`** — the rest of the recipe assumes it's already known.
+Register a new one if none fits (MySQL example):
+
+```bash
+openbkn vega catalog create --name "erp" --connector-type mysql \
+  --connector-config '{"host":"db.example.com","port":3306,"username":"root","password":"pass123","databases":["erp"]}'
+# → returns a catalog id
+
+openbkn vega catalog enable <catalog_id>
+openbkn vega catalog discover <catalog_id> --wait
+```
+
+> Record **`<catalog_id>`** — the rest of the recipe assumes it's already known.
 
 ### 3.2 One-shot: build a KN from CSV
 
 ```bash
-openbkn bkn create-from-csv <ds_id> \
+openbkn bkn create-from-csv <catalog_id> \
   --files "materials.csv,inventory.csv" \
   --name "supply-kn" \
   --table-prefix sc_
@@ -53,7 +56,7 @@ Quick parameter reference:
 
 | Parameter | Required | Description |
 | --- | --- | --- |
-| `<ds_id>` | yes | Datasource that stages the CSVs |
+| `<catalog_id>` | yes | Catalog whose database stages the CSVs |
 | `--files` | yes | Comma-separated paths or a glob (e.g. `"*.csv"`) |
 | `--name` | yes | Knowledge network name |
 | `--table-prefix` | no | Prefix for staging tables (avoids name clashes) |
@@ -63,9 +66,17 @@ Quick parameter reference:
 <details>
 <summary>Equivalent two-step path (use this when you want to override primary/display keys)</summary>
 
-```bash
-openbkn ds import-csv <ds_id> --files "*.csv" --table-prefix sc_
-openbkn bkn create-from-ds <ds_id> --name "supply-kn" --build
+```
+
+> **This command does not currently work**: its CSV loading depends on the retired dataflow path.
+> Use the step-by-step route below (mysql client → re-discover → `create-from-catalog`);
+> `examples/02-csv-to-kn` is a runnable version.bash
+# 1. Load the CSVs with the mysql client (the platform-side import-csv is retired)
+mysql -h db.example.com -u root -p erp < load_csv.sql
+
+# 2. Re-discover tables, then build the KN from the catalog
+openbkn vega catalog discover <catalog_id> --wait
+openbkn bkn create-from-catalog <catalog_id> --name "supply-kn" --build
 ```
 
 In the step-by-step path you can pass `--primary-key` / `--display-key` to `bkn object-type create` to pin the keys explicitly.
@@ -115,8 +126,8 @@ A non-empty `concepts` list from `bkn search` indicates the retrieval pipeline i
 | --- | --- | --- |
 | `401 Unauthorized`, or response body contains `oauth info is not active` | Token expired | `openbkn auth login <platform-url>` |
 | `openbkn bkn object-type list <kn_id>` prints `[]` | Wrong path or glob matched nothing | Check `--files`; use absolute paths if needed |
-| `object-type query` response shows `total = 0` | Build incomplete or mapping mismatch | `openbkn bkn stats <kn_id>` to check `doc_count`; rebuild with `openbkn bkn build <kn_id> --wait --timeout 600` |
-| `ds import-csv` reports `table already exists` | Staging table already there | First batch with `--recreate`: `openbkn ds import-csv <ds_id> --files "*.csv" --recreate` |
+| `object-type query` response shows `total = 0` | Empty source table, wrong mapping, or an index that never completed | Check the source with `openbkn vega resource query <resource_id> --limit 5`; if you built an index, check `index_health` via `openbkn vega dataset build-list --resource-id <resource_id>` |
+| Loading CSVs reports `table already exists` | The table is already there | Add `DROP TABLE IF EXISTS` to the SQL (the platform-side `ds import-csv` is retired; loading is done by the mysql client) |
 | Auto-detected primary key is not your business key | Heuristic could not infer it | Use the step-by-step path and pass `openbkn bkn object-type create ... --primary-key ... --display-key ...` |
 | `bkn search` returns `HTTP 500` | The view does not support full-text search | Switch the query `condition` from `match` to `like` |
 

--- a/help/en/cookbook/cookbook_example.md
+++ b/help/en/cookbook/cookbook_example.md
@@ -48,9 +48,12 @@ openbkn bkn create-from-csv <catalog_id> \
   --files "materials.csv,inventory.csv" \
   --name "supply-kn" \
   --table-prefix sc_
-# → Imports the CSVs, creates the dataview, the OTs, and runs the index build.
 # → Returns kn_id.
 ```
+
+> **This command does not currently work**: its CSV loading depends on the retired dataflow path.
+> Use the two-step route below (mysql client → re-discover → `create-from-catalog`);
+> `examples/02-csv-to-kn` is a runnable version.
 
 Quick parameter reference:
 
@@ -66,11 +69,7 @@ Quick parameter reference:
 <details>
 <summary>Equivalent two-step path (use this when you want to override primary/display keys)</summary>
 
-```
-
-> **This command does not currently work**: its CSV loading depends on the retired dataflow path.
-> Use the step-by-step route below (mysql client → re-discover → `create-from-catalog`);
-> `examples/02-csv-to-kn` is a runnable version.bash
+```bash
 # 1. Load the CSVs with the mysql client (the platform-side import-csv is retired)
 mysql -h db.example.com -u root -p erp < load_csv.sql
 

--- a/help/en/install.md
+++ b/help/en/install.md
@@ -274,7 +274,7 @@ Typical flags:
 2. **`openbkn` on `PATH`** (`onboard_ensure_bkn_cli`) — runs `npm i -g @openbkn/bkn-sdk` if missing (interactive prompt, or auto under `-y`). Admin is built in via the `openbkn admin` subcommand — no separate package.
 3. **Admin auth** (`onboard_ensure_bkn_auth` (shared by admin and business use)) — admin operations reuse the **same `openbkn` login / token store** as step 1 (`admin` + recorded initial-password defaults). Uses `-u` / `-p` / `-k` (HTTP `/oauth2/signin` is selected automatically). On a TTY a browser flow is also offered.
 4. **User `test`** (`onboard_provision_bkn_safe_test_user`) — created with password `111111` (override with `ONBOARD_TEST_USER_PASSWORD`), every role from `openbkn admin role list` assigned, then **`openbkn auth login` as `test`** so the SDK session matches the business user for the next steps. If `test` already exists, only role-sync runs.
-5. **Model registration** (interactive or YAML) — uses **`~/.bkn` as `test`**. The Context Loader built-in toolbox is registered by the platform install flow and is no longer a separate onboard step; see [Quick Start](quick-start.md) for how to verify it.
+5. **Model registration** (interactive or YAML) — uses **`~/.bkn` as `test`**. The Context Loader built-in toolbox is auto-imported by agent-retrieval at startup and is no longer a separate onboard step; see [Quick Start](quick-start.md) for how to verify it.
 
 If any step fails, the script exits non-zero with a clear message; re-run `sudo bash deploy/onboard.sh` (Linux) / `bash deploy/onboard.sh` (macOS dev) after fixing the cause — earlier successful steps are detected and skipped (idempotent re-runs).
 

--- a/help/en/install.md
+++ b/help/en/install.md
@@ -275,7 +275,7 @@ Typical flags:
 2. **`openbkn` on `PATH`** (`onboard_ensure_kweaver_admin_for_isf`) — runs `npm i -g @openbkn/bkn-sdk` if missing (interactive prompt, or auto under `-y`). Admin is built in via the `openbkn admin` subcommand — no separate package.
 3. **Admin auth** (`onboard_ensure_kweaver_admin_auth_for_isf`) — admin operations reuse the **same `openbkn` login / token store** as step 1 (`admin` + recorded initial-password defaults). Uses `-u` / `-p` / `-k` (HTTP `/oauth2/signin` is selected automatically). On a TTY a browser flow is also offered.
 4. **User `test`** (`onboard_offer_isf_test_user`) — created with password `111111` (override with `ONBOARD_TEST_USER_PASSWORD`), every role from `openbkn admin role list` assigned, then **`openbkn auth login` as `test`** so the SDK session matches the business user for the next steps. If `test` already exists, only role-sync runs.
-5. **Context Loader + model registration** (`onboard_offer_context_loader_toolset` → `openbkn call impex`; then interactive / YAML model registration) — both use **`~/.bkn` as `test`** (the console `admin` session usually returns `403` on impex).
+5. **Model registration** (interactive or YAML) — uses **`~/.bkn` as `test`**. The Context Loader built-in toolbox is registered by the platform install flow and is no longer a separate onboard step; see [Quick Start](quick-start.md) for how to verify it.
 
 If any step fails, the script exits non-zero with a clear message; re-run `sudo bash deploy/onboard.sh` (Linux) / `bash deploy/onboard.sh` (macOS dev) after fixing the cause — earlier successful steps are detected and skipped (idempotent re-runs).
 
@@ -314,10 +314,10 @@ flowchart TB
     A["onboard_ensure_kweaver_auth\n(openbkn: HTTP default admin + recorded initial password, or browser)"] --> B["kubectl: ns or target namespace"]
     B --> C["onboard_prepend_npm_global_bin_to_path"]
     C --> D["onboard_recommend_admin_cli (Helm / ns → full-auth?)"]
-    D --> E["onboard_ensure_kweaver_admin_for_isf\n(npm -g openbkn on full-auth installs if needed)"]
+    D --> E["ensure admin CLI\n(npm -g openbkn on full-auth installs if needed)"]
     E --> F["onboard_ensure_kweaver_admin_auth_for_isf\n(admin auth: same openbkn defaults, or -k browser; -y: auto HTTP)"]
     F --> G1["onboard_offer_isf_test_user\ncreate or sync test + roles"]
-    G1 --> G2["onboard_isf_relogin…\nopenbkn auth as test (HTTP)"]
+    G1 --> G2["onboard re-login…\nopenbkn auth login … -u test (HTTP)"]
     G2 --> H["onboard_offer_context_loader_toolset\n(openbkn impex)"]
   end
 ```
@@ -338,8 +338,8 @@ sequenceDiagram
   O->>A: openbkn admin (same login / token) — HTTP defaults or -k browser
   A->>A: user create, password, assign roles
   A-->>O: user list OK
-  O->>K: openbkn auth as test — HTTP (test password)
-  O->>K: openbkn call impex / later openbkn steps
+  O->>K: openbkn auth login -u test — HTTP (test password)
+  O->>K: model registration / later openbkn steps
 ```
 
 After **probe**, the default path continues with **Namespace + models + BKN** in this shell: **~/.bkn** should already be **test** on a full-auth install so those calls use the business user.

--- a/help/en/install.md
+++ b/help/en/install.md
@@ -278,7 +278,7 @@ Typical flags:
 
 If any step fails, the script exits non-zero with a clear message; re-run `sudo bash deploy/onboard.sh` (Linux) / `bash deploy/onboard.sh` (macOS dev) after fixing the cause — earlier successful steps are detected and skipped (idempotent re-runs).
 
-**Minimum install** (`--minimum`): only `openbkn auth` (often `--no-auth`); the full-auth-only steps 2–4 above are no-ops (admin tasks need the auth-enabled backend), 
+**Minimum install** (`--minimum`): only `openbkn auth` (often `--no-auth`); the full-auth-only steps 2–4 above are no-ops (admin tasks need the auth-enabled backend).
 
 At the end, an **English completion report** is printed unless `ONBOARD_NO_COMPLETION_REPORT=1`.
 

--- a/help/en/install.md
+++ b/help/en/install.md
@@ -263,23 +263,22 @@ Typical flags:
 
 | Flag | Meaning |
 | --- | --- |
-| *(none)* | Interactive: walks through Node / `openbkn` install (if missing), auth (single CLI — admin is built in via `openbkn admin`), then model / BKN / Context Loader prompts |
-| `-y` / `--yes` | Auto-accept all prompts: bootstrap, full-auth HTTP defaults (`admin` + the per-install initial password from `bknSafe.initialPassword` in config.yaml), `test` user creation + role sync, `openbkn` relogin as `test`, Context Loader import. Skips interactive **model registration**; use `--config=models.yaml` for non-interactive model registration. |
+| *(none)* | Interactive: walks through Node / `openbkn` install (if missing), auth (single CLI — admin is built in via `openbkn admin`), then model / BKN prompts |
+| `-y` / `--yes` | Auto-accept all prompts: bootstrap, full-auth HTTP defaults (`admin` + the per-install initial password from `bknSafe.initialPassword` in config.yaml), `test` user creation + role sync, `openbkn` relogin as `test`. Skips interactive **model registration**; use `--config=models.yaml` for non-interactive model registration. |
 | `--config=models.yaml` | Non-interactive: register models (and optional BKN) via YAML; see `deploy/conf/models.yaml.example` |
 | `--enable-bkn-search` | BKN ConfigMap patch only (after probe) |
-| `--skip-context-loader` | Skip ADP Context Loader toolbox import |
 
 **Full install (auth + business domain):** onboarding treats the cluster as a full-auth install when related Helm releases or namespaces exist. **`onboard.sh` then performs the following 5 steps automatically** (you do **not** need to run them by hand — they are listed here so you know what is happening, and what to fall back to if a step fails):
 
-1. **`openbkn auth login`** (`onboard_ensure_kweaver_auth`) — session saved under `~/.bkn`. HTTP defaults to `admin` + the per-install initial password (`bknSafe.initialPassword` in config.yaml) (or browser OAuth on a TTY); under `-y` HTTP defaults are used automatically.
-2. **`openbkn` on `PATH`** (`onboard_ensure_kweaver_admin_for_isf`) — runs `npm i -g @openbkn/bkn-sdk` if missing (interactive prompt, or auto under `-y`). Admin is built in via the `openbkn admin` subcommand — no separate package.
-3. **Admin auth** (`onboard_ensure_kweaver_admin_auth_for_isf`) — admin operations reuse the **same `openbkn` login / token store** as step 1 (`admin` + recorded initial-password defaults). Uses `-u` / `-p` / `-k` (HTTP `/oauth2/signin` is selected automatically). On a TTY a browser flow is also offered.
-4. **User `test`** (`onboard_offer_isf_test_user`) — created with password `111111` (override with `ONBOARD_TEST_USER_PASSWORD`), every role from `openbkn admin role list` assigned, then **`openbkn auth login` as `test`** so the SDK session matches the business user for the next steps. If `test` already exists, only role-sync runs.
+1. **`openbkn auth login`** (`onboard_ensure_bkn_auth`) — session saved under `~/.bkn`. HTTP defaults to `admin` + the per-install initial password (`bknSafe.initialPassword` in config.yaml) (or browser OAuth on a TTY); under `-y` HTTP defaults are used automatically.
+2. **`openbkn` on `PATH`** (`onboard_ensure_bkn_cli`) — runs `npm i -g @openbkn/bkn-sdk` if missing (interactive prompt, or auto under `-y`). Admin is built in via the `openbkn admin` subcommand — no separate package.
+3. **Admin auth** (`onboard_ensure_bkn_auth` (shared by admin and business use)) — admin operations reuse the **same `openbkn` login / token store** as step 1 (`admin` + recorded initial-password defaults). Uses `-u` / `-p` / `-k` (HTTP `/oauth2/signin` is selected automatically). On a TTY a browser flow is also offered.
+4. **User `test`** (`onboard_provision_bkn_safe_test_user`) — created with password `111111` (override with `ONBOARD_TEST_USER_PASSWORD`), every role from `openbkn admin role list` assigned, then **`openbkn auth login` as `test`** so the SDK session matches the business user for the next steps. If `test` already exists, only role-sync runs.
 5. **Model registration** (interactive or YAML) — uses **`~/.bkn` as `test`**. The Context Loader built-in toolbox is registered by the platform install flow and is no longer a separate onboard step; see [Quick Start](quick-start.md) for how to verify it.
 
 If any step fails, the script exits non-zero with a clear message; re-run `sudo bash deploy/onboard.sh` (Linux) / `bash deploy/onboard.sh` (macOS dev) after fixing the cause — earlier successful steps are detected and skipped (idempotent re-runs).
 
-**Minimum install** (`--minimum`): only `openbkn auth` (often `--no-auth`); the full-auth-only steps 2–4 above are no-ops (admin tasks need the auth-enabled backend), and Context Loader (step 5) only runs if the operator deployment is present.
+**Minimum install** (`--minimum`): only `openbkn auth` (often `--no-auth`); the full-auth-only steps 2–4 above are no-ops (admin tasks need the auth-enabled backend), 
 
 At the end, an **English completion report** is printed unless `ONBOARD_NO_COMPLETION_REPORT=1`.
 
@@ -296,7 +295,7 @@ flowchart TB
   mode -->|default: interactive; optional -y| p3[onboard_probe] --> ui["Namespace + LLM/embedding (skip-if-already-exists) + BKN patch (only when default actually changes)"] --> r2[Completion report] --> e3([exit 0])
 ```
 
-- **`onboard_probe` runs in all three modes** before BKN-only, YAML, or interactive model registration. On a **full-auth install**, it includes **admin HTTP auth (same `openbkn` defaults)**, **user `test`**, **`openbkn` relogin as `test`**, then **Context Loader** when applicable.
+- **`onboard_probe` runs in all three modes** before BKN-only, YAML, or interactive model registration. On a **full-auth install**, it includes **admin HTTP auth (same `openbkn` defaults)**, **user `test`**, **`openbkn` relogin as `test`**, then model registration.
 - **`-y`** does not set `--config`; it mainly auto-accepts **Node / npm -g** bootstrap and **full-auth** `openbkn` **HTTP** auth defaults where applicable. Under `-y` the interactive model section is skipped (use `--config=models.yaml` to register non-interactively); the completion report still shows what is already on the platform.
 - **Re-runs are safe.** Interactive model registration **detects what is already there** and only asks to add more:
   - **LLM** — if any LLM is already registered, the script asks `Register another LLM now? [y/N]` (default **No**).
@@ -311,20 +310,20 @@ flowchart TB
 ```mermaid
 flowchart TB
   subgraph probe["onboard_probe"]
-    A["onboard_ensure_kweaver_auth\n(openbkn: HTTP default admin + recorded initial password, or browser)"] --> B["kubectl: ns or target namespace"]
+    A["onboard_ensure_bkn_auth\n(openbkn: HTTP default admin + recorded initial password, or browser)"] --> B["kubectl: ns or target namespace"]
     B --> C["onboard_prepend_npm_global_bin_to_path"]
     C --> D["onboard_recommend_admin_cli (Helm / ns → full-auth?)"]
     D --> E["ensure admin CLI\n(npm -g openbkn on full-auth installs if needed)"]
-    E --> F["onboard_ensure_kweaver_admin_auth_for_isf\n(admin auth: same openbkn defaults, or -k browser; -y: auto HTTP)"]
-    F --> G1["onboard_offer_isf_test_user\ncreate or sync test + roles"]
+    E --> F["admin auth (same openbkn defaults)\n(admin auth: same openbkn defaults, or -k browser; -y: auto HTTP)"]
+    F --> G1["onboard_provision_bkn_safe_test_user\ncreate or sync test + roles"]
     G1 --> G2["onboard re-login…\nopenbkn auth login … -u test (HTTP)"]
-    G2 --> H["onboard_offer_context_loader_toolset\n(openbkn impex)"]
+    G2 --> H["model registration (interactive or --config=models.yaml)"]
   end
 ```
 
-On **minimum (no-auth)** installs, the full-auth-only steps do not require the admin backend and typically skip the **test** / **relogin** / impex gating; Context Loader may still run if the operator deployment exists.
+On **minimum (no-auth)** installs, the full-auth-only steps do not require the admin backend and typically skip the **test** / **relogin** gating.
 
-**3) Full-auth install: who talks to whom (user `test` + Context Loader impex)**
+**3) Full-auth install: who talks to whom (user `test`)**
 
 ```mermaid
 sequenceDiagram
@@ -344,7 +343,7 @@ sequenceDiagram
 
 After **probe**, the default path continues with **Namespace + models + BKN** in this shell: **~/.bkn** should already be **test** on a full-auth install so those calls use the business user.
 
-The `openbkn` CLI and its `admin` subcommand share **one** login and token store. For impex, **`openbkn` must be signed in as `test`**, not the initial console `admin` session when the API returns 403.
+The `openbkn` CLI and its `admin` subcommand share **one** login and token store. Business-plane work such as model registration uses the `test` session; the initial console `admin` session often gets 403 there.
 
 ---
 

--- a/help/en/manual/bkn.md
+++ b/help/en/manual/bkn.md
@@ -182,18 +182,22 @@ openbkn bkn create-from-catalog <catalog_id> \
   --tables orders,customers,products \
   --build --embedding-model <model-name>
 
-# From CSV files
+# From CSV files (load them into the catalog's database first, then build)
 openbkn bkn create-from-csv <catalog_id> \
   --files "./data/*.csv" \
   --name "analytics-network" \
   --build
 ```
 
----
-
 Catalog registration and table discovery are covered in [Data Ingestion](datasource.md).
 `--build` submits one Vega build task per resource; index configuration lives on the
 resource — see [VEGA Engine](vega.md).
+
+`create-from-csv` still exists in the CLI, but its CSV loading depends on the retired
+dataflow path and does not work on current deployments — load the files with the `mysql`
+client first, then use `create-from-catalog` (see `examples/02-csv-to-kn`).
+
+---
 
 ## 💻 CLI
 

--- a/help/en/manual/bkn.md
+++ b/help/en/manual/bkn.md
@@ -160,8 +160,10 @@ openbkn bkn push ./supply-chain/
 # 4. List the created network
 openbkn bkn list
 
-# 5. Build indexes
-openbkn bkn build <kn_id> --wait
+# 5. Build search indexes for the bound resources (one per resource)
+openbkn vega dataset build <resource_id> --mode batch --execute-type full \
+  --build-key-fields <pk-column> --fulltext-fields <text-column> \
+  --embedding-fields <text-column> --embedding-model <model-name> --wait
 
 # 6. Verify with semantic search
 openbkn bkn search <kn_id> "materials running low on stock"
@@ -174,20 +176,24 @@ openbkn bkn search <kn_id> "materials running low on stock"
 Instead of writing BKN files, you can generate a knowledge network directly from an existing data source:
 
 ```bash
-# From a database: auto-discover table schemas and build indexes
-openbkn bkn create-from-ds <ds_id> \
+# From a Vega catalog: discovered tables become object types; --build also indexes them
+openbkn bkn create-from-catalog <catalog_id> \
   --name "sales-network" \
   --tables orders,customers,products \
-  --build --timeout 300
+  --build --embedding-model <model-name>
 
 # From CSV files
-openbkn bkn create-from-csv <ds_id> \
+openbkn bkn create-from-csv <catalog_id> \
   --files "./data/*.csv" \
   --name "analytics-network" \
   --build
 ```
 
 ---
+
+Catalog registration and table discovery are covered in [Data Ingestion](datasource.md).
+`--build` submits one Vega build task per resource; index configuration lives on the
+resource — see [VEGA Engine](vega.md).
 
 ## 💻 CLI
 
@@ -200,12 +206,15 @@ openbkn bkn get <kn_id> --export
 openbkn bkn pull <kn_id> ./export-dir/
 ```
 
-### Build and Push
+### Validate and Push
 
 ```bash
-openbkn bkn build <kn_id> --wait --timeout 300
 openbkn bkn validate ./my-network/
 openbkn bkn push ./my-network/ --branch main
+
+# There is no KN-level build API; search indexes are built per resource
+openbkn vega dataset build <resource_id> --mode batch --execute-type full \
+  --build-key-fields <pk-column> --wait
 ```
 
 ### Object Type CRUD
@@ -300,12 +309,16 @@ openbkn bkn action-execution get <kn_id> <execution_id>
 ### End-to-End Example
 
 ```bash
-# 1. Connect a MySQL data source
-openbkn ds connect mysql db.example.com 3306 mydb --account root --password secret
-# → ds_id: ds-abc123
+# 1. Register a MySQL catalog and discover its tables
+CAT=$(openbkn --json vega catalog create --name "ecommerce-db" --connector-type mysql \
+  --connector-config '{"host":"db.example.com","port":3306,"username":"root","password":"secret","databases":["mydb"]}' \
+  | python3 -c 'import json,sys;print(json.load(sys.stdin)["id"])')
+openbkn vega catalog enable "$CAT"
+openbkn vega catalog discover "$CAT" --wait
 
-# 2. Create a knowledge network from the data source
-openbkn bkn create-from-ds ds-abc123 --name "ecommerce" --tables orders,customers --build --wait
+# 2. Create a knowledge network from the catalog
+openbkn bkn create-from-catalog "$CAT" --name "ecommerce" --tables orders,customers \
+  --build --embedding-model <model-name>
 
 # 3. Inspect the generated object types
 openbkn bkn object-type list <kn_id>

--- a/help/en/quick-start.md
+++ b/help/en/quick-start.md
@@ -2,7 +2,7 @@
 
 This walkthrough assumes BKN Foundry is already [installed and deployed](install.md), including the post-install checks on that page. **Full installs assume Linux**; optional **macOS** + kind flow: [`deploy/dev/README.md`](../../deploy/dev/README.md) ([中文](../../deploy/dev/README.zh.md)).
 
-> Before installing on a new host, run **`sudo bash deploy/preflight.sh`** (check / `--fix`) to validate kernel, sysctl, containerd, kubectl, helm, Node and the `openbkn` CLI. After `deploy.sh openbkn install`, run **`sudo bash deploy/onboard.sh`** (Linux — matches `sudo deploy.sh`; macOS dev path uses plain `bash`) to register an LLM + embedding, patch the BKN ConfigMap (only when the default actually changes), and on a full install create the business user **`test`** + import the Context Loader toolset. Both are documented in [Install — Pre-install host check / fix: `preflight.sh`](install.md#-pre-install-host-check--fix-preflightsh) and [Install — Post-install: `onboard.sh`](install.md#post-install-onboardsh).
+> Before installing on a new host, run **`sudo bash deploy/preflight.sh`** (check / `--fix`) to validate kernel, sysctl, containerd, kubectl, helm, Node and the `openbkn` CLI. After `deploy.sh openbkn install`, run **`sudo bash deploy/onboard.sh`** (Linux — matches `sudo deploy.sh`; macOS dev path uses plain `bash`) to register an LLM + embedding, patch the BKN ConfigMap (only when the default actually changes), and on a full install create the business user **`test`** (the Context Loader toolset is auto-imported by agent-retrieval at startup, not by onboard). Both are documented in [Install — Pre-install host check / fix: `preflight.sh`](install.md#-pre-install-host-check--fix-preflightsh) and [Install — Post-install: `onboard.sh`](install.md#post-install-onboardsh).
 
 > **Model configuration note**: **Register at least one LLM and one embedding (vector) small model** when possible: the LLM powers Agent chat and reasoning; the embedding model powers semantic search and vectorization. Semantic search (Step 4) and Agent chat (Step 5) depend on these; after registering an embedding, complete [Enable BKN semantic search](manual/model.md#enable-bkn-semantic-search) in the cluster (ConfigMap / default small-model name). Other registration details are in [Model management](manual/model.md). A `--minimum` install has no bundled models; see also [Install and deploy — Configure models](install.md#configure-models). Data source connection, knowledge network creation, and conditional queries work without models.
 
@@ -85,7 +85,7 @@ After a successful browser login, the page states you can close the tab and expl
 openbkn config show
 ```
 
-The Context Loader toolset (used by agents to query knowledge networks) is registered as a built-in toolbox by the platform install flow. To verify it is registered:
+The Context Loader toolset (used by agents to query knowledge networks) is **auto-imported by agent-retrieval at startup** — there is no manual step (`deploy/scripts/lib/onboard_report.sh:105` says the same). So if it is missing, check whether agent-retrieval came up rather than re-running the installer. To verify:
 
 ```bash
 openbkn call '/api/agent-operator-integration/v1/tool-box/list?name=contextloader&page=1&page_size=50' -bd bd_public --pretty

--- a/help/en/quick-start.md
+++ b/help/en/quick-start.md
@@ -85,13 +85,13 @@ After a successful browser login, the page states you can close the tab and expl
 openbkn config show
 ```
 
-The Context Loader toolset ADP (used by agents to query knowledge networks) is now imported by **`onboard.sh`** via `openbkn call impex` (no longer by `deploy.sh`). To verify it is registered on the platform:
+The Context Loader toolset (used by agents to query knowledge networks) is registered as a built-in toolbox by the platform install flow. To verify it is registered:
 
 ```bash
 openbkn call '/api/agent-operator-integration/v1/tool-box/list?name=contextloader&page=1&page_size=50' -bd bd_public --pretty
 ```
 
-(This differs from `openbkn context-loader tools`: the former lists Operator toolboxes; the latter lists MCP tools.)
+(That lists Operator-side toolboxes. For the MCP tool catalog use `openbkn context info`, or `openbkn context tools <kn-id>` for one knowledge network.)
 
 If later commands return empty results, the domain may be wrong. The next two commands — **`openbkn config list-bd`** and **`openbkn config set-bd`** — require the platform’s **business-domain management service**. **`--minimum` / minimal installs omit that service**, so **these two CLI subcommands are not available** (e.g. `list-bd` returns **404**). That does **not** mean there is no business domain or that `config show` is wrong — on minimal installs **do not run** the commands below; trust `config show`. Use them only on a **full install** when you need to **list or switch** among multiple domains:
 
@@ -105,21 +105,28 @@ openbkn config set-bd <uuid>
 > - **`openbkn auth whoami`** needs an `id_token` from OAuth login. If you used `openbkn auth login … --no-auth` (or the platform is a minimal / no-auth install), the CLI is in **no-auth** mode and `whoami` will report no `id_token` — **expected**; use `openbkn auth status` to confirm no-auth.
 > - **`openbkn config list-bd` / `set-bd`**: As above, **minimal installs do not include** the backend for these two subcommands. Use `config show` for the default domain. On a **full install**, use `list-bd` / `set-bd` to list or switch domains; if `list-bd` still returns **404**, check gateway routing or whether the service is deployed.
 
-### Step 2: Connect a Data Source
+### Step 2: Connect a Database (register a Vega catalog)
 
 ```bash
-openbkn ds connect mysql db.example.com 3306 erp \
-  --account root --password pass123
-# → returns ds_id, e.g. ds-abc123
+CAT=$(openbkn --json vega catalog create --name "erp" --connector-type mysql \
+  --connector-config '{"host":"db.example.com","port":3306,"username":"root","password":"pass123","databases":["erp"]}' \
+  | python3 -c 'import json,sys;print(json.load(sys.stdin)["id"])')
+echo "$CAT"   # → catalog id
 ```
 
-Arguments: `mysql` is the data source type (supports mysql / postgresql / hive, etc.), followed by **host**, **port**, **database name**. `--account` and `--password` are the connection credentials.
+The fields inside `connector_config` vary by connector type; `openbkn vega connector-type get <type>`
+is authoritative. **The host must be reachable from the network vega-backend runs in** — usually an
+internal address.
 
-Inspect what's available:
+A catalog is created disabled. Enable it, then discover its tables:
 
 ```bash
-openbkn ds list
-openbkn ds tables ds-abc123
+openbkn vega catalog enable "$CAT"
+openbkn vega catalog discover "$CAT" --wait
+
+# Inspect the discovered table resources
+openbkn vega catalog list
+openbkn vega resource list --catalog-id "$CAT" --category table
 ```
 
 ### Step 3: Create a Knowledge Network
@@ -127,17 +134,23 @@ openbkn ds tables ds-abc123
 **Option A: CLI one-liner**
 
 ```bash
-openbkn bkn create-from-ds ds-abc123 \
+openbkn bkn create-from-catalog "$CAT" \
   --name "erp-supply-chain" \
-  --tables "erp.orders,erp.products,erp.customers" \
-  --build --timeout 600
+  --tables "orders,products,customers" \
+  --build --embedding-model text-embedding-v4
 ```
 
-> **Table name format**: `--tables` requires fully-qualified names in `database.table` format (matching the output of `openbkn ds tables`). Bare table names will result in a `No tables available` error.
+This creates one object type per table, binds each to its Vega resource, and maps the fields.
+`--build` additionally submits a search-index build (full text + vector) per resource.
 
-This single command discovers table schemas, creates object types, and maps fields. If the resulting object types are resource-backed (directly mapped to data source tables), `--build` is automatically skipped (no index needed — data is queried in real time from the source); only object types that require an independent index will be built.
+> **`--build` changes the read path**: once a table resource has a local index, Vega serves rows from
+> that index and only falls back to the source database while no index exists — later `UPDATE`s in the
+> source are invisible until the resource is rebuilt. Omit `--build` to keep reads live, at the cost of
+> full-text and vector search.
 
-> **Note**: `create-from-ds` automatically selects a primary key and display key. If the source table has no explicit primary key, the auto-selection may be suboptimal (e.g. choosing `status`), causing records with the same key value to be merged. You can later fix this with `openbkn bkn object-type update`.
+> **Note**: `create-from-catalog` auto-selects a primary key and display key. If the source table has no
+> explicit primary key the choice may be suboptimal (e.g. `status`), merging records that share a value.
+> Fix it afterwards with `openbkn bkn object-type update`.
 
 **Option B: Via AI coding assistant**
 
@@ -385,54 +398,59 @@ The trace returns a Span tree ordered by time, showing:
 
 **Story**: You don't have a database — just a few CSV reports.
 
+CSV still needs a database to land in: load the files, then register a catalog and build.
+
 ```bash
-# List available data sources (CSV needs an intermediate store)
-openbkn ds list
+# 1. Load the CSVs with the standard mysql client (see examples/02-csv-to-kn)
+mysql -h db.example.com -u root -p supply_chain < load_csv.sql
 
-# Import CSV into a data source
-openbkn ds import-csv <ds_id> --files "materials.csv,inventory.csv" --table-prefix sc_
+# 2. Register the catalog and discover tables (as in the scenario above)
+openbkn vega catalog create --name "supply" --connector-type mysql \
+  --connector-config '{"host":"db.example.com","port":3306,"username":"root","password":"pass123","databases":["supply_chain"]}'
+openbkn vega catalog enable <catalog_id>
+openbkn vega catalog discover <catalog_id> --wait
 
-# Create and build the knowledge network
-openbkn bkn create-from-csv <ds_id> \
-  --files "materials.csv,inventory.csv" \
-  --name "supply-reports" --build
+# 3. Build the knowledge network and its indexes
+openbkn bkn create-from-catalog <catalog_id> \
+  --name "supply-reports" --build --embedding-model text-embedding-v4
 
 # Verify
 openbkn bkn search <kn_id> "zero inventory"
 ```
 
+> `openbkn bkn create-from-csv <catalog_id> --files ...` still exists in the CLI, but it relies on the
+> retired dataflow import path and does not work on current deployments. Use the three steps above;
+> `examples/02-csv-to-kn` is a runnable version.
+
 ---
 
-## 🎯 Scenario: VEGA data views and SQL
+## 🎯 Scenario: Run SQL directly against the data
 
-**Story**: You want to run SQL directly against the underlying data, bypassing the knowledge network.
+**Story**: You want to query the underlying data, bypassing the knowledge network.
 
 ```bash
-# Platform health check
-openbkn vega inspect
-
-# List catalogs
-openbkn vega catalog list
+# Probe: a catalog listing means the service is up and the token is valid
+openbkn vega catalog list --limit 1
 
 # Browse resources in a catalog
 openbkn vega catalog resources <catalog_id> --category table
 
-# Find data views
-openbkn dataview find --name "supplier_entity"
+# Sample rows from one resource
+openbkn vega resource query <resource_id> --limit 10 --need-total
 
-# Query a data view (uses the view's stored definition)
-openbkn dataview query <view_id> --limit 10
+# Direct SQL: reference a resource with the {{<resource_id>}} placeholder
+# instead of hand-writing fully-qualified table names
+openbkn vega sql --input-dialect mysql \
+  --query "SELECT supplier_name, city FROM {{<resource_id>}} LIMIT 10"
 
-# Custom SQL query (use fully-qualified catalog."schema"."table" names)
-openbkn dataview query <view_id> --sql "SELECT supplier_name, city FROM <catalog>.\"supply_chain\".\"supplier_entity\" LIMIT 10"
-
-# Prefer names from the data view (do not guess the catalog):
-# openbkn dataview get <view_id> → use JSON field meta_table_name (Vega catalog id + source schema + table)
+# Multi-table JOINs within one catalog go through the structured query endpoint
+openbkn call /api/vega-backend/v1/resources/query -X POST \
+  -d '{"tables":[{"resource_id":"<resource_id>"}],"limit":5,"need_total":true}'
 ```
 
-`<catalog>` must be the **Vega catalog id** for that data source (see `openbkn vega catalog list`); `"supply_chain"` / `"supplier_entity"` map to the source database/schema and table. **Reliable approach**: copy the **`meta_table_name`** field from **`openbkn dataview get <view_id>`** into your SQL. For `sql_str`, `fields`, and the field table, see the Dataview section in [VEGA](manual/vega.md).
-
-On a **Core-only** install, `dataview query` without `--sql` supports structured reads (pagination, column selection, etc.). **Ad-hoc `--sql`** requires a separately managed **`vega-calculate-coordinator`**, which is not installed by the BKN Foundry deployment scripts. See [VEGA](manual/vega.md).
+> Data views (`openbkn dataview`, mdl-uniquery) and the `vega-calculate-coordinator` that ad-hoc SQL
+> depended on have both been retired. Use resource queries and `vega sql` instead — see
+> [VEGA](manual/vega.md).
 
 ---
 

--- a/help/zh/cookbook/cookbook_example.md
+++ b/help/zh/cookbook/cookbook_example.md
@@ -20,40 +20,46 @@
 
 ## 3. Steps（操作步骤）
 
-### 3.1 选/建数据源
+### 3.1 选/建 Catalog
 
-先看现有数据源，从中挑一个：
-
-```bash
-openbkn ds list
-```
-
-如果没有合适的，连接一个新的（示例为 MySQL）：
+先看现有 Catalog，从中挑一个：
 
 ```bash
-openbkn ds connect mysql db.example.com 3306 erp \
-  --account root --password pass123
-# → 返回 ds_id
+openbkn vega catalog list
 ```
 
-> 选好后记下 **`<ds_id>`**。下面把它当成已知量。
+如果没有合适的，注册一个新的（示例为 MySQL）：
+
+```bash
+openbkn vega catalog create --name "erp" --connector-type mysql \
+  --connector-config '{"host":"db.example.com","port":3306,"username":"root","password":"pass123","databases":["erp"]}'
+# → 返回 catalog id
+
+openbkn vega catalog enable <catalog_id>
+openbkn vega catalog discover <catalog_id> --wait
+```
+
+> 选好后记下 **`<catalog_id>`**。下面把它当成已知量。
 
 ### 3.2 一键从 CSV 建 KN
 
 ```bash
-openbkn bkn create-from-csv <ds_id> \
+openbkn bkn create-from-csv <catalog_id> \
   --files "物料.csv,库存.csv" \
   --name "supply-kn" \
   --table-prefix sc_
-# → 自动完成：CSV 入库 → 创建 dataview → 创建 OT → 构建索引
 # → 返回 kn_id
 ```
+
+> **该命令当前不可用**：它的 CSV 入库依赖已下线的 dataflow 通道。请走下面的分步路径
+> （mysql 客户端装库 → 重新发现 → `create-from-catalog`），`examples/02-csv-to-kn`
+> 是完整可运行版本。
 
 参数速查：
 
 | 参数 | 是否必填 | 说明 |
 | --- | --- | --- |
-| `<ds_id>` | 是 | 用于落 CSV 的数据源 ID |
+| `<catalog_id>` | 是 | CSV 落地库对应的 Catalog ID |
 | `--files` | 是 | 逗号分隔或 glob，例如 `"*.csv"` |
 | `--name` | 是 | 知识网络名 |
 | `--table-prefix` | 否 | 表名前缀，避免和已有表冲突 |
@@ -64,8 +70,12 @@ openbkn bkn create-from-csv <ds_id> \
 <summary>等价的两步路径（想自定义主键 / 显示键时用）</summary>
 
 ```bash
-openbkn ds import-csv <ds_id> --files "*.csv" --table-prefix sc_
-openbkn bkn create-from-ds <ds_id> --name "supply-kn" --build
+# 1. 用 mysql 客户端把 CSV 装进 Catalog 对应的库（平台侧 import-csv 已下线）
+mysql -h db.example.com -u root -p erp < load_csv.sql
+
+# 2. 重新发现表，再从 Catalog 建网
+openbkn vega catalog discover <catalog_id> --wait
+openbkn bkn create-from-catalog <catalog_id> --name "supply-kn" --build
 ```
 
 分步路径下可在 `bkn object-type create` 时用 `--primary-key` / `--display-key` 显式指定字段。
@@ -115,8 +125,8 @@ openbkn bkn search <kn_id> "物料"
 | --- | --- | --- |
 | `401 Unauthorized` 或返回体含 `oauth info is not active` | token 过期 | `openbkn auth login <平台地址>` |
 | `openbkn bkn object-type list <kn_id>` 输出 `[]` | CSV 路径错 / glob 没匹配到 | 确认 `--files` 路径，必要时改用绝对路径 |
-| `object-type query` 响应中 `total = 0` | 构建未完成或映射错 | `openbkn bkn stats <kn_id>` 看 `doc_count`；必要时 `openbkn bkn build <kn_id> --wait --timeout 600` 重建 |
-| `ds import-csv` 报 `table already exists` | 同名表已存在 | 首批加 `--recreate`：`openbkn ds import-csv <ds_id> --files "*.csv" --recreate` |
+| `object-type query` 响应中 `total = 0` | 源表为空、映射错，或索引未建好 | 先 `openbkn vega resource query <resource_id> --limit 5` 看源端有没有数据；建过索引的用 `openbkn vega dataset build-list --resource-id <resource_id>` 看 `index_health` |
+| 装 CSV 时报 `table already exists` | 同名表已存在 | 在 SQL 里先 `DROP TABLE IF EXISTS`（平台侧的 `ds import-csv` 已下线，导入由 mysql 客户端完成） |
 | 自动选出的主键不是业务唯一键 | 启发式无法识别 | 走分步路径，`openbkn bkn object-type create` 显式 `--primary-key` / `--display-key` |
 | `bkn search` 返回 `HTTP 500` | 视图不支持全文检索 | 把查询 `condition` 从 `match` 改为 `like` |
 

--- a/help/zh/install.md
+++ b/help/zh/install.md
@@ -275,10 +275,10 @@ sudo bash ./onboard.sh --help
 **完整鉴权安装（启用 auth + business domain）**：脚本根据 Helm/命名空间判断为完整鉴权安装 后，**会自动按以下 5 步执行**（你不需要手工逐条做——这里列出来只是让你知道脚本在干什么，以及某一步失败时该回到哪一步）：
 
 1. **`openbkn auth login`**（`onboard_ensure_kweaver_auth`）— 会话写入 `~/.bkn`。HTTP 默认 `admin` + 安装时生成的初始密码（config.yaml `bknSafe.initialPassword`）（TTY 下也可改走浏览器 OAuth）；`-y` 模式直接走 HTTP 默认。
-2. **`openbkn` 在 PATH**（`onboard_ensure_kweaver_admin_for_isf`）— 缺则自动 `npm i -g @openbkn/bkn-sdk`（交互提示，或 `-y` 时自动安装）。管理能力内置于 `openbkn admin` 子命令，无需单独的包。
+2. **`openbkn` 在 PATH**（`ensure admin CLI`）— 缺则自动 `npm i -g @openbkn/bkn-sdk`（交互提示，或 `-y` 时自动安装）。管理能力内置于 `openbkn admin` 子命令，无需单独的包。
 3. **管理认证**（`onboard_ensure_kweaver_admin_auth_for_isf`）— 管理操作**复用第 1 步同一份 `openbkn` 登录与 token 存储**（默认仍是 `admin` + 记录的初始密码）。命令是 `-u` / `-p` / `-k`（带上即走 HTTP `/oauth2/signin`）。TTY 下也支持浏览器 OAuth。
 4. **业务用户 `test`**（`onboard_offer_isf_test_user`）— 创建 `test`，密码 `111111`（可用 `ONBOARD_TEST_USER_PASSWORD` 覆盖），把 `openbkn admin role list` 中**所有**角色都挂上，然后 **`openbkn auth login` 为 `test`**，让 SDK 会话切到业务用户，供后续步骤使用。若 `test` 已存在，则只做角色同步。
-5. **Context Loader + 模型注册**（`onboard_offer_context_loader_toolset` → `openbkn call impex`；随后是交互式或 YAML 模型注册）— 都使用**以 `test` 登录的 `openbkn`（`~/.bkn`）**；仅 **admin** 的 `openbkn` 会话对 impex 常见 **403**。
+5. **模型注册**（交互式或 YAML）— 使用**以 `test` 登录的 `openbkn`（`~/.bkn`）**。Context Loader 的内置工具箱由平台安装流程注册，不再是 onboard 的独立步骤；确认方式见[快速开始](quick-start.md)。
 
 任何一步失败脚本都会非零退出并打印清楚原因；修好之后重跑 `sudo bash deploy/onboard.sh`（Linux）/ `bash deploy/onboard.sh`（macOS dev）即可——已成功的步骤会被检测并跳过（重复运行幂等）。
 
@@ -317,10 +317,10 @@ flowchart TB
     A["onboard_ensure_kweaver_auth\n（openbkn：HTTP 默认 admin + 记录的初始密码，或浏览器）"] --> B["kubectl：命名空间或目标 namespace"]
     B --> C["onboard_prepend_npm_global_bin_to_path"]
     C --> D["onboard_recommend_admin_cli（Helm/命名空间 → 是否完整鉴权）"]
-    D --> E["onboard_ensure_kweaver_admin_for_isf\n（完整鉴权时按需 npm -g 安装 openbkn）"]
+    D --> E["ensure admin CLI\n（完整鉴权时按需 npm -g 安装 openbkn）"]
     E --> F["onboard_ensure_kweaver_admin_auth_for_isf\n（管理认证 与 openbkn 同默认；或 -k 浏览器；-y 自动 HTTP）"]
     F --> G1["onboard_offer_isf_test_user\n创建或同步 test 与角色"]
-    G1 --> G2["onboard_isf_relogin…\nopenbkn 以 test 登录（HTTP）"]
+    G1 --> G2["onboard re-login…\nopenbkn 以 test 登录（HTTP）"]
     G2 --> H["onboard_offer_context_loader_toolset\n（openbkn impex）"]
   end
 ```
@@ -342,7 +342,7 @@ sequenceDiagram
   A->>A: 创建 user、设密、挂载角色
   A-->>O: user list 成功
   O->>K: openbkn 以 test 登录 — HTTP（test 的密码）
-  O->>K: openbkn call impex / 后续 openbkn 操作
+  O->>K: 模型注册 / 后续 openbkn 操作
 ```
 
 **probe 之后**，默认模式会继续 **命名空间 + 模型 + BKN** 交互；在完整鉴权安装上此时 **`~/.bkn` 宜已为 `test`**，后续注册走业务用户。

--- a/help/zh/install.md
+++ b/help/zh/install.md
@@ -266,23 +266,22 @@ sudo bash ./onboard.sh --help
 
 | 参数 | 含义 |
 | --- | --- |
-| 无参数 | 交互模式：按需引导安装 Node / `openbkn`，完成认证（单一 CLI——管理能力内置于 `openbkn admin`），再依次走模型 / BKN / Context Loader 提示 |
-| `-y` / `--yes` | 全部自动：bootstrap、完整鉴权下 HTTP 默认登录（`admin` + 安装时生成、记录在 config.yaml `bknSafe.initialPassword` 的初始密码）、`test` 用户创建 + 角色同步、`openbkn` 以 `test` 重登、Context Loader 导入。会**跳过交互式模型注册**；如需非交互注册模型，请用 `--config=models.yaml`。 |
+| 无参数 | 交互模式：按需引导安装 Node / `openbkn`，完成认证（单一 CLI——管理能力内置于 `openbkn admin`），再依次走模型 / BKN 提示 |
+| `-y` / `--yes` | 全部自动：bootstrap、完整鉴权下 HTTP 默认登录（`admin` + 安装时生成、记录在 config.yaml `bknSafe.initialPassword` 的初始密码）、`test` 用户创建 + 角色同步、`openbkn` 以 `test` 重登。会**跳过交互式模型注册**；如需非交互注册模型，请用 `--config=models.yaml`。 |
 | `--config=xxx.yaml` | 非交互：按 YAML 注册模型与可选 BKN；参考 `deploy/conf/models.yaml.example` |
 | `--enable-bkn-search` | 仅做 BKN ConfigMap 类操作（仍先走 probe） |
-| `--skip-context-loader` | 跳过 ADP Context Loader 工具集导入 |
 
 **完整鉴权安装（启用 auth + business domain）**：脚本根据 Helm/命名空间判断为完整鉴权安装 后，**会自动按以下 5 步执行**（你不需要手工逐条做——这里列出来只是让你知道脚本在干什么，以及某一步失败时该回到哪一步）：
 
-1. **`openbkn auth login`**（`onboard_ensure_kweaver_auth`）— 会话写入 `~/.bkn`。HTTP 默认 `admin` + 安装时生成的初始密码（config.yaml `bknSafe.initialPassword`）（TTY 下也可改走浏览器 OAuth）；`-y` 模式直接走 HTTP 默认。
+1. **`openbkn auth login`**（`onboard_ensure_bkn_auth`）— 会话写入 `~/.bkn`。HTTP 默认 `admin` + 安装时生成的初始密码（config.yaml `bknSafe.initialPassword`）（TTY 下也可改走浏览器 OAuth）；`-y` 模式直接走 HTTP 默认。
 2. **`openbkn` 在 PATH**（`ensure admin CLI`）— 缺则自动 `npm i -g @openbkn/bkn-sdk`（交互提示，或 `-y` 时自动安装）。管理能力内置于 `openbkn admin` 子命令，无需单独的包。
-3. **管理认证**（`onboard_ensure_kweaver_admin_auth_for_isf`）— 管理操作**复用第 1 步同一份 `openbkn` 登录与 token 存储**（默认仍是 `admin` + 记录的初始密码）。命令是 `-u` / `-p` / `-k`（带上即走 HTTP `/oauth2/signin`）。TTY 下也支持浏览器 OAuth。
-4. **业务用户 `test`**（`onboard_offer_isf_test_user`）— 创建 `test`，密码 `111111`（可用 `ONBOARD_TEST_USER_PASSWORD` 覆盖），把 `openbkn admin role list` 中**所有**角色都挂上，然后 **`openbkn auth login` 为 `test`**，让 SDK 会话切到业务用户，供后续步骤使用。若 `test` 已存在，则只做角色同步。
+3. **管理认证**（`onboard_ensure_bkn_auth`（管理与业务共用））— 管理操作**复用第 1 步同一份 `openbkn` 登录与 token 存储**（默认仍是 `admin` + 记录的初始密码）。命令是 `-u` / `-p` / `-k`（带上即走 HTTP `/oauth2/signin`）。TTY 下也支持浏览器 OAuth。
+4. **业务用户 `test`**（`onboard_provision_bkn_safe_test_user`）— 创建 `test`，密码 `111111`（可用 `ONBOARD_TEST_USER_PASSWORD` 覆盖），把 `openbkn admin role list` 中**所有**角色都挂上，然后 **`openbkn auth login` 为 `test`**，让 SDK 会话切到业务用户，供后续步骤使用。若 `test` 已存在，则只做角色同步。
 5. **模型注册**（交互式或 YAML）— 使用**以 `test` 登录的 `openbkn`（`~/.bkn`）**。Context Loader 的内置工具箱由平台安装流程注册，不再是 onboard 的独立步骤；确认方式见[快速开始](quick-start.md)。
 
 任何一步失败脚本都会非零退出并打印清楚原因；修好之后重跑 `sudo bash deploy/onboard.sh`（Linux）/ `bash deploy/onboard.sh`（macOS dev）即可——已成功的步骤会被检测并跳过（重复运行幂等）。
 
-**最小化安装**（`--minimum`）：通常只需 `openbkn`（常为 `--no-auth`）；上述 完整鉴权专属步骤 2–4 会被自动跳过（管理操作需启用鉴权的后端），第 5 步的 Context Loader 仅在集群中确实有 operator deployment 时才执行。
+**最小化安装**（`--minimum`）：通常只需 `openbkn`（常为 `--no-auth`）；上述 完整鉴权专属步骤 2–4 会被自动跳过（管理操作需启用鉴权的后端）。
 
 结束前会打印 **英文** 完成报告（可用 `ONBOARD_NO_COMPLETION_REPORT=1` 关闭）。
 
@@ -299,7 +298,7 @@ flowchart TB
   mode -->|默认交互；可选 -y| p3[onboard_probe] --> ui["命名空间 + LLM/向量（已存在则只问是否新增）+ BKN 补丁（仅在更换默认时执行）"] --> r2[完成报告] --> e3([exit 0])
 ```
 
-- **三种模式都会先跑 `onboard_probe`**，再进入「仅 BKN」、YAML 或交互式注册。**完整鉴权安装** 时 probe 内含：**与 openbkn 同默认的管理 HTTP 登录**、**用户 `test`**、**`openbkn` 以 `test` 重登**、再 **Context Loader**（条件满足时）。
+- **三种模式都会先跑 `onboard_probe`**，再进入「仅 BKN」、YAML 或交互式注册。**完整鉴权安装** 时 probe 内含：**与 openbkn 同默认的管理 HTTP 登录**、**用户 `test`**、**`openbkn` 以 `test` 重登**、再进入模型注册。
 - **`-y`** 不会自动等价于 `--config`；主要自动确认 **Node / npm -g**，以及在 **完整鉴权安装** 下 `openbkn` 的 **HTTP** 登录默认行为。`-y` 模式下不会跑交互式模型注册（如需非交互注册请使用 `--config=models.yaml`），完成报告里会列出平台上现有模型计数，方便确认。
 - **可重复执行（已注册 / 已配置自动跳过）。** 交互式模型注册会先探测平台现状，再决定是否提问：
   - **大模型 LLM**：若平台已有任何 LLM，先问 `Register another LLM now? [y/N]`，默认 **否**；选否则跳过 LLM 提示。
@@ -314,20 +313,20 @@ flowchart TB
 ```mermaid
 flowchart TB
   subgraph probe["onboard_probe"]
-    A["onboard_ensure_kweaver_auth\n（openbkn：HTTP 默认 admin + 记录的初始密码，或浏览器）"] --> B["kubectl：命名空间或目标 namespace"]
+    A["onboard_ensure_bkn_auth\n（openbkn：HTTP 默认 admin + 记录的初始密码，或浏览器）"] --> B["kubectl：命名空间或目标 namespace"]
     B --> C["onboard_prepend_npm_global_bin_to_path"]
     C --> D["onboard_recommend_admin_cli（Helm/命名空间 → 是否完整鉴权）"]
     D --> E["ensure admin CLI\n（完整鉴权时按需 npm -g 安装 openbkn）"]
-    E --> F["onboard_ensure_kweaver_admin_auth_for_isf\n（管理认证 与 openbkn 同默认；或 -k 浏览器；-y 自动 HTTP）"]
-    F --> G1["onboard_offer_isf_test_user\n创建或同步 test 与角色"]
+    E --> F["管理认证（与 openbkn 同默认）\n（管理认证 与 openbkn 同默认；或 -k 浏览器；-y 自动 HTTP）"]
+    F --> G1["onboard_provision_bkn_safe_test_user\n创建或同步 test 与角色"]
     G1 --> G2["onboard re-login…\nopenbkn 以 test 登录（HTTP）"]
-    G2 --> H["onboard_offer_context_loader_toolset\n（openbkn impex）"]
+    G2 --> H["模型注册（交互式或 --config=models.yaml）"]
   end
 ```
 
-**非全量 / 最小化**：通常不需要管理后端的建用户与 **test 重登** 门禁；若集群仍有 operator，Context Loader 仍可能按条件执行。
+**非全量 / 最小化**：通常不需要管理后端的建用户与 **test 重登** 门禁。
 
-**3）完整鉴权安装：CLI 与 impex 会话（序列图）**
+**3）完整鉴权安装：CLI 会话（序列图）**
 
 ```mermaid
 sequenceDiagram
@@ -347,7 +346,7 @@ sequenceDiagram
 
 **probe 之后**，默认模式会继续 **命名空间 + 模型 + BKN** 交互；在完整鉴权安装上此时 **`~/.bkn` 宜已为 `test`**，后续注册走业务用户。
 
-`openbkn` 与其 `admin` 子命令**共用**同一份登录与 token 存储。**impex 需 `openbkn` 的 `test` 会话**；仅 **admin** 的 openbkn 对 impex 常见 **403**。
+`openbkn` 与其 `admin` 子命令**共用**同一份登录与 token 存储。模型注册等业务操作使用 `openbkn` 的 `test` 会话；仅 **admin** 会话对业务面操作常见 **403**。
 
 ---
 

--- a/help/zh/install.md
+++ b/help/zh/install.md
@@ -277,7 +277,7 @@ sudo bash ./onboard.sh --help
 2. **`openbkn` 在 PATH**（`ensure admin CLI`）— 缺则自动 `npm i -g @openbkn/bkn-sdk`（交互提示，或 `-y` 时自动安装）。管理能力内置于 `openbkn admin` 子命令，无需单独的包。
 3. **管理认证**（`onboard_ensure_bkn_auth`（管理与业务共用））— 管理操作**复用第 1 步同一份 `openbkn` 登录与 token 存储**（默认仍是 `admin` + 记录的初始密码）。命令是 `-u` / `-p` / `-k`（带上即走 HTTP `/oauth2/signin`）。TTY 下也支持浏览器 OAuth。
 4. **业务用户 `test`**（`onboard_provision_bkn_safe_test_user`）— 创建 `test`，密码 `111111`（可用 `ONBOARD_TEST_USER_PASSWORD` 覆盖），把 `openbkn admin role list` 中**所有**角色都挂上，然后 **`openbkn auth login` 为 `test`**，让 SDK 会话切到业务用户，供后续步骤使用。若 `test` 已存在，则只做角色同步。
-5. **模型注册**（交互式或 YAML）— 使用**以 `test` 登录的 `openbkn`（`~/.bkn`）**。Context Loader 的内置工具箱由平台安装流程注册，不再是 onboard 的独立步骤；确认方式见[快速开始](quick-start.md)。
+5. **模型注册**（交互式或 YAML）— 使用**以 `test` 登录的 `openbkn`（`~/.bkn`）**。Context Loader 的内置工具箱由 agent-retrieval 启动时自动导入，不再是 onboard 的独立步骤；确认方式见[快速开始](quick-start.md)。
 
 任何一步失败脚本都会非零退出并打印清楚原因；修好之后重跑 `sudo bash deploy/onboard.sh`（Linux）/ `bash deploy/onboard.sh`（macOS dev）即可——已成功的步骤会被检测并跳过（重复运行幂等）。
 

--- a/help/zh/manual/bkn.md
+++ b/help/zh/manual/bkn.md
@@ -159,8 +159,10 @@ openbkn bkn push ./supply-chain/
 # 4. 查看已创建的知识网络
 openbkn bkn list
 
-# 5. 构建索引
-openbkn bkn build <kn_id> --wait
+# 5. 为绑定的资源建检索索引（按资源，逐个执行）
+openbkn vega dataset build <resource_id> --mode batch --execute-type full \
+  --build-key-fields <主键列> --fulltext-fields <文本列> \
+  --embedding-fields <文本列> --embedding-model <模型名> --wait
 
 # 6. 语义搜索验证
 openbkn bkn search <kn_id> "库存不足的物料"
@@ -173,18 +175,21 @@ openbkn bkn search <kn_id> "库存不足的物料"
 除了用 Agent 编写 BKN 文件，也可以直接从已有数据源自动生成知识网络：
 
 ```bash
-# 从数据库数据源创建，自动发现表结构并构建索引
-openbkn bkn create-from-ds <ds_id> \
+# 从 Vega Catalog 创建：自动发现的表转为对象类，--build 顺带建检索索引
+openbkn bkn create-from-catalog <catalog_id> \
   --name "销售网络" \
   --tables orders,customers,products \
-  --build --timeout 300
+  --build --embedding-model <模型名>
 
-# 从 CSV 文件批量创建
-openbkn bkn create-from-csv <ds_id> \
+# 从 CSV 文件批量创建（先导入该 Catalog 对应的库，再建网）
+openbkn bkn create-from-csv <catalog_id> \
   --files "./data/*.csv" \
   --name "财务分析网络" \
   --build
 ```
+
+Catalog 的注册与表发现见[数据接入](datasource.md)。`--build` 会为每个资源提交一次 Vega
+构建任务；索引配置归属于资源，细节见 [VEGA 引擎](vega.md)。
 
 ---
 
@@ -199,12 +204,15 @@ openbkn bkn get kn_abc123 --export
 openbkn bkn pull kn_abc123 ./my-network
 ```
 
-### 构建与推送
+### 校验与推送
 
 ```bash
-openbkn bkn build kn_abc123 --wait --timeout 300
 openbkn bkn validate ./my-network
 openbkn bkn push ./my-network --branch main
+
+# 知识网络层面已无 build 接口；检索索引按资源构建
+openbkn vega dataset build <resource_id> --mode batch --execute-type full \
+  --build-key-fields <主键列> --wait
 ```
 
 ### 对象类 CRUD
@@ -287,14 +295,15 @@ openbkn bkn action-execution get kn_abc123 exec_456
 ### 端到端流程
 
 ```bash
-# 1. 连接数据源
-openbkn ds connect --type postgresql \
-  --host db.example.com --port 5432 \
-  --database sales --user admin --password secret \
-  --name "销售数据库"
+# 1. 注册 Vega Catalog 并发现表
+CAT=$(openbkn --json vega catalog create --name "销售数据库" --connector-type postgresql \
+  --connector-config '{"host":"db.example.com","port":5432,"username":"admin","password":"secret","databases":["sales"]}' \
+  | python3 -c 'import json,sys;print(json.load(sys.stdin)["id"])')
+openbkn vega catalog enable "$CAT"
+openbkn vega catalog discover "$CAT" --wait
 
-# 2. 从数据源创建知识网络
-openbkn bkn create-from-ds ds_001 --name "销售网络" --build --timeout 300
+# 2. 从 Catalog 创建知识网络（--build 顺带建检索索引）
+openbkn bkn create-from-catalog "$CAT" --name "销售网络" --build --embedding-model <模型名>
 
 # 3. 查看生成的对象类
 openbkn bkn object-type list kn_abc123

--- a/help/zh/manual/bkn.md
+++ b/help/zh/manual/bkn.md
@@ -181,7 +181,7 @@ openbkn bkn create-from-catalog <catalog_id> \
   --tables orders,customers,products \
   --build --embedding-model <模型名>
 
-# 从 CSV 文件批量创建（先导入该 Catalog 对应的库，再建网）
+# 从 CSV 文件批量创建（先把文件装进该 Catalog 对应的库，再建网）
 openbkn bkn create-from-csv <catalog_id> \
   --files "./data/*.csv" \
   --name "财务分析网络" \
@@ -190,6 +190,9 @@ openbkn bkn create-from-csv <catalog_id> \
 
 Catalog 的注册与表发现见[数据接入](datasource.md)。`--build` 会为每个资源提交一次 Vega
 构建任务；索引配置归属于资源，细节见 [VEGA 引擎](vega.md)。
+
+`create-from-csv` 仍在 CLI 中，但其 CSV 入库依赖已下线的 dataflow 通道，当前部署上不可用——
+请先用 `mysql` 客户端把文件装进库，再走 `create-from-catalog`（参见 `examples/02-csv-to-kn`）。
 
 ---
 

--- a/help/zh/quick-start.md
+++ b/help/zh/quick-start.md
@@ -2,7 +2,7 @@
 
 以下步骤假设 BKN Foundry 已按 [安装与部署](install.md) 文档完成安装及文中的安装后检查。**完整安装以 Linux 为主**；可选 **macOS** + kind 流程见 [`deploy/dev/README.zh.md`](../../deploy/dev/README.zh.md)（[English](../../deploy/dev/README.md)）。
 
-> 新主机安装前，先在目标机上跑 **`sudo bash deploy/preflight.sh`**（仅检查 / 加 `--fix`）确认内核、sysctl、containerd、kubectl、helm、Node 与 `openbkn` CLI 都齐了；`deploy.sh openbkn install` 之后，再跑 **`sudo bash deploy/onboard.sh`**（Linux，与 `sudo deploy.sh` 对齐；macOS 开发路径用普通 `bash`）完成 LLM + embedding 注册、按需 patch BKN ConfigMap（仅在默认变化时执行），完整安装下还会建好业务用户 **`test`** 并导入 Context Loader 工具集。两者详见 [安装与部署 — 装机前体检：`preflight.sh`](install.md#-装机前体检--修复preflightsh) 与 [安装与部署 — Post-install：`onboard.sh`](install.md#post-installonboardsh安装后引导)。
+> 新主机安装前，先在目标机上跑 **`sudo bash deploy/preflight.sh`**（仅检查 / 加 `--fix`）确认内核、sysctl、containerd、kubectl、helm、Node 与 `openbkn` CLI 都齐了；`deploy.sh openbkn install` 之后，再跑 **`sudo bash deploy/onboard.sh`**（Linux，与 `sudo deploy.sh` 对齐；macOS 开发路径用普通 `bash`）完成 LLM + embedding 注册、按需 patch BKN ConfigMap（仅在默认变化时执行），完整安装下还会建好业务用户 **`test`**（Context Loader 工具集由 agent-retrieval 启动时自动导入，不是 onboard 的步骤）。两者详见 [安装与部署 — 装机前体检：`preflight.sh`](install.md#-装机前体检--修复preflightsh) 与 [安装与部署 — Post-install：`onboard.sh`](install.md#post-installonboardsh安装后引导)。
 
 ---
 
@@ -83,7 +83,7 @@ openbkn config show
 
 > 💡 **无浏览器 / CI 场景** 的更多登录方式（`--no-browser` 一次性 OAuth、`openbkn auth export` + 重放、HTTP 用户名密码等）见 [安装与部署 — Post-install：`onboard.sh`](install.md#post-installonboardsh安装后引导)（脚本内部用的就是 HTTP `-u`/`-p`）以及 [OpenBKN SDK 认证文档](https://github.com/openbkn-ai/bkn-sdk#authentication)。
 
-Context Loader 工具集（供 Agent 调用知识网络）由平台安装流程注册为内置工具箱。要确认当前平台上是否已注册：
+Context Loader 工具集（供 Agent 调用知识网络）由 **agent-retrieval 服务在启动时自动导入**，没有手工步骤（`deploy/scripts/lib/onboard_report.sh:105` 也是这个口径）。因此若查不到它，先看 agent-retrieval 是否正常起来，而不是重跑安装。确认命令：
 
 ```bash
 openbkn call '/api/agent-operator-integration/v1/tool-box/list?name=contextloader&page=1&page_size=50' -bd bd_public --pretty

--- a/help/zh/quick-start.md
+++ b/help/zh/quick-start.md
@@ -83,13 +83,13 @@ openbkn config show
 
 > 💡 **无浏览器 / CI 场景** 的更多登录方式（`--no-browser` 一次性 OAuth、`openbkn auth export` + 重放、HTTP 用户名密码等）见 [安装与部署 — Post-install：`onboard.sh`](install.md#post-installonboardsh安装后引导)（脚本内部用的就是 HTTP `-u`/`-p`）以及 [OpenBKN SDK 认证文档](https://github.com/openbkn-ai/bkn-sdk#authentication)。
 
-Context Loader 工具集 ADP（用于 agent 调用知识网络）现在由 **`onboard.sh`** 通过 `openbkn call impex` 自动导入（不再走 `deploy.sh`）。要确认平台上是否已注册：
+Context Loader 工具集（供 Agent 调用知识网络）由平台安装流程注册为内置工具箱。要确认当前平台上是否已注册：
 
 ```bash
 openbkn call '/api/agent-operator-integration/v1/tool-box/list?name=contextloader&page=1&page_size=50' -bd bd_public --pretty
 ```
 
-（与 `openbkn context-loader tools` 不同：前者为 Operator 工具箱列表，后者为 MCP 工具列表。）
+（这查的是 Operator 侧的工具箱列表；MCP 侧的工具目录用 `openbkn context info`，或按知识网络看 `openbkn context tools <kn-id>`。）
 
 ### 🧠 配置模型（按需）
 
@@ -163,37 +163,47 @@ AI 助手会自动调用 `openbkn` CLI 完成全部操作，包括数据源发�
 
 **故事线**：你刚部署好 BKN Foundry，手头有一台 MySQL 数据库装着 ERP 数据。你的目标是把数据库变成一个知识网络，然后查询数据。
 
-#### 第 1 步：接入数据源
+#### 第 1 步：接入数据库（注册 Vega Catalog）
 
 ```bash
-openbkn ds connect mysql db.example.com 3306 erp \
-  --account root --password pass123
-# → 返回 ds_id，例如 ds-abc123
+CAT=$(openbkn --json vega catalog create --name "erp" --connector-type mysql \
+  --connector-config '{"host":"db.example.com","port":3306,"username":"root","password":"pass123","databases":["erp"]}' \
+  | python3 -c 'import json,sys;print(json.load(sys.stdin)["id"])')
+echo "$CAT"   # → catalog id
 ```
 
-参数说明：`mysql` 为数据源类型（支持 mysql / postgresql / hive 等），后跟 **主机**、**端口**、**数据库名**，`--account` 和 `--password` 为连接凭据。
+`connector_config` 的字段随连接器类型而异，以 `openbkn vega connector-type get <type>` 返回的
+schema 为准。**主机地址须由 vega-backend 所在网络可达**，通常是内网地址。
 
-查看已有数据源和表结构：
+Catalog 创建后默认禁用，先启用再发现表：
 
 ```bash
-openbkn ds list
-openbkn ds tables ds-abc123
+openbkn vega catalog enable "$CAT"
+openbkn vega catalog discover "$CAT" --wait
+
+# 查看发现出的表资源
+openbkn vega catalog list
+openbkn vega resource list --catalog-id "$CAT" --category table
 ```
 
 #### 第 2 步：创建知识网络
 
 ```bash
-openbkn bkn create-from-ds ds-abc123 \
+openbkn bkn create-from-catalog "$CAT" \
   --name "erp-供应链" \
-  --tables "erp.orders,erp.products,erp.customers" \
-  --build --timeout 600
+  --tables "orders,products,customers" \
+  --build --embedding-model text-embedding-v4
 ```
 
-> **表名格式**：`--tables` 需要使用 `数据库名.表名` 的全限定格式（与 `openbkn ds tables` 输出一致）。裸表名会导致 `No tables available` 错误。
+这一条命令完成：按表创建对象类 → 绑定 Vega 资源 → 映射字段；`--build` 会为每个资源再提交一次
+检索索引构建任务（全文 + 向量）。
 
-这一条命令完成了：自动发现表结构 → 创建对象类 → 映射字段。如果对象类是 resource-backed（直接映射数据源表），`--build` 会自动跳过（不需要构建索引，数据直接从源表实时查询）；只有需要独立索引的对象类才会执行构建。
+> **`--build` 会改变读取路径**：表资源一旦有了本地索引，Vega 就从索引读，只有在没有索引时才回源库
+> 实时查；源库的后续更新要等重建索引才可见。只想要实时读就别加 `--build`，代价是没有全文与向量检索。
 
-> **注意**：`create-from-ds` 会自动选择主键（primary key）和显示键（display key）。如果源表没有明确的主键，自动选择可能不理想（如选择 `status` 字段），导致相同主键值的记录被合并。建议后续通过 `openbkn bkn object-type update` 手动指定正确的主键。
+> **注意**：`create-from-catalog` 会自动选择主键与显示键。源表没有明确主键时，自动选择可能不理想
+> （例如选中 `status`），导致相同主键值的记录被合并。可事后用 `openbkn bkn object-type update`
+> 指定正确的主键。
 
 验证：
 
@@ -297,54 +307,58 @@ Trace 返回按时间排列的 Span 树，展示：
 
 **故事线**：你没有数据库，只有几份 CSV 报表。
 
+CSV 仍需要一个数据库作为落地存储：先把 CSV 装进库，再注册 Catalog 建网。
+
 ```bash
-# 先找一个可用的数据源（CSV 需要一个中间存储）
-openbkn ds list
+# 1. 用标准 mysql 客户端把 CSV 装进目标库（示例见 examples/02-csv-to-kn）
+mysql -h db.example.com -u root -p supply_chain < load_csv.sql
 
-# 导入 CSV 到数据源
-openbkn ds import-csv <ds_id> --files "物料.csv,库存.csv" --table-prefix sc_
+# 2. 注册 Catalog 并发现表（同上一场景）
+openbkn vega catalog create --name "supply" --connector-type mysql \
+  --connector-config '{"host":"db.example.com","port":3306,"username":"root","password":"pass123","databases":["supply_chain"]}'
+openbkn vega catalog enable <catalog_id>
+openbkn vega catalog discover <catalog_id> --wait
 
-# 一键创建知识网络
-openbkn bkn create-from-csv <ds_id> \
-  --files "物料.csv,库存.csv" \
-  --name "供应链报表" --build
+# 3. 建网并建索引
+openbkn bkn create-from-catalog <catalog_id> \
+  --name "供应链报表" --build --embedding-model text-embedding-v4
 
 # 验证
 openbkn bkn search <kn_id> "库存为零"
 ```
 
+> `openbkn bkn create-from-csv <catalog_id> --files ...` 仍在 CLI 中，但它依赖已下线的
+> dataflow 导入通道，当前部署上不可用；请按上面的三步走。完整可运行版本见
+> `examples/02-csv-to-kn`。
+
 ---
 
-### 🎯 场景：VEGA 数据视图与 SQL 查询
+### 🎯 场景：直接对底层数据执行 SQL
 
-**故事线**：你想直接对底层数据执行 SQL，而不是通过知识网络。
+**故事线**：你想绕过知识网络，直接查数据。
 
 ```bash
-# 平台健康检查
-openbkn vega inspect
-
-# 列出 catalog
-openbkn vega catalog list
+# 探活：能列出 catalog 即服务可达、token 有效
+openbkn vega catalog list --limit 1
 
 # 查看某个 catalog 下的资源
 openbkn vega catalog resources <catalog_id> --category table
 
-# 查找数据视图
-openbkn dataview find --name "supplier_entity"
+# 抽样看某个资源的数据
+openbkn vega resource query <resource_id> --limit 10 --need-total
 
-# 查询数据视图（默认使用视图定义）
-openbkn dataview query <view_id> --limit 10
+# 直连 SQL：用 {{<resource_id>}} 占位符引用资源，避免手写全限定表名
+openbkn vega sql --input-dialect mysql \
+  --query "SELECT supplier_name, city FROM {{<resource_id>}} LIMIT 10"
 
-# 自定义 SQL 查询（需使用 catalog."schema"."table" 全限定名）
-openbkn dataview query <view_id> --sql "SELECT supplier_name, city FROM <catalog>.\"supply_chain\".\"supplier_entity\" LIMIT 10"
-
-# 全限定名请以 dataview 为准（勿手写猜 catalog）：
-# openbkn dataview get <view_id> → 使用响应 JSON 字段 meta_table_name（与 vega catalog id + 源库 schema/表名 一致）
+# 同一 Catalog 内多表 JOIN 走结构化查询接口
+openbkn call /api/vega-backend/v1/resources/query -X POST \
+  -d '{"tables":[{"resource_id":"<resource_id>"}],"limit":5,"need_total":true}'
 ```
 
-其中 `<catalog>` 须替换为该数据源在 **Vega** 中注册得到的 **catalog id**（见 `openbkn vega catalog list`），**不要**用视图逻辑名或裸表名代替；`"supply_chain"`、`"supplier_entity"` 分别对应源库中的 database/schema 与物理表名。**可靠做法**：`openbkn dataview get <view_id>` 取响应中的 **`meta_table_name`** 字段，在 SQL 中原样引用；`sql_str`、`fields` 含义见 [VEGA](manual/vega.md)「数据视图」中的字段表。
-
-仅 **Core** 部署时，`dataview query` 不带 `--sql` 可做分页、选列等结构化查询；**`--sql` 复杂自定义 SQL** 需要单独维护的 **`vega-calculate-coordinator`**，BKN Foundry 部署脚本不再安装该组件。详见 [VEGA](manual/vega.md)。
+> 早期的数据视图（`openbkn dataview`、mdl-uniquery）与自定义 SQL 依赖的
+> `vega-calculate-coordinator` 均已下线，改用上面的资源查询与 `vega sql`。详见
+> [VEGA](manual/vega.md)。
 
 ---
 


### PR DESCRIPTION
接 #642，把 `help/` 手册里剩余引用已下线命令的部分改到 CLI 0.1.2 的实际命令面。

> **范围调整**：原版本包含 Context Loader 手册，导致评审跑到轮次上限失败。已拆出为 #655，本 PR 只保留 BKN / 快速开始 / cookbook / 安装文档四篇（中英共八个文件）。与 #642、#655 均无文件重叠。

## 背景

对文档中出现的 `openbkn` 命令逐条实测，下列在 CLI 0.1.2 中不存在：`ds connect|list|get|tables|import-csv|delete`、`dataview *`、`bkn build`、`bkn create-from-ds`、`call impex`、`auth as`。`openbkn ds` 与 `openbkn dataview` 两个组仍在，但组内零子命令。

## 改动

**BKN 手册（中英）** — `bkn build` 改为按资源执行 `vega dataset build`（章节名由「构建与推送」改为「校验与推送」）；`create-from-ds` 改为 `create-from-catalog`；端到端示例的前置步骤换成注册 Vega Catalog、启用、发现表；`create-from-csv` 的入参由 ds_id 改为 catalog_id。

**快速开始（中英）** — 主线第 1、2 步改为 Catalog 路径，并写明 `--build` 会把该资源的读取路径切到索引快照（源库后续更新要等重建才可见）；CSV 场景改为「mysql 客户端装库 → 注册 Catalog → 建网」三步，并注明 `create-from-csv` 虽在 CLI 中但依赖已下线的 dataflow 通道；数据视图场景整体改写为资源抽样 + `vega sql` + 结构化查询接口。

**Cookbook（中英）** — 3.1 由「选/建数据源」改为「选/建 Catalog」；分步路径的 `ds import-csv` + `create-from-ds` 改为 mysql 装库 + 重新发现 + `create-from-catalog`；排障表两条同步订正（`bkn build` 重建 → 查资源数据与 build-list 的 index_health；`ds import-csv` 报表已存在 → 在 SQL 里先 DROP）。

**安装文档（中英）** — onboard 步骤 5 里已不存在的 `onboard_offer_context_loader_toolset` 与 `openbkn call impex` 去掉，改为模型注册并说明 Context Loader 工具箱由平台安装流程注册；时序图同步；`openbkn auth as test` 改为实际存在的 `auth login … -u test`；几处停留在 ISF 时代的 onboard 函数名改为描述性文字。

## 验证

文中每条 `openbkn X Y` 命令都用脚本对 `openbkn <group> --help` 的实际子命令表做过存在性校验，八个文件均无残留；参数与请求体对照仓内路由与 binding 核对。关键路径在 VM 上抽查：Catalog 注册/启用/发现、`vega resource list|get|query`、`vega dataset build` 均可用。

🤖 Generated with [Claude Code](https://claude.com/claude-code)