### PR TITLE
fix(trace): authorize business provenance by interaction

### DIFF
--- a/bkn-trace/agent-observability/src/drivenadapter/httpaccess/opensearchcoreprojection/source.go
+++ b/bkn-trace/agent-observability/src/drivenadapter/httpaccess/opensearchcoreprojection/source.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"sort"
+	"time"
 
 	"github.com/openbkn-ai/bkn-foundry/bkn-trace/agent-observability/src/domain/valueobject/evidencevo"
 	"github.com/openbkn-ai/bkn-foundry/bkn-trace/agent-observability/src/domain/valueobject/sessionvo"
@@ -46,18 +47,18 @@ type receiptDocument struct {
 }
 
 func (s *Source) LoadExecutionProjection(ctx context.Context, query iprojectionsource.Query) (iprojectionsource.Result, error) {
-	receipts, truncated, err := s.loadReceipts(ctx, query)
+	receipts, authorizedInteractions, truncated, err := s.loadReceipts(ctx, query)
 	if err != nil {
 		return iprojectionsource.Result{}, err
 	}
 	artifactResult := iprojectionsource.Result{}
 	if s.artifacts != nil {
 		artifactQuery := query
-		if query.RequestID != "" {
-			if interactionID := stableReceiptInteraction(receipts); interactionID != "" {
-				artifactQuery.RequestID = ""
-				artifactQuery.InteractionID = interactionID
-			}
+		if len(authorizedInteractions) > 0 {
+			artifactQuery.RequestID = ""
+			artifactQuery.TraceID = ""
+			artifactQuery.InteractionID = ""
+			artifactQuery.AuthorizedInteractionIDs = authorizedInteractions
 		}
 		artifactResult, err = s.artifacts.LoadExecutionProjection(ctx, artifactQuery)
 		if err != nil {
@@ -73,24 +74,47 @@ func (s *Source) LoadExecutionProjection(ctx context.Context, query iprojections
 	}, nil
 }
 
-func stableReceiptInteraction(receipts []receiptDocument) string {
-	interactionID := ""
-	for _, receipt := range receipts {
-		if receipt.InteractionID == "" {
+func (s *Source) loadReceipts(ctx context.Context, query iprojectionsource.Query) ([]receiptDocument, []string, bool, error) {
+	candidates, truncated, err := s.searchReceipts(ctx, query, !hasExactReceiptSelector(query))
+	if err != nil {
+		return nil, nil, false, err
+	}
+	interactionIDs := receiptInteractionIDs(candidates)
+	interactionReceipts, interactionTruncated, err := s.loadInteractionReceipts(ctx, query, interactionIDs)
+	if err != nil {
+		return nil, nil, false, err
+	}
+	truncated = truncated || interactionTruncated
+	byInteraction := receiptsByInteraction(interactionReceipts)
+	result := make([]receiptDocument, 0, len(candidates)+len(interactionReceipts))
+	authorizedInteractions := make([]string, 0, len(byInteraction))
+	for interactionID, receipts := range byInteraction {
+		if !interactionMatchesScope(receipts, query.Scope) {
 			continue
 		}
-		if interactionID == "" {
-			interactionID = receipt.InteractionID
-			continue
-		}
-		if interactionID != receipt.InteractionID {
-			return ""
+		authorizedInteractions = append(authorizedInteractions, interactionID)
+		for _, receipt := range receipts {
+			if matchesReceiptQuery(receipt, query) {
+				result = append(result, receipt)
+			}
 		}
 	}
-	return interactionID
+	for _, receipt := range candidates {
+		if receipt.InteractionID == "" && receiptMatchesScope(receipt, query.Scope) {
+			result = append(result, receipt)
+		}
+	}
+	sort.Strings(authorizedInteractions)
+	sort.Slice(result, func(i, j int) bool {
+		if result[i].IssuedAt == result[j].IssuedAt {
+			return result[i].ReceiptID < result[j].ReceiptID
+		}
+		return result[i].IssuedAt < result[j].IssuedAt
+	})
+	return result, authorizedInteractions, truncated, nil
 }
 
-func (s *Source) loadReceipts(ctx context.Context, query iprojectionsource.Query) ([]receiptDocument, bool, error) {
+func (s *Source) searchReceipts(ctx context.Context, query iprojectionsource.Query, applyScopeCandidates bool) ([]receiptDocument, bool, error) {
 	size := maxProjectionDocuments
 	if query.Limit > 0 && query.Limit*20+1 < size {
 		size = query.Limit*20 + 1
@@ -107,7 +131,9 @@ func (s *Source) loadReceipts(ctx context.Context, query iprojectionsource.Query
 			must = append(must, exactKeywordQuery(field, value))
 		}
 	}
-	must = append(must, receiptScopeCandidates(query.Scope)...)
+	if applyScopeCandidates {
+		must = append(must, receiptScopeCandidates(query.Scope)...)
+	}
 	if !query.From.IsZero() || !query.To.IsZero() {
 		bounds := map[string]any{}
 		if !query.From.IsZero() {
@@ -142,11 +168,137 @@ func (s *Source) loadReceipts(ctx context.Context, query iprojectionsource.Query
 	}
 	result := make([]receiptDocument, 0, len(response.Hits.Hits))
 	for _, hit := range response.Hits.Hits {
-		if receiptMatchesScope(hit.Source, query.Scope) {
-			result = append(result, hit.Source)
-		}
+		result = append(result, hit.Source)
 	}
 	return result, len(response.Hits.Hits) >= size, nil
+}
+
+func (s *Source) loadInteractionReceipts(ctx context.Context, query iprojectionsource.Query, interactionIDs []string) ([]receiptDocument, bool, error) {
+	if len(interactionIDs) == 0 {
+		return nil, false, nil
+	}
+	interactionQuery := query
+	interactionQuery.RequestID = ""
+	interactionQuery.TraceID = ""
+	interactionQuery.InteractionID = ""
+	interactionQuery.From = time.Time{}
+	interactionQuery.To = time.Time{}
+	return s.searchReceiptsForInteractions(ctx, interactionQuery, interactionIDs)
+}
+
+func (s *Source) searchReceiptsForInteractions(ctx context.Context, query iprojectionsource.Query, interactionIDs []string) ([]receiptDocument, bool, error) {
+	size := maxProjectionDocuments
+	must := []map[string]any{{"exists": map[string]any{"field": "receipt_id"}}}
+	for field, value := range map[string]string{
+		"owner.tenant_id":          query.Scope.TenantID,
+		"owner.business_domain_id": firstNonEmpty(query.BusinessDomain, query.Scope.BusinessDomain),
+	} {
+		if value != "" {
+			must = append(must, exactKeywordQuery(field, value))
+		}
+	}
+	must = append(must, map[string]any{"terms": map[string]any{"interaction_id.keyword": interactionIDs}})
+	body, err := json.Marshal(map[string]any{
+		"size":  size,
+		"query": map[string]any{"bool": map[string]any{"must": must}},
+		"sort":  []map[string]any{{"issued_at": map[string]any{"order": "desc"}}, {"_id": map[string]any{"order": "desc"}}},
+	})
+	if err != nil {
+		return nil, false, err
+	}
+	responseBody, err := s.client.Search(ctx, s.index, body)
+	if err != nil {
+		return nil, false, err
+	}
+	var response struct {
+		Hits struct {
+			Hits []struct {
+				Source receiptDocument `json:"_source"`
+			} `json:"hits"`
+		} `json:"hits"`
+	}
+	if err := json.Unmarshal(responseBody, &response); err != nil {
+		return nil, false, fmt.Errorf("decode Core interaction receipt projection: %w", err)
+	}
+	result := make([]receiptDocument, 0, len(response.Hits.Hits))
+	for _, hit := range response.Hits.Hits {
+		result = append(result, hit.Source)
+	}
+	return result, len(response.Hits.Hits) >= size, nil
+}
+
+func hasExactReceiptSelector(query iprojectionsource.Query) bool {
+	return query.RequestID != "" || query.TraceID != "" || query.InteractionID != ""
+}
+
+func receiptInteractionIDs(receipts []receiptDocument) []string {
+	seen := make(map[string]struct{})
+	for _, receipt := range receipts {
+		if receipt.InteractionID != "" {
+			seen[receipt.InteractionID] = struct{}{}
+		}
+	}
+	result := make([]string, 0, len(seen))
+	for interactionID := range seen {
+		result = append(result, interactionID)
+	}
+	sort.Strings(result)
+	return result
+}
+
+func receiptsByInteraction(receipts []receiptDocument) map[string][]receiptDocument {
+	result := make(map[string][]receiptDocument)
+	for _, receipt := range receipts {
+		if receipt.InteractionID != "" {
+			result[receipt.InteractionID] = append(result[receipt.InteractionID], receipt)
+		}
+	}
+	return result
+}
+
+func interactionMatchesScope(receipts []receiptDocument, scope evidencevo.QueryScope) bool {
+	if len(receipts) == 0 {
+		return false
+	}
+	networks := make(map[string]struct{})
+	for _, receipt := range receipts {
+		for _, networkID := range receiptKnowledgeNetworks(receipt) {
+			networks[networkID] = struct{}{}
+		}
+	}
+	knowledgeNetworkIDs := make([]string, 0, len(networks))
+	for networkID := range networks {
+		knowledgeNetworkIDs = append(knowledgeNetworkIDs, networkID)
+	}
+	record := evidencevo.RecordScope{
+		TenantID:               receipts[0].Owner.TenantID,
+		BusinessDomain:         receipts[0].Owner.BusinessDomainID,
+		EffectiveSubjectID:     receipts[0].Owner.EffectiveSubjectID,
+		ApplicationPrincipalID: receipts[0].Owner.ApplicationPrincipalID,
+		KnowledgeNetworkIDs:    knowledgeNetworkIDs,
+	}
+	if scope.AccessProfile != nil {
+		return evidencevo.CanReadRecord(*scope.AccessProfile, record, evidencevo.AccessViewBusiness)
+	}
+	return receiptMatchesScope(receipts[0], scope)
+}
+
+func matchesReceiptQuery(receipt receiptDocument, query iprojectionsource.Query) bool {
+	if query.RequestID != "" && receipt.RequestID != query.RequestID ||
+		query.TraceID != "" && receipt.TraceID != query.TraceID ||
+		query.InteractionID != "" && receipt.InteractionID != query.InteractionID ||
+		query.BusinessDomain != "" && receipt.Owner.BusinessDomainID != query.BusinessDomain {
+		return false
+	}
+	if query.From.IsZero() && query.To.IsZero() {
+		return true
+	}
+	issuedAt, err := time.Parse(time.RFC3339Nano, receipt.IssuedAt)
+	if err != nil {
+		return false
+	}
+	return (query.From.IsZero() || !issuedAt.Before(query.From)) &&
+		(query.To.IsZero() || !issuedAt.After(query.To))
 }
 
 func exactKeywordQuery(field string, value string) map[string]any {

--- a/bkn-trace/agent-observability/src/drivenadapter/httpaccess/opensearchcoreprojection/source_test.go
+++ b/bkn-trace/agent-observability/src/drivenadapter/httpaccess/opensearchcoreprojection/source_test.go
@@ -19,10 +19,12 @@ import (
 func TestSourceBuildsAuthorizedExecutionProjectionFromCoreReceiptsAndArtifacts(t *testing.T) {
 	t.Parallel()
 
+	searches := 0
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path != "/bkn-trace-core/_search" {
 			t.Fatalf("unexpected path: %s", r.URL.Path)
 		}
+		searches++
 		body, _ := io.ReadAll(r.Body)
 		if !json.Valid(body) {
 			t.Fatalf("invalid search body: %s", body)
@@ -31,20 +33,22 @@ func TestSourceBuildsAuthorizedExecutionProjectionFromCoreReceiptsAndArtifacts(t
 		if strings.Contains(queryBody, "match_phrase") {
 			t.Fatalf("authorization filters must not use analyzed phrase matching: %s", body)
 		}
-		for _, field := range []string{
-			"owner.tenant_id.keyword", "owner.business_domain_id.keyword",
-			"request_id.keyword", "trace_id.keyword", "interaction_id.keyword",
-		} {
-			if !strings.Contains(queryBody, field) {
-				t.Fatalf("identifier filter %q must use exact keyword matching: %s", field, body)
+		if searches == 1 {
+			for _, field := range []string{
+				"owner.tenant_id.keyword", "owner.business_domain_id.keyword",
+				"request_id.keyword", "trace_id.keyword", "interaction_id.keyword",
+			} {
+				if !strings.Contains(queryBody, field) {
+					t.Fatalf("identifier filter %q must use exact keyword matching: %s", field, body)
+				}
 			}
-		}
-		for _, field := range []string{
-			"owner.tenant_id", "owner.business_domain_id",
-			"request_id", "trace_id", "interaction_id",
-		} {
-			if strings.Contains(queryBody, `"`+field+`":{"value"`) {
-				t.Fatalf("identifier filter %q must not query the analyzed text field: %s", field, body)
+			for _, field := range []string{
+				"owner.tenant_id", "owner.business_domain_id",
+				"request_id", "trace_id", "interaction_id",
+			} {
+				if strings.Contains(queryBody, `"`+field+`":{"value"`) {
+					t.Fatalf("identifier filter %q must not query the analyzed text field: %s", field, body)
+				}
 			}
 		}
 		_, _ = io.WriteString(w, `{
@@ -111,12 +115,12 @@ func TestSourceBuildsAuthorizedExecutionProjectionFromCoreReceiptsAndArtifacts(t
 	if err != nil {
 		t.Fatalf("load projection: %v", err)
 	}
-	if len(result.Traces) != 2 {
-		t.Fatalf("expected two traces, got %#v", result.Traces)
+	if len(result.Traces) != 1 {
+		t.Fatalf("expected the requested trace only, got %#v", result.Traces)
 	}
 	for _, trace := range result.Traces {
 		if trace.ConversationID != "conv-1" || len(trace.Events) != 3 {
-			t.Fatalf("each call must inherit the interaction question/result: %#v", trace)
+			t.Fatalf("the requested call must inherit the interaction question/result: %#v", trace)
 		}
 	}
 	trace := result.Traces[0]
@@ -128,12 +132,12 @@ func TestSourceBuildsAuthorizedExecutionProjectionFromCoreReceiptsAndArtifacts(t
 	if len(trace.KnowledgeNetworkIDs) != 1 || trace.KnowledgeNetworkIDs[0] != "supplychain_hd0202" {
 		t.Fatalf("knowledge network was not derived: %#v", trace.KnowledgeNetworkIDs)
 	}
-	if len(result.Artifacts) != 4 {
+	if len(result.Artifacts) != 2 {
 		t.Fatalf("authorized artifacts were not preserved: %#v", result.Artifacts)
 	}
 	requests, _ := evidencevo.BuildExecutionSummaries(result.Traces, result.Artifacts)
-	if len(requests) != 2 {
-		t.Fatalf("expected two request summaries, got %#v", requests)
+	if len(requests) != 1 {
+		t.Fatalf("expected one request summary, got %#v", requests)
 	}
 	for _, request := range requests {
 		if request.DurationMS != 1000 {
@@ -183,7 +187,8 @@ func TestRequestProjectionHydratesArtifactsByReceiptInteraction(t *testing.T) {
 	if err != nil {
 		t.Fatalf("load request projection: %v", err)
 	}
-	if len(artifacts.queries) != 1 || artifacts.queries[0].InteractionID != "int-1" || artifacts.queries[0].RequestID != "" {
+	if len(artifacts.queries) != 1 || len(artifacts.queries[0].AuthorizedInteractionIDs) != 1 ||
+		artifacts.queries[0].AuthorizedInteractionIDs[0] != "int-1" || artifacts.queries[0].RequestID != "" {
 		t.Fatalf("request artifacts must be hydrated from receipt interaction: %+v", artifacts.queries)
 	}
 	if len(result.Traces) != 1 || len(result.Traces[0].Events) != 2 || len(result.Artifacts) != 1 {
@@ -194,10 +199,12 @@ func TestRequestProjectionHydratesArtifactsByReceiptInteraction(t *testing.T) {
 func TestSourceUsesManagedKnowledgeNetworksAsBusinessCandidates(t *testing.T) {
 	t.Parallel()
 
+	searches := 0
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		searches++
 		body, _ := io.ReadAll(r.Body)
-		if !strings.Contains(string(body), `"knowledge_network_ids.keyword"`) ||
-			!strings.Contains(string(body), `"kn-managed"`) {
+		if searches == 1 && (!strings.Contains(string(body), `"knowledge_network_ids.keyword"`) ||
+			!strings.Contains(string(body), `"kn-managed"`)) {
 			t.Fatalf("managed KN candidate filter missing: %s", body)
 		}
 		_, _ = io.WriteString(w, `{"hits":{"hits":[{"_source":{
@@ -233,13 +240,113 @@ func TestSourceUsesManagedKnowledgeNetworksAsBusinessCandidates(t *testing.T) {
 	}
 }
 
+func TestSourceProjectsAuthorizedInteractionForManagedBuilder(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = io.WriteString(w, `{"hits":{"hits":[{"_source":{
+			"receipt_id":"rcpt-schema","schema_version":"3.0.0",
+			"owner":{"tenant_id":"tenant-1","business_domain_id":"domain-1","application_principal_id":"cursor","effective_subject_type":"user","effective_subject_id":"admin"},
+			"conversation_id":"conv-1","interaction_id":"int-1","operation_id":"op-schema",
+			"tool_name":"search_schema","receipt_status":"completed","evidence_durability":"durable",
+			"request_id":"req-schema","trace_id":"11111111111111111111111111111111",
+			"knowledge_network_ids":["kn-managed"],
+			"issued_at":"2026-08-02T07:35:26Z","terminal_at":"2026-08-02T07:35:27Z"
+		}}, {"_source":{
+			"receipt_id":"rcpt-sql","schema_version":"3.0.0",
+			"owner":{"tenant_id":"tenant-1","business_domain_id":"domain-1","application_principal_id":"cursor","effective_subject_type":"user","effective_subject_id":"admin"},
+			"conversation_id":"conv-1","interaction_id":"int-1","operation_id":"op-sql",
+			"tool_name":"run_sql","receipt_status":"completed","evidence_durability":"durable",
+			"request_id":"req-sql","trace_id":"22222222222222222222222222222222",
+			"business_refs":[{"ref_type":"data_resource","ref_id":"resource:inventory","business_domain_id":"domain-1","version":"v1"}],
+			"issued_at":"2026-08-02T07:35:28Z","terminal_at":"2026-08-02T07:35:29Z"
+		}}]}}`)
+	}))
+	t.Cleanup(server.Close)
+
+	artifacts := artifactProjectionSource{result: iprojectionsource.Result{Artifacts: []evidencevo.EvidenceArtifact{
+		{
+			ArtifactID: "question-1", ArtifactType: evidencevo.ArtifactTypeQuestion,
+			RequestID: "req-start", InteractionID: "int-1", Content: "查询库存",
+			ObservedAt: "2026-08-02T07:35:25Z", TenantID: "tenant-1", BusinessDomain: "domain-1",
+			AccountID: "admin", AccountType: "user",
+		},
+		{
+			ArtifactID: "result-1", ArtifactType: evidencevo.ArtifactTypeResult,
+			RequestID: "req-finish", InteractionID: "int-1", Content: "库存为 100",
+			ObservedAt: "2026-08-02T07:35:30Z", TenantID: "tenant-1", BusinessDomain: "domain-1",
+			AccountID: "admin", AccountType: "user",
+		},
+	}}}
+	source := opensearchcoreprojection.New(
+		opensearch.New(server.URL, opensearch.AuthConfig{}, time.Second), "bkn-trace-core", artifacts,
+	)
+
+	result, err := source.LoadExecutionProjection(context.Background(), iprojectionsource.Query{
+		InteractionID: "int-1",
+		Scope: evidencevo.QueryScope{AccessProfile: &evidencevo.AccessProfile{
+			TenantID: "tenant-1", BusinessDomain: "domain-1", EffectiveSubjectID: "builder",
+			Roles: []string{"network_builder"}, ManagedKnowledgeNetworkIDs: []string{"kn-managed"},
+			AccountActive: true, TenantActive: true,
+		}},
+	})
+	if err != nil {
+		t.Fatalf("load projection: %v", err)
+	}
+	if len(result.Traces) != 2 {
+		t.Fatalf("authorized builder must receive every operation in the interaction, got %#v", result.Traces)
+	}
+	if len(result.Artifacts) != 4 {
+		t.Fatalf("authorized builder must receive interaction question and result for every operation, got %#v", result.Artifacts)
+	}
+}
+
+func TestSourceDoesNotDiscloseInteractionWithUnmanagedKnowledgeNetwork(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = io.WriteString(w, `{"hits":{"hits":[{"_source":{
+			"receipt_id":"rcpt-managed","schema_version":"3.0.0",
+			"owner":{"tenant_id":"tenant-1","business_domain_id":"domain-1","effective_subject_type":"user","effective_subject_id":"owner"},
+			"interaction_id":"int-1","operation_id":"op-managed","tool_name":"search_schema",
+			"request_id":"req-managed","trace_id":"11111111111111111111111111111111",
+			"knowledge_network_ids":["kn-managed"],"issued_at":"2026-08-02T07:35:26Z"
+		}}, {"_source":{
+			"receipt_id":"rcpt-unmanaged","schema_version":"3.0.0",
+			"owner":{"tenant_id":"tenant-1","business_domain_id":"domain-1","effective_subject_type":"user","effective_subject_id":"owner"},
+			"interaction_id":"int-1","operation_id":"op-unmanaged","tool_name":"search_schema",
+			"request_id":"req-unmanaged","trace_id":"22222222222222222222222222222222",
+			"knowledge_network_ids":["kn-unmanaged"],"issued_at":"2026-08-02T07:35:27Z"
+		}}]}}`)
+	}))
+	t.Cleanup(server.Close)
+
+	source := opensearchcoreprojection.New(opensearch.New(server.URL, opensearch.AuthConfig{}, time.Second), "bkn-trace-core", nil)
+	result, err := source.LoadExecutionProjection(context.Background(), iprojectionsource.Query{
+		InteractionID: "int-1",
+		Scope: evidencevo.QueryScope{AccessProfile: &evidencevo.AccessProfile{
+			TenantID: "tenant-1", BusinessDomain: "domain-1", EffectiveSubjectID: "builder",
+			Roles: []string{"network_builder"}, ManagedKnowledgeNetworkIDs: []string{"kn-managed"},
+			AccountActive: true, TenantActive: true,
+		}},
+	})
+	if err != nil {
+		t.Fatalf("load projection: %v", err)
+	}
+	if len(result.Traces) != 0 || len(result.Artifacts) != 0 {
+		t.Fatalf("partially managed interaction must not be disclosed: %#v", result)
+	}
+}
+
 func TestSourceUsesApplicationPrincipalAsTechnicalOwnerCandidate(t *testing.T) {
 	t.Parallel()
 
+	searches := 0
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		searches++
 		body, _ := io.ReadAll(r.Body)
-		if !strings.Contains(string(body), `"owner.application_principal_id.keyword"`) ||
-			!strings.Contains(string(body), `"app-a"`) {
+		if searches == 1 && (!strings.Contains(string(body), `"owner.application_principal_id.keyword"`) ||
+			!strings.Contains(string(body), `"app-a"`)) {
 			t.Fatalf("application owner candidate missing: %s", body)
 		}
 		_, _ = io.WriteString(w, `{"hits":{"hits":[{"_source":{

--- a/bkn-trace/agent-observability/src/drivenadapter/httpaccess/opensearchevidencestore/projection_source.go
+++ b/bkn-trace/agent-observability/src/drivenadapter/httpaccess/opensearchevidencestore/projection_source.go
@@ -143,7 +143,7 @@ func (s *Store) listArtifactProjection(ctx context.Context, query iprojectionsou
 	}
 	artifacts := make([]evidencevo.EvidenceArtifact, 0, len(allHits))
 	for _, hit := range allHits {
-		if evidencevo.MatchesArtifactScope(hit.Source, query.Scope) && matchesProjectionArtifact(hit.Source, query) {
+		if artifactMatchesProjectionScope(hit.Source, query) && matchesProjectionArtifact(hit.Source, query) {
 			artifacts = append(artifacts, hit.Source)
 		}
 	}
@@ -208,7 +208,12 @@ type artifactProjectionHit struct {
 }
 
 func (s *Store) listArtifactProjectionPage(ctx context.Context, query iprojectionsource.Query, searchAfter []any, size int) ([]artifactProjectionHit, error) {
-	must := appendProjectionIdentityFilters(ownershipMust(query.Scope), query)
+	must := ownershipMust(query.Scope)
+	if len(query.AuthorizedInteractionIDs) > 0 {
+		must = scopeBoundaryMust(query.Scope)
+		must = append(must, map[string]any{"terms": map[string]any{"interaction_id": query.AuthorizedInteractionIDs}})
+	}
+	must = appendProjectionIdentityFilters(must, query)
 	if query.InteractionID != "" {
 		must = append(must, map[string]any{"bool": exactTermQuery("interaction_id", query.InteractionID)})
 	}
@@ -261,6 +266,15 @@ func (s *Store) listArtifactProjectionPage(ctx context.Context, query iprojectio
 		hits = append(hits, artifactProjectionHit{Source: artifact, Sort: hit.Sort})
 	}
 	return hits, nil
+}
+
+func artifactMatchesProjectionScope(artifact evidencevo.EvidenceArtifact, query iprojectionsource.Query) bool {
+	for _, interactionID := range query.AuthorizedInteractionIDs {
+		if artifact.InteractionID == interactionID {
+			return true
+		}
+	}
+	return evidencevo.MatchesArtifactScope(artifact, query.Scope)
 }
 
 func projectionPageSize(limit, loaded int) int {

--- a/bkn-trace/agent-observability/src/drivenadapter/httpaccess/opensearchevidencestore/scope_query.go
+++ b/bkn-trace/agent-observability/src/drivenadapter/httpaccess/opensearchevidencestore/scope_query.go
@@ -3,18 +3,7 @@ package opensearchevidencestore
 import "github.com/openbkn-ai/bkn-foundry/bkn-trace/agent-observability/src/domain/valueobject/evidencevo"
 
 func scopeCandidateMust(scope evidencevo.QueryScope) []map[string]any {
-	must := make([]map[string]any, 0, 3)
-	for _, item := range []struct {
-		field string
-		value string
-	}{
-		{"bkn.tenant.id", scope.TenantID},
-		{"business_domain", scope.BusinessDomain},
-	} {
-		if item.value != "" {
-			must = append(must, map[string]any{"bool": exactTermQuery(item.field, item.value)})
-		}
-	}
+	must := scopeBoundaryMust(scope)
 
 	if scope.AccessProfile == nil {
 		return appendLegacyOwnerMust(must, scope)
@@ -49,6 +38,22 @@ func scopeCandidateMust(scope evidencevo.QueryScope) []map[string]any {
 	return append(must, map[string]any{"bool": map[string]any{
 		"should": should, "minimum_should_match": 1,
 	}})
+}
+
+func scopeBoundaryMust(scope evidencevo.QueryScope) []map[string]any {
+	must := make([]map[string]any, 0, 2)
+	for _, item := range []struct {
+		field string
+		value string
+	}{
+		{"bkn.tenant.id", scope.TenantID},
+		{"business_domain", scope.BusinessDomain},
+	} {
+		if item.value != "" {
+			must = append(must, map[string]any{"bool": exactTermQuery(item.field, item.value)})
+		}
+	}
+	return must
 }
 
 func appendLegacyOwnerMust(must []map[string]any, scope evidencevo.QueryScope) []map[string]any {

--- a/bkn-trace/agent-observability/src/port/driven/iprojectionsource/port.go
+++ b/bkn-trace/agent-observability/src/port/driven/iprojectionsource/port.go
@@ -16,7 +16,10 @@ type Query struct {
 	RequestID      string
 	TraceID        string
 	InteractionID  string
-	Limit          int
+	// AuthorizedInteractionIDs is an internal handoff from the Core projection.
+	// It carries an Interaction-level authorization decision to its artifact reader.
+	AuthorizedInteractionIDs []string
+	Limit                    int
 }
 
 type Result struct {


### PR DESCRIPTION
## What Changed

- [x] Aggregate an Interaction's knowledge-network scope before business-provenance authorization.
- [x] Return every authorized operation and its question/result artifacts without receipt-level filtering.
- [x] Add regression coverage for complete disclosure and partial-management denial.

---

## Why

- Related Issue: Closes #740
- Background: the same Interaction returned complete business semantics to its owner but only IDs to a network manager because receipts and artifacts were independently authorized.

---

## How

- Candidate receipts locate Interactions; a bounded second read hydrates each candidate Interaction before one access decision.
- Artifact hydration accepts only Interaction IDs already authorized by Core, while retaining tenant and business-domain boundaries.
- Breaking changes: none.

---

## Testing

- [x] Unit tests passed locally
- [x] Integration tests passed locally
- [ ] Verified in test environment

Test notes: `go test ./...` in `bkn-trace/agent-observability` passed.

---

## Risk & Rollback

- Potential risks: projection reads perform one additional bounded Core query per candidate Interaction set.
- Rollback plan: revert this PR; no API, schema, configuration, or data migration is involved.

---

## Additional Notes

- The corresponding authorization-contract clarification is in the linked bkn-docs PR.