### PR TITLE
fix(deploy): merge release 0.1.3 main diffs

### DIFF
--- a/bkn-trace/agent-observability/README.md
+++ b/bkn-trace/agent-observability/README.md
@@ -187,7 +187,7 @@ Trace Graph 单次最多返回 1000 个 span 节点。命中上限时服务会�
 
 该 NetworkPolicy 依赖 Kubernetes 1.23 或更高版本。离线执行 `helm template` 时应显式传入 `--kube-version 1.23.0` 或实际目标集群版本；连接集群的 `helm install/upgrade` 会按目标集群能力校验。
 
-Chart 默认不创建或接管 `bkn-trace-evidence-ingest` Secret。OpenBKN 整体安装器在 release 循环前创建或验证该 Secret，并将同一 token 注入 Agent Observability、Context Loader、Vega、BKN Backend、Ontology Query、BKN Agent 与行动执行服务；BKN Backend 和 Ontology Query 同时启用其持久 Evidence outbox worker 与既有清理任务（已投递记录保留 30 天，放弃记录保留 180 天）。单独安装任一 Chart 时，应预先创建并显式引用该 Secret。若要禁用 Evidence 写入，必须同时清空生产者的 ingest URL，不能只省略 token Secret。`evidence.ingestAuth.createSecret=true` 只适用于 Helm 直接执行的首次安装，不适用于 `helm template | kubectl apply`，也不能用于接管已有的外部 Secret。
+Chart 默认不创建或接管 `bkn-trace-evidence-ingest` Secret。OpenBKN 整体安装器在 release 循环前创建或验证该 Secret，并将同一 token 注入 Agent Observability、Context Loader、Vega、BKN Backend、Ontology Query、BKN Agent 与行动执行服务；BKN Backend 和 Ontology Query 同时启用其持久 Evidence outbox worker 与既有清理任务（已投递记录保留 30 天，放弃记录保留 180 天）。单独安装任一 Chart 时，应预先创建并显式引用该 Secret。对无 outbox 的生产者，禁用 Evidence 写入须同时清空 ingest URL 与 token Secret；对启用了 producer outbox 的 BKN Backend 和 Ontology Query，须同时关闭 outbox 与 worker，不能只清空 URL。`evidence.ingestAuth.createSecret=true` 只适用于 Helm 直接执行的首次安装，不适用于 `helm template | kubectl apply`，也不能用于接管已有的外部 Secret。
 
 ```bash
 printf '%s' '<user>:<password>@tcp(<host>:3306)/<database>?parseTime=true' | \

--- a/deploy/release-manifests/0.1.3/bkn-foundry.yaml
+++ b/deploy/release-manifests/0.1.3/bkn-foundry.yaml
@@ -1,0 +1,61 @@
+# Release lockfile for bkn-foundry 0.1.3 — pins the chart version of every
+# component that makes up the product. Consumed by:
+#     deploy.sh openbkn install --version=0.1.3
+# All charts are published at 0.1.3 by the v0.1.3 tag build.
+apiVersion: deploy.openbkn.ai/v0.1.3
+kind: VersionSet
+product: bkn-foundry
+version: 0.1.3
+source:
+  type: oci
+  registry: oci://ghcr.io/openbkn-ai/charts
+releases:
+  core-data-migrator:
+    chart: core-data-migrator
+    version: 0.1.3-release
+    stage: pre
+  bkn-safe:
+    chart: bkn-safe
+    version: 0.1.3-release
+  mf-model-manager:
+    chart: mf-model-manager
+    version: 0.1.3-release
+  mf-model-api:
+    chart: mf-model-api
+    version: 0.1.3-release
+  kafka-connect:
+    chart: kafka-connect
+    version: 0.1.3-release
+  vega-backend:
+    chart: vega-backend
+    version: 0.1.3-release
+  bkn-backend:
+    chart: bkn-backend
+    version: 0.1.3-release
+  ontology-query:
+    chart: ontology-query
+    version: 0.1.3-release
+  agent-operator-integration:
+    chart: agent-operator-integration
+    version: 0.1.3-release
+  oss-gateway-backend:
+    chart: oss-gateway-backend
+    version: 0.1.3-release
+  sandbox:
+    chart: sandbox
+    version: 0.1.3-release
+  agent-retrieval:
+    chart: agent-retrieval
+    version: 0.1.3-release
+  bkn-agent:
+    chart: bkn-agent
+    version: 0.1.3-release
+  agent-observability:
+    chart: agent-observability
+    version: 0.1.3-release
+  otelcol-contrib:
+    chart: otelcol-contrib
+    version: 0.1.3-release
+  bkn-studio:
+    chart: bkn-studio
+    version: 0.1.3-release

--- a/deploy/scripts/services/openbkn.sh
+++ b/deploy/scripts/services/openbkn.sh
@@ -714,13 +714,24 @@ _openbkn_adopt_unowned_resources() {
 
 _openbkn_warn_unwired_evidence_producers() {
     local -a unwired=()
-    local release_name
+    local release_name set_value
+    local has_ingest_url has_ingest_secret
     for release_name in "$@"; do
         _openbkn_release_list_contains "${release_name}" "${_OPENBKN_TRACE_EVIDENCE_PRODUCERS[@]}" || continue
-        case "${release_name}" in
-            agent-retrieval|vega-backend|bkn-backend|ontology-query|bkn-agent|agent-operator-integration) ;;
-            *) unwired+=("${release_name}") ;;
-        esac
+        _openbkn_release_extra_sets "${release_name}"
+        has_ingest_url=false
+        has_ingest_secret=false
+        for set_value in "${CORE_RELEASE_EXTRA_SETS[@]:-}"; do
+            [[ "${set_value}" == *"=${OPENBKN_TRACE_EVIDENCE_INGEST_URL}" ]] && has_ingest_url=true
+            case "${set_value}" in
+                *"ingestTokenSecretName=${OPENBKN_TRACE_INGEST_SECRET}"|\
+                *"ingest_token_secret_name=${OPENBKN_TRACE_INGEST_SECRET}"|\
+                *"EvidenceIngestTokenSecretName=${OPENBKN_TRACE_INGEST_SECRET}")
+                    has_ingest_secret=true
+                    ;;
+            esac
+        done
+        [[ "${has_ingest_url}" == true && "${has_ingest_secret}" == true ]] || unwired+=("${release_name}")
     done
     if [[ ${#unwired[@]} -gt 0 ]]; then
         log_warn "BKN Trace: no Evidence ingest token wired for ${unwired[*]} — their Evidence writes will be rejected until their charts are wired here"

--- a/deploy/scripts/services/openbkn_trace_profile_test.sh
+++ b/deploy/scripts/services/openbkn_trace_profile_test.sh
@@ -190,12 +190,13 @@ else
     ok
 fi
 
-# Keep the guard meaningful: a declared producer without a release profile
-# must still be disclosed instead of letting the no-warning assertion pass.
+# Keep the guard tied to the release entrypoint. If a declared producer is
+# omitted from its outer gate, its actual extra-set result is empty even though
+# the producer name itself is known to the installer.
 LAST_WARN=""
-_OPENBKN_TRACE_EVIDENCE_PRODUCERS+=(not-wired-producer)
-_openbkn_warn_unwired_evidence_producers agent-retrieval not-wired-producer
-contains "names an unwired producer" "${LAST_WARN}" "not-wired-producer"
+_openbkn_release_extra_sets() { CORE_RELEASE_EXTRA_SETS=(); }
+_openbkn_warn_unwired_evidence_producers bkn-agent
+contains "names a declared producer without actual wiring" "${LAST_WARN}" "bkn-agent"
 
 CORE_SET_VALUES=()
 OFFLINE_MODE=true


### PR DESCRIPTION
## What Changed

Brief description of changes:

- [x] Add the `0.1.3` bkn-foundry release manifest to main.
- [x] Bring the release branch deploy-script evidence-producer wiring guard into main.
- [x] Bring the matching trace profile test and Agent Observability README update into main.

---

## Why

- Related Issue: N/A - requested release branch diff merge.
- Related Feature: OpenBKN deployment and BKN Trace Evidence wiring.
- Background: `release/0.1.3` still had four file-level diffs against `main`; this PR carries those release branch differences forward so main retains the 0.1.3 release manifest and deployment guard behavior.

---

## How

- Key implementation points:
  - Copied the four remaining `origin/release/0.1.3` file versions over latest `origin/main` in a clean worktree.
  - The deploy guard now checks actual release extra-set wiring for ingest URL and token secret instead of relying on a hard-coded allowlist.
  - Added the `deploy/release-manifests/0.1.3/bkn-foundry.yaml` version set.
- Breaking changes (API, config, database, etc.): None expected. Deployment script behavior becomes stricter about warning when declared Evidence producers lack actual wiring.

---

## Testing

- [ ] Unit tests passed locally - Not run; no unit-test target for these shell/doc/manifest changes.
- [ ] Integration tests passed locally - Not run.
- [ ] Verified in test environment - Not run locally.

Test notes:

```bash
git diff --cached --check
```

Result: passed.

Attempted related script test:

```bash
bash deploy/scripts/services/openbkn_trace_profile_test.sh
```

Result: could not run locally because `bash` resolves to unavailable Windows/WSL bash, and no Git Bash/sh executable is installed in this environment. Full repository CI was not run.

---

## Risk & Rollback

- Potential risks: Deploy warning behavior may flag producers whose chart values are wired through a pattern not covered by the current extra-set inspection.
- Rollback plan: Revert this PR to restore the previous main-branch deploy script and remove the 0.1.3 release manifest addition.

---

## Additional Notes

- Screenshots, logs, documentation links, etc.: N/A.