### PR TITLE
feat(vega): add runtime analyzer capabilities

### DIFF
--- a/adp/vega/vega-backend/server/driveradapters/index_capability_handler.go
+++ b/adp/vega/vega-backend/server/driveradapters/index_capability_handler.go
@@ -1,6 +1,4 @@
 // Copyright openbkn.ai
-// Copyright The kweaver.ai Authors.
-//
 // Licensed under the Apache License, Version 2.0.
 // See the LICENSE file in the project root for details.
 

--- a/adp/vega/vega-backend/server/driveradapters/index_capability_handler.go
+++ b/adp/vega/vega-backend/server/driveradapters/index_capability_handler.go
@@ -1,0 +1,41 @@
+// Copyright openbkn.ai
+// Copyright The kweaver.ai Authors.
+//
+// Licensed under the Apache License, Version 2.0.
+// See the LICENSE file in the project root for details.
+
+package driveradapters
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+	"github.com/openbkn-ai/bkn-comm-go/otel/oteltrace"
+	"github.com/openbkn-ai/bkn-comm-go/rest"
+
+	verrors "vega-backend/errors"
+	"vega-backend/interfaces"
+)
+
+// GetIndexCapabilitiesByEx handles GET /api/vega-backend/v1/index-capabilities.
+func (r *restHandler) GetIndexCapabilitiesByEx(c *gin.Context) {
+	visitor, err := r.verifyOAuth(rest.GetLanguageCtx(c), c)
+	if err != nil {
+		return
+	}
+
+	ctx, span := oteltrace.StartServerSpan(c)
+	defer span.End()
+
+	accountInfo := interfaces.AccountInfo{ID: visitor.ID, Type: string(visitor.Type)}
+	ctx = context.WithValue(ctx, interfaces.ACCOUNT_INFO_KEY, accountInfo)
+
+	capabilities, err := r.lim.GetIndexCapabilities(ctx)
+	if err != nil {
+		rest.ReplyError(c, rest.NewHTTPError(ctx, http.StatusServiceUnavailable,
+			verrors.VegaBackend_IndexCapability_InternalError_Unavailable).WithErrorDetails(err.Error()))
+		return
+	}
+	rest.ReplyOK(c, http.StatusOK, capabilities)
+}

--- a/adp/vega/vega-backend/server/driveradapters/router.go
+++ b/adp/vega/vega-backend/server/driveradapters/router.go
@@ -31,6 +31,7 @@ import (
 	"vega-backend/logics/dataset"
 	"vega-backend/logics/discover_schedule"
 	"vega-backend/logics/discover_task"
+	"vega-backend/logics/local_index"
 	"vega-backend/logics/resource"
 	"vega-backend/logics/resource_data"
 	"vega-backend/logics/semantic_understanding_task"
@@ -46,15 +47,16 @@ type RestHandler interface {
 type restHandler struct {
 	appSetting *common.AppSetting
 	as         interfaces.AuthService
-	cs         interfaces.CatalogService
-	rs         interfaces.ResourceService
 	bts        interfaces.BuildTaskService
-	ds         interfaces.DatasetService
+	cs         interfaces.CatalogService
 	cts        interfaces.ConnectorTypeService
-	dts        interfaces.DiscoverTaskService
+	ds         interfaces.DatasetService
 	dss        interfaces.DiscoverScheduleService
+	dts        interfaces.DiscoverTaskService
 	hcss       interfaces.CatalogHealthCheckScheduleService
+	lim        interfaces.LocalIndexManager
 	rds        interfaces.ResourceDataService
+	rs         interfaces.ResourceService
 	suts       interfaces.SemanticUnderstandingTaskService
 
 	sw *worker.ScheduleWorker
@@ -64,15 +66,16 @@ type restHandler struct {
 func NewRestHandler(appSetting *common.AppSetting, sw *worker.ScheduleWorker) RestHandler {
 	as := auth.NewAuthService(appSetting)
 	cs := catalog.NewCatalogService(appSetting)
-	rs := resource.NewResourceService(appSetting)
-	bts := build_task.NewBuildTaskService(appSetting, rs)
 	cts := connector_type.NewConnectorTypeService(appSetting)
 	ds := dataset.NewDatasetService(appSetting)
 	dts := discover_task.NewDiscoverTaskService(appSetting)
 	dss := discover_schedule.NewDiscoverScheduleService(appSetting, dts)
 	hcss := catalog_health_check_schedule.NewCatalogHealthCheckScheduleService(appSetting)
-	suts := semantic_understanding_task.NewSemanticUnderstandingTaskService(appSetting)
+	lim := local_index.NewLocalIndexManager(appSetting)
 	rds := resource_data.NewResourceDataService(appSetting)
+	rs := resource.NewResourceService(appSetting)
+	bts := build_task.NewBuildTaskService(appSetting, rs)
+	suts := semantic_understanding_task.NewSemanticUnderstandingTaskService(appSetting)
 
 	return &restHandler{
 		appSetting: appSetting,
@@ -82,8 +85,9 @@ func NewRestHandler(appSetting *common.AppSetting, sw *worker.ScheduleWorker) Re
 		cts:        cts,
 		ds:         ds,
 		dss:        dss,
-		hcss:       hcss,
 		dts:        dts,
+		hcss:       hcss,
+		lim:        lim,
 		rds:        rds,
 		rs:         rs,
 		suts:       suts,
@@ -190,6 +194,8 @@ func (r *restHandler) RegisterPublic(c *gin.Engine) {
 			connectorTypes.POST("/:type/enable", r.EnableConnectorType)
 			connectorTypes.POST("/:type/disable", r.DisableConnectorType)
 		}
+
+		apiV1.GET("/index-capabilities", r.GetIndexCapabilitiesByEx)
 
 		apiV1.GET("/auth-resources", r.ListAuthResources)
 	}

--- a/adp/vega/vega-backend/server/errors/error_code.go
+++ b/adp/vega/vega-backend/server/errors/error_code.go
@@ -108,4 +108,5 @@ func init() {
 	rest.Register(DiscoverScheduleErrCodeList)
 	rest.Register(ExtensionsErrCodeList)
 	rest.Register(SemanticUnderstandingTaskErrCodeList)
+	rest.Register(IndexCapabilityErrCodeList)
 }

--- a/adp/vega/vega-backend/server/errors/index_capability.go
+++ b/adp/vega/vega-backend/server/errors/index_capability.go
@@ -1,6 +1,4 @@
 // Copyright openbkn.ai
-// Copyright The kweaver.ai Authors.
-//
 // Licensed under the Apache License, Version 2.0.
 // See the LICENSE file in the project root for details.
 

--- a/adp/vega/vega-backend/server/errors/index_capability.go
+++ b/adp/vega/vega-backend/server/errors/index_capability.go
@@ -1,0 +1,13 @@
+// Copyright openbkn.ai
+// Copyright The kweaver.ai Authors.
+//
+// Licensed under the Apache License, Version 2.0.
+// See the LICENSE file in the project root for details.
+
+package errors
+
+const VegaBackend_IndexCapability_InternalError_Unavailable = "VegaBackend.IndexCapability.InternalError.Unavailable"
+
+var IndexCapabilityErrCodeList = []string{
+	VegaBackend_IndexCapability_InternalError_Unavailable,
+}

--- a/adp/vega/vega-backend/server/errors/resource.go
+++ b/adp/vega/vega-backend/server/errors/resource.go
@@ -14,6 +14,7 @@ const (
 	VegaBackend_Resource_InvalidParameter_Type      = "VegaBackend.Resource.InvalidParameter.Type"
 	VegaBackend_Resource_InvalidParameter_Name      = "VegaBackend.Resource.InvalidParameter.Name"
 	VegaBackend_Resource_InvalidParameter_CatalogID = "VegaBackend.Resource.InvalidParameter.CatalogID"
+	VegaBackend_Resource_InvalidParameter_Analyzer  = "VegaBackend.Resource.InvalidParameter.Analyzer"
 	VegaBackend_Resource_LengthExceeded_Name        = "VegaBackend.Resource.LengthExceeded.Name"
 	VegaBackend_Resource_LengthExceeded_Description = "VegaBackend.Resource.LengthExceeded.Description"
 	VegaBackend_Resource_CategoryNotCreatable       = "VegaBackend.Resource.CategoryNotCreatable"
@@ -52,6 +53,7 @@ var ResourceErrCodeList = []string{
 	VegaBackend_Resource_InvalidParameter_Type,
 	VegaBackend_Resource_InvalidParameter_Name,
 	VegaBackend_Resource_InvalidParameter_CatalogID,
+	VegaBackend_Resource_InvalidParameter_Analyzer,
 	VegaBackend_Resource_LengthExceeded_Name,
 	VegaBackend_Resource_LengthExceeded_Description,
 	VegaBackend_Resource_CategoryNotCreatable,

--- a/adp/vega/vega-backend/server/interfaces/connector_interface.go
+++ b/adp/vega/vega-backend/server/interfaces/connector_interface.go
@@ -6,23 +6,7 @@
 
 package interfaces
 
-import (
-	"context"
-	"fmt"
-	"strings"
-)
-
-// AnalyzerUnavailableError indicates that OpenSearch accepted the validation
-// request but could not resolve the configured analyzer.
-type AnalyzerUnavailableError struct {
-	Analyzer string
-	Fields   []string
-	Detail   string
-}
-
-func (e *AnalyzerUnavailableError) Error() string {
-	return fmt.Sprintf("analyzer %q for fields %q is unavailable: %s", e.Analyzer, strings.Join(e.Fields, ", "), e.Detail)
-}
+import "context"
 
 //go:generate mockgen -source ../interfaces/connector_interface.go -destination ../interfaces/mock/mock_connector_interface.go
 
@@ -127,7 +111,7 @@ type IndexConnector interface {
 	Update(ctx context.Context, name string, schemaDefinition []*Property) error
 	Delete(ctx context.Context, name string) error
 	CheckExist(ctx context.Context, name string) (bool, error)
-	ValidateAnalyzers(ctx context.Context, analyzers map[string]string) error
+	ValidateAnalyzers(ctx context.Context, analyzers map[string]string) (bool, error)
 	CreateDocuments(ctx context.Context, name string, documents []map[string]any) ([]string, error)
 	GetDocument(ctx context.Context, name string, docID string) (map[string]any, error)
 	DeleteDocument(ctx context.Context, name string, docID string) error

--- a/adp/vega/vega-backend/server/interfaces/connector_interface.go
+++ b/adp/vega/vega-backend/server/interfaces/connector_interface.go
@@ -111,7 +111,7 @@ type IndexConnector interface {
 	Update(ctx context.Context, name string, schemaDefinition []*Property) error
 	Delete(ctx context.Context, name string) error
 	CheckExist(ctx context.Context, name string) (bool, error)
-	ValidateAnalyzers(ctx context.Context, analyzers map[string]string) (bool, error)
+	ValidateAnalyzer(ctx context.Context, analyzer string) (bool, error)
 	CreateDocuments(ctx context.Context, name string, documents []map[string]any) ([]string, error)
 	GetDocument(ctx context.Context, name string, docID string) (map[string]any, error)
 	DeleteDocument(ctx context.Context, name string, docID string) error

--- a/adp/vega/vega-backend/server/interfaces/local_index_manager.go
+++ b/adp/vega/vega-backend/server/interfaces/local_index_manager.go
@@ -33,7 +33,7 @@ type LocalIndexManager interface {
 	UpdateIndex(ctx context.Context, indexName string, schema []*Property) error
 	DeleteIndex(ctx context.Context, indexName string) error
 	CheckExist(ctx context.Context, indexName string) (bool, error)
-	ValidateAnalyzers(ctx context.Context, analyzers map[string]string) (bool, error)
+	ValidateAnalyzer(ctx context.Context, analyzer string) (bool, error)
 	GetIndexCapabilities(ctx context.Context) (*IndexCapabilities, error)
 
 	ListDocuments(ctx context.Context, indexName string, res *Resource, params *ResourceDataQueryParams) ([]map[string]any, int64, error)

--- a/adp/vega/vega-backend/server/interfaces/local_index_manager.go
+++ b/adp/vega/vega-backend/server/interfaces/local_index_manager.go
@@ -6,7 +6,24 @@
 
 package interfaces
 
-import "context"
+import (
+	"context"
+	"fmt"
+)
+
+type AnalyzerCapability struct {
+	ID string `json:"id"`
+}
+type IndexCapabilities struct {
+	FulltextAnalyzers []AnalyzerCapability `json:"fulltext_analyzers"`
+	CheckedAt         int64                `json:"checked_at"`
+}
+type IndexCapabilitiesUnavailableError struct{ Cause error }
+
+func (e *IndexCapabilitiesUnavailableError) Error() string {
+	return fmt.Sprintf("index capabilities unavailable: %v", e.Cause)
+}
+func (e *IndexCapabilitiesUnavailableError) Unwrap() error { return e.Cause }
 
 // LocalIndexManager manages local index storage backed by the local search engine.
 //
@@ -16,7 +33,8 @@ type LocalIndexManager interface {
 	UpdateIndex(ctx context.Context, indexName string, schema []*Property) error
 	DeleteIndex(ctx context.Context, indexName string) error
 	CheckExist(ctx context.Context, indexName string) (bool, error)
-	ValidateAnalyzers(ctx context.Context, analyzers map[string]string) error
+	ValidateAnalyzers(ctx context.Context, analyzers map[string]string) (bool, error)
+	GetIndexCapabilities(ctx context.Context) (*IndexCapabilities, error)
 
 	ListDocuments(ctx context.Context, indexName string, res *Resource, params *ResourceDataQueryParams) ([]map[string]any, int64, error)
 	GetDocument(ctx context.Context, indexName string, docID string) (map[string]any, error)

--- a/adp/vega/vega-backend/server/interfaces/mock/mock_connector_interface.go
+++ b/adp/vega/vega-backend/server/interfaces/mock/mock_connector_interface.go
@@ -1921,11 +1921,12 @@ func (mr *MockIndexConnectorMockRecorder) UpsertDocuments(ctx, name, updateReque
 }
 
 // ValidateAnalyzers mocks base method.
-func (m *MockIndexConnector) ValidateAnalyzers(ctx context.Context, analyzers map[string]string) error {
+func (m *MockIndexConnector) ValidateAnalyzers(ctx context.Context, analyzers map[string]string) (bool, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ValidateAnalyzers", ctx, analyzers)
-	ret0, _ := ret[0].(error)
-	return ret0
+	ret0, _ := ret[0].(bool)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
 }
 
 // ValidateAnalyzers indicates an expected call of ValidateAnalyzers.

--- a/adp/vega/vega-backend/server/interfaces/mock/mock_connector_interface.go
+++ b/adp/vega/vega-backend/server/interfaces/mock/mock_connector_interface.go
@@ -1920,19 +1920,19 @@ func (mr *MockIndexConnectorMockRecorder) UpsertDocuments(ctx, name, updateReque
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpsertDocuments", reflect.TypeOf((*MockIndexConnector)(nil).UpsertDocuments), ctx, name, updateRequests)
 }
 
-// ValidateAnalyzers mocks base method.
-func (m *MockIndexConnector) ValidateAnalyzers(ctx context.Context, analyzers map[string]string) (bool, error) {
+// ValidateAnalyzer mocks base method.
+func (m *MockIndexConnector) ValidateAnalyzer(ctx context.Context, analyzer string) (bool, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ValidateAnalyzers", ctx, analyzers)
+	ret := m.ctrl.Call(m, "ValidateAnalyzer", ctx, analyzer)
 	ret0, _ := ret[0].(bool)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// ValidateAnalyzers indicates an expected call of ValidateAnalyzers.
-func (mr *MockIndexConnectorMockRecorder) ValidateAnalyzers(ctx, analyzers any) *gomock.Call {
+// ValidateAnalyzer indicates an expected call of ValidateAnalyzer.
+func (mr *MockIndexConnectorMockRecorder) ValidateAnalyzer(ctx, analyzer any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ValidateAnalyzers", reflect.TypeOf((*MockIndexConnector)(nil).ValidateAnalyzers), ctx, analyzers)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ValidateAnalyzer", reflect.TypeOf((*MockIndexConnector)(nil).ValidateAnalyzer), ctx, analyzer)
 }
 
 // MockAPIConnector is a mock of APIConnector interface.

--- a/adp/vega/vega-backend/server/interfaces/mock/mock_local_index_manager.go
+++ b/adp/vega/vega-backend/server/interfaces/mock/mock_local_index_manager.go
@@ -216,17 +216,17 @@ func (mr *MockLocalIndexManagerMockRecorder) UpsertDocuments(ctx, indexName, upd
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpsertDocuments", reflect.TypeOf((*MockLocalIndexManager)(nil).UpsertDocuments), ctx, indexName, updateRequests)
 }
 
-// ValidateAnalyzers mocks base method.
-func (m *MockLocalIndexManager) ValidateAnalyzers(ctx context.Context, analyzers map[string]string) (bool, error) {
+// ValidateAnalyzer mocks base method.
+func (m *MockLocalIndexManager) ValidateAnalyzer(ctx context.Context, analyzer string) (bool, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ValidateAnalyzers", ctx, analyzers)
+	ret := m.ctrl.Call(m, "ValidateAnalyzer", ctx, analyzer)
 	ret0, _ := ret[0].(bool)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// ValidateAnalyzers indicates an expected call of ValidateAnalyzers.
-func (mr *MockLocalIndexManagerMockRecorder) ValidateAnalyzers(ctx, analyzers any) *gomock.Call {
+// ValidateAnalyzer indicates an expected call of ValidateAnalyzer.
+func (mr *MockLocalIndexManagerMockRecorder) ValidateAnalyzer(ctx, analyzer any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ValidateAnalyzers", reflect.TypeOf((*MockLocalIndexManager)(nil).ValidateAnalyzers), ctx, analyzers)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ValidateAnalyzer", reflect.TypeOf((*MockLocalIndexManager)(nil).ValidateAnalyzer), ctx, analyzer)
 }

--- a/adp/vega/vega-backend/server/interfaces/mock/mock_local_index_manager.go
+++ b/adp/vega/vega-backend/server/interfaces/mock/mock_local_index_manager.go
@@ -156,6 +156,21 @@ func (mr *MockLocalIndexManagerMockRecorder) GetDocument(ctx, indexName, docID a
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetDocument", reflect.TypeOf((*MockLocalIndexManager)(nil).GetDocument), ctx, indexName, docID)
 }
 
+// GetIndexCapabilities mocks base method.
+func (m *MockLocalIndexManager) GetIndexCapabilities(ctx context.Context) (*interfaces.IndexCapabilities, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetIndexCapabilities", ctx)
+	ret0, _ := ret[0].(*interfaces.IndexCapabilities)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetIndexCapabilities indicates an expected call of GetIndexCapabilities.
+func (mr *MockLocalIndexManagerMockRecorder) GetIndexCapabilities(ctx any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetIndexCapabilities", reflect.TypeOf((*MockLocalIndexManager)(nil).GetIndexCapabilities), ctx)
+}
+
 // ListDocuments mocks base method.
 func (m *MockLocalIndexManager) ListDocuments(ctx context.Context, indexName string, res *interfaces.Resource, params *interfaces.ResourceDataQueryParams) ([]map[string]any, int64, error) {
 	m.ctrl.T.Helper()
@@ -202,11 +217,12 @@ func (mr *MockLocalIndexManagerMockRecorder) UpsertDocuments(ctx, indexName, upd
 }
 
 // ValidateAnalyzers mocks base method.
-func (m *MockLocalIndexManager) ValidateAnalyzers(ctx context.Context, analyzers map[string]string) error {
+func (m *MockLocalIndexManager) ValidateAnalyzers(ctx context.Context, analyzers map[string]string) (bool, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ValidateAnalyzers", ctx, analyzers)
-	ret0, _ := ret[0].(error)
-	return ret0
+	ret0, _ := ret[0].(bool)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
 }
 
 // ValidateAnalyzers indicates an expected call of ValidateAnalyzers.

--- a/adp/vega/vega-backend/server/locale/index_capability.en-US.toml
+++ b/adp/vega/vega-backend/server/locale/index_capability.en-US.toml
@@ -1,0 +1,4 @@
+[VegaBackend.IndexCapability.InternalError.Unavailable]
+Description = "Full-text analyzer capability is unavailable"
+Solution = "Restore OpenSearch connectivity and restart Vega"
+ErrorLink = "None"

--- a/adp/vega/vega-backend/server/locale/index_capability.zh-CN.toml
+++ b/adp/vega/vega-backend/server/locale/index_capability.zh-CN.toml
@@ -1,0 +1,4 @@
+[VegaBackend.IndexCapability.InternalError.Unavailable]
+Description = "全文分词器能力不可用"
+Solution = "请恢复 OpenSearch 连接后重启 Vega"
+ErrorLink = "暂无"

--- a/adp/vega/vega-backend/server/locale/resource.en-US.toml
+++ b/adp/vega/vega-backend/server/locale/resource.en-US.toml
@@ -23,6 +23,11 @@ Description = "Catalog ID is required"
 Solution = "Please provide a valid catalog ID"
 ErrorLink = "None"
 
+[VegaBackend.Resource.InvalidParameter.Analyzer]
+Description = "Configured full-text analyzer is unavailable"
+Solution = "Choose an analyzer supported by the current index capability snapshot"
+ErrorLink = "None"
+
 [VegaBackend.Resource.LengthExceeded.Name]
 Description = "Resource name length exceeded"
 Solution = "Please shorten the name"

--- a/adp/vega/vega-backend/server/locale/resource.zh-CN.toml
+++ b/adp/vega/vega-backend/server/locale/resource.zh-CN.toml
@@ -23,6 +23,11 @@ Description = "目录ID为必填项"
 Solution = "请提供有效的目录ID"
 ErrorLink = "暂无"
 
+[VegaBackend.Resource.InvalidParameter.Analyzer]
+Description = "配置的全文分词器不可用"
+Solution = "请选择当前索引能力快照支持的分词器"
+ErrorLink = "暂无"
+
 [VegaBackend.Resource.LengthExceeded.Name]
 Description = "数据资源名称长度超限"
 Solution = "请缩短名称"

--- a/adp/vega/vega-backend/server/logics/build_task/build_task_service.go
+++ b/adp/vega/vega-backend/server/logics/build_task/build_task_service.go
@@ -197,14 +197,19 @@ func validateBuildTaskAnalyzers(ctx context.Context, indexManager interfaces.Loc
 	if len(analyzers) == 0 {
 		return nil
 	}
-	if err := indexManager.ValidateAnalyzers(ctx, analyzers); err != nil {
-		var unavailableErr *interfaces.AnalyzerUnavailableError
+	available, err := indexManager.ValidateAnalyzers(ctx, analyzers)
+	if err != nil {
+		var unavailableErr *interfaces.IndexCapabilitiesUnavailableError
 		if errors.As(err, &unavailableErr) {
-			return rest.NewHTTPError(ctx, http.StatusBadRequest, verrors.VegaBackend_BuildTask_InvalidParameter_Analyzer).
-				WithErrorDetails(unavailableErr.Error())
+			return rest.NewHTTPError(ctx, http.StatusServiceUnavailable, verrors.VegaBackend_IndexCapability_InternalError_Unavailable).
+				WithErrorDetails(err.Error())
 		}
 		return rest.NewHTTPError(ctx, http.StatusInternalServerError, verrors.VegaBackend_BuildTask_InternalError_ValidateAnalyzerFailed).
 			WithErrorDetails(err.Error())
+	}
+	if !available {
+		return rest.NewHTTPError(ctx, http.StatusBadRequest, verrors.VegaBackend_BuildTask_InvalidParameter_Analyzer).
+			WithErrorDetails("one or more configured analyzers are unavailable")
 	}
 	return nil
 }

--- a/adp/vega/vega-backend/server/logics/build_task/build_task_service.go
+++ b/adp/vega/vega-backend/server/logics/build_task/build_task_service.go
@@ -185,31 +185,27 @@ func validateBuildTaskAnalyzers(ctx context.Context, indexManager interfaces.Loc
 	if indexManager == nil {
 		return nil
 	}
-	analyzers := map[string]string{}
 	if buildTask == nil || buildTask.IndexConfig == nil {
 		return nil
 	}
 	for field, feature := range buildTask.IndexConfig.Features {
-		if feature.Fulltext != nil && strings.TrimSpace(feature.Fulltext.Analyzer) != "" {
-			analyzers[field] = feature.Fulltext.Analyzer
+		if feature.Fulltext == nil || strings.TrimSpace(feature.Fulltext.Analyzer) == "" {
+			continue
 		}
-	}
-	if len(analyzers) == 0 {
-		return nil
-	}
-	available, err := indexManager.ValidateAnalyzers(ctx, analyzers)
-	if err != nil {
-		var unavailableErr *interfaces.IndexCapabilitiesUnavailableError
-		if errors.As(err, &unavailableErr) {
-			return rest.NewHTTPError(ctx, http.StatusServiceUnavailable, verrors.VegaBackend_IndexCapability_InternalError_Unavailable).
+		available, err := indexManager.ValidateAnalyzer(ctx, feature.Fulltext.Analyzer)
+		if err != nil {
+			var unavailableErr *interfaces.IndexCapabilitiesUnavailableError
+			if errors.As(err, &unavailableErr) {
+				return rest.NewHTTPError(ctx, http.StatusServiceUnavailable, verrors.VegaBackend_IndexCapability_InternalError_Unavailable).
+					WithErrorDetails(err.Error())
+			}
+			return rest.NewHTTPError(ctx, http.StatusInternalServerError, verrors.VegaBackend_BuildTask_InternalError_ValidateAnalyzerFailed).
 				WithErrorDetails(err.Error())
 		}
-		return rest.NewHTTPError(ctx, http.StatusInternalServerError, verrors.VegaBackend_BuildTask_InternalError_ValidateAnalyzerFailed).
-			WithErrorDetails(err.Error())
-	}
-	if !available {
-		return rest.NewHTTPError(ctx, http.StatusBadRequest, verrors.VegaBackend_BuildTask_InvalidParameter_Analyzer).
-			WithErrorDetails("one or more configured analyzers are unavailable")
+		if !available {
+			return rest.NewHTTPError(ctx, http.StatusBadRequest, verrors.VegaBackend_BuildTask_InvalidParameter_Analyzer).
+				WithErrorDetails(fmt.Sprintf("analyzer %q for field %q is unavailable", feature.Fulltext.Analyzer, field))
+		}
 	}
 	return nil
 }

--- a/adp/vega/vega-backend/server/logics/build_task/build_task_service.go
+++ b/adp/vega/vega-backend/server/logics/build_task/build_task_service.go
@@ -284,6 +284,22 @@ func (bts *buildTaskService) newBuildTaskFromCreateRequest(ctx context.Context, 
 }
 
 func (bts *buildTaskService) fillBuildTaskIndexSnapshot(ctx context.Context, resource *interfaces.Resource, buildTask *interfaces.BuildTask) error {
+	for _, property := range resource.SchemaDefinition {
+		if property == nil {
+			continue
+		}
+		seenFeatureTypes := make(map[string]struct{}, len(property.Features))
+		for _, feature := range property.Features {
+			if feature.FeatureType == "" {
+				continue
+			}
+			if _, exists := seenFeatureTypes[feature.FeatureType]; exists {
+				return rest.NewHTTPError(ctx, http.StatusBadRequest, verrors.VegaBackend_InvalidParameter_RequestBody).
+					WithErrorDetails(fmt.Sprintf("property %q has more than one %q feature", property.Name, feature.FeatureType))
+			}
+			seenFeatureTypes[feature.FeatureType] = struct{}{}
+		}
+	}
 	defaultEmbeddingModel := ""
 	defaultFulltextAnalyzer := ""
 	buildTask.IndexConfig = &interfaces.BuildTaskIndexConfig{

--- a/adp/vega/vega-backend/server/logics/build_task/build_task_service_test.go
+++ b/adp/vega/vega-backend/server/logics/build_task/build_task_service_test.go
@@ -92,6 +92,24 @@ func TestFillBuildTaskIndexSnapshotRejectsMissingEmbeddingModel(t *testing.T) {
 	requireHTTPError(t, err, verrors.VegaBackend_BuildTask_InvalidParameter_EmbeddingModel)
 }
 
+func TestFillBuildTaskIndexSnapshotRejectsDuplicateFeatureType(t *testing.T) {
+	service := &buildTaskService{}
+	buildTask := &interfaces.BuildTask{}
+
+	err := service.fillBuildTaskIndexSnapshot(context.Background(), &interfaces.Resource{
+		SchemaDefinition: []*interfaces.Property{{
+			Name: "title",
+			Features: []interfaces.PropertyFeature{
+				{FeatureType: interfaces.PropertyFeatureType_Fulltext},
+				{FeatureType: interfaces.PropertyFeatureType_Fulltext},
+			},
+		}},
+	}, buildTask)
+
+	httpErr := requireHTTPError(t, err, verrors.VegaBackend_InvalidParameter_RequestBody)
+	assert.Contains(t, httpErr.BaseError.ErrorDetails, `property "title" has more than one "fulltext" feature`)
+}
+
 func TestValidateBuildTaskAnalyzersReturnsInternalErrorForTransportFailure(t *testing.T) {
 	validator := &analyzerValidatingIndexManager{err: errors.New("connect OpenSearch: connection refused")}
 	buildTask := &interfaces.BuildTask{IndexConfig: &interfaces.BuildTaskIndexConfig{

--- a/adp/vega/vega-backend/server/logics/build_task/build_task_service_test.go
+++ b/adp/vega/vega-backend/server/logics/build_task/build_task_service_test.go
@@ -28,13 +28,14 @@ import (
 
 type analyzerValidatingIndexManager struct {
 	interfaces.LocalIndexManager
-	err      error
-	captured map[string]string
+	available bool
+	err       error
+	captured  map[string]string
 }
 
-func (m *analyzerValidatingIndexManager) ValidateAnalyzers(_ context.Context, analyzers map[string]string) error {
+func (m *analyzerValidatingIndexManager) ValidateAnalyzers(_ context.Context, analyzers map[string]string) (bool, error) {
 	m.captured = analyzers
-	return m.err
+	return m.available, m.err
 }
 
 func TestBuildTaskServiceRejectsUnavailableFieldAnalyzerBeforePersistence(t *testing.T) {
@@ -42,11 +43,7 @@ func TestBuildTaskServiceRejectsUnavailableFieldAnalyzerBeforePersistence(t *tes
 	mockCS := mock_interfaces.NewMockCatalogService(ctrl)
 	mockRS := mock_interfaces.NewMockResourceService(ctrl)
 	mockBTA := mock_interfaces.NewMockBuildTaskAccess(ctrl)
-	validator := &analyzerValidatingIndexManager{err: &interfaces.AnalyzerUnavailableError{
-		Analyzer: "hanlp_index",
-		Fields:   []string{"status"},
-		Detail:   "analyzer not found",
-	}}
+	validator := &analyzerValidatingIndexManager{}
 	service := &buildTaskService{
 		bta:            mockBTA,
 		cs:             mockCS,
@@ -74,7 +71,7 @@ func TestBuildTaskServiceRejectsUnavailableFieldAnalyzerBeforePersistence(t *tes
 
 	_, err := service.Create(context.Background(), &interfaces.CreateBuildTaskRequest{ResourceID: "resource-1", Mode: interfaces.BuildTaskModeBatch})
 	httpErr := requireHTTPError(t, err, verrors.VegaBackend_BuildTask_InvalidParameter_Analyzer)
-	assert.Contains(t, httpErr.BaseError.ErrorDetails, "status")
+	assert.Contains(t, httpErr.BaseError.ErrorDetails, "unavailable")
 	assert.Equal(t, map[string]string{"coupon_code": "standard", "status": "hanlp_index"}, validator.captured)
 }
 
@@ -106,6 +103,20 @@ func TestValidateBuildTaskAnalyzersReturnsInternalErrorForTransportFailure(t *te
 	err := validateBuildTaskAnalyzers(context.Background(), validator, buildTask)
 	httpErr := requireHTTPError(t, err, verrors.VegaBackend_BuildTask_InternalError_ValidateAnalyzerFailed)
 	assert.Equal(t, http.StatusInternalServerError, httpErr.HTTPCode)
+}
+
+func TestValidateBuildTaskAnalyzersReturnsCapabilityUnavailableForStartupProbeFailure(t *testing.T) {
+	validator := &analyzerValidatingIndexManager{err: &interfaces.IndexCapabilitiesUnavailableError{Cause: errors.New("connection refused")}}
+	buildTask := &interfaces.BuildTask{IndexConfig: &interfaces.BuildTaskIndexConfig{
+		Features: map[string]interfaces.BuildTaskFieldIndexFeature{
+			"status": {Fulltext: &interfaces.BuildTaskFulltextConfig{Analyzer: "hanlp_index"}},
+		},
+	}}
+
+	err := validateBuildTaskAnalyzers(context.Background(), validator, buildTask)
+	httpErr := requireHTTPError(t, err, verrors.VegaBackend_IndexCapability_InternalError_Unavailable)
+	assert.Equal(t, http.StatusServiceUnavailable, httpErr.HTTPCode)
+	assert.Contains(t, httpErr.BaseError.ErrorDetails, "connection refused")
 }
 
 func TestBuildTaskServicePopulatesTaskReferencesForListAndGet(t *testing.T) {
@@ -932,11 +943,7 @@ func TestBuildTaskServiceStartBuildTask(t *testing.T) {
 		mockCS := mock_interfaces.NewMockCatalogService(ctrl)
 		mockRS := mock_interfaces.NewMockResourceService(ctrl)
 		mockBTA := mock_interfaces.NewMockBuildTaskAccess(ctrl)
-		validator := &analyzerValidatingIndexManager{err: &interfaces.AnalyzerUnavailableError{
-			Analyzer: "hanlp_index",
-			Fields:   []string{"status"},
-			Detail:   "analyzer not found",
-		}}
+		validator := &analyzerValidatingIndexManager{}
 		service := &buildTaskService{
 			debugTaskQueue: make(chan *asynq.Task, 10),
 			bta:            mockBTA,
@@ -978,7 +985,7 @@ func TestBuildTaskServiceStartBuildTask(t *testing.T) {
 		err := service.Start(context.Background(), "task-1", false)
 		httpErr := requireHTTPError(t, err, verrors.VegaBackend_BuildTask_InvalidParameter_Analyzer)
 		assert.Equal(t, http.StatusBadRequest, httpErr.HTTPCode)
-		assert.Contains(t, httpErr.BaseError.ErrorDetails, "status")
+		assert.Contains(t, httpErr.BaseError.ErrorDetails, "unavailable")
 		assert.Equal(t, map[string]string{"status": "hanlp_index"}, validator.captured)
 		select {
 		case queued := <-service.DebugTaskQueue():

--- a/adp/vega/vega-backend/server/logics/build_task/build_task_service_test.go
+++ b/adp/vega/vega-backend/server/logics/build_task/build_task_service_test.go
@@ -30,11 +30,11 @@ type analyzerValidatingIndexManager struct {
 	interfaces.LocalIndexManager
 	available bool
 	err       error
-	captured  map[string]string
+	captured  []string
 }
 
-func (m *analyzerValidatingIndexManager) ValidateAnalyzers(_ context.Context, analyzers map[string]string) (bool, error) {
-	m.captured = analyzers
+func (m *analyzerValidatingIndexManager) ValidateAnalyzer(_ context.Context, analyzer string) (bool, error) {
+	m.captured = append(m.captured, analyzer)
 	return m.available, m.err
 }
 
@@ -71,8 +71,8 @@ func TestBuildTaskServiceRejectsUnavailableFieldAnalyzerBeforePersistence(t *tes
 
 	_, err := service.Create(context.Background(), &interfaces.CreateBuildTaskRequest{ResourceID: "resource-1", Mode: interfaces.BuildTaskModeBatch})
 	httpErr := requireHTTPError(t, err, verrors.VegaBackend_BuildTask_InvalidParameter_Analyzer)
-	assert.Contains(t, httpErr.BaseError.ErrorDetails, "unavailable")
-	assert.Equal(t, map[string]string{"coupon_code": "standard", "status": "hanlp_index"}, validator.captured)
+	assert.Contains(t, httpErr.BaseError.ErrorDetails, "analyzer")
+	assert.Len(t, validator.captured, 1)
 }
 
 func TestFillBuildTaskIndexSnapshotRejectsMissingEmbeddingModel(t *testing.T) {
@@ -986,7 +986,7 @@ func TestBuildTaskServiceStartBuildTask(t *testing.T) {
 		httpErr := requireHTTPError(t, err, verrors.VegaBackend_BuildTask_InvalidParameter_Analyzer)
 		assert.Equal(t, http.StatusBadRequest, httpErr.HTTPCode)
 		assert.Contains(t, httpErr.BaseError.ErrorDetails, "unavailable")
-		assert.Equal(t, map[string]string{"status": "hanlp_index"}, validator.captured)
+		assert.Equal(t, []string{"hanlp_index"}, validator.captured)
 		select {
 		case queued := <-service.DebugTaskQueue():
 			t.Fatalf("expected no queued task, got %s", queued.Type())

--- a/adp/vega/vega-backend/server/logics/connector/local/index/opensearch/opensearch.go
+++ b/adp/vega/vega-backend/server/logics/connector/local/index/opensearch/opensearch.go
@@ -12,7 +12,6 @@ import (
 	"context"
 	"fmt"
 	"net/http"
-	"sort"
 	"strings"
 
 	"github.com/bytedance/sonic"
@@ -38,50 +37,36 @@ type OpenSearchConnector struct {
 	client  *opensearch.Client
 }
 
-// ValidateAnalyzers verifies that each field's configured analyzer is available
-// in the connected OpenSearch cluster before a build task is persisted.
-func (c *OpenSearchConnector) ValidateAnalyzers(ctx context.Context, analyzers map[string]string) (bool, error) {
+// ValidateAnalyzer verifies that a configured analyzer is available in the connected OpenSearch cluster.
+func (c *OpenSearchConnector) ValidateAnalyzer(ctx context.Context, analyzer string) (bool, error) {
 	if err := c.Connect(ctx); err != nil {
 		return false, err
 	}
-
-	analyzerFields := map[string][]string{}
-	for field, configuredAnalyzer := range analyzers {
-		analyzer := strings.TrimSpace(configuredAnalyzer)
-		if analyzer != "" {
-			analyzerFields[analyzer] = append(analyzerFields[analyzer], field)
-		}
+	analyzer = strings.TrimSpace(analyzer)
+	if analyzer == "" {
+		return true, nil
 	}
-	analyzerNames := make([]string, 0, len(analyzerFields))
-	for analyzer := range analyzerFields {
-		analyzerNames = append(analyzerNames, analyzer)
+	body, err := sonic.Marshal(map[string]any{"analyzer": analyzer, "text": "bkn"})
+	if err != nil {
+		return false, fmt.Errorf("marshal analyzer validation request: %w", err)
 	}
-	sort.Strings(analyzerNames)
-	for _, analyzer := range analyzerNames {
-		fields := analyzerFields[analyzer]
-		sort.Strings(fields)
-		body, err := sonic.Marshal(map[string]any{"analyzer": analyzer, "text": "bkn"})
-		if err != nil {
-			return false, fmt.Errorf("marshal analyzer validation request: %w", err)
-		}
-		resp, err := c.client.Indices.Analyze(
-			c.client.Indices.Analyze.WithContext(ctx),
-			c.client.Indices.Analyze.WithBody(bytes.NewReader(body)),
-		)
-		if err != nil {
-			return false, fmt.Errorf("validate analyzer %q for fields %q: %w", analyzer, strings.Join(fields, ", "), err)
-		}
-		if resp.StatusCode == http.StatusBadRequest {
-			_ = resp.Body.Close()
-			return false, nil
-		}
-		if resp.IsError() {
-			detail := resp.String()
-			_ = resp.Body.Close()
-			return false, fmt.Errorf("validate analyzer %q for fields %q: OpenSearch returned %s: %s", analyzer, strings.Join(fields, ", "), resp.Status(), detail)
-		}
+	resp, err := c.client.Indices.Analyze(
+		c.client.Indices.Analyze.WithContext(ctx),
+		c.client.Indices.Analyze.WithBody(bytes.NewReader(body)),
+	)
+	if err != nil {
+		return false, fmt.Errorf("validate analyzer %q: %w", analyzer, err)
+	}
+	if resp.StatusCode == http.StatusBadRequest {
 		_ = resp.Body.Close()
+		return false, nil
 	}
+	if resp.IsError() {
+		detail := resp.String()
+		_ = resp.Body.Close()
+		return false, fmt.Errorf("validate analyzer %q: OpenSearch returned %s: %s", analyzer, resp.Status(), detail)
+	}
+	_ = resp.Body.Close()
 	return true, nil
 }
 

--- a/adp/vega/vega-backend/server/logics/connector/local/index/opensearch/opensearch.go
+++ b/adp/vega/vega-backend/server/logics/connector/local/index/opensearch/opensearch.go
@@ -40,9 +40,9 @@ type OpenSearchConnector struct {
 
 // ValidateAnalyzers verifies that each field's configured analyzer is available
 // in the connected OpenSearch cluster before a build task is persisted.
-func (c *OpenSearchConnector) ValidateAnalyzers(ctx context.Context, analyzers map[string]string) error {
+func (c *OpenSearchConnector) ValidateAnalyzers(ctx context.Context, analyzers map[string]string) (bool, error) {
 	if err := c.Connect(ctx); err != nil {
-		return err
+		return false, err
 	}
 
 	analyzerFields := map[string][]string{}
@@ -62,32 +62,27 @@ func (c *OpenSearchConnector) ValidateAnalyzers(ctx context.Context, analyzers m
 		sort.Strings(fields)
 		body, err := sonic.Marshal(map[string]any{"analyzer": analyzer, "text": "bkn"})
 		if err != nil {
-			return fmt.Errorf("marshal analyzer validation request: %w", err)
+			return false, fmt.Errorf("marshal analyzer validation request: %w", err)
 		}
 		resp, err := c.client.Indices.Analyze(
 			c.client.Indices.Analyze.WithContext(ctx),
 			c.client.Indices.Analyze.WithBody(bytes.NewReader(body)),
 		)
 		if err != nil {
-			return fmt.Errorf("validate analyzer %q for fields %q: %w", analyzer, strings.Join(fields, ", "), err)
+			return false, fmt.Errorf("validate analyzer %q for fields %q: %w", analyzer, strings.Join(fields, ", "), err)
 		}
 		if resp.StatusCode == http.StatusBadRequest {
-			detail := resp.String()
 			_ = resp.Body.Close()
-			return &interfaces.AnalyzerUnavailableError{
-				Analyzer: analyzer,
-				Fields:   fields,
-				Detail:   detail,
-			}
+			return false, nil
 		}
 		if resp.IsError() {
 			detail := resp.String()
 			_ = resp.Body.Close()
-			return fmt.Errorf("validate analyzer %q for fields %q: OpenSearch returned %s: %s", analyzer, strings.Join(fields, ", "), resp.Status(), detail)
+			return false, fmt.Errorf("validate analyzer %q for fields %q: OpenSearch returned %s: %s", analyzer, strings.Join(fields, ", "), resp.Status(), detail)
 		}
 		_ = resp.Body.Close()
 	}
-	return nil
+	return true, nil
 }
 
 // NewOpenSearchConnector 创建 OpenSearch connector 构建器

--- a/adp/vega/vega-backend/server/logics/connector/local/index/opensearch/opensearch.go
+++ b/adp/vega/vega-backend/server/logics/connector/local/index/opensearch/opensearch.go
@@ -57,17 +57,23 @@ func (c *OpenSearchConnector) ValidateAnalyzer(ctx context.Context, analyzer str
 	if err != nil {
 		return false, fmt.Errorf("validate analyzer %q: %w", analyzer, err)
 	}
-	if resp.StatusCode == http.StatusBadRequest {
-		_ = resp.Body.Close()
-		return false, nil
-	}
 	if resp.IsError() {
 		detail := resp.String()
 		_ = resp.Body.Close()
+		if resp.StatusCode == http.StatusBadRequest && isAnalyzerNotFound(detail) {
+			return false, nil
+		}
 		return false, fmt.Errorf("validate analyzer %q: OpenSearch returned %s: %s", analyzer, resp.Status(), detail)
 	}
 	_ = resp.Body.Close()
 	return true, nil
+}
+
+func isAnalyzerNotFound(detail string) bool {
+	message := strings.ToLower(detail)
+	return strings.Contains(message, "failed to find global analyzer") ||
+		strings.Contains(message, "analyzer not found") ||
+		strings.Contains(message, "unknown analyzer")
 }
 
 // NewOpenSearchConnector 创建 OpenSearch connector 构建器

--- a/adp/vega/vega-backend/server/logics/connector/local/index/opensearch/opensearch_query_test.go
+++ b/adp/vega/vega-backend/server/logics/connector/local/index/opensearch/opensearch_query_test.go
@@ -62,7 +62,7 @@ func TestOpenSearchQueryTracksTotalOnlyWhenRequested(t *testing.T) {
 	assert.Equal(t, true, (<-queries)["track_total_hits"])
 }
 
-func TestValidateAnalyzersChecksEachDistinctAnalyzerOnce(t *testing.T) {
+func TestValidateAnalyzerCallsOpenSearch(t *testing.T) {
 	requests := 0
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		require.Equal(t, "/_analyze", r.URL.Path)
@@ -81,17 +81,13 @@ func TestValidateAnalyzersChecksEachDistinctAnalyzerOnce(t *testing.T) {
 	require.NoError(t, err)
 	connector := &OpenSearchConnector{Config: &opensearchConfig{Host: host, Port: port}}
 
-	available, err := connector.ValidateAnalyzers(context.Background(), map[string]string{
-		"coupon_code": "standard",
-		"name":        "standard",
-		"status":      "ik_max_word",
-	})
+	available, err := connector.ValidateAnalyzer(context.Background(), "ik_max_word")
 	require.NoError(t, err)
 	assert.True(t, available)
-	assert.Equal(t, 2, requests)
+	assert.Equal(t, 1, requests)
 }
 
-func TestValidateAnalyzersReportsUnavailableForOpenSearchResponse(t *testing.T) {
+func TestValidateAnalyzerReportsUnavailableForOpenSearchResponse(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		require.Equal(t, "/_analyze", r.URL.Path)
 		w.Header().Set("Content-Type", "application/json")
@@ -109,14 +105,12 @@ func TestValidateAnalyzersReportsUnavailableForOpenSearchResponse(t *testing.T) 
 	require.NoError(t, err)
 	connector := &OpenSearchConnector{Config: &opensearchConfig{Host: host, Port: port}}
 
-	available, err := connector.ValidateAnalyzers(context.Background(), map[string]string{
-		"status": "hanlp_index",
-	})
+	available, err := connector.ValidateAnalyzer(context.Background(), "hanlp_index")
 	require.NoError(t, err)
 	assert.False(t, available)
 }
 
-func TestValidateAnalyzersReturnsDependencyErrorForNonBadRequestResponse(t *testing.T) {
+func TestValidateAnalyzerReturnsDependencyErrorForNonBadRequestResponse(t *testing.T) {
 	for _, statusCode := range []int{http.StatusUnauthorized, http.StatusInternalServerError} {
 		t.Run(http.StatusText(statusCode), func(t *testing.T) {
 			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -136,7 +130,7 @@ func TestValidateAnalyzersReturnsDependencyErrorForNonBadRequestResponse(t *test
 			require.NoError(t, err)
 			connector := &OpenSearchConnector{Config: &opensearchConfig{Host: host, Port: port}}
 
-			available, err := connector.ValidateAnalyzers(context.Background(), map[string]string{"status": "hanlp_index"})
+			available, err := connector.ValidateAnalyzer(context.Background(), "hanlp_index")
 			require.Error(t, err)
 			assert.False(t, available)
 		})

--- a/adp/vega/vega-backend/server/logics/connector/local/index/opensearch/opensearch_query_test.go
+++ b/adp/vega/vega-backend/server/logics/connector/local/index/opensearch/opensearch_query_test.go
@@ -137,6 +137,29 @@ func TestValidateAnalyzerReturnsDependencyErrorForNonBadRequestResponse(t *testi
 	}
 }
 
+func TestValidateAnalyzerReturnsDependencyErrorForUnrelatedBadRequest(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, "/_analyze", r.URL.Path)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusBadRequest)
+		_, err := w.Write([]byte(`{"error":"invalid analyze request"}`))
+		require.NoError(t, err)
+	}))
+	t.Cleanup(server.Close)
+
+	serverURL, err := url.Parse(server.URL)
+	require.NoError(t, err)
+	host, portText, err := net.SplitHostPort(serverURL.Host)
+	require.NoError(t, err)
+	port, err := strconv.Atoi(portText)
+	require.NoError(t, err)
+	connector := &OpenSearchConnector{Config: &opensearchConfig{Host: host, Port: port}}
+
+	available, err := connector.ValidateAnalyzer(context.Background(), "hanlp_index")
+	require.Error(t, err)
+	assert.False(t, available)
+}
+
 func TestExecuteRawQueryFlattensAggregationsIntoEntries(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.Header().Set("Content-Type", "application/json")

--- a/adp/vega/vega-backend/server/logics/connector/local/index/opensearch/opensearch_query_test.go
+++ b/adp/vega/vega-backend/server/logics/connector/local/index/opensearch/opensearch_query_test.go
@@ -8,7 +8,6 @@ package opensearch
 
 import (
 	"context"
-	"errors"
 	"io"
 	"net"
 	"net/http"
@@ -82,16 +81,17 @@ func TestValidateAnalyzersChecksEachDistinctAnalyzerOnce(t *testing.T) {
 	require.NoError(t, err)
 	connector := &OpenSearchConnector{Config: &opensearchConfig{Host: host, Port: port}}
 
-	err = connector.ValidateAnalyzers(context.Background(), map[string]string{
+	available, err := connector.ValidateAnalyzers(context.Background(), map[string]string{
 		"coupon_code": "standard",
 		"name":        "standard",
 		"status":      "ik_max_word",
 	})
 	require.NoError(t, err)
+	assert.True(t, available)
 	assert.Equal(t, 2, requests)
 }
 
-func TestValidateAnalyzersReturnsUnavailableErrorForOpenSearchResponse(t *testing.T) {
+func TestValidateAnalyzersReportsUnavailableForOpenSearchResponse(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		require.Equal(t, "/_analyze", r.URL.Path)
 		w.Header().Set("Content-Type", "application/json")
@@ -109,13 +109,11 @@ func TestValidateAnalyzersReturnsUnavailableErrorForOpenSearchResponse(t *testin
 	require.NoError(t, err)
 	connector := &OpenSearchConnector{Config: &opensearchConfig{Host: host, Port: port}}
 
-	err = connector.ValidateAnalyzers(context.Background(), map[string]string{
+	available, err := connector.ValidateAnalyzers(context.Background(), map[string]string{
 		"status": "hanlp_index",
 	})
-	var unavailableErr *interfaces.AnalyzerUnavailableError
-	require.ErrorAs(t, err, &unavailableErr)
-	assert.Equal(t, "hanlp_index", unavailableErr.Analyzer)
-	assert.Equal(t, []string{"status"}, unavailableErr.Fields)
+	require.NoError(t, err)
+	assert.False(t, available)
 }
 
 func TestValidateAnalyzersReturnsDependencyErrorForNonBadRequestResponse(t *testing.T) {
@@ -138,10 +136,9 @@ func TestValidateAnalyzersReturnsDependencyErrorForNonBadRequestResponse(t *test
 			require.NoError(t, err)
 			connector := &OpenSearchConnector{Config: &opensearchConfig{Host: host, Port: port}}
 
-			err = connector.ValidateAnalyzers(context.Background(), map[string]string{"status": "hanlp_index"})
+			available, err := connector.ValidateAnalyzers(context.Background(), map[string]string{"status": "hanlp_index"})
 			require.Error(t, err)
-			var unavailableErr *interfaces.AnalyzerUnavailableError
-			assert.False(t, errors.As(err, &unavailableErr))
+			assert.False(t, available)
 		})
 	}
 }

--- a/adp/vega/vega-backend/server/logics/local_index/local_index_manager.go
+++ b/adp/vega/vega-backend/server/logics/local_index/local_index_manager.go
@@ -10,7 +10,10 @@ package local_index
 import (
 	"context"
 	"fmt"
+	"sort"
+	"strings"
 	"sync"
+	"time"
 
 	"vega-backend/common"
 	"vega-backend/interfaces"
@@ -24,8 +27,13 @@ var (
 )
 
 type localIndexManager struct {
-	c interfaces.IndexConnector
+	lic interfaces.IndexConnector // Local Index Connector
+
+	capabilities  interfaces.IndexCapabilities
+	capabilityErr error
 }
+
+var analyzerCandidates = []string{"standard", "english", "ik_max_word", "hanlp_index"}
 
 // NewLocalIndexManager creates a LocalIndexManager.
 func NewLocalIndexManager(appSetting *common.AppSetting) interfaces.LocalIndexManager {
@@ -48,36 +56,80 @@ func NewLocalIndexManager(appSetting *common.AppSetting) interfaces.LocalIndexMa
 			panic(fmt.Sprintf("failed to create OpenSearch connector: %v", err))
 		}
 
-		managerInst = &localIndexManager{
-			c: connector.(interfaces.IndexConnector),
+		manager := &localIndexManager{
+			lic:          connector.(interfaces.IndexConnector),
+			capabilities: interfaces.IndexCapabilities{CheckedAt: time.Now().UnixMilli()},
 		}
+		for _, analyzer := range analyzerCandidates {
+			available, err := manager.lic.ValidateAnalyzers(context.Background(), map[string]string{"_capability_probe": analyzer})
+			if err != nil {
+				manager.capabilityErr = err
+				manager.capabilities.FulltextAnalyzers = nil
+				break
+			}
+			if available {
+				manager.capabilities.FulltextAnalyzers = append(manager.capabilities.FulltextAnalyzers, interfaces.AnalyzerCapability{ID: analyzer})
+			}
+		}
+		managerInst = manager
 	})
 	return managerInst
 }
 
 func (lim *localIndexManager) CreateIndex(ctx context.Context, indexName string, schema []*interfaces.Property) error {
-	return lim.c.Create(ctx, indexName, schema)
+	return lim.lic.Create(ctx, indexName, schema)
 }
 
 func (lim *localIndexManager) UpdateIndex(ctx context.Context, indexName string, schema []*interfaces.Property) error {
-	return lim.c.Update(ctx, indexName, schema)
+	return lim.lic.Update(ctx, indexName, schema)
 }
 
 func (lim *localIndexManager) DeleteIndex(ctx context.Context, indexName string) error {
-	return lim.c.Delete(ctx, indexName)
+	return lim.lic.Delete(ctx, indexName)
 }
 
 func (lim *localIndexManager) CheckExist(ctx context.Context, indexName string) (bool, error) {
-	return lim.c.CheckExist(ctx, indexName)
+	return lim.lic.CheckExist(ctx, indexName)
 }
 
-// ValidateAnalyzers delegates analyzer availability checks to the local index connector.
-func (lim *localIndexManager) ValidateAnalyzers(ctx context.Context, analyzers map[string]string) error {
-	return lim.c.ValidateAnalyzers(ctx, analyzers)
+func (lim *localIndexManager) ValidateAnalyzers(ctx context.Context, analyzers map[string]string) (bool, error) {
+	if _, err := lim.GetIndexCapabilities(ctx); err != nil {
+		return false, err
+	}
+	available := map[string]struct{}{}
+	for _, item := range lim.capabilities.FulltextAnalyzers {
+		available[item.ID] = struct{}{}
+	}
+	byAnalyzer := map[string][]string{}
+	for field, value := range analyzers {
+		if analyzer := strings.TrimSpace(value); analyzer != "" {
+			byAnalyzer[analyzer] = append(byAnalyzer[analyzer], field)
+		}
+	}
+	names := make([]string, 0, len(byAnalyzer))
+	for analyzer := range byAnalyzer {
+		names = append(names, analyzer)
+	}
+	sort.Strings(names)
+	for _, analyzer := range names {
+		if _, ok := available[analyzer]; !ok {
+			return false, nil
+		}
+	}
+	return true, nil
+}
+
+func (lim *localIndexManager) GetIndexCapabilities(_ context.Context) (*interfaces.IndexCapabilities, error) {
+	if lim.capabilityErr != nil {
+		return nil, &interfaces.IndexCapabilitiesUnavailableError{Cause: lim.capabilityErr}
+	}
+	result := lim.capabilities
+	result.FulltextAnalyzers = append([]interfaces.AnalyzerCapability(nil), lim.capabilities.FulltextAnalyzers...)
+	return &result, nil
 }
 
 func (lim *localIndexManager) ListDocuments(ctx context.Context, indexName string, res *interfaces.Resource, params *interfaces.ResourceDataQueryParams) ([]map[string]any, int64, error) {
-	queryResult, err := lim.c.ExecuteQuery(ctx, indexName, res, params)
+	queryResult, err := lim.lic.ExecuteQuery(ctx, indexName, res, params)
 	if err != nil {
 		return nil, 0, err
 	}
@@ -89,23 +141,23 @@ func (lim *localIndexManager) ListDocuments(ctx context.Context, indexName strin
 }
 
 func (lim *localIndexManager) GetDocument(ctx context.Context, indexName string, docID string) (map[string]any, error) {
-	return lim.c.GetDocument(ctx, indexName, docID)
+	return lim.lic.GetDocument(ctx, indexName, docID)
 }
 
 func (lim *localIndexManager) CreateDocuments(ctx context.Context, indexName string, documents []map[string]any) ([]string, error) {
-	return lim.c.CreateDocuments(ctx, indexName, documents)
+	return lim.lic.CreateDocuments(ctx, indexName, documents)
 }
 
 func (lim *localIndexManager) UpsertDocuments(ctx context.Context, indexName string, updateRequests []map[string]any) ([]string, error) {
-	return lim.c.UpsertDocuments(ctx, indexName, updateRequests)
+	return lim.lic.UpsertDocuments(ctx, indexName, updateRequests)
 }
 
 func (lim *localIndexManager) DeleteDocument(ctx context.Context, indexName string, docID string) error {
-	return lim.c.DeleteDocument(ctx, indexName, docID)
+	return lim.lic.DeleteDocument(ctx, indexName, docID)
 }
 
 func (lim *localIndexManager) DeleteDocuments(ctx context.Context, indexName string, docIDs string) error {
-	return lim.c.DeleteDocuments(ctx, indexName, docIDs)
+	return lim.lic.DeleteDocuments(ctx, indexName, docIDs)
 }
 
 func (lim *localIndexManager) DeleteDocumentsByQuery(ctx context.Context, indexName string, res *interfaces.Resource, params *interfaces.ResourceDataQueryParams) error {
@@ -125,5 +177,5 @@ func (lim *localIndexManager) DeleteDocumentsByQuery(ctx context.Context, indexN
 	}
 	params.ActualFilterCond = actualFilterCond
 
-	return lim.c.DeleteDocumentsByQuery(ctx, indexName, params, res.SchemaDefinition)
+	return lim.lic.DeleteDocumentsByQuery(ctx, indexName, params, res.SchemaDefinition)
 }

--- a/adp/vega/vega-backend/server/logics/local_index/local_index_manager.go
+++ b/adp/vega/vega-backend/server/logics/local_index/local_index_manager.go
@@ -10,7 +10,6 @@ package local_index
 import (
 	"context"
 	"fmt"
-	"sort"
 	"strings"
 	"sync"
 	"time"
@@ -61,7 +60,7 @@ func NewLocalIndexManager(appSetting *common.AppSetting) interfaces.LocalIndexMa
 			capabilities: interfaces.IndexCapabilities{CheckedAt: time.Now().UnixMilli()},
 		}
 		for _, analyzer := range analyzerCandidates {
-			available, err := manager.lic.ValidateAnalyzers(context.Background(), map[string]string{"_capability_probe": analyzer})
+			available, err := manager.lic.ValidateAnalyzer(context.Background(), analyzer)
 			if err != nil {
 				manager.capabilityErr = err
 				manager.capabilities.FulltextAnalyzers = nil
@@ -92,31 +91,20 @@ func (lim *localIndexManager) CheckExist(ctx context.Context, indexName string) 
 	return lim.lic.CheckExist(ctx, indexName)
 }
 
-func (lim *localIndexManager) ValidateAnalyzers(ctx context.Context, analyzers map[string]string) (bool, error) {
+func (lim *localIndexManager) ValidateAnalyzer(ctx context.Context, analyzer string) (bool, error) {
 	if _, err := lim.GetIndexCapabilities(ctx); err != nil {
 		return false, err
+	}
+	analyzer = strings.TrimSpace(analyzer)
+	if analyzer == "" {
+		return true, nil
 	}
 	available := map[string]struct{}{}
 	for _, item := range lim.capabilities.FulltextAnalyzers {
 		available[item.ID] = struct{}{}
 	}
-	byAnalyzer := map[string][]string{}
-	for field, value := range analyzers {
-		if analyzer := strings.TrimSpace(value); analyzer != "" {
-			byAnalyzer[analyzer] = append(byAnalyzer[analyzer], field)
-		}
-	}
-	names := make([]string, 0, len(byAnalyzer))
-	for analyzer := range byAnalyzer {
-		names = append(names, analyzer)
-	}
-	sort.Strings(names)
-	for _, analyzer := range names {
-		if _, ok := available[analyzer]; !ok {
-			return false, nil
-		}
-	}
-	return true, nil
+	_, ok := available[analyzer]
+	return ok, nil
 }
 
 func (lim *localIndexManager) GetIndexCapabilities(_ context.Context) (*interfaces.IndexCapabilities, error) {

--- a/adp/vega/vega-backend/server/logics/local_index/local_index_manager_test.go
+++ b/adp/vega/vega-backend/server/logics/local_index/local_index_manager_test.go
@@ -24,7 +24,7 @@ func TestLocalIndexManagerDelegatesToIndexConnector(t *testing.T) {
 		t.Cleanup(ctrl.Finish)
 		ctx := context.Background()
 		connector := vmock.NewMockIndexConnector(ctrl)
-		manager := &localIndexManager{c: connector}
+		manager := &localIndexManager{lic: connector}
 		schema := []*interfaces.Property{{Name: "id", Type: "integer"}}
 		resource := &interfaces.Resource{ID: "resource-1", SchemaDefinition: schema}
 		params := &interfaces.ResourceDataQueryParams{}
@@ -85,7 +85,7 @@ func TestLocalIndexManagerDeleteDocumentsByQueryBuildsActualFilter(t *testing.T)
 		t.Cleanup(ctrl.Finish)
 		ctx := context.Background()
 		connector := vmock.NewMockIndexConnector(ctrl)
-		manager := &localIndexManager{c: connector}
+		manager := &localIndexManager{lic: connector}
 		resource := &interfaces.Resource{
 			SchemaDefinition: []*interfaces.Property{{Name: "id", Type: "integer"}},
 		}

--- a/adp/vega/vega-backend/server/logics/resource/resource_service.go
+++ b/adp/vega/vega-backend/server/logics/resource/resource_service.go
@@ -236,6 +236,9 @@ func (rs *resourceService) Create(ctx context.Context, req *interfaces.ResourceR
 	if err := extensions.ValidateSchemaPropertiesExtensions(ctx, req.SchemaDefinition); err != nil {
 		return nil, err
 	}
+	if err := validateSingleFeatureTypePerProperty(ctx, req.SchemaDefinition); err != nil {
+		return nil, err
+	}
 	if err := rs.validateIndexConfigModels(ctx, req.SchemaDefinition, req.IndexConfig); err != nil {
 		return nil, err
 	}
@@ -721,6 +724,9 @@ func (rs *resourceService) Update(ctx context.Context, resource *interfaces.Reso
 	if err := extensions.ValidateSchemaPropertiesExtensions(ctx, resource.SchemaDefinition); err != nil {
 		return err
 	}
+	if err := validateSingleFeatureTypePerProperty(ctx, resource.SchemaDefinition); err != nil {
+		return err
+	}
 	if err := rs.validateIndexConfigModels(ctx, resource.SchemaDefinition, resource.IndexConfig); err != nil {
 		return err
 	}
@@ -1072,6 +1078,26 @@ func (rs *resourceService) validateResourceUpdateScope(ctx context.Context, reso
 		resource.Category == interfaces.ResourceCategoryDataset,
 	)
 	return schemaChanged || indexConfigChanged, err
+}
+
+func validateSingleFeatureTypePerProperty(ctx context.Context, schema []*interfaces.Property) error {
+	for _, property := range schema {
+		if property == nil {
+			continue
+		}
+		seen := make(map[string]struct{}, len(property.Features))
+		for _, feature := range property.Features {
+			if feature.FeatureType == "" {
+				continue
+			}
+			if _, exists := seen[feature.FeatureType]; exists {
+				return rest.NewHTTPError(ctx, http.StatusBadRequest, verrors.VegaBackend_InvalidParameter_RequestBody).
+					WithErrorDetails(fmt.Sprintf("property %q has more than one %q feature", property.Name, feature.FeatureType))
+			}
+			seen[feature.FeatureType] = struct{}{}
+		}
+	}
+	return nil
 }
 
 func (rs *resourceService) validateIndexConfigModels(ctx context.Context, schema []*interfaces.Property, indexConfig *interfaces.ResourceIndexConfig) error {

--- a/adp/vega/vega-backend/server/logics/resource/resource_service.go
+++ b/adp/vega/vega-backend/server/logics/resource/resource_service.go
@@ -13,6 +13,7 @@ import (
 	"fmt"
 	"net/http"
 	"reflect"
+	"sort"
 	"strings"
 	"sync"
 	"time"
@@ -237,6 +238,9 @@ func (rs *resourceService) Create(ctx context.Context, req *interfaces.ResourceR
 		return nil, err
 	}
 	if err := rs.validateIndexConfigModels(ctx, req.SchemaDefinition, req.IndexConfig); err != nil {
+		return nil, err
+	}
+	if err := rs.validateIndexConfigAnalyzers(ctx, req.SchemaDefinition, req.IndexConfig); err != nil {
 		return nil, err
 	}
 	if req.Extensions != nil {
@@ -721,6 +725,9 @@ func (rs *resourceService) Update(ctx context.Context, resource *interfaces.Reso
 	if err := rs.validateIndexConfigModels(ctx, resource.SchemaDefinition, resource.IndexConfig); err != nil {
 		return err
 	}
+	if err := rs.validateIndexConfigAnalyzers(ctx, resource.SchemaDefinition, resource.IndexConfig); err != nil {
+		return err
+	}
 	if req.Extensions != nil {
 		if err := extensions.ValidateEntityExtensionsMap(ctx, *req.Extensions); err != nil {
 			return err
@@ -1116,6 +1123,79 @@ func (rs *resourceService) validateIndexConfigModels(ctx context.Context, schema
 		}
 	}
 	return nil
+}
+
+func (rs *resourceService) validateIndexConfigAnalyzers(ctx context.Context, schema []*interfaces.Property, indexConfig *interfaces.ResourceIndexConfig) error {
+	if rs.lim == nil {
+		return nil
+	}
+	analyzers := collectFulltextAnalyzers(schema, indexConfig)
+	if len(analyzers) == 0 {
+		return nil
+	}
+	capabilities, err := rs.lim.GetIndexCapabilities(ctx)
+	if err != nil {
+		return rest.NewHTTPError(ctx, http.StatusServiceUnavailable, verrors.VegaBackend_IndexCapability_InternalError_Unavailable).
+			WithErrorDetails(err.Error())
+	}
+	available := make(map[string]struct{}, len(capabilities.FulltextAnalyzers))
+	for _, analyzer := range capabilities.FulltextAnalyzers {
+		available[analyzer.ID] = struct{}{}
+	}
+	names := make([]string, 0, len(analyzers))
+	for analyzer := range analyzers {
+		names = append(names, analyzer)
+	}
+	sort.Strings(names)
+	for _, analyzer := range names {
+		if _, ok := available[analyzer]; ok {
+			continue
+		}
+		fields := append([]string(nil), analyzers[analyzer]...)
+		sort.Strings(fields)
+		return rest.NewHTTPError(ctx, http.StatusBadRequest, verrors.VegaBackend_Resource_InvalidParameter_Analyzer).
+			WithErrorDetails(fmt.Sprintf("analyzer %q is unavailable for fields %q", analyzer, strings.Join(fields, ", ")))
+	}
+	return nil
+}
+
+func collectFulltextAnalyzers(schema []*interfaces.Property, indexConfig *interfaces.ResourceIndexConfig) map[string][]string {
+	defaultAnalyzer := ""
+	if indexConfig != nil {
+		defaultAnalyzer = strings.TrimSpace(indexConfig.DefaultFulltextAnalyzer)
+	}
+	result := map[string][]string{}
+	for _, prop := range schema {
+		if prop == nil {
+			continue
+		}
+		for _, feature := range prop.Features {
+			if feature.FeatureType != interfaces.PropertyFeatureType_Fulltext {
+				continue
+			}
+			analyzer := strings.TrimSpace(fulltextAnalyzerConfigValue(feature.Config))
+			if analyzer == "" {
+				analyzer = defaultAnalyzer
+			}
+			if analyzer == "" {
+				continue
+			}
+			fieldName := prop.Name
+			if feature.RefProperty != "" {
+				fieldName = feature.RefProperty
+			}
+			result[analyzer] = append(result[analyzer], fieldName)
+		}
+	}
+	return result
+}
+
+func fulltextAnalyzerConfigValue(config map[string]any) string {
+	if config == nil {
+		return ""
+	}
+	value, _ := config["analyzer"].(string)
+	return value
 }
 
 func validateIndexConfigBuildKeyFields(ctx context.Context, schema []*interfaces.Property, indexConfig *interfaces.ResourceIndexConfig) error {

--- a/adp/vega/vega-backend/server/logics/resource/resource_service.go
+++ b/adp/vega/vega-backend/server/logics/resource/resource_service.go
@@ -13,7 +13,6 @@ import (
 	"fmt"
 	"net/http"
 	"reflect"
-	"sort"
 	"strings"
 	"sync"
 	"time"
@@ -1129,42 +1128,10 @@ func (rs *resourceService) validateIndexConfigAnalyzers(ctx context.Context, sch
 	if rs.lim == nil {
 		return nil
 	}
-	analyzers := collectFulltextAnalyzers(schema, indexConfig)
-	if len(analyzers) == 0 {
-		return nil
-	}
-	capabilities, err := rs.lim.GetIndexCapabilities(ctx)
-	if err != nil {
-		return rest.NewHTTPError(ctx, http.StatusServiceUnavailable, verrors.VegaBackend_IndexCapability_InternalError_Unavailable).
-			WithErrorDetails(err.Error())
-	}
-	available := make(map[string]struct{}, len(capabilities.FulltextAnalyzers))
-	for _, analyzer := range capabilities.FulltextAnalyzers {
-		available[analyzer.ID] = struct{}{}
-	}
-	names := make([]string, 0, len(analyzers))
-	for analyzer := range analyzers {
-		names = append(names, analyzer)
-	}
-	sort.Strings(names)
-	for _, analyzer := range names {
-		if _, ok := available[analyzer]; ok {
-			continue
-		}
-		fields := append([]string(nil), analyzers[analyzer]...)
-		sort.Strings(fields)
-		return rest.NewHTTPError(ctx, http.StatusBadRequest, verrors.VegaBackend_Resource_InvalidParameter_Analyzer).
-			WithErrorDetails(fmt.Sprintf("analyzer %q is unavailable for fields %q", analyzer, strings.Join(fields, ", ")))
-	}
-	return nil
-}
-
-func collectFulltextAnalyzers(schema []*interfaces.Property, indexConfig *interfaces.ResourceIndexConfig) map[string][]string {
 	defaultAnalyzer := ""
 	if indexConfig != nil {
 		defaultAnalyzer = strings.TrimSpace(indexConfig.DefaultFulltextAnalyzer)
 	}
-	result := map[string][]string{}
 	for _, prop := range schema {
 		if prop == nil {
 			continue
@@ -1184,10 +1151,18 @@ func collectFulltextAnalyzers(schema []*interfaces.Property, indexConfig *interf
 			if feature.RefProperty != "" {
 				fieldName = feature.RefProperty
 			}
-			result[analyzer] = append(result[analyzer], fieldName)
+			available, err := rs.lim.ValidateAnalyzer(ctx, analyzer)
+			if err != nil {
+				return rest.NewHTTPError(ctx, http.StatusServiceUnavailable, verrors.VegaBackend_IndexCapability_InternalError_Unavailable).
+					WithErrorDetails(err.Error())
+			}
+			if !available {
+				return rest.NewHTTPError(ctx, http.StatusBadRequest, verrors.VegaBackend_Resource_InvalidParameter_Analyzer).
+					WithErrorDetails(fmt.Sprintf("analyzer %q for field %q is unavailable", analyzer, fieldName))
+			}
 		}
 	}
-	return result
+	return nil
 }
 
 func fulltextAnalyzerConfigValue(config map[string]any) string {

--- a/adp/vega/vega-backend/server/logics/resource/resource_service.go
+++ b/adp/vega/vega-backend/server/logics/resource/resource_service.go
@@ -10,6 +10,7 @@ package resource
 import (
 	"context"
 	"database/sql"
+	"errors"
 	"fmt"
 	"net/http"
 	"reflect"
@@ -1179,7 +1180,12 @@ func (rs *resourceService) validateIndexConfigAnalyzers(ctx context.Context, sch
 			}
 			available, err := rs.lim.ValidateAnalyzer(ctx, analyzer)
 			if err != nil {
-				return rest.NewHTTPError(ctx, http.StatusServiceUnavailable, verrors.VegaBackend_IndexCapability_InternalError_Unavailable).
+				var unavailableErr *interfaces.IndexCapabilitiesUnavailableError
+				if errors.As(err, &unavailableErr) {
+					return rest.NewHTTPError(ctx, http.StatusServiceUnavailable, verrors.VegaBackend_IndexCapability_InternalError_Unavailable).
+						WithErrorDetails(err.Error())
+				}
+				return rest.NewHTTPError(ctx, http.StatusInternalServerError, verrors.VegaBackend_Resource_InternalError).
 					WithErrorDetails(err.Error())
 			}
 			if !available {

--- a/adp/vega/vega-backend/server/logics/resource/resource_service_test.go
+++ b/adp/vega/vega-backend/server/logics/resource/resource_service_test.go
@@ -421,7 +421,8 @@ func TestValidateIndexConfigAnalyzers(t *testing.T) {
 	t.Run("accepts defaults and field overrides in the capability snapshot", func(t *testing.T) {
 		ctrl := gomock.NewController(t)
 		lim := vmock.NewMockLocalIndexManager(ctrl)
-		lim.EXPECT().GetIndexCapabilities(gomock.Any()).Return(&interfaces.IndexCapabilities{FulltextAnalyzers: []interfaces.AnalyzerCapability{{ID: "standard"}, {ID: "english"}}}, nil)
+		lim.EXPECT().ValidateAnalyzer(gomock.Any(), "standard").Return(true, nil)
+		lim.EXPECT().ValidateAnalyzer(gomock.Any(), "english").Return(true, nil)
 		rs := &resourceService{lim: lim}
 
 		err := rs.validateIndexConfigAnalyzers(context.Background(), schema, &interfaces.ResourceIndexConfig{DefaultFulltextAnalyzer: "standard"})
@@ -431,7 +432,8 @@ func TestValidateIndexConfigAnalyzers(t *testing.T) {
 	t.Run("rejects an unavailable analyzer with affected fields", func(t *testing.T) {
 		ctrl := gomock.NewController(t)
 		lim := vmock.NewMockLocalIndexManager(ctrl)
-		lim.EXPECT().GetIndexCapabilities(gomock.Any()).Return(&interfaces.IndexCapabilities{FulltextAnalyzers: []interfaces.AnalyzerCapability{{ID: "standard"}}}, nil)
+		lim.EXPECT().ValidateAnalyzer(gomock.Any(), "standard").Return(true, nil)
+		lim.EXPECT().ValidateAnalyzer(gomock.Any(), "english").Return(false, nil)
 		rs := &resourceService{lim: lim}
 
 		err := rs.validateIndexConfigAnalyzers(context.Background(), schema, &interfaces.ResourceIndexConfig{DefaultFulltextAnalyzer: "standard"})
@@ -444,13 +446,30 @@ func TestValidateIndexConfigAnalyzers(t *testing.T) {
 	t.Run("returns capability unavailable when the startup probe failed", func(t *testing.T) {
 		ctrl := gomock.NewController(t)
 		lim := vmock.NewMockLocalIndexManager(ctrl)
-		lim.EXPECT().GetIndexCapabilities(gomock.Any()).Return(nil, &interfaces.IndexCapabilitiesUnavailableError{Cause: errors.New("connection refused")})
+		lim.EXPECT().ValidateAnalyzer(gomock.Any(), "standard").Return(false, &interfaces.IndexCapabilitiesUnavailableError{Cause: errors.New("connection refused")})
 		rs := &resourceService{lim: lim}
 
 		err := rs.validateIndexConfigAnalyzers(context.Background(), schema, &interfaces.ResourceIndexConfig{DefaultFulltextAnalyzer: "standard"})
 		httpErr := requireResourceHTTPError(t, err, verrors.VegaBackend_IndexCapability_InternalError_Unavailable)
 		assert.Equal(t, http.StatusServiceUnavailable, httpErr.HTTPCode)
 		assert.Contains(t, httpErr.BaseError.ErrorDetails, "connection refused")
+	})
+
+	t.Run("validates each configured fulltext feature without collection", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		lim := vmock.NewMockLocalIndexManager(ctrl)
+		lim.EXPECT().ValidateAnalyzer(gomock.Any(), "standard").Return(true, nil)
+		lim.EXPECT().ValidateAnalyzer(gomock.Any(), "english").Return(true, nil)
+		rs := &resourceService{lim: lim}
+		multiFeatureSchema := []*interfaces.Property{{
+			Name: "title",
+			Features: []interfaces.PropertyFeature{
+				{FeatureType: interfaces.PropertyFeatureType_Fulltext, Config: map[string]any{"analyzer": "standard"}},
+				{FeatureType: interfaces.PropertyFeatureType_Fulltext, Config: map[string]any{"analyzer": "english"}},
+			},
+		}}
+
+		require.NoError(t, rs.validateIndexConfigAnalyzers(context.Background(), multiFeatureSchema, nil))
 	})
 }
 

--- a/adp/vega/vega-backend/server/logics/resource/resource_service_test.go
+++ b/adp/vega/vega-backend/server/logics/resource/resource_service_test.go
@@ -79,6 +79,19 @@ func expectResourceServiceTransaction(t *testing.T, rs *resourceService, commit 
 	})
 }
 
+func TestValidateSingleFeatureTypePerPropertyRejectsKeywordDuplicates(t *testing.T) {
+	err := validateSingleFeatureTypePerProperty(context.Background(), []*interfaces.Property{{
+		Name: "code",
+		Features: []interfaces.PropertyFeature{
+			{FeatureType: interfaces.PropertyFeatureType_Keyword},
+			{FeatureType: interfaces.PropertyFeatureType_Keyword},
+		},
+	}})
+
+	httpErr := requireResourceHTTPError(t, err, verrors.VegaBackend_InvalidParameter_RequestBody)
+	assert.Contains(t, httpErr.BaseError.ErrorDetails, `property "code" has more than one "keyword" feature`)
+}
+
 func TestValidateIndexConfigBuildKeyFields(t *testing.T) {
 	schema := []*interfaces.Property{{Name: "id"}, {Name: "updated_at"}}
 

--- a/adp/vega/vega-backend/server/logics/resource/resource_service_test.go
+++ b/adp/vega/vega-backend/server/logics/resource/resource_service_test.go
@@ -468,6 +468,18 @@ func TestValidateIndexConfigAnalyzers(t *testing.T) {
 		assert.Contains(t, httpErr.BaseError.ErrorDetails, "connection refused")
 	})
 
+	t.Run("returns an internal error for other analyzer validation failures", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		lim := vmock.NewMockLocalIndexManager(ctrl)
+		lim.EXPECT().ValidateAnalyzer(gomock.Any(), "standard").Return(false, errors.New("unexpected validation failure"))
+		rs := &resourceService{lim: lim}
+
+		err := rs.validateIndexConfigAnalyzers(context.Background(), schema, &interfaces.ResourceIndexConfig{DefaultFulltextAnalyzer: "standard"})
+		httpErr := requireResourceHTTPError(t, err, verrors.VegaBackend_Resource_InternalError)
+		assert.Equal(t, http.StatusInternalServerError, httpErr.HTTPCode)
+		assert.Contains(t, httpErr.BaseError.ErrorDetails, "unexpected validation failure")
+	})
+
 	t.Run("validates each configured fulltext feature without collection", func(t *testing.T) {
 		ctrl := gomock.NewController(t)
 		lim := vmock.NewMockLocalIndexManager(ctrl)

--- a/adp/vega/vega-backend/server/logics/resource/resource_service_test.go
+++ b/adp/vega/vega-backend/server/logics/resource/resource_service_test.go
@@ -412,6 +412,57 @@ func TestResourceServiceList(t *testing.T) {
 	})
 }
 
+func TestValidateIndexConfigAnalyzers(t *testing.T) {
+	schema := []*interfaces.Property{
+		{Name: "title", Features: []interfaces.PropertyFeature{{FeatureType: interfaces.PropertyFeatureType_Fulltext}}},
+		{Name: "summary", Features: []interfaces.PropertyFeature{{FeatureType: interfaces.PropertyFeatureType_Fulltext, Config: map[string]any{"analyzer": "english"}}}},
+	}
+
+	t.Run("accepts defaults and field overrides in the capability snapshot", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		lim := vmock.NewMockLocalIndexManager(ctrl)
+		lim.EXPECT().GetIndexCapabilities(gomock.Any()).Return(&interfaces.IndexCapabilities{FulltextAnalyzers: []interfaces.AnalyzerCapability{{ID: "standard"}, {ID: "english"}}}, nil)
+		rs := &resourceService{lim: lim}
+
+		err := rs.validateIndexConfigAnalyzers(context.Background(), schema, &interfaces.ResourceIndexConfig{DefaultFulltextAnalyzer: "standard"})
+		require.NoError(t, err)
+	})
+
+	t.Run("rejects an unavailable analyzer with affected fields", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		lim := vmock.NewMockLocalIndexManager(ctrl)
+		lim.EXPECT().GetIndexCapabilities(gomock.Any()).Return(&interfaces.IndexCapabilities{FulltextAnalyzers: []interfaces.AnalyzerCapability{{ID: "standard"}}}, nil)
+		rs := &resourceService{lim: lim}
+
+		err := rs.validateIndexConfigAnalyzers(context.Background(), schema, &interfaces.ResourceIndexConfig{DefaultFulltextAnalyzer: "standard"})
+		httpErr := requireResourceHTTPError(t, err, verrors.VegaBackend_Resource_InvalidParameter_Analyzer)
+		assert.Equal(t, http.StatusBadRequest, httpErr.HTTPCode)
+		assert.Contains(t, httpErr.BaseError.ErrorDetails, "english")
+		assert.Contains(t, httpErr.BaseError.ErrorDetails, "summary")
+	})
+
+	t.Run("returns capability unavailable when the startup probe failed", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		lim := vmock.NewMockLocalIndexManager(ctrl)
+		lim.EXPECT().GetIndexCapabilities(gomock.Any()).Return(nil, &interfaces.IndexCapabilitiesUnavailableError{Cause: errors.New("connection refused")})
+		rs := &resourceService{lim: lim}
+
+		err := rs.validateIndexConfigAnalyzers(context.Background(), schema, &interfaces.ResourceIndexConfig{DefaultFulltextAnalyzer: "standard"})
+		httpErr := requireResourceHTTPError(t, err, verrors.VegaBackend_IndexCapability_InternalError_Unavailable)
+		assert.Equal(t, http.StatusServiceUnavailable, httpErr.HTTPCode)
+		assert.Contains(t, httpErr.BaseError.ErrorDetails, "connection refused")
+	})
+}
+
+func requireResourceHTTPError(t *testing.T, err error, wantCode string) *rest.HTTPError {
+	t.Helper()
+	require.Error(t, err)
+	httpErr, ok := err.(*rest.HTTPError)
+	require.Truef(t, ok, "expected HTTPError, got %T", err)
+	assert.Equal(t, wantCode, httpErr.BaseError.ErrorCode)
+	return httpErr
+}
+
 func TestResourceServiceCreate(t *testing.T) {
 	t.Run("rolls back resource and extensions when extension replacement fails", func(t *testing.T) {
 		rs, mockRA, mockPS, _, _, mockCS, _ := newTestService(t)


### PR DESCRIPTION
# Pull Request

## What Changed

Brief description of changes:

- [x] Add an immutable startup-time OpenSearch analyzer capability snapshot and the authenticated GET /api/vega-backend/v1/index-capabilities endpoint.
- [x] Validate Resource writes and BuildTask create/restart against the in-memory snapshot.
- [x] Reject duplicate feature types on one Property until the multi-feature model is implemented.
- [x] Add focused regression coverage for analyzer failures and duplicate feature types.

---

## Why

- Related Issue: [openbkn-ai/bkn-studio#369](https://github.com/openbkn-ai/bkn-studio/issues/369)
- Related Feature: Runtime analyzer capability discovery
- Background: Static analyzer options allowed unavailable OpenSearch analyzers to be persisted and later fail index builds.

---

## How

- Key implementation points: Probe the supported analyzer set once during LocalIndexManager initialization; retain the result in memory until restart; expose only available analyzers through the capability endpoint.
- Breaking changes (API, config, database, etc.): New additive endpoint. Resource and BuildTask operations now reject unavailable analyzers. A Property now permits at most one feature of each feature type.

---

## Testing

- [x] Unit tests passed locally
- [ ] Integration tests passed locally
- [ ] Verified in test environment

Test notes:

- make ci passed.

---

## Risk & Rollback

- Potential risks: Capability state remains fixed until Vega restarts; deployments with unavailable OpenSearch return 503 for capability-dependent operations.
- Rollback plan: Revert this PR to restore the prior static analyzer behavior and remove the endpoint.

---

## Additional Notes

- Design document: [issue-369-opensearch-analyzer-capabilities.md](https://github.com/openbkn-ai/bkn-docs/blob/main/docs/foundry/vega/design/issue-369-opensearch-analyzer-capabilities.md)
- Follow-up: [openbkn-ai/bkn-studio#392](https://github.com/openbkn-ai/bkn-studio/issues/392) will design multi-feature support with stable physical fields, snapshots, and query semantics.