### PR TITLE
feat(bkn-safe): add batched resource-operation authorization query

### DIFF
--- a/adp/bkn/bkn-backend/server/drivenadapters/permission/shadow.go
+++ b/adp/bkn/bkn-backend/server/drivenadapters/permission/shadow.go
@@ -46,17 +46,39 @@ func (c *safeClient) checkOne(ctx context.Context, accessorID, rtype, rid, op st
 	return out.Allowed, err
 }
 
-// allowedOps returns the subset of candidate ops the accessor may perform.
-func (c *safeClient) allowedOps(ctx context.Context, accessorID, rtype, rid string, cands []string) ([]string, error) {
-	out := make([]string, 0, len(cands))
-	for _, op := range cands {
-		ok, err := c.checkOne(ctx, accessorID, rtype, rid, op)
-		if err != nil {
-			return nil, err
-		}
-		if ok {
-			out = append(out, op)
-		}
+// safeResource is one { type, id } pair in the batch filter request.
+type safeResource struct {
+	Type string `json:"type"`
+	ID   string `json:"id"`
+}
+
+// filterResources runs one batched decision for a whole page: visibility decides
+// which resources come back, candidates decide which operations each carries.
+// One round trip regardless of resource or operation count — the per-resource,
+// per-operation loop it replaces made list pages scale as N x M (#357).
+func (c *safeClient) filterResources(ctx context.Context, accessorID string,
+	resources []safeResource, visibility, candidates []string) (map[string][]string, error) {
+
+	out := map[string][]string{}
+	if len(resources) == 0 {
+		return out, nil
+	}
+	var resp struct {
+		Resources []struct {
+			ResourceID string   `json:"resource_id"`
+			Operations []string `json:"operations"`
+		} `json:"resources"`
+	}
+	if err := c.do(ctx, http.MethodPost, "/api/safe/v1/authz/resource-filter", map[string]any{
+		"accessor_id":           accessorID,
+		"resources":             resources,
+		"visibility_operations": visibility,
+		"candidate_operations":  candidates,
+	}, &resp); err != nil {
+		return nil, err
+	}
+	for _, r := range resp.Resources {
+		out[r.ResourceID] = r.Operations
 	}
 	return out, nil
 }
@@ -125,30 +147,42 @@ func (s *safePermissionAccess) CheckPermission(ctx context.Context, check interf
 	return s.safe.allowedAll(ctx, check.Accessor.ID, check.Resource.Type, check.Resource.ID, check.Operations)
 }
 
-func (s *safePermissionAccess) FilterResources(ctx context.Context, filter interfaces.PermissionResourcesFilter) (map[string]interfaces.PermissionResourceOps, error) {
-	out := map[string]interfaces.PermissionResourceOps{}
+// filterBatch is the shared body of FilterResources and GetResourcesOperations:
+// both project the candidate operations onto a set of resources; they differ
+// only in whether the visibility operations filter the result.
+func (s *safePermissionAccess) filterBatch(ctx context.Context,
+	filter interfaces.PermissionResourcesFilter, visibility []string) (map[string]interfaces.PermissionResourceOps, error) {
+
+	resources := make([]safeResource, 0, len(filter.Resources))
 	for _, r := range filter.Resources {
-		ops, err := s.safe.allowedOps(ctx, filter.Accessor.ID, r.Type, r.ID, filter.Operations)
-		if err != nil {
-			return nil, err
-		}
-		if len(ops) > 0 {
-			out[r.ID] = interfaces.PermissionResourceOps{ResourceID: r.ID, Operations: ops}
-		}
+		resources = append(resources, safeResource{Type: r.Type, ID: r.ID})
+	}
+	// Callers that only pass a visibility list keep the old behaviour: the
+	// operations they asked about are also the ones projected back.
+	candidates := filter.CandidateOperations
+	if len(candidates) == 0 {
+		candidates = filter.Operations
+	}
+	ops, err := s.safe.filterResources(ctx, filter.Accessor.ID, resources, visibility, candidates)
+	if err != nil {
+		return nil, err
+	}
+	out := make(map[string]interfaces.PermissionResourceOps, len(ops))
+	for id, allowed := range ops {
+		out[id] = interfaces.PermissionResourceOps{ResourceID: id, Operations: allowed}
 	}
 	return out, nil
 }
 
+func (s *safePermissionAccess) FilterResources(ctx context.Context, filter interfaces.PermissionResourcesFilter) (map[string]interfaces.PermissionResourceOps, error) {
+	return s.filterBatch(ctx, filter, filter.Operations)
+}
+
+// GetResourcesOperations answers "what may I do on each of these", so no
+// visibility filter — every requested resource comes back, possibly with an
+// empty operation set.
 func (s *safePermissionAccess) GetResourcesOperations(ctx context.Context, filter interfaces.PermissionResourcesFilter) (map[string]interfaces.PermissionResourceOps, error) {
-	out := map[string]interfaces.PermissionResourceOps{}
-	for _, r := range filter.Resources {
-		ops, err := s.safe.allowedOps(ctx, filter.Accessor.ID, r.Type, r.ID, filter.Operations)
-		if err != nil {
-			return nil, err
-		}
-		out[r.ID] = interfaces.PermissionResourceOps{ResourceID: r.ID, Operations: ops}
-	}
-	return out, nil
+	return s.filterBatch(ctx, filter, nil)
 }
 
 func (s *safePermissionAccess) CreateResources(ctx context.Context, policies []interfaces.PermissionPolicy) error {

--- a/adp/bkn/bkn-backend/server/drivenadapters/permission/shadow_test.go
+++ b/adp/bkn/bkn-backend/server/drivenadapters/permission/shadow_test.go
@@ -1,0 +1,182 @@
+// Copyright openbkn.ai
+//
+// Licensed under the OpenBKN License. See LICENSE-OPENBKN.txt in the project root.
+
+package permission
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"reflect"
+	"testing"
+
+	"bkn-backend/interfaces"
+)
+
+// capturedFilter is the decoded /resource-filter request body.
+type capturedFilter struct {
+	AccessorID string `json:"accessor_id"`
+	Resources  []struct {
+		Type string `json:"type"`
+		ID   string `json:"id"`
+	} `json:"resources"`
+	VisibilityOperations []string `json:"visibility_operations"`
+	CandidateOperations  []string `json:"candidate_operations"`
+}
+
+// newFilterStub stands in for bkn-safe: it records every request it receives and
+// replies with the given resource -> operations mapping.
+func newFilterStub(t *testing.T, reply map[string][]string) (*safePermissionAccess, *[]capturedFilter) {
+	t.Helper()
+	calls := &[]capturedFilter{}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/safe/v1/authz/resource-filter" {
+			t.Errorf("unexpected path %s", r.URL.Path)
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		body, _ := io.ReadAll(r.Body)
+		var got capturedFilter
+		if err := json.Unmarshal(body, &got); err != nil {
+			t.Errorf("decode request: %v (%s)", err, body)
+		}
+		*calls = append(*calls, got)
+
+		entries := make([]map[string]any, 0, len(reply))
+		for id, ops := range reply {
+			entries = append(entries, map[string]any{
+				"resource_type": "knowledge_network",
+				"resource_id":   id,
+				"operations":    ops,
+			})
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{"resources": entries})
+	}))
+	t.Cleanup(srv.Close)
+	return &safePermissionAccess{safe: newSafeClient(srv.URL)}, calls
+}
+
+func knFilter(ids []string, ops, candidates []string) interfaces.PermissionResourcesFilter {
+	resources := make([]interfaces.PermissionResource, 0, len(ids))
+	for _, id := range ids {
+		resources = append(resources, interfaces.PermissionResource{Type: "knowledge_network", ID: id})
+	}
+	return interfaces.PermissionResourcesFilter{
+		Accessor:            interfaces.PermissionAccessor{ID: "u-1", Type: "user"},
+		Resources:           resources,
+		Operations:          ops,
+		CandidateOperations: candidates,
+		AllowOperation:      true,
+	}
+}
+
+// TestSafeFilterResourcesIsOneCall pins the two properties the batch endpoint
+// exists for: a page costs one round trip regardless of size, and the candidate
+// operations reach bkn-safe instead of collapsing to the visibility op.
+func TestSafeFilterResourcesIsOneCall(t *testing.T) {
+	candidates := []string{"view_detail", "modify", "delete"}
+	access, calls := newFilterStub(t, map[string][]string{
+		"kn-1": {"view_detail", "modify", "delete"},
+		"kn-2": {"view_detail"},
+	})
+
+	got, err := access.FilterResources(context.Background(),
+		knFilter([]string{"kn-1", "kn-2", "kn-3"}, []string{"view_detail"}, candidates))
+	if err != nil {
+		t.Fatalf("filter: %v", err)
+	}
+
+	if len(*calls) != 1 {
+		t.Fatalf("made %d requests, want exactly 1", len(*calls))
+	}
+	call := (*calls)[0]
+	if call.AccessorID != "u-1" || len(call.Resources) != 3 {
+		t.Errorf("request = %+v", call)
+	}
+	if !reflect.DeepEqual(call.VisibilityOperations, []string{"view_detail"}) {
+		t.Errorf("visibility = %v", call.VisibilityOperations)
+	}
+	if !reflect.DeepEqual(call.CandidateOperations, candidates) {
+		t.Errorf("candidates = %v, want %v", call.CandidateOperations, candidates)
+	}
+
+	// kn-3 is absent from the reply: not visible, so it must not appear.
+	if len(got) != 2 {
+		t.Fatalf("got %v, want kn-1 and kn-2", got)
+	}
+	if want := []string{"view_detail", "modify", "delete"}; !reflect.DeepEqual(got["kn-1"].Operations, want) {
+		t.Errorf("kn-1 ops = %v, want %v", got["kn-1"].Operations, want)
+	}
+	if got["kn-1"].ResourceID != "kn-1" {
+		t.Errorf("resource id = %q", got["kn-1"].ResourceID)
+	}
+}
+
+// TestSafeFilterResourcesCandidateFallback covers callers that pass no candidate
+// set: the operations they filtered on stay the ones projected back, which is
+// the pre-existing behaviour.
+func TestSafeFilterResourcesCandidateFallback(t *testing.T) {
+	access, calls := newFilterStub(t, map[string][]string{"kn-1": {"view_detail"}})
+
+	if _, err := access.FilterResources(context.Background(),
+		knFilter([]string{"kn-1"}, []string{"view_detail"}, nil)); err != nil {
+		t.Fatalf("filter: %v", err)
+	}
+	if want := []string{"view_detail"}; !reflect.DeepEqual((*calls)[0].CandidateOperations, want) {
+		t.Errorf("candidates = %v, want %v", (*calls)[0].CandidateOperations, want)
+	}
+}
+
+// TestSafeGetResourcesOperationsHasNoVisibilityFilter checks the other adapter
+// method keeps its "every requested resource comes back" contract, which the
+// endpoint expresses as an empty visibility list.
+func TestSafeGetResourcesOperationsHasNoVisibilityFilter(t *testing.T) {
+	access, calls := newFilterStub(t, map[string][]string{"kn-1": {"view_detail"}, "kn-2": {}})
+
+	got, err := access.GetResourcesOperations(context.Background(),
+		knFilter([]string{"kn-1", "kn-2"}, []string{"view_detail"}, []string{"view_detail", "modify"}))
+	if err != nil {
+		t.Fatalf("get operations: %v", err)
+	}
+	if len((*calls)[0].VisibilityOperations) != 0 {
+		t.Errorf("visibility = %v, want empty", (*calls)[0].VisibilityOperations)
+	}
+	if len(got) != 2 {
+		t.Fatalf("got %v, want both resources", got)
+	}
+	if len(got["kn-2"].Operations) != 0 {
+		t.Errorf("kn-2 ops = %v, want empty", got["kn-2"].Operations)
+	}
+}
+
+// TestSafeFilterResourcesEmptyBatch guards the empty page: no request at all.
+func TestSafeFilterResourcesEmptyBatch(t *testing.T) {
+	access, calls := newFilterStub(t, nil)
+
+	got, err := access.FilterResources(context.Background(),
+		knFilter(nil, []string{"view_detail"}, []string{"view_detail"}))
+	if err != nil {
+		t.Fatalf("filter: %v", err)
+	}
+	if len(got) != 0 || len(*calls) != 0 {
+		t.Fatalf("got %v after %d calls, want empty and no call", got, len(*calls))
+	}
+}
+
+// TestSafeFilterResourcesPropagatesError checks a bkn-safe failure surfaces as an
+// error rather than an empty (i.e. silently unauthorized) result.
+func TestSafeFilterResourcesPropagatesError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, `{"error":"boom"}`, http.StatusInternalServerError)
+	}))
+	t.Cleanup(srv.Close)
+	access := &safePermissionAccess{safe: newSafeClient(srv.URL)}
+
+	if _, err := access.FilterResources(context.Background(),
+		knFilter([]string{"kn-1"}, []string{"view_detail"}, []string{"view_detail"})); err == nil {
+		t.Fatal("want error from a failing bkn-safe, got nil")
+	}
+}

--- a/adp/bkn/bkn-backend/server/interfaces/permission_access.go
+++ b/adp/bkn/bkn-backend/server/interfaces/permission_access.go
@@ -76,12 +76,23 @@ type PermissionResource struct {
 }
 
 // 过滤/删除
+//
+// Operations 与 CandidateOperations 是两个独立维度:
+//   - Operations 判定「可见性」——资源需持有其中全部操作才会被返回;
+//   - CandidateOperations 决定「返回哪些操作」——即返回给前端的 operations 字段的
+//     候选集,与资源因何可见无关。为空时退化为 Operations(即老行为)。
+//
+// 两者曾共用 Operations 一个字段:ISF 在 allow_operation=true 时无视请求的操作列表、
+// 直接回该资源的全部允许操作,所以少传候选集不显症;切到 bkn-safe 后按请求列表求交,
+// 列表页于是只剩 view_detail。候选集必须显式传到适配器。
 type PermissionResourcesFilter struct {
 	Accessor       PermissionAccessor   `json:"accessor,omitempty"`
 	Resources      []PermissionResource `json:"resources,omitempty"`
 	Operations     []string             `json:"operation,omitempty"`
 	AllowOperation bool                 `json:"allow_operation"`
 	Method         string               `json:"method,omitempty"`
+	// json:"-":该结构体会被整体序列化成 ISF 请求体,新字段不进入 ISF 契约。
+	CandidateOperations []string `json:"-"`
 }
 
 // 设置权限

--- a/adp/bkn/bkn-backend/server/logics/permission/filter_operations_test.go
+++ b/adp/bkn/bkn-backend/server/logics/permission/filter_operations_test.go
@@ -1,0 +1,83 @@
+// Copyright openbkn.ai
+//
+// Licensed under the OpenBKN License. See LICENSE-OPENBKN.txt in the project root.
+
+package permission
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	. "github.com/smartystreets/goconvey/convey"
+
+	"bkn-backend/common"
+	padapter "bkn-backend/drivenadapters/permission"
+	"bkn-backend/interfaces"
+)
+
+// Test_PermissionServiceImpl_FilterResources_FullOperationSet wires the service
+// to the real bkn-safe adapter against a stub bkn-safe, and asserts the whole
+// chain the knowledge-network list and detail responses depend on:
+//
+//   - the candidate operation set (COMMON_OPERATIONS) reaches bkn-safe instead
+//     of being dropped at the service layer;
+//   - view_detail, modify and delete come back together for an authorized
+//     resource, which is what Studio reads to decide whether to show the
+//     edit/delete entry points;
+//   - the page costs one request, not one per resource per operation.
+func Test_PermissionServiceImpl_FilterResources_FullOperationSet(t *testing.T) {
+	Convey("Test FilterResources returns the full allowed operation set\n", t, func() {
+		// Assertions stay out of the handler: goconvey's So panics when called
+		// off the Convey goroutine, which would surface as a connection error
+		// rather than a test failure.
+		var requests []map[string]any
+		var paths []string
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			paths = append(paths, r.URL.Path)
+			body, _ := io.ReadAll(r.Body)
+			var req map[string]any
+			_ = json.Unmarshal(body, &req)
+			requests = append(requests, req)
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"resources": []map[string]any{
+					{
+						"resource_type": interfaces.RESOURCE_TYPE_KN,
+						"resource_id":   "kn1",
+						"operations":    []string{"view_detail", "modify", "delete"},
+					},
+				},
+			})
+		}))
+		defer srv.Close()
+
+		t.Setenv("AUTHZ_PROVIDER", "bkn-safe")
+		t.Setenv("BKN_SAFE_URL", srv.URL)
+		svc := &PermissionServiceImpl{
+			appSetting: &common.AppSetting{},
+			mqClient:   &mockMQClient{},
+			pa:         padapter.MaybeShadow(nil),
+		}
+
+		ctx := withAccountInfo(context.Background(), "u1", "user")
+		result, err := svc.FilterResources(ctx, interfaces.RESOURCE_TYPE_KN, []string{"kn1", "kn2"},
+			[]string{interfaces.OPERATION_TYPE_VIEW_DETAIL}, true, interfaces.COMMON_OPERATIONS)
+
+		So(err, ShouldBeNil)
+		So(paths, ShouldResemble, []string{"/api/safe/v1/authz/resource-filter"})
+		So(len(requests), ShouldEqual, 1)
+
+		candidates, _ := requests[0]["candidate_operations"].([]any)
+		So(len(candidates), ShouldEqual, len(interfaces.COMMON_OPERATIONS))
+		So(candidates[0], ShouldEqual, interfaces.OPERATION_TYPE_VIEW_DETAIL)
+		visibility, _ := requests[0]["visibility_operations"].([]any)
+		So(len(visibility), ShouldEqual, 1)
+
+		// kn2 is absent from the reply: not visible, so it is filtered out.
+		So(len(result), ShouldEqual, 1)
+		So(result["kn1"].Operations, ShouldResemble, []string{"view_detail", "modify", "delete"})
+	})
+}

--- a/adp/bkn/bkn-backend/server/logics/permission/permission_service_impl.go
+++ b/adp/bkn/bkn-backend/server/logics/permission/permission_service_impl.go
@@ -193,15 +193,19 @@ func (ps *PermissionServiceImpl) FilterResources(ctx context.Context, resourceTy
 		})
 	}
 
-	// todo: 权限过滤先去掉，进来多少个id就返回多少个id
+	// ops 判定可见性，fullOps 是回给前端的候选操作集——两者必须都传下去。
+	// 早前 fullOps 收而不用：ISF 在 allow_operation=true 时无视请求的操作列表、直接
+	// 回该资源的全部允许操作，遗漏不显症；bkn-safe 严格按请求列表求交，于是列表/详情
+	// 的 operations 塌成只剩 ops（如 view_detail），Studio 据此把编辑/删除入口藏了。
 	matchResouces, err := ps.pa.FilterResources(ctx, interfaces.PermissionResourcesFilter{
 		Accessor: interfaces.PermissionAccessor{
 			ID:   accountInfo.ID,
 			Type: accountInfo.Type,
 		},
-		Resources:      resources,
-		Operations:     ops,
-		AllowOperation: allowOperation,
+		Resources:           resources,
+		Operations:          ops,
+		CandidateOperations: fullOps,
+		AllowOperation:      allowOperation,
 	})
 	if err != nil {
 		httpErr := rest.NewHTTPError(ctx, http.StatusInternalServerError,

--- a/bkn-safe/README.md
+++ b/bkn-safe/README.md
@@ -96,10 +96,56 @@ VS Code / Cursor：打开 `bkn-safe` 根目录，选 **Run and Debug → bkn-saf
 ## HTTP 接口（节选）
 
 - 认证（hydra 重定向到这里）：`GET/POST /login`、`GET /consent`、`GET/POST /device`
-- 鉴权 `/api/safe/v1/authz`：`POST /check`、`POST /operations`、`POST|DELETE /policies`、`POST /role-bindings`
+- 鉴权 `/api/safe/v1/authz`：`POST /check`、`POST /operations`、`POST /resource-filter`、
+  `POST|DELETE /policies`、`POST /role-bindings`
 - 目录 `/api/safe/v1/directory`：`GET /users/:id`、`POST /names`、`GET /departments`、
   `GET /groups/:id/members`、`POST /search-org`、`POST /users`、`PUT /users/:id/password`
 - 健康：`GET /health/ready`、`/health/alive`
+
+### `POST /api/safe/v1/authz/resource-filter`（列表页批量判定）
+
+一次请求判完一页资源：既回**哪些可见**，也回**每个资源上持有哪些操作**。业务服务的
+列表/详情响应据此填 `operations` 字段，无需按资源、按操作逐次调 `/check`。
+
+```json
+{
+  "accessor_id": "u-1",
+  "resources": [{ "type": "knowledge_network", "id": "kn-1" }],
+  "visibility_operations": ["view_detail"],
+  "candidate_operations": ["view_detail", "create", "modify", "delete"]
+}
+```
+
+```json
+{
+  "resources": [
+    {
+      "resource_type": "knowledge_network",
+      "resource_id": "kn-1",
+      "operations": ["view_detail", "modify", "delete"]
+    }
+  ]
+}
+```
+
+**两个操作列表是彼此独立的两个维度，这正是本端点存在的理由：**
+
+| 字段 | 作用 | 留空时 |
+| --- | --- | --- |
+| `visibility_operations` | 过滤：资源需**全部**持有这些操作才返回 | 不过滤，请求的资源全部返回（各自带操作集，可能为空） |
+| `candidate_operations` | 投影：返回的 `operations` 从该候选集中取子集，与资源因何可见无关 | 回落到该资源类型的操作目录（与 `POST /operations` 一致） |
+
+资源可用 `resources: [{type,id}]` 给出，也可用 `resource_type` + `resource_ids`
+的单类型形式；两者可同时出现，一次请求内允许混合资源类型。
+
+判定语义与单条 `POST /check` 完全一致：直接授权、角色继承（含角色间传递）、
+根部门公共授权、超管通配、`act` 通配一视同仁。内部不逐 (资源 × 操作) 调用引擎，
+而是先解析该访问者的授权集再在内存中投影，故耗时与资源数近似线性；两条路径由
+`TestFilterResourceOpsMatchesCheck` 钉住一致性。
+
+错误行为：请求体不合法或缺 `accessor_id` 返回 `400`；给了 `resource_ids` 却没给
+`resource_type` 返回 `400`；引擎失败返回 `500`。**空资源列表不是错误**，返回
+`{"resources": []}`，分页调用方无需特判。
 
 ## 授权档位（付费能力门控）
 

--- a/bkn-safe/server/internal/authz/filter.go
+++ b/bkn-safe/server/internal/authz/filter.go
@@ -1,0 +1,184 @@
+// Copyright openbkn.ai
+//
+// Licensed under the OpenBKN License. See LICENSE-OPENBKN.txt in the project root.
+
+package authz
+
+import (
+	"github.com/casbin/casbin/v2/util"
+)
+
+// ResourceRef names one concrete resource instance ("type:id").
+type ResourceRef struct {
+	Type string
+	ID   string
+}
+
+// FilteredResource is one visible resource plus the subset of the candidate
+// operations the accessor holds on it.
+type FilteredResource struct {
+	Type       string
+	ID         string
+	Operations []string
+}
+
+// FilterResourceOps answers, for a batch of resource instances at once: which
+// of them the accessor may see, and which of the candidate operations it holds
+// on each.
+//
+// Semantics, deliberately two separate axes (this is the whole point of the
+// batch contract — callers previously had to conflate them):
+//
+//   - visibility: a resource is returned only when the accessor holds EVERY
+//     operation in visibility. An empty visibility list imposes no constraint,
+//     so every requested resource is returned (the "give me each resource's
+//     operation set" query).
+//   - projection: the returned Operations are the subset of candidates the
+//     accessor holds. Independent of visibility — a resource may be visible via
+//     view_detail and still come back with modify and delete attached.
+//
+// Decisions are identical to Check: same grant sources (direct, role-derived
+// including transitive roles, public/root-department, super-admin wildcard),
+// same object and act wildcard rules. It does not call Check per (resource, op)
+// because that is O(resources x ops x policies) inside Casbin's matcher — the
+// list pages this endpoint exists for would time out exactly as they did before
+// (#357). Instead the accessor's grants are resolved once and projected onto
+// each resource; TestFilterResourceOpsMatchesCheck pins the two paths together.
+func (en *Enforcer) FilterResourceOps(accessorID string, resources []ResourceRef, visibility, candidates []string) ([]FilteredResource, error) {
+	idx, err := en.grantIndex(accessorID)
+	if err != nil {
+		return nil, err
+	}
+
+	// One decision pass per distinct resource, over the union of both op sets.
+	union := make([]string, 0, len(visibility)+len(candidates))
+	seenOp := map[string]bool{}
+	for _, op := range append(append([]string{}, visibility...), candidates...) {
+		if op == "" || seenOp[op] {
+			continue
+		}
+		seenOp[op] = true
+		union = append(union, op)
+	}
+
+	out := make([]FilteredResource, 0, len(resources))
+	decided := map[ResourceRef]map[string]bool{}
+	for _, r := range resources {
+		allowed, done := decided[r]
+		if !done {
+			allowed = idx.allowed(r, union)
+			decided[r] = allowed
+		}
+		visible := true
+		for _, op := range visibility {
+			if !allowed[op] {
+				visible = false
+				break
+			}
+		}
+		if !visible {
+			continue
+		}
+		ops := make([]string, 0, len(candidates))
+		for _, op := range candidates {
+			if allowed[op] {
+				ops = append(ops, op)
+			}
+		}
+		out = append(out, FilteredResource{Type: r.Type, ID: r.ID, Operations: ops})
+	}
+	return out, nil
+}
+
+// grantRow is one policy line the accessor can invoke: the object pattern and
+// the operation it grants (act "*" grants every operation).
+type grantRow struct {
+	object string
+	act    string
+}
+
+// grantIndex is an accessor's effective grant set, split by whether the object
+// pattern needs wildcard matching. Exact patterns resolve by map lookup; only
+// the (few) wildcard patterns are walked per resource, which keeps a list page
+// linear in resources rather than resources x policies.
+type grantIndex struct {
+	exact    map[string][]string // object key -> acts
+	wildcard []grantRow
+}
+
+// grantIndex collects every policy row that can satisfy the matcher's subject
+// clause for this accessor:
+//
+//	(g(r.sub, p.sub) || p.sub == PublicAccessorID)
+//
+// GetImplicitPermissionsForUser covers the g() half (the accessor itself plus
+// every role reachable through g, transitively); the public/root-department
+// grants are the other half and are NOT part of implicit permissions, so they
+// are read separately. Missing them here would silently deny access the
+// single-decision Check grants.
+func (en *Enforcer) grantIndex(accessorID string) (*grantIndex, error) {
+	rows, err := en.e.GetImplicitPermissionsForUser(accessorID)
+	if err != nil {
+		return nil, err
+	}
+	public, err := en.e.GetFilteredPolicy(0, PublicAccessorID)
+	if err != nil {
+		return nil, err
+	}
+
+	idx := &grantIndex{exact: make(map[string][]string, len(rows))}
+	for _, row := range append(rows, public...) {
+		if len(row) < 3 {
+			continue
+		}
+		object, act := row[1], row[2]
+		if hasWildcard(object) {
+			idx.wildcard = append(idx.wildcard, grantRow{object: object, act: act})
+			continue
+		}
+		idx.exact[object] = append(idx.exact[object], act)
+	}
+	return idx, nil
+}
+
+// allowed reports, for one resource, which of ops the grants cover. It mirrors
+// the matcher's remaining two clauses: keyMatch(r.obj, p.obj) — via the same
+// util.KeyMatch the model uses — and (p.act == "*" || r.act == p.act).
+func (idx *grantIndex) allowed(r ResourceRef, ops []string) map[string]bool {
+	out := make(map[string]bool, len(ops))
+	object := obj(r.Type, r.ID)
+	grant := func(act string) {
+		if act == ActAll {
+			for _, op := range ops {
+				out[op] = true
+			}
+			return
+		}
+		for _, op := range ops {
+			if op == act {
+				out[op] = true
+			}
+		}
+	}
+	for _, act := range idx.exact[object] {
+		grant(act)
+	}
+	for _, row := range idx.wildcard {
+		if util.KeyMatch(object, row.object) {
+			grant(row.act)
+		}
+	}
+	return out
+}
+
+// hasWildcard reports whether an object pattern needs keyMatch rather than a
+// plain equality lookup. keyMatch treats "*" as the only wildcard, so a pattern
+// without one matches exactly itself.
+func hasWildcard(object string) bool {
+	for i := 0; i < len(object); i++ {
+		if object[i] == '*' {
+			return true
+		}
+	}
+	return false
+}

--- a/bkn-safe/server/internal/authz/filter_test.go
+++ b/bkn-safe/server/internal/authz/filter_test.go
@@ -1,0 +1,274 @@
+// Copyright openbkn.ai
+//
+// Licensed under the OpenBKN License. See LICENSE-OPENBKN.txt in the project root.
+
+package authz
+
+import (
+	"reflect"
+	"testing"
+)
+
+const (
+	superAdminRole = "7dcfcc9c-ad02-11e8-aa06-000c29358ad6"
+	builderRole    = "network-builder-role"
+)
+
+var knOps = []string{"view_detail", "create", "modify", "delete", "data_query", "authorize", "task_manage"}
+
+// opsOf indexes a filter result by resource id.
+func opsOf(t *testing.T, got []FilteredResource) map[string][]string {
+	t.Helper()
+	out := map[string][]string{}
+	for _, r := range got {
+		out[r.ID] = r.Operations
+	}
+	return out
+}
+
+// TestFilterResourceOpsProjection is the case the batch contract exists for:
+// visibility is decided by view_detail alone, while the returned operation set
+// is the full candidate subset the accessor holds. Before this, a caller could
+// only ask one question and got [view_detail] back for everyone.
+func TestFilterResourceOpsProjection(t *testing.T) {
+	e := newTestEnforcer(t)
+	const user = "u-1"
+
+	// Role-derived: view_detail on every knowledge network.
+	mustNoErr(t, e.GrantRolePermission(builderRole, "knowledge_network", "*", "view_detail"))
+	mustNoErr(t, e.AssignRole(user, builderRole))
+	// Direct instance grants: owner-ish ops on kn-1 only.
+	mustNoErr(t, e.GrantObjectPermission(user, "knowledge_network", "kn-1", "modify"))
+	mustNoErr(t, e.GrantObjectPermission(user, "knowledge_network", "kn-1", "delete"))
+	// A resource the accessor cannot see at all.
+	mustNoErr(t, e.GrantObjectPermission("someone-else", "knowledge_network", "kn-3", "view_detail"))
+
+	got, err := e.FilterResourceOps(user, []ResourceRef{
+		{"knowledge_network", "kn-1"},
+		{"knowledge_network", "kn-2"},
+	}, []string{"view_detail"}, knOps)
+	if err != nil {
+		t.Fatalf("filter: %v", err)
+	}
+
+	ops := opsOf(t, got)
+	if want := []string{"view_detail", "modify", "delete"}; !reflect.DeepEqual(ops["kn-1"], want) {
+		t.Errorf("kn-1 ops = %v, want %v", ops["kn-1"], want)
+	}
+	if want := []string{"view_detail"}; !reflect.DeepEqual(ops["kn-2"], want) {
+		t.Errorf("kn-2 ops = %v, want %v", ops["kn-2"], want)
+	}
+	if len(got) != 2 {
+		t.Errorf("got %d resources, want 2 (kn-3 was never requested)", len(got))
+	}
+}
+
+// TestFilterResourceOpsVisibility covers the filtering axis: resources missing
+// any visibility op are dropped entirely, not returned with an empty op set.
+func TestFilterResourceOpsVisibility(t *testing.T) {
+	e := newTestEnforcer(t)
+	const user = "u-1"
+	mustNoErr(t, e.GrantObjectPermission(user, "knowledge_network", "kn-1", "view_detail"))
+	mustNoErr(t, e.GrantObjectPermission(user, "knowledge_network", "kn-1", "data_query"))
+	mustNoErr(t, e.GrantObjectPermission(user, "knowledge_network", "kn-2", "view_detail"))
+
+	refs := []ResourceRef{
+		{"knowledge_network", "kn-1"},
+		{"knowledge_network", "kn-2"},
+		{"knowledge_network", "kn-3"},
+	}
+
+	t.Run("single visibility op", func(t *testing.T) {
+		got, err := e.FilterResourceOps(user, refs, []string{"view_detail"}, knOps)
+		if err != nil {
+			t.Fatalf("filter: %v", err)
+		}
+		if len(got) != 2 {
+			t.Fatalf("got %v, want kn-1 and kn-2 only", got)
+		}
+	})
+
+	t.Run("multiple visibility ops are conjunctive", func(t *testing.T) {
+		got, err := e.FilterResourceOps(user, refs, []string{"view_detail", "data_query"}, knOps)
+		if err != nil {
+			t.Fatalf("filter: %v", err)
+		}
+		if len(got) != 1 || got[0].ID != "kn-1" {
+			t.Fatalf("got %v, want kn-1 only (kn-2 lacks data_query)", got)
+		}
+	})
+
+	t.Run("no visibility ops returns every requested resource", func(t *testing.T) {
+		got, err := e.FilterResourceOps(user, refs, nil, knOps)
+		if err != nil {
+			t.Fatalf("filter: %v", err)
+		}
+		if len(got) != 3 {
+			t.Fatalf("got %d resources, want 3", len(got))
+		}
+		ops := opsOf(t, got)
+		if len(ops["kn-3"]) != 0 {
+			t.Errorf("kn-3 ops = %v, want empty", ops["kn-3"])
+		}
+	})
+}
+
+// TestFilterResourceOpsSuperAdmin pins the wildcard path: the seeded super_admin
+// grant is object "*" / act "*", which must yield the complete candidate set on
+// every resource of every type — the exact case that regressed to [view_detail].
+func TestFilterResourceOpsSuperAdmin(t *testing.T) {
+	e := newTestEnforcer(t)
+	const admin = "admin-1"
+	mustNoErr(t, e.Grant(superAdminRole, "*", "*"))
+	mustNoErr(t, e.AssignRole(admin, superAdminRole))
+
+	got, err := e.FilterResourceOps(admin, []ResourceRef{
+		{"knowledge_network", "kn-1"},
+		{"resource", "r-9"},
+	}, []string{"view_detail"}, knOps)
+	if err != nil {
+		t.Fatalf("filter: %v", err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("got %d resources, want 2", len(got))
+	}
+	for _, r := range got {
+		if !reflect.DeepEqual(r.Operations, knOps) {
+			t.Errorf("%s:%s ops = %v, want all candidates", r.Type, r.ID, r.Operations)
+		}
+	}
+}
+
+// TestFilterResourceOpsPublicGrant covers the root-department ("public") policy
+// subject. Those rows are not part of GetImplicitPermissionsForUser, so an index
+// built from implicit permissions alone would deny what Check allows.
+func TestFilterResourceOpsPublicGrant(t *testing.T) {
+	e := newTestEnforcer(t)
+	const stranger = "u-nobody"
+	mustNoErr(t, e.GrantObjectPermission(PublicAccessorID, "toolbox", "built-in", "use"))
+
+	got, err := e.FilterResourceOps(stranger, []ResourceRef{
+		{"toolbox", "built-in"},
+		{"toolbox", "private"},
+	}, []string{"use"}, []string{"use", "modify"})
+	if err != nil {
+		t.Fatalf("filter: %v", err)
+	}
+	if len(got) != 1 || got[0].ID != "built-in" {
+		t.Fatalf("got %v, want built-in only", got)
+	}
+	if want := []string{"use"}; !reflect.DeepEqual(got[0].Operations, want) {
+		t.Errorf("ops = %v, want %v", got[0].Operations, want)
+	}
+}
+
+// TestFilterResourceOpsMixedTypes checks one batch carrying several resource
+// types: grants must not leak across types (the keyMatch, not keyMatch2, rule).
+func TestFilterResourceOpsMixedTypes(t *testing.T) {
+	e := newTestEnforcer(t)
+	const user = "u-1"
+	mustNoErr(t, e.GrantRolePermission(builderRole, "knowledge_network", "*", "view_detail"))
+	mustNoErr(t, e.AssignRole(user, builderRole))
+	mustNoErr(t, e.GrantObjectPermission(user, "resource", "r-1", "view_detail"))
+
+	got, err := e.FilterResourceOps(user, []ResourceRef{
+		{"knowledge_network", "kn-1"},
+		{"resource", "r-1"},
+		{"resource", "r-2"},
+		{"internal_resource", "i-1"},
+	}, []string{"view_detail"}, []string{"view_detail", "modify"})
+	if err != nil {
+		t.Fatalf("filter: %v", err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("got %v, want kn-1 and r-1", got)
+	}
+	for _, r := range got {
+		if r.Type == "resource" && r.ID != "r-1" {
+			t.Errorf("unexpected resource %s", r.ID)
+		}
+	}
+}
+
+// TestFilterResourceOpsEmptyInputs guards the degenerate calls a list page makes
+// on an empty page or an unauthenticated-but-routed request.
+func TestFilterResourceOpsEmptyInputs(t *testing.T) {
+	e := newTestEnforcer(t)
+	got, err := e.FilterResourceOps("u-1", nil, []string{"view_detail"}, knOps)
+	if err != nil {
+		t.Fatalf("filter: %v", err)
+	}
+	if len(got) != 0 {
+		t.Fatalf("got %v, want empty", got)
+	}
+
+	// Unknown accessor: no grants, nothing visible, no error.
+	got, err = e.FilterResourceOps("", []ResourceRef{{"knowledge_network", "kn-1"}}, []string{"view_detail"}, knOps)
+	if err != nil {
+		t.Fatalf("filter: %v", err)
+	}
+	if len(got) != 0 {
+		t.Fatalf("got %v, want empty", got)
+	}
+}
+
+// TestFilterResourceOpsMatchesCheck is the parity guard. The batch path resolves
+// grants once and projects them in memory instead of calling Enforce per
+// (resource, op); this asserts the two agree on a matrix spanning direct grants,
+// role inheritance, type-wide wildcards, act "*", public grants and misses.
+func TestFilterResourceOpsMatchesCheck(t *testing.T) {
+	e := newTestEnforcer(t)
+	const (
+		user     = "u-1"
+		admin    = "admin-1"
+		stranger = "u-nobody"
+		subRole  = "sub-role"
+	)
+	mustNoErr(t, e.Grant(superAdminRole, "*", "*"))
+	mustNoErr(t, e.AssignRole(admin, superAdminRole))
+	mustNoErr(t, e.GrantRolePermission(builderRole, "knowledge_network", "*", "view_detail"))
+	mustNoErr(t, e.GrantRolePermission(subRole, "knowledge_network", "kn-2", "modify"))
+	mustNoErr(t, e.AssignRole(user, builderRole))
+	// Role -> role: inherited transitively by g().
+	mustNoErr(t, e.AssignRole(builderRole, subRole))
+	mustNoErr(t, e.GrantObjectPermission(user, "knowledge_network", "kn-1", "delete"))
+	mustNoErr(t, e.GrantObjectPermission(user, "resource", "r-1", "*"))
+	mustNoErr(t, e.GrantObjectPermission(PublicAccessorID, "toolbox", "built-in", "use"))
+
+	refs := []ResourceRef{
+		{"knowledge_network", "kn-1"},
+		{"knowledge_network", "kn-2"},
+		{"resource", "r-1"},
+		{"resource", "r-2"},
+		{"toolbox", "built-in"},
+		{"toolbox", "private"},
+	}
+	ops := append(append([]string{}, knOps...), "use")
+
+	for _, accessor := range []string{user, admin, stranger} {
+		got, err := e.FilterResourceOps(accessor, refs, nil, ops)
+		if err != nil {
+			t.Fatalf("filter(%s): %v", accessor, err)
+		}
+		batch := map[string]map[string]bool{}
+		for _, r := range got {
+			key := r.Type + ":" + r.ID
+			batch[key] = map[string]bool{}
+			for _, op := range r.Operations {
+				batch[key][op] = true
+			}
+		}
+		for _, ref := range refs {
+			for _, op := range ops {
+				want, err := e.Check(accessor, ref.Type, ref.ID, op)
+				if err != nil {
+					t.Fatalf("check: %v", err)
+				}
+				if got := batch[ref.Type+":"+ref.ID][op]; got != want {
+					t.Errorf("accessor=%s %s:%s op=%s: batch=%v check=%v",
+						accessor, ref.Type, ref.ID, op, got, want)
+				}
+			}
+		}
+	}
+}

--- a/bkn-safe/server/internal/httpapi/authz.go
+++ b/bkn-safe/server/internal/httpapi/authz.go
@@ -123,10 +123,31 @@ func registerAuthz(r *gin.Engine, e *authz.Enforcer, db *gorm.DB) {
 			}
 		}
 
-		// Candidate ops default to each type's catalog. Resolved per distinct
-		// type so a mixed-type batch stays one request, then evaluated type by
-		// type; a single shared candidate list is the common case and costs one
-		// pass.
+		// One evaluation pass for the whole batch — including mixed types — when
+		// the caller states the candidate operations, which is the list-page
+		// case. Only the catalog fallback has to split by type, because there
+		// the candidate set is a property of the type rather than the request.
+		out := make([]gin.H, 0, len(refs))
+		appendResults := func(results []authz.FilteredResource) {
+			for _, r := range results {
+				out = append(out, gin.H{
+					"resource_type": r.Type,
+					"resource_id":   r.ID,
+					"operations":    r.Operations,
+				})
+			}
+		}
+		if len(req.CandidateOperations) > 0 {
+			results, err := e.FilterResourceOps(req.AccessorID, refs, req.VisibilityOperations, req.CandidateOperations)
+			if err != nil {
+				serverError(c, err)
+				return
+			}
+			appendResults(results)
+			c.JSON(http.StatusOK, gin.H{"resources": out})
+			return
+		}
+
 		byType := map[string][]authz.ResourceRef{}
 		order := make([]string, 0, 4)
 		for _, r := range refs {
@@ -135,28 +156,18 @@ func registerAuthz(r *gin.Engine, e *authz.Enforcer, db *gorm.DB) {
 			}
 			byType[r.Type] = append(byType[r.Type], r)
 		}
-		out := make([]gin.H, 0, len(refs))
 		for _, rtype := range order {
-			candidates := req.CandidateOperations
-			if len(candidates) == 0 {
-				var err error
-				if candidates, err = catalogOps(db, rtype); err != nil {
-					serverError(c, err)
-					return
-				}
+			candidates, err := catalogOps(db, rtype)
+			if err != nil {
+				serverError(c, err)
+				return
 			}
 			results, err := e.FilterResourceOps(req.AccessorID, byType[rtype], req.VisibilityOperations, candidates)
 			if err != nil {
 				serverError(c, err)
 				return
 			}
-			for _, r := range results {
-				out = append(out, gin.H{
-					"resource_type": r.Type,
-					"resource_id":   r.ID,
-					"operations":    r.Operations,
-				})
-			}
+			appendResults(results)
 		}
 		c.JSON(http.StatusOK, gin.H{"resources": out})
 	})

--- a/bkn-safe/server/internal/httpapi/authz.go
+++ b/bkn-safe/server/internal/httpapi/authz.go
@@ -76,6 +76,91 @@ func registerAuthz(r *gin.Engine, e *authz.Enforcer, db *gorm.DB) {
 		c.JSON(http.StatusOK, gin.H{"operations": allowed})
 	})
 
+	// POST /resource-filter — batched decision for a whole list page: which of
+	// the given resources the accessor may see, and which of the candidate
+	// operations it holds on each.
+	//
+	//	{ accessor_id, resources:[{type,id}], visibility_operations:[...], candidate_operations:[...] }
+	//	-> { resources:[ {resource_type, resource_id, operations:[...]} ] }
+	//
+	// Resources may also be given as resource_type + resource_ids (the
+	// single-type list-page form); both forms may be combined, and types may be
+	// mixed within one request.
+	//
+	// The two operation lists are separate axes on purpose. visibility_operations
+	// filters — a resource is returned only if the accessor holds every one of
+	// them; an empty list returns each requested resource. candidate_operations
+	// projects — the returned operations are the subset held, regardless of what
+	// made the resource visible. Omitting candidate_operations falls back to the
+	// resource type's catalog ops, as POST /operations does.
+	//
+	// Errors: 400 on a malformed body or a missing accessor_id; 500 on an engine
+	// failure. An empty resource list is not an error — it returns an empty
+	// result, so paginating callers need no special case.
+	g.POST("/resource-filter", func(c *gin.Context) {
+		var req struct {
+			AccessorID           string        `json:"accessor_id" binding:"required"`
+			Resources            []resourceRef `json:"resources"`
+			ResourceType         string        `json:"resource_type"`
+			ResourceIDs          []string      `json:"resource_ids"`
+			VisibilityOperations []string      `json:"visibility_operations"`
+			CandidateOperations  []string      `json:"candidate_operations"`
+		}
+		if !bind(c, &req) {
+			return
+		}
+		refs := make([]authz.ResourceRef, 0, len(req.Resources)+len(req.ResourceIDs))
+		for _, r := range req.Resources {
+			refs = append(refs, authz.ResourceRef{Type: r.Type, ID: r.ID})
+		}
+		if len(req.ResourceIDs) > 0 {
+			if req.ResourceType == "" {
+				c.JSON(http.StatusBadRequest, gin.H{"error": "resource_type required with resource_ids"})
+				return
+			}
+			for _, id := range req.ResourceIDs {
+				refs = append(refs, authz.ResourceRef{Type: req.ResourceType, ID: id})
+			}
+		}
+
+		// Candidate ops default to each type's catalog. Resolved per distinct
+		// type so a mixed-type batch stays one request, then evaluated type by
+		// type; a single shared candidate list is the common case and costs one
+		// pass.
+		byType := map[string][]authz.ResourceRef{}
+		order := make([]string, 0, 4)
+		for _, r := range refs {
+			if _, seen := byType[r.Type]; !seen {
+				order = append(order, r.Type)
+			}
+			byType[r.Type] = append(byType[r.Type], r)
+		}
+		out := make([]gin.H, 0, len(refs))
+		for _, rtype := range order {
+			candidates := req.CandidateOperations
+			if len(candidates) == 0 {
+				var err error
+				if candidates, err = catalogOps(db, rtype); err != nil {
+					serverError(c, err)
+					return
+				}
+			}
+			results, err := e.FilterResourceOps(req.AccessorID, byType[rtype], req.VisibilityOperations, candidates)
+			if err != nil {
+				serverError(c, err)
+				return
+			}
+			for _, r := range results {
+				out = append(out, gin.H{
+					"resource_type": r.Type,
+					"resource_id":   r.ID,
+					"operations":    r.Operations,
+				})
+			}
+		}
+		c.JSON(http.StatusOK, gin.H{"resources": out})
+	})
+
 	// POST /policies — grant an accessor concrete ops on one resource instance
 	// (the create-resource pattern). { accessor_id, resource, operations:[...] }
 	g.POST("/policies", func(c *gin.Context) {

--- a/bkn-safe/server/internal/httpapi/resourcefilter_test.go
+++ b/bkn-safe/server/internal/httpapi/resourcefilter_test.go
@@ -8,6 +8,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"reflect"
+	"sort"
 	"testing"
 
 	"github.com/gin-gonic/gin"
@@ -181,5 +182,39 @@ func TestResourceFilterEndpointCatalogFallback(t *testing.T) {
 	}
 	if want := []string{"view_detail"}; !reflect.DeepEqual(got[0].Operations, want) {
 		t.Errorf("ops = %v, want %v", got[0].Operations, want)
+	}
+}
+
+// TestResourceFilterEndpointCatalogFallbackMixedTypes covers the one case where
+// the batch has to be split: without candidate_operations each type projects its
+// own catalog, so the two types must not borrow each other's operations.
+func TestResourceFilterEndpointCatalogFallbackMixedTypes(t *testing.T) {
+	r, e, db := newTestServer(t)
+	const user = "u-1"
+	seedCatalogOps(t, db, "knowledge_network", "view_detail", "modify")
+	seedCatalogOps(t, db, "toolbox", "use")
+	_ = e.GrantObjectPermission(user, "knowledge_network", "kn-1", "view_detail")
+	_ = e.GrantObjectPermission(user, "knowledge_network", "kn-1", "modify")
+	_ = e.GrantObjectPermission(user, "toolbox", "tb-1", "use")
+
+	got := postFilter(t, r, map[string]any{
+		"accessor_id": user,
+		"resources": []map[string]string{
+			{"type": "knowledge_network", "id": "kn-1"},
+			{"type": "toolbox", "id": "tb-1"},
+		},
+	})
+
+	// Catalog order is a database detail, so compare the projections as sets.
+	ops := map[string][]string{}
+	for _, entry := range got {
+		sort.Strings(entry.Operations)
+		ops[entry.ResourceType] = entry.Operations
+	}
+	if want := []string{"modify", "view_detail"}; !reflect.DeepEqual(ops["knowledge_network"], want) {
+		t.Errorf("knowledge_network ops = %v, want %v", ops["knowledge_network"], want)
+	}
+	if want := []string{"use"}; !reflect.DeepEqual(ops["toolbox"], want) {
+		t.Errorf("toolbox ops = %v, want %v", ops["toolbox"], want)
 	}
 }

--- a/bkn-safe/server/internal/httpapi/resourcefilter_test.go
+++ b/bkn-safe/server/internal/httpapi/resourcefilter_test.go
@@ -1,0 +1,185 @@
+// Copyright openbkn.ai
+//
+// Licensed under the OpenBKN License. See LICENSE-OPENBKN.txt in the project root.
+
+package httpapi
+
+import (
+	"encoding/json"
+	"net/http"
+	"reflect"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+)
+
+type filterEntry struct {
+	ResourceType string   `json:"resource_type"`
+	ResourceID   string   `json:"resource_id"`
+	Operations   []string `json:"operations"`
+}
+
+func postFilter(t *testing.T, r *gin.Engine, body any) []filterEntry {
+	t.Helper()
+	w := do(t, r, http.MethodPost, "/api/safe/v1/authz/resource-filter", body)
+	if w.Code != http.StatusOK {
+		t.Fatalf("resource-filter = %d body=%s", w.Code, w.Body.String())
+	}
+	var resp struct {
+		Resources []filterEntry `json:"resources"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode: %v (%s)", err, w.Body.String())
+	}
+	return resp.Resources
+}
+
+// TestResourceFilterEndpoint is the contract this endpoint exists for: one call
+// per list page returns the visible resources with their full operation set.
+func TestResourceFilterEndpoint(t *testing.T) {
+	r, e, _ := newTestServer(t)
+	const user, role = "u-1", "role-builder"
+	_ = e.GrantRolePermission(role, "knowledge_network", "*", "view_detail")
+	_ = e.AssignRole(user, role)
+	_ = e.GrantObjectPermission(user, "knowledge_network", "kn-1", "modify")
+	_ = e.GrantObjectPermission(user, "knowledge_network", "kn-1", "delete")
+
+	got := postFilter(t, r, map[string]any{
+		"accessor_id":           user,
+		"resource_type":         "knowledge_network",
+		"resource_ids":          []string{"kn-1", "kn-2"},
+		"visibility_operations": []string{"view_detail"},
+		"candidate_operations":  []string{"view_detail", "create", "modify", "delete"},
+	})
+
+	if len(got) != 2 {
+		t.Fatalf("got %v, want 2 entries", got)
+	}
+	byID := map[string][]string{}
+	for _, r := range got {
+		if r.ResourceType != "knowledge_network" {
+			t.Errorf("resource_type = %q", r.ResourceType)
+		}
+		byID[r.ResourceID] = r.Operations
+	}
+	if want := []string{"view_detail", "modify", "delete"}; !reflect.DeepEqual(byID["kn-1"], want) {
+		t.Errorf("kn-1 = %v, want %v", byID["kn-1"], want)
+	}
+	if want := []string{"view_detail"}; !reflect.DeepEqual(byID["kn-2"], want) {
+		t.Errorf("kn-2 = %v, want %v", byID["kn-2"], want)
+	}
+}
+
+// TestResourceFilterEndpointMixedTypes covers the resources[] form with more
+// than one type in a single request.
+func TestResourceFilterEndpointMixedTypes(t *testing.T) {
+	r, e, _ := newTestServer(t)
+	const user = "u-1"
+	_ = e.GrantObjectPermission(user, "knowledge_network", "kn-1", "view_detail")
+	_ = e.GrantObjectPermission(user, "resource", "r-1", "view_detail")
+	_ = e.GrantObjectPermission(user, "resource", "r-1", "modify")
+
+	got := postFilter(t, r, map[string]any{
+		"accessor_id": user,
+		"resources": []map[string]string{
+			{"type": "knowledge_network", "id": "kn-1"},
+			{"type": "resource", "id": "r-1"},
+			{"type": "resource", "id": "r-2"},
+		},
+		"visibility_operations": []string{"view_detail"},
+		"candidate_operations":  []string{"view_detail", "modify"},
+	})
+
+	if len(got) != 2 {
+		t.Fatalf("got %v, want kn-1 and r-1", got)
+	}
+	for _, entry := range got {
+		if entry.ResourceType == "resource" && entry.ResourceID != "r-1" {
+			t.Errorf("unexpected entry %v", entry)
+		}
+	}
+}
+
+// TestResourceFilterEndpointSuperAdmin pins the reported regression: a wildcard
+// accessor must get the whole candidate set back, not just the visibility op.
+func TestResourceFilterEndpointSuperAdmin(t *testing.T) {
+	r, e, _ := newTestServer(t)
+	const admin, role = "admin-1", "role-super"
+	_ = e.Grant(role, "*", "*")
+	_ = e.AssignRole(admin, role)
+
+	candidates := []string{"view_detail", "create", "modify", "delete", "data_query", "authorize", "task_manage"}
+	got := postFilter(t, r, map[string]any{
+		"accessor_id":           admin,
+		"resource_type":         "knowledge_network",
+		"resource_ids":          []string{"kn-1"},
+		"visibility_operations": []string{"view_detail"},
+		"candidate_operations":  candidates,
+	})
+	if len(got) != 1 {
+		t.Fatalf("got %v, want 1 entry", got)
+	}
+	if !reflect.DeepEqual(got[0].Operations, candidates) {
+		t.Errorf("ops = %v, want %v", got[0].Operations, candidates)
+	}
+}
+
+// TestResourceFilterEndpointEdges covers the empty page, the missing accessor
+// and the malformed single-type form.
+func TestResourceFilterEndpointEdges(t *testing.T) {
+	r, _, _ := newTestServer(t)
+
+	t.Run("empty resource list is not an error", func(t *testing.T) {
+		got := postFilter(t, r, map[string]any{
+			"accessor_id":           "u-1",
+			"visibility_operations": []string{"view_detail"},
+			"candidate_operations":  []string{"view_detail"},
+		})
+		if len(got) != 0 {
+			t.Fatalf("got %v, want empty", got)
+		}
+	})
+
+	t.Run("missing accessor_id is rejected", func(t *testing.T) {
+		w := do(t, r, http.MethodPost, "/api/safe/v1/authz/resource-filter", map[string]any{
+			"resource_type": "knowledge_network",
+			"resource_ids":  []string{"kn-1"},
+		})
+		if w.Code != http.StatusBadRequest {
+			t.Fatalf("code = %d, want 400 (body=%s)", w.Code, w.Body.String())
+		}
+	})
+
+	t.Run("resource_ids without resource_type is rejected", func(t *testing.T) {
+		w := do(t, r, http.MethodPost, "/api/safe/v1/authz/resource-filter", map[string]any{
+			"accessor_id":  "u-1",
+			"resource_ids": []string{"kn-1"},
+		})
+		if w.Code != http.StatusBadRequest {
+			t.Fatalf("code = %d, want 400 (body=%s)", w.Code, w.Body.String())
+		}
+	})
+}
+
+// TestResourceFilterEndpointCatalogFallback checks that omitting
+// candidate_operations projects the resource type's catalog ops, matching what
+// POST /operations returns for the same resource.
+func TestResourceFilterEndpointCatalogFallback(t *testing.T) {
+	r, e, db := newTestServer(t)
+	const user = "u-1"
+	seedCatalogOps(t, db, "knowledge_network", "view_detail", "modify")
+	_ = e.GrantObjectPermission(user, "knowledge_network", "kn-1", "view_detail")
+
+	got := postFilter(t, r, map[string]any{
+		"accessor_id":           user,
+		"resource_type":         "knowledge_network",
+		"resource_ids":          []string{"kn-1"},
+		"visibility_operations": []string{"view_detail"},
+	})
+	if len(got) != 1 {
+		t.Fatalf("got %v, want 1 entry", got)
+	}
+	if want := []string{"view_detail"}; !reflect.DeepEqual(got[0].Operations, want) {
+		t.Errorf("ops = %v, want %v", got[0].Operations, want)
+	}
+}


### PR DESCRIPTION
Closes #698.

Knowledge-network list and detail responses returned `operations: ["view_detail"]` for every user, super_admin included, so Studio hid the edit/delete/create entry points. This adds the batched authorization query the issue asks for, and fixes the reason the candidate operation set never reached it.

## Root cause

`PermissionServiceImpl.FilterResources` accepts `fullOps []string` and never uses it — the filter it builds carries only the visibility list (`permission_service_impl.go:172-205`). `interfaces.COMMON_OPERATIONS`, passed at every knowledge-network call site, was discarded at the service layer.

ISF masked this: its `resource-filter` returned a resource's full allowed operation set when `allow_operation=true`, regardless of the requested operation list, so the adapter's `allow_operation` passthrough still produced a complete field. bkn-safe's adapter intersects with the requested operations instead, which collapsed the result to the visibility op. `deploy/conf/config.yaml` sets `authzProvider: bkn-safe`, so this is live on current installs.

The structural cause is that `PermissionResourcesFilter` had one `Operations` field serving two roles: visibility predicate and returned operation set.

## What changed

**bkn-safe — new batch endpoint** (additive; `/check`, `/operations`, `/resources`, `/policies` untouched):

```
POST /api/safe/v1/authz/resource-filter
{ accessor_id, resources:[{type,id}], visibility_operations:[...], candidate_operations:[...] }
-> { resources:[ {resource_type, resource_id, operations:[...]} ] }
```

The two operation lists are independent axes. `visibility_operations` filters — a resource is returned only if the accessor holds all of them; an empty list returns every requested resource. `candidate_operations` projects — the returned operations are the subset held, regardless of what made the resource visible; omitting it falls back to the type's catalog ops, as `POST /operations` does. Resources may also be given as `resource_type` + `resource_ids`, and types may be mixed in one request.

Decisions match `Check` exactly: direct grants, role-derived grants including transitive roles, root-department public grants, super-admin wildcard, and `act` wildcards. The implementation resolves the accessor's grants once and projects them per resource rather than calling `Enforce` per (resource, operation) — that would be O(resources x ops x policies) inside Casbin's matcher and would reproduce #357 on this path. `TestFilterResourceOpsMatchesCheck` asserts the two paths agree across a matrix covering all of the above.

**bkn-backend — propagate the candidate set and use the endpoint:**

- `PermissionResourcesFilter` gains `CandidateOperations` (`json:"-"`, so the ISF request shape is unchanged and the `AUTHZ_PROVIDER` revert path still works).
- `PermissionServiceImpl.FilterResources` forwards `fullOps`.
- The bkn-safe adapter makes one pass-through call instead of looping per resource per operation. That loop was the same N x M shape that timed out vega's resource list in #357; the knowledge-network list filters before pagination, so forwarding the candidate set without a batch endpoint would have turned N calls into 7N.
- Single-resource `/check` enforcement on write paths is unchanged.

## Relationship to #389

#389 item ① is the same gap approached from vega, with a single `operations` list that conflates visibility with projection. This PR owns the endpoint with the two-axis contract; #389 keeps its remaining work — moving vega's adapter onto this endpoint (dropping the `resolveOps`/`resolveFilter` workaround from #384), retiring the shadow/ISF paths, and orphan-grant reconciliation. vega behaviour is untouched here.

## Tests

- Engine: visibility filtering (single and conjunctive), operation-set projection, super-admin wildcard, role-derived and direct grants, public/root-department grants, mixed types, empty inputs, and the parity matrix against `Check`.
- Endpoint: both request forms, mixed types, super-admin, catalog fallback, empty page, and the 400 cases.
- Adapter: exactly one request per page, candidate operations present on the wire, candidate fallback, `GetResourcesOperations` sending no visibility filter, empty batch making no call, and error propagation.
- Service: `PermissionServiceImpl` wired to the real adapter against a stub bkn-safe, asserting `COMMON_OPERATIONS` reaches the wire and `view_detail` + `modify` + `delete` come back together.

## Verified on the test server (14.103.77.23)

Both services rebuilt from this branch and rolled out.

- `GET /api/bkn-backend/v1/knowledge-networks` — `operations` is now the full set `["view_detail","create","modify","delete","data_query","authorize","task_manage"]`; detail returns the same.
- `POST /api/safe/v1/authz/resource-filter` directly: authorized accessor returns the candidate subset; unknown accessor returns `{"resources":[]}`; missing `accessor_id` returns 400.
- Full list (`limit=-1`, 15 networks) responds in 0.04s.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
