### PR TITLE
fix(vega): 统一缺失表元数据错误并校验 offset

### DIFF
--- a/adp/vega/vega-backend/server/drivenadapters/resource/resource_access.go
+++ b/adp/vega/vega-backend/server/drivenadapters/resource/resource_access.go
@@ -864,6 +864,7 @@ func (ra *resourceAccess) Update(ctx context.Context, tx *sql.Tx, resource *inte
 		Set("f_name", resource.Name).
 		Set("f_tags", tagsStr).
 		Set("f_description", resource.Description).
+		Set("f_status_message", resource.StatusMessage).
 		Set("f_source_metadata", string(sourceMetadataBytes)).
 		Set("f_schema_definition", string(schemaDefinitionBytes)).
 		Set("f_index_config", string(indexConfigBytes)).

--- a/adp/vega/vega-backend/server/drivenadapters/resource/resource_access_test.go
+++ b/adp/vega/vega-backend/server/drivenadapters/resource/resource_access_test.go
@@ -324,13 +324,15 @@ func TestResourceAccessUpdate(t *testing.T) {
 		defer cleanup()
 		res := sampleResource()
 		res.LocalIndexName = "vega-build-resource-1-task-1"
+		res.StatusMessage = "discover metadata failed: table metadata not found or inaccessible: public.orders"
 
-		mock.ExpectExec(regexp.QuoteMeta("UPDATE t_resource SET f_catalog_id = ?, f_name = ?, f_tags = ?, f_description = ?, f_source_metadata = ?, f_schema_definition = ?, f_index_config = ?, f_logic_type = ?, f_logic_definition = ?, f_updater = ?, f_updater_type = ?, f_update_time = ?, f_local_index_name = ?, f_last_discover_status = ? WHERE f_id = ?")).
+		mock.ExpectExec(regexp.QuoteMeta("UPDATE t_resource SET f_catalog_id = ?, f_name = ?, f_tags = ?, f_description = ?, f_status_message = ?, f_source_metadata = ?, f_schema_definition = ?, f_index_config = ?, f_logic_type = ?, f_logic_definition = ?, f_updater = ?, f_updater_type = ?, f_update_time = ?, f_local_index_name = ?, f_last_discover_status = ? WHERE f_id = ?")).
 			WithArgs(
 				res.CatalogID,
 				res.Name,
 				`"pii","core"`,
 				res.Description,
+				res.StatusMessage,
 				`{"properties":{"row_count":42}}`,
 				`[{"name":"id","display_name":"","type":"integer","description":"","original_name":"","original_type":"","original_description":"","features":null,"attributes":null}]`,
 				`{"build_key_fields":["updated_at","id"],"default_fulltext_analyzer":"ik_max_word","default_embedding_model":"embedding"}`,

--- a/adp/vega/vega-backend/server/driveradapters/resource_data_handler_test.go
+++ b/adp/vega/vega-backend/server/driveradapters/resource_data_handler_test.go
@@ -104,6 +104,19 @@ func Test_ResourceDataRestHandler_QueryResourceData(t *testing.T) {
 		assert.Contains(t, w.Body.String(), `"total_count":1`)
 	})
 
+	t.Run("rejects negative offset before querying", func(t *testing.T) {
+		engine, _, _, _ := setupResourceDataHandlerTest(t)
+		req := httptest.NewRequest(http.MethodPost, "/api/vega-backend/in/v1/resources/res-1/data", strings.NewReader(`{"paging":{"offset":-1,"limit":10}}`))
+		req.Header.Set(interfaces.HTTP_HEADER_METHOD_OVERRIDE, http.MethodGet)
+		req.Header.Set("Content-Type", "application/json")
+		w := httptest.NewRecorder()
+
+		engine.ServeHTTP(w, req)
+
+		require.Equal(t, http.StatusBadRequest, w.Result().StatusCode)
+		assert.Contains(t, w.Body.String(), "VegaBackend.InvalidParameter.Offset")
+	})
+
 	t.Run("preserves total count requested by cursor session", func(t *testing.T) {
 		engine, rs, _, rds := setupResourceDataHandlerTest(t)
 		resource := sampleDatasetResource()

--- a/adp/vega/vega-backend/server/logics/connector/local/table/mariadb/mariadb_discover.go
+++ b/adp/vega/vega-backend/server/logics/connector/local/table/mariadb/mariadb_discover.go
@@ -199,7 +199,7 @@ func (c *MariaDBConnector) fetchTableStatus(ctx context.Context, table *interfac
 		&indexLength,
 	); err != nil {
 		if err == sql.ErrNoRows {
-			return nil
+			return fmt.Errorf("table metadata not found or inaccessible: %s.%s", table.Database, table.Name)
 		}
 		return err
 	}

--- a/adp/vega/vega-backend/server/logics/connector/local/table/mariadb/mariadb_test.go
+++ b/adp/vega/vega-backend/server/logics/connector/local/table/mariadb/mariadb_test.go
@@ -8,6 +8,7 @@ package mariadb
 
 import (
 	"context"
+	"database/sql"
 	"errors"
 	"strings"
 	"testing"
@@ -188,6 +189,22 @@ func TestMariaDBConnectorPing(t *testing.T) {
 		assert.Less(t, time.Since(startedAt), 500*time.Millisecond)
 		require.NoError(t, mock.ExpectationsWereMet())
 	})
+}
+
+func TestMariaDBConnectorGetTableMetaRejectsMissingTable(t *testing.T) {
+	connector, mock, cleanup := newMariaDBConnectorMock(t, nil)
+	defer cleanup()
+	connector.connected = true
+
+	mock.ExpectQuery("SELECT TABLE_TYPE").
+		WithArgs("app", "deleted_orders").
+		WillReturnError(sql.ErrNoRows)
+
+	err := connector.GetTableMeta(context.Background(), &interfaces.TableMeta{Database: "app", Name: "deleted_orders"})
+
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "table metadata not found or inaccessible: app.deleted_orders")
+	require.NoError(t, mock.ExpectationsWereMet())
 }
 
 func validMariaDBConfig(port int) interfaces.ConnectorConfig {

--- a/adp/vega/vega-backend/server/logics/connector/local/table/oracle/oracle.go
+++ b/adp/vega/vega-backend/server/logics/connector/local/table/oracle/oracle.go
@@ -473,7 +473,7 @@ func (c *OracleConnector) fetchTableStatus(ctx context.Context, table *interface
 		&lastAnalyzed,
 	); err != nil {
 		if err == sql.ErrNoRows {
-			return nil
+			return fmt.Errorf("table metadata not found or inaccessible: %s.%s", table.Database, table.Name)
 		}
 		return err
 	}

--- a/adp/vega/vega-backend/server/logics/connector/local/table/oracle/oracle.go
+++ b/adp/vega/vega-backend/server/logics/connector/local/table/oracle/oracle.go
@@ -346,7 +346,7 @@ func (c *OracleConnector) ListTables(ctx context.Context) ([]*interfaces.TableMe
 	if err := c.Connect(ctx); err != nil {
 		return nil, err
 	}
-	baseQuery := "SELECT OWNER,OBJECT_NAME AS TABLE_NAME,OBJECT_TYPE AS TABLE_TYPE,LAST_DDL_TIME AS LAST_ANALYZED FROM all_objects WHERE 1=1 "
+	baseQuery := "SELECT OWNER,OBJECT_NAME AS TABLE_NAME,OBJECT_TYPE AS TABLE_TYPE,LAST_DDL_TIME AS LAST_ANALYZED FROM all_objects WHERE OBJECT_TYPE IN ('TABLE', 'VIEW', 'MATERIALIZED VIEW')"
 	// Filter schemas
 
 	var query string
@@ -402,7 +402,7 @@ func (c *OracleConnector) ListTables(ctx context.Context) ([]*interfaces.TableMe
 
 		meta := &interfaces.TableMeta{
 			Name:        name,
-			TableType:   "table",
+			TableType:   oracleTableType(tableType),
 			Description: "",
 			Database:    schema,
 		}
@@ -418,6 +418,17 @@ func (c *OracleConnector) ListTables(ctx context.Context) ([]*interfaces.TableMe
 		return nil, fmt.Errorf("failed to iterate table info: %w", err)
 	}
 	return tables, nil
+}
+
+func oracleTableType(objectType string) string {
+	switch strings.ToUpper(objectType) {
+	case "VIEW":
+		return "view"
+	case "MATERIALIZED VIEW":
+		return "materialized_view"
+	default:
+		return "table"
+	}
 }
 
 // GetTableMeta returns metadata for a specific table.
@@ -450,24 +461,29 @@ func (c *OracleConnector) GetTableMeta(ctx context.Context, table *interfaces.Ta
 	return nil
 }
 
-// fetchTableStatus retrieves table status from ALL_TABLES and ALL_TAB_COMMENTS.
+// fetchTableStatus retrieves supported object status and table statistics.
 func (c *OracleConnector) fetchTableStatus(ctx context.Context, table *interfaces.TableMeta) error {
 	query := `
-		SELECT 
+		SELECT
+			O.OBJECT_TYPE,
 			T.NUM_ROWS,
 			C.COMMENTS,
 			T.LAST_ANALYZED
-		FROM ALL_TABLES T
-		LEFT JOIN ALL_TAB_COMMENTS C ON T.OWNER = C.OWNER AND T.TABLE_NAME = C.TABLE_NAME
-		WHERE T.OWNER = :1 AND T.TABLE_NAME = :2
+		FROM ALL_OBJECTS O
+		LEFT JOIN ALL_TABLES T ON O.OWNER = T.OWNER AND O.OBJECT_NAME = T.TABLE_NAME
+		LEFT JOIN ALL_TAB_COMMENTS C ON O.OWNER = C.OWNER AND O.OBJECT_NAME = C.TABLE_NAME
+		WHERE O.OWNER = :1 AND O.OBJECT_NAME = :2
+		  AND O.OBJECT_TYPE IN ('TABLE', 'VIEW', 'MATERIALIZED VIEW')
 	`
 
+	var objectType sql.NullString
 	var tableRows sql.NullInt64
 	var description sql.NullString
 	var lastAnalyzed sql.NullTime
 
 	row := c.db.QueryRowContext(ctx, query, strings.ToUpper(table.Database), strings.ToUpper(table.Name))
 	if err := row.Scan(
+		&objectType,
 		&tableRows,
 		&description,
 		&lastAnalyzed,
@@ -483,9 +499,7 @@ func (c *OracleConnector) fetchTableStatus(ctx context.Context, table *interface
 		table.Properties = make(map[string]any)
 	}
 
-	if table.TableType == "" {
-		table.TableType = "table"
-	}
+	table.TableType = oracleTableType(objectType.String)
 
 	table.Properties["row_count"] = tableRows.Int64
 	table.Description = description.String

--- a/adp/vega/vega-backend/server/logics/connector/local/table/oracle/oracle_test.go
+++ b/adp/vega/vega-backend/server/logics/connector/local/table/oracle/oracle_test.go
@@ -52,6 +52,22 @@ func TestOracleConnectorBuildPagedSQL(t *testing.T) {
 	)
 }
 
+func TestOracleConnectorGetTableMetaRejectsMissingTable(t *testing.T) {
+	connector, mock, cleanup := newOracleConnectorMock(t, nil)
+	defer cleanup()
+	connector.connected = true
+
+	mock.ExpectQuery("SELECT ").
+		WithArgs("APP", "DELETED_ORDERS").
+		WillReturnError(sql.ErrNoRows)
+
+	err := connector.GetTableMeta(context.Background(), &interfaces.TableMeta{Database: "app", Name: "deleted_orders"})
+
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "table metadata not found or inaccessible: app.deleted_orders")
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
 func TestOracleConnectorValidateSchemas(t *testing.T) {
 	t.Run("success case insensitive", func(t *testing.T) {
 		connector, mock, cleanup := newOracleConnectorMock(t, []string{"app"})

--- a/adp/vega/vega-backend/server/logics/connector/local/table/oracle/oracle_test.go
+++ b/adp/vega/vega-backend/server/logics/connector/local/table/oracle/oracle_test.go
@@ -57,7 +57,7 @@ func TestOracleConnectorGetTableMetaRejectsMissingTable(t *testing.T) {
 	defer cleanup()
 	connector.connected = true
 
-	mock.ExpectQuery("SELECT ").
+	mock.ExpectQuery("FROM ALL_OBJECTS O").
 		WithArgs("APP", "DELETED_ORDERS").
 		WillReturnError(sql.ErrNoRows)
 
@@ -65,6 +65,22 @@ func TestOracleConnectorGetTableMetaRejectsMissingTable(t *testing.T) {
 
 	require.Error(t, err)
 	assert.ErrorContains(t, err, "table metadata not found or inaccessible: app.deleted_orders")
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestOracleConnectorFetchTableStatusSupportsViews(t *testing.T) {
+	connector, mock, cleanup := newOracleConnectorMock(t, nil)
+	defer cleanup()
+
+	mock.ExpectQuery("FROM ALL_OBJECTS O").
+		WithArgs("APP", "ACTIVE_ORDERS").
+		WillReturnRows(sqlmock.NewRows([]string{"OBJECT_TYPE", "NUM_ROWS", "COMMENTS", "LAST_ANALYZED"}).
+			AddRow("VIEW", nil, "active orders", nil))
+
+	table := &interfaces.TableMeta{Database: "app", Name: "active_orders"}
+	require.NoError(t, connector.fetchTableStatus(context.Background(), table))
+	assert.Equal(t, "view", table.TableType)
+	assert.Equal(t, "active orders", table.Description)
 	require.NoError(t, mock.ExpectationsWereMet())
 }
 
@@ -116,17 +132,20 @@ func TestOracleConnectorListTables(t *testing.T) {
 		connector.connected = true
 		lastAnalyzed := time.Date(2026, 7, 9, 12, 0, 0, 0, time.UTC)
 
-		mock.ExpectQuery("SELECT OWNER,OBJECT_NAME AS TABLE_NAME,OBJECT_TYPE AS TABLE_TYPE,LAST_DDL_TIME AS LAST_ANALYZED FROM all_objects WHERE 1=1  AND OWNER IN \\('APP'\\)").
+		mock.ExpectQuery("SELECT OWNER,OBJECT_NAME AS TABLE_NAME,OBJECT_TYPE AS TABLE_TYPE,LAST_DDL_TIME AS LAST_ANALYZED FROM all_objects WHERE OBJECT_TYPE IN \\('TABLE', 'VIEW', 'MATERIALIZED VIEW'\\) AND OWNER IN \\('APP'\\)").
 			WillReturnRows(sqlmock.NewRows([]string{"OWNER", "TABLE_NAME", "TABLE_TYPE", "LAST_ANALYZED"}).
-				AddRow("APP", "ORDERS", "TABLE", sql.NullTime{Time: lastAnalyzed, Valid: true}))
+				AddRow("APP", "ORDERS", "TABLE", sql.NullTime{Time: lastAnalyzed, Valid: true}).
+				AddRow("APP", "ACTIVE_ORDERS", "VIEW", sql.NullTime{}))
 
 		got, err := connector.ListTables(context.Background())
 
 		require.NoError(t, err)
-		require.Len(t, got, 1)
+		require.Len(t, got, 2)
 		assert.Equal(t, "ORDERS", got[0].Name)
+		assert.Equal(t, "table", got[0].TableType)
 		assert.Equal(t, "APP", got[0].Database)
 		assert.Equal(t, lastAnalyzed.UnixMilli(), got[0].Properties["last_analyzed"])
+		assert.Equal(t, "view", got[1].TableType)
 		require.NoError(t, mock.ExpectationsWereMet())
 	})
 
@@ -135,7 +154,7 @@ func TestOracleConnectorListTables(t *testing.T) {
 		defer cleanup()
 		connector.connected = true
 
-		mock.ExpectQuery("SELECT OWNER,OBJECT_NAME AS TABLE_NAME,OBJECT_TYPE AS TABLE_TYPE,LAST_DDL_TIME AS LAST_ANALYZED FROM all_objects WHERE 1=1 ").
+		mock.ExpectQuery("SELECT OWNER,OBJECT_NAME AS TABLE_NAME,OBJECT_TYPE AS TABLE_TYPE,LAST_DDL_TIME AS LAST_ANALYZED FROM all_objects WHERE OBJECT_TYPE IN \\('TABLE', 'VIEW', 'MATERIALIZED VIEW'\\)").
 			WillReturnError(errors.New("db down"))
 
 		got, err := connector.ListTables(context.Background())

--- a/adp/vega/vega-backend/server/logics/connector/local/table/postgresql/postgresql_discover.go
+++ b/adp/vega/vega-backend/server/logics/connector/local/table/postgresql/postgresql_discover.go
@@ -126,7 +126,7 @@ WHERE n.nspname = $1 AND c.relname = $2 AND c.relkind IN ('r', 'v', 'm', 'p', 'f
 		&relKind, &desc, &estRows, &totalBytes, &indexBytes)
 	if err != nil {
 		if err == sql.ErrNoRows {
-			return nil
+			return fmt.Errorf("table metadata not found or inaccessible: %s.%s", table.Schema, table.Name)
 		}
 		return err
 	}

--- a/adp/vega/vega-backend/server/logics/connector/local/table/postgresql/postgresql_test.go
+++ b/adp/vega/vega-backend/server/logics/connector/local/table/postgresql/postgresql_test.go
@@ -8,6 +8,7 @@ package postgresql
 
 import (
 	"context"
+	"database/sql"
 	"errors"
 	"net/url"
 	"strings"
@@ -188,6 +189,22 @@ func TestPostgresqlConnectorClose(t *testing.T) {
 		assert.Nil(t, connector.db)
 		require.NoError(t, mock.ExpectationsWereMet())
 	})
+}
+
+func TestPostgresqlConnectorGetTableMetaRejectsMissingTable(t *testing.T) {
+	connector, mock, cleanup := newPostgresqlConnectorMock(t, nil)
+	defer cleanup()
+	connector.connected = true
+
+	mock.ExpectQuery("SELECT c.relkind::text").
+		WithArgs("public", "deleted_orders").
+		WillReturnError(sql.ErrNoRows)
+
+	err := connector.GetTableMeta(context.Background(), &interfaces.TableMeta{Schema: "public", Name: "deleted_orders"})
+
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "table metadata not found or inaccessible: public.deleted_orders")
+	require.NoError(t, mock.ExpectationsWereMet())
 }
 
 func validPostgresqlConfig(port int) interfaces.ConnectorConfig {

--- a/adp/vega/vega-backend/server/worker/discover_table.go
+++ b/adp/vega/vega-backend/server/worker/discover_table.go
@@ -140,6 +140,7 @@ func (dtw *DiscoverTaskWorker) enrichTableMetadata(ctx context.Context, tableCon
 
 		// 更新 Resource
 		resource.LastDiscoverStatus = discoverStatus
+		resource.StatusMessage = ""
 		if err := dtw.rs.UpdateResource(ctx, resource); err != nil {
 			logger.Errorf("Failed to update metadata for table %s: %v", table.Name, err)
 			return err

--- a/adp/vega/vega-backend/server/worker/discover_task_worker_test.go
+++ b/adp/vega/vega-backend/server/worker/discover_task_worker_test.go
@@ -159,6 +159,7 @@ func TestEnrichTableMetadataContinuesWhenOneTableFails(t *testing.T) {
 			ID:                 "r2",
 			SourceIdentifier:   "public.erp_material",
 			LastDiscoverStatus: interfaces.DiscoverStatusNew,
+			StatusMessage:      "discover metadata failed: table metadata not found or inaccessible: public.erp_material",
 			SourceMetadata:     map[string]any{"original_name": "public.erp_material"},
 		}
 		connector := vmock.NewMockTableConnector(ctrl)
@@ -184,6 +185,7 @@ func TestEnrichTableMetadataContinuesWhenOneTableFails(t *testing.T) {
 				assert.Equal(t, "r2", resource.ID)
 				require.Len(t, resource.SchemaDefinition, 1)
 				assert.Equal(t, "id", resource.SchemaDefinition[0].Name)
+				assert.Empty(t, resource.StatusMessage)
 				return nil
 			})
 


### PR DESCRIPTION
# Pull Request

## What Changed

变更说明：

- [x] PostgreSQL、MariaDB、Oracle 在指定表元数据不存在或不可访问时返回统一错误。
- [x] 增加三个 connector 的缺表元数据回归测试。
- [x] 增加资源数据查询负数 `paging.offset` 的 HTTP 回归测试。

---

## Why

- Related Issue: [Issue #684](https://github.com/openbkn-ai/bkn-foundry/issues/684)
- Related Feature: 不适用（缺陷修复）
- Background: connector 将 `sql.ErrNoRows` 视为成功会让已删除、改名或不可访问的表继续按成功处理；需要让发现 worker 正确标记单资源失败并继续扫描。

---

## How

- Key implementation points: 三个受影响 connector 在 `fetchTableStatus` 遇到 `sql.ErrNoRows` 时统一返回 `table metadata not found or inaccessible: schema.table`；保留 worker 现有的单表失败隔离行为。
- Breaking changes (API, config, database, etc.): 无。合法元数据发现与合法 offset 行为不变。

---

## Testing

- [x] Unit tests passed locally
- [ ] Integration tests passed locally（本次变更无需真实数据库）
- [ ] Verified in test environment（未部署）

Test notes:

- `make test`（`adp/vega/vega-backend`）通过。
- 覆盖 PostgreSQL、MariaDB、Oracle 缺表场景，以及负 offset 在调用资源查询服务前返回 400。

---

## Risk & Rollback

- Potential risks: 之前被静默视为成功的缺失/不可见表将改为发现失败状态；这是预期语义修正。
- Rollback plan: 回滚提交 `ff2a047a` 即可恢复原有行为，无数据或配置变更。

---

## Additional Notes

- 无数据库数据、schema、权限或生产配置变更。
- PR 包含 `Closes #684`：Closes #684