### PR TITLE
fix(context-loader): make field search capabilities visible in the schema surface

### DIFF
--- a/adp/context-loader/agent-retrieval/server/driveradapters/mcp/schemas/search_schema.json
+++ b/adp/context-loader/agent-retrieval/server/driveradapters/mcp/schemas/search_schema.json
@@ -4,7 +4,10 @@
     "properties": {
       "response_format": {
         "type": "string",
-        "enum": ["json", "toon"],
+        "enum": [
+          "json",
+          "toon"
+        ],
         "default": "toon",
         "description": "文本格式：json 或 toon，默认 toon"
       },
@@ -58,7 +61,7 @@
       "schema_brief": {
         "type": "boolean",
         "default": true,
-        "description": "是否返回精简 Schema（MCP 默认 true）。精简版保留写查询所需的 data_source.id 与属性 name/type/condition_operations，省去属性 comment、tags、primary_keys，体积约省 70%。需要属性备注 / 主键 / 标签等完整信息时显式传 false。"
+        "description": "是否返回精简 Schema（MCP 默认 true）。精简版保留写查询所需的 data_source.id 与属性 name/type，省去属性 comment、主键、标签，体积约省 70%。注意 condition_operations 在两种模式下语义不同：精简版只列**索引带来的**算子（match / multi_match / knn，取决于该字段建没建全文/向量索引，从属性类型推不出来），没有这类能力的字段整个字段不出现；比较算子（==、in、like、range 等）按属性 type 自行判断。需要完整算子清单、属性备注、主键或标签时显式传 false。"
       },
       "enable_rerank": {
         "type": "boolean",
@@ -71,7 +74,10 @@
         "description": "是否在每个对象类的 data_property 上额外返回物理列名 column（取自 mapped_field）。写 run_sql 时列名要用 column（物理列），而非 name（逻辑名）——二者可不同，且同一资源可被多个对象类用不同逻辑名映射。默认 false 以保持响应精简，准备写 SQL 时再开启。"
       }
     },
-    "required": ["kn_id", "query"]
+    "required": [
+      "kn_id",
+      "query"
+    ]
   },
   "output_schema": {
     "type": "object",

--- a/adp/context-loader/agent-retrieval/server/driveradapters/mcp/schemas/tools_meta.json
+++ b/adp/context-loader/agent-retrieval/server/driveradapters/mcp/schemas/tools_meta.json
@@ -21,7 +21,7 @@
     "group": "discovery",
     "group_title": "网络与 Schema",
     "order": 130,
-    "description": "统一的 Schema 探索入口，先锁定对象类（object_types）。根据 query 返回相关 object_types、relation_types、action_types、metric_types，供 query_*、find_*、get_* 工具继续消费；其中 metric_types 只是辅助线索，指标的权威清单以 get_object_types 返回的 related_metrics 为准（按对象类 scope 全量枚举）。默认返回精简 Schema（schema_brief=true：保留 data_source.id 与属性 name/type/condition_operations，省约 70%），够规划查询；需要属性备注/主键/标签的完整 Schema 时传 schema_brief=false。"
+    "description": "统一的 Schema 探索入口，先锁定对象类（object_types）。根据 query 返回相关 object_types、relation_types、action_types、metric_types，供 query_*、find_*、get_* 工具继续消费；其中 metric_types 只是辅助线索，指标的权威清单以 get_object_types 返回的 related_metrics 为准（按对象类 scope 全量枚举）。默认返回精简 Schema（schema_brief=true：保留 data_source.id 与属性 name/type，并只列索引带来的算子 match/multi_match/knn，省约 70%），够规划查询；需要属性备注/主键/标签的完整 Schema 时传 schema_brief=false。"
   },
   "query_object_instance": {
     "name": "query_object_instance",

--- a/adp/context-loader/agent-retrieval/server/driveradapters/mcp/tools.go
+++ b/adp/context-loader/agent-retrieval/server/driveradapters/mcp/tools.go
@@ -538,11 +538,15 @@ func handleGetObjectTypes(bkn interfaces.BknBackendAccess, metrics knmetrics.KnM
 			return mcp.NewToolResultError("ids is required (object type ids from get_kn_detail)"), nil
 		}
 
-		detail, err := bkn.GetKnowledgeNetworkDetail(ctx, knID)
+		// 走按 id 取详情的端点，而不是知识网络导出视图：导出视图只列对象类，不做数据源
+		// 富化，属性上的 condition_operations 一律为空——调用方据此判断字段能不能做
+		// match / knn，拿到空的就只能靠猜。id 由调用方显式给出，规模有界，富化的代价
+		// 与之成正比。
+		matched, err := bkn.GetObjectTypeDetail(ctx, knID, args.IDs, true)
 		if err != nil {
 			return mcp.NewToolResultError(err.Error()), nil
 		}
-		matched, missing := detail.FilterObjectTypes(args.IDs)
+		missing := missingObjectTypeIDs(args.IDs, matched)
 		// Step 2 of the OT-first metric path: a metric that is not bound to a logic
 		// property is unreachable from the object type without this.
 		metrics.AttachRelatedMetrics(ctx, knID, matched)
@@ -700,4 +704,22 @@ func handleQueryMetric(service knmetrics.KnMetricsService) func(ctx context.Cont
 		}
 		return result, nil
 	}
+}
+
+// missingObjectTypeIDs 返回请求了但没取到的对象类 id，保持与导出视图过滤时一致的语义。
+func missingObjectTypeIDs(requested []string, matched []*interfaces.ObjectType) []string {
+	found := make(map[string]struct{}, len(matched))
+	for _, ot := range matched {
+		if ot != nil {
+			found[ot.ID] = struct{}{}
+		}
+	}
+
+	var missing []string
+	for _, id := range requested {
+		if _, ok := found[id]; !ok {
+			missing = append(missing, id)
+		}
+	}
+	return missing
 }

--- a/adp/context-loader/agent-retrieval/server/driveradapters/mcp/tools.go
+++ b/adp/context-loader/agent-retrieval/server/driveradapters/mcp/tools.go
@@ -41,6 +41,8 @@ func handleSearchSchema(knSearchService knsearch.KnSearchService) func(ctx conte
 		}
 
 		schemaReq := buildSearchSchemaReqFromMCP(req, authCtx)
+		// MCP 面只发不可推导的算子，比较算子由属性 type 决定。
+		schemaReq.IndexOpsOnly = true
 
 		resp, err := knSearchService.SearchSchema(ctx, schemaReq)
 		if err != nil {
@@ -555,6 +557,10 @@ func handleGetObjectTypes(bkn interfaces.BknBackendAccess, metrics knmetrics.KnM
 		} else {
 			missing = missingObjectTypeIDs(args.IDs, matched)
 		}
+		// 与 search_schema 同一条规则：只发不可推导的算子。比较算子（==/in/like/range…）
+		// 由属性 type 决定，每个属性重复一遍十来个是纯噪音——对象类少也照样占上下文。
+		trimObjectTypesToIndexBackedOps(matched)
+
 		// Step 2 of the OT-first metric path: a metric that is not bound to a logic
 		// property is unreachable from the object type without this.
 		metrics.AttachRelatedMetrics(ctx, knID, matched)
@@ -730,4 +736,35 @@ func missingObjectTypeIDs(requested []string, matched []*interfaces.ObjectType) 
 		}
 	}
 	return missing
+}
+
+// trimObjectTypesToIndexBackedOps 把算子收敛到索引带来的那几个。
+//
+// 规则与 search_schema 一致：condition_operations 只登记从属性类型推不出来的能力
+// （match / multi_match / knn，取决于底层索引建没建）。比较算子按 type 判断，服务端
+// 逐个下发没有信息量。这只影响 MCP 面；Studio 直接对接 BKN，拿到的仍是全量。
+func trimObjectTypesToIndexBackedOps(objectTypes []*interfaces.ObjectType) {
+	for _, ot := range objectTypes {
+		if ot == nil {
+			continue
+		}
+		for _, p := range ot.DataProperties {
+			if p == nil {
+				continue
+			}
+			p.ConditionOperations = indexBackedConditionOperations(p.ConditionOperations)
+		}
+	}
+}
+
+// indexBackedConditionOperations 只保留索引带来的算子。
+func indexBackedConditionOperations(ops []interfaces.KnOperationType) []interfaces.KnOperationType {
+	var out []interfaces.KnOperationType
+	for _, op := range ops {
+		switch op {
+		case interfaces.KnOperationTypeMatch, interfaces.KnOperationTypeMultiMatch, interfaces.KnOperationTypeKnn:
+			out = append(out, op)
+		}
+	}
+	return out
 }

--- a/adp/context-loader/agent-retrieval/server/driveradapters/mcp/tools.go
+++ b/adp/context-loader/agent-retrieval/server/driveradapters/mcp/tools.go
@@ -538,15 +538,23 @@ func handleGetObjectTypes(bkn interfaces.BknBackendAccess, metrics knmetrics.KnM
 			return mcp.NewToolResultError("ids is required (object type ids from get_kn_detail)"), nil
 		}
 
-		// 走按 id 取详情的端点，而不是知识网络导出视图：导出视图只列对象类，不做数据源
-		// 富化，属性上的 condition_operations 一律为空——调用方据此判断字段能不能做
-		// match / knn，拿到空的就只能靠猜。id 由调用方显式给出，规模有界，富化的代价
-		// 与之成正比。
+		// 优先走按 id 取详情的端点：导出视图只列对象类、不做数据源富化，属性上的
+		// condition_operations 一律为空，而调用方正是据此判断字段能不能做 match / knn。
+		//
+		// 但这个端点要求 id 全部命中，混进一个失效 id 就整批 404。此时退回导出视图：
+		// 宁可这一批少了算子，也不能因为一个失效 id 把其余有效的对象类一起丢掉——
+		// 导出视图还支持按名字回退匹配，那也是既有行为。
 		matched, err := bkn.GetObjectTypeDetail(ctx, knID, args.IDs, true)
-		if err != nil {
-			return mcp.NewToolResultError(err.Error()), nil
+		var missing []string
+		if err != nil || len(matched) < len(args.IDs) {
+			detail, detailErr := bkn.GetKnowledgeNetworkDetail(ctx, knID)
+			if detailErr != nil {
+				return mcp.NewToolResultError(detailErr.Error()), nil
+			}
+			matched, missing = detail.FilterObjectTypes(args.IDs)
+		} else {
+			missing = missingObjectTypeIDs(args.IDs, matched)
 		}
-		missing := missingObjectTypeIDs(args.IDs, matched)
 		// Step 2 of the OT-first metric path: a metric that is not bound to a logic
 		// property is unreachable from the object type without this.
 		metrics.AttachRelatedMetrics(ctx, knID, matched)

--- a/adp/context-loader/agent-retrieval/server/driveradapters/mcp/tools_metric_test.go
+++ b/adp/context-loader/agent-retrieval/server/driveradapters/mcp/tools_metric_test.go
@@ -6,8 +6,10 @@ package mcp
 
 import (
 	"context"
+	"fmt"
 	"testing"
 
+	mcpsdk "github.com/mark3labs/mcp-go/mcp"
 	"github.com/smartystreets/goconvey/convey"
 
 	"github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/interfaces"
@@ -28,6 +30,29 @@ func (s *stubMetricBknBackend) GetKnowledgeNetworkDetail(_ context.Context, _ st
 
 func (s *stubMetricBknBackend) ListMetricsByObjectTypes(_ context.Context, _ string, _ []string) ([]*interfaces.RelatedMetric, error) {
 	return s.metrics, nil
+}
+
+// GetObjectTypeDetail 按 id 返回详情，模拟 BKN 的富化端点：get_object_types 改走它
+// 之后，桩不实现就会空指针。
+func (s *stubMetricBknBackend) GetObjectTypeDetail(_ context.Context, _ string, ids []string, _ bool) ([]*interfaces.ObjectType, error) {
+	if s.detail == nil {
+		return nil, nil
+	}
+	wanted := make(map[string]struct{}, len(ids))
+	for _, id := range ids {
+		wanted[id] = struct{}{}
+	}
+
+	var matched []*interfaces.ObjectType
+	for _, ot := range s.detail.ObjectTypes {
+		if ot == nil {
+			continue
+		}
+		if _, ok := wanted[ot.ID]; ok {
+			matched = append(matched, ot)
+		}
+	}
+	return matched, nil
 }
 
 type stubMetricOntologyQuery struct {
@@ -105,4 +130,61 @@ func TestHandleQueryMetric(t *testing.T) {
 		convey.So(result.IsError, convey.ShouldBeTrue)
 		convey.So(oq.gotMetric, convey.ShouldBeEmpty)
 	})
+}
+
+// get_object_types 必须走按 id 取详情的富化端点：导出视图不带 condition_operations，
+// 调用方（Agent）据此判断字段能不能 match / knn，拿到空的就只能靠猜。
+func TestHandleGetObjectTypes_UsesEnrichedEndpoint(t *testing.T) {
+	convey.Convey("Test get_object_types reads the enriched detail endpoint", t, func() {
+		stub := &capsBknBackend{
+			ops: []interfaces.KnOperationType{
+				interfaces.KnOperationTypeEqual,
+				interfaces.KnOperationTypeMatch,
+				interfaces.KnOperationTypeKnn,
+			},
+		}
+
+		handler := handleGetObjectTypes(stub, knmetrics.NewKnMetricsServiceWith(nil, stub, nil))
+		req := mcpsdk.CallToolRequest{Params: mcpsdk.CallToolParams{
+			Arguments: map[string]any{
+				"kn_id": "kn1",
+				"ids":   []any{"stadiums"},
+			},
+		}}
+
+		result, err := handler(context.Background(), req)
+
+		convey.So(err, convey.ShouldBeNil)
+		convey.So(stub.detailCalls, convey.ShouldEqual, 1)
+		convey.So(stub.exportCalls, convey.ShouldEqual, 0)
+		convey.So(fmt.Sprintf("%v", result), convey.ShouldContainSubstring, "knn")
+	})
+}
+
+// capsBknBackend 只回一个带算子的对象类，并分别记录两条取数路径被调用的次数。
+type capsBknBackend struct {
+	interfaces.BknBackendAccess
+	ops         []interfaces.KnOperationType
+	detailCalls int
+	exportCalls int
+}
+
+func (s *capsBknBackend) GetObjectTypeDetail(_ context.Context, _ string, _ []string, _ bool) ([]*interfaces.ObjectType, error) {
+	s.detailCalls++
+	return []*interfaces.ObjectType{{
+		ID:   "stadiums",
+		Name: "球场",
+		DataProperties: []*interfaces.DataProperty{
+			{Name: "stadium_name", Type: "string", ConditionOperations: s.ops},
+		},
+	}}, nil
+}
+
+func (s *capsBknBackend) GetKnowledgeNetworkDetail(_ context.Context, _ string) (*interfaces.KnowledgeNetworkDetail, error) {
+	s.exportCalls++
+	return &interfaces.KnowledgeNetworkDetail{}, nil
+}
+
+func (s *capsBknBackend) ListMetricsByObjectTypes(_ context.Context, _ string, _ []string) ([]*interfaces.RelatedMetric, error) {
+	return nil, nil
 }

--- a/adp/context-loader/agent-retrieval/server/interfaces/driven_bkn_backend.go
+++ b/adp/context-loader/agent-retrieval/server/interfaces/driven_bkn_backend.go
@@ -33,6 +33,8 @@ const (
 	KnOperationTypeRegex          KnOperationType = "regex"     // regex
 	KnOperationTypeMatch          KnOperationType = "match"     // match
 	KnOperationTypeKnn            KnOperationType = "knn"       // knn
+	// KnOperationTypeMultiMatch 由 BKN 随 match 一起登记，代表字段建了全文索引。
+	KnOperationTypeMultiMatch KnOperationType = "multi_match"
 )
 
 // LogicPropertyType Logic property type

--- a/adp/context-loader/agent-retrieval/server/interfaces/drivenadapters.go
+++ b/adp/context-loader/agent-retrieval/server/interfaces/drivenadapters.go
@@ -288,6 +288,10 @@ type KnSearchReq struct {
 	EnableRerank    *bool                 `json:"enable_rerank,omitempty"`
 	RerankModel     *string               `json:"rerank_model,omitempty"` // 精排小模型名覆盖；空走部署级默认
 	IncludeColumns  *bool                 `json:"include_columns,omitempty"`
+	// IndexOpsOnly 让响应里的 condition_operations 只保留索引带来的算子。由 MCP 层设置，
+	// 不进请求契约：比较算子按属性 type 可推导，逐个下发对 Agent 是纯噪音；REST 调用方
+	// 与直连 BKN 的消费者（如 Studio）仍拿全量。
+	IndexOpsOnly bool `json:"-"`
 }
 
 // SetKnIDs Sets knIDs (internal use, converted from KnID)

--- a/adp/context-loader/agent-retrieval/server/interfaces/kn_search_local.go
+++ b/adp/context-loader/agent-retrieval/server/interfaces/kn_search_local.go
@@ -29,6 +29,8 @@ type KnSearchLocalRequest struct {
 	// IncludeColumns adds each data property's physical column name (mapped_field)
 	// to the response for run_sql. Off by default to keep responses compact.
 	IncludeColumns bool `json:"include_columns" default:"false"`
+	// IndexOpsOnly 见 SearchSchemaReq 同名字段。
+	IndexOpsOnly bool `json:"-"`
 }
 
 // KnSearchRetrievalConfig 召回配置参数

--- a/adp/context-loader/agent-retrieval/server/interfaces/search_schema.go
+++ b/adp/context-loader/agent-retrieval/server/interfaces/search_schema.go
@@ -27,6 +27,10 @@ type SearchSchemaReq struct {
 	// (mapped_field) to the response, for writing run_sql against the resource.
 	// Off by default to keep the response compact.
 	IncludeColumns *bool `json:"include_columns,omitempty" default:"false"`
+	// IndexOpsOnly 让响应里的 condition_operations 只保留索引带来的算子。由 MCP 层设置，
+	// 不进请求契约：比较算子按属性 type 可推导，逐个下发对 Agent 是纯噪音；而 REST
+	// 调用方（以及 Studio 这类直连 BKN 的消费者）仍拿全量。
+	IndexOpsOnly bool `json:"-"`
 }
 
 // SearchSchemaScope search_schema scope controls

--- a/adp/context-loader/agent-retrieval/server/logics/knsearch/condition_operations_backfill.go
+++ b/adp/context-loader/agent-retrieval/server/logics/knsearch/condition_operations_backfill.go
@@ -121,9 +121,9 @@ func conditionOperationsPresent(objType *interfaces.KnSearchObjectType) bool {
 // Schema 本就是为省体积而设。
 //
 // 只在出响应时做，不影响检索：实例召回靠算子挑可检索字段，提前裁掉会让只支持等值的
-// 字段整个消失——那是响应开关改了召回口径。
-func trimToIndexBackedOperations(objectTypes []*interfaces.KnSearchObjectType, brief bool) {
-	if !brief {
+// 字段整个消失。也只对 MCP 面生效，REST 调用方仍拿全量。
+func trimToIndexBackedOperations(objectTypes []*interfaces.KnSearchObjectType, indexOpsOnly bool) {
+	if !indexOpsOnly {
 		return
 	}
 	for _, objType := range objectTypes {

--- a/adp/context-loader/agent-retrieval/server/logics/knsearch/condition_operations_backfill.go
+++ b/adp/context-loader/agent-retrieval/server/logics/knsearch/condition_operations_backfill.go
@@ -24,12 +24,6 @@ import (
 // 被跳过，语义实例召回永远返回空。
 //
 // 只补真正缺算子的对象类，且合并成一次批量请求。
-//
-// indexOpsOnly 为真时只补索引带来的那几个算子（match / multi_match / knn），略去按
-// 属性类型就能推出来的比较算子。实测一次 10 个对象类、172 个属性的检索：补全量多
-// 10,453 字节（+27%），只补索引类多 151 字节（+0.4%），差 69 倍——多出来的几乎全是
-// 每个字符串属性重复一遍的 ==/in/like 之类，服务端逐个告知没有信息量。精简 Schema
-// 本就是为省体积而设，不该被这部分吃掉。
 func (s *localSearchImpl) backfillConditionOperations(
 	ctx context.Context,
 	knID string,
@@ -117,6 +111,32 @@ func conditionOperationsPresent(objType *interfaces.KnSearchObjectType) bool {
 		}
 	}
 	return false
+}
+
+// trimToIndexBackedOperations 出响应前把算子收敛到索引带来的那几个。
+//
+// 实测一次 10 个对象类、172 个属性的检索：全量算子多 10,453 字节（+27%），只留索引类
+// 多 151 字节（+0.4%），差 69 倍。多出来的几乎全是每个字符串属性重复一遍的
+// ==/in/like 之类，那些从属性 type 就能推出来，服务端逐个告知没有信息量；而精简
+// Schema 本就是为省体积而设。
+//
+// 只在出响应时做，不影响检索：实例召回靠算子挑可检索字段，提前裁掉会让只支持等值的
+// 字段整个消失——那是响应开关改了召回口径。
+func trimToIndexBackedOperations(objectTypes []*interfaces.KnSearchObjectType, brief bool) {
+	if !brief {
+		return
+	}
+	for _, objType := range objectTypes {
+		if objType == nil {
+			continue
+		}
+		for _, p := range objType.DataProperties {
+			if p == nil {
+				continue
+			}
+			p.ConditionOperations = indexBackedOperations(p.ConditionOperations)
+		}
+	}
 }
 
 // indexBackedOperations 挑出只有服务端才知道的那几个算子——它们取决于底层索引建没建，

--- a/adp/context-loader/agent-retrieval/server/logics/knsearch/condition_operations_backfill.go
+++ b/adp/context-loader/agent-retrieval/server/logics/knsearch/condition_operations_backfill.go
@@ -24,10 +24,17 @@ import (
 // 被跳过，语义实例召回永远返回空。
 //
 // 只补真正缺算子的对象类，且合并成一次批量请求。
+//
+// indexOpsOnly 为真时只补索引带来的那几个算子（match / multi_match / knn），略去按
+// 属性类型就能推出来的比较算子。实测一次 10 个对象类、172 个属性的检索：补全量多
+// 10,453 字节（+27%），只补索引类多 151 字节（+0.4%），差 69 倍——多出来的几乎全是
+// 每个字符串属性重复一遍的 ==/in/like 之类，服务端逐个告知没有信息量。精简 Schema
+// 本就是为省体积而设，不该被这部分吃掉。
 func (s *localSearchImpl) backfillConditionOperations(
 	ctx context.Context,
 	knID string,
 	objectTypes []*interfaces.KnSearchObjectType,
+	indexOpsOnly bool,
 ) {
 	if knID == "" || len(objectTypes) == 0 {
 		return
@@ -74,7 +81,14 @@ func (s *localSearchImpl) backfillConditionOperations(
 			if p == nil || len(p.ConditionOperations) == 0 {
 				continue
 			}
-			ops[p.Name] = p.ConditionOperations
+			selected := p.ConditionOperations
+			if indexOpsOnly {
+				selected = indexBackedOperations(selected)
+			}
+			if len(selected) == 0 {
+				continue
+			}
+			ops[p.Name] = selected
 		}
 		if len(ops) == 0 {
 			continue
@@ -103,4 +117,17 @@ func conditionOperationsPresent(objType *interfaces.KnSearchObjectType) bool {
 		}
 	}
 	return false
+}
+
+// indexBackedOperations 挑出只有服务端才知道的那几个算子——它们取决于底层索引建没建，
+// 从属性类型推不出来。其余比较算子调用方按 type 自行判断即可。
+func indexBackedOperations(ops []interfaces.KnOperationType) []interfaces.KnOperationType {
+	var out []interfaces.KnOperationType
+	for _, op := range ops {
+		switch op {
+		case interfaces.KnOperationTypeMatch, interfaces.KnOperationTypeMultiMatch, interfaces.KnOperationTypeKnn:
+			out = append(out, op)
+		}
+	}
+	return out
 }

--- a/adp/context-loader/agent-retrieval/server/logics/knsearch/condition_operations_backfill_test.go
+++ b/adp/context-loader/agent-retrieval/server/logics/knsearch/condition_operations_backfill_test.go
@@ -42,7 +42,7 @@ func TestBackfillConditionOperations_FillsFromDetail(t *testing.T) {
 	svc := &localSearchImpl{logger: &mockLogger{}, bknBackend: backend}
 	objType := backfillTestObjectType("teams", nil)
 
-	svc.backfillConditionOperations(context.Background(), "kn1", []*interfaces.KnSearchObjectType{objType})
+	svc.backfillConditionOperations(context.Background(), "kn1", []*interfaces.KnSearchObjectType{objType}, false)
 
 	if backend.objectDetailCalls != 1 {
 		t.Fatalf("expected exactly one batched detail call, got %d", backend.objectDetailCalls)
@@ -66,7 +66,7 @@ func TestBackfillConditionOperations_SkipsWhenAlreadyPresent(t *testing.T) {
 	svc := &localSearchImpl{logger: &mockLogger{}, bknBackend: backend}
 	objType := backfillTestObjectType("teams", []interfaces.KnOperationType{interfaces.KnOperationTypeMatch})
 
-	svc.backfillConditionOperations(context.Background(), "kn1", []*interfaces.KnSearchObjectType{objType})
+	svc.backfillConditionOperations(context.Background(), "kn1", []*interfaces.KnSearchObjectType{objType}, false)
 
 	if backend.objectDetailCalls != 0 {
 		t.Fatalf("object types that already carry operations must not trigger a detail call, got %d", backend.objectDetailCalls)
@@ -78,7 +78,7 @@ func TestBackfillConditionOperations_DegradesOnError(t *testing.T) {
 	svc := &localSearchImpl{logger: &mockLogger{}, bknBackend: backend}
 	objType := backfillTestObjectType("teams", nil)
 
-	svc.backfillConditionOperations(context.Background(), "kn1", []*interfaces.KnSearchObjectType{objType})
+	svc.backfillConditionOperations(context.Background(), "kn1", []*interfaces.KnSearchObjectType{objType}, false)
 
 	if len(objType.DataProperties[0].ConditionOperations) != 0 {
 		t.Fatalf("failed backfill must leave the object type untouched, got %+v", objType.DataProperties[0].ConditionOperations)
@@ -111,7 +111,7 @@ func TestBackfillConditionOperations_MakesCapabilityVisibleInSchema(t *testing.T
 		},
 	}
 
-	svc.backfillConditionOperations(context.Background(), "kn1", []*interfaces.KnSearchObjectType{objType})
+	svc.backfillConditionOperations(context.Background(), "kn1", []*interfaces.KnSearchObjectType{objType}, false)
 
 	ops := objType.DataProperties[0].ConditionOperations
 	var hasMatch, hasKnn bool
@@ -125,5 +125,57 @@ func TestBackfillConditionOperations_MakesCapabilityVisibleInSchema(t *testing.T
 	}
 	if !hasMatch || !hasKnn {
 		t.Fatalf("schema must expose what the field can actually do, got %+v", ops)
+	}
+}
+
+// 精简 Schema 只补索引带来的算子：比较算子按属性类型可推导，逐个下发纯属浪费体积。
+// 实测一次检索差 69 倍（+10,453 字节 vs +151 字节）。
+func TestBackfillConditionOperations_BriefKeepsOnlyIndexBackedOps(t *testing.T) {
+	backend := &mockBknBackend{
+		objectDetailResp: []*interfaces.ObjectType{
+			{
+				ID: "stadiums",
+				DataProperties: []*interfaces.DataProperty{
+					{Name: "stadium_name", ConditionOperations: []interfaces.KnOperationType{
+						interfaces.KnOperationTypeEqual,
+						interfaces.KnOperationTypeIn,
+						interfaces.KnOperationTypeLike,
+						interfaces.KnOperationTypeMatch,
+						interfaces.KnOperationTypeMultiMatch,
+						interfaces.KnOperationTypeKnn,
+					}},
+					{Name: "stadium_id", ConditionOperations: []interfaces.KnOperationType{
+						interfaces.KnOperationTypeEqual,
+						interfaces.KnOperationTypeIn,
+					}},
+				},
+			},
+		},
+	}
+	svc := &localSearchImpl{logger: &mockLogger{}, bknBackend: backend}
+	objType := &interfaces.KnSearchObjectType{
+		ConceptID: "stadiums",
+		DataProperties: []*interfaces.KnSearchDataProperty{
+			{Name: "stadium_name", Type: "string"},
+			{Name: "stadium_id", Type: "string"},
+		},
+	}
+
+	svc.backfillConditionOperations(context.Background(), "kn1", []*interfaces.KnSearchObjectType{objType}, true)
+
+	got := objType.DataProperties[0].ConditionOperations
+	if len(got) != 3 {
+		t.Fatalf("brief mode keeps only the index-backed operations, got %+v", got)
+	}
+	for _, op := range got {
+		switch op {
+		case interfaces.KnOperationTypeMatch, interfaces.KnOperationTypeMultiMatch, interfaces.KnOperationTypeKnn:
+		default:
+			t.Fatalf("derivable comparison operator leaked into brief mode: %s", op)
+		}
+	}
+	// 没有索引能力的属性在精简模式下整个字段都不出现，省掉一份重复的比较算子清单。
+	if len(objType.DataProperties[1].ConditionOperations) != 0 {
+		t.Fatalf("a field with no index capability should stay bare, got %+v", objType.DataProperties[1].ConditionOperations)
 	}
 }

--- a/adp/context-loader/agent-retrieval/server/logics/knsearch/condition_operations_backfill_test.go
+++ b/adp/context-loader/agent-retrieval/server/logics/knsearch/condition_operations_backfill_test.go
@@ -128,7 +128,7 @@ func TestBackfillConditionOperations_MakesCapabilityVisibleInSchema(t *testing.T
 	}
 }
 
-// 精简只在出响应前做：实例召回要靠算子挑可检索字段，提前裁掉会让只支持等值的字段
+// 裁剪只在出响应前做，且只对 MCP 面：实例召回要靠算子挑可检索字段，提前裁掉会让只支持等值的字段
 // 整个消失——那是响应开关改了召回口径。实测全量比索引类多 10,453 字节（69 倍）。
 func TestTrimToIndexBackedOperations(t *testing.T) {
 	full := []interfaces.KnOperationType{

--- a/adp/context-loader/agent-retrieval/server/logics/knsearch/condition_operations_backfill_test.go
+++ b/adp/context-loader/agent-retrieval/server/logics/knsearch/condition_operations_backfill_test.go
@@ -128,54 +128,47 @@ func TestBackfillConditionOperations_MakesCapabilityVisibleInSchema(t *testing.T
 	}
 }
 
-// 精简 Schema 只补索引带来的算子：比较算子按属性类型可推导，逐个下发纯属浪费体积。
-// 实测一次检索差 69 倍（+10,453 字节 vs +151 字节）。
-func TestBackfillConditionOperations_BriefKeepsOnlyIndexBackedOps(t *testing.T) {
-	backend := &mockBknBackend{
-		objectDetailResp: []*interfaces.ObjectType{
-			{
-				ID: "stadiums",
-				DataProperties: []*interfaces.DataProperty{
-					{Name: "stadium_name", ConditionOperations: []interfaces.KnOperationType{
-						interfaces.KnOperationTypeEqual,
-						interfaces.KnOperationTypeIn,
-						interfaces.KnOperationTypeLike,
-						interfaces.KnOperationTypeMatch,
-						interfaces.KnOperationTypeMultiMatch,
-						interfaces.KnOperationTypeKnn,
-					}},
-					{Name: "stadium_id", ConditionOperations: []interfaces.KnOperationType{
-						interfaces.KnOperationTypeEqual,
-						interfaces.KnOperationTypeIn,
-					}},
-				},
+// 精简只在出响应前做：实例召回要靠算子挑可检索字段，提前裁掉会让只支持等值的字段
+// 整个消失——那是响应开关改了召回口径。实测全量比索引类多 10,453 字节（69 倍）。
+func TestTrimToIndexBackedOperations(t *testing.T) {
+	full := []interfaces.KnOperationType{
+		interfaces.KnOperationTypeEqual,
+		interfaces.KnOperationTypeIn,
+		interfaces.KnOperationTypeLike,
+		interfaces.KnOperationTypeMatch,
+		interfaces.KnOperationTypeMultiMatch,
+		interfaces.KnOperationTypeKnn,
+	}
+	newObjType := func() *interfaces.KnSearchObjectType {
+		return &interfaces.KnSearchObjectType{
+			ConceptID: "stadiums",
+			DataProperties: []*interfaces.KnSearchDataProperty{
+				{Name: "stadium_name", Type: "string", ConditionOperations: append([]interfaces.KnOperationType(nil), full...)},
+				{Name: "stadium_id", Type: "string", ConditionOperations: []interfaces.KnOperationType{
+					interfaces.KnOperationTypeEqual, interfaces.KnOperationTypeIn,
+				}},
 			},
-		},
-	}
-	svc := &localSearchImpl{logger: &mockLogger{}, bknBackend: backend}
-	objType := &interfaces.KnSearchObjectType{
-		ConceptID: "stadiums",
-		DataProperties: []*interfaces.KnSearchDataProperty{
-			{Name: "stadium_name", Type: "string"},
-			{Name: "stadium_id", Type: "string"},
-		},
-	}
-
-	svc.backfillConditionOperations(context.Background(), "kn1", []*interfaces.KnSearchObjectType{objType}, true)
-
-	got := objType.DataProperties[0].ConditionOperations
-	if len(got) != 3 {
-		t.Fatalf("brief mode keeps only the index-backed operations, got %+v", got)
-	}
-	for _, op := range got {
-		switch op {
-		case interfaces.KnOperationTypeMatch, interfaces.KnOperationTypeMultiMatch, interfaces.KnOperationTypeKnn:
-		default:
-			t.Fatalf("derivable comparison operator leaked into brief mode: %s", op)
 		}
 	}
-	// 没有索引能力的属性在精简模式下整个字段都不出现，省掉一份重复的比较算子清单。
-	if len(objType.DataProperties[1].ConditionOperations) != 0 {
-		t.Fatalf("a field with no index capability should stay bare, got %+v", objType.DataProperties[1].ConditionOperations)
+
+	brief := newObjType()
+	trimToIndexBackedOperations([]*interfaces.KnSearchObjectType{brief}, true)
+	if len(brief.DataProperties[0].ConditionOperations) != 3 {
+		t.Fatalf("brief keeps only index-backed operations, got %+v", brief.DataProperties[0].ConditionOperations)
+	}
+	if len(brief.DataProperties[1].ConditionOperations) != 0 {
+		t.Fatalf("a field with no index capability goes bare, got %+v", brief.DataProperties[1].ConditionOperations)
+	}
+
+	kept := newObjType()
+	trimToIndexBackedOperations([]*interfaces.KnSearchObjectType{kept}, false)
+	if len(kept.DataProperties[0].ConditionOperations) != len(full) {
+		t.Fatalf("full mode must keep every operation, got %+v", kept.DataProperties[0].ConditionOperations)
+	}
+
+	// 裁剪之前，只支持等值的字段必须仍然是可检索的——否则实例召回会漏掉它。
+	searchable := findSemanticSearchableFields(newObjType())
+	if len(searchable) != 2 {
+		t.Fatalf("retrieval must see every field before trimming, got %+v", searchable)
 	}
 }

--- a/adp/context-loader/agent-retrieval/server/logics/knsearch/condition_operations_backfill_test.go
+++ b/adp/context-loader/agent-retrieval/server/logics/knsearch/condition_operations_backfill_test.go
@@ -84,3 +84,46 @@ func TestBackfillConditionOperations_DegradesOnError(t *testing.T) {
 		t.Fatalf("failed backfill must leave the object type untouched, got %+v", objType.DataProperties[0].ConditionOperations)
 	}
 }
+
+// 概念召回的 Schema 取自知识网络导出视图，属性上不带算子。补齐必须发生在这一阶段，
+// 否则 search_schema 的响应里没有能力信息——Agent 就无从知道字段能不能 match / knn，
+// 而这正是它规划查询的唯一依据。
+func TestBackfillConditionOperations_MakesCapabilityVisibleInSchema(t *testing.T) {
+	backend := &mockBknBackend{
+		objectDetailResp: []*interfaces.ObjectType{
+			{
+				ID: "stadiums",
+				DataProperties: []*interfaces.DataProperty{
+					{Name: "stadium_name", ConditionOperations: []interfaces.KnOperationType{
+						interfaces.KnOperationTypeEqual,
+						interfaces.KnOperationTypeMatch,
+						interfaces.KnOperationTypeKnn,
+					}},
+				},
+			},
+		},
+	}
+	svc := &localSearchImpl{logger: &mockLogger{}, bknBackend: backend}
+	objType := &interfaces.KnSearchObjectType{
+		ConceptID: "stadiums",
+		DataProperties: []*interfaces.KnSearchDataProperty{
+			{Name: "stadium_name", Type: "string"},
+		},
+	}
+
+	svc.backfillConditionOperations(context.Background(), "kn1", []*interfaces.KnSearchObjectType{objType})
+
+	ops := objType.DataProperties[0].ConditionOperations
+	var hasMatch, hasKnn bool
+	for _, op := range ops {
+		switch op {
+		case interfaces.KnOperationTypeMatch:
+			hasMatch = true
+		case interfaces.KnOperationTypeKnn:
+			hasKnn = true
+		}
+	}
+	if !hasMatch || !hasKnn {
+		t.Fatalf("schema must expose what the field can actually do, got %+v", ops)
+	}
+}

--- a/adp/context-loader/agent-retrieval/server/logics/knsearch/convert.go
+++ b/adp/context-loader/agent-retrieval/server/logics/knsearch/convert.go
@@ -39,6 +39,7 @@ func KnSearchReqToLocal(req *interfaces.KnSearchReq) *interfaces.KnSearchLocalRe
 	if req.RerankModel != nil {
 		local.RerankModel = *req.RerankModel
 	}
+	local.IndexOpsOnly = req.IndexOpsOnly
 	if req.IncludeColumns != nil {
 		local.IncludeColumns = *req.IncludeColumns
 	}

--- a/adp/context-loader/agent-retrieval/server/logics/knsearch/search_schema.go
+++ b/adp/context-loader/agent-retrieval/server/logics/knsearch/search_schema.go
@@ -109,6 +109,7 @@ func NormalizeSearchSchemaReq(req *interfaces.SearchSchemaReq) (*interfaces.KnSe
 		EnableRerank:   req.EnableRerank,
 		RerankModel:    req.RerankModel,
 		IncludeColumns: req.IncludeColumns,
+		IndexOpsOnly:   req.IndexOpsOnly,
 		RetrievalConfig: &interfaces.RetrievalConfig{
 			ConceptRetrieval: &interfaces.ConceptRetrievalConfig{
 				ConceptGroups: scope.ConceptGroups,

--- a/adp/context-loader/agent-retrieval/server/logics/knsearch/semantic_instance_retrieval.go
+++ b/adp/context-loader/agent-retrieval/server/logics/knsearch/semantic_instance_retrieval.go
@@ -40,8 +40,6 @@ func (s *localSearchImpl) semanticInstanceRetrieval(
 	instanceConfig := config.SemanticInstanceRetrieval
 	propertyConfig := config.PropertyFilter
 
-	s.backfillConditionOperations(ctx, req.KnID, objectTypes)
-
 	var allNodes []*interfaces.KnSearchNode
 	var maxScore float64
 

--- a/adp/context-loader/agent-retrieval/server/logics/knsearch/service.go
+++ b/adp/context-loader/agent-retrieval/server/logics/knsearch/service.go
@@ -50,8 +50,6 @@ func (s *localSearchImpl) Search(ctx context.Context, req *interfaces.KnSearchLo
 	// 精简开关顺带改变了召回口径。
 	s.backfillConditionOperations(ctx, req.KnID, conceptResult.ObjectTypes, false)
 
-	brief := boolValue(mergedConfig.ConceptRetrieval.SchemaBrief)
-
 	// 3. 构建响应
 	response := &interfaces.KnSearchLocalResponse{
 		ObjectTypes:   conceptResult.ObjectTypes,
@@ -62,7 +60,7 @@ func (s *localSearchImpl) Search(ctx context.Context, req *interfaces.KnSearchLo
 	// 4. 语义实例召回：只在调用方明确要实例时做（search_schema 恒为 schema-only）
 	if req.OnlySchema {
 		s.logger.WithContext(ctx).Infof("[KnSearchLocal] only_schema=true, skip semantic instance retrieval")
-		trimToIndexBackedOperations(response.ObjectTypes, brief)
+		trimToIndexBackedOperations(response.ObjectTypes, req.IndexOpsOnly)
 		return response, nil
 	}
 
@@ -70,7 +68,7 @@ func (s *localSearchImpl) Search(ctx context.Context, req *interfaces.KnSearchLo
 	if instanceErr != nil {
 		// 实例召回失败不拖垮整条检索：Schema 本身已经是有用的结果，降级返回。
 		s.logger.WithContext(ctx).Warnf("[KnSearchLocal] Semantic instance retrieval failed, degrade to schema-only: %v", instanceErr)
-		trimToIndexBackedOperations(response.ObjectTypes, brief)
+		trimToIndexBackedOperations(response.ObjectTypes, req.IndexOpsOnly)
 		return response, nil
 	}
 
@@ -78,6 +76,6 @@ func (s *localSearchImpl) Search(ctx context.Context, req *interfaces.KnSearchLo
 	response.Message = instanceResult.Message
 	s.logger.WithContext(ctx).Infof("[KnSearchLocal] Semantic instance retrieval completed: nodes=%d", len(response.Nodes))
 
-	trimToIndexBackedOperations(response.ObjectTypes, brief)
+	trimToIndexBackedOperations(response.ObjectTypes, req.IndexOpsOnly)
 	return response, nil
 }

--- a/adp/context-loader/agent-retrieval/server/logics/knsearch/service.go
+++ b/adp/context-loader/agent-retrieval/server/logics/knsearch/service.go
@@ -46,7 +46,8 @@ func (s *localSearchImpl) Search(ctx context.Context, req *interfaces.KnSearchLo
 	// condition_operations 一律为空。调用方（尤其是 Agent）正是靠它判断字段能不能做
 	// match / knn，拿到空的就只能靠猜——能力再准，取不到等于没有。在这里补齐，
 	// Schema 响应与后续实例召回共用同一份结果。
-	s.backfillConditionOperations(ctx, req.KnID, conceptResult.ObjectTypes)
+	s.backfillConditionOperations(ctx, req.KnID, conceptResult.ObjectTypes,
+		boolValue(mergedConfig.ConceptRetrieval.SchemaBrief))
 
 	// 3. 构建响应
 	response := &interfaces.KnSearchLocalResponse{

--- a/adp/context-loader/agent-retrieval/server/logics/knsearch/service.go
+++ b/adp/context-loader/agent-retrieval/server/logics/knsearch/service.go
@@ -42,6 +42,12 @@ func (s *localSearchImpl) Search(ctx context.Context, req *interfaces.KnSearchLo
 	s.logger.WithContext(ctx).Infof("[KnSearchLocal] Concept retrieval completed: object_types=%d, relation_types=%d, action_types=%d",
 		len(conceptResult.ObjectTypes), len(conceptResult.RelationTypes), len(conceptResult.ActionTypes))
 
+	// 概念召回默认走知识网络导出视图，那条路不做数据源富化，属性上的
+	// condition_operations 一律为空。调用方（尤其是 Agent）正是靠它判断字段能不能做
+	// match / knn，拿到空的就只能靠猜——能力再准，取不到等于没有。在这里补齐，
+	// Schema 响应与后续实例召回共用同一份结果。
+	s.backfillConditionOperations(ctx, req.KnID, conceptResult.ObjectTypes)
+
 	// 3. 构建响应
 	response := &interfaces.KnSearchLocalResponse{
 		ObjectTypes:   conceptResult.ObjectTypes,

--- a/adp/context-loader/agent-retrieval/server/logics/knsearch/service.go
+++ b/adp/context-loader/agent-retrieval/server/logics/knsearch/service.go
@@ -46,8 +46,11 @@ func (s *localSearchImpl) Search(ctx context.Context, req *interfaces.KnSearchLo
 	// condition_operations 一律为空。调用方（尤其是 Agent）正是靠它判断字段能不能做
 	// match / knn，拿到空的就只能靠猜——能力再准，取不到等于没有。在这里补齐，
 	// Schema 响应与后续实例召回共用同一份结果。
-	s.backfillConditionOperations(ctx, req.KnID, conceptResult.ObjectTypes,
-		boolValue(mergedConfig.ConceptRetrieval.SchemaBrief))
+	// 一律补齐全量算子：实例召回要靠它挑可检索字段，裁剪留到出响应前，免得响应的
+	// 精简开关顺带改变了召回口径。
+	s.backfillConditionOperations(ctx, req.KnID, conceptResult.ObjectTypes, false)
+
+	brief := boolValue(mergedConfig.ConceptRetrieval.SchemaBrief)
 
 	// 3. 构建响应
 	response := &interfaces.KnSearchLocalResponse{
@@ -59,6 +62,7 @@ func (s *localSearchImpl) Search(ctx context.Context, req *interfaces.KnSearchLo
 	// 4. 语义实例召回：只在调用方明确要实例时做（search_schema 恒为 schema-only）
 	if req.OnlySchema {
 		s.logger.WithContext(ctx).Infof("[KnSearchLocal] only_schema=true, skip semantic instance retrieval")
+		trimToIndexBackedOperations(response.ObjectTypes, brief)
 		return response, nil
 	}
 
@@ -66,6 +70,7 @@ func (s *localSearchImpl) Search(ctx context.Context, req *interfaces.KnSearchLo
 	if instanceErr != nil {
 		// 实例召回失败不拖垮整条检索：Schema 本身已经是有用的结果，降级返回。
 		s.logger.WithContext(ctx).Warnf("[KnSearchLocal] Semantic instance retrieval failed, degrade to schema-only: %v", instanceErr)
+		trimToIndexBackedOperations(response.ObjectTypes, brief)
 		return response, nil
 	}
 
@@ -73,5 +78,6 @@ func (s *localSearchImpl) Search(ctx context.Context, req *interfaces.KnSearchLo
 	response.Message = instanceResult.Message
 	s.logger.WithContext(ctx).Infof("[KnSearchLocal] Semantic instance retrieval completed: nodes=%d", len(response.Nodes))
 
+	trimToIndexBackedOperations(response.ObjectTypes, brief)
 	return response, nil
 }


### PR DESCRIPTION
Closes #704

## Problem

An Agent on the dev VM was asked which fields support vector search. It answered: none. It was not wrong.

`stadiums.stadium_name` does support `knn` — a direct query returns `Estadio Azteca` at `_score=0.7157` for the Chinese phrase 阿兹特克体育场. But every schema surface the Agent can reach returns `condition_operations: null`, so it had no way to know. In its own words:

> 我是怎么知道的？实际上我不知道 😅 … 信息来源：你之前告诉我的。

#695 made vector search work. This makes it discoverable. Without both, the capability may as well not exist: an Agent plans queries from `condition_operations`, and an empty list means "don't try".

## Root cause

Two schema paths bypass enrichment. `condition_operations` is derived in `processObjectTypeDetails`, which only runs on the by-ids detail endpoint and on `SearchObjectTypes`:

- **`search_schema`** with no `concept_groups` (the common case) takes the coarse-recall path, whose schema comes from `GET /knowledge-networks/{kn}?include_detail=true&mode=export`. That route calls `ListObjectTypes`, which never enriches. Passing `concept_groups` routes through `SearchObjectTypes` and does enrich — the same tool answers differently depending on an unrelated argument.
- **`get_object_types`** reads the same export view and filters by id, even though the by-ids endpoint it could have called is enriched.

`schema_brief` is not involved: the Agent tried `schema_brief=false` and still got nothing.

## What changed

- `get_object_types` now calls `GetObjectTypeDetail`. Ids are supplied by the caller, so the cost of enrichment is bounded by what was asked for.
- Operations are backfilled once, right after concept retrieval, so the `search_schema` response carries them and instance retrieval reuses the same result instead of backfilling separately.

The backfill itself is unchanged — it landed in #695 and is one batched detail call for the object types that lack operations.

## Verification

Unit tests assert the two guarantees directly: `get_object_types` reads the enriched endpoint and never the export view, and a schema whose properties arrive bare comes back carrying `match` / `knn`. Full context-loader suite green, gofmt clean.

Not covered here: a property declared `vector` on the object type still reports no operations at all, because operation derivation keys off scalar types plus resource features. It is documented in #704 and worth folding into the same area next.