### PR TITLE
feat(context-loader): MCP 工具目录把技能从数据资源里拆出来

### DIFF
--- a/adp/context-loader/agent-retrieval/server/driveradapters/mcp/schemas/locales/en-US/tools_meta.json
+++ b/adp/context-loader/agent-retrieval/server/driveradapters/mcp/schemas/locales/en-US/tools_meta.json
@@ -54,7 +54,7 @@
   },
   "find_skills": {
     "title": "Find Skills",
-    "group_title": "Resources & Skills",
+    "group_title": "Skills",
     "description": "Find available skills that match a knowledge network, object type, instance context, or user intent."
   },
   "list_knowledge_networks": {
@@ -84,32 +84,32 @@
   },
   "list_resources": {
     "title": "Data Resources",
-    "group_title": "Resources & Skills",
+    "group_title": "Data Resources",
     "description": "List visible data-layer resources independent of ontology object types. Use this when resources are not modeled as object types or when querying raw data directly."
   },
   "describe_resource": {
     "title": "Resource Detail",
-    "group_title": "Resources & Skills",
+    "group_title": "Data Resources",
     "description": "Describe one data resource's physical schema, including connector type and columns. Use this before writing run_sql against raw resources."
   },
   "list_skills": {
     "title": "Skill List",
-    "group_title": "Resources & Skills",
+    "group_title": "Skills",
     "description": "Browse published skills without a knowledge-network context. Complements find_skills, which recalls by object type or instance: this one pages a list filtered by name or category. Take the skill_id to get_skill_content for SKILL.md, read_skill_file for bundled files, execute_skill to run the entry command."
   },
   "get_skill_content": {
     "title": "Skill Content",
-    "group_title": "Resources & Skills",
+    "group_title": "Skills",
     "description": "Read a skill's SKILL.md body and the file listing of its bundle (files[].rel_path). Usage and entry commands are documented there; fetch individual bundled files with read_skill_file instead of reading the whole package."
   },
   "read_skill_file": {
     "title": "Read Skill File",
-    "group_title": "Resources & Skills",
+    "group_title": "Skills",
     "description": "Read one file from a skill bundle; rel_path comes from the files listing returned by get_skill_content. For progressive loading — large files need not stay in context. Binary files return metadata only, no body."
   },
   "execute_skill": {
     "title": "Execute Skill",
-    "group_title": "Resources & Skills",
+    "group_title": "Skills",
     "description": "Run a skill's entry command inside the sandbox and return exit_code / stdout / stderr. entry_shell must come from the entry declared in SKILL.md — read it with get_skill_content first."
   }
 }

--- a/adp/context-loader/agent-retrieval/server/driveradapters/mcp/schemas/tools_meta.json
+++ b/adp/context-loader/agent-retrieval/server/driveradapters/mcp/schemas/tools_meta.json
@@ -90,9 +90,9 @@
   "find_skills": {
     "name": "find_skills",
     "title": "技能召回",
-    "group": "resource",
-    "group_title": "数据资源与技能",
-    "order": 430,
+    "group": "skill",
+    "group_title": "技能",
+    "order": 510,
     "description": "技能召回。根据知识网络、对象类型、实例上下文等召回匹配的可用技能列表。"
   },
   "list_knowledge_networks": {
@@ -139,7 +139,7 @@
     "name": "list_resources",
     "title": "数据资源列表",
     "group": "resource",
-    "group_title": "数据资源与技能",
+    "group_title": "数据资源",
     "order": 410,
     "description": "数据层资源直查（脱离本体）：列出当前账户有权查看的数据资源（resource_id、name、type、catalog_id），可按 catalog_id / type 过滤。资源未建成对象类、或想绕本体直查数据时用。配合 describe_resource + run_sql。"
   },
@@ -147,40 +147,40 @@
     "name": "describe_resource",
     "title": "数据资源详情",
     "group": "resource",
-    "group_title": "数据资源与技能",
+    "group_title": "数据资源",
     "order": 420,
     "description": "取单个数据资源的物理 schema：connector_type 与列（columns:[{name,type}]）。写 run_sql 前用它拿物理列名。入参 resource_id 取自 list_resources。"
   },
   "list_skills": {
     "name": "list_skills",
     "title": "技能列表",
-    "group": "resource",
-    "group_title": "数据资源与技能",
-    "order": 440,
+    "group": "skill",
+    "group_title": "技能",
+    "order": 520,
     "description": "浏览已发布技能（不需要知识网络上下文）。与 find_skills 互补：那条按对象类/实例召回，这条按名称或分类翻列表。拿到 skill_id 后用 get_skill_content 读 SKILL.md，用 read_skill_file 下钻附属文件，用 execute_skill 执行入口命令。"
   },
   "get_skill_content": {
     "name": "get_skill_content",
     "title": "技能内容",
-    "group": "resource",
-    "group_title": "数据资源与技能",
-    "order": 450,
+    "group": "skill",
+    "group_title": "技能",
+    "order": 530,
     "description": "读技能主文档 SKILL.md 正文，并返回技能包内的文件清单（files[].rel_path）。技能的用法与入口命令都写在这里；需要哪个附属文件再用 read_skill_file 单取，不必整包读。"
   },
   "read_skill_file": {
     "name": "read_skill_file",
     "title": "读技能文件",
-    "group": "resource",
-    "group_title": "数据资源与技能",
-    "order": 460,
+    "group": "skill",
+    "group_title": "技能",
+    "order": 540,
     "description": "读技能包内单个文件的正文，rel_path 取自 get_skill_content 返回的 files 清单。渐进式加载用：大文件不必常驻上下文。二进制文件只回元数据不回正文。"
   },
   "execute_skill": {
     "name": "execute_skill",
     "title": "执行技能",
-    "group": "resource",
-    "group_title": "数据资源与技能",
-    "order": 470,
+    "group": "skill",
+    "group_title": "技能",
+    "order": 550,
     "description": "在沙箱内执行技能的入口命令，返回 exit_code / stdout / stderr。entry_shell 必须取自 SKILL.md 声明的入口，先用 get_skill_content 读清楚再调。"
   }
 }


### PR DESCRIPTION
## 问题

`resource` 组装了 7 个工具，两类任务混在一起：

- 数据层直查：`list_resources` / `describe_resource` —— 回答"有哪些表、表里有什么"
- 技能：`find_skills` / `list_skills` / `get_skill_content` / `read_skill_file` / `execute_skill` —— 回答"有哪些能力、怎么用"

组名只好叫「数据资源与技能」，目录读起来像个杂项筐。

## 改动

拆成两组，纯元数据改动（两个 JSON），Go 代码零改动：

| group | 组名 | en-US | order | 工具 |
|---|---|---|---|---|
| `resource` | 数据资源 | Data Resources | 410-420 | `list_resources`, `describe_resource` |
| `skill` | 技能 | Skills | 510-550 | `find_skills`, `list_skills`, `get_skill_content`, `read_skill_file`, `execute_skill` |

其余四组（lifecycle / discovery / query / action）不动。

## 兼容性

工具本身与调用契约不变，只有 `_meta["openbkn.ai/group"]` 与 `openbkn.ai/order` 的取值变了。客户端按这两项分组排序，不需要跟着改代码 —— bkn-studio 侧已按 #665 的契约实现，本地兜底表里 `skill` 组和文案都现成。

## 验证

- `go test ./server/driveradapters/mcp/...` 通过。其中两条守卫正好覆盖这次改动：每个工具必须有 title/group/order 且 order 不可重复；本地化文件只准翻译、不准自带 group/order。
- order 唯一性另外核了一遍（510-550 此前未占用）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)