### PR TITLE
feat(observability): disclose durable log source degradation

### DIFF
--- a/bkn-trace/agent-observability/charts/agent-observability/templates/deployment.yaml
+++ b/bkn-trace/agent-observability/charts/agent-observability/templates/deployment.yaml
@@ -125,6 +125,16 @@ spec:
               value: {{ .Values.observability.sourceTimeout | quote }}
             - name: BKN_OBSERVABILITY_MAX_CONCURRENT_SOURCES
               value: {{ .Values.observability.maxConcurrentSources | quote }}
+            {{- if .Values.observability.sourceCoverage.enabled }}
+            - name: BKN_OBSERVABILITY_SOURCE_COVERAGE_METRICS_ENDPOINT
+              value: {{ required "observability.sourceCoverage.metricsEndpoint is required when source coverage monitoring is enabled" .Values.observability.sourceCoverage.metricsEndpoint | quote }}
+            - name: BKN_OBSERVABILITY_SOURCE_COVERAGE_SOURCE_ID
+              value: {{ required "observability.sourceCoverage.sourceID is required when source coverage monitoring is enabled" .Values.observability.sourceCoverage.sourceID | quote }}
+            - name: BKN_OBSERVABILITY_SOURCE_COVERAGE_DEPLOYMENT_ID
+              value: {{ required "observability.sourceCoverage.deploymentID is required when source coverage monitoring is enabled" .Values.observability.sourceCoverage.deploymentID | quote }}
+            - name: BKN_OBSERVABILITY_SOURCE_COVERAGE_INTERVAL
+              value: {{ .Values.observability.sourceCoverage.interval | quote }}
+            {{- end }}
           livenessProbe:
             tcpSocket:
               port: http

--- a/bkn-trace/agent-observability/charts/agent-observability/values.yaml
+++ b/bkn-trace/agent-observability/charts/agent-observability/values.yaml
@@ -96,6 +96,15 @@ observability:
     secretKey: key
   sourceTimeout: 3s
   maxConcurrentSources: 4
+  sourceCoverage:
+    # Optional independent health probe. It is disabled unless the installation
+    # uses the persistent MariaDB Core store and provides a cluster-internal
+    # Collector metrics endpoint.
+    enabled: false
+    metricsEndpoint: ""
+    sourceID: otel-runtime
+    deploymentID: observability/otelcol-contrib
+    interval: 30s
 
 core:
   # Keep existing trace/evidence reads available after an upgrade. Enable

--- a/bkn-trace/agent-observability/migrations/mariadb/v014/init.sql
+++ b/bkn-trace/agent-observability/migrations/mariadb/v014/init.sql
@@ -1,0 +1,14 @@
+CREATE TABLE IF NOT EXISTS bkn_trace_log_source_coverage (
+    source_id VARCHAR(128) CHARACTER SET ascii COLLATE ascii_bin NOT NULL,
+    deployment_id VARCHAR(128) CHARACTER SET ascii COLLATE ascii_bin NOT NULL,
+    coverage_state VARCHAR(16) CHARACTER SET ascii COLLATE ascii_bin NOT NULL,
+    reason VARCHAR(64) CHARACTER SET ascii COLLATE ascii_bin NOT NULL DEFAULT '',
+    dropped_records BIGINT UNSIGNED NOT NULL DEFAULT 0,
+    first_observed_at DATETIME(6) NULL,
+    last_observed_at DATETIME(6) NULL,
+    recovered_at DATETIME(6) NULL,
+    row_version BIGINT UNSIGNED NOT NULL DEFAULT 1,
+    updated_at DATETIME(6) NOT NULL,
+    PRIMARY KEY (source_id, deployment_id),
+    INDEX idx_bkn_trace_log_source_coverage_state (coverage_state, updated_at)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin;

--- a/bkn-trace/agent-observability/migrations/mariadb/v014/schema.go
+++ b/bkn-trace/agent-observability/migrations/mariadb/v014/schema.go
@@ -1,0 +1,10 @@
+package v014
+
+import _ "embed"
+
+//go:embed init.sql
+var schemaSQL string
+
+func SchemaSQL() string {
+	return schemaSQL
+}

--- a/bkn-trace/agent-observability/src/boot/bootstrap.go
+++ b/bkn-trace/agent-observability/src/boot/bootstrap.go
@@ -20,6 +20,7 @@ import (
 	"github.com/openbkn-ai/bkn-foundry/bkn-trace/agent-observability/src/domain/service/projectionrebuildsvc"
 	"github.com/openbkn-ai/bkn-foundry/bkn-trace/agent-observability/src/domain/service/projectorsvc"
 	"github.com/openbkn-ai/bkn-foundry/bkn-trace/agent-observability/src/domain/service/sessionsvc"
+	"github.com/openbkn-ai/bkn-foundry/bkn-trace/agent-observability/src/domain/service/sourcecoveragesvc"
 	"github.com/openbkn-ai/bkn-foundry/bkn-trace/agent-observability/src/domain/service/tracesvc"
 	"github.com/openbkn-ai/bkn-foundry/bkn-trace/agent-observability/src/domain/valueobject/observabilityvo"
 	mariadbsessionstore "github.com/openbkn-ai/bkn-foundry/bkn-trace/agent-observability/src/drivenadapter/dbaccess/mariadb/sessionstore"
@@ -31,6 +32,7 @@ import (
 	"github.com/openbkn-ai/bkn-foundry/bkn-trace/agent-observability/src/drivenadapter/httpaccess/opensearchlogaccess"
 	"github.com/openbkn-ai/bkn-foundry/bkn-trace/agent-observability/src/drivenadapter/httpaccess/opensearchprojection"
 	"github.com/openbkn-ai/bkn-foundry/bkn-trace/agent-observability/src/drivenadapter/httpaccess/opensearchtraceaccess"
+	"github.com/openbkn-ai/bkn-foundry/bkn-trace/agent-observability/src/drivenadapter/httpaccess/otelcolmetrics"
 	"github.com/openbkn-ai/bkn-foundry/bkn-trace/agent-observability/src/drivenadapter/memoryaccess/evidencestore"
 	"github.com/openbkn-ai/bkn-foundry/bkn-trace/agent-observability/src/drivenadapter/memoryaccess/ledgerstore"
 	memorysessionstore "github.com/openbkn-ai/bkn-foundry/bkn-trace/agent-observability/src/drivenadapter/memoryaccess/sessionstore"
@@ -46,6 +48,7 @@ import (
 	"github.com/openbkn-ai/bkn-foundry/bkn-trace/agent-observability/src/port/driven/iprojectionrebuild"
 	"github.com/openbkn-ai/bkn-foundry/bkn-trace/agent-observability/src/port/driven/iprojectionsource"
 	"github.com/openbkn-ai/bkn-foundry/bkn-trace/agent-observability/src/port/driven/isessionstore"
+	"github.com/openbkn-ai/bkn-foundry/bkn-trace/agent-observability/src/port/driven/isourcecoveragestore"
 	httpSwagger "github.com/swaggo/http-swagger/v2"
 )
 
@@ -95,6 +98,14 @@ func NewApp() (*App, error) {
 	if err != nil {
 		return nil, err
 	}
+	coverageStore, coverageStoreSupported := sessionStore.(isourcecoveragestore.Store)
+	coverageMonitorEnabled := observabilityConfig.SourceCoverageMetricsEndpoint != ""
+	if coverageMonitorEnabled && (!coverageStoreSupported || observabilityConfig.SourceCoverageSourceID == "" || observabilityConfig.SourceCoverageDeploymentID == "") {
+		if closeDatabase != nil {
+			_ = closeDatabase()
+		}
+		return nil, errors.New("configured source coverage monitor requires MariaDB Core store, source ID, and deployment ID")
+	}
 	var summaryProjection iprojectionsource.ProjectionSourcePort
 	if legacyProjection, ok := evidenceStore.(iprojectionsource.ProjectionSourcePort); ok {
 		summaryProjection = legacyProjection
@@ -121,6 +132,14 @@ func NewApp() (*App, error) {
 		&http.Client{Timeout: accessScopeConfig.Timeout},
 	)
 	evidenceHandler := httphandler.NewEvidenceHandlerWithAuthorizationScopeResolver(evidenceService, accessScopeResolver)
+	logOptions := logsvc.Options{
+		CursorKey: observabilityConfig.CursorSigningKey, SourceTimeout: observabilityConfig.SourceTimeout,
+		MaxConcurrentSources: observabilityConfig.MaxConcurrentSources,
+	}
+	if coverageStoreSupported && observabilityConfig.SourceCoverageDeploymentID != "" {
+		logOptions.CoverageStore = coverageStore
+		logOptions.CoverageDeploymentID = observabilityConfig.SourceCoverageDeploymentID
+	}
 	logHandler := httphandler.NewLogHandler(logsvc.NewWithOptions([]logsvc.Source{
 		opensearchlogaccess.New(openSearchClient, openSearchConfig.LogIndex),
 		bknsafeaudit.New(accessScopeConfig.BKNBaseURL, &http.Client{Timeout: accessScopeConfig.Timeout}),
@@ -130,11 +149,7 @@ func NewApp() (*App, error) {
 		logsvc.NewNotIntegratedSource("bkn-safe-security", []string{
 			observabilityvo.CategoryAuditSecurity,
 		}, []string{"BKN Safe Authorization"}),
-	}, logsvc.Options{
-		CursorKey:            observabilityConfig.CursorSigningKey,
-		SourceTimeout:        observabilityConfig.SourceTimeout,
-		MaxConcurrentSources: observabilityConfig.MaxConcurrentSources,
-	}), evidenceHandler)
+	}, logOptions), evidenceHandler)
 	sessionService := sessionsvc.New(sessionStore, sessionsvc.Options{
 		EvidenceCollectionState: func() string {
 			if coreConfig.EvidenceCollectionState == "" {
@@ -164,6 +179,20 @@ func NewApp() (*App, error) {
 			sessionService,
 		)
 	}()
+	if coverageMonitorEnabled {
+		coverageMonitor := sourcecoveragesvc.New(
+			coverageStore,
+			otelcolmetrics.New(observabilityConfig.SourceCoverageMetricsEndpoint, &http.Client{Timeout: 3 * time.Second}),
+			sourcecoveragesvc.Options{
+				SourceID: observabilityConfig.SourceCoverageSourceID, DeploymentID: observabilityConfig.SourceCoverageDeploymentID,
+			},
+		)
+		app.workers.Add(1)
+		go func() {
+			defer app.workers.Done()
+			runSourceCoverageMonitor(workerContext, observabilityConfig.SourceCoverageInterval, coverageMonitor)
+		}()
+	}
 	if coreConfig.ProjectionEnabled {
 		outboxStore, supported := sessionStore.(iprojectionoutbox.Store)
 		if !supported {
@@ -262,6 +291,25 @@ func runLeaseReaper(
 			_, _ = service.AbandonExpiredInteractions(ctx, 100)
 			_, _ = service.ExpireIdleOneShotConversations(ctx, oneShotIdleTTL, 100)
 			_, _ = service.AssembleDueInteractions(ctx, 100)
+		}
+	}
+}
+
+func runSourceCoverageMonitor(ctx context.Context, interval time.Duration, service *sourcecoveragesvc.Service) {
+	observe := func() {
+		if err := service.Observe(ctx); err != nil && ctx.Err() == nil {
+			log.Printf("BKN Trace source coverage monitor failed: %v", err)
+		}
+	}
+	observe()
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			observe()
 		}
 	}
 }

--- a/bkn-trace/agent-observability/src/conf/observability.go
+++ b/bkn-trace/agent-observability/src/conf/observability.go
@@ -9,9 +9,13 @@ import (
 )
 
 type ObservabilityConfig struct {
-	CursorSigningKey     []byte
-	SourceTimeout        time.Duration
-	MaxConcurrentSources int
+	CursorSigningKey              []byte
+	SourceTimeout                 time.Duration
+	MaxConcurrentSources          int
+	SourceCoverageMetricsEndpoint string
+	SourceCoverageSourceID        string
+	SourceCoverageDeploymentID    string
+	SourceCoverageInterval        time.Duration
 }
 
 func NewObservabilityConfig() ObservabilityConfig {
@@ -33,9 +37,22 @@ func NewObservabilityConfig() ObservabilityConfig {
 			maxConcurrentSources = configured
 		}
 	}
+	coverageInterval := 30 * time.Second
+	if value := strings.TrimSpace(os.Getenv("BKN_OBSERVABILITY_SOURCE_COVERAGE_INTERVAL")); value != "" {
+		configured, err := time.ParseDuration(value)
+		if err != nil || configured <= 0 {
+			slog.Warn("invalid source coverage interval; using default", "value", value, "default", coverageInterval)
+		} else {
+			coverageInterval = configured
+		}
+	}
 	return ObservabilityConfig{
-		CursorSigningKey:     []byte(os.Getenv("BKN_OBSERVABILITY_CURSOR_SIGNING_KEY")),
-		SourceTimeout:        sourceTimeout,
-		MaxConcurrentSources: maxConcurrentSources,
+		CursorSigningKey:              []byte(os.Getenv("BKN_OBSERVABILITY_CURSOR_SIGNING_KEY")),
+		SourceTimeout:                 sourceTimeout,
+		MaxConcurrentSources:          maxConcurrentSources,
+		SourceCoverageMetricsEndpoint: strings.TrimSpace(os.Getenv("BKN_OBSERVABILITY_SOURCE_COVERAGE_METRICS_ENDPOINT")),
+		SourceCoverageSourceID:        strings.TrimSpace(os.Getenv("BKN_OBSERVABILITY_SOURCE_COVERAGE_SOURCE_ID")),
+		SourceCoverageDeploymentID:    strings.TrimSpace(os.Getenv("BKN_OBSERVABILITY_SOURCE_COVERAGE_DEPLOYMENT_ID")),
+		SourceCoverageInterval:        coverageInterval,
 	}
 }

--- a/bkn-trace/agent-observability/src/conf/observability_test.go
+++ b/bkn-trace/agent-observability/src/conf/observability_test.go
@@ -45,3 +45,18 @@ func TestObservabilityConfigRejectsInvalidSourceQueryLimits(t *testing.T) {
 		t.Fatalf("invalid values must fall back to defaults: %+v", config)
 	}
 }
+
+func TestObservabilityConfigReadsSourceCoverageMonitor(t *testing.T) {
+	t.Setenv("BKN_OBSERVABILITY_SOURCE_COVERAGE_METRICS_ENDPOINT", "http://otelcol:8888/metrics")
+	t.Setenv("BKN_OBSERVABILITY_SOURCE_COVERAGE_SOURCE_ID", "otel-runtime")
+	t.Setenv("BKN_OBSERVABILITY_SOURCE_COVERAGE_DEPLOYMENT_ID", "observability/otelcol-contrib")
+	t.Setenv("BKN_OBSERVABILITY_SOURCE_COVERAGE_INTERVAL", "15s")
+
+	config := NewObservabilityConfig()
+	if config.SourceCoverageMetricsEndpoint != "http://otelcol:8888/metrics" ||
+		config.SourceCoverageSourceID != "otel-runtime" ||
+		config.SourceCoverageDeploymentID != "observability/otelcol-contrib" ||
+		config.SourceCoverageInterval != 15*time.Second {
+		t.Fatalf("unexpected source coverage monitor config: %+v", config)
+	}
+}

--- a/bkn-trace/agent-observability/src/domain/service/logsvc/service.go
+++ b/bkn-trace/agent-observability/src/domain/service/logsvc/service.go
@@ -384,10 +384,6 @@ func (service *Service) searchSources(
 		if results[index].status.Status == "not_integrated" {
 			continue
 		}
-		if results[index].status.Status == "unavailable" && results[index].status.Reason == "source_status_probe_failed" {
-			results[index].err = errors.New("source coverage state is unavailable")
-			continue
-		}
 		waitGroup.Add(1)
 		go func(index int, source Source) {
 			defer waitGroup.Done()
@@ -610,9 +606,9 @@ func (service *Service) sourceStatus(ctx context.Context, source Source) observa
 	}
 	coverage, found, err := service.coverageStore.Get(ctx, source.ID(), service.coverageDeploymentID)
 	if err != nil {
-		status.Status = "unavailable"
+		status.Status = observabilityvo.SourceCoverageDegraded
 		status.Reason = "source_status_probe_failed"
-		status.CountAccuracy = "unavailable"
+		status.CountAccuracy = "partial"
 		return status
 	}
 	if found {

--- a/bkn-trace/agent-observability/src/domain/service/logsvc/service.go
+++ b/bkn-trace/agent-observability/src/domain/service/logsvc/service.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/openbkn-ai/bkn-foundry/bkn-trace/agent-observability/src/domain/valueobject/evidencevo"
 	"github.com/openbkn-ai/bkn-foundry/bkn-trace/agent-observability/src/domain/valueobject/observabilityvo"
+	"github.com/openbkn-ai/bkn-foundry/bkn-trace/agent-observability/src/port/driven/isourcecoveragestore"
 )
 
 var (
@@ -40,12 +41,16 @@ type Service struct {
 	cursorKey            []byte
 	sourceTimeout        time.Duration
 	maxConcurrentSources int
+	coverageStore        isourcecoveragestore.Store
+	coverageDeploymentID string
 }
 
 type Options struct {
 	CursorKey            []byte
 	SourceTimeout        time.Duration
 	MaxConcurrentSources int
+	CoverageStore        isourcecoveragestore.Store
+	CoverageDeploymentID string
 }
 
 const (
@@ -74,6 +79,7 @@ func NewWithOptions(sources []Source, options Options) *Service {
 	return &Service{
 		sources: append([]Source(nil), sources...), cursorKey: append([]byte(nil), options.CursorKey...),
 		sourceTimeout: options.SourceTimeout, maxConcurrentSources: options.MaxConcurrentSources,
+		coverageStore: options.CoverageStore, coverageDeploymentID: options.CoverageDeploymentID,
 	}
 }
 
@@ -214,6 +220,7 @@ func (service *Service) listPage(
 	sourceQuery.ObservedBefore = &queryWatermark
 	succeeded := 0
 	failed := 0
+	coveragePartial := false
 	sourcePageSizes := make(map[string]int)
 	sourceCandidates := make(map[string]int)
 	sourceLastRawPosition := make(map[string]observabilityvo.SourcePosition)
@@ -237,6 +244,7 @@ func (service *Service) listPage(
 		succeeded++
 		page := sourceResult.page
 		result.SourceStatus = append(result.SourceStatus, sourceResult.status)
+		coveragePartial = coveragePartial || sourceResult.status.Status == "degraded"
 		sourcePageSizes[source.ID()] = len(page.Records)
 		totalCount += page.Count
 		countExact = countExact && normalizedAccuracy(page.CountAccuracy) == "exact"
@@ -301,7 +309,7 @@ func (service *Service) listPage(
 			})
 		}
 	}
-	result.Partial = failed > 0
+	result.Partial = failed > 0 || coveragePartial
 	result.Count = totalCount
 	result.CountExact = !result.Partial && countExact
 	return result, nil
@@ -372,8 +380,12 @@ func (service *Service) searchSources(
 	semaphore := make(chan struct{}, service.maxConcurrentSources)
 	var waitGroup sync.WaitGroup
 	for index, source := range sources {
-		results[index] = sourceSearchResult{source: source, status: sourceStatus(source)}
+		results[index] = sourceSearchResult{source: source, status: service.sourceStatus(ctx, source)}
 		if results[index].status.Status == "not_integrated" {
+			continue
+		}
+		if results[index].status.Status == "unavailable" && results[index].status.Reason == "source_status_probe_failed" {
+			results[index].err = errors.New("source coverage state is unavailable")
 			continue
 		}
 		waitGroup.Add(1)
@@ -412,8 +424,10 @@ func (service *Service) searchSources(
 				results[index].status.CountAccuracy = "unavailable"
 				return
 			}
-			results[index].status.Status = "healthy"
-			results[index].status.CountAccuracy = normalizedAccuracy(page.CountAccuracy)
+			if results[index].status.Status != observabilityvo.SourceCoverageDegraded {
+				results[index].status.Status = "healthy"
+				results[index].status.CountAccuracy = normalizedAccuracy(page.CountAccuracy)
+			}
 		}(index, source)
 	}
 	waitGroup.Wait()
@@ -582,13 +596,29 @@ func sourceIDs(sources []Source) []string {
 	return normalizedStrings(result)
 }
 
-func sourceStatus(source Source) observabilityvo.SourceStatus {
+func (service *Service) sourceStatus(ctx context.Context, source Source) observabilityvo.SourceStatus {
+	var status observabilityvo.SourceStatus
 	if metadata, ok := source.(metadataSource); ok {
-		return metadata.Metadata()
+		status = metadata.Metadata()
+	} else {
+		status = observabilityvo.SourceStatus{
+			SourceID: source.ID(), Reliability: "best_effort", CountAccuracy: "exact",
+		}
 	}
-	return observabilityvo.SourceStatus{
-		SourceID: source.ID(), Reliability: "best_effort", CountAccuracy: "exact",
+	if service.coverageStore == nil || service.coverageDeploymentID == "" {
+		return status
 	}
+	coverage, found, err := service.coverageStore.Get(ctx, source.ID(), service.coverageDeploymentID)
+	if err != nil {
+		status.Status = "unavailable"
+		status.Reason = "source_status_probe_failed"
+		status.CountAccuracy = "unavailable"
+		return status
+	}
+	if found {
+		return coverage.Merge(status)
+	}
+	return status
 }
 
 func afterSourcePosition(record observabilityvo.LogRecord, position *observabilityvo.SourcePosition) bool {

--- a/bkn-trace/agent-observability/src/domain/service/logsvc/service_test.go
+++ b/bkn-trace/agent-observability/src/domain/service/logsvc/service_test.go
@@ -125,15 +125,21 @@ func TestListDisclosesDurableDegradedCoverageAfterSuccessfulSourceQuery(t *testi
 	}
 }
 
-func TestListDoesNotClaimHealthyWhenCoverageStateCannotBeRead(t *testing.T) {
+func TestListReturnsLogsButMarksCoveragePartialWhenStateCannotBeRead(t *testing.T) {
 	coverageStore := &coverageStore{err: errors.New("coverage database unavailable")}
-	service := NewWithOptions([]Source{fakeSource{id: "runtime"}}, Options{
+	service := NewWithOptions([]Source{fakeSource{id: "runtime", records: []observabilityvo.LogRecord{{
+		LogID: "log-1", Category: observabilityvo.CategoryRuntimeSystem, TenantID: "tenant-a",
+		EventTimestamp: time.Now().UTC(), TrustLevel: "trusted", IngressPrincipal: "otel-gateway",
+	}}}}, Options{
 		CursorKey: []byte("coverage-error-test"), CoverageStore: coverageStore, CoverageDeploymentID: "local",
 	})
 
-	_, err := service.List(context.Background(), activeProfile("admin-a", "admin"), observabilityvo.LogQuery{Limit: 10})
-	if !errors.Is(err, ErrSourcesUnavailable) {
-		t.Fatalf("expected unavailable sources when coverage cannot be read, got %v", err)
+	result, err := service.List(context.Background(), activeProfile("admin-a", "admin"), observabilityvo.LogQuery{Limit: 10})
+	if err != nil || !result.Partial || len(result.SourceStatus) != 1 {
+		t.Fatalf("expected available partial log result, got result=%+v err=%v", result, err)
+	}
+	if result.SourceStatus[0].Status != "degraded" || result.SourceStatus[0].Reason != "source_status_probe_failed" {
+		t.Fatalf("coverage uncertainty was not disclosed: %+v", result.SourceStatus[0])
 	}
 }
 

--- a/bkn-trace/agent-observability/src/domain/service/logsvc/service_test.go
+++ b/bkn-trace/agent-observability/src/domain/service/logsvc/service_test.go
@@ -100,6 +100,60 @@ func (source fakeSource) Search(
 	return observabilityvo.SourcePage{Records: validTestRecords(source.records), Count: int64(len(source.records)), CountAccuracy: "exact"}, nil
 }
 
+func TestListDisclosesDurableDegradedCoverageAfterSuccessfulSourceQuery(t *testing.T) {
+	coverageStore := &coverageStore{coverage: observabilityvo.SourceCoverage{
+		SourceID: "runtime", DeploymentID: "local", State: observabilityvo.SourceCoverageDegraded,
+		Reason: "telemetry_dropped", DroppedRecords: 4,
+	}}
+	service := NewWithOptions([]Source{fakeSource{id: "runtime", records: []observabilityvo.LogRecord{{
+		LogID: "log-1", Category: observabilityvo.CategoryRuntimeSystem, TenantID: "tenant-a",
+		EventTimestamp: time.Now().UTC(), TrustLevel: "trusted", IngressPrincipal: "otel-gateway",
+	}}}}, Options{
+		CursorKey: []byte("coverage-test"), CoverageStore: coverageStore, CoverageDeploymentID: "local",
+	})
+
+	result, err := service.List(context.Background(), activeProfile("admin-a", "admin"), observabilityvo.LogQuery{Limit: 10})
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	if !result.Partial || len(result.SourceStatus) != 1 {
+		t.Fatalf("expected partial result with one source status: %+v", result)
+	}
+	status := result.SourceStatus[0]
+	if status.Status != "degraded" || status.Reason != "telemetry_dropped" || status.DroppedRecords == nil || *status.DroppedRecords != 4 {
+		t.Fatalf("durable coverage degradation was hidden: %+v", status)
+	}
+}
+
+func TestListDoesNotClaimHealthyWhenCoverageStateCannotBeRead(t *testing.T) {
+	coverageStore := &coverageStore{err: errors.New("coverage database unavailable")}
+	service := NewWithOptions([]Source{fakeSource{id: "runtime"}}, Options{
+		CursorKey: []byte("coverage-error-test"), CoverageStore: coverageStore, CoverageDeploymentID: "local",
+	})
+
+	_, err := service.List(context.Background(), activeProfile("admin-a", "admin"), observabilityvo.LogQuery{Limit: 10})
+	if !errors.Is(err, ErrSourcesUnavailable) {
+		t.Fatalf("expected unavailable sources when coverage cannot be read, got %v", err)
+	}
+}
+
+type coverageStore struct {
+	coverage observabilityvo.SourceCoverage
+	err      error
+}
+
+func (store *coverageStore) Get(context.Context, string, string) (observabilityvo.SourceCoverage, bool, error) {
+	return store.coverage, store.coverage.SourceID != "", store.err
+}
+
+func (store *coverageStore) UpsertDegraded(context.Context, observabilityvo.SourceCoverage) error {
+	return nil
+}
+
+func (store *coverageStore) MarkHealthyAfterCatchUp(context.Context, string, string, uint64) error {
+	return nil
+}
+
 type categorizedSource struct {
 	id         string
 	categories []string

--- a/bkn-trace/agent-observability/src/domain/service/sourcecoveragesvc/service.go
+++ b/bkn-trace/agent-observability/src/domain/service/sourcecoveragesvc/service.go
@@ -51,8 +51,13 @@ func (service *Service) Observe(ctx context.Context) error {
 	if err != nil {
 		return fmt.Errorf("read collector coverage metrics: %w", err)
 	}
-	dropped := counterDelta(snapshot.RefusedLogs, service.previous.RefusedLogs, service.hasPrevious) +
-		counterDelta(snapshot.FailedLogs, service.previous.FailedLogs, service.hasPrevious)
+	if !service.hasPrevious {
+		service.previous = snapshot
+		service.hasPrevious = true
+		return nil
+	}
+	dropped := counterDelta(snapshot.RefusedLogs, service.previous.RefusedLogs) +
+		counterDelta(snapshot.FailedLogs, service.previous.FailedLogs)
 	service.previous = snapshot
 	service.hasPrevious = true
 	coverage, found, err := service.store.Get(ctx, service.options.SourceID, service.options.DeploymentID)
@@ -73,7 +78,7 @@ func (service *Service) Observe(ctx context.Context) error {
 		coverage.LastObservedAt = time.Now().UTC()
 		return service.store.UpsertDegraded(ctx, coverage)
 	}
-	if !found || coverage.State != observabilityvo.SourceCoverageDegraded || snapshot.QueueSize != 0 {
+	if !found || coverage.State != observabilityvo.SourceCoverageDegraded {
 		service.healthySamples = 0
 		return nil
 	}
@@ -88,11 +93,11 @@ func (service *Service) Observe(ctx context.Context) error {
 	return nil
 }
 
-func counterDelta(current, previous int64, hasPrevious bool) int64 {
+func counterDelta(current, previous int64) int64 {
 	if current < 0 {
 		return 0
 	}
-	if !hasPrevious || current >= previous {
+	if current >= previous {
 		return current - previous
 	}
 	// A Collector restart resets counters. Any post-reset nonzero value is still

--- a/bkn-trace/agent-observability/src/domain/service/sourcecoveragesvc/service.go
+++ b/bkn-trace/agent-observability/src/domain/service/sourcecoveragesvc/service.go
@@ -1,0 +1,101 @@
+package sourcecoveragesvc
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/openbkn-ai/bkn-foundry/bkn-trace/agent-observability/src/domain/valueobject/observabilityvo"
+	"github.com/openbkn-ai/bkn-foundry/bkn-trace/agent-observability/src/port/driven/isourcecoveragestore"
+)
+
+var ErrVersionConflict = errors.New("source coverage version conflict")
+
+type Snapshot struct {
+	RefusedLogs   int64
+	FailedLogs    int64
+	QueueSize     int64
+	QueueCapacity int64
+}
+
+type Reader interface {
+	Read(ctx context.Context) (Snapshot, error)
+}
+
+type Options struct {
+	SourceID     string
+	DeploymentID string
+}
+
+type Service struct {
+	store          isourcecoveragestore.Store
+	reader         Reader
+	options        Options
+	previous       Snapshot
+	hasPrevious    bool
+	healthySamples int
+}
+
+func New(store isourcecoveragestore.Store, reader Reader, options Options) *Service {
+	return &Service{store: store, reader: reader, options: options}
+}
+
+// Observe records a loss signal immediately. Recovery needs two independent,
+// drained samples so a transient exporter recovery cannot overstate coverage.
+func (service *Service) Observe(ctx context.Context) error {
+	if service.store == nil || service.reader == nil || service.options.SourceID == "" || service.options.DeploymentID == "" {
+		return errors.New("source coverage monitor is not configured")
+	}
+	snapshot, err := service.reader.Read(ctx)
+	if err != nil {
+		return fmt.Errorf("read collector coverage metrics: %w", err)
+	}
+	dropped := counterDelta(snapshot.RefusedLogs, service.previous.RefusedLogs, service.hasPrevious) +
+		counterDelta(snapshot.FailedLogs, service.previous.FailedLogs, service.hasPrevious)
+	service.previous = snapshot
+	service.hasPrevious = true
+	coverage, found, err := service.store.Get(ctx, service.options.SourceID, service.options.DeploymentID)
+	if err != nil {
+		return fmt.Errorf("load source coverage: %w", err)
+	}
+	if dropped > 0 {
+		service.healthySamples = 0
+		if !found {
+			coverage = observabilityvo.SourceCoverage{
+				SourceID: service.options.SourceID, DeploymentID: service.options.DeploymentID,
+				FirstObservedAt: time.Now().UTC(),
+			}
+		}
+		coverage.State = observabilityvo.SourceCoverageDegraded
+		coverage.Reason = "telemetry_dropped"
+		coverage.DroppedRecords += dropped
+		coverage.LastObservedAt = time.Now().UTC()
+		return service.store.UpsertDegraded(ctx, coverage)
+	}
+	if !found || coverage.State != observabilityvo.SourceCoverageDegraded || snapshot.QueueSize != 0 {
+		service.healthySamples = 0
+		return nil
+	}
+	service.healthySamples++
+	if service.healthySamples < 2 {
+		return nil
+	}
+	service.healthySamples = 0
+	if err := service.store.MarkHealthyAfterCatchUp(ctx, coverage.SourceID, coverage.DeploymentID, coverage.Version); err != nil {
+		return fmt.Errorf("mark source coverage healthy: %w", err)
+	}
+	return nil
+}
+
+func counterDelta(current, previous int64, hasPrevious bool) int64 {
+	if current < 0 {
+		return 0
+	}
+	if !hasPrevious || current >= previous {
+		return current - previous
+	}
+	// A Collector restart resets counters. Any post-reset nonzero value is still
+	// a new loss signal; a zero value is neutral and cannot clear durable state.
+	return current
+}

--- a/bkn-trace/agent-observability/src/domain/service/sourcecoveragesvc/service_test.go
+++ b/bkn-trace/agent-observability/src/domain/service/sourcecoveragesvc/service_test.go
@@ -1,0 +1,90 @@
+package sourcecoveragesvc
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/openbkn-ai/bkn-foundry/bkn-trace/agent-observability/src/domain/valueobject/observabilityvo"
+)
+
+func TestObserveDegradesSourceWhenCollectorDropsRecords(t *testing.T) {
+	store := &fakeStore{}
+	service := New(store, &fakeReader{snapshots: []Snapshot{{RefusedLogs: 3}}}, Options{
+		SourceID: "otel-runtime", DeploymentID: "observability/otelcol-contrib",
+	})
+
+	if err := service.Observe(context.Background()); err != nil {
+		t.Fatalf("observe: %v", err)
+	}
+	coverage, found, err := store.Get(context.Background(), "otel-runtime", "observability/otelcol-contrib")
+	if err != nil || !found || coverage.State != observabilityvo.SourceCoverageDegraded || coverage.DroppedRecords != 3 {
+		t.Fatalf("expected degraded coverage, got %+v found=%t err=%v", coverage, found, err)
+	}
+}
+
+func TestObserveRecoversOnlyAfterTwoHealthyDrainedSamples(t *testing.T) {
+	now := time.Now().UTC()
+	store := &fakeStore{coverage: observabilityvo.SourceCoverage{
+		SourceID: "otel-runtime", DeploymentID: "observability/otelcol-contrib",
+		State: observabilityvo.SourceCoverageDegraded, Reason: "telemetry_dropped", DroppedRecords: 3,
+		FirstObservedAt: now.Add(-time.Minute), LastObservedAt: now, Version: 1,
+	}}
+	service := New(store, &fakeReader{snapshots: []Snapshot{
+		{QueueSize: 0, QueueCapacity: 512},
+		{QueueSize: 0, QueueCapacity: 512},
+	}}, Options{SourceID: "otel-runtime", DeploymentID: "observability/otelcol-contrib"})
+
+	if err := service.Observe(context.Background()); err != nil {
+		t.Fatalf("first observe: %v", err)
+	}
+	if store.coverage.State != observabilityvo.SourceCoverageDegraded {
+		t.Fatalf("recovered after one healthy sample: %+v", store.coverage)
+	}
+	if err := service.Observe(context.Background()); err != nil {
+		t.Fatalf("second observe: %v", err)
+	}
+	if store.coverage.State != observabilityvo.SourceCoverageHealthy || store.coverage.RecoveredAt == nil {
+		t.Fatalf("expected recovered coverage after two samples: %+v", store.coverage)
+	}
+}
+
+type fakeReader struct {
+	snapshots []Snapshot
+}
+
+func (reader *fakeReader) Read(context.Context) (Snapshot, error) {
+	result := reader.snapshots[0]
+	reader.snapshots = reader.snapshots[1:]
+	return result, nil
+}
+
+type fakeStore struct {
+	coverage observabilityvo.SourceCoverage
+}
+
+func (store *fakeStore) Get(_ context.Context, _, _ string) (observabilityvo.SourceCoverage, bool, error) {
+	return store.coverage, store.coverage.SourceID != "", nil
+}
+
+func (store *fakeStore) UpsertDegraded(_ context.Context, coverage observabilityvo.SourceCoverage) error {
+	if store.coverage.SourceID != "" {
+		coverage.Version = store.coverage.Version + 1
+	} else {
+		coverage.Version = 1
+	}
+	store.coverage = coverage
+	return nil
+}
+
+func (store *fakeStore) MarkHealthyAfterCatchUp(_ context.Context, _, _ string, version uint64) error {
+	if store.coverage.Version != version {
+		return ErrVersionConflict
+	}
+	now := time.Now().UTC()
+	store.coverage.State = observabilityvo.SourceCoverageHealthy
+	store.coverage.Reason = ""
+	store.coverage.RecoveredAt = &now
+	store.coverage.Version++
+	return nil
+}

--- a/bkn-trace/agent-observability/src/domain/service/sourcecoveragesvc/service_test.go
+++ b/bkn-trace/agent-observability/src/domain/service/sourcecoveragesvc/service_test.go
@@ -10,16 +10,33 @@ import (
 
 func TestObserveDegradesSourceWhenCollectorDropsRecords(t *testing.T) {
 	store := &fakeStore{}
-	service := New(store, &fakeReader{snapshots: []Snapshot{{RefusedLogs: 3}}}, Options{
+	service := New(store, &fakeReader{snapshots: []Snapshot{{RefusedLogs: 0}, {RefusedLogs: 3}}}, Options{
 		SourceID: "otel-runtime", DeploymentID: "observability/otelcol-contrib",
 	})
 
 	if err := service.Observe(context.Background()); err != nil {
-		t.Fatalf("observe: %v", err)
+		t.Fatalf("baseline observe: %v", err)
+	}
+	if err := service.Observe(context.Background()); err != nil {
+		t.Fatalf("loss observe: %v", err)
 	}
 	coverage, found, err := store.Get(context.Background(), "otel-runtime", "observability/otelcol-contrib")
 	if err != nil || !found || coverage.State != observabilityvo.SourceCoverageDegraded || coverage.DroppedRecords != 3 {
 		t.Fatalf("expected degraded coverage, got %+v found=%t err=%v", coverage, found, err)
+	}
+}
+
+func TestObserveUsesFirstCollectorSnapshotOnlyAsBaseline(t *testing.T) {
+	store := &fakeStore{}
+	service := New(store, &fakeReader{snapshots: []Snapshot{{RefusedLogs: 1000, FailedLogs: 20}}}, Options{
+		SourceID: "otel-runtime", DeploymentID: "observability/otelcol-contrib",
+	})
+
+	if err := service.Observe(context.Background()); err != nil {
+		t.Fatalf("baseline observe: %v", err)
+	}
+	if _, found, _ := store.Get(context.Background(), "otel-runtime", "observability/otelcol-contrib"); found {
+		t.Fatal("first snapshot must not re-count historical Collector counters")
 	}
 }
 
@@ -31,8 +48,9 @@ func TestObserveRecoversOnlyAfterTwoHealthyDrainedSamples(t *testing.T) {
 		FirstObservedAt: now.Add(-time.Minute), LastObservedAt: now, Version: 1,
 	}}
 	service := New(store, &fakeReader{snapshots: []Snapshot{
-		{QueueSize: 0, QueueCapacity: 512},
-		{QueueSize: 0, QueueCapacity: 512},
+		{QueueSize: 512, QueueCapacity: 512},
+		{QueueSize: 512, QueueCapacity: 512},
+		{QueueSize: 512, QueueCapacity: 512},
 	}}, Options{SourceID: "otel-runtime", DeploymentID: "observability/otelcol-contrib"})
 
 	if err := service.Observe(context.Background()); err != nil {
@@ -42,7 +60,10 @@ func TestObserveRecoversOnlyAfterTwoHealthyDrainedSamples(t *testing.T) {
 		t.Fatalf("recovered after one healthy sample: %+v", store.coverage)
 	}
 	if err := service.Observe(context.Background()); err != nil {
-		t.Fatalf("second observe: %v", err)
+		t.Fatalf("second healthy observe: %v", err)
+	}
+	if err := service.Observe(context.Background()); err != nil {
+		t.Fatalf("third healthy observe: %v", err)
 	}
 	if store.coverage.State != observabilityvo.SourceCoverageHealthy || store.coverage.RecoveredAt == nil {
 		t.Fatalf("expected recovered coverage after two samples: %+v", store.coverage)

--- a/bkn-trace/agent-observability/src/domain/valueobject/observabilityvo/source_coverage.go
+++ b/bkn-trace/agent-observability/src/domain/valueobject/observabilityvo/source_coverage.go
@@ -1,0 +1,35 @@
+package observabilityvo
+
+import "time"
+
+const (
+	SourceCoverageHealthy  = "healthy"
+	SourceCoverageDegraded = "degraded"
+)
+
+// SourceCoverage is the durable collection-coverage fact for a log source.
+// It intentionally excludes log payloads and business data.
+type SourceCoverage struct {
+	SourceID        string
+	DeploymentID    string
+	State           string
+	Reason          string
+	DroppedRecords  int64
+	FirstObservedAt time.Time
+	LastObservedAt  time.Time
+	RecoveredAt     *time.Time
+	Version         uint64
+}
+
+// Merge applies coverage completeness without changing source availability.
+func (coverage SourceCoverage) Merge(status SourceStatus) SourceStatus {
+	if coverage.SourceID == "" || coverage.SourceID != status.SourceID || coverage.State != SourceCoverageDegraded {
+		return status
+	}
+	dropped := coverage.DroppedRecords
+	status.Status = SourceCoverageDegraded
+	status.Reason = coverage.Reason
+	status.DroppedRecords = &dropped
+	status.CountAccuracy = "partial"
+	return status
+}

--- a/bkn-trace/agent-observability/src/domain/valueobject/observabilityvo/source_coverage_test.go
+++ b/bkn-trace/agent-observability/src/domain/valueobject/observabilityvo/source_coverage_test.go
@@ -1,0 +1,40 @@
+package observabilityvo
+
+import (
+	"testing"
+	"time"
+)
+
+func TestSourceCoverageStatusDisclosesDroppedTelemetry(t *testing.T) {
+	now := time.Date(2026, time.August, 7, 12, 0, 0, 0, time.UTC)
+	coverage := SourceCoverage{
+		SourceID:          "otel-runtime",
+		DeploymentID:      "observability/otelcol-contrib",
+		State:             SourceCoverageDegraded,
+		Reason:            "telemetry_dropped",
+		DroppedRecords:    3,
+		FirstObservedAt:   now.Add(-time.Minute),
+		LastObservedAt:    now,
+	}
+
+	status := coverage.Merge(SourceStatus{SourceID: "otel-runtime", Status: "healthy", Reliability: "best_effort"})
+	if status.Status != "degraded" || status.Reason != "telemetry_dropped" {
+		t.Fatalf("expected durable degradation, got %+v", status)
+	}
+	if status.DroppedRecords == nil || *status.DroppedRecords != 3 {
+		t.Fatalf("expected dropped record count, got %+v", status.DroppedRecords)
+	}
+}
+
+func TestSourceCoverageStatusDoesNotOverrideHealthyWhenRecovered(t *testing.T) {
+	now := time.Date(2026, time.August, 7, 12, 0, 0, 0, time.UTC)
+	coverage := SourceCoverage{
+		SourceID: "otel-runtime", DeploymentID: "observability/otelcol-contrib",
+		State: SourceCoverageHealthy, RecoveredAt: &now,
+	}
+
+	status := coverage.Merge(SourceStatus{SourceID: "otel-runtime", Status: "healthy", Reliability: "best_effort"})
+	if status.Status != "healthy" || status.Reason != "" || status.DroppedRecords != nil {
+		t.Fatalf("expected healthy source status, got %+v", status)
+	}
+}

--- a/bkn-trace/agent-observability/src/drivenadapter/dbaccess/mariadb/sessionstore/schema.go
+++ b/bkn-trace/agent-observability/src/drivenadapter/dbaccess/mariadb/sessionstore/schema.go
@@ -1,5 +1,8 @@
 package sessionstore
 
-import v013 "github.com/openbkn-ai/bkn-foundry/bkn-trace/agent-observability/migrations/mariadb/v013"
+import (
+	v013 "github.com/openbkn-ai/bkn-foundry/bkn-trace/agent-observability/migrations/mariadb/v013"
+	v014 "github.com/openbkn-ai/bkn-foundry/bkn-trace/agent-observability/migrations/mariadb/v014"
+)
 
-func SchemaSQL() string { return v013.SchemaSQL() }
+func SchemaSQL() string { return v013.SchemaSQL() + "\n" + v014.SchemaSQL() }

--- a/bkn-trace/agent-observability/src/drivenadapter/dbaccess/mariadb/sessionstore/schema_test.go
+++ b/bkn-trace/agent-observability/src/drivenadapter/dbaccess/mariadb/sessionstore/schema_test.go
@@ -31,6 +31,9 @@ func TestSchemaFreezesLifecycleAndDurableEvidenceConstraints(t *testing.T) {
 		"bkn_trace_projection_checkpoints",
 		"bkn_trace_dlq",
 		"bkn_trace_dlq_replay_audit",
+		"bkn_trace_log_source_coverage",
+		"PRIMARY KEY (source_id, deployment_id)",
+		"dropped_records BIGINT UNSIGNED NOT NULL DEFAULT 0",
 	}
 	for _, fragment := range required {
 		if !strings.Contains(schema, fragment) {

--- a/bkn-trace/agent-observability/src/drivenadapter/dbaccess/mariadb/sessionstore/source_coverage.go
+++ b/bkn-trace/agent-observability/src/drivenadapter/dbaccess/mariadb/sessionstore/source_coverage.go
@@ -1,0 +1,115 @@
+package sessionstore
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/openbkn-ai/bkn-foundry/bkn-trace/agent-observability/src/domain/valueobject/observabilityvo"
+)
+
+var ErrSourceCoverageVersionConflict = errors.New("source coverage version conflict")
+
+func (s *Store) Get(ctx context.Context, sourceID, deploymentID string) (observabilityvo.SourceCoverage, bool, error) {
+	row := s.db.QueryRowContext(ctx, `
+		SELECT source_id, deployment_id, coverage_state, reason, dropped_records,
+		       first_observed_at, last_observed_at, recovered_at, row_version
+		FROM bkn_trace_log_source_coverage
+		WHERE source_id=? AND deployment_id=?`, sourceID, deploymentID)
+	coverage, err := scanSourceCoverage(row)
+	if errors.Is(err, sql.ErrNoRows) {
+		return observabilityvo.SourceCoverage{}, false, nil
+	}
+	if err != nil {
+		return observabilityvo.SourceCoverage{}, false, err
+	}
+	return coverage, true, nil
+}
+
+func (s *Store) UpsertDegraded(ctx context.Context, coverage observabilityvo.SourceCoverage) error {
+	if coverage.SourceID == "" || coverage.DeploymentID == "" {
+		return errors.New("source coverage source_id and deployment_id are required")
+	}
+	if coverage.State != observabilityvo.SourceCoverageDegraded || coverage.Reason != "telemetry_dropped" {
+		return errors.New("source coverage degradation must be telemetry_dropped")
+	}
+	if coverage.DroppedRecords <= 0 {
+		return errors.New("source coverage dropped_records must be positive")
+	}
+	if coverage.FirstObservedAt.IsZero() {
+		coverage.FirstObservedAt = time.Now().UTC()
+	}
+	if coverage.LastObservedAt.IsZero() {
+		coverage.LastObservedAt = coverage.FirstObservedAt
+	}
+	_, err := s.db.ExecContext(ctx, `
+		INSERT INTO bkn_trace_log_source_coverage (
+			source_id, deployment_id, coverage_state, reason, dropped_records,
+			first_observed_at, last_observed_at, recovered_at, row_version, updated_at
+		) VALUES (?, ?, ?, ?, ?, ?, ?, NULL, 1, UTC_TIMESTAMP(6))
+		ON DUPLICATE KEY UPDATE
+			coverage_state=VALUES(coverage_state),
+			reason=VALUES(reason),
+			dropped_records=GREATEST(dropped_records, VALUES(dropped_records)),
+			first_observed_at=IF(coverage_state='healthy' OR first_observed_at IS NULL, VALUES(first_observed_at), first_observed_at),
+			last_observed_at=GREATEST(COALESCE(last_observed_at, VALUES(last_observed_at)), VALUES(last_observed_at)),
+			recovered_at=NULL,
+			row_version=row_version+1,
+			updated_at=UTC_TIMESTAMP(6)`,
+		coverage.SourceID, coverage.DeploymentID, coverage.State, coverage.Reason, coverage.DroppedRecords,
+		coverage.FirstObservedAt.UTC(), coverage.LastObservedAt.UTC(),
+	)
+	if err != nil {
+		return fmt.Errorf("upsert source coverage: %w", err)
+	}
+	return nil
+}
+
+func (s *Store) MarkHealthyAfterCatchUp(ctx context.Context, sourceID, deploymentID string, version uint64) error {
+	result, err := s.db.ExecContext(ctx, `
+		UPDATE bkn_trace_log_source_coverage
+		SET coverage_state=?, reason='', recovered_at=UTC_TIMESTAMP(6),
+		    row_version=row_version+1, updated_at=UTC_TIMESTAMP(6)
+		WHERE source_id=? AND deployment_id=? AND row_version=?`,
+		observabilityvo.SourceCoverageHealthy, sourceID, deploymentID, version,
+	)
+	if err != nil {
+		return fmt.Errorf("recover source coverage: %w", err)
+	}
+	updated, err := result.RowsAffected()
+	if err != nil {
+		return fmt.Errorf("inspect source coverage recovery: %w", err)
+	}
+	if updated != 1 {
+		return ErrSourceCoverageVersionConflict
+	}
+	return nil
+}
+
+type sourceCoverageRow interface {
+	Scan(dest ...any) error
+}
+
+func scanSourceCoverage(row sourceCoverageRow) (observabilityvo.SourceCoverage, error) {
+	var coverage observabilityvo.SourceCoverage
+	var firstObservedAt, lastObservedAt, recoveredAt sql.NullTime
+	if err := row.Scan(
+		&coverage.SourceID, &coverage.DeploymentID, &coverage.State, &coverage.Reason, &coverage.DroppedRecords,
+		&firstObservedAt, &lastObservedAt, &recoveredAt, &coverage.Version,
+	); err != nil {
+		return observabilityvo.SourceCoverage{}, err
+	}
+	if firstObservedAt.Valid {
+		coverage.FirstObservedAt = firstObservedAt.Time.UTC()
+	}
+	if lastObservedAt.Valid {
+		coverage.LastObservedAt = lastObservedAt.Time.UTC()
+	}
+	if recoveredAt.Valid {
+		value := recoveredAt.Time.UTC()
+		coverage.RecoveredAt = &value
+	}
+	return coverage, nil
+}

--- a/bkn-trace/agent-observability/src/drivenadapter/dbaccess/mariadb/sessionstore/store_integration_test.go
+++ b/bkn-trace/agent-observability/src/drivenadapter/dbaccess/mariadb/sessionstore/store_integration_test.go
@@ -21,12 +21,49 @@ import (
 	"github.com/openbkn-ai/bkn-foundry/bkn-trace/agent-observability/src/domain/service/projectionrebuildsvc"
 	"github.com/openbkn-ai/bkn-foundry/bkn-trace/agent-observability/src/domain/service/sessionsvc"
 	"github.com/openbkn-ai/bkn-foundry/bkn-trace/agent-observability/src/domain/valueobject/ledgervo"
+	"github.com/openbkn-ai/bkn-foundry/bkn-trace/agent-observability/src/domain/valueobject/observabilityvo"
 	"github.com/openbkn-ai/bkn-foundry/bkn-trace/agent-observability/src/domain/valueobject/sessionvo"
 	"github.com/openbkn-ai/bkn-foundry/bkn-trace/agent-observability/src/drivenadapter/dbaccess/mariadb/sessionstore"
 	"github.com/openbkn-ai/bkn-foundry/bkn-trace/agent-observability/src/drivenadapter/httpaccess/opensearchprojection"
 	"github.com/openbkn-ai/bkn-foundry/bkn-trace/agent-observability/src/infra/opensearch"
 	"github.com/openbkn-ai/bkn-foundry/bkn-trace/agent-observability/src/port/driven/iprojectionoutbox"
 )
+
+func TestSourceCoverageSurvivesStoreRestart(t *testing.T) {
+	dsn := os.Getenv("BKN_TRACE_TEST_MARIADB_DSN")
+	if dsn == "" {
+		t.Skip("BKN_TRACE_TEST_MARIADB_DSN is not set")
+	}
+	db, err := sql.Open("mysql", dsn)
+	if err != nil {
+		t.Fatalf("open MariaDB: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	store := sessionstore.New(db)
+	if err := store.Migrate(context.Background()); err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+	coverage := observabilityvo.SourceCoverage{
+		SourceID: "otel-runtime-test", DeploymentID: "cluster-test",
+		State: observabilityvo.SourceCoverageDegraded, Reason: "telemetry_dropped",
+		DroppedRecords: 3, FirstObservedAt: time.Now().UTC(), LastObservedAt: time.Now().UTC(),
+	}
+	if err := store.UpsertDegraded(context.Background(), coverage); err != nil {
+		t.Fatalf("upsert coverage: %v", err)
+	}
+	restarted := sessionstore.New(db)
+	stored, found, err := restarted.Get(context.Background(), coverage.SourceID, coverage.DeploymentID)
+	if err != nil || !found || stored.State != observabilityvo.SourceCoverageDegraded || stored.DroppedRecords != 3 {
+		t.Fatalf("coverage was not durable after restart: coverage=%+v found=%t err=%v", stored, found, err)
+	}
+	if err := restarted.MarkHealthyAfterCatchUp(context.Background(), coverage.SourceID, coverage.DeploymentID, stored.Version); err != nil {
+		t.Fatalf("recover coverage: %v", err)
+	}
+	recovered, found, err := restarted.Get(context.Background(), coverage.SourceID, coverage.DeploymentID)
+	if err != nil || !found || recovered.State != observabilityvo.SourceCoverageHealthy || recovered.RecoveredAt == nil || recovered.DroppedRecords != 3 {
+		t.Fatalf("coverage recovery lost audit state: coverage=%+v found=%t err=%v", recovered, found, err)
+	}
+}
 
 func TestConcurrentEnsureCurrentHasOneGeneration(t *testing.T) {
 	dsn := os.Getenv("BKN_TRACE_TEST_MARIADB_DSN")

--- a/bkn-trace/agent-observability/src/drivenadapter/httpaccess/otelcolmetrics/client.go
+++ b/bkn-trace/agent-observability/src/drivenadapter/httpaccess/otelcolmetrics/client.go
@@ -1,0 +1,95 @@
+package otelcolmetrics
+
+import (
+	"bufio"
+	"context"
+	"fmt"
+	"net/http"
+	"strconv"
+	"strings"
+
+	"github.com/openbkn-ai/bkn-foundry/bkn-trace/agent-observability/src/domain/service/sourcecoveragesvc"
+)
+
+const (
+	refusedLogsMetric   = "otelcol_receiver_refused_log_records_total"
+	failedLogsMetric    = "otelcol_exporter_send_failed_log_records_total"
+	queueSizeMetric     = "otelcol_exporter_queue_size"
+	queueCapacityMetric = "otelcol_exporter_queue_capacity"
+)
+
+type Client struct {
+	endpoint   string
+	httpClient *http.Client
+}
+
+func New(endpoint string, httpClient *http.Client) *Client {
+	if httpClient == nil {
+		httpClient = http.DefaultClient
+	}
+	return &Client{endpoint: strings.TrimRight(endpoint, "/"), httpClient: httpClient}
+}
+
+func (client *Client) Read(ctx context.Context) (sourcecoveragesvc.Snapshot, error) {
+	request, err := http.NewRequestWithContext(ctx, http.MethodGet, client.endpoint, nil)
+	if err != nil {
+		return sourcecoveragesvc.Snapshot{}, fmt.Errorf("build collector metrics request: %w", err)
+	}
+	response, err := client.httpClient.Do(request)
+	if err != nil {
+		return sourcecoveragesvc.Snapshot{}, fmt.Errorf("request collector metrics: %w", err)
+	}
+	defer func() { _ = response.Body.Close() }()
+	if response.StatusCode != http.StatusOK {
+		return sourcecoveragesvc.Snapshot{}, fmt.Errorf("collector metrics returned status %d", response.StatusCode)
+	}
+	values, err := readMetrics(response.Body)
+	if err != nil {
+		return sourcecoveragesvc.Snapshot{}, err
+	}
+	return sourcecoveragesvc.Snapshot{
+		RefusedLogs: values[refusedLogsMetric], FailedLogs: values[failedLogsMetric],
+		QueueSize: values[queueSizeMetric], QueueCapacity: values[queueCapacityMetric],
+	}, nil
+}
+
+func readMetrics(body interface{ Read([]byte) (int, error) }) (map[string]int64, error) {
+	values := map[string]int64{}
+	scanner := bufio.NewScanner(body)
+	scanner.Buffer(make([]byte, 64*1024), 1024*1024)
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+		fields := strings.Fields(line)
+		if len(fields) < 2 {
+			continue
+		}
+		name := fields[0]
+		if label := strings.IndexByte(name, '{'); label >= 0 {
+			name = name[:label]
+		}
+		if !isCoverageMetric(name) {
+			continue
+		}
+		value, err := strconv.ParseFloat(fields[1], 64)
+		if err != nil || value < 0 {
+			continue
+		}
+		values[name] += int64(value)
+	}
+	if err := scanner.Err(); err != nil {
+		return nil, fmt.Errorf("read collector metrics: %w", err)
+	}
+	return values, nil
+}
+
+func isCoverageMetric(name string) bool {
+	switch name {
+	case refusedLogsMetric, failedLogsMetric, queueSizeMetric, queueCapacityMetric:
+		return true
+	default:
+		return false
+	}
+}

--- a/bkn-trace/agent-observability/src/drivenadapter/httpaccess/otelcolmetrics/client_test.go
+++ b/bkn-trace/agent-observability/src/drivenadapter/httpaccess/otelcolmetrics/client_test.go
@@ -1,0 +1,29 @@
+package otelcolmetrics
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestClientSumsCollectorLogCoverageMetrics(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`# TYPE otelcol_receiver_refused_log_records_total counter
+otelcol_receiver_refused_log_records_total{receiver="otlp"} 2
+otelcol_receiver_refused_log_records_total{receiver="http"} 1
+otelcol_exporter_send_failed_log_records_total{exporter="opensearch"} 4
+otelcol_exporter_queue_size{exporter="opensearch"} 6
+otelcol_exporter_queue_capacity{exporter="opensearch"} 512
+`))
+	}))
+	defer server.Close()
+
+	snapshot, err := New(server.URL, server.Client()).Read(context.Background())
+	if err != nil {
+		t.Fatalf("read metrics: %v", err)
+	}
+	if snapshot.RefusedLogs != 3 || snapshot.FailedLogs != 4 || snapshot.QueueSize != 6 || snapshot.QueueCapacity != 512 {
+		t.Fatalf("unexpected snapshot: %+v", snapshot)
+	}
+}

--- a/bkn-trace/agent-observability/src/port/driven/isourcecoveragestore/port.go
+++ b/bkn-trace/agent-observability/src/port/driven/isourcecoveragestore/port.go
@@ -1,0 +1,14 @@
+package isourcecoveragestore
+
+import (
+	"context"
+
+	"github.com/openbkn-ai/bkn-foundry/bkn-trace/agent-observability/src/domain/valueobject/observabilityvo"
+)
+
+// Store owns durable collection-coverage facts, separate from log payload storage.
+type Store interface {
+	Get(ctx context.Context, sourceID, deploymentID string) (observabilityvo.SourceCoverage, bool, error)
+	UpsertDegraded(ctx context.Context, coverage observabilityvo.SourceCoverage) error
+	MarkHealthyAfterCatchUp(ctx context.Context, sourceID, deploymentID string, version uint64) error
+}


### PR DESCRIPTION
## Summary
- persist Collector log-loss coverage by source and deployment in the BKN Trace MariaDB Core
- monitor the Collector metrics endpoint outside the Log Query request path
- disclose degraded coverage as partial results instead of overwriting it to healthy after OpenSearch succeeds
- keep monitoring disabled unless a persistent Core store and internal endpoint are configured

## Related
- #547
- #545
- docs: openbkn-ai/bkn-docs#53

## Verification
- Complete Go suite passed in bkn-trace/agent-observability: go test ./...
- Helm rendered with monitoring disabled and enabled configuration
- MariaDB integration test compiles under the integration build tag; execution requires BKN_TRACE_TEST_MARIADB_DSN

## Remaining release validation
- Local fault injection: force exporter failure or queue overflow, then validate degraded disclosure, Collector restart persistence, and two-sample recovery.