### PR TITLE
fix(action-logs): stop the execution-log list from dragging back per-instance results

### DIFF
--- a/adp/bkn/ontology-query/server/logics/action_logs/action_logs_service.go
+++ b/adp/bkn/ontology-query/server/logics/action_logs/action_logs_service.go
@@ -305,6 +305,16 @@ func (s *actionLogsService) QueryExecutions(ctx context.Context, query *interfac
 		},
 		"from": offset,
 		"size": limit,
+		// The list only carries execution summaries. Per-instance results live in the same
+		// document and grow with the instance count; reading them here made a single page
+		// drag every historical task's full execution detail across the wire.
+		// action_type_snapshot and action_source are per-execution config copies that no list
+		// consumer reads (the studio list mapper ignores them, context-loader strips them).
+		// Excluded at the OpenSearch level so old documents carrying these fields are covered too.
+		// dynamic_params stays: context-loader keeps it in the slimmed list for the agent.
+		"_source": map[string]any{
+			"excludes": []string{"results", "action_type_snapshot", "action_source"},
+		},
 		"sort": []map[string]any{
 			{"start_time": map[string]any{"order": "desc"}},
 			{"id": map[string]any{"order": "asc"}},

--- a/adp/bkn/ontology-query/server/logics/action_logs/action_logs_service_test.go
+++ b/adp/bkn/ontology-query/server/logics/action_logs/action_logs_service_test.go
@@ -157,6 +157,40 @@ func Test_QueryExecutions_IndexNotExists_ReturnsEmpty(t *testing.T) {
 	})
 }
 
+func Test_QueryExecutions_ExcludesResultsFromSource(t *testing.T) {
+	Convey("QueryExecutions must not read per-instance results from OpenSearch", t, func() {
+		ctrl := gomock.NewController(t)
+		mockOSA := omock.NewMockOpenSearchAccess(ctrl)
+		mockOSA.EXPECT().IndexExists(gomock.Any(), gomock.Any()).Return(true, nil)
+
+		var captured map[string]any
+		mockOSA.EXPECT().SearchData(gomock.Any(), gomock.Any(), gomock.Any()).
+			DoAndReturn(func(_ context.Context, _ string, q any) ([]interfaces.Hit, error) {
+				captured, _ = q.(map[string]any)
+				return []interfaces.Hit{{Source: map[string]any{
+					"id":     "exec_123",
+					"status": "completed",
+				}}}, nil
+			})
+
+		svc := &actionLogsService{osAccess: mockOSA}
+		res, err := svc.QueryExecutions(context.Background(), &interfaces.ActionLogQuery{KNID: "kn_001"})
+
+		So(err, ShouldBeNil)
+		So(len(res.Entries), ShouldEqual, 1)
+
+		source, ok := captured["_source"].(map[string]any)
+		So(ok, ShouldBeTrue)
+		excludes, ok := source["excludes"].([]string)
+		So(ok, ShouldBeTrue)
+		So(excludes, ShouldContain, "results")
+		So(excludes, ShouldContain, "action_type_snapshot")
+		So(excludes, ShouldContain, "action_source")
+		// context-loader keeps dynamic_params in the slimmed list for the agent.
+		So(excludes, ShouldNotContain, "dynamic_params")
+	})
+}
+
 func Test_ActionLogQuery_Defaults(t *testing.T) {
 	Convey("Test ActionLogQuery defaults", t, func() {
 		Convey("should have default values", func() {

--- a/adp/context-loader/agent-retrieval/server/logics/knactionrecall/execute_action.go
+++ b/adp/context-loader/agent-retrieval/server/logics/knactionrecall/execute_action.go
@@ -127,12 +127,15 @@ func (s *knActionRecallServiceImpl) ListActionExecutions(ctx context.Context, re
 		s.logger.WithContext(ctx).Errorf("[KnActionRecall#ListActionExecutions] ListActionExecutions failed, err: %v", err)
 		return nil, err
 	}
-	// 列表每条同样剔除重货（action_type_snapshot 等），仅保留概览字段
+	// 列表每条同样剔除重货（action_type_snapshot 等），仅保留概览字段。
+	// results 不进列表：逐实例明细只在 get_action_execution 里给，列表拿的是任务摘要。
 	if entries, ok := resp["entries"].([]any); ok {
 		slimmed := make([]any, 0, len(entries))
 		for _, e := range entries {
 			if m, ok := e.(map[string]any); ok {
-				slimmed = append(slimmed, slimActionExecution(m))
+				summary := slimActionExecution(m)
+				delete(summary, "results")
+				slimmed = append(slimmed, summary)
 			} else {
 				slimmed = append(slimmed, e)
 			}

--- a/adp/context-loader/agent-retrieval/server/logics/knactionrecall/execute_action_test.go
+++ b/adp/context-loader/agent-retrieval/server/logics/knactionrecall/execute_action_test.go
@@ -171,7 +171,8 @@ func TestListActionExecutions_Success(t *testing.T) {
 						map[string]any{
 							"id":                   "exec-001",
 							"status":               "completed",
-							"action_type_snapshot": map[string]any{"parameters": []any{"x"}}, // 重货，list 精简后应剔除
+							"action_type_snapshot": map[string]any{"parameters": []any{"x"}},   // 重货，list 精简后应剔除
+							"results":              []any{map[string]any{"status": "success"}}, // 逐对象明细只在单查里给
 						},
 					},
 				}, nil
@@ -190,6 +191,9 @@ func TestListActionExecutions_Success(t *testing.T) {
 		convey.So(e0["id"], convey.ShouldEqual, "exec-001")
 		convey.So(e0["status"], convey.ShouldEqual, "completed")
 		convey.So(e0["action_type_snapshot"], convey.ShouldBeNil)
+		// 列表不带逐对象明细：键本身也不应存在，而不是留一个 null
+		_, hasResults := e0["results"]
+		convey.So(hasResults, convey.ShouldBeFalse)
 	})
 }
 

--- a/docs/api/context-loader/action.yaml
+++ b/docs/api/context-loader/action.yaml
@@ -543,7 +543,66 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/ActionExecutionResult'
-          description: 逐对象执行结果。
+          description: 逐对象执行结果。仅单次查询返回，列表不含此字段。
+
+    ActionExecutionSummary:
+      type: object
+      description: |
+        列表里的执行记录摘要。字段与 `ActionExecution` 相同，只是不含 `results`——
+        要逐对象明细请用 `get_action_execution` 按 `id` 单查。
+      properties:
+        id:
+          type: string
+          description: 执行 ID。
+        kn_id:
+          type: string
+          description: 知识网络 ID。
+        action_type_id:
+          type: string
+          description: 行动类 ID。
+        action_type_name:
+          type: string
+          description: 行动类名称。
+        status:
+          type: string
+          enum:
+            - pending
+            - running
+            - completed
+            - failed
+            - cancelled
+          description: 执行状态。
+        trigger_type:
+          type: string
+          enum:
+            - manual
+            - scheduled
+          description: 触发方式。
+        total_count:
+          type: integer
+          description: 目标对象总数。
+        success_count:
+          type: integer
+          description: 成功对象数。
+        failed_count:
+          type: integer
+          description: 失败对象数。
+        start_time:
+          type: integer
+          format: int64
+          description: 开始时间（Unix 毫秒）。
+        end_time:
+          type: integer
+          format: int64
+          description: 结束时间（Unix 毫秒）。
+        duration_ms:
+          type: integer
+          format: int64
+          description: 总耗时（毫秒）。
+        dynamic_params:
+          type: object
+          additionalProperties: true
+          description: 本次执行使用的动态参数。
 
     ActionExecutionResult:
       type: object
@@ -582,8 +641,11 @@ components:
         entries:
           type: array
           items:
-            $ref: '#/components/schemas/ActionExecution'
-          description: 执行记录列表，每条与单次查询同样做过裁剪。
+            $ref: '#/components/schemas/ActionExecutionSummary'
+          description: |
+            执行记录列表，每条与单次查询同样做过裁剪，且**不含 `results`**——
+            逐对象明细只在 `get_action_execution` 里给，避免列表被历史任务的
+            实例明细撑爆。
         total_count:
           type: integer
           description: 命中总数。


### PR DESCRIPTION
## Problem

Per-instance execution results and the task summary live in the same OpenSearch document. `QueryExecutions` applied no `_source` trimming, so every page of the action-log list read, deserialized and returned the full execution detail of every historical task it touched.

Measured on the reporter's test data: **31.4 seconds** for one list request, ~36,642 lines of formatted JSON.

Part of #724 (the list-payload half). The aggregated-execution half and the summary/result storage split follow in separate PRs.

## Change

Exclude the heavy fields at the OpenSearch query layer:

```go
"_source": map[string]any{
    "excludes": []string{"results", "action_type_snapshot", "action_source"},
},
```

Why at the query layer rather than nulling `exec.Results` after the read: the latter only shrinks the response body, while the document read and deserialization cost stays. Query-time trimming also covers historical documents that already carry embedded results, so no data migration is needed.

`action_type_snapshot` and `action_source` are per-execution config copies that no list consumer reads — the studio list mapper ignores them and context-loader's `slimActionExecution` strips them explicitly. `dynamic_params` stays, since context-loader keeps it in the slimmed list for the agent.

## Blast radius

Both callers were checked:

- `duplicate_check.go` only reads `Entries[0].ID` — unaffected.
- `action_execution_handler.go` feeds the REST list response — this is the intended target.

The detail endpoint uses a different code path and still returns `results`. The studio list mapper (`mapExecutionLog`) never read `results`, so the frontend needs no change.

## Testing

`Test_QueryExecutions_ExcludesResultsFromSource` captures the query body actually sent to OpenSearch and asserts the exclude list. It fails on the pre-fix code (`Expected: true Actual: false`) and passes after.

```
ok  ontology-query/logics/action_logs       2.537s
ok  ontology-query/logics/action_scheduler  3.138s
ok  ontology-query/driveradapters           4.081s
```

## Pre-merge checklist

- [x] Reproducing test written before the fix
- [x] Package tests green
- [ ] Human review

Refs #724

🤖 Generated with [Claude Code](https://claude.com/claude-code)