### PR TITLE
chore(deploy): align release manifest installation order

### DIFF
--- a/deploy/release-manifests/0.1.2/bkn-foundry.yaml
+++ b/deploy/release-manifests/0.1.2/bkn-foundry.yaml
@@ -14,17 +14,20 @@ releases:
     chart: core-data-migrator
     version: 0.1.2
     stage: pre
+  bkn-safe:
+    chart: bkn-safe
+    version: 0.1.2
   mf-model-manager:
     chart: mf-model-manager
     version: 0.1.2
   mf-model-api:
     chart: mf-model-api
     version: 0.1.2
-  oss-gateway-backend:
-    chart: oss-gateway-backend
+  kafka-connect:
+    chart: kafka-connect
     version: 0.1.2
-  sandbox:
-    chart: sandbox
+  vega-backend:
+    chart: vega-backend
     version: 0.1.2
   bkn-backend:
     chart: bkn-backend
@@ -32,14 +35,14 @@ releases:
   ontology-query:
     chart: ontology-query
     version: 0.1.2
-  vega-backend:
-    chart: vega-backend
-    version: 0.1.2
-  kafka-connect:
-    chart: kafka-connect
-    version: 0.1.2
   agent-operator-integration:
     chart: agent-operator-integration
+    version: 0.1.2
+  oss-gateway-backend:
+    chart: oss-gateway-backend
+    version: 0.1.2
+  sandbox:
+    chart: sandbox
     version: 0.1.2
   agent-retrieval:
     chart: agent-retrieval
@@ -52,9 +55,6 @@ releases:
     version: 0.1.2
   otelcol-contrib:
     chart: otelcol-contrib
-    version: 0.1.2
-  bkn-safe:
-    chart: bkn-safe
     version: 0.1.2
   bkn-studio:
     chart: bkn-studio

--- a/deploy/scripts/bkn-foundry.template.yaml
+++ b/deploy/scripts/bkn-foundry.template.yaml
@@ -14,17 +14,20 @@ releases:
     chart: core-data-migrator
     version: main
     stage: pre
+  bkn-safe:
+    chart: bkn-safe
+    version: main
   mf-model-manager:
     chart: mf-model-manager
     version: main
   mf-model-api:
     chart: mf-model-api
     version: main
-  oss-gateway-backend:
-    chart: oss-gateway-backend
+  kafka-connect:
+    chart: kafka-connect
     version: main
-  sandbox:
-    chart: sandbox
+  vega-backend:
+    chart: vega-backend
     version: main
   bkn-backend:
     chart: bkn-backend
@@ -32,17 +35,14 @@ releases:
   ontology-query:
     chart: ontology-query
     version: main
-  vega-backend:
-    chart: vega-backend
-    version: main
-  kafka-connect:
-    chart: kafka-connect
-    version: main
   agent-operator-integration:
     chart: agent-operator-integration
     version: main
-  agent-observability:
-    chart: agent-observability
+  oss-gateway-backend:
+    chart: oss-gateway-backend
+    version: main
+  sandbox:
+    chart: sandbox
     version: main
   agent-retrieval:
     chart: agent-retrieval
@@ -50,11 +50,11 @@ releases:
   bkn-agent:
     chart: bkn-agent
     version: main
+  agent-observability:
+    chart: agent-observability
+    version: main
   otelcol-contrib:
     chart: otelcol-contrib
-    version: main
-  bkn-safe:
-    chart: bkn-safe
     version: main
   bkn-studio:
     chart: bkn-studio


### PR DESCRIPTION
# Pull Request

## What Changed

Brief description of changes:

- [x] 调整 `deploy/release-manifests/0.1.2/bkn-foundry.yaml` 的 release 安装顺序。
- [x] 同步 `deploy/scripts/bkn-foundry.template.yaml` 的顺序，确保开发/测试生成的 manifest 与 0.1.2 发布清单一致。
- [x] 将 `bkn-safe` 提前至核心业务服务之前。
- [x] 调整为先安装 `kafka-connect`，再安装依赖其服务地址的 `vega-backend`。

---

## Why

- Related Issue: N/A
- Related Feature: N/A
- Background: 安装器按 manifest 中 `releases` 的声明顺序串行执行 Helm 安装。统一发布与开发 manifest 的顺序，并使显式上游依赖优先部署，降低首装时服务发现缺失或连接失败的风险。

---

## How

- Key implementation points:
  - 保持 `core-data-migrator` 为首个 `stage: pre` release。
  - 保持所有 chart 名称、版本及其他配置不变，仅调整 release 声明顺序。
  - 模板与 0.1.2 发布清单的 release 顺序逐项一致。
- Breaking changes (API, config, database, etc.): 无。

---

## Testing

- [x] Unit tests passed locally — N/A，仅 manifest 顺序调整。
- [x] Integration tests passed locally — N/A，仅 manifest 顺序调整。
- [x] Verified in test environment — 未执行集群安装验证。

Test notes:

- 已执行 `git diff --check`，通过。
- 已逐项比较 release 名称顺序，发布清单与开发模板一致。

---

## Risk & Rollback

- Potential risks: 远程 chart 安装路径不使用 `--wait`，因此排序只能确保 Helm 命令串行提交资源，不能保证上游工作负载在下游开始前已 Ready。
- Rollback plan: 恢复两个 manifest 文件中原有的 release 声明顺序即可。

---

## Additional Notes

- 未修改 chart 版本、values 或服务配置。
- 未提交、推送或创建 PR。