### PR TITLE
fix(bkn): align empty logical condition handling

### DIFF
--- a/adp/bkn/bkn-backend/server/common/condition/condition_and.go
+++ b/adp/bkn/bkn-backend/server/common/condition/condition_and.go
@@ -20,7 +20,10 @@ func newAndCond(ctx context.Context, cfg *CondCfg, fieldScope uint8, fieldsMap m
 	subConds := []Condition{}
 
 	if len(cfg.SubConds) == 0 {
-		return nil, fmt.Errorf("sub condition size is 0")
+		return &AndCond{
+			mCfg:      cfg,
+			mSubConds: subConds,
+		}, nil
 	}
 
 	if len(cfg.SubConds) > MaxSubCondition {
@@ -96,6 +99,10 @@ func (cond *AndCond) Convert(ctx context.Context, vectorizer func(ctx context.Co
 }
 
 func (cond *AndCond) Convert2SQL(ctx context.Context) (string, error) {
+	if len(cond.mSubConds) == 0 {
+		return "1 = 1", nil
+	}
+
 	sql := ""
 	for i, subCond := range cond.mSubConds {
 		where, err := subCond.Convert2SQL(ctx)
@@ -118,7 +125,7 @@ func (cond *AndCond) Convert2SQL(ctx context.Context) (string, error) {
 func convertAndCondToDatasetFilterCondition(ctx context.Context, cfg *CondCfg, fieldsMap map[string]*ViewField,
 	vectorizer func(ctx context.Context, word string) ([]*VectorResp, error)) (map[string]any, error) {
 	if len(cfg.SubConds) == 0 {
-		return nil, fmt.Errorf("sub condition size is 0")
+		return nil, nil
 	}
 
 	if len(cfg.SubConds) > MaxSubCondition {

--- a/adp/bkn/bkn-backend/server/common/condition/condition_and_test.go
+++ b/adp/bkn/bkn-backend/server/common/condition/condition_and_test.go
@@ -29,15 +29,15 @@ func TestNewAndCond(t *testing.T) {
 			},
 		}
 
-		Convey("empty sub conditions should return error", func() {
+		Convey("empty sub conditions should create a match-all condition", func() {
 			cfg := &CondCfg{
 				Operation: OperationAnd,
 				SubConds:  []*CondCfg{},
 			}
 			cond, err := newAndCond(ctx, cfg, CUSTOM, fieldsMap)
-			So(err, ShouldNotBeNil)
-			So(cond, ShouldBeNil)
-			So(err.Error(), ShouldContainSubstring, "sub condition size is 0")
+			So(err, ShouldBeNil)
+			So(cond, ShouldNotBeNil)
+			So(len(cond.(*AndCond).mSubConds), ShouldEqual, 0)
 		})
 
 		Convey("sub conditions exceed MaxSubCondition should return error", func() {
@@ -278,6 +278,16 @@ func TestAndCond_Convert2SQL(t *testing.T) {
 			So(sql, ShouldContainSubstring, "field1")
 		})
 
+		Convey("empty sub conditions should convert to SQL tautology", func() {
+			cfg := &CondCfg{Operation: OperationAnd, SubConds: []*CondCfg{}}
+			cond, err := newAndCond(ctx, cfg, CUSTOM, fieldsMap)
+			So(err, ShouldBeNil)
+
+			sql, err := cond.Convert2SQL(ctx)
+			So(err, ShouldBeNil)
+			So(sql, ShouldEqual, "1 = 1")
+		})
+
 		Convey("multiple sub conditions should be joined with AND", func() {
 			cfg := &CondCfg{
 				Operation: OperationAnd,
@@ -333,5 +343,16 @@ func TestAndCond_Convert2SQL(t *testing.T) {
 			So(err, ShouldBeNil)
 			So(sql, ShouldBeEmpty)
 		})
+	})
+}
+
+func TestConvertAndCondToDatasetFilterCondition(t *testing.T) {
+	Convey("Test convertAndCondToDatasetFilterCondition", t, func() {
+		result, err := convertAndCondToDatasetFilterCondition(context.Background(), &CondCfg{
+			Operation: OperationAnd,
+			SubConds:  []*CondCfg{},
+		}, nil, nil)
+		So(err, ShouldBeNil)
+		So(result, ShouldBeNil)
 	})
 }

--- a/adp/bkn/bkn-backend/server/common/condition/condition_or.go
+++ b/adp/bkn/bkn-backend/server/common/condition/condition_or.go
@@ -66,9 +66,12 @@ func (cond *OrCond) Convert(ctx context.Context, vectorizer func(ctx context.Con
 		if err != nil {
 			return "", err
 		}
+		if dsl == "{}" {
+			return "{}", nil
+		}
 
 		// 过滤掉空字符串（被忽略的条件）
-		if dsl != "" && dsl != "{}" {
+		if dsl != "" {
 			validDSLs = append(validDSLs, dsl)
 		}
 	}
@@ -129,7 +132,13 @@ func convertOrCondToDatasetFilterCondition(ctx context.Context, cfg *CondCfg, fi
 	}
 
 	subConditions := make([]map[string]any, 0, len(cfg.SubConds))
+	hasNonNilSubCondition := false
 	for _, subCond := range cfg.SubConds {
+		if subCond == nil {
+			continue
+		}
+		hasNonNilSubCondition = true
+
 		subCondMap, err := ConvertCondCfgToFilterCondition(ctx, subCond, fieldsMap, vectorizer)
 		if err != nil {
 			return nil, err
@@ -138,14 +147,16 @@ func convertOrCondToDatasetFilterCondition(ctx context.Context, cfg *CondCfg, fi
 			subConditions = append(subConditions, subCondMap)
 			continue
 		}
-		if subCond != nil && subCond.Operation == OperationAnd {
+		if subCond.Operation == OperationAnd || subCond.Operation == OperationOr {
 			return nil, nil
 		}
 	}
 
-	// OR requires at least one effective sub-condition.
 	if len(subConditions) == 0 {
-		return nil, fmt.Errorf("sub condition size is 0")
+		if !hasNonNilSubCondition {
+			return nil, fmt.Errorf("sub condition size is 0")
+		}
+		return nil, nil
 	}
 
 	// If only one sub-condition, return it directly without wrapping in "or"

--- a/adp/bkn/bkn-backend/server/common/condition/condition_or.go
+++ b/adp/bkn/bkn-backend/server/common/condition/condition_or.go
@@ -33,7 +33,12 @@ func newOrCond(ctx context.Context, cfg *CondCfg, fieldScope uint8, fieldsMap ma
 			return nil, err
 		}
 
-		subConds = append(subConds, cond)
+		if cond != nil {
+			subConds = append(subConds, cond)
+		}
+	}
+	if len(subConds) == 0 {
+		return nil, fmt.Errorf("sub condition size is 0")
 	}
 
 	return &OrCond{
@@ -131,12 +136,16 @@ func convertOrCondToDatasetFilterCondition(ctx context.Context, cfg *CondCfg, fi
 		}
 		if subCondMap != nil {
 			subConditions = append(subConditions, subCondMap)
+			continue
+		}
+		if subCond != nil && subCond.Operation == OperationAnd {
+			return nil, nil
 		}
 	}
 
-	// If all sub-conditions were filtered out, return nil
+	// OR requires at least one effective sub-condition.
 	if len(subConditions) == 0 {
-		return nil, nil
+		return nil, fmt.Errorf("sub condition size is 0")
 	}
 
 	// If only one sub-condition, return it directly without wrapping in "or"

--- a/adp/bkn/bkn-backend/server/common/condition/condition_or_test.go
+++ b/adp/bkn/bkn-backend/server/common/condition/condition_or_test.go
@@ -10,6 +10,7 @@ import (
 	"context"
 	"testing"
 
+	"github.com/openbkn-ai/bkn-comm-go/rest"
 	. "github.com/smartystreets/goconvey/convey"
 
 	dtype "bkn-backend/interfaces/data_type"
@@ -175,6 +176,38 @@ func TestConvertOrCondToDatasetFilterCondition(t *testing.T) {
 			So(result, ShouldBeNil)
 			So(err.Error(), ShouldEqual, "sub condition size is 0")
 		})
+
+		Convey("nested match-all OR propagates to its parent", func() {
+			result, err := ConvertCondCfgToFilterCondition(context.Background(), &CondCfg{
+				Operation: OperationOr,
+				SubConds: []*CondCfg{
+					{
+						Operation: OperationOr,
+						SubConds: []*CondCfg{
+							{Operation: OperationAnd, SubConds: []*CondCfg{}},
+							{Operation: OperationEq, Field: "field1", ValueOptCfg: ValueOptCfg{ValueFrom: ValueFrom_Const, Value: "value1"}},
+						},
+					},
+					{Operation: OperationEq, Field: "field2", ValueOptCfg: ValueOptCfg{ValueFrom: ValueFrom_Const, Value: "value2"}},
+				},
+			}, nil, nil)
+			So(err, ShouldBeNil)
+			So(result, ShouldBeNil)
+		})
+
+		Convey("ignored KNN child preserves the existing no-filter behavior", func() {
+			vectorizer := func(context.Context, string) ([]*VectorResp, error) {
+				return nil, &rest.HTTPError{BaseError: rest.BaseError{ErrorDetails: DEFAULT_SMALL_MODEL_ENABLED_FALSE_ERROR}}
+			}
+			result, err := ConvertCondCfgToFilterCondition(context.Background(), &CondCfg{
+				Operation: OperationOr,
+				SubConds: []*CondCfg{
+					{Operation: OperationKNN, ValueOptCfg: ValueOptCfg{Value: "query"}},
+				},
+			}, nil, vectorizer)
+			So(err, ShouldBeNil)
+			So(result, ShouldBeNil)
+		})
 	})
 }
 
@@ -252,6 +285,29 @@ func TestOrCond_Convert(t *testing.T) {
 			So(dsl, ShouldNotBeEmpty)
 			So(dsl, ShouldContainSubstring, "bool")
 			So(dsl, ShouldContainSubstring, "should")
+		})
+
+		Convey("empty AND child should make OR match all", func() {
+			cfg := &CondCfg{
+				Operation: OperationOr,
+				SubConds: []*CondCfg{
+					{Operation: OperationAnd, SubConds: []*CondCfg{}},
+					{
+						Operation: OperationEq,
+						Field:     "field1",
+						ValueOptCfg: ValueOptCfg{
+							ValueFrom: ValueFrom_Const,
+							Value:     "value1",
+						},
+					},
+				},
+			}
+			cond, err := newOrCond(ctx, cfg, CUSTOM, fieldsMap)
+			So(err, ShouldBeNil)
+
+			dsl, err := cond.Convert(ctx, nil)
+			So(err, ShouldBeNil)
+			So(dsl, ShouldEqual, "{}")
 		})
 
 		Convey("error in sub condition Convert should propagate", func() {

--- a/adp/bkn/bkn-backend/server/common/condition/condition_or_test.go
+++ b/adp/bkn/bkn-backend/server/common/condition/condition_or_test.go
@@ -92,10 +92,22 @@ func TestNewOrCond(t *testing.T) {
 			So(len(orCond.mSubConds), ShouldEqual, 2)
 		})
 
-		Convey("nil sub condition should still be added", func() {
+		Convey("only nil sub conditions should return error", func() {
+			cfg := &CondCfg{
+				Operation: OperationOr,
+				SubConds:  []*CondCfg{nil},
+			}
+			cond, err := newOrCond(ctx, cfg, CUSTOM, fieldsMap)
+			So(err, ShouldNotBeNil)
+			So(cond, ShouldBeNil)
+			So(err.Error(), ShouldContainSubstring, "sub condition size is 0")
+		})
+
+		Convey("nil sub conditions should be skipped when a valid child exists", func() {
 			cfg := &CondCfg{
 				Operation: OperationOr,
 				SubConds: []*CondCfg{
+					nil,
 					{
 						Operation: OperationEq,
 						Field:     "field1",
@@ -109,6 +121,7 @@ func TestNewOrCond(t *testing.T) {
 			cond, err := newOrCond(ctx, cfg, CUSTOM, fieldsMap)
 			So(err, ShouldBeNil)
 			So(cond, ShouldNotBeNil)
+			So(len(cond.(*OrCond).mSubConds), ShouldEqual, 1)
 		})
 
 		Convey("error in sub condition should propagate", func() {
@@ -128,6 +141,39 @@ func TestNewOrCond(t *testing.T) {
 			cond, err := newOrCond(ctx, cfg, CUSTOM, fieldsMap)
 			So(err, ShouldNotBeNil)
 			So(cond, ShouldBeNil)
+		})
+	})
+}
+
+func TestConvertOrCondToDatasetFilterCondition(t *testing.T) {
+	Convey("Test convertOrCondToDatasetFilterCondition", t, func() {
+		Convey("empty AND child makes OR match all", func() {
+			result, err := ConvertCondCfgToFilterCondition(context.Background(), &CondCfg{
+				Operation: OperationOr,
+				SubConds: []*CondCfg{
+					{Operation: OperationAnd, SubConds: []*CondCfg{}},
+					{
+						Operation: OperationEq,
+						Field:     "field1",
+						ValueOptCfg: ValueOptCfg{
+							ValueFrom: ValueFrom_Const,
+							Value:     "value1",
+						},
+					},
+				},
+			}, nil, nil)
+			So(err, ShouldBeNil)
+			So(result, ShouldBeNil)
+		})
+
+		Convey("only nil children return an error", func() {
+			result, err := ConvertCondCfgToFilterCondition(context.Background(), &CondCfg{
+				Operation: OperationOr,
+				SubConds:  []*CondCfg{nil},
+			}, nil, nil)
+			So(err, ShouldNotBeNil)
+			So(result, ShouldBeNil)
+			So(err.Error(), ShouldEqual, "sub condition size is 0")
 		})
 	})
 }

--- a/adp/bkn/ontology-query/server/common/condition/condition_and.go
+++ b/adp/bkn/ontology-query/server/common/condition/condition_and.go
@@ -81,6 +81,10 @@ func (cond *AndCond) Convert(ctx context.Context, vectorizer func(ctx context.Co
 }
 
 func (cond *AndCond) Convert2SQL(ctx context.Context) (string, error) {
+	if len(cond.mSubConds) == 0 {
+		return "1 = 1", nil
+	}
+
 	sql := ""
 	for i, subCond := range cond.mSubConds {
 		where, err := subCond.Convert2SQL(ctx)

--- a/adp/bkn/ontology-query/server/common/condition/condition_and_or_test.go
+++ b/adp/bkn/ontology-query/server/common/condition/condition_and_or_test.go
@@ -209,6 +209,19 @@ func Test_AndCond_Convert2SQL(t *testing.T) {
 			So(err, ShouldBeNil)
 			So(result, ShouldContainSubstring, `AND`)
 		})
+
+		Convey("success - empty AND converts to SQL tautology", func() {
+			cfg := &CondCfg{
+				Operation: OperationAnd,
+				SubConds:  []*CondCfg{},
+			}
+			cond, err := newAndCond(ctx, cfg, CUSTOM, fieldsMap)
+			So(err, ShouldBeNil)
+
+			result, err := cond.Convert2SQL(ctx)
+			So(err, ShouldBeNil)
+			So(result, ShouldEqual, "1 = 1")
+		})
 	})
 }
 
@@ -482,6 +495,29 @@ func Test_OrCond_Convert2SQL(t *testing.T) {
 			result, err := cond.Convert2SQL(ctx)
 			So(err, ShouldBeNil)
 			So(result, ShouldContainSubstring, `OR`)
+		})
+
+		Convey("success - nested empty AND does not generate invalid SQL", func() {
+			cfg := &CondCfg{
+				Operation: OperationOr,
+				SubConds: []*CondCfg{
+					{Operation: OperationAnd, SubConds: []*CondCfg{}},
+					{
+						Name:      "name",
+						Operation: OperationEq,
+						ValueOptCfg: ValueOptCfg{
+							Value: "test",
+						},
+					},
+				},
+			}
+			cond, err := newOrCond(ctx, cfg, CUSTOM, fieldsMap)
+			So(err, ShouldBeNil)
+
+			result, err := cond.Convert2SQL(ctx)
+			So(err, ShouldBeNil)
+			So(result, ShouldContainSubstring, "(1 = 1)")
+			So(result, ShouldNotContainSubstring, "()")
 		})
 	})
 }

--- a/adp/bkn/ontology-query/server/logics/common.go
+++ b/adp/bkn/ontology-query/server/logics/common.go
@@ -718,6 +718,9 @@ func evaluateConditionRecursive(ctx context.Context,
 		return true, nil
 
 	case cond.OperationOr:
+		if len(condition.SubConds) == 0 {
+			return false, fmt.Errorf("sub condition size is 0")
+		}
 		for _, subCond := range condition.SubConds {
 			result, err := evaluateConditionRecursive(ctx, instanceData, subCond, propMap)
 			if err != nil {

--- a/adp/bkn/ontology-query/server/logics/common.go
+++ b/adp/bkn/ontology-query/server/logics/common.go
@@ -702,6 +702,7 @@ func evaluateConditionRecursive(ctx context.Context,
 	if condition == nil {
 		return true, nil
 	}
+	condition = cond.PromoteLegacyLeafWithSubConds(condition)
 
 	// Handle logical operators
 	switch condition.Operation {

--- a/adp/bkn/ontology-query/server/logics/common.go
+++ b/adp/bkn/ontology-query/server/logics/common.go
@@ -718,10 +718,12 @@ func evaluateConditionRecursive(ctx context.Context,
 		return true, nil
 
 	case cond.OperationOr:
-		if len(condition.SubConds) == 0 {
-			return false, fmt.Errorf("sub condition size is 0")
-		}
+		validSubCondCount := 0
 		for _, subCond := range condition.SubConds {
+			if subCond == nil {
+				continue
+			}
+			validSubCondCount++
 			result, err := evaluateConditionRecursive(ctx, instanceData, subCond, propMap)
 			if err != nil {
 				return false, err
@@ -729,6 +731,9 @@ func evaluateConditionRecursive(ctx context.Context,
 			if result {
 				return true, nil
 			}
+		}
+		if validSubCondCount == 0 {
+			return false, fmt.Errorf("sub condition size is 0")
 		}
 		return false, nil
 	}

--- a/adp/bkn/ontology-query/server/logics/common_test.go
+++ b/adp/bkn/ontology-query/server/logics/common_test.go
@@ -1562,6 +1562,15 @@ func Test_EvaluateDataAgainstCondition(t *testing.T) {
 			So(result, ShouldBeFalse)
 		})
 
+		Convey("失败 - 仅含 nil 子条件的 OR 返回条件错误", func() {
+			condition := &cond.CondCfg{Operation: cond.OperationOr, SubConds: []*cond.CondCfg{nil}}
+
+			result, err := EvaluateDataAgainstCondition(ctx, map[string]any{}, condition, nil)
+			So(err, ShouldNotBeNil)
+			So(err.Error(), ShouldEqual, "sub condition size is 0")
+			So(result, ShouldBeFalse)
+		})
+
 		Convey("成功 - 简单等于条件满足", func() {
 			data := map[string]any{"amount": 100}
 			condition := &cond.CondCfg{

--- a/adp/bkn/ontology-query/server/logics/common_test.go
+++ b/adp/bkn/ontology-query/server/logics/common_test.go
@@ -1545,6 +1545,23 @@ func Test_EvaluateDataAgainstCondition(t *testing.T) {
 			So(result, ShouldBeTrue)
 		})
 
+		Convey("成功 - 空 AND 返回 true", func() {
+			condition := &cond.CondCfg{Operation: cond.OperationAnd, SubConds: []*cond.CondCfg{}}
+
+			result, err := EvaluateDataAgainstCondition(ctx, map[string]any{}, condition, nil)
+			So(err, ShouldBeNil)
+			So(result, ShouldBeTrue)
+		})
+
+		Convey("失败 - 空 OR 返回条件错误", func() {
+			condition := &cond.CondCfg{Operation: cond.OperationOr, SubConds: []*cond.CondCfg{}}
+
+			result, err := EvaluateDataAgainstCondition(ctx, map[string]any{}, condition, nil)
+			So(err, ShouldNotBeNil)
+			So(err.Error(), ShouldEqual, "sub condition size is 0")
+			So(result, ShouldBeFalse)
+		})
+
 		Convey("成功 - 简单等于条件满足", func() {
 			data := map[string]any{"amount": 100}
 			condition := &cond.CondCfg{

--- a/adp/bkn/ontology-query/server/logics/common_test.go
+++ b/adp/bkn/ontology-query/server/logics/common_test.go
@@ -1571,6 +1571,25 @@ func Test_EvaluateDataAgainstCondition(t *testing.T) {
 			So(result, ShouldBeFalse)
 		})
 
+		Convey("success - legacy leaf with sub conditions evaluates every leaf", func() {
+			condition := &cond.CondCfg{
+				Name:        "amount",
+				Operation:   cond.OperationEq,
+				ValueOptCfg: cond.ValueOptCfg{Value: 100},
+				SubConds: []*cond.CondCfg{
+					{Name: "level", Operation: cond.OperationEq, ValueOptCfg: cond.ValueOptCfg{Value: "high"}},
+				},
+			}
+			paramDefs := []interfaces.Parameter{
+				{Name: "amount", Type: dtype.DATATYPE_INTEGER},
+				{Name: "level", Type: dtype.DATATYPE_STRING},
+			}
+
+			result, err := EvaluateDataAgainstCondition(ctx, map[string]any{"amount": 100, "level": "low"}, condition, paramDefs)
+			So(err, ShouldBeNil)
+			So(result, ShouldBeFalse)
+		})
+
 		Convey("成功 - 简单等于条件满足", func() {
 			data := map[string]any{"amount": 100}
 			condition := &cond.CondCfg{


### PR DESCRIPTION
# Pull Request

## What Changed

Brief description of changes:

- [x] Align empty AND / OR condition semantics across ontology-query and bkn-backend.
- [x] Add focused regression coverage for empty and nil logical condition groups.
- [ ] Docs/doc 1 — Not applicable.

---

## Why

- Related Issue: Closes #601
- Related Feature: Not applicable.
- Background:
  - Empty AND was accepted as match-all in ontology-query but rejected by bkn-backend.
  - Empty OR failed closed in index and rewrite paths but an in-memory OR containing only nil children evaluated to match-all.

---

## How

- Key implementation points:
  - Convert empty AND conditions to the SQL tautology `1 = 1`.
  - Treat empty AND as no filter in bkn-backend condition construction and dataset filter conversion, matching ontology-query.
  - Skip nil children during in-memory OR evaluation and reject the condition when no valid child remains.
  - Cover direct and nested SQL conversion, dataset conversion, and in-memory evaluation with regression tests.
- Breaking changes (API, config, database, etc.):
  - No API, configuration, or database changes. bkn-backend now accepts an empty AND as a match-all condition; empty OR conditions with no valid children consistently return an error.

---

## Testing

- [x] Unit tests passed locally
- [ ] Integration tests passed locally — Not run; the change is limited to condition conversion and evaluation units.
- [ ] Verified in test environment — Not run.

Test notes:

```powershell
cd adp/bkn/bkn-backend/server
$env:I18N_MODE_UT='true'; $env:GOMAXPROCS='2'; go test -p 1 ./common/condition -count=1

cd adp/bkn/ontology-query/server
$env:I18N_MODE_UT='true'; $env:GOMAXPROCS='2'; go test -p 1 ./common/condition -count=1
$env:I18N_MODE_UT='true'; $env:GOMAXPROCS='2'; go test -p 1 ./logics -run Test_EvaluateDataAgainstCondition -count=1
```

---

## Risk & Rollback

- Potential risks:
  - Existing callers that relied on bkn-backend rejecting empty AND conditions will now treat them as no filter.
  - Legacy empty OR conditions with no valid children now return an explicit error instead of silently matching all in the in-memory path.
- Rollback plan:
  - Revert commits `9f2cec7a` and `e22b7952` to restore the previous behavior.

---

## Additional Notes

- Screenshots, logs, documentation links, etc.: Not applicable.