### PR TITLE
fix(bkn-trace): secure OpenSearch credentials

### DIFF
--- a/bkn-trace/agent-observability/Makefile
+++ b/bkn-trace/agent-observability/Makefile
@@ -56,6 +56,7 @@ docker-build:
 helm-lint:
 	helm lint $(CHART_PATH)
 	bash scripts/test_evidence_index_governance.sh $(CHART_PATH)
+	bash ../scripts/test_secure_opensearch_contract.sh
 
 helm-package:
 	mkdir -p dist

--- a/bkn-trace/agent-observability/README.md
+++ b/bkn-trace/agent-observability/README.md
@@ -414,6 +414,9 @@ helm upgrade --install agent-observability charts/agent-observability \
 启用 OpenSearch Basic Auth：
 
 ```bash
+printf '%s' 'your-username' > /path/to/opensearch-username
+printf '%s' 'your-password' > /path/to/opensearch-password
+
 kubectl create secret generic bkn-trace-opensearch \
   -n observability \
   --from-file=username=/path/to/opensearch-username \
@@ -429,6 +432,7 @@ helm upgrade --install agent-observability charts/agent-observability \
 ```
 
 不要通过 Helm `--set` 传递 OpenSearch 用户名或密码。Chart 只接受已有 Secret 的名称；用户名与密码键默认为 `username`、`password`，可用 `opensearch.auth.usernameKey` 与 `passwordKey` 覆盖。
+创建凭据文件时使用 `printf`，避免 `echo` 在文件末尾写入换行。
 
 ## CI/CD
 

--- a/bkn-trace/agent-observability/README.md
+++ b/bkn-trace/agent-observability/README.md
@@ -414,15 +414,21 @@ helm upgrade --install agent-observability charts/agent-observability \
 启用 OpenSearch Basic Auth：
 
 ```bash
+kubectl create secret generic bkn-trace-opensearch \
+  -n observability \
+  --from-file=username=/path/to/opensearch-username \
+  --from-file=password=/path/to/opensearch-password
+
 helm upgrade --install agent-observability charts/agent-observability \
   --set image.repository=swr.cn-east-3.myhuaweicloud.com/kweaver-ai/agent-observability \
   --set image.tag=0.1.1 \
   --set opensearch.endpoint=http://opensearch-cluster-master:9200 \
   --set opensearch.auth.enabled=true \
-  --set opensearch.auth.username=your-username \
-  --set opensearch.auth.password=your-password \
+  --set opensearch.auth.existingSecret=bkn-trace-opensearch \
   -n observability --create-namespace
 ```
+
+不要通过 Helm `--set` 传递 OpenSearch 用户名或密码。Chart 只接受已有 Secret 的名称；用户名与密码键默认为 `username`、`password`，可用 `opensearch.auth.usernameKey` 与 `passwordKey` 覆盖。
 
 ## CI/CD
 

--- a/bkn-trace/agent-observability/charts/agent-observability/templates/deployment.yaml
+++ b/bkn-trace/agent-observability/charts/agent-observability/templates/deployment.yaml
@@ -103,9 +103,15 @@ spec:
               value: {{ ternary "true" "false" .Values.opensearch.auth.enabled | quote }}
             {{- if .Values.opensearch.auth.enabled }}
             - name: OPENSEARCH_AUTH_USERNAME
-              value: {{ .Values.opensearch.auth.username | quote }}
+              valueFrom:
+                secretKeyRef:
+                  name: {{ required "opensearch.auth.existingSecret is required when OpenSearch auth is enabled" .Values.opensearch.auth.existingSecret | quote }}
+                  key: {{ .Values.opensearch.auth.usernameKey | quote }}
             - name: OPENSEARCH_AUTH_PASSWORD
-              value: {{ .Values.opensearch.auth.password | quote }}
+              valueFrom:
+                secretKeyRef:
+                  name: {{ required "opensearch.auth.existingSecret is required when OpenSearch auth is enabled" .Values.opensearch.auth.existingSecret | quote }}
+                  key: {{ .Values.opensearch.auth.passwordKey | quote }}
             {{- end }}
             {{- if .Values.evidence.ingestAuth.existingSecret }}
             - name: BKN_TRACE_EVIDENCE_INGEST_TOKEN

--- a/bkn-trace/agent-observability/charts/agent-observability/values.yaml
+++ b/bkn-trace/agent-observability/charts/agent-observability/values.yaml
@@ -130,5 +130,6 @@ opensearch:
   logIndex: ss4o_logs-default-namespace
   auth:
     enabled: false
-    username: ""
-    password: ""
+    existingSecret: ""
+    usernameKey: username
+    passwordKey: password

--- a/bkn-trace/otelcol-contribute-chart/README.md
+++ b/bkn-trace/otelcol-contribute-chart/README.md
@@ -205,13 +205,19 @@ helm upgrade --install otelcol-contrib charts/otelcol-contrib \
 开启 Basic Auth 示例：
 
 ```bash
+kubectl create secret generic bkn-trace-opensearch \
+  -n observability \
+  --from-file=username=/path/to/opensearch-username \
+  --from-file=password=/path/to/opensearch-password
+
 helm upgrade --install otelcol-contrib charts/otelcol-contrib \
   -n observability \
   --create-namespace \
   --set opensearchExporter.auth.enabled=true \
-  --set opensearchExporter.auth.username=admin \
-  --set opensearchExporter.auth.password=admin
+  --set opensearchExporter.auth.existingSecret=bkn-trace-opensearch
 ```
+
+不要通过 Helm `--set` 传递 OpenSearch 用户名或密码。Chart 只接受已有 Secret 的名称；用户名与密码键默认为 `username`、`password`，可用 `opensearchExporter.auth.usernameKey` 与 `passwordKey` 覆盖。
 
 ## 7. 使用 telemetrygen 生成测试 Trace
 

--- a/bkn-trace/otelcol-contribute-chart/README.md
+++ b/bkn-trace/otelcol-contribute-chart/README.md
@@ -205,6 +205,9 @@ helm upgrade --install otelcol-contrib charts/otelcol-contrib \
 开启 Basic Auth 示例：
 
 ```bash
+printf '%s' 'your-username' > /path/to/opensearch-username
+printf '%s' 'your-password' > /path/to/opensearch-password
+
 kubectl create secret generic bkn-trace-opensearch \
   -n observability \
   --from-file=username=/path/to/opensearch-username \
@@ -218,6 +221,7 @@ helm upgrade --install otelcol-contrib charts/otelcol-contrib \
 ```
 
 不要通过 Helm `--set` 传递 OpenSearch 用户名或密码。Chart 只接受已有 Secret 的名称；用户名与密码键默认为 `username`、`password`，可用 `opensearchExporter.auth.usernameKey` 与 `passwordKey` 覆盖。
+创建凭据文件时使用 `printf`，避免 `echo` 在文件末尾写入换行。
 
 ## 7. 使用 telemetrygen 生成测试 Trace
 

--- a/bkn-trace/otelcol-contribute-chart/charts/otelcol-contrib/templates/configmap.yaml
+++ b/bkn-trace/otelcol-contribute-chart/charts/otelcol-contrib/templates/configmap.yaml
@@ -58,7 +58,7 @@ metadata:
 {{- if not (hasKey $config "extensions") }}
 {{- $_ := set $config "extensions" (dict) }}
 {{- end }}
-{{- $_ := set (get $config "extensions") "basicauth/client" (dict "client_auth" (dict "username" .Values.opensearchExporter.auth.username "password" .Values.opensearchExporter.auth.password)) }}
+{{- $_ := set (get $config "extensions") "basicauth/client" (dict "client_auth" (dict "username" "${env:OPENSEARCH_AUTH_USERNAME}" "password" "${env:OPENSEARCH_AUTH_PASSWORD}")) }}
 {{- $_ := set (get $opensearch "http") "auth" (dict "authenticator" "basicauth/client") }}
 {{- if not (hasKey $config "service") }}
 {{- $_ := set $config "service" (dict) }}

--- a/bkn-trace/otelcol-contribute-chart/charts/otelcol-contrib/templates/deployment.yaml
+++ b/bkn-trace/otelcol-contribute-chart/charts/otelcol-contrib/templates/deployment.yaml
@@ -50,6 +50,18 @@ spec:
               containerPort: {{ .Values.service.ports.metrics }}
               protocol: TCP
           env:
+            {{- if .Values.opensearchExporter.auth.enabled }}
+            - name: OPENSEARCH_AUTH_USERNAME
+              valueFrom:
+                secretKeyRef:
+                  name: {{ required "opensearch.auth.existingSecret is required when OpenSearch auth is enabled" .Values.opensearchExporter.auth.existingSecret | quote }}
+                  key: {{ .Values.opensearchExporter.auth.usernameKey | quote }}
+            - name: OPENSEARCH_AUTH_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ required "opensearch.auth.existingSecret is required when OpenSearch auth is enabled" .Values.opensearchExporter.auth.existingSecret | quote }}
+                  key: {{ .Values.opensearchExporter.auth.passwordKey | quote }}
+            {{- end }}
             {{- with .Values.extraEnvs }}
             {{- toYaml . | nindent 12 }}
             {{- end }}

--- a/bkn-trace/otelcol-contribute-chart/charts/otelcol-contrib/templates/deployment.yaml
+++ b/bkn-trace/otelcol-contribute-chart/charts/otelcol-contrib/templates/deployment.yaml
@@ -54,12 +54,12 @@ spec:
             - name: OPENSEARCH_AUTH_USERNAME
               valueFrom:
                 secretKeyRef:
-                  name: {{ required "opensearch.auth.existingSecret is required when OpenSearch auth is enabled" .Values.opensearchExporter.auth.existingSecret | quote }}
+                  name: {{ required "opensearchExporter.auth.existingSecret is required when OpenSearch auth is enabled" .Values.opensearchExporter.auth.existingSecret | quote }}
                   key: {{ .Values.opensearchExporter.auth.usernameKey | quote }}
             - name: OPENSEARCH_AUTH_PASSWORD
               valueFrom:
                 secretKeyRef:
-                  name: {{ required "opensearch.auth.existingSecret is required when OpenSearch auth is enabled" .Values.opensearchExporter.auth.existingSecret | quote }}
+                  name: {{ required "opensearchExporter.auth.existingSecret is required when OpenSearch auth is enabled" .Values.opensearchExporter.auth.existingSecret | quote }}
                   key: {{ .Values.opensearchExporter.auth.passwordKey | quote }}
             {{- end }}
             {{- with .Values.extraEnvs }}

--- a/bkn-trace/otelcol-contribute-chart/charts/otelcol-contrib/values.yaml
+++ b/bkn-trace/otelcol-contribute-chart/charts/otelcol-contrib/values.yaml
@@ -81,8 +81,9 @@ opensearchExporter:
       insecure: true
   auth:
     enabled: false
-    username: ""
-    password: ""
+    existingSecret: ""
+    usernameKey: username
+    passwordKey: password
   dataset: default
   namespace: namespace
   logsIndex: ""

--- a/bkn-trace/scripts/test_secure_opensearch_contract.sh
+++ b/bkn-trace/scripts/test_secure_opensearch_contract.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+root_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+agent_chart="${root_dir}/agent-observability/charts/agent-observability"
+collector_chart="${root_dir}/otelcol-contribute-chart/charts/otelcol-contrib"
+secret_name="bkn-trace-opensearch"
+sentinel_password="must-not-appear-in-rendered-manifests"
+
+assert_contains() {
+  local rendered="$1"
+  local needle="$2"
+  if ! grep -Fq -- "${needle}" <<<"${rendered}"; then
+    echo "expected rendered chart to contain: ${needle}" >&2
+    exit 1
+  fi
+}
+
+assert_not_contains() {
+  local rendered="$1"
+  local needle="$2"
+  if grep -Fq -- "${needle}" <<<"${rendered}"; then
+    echo "rendered chart must not contain: ${needle}" >&2
+    exit 1
+  fi
+}
+
+assert_requires_secret() {
+  local chart_name="$1"
+  local chart_path="$2"
+  local auth_path="$3"
+  local stderr_file
+  stderr_file="$(mktemp)"
+
+  if helm template "${chart_name}" "${chart_path}" --set "${auth_path}.enabled=true" >/dev/null 2>"${stderr_file}"; then
+    rm -f "${stderr_file}"
+    echo "${chart_name} must fail closed when OpenSearch auth has no existingSecret" >&2
+    exit 1
+  fi
+  if ! grep -Fq "opensearch.auth.existingSecret is required" "${stderr_file}"; then
+    rm -f "${stderr_file}"
+    echo "${chart_name} must report the missing OpenSearch existingSecret" >&2
+    exit 1
+  fi
+  rm -f "${stderr_file}"
+}
+
+agent_default="$(helm template agent-observability "${agent_chart}")"
+collector_default="$(helm template otelcol-contrib "${collector_chart}")"
+assert_not_contains "${agent_default}" "OPENSEARCH_AUTH_USERNAME"
+assert_not_contains "${agent_default}" "OPENSEARCH_AUTH_PASSWORD"
+assert_not_contains "${collector_default}" "OPENSEARCH_AUTH_USERNAME"
+assert_not_contains "${collector_default}" "OPENSEARCH_AUTH_PASSWORD"
+
+assert_requires_secret agent-observability "${agent_chart}" opensearch.auth
+assert_requires_secret otelcol-contrib "${collector_chart}" opensearchExporter.auth
+
+agent_secure="$(helm template agent-observability "${agent_chart}" \
+  --set evidence.store=opensearch \
+  --set opensearch.auth.enabled=true \
+  --set opensearch.auth.existingSecret="${secret_name}" \
+  --set-string opensearch.auth.password="${sentinel_password}")"
+assert_contains "${agent_secure}" "name: OPENSEARCH_AUTH_USERNAME"
+assert_contains "${agent_secure}" "name: OPENSEARCH_AUTH_PASSWORD"
+assert_contains "${agent_secure}" "${secret_name}"
+assert_not_contains "${agent_secure}" "${sentinel_password}"
+
+collector_secure="$(helm template otelcol-contrib "${collector_chart}" \
+  --set opensearchExporter.auth.enabled=true \
+  --set opensearchExporter.auth.existingSecret="${secret_name}" \
+  --set-string opensearchExporter.auth.password="${sentinel_password}")"
+assert_contains "${collector_secure}" "name: OPENSEARCH_AUTH_USERNAME"
+assert_contains "${collector_secure}" "name: OPENSEARCH_AUTH_PASSWORD"
+assert_contains "${collector_secure}" "${secret_name}"
+assert_contains "${collector_secure}" '${env:OPENSEARCH_AUTH_USERNAME}'
+assert_contains "${collector_secure}" '${env:OPENSEARCH_AUTH_PASSWORD}'
+assert_not_contains "${collector_secure}" "${sentinel_password}"

--- a/bkn-trace/scripts/test_secure_opensearch_contract.sh
+++ b/bkn-trace/scripts/test_secure_opensearch_contract.sh
@@ -29,6 +29,7 @@ assert_requires_secret() {
   local chart_name="$1"
   local chart_path="$2"
   local auth_path="$3"
+  local required_message="$4"
   local stderr_file
   stderr_file="$(mktemp)"
 
@@ -37,7 +38,7 @@ assert_requires_secret() {
     echo "${chart_name} must fail closed when OpenSearch auth has no existingSecret" >&2
     exit 1
   fi
-  if ! grep -Fq "opensearch.auth.existingSecret is required" "${stderr_file}"; then
+  if ! grep -Fq "${required_message}" "${stderr_file}"; then
     rm -f "${stderr_file}"
     echo "${chart_name} must report the missing OpenSearch existingSecret" >&2
     exit 1
@@ -52,8 +53,8 @@ assert_not_contains "${agent_default}" "OPENSEARCH_AUTH_PASSWORD"
 assert_not_contains "${collector_default}" "OPENSEARCH_AUTH_USERNAME"
 assert_not_contains "${collector_default}" "OPENSEARCH_AUTH_PASSWORD"
 
-assert_requires_secret agent-observability "${agent_chart}" opensearch.auth
-assert_requires_secret otelcol-contrib "${collector_chart}" opensearchExporter.auth
+assert_requires_secret agent-observability "${agent_chart}" opensearch.auth "opensearch.auth.existingSecret is required"
+assert_requires_secret otelcol-contrib "${collector_chart}" opensearchExporter.auth "opensearchExporter.auth.existingSecret is required"
 
 agent_secure="$(helm template agent-observability "${agent_chart}" \
   --set evidence.store=opensearch \

--- a/deploy/scripts/services/openbkn.sh
+++ b/deploy/scripts/services/openbkn.sh
@@ -437,6 +437,22 @@ CORE_RELEASE_EXTRA_SET_STRINGS=()
 OPENBKN_TRACE_CORE_SECRET="${OPENBKN_TRACE_CORE_SECRET:-bkn-trace-core-mariadb}"
 OPENBKN_TRACE_DATABASE="bkn_trace"
 OPENBKN_TRACE_INGEST_SECRET="${OPENBKN_TRACE_INGEST_SECRET:-bkn-trace-evidence-ingest}"
+OPENBKN_TRACE_OPENSEARCH_SECRET="${OPENBKN_TRACE_OPENSEARCH_SECRET:-bkn-trace-opensearch}"
+
+_openbkn_trace_opensearch_protocol() {
+    local protocol="${1:-}"
+    protocol="${protocol:-$(config_yaml_dep_field opensearch protocol)}"
+    printf '%s' "${protocol:-http}"
+}
+
+_openbkn_trace_opensearch_endpoint() {
+    local protocol host port
+    protocol="$(_openbkn_trace_opensearch_protocol)"
+    host="$(config_yaml_dep_field opensearch host)"
+    port="$(config_yaml_dep_field opensearch port)"
+    port="${port:-9200}"
+    printf '%s://%s:%s' "${protocol}" "${host}" "${port}"
+}
 
 # The chart defaults keep standalone development lightweight. A complete
 # OpenBKN installation, however, must make managed Agent conversations durable
@@ -456,6 +472,23 @@ _openbkn_trace_profile_sets() {
                 "opensearch.traceIndex=ss4o_traces-default-namespace"
                 "opensearch.logIndex=ss4o_logs-default-namespace"
             )
+            if [[ "$(_openbkn_trace_opensearch_protocol)" == "https" ]]; then
+                CORE_RELEASE_EXTRA_SETS+=(
+                    "opensearch.endpoint=$(_openbkn_trace_opensearch_endpoint)"
+                    "opensearch.auth.enabled=true"
+                    "opensearch.auth.existingSecret=${OPENBKN_TRACE_OPENSEARCH_SECRET}"
+                )
+            fi
+            ;;
+        otelcol-contrib)
+            if [[ "$(_openbkn_trace_opensearch_protocol)" == "https" ]]; then
+                CORE_RELEASE_EXTRA_SETS+=(
+                    "opensearchExporter.http.endpoint=$(_openbkn_trace_opensearch_endpoint)"
+                    "opensearchExporter.http.tls.insecure=false"
+                    "opensearchExporter.auth.enabled=true"
+                    "opensearchExporter.auth.existingSecret=${OPENBKN_TRACE_OPENSEARCH_SECRET}"
+                )
+            fi
             ;;
         agent-retrieval)
             CORE_RELEASE_EXTRA_SETS+=(
@@ -495,6 +528,49 @@ _openbkn_prepare_trace_ingest_secret() {
     if ! generate_random_password 48 | kubectl create secret generic "${OPENBKN_TRACE_INGEST_SECRET}" -n "${namespace}" \
         --from-file=token=/dev/stdin --dry-run=client -o yaml | kubectl apply -f - >/dev/null; then
         log_error "BKN Trace cannot create Evidence ingest Secret ${OPENBKN_TRACE_INGEST_SECRET}"
+        return 1
+    fi
+}
+
+_openbkn_prepare_trace_opensearch_secret() {
+    local namespace="$1"
+    local protocol host user password username_data password_data
+    protocol="$(_openbkn_trace_opensearch_protocol)"
+    if [[ "${protocol}" == "http" ]]; then
+        return 0
+    fi
+    if [[ "${protocol}" != "https" ]]; then
+        log_error "BKN Trace depServices.opensearch.protocol must be http or https; got ${protocol}"
+        return 1
+    fi
+
+    host="$(config_yaml_dep_field opensearch host)"
+    if [[ -z "${host}" ]]; then
+        log_error "BKN Trace secure OpenSearch requires depServices.opensearch.host"
+        return 1
+    fi
+
+    if kubectl get secret "${OPENBKN_TRACE_OPENSEARCH_SECRET}" -n "${namespace}" >/dev/null 2>&1; then
+        username_data="$(kubectl get secret "${OPENBKN_TRACE_OPENSEARCH_SECRET}" -n "${namespace}" -o jsonpath='{.data.username}' 2>/dev/null)"
+        password_data="$(kubectl get secret "${OPENBKN_TRACE_OPENSEARCH_SECRET}" -n "${namespace}" -o jsonpath='{.data.password}' 2>/dev/null)"
+        if [[ -z "${username_data}" || -z "${password_data}" ]]; then
+            log_error "BKN Trace OpenSearch Secret ${OPENBKN_TRACE_OPENSEARCH_SECRET} must contain username and password"
+            return 1
+        fi
+        return 0
+    fi
+
+    user="$(config_yaml_dep_field opensearch user)"
+    password="$(config_yaml_dep_field opensearch password)"
+    if [[ -z "${user}" || -z "${password}" ]]; then
+        log_error "BKN Trace secure OpenSearch requires depServices.opensearch user and password, or an existing Secret ${OPENBKN_TRACE_OPENSEARCH_SECRET}"
+        return 1
+    fi
+    if ! kubectl create secret generic "${OPENBKN_TRACE_OPENSEARCH_SECRET}" -n "${namespace}" \
+        --from-file=username=<(printf '%s' "${user}") \
+        --from-file=password=<(printf '%s' "${password}") \
+        --dry-run=client -o yaml | kubectl apply -f - >/dev/null; then
+        log_error "BKN Trace cannot create OpenSearch Secret ${OPENBKN_TRACE_OPENSEARCH_SECRET}"
         return 1
     fi
 }
@@ -558,6 +634,7 @@ _openbkn_prepare_trace_profile() {
     fi
 
     _openbkn_prepare_trace_ingest_secret "${namespace}"
+    _openbkn_prepare_trace_opensearch_secret "${namespace}"
 }
 
 _secret_is_owned_by_release() {

--- a/deploy/scripts/services/openbkn.sh
+++ b/deploy/scripts/services/openbkn.sh
@@ -633,7 +633,9 @@ _openbkn_prepare_trace_profile() {
         return 1
     fi
 
-    _openbkn_prepare_trace_ingest_secret "${namespace}"
+    if ! _openbkn_prepare_trace_ingest_secret "${namespace}"; then
+        return 1
+    fi
     _openbkn_prepare_trace_opensearch_secret "${namespace}"
 }
 
@@ -662,11 +664,13 @@ _openbkn_release_extra_sets() {
         else
             CORE_RELEASE_EXTRA_SETS+=("evidence.ingestAuth.createSecret=false")
         fi
-    elif [[ "${release_name}" == "agent-retrieval" ]]; then
+    elif [[ "${release_name}" == "agent-retrieval" || "${release_name}" == "otelcol-contrib" ]]; then
         _openbkn_trace_profile_sets "${release_name}"
-        # This chart renders metadata.namespace from values; keep it aligned
-        # with Helm's target namespace so the private lifecycle policy matches.
-        CORE_RELEASE_EXTRA_SETS+=("namespace=${namespace}")
+        if [[ "${release_name}" == "agent-retrieval" ]]; then
+            # This chart renders metadata.namespace from values; keep it aligned
+            # with Helm's target namespace so the private lifecycle policy matches.
+            CORE_RELEASE_EXTRA_SETS+=("namespace=${namespace}")
+        fi
     elif [[ "${release_name}" == "bkn-safe" ]]; then
         local initial_pwd
         initial_pwd="$(config_yaml_top_field bknSafe initialPassword)"

--- a/deploy/scripts/services/openbkn_trace_prerequisites_test.sh
+++ b/deploy/scripts/services/openbkn_trace_prerequisites_test.sh
@@ -8,6 +8,8 @@ CALLS=()
 EXISTING_SECRETS=""
 EXISTING_DSN_DATA="dHJhY2U6c2VjcmV0QHRjcChkYi5leGFtcGxlOjMzMDYpL2Jrbl90cmFjZT9jaGFyc2V0PXV0ZjhtYjQ="
 EXISTING_TOKEN_DATA=""
+EXISTING_OPENSEARCH_USERNAME_DATA=""
+EXISTING_OPENSEARCH_PASSWORD_DATA=""
 KUBECTL_LOG="$(mktemp)"
 LAST_ERROR=""
 
@@ -46,13 +48,19 @@ kubectl() {
                 printf '%s' "${EXISTING_DSN_DATA}"
             elif [[ "$*" == *"jsonpath={.data.token}"* ]]; then
                 printf '%s' "${EXISTING_TOKEN_DATA}"
+            elif [[ "$*" == *"jsonpath={.data.username}"* ]]; then
+                printf '%s' "${EXISTING_OPENSEARCH_USERNAME_DATA}"
+            elif [[ "$*" == *"jsonpath={.data.password}"* ]]; then
+                printf '%s' "${EXISTING_OPENSEARCH_PASSWORD_DATA}"
             fi
             return 0
             ;;
         *"create secret"*)
-            local stdin_value
-            stdin_value="$(cat)"
-            printf 'stdin:%s\n' "${stdin_value}" >>"${KUBECTL_LOG}"
+            if [[ "$*" != *"--from-file=username="* ]]; then
+                local stdin_value
+                stdin_value="$(cat)"
+                printf 'stdin:%s\n' "${stdin_value}" >>"${KUBECTL_LOG}"
+            fi
             printf '%s\n' 'apiVersion: v1' 'kind: Secret'
             return 0
             ;;
@@ -79,6 +87,12 @@ depServices:
     port: "3306"
     user: "openbkn"
     password: "trace-password"
+  opensearch:
+    host: "opensearch-secure.resource.svc.cluster.local"
+    user: "trace-reader"
+    password: "opensearch-password"
+    port: "9200"
+    protocol: https
 EOF
 _openbkn_prepare_trace_profile openbkn
 assert_contains "creates the Evidence ingest Secret before releases" "create secret generic bkn-trace-evidence-ingest"
@@ -91,8 +105,37 @@ fi
 assert_contains "creates the Core DSN Secret" "create secret generic bkn-trace-core-mariadb"
 assert_contains "uses the Trace database DSN" "/bkn_trace?charset=utf8mb4"
 assert_contains "passes the DSN through stdin" "--from-file=dsn=/dev/stdin"
+assert_contains "creates the secure OpenSearch Secret" "create secret generic bkn-trace-opensearch"
+assert_contains "passes the OpenSearch username through a file descriptor" "--from-file=username="
+assert_contains "passes the OpenSearch password through a file descriptor" "--from-file=password="
 if grep -Fq -- "--from-literal=dsn=" "${KUBECTL_LOG}"; then
     fail "Core DSN must not be exposed in kubectl process arguments"
+else
+    ok
+fi
+if grep -Fq -- "opensearch-password" "${KUBECTL_LOG}" || grep -Fq -- "--from-literal=password=" "${KUBECTL_LOG}"; then
+    fail "OpenSearch password must not be exposed in kubectl process arguments or logs"
+else
+    ok
+fi
+
+CALLS=()
+: >"${KUBECTL_LOG}"
+EXISTING_SECRETS="bkn-trace-opensearch"
+EXISTING_OPENSEARCH_USERNAME_DATA="dHJhY2UtcmVhZGVy"
+EXISTING_OPENSEARCH_PASSWORD_DATA="c2VjdXJlLXBhc3N3b3Jk"
+_openbkn_prepare_trace_opensearch_secret openbkn
+if grep -Fq "create secret generic bkn-trace-opensearch" "${KUBECTL_LOG}"; then
+    fail "existing OpenSearch Secret must be reused"
+else
+    ok
+fi
+
+CALLS=()
+: >"${KUBECTL_LOG}"
+EXISTING_OPENSEARCH_PASSWORD_DATA=""
+if _openbkn_prepare_trace_opensearch_secret openbkn; then
+    fail "existing OpenSearch Secret without password must fail"
 else
     ok
 fi

--- a/deploy/scripts/services/openbkn_trace_prerequisites_test.sh
+++ b/deploy/scripts/services/openbkn_trace_prerequisites_test.sh
@@ -274,6 +274,21 @@ _openbkn_prepare_trace_profile openbkn
 assert_contains "internal Core DSN Secret is refreshed from current RDS configuration" "create secret generic bkn-trace-core-mariadb"
 assert_contains "internal Core DSN Secret is updated idempotently" "apply -f -"
 
+CALLS=()
+: >"${KUBECTL_LOG}"
+EXISTING_SECRETS="bkn-trace-evidence-ingest"
+EXISTING_TOKEN_DATA=""
+if _openbkn_prepare_trace_profile openbkn; then
+    fail "Trace profile must fail when the existing Evidence ingest Secret has no token"
+else
+    ok
+fi
+if [[ "${LAST_ERROR}" == *"Evidence ingest Secret"*"must contain key token"* ]]; then
+    ok
+else
+    fail "Trace profile must preserve the Evidence ingest Secret validation error"
+fi
+
 if grep -Eq -- '^[[:space:]]{2}-[[:space:]]+bkn_trace([[:space:]]|$)' "${SCRIPT_DIR}/../data-migrator/config.monorepo.yaml"; then
     ok
 else

--- a/deploy/scripts/services/openbkn_trace_profile_test.sh
+++ b/deploy/scripts/services/openbkn_trace_profile_test.sh
@@ -83,6 +83,15 @@ contains "secure Collector enables OpenSearch auth" "${secure_collector_sets}" "
 contains "secure Collector references the shared OpenSearch Secret" "${secure_collector_sets}" "opensearchExporter.auth.existingSecret=bkn-trace-opensearch"
 not_contains "secure Collector never forwards an OpenSearch password to Helm" "${secure_collector_sets}" "password="
 
+# The installer must apply the Collector profile, not merely expose a helper
+# that unit tests can call directly.
+CORE_RELEASE_EXTRA_SETS=()
+CORE_RELEASE_EXTRA_SET_STRINGS=()
+_openbkn_release_extra_sets otelcol-contrib openbkn
+installed_collector_sets="${CORE_RELEASE_EXTRA_SETS[*]:-}"
+contains "installer applies secure Collector endpoint" "${installed_collector_sets}" "opensearchExporter.http.endpoint=https://opensearch-secure.resource.svc.cluster.local:9200"
+contains "installer applies secure Collector auth Secret" "${installed_collector_sets}" "opensearchExporter.auth.existingSecret=bkn-trace-opensearch"
+
 otel_values="$(<"${SCRIPT_DIR}/../bkn-trace/otelcol-contribute-chart/charts/otelcol-contrib/values.yaml")"
 contains "collector uses the Trace profile dataset" "${otel_values}" "dataset: default"
 contains "collector uses the Trace profile namespace" "${otel_values}" "namespace: namespace"

--- a/deploy/scripts/services/openbkn_trace_profile_test.sh
+++ b/deploy/scripts/services/openbkn_trace_profile_test.sh
@@ -35,6 +35,17 @@ trap 'rm -f "${CONFIG_REGISTRY_FILE}"' EXIT
 # shellcheck source=../services/openbkn.sh
 source "${SCRIPT_DIR}/scripts/services/openbkn.sh"
 
+# The production installer loads common.sh before this module. Keep this unit
+# test cluster-free while exercising the same config contract.
+config_yaml_dep_field() {
+    local section="$1" field="$2"
+    awk -v sec="${section}:" -v fld="${field}:" '
+        !in_block && $1 == sec && substr($0, 1, 2) == "  " {in_block=1; next}
+        in_block && NF && $0 !~ /^    / {exit}
+        in_block && $1 == fld {gsub(/'"'"'|"/, "", $2); print $2; exit}
+    ' "${CONFIG_REGISTRY_FILE}" 2>/dev/null
+}
+
 # The profile builder is deliberately pure: install tests can validate the product
 # contract without a cluster, credentials, or a Helm chart archive.
 CORE_RELEASE_EXTRA_SETS=()
@@ -47,6 +58,30 @@ contains "AO enables projection" "${ao_sets}" "core.projection.enabled=true"
 not_contains "AO leaves index initialization to runtime" "${ao_sets}" "evidence.indexManagement"
 contains "AO protects evidence producer ingest" "${ao_sets}" "evidence.ingestAuth.existingSecret=bkn-trace-evidence-ingest"
 not_contains "AO has no query gateway Secret" "${ao_sets}" "queryAuth.existingSecret="
+
+cat >"${CONFIG_REGISTRY_FILE}" <<'EOF'
+depServices:
+  opensearch:
+    host: opensearch-secure.resource.svc.cluster.local
+    port: 9200
+    protocol: https
+EOF
+CORE_RELEASE_EXTRA_SETS=()
+_openbkn_trace_profile_sets agent-observability
+secure_ao_sets="${CORE_RELEASE_EXTRA_SETS[*]:-}"
+contains "secure AO uses the OpenSearch endpoint from config" "${secure_ao_sets}" "opensearch.endpoint=https://opensearch-secure.resource.svc.cluster.local:9200"
+contains "secure AO enables OpenSearch auth" "${secure_ao_sets}" "opensearch.auth.enabled=true"
+contains "secure AO references the shared OpenSearch Secret" "${secure_ao_sets}" "opensearch.auth.existingSecret=bkn-trace-opensearch"
+not_contains "secure AO never forwards an OpenSearch password to Helm" "${secure_ao_sets}" "password="
+
+CORE_RELEASE_EXTRA_SETS=()
+_openbkn_trace_profile_sets otelcol-contrib
+secure_collector_sets="${CORE_RELEASE_EXTRA_SETS[*]:-}"
+contains "secure Collector uses the OpenSearch endpoint from config" "${secure_collector_sets}" "opensearchExporter.http.endpoint=https://opensearch-secure.resource.svc.cluster.local:9200"
+contains "secure Collector verifies the OpenSearch TLS peer" "${secure_collector_sets}" "opensearchExporter.http.tls.insecure=false"
+contains "secure Collector enables OpenSearch auth" "${secure_collector_sets}" "opensearchExporter.auth.enabled=true"
+contains "secure Collector references the shared OpenSearch Secret" "${secure_collector_sets}" "opensearchExporter.auth.existingSecret=bkn-trace-opensearch"
+not_contains "secure Collector never forwards an OpenSearch password to Helm" "${secure_collector_sets}" "password="
 
 otel_values="$(<"${SCRIPT_DIR}/../bkn-trace/otelcol-contribute-chart/charts/otelcol-contrib/values.yaml")"
 contains "collector uses the Trace profile dataset" "${otel_values}" "dataset: default"


### PR DESCRIPTION
# Pull Request

## What Changed

- [x] Trace Core reads OpenSearch credentials only from an existing Kubernetes Secret.
- [x] OTEL Collector reads the same Secret through Pod environment variables; its ConfigMap contains no credential values.
- [x] Secure install Profile creates or reuses the Secret without passing credentials through Helm values.
- [x] Added Helm, installer, and runtime regression coverage.

---

## Why

- Related Issue: Closes #699
- Background: HTTPS/OpenSearch Security deployments previously exposed credentials through Helm values or rendered configuration.

---

## How

- `auth.enabled` requires `auth.existingSecret`; username/password key names remain configurable.
- HTTPS Profile injects non-secret endpoint/TLS values and the shared Secret name only.
- Evidence and Artifact indexes remain initialized by runtime `EnsureIndex`; no Helm index Hook is restored.
- Breaking changes: authenticated standalone Chart users must create a Secret instead of supplying username/password with `--set`.

---

## Testing

- [x] Unit tests passed locally
- [x] Integration/render tests passed locally
- [ ] Verified in test environment (requires an isolated HTTPS OpenSearch namespace)

Test notes:

- `bash bkn-trace/scripts/test_secure_opensearch_contract.sh`
- `bash deploy/scripts/services/openbkn_trace_profile_test.sh`
- `bash deploy/scripts/services/openbkn_trace_prerequisites_test.sh`
- `bash bkn-trace/agent-observability/scripts/test_evidence_index_governance.sh`
- Helm lint for both Trace charts
- `go test ./src/drivenadapter/httpaccess/opensearchevidencestore ./src/infra/opensearch`

---

## Risk & Rollback

- Potential risks: a secure Profile fails closed when the Secret is missing or incomplete; existing plaintext `--set` authentication overrides are no longer supported.
- Rollback plan: revert this PR before applying the secure Profile; existing default HTTP behavior is unchanged.

---

## Additional Notes

- The runtime OpenSearch initializer remains the only Evidence/Artifact index initialization path after #731.
