### PR TITLE
ci(bkn): run ontology query unit tests

### DIFF
--- a/.github/workflows/ci-adp-bkn.yml
+++ b/.github/workflows/ci-adp-bkn.yml
@@ -40,3 +40,7 @@ jobs:
         with:
           go-version-file: adp/bkn/ontology-query/server/go.mod
       - run: go build ./...
+      - name: Run ontology query unit tests
+        env:
+          I18N_MODE_UT: "true"
+        run: go test -count=1 -gcflags="all=-l" ./...


### PR DESCRIPTION
# Pull Request

## What Changed

Brief description of changes:

- [x] Add ontology-query unit test execution to the ADP BKN GitHub CI workflow
- [ ] Feature/module 2
- [ ] Docs/doc 1

---

## Why

- Related Issue: N/A - requested directly in Codex task
- Related Feature: BKN CI quality gate coverage
- Background: The ontology-query module previously ran `go build ./...` in GitHub CI but did not run its existing unit tests, leaving regressions less visible before merge.

---

## How

- Key implementation points: Added a `Run ontology query unit tests` step after the existing ontology-query build step, using `I18N_MODE_UT=true` and the same Go test flags already used by the bkn-backend job.
- Breaking changes (API, config, database, etc.): None.

---

## Testing

- [ ] Unit tests passed locally
- [ ] Integration tests passed locally
- [ ] Verified in test environment

Test notes:

- `git diff --check -- .github\workflows\ci-adp-bkn.yml` passed.
- `I18N_MODE_UT=true go test -count=1 -gcflags=all=-l ./...` was attempted locally under `adp/bkn/ontology-query/server`, but Windows failed during test binary linking with `VirtualAlloc errno=1455 / out of memory`.
- Retried locally with `go test -p 1 -count=1 -gcflags=all=-l ./...`; it also failed at the same Windows linker out-of-memory point in `action_logs.test`, not on a test assertion.

---

## Risk & Rollback

- Potential risks: CI runtime can increase because ontology-query unit tests now run; if existing tests are flaky or environment-sensitive, this PR will expose those failures.
- Rollback plan: Revert this workflow-only commit to restore the prior build-only ontology-query CI behavior.

---

## Additional Notes

- No application code changed.