### PR TITLE
feat(context-loader): #597 OT-first 指标路径——对象类带出指标 + query_metric 取数

### DIFF
--- a/adp/bkn/bkn-backend/server/drivenadapters/metric/metric_access.go
+++ b/adp/bkn/bkn-backend/server/drivenadapters/metric/metric_access.go
@@ -389,8 +389,10 @@ func processMetricQueryCondition(query interfaces.MetricsListQueryParams, subBui
 	if query.ScopeType != "" {
 		subBuilder = subBuilder.Where(sq.Eq{"f_scope_type": query.ScopeType})
 	}
-	// 统计主体id
-	if query.ScopeRef != "" {
+	// 统计主体id：多值走 IN（OT-first 场景一次枚举多个对象类的指标），单值保持等值
+	if len(query.ScopeRefs) > 0 {
+		subBuilder = subBuilder.Where(sq.Eq{"f_scope_ref": query.ScopeRefs})
+	} else if query.ScopeRef != "" {
 		subBuilder = subBuilder.Where(sq.Eq{"f_scope_ref": query.ScopeRef})
 	}
 	if query.Tag != "" {

--- a/adp/bkn/bkn-backend/server/drivenadapters/metric/metric_access.go
+++ b/adp/bkn/bkn-backend/server/drivenadapters/metric/metric_access.go
@@ -413,7 +413,9 @@ func (ma *metricAccess) ListMetrics(ctx context.Context, query interfaces.Metric
 		if dir == "" {
 			dir = interfaces.DESC_DIRECTION
 		}
-		builder = builder.OrderBy(fmt.Sprintf("%s %s", sortCol, dir))
+		// f_id 兜底：默认按 f_update_time 排序，同批导入的指标时间戳完全相同，
+		// 没有 tiebreaker 时跨页边界的行序不保证稳定（同一行可能翻两次或被跳过）。
+		builder = builder.OrderBy(fmt.Sprintf("%s %s", sortCol, dir), "f_id ASC")
 	}
 
 	sqlStr, vals, err := builder.ToSql()

--- a/adp/bkn/bkn-backend/server/drivenadapters/metric/metric_access_test.go
+++ b/adp/bkn/bkn-backend/server/drivenadapters/metric/metric_access_test.go
@@ -12,6 +12,7 @@ import (
 	"testing"
 
 	"github.com/DATA-DOG/go-sqlmock"
+	sq "github.com/Masterminds/squirrel"
 	. "github.com/smartystreets/goconvey/convey"
 
 	"bkn-backend/common"
@@ -349,5 +350,41 @@ func TestMetricAccess_GetMetricByID_notFound(t *testing.T) {
 		So(err, ShouldEqual, sql.ErrNoRows)
 		So(def, ShouldBeNil)
 		So(mock.ExpectationsWereMet(), ShouldBeNil)
+	})
+}
+
+func TestProcessMetricQueryCondition_ScopeRefs(t *testing.T) {
+	Convey("scope_ref filtering", t, func() {
+		build := func(query interfaces.MetricsListQueryParams) (string, []any) {
+			sqlStr, vals, err := processMetricQueryCondition(query,
+				sq.Select("f_id").From(METRIC_TABLE_NAME)).ToSql()
+			So(err, ShouldBeNil)
+			return sqlStr, vals
+		}
+
+		Convey("multiple scope refs become an IN filter", func() {
+			sqlStr, vals := build(interfaces.MetricsListQueryParams{
+				KNID:      "kn1",
+				ScopeType: interfaces.ScopeTypeObjectType,
+				ScopeRefs: []string{"ot1", "ot2"},
+			})
+			So(sqlStr, ShouldContainSubstring, "f_scope_ref IN (?,?)")
+			So(vals, ShouldContain, "ot1")
+			So(vals, ShouldContain, "ot2")
+		})
+
+		Convey("single scope ref stays an equality filter", func() {
+			sqlStr, vals := build(interfaces.MetricsListQueryParams{
+				KNID:     "kn1",
+				ScopeRef: "ot1",
+			})
+			So(sqlStr, ShouldContainSubstring, "f_scope_ref = ?")
+			So(vals, ShouldContain, "ot1")
+		})
+
+		Convey("no scope ref leaves the filter out", func() {
+			sqlStr, _ := build(interfaces.MetricsListQueryParams{KNID: "kn1"})
+			So(sqlStr, ShouldNotContainSubstring, "f_scope_ref")
+		})
 	})
 }

--- a/adp/bkn/bkn-backend/server/driveradapters/metric_handler.go
+++ b/adp/bkn/bkn-backend/server/driveradapters/metric_handler.go
@@ -268,6 +268,29 @@ func (r *restHandler) ValidateMetrics(c *gin.Context, vis hydra.Visitor) {
 	rest.ReplyOK(c, http.StatusOK, nil)
 }
 
+// splitScopeRefs parses the scope_ref query parameter: one id, or several
+// separated by commas. Blanks and duplicates are dropped so the resulting IN
+// filter carries only what the caller actually asked for.
+func splitScopeRefs(raw string) []string {
+	if strings.TrimSpace(raw) == "" {
+		return nil
+	}
+	refs := make([]string, 0, 4)
+	seen := make(map[string]struct{}, 4)
+	for _, part := range strings.Split(raw, ",") {
+		ref := strings.TrimSpace(part)
+		if ref == "" {
+			continue
+		}
+		if _, dup := seen[ref]; dup {
+			continue
+		}
+		seen[ref] = struct{}{}
+		refs = append(refs, ref)
+	}
+	return refs
+}
+
 func (r *restHandler) ListMetricsByIn(c *gin.Context) {
 	r.ListMetrics(c, visitor.GenerateVisitor(c))
 }
@@ -308,9 +331,15 @@ func (r *restHandler) ListMetrics(c *gin.Context, vis hydra.Visitor) {
 
 	namePattern := c.Query("name_pattern")
 	tag := strings.Trim(c.Query("tag"), " ")
-	scopeRef := strings.TrimSpace(c.Query("scope_ref"))
+	// scope_ref accepts one id or a comma-separated list, so an OT-first caller can
+	// enumerate the metrics of several object types in one request.
+	scopeRefs := splitScopeRefs(c.Query("scope_ref"))
+	scopeRef := ""
+	if len(scopeRefs) == 1 {
+		scopeRef = scopeRefs[0]
+	}
 	scopeType := strings.TrimSpace(c.Query("scope_type"))
-	if scopeRef != "" && scopeType == "" {
+	if len(scopeRefs) > 0 && scopeType == "" {
 		scopeType = interfaces.ScopeTypeObjectType
 	}
 	offset := c.DefaultQuery("offset", interfaces.DEFAULT_OFFEST)
@@ -337,6 +366,7 @@ func (r *restHandler) ListMetrics(c *gin.Context, vis hydra.Visitor) {
 		Tag:         tag,
 		ScopeType:   scopeType,
 		ScopeRef:    scopeRef,
+		ScopeRefs:   scopeRefs,
 		Branch:      branch,
 		KNID:        knID,
 	}

--- a/adp/bkn/bkn-backend/server/driveradapters/metric_handler_scope_ref_test.go
+++ b/adp/bkn/bkn-backend/server/driveradapters/metric_handler_scope_ref_test.go
@@ -1,0 +1,30 @@
+// Copyright openbkn.ai
+//
+// Licensed under the Apache License, Version 2.0.
+// See the LICENSE file in the project root for details.
+
+package driveradapters
+
+import (
+	"testing"
+
+	. "github.com/smartystreets/goconvey/convey"
+)
+
+func TestSplitScopeRefs(t *testing.T) {
+	Convey("splitScopeRefs parses the scope_ref query parameter", t, func() {
+		Convey("empty input yields no filter", func() {
+			So(splitScopeRefs(""), ShouldBeNil)
+			So(splitScopeRefs("   "), ShouldBeNil)
+			So(splitScopeRefs(" , , "), ShouldBeEmpty)
+		})
+
+		Convey("single id", func() {
+			So(splitScopeRefs(" ot1 "), ShouldResemble, []string{"ot1"})
+		})
+
+		Convey("comma separated ids are trimmed and de-duplicated", func() {
+			So(splitScopeRefs("ot1, ot2 ,ot1,,ot3"), ShouldResemble, []string{"ot1", "ot2", "ot3"})
+		})
+	})
+}

--- a/adp/bkn/bkn-backend/server/interfaces/metric.go
+++ b/adp/bkn/bkn-backend/server/interfaces/metric.go
@@ -284,6 +284,11 @@ type ReqMetrics struct {
 }
 
 // MetricsListQueryParams lists metrics under a knowledge network (GET .../metrics query params).
+//
+// ScopeRefs holds the comma-separated scope_ref values of the query and filters
+// with IN; it is what an OT-first caller uses to enumerate the metrics of several
+// object types in one round trip. ScopeRef stays for single-value callers and is
+// ignored once ScopeRefs is set.
 type MetricsListQueryParams struct {
 	PaginationQueryParameters
 	NamePattern string
@@ -292,6 +297,7 @@ type MetricsListQueryParams struct {
 	KNID        string
 	ScopeType   string
 	ScopeRef    string
+	ScopeRefs   []string
 }
 
 // MetricsList is the list response for GET .../metrics (bkn-metrics.yaml ListMetrics: entries, total_count).

--- a/adp/context-loader/agent-retrieval/server/bootstrap/tool_dependencies/context_loader_toolset.adp
+++ b/adp/context-loader/agent-retrieval/server/bootstrap/tool_dependencies/context_loader_toolset.adp
@@ -317,6 +317,223 @@
       "dependencies_url": ""
      },
      {
+      "tool_id": "f80dc18e-955e-43af-b0f7-2000287d6848",
+      "name": "query_metric",
+      "description": "按已建模指标的口径取数（OT-first 第 3 步）。先 get_object_types 从 related_metrics 选定 metric_id，再调本工具；口径写在 MetricDefinition 里，不要用 run_sql 重写。实例级且已绑逻辑属性的走 get_logic_properties_values。",
+      "status": "enabled",
+      "metadata_type": "openapi",
+      "metadata": {
+       "version": "3c5c43e5-a1d7-483b-97b5-8f993cd1815a",
+       "summary": "query_metric",
+       "description": "按已建模指标的口径取数（OT-first 第 3 步）。先 get_object_types 从 related_metrics 选定 metric_id，再调本工具；口径写在 MetricDefinition 里，不要用 run_sql 重写。实例级且已绑逻辑属性的走 get_logic_properties_values。",
+       "server_url": "http://agent-retrieval:30779",
+       "path": "/api/agent-retrieval/in/v1/kn/query_metric",
+       "method": "POST",
+       "create_time": 1776920840668983300,
+       "update_time": 1776920840668983300,
+       "create_user": "ede150ba-06f4-11f1-85aa-3a34099a4c4b",
+       "update_user": "ede150ba-06f4-11f1-85aa-3a34099a4c4b",
+       "api_spec": {
+        "parameters": [
+         {
+          "name": "x-account-id",
+          "in": "header",
+          "description": "账户ID，用于内部服务调用时传递账户信息",
+          "required": false,
+          "schema": {
+           "type": "string"
+          }
+         },
+         {
+          "name": "x-account-type",
+          "in": "header",
+          "description": "账户类型：user(用户), app(应用), anonymous(匿名)",
+          "required": false,
+          "schema": {
+           "enum": [
+            "user",
+            "app",
+            "anonymous"
+           ],
+           "type": "string"
+          }
+         }
+        ],
+        "request_body": {
+         "description": "",
+         "content": {
+          "application/json": {
+           "schema": {
+            "type": "object",
+            "properties": {
+             "response_format": {
+              "type": "string",
+              "enum": [
+               "json",
+               "toon"
+              ],
+              "default": "toon",
+              "description": "文本格式：json 或 toon，默认 toon"
+             },
+             "kn_id": {
+              "type": "string",
+              "description": "知识网络 ID。也可改用 X-Kn-ID 请求头传入。"
+             },
+             "metric_id": {
+              "type": "string",
+              "description": "指标 ID，取自 get_object_types 的 related_metrics[].id"
+             },
+             "time": {
+              "type": "object",
+              "description": "时间窗；指标无时间维度时可省略。instant=true 取单点且不得传 step，instant=false 取序列且必须传 step。",
+              "properties": {
+               "instant": {
+                "type": "boolean"
+               },
+               "start": {
+                "type": "integer",
+                "description": "起始时间，unix 秒"
+               },
+               "end": {
+                "type": "integer",
+                "description": "结束时间，unix 秒"
+               },
+               "step": {
+                "type": "string",
+                "enum": [
+                 "day",
+                 "week",
+                 "month",
+                 "quarter",
+                 "year"
+                ]
+               }
+              }
+             },
+             "condition": {
+              "type": "object",
+              "additionalProperties": true,
+              "description": "过滤条件，结构同 query_object_instance 的 condition"
+             },
+             "analysis_dimensions": {
+              "type": "array",
+              "items": {
+               "type": "string"
+              },
+              "description": "分析维度，取值来自 related_metrics[].analysis_dimensions"
+             },
+             "order_by": {
+              "type": "array",
+              "items": {
+               "type": "object",
+               "properties": {
+                "property": {
+                 "type": "string"
+                },
+                "direction": {
+                 "type": "string",
+                 "enum": [
+                  "asc",
+                  "desc"
+                 ]
+                }
+               }
+              }
+             },
+             "having": {
+              "type": "object",
+              "properties": {
+               "field": {
+                "type": "string"
+               },
+               "operation": {
+                "type": "string"
+               },
+               "value": {}
+              }
+             },
+             "limit": {
+              "type": "integer",
+              "description": "返回条数上限"
+             },
+             "fill_null": {
+              "type": "boolean",
+              "description": "区间查询时无数据的步长点是否补空，默认 false"
+             }
+            },
+            "required": [
+             "kn_id",
+             "metric_id"
+            ]
+           }
+          }
+         },
+         "required": true
+        },
+        "responses": [
+         {
+          "status_code": "200",
+          "description": "ok",
+          "content": {
+           "application/json": {
+            "schema": {
+             "type": "object",
+             "properties": {
+              "kn_id": {
+               "type": "string",
+               "description": "知识网络 ID"
+              },
+              "metric_id": {
+               "type": "string",
+               "description": "指标 ID"
+              },
+              "datas": {
+               "type": "array",
+               "description": "按 labels 分组的结果序列",
+               "items": {
+                "type": "object",
+                "additionalProperties": true
+               }
+              },
+              "overall_ms": {
+               "type": "integer",
+               "description": "耗时（毫秒）"
+              }
+             }
+            }
+           }
+          }
+         }
+        ],
+        "components": null,
+        "callbacks": null,
+        "security": null,
+        "tags": null
+       }
+      },
+      "use_rule": "",
+      "global_parameters": {
+       "name": "",
+       "description": "",
+       "required": false,
+       "in": "",
+       "type": "",
+       "value": null
+      },
+      "create_time": 1776920840668983300,
+      "update_time": 1776920840668983300,
+      "create_user": "ede150ba-06f4-11f1-85aa-3a34099a4c4b",
+      "update_user": "ede150ba-06f4-11f1-85aa-3a34099a4c4b",
+      "extend_info": null,
+      "resource_object": "tool",
+      "source_id": "3c5c43e5-a1d7-483b-97b5-8f993cd1815a",
+      "source_type": "openapi",
+      "script_type": "",
+      "code": "",
+      "dependencies": [],
+      "dependencies_url": ""
+     },
+     {
       "tool_id": "52b35175-cee3-41ea-91c0-1d70e8371f9c",
       "name": "search_schema",
       "description": "统一的 Schema 探索入口。根据 query 返回相关 object_types、relation_types、action_types。",
@@ -2800,13 +3017,13 @@
      {
       "tool_id": "007bb878-29ee-40ed-9d55-bbea8d9f55eb",
       "name": "get_object_types",
-      "description": "按 id 批量取对象类的完整定义（data_properties 含 mapped_field/condition_operations，logic_properties 含 data_source/parameters）。渐进式下钻：先 get_kn_detail(summary) 拿对象 id，再用本工具展开。ids 支持多个，未匹配的在 missing 返回。",
+      "description": "按 id 批量取对象类的完整定义（data_properties 含 mapped_field/condition_operations，logic_properties 含 data_source/parameters），并返回该对象类 scope 下的 related_metrics（含未绑逻辑属性的指标）。渐进式下钻：先 get_kn_detail(summary) 拿对象 id，再用本工具展开。ids 支持多个，未匹配的在 missing 返回。",
       "status": "enabled",
       "metadata_type": "openapi",
       "metadata": {
        "version": "192b5f4e-5d29-4ecb-9c45-77e38852978b",
        "summary": "get_object_types",
-       "description": "按 id 批量取对象类的完整定义（data_properties 含 mapped_field/condition_operations，logic_properties 含 data_source/parameters）。渐进式下钻：先 get_kn_detail(summary) 拿对象 id，再用本工具展开。ids 支持多个，未匹配的在 missing 返回。",
+       "description": "按 id 批量取对象类的完整定义（data_properties 含 mapped_field/condition_operations，logic_properties 含 data_source/parameters），并返回该对象类 scope 下的 related_metrics（含未绑逻辑属性的指标）。渐进式下钻：先 get_kn_detail(summary) 拿对象 id，再用本工具展开。ids 支持多个，未匹配的在 missing 返回。",
        "server_url": "http://agent-retrieval:30779",
        "path": "/api/agent-retrieval/in/v1/kn/get_object_types",
        "method": "POST",
@@ -2896,7 +3113,7 @@
                 "type": "object",
                 "additionalProperties": true
                },
-               "description": "对象类完整定义（含 data_properties / logic_properties 的映射细节）"
+               "description": "对象类完整定义（含 data_properties / logic_properties 的映射细节），related_metrics 为该对象类下可用指标（id/name/comment/unit/metric_type/analysis_dimensions/time_dimension）"
               },
               "missing": {
                "type": "array",

--- a/adp/context-loader/agent-retrieval/server/bootstrap/tool_dependencies/context_loader_toolset.adp
+++ b/adp/context-loader/agent-retrieval/server/bootstrap/tool_dependencies/context_loader_toolset.adp
@@ -385,7 +385,7 @@
              },
              "time": {
               "type": "object",
-              "description": "时间窗；指标无时间维度时可省略。instant=true 取单点且不得传 step，instant=false 取序列且必须传 step。",
+              "description": "时间窗；指标无时间维度时可省略。省略 instant 等同于序列查询（必须传 step）；instant=true 取单点。start 与 end 要么都传要么都不传。",
               "properties": {
                "instant": {
                 "type": "boolean"
@@ -406,7 +406,8 @@
                  "month",
                  "quarter",
                  "year"
-                ]
+                ],
+                "description": "序列步长（大小写不敏感），序列查询必传"
                }
               }
              },
@@ -458,7 +459,7 @@
              },
              "fill_null": {
               "type": "boolean",
-              "description": "区间查询时无数据的步长点是否补空，默认 false"
+              "description": "区间查询时无数据的步长点是否补空，默认 false；仅序列查询有效且需同时给 start/end"
              }
             },
             "required": [

--- a/adp/context-loader/agent-retrieval/server/drivenadapters/bkn_backend.go
+++ b/adp/context-loader/agent-retrieval/server/drivenadapters/bkn_backend.go
@@ -549,31 +549,37 @@ func (b *bknBackendAccess) GetActionTypeDetail(ctx context.Context, knID string,
 	return actionTypes, nil
 }
 
-// metricsListResp is the bkn-backend GET .../metrics response.
-type metricsListResp struct {
-	Entries []struct {
-		ID            string `json:"id"`
-		Name          string `json:"name"`
-		Comment       string `json:"comment"`
-		Unit          string `json:"unit"`
-		UnitType      string `json:"unit_type"`
-		MetricType    string `json:"metric_type"`
-		ScopeType     string `json:"scope_type"`
-		ScopeRef      string `json:"scope_ref"`
-		TimeDimension *struct {
-			Property string `json:"property"`
-		} `json:"time_dimension"`
-		AnalysisDimensions []struct {
-			Name string `json:"name"`
-		} `json:"analysis_dimensions"`
-	} `json:"entries"`
-	TotalCount int64 `json:"total_count"`
+// metricsListEntry is one entry of the bkn-backend GET .../metrics response.
+type metricsListEntry struct {
+	ID            string `json:"id"`
+	Name          string `json:"name"`
+	Comment       string `json:"comment"`
+	Unit          string `json:"unit"`
+	UnitType      string `json:"unit_type"`
+	MetricType    string `json:"metric_type"`
+	ScopeType     string `json:"scope_type"`
+	ScopeRef      string `json:"scope_ref"`
+	TimeDimension *struct {
+		Property string `json:"property"`
+	} `json:"time_dimension"`
+	AnalysisDimensions []struct {
+		Name string `json:"name"`
+	} `json:"analysis_dimensions"`
 }
 
-// maxScopedMetrics caps how many scoped metrics one get_object_types answer carries.
-// It matches bkn-backend's own MAX_LIMIT, and exists so a knowledge network with a
-// runaway metric count cannot quietly blow up a tool result.
-const maxScopedMetrics = 1000
+// metricsListResp is the bkn-backend GET .../metrics response.
+type metricsListResp struct {
+	Entries    []metricsListEntry `json:"entries"`
+	TotalCount int64              `json:"total_count"`
+}
+
+const (
+	// metricsPageSize is one request's worth of metrics; bkn-backend's own MAX_LIMIT.
+	metricsPageSize = 1000
+	// maxScopedMetrics bounds the whole paged walk. It is a runaway guard for a
+	// knowledge network with an absurd metric count, not the expected ceiling.
+	maxScopedMetrics = 10000
+)
 
 // ListMetricsByObjectTypes 枚举挂在给定对象类下的指标（scope_type=object_type）。
 // 走 bkn-backend 指标注册表（GET .../metrics），不是概念索引语义召回：对象类要"看得见"
@@ -600,48 +606,70 @@ func (b *bknBackendAccess) ListMetricsByObjectTypes(ctx context.Context, knID st
 	header := common.GetHeaderForChildOperation(ctx, "bkn.metric.list", 1)
 	header[rest.ContentTypeKey] = rest.ContentTypeJSON
 
-	queryValues := url.Values{}
-	queryValues.Set("scope_type", "object_type")
-	queryValues.Set("scope_ref", strings.Join(scopeRefs, ","))
-	queryValues.Set("limit", strconv.Itoa(maxScopedMetrics))
+	// Page rather than cap. A truncated answer is indistinguishable from "this
+	// object type has no metrics", and that is precisely the state that sends an
+	// agent back to run_sql — the behaviour this whole path exists to remove.
+	entries := make([]metricsListEntry, 0, metricsPageSize)
+	var total int64
+	for offset := 0; offset < maxScopedMetrics; offset += metricsPageSize {
+		queryValues := url.Values{}
+		queryValues.Set("scope_type", "object_type")
+		queryValues.Set("scope_ref", strings.Join(scopeRefs, ","))
+		queryValues.Set("limit", strconv.Itoa(metricsPageSize))
+		queryValues.Set("offset", strconv.Itoa(offset))
 
-	respCode, respBody, err := b.httpClient.GetNoUnmarshal(ctx, src, queryValues, header)
-	if err != nil {
-		b.logger.WithContext(ctx).Warnf("[BknBackendAccess] ListMetricsByObjectTypes request failed, err: %v", err)
-		return nil, infraErr.DefaultHTTPError(ctx, respCode,
-			fmt.Sprintf("[BknBackendAccess] ListMetricsByObjectTypes request failed, err: %v", err))
-	}
-
-	if (respCode < http.StatusOK) || (respCode >= http.StatusMultipleChoices) {
-		b.logger.WithContext(ctx).Warnf("[BknBackendAccess] ListMetricsByObjectTypes failed, [%s], code %d", src, respCode)
-
-		var baseError interfaces.KnBaseError
-		if err := sonic.Unmarshal(respBody, &baseError); err != nil {
+		respCode, respBody, err := b.httpClient.GetNoUnmarshal(ctx, src, queryValues, header)
+		if err != nil {
+			b.logger.WithContext(ctx).Warnf("[BknBackendAccess] ListMetricsByObjectTypes request failed, err: %v", err)
 			return nil, infraErr.DefaultHTTPError(ctx, respCode,
-				fmt.Sprintf("[BknBackendAccess] ListMetricsByObjectTypes failed, code %d", respCode))
+				fmt.Sprintf("[BknBackendAccess] ListMetricsByObjectTypes request failed, err: %v", err))
 		}
-		return nil, &infraErr.HTTPError{
-			HTTPCode:     respCode,
-			Code:         baseError.ErrorCode,
-			Description:  baseError.Description,
-			Solution:     baseError.Solution,
-			ErrorLink:    baseError.ErrorLink,
-			ErrorDetails: baseError.ErrorDetails,
+
+		if (respCode < http.StatusOK) || (respCode >= http.StatusMultipleChoices) {
+			b.logger.WithContext(ctx).Warnf("[BknBackendAccess] ListMetricsByObjectTypes failed, [%s], code %d", src, respCode)
+
+			var baseError interfaces.KnBaseError
+			if err := sonic.Unmarshal(respBody, &baseError); err != nil {
+				return nil, infraErr.DefaultHTTPError(ctx, respCode,
+					fmt.Sprintf("[BknBackendAccess] ListMetricsByObjectTypes failed, code %d", respCode))
+			}
+			return nil, &infraErr.HTTPError{
+				HTTPCode:     respCode,
+				Code:         baseError.ErrorCode,
+				Description:  baseError.Description,
+				Solution:     baseError.Solution,
+				ErrorLink:    baseError.ErrorLink,
+				ErrorDetails: baseError.ErrorDetails,
+			}
+		}
+
+		if len(respBody) == 0 {
+			break
+		}
+
+		parsed := &metricsListResp{}
+		if err := sonic.Unmarshal(respBody, parsed); err != nil {
+			b.logger.WithContext(ctx).Errorf("[BknBackendAccess] ListMetricsByObjectTypes unmarshal failed: %v", err)
+			return nil, err
+		}
+		total = parsed.TotalCount
+		entries = append(entries, parsed.Entries...)
+		if len(parsed.Entries) < metricsPageSize || int64(len(entries)) >= parsed.TotalCount {
+			break
 		}
 	}
 
-	if len(respBody) == 0 {
-		return nil, nil
+	// The hard cap is a runaway guard, not a page size. If it ever bites, the
+	// answer is incomplete and has to say so out loud.
+	if total > int64(len(entries)) {
+		b.logger.WithContext(ctx).Warnf(
+			"[BknBackendAccess] ListMetricsByObjectTypes stopped at %d of %d metrics for kn=%s (%d object types); "+
+				"object types beyond the cap are advertised without their metrics",
+			len(entries), total, knID, len(scopeRefs))
 	}
 
-	parsed := &metricsListResp{}
-	if err := sonic.Unmarshal(respBody, parsed); err != nil {
-		b.logger.WithContext(ctx).Errorf("[BknBackendAccess] ListMetricsByObjectTypes unmarshal failed: %v", err)
-		return nil, err
-	}
-
-	metrics := make([]*interfaces.RelatedMetric, 0, len(parsed.Entries))
-	for _, e := range parsed.Entries {
+	metrics := make([]*interfaces.RelatedMetric, 0, len(entries))
+	for _, e := range entries {
 		// bkn-backend applies the scope filter, but an older backend that ignores the
 		// query parameter would otherwise hand every metric of the network to every
 		// object type. Cheap to re-check, and wrong-by-default if we do not.

--- a/adp/context-loader/agent-retrieval/server/drivenadapters/bkn_backend.go
+++ b/adp/context-loader/agent-retrieval/server/drivenadapters/bkn_backend.go
@@ -576,39 +576,22 @@ type metricsListResp struct {
 const (
 	// metricsPageSize is one request's worth of metrics; bkn-backend's own MAX_LIMIT.
 	metricsPageSize = 1000
-	// maxScopedMetrics bounds the whole paged walk. It is a runaway guard for a
-	// knowledge network with an absurd metric count, not the expected ceiling.
+	// maxScopedMetrics bounds the paged walk of one batch. It is a runaway guard for
+	// a knowledge network with an absurd metric count, not the expected ceiling.
 	maxScopedMetrics = 10000
+	// metricsScopeBatch caps how many object-type ids go into one scope_ref value.
+	// get_kn_detail asks about every object type of a network, and those ids are
+	// comma-joined into the query string — a few hundred of them make a request
+	// line large enough to hit a proxy's header buffer (commonly 8 KB).
+	metricsScopeBatch = 100
 )
 
-// ListMetricsByObjectTypes 枚举挂在给定对象类下的指标（scope_type=object_type）。
-// 走 bkn-backend 指标注册表（GET .../metrics），不是概念索引语义召回：对象类要"看得见"
-// 自己的指标，必须是全量且与库一致的。
-func (b *bknBackendAccess) ListMetricsByObjectTypes(ctx context.Context, knID string, otIDs []string) ([]*interfaces.RelatedMetric, error) {
-	scopeRefs := make([]string, 0, len(otIDs))
-	seen := make(map[string]struct{}, len(otIDs))
-	for _, id := range otIDs {
-		id = strings.TrimSpace(id)
-		if id == "" {
-			continue
-		}
-		if _, dup := seen[id]; dup {
-			continue
-		}
-		seen[id] = struct{}{}
-		scopeRefs = append(scopeRefs, id)
-	}
-	if strings.TrimSpace(knID) == "" || len(scopeRefs) == 0 {
-		return nil, nil
-	}
-
-	src := fmt.Sprintf("%s/in/v1/knowledge-networks/%s/metrics", b.baseURL, knID)
-	header := common.GetHeaderForChildOperation(ctx, "bkn.metric.list", 1)
-	header[rest.ContentTypeKey] = rest.ContentTypeJSON
-
-	// Page rather than cap. A truncated answer is indistinguishable from "this
-	// object type has no metrics", and that is precisely the state that sends an
-	// agent back to run_sql — the behaviour this whole path exists to remove.
+// listMetricsPage 取一批对象类的指标，翻页取全。
+//
+// 分页而不是截断：截断后的答案与「这个对象类没有指标」在调用方眼里完全一样，
+// 而那正是把 Agent 推回 run_sql 的状态——本条链路存在的理由就是消灭它。
+func (b *bknBackendAccess) listMetricsPage(ctx context.Context, src string, header map[string]string,
+	scopeRefs []string, knID string) ([]metricsListEntry, error) {
 	entries := make([]metricsListEntry, 0, metricsPageSize)
 	var total int64
 	for offset := 0; offset < maxScopedMetrics; offset += metricsPageSize {
@@ -666,6 +649,50 @@ func (b *bknBackendAccess) ListMetricsByObjectTypes(ctx context.Context, knID st
 			"[BknBackendAccess] ListMetricsByObjectTypes stopped at %d of %d metrics for kn=%s (%d object types); "+
 				"object types beyond the cap are advertised without their metrics",
 			len(entries), total, knID, len(scopeRefs))
+	}
+	return entries, nil
+}
+
+// ListMetricsByObjectTypes 枚举挂在给定对象类下的指标（scope_type=object_type）。
+// 走 bkn-backend 指标注册表（GET .../metrics），不是概念索引语义召回：对象类要"看得见"
+// 自己的指标，必须是全量且与库一致的。
+func (b *bknBackendAccess) ListMetricsByObjectTypes(ctx context.Context, knID string, otIDs []string) ([]*interfaces.RelatedMetric, error) {
+	scopeRefs := make([]string, 0, len(otIDs))
+	seen := make(map[string]struct{}, len(otIDs))
+	for _, id := range otIDs {
+		id = strings.TrimSpace(id)
+		if id == "" {
+			continue
+		}
+		if _, dup := seen[id]; dup {
+			continue
+		}
+		seen[id] = struct{}{}
+		scopeRefs = append(scopeRefs, id)
+	}
+	if strings.TrimSpace(knID) == "" || len(scopeRefs) == 0 {
+		return nil, nil
+	}
+
+	// knID is escaped for the same reason metric_id is on the ontology-query side:
+	// the shared HTTP client folds any query string parsed out of the raw URL back
+	// over the caller's values (comm-go/rest generateURL), so an id carrying "?"
+	// would override the scope_type this call depends on.
+	src := fmt.Sprintf("%s/in/v1/knowledge-networks/%s/metrics", b.baseURL, url.PathEscape(knID))
+	header := common.GetHeaderForChildOperation(ctx, "bkn.metric.list", 1)
+	header[rest.ContentTypeKey] = rest.ContentTypeJSON
+
+	// Batch the ids rather than sending all of them at once: get_kn_detail asks for
+	// every object type of the network, and a few hundred ids comma-joined make a
+	// request line big enough to trip a proxy's header buffer.
+	entries := make([]metricsListEntry, 0, metricsPageSize)
+	for start := 0; start < len(scopeRefs); start += metricsScopeBatch {
+		end := min(start+metricsScopeBatch, len(scopeRefs))
+		batch, err := b.listMetricsPage(ctx, src, header, scopeRefs[start:end], knID)
+		if err != nil {
+			return nil, err
+		}
+		entries = append(entries, batch...)
 	}
 
 	metrics := make([]*interfaces.RelatedMetric, 0, len(entries))

--- a/adp/context-loader/agent-retrieval/server/drivenadapters/bkn_backend.go
+++ b/adp/context-loader/agent-retrieval/server/drivenadapters/bkn_backend.go
@@ -548,3 +548,124 @@ func (b *bknBackendAccess) GetActionTypeDetail(ctx context.Context, knID string,
 
 	return actionTypes, nil
 }
+
+// metricsListResp is the bkn-backend GET .../metrics response.
+type metricsListResp struct {
+	Entries []struct {
+		ID            string `json:"id"`
+		Name          string `json:"name"`
+		Comment       string `json:"comment"`
+		Unit          string `json:"unit"`
+		UnitType      string `json:"unit_type"`
+		MetricType    string `json:"metric_type"`
+		ScopeType     string `json:"scope_type"`
+		ScopeRef      string `json:"scope_ref"`
+		TimeDimension *struct {
+			Property string `json:"property"`
+		} `json:"time_dimension"`
+		AnalysisDimensions []struct {
+			Name string `json:"name"`
+		} `json:"analysis_dimensions"`
+	} `json:"entries"`
+	TotalCount int64 `json:"total_count"`
+}
+
+// maxScopedMetrics caps how many scoped metrics one get_object_types answer carries.
+// It matches bkn-backend's own MAX_LIMIT, and exists so a knowledge network with a
+// runaway metric count cannot quietly blow up a tool result.
+const maxScopedMetrics = 1000
+
+// ListMetricsByObjectTypes 枚举挂在给定对象类下的指标（scope_type=object_type）。
+// 走 bkn-backend 指标注册表（GET .../metrics），不是概念索引语义召回：对象类要"看得见"
+// 自己的指标，必须是全量且与库一致的。
+func (b *bknBackendAccess) ListMetricsByObjectTypes(ctx context.Context, knID string, otIDs []string) ([]*interfaces.RelatedMetric, error) {
+	scopeRefs := make([]string, 0, len(otIDs))
+	seen := make(map[string]struct{}, len(otIDs))
+	for _, id := range otIDs {
+		id = strings.TrimSpace(id)
+		if id == "" {
+			continue
+		}
+		if _, dup := seen[id]; dup {
+			continue
+		}
+		seen[id] = struct{}{}
+		scopeRefs = append(scopeRefs, id)
+	}
+	if strings.TrimSpace(knID) == "" || len(scopeRefs) == 0 {
+		return nil, nil
+	}
+
+	src := fmt.Sprintf("%s/in/v1/knowledge-networks/%s/metrics", b.baseURL, knID)
+	header := common.GetHeaderForChildOperation(ctx, "bkn.metric.list", 1)
+	header[rest.ContentTypeKey] = rest.ContentTypeJSON
+
+	queryValues := url.Values{}
+	queryValues.Set("scope_type", "object_type")
+	queryValues.Set("scope_ref", strings.Join(scopeRefs, ","))
+	queryValues.Set("limit", strconv.Itoa(maxScopedMetrics))
+
+	respCode, respBody, err := b.httpClient.GetNoUnmarshal(ctx, src, queryValues, header)
+	if err != nil {
+		b.logger.WithContext(ctx).Warnf("[BknBackendAccess] ListMetricsByObjectTypes request failed, err: %v", err)
+		return nil, infraErr.DefaultHTTPError(ctx, respCode,
+			fmt.Sprintf("[BknBackendAccess] ListMetricsByObjectTypes request failed, err: %v", err))
+	}
+
+	if (respCode < http.StatusOK) || (respCode >= http.StatusMultipleChoices) {
+		b.logger.WithContext(ctx).Warnf("[BknBackendAccess] ListMetricsByObjectTypes failed, [%s], code %d", src, respCode)
+
+		var baseError interfaces.KnBaseError
+		if err := sonic.Unmarshal(respBody, &baseError); err != nil {
+			return nil, infraErr.DefaultHTTPError(ctx, respCode,
+				fmt.Sprintf("[BknBackendAccess] ListMetricsByObjectTypes failed, code %d", respCode))
+		}
+		return nil, &infraErr.HTTPError{
+			HTTPCode:     respCode,
+			Code:         baseError.ErrorCode,
+			Description:  baseError.Description,
+			Solution:     baseError.Solution,
+			ErrorLink:    baseError.ErrorLink,
+			ErrorDetails: baseError.ErrorDetails,
+		}
+	}
+
+	if len(respBody) == 0 {
+		return nil, nil
+	}
+
+	parsed := &metricsListResp{}
+	if err := sonic.Unmarshal(respBody, parsed); err != nil {
+		b.logger.WithContext(ctx).Errorf("[BknBackendAccess] ListMetricsByObjectTypes unmarshal failed: %v", err)
+		return nil, err
+	}
+
+	metrics := make([]*interfaces.RelatedMetric, 0, len(parsed.Entries))
+	for _, e := range parsed.Entries {
+		// bkn-backend applies the scope filter, but an older backend that ignores the
+		// query parameter would otherwise hand every metric of the network to every
+		// object type. Cheap to re-check, and wrong-by-default if we do not.
+		if _, ok := seen[e.ScopeRef]; !ok {
+			continue
+		}
+		metric := &interfaces.RelatedMetric{
+			ID:         e.ID,
+			Name:       e.Name,
+			Comment:    e.Comment,
+			MetricType: e.MetricType,
+			Unit:       e.Unit,
+			UnitType:   e.UnitType,
+			ScopeRef:   e.ScopeRef,
+		}
+		if e.TimeDimension != nil {
+			metric.TimeDimension = e.TimeDimension.Property
+		}
+		for _, d := range e.AnalysisDimensions {
+			if strings.TrimSpace(d.Name) != "" {
+				metric.AnalysisDimensions = append(metric.AnalysisDimensions, d.Name)
+			}
+		}
+		metrics = append(metrics, metric)
+	}
+	return metrics, nil
+}

--- a/adp/context-loader/agent-retrieval/server/drivenadapters/bkn_backend_metrics_test.go
+++ b/adp/context-loader/agent-retrieval/server/drivenadapters/bkn_backend_metrics_test.go
@@ -170,3 +170,52 @@ func TestListMetricsByObjectTypes_StopsOnShortPage(t *testing.T) {
 		convey.So(len(metrics), convey.ShouldEqual, 1)
 	})
 }
+
+func TestListMetricsByObjectTypes_BatchesScopeRefs(t *testing.T) {
+	convey.Convey("对象类 id 过多时分批发，避免请求行过长", t, func() {
+		client, mockHTTP, ctrl := newMetricsTestClient(t)
+		defer ctrl.Finish()
+
+		ids := make([]string, metricsScopeBatch+5)
+		for i := range ids {
+			ids[i] = "ot" + strconv.Itoa(i)
+		}
+
+		var batchSizes []int
+		mockHTTP.EXPECT().GetNoUnmarshal(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+			DoAndReturn(func(_ context.Context, _ string, q url.Values, _ map[string]string) (int, []byte, error) {
+				batchSizes = append(batchSizes, len(strings.Split(q.Get("scope_ref"), ",")))
+				return http.StatusOK, []byte(`{"entries":[{"id":"m1","scope_ref":"ot0"}],"total_count":1}`), nil
+			}).Times(2)
+
+		metrics, err := client.ListMetricsByObjectTypes(context.Background(), "kn1", ids)
+
+		convey.So(err, convey.ShouldBeNil)
+		convey.So(batchSizes, convey.ShouldResemble, []int{metricsScopeBatch, 5})
+		// 每批各回一条同 scope 的指标，合并后两条都在
+		convey.So(len(metrics), convey.ShouldEqual, 2)
+	})
+}
+
+func TestListMetricsByObjectTypes_EscapesKnID(t *testing.T) {
+	convey.Convey("kn_id 转义后才进 path，注入的查询参数盖不掉 scope_type", t, func() {
+		client, mockHTTP, ctrl := newMetricsTestClient(t)
+		defer ctrl.Finish()
+
+		var gotURL string
+		var gotQuery url.Values
+		mockHTTP.EXPECT().GetNoUnmarshal(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+			DoAndReturn(func(_ context.Context, src string, q url.Values, _ map[string]string) (int, []byte, error) {
+				gotURL, gotQuery = src, q
+				return http.StatusOK, []byte(`{"entries":[],"total_count":0}`), nil
+			})
+
+		_, err := client.ListMetricsByObjectTypes(context.Background(),
+			"kn1/metrics?scope_type=subgraph&x=", []string{"ot1"})
+
+		convey.So(err, convey.ShouldBeNil)
+		convey.So(gotURL, convey.ShouldNotContainSubstring, "?")
+		convey.So(gotURL, convey.ShouldEndWith, "/knowledge-networks/kn1%2Fmetrics%3Fscope_type=subgraph&x=/metrics")
+		convey.So(gotQuery.Get("scope_type"), convey.ShouldEqual, "object_type")
+	})
+}

--- a/adp/context-loader/agent-retrieval/server/drivenadapters/bkn_backend_metrics_test.go
+++ b/adp/context-loader/agent-retrieval/server/drivenadapters/bkn_backend_metrics_test.go
@@ -1,0 +1,115 @@
+// Copyright openbkn.ai
+//
+// Licensed under the OpenBKN License. See LICENSE-OPENBKN.txt in the project root.
+
+package drivenadapters
+
+import (
+	"context"
+	"net/http"
+	"net/url"
+	"testing"
+
+	"github.com/smartystreets/goconvey/convey"
+	"go.uber.org/mock/gomock"
+
+	"github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/mocks"
+)
+
+func newMetricsTestClient(t *testing.T) (*bknBackendAccess, *mocks.MockHTTPClient, *gomock.Controller) {
+	t.Helper()
+	ctrl := gomock.NewController(t)
+	mockLogger := mocks.NewMockLogger(ctrl)
+	mockLogger.EXPECT().WithContext(gomock.Any()).Return(mockLogger).AnyTimes()
+	mockLogger.EXPECT().Warnf(gomock.Any(), gomock.Any()).AnyTimes()
+	mockLogger.EXPECT().Errorf(gomock.Any(), gomock.Any()).AnyTimes()
+	mockHTTP := mocks.NewMockHTTPClient(ctrl)
+	return &bknBackendAccess{
+		logger:     mockLogger,
+		baseURL:    "http://localhost:8080/api/bkn-backend",
+		httpClient: mockHTTP,
+	}, mockHTTP, ctrl
+}
+
+func TestListMetricsByObjectTypes_QueriesMetricRegistryByScope(t *testing.T) {
+	convey.Convey("ListMetricsByObjectTypes 走指标注册表并按 scope 批量过滤", t, func() {
+		client, mockHTTP, ctrl := newMetricsTestClient(t)
+		defer ctrl.Finish()
+
+		var gotURL string
+		var gotQuery url.Values
+		mockHTTP.EXPECT().GetNoUnmarshal(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+			DoAndReturn(func(_ context.Context, src string, q url.Values, _ map[string]string) (int, []byte, error) {
+				gotURL, gotQuery = src, q
+				return http.StatusOK, []byte(`{"entries":[
+					{"id":"m1","name":"产品总数","comment":"c","unit":"个","unit_type":"count",
+					 "metric_type":"atomic","scope_type":"object_type","scope_ref":"ot1",
+					 "time_dimension":{"property":"stat_date"},
+					 "analysis_dimensions":[{"name":"region"},{"name":""}]},
+					{"id":"m2","name":"物料总数","scope_type":"object_type","scope_ref":"ot2"}
+				],"total_count":2}`), nil
+			})
+
+		metrics, err := client.ListMetricsByObjectTypes(context.Background(), "kn1", []string{"ot1", " ot2 ", "ot1", ""})
+
+		convey.So(err, convey.ShouldBeNil)
+		convey.So(gotURL, convey.ShouldEqual, "http://localhost:8080/api/bkn-backend/in/v1/knowledge-networks/kn1/metrics")
+		convey.So(gotQuery.Get("scope_type"), convey.ShouldEqual, "object_type")
+		convey.So(gotQuery.Get("scope_ref"), convey.ShouldEqual, "ot1,ot2")
+		convey.So(len(metrics), convey.ShouldEqual, 2)
+		convey.So(metrics[0].ID, convey.ShouldEqual, "m1")
+		convey.So(metrics[0].TimeDimension, convey.ShouldEqual, "stat_date")
+		convey.So(metrics[0].AnalysisDimensions, convey.ShouldResemble, []string{"region"})
+		convey.So(metrics[1].ScopeRef, convey.ShouldEqual, "ot2")
+	})
+}
+
+func TestListMetricsByObjectTypes_DropsMetricsOutsideRequestedScope(t *testing.T) {
+	convey.Convey("后端若忽略 scope_ref 过滤，本地仍不把别的对象类的指标塞回来", t, func() {
+		client, mockHTTP, ctrl := newMetricsTestClient(t)
+		defer ctrl.Finish()
+
+		mockHTTP.EXPECT().GetNoUnmarshal(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+			Return(http.StatusOK, []byte(`{"entries":[
+				{"id":"m1","name":"要的","scope_ref":"ot1"},
+				{"id":"m9","name":"别人的","scope_ref":"ot9"}
+			]}`), nil)
+
+		metrics, err := client.ListMetricsByObjectTypes(context.Background(), "kn1", []string{"ot1"})
+
+		convey.So(err, convey.ShouldBeNil)
+		convey.So(len(metrics), convey.ShouldEqual, 1)
+		convey.So(metrics[0].ID, convey.ShouldEqual, "m1")
+	})
+}
+
+func TestListMetricsByObjectTypes_NoRequestWithoutIDs(t *testing.T) {
+	convey.Convey("kn_id 或对象类 id 为空时不发请求", t, func() {
+		client, mockHTTP, ctrl := newMetricsTestClient(t)
+		defer ctrl.Finish()
+
+		mockHTTP.EXPECT().GetNoUnmarshal(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Times(0)
+
+		metrics, err := client.ListMetricsByObjectTypes(context.Background(), "kn1", []string{" ", ""})
+		convey.So(err, convey.ShouldBeNil)
+		convey.So(metrics, convey.ShouldBeNil)
+
+		metrics, err = client.ListMetricsByObjectTypes(context.Background(), "", []string{"ot1"})
+		convey.So(err, convey.ShouldBeNil)
+		convey.So(metrics, convey.ShouldBeNil)
+	})
+}
+
+func TestListMetricsByObjectTypes_SurfacesBackendError(t *testing.T) {
+	convey.Convey("后端 4xx 带上错误码回给调用方", t, func() {
+		client, mockHTTP, ctrl := newMetricsTestClient(t)
+		defer ctrl.Finish()
+
+		mockHTTP.EXPECT().GetNoUnmarshal(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+			Return(http.StatusForbidden, []byte(`{"ErrorCode":"BknBackend.Forbidden","Description":"no permission"}`), nil)
+
+		metrics, err := client.ListMetricsByObjectTypes(context.Background(), "kn1", []string{"ot1"})
+		convey.So(err, convey.ShouldNotBeNil)
+		convey.So(metrics, convey.ShouldBeNil)
+	})
+}

--- a/adp/context-loader/agent-retrieval/server/drivenadapters/bkn_backend_metrics_test.go
+++ b/adp/context-loader/agent-retrieval/server/drivenadapters/bkn_backend_metrics_test.go
@@ -8,6 +8,8 @@ import (
 	"context"
 	"net/http"
 	"net/url"
+	"strconv"
+	"strings"
 	"testing"
 
 	"github.com/smartystreets/goconvey/convey"
@@ -111,5 +113,60 @@ func TestListMetricsByObjectTypes_SurfacesBackendError(t *testing.T) {
 		metrics, err := client.ListMetricsByObjectTypes(context.Background(), "kn1", []string{"ot1"})
 		convey.So(err, convey.ShouldNotBeNil)
 		convey.So(metrics, convey.ShouldBeNil)
+	})
+}
+
+func TestListMetricsByObjectTypes_PagesUntilComplete(t *testing.T) {
+	convey.Convey("指标数超过单页时继续翻页，不静默截断", t, func() {
+		client, mockHTTP, ctrl := newMetricsTestClient(t)
+		defer ctrl.Finish()
+
+		// 第一页满页且 total 更大 → 必须再请求一次；两页拼起来才是完整答案。
+		page := func(ids []string, total int) []byte {
+			entries := make([]string, 0, len(ids))
+			for _, id := range ids {
+				entries = append(entries, `{"id":"`+id+`","name":"`+id+`","scope_ref":"ot1"}`)
+			}
+			return []byte(`{"entries":[` + strings.Join(entries, ",") + `],"total_count":` + strconv.Itoa(total) + `}`)
+		}
+		first := make([]string, metricsPageSize)
+		for i := range first {
+			first[i] = "m" + strconv.Itoa(i)
+		}
+
+		var offsets []string
+		gomock.InOrder(
+			mockHTTP.EXPECT().GetNoUnmarshal(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+				DoAndReturn(func(_ context.Context, _ string, q url.Values, _ map[string]string) (int, []byte, error) {
+					offsets = append(offsets, q.Get("offset"))
+					return http.StatusOK, page(first, metricsPageSize+1), nil
+				}),
+			mockHTTP.EXPECT().GetNoUnmarshal(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+				DoAndReturn(func(_ context.Context, _ string, q url.Values, _ map[string]string) (int, []byte, error) {
+					offsets = append(offsets, q.Get("offset"))
+					return http.StatusOK, page([]string{"tail"}, metricsPageSize+1), nil
+				}),
+		)
+
+		metrics, err := client.ListMetricsByObjectTypes(context.Background(), "kn1", []string{"ot1"})
+
+		convey.So(err, convey.ShouldBeNil)
+		convey.So(offsets, convey.ShouldResemble, []string{"0", strconv.Itoa(metricsPageSize)})
+		convey.So(len(metrics), convey.ShouldEqual, metricsPageSize+1)
+		convey.So(metrics[len(metrics)-1].ID, convey.ShouldEqual, "tail")
+	})
+}
+
+func TestListMetricsByObjectTypes_StopsOnShortPage(t *testing.T) {
+	convey.Convey("一页拿完就不再请求", t, func() {
+		client, mockHTTP, ctrl := newMetricsTestClient(t)
+		defer ctrl.Finish()
+
+		mockHTTP.EXPECT().GetNoUnmarshal(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+			Return(http.StatusOK, []byte(`{"entries":[{"id":"m1","scope_ref":"ot1"}],"total_count":1}`), nil).Times(1)
+
+		metrics, err := client.ListMetricsByObjectTypes(context.Background(), "kn1", []string{"ot1"})
+		convey.So(err, convey.ShouldBeNil)
+		convey.So(len(metrics), convey.ShouldEqual, 1)
 	})
 }

--- a/adp/context-loader/agent-retrieval/server/drivenadapters/ontology_query.go
+++ b/adp/context-loader/agent-retrieval/server/drivenadapters/ontology_query.go
@@ -52,7 +52,12 @@ const (
 	// https://{host}:{port}/api/ontology-query/in/v1/knowledge-networks/:kn_id/subgraph
 	queryInstanceSubgraphURI = "/in/v1/knowledge-networks/%s/subgraph"
 	// https://{host}:{port}/api/ontology-query/in/v1/knowledge-networks/:kn_id/metrics/:metric_id/data
-	queryMetricDataURI = "/in/v1/knowledge-networks/%s/metrics/%s/data?fill_null=%v"
+	//
+	// Both ids are escaped at call time: metric_id arrives straight from an agent
+	// (the tool schema constrains it to a string and nothing more), and an
+	// unescaped one carrying "?" or "&" would smuggle query parameters — branch
+	// and fill_null among them — into the downstream request.
+	queryMetricDataURI = "/in/v1/knowledge-networks/%s/metrics/%s/data"
 )
 
 // NewOntologyQueryAccess 创建OntologyQueryAccess
@@ -440,8 +445,10 @@ func (o *ontologyQueryClient) QueryInstanceSubgraph(ctx context.Context, req *in
 // 透传，授权在下游判定。
 func (o *ontologyQueryClient) QueryMetricData(ctx context.Context, knID, metricID string, fillNull bool,
 	req *interfaces.MetricQueryDownstreamReq) (resp *interfaces.MetricQueryDownstreamResp, err error) {
-	uri := fmt.Sprintf(queryMetricDataURI, knID, metricID, fillNull)
-	url := fmt.Sprintf("%s%s", o.baseURL, uri)
+	uri := fmt.Sprintf(queryMetricDataURI, url.PathEscape(knID), url.PathEscape(metricID))
+	query := url.Values{}
+	query.Set("fill_null", strconv.FormatBool(fillNull))
+	target := fmt.Sprintf("%s%s?%s", o.baseURL, uri, query.Encode())
 
 	header := common.GetHeaderForChildOperation(ctx, "ontology.metric.query", 1)
 	header[rest.ContentTypeKey] = rest.ContentTypeJSON
@@ -449,7 +456,7 @@ func (o *ontologyQueryClient) QueryMetricData(ctx context.Context, knID, metricI
 	if req == nil {
 		req = &interfaces.MetricQueryDownstreamReq{}
 	}
-	_, respBody, err := o.httpClient.Post(ctx, url, header, req)
+	_, respBody, err := o.httpClient.Post(ctx, target, header, req)
 	if err != nil {
 		o.logger.WithContext(ctx).Warnf("[OntologyQuery#QueryMetricData] kn=%s metric=%s failed: %v", knID, metricID, err)
 		// 指标不存在 / 参数不合法是调用方的错，别混进依赖故障。

--- a/adp/context-loader/agent-retrieval/server/drivenadapters/ontology_query.go
+++ b/adp/context-loader/agent-retrieval/server/drivenadapters/ontology_query.go
@@ -51,6 +51,8 @@ const (
 	listActionExecutionsURI = "/in/v1/knowledge-networks/%s/action-logs"
 	// https://{host}:{port}/api/ontology-query/in/v1/knowledge-networks/:kn_id/subgraph
 	queryInstanceSubgraphURI = "/in/v1/knowledge-networks/%s/subgraph"
+	// https://{host}:{port}/api/ontology-query/in/v1/knowledge-networks/:kn_id/metrics/:metric_id/data
+	queryMetricDataURI = "/in/v1/knowledge-networks/%s/metrics/%s/data?fill_null=%v"
 )
 
 // NewOntologyQueryAccess 创建OntologyQueryAccess
@@ -429,5 +431,36 @@ func (o *ontologyQueryClient) QueryInstanceSubgraph(ctx context.Context, req *in
 	respJSON, _ := json.Marshal(resp)
 	o.logger.WithContext(ctx).Debugf("[OntologyQuery#QueryInstanceSubgraph] Response: %s", string(respJSON))
 
+	return resp, nil
+}
+
+// QueryMetricData 按指标自身口径计算取数（OT-first 路径第 3 步）。
+//
+// 走 ontology-query 内部路由，与 QueryLogicProperties 同一姿势：账户信息随 header
+// 透传，授权在下游判定。
+func (o *ontologyQueryClient) QueryMetricData(ctx context.Context, knID, metricID string, fillNull bool,
+	req *interfaces.MetricQueryDownstreamReq) (resp *interfaces.MetricQueryDownstreamResp, err error) {
+	uri := fmt.Sprintf(queryMetricDataURI, knID, metricID, fillNull)
+	url := fmt.Sprintf("%s%s", o.baseURL, uri)
+
+	header := common.GetHeaderForChildOperation(ctx, "ontology.metric.query", 1)
+	header[rest.ContentTypeKey] = rest.ContentTypeJSON
+
+	if req == nil {
+		req = &interfaces.MetricQueryDownstreamReq{}
+	}
+	_, respBody, err := o.httpClient.Post(ctx, url, header, req)
+	if err != nil {
+		o.logger.WithContext(ctx).Warnf("[OntologyQuery#QueryMetricData] kn=%s metric=%s failed: %v", knID, metricID, err)
+		// 指标不存在 / 参数不合法是调用方的错，别混进依赖故障。
+		return nil, classifyQueryError(ctx, err)
+	}
+
+	resp = &interfaces.MetricQueryDownstreamResp{}
+	resultByt := utils.ObjectToByte(respBody)
+	if err = json.Unmarshal(resultByt, resp); err != nil {
+		o.logger.WithContext(ctx).Errorf("[OntologyQuery#QueryMetricData] Unmarshal %s err:%v", string(resultByt), err)
+		return nil, infraErr.DefaultHTTPError(ctx, http.StatusInternalServerError, err.Error())
+	}
 	return resp, nil
 }

--- a/adp/context-loader/agent-retrieval/server/drivenadapters/ontology_query_metric_test.go
+++ b/adp/context-loader/agent-retrieval/server/drivenadapters/ontology_query_metric_test.go
@@ -1,0 +1,88 @@
+// Copyright openbkn.ai
+//
+// Licensed under the OpenBKN License. See LICENSE-OPENBKN.txt in the project root.
+
+package drivenadapters
+
+import (
+	"context"
+	"net/url"
+	"strings"
+	"testing"
+
+	"github.com/smartystreets/goconvey/convey"
+	"go.uber.org/mock/gomock"
+
+	"github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/interfaces"
+	"github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/mocks"
+)
+
+// metric_id 是 agent 自由填写的字符串。未转义就拼进 path 的话，一个带 "?" 的值
+// 就能给下游塞进 branch / fill_null 等查询参数——下游按 path 路由仍会命中，
+// 只是参数被调用方接管了。
+func TestQueryMetricData_EscapesIDsIntoPath(t *testing.T) {
+	convey.Convey("kn_id / metric_id 转义后才进 URL", t, func() {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		mockLogger := mocks.NewMockLogger(ctrl)
+		mockLogger.EXPECT().WithContext(gomock.Any()).Return(mockLogger).AnyTimes()
+		mockLogger.EXPECT().Warnf(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes()
+		mockHTTP := mocks.NewMockHTTPClient(ctrl)
+
+		client := &ontologyQueryClient{
+			logger:     mockLogger,
+			baseURL:    "http://ontology-query:13018/api/ontology-query",
+			httpClient: mockHTTP,
+		}
+
+		var got string
+		mockHTTP.EXPECT().Post(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+			DoAndReturn(func(_ context.Context, target string, _ map[string]string, _ any) (int, any, error) {
+				got = target
+				return 200, map[string]any{"datas": []any{}}, nil
+			})
+
+		_, err := client.QueryMetricData(context.Background(), "kn1",
+			"m1/data?branch=dev&x=", false, &interfaces.MetricQueryDownstreamReq{})
+		convey.So(err, convey.ShouldBeNil)
+
+		parsed, perr := url.Parse(got)
+		convey.So(perr, convey.ShouldBeNil)
+		// 注入的 branch 没能进查询串，fill_null 仍是本层给的值
+		convey.So(parsed.Query().Get("branch"), convey.ShouldBeEmpty)
+		convey.So(parsed.Query().Get("fill_null"), convey.ShouldEqual, "false")
+		// 注入串整体留在 path 段里，下游只会把它当作一个不存在的 metric_id
+		convey.So(parsed.EscapedPath(), convey.ShouldEqual,
+			"/api/ontology-query/in/v1/knowledge-networks/kn1/metrics/m1%2Fdata%3Fbranch=dev&x=/data")
+		convey.So(strings.Count(got, "?"), convey.ShouldEqual, 1)
+	})
+}
+
+func TestQueryMetricData_ForwardsFillNull(t *testing.T) {
+	convey.Convey("fill_null 走查询串透传", t, func() {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		mockLogger := mocks.NewMockLogger(ctrl)
+		mockLogger.EXPECT().WithContext(gomock.Any()).Return(mockLogger).AnyTimes()
+		mockHTTP := mocks.NewMockHTTPClient(ctrl)
+		client := &ontologyQueryClient{
+			logger:     mockLogger,
+			baseURL:    "http://ontology-query:13018/api/ontology-query",
+			httpClient: mockHTTP,
+		}
+
+		var got string
+		mockHTTP.EXPECT().Post(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+			DoAndReturn(func(_ context.Context, target string, _ map[string]string, _ any) (int, any, error) {
+				got = target
+				return 200, map[string]any{"datas": []any{}}, nil
+			})
+
+		_, err := client.QueryMetricData(context.Background(), "kn1", "m1", true, nil)
+		convey.So(err, convey.ShouldBeNil)
+		convey.So(got, convey.ShouldEndWith,
+			"/in/v1/knowledge-networks/kn1/metrics/m1/data?fill_null=true")
+	})
+}

--- a/adp/context-loader/agent-retrieval/server/driveradapters/knquerytools/index.go
+++ b/adp/context-loader/agent-retrieval/server/driveradapters/knquerytools/index.go
@@ -20,6 +20,7 @@ import (
 	"github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/infra/errors"
 	"github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/infra/rest"
 	"github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/interfaces"
+	"github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/logics/knmetrics"
 	"github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/logics/knresources"
 	"github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/logics/knrunsql"
 )
@@ -32,6 +33,7 @@ type KnQueryToolsHandler interface {
 	GetKnDetail(c *gin.Context)
 	GetObjectTypes(c *gin.Context)
 	GetRelationTypes(c *gin.Context)
+	QueryMetric(c *gin.Context)
 	ListResources(c *gin.Context)
 	DescribeResource(c *gin.Context)
 }
@@ -41,6 +43,7 @@ type knQueryToolsHandler struct {
 	runSQL     knrunsql.KnRunSQLService
 	resources  knresources.KnResourcesService
 	bknBackend interfaces.BknBackendAccess
+	metrics    knmetrics.KnMetricsService
 }
 
 var (
@@ -57,6 +60,7 @@ func NewKnQueryToolsHandler() KnQueryToolsHandler {
 			runSQL:     knrunsql.NewKnRunSQLService(),
 			resources:  knresources.NewKnResourcesService(),
 			bknBackend: drivenadapters.NewBknBackendAccess(),
+			metrics:    knmetrics.NewKnMetricsService(),
 		}
 	})
 	return handler
@@ -126,6 +130,8 @@ func (h *knQueryToolsHandler) GetKnDetail(c *gin.Context) {
 		rest.ReplyError(c, err)
 		return
 	}
+	// 只挂计数不挂明细：够 Agent 判断哪个对象类值得下钻取指标。
+	h.metrics.AttachRelatedMetricCounts(ctx, req.KnID, resp.ObjectTypes)
 	detailLevel := req.DetailLevel
 	if detailLevel == "" {
 		detailLevel = interfaces.DetailLevelSummary
@@ -211,6 +217,8 @@ func (h *knQueryToolsHandler) GetObjectTypes(c *gin.Context) {
 		return
 	}
 	matched, missing := detail.FilterObjectTypes(req.IDs)
+	// OT-first 第 2 步：未绑逻辑属性的 scoped 指标只有在这里才看得见。
+	h.metrics.AttachRelatedMetrics(ctx, knID, matched)
 	bkntrace.EmitSchemaDefinitionEvents(ctx, h.logger, "object", knID, req.IDs, len(matched))
 	rest.ReplyOK(c, http.StatusOK, &interfaces.ObjectTypesResp{KnID: knID, ObjectTypes: matched, Missing: missing})
 }
@@ -240,4 +248,34 @@ func (h *knQueryToolsHandler) GetRelationTypes(c *gin.Context) {
 	matched, missing := detail.FilterRelationTypes(req.IDs)
 	bkntrace.EmitSchemaDefinitionEvents(ctx, h.logger, "relation", knID, req.IDs, len(matched))
 	rest.ReplyOK(c, http.StatusOK, &interfaces.RelationTypesResp{KnID: knID, RelationTypes: matched, Missing: missing})
+}
+
+// QueryMetric 按指标自身口径取数（OT-first 路径第 3 步）。
+//
+// 与 get_logic_properties_values 分流：实例级、已绑逻辑属性的走那条；类级、或未绑
+// 逻辑属性的走这条。两条都不该被 run_sql 取代——口径在 MetricDefinition 里。
+func (h *knQueryToolsHandler) QueryMetric(c *gin.Context) {
+	ctx := c.Request.Context()
+	req := &interfaces.QueryMetricReq{}
+	if err := c.ShouldBindJSON(req); err != nil {
+		rest.ReplyError(c, errors.DefaultHTTPError(ctx, http.StatusBadRequest, err.Error()))
+		return
+	}
+	if req.KnID == "" {
+		req.KnID = c.GetHeader("X-Kn-ID")
+	}
+
+	resp, err := h.metrics.QueryMetric(ctx, req)
+	if err != nil {
+		h.logger.WithContext(ctx).Warnf("[KnQueryToolsHandler#QueryMetric] kn=%s metric=%s failed: %v",
+			req.KnID, req.MetricID, err)
+		if httpErr, ok := err.(*errors.HTTPError); ok {
+			rest.ReplyError(c, httpErr)
+			return
+		}
+		// 入参错误（kn_id / metric_id 缺失、时间窗自相矛盾）都是调用方的错。
+		rest.ReplyError(c, errors.DefaultHTTPError(ctx, http.StatusBadRequest, err.Error()))
+		return
+	}
+	rest.ReplyOK(c, http.StatusOK, resp)
 }

--- a/adp/context-loader/agent-retrieval/server/driveradapters/mcp/app.go
+++ b/adp/context-loader/agent-retrieval/server/driveradapters/mcp/app.go
@@ -22,6 +22,7 @@ import (
 	logicsKar "github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/logics/knactionrecall"
 	logicsFs "github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/logics/knfindskills"
 	logicsKlp "github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/logics/knlogicpropertyresolver"
+	"github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/logics/knmetrics"
 	logicsKqs "github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/logics/knquerysubgraph"
 	"github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/logics/knresources"
 	"github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/logics/knrunsql"
@@ -36,6 +37,7 @@ const (
 	toolKeyQueryObjectInstance      = "query_object_instance"
 	toolKeyQueryInstanceSubgraph    = "query_instance_subgraph"
 	toolKeyGetLogicPropertiesValues = "get_logic_properties_values"
+	toolKeyQueryMetric              = "query_metric"
 	toolKeyGetActionInfo            = "get_action_info"
 	toolKeyExecuteAction            = "execute_action"
 	toolKeyGetActionExecution       = "get_action_execution"
@@ -66,8 +68,15 @@ const serverInstructions = `ContextLoader 知识网络查询工具集使用指�
 - 单对象类过滤 + 排序 + 分页（field op value，可 and/or 组合）→ query_object_instance；算子白名单以对象类的 condition_operations 为准。
 - 聚合 / 统计 / 排名（SUM、COUNT、AVG、GROUP BY、按聚合值排序、跨表 join）→ run_sql（Trino 只读 SQL）；表名用占位符 {{.<data_source.id>}}，<data_source.id> 必须替换成 search_schema 返回的真实 id 值（禁止照抄字面 resource_id；JOIN 多表时每个表用各自不同的 id）；列名用 search_schema 的 data_property.column（物理列，需 include_columns=true 获取），不是 name（逻辑名）。query_object_instance 不支持聚合。
 - 沿关系多跳取子图 → query_instance_subgraph。
-- 逻辑属性（指标/算子）计算 → get_logic_properties_values。
 - 对象可执行行动召回 → get_action_info。
+
+指标取数（OT 优先，三选一，禁止用 run_sql 重写已建模指标的口径）：
+1. 先锁定对象类：search_schema 或 get_kn_detail（summary 里 related_metric_count>0 的对象类才有指标）。
+2. get_object_types(ids) 看该对象类下有什么：logic_properties（data_source.type=metric）是实例级，related_metrics 是这个对象类 scope 下的全部指标（含未绑逻辑属性的）。
+3. 选定后计算：
+   - 实例级 + 已绑逻辑属性 → get_logic_properties_values
+   - 类级 / 未绑逻辑属性 → query_metric（传 metric_id，可选 condition / analysis_dimensions / time）
+   - 指标压根没建模，才用 run_sql 现算
 
 数据层直查（资源未建成对象类、或只想绕本体直查数据时）：
 - list_resources 列出账户可见的数据资源（resource_id、name、type、catalog_id），可按 catalog_id / type 过滤。
@@ -150,10 +159,13 @@ func newMCPServer(lifecycleClient *bkntrace.LifecycleClient) (*server.MCPServer,
 	findSkillsService := logicsFs.NewFindSkillsService()
 	b.add(toolKeyFindSkills, handleFindSkills(findSkillsService))
 
+	metricsService := knmetrics.NewKnMetricsService()
+	b.add(toolKeyQueryMetric, handleQueryMetric(metricsService))
+
 	bknBackend := drivenadapters.NewBknBackendAccess()
 	b.add(toolKeyListKnowledgeNetworks, handleListKnowledgeNetworks(bknBackend))
-	b.add(toolKeyGetKnDetail, handleGetKnDetail(bknBackend))
-	b.addEmbedded(toolKeyGetObjectTypes, handleGetObjectTypes(bknBackend))
+	b.add(toolKeyGetKnDetail, handleGetKnDetail(bknBackend, metricsService))
+	b.addEmbedded(toolKeyGetObjectTypes, handleGetObjectTypes(bknBackend, metricsService))
 	b.addEmbedded(toolKeyGetRelationTypes, handleGetRelationTypes(bknBackend))
 
 	runSQLService := knrunsql.NewKnRunSQLService()

--- a/adp/context-loader/agent-retrieval/server/driveradapters/mcp/community_parity_test.go
+++ b/adp/context-loader/agent-retrieval/server/driveradapters/mcp/community_parity_test.go
@@ -53,6 +53,7 @@ var communityTools = []string{
 	"list_knowledge_networks",
 	"list_resources",
 	"query_instance_subgraph",
+	"query_metric",
 	"query_object_instance",
 	"run_sql",
 	"search_schema",

--- a/adp/context-loader/agent-retrieval/server/driveradapters/mcp/schemas/get_kn_detail.json
+++ b/adp/context-loader/agent-retrieval/server/driveradapters/mcp/schemas/get_kn_detail.json
@@ -28,7 +28,7 @@
       "name": { "type": "string", "description": "知识网络名称" },
       "comment": { "type": "string", "description": "描述" },
       "concept_groups": { "type": "array", "items": { "type": "object", "additionalProperties": true }, "description": "概念组" },
-      "object_types": { "type": "array", "items": { "type": "object", "additionalProperties": true }, "description": "对象类型（含 data_source 等）" },
+      "object_types": { "type": "array", "items": { "type": "object", "additionalProperties": true }, "description": "对象类型（含 data_source 等）。related_metric_count 为该对象类下已建模指标数，>0 时可用 get_object_types 下钻拿 related_metrics 明细" },
       "relation_types": { "type": "array", "items": { "type": "object", "additionalProperties": true }, "description": "关系类型" },
       "action_types": { "type": "array", "items": { "type": "object", "additionalProperties": true }, "description": "行动类型" }
     }

--- a/adp/context-loader/agent-retrieval/server/driveradapters/mcp/schemas/get_object_types.json
+++ b/adp/context-loader/agent-retrieval/server/driveradapters/mcp/schemas/get_object_types.json
@@ -27,7 +27,7 @@
       "object_types": {
         "type": "array",
         "items": { "type": "object", "additionalProperties": true },
-        "description": "对象类完整定义（含 data_properties 的 mapped_field / condition_operations、logic_properties 的 data_source / parameters）"
+        "description": "对象类完整定义（含 data_properties 的 mapped_field / condition_operations、logic_properties 的 data_source / parameters）。related_metrics 为该对象类 scope 下的全部指标（id/name/comment/unit/metric_type/analysis_dimensions/time_dimension），含未绑逻辑属性的：实例级且已绑逻辑属性用 get_logic_properties_values 算，其余把 id 传给 query_metric 算。"
       },
       "missing": {
         "type": "array",

--- a/adp/context-loader/agent-retrieval/server/driveradapters/mcp/schemas/locales/en-US/instructions.txt
+++ b/adp/context-loader/agent-retrieval/server/driveradapters/mcp/schemas/locales/en-US/instructions.txt
@@ -9,8 +9,15 @@ Query routing:
 - Use query_object_instance for single object-type filtering, sorting, and cursor-style pagination.
 - Use run_sql for joins, aggregation, ranking, GROUP BY, COUNT, SUM, AVG, and cross-table analysis. Use read-only Trino SQL. Reference tables with placeholders such as {{.resource_id}} where resource_id comes from search_schema or list_resources. Use physical column names from search_schema with include_columns=true or from describe_resource.
 - Use query_instance_subgraph to expand related instances along relation paths.
-- Use get_logic_properties_values to resolve calculated logic properties, such as metrics or operators, for batches of instances.
 - Use get_action_info to discover actions that can be executed for object instances.
+
+Metrics, object type first. Never re-derive a modelled metric in run_sql — its formula lives in the metric definition:
+1. Recall the object type with search_schema or get_kn_detail. In the get_kn_detail summary, only object types with related_metric_count > 0 have metrics.
+2. Call get_object_types(ids) to see what that object type offers: logic_properties with data_source.type=metric are the instance-level ones; related_metrics lists every metric scoped to the object type, including those not bound to any logic property.
+3. Compute the one you picked:
+   - instance level, bound to a logic property: get_logic_properties_values
+   - class level, or not bound to a logic property: query_metric with the metric_id, plus optional condition / analysis_dimensions / time
+   - only when nothing is modelled as a metric: run_sql
 
 Direct data-layer path:
 - Use list_resources to list visible data resources with resource_id, name, type, and catalog_id.

--- a/adp/context-loader/agent-retrieval/server/driveradapters/mcp/schemas/locales/en-US/tools_meta.json
+++ b/adp/context-loader/agent-retrieval/server/driveradapters/mcp/schemas/locales/en-US/tools_meta.json
@@ -1,7 +1,7 @@
 {
   "search_schema": {
     "name": "search_schema",
-    "description": "Explore schema by natural language. Returns relevant object types, relation types, action types, metric types, condition operations, and data source metadata for downstream query tools."
+    "description": "Explore schema by natural language. Returns relevant object types, relation types, action types, metric types, condition operations, and data source metadata for downstream query tools. Object types come first: metric_types here is only a hint — the authoritative list of a metric for an object type is related_metrics from get_object_types."
   },
   "query_object_instance": {
     "name": "query_object_instance",
@@ -13,7 +13,11 @@
   },
   "get_logic_properties_values": {
     "name": "get_logic_properties_values",
-    "description": "Resolve calculated logic properties, such as metrics or operator-backed properties, for a batch of object instances."
+    "description": "Resolve calculated logic properties, such as metrics or operator-backed properties, for a batch of object instances. This is the instance-level branch of the metric path (a metric already bound to a logic property); class-level metrics and metrics not bound to a logic property go to query_metric."
+  },
+  "query_metric": {
+    "name": "query_metric",
+    "description": "Compute a modelled metric by its own definition (step 3 of the OT-first metric path). Recall the object type with search_schema / get_kn_detail, pick a metric_id from get_object_types' related_metrics, then call this tool — the formula lives in the MetricDefinition, so do not re-derive it with run_sql. Routing: instance-level values of a bound logic property go through get_logic_properties_values; class-level metrics, and metrics not bound to any logic property, come here. Optional condition filter, analysis_dimensions breakdown, and a time block for a single point or a series."
   },
   "get_action_info": {
     "name": "get_action_info",
@@ -41,11 +45,11 @@
   },
   "get_kn_detail": {
     "name": "get_kn_detail",
-    "description": "Get full knowledge network details, including concept groups, object types, relation types, and action types. Use this when a known kn_id needs a complete schema snapshot."
+    "description": "Get full knowledge network details, including concept groups, object types, relation types, and action types. Use this when a known kn_id needs a complete schema snapshot. Object type entries carry related_metric_count, the number of metrics modelled on that object type, so you can tell whether drilling in for metrics is worth it."
   },
   "run_sql": {
     "name": "run_sql",
-    "description": "Run one read-only SELECT statement in Trino SQL against data resources mounted by a knowledge network. Use table placeholders such as {{.resource_id}} and physical column names. JOIN, WHERE, GROUP BY/HAVING, ORDER BY, LIMIT, and common aggregates are supported within one catalog. WITH/CTE, UNION/INTERSECT/EXCEPT, multiple statements, writes/DDL, and cross-catalog joins are unsupported; subqueries and window functions are not part of the compatibility contract."
+    "description": "Run one read-only SELECT statement in Trino SQL against data resources mounted by a knowledge network. Use table placeholders such as {{.resource_id}} and physical column names. JOIN, WHERE, GROUP BY/HAVING, ORDER BY, LIMIT, and common aggregates are supported within one catalog. WITH/CTE, UNION/INTERSECT/EXCEPT, multiple statements, writes/DDL, and cross-catalog joins are unsupported; subqueries and window functions are not part of the compatibility contract. Do not re-derive a modelled metric in SQL: pick it from get_object_types' related_metrics and call query_metric (or get_logic_properties_values for a bound logic property). run_sql is for ad-hoc aggregation that has not been modelled as a metric."
   },
   "list_resources": {
     "name": "list_resources",

--- a/adp/context-loader/agent-retrieval/server/driveradapters/mcp/schemas/locales/en-US/tools_meta.json
+++ b/adp/context-loader/agent-retrieval/server/driveradapters/mcp/schemas/locales/en-US/tools_meta.json
@@ -17,7 +17,7 @@
   },
   "query_metric": {
     "name": "query_metric",
-    "description": "Compute a modelled metric by its own definition (step 3 of the OT-first metric path). Recall the object type with search_schema / get_kn_detail, pick a metric_id from get_object_types' related_metrics, then call this tool — the formula lives in the MetricDefinition, so do not re-derive it with run_sql. Routing: instance-level values of a bound logic property go through get_logic_properties_values; class-level metrics, and metrics not bound to any logic property, come here. Optional condition filter, analysis_dimensions breakdown, and a time block for a single point or a series."
+    "description": "Compute a modelled metric by its own definition (step 3 of the OT-first metric path). Recall the object type with search_schema / get_kn_detail, pick a metric_id from get_object_types' related_metrics, then call this tool — the formula lives in the MetricDefinition, so do not re-derive it with run_sql. Routing: instance-level values of a bound logic property go through get_logic_properties_values; class-level metrics, and metrics not bound to any logic property, come here. Optional condition filter, analysis_dimensions breakdown, and a time block for a single point or a series. Time window: omitting instant means a trend query, which requires step; start and end must both be set or both omitted."
   },
   "get_action_info": {
     "name": "get_action_info",

--- a/adp/context-loader/agent-retrieval/server/driveradapters/mcp/schemas/query_metric.json
+++ b/adp/context-loader/agent-retrieval/server/driveradapters/mcp/schemas/query_metric.json
@@ -4,7 +4,10 @@
     "properties": {
       "response_format": {
         "type": "string",
-        "enum": ["json", "toon"],
+        "enum": [
+          "json",
+          "toon"
+        ],
         "default": "toon",
         "description": "文本格式：json 或 toon，默认 toon"
       },
@@ -18,18 +21,30 @@
       },
       "time": {
         "type": "object",
-        "description": "时间窗。指标无时间维度（related_metrics[].time_dimension 为空）时可整体省略。",
+        "description": "时间窗。指标无时间维度（related_metrics[].time_dimension 为空）时可整体省略。注意：省略 instant 等同于 instant=false（序列查询），此时必须传 step。start 与 end 要么都传要么都不传。",
         "properties": {
           "instant": {
             "type": "boolean",
-            "description": "true=取单点（当前值），此时不得传 step；false=取序列，此时必须传 step。"
+            "description": "true=取单点（当前值）；false 或省略=取序列，此时必须传 step。"
           },
-          "start": { "type": "integer", "description": "起始时间，unix 秒" },
-          "end": { "type": "integer", "description": "结束时间，unix 秒" },
+          "start": {
+            "type": "integer",
+            "description": "起始时间，unix 秒"
+          },
+          "end": {
+            "type": "integer",
+            "description": "结束时间，unix 秒"
+          },
           "step": {
             "type": "string",
-            "enum": ["day", "week", "month", "quarter", "year"],
-            "description": "序列步长，仅 instant=false 时传"
+            "enum": [
+              "day",
+              "week",
+              "month",
+              "quarter",
+              "year"
+            ],
+            "description": "序列步长（大小写不敏感）。序列查询必传；instant=true 时会被下游忽略。"
           }
         }
       },
@@ -40,7 +55,9 @@
       },
       "analysis_dimensions": {
         "type": "array",
-        "items": { "type": "string" },
+        "items": {
+          "type": "string"
+        },
         "description": "分析维度（按维度拆分结果），取值必须来自 related_metrics[].analysis_dimensions。"
       },
       "order_by": {
@@ -49,8 +66,16 @@
         "items": {
           "type": "object",
           "properties": {
-            "property": { "type": "string" },
-            "direction": { "type": "string", "enum": ["asc", "desc"] }
+            "property": {
+              "type": "string"
+            },
+            "direction": {
+              "type": "string",
+              "enum": [
+                "asc",
+                "desc"
+              ]
+            }
           }
         }
       },
@@ -58,41 +83,87 @@
         "type": "object",
         "description": "对聚合结果过滤",
         "properties": {
-          "field": { "type": "string" },
-          "operation": { "type": "string" },
+          "field": {
+            "type": "string"
+          },
+          "operation": {
+            "type": "string"
+          },
           "value": {}
         }
       },
-      "limit": { "type": "integer", "description": "返回条数上限" },
+      "limit": {
+        "type": "integer",
+        "description": "返回条数上限"
+      },
       "fill_null": {
         "type": "boolean",
-        "description": "区间查询时，无数据的步长点是否补空，默认 false"
+        "description": "区间序列查询时，无数据的步长点是否补空，默认 false。仅对序列查询有效，且必须同时给 time.start 与 time.end。"
       }
     },
-    "required": ["kn_id", "metric_id"]
+    "required": [
+      "kn_id",
+      "metric_id"
+    ]
   },
   "output_schema": {
     "type": "object",
     "properties": {
-      "kn_id": { "type": "string", "description": "知识网络 ID" },
-      "metric_id": { "type": "string", "description": "指标 ID" },
+      "kn_id": {
+        "type": "string",
+        "description": "知识网络 ID"
+      },
+      "metric_id": {
+        "type": "string",
+        "description": "指标 ID"
+      },
       "datas": {
         "type": "array",
         "description": "按 labels 分组的结果序列。未传 analysis_dimensions 时通常只有一条，labels 为空。",
         "items": {
           "type": "object",
           "properties": {
-            "labels": { "type": "object", "additionalProperties": true, "description": "该序列对应的维度取值" },
-            "times": { "type": "array", "items": {}, "description": "时间点（unix 秒）" },
-            "time_strs": { "type": "array", "items": { "type": "string" }, "description": "时间点的可读形式" },
-            "values": { "type": "array", "items": {}, "description": "与 times 一一对应的指标值" },
-            "growth_values": { "type": "array", "items": {} },
-            "growth_rates": { "type": "array", "items": {} },
-            "proportions": { "type": "array", "items": {} }
+            "labels": {
+              "type": "object",
+              "additionalProperties": true,
+              "description": "该序列对应的维度取值"
+            },
+            "times": {
+              "type": "array",
+              "items": {},
+              "description": "时间点（unix 秒）"
+            },
+            "time_strs": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "description": "时间点的可读形式"
+            },
+            "values": {
+              "type": "array",
+              "items": {},
+              "description": "与 times 一一对应的指标值"
+            },
+            "growth_values": {
+              "type": "array",
+              "items": {}
+            },
+            "growth_rates": {
+              "type": "array",
+              "items": {}
+            },
+            "proportions": {
+              "type": "array",
+              "items": {}
+            }
           }
         }
       },
-      "overall_ms": { "type": "integer", "description": "耗时（毫秒）" }
+      "overall_ms": {
+        "type": "integer",
+        "description": "耗时（毫秒）"
+      }
     }
   }
 }

--- a/adp/context-loader/agent-retrieval/server/driveradapters/mcp/schemas/query_metric.json
+++ b/adp/context-loader/agent-retrieval/server/driveradapters/mcp/schemas/query_metric.json
@@ -1,0 +1,98 @@
+{
+  "input_schema": {
+    "type": "object",
+    "properties": {
+      "response_format": {
+        "type": "string",
+        "enum": ["json", "toon"],
+        "default": "toon",
+        "description": "文本格式：json 或 toon，默认 toon"
+      },
+      "kn_id": {
+        "type": "string",
+        "description": "知识网络 ID。也可改用 X-Kn-ID 请求头传入。"
+      },
+      "metric_id": {
+        "type": "string",
+        "description": "指标 ID，取自 get_object_types 返回的 related_metrics[].id。不要自己编造。"
+      },
+      "time": {
+        "type": "object",
+        "description": "时间窗。指标无时间维度（related_metrics[].time_dimension 为空）时可整体省略。",
+        "properties": {
+          "instant": {
+            "type": "boolean",
+            "description": "true=取单点（当前值），此时不得传 step；false=取序列，此时必须传 step。"
+          },
+          "start": { "type": "integer", "description": "起始时间，unix 秒" },
+          "end": { "type": "integer", "description": "结束时间，unix 秒" },
+          "step": {
+            "type": "string",
+            "enum": ["day", "week", "month", "quarter", "year"],
+            "description": "序列步长，仅 instant=false 时传"
+          }
+        }
+      },
+      "condition": {
+        "type": "object",
+        "additionalProperties": true,
+        "description": "过滤条件，结构与 query_object_instance 的 condition 一致（field / operation / value / value_from，可 and/or 嵌套）。"
+      },
+      "analysis_dimensions": {
+        "type": "array",
+        "items": { "type": "string" },
+        "description": "分析维度（按维度拆分结果），取值必须来自 related_metrics[].analysis_dimensions。"
+      },
+      "order_by": {
+        "type": "array",
+        "description": "结果排序",
+        "items": {
+          "type": "object",
+          "properties": {
+            "property": { "type": "string" },
+            "direction": { "type": "string", "enum": ["asc", "desc"] }
+          }
+        }
+      },
+      "having": {
+        "type": "object",
+        "description": "对聚合结果过滤",
+        "properties": {
+          "field": { "type": "string" },
+          "operation": { "type": "string" },
+          "value": {}
+        }
+      },
+      "limit": { "type": "integer", "description": "返回条数上限" },
+      "fill_null": {
+        "type": "boolean",
+        "description": "区间查询时，无数据的步长点是否补空，默认 false"
+      }
+    },
+    "required": ["kn_id", "metric_id"]
+  },
+  "output_schema": {
+    "type": "object",
+    "properties": {
+      "kn_id": { "type": "string", "description": "知识网络 ID" },
+      "metric_id": { "type": "string", "description": "指标 ID" },
+      "datas": {
+        "type": "array",
+        "description": "按 labels 分组的结果序列。未传 analysis_dimensions 时通常只有一条，labels 为空。",
+        "items": {
+          "type": "object",
+          "properties": {
+            "labels": { "type": "object", "additionalProperties": true, "description": "该序列对应的维度取值" },
+            "times": { "type": "array", "items": {}, "description": "时间点（unix 秒）" },
+            "time_strs": { "type": "array", "items": { "type": "string" }, "description": "时间点的可读形式" },
+            "values": { "type": "array", "items": {}, "description": "与 times 一一对应的指标值" },
+            "growth_values": { "type": "array", "items": {} },
+            "growth_rates": { "type": "array", "items": {} },
+            "proportions": { "type": "array", "items": {} }
+          }
+        }
+      },
+      "overall_ms": { "type": "integer", "description": "耗时（毫秒）" }
+    }
+  }
+}

--- a/adp/context-loader/agent-retrieval/server/driveradapters/mcp/schemas/tools_meta.json
+++ b/adp/context-loader/agent-retrieval/server/driveradapters/mcp/schemas/tools_meta.json
@@ -25,7 +25,7 @@
   },
   "query_metric": {
     "name": "query_metric",
-    "description": "按已建模指标的口径取数（OT-first 路径第 3 步）。先 search_schema / get_kn_detail 锁定对象类，再 get_object_types 从 related_metrics 里选定 metric_id，最后调本工具计算——口径写在 MetricDefinition 里，别用 run_sql 自己重写。分流：实例级且已绑逻辑属性的走 get_logic_properties_values；类级、或未绑逻辑属性的走本工具。可选 condition 过滤、analysis_dimensions 拆维、time 取单点或序列。"
+    "description": "按已建模指标的口径取数（OT-first 路径第 3 步）。先 search_schema / get_kn_detail 锁定对象类，再 get_object_types 从 related_metrics 里选定 metric_id，最后调本工具计算——口径写在 MetricDefinition 里，别用 run_sql 自己重写。分流：实例级且已绑逻辑属性的走 get_logic_properties_values；类级、或未绑逻辑属性的走本工具。可选 condition 过滤、analysis_dimensions 拆维、time 取单点或序列。时间窗规则：省略 instant 等同于序列查询，必须给 step；start 与 end 要么都给要么都不给。"
   },
   "get_action_info": {
     "name": "get_action_info",

--- a/adp/context-loader/agent-retrieval/server/driveradapters/mcp/schemas/tools_meta.json
+++ b/adp/context-loader/agent-retrieval/server/driveradapters/mcp/schemas/tools_meta.json
@@ -9,7 +9,7 @@
   },
   "search_schema": {
     "name": "search_schema",
-    "description": "统一的 Schema 探索入口。根据 query 返回相关 object_types、relation_types、action_types、metric_types，供 query_*、find_*、get_* 工具继续消费。默认返回精简 Schema（schema_brief=true：保留 data_source.id 与属性 name/type/condition_operations，省约 70%），够规划查询；需要属性备注/主键/标签的完整 Schema 时传 schema_brief=false。"
+    "description": "统一的 Schema 探索入口，先锁定对象类（object_types）。根据 query 返回相关 object_types、relation_types、action_types、metric_types，供 query_*、find_*、get_* 工具继续消费；其中 metric_types 只是辅助线索，指标的权威清单以 get_object_types 返回的 related_metrics 为准（按对象类 scope 全量枚举）。默认返回精简 Schema（schema_brief=true：保留 data_source.id 与属性 name/type/condition_operations，省约 70%），够规划查询；需要属性备注/主键/标签的完整 Schema 时传 schema_brief=false。"
   },
   "query_object_instance": {
     "name": "query_object_instance",
@@ -21,7 +21,11 @@
   },
   "get_logic_properties_values": {
     "name": "get_logic_properties_values",
-    "description": "逻辑属性解析（指标/算子）。针对实例批量计算逻辑属性值。"
+    "description": "逻辑属性解析（指标/算子）。针对实例批量计算已绑逻辑属性的值——指标路径里对应「实例级 + 已绑 logic property」这一支；类级指标、或未绑逻辑属性的指标改调 query_metric。"
+  },
+  "query_metric": {
+    "name": "query_metric",
+    "description": "按已建模指标的口径取数（OT-first 路径第 3 步）。先 search_schema / get_kn_detail 锁定对象类，再 get_object_types 从 related_metrics 里选定 metric_id，最后调本工具计算——口径写在 MetricDefinition 里，别用 run_sql 自己重写。分流：实例级且已绑逻辑属性的走 get_logic_properties_values；类级、或未绑逻辑属性的走本工具。可选 condition 过滤、analysis_dimensions 拆维、time 取单点或序列。"
   },
   "get_action_info": {
     "name": "get_action_info",
@@ -49,11 +53,11 @@
   },
   "get_kn_detail": {
     "name": "get_kn_detail",
-    "description": "获取知识网络 schema（概念组、对象类型含 data_source.id、关系类型、行动类型）。默认 detail_level=summary：返回骨架 + 每个属性仅 name+type（不含 display_name/comment/字段映射/查询算子/映射规则）——足够理解结构与规划查询，体积小。需要某对象的完整字段映射（含 comment）时调 get_object_types，需要关系的 mapping_rules 时调 get_relation_types。detail_level=full 一次拿全量（体积大，慎用）。"
+    "description": "获取知识网络 schema（概念组、对象类型含 data_source.id、关系类型、行动类型）。默认 detail_level=summary：返回骨架 + 每个属性仅 name+type（不含 display_name/comment/字段映射/查询算子/映射规则）——足够理解结构与规划查询，体积小。需要某对象的完整字段映射（含 comment）时调 get_object_types，需要关系的 mapping_rules 时调 get_relation_types。detail_level=full 一次拿全量（体积大，慎用）。对象类条目附带 related_metric_count（该对象类下已建模指标数），用来判断是否值得下钻取指标。"
   },
   "get_object_types": {
     "name": "get_object_types",
-    "description": "按 id 批量取对象类的完整定义（data_properties 含 mapped_field/condition_operations，logic_properties 含 data_source/parameters）。渐进式下钻用：先 get_kn_detail（summary）拿对象 id，再用本工具展开需要的对象。ids 支持多个，一次取回；未匹配的 id 会在 missing 返回。"
+    "description": "按 id 批量取对象类的完整定义（data_properties 含 mapped_field/condition_operations，logic_properties 含 data_source/parameters），并返回该对象类下可用的指标 related_metrics（scope_type=object_type 且 scope_ref=对象类 id，含未绑逻辑属性的指标）。渐进式下钻用：先 get_kn_detail（summary）拿对象 id，再用本工具展开需要的对象。选定指标后：实例级且已绑逻辑属性走 get_logic_properties_values，类级或未绑的走 query_metric。ids 支持多个，一次取回；未匹配的 id 会在 missing 返回。"
   },
   "get_relation_types": {
     "name": "get_relation_types",
@@ -61,7 +65,7 @@
   },
   "run_sql": {
     "name": "run_sql",
-    "description": "对知识网络挂载的数据资源执行只读 SQL（Trino 方言）。表名用占位符 {{.resource_id}} 引用；vega 会解析成真实表并限量。仅允许单条 SELECT：支持同一 catalog 内的 JOIN、WHERE、GROUP BY/HAVING、ORDER BY、LIMIT 和常用聚合函数；不支持 WITH/CTE、UNION/INTERSECT/EXCEPT、多语句、写入/DDL 和跨目录 join，子查询与窗口函数不在兼容性承诺内。两种拿 resource_id + 物理列的方式：本体路 search_schema（对象类 data_source.id + data_property.column），数据层路 list_resources → describe_resource（直查裸资源，脱离本体）。"
+    "description": "对知识网络挂载的数据资源执行只读 SQL（Trino 方言）。注意：已建模指标不要用 SQL 重写口径——指标走 get_object_types 选定后的 query_metric / get_logic_properties_values；run_sql 用于未建成指标的即席聚合与跨表统计。表名用占位符 {{.resource_id}} 引用；vega 会解析成真实表并限量。仅允许单条 SELECT：支持同一 catalog 内的 JOIN、WHERE、GROUP BY/HAVING、ORDER BY、LIMIT 和常用聚合函数；不支持 WITH/CTE、UNION/INTERSECT/EXCEPT、多语句、写入/DDL 和跨目录 join，子查询与窗口函数不在兼容性承诺内。两种拿 resource_id + 物理列的方式：本体路 search_schema（对象类 data_source.id + data_property.column），数据层路 list_resources → describe_resource（直查裸资源，脱离本体）。"
   },
   "list_resources": {
     "name": "list_resources",

--- a/adp/context-loader/agent-retrieval/server/driveradapters/mcp/tools.go
+++ b/adp/context-loader/agent-retrieval/server/driveradapters/mcp/tools.go
@@ -18,6 +18,7 @@ import (
 	"github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/infra/common"
 	"github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/infra/rest"
 	"github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/interfaces"
+	"github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/logics/knmetrics"
 	logicsKqs "github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/logics/knquerysubgraph"
 	"github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/logics/knresources"
 	"github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/logics/knrunsql"
@@ -470,7 +471,7 @@ func handleDescribeResource(svc knresources.KnResourcesService) func(ctx context
 // handleGetKnDetail handles get_kn_detail tool calls.
 // 包装 bkn-backend 的知识网络详情（概念组 / 对象类 / 关系类 / 行动类），并按
 // detail_level 做渐进式裁剪：summary（默认）返回骨架 + 属性名，full 返回全量。
-func handleGetKnDetail(bkn interfaces.BknBackendAccess) func(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+func handleGetKnDetail(bkn interfaces.BknBackendAccess, metrics knmetrics.KnMetricsService) func(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 	return func(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 		format, err := GetResponseFormatFromRequest(req)
 		if err != nil {
@@ -489,6 +490,9 @@ func handleGetKnDetail(bkn interfaces.BknBackendAccess) func(ctx context.Context
 		if err != nil {
 			return mcp.NewToolResultError(err.Error()), nil
 		}
+		// Counts only: which object types have metrics worth drilling into, without
+		// carrying the metric list itself at this level.
+		metrics.AttachRelatedMetricCounts(ctx, knID, resp.ObjectTypes)
 		resp.Slim(getStringArg(req, "detail_level", interfaces.DetailLevelSummary))
 		result, err := BuildMCPToolResult(resp, format)
 		if err != nil {
@@ -514,8 +518,9 @@ func (a *knDrillArgs) resolveKnID(req mcp.CallToolRequest) string {
 
 // handleGetObjectTypes handles get_object_types tool calls: return the full
 // definition (data/logic properties incl. mappings) of the requested object type
-// ids. Pairs with get_kn_detail summary, which omits that heavy detail.
-func handleGetObjectTypes(bkn interfaces.BknBackendAccess) func(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+// ids, plus the metrics scoped to them. Pairs with get_kn_detail summary, which
+// omits that heavy detail.
+func handleGetObjectTypes(bkn interfaces.BknBackendAccess, metrics knmetrics.KnMetricsService) func(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 	return func(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 		format, err := GetResponseFormatFromRequest(req)
 		if err != nil {
@@ -538,6 +543,9 @@ func handleGetObjectTypes(bkn interfaces.BknBackendAccess) func(ctx context.Cont
 			return mcp.NewToolResultError(err.Error()), nil
 		}
 		matched, missing := detail.FilterObjectTypes(args.IDs)
+		// Step 2 of the OT-first metric path: a metric that is not bound to a logic
+		// property is unreachable from the object type without this.
+		metrics.AttachRelatedMetrics(ctx, knID, matched)
 		bkntrace.EmitSchemaDefinitionEvents(ctx, nil, "object", knID, args.IDs, len(matched))
 		resp := &interfaces.ObjectTypesResp{KnID: knID, ObjectTypes: matched, Missing: missing}
 		result, err := BuildMCPToolResult(resp, format)
@@ -653,6 +661,39 @@ func handleFindSkills(service interfaces.IFindSkillsService) func(ctx context.Co
 			return mcp.NewToolResultError(err.Error()), nil
 		}
 
+		result, err := BuildMCPToolResult(resp, format)
+		if err != nil {
+			return mcp.NewToolResultError(err.Error()), nil
+		}
+		return result, nil
+	}
+}
+
+// handleQueryMetric handles query_metric tool calls: compute one modelled metric
+// by its own definition.
+//
+// This is step 3 of the OT-first metric path and the reason run_sql is not the
+// answer for a metric: the calculation formula lives in the MetricDefinition, so
+// the caller names the metric instead of re-deriving it in SQL.
+func handleQueryMetric(service knmetrics.KnMetricsService) func(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	return func(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		format, err := GetResponseFormatFromRequest(req)
+		if err != nil {
+			return mcp.NewToolResultError(err.Error()), nil
+		}
+
+		args := &interfaces.QueryMetricReq{}
+		if err := bindArguments(req, args); err != nil {
+			return mcp.NewToolResultError(err.Error()), nil
+		}
+		if args.KnID == "" {
+			args.KnID = getKnIDFromHeader(req)
+		}
+
+		resp, err := service.QueryMetric(ctx, args)
+		if err != nil {
+			return mcp.NewToolResultError(err.Error()), nil
+		}
 		result, err := BuildMCPToolResult(resp, format)
 		if err != nil {
 			return mcp.NewToolResultError(err.Error()), nil

--- a/adp/context-loader/agent-retrieval/server/driveradapters/mcp/tools_field_reduction_test.go
+++ b/adp/context-loader/agent-retrieval/server/driveradapters/mcp/tools_field_reduction_test.go
@@ -61,6 +61,11 @@ func (s *stubOntologyQuery) ListActionExecutions(_ context.Context, _ *interface
 	return nil, nil
 }
 
+func (s *stubOntologyQuery) QueryMetricData(_ context.Context, _, _ string, _ bool,
+	_ *interfaces.MetricQueryDownstreamReq) (*interfaces.MetricQueryDownstreamResp, error) {
+	return nil, nil
+}
+
 func (s *stubOntologyQuery) QueryInstanceSubgraph(_ context.Context, _ *interfaces.QueryInstanceSubgraphReq) (*interfaces.QueryInstanceSubgraphResp, error) {
 	return nil, nil
 }

--- a/adp/context-loader/agent-retrieval/server/driveradapters/mcp/tools_metric_test.go
+++ b/adp/context-loader/agent-retrieval/server/driveradapters/mcp/tools_metric_test.go
@@ -1,0 +1,108 @@
+// Copyright openbkn.ai
+//
+// Licensed under the OpenBKN License. See LICENSE-OPENBKN.txt in the project root.
+
+package mcp
+
+import (
+	"context"
+	"testing"
+
+	"github.com/smartystreets/goconvey/convey"
+
+	"github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/interfaces"
+	"github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/logics/knmetrics"
+)
+
+// stubMetricBknBackend serves one knowledge-network detail and the metrics scoped
+// to its object types.
+type stubMetricBknBackend struct {
+	interfaces.BknBackendAccess
+	detail  *interfaces.KnowledgeNetworkDetail
+	metrics []*interfaces.RelatedMetric
+}
+
+func (s *stubMetricBknBackend) GetKnowledgeNetworkDetail(_ context.Context, _ string) (*interfaces.KnowledgeNetworkDetail, error) {
+	return s.detail, nil
+}
+
+func (s *stubMetricBknBackend) ListMetricsByObjectTypes(_ context.Context, _ string, _ []string) ([]*interfaces.RelatedMetric, error) {
+	return s.metrics, nil
+}
+
+type stubMetricOntologyQuery struct {
+	interfaces.DrivenOntologyQuery
+	resp      *interfaces.MetricQueryDownstreamResp
+	gotMetric string
+}
+
+func (s *stubMetricOntologyQuery) QueryMetricData(_ context.Context, _, metricID string, _ bool,
+	_ *interfaces.MetricQueryDownstreamReq) (*interfaces.MetricQueryDownstreamResp, error) {
+	s.gotMetric = metricID
+	return s.resp, nil
+}
+
+func TestHandleGetObjectTypes_AdvertisesScopedMetrics(t *testing.T) {
+	convey.Convey("get_object_types 带出该对象类下的指标（含未绑逻辑属性的）", t, func() {
+		bkn := &stubMetricBknBackend{
+			detail: &interfaces.KnowledgeNetworkDetail{
+				ID:          "kn-001",
+				ObjectTypes: []*interfaces.ObjectType{{ID: "ot-001", Name: "产品"}},
+			},
+			metrics: []*interfaces.RelatedMetric{
+				{ID: "m-001", Name: "产品总数", ScopeRef: "ot-001", MetricType: "atomic"},
+			},
+		}
+		handler := handleGetObjectTypes(bkn, knmetrics.NewKnMetricsServiceWith(nil, bkn, nil))
+
+		result, err := handler(context.Background(), mcpReq(map[string]any{
+			"kn_id":           "kn-001",
+			"ids":             []any{"ot-001"},
+			"response_format": "json",
+		}))
+
+		convey.So(err, convey.ShouldBeNil)
+		convey.So(result.IsError, convey.ShouldBeFalse)
+
+		m := resultToMap(t, result)
+		objectTypes := m["object_types"].([]any)
+		first := objectTypes[0].(map[string]any)
+		related := first["related_metrics"].([]any)
+		convey.So(len(related), convey.ShouldEqual, 1)
+		convey.So(related[0].(map[string]any)["id"], convey.ShouldEqual, "m-001")
+	})
+}
+
+func TestHandleQueryMetric(t *testing.T) {
+	convey.Convey("query_metric 按 metric_id 取数", t, func() {
+		oq := &stubMetricOntologyQuery{resp: &interfaces.MetricQueryDownstreamResp{
+			Datas: []*interfaces.MetricDataSeries{{Values: []any{431}}},
+		}}
+		handler := handleQueryMetric(knmetrics.NewKnMetricsServiceWith(nil, nil, oq))
+
+		result, err := handler(context.Background(), mcpReq(map[string]any{
+			"kn_id":           "kn-001",
+			"metric_id":       "m-001",
+			"response_format": "json",
+		}))
+
+		convey.So(err, convey.ShouldBeNil)
+		convey.So(result.IsError, convey.ShouldBeFalse)
+		convey.So(oq.gotMetric, convey.ShouldEqual, "m-001")
+
+		m := resultToMap(t, result)
+		convey.So(m["metric_id"], convey.ShouldEqual, "m-001")
+		convey.So(len(m["datas"].([]any)), convey.ShouldEqual, 1)
+	})
+
+	convey.Convey("缺 metric_id 回错误而不是打下游", t, func() {
+		oq := &stubMetricOntologyQuery{}
+		handler := handleQueryMetric(knmetrics.NewKnMetricsServiceWith(nil, nil, oq))
+
+		result, err := handler(context.Background(), mcpReq(map[string]any{"kn_id": "kn-001"}))
+
+		convey.So(err, convey.ShouldBeNil)
+		convey.So(result.IsError, convey.ShouldBeTrue)
+		convey.So(oq.gotMetric, convey.ShouldBeEmpty)
+	})
+}

--- a/adp/context-loader/agent-retrieval/server/driveradapters/middleware_test.go
+++ b/adp/context-loader/agent-retrieval/server/driveradapters/middleware_test.go
@@ -237,6 +237,7 @@ func (stubKnQueryToolsHandler) ListKnowledgeNetworks(c *gin.Context) { c.Status(
 func (stubKnQueryToolsHandler) GetKnDetail(c *gin.Context)           { c.Status(http.StatusOK) }
 func (stubKnQueryToolsHandler) GetObjectTypes(c *gin.Context)        { c.Status(http.StatusOK) }
 func (stubKnQueryToolsHandler) GetRelationTypes(c *gin.Context)      { c.Status(http.StatusOK) }
+func (stubKnQueryToolsHandler) QueryMetric(c *gin.Context)           { c.Status(http.StatusOK) }
 func (stubKnQueryToolsHandler) ListResources(c *gin.Context)         { c.Status(http.StatusOK) }
 func (stubKnQueryToolsHandler) DescribeResource(c *gin.Context)      { c.Status(http.StatusOK) }
 

--- a/adp/context-loader/agent-retrieval/server/driveradapters/rest_private_handler.go
+++ b/adp/context-loader/agent-retrieval/server/driveradapters/rest_private_handler.go
@@ -80,6 +80,7 @@ func (r *restPrivateHandler) RegisterRouter(engine *gin.RouterGroup) {
 	engine.POST("/kn/get_kn_detail", r.KnQueryToolsHandler.GetKnDetail)
 	engine.POST("/kn/get_object_types", r.KnQueryToolsHandler.GetObjectTypes)
 	engine.POST("/kn/get_relation_types", r.KnQueryToolsHandler.GetRelationTypes)
+	engine.POST("/kn/query_metric", r.KnQueryToolsHandler.QueryMetric)
 	engine.POST("/kn/list_resources", r.KnQueryToolsHandler.ListResources)
 	engine.POST("/kn/describe_resource", r.KnQueryToolsHandler.DescribeResource)
 

--- a/adp/context-loader/agent-retrieval/server/driveradapters/rest_public_handler.go
+++ b/adp/context-loader/agent-retrieval/server/driveradapters/rest_public_handler.go
@@ -85,6 +85,7 @@ func (r *restPublicHandler) RegisterRouter(engine *gin.RouterGroup) {
 	engine.POST("/kn/get_kn_detail", r.KnQueryToolsHandler.GetKnDetail)
 	engine.POST("/kn/get_object_types", r.KnQueryToolsHandler.GetObjectTypes)
 	engine.POST("/kn/get_relation_types", r.KnQueryToolsHandler.GetRelationTypes)
+	engine.POST("/kn/query_metric", r.KnQueryToolsHandler.QueryMetric)
 	engine.POST("/kn/list_resources", r.KnQueryToolsHandler.ListResources)
 	engine.POST("/kn/describe_resource", r.KnQueryToolsHandler.DescribeResource)
 

--- a/adp/context-loader/agent-retrieval/server/interfaces/driven_bkn_backend.go
+++ b/adp/context-loader/agent-retrieval/server/interfaces/driven_bkn_backend.go
@@ -110,6 +110,37 @@ type ObjectType struct {
 	DataProperties  []*DataProperty     `json:"data_properties,omitempty"`  // Data properties
 	LogicProperties []*LogicPropertyDef `json:"logic_properties,omitempty"` // Logic properties
 	PrimaryKeys     []string            `json:"primary_keys"`               // Primary key fields
+
+	// RelatedMetrics are the metrics scoped to this object type (scope_type=object_type,
+	// scope_ref=<this id>). It is filled by get_object_types only: a metric that is not
+	// bound to a logic property is invisible from the object type otherwise, which is
+	// what leaves an agent with no way to reach it except run_sql.
+	RelatedMetrics []*RelatedMetric `json:"related_metrics,omitempty"`
+	// RelatedMetricCount is the same information one number wide, for the get_kn_detail
+	// summary: enough to decide whether drilling into this object type is worth it.
+	RelatedMetricCount int `json:"related_metric_count,omitempty"`
+}
+
+// RelatedMetric is one metric scoped to an object type, as advertised on that object
+// type by get_object_types.
+//
+// It carries what an agent needs to *choose* a metric — what it measures, in which
+// unit, sliceable by which dimensions — and stops there. The calculation formula is
+// deliberately absent: the whole point of query_metric is that the agent does not
+// reimplement the formula, it names the metric and lets ontology-query apply it.
+type RelatedMetric struct {
+	ID                 string   `json:"id"`
+	Name               string   `json:"name"`
+	Comment            string   `json:"comment,omitempty"`
+	MetricType         string   `json:"metric_type,omitempty"`
+	Unit               string   `json:"unit,omitempty"`
+	UnitType           string   `json:"unit_type,omitempty"`
+	ScopeRef           string   `json:"scope_ref,omitempty"`
+	AnalysisDimensions []string `json:"analysis_dimensions,omitempty"`
+	// TimeDimension is the property the metric is measured over, empty when the
+	// metric has none. An agent reads it to know whether a range query (instant=false
+	// with a step) is meaningful at all.
+	TimeDimension string `json:"time_dimension,omitempty"`
 }
 
 // RelationType Relation type structure definition
@@ -467,4 +498,13 @@ type BknBackendAccess interface {
 
 	// SearchMetricTypes Search metric types
 	SearchMetricTypes(ctx context.Context, query *QueryConceptsReq) (metricTypes *MetricTypeConcepts, err error)
+
+	// ListMetricsByObjectTypes enumerates the metrics scoped to the given object types.
+	//
+	// It is deliberately not SearchMetricTypes: that one is a semantic recall over the
+	// concept index and answers "which metrics look relevant to this question", which
+	// is both ranked and only as fresh as the index. Advertising the metrics of an
+	// object type has to be exhaustive and authoritative, so this reads the metric
+	// registry itself.
+	ListMetricsByObjectTypes(ctx context.Context, knID string, otIDs []string) ([]*RelatedMetric, error)
 }

--- a/adp/context-loader/agent-retrieval/server/interfaces/driven_ontology_query.go
+++ b/adp/context-loader/agent-retrieval/server/interfaces/driven_ontology_query.go
@@ -162,4 +162,8 @@ type DrivenOntologyQuery interface {
 	ListActionExecutions(ctx context.Context, req *ListActionExecutionsRequest) (resp map[string]any, err error)
 	// QueryInstanceSubgraph queries object subgraph
 	QueryInstanceSubgraph(ctx context.Context, req *QueryInstanceSubgraphReq) (resp *QueryInstanceSubgraphResp, err error)
+	// QueryMetricData computes one metric by its own definition
+	// (POST .../metrics/{metric_id}/data)
+	QueryMetricData(ctx context.Context, knID, metricID string, fillNull bool,
+		req *MetricQueryDownstreamReq) (resp *MetricQueryDownstreamResp, err error)
 }

--- a/adp/context-loader/agent-retrieval/server/interfaces/kn_metric_query.go
+++ b/adp/context-loader/agent-retrieval/server/interfaces/kn_metric_query.go
@@ -1,0 +1,97 @@
+// Copyright openbkn.ai
+//
+// Licensed under the OpenBKN License. See LICENSE-OPENBKN.txt in the project root.
+
+package interfaces
+
+// Metric query is the third step of the OT-first metric path: an object type has
+// been recalled, a metric of that object type has been chosen from
+// get_object_types' related_metrics, and now it is computed — by its own
+// definition, in ontology-query, rather than re-derived in SQL.
+//
+// The request mirrors ontology-query's MetricQueryRequestBody
+// (POST .../metrics/{metric_id}/data) so nothing is lost in translation.
+
+// QueryMetricReq is the query_metric request.
+type QueryMetricReq struct {
+	KnID     string `json:"kn_id" form:"kn_id"`
+	MetricID string `json:"metric_id" form:"metric_id"`
+
+	Time               *MetricTimeWindow `json:"time,omitempty"`
+	Cond               *KnCondition      `json:"condition,omitempty"`
+	AnalysisDimensions []string          `json:"analysis_dimensions,omitempty"`
+	OrderBy            []*MetricOrderBy  `json:"order_by,omitempty"`
+	Having             *MetricHaving     `json:"having,omitempty"`
+	Limit              *int              `json:"limit,omitempty"`
+	// FillNull pads the steps of a range query that produced no data point.
+	// Sent as a URL query parameter, exactly as ontology-query expects it.
+	FillNull bool `json:"fill_null,omitempty"`
+}
+
+// MetricTimeWindow is the time block of a metric query.
+//
+// Instant=true asks for one point (a "how much is it now" question) and takes no
+// step; Instant=false asks for a series and requires one. Start/End are unix
+// timestamps in seconds.
+type MetricTimeWindow struct {
+	Start   *int64  `json:"start,omitempty"`
+	End     *int64  `json:"end,omitempty"`
+	Instant *bool   `json:"instant,omitempty"`
+	Step    *string `json:"step,omitempty"`
+}
+
+// MetricOrderBy is one ordering entry of a metric query.
+type MetricOrderBy struct {
+	Property  string `json:"property"`
+	Direction string `json:"direction"`
+}
+
+// MetricHaving filters the aggregated result of a metric query.
+type MetricHaving struct {
+	Field     string `json:"field"`
+	Operation string `json:"operation"`
+	Value     any    `json:"value,omitempty"`
+}
+
+// QueryMetricResp is the query_metric response.
+//
+// It carries the computed series and nothing else: ontology-query also echoes the
+// metric definition back under "model", which is the same formula the caller just
+// read from related_metrics, and repeating it in every data response is exactly
+// the kind of payload this tool surface trims elsewhere.
+type QueryMetricResp struct {
+	KnID      string              `json:"kn_id"`
+	MetricID  string              `json:"metric_id"`
+	Datas     []*MetricDataSeries `json:"datas"`
+	OverallMs int64               `json:"overall_ms,omitempty"`
+}
+
+// MetricDataSeries is one labelled series of a metric result, matching
+// ontology-query's BknMetricData.
+type MetricDataSeries struct {
+	Labels       map[string]string `json:"labels,omitempty"`
+	Times        []any             `json:"times,omitempty"`
+	TimeStrs     []string          `json:"time_strs,omitempty"`
+	Values       []any             `json:"values"`
+	GrowthValues []any             `json:"growth_values,omitempty"`
+	GrowthRates  []any             `json:"growth_rates,omitempty"`
+	Proportions  []any             `json:"proportions,omitempty"`
+}
+
+// MetricQueryDownstreamReq is what goes on the wire to ontology-query: the request
+// without the routing fields that live in the URL.
+type MetricQueryDownstreamReq struct {
+	Time               *MetricTimeWindow `json:"time,omitempty"`
+	Cond               *KnCondition      `json:"condition,omitempty"`
+	AnalysisDimensions []string          `json:"analysis_dimensions,omitempty"`
+	OrderBy            []*MetricOrderBy  `json:"order_by,omitempty"`
+	Having             *MetricHaving     `json:"having,omitempty"`
+	Limit              *int              `json:"limit,omitempty"`
+}
+
+// MetricQueryDownstreamResp is ontology-query's MetricResponse, of which only the
+// series are forwarded.
+type MetricQueryDownstreamResp struct {
+	Datas     []*MetricDataSeries `json:"datas"`
+	OverallMs int64               `json:"overall_ms,omitempty"`
+}

--- a/adp/context-loader/agent-retrieval/server/logics/knfindskills/mock_test.go
+++ b/adp/context-loader/agent-retrieval/server/logics/knfindskills/mock_test.go
@@ -75,6 +75,10 @@ func (m *testBknBackend) SearchActionTypes(ctx context.Context, query *interface
 	return nil, nil
 }
 
+func (m *testBknBackend) ListMetricsByObjectTypes(ctx context.Context, knID string, otIDs []string) ([]*interfaces.RelatedMetric, error) {
+	return nil, nil
+}
+
 func (m *testBknBackend) SearchMetricTypes(ctx context.Context, query *interfaces.QueryConceptsReq) (*interfaces.MetricTypeConcepts, error) {
 	return nil, nil
 }
@@ -95,6 +99,11 @@ func (m *testOntologyQuery) QueryObjectInstances(ctx context.Context, req *inter
 		return m.queryObjectInstancesFunc(ctx, req)
 	}
 	return &interfaces.QueryObjectInstancesResp{}, nil
+}
+
+func (m *testOntologyQuery) QueryMetricData(ctx context.Context, knID, metricID string, fillNull bool,
+	req *interfaces.MetricQueryDownstreamReq) (*interfaces.MetricQueryDownstreamResp, error) {
+	return &interfaces.MetricQueryDownstreamResp{}, nil
 }
 
 func (m *testOntologyQuery) QueryInstanceSubgraph(ctx context.Context, req *interfaces.QueryInstanceSubgraphReq) (*interfaces.QueryInstanceSubgraphResp, error) {

--- a/adp/context-loader/agent-retrieval/server/logics/knmetrics/index.go
+++ b/adp/context-loader/agent-retrieval/server/logics/knmetrics/index.go
@@ -1,0 +1,214 @@
+// Copyright openbkn.ai
+//
+// Licensed under the OpenBKN License. See LICENSE-OPENBKN.txt in the project root.
+
+// Package knmetrics 承载 OT-first 指标路径的第 2、3 步：
+//
+//	召回对象类 → 在该对象类下看见可用指标 → 按指标自身口径取数
+//
+// 第 2 步是 AttachRelatedMetrics：把 scope_type=object_type 且 scope_ref=<ot_id> 的
+// 指标挂到对象类上。未绑逻辑属性的指标在对象类上本来完全不可见，Agent 因此只能退化成
+// run_sql 自己重写口径。
+//
+// 第 3 步是 QueryMetric：选定指标后交给 ontology-query 按 MetricDefinition 计算。
+// 实例级、且已绑逻辑属性的那一支仍走 get_logic_properties_values，不在本包。
+package knmetrics
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"sync"
+
+	"github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/drivenadapters"
+	"github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/infra/config"
+	"github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/interfaces"
+)
+
+// 指标查询入参错误。均为调用方错误，直接回给 Agent 让它改参数重试。
+var (
+	ErrKnIDRequired     = errors.New("kn_id is required")
+	ErrMetricIDRequired = errors.New("metric_id is required (from get_object_types related_metrics)")
+)
+
+// 步长白名单，与 MetricDefinition 支持的粒度一致。
+var validSteps = map[string]struct{}{
+	"day": {}, "week": {}, "month": {}, "quarter": {}, "year": {},
+}
+
+// KnMetricsService 指标可见性与指标取数。
+type KnMetricsService interface {
+	// AttachRelatedMetrics 给对象类挂上其 scope 下的指标（失败降级为不挂）。
+	AttachRelatedMetrics(ctx context.Context, knID string, objectTypes []*interfaces.ObjectType)
+	// AttachRelatedMetricCounts 只挂计数，用于 get_kn_detail 的渐进式下钻。
+	AttachRelatedMetricCounts(ctx context.Context, knID string, objectTypes []*interfaces.ObjectType)
+	// QueryMetric 按指标自身口径取数。
+	QueryMetric(ctx context.Context, req *interfaces.QueryMetricReq) (*interfaces.QueryMetricResp, error)
+}
+
+type knMetricsService struct {
+	logger        interfaces.Logger
+	bknBackend    interfaces.BknBackendAccess
+	ontologyQuery interfaces.DrivenOntologyQuery
+}
+
+var (
+	once     sync.Once
+	instance KnMetricsService
+)
+
+// NewKnMetricsService 创建 KnMetricsService 单例。
+func NewKnMetricsService() KnMetricsService {
+	once.Do(func() {
+		conf := config.NewConfigLoader()
+		instance = &knMetricsService{
+			logger:        conf.GetLogger(),
+			bknBackend:    drivenadapters.NewBknBackendAccess(),
+			ontologyQuery: drivenadapters.NewOntologyQueryAccess(),
+		}
+	})
+	return instance
+}
+
+// NewKnMetricsServiceWith 注入依赖创建（测试用）。
+func NewKnMetricsServiceWith(logger interfaces.Logger, bkn interfaces.BknBackendAccess,
+	oq interfaces.DrivenOntologyQuery) KnMetricsService {
+	return &knMetricsService{logger: logger, bknBackend: bkn, ontologyQuery: oq}
+}
+
+// AttachRelatedMetrics 按 scope_ref 把指标分发到各对象类。
+//
+// 取不到指标不算致命：对象类定义本身已经拿到了，把整个 get_object_types 打成失败只会
+// 让 Agent 连 schema 都读不到。降级成「没有 related_metrics」并留日志。
+func (s *knMetricsService) AttachRelatedMetrics(ctx context.Context, knID string, objectTypes []*interfaces.ObjectType) {
+	byScope := s.metricsByScope(ctx, knID, objectTypes)
+	if byScope == nil {
+		return
+	}
+	for _, ot := range objectTypes {
+		if ot == nil {
+			continue
+		}
+		ot.RelatedMetrics = byScope[ot.ID]
+		ot.RelatedMetricCount = len(ot.RelatedMetrics)
+	}
+}
+
+// AttachRelatedMetricCounts 只写计数，不写明细（get_kn_detail summary 用）。
+func (s *knMetricsService) AttachRelatedMetricCounts(ctx context.Context, knID string, objectTypes []*interfaces.ObjectType) {
+	byScope := s.metricsByScope(ctx, knID, objectTypes)
+	if byScope == nil {
+		return
+	}
+	for _, ot := range objectTypes {
+		if ot == nil {
+			continue
+		}
+		ot.RelatedMetricCount = len(byScope[ot.ID])
+	}
+}
+
+// metricsByScope 一次批量取回这批对象类下的指标，按 scope_ref 归类；失败返回 nil。
+func (s *knMetricsService) metricsByScope(ctx context.Context, knID string,
+	objectTypes []*interfaces.ObjectType) map[string][]*interfaces.RelatedMetric {
+	ids := make([]string, 0, len(objectTypes))
+	for _, ot := range objectTypes {
+		if ot != nil && strings.TrimSpace(ot.ID) != "" {
+			ids = append(ids, ot.ID)
+		}
+	}
+	if len(ids) == 0 {
+		return nil
+	}
+
+	metrics, err := s.bknBackend.ListMetricsByObjectTypes(ctx, knID, ids)
+	if err != nil {
+		s.warnf(ctx, "[KnMetrics] list metrics for kn=%s failed, object types answered without metrics: %v", knID, err)
+		return nil
+	}
+
+	byScope := make(map[string][]*interfaces.RelatedMetric, len(ids))
+	for _, m := range metrics {
+		if m == nil || m.ScopeRef == "" {
+			continue
+		}
+		byScope[m.ScopeRef] = append(byScope[m.ScopeRef], m)
+	}
+	return byScope
+}
+
+// QueryMetric 校验入参后转发 ontology-query 的指标取数端点。
+func (s *knMetricsService) QueryMetric(ctx context.Context, req *interfaces.QueryMetricReq) (*interfaces.QueryMetricResp, error) {
+	if req == nil {
+		return nil, ErrKnIDRequired
+	}
+	knID := strings.TrimSpace(req.KnID)
+	metricID := strings.TrimSpace(req.MetricID)
+	if knID == "" {
+		return nil, ErrKnIDRequired
+	}
+	if metricID == "" {
+		return nil, ErrMetricIDRequired
+	}
+	if err := validateTimeWindow(req.Time); err != nil {
+		return nil, err
+	}
+
+	downstream := &interfaces.MetricQueryDownstreamReq{
+		Time:               req.Time,
+		Cond:               req.Cond,
+		AnalysisDimensions: req.AnalysisDimensions,
+		OrderBy:            req.OrderBy,
+		Having:             req.Having,
+		Limit:              req.Limit,
+	}
+	resp, err := s.ontologyQuery.QueryMetricData(ctx, knID, metricID, req.FillNull, downstream)
+	if err != nil {
+		return nil, err
+	}
+
+	out := &interfaces.QueryMetricResp{KnID: knID, MetricID: metricID, Datas: []*interfaces.MetricDataSeries{}}
+	if resp != nil {
+		if len(resp.Datas) > 0 {
+			out.Datas = resp.Datas
+		}
+		out.OverallMs = resp.OverallMs
+	}
+	return out, nil
+}
+
+// validateTimeWindow 在本地拦掉时间窗的自相矛盾组合。
+//
+// 这些组合下游同样会拒，但错误信息会绕一圈才回到 Agent；就地判定给的是能直接照着改的
+// 提示。规则与逻辑属性 metric 参数校验一致：instant=true 取一个点，不带 step；
+// instant=false 取序列，必须带 step。
+func validateTimeWindow(t *interfaces.MetricTimeWindow) error {
+	if t == nil {
+		return nil
+	}
+	instant := t.Instant != nil && *t.Instant
+	if t.Instant != nil && instant && t.Step != nil && strings.TrimSpace(*t.Step) != "" {
+		return errors.New("time.instant=true cannot be combined with time.step (instant asks for a single point)")
+	}
+	if t.Instant != nil && !instant && (t.Step == nil || strings.TrimSpace(*t.Step) == "") {
+		return errors.New("time.instant=false requires time.step (one of: day, week, month, quarter, year)")
+	}
+	if t.Step != nil && strings.TrimSpace(*t.Step) != "" {
+		step := strings.TrimSpace(*t.Step)
+		if _, ok := validSteps[step]; !ok {
+			return fmt.Errorf("invalid time.step %q, must be one of: day, week, month, quarter, year", step)
+		}
+	}
+	if t.Start != nil && t.End != nil && *t.Start > *t.End {
+		return errors.New("time.start must not be later than time.end")
+	}
+	return nil
+}
+
+func (s *knMetricsService) warnf(ctx context.Context, format string, args ...any) {
+	if s.logger == nil {
+		return
+	}
+	s.logger.WithContext(ctx).Warnf(format, args...)
+}

--- a/adp/context-loader/agent-retrieval/server/logics/knmetrics/index.go
+++ b/adp/context-loader/agent-retrieval/server/logics/knmetrics/index.go
@@ -151,7 +151,7 @@ func (s *knMetricsService) QueryMetric(ctx context.Context, req *interfaces.Quer
 	if metricID == "" {
 		return nil, ErrMetricIDRequired
 	}
-	if err := validateTimeWindow(req.Time); err != nil {
+	if err := validateTimeWindow(req.Time, req.FillNull); err != nil {
 		return nil, err
 	}
 
@@ -178,30 +178,58 @@ func (s *knMetricsService) QueryMetric(ctx context.Context, req *interfaces.Quer
 	return out, nil
 }
 
-// validateTimeWindow 在本地拦掉时间窗的自相矛盾组合。
+// isTrendWindow mirrors ontology-query's metricQueryIsTrendTime: a window is a
+// trend (series) query unless instant is explicitly true. Omitting instant means
+// trend, not instant — getting this backwards is what makes the common
+// {"start":…,"end":…} shape pass here and fail downstream.
+func isTrendWindow(t *interfaces.MetricTimeWindow) bool {
+	return t != nil && (t.Instant == nil || !*t.Instant)
+}
+
+// validateTimeWindow rejects a malformed time window before it costs a round trip.
 //
-// 这些组合下游同样会拒，但错误信息会绕一圈才回到 Agent；就地判定给的是能直接照着改的
-// 提示。规则与逻辑属性 metric 参数校验一致：instant=true 取一个点，不带 step；
-// instant=false 取序列，必须带 step。
-func validateTimeWindow(t *interfaces.MetricTimeWindow) error {
+// Every rule here mirrors ontology-query's validateMetricQueryRequest exactly —
+// same conditions, same wording — because a local check that is stricter than the
+// downstream one turns a valid call into a false rejection, and a looser one just
+// delays the same error. The point is a faster, identical verdict, not a second
+// opinion.
+func validateTimeWindow(t *interfaces.MetricTimeWindow, fillNull bool) error {
 	if t == nil {
+		if fillNull {
+			return errors.New("fill_null requires a time range (time is required)")
+		}
 		return nil
 	}
-	instant := t.Instant != nil && *t.Instant
-	if t.Instant != nil && instant && t.Step != nil && strings.TrimSpace(*t.Step) != "" {
-		return errors.New("time.instant=true cannot be combined with time.step (instant asks for a single point)")
-	}
-	if t.Instant != nil && !instant && (t.Step == nil || strings.TrimSpace(*t.Step) == "") {
-		return errors.New("time.instant=false requires time.step (one of: day, week, month, quarter, year)")
-	}
-	if t.Step != nil && strings.TrimSpace(*t.Step) != "" {
-		step := strings.TrimSpace(*t.Step)
-		if _, ok := validSteps[step]; !ok {
-			return fmt.Errorf("invalid time.step %q, must be one of: day, week, month, quarter, year", step)
-		}
+	if (t.Start != nil) != (t.End != nil) {
+		return errors.New("time.start and time.end must both be set when either is set")
 	}
 	if t.Start != nil && t.End != nil && *t.Start > *t.End {
-		return errors.New("time.start must not be later than time.end")
+		return errors.New("time.start must be <= time.end")
+	}
+	if isTrendWindow(t) {
+		if t.Step == nil || strings.TrimSpace(*t.Step) == "" {
+			return errors.New("trend query requires time.step (calendar interval only). " +
+				"Omitting time.instant means a trend query; set time.instant=true for a single point")
+		}
+		if err := validateCalendarStep(*t.Step); err != nil {
+			return err
+		}
+	}
+	if fillNull {
+		if !isTrendWindow(t) {
+			return errors.New("fill_null is only valid for trend (range) queries: set time.instant to false or omit it")
+		}
+		if t.Start == nil || t.End == nil {
+			return errors.New("fill_null requires time.start and time.end")
+		}
+	}
+	return nil
+}
+
+// validateCalendarStep accepts the same steps as ontology-query, case-insensitively.
+func validateCalendarStep(raw string) error {
+	if _, ok := validSteps[strings.ToLower(strings.TrimSpace(raw))]; !ok {
+		return fmt.Errorf("step must be a calendar interval: day, week, month, quarter, year (got %q)", raw)
 	}
 	return nil
 }

--- a/adp/context-loader/agent-retrieval/server/logics/knmetrics/index_test.go
+++ b/adp/context-loader/agent-retrieval/server/logics/knmetrics/index_test.go
@@ -165,31 +165,86 @@ func TestQueryMetric(t *testing.T) {
 		convey.So(oq.calls, convey.ShouldEqual, 0)
 	})
 
-	convey.Convey("时间窗自相矛盾就地拦下", t, func() {
+	// 时间窗规则逐条对齐 ontology-query 的 validateMetricQueryRequest：本地比下游严
+	// 会把合法调用误拒，比下游松只是把同一个错误延后，两者都不可接受。
+	convey.Convey("时间窗校验与下游同规则", t, func() {
 		oq := &stubOntologyQuery{}
 		svc := NewKnMetricsServiceWith(nil, nil, oq)
 		base := func(tw *interfaces.MetricTimeWindow) *interfaces.QueryMetricReq {
 			return &interfaces.QueryMetricReq{KnID: "kn1", MetricID: "m1", Time: tw}
 		}
 
-		_, err := svc.QueryMetric(context.Background(), base(&interfaces.MetricTimeWindow{
-			Instant: ptr(true), Step: ptr("day")}))
-		convey.So(err, convey.ShouldNotBeNil)
-		convey.So(err.Error(), convey.ShouldContainSubstring, "instant=true")
+		convey.Convey("省略 instant 等同于序列查询，缺 step 就地拒", func() {
+			_, err := svc.QueryMetric(context.Background(), base(&interfaces.MetricTimeWindow{
+				Start: ptr(int64(1)), End: ptr(int64(2))}))
+			convey.So(err, convey.ShouldNotBeNil)
+			convey.So(err.Error(), convey.ShouldContainSubstring, "trend query requires time.step")
+			convey.So(oq.calls, convey.ShouldEqual, 0)
+		})
 
-		_, err = svc.QueryMetric(context.Background(), base(&interfaces.MetricTimeWindow{Instant: ptr(false)}))
-		convey.So(err, convey.ShouldNotBeNil)
-		convey.So(err.Error(), convey.ShouldContainSubstring, "requires time.step")
+		convey.Convey("instant=false 缺 step 同样拒", func() {
+			_, err := svc.QueryMetric(context.Background(), base(&interfaces.MetricTimeWindow{Instant: ptr(false)}))
+			convey.So(err, convey.ShouldNotBeNil)
+			convey.So(err.Error(), convey.ShouldContainSubstring, "trend query requires time.step")
+		})
 
-		_, err = svc.QueryMetric(context.Background(), base(&interfaces.MetricTimeWindow{
-			Instant: ptr(false), Step: ptr("fortnight")}))
-		convey.So(err, convey.ShouldNotBeNil)
-		convey.So(err.Error(), convey.ShouldContainSubstring, "invalid time.step")
+		convey.Convey("step 不在日历粒度里就拒", func() {
+			_, err := svc.QueryMetric(context.Background(), base(&interfaces.MetricTimeWindow{
+				Instant: ptr(false), Step: ptr("fortnight")}))
+			convey.So(err, convey.ShouldNotBeNil)
+			convey.So(err.Error(), convey.ShouldContainSubstring, "step must be a calendar interval")
+		})
 
-		_, err = svc.QueryMetric(context.Background(), base(&interfaces.MetricTimeWindow{
-			Start: ptr(int64(20)), End: ptr(int64(10))}))
+		convey.Convey("step 大小写不敏感（下游 ToLower，本地不能更严）", func() {
+			_, err := svc.QueryMetric(context.Background(), base(&interfaces.MetricTimeWindow{
+				Instant: ptr(false), Step: ptr("Day")}))
+			convey.So(err, convey.ShouldBeNil)
+			convey.So(oq.calls, convey.ShouldEqual, 1)
+		})
+
+		convey.Convey("instant=true 带 step 不拒（下游只是忽略它）", func() {
+			_, err := svc.QueryMetric(context.Background(), base(&interfaces.MetricTimeWindow{
+				Instant: ptr(true), Step: ptr("day")}))
+			convey.So(err, convey.ShouldBeNil)
+			convey.So(oq.calls, convey.ShouldEqual, 1)
+		})
+
+		convey.Convey("start/end 必须成对", func() {
+			_, err := svc.QueryMetric(context.Background(), base(&interfaces.MetricTimeWindow{
+				Instant: ptr(true), Start: ptr(int64(1))}))
+			convey.So(err, convey.ShouldNotBeNil)
+			convey.So(err.Error(), convey.ShouldContainSubstring, "must both be set")
+			convey.So(oq.calls, convey.ShouldEqual, 0)
+		})
+
+		convey.Convey("start 晚于 end 就拒", func() {
+			_, err := svc.QueryMetric(context.Background(), base(&interfaces.MetricTimeWindow{
+				Instant: ptr(true), Start: ptr(int64(20)), End: ptr(int64(10))}))
+			convey.So(err, convey.ShouldNotBeNil)
+			convey.So(err.Error(), convey.ShouldContainSubstring, "time.start must be <= time.end")
+		})
+	})
+
+	convey.Convey("fill_null 只对区间查询有效", t, func() {
+		oq := &stubOntologyQuery{}
+		svc := NewKnMetricsServiceWith(nil, nil, oq)
+
+		_, err := svc.QueryMetric(context.Background(), &interfaces.QueryMetricReq{
+			KnID: "kn1", MetricID: "m1", FillNull: true})
 		convey.So(err, convey.ShouldNotBeNil)
-		convey.So(err.Error(), convey.ShouldContainSubstring, "time.start")
+		convey.So(err.Error(), convey.ShouldContainSubstring, "fill_null requires a time range")
+
+		_, err = svc.QueryMetric(context.Background(), &interfaces.QueryMetricReq{
+			KnID: "kn1", MetricID: "m1", FillNull: true,
+			Time: &interfaces.MetricTimeWindow{Instant: ptr(true), Start: ptr(int64(1)), End: ptr(int64(2))}})
+		convey.So(err, convey.ShouldNotBeNil)
+		convey.So(err.Error(), convey.ShouldContainSubstring, "only valid for trend")
+
+		_, err = svc.QueryMetric(context.Background(), &interfaces.QueryMetricReq{
+			KnID: "kn1", MetricID: "m1", FillNull: true,
+			Time: &interfaces.MetricTimeWindow{Instant: ptr(false), Step: ptr("day")}})
+		convey.So(err, convey.ShouldNotBeNil)
+		convey.So(err.Error(), convey.ShouldContainSubstring, "fill_null requires time.start and time.end")
 
 		convey.So(oq.calls, convey.ShouldEqual, 0)
 	})

--- a/adp/context-loader/agent-retrieval/server/logics/knmetrics/index_test.go
+++ b/adp/context-loader/agent-retrieval/server/logics/knmetrics/index_test.go
@@ -126,7 +126,9 @@ func TestQueryMetric(t *testing.T) {
 			AnalysisDimensions: []string{"region"},
 			Limit:              ptr(10),
 			FillNull:           true,
-			Time:               &interfaces.MetricTimeWindow{Instant: ptr(true), Start: ptr(int64(1)), End: ptr(int64(2))},
+			// fill_null 只对带 start/end 的序列查询有效，与下游同规则。
+			Time: &interfaces.MetricTimeWindow{
+				Instant: ptr(false), Start: ptr(int64(1)), End: ptr(int64(2)), Step: ptr("day")},
 		})
 
 		convey.So(err, convey.ShouldBeNil)

--- a/adp/context-loader/agent-retrieval/server/logics/knmetrics/index_test.go
+++ b/adp/context-loader/agent-retrieval/server/logics/knmetrics/index_test.go
@@ -1,0 +1,206 @@
+// Copyright openbkn.ai
+//
+// Licensed under the OpenBKN License. See LICENSE-OPENBKN.txt in the project root.
+
+package knmetrics
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/smartystreets/goconvey/convey"
+
+	"github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/interfaces"
+)
+
+// stubBknBackend only implements what this package calls; the rest of
+// BknBackendAccess is embedded so the stub keeps compiling as that interface grows.
+type stubBknBackend struct {
+	interfaces.BknBackendAccess
+	metrics []*interfaces.RelatedMetric
+	err     error
+	gotKnID string
+	gotIDs  []string
+	calls   int
+}
+
+func (s *stubBknBackend) ListMetricsByObjectTypes(_ context.Context, knID string, otIDs []string) ([]*interfaces.RelatedMetric, error) {
+	s.calls++
+	s.gotKnID, s.gotIDs = knID, otIDs
+	return s.metrics, s.err
+}
+
+type stubOntologyQuery struct {
+	interfaces.DrivenOntologyQuery
+	resp       *interfaces.MetricQueryDownstreamResp
+	err        error
+	gotKnID    string
+	gotMetric  string
+	gotFillNil bool
+	gotReq     *interfaces.MetricQueryDownstreamReq
+	calls      int
+}
+
+func (s *stubOntologyQuery) QueryMetricData(_ context.Context, knID, metricID string, fillNull bool,
+	req *interfaces.MetricQueryDownstreamReq) (*interfaces.MetricQueryDownstreamResp, error) {
+	s.calls++
+	s.gotKnID, s.gotMetric, s.gotFillNil, s.gotReq = knID, metricID, fillNull, req
+	return s.resp, s.err
+}
+
+func ptr[T any](v T) *T { return &v }
+
+func TestAttachRelatedMetrics(t *testing.T) {
+	convey.Convey("指标按 scope_ref 分发到各对象类", t, func() {
+		bkn := &stubBknBackend{metrics: []*interfaces.RelatedMetric{
+			{ID: "m1", Name: "产品总数", ScopeRef: "ot1"},
+			{ID: "m2", Name: "物料总数", ScopeRef: "ot2"},
+			{ID: "m3", Name: "在途产品数", ScopeRef: "ot1"},
+			{ID: "m4", Name: "无归属", ScopeRef: ""},
+		}}
+		svc := NewKnMetricsServiceWith(nil, bkn, nil)
+		ots := []*interfaces.ObjectType{{ID: "ot1"}, {ID: "ot2"}, {ID: "ot3"}, nil}
+
+		svc.AttachRelatedMetrics(context.Background(), "kn1", ots)
+
+		convey.So(bkn.calls, convey.ShouldEqual, 1)
+		convey.So(bkn.gotKnID, convey.ShouldEqual, "kn1")
+		convey.So(bkn.gotIDs, convey.ShouldResemble, []string{"ot1", "ot2", "ot3"})
+		convey.So(len(ots[0].RelatedMetrics), convey.ShouldEqual, 2)
+		convey.So(ots[0].RelatedMetricCount, convey.ShouldEqual, 2)
+		convey.So(ots[1].RelatedMetrics[0].ID, convey.ShouldEqual, "m2")
+		convey.So(ots[2].RelatedMetrics, convey.ShouldBeEmpty)
+		convey.So(ots[2].RelatedMetricCount, convey.ShouldEqual, 0)
+	})
+
+	convey.Convey("取指标失败时对象类照常返回，只是没有指标", t, func() {
+		bkn := &stubBknBackend{err: errors.New("backend down")}
+		svc := NewKnMetricsServiceWith(nil, bkn, nil)
+		ots := []*interfaces.ObjectType{{ID: "ot1"}}
+
+		svc.AttachRelatedMetrics(context.Background(), "kn1", ots)
+
+		convey.So(ots[0].RelatedMetrics, convey.ShouldBeNil)
+		convey.So(ots[0].RelatedMetricCount, convey.ShouldEqual, 0)
+	})
+
+	convey.Convey("没有对象类时不打后端", t, func() {
+		bkn := &stubBknBackend{}
+		svc := NewKnMetricsServiceWith(nil, bkn, nil)
+
+		svc.AttachRelatedMetrics(context.Background(), "kn1", nil)
+
+		convey.So(bkn.calls, convey.ShouldEqual, 0)
+	})
+}
+
+func TestAttachRelatedMetricCounts(t *testing.T) {
+	convey.Convey("只写计数不写明细", t, func() {
+		bkn := &stubBknBackend{metrics: []*interfaces.RelatedMetric{
+			{ID: "m1", ScopeRef: "ot1"},
+			{ID: "m2", ScopeRef: "ot1"},
+		}}
+		svc := NewKnMetricsServiceWith(nil, bkn, nil)
+		ots := []*interfaces.ObjectType{{ID: "ot1"}, {ID: "ot2"}}
+
+		svc.AttachRelatedMetricCounts(context.Background(), "kn1", ots)
+
+		convey.So(ots[0].RelatedMetricCount, convey.ShouldEqual, 2)
+		convey.So(ots[0].RelatedMetrics, convey.ShouldBeNil)
+		convey.So(ots[1].RelatedMetricCount, convey.ShouldEqual, 0)
+	})
+}
+
+func TestQueryMetric(t *testing.T) {
+	convey.Convey("入参透传给 ontology-query，出参只留序列", t, func() {
+		oq := &stubOntologyQuery{resp: &interfaces.MetricQueryDownstreamResp{
+			Datas:     []*interfaces.MetricDataSeries{{Values: []any{431}}},
+			OverallMs: 12,
+		}}
+		svc := NewKnMetricsServiceWith(nil, nil, oq)
+
+		resp, err := svc.QueryMetric(context.Background(), &interfaces.QueryMetricReq{
+			KnID:               " kn1 ",
+			MetricID:           " m1 ",
+			AnalysisDimensions: []string{"region"},
+			Limit:              ptr(10),
+			FillNull:           true,
+			Time:               &interfaces.MetricTimeWindow{Instant: ptr(true), Start: ptr(int64(1)), End: ptr(int64(2))},
+		})
+
+		convey.So(err, convey.ShouldBeNil)
+		convey.So(oq.gotKnID, convey.ShouldEqual, "kn1")
+		convey.So(oq.gotMetric, convey.ShouldEqual, "m1")
+		convey.So(oq.gotFillNil, convey.ShouldBeTrue)
+		convey.So(oq.gotReq.AnalysisDimensions, convey.ShouldResemble, []string{"region"})
+		convey.So(*oq.gotReq.Limit, convey.ShouldEqual, 10)
+		convey.So(resp.KnID, convey.ShouldEqual, "kn1")
+		convey.So(resp.MetricID, convey.ShouldEqual, "m1")
+		convey.So(len(resp.Datas), convey.ShouldEqual, 1)
+		convey.So(resp.OverallMs, convey.ShouldEqual, 12)
+	})
+
+	convey.Convey("空结果返回空数组而不是 null", t, func() {
+		oq := &stubOntologyQuery{resp: &interfaces.MetricQueryDownstreamResp{}}
+		svc := NewKnMetricsServiceWith(nil, nil, oq)
+
+		resp, err := svc.QueryMetric(context.Background(), &interfaces.QueryMetricReq{KnID: "kn1", MetricID: "m1"})
+
+		convey.So(err, convey.ShouldBeNil)
+		convey.So(resp.Datas, convey.ShouldNotBeNil)
+		convey.So(len(resp.Datas), convey.ShouldEqual, 0)
+	})
+
+	convey.Convey("缺 kn_id / metric_id 直接拒，不打下游", t, func() {
+		oq := &stubOntologyQuery{}
+		svc := NewKnMetricsServiceWith(nil, nil, oq)
+
+		_, err := svc.QueryMetric(context.Background(), &interfaces.QueryMetricReq{MetricID: "m1"})
+		convey.So(err, convey.ShouldEqual, ErrKnIDRequired)
+
+		_, err = svc.QueryMetric(context.Background(), &interfaces.QueryMetricReq{KnID: "kn1"})
+		convey.So(err, convey.ShouldEqual, ErrMetricIDRequired)
+
+		convey.So(oq.calls, convey.ShouldEqual, 0)
+	})
+
+	convey.Convey("时间窗自相矛盾就地拦下", t, func() {
+		oq := &stubOntologyQuery{}
+		svc := NewKnMetricsServiceWith(nil, nil, oq)
+		base := func(tw *interfaces.MetricTimeWindow) *interfaces.QueryMetricReq {
+			return &interfaces.QueryMetricReq{KnID: "kn1", MetricID: "m1", Time: tw}
+		}
+
+		_, err := svc.QueryMetric(context.Background(), base(&interfaces.MetricTimeWindow{
+			Instant: ptr(true), Step: ptr("day")}))
+		convey.So(err, convey.ShouldNotBeNil)
+		convey.So(err.Error(), convey.ShouldContainSubstring, "instant=true")
+
+		_, err = svc.QueryMetric(context.Background(), base(&interfaces.MetricTimeWindow{Instant: ptr(false)}))
+		convey.So(err, convey.ShouldNotBeNil)
+		convey.So(err.Error(), convey.ShouldContainSubstring, "requires time.step")
+
+		_, err = svc.QueryMetric(context.Background(), base(&interfaces.MetricTimeWindow{
+			Instant: ptr(false), Step: ptr("fortnight")}))
+		convey.So(err, convey.ShouldNotBeNil)
+		convey.So(err.Error(), convey.ShouldContainSubstring, "invalid time.step")
+
+		_, err = svc.QueryMetric(context.Background(), base(&interfaces.MetricTimeWindow{
+			Start: ptr(int64(20)), End: ptr(int64(10))}))
+		convey.So(err, convey.ShouldNotBeNil)
+		convey.So(err.Error(), convey.ShouldContainSubstring, "time.start")
+
+		convey.So(oq.calls, convey.ShouldEqual, 0)
+	})
+
+	convey.Convey("无时间窗（无时间维度的指标）直接放行", t, func() {
+		oq := &stubOntologyQuery{resp: &interfaces.MetricQueryDownstreamResp{}}
+		svc := NewKnMetricsServiceWith(nil, nil, oq)
+
+		_, err := svc.QueryMetric(context.Background(), &interfaces.QueryMetricReq{KnID: "kn1", MetricID: "m1"})
+
+		convey.So(err, convey.ShouldBeNil)
+		convey.So(oq.calls, convey.ShouldEqual, 1)
+	})
+}

--- a/adp/context-loader/agent-retrieval/server/logics/knsearch/mock_test.go
+++ b/adp/context-loader/agent-retrieval/server/logics/knsearch/mock_test.go
@@ -105,6 +105,10 @@ func (m *mockBknBackend) SearchActionTypes(ctx context.Context, req *interfaces.
 	return m.actionTypesResp, m.actionTypesError
 }
 
+func (m *mockBknBackend) ListMetricsByObjectTypes(ctx context.Context, knID string, otIDs []string) ([]*interfaces.RelatedMetric, error) {
+	return nil, nil
+}
+
 func (m *mockBknBackend) SearchMetricTypes(ctx context.Context, query *interfaces.QueryConceptsReq) (*interfaces.MetricTypeConcepts, error) {
 	return nil, nil
 }
@@ -143,6 +147,11 @@ func (m *mockOntologyQuery) GetActionExecution(ctx context.Context, req *interfa
 
 func (m *mockOntologyQuery) ListActionExecutions(ctx context.Context, req *interfaces.ListActionExecutionsRequest) (map[string]any, error) {
 	return nil, nil
+}
+
+func (m *mockOntologyQuery) QueryMetricData(ctx context.Context, knID, metricID string, fillNull bool,
+	req *interfaces.MetricQueryDownstreamReq) (*interfaces.MetricQueryDownstreamResp, error) {
+	return &interfaces.MetricQueryDownstreamResp{}, nil
 }
 
 func (m *mockOntologyQuery) QueryInstanceSubgraph(ctx context.Context, req *interfaces.QueryInstanceSubgraphReq) (resp *interfaces.QueryInstanceSubgraphResp, err error) {

--- a/adp/context-loader/agent-retrieval/server/logics/knsearch/search_schema_test.go
+++ b/adp/context-loader/agent-retrieval/server/logics/knsearch/search_schema_test.go
@@ -57,6 +57,10 @@ func (s *stubSearchSchemaBknBackend) GetActionTypeDetail(_ context.Context, _ st
 	return nil, nil
 }
 
+func (s *stubSearchSchemaBknBackend) ListMetricsByObjectTypes(ctx context.Context, knID string, otIDs []string) ([]*interfaces.RelatedMetric, error) {
+	return nil, nil
+}
+
 func (s *stubSearchSchemaBknBackend) SearchMetricTypes(ctx context.Context, req *interfaces.QueryConceptsReq) (*interfaces.MetricTypeConcepts, error) {
 	s.searchMetricCalls++
 	if s.searchMetricTypesFunc != nil {

--- a/adp/context-loader/agent-retrieval/server/mocks/driven_ontology_query.go
+++ b/adp/context-loader/agent-retrieval/server/mocks/driven_ontology_query.go
@@ -131,6 +131,21 @@ func (mr *MockDrivenOntologyQueryMockRecorder) QueryLogicProperties(ctx, req any
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "QueryLogicProperties", reflect.TypeOf((*MockDrivenOntologyQuery)(nil).QueryLogicProperties), ctx, req)
 }
 
+// QueryMetricData mocks base method.
+func (m *MockDrivenOntologyQuery) QueryMetricData(ctx context.Context, knID, metricID string, fillNull bool, req *interfaces.MetricQueryDownstreamReq) (*interfaces.MetricQueryDownstreamResp, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "QueryMetricData", ctx, knID, metricID, fillNull, req)
+	ret0, _ := ret[0].(*interfaces.MetricQueryDownstreamResp)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// QueryMetricData indicates an expected call of QueryMetricData.
+func (mr *MockDrivenOntologyQueryMockRecorder) QueryMetricData(ctx, knID, metricID, fillNull, req any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "QueryMetricData", reflect.TypeOf((*MockDrivenOntologyQuery)(nil).QueryMetricData), ctx, knID, metricID, fillNull, req)
+}
+
 // QueryObjectInstances mocks base method.
 func (m *MockDrivenOntologyQuery) QueryObjectInstances(ctx context.Context, req *interfaces.QueryObjectInstancesReq) (*interfaces.QueryObjectInstancesResp, error) {
 	m.ctrl.T.Helper()

--- a/docs/api/bkn/bkn-metrics.yaml
+++ b/docs/api/bkn/bkn-metrics.yaml
@@ -101,7 +101,11 @@ paths:
               - subgraph
           in: query
         - name: scope_ref
-          description: 按指标作用域所指向的概念 ID 过滤（如 object_type 的对象类 ID）
+          description: |
+            按指标作用域所指向的概念 ID 过滤（如 object_type 的对象类 ID）。
+            支持逗号分隔的多个 ID（如 `ot_a,ot_b`），命中其中任一即返回——
+            一次列出多个对象类下的指标用。只传 `scope_ref` 不传 `scope_type` 时，
+            `scope_type` 默认按 `object_type` 处理。
           schema:
             type: string
           in: query

--- a/docs/api/context-loader/README.md
+++ b/docs/api/context-loader/README.md
@@ -11,7 +11,7 @@
 | [kn-explore.yaml](kn-explore.yaml) | 知识网络浏览 | `POST /kn/list_knowledge_networks`、`POST /kn/get_kn_detail`、`POST /kn/get_object_types`、`POST /kn/get_relation_types` |
 | [object-instance.yaml](object-instance.yaml) | 对象实例查询 | `POST /kn/query_object_instance` |
 | [instance-subgraph.yaml](instance-subgraph.yaml) | 实例子图查询 | `POST /kn/query_instance_subgraph` |
-| [logic-property.yaml](logic-property.yaml) | 逻辑属性求值 | `POST /kn/logic-property-resolver` |
+| [logic-property.yaml](logic-property.yaml) | 逻辑属性求值与指标取数 | `POST /kn/logic-property-resolver`、`POST /kn/query_metric` |
 | [action.yaml](action.yaml) | 行动召回与执行 | `POST /kn/get_action_info`、`POST /kn/execute_action`、`POST /kn/get_action_execution`、`POST /kn/list_action_executions` |
 | [skill.yaml](skill.yaml) | Skill 召回 | `POST /kn/find_skills` |
 | [data-access.yaml](data-access.yaml) | 数据层直查 | `POST /kn/list_resources`、`POST /kn/describe_resource`、`POST /kn/run_sql` |
@@ -22,11 +22,20 @@
 ```text
 list_knowledge_networks  → 发现 kn_id
 search_schema            → 一句话找到相关对象类 / 关系类 / 行动类 / 指标类
-get_object_types         → 下钻拿属性的物理列名与可用算子
+get_object_types         → 下钻拿属性的物理列名、可用算子，以及该对象类下的 related_metrics
 query_object_instance    → 取实例，从 _instance_identity 拿主键
-  ├→ logic-property-resolver → 求指标 / 算子类逻辑属性
+  ├→ logic-property-resolver → 求指标 / 算子类逻辑属性（实例 + 已绑逻辑属性）
   ├→ get_action_info → execute_action → get_action_execution → 执行闭环
   └→ find_skills            → 召回可装载的 Skill
+```
+
+指标取数（OT 优先，已建模指标别用 `run_sql` 重写口径）：
+
+```text
+search_schema / get_kn_detail  → 锁定对象类（summary 里 related_metric_count > 0 才有指标）
+get_object_types               → 从 related_metrics 选定指标
+  ├→ logic-property-resolver   → 实例级 + 已绑逻辑属性
+  └→ query_metric              → 类级 / 未绑逻辑属性，按 MetricDefinition 口径算
 ```
 
 绕开本体直查数据：`list_resources` → `describe_resource` → `run_sql`。
@@ -52,7 +61,7 @@ make api-contract-diff CONTRACT_FACE=ex CONTRACT_SSH=root@<host> \
      CONTRACT_ARGS="--include-probe-post --token $TOKEN"
 ```
 
-20 个操作里 **15 个在探测范围内**，其余 5 个不探测，原因如下——它们的响应结构
+21 个操作里 **15 个在探测范围内**，其余 6 个不探测，原因如下——它们的响应结构
 **未经实机验证**，改动时请人工核对：
 
 | 端点 | 不探测的原因 |
@@ -60,6 +69,7 @@ make api-contract-diff CONTRACT_FACE=ex CONTRACT_SSH=root@<host> \
 | `execute_action` | **有副作用**，会真的触发行动执行 |
 | `semantic-search` | 走大模型，耗时与成本不适合常态巡检 |
 | `logic-property-resolver` | 同上，且需要真实实例标识才能求值 |
+| `query_metric` | 需要环境里存在已建模指标，`metric_id` 无法自动合成 |
 | `run_sql` | 需要针对具体资源构造有意义的 SQL，无法自动合成 |
 | `POST /mcp` | JSON-RPC 会话语义，不是普通请求 / 响应结构 |
 

--- a/docs/api/context-loader/kn-explore.yaml
+++ b/docs/api/context-loader/kn-explore.yaml
@@ -98,6 +98,8 @@ paths:
         这些是顶层数组的重复拷贝，概念组只保留 `object_type_ids` 作为分组边界。
 
         被剥掉的细节按需用 `get_object_types` / `get_relation_types` 取回。
+        对象类条目带 `related_metric_count`（该对象类下已建模指标数），`>0` 才值得
+        为取指标下钻。
       parameters:
         - $ref: '#/components/parameters/ResponseFormat'
         - $ref: '#/components/parameters/XKnID'
@@ -153,6 +155,11 @@ paths:
         取 `get_kn_detail` 在 summary 级别剥掉的对象类细节：属性的 `mapped_field`
         （写 `run_sql` 要的物理列名）、`condition_operations`（该属性可用的查询算子）、
         逻辑属性的 `data_source` 与 `parameters`。
+
+        同时返回 `related_metrics`——挂在该对象类下的指标，**包括没绑到逻辑属性、
+        因而在 `logic_properties` 里根本看不见的那些**。这是 Agent 选指标的权威清单，
+        选定后走 [logic-property.yaml](logic-property.yaml) 的
+        `logic-property-resolver`（实例 + 已绑逻辑属性）或 `query_metric`（其余）。
 
         `ids` 里既可以传对象类 ID，也可以传对象类名（ID 优先，名称仅作兜底）；
         匹配不到的 ID 原样回填在 `missing` 里，不报错。属性的 `display_name`
@@ -493,6 +500,54 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/LogicProperty'
+        related_metrics:
+          type: array
+          description: |
+            挂在该对象类下的指标（`scope_type=object_type` 且 `scope_ref` 等于本对象类
+            ID），**含没绑到任何逻辑属性的指标**。仅 `get_object_types` 返回。
+            选定后怎么算：实例级且已绑逻辑属性走
+            [logic-property.yaml](logic-property.yaml) 的 `logic-property-resolver`，
+            其余把 `id` 传给同文件的 `query_metric`。
+          items:
+            $ref: '#/components/schemas/RelatedMetric'
+        related_metric_count:
+          type: integer
+          description: |
+            该对象类下的指标数。`get_kn_detail` 只给这个数，判断值不值得用
+            `get_object_types` 下钻拿 `related_metrics` 明细。
+
+    RelatedMetric:
+      type: object
+      description: |
+        对象类下可用指标的精简描述——够选指标，不含计算公式：口径在
+        MetricDefinition 里，由 `query_metric` 执行，调用方不该自己重写。
+      properties:
+        id:
+          type: string
+          description: 指标 ID，直接传给 `query_metric` 的 `metric_id`。
+        name:
+          type: string
+        comment:
+          type: string
+        metric_type:
+          type: string
+          description: 指标类型（如 `atomic`）。
+        unit:
+          type: string
+        unit_type:
+          type: string
+        scope_ref:
+          type: string
+          description: 统计主体对象类 ID，等于所在对象类的 `id`。
+        analysis_dimensions:
+          type: array
+          items:
+            type: string
+          description: 可用的分析维度名，`query_metric` 的 `analysis_dimensions` 只能从这里取值。
+        time_dimension:
+          type: string
+          description: |
+            指标的时间属性名；为空表示该指标没有时间维度，`query_metric` 可以不传 `time`。
 
     DataProperty:
       type: object

--- a/docs/api/context-loader/logic-property.yaml
+++ b/docs/api/context-loader/logic-property.yaml
@@ -13,6 +13,12 @@ info:
     [kn-explore.yaml](kn-explore.yaml) 的 `get_object_types` 返回的
     `logic_properties[].parameters`。
 
+    同一份文件里还有 `POST /kn/query_metric`：**类级指标、或没绑到任何逻辑属性的
+    指标**走它，直接按 `metric_id` 与 MetricDefinition 的口径取数。两条路的分工是
+    「实例 + 已绑逻辑属性 → `logic-property-resolver`，其余 → `query_metric`」；
+    已建模的指标一律不该用 `run_sql` 重写口径。指标清单来自 `get_object_types`
+    返回的 `related_metrics`。
+
     **认证**：`Authorization: Bearer <token>`（OAuth access token 或 `bak_` AppKey）。
   version: 0.1.3
 servers:
@@ -107,6 +113,90 @@ paths:
               schema:
                 $ref: '../_shared/errors.yaml#/components/schemas/ErrorAgentRetrieval'
 
+  /kn/query_metric:
+    post:
+      tags:
+        - LogicProperty
+      summary: 按指标口径取数
+      operationId: queryMetric
+      description: |
+        按已建模指标自身的口径计算取数，是 OT-first 指标路径的第 3 步：
+        `search_schema` / `get_kn_detail` 锁定对象类 → `get_object_types` 从
+        `related_metrics` 里选定 `metric_id` → 本接口计算。
+
+        与 `logic-property-resolver` 的分工：实例级、且已绑到逻辑属性的指标走那条
+        （它会先用大模型推参数）；**类级指标、或未绑逻辑属性的指标走本接口**，参数
+        由调用方显式给出，不经大模型。
+
+        `time` 在指标没有时间维度（`related_metrics[].time_dimension` 为空）时可整体
+        省略。给了就要自洽：`instant=true` 取单点，不得带 `step`；`instant=false`
+        取序列，必须带 `step`。这些组合在本服务就地校验，返回 400。
+
+        请求体与 ontology-query 的 `MetricQueryRequestBody` 同构；响应只保留结果序列，
+        不回带指标定义（`related_metrics` 里已经有了）。
+      parameters:
+        - $ref: '#/components/parameters/ResponseFormat'
+        - $ref: '#/components/parameters/XKnID'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/QueryMetricRequest'
+            examples:
+              取单点:
+                value:
+                  kn_id: kn_supplychain
+                  metric_id: metric_product_total
+              按维度拆分的区间序列:
+                value:
+                  kn_id: kn_supplychain
+                  metric_id: metric_product_total
+                  analysis_dimensions:
+                    - region
+                  time:
+                    instant: false
+                    start: 1735660800
+                    end: 1743436800
+                    step: month
+      responses:
+        '200':
+          description: 指标结果序列
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/QueryMetricResponse'
+            application/toon:
+              schema:
+                type: string
+                description: TOON 编码的同一结构（`response_format=toon` 时）。
+        '400':
+          description: |
+            缺 `kn_id` / `metric_id`，或时间窗自相矛盾（`instant=true` 带 `step`、
+            `instant=false` 缺 `step`、`step` 不在枚举内、`start` 晚于 `end`）
+          content:
+            application/json:
+              schema:
+                $ref: '../_shared/errors.yaml#/components/schemas/ErrorAgentRetrieval'
+        '401':
+          description: 凭据缺失或无效
+          content:
+            application/json:
+              schema:
+                $ref: '../_shared/errors.yaml#/components/schemas/ErrorAgentRetrieval'
+        '404':
+          description: 指标不存在（下游 ontology-query 判定）
+          content:
+            application/json:
+              schema:
+                $ref: '../_shared/errors.yaml#/components/schemas/ErrorAgentRetrieval'
+        '500':
+          description: 服务内部错误或下游异常
+          content:
+            application/json:
+              schema:
+                $ref: '../_shared/errors.yaml#/components/schemas/ErrorAgentRetrieval'
+
 components:
   securitySchemes:
     OAuth2:
@@ -126,8 +216,150 @@ components:
           - toon
         default: json
       description: 响应格式。`toon` 返回 `application/toon`，同构数组压成表格，省 token。
+    XKnID:
+      name: x-kn-id
+      in: header
+      required: false
+      schema:
+        type: string
+      description: 知识网络 ID 的请求头写法；请求体里给了 `kn_id` 时以请求体为准。
 
   schemas:
+    QueryMetricRequest:
+      type: object
+      required:
+        - kn_id
+        - metric_id
+      properties:
+        kn_id:
+          type: string
+          description: 知识网络 ID。也可用 `x-kn-id` 头传。
+        metric_id:
+          type: string
+          description: |
+            指标 ID，取自 `get_object_types` 返回的 `related_metrics[].id`，
+            或对象类逻辑属性 `data_source` 里引用的指标 ID。
+        time:
+          $ref: '#/components/schemas/MetricTimeWindow'
+        condition:
+          type: object
+          additionalProperties: true
+          description: |
+            过滤条件，结构与 `query_object_instance` 的 `condition` 一致
+            （`field` / `operation` / `value` / `value_from`，可 `and` / `or` 嵌套）。
+        analysis_dimensions:
+          type: array
+          items:
+            type: string
+          description: |
+            分析维度（按维度拆分结果）。取值须来自
+            `related_metrics[].analysis_dimensions`。
+        order_by:
+          type: array
+          description: 结果排序。
+          items:
+            type: object
+            properties:
+              property:
+                type: string
+              direction:
+                type: string
+                enum:
+                  - asc
+                  - desc
+        having:
+          type: object
+          description: 对聚合结果过滤。
+          properties:
+            field:
+              type: string
+            operation:
+              type: string
+            value: {}
+        limit:
+          type: integer
+          description: 返回条数上限。
+        fill_null:
+          type: boolean
+          default: false
+          description: 区间查询时，无数据的步长点是否补空。
+
+    MetricTimeWindow:
+      type: object
+      description: |
+        时间窗。指标没有时间维度时可整体省略；给了就要自洽（见接口说明）。
+      properties:
+        instant:
+          type: boolean
+          description: '`true` 取单点（不得带 `step`）；`false` 取序列（必须带 `step`）。'
+        start:
+          type: integer
+          format: int64
+          description: 起始时间，unix 秒。
+        end:
+          type: integer
+          format: int64
+          description: 结束时间，unix 秒。
+        step:
+          type: string
+          enum:
+            - day
+            - week
+            - month
+            - quarter
+            - year
+          description: 序列步长，仅 `instant=false` 时传。
+
+    QueryMetricResponse:
+      type: object
+      properties:
+        kn_id:
+          type: string
+        metric_id:
+          type: string
+        datas:
+          type: array
+          description: |
+            按 `labels` 分组的结果序列。未传 `analysis_dimensions` 时通常只有一条，
+            `labels` 为空。
+          items:
+            $ref: '#/components/schemas/MetricDataSeries'
+        overall_ms:
+          type: integer
+          format: int64
+          description: 耗时（毫秒）。
+
+    MetricDataSeries:
+      type: object
+      properties:
+        labels:
+          type: object
+          additionalProperties:
+            type: string
+          description: 该序列对应的维度取值。
+        times:
+          type: array
+          items: {}
+          description: 时间点（unix 秒）。
+        time_strs:
+          type: array
+          items:
+            type: string
+          description: 时间点的可读形式。
+        values:
+          type: array
+          items: {}
+          description: 与 `times` 一一对应的指标值。
+        growth_values:
+          type: array
+          items: {}
+        growth_rates:
+          type: array
+          items: {}
+        proportions:
+          type: array
+          items: {}
+
     ResolveLogicPropertiesRequest:
       type: object
       required:

--- a/docs/api/context-loader/logic-property.yaml
+++ b/docs/api/context-loader/logic-property.yaml
@@ -129,8 +129,13 @@ paths:
         由调用方显式给出，不经大模型。
 
         `time` 在指标没有时间维度（`related_metrics[].time_dimension` 为空）时可整体
-        省略。给了就要自洽：`instant=true` 取单点，不得带 `step`；`instant=false`
-        取序列，必须带 `step`。这些组合在本服务就地校验，返回 400。
+        省略。给了就要自洽：**省略 `instant` 等同于 `instant=false`（序列查询），
+        必须带 `step`**；`instant=true` 取单点（此时 `step` 被下游忽略）；
+        `start` 与 `end` 要么都给要么都不给。`step` 大小写不敏感。
+
+        这些规则在本服务就地校验并返回 400，规则逐条对齐 ontology-query 的
+        `validateMetricQueryRequest`——本地比下游严会把合法调用误拒，比下游松只是
+        把同一个错误延后。
 
         请求体与 ontology-query 的 `MetricQueryRequestBody` 同构；响应只保留结果序列，
         不回带指标定义（`related_metrics` 里已经有了）。
@@ -172,8 +177,9 @@ paths:
                 description: TOON 编码的同一结构（`response_format=toon` 时）。
         '400':
           description: |
-            缺 `kn_id` / `metric_id`，或时间窗自相矛盾（`instant=true` 带 `step`、
-            `instant=false` 缺 `step`、`step` 不在枚举内、`start` 晚于 `end`）
+            缺 `kn_id` / `metric_id`，或时间窗不合法（序列查询缺 `step`、`step` 不是
+            日历粒度、`start`/`end` 未成对、`start` 晚于 `end`、`fill_null` 用在
+            非序列查询上）
           content:
             application/json:
               schema:
@@ -282,7 +288,9 @@ components:
         fill_null:
           type: boolean
           default: false
-          description: 区间查询时，无数据的步长点是否补空。
+          description: |
+            区间查询时，无数据的步长点是否补空。仅对序列查询有效，且必须同时给
+            `time.start` 与 `time.end`。
 
     MetricTimeWindow:
       type: object
@@ -291,7 +299,7 @@ components:
       properties:
         instant:
           type: boolean
-          description: '`true` 取单点（不得带 `step`）；`false` 取序列（必须带 `step`）。'
+          description: '`true` 取单点（`step` 被忽略）；`false` 或**省略**取序列（必须带 `step`）。'
         start:
           type: integer
           format: int64
@@ -308,7 +316,7 @@ components:
             - month
             - quarter
             - year
-          description: 序列步长，仅 `instant=false` 时传。
+          description: 序列步长（大小写不敏感）。序列查询必传（含省略 `instant` 的情形）。
 
     QueryMetricResponse:
       type: object

--- a/docs/design/context-loader/features/597-ot-first-metric-path.md
+++ b/docs/design/context-loader/features/597-ot-first-metric-path.md
@@ -63,6 +63,11 @@ MCP 工具 + REST 端点 `POST /kn/query_metric`，转发 ontology-query 的
   是 Agent 自由填写的字符串，不转义的话一个带 `?` 的值就能给下游塞进 `branch` 等查询参数。
 - 指标列表**分页取全**（单页 1000，硬上限 10000 只是失控保护）：截断后的答案与「这个对象类
   没有指标」在 Agent 眼里完全一样，而那正是把它推回 `run_sql` 的状态；真触到上限会打 warn。
+  对象类 id 按 100 个一批发（`get_kn_detail` 会问整网的对象类，几百个 id 逗号拼进查询串足以
+  撑爆代理的请求行缓冲）。bkn-backend 侧排序补 `f_id` tiebreaker——默认按 `f_update_time`
+  排，同批导入的指标时间戳相同，没有兜底列时跨页边界行序不稳。
+- `kn_id` 在两处适配器都 `PathEscape`：comm-go 的 `generateURL` 会把 URL 自带的查询参数
+  **反向覆盖**调用方传的值，不转义的话一个带 `?` 的 id 就能把 `scope_type` 顶掉。
 
 ### 2.3 口径写进工具描述
 

--- a/docs/design/context-loader/features/597-ot-first-metric-path.md
+++ b/docs/design/context-loader/features/597-ot-first-metric-path.md
@@ -55,8 +55,14 @@ MCP 工具 + REST 端点 `POST /kn/query_metric`，转发 ontology-query 的
   那份定义调用方刚从 `related_metrics` 拿过，每次取数再抄一遍是这套工具面一直在削的体积。
 - 走内部路由 `/in`，账户随 header 透传、授权由下游判定，与 `get_logic_properties_values`
   同一姿势——因此 issue 里担心的「AppKey/OAuth 打不通 metric data 会 401」不成立。
-- 时间窗自相矛盾（`instant=true` 带 `step`、`instant=false` 缺 `step`、`step` 不在枚举内、
-  `start` 晚于 `end`）就地拦下返回 400，规则与逻辑属性的 metric 参数校验一致。
+- 时间窗就地校验返回 400，规则**逐条对齐 ontology-query 的 `validateMetricQueryRequest`**：
+  省略 `instant` 等同于序列查询（必须给 `step`）、`step` 限日历粒度且大小写不敏感、
+  `start`/`end` 必须成对、`start <= end`、`fill_null` 仅对带 `start`/`end` 的序列查询有效。
+  本地比下游严会把合法调用误拒，比下游松只是把同一个错误延后——所以是复刻，不是另立一套。
+- `kn_id` / `metric_id` 进 URL 前 `url.PathEscape`，`fill_null` 走 `url.Values`：`metric_id`
+  是 Agent 自由填写的字符串，不转义的话一个带 `?` 的值就能给下游塞进 `branch` 等查询参数。
+- 指标列表**分页取全**（单页 1000，硬上限 10000 只是失控保护）：截断后的答案与「这个对象类
+  没有指标」在 Agent 眼里完全一样，而那正是把它推回 `run_sql` 的状态；真触到上限会打 warn。
 
 ### 2.3 口径写进工具描述
 
@@ -116,8 +122,13 @@ MCP 工具 + REST 端点 `POST /kn/query_metric`，转发 ontology-query 的
 - 单测：适配器（查询参数、scope 复筛、错误透传）、服务（分组、降级、时间窗校验、透传）、
   MCP 工具（`related_metrics` 出现在结果里、`query_metric` happy path 与缺参）、
   bkn-backend（`IN` 过滤、`splitScopeRefs`）、社区工具面基线
-- 实机（VM）：`supplychain_hd0202` 的 8 个指标在 `get_object_types` 可见；
-  `query_metric` 取「产品总数」结果与 `openbkn bkn metric query` 一致（431）
+- 实机（测试服 14.103.77.23，KN `ecommerce_ops_bkn_public`，14 个 atomic 指标）：
+  - `order` 的 5 个指标全部可见（此前只有绑了 `lp_gmv_metric` 的 GMV 一个）；
+    `shipment` 无任何逻辑属性，其 2 个指标此前完全不可见，现可见
+  - `get_kn_detail` 的 20 个对象类计数与指标注册表逐一吻合
+  - `query_metric` 取 `m_shipment_cnt` = 12190；`m_gmv` 带 `condition` 排除
+    `cancelled` 得 436,367,809.20，与 `run_sql` 分组对账（469,497,191.25 −
+    33,129,382.05）完全一致
 
 ## 6. 不在范围内
 

--- a/docs/design/context-loader/features/597-ot-first-metric-path.md
+++ b/docs/design/context-loader/features/597-ot-first-metric-path.md
@@ -1,0 +1,126 @@
+# OT-first 指标路径：对象类看得见指标，选定后按口径取数
+
+- Issue：[#597](https://github.com/openbkn-ai/bkn-foundry/issues/597)
+- 分支：`feature/597-ot-first-metric-path`
+- 模块：context-loader（agent-retrieval）、bkn-backend
+- 状态：implementing
+
+## 1. 背景与问题
+
+第三方 Agent 取指标的目标路径是 **OT-first**：
+
+```text
+召回对象类 → 在该对象类下判断用哪个指标 → 按 MetricDefinition 口径计算
+```
+
+供应链 POC（`supplychain_hd0202`，8 个 atomic 指标）实测下来，第 1 步基本可用，
+第 2、3 步断链：
+
+| 步骤 | 现状 | 后果 |
+|---|---|---|
+| 2. 选指标 | 对象类只能通过**已绑定的逻辑属性**间接暴露指标；未绑逻辑属性的 scoped 指标在 `get_object_types` / `get_kn_detail` 里完全不可见 | Agent 看不到可用指标 |
+| 3. 计算 | 实例级 + 已绑逻辑属性有 `get_logic_properties_values`；类级 / 未绑的只有 ontology-query 的 `POST .../metrics/{id}/data`，MCP 无对应工具 | Agent 退化成 `run_sql` 自己重写口径 |
+
+「用 SQL 重写已建模指标」是这条链路真正的代价：口径写在 MetricDefinition 里，
+SQL 重写等于把治理过的口径复制一份到 Agent 的临时推理里。
+
+## 2. 方案
+
+### 2.1 第 2 步：对象类带出 `related_metrics`
+
+`get_object_types` 在返回对象类完整定义时，附带 `related_metrics[]` ——
+`scope_type=object_type` 且 `scope_ref=<对象类 ID>` 的全部指标，**含未绑逻辑属性的**。
+
+数据来源选择：**bkn-backend 指标注册表**（`GET /in/v1/knowledge-networks/{kn}/metrics`，
+DB 直查、带 KN `view_detail` 鉴权），不是 `SearchMetricTypes`。后者是概念索引上的语义召回，
+既是排序结果、又只有索引那么新（见 #535）；而「这个对象类有哪些指标」必须全量且与库一致。
+
+批量：bkn-backend 的 `scope_ref` 扩成支持逗号多值（`sq.Eq` 遇切片自然落成 `IN`），
+于是一次 `get_object_types(ids=[a,b,c])` 只多打一次后端，不按对象类扇出。
+
+降级：取指标失败只记 warn 并返回没有 `related_metrics` 的对象类。对象类定义本身已经拿到了，
+让整个 `get_object_types` 失败会连 schema 都读不到。
+
+`get_kn_detail` 只挂 `related_metric_count`（计数，不含明细），维持渐进式下钻的体积约束：
+`>0` 才值得为取指标下钻。
+
+### 2.2 第 3 步：新增 `query_metric`
+
+MCP 工具 + REST 端点 `POST /kn/query_metric`，转发 ontology-query 的
+`POST /in/v1/knowledge-networks/{kn_id}/metrics/{metric_id}/data`。
+
+- 请求体与 ontology-query 的 `MetricQueryRequestBody` 同构（`time` / `condition` /
+  `analysis_dimensions` / `order_by` / `having` / `limit`），`fill_null` 走 URL query。
+- 响应只留结果序列（`datas` + `overall_ms`），**不回带 `model`（指标定义）**：
+  那份定义调用方刚从 `related_metrics` 拿过，每次取数再抄一遍是这套工具面一直在削的体积。
+- 走内部路由 `/in`，账户随 header 透传、授权由下游判定，与 `get_logic_properties_values`
+  同一姿势——因此 issue 里担心的「AppKey/OAuth 打不通 metric data 会 401」不成立。
+- 时间窗自相矛盾（`instant=true` 带 `step`、`instant=false` 缺 `step`、`step` 不在枚举内、
+  `start` 晚于 `end`）就地拦下返回 400，规则与逻辑属性的 metric 参数校验一致。
+
+### 2.3 口径写进工具描述
+
+三分流写进 MCP `serverInstructions`（中英）与 `tools_meta`：
+
+- 实例级 + 已绑逻辑属性 → `get_logic_properties_values`
+- 类级 / 未绑逻辑属性 → `query_metric`
+- 压根没建模成指标 → 才用 `run_sql`
+
+`search_schema` 的描述同时降级 `metric_types` 为辅助线索——指标的权威清单是
+`get_object_types` 的 `related_metrics`。
+
+## 3. 改动清单
+
+**bkn-backend**
+
+- `driveradapters/metric_handler.go`：`scope_ref` 支持逗号多值（`splitScopeRefs`）
+- `interfaces/metric.go`：`MetricsListQueryParams.ScopeRefs []string`（保留单值 `ScopeRef`）
+- `drivenadapters/metric/metric_access.go`：多值走 `IN`，单值仍等值
+
+**context-loader（agent-retrieval）**
+
+- `interfaces/driven_bkn_backend.go`：`RelatedMetric`；`ObjectType.RelatedMetrics` /
+  `RelatedMetricCount`；`BknBackendAccess.ListMetricsByObjectTypes`
+- `drivenadapters/bkn_backend.go`：`ListMetricsByObjectTypes`（含「后端忽略过滤时本地再筛一遍」）
+- `interfaces/kn_metric_query.go`、`interfaces/driven_ontology_query.go`、
+  `drivenadapters/ontology_query.go`：`query_metric` 的请求 / 响应与下游调用
+- `logics/knmetrics/`：挂指标、挂计数、指标取数与参数校验（MCP 与 REST 共用）
+- `driveradapters/mcp/`：`query_metric` 工具（`app.go` / `tools.go` /
+  `schemas/query_metric.json` / `tools_meta.json` / `locales/en-US/*`），
+  `get_object_types`、`get_kn_detail` 接线，社区工具面基线 +1
+- `driveradapters/knquerytools/index.go` + `rest_public_handler.go` /
+  `rest_private_handler.go`：REST 侧同源接线与路由
+- `bootstrap/tool_dependencies/context_loader_toolset.adp`：新增 `query_metric` 工具条目
+  （`metadata.version == source_id`）
+
+**文档**
+
+- `docs/api/context-loader/logic-property.yaml`：新增 `/kn/query_metric`
+- `docs/api/context-loader/kn-explore.yaml`：`related_metrics` / `related_metric_count` / `RelatedMetric`
+- `docs/api/context-loader/README.md`：文件索引、指标链路、巡检覆盖
+- `docs/api/bkn/bkn-metrics.yaml`：`scope_ref` 多值语义
+
+## 4. 兼容性
+
+全部是**新增字段与新增端点**，没有改动既有响应字段的含义：
+
+- `related_metrics` / `related_metric_count` 都是 `omitempty`，老调用方不受影响
+- `scope_ref` 单值行为不变，多值是新增能力
+- 新 MCP 工具属 core（社区档位可见），不进企业门控
+
+老版本 bkn-backend 配新版 context-loader：多值 `scope_ref` 会被老后端当作单个字符串匹配不到，
+返回空列表——表现为「没有 related_metrics」，不报错、不串对象类（适配器还会本地再筛一遍）。
+
+## 5. 验收
+
+- 单测：适配器（查询参数、scope 复筛、错误透传）、服务（分组、降级、时间窗校验、透传）、
+  MCP 工具（`related_metrics` 出现在结果里、`query_metric` happy path 与缺参）、
+  bkn-backend（`IN` 过滤、`splitScopeRefs`）、社区工具面基线
+- 实机（VM）：`supplychain_hd0202` 的 8 个指标在 `get_object_types` 可见；
+  `query_metric` 取「产品总数」结果与 `openbkn bkn metric query` 一致（431）
+
+## 6. 不在范围内
+
+- Studio Context Loader 调试台的 `query_metric` op 与示例（转交前端同事，见 Issue 评论）
+- 指标写操作、uniquery 路径变更（#151）
+- ConceptSyncer / KN detail 质量（#535）


### PR DESCRIPTION
Closes #597

设计文档：[`docs/design/context-loader/features/597-ot-first-metric-path.md`](https://github.com/openbkn-ai/bkn-foundry/blob/feature/597-ot-first-metric-path/docs/design/context-loader/features/597-ot-first-metric-path.md)

## 解决什么

OT-first 指标路径「召回对象类 → 在该对象类下选指标 → 按 MetricDefinition 口径计算」的第 2、3 步是断的：

- 第 2 步：未绑逻辑属性的 scoped 指标在对象类上完全不可见（`get_object_types` 只能通过已绑 logic property 间接暴露，`get_kn_detail` 没有指标）
- 第 3 步：选定后没有按口径执行的工具，Agent 退化成 `run_sql` 把已建模的口径重写一遍

## 怎么做

**第 2 步 — 对象类带出 `related_metrics`**

`get_object_types` 返回 `scope_type=object_type` 且 `scope_ref` 为该对象类的全部指标，含未绑逻辑属性的。数据取自 **bkn-backend 指标注册表**（DB 直查、带 KN `view_detail` 鉴权），不是 `SearchMetricTypes`——后者是概念索引上的语义召回，既是排序结果又只有索引那么新（#535），而「这个对象类有哪些指标」必须全量且与库一致。

取指标失败只记 warn 并返回没有指标的对象类：对象类定义已经拿到了，让整个调用失败会连 schema 都读不到。

`get_kn_detail` 只挂 `related_metric_count`，维持渐进式下钻的体积约束。

**第 3 步 — 新增 `query_metric`**

MCP 工具 + REST `POST /kn/query_metric`，转发 ontology-query 的 `POST /in/v1/knowledge-networks/{kn}/metrics/{id}/data`，请求体与 `MetricQueryRequestBody` 同构。

- 响应只留结果序列，**不回带 `model`（指标定义）**——调用方刚从 `related_metrics` 拿过，每次取数再抄一份是这套工具面一直在削的体积
- 走内部路由 `/in`，账户随 header 透传、授权下游判定，与 `get_logic_properties_values` 同一姿势（issue 里担心的 401 不成立）
- 时间窗就地校验返回 400，规则**逐条复刻 ontology-query 的 `validateMetricQueryRequest`**：省略 `instant` 等同于序列查询（必须给 `step`）、`step` 限日历粒度且大小写不敏感、`start`/`end` 必须成对、`start <= end`、`fill_null` 仅对带 `start`/`end` 的序列查询有效。（`instant=true` 带 `step` **不拒**——下游只是忽略它，本地比下游严就是误拒；`433a9bf` 已改）

**bkn-backend 配合**

`GET .../metrics` 的 `scope_ref` 支持逗号多值（`sq.Eq` 遇切片落成 `IN`），于是一次 `get_object_types(ids=[a,b,c])` 只多打一次后端，不按对象类扇出。

**口径写进工具描述**

`serverInstructions` 与 `tools_meta`（中英）写清三分流：实例 + 已绑逻辑属性 → `get_logic_properties_values`；类级 / 未绑 → `query_metric`；压根没建模成指标 → 才用 `run_sql`。`search_schema` 里 `metric_types` 降级为辅助线索。

**三处对齐**：MCP schema/tools_meta + `.adp` 工具条目（`metadata.version == source_id`）+ 社区工具面基线。

## 兼容性

全是新增字段与新增端点：`related_metrics` / `related_metric_count` 都是 `omitempty`；`scope_ref` 单值行为不变；新工具属 core，不进企业门控。老 bkn-backend 配新 context-loader 时多值 `scope_ref` 匹配不到会返回空列表，表现为「没有 related_metrics」，不报错、不串对象类（适配器还会本地按 scope 再筛一遍）。

## 测试

- context-loader：适配器（查询参数 / scope 复筛 / 错误透传）、`knmetrics` 服务（分组 / 降级 / 时间窗校验 / 透传）、MCP 工具（`related_metrics` 出现在结果里、`query_metric` happy path 与缺参）、社区工具面基线 +1；`go build ./... && go test ./...` 全绿
- bkn-backend：`IN` 过滤与 `splitScopeRefs` 单测；`I18N_MODE_UT=true go test ./...` 全绿

VM 实机验证（`supplychain_hd0202` 8 个指标 + 产品总数 431 对账）待部署后补。

## 不在本 PR 范围

- Studio Context Loader 调试台的 `query_metric` op 与示例——转交前端同事，已在 Issue 留待办
- 指标写操作、uniquery（#151）、ConceptSyncer（#535）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

**评审后续**：`433a9bf` 收敛评审三项（`metric_id` 转义 / 指标列表翻页 / 时间窗对齐下游），
`1e1cb64c` 收敛 approve 时留的三条待确认（`kn_id` 转义、`scope_ref` 按 100 分批、
bkn-backend 排序补 `f_id` tiebreaker）。测试服 14.103.77.23 全程复测通过。
