### PR TITLE
feat(context-loader): serve display metadata on MCP tools, and fix the catalogue's locale bypass

### DIFF
--- a/adp/context-loader/agent-retrieval/server/driveradapters/mcp/app.go
+++ b/adp/context-loader/agent-retrieval/server/driveradapters/mcp/app.go
@@ -170,8 +170,8 @@ func newMCPServer(lifecycleClient *bkntrace.LifecycleClient) (*server.MCPServer,
 	bknBackend := drivenadapters.NewBknBackendAccess()
 	b.add(toolKeyListKnowledgeNetworks, handleListKnowledgeNetworks(bknBackend))
 	b.add(toolKeyGetKnDetail, handleGetKnDetail(bknBackend, metricsService))
-	b.addEmbedded(toolKeyGetObjectTypes, handleGetObjectTypes(bknBackend, metricsService))
-	b.addEmbedded(toolKeyGetRelationTypes, handleGetRelationTypes(bknBackend))
+	b.add(toolKeyGetObjectTypes, handleGetObjectTypes(bknBackend, metricsService))
+	b.add(toolKeyGetRelationTypes, handleGetRelationTypes(bknBackend))
 
 	runSQLService := knrunsql.NewKnRunSQLService()
 	b.add(toolKeyRunSQL, handleRunSQL(runSQLService))
@@ -220,7 +220,7 @@ func newMCPServer(lifecycleClient *bkntrace.LifecycleClient) (*server.MCPServer,
 		// notices.
 		server.WithToolFilter(b.filter),
 	)
-	registerLifecycleTools(mcpServer, lifecycleClient)
+	registerLifecycleTools(mcpServer, lifecycleClient, localeBundle)
 	b.attach(mcpServer)
 	return mcpServer, b
 }

--- a/adp/context-loader/agent-retrieval/server/driveradapters/mcp/app.go
+++ b/adp/context-loader/agent-retrieval/server/driveradapters/mcp/app.go
@@ -225,8 +225,44 @@ func newMCPServer(lifecycleClient *bkntrace.LifecycleClient) (*server.MCPServer,
 	return mcpServer, b
 }
 
-func newToolWithSchemas(name, description string, input, output json.RawMessage) mcp.Tool {
-	tool := mcp.NewToolWithRawSchema(name, description, input)
+// Prefix for this service's own `_meta` keys on a tool.
+//
+// MCP reserves modelcontextprotocol.io/ and mcp.dev/ for itself and asks
+// everyone else to prefix with a domain they control, so these keys cannot
+// collide with a future protocol field of the same short name.
+const toolMetaKeyPrefix = "openbkn.ai/"
+
+// Presentation hints that have no field of their own in the protocol. `title`
+// does have one and is set on the tool directly.
+const (
+	toolMetaKeyGroup      = toolMetaKeyPrefix + "group"
+	toolMetaKeyGroupTitle = toolMetaKeyPrefix + "group_title"
+	toolMetaKeyOrder      = toolMetaKeyPrefix + "order"
+)
+
+func newToolWithSchemas(meta ToolMeta, input, output json.RawMessage) mcp.Tool {
+	tool := mcp.NewToolWithRawSchema(meta.Name, meta.Description, input)
 	tool.RawOutputSchema = output
+	tool.Title = meta.Title
+	if fields := toolDisplayMetaFields(meta); len(fields) > 0 {
+		tool.Meta = &mcp.Meta{AdditionalFields: fields}
+	}
 	return tool
+}
+
+// toolDisplayMetaFields renders the non-protocol presentation hints as `_meta`
+// entries, omitting whatever the tool did not declare — an absent key is how a
+// client tells "ungrouped" from "grouped under the empty string".
+func toolDisplayMetaFields(meta ToolMeta) map[string]any {
+	fields := map[string]any{}
+	if meta.Group != "" {
+		fields[toolMetaKeyGroup] = meta.Group
+	}
+	if meta.GroupTitle != "" {
+		fields[toolMetaKeyGroupTitle] = meta.GroupTitle
+	}
+	if meta.Order != 0 {
+		fields[toolMetaKeyOrder] = meta.Order
+	}
+	return fields
 }

--- a/adp/context-loader/agent-retrieval/server/driveradapters/mcp/assemble.go
+++ b/adp/context-loader/agent-retrieval/server/driveradapters/mcp/assemble.go
@@ -59,9 +59,8 @@ func newToolBuilder(locale *mcpLocaleBundle) *toolBuilder {
 // add registers a core tool, taking metadata and schemas from the locale
 // bundle.
 func (b *toolBuilder) add(key string, h mcptool.Handler) {
-	name, desc := b.locale.ToolMeta(key)
 	in, out := b.locale.ToolSchemas(key)
-	b.addWith(key, name, desc, in, out, h)
+	b.addWith(key, b.locale.ToolMeta(key), in, out, h)
 }
 
 // addEmbedded registers a core tool from the embedded schemas directory,
@@ -72,9 +71,8 @@ func (b *toolBuilder) add(key string, h mcptool.Handler) {
 // changes what a community binary advertises, so it is a separate change with
 // its own parity baseline.
 func (b *toolBuilder) addEmbedded(key string, h mcptool.Handler) {
-	name, desc := loadToolMeta(key)
 	in, out := loadToolSchemas(key)
-	b.addWith(key, name, desc, in, out, h)
+	b.addWith(key, loadToolMeta(key), in, out, h)
 }
 
 // addWith is where a core tool meets its decorator, if it has one.
@@ -85,13 +83,13 @@ func (b *toolBuilder) addEmbedded(key string, h mcptool.Handler) {
 // publish a paid parameter in its schema and stop being byte-identical to
 // community. The handler is wrapped either way — Wrap re-checks the licence on
 // every call and falls back to core's own result when it does not hold.
-func (b *toolBuilder) addWith(key, name, desc string, in, out json.RawMessage, h mcptool.Handler) {
-	b.claimName(name, key)
+func (b *toolBuilder) addWith(key string, meta ToolMeta, in, out json.RawMessage, h mcptool.Handler) {
+	b.claimName(meta.Name, key)
 	if d, ok := mcptool.DecoratorFor(key); ok {
-		b.patched[name] = newToolWithSchemas(name, desc, d.Patch(in), out)
+		b.patched[meta.Name] = newToolWithSchemas(meta, d.Patch(in), out)
 		h = d.Wrap(h)
 	}
-	b.pending = append(b.pending, pendingTool{newToolWithSchemas(name, desc, in, out), h})
+	b.pending = append(b.pending, pendingTool{newToolWithSchemas(meta, in, out), h})
 }
 
 // addExtras appends the enterprise-only tools. In a community binary the
@@ -108,7 +106,7 @@ func (b *toolBuilder) addExtras() {
 		// tool is unusable by anyone following it — the schema comes from ee,
 		// which has no reason to know this service has a lifecycle guard.
 		b.pending = append(b.pending, pendingTool{
-			newToolWithSchemas(t.Name, t.Desc, offerBKNContext(t.Input), t.Output),
+			newToolWithSchemas(extraToolMeta(t), offerBKNContext(t.Input), t.Output),
 			mcptool.Gated(t),
 		})
 	}
@@ -163,8 +161,26 @@ func (b *toolBuilder) claimName(name, key string) {
 // AddTool lets the later registration win.
 func (b *toolBuilder) claimLifecycleNames() {
 	for key := range lifecycleToolNames {
-		name, _ := loadToolMeta(key)
-		b.claimName(name, key)
+		b.claimName(loadToolMeta(key).Name, key)
+	}
+}
+
+// extraToolMeta reads an enterprise tool's presentation hints off its
+// declaration.
+//
+// They are optional there and stay optional here: an ee build that declares
+// none gets a tool with no title and no group, which is what every tool looked
+// like before this existed. Core does not invent a group for it — inventing one
+// would put a paid tool under a heading core made up, and core cannot see the
+// capability well enough to name it.
+func extraToolMeta(t mcptool.ExtraTool) ToolMeta {
+	return ToolMeta{
+		Name:        t.Name,
+		Title:       t.Title,
+		Group:       t.Group,
+		GroupTitle:  t.GroupTitle,
+		Order:       t.Order,
+		Description: t.Desc,
 	}
 }
 

--- a/adp/context-loader/agent-retrieval/server/driveradapters/mcp/assemble.go
+++ b/adp/context-loader/agent-retrieval/server/driveradapters/mcp/assemble.go
@@ -63,18 +63,6 @@ func (b *toolBuilder) add(key string, h mcptool.Handler) {
 	b.addWith(key, b.locale.ToolMeta(key), in, out, h)
 }
 
-// addEmbedded registers a core tool from the embedded schemas directory,
-// bypassing the locale bundle.
-//
-// Only get_object_types and get_relation_types come through here, and that is a
-// standing bug rather than a design — they miss out on localisation. Fixing it
-// changes what a community binary advertises, so it is a separate change with
-// its own parity baseline.
-func (b *toolBuilder) addEmbedded(key string, h mcptool.Handler) {
-	in, out := loadToolSchemas(key)
-	b.addWith(key, loadToolMeta(key), in, out, h)
-}
-
 // addWith is where a core tool meets its decorator, if it has one.
 //
 // The tool is registered with core's own schema and the patched variant is kept
@@ -161,7 +149,7 @@ func (b *toolBuilder) claimName(name, key string) {
 // AddTool lets the later registration win.
 func (b *toolBuilder) claimLifecycleNames() {
 	for key := range lifecycleToolNames {
-		b.claimName(loadToolMeta(key).Name, key)
+		b.claimName(b.locale.ToolMeta(key).Name, key)
 	}
 }
 

--- a/adp/context-loader/agent-retrieval/server/driveradapters/mcp/community_parity_test.go
+++ b/adp/context-loader/agent-retrieval/server/driveradapters/mcp/community_parity_test.go
@@ -104,11 +104,6 @@ func TestCommunityToolSchemasUnchanged(t *testing.T) {
 			t.Fatalf("tool %q missing from the assembled server", key)
 		}
 		want, _ := bundle.ToolSchemas(key)
-		if key == toolKeyGetObjectTypes || key == toolKeyGetRelationTypes {
-			// These two still read the embedded schemas directly; see
-			// toolBuilder.addEmbedded.
-			want, _ = loadToolSchemas(key)
-		}
 		if string(tool.Tool.RawInputSchema) != string(want) {
 			t.Fatalf("tool %q input schema was modified with no extension registered", key)
 		}
@@ -157,8 +152,9 @@ func TestCommunityMCPInfoSchemasComeFromEmbeddedFiles(t *testing.T) {
 	if err != nil {
 		t.Fatalf("BuildMCPInfo: %v", err)
 	}
+	locale := loadMCPLocaleBundle(mcpLocaleFromEnv())
 	for _, tool := range info.Tools {
-		want, _ := tryLoadToolSchemas(tool.Name)
+		want, _ := tryLoadToolSchemas(locale, tool.Name)
 		if len(want) == 0 {
 			continue
 		}

--- a/adp/context-loader/agent-retrieval/server/driveradapters/mcp/info.go
+++ b/adp/context-loader/agent-retrieval/server/driveradapters/mcp/info.go
@@ -42,10 +42,10 @@ type MCPInfo struct {
 }
 
 // tryLoadToolSchemas 与 loadToolSchemas 同源，但读不到/解析失败时返回 nil 而非 panic，
-// 供 info 端点容错使用。
-func tryLoadToolSchemas(toolKey string) (input, output json.RawMessage) {
+// 供 info 端点容错使用。取到之后按 locale 叠一层，与 tools/list 同一份答案。
+func tryLoadToolSchemas(locale *mcpLocaleBundle, toolKey string) (input, output json.RawMessage) {
 	if input, output, ok := lifecycleToolSchemas(toolKey); ok {
-		return input, output
+		return locale.OverlaySchemas(toolKey, input, output)
 	}
 	data, err := schemasFS.ReadFile(fmt.Sprintf("schemas/%s.json", toolKey))
 	if err != nil {
@@ -58,7 +58,7 @@ func tryLoadToolSchemas(toolKey string) (input, output json.RawMessage) {
 	if isBusinessTool(toolKey) {
 		wrapper.InputSchema = offerBKNContext(wrapper.InputSchema)
 	}
-	return wrapper.InputSchema, wrapper.OutputSchema
+	return locale.OverlaySchemas(toolKey, wrapper.InputSchema, wrapper.OutputSchema)
 }
 
 // BuildMCPInfo 基于内嵌的 tools_meta.json + schemas/*.json 组装 MCP 自描述文档。
@@ -72,8 +72,8 @@ func BuildMCPInfo(endpoint string) (*MCPInfo, error) {
 	if err := json.Unmarshal(data, &meta); err != nil {
 		return nil, fmt.Errorf("parse tools_meta.json: %w", err)
 	}
-	// 这里读的恒是内嵌的那份，不过 locale——和 name/description 一样，是这个端点
-	// 早就有的缺口（见 socket_call_test.go 里那条注释），展示元数据只是跟着它走。
+	// 本地化按与 tools/list 同一个来源解析（进程环境）。这个端点此前对 locale
+	// 失明，非中文部署下它与 tools/list 会给出两种语言的同一份目录。
 
 	// 与 tools/list 用同一套按当前档位的判定：装饰过的工具带上付费参数、
 	// 未授权的企业工具不出现。两处若不一致，这个端点就比不存在更糟——它的
@@ -82,14 +82,16 @@ func BuildMCPInfo(endpoint string) (*MCPInfo, error) {
 		key  string
 		info MCPToolInfo
 	}
+	locale := loadMCPLocaleBundle(mcpLocaleFromEnv())
 	all := make([]entry, 0, len(meta))
-	for key, m := range meta {
+	for key := range meta {
 		// 未装配的工具不能出现在这里：这个端点的用途是「不握手就看清能力面」，
 		// 广播一条 tools/call 会答「无此工具」的条目比不广播更糟。
 		if key == toolKeyExecuteSkill && !executeSkillEnabled() {
 			continue
 		}
-		in, out := tryLoadToolSchemas(key)
+		m := locale.ToolMeta(key)
+		in, out := tryLoadToolSchemas(locale, key)
 		if d, ok := mcptool.DecoratorFor(key); ok && d.Allowed() {
 			in = d.Patch(in)
 		}

--- a/adp/context-loader/agent-retrieval/server/driveradapters/mcp/info.go
+++ b/adp/context-loader/agent-retrieval/server/driveradapters/mcp/info.go
@@ -12,9 +12,17 @@ import (
 	"github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/extension/mcptool"
 )
 
-// MCPToolInfo 单个工具的对外说明（名称 / 描述 / 输入输出 schema）。
+// MCPToolInfo 单个工具的对外说明（名称 / 展示元数据 / 描述 / 输入输出 schema）。
+//
+// title / group / group_title / order 与 tools/list 同源：那边 title 落在协议
+// 自己的字段上、其余三个落在工具的 `_meta`，这边一律是平铺字段。两处必须给出
+// 同一份答案——这个端点存在的理由就是「不握手也能看清能力面」。
 type MCPToolInfo struct {
 	Name         string          `json:"name"`
+	Title        string          `json:"title,omitempty"`
+	Group        string          `json:"group,omitempty"`
+	GroupTitle   string          `json:"group_title,omitempty"`
+	Order        int             `json:"order,omitempty"`
 	Description  string          `json:"description"`
 	InputSchema  json.RawMessage `json:"input_schema,omitempty"`
 	OutputSchema json.RawMessage `json:"output_schema,omitempty"`
@@ -64,6 +72,8 @@ func BuildMCPInfo(endpoint string) (*MCPInfo, error) {
 	if err := json.Unmarshal(data, &meta); err != nil {
 		return nil, fmt.Errorf("parse tools_meta.json: %w", err)
 	}
+	// 这里读的恒是内嵌的那份，不过 locale——和 name/description 一样，是这个端点
+	// 早就有的缺口（见 socket_call_test.go 里那条注释），展示元数据只是跟着它走。
 
 	// 与 tools/list 用同一套按当前档位的判定：装饰过的工具带上付费参数、
 	// 未授权的企业工具不出现。两处若不一致，这个端点就比不存在更糟——它的
@@ -85,6 +95,10 @@ func BuildMCPInfo(endpoint string) (*MCPInfo, error) {
 		}
 		all = append(all, entry{key, MCPToolInfo{
 			Name:         m.Name,
+			Title:        m.Title,
+			Group:        m.Group,
+			GroupTitle:   m.GroupTitle,
+			Order:        m.Order,
 			Description:  m.Description,
 			InputSchema:  in,
 			OutputSchema: out,
@@ -97,6 +111,10 @@ func BuildMCPInfo(endpoint string) (*MCPInfo, error) {
 		}
 		all = append(all, entry{t.Key, MCPToolInfo{
 			Name:        t.Name,
+			Title:       t.Title,
+			Group:       t.Group,
+			GroupTitle:  t.GroupTitle,
+			Order:       t.Order,
 			Description: t.Desc,
 			// 与 tools/list 同样施加（assemble.go 的 addExtras）：企业工具按本服务
 			// 自己的定义就是业务工具，生命周期守卫会向它要 bkn_context。这个端点

--- a/adp/context-loader/agent-retrieval/server/driveradapters/mcp/lifecycle_adapter.go
+++ b/adp/context-loader/agent-retrieval/server/driveradapters/mcp/lifecycle_adapter.go
@@ -136,11 +136,19 @@ func hashBytes(raw []byte) string {
 	return "sha256:" + hex.EncodeToString(sum[:])
 }
 
-func registerLifecycleTools(mcpServer *server.MCPServer, client *bkntrace.LifecycleClient) {
+// registerLifecycleTools hangs the tracing lifecycle tools straight off the
+// server rather than putting them through toolBuilder, but it takes the same
+// locale bundle: a client sees one catalogue, and half of it arriving in
+// another language is the kind of defect only a non-default deployment shows.
+func registerLifecycleTools(
+	mcpServer *server.MCPServer,
+	client *bkntrace.LifecycleClient,
+	locale *mcpLocaleBundle,
+) {
 	for name := range lifecycleToolNames {
-		input, output := loadToolSchemas(name)
+		input, output := locale.ToolSchemas(name)
 		mcpServer.AddTool(
-			newToolWithSchemas(loadToolMeta(name), input, output),
+			newToolWithSchemas(locale.ToolMeta(name), input, output),
 			handleLifecycleTool(client, name),
 		)
 	}

--- a/adp/context-loader/agent-retrieval/server/driveradapters/mcp/lifecycle_adapter.go
+++ b/adp/context-loader/agent-retrieval/server/driveradapters/mcp/lifecycle_adapter.go
@@ -139,9 +139,8 @@ func hashBytes(raw []byte) string {
 func registerLifecycleTools(mcpServer *server.MCPServer, client *bkntrace.LifecycleClient) {
 	for name := range lifecycleToolNames {
 		input, output := loadToolSchemas(name)
-		title, description := loadToolMeta(name)
 		mcpServer.AddTool(
-			newToolWithSchemas(title, description, input, output),
+			newToolWithSchemas(loadToolMeta(name), input, output),
 			handleLifecycleTool(client, name),
 		)
 	}

--- a/adp/context-loader/agent-retrieval/server/driveradapters/mcp/locale.go
+++ b/adp/context-loader/agent-retrieval/server/driveradapters/mcp/locale.go
@@ -118,7 +118,18 @@ func (b *mcpLocaleBundle) ToolMeta(toolKey string) ToolMeta {
 
 func (b *mcpLocaleBundle) ToolSchemas(toolKey string) (input, output json.RawMessage) {
 	input, output = loadToolSchemas(toolKey)
-	if b.schemaDescriptions == nil {
+	return b.OverlaySchemas(toolKey, input, output)
+}
+
+// OverlaySchemas applies the locale's description overlay to schemas the caller
+// already has. Split out of ToolSchemas for /mcp/info, which loads its schemas
+// its own way (nil instead of a panic when a file is missing) but has to end up
+// with the same text tools/list serves.
+func (b *mcpLocaleBundle) OverlaySchemas(
+	toolKey string,
+	input, output json.RawMessage,
+) (json.RawMessage, json.RawMessage) {
+	if b == nil || b.schemaDescriptions == nil {
 		return input, output
 	}
 	replacements := b.schemaDescriptions[toolKey]

--- a/adp/context-loader/agent-retrieval/server/driveradapters/mcp/locale.go
+++ b/adp/context-loader/agent-retrieval/server/driveradapters/mcp/locale.go
@@ -11,6 +11,7 @@ import (
 	"fmt"
 	"os"
 	"strings"
+	"sync"
 )
 
 const defaultMCPLocale = "zh-CN"
@@ -22,8 +23,24 @@ type mcpLocaleBundle struct {
 	schemaDescriptions map[string]map[string]string
 }
 
+// localeBundles memoises the parsed bundles.
+//
+// /mcp/info builds one per request, and each build re-reads and re-decodes
+// three embedded files. A bundle is immutable once constructed and the set of
+// locales is closed, so caching them is free of the usual staleness risk.
+var localeBundles sync.Map // normalised locale -> *mcpLocaleBundle
+
 func loadMCPLocaleBundle(locale string) *mcpLocaleBundle {
 	normalized := normalizeMCPLocale(locale)
+	if cached, ok := localeBundles.Load(normalized); ok {
+		return cached.(*mcpLocaleBundle)
+	}
+	bundle := buildMCPLocaleBundle(normalized)
+	localeBundles.Store(normalized, bundle)
+	return bundle
+}
+
+func buildMCPLocaleBundle(normalized string) *mcpLocaleBundle {
 	bundle := &mcpLocaleBundle{
 		locale:       normalized,
 		instructions: serverInstructions,
@@ -86,6 +103,13 @@ func (b *mcpLocaleBundle) ServerInstructions() string {
 // to the base file — a translator who adds a title but no group must not drop
 // the tool out of its group, and Order is a layout decision that has no reason
 // to differ between languages at all.
+//
+// Name is deliberately not overlayable. It is the identifier a tools/call
+// carries, and a locale file that renamed it would give the same tool two
+// different names depending on the deployment's language — every client
+// integration written against one would break on the other. Before Title
+// existed a locale file could set it, which was the only way to localise how a
+// tool reads; now that Title is where display names live, that door closes.
 func (b *mcpLocaleBundle) ToolMeta(toolKey string) ToolMeta {
 	meta := loadToolMeta(toolKey)
 	if b.toolMeta == nil {
@@ -94,9 +118,6 @@ func (b *mcpLocaleBundle) ToolMeta(toolKey string) ToolMeta {
 	localized, ok := b.toolMeta[toolKey]
 	if !ok {
 		return meta
-	}
-	if localized.Name != "" {
-		meta.Name = localized.Name
 	}
 	if localized.Title != "" {
 		meta.Title = localized.Title

--- a/adp/context-loader/agent-retrieval/server/driveradapters/mcp/locale.go
+++ b/adp/context-loader/agent-retrieval/server/driveradapters/mcp/locale.go
@@ -79,13 +79,41 @@ func (b *mcpLocaleBundle) ServerInstructions() string {
 	return b.instructions
 }
 
-func (b *mcpLocaleBundle) ToolMeta(toolKey string) (name, description string) {
-	if b.toolMeta != nil {
-		if meta, ok := b.toolMeta[toolKey]; ok {
-			return meta.Name, meta.Description
-		}
+// ToolMeta returns the tool's metadata for the bundle's locale.
+//
+// A locale file translates; it does not re-model. So the localized entry
+// overlays only the fields it actually carries and everything else falls back
+// to the base file — a translator who adds a title but no group must not drop
+// the tool out of its group, and Order is a layout decision that has no reason
+// to differ between languages at all.
+func (b *mcpLocaleBundle) ToolMeta(toolKey string) ToolMeta {
+	meta := loadToolMeta(toolKey)
+	if b.toolMeta == nil {
+		return meta
 	}
-	return loadToolMeta(toolKey)
+	localized, ok := b.toolMeta[toolKey]
+	if !ok {
+		return meta
+	}
+	if localized.Name != "" {
+		meta.Name = localized.Name
+	}
+	if localized.Title != "" {
+		meta.Title = localized.Title
+	}
+	if localized.Group != "" {
+		meta.Group = localized.Group
+	}
+	if localized.GroupTitle != "" {
+		meta.GroupTitle = localized.GroupTitle
+	}
+	if localized.Order != 0 {
+		meta.Order = localized.Order
+	}
+	if localized.Description != "" {
+		meta.Description = localized.Description
+	}
+	return meta
 }
 
 func (b *mcpLocaleBundle) ToolSchemas(toolKey string) (input, output json.RawMessage) {

--- a/adp/context-loader/agent-retrieval/server/driveradapters/mcp/locale_test.go
+++ b/adp/context-loader/agent-retrieval/server/driveradapters/mcp/locale_test.go
@@ -14,9 +14,15 @@ func TestMCPLocaleBundle(t *testing.T) {
 
 		convey.So(bundle.ServerInstructions(), convey.ShouldContainSubstring, "Context Loader knowledge network tools")
 
-		name, description := bundle.ToolMeta(toolKeySearchSchema)
-		convey.So(name, convey.ShouldEqual, "search_schema")
-		convey.So(description, convey.ShouldContainSubstring, "Explore schema")
+		meta := bundle.ToolMeta(toolKeySearchSchema)
+		convey.So(meta.Name, convey.ShouldEqual, "search_schema")
+		convey.So(meta.Description, convey.ShouldContainSubstring, "Explore schema")
+		convey.So(meta.Title, convey.ShouldEqual, "Explore Schema")
+		convey.So(meta.GroupTitle, convey.ShouldEqual, "Networks & Schema")
+		// group / order 只在基准文件里声明，本地化文件不重复一遍——翻译改不动
+		// 分组归属和排序。
+		convey.So(meta.Group, convey.ShouldEqual, "discovery")
+		convey.So(meta.Order, convey.ShouldEqual, 130)
 
 		input, _ := bundle.ToolSchemas(toolKeySearchSchema)
 		var schema map[string]any
@@ -30,8 +36,7 @@ func TestMCPLocaleBundle(t *testing.T) {
 		bundle := loadMCPLocaleBundle("fr-FR")
 
 		convey.So(bundle.ServerInstructions(), convey.ShouldEqual, serverInstructions)
-		name, _ := bundle.ToolMeta(toolKeyRunSQL)
-		convey.So(name, convey.ShouldEqual, toolKeyRunSQL)
+		convey.So(bundle.ToolMeta(toolKeyRunSQL).Name, convey.ShouldEqual, toolKeyRunSQL)
 	})
 
 	convey.Convey("localized schema description overlays should match existing schema paths", t, func() {

--- a/adp/context-loader/agent-retrieval/server/driveradapters/mcp/schemas.go
+++ b/adp/context-loader/agent-retrieval/server/driveradapters/mcp/schemas.go
@@ -10,6 +10,7 @@ import (
 	"embed"
 	"encoding/json"
 	"fmt"
+	"sync"
 )
 
 //go:embed schemas/*.json schemas/locales/*/*.json schemas/locales/*/*.txt
@@ -43,8 +44,13 @@ func loadToolMeta(toolKey string) ToolMeta {
 	return t
 }
 
-// allToolMeta decodes the embedded tools_meta.json.
-func allToolMeta() map[string]ToolMeta {
+// allToolMeta returns the decoded tools_meta.json.
+//
+// Decoded once: the file is embedded and immutable, while /mcp/info resolves
+// every tool's metadata on every request — without this, one request re-parses
+// the whole file once per tool. The returned map is shared, so callers must
+// treat it as read-only.
+var allToolMeta = sync.OnceValue(func() map[string]ToolMeta {
 	data, err := schemasFS.ReadFile("schemas/tools_meta.json")
 	if err != nil {
 		panic("cannot read tools_meta.json: " + err.Error())
@@ -54,7 +60,7 @@ func allToolMeta() map[string]ToolMeta {
 		panic("invalid tools_meta.json: " + err.Error())
 	}
 	return meta
-}
+})
 
 // toolSchemaFile defines the structure of a merged tool schema JSON file.
 type toolSchemaFile struct {

--- a/adp/context-loader/agent-retrieval/server/driveradapters/mcp/schemas.go
+++ b/adp/context-loader/agent-retrieval/server/driveradapters/mcp/schemas.go
@@ -15,14 +15,36 @@ import (
 //go:embed schemas/*.json schemas/locales/*/*.json schemas/locales/*/*.txt
 var schemasFS embed.FS
 
-// ToolMeta defines tool metadata (name, description).
+// ToolMeta defines tool metadata: the wire identity (name, description) plus
+// the presentation hints a UI needs to render a catalogue — a display name, a
+// group, and a position within it.
+//
+// Name is what a call carries and never changes for cosmetic reasons; Title is
+// free to. The two are separate fields in the MCP protocol itself since the
+// 2025-06-18 revision, and that is where Title is published. Group/GroupTitle/
+// Order have no protocol field, so they travel in the tool's `_meta` under an
+// openbkn.ai/ prefix — a client that does not know them ignores them, which is
+// what `_meta` is for.
 type ToolMeta struct {
 	Name        string `json:"name"`
-	Description string `json:"description"`
+	Title       string `json:"title,omitempty"`
+	Group       string `json:"group,omitempty"`
+	GroupTitle  string `json:"group_title,omitempty"`
+	Order       int    `json:"order,omitempty"`
+	Description string `json:"description,omitempty"`
 }
 
-// loadToolMeta loads tool metadata (name, description) from schemas/tools_meta.json.
-func loadToolMeta(toolKey string) (name, description string) {
+// loadToolMeta loads a tool's metadata from schemas/tools_meta.json.
+func loadToolMeta(toolKey string) ToolMeta {
+	t, ok := allToolMeta()[toolKey]
+	if !ok {
+		panic("tool meta not found: " + toolKey)
+	}
+	return t
+}
+
+// allToolMeta decodes the embedded tools_meta.json.
+func allToolMeta() map[string]ToolMeta {
 	data, err := schemasFS.ReadFile("schemas/tools_meta.json")
 	if err != nil {
 		panic("cannot read tools_meta.json: " + err.Error())
@@ -31,11 +53,7 @@ func loadToolMeta(toolKey string) (name, description string) {
 	if err := json.Unmarshal(data, &meta); err != nil {
 		panic("invalid tools_meta.json: " + err.Error())
 	}
-	t, ok := meta[toolKey]
-	if !ok {
-		panic("tool meta not found: " + toolKey)
-	}
-	return t.Name, t.Description
+	return meta
 }
 
 // toolSchemaFile defines the structure of a merged tool schema JSON file.

--- a/adp/context-loader/agent-retrieval/server/driveradapters/mcp/schemas/locales/en-US/tools_meta.json
+++ b/adp/context-loader/agent-retrieval/server/driveradapters/mcp/schemas/locales/en-US/tools_meta.json
@@ -1,136 +1,113 @@
 {
   "bkn_finish_interaction": {
-    "name": "bkn_finish_interaction",
     "title": "Finish Interaction",
     "group_title": "Session Lifecycle"
   },
   "bkn_start_interaction": {
-    "name": "bkn_start_interaction",
     "title": "Start Interaction",
     "group_title": "Session Lifecycle"
   },
   "search_schema": {
-    "name": "search_schema",
     "title": "Explore Schema",
     "group_title": "Networks & Schema",
     "description": "Explore schema by natural language. Returns relevant object types, relation types, action types, metric types, condition operations, and data source metadata for downstream query tools. Object types come first: metric_types here is only a hint — the authoritative list of a metric for an object type is related_metrics from get_object_types."
   },
   "query_object_instance": {
-    "name": "query_object_instance",
     "title": "Query Instances",
     "group_title": "Instance Queries",
     "description": "Query instances of one known object type with filters, sorting, selected properties, and cursor-style pagination. Use this for row-level object retrieval, not joins or aggregation."
   },
   "query_instance_subgraph": {
-    "name": "query_instance_subgraph",
     "title": "Query Subgraph",
     "group_title": "Instance Queries",
     "description": "Fetch instance subgraphs by following relation paths across object types. Use this when the question needs related objects around one or more seed instances."
   },
   "get_logic_properties_values": {
-    "name": "get_logic_properties_values",
     "title": "Compute Logic Properties",
     "group_title": "Instance Queries",
     "description": "Resolve calculated logic properties, such as metrics or operator-backed properties, for a batch of object instances. This is the instance-level branch of the metric path (a metric already bound to a logic property); class-level metrics and metrics not bound to a logic property go to query_metric."
   },
   "query_metric": {
-    "name": "query_metric",
     "title": "Query Metrics",
     "group_title": "Instance Queries",
     "description": "Compute a modelled metric by its own definition (step 3 of the OT-first metric path). Recall the object type with search_schema / get_kn_detail, pick a metric_id from get_object_types' related_metrics, then call this tool — the formula lives in the MetricDefinition, so do not re-derive it with run_sql. Routing: instance-level values of a bound logic property go through get_logic_properties_values; class-level metrics, and metrics not bound to any logic property, come here. Optional condition filter, analysis_dimensions breakdown, and a time block for a single point or a series. Time window: omitting instant means a trend query, which requires step; start and end must both be set or both omitted."
   },
   "get_action_info": {
-    "name": "get_action_info",
     "title": "Action Info",
     "group_title": "Actions",
     "description": "Return executable action definitions for object instances, including dynamic tool schemas that an agent can call."
   },
   "execute_action": {
-    "name": "execute_action",
     "title": "Execute Action",
     "group_title": "Actions",
     "description": "Execute an action. First call get_action_info to obtain the action's dynamic_params schema, then fill in the real dynamic parameter values to trigger execution (asynchronous, returns an execution_id). Duplicate submissions for the same kn + action type + instance set + dynamic_params within the duplicate window return HTTP 409; do not retry—use get_action_execution to poll the existing execution instead."
   },
   "get_action_execution": {
-    "name": "get_action_execution",
     "title": "Action Result",
     "group_title": "Actions",
     "description": "Query the status and results of a single action execution. Use the execution_id returned by execute_action to fetch the overall status and per-object results."
   },
   "list_action_executions": {
-    "name": "list_action_executions",
     "title": "Action History",
     "group_title": "Actions",
     "description": "List action execution history, filterable by action type, status, and trigger type, with pagination."
   },
   "find_skills": {
-    "name": "find_skills",
     "title": "Find Skills",
     "group_title": "Resources & Skills",
     "description": "Find available skills that match a knowledge network, object type, instance context, or user intent."
   },
   "list_knowledge_networks": {
-    "name": "list_knowledge_networks",
     "title": "Knowledge Networks",
     "group_title": "Networks & Schema",
     "description": "List knowledge networks visible to the current account. Call this first to obtain kn_id for other tools."
   },
   "get_kn_detail": {
-    "name": "get_kn_detail",
     "title": "Network Structure",
     "group_title": "Networks & Schema",
     "description": "Get full knowledge network details, including concept groups, object types, relation types, and action types. Use this when a known kn_id needs a complete schema snapshot. Object type entries carry related_metric_count, the number of metrics modelled on that object type, so you can tell whether drilling in for metrics is worth it."
   },
   "get_object_types": {
-    "name": "get_object_types",
     "title": "Object Type Detail",
     "group_title": "Networks & Schema",
     "description": "Fetch full object type definitions by id (data_properties carry mapped_field/condition_operations, logic_properties carry data_source/parameters). For progressive drill-down: call get_kn_detail (summary) for the object ids first, then expand only the ones you need. ids takes several at once; ids that match nothing come back under missing."
   },
   "get_relation_types": {
-    "name": "get_relation_types",
     "title": "Relation Type Detail",
     "group_title": "Networks & Schema",
     "description": "Fetch full relation type definitions by id (including mapping_rules and the source/target object names). For progressive drill-down: call get_kn_detail (summary) for the relation ids first, then expand them here. ids takes several at once; ids that match nothing come back under missing."
   },
   "run_sql": {
-    "name": "run_sql",
     "title": "Run SQL",
     "group_title": "Instance Queries",
     "description": "Run one read-only SELECT statement in Trino SQL against data resources mounted by a knowledge network. Use table placeholders such as {{.resource_id}} and physical column names. JOIN, WHERE, GROUP BY/HAVING, ORDER BY, LIMIT, and common aggregates are supported within one catalog. WITH/CTE, UNION/INTERSECT/EXCEPT, multiple statements, writes/DDL, and cross-catalog joins are unsupported; subqueries and window functions are not part of the compatibility contract. Do not re-derive a modelled metric in SQL: pick it from get_object_types' related_metrics and call query_metric (or get_logic_properties_values for a bound logic property). run_sql is for ad-hoc aggregation that has not been modelled as a metric."
   },
   "list_resources": {
-    "name": "list_resources",
     "title": "Data Resources",
     "group_title": "Resources & Skills",
     "description": "List visible data-layer resources independent of ontology object types. Use this when resources are not modeled as object types or when querying raw data directly."
   },
   "describe_resource": {
-    "name": "describe_resource",
     "title": "Resource Detail",
     "group_title": "Resources & Skills",
     "description": "Describe one data resource's physical schema, including connector type and columns. Use this before writing run_sql against raw resources."
   },
   "list_skills": {
-    "name": "list_skills",
     "title": "Skill List",
     "group_title": "Resources & Skills",
     "description": "Browse published skills without a knowledge-network context. Complements find_skills, which recalls by object type or instance: this one pages a list filtered by name or category. Take the skill_id to get_skill_content for SKILL.md, read_skill_file for bundled files, execute_skill to run the entry command."
   },
   "get_skill_content": {
-    "name": "get_skill_content",
     "title": "Skill Content",
     "group_title": "Resources & Skills",
     "description": "Read a skill's SKILL.md body and the file listing of its bundle (files[].rel_path). Usage and entry commands are documented there; fetch individual bundled files with read_skill_file instead of reading the whole package."
   },
   "read_skill_file": {
-    "name": "read_skill_file",
     "title": "Read Skill File",
     "group_title": "Resources & Skills",
     "description": "Read one file from a skill bundle; rel_path comes from the files listing returned by get_skill_content. For progressive loading — large files need not stay in context. Binary files return metadata only, no body."
   },
   "execute_skill": {
-    "name": "execute_skill",
     "title": "Execute Skill",
     "group_title": "Resources & Skills",
     "description": "Run a skill's entry command inside the sandbox and return exit_code / stdout / stderr. entry_shell must come from the entry declared in SKILL.md — read it with get_skill_content first."

--- a/adp/context-loader/agent-retrieval/server/driveradapters/mcp/schemas/locales/en-US/tools_meta.json
+++ b/adp/context-loader/agent-retrieval/server/driveradapters/mcp/schemas/locales/en-US/tools_meta.json
@@ -1,78 +1,138 @@
 {
+  "bkn_finish_interaction": {
+    "name": "bkn_finish_interaction",
+    "title": "Finish Interaction",
+    "group_title": "Session Lifecycle"
+  },
+  "bkn_start_interaction": {
+    "name": "bkn_start_interaction",
+    "title": "Start Interaction",
+    "group_title": "Session Lifecycle"
+  },
   "search_schema": {
     "name": "search_schema",
+    "title": "Explore Schema",
+    "group_title": "Networks & Schema",
     "description": "Explore schema by natural language. Returns relevant object types, relation types, action types, metric types, condition operations, and data source metadata for downstream query tools. Object types come first: metric_types here is only a hint — the authoritative list of a metric for an object type is related_metrics from get_object_types."
   },
   "query_object_instance": {
     "name": "query_object_instance",
+    "title": "Query Instances",
+    "group_title": "Instance Queries",
     "description": "Query instances of one known object type with filters, sorting, selected properties, and cursor-style pagination. Use this for row-level object retrieval, not joins or aggregation."
   },
   "query_instance_subgraph": {
     "name": "query_instance_subgraph",
+    "title": "Query Subgraph",
+    "group_title": "Instance Queries",
     "description": "Fetch instance subgraphs by following relation paths across object types. Use this when the question needs related objects around one or more seed instances."
   },
   "get_logic_properties_values": {
     "name": "get_logic_properties_values",
+    "title": "Compute Logic Properties",
+    "group_title": "Instance Queries",
     "description": "Resolve calculated logic properties, such as metrics or operator-backed properties, for a batch of object instances. This is the instance-level branch of the metric path (a metric already bound to a logic property); class-level metrics and metrics not bound to a logic property go to query_metric."
   },
   "query_metric": {
     "name": "query_metric",
+    "title": "Query Metrics",
+    "group_title": "Instance Queries",
     "description": "Compute a modelled metric by its own definition (step 3 of the OT-first metric path). Recall the object type with search_schema / get_kn_detail, pick a metric_id from get_object_types' related_metrics, then call this tool — the formula lives in the MetricDefinition, so do not re-derive it with run_sql. Routing: instance-level values of a bound logic property go through get_logic_properties_values; class-level metrics, and metrics not bound to any logic property, come here. Optional condition filter, analysis_dimensions breakdown, and a time block for a single point or a series. Time window: omitting instant means a trend query, which requires step; start and end must both be set or both omitted."
   },
   "get_action_info": {
     "name": "get_action_info",
+    "title": "Action Info",
+    "group_title": "Actions",
     "description": "Return executable action definitions for object instances, including dynamic tool schemas that an agent can call."
   },
   "execute_action": {
     "name": "execute_action",
+    "title": "Execute Action",
+    "group_title": "Actions",
     "description": "Execute an action. First call get_action_info to obtain the action's dynamic_params schema, then fill in the real dynamic parameter values to trigger execution (asynchronous, returns an execution_id). Duplicate submissions for the same kn + action type + instance set + dynamic_params within the duplicate window return HTTP 409; do not retry—use get_action_execution to poll the existing execution instead."
   },
   "get_action_execution": {
     "name": "get_action_execution",
+    "title": "Action Result",
+    "group_title": "Actions",
     "description": "Query the status and results of a single action execution. Use the execution_id returned by execute_action to fetch the overall status and per-object results."
   },
   "list_action_executions": {
     "name": "list_action_executions",
+    "title": "Action History",
+    "group_title": "Actions",
     "description": "List action execution history, filterable by action type, status, and trigger type, with pagination."
   },
   "find_skills": {
     "name": "find_skills",
+    "title": "Find Skills",
+    "group_title": "Resources & Skills",
     "description": "Find available skills that match a knowledge network, object type, instance context, or user intent."
   },
   "list_knowledge_networks": {
     "name": "list_knowledge_networks",
+    "title": "Knowledge Networks",
+    "group_title": "Networks & Schema",
     "description": "List knowledge networks visible to the current account. Call this first to obtain kn_id for other tools."
   },
   "get_kn_detail": {
     "name": "get_kn_detail",
+    "title": "Network Structure",
+    "group_title": "Networks & Schema",
     "description": "Get full knowledge network details, including concept groups, object types, relation types, and action types. Use this when a known kn_id needs a complete schema snapshot. Object type entries carry related_metric_count, the number of metrics modelled on that object type, so you can tell whether drilling in for metrics is worth it."
+  },
+  "get_object_types": {
+    "name": "get_object_types",
+    "title": "Object Type Detail",
+    "group_title": "Networks & Schema",
+    "description": "Fetch full object type definitions by id (data_properties carry mapped_field/condition_operations, logic_properties carry data_source/parameters). For progressive drill-down: call get_kn_detail (summary) for the object ids first, then expand only the ones you need. ids takes several at once; ids that match nothing come back under missing."
+  },
+  "get_relation_types": {
+    "name": "get_relation_types",
+    "title": "Relation Type Detail",
+    "group_title": "Networks & Schema",
+    "description": "Fetch full relation type definitions by id (including mapping_rules and the source/target object names). For progressive drill-down: call get_kn_detail (summary) for the relation ids first, then expand them here. ids takes several at once; ids that match nothing come back under missing."
   },
   "run_sql": {
     "name": "run_sql",
+    "title": "Run SQL",
+    "group_title": "Instance Queries",
     "description": "Run one read-only SELECT statement in Trino SQL against data resources mounted by a knowledge network. Use table placeholders such as {{.resource_id}} and physical column names. JOIN, WHERE, GROUP BY/HAVING, ORDER BY, LIMIT, and common aggregates are supported within one catalog. WITH/CTE, UNION/INTERSECT/EXCEPT, multiple statements, writes/DDL, and cross-catalog joins are unsupported; subqueries and window functions are not part of the compatibility contract. Do not re-derive a modelled metric in SQL: pick it from get_object_types' related_metrics and call query_metric (or get_logic_properties_values for a bound logic property). run_sql is for ad-hoc aggregation that has not been modelled as a metric."
   },
   "list_resources": {
     "name": "list_resources",
+    "title": "Data Resources",
+    "group_title": "Resources & Skills",
     "description": "List visible data-layer resources independent of ontology object types. Use this when resources are not modeled as object types or when querying raw data directly."
   },
   "describe_resource": {
     "name": "describe_resource",
+    "title": "Resource Detail",
+    "group_title": "Resources & Skills",
     "description": "Describe one data resource's physical schema, including connector type and columns. Use this before writing run_sql against raw resources."
   },
   "list_skills": {
     "name": "list_skills",
+    "title": "Skill List",
+    "group_title": "Resources & Skills",
     "description": "Browse published skills without a knowledge-network context. Complements find_skills, which recalls by object type or instance: this one pages a list filtered by name or category. Take the skill_id to get_skill_content for SKILL.md, read_skill_file for bundled files, execute_skill to run the entry command."
   },
   "get_skill_content": {
     "name": "get_skill_content",
+    "title": "Skill Content",
+    "group_title": "Resources & Skills",
     "description": "Read a skill's SKILL.md body and the file listing of its bundle (files[].rel_path). Usage and entry commands are documented there; fetch individual bundled files with read_skill_file instead of reading the whole package."
   },
   "read_skill_file": {
     "name": "read_skill_file",
+    "title": "Read Skill File",
+    "group_title": "Resources & Skills",
     "description": "Read one file from a skill bundle; rel_path comes from the files listing returned by get_skill_content. For progressive loading — large files need not stay in context. Binary files return metadata only, no body."
   },
   "execute_skill": {
     "name": "execute_skill",
+    "title": "Execute Skill",
+    "group_title": "Resources & Skills",
     "description": "Run a skill's entry command inside the sandbox and return exit_code / stdout / stderr. entry_shell must come from the entry declared in SKILL.md — read it with get_skill_content first."
   }
 }

--- a/adp/context-loader/agent-retrieval/server/driveradapters/mcp/schemas/tools_meta.json
+++ b/adp/context-loader/agent-retrieval/server/driveradapters/mcp/schemas/tools_meta.json
@@ -1,94 +1,186 @@
 {
   "bkn_finish_interaction": {
     "name": "bkn_finish_interaction",
+    "title": "结束交互",
+    "group": "lifecycle",
+    "group_title": "会话生命周期",
+    "order": 20,
     "description": "Submit the current Interaction result and final answer. This does not close the Conversation."
   },
   "bkn_start_interaction": {
     "name": "bkn_start_interaction",
+    "title": "开始交互",
+    "group": "lifecycle",
+    "group_title": "会话生命周期",
+    "order": 10,
     "description": "Start one managed Interaction. Omit conversation_id on the first turn; reuse the returned conversation_id on later turns."
   },
   "search_schema": {
     "name": "search_schema",
+    "title": "Schema 探索",
+    "group": "discovery",
+    "group_title": "网络与 Schema",
+    "order": 130,
     "description": "统一的 Schema 探索入口，先锁定对象类（object_types）。根据 query 返回相关 object_types、relation_types、action_types、metric_types，供 query_*、find_*、get_* 工具继续消费；其中 metric_types 只是辅助线索，指标的权威清单以 get_object_types 返回的 related_metrics 为准（按对象类 scope 全量枚举）。默认返回精简 Schema（schema_brief=true：保留 data_source.id 与属性 name/type/condition_operations，省约 70%），够规划查询；需要属性备注/主键/标签的完整 Schema 时传 schema_brief=false。"
   },
   "query_object_instance": {
     "name": "query_object_instance",
+    "title": "实例查询",
+    "group": "query",
+    "group_title": "实例查询",
+    "order": 210,
     "description": "单对象类实例过滤查询。已知对象类与过滤条件时，查询实例列表。支持 search_after 游标顺序翻页（用上一页返回的 search_after 取下一页，不支持跳页）。"
   },
   "query_instance_subgraph": {
     "name": "query_instance_subgraph",
+    "title": "子图查询",
+    "group": "query",
+    "group_title": "实例查询",
+    "order": 220,
     "description": "沿关系路径拉取实例子图，支持多跳关系查询。"
   },
   "get_logic_properties_values": {
     "name": "get_logic_properties_values",
+    "title": "逻辑属性计算",
+    "group": "query",
+    "group_title": "实例查询",
+    "order": 230,
     "description": "逻辑属性解析（指标/算子）。针对实例批量计算已绑逻辑属性的值——指标路径里对应「实例级 + 已绑 logic property」这一支；类级指标、或未绑逻辑属性的指标改调 query_metric。"
   },
   "query_metric": {
     "name": "query_metric",
+    "title": "指标查询",
+    "group": "query",
+    "group_title": "实例查询",
+    "order": 250,
     "description": "按已建模指标的口径取数（OT-first 路径第 3 步）。先 search_schema / get_kn_detail 锁定对象类，再 get_object_types 从 related_metrics 里选定 metric_id，最后调本工具计算——口径写在 MetricDefinition 里，别用 run_sql 自己重写。分流：实例级且已绑逻辑属性的走 get_logic_properties_values；类级、或未绑逻辑属性的走本工具。可选 condition 过滤、analysis_dimensions 拆维、time 取单点或序列。时间窗规则：省略 instant 等同于序列查询，必须给 step；start 与 end 要么都给要么都不给。"
   },
   "get_action_info": {
     "name": "get_action_info",
+    "title": "行动信息",
+    "group": "action",
+    "group_title": "行动",
+    "order": 310,
     "description": "行动信息召回。针对对象实例返回可执行行动的工具定义。"
   },
   "execute_action": {
     "name": "execute_action",
+    "title": "执行行动",
+    "group": "action",
+    "group_title": "行动",
+    "order": 320,
     "description": "执行行动。先用 get_action_info 获取行动的 dynamic_params schema，再填入真实动态参数值触发执行（异步，返回 execution_id）。同一 kn + 行动类型 + 实例集合与 dynamic_params 在窗口期内重复提交会返回 409，不要重试，改用 get_action_execution 查询已有 execution。"
   },
   "get_action_execution": {
     "name": "get_action_execution",
+    "title": "执行结果",
+    "group": "action",
+    "group_title": "行动",
+    "order": 330,
     "description": "查询单次行动执行的状态与结果。用 execute_action 返回的 execution_id 查询整体 status 与逐对象 results。"
   },
   "list_action_executions": {
     "name": "list_action_executions",
+    "title": "执行历史",
+    "group": "action",
+    "group_title": "行动",
+    "order": 340,
     "description": "列出行动执行历史，可按行动类型、状态、触发方式过滤并分页。"
   },
   "find_skills": {
     "name": "find_skills",
+    "title": "技能召回",
+    "group": "resource",
+    "group_title": "数据资源与技能",
+    "order": 430,
     "description": "技能召回。根据知识网络、对象类型、实例上下文等召回匹配的可用技能列表。"
   },
   "list_knowledge_networks": {
     "name": "list_knowledge_networks",
+    "title": "知识网络列表",
+    "group": "discovery",
+    "group_title": "网络与 Schema",
+    "order": 110,
     "description": "列出可用的知识网络（返回 kn_id、名称、描述）。其余查询工具均需 kn_id，作为探索的第一步入口。"
   },
   "get_kn_detail": {
     "name": "get_kn_detail",
+    "title": "网络结构",
+    "group": "discovery",
+    "group_title": "网络与 Schema",
+    "order": 120,
     "description": "获取知识网络 schema（概念组、对象类型含 data_source.id、关系类型、行动类型）。默认 detail_level=summary：返回骨架 + 每个属性仅 name+type（不含 display_name/comment/字段映射/查询算子/映射规则）——足够理解结构与规划查询，体积小。需要某对象的完整字段映射（含 comment）时调 get_object_types，需要关系的 mapping_rules 时调 get_relation_types。detail_level=full 一次拿全量（体积大，慎用）。对象类条目附带 related_metric_count（该对象类下已建模指标数），用来判断是否值得下钻取指标。"
   },
   "get_object_types": {
     "name": "get_object_types",
+    "title": "对象类详情",
+    "group": "discovery",
+    "group_title": "网络与 Schema",
+    "order": 140,
     "description": "按 id 批量取对象类的完整定义（data_properties 含 mapped_field/condition_operations，logic_properties 含 data_source/parameters），并返回该对象类下可用的指标 related_metrics（scope_type=object_type 且 scope_ref=对象类 id，含未绑逻辑属性的指标）。渐进式下钻用：先 get_kn_detail（summary）拿对象 id，再用本工具展开需要的对象。选定指标后：实例级且已绑逻辑属性走 get_logic_properties_values，类级或未绑的走 query_metric。ids 支持多个，一次取回；未匹配的 id 会在 missing 返回。"
   },
   "get_relation_types": {
     "name": "get_relation_types",
+    "title": "关系类详情",
+    "group": "discovery",
+    "group_title": "网络与 Schema",
+    "order": 150,
     "description": "按 id 批量取关系类的完整定义（含 mapping_rules、source/target 对象名）。渐进式下钻用：先 get_kn_detail（summary）拿关系 id，再用本工具展开。ids 支持多个，一次取回；未匹配的 id 会在 missing 返回。"
   },
   "run_sql": {
     "name": "run_sql",
+    "title": "SQL 查询",
+    "group": "query",
+    "group_title": "实例查询",
+    "order": 240,
     "description": "对知识网络挂载的数据资源执行只读 SQL（Trino 方言）。注意：已建模指标不要用 SQL 重写口径——指标走 get_object_types 选定后的 query_metric / get_logic_properties_values；run_sql 用于未建成指标的即席聚合与跨表统计。表名用占位符 {{.resource_id}} 引用；vega 会解析成真实表并限量。仅允许单条 SELECT：支持同一 catalog 内的 JOIN、WHERE、GROUP BY/HAVING、ORDER BY、LIMIT 和常用聚合函数；不支持 WITH/CTE、UNION/INTERSECT/EXCEPT、多语句、写入/DDL 和跨目录 join，子查询与窗口函数不在兼容性承诺内。两种拿 resource_id + 物理列的方式：本体路 search_schema（对象类 data_source.id + data_property.column），数据层路 list_resources → describe_resource（直查裸资源，脱离本体）。"
   },
   "list_resources": {
     "name": "list_resources",
+    "title": "数据资源列表",
+    "group": "resource",
+    "group_title": "数据资源与技能",
+    "order": 410,
     "description": "数据层资源直查（脱离本体）：列出当前账户有权查看的数据资源（resource_id、name、type、catalog_id），可按 catalog_id / type 过滤。资源未建成对象类、或想绕本体直查数据时用。配合 describe_resource + run_sql。"
   },
   "describe_resource": {
     "name": "describe_resource",
+    "title": "数据资源详情",
+    "group": "resource",
+    "group_title": "数据资源与技能",
+    "order": 420,
     "description": "取单个数据资源的物理 schema：connector_type 与列（columns:[{name,type}]）。写 run_sql 前用它拿物理列名。入参 resource_id 取自 list_resources。"
   },
   "list_skills": {
     "name": "list_skills",
+    "title": "技能列表",
+    "group": "resource",
+    "group_title": "数据资源与技能",
+    "order": 440,
     "description": "浏览已发布技能（不需要知识网络上下文）。与 find_skills 互补：那条按对象类/实例召回，这条按名称或分类翻列表。拿到 skill_id 后用 get_skill_content 读 SKILL.md，用 read_skill_file 下钻附属文件，用 execute_skill 执行入口命令。"
   },
   "get_skill_content": {
     "name": "get_skill_content",
+    "title": "技能内容",
+    "group": "resource",
+    "group_title": "数据资源与技能",
+    "order": 450,
     "description": "读技能主文档 SKILL.md 正文，并返回技能包内的文件清单（files[].rel_path）。技能的用法与入口命令都写在这里；需要哪个附属文件再用 read_skill_file 单取，不必整包读。"
   },
   "read_skill_file": {
     "name": "read_skill_file",
+    "title": "读技能文件",
+    "group": "resource",
+    "group_title": "数据资源与技能",
+    "order": 460,
     "description": "读技能包内单个文件的正文，rel_path 取自 get_skill_content 返回的 files 清单。渐进式加载用：大文件不必常驻上下文。二进制文件只回元数据不回正文。"
   },
   "execute_skill": {
     "name": "execute_skill",
+    "title": "执行技能",
+    "group": "resource",
+    "group_title": "数据资源与技能",
+    "order": 470,
     "description": "在沙箱内执行技能的入口命令，返回 exit_code / stdout / stderr。entry_shell 必须取自 SKILL.md 声明的入口，先用 get_skill_content 读清楚再调。"
   }
 }

--- a/adp/context-loader/agent-retrieval/server/driveradapters/mcp/tools_display_meta_test.go
+++ b/adp/context-loader/agent-retrieval/server/driveradapters/mcp/tools_display_meta_test.go
@@ -19,6 +19,9 @@ import (
 func TestToolsListCarriesDisplayMetadata(t *testing.T) {
 	noExtensions(t)
 
+	// 按进程当前的 locale 取期望值，而不是恒读中文基准文件：本地开发机上
+	// LANG=en_US 是常态，写死基准文件会让这条断言在那里假红。
+	locale := loadMCPLocaleBundle(mcpLocaleFromEnv())
 	for _, tool := range assembledTools(t) {
 		raw, err := json.Marshal(tool)
 		if err != nil {
@@ -33,22 +36,22 @@ func TestToolsListCarriesDisplayMetadata(t *testing.T) {
 			t.Fatalf("decode tool %q: %v", tool.Name, err)
 		}
 
-		want := loadToolMeta(wire.Name)
+		want := locale.ToolMeta(wire.Name)
 		if wire.Title != want.Title {
-			t.Fatalf("tool %q advertises title %q, tools_meta.json says %q", wire.Name, wire.Title, want.Title)
+			t.Fatalf("tool %q advertises title %q, tool metadata says %q", wire.Name, wire.Title, want.Title)
 		}
 		if wire.Title == "" {
 			t.Fatalf("tool %q has no title — a client would have to keep its own display-name table, which is what this field exists to remove", wire.Name)
 		}
 		if got := wire.Meta[toolMetaKeyGroup]; got != want.Group {
-			t.Fatalf("tool %q advertises group %v, tools_meta.json says %q", wire.Name, got, want.Group)
+			t.Fatalf("tool %q advertises group %v, tool metadata says %q", wire.Name, got, want.Group)
 		}
 		if got := wire.Meta[toolMetaKeyGroupTitle]; got != want.GroupTitle {
-			t.Fatalf("tool %q advertises group_title %v, tools_meta.json says %q", wire.Name, got, want.GroupTitle)
+			t.Fatalf("tool %q advertises group_title %v, tool metadata says %q", wire.Name, got, want.GroupTitle)
 		}
 		// JSON 数字解到 any 上是 float64，比较前先归一。
 		if got, _ := wire.Meta[toolMetaKeyOrder].(float64); int(got) != want.Order {
-			t.Fatalf("tool %q advertises order %v, tools_meta.json says %d", wire.Name, wire.Meta[toolMetaKeyOrder], want.Order)
+			t.Fatalf("tool %q advertises order %v, tool metadata says %d", wire.Name, wire.Meta[toolMetaKeyOrder], want.Order)
 		}
 	}
 }
@@ -86,6 +89,11 @@ func TestLocalizedToolMetaTranslatesWithoutRemodelling(t *testing.T) {
 		t.Fatalf("decode localized tool metadata: %v", err)
 	}
 	base := allToolMeta()
+	for key := range base {
+		if _, ok := meta[key]; !ok {
+			t.Errorf("tool %q has no en-US entry — it would advertise its zh-CN title in an English catalogue", key)
+		}
+	}
 	for key, m := range meta {
 		if _, ok := base[key]; !ok {
 			t.Errorf("localized tool metadata has %q, which tools_meta.json does not", key)
@@ -132,6 +140,36 @@ func TestMCPInfoDisplayMetadataMatchesToolsList(t *testing.T) {
 		if tool.Group != group || tool.GroupTitle != groupTitle || tool.Order != order {
 			t.Fatalf("tool %q: /mcp/info says (%q, %q, %d), tools/list says (%q, %q, %d)",
 				tool.Name, tool.Group, tool.GroupTitle, tool.Order, group, groupTitle, order)
+		}
+	}
+}
+
+// 三条注册路径——toolBuilder、生命周期适配层、企业插座——此前只有第一条过
+// locale，另外两条直接读中文基准文件。缺陷只在非中文部署上现形：一份目录里
+// 14 个英文名配 4 个中文名。这条测试把整个目录按非默认 locale 装配一遍，任何
+// 一条路径漏接都会红。
+func TestEveryRegistrationPathHonoursTheLocale(t *testing.T) {
+	noExtensions(t)
+	t.Setenv("MCP_LOCALE", "en-US")
+
+	raw, err := schemasFS.ReadFile("schemas/locales/en-US/tools_meta.json")
+	if err != nil {
+		t.Fatalf("read localized tool metadata: %v", err)
+	}
+	var localized map[string]ToolMeta
+	if err := json.Unmarshal(raw, &localized); err != nil {
+		t.Fatalf("decode localized tool metadata: %v", err)
+	}
+
+	for _, tool := range assembledTools(t) {
+		want, ok := localized[tool.Name]
+		if !ok {
+			t.Errorf("tool %q has no en-US entry", tool.Name)
+			continue
+		}
+		if tool.Title != want.Title {
+			t.Errorf("tool %q advertises title %q under en-US, the localized file says %q — its registration path does not go through the locale bundle",
+				tool.Name, tool.Title, want.Title)
 		}
 	}
 }

--- a/adp/context-loader/agent-retrieval/server/driveradapters/mcp/tools_display_meta_test.go
+++ b/adp/context-loader/agent-retrieval/server/driveradapters/mcp/tools_display_meta_test.go
@@ -105,6 +105,11 @@ func TestLocalizedToolMetaTranslatesWithoutRemodelling(t *testing.T) {
 		if m.Group != "" || m.Order != 0 {
 			t.Errorf("localized tool %q declares group/order; those belong to tools_meta.json alone", key)
 		}
+		// Name 是 tools/call 携带的标识。本地化文件写了它，同一个工具在中文和
+		// 英文部署上就会有两个名字，照着一边写的客户端在另一边直接调不通。
+		if m.Name != "" {
+			t.Errorf("localized tool %q declares a name; the wire identifier must not depend on the deployment's language", key)
+		}
 	}
 }
 
@@ -170,6 +175,47 @@ func TestEveryRegistrationPathHonoursTheLocale(t *testing.T) {
 		if tool.Title != want.Title {
 			t.Errorf("tool %q advertises title %q under en-US, the localized file says %q — its registration path does not go through the locale bundle",
 				tool.Name, tool.Title, want.Title)
+		}
+	}
+}
+
+// 这条钉的是 /mcp/info 那一侧的 locale 接线，而且必须在非默认 locale 下钉。
+//
+// zh-CN 下本地化覆盖层是空的：OverlaySchemas 原样返回，ToolMeta 也落回基准
+// 文件，于是把 BuildMCPInfo 里的 locale 参数删掉两侧照样相等——默认 locale 的
+// 那条一致性测试永远绿，看不出任何东西。en-US 下两侧才真正走不同的代码路径。
+func TestMCPInfoAgreesWithToolsListUnderANonDefaultLocale(t *testing.T) {
+	noExtensions(t)
+	t.Setenv("MCP_LOCALE", "en-US")
+
+	info, err := BuildMCPInfo("https://example.invalid/mcp")
+	if err != nil {
+		t.Fatalf("BuildMCPInfo: %v", err)
+	}
+	listed := map[string]mcp.Tool{}
+	for _, tool := range assembledTools(t) {
+		listed[tool.Name] = tool
+	}
+	if len(info.Tools) != len(listed) {
+		t.Fatalf("/mcp/info 有 %d 个工具，tools/list 有 %d 个", len(info.Tools), len(listed))
+	}
+
+	for _, tool := range info.Tools {
+		got, ok := listed[tool.Name]
+		if !ok {
+			t.Fatalf("/mcp/info advertises %q, which tools/list does not", tool.Name)
+		}
+		if tool.Description != got.Description {
+			t.Errorf("tool %q description differs between the two endpoints:\n/mcp/info : %s\ntools/list: %s",
+				tool.Name, tool.Description, got.Description)
+		}
+		if string(tool.InputSchema) != string(got.RawInputSchema) {
+			t.Errorf("tool %q input schema differs between the two endpoints:\n/mcp/info : %s\ntools/list: %s",
+				tool.Name, tool.InputSchema, got.RawInputSchema)
+		}
+		if string(tool.OutputSchema) != string(got.RawOutputSchema) {
+			t.Errorf("tool %q output schema differs between the two endpoints:\n/mcp/info : %s\ntools/list: %s",
+				tool.Name, tool.OutputSchema, got.RawOutputSchema)
 		}
 	}
 }

--- a/adp/context-loader/agent-retrieval/server/driveradapters/mcp/tools_display_meta_test.go
+++ b/adp/context-loader/agent-retrieval/server/driveradapters/mcp/tools_display_meta_test.go
@@ -1,0 +1,149 @@
+// Copyright openbkn.ai
+//
+// Licensed under the OpenBKN License. See LICENSE-OPENBKN.txt in the project root.
+
+package mcp
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/mark3labs/mcp-go/mcp"
+)
+
+// 展示元数据的价值全在「客户端不用自己维护一张工具名到中文名的表」。所以每条
+// 断言都对着序列化后的 JSON 走，而不是对着 Go 结构体——结构体填对了但没进
+// wire 的情况，正是这类字段最容易出的问题。
+
+func TestToolsListCarriesDisplayMetadata(t *testing.T) {
+	noExtensions(t)
+
+	for _, tool := range assembledTools(t) {
+		raw, err := json.Marshal(tool)
+		if err != nil {
+			t.Fatalf("marshal tool %q: %v", tool.Name, err)
+		}
+		var wire struct {
+			Name  string         `json:"name"`
+			Title string         `json:"title"`
+			Meta  map[string]any `json:"_meta"`
+		}
+		if err := json.Unmarshal(raw, &wire); err != nil {
+			t.Fatalf("decode tool %q: %v", tool.Name, err)
+		}
+
+		want := loadToolMeta(wire.Name)
+		if wire.Title != want.Title {
+			t.Fatalf("tool %q advertises title %q, tools_meta.json says %q", wire.Name, wire.Title, want.Title)
+		}
+		if wire.Title == "" {
+			t.Fatalf("tool %q has no title — a client would have to keep its own display-name table, which is what this field exists to remove", wire.Name)
+		}
+		if got := wire.Meta[toolMetaKeyGroup]; got != want.Group {
+			t.Fatalf("tool %q advertises group %v, tools_meta.json says %q", wire.Name, got, want.Group)
+		}
+		if got := wire.Meta[toolMetaKeyGroupTitle]; got != want.GroupTitle {
+			t.Fatalf("tool %q advertises group_title %v, tools_meta.json says %q", wire.Name, got, want.GroupTitle)
+		}
+		// JSON 数字解到 any 上是 float64，比较前先归一。
+		if got, _ := wire.Meta[toolMetaKeyOrder].(float64); int(got) != want.Order {
+			t.Fatalf("tool %q advertises order %v, tools_meta.json says %d", wire.Name, wire.Meta[toolMetaKeyOrder], want.Order)
+		}
+	}
+}
+
+// 每个核心工具都得声明齐这四项，且 order 互不重复——重复的 order 会让两个工具
+// 在前端之间换位置，跟没有排序一样。
+func TestEveryCoreToolDeclaresDisplayMetadata(t *testing.T) {
+	seenOrder := map[int]string{}
+	for key, meta := range allToolMeta() {
+		if meta.Title == "" {
+			t.Errorf("tool %q has no title in tools_meta.json", key)
+		}
+		if meta.Group == "" || meta.GroupTitle == "" {
+			t.Errorf("tool %q has no group in tools_meta.json", key)
+		}
+		if meta.Order == 0 {
+			t.Errorf("tool %q has no order in tools_meta.json (0 means \"unset\" on the wire, so it is not a usable position)", key)
+		}
+		if prev, dup := seenOrder[meta.Order]; dup {
+			t.Errorf("tools %q and %q share order %d — they would swap places between renders", prev, key, meta.Order)
+		}
+		seenOrder[meta.Order] = key
+	}
+}
+
+// 本地化文件只翻译，不重新建模：它可以给 title/group_title，但不该自带 group
+// 或 order——那两项一旦分语言就意味着中英文两套目录结构。
+func TestLocalizedToolMetaTranslatesWithoutRemodelling(t *testing.T) {
+	raw, err := schemasFS.ReadFile("schemas/locales/en-US/tools_meta.json")
+	if err != nil {
+		t.Fatalf("read localized tool metadata: %v", err)
+	}
+	var meta map[string]ToolMeta
+	if err := json.Unmarshal(raw, &meta); err != nil {
+		t.Fatalf("decode localized tool metadata: %v", err)
+	}
+	base := allToolMeta()
+	for key, m := range meta {
+		if _, ok := base[key]; !ok {
+			t.Errorf("localized tool metadata has %q, which tools_meta.json does not", key)
+			continue
+		}
+		if m.Title == "" {
+			t.Errorf("localized tool %q has no title — it would fall back to the zh-CN one", key)
+		}
+		if m.Group != "" || m.Order != 0 {
+			t.Errorf("localized tool %q declares group/order; those belong to tools_meta.json alone", key)
+		}
+	}
+}
+
+// /mcp/info 的用途是「不握手就看清能力面」，展示元数据两边说法不一致，前端按
+// 哪一份渲染就成了掷硬币。
+func TestMCPInfoDisplayMetadataMatchesToolsList(t *testing.T) {
+	noExtensions(t)
+
+	info, err := BuildMCPInfo("https://example.invalid/mcp")
+	if err != nil {
+		t.Fatalf("BuildMCPInfo: %v", err)
+	}
+	listed := map[string]mcp.Tool{}
+	for _, tool := range assembledTools(t) {
+		listed[tool.Name] = tool
+	}
+
+	for _, tool := range info.Tools {
+		got, ok := listed[tool.Name]
+		if !ok {
+			t.Fatalf("/mcp/info advertises %q, which tools/list does not", tool.Name)
+		}
+		if tool.Title != got.Title {
+			t.Fatalf("tool %q: /mcp/info title %q, tools/list title %q", tool.Name, tool.Title, got.Title)
+		}
+		var group, groupTitle string
+		var order int
+		if got.Meta != nil {
+			group, _ = got.Meta.AdditionalFields[toolMetaKeyGroup].(string)
+			groupTitle, _ = got.Meta.AdditionalFields[toolMetaKeyGroupTitle].(string)
+			order, _ = got.Meta.AdditionalFields[toolMetaKeyOrder].(int)
+		}
+		if tool.Group != group || tool.GroupTitle != groupTitle || tool.Order != order {
+			t.Fatalf("tool %q: /mcp/info says (%q, %q, %d), tools/list says (%q, %q, %d)",
+				tool.Name, tool.Group, tool.GroupTitle, tool.Order, group, groupTitle, order)
+		}
+	}
+}
+
+// assembledTools returns the tools a client would see from tools/list.
+func assembledTools(t *testing.T) []mcp.Tool {
+	t.Helper()
+	srv, b := newMCPServer(nil)
+
+	all := make([]mcp.Tool, 0, len(srv.ListTools()))
+	for _, st := range srv.ListTools() {
+		all = append(all, st.Tool)
+	}
+	return b.filter(context.Background(), all)
+}

--- a/adp/context-loader/agent-retrieval/server/driveradapters/mcp/tools_skills_test.go
+++ b/adp/context-loader/agent-retrieval/server/driveradapters/mcp/tools_skills_test.go
@@ -55,8 +55,9 @@ func TestExecuteSkillOnlyAppearsWhenEnabled(t *testing.T) {
 func TestSkillToolsAdvertiseSchemas(t *testing.T) {
 	noExtensions(t)
 
+	locale := loadMCPLocaleBundle(mcpLocaleFromEnv())
 	for _, key := range []string{toolKeyListSkills, toolKeyGetSkillContent, toolKeyReadSkillFile, toolKeyExecuteSkill} {
-		in, out := tryLoadToolSchemas(key)
+		in, out := tryLoadToolSchemas(locale, key)
 		if len(in) == 0 {
 			t.Fatalf("%s 缺 input_schema", key)
 		}

--- a/adp/context-loader/agent-retrieval/server/extension/mcptool/mcptool.go
+++ b/adp/context-loader/agent-retrieval/server/extension/mcptool/mcptool.go
@@ -79,6 +79,19 @@ type ExtraTool struct {
 	Name, Desc    string
 	Input, Output json.RawMessage
 	Handle        Handler
+
+	// Presentation hints, all optional. Title is a UI-friendly display name
+	// (MCP's own `title` field); Group/GroupTitle/Order let the tool sit in a
+	// catalogue next to core's, and travel in the tool's `_meta`.
+	//
+	// Optional because a tool is usable without them and core will not invent
+	// them: left unset the tool is advertised with its Name and no group, which
+	// is how every tool looked before these existed. Group is a stable
+	// identifier a client may branch on; GroupTitle is the label it renders.
+	Title      string
+	Group      string
+	GroupTitle string
+	Order      int
 }
 
 // Decorator adds to a tool core already serves.

--- a/docs/api/context-loader/mcp.yaml
+++ b/docs/api/context-loader/mcp.yaml
@@ -90,6 +90,18 @@ paths:
 
         同一路径也接受协议规定的其他方法（如用于服务端推送的 `GET`、用于结束会话的
         `DELETE`），具体以 MCP 规范为准。
+
+        `tools/list` 的每个工具除协议必备字段外，还带一组展示元数据，供客户端直接
+        渲染工具目录，不必自行维护工具名到中文名的映射表：
+
+        - `title`：展示名，MCP 协议自身的字段（2025-06-18 起）。缺失时回退到 `name`。
+        - `_meta["openbkn.ai/group"]`：分组标识，稳定值，可用于分支判断。
+        - `_meta["openbkn.ai/group_title"]`：分组展示名。
+        - `_meta["openbkn.ai/order"]`：目录内位置，升序；未声明的排在末尾。
+
+        `title` 与 `group_title` 随部署的语言设置本地化；`group` 与 `order` 不随语言
+        变化。`_meta` 下这三项不是协议字段，不认识它们的客户端会按协议忽略。
+        `GET /mcp/info` 返回同一份元数据，只是平铺成普通字段。
       requestBody:
         required: true
         content:
@@ -185,7 +197,25 @@ components:
       properties:
         name:
           type: string
-          description: 工具名。
+          description: 工具名，调用时使用的程序标识，不随展示需要变化。
+        title:
+          type: string
+          description: |
+            工具展示名（随部署语言设置本地化）。对应 `tools/list` 里 MCP 协议
+            自身的 `title` 字段；客户端应优先展示它，缺失时回退到 `name`。
+        group:
+          type: string
+          description: |
+            分组标识，稳定值，供客户端分组或分支判断。当前取值：
+            `lifecycle` / `discovery` / `query` / `action` / `resource`。
+            扩展工具未声明时不返回。
+        group_title:
+          type: string
+          description: 分组展示名（随部署语言设置本地化）。
+        order:
+          type: integer
+          description: |
+            目录内的排列位置，升序。未声明时不返回，客户端应把这类工具排在末尾。
         description:
           type: string
           description: 工具描述（随部署语言设置本地化）。


### PR DESCRIPTION
# Pull Request

## What Changed

- [x] `tools/list` now carries display metadata for every tool: `title` (the protocol's own field) plus `openbkn.ai/group`, `openbkn.ai/group_title` and `openbkn.ai/order` under `_meta`
- [x] `GET /mcp/info` exposes the same metadata as flat fields, and is wired to the locale it had been blind to
- [x] Fixes a standing defect where two of the three tool-registration paths bypassed the locale bundle
- [x] `mcptool.ExtraTool` gains the same optional fields so the enterprise code line can declare its own display metadata
- [x] Docs: `docs/api/context-loader/mcp.yaml` updated in both places

---

## Why

- Related Issue: [#666](https://github.com/openbkn-ai/bkn-foundry/issues/666) (the defect the second commit fixes, closes #666)
- Background: a client rendering the MCP tool catalogue only gets `name` and `description` from `tools/list`, so it has to maintain its own "tool name → display name / group / order" table. Every time the tool surface changes, that table goes stale without anyone noticing.
- No new convention was needed for the display name: MCP has had a `title` field since the 2025-06-18 revision, and that is where it now lives. Group and order have no protocol field, so they travel in the tool's `_meta` under an `openbkn.ai/` prefix (the spec reserves `modelcontextprotocol.io/` and `mcp.dev/` for itself). Clients that do not know these keys ignore them, which is what `_meta` is for.

---

## How

Key implementation points:

- `tools_meta.json` declares `title` / `group` / `group_title` / `order` for all 23 core tools, in five groups — lifecycle, discovery, query, action, resource — with `order` stepping by ten so tools can be inserted later without renumbering. The five tools that landed on main while this branch was open (`query_metric`, `list_skills`, `get_skill_content`, `read_skill_file`, `execute_skill`) were given declarations during the rebase.
- A locale file translates; it does not re-model. The localized entry overlays only the fields it actually carries: `title` and `group_title` are translated, while `group` and `order` are declared once in the base file so the two languages cannot drift into two different catalogue structures. `name` is not overlayable at all — it is the identifier a `tools/call` carries, and a locale file that renamed it would give one tool two names depending on the deployment's language.
- The second commit fixes what testing on the test environment exposed. Of the three registration paths — `toolBuilder`, the lifecycle adapter and `addEmbedded` — only the first went through the locale bundle, and `/mcp/info` was blind to the locale entirely. `addEmbedded` differed from `add` in nothing but that bypass and is deleted; lifecycle registration now takes the bundle; `BuildMCPInfo` resolves from the same source as `tools/list`.
- All the enterprise-side fields are optional. Left unset, a tool is advertised with no title and no group — exactly how every tool looked before this change. Core does not invent a group for a paid tool it cannot see well enough to name.

Breaking changes: none. Both `tools/list` and `/mcp/info` only gain fields.

Behaviour change (not breaking, but worth knowing): on non-Chinese deployments (`LANG=en_US` and friends), the descriptions of `bkn_start_interaction`, `bkn_finish_interaction`, `get_object_types` and `get_relation_types`, along with every tool's name/description/schema text served by `/mcp/info`, used to come back in Chinese regardless of locale. They now follow the locale. This is the fix, not a regression — the same catalogue previously mixed two languages.

---

## Testing

- [x] Unit tests passed locally
- [ ] Integration tests passed locally
- [x] Verified in test environment

Test notes:

- `go test ./...` green across the agent-retrieval module; the MCP package was additionally run under `MCP_LOCALE` unset, `en-US` and `zh-CN`, and under `-race`
- Six new assertions, all made against the serialized JSON rather than the Go structs — a field set correctly on the struct but never reaching the wire is the usual way this class of change fails:
  - every tool in `tools/list` carries a non-empty title and `_meta` matching its metadata
  - every core tool declares all four fields, with no duplicate `order`
  - the locale file translates without re-modelling (no `group` / `order` / `name`) and covers every tool
  - assembling the whole catalogue under `en-US` — any registration path that skips the locale turns this red
  - `/mcp/info` and `tools/list` agree on the display metadata
  - `/mcp/info` and `tools/list` agree on description and both schemas under a non-default locale. This one is pinned to `en-US` deliberately: under the default locale the overlay is a no-op and both sides match even with the wiring removed, so a default-locale assertion proves nothing. Verified by mutation — reverting the `BuildMCPInfo` wiring turns this test red while the existing default-locale test stays green.
- Verified on test environment 14.103.77.23, whose pod runs `LANG=en_US.UTF-8` (main had not yet landed the skill tools at the time, so the catalogue was 18 tools): every tool carried its title and `_meta`, grouping and ordering were as intended, the mixed-language catalogue was gone, `/mcp/info` matched `tools/list` field by field, and `tools/call bkn_start_interaction` returned normally.

---

## Risk & Rollback

- Risk: description text changes for the four tools above on non-Chinese deployments. Schema structure and tool names are untouched, so agent-side calls are unaffected.
- Rollback: the commits are independently revertable. Reverting the second one leaves the display metadata working; non-Chinese deployments go back to a mixed-language catalogue.
- Not re-verified on a live environment: the five tools that arrived from main during the rebase have their display metadata covered by unit tests only. Worth one look at `tools/list` after this merges.

---

## Additional Notes

The frontend can drop its local mapping table, but needs a fallback: an older server sends no `title`, so fall back to `name`, and sort tools without an `order` last. Branch on `group` (a stable identifier), never on `group_title` (display text that follows the deployment's language).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
