### PR TITLE
fix(deploy): 让 config.yaml 生成认得出 bundled proton-redis

### DIFF
--- a/deploy/scripts/services/config.sh
+++ b/deploy/scripts/services/config.sh
@@ -122,14 +122,16 @@ STORAGE_EOF
     local redis_ns="${REDIS_NAMESPACE}"
     local redis_release_name="redis"
     
-    # Try to get actual StatefulSet name
-    # For redis chart: StatefulSet name is {release-name}-redis (e.g., redis)
+    # Try to get actual StatefulSet name. The bundled chart is proton-redis, so
+    # its StatefulSet is {release-name}-proton-redis; plain "redis" covers a
+    # release whose chart names the StatefulSet after the release only.
     local redis_sts_name=""
-    if kubectl -n "${redis_ns}" get statefulset redis >/dev/null 2>&1; then
-        redis_sts_name="redis"
-    elif kubectl -n "${redis_ns}" get statefulset redis >/dev/null 2>&1; then
-        redis_sts_name="redis"
-    fi
+    for sts_name in "${redis_release_name}-proton-redis" "${redis_release_name}-redis" "redis"; do
+        if kubectl -n "${redis_ns}" get statefulset "${sts_name}" >/dev/null 2>&1; then
+            redis_sts_name="${sts_name}"
+            break
+        fi
+    done
 
     # Only treat Redis as configured when a release/resource truly exists in cluster.
     local redis_configured=false
@@ -165,42 +167,24 @@ STORAGE_EOF
     # Try to get password from secret (check multiple possible secret names)
     # For redis chart: secret name is {release-name}-redis-secret (e.g., redis-secret)
     local redis_secret_names=(
+        "${redis_release_name}-proton-redis-secret"    # bundled proton-redis chart
         "${redis_release_name}-redis-secret"          # redis chart naming
         "${redis_release_name}-secret"                # generic naming
         "redis-auth"                                  # fallback
     )
     local redis_secret_password=""
+    # nonEncrpt-password is checked first: the bundled proton-redis chart keeps
+    # BOTH keys, and its "password" is not the value clients authenticate with.
     for secret_name in "${redis_secret_names[@]}"; do
-        redis_secret_password="$(get_secret_b64_key "${redis_ns}" "${secret_name}" password 2>/dev/null || echo "")"
-        if [[ -n "${redis_secret_password}" ]]; then
-            # Check if password is base64 encoded (Bitnami chart stores base64-encoded password)
-            # Try to decode it; if it's already plain text, decoding will fail or produce garbage
-            local decoded_password
-            decoded_password="$(printf '%s' "${redis_secret_password}" | base64 -d 2>/dev/null || echo "")"
-            if [[ -n "${decoded_password}" ]] && [[ "${decoded_password}" != "${redis_secret_password}" ]]; then
-                # Successfully decoded, use the decoded version
-                redis_password="${decoded_password}"
-            else
-                # Not base64 or already plain text
-                redis_password="${redis_secret_password}"
-            fi
-            break
-        fi
-        # Also try nonEncrpt-password key (used by local chart)
-        redis_secret_password="$(get_secret_b64_key "${redis_ns}" "${secret_name}" nonEncrpt-password 2>/dev/null || echo "")"
-        if [[ -n "${redis_secret_password}" ]]; then
-            # Check if password is base64 encoded
-            local decoded_password
-            decoded_password="$(printf '%s' "${redis_secret_password}" | base64 -d 2>/dev/null || echo "")"
-            if [[ -n "${decoded_password}" ]] && [[ "${decoded_password}" != "${redis_secret_password}" ]]; then
-                # Successfully decoded, use the decoded version
-                redis_password="${decoded_password}"
-            else
-                # Not base64 or already plain text
-                redis_password="${redis_secret_password}"
-            fi
-            break
-        fi
+        for secret_key in nonEncrpt-password password; do
+            # get_secret_b64_key already base64-decodes the Secret field, so this
+            # is the plaintext password — decoding it again corrupts any value
+            # that happens to be valid base64 (e.g. "ede2177d6b").
+            redis_secret_password="$(get_secret_b64_key "${redis_ns}" "${secret_name}" "${secret_key}" 2>/dev/null || echo "")"
+            [[ -z "${redis_secret_password}" ]] && continue
+            redis_password="${redis_secret_password}"
+            break 2
+        done
     done
     
     # Detect Redis deployment mode (standalone or sentinel)
@@ -215,6 +199,7 @@ STORAGE_EOF
     # For redis chart: service name is {release-name}-redis-sentinel
     # If release name is "redis", service is "redis-sentinel"
     local sentinel_svc_names=(
+        "${redis_release_name}-proton-redis-sentinel"   # bundled proton-redis chart
         "${redis_release_name}-redis-sentinel"          # redis chart naming
         "${redis_release_name}-sentinel"               # generic naming
         "redis-sentinel"                                # fallback


### PR DESCRIPTION
## 问题

`generate_config_yaml` 探测 Redis 时，三处命名和一处解码都对不上实际部署，结果是装完集群后 `config.yaml` 里的 Redis 段是错的。在 k3s 单节点上实测复现（release 名 `redis`，chart 为 proton-redis，StatefulSet 实际叫 `redis-proton-redis`）。

## 四处修复

**1. StatefulSet 探测有个死分支**

```bash
if kubectl -n "${redis_ns}" get statefulset redis >/dev/null 2>&1; then
    redis_sts_name="redis"
elif kubectl -n "${redis_ns}" get statefulset redis >/dev/null 2>&1; then   # ← 条件与上面完全相同
    redis_sts_name="redis"
fi
```

`elif` 的条件和 `if` 一字不差，是复制粘贴留下的。写它的人本意显然是探测第二种命名，但这个分支永远走不到。而实际部署叫 `redis-proton-redis`，两个分支都匹配不上 → `redis_sts_name` 为空 → 后面取用户名的整段逻辑被跳过。

改成按候选名依次探测：`<release>-proton-redis` → `<release>-redis` → `redis`。

**2. Secret 名单缺 bundled chart 的命名**

少了 `<release>-proton-redis-secret`，密码取不到。

**3. 密码被解了两次（这条最隐蔽）**

`get_secret_b64_key` 已经对 Secret 字段做过 base64 解码，返回的就是明文。上层却又判断「看着像 base64 就再解一次」：

```bash
decoded_password="$(printf '%s' "${redis_secret_password}" | base64 -d 2>/dev/null || echo "")"
if [[ -n "${decoded_password}" ]] && [[ "${decoded_password}" != "${redis_secret_password}" ]]; then
    redis_password="${decoded_password}"   # ← 把明文当密文又解一遍
```

于是**任何本身是合法 base64 的密码都会被解坏**。实测 `ede2177d6b` 会被解成乱码。这类 bug 只在密码恰好长得像 base64 时才发作，从现象很难反推到这里。

改为直接取值，并把 `nonEncrpt-password` 排在 `password` 前面 —— bundled proton-redis chart 两个 key 都写，而它的 `password` 不是客户端用来认证的那个值。

**4. sentinel service 名单同样缺 `<release>-proton-redis-sentinel`**

导致部署模式被误判成 standalone。

## 验证

`bash -n` 通过。在 k3s 单节点上跑 `deploy.sh openbkn install`：

```
[INFO] Redis sentinel mode detected (via service: redis-proton-redis-sentinel)
[INFO] Wrote config file: /root/.openbkn-ai/config.yaml
[INFO] Included services in config.yaml: Ingress-Nginx Redis Kafka OpenSearch MariaDB
```

修复前这行是探测不到 sentinel 的，config.yaml 的 Redis 段与集群实际不一致。

## 说明

这套改动此前是以**未提交的本地补丁**形式挂在测试机上的 —— 等于每台新装的机器都要再踩一次同样的坑。这个 PR 把它收敛回上游。

🤖 Generated with [Claude Code](https://claude.com/claude-code)