### PR TITLE
fix(trace): derive managed scope from direct KN grants

### DIFF
--- a/bkn-safe/server/internal/httpapi/me.go
+++ b/bkn-safe/server/internal/httpapi/me.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"net/http"
 	"net/mail"
+	"sort"
 	"strings"
 
 	"github.com/gin-gonic/gin"
@@ -154,6 +155,36 @@ func registerMeReads(g *gin.RouterGroup, e *authz.Enforcer, db *gorm.DB, dir *di
 			"permissions": grantsJSON(grants),
 		})
 	})
+
+	// GET /knowledge-network-grants exposes only the caller's direct grants on
+	// concrete knowledge-network instances. It deliberately does not include
+	// inherited role grants or type-wide wildcards: consumers that need a set of
+	// managed network IDs must not turn a role capability into data scope.
+	g.GET("/knowledge-network-grants", func(c *gin.Context) {
+		grants, err := e.ListObjectGrants(c.GetString(ctxAccessorID), "knowledge_network", "")
+		if err != nil {
+			serverError(c, err)
+			return
+		}
+		result := make([]knowledgeNetworkGrantJSON, 0, len(grants))
+		for _, grant := range grants {
+			operations := append([]string(nil), grant.Operations...)
+			sort.Strings(operations)
+			result = append(result, knowledgeNetworkGrantJSON{
+				KnowledgeNetworkID: grant.ResourceID,
+				Operations:         operations,
+			})
+		}
+		sort.Slice(result, func(i, j int) bool {
+			return result[i].KnowledgeNetworkID < result[j].KnowledgeNetworkID
+		})
+		c.JSON(http.StatusOK, gin.H{"grants": result})
+	})
+}
+
+type knowledgeNetworkGrantJSON struct {
+	KnowledgeNetworkID string   `json:"knowledge_network_id"`
+	Operations         []string `json:"operations"`
 }
 
 // registerMeProfile mounts the MUTATING self-service profile endpoint (PUT "")

--- a/bkn-safe/server/internal/httpapi/me_test.go
+++ b/bkn-safe/server/internal/httpapi/me_test.go
@@ -247,6 +247,56 @@ func TestMePermissions(t *testing.T) {
 	}
 }
 
+func TestMeKnowledgeNetworkGrantsReturnsDirectInstancesWithoutRoleWildcard(t *testing.T) {
+	r, e, _, _ := newAdminServer(t)
+	const path = "/api/safe/v1/me/knowledge-network-grants"
+
+	// The role-wide grant intentionally covers the direct grant. The normal
+	// effective-permissions endpoint collapses that direct row, but Trace needs
+	// the concrete management scope without treating the wildcard as data scope.
+	if err := e.GrantRolePermission("network_builder", "knowledge_network", "*", "modify"); err != nil {
+		t.Fatal(err)
+	}
+	if err := e.AssignRole("builder-1", "network_builder"); err != nil {
+		t.Fatal(err)
+	}
+	if err := e.GrantObjectPermission("builder-1", "knowledge_network", "kn-managed", "modify"); err != nil {
+		t.Fatal(err)
+	}
+	if err := e.GrantObjectPermission("builder-1", "knowledge_network", "kn-managed", "task_manage"); err != nil {
+		t.Fatal(err)
+	}
+	if err := e.GrantObjectPermission("builder-1", "agent", "agent-1", "use"); err != nil {
+		t.Fatal(err)
+	}
+	if err := e.GrantObjectPermission("other-user", "knowledge_network", "kn-other", "modify"); err != nil {
+		t.Fatal(err)
+	}
+
+	if w := tokReq(t, r, http.MethodGet, path, nil, ""); w.Code != http.StatusUnauthorized {
+		t.Fatalf("no token: want 401, got %d", w.Code)
+	}
+	w := tokReq(t, r, http.MethodGet, path, nil, "builder-1")
+	if w.Code != http.StatusOK {
+		t.Fatalf("want 200, got %d (%s)", w.Code, w.Body.String())
+	}
+	var response struct {
+		Grants []struct {
+			KnowledgeNetworkID string   `json:"knowledge_network_id"`
+			Operations         []string `json:"operations"`
+		} `json:"grants"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &response); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if len(response.Grants) != 1 || response.Grants[0].KnowledgeNetworkID != "kn-managed" {
+		t.Fatalf("want only the caller's direct KN grant, got %#v", response.Grants)
+	}
+	if got := response.Grants[0].Operations; len(got) != 2 || got[0] != "modify" || got[1] != "task_manage" {
+		t.Fatalf("direct grant operations = %v, want [modify task_manage]", got)
+	}
+}
+
 // TestMePermissionsScope covers the scope filters and their validation.
 func TestMePermissionsScope(t *testing.T) {
 	r, e, _, _ := newAdminServer(t)

--- a/bkn-trace/agent-observability/charts/agent-observability/values.yaml
+++ b/bkn-trace/agent-observability/charts/agent-observability/values.yaml
@@ -109,7 +109,7 @@ core:
     enabled: false
     index: bkn-trace-core
     interval: 1s
-    rebuildVersion: bkn-trace-core-v013
+    rebuildVersion: bkn-trace-core-v014
   mariadb:
     existingSecret: bkn-trace-core-mariadb
     dsnKey: dsn

--- a/bkn-trace/agent-observability/src/conf/core.go
+++ b/bkn-trace/agent-observability/src/conf/core.go
@@ -51,7 +51,7 @@ func NewCoreConfig() CoreConfig {
 	}
 	projectionRebuildVersion := strings.TrimSpace(os.Getenv("BKN_TRACE_PROJECTION_REBUILD_VERSION"))
 	if projectionEnabled && projectionRebuildVersion == "" {
-		projectionRebuildVersion = projectionIndex + "-v013"
+		projectionRebuildVersion = projectionIndex + "-v014"
 	}
 	return CoreConfig{
 		Store: store, MariaDBDSN: strings.TrimSpace(os.Getenv("BKN_TRACE_CORE_MARIADB_DSN")),

--- a/bkn-trace/agent-observability/src/conf/core_test.go
+++ b/bkn-trace/agent-observability/src/conf/core_test.go
@@ -26,7 +26,7 @@ func TestProjectionUsesVersionedIndexBehindAliasByDefault(t *testing.T) {
 	t.Setenv("BKN_TRACE_PROJECTION_REBUILD_VERSION", "")
 
 	config := NewCoreConfig()
-	if config.ProjectionRebuildVersion != "bkn-trace-core-v013" {
+	if config.ProjectionRebuildVersion != "bkn-trace-core-v014" {
 		t.Fatalf("projection could create a concrete alias index: %#v", config)
 	}
 }

--- a/bkn-trace/agent-observability/src/domain/service/sessionsvc/service.go
+++ b/bkn-trace/agent-observability/src/domain/service/sessionsvc/service.go
@@ -1518,7 +1518,11 @@ func hashValue(value any) string {
 }
 
 func (s *Service) appendProjection(tx isessionstore.Transaction, aggregateType, aggregateID, eventType string, value any) error {
-	payload, err := json.Marshal(value)
+	projectionValue := value
+	if receipt, ok := value.(sessionvo.Receipt); ok {
+		projectionValue = sessionvo.NewReceiptProjectionDocument(receipt)
+	}
+	payload, err := json.Marshal(projectionValue)
 	if err != nil {
 		return err
 	}

--- a/bkn-trace/agent-observability/src/domain/valueobject/sessionvo/projection.go
+++ b/bkn-trace/agent-observability/src/domain/valueobject/sessionvo/projection.go
@@ -1,5 +1,10 @@
 package sessionvo
 
+import (
+	"sort"
+	"strings"
+)
+
 type ProjectionMutation struct {
 	EventID          string
 	AggregateType    string
@@ -7,4 +12,34 @@ type ProjectionMutation struct {
 	AggregateVersion uint64
 	EventType        string
 	Payload          []byte
+}
+
+// ReceiptProjectionDocument keeps the Core read model queryable by the same
+// immutable knowledge-network scope used for final authorization.
+type ReceiptProjectionDocument struct {
+	Receipt
+	KnowledgeNetworkIDs []string `json:"knowledge_network_ids,omitempty"`
+}
+
+func NewReceiptProjectionDocument(receipt Receipt) ReceiptProjectionDocument {
+	return ReceiptProjectionDocument{
+		Receipt:             receipt,
+		KnowledgeNetworkIDs: KnowledgeNetworkIDs(receipt.BusinessRefs),
+	}
+}
+
+func KnowledgeNetworkIDs(refs []BusinessRef) []string {
+	set := map[string]struct{}{}
+	for _, ref := range refs {
+		parts := strings.Split(ref.RefID, ":")
+		if len(parts) >= 2 && parts[0] != "resource" && parts[1] != "" {
+			set[parts[1]] = struct{}{}
+		}
+	}
+	values := make([]string, 0, len(set))
+	for value := range set {
+		values = append(values, value)
+	}
+	sort.Strings(values)
+	return values
 }

--- a/bkn-trace/agent-observability/src/domain/valueobject/sessionvo/projection_test.go
+++ b/bkn-trace/agent-observability/src/domain/valueobject/sessionvo/projection_test.go
@@ -1,0 +1,18 @@
+package sessionvo
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestNewReceiptProjectionDocumentDerivesKnowledgeNetworkIDs(t *testing.T) {
+	document := NewReceiptProjectionDocument(Receipt{BusinessRefs: []BusinessRef{
+		{RefID: "object:kn-b:forecast"},
+		{RefID: "kn:kn-a"},
+		{RefID: "resource:inventory"},
+		{RefID: "object:kn-b:item"},
+	}})
+	if !reflect.DeepEqual(document.KnowledgeNetworkIDs, []string{"kn-a", "kn-b"}) {
+		t.Fatalf("knowledge_network_ids = %v", document.KnowledgeNetworkIDs)
+	}
+}

--- a/bkn-trace/agent-observability/src/drivenadapter/dbaccess/mariadb/sessionstore/rebuild.go
+++ b/bkn-trace/agent-observability/src/drivenadapter/dbaccess/mariadb/sessionstore/rebuild.go
@@ -97,7 +97,11 @@ func projectionItem(
 	aggregateVersion uint64,
 	value any,
 ) (iprojectionoutbox.Item, error) {
-	payload, err := json.Marshal(value)
+	projectionValue := value
+	if receipt, ok := value.(sessionvo.Receipt); ok {
+		projectionValue = sessionvo.NewReceiptProjectionDocument(receipt)
+	}
+	payload, err := json.Marshal(projectionValue)
 	if err != nil {
 		return iprojectionoutbox.Item{}, err
 	}

--- a/bkn-trace/agent-observability/src/drivenadapter/httpaccess/bknsafeaccess/client.go
+++ b/bkn-trace/agent-observability/src/drivenadapter/httpaccess/bknsafeaccess/client.go
@@ -32,6 +32,14 @@ type Client struct {
 	http    *http.Client
 }
 
+type responseStatusError struct {
+	status int
+}
+
+func (e responseStatusError) Error() string {
+	return fmt.Sprintf("BKN Safe returned status %d", e.status)
+}
+
 type meResponse struct {
 	ID      string   `json:"id"`
 	Enabled bool     `json:"enabled"`
@@ -83,7 +91,10 @@ func (c *Client) Resolve(
 
 	var grants knowledgeNetworkGrantsResponse
 	if err := c.get(ctx, "/api/safe/v1/me/knowledge-network-grants", authorization, &grants); err != nil {
-		return evidencevo.AccessProfile{}, fmt.Errorf("resolve current BKN Safe knowledge-network grants: %w", err)
+		var statusErr responseStatusError
+		if !errors.As(err, &statusErr) || statusErr.status != http.StatusNotFound {
+			return evidencevo.AccessProfile{}, fmt.Errorf("resolve current BKN Safe knowledge-network grants: %w", err)
+		}
 	}
 
 	roles := currentBuiltInRoles(me.Roles)
@@ -117,7 +128,7 @@ func (c *Client) get(ctx context.Context, path, authorization string, target any
 	defer func() { _ = response.Body.Close() }()
 	if response.StatusCode != http.StatusOK {
 		_, _ = io.Copy(io.Discard, io.LimitReader(response.Body, maxSafeResponseBytes))
-		return fmt.Errorf("BKN Safe returned status %d", response.StatusCode)
+		return responseStatusError{status: response.StatusCode}
 	}
 	decoder := json.NewDecoder(io.LimitReader(response.Body, maxSafeResponseBytes))
 	if err := decoder.Decode(target); err != nil {

--- a/bkn-trace/agent-observability/src/drivenadapter/httpaccess/bknsafeaccess/client.go
+++ b/bkn-trace/agent-observability/src/drivenadapter/httpaccess/bknsafeaccess/client.go
@@ -38,14 +38,11 @@ type meResponse struct {
 	Roles   []string `json:"roles"`
 }
 
-type permissionsResponse struct {
-	Permissions []struct {
-		Resource struct {
-			Type string `json:"type"`
-			ID   string `json:"id"`
-		} `json:"resource"`
-		Operations []string `json:"operations"`
-	} `json:"permissions"`
+type knowledgeNetworkGrantsResponse struct {
+	Grants []struct {
+		KnowledgeNetworkID string   `json:"knowledge_network_id"`
+		Operations         []string `json:"operations"`
+	} `json:"grants"`
 }
 
 type fingerprintInput struct {
@@ -84,13 +81,13 @@ func (c *Client) Resolve(
 		return evidencevo.AccessProfile{}, errors.New("current BKN Safe identity is disabled or does not match the trusted actor")
 	}
 
-	var permissions permissionsResponse
-	if err := c.get(ctx, "/api/safe/v1/me/permissions", authorization, &permissions); err != nil {
-		return evidencevo.AccessProfile{}, fmt.Errorf("resolve current BKN Safe permissions: %w", err)
+	var grants knowledgeNetworkGrantsResponse
+	if err := c.get(ctx, "/api/safe/v1/me/knowledge-network-grants", authorization, &grants); err != nil {
+		return evidencevo.AccessProfile{}, fmt.Errorf("resolve current BKN Safe knowledge-network grants: %w", err)
 	}
 
 	roles := currentBuiltInRoles(me.Roles)
-	managedNetworks := concreteManagedNetworks(permissions)
+	managedNetworks := concreteManagedNetworks(grants)
 	input := fingerprintInput{
 		TenantID: identity.TenantID, BusinessDomain: identity.BusinessDomain,
 		ActorID: identity.ActorID, EffectiveSubjectID: identity.EffectiveSubjectID,
@@ -147,15 +144,15 @@ func currentBuiltInRoles(values []string) []string {
 	return roles
 }
 
-func concreteManagedNetworks(response permissionsResponse) []string {
+func concreteManagedNetworks(response knowledgeNetworkGrantsResponse) []string {
 	networks := map[string]struct{}{}
-	for _, permission := range response.Permissions {
-		if permission.Resource.Type != "knowledge_network" || permission.Resource.ID == "" || permission.Resource.ID == "*" {
+	for _, grant := range response.Grants {
+		if grant.KnowledgeNetworkID == "" || grant.KnowledgeNetworkID == "*" {
 			continue
 		}
-		for _, operation := range permission.Operations {
+		for _, operation := range grant.Operations {
 			if _, allowed := networkManagementOperations[operation]; allowed {
-				networks[permission.Resource.ID] = struct{}{}
+				networks[grant.KnowledgeNetworkID] = struct{}{}
 				break
 			}
 		}

--- a/bkn-trace/agent-observability/src/drivenadapter/httpaccess/bknsafeaccess/client_test.go
+++ b/bkn-trace/agent-observability/src/drivenadapter/httpaccess/bknsafeaccess/client_test.go
@@ -26,6 +26,12 @@ func TestResolveBuildsProfileFromCurrentSafeIdentityAndNetworkGrants(t *testing.
 				{"resource":{"type":"knowledge_network","id":"kn-a"},"operations":["authorize"]},
 				{"resource":{"type":"knowledge_network","id":"kn-c"},"operations":["view_detail"]}
 			]}`))
+		case "/api/safe/v1/me/knowledge-network-grants":
+			_, _ = w.Write([]byte(`{"grants":[
+				{"knowledge_network_id":"kn-b","operations":["view_detail","task_manage"]},
+				{"knowledge_network_id":"kn-a","operations":["authorize"]},
+				{"knowledge_network_id":"kn-c","operations":["view_detail"]}
+			]}`))
 		default:
 			http.NotFound(w, r)
 		}
@@ -62,6 +68,8 @@ func TestResolveDoesNotTreatGlobalAdminWildcardAsNetworkManagement(t *testing.T)
 			_, _ = w.Write([]byte(`{"id":"actor-a","enabled":true,"roles":["super_admin"]}`))
 		case "/api/safe/v1/me/permissions":
 			_, _ = w.Write([]byte(`{"permissions":[{"resource":{"type":"*","id":"*"},"operations":["*"]}]}`))
+		case "/api/safe/v1/me/knowledge-network-grants":
+			_, _ = w.Write([]byte(`{"grants":[]}`))
 		default:
 			http.NotFound(w, r)
 		}

--- a/bkn-trace/agent-observability/src/drivenadapter/httpaccess/bknsafeaccess/client_test.go
+++ b/bkn-trace/agent-observability/src/drivenadapter/httpaccess/bknsafeaccess/client_test.go
@@ -89,6 +89,32 @@ func TestResolveDoesNotTreatGlobalAdminWildcardAsNetworkManagement(t *testing.T)
 	}
 }
 
+func TestResolveKeepsOwnerScopeWhenDirectGrantEndpointIsNotDeployed(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/safe/v1/me":
+			_, _ = w.Write([]byte(`{"id":"actor-a","enabled":true,"roles":["network_builder"]}`))
+		case "/api/safe/v1/me/knowledge-network-grants":
+			http.NotFound(w, r)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	profile, err := New(server.URL, server.Client()).Resolve(
+		context.Background(), "Bearer current-token", iauthorizationscope.TrustedIdentity{
+			TenantID: "tenant-a", ActorID: "actor-a", EffectiveSubjectID: "user-a",
+		},
+	)
+	if err != nil {
+		t.Fatalf("missing direct-grant endpoint must preserve owner scope: %v", err)
+	}
+	if len(profile.ManagedKnowledgeNetworkIDs) != 0 {
+		t.Fatalf("missing direct-grant endpoint must not grant cross-network access: %v", profile.ManagedKnowledgeNetworkIDs)
+	}
+}
+
 func TestResolveFailsClosedForDisabledOrMismatchedIdentity(t *testing.T) {
 	for _, body := range []string{
 		`{"id":"actor-a","account_type":"user","enabled":false,"roles":["normal_user"]}`,

--- a/bkn-trace/agent-observability/src/drivenadapter/httpaccess/opensearchcoreprojection/source.go
+++ b/bkn-trace/agent-observability/src/drivenadapter/httpaccess/opensearchcoreprojection/source.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"sort"
-	"strings"
 
 	"github.com/openbkn-ai/bkn-foundry/bkn-trace/agent-observability/src/domain/valueobject/evidencevo"
 	"github.com/openbkn-ai/bkn-foundry/bkn-trace/agent-observability/src/domain/valueobject/sessionvo"
@@ -26,23 +25,24 @@ func New(client *opensearch.Client, index string, artifacts iprojectionsource.Pr
 }
 
 type receiptDocument struct {
-	ReceiptID          string                  `json:"receipt_id"`
-	SchemaVersion      string                  `json:"schema_version"`
-	Owner              sessionvo.Owner         `json:"owner"`
-	ConversationID     string                  `json:"conversation_id"`
-	InteractionID      string                  `json:"interaction_id"`
-	OperationID        string                  `json:"operation_id"`
-	OperationKey       string                  `json:"operation_key"`
-	ToolName           string                  `json:"tool_name"`
-	Status             string                  `json:"receipt_status"`
-	EvidenceDurability string                  `json:"evidence_durability"`
-	RequestID          string                  `json:"request_id"`
-	TraceID            string                  `json:"trace_id"`
-	BusinessRefs       []sessionvo.BusinessRef `json:"business_refs"`
-	ArtifactRefs       []string                `json:"artifact_refs"`
-	PartialReasons     []string                `json:"partial_reasons"`
-	IssuedAt           string                  `json:"issued_at"`
-	TerminalAt         string                  `json:"terminal_at"`
+	ReceiptID           string                  `json:"receipt_id"`
+	SchemaVersion       string                  `json:"schema_version"`
+	Owner               sessionvo.Owner         `json:"owner"`
+	ConversationID      string                  `json:"conversation_id"`
+	InteractionID       string                  `json:"interaction_id"`
+	OperationID         string                  `json:"operation_id"`
+	OperationKey        string                  `json:"operation_key"`
+	ToolName            string                  `json:"tool_name"`
+	Status              string                  `json:"receipt_status"`
+	EvidenceDurability  string                  `json:"evidence_durability"`
+	RequestID           string                  `json:"request_id"`
+	TraceID             string                  `json:"trace_id"`
+	BusinessRefs        []sessionvo.BusinessRef `json:"business_refs"`
+	ArtifactRefs        []string                `json:"artifact_refs"`
+	PartialReasons      []string                `json:"partial_reasons"`
+	KnowledgeNetworkIDs []string                `json:"knowledge_network_ids"`
+	IssuedAt            string                  `json:"issued_at"`
+	TerminalAt          string                  `json:"terminal_at"`
 }
 
 func (s *Source) LoadExecutionProjection(ctx context.Context, query iprojectionsource.Query) (iprojectionsource.Result, error) {
@@ -107,6 +107,7 @@ func (s *Source) loadReceipts(ctx context.Context, query iprojectionsource.Query
 			must = append(must, exactKeywordQuery(field, value))
 		}
 	}
+	must = append(must, receiptScopeCandidates(query.Scope)...)
 	if !query.From.IsZero() || !query.To.IsZero() {
 		bounds := map[string]any{}
 		if !query.From.IsZero() {
@@ -153,7 +154,7 @@ func exactKeywordQuery(field string, value string) map[string]any {
 }
 
 func receiptMatchesScope(receipt receiptDocument, scope evidencevo.QueryScope) bool {
-	networks := knowledgeNetworks(receipt.BusinessRefs)
+	networks := receiptKnowledgeNetworks(receipt)
 	record := evidencevo.RecordScope{
 		TenantID: receipt.Owner.TenantID, BusinessDomain: receipt.Owner.BusinessDomainID,
 		EffectiveSubjectID:     receipt.Owner.EffectiveSubjectID,
@@ -185,7 +186,7 @@ func tracesFromReceipts(receipts []receiptDocument) []evidencevo.NormalizedTrace
 				AccountType:            string(receipt.Owner.EffectiveSubjectType),
 				EffectiveSubjectID:     receipt.Owner.EffectiveSubjectID,
 				ApplicationPrincipalID: receipt.Owner.ApplicationPrincipalID,
-				KnowledgeNetworkIDs:    knowledgeNetworks(receipt.BusinessRefs),
+				KnowledgeNetworkIDs:    receiptKnowledgeNetworks(receipt),
 				SchemaVersion:          receipt.SchemaVersion,
 			}
 			trace = &value
@@ -292,20 +293,48 @@ func artifactLink(artifactType evidencevo.ArtifactType) (string, string) {
 	}
 }
 
-func knowledgeNetworks(refs []sessionvo.BusinessRef) []string {
-	set := map[string]struct{}{}
-	for _, ref := range refs {
-		parts := strings.Split(ref.RefID, ":")
-		if len(parts) >= 2 && parts[1] != "" && parts[0] != "resource" {
-			set[parts[1]] = struct{}{}
+func receiptScopeCandidates(scope evidencevo.QueryScope) []map[string]any {
+	if scope.AccessProfile == nil {
+		return receiptLegacyOwnerCandidate(scope)
+	}
+	if scope.View != "" && scope.View != evidencevo.AccessViewBusiness {
+		if evidencevo.NeedsCrossAccountCandidates(scope) {
+			return nil
 		}
+		return receiptLegacyOwnerCandidate(scope)
 	}
-	result := make([]string, 0, len(set))
-	for value := range set {
-		result = append(result, value)
+	profile := *scope.AccessProfile
+	should := make([]map[string]any, 0, 3)
+	if profile.EffectiveSubjectID != "" {
+		should = append(should, exactKeywordQuery("owner.effective_subject_id", profile.EffectiveSubjectID))
 	}
-	sort.Strings(result)
-	return result
+	if profile.ApplicationPrincipalID != "" {
+		should = append(should, exactKeywordQuery("owner.application_principal_id", profile.ApplicationPrincipalID))
+	}
+	if evidencevo.NeedsCrossAccountCandidates(scope) {
+		should = append(should, map[string]any{"terms": map[string]any{
+			"knowledge_network_ids.keyword": profile.ManagedKnowledgeNetworkIDs,
+		}})
+	}
+	if len(should) == 0 {
+		return receiptLegacyOwnerCandidate(scope)
+	}
+	return []map[string]any{{"bool": map[string]any{"should": should, "minimum_should_match": 1}}}
+}
+
+func receiptKnowledgeNetworks(receipt receiptDocument) []string {
+	return receipt.KnowledgeNetworkIDs
+}
+
+func receiptLegacyOwnerCandidate(scope evidencevo.QueryScope) []map[string]any {
+	should := make([]map[string]any, 0, 2)
+	if scope.AccountID != "" {
+		should = append(should, exactKeywordQuery("owner.effective_subject_id", scope.AccountID))
+	}
+	if len(should) == 0 {
+		return nil
+	}
+	return []map[string]any{{"bool": map[string]any{"should": should, "minimum_should_match": 1}}}
 }
 
 func firstNonEmpty(values ...string) string {

--- a/bkn-trace/agent-observability/src/drivenadapter/httpaccess/opensearchcoreprojection/source.go
+++ b/bkn-trace/agent-observability/src/drivenadapter/httpaccess/opensearchcoreprojection/source.go
@@ -297,13 +297,13 @@ func receiptScopeCandidates(scope evidencevo.QueryScope) []map[string]any {
 	if scope.AccessProfile == nil {
 		return receiptLegacyOwnerCandidate(scope)
 	}
+	profile := *scope.AccessProfile
 	if scope.View != "" && scope.View != evidencevo.AccessViewBusiness {
 		if evidencevo.NeedsCrossAccountCandidates(scope) {
 			return nil
 		}
-		return receiptLegacyOwnerCandidate(scope)
+		return receiptProfileOwnerCandidates(profile)
 	}
-	profile := *scope.AccessProfile
 	should := make([]map[string]any, 0, 3)
 	if profile.EffectiveSubjectID != "" {
 		should = append(should, exactKeywordQuery("owner.effective_subject_id", profile.EffectiveSubjectID))
@@ -327,9 +327,20 @@ func receiptKnowledgeNetworks(receipt receiptDocument) []string {
 }
 
 func receiptLegacyOwnerCandidate(scope evidencevo.QueryScope) []map[string]any {
+	return receiptCandidateSubjects(scope.AccountID, "")
+}
+
+func receiptProfileOwnerCandidates(profile evidencevo.AccessProfile) []map[string]any {
+	return receiptCandidateSubjects(profile.EffectiveSubjectID, profile.ApplicationPrincipalID)
+}
+
+func receiptCandidateSubjects(effectiveSubjectID, applicationPrincipalID string) []map[string]any {
 	should := make([]map[string]any, 0, 2)
-	if scope.AccountID != "" {
-		should = append(should, exactKeywordQuery("owner.effective_subject_id", scope.AccountID))
+	if effectiveSubjectID != "" {
+		should = append(should, exactKeywordQuery("owner.effective_subject_id", effectiveSubjectID))
+	}
+	if applicationPrincipalID != "" {
+		should = append(should, exactKeywordQuery("owner.application_principal_id", applicationPrincipalID))
 	}
 	if len(should) == 0 {
 		return nil

--- a/bkn-trace/agent-observability/src/drivenadapter/httpaccess/opensearchcoreprojection/source_test.go
+++ b/bkn-trace/agent-observability/src/drivenadapter/httpaccess/opensearchcoreprojection/source_test.go
@@ -58,6 +58,7 @@ func TestSourceBuildsAuthorizedExecutionProjectionFromCoreReceiptsAndArtifacts(t
 					{"ref_type":"knowledge_network","ref_id":"kn:supplychain_hd0202","business_domain_id":"domain-1","version":"v3"},
 					{"ref_type":"object_type","ref_id":"object:supplychain_hd0202:forecast","business_domain_id":"domain-1","version":"v3"}
 				],
+				"knowledge_network_ids":["supplychain_hd0202"],
 				"artifact_refs":[],"partial_reasons":[],
 				"issued_at":"2026-08-02T07:35:26Z","terminal_at":"2026-08-02T07:35:27Z"
 			}}, {"_source":{
@@ -187,6 +188,48 @@ func TestRequestProjectionHydratesArtifactsByReceiptInteraction(t *testing.T) {
 	}
 	if len(result.Traces) != 1 || len(result.Traces[0].Events) != 2 || len(result.Artifacts) != 1 {
 		t.Fatalf("only interaction-scoped artifacts may be projected onto another request: traces=%+v artifacts=%+v", result.Traces, result.Artifacts)
+	}
+}
+
+func TestSourceUsesManagedKnowledgeNetworksAsBusinessCandidates(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		if !strings.Contains(string(body), `"knowledge_network_ids.keyword"`) ||
+			!strings.Contains(string(body), `"kn-managed"`) {
+			t.Fatalf("managed KN candidate filter missing: %s", body)
+		}
+		_, _ = io.WriteString(w, `{"hits":{"hits":[{"_source":{
+			"receipt_id":"rcpt-managed","schema_version":"3.0.0",
+			"owner":{"tenant_id":"tenant-1","business_domain_id":"domain-1","application_principal_id":"other-app","effective_subject_type":"user","effective_subject_id":"other-user"},
+			"conversation_id":"conv-1","interaction_id":"int-1","operation_id":"op-1",
+			"tool_name":"query_object_instance","receipt_status":"completed","evidence_durability":"durable",
+			"request_id":"req-1","trace_id":"11111111111111111111111111111111",
+			"knowledge_network_ids":["kn-managed"],
+			"issued_at":"2026-08-02T07:35:26Z","terminal_at":"2026-08-02T07:35:27Z"
+		}}]}}`)
+	}))
+	t.Cleanup(server.Close)
+
+	source := opensearchcoreprojection.New(
+		opensearch.New(server.URL, opensearch.AuthConfig{}, time.Second), "bkn-trace-core", nil,
+	)
+	result, err := source.LoadExecutionProjection(context.Background(), iprojectionsource.Query{
+		Scope: evidencevo.QueryScope{
+			TenantID: "tenant-1", BusinessDomain: "domain-1", AccountID: "builder-1", AccountType: "user",
+			AccessProfile: &evidencevo.AccessProfile{
+				TenantID: "tenant-1", BusinessDomain: "domain-1", EffectiveSubjectID: "builder-1",
+				Roles: []string{"network_builder"}, ManagedKnowledgeNetworkIDs: []string{"kn-managed"},
+				AccountActive: true, TenantActive: true,
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("load projection: %v", err)
+	}
+	if len(result.Traces) != 1 || result.Traces[0].AccountID != "other-user" {
+		t.Fatalf("managed KN receipt was not projected: %#v", result.Traces)
 	}
 }
 

--- a/bkn-trace/agent-observability/src/drivenadapter/httpaccess/opensearchcoreprojection/source_test.go
+++ b/bkn-trace/agent-observability/src/drivenadapter/httpaccess/opensearchcoreprojection/source_test.go
@@ -233,6 +233,47 @@ func TestSourceUsesManagedKnowledgeNetworksAsBusinessCandidates(t *testing.T) {
 	}
 }
 
+func TestSourceUsesApplicationPrincipalAsTechnicalOwnerCandidate(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		if !strings.Contains(string(body), `"owner.application_principal_id.keyword"`) ||
+			!strings.Contains(string(body), `"app-a"`) {
+			t.Fatalf("application owner candidate missing: %s", body)
+		}
+		_, _ = io.WriteString(w, `{"hits":{"hits":[{"_source":{
+			"receipt_id":"rcpt-app","schema_version":"3.0.0",
+			"owner":{"tenant_id":"tenant-1","business_domain_id":"domain-1","application_principal_id":"app-a","effective_subject_type":"user","effective_subject_id":"other-user"},
+			"conversation_id":"conv-1","interaction_id":"int-1","operation_id":"op-1",
+			"tool_name":"query_object_instance","receipt_status":"completed","evidence_durability":"durable",
+			"request_id":"req-1","trace_id":"11111111111111111111111111111111",
+			"issued_at":"2026-08-02T07:35:26Z","terminal_at":"2026-08-02T07:35:27Z"
+		}}]}}`)
+	}))
+	t.Cleanup(server.Close)
+
+	source := opensearchcoreprojection.New(
+		opensearch.New(server.URL, opensearch.AuthConfig{}, time.Second), "bkn-trace-core", nil,
+	)
+	result, err := source.LoadExecutionProjection(context.Background(), iprojectionsource.Query{
+		Scope: evidencevo.QueryScope{
+			View: evidencevo.AccessViewTechnical,
+			AccessProfile: &evidencevo.AccessProfile{
+				TenantID: "tenant-1", BusinessDomain: "domain-1",
+				EffectiveSubjectID: "user-a", ApplicationPrincipalID: "app-a",
+				AccountActive: true, TenantActive: true,
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("load projection: %v", err)
+	}
+	if len(result.Traces) != 1 || result.Traces[0].AccountID != "other-user" {
+		t.Fatalf("application-owned receipt was not projected: %#v", result.Traces)
+	}
+}
+
 type artifactProjectionSource struct {
 	result iprojectionsource.Result
 }

--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -28,8 +28,9 @@
 | 🟫 context-loader | [`context-loader/`](context-loader/) | Agent 上下文入口：Schema 检索 / 实例与子图查询 / 逻辑属性 / 行动执行 / Skill 召回 / 数据直查 / MCP。**外部面全量**（内部 `/in/v1` 面不收录） |
 | 🟩 execution-factory | [`execution-factory/`](execution-factory/) | 执行工厂：函数 / 沙箱观测 / 导入导出 / 算子 / MCP / 工具箱 / Skill。**公开面全量**（89 个端点）。只收 Ingress 暴露的 `/v1`，内部面 `internal-v1` 刻意不收（不校验令牌），能力面 `/api/capabilities-lab/v1` 暂未收 |
 | 🟧 mf-model-manager | [`mf-model-manager/`](mf-model-manager/) | 模型工厂。**仅部分**：目前只覆盖大模型的连通性测试、默认模型设置与用量总览，其余接口（小模型、配额、提示词等）尚未文档化 |
+| 🟦 bkn-safe | [`bkn-safe/`](bkn-safe/) | BKN Trace 依赖的自助知识网络授权范围读取。**部分** |
 
-> 未文档化的服务：`bkn-safe`。
+> `bkn-safe` 仅收录已由外部运行时依赖的自助读取接口，不将管理面 API 误作为通用集成合同。
 
 ### ⚠️ `/api/ontology-manager/v1` 是历史别名，不要再用
 

--- a/docs/api/bkn-safe/self-service.yaml
+++ b/docs/api/bkn-safe/self-service.yaml
@@ -1,0 +1,51 @@
+openapi: 3.0.3
+info:
+  title: BKN Safe 自助授权范围 API
+  version: 0.1.3
+  description: |
+    供已认证主体读取自身的直接知识网络实例授权。BKN Trace 用此接口恢复
+    network_builder 的精确受管知识网络范围；它不是角色权限清单，也不返回
+    角色继承授权、通配授权或其他主体的授权信息。
+servers:
+  - url: /api/safe/v1
+security:
+  - BearerAuth: []
+paths:
+  /me/knowledge-network-grants:
+    get:
+      tags: [Self service]
+      operationId: getMyKnowledgeNetworkGrants
+      summary: 获取当前主体的直接知识网络实例授权
+      description: |
+        返回 bearer token 对应主体在具体知识网络实例上的直接授权及操作集合。
+        `knowledge_network:*` 等角色级或类型级授权不会出现在响应中，调用方不得
+        将角色能力通配符解释为业务内容读取范围。
+      responses:
+        '200':
+          description: 当前主体的直接知识网络实例授权
+          content:
+            application/json:
+              schema:
+                type: object
+                required: [grants]
+                properties:
+                  grants:
+                    type: array
+                    items:
+                      type: object
+                      required: [knowledge_network_id, operations]
+                      properties:
+                        knowledge_network_id:
+                          type: string
+                          description: 具体知识网络 ID，永不为 '*'
+                        operations:
+                          type: array
+                          items:
+                            type: string
+        '401':
+          description: 缺少或无效 bearer token
+components:
+  securitySchemes:
+    BearerAuth:
+      type: http
+      scheme: bearer

--- a/docs/api/observability/observability.json
+++ b/docs/api/observability/observability.json
@@ -28,6 +28,7 @@
       "log_policy_read"
     ],
     "access_scope_fingerprint_owner": "observability-gateway",
+    "managed_knowledge_network_scope_source": "BKN Safe GET /api/safe/v1/me/knowledge-network-grants (current-subject direct instance grants only)",
     "access_scope_inputs": [
       "account_status",
       "tenant_membership",


### PR DESCRIPTION
## 解决
- BKN Safe 仅暴露当前主体的直接、具体知识网络管理授权；继承角色和通配符不会扩展业务内容范围。
- BKN Trace 仅从这些具体授权导出 network_builder 的跨账户知识网络范围。
- Receipt 投影显式写入 `knowledge_network_ids`，候选查询与最终范围校验使用同一字段。
- 不对历史 Trace 投影做兼容、回填或重建；当前合同只适用于新写入数据。

## 验证
- `go test ./internal/httpapi -count=1`
- `go test ./src/domain/valueobject/sessionvo ./src/domain/service/sessionsvc ./src/drivenadapter/dbaccess/mariadb/sessionstore ./src/drivenadapter/httpaccess/bknsafeaccess ./src/drivenadapter/httpaccess/opensearchcoreprojection`
- `helm lint charts/agent-observability`
- `make api-docs-lint`（仅既有告警）

Closes #701