### PR TITLE
ix(deploy): support offline install-status images

### DIFF
--- a/deploy/README.md
+++ b/deploy/README.md
@@ -302,6 +302,15 @@ section (probed via the apiserver service proxy: `/health/ready` → `/api/v1/he
 ./deploy.sh openbkn publish-status
 ```
 
+For an offline environment, sync the latest images (including
+`openbkn-ai/library/nginx:1.27-alpine`) before republishing the endpoint, and
+pass the offline flag to `publish-status`:
+
+```bash
+./scripts/sync-k8s-images.sh <offline-registry>
+./deploy.sh --offline=<offline-registry> openbkn publish-status
+```
+
 A **non-sensitive** dashboard is also served, unauthenticated, through the ingress
 (a tiny nginx serving ConfigMaps — see `conf/install-status/`):
 

--- a/deploy/README.zh.md
+++ b/deploy/README.zh.md
@@ -297,6 +297,14 @@ kubectl get pods -A
 ./deploy.sh openbkn publish-status
 ```
 
+离线环境请在重新发布 install-status 前带上 `--offline`，并先同步最新镜像（包括
+`openbkn-ai/library/nginx:1.27-alpine`）：
+
+```bash
+./scripts/sync-k8s-images.sh <offline-registry>
+./deploy.sh --offline=<offline-registry> openbkn publish-status
+```
+
 同时通过 ingress 以**非敏感**面板对外提供(由一个极小的 nginx 托管 ConfigMap,见
 `conf/install-status/`):
 

--- a/deploy/conf/install-status/endpoint.yaml
+++ b/deploy/conf/install-status/endpoint.yaml
@@ -21,8 +21,8 @@
 # read only — NO secrets, NO helm). The expected release list still comes from
 # the publish-time snapshot, mounted read-only from the data ConfigMap.
 #
-# Placeholders __NAMESPACE__ / __INGRESS_CLASS__ / __KUBECTL_IMAGE__ are
-# substituted by status.sh.
+# Placeholders __NAMESPACE__ / __INGRESS_CLASS__ / __KUBECTL_IMAGE__ /
+# __NGINX_IMAGE__ are substituted by status.sh.
 apiVersion: v1
 kind: ServiceAccount
 metadata:

--- a/deploy/conf/install-status/endpoint.yaml
+++ b/deploy/conf/install-status/endpoint.yaml
@@ -123,7 +123,7 @@ spec:
               mountPath: /scripts
               readOnly: true
         - name: nginx
-          image: swr.cn-east-3.myhuaweicloud.com/openbkn-ai/library/nginx:1.27-alpine
+          image: __NGINX_IMAGE__
           ports:
             - containerPort: 80
           readinessProbe:

--- a/deploy/scripts/services/status.sh
+++ b/deploy/scripts/services/status.sh
@@ -165,10 +165,6 @@ gen_install_status_json() {
     local namespace
     namespace="$(_openbkn_resolve_target_namespace)"
 
-    # Resolve both endpoint images here, after deploy.sh has parsed global
-    # flags such as --offline.
-    _status_resolve_images
-
     if ! command -v python3 >/dev/null 2>&1; then
         log_warn "python3 not found; skipping install-status snapshot."
         return 0

--- a/deploy/scripts/services/status.sh
+++ b/deploy/scripts/services/status.sh
@@ -28,12 +28,29 @@ INSTALL_STATUS_MERGE_JQ="${INSTALL_STATUS_DIR}/merge.jq"
 # alpine/k8s (which the docker.1panel.live mirror 403s) and bitnami/kubectl (whose
 # docker.io tags are being pruned post-deprecation), is reliably served by the
 # install-time --dockerhub-mirror on CN/restricted nets. Override via env.
-# In offline mode, use offline registry; otherwise use SWR mirror
-if [[ "${OFFLINE_MODE}" == "true" ]]; then
-    INSTALL_STATUS_KUBECTL_IMAGE="${INSTALL_STATUS_KUBECTL_IMAGE:-${OFFLINE_REGISTRY}/openbkn-ai/portainer/kubectl-shell:latest}"
-else
-    INSTALL_STATUS_KUBECTL_IMAGE="${INSTALL_STATUS_KUBECTL_IMAGE:-swr.cn-east-3.myhuaweicloud.com/openbkn-ai/portainer/kubectl-shell:latest}"
-fi
+# Keep explicit image overrides, but resolve the defaults when the endpoint is
+# actually published. `deploy.sh` parses --offline after sourcing this file.
+INSTALL_STATUS_KUBECTL_IMAGE_OVERRIDE="${INSTALL_STATUS_KUBECTL_IMAGE:-}"
+INSTALL_STATUS_NGINX_IMAGE_OVERRIDE="${INSTALL_STATUS_NGINX_IMAGE:-}"
+
+_status_resolve_images() {
+    local offline_registry="${OFFLINE_REGISTRY:-registry.openbkn.ai:5000}"
+    if [[ -n "${INSTALL_STATUS_KUBECTL_IMAGE_OVERRIDE}" ]]; then
+        INSTALL_STATUS_KUBECTL_IMAGE="${INSTALL_STATUS_KUBECTL_IMAGE_OVERRIDE}"
+    elif [[ "${OFFLINE_MODE:-false}" == "true" ]]; then
+        INSTALL_STATUS_KUBECTL_IMAGE="${offline_registry}/openbkn-ai/portainer/kubectl-shell:latest"
+    else
+        INSTALL_STATUS_KUBECTL_IMAGE="swr.cn-east-3.myhuaweicloud.com/openbkn-ai/portainer/kubectl-shell:latest"
+    fi
+
+    if [[ -n "${INSTALL_STATUS_NGINX_IMAGE_OVERRIDE}" ]]; then
+        INSTALL_STATUS_NGINX_IMAGE="${INSTALL_STATUS_NGINX_IMAGE_OVERRIDE}"
+    elif [[ "${OFFLINE_MODE:-false}" == "true" ]]; then
+        INSTALL_STATUS_NGINX_IMAGE="${offline_registry}/openbkn-ai/library/nginx:1.27-alpine"
+    else
+        INSTALL_STATUS_NGINX_IMAGE="swr.cn-east-3.myhuaweicloud.com/openbkn-ai/library/nginx:1.27-alpine"
+    fi
+}
 
 # Detect the ingress-nginx IngressClass to bind the endpoint to.
 _status_detect_ingress_class() {
@@ -110,11 +127,14 @@ _status_apply_endpoint() {
         rolebinding/install-status-rt \
         -n "${namespace}" --ignore-not-found >/dev/null 2>&1 || true
 
+    _status_resolve_images
+
     local ingress_class
     ingress_class="$(_status_detect_ingress_class)"
     sed -e "s|__NAMESPACE__|${namespace}|g" \
         -e "s|__INGRESS_CLASS__|${ingress_class}|g" \
         -e "s|__KUBECTL_IMAGE__|${INSTALL_STATUS_KUBECTL_IMAGE}|g" \
+        -e "s|__NGINX_IMAGE__|${INSTALL_STATUS_NGINX_IMAGE}|g" \
         "${INSTALL_STATUS_ENDPOINT_TPL}" \
         | kubectl apply -f - >/dev/null 2>&1 || {
             log_warn "Failed to apply install-status endpoint manifests."
@@ -144,6 +164,10 @@ _status_auth_disabled() {
 gen_install_status_json() {
     local namespace
     namespace="$(_openbkn_resolve_target_namespace)"
+
+    # Resolve both endpoint images here, after deploy.sh has parsed global
+    # flags such as --offline.
+    _status_resolve_images
 
     if ! command -v python3 >/dev/null 2>&1; then
         log_warn "python3 not found; skipping install-status snapshot."

--- a/deploy/scripts/services/status_test.sh
+++ b/deploy/scripts/services/status_test.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+# Regression tests for install-status image resolution.
+set -euo pipefail
+
+PASS=0
+FAIL=0
+ok() { PASS=$((PASS + 1)); }
+fail() { echo "FAIL: $*"; FAIL=$((FAIL + 1)); }
+assert_eq() {
+    local name="$1" got="$2" want="$3"
+    if [[ "${got}" == "${want}" ]]; then ok; else fail "${name}: got[${got}] want[${want}]"; fi
+}
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+
+resolve_images() {
+    local mode="$1"
+    local kubectl_override="${2:-}"
+    local nginx_override="${3:-}"
+    env \
+        "TEST_MODE=${mode}" \
+        "TEST_KUBECTL_OVERRIDE=${kubectl_override}" \
+        "TEST_NGINX_OVERRIDE=${nginx_override}" \
+        bash -c '
+            SCRIPT_DIR="$1"
+            OFFLINE_MODE=false
+            OFFLINE_REGISTRY=registry.test:5000
+            if [[ -n "${TEST_KUBECTL_OVERRIDE}" ]]; then
+                INSTALL_STATUS_KUBECTL_IMAGE="${TEST_KUBECTL_OVERRIDE}"
+            fi
+            if [[ -n "${TEST_NGINX_OVERRIDE}" ]]; then
+                INSTALL_STATUS_NGINX_IMAGE="${TEST_NGINX_OVERRIDE}"
+            fi
+            source "${SCRIPT_DIR}/scripts/services/status.sh"
+            # Simulate deploy.sh parsing --offline after status.sh is sourced.
+            OFFLINE_MODE="${TEST_MODE}"
+            _status_resolve_images
+            printf "%s\n%s\n" "${INSTALL_STATUS_KUBECTL_IMAGE}" "${INSTALL_STATUS_NGINX_IMAGE}"
+        ' bash "${SCRIPT_DIR}"
+}
+
+offline_images="$(resolve_images true)"
+assert_eq "offline-kubectl" "$(sed -n '1p' <<<"${offline_images}")" \
+    "registry.test:5000/openbkn-ai/portainer/kubectl-shell:latest"
+assert_eq "offline-nginx" "$(sed -n '2p' <<<"${offline_images}")" \
+    "registry.test:5000/openbkn-ai/library/nginx:1.27-alpine"
+
+online_images="$(resolve_images false)"
+assert_eq "online-kubectl" "$(sed -n '1p' <<<"${online_images}")" \
+    "swr.cn-east-3.myhuaweicloud.com/openbkn-ai/portainer/kubectl-shell:latest"
+assert_eq "online-nginx" "$(sed -n '2p' <<<"${online_images}")" \
+    "swr.cn-east-3.myhuaweicloud.com/openbkn-ai/library/nginx:1.27-alpine"
+
+override_images="$(resolve_images true custom/kubectl:tag custom/nginx:tag)"
+assert_eq "kubectl-override" "$(sed -n '1p' <<<"${override_images}")" "custom/kubectl:tag"
+assert_eq "nginx-override" "$(sed -n '2p' <<<"${override_images}")" "custom/nginx:tag"
+
+if [[ "${FAIL}" -eq 0 ]]; then
+    echo "status_test: all ${PASS} checks passed"
+    exit 0
+fi
+echo "status_test: FAILED"
+exit 1

--- a/deploy/scripts/sync-k8s-images.sh
+++ b/deploy/scripts/sync-k8s-images.sh
@@ -94,6 +94,7 @@ OPENSEARCH_IMAGES=(
 # Required images for other components
 OTHER_IMAGES=(
     "openbkn-ai/portainer/kubectl-shell:latest"
+    "openbkn-ai/library/nginx:1.27-alpine"
 )
 
 # Required images for OpenBKN Applications


### PR DESCRIPTION
# Pull Request

## What Changed

- [x] 参数化 install-status 的 nginx 镜像。
- [x] 根据 `OFFLINE_MODE` 和 `OFFLINE_REGISTRY` 动态解析 kubectl 与 nginx 镜像。
- [x] 将 install-status nginx 镜像加入离线镜像同步清单。
- [ ] Docs/doc 1 — N/A

---

## Why

- Related Issue: N/A
- Related Feature: N/A
- Background: install-status 原先将 nginx 镜像硬编码为在线 SWR 地址，且 kubectl sidecar 镜像在脚本加载阶段解析。由于 `--offline` 参数是在脚本加载后才解析，离线安装时可能仍使用在线镜像，导致 install-status Pod 出现 `ImagePullBackOff`。

---

## How

- Key implementation points:
  - 将 `endpoint.yaml` 中的 nginx 镜像改为 `__NGINX_IMAGE__` 占位符。
  - 在 `gen_install_status_json` 执行阶段动态解析两个镜像：
    - 在线模式：
      - `swr.cn-east-3.myhuaweicloud.com/openbkn-ai/portainer/kubectl-shell:latest`
      - `swr.cn-east-3.myhuaweicloud.com/openbkn-ai/library/nginx:1.27-alpine`
    - 离线模式：
      - `${OFFLINE_REGISTRY}/openbkn-ai/portainer/kubectl-shell:latest`
      - `${OFFLINE_REGISTRY}/openbkn-ai/library/nginx:1.27-alpine`
  - 保留 `INSTALL_STATUS_KUBECTL_IMAGE` 和 `INSTALL_STATUS_NGINX_IMAGE` 的显式镜像覆盖能力。
  - 将 `openbkn-ai/library/nginx:1.27-alpine` 加入 `sync-k8s-images.sh` 的离线镜像清单。
- Breaking changes (API, config, database, etc.): None.

---

## Testing

- [x] Unit tests passed locally
- [ ] Integration tests passed locally — N/A; no Kubernetes deployment was performed.
- [ ] Verified in test environment — Not run.

Test notes:

    bash -n deploy/scripts/services/status.sh deploy/scripts/sync-k8s-images.sh

    # Offline image resolution
    OFFLINE_MODE=true
    OFFLINE_REGISTRY=registry.test:5000
    _status_resolve_images
    # verified kubectl-shell and nginx both use registry.test:5000

    # Online image resolution
    OFFLINE_MODE=false
    _status_resolve_images
    # verified both images use the SWR registry

    # endpoint placeholder replacement
    # verified __NGINX_IMAGE__ is replaced with the resolved nginx image

    git diff --check

---

## Risk & Rollback

- Potential risks:
  - 离线环境需要提前同步 `openbkn-ai/library/nginx:1.27-alpine` 镜像。
  - 如果离线 registry 中缺少该镜像，install-status Pod 仍会无法启动，但不会阻断主 OpenBKN 安装流程。
- Rollback plan:
  - Revert this PR，恢复原有镜像配置。
  - 不涉及数据库、Helm values 或持久化数据迁移。

---

## Additional Notes

- 本 PR 涉及文件：
  - `deploy/scripts/services/status.sh`
  - `deploy/conf/install-status/endpoint.yaml`
  - `deploy/scripts/sync-k8s-images.sh`
- 未执行实际 Kubernetes 部署。
- 请勿将工作区中的其他无关改动带入本 PR。