### PR TITLE
fix(trace): aggregate span stats on keyword fields

### DIFF
--- a/bkn-trace/agent-observability/src/domain/service/tracesvc/service.go
+++ b/bkn-trace/agent-observability/src/domain/service/tracesvc/service.go
@@ -47,12 +47,12 @@ func (s *TraceQueryService) CountSpansByTraceIDs(ctx context.Context, traceIDs [
 	}
 	query, err := json.Marshal(map[string]any{
 		"size":  0,
-		"query": map[string]any{"terms": map[string]any{"traceId": unique}},
+		"query": map[string]any{"terms": map[string]any{"traceId.keyword": unique}},
 		"aggs": map[string]any{
 			"by_trace": map[string]any{
-				"terms": map[string]any{"field": "traceId", "size": len(unique)},
+				"terms": map[string]any{"field": "traceId.keyword", "size": len(unique)},
 				"aggs": map[string]any{"span_count": map[string]any{
-					"cardinality": map[string]any{"field": "spanId"},
+					"cardinality": map[string]any{"field": "spanId.keyword"},
 				}},
 			},
 		},

--- a/bkn-trace/agent-observability/src/domain/service/tracesvc/service_test.go
+++ b/bkn-trace/agent-observability/src/domain/service/tracesvc/service_test.go
@@ -71,7 +71,8 @@ func TestCountSpansByTraceIDsUsesOneAggregationQuery(t *testing.T) {
 		t.Fatalf("unexpected counts: %+v", counts)
 	}
 	query := string(port.query)
-	if !strings.Contains(query, `"size":0`) || !strings.Contains(query, `"terms":{"traceId":["trace_a","trace_b"]}`) {
+	if !strings.Contains(query, `"size":0`) || !strings.Contains(query, `"terms":{"traceId.keyword":["trace_a","trace_b"]}`) ||
+		!strings.Contains(query, `"field":"spanId.keyword"`) {
 		t.Fatalf("expected one bounded terms aggregation query, got %s", query)
 	}
 }


### PR DESCRIPTION
## Summary
- aggregate Trace summary counts on OpenSearch keyword fields
- keep request Trace summaries consistent with trace graph details
- cover the aggregation field contract with a regression test

## Verification
- `go test ./...` in `bkn-trace/agent-observability`
- local Kind deployment: the same trace now reports `span_count=12`, matching its 12-node trace graph