### PR TITLE
fix(otelcol): roll out config changes

### DIFF
--- a/.github/workflows/release-bkn-trace-otelcol.yml
+++ b/.github/workflows/release-bkn-trace-otelcol.yml
@@ -31,8 +31,22 @@ jobs:
       service-path: bkn-trace/otelcol-contribute-chart
       stack: chart-only
 
-  chart:
+  chart-regression:
     needs: test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: azure/setup-helm@v4
+
+      - name: Verify Collector chart regressions
+        working-directory: bkn-trace/otelcol-contribute-chart
+        run: |
+          ./scripts/test_4c8g_baseline.sh
+          ./scripts/test_config_rollout.sh
+
+  chart:
+    needs: chart-regression
     uses: ./.github/workflows/reusable-chart.yml
     with:
       service-path: bkn-trace/otelcol-contribute-chart

--- a/.github/workflows/release-bkn-trace-otelcol.yml
+++ b/.github/workflows/release-bkn-trace-otelcol.yml
@@ -46,7 +46,7 @@ jobs:
           ./scripts/test_config_rollout.sh
 
   chart:
-    needs: chart-regression
+    needs: [test, chart-regression]
     uses: ./.github/workflows/reusable-chart.yml
     with:
       service-path: bkn-trace/otelcol-contribute-chart

--- a/bkn-trace/otelcol-contribute-chart/charts/otelcol-contrib/templates/deployment.yaml
+++ b/bkn-trace/otelcol-contribute-chart/charts/otelcol-contrib/templates/deployment.yaml
@@ -20,10 +20,11 @@ spec:
         {{- with .Values.podLabels }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
-      {{- with .Values.podAnnotations }}
       annotations:
+        checksum/collector-config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+        {{- with .Values.podAnnotations }}
         {{- toYaml . | nindent 8 }}
-      {{- end }}
+        {{- end }}
     spec:
       serviceAccountName: {{ include "otelcol-contrib.serviceAccountName" . }}
       containers:

--- a/bkn-trace/otelcol-contribute-chart/scripts/test_config_rollout.sh
+++ b/bkn-trace/otelcol-contribute-chart/scripts/test_config_rollout.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+chart_dir="${1:-charts/otelcol-contrib}"
+
+checksum() {
+  helm template otelcol-contrib "${chart_dir}" "$@" |
+    awk '/checksum\/collector-config:/ { print $2; exit }'
+}
+
+baseline="$(checksum)"
+changed_exporter="$(checksum --set opensearchExporter.http.endpoint=http://example.invalid:9200)"
+unchanged="$(checksum)"
+
+if [[ -z "${baseline}" ]]; then
+  echo "collector config checksum was not rendered" >&2
+  exit 1
+fi
+
+if [[ "${baseline}" == "${changed_exporter}" ]]; then
+  echo "collector config checksum did not change after exporter configuration changed" >&2
+  exit 1
+fi
+
+if [[ "${baseline}" != "${unchanged}" ]]; then
+  echo "collector config checksum changed without a configuration change" >&2
+  exit 1
+fi
+
+echo "collector config rollout checksum verified"


### PR DESCRIPTION
## What Changed

- [x] Add a deterministic checksum of rendered `collector-config.yaml` to the Collector Deployment pod template.
- [x] Add chart regression coverage for stable and changed configuration checksums.
- [x] Run the Collector chart regressions from its release workflow.

---

## Why

- Related Issue: Closes #717
- Background: Helm upgrades previously changed the ConfigMap without rolling the running Collector Pod, leaving the old in-memory configuration active.

---

## How

- The Deployment annotation hashes the existing rendered ConfigMap template, so only an effective collector configuration change changes the Pod template.
- No API, data model, or default capacity configuration changes.

---

## Testing

- [x] Helm lint passed locally.
- [x] `test_4c8g_baseline.sh` passed locally.
- [x] `test_config_rollout.sh` passed locally.
- [x] Local Kind verification: changing `batch.timeout` changed the checksum and created a new Collector ReplicaSet; restoring `1s` created the expected replacement ReplicaSet.

---

## Risk & Rollback

- Potential risks: any effective Collector configuration upgrade now deliberately restarts its single local replica.
- Rollback plan: revert this commit; Helm returns to the prior no-automatic-reload behavior.

---

## Additional Notes

- This fixes the deployment gap discovered during BKN Trace GWT-068 validation.