### PR TITLE
test(observability): add collector capacity probe

### DIFF
--- a/bkn-trace/otelcol-contribute-chart/README.md
+++ b/bkn-trace/otelcol-contribute-chart/README.md
@@ -119,6 +119,8 @@ exporters:
 
 `monitoring.prometheusRule.enabled=true` 时渲染队列接近容量、日志导出失败和遥测拒绝告警。`networkPolicy.enabled=true` 时只允许带 `openbkn.ai/otel-producer=true` 标签的同命名空间 Pod 写入 OTLP，并允许指定监控命名空间抓取指标。两项默认关闭，启用前必须核对目标集群的 CRD、命名空间和工作负载标签。
 
+使用 `scripts/run_otlp_capacity_probe.sh` 做本地 Collector 验收。脚本默认只发送 5 条无敏感内容的 OTLP 日志；显式设置 `RATE_PER_SECOND=100 DURATION_SECONDS=300` 可执行稳态门，设置为 `300 / 300` 可执行突发门。脚本按 Collector 指标校验接收、导出、拒收和失败计数，并在结束时清理临时端口转发。
+
 ---
 
 ## 4. Pipeline 设计

--- a/bkn-trace/otelcol-contribute-chart/scripts/run_otlp_capacity_probe.sh
+++ b/bkn-trace/otelcol-contribute-chart/scripts/run_otlp_capacity_probe.sh
@@ -1,0 +1,88 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Sends synthetic, non-sensitive OTLP logs and checks Collector counter deltas.
+# Use RATE_PER_SECOND=100 DURATION_SECONDS=300 for the steady release gate, or
+# RATE_PER_SECOND=300 DURATION_SECONDS=300 for the burst gate.
+
+namespace="${NAMESPACE:-openbkn}"
+service="${SERVICE:-otelcol-contrib}"
+rate_per_second="${RATE_PER_SECOND:-1}"
+duration_seconds="${DURATION_SECONDS:-5}"
+otlp_endpoint="${OTLP_ENDPOINT:-}"
+metrics_endpoint="${METRICS_ENDPOINT:-}"
+port_forward_pid=""
+
+cleanup() {
+  if [[ -n "${port_forward_pid}" ]]; then
+    kill "${port_forward_pid}" 2>/dev/null || true
+  fi
+}
+trap cleanup EXIT
+
+if [[ -z "${otlp_endpoint}" || -z "${metrics_endpoint}" ]]; then
+  local_otlp_port="${LOCAL_OTLP_PORT:-14318}"
+  local_metrics_port="${LOCAL_METRICS_PORT:-18888}"
+  kubectl port-forward -n "${namespace}" "service/${service}" \
+    "${local_otlp_port}:4318" "${local_metrics_port}:8888" >/tmp/openbkn-otelcol-capacity-probe.log 2>&1 &
+  port_forward_pid=$!
+  otlp_endpoint="http://127.0.0.1:${local_otlp_port}/v1/logs"
+  metrics_endpoint="http://127.0.0.1:${local_metrics_port}/metrics"
+  for _ in {1..30}; do
+    if curl -fsS "${metrics_endpoint}" >/dev/null 2>&1; then
+      break
+    fi
+    sleep 1
+  done
+fi
+
+metric_sum() {
+  local metric="$1"
+  curl -fsS "${metrics_endpoint}" |
+    awk -v metric="${metric}" '$1 ~ ("^" metric "{") {sum += $NF} END {print sum + 0}'
+}
+
+accepted_before="$(metric_sum otelcol_receiver_accepted_log_records_total)"
+sent_before="$(metric_sum otelcol_exporter_sent_log_records_total)"
+refused_before="$(metric_sum otelcol_receiver_refused_log_records_total)"
+failed_before="$(metric_sum otelcol_exporter_send_failed_log_records_total)"
+
+records_json=""
+for ((record = 1; record <= rate_per_second; record++)); do
+  [[ -n "${records_json}" ]] && records_json+=","
+  records_json+="{\"timeUnixNano\":\"1786077600000000000\",\"severityText\":\"INFO\",\"body\":{\"stringValue\":\"collector capacity probe\"},\"attributes\":[{\"key\":\"event.name\",\"value\":{\"stringValue\":\"capacity.probe\"}}]}"
+done
+payload="{\"resourceLogs\":[{\"resource\":{\"attributes\":[{\"key\":\"service.name\",\"value\":{\"stringValue\":\"bkn-trace-capacity-probe\"}}]},\"scopeLogs\":[{\"scope\":{\"name\":\"bkn-trace.capacity\"},\"logRecords\":[${records_json}]}]}]}"
+expected_records=$((rate_per_second * duration_seconds))
+
+for ((second = 1; second <= duration_seconds; second++)); do
+  curl -fsS -o /dev/null -X POST "${otlp_endpoint}" \
+    -H 'Content-Type: application/json' --data "${payload}"
+  sleep 1
+done
+
+for _ in {1..30}; do
+  accepted_after="$(metric_sum otelcol_receiver_accepted_log_records_total)"
+  sent_after="$(metric_sum otelcol_exporter_sent_log_records_total)"
+  if ((accepted_after - accepted_before >= expected_records && sent_after - sent_before >= expected_records)); then
+    break
+  fi
+  sleep 1
+done
+
+accepted_after="$(metric_sum otelcol_receiver_accepted_log_records_total)"
+sent_after="$(metric_sum otelcol_exporter_sent_log_records_total)"
+refused_after="$(metric_sum otelcol_receiver_refused_log_records_total)"
+failed_after="$(metric_sum otelcol_exporter_send_failed_log_records_total)"
+
+accepted_delta=$((accepted_after - accepted_before))
+sent_delta=$((sent_after - sent_before))
+refused_delta=$((refused_after - refused_before))
+failed_delta=$((failed_after - failed_before))
+
+printf 'expected=%d accepted=%d sent=%d refused=%d failed=%d\n' \
+  "${expected_records}" "${accepted_delta}" "${sent_delta}" "${refused_delta}" "${failed_delta}"
+
+if ((accepted_delta < expected_records || sent_delta < expected_records || refused_delta != 0 || failed_delta != 0)); then
+  exit 1
+fi


### PR DESCRIPTION
## Summary
- add a self-contained OTLP log capacity probe for the Collector
- verify accepted, sent, refused and failed metric deltas
- default to a five-record smoke test; explicit rate and duration variables run the release load gates

## Local evidence
- 100 records/s for 300 seconds: expected 30000, accepted 30000, sent 30000, refused 0, failed 0
- retry queue returned to 0 of 512 and the Collector Pod remained ready with 0 restarts

## Validation
- default capacity probe passed
- 100 records/s for 10 seconds passed
- Helm lint passed
- Collector config validation passed
- git diff --check passed

Refs #547 and #545