### PR TITLE
fix(claude-review): make open questions converge across rounds

### DIFF
--- a/.github/workflows/automation-claude-review.yml
+++ b/.github/workflows/automation-claude-review.yml
@@ -144,6 +144,7 @@ jobs:
       pr_number: ${{ steps.meta.outputs.pr_number }}
       shards: ${{ steps.plan.outputs.shards }}
       has_shards: ${{ steps.plan.outputs.has_shards }}
+      prior_rounds: ${{ steps.plan.outputs.prior_rounds }}
       file_total: ${{ steps.plan.outputs.file_total }}
       file_listed: ${{ steps.plan.outputs.file_listed }}
     env:
@@ -287,6 +288,14 @@ jobs:
 
           print("shards=" + json.dumps(shards, ensure_ascii=False))
           print("has_shards=" + ("true" if shards else "false"))
+          # 已有过几轮结论。分片与 verdict 共用这一个数来收紧配额，免得各自从评论历史
+          # 里推断「这是第几轮」还推出不同结果。
+          prior = subprocess.run(
+              ["gh", "api", "repos/%s/pulls/%s/reviews" % (os.environ["GH_REPO"], pr),
+               "--paginate", "--jq", '[.[] | select((.body // "") != "")] | length'],
+              capture_output=True, text=True)
+          print("prior_rounds=%s"
+                % ((prior.stdout.split() or ["0"])[0] if prior.returncode == 0 else "0"))
           print("file_total=%d" % total)
           print("file_listed=%d" % len(paths))
           PY
@@ -553,6 +562,13 @@ jobs:
 
             **一律用中文**写 inline comment 与 findings JSON 里的所有文字。代码标识符、
             错误信息、命令、路径保持原样，不翻译。
+
+            **inline comment 的配额**：此前已有 ${{ needs.plan.outputs.prior_rounds }}
+            轮结论。为 0 时本片最多贴 3 条；不为 0 时最多 1 条，且只针对本轮新增提交。
+            每条 inline 都是一次通知和一个要人去关掉的会话，堆在 Files 视图里不会自己
+            消失——实测出现过 31 个文件的 PR 一轮贴 15 条、1 个文件的 PR 贴 5 条。
+            同一个问题**不要既贴 inline 又写进 unconfirmed**：位置明确、作者照着改就行
+            的贴 inline；需要他判断的写 unconfirmed。
 
             **一、先写 `${{ github.workspace }}/findings/${{ matrix.shard.key }}.json`**
             （绝对路径）。**这一步排在最前面是有意的**：它是你这片唯一会进入最终结论的

--- a/.github/workflows/automation-claude-review.yml
+++ b/.github/workflows/automation-claude-review.yml
@@ -970,6 +970,7 @@ jobs:
     env:
       PR_NUMBER: ${{ needs.plan.outputs.pr_number }}
       SHARDS: ${{ needs.plan.outputs.shards }}
+      PRIOR_ROUNDS: ${{ needs.plan.outputs.prior_rounds }}
       FILE_TOTAL: ${{ needs.plan.outputs.file_total }}
       FILE_LISTED: ${{ needs.plan.outputs.file_listed }}
       GH_TOKEN: ${{ github.token }}
@@ -1158,14 +1159,9 @@ jobs:
           # 复评轮的配额要衰减。待确认项不阻断、成本低，模型每轮都会把配额填满，于是
           # 「每轮十条互不重叠的新问题」可以无限持续——实测 #683 连续三轮如此，而后两轮
           # 本身已经是 approve。收敛规则写进了 prompt，但那靠自觉，这里再挡一道。
-          prior_rounds = 0
-          try:
-              prior_rounds = int(subprocess.run(
-                  ["gh", "api", "repos/%s/pulls/%s/reviews" % (repo, pr), "--paginate",
-                   "--jq", '[.[] | select((.body // "") != "")] | length'],
-                  capture_output=True, text=True, check=True).stdout.split()[0])
-          except Exception:
-              prior_rounds = 0
+          # 轮次由 plan 一次算好传下来，分片与这里共用同一个数，避免两处各查一次、
+          # 也避免它们对「这是第几轮」得出不同结论。
+          prior_rounds = int(os.environ.get("PRIOR_ROUNDS") or 0)
           per_shard_cap, total_cap = (1, 2) if prior_rounds else (2, 6)
 
           # 首轮每片至多 2 条、总共 6 条；复评轮收到 1 条 / 2 条。

--- a/.github/workflows/automation-claude-review.yml
+++ b/.github/workflows/automation-claude-review.yml
@@ -418,8 +418,14 @@ jobs:
             echo ',"review_comments":'
             fetch "pulls/${PR_NUMBER}/comments" \
               '{path, line, user: .user.login, created_at, body}' || echo '[]'
+            # 上一轮的结论正文在 /pulls/N/reviews，与 inline 评论是两个端点。待确认项
+            # 只存在于正文里，不取就等于每轮从零开始——实测 #683 连续三轮各报十条互不
+            # 重叠的待确认项，正是因为看不见自己上一轮说过什么。
+            echo ',"prior_verdicts":'
+            fetch "pulls/${PR_NUMBER}/reviews" \
+              '{user: .user.login, state, submitted_at, body}' || echo '[]'
             echo '}'
-          } > prior-comments.json || echo '{"issue_comments":[],"review_comments":[]}' \
+          } > prior-comments.json || echo '{"issue_comments":[],"review_comments":[],"prior_verdicts":[]}' \
             > prior-comments.json
 
       - name: Claude review
@@ -512,11 +518,18 @@ jobs:
             - 先读回上一轮的评论：已经预取到 `${{ github.workspace }}/prior-comments.json`（绝对
               路径），直接读文件，不要自己去调 API。里面两个来源都有：`issue_comments`
               是顶层评论——作者的处理说明（哪条采纳、哪条不采纳）多半发在这里，
-              `review_comments` 是 inline 评论及其回复。inline 那部分只看落在你这片
-              文件上的；顶层那部分全看。
+              `review_comments` 是 inline 评论及其回复，`prior_verdicts` 是此前每一轮
+              的结论正文——**待确认项只出现在那里**，不读就会把上一轮说过的话换个说法
+              再说一遍。inline 那部分只看落在你这片文件上的；顶层与结论正文全看。
             - **作者明确表示不采纳的建议，记一次就够，本轮不要再列**——包括写进
               unconfirmed。他已经做过判断，再列一遍只是在告诉他你没读他的回复。只有
               出现新证据推翻他的理由时才重提，并在 what 里说清新证据是什么。
+            - **待确认项必须收敛。** 只要 `prior_verdicts` 非空（即此前已有过结论），
+              这一轮的 unconfirmed **每片至多 1 条，且只能是本轮新增提交引入的问题**。
+              此前任何一轮结论正文里出现过的，无论作者有没有处理，都不再提。
+              「换个角度再说一遍同一个文件」也算重提。
+              评审的目标是让 PR 能走，不是每轮都证明自己还能找出东西——一份挑不完
+              毛病的清单，作者第三轮就不看了。
             - 已经提过的问题，作者改了、或给出对得上疑点的解释，就算过。不必追求措辞
               完美，更不要凭「可能」把同一条追问第二遍。
             - 上面的触发式深挖只在首轮做；复评的范围限定在上一轮之后新增的提交与文件。
@@ -991,12 +1004,11 @@ jobs:
         run: |
           set -euo pipefail
           python3 - <<'PY' >> "$GITHUB_OUTPUT"
-          import json, os, pathlib
+          import collections, json, os, pathlib, subprocess
 
+          repo, pr = os.environ["GH_REPO"], os.environ["PR_NUMBER"]
           shards = json.loads(os.environ["SHARDS"])
           root = pathlib.Path("findings")
-
-          import collections
 
           done, missing, blockers, unconfirmed, lines = [], [], [], [], []
           for s in shards:
@@ -1143,7 +1155,20 @@ jobs:
               lines += detail
               lines.append("</details>\n")
 
-          # 每片至多 3 条，且整体封顶——各片各写各的，不封顶就会线性膨胀。
+          # 复评轮的配额要衰减。待确认项不阻断、成本低，模型每轮都会把配额填满，于是
+          # 「每轮十条互不重叠的新问题」可以无限持续——实测 #683 连续三轮如此，而后两轮
+          # 本身已经是 approve。收敛规则写进了 prompt，但那靠自觉，这里再挡一道。
+          prior_rounds = 0
+          try:
+              prior_rounds = int(subprocess.run(
+                  ["gh", "api", "repos/%s/pulls/%s/reviews" % (repo, pr), "--paginate",
+                   "--jq", '[.[] | select((.body // "") != "")] | length'],
+                  capture_output=True, text=True, check=True).stdout.split()[0])
+          except Exception:
+              prior_rounds = 0
+          per_shard_cap, total_cap = (1, 2) if prior_rounds else (2, 6)
+
+          # 首轮每片至多 2 条、总共 6 条；复评轮收到 1 条 / 2 条。
           if unconfirmed:
               lines.append("## %s\n" % T["unconf"])
               # 轮转取，不是先到先得：contract 片固定排在最后，先到先得会让多模块 PR
@@ -1152,9 +1177,9 @@ jobs:
               for s, u in unconfirmed:
                   by_shard.setdefault(s["key"], []).append((s, u))
               shown = 0
-              for rnd in range(2):
+              for rnd in range(per_shard_cap):
                   for k, items in by_shard.items():
-                      if len(items) <= rnd or shown >= 6:
+                      if len(items) <= rnd or shown >= total_cap:
                           continue
                       s, u = items[rnd]
                       shown += 1

--- a/assemble.py
+++ b/assemble.py
@@ -1,0 +1,207 @@
+import collections, json, os, pathlib, subprocess
+
+repo, pr = os.environ["GH_REPO"], os.environ["PR_NUMBER"]
+shards = json.loads(os.environ["SHARDS"])
+root = pathlib.Path("findings")
+
+done, missing, blockers, unconfirmed, lines = [], [], [], [], []
+for s in shards:
+    path = root / (s["key"] + ".json")
+    if not path.exists():
+        missing.append((s, "absent"))
+        continue
+    # 防御要罩住整个循环体，不能只罩 json.loads：文件解析成顶层数组时
+    # data.get() 抛 AttributeError，同样会让 Assemble 非零退出。
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+        if not isinstance(data, dict):
+            raise ValueError("not an object")
+        # 回填的占位不算「产出过结论」：否则全片静默失败会变成 approve 一个
+        # 从没被审过的 PR——比不表态糟得多。
+        status = data.get("status")
+    except (ValueError, OSError, AttributeError):
+        missing.append((s, "malformed"))
+        continue
+    if status == "no_output":
+        missing.append((s, "no_output"))
+        continue
+    done.append((s, data))
+    # findings 是模型写的，属于不可信输入：JSON 合法但结构不对（元素是字符串
+    # 而非对象）会让下面的 dict()/get() 抛异常，Assemble 非零退出后 Post review
+    # 不执行、告警分支也不成立——PR 上既无表态也无告警，只剩一个红叉。
+    # 序号取自 enumerate 而非计数器，跳过畸形元素不会让 id 错位（id 是
+    # survived/refuted 分类的唯一依据，错位会把复核结论贴到别的阻塞项上）。
+    # verify 的 collect 步骤必须用完全相同的过滤规则。
+    for i, b in enumerate(data.get("blockers") or []):
+        if not isinstance(b, dict):
+            continue
+        # id 规则必须与 verify 的 collect 步骤一致：<分片 key>#<片内序号>。
+        b = dict(b, id="%s#%d" % (s["key"], i))
+        blockers.append((s, b))
+    for u in data.get("unconfirmed") or []:
+        if isinstance(u, dict):
+            unconfirmed.append((s, u))
+
+# 一片都没产出（多半是 secret 缺失或全线失败）：不表态，只留告警。
+# 此时 request-changes 会拿一个「什么都没审」当阻塞理由挂住 PR。
+if not done:
+    print("action=none")
+    raise SystemExit(0)
+
+# 复核结论：refuted 的阻塞项不进 PR，只留在折叠区里备查——全部丢掉的话，
+# 复核环节把真问题误杀了也没人看得见。
+verdicts = {}
+vpath = pathlib.Path("verification/verified.json")
+if vpath.exists():
+    try:
+        for v in json.loads(vpath.read_text(encoding="utf-8")).get("verdicts") or []:
+            verdicts[v.get("id")] = v
+    except (ValueError, OSError):
+        verdicts = {}
+
+# 机器人贴到 PR 上的文字一律中文：结论骨架、分片名、进度评论、空转通告、
+# 回填占位、verify 的驳回理由，全部同一种语言。曾按分片投票在 zh/en 之间切换，
+# 结果是骨架跟着投票走、分片名等仍写死中文，拿到的是混排文档——所以不做切换，
+# 定死一种。注意这与「我们自己写的 PR 标题与正文用英文」是两回事，别混淆。
+T = {"block": "阻塞项",
+     "verified": "以下每一条都经过一轮独立复核（默认驳回，核实通过才保留）。",
+     "unrev": "（**未复核**，复核环节未产出结论）",
+     "scen": "失效场景：",
+     "dropped": "复核未通过、已丢弃的 %d 条", "why": "驳回理由：",
+     "byshard": "各分片结论", "impact": "影响范围：", "notcov": "未覆盖：",
+     "clean": "_（无问题）_", "counts": "_（阻塞 %d，待确认 %d）_",
+     "detail": "各分片的影响范围与未覆盖面",
+     "more_unconf": "另有 %d 条待确认项已省略，以免正文过长；详见各分片日志。",
+     "unconf": "待确认项（不阻断放行）", "missing": "未产出结论的分片",
+     "missing_body": "下面这些分片没有产出结论，**这些文件本轮未经评审**：",
+     "reason_no_output": "跑完了但没落下结论（多半是撞轮次上限或提前收尾）",
+     "reason_absent": "整个分片没跑起来或中途挂了",
+     "reason_malformed": "写出的结论文件解析不了",
+     "trunc": "文件清单被截断",
+     "trunc_body": "本 PR 共 %s 个改动文件，分片只拿到 %s 个（`gh pr view --json files` 单次上限 100），**其余 %d 个未进入任何分片、本轮未经评审**。",
+     "footer": "改完请推新提交，或回复 `/review` 要一轮复评。",
+     "footer_ok": "有异议或想再评一轮，请回复 `/review`——普通回帖不会触发复评，且回帖人需为本仓 OWNER/MEMBER/COLLABORATOR。"}
+
+# 模型不一定听话，长度要有确定性兜底——与「模型输出是不可信输入」同一思路。
+def clip(x, n):
+    x = " ".join(str(x).split())
+    return x if len(x) <= n else x[:n - 1].rstrip() + "…"
+
+survived, refuted, unreviewed = [], [], []
+for s_, b in blockers:
+    v = verdicts.get(b["id"])
+    if v is None:
+        unreviewed.append((s_, b, None))
+    elif v.get("refuted"):
+        refuted.append((s_, b, v))
+    else:
+        survived.append((s_, b, v))
+
+# 未复核的仍然当阻塞项报，但在正文里标出来——复核缺席是降可信度，不是免罪。
+blockers = [(s_, b) for s_, b, _ in survived + unreviewed]
+
+if blockers:
+    lines.append("## %s\n" % T["block"])
+    lines.append(T["verified"] + "\n")
+    for s_, b in blockers:
+        loc = b.get("file", "")
+        if b.get("line"):
+            loc += ":%s" % b["line"]
+        mark = "" if verdicts.get(b["id"]) else T["unrev"]
+        lines.append("- **[%s] %s** — %s%s"
+                     % (s_["label"], loc, clip(b.get("what", ""), 300), mark))
+        if b.get("scenario"):
+            lines.append("  %s%s" % (T["scen"], clip(b["scenario"], 300)))
+    lines.append("")
+
+if refuted:
+    lines.append("<details><summary>" + (T["dropped"] % len(refuted)) + "</summary>\n")
+    for s_, b, v in refuted:
+        lines.append("- **[%s] %s** — %s" % (s_["label"], b.get("file", ""),
+                                             clip(b.get("what", ""), 200)))
+        lines.append("  %s%s" % (T["why"], clip(v.get("reason", ""), 200)))
+    lines.append("\n</details>\n")
+
+# 标量字段同样是不可信输入：这里用 + 拼接（而非 %s 格式化）要求 str，
+# 模型把 impact 写成数组就抛 TypeError，失败形态与上面挡掉的畸形元素一致
+# ——Assemble 非零退出后既无表态也无告警。一律套 str()。
+# 每片一行，详情折叠。改造前影响范围是整个 PR 写一次，分片后变成每片各写一段，
+# 实测把结论正文撑到了改造前的 3 倍——阻塞项被埋在中间没人看得见。
+lines.append("## %s\n" % T["byshard"])
+for s, data in done:
+    n_b = len([b for _, b in blockers if _ is s])
+    n_u = len([u for ss, u in unconfirmed if ss is s])
+    tag = T["clean"] if not (n_b or n_u) else T["counts"] % (n_b, n_u)
+    lines.append("- **%s** — %s %s" % (s["label"], clip(data.get("summary") or "", 240), tag))
+lines.append("")
+
+detail = []
+for s, data in done:
+    extra = [(T["impact"], data.get("impact")), (T["notcov"], data.get("not_covered"))]
+    extra = [(k, v) for k, v in extra if str(v or "").strip()]
+    if not extra:
+        continue
+    detail.append("**%s**" % s["label"])
+    detail += ["- %s%s" % (k, clip(v, 200)) for k, v in extra]
+    detail.append("")
+if detail:
+    lines.append("<details><summary>%s</summary>\n" % T["detail"])
+    lines += detail
+    lines.append("</details>\n")
+
+# 复评轮的配额要衰减。待确认项不阻断、成本低，模型每轮都会把配额填满，于是
+# 「每轮十条互不重叠的新问题」可以无限持续——实测 #683 连续三轮如此，而后两轮
+# 本身已经是 approve。收敛规则写进了 prompt，但那靠自觉，这里再挡一道。
+prior_rounds = 0
+try:
+    prior_rounds = int(subprocess.run(
+        ["gh", "api", "repos/%s/pulls/%s/reviews" % (repo, pr), "--paginate",
+         "--jq", '[.[] | select((.body // "") != "")] | length'],
+        capture_output=True, text=True, check=True).stdout.split()[0])
+except Exception:
+    prior_rounds = 0
+per_shard_cap, total_cap = (1, 2) if prior_rounds else (2, 6)
+
+# 首轮每片至多 2 条、总共 6 条；复评轮收到 1 条 / 2 条。
+if unconfirmed:
+    lines.append("## %s\n" % T["unconf"])
+    # 轮转取，不是先到先得：contract 片固定排在最后，先到先得会让多模块 PR
+    # 上它的待确认项被前面的模块片整片挤掉，而它恰恰是唯一看跨模块的。
+    by_shard = collections.OrderedDict()
+    for s, u in unconfirmed:
+        by_shard.setdefault(s["key"], []).append((s, u))
+    shown = 0
+    for rnd in range(per_shard_cap):
+        for k, items in by_shard.items():
+            if len(items) <= rnd or shown >= total_cap:
+                continue
+            s, u = items[rnd]
+            shown += 1
+            lines.append("- **[%s] %s** — %s"
+                         % (s["label"], u.get("file", ""), clip(u.get("what", ""), 220)))
+    dropped_u = len(unconfirmed) - shown
+    if dropped_u > 0:
+        lines.append("- _%s_" % (T["more_unconf"] % dropped_u))
+    lines.append("")
+
+if missing:
+    lines.append("## %s\n" % T["missing"])
+    lines.append(T["missing_body"] + "\n")
+    # 两种原因指向完全不同的修法（轮次预算 vs job 失败），所以要分开写，
+    # 不能都渲染成一行「未覆盖」。
+    for s, reason in missing:
+        lines.append("- %s — %s" % (s["label"], T["reason_" + reason]))
+    lines.append("")
+
+dropped = int(os.environ.get("FILE_TOTAL") or 0) - int(os.environ.get("FILE_LISTED") or 0)
+if dropped > 0:
+    lines.append("## %s\n" % T["trunc"])
+    lines.append(T["trunc_body"] % (os.environ["FILE_TOTAL"],
+                                os.environ["FILE_LISTED"], dropped) + "\n")
+
+# approve 之后作者仍可能想争一句，而普通回帖不触发复评（评论正文必须含
+# /review 或 @claude）。不写这句，他没有别的途径知道这件事。
+lines.append(T["footer"] if blockers else T["footer_ok"])
+
+pathlib.Path("verdict.md").write_text("\n".join(lines), encoding="utf-8")
+print("action=" + ("request-changes" if blockers else "approve"))


### PR DESCRIPTION
## The observation

Findings keep coming and the list never shrinks.

Checked #683 — three rounds, roughly ten open questions each, on largely **disjoint** files and topics. So this is not the reviewer repeating itself; it is producing a fresh batch every round. The last two rounds were already `APPROVED`, so the merge gate was never blocked. What does not converge is the reading burden.

## Two mechanisms

**1. The reviewer cannot see its own previous verdicts.**

The prefetch pulls two endpoints:

```
issues/N/comments   → top-level comments
pulls/N/comments    → inline review comments
```

Open questions live in neither. They exist only in review **bodies**, at `pulls/N/reviews`, which was never fetched. The existing rule — "do not relist what was already raised" — had nothing to match against, so every round started blind.

Verdict bodies are now included as `prior_verdicts`, and the prompt says explicitly that open questions live there and that skipping them means restating last round in different words.

**2. Nothing made the list shrink.**

Open questions do not block and are cheap to produce, so each round fills its quota. On a large diff there is always something more to say, and this can continue indefinitely.

From the second round on: at most one per shard, only for problems introduced by that round's new commits, and nothing from an earlier verdict may be re-raised — whether or not it was addressed, and including the same file approached from a new angle.

Because that depends on the model complying, the assembly script enforces a decaying cap on its own:

| | per shard | overall |
|---|---|---|
| first round | 2 | 6 |
| any prior verdict exists | 1 | 2 |

## Verification

Ran the assembly script against #683's real review history with a fixture carrying 20 open questions: the first-round path renders 6, the re-review path renders 2, and the trimmed count is stated rather than silently dropped.