### PR TITLE
fix(oss-gateway): backport crypto test + lint fixes to release/0.1.3

### DIFF
--- a/.github/workflows/release-infra-oss-gateway.yml
+++ b/.github/workflows/release-infra-oss-gateway.yml
@@ -26,10 +26,8 @@ jobs:
     uses: ./.github/workflows/reusable-test.yml
     with:
       service-path: infra/oss-gateway-backend
-      # go test 暂跳过 —— crypto 测试有未解 panic（详见 issue），
-      # 与 adp 各服务一致用 chart-only（老 pipeline 默认 code-check 关）。
-      # 测试真修完后切回 stack: go + go-mod-file: go.mod。
-      stack: chart-only
+      stack: go
+      go-mod-file: go.mod
 
   build:
     needs: test

--- a/infra/oss-gateway-backend/internal/handler/storage.go
+++ b/infra/oss-gateway-backend/internal/handler/storage.go
@@ -26,16 +26,17 @@ func (h *StorageHandler) Create(c *gin.Context) {
 	if err != nil {
 		// 检查是否是校验错误
 		if validationErr, ok := err.(*service.StorageValidationError); ok {
-			if validationErr.Code == "400031107" {
+			switch validationErr.Code {
+			case "400031107":
 				response.StorageNameExist(c, req.StorageName)
 				return
-			} else if validationErr.Code == "400031108" {
+			case "400031108":
 				response.StorageExist(c, validationErr.Description)
 				return
-			} else if validationErr.Code == "400031110" {
+			case "400031110":
 				response.InvalidVendorType(c, req.VendorType)
 				return
-			} else if validationErr.Code == "400031112" {
+			case "400031112":
 				// validationErr.Description 已经是完整的错误描述
 				response.DefaultStorageExists(c, validationErr.Description)
 				return

--- a/infra/oss-gateway-backend/pkg/adapter/minio_adapter.go
+++ b/infra/oss-gateway-backend/pkg/adapter/minio_adapter.go
@@ -104,9 +104,15 @@ func (a *MinIOAdapter) GetHeadURL(ctx context.Context, objectKey string, validSe
 
 func (a *MinIOAdapter) GetUploadURL(ctx context.Context, objectKey string, validSeconds int64) (*PresignedURL, error) {
 	policy := minio.NewPostPolicy()
-	policy.SetBucket(a.bucketName)
-	policy.SetKey(objectKey)
-	policy.SetExpires(time.Now().UTC().Add(time.Duration(validSeconds) * time.Second))
+	if err := policy.SetBucket(a.bucketName); err != nil {
+		return nil, fmt.Errorf("failed to set post policy bucket: %w", err)
+	}
+	if err := policy.SetKey(objectKey); err != nil {
+		return nil, fmt.Errorf("failed to set post policy key: %w", err)
+	}
+	if err := policy.SetExpires(time.Now().UTC().Add(time.Duration(validSeconds) * time.Second)); err != nil {
+		return nil, fmt.Errorf("failed to set post policy expiry: %w", err)
+	}
 
 	presignedURL, formData, err := a.client.PresignedPostPolicy(ctx, policy)
 	if err != nil {

--- a/infra/oss-gateway-backend/pkg/crypto/aes.go
+++ b/infra/oss-gateway-backend/pkg/crypto/aes.go
@@ -35,7 +35,9 @@ func (c *AESCrypto) Encrypt(plaintext string) (string, error) {
 		return "", err
 	}
 
-	stream := cipher.NewCFBEncrypter(block, iv)
+	// CFB 是未认证模式（Go 1.24 起标记废弃）。存量凭据都是这个格式加密的，
+	// 直接换 GCM 会导致老数据解不开，迁移方案见 #766。
+	stream := cipher.NewCFBEncrypter(block, iv) //nolint:staticcheck // SA1019: 待 #766 带版本前缀迁移到 GCM
 	stream.XORKeyStream(ciphertext[aes.BlockSize:], plaintextBytes)
 
 	return base64.StdEncoding.EncodeToString(ciphertext), nil
@@ -59,7 +61,7 @@ func (c *AESCrypto) Decrypt(ciphertext string) (string, error) {
 	iv := ciphertextBytes[:aes.BlockSize]
 	ciphertextBytes = ciphertextBytes[aes.BlockSize:]
 
-	stream := cipher.NewCFBDecrypter(block, iv)
+	stream := cipher.NewCFBDecrypter(block, iv) //nolint:staticcheck // SA1019: 同上，见 #766
 	stream.XORKeyStream(ciphertextBytes, ciphertextBytes)
 
 	return string(ciphertextBytes), nil

--- a/infra/oss-gateway-backend/test/pkg/crypto_test.go
+++ b/infra/oss-gateway-backend/test/pkg/crypto_test.go
@@ -5,11 +5,17 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// AES-256 requires a 32-byte key; NewAESCrypto returns nil for anything else.
+const (
+	testKey    = "01234567890123456789012345678901"
+	testAltKey = "abcdefghijklmnopqrstuvwxyz123456"
 )
 
 func TestNewAESCrypto_ValidKey(t *testing.T) {
-	key := "01234567890123456789012345678901" // 32 bytes
-	aes, err := crypto.NewAESCrypto(key)
+	aes, err := crypto.NewAESCrypto(testKey)
 
 	assert.NoError(t, err)
 	assert.NotNil(t, aes)
@@ -44,8 +50,8 @@ func TestNewAESCrypto_InvalidKey(t *testing.T) {
 }
 
 func TestAESCrypto_Encrypt_Success(t *testing.T) {
-	key := ""
-	aes, _ := crypto.NewAESCrypto(key)
+	aes, err := crypto.NewAESCrypto(testKey)
+	require.NoError(t, err)
 
 	plaintext := "Hello, World!"
 	ciphertext, err := aes.Encrypt(plaintext)
@@ -56,8 +62,8 @@ func TestAESCrypto_Encrypt_Success(t *testing.T) {
 }
 
 func TestAESCrypto_Decrypt_Success(t *testing.T) {
-	key := ""
-	aes, _ := crypto.NewAESCrypto(key)
+	aes, err := crypto.NewAESCrypto(testKey)
+	require.NoError(t, err)
 
 	plaintext := "Hello, World!"
 	ciphertext, _ := aes.Encrypt(plaintext)
@@ -69,8 +75,8 @@ func TestAESCrypto_Decrypt_Success(t *testing.T) {
 }
 
 func TestAESCrypto_EncryptDecrypt_MultipleValues(t *testing.T) {
-	key := ""
-	aes, _ := crypto.NewAESCrypto(key)
+	aes, err := crypto.NewAESCrypto(testKey)
+	require.NoError(t, err)
 
 	testCases := []string{
 		"",
@@ -94,8 +100,8 @@ func TestAESCrypto_EncryptDecrypt_MultipleValues(t *testing.T) {
 }
 
 func TestAESCrypto_Decrypt_InvalidCiphertext(t *testing.T) {
-	key := ""
-	aes, _ := crypto.NewAESCrypto(key)
+	aes, err := crypto.NewAESCrypto(testKey)
+	require.NoError(t, err)
 
 	tests := []struct {
 		name       string
@@ -124,8 +130,8 @@ func TestAESCrypto_Decrypt_InvalidCiphertext(t *testing.T) {
 }
 
 func TestAESCrypto_EncryptProducesDifferentOutputs(t *testing.T) {
-	key := ""
-	aes, _ := crypto.NewAESCrypto(key)
+	aes, err := crypto.NewAESCrypto(testKey)
+	require.NoError(t, err)
 
 	plaintext := "same plaintext"
 
@@ -144,11 +150,10 @@ func TestAESCrypto_EncryptProducesDifferentOutputs(t *testing.T) {
 }
 
 func TestAESCrypto_DifferentKeysProduceDifferentOutputs(t *testing.T) {
-	key1 := ""
-	key2 := "abcdefghijklmnopqrstuvwxyz123456"
-
-	aes1, _ := crypto.NewAESCrypto(key1)
-	aes2, _ := crypto.NewAESCrypto(key2)
+	aes1, err := crypto.NewAESCrypto(testKey)
+	require.NoError(t, err)
+	aes2, err := crypto.NewAESCrypto(testAltKey)
+	require.NoError(t, err)
 
 	plaintext := "test message"
 
@@ -159,7 +164,7 @@ func TestAESCrypto_DifferentKeysProduceDifferentOutputs(t *testing.T) {
 	assert.NotEqual(t, encrypted1, encrypted2)
 
 	// 用错误的密钥解密应该失败或得到错误结果
-	_, err := aes1.Decrypt(encrypted2)
+	_, err = aes1.Decrypt(encrypted2)
 	// 可能会失败，也可能得到错误的结果
 	if err == nil {
 		decrypted, _ := aes1.Decrypt(encrypted2)
@@ -168,8 +173,8 @@ func TestAESCrypto_DifferentKeysProduceDifferentOutputs(t *testing.T) {
 }
 
 func TestAESCrypto_LargeData(t *testing.T) {
-	key := ""
-	aes, _ := crypto.NewAESCrypto(key)
+	aes, err := crypto.NewAESCrypto(testKey)
+	require.NoError(t, err)
 
 	// 生成一个大字符串
 	largeText := ""


### PR DESCRIPTION
Backport of #765 (merged to `main`) onto `release/0.1.3`. Clean cherry-pick of both commits, no conflicts, no additional changes.

## What it carries

1. **Crypto tests were passing an empty key.** Seven cases used `key := ""` with `aes, _ := crypto.NewAESCrypto(key)`. The constructor correctly returns `nil` for any key that is not 32 bytes; the discarded error meant the following `Encrypt` call dereferenced a nil receiver and panicked. Replaced with 32-byte constants and `require.NoError`, so the encrypt/decrypt paths are actually exercised. `release-infra-oss-gateway.yml` goes back to `stack: go` + `go-mod-file: go.mod` (it had been switched to `chart-only` to unblock publishing).

2. **Six pre-existing lint findings** that surfaced once the `go` stack (and therefore golangci-lint) was restored:
   - `errcheck` ×3 in `pkg/adapter/minio_adapter.go` — the errors from `policy.SetBucket` / `SetKey` / `SetExpires` were discarded, so a failure there would silently yield an under-constrained presigned POST URL. Now checked and wrapped.
   - `QF1003` in `internal/handler/storage.go` — if/else chain converted to a tagged switch.
   - `SA1019` ×2 in `pkg/crypto/aes.go` — AES-CFB is deprecated and unauthenticated, but it encrypts credentials already stored in the database, so swapping in GCM in place would make existing rows undecryptable. Annotated with `//nolint:staticcheck`; the versioned migration is tracked in #766.

## Verification

`go build ./...` and `go test ./...` pass on this branch (go1.25.6):

```
ok  	oss-gateway/pkg/snowflake	1.065s
ok  	oss-gateway/test/handler	1.430s
ok  	oss-gateway/test/pkg	1.908s
```

golangci-lint is verified by CI (it passed on #765 with the same diff).

Refs #5, #766

🤖 Generated with [Claude Code](https://claude.com/claude-code)