### PR TITLE
fix(context-loader): backport execution-mode surfacing and target cap to release/0.1.3

### DIFF
--- a/adp/context-loader/agent-retrieval/server/logics/knactionrecall/execute_action.go
+++ b/adp/context-loader/agent-retrieval/server/logics/knactionrecall/execute_action.go
@@ -60,9 +60,12 @@ func (s *knActionRecallServiceImpl) GetActionExecution(ctx context.Context, req 
 }
 
 // actionExecutionKeepKeys 是单次执行详情中对 Agent 有用、需保留的顶层字段。
+// execution_mode/target_count 必须留：once 模式下 total_count 是工具调用次数（恒为 1），
+// 没有这两个字段，Agent 会把「30 个实例合并成 1 次调用」误读成「只处理了 1 个对象」。
 var actionExecutionKeepKeys = []string{
 	"id", "kn_id", "action_type_id", "action_type_name",
-	"status", "trigger_type", "total_count", "success_count", "failed_count",
+	"status", "trigger_type", "execution_mode", "target_count",
+	"total_count", "success_count", "failed_count",
 	"start_time", "end_time", "duration_ms", "dynamic_params", "results",
 }
 
@@ -86,10 +89,19 @@ func slimActionExecution(full map[string]any) map[string]any {
 }
 
 // actionResultKeepKeys 是逐对象结果中需保留的字段。
+// targets 只在 once 模式出现，装着这一次调用覆盖的实例，是 Agent 判断
+// 「这条聚合结果对应哪些对象」的唯一依据。
 var actionResultKeepKeys = []string{
-	"_instance_id", "_instance_identity", "_display",
+	"_instance_id", "_instance_identity", "_display", "targets",
 	"status", "parameters", "duration_ms", "error_message", "result",
 }
+
+// maxSlimTargets 是单条结果里 targets 的返回上限。
+// once 模式下 results 恒为 1 条，results_limit 只裁结果条数、裁不到条内的 targets，
+// 而一次不带 _instance_identities 的扫描最多可命中 ACTION_EXECUTION_MAX_OBJECTS
+// （默认 10000）个实例。不设上限，一次查询就能把 MB 级实例明细灌进 Agent 上下文，
+// 与这一层压 token 的目的相反。覆盖总数看 target_count，这里只给样本。
+const maxSlimTargets = 20
 
 func slimActionResults(results []any) []any {
 	slim := make([]any, 0, len(results))
@@ -104,6 +116,11 @@ func slimActionResults(results []any) []any {
 			if v, ok := r[k]; ok {
 				out[k] = v
 			}
+		}
+		if targets, ok := out["targets"].([]any); ok && len(targets) > maxSlimTargets {
+			out["targets"] = targets[:maxSlimTargets]
+			out["targets_total"] = len(targets)
+			out["targets_truncated"] = true
 		}
 		slim = append(slim, out)
 	}

--- a/adp/context-loader/agent-retrieval/server/logics/knactionrecall/execute_action_test.go
+++ b/adp/context-loader/agent-retrieval/server/logics/knactionrecall/execute_action_test.go
@@ -125,7 +125,15 @@ func TestGetActionExecution_Success(t *testing.T) {
 			DoAndReturn(func(_ context.Context, r *interfaces.GetActionExecutionRequest) (map[string]any, error) {
 				convey.So(r.KnID, convey.ShouldEqual, "kn-001")
 				convey.So(r.ExecutionID, convey.ShouldEqual, "exec-001")
-				return map[string]any{"id": "exec-001", "status": "completed"}, nil
+				return map[string]any{
+					"id": "exec-001", "status": "completed",
+					"execution_mode": "once", "target_count": 30, "total_count": 1,
+					"results": []any{map[string]any{
+						"status":   "success",
+						"_display": "30 个目标实例合并为 1 次调用",
+						"targets":  []any{map[string]any{"id": "1"}, map[string]any{"id": "2"}},
+					}},
+				}, nil
 			})
 
 		resp, err := service.GetActionExecution(context.Background(), &interfaces.KnGetActionExecutionRequest{
@@ -133,6 +141,54 @@ func TestGetActionExecution_Success(t *testing.T) {
 		})
 		convey.So(err, convey.ShouldBeNil)
 		convey.So(resp["status"], convey.ShouldEqual, "completed")
+		// once 模式的执行必须把粒度与覆盖范围透给 Agent，否则 total_count=1 会被
+		// 误读成「只处理了 1 个对象」
+		convey.So(resp["execution_mode"], convey.ShouldEqual, "once")
+		convey.So(resp["target_count"], convey.ShouldEqual, 30)
+		r0 := resp["results"].([]any)[0].(map[string]any)
+		convey.So(len(r0["targets"].([]any)), convey.ShouldEqual, 2)
+	})
+}
+
+// TestGetActionExecution_TargetsCapped once 模式命中上万实例时,投影层必须截断 targets,
+// 否则一次查询就能把 MB 级实例明细灌进 Agent 上下文
+func TestGetActionExecution_TargetsCapped(t *testing.T) {
+	convey.Convey("TestGetActionExecution_TargetsCapped", t, func() {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		mockLogger := mocks.NewMockLogger(ctrl)
+		mockOntologyQuery := mocks.NewMockDrivenOntologyQuery(ctrl)
+		mockLogger.EXPECT().WithContext(gomock.Any()).Return(mockLogger).AnyTimes()
+		mockLogger.EXPECT().Errorf(gomock.Any(), gomock.Any()).AnyTimes()
+
+		service := &knActionRecallServiceImpl{
+			logger:        mockLogger,
+			config:        &config.Config{},
+			ontologyQuery: mockOntologyQuery,
+		}
+
+		targets := make([]any, 0, 5000)
+		for i := 0; i < 5000; i++ {
+			targets = append(targets, map[string]any{"_instance_identity": map[string]any{"id": i}})
+		}
+		mockOntologyQuery.EXPECT().GetActionExecution(gomock.Any(), gomock.Any()).
+			Return(map[string]any{
+				"id": "exec-agg", "status": "completed",
+				"execution_mode": "once", "target_count": 5000, "total_count": 1,
+				"results": []any{map[string]any{"status": "success", "targets": targets}},
+			}, nil)
+
+		resp, err := service.GetActionExecution(context.Background(), &interfaces.KnGetActionExecutionRequest{
+			KnID: "kn-001", ExecutionID: "exec-agg",
+		})
+		convey.So(err, convey.ShouldBeNil)
+		r0 := resp["results"].([]any)[0].(map[string]any)
+		convey.So(len(r0["targets"].([]any)), convey.ShouldEqual, maxSlimTargets)
+		convey.So(r0["targets_total"], convey.ShouldEqual, 5000)
+		convey.So(r0["targets_truncated"], convey.ShouldBeTrue)
+		// 覆盖总数仍然拿得到
+		convey.So(resp["target_count"], convey.ShouldEqual, 5000)
 	})
 }
 

--- a/docs/api/context-loader/action.yaml
+++ b/docs/api/context-loader/action.yaml
@@ -514,15 +514,34 @@ components:
             - manual
             - scheduled
           description: 触发方式。
+        execution_mode:
+          type: string
+          enum:
+            - once
+            - per_instance
+          description: |
+            执行粒度，由行动类的参数来源推导。参数中存在 `value_from=property` 的项时
+            为 `per_instance`，每个命中实例各调用一次工具；否则所有命中实例解析出的
+            参数完全相同，为 `once`，只调用一次工具。
+        target_count:
+          type: integer
+          description: |
+            命中的目标实例数。`per_instance` 下与 `total_count` 相等；`once` 下可远大于
+            `total_count`——**读这个字段判断这次行动覆盖了多少对象，不要读 total_count**。
+
+            本特性上线前落库的历史记录没有这个字段，也没有 `execution_mode`：那些记录
+            一律是逐实例执行，`total_count` 就是对象数。**判定方法**：`execution_mode`
+            缺失时按 `per_instance` 处理，覆盖范围读 `total_count`。
         total_count:
           type: integer
-          description: 目标对象总数。
+          description: |
+            本次执行的工具调用次数。`per_instance` 下等于命中实例数；`once` 下恒为 1。
         success_count:
           type: integer
-          description: 成功对象数。
+          description: 成功的工具调用次数。
         failed_count:
           type: integer
-          description: 失败对象数。
+          description: 失败的工具调用次数。
         start_time:
           type: integer
           format: int64
@@ -578,15 +597,34 @@ components:
             - manual
             - scheduled
           description: 触发方式。
+        execution_mode:
+          type: string
+          enum:
+            - once
+            - per_instance
+          description: |
+            执行粒度，由行动类的参数来源推导。参数中存在 `value_from=property` 的项时
+            为 `per_instance`，每个命中实例各调用一次工具；否则所有命中实例解析出的
+            参数完全相同，为 `once`，只调用一次工具。
+        target_count:
+          type: integer
+          description: |
+            命中的目标实例数。`per_instance` 下与 `total_count` 相等；`once` 下可远大于
+            `total_count`——**读这个字段判断这次行动覆盖了多少对象，不要读 total_count**。
+
+            本特性上线前落库的历史记录没有这个字段，也没有 `execution_mode`：那些记录
+            一律是逐实例执行，`total_count` 就是对象数。**判定方法**：`execution_mode`
+            缺失时按 `per_instance` 处理，覆盖范围读 `total_count`。
         total_count:
           type: integer
-          description: 目标对象总数。
+          description: |
+            本次执行的工具调用次数。`per_instance` 下等于命中实例数；`once` 下恒为 1。
         success_count:
           type: integer
-          description: 成功对象数。
+          description: 成功的工具调用次数。
         failed_count:
           type: integer
-          description: 失败对象数。
+          description: 失败的工具调用次数。
         start_time:
           type: integer
           format: int64
@@ -606,15 +644,31 @@ components:
 
     ActionExecutionResult:
       type: object
-      description: 单个对象的执行结果（同样是裁剪后的投影）。
+      description: |
+        单次工具调用的执行结果（同样是裁剪后的投影）。`per_instance` 模式下一条对应一个
+        实例；`once` 模式下整次执行只有一条，它覆盖的实例在 `targets` 里。
       properties:
         _instance_id:
           type: string
-          description: 对象唯一标识。
+          description: 对象唯一标识。`once` 模式下为空。
         _instance_identity:
           $ref: '#/components/schemas/InstanceIdentity'
         _display:
-          description: 对象的显示值。
+          description: 对象的显示值。`once` 模式下是「N 个目标实例合并为 1 次调用」。
+        targets:
+          type: array
+          items:
+            type: object
+            additionalProperties: true
+          description: |
+            本次调用覆盖的目标实例，仅 `once` 模式返回，**最多 20 条**。命中实例可能上万，
+            全量返回会撑爆上下文，所以这里只是样本；覆盖总数看外层的 `target_count`。
+        targets_total:
+          type: integer
+          description: 被截断前的 targets 总数，仅截断时返回。
+        targets_truncated:
+          type: boolean
+          description: targets 是否被截断。为 true 时说明实际覆盖实例多于返回的条数。
         status:
           type: string
           description: 该对象的执行结果状态（如 `success` / `failed`）。

--- a/docs/api/ontology-query/ontology-query.yaml
+++ b/docs/api/ontology-query/ontology-query.yaml
@@ -5288,6 +5288,88 @@ components:
             - $ref: '#/components/schemas/ToolSource'
             - $ref: '#/components/schemas/MCPSource'
           description: 行动绑定的执行资源（工具箱工具或 MCP 工具）
+    ActionExecutionSummary:
+      description: |
+        列表里的执行记录摘要。字段与 ActionExecution 相同，但不含 results、
+        action_type_snapshot 与 action_source——要逐实例明细请单查详情端点。
+      type: object
+      properties:
+        id:
+          description: 执行ID
+          type: string
+        kn_id:
+          description: 业务知识网络ID
+          type: string
+        action_type_id:
+          description: 行动类ID
+          type: string
+        action_type_name:
+          description: 行动类名称
+          type: string
+        action_source_type:
+          description: 行动源类型
+          enum:
+            - tool
+            - mcp
+          type: string
+        object_type_id:
+          description: 对象类ID
+          type: string
+        trigger_type:
+          description: 触发类型
+          enum:
+            - manual
+            - scheduled
+          type: string
+        status:
+          description: 执行状态
+          enum:
+            - pending
+            - running
+            - completed
+            - failed
+            - cancelled
+          type: string
+        execution_mode:
+          description: 执行粒度，取值同 ActionExecution。
+          enum:
+            - once
+            - per_instance
+          type: string
+        target_count:
+          description: 命中的目标实例数。
+          type: integer
+        total_count:
+          description: 工具调用次数。once 下恒为 1。
+          type: integer
+        success_count:
+          description: 成功的工具调用次数
+          type: integer
+        failed_count:
+          description: 失败的工具调用次数
+          type: integer
+        dynamic_params:
+          description: 动态参数
+          type: object
+          additionalProperties: true
+        executor_id:
+          description: 执行者ID（已废弃，请使用 executor）
+          type: string
+        executor:
+          $ref: '../_shared/common.yaml#/components/schemas/AccountInfo'
+        start_time:
+          description: 开始时间（Unix 毫秒）
+          type: integer
+          format: int64
+        end_time:
+          description: 结束时间（Unix 毫秒）
+          type: integer
+          format: int64
+        duration_ms:
+          description: 执行耗时（毫秒）
+          type: integer
+          format: int64
+
     ObjectExecutionResult:
       description: 单次工具调用的执行结果。per_instance 模式下对应一个实例，once 模式下对应整次执行。
       type: object
@@ -5395,10 +5477,12 @@ components:
       type: object
       properties:
         entries:
-          description: 执行记录列表
+          description: |
+            执行记录列表。每条只是任务摘要：results、action_type_snapshot、action_source
+            三项在 OpenSearch 查询层就被排除，不随列表返回——逐实例明细请按 log_id 查详情。
           type: array
           items:
-            $ref: "#/components/schemas/ActionExecution"
+            $ref: "#/components/schemas/ActionExecutionSummary"
         total_count:
           description: 总数（当 need_total 为 true 时返回）
           type: integer


### PR DESCRIPTION
Backport of #772 to `release/0.1.3`. Clean cherry-pick of `ee3ae1fe`, no conflicts, no changes beyond the original.

Follows #771, which brought #767 and #769 onto this branch. Together they close the two reported halves of #724 on 0.1.3.

## What it fixes

**The agent could not see what an aggregated run covered.** #769 added `execution_mode`, `target_count` and per-result `targets`, but context-loader's slimming projection never let them through — via `get_action_execution` the agent saw `total_count: 1` and an empty `_instance_identity`, reading "30 instances collapsed into one invocation" as "only 1 object was processed".

**`targets` had no cap.** Under `once` there is exactly one result, so `results_limit` trims the number of results but never reaches inside one, and a scan without `_instance_identities` can match up to `ACTION_EXECUTION_MAX_OBJECTS` (10000 by default). The projection now truncates to 20 targets and adds `targets_total` / `targets_truncated`; the exact coverage number stays available as `target_count`.

**Contracts had drifted.** `total_count` still read "目标对象总数" in both CL schemas; it is now the tool-invocation count, with `execution_mode` and `target_count` documented, plus the rule for records written before this feature (no `execution_mode` → treat as `per_instance`, read coverage from `total_count`). `ActionExecutionList.entries` in `ontology-query.yaml` now points at a summary schema that omits the three fields excluded at the OpenSearch layer.

## Testing

```
ok  context-loader/agent-retrieval/logics/knactionrecall  2.264s
```

Both OpenAPI files parse.

Refs #724

🤖 Generated with [Claude Code](https://claude.com/claude-code)