### PR TITLE
fix(trace): expose interaction artifacts in read model

### DIFF
--- a/bkn-trace/agent-observability/docs/swagger/docs.go
+++ b/bkn-trace/agent-observability/docs/swagger/docs.go
@@ -3895,6 +3895,9 @@ const docTemplate = `{
                         "type": "string"
                     }
                 },
+                "question_artifact_ref": {
+                    "type": "string"
+                },
                 "question_preview": {
                     "type": "string"
                 },
@@ -3903,6 +3906,9 @@ const docTemplate = `{
                     "items": {
                         "$ref": "#/definitions/evidencevo.RequestSummary"
                     }
+                },
+                "result_artifact_ref": {
+                    "type": "string"
                 },
                 "result_preview": {
                     "type": "string"

--- a/bkn-trace/agent-observability/docs/swagger/swagger.json
+++ b/bkn-trace/agent-observability/docs/swagger/swagger.json
@@ -3887,6 +3887,9 @@
                         "type": "string"
                     }
                 },
+                "question_artifact_ref": {
+                    "type": "string"
+                },
                 "question_preview": {
                     "type": "string"
                 },
@@ -3895,6 +3898,9 @@
                     "items": {
                         "$ref": "#/definitions/evidencevo.RequestSummary"
                     }
+                },
+                "result_artifact_ref": {
+                    "type": "string"
                 },
                 "result_preview": {
                     "type": "string"

--- a/bkn-trace/agent-observability/src/domain/service/evidencesvc/service.go
+++ b/bkn-trace/agent-observability/src/domain/service/evidencesvc/service.go
@@ -606,13 +606,13 @@ func buildEvidenceChain(traces []evidencevo.NormalizedTrace, truncated bool) evi
 			switch event.EventType {
 			case "claim.created":
 				claimSourceEventIDs = append(claimSourceEventIDs, stringArrayField(event.Payload, "source_event_ids")...)
-				if visible(event.Payload) {
-					response.Data.Claims = append(response.Data.Claims, cloneMap(event.Payload))
-				} else {
-					countVisibility(event.Payload, &response.VisibilitySummary)
-				}
 				if claimID, ok := stringField(event.Payload, "claim_id"); ok && claimID != "" {
 					knownClaims[claimID] = struct{}{}
+					if visible(event.Payload) {
+						response.Data.Claims = append(response.Data.Claims, cloneMap(event.Payload))
+					} else {
+						countVisibility(event.Payload, &response.VisibilitySummary)
+					}
 				}
 			case "evidence.refs.created":
 				claimID, _ := stringField(event.Payload, "claim_id")
@@ -1234,6 +1234,11 @@ func conclusionScope(traces []evidencevo.NormalizedTrace, knownClaims map[string
 	}
 	for _, trace := range traces {
 		for _, event := range trace.Events {
+			if event.EventType == "claim.created" && event.InteractionID != "" {
+				if claimID, _ := stringField(event.Payload, "claim_id"); claimID == "" {
+					return "interaction"
+				}
+			}
 			if isExecutionFact(event.EventType) && event.InteractionID != "" && event.OperationID != "" {
 				return "interaction"
 			}

--- a/bkn-trace/agent-observability/src/domain/service/evidencesvc/service_test.go
+++ b/bkn-trace/agent-observability/src/domain/service/evidencesvc/service_test.go
@@ -395,6 +395,25 @@ func TestDirectKnowledgeReadExposesBusinessRefsWithoutFabricatingClaim(t *testin
 	}
 }
 
+func TestInteractionResultLinkDoesNotRequireClaimVersionStatus(t *testing.T) {
+	trace := evidencevo.NormalizedTrace{
+		TraceID: "trace_interaction_result", RequestID: "req_interaction_result",
+		Events: []evidencevo.EvidenceEvent{{
+			EventID: "event_interaction_result", EventType: "claim.created",
+			InteractionID: "interaction_result", Payload: map[string]any{
+				"result_artifact_ref": "artifact:result_interaction_result",
+			},
+		}},
+	}
+
+	chain := buildEvidenceChain([]evidencevo.NormalizedTrace{trace}, false)
+
+	if chain.ConclusionScope != "interaction" || chain.Partial ||
+		contains(chain.PartialReasons, "version_status_missing") {
+		t.Fatalf("an interaction result link is not a structured claim: %+v", chain)
+	}
+}
+
 func TestClaimedTraceOwnsItsConclusion(t *testing.T) {
 	trace := queryTrace("trace_claim_scope", "req_claim_scope")
 	service := New(&fakeStore{traces: []evidencevo.NormalizedTrace{trace}})

--- a/bkn-trace/agent-observability/src/domain/service/evidencesvc/summary.go
+++ b/bkn-trace/agent-observability/src/domain/service/evidencesvc/summary.go
@@ -302,6 +302,8 @@ func aggregateRequestGroup(requests []evidencevo.RequestSummary) (evidencevo.Req
 		firstNonEmptySummary(&result.EffectiveSubjectID, request.EffectiveSubjectID)
 		firstNonEmptySummary(&result.BusinessDomain, request.BusinessDomain)
 		firstNonEmptySummary(&result.ErrorSummary, request.ErrorSummary)
+		firstNonEmptySummary(&result.InteractionQuestionArtifactRef, request.InteractionQuestionArtifactRef)
+		firstNonEmptySummary(&result.InteractionResultArtifactRef, request.InteractionResultArtifactRef)
 		result.TraceCount += request.TraceCount
 		if request.InteractionID != "" {
 			interactions[request.InteractionID] = struct{}{}
@@ -437,6 +439,9 @@ func (s *Service) applyCanonicalConversationState(
 				tx, requestsByConversation[entries[index].ConversationID],
 			)
 			entries[index].Status = string(conversation.Status)
+			if !conversation.CreatedAt.IsZero() {
+				entries[index].StartedAt = conversation.CreatedAt.UTC().Format(time.RFC3339Nano)
+			}
 			entries[index].AgentName = conversation.AgentName
 			entries[index].ApplicationPrincipalID = conversation.Owner.ApplicationPrincipalID
 			entries[index].EffectiveSubjectID = conversation.Owner.EffectiveSubjectID
@@ -844,7 +849,9 @@ func (s *Service) GetInteractionSummary(
 	summary.ApplicationPrincipalID = base.ApplicationPrincipalID
 	summary.EffectiveSubjectID = base.EffectiveSubjectID
 	summary.QuestionPreview = base.QuestionPreview
+	summary.QuestionArtifactRef = base.InteractionQuestionArtifactRef
 	summary.ResultPreview = base.ResultPreview
+	summary.ResultArtifactRef = base.InteractionResultArtifactRef
 	summary.EvidenceCompleteness = base.EvidenceCompleteness
 	summary.PartialReasons = append([]string{}, base.PartialReasons...)
 	summary.ErrorSummary = base.ErrorSummary

--- a/bkn-trace/agent-observability/src/domain/service/evidencesvc/summary_service_test.go
+++ b/bkn-trace/agent-observability/src/domain/service/evidencesvc/summary_service_test.go
@@ -77,6 +77,9 @@ func TestListConversationsUsesCanonicalSessionStatus(t *testing.T) {
 	if page.Entries[0].DurationMS != 3000 {
 		t.Fatalf("active conversation must retain completed interaction duration: %+v", page.Entries[0])
 	}
+	if page.Entries[0].StartedAt != "2026-08-03T08:00:00Z" {
+		t.Fatalf("conversation start must come from the Core lifecycle: %+v", page.Entries[0])
+	}
 }
 
 func TestListConversationsSumsCompletedInteractionDurations(t *testing.T) {

--- a/bkn-trace/agent-observability/src/domain/valueobject/evidencevo/summary.go
+++ b/bkn-trace/agent-observability/src/domain/valueobject/evidencevo/summary.go
@@ -17,35 +17,37 @@ type ActionSummary struct {
 }
 
 type RequestSummary struct {
-	RequestID              string        `json:"request_id"`
-	OperationID            string        `json:"operation_id,omitempty"`
-	OperationKey           string        `json:"operation_key,omitempty"`
-	ToolName               string        `json:"tool_name,omitempty"`
-	ControlledSummary      string        `json:"controlled_summary,omitempty"`
-	ConversationID         string        `json:"conversation_id,omitempty"`
-	InteractionID          string        `json:"interaction_id,omitempty"`
-	StartedAt              string        `json:"started_at,omitempty"`
-	CompletedAt            string        `json:"completed_at,omitempty"`
-	Initiator              string        `json:"initiator,omitempty"`
-	AgentOrApp             string        `json:"agent_or_app,omitempty"`
-	AgentName              string        `json:"agent_name,omitempty"`
-	ApplicationPrincipalID string        `json:"application_principal_id,omitempty"`
-	EffectiveSubjectID     string        `json:"effective_subject_id,omitempty"`
-	BusinessDomain         string        `json:"business_domain,omitempty"`
-	KnowledgeNetworks      []string      `json:"knowledge_networks,omitempty"`
-	QuestionPreview        string        `json:"question_preview,omitempty"`
-	ResultPreview          string        `json:"result_preview,omitempty"`
-	ResultCount            *int          `json:"result_count,omitempty"`
-	Status                 string        `json:"status"`
-	EvidenceCompleteness   string        `json:"evidence_completeness"`
-	PartialReasons         []string      `json:"partial_reasons,omitempty"`
-	BusinessRefs           []string      `json:"business_refs,omitempty"`
-	ActionSummary          ActionSummary `json:"action_summary"`
-	TraceCount             int           `json:"trace_count"`
-	DurationMS             int64         `json:"duration_ms,omitempty"`
-	ErrorSummary           string        `json:"error_summary,omitempty"`
-	InteractionQuestion    string        `json:"-"`
-	InteractionResult      string        `json:"-"`
+	RequestID                      string        `json:"request_id"`
+	OperationID                    string        `json:"operation_id,omitempty"`
+	OperationKey                   string        `json:"operation_key,omitempty"`
+	ToolName                       string        `json:"tool_name,omitempty"`
+	ControlledSummary              string        `json:"controlled_summary,omitempty"`
+	ConversationID                 string        `json:"conversation_id,omitempty"`
+	InteractionID                  string        `json:"interaction_id,omitempty"`
+	StartedAt                      string        `json:"started_at,omitempty"`
+	CompletedAt                    string        `json:"completed_at,omitempty"`
+	Initiator                      string        `json:"initiator,omitempty"`
+	AgentOrApp                     string        `json:"agent_or_app,omitempty"`
+	AgentName                      string        `json:"agent_name,omitempty"`
+	ApplicationPrincipalID         string        `json:"application_principal_id,omitempty"`
+	EffectiveSubjectID             string        `json:"effective_subject_id,omitempty"`
+	BusinessDomain                 string        `json:"business_domain,omitempty"`
+	KnowledgeNetworks              []string      `json:"knowledge_networks,omitempty"`
+	QuestionPreview                string        `json:"question_preview,omitempty"`
+	ResultPreview                  string        `json:"result_preview,omitempty"`
+	ResultCount                    *int          `json:"result_count,omitempty"`
+	Status                         string        `json:"status"`
+	EvidenceCompleteness           string        `json:"evidence_completeness"`
+	PartialReasons                 []string      `json:"partial_reasons,omitempty"`
+	BusinessRefs                   []string      `json:"business_refs,omitempty"`
+	ActionSummary                  ActionSummary `json:"action_summary"`
+	TraceCount                     int           `json:"trace_count"`
+	DurationMS                     int64         `json:"duration_ms,omitempty"`
+	ErrorSummary                   string        `json:"error_summary,omitempty"`
+	InteractionQuestion            string        `json:"-"`
+	InteractionResult              string        `json:"-"`
+	InteractionQuestionArtifactRef string        `json:"-"`
+	InteractionResultArtifactRef   string        `json:"-"`
 }
 
 type TraceSummary struct {
@@ -185,7 +187,9 @@ type InteractionSummary struct {
 	StartedAt              string           `json:"started_at,omitempty"`
 	CompletedAt            string           `json:"completed_at,omitempty"`
 	QuestionPreview        string           `json:"question_preview,omitempty"`
+	QuestionArtifactRef    string           `json:"question_artifact_ref,omitempty"`
 	ResultPreview          string           `json:"result_preview,omitempty"`
+	ResultArtifactRef      string           `json:"result_artifact_ref,omitempty"`
 	Status                 string           `json:"status"`
 	EvidenceCompleteness   string           `json:"evidence_completeness"`
 	PartialReasons         []string         `json:"partial_reasons,omitempty"`
@@ -383,6 +387,9 @@ func buildRequestSummary(
 		}
 		switch artifact.ArtifactType {
 		case ArtifactTypeQuestion:
+			if interactionScopedArtifact(artifact) {
+				firstNonEmpty(&summary.InteractionQuestionArtifactRef, artifactReference(artifact.ArtifactID))
+			}
 			if preview := artifactPreview(artifact); preview != "" {
 				if interactionScopedArtifact(artifact) {
 					firstNonEmpty(&summary.InteractionQuestion, preview)
@@ -392,6 +399,9 @@ func buildRequestSummary(
 				}
 			}
 		case ArtifactTypeResult:
+			if interactionScopedArtifact(artifact) {
+				firstNonEmpty(&summary.InteractionResultArtifactRef, artifactReference(artifact.ArtifactID))
+			}
 			if preview := artifactPreview(artifact); preview != "" {
 				if interactionScopedArtifact(artifact) {
 					summary.InteractionResult = preview
@@ -517,6 +527,13 @@ func summaryStringValues(value any) []string {
 
 func interactionScopedArtifact(artifact EvidenceArtifact) bool {
 	return artifact.InteractionID != "" && artifact.OperationID == ""
+}
+
+func artifactReference(artifactID string) string {
+	if artifactID == "" {
+		return ""
+	}
+	return "artifact:" + strings.TrimPrefix(artifactID, "artifact:")
 }
 
 func summaryIntPointer(payload map[string]any, key string) *int {

--- a/bkn-trace/agent-observability/src/domain/valueobject/evidencevo/summary_test.go
+++ b/bkn-trace/agent-observability/src/domain/valueobject/evidencevo/summary_test.go
@@ -459,6 +459,9 @@ func TestBuildExecutionSummariesDoesNotCopyInteractionResultIntoOperation(t *tes
 	if requests[0].ResultPreview != "" {
 		t.Fatalf("interaction result must not be copied into an OpenBKN operation: %+v", requests[0])
 	}
+	if requests[0].InteractionResultArtifactRef != "artifact:interaction_result" {
+		t.Fatalf("interaction result artifact must remain available to the interaction read model: %+v", requests[0])
+	}
 	if len(executions) != 1 || executions[0].Status != "error" {
 		t.Fatalf("failed trace must remain visible: %+v", executions)
 	}

--- a/docs/api/agent-observability/agent-observability.yaml
+++ b/docs/api/agent-observability/agent-observability.yaml
@@ -574,12 +574,16 @@ definitions:
         items:
           type: string
         type: array
+      question_artifact_ref:
+        type: string
       question_preview:
         type: string
       requests:
         items:
           $ref: '#/definitions/evidencevo.RequestSummary'
         type: array
+      result_artifact_ref:
+        type: string
       result_preview:
         type: string
       started_at:


### PR DESCRIPTION
## Summary
- expose interaction question/result artifact references in the canonical read model
- keep request details scoped to the operation while lazily loading full interaction context
- avoid treating interaction results without claim IDs as governed claims

## Verification
- GOCACHE=/private/tmp/openbkn-go-cache go test ./... -count=1
- make check-swag