### PR TITLE
docs(help): Context Loader 手册改到 openbkn context 命令组

### DIFF
--- a/help/en/manual/context-loader.md
+++ b/help/en/manual/context-loader.md
@@ -137,17 +137,24 @@ openbkn context relation-types <kn-id> rt_purchase
 ```bash
 # Object instances with conditions
 openbkn context query-object-instance <kn-id> --args '{
-  "object_type_id": "ot_orders",
-  "conditions": [{"field": "priority", "operation": "==", "value": "high"}],
+  "ot_id": "ot_orders",
+  "filters": [{"field": "priority", "op": "==", "value": "high"}],
   "limit": 20
 }'
 
 # Relation subgraph around instances
 openbkn context query-instance-subgraph <kn-id> --args '{
-  "object_type_id": "ot_orders",
-  "instance_identities": [{"id": "ord-5521"}],
-  "relation_type_ids": ["rt_belongs_to"],
-  "limit": 50
+  "relation_type_paths": [{
+    "object_types": [
+      {"id": "ot_orders",   "condition": {"operation": "and", "sub_conditions": []}, "limit": 10},
+      {"id": "ot_customer", "condition": {"operation": "and", "sub_conditions": []}, "limit": 10}
+    ],
+    "relation_types": [{
+      "relation_type_id": "rt_belongs_to",
+      "source_object_type_id": "ot_orders",
+      "target_object_type_id": "ot_customer"
+    }]
+  }]
 }'
 ```
 
@@ -156,15 +163,17 @@ openbkn context query-instance-subgraph <kn-id> --args '{
 ```bash
 # Computed / derived property values
 openbkn context get-logic-properties <kn-id> --args '{
-  "object_type_id": "ot_orders",
-  "instance_identities": [{"id": "ord-5521"}],
-  "logic_property_names": ["days_overdue"]
+  "ot_id": "ot_orders",
+  "query": "how overdue are these orders",
+  "_instance_identities": [{"...": "copied verbatim from _instance_identity in a query result"}],
+  "properties": ["days_overdue"]
 }'
 
-# Actions available on an instance
+# Tool definition and parameter schema for one action type (at_id is required —
+# get it from search_schema / get_kn_detail first)
 openbkn context get-action-info <kn-id> --args '{
-  "object_type_id": "ot_orders",
-  "instance_identities": [{"id": "ord-5521"}]
+  "at_id": "at_escalate",
+  "_instance_identities": [{"...": "copied verbatim from _instance_identity in a query result"}]
 }'
 
 # Skills bound to an object type
@@ -177,7 +186,11 @@ The catalog grows between releases and the CLI does not wrap every tool. `tool-c
 
 ```bash
 openbkn context tool-call <kn-id> run_sql --args '{"sql":"SELECT 1"}'
-openbkn context tool-call <kn-id> execute_action --arg action_type_id=at_notify --arg dry_run=true
+openbkn context tool-call <kn-id> execute_action --args '{
+  "at_id": "at_escalate",
+  "_instance_identities": [{"...": "as above"}],
+  "dynamic_params": {}
+}'
 openbkn context call-method <kn-id> tools/list
 ```
 
@@ -194,21 +207,30 @@ openbkn context search-schema "$KN" "high-priority orders" --scope object
 
 # 3. Query instances
 openbkn context query-object-instance "$KN" --args '{
-  "object_type_id": "ot_orders",
-  "conditions": [{"field": "priority", "operation": "==", "value": "high"}],
+  "ot_id": "ot_orders",
+  "filters": [{"field": "priority", "op": "==", "value": "high"}],
   "limit": 10
 }'
 
 # 4. Explore the neighbourhood
 openbkn context query-instance-subgraph "$KN" --args '{
-  "object_type_id": "ot_orders",
-  "instance_identities": [{"id": "ord-5521"}]
+  "relation_type_paths": [{
+    "object_types": [
+      {"id": "ot_orders",   "condition": {"operation": "and", "sub_conditions": []}, "limit": 10},
+      {"id": "ot_customer", "condition": {"operation": "and", "sub_conditions": []}, "limit": 10}
+    ],
+    "relation_types": [{
+      "relation_type_id": "rt_belongs_to",
+      "source_object_type_id": "ot_orders",
+      "target_object_type_id": "ot_customer"
+    }]
+  }]
 }'
 
 # 5. Check what can be done to it
 openbkn context get-action-info "$KN" --args '{
-  "object_type_id": "ot_orders",
-  "instance_identities": [{"id": "ord-5521"}]
+  "at_id": "at_escalate",
+  "_instance_identities": [{"...": "from step 3's _instance_identity"}]
 }'
 ```
 
@@ -236,26 +258,37 @@ const ots = await bkn.context.objectTypes(knId, ['ot_orders']);
 
 // Instance queries
 const instances = await bkn.context.queryObjectInstance(knId, {
-  object_type_id: 'ot_orders',
-  conditions: [{ field: 'priority', operation: '==', value: 'high' }],
+  ot_id: 'ot_orders',
+  filters: [{ field: 'priority', op: '==', value: 'high' }],
   limit: 20,
 });
 
 const subgraph = await bkn.context.queryInstanceSubgraph(knId, {
-  object_type_id: 'ot_orders',
-  instance_identities: [{ id: 'ord-5521' }],
-  relation_type_ids: ['rt_belongs_to'],
+  relation_type_paths: [{
+    object_types: [
+      { id: 'ot_orders', condition: { operation: 'and', sub_conditions: [] }, limit: 10 },
+      { id: 'ot_customer', condition: { operation: 'and', sub_conditions: [] }, limit: 10 },
+    ],
+    relation_types: [{
+      relation_type_id: 'rt_belongs_to',
+      source_object_type_id: 'ot_orders',
+      target_object_type_id: 'ot_customer',
+    }],
+  }],
 });
 
 // Logic properties and actions
+// _instance_identities must be copied verbatim from the previous result's
+// _instance_identity field — never hand-written
 const logic = await bkn.context.logicProperties(knId, {
-  object_type_id: 'ot_orders',
-  instance_identities: [{ id: 'ord-5521' }],
-  logic_property_names: ['days_overdue'],
+  ot_id: 'ot_orders',
+  query: 'how overdue are these orders',
+  _instance_identities: instances.map((r: any) => r._instance_identity),
+  properties: ['days_overdue'],
 });
 const actions = await bkn.context.actionInfo(knId, {
-  object_type_id: 'ot_orders',
-  instance_identities: [{ id: 'ord-5521' }],
+  at_id: 'at_escalate',
+  _instance_identities: instances.map((r: any) => r._instance_identity),
 });
 
 // Skills
@@ -270,6 +303,27 @@ const sql = await bkn.context.toolCall(knId, 'run_sql', { sql: 'SELECT 1' });
 ## curl
 
 REST paths are `/api/agent-retrieval/v1/kn/<tool-name>`, matching the MCP tool names. Health checks live under `/health`, outside the `/api` prefix.
+
+> **Read this first**: since 0.1.3 every POST to `/kn/*` requires a `bkn_context` in the body and
+> returns 400 without one. The check is unconditional and fail-closed (`rest_public_handler.go:67`
+> mounts the middleware unconditionally; `isLifecycleBusinessRequest` matches any POST whose path
+> contains `/kn/`), so **the curl examples below are rejected on a build from current code**. The
+> v0.1.2 release does not have this middleware and runs them as written.
+>
+> `bkn_context` accepts exactly five fields: `conversation_id`, `interaction_id`,
+> `parent_operation_id`, `causation_event_ids`, `business_refs`. Anything else returns
+> `invalid_business_context` — in particular **you cannot pass `operation_key`**; the server derives
+> it from trusted request correlation. A missing `conversation_id` returns `conversation_required`;
+> a missing `interaction_id` returns `interaction_required`.
+>
+> Those ids come from `bkn_start_interaction`, which is exposed only over MCP — there is no REST
+> route for it. So on 0.1.3+ a plain HTTP caller cannot obtain them: use the MCP transport instead
+> (`openbkn context ...` goes through it and the server derives the session per connection).
+
+```bash
+# On 0.1.3+ the body needs a session supplied by MCP; plain curl cannot mint one:
+# {"kn_id":"kn-001","query":"orders","bkn_context":{"conversation_id":"…","interaction_id":"…"}}
+```
 
 ```bash
 # Health check (no auth)
@@ -288,8 +342,8 @@ curl -sk -X POST "https://<access-address>/api/agent-retrieval/v1/kn/query_objec
   -H "Content-Type: application/json" \
   -d '{
     "kn_id": "kn-001",
-    "object_type_id": "ot_orders",
-    "conditions": [{"field":"priority","operation":"==","value":"high"}],
+    "ot_id": "ot_orders",
+    "filters": [{"field":"priority","op":"==","value":"high"}],
     "limit": 20
   }'
 
@@ -299,9 +353,17 @@ curl -sk -X POST "https://<access-address>/api/agent-retrieval/v1/kn/query_insta
   -H "Content-Type: application/json" \
   -d '{
     "kn_id": "kn-001",
-    "object_type_id": "ot_orders",
-    "instance_identities": [{"id":"ord-5521"}],
-    "relation_type_ids": ["rt_belongs_to"]
+    "relation_type_paths": [{
+      "object_types": [
+        {"id":"ot_orders","condition":{"operation":"and","sub_conditions":[]},"limit":10},
+        {"id":"ot_customer","condition":{"operation":"and","sub_conditions":[]},"limit":10}
+      ],
+      "relation_types": [{
+        "relation_type_id":"rt_belongs_to",
+        "source_object_type_id":"ot_orders",
+        "target_object_type_id":"ot_customer"
+      }]
+    }]
   }'
 
 # Logic properties (path is logic-property-resolver, not the tool name)
@@ -310,9 +372,10 @@ curl -sk -X POST "https://<access-address>/api/agent-retrieval/v1/kn/logic-prope
   -H "Content-Type: application/json" \
   -d '{
     "kn_id": "kn-001",
-    "object_type_id": "ot_orders",
-    "instance_identities": [{"id":"ord-5521"}],
-    "logic_property_names": ["days_overdue"]
+    "ot_id": "ot_orders",
+    "query": "how overdue are these orders",
+    "_instance_identities": [{"...": "copied from _instance_identity in a query result"}],
+    "properties": ["days_overdue"]
   }'
 
 # Action info
@@ -321,16 +384,10 @@ curl -sk -X POST "https://<access-address>/api/agent-retrieval/v1/kn/get_action_
   -H "Content-Type: application/json" \
   -d '{
     "kn_id": "kn-001",
-    "object_type_id": "ot_orders",
-    "instance_identities": [{"id":"ord-5521"}]
+    "at_id": "at_escalate",
+    "_instance_identities": [{"...": "copied from _instance_identity in a query result"}]
   }'
 ```
-
-> **Note:** some builds gate `POST /kn/*` on session context and answer
-> `400 conversation_required` when the body has no `bkn_context`
-> (`conversation_id` / `interaction_id` / `operation_key`). The v0.1.2 release does not
-> have this check. Over the MCP transport the server derives the context per connection,
-> so callers never supply it themselves.
 
 ---
 

--- a/help/en/manual/context-loader.md
+++ b/help/en/manual/context-loader.md
@@ -43,7 +43,7 @@ Create `.cursor/mcp.json` in your project root (or globally at `~/.cursor/mcp.js
 }
 ```
 
-Get a token with `openbkn token`. Once saved, Cursor will auto-discover the MCP tools exposed by Context Loader, and the agent can call them directly in conversation.
+Get a token with `openbkn auth token`. Once saved, Cursor will auto-discover the MCP tools exposed by Context Loader, and the agent can call them directly in conversation.
 
 ### Configure in Claude Desktop
 
@@ -64,116 +64,152 @@ Edit `claude_desktop_config.json`:
 
 ### Available MCP Tools
 
-Once configured, MCP clients can discover and call these tools:
+Once configured, MCP clients can discover and call these tools (your deployment is authoritative — run `openbkn context info` to see the live catalog):
 
-| Tool | Layer | Description |
-|------|-------|-------------|
-| `kn_search` | L1 | Semantic search across schema and instances |
-| `kn_schema_search` | L1 | Search schema metadata only (discover candidate concepts) |
-| `query_object_instance` | L2 | Query object instances with conditions |
-| `query_instance_subgraph` | L2 | Query the relation subgraph around an instance |
-| `get_logic_properties` | L3 | Get computed / derived property values |
-| `get_action_info` | L3 | Get action type definition and parameter schema |
+| Tool | Purpose |
+|------|---------|
+| `search_schema` | Search object / relation / action / metric schemas |
+| `get_kn_detail` | Fetch a KN's schema — `summary` skeleton, then drill down |
+| `get_object_types` / `get_relation_types` | Full definitions for given ids |
+| `query_object_instance` | Query object instances with conditions |
+| `query_instance_subgraph` | Query the relation subgraph around instances |
+| `get_logic_properties_values` | Compute derived property values |
+| `get_action_info` | Get action type definition and parameter schema |
+| `execute_action` | Execute an action type |
+| `get_action_execution` / `list_action_executions` | Action execution status and history |
+| `find_skills` | Recall skills bound to an object type |
+| `list_knowledge_networks` | List knowledge networks |
+| `list_resources` / `describe_resource` | List and describe Vega resources |
+| `run_sql` | Run SQL directly against a resource |
+| `bkn_start_interaction` / `bkn_finish_interaction` | Session lifecycle (business traceability) |
 
-Every tool call requires the common parameter `kn_id` (knowledge network ID). Use `openbkn bkn list` to find it.
+Every tool call requires `kn_id` (knowledge network ID). Use `openbkn bkn list` to find it.
 
 ### Verify with CLI
 
-You can verify the MCP server is working without configuring a full MCP client:
+You can verify the MCP server without configuring a full MCP client. There is no global "current KN" setting — `kn-id` is a positional argument on every command:
 
 ```bash
-# Set the knowledge network
-openbkn context-loader config set --kn-id kn_abc123
+# Deployment-wide tool catalog (no kn-id needed)
+openbkn context info
 
-# List MCP tools
-openbkn context-loader tools
+# Tools advertised for one knowledge network's session
+openbkn context tools <kn-id>
 ```
 
 ---
 
 ## 💻 CLI
 
-### Configuration Management
+The command group is `openbkn context`. (The earlier `openbkn context-loader` group was renamed, and its `config set/use/list/show/remove` subcommands are gone — `kn-id` is now a positional argument on every command.) Commands that take tool arguments accept them as `--args '<json>'`.
+
+### Catalog and introspection
 
 ```bash
-# Set active BKN Foundry server configuration
-openbkn config set <alias> --url https://<access-address> --token <token>
+# Deployment-wide tool catalog (no kn-id)
+openbkn context info
 
-# Use a saved configuration
-openbkn config use <alias>
-
-# List all saved configurations
-openbkn config list
-
-# Show current active configuration
-openbkn config show
-
-# Remove a saved configuration
-openbkn config remove <alias>
+# Per-session tools / resources / prompts
+openbkn context tools <kn-id>
+openbkn context resources <kn-id>
+openbkn context templates <kn-id>
+openbkn context prompts <kn-id>
+openbkn context prompt <kn-id> <name> --args '{"k":"v"}'
+openbkn context resource <kn-id> <uri>
 ```
 
-### MCP Integration
-
-The Context Loader exposes MCP (Model Context Protocol) endpoints for tool-aware LLM applications.
+### Schema exploration
 
 ```bash
-# List available MCP tools
-openbkn mcp tools
+# Semantic schema search, optionally scoped
+openbkn context search-schema <kn-id> "customer order relationships"
+openbkn context search-schema <kn-id> "which object types describe a customer" \
+  --scope object,relation --max 10
+
+# Progressive schema: skeleton first, then drill down by id
+openbkn context kn-detail <kn-id> --detail-level summary
+openbkn context object-types <kn-id> ot_customer ot_order
+openbkn context relation-types <kn-id> rt_purchase
 ```
 
-### Knowledge Network Search
+### Instance queries
 
 ```bash
-# Semantic search across a knowledge network
-openbkn kn-search <kn_id> "quarterly revenue trends"
-openbkn kn-search <kn_id> "customer churn risk factors" --limit 15
+# Object instances with conditions
+openbkn context query-object-instance <kn-id> --args '{
+  "object_type_id": "ot_orders",
+  "conditions": [{"field": "priority", "operation": "==", "value": "high"}],
+  "limit": 20
+}'
+
+# Relation subgraph around instances
+openbkn context query-instance-subgraph <kn-id> --args '{
+  "object_type_id": "ot_orders",
+  "instance_identities": [{"id": "ord-5521"}],
+  "relation_type_ids": ["rt_belongs_to"],
+  "limit": 50
+}'
 ```
 
-### Instance Queries
+### Logic properties, actions, skills
 
 ```bash
-# Query a specific object instance by ID
-openbkn query-object-instance <kn_id> <ot_id> <instance_id>
+# Computed / derived property values
+openbkn context get-logic-properties <kn-id> --args '{
+  "object_type_id": "ot_orders",
+  "instance_identities": [{"id": "ord-5521"}],
+  "logic_property_names": ["days_overdue"]
+}'
 
-# Query the subgraph around an instance (neighbors, relations)
-openbkn query-instance-subgraph <kn_id> <ot_id> <instance_id>
-openbkn query-instance-subgraph <kn_id> <ot_id> <instance_id> --depth 2
+# Actions available on an instance
+openbkn context get-action-info <kn-id> --args '{
+  "object_type_id": "ot_orders",
+  "instance_identities": [{"id": "ord-5521"}]
+}'
 
-# Get computed / logic properties for an instance
-openbkn get-logic-properties <kn_id> <ot_id> <instance_id>
+# Skills bound to an object type
+openbkn context find-skills <kn-id> ot_orders --top-k 5
 ```
 
-### Action Information
+### Calling any tool
+
+The catalog grows between releases and the CLI does not wrap every tool. `tool-call` invokes any MCP tool by name; `call-method` invokes any MCP method:
 
 ```bash
-# Get full action type definition and parameter schema
-openbkn get-action-info <kn_id> <action_id>
+openbkn context tool-call <kn-id> run_sql --args '{"sql":"SELECT 1"}'
+openbkn context tool-call <kn-id> execute_action --arg action_type_id=at_notify --arg dry_run=true
+openbkn context call-method <kn-id> tools/list
 ```
 
 ### End-to-End Example
 
 ```bash
-# 1. Configure and authenticate
-openbkn config set prod --url https://openbkn.example.com --token eyJ...
-openbkn config use prod
+KN=<kn-id>
 
-# 2. Search the knowledge network for context
-openbkn kn-search kn-001 "high-priority orders this month"
+# 1. See which tools this session exposes
+openbkn context tools "$KN"
 
-# 3. Drill into a specific instance
-openbkn query-object-instance kn-001 ot-orders ord-5521
+# 2. Find the relevant object type
+openbkn context search-schema "$KN" "high-priority orders" --scope object
 
-# 4. Explore its neighborhood
-openbkn query-instance-subgraph kn-001 ot-orders ord-5521 --depth 2
+# 3. Query instances
+openbkn context query-object-instance "$KN" --args '{
+  "object_type_id": "ot_orders",
+  "conditions": [{"field": "priority", "operation": "==", "value": "high"}],
+  "limit": 10
+}'
 
-# 5. Check logic properties
-openbkn get-logic-properties kn-001 ot-orders ord-5521
+# 4. Explore the neighbourhood
+openbkn context query-instance-subgraph "$KN" --args '{
+  "object_type_id": "ot_orders",
+  "instance_identities": [{"id": "ord-5521"}]
+}'
 
-# 6. Get action info before executing
-openbkn get-action-info kn-001 act-escalate
-
-# 7. List available MCP tools for agent integration
-openbkn mcp tools
+# 5. Check what can be done to it
+openbkn context get-action-info "$KN" --args '{
+  "object_type_id": "ot_orders",
+  "instance_identities": [{"id": "ord-5521"}]
+}'
 ```
 
 ---
@@ -189,59 +225,124 @@ const bkn = createClient({ baseUrl: 'https://<access-address>', token: process.e
 
 const knId = 'kn-001';
 
-// Semantic search across a knowledge network
-const results = await bkn.kn.search(knId, 'quarterly revenue trends');
-console.log('Search hits:', results);
+// Catalog
+console.log(await bkn.context.info());
+console.log(await bkn.context.tools(knId));
 
-// Context Loader retrieval runs over the agent-retrieval MCP endpoint.
-// Endpoints without a typed helper are reachable via the generic passthrough.
-const instance = await bkn.call(
-  `/api/agent-retrieval/v1/knowledge-networks/${knId}/object-types/ot-orders/instances/ord-5521`,
-  { method: 'GET' },
-);
-console.log('Instance:', instance);
+// Schema exploration
+const schema = await bkn.context.searchSchema(knId, 'high-priority orders', { scope: ['object'] });
+const skeleton = await bkn.context.knDetail(knId, 'summary');
+const ots = await bkn.context.objectTypes(knId, ['ot_orders']);
 
-const subgraph = await bkn.call(
-  `/api/agent-retrieval/v1/knowledge-networks/${knId}/object-types/ot-orders/instances/ord-5521/subgraph`,
-  { method: 'POST', body: { depth: 2 } },
-);
-console.log('Subgraph:', subgraph);
+// Instance queries
+const instances = await bkn.context.queryObjectInstance(knId, {
+  object_type_id: 'ot_orders',
+  conditions: [{ field: 'priority', operation: '==', value: 'high' }],
+  limit: 20,
+});
+
+const subgraph = await bkn.context.queryInstanceSubgraph(knId, {
+  object_type_id: 'ot_orders',
+  instance_identities: [{ id: 'ord-5521' }],
+  relation_type_ids: ['rt_belongs_to'],
+});
+
+// Logic properties and actions
+const logic = await bkn.context.logicProperties(knId, {
+  object_type_id: 'ot_orders',
+  instance_identities: [{ id: 'ord-5521' }],
+  logic_property_names: ['days_overdue'],
+});
+const actions = await bkn.context.actionInfo(knId, {
+  object_type_id: 'ot_orders',
+  instance_identities: [{ id: 'ord-5521' }],
+});
+
+// Skills
+const skills = await bkn.context.findSkills(knId, 'ot_orders', 5);
+
+// Anything not wrapped: call the tool by name
+const sql = await bkn.context.toolCall(knId, 'run_sql', { sql: 'SELECT 1' });
 ```
 
 ---
 
 ## curl
 
+REST paths are `/api/agent-retrieval/v1/kn/<tool-name>`, matching the MCP tool names. Health checks live under `/health`, outside the `/api` prefix.
+
 ```bash
-# Health check
-curl -sk "https://<access-address>/api/agent-retrieval/v1/health" \
-  -H "Authorization: Bearer $(openbkn token)"
+# Health check (no auth)
+curl -sk "https://<access-address>/health/ready"
+curl -sk "https://<access-address>/health/alive"
 
-# Semantic search across a knowledge network
-curl -sk -X POST "https://<access-address>/api/agent-retrieval/v1/knowledge-networks/kn-001/search" \
-  -H "Authorization: Bearer $(openbkn token)" \
+# Schema search
+curl -sk -X POST "https://<access-address>/api/agent-retrieval/v1/kn/search_schema" \
+  -H "Authorization: Bearer $(openbkn auth token)" \
   -H "Content-Type: application/json" \
-  -d '{"query": "quarterly revenue trends", "limit": 10}'
+  -d '{"kn_id":"kn-001","query":"high-priority orders"}'
 
-# Query a specific object instance
-curl -sk "https://<access-address>/api/agent-retrieval/v1/knowledge-networks/kn-001/object-types/ot-orders/instances/ord-5521" \
-  -H "Authorization: Bearer $(openbkn token)"
-
-# Query the subgraph around an instance
-curl -sk -X POST "https://<access-address>/api/agent-retrieval/v1/knowledge-networks/kn-001/object-types/ot-orders/instances/ord-5521/subgraph" \
-  -H "Authorization: Bearer $(openbkn token)" \
+# Query object instances
+curl -sk -X POST "https://<access-address>/api/agent-retrieval/v1/kn/query_object_instance" \
+  -H "Authorization: Bearer $(openbkn auth token)" \
   -H "Content-Type: application/json" \
-  -d '{"depth": 2}'
+  -d '{
+    "kn_id": "kn-001",
+    "object_type_id": "ot_orders",
+    "conditions": [{"field":"priority","operation":"==","value":"high"}],
+    "limit": 20
+  }'
 
-# Get logic properties
-curl -sk "https://<access-address>/api/agent-retrieval/v1/knowledge-networks/kn-001/object-types/ot-orders/instances/ord-5521/logic-properties" \
-  -H "Authorization: Bearer $(openbkn token)"
+# Query an instance subgraph
+curl -sk -X POST "https://<access-address>/api/agent-retrieval/v1/kn/query_instance_subgraph" \
+  -H "Authorization: Bearer $(openbkn auth token)" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "kn_id": "kn-001",
+    "object_type_id": "ot_orders",
+    "instance_identities": [{"id":"ord-5521"}],
+    "relation_type_ids": ["rt_belongs_to"]
+  }'
 
-# Get action type information
-curl -sk "https://<access-address>/api/agent-retrieval/v1/knowledge-networks/kn-001/actions/act-escalate/info" \
-  -H "Authorization: Bearer $(openbkn token)"
+# Logic properties (path is logic-property-resolver, not the tool name)
+curl -sk -X POST "https://<access-address>/api/agent-retrieval/v1/kn/logic-property-resolver" \
+  -H "Authorization: Bearer $(openbkn auth token)" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "kn_id": "kn-001",
+    "object_type_id": "ot_orders",
+    "instance_identities": [{"id":"ord-5521"}],
+    "logic_property_names": ["days_overdue"]
+  }'
 
-# List MCP tools
-curl -sk "https://<access-address>/api/agent-retrieval/v1/mcp/tools" \
-  -H "Authorization: Bearer $(openbkn token)"
+# Action info
+curl -sk -X POST "https://<access-address>/api/agent-retrieval/v1/kn/get_action_info" \
+  -H "Authorization: Bearer $(openbkn auth token)" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "kn_id": "kn-001",
+    "object_type_id": "ot_orders",
+    "instance_identities": [{"id":"ord-5521"}]
+  }'
 ```
+
+> **Note:** some builds gate `POST /kn/*` on session context and answer
+> `400 conversation_required` when the body has no `bkn_context`
+> (`conversation_id` / `interaction_id` / `operation_key`). The v0.1.2 release does not
+> have this check. Over the MCP transport the server derives the context per connection,
+> so callers never supply it themselves.
+
+---
+
+## Retired command mapping
+
+| Retired | Current practice |
+| --- | --- |
+| `openbkn context-loader config set/use/list/show/remove` | Gone; `kn-id` is a positional argument on every command |
+| `openbkn context-loader tools` / `openbkn mcp tools` | `openbkn context tools <kn-id>` (deployment catalog: `openbkn context info`) |
+| `openbkn kn-search <kn_id> <query>` | `openbkn context search-schema <kn-id> <query>` |
+| `openbkn query-object-instance <kn_id> <ot_id> <id>` | `openbkn context query-object-instance <kn-id> --args '<json>'` |
+| `openbkn query-instance-subgraph <kn_id> <ot_id> <id>` | `openbkn context query-instance-subgraph <kn-id> --args '<json>'` |
+| `openbkn get-logic-properties <kn_id> <ot_id> <id>` | `openbkn context get-logic-properties <kn-id> --args '<json>'` |
+| `openbkn get-action-info <kn_id> <action_id>` | `openbkn context get-action-info <kn-id> --args '<json>'` |
+| `openbkn config set/use` (CLI profiles) | `openbkn auth login` / `openbkn auth use` / `openbkn auth list` |

--- a/help/zh/manual/context-loader.md
+++ b/help/zh/manual/context-loader.md
@@ -140,19 +140,24 @@ openbkn context relation-types <kn-id> rt_purchase
 ```bash
 # 条件查询对象实例
 openbkn context query-object-instance <kn-id> --args '{
-  "object_type_id": "ot_customer",
-  "conditions": [
-    {"field": "status", "operation": "==", "value": "active"}
-  ],
+  "ot_id": "ot_customer",
+  "filters": [{"field": "status", "op": "==", "value": "active"}],
   "limit": 20
 }'
 
 # 沿关系类路径查询实例子图
 openbkn context query-instance-subgraph <kn-id> --args '{
-  "object_type_id": "ot_customer",
-  "instance_identities": [{"id": "cust_001"}],
-  "relation_type_ids": ["rt_purchase"],
-  "limit": 50
+  "relation_type_paths": [{
+    "object_types": [
+      {"id": "ot_customer", "condition": {"operation": "and", "sub_conditions": []}, "limit": 10},
+      {"id": "ot_order",    "condition": {"operation": "and", "sub_conditions": []}, "limit": 10}
+    ],
+    "relation_types": [{
+      "relation_type_id": "rt_purchase",
+      "source_object_type_id": "ot_customer",
+      "target_object_type_id": "ot_order"
+    }]
+  }]
 }'
 ```
 
@@ -161,15 +166,16 @@ openbkn context query-instance-subgraph <kn-id> --args '{
 ```bash
 # 计算逻辑属性取值
 openbkn context get-logic-properties <kn-id> --args '{
-  "object_type_id": "ot_customer",
-  "instance_identities": [{"id": "cust_001"}],
-  "logic_property_names": ["lifetime_value", "risk_score"]
+  "ot_id": "ot_customer",
+  "query": "这批客户近一年的终身价值与风险分",
+  "_instance_identities": [{"...": "从 query_object_instance 返回的 _instance_identity 原样取"}],
+  "properties": ["lifetime_value", "risk_score"]
 }'
 
-# 取该实例可触发的行动类信息
+# 取某个行动类的工具定义与参数 Schema（at_id 必填，来自 search_schema / get_kn_detail）
 openbkn context get-action-info <kn-id> --args '{
-  "object_type_id": "ot_customer",
-  "instance_identities": [{"id": "cust_001"}]
+  "at_id": "at_send_coupon",
+  "_instance_identities": [{"...": "从 query_object_instance 返回的 _instance_identity 原样取"}]
 }'
 
 # 按对象类召回可用 Skill
@@ -182,7 +188,11 @@ openbkn context find-skills <kn-id> ot_customer --top-k 5
 
 ```bash
 openbkn context tool-call <kn-id> run_sql --args '{"sql":"SELECT 1"}'
-openbkn context tool-call <kn-id> execute_action --arg action_type_id=at_notify --arg dry_run=true
+openbkn context tool-call <kn-id> execute_action --args '{
+  "at_id": "at_send_coupon",
+  "_instance_identities": [{"...": "同上"}],
+  "dynamic_params": {}
+}'
 openbkn context call-method <kn-id> tools/list
 ```
 
@@ -199,22 +209,30 @@ openbkn context search-schema "$KN" "客户" --scope object
 
 # 3. 实例查询 — 取活跃客户
 openbkn context query-object-instance "$KN" --args '{
-  "object_type_id": "ot_customer",
-  "conditions": [{"field": "status", "operation": "==", "value": "active"}],
+  "ot_id": "ot_customer",
+  "filters": [{"field": "status", "op": "==", "value": "active"}],
   "limit": 10
 }'
 
 # 4. 子图扩展 — 看该客户的购买关系
 openbkn context query-instance-subgraph "$KN" --args '{
-  "object_type_id": "ot_customer",
-  "instance_identities": [{"id": "cust_001"}],
-  "relation_type_ids": ["rt_purchase"]
+  "relation_type_paths": [{
+    "object_types": [
+      {"id": "ot_customer", "condition": {"operation": "and", "sub_conditions": []}, "limit": 10},
+      {"id": "ot_order",    "condition": {"operation": "and", "sub_conditions": []}, "limit": 10}
+    ],
+    "relation_types": [{
+      "relation_type_id": "rt_purchase",
+      "source_object_type_id": "ot_customer",
+      "target_object_type_id": "ot_order"
+    }]
+  }]
 }'
 
 # 5. 行动信息 — 看可对该客户执行什么
 openbkn context get-action-info "$KN" --args '{
-  "object_type_id": "ot_customer",
-  "instance_identities": [{"id": "cust_001"}]
+  "at_id": "at_send_coupon",
+  "_instance_identities": [{"...": "取自第 3 步返回的 _instance_identity"}]
 }'
 ```
 
@@ -242,27 +260,37 @@ const ots = await bkn.context.objectTypes(knId, ['ot_customer']);
 
 // 实例查询
 const instances = await bkn.context.queryObjectInstance(knId, {
-  object_type_id: 'ot_customer',
-  conditions: [{ field: 'status', operation: '==', value: 'active' }],
+  ot_id: 'ot_customer',
+  filters: [{ field: 'status', op: '==', value: 'active' }],
   limit: 20,
 });
 
 // 子图遍历
 const subgraph = await bkn.context.queryInstanceSubgraph(knId, {
-  object_type_id: 'ot_customer',
-  instance_identities: [{ id: 'cust-5521' }],
-  relation_type_ids: ['rt_purchase'],
+  relation_type_paths: [{
+    object_types: [
+      { id: 'ot_customer', condition: { operation: 'and', sub_conditions: [] }, limit: 10 },
+      { id: 'ot_order', condition: { operation: 'and', sub_conditions: [] }, limit: 10 },
+    ],
+    relation_types: [{
+      relation_type_id: 'rt_purchase',
+      source_object_type_id: 'ot_customer',
+      target_object_type_id: 'ot_order',
+    }],
+  }],
 });
 
 // 逻辑属性与行动
+// _instance_identities 必须原样取自上一步返回的 _instance_identity，不能自己编
 const logic = await bkn.context.logicProperties(knId, {
-  object_type_id: 'ot_customer',
-  instance_identities: [{ id: 'cust-5521' }],
-  logic_property_names: ['lifetime_value'],
+  ot_id: 'ot_customer',
+  query: '这批客户近一年的终身价值',
+  _instance_identities: instances.map((r: any) => r._instance_identity),
+  properties: ['lifetime_value'],
 });
 const actions = await bkn.context.actionInfo(knId, {
-  object_type_id: 'ot_customer',
-  instance_identities: [{ id: 'cust-5521' }],
+  at_id: 'at_send_coupon',
+  _instance_identities: instances.map((r: any) => r._instance_identity),
 });
 
 // 技能召回
@@ -277,6 +305,25 @@ const sql = await bkn.context.toolCall(knId, 'run_sql', { sql: 'SELECT 1' });
 ### curl
 
 REST 面的路径是 `/api/agent-retrieval/v1/kn/<工具名>`，与 MCP 工具同名；健康检查在 `/health` 下，不带 `/api` 前缀。
+
+> **先读这条**：自 0.1.3 起，`/kn/*` 的所有 POST 一律要求请求体带 `bkn_context`，缺失即 400。
+> 这是无条件、fail-closed 的校验（`rest_public_handler.go:67` 无条件挂载中间件，
+> `isLifecycleBusinessRequest` 对任意路径含 `/kn/` 的 POST 生效），所以**下面的 curl 示例
+> 在按当前代码构建的部署上都会被挡下**。v0.1.2 发布版不含该中间件，示例可直接运行。
+>
+> `bkn_context` 只接受五个字段：`conversation_id`、`interaction_id`、`parent_operation_id`、
+> `causation_event_ids`、`business_refs`。传入其它字段返回 `invalid_business_context`——
+> 尤其注意 **`operation_key` 不能自己传**，它由服务端从请求关联信息推导。
+> 缺 `conversation_id` 返回 `conversation_required`，缺 `interaction_id` 返回 `interaction_required`。
+>
+> 会话 id 的来源是 `bkn_start_interaction`，而该工具只在 MCP 通道上公开，没有对应的 REST 路由。
+> 也就是说 0.1.3+ 上纯 HTTP 调用方拿不到这两个 id：请改走 MCP（`openbkn context ...` 即走此路径，
+> 由服务端按连接自动归并会话）。
+
+```bash
+# 0.1.3+ 上的形态：bkn_context 由 MCP 会话提供，纯 curl 无法自行获得
+# {"kn_id":"kn_abc123","query":"客户","bkn_context":{"conversation_id":"…","interaction_id":"…"}}
+```
 
 ```bash
 # 健康检查（无需鉴权）
@@ -295,8 +342,8 @@ curl -sk -X POST "https://<访问地址>/api/agent-retrieval/v1/kn/query_object_
   -H "Content-Type: application/json" \
   -d '{
     "kn_id": "kn_abc123",
-    "object_type_id": "ot_customer",
-    "conditions": [{"field":"status","operation":"==","value":"active"}],
+    "ot_id": "ot_customer",
+    "filters": [{"field":"status","op":"==","value":"active"}],
     "limit": 20
   }'
 
@@ -306,9 +353,17 @@ curl -sk -X POST "https://<访问地址>/api/agent-retrieval/v1/kn/query_instanc
   -H "Content-Type: application/json" \
   -d '{
     "kn_id": "kn_abc123",
-    "object_type_id": "ot_customer",
-    "instance_identities": [{"id":"cust_001"}],
-    "relation_type_ids": ["rt_purchase"]
+    "relation_type_paths": [{
+      "object_types": [
+        {"id":"ot_customer","condition":{"operation":"and","sub_conditions":[]},"limit":10},
+        {"id":"ot_order","condition":{"operation":"and","sub_conditions":[]},"limit":10}
+      ],
+      "relation_types": [{
+        "relation_type_id":"rt_purchase",
+        "source_object_type_id":"ot_customer",
+        "target_object_type_id":"ot_order"
+      }]
+    }]
   }'
 
 # 逻辑属性（注意路径是 logic-property-resolver，不与工具同名）
@@ -317,9 +372,10 @@ curl -sk -X POST "https://<访问地址>/api/agent-retrieval/v1/kn/logic-propert
   -H "Content-Type: application/json" \
   -d '{
     "kn_id": "kn_abc123",
-    "object_type_id": "ot_customer",
-    "instance_identities": [{"id":"cust_001"}],
-    "logic_property_names": ["lifetime_value"]
+    "ot_id": "ot_customer",
+    "query": "这批客户近一年的终身价值",
+    "_instance_identities": [{"...": "取自 query_object_instance 返回的 _instance_identity"}],
+    "properties": ["lifetime_value"]
   }'
 
 # 行动信息
@@ -328,15 +384,10 @@ curl -sk -X POST "https://<访问地址>/api/agent-retrieval/v1/kn/get_action_in
   -H "Content-Type: application/json" \
   -d '{
     "kn_id": "kn_abc123",
-    "object_type_id": "ot_customer",
-    "instance_identities": [{"id":"cust_001"}]
+    "at_id": "at_send_coupon",
+    "_instance_identities": [{"...": "取自 query_object_instance 返回的 _instance_identity"}]
   }'
 ```
-
-> **注意**：部分版本的 context-loader 会对 `/kn/*` 的 POST 请求校验会话上下文，请求体缺少
-> `bkn_context`（`conversation_id` / `interaction_id` / `operation_key`）时返回
-> `400 conversation_required`。该校验在 v0.1.2 发布版中不存在。走 MCP 通道时由服务端按连接
-> 自动归并，不需要调用方自己造。
 
 ---
 

--- a/help/zh/manual/context-loader.md
+++ b/help/zh/manual/context-loader.md
@@ -47,7 +47,7 @@ https://<访问地址>/api/agent-retrieval/v1/mcp
 }
 ```
 
-Token 可通过 `openbkn token` 命令获取。配置保存后，Cursor 会自动发现 Context Loader 暴露的 MCP 工具，Agent 在对话中即可直接调用。
+Token 可通过 `openbkn auth token` 命令获取。配置保存后，Cursor 会自动发现 Context Loader 暴露的 MCP 工具，Agent 在对话中即可直接调用。
 
 ### 在 Claude Desktop 中配置
 
@@ -68,154 +68,153 @@ Token 可通过 `openbkn token` 命令获取。配置保存后，Cursor 会自�
 
 ### MCP 工具列表
 
-配置完成后，MCP 客户端可获取以下工具：
+配置完成后，MCP 客户端可获取以下工具（以部署实际返回为准，用 `openbkn context info` 查看当前目录）：
 
-| 工具 | 层级 | 说明 |
-|------|------|------|
-| `kn_search` | L1 | 语义搜索知识网络 Schema 与实例 |
-| `kn_schema_search` | L1 | 仅搜索 Schema 元数据（发现候选概念） |
-| `query_object_instance` | L2 | 条件查询对象实例 |
-| `query_instance_subgraph` | L2 | 查询实例的关系子图 |
-| `get_logic_properties` | L3 | 获取逻辑属性（计算字段、派生指标） |
-| `get_action_info` | L3 | 获取行动类信息与参数 Schema |
+| 工具 | 用途 |
+|------|------|
+| `search_schema` | 搜索对象类 / 关系类 / 行动类 / 指标的 Schema |
+| `get_kn_detail` | 取知识网络 Schema，支持 `summary` 骨架与逐层下钻 |
+| `get_object_types` / `get_relation_types` | 按 id 取对象类 / 关系类的完整定义 |
+| `query_object_instance` | 条件查询对象实例 |
+| `query_instance_subgraph` | 沿关系类路径查询实例子图 |
+| `get_logic_properties_values` | 计算逻辑属性（派生字段）取值 |
+| `get_action_info` | 取行动类信息与参数 Schema |
+| `execute_action` | 执行行动类 |
+| `get_action_execution` / `list_action_executions` | 查询行动执行状态与历史 |
+| `find_skills` | 按对象类召回可用 Skill |
+| `list_knowledge_networks` | 列出知识网络 |
+| `list_resources` / `describe_resource` | 列出与描述 Vega 资源 |
+| `run_sql` | 直接对资源执行 SQL |
+| `bkn_start_interaction` / `bkn_finish_interaction` | 会话生命周期（业务可追溯性） |
 
-每个工具调用需要的公共参数：`kn_id`（知识网络 ID）。可通过 `openbkn bkn list` 获取。
+每个工具调用需要 `kn_id`（知识网络 ID），可用 `openbkn bkn list` 获取。
 
 ### 使用 CLI 探测
 
-不配置 MCP 客户端也可以通过 CLI 快速验证 MCP 服务是否正常：
+不配置 MCP 客户端也能用 CLI 验证服务是否正常。CLI 没有「当前知识网络」这种全局配置，`kn-id` 是每条命令的位置参数：
 
 ```bash
-# 设置知识网络
-openbkn context-loader config set --kn-id kn_abc123
+# 查看部署的 MCP 工具目录（全局，不需要 kn-id）
+openbkn context info
 
-# 列出 MCP 工具
-openbkn context-loader tools
+# 查看某个知识网络会话下实际公布的工具
+openbkn context tools <kn-id>
 ```
 
 ---
 
 ## 💻 CLI
 
-#### 配置管理
+命令组是 `openbkn context`（早期的 `openbkn context-loader` 已改名，`config set/use/list/show/remove` 那套也一并取消——`kn-id` 现在是每条命令的位置参数）。取实例数据的几条统一用 `--args '<json>'` 传工具参数。
 
-Context Loader CLI 需先指定目标知识网络：
-
-```bash
-# 设置当前使用的知识网络
-openbkn context-loader config set --kn-id kn_abc123
-
-# 切换到已保存的配置
-openbkn context-loader config use my-config
-
-# 列出所有已保存配置
-openbkn context-loader config list
-
-# 显示当前配置详情
-openbkn context-loader config show
-
-# 删除配置
-openbkn context-loader config remove my-config
-```
-
-#### MCP 内省
-
-查看 Context Loader 暴露的 MCP 能力：
+#### 目录与内省
 
 ```bash
-# 列出所有可用工具（MCP tools）
-openbkn context-loader tools
+# 部署级工具目录（不需要 kn-id）
+openbkn context info
+
+# 某个知识网络会话公布的工具 / 资源 / 提示词
+openbkn context tools <kn-id>
+openbkn context resources <kn-id>
+openbkn context templates <kn-id>
+openbkn context prompts <kn-id>
+openbkn context prompt <kn-id> <name> --args '{"k":"v"}'
+openbkn context resource <kn-id> <uri>
 ```
 
-#### Layer 1 — Schema 搜索
-
-在知识网络的 Schema 层做语义搜索，定位相关对象类与关系类：
+#### Schema 探索
 
 ```bash
-# 全文搜索知识网络 Schema 与实例
-openbkn context-loader kn-search "客户订单关系" --only-schema
+# 语义搜索 Schema（可限定范围与返回上限）
+openbkn context search-schema <kn-id> "客户订单关系"
+openbkn context search-schema <kn-id> "哪些对象类描述了客户" --scope object,relation --max 10
 
-# 仅搜索 Schema 元数据（对象类、关系类定义）
-openbkn context-loader kn-schema-search "哪些对象类描述了客户"
+# 渐进式取 Schema：先要骨架，再按 id 下钻
+openbkn context kn-detail <kn-id> --detail-level summary
+openbkn context object-types <kn-id> ot_customer ot_order
+openbkn context relation-types <kn-id> rt_purchase
 ```
 
-#### Layer 2 — 实例查询
-
-根据 Layer 1 定位到的对象类，查询具体实例数据：
+#### 实例查询
 
 ```bash
 # 条件查询对象实例
-openbkn context-loader query-object-instance '{
-  "kn_id": "kn_abc123",
+openbkn context query-object-instance <kn-id> --args '{
   "object_type_id": "ot_customer",
   "conditions": [
-    {"field": "status", "op": "==", "value": "active"},
-    {"field": "region", "op": "in", "value": ["华东","华北"]}
+    {"field": "status", "operation": "==", "value": "active"}
   ],
-  "logic": "and",
   "limit": 20
 }'
 
-# 查询实例的关系子图
-openbkn context-loader query-instance-subgraph '{
-  "kn_id": "kn_abc123",
-  "instance_id": "cust_001",
-  "depth": 2,
-  "relation_types": ["rt_purchase", "rt_belongs_to"],
+# 沿关系类路径查询实例子图
+openbkn context query-instance-subgraph <kn-id> --args '{
+  "object_type_id": "ot_customer",
+  "instance_identities": [{"id": "cust_001"}],
+  "relation_type_ids": ["rt_purchase"],
   "limit": 50
 }'
 ```
 
-#### Layer 3 — 逻辑属性与动作
-
-获取计算字段和可执行动作信息：
+#### 逻辑属性、行动与技能
 
 ```bash
-# 获取逻辑属性（计算字段、派生属性）
-openbkn context-loader get-logic-properties '{
-  "kn_id": "kn_abc123",
+# 计算逻辑属性取值
+openbkn context get-logic-properties <kn-id> --args '{
   "object_type_id": "ot_customer",
-  "instance_id": "cust_001",
-  "properties": ["lifetime_value", "risk_score"]
+  "instance_identities": [{"id": "cust_001"}],
+  "logic_property_names": ["lifetime_value", "risk_score"]
 }'
 
-# 获取动作信息（该实例可触发的业务动作）
-openbkn context-loader get-action-info '{
-  "kn_id": "kn_abc123",
+# 取该实例可触发的行动类信息
+openbkn context get-action-info <kn-id> --args '{
   "object_type_id": "ot_customer",
-  "instance_id": "cust_001"
+  "instance_identities": [{"id": "cust_001"}]
 }'
+
+# 按对象类召回可用 Skill
+openbkn context find-skills <kn-id> ot_customer --top-k 5
+```
+
+#### 调用任意工具
+
+工具目录会随版本增长，CLI 未必为每个工具都配了子命令。`tool-call` 按名调用任意 MCP 工具，`call-method` 调任意 MCP 方法：
+
+```bash
+openbkn context tool-call <kn-id> run_sql --args '{"sql":"SELECT 1"}'
+openbkn context tool-call <kn-id> execute_action --arg action_type_id=at_notify --arg dry_run=true
+openbkn context call-method <kn-id> tools/list
 ```
 
 #### 端到端流程
 
 ```bash
-# 1. 配置知识网络
-openbkn context-loader config set --kn-id kn_abc123
+KN=<kn-id>
+
+# 1. 看有哪些工具可用
+openbkn context tools "$KN"
 
 # 2. Schema 探索 — 找到相关对象类
-openbkn context-loader kn-schema-search "订单和客户的关系"
+openbkn context search-schema "$KN" "客户" --scope object
 
-# 3. 实例查询 — 获取活跃客户
-openbkn context-loader query-object-instance '{
-  "kn_id": "kn_abc123",
+# 3. 实例查询 — 取活跃客户
+openbkn context query-object-instance "$KN" --args '{
   "object_type_id": "ot_customer",
-  "conditions": [{"field": "status", "op": "==", "value": "active"}],
-  "limit": 5
+  "conditions": [{"field": "status", "operation": "==", "value": "active"}],
+  "limit": 10
 }'
 
-# 4. 子图扩展 — 查看客户的购买关系
-openbkn context-loader query-instance-subgraph '{
-  "kn_id": "kn_abc123",
-  "instance_id": "cust_001",
-  "depth": 1
+# 4. 子图扩展 — 看该客户的购买关系
+openbkn context query-instance-subgraph "$KN" --args '{
+  "object_type_id": "ot_customer",
+  "instance_identities": [{"id": "cust_001"}],
+  "relation_type_ids": ["rt_purchase"]
 }'
 
-# 5. 获取动作信息 — 查看可对该客户执行的操作
-openbkn context-loader get-action-info '{
-  "kn_id": "kn_abc123",
+# 5. 行动信息 — 看可对该客户执行什么
+openbkn context get-action-info "$KN" --args '{
   "object_type_id": "ot_customer",
-  "instance_id": "cust_001"
+  "instance_identities": [{"id": "cust_001"}]
 }'
 ```
 
@@ -232,93 +231,124 @@ const bkn = createClient({ baseUrl: 'https://<访问地址>', token: process.env
 
 const knId = 'kn-001';
 
-// Layer 1：Schema 搜索 — 用自然语言发现对象类
-const schema = await bkn.context.searchSchema(knId, '客户订单关系');
-console.log('Schema 搜索结果:', schema);
+// 工具目录
+console.log(await bkn.context.info());
+console.log(await bkn.context.tools(knId));
 
-// Layer 2：实例查询 — 根据 Layer 1 找到的对象类查询具体数据
+// Schema 探索
+const schema = await bkn.context.searchSchema(knId, '客户订单关系', { scope: ['object', 'relation'] });
+const skeleton = await bkn.context.knDetail(knId, 'summary');
+const ots = await bkn.context.objectTypes(knId, ['ot_customer']);
+
+// 实例查询
 const instances = await bkn.context.queryObjectInstance(knId, {
-  ot_id: 'ot_customer',
+  object_type_id: 'ot_customer',
+  conditions: [{ field: 'status', operation: '==', value: 'active' }],
   limit: 20,
 });
-console.log('实例:', instances);
 
-// 跨知识网络的语义搜索
-const results = await bkn.kn.search(knId, '高价值客户');
-console.log('搜索命中:', results);
-
-// 子图遍历 — 沿关系类展开（按实例）
+// 子图遍历
 const subgraph = await bkn.context.queryInstanceSubgraph(knId, {
-  ot_id: 'ot_customer',
-  instance_id: 'cust-5521',
-  depth: 2,
+  object_type_id: 'ot_customer',
+  instance_identities: [{ id: 'cust-5521' }],
+  relation_type_ids: ['rt_purchase'],
 });
-console.log('子图:', subgraph);
+
+// 逻辑属性与行动
+const logic = await bkn.context.logicProperties(knId, {
+  object_type_id: 'ot_customer',
+  instance_identities: [{ id: 'cust-5521' }],
+  logic_property_names: ['lifetime_value'],
+});
+const actions = await bkn.context.actionInfo(knId, {
+  object_type_id: 'ot_customer',
+  instance_identities: [{ id: 'cust-5521' }],
+});
+
+// 技能召回
+const skills = await bkn.context.findSkills(knId, 'ot_customer', 5);
+
+// 目录之外的工具：按名调用
+const sql = await bkn.context.toolCall(knId, 'run_sql', { sql: 'SELECT 1' });
 ```
 
 ---
 
 ### curl
 
+REST 面的路径是 `/api/agent-retrieval/v1/kn/<工具名>`，与 MCP 工具同名；健康检查在 `/health` 下，不带 `/api` 前缀。
+
 ```bash
-# 健康检查
-curl -sk "https://<访问地址>/api/agent-retrieval/v1/health" \
-  -H "Authorization: Bearer $(openbkn token)"
+# 健康检查（无需鉴权）
+curl -sk "https://<访问地址>/health/ready"
+curl -sk "https://<访问地址>/health/alive"
 
 # Schema 搜索
-curl -sk -X POST "https://<访问地址>/api/agent-retrieval/v1/kn-search" \
-  -H "Authorization: Bearer $(openbkn token)" \
+curl -sk -X POST "https://<访问地址>/api/agent-retrieval/v1/kn/search_schema" \
+  -H "Authorization: Bearer $(openbkn auth token)" \
   -H "Content-Type: application/json" \
-  -d '{
-    "kn_id": "kn_abc123",
-    "query": "客户订单关系",
-    "only_schema": true,
-    "limit": 10
-  }'
+  -d '{"kn_id":"kn_abc123","query":"客户订单关系"}'
 
 # 查询对象实例
-curl -sk -X POST "https://<访问地址>/api/agent-retrieval/v1/query-object-instance" \
-  -H "Authorization: Bearer $(openbkn token)" \
+curl -sk -X POST "https://<访问地址>/api/agent-retrieval/v1/kn/query_object_instance" \
+  -H "Authorization: Bearer $(openbkn auth token)" \
   -H "Content-Type: application/json" \
   -d '{
     "kn_id": "kn_abc123",
     "object_type_id": "ot_customer",
-    "conditions": [
-      {"field": "status", "op": "==", "value": "active"}
-    ],
+    "conditions": [{"field":"status","operation":"==","value":"active"}],
     "limit": 20
   }'
 
 # 查询实例子图
-curl -sk -X POST "https://<访问地址>/api/agent-retrieval/v1/query-instance-subgraph" \
-  -H "Authorization: Bearer $(openbkn token)" \
-  -H "Content-Type: application/json" \
-  -d '{
-    "kn_id": "kn_abc123",
-    "instance_id": "cust_001",
-    "depth": 2,
-    "relation_types": ["rt_purchase"],
-    "limit": 50
-  }'
-
-# 获取逻辑属性
-curl -sk -X POST "https://<访问地址>/api/agent-retrieval/v1/get-logic-properties" \
-  -H "Authorization: Bearer $(openbkn token)" \
+curl -sk -X POST "https://<访问地址>/api/agent-retrieval/v1/kn/query_instance_subgraph" \
+  -H "Authorization: Bearer $(openbkn auth token)" \
   -H "Content-Type: application/json" \
   -d '{
     "kn_id": "kn_abc123",
     "object_type_id": "ot_customer",
-    "instance_id": "cust_001",
-    "properties": ["lifetime_value", "risk_score"]
+    "instance_identities": [{"id":"cust_001"}],
+    "relation_type_ids": ["rt_purchase"]
   }'
 
-# 获取动作信息
-curl -sk -X POST "https://<访问地址>/api/agent-retrieval/v1/get-action-info" \
-  -H "Authorization: Bearer $(openbkn token)" \
+# 逻辑属性（注意路径是 logic-property-resolver，不与工具同名）
+curl -sk -X POST "https://<访问地址>/api/agent-retrieval/v1/kn/logic-property-resolver" \
+  -H "Authorization: Bearer $(openbkn auth token)" \
   -H "Content-Type: application/json" \
   -d '{
     "kn_id": "kn_abc123",
     "object_type_id": "ot_customer",
-    "instance_id": "cust_001"
+    "instance_identities": [{"id":"cust_001"}],
+    "logic_property_names": ["lifetime_value"]
+  }'
+
+# 行动信息
+curl -sk -X POST "https://<访问地址>/api/agent-retrieval/v1/kn/get_action_info" \
+  -H "Authorization: Bearer $(openbkn auth token)" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "kn_id": "kn_abc123",
+    "object_type_id": "ot_customer",
+    "instance_identities": [{"id":"cust_001"}]
   }'
 ```
+
+> **注意**：部分版本的 context-loader 会对 `/kn/*` 的 POST 请求校验会话上下文，请求体缺少
+> `bkn_context`（`conversation_id` / `interaction_id` / `operation_key`）时返回
+> `400 conversation_required`。该校验在 v0.1.2 发布版中不存在。走 MCP 通道时由服务端按连接
+> 自动归并，不需要调用方自己造。
+
+---
+
+## 已下线命令对照
+
+| 已下线 | 现行做法 |
+| --- | --- |
+| `openbkn context-loader config set/use/list/show/remove` | 取消，`kn-id` 改为每条命令的位置参数 |
+| `openbkn context-loader tools` | `openbkn context tools <kn-id>`（部署级目录用 `openbkn context info`） |
+| `openbkn context-loader kn-search` | `openbkn context search-schema <kn-id> <query>` |
+| `openbkn context-loader kn-schema-search` | 同上，用 `--scope` 限定范围 |
+| `openbkn context-loader query-object-instance '<json>'` | `openbkn context query-object-instance <kn-id> --args '<json>'` |
+| `openbkn context-loader query-instance-subgraph '<json>'` | `openbkn context query-instance-subgraph <kn-id> --args '<json>'` |
+| `openbkn context-loader get-logic-properties '<json>'` | `openbkn context get-logic-properties <kn-id> --args '<json>'` |
+| `openbkn context-loader get-action-info '<json>'` | `openbkn context get-action-info <kn-id> --args '<json>'` |


### PR DESCRIPTION
从 #652 拆出（上一版一个 PR 十个文件、评审跑到轮次上限失败）。本 PR 只含 Context Loader 手册中英两份，#652 保留其余四篇（bkn / quick-start / cookbook / install），两者文件不重叠。

## 背景

`openbkn context-loader` 整组已改名为 `openbkn context`，子命令从 8 条扩到 19 条，`config set/use/list/show/remove` 取消、`kn-id` 改为每条命令的位置参数、取数据的几条统一用 `--args '<json>'`。原手册整篇建立在旧命令上。

## 三处硬错误（不只是改名）

1. **MCP 工具表 6 条里有 2 条不存在** —— `kn_search` / `kn_schema_search` 都不在工具目录里，`get_logic_properties` 实际叫 `get_logic_properties_values`。按 `adp/context-loader/agent-retrieval/server/driveradapters/mcp/schemas/tools_meta.json` 的实际 18 条重写。
2. **curl 路径全错** —— 原文写 `/api/agent-retrieval/v1/kn-search`、`.../knowledge-networks/{id}/search` 等，实际是 `/api/agent-retrieval/v1/kn/<工具名>`（见 `rest_public_handler.go:70-89`）；逻辑属性那条是例外，路径为 `logic-property-resolver`，与工具名不同。
3. **健康检查路径错** —— 不在 `/api/agent-retrieval/v1/health`，而是 `/health/ready` 与 `/health/alive`（`app.go:135-136` 单独注册 `/health` 组），且不需要鉴权。

## 改动

- CLI 段整体改写，补上目录内省（`info` / `tools` / `resources` / `templates` / `prompts`）、渐进式 Schema（`kn-detail` / `object-types` / `relation-types`）、`find-skills`，以及可调任意工具的 `tool-call` / `call-method`。
- TypeScript 段按 SDK 实际导出的 `bkn.context.*` 十八个方法重写。
- 补 `bkn_context` 会话校验说明：部分版本对 `/kn/*` 返回 `400 conversation_required`，v0.1.2 发布版没有该校验，MCP 通道由服务端按连接自动归并。
- 两份手册各加「已下线命令对照」表。

## 验证

文中每条 `openbkn X Y` 命令都用脚本对 `openbkn <group> --help` 的实际子命令表做过存在性校验，除对照表里的历史命令外无残留；工具清单、HTTP 路由、健康检查路径均对照仓内源码核实。VM 上抽查了 `openbkn context info` / `tools`。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
