### PR TITLE
fix(trace): keep conversation summaries coherent

### DIFF
--- a/bkn-trace/agent-observability/src/domain/service/evidencesvc/summary.go
+++ b/bkn-trace/agent-observability/src/domain/service/evidencesvc/summary.go
@@ -197,17 +197,46 @@ func (s *Service) ListInteractions(ctx context.Context, options evidencevo.Summa
 
 func buildConversationSummary(conversationID string, requests []evidencevo.RequestSummary) evidencevo.ConversationSummary {
 	base, interactionCount := aggregateRequestGroup(requests)
+	questionPreview, resultPreview := latestConversationInteractionPreview(requests)
 	return evidencevo.ConversationSummary{
 		ConversationID: conversationID,
 		StartedAt:      base.StartedAt, CompletedAt: base.CompletedAt,
 		Initiator: base.Initiator, AgentOrApp: base.AgentOrApp, BusinessDomain: base.BusinessDomain,
 		AgentName: base.AgentName, ApplicationPrincipalID: base.ApplicationPrincipalID,
 		EffectiveSubjectID: base.EffectiveSubjectID,
-		KnowledgeNetworks:  base.KnowledgeNetworks, QuestionPreview: base.QuestionPreview, ResultPreview: base.ResultPreview,
+		KnowledgeNetworks:  base.KnowledgeNetworks, QuestionPreview: questionPreview, ResultPreview: resultPreview,
 		Status: base.Status, EvidenceCompleteness: base.EvidenceCompleteness, PartialReasons: base.PartialReasons,
 		InteractionCount: interactionCount, RequestCount: len(requests), TraceCount: base.TraceCount,
-		DurationMS: conversationDurationMS(requests), ErrorSummary: base.ErrorSummary,
+		DurationMS: conversationDurationMS(requests),
 	}
+}
+
+// A conversation is a sequence of interactions. Its list preview must describe
+// one interaction, rather than combining an earlier question with a later result.
+func latestConversationInteractionPreview(requests []evidencevo.RequestSummary) (string, string) {
+	byInteraction := map[string][]evidencevo.RequestSummary{}
+	for _, request := range requests {
+		if request.InteractionID != "" {
+			byInteraction[request.InteractionID] = append(byInteraction[request.InteractionID], request)
+		}
+	}
+
+	var question, result, latestAt, latestID string
+	for interactionID, interactionRequests := range byInteraction {
+		summary, _ := aggregateRequestGroup(interactionRequests)
+		if summary.QuestionPreview == "" || summary.ResultPreview == "" {
+			continue
+		}
+		at := firstPresentSummary(summary.CompletedAt, summary.StartedAt)
+		if question == "" || summaryTimeAfter(at, latestAt) || (at == latestAt && interactionID > latestID) {
+			question, result, latestAt, latestID = summary.QuestionPreview, summary.ResultPreview, at, interactionID
+		}
+	}
+	if question != "" {
+		return question, result
+	}
+	base, _ := aggregateRequestGroup(requests)
+	return base.QuestionPreview, base.ResultPreview
 }
 
 func buildInteractionListSummary(interactionID string, requests []evidencevo.RequestSummary) evidencevo.InteractionListSummary {

--- a/bkn-trace/agent-observability/src/domain/service/evidencesvc/summary_service_test.go
+++ b/bkn-trace/agent-observability/src/domain/service/evidencesvc/summary_service_test.go
@@ -131,6 +131,37 @@ func TestListConversationsSumsCompletedInteractionDurations(t *testing.T) {
 	}
 }
 
+func TestBuildConversationSummaryUsesLatestCoherentInteractionAndHidesChildCallError(t *testing.T) {
+
+	summary := buildConversationSummary("conversation_supply", []evidencevo.RequestSummary{
+		{
+			RequestID: "req_first", InteractionID: "interaction_first",
+			StartedAt: "2026-08-07T08:00:00Z", CompletedAt: "2026-08-07T08:00:01Z",
+			Status: "completed", EvidenceCompleteness: "complete",
+			InteractionQuestion: "6月份有哪些需求预测单？", InteractionResult: "6月份需求总量为 11594。",
+		},
+		{
+			RequestID: "req_rejected", InteractionID: "interaction_latest",
+			StartedAt: "2026-08-07T08:02:00Z", CompletedAt: "2026-08-07T08:02:01Z",
+			Status: "error", EvidenceCompleteness: "complete", ErrorSummary: "OpenBKN operation failed",
+		},
+		{
+			RequestID: "req_latest", InteractionID: "interaction_latest",
+			StartedAt: "2026-08-07T08:02:02Z", CompletedAt: "2026-08-07T08:02:03Z",
+			Status: "completed", EvidenceCompleteness: "complete",
+			InteractionQuestion: "迄今为止有多少销售订单？", InteractionResult: "共有 1441 张销售订单。",
+		},
+	})
+
+	if summary.QuestionPreview != "迄今为止有多少销售订单？" ||
+		summary.ResultPreview != "共有 1441 张销售订单。" {
+		t.Fatalf("conversation must show one coherent latest interaction: %+v", summary)
+	}
+	if summary.ErrorSummary != "" {
+		t.Fatalf("a recoverable child call error must remain at request level: %+v", summary)
+	}
+}
+
 func TestListConversationsFiltersAfterApplyingCanonicalSessionStatus(t *testing.T) {
 	evidenceStore := evidencestore.New()
 	seedBusinessProvenanceRequest(


### PR DESCRIPTION
## What Changed

- [x] Use a conversation-specific preview policy: the displayed question and result now come from the same latest completed interaction.
- [x] Keep child OpenBKN operation errors at the request/operation layer instead of promoting them into a conversation summary.
- [x] Add a three-turn regression test with a rejected child operation followed by a completed interaction.
- [ ] Docs/doc 1: not needed; no external contract or product behaviour expansion.

---

## Why

- Related Issue: Closes #720
- Background: the multi-turn read model combined an earliest question, a latest result, and a historical child-operation error, which was misleading in Business Provenance.

---

## How

- Group request summaries by interaction when deriving the conversation preview.
- Select the latest interaction that has both a readable question and result, with a deterministic ID tie-breaker.
- Preserve timing, cardinality, evidence completeness, and lower-level drill-down data.
- Breaking changes: none.

---

## Testing

- [x] Unit tests passed locally
- [x] Integration tests passed locally (`go test ./...` for `agent-observability`)
- [ ] Verified in test environment: pending merge and local image deployment.

Test notes:

- Regression test first reproduced the incoherent `first question + latest result + child error` summary, then passed after the minimal fix.

---

## Risk & Rollback

- Potential risks: conversations without a complete interaction retain the existing request-derived fallback preview.
- Rollback plan: revert commit `2ddee892`.

---

## Additional Notes

- SDK E2E evidence recorded in [#545](https://github.com/openbkn-ai/bkn-foundry/issues/545#issuecomment-5212502557).
- This PR intentionally adds no lifecycle state, endpoint, schema, or historical-data migration.