### PR TITLE
feat(bkn-agent): reach Context Loader tools over its MCP face

### DIFF
--- a/docs/api/bkn-agent/bkn-agent.yaml
+++ b/docs/api/bkn-agent/bkn-agent.yaml
@@ -809,10 +809,12 @@ components:
             - $ref: '#/components/schemas/McpToolRef'
             - $ref: '#/components/schemas/ToolboxToolRef'
             - $ref: '#/components/schemas/AgentToolRef'
+            - $ref: '#/components/schemas/ContextLoaderToolRef'
             discriminator:
               propertyName: type
               mapping:
                 agent: '#/components/schemas/AgentToolRef'
+                context_loader: '#/components/schemas/ContextLoaderToolRef'
                 mcp: '#/components/schemas/McpToolRef'
                 toolbox: '#/components/schemas/ToolboxToolRef'
           type: array
@@ -905,6 +907,35 @@ components:
       - agent_id
       - message
       title: ChatRequest
+    ContextLoaderToolRef:
+      properties:
+        name:
+          anyOf:
+          - type: string
+            maxLength: 100
+          - type: 'null'
+          title: Name
+        description:
+          anyOf:
+          - type: string
+            maxLength: 500
+          - type: 'null'
+          title: Description
+        type:
+          type: string
+          const: context_loader
+          title: Type
+      additionalProperties: true
+      type: object
+      required:
+      - type
+      title: ContextLoaderToolRef
+      description: 'Context Loader 的知识网络检索工具，经其 MCP 面装载。
+
+
+        刻意不带 url：端点来自 CONTEXT_LOADER_MCP_URL，agent 定义因此可以跨环境
+
+        导入导出而不带环境地址（type=mcp 写死 url 就不行）。'
     EffectivePromptOut:
       properties:
         source:

--- a/infra/bkn-agent/app/auth.py
+++ b/infra/bkn-agent/app/auth.py
@@ -25,7 +25,16 @@ def caller_token() -> str | None:
 
 
 def set_caller_token(value: str | None):
+    """由 HTTP 中间件调用（见 app/main.py）。
+
+    刻意不放在 get_account 里：那是个同步依赖，FastAPI 会丢进线程池执行，
+    在线程池里 set 的 ContextVar 回不到请求协程，读出来永远是 None。
+    """
     return _caller_token.set(value or None)
+
+
+def reset_caller_token(token) -> None:
+    _caller_token.reset(token)
 
 
 @dataclass(frozen=True)
@@ -37,10 +46,9 @@ class Account:
 def get_account(request: Request) -> Account:
     """/in 约定：网关信任请求头，鉴权押下游。空账户 fail-closed（本服务仅内部）。
 
-    另外把 Authorization 原样收进 ContextVar：本服务自身不校验它（身份仍以
-    x-account-id 为准），只在需要令牌的下游（Context Loader MCP 公开面）原样转发。
+    Authorization 不在这里收——见 set_caller_token 的说明，同步依赖跑在线程池里，
+    ContextVar 传不回来。收在 app/main.py 的中间件。
     """
-    set_caller_token(request.headers.get("authorization"))
     account_id = (request.headers.get("x-account-id") or "").strip()
     account_type = (request.headers.get("x-account-type") or "").strip()
     if not account_id or account_type not in _ALLOWED_TYPES:

--- a/infra/bkn-agent/app/auth.py
+++ b/infra/bkn-agent/app/auth.py
@@ -1,3 +1,4 @@
+from contextvars import ContextVar
 from dataclasses import dataclass
 
 from fastapi import Request
@@ -5,6 +6,26 @@ from fastapi import Request
 from app.errors import err
 
 _ALLOWED_TYPES = {"user", "app"}
+
+# 调用方原样带来的 Authorization 头。
+#
+# 存在这里而不是穿进每层函数签名：从路由到 runner 到工具装载有十几处
+# (account_id, account_type) 位置参数，再加一个会把整条链全改一遍；而
+# ContextVar 在 asyncio.create_task 时会随上下文复制，/run 的后台任务同样拿得到。
+#
+# 谁用它：Context Loader 的 MCP 面只认真实令牌（公开面挂 introspect），
+# 不吃 /in 那套头部身份，所以 type=context_loader 工具靠这个透传的令牌调用，
+# 保住 per-user 授权。见 app/core/context_loader.py。
+_caller_token: ContextVar[str | None] = ContextVar("bkn_agent_caller_token", default=None)
+
+
+def caller_token() -> str | None:
+    """当前请求透传进来的 Authorization 头原文（含 Bearer 前缀），没有则 None。"""
+    return _caller_token.get()
+
+
+def set_caller_token(value: str | None):
+    return _caller_token.set(value or None)
 
 
 @dataclass(frozen=True)
@@ -14,7 +35,12 @@ class Account:
 
 
 def get_account(request: Request) -> Account:
-    """/in 约定：网关信任请求头，鉴权押下游。空账户 fail-closed（本服务仅内部）。"""
+    """/in 约定：网关信任请求头，鉴权押下游。空账户 fail-closed（本服务仅内部）。
+
+    另外把 Authorization 原样收进 ContextVar：本服务自身不校验它（身份仍以
+    x-account-id 为准），只在需要令牌的下游（Context Loader MCP 公开面）原样转发。
+    """
+    set_caller_token(request.headers.get("authorization"))
     account_id = (request.headers.get("x-account-id") or "").strip()
     account_type = (request.headers.get("x-account-type") or "").strip()
     if not account_id or account_type not in _ALLOWED_TYPES:

--- a/infra/bkn-agent/app/config.py
+++ b/infra/bkn-agent/app/config.py
@@ -38,12 +38,9 @@ class Config:
         "CONTEXT_LOADER_MCP_URL",
         "http://agent-retrieval:30779/api/agent-retrieval/v1/mcp/",
     )
-    # 兜底服务凭据（bak_ AppKey）。仅在调用方没有透传令牌时启用。
-    #
-    # ⚠️ 一旦用上，Context Loader 看到的就是这个服务主体而不是真实调用者，
-    # per-user 授权在该次调用上塌缩为「AppKey 签发人可见的范围」。主路是透传
-    # 调用方令牌（见 auth.caller_token）；留空则没有兜底，无令牌时不挂 CL 工具。
-    CONTEXT_LOADER_APPKEY = _env("CONTEXT_LOADER_APPKEY", "")
+    # 凭据只走调用方透传的令牌（见 auth.caller_token）。刻意不设服务凭据兜底：
+    # 用服务 AppKey 顶上去会让 Context Loader 看到签发人而非真实调用者，
+    # per-user 授权当场塌缩。没令牌就不挂 CL 工具。
     CONTEXT_LOADER_MCP_TIMEOUT_S = float(_env("CONTEXT_LOADER_MCP_TIMEOUT_S", "30"))
 
     # BKN Trace phase-two evidence ingestion. Empty URL = construct evidence facts

--- a/infra/bkn-agent/app/config.py
+++ b/infra/bkn-agent/app/config.py
@@ -33,7 +33,7 @@ class Config:
     #
     # 这是 Context Loader 的**公开面**：它挂 middlewareIntrospectVerify，只认真实
     # 令牌（OAuth access token 或 bak_ AppKey），不吃 /in 那套 x-account-id 头部身份。
-    # 所以下面两个凭据配置是这条路的前提，不是可选优化。
+    # 所以调用方必须透传最终用户的令牌，这条路才成立。
     CONTEXT_LOADER_MCP_URL = _env(
         "CONTEXT_LOADER_MCP_URL",
         "http://agent-retrieval:30779/api/agent-retrieval/v1/mcp/",

--- a/infra/bkn-agent/app/config.py
+++ b/infra/bkn-agent/app/config.py
@@ -28,6 +28,24 @@ class Config:
     # （#322 把技能面从 capabilities-lab 收敛过来）
     OPERATOR_INTEGRATION_BASE = _env("OPERATOR_INTEGRATION_BASE", "http://agent-operator-integration:9000/api/agent-operator-integration")
 
+    # Context Loader MCP 面。ToolRef type=context_loader 由此装载，不需要在 agent
+    # 定义里写死 URL（写死会让定义不能跨环境搬）。
+    #
+    # 这是 Context Loader 的**公开面**：它挂 middlewareIntrospectVerify，只认真实
+    # 令牌（OAuth access token 或 bak_ AppKey），不吃 /in 那套 x-account-id 头部身份。
+    # 所以下面两个凭据配置是这条路的前提，不是可选优化。
+    CONTEXT_LOADER_MCP_URL = _env(
+        "CONTEXT_LOADER_MCP_URL",
+        "http://agent-retrieval:30779/api/agent-retrieval/v1/mcp/",
+    )
+    # 兜底服务凭据（bak_ AppKey）。仅在调用方没有透传令牌时启用。
+    #
+    # ⚠️ 一旦用上，Context Loader 看到的就是这个服务主体而不是真实调用者，
+    # per-user 授权在该次调用上塌缩为「AppKey 签发人可见的范围」。主路是透传
+    # 调用方令牌（见 auth.caller_token）；留空则没有兜底，无令牌时不挂 CL 工具。
+    CONTEXT_LOADER_APPKEY = _env("CONTEXT_LOADER_APPKEY", "")
+    CONTEXT_LOADER_MCP_TIMEOUT_S = float(_env("CONTEXT_LOADER_MCP_TIMEOUT_S", "30"))
+
     # BKN Trace phase-two evidence ingestion. Empty URL = construct evidence facts
     # locally but do not submit them, so bkn-agent can deploy before bkn-trace.
     BKN_TRACE_EVIDENCE_INGEST_URL = _env("BKN_TRACE_EVIDENCE_INGEST_URL", "")

--- a/infra/bkn-agent/app/core/context_loader.py
+++ b/infra/bkn-agent/app/core/context_loader.py
@@ -12,11 +12,12 @@
   `bkn_start_interaction` 领一对真 id，再拿它调业务工具。领到的 id 与令牌身份
   绑定、不与 MCP 会话绑定，所以一轮对话领一次即可复用。
 
-凭据优先级：
-1. 调用方透传的 Authorization（`auth.caller_token()`）——主路，保住 per-user 授权
-2. `CONTEXT_LOADER_APPKEY`——兜底。⚠️ 用上它时 Context Loader 看到的是该 AppKey
-   的签发人而不是真实调用者，这一次调用的 per-user 授权就塌缩了
-3. 都没有 → 不挂 CL 工具，并记一条 warning（不静默返回空工具集）
+凭据只有一个来源：调用方透传的 Authorization（`auth.caller_token()`）。
+
+刻意不留服务凭据兜底。用服务 AppKey 顶上去的话，Context Loader 看到的是该
+AppKey 的签发人而不是真实调用者，per-user 授权当场塌缩成「签发人可见的范围」——
+一个默认关闭但存在的开关，迟早会被人为了「让它跑起来」打开。没令牌就不挂工具，
+并记一条 warning（不静默返回空工具集），失败留在看得见的地方。
 """
 import logging
 from contextvars import ContextVar
@@ -61,14 +62,9 @@ def wanted(tool_refs: list[dict]) -> bool:
     return any(ref.get("type") == "context_loader" for ref in tool_refs)
 
 
-def _credential() -> tuple[Optional[str], str]:
-    """返回 (Authorization 头原文, 凭据来源)。都没有则 (None, "none")。"""
-    token = caller_token()
-    if token:
-        return token, "caller"
-    if config.CONTEXT_LOADER_APPKEY:
-        return f"Bearer {config.CONTEXT_LOADER_APPKEY}", "service_appkey"
-    return None, "none"
+def _credential() -> Optional[str]:
+    """当前调用方透传的 Authorization 头原文；没有则 None。"""
+    return caller_token()
 
 
 def _client(authorization: str) -> MultiServerMCPClient:
@@ -91,10 +87,9 @@ class ContextLoaderSession:
     参数表——什么时候算一轮交互是运行时的事，不是模型该决策的事。
     """
 
-    def __init__(self, conversation_id: str, interaction_id: str, credential_source: str):
+    def __init__(self, conversation_id: str, interaction_id: str):
         self.conversation_id = conversation_id
         self.interaction_id = interaction_id
-        self.credential_source = credential_source
         self._tools: list[Any] = []
         self._finish: Any = None
 
@@ -146,13 +141,19 @@ def _bind_context(tool: Any, session: ContextLoaderSession) -> Any:
     )
 
 
-async def open_session() -> Optional[ContextLoaderSession]:
-    """握手并装载工具。凭据缺失或握手失败返回 None（调用方决定是否致命）。"""
-    authorization, source = _credential()
+async def open_session(
+    question: str = "", *, agent_name: str | None = None
+) -> Optional[ContextLoaderSession]:
+    """握手并装载工具。凭据缺失或握手失败返回 None（调用方决定是否致命）。
+
+    question 是 bkn_start_interaction 的必填项，语义是「这一轮用户问了什么」，
+    传本轮真实输入而不是空串——生命周期服务按它归档这一轮。
+    """
+    authorization = _credential()
     if not authorization:
         logger.warning(
-            "[ContextLoader] 无可用凭据（调用方未透传 Authorization，且未配置 "
-            "CONTEXT_LOADER_APPKEY），跳过 context_loader 工具装载"
+            "[ContextLoader] 调用方未透传 Authorization，跳过 context_loader 工具装载。"
+            "Context Loader 的 MCP 面只认真实令牌，调用 bkn-agent 时需带上最终用户的令牌"
         )
         return None
 
@@ -163,7 +164,7 @@ async def open_session() -> Optional[ContextLoaderSession]:
         # ExceptionGroup 的 str() 只有 "unhandled errors in a TaskGroup"，真因全在
         # 子异常里。VM 上第一次排查就卡在这条日志上（真因是 401），所以摊开打。
         detail = "; ".join(f"{type(x).__name__}: {x}" for x in getattr(e, "exceptions", ()) or ()) or f"{type(e).__name__}: {e}"
-        logger.warning("[ContextLoader] 连接 MCP 面失败（%s），跳过工具装载：%s", source, detail)
+        logger.warning("[ContextLoader] 连接 MCP 面失败，跳过工具装载：%s", detail)
         return None
 
     by_name = {getattr(t, "name", ""): t for t in tools}
@@ -173,7 +174,10 @@ async def open_session() -> Optional[ContextLoaderSession]:
         return None
 
     try:
-        raw = await start.coroutine(question="")
+        args = {"question": question or "(未提供)"}
+        if agent_name:
+            args["agent_name"] = agent_name[:128]
+        raw = await start.coroutine(**args)
     except Exception as e:
         logger.warning("[ContextLoader] bkn_start_interaction 失败，跳过工具装载：%s", e)
         return None
@@ -183,7 +187,7 @@ async def open_session() -> Optional[ContextLoaderSession]:
         logger.warning("[ContextLoader] bkn_start_interaction 未返回可用 id：%r", raw)
         return None
 
-    session = ContextLoaderSession(ids[0], ids[1], source)
+    session = ContextLoaderSession(ids[0], ids[1])
     session._finish = by_name.get("bkn_finish_interaction")
     session._tools = [
         _bind_context(t, session)
@@ -191,9 +195,8 @@ async def open_session() -> Optional[ContextLoaderSession]:
         if name not in _LIFECYCLE_TOOLS
     ]
     logger.info(
-        "[ContextLoader] 会话就绪：%d 个工具，凭据来源 %s，interaction %s",
+        "[ContextLoader] 会话就绪：%d 个工具，interaction %s",
         len(session._tools),
-        source,
         session.interaction_id,
     )
     return session
@@ -252,15 +255,36 @@ def _id_candidates(raw: Any):
     return [c for c in seen if isinstance(c, dict)]
 
 
-async def close_session(session: Optional[ContextLoaderSession]) -> None:
+# bkn_finish_interaction 的 outcome 枚举（取自 MCP 面 input_schema）。
+# 早先这里传的是 "succeeded"——不在枚举里，连同把 id 塞进 bkn_context 而不是
+# interaction_id，导致每一轮收尾都被 resource_not_disclosed 拒掉，交互全挂在
+# active 上没人关。
+_OUTCOMES = {"completed", "failed", "cancelled", "handed_off"}
+
+
+async def close_session(
+    session: Optional[ContextLoaderSession],
+    *,
+    outcome: str = "completed",
+    answer: str | None = None,
+    reason: str | None = None,
+) -> None:
     """收尾 bkn_finish_interaction。失败只告警：一轮已经跑完，不该因为收尾失败
     把成功的结果翻成失败。"""
     if session is None or session._finish is None:
         return
+    if outcome not in _OUTCOMES:
+        outcome = "completed"
+    args: dict[str, Any] = {
+        "interaction_id": session.interaction_id,
+        "outcome": outcome,
+    }
+    if answer:
+        args["answer"] = answer[:4000]
+    if reason:
+        args["reason"] = reason[:1000]
     try:
-        await session._finish.coroutine(
-            bkn_context=session.bkn_context, outcome="succeeded"
-        )
+        await session._finish.coroutine(**args)
     except Exception as e:
         logger.warning(
             "[ContextLoader] bkn_finish_interaction 失败（interaction %s）：%s",

--- a/infra/bkn-agent/app/core/context_loader.py
+++ b/infra/bkn-agent/app/core/context_loader.py
@@ -160,7 +160,10 @@ async def open_session() -> Optional[ContextLoaderSession]:
     try:
         tools = await client.get_tools()
     except Exception as e:
-        logger.warning("[ContextLoader] 连接 MCP 面失败（%s），跳过工具装载：%s", source, e)
+        # ExceptionGroup 的 str() 只有 "unhandled errors in a TaskGroup"，真因全在
+        # 子异常里。VM 上第一次排查就卡在这条日志上（真因是 401），所以摊开打。
+        detail = "; ".join(f"{type(x).__name__}: {x}" for x in getattr(e, "exceptions", ()) or ()) or f"{type(e).__name__}: {e}"
+        logger.warning("[ContextLoader] 连接 MCP 面失败（%s），跳过工具装载：%s", source, detail)
         return None
 
     by_name = {getattr(t, "name", ""): t for t in tools}
@@ -199,31 +202,54 @@ async def open_session() -> Optional[ContextLoaderSession]:
 def _parse_ids(raw: Any) -> Optional[tuple[str, str]]:
     """从 bkn_start_interaction 的返回里取出 (conversation_id, interaction_id)。
 
-    langchain-mcp-adapters 可能把 structuredContent 直接给成 dict，也可能给回
-    文本内容，两种都收。
+    langchain-mcp-adapters 的实际返回形状（VM 实测）是个二元组：
+
+        ([{"type": "text", "text": "<json>", "id": ...}],
+         {"structured_content": {"conversation_id": ..., "interaction_id": ...}})
+
+    早先这里只认 dict 和裸 JSON 串，撞上真实形状直接返回 None —— 握手其实成功了，
+    id 也拿到了，却被判成「未返回可用 id」而跳过整个工具装载。这里按「先找
+    structured_content，再退回文本块里的 JSON」两级解析，并保留 dict / 裸串两种
+    简单形状。
     """
+    for candidate in _id_candidates(raw):
+        cid = candidate.get("conversation_id")
+        iid = candidate.get("interaction_id")
+        if isinstance(cid, str) and cid and isinstance(iid, str) and iid:
+            return cid, iid
+    return None
+
+
+def _id_candidates(raw: Any):
+    """把可能藏着 id 的字典逐个吐出来，从最可信的来源开始。"""
     import json
 
-    payload = raw
-    if isinstance(payload, str):
-        try:
-            payload = json.loads(payload)
-        except (TypeError, ValueError):
-            return None
-    if isinstance(payload, (list, tuple)):
-        payload = payload[0] if payload else None
-        if isinstance(payload, str):
+    seen: list[Any] = []
+
+    def walk(node: Any, depth: int = 0) -> None:
+        if depth > 4 or node is None:
+            return
+        if isinstance(node, str):
             try:
-                payload = json.loads(payload)
+                walk(json.loads(node), depth + 1)
             except (TypeError, ValueError):
-                return None
-    if not isinstance(payload, dict):
-        return None
-    cid = payload.get("conversation_id")
-    iid = payload.get("interaction_id")
-    if isinstance(cid, str) and isinstance(iid, str) and cid and iid:
-        return cid, iid
-    return None
+                pass
+            return
+        if isinstance(node, dict):
+            # structured_content / structuredContent 是 MCP 的结构化输出，优先
+            for key in ("structured_content", "structuredContent"):
+                if isinstance(node.get(key), dict):
+                    seen.append(node[key])
+            seen.append(node)
+            if isinstance(node.get("text"), str):
+                walk(node["text"], depth + 1)
+            return
+        if isinstance(node, (list, tuple)):
+            for item in node:
+                walk(item, depth + 1)
+
+    walk(raw)
+    return [c for c in seen if isinstance(c, dict)]
 
 
 async def close_session(session: Optional[ContextLoaderSession]) -> None:

--- a/infra/bkn-agent/app/core/context_loader.py
+++ b/infra/bkn-agent/app/core/context_loader.py
@@ -101,6 +101,8 @@ class ContextLoaderSession:
     def __init__(self, conversation_id: str, interaction_id: str):
         self.conversation_id = conversation_id
         self.interaction_id = interaction_id
+        # 收尾在正常路径上提前做一次、finally 再兜一次，必须幂等
+        self.closed = False
         self._tools: list[Any] = []
         self._finish: Any = None
 
@@ -289,8 +291,9 @@ async def close_session(
 ) -> None:
     """收尾 bkn_finish_interaction。失败只告警：一轮已经跑完，不该因为收尾失败
     把成功的结果翻成失败。"""
-    if session is None or session._finish is None:
+    if session is None or session._finish is None or session.closed:
         return
+    session.closed = True
     if outcome not in _OUTCOMES:
         outcome = "completed"
     args: dict[str, Any] = {

--- a/infra/bkn-agent/app/core/context_loader.py
+++ b/infra/bkn-agent/app/core/context_loader.py
@@ -1,0 +1,243 @@
+"""Context Loader 的 MCP 面装载（ToolRef type=context_loader）。
+
+与 toolbox 那条路的区别，以及为什么要有这个模块：
+
+- Context Loader 的 MCP JSON-RPC 只挂在**公开路由**上，且该路由挂了
+  `middlewareIntrospectVerify`，只认真实令牌（OAuth access token 或 bak_ AppKey）。
+  它不吃 `/in` 那套 `x-account-id` 头部身份。所以这里必须带 Authorization。
+- Context Loader 对所有业务工具有生命周期守卫：`bkn_context`（conversation_id +
+  interaction_id）是**必填入参**，缺了返回 `conversation_required`。
+- 这对 id **不能本地铸**。实测本地铸的 `int_...` 会被 `resource_not_disclosed`
+  拒掉——MCP 侧的 owner tuple 从令牌推导，与自铸 id 对不上。正路是先调
+  `bkn_start_interaction` 领一对真 id，再拿它调业务工具。领到的 id 与令牌身份
+  绑定、不与 MCP 会话绑定，所以一轮对话领一次即可复用。
+
+凭据优先级：
+1. 调用方透传的 Authorization（`auth.caller_token()`）——主路，保住 per-user 授权
+2. `CONTEXT_LOADER_APPKEY`——兜底。⚠️ 用上它时 Context Loader 看到的是该 AppKey
+   的签发人而不是真实调用者，这一次调用的 per-user 授权就塌缩了
+3. 都没有 → 不挂 CL 工具，并记一条 warning（不静默返回空工具集）
+"""
+import logging
+from contextvars import ContextVar
+from typing import Any, Optional
+
+from langchain_core.tools import StructuredTool
+from langchain_mcp_adapters.client import MultiServerMCPClient
+
+from app import observability
+from app.auth import caller_token
+from app.config import config
+
+logger = logging.getLogger("bkn-agent.context-loader")
+
+# 生命周期工具本身不是业务工具，不需要 bkn_context，也不该暴露给模型 ——
+# 模型不该自己决定何时开一轮交互。
+_LIFECYCLE_TOOLS = {"bkn_start_interaction", "bkn_finish_interaction"}
+
+_CONNECTION_NAME = "context_loader"
+
+# 本轮执行的会话。load_tools 装载时设置，runner / graph 取里面的真 id 交给
+# evidence.begin_interaction，让证据链与 Context Loader 用同一对 id ——
+# 否则一轮对话在 trace 里会裂成两条。
+_current: ContextVar[Optional["ContextLoaderSession"]] = ContextVar(
+    "bkn_agent_context_loader_session", default=None
+)
+
+
+def current_session() -> Optional["ContextLoaderSession"]:
+    return _current.get()
+
+
+def set_current(session: Optional["ContextLoaderSession"]):
+    return _current.set(session)
+
+
+def reset_current(token) -> None:
+    _current.reset(token)
+
+
+def wanted(tool_refs: list[dict]) -> bool:
+    return any(ref.get("type") == "context_loader" for ref in tool_refs)
+
+
+def _credential() -> tuple[Optional[str], str]:
+    """返回 (Authorization 头原文, 凭据来源)。都没有则 (None, "none")。"""
+    token = caller_token()
+    if token:
+        return token, "caller"
+    if config.CONTEXT_LOADER_APPKEY:
+        return f"Bearer {config.CONTEXT_LOADER_APPKEY}", "service_appkey"
+    return None, "none"
+
+
+def _client(authorization: str) -> MultiServerMCPClient:
+    headers = {"Authorization": authorization, **observability.outbound_headers()}
+    return MultiServerMCPClient(
+        {
+            _CONNECTION_NAME: {
+                "transport": "streamable_http",
+                "url": config.CONTEXT_LOADER_MCP_URL,
+                "headers": headers,
+            }
+        }
+    )
+
+
+class ContextLoaderSession:
+    """一轮 agent 执行期间对 Context Loader 的一次会话。
+
+    持有真 id 与已装载的工具。`bkn_context` 由本类在调用时注入，不进模型可见的
+    参数表——什么时候算一轮交互是运行时的事，不是模型该决策的事。
+    """
+
+    def __init__(self, conversation_id: str, interaction_id: str, credential_source: str):
+        self.conversation_id = conversation_id
+        self.interaction_id = interaction_id
+        self.credential_source = credential_source
+        self._tools: list[Any] = []
+        self._finish: Any = None
+
+    @property
+    def bkn_context(self) -> dict[str, str]:
+        return {
+            "conversation_id": self.conversation_id,
+            "interaction_id": self.interaction_id,
+        }
+
+    def tools(self) -> list[Any]:
+        return self._tools
+
+
+def _strip_bkn_context(tool: Any) -> None:
+    """把 bkn_context 从模型可见的入参表里摘掉（含 required 列表）。
+
+    MCP 侧把它声明为 required，照原样透给模型会让模型去编造 id；实际值由
+    ContextLoaderSession 在调用时注入。
+    """
+    schema = getattr(tool, "args_schema", None)
+    if not isinstance(schema, dict):
+        return
+    props = schema.get("properties")
+    if isinstance(props, dict):
+        props.pop("bkn_context", None)
+    required = schema.get("required")
+    if isinstance(required, list) and "bkn_context" in required:
+        schema["required"] = [r for r in required if r != "bkn_context"]
+
+
+def _bind_context(tool: Any, session: ContextLoaderSession) -> Any:
+    """包一层：调用时补上 bkn_context 再转给原工具。"""
+    inner = getattr(tool, "coroutine", None)
+    if inner is None:
+        return tool
+
+    async def call(**kwargs):
+        kwargs["bkn_context"] = session.bkn_context
+        return await inner(**kwargs)
+
+    _strip_bkn_context(tool)
+    return StructuredTool.from_function(
+        coroutine=call,
+        name=tool.name,
+        description=tool.description,
+        args_schema=tool.args_schema,
+        metadata={**(getattr(tool, "metadata", None) or {}), "bkn_context_loader": True},
+    )
+
+
+async def open_session() -> Optional[ContextLoaderSession]:
+    """握手并装载工具。凭据缺失或握手失败返回 None（调用方决定是否致命）。"""
+    authorization, source = _credential()
+    if not authorization:
+        logger.warning(
+            "[ContextLoader] 无可用凭据（调用方未透传 Authorization，且未配置 "
+            "CONTEXT_LOADER_APPKEY），跳过 context_loader 工具装载"
+        )
+        return None
+
+    client = _client(authorization)
+    try:
+        tools = await client.get_tools()
+    except Exception as e:
+        logger.warning("[ContextLoader] 连接 MCP 面失败（%s），跳过工具装载：%s", source, e)
+        return None
+
+    by_name = {getattr(t, "name", ""): t for t in tools}
+    start = by_name.get("bkn_start_interaction")
+    if start is None:
+        logger.warning("[ContextLoader] MCP 面未暴露 bkn_start_interaction，跳过工具装载")
+        return None
+
+    try:
+        raw = await start.coroutine(question="")
+    except Exception as e:
+        logger.warning("[ContextLoader] bkn_start_interaction 失败，跳过工具装载：%s", e)
+        return None
+
+    ids = _parse_ids(raw)
+    if not ids:
+        logger.warning("[ContextLoader] bkn_start_interaction 未返回可用 id：%r", raw)
+        return None
+
+    session = ContextLoaderSession(ids[0], ids[1], source)
+    session._finish = by_name.get("bkn_finish_interaction")
+    session._tools = [
+        _bind_context(t, session)
+        for name, t in by_name.items()
+        if name not in _LIFECYCLE_TOOLS
+    ]
+    logger.info(
+        "[ContextLoader] 会话就绪：%d 个工具，凭据来源 %s，interaction %s",
+        len(session._tools),
+        source,
+        session.interaction_id,
+    )
+    return session
+
+
+def _parse_ids(raw: Any) -> Optional[tuple[str, str]]:
+    """从 bkn_start_interaction 的返回里取出 (conversation_id, interaction_id)。
+
+    langchain-mcp-adapters 可能把 structuredContent 直接给成 dict，也可能给回
+    文本内容，两种都收。
+    """
+    import json
+
+    payload = raw
+    if isinstance(payload, str):
+        try:
+            payload = json.loads(payload)
+        except (TypeError, ValueError):
+            return None
+    if isinstance(payload, (list, tuple)):
+        payload = payload[0] if payload else None
+        if isinstance(payload, str):
+            try:
+                payload = json.loads(payload)
+            except (TypeError, ValueError):
+                return None
+    if not isinstance(payload, dict):
+        return None
+    cid = payload.get("conversation_id")
+    iid = payload.get("interaction_id")
+    if isinstance(cid, str) and isinstance(iid, str) and cid and iid:
+        return cid, iid
+    return None
+
+
+async def close_session(session: Optional[ContextLoaderSession]) -> None:
+    """收尾 bkn_finish_interaction。失败只告警：一轮已经跑完，不该因为收尾失败
+    把成功的结果翻成失败。"""
+    if session is None or session._finish is None:
+        return
+    try:
+        await session._finish.coroutine(
+            bkn_context=session.bkn_context, outcome="succeeded"
+        )
+    except Exception as e:
+        logger.warning(
+            "[ContextLoader] bkn_finish_interaction 失败（interaction %s）：%s",
+            session.interaction_id,
+            e,
+        )

--- a/infra/bkn-agent/app/core/context_loader.py
+++ b/infra/bkn-agent/app/core/context_loader.py
@@ -67,14 +67,25 @@ def _credential() -> Optional[str]:
     return caller_token()
 
 
-def _client(authorization: str) -> MultiServerMCPClient:
+# 服务端据此把多轮归到同一个 managed conversation；不给就每轮新铸一个，
+# 一段多轮对话会被存成 N 个各含一次交互的独立会话，且事后无法合并。
+# 见 adp/context-loader/.../mcp/host_lifecycle_hints.go:22。
+_HOST_CONVERSATION_KEY_HEADER = "X-OpenBKN-Host-Conversation-Key"
+
+
+def _client(
+    authorization: str, host_conversation_key: Optional[str] = None
+) -> MultiServerMCPClient:
     headers = {"Authorization": authorization, **observability.outbound_headers()}
+    if host_conversation_key:
+        headers[_HOST_CONVERSATION_KEY_HEADER] = host_conversation_key
     return MultiServerMCPClient(
         {
             _CONNECTION_NAME: {
                 "transport": "streamable_http",
                 "url": config.CONTEXT_LOADER_MCP_URL,
                 "headers": headers,
+                "timeout": config.CONTEXT_LOADER_MCP_TIMEOUT_S,
             }
         }
     )
@@ -142,12 +153,19 @@ def _bind_context(tool: Any, session: ContextLoaderSession) -> Any:
 
 
 async def open_session(
-    question: str = "", *, agent_name: str | None = None
+    question: str = "",
+    *,
+    agent_name: str | None = None,
+    host_conversation_key: str | None = None,
 ) -> Optional[ContextLoaderSession]:
     """握手并装载工具。凭据缺失或握手失败返回 None（调用方决定是否致命）。
 
     question 是 bkn_start_interaction 的必填项，语义是「这一轮用户问了什么」，
     传本轮真实输入而不是空串——生命周期服务按它归档这一轮。
+
+    host_conversation_key 是多轮连续性的锚：chat 传 thread_id，服务端据此把
+    同一 thread 的各轮归到同一个 conversation。不传就每轮新铸一个，一段五轮
+    对话会被存成五个互不相干的单轮会话，且是持久化数据、事后补不回来。
     """
     authorization = _credential()
     if not authorization:
@@ -157,7 +175,7 @@ async def open_session(
         )
         return None
 
-    client = _client(authorization)
+    client = _client(authorization, host_conversation_key)
     try:
         tools = await client.get_tools()
     except Exception as e:
@@ -280,7 +298,11 @@ async def close_session(
         "outcome": outcome,
     }
     if answer:
-        args["answer"] = answer[:4000]
+        # 归档的答案是持久化数据，截断必须留痕，否则存档与用户实际收到的
+        # 内容会静默不一致。
+        args["answer"] = (
+            answer if len(answer) <= 4000 else answer[:4000] + "…[truncated by bkn-agent]"
+        )
     if reason:
         args["reason"] = reason[:1000]
     try:

--- a/infra/bkn-agent/app/core/graph.py
+++ b/infra/bkn-agent/app/core/graph.py
@@ -73,7 +73,7 @@ async def stream_chat(
         # 证据链这一轮的 id。load_tools 会复用这个已开的会话，不重复握手。
         cl_session = None
         if context_loader.wanted(agent.tools):
-            cl_session = await context_loader.open_session()
+            cl_session = await context_loader.open_session(req.message, agent_name=agent.name)
             context_loader.set_current(cl_session)
         tools = await load_tools(
             agent.tools,

--- a/infra/bkn-agent/app/core/graph.py
+++ b/infra/bkn-agent/app/core/graph.py
@@ -84,18 +84,28 @@ async def stream_chat(
                 req.message, agent_name=agent.name, host_conversation_key=thread_id
             )
             if cl_session is not None:
-                # 只有真开出会话才置 ContextVar：置成 None 会让 tools.py 的
-                # `current_session() or await open_session()` 再握一次手，
-                # 那次的 interaction_id evidence 从来没见过。
+                # 只在真开出会话时置位。ContextVar 的作用域就只有 load_tools
+                # 这一段——tools.py 靠它拿会话——所以设与复位都收在这里，
+                # 且必须在同一个 context 里成对出现。
+                #
+                # 早先是在 _events() 的 finally 里复位的：那是个异步生成器，跑在
+                # 复制出来的独立 context，token 跨 context 复位直接抛
+                # ValueError: Token was created in a different Context，
+                # 而且它抛在 finally 开头，把后面的兜底收尾一并废掉。
                 cl_token = context_loader.set_current(cl_session)
-        tools = await load_tools(
-            agent.tools,
-            account_id,
-            account_type,
-            depth=0,
-            parent_thread_id=thread_id,
-            skill_ids=skill_ids,
-        )
+        try:
+            tools = await load_tools(
+                agent.tools,
+                account_id,
+                account_type,
+                depth=0,
+                parent_thread_id=thread_id,
+                skill_ids=skill_ids,
+            )
+        finally:
+            if cl_token is not None:
+                context_loader.reset_current(cl_token)
+                cl_token = None
         tools = instrument_tool_calls(tools, account_id, account_type)
         limits = agent.limits or None
         max_turns = (
@@ -118,8 +128,6 @@ async def stream_chat(
         )
     except BaseException:
         _busy_threads.discard(thread_id)  # setup 失败必须放位，否则该 thread 永久 409
-        if cl_token is not None:
-            context_loader.reset_current(cl_token)
         # setup 阶段抛异常时 _events() 根本没被构造，它的 finally 也就永远不会跑。
         # 握手若已经成功，那次交互会永久停在 active——而且是确定性的：同一个请求
         # 每重试一次就再泄一个。这里补收尾。
@@ -281,8 +289,9 @@ async def stream_chat(
             # BaseExceptionGroup 都会穿透 finally，排在它后面的语句永远跑不到，
             # 该 thread 就会一直卡在 409 Thread.Busy 直到进程重启。
             _busy_threads.discard(thread_id)
-            if cl_token is not None:
-                context_loader.reset_current(cl_token)
+            # 这里不复位 ContextVar：本函数体跑在生成器自己的 context 里，
+            # 复位一个在 stream_chat 的 context 里创建的 token 会抛 ValueError，
+            # 且会顶掉后面的收尾。复位已在 load_tools 那段成对做完。
             # completed 必须带 answer（不带会被 closure_manifest_invalid 拒）。
             # 用显式的成功标记而不是「答案非空」：结构化输出那条路走 structured
             # 事件、answer_parts 是空的，按空判会把成功的一轮误报成 failed；

--- a/infra/bkn-agent/app/core/graph.py
+++ b/infra/bkn-agent/app/core/graph.py
@@ -9,6 +9,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app import dao, evidence, observability
 from app.config import config
+from app.core import context_loader
 from app.core.checkpoint import open_checkpointer
 from app.core.llm import build_chat_model
 from app.core.structured import structured_extract_with_path
@@ -68,6 +69,12 @@ async def stream_chat(
         )
         skill_ids = list(dict.fromkeys([*agent.skills, *req.skills]))
         system_prompt += await load_skills(skill_ids, account_id, account_type)
+        # 与 runner 同序：Context Loader 会话先开，它领到的 interaction_id 同时是
+        # 证据链这一轮的 id。load_tools 会复用这个已开的会话，不重复握手。
+        cl_session = None
+        if context_loader.wanted(agent.tools):
+            cl_session = await context_loader.open_session()
+            context_loader.set_current(cl_session)
         tools = await load_tools(
             agent.tools,
             account_id,
@@ -117,7 +124,8 @@ async def stream_chat(
             "chat",
             agent.agent_id,
             "bkn.agent.chat",
-            conversation_id=thread_id,
+            conversation_id=cl_session.conversation_id if cl_session else thread_id,
+            interaction_id=cl_session.interaction_id if cl_session else None,
         )
         try:
             await evidence.submit_interaction_started(account_id, account_type)
@@ -219,6 +227,7 @@ async def stream_chat(
             yield _sse("error", {"code": "BknAgent.Chat.Failed", "detail": str(e)})
         finally:  # 正常结束、客户端断连（GeneratorExit）、异常，都要放位
             evidence.end_interaction(interaction_token)
+            await context_loader.close_session(cl_session)
             _busy_threads.discard(thread_id)
 
     return _events()

--- a/infra/bkn-agent/app/core/graph.py
+++ b/infra/bkn-agent/app/core/graph.py
@@ -1,5 +1,6 @@
 import asyncio
 import json
+import logging
 import uuid
 from typing import AsyncIterator
 
@@ -24,6 +25,8 @@ from app.models import AgentOut, ChatRequest, ThreadMessage
 # 否则 setup 阶段的多个 await 之间会有竞态窗口，两个请求双双通过检查再排队执行，
 # 交错写同一份 checkpoint；用完 discard，也不会像锁表那样按 thread_id 无限增长。
 # 多副本的跨副本串行化仍待定（会话粘滞或 DB 锁）。
+logger = logging.getLogger("bkn-agent.chat")
+
 _busy_threads: set[str] = set()
 
 
@@ -49,6 +52,10 @@ async def stream_chat(
         )
     _busy_threads.add(thread_id)  # 检查与占位之间不能有 await，否则并发请求双双通过
 
+    # 在 try 之前绑定：setup 早期抛异常时 except 分支也要能安全引用
+    cl_session = None
+    cl_token = None
+
     try:
         thread_row = await dao.get_thread_row(session, thread_id)
         if thread_row:
@@ -71,8 +78,6 @@ async def stream_chat(
         system_prompt += await load_skills(skill_ids, account_id, account_type)
         # 与 runner 同序：Context Loader 会话先开，它领到的 interaction_id 同时是
         # 证据链这一轮的 id。load_tools 会复用这个已开的会话，不重复握手。
-        cl_session = None
-        cl_token = None
         if context_loader.wanted(agent.tools):
             # thread_id 当会话锚：同一 thread 的多轮归进同一个 conversation
             cl_session = await context_loader.open_session(
@@ -113,6 +118,20 @@ async def stream_chat(
         )
     except BaseException:
         _busy_threads.discard(thread_id)  # setup 失败必须放位，否则该 thread 永久 409
+        if cl_token is not None:
+            context_loader.reset_current(cl_token)
+        # setup 阶段抛异常时 _events() 根本没被构造，它的 finally 也就永远不会跑。
+        # 握手若已经成功，那次交互会永久停在 active——而且是确定性的：同一个请求
+        # 每重试一次就再泄一个。这里补收尾。
+        #
+        # 收尾自身再出错不能改写原始异常：调用方要看到的是 setup 为什么失败，
+        # 不是收尾为什么失败。
+        try:
+            await context_loader.close_session(
+                cl_session, outcome="failed", reason="会话建立阶段失败，本轮未开始"
+            )
+        except BaseException as close_err:  # noqa: BLE001 - 收尾失败不得掩盖原始异常
+            logger.warning("[ContextLoader] setup 失败后的收尾也失败了：%s", close_err)
         raise
 
     span_attrs = {

--- a/infra/bkn-agent/app/core/graph.py
+++ b/infra/bkn-agent/app/core/graph.py
@@ -227,7 +227,15 @@ async def stream_chat(
             yield _sse("error", {"code": "BknAgent.Chat.Failed", "detail": str(e)})
         finally:  # 正常结束、客户端断连（GeneratorExit）、异常，都要放位
             evidence.end_interaction(interaction_token)
-            await context_loader.close_session(cl_session)
+            # completed 必须带 answer（不带会被 closure_manifest_invalid 拒），
+            # 所以用累积到的回复；一个 token 都没产出就按 failed 收，别谎报完成。
+            _answer = "".join(answer_parts)
+            await context_loader.close_session(
+                cl_session,
+                outcome="completed" if _answer else "failed",
+                answer=_answer or None,
+                reason=None if _answer else "本轮未产出回复（异常或客户端断连）",
+            )
             _busy_threads.discard(thread_id)
 
     return _events()

--- a/infra/bkn-agent/app/core/graph.py
+++ b/infra/bkn-agent/app/core/graph.py
@@ -242,6 +242,21 @@ async def stream_chat(
                                     tool_names=tool_names,
                                 )
                         _completed = True
+                        # 在 yield done 之前收尾，不能留给 finally。
+                        #
+                        # SSE 的 finally 挂在异步生成器的终结上：客户端收完就断，
+                        # 驱动生成器的任务被取消，生成器停在 yield 上，finally 要等
+                        # GC 触发 aclose 才跑——甚至可能不跑。VM 三轮实测的表现是
+                        # 第一轮开的交互一直 active，第二、三轮全被
+                        # interaction_in_progress 挡掉。跨服务状态的释放不能依赖
+                        # 生成器终结时机。close_session 是幂等的，finally 那次是兜底。
+                        _answer_now = (
+                            _final_answer if _final_answer is not None else "".join(answer_parts)
+                        )
+                        if _answer_now:
+                            await context_loader.close_session(
+                                cl_session, outcome="completed", answer=_answer_now
+                            )
                         yield _sse("done", {"thread_id": thread_id})
                     except TimeoutError:
                         yield _sse(

--- a/infra/bkn-agent/app/core/graph.py
+++ b/infra/bkn-agent/app/core/graph.py
@@ -72,9 +72,17 @@ async def stream_chat(
         # 与 runner 同序：Context Loader 会话先开，它领到的 interaction_id 同时是
         # 证据链这一轮的 id。load_tools 会复用这个已开的会话，不重复握手。
         cl_session = None
+        cl_token = None
         if context_loader.wanted(agent.tools):
-            cl_session = await context_loader.open_session(req.message, agent_name=agent.name)
-            context_loader.set_current(cl_session)
+            # thread_id 当会话锚：同一 thread 的多轮归进同一个 conversation
+            cl_session = await context_loader.open_session(
+                req.message, agent_name=agent.name, host_conversation_key=thread_id
+            )
+            if cl_session is not None:
+                # 只有真开出会话才置 ContextVar：置成 None 会让 tools.py 的
+                # `current_session() or await open_session()` 再握一次手，
+                # 那次的 interaction_id evidence 从来没见过。
+                cl_token = context_loader.set_current(cl_session)
         tools = await load_tools(
             agent.tools,
             account_id,
@@ -118,6 +126,11 @@ async def stream_chat(
 
     async def _events() -> AsyncIterator[str]:
         answer_parts: list[str] = []
+        # 收尾要报的终态。_completed 只在真正走到 done 时置位；结构化输出那条
+        # 路的答案不在 answer_parts 里，单独记进 _final_answer。
+        _completed = False
+        _final_answer: str | None = None
+        _failure_reason: str | None = "本轮未产出回复（异常或客户端断连）"
         tool_names: list[str] = []
         interaction_token = evidence.begin_interaction(
             req.message,
@@ -180,6 +193,7 @@ async def stream_chat(
                                     req.response_format,
                                     system_prompt,
                                 )
+                                _final_answer = json.dumps(obj, ensure_ascii=False)
                                 yield _sse("structured", {"content": obj})
                                 await _emit_chat_evidence(
                                     agent=agent,
@@ -208,6 +222,7 @@ async def stream_chat(
                                     structured_validation_path=None,
                                     tool_names=tool_names,
                                 )
+                        _completed = True
                         yield _sse("done", {"thread_id": thread_id})
                     except TimeoutError:
                         yield _sse(
@@ -227,16 +242,25 @@ async def stream_chat(
             yield _sse("error", {"code": "BknAgent.Chat.Failed", "detail": str(e)})
         finally:  # 正常结束、客户端断连（GeneratorExit）、异常，都要放位
             evidence.end_interaction(interaction_token)
-            # completed 必须带 answer（不带会被 closure_manifest_invalid 拒），
-            # 所以用累积到的回复；一个 token 都没产出就按 failed 收，别谎报完成。
-            _answer = "".join(answer_parts)
+            # 放位必须排在收尾的网络调用之前：close_session 只 catch Exception，
+            # 客户端断连时的 CancelledError（BaseException）与 MCP TaskGroup 抛的
+            # BaseExceptionGroup 都会穿透 finally，排在它后面的语句永远跑不到，
+            # 该 thread 就会一直卡在 409 Thread.Busy 直到进程重启。
+            _busy_threads.discard(thread_id)
+            if cl_token is not None:
+                context_loader.reset_current(cl_token)
+            # completed 必须带 answer（不带会被 closure_manifest_invalid 拒）。
+            # 用显式的成功标记而不是「答案非空」：结构化输出那条路走 structured
+            # 事件、answer_parts 是空的，按空判会把成功的一轮误报成 failed；
+            # 反过来流了一半再超时，答案非空却不是完成。
+            _answer = _final_answer if _final_answer is not None else "".join(answer_parts)
+            _ok = _completed and bool(_answer)
             await context_loader.close_session(
                 cl_session,
-                outcome="completed" if _answer else "failed",
-                answer=_answer or None,
-                reason=None if _answer else "本轮未产出回复（异常或客户端断连）",
+                outcome="completed" if _ok else "failed",
+                answer=_answer if _ok else None,
+                reason=None if _ok else _failure_reason,
             )
-            _busy_threads.discard(thread_id)
 
     return _events()
 

--- a/infra/bkn-agent/app/core/graph.py
+++ b/infra/bkn-agent/app/core/graph.py
@@ -54,7 +54,6 @@ async def stream_chat(
 
     # 在 try 之前绑定：setup 早期抛异常时 except 分支也要能安全引用
     cl_session = None
-    cl_token = None
 
     try:
         thread_row = await dao.get_thread_row(session, thread_id)
@@ -92,20 +91,23 @@ async def stream_chat(
                 # 复制出来的独立 context，token 跨 context 复位直接抛
                 # ValueError: Token was created in a different Context，
                 # 而且它抛在 finally 开头，把后面的兜底收尾一并废掉。
-                cl_token = context_loader.set_current(cl_session)
-        try:
-            tools = await load_tools(
-                agent.tools,
-                account_id,
-                account_type,
-                depth=0,
-                parent_thread_id=thread_id,
-                skill_ids=skill_ids,
-            )
-        finally:
-            if cl_token is not None:
-                context_loader.reset_current(cl_token)
-                cl_token = None
+                # 设了就不复位。
+                #
+                # 上一版把它收窄到只活过 load_tools，结果 agent-as-tool 的子 agent
+                # 在执行期 current_session() 恒为 None，带着零个 CL 工具作答，
+                # 而且不报错不告警。ContextVar 的作用域是整轮，不是装载那一段。
+                #
+                # 不复位是安全的：它活在这个请求自己的 context 里，随请求消亡；
+                # 而跨 context 复位（生成器 / aclose 任务）必抛 ValueError。
+                context_loader.set_current(cl_session)
+        tools = await load_tools(
+            agent.tools,
+            account_id,
+            account_type,
+            depth=0,
+            parent_thread_id=thread_id,
+            skill_ids=skill_ids,
+        )
         tools = instrument_tool_calls(tools, account_id, account_type)
         limits = agent.limits or None
         max_turns = (
@@ -283,15 +285,20 @@ async def stream_chat(
         ) as e:  # 组装阶段（checkpointer/graph 建立）异常也要送 error，不裸断流
             yield _sse("error", {"code": "BknAgent.Chat.Failed", "detail": str(e)})
         finally:  # 正常结束、客户端断连（GeneratorExit）、异常，都要放位
-            evidence.end_interaction(interaction_token)
-            # 放位必须排在收尾的网络调用之前：close_session 只 catch Exception，
-            # 客户端断连时的 CancelledError（BaseException）与 MCP TaskGroup 抛的
-            # BaseExceptionGroup 都会穿透 finally，排在它后面的语句永远跑不到，
-            # 该 thread 就会一直卡在 409 Thread.Busy 直到进程重启。
+            # 放位是 finally 的第一条，前面不许有任何会抛的语句。
+            #
+            # 排在它前面的每一条都是地雷：close_session 只 catch Exception，
+            # 挡不住断连的 CancelledError 与 MCP TaskGroup 的 BaseExceptionGroup；
+            # evidence.end_interaction 是 ContextVar 复位，而这段 finally 可能由
+            # GC 触发的 aclose 任务驱动——那是另一个 context，复位必抛 ValueError。
+            # 任何一个抛出来，thread 就永久停在 409 Thread.Busy 直到进程重启。
             _busy_threads.discard(thread_id)
-            # 这里不复位 ContextVar：本函数体跑在生成器自己的 context 里，
-            # 复位一个在 stream_chat 的 context 里创建的 token 会抛 ValueError，
-            # 且会顶掉后面的收尾。复位已在 load_tools 那段成对做完。
+            try:
+                evidence.end_interaction(interaction_token)
+            except ValueError as e:  # 跨 context 复位；证据链这一轮已经落完
+                logger.warning("[Chat] 证据链交互复位失败（跨 context）：%s", e)
+            # ContextVar 不在这里复位：本函数体可能跑在别的 context 里。
+            # 它随请求 context 消亡，不需要显式复位。
             # completed 必须带 answer（不带会被 closure_manifest_invalid 拒）。
             # 用显式的成功标记而不是「答案非空」：结构化输出那条路走 structured
             # 事件、answer_parts 是空的，按空判会把成功的一轮误报成 failed；

--- a/infra/bkn-agent/app/core/runner.py
+++ b/infra/bkn-agent/app/core/runner.py
@@ -52,7 +52,7 @@ async def run_agent_once(
     cl_session = None
     cl_token = None
     if context_loader.wanted(agent.tools):
-        cl_session = await context_loader.open_session()
+        cl_session = await context_loader.open_session(message, agent_name=agent.name)
         cl_token = context_loader.set_current(cl_session)
     token = evidence.begin_interaction(
         message,
@@ -78,7 +78,7 @@ async def run_agent_once(
         )
     finally:
         evidence.end_interaction(token)
-        await context_loader.close_session(cl_session)
+        await context_loader.close_session(cl_session, outcome="completed")
         if cl_token is not None:
             context_loader.reset_current(cl_token)
 

--- a/infra/bkn-agent/app/core/runner.py
+++ b/infra/bkn-agent/app/core/runner.py
@@ -62,9 +62,11 @@ async def run_agent_once(
         conversation_id=cl_session.conversation_id if cl_session else None,
         interaction_id=cl_session.interaction_id if cl_session else None,
     )
+    answer: str | None = None
+    failure: str | None = None
     try:
         await evidence.submit_interaction_started(account_id, account_type)
-        return await _run_agent_once_core(
+        answer = await _run_agent_once_core(
             agent,
             message,
             prompt_vars,
@@ -76,9 +78,20 @@ async def run_agent_once(
             response_format,
             task_id,
         )
+        return answer
+    except Exception as e:
+        failure = f"{type(e).__name__}: {e}"
+        raise
     finally:
         evidence.end_interaction(token)
-        await context_loader.close_session(cl_session, outcome="completed")
+        # outcome=completed 的时候 answer 是必填的（不带会被 closure_manifest_invalid
+        # 拒掉），所以本轮答案要一路带到这里，不能在 finally 里凭空补。
+        await context_loader.close_session(
+            cl_session,
+            outcome="completed" if answer is not None else "failed",
+            answer=answer,
+            reason=failure or (None if answer is not None else "本轮未产出回复"),
+        )
         if cl_token is not None:
             context_loader.reset_current(cl_token)
 

--- a/infra/bkn-agent/app/core/runner.py
+++ b/infra/bkn-agent/app/core/runner.py
@@ -52,6 +52,8 @@ async def run_agent_once(
     cl_session = None
     cl_token = None
     if context_loader.wanted(agent.tools):
+        # 不传 host_conversation_key：/run 与 /invoke 是一次性执行，每次本就该
+        # 各自成一个 conversation。多轮连续性只有 chat 有（graph.py 传 thread_id）。
         cl_session = await context_loader.open_session(message, agent_name=agent.name)
         cl_token = context_loader.set_current(cl_session)
     token = evidence.begin_interaction(

--- a/infra/bkn-agent/app/core/runner.py
+++ b/infra/bkn-agent/app/core/runner.py
@@ -7,6 +7,7 @@ from langchain_core.messages import AIMessage, ToolMessage
 
 from app import dao, evidence, observability
 from app.config import config
+from app.core import context_loader
 from app.core.llm import build_chat_model
 from app.core.structured import structured_extract_with_path
 from app.core.prompt import resolve_prompt
@@ -46,7 +47,21 @@ async def run_agent_once(
             response_format,
             task_id,
         )
-    token = evidence.begin_interaction(message, "task", agent.agent_id, "bkn.agent.task")
+    # Context Loader 的会话要在 begin_interaction 之前开：它领到的 interaction_id
+    # 同时是证据链这一轮的 id，两边共用一对，trace 才不会裂。
+    cl_session = None
+    cl_token = None
+    if context_loader.wanted(agent.tools):
+        cl_session = await context_loader.open_session()
+        cl_token = context_loader.set_current(cl_session)
+    token = evidence.begin_interaction(
+        message,
+        "task",
+        agent.agent_id,
+        "bkn.agent.task",
+        conversation_id=cl_session.conversation_id if cl_session else None,
+        interaction_id=cl_session.interaction_id if cl_session else None,
+    )
     try:
         await evidence.submit_interaction_started(account_id, account_type)
         return await _run_agent_once_core(
@@ -63,6 +78,9 @@ async def run_agent_once(
         )
     finally:
         evidence.end_interaction(token)
+        await context_loader.close_session(cl_session)
+        if cl_token is not None:
+            context_loader.reset_current(cl_token)
 
 
 async def _run_agent_once_core(

--- a/infra/bkn-agent/app/core/runner.py
+++ b/infra/bkn-agent/app/core/runner.py
@@ -35,18 +35,49 @@ async def run_agent_once(
     task_id: Optional[str] = None,
 ) -> str:
     if evidence.has_interaction():
-        return await _run_agent_once_core(
-            agent,
-            message,
-            prompt_vars,
-            skills,
-            prompt_override,
-            account_id,
-            account_type,
-            depth,
-            response_format,
-            task_id,
-        )
+        # 父轮已经开着交互——agent-as-tool 走的就是这条。证据链沿用父轮的 id，
+        # 但 Context Loader 会话不一定有：父 agent 没声明 context_loader 时，
+        # current_session() 是 None，子 agent 就会带着零个 CL 工具作答，
+        # 而且因为 open_session 根本没被调用，连那条 warning 都不会出现。
+        #
+        # 所以这里补一次「谁开谁关」：能继承就继承（不重复握手，也不去关别人
+        # 开的会话），继承不到又确实要用，就自己开、自己关。
+        inherited = context_loader.current_session()
+        own = None
+        own_token = None
+        if inherited is None and context_loader.wanted(agent.tools):
+            own = await context_loader.open_session(message, agent_name=agent.name)
+            if own is not None:
+                own_token = context_loader.set_current(own)
+        sub_answer: str | None = None
+        sub_failure: str | None = None
+        try:
+            sub_answer = await _run_agent_once_core(
+                agent,
+                message,
+                prompt_vars,
+                skills,
+                prompt_override,
+                account_id,
+                account_type,
+                depth,
+                response_format,
+                task_id,
+            )
+            return sub_answer
+        except Exception as e:
+            sub_failure = f"{type(e).__name__}: {e}"
+            raise
+        finally:
+            if own_token is not None:
+                context_loader.reset_current(own_token)
+            # 只关自己开的那个；继承来的归开它的人关
+            await context_loader.close_session(
+                own,
+                outcome="completed" if sub_answer is not None else "failed",
+                answer=sub_answer,
+                reason=sub_failure or (None if sub_answer is not None else "子 agent 未产出回复"),
+            )
     # Context Loader 的会话要在 begin_interaction 之前开：它领到的 interaction_id
     # 同时是证据链这一轮的 id，两边共用一对，trace 才不会裂。
     cl_session = None

--- a/infra/bkn-agent/app/core/tools.py
+++ b/infra/bkn-agent/app/core/tools.py
@@ -7,6 +7,7 @@ from langchain_mcp_adapters.client import MultiServerMCPClient
 
 from app import evidence, observability
 from app.config import config
+from app.core import context_loader
 from app.core.skills import normalize_skill_id
 from app.core.toolbox import _safe_name, load_toolbox_tools
 from app.errors import bad_request
@@ -36,8 +37,10 @@ def _mcp_connections(tool_refs: list[dict], account_id: str, account_type: str) 
                 "url": url,
                 "headers": headers,
             }
-        elif kind in ("agent", "toolbox"):
-            continue  # agent-as-tool 见 _agent_tool；toolbox 见 _toolbox_tools
+        elif kind in ("agent", "toolbox", "context_loader"):
+            # agent-as-tool 见 _agent_tool；toolbox 见 _toolbox_tools；
+            # context_loader 见 app/core/context_loader.py（端点来自配置，且要先握手）
+            continue
         else:
             raise bad_request("ToolRef", "未知工具类型", str(ref))
     return conns
@@ -182,6 +185,14 @@ async def load_tools(
     skill_ids: list[str] | None = None,
 ) -> list[Any]:
     tools: list[Any] = await _toolbox_tools(tool_refs, account_id, account_type)
+    if context_loader.wanted(tool_refs):
+        # 会话通常已由调用方（runner / graph）在 begin_interaction 之前开好——那对
+        # 真 id 要先拿到才能让证据链和 Context Loader 落在同一轮交互上。这里兜住
+        # 直接调 load_tools 的场景（测试、将来的其他入口），不重复握手。
+        session = context_loader.current_session() or await context_loader.open_session()
+        if session is not None:
+            context_loader.set_current(session)
+            tools.extend(session.tools())
     conns = _mcp_connections(tool_refs, account_id, account_type)
     if conns:
         client = MultiServerMCPClient(conns, tool_interceptors=[_trace_mcp_call])

--- a/infra/bkn-agent/app/core/tools.py
+++ b/infra/bkn-agent/app/core/tools.py
@@ -186,12 +186,19 @@ async def load_tools(
 ) -> list[Any]:
     tools: list[Any] = await _toolbox_tools(tool_refs, account_id, account_type)
     if context_loader.wanted(tool_refs):
-        # 会话通常已由调用方（runner / graph）在 begin_interaction 之前开好——那对
-        # 真 id 要先拿到才能让证据链和 Context Loader 落在同一轮交互上。这里兜住
-        # 直接调 load_tools 的场景（测试、将来的其他入口），不重复握手。
-        session = context_loader.current_session() or await context_loader.open_session()
+        # 只用调用方（runner / graph）已经开好的会话，这里绝不自己开。
+        #
+        # 原先这里是 `current_session() or await open_session()`，想兜住直接调
+        # load_tools 的场景。实测证明那是个泄漏源：主路握手失败时它会再开一个
+        # 交互，而 graph 的 finally 只关自己持有的 cl_session（此时是 None），
+        # 兜底开的那个永远关不掉。服务端一个 conversation 只允许一个 active
+        # 交互，于是每轮泄一个、下一轮必被 interaction_in_progress 挡掉，
+        # 一条 thread 从第二轮起就再也拿不到工具。
+        #
+        # 没开出会话就没有工具——open_session 已经打过 warning，失败留在看得见
+        # 的地方，比静默开一个关不掉的交互好。
+        session = context_loader.current_session()
         if session is not None:
-            context_loader.set_current(session)
             tools.extend(session.tools())
     conns = _mcp_connections(tool_refs, account_id, account_type)
     if conns:

--- a/infra/bkn-agent/app/evidence.py
+++ b/infra/bkn-agent/app/evidence.py
@@ -238,11 +238,22 @@ def begin_interaction(
     operation_name: str,
     *,
     conversation_id: str | None = None,
+    interaction_id: str | None = None,
 ):
+    """开一轮交互。
+
+    interaction_id 传入时用传入的，否则本地铸一个。传入的来源是 Context Loader
+    的 bkn_start_interaction —— 那条路上的 id 必须是生命周期服务发的（本地铸的会被
+    MCP 面按 owner tuple 拒掉），同时也让证据链与 Context Loader 落在同一轮交互上，
+    不至于一次对话在 trace 里裂成两条。
+
+    没挂 Context Loader 工具的 agent 仍走本地铸：为了拿一个服务端 id 就让每次执行
+    都依赖生命周期服务，会把一个可选能力变成硬依赖。
+    """
     ctx = observability.current_context()
     if not ctx:
         return _interaction.set(None)
-    interaction_id = "int_" + _stable_id(
+    interaction_id = interaction_id or "int_" + _stable_id(
         "interaction", ctx.trace_id, ctx.request_id, mode, agent_id, operation_name
     )
     started = _event(

--- a/infra/bkn-agent/app/main.py
+++ b/infra/bkn-agent/app/main.py
@@ -8,7 +8,7 @@ from fastapi.responses import JSONResponse
 from starlette.exceptions import HTTPException as StarletteHTTPException
 
 from app.models import ErrorEnvelope
-from app import evidence, observability
+from app import auth, evidence, observability
 from app.observability import setup_otel
 from app.routers import agents, chat, impex, prompts, tasks, threads
 
@@ -61,9 +61,15 @@ async def bkn_trace_context_middleware(request: Request, call_next):
     ctx = observability.build_context(request.headers)
     request.state.bkn_trace_context = ctx
     token = observability.set_context(ctx)
+    # 令牌在这里收，不在 get_account 里收：FastAPI 把 **同步** 依赖丢进线程池跑，
+    # 在那里 set 的 ContextVar 回不到请求协程，caller_token() 永远是 None
+    # （VM 实测踩到：工具没挂，模型改口编了个工具调用当答案）。中间件与端点同
+    # 上下文链，这里 set 才可见。顺带覆盖不走 get_account 的路由。
+    auth_token = auth.set_caller_token(request.headers.get("authorization"))
     try:
         response = await call_next(request)
     finally:
+        auth.reset_caller_token(auth_token)
         observability.reset_context(token)
     for key, value in {
         observability.TRACE_ID_HEADER: ctx.trace_id,

--- a/infra/bkn-agent/app/models.py
+++ b/infra/bkn-agent/app/models.py
@@ -117,8 +117,19 @@ class AgentToolRef(_ToolRefBase):
     agent_id: str = Field(min_length=1, max_length=100)
 
 
+class ContextLoaderToolRef(_ToolRefBase):
+    """Context Loader 的知识网络检索工具，经其 MCP 面装载。
+
+    刻意不带 url：端点来自 CONTEXT_LOADER_MCP_URL，agent 定义因此可以跨环境
+    导入导出而不带环境地址（type=mcp 写死 url 就不行）。
+    """
+
+    type: Literal["context_loader"]
+
+
 ToolRef = Annotated[
-    McpToolRef | ToolboxToolRef | AgentToolRef, Field(discriminator="type")
+    McpToolRef | ToolboxToolRef | AgentToolRef | ContextLoaderToolRef,
+    Field(discriminator="type"),
 ]
 
 

--- a/infra/bkn-agent/app/test/test_context_loader.py
+++ b/infra/bkn-agent/app/test/test_context_loader.py
@@ -322,3 +322,36 @@ async def _async_str():
 
 async def _async_prompt():
     return ("prompt", "src", "v1")
+
+
+def test_load_tools_never_opens_its_own_session(monkeypatch):
+    """load_tools 绝不自己握手。
+
+    原先是 `current_session() or await open_session()`。主路握手失败时它会再开
+    一个交互，而 graph 的 finally 只关自己持有的 cl_session（那时是 None），
+    兜底开的那个永远关不掉。服务端一个 conversation 只允许一个 active 交互，
+    于是每轮泄一个，下一轮必被 interaction_in_progress 挡掉。
+    """
+    from app.core import tools as tools_mod
+
+    opened = []
+
+    async def spy_open(*_a, **_k):
+        opened.append(1)
+        return context_loader.ContextLoaderSession("c", "i")
+
+    monkeypatch.setattr(tools_mod.context_loader, "open_session", spy_open)
+    monkeypatch.setattr(tools_mod.context_loader, "current_session", lambda: None)
+    monkeypatch.setattr(tools_mod.context_loader, "wanted", lambda _refs: True)
+
+    async def no_toolbox(*_a, **_k):
+        return []
+
+    monkeypatch.setattr(tools_mod, "_toolbox_tools", no_toolbox)
+
+    result = asyncio.run(
+        tools_mod.load_tools([{"type": "context_loader"}], "acct", "user")
+    )
+
+    assert opened == [], "load_tools 自己开了会话——那个交互没人关，会挡住下一轮"
+    assert result == []

--- a/infra/bkn-agent/app/test/test_context_loader.py
+++ b/infra/bkn-agent/app/test/test_context_loader.py
@@ -1,0 +1,140 @@
+"""Context Loader MCP 装载（ToolRef type=context_loader）。
+
+守的是三件不能回退的事：
+1. bkn_context 由运行时注入，不进模型可见的参数表（模型编不出合法 id）
+2. 凭据优先调用方透传，AppKey 只是兜底；两个都没有就不挂工具，且不静默
+3. 生命周期工具不暴露给模型
+"""
+import asyncio
+
+import pytest
+
+from app import auth
+from app.config import config
+from app.core import context_loader
+
+
+class _FakeTool:
+    def __init__(self, name, args_schema=None, result=None):
+        self.name = name
+        self.description = f"desc {name}"
+        self.args_schema = args_schema if args_schema is not None else {
+            "type": "object",
+            "properties": {"kn_id": {"type": "string"}, "bkn_context": {"type": "object"}},
+            "required": ["kn_id", "bkn_context"],
+        }
+        self.metadata = {}
+        self._result = result
+        self.calls = []
+
+    async def coroutine(self, **kwargs):
+        self.calls.append(kwargs)
+        return self._result
+
+
+def _start_tool():
+    return _FakeTool(
+        "bkn_start_interaction",
+        args_schema={"type": "object", "properties": {}},
+        result={"conversation_id": "conv_real", "interaction_id": "int_real"},
+    )
+
+
+def _install(monkeypatch, tools):
+    class _Client:
+        async def get_tools(self):
+            return tools
+
+    monkeypatch.setattr(context_loader, "_client", lambda _auth: _Client())
+
+
+def test_no_credential_skips_and_warns(monkeypatch, caplog):
+    monkeypatch.setattr(config, "CONTEXT_LOADER_APPKEY", "")
+    token = auth.set_caller_token(None)
+    try:
+        with caplog.at_level("WARNING"):
+            assert asyncio.run(context_loader.open_session()) is None
+        assert "无可用凭据" in caplog.text  # 不静默
+    finally:
+        auth._caller_token.reset(token)
+
+
+def test_caller_token_preferred_over_appkey(monkeypatch):
+    monkeypatch.setattr(config, "CONTEXT_LOADER_APPKEY", "bak_service")
+    token = auth.set_caller_token("Bearer user-token")
+    try:
+        assert context_loader._credential() == ("Bearer user-token", "caller")
+    finally:
+        auth._caller_token.reset(token)
+
+
+def test_appkey_is_fallback_only(monkeypatch):
+    monkeypatch.setattr(config, "CONTEXT_LOADER_APPKEY", "bak_service")
+    token = auth.set_caller_token(None)
+    try:
+        assert context_loader._credential() == ("Bearer bak_service", "service_appkey")
+    finally:
+        auth._caller_token.reset(token)
+
+
+def test_session_injects_bkn_context_and_hides_it(monkeypatch):
+    business = _FakeTool("search_schema", result="ok")
+    _install(monkeypatch, [_start_tool(), _FakeTool("bkn_finish_interaction"), business])
+    token = auth.set_caller_token("Bearer t")
+    try:
+        session = asyncio.run(context_loader.open_session())
+    finally:
+        auth._caller_token.reset(token)
+
+    assert session is not None
+    assert session.conversation_id == "conv_real"
+    assert session.interaction_id == "int_real"
+
+    # 生命周期工具不给模型
+    names = [t.name for t in session.tools()]
+    assert names == ["search_schema"]
+
+    # bkn_context 已从模型可见的入参表里摘掉
+    assert "bkn_context" not in business.args_schema["properties"]
+    assert "bkn_context" not in business.args_schema["required"]
+
+    # 但调用时会被补上
+    asyncio.run(session.tools()[0].coroutine(kn_id="kn-1"))
+    assert business.calls == [
+        {"kn_id": "kn-1", "bkn_context": {"conversation_id": "conv_real", "interaction_id": "int_real"}}
+    ]
+
+
+def test_start_interaction_failure_skips_tools(monkeypatch):
+    class _Boom(_FakeTool):
+        async def coroutine(self, **kwargs):
+            raise RuntimeError("resource_not_disclosed")
+
+    _install(monkeypatch, [_Boom("bkn_start_interaction"), _FakeTool("search_schema")])
+    token = auth.set_caller_token("Bearer t")
+    try:
+        assert asyncio.run(context_loader.open_session()) is None
+    finally:
+        auth._caller_token.reset(token)
+
+
+@pytest.mark.parametrize(
+    "raw",
+    [
+        {"conversation_id": "c", "interaction_id": "i"},
+        '{"conversation_id":"c","interaction_id":"i"}',
+        ['{"conversation_id":"c","interaction_id":"i"}'],
+    ],
+)
+def test_parse_ids_accepts_dict_text_and_list(raw):
+    assert context_loader._parse_ids(raw) == ("c", "i")
+
+
+@pytest.mark.parametrize("raw", [None, "not json", {}, {"conversation_id": "c"}, []])
+def test_parse_ids_rejects_garbage(raw):
+    assert context_loader._parse_ids(raw) is None
+
+
+def test_wanted_detects_ref():
+    assert context_loader.wanted([{"type": "context_loader"}])
+    assert not context_loader.wanted([{"type": "toolbox", "box_id": "b"}])

--- a/infra/bkn-agent/app/test/test_context_loader.py
+++ b/infra/bkn-agent/app/test/test_context_loader.py
@@ -36,7 +36,17 @@ def _start_tool():
     return _FakeTool(
         "bkn_start_interaction",
         args_schema={"type": "object", "properties": {}},
-        result={"conversation_id": "conv_real", "interaction_id": "int_real"},
+        # VM 实测形状：(content_blocks, {"structured_content": {...}})
+        result=(
+            [{"type": "text",
+              "text": '{"conversation_id":"conv_real","execution_status":"active",'
+                      '"interaction_id":"int_real"}',
+              "id": "lc_1"}],
+            {"structured_content": {
+                "conversation_id": "conv_real",
+                "execution_status": "active",
+                "interaction_id": "int_real"}},
+        ),
     )
 
 
@@ -118,19 +128,29 @@ def test_start_interaction_failure_skips_tools(monkeypatch):
         auth._caller_token.reset(token)
 
 
-@pytest.mark.parametrize(
-    "raw",
-    [
-        {"conversation_id": "c", "interaction_id": "i"},
-        '{"conversation_id":"c","interaction_id":"i"}',
-        ['{"conversation_id":"c","interaction_id":"i"}'],
-    ],
-)
-def test_parse_ids_accepts_dict_text_and_list(raw):
+@pytest.mark.parametrize("raw", [
+    # 裸 dict
+    {"conversation_id": "c", "interaction_id": "i"},
+    # JSON 串
+    '{"conversation_id":"c","interaction_id":"i"}',
+    # VM 实测：(content_blocks, artifact)，id 在 structured_content 里
+    ([{"type": "text", "text": '{"conversation_id":"c","interaction_id":"i"}'}],
+     {"structured_content": {"conversation_id": "c", "interaction_id": "i"}}),
+    # 同上但只有文本块，没有 structured_content —— 退回解析 text
+    ([{"type": "text", "text": '{"conversation_id":"c","interaction_id":"i"}'}], {}),
+    # camelCase 的 structuredContent
+    ([], {"structuredContent": {"conversation_id": "c", "interaction_id": "i"}}),
+])
+def test_parse_ids_accepts_real_and_simple_shapes(raw):
     assert context_loader._parse_ids(raw) == ("c", "i")
 
 
-@pytest.mark.parametrize("raw", [None, "not json", {}, {"conversation_id": "c"}, []])
+@pytest.mark.parametrize("raw", [
+    None, "", "not json", 123, [], {},
+    {"conversation_id": "c"},                      # 缺一半
+    {"conversation_id": "", "interaction_id": "i"},  # 空串不算
+    ([{"type": "text", "text": "plain text"}], {}),
+])
 def test_parse_ids_rejects_garbage(raw):
     assert context_loader._parse_ids(raw) is None
 

--- a/infra/bkn-agent/app/test/test_context_loader.py
+++ b/infra/bkn-agent/app/test/test_context_loader.py
@@ -399,3 +399,44 @@ def test_contextvar_token_reset_in_same_context():
     # 同一 context 内复位则正常
     context_loader.reset_current(token)
     assert context_loader.current_session() is None
+
+
+def test_session_stays_visible_after_load_tools():
+    """会话必须活过整轮，不能只活到 load_tools 结束。
+
+    agent-as-tool 的子 agent 在执行期才调 load_tools，靠 current_session() 拿
+    父会话。上一版把 ContextVar 收窄到装载那一段，子 agent 于是带着零个 CL 工具
+    作答——不报错、不告警。
+    """
+    sess = context_loader.ContextLoaderSession("c", "i")
+    context_loader.set_current(sess)
+    try:
+        # 装载早已结束；执行期（子 agent）仍要看得见
+        assert context_loader.current_session() is sess
+    finally:
+        context_loader.set_current(None)
+
+
+def test_busy_release_is_first_in_sse_finally():
+    """放位必须是 SSE finally 的第一条语句，前面不许有会抛的调用。
+
+    这条守的是模式而不是某一行：排在放位前面的每一条都可能把 thread 永久留在
+    409——close_session 挡不住断连的 CancelledError，evidence.end_interaction 是
+    ContextVar 复位、由 aclose 任务驱动时跨 context 必抛。两者都真的踩过。
+
+    源码级断言是刻意的：这个失效只在客户端中途断连时发生，单测跑不出来。
+    """
+    import inspect
+    import re
+
+    from app.core import graph
+
+    src = inspect.getsource(graph.stream_chat)
+    # 取最后一个 finally 块（_events 的那个）
+    tail = src[src.rindex("finally:"):]
+    body = [ln.strip() for ln in tail.splitlines()[1:] if ln.strip() and not ln.strip().startswith("#")]
+    assert body, "没解析到 finally 块"
+    assert re.match(r"_busy_threads\.discard", body[0]), (
+        f"finally 的第一条不是放位，而是：{body[0]}\n"
+        "排在放位前面的任何抛出都会让该 thread 永久停在 409"
+    )

--- a/infra/bkn-agent/app/test/test_context_loader.py
+++ b/infra/bkn-agent/app/test/test_context_loader.py
@@ -138,3 +138,43 @@ def test_parse_ids_rejects_garbage(raw):
 def test_wanted_detects_ref():
     assert context_loader.wanted([{"type": "context_loader"}])
     assert not context_loader.wanted([{"type": "toolbox", "box_id": "b"}])
+
+
+def test_caller_token_visible_inside_request_handler():
+    """回归：令牌必须在请求协程里读得到。
+
+    原先在 get_account（同步依赖）里 set，FastAPI 把同步依赖丢进线程池执行，
+    ContextVar 传不回请求协程，caller_token() 恒为 None —— VM 实测的表现是
+    CL 工具静默不挂、模型改口编了个工具调用当答案。改由中间件 set。
+    """
+    from fastapi.testclient import TestClient
+
+    from app.main import app as real_app
+
+    seen = {}
+
+    @real_app.get("/__probe_caller_token")
+    def _probe():
+        seen["token"] = auth.caller_token()
+        return {"ok": True}
+
+    client = TestClient(real_app)
+    client.get("/__probe_caller_token", headers={"Authorization": "Bearer probe-token"})
+    assert seen["token"] == "Bearer probe-token"
+
+
+def test_caller_token_absent_when_header_missing():
+    from fastapi.testclient import TestClient
+
+    from app.main import app as real_app
+
+    seen = {}
+
+    @real_app.get("/__probe_caller_token_absent")
+    def _probe():
+        seen["token"] = auth.caller_token()
+        return {"ok": True}
+
+    client = TestClient(real_app)
+    client.get("/__probe_caller_token_absent")
+    assert seen["token"] is None

--- a/infra/bkn-agent/app/test/test_context_loader.py
+++ b/infra/bkn-agent/app/test/test_context_loader.py
@@ -2,7 +2,7 @@
 
 守的是三件不能回退的事：
 1. bkn_context 由运行时注入，不进模型可见的参数表（模型编不出合法 id）
-2. 凭据优先调用方透传，AppKey 只是兜底；两个都没有就不挂工具，且不静默
+2. 凭据只认调用方透传的令牌；没有就不挂工具，且不静默（无服务凭据兜底）
 3. 生命周期工具不暴露给模型
 """
 import asyncio
@@ -10,7 +10,6 @@ import asyncio
 import pytest
 
 from app import auth
-from app.config import config
 from app.core import context_loader
 
 
@@ -59,30 +58,11 @@ def _install(monkeypatch, tools):
 
 
 def test_no_credential_skips_and_warns(monkeypatch, caplog):
-    monkeypatch.setattr(config, "CONTEXT_LOADER_APPKEY", "")
     token = auth.set_caller_token(None)
     try:
         with caplog.at_level("WARNING"):
             assert asyncio.run(context_loader.open_session()) is None
-        assert "无可用凭据" in caplog.text  # 不静默
-    finally:
-        auth._caller_token.reset(token)
-
-
-def test_caller_token_preferred_over_appkey(monkeypatch):
-    monkeypatch.setattr(config, "CONTEXT_LOADER_APPKEY", "bak_service")
-    token = auth.set_caller_token("Bearer user-token")
-    try:
-        assert context_loader._credential() == ("Bearer user-token", "caller")
-    finally:
-        auth._caller_token.reset(token)
-
-
-def test_appkey_is_fallback_only(monkeypatch):
-    monkeypatch.setattr(config, "CONTEXT_LOADER_APPKEY", "bak_service")
-    token = auth.set_caller_token(None)
-    try:
-        assert context_loader._credential() == ("Bearer bak_service", "service_appkey")
+        assert "未透传 Authorization" in caplog.text  # 不静默
     finally:
         auth._caller_token.reset(token)
 

--- a/infra/bkn-agent/app/test/test_context_loader.py
+++ b/infra/bkn-agent/app/test/test_context_loader.py
@@ -54,7 +54,7 @@ def _install(monkeypatch, tools):
         async def get_tools(self):
             return tools
 
-    monkeypatch.setattr(context_loader, "_client", lambda _auth: _Client())
+    monkeypatch.setattr(context_loader, "_client", lambda *_a, **_k: _Client())
 
 
 def test_no_credential_skips_and_warns(monkeypatch, caplog):
@@ -189,3 +189,66 @@ def test_caller_token_absent_when_header_missing():
 
     TestClient(probe).get("/t")
     assert seen["token"] is None
+
+
+class _FinishTool:
+    def __init__(self):
+        self.calls = []
+
+    async def coroutine(self, **kwargs):
+        self.calls.append(kwargs)
+        return {"execution_status": "completed"}
+
+
+def _session_with_finish():
+    s = context_loader.ContextLoaderSession("conv_x", "int_x")
+    fin = _FinishTool()
+    s._finish = fin
+    return s, fin
+
+
+def test_close_sends_interaction_id_not_bkn_context():
+    """服务端要平铺的 interaction_id；包进 bkn_context 会被 resource_not_disclosed 拒。"""
+    s, fin = _session_with_finish()
+    asyncio.run(context_loader.close_session(s, outcome="completed", answer="a"))
+    assert fin.calls[0]["interaction_id"] == "int_x"
+    assert "bkn_context" not in fin.calls[0]
+
+
+def test_close_completed_always_carries_answer():
+    """outcome=completed 不带 answer 会被 closure_manifest_invalid 拒。"""
+    s, fin = _session_with_finish()
+    asyncio.run(context_loader.close_session(s, outcome="completed", answer="hello"))
+    assert fin.calls[0]["outcome"] == "completed"
+    assert fin.calls[0]["answer"] == "hello"
+
+
+@pytest.mark.parametrize("bad", ["succeeded", "ok", "", None, "COMPLETED"])
+def test_close_clamps_outcome_to_enum(bad):
+    """枚举只有 completed/failed/cancelled/handed_off，别的一律夹回 completed。"""
+    s, fin = _session_with_finish()
+    asyncio.run(context_loader.close_session(s, outcome=bad, answer="a"))
+    assert fin.calls[0]["outcome"] in context_loader._OUTCOMES
+
+
+def test_close_failed_carries_reason_and_no_answer():
+    s, fin = _session_with_finish()
+    asyncio.run(context_loader.close_session(s, outcome="failed", reason="没产出"))
+    assert fin.calls[0]["outcome"] == "failed"
+    assert fin.calls[0]["reason"] == "没产出"
+    assert "answer" not in fin.calls[0]
+
+
+def test_close_failure_is_warned_not_raised():
+    """收尾失败不该把已经跑完的一轮翻成失败。"""
+    s, fin = _session_with_finish()
+
+    async def boom(**_):
+        raise RuntimeError("resource_not_disclosed")
+
+    fin.coroutine = boom
+    asyncio.run(context_loader.close_session(s, outcome="completed", answer="a"))
+
+
+def test_close_on_none_session_is_noop():
+    asyncio.run(context_loader.close_session(None, outcome="completed", answer="a"))

--- a/infra/bkn-agent/app/test/test_context_loader.py
+++ b/infra/bkn-agent/app/test/test_context_loader.py
@@ -140,6 +140,21 @@ def test_wanted_detects_ref():
     assert not context_loader.wanted([{"type": "toolbox", "box_id": "b"}])
 
 
+def _probe_app():
+    """装同一条中间件的一次性 app。
+
+    不往 app.main 的真 app 上挂路由——那会漏进 openapi()，把契约冻结测试撞红
+    （已经撞过一次）。
+    """
+    from fastapi import FastAPI
+
+    from app.main import bkn_trace_context_middleware
+
+    probe = FastAPI()
+    probe.middleware("http")(bkn_trace_context_middleware)
+    return probe
+
+
 def test_caller_token_visible_inside_request_handler():
     """回归：令牌必须在请求协程里读得到。
 
@@ -149,32 +164,28 @@ def test_caller_token_visible_inside_request_handler():
     """
     from fastapi.testclient import TestClient
 
-    from app.main import app as real_app
-
     seen = {}
+    probe = _probe_app()
 
-    @real_app.get("/__probe_caller_token")
-    def _probe():
+    @probe.get("/t")
+    def _t():
         seen["token"] = auth.caller_token()
         return {"ok": True}
 
-    client = TestClient(real_app)
-    client.get("/__probe_caller_token", headers={"Authorization": "Bearer probe-token"})
+    TestClient(probe).get("/t", headers={"Authorization": "Bearer probe-token"})
     assert seen["token"] == "Bearer probe-token"
 
 
 def test_caller_token_absent_when_header_missing():
     from fastapi.testclient import TestClient
 
-    from app.main import app as real_app
-
     seen = {}
+    probe = _probe_app()
 
-    @real_app.get("/__probe_caller_token_absent")
-    def _probe():
+    @probe.get("/t")
+    def _t():
         seen["token"] = auth.caller_token()
         return {"ok": True}
 
-    client = TestClient(real_app)
-    client.get("/__probe_caller_token_absent")
+    TestClient(probe).get("/t")
     assert seen["token"] is None

--- a/infra/bkn-agent/app/test/test_context_loader.py
+++ b/infra/bkn-agent/app/test/test_context_loader.py
@@ -440,3 +440,95 @@ def test_busy_release_is_first_in_sse_finally():
         f"finally 的第一条不是放位，而是：{body[0]}\n"
         "排在放位前面的任何抛出都会让该 thread 永久停在 409"
     )
+
+
+def test_sub_agent_opens_and_closes_its_own_session(monkeypatch):
+    """agent-as-tool：父轮已开交互时，子 agent 也要拿得到 CL 会话。
+
+    run_agent_once 在 has_interaction() 为真时直接短路进 core，从不调
+    open_session。父 agent 没声明 context_loader 时 current_session() 是 None，
+    子 agent 于是带着零个 CL 工具作答——而且 open_session 没被调用过，
+    连 warning 都没有，日志里什么都看不到。
+
+    继承得到就不重复握手、也不去关别人开的会话；继承不到才自己开、自己关。
+    """
+    from app.core import runner as runner_mod
+
+    opened, closed = [], []
+    sess = context_loader.ContextLoaderSession("c-sub", "i-sub")
+
+    async def fake_open(*_a, **_k):
+        opened.append(1)
+        return sess
+
+    async def fake_close(s, **kw):
+        closed.append((s, kw))
+
+    async def fake_core(*_a, **_k):
+        assert context_loader.current_session() is sess, "子 agent 执行期看不到会话"
+        return "子 agent 的回答"
+
+    monkeypatch.setattr(runner_mod.evidence, "has_interaction", lambda: True)
+    monkeypatch.setattr(runner_mod.context_loader, "open_session", fake_open)
+    monkeypatch.setattr(runner_mod.context_loader, "close_session", fake_close)
+    monkeypatch.setattr(runner_mod, "_run_agent_once_core", fake_core)
+
+    class _Sub:
+        agent_id = "b"
+        name = "b"
+        tools = [{"type": "context_loader"}]
+        skills: list = []
+        limits = None
+        model = ""
+
+    out = asyncio.run(
+        runner_mod.run_agent_once(_Sub(), "问题", {}, [], None, "acct", "user", 1)
+    )
+
+    assert out == "子 agent 的回答"
+    assert opened == [1], "子 agent 没拿到会话——它会静默少掉全部检索工具"
+    assert closed and closed[0][0] is sess, "自己开的会话必须自己关"
+    assert closed[0][1]["outcome"] == "completed"
+    assert context_loader.current_session() is None, "ContextVar 没复位"
+
+
+def test_sub_agent_does_not_close_inherited_session(monkeypatch):
+    """继承来的会话归开它的人关，子 agent 不许代关。"""
+    from app.core import runner as runner_mod
+
+    parent = context_loader.ContextLoaderSession("c-p", "i-p")
+    opened, closed = [], []
+
+    async def fake_open(*_a, **_k):
+        opened.append(1)
+        return context_loader.ContextLoaderSession("c-x", "i-x")
+
+    async def fake_close(s, **kw):
+        closed.append(s)
+
+    async def fake_core(*_a, **_k):
+        return "ok"
+
+    monkeypatch.setattr(runner_mod.evidence, "has_interaction", lambda: True)
+    monkeypatch.setattr(runner_mod.context_loader, "open_session", fake_open)
+    monkeypatch.setattr(runner_mod.context_loader, "close_session", fake_close)
+    monkeypatch.setattr(runner_mod, "_run_agent_once_core", fake_core)
+
+    class _Sub:
+        agent_id = "b"
+        name = "b"
+        tools = [{"type": "context_loader"}]
+        skills: list = []
+        limits = None
+        model = ""
+
+    token = context_loader.set_current(parent)
+    try:
+        asyncio.run(
+            runner_mod.run_agent_once(_Sub(), "问题", {}, [], None, "acct", "user", 1)
+        )
+    finally:
+        context_loader.reset_current(token)
+
+    assert opened == [], "继承得到会话还去重复握手"
+    assert all(s is not parent for s in closed), "把继承来的会话关掉了"

--- a/infra/bkn-agent/app/test/test_context_loader.py
+++ b/infra/bkn-agent/app/test/test_context_loader.py
@@ -355,3 +355,16 @@ def test_load_tools_never_opens_its_own_session(monkeypatch):
 
     assert opened == [], "load_tools 自己开了会话——那个交互没人关，会挡住下一轮"
     assert result == []
+
+
+def test_close_session_is_idempotent():
+    """正常路径提前关一次、finally 再兜一次，第二次必须是 no-op。
+
+    不幂等的话第二次会打到服务端，拿一个已经 completed 的交互再 finish，
+    白落一条告警。
+    """
+    s, fin = _session_with_finish()
+    asyncio.run(context_loader.close_session(s, outcome="completed", answer="a"))
+    asyncio.run(context_loader.close_session(s, outcome="completed", answer="a"))
+    assert len(fin.calls) == 1
+    assert s.closed is True

--- a/infra/bkn-agent/app/test/test_context_loader.py
+++ b/infra/bkn-agent/app/test/test_context_loader.py
@@ -252,3 +252,73 @@ def test_close_failure_is_warned_not_raised():
 
 def test_close_on_none_session_is_noop():
     asyncio.run(context_loader.close_session(None, outcome="completed", answer="a"))
+
+
+def test_setup_failure_still_finishes_interaction(monkeypatch):
+    """setup 阶段抛异常时，已握手的交互必须被收尾。
+
+    _events() 在 stream_chat 抛异常时根本没被构造，它的 finally 永远不跑。
+    握手若已成功，那次交互会永久停在 active，且每次重试再泄一个。
+    """
+    from app.core import graph
+
+    closed = []
+
+    async def fake_close(session, **kw):
+        closed.append((session, kw))
+
+    fake_session = context_loader.ContextLoaderSession("conv_s", "int_s")
+
+    async def fake_open(*_a, **_k):
+        return fake_session
+
+    monkeypatch.setattr(graph.context_loader, "open_session", fake_open)
+    monkeypatch.setattr(graph.context_loader, "close_session", fake_close)
+    monkeypatch.setattr(graph.context_loader, "wanted", lambda _refs: True)
+
+    async def boom(*_a, **_k):
+        raise RuntimeError("toolbox 解析不了")
+
+    monkeypatch.setattr(graph, "load_tools", boom)
+    monkeypatch.setattr(graph, "load_skills", lambda *_a, **_k: _async_str())
+    monkeypatch.setattr(graph, "resolve_prompt", lambda *_a, **_k: _async_prompt())
+
+    class _Dao:
+        async def get_thread_row(self, *_a, **_k):
+            return None
+
+        async def touch_thread(self, *_a, **_k):
+            return None
+
+    monkeypatch.setattr(graph, "dao", _Dao())
+
+    class _Req:
+        thread_id = "thread-setup-fail"
+        message = "hi"
+        skills: list = []
+        prompt_override = None
+        prompt_vars: dict = {}
+        response_format = None
+
+    class _Agent:
+        agent_id = "a"
+        name = "a"
+        tools = [{"type": "context_loader"}]
+        skills: list = []
+        limits = None
+        model = ""
+
+    with pytest.raises(RuntimeError):
+        asyncio.run(graph.stream_chat(None, _Agent(), _Req(), "acct", "user"))
+
+    assert closed, "setup 失败后必须调 close_session，否则交互永久 active"
+    assert closed[0][1]["outcome"] == "failed"
+    assert "thread-setup-fail" not in graph._busy_threads
+
+
+async def _async_str():
+    return ""
+
+
+async def _async_prompt():
+    return ("prompt", "src", "v1")

--- a/infra/bkn-agent/app/test/test_context_loader.py
+++ b/infra/bkn-agent/app/test/test_context_loader.py
@@ -368,3 +368,34 @@ def test_close_session_is_idempotent():
     asyncio.run(context_loader.close_session(s, outcome="completed", answer="a"))
     assert len(fin.calls) == 1
     assert s.closed is True
+
+
+def test_contextvar_token_reset_in_same_context():
+    """ContextVar 的 set/reset 必须成对出现在同一个 context。
+
+    早先是在 stream_chat 里 set、在 _events() 这个异步生成器的 finally 里 reset。
+    生成器跑在复制出来的独立 context，跨 context 复位直接抛
+    ValueError: Token was created in a different Context，而且它抛在 finally
+    开头，把后面的兜底收尾一并废掉——VM 上每个 /chat 请求都在刷这条 ASGI 异常。
+    """
+    import contextvars
+
+    sess = context_loader.ContextLoaderSession("c", "i")
+    token = context_loader.set_current(sess)
+    assert context_loader.current_session() is sess
+
+    def _in_copied_context():
+        # 生成器/任务拿到的是 context 的副本：读得到，但复位会炸
+        assert context_loader.current_session() is sess
+        try:
+            context_loader.reset_current(token)
+        except ValueError as e:
+            return str(e)
+        return None
+
+    err = contextvars.copy_context().run(_in_copied_context)
+    assert err is not None and "different Context" in err
+
+    # 同一 context 内复位则正常
+    context_loader.reset_current(token)
+    assert context_loader.current_session() is None

--- a/infra/bkn-agent/charts/templates/deployment.yaml
+++ b/infra/bkn-agent/charts/templates/deployment.yaml
@@ -72,6 +72,10 @@ spec:
               value: {{ .Values.runtime.mfModelApiPrivateBase | quote }}
             - name: OPERATOR_INTEGRATION_BASE
               value: {{ .Values.runtime.operatorIntegrationBase | quote }}
+            - name: CONTEXT_LOADER_MCP_URL
+              value: {{ .Values.runtime.contextLoaderMcpUrl | quote }}
+            - name: CONTEXT_LOADER_APPKEY
+              value: {{ .Values.runtime.contextLoaderAppKey | quote }}
             - name: BKN_AGENT_DEFAULT_MODEL
               value: {{ .Values.runtime.defaultModel | quote }}
             - name: CHECKPOINTER_BACKEND

--- a/infra/bkn-agent/charts/templates/deployment.yaml
+++ b/infra/bkn-agent/charts/templates/deployment.yaml
@@ -74,8 +74,6 @@ spec:
               value: {{ .Values.runtime.operatorIntegrationBase | quote }}
             - name: CONTEXT_LOADER_MCP_URL
               value: {{ .Values.runtime.contextLoaderMcpUrl | quote }}
-            - name: CONTEXT_LOADER_APPKEY
-              value: {{ .Values.runtime.contextLoaderAppKey | quote }}
             - name: BKN_AGENT_DEFAULT_MODEL
               value: {{ .Values.runtime.defaultModel | quote }}
             - name: CHECKPOINTER_BACKEND

--- a/infra/bkn-agent/charts/values.yaml
+++ b/infra/bkn-agent/charts/values.yaml
@@ -41,10 +41,6 @@ runtime:
   # Context Loader 的 MCP 面（ToolRef type=context_loader 由此装载）。这是公开面：
   # 它挂 introspect，只认真实令牌，不吃 /in 的头部身份。
   contextLoaderMcpUrl: "http://agent-retrieval:30779/api/agent-retrieval/v1/mcp/"
-  # 兜底服务凭据（bak_ AppKey），仅在调用方没透传 Authorization 时启用。
-  # ⚠️ 一旦启用，Context Loader 看到的是该 AppKey 的签发人而非真实调用者，
-  # per-user 授权在这次调用上塌缩。默认留空 = 无兜底，无令牌时不挂 CL 工具。
-  contextLoaderAppKey: ""
   defaultModel: ""
   checkpointerBackend: "mysql"
   # 建表统一归 migrations/bkn-agent/（core-data-migrator）。

--- a/infra/bkn-agent/charts/values.yaml
+++ b/infra/bkn-agent/charts/values.yaml
@@ -38,6 +38,13 @@ runtime:
   mfModelApiPrivateBase: "http://mf-model-api:9898/api/private/mf-model-api/v1"
   # 工具面与技能面统一走这里（#322）
   operatorIntegrationBase: "http://agent-operator-integration:9000/api/agent-operator-integration"
+  # Context Loader 的 MCP 面（ToolRef type=context_loader 由此装载）。这是公开面：
+  # 它挂 introspect，只认真实令牌，不吃 /in 的头部身份。
+  contextLoaderMcpUrl: "http://agent-retrieval:30779/api/agent-retrieval/v1/mcp/"
+  # 兜底服务凭据（bak_ AppKey），仅在调用方没透传 Authorization 时启用。
+  # ⚠️ 一旦启用，Context Loader 看到的是该 AppKey 的签发人而非真实调用者，
+  # per-user 授权在这次调用上塌缩。默认留空 = 无兜底，无令牌时不挂 CL 工具。
+  contextLoaderAppKey: ""
   defaultModel: ""
   checkpointerBackend: "mysql"
   # 建表统一归 migrations/bkn-agent/（core-data-migrator）。


### PR DESCRIPTION
## Why

Once #676 stops registering Context Loader's built-in toolbox into the execution factory, agents **inside the platform** lose their path to the knowledge-network retrieval tools. MCP only ever covered the other half — external clients (Cursor, `openbkn` CLI). bkn-agent loads tools from the execution factory toolbox, not over MCP. This PR builds the missing half.

## Three walls, all confirmed against source and on the VM

None is solved by "just configure a URL":

1. **Context Loader's MCP JSON-RPC lives on the public router only** (`rest_public_handler.go:109`), and that router mounts `middlewareIntrospectVerify` — it takes a real credential and does **not** accept the `/in` header identity. bkn-agent works on the `/in` convention and holds no token.
2. **Every business tool sits behind the lifecycle guard.** `bkn_context` (conversation_id + interaction_id) is a required input; without it the call returns `conversation_required`.
3. **Those ids cannot be minted locally.** A locally minted `int_...` is rejected with `resource_not_disclosed` — the MCP side derives its owner tuple from the credential. The supported path is `bkn_start_interaction` first, then reuse what it returns.

## What this does

- **`auth`** — capture the caller's `Authorization` verbatim into a ContextVar and forward it to Context Loader. This service still does not verify it; identity remains `x-account-id`. A ContextVar rather than a threaded parameter: there are a dozen `(account_id, account_type)` call sites between router and tool loading.
- **`config` / chart** — `CONTEXT_LOADER_MCP_URL`. **No service-credential fallback**: an AppKey fallback would make Context Loader see the key's issuer instead of the real caller, collapsing per-user authorization. A default-off switch like that eventually gets turned on to "make it work", and that is the last downgrade that should happen quietly. No token means no tools, plus a warning.
- **`core/context_loader`** — opening a session means handshake for ids, then load tools. `bkn_context` is injected at call time and **stripped from the model-visible schema**: when a turn starts is a runtime decision, not the model's, and a required id field just invites the model to invent one.
- **`ToolRef type=context_loader`** — deliberately carries no URL, so agent definitions stay portable across environments.
- **`evidence.begin_interaction`** accepts externally issued ids, so the evidence chain and Context Loader share one interaction. Agents without Context Loader tools keep minting locally — a lifecycle round-trip on every execution would turn an optional capability into a hard dependency.

## Four bugs this found, every one of them on the VM

Unit tests passed throughout. None of these was visible without running it.

**1. Token passthrough was silently dead.** `set_caller_token` sat in `get_account`, a **sync** dependency — FastAPI runs those in a threadpool, and a ContextVar set there never reaches the request coroutine. `caller_token()` was always `None`. The symptom was ugly: the task reported `succeeded` while the model, having no tools, **wrote a tool call as its answer**. Only the log showed `无可用凭据…跳过装载`. Now captured in the HTTP middleware, where `observability` already installs its TraceContext. Regression test included; reverting the fix reddens it at `assert None == 'Bearer probe-token'`.

**2. Handshake ids were parsed against a shape that does not exist.** langchain-mcp-adapters returns a 2-tuple `([{"type":"text","text":"<json>"}], {"structured_content": {...}})`. The parser only accepted a dict or a bare JSON string, so a **successful** handshake was judged "no usable id" and the whole tool load was skipped. The unit test used a simplified shape I had invented, so it passed. Tests now use the shape observed on the VM, plus the camelCase and text-block-only degradations.

**3. `bkn_finish_interaction` was called against the wrong contract** — `bkn_context` instead of `interaction_id`, and `outcome="succeeded"` which is not in the enum (`completed` / `failed` / `cancelled` / `handed_off`). Every turn's closure was rejected and interactions piled up in `active`. Four probes against the live MCP face separated the causes:

   | call | result |
   |---|---|
   | id wrapped in `bkn_context`, `outcome=succeeded` | `resource_not_disclosed` |
   | correct id, `outcome=succeeded` | `interaction_required: unsupported finish outcome` |
   | correct id, `outcome=completed`, no `answer` | `closure_manifest_invalid: completed outcome requires answer` |
   | full contract | success, `execution_status: completed` |

   `resource_not_disclosed` turns out to mean "no resolvable id" — the guard collapses "does not exist" and "not yours" into one code so it cannot be used to enumerate other people's ids.

**4. `outcome=completed` requires `answer`** (row 3 above), but closure happened in a `finally` block with no access to the turn's answer. Both paths now thread it through — runner captures the core return value, chat uses its accumulated `answer_parts`. A turn that produced no output closes as `failed` with a reason rather than falsely reporting `completed`.

Also widened: the connection-failure log printed only `ExceptionGroup.str()` — `"unhandled errors in a TaskGroup (1 sub-exception)"` — burying the real cause (a 401) in the sub-exception. It now unpacks them.

## Verification

182 unit tests pass. The contract spec is regenerated with `scripts/export_openapi.py`, not hand-edited. `helm template` renders.

**Multi-turn chat on the VM**, agent with `tools: [{"type": "context_loader"}]`, three turns on one `thread_id`, prompted so each turn *must* re-query rather than reuse history:

| check | result |
|---|---|
| tools actually mounted each turn | 3 turns, one `tool_call` event each |
| `interaction_in_progress` warnings | 0 |
| `Exception in ASGI` / `different Context` | 0 |

Single-turn `/invoke` also returns real data (the same five knowledge networks a direct MCP probe returns), so the tool path and the lifecycle closure are confirmed together.

### Coverage gap, stated plainly

Seven of the ten defects fixed in this PR were found only by running multi-turn traffic on a VM. Unit tests caught one (via CI), review caught two. None of the seven is a wrong branch — they are all "which context / which task / when does this run": a ContextVar set in a threadpool, a token reset across a generator context, cleanup parked in an async generator's `finally`, a session opened by code that had no responsibility to close it.

The regression tests I added pin each specific line. **They do not pin the pattern**, and this repo has no integration smoke that drives the Context Loader path across turns. A future change that parks cross-service cleanup in a generator `finally`, or opens a session without owning its closure, would pass CI. Worth a follow-up integration test (multi-turn + client disconnect + assert interaction terminal state); flagging rather than silently leaving it.

## Merge order

Independent of #676/#677/#678, but it is what makes #676 safe to land: without it, a fresh install has no path from a platform agent to the knowledge-network tools.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

