### PR TITLE
fix(vega): 内置连接器类型被关掉后，迁移得能把它开回来

### DIFF
--- a/migrations/vega-backend/mariadb/0.1.3/05-enable-builtin-connector-types.sql
+++ b/migrations/vega-backend/mariadb/0.1.3/05-enable-builtin-connector-types.sql
@@ -1,0 +1,37 @@
+-- Copyright 2026 openbkn.ai
+-- Copyright The kweaver.ai Authors.
+--
+-- Licensed under the Apache License, Version 2.0.
+
+-- Turn the built-in connector types back on, once.
+--
+-- Every INSERT that seeds a built-in type is guarded by
+-- "WHERE NOT EXISTS (... f_type = ...)", so it creates and never corrects. That
+-- is right for what an operator configures, and wrong for what the product
+-- ships: a row created once with f_enabled = 0 stays off through every upgrade,
+-- and no migration can reach it. It happens easily — POST /connector-types
+-- takes f_enabled straight from the request body, so a caller that simply omits
+-- the field registers a built-in type disabled, permanently.
+--
+-- The symptom is a connector the product clearly supports showing up greyed out
+-- as "unavailable", with the implementation compiled in and the licence in
+-- order. Nothing in the logs says why.
+--
+-- Runs ONCE, which is the whole design. Deliberately disabling a connector has
+-- to keep working, so this must not be turned into a rule that re-asserts
+-- itself on every upgrade — that would take the switch away from the operator
+-- rather than fix it being stuck.
+--
+-- Scoped to the types this product seeds itself — the exact list the INSERTs in
+-- 0.1.0/init.sql and 0.1.3/{init,04-add-sqlserver-connector}.sql create. A type
+-- an operator registered is theirs, including whether it is on.
+--
+-- oracle is deliberately absent: the connector exists in the code but no
+-- migration seeds a row for it, so there is nothing here to correct.
+USE openbkn;
+
+UPDATE t_connector_type
+   SET f_enabled = TRUE
+ WHERE f_type IN ('mysql', 'mariadb', 'postgresql', 'sqlserver',
+                  'opensearch', 'anyshare')
+   AND f_enabled = FALSE;


### PR DESCRIPTION
## 现象

产品明明支持的连接器（这次是 SQL Server）在界面上灰着显示「暂不可用」——实现编进二进制了、证书也没问题，日志里什么都没有。

## 原因

seed 内置类型的 INSERT 全都带这个守卫：

```sql
FROM DUAL WHERE NOT EXISTS ( SELECT f_type FROM t_connector_type WHERE f_type = 'sqlserver' );
```

**只创建，不纠正**。对运维自己注册的连接器类型这是对的，对产品自带的类型是错的：一旦某行以 `f_enabled = 0` 建出来，之后每次升级都改不动它，也没有任何迁移够得着。

而这行很容易被建错——`connector_type_service.go` 的 `Register` 直接取请求体：

```go
Enabled: req.Enabled,
```

调用方少传这个字段，Go 零值就是 `false`，一个内置类型就此永久停用。

`04-add-sqlserver-connector.sql` 和 `init.sql` 里写的都是 `TRUE`，从来没有插过 `FALSE` 的版本——所以问题不在 seed 的值，在于它够不到已存在的行。

## 改法

加一条新迁移 `05-enable-builtin-connector-types.sql`，把内置类型里 `f_enabled = FALSE` 的置回 `TRUE`。

**只跑一次，这是设计不是偷懒**：故意停用某个连接器必须继续有效，所以不能写成每次升级都重新断言的规则——那是把开关从运维手里拿走，不是修好它卡住。

范围严格对齐 `0.1.0/init.sql` 与 `0.1.3/{init,04-add-sqlserver-connector}.sql` 实际 seed 的六个类型（mysql / mariadb / postgresql / sqlserver / opensearch / anyshare）。`oracle` 不在其中：代码里有这个连接器，但没有任何迁移为它建行，没有可纠正的对象。

## 手工绕过

已经踩到的部署不必等这条迁移：

```
POST /api/vega-backend/v1/connector-types/sqlserver/enable
```

## 尚未实测

改动是从代码推的（迁移文件历史、`Register` 的取值、`SetConnectorEnabled` 全仓唯一调用点）。验证机当前从我这边网络不可达，`t_connector_type` 里的实际值没能取证。合并前值得在一台复现过灰显的环境上跑一次确认。