### PR TITLE
fix(deploy): wire all trace evidence producers

### DIFF
--- a/bkn-trace/agent-observability/README.md
+++ b/bkn-trace/agent-observability/README.md
@@ -187,7 +187,7 @@ Trace Graph 单次最多返回 1000 个 span 节点。命中上限时服务会�
 
 该 NetworkPolicy 依赖 Kubernetes 1.23 或更高版本。离线执行 `helm template` 时应显式传入 `--kube-version 1.23.0` 或实际目标集群版本；连接集群的 `helm install/upgrade` 会按目标集群能力校验。
 
-Chart 默认不创建或接管 `bkn-trace-evidence-ingest` Secret。OpenBKN 整体安装器在 release 循环前创建或验证该 Secret，并将同一 token 注入 Agent Observability 与 Context Loader，因此不依赖两者的安装顺序；单独安装任一 Chart 时，应预先创建 Secret。若要禁用 Evidence 写入，必须同时清空 Context Loader 的 `observability.evidence.ingest_url`，不能只省略 token Secret。`evidence.ingestAuth.createSecret=true` 只适用于 Helm 直接执行的首次安装，不适用于 `helm template | kubectl apply`，也不能用于接管已有的外部 Secret。
+Chart 默认不创建或接管 `bkn-trace-evidence-ingest` Secret。OpenBKN 整体安装器在 release 循环前创建或验证该 Secret，并将同一 token 注入 Agent Observability、Context Loader、Vega、BKN Backend、Ontology Query、BKN Agent 与行动执行服务；BKN Backend 和 Ontology Query 同时启用其持久 Evidence outbox worker。单独安装任一 Chart 时，应预先创建并显式引用该 Secret。若要禁用 Evidence 写入，必须同时清空生产者的 ingest URL，不能只省略 token Secret。`evidence.ingestAuth.createSecret=true` 只适用于 Helm 直接执行的首次安装，不适用于 `helm template | kubectl apply`，也不能用于接管已有的外部 Secret。
 
 ```bash
 printf '%s' '<user>:<password>@tcp(<host>:3306)/<database>?parseTime=true' | \

--- a/bkn-trace/agent-observability/README.md
+++ b/bkn-trace/agent-observability/README.md
@@ -187,7 +187,7 @@ Trace Graph 单次最多返回 1000 个 span 节点。命中上限时服务会�
 
 该 NetworkPolicy 依赖 Kubernetes 1.23 或更高版本。离线执行 `helm template` 时应显式传入 `--kube-version 1.23.0` 或实际目标集群版本；连接集群的 `helm install/upgrade` 会按目标集群能力校验。
 
-Chart 默认不创建或接管 `bkn-trace-evidence-ingest` Secret。OpenBKN 整体安装器在 release 循环前创建或验证该 Secret，并将同一 token 注入 Agent Observability、Context Loader、Vega、BKN Backend、Ontology Query、BKN Agent 与行动执行服务；BKN Backend 和 Ontology Query 同时启用其持久 Evidence outbox worker。单独安装任一 Chart 时，应预先创建并显式引用该 Secret。若要禁用 Evidence 写入，必须同时清空生产者的 ingest URL，不能只省略 token Secret。`evidence.ingestAuth.createSecret=true` 只适用于 Helm 直接执行的首次安装，不适用于 `helm template | kubectl apply`，也不能用于接管已有的外部 Secret。
+Chart 默认不创建或接管 `bkn-trace-evidence-ingest` Secret。OpenBKN 整体安装器在 release 循环前创建或验证该 Secret，并将同一 token 注入 Agent Observability、Context Loader、Vega、BKN Backend、Ontology Query、BKN Agent 与行动执行服务；BKN Backend 和 Ontology Query 同时启用其持久 Evidence outbox worker 与既有清理任务（已投递记录保留 30 天，放弃记录保留 180 天）。单独安装任一 Chart 时，应预先创建并显式引用该 Secret。若要禁用 Evidence 写入，必须同时清空生产者的 ingest URL，不能只省略 token Secret。`evidence.ingestAuth.createSecret=true` 只适用于 Helm 直接执行的首次安装，不适用于 `helm template | kubectl apply`，也不能用于接管已有的外部 Secret。
 
 ```bash
 printf '%s' '<user>:<password>@tcp(<host>:3306)/<database>?parseTime=true' | \

--- a/bkn-trace/agent-observability/README.md
+++ b/bkn-trace/agent-observability/README.md
@@ -187,7 +187,7 @@ Trace Graph 单次最多返回 1000 个 span 节点。命中上限时服务会�
 
 该 NetworkPolicy 依赖 Kubernetes 1.23 或更高版本。离线执行 `helm template` 时应显式传入 `--kube-version 1.23.0` 或实际目标集群版本；连接集群的 `helm install/upgrade` 会按目标集群能力校验。
 
-Chart 默认不创建或接管 `bkn-trace-evidence-ingest` Secret。OpenBKN 整体安装器在 release 循环前创建或验证该 Secret，并将同一 token 注入 Agent Observability、Context Loader、Vega、BKN Backend、Ontology Query、BKN Agent 与行动执行服务；BKN Backend 和 Ontology Query 同时启用其持久 Evidence outbox worker 与既有清理任务（已投递记录保留 30 天，放弃记录保留 180 天）。单独安装任一 Chart 时，应预先创建并显式引用该 Secret。若要禁用 Evidence 写入，必须同时清空生产者的 ingest URL，不能只省略 token Secret。`evidence.ingestAuth.createSecret=true` 只适用于 Helm 直接执行的首次安装，不适用于 `helm template | kubectl apply`，也不能用于接管已有的外部 Secret。
+Chart 默认不创建或接管 `bkn-trace-evidence-ingest` Secret。OpenBKN 整体安装器在 release 循环前创建或验证该 Secret，并将同一 token 注入 Agent Observability、Context Loader、Vega、BKN Backend、Ontology Query、BKN Agent 与行动执行服务；BKN Backend 和 Ontology Query 同时启用其持久 Evidence outbox worker 与既有清理任务（已投递记录保留 30 天，放弃记录保留 180 天）。单独安装任一 Chart 时，应预先创建并显式引用该 Secret。对无 outbox 的生产者，禁用 Evidence 写入须同时清空 ingest URL 与 token Secret；对启用了 producer outbox 的 BKN Backend 和 Ontology Query，须同时关闭 outbox 与 worker，不能只清空 URL。`evidence.ingestAuth.createSecret=true` 只适用于 Helm 直接执行的首次安装，不适用于 `helm template | kubectl apply`，也不能用于接管已有的外部 Secret。
 
 ```bash
 printf '%s' '<user>:<password>@tcp(<host>:3306)/<database>?parseTime=true' | \

--- a/deploy/scripts/services/openbkn.sh
+++ b/deploy/scripts/services/openbkn.sh
@@ -714,13 +714,24 @@ _openbkn_adopt_unowned_resources() {
 
 _openbkn_warn_unwired_evidence_producers() {
     local -a unwired=()
-    local release_name
+    local release_name set_value
+    local has_ingest_url has_ingest_secret
     for release_name in "$@"; do
         _openbkn_release_list_contains "${release_name}" "${_OPENBKN_TRACE_EVIDENCE_PRODUCERS[@]}" || continue
-        case "${release_name}" in
-            agent-retrieval|vega-backend|bkn-backend|ontology-query|bkn-agent|agent-operator-integration) ;;
-            *) unwired+=("${release_name}") ;;
-        esac
+        _openbkn_release_extra_sets "${release_name}"
+        has_ingest_url=false
+        has_ingest_secret=false
+        for set_value in "${CORE_RELEASE_EXTRA_SETS[@]:-}"; do
+            [[ "${set_value}" == *"=${OPENBKN_TRACE_EVIDENCE_INGEST_URL}" ]] && has_ingest_url=true
+            case "${set_value}" in
+                *"ingestTokenSecretName=${OPENBKN_TRACE_INGEST_SECRET}"|\
+                *"ingest_token_secret_name=${OPENBKN_TRACE_INGEST_SECRET}"|\
+                *"EvidenceIngestTokenSecretName=${OPENBKN_TRACE_INGEST_SECRET}")
+                    has_ingest_secret=true
+                    ;;
+            esac
+        done
+        [[ "${has_ingest_url}" == true && "${has_ingest_secret}" == true ]] || unwired+=("${release_name}")
     done
     if [[ ${#unwired[@]} -gt 0 ]]; then
         log_warn "BKN Trace: no Evidence ingest token wired for ${unwired[*]} — their Evidence writes will be rejected until their charts are wired here"

--- a/deploy/scripts/services/openbkn.sh
+++ b/deploy/scripts/services/openbkn.sh
@@ -517,18 +517,42 @@ _openbkn_trace_profile_sets() {
                 "bknTrace.evidence.ingestTokenSecretKey=token"
             )
             ;;
+        bkn-backend|ontology-query)
+            # These producers enqueue evidence in their durable outbox. Its
+            # configuration requires a trusted-delivery token, so reuse the
+            # installer-managed ingest Secret rather than introduce another
+            # unrotated cluster credential.
+            CORE_RELEASE_EXTRA_SETS+=(
+                "bknTrace.evidence.ingestUrl=${OPENBKN_TRACE_EVIDENCE_INGEST_URL}"
+                "bknTrace.evidence.ingestTokenSecretName=${OPENBKN_TRACE_INGEST_SECRET}"
+                "bknTrace.evidence.ingestTokenSecretKey=token"
+                "bknTrace.producerOutbox.enabled=true"
+                "bknTrace.producerOutbox.workerEnabled=true"
+                "bknTrace.producerOutbox.queryGatewayTokenSecretName=${OPENBKN_TRACE_INGEST_SECRET}"
+                "bknTrace.producerOutbox.queryGatewayTokenSecretKey=token"
+            )
+            ;;
+        agent-operator-integration)
+            CORE_RELEASE_EXTRA_SETS+=(
+                "observability.evidence.ingest_url=${OPENBKN_TRACE_EVIDENCE_INGEST_URL}"
+                "observability.evidence.ingest_token_secret_name=${OPENBKN_TRACE_INGEST_SECRET}"
+                "observability.evidence.ingest_token_secret_key=token"
+            )
+            ;;
+        bkn-agent)
+            CORE_RELEASE_EXTRA_SETS+=(
+                "observability.bknTraceEvidenceIngestUrl=${OPENBKN_TRACE_EVIDENCE_INGEST_URL}"
+                "observability.bknTraceArtifactIngestUrl=${OPENBKN_TRACE_ARTIFACT_INGEST_URL}"
+                "observability.bknTraceEvidenceIngestTokenSecretName=${OPENBKN_TRACE_INGEST_SECRET}"
+                "observability.bknTraceEvidenceIngestTokenSecretKey=token"
+            )
+            ;;
     esac
 }
 
-# Releases that write Evidence and therefore need the ingest token. Their charts
-# all default ingestTokenSecretName to the empty string, and the template only
-# injects the token env when that name is set — so a producer nobody wires here
-# posts Evidence with no token at all, which agent-observability rejects
-# (allowUnauthenticated defaults to false).
-#
-# That failure is silent: the pod stays green and only the Evidence goes
-# missing. Naming the unwired ones at install time is the difference between a
-# known gap and a mystery weeks later.
+# Releases that write Evidence and therefore must receive the installer-managed
+# ingest Secret. Chart defaults stay empty for standalone deployments; the
+# complete product install is responsible for wiring every producer here.
 _OPENBKN_TRACE_EVIDENCE_PRODUCERS=(
     agent-retrieval
     vega-backend
@@ -693,7 +717,7 @@ _openbkn_warn_unwired_evidence_producers() {
     for release_name in "$@"; do
         _openbkn_release_list_contains "${release_name}" "${_OPENBKN_TRACE_EVIDENCE_PRODUCERS[@]}" || continue
         case "${release_name}" in
-            agent-retrieval|vega-backend) ;;
+            agent-retrieval|vega-backend|bkn-backend|ontology-query|bkn-agent|agent-operator-integration) ;;
             *) unwired+=("${release_name}") ;;
         esac
     done
@@ -893,7 +917,9 @@ _openbkn_release_extra_sets() {
             CORE_RELEASE_EXTRA_SETS+=("evidence.ingestAuth.createSecret=false")
         fi
     elif [[ "${release_name}" == "agent-retrieval" || "${release_name}" == "otelcol-contrib" ||
-            "${release_name}" == "vega-backend" ]]; then
+            "${release_name}" == "vega-backend" || "${release_name}" == "bkn-backend" ||
+            "${release_name}" == "ontology-query" || "${release_name}" == "agent-operator-integration" ||
+            "${release_name}" == "bkn-agent" ]]; then
         # This list gates _openbkn_trace_profile_sets: a release absent here
         # never reaches the case inside it, however complete that case looks.
         # Adding a producer means adding it in both places.

--- a/deploy/scripts/services/openbkn.sh
+++ b/deploy/scripts/services/openbkn.sh
@@ -528,6 +528,7 @@ _openbkn_trace_profile_sets() {
                 "bknTrace.evidence.ingestTokenSecretKey=token"
                 "bknTrace.producerOutbox.enabled=true"
                 "bknTrace.producerOutbox.workerEnabled=true"
+                "bknTrace.producerOutbox.cleanup.enabled=true"
                 "bknTrace.producerOutbox.queryGatewayTokenSecretName=${OPENBKN_TRACE_INGEST_SECRET}"
                 "bknTrace.producerOutbox.queryGatewayTokenSecretKey=token"
             )

--- a/deploy/scripts/services/openbkn_trace_profile_test.sh
+++ b/deploy/scripts/services/openbkn_trace_profile_test.sh
@@ -190,12 +190,13 @@ else
     ok
 fi
 
-# Keep the guard meaningful: a declared producer without a release profile
-# must still be disclosed instead of letting the no-warning assertion pass.
+# Keep the guard tied to the release entrypoint. If a declared producer is
+# omitted from its outer gate, its actual extra-set result is empty even though
+# the producer name itself is known to the installer.
 LAST_WARN=""
-_OPENBKN_TRACE_EVIDENCE_PRODUCERS+=(not-wired-producer)
-_openbkn_warn_unwired_evidence_producers agent-retrieval not-wired-producer
-contains "names an unwired producer" "${LAST_WARN}" "not-wired-producer"
+_openbkn_release_extra_sets() { CORE_RELEASE_EXTRA_SETS=(); }
+_openbkn_warn_unwired_evidence_producers bkn-agent
+contains "names a declared producer without actual wiring" "${LAST_WARN}" "bkn-agent"
 
 CORE_SET_VALUES=()
 OFFLINE_MODE=true

--- a/deploy/scripts/services/openbkn_trace_profile_test.sh
+++ b/deploy/scripts/services/openbkn_trace_profile_test.sh
@@ -148,6 +148,7 @@ contains "bkn-backend uses the evidence ingest Secret" "${bkn_backend_sets}" "bk
 contains "bkn-backend reads the token key the receiver writes" "${bkn_backend_sets}" "bknTrace.evidence.ingestTokenSecretKey=token"
 contains "bkn-backend enables its durable outbox" "${bkn_backend_sets}" "bknTrace.producerOutbox.enabled=true"
 contains "bkn-backend starts its durable outbox worker" "${bkn_backend_sets}" "bknTrace.producerOutbox.workerEnabled=true"
+contains "bkn-backend enables delivered outbox cleanup" "${bkn_backend_sets}" "bknTrace.producerOutbox.cleanup.enabled=true"
 contains "bkn-backend uses the trusted delivery Secret" "${bkn_backend_sets}" "bknTrace.producerOutbox.queryGatewayTokenSecretName=bkn-trace-evidence-ingest"
 contains "bkn-backend reads the trusted delivery token key" "${bkn_backend_sets}" "bknTrace.producerOutbox.queryGatewayTokenSecretKey=token"
 
@@ -159,6 +160,7 @@ contains "ontology-query uses the evidence ingest Secret" "${ontology_query_sets
 contains "ontology-query reads the token key the receiver writes" "${ontology_query_sets}" "bknTrace.evidence.ingestTokenSecretKey=token"
 contains "ontology-query enables its durable outbox" "${ontology_query_sets}" "bknTrace.producerOutbox.enabled=true"
 contains "ontology-query starts its durable outbox worker" "${ontology_query_sets}" "bknTrace.producerOutbox.workerEnabled=true"
+contains "ontology-query enables delivered outbox cleanup" "${ontology_query_sets}" "bknTrace.producerOutbox.cleanup.enabled=true"
 contains "ontology-query uses the trusted delivery Secret" "${ontology_query_sets}" "bknTrace.producerOutbox.queryGatewayTokenSecretName=bkn-trace-evidence-ingest"
 contains "ontology-query reads the trusted delivery token key" "${ontology_query_sets}" "bknTrace.producerOutbox.queryGatewayTokenSecretKey=token"
 
@@ -181,12 +183,19 @@ contains "bkn-agent reads the token key the receiver writes" "${bkn_agent_sets}"
 # must either be wired above or make this installer-level assertion fail.
 LAST_WARN=""
 log_warn() { LAST_WARN="$*"; }
-_openbkn_warn_unwired_evidence_producers agent-retrieval vega-backend bkn-backend ontology-query agent-operator-integration bkn-agent bkn-safe
+_openbkn_warn_unwired_evidence_producers "${_OPENBKN_TRACE_EVIDENCE_PRODUCERS[@]}" bkn-safe
 if [[ -n "${LAST_WARN}" ]]; then
     fail "no warning when every present producer is wired: ${LAST_WARN}"
 else
     ok
 fi
+
+# Keep the guard meaningful: a declared producer without a release profile
+# must still be disclosed instead of letting the no-warning assertion pass.
+LAST_WARN=""
+_OPENBKN_TRACE_EVIDENCE_PRODUCERS+=(not-wired-producer)
+_openbkn_warn_unwired_evidence_producers agent-retrieval not-wired-producer
+contains "names an unwired producer" "${LAST_WARN}" "not-wired-producer"
 
 CORE_SET_VALUES=()
 OFFLINE_MODE=true

--- a/deploy/scripts/services/openbkn_trace_profile_test.sh
+++ b/deploy/scripts/services/openbkn_trace_profile_test.sh
@@ -136,21 +136,54 @@ contains "vega uses the evidence ingest Secret" "${vega_sets}" "bknTrace.evidenc
 contains "vega reads the token key the receiver writes" "${vega_sets}" "bknTrace.evidence.ingestTokenSecretKey=token"
 not_contains "vega does not keep the pre-rename key" "${vega_sets}" "ingestTokenSecretKey=ingest-token"
 
-# Producers still unwired must be named at install time. The failure is
-# otherwise invisible: green pods, missing Evidence.
+# A full OpenBKN installation must wire every declared producer through the
+# real installer entrypoint. bkn-backend and ontology-query are durable
+# producers, so the shared trusted-delivery Secret and both outbox switches are
+# required in addition to the ingest route. The remaining two post directly.
+CORE_RELEASE_EXTRA_SETS=()
+_openbkn_release_extra_sets bkn-backend openbkn
+bkn_backend_sets="${CORE_RELEASE_EXTRA_SETS[*]:-}"
+contains "bkn-backend posts evidence to the ingest route" "${bkn_backend_sets}" "bknTrace.evidence.ingestUrl=http://agent-observability:8080/api/agent-observability/v1/evidence/events"
+contains "bkn-backend uses the evidence ingest Secret" "${bkn_backend_sets}" "bknTrace.evidence.ingestTokenSecretName=bkn-trace-evidence-ingest"
+contains "bkn-backend reads the token key the receiver writes" "${bkn_backend_sets}" "bknTrace.evidence.ingestTokenSecretKey=token"
+contains "bkn-backend enables its durable outbox" "${bkn_backend_sets}" "bknTrace.producerOutbox.enabled=true"
+contains "bkn-backend starts its durable outbox worker" "${bkn_backend_sets}" "bknTrace.producerOutbox.workerEnabled=true"
+contains "bkn-backend uses the trusted delivery Secret" "${bkn_backend_sets}" "bknTrace.producerOutbox.queryGatewayTokenSecretName=bkn-trace-evidence-ingest"
+contains "bkn-backend reads the trusted delivery token key" "${bkn_backend_sets}" "bknTrace.producerOutbox.queryGatewayTokenSecretKey=token"
+
+CORE_RELEASE_EXTRA_SETS=()
+_openbkn_release_extra_sets ontology-query openbkn
+ontology_query_sets="${CORE_RELEASE_EXTRA_SETS[*]:-}"
+contains "ontology-query posts evidence to the ingest route" "${ontology_query_sets}" "bknTrace.evidence.ingestUrl=http://agent-observability:8080/api/agent-observability/v1/evidence/events"
+contains "ontology-query uses the evidence ingest Secret" "${ontology_query_sets}" "bknTrace.evidence.ingestTokenSecretName=bkn-trace-evidence-ingest"
+contains "ontology-query reads the token key the receiver writes" "${ontology_query_sets}" "bknTrace.evidence.ingestTokenSecretKey=token"
+contains "ontology-query enables its durable outbox" "${ontology_query_sets}" "bknTrace.producerOutbox.enabled=true"
+contains "ontology-query starts its durable outbox worker" "${ontology_query_sets}" "bknTrace.producerOutbox.workerEnabled=true"
+contains "ontology-query uses the trusted delivery Secret" "${ontology_query_sets}" "bknTrace.producerOutbox.queryGatewayTokenSecretName=bkn-trace-evidence-ingest"
+contains "ontology-query reads the trusted delivery token key" "${ontology_query_sets}" "bknTrace.producerOutbox.queryGatewayTokenSecretKey=token"
+
+CORE_RELEASE_EXTRA_SETS=()
+_openbkn_release_extra_sets agent-operator-integration openbkn
+operator_sets="${CORE_RELEASE_EXTRA_SETS[*]:-}"
+contains "operator integration posts evidence to the ingest route" "${operator_sets}" "observability.evidence.ingest_url=http://agent-observability:8080/api/agent-observability/v1/evidence/events"
+contains "operator integration uses the evidence ingest Secret" "${operator_sets}" "observability.evidence.ingest_token_secret_name=bkn-trace-evidence-ingest"
+contains "operator integration reads the token key the receiver writes" "${operator_sets}" "observability.evidence.ingest_token_secret_key=token"
+
+CORE_RELEASE_EXTRA_SETS=()
+_openbkn_release_extra_sets bkn-agent openbkn
+bkn_agent_sets="${CORE_RELEASE_EXTRA_SETS[*]:-}"
+contains "bkn-agent posts evidence to the ingest route" "${bkn_agent_sets}" "observability.bknTraceEvidenceIngestUrl=http://agent-observability:8080/api/agent-observability/v1/evidence/events"
+contains "bkn-agent posts artifacts to the artifact route" "${bkn_agent_sets}" "observability.bknTraceArtifactIngestUrl=http://agent-observability:8080/api/agent-observability/v1/evidence/artifacts"
+contains "bkn-agent uses the evidence ingest Secret" "${bkn_agent_sets}" "observability.bknTraceEvidenceIngestTokenSecretName=bkn-trace-evidence-ingest"
+contains "bkn-agent reads the token key the receiver writes" "${bkn_agent_sets}" "observability.bknTraceEvidenceIngestTokenSecretKey=token"
+
+# The full release manifest contains all declared producers. A new producer
+# must either be wired above or make this installer-level assertion fail.
 LAST_WARN=""
 log_warn() { LAST_WARN="$*"; }
-_openbkn_warn_unwired_evidence_producers agent-retrieval vega-backend bkn-backend ontology-query bkn-safe
-contains "names bkn-backend as unwired" "${LAST_WARN}" "bkn-backend"
-contains "names ontology-query as unwired" "${LAST_WARN}" "ontology-query"
-not_contains "does not name a wired producer" "${LAST_WARN}" "agent-retrieval"
-not_contains "does not name vega once wired" "${LAST_WARN}" "vega-backend"
-not_contains "does not name a release that emits no evidence" "${LAST_WARN}" "bkn-safe"
-
-LAST_WARN=""
-_openbkn_warn_unwired_evidence_producers agent-retrieval vega-backend
+_openbkn_warn_unwired_evidence_producers agent-retrieval vega-backend bkn-backend ontology-query agent-operator-integration bkn-agent bkn-safe
 if [[ -n "${LAST_WARN}" ]]; then
-    fail "no warning when every present producer is wired"
+    fail "no warning when every present producer is wired: ${LAST_WARN}"
 else
     ok
 fi


### PR DESCRIPTION
## Summary
- backport #760 to `release/0.1.3`
- wire the installer-managed Evidence ingest Secret into every declared producer
- enable durable outbox workers and the existing cleanup policy for BKN Backend and Ontology Query
- cover the producer registry with positive and negative installer tests

## Validation
- `bash -n deploy/scripts/services/openbkn.sh`
- all `deploy/scripts/services/*_test.sh`
- Helm rendering for both durable outbox cleanup CronJobs

Backport of #760. Tracks #759.