### PR TITLE
fix(claude-review): the bot writes Chinese on the PR again

### DIFF
--- a/.github/workflows/automation-claude-review.yml
+++ b/.github/workflows/automation-claude-review.yml
@@ -268,7 +268,7 @@ jobs:
           if paths:
               shards.append({
                   "key": "contract",
-                  "label": "cross-module contracts / config & deployment / data plane",
+                  "label": "跨模块契约 / 配置与部署面 / 数据面",
                   "kind": "contract",
                   "files": "",
                   "files_shallow": "",
@@ -301,16 +301,15 @@ jobs:
           import json, os
           shards = json.loads(os.environ["SHARDS"])
           lines = ["<!-- claude-review-progress -->",
-                   '### <img src="%s" width="16" height="16" /> Review in progress'
+                   '### <img src="%s" width="16" height="16" /> 评审进行中'
                    % os.environ["SPINNER"],
                    "",
-                   "Running %d shards in parallel; a single verdict lands once "
-                   "they all report." % len(shards),
+                   "按模块分 %d 片并行，逐片完成后统一给出一次结论。" % len(shards),
                    ""]
           # 复选框由各分片跑完后回来打勾（review job 的 Tick progress 步骤）。
           lines += ["- [ ] `%s`" % s["label"] for s in shards]
-          lines += ["", "[View run](%s)" % os.environ["RUN_URL"],
-                    "", "_This comment disappears once the verdict is posted._"]
+          lines += ["", "[查看运行日志](%s)" % os.environ["RUN_URL"],
+                    "", "_结论落地后这条会自动消失。_"]
           print("\n".join(lines))
           PY
           )
@@ -528,9 +527,8 @@ jobs:
 
             两件事，缺一不可：
 
-            **一律用英文**写 inline comment 与 findings JSON 里的所有文字，不论 PR
-            本身是什么语言——本仓的 PR 标题、正文与评审输出统一用英文。代码标识符、
-            错误信息、命令、路径保持原样。
+            **一律用中文**写 inline comment 与 findings JSON 里的所有文字。代码标识符、
+            错误信息、命令、路径保持原样，不翻译。
 
             **一、先写 `${{ github.workspace }}/findings/${{ matrix.shard.key }}.json`**
             （绝对路径）。**这一步排在最前面是有意的**：它是你这片唯一会进入最终结论的
@@ -618,7 +616,7 @@ jobs:
           f="findings/${SHARD_KEY}.json"
           if [ ! -s "$f" ]; then
             echo "::warning::分片 ${SHARD_KEY} 未写出 findings，回填占位。"
-            printf '{"shard":"%s","status":"no_output","summary":"","impact":"","blockers":[],"unconfirmed":[],"not_covered":"Shard finished without writing a conclusion; its files were not reviewed."}\n' \
+            printf '{"shard":"%s","status":"no_output","summary":"","impact":"","blockers":[],"unconfirmed":[],"not_covered":"本片跑完但没落下结论，这些文件未经评审。"}\n' \
               "${SHARD_KEY}" > "$f"
           fi
 
@@ -661,7 +659,7 @@ jobs:
 
           done = "- [x] `%s`" % label
           if not reviewed:
-              done += " — no conclusion produced; these files were not reviewed"
+              done += " —— 未产出结论，本片文件未经评审"
           todo = "- [ ] `%s`" % label
 
           def gh(*args):
@@ -876,7 +874,7 @@ jobs:
             {
               "verdicts": [
                 {"id": "adp-bkn#0", "refuted": true,
-                 "reason": "why it was refuted or confirmed, naming the file and lines you read"}
+                 "reason": "驳回或确认的理由，指明你读了哪个文件的哪几行"}
               ],
               "notes": "复核过程中顺带发现的、但不属于本次阻塞项的事情，可以为空串"
             }
@@ -885,8 +883,8 @@ jobs:
             `reason` 里必须出现你**这一轮真读过的** file:line。这是复核结论本身的
             evidence，写不出来的结论和它要驳回的东西是同一种毛病。
 
-            `reason` **一律用英文**。它会原样进 verdict 正文，夹在英文骨架
-            （`Refuted because:` 与折叠区标题）之间，写中文就又成了一份混排文档。
+            `reason` **一律用中文**。它会原样进 verdict 正文，与骨架和分片给的文字
+            并排显示，语言不一致会读成两份东西。
           claude_args: |
             --model claude-opus-5
             --effort xhigh
@@ -1010,26 +1008,28 @@ jobs:
               except (ValueError, OSError):
                   verdicts = {}
 
-          # 所有面向 PR 的文字一律英文（PR 标题/正文/评审输出的既定口径）。此前这里
-          # 按分片投票在 zh/en 之间切换，结果是英文 PR 上仍会混进中文骨架与中文分片名。
-          T = {"block": "Blockers",
-               "verified": "Each item below survived an independent verification pass (refuted by default; kept only when confirmed against the source).",
-               "unrev": " (**unverified** — the verification stage produced no result)",
-               "scen": "Failure scenario: ",
-               "dropped": "%d item(s) dropped by verification", "why": "Refuted because: ",
-               "byshard": "Per-shard findings", "impact": "Blast radius: ", "notcov": "Not covered: ",
-               "clean": "_(no issues)_", "counts": "_(%d blocking, %d open)_",
-               "detail": "Blast radius and coverage gaps, per shard",
-               "more_unconf": "%d further open questions were trimmed to keep this readable; see the shard logs.",
-               "unconf": "Open questions (non-blocking)", "missing": "Shards with no result",
-               "missing_body": "These shards produced no findings — **their files were not reviewed this round**:",
-               "reason_no_output": "ran, but wrote no conclusion (most likely the turn limit, or it wrapped up early)",
-               "reason_absent": "never ran, or died partway through",
-               "reason_malformed": "wrote a conclusion file that could not be parsed",
-               "trunc": "File list truncated",
-               "trunc_body": "This PR changes %s files but only %s reached the planner (`gh pr view --json files` caps at 100) — **the remaining %d were not assigned to any shard and were not reviewed**.",
-               "footer": "Push a new commit when addressed, or reply `/review` for another round.",
-               "footer_ok": "Disagree, or want another pass? Reply `/review` — a plain comment does not trigger one, and the replier must be an OWNER/MEMBER/COLLABORATOR of this repo."}
+          # 机器人贴到 PR 上的文字一律中文：结论骨架、分片名、进度评论、空转通告、
+          # 回填占位、verify 的驳回理由，全部同一种语言。曾按分片投票在 zh/en 之间切换，
+          # 结果是骨架跟着投票走、分片名等仍写死中文，拿到的是混排文档——所以不做切换，
+          # 定死一种。注意这与「我们自己写的 PR 标题与正文用英文」是两回事，别混淆。
+          T = {"block": "阻塞项",
+               "verified": "以下每一条都经过一轮独立复核（默认驳回，核实通过才保留）。",
+               "unrev": "（**未复核**，复核环节未产出结论）",
+               "scen": "失效场景：",
+               "dropped": "复核未通过、已丢弃的 %d 条", "why": "驳回理由：",
+               "byshard": "各分片结论", "impact": "影响范围：", "notcov": "未覆盖：",
+               "clean": "_（无问题）_", "counts": "_（阻塞 %d，待确认 %d）_",
+               "detail": "各分片的影响范围与未覆盖面",
+               "more_unconf": "另有 %d 条待确认项已省略，以免正文过长；详见各分片日志。",
+               "unconf": "待确认项（不阻断放行）", "missing": "未产出结论的分片",
+               "missing_body": "下面这些分片没有产出结论，**这些文件本轮未经评审**：",
+               "reason_no_output": "跑完了但没落下结论（多半是撞轮次上限或提前收尾）",
+               "reason_absent": "整个分片没跑起来或中途挂了",
+               "reason_malformed": "写出的结论文件解析不了",
+               "trunc": "文件清单被截断",
+               "trunc_body": "本 PR 共 %s 个改动文件，分片只拿到 %s 个（`gh pr view --json files` 单次上限 100），**其余 %d 个未进入任何分片、本轮未经评审**。",
+               "footer": "改完请推新提交，或回复 `/review` 要一轮复评。",
+               "footer_ok": "有异议或想再评一轮，请回复 `/review`——普通回帖不会触发复评，且回帖人需为本仓 OWNER/MEMBER/COLLABORATOR。"}
 
           # 模型不一定听话，长度要有确定性兜底——与「模型输出是不可信输入」同一思路。
           def clip(x, n):
@@ -1206,7 +1206,7 @@ jobs:
           state=$(gh pr view "$PR_NUMBER" --json state --jq .state)
           [ "$state" = "OPEN" ] || exit 0
           MARKER='<!-- claude-review-empty -->'
-          body=$(printf '%s\n### Review round produced nothing\n\nNo shard produced a conclusion, so **these changes were not reviewed this round**. No verdict was recorded because there is nothing to vote on — neither `request-changes` nor `approve` would be honest.\n\nUsual causes: a shard hit the turn limit, the model never wrote its conclusion file, the assembly step failed, or the credential is missing. [View run](%s)\n\nReply `/review` to ask for another round. This notice disappears as soon as a round lands a verdict.' "$MARKER" "$RUN_URL")
+          body=$(printf '%s\n### 本轮评审没有产出结论\n\n没有分片落下结论，**这些改动本轮未经评审**。没有表态是因为无从表态——既不该 request-changes，也不该 approve。\n\n常见原因：分片撞轮次上限、模型未写出结论文件、汇总步骤失败、凭据缺失。[查看运行日志](%s)\n\n回复 `/review` 可以再要一轮。下一轮真出了结论，这条会自动消失。' "$MARKER" "$RUN_URL")
           # 复用同一条：synchronize 每次推送跑一轮，凭据缺失这类持续故障否则会在 PR 上
           # 堆出一串一模一样的通告，正是进度评论当初特意避开的噪声。
           existing=$(gh api "repos/${GH_REPO}/issues/${PR_NUMBER}/comments" --paginate \


### PR DESCRIPTION
> Stacked on #689, which is stacked on #688. Bases collapse to `main` as they merge.

## What changes

#681 switched every PR-facing string the workflow emits to English. This reverts that part. Back to Chinese:

- inline comments and the findings JSON text
- the verdict body and its skeleton (`阻塞项` / `各分片结论` / `待确认项` / …)
- shard labels — the contract shard is `跨模块契约 / 配置与部署面 / 数据面` again
- the progress comment and the empty-round notice
- the backfill placeholder and the "no conclusion produced" annotation
- verify's refutation reasons

## What #681 got right, and this keeps

There is exactly **one** language, chosen statically. The zh/en switch #681 removed voted on a per-shard `lang` field for the body skeleton, while shard labels and the surrounding notices stayed hardcoded Chinese — so the output was mixed whichever way the vote went. No switch is reintroduced here.

## Not to be conflated

This governs what the **bot** writes on a PR. PR titles and bodies **we** write stay English. Both rules now sit next to the string table in a comment, since this is the second time they have been mixed up.

## Rendered

```
## 阻塞项

以下每一条都经过一轮独立复核（默认驳回，核实通过才保留）。

- **[module/a] x.go:42** — 空指针解引用
  失效场景：入参为空时崩

## 各分片结论

- **module/a** — 核过重试路径。 _（阻塞 1，待确认 1）_
- **module/b** — 无问题。 _（无问题）_
```

## Verification

Assembly script run against a fixture: skeleton, per-shard line, counts tag and footer all render in Chinese; no English string survives outside code identifiers, `gh` commands and file paths.