### PR TITLE
feat(context-loader,execution-factory): MCP 补齐技能浏览/读取/执行

### DIFF
--- a/adp/context-loader/agent-retrieval/server/bootstrap/tool_dependencies/context_loader_toolset.adp
+++ b/adp/context-loader/agent-retrieval/server/bootstrap/tool_dependencies/context_loader_toolset.adp
@@ -4175,6 +4175,635 @@
       "code": "",
       "dependencies": [],
       "dependencies_url": ""
+     },
+     {
+      "tool_id": "87b2b1d5-1830-52b2-a064-48ec2ac260e7",
+      "name": "list_skills",
+      "description": "浏览已发布技能（不需要知识网络上下文）。与 find_skills 互补：那条按对象类/实例召回，这条按名称或分类翻列表。拿到 skill_id 后用 get_skill_content 读 SKILL.md，用 read_skill_file 下钻附属文件，用 execute_skill 执行入口命令。",
+      "status": "enabled",
+      "metadata_type": "openapi",
+      "metadata": {
+       "version": "353f83c8-a32e-5a67-b454-36508e113845",
+       "summary": "list_skills",
+       "description": "浏览已发布技能（不需要知识网络上下文）。与 find_skills 互补：那条按对象类/实例召回，这条按名称或分类翻列表。拿到 skill_id 后用 get_skill_content 读 SKILL.md，用 read_skill_file 下钻附属文件，用 execute_skill 执行入口命令。",
+       "server_url": "http://agent-retrieval:30779",
+       "path": "/api/agent-retrieval/in/v1/kn/list_skills",
+       "method": "POST",
+       "create_time": 1776920840668983300,
+       "update_time": 1776920840668983300,
+       "create_user": "ede150ba-06f4-11f1-85aa-3a34099a4c4b",
+       "update_user": "ede150ba-06f4-11f1-85aa-3a34099a4c4b",
+       "api_spec": {
+        "parameters": [
+         {
+          "name": "x-account-id",
+          "in": "header",
+          "description": "账户ID，用于内部服务调用时传递账户信息",
+          "required": false,
+          "schema": {
+           "type": "string"
+          }
+         },
+         {
+          "name": "x-account-type",
+          "in": "header",
+          "description": "账户类型：user(用户), app(应用), anonymous(匿名)",
+          "required": false,
+          "schema": {
+           "enum": [
+            "user",
+            "app",
+            "anonymous"
+           ],
+           "type": "string"
+          }
+         }
+        ],
+        "request_body": {
+         "description": "",
+         "content": {
+          "application/json": {
+           "schema": {
+            "type": "object",
+            "properties": {
+             "response_format": {
+              "type": "string",
+              "enum": [
+               "json",
+               "toon"
+              ],
+              "default": "toon",
+              "description": "文本格式：json 或 toon，默认 toon"
+             },
+             "name": {
+              "type": "string",
+              "description": "可选。按技能名称模糊过滤。"
+             },
+             "category": {
+              "type": "string",
+              "description": "可选。按技能分类过滤。"
+             },
+             "page": {
+              "type": "integer",
+              "minimum": 1,
+              "description": "可选。页码，从 1 开始，默认 1。"
+             },
+             "page_size": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 100,
+              "description": "可选。每页大小，默认 20。"
+             }
+            }
+           }
+          }
+         },
+         "required": false
+        },
+        "responses": [
+         {
+          "status_code": "200",
+          "description": "ok",
+          "content": {
+           "application/json": {
+            "schema": {
+             "type": "object",
+             "properties": {
+              "entries": {
+               "type": "array",
+               "description": "已发布的技能列表",
+               "items": {
+                "type": "object",
+                "properties": {
+                 "skill_id": {
+                  "type": "string",
+                  "description": "技能 ID，供 get_skill_content / read_skill_file / execute_skill 使用"
+                 },
+                 "name": {
+                  "type": "string",
+                  "description": "技能名"
+                 },
+                 "description": {
+                  "type": "string",
+                  "description": "技能描述"
+                 },
+                 "version": {
+                  "type": "string",
+                  "description": "已发布版本"
+                 },
+                 "category": {
+                  "type": "string",
+                  "description": "技能分类"
+                 }
+                },
+                "additionalProperties": true
+               }
+              },
+              "total_count": {
+               "type": "integer",
+               "description": "符合过滤条件的技能总数"
+              },
+              "page": {
+               "type": "integer"
+              },
+              "page_size": {
+               "type": "integer"
+              },
+              "message": {
+               "type": "string",
+               "description": "空结果说明，仅当 entries 为空时出现"
+              }
+             }
+            }
+           }
+          }
+         }
+        ],
+        "components": null,
+        "callbacks": null,
+        "security": null,
+        "tags": null,
+        "external_docs": null
+       }
+      },
+      "use_rule": "",
+      "global_parameters": {
+       "name": "",
+       "description": "",
+       "required": false,
+       "in": "",
+       "type": "",
+       "value": null
+      },
+      "create_time": 1776920840668983300,
+      "update_time": 1776920840668983300,
+      "create_user": "ede150ba-06f4-11f1-85aa-3a34099a4c4b",
+      "update_user": "ede150ba-06f4-11f1-85aa-3a34099a4c4b",
+      "extend_info": null,
+      "resource_object": "tool",
+      "source_id": "353f83c8-a32e-5a67-b454-36508e113845",
+      "source_type": "openapi",
+      "script_type": "",
+      "code": "",
+      "dependencies": [],
+      "dependencies_url": ""
+     },
+     {
+      "tool_id": "9db297b5-e07d-594e-a1a4-1143ddbfe965",
+      "name": "get_skill_content",
+      "description": "读技能主文档 SKILL.md 正文，并返回技能包内的文件清单（files[].rel_path）。技能的用法与入口命令都写在这里；需要哪个附属文件再用 read_skill_file 单取，不必整包读。",
+      "status": "enabled",
+      "metadata_type": "openapi",
+      "metadata": {
+       "version": "e0169fb5-751b-52a2-a411-0c683e2cf51b",
+       "summary": "get_skill_content",
+       "description": "读技能主文档 SKILL.md 正文，并返回技能包内的文件清单（files[].rel_path）。技能的用法与入口命令都写在这里；需要哪个附属文件再用 read_skill_file 单取，不必整包读。",
+       "server_url": "http://agent-retrieval:30779",
+       "path": "/api/agent-retrieval/in/v1/kn/get_skill_content",
+       "method": "POST",
+       "create_time": 1776920840668983300,
+       "update_time": 1776920840668983300,
+       "create_user": "ede150ba-06f4-11f1-85aa-3a34099a4c4b",
+       "update_user": "ede150ba-06f4-11f1-85aa-3a34099a4c4b",
+       "api_spec": {
+        "parameters": [
+         {
+          "name": "x-account-id",
+          "in": "header",
+          "description": "账户ID，用于内部服务调用时传递账户信息",
+          "required": false,
+          "schema": {
+           "type": "string"
+          }
+         },
+         {
+          "name": "x-account-type",
+          "in": "header",
+          "description": "账户类型：user(用户), app(应用), anonymous(匿名)",
+          "required": false,
+          "schema": {
+           "enum": [
+            "user",
+            "app",
+            "anonymous"
+           ],
+           "type": "string"
+          }
+         }
+        ],
+        "request_body": {
+         "description": "",
+         "content": {
+          "application/json": {
+           "schema": {
+            "type": "object",
+            "properties": {
+             "response_format": {
+              "type": "string",
+              "enum": [
+               "json",
+               "toon"
+              ],
+              "default": "toon",
+              "description": "文本格式：json 或 toon，默认 toon"
+             },
+             "skill_id": {
+              "type": "string",
+              "description": "技能 ID（取自 list_skills 或 find_skills 的 skill_id）。"
+             }
+            },
+            "required": [
+             "skill_id"
+            ]
+           }
+          }
+         },
+         "required": true
+        },
+        "responses": [
+         {
+          "status_code": "200",
+          "description": "ok",
+          "content": {
+           "application/json": {
+            "schema": {
+             "type": "object",
+             "properties": {
+              "skill_id": {
+               "type": "string"
+              },
+              "status": {
+               "type": "string",
+               "description": "技能状态（published 等）"
+              },
+              "content": {
+               "type": "string",
+               "description": "SKILL.md 正文（技能的使用说明与入口命令）"
+              },
+              "truncated": {
+               "type": "boolean",
+               "description": "正文是否因超长被截断"
+              },
+              "files": {
+               "type": "array",
+               "description": "技能包内的文件清单。需要哪个文件的内容再用 read_skill_file 取，不必整包读。",
+               "items": {
+                "type": "object",
+                "properties": {
+                 "rel_path": {
+                  "type": "string",
+                  "description": "包内相对路径，read_skill_file 的 rel_path 用此值"
+                 },
+                 "file_type": {
+                  "type": "string"
+                 },
+                 "size": {
+                  "type": "integer",
+                  "description": "字节数"
+                 },
+                 "mime_type": {
+                  "type": "string"
+                 }
+                },
+                "additionalProperties": true
+               }
+              },
+              "message": {
+               "type": "string",
+               "description": "补充说明（如截断提示）"
+              }
+             }
+            }
+           }
+          }
+         }
+        ],
+        "components": null,
+        "callbacks": null,
+        "security": null,
+        "tags": null,
+        "external_docs": null
+       }
+      },
+      "use_rule": "",
+      "global_parameters": {
+       "name": "",
+       "description": "",
+       "required": false,
+       "in": "",
+       "type": "",
+       "value": null
+      },
+      "create_time": 1776920840668983300,
+      "update_time": 1776920840668983300,
+      "create_user": "ede150ba-06f4-11f1-85aa-3a34099a4c4b",
+      "update_user": "ede150ba-06f4-11f1-85aa-3a34099a4c4b",
+      "extend_info": null,
+      "resource_object": "tool",
+      "source_id": "e0169fb5-751b-52a2-a411-0c683e2cf51b",
+      "source_type": "openapi",
+      "script_type": "",
+      "code": "",
+      "dependencies": [],
+      "dependencies_url": ""
+     },
+     {
+      "tool_id": "5d0433cf-8d3a-5843-bf8a-1aafe9fd93e0",
+      "name": "read_skill_file",
+      "description": "读技能包内单个文件的正文，rel_path 取自 get_skill_content 返回的 files 清单。渐进式加载用：大文件不必常驻上下文。二进制文件只回元数据不回正文。",
+      "status": "enabled",
+      "metadata_type": "openapi",
+      "metadata": {
+       "version": "3926edb8-64d9-5c93-b8a9-2f644707ca33",
+       "summary": "read_skill_file",
+       "description": "读技能包内单个文件的正文，rel_path 取自 get_skill_content 返回的 files 清单。渐进式加载用：大文件不必常驻上下文。二进制文件只回元数据不回正文。",
+       "server_url": "http://agent-retrieval:30779",
+       "path": "/api/agent-retrieval/in/v1/kn/read_skill_file",
+       "method": "POST",
+       "create_time": 1776920840668983300,
+       "update_time": 1776920840668983300,
+       "create_user": "ede150ba-06f4-11f1-85aa-3a34099a4c4b",
+       "update_user": "ede150ba-06f4-11f1-85aa-3a34099a4c4b",
+       "api_spec": {
+        "parameters": [
+         {
+          "name": "x-account-id",
+          "in": "header",
+          "description": "账户ID，用于内部服务调用时传递账户信息",
+          "required": false,
+          "schema": {
+           "type": "string"
+          }
+         },
+         {
+          "name": "x-account-type",
+          "in": "header",
+          "description": "账户类型：user(用户), app(应用), anonymous(匿名)",
+          "required": false,
+          "schema": {
+           "enum": [
+            "user",
+            "app",
+            "anonymous"
+           ],
+           "type": "string"
+          }
+         }
+        ],
+        "request_body": {
+         "description": "",
+         "content": {
+          "application/json": {
+           "schema": {
+            "type": "object",
+            "properties": {
+             "response_format": {
+              "type": "string",
+              "enum": [
+               "json",
+               "toon"
+              ],
+              "default": "toon",
+              "description": "文本格式：json 或 toon，默认 toon"
+             },
+             "skill_id": {
+              "type": "string",
+              "description": "技能 ID（取自 list_skills 或 find_skills 的 skill_id）。"
+             },
+             "rel_path": {
+              "type": "string",
+              "description": "技能包内相对路径，取自 get_skill_content 返回的 files[].rel_path。不接受包外路径（../ 会被拒）。"
+             }
+            },
+            "required": [
+             "skill_id",
+             "rel_path"
+            ]
+           }
+          }
+         },
+         "required": true
+        },
+        "responses": [
+         {
+          "status_code": "200",
+          "description": "ok",
+          "content": {
+           "application/json": {
+            "schema": {
+             "type": "object",
+             "properties": {
+              "skill_id": {
+               "type": "string"
+              },
+              "rel_path": {
+               "type": "string"
+              },
+              "mime_type": {
+               "type": "string"
+              },
+              "file_type": {
+               "type": "string"
+              },
+              "content": {
+               "type": "string",
+               "description": "文件正文。二进制文件不返回此字段，只回 message 说明。"
+              },
+              "truncated": {
+               "type": "boolean",
+               "description": "正文是否因超长被截断"
+              },
+              "message": {
+               "type": "string",
+               "description": "补充说明（二进制未返回正文 / 截断提示）"
+              }
+             }
+            }
+           }
+          }
+         }
+        ],
+        "components": null,
+        "callbacks": null,
+        "security": null,
+        "tags": null,
+        "external_docs": null
+       }
+      },
+      "use_rule": "",
+      "global_parameters": {
+       "name": "",
+       "description": "",
+       "required": false,
+       "in": "",
+       "type": "",
+       "value": null
+      },
+      "create_time": 1776920840668983300,
+      "update_time": 1776920840668983300,
+      "create_user": "ede150ba-06f4-11f1-85aa-3a34099a4c4b",
+      "update_user": "ede150ba-06f4-11f1-85aa-3a34099a4c4b",
+      "extend_info": null,
+      "resource_object": "tool",
+      "source_id": "3926edb8-64d9-5c93-b8a9-2f644707ca33",
+      "source_type": "openapi",
+      "script_type": "",
+      "code": "",
+      "dependencies": [],
+      "dependencies_url": ""
+     },
+     {
+      "tool_id": "d3b3582b-ae4a-5b78-b1a0-aaf6b8c0065c",
+      "name": "execute_skill",
+      "description": "在沙箱内执行技能的入口命令，返回 exit_code / stdout / stderr。entry_shell 必须取自 SKILL.md 声明的入口，先用 get_skill_content 读清楚再调。",
+      "status": "enabled",
+      "metadata_type": "openapi",
+      "metadata": {
+       "version": "04acbde8-ca98-5bab-a2a7-2753218e4e06",
+       "summary": "execute_skill",
+       "description": "在沙箱内执行技能的入口命令，返回 exit_code / stdout / stderr。entry_shell 必须取自 SKILL.md 声明的入口，先用 get_skill_content 读清楚再调。",
+       "server_url": "http://agent-retrieval:30779",
+       "path": "/api/agent-retrieval/in/v1/kn/execute_skill",
+       "method": "POST",
+       "create_time": 1776920840668983300,
+       "update_time": 1776920840668983300,
+       "create_user": "ede150ba-06f4-11f1-85aa-3a34099a4c4b",
+       "update_user": "ede150ba-06f4-11f1-85aa-3a34099a4c4b",
+       "api_spec": {
+        "parameters": [
+         {
+          "name": "x-account-id",
+          "in": "header",
+          "description": "账户ID，用于内部服务调用时传递账户信息",
+          "required": false,
+          "schema": {
+           "type": "string"
+          }
+         },
+         {
+          "name": "x-account-type",
+          "in": "header",
+          "description": "账户类型：user(用户), app(应用), anonymous(匿名)",
+          "required": false,
+          "schema": {
+           "enum": [
+            "user",
+            "app",
+            "anonymous"
+           ],
+           "type": "string"
+          }
+         }
+        ],
+        "request_body": {
+         "description": "",
+         "content": {
+          "application/json": {
+           "schema": {
+            "type": "object",
+            "properties": {
+             "skill_id": {
+              "type": "string",
+              "description": "技能 ID（取自 list_skills 或 find_skills 的 skill_id）。"
+             },
+             "entry_shell": {
+              "type": "string",
+              "description": "在沙箱内执行的入口命令。必须取自 SKILL.md 中声明的入口，不要自行拼装无关命令。技能包已解压到工作目录，命令相对该目录执行。"
+             },
+             "timeout": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 600,
+              "description": "可选。执行超时秒数。"
+             }
+            },
+            "required": [
+             "skill_id",
+             "entry_shell"
+            ]
+           }
+          }
+         },
+         "required": true
+        },
+        "responses": [
+         {
+          "status_code": "200",
+          "description": "ok",
+          "content": {
+           "application/json": {
+            "schema": {
+             "type": "object",
+             "properties": {
+              "skill_id": {
+               "type": "string"
+              },
+              "exit_code": {
+               "type": "integer",
+               "description": "进程退出码，0 为成功"
+              },
+              "stdout": {
+               "type": "string",
+               "description": "标准输出（超长会截断）"
+              },
+              "stderr": {
+               "type": "string",
+               "description": "标准错误（超长会截断）"
+              },
+              "truncated": {
+               "type": "boolean",
+               "description": "stdout / stderr 是否被截断"
+              },
+              "execution_time": {
+               "type": "integer",
+               "description": "执行耗时（毫秒）"
+              },
+              "work_dir": {
+               "type": "string",
+               "description": "沙箱内工作目录"
+              },
+              "command": {
+               "type": "string",
+               "description": "实际执行的命令"
+              },
+              "mocked": {
+               "type": "boolean",
+               "description": "沙箱不可用时的桩执行标记"
+              }
+             }
+            }
+           }
+          }
+         }
+        ],
+        "components": null,
+        "callbacks": null,
+        "security": null,
+        "tags": null,
+        "external_docs": null
+       }
+      },
+      "use_rule": "",
+      "global_parameters": {
+       "name": "",
+       "description": "",
+       "required": false,
+       "in": "",
+       "type": "",
+       "value": null
+      },
+      "create_time": 1776920840668983300,
+      "update_time": 1776920840668983300,
+      "create_user": "ede150ba-06f4-11f1-85aa-3a34099a4c4b",
+      "update_user": "ede150ba-06f4-11f1-85aa-3a34099a4c4b",
+      "extend_info": null,
+      "resource_object": "tool",
+      "source_id": "04acbde8-ca98-5bab-a2a7-2753218e4e06",
+      "source_type": "openapi",
+      "script_type": "",
+      "code": "",
+      "dependencies": [],
+      "dependencies_url": ""
      }
     ],
     "create_time": 1776920840665934300,

--- a/adp/context-loader/agent-retrieval/server/drivenadapters/operator_integration_skill.go
+++ b/adp/context-loader/agent-retrieval/server/drivenadapters/operator_integration_skill.go
@@ -1,0 +1,247 @@
+// Copyright openbkn.ai
+//
+// Licensed under the OpenBKN License. See LICENSE-OPENBKN.txt in the project root.
+
+package drivenadapters
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strconv"
+
+	"github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/infra/common"
+	infraErr "github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/infra/errors"
+	"github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/interfaces"
+	"github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/utils"
+)
+
+const (
+	// https://{host}:{port}/api/agent-operator-integration/internal-v1/skills/market
+	listSkillsURI = "/internal-v1/skills/market"
+	// https://{host}:{port}/api/agent-operator-integration/internal-v1/skills/:skill_id/content
+	getSkillContentURI = "/internal-v1/skills/%s/content"
+	// https://{host}:{port}/api/agent-operator-integration/internal-v1/skills/:skill_id/files/read
+	readSkillFileURI = "/internal-v1/skills/%s/files/read"
+	// https://{host}:{port}/api/agent-operator-integration/internal-v1/skills/:skill_id/execute
+	executeSkillURI = "/internal-v1/skills/%s/execute"
+
+	defaultSkillPageSize = 20
+	// maxSkillAssetBytes 单个技能文件从对象存储取回的上限。超出即报错而不是截断：
+	// 截断点落在多字节字符中间会产出乱码，交给上层按 mime 决定要不要读更划算。
+	maxSkillAssetBytes = 5 << 20
+)
+
+// ListSkills 浏览已发布技能（走执行工厂的技能市场列表，只含已发布态）。
+func (o *operatorIntegrationClient) ListSkills(ctx context.Context, req *interfaces.ListSkillsRequest) (*interfaces.ListSkillsResponse, error) {
+	if req == nil {
+		req = &interfaces.ListSkillsRequest{}
+	}
+	page, pageSize := req.Page, req.PageSize
+	if page < 1 {
+		page = 1
+	}
+	if pageSize < 1 {
+		pageSize = defaultSkillPageSize
+	}
+
+	query := url.Values{}
+	query.Set("page", strconv.Itoa(page))
+	query.Set("page_size", strconv.Itoa(pageSize))
+	if req.Name != "" {
+		query.Set("name", req.Name)
+	}
+	if req.Category != "" {
+		query.Set("category", req.Category)
+	}
+
+	fullURL := o.baseURL + listSkillsURI
+	o.logger.WithContext(ctx).Debugf("[OperatorIntegration#ListSkills] URL: %s?%s", fullURL, query.Encode())
+
+	header := o.skillHeader(ctx, "operator.skill.list")
+	_, respBody, err := o.httpClient.Get(ctx, fullURL, query, header)
+	if err != nil {
+		o.logger.WithContext(ctx).Errorf("[OperatorIntegration#ListSkills] Request failed, err: %v", err)
+		return nil, infraErr.DefaultHTTPError(ctx, http.StatusBadGateway, fmt.Sprintf("技能列表接口调用失败: %v", err))
+	}
+
+	var raw struct {
+		Total    int `json:"total"`
+		Page     int `json:"page"`
+		PageSize int `json:"page_size"`
+		Data     []struct {
+			SkillID     string `json:"skill_id"`
+			Name        string `json:"name"`
+			Description string `json:"description"`
+			Version     string `json:"version"`
+			Category    string `json:"category"`
+			Status      string `json:"status"`
+		} `json:"data"`
+	}
+	if err = json.Unmarshal(utils.ObjectToByte(respBody), &raw); err != nil {
+		o.logger.WithContext(ctx).Errorf("[OperatorIntegration#ListSkills] Unmarshal failed, err: %v", err)
+		return nil, infraErr.DefaultHTTPError(ctx, http.StatusInternalServerError, fmt.Sprintf("解析技能列表响应失败: %v", err))
+	}
+
+	resp := &interfaces.ListSkillsResponse{
+		Entries:    make([]interfaces.SkillBrief, 0, len(raw.Data)),
+		TotalCount: raw.Total,
+		Page:       raw.Page,
+		PageSize:   raw.PageSize,
+	}
+	for _, item := range raw.Data {
+		resp.Entries = append(resp.Entries, interfaces.SkillBrief{
+			SkillID:     item.SkillID,
+			Name:        item.Name,
+			Description: item.Description,
+			Version:     item.Version,
+			Category:    item.Category,
+			Status:      item.Status,
+		})
+	}
+	return resp, nil
+}
+
+// GetSkillContent 取技能主文档正文 + 包内文件清单。
+// 执行工厂只回 presigned URL，正文由这里补第二跳取回。
+func (o *operatorIntegrationClient) GetSkillContent(ctx context.Context, skillID string) (*interfaces.GetSkillContentResponse, error) {
+	fullURL := o.baseURL + fmt.Sprintf(getSkillContentURI, url.PathEscape(skillID))
+	o.logger.WithContext(ctx).Debugf("[OperatorIntegration#GetSkillContent] URL: %s", fullURL)
+
+	header := o.skillHeader(ctx, "operator.skill.content")
+	_, respBody, err := o.httpClient.Get(ctx, fullURL, nil, header)
+	if err != nil {
+		o.logger.WithContext(ctx).Errorf("[OperatorIntegration#GetSkillContent] Request failed, err: %v", err)
+		return nil, infraErr.DefaultHTTPError(ctx, http.StatusBadGateway, fmt.Sprintf("技能内容接口调用失败: %v", err))
+	}
+
+	var raw struct {
+		SkillID string                        `json:"skill_id"`
+		URL     string                        `json:"url"`
+		Status  string                        `json:"status"`
+		Files   []interfaces.SkillFileSummary `json:"files"`
+	}
+	if err = json.Unmarshal(utils.ObjectToByte(respBody), &raw); err != nil {
+		o.logger.WithContext(ctx).Errorf("[OperatorIntegration#GetSkillContent] Unmarshal failed, err: %v", err)
+		return nil, infraErr.DefaultHTTPError(ctx, http.StatusInternalServerError, fmt.Sprintf("解析技能内容响应失败: %v", err))
+	}
+
+	content, err := o.fetchSkillAsset(ctx, raw.URL)
+	if err != nil {
+		return nil, err
+	}
+	return &interfaces.GetSkillContentResponse{
+		SkillID: firstNonEmptyStr(raw.SkillID, skillID),
+		Content: content,
+		Status:  raw.Status,
+		Files:   raw.Files,
+	}, nil
+}
+
+// ReadSkillFile 读技能包内单个文件（同样两跳）。
+func (o *operatorIntegrationClient) ReadSkillFile(ctx context.Context, req *interfaces.ReadSkillFileRequest) (*interfaces.ReadSkillFileResponse, error) {
+	fullURL := o.baseURL + fmt.Sprintf(readSkillFileURI, url.PathEscape(req.SkillID))
+	o.logger.WithContext(ctx).Debugf("[OperatorIntegration#ReadSkillFile] URL: %s, RelPath: %s", fullURL, req.RelPath)
+
+	header := o.skillHeader(ctx, "operator.skill.file_read")
+	// 字段名是 rel_path，执行工厂侧 validate:"required"；发 path 会 400。
+	_, respBody, err := o.httpClient.Post(ctx, fullURL, header, map[string]string{"rel_path": req.RelPath})
+	if err != nil {
+		o.logger.WithContext(ctx).Errorf("[OperatorIntegration#ReadSkillFile] Request failed, err: %v", err)
+		return nil, infraErr.DefaultHTTPError(ctx, http.StatusBadGateway, fmt.Sprintf("技能文件读取接口调用失败: %v", err))
+	}
+
+	var raw struct {
+		SkillID  string `json:"skill_id"`
+		RelPath  string `json:"rel_path"`
+		URL      string `json:"url"`
+		MimeType string `json:"mime_type"`
+		FileType string `json:"file_type"`
+	}
+	if err = json.Unmarshal(utils.ObjectToByte(respBody), &raw); err != nil {
+		o.logger.WithContext(ctx).Errorf("[OperatorIntegration#ReadSkillFile] Unmarshal failed, err: %v", err)
+		return nil, infraErr.DefaultHTTPError(ctx, http.StatusInternalServerError, fmt.Sprintf("解析技能文件响应失败: %v", err))
+	}
+
+	content, err := o.fetchSkillAsset(ctx, raw.URL)
+	if err != nil {
+		return nil, err
+	}
+	return &interfaces.ReadSkillFileResponse{
+		SkillID:  firstNonEmptyStr(raw.SkillID, req.SkillID),
+		RelPath:  firstNonEmptyStr(raw.RelPath, req.RelPath),
+		MimeType: raw.MimeType,
+		FileType: raw.FileType,
+		Content:  content,
+	}, nil
+}
+
+// ExecuteSkill 在沙箱内执行技能入口命令。授权由执行工厂按账户强制（execute / public_access）。
+func (o *operatorIntegrationClient) ExecuteSkill(ctx context.Context, req *interfaces.ExecuteSkillRequest) (*interfaces.ExecuteSkillResponse, error) {
+	fullURL := o.baseURL + fmt.Sprintf(executeSkillURI, url.PathEscape(req.SkillID))
+	o.logger.WithContext(ctx).Debugf("[OperatorIntegration#ExecuteSkill] URL: %s", fullURL)
+
+	header := o.skillHeader(ctx, "operator.skill.execute")
+	body := map[string]any{"entry_shell": req.EntryShell}
+	if req.Timeout > 0 {
+		body["timeout"] = req.Timeout
+	}
+	_, respBody, err := o.httpClient.Post(ctx, fullURL, header, body)
+	if err != nil {
+		o.logger.WithContext(ctx).Errorf("[OperatorIntegration#ExecuteSkill] Request failed, err: %v", err)
+		return nil, infraErr.DefaultHTTPError(ctx, http.StatusBadGateway, fmt.Sprintf("技能执行接口调用失败: %v", err))
+	}
+
+	resp := &interfaces.ExecuteSkillResponse{}
+	if err = json.Unmarshal(utils.ObjectToByte(respBody), resp); err != nil {
+		o.logger.WithContext(ctx).Errorf("[OperatorIntegration#ExecuteSkill] Unmarshal failed, err: %v", err)
+		return nil, infraErr.DefaultHTTPError(ctx, http.StatusInternalServerError, fmt.Sprintf("解析技能执行响应失败: %v", err))
+	}
+	if resp.SkillID == "" {
+		resp.SkillID = req.SkillID
+	}
+	return resp, nil
+}
+
+// fetchSkillAsset 取对象存储上的技能文件正文。
+// 这是发布态技能的第二跳：元数据接口只回 presigned URL，正文得自己取。
+func (o *operatorIntegrationClient) fetchSkillAsset(ctx context.Context, assetURL string) ([]byte, error) {
+	if assetURL == "" {
+		return nil, infraErr.DefaultHTTPError(ctx, http.StatusNotFound, "技能文件下载地址为空")
+	}
+	// presigned URL 自带签名，不能带上账户/追踪头（部分对象存储会把额外头计入签名校验）。
+	code, body, err := o.httpClient.GetNoUnmarshal(ctx, assetURL, nil, nil)
+	if err != nil {
+		o.logger.WithContext(ctx).Errorf("[OperatorIntegration#fetchSkillAsset] Request failed, err: %v", err)
+		return nil, infraErr.DefaultHTTPError(ctx, http.StatusBadGateway, fmt.Sprintf("技能文件下载失败: %v", err))
+	}
+	if code < http.StatusOK || code >= http.StatusMultipleChoices {
+		return nil, infraErr.DefaultHTTPError(ctx, http.StatusBadGateway, fmt.Sprintf("技能文件下载返回异常状态: %d", code))
+	}
+	if len(body) > maxSkillAssetBytes {
+		return nil, infraErr.DefaultHTTPError(ctx, http.StatusRequestEntityTooLarge,
+			fmt.Sprintf("技能文件超过 %d 字节上限，请改用技能包下载接口获取", maxSkillAssetBytes))
+	}
+	return body, nil
+}
+
+// skillHeader 组装出站头：账户身份 + 追踪上下文 + 业务域。
+// 业务域是技能市场列表的必填项，取不到时退回默认业务域。
+func (o *operatorIntegrationClient) skillHeader(ctx context.Context, operationName string) map[string]string {
+	header := common.GetHeaderForChildOperation(ctx, operationName, 1)
+	if bd := header[string(interfaces.HeaderXBusinessDomain)]; bd == "" {
+		header[string(interfaces.HeaderXBusinessDomain)] = interfaces.DefaultBusinessDomainID
+	}
+	return header
+}
+
+func firstNonEmptyStr(values ...string) string {
+	for _, value := range values {
+		if value != "" {
+			return value
+		}
+	}
+	return ""
+}

--- a/adp/context-loader/agent-retrieval/server/driveradapters/knskills/index.go
+++ b/adp/context-loader/agent-retrieval/server/driveradapters/knskills/index.go
@@ -1,0 +1,129 @@
+// Copyright openbkn.ai
+//
+// Licensed under the OpenBKN License. See LICENSE-OPENBKN.txt in the project root.
+
+// Package knskills 提供技能浏览 / 阅读 / 执行工具的内部 REST 入口：
+// list_skills、get_skill_content、read_skill_file、execute_skill。
+// 这几条与同名 MCP 工具同源，同时作为 operator-integration toolbox(OpenAPI HTTP)的后端。
+package knskills
+
+import (
+	"net/http"
+	"sync"
+
+	"github.com/gin-gonic/gin"
+
+	"github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/infra/config"
+	"github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/infra/errors"
+	"github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/infra/rest"
+	"github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/interfaces"
+	logicsSkills "github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/logics/knskills"
+)
+
+// KnSkillsHandler 技能浏览 / 阅读 / 执行的 HTTP 入口。
+type KnSkillsHandler interface {
+	ListSkills(c *gin.Context)
+	GetSkillContent(c *gin.Context)
+	ReadSkillFile(c *gin.Context)
+	ExecuteSkill(c *gin.Context)
+}
+
+type knSkillsHandler struct {
+	logger interfaces.Logger
+	skills logicsSkills.KnSkillsService
+}
+
+var (
+	handlerOnce sync.Once
+	handlerInst KnSkillsHandler
+)
+
+// NewKnSkillsHandler 创建 KnSkillsHandler 单例。
+func NewKnSkillsHandler() KnSkillsHandler {
+	handlerOnce.Do(func() {
+		conf := config.NewConfigLoader()
+		handlerInst = &knSkillsHandler{
+			logger: conf.GetLogger(),
+			skills: logicsSkills.NewKnSkillsService(),
+		}
+	})
+	return handlerInst
+}
+
+// ListSkills 浏览已发布技能（不需要知识网络上下文，与 find_skills 互补）。
+func (h *knSkillsHandler) ListSkills(c *gin.Context) {
+	ctx := c.Request.Context()
+	req := &logicsSkills.ListSkillsReq{}
+	// body 可选；忽略空 body 的绑定错误。
+	_ = c.ShouldBindJSON(req)
+
+	resp, err := h.skills.ListSkills(ctx, req)
+	if err != nil {
+		h.logger.WithContext(ctx).Warnf("[KnSkillsHandler#ListSkills] failed: %v", err)
+		rest.ReplyError(c, err)
+		return
+	}
+	rest.ReplyOK(c, http.StatusOK, resp)
+}
+
+// skillIDReq get_skill_content 入参。
+type skillIDReq struct {
+	SkillID string `json:"skill_id" form:"skill_id"`
+}
+
+// GetSkillContent 取 SKILL.md 正文 + 包内文件清单。
+func (h *knSkillsHandler) GetSkillContent(c *gin.Context) {
+	ctx := c.Request.Context()
+	req := &skillIDReq{}
+	_ = c.ShouldBindQuery(req)
+	_ = c.ShouldBindJSON(req)
+	if req.SkillID == "" {
+		rest.ReplyError(c, errors.DefaultHTTPError(ctx, http.StatusBadRequest, logicsSkills.ErrSkillIDRequired.Error()))
+		return
+	}
+
+	resp, err := h.skills.GetSkillContent(ctx, req.SkillID)
+	if err != nil {
+		h.logger.WithContext(ctx).Warnf("[KnSkillsHandler#GetSkillContent] failed: %v", err)
+		rest.ReplyError(c, err)
+		return
+	}
+	rest.ReplyOK(c, http.StatusOK, resp)
+}
+
+// ReadSkillFile 读技能包内单个文件（rel_path 取自 get_skill_content 的 files 清单）。
+func (h *knSkillsHandler) ReadSkillFile(c *gin.Context) {
+	ctx := c.Request.Context()
+	req := &logicsSkills.ReadSkillFileReq{}
+	_ = c.ShouldBindQuery(req)
+	if err := c.ShouldBindJSON(req); err != nil && req.SkillID == "" {
+		rest.ReplyError(c, errors.DefaultHTTPError(ctx, http.StatusBadRequest, err.Error()))
+		return
+	}
+
+	resp, err := h.skills.ReadSkillFile(ctx, req)
+	if err != nil {
+		h.logger.WithContext(ctx).Warnf("[KnSkillsHandler#ReadSkillFile] failed: %v", err)
+		rest.ReplyError(c, errors.DefaultHTTPError(ctx, http.StatusBadRequest, err.Error()))
+		return
+	}
+	rest.ReplyOK(c, http.StatusOK, resp)
+}
+
+// ExecuteSkill 在沙箱内执行技能入口命令。
+func (h *knSkillsHandler) ExecuteSkill(c *gin.Context) {
+	ctx := c.Request.Context()
+	req := &logicsSkills.ExecuteSkillReq{}
+	if err := c.ShouldBindJSON(req); err != nil {
+		rest.ReplyError(c, errors.DefaultHTTPError(ctx, http.StatusBadRequest, err.Error()))
+		return
+	}
+
+	resp, err := h.skills.ExecuteSkill(ctx, req)
+	if err != nil {
+		h.logger.WithContext(ctx).Warnf("[KnSkillsHandler#ExecuteSkill] failed: %v", err)
+		rest.ReplyError(c, errors.DefaultHTTPError(ctx, http.StatusBadRequest, err.Error()))
+		return
+	}
+	rest.ReplyOK(c, http.StatusOK, resp)
+}

--- a/adp/context-loader/agent-retrieval/server/driveradapters/lifecycle_middleware_test.go
+++ b/adp/context-loader/agent-retrieval/server/driveradapters/lifecycle_middleware_test.go
@@ -116,6 +116,7 @@ func TestRegisteredOperatorAndMCPProxyRoutesCannotBypassLifecycle(t *testing.T) 
 		KnSearchHandler:                stubKnSearchHandler{},
 		KnFindSkillsHandler:            stubKnFindSkillsHandler{},
 		KnQueryToolsHandler:            queryTools,
+		KnSkillsHandler:                stubKnSkillsHandler{},
 		LifecycleClient:                bkntrace.NewLifecycleClient("", nil),
 		Logger:                         logger.DefaultLogger(),
 	}
@@ -145,6 +146,7 @@ func TestRegisteredOperatorAndMCPProxyRoutesCannotBypassLifecycle(t *testing.T) 
 		KnSearchHandler:                stubKnSearchHandler{},
 		KnFindSkillsHandler:            stubKnFindSkillsHandler{},
 		KnQueryToolsHandler:            &countingQueryToolsHandler{},
+		KnSkillsHandler:                stubKnSkillsHandler{},
 		MCPProxyHandler:                proxy,
 		LifecycleClient:                bkntrace.NewLifecycleClient("", nil),
 		Logger:                         logger.DefaultLogger(),

--- a/adp/context-loader/agent-retrieval/server/driveradapters/mcp/app.go
+++ b/adp/context-loader/agent-retrieval/server/driveradapters/mcp/app.go
@@ -27,6 +27,7 @@ import (
 	"github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/logics/knresources"
 	"github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/logics/knrunsql"
 	"github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/logics/knsearch"
+	"github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/logics/knskills"
 )
 
 const (
@@ -50,6 +51,10 @@ const (
 	toolKeyRunSQL                   = "run_sql"
 	toolKeyListResources            = "list_resources"
 	toolKeyDescribeResource         = "describe_resource"
+	toolKeyListSkills               = "list_skills"
+	toolKeyGetSkillContent          = "get_skill_content"
+	toolKeyReadSkillFile            = "read_skill_file"
+	toolKeyExecuteSkill             = "execute_skill"
 )
 
 // serverInstructions is returned at MCP initialize. It gives the LLM a
@@ -174,6 +179,16 @@ func newMCPServer(lifecycleClient *bkntrace.LifecycleClient) (*server.MCPServer,
 	resourcesService := knresources.NewKnResourcesService()
 	b.add(toolKeyListResources, handleListResources(resourcesService))
 	b.add(toolKeyDescribeResource, handleDescribeResource(resourcesService))
+
+	// 技能面：find_skills 只回 id/名/描述，下面三条才是拿到 id 之后能走的路。
+	skillsService := knskills.NewKnSkillsService()
+	b.add(toolKeyListSkills, handleListSkills(skillsService))
+	b.add(toolKeyGetSkillContent, handleGetSkillContent(skillsService))
+	b.add(toolKeyReadSkillFile, handleReadSkillFile(skillsService))
+	// execute_skill 是工具面唯一的命令执行通道，默认不装配（见 executeSkillEnabled）。
+	if executeSkillEnabled() {
+		b.add(toolKeyExecuteSkill, handleExecuteSkill(skillsService))
+	}
 
 	// The lifecycle tools are registered straight onto the server by the tracing
 	// adapter rather than through the builder. Claim their advertised names all

--- a/adp/context-loader/agent-retrieval/server/driveradapters/mcp/community_parity_test.go
+++ b/adp/context-loader/agent-retrieval/server/driveradapters/mcp/community_parity_test.go
@@ -49,14 +49,19 @@ var communityTools = []string{
 	"get_logic_properties_values",
 	"get_object_types",
 	"get_relation_types",
+	"get_skill_content",
 	"list_action_executions",
 	"list_knowledge_networks",
 	"list_resources",
+	"list_skills",
 	"query_instance_subgraph",
 	"query_metric",
 	"query_object_instance",
+	"read_skill_file",
 	"run_sql",
 	"search_schema",
+	// execute_skill 默认不装配（MCP_EXECUTE_SKILL_ENABLED），所以不在这份基线里，
+	// 由 TestExecuteSkillOnlyAppearsWhenEnabled 单独盯。
 }
 
 // noExtensions puts the process in the state a community binary is always in:

--- a/adp/context-loader/agent-retrieval/server/driveradapters/mcp/info.go
+++ b/adp/context-loader/agent-retrieval/server/driveradapters/mcp/info.go
@@ -74,6 +74,11 @@ func BuildMCPInfo(endpoint string) (*MCPInfo, error) {
 	}
 	all := make([]entry, 0, len(meta))
 	for key, m := range meta {
+		// 未装配的工具不能出现在这里：这个端点的用途是「不握手就看清能力面」，
+		// 广播一条 tools/call 会答「无此工具」的条目比不广播更糟。
+		if key == toolKeyExecuteSkill && !executeSkillEnabled() {
+			continue
+		}
 		in, out := tryLoadToolSchemas(key)
 		if d, ok := mcptool.DecoratorFor(key); ok && d.Allowed() {
 			in = d.Patch(in)

--- a/adp/context-loader/agent-retrieval/server/driveradapters/mcp/schemas/README.md
+++ b/adp/context-loader/agent-retrieval/server/driveradapters/mcp/schemas/README.md
@@ -15,6 +15,17 @@
 2. 添加 `{tool_key}.json`，包含 `input_schema` 与 `output_schema` 两个 JSON Schema 对象
 3. 在 `app.go` 中注册工具（`loadToolMeta` 与 `loadToolSchemas` 已统一封装，无需修改 `schemas.go`）
 
+## 开关控制的工具
+
+个别工具默认不装配，需要显式开启后才出现在 `tools/list` 与 `GET /mcp/info`：
+
+| 工具 | 环境变量 | 默认 | 说明 |
+|------|---------|------|------|
+| `execute_skill` | `MCP_EXECUTE_SKILL_ENABLED` | 关 | 把入口命令送进沙箱执行，是工具面唯一的命令执行通道。未开启时与「没编译进来」无异——不能让「未开启」和「不存在」在探测者眼里长得不一样 |
+
+新增此类工具时，`app.go` 的装配与 `info.go` 的目录都要按同一个判定跳过，
+两处不一致会让 `/mcp/info` 广播一条调不通的工具。
+
 ## 描述参考
 
 描述建议参考 `docs/releases/v5.0.4/tool-usage-guide.md` 中的「工具总览」与「工具参考」章节。

--- a/adp/context-loader/agent-retrieval/server/driveradapters/mcp/schemas/execute_skill.json
+++ b/adp/context-loader/agent-retrieval/server/driveradapters/mcp/schemas/execute_skill.json
@@ -1,0 +1,36 @@
+{
+  "input_schema": {
+    "type": "object",
+    "properties": {
+      "skill_id": {
+        "type": "string",
+        "description": "技能 ID（取自 list_skills 或 find_skills 的 skill_id）。"
+      },
+      "entry_shell": {
+        "type": "string",
+        "description": "在沙箱内执行的入口命令。必须取自 SKILL.md 中声明的入口，不要自行拼装无关命令。技能包已解压到工作目录，命令相对该目录执行。"
+      },
+      "timeout": {
+        "type": "integer",
+        "minimum": 1,
+        "maximum": 600,
+        "description": "可选。执行超时秒数。"
+      }
+    },
+    "required": ["skill_id", "entry_shell"]
+  },
+  "output_schema": {
+    "type": "object",
+    "properties": {
+      "skill_id": { "type": "string" },
+      "exit_code": { "type": "integer", "description": "进程退出码，0 为成功" },
+      "stdout": { "type": "string", "description": "标准输出（超长会截断）" },
+      "stderr": { "type": "string", "description": "标准错误（超长会截断）" },
+      "truncated": { "type": "boolean", "description": "stdout / stderr 是否被截断" },
+      "execution_time": { "type": "integer", "description": "执行耗时（毫秒）" },
+      "work_dir": { "type": "string", "description": "沙箱内工作目录" },
+      "command": { "type": "string", "description": "实际执行的命令" },
+      "mocked": { "type": "boolean", "description": "沙箱不可用时的桩执行标记" }
+    }
+  }
+}

--- a/adp/context-loader/agent-retrieval/server/driveradapters/mcp/schemas/get_skill_content.json
+++ b/adp/context-loader/agent-retrieval/server/driveradapters/mcp/schemas/get_skill_content.json
@@ -1,0 +1,42 @@
+{
+  "input_schema": {
+    "type": "object",
+    "properties": {
+      "response_format": {
+        "type": "string",
+        "enum": ["json", "toon"],
+        "default": "toon",
+        "description": "文本格式：json 或 toon，默认 toon"
+      },
+      "skill_id": {
+        "type": "string",
+        "description": "技能 ID（取自 list_skills 或 find_skills 的 skill_id）。"
+      }
+    },
+    "required": ["skill_id"]
+  },
+  "output_schema": {
+    "type": "object",
+    "properties": {
+      "skill_id": { "type": "string" },
+      "status": { "type": "string", "description": "技能状态（published 等）" },
+      "content": { "type": "string", "description": "SKILL.md 正文（技能的使用说明与入口命令）" },
+      "truncated": { "type": "boolean", "description": "正文是否因超长被截断" },
+      "files": {
+        "type": "array",
+        "description": "技能包内的文件清单。需要哪个文件的内容再用 read_skill_file 取，不必整包读。",
+        "items": {
+          "type": "object",
+          "properties": {
+            "rel_path": { "type": "string", "description": "包内相对路径，read_skill_file 的 rel_path 用此值" },
+            "file_type": { "type": "string" },
+            "size": { "type": "integer", "description": "字节数" },
+            "mime_type": { "type": "string" }
+          },
+          "additionalProperties": true
+        }
+      },
+      "message": { "type": "string", "description": "补充说明（如截断提示）" }
+    }
+  }
+}

--- a/adp/context-loader/agent-retrieval/server/driveradapters/mcp/schemas/list_skills.json
+++ b/adp/context-loader/agent-retrieval/server/driveradapters/mcp/schemas/list_skills.json
@@ -1,0 +1,56 @@
+{
+  "input_schema": {
+    "type": "object",
+    "properties": {
+      "response_format": {
+        "type": "string",
+        "enum": ["json", "toon"],
+        "default": "toon",
+        "description": "文本格式：json 或 toon，默认 toon"
+      },
+      "name": {
+        "type": "string",
+        "description": "可选。按技能名称模糊过滤。"
+      },
+      "category": {
+        "type": "string",
+        "description": "可选。按技能分类过滤。"
+      },
+      "page": {
+        "type": "integer",
+        "minimum": 1,
+        "description": "可选。页码，从 1 开始，默认 1。"
+      },
+      "page_size": {
+        "type": "integer",
+        "minimum": 1,
+        "maximum": 100,
+        "description": "可选。每页大小，默认 20。"
+      }
+    }
+  },
+  "output_schema": {
+    "type": "object",
+    "properties": {
+      "entries": {
+        "type": "array",
+        "description": "已发布的技能列表",
+        "items": {
+          "type": "object",
+          "properties": {
+            "skill_id": { "type": "string", "description": "技能 ID，供 get_skill_content / read_skill_file / execute_skill 使用" },
+            "name": { "type": "string", "description": "技能名" },
+            "description": { "type": "string", "description": "技能描述" },
+            "version": { "type": "string", "description": "已发布版本" },
+            "category": { "type": "string", "description": "技能分类" }
+          },
+          "additionalProperties": true
+        }
+      },
+      "total_count": { "type": "integer", "description": "符合过滤条件的技能总数" },
+      "page": { "type": "integer" },
+      "page_size": { "type": "integer" },
+      "message": { "type": "string", "description": "空结果说明，仅当 entries 为空时出现" }
+    }
+  }
+}

--- a/adp/context-loader/agent-retrieval/server/driveradapters/mcp/schemas/locales/en-US/tools_meta.json
+++ b/adp/context-loader/agent-retrieval/server/driveradapters/mcp/schemas/locales/en-US/tools_meta.json
@@ -58,5 +58,21 @@
   "describe_resource": {
     "name": "describe_resource",
     "description": "Describe one data resource's physical schema, including connector type and columns. Use this before writing run_sql against raw resources."
+  },
+  "list_skills": {
+    "name": "list_skills",
+    "description": "Browse published skills without a knowledge-network context. Complements find_skills, which recalls by object type or instance: this one pages a list filtered by name or category. Take the skill_id to get_skill_content for SKILL.md, read_skill_file for bundled files, execute_skill to run the entry command."
+  },
+  "get_skill_content": {
+    "name": "get_skill_content",
+    "description": "Read a skill's SKILL.md body and the file listing of its bundle (files[].rel_path). Usage and entry commands are documented there; fetch individual bundled files with read_skill_file instead of reading the whole package."
+  },
+  "read_skill_file": {
+    "name": "read_skill_file",
+    "description": "Read one file from a skill bundle; rel_path comes from the files listing returned by get_skill_content. For progressive loading — large files need not stay in context. Binary files return metadata only, no body."
+  },
+  "execute_skill": {
+    "name": "execute_skill",
+    "description": "Run a skill's entry command inside the sandbox and return exit_code / stdout / stderr. entry_shell must come from the entry declared in SKILL.md — read it with get_skill_content first."
   }
 }

--- a/adp/context-loader/agent-retrieval/server/driveradapters/mcp/schemas/read_skill_file.json
+++ b/adp/context-loader/agent-retrieval/server/driveradapters/mcp/schemas/read_skill_file.json
@@ -1,0 +1,34 @@
+{
+  "input_schema": {
+    "type": "object",
+    "properties": {
+      "response_format": {
+        "type": "string",
+        "enum": ["json", "toon"],
+        "default": "toon",
+        "description": "文本格式：json 或 toon，默认 toon"
+      },
+      "skill_id": {
+        "type": "string",
+        "description": "技能 ID（取自 list_skills 或 find_skills 的 skill_id）。"
+      },
+      "rel_path": {
+        "type": "string",
+        "description": "技能包内相对路径，取自 get_skill_content 返回的 files[].rel_path。不接受包外路径（../ 会被拒）。"
+      }
+    },
+    "required": ["skill_id", "rel_path"]
+  },
+  "output_schema": {
+    "type": "object",
+    "properties": {
+      "skill_id": { "type": "string" },
+      "rel_path": { "type": "string" },
+      "mime_type": { "type": "string" },
+      "file_type": { "type": "string" },
+      "content": { "type": "string", "description": "文件正文。二进制文件不返回此字段，只回 message 说明。" },
+      "truncated": { "type": "boolean", "description": "正文是否因超长被截断" },
+      "message": { "type": "string", "description": "补充说明（二进制未返回正文 / 截断提示）" }
+    }
+  }
+}

--- a/adp/context-loader/agent-retrieval/server/driveradapters/mcp/schemas/tools_meta.json
+++ b/adp/context-loader/agent-retrieval/server/driveradapters/mcp/schemas/tools_meta.json
@@ -74,5 +74,21 @@
   "describe_resource": {
     "name": "describe_resource",
     "description": "取单个数据资源的物理 schema：connector_type 与列（columns:[{name,type}]）。写 run_sql 前用它拿物理列名。入参 resource_id 取自 list_resources。"
+  },
+  "list_skills": {
+    "name": "list_skills",
+    "description": "浏览已发布技能（不需要知识网络上下文）。与 find_skills 互补：那条按对象类/实例召回，这条按名称或分类翻列表。拿到 skill_id 后用 get_skill_content 读 SKILL.md，用 read_skill_file 下钻附属文件，用 execute_skill 执行入口命令。"
+  },
+  "get_skill_content": {
+    "name": "get_skill_content",
+    "description": "读技能主文档 SKILL.md 正文，并返回技能包内的文件清单（files[].rel_path）。技能的用法与入口命令都写在这里；需要哪个附属文件再用 read_skill_file 单取，不必整包读。"
+  },
+  "read_skill_file": {
+    "name": "read_skill_file",
+    "description": "读技能包内单个文件的正文，rel_path 取自 get_skill_content 返回的 files 清单。渐进式加载用：大文件不必常驻上下文。二进制文件只回元数据不回正文。"
+  },
+  "execute_skill": {
+    "name": "execute_skill",
+    "description": "在沙箱内执行技能的入口命令，返回 exit_code / stdout / stderr。entry_shell 必须取自 SKILL.md 声明的入口，先用 get_skill_content 读清楚再调。"
   }
 }

--- a/adp/context-loader/agent-retrieval/server/driveradapters/mcp/tools_skills.go
+++ b/adp/context-loader/agent-retrieval/server/driveradapters/mcp/tools_skills.go
@@ -1,0 +1,142 @@
+// Copyright openbkn.ai
+//
+// Licensed under the OpenBKN License. See LICENSE-OPENBKN.txt in the project root.
+
+package mcp
+
+import (
+	"context"
+	"os"
+	"strconv"
+	"strings"
+
+	"github.com/mark3labs/mcp-go/mcp"
+
+	"github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/infra/rest"
+	"github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/logics/knskills"
+)
+
+// executeSkillEnabledEnv 控制 execute_skill 是否出现在工具面。
+//
+// 这条工具把模型生成的 shell 命令送进沙箱执行，是整个工具面唯一的命令执行通道，
+// 所以默认不装配：未开启时它既不在 tools/list 也不在 /mcp/info，与从未编译进来无异。
+const executeSkillEnabledEnv = "MCP_EXECUTE_SKILL_ENABLED"
+
+// executeSkillEnabled 判断是否装配 execute_skill。默认关。
+func executeSkillEnabled() bool {
+	value := strings.TrimSpace(os.Getenv(executeSkillEnabledEnv))
+	if value == "" {
+		return false
+	}
+	enabled, err := strconv.ParseBool(value)
+	return err == nil && enabled
+}
+
+// handleListSkills handles list_skills tool calls: 浏览已发布技能，不需要知识网络上下文。
+func handleListSkills(svc knskills.KnSkillsService) func(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	return func(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		format, err := GetResponseFormatFromRequest(req)
+		if err != nil {
+			return mcp.NewToolResultError(err.Error()), nil
+		}
+
+		listReq := &knskills.ListSkillsReq{}
+		if err := bindArguments(req, listReq); err != nil {
+			return mcp.NewToolResultError(err.Error()), nil
+		}
+
+		resp, err := svc.ListSkills(ctx, listReq)
+		if err != nil {
+			return mcp.NewToolResultError(err.Error()), nil
+		}
+		result, err := BuildMCPToolResult(resp, format)
+		if err != nil {
+			return mcp.NewToolResultError(err.Error()), nil
+		}
+		return result, nil
+	}
+}
+
+// handleGetSkillContent handles get_skill_content tool calls: SKILL.md 正文 + 包内文件清单。
+func handleGetSkillContent(svc knskills.KnSkillsService) func(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	return func(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		format, err := GetResponseFormatFromRequest(req)
+		if err != nil {
+			return mcp.NewToolResultError(err.Error()), nil
+		}
+
+		skillID := getStringArg(req, "skill_id", "")
+		if skillID == "" {
+			return mcp.NewToolResultError(knskills.ErrSkillIDRequired.Error()), nil
+		}
+
+		resp, err := svc.GetSkillContent(ctx, skillID)
+		if err != nil {
+			return mcp.NewToolResultError(err.Error()), nil
+		}
+		result, err := BuildMCPToolResult(resp, format)
+		if err != nil {
+			return mcp.NewToolResultError(err.Error()), nil
+		}
+		return result, nil
+	}
+}
+
+// handleReadSkillFile handles read_skill_file tool calls: 按 rel_path 取技能包内单个文件正文。
+func handleReadSkillFile(svc knskills.KnSkillsService) func(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	return func(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		format, err := GetResponseFormatFromRequest(req)
+		if err != nil {
+			return mcp.NewToolResultError(err.Error()), nil
+		}
+
+		readReq := &knskills.ReadSkillFileReq{}
+		if err := bindArguments(req, readReq); err != nil {
+			return mcp.NewToolResultError(err.Error()), nil
+		}
+		if readReq.SkillID == "" {
+			return mcp.NewToolResultError(knskills.ErrSkillIDRequired.Error()), nil
+		}
+		if readReq.RelPath == "" {
+			return mcp.NewToolResultError(knskills.ErrRelPathRequired.Error()), nil
+		}
+
+		resp, err := svc.ReadSkillFile(ctx, readReq)
+		if err != nil {
+			return mcp.NewToolResultError(err.Error()), nil
+		}
+		result, err := BuildMCPToolResult(resp, format)
+		if err != nil {
+			return mcp.NewToolResultError(err.Error()), nil
+		}
+		return result, nil
+	}
+}
+
+// handleExecuteSkill handles execute_skill tool calls: 在沙箱内执行技能入口命令。
+// 授权由执行工厂按账户强制（execute / public_access 二者之一）。
+func handleExecuteSkill(svc knskills.KnSkillsService) func(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	return func(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		execReq := &knskills.ExecuteSkillReq{}
+		if err := bindArguments(req, execReq); err != nil {
+			return mcp.NewToolResultError(err.Error()), nil
+		}
+		if execReq.SkillID == "" {
+			return mcp.NewToolResultError(knskills.ErrSkillIDRequired.Error()), nil
+		}
+		if execReq.EntryShell == "" {
+			return mcp.NewToolResultError(knskills.ErrEntryShellRequired.Error()), nil
+		}
+
+		resp, err := svc.ExecuteSkill(ctx, execReq)
+		if err != nil {
+			return mcp.NewToolResultError(err.Error()), nil
+		}
+		// 与 execute_action 一致：执行结果始终返回 JSON，exit_code / stdout 需机器可消费。
+		result, err := BuildMCPToolResult(resp, rest.FormatJSON)
+		if err != nil {
+			return mcp.NewToolResultError(err.Error()), nil
+		}
+		return result, nil
+	}
+}

--- a/adp/context-loader/agent-retrieval/server/driveradapters/mcp/tools_skills_test.go
+++ b/adp/context-loader/agent-retrieval/server/driveradapters/mcp/tools_skills_test.go
@@ -1,0 +1,67 @@
+// Copyright openbkn.ai
+//
+// Licensed under the OpenBKN License. See LICENSE-OPENBKN.txt in the project root.
+
+package mcp
+
+import (
+	"slices"
+	"testing"
+)
+
+// TestExecuteSkillOnlyAppearsWhenEnabled 盯住那条命令执行通道的默认状态。
+//
+// execute_skill 把模型生成的 shell 送进沙箱，默认必须既不在 tools/list 也不在
+// /mcp/info——「未开启」要和「没编译进来」长得一样，否则等于对着任何探测者
+// 广播这台服务能执行命令。
+func TestExecuteSkillOnlyAppearsWhenEnabled(t *testing.T) {
+	noExtensions(t)
+
+	if slices.Contains(assembledNames(t), toolKeyExecuteSkill) {
+		t.Fatalf("execute_skill 在未开启时出现在 tools/list")
+	}
+	info, err := BuildMCPInfo("https://example.invalid/mcp")
+	if err != nil {
+		t.Fatalf("BuildMCPInfo: %v", err)
+	}
+	for _, tool := range info.Tools {
+		if tool.Name == toolKeyExecuteSkill {
+			t.Fatalf("execute_skill 在未开启时出现在 /mcp/info")
+		}
+	}
+
+	t.Setenv(executeSkillEnabledEnv, "true")
+
+	if !slices.Contains(assembledNames(t), toolKeyExecuteSkill) {
+		t.Fatalf("开启后 execute_skill 仍未出现在 tools/list")
+	}
+	info, err = BuildMCPInfo("https://example.invalid/mcp")
+	if err != nil {
+		t.Fatalf("BuildMCPInfo: %v", err)
+	}
+	found := false
+	for _, tool := range info.Tools {
+		if tool.Name == toolKeyExecuteSkill {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("开启后 execute_skill 仍未出现在 /mcp/info")
+	}
+}
+
+// TestSkillToolsAdvertiseSchemas 三条读工具的 schema 必须能加载且非空——
+// 装配期 loadToolSchemas 是 panic 语义，漏文件会在服务启动时才炸。
+func TestSkillToolsAdvertiseSchemas(t *testing.T) {
+	noExtensions(t)
+
+	for _, key := range []string{toolKeyListSkills, toolKeyGetSkillContent, toolKeyReadSkillFile, toolKeyExecuteSkill} {
+		in, out := tryLoadToolSchemas(key)
+		if len(in) == 0 {
+			t.Fatalf("%s 缺 input_schema", key)
+		}
+		if len(out) == 0 {
+			t.Fatalf("%s 缺 output_schema", key)
+		}
+	}
+}

--- a/adp/context-loader/agent-retrieval/server/driveradapters/middleware_test.go
+++ b/adp/context-loader/agent-retrieval/server/driveradapters/middleware_test.go
@@ -230,6 +230,13 @@ func (stubKnFindSkillsHandler) FindSkills(c *gin.Context) {
 	c.Status(http.StatusOK)
 }
 
+type stubKnSkillsHandler struct{}
+
+func (stubKnSkillsHandler) ListSkills(c *gin.Context)      { c.Status(http.StatusOK) }
+func (stubKnSkillsHandler) GetSkillContent(c *gin.Context) { c.Status(http.StatusOK) }
+func (stubKnSkillsHandler) ReadSkillFile(c *gin.Context)   { c.Status(http.StatusOK) }
+func (stubKnSkillsHandler) ExecuteSkill(c *gin.Context)    { c.Status(http.StatusOK) }
+
 type stubKnQueryToolsHandler struct{}
 
 func (stubKnQueryToolsHandler) RunSQL(c *gin.Context)                { c.Status(http.StatusOK) }
@@ -258,6 +265,7 @@ func TestRestPublicHandler_AppliesResponseFormatMiddleware(t *testing.T) {
 			KnSearchHandler:                stubKnSearchHandler{},
 			KnFindSkillsHandler:            stubKnFindSkillsHandler{},
 			KnQueryToolsHandler:            stubKnQueryToolsHandler{},
+			KnSkillsHandler:                stubKnSkillsHandler{},
 			LifecycleClient:                inProcessLifecycleClient(t),
 			Logger:                         logger.DefaultLogger(),
 		}

--- a/adp/context-loader/agent-retrieval/server/driveradapters/rest_private_handler.go
+++ b/adp/context-loader/agent-retrieval/server/driveradapters/rest_private_handler.go
@@ -20,6 +20,7 @@ import (
 	"github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/driveradapters/knquerytools"
 	"github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/driveradapters/knretrieval"
 	"github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/driveradapters/knsearch"
+	"github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/driveradapters/knskills"
 	"github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/driveradapters/mcpproxy"
 	"github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/infra/bkntrace"
 	"github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/interfaces"
@@ -35,6 +36,7 @@ type restPrivateHandler struct {
 	MCPProxyHandler                mcpproxy.MCPProxyHandler
 	KnFindSkillsHandler            knfindskills.KnFindSkillsHandler
 	KnQueryToolsHandler            knquerytools.KnQueryToolsHandler
+	KnSkillsHandler                knskills.KnSkillsHandler
 	Logger                         interfaces.Logger
 	LifecycleClient                *bkntrace.LifecycleClient
 }
@@ -51,6 +53,7 @@ func NewRestPrivateHandler(logger interfaces.Logger) interfaces.HTTPRouterInterf
 		MCPProxyHandler:                mcpproxy.NewMCPProxyHandler(),
 		KnFindSkillsHandler:            knfindskills.NewKnFindSkillsHandler(),
 		KnQueryToolsHandler:            knquerytools.NewKnQueryToolsHandler(),
+		KnSkillsHandler:                knskills.NewKnSkillsHandler(),
 		Logger:                         logger,
 		LifecycleClient:                bkntrace.NewLifecycleClientFromEnv(),
 	}
@@ -83,6 +86,12 @@ func (r *restPrivateHandler) RegisterRouter(engine *gin.RouterGroup) {
 	engine.POST("/kn/query_metric", r.KnQueryToolsHandler.QueryMetric)
 	engine.POST("/kn/list_resources", r.KnQueryToolsHandler.ListResources)
 	engine.POST("/kn/describe_resource", r.KnQueryToolsHandler.DescribeResource)
+
+	// 技能面：浏览 / 读文件 / 执行（find_skills 之后的下钻链路）
+	engine.POST("/kn/list_skills", r.KnSkillsHandler.ListSkills)
+	engine.POST("/kn/get_skill_content", r.KnSkillsHandler.GetSkillContent)
+	engine.POST("/kn/read_skill_file", r.KnSkillsHandler.ReadSkillFile)
+	engine.POST("/kn/execute_skill", r.KnSkillsHandler.ExecuteSkill)
 
 	// MCP Proxy
 	engine.POST("/mcp/proxy/:mcp_id/tools/:tool_name/call", r.MCPProxyHandler.CallMCPTool)

--- a/adp/context-loader/agent-retrieval/server/driveradapters/rest_public_handler.go
+++ b/adp/context-loader/agent-retrieval/server/driveradapters/rest_public_handler.go
@@ -21,6 +21,7 @@ import (
 	"github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/driveradapters/knquerytools"
 	"github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/driveradapters/knretrieval"
 	"github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/driveradapters/knsearch"
+	"github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/driveradapters/knskills"
 	"github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/driveradapters/mcp"
 	"github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/infra/bkntrace"
 	"github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/interfaces"
@@ -38,6 +39,7 @@ type restPublicHandler struct {
 	KnSearchHandler                knsearch.KnSearchHandler
 	KnFindSkillsHandler            knfindskills.KnFindSkillsHandler
 	KnQueryToolsHandler            knquerytools.KnQueryToolsHandler
+	KnSkillsHandler                knskills.KnSkillsHandler
 	Logger                         interfaces.Logger
 	LifecycleClient                *bkntrace.LifecycleClient
 }
@@ -56,6 +58,7 @@ func NewRestPublicHandler(logger interfaces.Logger) interfaces.HTTPRouterInterfa
 		KnSearchHandler:                knsearch.NewKnSearchHandler(),
 		KnFindSkillsHandler:            knfindskills.NewKnFindSkillsHandler(),
 		KnQueryToolsHandler:            knquerytools.NewKnQueryToolsHandler(),
+		KnSkillsHandler:                knskills.NewKnSkillsHandler(),
 		Logger:                         logger,
 		LifecycleClient:                bkntrace.NewLifecycleClientFromEnv(),
 	}
@@ -88,6 +91,12 @@ func (r *restPublicHandler) RegisterRouter(engine *gin.RouterGroup) {
 	engine.POST("/kn/query_metric", r.KnQueryToolsHandler.QueryMetric)
 	engine.POST("/kn/list_resources", r.KnQueryToolsHandler.ListResources)
 	engine.POST("/kn/describe_resource", r.KnQueryToolsHandler.DescribeResource)
+
+	// 技能面：浏览 / 读文件 / 执行（find_skills 之后的下钻链路）
+	engine.POST("/kn/list_skills", r.KnSkillsHandler.ListSkills)
+	engine.POST("/kn/get_skill_content", r.KnSkillsHandler.GetSkillContent)
+	engine.POST("/kn/read_skill_file", r.KnSkillsHandler.ReadSkillFile)
+	engine.POST("/kn/execute_skill", r.KnSkillsHandler.ExecuteSkill)
 
 	// MCP Server (Bearer token auth, supports Cursor/Claude Desktop)
 	// GET /mcp/info 返回自描述文档（工具目录 + 连接方式），其余走标准 MCP Streamable HTTP。

--- a/adp/context-loader/agent-retrieval/server/driveradapters/search_schema_route_test.go
+++ b/adp/context-loader/agent-retrieval/server/driveradapters/search_schema_route_test.go
@@ -35,6 +35,7 @@ func TestRestPublicHandler_RegistersSearchSchemaRoute(t *testing.T) {
 			KnSearchHandler:                stubKnSearchHandler{},
 			KnFindSkillsHandler:            stubKnFindSkillsHandler{},
 			KnQueryToolsHandler:            stubKnQueryToolsHandler{},
+			KnSkillsHandler:                stubKnSkillsHandler{},
 			LifecycleClient:                inProcessLifecycleClient(t),
 			Logger:                         logger.DefaultLogger(),
 		}

--- a/adp/context-loader/agent-retrieval/server/interfaces/driven_operator_integration.go
+++ b/adp/context-loader/agent-retrieval/server/interfaces/driven_operator_integration.go
@@ -87,4 +87,12 @@ type DrivenOperatorIntegration interface {
 	CallMCPTool(ctx context.Context, req *CallMCPToolRequest) (map[string]interface{}, error)
 	// SyncToolDependencyPackage Sync internal tool dependency package
 	SyncToolDependencyPackage(ctx context.Context, req *SyncToolDependencyPackageRequest) error
+	// ListSkills 浏览已发布技能（技能市场）
+	ListSkills(ctx context.Context, req *ListSkillsRequest) (*ListSkillsResponse, error)
+	// GetSkillContent 取技能主文档（SKILL.md）正文与包内文件清单
+	GetSkillContent(ctx context.Context, skillID string) (*GetSkillContentResponse, error)
+	// ReadSkillFile 读技能包内单个文件正文
+	ReadSkillFile(ctx context.Context, req *ReadSkillFileRequest) (*ReadSkillFileResponse, error)
+	// ExecuteSkill 在沙箱内执行技能入口命令
+	ExecuteSkill(ctx context.Context, req *ExecuteSkillRequest) (*ExecuteSkillResponse, error)
 }

--- a/adp/context-loader/agent-retrieval/server/interfaces/driven_skill.go
+++ b/adp/context-loader/agent-retrieval/server/interfaces/driven_skill.go
@@ -1,0 +1,91 @@
+// Copyright openbkn.ai
+//
+// Licensed under the OpenBKN License. See LICENSE-OPENBKN.txt in the project root.
+
+package interfaces
+
+// ==================== Skill 浏览 / 读取 / 执行（执行工厂）====================
+//
+// find_skills 只回 skill_id + name + description，拿到之后无路可走：既读不到 SKILL.md，
+// 也列不出附属文件，更执行不了脚本。这里补的是那条链路的出站契约——执行工厂
+// (operator-integration) 的 internal-v1 技能接口。
+//
+// 发布态的文件接口只回对象存储的 presigned URL，不回正文，所以适配层统一走两跳：
+// 先拿元数据再取正文，正文以 []byte 交给上层，由上层决定文本判定与截断。
+
+// ListSkillsRequest 浏览已发布技能（技能市场）请求。
+type ListSkillsRequest struct {
+	Name     string `json:"name,omitempty"`     // 按名称模糊过滤
+	Category string `json:"category,omitempty"` // 按分类过滤
+	Page     int    `json:"page,omitempty"`     // 页码，从 1 开始
+	PageSize int    `json:"page_size,omitempty"`
+}
+
+// SkillBrief 技能条目摘要（浏览用，不含文件与正文）。
+type SkillBrief struct {
+	SkillID     string `json:"skill_id"`
+	Name        string `json:"name"`
+	Description string `json:"description,omitempty"`
+	Version     string `json:"version,omitempty"`
+	Category    string `json:"category,omitempty"`
+	Status      string `json:"status,omitempty"`
+}
+
+// ListSkillsResponse 浏览已发布技能响应。
+type ListSkillsResponse struct {
+	Entries    []SkillBrief `json:"entries"`
+	TotalCount int          `json:"total_count"`
+	Page       int          `json:"page"`
+	PageSize   int          `json:"page_size"`
+}
+
+// SkillFileSummary 技能包内的文件条目。
+type SkillFileSummary struct {
+	RelPath  string `json:"rel_path"`
+	FileType string `json:"file_type,omitempty"`
+	Size     int64  `json:"size,omitempty"`
+	MimeType string `json:"mime_type,omitempty"`
+}
+
+// GetSkillContentResponse 技能主文档（SKILL.md）正文 + 包内文件清单。
+type GetSkillContentResponse struct {
+	SkillID string
+	Content []byte
+	Status  string
+	Files   []SkillFileSummary
+}
+
+// ReadSkillFileRequest 读取技能包内单个文件。
+type ReadSkillFileRequest struct {
+	SkillID string
+	RelPath string
+}
+
+// ReadSkillFileResponse 技能包内单个文件的元数据 + 正文。
+type ReadSkillFileResponse struct {
+	SkillID  string
+	RelPath  string
+	MimeType string
+	FileType string
+	Content  []byte
+}
+
+// ExecuteSkillRequest 在沙箱内执行技能入口命令。
+type ExecuteSkillRequest struct {
+	SkillID    string `json:"-"`
+	EntryShell string `json:"entry_shell"`
+	Timeout    int    `json:"timeout,omitempty"` // 秒
+}
+
+// ExecuteSkillResponse 沙箱执行结果。
+type ExecuteSkillResponse struct {
+	SkillID       string `json:"skill_id"`
+	SessionID     string `json:"session_id"`
+	WorkDir       string `json:"work_dir"`
+	Command       string `json:"command"`
+	ExitCode      int    `json:"exit_code"`
+	Stdout        string `json:"stdout"`
+	Stderr        string `json:"stderr"`
+	ExecutionTime int64  `json:"execution_time"`
+	Mocked        bool   `json:"mocked"`
+}

--- a/adp/context-loader/agent-retrieval/server/logics/knskills/index.go
+++ b/adp/context-loader/agent-retrieval/server/logics/knskills/index.go
@@ -1,0 +1,332 @@
+// Copyright openbkn.ai
+//
+// Licensed under the OpenBKN License. See LICENSE-OPENBKN.txt in the project root.
+
+// Package knskills 提供技能的浏览 / 阅读 / 执行能力，补齐 find_skills 之后的链路：
+// find_skills 只回 skill_id + name + description，拿到之后既读不到 SKILL.md，
+// 也列不出附属文件，更执行不了脚本。
+//
+// 这一层是薄的：出站两跳（元数据 + 对象存储正文）由 drivenadapters 完成，这里只管
+// 面向大模型的整形——文本判定、体积截断、空结果说明。授权在执行工厂侧按账户判定。
+package knskills
+
+import (
+	"context"
+	"errors"
+	"strconv"
+	"strings"
+	"sync"
+	"unicode/utf8"
+
+	"github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/drivenadapters"
+	"github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/interfaces"
+)
+
+const (
+	// maxDocChars SKILL.md / 技能文件返回给模型的字符上限。
+	// 超出即截断并显式标注，宁可让模型知道自己只看了一半，也不要静默丢尾。
+	maxDocChars = 40000
+	// maxStreamChars 执行结果 stdout / stderr 各自的字符上限。
+	maxStreamChars = 8000
+)
+
+// ErrSkillIDRequired 入参缺 skill_id。
+var ErrSkillIDRequired = errors.New("skill_id is required")
+
+// ErrRelPathRequired read_skill_file 缺 rel_path。
+var ErrRelPathRequired = errors.New("rel_path is required (take it from get_skill_content 的 files 清单)")
+
+// ErrEntryShellRequired execute_skill 缺 entry_shell。
+var ErrEntryShellRequired = errors.New("entry_shell is required (取自 SKILL.md 中声明的入口命令)")
+
+// ListSkillsReq list_skills 入参。
+type ListSkillsReq struct {
+	Name     string `json:"name"`      // 可选，按名称模糊过滤
+	Category string `json:"category"`  // 可选，按分类过滤
+	Page     int    `json:"page"`      // 可选，页码，从 1 开始
+	PageSize int    `json:"page_size"` // 可选，每页大小
+}
+
+// SkillEntry list_skills 的技能条目。
+type SkillEntry struct {
+	SkillID     string `json:"skill_id"`
+	Name        string `json:"name"`
+	Description string `json:"description,omitempty"`
+	Version     string `json:"version,omitempty"`
+	Category    string `json:"category,omitempty"`
+}
+
+// ListSkillsResp list_skills 响应。
+type ListSkillsResp struct {
+	Entries    []SkillEntry `json:"entries"`
+	TotalCount int          `json:"total_count"`
+	Page       int          `json:"page,omitempty"`
+	PageSize   int          `json:"page_size,omitempty"`
+	Message    string       `json:"message,omitempty"`
+}
+
+// SkillFileEntry 技能包内的文件条目（渐进式阅读的下钻线索）。
+type SkillFileEntry struct {
+	RelPath  string `json:"rel_path"`
+	FileType string `json:"file_type,omitempty"`
+	Size     int64  `json:"size,omitempty"`
+	MimeType string `json:"mime_type,omitempty"`
+}
+
+// GetSkillContentResp get_skill_content 响应：SKILL.md 正文 + 包内文件清单。
+type GetSkillContentResp struct {
+	SkillID   string           `json:"skill_id"`
+	Status    string           `json:"status,omitempty"`
+	Content   string           `json:"content"`
+	Truncated bool             `json:"truncated,omitempty"`
+	Files     []SkillFileEntry `json:"files"`
+	Message   string           `json:"message,omitempty"`
+}
+
+// ReadSkillFileReq read_skill_file 入参。
+type ReadSkillFileReq struct {
+	SkillID string `json:"skill_id"`
+	RelPath string `json:"rel_path"`
+}
+
+// ReadSkillFileResp read_skill_file 响应。
+// 二进制文件不回正文，只回元数据 + message 说明，避免把乱码灌进上下文。
+type ReadSkillFileResp struct {
+	SkillID   string `json:"skill_id"`
+	RelPath   string `json:"rel_path"`
+	MimeType  string `json:"mime_type,omitempty"`
+	FileType  string `json:"file_type,omitempty"`
+	Content   string `json:"content,omitempty"`
+	Truncated bool   `json:"truncated,omitempty"`
+	Message   string `json:"message,omitempty"`
+}
+
+// ExecuteSkillReq execute_skill 入参。
+type ExecuteSkillReq struct {
+	SkillID    string `json:"skill_id"`
+	EntryShell string `json:"entry_shell"`
+	Timeout    int    `json:"timeout"` // 秒，可选
+}
+
+// ExecuteSkillResp execute_skill 响应。
+type ExecuteSkillResp struct {
+	SkillID       string `json:"skill_id"`
+	ExitCode      int    `json:"exit_code"`
+	Stdout        string `json:"stdout"`
+	Stderr        string `json:"stderr,omitempty"`
+	Truncated     bool   `json:"truncated,omitempty"`
+	ExecutionTime int64  `json:"execution_time,omitempty"`
+	WorkDir       string `json:"work_dir,omitempty"`
+	Command       string `json:"command,omitempty"`
+	Mocked        bool   `json:"mocked,omitempty"`
+}
+
+// KnSkillsService 技能浏览 / 阅读 / 执行。
+type KnSkillsService interface {
+	ListSkills(ctx context.Context, req *ListSkillsReq) (*ListSkillsResp, error)
+	GetSkillContent(ctx context.Context, skillID string) (*GetSkillContentResp, error)
+	ReadSkillFile(ctx context.Context, req *ReadSkillFileReq) (*ReadSkillFileResp, error)
+	ExecuteSkill(ctx context.Context, req *ExecuteSkillReq) (*ExecuteSkillResp, error)
+}
+
+type knSkillsService struct {
+	operator interfaces.DrivenOperatorIntegration
+}
+
+var (
+	once     sync.Once
+	instance KnSkillsService
+)
+
+// NewKnSkillsService 创建 KnSkillsService 单例。
+func NewKnSkillsService() KnSkillsService {
+	once.Do(func() {
+		instance = &knSkillsService{operator: drivenadapters.NewOperatorIntegrationClient()}
+	})
+	return instance
+}
+
+// NewKnSkillsServiceWith 注入依赖创建（测试用）。
+func NewKnSkillsServiceWith(operator interfaces.DrivenOperatorIntegration) KnSkillsService {
+	return &knSkillsService{operator: operator}
+}
+
+// ListSkills 浏览已发布技能。与 find_skills 互补：那条按对象类召回，这条不需要知识网络上下文。
+func (s *knSkillsService) ListSkills(ctx context.Context, req *ListSkillsReq) (*ListSkillsResp, error) {
+	if req == nil {
+		req = &ListSkillsReq{}
+	}
+	resp, err := s.operator.ListSkills(ctx, &interfaces.ListSkillsRequest{
+		Name:     strings.TrimSpace(req.Name),
+		Category: strings.TrimSpace(req.Category),
+		Page:     req.Page,
+		PageSize: req.PageSize,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	out := &ListSkillsResp{
+		Entries:    make([]SkillEntry, 0, len(resp.Entries)),
+		TotalCount: resp.TotalCount,
+		Page:       resp.Page,
+		PageSize:   resp.PageSize,
+	}
+	for _, item := range resp.Entries {
+		out.Entries = append(out.Entries, SkillEntry{
+			SkillID:     item.SkillID,
+			Name:        item.Name,
+			Description: item.Description,
+			Version:     item.Version,
+			Category:    item.Category,
+		})
+	}
+	if len(out.Entries) == 0 {
+		out.Message = "没有匹配的已发布技能。技能需先在执行工厂注册并发布；也可放宽 name / category 过滤后重试。"
+	}
+	return out, nil
+}
+
+// GetSkillContent 取技能主文档正文与包内文件清单，供模型判断要不要继续下钻。
+func (s *knSkillsService) GetSkillContent(ctx context.Context, skillID string) (*GetSkillContentResp, error) {
+	skillID = strings.TrimSpace(skillID)
+	if skillID == "" {
+		return nil, ErrSkillIDRequired
+	}
+	resp, err := s.operator.GetSkillContent(ctx, skillID)
+	if err != nil {
+		return nil, err
+	}
+
+	content, truncated := truncateRunes(string(resp.Content), maxDocChars)
+	out := &GetSkillContentResp{
+		SkillID:   resp.SkillID,
+		Status:    resp.Status,
+		Content:   content,
+		Truncated: truncated,
+		Files:     make([]SkillFileEntry, 0, len(resp.Files)),
+	}
+	for _, f := range resp.Files {
+		out.Files = append(out.Files, SkillFileEntry{
+			RelPath:  f.RelPath,
+			FileType: f.FileType,
+			Size:     f.Size,
+			MimeType: f.MimeType,
+		})
+	}
+	if truncated {
+		out.Message = "SKILL.md 超长已截断；需要完整内容请用 read_skill_file 分文件读取。"
+	}
+	return out, nil
+}
+
+// ReadSkillFile 读技能包内单个文件。二进制文件只回元数据不回正文。
+func (s *knSkillsService) ReadSkillFile(ctx context.Context, req *ReadSkillFileReq) (*ReadSkillFileResp, error) {
+	if req == nil {
+		return nil, ErrSkillIDRequired
+	}
+	skillID := strings.TrimSpace(req.SkillID)
+	if skillID == "" {
+		return nil, ErrSkillIDRequired
+	}
+	relPath := strings.TrimSpace(req.RelPath)
+	if relPath == "" {
+		return nil, ErrRelPathRequired
+	}
+
+	resp, err := s.operator.ReadSkillFile(ctx, &interfaces.ReadSkillFileRequest{SkillID: skillID, RelPath: relPath})
+	if err != nil {
+		return nil, err
+	}
+
+	out := &ReadSkillFileResp{
+		SkillID:  resp.SkillID,
+		RelPath:  resp.RelPath,
+		MimeType: resp.MimeType,
+		FileType: resp.FileType,
+	}
+	if !isTextual(resp.MimeType, resp.Content) {
+		out.Message = "该文件不是文本（mime_type=" + resp.MimeType + "），未返回正文。二进制内容请用技能包下载接口获取。"
+		return out, nil
+	}
+	out.Content, out.Truncated = truncateRunes(string(resp.Content), maxDocChars)
+	if out.Truncated {
+		out.Message = "文件超长已截断，仅返回前 " + strconv.Itoa(maxDocChars) + " 个字符。"
+	}
+	return out, nil
+}
+
+// ExecuteSkill 在沙箱内执行技能入口命令。
+// entry_shell 取自 SKILL.md 声明的入口；授权由执行工厂按账户强制。
+func (s *knSkillsService) ExecuteSkill(ctx context.Context, req *ExecuteSkillReq) (*ExecuteSkillResp, error) {
+	if req == nil {
+		return nil, ErrSkillIDRequired
+	}
+	skillID := strings.TrimSpace(req.SkillID)
+	if skillID == "" {
+		return nil, ErrSkillIDRequired
+	}
+	entryShell := strings.TrimSpace(req.EntryShell)
+	if entryShell == "" {
+		return nil, ErrEntryShellRequired
+	}
+
+	resp, err := s.operator.ExecuteSkill(ctx, &interfaces.ExecuteSkillRequest{
+		SkillID:    skillID,
+		EntryShell: entryShell,
+		Timeout:    req.Timeout,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	stdout, stdoutTruncated := truncateRunes(resp.Stdout, maxStreamChars)
+	stderr, stderrTruncated := truncateRunes(resp.Stderr, maxStreamChars)
+	return &ExecuteSkillResp{
+		SkillID:       resp.SkillID,
+		ExitCode:      resp.ExitCode,
+		Stdout:        stdout,
+		Stderr:        stderr,
+		Truncated:     stdoutTruncated || stderrTruncated,
+		ExecutionTime: resp.ExecutionTime,
+		WorkDir:       resp.WorkDir,
+		Command:       resp.Command,
+		Mocked:        resp.Mocked,
+	}, nil
+}
+
+// truncateRunes 按字符（非字节）截断，避免切在多字节字符中间产出乱码。
+func truncateRunes(text string, limit int) (string, bool) {
+	if utf8.RuneCountInString(text) <= limit {
+		return text, false
+	}
+	count := 0
+	for idx := range text {
+		if count == limit {
+			return text[:idx], true
+		}
+		count++
+	}
+	return text, false
+}
+
+// isTextual 判定文件正文能否直接喂给模型。
+// mime 是弱证据（对象存储常回 application/octet-stream），最终以正文是否合法 UTF-8 为准。
+func isTextual(mimeType string, content []byte) bool {
+	mimeType = strings.ToLower(strings.TrimSpace(mimeType))
+	switch {
+	case strings.HasPrefix(mimeType, "image/"),
+		strings.HasPrefix(mimeType, "audio/"),
+		strings.HasPrefix(mimeType, "video/"),
+		strings.HasPrefix(mimeType, "application/zip"),
+		strings.HasPrefix(mimeType, "application/x-tar"),
+		strings.HasPrefix(mimeType, "application/gzip"),
+		strings.HasPrefix(mimeType, "application/pdf"):
+		return false
+	}
+	if !utf8.Valid(content) {
+		return false
+	}
+	// 合法 UTF-8 里混着 NUL 基本只可能是二进制。
+	return !strings.ContainsRune(string(content), '\x00')
+}

--- a/adp/context-loader/agent-retrieval/server/logics/knskills/index_test.go
+++ b/adp/context-loader/agent-retrieval/server/logics/knskills/index_test.go
@@ -1,0 +1,169 @@
+// Copyright openbkn.ai
+//
+// Licensed under the OpenBKN License. See LICENSE-OPENBKN.txt in the project root.
+
+package knskills
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/interfaces"
+)
+
+// fakeOperator 只实现技能面，其余方法留空——这一层只用得着这四条。
+type fakeOperator struct {
+	interfaces.DrivenOperatorIntegration
+
+	listResp    *interfaces.ListSkillsResponse
+	contentResp *interfaces.GetSkillContentResponse
+	fileResp    *interfaces.ReadSkillFileResponse
+	execResp    *interfaces.ExecuteSkillResponse
+	err         error
+
+	gotListReq *interfaces.ListSkillsRequest
+	gotFileReq *interfaces.ReadSkillFileRequest
+	gotExecReq *interfaces.ExecuteSkillRequest
+}
+
+func (f *fakeOperator) ListSkills(_ context.Context, req *interfaces.ListSkillsRequest) (*interfaces.ListSkillsResponse, error) {
+	f.gotListReq = req
+	return f.listResp, f.err
+}
+
+func (f *fakeOperator) GetSkillContent(_ context.Context, _ string) (*interfaces.GetSkillContentResponse, error) {
+	return f.contentResp, f.err
+}
+
+func (f *fakeOperator) ReadSkillFile(_ context.Context, req *interfaces.ReadSkillFileRequest) (*interfaces.ReadSkillFileResponse, error) {
+	f.gotFileReq = req
+	return f.fileResp, f.err
+}
+
+func (f *fakeOperator) ExecuteSkill(_ context.Context, req *interfaces.ExecuteSkillRequest) (*interfaces.ExecuteSkillResponse, error) {
+	f.gotExecReq = req
+	return f.execResp, f.err
+}
+
+func TestListSkillsExplainsEmptyResult(t *testing.T) {
+	fake := &fakeOperator{listResp: &interfaces.ListSkillsResponse{}}
+	svc := NewKnSkillsServiceWith(fake)
+
+	resp, err := svc.ListSkills(context.Background(), &ListSkillsReq{Name: "  合同  "})
+	if err != nil {
+		t.Fatalf("ListSkills: %v", err)
+	}
+	if resp.Message == "" {
+		t.Fatal("空结果没有给出说明，模型无从判断是没权限还是没匹配")
+	}
+	if fake.gotListReq.Name != "合同" {
+		t.Fatalf("过滤条件未去空白: %q", fake.gotListReq.Name)
+	}
+}
+
+func TestGetSkillContentTruncatesByRune(t *testing.T) {
+	// 全中文正文，按字节截断会切碎多字节字符。
+	body := strings.Repeat("知", maxDocChars+10)
+	fake := &fakeOperator{contentResp: &interfaces.GetSkillContentResponse{
+		SkillID: "sk-1",
+		Content: []byte(body),
+		Files:   []interfaces.SkillFileSummary{{RelPath: "refs/guide.md"}},
+	}}
+
+	resp, err := NewKnSkillsServiceWith(fake).GetSkillContent(context.Background(), "sk-1")
+	if err != nil {
+		t.Fatalf("GetSkillContent: %v", err)
+	}
+	if !resp.Truncated || resp.Message == "" {
+		t.Fatal("超长正文未标注截断")
+	}
+	if !strings.HasSuffix(resp.Content, "知") {
+		t.Fatal("截断切碎了多字节字符")
+	}
+	if len([]rune(resp.Content)) != maxDocChars {
+		t.Fatalf("截断长度 = %d 字符，want %d", len([]rune(resp.Content)), maxDocChars)
+	}
+	if len(resp.Files) != 1 || resp.Files[0].RelPath != "refs/guide.md" {
+		t.Fatal("文件清单丢失，下钻链路断了")
+	}
+}
+
+func TestReadSkillFileWithholdsBinaryBody(t *testing.T) {
+	fake := &fakeOperator{fileResp: &interfaces.ReadSkillFileResponse{
+		SkillID:  "sk-1",
+		RelPath:  "assets/logo.png",
+		MimeType: "image/png",
+		Content:  []byte{0x89, 0x50, 0x4e, 0x47, 0x00, 0xff},
+	}}
+
+	resp, err := NewKnSkillsServiceWith(fake).ReadSkillFile(context.Background(),
+		&ReadSkillFileReq{SkillID: "sk-1", RelPath: "assets/logo.png"})
+	if err != nil {
+		t.Fatalf("ReadSkillFile: %v", err)
+	}
+	if resp.Content != "" {
+		t.Fatal("二进制正文被塞进了上下文")
+	}
+	if resp.Message == "" {
+		t.Fatal("二进制文件未说明为何没有正文")
+	}
+}
+
+func TestReadSkillFileKeepsUTF8Body(t *testing.T) {
+	fake := &fakeOperator{fileResp: &interfaces.ReadSkillFileResponse{
+		SkillID:  "sk-1",
+		RelPath:  "refs/guide.md",
+		MimeType: "application/octet-stream", // 对象存储常这么回，不能据此判定二进制
+		Content:  []byte("# 指南\n正文"),
+	}}
+
+	resp, err := NewKnSkillsServiceWith(fake).ReadSkillFile(context.Background(),
+		&ReadSkillFileReq{SkillID: "sk-1", RelPath: "refs/guide.md"})
+	if err != nil {
+		t.Fatalf("ReadSkillFile: %v", err)
+	}
+	if resp.Content != "# 指南\n正文" {
+		t.Fatalf("正文被误判为二进制: %q / %s", resp.Content, resp.Message)
+	}
+}
+
+func TestReadSkillFileRequiresRelPath(t *testing.T) {
+	svc := NewKnSkillsServiceWith(&fakeOperator{})
+
+	if _, err := svc.ReadSkillFile(context.Background(), &ReadSkillFileReq{SkillID: "sk-1"}); !errors.Is(err, ErrRelPathRequired) {
+		t.Fatalf("缺 rel_path 时 err = %v，want ErrRelPathRequired", err)
+	}
+	if _, err := svc.ReadSkillFile(context.Background(), &ReadSkillFileReq{RelPath: "a.md"}); !errors.Is(err, ErrSkillIDRequired) {
+		t.Fatalf("缺 skill_id 时 err = %v，want ErrSkillIDRequired", err)
+	}
+}
+
+func TestExecuteSkillRequiresEntryShellAndTruncatesStreams(t *testing.T) {
+	svc := NewKnSkillsServiceWith(&fakeOperator{})
+	if _, err := svc.ExecuteSkill(context.Background(), &ExecuteSkillReq{SkillID: "sk-1"}); !errors.Is(err, ErrEntryShellRequired) {
+		t.Fatalf("缺 entry_shell 时 err = %v，want ErrEntryShellRequired", err)
+	}
+
+	fake := &fakeOperator{execResp: &interfaces.ExecuteSkillResponse{
+		SkillID:  "sk-1",
+		ExitCode: 0,
+		Stdout:   strings.Repeat("x", maxStreamChars+1),
+		Stderr:   "warn",
+	}}
+	resp, err := NewKnSkillsServiceWith(fake).ExecuteSkill(context.Background(),
+		&ExecuteSkillReq{SkillID: "sk-1", EntryShell: " python main.py ", Timeout: 30})
+	if err != nil {
+		t.Fatalf("ExecuteSkill: %v", err)
+	}
+	if !resp.Truncated || len(resp.Stdout) != maxStreamChars {
+		t.Fatalf("stdout 未按上限截断: truncated=%v len=%d", resp.Truncated, len(resp.Stdout))
+	}
+	if fake.gotExecReq.EntryShell != "python main.py" {
+		t.Fatalf("entry_shell 未去空白: %q", fake.gotExecReq.EntryShell)
+	}
+	if fake.gotExecReq.Timeout != 30 {
+		t.Fatalf("timeout 未透传: %d", fake.gotExecReq.Timeout)
+	}
+}

--- a/adp/context-loader/agent-retrieval/server/mocks/driven_operator_integration.go
+++ b/adp/context-loader/agent-retrieval/server/mocks/driven_operator_integration.go
@@ -13,9 +13,8 @@ import (
 	context "context"
 	reflect "reflect"
 
-	gomock "go.uber.org/mock/gomock"
-
 	interfaces "github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/interfaces"
+	gomock "go.uber.org/mock/gomock"
 )
 
 // MockDrivenOperatorIntegration is a mock of DrivenOperatorIntegration interface.
@@ -57,6 +56,21 @@ func (mr *MockDrivenOperatorIntegrationMockRecorder) CallMCPTool(ctx, req any) *
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CallMCPTool", reflect.TypeOf((*MockDrivenOperatorIntegration)(nil).CallMCPTool), ctx, req)
 }
 
+// ExecuteSkill mocks base method.
+func (m *MockDrivenOperatorIntegration) ExecuteSkill(ctx context.Context, req *interfaces.ExecuteSkillRequest) (*interfaces.ExecuteSkillResponse, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ExecuteSkill", ctx, req)
+	ret0, _ := ret[0].(*interfaces.ExecuteSkillResponse)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ExecuteSkill indicates an expected call of ExecuteSkill.
+func (mr *MockDrivenOperatorIntegrationMockRecorder) ExecuteSkill(ctx, req any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ExecuteSkill", reflect.TypeOf((*MockDrivenOperatorIntegration)(nil).ExecuteSkill), ctx, req)
+}
+
 // GetMCPToolDetail mocks base method.
 func (m *MockDrivenOperatorIntegration) GetMCPToolDetail(ctx context.Context, req *interfaces.GetMCPToolDetailRequest) (*interfaces.GetMCPToolDetailResponse, error) {
 	m.ctrl.T.Helper()
@@ -72,6 +86,21 @@ func (mr *MockDrivenOperatorIntegrationMockRecorder) GetMCPToolDetail(ctx, req a
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetMCPToolDetail", reflect.TypeOf((*MockDrivenOperatorIntegration)(nil).GetMCPToolDetail), ctx, req)
 }
 
+// GetSkillContent mocks base method.
+func (m *MockDrivenOperatorIntegration) GetSkillContent(ctx context.Context, skillID string) (*interfaces.GetSkillContentResponse, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetSkillContent", ctx, skillID)
+	ret0, _ := ret[0].(*interfaces.GetSkillContentResponse)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetSkillContent indicates an expected call of GetSkillContent.
+func (mr *MockDrivenOperatorIntegrationMockRecorder) GetSkillContent(ctx, skillID any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetSkillContent", reflect.TypeOf((*MockDrivenOperatorIntegration)(nil).GetSkillContent), ctx, skillID)
+}
+
 // GetToolDetail mocks base method.
 func (m *MockDrivenOperatorIntegration) GetToolDetail(ctx context.Context, req *interfaces.GetToolDetailRequest) (*interfaces.GetToolDetailResponse, error) {
 	m.ctrl.T.Helper()
@@ -85,6 +114,36 @@ func (m *MockDrivenOperatorIntegration) GetToolDetail(ctx context.Context, req *
 func (mr *MockDrivenOperatorIntegrationMockRecorder) GetToolDetail(ctx, req any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetToolDetail", reflect.TypeOf((*MockDrivenOperatorIntegration)(nil).GetToolDetail), ctx, req)
+}
+
+// ListSkills mocks base method.
+func (m *MockDrivenOperatorIntegration) ListSkills(ctx context.Context, req *interfaces.ListSkillsRequest) (*interfaces.ListSkillsResponse, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ListSkills", ctx, req)
+	ret0, _ := ret[0].(*interfaces.ListSkillsResponse)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ListSkills indicates an expected call of ListSkills.
+func (mr *MockDrivenOperatorIntegrationMockRecorder) ListSkills(ctx, req any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListSkills", reflect.TypeOf((*MockDrivenOperatorIntegration)(nil).ListSkills), ctx, req)
+}
+
+// ReadSkillFile mocks base method.
+func (m *MockDrivenOperatorIntegration) ReadSkillFile(ctx context.Context, req *interfaces.ReadSkillFileRequest) (*interfaces.ReadSkillFileResponse, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ReadSkillFile", ctx, req)
+	ret0, _ := ret[0].(*interfaces.ReadSkillFileResponse)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ReadSkillFile indicates an expected call of ReadSkillFile.
+func (mr *MockDrivenOperatorIntegrationMockRecorder) ReadSkillFile(ctx, req any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReadSkillFile", reflect.TypeOf((*MockDrivenOperatorIntegration)(nil).ReadSkillFile), ctx, req)
 }
 
 // SyncToolDependencyPackage mocks base method.

--- a/adp/execution-factory/operator-integration/server/infra/common/skill_authz.go
+++ b/adp/execution-factory/operator-integration/server/infra/common/skill_authz.go
@@ -1,0 +1,41 @@
+package common
+
+import (
+	"os"
+	"strings"
+)
+
+// SkillReadAuthzMode 内部（internal-v1）技能读接口的授权模式。
+//
+// 历史上 GetSkillContent / ReadSkillFile 只在公开接口上做授权，内部接口一律放行——
+// 授权被押给调用方（bkn-agent 只读它自己挂载过的技能）。context-loader 把这两个接口
+// 包成 MCP 工具之后这个前提不再成立：MCP 客户端的 skill_id 是自己填的，内部接口再放行
+// 就等于任意账户可读任意技能全文。
+//
+// 直接翻成强制会打断存量调用方（它们未必都带得出账户上下文），所以按三段式走：
+// 先 shadow 只记日志不拦，观察线上没有误伤了再翻 enforce。
+type SkillReadAuthzMode string
+
+const (
+	// SkillReadAuthzOff 内部接口完全不查授权（翻车时的回退档）。
+	SkillReadAuthzOff SkillReadAuthzMode = "off"
+	// SkillReadAuthzShadow 内部接口查授权但不拦，未通过只打日志。默认档。
+	SkillReadAuthzShadow SkillReadAuthzMode = "shadow"
+	// SkillReadAuthzEnforce 内部接口按账户强制授权，未通过返回 403。
+	SkillReadAuthzEnforce SkillReadAuthzMode = "enforce"
+)
+
+// SkillReadAuthzModeEnv 控制内部技能读接口授权模式的环境变量。
+const SkillReadAuthzModeEnv = "SKILL_INTERNAL_READ_AUTHZ"
+
+// GetSkillReadAuthzMode 读取内部技能读接口的授权模式，取值非法时按默认档 shadow。
+func GetSkillReadAuthzMode() SkillReadAuthzMode {
+	switch strings.ToLower(strings.TrimSpace(os.Getenv(SkillReadAuthzModeEnv))) {
+	case string(SkillReadAuthzOff):
+		return SkillReadAuthzOff
+	case string(SkillReadAuthzEnforce):
+		return SkillReadAuthzEnforce
+	default:
+		return SkillReadAuthzShadow
+	}
+}

--- a/adp/execution-factory/operator-integration/server/logics/skill/reader.go
+++ b/adp/execution-factory/operator-integration/server/logics/skill/reader.go
@@ -53,6 +53,59 @@ func NewSkillReader() interfaces.SkillReader {
 	return readerInst
 }
 
+// authorizeSkillRead 校验调用方对该技能是否有读取权限（执行 / 公开访问 / 查看三者之一）。
+//
+// 公开接口一律强制。内部接口（internal-v1）看 SKILL_INTERNAL_READ_AUTHZ：
+// off 直接放行；shadow（默认）查但不拦，未通过只打日志；enforce 与公开接口一致返回 403。
+// 分档是为了不打断存量内部调用方——context-loader 把这两个接口包成 MCP 工具之后，
+// 内部路径再无条件放行就等于任意账户可读任意技能全文，但直接翻强制会误伤，先影子观察。
+//
+// 内部接口若拿不到账户身份（accessor 解析失败），shadow 档同样只记日志：
+// 那是「无从判断」，不是「判定为无权」，此时拦下来纯属误伤。
+func (r *skillReader) authorizeSkillRead(ctx context.Context, userID, skillID string) error {
+	isPublic := common.IsPublicAPIFromCtx(ctx)
+	mode := common.GetSkillReadAuthzMode()
+	if !isPublic {
+		if mode == common.SkillReadAuthzOff {
+			return nil
+		}
+		// 内部路径上没有账户身份就没得判：调用方连自己是谁都没说，此时查授权只会
+		// 把「无从判断」误判成「无权」。公开路径不走这里——那条的身份由令牌保证。
+		if authContext, ok := common.GetAccountAuthContextFromCtx(ctx); (!ok || authContext.AccountID == "") && userID == "" {
+			return nil
+		}
+	}
+
+	shadow := !isPublic && mode == common.SkillReadAuthzShadow
+	accessor, err := r.AuthService.GetAccessor(ctx, userID)
+	if err != nil {
+		if shadow {
+			r.Logger.WithContext(ctx).Warnf("[skill.read.authz.shadow] resolve accessor failed, skill %s, user %s: %v", skillID, userID, err)
+			return nil
+		}
+		return err
+	}
+	authorized, err := r.AuthService.OperationCheckAny(ctx, accessor, skillID, interfaces.AuthResourceTypeSkill,
+		interfaces.AuthOperationTypeExecute, interfaces.AuthOperationTypePublicAccess, interfaces.AuthOperationTypeView)
+	if err != nil {
+		if shadow {
+			r.Logger.WithContext(ctx).Warnf("[skill.read.authz.shadow] check failed, skill %s, user %s: %v", skillID, userID, err)
+			return nil
+		}
+		return err
+	}
+	if authorized {
+		return nil
+	}
+	if shadow {
+		r.Logger.WithContext(ctx).Warnf("[skill.read.authz.shadow] user %s would be denied on skill %s (mode=shadow, request allowed)", userID, skillID)
+		return nil
+	}
+	r.Logger.WithContext(ctx).Errorf("user %s has no permission to execute、view、public access skill %s", userID, skillID)
+	return errors.NewHTTPError(ctx, http.StatusForbidden, errors.ErrExtCommonOperationForbidden,
+		fmt.Sprintf("user has no permission to execute、view、public access skill %s", skillID))
+}
+
 // GetSkillContent 获取技能内容
 func (r *skillReader) GetSkillContent(ctx context.Context, req *interfaces.GetSkillContentReq) (resp *interfaces.GetSkillContentResp, err error) {
 	// 记录可观测
@@ -66,23 +119,8 @@ func (r *skillReader) GetSkillContent(ctx context.Context, req *interfaces.GetSk
 	if err != nil {
 		return
 	}
-	// 如果是外部接口
-	if common.IsPublicAPIFromCtx(ctx) {
-		// 有执行、查看、公开访问权限
-		accessor, err := r.AuthService.GetAccessor(ctx, req.UserID)
-		if err != nil {
-			return nil, err
-		}
-		authorized, err := r.AuthService.OperationCheckAny(ctx, accessor, req.SkillID, interfaces.AuthResourceTypeSkill,
-			interfaces.AuthOperationTypeExecute, interfaces.AuthOperationTypePublicAccess, interfaces.AuthOperationTypeView)
-		if err != nil {
-			return nil, err
-		}
-		if !authorized {
-			r.Logger.WithContext(ctx).Errorf("user has no permission to execute、view、public access skill %s", req.SkillID)
-			err = errors.NewHTTPError(ctx, http.StatusForbidden, errors.ErrExtCommonOperationForbidden, fmt.Sprintf("user has no permission to execute、view、public access skill %s", req.SkillID))
-			return nil, err
-		}
+	if err = r.authorizeSkillRead(ctx, req.UserID, req.SkillID); err != nil {
+		return nil, err
 	}
 	// 查询对应的"SKILL.md文件
 	skillFile, err := r.fileRepo.SelectSkillFileByPath(ctx, nil, skill.SkillID, skill.Version, SkillMD)
@@ -128,22 +166,8 @@ func (r *skillReader) ReadSkillFile(ctx context.Context, req *interfaces.ReadSki
 		r.Logger.WithContext(ctx).Errorf("read skill file failed: %v", err)
 		return nil, err
 	}
-	if common.IsPublicAPIFromCtx(ctx) {
-		// 有执行、查看、公开访问权限
-		accessor, err := r.AuthService.GetAccessor(ctx, req.UserID)
-		if err != nil {
-			return nil, err
-		}
-		authorized, err := r.AuthService.OperationCheckAny(ctx, accessor, req.SkillID, interfaces.AuthResourceTypeSkill,
-			interfaces.AuthOperationTypeExecute, interfaces.AuthOperationTypePublicAccess, interfaces.AuthOperationTypeView)
-		if err != nil {
-			return nil, err
-		}
-		if !authorized {
-			r.Logger.WithContext(ctx).Errorf("user %s has no permission to execute skill %s", req.UserID, req.SkillID)
-			err = errors.NewHTTPError(ctx, http.StatusForbidden, errors.ErrExtCommonOperationForbidden, fmt.Sprintf("user %s has no permission to execute skill %s", req.UserID, req.SkillID))
-			return nil, err
-		}
+	if err = r.authorizeSkillRead(ctx, req.UserID, req.SkillID); err != nil {
+		return nil, err
 	}
 	relPath, err := normalizeZipPath(req.RelPath)
 	if err != nil {

--- a/adp/execution-factory/operator-integration/server/logics/skill/reader_internal_authz_test.go
+++ b/adp/execution-factory/operator-integration/server/logics/skill/reader_internal_authz_test.go
@@ -1,0 +1,124 @@
+package skill
+
+import (
+	"context"
+	"database/sql"
+	"testing"
+
+	. "github.com/smartystreets/goconvey/convey"
+	"go.uber.org/mock/gomock"
+
+	"github.com/openbkn-ai/bkn-foundry/adp/execution-factory/operator-integration/server/infra/common"
+	"github.com/openbkn-ai/bkn-foundry/adp/execution-factory/operator-integration/server/infra/logger"
+	"github.com/openbkn-ai/bkn-foundry/adp/execution-factory/operator-integration/server/interfaces"
+	"github.com/openbkn-ai/bkn-foundry/adp/execution-factory/operator-integration/server/interfaces/model"
+	"github.com/openbkn-ai/bkn-foundry/adp/execution-factory/operator-integration/server/mocks"
+)
+
+// skillInternalCtx 构造内部面上下文：带账户身份，但不是公开接口。
+// context-loader 把技能读接口包成 MCP 工具后走的就是这条路。
+func skillInternalCtx() context.Context {
+	return common.SetAccountAuthContextToCtx(context.Background(), &interfaces.AccountAuthContext{
+		AccountID:   "user-1",
+		AccountType: interfaces.AccessorTypeUser,
+	})
+}
+
+// TestSkillInternalReadAuthzModes 盯住内部技能读接口的三档授权。
+//
+// 内部面历史上一律放行（授权押给调用方）。MCP 工具接上来之后 skill_id 由调用方自填，
+// 那个前提不再成立，于是加了这道判定——但直接强制会打断存量调用方，所以默认档是
+// shadow：查了、记了、不拦。这个测试锁的就是「默认不拦、开了才拦」。
+func TestSkillInternalReadAuthzModes(t *testing.T) {
+	Convey("内部面技能读接口的授权分档", t, func() {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		newReader := func(authService interfaces.IAuthorizationService, fileRepo model.ISkillFileIndex, assetStore skillAssetStore) *skillReader {
+			return &skillReader{
+				releaseRepo: &stubSkillReleaseRepo{
+					selectBySkillID: func(_ context.Context, _ *sql.Tx, _ string) (*model.SkillReleaseDB, error) {
+						return &model.SkillReleaseDB{
+							SkillID: "skill-1", Version: "v1",
+							Status: interfaces.BizStatusPublished.String(),
+						}, nil
+					},
+				},
+				fileRepo:    fileRepo,
+				assetStore:  assetStore,
+				AuthService: authService,
+				Logger:      logger.DefaultLogger(),
+			}
+		}
+
+		expectDenied := func(authService *mocks.MockIAuthorizationService) {
+			authService.EXPECT().GetAccessor(gomock.Any(), gomock.Any()).Return(&interfaces.AuthAccessor{ID: "user-1"}, nil)
+			authService.EXPECT().OperationCheckAny(gomock.Any(), gomock.Any(), "skill-1", interfaces.AuthResourceTypeSkill,
+				interfaces.AuthOperationTypeExecute, interfaces.AuthOperationTypePublicAccess, interfaces.AuthOperationTypeView).Return(false, nil)
+		}
+
+		Convey("默认档 shadow：判定不通过也放行，只记日志", func() {
+			t.Setenv(common.SkillReadAuthzModeEnv, "")
+			authService := mocks.NewMockIAuthorizationService(ctrl)
+			fileRepo := mocks.NewMockISkillFileIndex(ctrl)
+			assetStore := mocks.NewMockskillAssetStore(ctrl)
+			expectDenied(authService)
+			fileRepo.EXPECT().SelectSkillFileByPath(gomock.Any(), gomock.Nil(), "skill-1", "v1", "refs/guide.md").
+				Return(&model.SkillFileIndexDB{SkillID: "skill-1", SkillVersion: "v1", RelPath: "refs/guide.md"}, nil)
+			assetStore.EXPECT().GetDownloadURL(gomock.Any(), gomock.Any()).Return("https://download/guide.md", nil)
+
+			resp, err := newReader(authService, fileRepo, assetStore).ReadSkillFile(skillInternalCtx(),
+				&interfaces.ReadSkillFileReq{SkillID: "skill-1", RelPath: "refs/guide.md", UserID: "user-1"})
+
+			So(err, ShouldBeNil)
+			So(resp.URL, ShouldEqual, "https://download/guide.md")
+		})
+
+		Convey("enforce 档：判定不通过直接 403，不碰文件", func() {
+			t.Setenv(common.SkillReadAuthzModeEnv, "enforce")
+			authService := mocks.NewMockIAuthorizationService(ctrl)
+			// fileRepo / assetStore 不设 EXPECT：门禁若失效走到读文件，gomock 会因非预期调用失败。
+			expectDenied(authService)
+
+			resp, err := newReader(authService, mocks.NewMockISkillFileIndex(ctrl), mocks.NewMockskillAssetStore(ctrl)).
+				ReadSkillFile(skillInternalCtx(),
+					&interfaces.ReadSkillFileReq{SkillID: "skill-1", RelPath: "refs/guide.md", UserID: "user-1"})
+
+			So(resp, ShouldBeNil)
+			So(err, ShouldNotBeNil)
+		})
+
+		Convey("off 档：完全不查授权", func() {
+			t.Setenv(common.SkillReadAuthzModeEnv, "off")
+			// authService 不设 EXPECT：off 档下一次都不该调。
+			authService := mocks.NewMockIAuthorizationService(ctrl)
+			fileRepo := mocks.NewMockISkillFileIndex(ctrl)
+			assetStore := mocks.NewMockskillAssetStore(ctrl)
+			fileRepo.EXPECT().SelectSkillFileByPath(gomock.Any(), gomock.Nil(), "skill-1", "v1", "refs/guide.md").
+				Return(&model.SkillFileIndexDB{SkillID: "skill-1", SkillVersion: "v1", RelPath: "refs/guide.md"}, nil)
+			assetStore.EXPECT().GetDownloadURL(gomock.Any(), gomock.Any()).Return("https://download/guide.md", nil)
+
+			resp, err := newReader(authService, fileRepo, assetStore).ReadSkillFile(skillInternalCtx(),
+				&interfaces.ReadSkillFileReq{SkillID: "skill-1", RelPath: "refs/guide.md", UserID: "user-1"})
+
+			So(err, ShouldBeNil)
+			So(resp.URL, ShouldEqual, "https://download/guide.md")
+		})
+
+		Convey("无账户身份的内部调用：跳过判定，不误伤存量调用方", func() {
+			t.Setenv(common.SkillReadAuthzModeEnv, "enforce")
+			authService := mocks.NewMockIAuthorizationService(ctrl)
+			fileRepo := mocks.NewMockISkillFileIndex(ctrl)
+			assetStore := mocks.NewMockskillAssetStore(ctrl)
+			fileRepo.EXPECT().SelectSkillFileByPath(gomock.Any(), gomock.Nil(), "skill-1", "v1", "refs/guide.md").
+				Return(&model.SkillFileIndexDB{SkillID: "skill-1", SkillVersion: "v1", RelPath: "refs/guide.md"}, nil)
+			assetStore.EXPECT().GetDownloadURL(gomock.Any(), gomock.Any()).Return("https://download/guide.md", nil)
+
+			resp, err := newReader(authService, fileRepo, assetStore).ReadSkillFile(context.Background(),
+				&interfaces.ReadSkillFileReq{SkillID: "skill-1", RelPath: "refs/guide.md"})
+
+			So(err, ShouldBeNil)
+			So(resp.URL, ShouldEqual, "https://download/guide.md")
+		})
+	})
+}

--- a/docs/api/context-loader/README.md
+++ b/docs/api/context-loader/README.md
@@ -13,7 +13,7 @@
 | [instance-subgraph.yaml](instance-subgraph.yaml) | 实例子图查询 | `POST /kn/query_instance_subgraph` |
 | [logic-property.yaml](logic-property.yaml) | 逻辑属性求值与指标取数 | `POST /kn/logic-property-resolver`、`POST /kn/query_metric` |
 | [action.yaml](action.yaml) | 行动召回与执行 | `POST /kn/get_action_info`、`POST /kn/execute_action`、`POST /kn/get_action_execution`、`POST /kn/list_action_executions` |
-| [skill.yaml](skill.yaml) | Skill 召回 | `POST /kn/find_skills` |
+| [skill.yaml](skill.yaml) | Skill 召回与读取 | `POST /kn/find_skills`、`POST /kn/list_skills`、`POST /kn/get_skill_content`、`POST /kn/read_skill_file`、`POST /kn/execute_skill` |
 | [data-access.yaml](data-access.yaml) | 数据层直查 | `POST /kn/list_resources`、`POST /kn/describe_resource`、`POST /kn/run_sql` |
 | [mcp.yaml](mcp.yaml) | MCP 服务 | `GET /mcp/info`、`POST /mcp` |
 
@@ -27,6 +27,7 @@ query_object_instance    → 取实例，从 _instance_identity 拿主键
   ├→ logic-property-resolver → 求指标 / 算子类逻辑属性（实例 + 已绑逻辑属性）
   ├→ get_action_info → execute_action → get_action_execution → 执行闭环
   └→ find_skills            → 召回可装载的 Skill
+       └→ get_skill_content → read_skill_file → execute_skill
 ```
 
 指标取数（OT 优先，已建模指标别用 `run_sql` 重写口径）：
@@ -37,6 +38,9 @@ get_object_types               → 从 related_metrics 选定指标
   ├→ logic-property-resolver   → 实例级 + 已绑逻辑属性
   └→ query_metric              → 类级 / 未绑逻辑属性，按 MetricDefinition 口径算
 ```
+
+Skill 面另有一条不依赖知识网络的入口：`list_skills` 直接翻已发布 Skill 列表，
+再走同样的 `get_skill_content` → `read_skill_file` → `execute_skill`。
 
 绕开本体直查数据：`list_resources` → `describe_resource` → `run_sql`。
 
@@ -61,7 +65,7 @@ make api-contract-diff CONTRACT_FACE=ex CONTRACT_SSH=root@<host> \
      CONTRACT_ARGS="--include-probe-post --token $TOKEN"
 ```
 
-21 个操作里 **15 个在探测范围内**，其余 6 个不探测，原因如下——它们的响应结构
+25 个操作里 **16 个在探测范围内**，其余 9 个不探测，原因如下——它们的响应结构
 **未经实机验证**，改动时请人工核对：
 
 | 端点 | 不探测的原因 |
@@ -72,7 +76,11 @@ make api-contract-diff CONTRACT_FACE=ex CONTRACT_SSH=root@<host> \
 | `query_metric` | 需要环境里存在已建模指标，`metric_id` 无法自动合成 |
 | `run_sql` | 需要针对具体资源构造有意义的 SQL，无法自动合成 |
 | `POST /mcp` | JSON-RPC 会话语义，不是普通请求 / 响应结构 |
+| `execute_skill` | **有副作用**，会在沙箱内真的执行命令 |
+| `get_skill_content` | 需要环境里存在已发布 Skill 的真实 `skill_id` |
+| `read_skill_file` | 同上，且还需要包内一个真实存在的 `rel_path` |
 
-探测范围内的 15 个中，`get_action_info`、`get_action_execution`、`find_skills`
+探测范围内的 16 个中，`get_action_info`、`get_action_execution`、`find_skills`
 依赖环境里存在行动类 / 执行记录 / `skills` 对象类，数据不具备时报告会列为
-「缺少探测参数」或 404，同样按未验证处理。
+「缺少探测参数」或 404，同样按未验证处理。`list_skills` 在没有已发布 Skill 时
+返回空列表加 `message`，属正常 200。

--- a/docs/api/context-loader/mcp.yaml
+++ b/docs/api/context-loader/mcp.yaml
@@ -15,7 +15,10 @@ info:
     `get_action_info`、`execute_action`、`get_action_execution`、
     `list_action_executions`、`find_skills`、`run_sql`、`list_knowledge_networks`、
     `get_kn_detail`、`get_object_types`、`get_relation_types`、`list_resources`、
-    `describe_resource`。业务工具必须显式携带服务自描述 schema 中的 `bkn_context`，
+    `describe_resource`、`list_skills`、`get_skill_content`、`read_skill_file`。
+    另有一个默认不装配的 `execute_skill`：它把入口命令送进沙箱执行，只有显式开启
+    （`MCP_EXECUTE_SKILL_ENABLED=true`）才出现在 `tools/list` 与 `GET /mcp/info`，
+    未开启时与「没编译进来」无异。业务工具必须显式携带服务自描述 schema 中的 `bkn_context`，
     其中只要求权威返回的 `conversation_id` 和 `interaction_id`；Operation key、租约、
     重试和 closure manifest 由 Context Loader 与 BKN Trace Core 管理；
     各工具的语义与参数含义见本目录下对应的 REST 文档。

--- a/docs/api/context-loader/skill.yaml
+++ b/docs/api/context-loader/skill.yaml
@@ -7,6 +7,11 @@ info:
     实例），拿回一批相关 Skill 的最小元数据（`skill_id` / `name` / `description`），
     再决定装载哪一个。
 
+    召回只是入口。拿到 `skill_id` 之后：`get_skill_content` 读 SKILL.md 正文与包内
+    文件清单，`read_skill_file` 按 `rel_path` 单取附属文件（渐进式加载，大文件不必
+    常驻上下文），`execute_skill` 在沙箱内执行 SKILL.md 声明的入口命令。不需要知识
+    网络上下文时用 `list_skills` 直接翻已发布技能列表。
+
     Skill 与业务对象的绑定关系建在知识网络里：平台约定该网中存在一个固定的
     `skills` 对象类，业务对象类通过关系类与它相连，召回就是沿这些关系走。
     `skills` 对象类由 execution-factory 在注册 Skill 时写入。
@@ -149,6 +154,264 @@ paths:
               schema:
                 $ref: '../_shared/errors.yaml#/components/schemas/ErrorAgentRetrieval'
 
+  /kn/list_skills:
+    post:
+      tags:
+        - Skill
+      summary: 浏览已发布 Skill
+      operationId: listSkills
+      x-contract-probe:
+        readonly: true
+        order: 4
+        body:
+          page_size: 3
+      description: |
+        翻已发布 Skill 列表，不需要知识网络上下文。与 `find_skills` 互补：那条按对象类
+        / 实例召回，这条按名称或分类分页浏览。
+
+        只返回**已发布**状态的 Skill；草稿态不出现在这里。
+
+        **空结果是 200 不是错误**：无匹配时 `entries: []` 并带 `message` 说明。
+      parameters:
+        - $ref: '#/components/parameters/ResponseFormat'
+      requestBody:
+        required: false
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ListSkillsRequest'
+            examples:
+              全部:
+                value: {}
+              按名称过滤:
+                value:
+                  name: 合同
+                  page: 1
+                  page_size: 20
+      responses:
+        '200':
+          description: 已发布 Skill 列表，可能为空
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ListSkillsResponse'
+              examples:
+                有结果:
+                  value:
+                    entries:
+                      - skill_id: skill_contract_review
+                        name: 合同审查
+                        description: 对合同条款进行全面审查，识别风险点
+                        version: '1.0.2'
+                        category: legal
+                    total_count: 1
+                    page: 1
+                    page_size: 20
+            application/toon:
+              schema:
+                type: string
+        '401':
+          description: 凭据缺失或无效
+          content:
+            application/json:
+              schema:
+                $ref: '../_shared/errors.yaml#/components/schemas/ErrorAgentRetrieval'
+        '502':
+          description: 上游 execution-factory 不可用
+          content:
+            application/json:
+              schema:
+                $ref: '../_shared/errors.yaml#/components/schemas/ErrorAgentRetrieval'
+
+  /kn/get_skill_content:
+    post:
+      tags:
+        - Skill
+      summary: 读 SKILL.md 正文与包内文件清单
+      operationId: getSkillContent
+      description: |
+        返回 Skill 主文档 `SKILL.md` 的正文，以及技能包内的文件清单
+        （`files[].rel_path`）。Skill 的用法与入口命令都写在正文里。
+
+        需要某个附属文件的内容时再调 `read_skill_file` 单取，不必整包下载。
+
+        正文超过 40000 字符会截断，此时 `truncated=true` 并带 `message` 说明。
+      parameters:
+        - $ref: '#/components/parameters/ResponseFormat'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/GetSkillContentRequest'
+            examples:
+              example:
+                value:
+                  skill_id: skill_contract_review
+      responses:
+        '200':
+          description: SKILL.md 正文与文件清单
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GetSkillContentResponse'
+            application/toon:
+              schema:
+                type: string
+        '400':
+          description: 缺少 `skill_id`
+          content:
+            application/json:
+              schema:
+                $ref: '../_shared/errors.yaml#/components/schemas/ErrorAgentRetrieval'
+        '401':
+          description: 凭据缺失或无效
+          content:
+            application/json:
+              schema:
+                $ref: '../_shared/errors.yaml#/components/schemas/ErrorAgentRetrieval'
+        '403':
+          description: 当前账户对该 Skill 无执行 / 查看 / 公开访问权限
+          content:
+            application/json:
+              schema:
+                $ref: '../_shared/errors.yaml#/components/schemas/ErrorAgentRetrieval'
+        '404':
+          description: Skill 不存在或未发布
+          content:
+            application/json:
+              schema:
+                $ref: '../_shared/errors.yaml#/components/schemas/ErrorAgentRetrieval'
+
+  /kn/read_skill_file:
+    post:
+      tags:
+        - Skill
+      summary: 读技能包内单个文件
+      operationId: readSkillFile
+      description: |
+        按 `rel_path` 取技能包内单个文件的正文。`rel_path` 取自
+        `get_skill_content` 返回的 `files[].rel_path`，**不接受包外路径**（`../` 被拒）。
+
+        **二进制文件不回正文**：`mime_type` 为图片 / 音视频 / 压缩包 / PDF，或正文不是
+        合法 UTF-8 时，只返回元数据与 `message` 说明，避免把乱码灌进模型上下文。
+
+        正文超过 40000 字符会截断（`truncated=true`）；单文件超过 5 MiB 返回 413。
+      parameters:
+        - $ref: '#/components/parameters/ResponseFormat'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ReadSkillFileRequest'
+            examples:
+              example:
+                value:
+                  skill_id: skill_contract_review
+                  rel_path: refs/checklist.md
+      responses:
+        '200':
+          description: 文件元数据与正文（二进制文件无正文）
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ReadSkillFileResponse'
+            application/toon:
+              schema:
+                type: string
+        '400':
+          description: 缺少 `skill_id` / `rel_path`，或路径越出技能包
+          content:
+            application/json:
+              schema:
+                $ref: '../_shared/errors.yaml#/components/schemas/ErrorAgentRetrieval'
+        '403':
+          description: 当前账户对该 Skill 无执行 / 查看 / 公开访问权限
+          content:
+            application/json:
+              schema:
+                $ref: '../_shared/errors.yaml#/components/schemas/ErrorAgentRetrieval'
+        '404':
+          description: Skill 或该路径的文件不存在
+          content:
+            application/json:
+              schema:
+                $ref: '../_shared/errors.yaml#/components/schemas/ErrorAgentRetrieval'
+        '413':
+          description: 文件超过 5 MiB 上限，改用技能包下载接口
+          content:
+            application/json:
+              schema:
+                $ref: '../_shared/errors.yaml#/components/schemas/ErrorAgentRetrieval'
+
+  /kn/execute_skill:
+    post:
+      tags:
+        - Skill
+      summary: 在沙箱内执行 Skill 入口命令
+      operationId: executeSkill
+      description: |
+        把 Skill 包投进沙箱会话解压，执行 `entry_shell` 指定的入口命令，回收
+        `exit_code` / `stdout` / `stderr`。
+
+        **`entry_shell` 必须取自 SKILL.md 声明的入口**，先用 `get_skill_content`
+        读清楚再调；这条接口不校验命令与 Skill 的对应关系。
+
+        授权由 execution-factory 按账户强制：需要该 Skill 的 `execute` 或
+        `public_access` 权限，无权限返回 403。
+
+        `stdout` / `stderr` 各自超过 8000 字符会截断（`truncated=true`）。
+
+        **同名 MCP 工具默认不装配**：MCP 面的 `execute_skill` 需要显式开启
+        （`MCP_EXECUTE_SKILL_ENABLED=true`）；未开启时它既不出现在 `tools/list`
+        也不出现在 `GET /mcp/info`。本 REST 端点不受该开关影响。
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ExecuteSkillRequest'
+            examples:
+              example:
+                value:
+                  skill_id: skill_contract_review
+                  entry_shell: python main.py --input contract.txt
+                  timeout: 60
+      responses:
+        '200':
+          description: |
+            执行完成。注意 `exit_code != 0` 同样是 200——命令跑完了但业务失败，
+            与接口调用失败是两回事。
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ExecuteSkillResponse'
+        '400':
+          description: 缺少 `skill_id` / `entry_shell`
+          content:
+            application/json:
+              schema:
+                $ref: '../_shared/errors.yaml#/components/schemas/ErrorAgentRetrieval'
+        '403':
+          description: 当前账户对该 Skill 无执行权限
+          content:
+            application/json:
+              schema:
+                $ref: '../_shared/errors.yaml#/components/schemas/ErrorAgentRetrieval'
+        '404':
+          description: Skill 不存在或未发布
+          content:
+            application/json:
+              schema:
+                $ref: '../_shared/errors.yaml#/components/schemas/ErrorAgentRetrieval'
+        '502':
+          description: 沙箱或上游 execution-factory 不可用
+          content:
+            application/json:
+              schema:
+                $ref: '../_shared/errors.yaml#/components/schemas/ErrorAgentRetrieval'
+
 components:
   securitySchemes:
     OAuth2:
@@ -255,3 +518,220 @@ components:
           type: string
           description: Skill 功能描述。BKN 中无该属性时不返回，也不影响召回。
           example: 对合同条款进行全面审查，识别风险点
+
+    ListSkillsRequest:
+      type: object
+      properties:
+        bkn_context:
+          $ref: '../_shared/common.yaml#/components/schemas/BKNContext'
+        name:
+          type: string
+          description: 按 Skill 名称模糊过滤。
+          example: 合同
+        category:
+          type: string
+          description: 按 Skill 分类过滤。
+        page:
+          type: integer
+          minimum: 1
+          default: 1
+          description: 页码，从 1 开始。
+        page_size:
+          type: integer
+          minimum: 1
+          maximum: 100
+          default: 20
+          description: 每页大小。
+
+    ListSkillsResponse:
+      type: object
+      required:
+        - entries
+        - total_count
+      properties:
+        entries:
+          type: array
+          items:
+            $ref: '#/components/schemas/SkillListItem'
+        total_count:
+          type: integer
+          description: 符合过滤条件的已发布 Skill 总数。
+        page:
+          type: integer
+        page_size:
+          type: integer
+        message:
+          type: string
+          description: 空结果说明。仅当 `entries` 为空时出现。
+
+    SkillListItem:
+      type: object
+      required:
+        - skill_id
+        - name
+      properties:
+        skill_id:
+          type: string
+          example: skill_contract_review
+        name:
+          type: string
+          example: 合同审查
+        description:
+          type: string
+        version:
+          type: string
+          description: 已发布版本。
+          example: '1.0.2'
+        category:
+          type: string
+
+    GetSkillContentRequest:
+      type: object
+      required:
+        - bkn_context
+        - skill_id
+      properties:
+        bkn_context:
+          $ref: '../_shared/common.yaml#/components/schemas/BKNContext'
+        skill_id:
+          type: string
+          description: Skill ID，取自 `find_skills` 或 `list_skills`。
+          example: skill_contract_review
+
+    GetSkillContentResponse:
+      type: object
+      required:
+        - skill_id
+        - content
+        - files
+      properties:
+        skill_id:
+          type: string
+        status:
+          type: string
+          description: Skill 状态，正常为 `published`。
+        content:
+          type: string
+          description: SKILL.md 正文。
+        truncated:
+          type: boolean
+          description: 正文是否因超长（40000 字符）被截断。
+        files:
+          type: array
+          description: 技能包内文件清单，`rel_path` 供 `read_skill_file` 使用。
+          items:
+            $ref: '#/components/schemas/SkillFileSummary'
+        message:
+          type: string
+          description: 补充说明（如截断提示）。
+
+    SkillFileSummary:
+      type: object
+      required:
+        - rel_path
+      properties:
+        rel_path:
+          type: string
+          example: refs/checklist.md
+        file_type:
+          type: string
+        size:
+          type: integer
+          description: 字节数。
+        mime_type:
+          type: string
+
+    ReadSkillFileRequest:
+      type: object
+      required:
+        - bkn_context
+        - skill_id
+        - rel_path
+      properties:
+        bkn_context:
+          $ref: '../_shared/common.yaml#/components/schemas/BKNContext'
+        skill_id:
+          type: string
+          example: skill_contract_review
+        rel_path:
+          type: string
+          description: |
+            技能包内相对路径，取自 `get_skill_content` 的 `files[].rel_path`。
+            包外路径（含 `../`）返回 400。
+          example: refs/checklist.md
+
+    ReadSkillFileResponse:
+      type: object
+      required:
+        - skill_id
+        - rel_path
+      properties:
+        skill_id:
+          type: string
+        rel_path:
+          type: string
+        mime_type:
+          type: string
+        file_type:
+          type: string
+        content:
+          type: string
+          description: 文件正文。二进制文件不返回该字段。
+        truncated:
+          type: boolean
+        message:
+          type: string
+          description: 补充说明（二进制未返回正文 / 截断提示）。
+
+    ExecuteSkillRequest:
+      type: object
+      required:
+        - bkn_context
+        - skill_id
+        - entry_shell
+      properties:
+        bkn_context:
+          $ref: '../_shared/common.yaml#/components/schemas/BKNContext'
+        skill_id:
+          type: string
+          example: skill_contract_review
+        entry_shell:
+          type: string
+          description: |
+            沙箱内执行的入口命令，取自 SKILL.md 声明的入口。技能包已解压到工作目录，
+            命令相对该目录执行。
+          example: python main.py --input contract.txt
+        timeout:
+          type: integer
+          minimum: 1
+          maximum: 600
+          description: 执行超时秒数。
+
+    ExecuteSkillResponse:
+      type: object
+      required:
+        - skill_id
+        - exit_code
+      properties:
+        skill_id:
+          type: string
+        exit_code:
+          type: integer
+          description: 进程退出码，0 为成功。非 0 时接口仍返回 200。
+        stdout:
+          type: string
+        stderr:
+          type: string
+        truncated:
+          type: boolean
+          description: "`stdout` / `stderr` 是否被截断（各自 8000 字符上限）。"
+        execution_time:
+          type: integer
+          description: 执行耗时（毫秒）。
+        work_dir:
+          type: string
+        command:
+          type: string
+        mocked:
+          type: boolean
+          description: 沙箱不可用时的桩执行标记。

--- a/docs/api/execution-factory/skill.yaml
+++ b/docs/api/execution-factory/skill.yaml
@@ -28,6 +28,15 @@ info:
 
     **认证**：`Authorization: Bearer <token>`（OAuth access token 或 `bak_` 前缀的
     AppKey）。**本面所有接口都要求 `x-business-domain` 头**（路由组统一加了中间件）。
+
+    **内部面（`internal-v1`）的读授权按档位**：`/content` 与 `/files/read` 在公开面
+    一律按账户判定（`execute` / `public_access` / `view` 三者有其一），内部面则看
+    `SKILL_INTERNAL_READ_AUTHZ`——`shadow`（默认）查了但不拦、判定不通过只打日志，
+    `enforce` 与公开面一致返回 403，`off` 完全不查。分档是为了不打断存量内部调用方：
+    context-loader 已把这两个接口包成 MCP 工具，`skill_id` 由调用方自填，内部面无条件
+    放行等于任意账户可读任意技能全文，但直接翻强制会误伤，先影子观察再翻。
+    调用方没带账户身份时任何档位都跳过判定——那是「无从判断」，不是「判定为无权」。
+    `/execute` 不受该档位影响，一直按账户强制。
   version: 0.1.3
 servers:
   - url: /api/agent-operator-integration/v1


### PR DESCRIPTION
## 问题

`find_skills` 只回 `skill_id` + `name` + `description`，拿到之后无路可走：读不到 SKILL.md、列不出包内文件、执行不了脚本。执行工厂那三条接口一直都在（`/skills/:id/content`、`/files/read`、`/execute`），缺的是 MCP 这一层的封装。

## 改了什么

MCP 与 `/in` REST 同源新增四条工具：

| 工具 | 后端 | 说明 |
|---|---|---|
| `list_skills` | internal-v1 `/skills/market` | 浏览已发布技能，不需要知识网络上下文，与 `find_skills` 互补 |
| `get_skill_content` | `/skills/:id/content` | SKILL.md **正文** + 包内文件清单 `files[].rel_path` |
| `read_skill_file` | `/skills/:id/files/read` | 按 `rel_path` 单取附属文件，渐进式加载 |
| `execute_skill` | `/skills/:id/execute` | 沙箱内执行 SKILL.md 声明的入口命令 |

发布态接口只回对象存储 presigned URL，适配层补第二跳把正文取回来，模型拿到的是文本不是链接。正文按**字符**（非字节）截断，避免切碎多字节字符；二进制文件（mime 命中黑名单、非法 UTF-8、含 NUL）只回元数据加说明，不把乱码灌进上下文。

`.adp` 同步四条，`metadata.version == source_id`；社区版工具面基线、`/mcp/info` 与 API 文档一并更新。

## 两个需要评审注意的判断

**`execute_skill` 默认不装配。** 它是工具面唯一的命令执行通道，要 `MCP_EXECUTE_SKILL_ENABLED=true` 才出现在 `tools/list` 与 `GET /mcp/info`——未开启时与「没编译进来」无异，否则等于对任何探测者广播这台服务能执行命令。REST 端点 `/in/v1/kn/execute_skill` 不受该开关影响。

**技能读接口的内部授权补丁走三段式。** `/execute` 在执行工厂侧本就按账户强制；`/content` 与 `/files/read` 此前只在公开面判定，内部面无条件放行——MCP 一接上去 `skill_id` 由调用方自填，等于任意账户可读任意技能全文。新增 `SKILL_INTERNAL_READ_AUTHZ`：

- `shadow`（默认）查而不拦，判定不通过只打 `[skill.read.authz.shadow]` 日志
- `enforce` 与公开面一致返回 403
- `off` 完全不查
- 调用方没带账户身份时任何档位都跳过——那是「无从判断」，不是「判定为无权」，拦下来会误伤 bkn-agent

默认档与旧行为完全等价，只多日志。观察线上无误伤后再翻 `enforce`。

## 测试

- context-loader `go test ./...` 全绿，含 knskills 单测 6 例（多字节截断 / 二进制拒回正文 / `application/octet-stream` 的文本不被误杀 / 缺参 / stdout 截断）、MCP 开关两态 2 例
- execution-factory `go test ./...` 全绿，含内部授权三档 + 无身份 4 例；`tests/local` 那 3 个 fail 是 main 上就坏的（缺 fixture 文件），与本 PR 无关

## 尚未验证

VM 当前有另一场部署在跑且镜像拉取大面积失败，真机验证没做成。待验：`../` 越权路径、单文件超 5 MiB 走 413、presigned URL 过期的报错形态、`list_skills` 分页边界、`bkn_context` 缺失时生命周期守卫对这四条的拦截。

🤖 Generated with [Claude Code](https://claude.com/claude-code)