### PR TITLE
fix(bkn-backend): pass branch when listing relation types so source/target object types are populated

### DIFF
--- a/adp/bkn/bkn-backend/server/logics/knowledge_network/knowledge_network_service.go
+++ b/adp/bkn/bkn-backend/server/logics/knowledge_network/knowledge_network_service.go
@@ -691,7 +691,8 @@ func (kns *knowledgeNetworkService) GetKNByID(ctx context.Context, knID string, 
 			PaginationQueryParameters: interfaces.PaginationQueryParameters{
 				Limit: -1,
 			},
-			KNID: kn.KNID,
+			KNID:   kn.KNID,
+			Branch: kn.Branch,
 		})
 		if err != nil {
 			return nil, err
@@ -702,7 +703,8 @@ func (kns *knowledgeNetworkService) GetKNByID(ctx context.Context, knID string, 
 			PaginationQueryParameters: interfaces.PaginationQueryParameters{
 				Limit: -1,
 			},
-			KNID: kn.KNID,
+			KNID:   kn.KNID,
+			Branch: kn.Branch,
 		})
 		if err != nil {
 			return nil, err
@@ -713,7 +715,8 @@ func (kns *knowledgeNetworkService) GetKNByID(ctx context.Context, knID string, 
 			PaginationQueryParameters: interfaces.PaginationQueryParameters{
 				Limit: -1,
 			},
-			KNID: kn.KNID,
+			KNID:   kn.KNID,
+			Branch: kn.Branch,
 		})
 		if err != nil {
 			return nil, err

--- a/adp/bkn/bkn-backend/server/logics/relation_type/relation_type_service.go
+++ b/adp/bkn/bkn-backend/server/logics/relation_type/relation_type_service.go
@@ -244,6 +244,12 @@ func (rts *relationTypeService) ListRelationTypes(ctx context.Context,
 	ctx, span := oteltrace.StartNamedInternalSpan(ctx, "查询关系类列表")
 	defer span.End()
 
+	// 分支为空时兜底到主分支：关系类查询本身对空分支有兜底，但补全起点/终点对象类名称的查询没有，
+	// 空分支会硬匹配 f_branch = '' 查出 0 行，导致 SourceObjectType/TargetObjectType 变成空结构体。
+	if query.Branch == "" {
+		query.Branch = interfaces.MAIN_BRANCH
+	}
+
 	// 判断userid是否有查看业务知识网络的权限
 	err := rts.ps.CheckPermission(ctx, interfaces.PermissionResource{
 		Type: interfaces.RESOURCE_TYPE_KN,

--- a/adp/bkn/bkn-backend/server/logics/relation_type/relation_type_service_test.go
+++ b/adp/bkn/bkn-backend/server/logics/relation_type/relation_type_service_test.go
@@ -368,6 +368,50 @@ func Test_relationTypeService_ListRelationTypes(t *testing.T) {
 			So(len(rts), ShouldEqual, 1)
 		})
 
+		Convey("Empty branch falls back to main when filling object type names\n", func() {
+			query := interfaces.RelationTypesQueryParams{
+				KNID: "kn1",
+				PaginationQueryParameters: interfaces.PaginationQueryParameters{
+					Limit:  10,
+					Offset: 0,
+				},
+			}
+			rtArr := []*interfaces.RelationType{
+				{
+					RelationTypeWithKeyField: interfaces.RelationTypeWithKeyField{
+						RTID:               "rt1",
+						RTName:             "rt1",
+						SourceObjectTypeID: "ot1",
+						TargetObjectTypeID: "ot2",
+					},
+				},
+			}
+
+			ps.EXPECT().CheckPermission(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
+			rta.EXPECT().ListRelationTypes(gomock.Any(), gomock.Any()).DoAndReturn(
+				func(_ context.Context, q interfaces.RelationTypesQueryParams) ([]*interfaces.RelationType, error) {
+					So(q.Branch, ShouldEqual, interfaces.MAIN_BRANCH)
+					return rtArr, nil
+				})
+			rta.EXPECT().GetRelationTypesTotal(gomock.Any(), gomock.Any()).Return(1, nil)
+			ots.EXPECT().GetObjectTypesMapByIDs(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(
+				func(_ context.Context, knID string, branch string, otIDs []string, _ bool) (map[string]*interfaces.ObjectType, error) {
+					So(branch, ShouldEqual, interfaces.MAIN_BRANCH)
+					return map[string]*interfaces.ObjectType{
+						"ot1": {ObjectTypeWithKeyField: interfaces.ObjectTypeWithKeyField{OTID: "ot1", OTName: "订单"}},
+						"ot2": {ObjectTypeWithKeyField: interfaces.ObjectTypeWithKeyField{OTID: "ot2", OTName: "用户"}},
+					}, nil
+				})
+			ums.EXPECT().GetAccountNames(gomock.Any(), gomock.Any()).Return(nil)
+
+			rts, total, err := service.ListRelationTypes(ctx, query)
+			So(err, ShouldBeNil)
+			So(total, ShouldEqual, 1)
+			So(len(rts), ShouldEqual, 1)
+			So(rts[0].SourceObjectType.OTName, ShouldEqual, "订单")
+			So(rts[0].TargetObjectType.OTName, ShouldEqual, "用户")
+		})
+
 		Convey("Success with empty result\n", func() {
 			query := interfaces.RelationTypesQueryParams{
 				KNID:   "kn1",


### PR DESCRIPTION
## Problem

`get_relation_types` returns empty `source_object_type` / `target_object_type`:

```json
"source_object_type": {"id":"","name":"","branch":"","icon":"","color":""}
```

Reproduced on the test server with KN `ecommerce_ops_bkn_zh_attrs`, relation type `rel_order_user`.

## Root cause

1. The KN export view (`?mode=export`) calls `ListRelationTypes` without `Branch`, so the branch is an empty string.
2. Relation types themselves are still returned — the relation type SQL falls back to `main` when the branch is empty. But the follow-up step that fills in the source/target object type names passes the empty branch straight to the object type query, and that SQL has no fallback: it matches `f_branch = ''` literally and returns 0 rows.
3. With no object type found, the assignment branch is skipped and `SourceObjectType` keeps its zero value. It is a struct value, not a pointer, so `omitempty` does not apply and it is serialized as `{"id":"","name":"",...}` instead of being omitted.

`source_object_type_id` / `target_object_type_id` were always correct; only the enriched name fields were broken.

## Fix

- `ListRelationTypes` falls back to `MAIN_BRANCH` when the incoming query has an empty branch. This covers every caller, not just export.
- The export block now passes `Branch: kn.Branch` to `ListObjectTypes`, `ListRelationTypes` and `ListActionTypes` (action types had the same omission).

`agent-retrieval` only forwards the payload and needs no change. bkn-studio already falls back to the id for display, which is why the UI looked fine and only MCP/tool consumers saw the empty values.

## Impact

`?mode=export` KN detail, `get_kn_detail` at `full` level, and `get_relation_types`.

## Test

New unit test `Empty branch falls back to main when filling object type names` asserts the downstream object type lookup receives `main` and that the names are populated. It fails without the fix (`Expected: "main"`) and passes with it.

Verified end to end on the test server (14.103.77.23) with an overlay image:

```json
"source_object_type":{"id":"order","name":"销售订单",...},
"target_object_type":{"id":"user","name":"用户",...}
```

A companion PR targets `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)