### PR TITLE
fix(bkn,vega): mark internal S2S access on /in/ document endpoints and stop unsafe error assertion

### DIFF
--- a/adp/bkn/bkn-backend/server/driveradapters/object_type_handler.go
+++ b/adp/bkn/bkn-backend/server/driveradapters/object_type_handler.go
@@ -782,7 +782,12 @@ func (r *restHandler) DeleteObjectTypes(c *gin.Context) {
 	// 批量删除对象类
 	err = r.ots.DeleteObjectTypesByIDs(ctx, nil, knID, branch, otIDs)
 	if err != nil {
-		httpErr := err.(*rest.HTTPError)
+		// 兜底：下游若回普通 error，直接断言会 panic 成 502。归一为 500 再回。
+		httpErr, ok := err.(*rest.HTTPError)
+		if !ok {
+			httpErr = rest.NewHTTPError(ctx, http.StatusInternalServerError,
+				berrors.BknBackend_ObjectType_InternalError).WithErrorDetails(err.Error())
+		}
 		// 设置 trace 的错误信息的 attributes
 		oteltrace.AddHttpAttrs4HttpError(span, httpErr)
 		rest.ReplyError(c, httpErr)

--- a/adp/bkn/bkn-backend/server/driveradapters/object_type_handler_test.go
+++ b/adp/bkn/bkn-backend/server/driveradapters/object_type_handler_test.go
@@ -9,6 +9,7 @@ package driveradapters
 import (
 	"bytes"
 	"context"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -405,6 +406,26 @@ func Test_ObjectTypeRestHandler_DeleteObjectTypes(t *testing.T) {
 			engine.ServeHTTP(w, req)
 
 			So(w.Result().StatusCode, ShouldEqual, http.StatusInternalServerError)
+		})
+
+		// 下游（如 Vega）返回普通 error 时，handler 不得做裸类型断言：
+		// panic 会让连接在写响应头前断开，网关只能回 502。必须映射为可诊断的 500。
+		Convey("DeleteObjectTypes maps plain downstream error without panic\n", func() {
+			kns.EXPECT().CheckKNExistByID(gomock.Any(), knID, gomock.Any()).Return(knID, true, nil)
+			ots.EXPECT().CheckObjectTypeExistByID(gomock.Any(), knID, gomock.Any(), "ot1").Return("object1", true, nil)
+			ots.EXPECT().CheckObjectTypeExistByID(gomock.Any(), knID, gomock.Any(), "ot2").Return("object2", true, nil)
+			ots.EXPECT().DeleteObjectTypesByIDs(gomock.Any(), gomock.Any(), knID, gomock.Any(), gomock.Any()).
+				Return(errors.New("DeleteDatasetDocumentByID returned HTTP 403"))
+			rts.EXPECT().ListRelationTypes(gomock.Any(), gomock.Any()).Return([]*interfaces.RelationType{}, 0, nil)
+			ats.EXPECT().ListActionTypes(gomock.Any(), gomock.Any()).Return([]*interfaces.ActionType{}, 0, nil)
+
+			req := httptest.NewRequest(http.MethodDelete, url, nil)
+			w := httptest.NewRecorder()
+			engine.ServeHTTP(w, req)
+
+			So(w.Result().StatusCode, ShouldEqual, http.StatusInternalServerError)
+			// 断言错误码存在，用以区分「规范错误响应」与「Recovery 中间件兜住的 panic」。
+			So(w.Body.String(), ShouldContainSubstring, berrors.BknBackend_ObjectType_InternalError)
 		})
 	})
 }

--- a/adp/bkn/bkn-backend/server/logics/object_type/object_type_service.go
+++ b/adp/bkn/bkn-backend/server/logics/object_type/object_type_service.go
@@ -1209,7 +1209,15 @@ func (ots *objectTypeService) DeleteObjectTypesByIDs(ctx context.Context, tx *sq
 		if err != nil {
 			logger.Errorf("DeleteDatasetDocumentByID error: %s", err.Error())
 			span.SetStatus(codes.Error, "删除对象类概念索引失败")
-			return err
+
+			// Vega 返回的是普通 error，必须归一为 HTTPError 后再上抛，
+			// 否则 handler 侧的类型断言会 panic，连接在写响应头前断开，网关只能报 502。
+			var httpErr *rest.HTTPError
+			if errors.As(err, &httpErr) {
+				return httpErr
+			}
+			return rest.NewHTTPError(ctx, http.StatusInternalServerError,
+				berrors.BknBackend_ObjectType_InternalError).WithErrorDetails(err.Error())
 		}
 	}
 

--- a/adp/vega/vega-backend/server/driveradapters/resource_data_handler.go
+++ b/adp/vega/vega-backend/server/driveradapters/resource_data_handler.go
@@ -253,21 +253,27 @@ func (r *restHandler) PutResourceDataByEx(c *gin.Context) {
 	if err != nil {
 		return
 	}
-	r.putResourceData(c, visitor)
+	r.putResourceData(c, visitor, false)
 }
 
 // PutResourceDataByIn handles PUT /api/vega-backend/in/v1/resources/:id/data (Internal).
 func (r *restHandler) PutResourceDataByIn(c *gin.Context) {
 	visitor := visitor.GenerateVisitor(c)
-	r.putResourceData(c, visitor)
+	// 内网 /in/ 为集群内 S2S 边界：标记 S2S，使内部基础设施资源默认放行 per-account 鉴权。
+	r.putResourceData(c, visitor, true)
 }
 
-func (r *restHandler) putResourceData(c *gin.Context, visitor hydra.Visitor) {
+// putResourceData 批量 upsert 文档。s2sInternal 为 true 时（仅 /in/ 内网端点），
+// 内部目录资源跳过 per-account view_detail 校验。
+func (r *restHandler) putResourceData(c *gin.Context, visitor hydra.Visitor, s2sInternal bool) {
 	ctx, span := oteltrace.StartServerSpan(c)
 	defer span.End()
 
 	accountInfo := interfaces.AccountInfo{ID: visitor.ID, Type: string(visitor.Type)}
 	ctx = context.WithValue(ctx, interfaces.ACCOUNT_INFO_KEY, accountInfo)
+	if s2sInternal {
+		ctx = interfaces.WithS2SInternalAccess(ctx)
+	}
 	oteltrace.AddHttpAttrs4API(span, oteltrace.GetAttrsByGinCtx(c))
 
 	resource, ok := r.requireDatasetResource(c, ctx, span, c.Param("id"))
@@ -330,21 +336,27 @@ func (r *restHandler) GetResourceDataDocByEx(c *gin.Context) {
 	if err != nil {
 		return
 	}
-	r.getResourceDataDoc(c, visitor)
+	r.getResourceDataDoc(c, visitor, false)
 }
 
 // GetResourceDataDocByIn handles GET /api/vega-backend/in/v1/resources/:id/data/:doc_id (Internal).
 func (r *restHandler) GetResourceDataDocByIn(c *gin.Context) {
 	visitor := visitor.GenerateVisitor(c)
-	r.getResourceDataDoc(c, visitor)
+	// 内网 /in/ 为集群内 S2S 边界：标记 S2S，使内部基础设施资源默认放行 per-account 鉴权。
+	r.getResourceDataDoc(c, visitor, true)
 }
 
-func (r *restHandler) getResourceDataDoc(c *gin.Context, visitor hydra.Visitor) {
+// getResourceDataDoc 读取单个文档。s2sInternal 为 true 时（仅 /in/ 内网端点），
+// 内部目录资源跳过 per-account view_detail 校验。
+func (r *restHandler) getResourceDataDoc(c *gin.Context, visitor hydra.Visitor, s2sInternal bool) {
 	ctx, span := oteltrace.StartServerSpan(c)
 	defer span.End()
 
 	accountInfo := interfaces.AccountInfo{ID: visitor.ID, Type: string(visitor.Type)}
 	ctx = context.WithValue(ctx, interfaces.ACCOUNT_INFO_KEY, accountInfo)
+	if s2sInternal {
+		ctx = interfaces.WithS2SInternalAccess(ctx)
+	}
 	oteltrace.AddHttpAttrs4API(span, oteltrace.GetAttrsByGinCtx(c))
 
 	resource, ok := r.requireDatasetResource(c, ctx, span, c.Param("id"))
@@ -381,21 +393,27 @@ func (r *restHandler) PutResourceDataDocByEx(c *gin.Context) {
 	if err != nil {
 		return
 	}
-	r.putResourceDataDoc(c, visitor)
+	r.putResourceDataDoc(c, visitor, false)
 }
 
 // PutResourceDataDocByIn handles PUT /api/vega-backend/in/v1/resources/:id/data/:doc_id (Internal).
 func (r *restHandler) PutResourceDataDocByIn(c *gin.Context) {
 	visitor := visitor.GenerateVisitor(c)
-	r.putResourceDataDoc(c, visitor)
+	// 内网 /in/ 为集群内 S2S 边界：标记 S2S，使内部基础设施资源默认放行 per-account 鉴权。
+	r.putResourceDataDoc(c, visitor, true)
 }
 
-func (r *restHandler) putResourceDataDoc(c *gin.Context, visitor hydra.Visitor) {
+// putResourceDataDoc 更新单个文档。s2sInternal 为 true 时（仅 /in/ 内网端点），
+// 内部目录资源跳过 per-account view_detail 校验。
+func (r *restHandler) putResourceDataDoc(c *gin.Context, visitor hydra.Visitor, s2sInternal bool) {
 	ctx, span := oteltrace.StartServerSpan(c)
 	defer span.End()
 
 	accountInfo := interfaces.AccountInfo{ID: visitor.ID, Type: string(visitor.Type)}
 	ctx = context.WithValue(ctx, interfaces.ACCOUNT_INFO_KEY, accountInfo)
+	if s2sInternal {
+		ctx = interfaces.WithS2SInternalAccess(ctx)
+	}
 	oteltrace.AddHttpAttrs4API(span, oteltrace.GetAttrsByGinCtx(c))
 
 	resource, ok := r.requireDatasetResource(c, ctx, span, c.Param("id"))
@@ -444,21 +462,27 @@ func (r *restHandler) DeleteResourceDataByEx(c *gin.Context) {
 	if err != nil {
 		return
 	}
-	r.deleteResourceData(c, visitor)
+	r.deleteResourceData(c, visitor, false)
 }
 
 // DeleteResourceDataByIn handles DELETE /api/vega-backend/in/v1/resources/:id/data/:doc_ids (Internal).
 func (r *restHandler) DeleteResourceDataByIn(c *gin.Context) {
 	visitor := visitor.GenerateVisitor(c)
-	r.deleteResourceData(c, visitor)
+	// 内网 /in/ 为集群内 S2S 边界：标记 S2S，使内部基础设施资源默认放行 per-account 鉴权。
+	r.deleteResourceData(c, visitor, true)
 }
 
-func (r *restHandler) deleteResourceData(c *gin.Context, visitor hydra.Visitor) {
+// deleteResourceData 按 ID 批量删除文档。s2sInternal 为 true 时（仅 /in/ 内网端点），
+// 内部目录资源跳过 per-account view_detail 校验。
+func (r *restHandler) deleteResourceData(c *gin.Context, visitor hydra.Visitor, s2sInternal bool) {
 	ctx, span := oteltrace.StartServerSpan(c)
 	defer span.End()
 
 	accountInfo := interfaces.AccountInfo{ID: visitor.ID, Type: string(visitor.Type)}
 	ctx = context.WithValue(ctx, interfaces.ACCOUNT_INFO_KEY, accountInfo)
+	if s2sInternal {
+		ctx = interfaces.WithS2SInternalAccess(ctx)
+	}
 	oteltrace.AddHttpAttrs4API(span, oteltrace.GetAttrsByGinCtx(c))
 
 	resource, ok := r.requireDatasetResource(c, ctx, span, c.Param("id"))

--- a/adp/vega/vega-backend/server/driveradapters/resource_data_handler_test.go
+++ b/adp/vega/vega-backend/server/driveradapters/resource_data_handler_test.go
@@ -14,6 +14,7 @@ import (
 	"testing"
 
 	"github.com/gin-gonic/gin"
+	"github.com/openbkn-ai/bkn-comm-go/hydra"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
@@ -342,5 +343,119 @@ func Test_ResourceDataRestHandler_RequireDatasetResource(t *testing.T) {
 
 		require.Equal(t, http.StatusBadRequest, w.Result().StatusCode)
 		assert.Contains(t, w.Body.String(), "operation requires resource category=dataset")
+	})
+}
+
+// Test_ResourceDataRestHandler_S2SInternalAccessMarker 锁定 /in/ 与外部端点的鉴权语义差异：
+// 内网端点必须带 S2S 标记，否则内部基础设施数据集会按 per-account view_detail 校验而误拒 403；
+// 外部端点必须不带，否则等于让普通用户绕过资源鉴权。
+func Test_ResourceDataRestHandler_S2SInternalAccessMarker(t *testing.T) {
+	restoreGinMode := setGinMode()
+	defer restoreGinMode()
+
+	// captureS2S 记录 GetByID 收到的 ctx 是否被标记为 S2S 内部访问。
+	captureS2S := func(rs *vmock.MockResourceService, got *bool) {
+		rs.EXPECT().GetByID(gomock.Any(), "res-1").
+			DoAndReturn(func(ctx context.Context, _ string) (*interfaces.Resource, error) {
+				*got = interfaces.IsS2SInternalAccess(ctx)
+				return sampleDatasetResource(), nil
+			})
+	}
+
+	internalCases := []struct {
+		name       string
+		method     string
+		url        string
+		body       string
+		expectCode int
+		expectCall func(ds *vmock.MockDatasetService)
+	}{
+		{
+			name:       "DELETE /in/ documents by ids",
+			method:     http.MethodDelete,
+			url:        "/api/vega-backend/in/v1/resources/res-1/data/doc-1",
+			expectCode: http.StatusNoContent,
+			expectCall: func(ds *vmock.MockDatasetService) {
+				ds.EXPECT().DeleteDocuments(gomock.Any(), "res-1", "doc-1").Return(nil)
+			},
+		},
+		{
+			name:       "PUT /in/ documents",
+			method:     http.MethodPut,
+			url:        "/api/vega-backend/in/v1/resources/res-1/data",
+			body:       `[{"id":"doc-1"}]`,
+			expectCode: http.StatusOK,
+			expectCall: func(ds *vmock.MockDatasetService) {
+				ds.EXPECT().UpsertDocuments(gomock.Any(), "res-1", gomock.Any()).Return([]string{"doc-1"}, nil)
+			},
+		},
+		{
+			name:       "GET /in/ single document",
+			method:     http.MethodGet,
+			url:        "/api/vega-backend/in/v1/resources/res-1/data/doc-1",
+			expectCode: http.StatusOK,
+			expectCall: func(ds *vmock.MockDatasetService) {
+				ds.EXPECT().GetDocument(gomock.Any(), "res-1", "doc-1").Return(map[string]any{"id": "doc-1"}, nil)
+			},
+		},
+		{
+			name:       "PUT /in/ single document",
+			method:     http.MethodPut,
+			url:        "/api/vega-backend/in/v1/resources/res-1/data/doc-1",
+			body:       `{"title":"one"}`,
+			expectCode: http.StatusOK,
+			expectCall: func(ds *vmock.MockDatasetService) {
+				ds.EXPECT().UpsertDocuments(gomock.Any(), "res-1", gomock.Any()).Return([]string{"doc-1"}, nil)
+			},
+		},
+	}
+
+	for _, tc := range internalCases {
+		t.Run(tc.name+" marks S2S internal access", func(t *testing.T) {
+			engine, rs, ds, _ := setupResourceDataHandlerTest(t)
+
+			var gotS2S bool
+			captureS2S(rs, &gotS2S)
+			tc.expectCall(ds)
+
+			var bodyReader *strings.Reader
+			if tc.body != "" {
+				bodyReader = strings.NewReader(tc.body)
+			} else {
+				bodyReader = strings.NewReader("")
+			}
+			req := httptest.NewRequest(tc.method, tc.url, bodyReader)
+			if tc.body != "" {
+				req.Header.Set("Content-Type", "application/json")
+			}
+			w := httptest.NewRecorder()
+
+			engine.ServeHTTP(w, req)
+
+			require.Equal(t, tc.expectCode, w.Result().StatusCode)
+			assert.True(t, gotS2S, "internal /in/ endpoint must mark the context as S2S internal access")
+		})
+	}
+
+	// 外部端点走 OAuth 校验，无法经路由直达；直接调用内部方法验证 s2sInternal=false 的语义。
+	t.Run("external delete does not mark S2S internal access", func(t *testing.T) {
+		engine, rs, ds, _ := setupResourceDataHandlerTest(t)
+
+		var gotS2S bool
+		captureS2S(rs, &gotS2S)
+		ds.EXPECT().DeleteDocuments(gomock.Any(), "res-1", "doc-1").Return(nil)
+
+		handler := MockNewRestHandler(&common.AppSetting{}, nil, nil, rs, nil, ds, nil, nil, nil, nil, nil)
+		engine.DELETE("/ex/resources/:id/data/:doc_ids", func(c *gin.Context) {
+			handler.deleteResourceData(c, hydra.Visitor{ID: "user-1"}, false)
+		})
+
+		req := httptest.NewRequest(http.MethodDelete, "/ex/resources/res-1/data/doc-1", nil)
+		w := httptest.NewRecorder()
+
+		engine.ServeHTTP(w, req)
+
+		require.Equal(t, http.StatusNoContent, w.Result().StatusCode)
+		assert.False(t, gotS2S, "external endpoint must keep per-account authorization")
 	})
 }


### PR DESCRIPTION
Closes #748.

## Problem

A normal user with `modify` permission on a knowledge network got HTTP 502 when deleting an object type. Two defects chained:

1. Vega's internal `/in/` document endpoints (DELETE/PUT/GET) never marked the request as S2S internal access, so internal infrastructure datasets fell through to the per-account `view_detail` check. Business users never hold that permission on internal datasets, so Vega replied 403. Only the POST entry point set the marker (added in #77); the write/read-single paths were never covered.
2. BKN Backend asserted the downstream error with `err.(*rest.HTTPError)`. Vega's adapter returns a plain `error`, so the assertion panicked. The connection dropped before response headers were written, and the ingress surfaced 502.

The path was previously unreachable because normal users could not reach KN `modify`; the recent permission migration exposed it.

## Changes

**Vega** — `putResourceData`, `getResourceDataDoc`, `putResourceDataDoc` and `deleteResourceData` now take an explicit `s2sInternal bool`, matching `postResourceData`. `ByIn` handlers pass `true`, external handlers pass `false`. Making the parameter explicit means a future entry point that forgets it fails to compile rather than silently losing the marker.

**BKN** — the service layer normalizes Vega's plain error into an `*rest.HTTPError` before propagating, and the handler assertion gained an `ok` guard. Downstream failures now map to a diagnosable 500.

The other ~322 occurrences of the same bare-assertion pattern in bkn-backend are left alone; that is separate technical debt.

## Tests

Both new tests were confirmed to fail against the unfixed code before the fix was restored:
- Vega: reverting the DELETE marker fails with `internal /in/ endpoint must mark the context as S2S internal access`.
- BKN: reverting the guard trips `panic recovered: TypeAssertionError` under gin's Recovery middleware.

Coverage added:
- All four Vega `/in/` document endpoints must carry the S2S marker.
- The external delete path must **not** carry it, so per-account authorization is not weakened.
- A plain downstream error from the object-type delete path returns a 500 carrying an error code, distinguishing a well-formed error response from a recovered panic.

Green locally:

```
ok  vega-backend/driveradapters        3.007s
ok  vega-backend/logics/resource       2.232s
ok  bkn-backend/driveradapters         1.132s
ok  bkn-backend/logics/object_type     0.736s
```

Note: the `bkn-backend` packages fatal locally with `load locale dir ... no such file or directory` on `main` as well; the runs above required symlinking `locale` into the package directory. Pre-existing, unrelated to this change.

## Not covered

Verified locally only — not yet deployed to the test server.

🤖 Generated with [Claude Code](https://claude.com/claude-code)