### PR TITLE
fix(context-loader): rank object types by their own query relevance in search_schema (backport #780 to release/0.1.3)

### DIFF
--- a/adp/context-loader/agent-retrieval/server/logics/knsearch/concept_retrieval.go
+++ b/adp/context-loader/agent-retrieval/server/logics/knsearch/concept_retrieval.go
@@ -56,6 +56,7 @@ func (s *localSearchImpl) conceptRetrieval(
 		len(networkDetail.ObjectTypes), len(networkDetail.RelationTypes), len(networkDetail.ActionTypes))
 
 	// 2. 粗召回（可选，针对大规模知识网络）
+	coarseScored := false
 	if boolValue(config.EnableCoarseRecall) && len(networkDetail.RelationTypes) >= config.CoarseMinRelationCount {
 		s.logger.WithContext(ctx).Infof("[ConceptRetrieval] Enable coarse recall, relation_count=%d >= threshold=%d",
 			len(networkDetail.RelationTypes), config.CoarseMinRelationCount)
@@ -63,14 +64,23 @@ func (s *localSearchImpl) conceptRetrieval(
 		if err != nil {
 			s.logger.WithContext(ctx).Warnf("[ConceptRetrieval] Coarse recall failed, continue with full schema: %v", err)
 			// 粗召回失败不影响后续流程，继续使用完整 Schema
+		} else {
+			coarseScored = true
 		}
 	}
 
-	// 3. 关系类型排序（基于语义相关性）并取 Top-K
+	// 3. 对象类相关性打分。粗召回只在超大网络（关系数 >= CoarseMinRelationCount）
+	// 触发，绝大多数真实网络走不到，对象侧就没有任何查询信号，只能被关系端点被动带出。
+	// 这里补上这条通道，让对象类的相关性能够独立参与后续排序。
+	if !coarseScored {
+		s.scoreObjectTypes(ctx, req.KnID, req.Query, networkDetail.ObjectTypes, config)
+	}
+
+	// 4. 关系类型排序（基于语义相关性）并取 Top-K
 	rankedRelations := s.rankRelationTypes(ctx, req.Query, networkDetail.ObjectTypes, networkDetail.RelationTypes, config.TopK, req.EnableRerank, req.RerankModel)
 	s.logger.WithContext(ctx).Debugf("[ConceptRetrieval] Ranked relations: %d -> top_k=%d", len(networkDetail.RelationTypes), len(rankedRelations))
 
-	// 4. 对象类型选择：按关系过滤 + 粗召回兜底补齐（以及无关系类型场景的排序截断）
+	// 5. 对象类型选择：按自身相关性排序，关系端点作为 schema 自洽约束并入
 	selectedObjects := s.selectObjectTypesForConceptRetrieval(networkDetail.ObjectTypes, rankedRelations, config.TopK)
 	s.logger.WithContext(ctx).Debugf("[ConceptRetrieval] Selected objects: %d", len(selectedObjects))
 
@@ -256,6 +266,69 @@ func (s *localSearchImpl) completeReferencedObjectTypes(
 	return out, nil
 }
 
+// scoreObjectTypes 为对象类打上与 query 的相关性分数（写入 obj.Score）。
+//
+// 与 coarseRecall 的区别：只打分、不裁剪候选集，并且不受 CoarseMinRelationCount
+// 门槛约束。此前 obj.Score 全局唯一的赋值点在 coarseRecall 内部，而它要求关系类型
+// 数 >= CoarseMinRelationCount（默认 5000），正常规模的知识网络永不触发，导致对象类
+// 的相关性从来没有信号来源，只能被关系端点被动带出（issue #778）。
+//
+// 打分失败不影响主流程：拿不到分数时退回原有的关系端点选择，行为与修复前一致。
+func (s *localSearchImpl) scoreObjectTypes(
+	ctx context.Context,
+	knID string,
+	query string,
+	objectTypes []*interfaces.ObjectType,
+	config *interfaces.KnSearchConceptRetrievalConfig,
+) {
+	if strings.TrimSpace(query) == "" || len(objectTypes) == 0 {
+		return
+	}
+
+	limit := config.CoarseObjectLimit
+	if limit <= 0 {
+		limit = DefaultConceptRetrievalConfig().CoarseObjectLimit
+	}
+
+	resp, err := s.bknBackend.SearchObjectTypes(ctx, s.buildCoarseRecallQuery(knID, query, limit, config.ConceptGroups))
+	if err != nil {
+		s.logger.WithContext(ctx).Warnf("[ScoreObjectTypes] SearchObjectTypes failed, object relevance unavailable: %v", err)
+		return
+	}
+	if resp == nil || len(resp.Entries) == 0 {
+		return
+	}
+
+	scoreByID := make(map[string]float64, len(resp.Entries))
+	for _, entry := range resp.Entries {
+		if entry == nil || entry.ID == "" {
+			continue
+		}
+		scoreByID[entry.ID] = entry.Score
+	}
+
+	scored := 0
+	for _, obj := range objectTypes {
+		if obj == nil {
+			continue
+		}
+		if score, ok := scoreByID[obj.ID]; ok && score > 0 {
+			obj.Score = score
+			scored++
+		}
+	}
+	s.logger.WithContext(ctx).Debugf("[ScoreObjectTypes] scored %d/%d object types", scored, len(objectTypes))
+}
+
+// selectObjectTypesForConceptRetrieval 选出参与响应的对象类。
+//
+// 排序主序是对象类自身与 query 的相关性（obj.Score）。关系端点不再是对象类的唯一
+// 来源，只作为 schema 自洽约束并入——返回的关系若指向未返回的对象，调用方拿到的是
+// 断头引用。因此顺序是：相关性最高的 topK 先占位，再并入入选关系的端点，仍有余量
+// 才按相关性补齐。
+//
+// 修复前的行为是反过来的：关系端点铺满即返回，对象自身相关性完全不参与，导致与
+// 查询高度匹配但所属关系排名靠后（或没有关系）的对象类被整体丢弃（issue #778）。
 func (s *localSearchImpl) selectObjectTypesForConceptRetrieval(
 	objectTypes []*interfaces.ObjectType,
 	relations []*interfaces.RelationType,
@@ -265,91 +338,80 @@ func (s *localSearchImpl) selectObjectTypesForConceptRetrieval(
 		return objectTypes
 	}
 
-	maxObjectCountNoRelation := topK * objectTypeRelationMultiplier
-	if len(relations) == 0 {
-		return sortAndTruncateObjectTypesByScore(objectTypes, maxObjectCountNoRelation)
+	maxObjectCount := topK * objectTypeRelationMultiplier
+	if len(relations) > 0 {
+		maxObjectCount = maxInt(len(relations)*objectTypeRelationMultiplier, topK)
+	}
+	if maxObjectCount <= 0 {
+		maxObjectCount = len(objectTypes)
 	}
 
-	filtered := s.filterObjectTypesByRelations(objectTypes, relations)
-	maxObjectCount := maxInt(len(relations)*objectTypeRelationMultiplier, topK)
-	if len(filtered) >= maxObjectCount {
-		return filtered
+	ranked := sortObjectTypesByScore(objectTypes)
+	known := make(map[string]struct{}, len(ranked))
+	for _, obj := range ranked {
+		known[obj.ID] = struct{}{}
 	}
 
-	included := make(map[string]bool, len(filtered))
-	for _, obj := range filtered {
-		included[obj.ID] = true
+	selected := make(map[string]struct{}, maxObjectCount)
+	// 1. 相关性最高的 topK 先占位：这是查询意图的直接体现，优先级高于关系端点
+	for _, obj := range ranked {
+		if len(selected) >= topK {
+			break
+		}
+		selected[obj.ID] = struct{}{}
 	}
-
-	type scoredObject struct {
-		obj   *interfaces.ObjectType
-		score float64
-	}
-	var candidatesWithScore []scoredObject
-	var candidatesWithoutScore []*interfaces.ObjectType
-	for _, obj := range objectTypes {
-		if included[obj.ID] {
+	// 2. 并入入选关系的端点，保证返回的关系不指向缺失的对象
+	for _, rel := range relations {
+		if rel == nil {
 			continue
 		}
-		if obj.Score > 0 {
-			candidatesWithScore = append(candidatesWithScore, scoredObject{obj: obj, score: obj.Score})
-		} else {
-			candidatesWithoutScore = append(candidatesWithoutScore, obj)
+		for _, id := range []string{rel.SourceObjectTypeID, rel.TargetObjectTypeID} {
+			if id == "" || len(selected) >= maxObjectCount {
+				continue
+			}
+			if _, ok := known[id]; !ok {
+				continue
+			}
+			selected[id] = struct{}{}
 		}
 	}
-
-	sort.SliceStable(candidatesWithScore, func(i, j int) bool {
-		return candidatesWithScore[i].score > candidatesWithScore[j].score
-	})
-
-	out := make([]*interfaces.ObjectType, 0, maxObjectCount)
-	out = append(out, filtered...)
-
-	remaining := maxObjectCount - len(out)
-	for i := 0; i < len(candidatesWithScore) && remaining > 0; i++ {
-		out = append(out, candidatesWithScore[i].obj)
-		remaining--
-	}
-	for i := 0; i < len(candidatesWithoutScore) && remaining > 0; i++ {
-		out = append(out, candidatesWithoutScore[i])
-		remaining--
+	// 3. 仍有余量则继续按相关性补齐
+	for _, obj := range ranked {
+		if len(selected) >= maxObjectCount {
+			break
+		}
+		selected[obj.ID] = struct{}{}
 	}
 
+	out := make([]*interfaces.ObjectType, 0, len(selected))
+	for _, obj := range ranked {
+		if _, ok := selected[obj.ID]; ok {
+			out = append(out, obj)
+		}
+	}
 	return out
 }
 
-func sortAndTruncateObjectTypesByScore(objectTypes []*interfaces.ObjectType, limit int) []*interfaces.ObjectType {
-	if limit <= 0 || len(objectTypes) <= limit {
-		return objectTypes
-	}
-
-	type scoredObject struct {
-		obj   *interfaces.ObjectType
-		score float64
-	}
-
-	var withScore []scoredObject
-	var withoutScore []*interfaces.ObjectType
+// sortObjectTypesByScore 按相关性降序排列对象类；无分数的保持原有相对顺序并排在后面。
+func sortObjectTypesByScore(objectTypes []*interfaces.ObjectType) []*interfaces.ObjectType {
+	scored := make([]*interfaces.ObjectType, 0, len(objectTypes))
+	unscored := make([]*interfaces.ObjectType, 0, len(objectTypes))
 	for _, obj := range objectTypes {
+		if obj == nil {
+			continue
+		}
 		if obj.Score > 0 {
-			withScore = append(withScore, scoredObject{obj: obj, score: obj.Score})
+			scored = append(scored, obj)
 		} else {
-			withoutScore = append(withoutScore, obj)
+			unscored = append(unscored, obj)
 		}
 	}
 
-	sort.SliceStable(withScore, func(i, j int) bool {
-		return withScore[i].score > withScore[j].score
+	sort.SliceStable(scored, func(i, j int) bool {
+		return scored[i].Score > scored[j].Score
 	})
 
-	out := make([]*interfaces.ObjectType, 0, limit)
-	for i := 0; i < len(withScore) && len(out) < limit; i++ {
-		out = append(out, withScore[i].obj)
-	}
-	for i := 0; i < len(withoutScore) && len(out) < limit; i++ {
-		out = append(out, withoutScore[i])
-	}
-	return out
+	return append(scored, unscored...)
 }
 
 func maxInt(a, b int) int {
@@ -696,32 +758,6 @@ func (s *localSearchImpl) rankRelationTypesBySimpleMatch(
 	return result
 }
 
-// filterObjectTypesByRelations 根据关系类型过滤对象类型
-func (s *localSearchImpl) filterObjectTypesByRelations(
-	objectTypes []*interfaces.ObjectType,
-	relations []*interfaces.RelationType,
-) []*interfaces.ObjectType {
-	if len(relations) == 0 {
-		return objectTypes
-	}
-
-	// 收集关系涉及的对象类型 ID
-	relatedObjectIDs := make(map[string]bool)
-	for _, rel := range relations {
-		relatedObjectIDs[rel.SourceObjectTypeID] = true
-		relatedObjectIDs[rel.TargetObjectTypeID] = true
-	}
-
-	// 过滤对象类型
-	var filtered []*interfaces.ObjectType
-	for _, obj := range objectTypes {
-		if relatedObjectIDs[obj.ID] {
-			filtered = append(filtered, obj)
-		}
-	}
-
-	return filtered
-}
 
 // calculateRelevanceScore 计算 Query 与概念的相关性分数
 func (s *localSearchImpl) calculateRelevanceScore(query, name, comment string) float64 {

--- a/adp/context-loader/agent-retrieval/server/logics/knsearch/concept_retrieval.go
+++ b/adp/context-loader/agent-retrieval/server/logics/knsearch/concept_retrieval.go
@@ -325,7 +325,10 @@ func (s *localSearchImpl) scoreObjectTypes(
 // 排序主序是对象类自身与 query 的相关性（obj.Score）。关系端点不再是对象类的唯一
 // 来源，只作为 schema 自洽约束并入——返回的关系若指向未返回的对象，调用方拿到的是
 // 断头引用。因此顺序是：相关性最高的 topK 先占位，再并入入选关系的端点，仍有余量
-// 才按相关性补齐。
+// 才按相关性补齐。端点并入**不受 maxObjectCount 约束**，自洽性优先于预算。
+//
+// 若没有任何对象类拿到分数（打分后端不可用等），退回修复前的端点优先顺序：此时
+// 相关性无从谈起，按定义序占满名额只会凭空改变行为。
 //
 // 修复前的行为是反过来的：关系端点铺满即返回，对象自身相关性完全不参与，导致与
 // 查询高度匹配但所属关系排名靠后（或没有关系）的对象类被整体丢弃（issue #778）。
@@ -348,32 +351,45 @@ func (s *localSearchImpl) selectObjectTypesForConceptRetrieval(
 
 	ranked := sortObjectTypesByScore(objectTypes)
 	known := make(map[string]struct{}, len(ranked))
+	scoreAvailable := false
 	for _, obj := range ranked {
 		known[obj.ID] = struct{}{}
+		if obj.Score > 0 {
+			scoreAvailable = true
+		}
 	}
 
-	selected := make(map[string]struct{}, maxObjectCount)
-	// 1. 相关性最高的 topK 先占位：这是查询意图的直接体现，优先级高于关系端点
-	for _, obj := range ranked {
-		if len(selected) >= topK {
-			break
-		}
-		selected[obj.ID] = struct{}{}
-	}
-	// 2. 并入入选关系的端点，保证返回的关系不指向缺失的对象
+	endpoints := make(map[string]struct{}, len(relations)*2)
 	for _, rel := range relations {
 		if rel == nil {
 			continue
 		}
 		for _, id := range []string{rel.SourceObjectTypeID, rel.TargetObjectTypeID} {
-			if id == "" || len(selected) >= maxObjectCount {
+			if id == "" {
 				continue
 			}
 			if _, ok := known[id]; !ok {
 				continue
 			}
-			selected[id] = struct{}{}
+			endpoints[id] = struct{}{}
 		}
+	}
+
+	selected := make(map[string]struct{}, maxObjectCount+len(endpoints))
+	// 1. 相关性最高的 topK 先占位：这是查询意图的直接体现，优先级高于关系端点。
+	// 无分数可用时跳过，把名额留给端点，保持与修复前一致的顺序。
+	if scoreAvailable {
+		for _, obj := range ranked {
+			if len(selected) >= topK {
+				break
+			}
+			selected[obj.ID] = struct{}{}
+		}
+	}
+	// 2. 并入入选关系的端点，保证返回的关系不指向缺失的对象。这里不设上限：
+	// 端点被截断就等于放任断头引用，而出参层只能从本函数的结果里补，救不回来。
+	for id := range endpoints {
+		selected[id] = struct{}{}
 	}
 	// 3. 仍有余量则继续按相关性补齐
 	for _, obj := range ranked {
@@ -384,11 +400,23 @@ func (s *localSearchImpl) selectObjectTypesForConceptRetrieval(
 	}
 
 	out := make([]*interfaces.ObjectType, 0, len(selected))
-	for _, obj := range ranked {
-		if _, ok := selected[obj.ID]; ok {
+	appendSelected := func(match func(id string) bool) {
+		for _, obj := range ranked {
+			if _, ok := selected[obj.ID]; !ok {
+				continue
+			}
+			if !match(obj.ID) {
+				continue
+			}
 			out = append(out, obj)
+			delete(selected, obj.ID)
 		}
 	}
+	if !scoreAvailable {
+		// 与修复前一致：端点优先，其余按定义序补齐
+		appendSelected(func(id string) bool { _, ok := endpoints[id]; return ok })
+	}
+	appendSelected(func(string) bool { return true })
 	return out
 }
 

--- a/adp/context-loader/agent-retrieval/server/logics/knsearch/object_recall_ranking_test.go
+++ b/adp/context-loader/agent-retrieval/server/logics/knsearch/object_recall_ranking_test.go
@@ -1,0 +1,236 @@
+package knsearch
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/interfaces"
+)
+
+// issue #778 回归：对象类必须按自身与 query 的相关性排序，不能只靠关系端点带出。
+//
+// 场景：查询「员工 性别」，「员工」对象类的 name/comment 与 query 命中度最高，
+// 但挂着它的唯一一条关系被 reranker 排在末位。修复前该对象类在 max_concepts=5
+// 时完全不出现，max_concepts=10 时排在最后。
+
+func buildObjectRankingNetwork() *interfaces.KnowledgeNetworkDetail {
+	objNames := []string{
+		"工单", "采购订单", "设备", "仓库", "结算单",
+		"运单", "客户", "入库记录", "质检记录", "员工",
+	}
+	detail := &interfaces.KnowledgeNetworkDetail{ID: "kn_demo"}
+	for i, n := range objNames {
+		detail.ObjectTypes = append(detail.ObjectTypes, &interfaces.ObjectType{
+			ID:      fmt.Sprintf("obj_%d", i),
+			Name:    n,
+			Comment: n + "实体",
+		})
+	}
+	detail.ObjectTypes[9].Comment = "员工主体，含姓名、性别、手机号、岗位"
+
+	rels := [][3]string{
+		{"工单-归属-采购订单", "obj_0", "obj_1"},
+		{"采购订单-使用-设备", "obj_1", "obj_2"},
+		{"采购订单-来自-仓库", "obj_1", "obj_3"},
+		{"采购订单-产生-结算单", "obj_1", "obj_4"},
+		{"运单-关联-采购订单", "obj_5", "obj_1"},
+		{"客户-下达-采购订单", "obj_6", "obj_1"},
+		{"入库-属于-运单", "obj_7", "obj_5"},
+		{"质检-属于-运单", "obj_8", "obj_5"},
+		{"设备-配备-员工", "obj_2", "obj_9"},
+	}
+	for i, r := range rels {
+		detail.RelationTypes = append(detail.RelationTypes, &interfaces.RelationType{
+			ID:                 fmt.Sprintf("rel_%d", i),
+			Name:               r[0],
+			Comment:            r[0],
+			SourceObjectTypeID: r[1],
+			TargetObjectTypeID: r[2],
+		})
+	}
+	return detail
+}
+
+// objectRankingRerank 把挂着「员工」的那条关系排到末位。
+type objectRankingRerank struct{}
+
+func (d *objectRankingRerank) Rerank(ctx context.Context, query string, documents []string, model string) (*interfaces.RerankResp, error) {
+	resp := &interfaces.RerankResp{}
+	for i, doc := range documents {
+		score := 0.9 - float64(i)*0.01
+		if strings.Contains(doc, "员工") {
+			score = 0.5
+		}
+		resp.Results = append(resp.Results, interfaces.RerankResult{Index: i, RelevanceScore: score})
+	}
+	return resp, nil
+}
+
+func (d *objectRankingRerank) Chat(ctx context.Context, req *interfaces.LLMChatReq) (string, error) {
+	return "", nil
+}
+
+// buildScoredObjectEntries 模拟 BKN 概念检索：与 query 最匹配的对象类得分最高。
+func buildScoredObjectEntries(net *interfaces.KnowledgeNetworkDetail, topName string) []*interfaces.ObjectType {
+	entries := make([]*interfaces.ObjectType, 0, len(net.ObjectTypes))
+	for _, o := range net.ObjectTypes {
+		cp := *o
+		cp.Score = 1.0
+		if cp.Name == topName {
+			cp.Score = 12.5
+		}
+		entries = append(entries, &cp)
+	}
+	return entries
+}
+
+func runObjectRankingCase(t *testing.T, maxConcepts int, scope SearchSchemaScope, conceptGroups []string) []string {
+	t.Helper()
+
+	net := buildObjectRankingNetwork()
+	backend := &mockBknBackend{
+		networkDetail:     net,
+		objectTypesResp:   &interfaces.ObjectTypeConcepts{Entries: buildScoredObjectEntries(net, "员工")},
+		relationTypesResp: &interfaces.RelationTypeConcepts{Entries: net.RelationTypes},
+		actionTypesResp:   &interfaces.ActionTypeConcepts{Entries: nil},
+	}
+	svc := &localSearchImpl{
+		logger:       &mockLogger{},
+		bknBackend:   backend,
+		rerankClient: &objectRankingRerank{},
+	}
+
+	cfg := DefaultConceptRetrievalConfig()
+	cfg.TopK = maxConcepts
+	cfg.ConceptGroups = conceptGroups
+
+	req := &interfaces.KnSearchLocalRequest{KnID: "kn_demo", Query: "员工 性别", EnableRerank: true}
+	res, err := svc.conceptRetrieval(context.Background(), req, cfg)
+	if err != nil {
+		t.Fatalf("conceptRetrieval failed: %v", err)
+	}
+
+	knResp := &interfaces.KnSearchResp{ObjectTypes: res.ObjectTypes, RelationTypes: res.RelationTypes}
+	filtered := FilterSearchSchemaResp(knResp, nil, scope, maxConcepts)
+
+	names := []string{}
+	for _, o := range filtered.ObjectTypes {
+		m, ok := o.(map[string]any)
+		if !ok {
+			continue
+		}
+		if n, ok := m["concept_name"].(string); ok {
+			names = append(names, n)
+		}
+	}
+	return names
+}
+
+func TestObjectTypesRankedByOwnRelevance(t *testing.T) {
+	allOn := SearchSchemaScope{IncludeObjectTypes: true, IncludeRelationTypes: true, IncludeActionTypes: true}
+	objectOnly := SearchSchemaScope{IncludeObjectTypes: true}
+
+	cases := []struct {
+		name          string
+		maxConcepts   int
+		scope         SearchSchemaScope
+		conceptGroups []string
+		// 关系一并返回时，端点补齐允许超出 max_concepts（既有的 schema 自洽契约）；
+		// 只要对象类，就必须严格受 max_concepts 约束。
+		exactLimit bool
+	}{
+		{"四类全开/传统路径", 5, allOn, nil, false},
+		{"仅对象类/传统路径", 5, objectOnly, nil, true},
+		{"四类全开/分组路径", 5, allOn, []string{"grp_demo"}, false},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := runObjectRankingCase(t, tc.maxConcepts, tc.scope, tc.conceptGroups)
+			t.Logf("max_concepts=%d -> %v", tc.maxConcepts, got)
+
+			if len(got) == 0 {
+				t.Fatalf("expected object types, got none")
+			}
+			if got[0] != "员工" {
+				t.Errorf("expected 员工 ranked first, got %v", got)
+			}
+			if tc.exactLimit && len(got) != tc.maxConcepts {
+				t.Errorf("expected exactly %d object types (max_concepts), got %d: %v", tc.maxConcepts, len(got), got)
+			}
+		})
+	}
+}
+
+// 孤儿对象类（不挂任何关系）同样必须能按相关性召回。
+func TestOrphanObjectTypeIsRecalled(t *testing.T) {
+	net := buildObjectRankingNetwork()
+	// 摘掉唯一一条挂着「员工」的关系，令其成为孤儿对象
+	net.RelationTypes = net.RelationTypes[:len(net.RelationTypes)-1]
+
+	backend := &mockBknBackend{
+		networkDetail:     net,
+		objectTypesResp:   &interfaces.ObjectTypeConcepts{Entries: buildScoredObjectEntries(net, "员工")},
+		relationTypesResp: &interfaces.RelationTypeConcepts{Entries: net.RelationTypes},
+	}
+	svc := &localSearchImpl{
+		logger:       &mockLogger{},
+		bknBackend:   backend,
+		rerankClient: &objectRankingRerank{},
+	}
+
+	cfg := DefaultConceptRetrievalConfig()
+	cfg.TopK = 5
+
+	req := &interfaces.KnSearchLocalRequest{KnID: "kn_demo", Query: "员工 性别", EnableRerank: true}
+	res, err := svc.conceptRetrieval(context.Background(), req, cfg)
+	if err != nil {
+		t.Fatalf("conceptRetrieval failed: %v", err)
+	}
+
+	knResp := &interfaces.KnSearchResp{ObjectTypes: res.ObjectTypes, RelationTypes: res.RelationTypes}
+	scope := SearchSchemaScope{IncludeObjectTypes: true, IncludeRelationTypes: true}
+	filtered := FilterSearchSchemaResp(knResp, nil, scope, 5)
+
+	names := []string{}
+	for _, o := range filtered.ObjectTypes {
+		if m, ok := o.(map[string]any); ok {
+			if n, ok := m["concept_name"].(string); ok {
+				names = append(names, n)
+			}
+		}
+	}
+	t.Logf("orphan case -> %v", names)
+
+	if len(names) == 0 || names[0] != "员工" {
+		t.Errorf("expected orphan 员工 ranked first, got %v", names)
+	}
+}
+
+// 打分不可用（BKN 检索失败）时必须优雅降级，不能报错或返回空。
+func TestObjectScoringDegradesWhenBackendFails(t *testing.T) {
+	net := buildObjectRankingNetwork()
+	backend := &mockBknBackend{
+		networkDetail:    net,
+		objectTypesError: fmt.Errorf("backend unavailable"),
+	}
+	svc := &localSearchImpl{
+		logger:       &mockLogger{},
+		bknBackend:   backend,
+		rerankClient: &objectRankingRerank{},
+	}
+
+	cfg := DefaultConceptRetrievalConfig()
+	cfg.TopK = 5
+
+	req := &interfaces.KnSearchLocalRequest{KnID: "kn_demo", Query: "员工 性别", EnableRerank: true}
+	res, err := svc.conceptRetrieval(context.Background(), req, cfg)
+	if err != nil {
+		t.Fatalf("expected graceful degradation, got error: %v", err)
+	}
+	if len(res.ObjectTypes) == 0 {
+		t.Errorf("expected object types on degraded path, got none")
+	}
+}

--- a/adp/context-loader/agent-retrieval/server/logics/knsearch/object_recall_ranking_test.go
+++ b/adp/context-loader/agent-retrieval/server/logics/knsearch/object_recall_ranking_test.go
@@ -209,10 +209,41 @@ func TestOrphanObjectTypeIsRecalled(t *testing.T) {
 	}
 }
 
+// buildEndpointsLastNetwork 构造一个「关系端点全部排在定义序末尾」的网络。
+//
+// 这个形状是刻意的：只有当端点集不等于定义序的前若干个时，「端点优先」与「定义序」
+// 才是两种可区分的顺序，降级路径的顺序断言才有鉴别力。
+func buildEndpointsLastNetwork() *interfaces.KnowledgeNetworkDetail {
+	detail := &interfaces.KnowledgeNetworkDetail{ID: "kn_endpoints_last"}
+	for i := 0; i < 10; i++ {
+		detail.ObjectTypes = append(detail.ObjectTypes, &interfaces.ObjectType{
+			ID:      fmt.Sprintf("obj_%d", i),
+			Name:    fmt.Sprintf("对象_%d", i),
+			Comment: fmt.Sprintf("对象_%d 说明", i),
+		})
+	}
+	// 关系只挂在定义序靠后的 obj_6..obj_9 上
+	rels := [][3]string{
+		{"关系_A", "obj_6", "obj_7"},
+		{"关系_B", "obj_8", "obj_9"},
+		{"关系_C", "obj_7", "obj_8"},
+	}
+	for i, r := range rels {
+		detail.RelationTypes = append(detail.RelationTypes, &interfaces.RelationType{
+			ID:                 fmt.Sprintf("rel_%d", i),
+			Name:               r[0],
+			Comment:            r[0],
+			SourceObjectTypeID: r[1],
+			TargetObjectTypeID: r[2],
+		})
+	}
+	return detail
+}
+
 // 打分不可用（BKN 检索失败）时必须优雅降级：不报错、不返回空，
 // 且顺序退回修复前的「关系端点优先」，不能凭空改成定义序。
 func TestObjectScoringDegradesWhenBackendFails(t *testing.T) {
-	net := buildObjectRankingNetwork()
+	net := buildEndpointsLastNetwork()
 	backend := &mockBknBackend{
 		networkDetail:    net,
 		objectTypesError: fmt.Errorf("backend unavailable"),
@@ -226,7 +257,7 @@ func TestObjectScoringDegradesWhenBackendFails(t *testing.T) {
 	cfg := DefaultConceptRetrievalConfig()
 	cfg.TopK = 5
 
-	req := &interfaces.KnSearchLocalRequest{KnID: "kn_demo", Query: "员工 性别", EnableRerank: true}
+	req := &interfaces.KnSearchLocalRequest{KnID: "kn_endpoints_last", Query: "对象", EnableRerank: true}
 	res, err := svc.conceptRetrieval(context.Background(), req, cfg)
 	if err != nil {
 		t.Fatalf("expected graceful degradation, got error: %v", err)
@@ -240,11 +271,38 @@ func TestObjectScoringDegradesWhenBackendFails(t *testing.T) {
 		endpoints[rel.SourceObjectTypeID] = struct{}{}
 		endpoints[rel.TargetObjectTypeID] = struct{}{}
 	}
-	seenNonEndpoint := false
+	if len(endpoints) == 0 {
+		t.Fatalf("fixture must yield relation endpoints, got none")
+	}
+
+	got := make([]string, 0, len(res.ObjectTypes))
 	for _, obj := range res.ObjectTypes {
-		_, isEndpoint := endpoints[obj.ConceptID]
+		got = append(got, obj.ConceptID)
+	}
+	t.Logf("degraded order -> %v (endpoints=%d)", got, len(endpoints))
+
+	// 断言的鉴别力前提：端点集不等于定义序的前 N 个，否则「端点优先」与「定义序」
+	// 无从区分，这条断言就是空的。
+	definitionOrderHead := map[string]struct{}{}
+	for i := 0; i < len(endpoints); i++ {
+		definitionOrderHead[fmt.Sprintf("obj_%d", i)] = struct{}{}
+	}
+	sameAsDefinitionOrder := true
+	for id := range endpoints {
+		if _, ok := definitionOrderHead[id]; !ok {
+			sameAsDefinitionOrder = false
+			break
+		}
+	}
+	if sameAsDefinitionOrder {
+		t.Fatalf("fixture cannot distinguish endpoint-first from definition order; endpoints=%v", endpoints)
+	}
+
+	seenNonEndpoint := false
+	for _, id := range got {
+		_, isEndpoint := endpoints[id]
 		if isEndpoint && seenNonEndpoint {
-			t.Errorf("degraded path must keep relation endpoints first, got %s after a non-endpoint", obj.ConceptID)
+			t.Errorf("degraded path must keep relation endpoints first, got %s after a non-endpoint: %v", id, got)
 			break
 		}
 		if !isEndpoint {

--- a/adp/context-loader/agent-retrieval/server/logics/knsearch/object_recall_ranking_test.go
+++ b/adp/context-loader/agent-retrieval/server/logics/knsearch/object_recall_ranking_test.go
@@ -209,7 +209,8 @@ func TestOrphanObjectTypeIsRecalled(t *testing.T) {
 	}
 }
 
-// 打分不可用（BKN 检索失败）时必须优雅降级，不能报错或返回空。
+// 打分不可用（BKN 检索失败）时必须优雅降级：不报错、不返回空，
+// 且顺序退回修复前的「关系端点优先」，不能凭空改成定义序。
 func TestObjectScoringDegradesWhenBackendFails(t *testing.T) {
 	net := buildObjectRankingNetwork()
 	backend := &mockBknBackend{
@@ -231,6 +232,87 @@ func TestObjectScoringDegradesWhenBackendFails(t *testing.T) {
 		t.Fatalf("expected graceful degradation, got error: %v", err)
 	}
 	if len(res.ObjectTypes) == 0 {
-		t.Errorf("expected object types on degraded path, got none")
+		t.Fatalf("expected object types on degraded path, got none")
+	}
+
+	endpoints := map[string]struct{}{}
+	for _, rel := range res.RelationTypes {
+		endpoints[rel.SourceObjectTypeID] = struct{}{}
+		endpoints[rel.TargetObjectTypeID] = struct{}{}
+	}
+	seenNonEndpoint := false
+	for _, obj := range res.ObjectTypes {
+		_, isEndpoint := endpoints[obj.ConceptID]
+		if isEndpoint && seenNonEndpoint {
+			t.Errorf("degraded path must keep relation endpoints first, got %s after a non-endpoint", obj.ConceptID)
+			break
+		}
+		if !isEndpoint {
+			seenNonEndpoint = true
+		}
+	}
+}
+
+// 入选关系的端点必须全部出现在对象类里，哪怕超出 maxObjectCount 预算——
+// 否则返回的关系会指向缺失的对象，调用方拿到断头引用。
+func TestRelationEndpointsAreNeverDropped(t *testing.T) {
+	// 5 条互不共享端点的关系 → 10 个不同端点，刻意超过 maxObjectCount 预算
+	detail := &interfaces.KnowledgeNetworkDetail{ID: "kn_disjoint"}
+	for i := 0; i < 12; i++ {
+		detail.ObjectTypes = append(detail.ObjectTypes, &interfaces.ObjectType{
+			ID:      fmt.Sprintf("obj_%d", i),
+			Name:    fmt.Sprintf("对象_%d", i),
+			Comment: fmt.Sprintf("对象_%d 说明", i),
+		})
+	}
+	for i := 0; i < 5; i++ {
+		detail.RelationTypes = append(detail.RelationTypes, &interfaces.RelationType{
+			ID:                 fmt.Sprintf("rel_%d", i),
+			Name:               fmt.Sprintf("关系_%d", i),
+			SourceObjectTypeID: fmt.Sprintf("obj_%d", i*2),
+			TargetObjectTypeID: fmt.Sprintf("obj_%d", i*2+1),
+		})
+	}
+	// 让两个与关系无关的对象类拿到最高分，占满 topK 名额
+	scoredEntries := make([]*interfaces.ObjectType, 0, len(detail.ObjectTypes))
+	for _, o := range detail.ObjectTypes {
+		cp := *o
+		cp.Score = 1.0
+		if cp.ID == "obj_10" || cp.ID == "obj_11" {
+			cp.Score = 99.0
+		}
+		scoredEntries = append(scoredEntries, &cp)
+	}
+
+	svc := &localSearchImpl{
+		logger: &mockLogger{},
+		bknBackend: &mockBknBackend{
+			networkDetail:     detail,
+			objectTypesResp:   &interfaces.ObjectTypeConcepts{Entries: scoredEntries},
+			relationTypesResp: &interfaces.RelationTypeConcepts{Entries: detail.RelationTypes},
+		},
+		rerankClient: &objectRankingRerank{},
+	}
+
+	cfg := DefaultConceptRetrievalConfig()
+	cfg.TopK = 5
+
+	req := &interfaces.KnSearchLocalRequest{KnID: "kn_disjoint", Query: "对象", EnableRerank: true}
+	res, err := svc.conceptRetrieval(context.Background(), req, cfg)
+	if err != nil {
+		t.Fatalf("conceptRetrieval failed: %v", err)
+	}
+
+	present := map[string]struct{}{}
+	for _, obj := range res.ObjectTypes {
+		present[obj.ConceptID] = struct{}{}
+	}
+	for _, rel := range res.RelationTypes {
+		for _, id := range []string{rel.SourceObjectTypeID, rel.TargetObjectTypeID} {
+			if _, ok := present[id]; !ok {
+				t.Errorf("relation %s references object %s missing from the response (objects=%d)",
+					rel.ConceptID, id, len(res.ObjectTypes))
+			}
+		}
 	}
 }

--- a/adp/context-loader/agent-retrieval/server/logics/knsearch/search_schema.go
+++ b/adp/context-loader/agent-retrieval/server/logics/knsearch/search_schema.go
@@ -136,7 +136,7 @@ func FilterSearchSchemaResp(resp *interfaces.KnSearchResp, metricTypes []any, sc
 	}
 	if scope.IncludeObjectTypes {
 		if scope.IncludeRelationTypes && len(relationTypes) > 0 {
-			objectTypes = mergeRelationEndpointObjectsWithDirectFill(objectTypes, relationTypes, maxConcepts)
+			objectTypes = limitObjectTypesKeepingRelationEndpoints(objectTypes, relationTypes, maxConcepts)
 		} else {
 			objectTypes = limitAnySlice(objectTypes, maxConcepts)
 		}
@@ -339,7 +339,15 @@ func limitAnySlice(items []any, limit int) []any {
 	return items[:limit]
 }
 
-func mergeRelationEndpointObjectsWithDirectFill(objectTypes, relationTypes []any, limit int) []any {
+// limitObjectTypesKeepingRelationEndpoints 按相关性截断对象类，同时补齐返回关系的端点。
+//
+// 两条约束的优先级：
+//  1. 相关性优先——检索层已按对象类自身与 query 的相关性排好序，先取前 limit 个。
+//     修复前这里会把关系端点整体提到最前，把相关性排序又打乱一次，导致与查询最匹配
+//     的对象类被挤出响应（issue #778）。
+//  2. 自洽兜底——返回的关系若指向未返回的对象，调用方拿到的是断头引用，因此缺失的
+//     端点一律补上，允许超出 limit。这是既有契约，本次修复保留。
+func limitObjectTypesKeepingRelationEndpoints(objectTypes, relationTypes []any, limit int) []any {
 	if len(objectTypes) == 0 {
 		return objectTypes
 	}
@@ -347,33 +355,48 @@ func mergeRelationEndpointObjectsWithDirectFill(objectTypes, relationTypes []any
 		return limitAnySlice(objectTypes, limit)
 	}
 
-	objectByID := make(map[string]any, len(objectTypes))
-	for _, obj := range objectTypes {
-		objMap, ok := obj.(map[string]any)
+	conceptIDOf := func(item any) string {
+		itemMap, ok := item.(map[string]any)
 		if !ok {
-			continue
+			return ""
 		}
-		conceptID, ok := objMap["concept_id"].(string)
-		if !ok || conceptID == "" {
-			continue
-		}
-		objectByID[conceptID] = obj
+		conceptID, _ := itemMap["concept_id"].(string)
+		return conceptID
 	}
 
-	seen := make(map[string]struct{}, len(objectTypes))
-	out := make([]any, 0, len(objectTypes))
-	appendObjectByID := func(conceptID string) {
+	// 必须拷贝：limitAnySlice 返回的是 objectTypes 的子切片，直接 append 会写坏原切片。
+	head := limitAnySlice(objectTypes, limit)
+	out := make([]any, len(head), len(objectTypes))
+	copy(out, head)
+
+	included := make(map[string]struct{}, len(out))
+	for _, obj := range out {
+		if conceptID := conceptIDOf(obj); conceptID != "" {
+			included[conceptID] = struct{}{}
+		}
+	}
+
+	objectByID := make(map[string]any, len(objectTypes))
+	for _, obj := range objectTypes {
+		if conceptID := conceptIDOf(obj); conceptID != "" {
+			if _, exists := objectByID[conceptID]; !exists {
+				objectByID[conceptID] = obj
+			}
+		}
+	}
+
+	appendEndpoint := func(conceptID string) {
 		if conceptID == "" {
 			return
 		}
-		if _, ok := seen[conceptID]; ok {
+		if _, ok := included[conceptID]; ok {
 			return
 		}
 		obj, ok := objectByID[conceptID]
 		if !ok {
 			return
 		}
-		seen[conceptID] = struct{}{}
+		included[conceptID] = struct{}{}
 		out = append(out, obj)
 	}
 
@@ -384,32 +407,8 @@ func mergeRelationEndpointObjectsWithDirectFill(objectTypes, relationTypes []any
 		}
 		sourceID, _ := relMap["source_object_type_id"].(string)
 		targetID, _ := relMap["target_object_type_id"].(string)
-		appendObjectByID(sourceID)
-		appendObjectByID(targetID)
-	}
-
-	remaining := limit - len(out)
-	if remaining <= 0 {
-		return out
-	}
-	for _, obj := range objectTypes {
-		objMap, ok := obj.(map[string]any)
-		if !ok {
-			continue
-		}
-		conceptID, ok := objMap["concept_id"].(string)
-		if !ok || conceptID == "" {
-			continue
-		}
-		if _, ok := seen[conceptID]; ok {
-			continue
-		}
-		seen[conceptID] = struct{}{}
-		out = append(out, obj)
-		remaining--
-		if remaining == 0 {
-			break
-		}
+		appendEndpoint(sourceID)
+		appendEndpoint(targetID)
 	}
 
 	return out

--- a/adp/context-loader/agent-retrieval/server/logics/knsearch/search_schema_test.go
+++ b/adp/context-loader/agent-retrieval/server/logics/knsearch/search_schema_test.go
@@ -264,7 +264,9 @@ func TestSearchSchema_LimitsObjectTypesWhenRelationTypesExcluded(t *testing.T) {
 	})
 }
 
-func TestSearchSchema_RelationEndpointsTakePriorityAndDirectObjectsFillRemainingBudget(t *testing.T) {
+// 对象类的相关性顺序（由检索层决定）不再被关系端点重排。
+// 修复前该用例断言端点优先，导致与查询最匹配的对象类被挤到后面甚至挤出响应（issue #778）。
+func TestSearchSchema_ObjectRelevanceOrderIsPreserved(t *testing.T) {
 	maxConcepts := 10
 	service := &knSearchService{
 		Logger: infraLogger.DefaultLogger(),
@@ -293,9 +295,10 @@ func TestSearchSchema_RelationEndpointsTakePriorityAndDirectObjectsFillRemaining
 		}
 
 		if got := len(resp.ObjectTypes); got != 3 {
-			t.Fatalf("ObjectTypes len=%d, want 3 endpoint objects plus direct object fill", got)
+			t.Fatalf("ObjectTypes len=%d, want all 3 objects within budget", got)
 		}
-		wantIDs := []string{"ot_requirement", "ot_project", "ot_resource_project"}
+		// 预算充足时全部返回，顺序保持检索层给出的相关性顺序
+		wantIDs := []string{"ot_resource_project", "ot_project", "ot_requirement"}
 		for i, want := range wantIDs {
 			if got := resp.ObjectTypes[i].(map[string]any)["concept_id"]; got != want {
 				t.Fatalf("ObjectTypes[%d] concept_id=%v, want %s", i, got, want)
@@ -335,10 +338,12 @@ func TestSearchSchema_RelationEndpointsMayExceedMaxConceptsForCompleteness(t *te
 		if got := len(resp.RelationTypes); got != 1 {
 			t.Fatalf("RelationTypes len=%d, want 1", got)
 		}
-		if got := len(resp.ObjectTypes); got != 2 {
-			t.Fatalf("ObjectTypes len=%d, want both relation endpoint objects", got)
+		// 预算内先给相关性最高的对象类，再补齐关系端点以保证 schema 自洽——
+		// 端点补齐允许超出 max_concepts，这是既有契约。
+		if got := len(resp.ObjectTypes); got != 3 {
+			t.Fatalf("ObjectTypes len=%d, want top-relevance object plus both relation endpoints", got)
 		}
-		wantIDs := []string{"ot_requirement", "ot_project"}
+		wantIDs := []string{"ot_resource_project", "ot_requirement", "ot_project"}
 		for i, want := range wantIDs {
 			if got := resp.ObjectTypes[i].(map[string]any)["concept_id"]; got != want {
 				t.Fatalf("ObjectTypes[%d] concept_id=%v, want %s", i, got, want)


### PR DESCRIPTION
Backport of #780 to `release/0.1.3`.

## Problem

`search_schema` ranked **relations** by query relevance and then derived object types from the endpoints of the top-ranked relations. An object type's own relevance to the query never entered the decision, so an object type whose name and comment matched the query closely was dropped entirely whenever its relations ranked low — or when it had no relations at all.

Root cause: `obj.Score` had exactly one assignment site, inside `coarseRecall`, gated on `len(relationTypes) >= CoarseMinRelationCount` (default 5000). Normal-sized networks never reach that threshold, so object scores were always 0 and the score-based fill branch in `selectObjectTypesForConceptRetrieval` was dead code.

Reported by a user on this release line, which is why the fix is backported rather than left to `0.1.4`.

## Changes

Identical to #780 — the three commits cherry-pick cleanly and the resulting `knsearch` sources match the `main` branch of that PR byte for byte, except for one pre-existing line (`IndexOpsOnly`) that differs between the two bases and is untouched here.

- `scoreObjectTypes`: scores object types against the query via `SearchObjectTypes` (`knn + match`, `_score`), not gated on `CoarseMinRelationCount`, scoring only and never pruning. Failures degrade to the previous behavior.
- `selectObjectTypesForConceptRetrieval`: relevance first, relation endpoints merged in as a schema-consistency constraint with no budget cap, remaining budget filled by relevance. Orphan object types become reachable. When no score is available at all, it falls back to the pre-fix endpoint-first ordering.
- Output layer: truncate by relevance instead of hoisting endpoints to the front; missing endpoints are still appended, and are still allowed to exceed `max_concepts`.

## Contract change

`object_types` ordering changes from "relation endpoint order" to "query relevance order". `rankRelationTypes` is untouched and `relation_types` output is unchanged. Two existing tests asserting the old endpoint-first ordering were updated accordingly.

## Verification

`go build ./...`, `go vet ./logics/...`, and `go test ./...` all pass on this branch.

The `main` PR was additionally validated on the test server against a real knowledge network, where the same three queries returned byte-identical, query-independent object lists before the fix and correctly ranked the targeted object type first after it. That validation applies to the same code as this backport carries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
