### PR TITLE
test(bkn-safe): #648 收尾——permobject 补 ResetForTest，README 补档位门控

### DIFF
--- a/bkn-safe/README.md
+++ b/bkn-safe/README.md
@@ -101,6 +101,34 @@ VS Code / Cursor：打开 `bkn-safe` 根目录，选 **Run and Debug → bkn-saf
   `GET /groups/:id/members`、`POST /search-org`、`POST /users`、`PUT /users/:id/password`
 - 健康：`GET /health/ready`、`/health/alive`
 
+## 授权档位（付费能力门控）
+
+付费能力按**档位**放行，不按证书里的 feature key —— 唯一判定入口是
+`entitlement.AtLeast(min)`，`community ⊂ professional ⊂ enterprise ⊂ industry`。
+证书里的 `features[]` 照签，但**只供展示与审计核对，任何代码路径不得据此放行**。
+
+档位不够时端点**伪装不存在**（404，与社区镜像逐字节一致），不是 403 —— 403 等于
+告诉探测者"这里有个付费端点"。升级引导走 `GET /api/safe/v1/capabilities`。
+
+### `-tags ee_dev` 与 `OPENBKN_EDITION` 对 bkn-safe 无效
+
+别的服务能用这两个东西在验证集群上切档位，**bkn-safe 不行**。它是集群的持证方，
+不是消费方：`app.Boot` 把 gate 直接接到自己的 `licSvc`（`license.Gate`），依赖图里
+根本没有那个环境变量桩可供覆盖。
+
+所以 bkn-safe 的档位只有两条路：
+
+| 场景 | 怎么切 |
+|---|---|
+| 集群 / 验证环境 | 导入**真证书**（`POST /api/safe/v1/admin/license/import`） |
+| 单元测试 | `entitlement.SetGateForTest(license.Gate(svc))`，或直接给一个假 gate |
+
+写在这里是因为它必然被踩：设了 `OPENBKN_EDITION=enterprise` 而档位纹丝不动，
+不知道这条的人会先去查环境变量有没有传进容器、再查 gate 有没有装，半天过去了。
+
+设计：bkn-docs `docs/shared/licensing/ee-design.md`、
+`docs/foundry/bkn-safe/design/issue-unknown-bkn-safe-edition-gating.md`。
+
 ## 注意
 
 - **绝不用 gobuffalo/pop** —— pop 按方言名分发，是 hydra 信创 fork 的坑根；GORM 吃 driver 层，openbkn 透明。

--- a/bkn-safe/server/extension/permobject/testsupport.go
+++ b/bkn-safe/server/extension/permobject/testsupport.go
@@ -1,0 +1,30 @@
+// Copyright openbkn.ai
+//
+// Licensed under the OpenBKN License. See LICENSE-OPENBKN.txt in the project root.
+
+package permobject
+
+import "testing"
+
+// ResetForTest clears the socket so a test does not inherit another's
+// Authorizer.
+//
+// It exists because Register refuses a second registration — one process
+// assembles once, and a silently replaced Authorizer would be an authorization
+// change with no trace. That guard makes every test after the first one panic
+// unless the socket can be emptied between them, and the enterprise code line
+// tests its own assembly from another repository, so an unexported reset does
+// not reach it. adminwrite exports the same helper for the same reason; this
+// package was missing it, which only surfaced once the guard existed.
+//
+// Panics outside a test binary. testing.Testing() rather than a convention plus
+// a lint, because this function is a way around the invariant the guard exists
+// to enforce: it lets a caller drop a running server's Authorizer and install
+// another. testing.Testing() reports whether the binary was built by `go test`,
+// so in a production build it cannot run at all, no matter who calls it.
+func ResetForTest() {
+	if !testing.Testing() {
+		panic("permobject: ResetForTest is test-only and must never run in a production binary")
+	}
+	reset()
+}

--- a/bkn-safe/server/internal/httpapi/adminwrite_svc.go
+++ b/bkn-safe/server/internal/httpapi/adminwrite_svc.go
@@ -36,8 +36,12 @@ func newAdminWriteServices(e *authz.Enforcer, db *gorm.DB) adminwrite.Services {
 }
 
 // RequirePermission hands ee core's RBAC middleware, so a write route keeps the
-// same per-caller check its community read sibling uses. The license layer
-// (RequireFeature) is ee's to add on top.
+// same per-caller check its community read sibling uses.
+//
+// This is the RBAC layer only. The entitlement layer is the socket's — it runs
+// ahead of this one and answers 404, because a missing licence has to look like
+// a route that does not exist while a missing permission is refused outright.
+// ee adds neither; both are core's.
 func (s *adminWriteServices) RequirePermission(resourceType, op string) gin.HandlerFunc {
 	return RequirePermission(s.e, resourceType, op)
 }


### PR DESCRIPTION
#648 的收尾。合并之后 bump openbkn-ee 的 pin 时暴露出来的，加上一轮全平台扫描的结果。

## 1. `permobject.ResetForTest`（阻断 ee）

#648 给 `permobject.Register` 加了二次注册守卫——第一个 `Authorizer` 被 `atomic.Value.Store` 静默替换是授权面问题，这是 casbin 之上唯一能出 `Deny` 的那层。守卫本身没错，但这个包只有未导出的 `reset()`，而 `adminwrite` 一直有导出的 `ResetForTest`。

不对称直到守卫存在才显出来：

```
--- FAIL: TestCertificateImportedAfterSetupActivatesTheCapability
panic: permobject: authorizer already registered — a second one would silently replace the first
```

装配测试里第一个用例之后的每一个都会撞守卫。企业代码线是**从另一个仓**测自己的装配的（`openbkn-ee/bkn-safe/permobject`），未导出的 `reset` 够不着。

补一个与 `adminwrite` 同形状的，`testing.Testing()` 守着——它同样是绕过守卫的一条路（能把运行中服务的 `Authorizer` 换掉），约定加 lint 拦不住不在 lint 匹配范围里的调用方，`testing.Testing()` 在生产构建里根本跑不起来。

## 2. README 补档位门控（设计文档明确要求，#648 漏了）

`issue-unknown-bkn-safe-edition-gating.md` 第 0 节明写「副作用要写进 bkn-safe 的 README」。

别的服务能用 `-tags ee_dev` + `OPENBKN_EDITION` 在验证集群上切档位，**bkn-safe 不行**——它是持证方，`app.Boot` 把 gate 直接接到自己的 `licSvc`，依赖图里没有那个环境变量桩可供覆盖。不写清，下一个人会先查环境变量有没有传进容器、再查 gate 有没有装，半天过去了。

顺带补了档位模型本身（`AtLeast`、`features[]` 只读不判、404 不 403）。

## 3. 两处过时注释

- `adminwrite_svc.go` 说 license 层「是 ee 的，加在上面」——#648 之后判定与拒绝形态都收回 core 的插座了
- `permobject_test.go` 提到的 `extension.Claim` 已随包删除

## 扫描结果（无需改动的）

| 目标 | 结论 |
|---|---|
| `bkn-studio` | 不读 `features` 做显隐、不消费 license 403、不调 `/capabilities`。**403 → 404 无需前端配合** |
| `bkn-foundry-ee` | 只发布 bkn-trace / vega-backend 两个镜像，其 bkn-safe 树纯由 `sync-upstream` 携带，无本地改动，会随同步自然更新 |
| charts / values.yaml | 未改，网关放行清单不变 |

配套文档：[bkn-docs#44](https://github.com/openbkn-ai/bkn-docs/pull/44)

🤖 Generated with [Claude Code](https://claude.com/claude-code)