### PR TITLE
fix(observability): align runtime log and trace indexes in install profile

### DIFF
--- a/bkn-trace/agent-observability/charts/agent-observability/values.yaml
+++ b/bkn-trace/agent-observability/charts/agent-observability/values.yaml
@@ -128,8 +128,9 @@ affinity: {}
 
 opensearch:
   endpoint:  http://opensearch-cluster-master.resource.svc.cluster.local:9200
-  traceIndex: ss4o_traces-default-anyshare
-  logIndex: ss4o_logs-default-anyshare
+  # Keep these aligned with the bundled Collector's ss4o dataset/namespace.
+  traceIndex: ss4o_traces-default-namespace
+  logIndex: ss4o_logs-default-namespace
   auth:
     enabled: false
     username: ""

--- a/deploy/scripts/services/openbkn.sh
+++ b/deploy/scripts/services/openbkn.sh
@@ -440,7 +440,8 @@ OPENBKN_TRACE_INGEST_SECRET="${OPENBKN_TRACE_INGEST_SECRET:-bkn-trace-evidence-i
 
 # The chart defaults keep standalone development lightweight. A complete
 # OpenBKN installation, however, must make managed Agent conversations durable
-# and queryable after agent-observability restarts.
+# and queryable after agent-observability restarts. The trace/log indexes below
+# must track the bundled Collector's ss4o dataset=default and namespace=namespace.
 _openbkn_trace_profile_sets() {
     local release_name="$1"
     case "${release_name}" in

--- a/deploy/scripts/services/openbkn.sh
+++ b/deploy/scripts/services/openbkn.sh
@@ -454,11 +454,14 @@ _openbkn_trace_profile_sets() {
                 "evidence.indexManagement.createJob.enabled=true"
                 "evidence.ingestAuth.existingSecret=${OPENBKN_TRACE_INGEST_SECRET}"
                 "evidence.ingestAuth.secretKey=token"
+                "opensearch.traceIndex=ss4o_traces-default-namespace"
+                "opensearch.logIndex=ss4o_logs-default-namespace"
             )
             ;;
         agent-retrieval)
             CORE_RELEASE_EXTRA_SETS+=(
                 "observability.trace.enabled=true"
+                "observability.log.enabled=true"
                 "observability.lifecycle.core_url=http://agent-observability-internal:8081"
                 "observability.evidence.ingest_url=http://agent-observability:8080/api/agent-observability/v1/evidence/events"
                 "observability.evidence.ingest_token_secret_name=${OPENBKN_TRACE_INGEST_SECRET}"

--- a/deploy/scripts/services/openbkn_trace_profile_test.sh
+++ b/deploy/scripts/services/openbkn_trace_profile_test.sh
@@ -46,9 +46,22 @@ contains "AO persists evidence" "${ao_sets}" "evidence.store=opensearch"
 contains "AO enables projection" "${ao_sets}" "core.projection.enabled=true"
 contains "AO creates evidence index" "${ao_sets}" "evidence.indexManagement.createJob.enabled=true"
 contains "AO protects evidence producer ingest" "${ao_sets}" "evidence.ingestAuth.existingSecret=bkn-trace-evidence-ingest"
-contains "AO reads Collector Trace index" "${ao_sets}" "opensearch.traceIndex=ss4o_traces-default-namespace"
-contains "AO reads Collector log index" "${ao_sets}" "opensearch.logIndex=ss4o_logs-default-namespace"
 not_contains "AO has no query gateway Secret" "${ao_sets}" "queryAuth.existingSecret="
+
+otel_values="$(<"${SCRIPT_DIR}/../bkn-trace/otelcol-contribute-chart/charts/otelcol-contrib/values.yaml")"
+contains "collector uses the Trace profile dataset" "${otel_values}" "dataset: default"
+contains "collector uses the Trace profile namespace" "${otel_values}" "namespace: namespace"
+contains "collector uses SS4O index names" "${otel_values}" "mode: ss4o"
+collector_dataset="$(awk '/^  dataset:/ { print $2; exit }' <<<"${otel_values}")"
+collector_namespace="$(awk '/^  namespace:/ { print $2; exit }' <<<"${otel_values}")"
+expected_trace_index="ss4o_traces-${collector_dataset}-${collector_namespace}"
+expected_log_index="ss4o_logs-${collector_dataset}-${collector_namespace}"
+contains "AO profile reads the Collector Trace index" "${ao_sets}" "opensearch.traceIndex=${expected_trace_index}"
+contains "AO profile reads the Collector log index" "${ao_sets}" "opensearch.logIndex=${expected_log_index}"
+
+agent_observability_values="$(<"${SCRIPT_DIR}/../bkn-trace/agent-observability/charts/agent-observability/values.yaml")"
+contains "standalone AO reads the Collector Trace index" "${agent_observability_values}" "traceIndex: ${expected_trace_index}"
+contains "standalone AO reads the Collector log index" "${agent_observability_values}" "logIndex: ${expected_log_index}"
 
 CORE_RELEASE_EXTRA_SETS=()
 _openbkn_trace_profile_sets agent-retrieval

--- a/deploy/scripts/services/openbkn_trace_profile_test.sh
+++ b/deploy/scripts/services/openbkn_trace_profile_test.sh
@@ -46,6 +46,8 @@ contains "AO persists evidence" "${ao_sets}" "evidence.store=opensearch"
 contains "AO enables projection" "${ao_sets}" "core.projection.enabled=true"
 contains "AO creates evidence index" "${ao_sets}" "evidence.indexManagement.createJob.enabled=true"
 contains "AO protects evidence producer ingest" "${ao_sets}" "evidence.ingestAuth.existingSecret=bkn-trace-evidence-ingest"
+contains "AO reads Collector Trace index" "${ao_sets}" "opensearch.traceIndex=ss4o_traces-default-namespace"
+contains "AO reads Collector log index" "${ao_sets}" "opensearch.logIndex=ss4o_logs-default-namespace"
 not_contains "AO has no query gateway Secret" "${ao_sets}" "queryAuth.existingSecret="
 
 CORE_RELEASE_EXTRA_SETS=()
@@ -53,6 +55,7 @@ _openbkn_trace_profile_sets agent-retrieval
 ar_sets="${CORE_RELEASE_EXTRA_SETS[*]:-}"
 contains "retrieval targets internal Trace Core" "${ar_sets}" "observability.lifecycle.core_url=http://agent-observability-internal:8081"
 contains "retrieval emits Trace spans" "${ar_sets}" "observability.trace.enabled=true"
+contains "retrieval emits searchable runtime logs" "${ar_sets}" "observability.log.enabled=true"
 contains "retrieval emits evidence through token-protected ingest" "${ar_sets}" "observability.evidence.ingest_url=http://agent-observability:8080/api/agent-observability/v1/evidence/events"
 contains "retrieval uses evidence ingest Secret" "${ar_sets}" "observability.evidence.ingest_token_secret_name=bkn-trace-evidence-ingest"
 not_contains "retrieval has no query gateway Secret" "${ar_sets}" "gateway_token_secret_name="


### PR DESCRIPTION
## Summary
- enable Context Loader runtime business logs in the complete OpenBKN install profile
- align Agent Observability log and trace query indexes with the OTEL Collector namespace indexes
- add regression coverage for all three release settings

## Validation
- `openbkn_trace_profile_test.sh`: 27 checks passed
- Trace prerequisite, MariaDB, initial-password, instance-id, retire, status, registry and preflight tests passed
- local E2E after restart: 1 conversation / 5 interactions / 11 OpenBKN calls persisted
- Trace -> logs navigation returned the matching `runtime.business` event and logs link back to Trace

## Scope
Standalone chart defaults remain unchanged; this only fixes the complete OpenBKN installation profile.