### PR TITLE
chore(deploy): add 0.1.3 release manifest

### DIFF
--- a/deploy/release-manifests/0.1.3/bkn-foundry.yaml
+++ b/deploy/release-manifests/0.1.3/bkn-foundry.yaml
@@ -1,0 +1,61 @@
+# Release lockfile for bkn-foundry 0.1.3-release — pins the chart version of every
+# component that makes up the product. Consumed by:
+#     deploy.sh openbkn install --version=0.1.3-release
+# All charts are published at 0.1.3 by the v0.1.3 tag build.
+apiVersion: deploy.openbkn.ai/v0.1.3
+kind: VersionSet
+product: bkn-foundry
+version: 0.1.3
+source:
+  type: oci
+  registry: oci://ghcr.io/openbkn-ai/charts
+releases:
+  core-data-migrator:
+    chart: core-data-migrator
+    version: 0.1.3-release
+    stage: pre
+  bkn-safe:
+    chart: bkn-safe
+    version: 0.1.3-release
+  mf-model-manager:
+    chart: mf-model-manager
+    version: 0.1.3-release
+  mf-model-api:
+    chart: mf-model-api
+    version: 0.1.3-release
+  kafka-connect:
+    chart: kafka-connect
+    version: 0.1.3-release
+  vega-backend:
+    chart: vega-backend
+    version: 0.1.3-release
+  bkn-backend:
+    chart: bkn-backend
+    version: 0.1.3-release
+  ontology-query:
+    chart: ontology-query
+    version: 0.1.3-release
+  agent-operator-integration:
+    chart: agent-operator-integration
+    version: 0.1.3-release
+  oss-gateway-backend:
+    chart: oss-gateway-backend
+    version: 0.1.3-release
+  sandbox:
+    chart: sandbox
+    version: 0.1.3-release
+  agent-retrieval:
+    chart: agent-retrieval
+    version: 0.1.3-release
+  bkn-agent:
+    chart: bkn-agent
+    version: 0.1.3-release
+  agent-observability:
+    chart: agent-observability
+    version: 0.1.3-release
+  otelcol-contrib:
+    chart: otelcol-contrib
+    version: 0.1.3-release
+  bkn-studio:
+    chart: bkn-studio
+    version: 0.1.3-release

--- a/deploy/release-manifests/0.1.3/bkn-foundry.yaml
+++ b/deploy/release-manifests/0.1.3/bkn-foundry.yaml
@@ -1,6 +1,6 @@
-# Release lockfile for bkn-foundry 0.1.3-release — pins the chart version of every
+# Release lockfile for bkn-foundry 0.1.3 — pins the chart version of every
 # component that makes up the product. Consumed by:
-#     deploy.sh openbkn install --version=0.1.3-release
+#     deploy.sh openbkn install --version=0.1.3
 # All charts are published at 0.1.3 by the v0.1.3 tag build.
 apiVersion: deploy.openbkn.ai/v0.1.3
 kind: VersionSet


### PR DESCRIPTION
Pin chart versions for the 0.1.3 release. The VersionSet covers 16 component charts (bkn-safe, mf-model-api, mf-model-manager, vega-backend, bkn-backend, bkn-studio, etc.) at 0.1.3-release, consumed by:

    deploy.sh openbkn install --version=0.1.3-release

# Pull Request

## What Changed

- [x] 新增 `deploy/release-manifests/0.1.3/bkn-foundry.yaml` 发布清单

---

## Why

- Related Issue: N/A
- Related Feature: bkn-foundry 0.1.3 版本发布
- Background: 0.1.3 版本各组件 chart 已由 v0.1.3 tag 构建并推送到 GHCR，需要一份 VersionSet 清单供 `deploy.sh openbkn install --version=0.1.3-release` 消费，完成全量组件的版本锁定与安装/升级。

---

## How

- 新增 `deploy/release-manifests/0.1.3/bkn-foundry.yaml`，`apiVersion: deploy.openbkn.ai/v0.1.3`，`kind: VersionSet`
- 锁定 16 个组件 chart 至 `0.1.3-release` 版本：
  - **pre 阶段**: core-data-migrator
  - **核心服务**: bkn-safe, mf-model-manager, mf-model-api, kafka-connect, vega-backend, bkn-backend, ontology-query, agent-operator-integration, oss-gateway-backend, sandbox
  - **Agent 层**: agent-retrieval, bkn-agent, agent-observability
  - **基础设施**: otelcol-contrib
  - **前端**: bkn-studio
- OCI registry 来源: `oci://ghcr.io/openbkn-ai/charts`
- 与 0.1.1、0.1.2 清单格式保持一致，无结构变更
- Breaking changes: 无

---

## Testing

- [ ] 本地 `deploy.sh openbkn install --version=0.1.3-release` 验证安装
- [ ] 从 0.1.2 升级路径验证
- [x] YAML 格式校验通过

Test notes: 清单为纯声明式配置，无代码逻辑变更；需在测试环境验证 `deploy.sh` 能正确拉取所有 chart。

---

## Risk & Rollback

- Potential risks: 若某个组件的 0.1.3-release chart 未成功推送到 GHCR，安装时会拉取失败
- Rollback plan: 回退使用 0.1.2 清单 `deploy.sh openbkn install --version=0.1.2-release`；或删除此文件回退到提交前状态

---

## Additional Notes

- 前序版本: 0.1.1、0.1.2（`deploy/release-manifests/0.1.1/`、`deploy/release-manifests/0.1.2/`）