### PR TITLE
fix(trace): initialize receipt projection mappings

### DIFF
--- a/bkn-trace/agent-observability/src/drivenadapter/httpaccess/opensearchprojection/sink.go
+++ b/bkn-trace/agent-observability/src/drivenadapter/httpaccess/opensearchprojection/sink.go
@@ -12,6 +12,30 @@ import (
 	"github.com/openbkn-ai/bkn-foundry/bkn-trace/agent-observability/src/port/driven/iprojectionoutbox"
 )
 
+const receiptProjectionIndexMapping = `{
+  "mappings": {
+    "dynamic": true,
+    "properties": {
+      "receipt_id": {"type": "text", "fields": {"keyword": {"type": "keyword"}}},
+      "conversation_id": {"type": "text", "fields": {"keyword": {"type": "keyword"}}},
+      "interaction_id": {"type": "text", "fields": {"keyword": {"type": "keyword"}}},
+      "request_id": {"type": "text", "fields": {"keyword": {"type": "keyword"}}},
+      "trace_id": {"type": "text", "fields": {"keyword": {"type": "keyword"}}},
+      "knowledge_network_ids": {"type": "text", "fields": {"keyword": {"type": "keyword"}}},
+      "issued_at": {"type": "date"},
+      "terminal_at": {"type": "date"},
+      "owner": {
+        "properties": {
+          "tenant_id": {"type": "text", "fields": {"keyword": {"type": "keyword"}}},
+          "business_domain_id": {"type": "text", "fields": {"keyword": {"type": "keyword"}}},
+          "effective_subject_id": {"type": "text", "fields": {"keyword": {"type": "keyword"}}},
+          "application_principal_id": {"type": "text", "fields": {"keyword": {"type": "keyword"}}}
+        }
+      }
+    }
+  }
+}`
+
 type Sink struct {
 	client *opensearch.Client
 	index  string
@@ -39,7 +63,7 @@ func (s *Sink) Project(ctx context.Context, item iprojectionoutbox.Item) error {
 }
 
 func (s *Sink) PrepareVersion(ctx context.Context, indexVersion string) error {
-	return s.client.EnsureIndex(ctx, indexVersion, []byte(`{"mappings":{"dynamic":true}}`))
+	return s.client.EnsureIndex(ctx, indexVersion, []byte(receiptProjectionIndexMapping))
 }
 
 func (s *Sink) ProjectVersion(ctx context.Context, indexVersion string, item iprojectionoutbox.Item) error {

--- a/bkn-trace/agent-observability/src/drivenadapter/httpaccess/opensearchprojection/sink_test.go
+++ b/bkn-trace/agent-observability/src/drivenadapter/httpaccess/opensearchprojection/sink_test.go
@@ -68,6 +68,43 @@ func TestSinkAcknowledgesStaleAggregateVersionWithoutRetry(t *testing.T) {
 	}
 }
 
+func TestPrepareVersionDefinesMappingsRequiredByEmptyReceiptQuery(t *testing.T) {
+	t.Parallel()
+
+	var mapping map[string]any
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPut || r.URL.Path != "/bkn-trace-core-v014" {
+			t.Fatalf("unexpected index preparation request: %s %s", r.Method, r.URL.Path)
+		}
+		if err := json.NewDecoder(r.Body).Decode(&mapping); err != nil {
+			t.Fatalf("decode index mapping: %v", err)
+		}
+		w.WriteHeader(http.StatusCreated)
+	}))
+	t.Cleanup(server.Close)
+
+	sink := opensearchprojection.New(
+		opensearch.New(server.URL, opensearch.AuthConfig{}, time.Second),
+		"bkn-trace-core",
+	)
+	if err := sink.PrepareVersion(context.Background(), "bkn-trace-core-v014"); err != nil {
+		t.Fatalf("prepare projection index: %v", err)
+	}
+
+	properties, ok := mapping["mappings"].(map[string]any)["properties"].(map[string]any)
+	if !ok {
+		t.Fatalf("receipt projection mapping must define properties: %#v", mapping)
+	}
+	issuedAt, ok := properties["issued_at"].(map[string]any)
+	if !ok || issuedAt["type"] != "date" {
+		t.Fatalf("issued_at must be mapped as date for empty-index sorting: %#v", issuedAt)
+	}
+	requestID, ok := properties["request_id"].(map[string]any)
+	if !ok || requestID["fields"].(map[string]any)["keyword"].(map[string]any)["type"] != "keyword" {
+		t.Fatalf("request_id must retain the exact keyword subfield used by summary queries: %#v", requestID)
+	}
+}
+
 func TestValidateVersionRejectsCorruptedDocumentContent(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary
- predefine Core receipt projection fields needed by zero-document business-provenance queries
- map `issued_at` as `date` before the first receipt is written
- preserve keyword subfields for exact scope and request filters

## Validation
- `go test ./...` in `bkn-trace/agent-observability`

Fixes #739.