### PR TITLE
docs(bkn): sync Chinese readmes

### DIFF
--- a/adp/bkn/README.zh.md
+++ b/adp/bkn/README.zh.md
@@ -1,326 +1,174 @@
-# 本体引擎 (Ontology Engine)
+# BKN Engine
 
-[中文](README.zh.md) | [English](README.md)
+中文 | [English](README.md)
 
-## 项目简介
+`adp/bkn` 是 BKN Engine 的后端子系统，负责业务知识网络
+（Business Knowledge Network）的建模与查询能力。它属于 BKN Foundry
+后端，不包含独立产品 UI。
 
-本体引擎是一个基于Go语言开发的分布式业务知识网络管理系统，提供本体建模、数据管理和智能查询功能。该系统采用微服务架构，分为本体管理模块和本体查询模块，支持大规模知识网络的构建、存储和查询。
+当前子系统由两个 Go 服务组成：
 
-本体引擎是OpenBKN平台的核心组件，专注于构建企业级业务知识网络，实现业务知识的建模、存储、查询和应用。系统采用清洁架构设计，遵循SOLID原则，具有良好的可扩展性和可维护性。
+| 服务 | 路径 | 默认端口 | 职责 |
+| --- | --- | --- | --- |
+| BKN Backend | `bkn-backend/` | `13014` | 知识网络建模、校验、导入导出、概念索引、指标、风险类和行动调度 |
+| Ontology Query | `ontology-query/` | `13018` | 对象数据查询、属性查询、子图查询、行动执行、行动日志和指标数据查询 |
 
-### 核心特性
+## 能力范围
 
-#### 本体建模与管理
-- **多维度本体定义**: 支持对象类、关系类、行动类的完整定义和管理
-- **分支管理**: 支持本体模型的分支开发和合并
-- **可视化配置**: 提供直观的本体模型可视化配置界面
+已实现并处于维护中的能力：
 
-#### 知识网络构建
-- **多领域知识网络**: 支持构建跨领域的复杂知识网络
-- **语义关系管理**: 支持定义和管理复杂的语义关系
-- **拓扑分析**: 提供知识网络的拓扑结构分析和优化
+- 知识网络 CRUD 与校验。
+- 对象类、关系类、行动类、概念组、指标、风险类和行动调度管理。
+- 通过公开 API 导入和导出 BKN 包。
+- 基于 OpenSearch 和已配置 embedding 模型的概念索引与搜索。
+- 对象实例、对象属性、子图和指定对象起点的子图查询。
+- 行动异步执行、执行记录、状态查询、日志查询和取消。
+- 通过 Ontology Query 与 VEGA resource data 执行指标查询和 dry-run。
+- BKN Trace outbox 的查看、手动重试和废弃操作。
 
-#### 智能查询引擎
-- **复杂关系查询**: 支持多跳关系路径查询和子图查询
-- **语义搜索**: 基于向量相似度的智能语义搜索
-- **性能优化**: 基于OpenSearch的高性能查询引擎
+已知边界：
 
-#### 数据集成与应用
-- **VEGA虚拟化**: 通过VEGA虚拟化引擎集成多种数据源
-- **数据同步**: 支持本体数据与业务数据的实时同步
-- **任务调度**: 支持复杂的后台任务调度和执行
-- **权限管理**: 基于角色的细粒度权限控制
+- `branch` 作为模型和查询维度已被支持，但该目录没有提供完整的分支生命周期 API，例如创建、合并、发布或回滚。
+- `bkn-backend` 中的细粒度权限集成尚未完全强制执行，部分权限 hook 仍在服务层关闭。
+- 自然语言规划和高层上下文召回不在 `adp/bkn` 内完成，对应能力属于 `adp/context-loader`。
+- 查询执行依赖 BKN 元数据、VEGA resource data、OpenSearch 索引和 model-factory embedding 配置。
+- 部分高级指标字段尚未形成完整端到端能力，应以 OpenAPI 说明和集成测试为准。
 
-#### 系统特性
-- **微服务架构**: 基于微服务设计，支持水平扩展
-- **高可用性**: 支持分布式部署和故障恢复
-- **监控集成**: 集成OpenTelemetry实现全链路监控
-- **国际化支持**: 多语言支持和本地化配置
-
-## 系统架构
-
-### 模块组成
+## 仓库结构
 
 ```text
-adp/
-└── bkn/
-    ├── bkn-backend/     # 本体管理模块
-    ├── ontology-query/       # 本体查询模块
-    ├── README.md             # 项目说明文档
-    └── README.zh.md          # 中文说明文档
+adp/bkn/
+  bkn-backend/       # 建模与管理服务
+  ontology-query/    # 查询与行动执行服务
+  AGENTS.md          # 本子系统的 Agent 协作规则
+  README.md          # 英文说明
+  README.zh.md       # 本文件
 ```
 
-### BKN管理模块 (bkn-backend)
+两个服务大体遵循相同目录结构：
 
-负责BKN模型的创建、编辑和管理，主要功能包括：
+```text
+server/
+  common/            # 公共工具、配置和条件处理
+  config/            # 本地配置文件
+  drivenadapters/    # 数据库、OpenSearch、model-factory、VEGA 和下游客户端
+  driveradapters/    # HTTP handler 和 router
+  errors/            # 服务错误定义
+  interfaces/        # DTO 和服务接口
+  locale/            # 国际化资源
+  logics/            # 业务逻辑
+  main.go            # 服务入口
+```
 
-- **知识网络管理**: 构建和管理业务知识网络
-- **对象类管理**: 定义和管理知识网络中的对象类
-- **关系类管理**: 定义和管理知识网络中的关系类
-- **行动类管理**: 定义可执行的操作和行动
-- **任务调度**: 后台任务和作业管理
+`bkn-backend` 额外包含 `worker/`，用于后台索引和任务执行；还包含
+`server/bkn-specification/`，用于 BKN 包解析、序列化和导入导出。
 
-### 本体查询模块 (ontology-query)
+## API 文档
 
-提供高效的知识图谱查询服务，主要功能包括：
+权威 API 文档位于仓库根目录：
 
-- **模型查询**: 本体模型的查询和浏览
-- **图谱查询**: 复杂的关系路径查询
-- **语义搜索**: 基于语义的智能搜索
-- **数据检索**: 多维度数据过滤和检索
+| 服务 | OpenAPI 源文件 |
+| --- | --- |
+| BKN Backend | `docs/api/bkn/*.yaml` |
+| Ontology Query | `docs/api/ontology-query/ontology-query.yaml` |
 
-## 快速开始
-
-### 环境要求
-
-- **Go**: 1.24.0 或更高版本
-- **数据库**: MariaDB 11.4+ 或 DM8（用于数据存储）
-- **搜索引擎**: OpenSearch 2.x（用于搜索和索引）
-- **依赖服务**: 需要BKN Foundry的其他服务支持
-- **Docker**: 可选，用于容器化部署
-- **Kubernetes**: 可选，用于集群部署
-
-### 本地开发
-
-#### 1. 克隆代码库
+在仓库根目录生成或检查文档：
 
 ```bash
-git clone https://github.com/kweaver-ai/adp.git
-cd adp/ontology
+npm install
+make api-docs-lint
+make api-docs-html
 ```
 
-#### 2. 配置环境
+公开 API 前缀：
 
-每个模块都有独立的配置文件，需要根据实际环境进行配置：
-
-```yaml
-# BKN管理模块配置
-bkn-backend/server/config/bkn-backend-config.yaml
-
-# 本体查询模块配置
-ontology-query/server/config/ontology-query-config.yaml
+```text
+/api/bkn-backend/v1
+/api/ontology-query/v1
 ```
 
-**关键配置项**：
-- 数据库连接信息（host、port、user、password）
-- OpenSearch连接信息
-- 依赖服务地址（如user-management、data-model等）
-- 服务端口配置
+内部 API 前缀：
 
-#### 3. 初始化数据库
+```text
+/api/bkn-backend/in/v1
+/api/ontology-query/in/v1
+```
+
+## 本地开发
+
+依赖要求：
+
+- Go 1.24+
+- MariaDB 11.4+ 或 DM8
+- OpenSearch 2.x
+- 按各服务 `server/config/*.yaml` 配置可访问的依赖服务
+
+运行 BKN Backend：
 
 ```bash
-# 执行数据库初始化脚本
-# MariaDB
-mysql -u root -p < bkn-backend/migrations/mariadb/6.x.x/pre/init.sql
-
-# DM8
-disql SYSDBA/SYSDBA@localhost:5236 < bkn-backend/migrations/dm8/6.x.x/pre/init.sql
-```
-
-#### 4. 运行BKN管理模块
-
-```bash
-cd bkn-backend/server
+cd adp/bkn/bkn-backend/server
 go mod download
 go run main.go
 ```
 
-服务将在 `http://localhost:13014` 启动
+运行 Ontology Query：
 
-**健康检查**：
+```bash
+cd adp/bkn/ontology-query/server
+go mod download
+go run main.go
+```
+
+健康检查：
+
 ```bash
 curl http://localhost:13014/health
-```
-
-#### 5. 运行本体查询模块
-
-```bash
-cd ../ontology-query/server
-go mod download
-go run main.go
-```
-
-服务将在 `http://localhost:13018` 启动
-
-**健康检查**：
-```bash
 curl http://localhost:13018/health
 ```
 
-### Docker 部署
+## 测试
 
-#### 构建镜像
+每个服务都通过自己的 Makefile 提供标准入口：
 
 ```bash
-# 构建BKN管理模块
-cd bkn-backend
+cd adp/bkn/bkn-backend
+make test
+make test-cover
+make lint
+make ci
+
+cd ../ontology-query
+make test
+make test-cover
+make lint
+make ci
+```
+
+单元测试需要 `I18N_MODE_UT=true`；Makefile 会自动设置。
+
+## 部署
+
+常规部署入口是仓库级 `deploy/` 安装器和 release manifest。
+
+服务级镜像构建示例：
+
+```bash
+cd adp/bkn/bkn-backend
 docker build -t bkn-backend:latest -f docker/Dockerfile .
 
-# 构建本体查询模块  
 cd ../ontology-query
 docker build -t ontology-query:latest -f docker/Dockerfile .
 ```
 
-#### 运行容器
-
-```bash
-# 运行BKN管理模块
-docker run -d -p 13014:13014 --name bkn-backend bkn-backend:latest
-
-# 运行本体查询模块
-docker run -d -p 13018:13018 --name ontology-query ontology-query:latest
-```
-
-### Kubernetes 部署
-
-项目提供了Helm charts用于Kubernetes部署：
-
-```bash
-# 部署BKN管理模块
-helm3 install bkn-backend bkn-backend/helm/bkn-backend/
-
-# 部署本体查询模块
-helm3 install ontology-query ontology-query/helm/ontology-query/
-```
-
-## API 文档
-
-系统提供完整的RESTful API文档，支持OpenAPI 3.0规范：
-
-### BKN管理API
-
-- **知识网络API**: [知识网络API](bkn-backend/api_doc/bkn-backend-network.html)
-  - 支持知识网络的创建、查询、更新和删除
-
-- **对象类API**: [对象类API](bkn-backend/api_doc/bkn-backend-object-type.html)
-  - 支持对象类的定义和管理
-
-- **关系类API**: [关系类API](bkn-backend/api_doc/bkn-backend-relation-type.html)
-  - 支持关系类的定义和管理
-  - 提供方向性和多重性配置
-
-- **动作类API**: [动作类API](bkn-backend/api_doc/bkn-backend-action-type.html)
-  - 支持动作类的定义和管理
-
-- **任务管理API**: [任务管理API](bkn-backend/api_doc/bkn-backend-job-api.html)
-  - 支持后台任务的创建和调度
-
-### 本体查询API
-
-- **查询服务API**: [查询服务API](ontology-query/api_doc/ontology-query.html)
-  - 支持复杂的关系路径查询
-  - 提供语义搜索和模式匹配
-  - 支持多维度数据过滤和检索
-  - 提供高性能的分页查询
-
-### API访问方式
-
-**本地开发环境**:
-```
-# BKN管理API
-http://localhost:13014/api/bkn-backend/v1/
-
-# 本体查询API
-http://localhost:13018/api/ontology-query/v1/
-```
-
-**生产环境**:
-```
-# BKN管理API
-https://your-domain.com/api/bkn-backend/v1/
-
-# 本体查询API
-https://your-domain.com/api/ontology-query/v1/
-```
-
-## 数据库支持
-
-系统支持多种数据库：
-
-- **MariaDB**: 主数据存储
-- **DM8**: 达梦数据库支持
-- **OpenSearch**: 搜索引擎和数据分析
-
-数据库升级脚本位于：
-
-- `bkn-backend/migrations/`
-- `ontology-query/migrations/`
-
-## 监控与日志
-
-- **日志系统**: 集成结构化日志，支持多级别日志记录
-- **链路追踪**: 基于OpenTelemetry的分布式链路追踪
-- **健康检查**: 提供健康检查端点
-
-## 开发指南
-
-### 代码结构
-
-项目采用清洁架构设计，遵循SOLID原则，代码结构清晰，易于维护和扩展：
+Helm chart 位于：
 
 ```text
-server/
-├── common/              # 公共配置、工具函数和常量
-├── config/              # 配置文件和配置加载
-├── drivenadapters/      # 数据访问层（驱动适配器）
-├── driveradapters/      # 接口适配层（驱动适配器）
-├── errors/              # 错误定义和处理机制
-├── interfaces/          # 接口定义和抽象
-├── locale/              # 国际化支持和多语言配置
-├── logics/              # 业务逻辑层
-├── main.go              # 应用入口和启动逻辑
-├── version/             # 版本信息和构建信息
-└── worker/              # 后台任务和作业执行器
+adp/bkn/bkn-backend/helm/bkn-backend/
+adp/bkn/ontology-query/helm/ontology-query/
 ```
 
-### 开发规范
+## 维护说明
 
-1. **清洁架构**: 遵循清洁架构原则，分离关注点
-2. **接口隔离**: 明确定义接口和实现，依赖抽象而非具体实现
-3. **错误处理**: 统一的错误处理机制，使用自定义错误类型
-4. **日志规范**: 结构化的日志记录，使用Zap日志库
-5. **测试覆盖**: 单元测试和集成测试，追求高测试覆盖率
-6. **代码风格**: 遵循Go官方代码风格，使用go fmt格式化代码
-7. **注释规范**: 清晰的注释，包括函数注释和复杂逻辑注释
-8. **版本控制**: 遵循Git Flow工作流，使用语义化版本
-
-### 测试指南
-
-```bash
-# 运行单元测试
-cd bkn-backend/server
-go test ./... -v
-
-# 运行集成测试
-cd bkn-backend/server
-go test ./... -v -tags=integration
-
-# 生成测试覆盖率报告
-cd bkn-backend/server
-go test ./... -coverprofile=coverage.out
-go tool cover -html=coverage.out
-```
-
-### 贡献指南
-
-参考kweaver项目内容
-
-## 版本历史
-
-- **v0.1.0**: 当前版本，基于Go 1.24
-
-## 许可证
-
-本项目采用 Apache License 2.0 许可证。详情请参阅 [LICENSE](../../LICENSE.txt) 文件。
-
-## 支持与联系
-
-- **技术支持**: AISHU ADP研发团队
-- **文档更新**: 持续更新中
-- **问题反馈**: 通过内部系统提交
-
----
-
-**注意**: 这是一个企业级内部项目，代码和文档可能包含特定的业务逻辑和配置。请根据实际环境进行相应的调整。
-
+- 保持本 README 与实际 router 和根部 OpenAPI 文件同步。
+- 不要重新引入旧的 `api_doc/*.html` 文档入口。
+- 如果某项能力由其他子系统实现，应明确写出所属子系统，不要描述为 `adp/bkn` 原生能力。

--- a/adp/bkn/bkn-backend/README.md
+++ b/adp/bkn/bkn-backend/README.md
@@ -1,5 +1,7 @@
 # BKN Backend
 
+[中文](README.zh.md) | English
+
 `bkn-backend` is the BKN Engine modeling and management service. It owns the
 metadata model for Business Knowledge Networks and exposes APIs for creating,
 validating, updating, searching, importing, and exporting BKN definitions.

--- a/adp/bkn/bkn-backend/README.zh.md
+++ b/adp/bkn/bkn-backend/README.zh.md
@@ -1,0 +1,203 @@
+# BKN Backend
+
+中文 | [English](README.md)
+
+`bkn-backend` 是 BKN Engine 的建模与管理服务。它负责业务知识网络
+（Business Knowledge Network）的元数据模型，并提供创建、校验、更新、
+搜索、导入和导出 BKN 定义的 API。
+
+## 当前能力范围
+
+已实现能力：
+
+- 知识网络创建、列表、详情、更新、删除、名称查询和校验。
+- 对象类管理，包括数据属性、逻辑属性、校验、样例数据查询和部分数据属性更新。
+- 关系类管理和关系类型路径查询。
+- 行动类管理、校验和概念搜索。
+- 概念组管理，包括嵌套概念和对象类成员关系。
+- 指标定义管理和校验。
+- 风险类管理。
+- 行动调度管理，包括 cron 校验、状态更新和下次运行时间计算。
+- 通过 VEGA 集成查询资源列表。
+- BKN 包上传和下载，用于导入导出。
+- 通过 OpenSearch 和 model-factory embedding 进行概念索引与搜索。
+- BKN Trace outbox 查看、重试和废弃操作。
+
+重要边界：
+
+- `branch` 作为数据维度通过查询参数支持，但服务没有提供完整的分支生命周期 API，例如创建、合并、发布或回滚。
+- 权限资源 hook 已存在，但细粒度资源权限强制执行在服务层尚未完整闭环。
+- 自然语言查询规划和上下文加载不由本服务负责，对应能力在 `adp/context-loader`。
+- 对象样例数据和资源相关操作依赖 VEGA 可用。
+- 向量搜索和概念索引依赖 OpenSearch 与 model-factory embedding 配置。
+
+## 主要 API 分组
+
+公开 API 前缀：
+
+```text
+/api/bkn-backend/v1
+```
+
+内部 API 前缀：
+
+```text
+/api/bkn-backend/in/v1
+```
+
+代表性公开路由注册在 `server/driveradapters/routers.go`：
+
+| 资源 | 路由 |
+| --- | --- |
+| 知识网络 | `/knowledge-networks`、`/knowledge-networks/{kn_id}`、`/knowledge-networks/{kn_id}/validation` |
+| 概念组 | `/knowledge-networks/{kn_id}/concept-groups` |
+| 对象类 | `/knowledge-networks/{kn_id}/object-types` |
+| 关系类 | `/knowledge-networks/{kn_id}/relation-types`、`/knowledge-networks/{kn_id}/relation-type-paths` |
+| 行动类 | `/knowledge-networks/{kn_id}/action-types` |
+| 指标 | `/knowledge-networks/{kn_id}/metrics` |
+| 风险类 | `/knowledge-networks/{kn_id}/risk-types` |
+| 行动调度 | `/knowledge-networks/{kn_id}/action-schedules` |
+| BKN 导入导出 | `/bkns`、`/bkns/{kn_id}` |
+| 资源 | `/resources` |
+| Trace outbox | `/api/bkn-backend/v1/trace/outbox` |
+
+权威 OpenAPI 源文件位于仓库根目录：
+
+```text
+docs/api/bkn/*.yaml
+```
+
+在仓库根目录运行：
+
+```bash
+npm install
+make api-docs-lint
+make api-docs-html
+```
+
+## 架构
+
+```text
+bkn-backend/
+  server/
+    common/              # 公共工具、配置、条件处理和 trace helper
+    config/              # 服务配置
+    drivenadapters/      # DB、OpenSearch、VEGA、model-factory、user-management 客户端
+    driveradapters/      # HTTP handler、router 和请求校验
+    errors/              # BKN Backend 错误定义
+    interfaces/          # DTO 和服务接口
+    locale/              # 国际化资源
+    logics/              # 业务逻辑
+    version/             # 构建和版本元数据
+    worker/              # 后台概念同步和任务执行
+    bkn-specification/   # BKN 包解析和序列化
+```
+
+核心逻辑包：
+
+| 包 | 职责 |
+| --- | --- |
+| `knowledge_network` | 知识网络生命周期编排 |
+| `object_type` | 对象类校验、CRUD、索引和样例数据 |
+| `relation_type` | 关系类校验、CRUD 和路径支持 |
+| `action_type` | 行动类校验、CRUD、搜索和来源检查 |
+| `concept_group` | 概念组树和成员管理 |
+| `metric` | 指标定义校验、CRUD 和搜索 |
+| `risk_type` | 风险类 CRUD 和概念搜索 |
+| `action_schedule` | 行动调度元数据和 cron 处理 |
+| `permission` | 权限资源集成 hook |
+| `bkn` | BKN 导入导出服务 |
+
+## 本地开发
+
+依赖要求：
+
+- Go 1.24+
+- MariaDB 11.4+ 或 DM8
+- OpenSearch 2.x
+- 调试集成路径时，需要可访问的 VEGA、model-factory 和身份/用户管理依赖。
+
+本地配置文件：
+
+```text
+server/config/bkn-backend-config.yaml
+```
+
+本地运行：
+
+```bash
+cd adp/bkn/bkn-backend/server
+go mod download
+go run main.go
+```
+
+默认端口：
+
+```text
+http://localhost:13014
+```
+
+健康检查：
+
+```bash
+curl http://localhost:13014/health
+```
+
+## 测试
+
+使用模块 Makefile：
+
+```bash
+cd adp/bkn/bkn-backend
+make test
+make test-cover
+make lint
+make ci
+```
+
+Makefile 会为单元测试设置 `I18N_MODE_UT=true`。覆盖率产物输出到：
+
+```text
+adp/bkn/bkn-backend/test-result/
+```
+
+直接运行单个包的示例：
+
+```bash
+cd adp/bkn/bkn-backend/server
+I18N_MODE_UT=true go test ./logics/object_type/... -v
+```
+
+依赖外部服务的集成测试必须通过显式环境变量或 build tag 隔离，不应进入默认
+`make test` 路径。
+
+## 构建与部署
+
+构建服务二进制：
+
+```bash
+cd adp/bkn/bkn-backend/server
+go build -o bkn-backend .
+```
+
+构建 Docker 镜像：
+
+```bash
+cd adp/bkn/bkn-backend
+docker build -t bkn-backend:latest -f docker/Dockerfile .
+```
+
+Helm chart：
+
+```text
+adp/bkn/bkn-backend/helm/bkn-backend/
+```
+
+常规产品部署入口是仓库级 `deploy/` 安装器，它会将本服务和依赖一起安装。
+
+## 维护检查项
+
+- 保持 `server/driveradapters/routers.go` 与 `docs/api/bkn/*.yaml` 同步。
+- README 只描述已实现的服务行为，不描述属于其他仓库或产品 UI 的能力。
+- 修改校验、导入导出、索引或 API 行为时，同步更新测试。
+- 权限、分支生命周期、模型/索引兼容性相关变更应视为跨服务变更，并明确说明影响范围。


### PR DESCRIPTION
# Pull Request

## What Changed

Brief description of changes:

- [x] Docs: refreshed `adp/bkn/README.zh.md` to match the updated English BKN Engine overview.
- [x] Docs: added `adp/bkn/bkn-backend/README.zh.md` as the Chinese counterpart of the BKN Backend README.
- [x] Docs: added the Chinese language switch link to `adp/bkn/bkn-backend/README.md`.

---

## Why

- Related Issue: N/A - follow-up documentation sync request.
- Related Feature: BKN Engine documentation alignment.
- Background: PR #734 refreshed the English README files. The Chinese documentation should stay in sync with those capability boundaries and current paths.

---

## How

- Key implementation points:
  - Replaced stale Chinese content that still referenced legacy repository paths and old `api_doc/*.html` documentation outputs.
  - Mirrored the current capability scope and known boundaries from the English README.
  - Added a Chinese README for `bkn-backend`, which previously only had an English module README.
- Breaking changes (API, config, database, etc.): None. Documentation-only change.

---

## Testing

- [ ] Unit tests passed locally
- [ ] Integration tests passed locally
- [ ] Verified in test environment

Test notes:

- Not run; documentation-only change.
- Ran `rg` checks for stale `kweaver-ai/adp`, `adp/ontology`, mojibake markers, and legacy active `api_doc/` references.
- Ran `git diff --check` for the changed README files.

---

## Risk & Rollback

- Potential risks: Chinese wording may need maintainer adjustment for product terminology.
- Rollback plan: Revert commit `2f2891df` if maintainers prefer the previous Chinese documentation.

---

## Additional Notes

- Follow-up to #734.