### PR TITLE
fix(trace): load artifacts through authorized interaction

### DIFF
--- a/bkn-trace/agent-observability/docs/swagger/docs.go
+++ b/bkn-trace/agent-observability/docs/swagger/docs.go
@@ -1274,7 +1274,7 @@ const docTemplate = `{
         },
         "/evidence/artifacts/{artifact_id}": {
             "get": {
-                "description": "Returns artifact content only when all persisted ownership dimensions match the trusted query identity.",
+                "description": "Returns an artifact through its own record scope, or through an authorized Interaction when interaction_id is supplied.",
                 "produces": [
                     "application/json"
                 ],
@@ -1289,6 +1289,12 @@ const docTemplate = `{
                         "name": "artifact_id",
                         "in": "path",
                         "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Authorized Interaction ID",
+                        "name": "interaction_id",
+                        "in": "query"
                     }
                 ],
                 "responses": {

--- a/bkn-trace/agent-observability/docs/swagger/swagger.json
+++ b/bkn-trace/agent-observability/docs/swagger/swagger.json
@@ -1266,7 +1266,7 @@
         },
         "/evidence/artifacts/{artifact_id}": {
             "get": {
-                "description": "Returns artifact content only when all persisted ownership dimensions match the trusted query identity.",
+                "description": "Returns an artifact through its own record scope, or through an authorized Interaction when interaction_id is supplied.",
                 "produces": [
                     "application/json"
                 ],
@@ -1281,6 +1281,12 @@
                         "name": "artifact_id",
                         "in": "path",
                         "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Authorized Interaction ID",
+                        "name": "interaction_id",
+                        "in": "query"
                     }
                 ],
                 "responses": {

--- a/bkn-trace/agent-observability/src/domain/service/evidencesvc/artifact_service_test.go
+++ b/bkn-trace/agent-observability/src/domain/service/evidencesvc/artifact_service_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/openbkn-ai/bkn-foundry/bkn-trace/agent-observability/src/domain/valueobject/evidencevo"
 	"github.com/openbkn-ai/bkn-foundry/bkn-trace/agent-observability/src/drivenadapter/memoryaccess/evidencestore"
 	"github.com/openbkn-ai/bkn-foundry/bkn-trace/agent-observability/src/port/driven/ibusinessresolver"
+	"github.com/openbkn-ai/bkn-foundry/bkn-trace/agent-observability/src/port/driven/iprojectionsource"
 )
 
 func TestIngestArtifactStoresNormalizedContentAndIsIdempotent(t *testing.T) {
@@ -72,6 +73,39 @@ func TestGetArtifactReturnsOnlyArtifactVisibleToScope(t *testing.T) {
 	})
 	if err != nil || found {
 		t.Fatalf("query without tenant or business domain must fail closed: found=%v err=%v", found, err)
+	}
+}
+
+func TestGetArtifactForAuthorizedInteractionReturnsArtifactToManagedBuilder(t *testing.T) {
+	store := evidencestore.New()
+	artifact, validationErrors := evidencevo.NormalizeArtifact(evidencevo.EvidenceArtifact{
+		ArtifactID: "artifact_interaction_result", ArtifactType: evidencevo.ArtifactTypeResult,
+		RequestID: "req_interaction_result", TraceID: "4bf92f3577b34da6a3ce929d0e0e4736",
+		InteractionID: "int-1", ContentType: "application/json", SchemaVersion: evidencevo.ArtifactContractVersion,
+		ObservedAt: "2026-08-07T15:00:00Z", Content: map[string]any{"summary": "库存为 100"},
+		TenantID: "tenant_demo", BusinessDomain: "bd_demo", AccountID: "owner", AccountType: "app",
+	})
+	if len(validationErrors) != 0 {
+		t.Fatalf("normalize artifact: %+v", validationErrors)
+	}
+	if _, err := store.StoreArtifact(context.Background(), artifact); err != nil {
+		t.Fatal(err)
+	}
+	projection := &artifactInteractionProjection{result: iprojectionsource.Result{Artifacts: []evidencevo.EvidenceArtifact{artifact}}}
+	service := New(store, WithProjectionSource(projection))
+	scope := evidencevo.QueryScope{AccessProfile: &evidencevo.AccessProfile{
+		TenantID: "tenant_demo", BusinessDomain: "bd_demo", EffectiveSubjectID: "builder",
+		Roles: []string{"network_builder"}, ManagedKnowledgeNetworkIDs: []string{"kn-managed"},
+		AccountActive: true, TenantActive: true,
+	}}
+
+	got, found, err := service.GetArtifactForInteraction(context.Background(), artifact.ArtifactID, "int-1", scope)
+
+	if err != nil || !found || got.Content == nil {
+		t.Fatalf("authorized interaction must disclose artifact: artifact=%+v found=%v err=%v", got, found, err)
+	}
+	if len(projection.queries) != 1 || projection.queries[0].InteractionID != "int-1" {
+		t.Fatalf("artifact fallback must use the authorized interaction only: %+v", projection.queries)
 	}
 }
 
@@ -252,4 +286,14 @@ func hasErrorCode(errors evidencevo.ValidationErrors, code string) bool {
 		}
 	}
 	return false
+}
+
+type artifactInteractionProjection struct {
+	result  iprojectionsource.Result
+	queries []iprojectionsource.Query
+}
+
+func (s *artifactInteractionProjection) LoadExecutionProjection(_ context.Context, query iprojectionsource.Query) (iprojectionsource.Result, error) {
+	s.queries = append(s.queries, query)
+	return s.result, nil
 }

--- a/bkn-trace/agent-observability/src/domain/service/evidencesvc/service.go
+++ b/bkn-trace/agent-observability/src/domain/service/evidencesvc/service.go
@@ -348,6 +348,33 @@ func (s *Service) GetArtifact(ctx context.Context, artifactID string, scope evid
 	return artifact, true, nil
 }
 
+// GetArtifactForInteraction resolves an artifact through an Interaction that has
+// already been selected by the caller. The projection source performs the
+// Interaction-level access decision before any artifact content is returned.
+func (s *Service) GetArtifactForInteraction(
+	ctx context.Context,
+	artifactID string,
+	interactionID string,
+	scope evidencevo.QueryScope,
+) (evidencevo.EvidenceArtifact, bool, error) {
+	artifact, found, err := s.GetArtifact(ctx, artifactID, scope)
+	if err != nil || found || interactionID == "" || s.projectionSource == nil {
+		return artifact, found, err
+	}
+	result, err := s.projectionSource.LoadExecutionProjection(ctx, iprojectionsource.Query{
+		Scope: scope, InteractionID: interactionID, Limit: MaxEvidenceQueryLimit,
+	})
+	if err != nil {
+		return evidencevo.EvidenceArtifact{}, false, err
+	}
+	for _, candidate := range result.Artifacts {
+		if candidate.ArtifactID == artifactID {
+			return candidate, true, nil
+		}
+	}
+	return evidencevo.EvidenceArtifact{}, false, nil
+}
+
 func artifactMatchesTrace(artifact evidencevo.EvidenceArtifact, trace evidencevo.NormalizedTrace) bool {
 	return artifact.TraceID == trace.TraceID &&
 		artifact.RequestID == trace.RequestID &&

--- a/bkn-trace/agent-observability/src/driveradapter/api/httphandler/evidence_handler.go
+++ b/bkn-trace/agent-observability/src/driveradapter/api/httphandler/evidence_handler.go
@@ -218,10 +218,11 @@ func (h *EvidenceHandler) IngestEvidenceArtifact(w http.ResponseWriter, r *http.
 
 // GetEvidenceArtifact godoc
 // @Summary Get an authorized evidence artifact by ID
-// @Description Returns artifact content only when all persisted ownership dimensions match the trusted query identity.
+// @Description Returns an artifact through its own record scope, or through an authorized Interaction when interaction_id is supplied.
 // @Tags evidence
 // @Produce json
 // @Param artifact_id path string true "Artifact ID"
+// @Param interaction_id query string false "Authorized Interaction ID"
 // @Success 200 {object} evidencevo.EvidenceArtifact
 // @Failure 400 {object} rdto.ErrorResponse
 // @Failure 401 {object} rdto.ErrorResponse
@@ -243,7 +244,9 @@ func (h *EvidenceHandler) GetEvidenceArtifact(w http.ResponseWriter, r *http.Req
 	if !ok {
 		return
 	}
-	artifact, found, err := h.evidenceService.GetArtifact(r.Context(), artifactID, options.Scope)
+	artifact, found, err := h.evidenceService.GetArtifactForInteraction(
+		r.Context(), artifactID, strings.TrimSpace(r.URL.Query().Get("interaction_id")), options.Scope,
+	)
 	if err != nil {
 		writeJSON(w, http.StatusInternalServerError, rdto.ErrorResponse{Code: "QUERY_FAILED", Message: "failed to query evidence artifact"})
 		return

--- a/docs/api/agent-observability/agent-observability.yaml
+++ b/docs/api/agent-observability/agent-observability.yaml
@@ -2747,13 +2747,17 @@ paths:
       - evidence
   /evidence/artifacts/{artifact_id}:
     get:
-      description: Returns artifact content only when all persisted ownership dimensions
-        match the trusted query identity.
+      description: Returns an artifact through its own record scope, or through an
+        authorized Interaction when interaction_id is supplied.
       parameters:
       - description: Artifact ID
         in: path
         name: artifact_id
         required: true
+        type: string
+      - description: Authorized Interaction ID
+        in: query
+        name: interaction_id
         type: string
       produces:
       - application/json


### PR DESCRIPTION
## Summary
- resolve evidence artifacts through an already authorized Interaction when the interaction_id query parameter is supplied
- retain strict standalone artifact authorization without an Interaction context
- document the optional query parameter in the published OpenAPI contract

## Verification
- go test ./...
- make check-swag

Closes #743