### PR TITLE
fix(deploy): avoid unnecessary pulls for install-status images

### DIFF
--- a/deploy/conf/install-status/endpoint.yaml
+++ b/deploy/conf/install-status/endpoint.yaml
@@ -85,6 +85,7 @@ spec:
           # kubectl image WITH a shell — distroless kubectl images (e.g.
           # rancher/kubectl) have no /bin/sh and won't start the loop.
           image: __KUBECTL_IMAGE__
+          imagePullPolicy: IfNotPresent
           command: ["/bin/sh", "-c"]
           args:
             - |
@@ -124,6 +125,7 @@ spec:
               readOnly: true
         - name: nginx
           image: __NGINX_IMAGE__
+          imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 80
           readinessProbe:


### PR DESCRIPTION
PR Title: fix(deploy): avoid unnecessary pulls for install-status images

# Pull Request

## What Changed

- [x] 将 install-status refresher 的 `imagePullPolicy` 从 Kubernetes 默认的 `Always` 显式设置为 `IfNotPresent`。
- [x] 将 install-status nginx 容器同步设置为 `IfNotPresent`。
- [ ] Feature/module 1 — N/A
- [ ] Docs/doc 1 — N/A

---

## Why

- Related Issue: N/A
- Related Feature: N/A
- Background: 离线环境中的 kubectl sidecar 使用 `:latest` 标签。Kubernetes 对 `:latest` 默认采用 `Always`，会在每次创建或重启 Pod 时尝试访问 registry，即使节点已经存在镜像，导致离线环境出现不必要的拉取失败。

---

## How

- Key implementation points:
  - 在 `deploy/conf/install-status/endpoint.yaml` 的 `refresher` 容器中加入：
    `imagePullPolicy: IfNotPresent`
  - 在 nginx 容器中加入相同配置，保持 install-status 两个容器的拉取策略一致。
  - 当节点已有镜像时直接使用本地缓存；镜像不存在时仍允许 Kubernetes 拉取。
- Breaking changes (API, config, database, etc.): None.

---

## Testing

- [x] Unit tests passed locally
- [ ] Integration tests passed locally — N/A; no Kubernetes deployment was performed.
- [ ] Verified in test environment — Not run.

Test notes:

    git diff --check

    python3 - <<'PY'
    from pathlib import Path

    text = Path("deploy/conf/install-status/endpoint.yaml").read_text()
    assert text.count("imagePullPolicy: IfNotPresent") == 2
    assert "image: __KUBECTL_IMAGE__\n          imagePullPolicy: IfNotPresent" in text
    assert "image: __NGINX_IMAGE__\n          imagePullPolicy: IfNotPresent" in text
    print("install-status image pull policy check: ok")
    PY

---

## Risk & Rollback

- Potential risks:
  - 如果镜像 tag 内容发生变化但节点已有旧镜像，`IfNotPresent` 不会自动重新拉取最新内容。
  - 更新镜像时需要手动同步、删除旧镜像或使用新 tag。
- Rollback plan:
  - Revert this PR，移除两个容器的 `imagePullPolicy: IfNotPresent` 配置。
  - 不涉及数据库、Helm values 或持久化数据。

---

## Additional Notes

- 修改文件：
  - `deploy/conf/install-status/endpoint.yaml`
- 该修改只影响 install-status Deployment，不影响 OpenBKN 主服务或其他 Helm release。
- 已有集群需要重新发布 install-status endpoint 才能应用：

    ./deploy.sh --offline=<offline-registry> openbkn publish-status