### PR TITLE
perf(claude-review): route files by class, tier effort, capture transcripts

### DIFF
--- a/.github/workflows/automation-claude-review.yml
+++ b/.github/workflows/automation-claude-review.yml
@@ -268,7 +268,7 @@ jobs:
           if paths:
               shards.append({
                   "key": "contract",
-                  "label": "cross-module contracts / config & deployment / data plane",
+                  "label": "跨模块契约 / 配置与部署面 / 数据面",
                   "kind": "contract",
                   "files": "",
                   "files_shallow": "",
@@ -301,16 +301,15 @@ jobs:
           import json, os
           shards = json.loads(os.environ["SHARDS"])
           lines = ["<!-- claude-review-progress -->",
-                   '### <img src="%s" width="16" height="16" /> Review in progress'
+                   '### <img src="%s" width="16" height="16" /> 评审进行中'
                    % os.environ["SPINNER"],
                    "",
-                   "Running %d shards in parallel; a single verdict lands once "
-                   "they all report." % len(shards),
+                   "按模块分 %d 片并行，逐片完成后统一给出一次结论。" % len(shards),
                    ""]
           # 复选框由各分片跑完后回来打勾（review job 的 Tick progress 步骤）。
           lines += ["- [ ] `%s`" % s["label"] for s in shards]
-          lines += ["", "[View run](%s)" % os.environ["RUN_URL"],
-                    "", "_This comment disappears once the verdict is posted._"]
+          lines += ["", "[查看运行日志](%s)" % os.environ["RUN_URL"],
+                    "", "_结论落地后这条会自动消失。_"]
           print("\n".join(lines))
           PY
           )
@@ -528,9 +527,8 @@ jobs:
 
             两件事，缺一不可：
 
-            **一律用英文**写 inline comment 与 findings JSON 里的所有文字，不论 PR
-            本身是什么语言——本仓的 PR 标题、正文与评审输出统一用英文。代码标识符、
-            错误信息、命令、路径保持原样。
+            **一律用中文**写 inline comment 与 findings JSON 里的所有文字。代码标识符、
+            错误信息、命令、路径保持原样，不翻译。
 
             **一、先写 `${{ github.workspace }}/findings/${{ matrix.shard.key }}.json`**
             （绝对路径）。**这一步排在最前面是有意的**：它是你这片唯一会进入最终结论的
@@ -618,7 +616,7 @@ jobs:
           f="findings/${SHARD_KEY}.json"
           if [ ! -s "$f" ]; then
             echo "::warning::分片 ${SHARD_KEY} 未写出 findings，回填占位。"
-            printf '{"shard":"%s","status":"no_output","summary":"","impact":"","blockers":[],"unconfirmed":[],"not_covered":"Shard finished without writing a conclusion; its files were not reviewed."}\n' \
+            printf '{"shard":"%s","status":"no_output","summary":"","impact":"","blockers":[],"unconfirmed":[],"not_covered":"本片跑完但没落下结论，这些文件未经评审。"}\n' \
               "${SHARD_KEY}" > "$f"
           fi
 
@@ -661,7 +659,7 @@ jobs:
 
           done = "- [x] `%s`" % label
           if not reviewed:
-              done += " — no conclusion produced; these files were not reviewed"
+              done += " —— 未产出结论，本片文件未经评审"
           todo = "- [ ] `%s`" % label
 
           def gh(*args):
@@ -876,7 +874,7 @@ jobs:
             {
               "verdicts": [
                 {"id": "adp-bkn#0", "refuted": true,
-                 "reason": "why it was refuted or confirmed, naming the file and lines you read"}
+                 "reason": "驳回或确认的理由，指明你读了哪个文件的哪几行"}
               ],
               "notes": "复核过程中顺带发现的、但不属于本次阻塞项的事情，可以为空串"
             }
@@ -885,8 +883,8 @@ jobs:
             `reason` 里必须出现你**这一轮真读过的** file:line。这是复核结论本身的
             evidence，写不出来的结论和它要驳回的东西是同一种毛病。
 
-            `reason` **一律用英文**。它会原样进 verdict 正文，夹在英文骨架
-            （`Refuted because:` 与折叠区标题）之间，写中文就又成了一份混排文档。
+            `reason` **一律用中文**。它会原样进 verdict 正文，与骨架和分片给的文字
+            并排显示，语言不一致会读成两份东西。
           claude_args: |
             --model claude-opus-5
             --effort xhigh
@@ -1010,26 +1008,28 @@ jobs:
               except (ValueError, OSError):
                   verdicts = {}
 
-          # 所有面向 PR 的文字一律英文（PR 标题/正文/评审输出的既定口径）。此前这里
-          # 按分片投票在 zh/en 之间切换，结果是英文 PR 上仍会混进中文骨架与中文分片名。
-          T = {"block": "Blockers",
-               "verified": "Each item below survived an independent verification pass (refuted by default; kept only when confirmed against the source).",
-               "unrev": " (**unverified** — the verification stage produced no result)",
-               "scen": "Failure scenario: ",
-               "dropped": "%d item(s) dropped by verification", "why": "Refuted because: ",
-               "byshard": "Per-shard findings", "impact": "Blast radius: ", "notcov": "Not covered: ",
-               "clean": "_(no issues)_", "counts": "_(%d blocking, %d open)_",
-               "detail": "Blast radius and coverage gaps, per shard",
-               "more_unconf": "%d further open questions were trimmed to keep this readable; see the shard logs.",
-               "unconf": "Open questions (non-blocking)", "missing": "Shards with no result",
-               "missing_body": "These shards produced no findings — **their files were not reviewed this round**:",
-               "reason_no_output": "ran, but wrote no conclusion (most likely the turn limit, or it wrapped up early)",
-               "reason_absent": "never ran, or died partway through",
-               "reason_malformed": "wrote a conclusion file that could not be parsed",
-               "trunc": "File list truncated",
-               "trunc_body": "This PR changes %s files but only %s reached the planner (`gh pr view --json files` caps at 100) — **the remaining %d were not assigned to any shard and were not reviewed**.",
-               "footer": "Push a new commit when addressed, or reply `/review` for another round.",
-               "footer_ok": "Disagree, or want another pass? Reply `/review` — a plain comment does not trigger one, and the replier must be an OWNER/MEMBER/COLLABORATOR of this repo."}
+          # 机器人贴到 PR 上的文字一律中文：结论骨架、分片名、进度评论、空转通告、
+          # 回填占位、verify 的驳回理由，全部同一种语言。曾按分片投票在 zh/en 之间切换，
+          # 结果是骨架跟着投票走、分片名等仍写死中文，拿到的是混排文档——所以不做切换，
+          # 定死一种。注意这与「我们自己写的 PR 标题与正文用英文」是两回事，别混淆。
+          T = {"block": "阻塞项",
+               "verified": "以下每一条都经过一轮独立复核（默认驳回，核实通过才保留）。",
+               "unrev": "（**未复核**，复核环节未产出结论）",
+               "scen": "失效场景：",
+               "dropped": "复核未通过、已丢弃的 %d 条", "why": "驳回理由：",
+               "byshard": "各分片结论", "impact": "影响范围：", "notcov": "未覆盖：",
+               "clean": "_（无问题）_", "counts": "_（阻塞 %d，待确认 %d）_",
+               "detail": "各分片的影响范围与未覆盖面",
+               "more_unconf": "另有 %d 条待确认项已省略，以免正文过长；详见各分片日志。",
+               "unconf": "待确认项（不阻断放行）", "missing": "未产出结论的分片",
+               "missing_body": "下面这些分片没有产出结论，**这些文件本轮未经评审**：",
+               "reason_no_output": "跑完了但没落下结论（多半是撞轮次上限或提前收尾）",
+               "reason_absent": "整个分片没跑起来或中途挂了",
+               "reason_malformed": "写出的结论文件解析不了",
+               "trunc": "文件清单被截断",
+               "trunc_body": "本 PR 共 %s 个改动文件，分片只拿到 %s 个（`gh pr view --json files` 单次上限 100），**其余 %d 个未进入任何分片、本轮未经评审**。",
+               "footer": "改完请推新提交，或回复 `/review` 要一轮复评。",
+               "footer_ok": "有异议或想再评一轮，请回复 `/review`——普通回帖不会触发复评，且回帖人需为本仓 OWNER/MEMBER/COLLABORATOR。"}
 
           # 模型不一定听话，长度要有确定性兜底——与「模型输出是不可信输入」同一思路。
           def clip(x, n):
@@ -1206,7 +1206,7 @@ jobs:
           state=$(gh pr view "$PR_NUMBER" --json state --jq .state)
           [ "$state" = "OPEN" ] || exit 0
           MARKER='<!-- claude-review-empty -->'
-          body=$(printf '%s\n### Review round produced nothing\n\nNo shard produced a conclusion, so **these changes were not reviewed this round**. No verdict was recorded because there is nothing to vote on — neither `request-changes` nor `approve` would be honest.\n\nUsual causes: a shard hit the turn limit, the model never wrote its conclusion file, the assembly step failed, or the credential is missing. [View run](%s)\n\nReply `/review` to ask for another round. This notice disappears as soon as a round lands a verdict.' "$MARKER" "$RUN_URL")
+          body=$(printf '%s\n### 本轮评审没有产出结论\n\n没有分片落下结论，**这些改动本轮未经评审**。没有表态是因为无从表态——既不该 request-changes，也不该 approve。\n\n常见原因：分片撞轮次上限、模型未写出结论文件、汇总步骤失败、凭据缺失。[查看运行日志](%s)\n\n回复 `/review` 可以再要一轮。下一轮真出了结论，这条会自动消失。' "$MARKER" "$RUN_URL")
           # 复用同一条：synchronize 每次推送跑一轮，凭据缺失这类持续故障否则会在 PR 上
           # 堆出一串一模一样的通告，正是进度评论当初特意避开的噪声。
           existing=$(gh api "repos/${GH_REPO}/issues/${PR_NUMBER}/comments" --paginate \

--- a/.github/workflows/automation-claude-review.yml
+++ b/.github/workflows/automation-claude-review.yml
@@ -195,8 +195,32 @@ jobs:
           TWO_LEVEL = {"adp", "infra"}
           TOP_LEVEL = {"bkn-safe", "comm-go", "deploy", "data-migrator", "migrations"}
 
-          groups = collections.OrderedDict()
+          # 实测最近 10 个 PR 的 222 个改动文件里只有 44% 是代码：测试 25%、文档 15%、
+          # 配置与生成物 12%。此前它们与代码同规格评审——文档也在被追引用点、被做触发式
+          # 深挖，一片就是 5 分钟和几十轮。按类分流：
+          #   deep    代码，全套
+          #   shallow 测试，跟着所属模块走但不追引用点（测试的调用方就是它自己）
+          #   低风险  文档/示例/生成物，单独一片浅审
+          # 迁移、helm、values 不在此列——它们是本仓最高频的事故来源，永远走 deep。
+          def klass(path):
+              risky = ("migrations/" in path or "/helm/" in path
+                       or path.endswith("values.yaml"))
+              if risky:
+                  return "deep"
+              if ("_test." in path or "/tests/" in path
+                      or path.endswith("_test.go")):
+                  return "shallow"
+              if (path.startswith(("docs/", "examples/")) or path.endswith(".md")
+                      or path.endswith((".lock", ".sum"))):
+                  return "lowrisk"
+              return "deep"
+
+          groups, lowrisk = collections.OrderedDict(), []
           for p in paths:
+              k = klass(p)
+              if k == "lowrisk":
+                  lowrisk.append(p)
+                  continue
               parts = p.split("/")
               if parts[0] in TWO_LEVEL and len(parts) > 2:
                   key = "/".join(parts[:2])
@@ -218,11 +242,25 @@ jobs:
 
           shards = []
           for key, files in groups.items():
+              deep = sorted(f for f in files if klass(f) == "deep")
+              shallow = sorted(f for f in files if klass(f) == "shallow")
               shards.append({
                   "key": key.replace("/", "-"),
                   "label": key,
                   "kind": "misc" if key == "misc" else "module",
-                  "files": "\n".join("- " + f for f in sorted(files)),
+                  "files": "\n".join("- " + f for f in deep) or "（本片没有代码改动）",
+                  "files_shallow": "\n".join("- " + f for f in shallow),
+              })
+
+          # 低风险文件单独成片而不是直接丢掉：静默不审比多花几分钱糟得多，
+          # 而且文档与代码对不上本身就是要报的问题。
+          if lowrisk:
+              shards.append({
+                  "key": "low-risk",
+                  "label": "docs / examples / generated",
+                  "kind": "lowrisk",
+                  "files": "\n".join("- " + f for f in sorted(lowrisk)),
+                  "files_shallow": "",
               })
 
           # contract 片固定存在（只要 PR 有改动）：跨模块契约、配置与部署面、数据面
@@ -233,6 +271,7 @@ jobs:
                   "label": "cross-module contracts / config & deployment / data plane",
                   "kind": "contract",
                   "files": "",
+                  "files_shallow": "",
               })
 
           print("shards=" + json.dumps(shards, ensure_ascii=False))
@@ -396,9 +435,13 @@ jobs:
 
             ## 你这一片的范围
 
-            ${{ matrix.shard.kind == 'contract' && '你拿的是全量 diff，但**只看跨模块一致性，不重复别人已经在做的模块内逻辑审查**。三个面：一、跨模块契约——同一能力在 REST 路由、MCP 工具定义、.adp 描述、SDK、CLI 等多处各有一份声明，必须同步改，只改其中一处就是线上不一致。二、配置与部署面——Helm values、configmap、环境变量、chart 默认值的改动，分别核存量环境升级（沿用旧值会不会失效、缺省值会不会被覆盖）与全新安装。三、数据面——落库字段、索引结构、消息体格式的变化，确认存量数据仍能被新代码正确读出；滚动升级期间新旧版本并存，两边必须互相兼容。' || '你负责为下面这些文件出结论：' }}
+            ${{ matrix.shard.kind == 'contract' && '你拿的是全量 diff，但**只看跨模块一致性，不重复别人已经在做的模块内逻辑审查**。三个面：一、跨模块契约——同一能力在 REST 路由、MCP 工具定义、.adp 描述、SDK、CLI 等多处各有一份声明，必须同步改，只改其中一处就是线上不一致。二、配置与部署面——Helm values、configmap、环境变量、chart 默认值的改动，分别核存量环境升级（沿用旧值会不会失效、缺省值会不会被覆盖）与全新安装。三、数据面——落库字段、索引结构、消息体格式的变化，确认存量数据仍能被新代码正确读出；滚动升级期间新旧版本并存，两边必须互相兼容。' || (matrix.shard.kind == 'lowrisk' && '这一片是文档、示例与生成物，**浅审**：只确认它们与本次代码改动是否一致（描述与实现对不上、示例跑不通、生成物与源不同步），以及有没有泄露凭据或内部地址。不做引用点追踪，不做触发式深挖，不写影响范围。没问题就直接落结论收工——这一片的预算远小于代码片。' || '你负责为下面这些文件出结论：') }}
 
             ${{ matrix.shard.files }}
+
+            ${{ matrix.shard.files_shallow != '' && '本片还有下面这些测试文件，**浅审**：只看它们是否验证了真实行为、有没有把断言写成永真。不追引用点、不做触发式深挖——测试的调用方就是它自己。' || '' }}
+
+            ${{ matrix.shard.files_shallow }}
 
             **责任范围不等于可读范围。** 上面的清单只圈定「你为哪些文件出结论」，
             核查时可以读全仓任意文件——改动在你这片、调用方在别的模块，是本仓最贵的
@@ -551,10 +594,13 @@ jobs:
           #
           # 轮次上限 80：#662 曾在 60 触顶零产出。分片后单片实际轮数远低于此，这个值
           # 是余量而非目标，跑不满不计费。
+          # effort 与轮次按片分档：contract 片要在全仓范围内比对多处声明，是最难的判断，
+          # 保持 xhigh；模块片做的是「读 diff 找问题」，high 足够，而 xhigh 每轮多生成的
+          # 思考 token 是实打实的成本。低风险片只做一致性核对，25 轮绰绰有余。
           claude_args: |
             --model claude-opus-5
-            --effort xhigh
-            --max-turns 80
+            --effort ${{ matrix.shard.kind == 'contract' && 'xhigh' || 'high' }}
+            --max-turns ${{ matrix.shard.kind == 'lowrisk' && '25' || '80' }}
             --allowedTools "mcp__github_inline_comment__create_inline_comment,Read,Grep,Glob,LS,Write,Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr checks:*),Bash(git diff:*),Bash(git log:*),Bash(git show:*),Bash(git grep:*)"
 
       # if: always()——分片撞上限时 action 以失败退出，但它此前可能已经写了 JSON；
@@ -646,12 +692,34 @@ jobs:
                   time.sleep(2)
           PY
 
+      # 逐轮的工具调用在 Actions 日志里看不到（track_progress: false 不流式输出），
+      # 于是「轮数花在哪」只能靠猜，后续调优也就没有依据。这里把 action 写的完整执行
+      # 记录留成 artifact，离线就能统计每轮在 Read / Grep / Bash / 思考上的分布。
+      - name: Upload transcript
+        if: always()
+        continue-on-error: true
+        run: |
+          set -euo pipefail
+          mkdir -p transcript
+          f="${RUNNER_TEMP}/claude-execution-output.json"
+          [ -f "$f" ] && cp "$f" "transcript/${SHARD_KEY}.json" || true
+
       - name: Upload findings
         if: always()
         uses: actions/upload-artifact@v4
         with:
           name: findings-${{ matrix.shard.key }}
           path: findings/
+          if-no-files-found: ignore
+          retention-days: 7
+
+      - name: Store transcript artifact
+        if: always()
+        continue-on-error: true
+        uses: actions/upload-artifact@v4
+        with:
+          name: transcript-${{ matrix.shard.key }}
+          path: transcript/
           if-no-files-found: ignore
           retention-days: 7
 


### PR DESCRIPTION
> Stacked on #688. Base moves to `main` once that merges.

## Measurement

222 changed files across the last ten PRs:

```
code          97   44%
tests         55   25%
docs          33   15%
config/gen    26   12%
deploy         7    3%
examples       2    1%
migrations     2    1%
```

**Only 44% is code**, and until now the other 56% was reviewed to the same depth — the `misc` shard on one run spent ~35 turns and 5.8 minutes chasing reference points through `docs/api` and `examples/`.

Turns are the only real cost variable: 44 per round before sharding, 152 after, $1–3 → $11.

## Three changes

**1. File-class routing.** `plan` classifies each path:

| class | what | treatment |
|---|---|---|
| `deep` | code | full treatment |
| `shallow` | tests | stay with their module shard; no reference-point sweep, no triggered deep dives — a test's caller is the test itself |
| `lowrisk` | docs, examples, generated | one shallow shard for all of them, `high` effort, 25-turn cap |

Migrations, helm templates and `values.yaml` are pinned to `deep` wherever they sit — this repo's most frequent source of incidents.

Low-risk files get their own shard rather than being dropped. Silently skipping them is worse than a few cents, and docs contradicting the code is itself a finding.

**2. Effort, only where it is justified.** Code shards stay at `xhigh` — today's behaviour, so no regression risk. Only the low-risk shard drops to `high`.

An earlier revision of this PR moved *module* shards to `high` on the reasoning that they only "read the diff and find problems". That undersells them: module shards are where logic errors, races and boundary conditions get found, and where the 90-confidence bar with `file:line` evidence actually bites. The contract shard is closer to mechanical cross-referencing — if anything the tiering was inverted. More to the point it was a guess, in a PR that deliberately holds back two other changes *for being guesses*. Downgrading also carries a concrete risk: weaker reasoning makes a shard likelier to wrap up without writing findings, or to produce conclusions that do not survive `verify` — two failure modes that took several PRs to close.

**3. Transcript capture.** With `track_progress: false` the per-turn tool calls never reach the Actions log. "Where do the turns go" has been guesswork, and so has every tuning decision resting on it. Each shard now uploads `claude-execution-output.json` as an artifact, so the breakdown becomes measurable offline.

## Deliberately not in this PR

The light/full profile split, the shared-context prefetch, and broader effort tiering. All three are sized from estimates; change 3 is what turns those estimates into measurements.

## Verification

Ran the classifier against PR #669 (31 files): 4 module shards + 1 low-risk + contract, with 10 test files routed to shallow. YAML parses; the three-way scope expression and both `claude_args` expressions render as intended.