### PR TITLE
fix(action): backport execution-log list trim and aggregated invocation to release/0.1.3

### DIFF
--- a/adp/bkn/ontology-query/server/interfaces/action_execution.go
+++ b/adp/bkn/ontology-query/server/interfaces/action_execution.go
@@ -29,6 +29,17 @@ const (
 	TriggerTypeScheduled = "scheduled"
 )
 
+// Execution mode constants.
+//
+// ExecutionModeOnce means the action parameters do not depend on any instance property,
+// so all matched instances share one identical parameter set and the tool is invoked once.
+// ExecutionModePerInstance means at least one parameter reads an instance property, so the
+// tool is invoked once per matched instance with that instance's own parameters.
+const (
+	ExecutionModeOnce        = "once"
+	ExecutionModePerInstance = "per_instance"
+)
+
 // Action source type constants
 const (
 	ActionSourceTypeTool = "tool"
@@ -69,9 +80,11 @@ type ActionExecution struct {
 	ActionSourceType     string                  `json:"action_source_type"` // "tool" | "mcp"
 	ActionSource         ActionSource            `json:"action_source"`
 	ObjectTypeID         string                  `json:"object_type_id"`
-	TriggerType          string                  `json:"trigger_type"` // "manual" | "scheduled"
-	Status               string                  `json:"status"`       // "pending" | "running" | "completed" | "failed"
-	TotalCount           int                     `json:"total_count"`
+	TriggerType          string                  `json:"trigger_type"`             // "manual" | "scheduled"
+	Status               string                  `json:"status"`                   // "pending" | "running" | "completed" | "failed"
+	ExecutionMode        string                  `json:"execution_mode,omitempty"` // "once" | "per_instance", resolved from the action parameters
+	TargetCount          int                     `json:"target_count,omitempty"`   // matched instances; equals TotalCount under per_instance
+	TotalCount           int                     `json:"total_count"`              // tool invocations planned for this execution
 	SuccessCount         int                     `json:"success_count"`
 	FailedCount          int                     `json:"failed_count"`
 	Results              []ObjectExecutionResult `json:"results"`
@@ -88,16 +101,19 @@ type ActionExecution struct {
 	InstanceIdentityHash string                  `json:"instance_identity_hash,omitempty"` // fingerprint of instances + dynamic_params for duplicate detection
 }
 
-// ObjectExecutionResult represents execution result for a single object
+// ObjectExecutionResult represents execution result for a single object.
+// Under ExecutionModeOnce a single result stands for the whole execution, and the matched
+// instances it covers are carried in Targets.
 type ObjectExecutionResult struct {
 	ObjectSystemInfo
-	Status       string         `json:"status"` // "pending" | "success" | "failed"
-	Parameters   map[string]any `json:"parameters,omitempty"`
-	Result       any            `json:"result,omitempty"`
-	ErrorMessage string         `json:"error_message,omitempty"`
-	StartTime    int64          `json:"start_time,omitempty"`
-	EndTime      int64          `json:"end_time,omitempty"`
-	DurationMs   int64          `json:"duration_ms,omitempty"`
+	Targets      []ObjectSystemInfo `json:"targets,omitempty"` // instances covered by this invocation (once mode only)
+	Status       string             `json:"status"`            // "pending" | "success" | "failed"
+	Parameters   map[string]any     `json:"parameters,omitempty"`
+	Result       any                `json:"result,omitempty"`
+	ErrorMessage string             `json:"error_message,omitempty"`
+	StartTime    int64              `json:"start_time,omitempty"`
+	EndTime      int64              `json:"end_time,omitempty"`
+	DurationMs   int64              `json:"duration_ms,omitempty"`
 }
 
 // ActionLogQuery represents query parameters for execution logs (supports both GET query params and JSON body)

--- a/adp/bkn/ontology-query/server/logics/action_logs/action_logs_service.go
+++ b/adp/bkn/ontology-query/server/logics/action_logs/action_logs_service.go
@@ -305,6 +305,16 @@ func (s *actionLogsService) QueryExecutions(ctx context.Context, query *interfac
 		},
 		"from": offset,
 		"size": limit,
+		// The list only carries execution summaries. Per-instance results live in the same
+		// document and grow with the instance count; reading them here made a single page
+		// drag every historical task's full execution detail across the wire.
+		// action_type_snapshot and action_source are per-execution config copies that no list
+		// consumer reads (the studio list mapper ignores them, context-loader strips them).
+		// Excluded at the OpenSearch level so old documents carrying these fields are covered too.
+		// dynamic_params stays: context-loader keeps it in the slimmed list for the agent.
+		"_source": map[string]any{
+			"excludes": []string{"results", "action_type_snapshot", "action_source"},
+		},
 		"sort": []map[string]any{
 			{"start_time": map[string]any{"order": "desc"}},
 			{"id": map[string]any{"order": "asc"}},

--- a/adp/bkn/ontology-query/server/logics/action_logs/action_logs_service_test.go
+++ b/adp/bkn/ontology-query/server/logics/action_logs/action_logs_service_test.go
@@ -157,6 +157,40 @@ func Test_QueryExecutions_IndexNotExists_ReturnsEmpty(t *testing.T) {
 	})
 }
 
+func Test_QueryExecutions_ExcludesResultsFromSource(t *testing.T) {
+	Convey("QueryExecutions must not read per-instance results from OpenSearch", t, func() {
+		ctrl := gomock.NewController(t)
+		mockOSA := omock.NewMockOpenSearchAccess(ctrl)
+		mockOSA.EXPECT().IndexExists(gomock.Any(), gomock.Any()).Return(true, nil)
+
+		var captured map[string]any
+		mockOSA.EXPECT().SearchData(gomock.Any(), gomock.Any(), gomock.Any()).
+			DoAndReturn(func(_ context.Context, _ string, q any) ([]interfaces.Hit, error) {
+				captured, _ = q.(map[string]any)
+				return []interfaces.Hit{{Source: map[string]any{
+					"id":     "exec_123",
+					"status": "completed",
+				}}}, nil
+			})
+
+		svc := &actionLogsService{osAccess: mockOSA}
+		res, err := svc.QueryExecutions(context.Background(), &interfaces.ActionLogQuery{KNID: "kn_001"})
+
+		So(err, ShouldBeNil)
+		So(len(res.Entries), ShouldEqual, 1)
+
+		source, ok := captured["_source"].(map[string]any)
+		So(ok, ShouldBeTrue)
+		excludes, ok := source["excludes"].([]string)
+		So(ok, ShouldBeTrue)
+		So(excludes, ShouldContain, "results")
+		So(excludes, ShouldContain, "action_type_snapshot")
+		So(excludes, ShouldContain, "action_source")
+		// context-loader keeps dynamic_params in the slimmed list for the agent.
+		So(excludes, ShouldNotContain, "dynamic_params")
+	})
+}
+
 func Test_ActionLogQuery_Defaults(t *testing.T) {
 	Convey("Test ActionLogQuery defaults", t, func() {
 		Convey("should have default values", func() {

--- a/adp/bkn/ontology-query/server/logics/action_scheduler/action_scheduler_service.go
+++ b/adp/bkn/ontology-query/server/logics/action_scheduler/action_scheduler_service.go
@@ -180,6 +180,16 @@ func (s *actionSchedulerService) ExecuteAction(ctx context.Context, req *interfa
 		}
 	}
 
+	// Resolve how many times the tool actually has to be invoked for this execution.
+	executionMode := resolveExecutionMode(&actionType)
+	invocationCount := len(req.Instances)
+	if executionMode == interfaces.ExecutionModeOnce {
+		invocationCount = 1
+		logger.Infof("Action type %s has no instance-dependent parameter, %d matched instances collapse into a single invocation",
+			actionType.ATID, len(req.Instances))
+	}
+	span.SetAttributes(attr.Key("execution_mode").String(executionMode))
+
 	// Generate execution ID
 	executionID := xid.New().String()
 	now := time.Now().UnixMilli()
@@ -202,7 +212,9 @@ func (s *actionSchedulerService) ExecuteAction(ctx context.Context, req *interfa
 		ObjectTypeID:         actionType.ObjectTypeID,
 		TriggerType:          triggerType,
 		Status:               interfaces.ExecutionStatusPending,
-		TotalCount:           len(req.Instances),
+		ExecutionMode:        executionMode,
+		TargetCount:          len(req.Instances),
+		TotalCount:           invocationCount,
 		SuccessCount:         0,
 		FailedCount:          0,
 		Results:              []interfaces.ObjectExecutionResult{}, // Empty initially to save space
@@ -272,13 +284,19 @@ func (s *actionSchedulerService) executeAsync(execution *interfaces.ActionExecut
 		ctx = context.WithValue(ctx, interfaces.BUSINESS_DOMAIN_KEY, req.BusinessDomain)
 	}
 
-	logger.Infof("Starting async execution: %s, total objects: %d", execution.ID, len(req.Instances))
+	logger.Infof("Starting async execution: %s, mode: %s, target instances: %d",
+		execution.ID, execution.ExecutionMode, len(req.Instances))
 
 	// Update status to running
 	if err := s.logsService.UpdateExecution(ctx, execution.KNID, execution.ID, map[string]any{
 		"status": interfaces.ExecutionStatusRunning,
 	}); err != nil {
 		logger.Warnf("Failed to update execution status to running: %v", err)
+	}
+
+	if execution.ExecutionMode == interfaces.ExecutionModeOnce {
+		s.executeOnce(ctx, execution, actionType, req)
+		return
 	}
 
 	// Execute objects in batches
@@ -325,19 +343,7 @@ func (s *actionSchedulerService) executeAsync(execution *interfaces.ActionExecut
 		}
 
 		// Execute based on action source type
-		var result any
-		var execErr error
-
-		switch actionType.ActionSource.Type {
-		case interfaces.ActionSourceTypeTool:
-			result, execErr = ExecuteTool(ctx, s.aoAccess, actionType, params)
-		case interfaces.ActionSourceTypeMCP:
-			// MCP 工具自带入参 schema，未在行动类声明的 dynamic_params 也要透传
-			params = buildMCPParameters(params, req.DynamicParams)
-			result, execErr = ExecuteMCP(ctx, s.aoAccess, actionType, params)
-		default:
-			execErr = fmt.Errorf("unsupported action source type: %s", actionType.ActionSource.Type)
-		}
+		params, result, execErr := s.invokeActionSource(ctx, actionType, params, req.DynamicParams)
 
 		endTime := time.Now().UnixMilli()
 		if execErr != nil {
@@ -399,6 +405,134 @@ func (s *actionSchedulerService) executeAsync(execution *interfaces.ActionExecut
 
 	logger.Infof("Completed async execution: %s, success: %d, failed: %d, cancelled: %d",
 		execution.ID, successCount, failedCount, cancelledCount)
+}
+
+// resolveExecutionMode decides whether the tool has to be invoked once per matched instance.
+//
+// A parameter sourced from an instance property makes every instance resolve a different
+// parameter set, so each instance needs its own invocation. Without any such parameter every
+// matched instance resolves a byte-identical parameter set — const values and the
+// execution-level dynamic_params are the only inputs — and invoking once per instance would
+// submit the very same request N times, i.e. repeat the same side effect N times.
+func resolveExecutionMode(actionType *interfaces.ActionType) string {
+	for _, param := range actionType.Parameters {
+		if param.ValueFrom == interfaces.LOGIC_PARAMS_VALUE_FROM_PROP {
+			return interfaces.ExecutionModePerInstance
+		}
+	}
+	return interfaces.ExecutionModeOnce
+}
+
+// invokeActionSource runs the configured action source once and returns the parameters that
+// were actually submitted, so the recorded result reflects the real request payload.
+func (s *actionSchedulerService) invokeActionSource(ctx context.Context, actionType *interfaces.ActionType,
+	params map[string]any, dynamicParams map[string]any) (map[string]any, any, error) {
+
+	switch actionType.ActionSource.Type {
+	case interfaces.ActionSourceTypeTool:
+		result, err := ExecuteTool(ctx, s.aoAccess, actionType, params)
+		return params, result, err
+	case interfaces.ActionSourceTypeMCP:
+		// MCP 工具自带入参 schema，未在行动类声明的 dynamic_params 也要透传
+		params = buildMCPParameters(params, dynamicParams)
+		result, err := ExecuteMCP(ctx, s.aoAccess, actionType, params)
+		return params, result, err
+	default:
+		return params, nil, fmt.Errorf("unsupported action source type: %s", actionType.ActionSource.Type)
+	}
+}
+
+// executeOnce handles ExecutionModeOnce: one invocation covering every matched instance.
+// The matched instances are recorded as the targets of that invocation, so the execution log
+// still shows what the action was aimed at.
+func (s *actionSchedulerService) executeOnce(ctx context.Context, execution *interfaces.ActionExecution,
+	actionType *interfaces.ActionType, req *interfaces.ActionExecutionRequest) {
+
+	startTime := time.Now().UnixMilli()
+	result := interfaces.ObjectExecutionResult{
+		ObjectSystemInfo: interfaces.ObjectSystemInfo{
+			InstanceIdentity: map[string]any{},
+			Display:          fmt.Sprintf("%d 个目标实例合并为 1 次调用", len(req.Instances)),
+		},
+		Targets:   req.Instances,
+		StartTime: startTime,
+	}
+
+	successCount := 0
+	failedCount := 0
+
+	// The per-instance loop checks for cancellation before each invocation; the single
+	// invocation of this mode needs the same guard, otherwise a cancelled execution would
+	// still fire its tool call.
+	if s.isExecutionCancelled(ctx, execution.KNID, execution.ID) {
+		logger.Infof("Execution %s cancelled before its single invocation was issued", execution.ID)
+		result.Status = interfaces.ObjectStatusCancelled
+		result.ErrorMessage = "execution cancelled"
+		endTime := time.Now().UnixMilli()
+		result.EndTime = endTime
+		result.DurationMs = endTime - startTime
+		s.finishOnce(ctx, execution, result, interfaces.ExecutionStatusCancelled, 0, 0, endTime)
+		return
+	}
+
+	// No parameter reads an instance property in this mode, so an empty object payload
+	// resolves exactly the parameters any matched instance would have resolved.
+	params, err := s.buildExecutionParams(actionType, map[string]any{}, req.DynamicParams)
+	if err != nil {
+		result.Status = interfaces.ObjectStatusFailed
+		result.ErrorMessage = fmt.Sprintf("Failed to build parameters: %v", err)
+		failedCount = 1
+	} else {
+		sentParams, invokeResult, execErr := s.invokeActionSource(ctx, actionType, params, req.DynamicParams)
+		result.Parameters = sentParams
+		if execErr != nil {
+			result.Status = interfaces.ObjectStatusFailed
+			result.ErrorMessage = execErr.Error()
+			failedCount = 1
+		} else {
+			result.Status = interfaces.ObjectStatusSuccess
+			result.Result = invokeResult
+			successCount = 1
+		}
+	}
+
+	endTime := time.Now().UnixMilli()
+	result.EndTime = endTime
+	result.DurationMs = endTime - startTime
+
+	finalStatus := interfaces.ExecutionStatusCompleted
+	if failedCount > 0 {
+		finalStatus = interfaces.ExecutionStatusFailed
+	}
+	// A cancel that lands while the tool call is in flight must not be overwritten by the
+	// terminal status of a call the user already asked to stop. The invocation happened, so
+	// its result is still recorded — only the execution status stays cancelled.
+	if s.isExecutionCancelled(ctx, execution.KNID, execution.ID) {
+		logger.Infof("Execution %s was cancelled while its single invocation was in flight", execution.ID)
+		finalStatus = interfaces.ExecutionStatusCancelled
+	}
+
+	s.finishOnce(ctx, execution, result, finalStatus, successCount, failedCount, endTime)
+
+	logger.Infof("Completed aggregated execution: %s, targets: %d, invocations: 1, status: %s",
+		execution.ID, len(req.Instances), finalStatus)
+}
+
+// finishOnce writes the terminal record of an ExecutionModeOnce run.
+func (s *actionSchedulerService) finishOnce(ctx context.Context, execution *interfaces.ActionExecution,
+	result interfaces.ObjectExecutionResult, finalStatus string, successCount, failedCount int, endTime int64) {
+
+	updates := map[string]any{
+		"status":        finalStatus,
+		"success_count": successCount,
+		"failed_count":  failedCount,
+		"results":       []interfaces.ObjectExecutionResult{result},
+		"end_time":      endTime,
+		"duration_ms":   endTime - execution.StartTime,
+	}
+	if err := s.logsService.UpdateExecution(ctx, execution.KNID, execution.ID, updates); err != nil {
+		logger.Errorf("Failed to update execution record: %v", err)
+	}
 }
 
 func shouldCheckExecutionCancellation(index, total int) bool {

--- a/adp/bkn/ontology-query/server/logics/action_scheduler/action_scheduler_service_test.go
+++ b/adp/bkn/ontology-query/server/logics/action_scheduler/action_scheduler_service_test.go
@@ -575,6 +575,295 @@ func Test_executeAsync_ContextAndProgress(t *testing.T) {
 	})
 }
 
+func Test_resolveExecutionMode(t *testing.T) {
+	Convey("resolveExecutionMode 按参数来源判定执行粒度", t, func() {
+		Convey("含 property 参数时逐实例执行", func() {
+			at := &interfaces.ActionType{Parameters: []interfaces.Parameter{
+				{Name: "text", ValueFrom: interfaces.LOGIC_PARAMS_VALUE_FROM_INPUT},
+				{Name: "order_no", ValueFrom: interfaces.LOGIC_PARAMS_VALUE_FROM_PROP, Value: "order_no"},
+			}}
+			So(resolveExecutionMode(at), ShouldEqual, interfaces.ExecutionModePerInstance)
+		})
+
+		Convey("参数全部来自 input/const 时只执行一次", func() {
+			at := &interfaces.ActionType{Parameters: []interfaces.Parameter{
+				{Name: "source", ValueFrom: interfaces.LOGIC_PARAMS_VALUE_FROM_CONST, Value: "bkn"},
+				{Name: "text", ValueFrom: interfaces.LOGIC_PARAMS_VALUE_FROM_INPUT},
+			}}
+			So(resolveExecutionMode(at), ShouldEqual, interfaces.ExecutionModeOnce)
+		})
+
+		Convey("无参数时只执行一次", func() {
+			at := &interfaces.ActionType{Parameters: []interfaces.Parameter{}}
+			So(resolveExecutionMode(at), ShouldEqual, interfaces.ExecutionModeOnce)
+		})
+	})
+}
+
+func Test_executeAsync_AggregatedInvokesToolOnce(t *testing.T) {
+	Convey("聚合参数命中多个实例时只调用一次工具（#724）", t, func() {
+		mockCtrl := gomock.NewController(t)
+		defer mockCtrl.Finish()
+
+		aoAccess := omock.NewMockAgentOperatorAccess(mockCtrl)
+		logsService := omock.NewMockActionLogsService(mockCtrl)
+		service := &actionSchedulerService{aoAccess: aoAccess, logsService: logsService}
+
+		execution := &interfaces.ActionExecution{
+			ID:            "exec_agg",
+			KNID:          "kn_001",
+			Status:        interfaces.ExecutionStatusPending,
+			ExecutionMode: interfaces.ExecutionModeOnce,
+			TargetCount:   7,
+			TotalCount:    1,
+			StartTime:     1700000000000,
+		}
+		actionType := &interfaces.ActionType{
+			ActionSource: interfaces.ActionSource{
+				Type:   interfaces.ActionSourceTypeTool,
+				BoxID:  "box_001",
+				ToolID: "tool_001",
+			},
+			Parameters: []interfaces.Parameter{
+				{Name: "source", ValueFrom: interfaces.LOGIC_PARAMS_VALUE_FROM_CONST, Value: "bkn"},
+				{Name: "text", ValueFrom: interfaces.LOGIC_PARAMS_VALUE_FROM_INPUT},
+			},
+		}
+
+		instances := make([]interfaces.ObjectSystemInfo, 0, 7)
+		objDatas := make([]map[string]any, 0, 7)
+		for i := 0; i < 7; i++ {
+			id := fmt.Sprintf("order_%d", i)
+			instances = append(instances, interfaces.ObjectSystemInfo{InstanceIdentity: map[string]any{"id": id}})
+			objDatas = append(objDatas, map[string]any{"id": id})
+		}
+		req := &interfaces.ActionExecutionRequest{
+			Instances:     instances,
+			ObjDatas:      objDatas,
+			DynamicParams: map[string]any{"text": "订单编号,订单状态,下单时间\n..."},
+		}
+
+		var finalUpdate map[string]any
+		logsService.EXPECT().UpdateExecution(gomock.Any(), "kn_001", "exec_agg", gomock.Any()).DoAndReturn(
+			func(ctx context.Context, knID, execID string, updates map[string]any) error {
+				if _, ok := updates["results"]; ok {
+					finalUpdate = updates
+				}
+				return nil
+			}).AnyTimes()
+		logsService.EXPECT().GetExecution(gomock.Any(), gomock.Any()).Return(&interfaces.ActionExecution{
+			Status: interfaces.ExecutionStatusRunning,
+		}, nil).AnyTimes()
+
+		// 核心断言：7 个目标实例只产生 1 次工具调用
+		aoAccess.EXPECT().ExecuteTool(gomock.Any(), "box_001", "tool_001", gomock.Any()).DoAndReturn(
+			func(ctx context.Context, boxID, toolID string, execRequest interfaces.ToolExecutionRequest) (any, error) {
+				return map[string]any{"message_id": "m_1"}, nil
+			}).Times(1)
+
+		service.executeAsync(execution, actionType, req)
+
+		So(finalUpdate, ShouldNotBeNil)
+		So(finalUpdate["status"], ShouldEqual, interfaces.ExecutionStatusCompleted)
+		So(finalUpdate["success_count"], ShouldEqual, 1)
+		So(finalUpdate["failed_count"], ShouldEqual, 0)
+
+		results, ok := finalUpdate["results"].([]interfaces.ObjectExecutionResult)
+		So(ok, ShouldBeTrue)
+		So(len(results), ShouldEqual, 1)
+		So(results[0].Status, ShouldEqual, interfaces.ObjectStatusSuccess)
+		// 目标实例不丢失
+		So(len(results[0].Targets), ShouldEqual, 7)
+		So(results[0].Parameters["text"], ShouldEqual, "订单编号,订单状态,下单时间\n...")
+	})
+}
+
+// aggregatedOnceFixture builds an ExecutionModeOnce execution whose parameters are all
+// instance-independent, so the scheduler collapses the matched instances into one invocation.
+func aggregatedOnceFixture(execID string) (*interfaces.ActionExecution, *interfaces.ActionType, *interfaces.ActionExecutionRequest) {
+	execution := &interfaces.ActionExecution{
+		ID:            execID,
+		KNID:          "kn_001",
+		Status:        interfaces.ExecutionStatusRunning,
+		ExecutionMode: interfaces.ExecutionModeOnce,
+		TargetCount:   3,
+		TotalCount:    1,
+		StartTime:     1700000000000,
+	}
+	actionType := &interfaces.ActionType{
+		ActionSource: interfaces.ActionSource{
+			Type:   interfaces.ActionSourceTypeTool,
+			BoxID:  "box_001",
+			ToolID: "tool_001",
+		},
+		Parameters: []interfaces.Parameter{
+			{Name: "text", ValueFrom: interfaces.LOGIC_PARAMS_VALUE_FROM_INPUT},
+		},
+	}
+	req := &interfaces.ActionExecutionRequest{
+		Instances: []interfaces.ObjectSystemInfo{
+			{InstanceIdentity: map[string]any{"id": "1"}},
+			{InstanceIdentity: map[string]any{"id": "2"}},
+			{InstanceIdentity: map[string]any{"id": "3"}},
+		},
+		ObjDatas:      []map[string]any{{"id": "1"}, {"id": "2"}, {"id": "3"}},
+		DynamicParams: map[string]any{"text": "汇总消息"},
+	}
+	return execution, actionType, req
+}
+
+func Test_executeAsync_AggregatedCancelledBeforeInvocation(t *testing.T) {
+	Convey("聚合执行在调用发出前被取消：不得再发出工具调用", t, func() {
+		mockCtrl := gomock.NewController(t)
+		defer mockCtrl.Finish()
+
+		aoAccess := omock.NewMockAgentOperatorAccess(mockCtrl)
+		logsService := omock.NewMockActionLogsService(mockCtrl)
+		service := &actionSchedulerService{aoAccess: aoAccess, logsService: logsService}
+
+		execution, actionType, req := aggregatedOnceFixture("exec_cancel_before")
+
+		var finalUpdate map[string]any
+		logsService.EXPECT().UpdateExecution(gomock.Any(), "kn_001", "exec_cancel_before", gomock.Any()).DoAndReturn(
+			func(ctx context.Context, knID, execID string, updates map[string]any) error {
+				if _, ok := updates["results"]; ok {
+					finalUpdate = updates
+				}
+				return nil
+			}).AnyTimes()
+		logsService.EXPECT().GetExecution(gomock.Any(), gomock.Any()).Return(&interfaces.ActionExecution{
+			Status: interfaces.ExecutionStatusCancelled,
+		}, nil).AnyTimes()
+
+		// 已取消，工具一次也不能调
+		aoAccess.EXPECT().ExecuteTool(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Times(0)
+
+		service.executeAsync(execution, actionType, req)
+
+		So(finalUpdate, ShouldNotBeNil)
+		So(finalUpdate["status"], ShouldEqual, interfaces.ExecutionStatusCancelled)
+		So(finalUpdate["success_count"], ShouldEqual, 0)
+		So(finalUpdate["failed_count"], ShouldEqual, 0)
+		results, ok := finalUpdate["results"].([]interfaces.ObjectExecutionResult)
+		So(ok, ShouldBeTrue)
+		So(results[0].Status, ShouldEqual, interfaces.ObjectStatusCancelled)
+	})
+}
+
+func Test_executeAsync_AggregatedCancelledDuringInvocation(t *testing.T) {
+	Convey("聚合执行在调用途中被取消：终态保持 cancelled，且已发出的调用结果照记", t, func() {
+		mockCtrl := gomock.NewController(t)
+		defer mockCtrl.Finish()
+
+		aoAccess := omock.NewMockAgentOperatorAccess(mockCtrl)
+		logsService := omock.NewMockActionLogsService(mockCtrl)
+		service := &actionSchedulerService{aoAccess: aoAccess, logsService: logsService}
+
+		execution, actionType, req := aggregatedOnceFixture("exec_cancel_during")
+
+		var finalUpdate map[string]any
+		logsService.EXPECT().UpdateExecution(gomock.Any(), "kn_001", "exec_cancel_during", gomock.Any()).DoAndReturn(
+			func(ctx context.Context, knID, execID string, updates map[string]any) error {
+				if _, ok := updates["results"]; ok {
+					finalUpdate = updates
+				}
+				return nil
+			}).AnyTimes()
+
+		// 调用发出前仍是 running，调用返回后已被取消
+		gomock.InOrder(
+			logsService.EXPECT().GetExecution(gomock.Any(), gomock.Any()).Return(&interfaces.ActionExecution{
+				Status: interfaces.ExecutionStatusRunning,
+			}, nil),
+			logsService.EXPECT().GetExecution(gomock.Any(), gomock.Any()).Return(&interfaces.ActionExecution{
+				Status: interfaces.ExecutionStatusCancelled,
+			}, nil),
+		)
+
+		aoAccess.EXPECT().ExecuteTool(gomock.Any(), "box_001", "tool_001", gomock.Any()).
+			Return(map[string]any{"message_id": "m_1"}, nil).Times(1)
+
+		service.executeAsync(execution, actionType, req)
+
+		So(finalUpdate, ShouldNotBeNil)
+		So(finalUpdate["status"], ShouldEqual, interfaces.ExecutionStatusCancelled)
+		// 副作用已经发生，结果必须留痕
+		results, ok := finalUpdate["results"].([]interfaces.ObjectExecutionResult)
+		So(ok, ShouldBeTrue)
+		So(results[0].Status, ShouldEqual, interfaces.ObjectStatusSuccess)
+		So(finalUpdate["success_count"], ShouldEqual, 1)
+	})
+}
+
+func Test_executeAsync_PerInstanceStillFansOut(t *testing.T) {
+	Convey("含 property 参数时仍逐实例执行，计数与改动前一致", t, func() {
+		mockCtrl := gomock.NewController(t)
+		defer mockCtrl.Finish()
+
+		aoAccess := omock.NewMockAgentOperatorAccess(mockCtrl)
+		logsService := omock.NewMockActionLogsService(mockCtrl)
+		service := &actionSchedulerService{aoAccess: aoAccess, logsService: logsService}
+
+		execution := &interfaces.ActionExecution{
+			ID:            "exec_fan",
+			KNID:          "kn_001",
+			Status:        interfaces.ExecutionStatusPending,
+			ExecutionMode: interfaces.ExecutionModePerInstance,
+			TargetCount:   3,
+			TotalCount:    3,
+			StartTime:     1700000000000,
+		}
+		actionType := &interfaces.ActionType{
+			ActionSource: interfaces.ActionSource{
+				Type:   interfaces.ActionSourceTypeTool,
+				BoxID:  "box_001",
+				ToolID: "tool_001",
+			},
+			Parameters: []interfaces.Parameter{
+				{Name: "order_no", ValueFrom: interfaces.LOGIC_PARAMS_VALUE_FROM_PROP, Value: "order_no"},
+			},
+		}
+		req := &interfaces.ActionExecutionRequest{
+			Instances: []interfaces.ObjectSystemInfo{
+				{InstanceIdentity: map[string]any{"id": "1"}},
+				{InstanceIdentity: map[string]any{"id": "2"}},
+				{InstanceIdentity: map[string]any{"id": "3"}},
+			},
+			ObjDatas: []map[string]any{
+				{"order_no": "A"}, {"order_no": "B"}, {"order_no": "C"},
+			},
+		}
+
+		var finalUpdate map[string]any
+		logsService.EXPECT().UpdateExecution(gomock.Any(), "kn_001", "exec_fan", gomock.Any()).DoAndReturn(
+			func(ctx context.Context, knID, execID string, updates map[string]any) error {
+				if _, ok := updates["end_time"]; ok {
+					finalUpdate = updates
+				}
+				return nil
+			}).AnyTimes()
+		logsService.EXPECT().GetExecution(gomock.Any(), gomock.Any()).Return(&interfaces.ActionExecution{
+			Status: interfaces.ExecutionStatusRunning,
+		}, nil).AnyTimes()
+
+		sentOrderNos := []any{}
+		aoAccess.EXPECT().ExecuteTool(gomock.Any(), "box_001", "tool_001", gomock.Any()).DoAndReturn(
+			func(ctx context.Context, boxID, toolID string, execRequest interfaces.ToolExecutionRequest) (any, error) {
+				sentOrderNos = append(sentOrderNos, execRequest.Body["order_no"])
+				return map[string]any{"ok": true}, nil
+			}).Times(3)
+
+		service.executeAsync(execution, actionType, req)
+
+		So(sentOrderNos, ShouldResemble, []any{"A", "B", "C"})
+		So(finalUpdate["success_count"], ShouldEqual, 3)
+		results, ok := finalUpdate["results"].([]interfaces.ObjectExecutionResult)
+		So(ok, ShouldBeTrue)
+		So(len(results), ShouldEqual, 3)
+		So(results[0].Targets, ShouldBeNil)
+	})
+}
+
 func Test_ExecuteAction_InputDynamicParamsValidation(t *testing.T) {
 	Convey("行动执行：行动类含 input 参数时，dynamic_params 未给齐则返回 400", t, func() {
 		mockCtrl := gomock.NewController(t)

--- a/adp/context-loader/agent-retrieval/server/logics/knactionrecall/execute_action.go
+++ b/adp/context-loader/agent-retrieval/server/logics/knactionrecall/execute_action.go
@@ -127,12 +127,15 @@ func (s *knActionRecallServiceImpl) ListActionExecutions(ctx context.Context, re
 		s.logger.WithContext(ctx).Errorf("[KnActionRecall#ListActionExecutions] ListActionExecutions failed, err: %v", err)
 		return nil, err
 	}
-	// 列表每条同样剔除重货（action_type_snapshot 等），仅保留概览字段
+	// 列表每条同样剔除重货（action_type_snapshot 等），仅保留概览字段。
+	// results 不进列表：逐实例明细只在 get_action_execution 里给，列表拿的是任务摘要。
 	if entries, ok := resp["entries"].([]any); ok {
 		slimmed := make([]any, 0, len(entries))
 		for _, e := range entries {
 			if m, ok := e.(map[string]any); ok {
-				slimmed = append(slimmed, slimActionExecution(m))
+				summary := slimActionExecution(m)
+				delete(summary, "results")
+				slimmed = append(slimmed, summary)
 			} else {
 				slimmed = append(slimmed, e)
 			}

--- a/adp/context-loader/agent-retrieval/server/logics/knactionrecall/execute_action_test.go
+++ b/adp/context-loader/agent-retrieval/server/logics/knactionrecall/execute_action_test.go
@@ -171,7 +171,8 @@ func TestListActionExecutions_Success(t *testing.T) {
 						map[string]any{
 							"id":                   "exec-001",
 							"status":               "completed",
-							"action_type_snapshot": map[string]any{"parameters": []any{"x"}}, // 重货，list 精简后应剔除
+							"action_type_snapshot": map[string]any{"parameters": []any{"x"}},   // 重货，list 精简后应剔除
+							"results":              []any{map[string]any{"status": "success"}}, // 逐对象明细只在单查里给
 						},
 					},
 				}, nil
@@ -190,6 +191,9 @@ func TestListActionExecutions_Success(t *testing.T) {
 		convey.So(e0["id"], convey.ShouldEqual, "exec-001")
 		convey.So(e0["status"], convey.ShouldEqual, "completed")
 		convey.So(e0["action_type_snapshot"], convey.ShouldBeNil)
+		// 列表不带逐对象明细：键本身也不应存在，而不是留一个 null
+		_, hasResults := e0["results"]
+		convey.So(hasResults, convey.ShouldBeFalse)
 	})
 }
 

--- a/docs/api/context-loader/action.yaml
+++ b/docs/api/context-loader/action.yaml
@@ -543,7 +543,66 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/ActionExecutionResult'
-          description: 逐对象执行结果。
+          description: 逐对象执行结果。仅单次查询返回，列表不含此字段。
+
+    ActionExecutionSummary:
+      type: object
+      description: |
+        列表里的执行记录摘要。字段与 `ActionExecution` 相同，只是不含 `results`——
+        要逐对象明细请用 `get_action_execution` 按 `id` 单查。
+      properties:
+        id:
+          type: string
+          description: 执行 ID。
+        kn_id:
+          type: string
+          description: 知识网络 ID。
+        action_type_id:
+          type: string
+          description: 行动类 ID。
+        action_type_name:
+          type: string
+          description: 行动类名称。
+        status:
+          type: string
+          enum:
+            - pending
+            - running
+            - completed
+            - failed
+            - cancelled
+          description: 执行状态。
+        trigger_type:
+          type: string
+          enum:
+            - manual
+            - scheduled
+          description: 触发方式。
+        total_count:
+          type: integer
+          description: 目标对象总数。
+        success_count:
+          type: integer
+          description: 成功对象数。
+        failed_count:
+          type: integer
+          description: 失败对象数。
+        start_time:
+          type: integer
+          format: int64
+          description: 开始时间（Unix 毫秒）。
+        end_time:
+          type: integer
+          format: int64
+          description: 结束时间（Unix 毫秒）。
+        duration_ms:
+          type: integer
+          format: int64
+          description: 总耗时（毫秒）。
+        dynamic_params:
+          type: object
+          additionalProperties: true
+          description: 本次执行使用的动态参数。
 
     ActionExecutionResult:
       type: object
@@ -582,8 +641,11 @@ components:
         entries:
           type: array
           items:
-            $ref: '#/components/schemas/ActionExecution'
-          description: 执行记录列表，每条与单次查询同样做过裁剪。
+            $ref: '#/components/schemas/ActionExecutionSummary'
+          description: |
+            执行记录列表，每条与单次查询同样做过裁剪，且**不含 `results`**——
+            逐对象明细只在 `get_action_execution` 里给，避免列表被历史任务的
+            实例明细撑爆。
         total_count:
           type: integer
           description: 命中总数。

--- a/docs/api/ontology-query/ontology-query.yaml
+++ b/docs/api/ontology-query/ontology-query.yaml
@@ -5208,17 +5208,28 @@ components:
             - failed
             - cancelled
           type: string
+        execution_mode:
+          description: |
+            执行粒度，由行动类参数来源推导：参数中存在 value_from=property 的项时为 per_instance，
+            每个命中实例各调用一次工具；否则所有命中实例解析出的参数完全相同，为 once，只调用一次工具。
+          enum:
+            - once
+            - per_instance
+          type: string
+        target_count:
+          description: 命中的目标实例数。per_instance 下与 total_count 相等；once 下可大于 total_count。
+          type: integer
         total_count:
-          description: 对象总数
+          description: 本次执行的工具调用次数。per_instance 下等于命中实例数；once 下恒为 1。
           type: integer
         success_count:
-          description: 成功数量
+          description: 成功的工具调用次数
           type: integer
         failed_count:
-          description: 失败数量
+          description: 失败的工具调用次数
           type: integer
         results:
-          description: 每个对象的执行结果（分页返回）
+          description: 每次工具调用的执行结果（分页返回）。once 模式下只有一条，其覆盖的实例见 targets。
           type: array
           items:
             $ref: "#/components/schemas/ObjectExecutionResult"
@@ -5278,13 +5289,19 @@ components:
             - $ref: '#/components/schemas/MCPSource'
           description: 行动绑定的执行资源（工具箱工具或 MCP 工具）
     ObjectExecutionResult:
-      description: 单个对象的执行结果
+      description: 单次工具调用的执行结果。per_instance 模式下对应一个实例，once 模式下对应整次执行。
       type: object
       properties:
         instance_identity:
           description: 对象实例标识
           type: object
           additionalProperties: true
+        targets:
+          description: 本次调用覆盖的目标实例（仅 once 模式返回）
+          type: array
+          items:
+            type: object
+            additionalProperties: true
         status:
           description: 执行状态
           enum:


### PR DESCRIPTION
Backport of #767 and #769 to `release/0.1.3`. Clean cherry-picks of `f78cc0c2` and `277f1562`, no conflicts, no changes beyond the originals.

Both address #724.

## #767 — execution-log list stops dragging back per-instance results

`QueryExecutions` applied no `_source` trimming, so each page of the action-log list read and returned the full per-instance execution detail of every task it touched (reported: 31.4s, ~36,642 lines of formatted JSON). `results`, `action_type_snapshot` and `action_source` are now excluded at the OpenSearch query layer, which also covers historical documents with embedded results — no migration needed. The context-loader list projection drops the `results` key outright so the agent gets a clean summary rather than a null.

## #769 — aggregated parameters invoke the tool once

If no action parameter has `value_from=property`, every matched instance resolves a byte-identical parameter set, so per-instance invocation repeats the same side effect N times (reported: one aggregated message submitted 7 times). Execution granularity is now resolved from the parameter sources: `per_instance` when a property parameter exists (unchanged behaviour), `once` otherwise. Counting splits into `target_count` (matched instances) and `total_count` (tool invocations). `executeOnce` checks for cancellation before and after the invocation so a cancelled execution neither fires nor gets its status overwritten.

## Verification

Both changes were A/B tested on the dev VM against real data (same action type, same 30 matched instances, images swapped back and forth):

| | invocations | list payload (20 entries) |
|---|---|---|
| before | 30 | 163,133 bytes |
| after | 1 | 12,182 bytes |

The control case — an action type with a `property` parameter — still fans out to 30 invocations with `execution_mode=per_instance` and unchanged counts.

Cancellation mid-invocation could not be reproduced on the VM (the available MCP tools fail within seconds, leaving no window); it is covered by unit tests with ordered mocks.

## Testing

```
ok  ontology-query/logics/action_logs                    3.732s
ok  ontology-query/logics/action_scheduler               3.468s
ok  context-loader/agent-retrieval/logics/knactionrecall 0.270s
```

Refs #724

🤖 Generated with [Claude Code](https://claude.com/claude-code)