### PR TITLE
docs(api): make module order explicit, unpublish bkn-safe and observability

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,11 +8,23 @@ API_DIR      := docs/api
 GEN_DIR      := $(API_DIR)/_generated
 HTML_DIR     := $(GEN_DIR)/html
 TPL_DIR      := $(API_DIR)/_templates
-# 模块目录 = docs/api 下除 _shared / _generated 外的子目录。
-# 用 $(API_DIR)/*/. 强制只匹配目录（GNU make 的 */ 通配会把 README.md 也算进来），
-# $(dir ...) 取目录路径，再 notdir 取目录名。
+# 发布的模块及其展示顺序。手写列表而非目录通配：通配按目录名排序，出来的是
+# "bkn-agent 排在 bkn 前面" 这种字典序巧合，且无法把某个模块暂时撤下发布面。
+# 顺序即站点首页的卡片分组顺序，改这里就改了线上顺序。
+MODULES      := bkn context-loader ontology-query vega execution-factory mf-model-manager \
+                agent-observability bkn-agent
+# 暂不发布的模块目录（YAML 保留在仓库，只是不进站点、不参与 lint）：
+#   bkn-safe      仅一份自助读取接口，不作为通用集成合同对外
+#   observability 只有 observability.json，没有可发布的 YAML，渲染出来是空分组
+MODULES_UNPUBLISHED := bkn-safe observability
+# 对账：docs/api 下的模块目录必须要么在 MODULES 里、要么在 MODULES_UNPUBLISHED 里，
+# 新增模块目录却忘了登记时直接报错，避免"加了文档但站点上没有"的静默漏发。
 MODULE_DIRS  := $(dir $(wildcard $(API_DIR)/*/.))
-MODULES      := $(filter-out _shared _generated _templates tools,$(foreach d,$(MODULE_DIRS),$(notdir $(patsubst %/,%,$(d)))))
+MODULE_ALL   := $(filter-out _shared _generated _templates tools,$(foreach d,$(MODULE_DIRS),$(notdir $(patsubst %/,%,$(d)))))
+MODULE_ORPHAN := $(filter-out $(MODULES) $(MODULES_UNPUBLISHED),$(MODULE_ALL))
+ifneq ($(MODULE_ORPHAN),)
+$(error docs/api 下存在未登记的模块目录：$(MODULE_ORPHAN)。请加入 Makefile 的 MODULES 或 MODULES_UNPUBLISHED)
+endif
 
 # 契约巡检:实际返回 vs 文档。默认打开发 VM 的内部面(免 token)。
 CONTRACT_SSH        ?= parallels@10.211.55.4

--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -18,19 +18,29 @@
 
 ## 🗂️ 模块一览
 
+下表顺序即站点首页的卡片分组顺序，由 [`Makefile`](../../Makefile) 的 `MODULES` 决定，改那一行即改线上顺序。
+
 | 模块 | 目录 | 覆盖情况 |
 |---|---|---|
 | 🟦 bkn-backend | [`bkn/`](bkn/) | 业务知识网络：对象类 / 关系类 / 行动类 / 概念组 / 指标 / 导入导出。**全量** |
+| 🟫 context-loader | [`context-loader/`](context-loader/) | Agent 上下文入口：Schema 检索 / 实例与子图查询 / 逻辑属性 / 行动执行 / Skill 召回 / 数据直查 / MCP。**外部面全量**（内部 `/in/v1` 面不收录） |
 | 🟩 ontology-query | [`ontology-query/`](ontology-query/) | 本体查询 / 语义检索 / 行动执行与日志。**全量** |
 | 🟨 vega-backend | [`vega/`](vega/) | 数据可观测：目录 / 资源 / 连接器 / 构建任务 / 发现任务 / 原生查询。**全量** |
-| 🟪 bkn-agent | [`bkn-agent/`](bkn-agent/) | Agent 运行时：agent CRUD / 对话 / 任务 / 提示词 / 导入导出。**全量** |
-| 🟥 agent-observability | [`agent-observability/`](agent-observability/) | BKN Trace：受管会话生命周期、业务证据、技术链路与快照。由 Go 注解生成，**禁止手改 YAML**。**全量** |
-| 🟫 context-loader | [`context-loader/`](context-loader/) | Agent 上下文入口：Schema 检索 / 实例与子图查询 / 逻辑属性 / 行动执行 / Skill 召回 / 数据直查 / MCP。**外部面全量**（内部 `/in/v1` 面不收录） |
 | 🟩 execution-factory | [`execution-factory/`](execution-factory/) | 执行工厂：函数 / 沙箱观测 / 导入导出 / 算子 / MCP / 工具箱 / Skill。**公开面全量**（89 个端点）。只收 Ingress 暴露的 `/v1`，内部面 `internal-v1` 刻意不收（不校验令牌），能力面 `/api/capabilities-lab/v1` 暂未收 |
 | 🟧 mf-model-manager | [`mf-model-manager/`](mf-model-manager/) | 模型工厂。**仅部分**：目前只覆盖大模型的连通性测试、默认模型设置与用量总览，其余接口（小模型、配额、提示词等）尚未文档化 |
-| 🟦 bkn-safe | [`bkn-safe/`](bkn-safe/) | BKN Trace 依赖的自助知识网络授权范围读取。**部分** |
+| 🟥 agent-observability | [`agent-observability/`](agent-observability/) | BKN Trace：受管会话生命周期、业务证据、技术链路与快照。由 Go 注解生成，**禁止手改 YAML**。**全量** |
+| 🟪 bkn-agent | [`bkn-agent/`](bkn-agent/) | Agent 运行时：agent CRUD / 对话 / 任务 / 提示词 / 导入导出。**全量** |
 
-> `bkn-safe` 仅收录已由外部运行时依赖的自助读取接口，不将管理面 API 误作为通用集成合同。
+### 暂不发布的模块
+
+目录仍在仓库里，但不进站点、不参与 lint。登记在 Makefile 的 `MODULES_UNPUBLISHED`：
+
+| 目录 | 原因 |
+| --- | --- |
+| [`bkn-safe/`](bkn-safe/) | 只有一份自助知识网络授权范围读取接口，不作为通用集成合同对外，管理面 API 更不宜误当集成合同 |
+| [`observability/`](observability/) | 只有 `observability.json`，没有可发布的 YAML，渲染出来是空分组 |
+
+> 新增模块目录必须登记到 `MODULES` 或 `MODULES_UNPUBLISHED`，否则 `make api-docs-*` 直接报错——防止"加了文档但站点上没有"的静默漏发。
 
 ### ⚠️ `/api/ontology-manager/v1` 是历史别名，不要再用
 


### PR DESCRIPTION
## Why

The API docs site groups modules by whatever order `$(wildcard docs/api/*/.)` returns, i.e. directory name collation. That is why `bkn-agent` (BKN 专属 Agent) rendered above `bkn` (BKN) — a coincidence of `-` sorting before `/`, not an editorial decision. There was also no way to take a module off the published site without deleting its YAML.

## What

- `MODULES` becomes an explicit ordered list. The list order is the card-group order on the site home page, so changing that one line changes the published order.
- New `MODULES_UNPUBLISHED` registers directories that stay in the repo but are excluded from the site and from lint:
  - `bkn-safe` — a single self-service read endpoint; not a general integration contract.
  - `observability` — only holds `observability.json`, no publishable YAML, so it rendered as an empty group.
- Module reconciliation: any directory under `docs/api/` that is in neither list fails the build with `$(error)`. This prevents the silent gap where a module is documented but never reaches the site.
- `docs/api/README.md`: module table reordered to match, plus a new "暂不发布的模块" section explaining where the two went.

Published order after this change: BKN → 上下文加载 → Ontology 查询 → VEGA 引擎 → 执行工厂 → 模型管理 → BKN Trace → BKN 专属 Agent.

## Verification

- `make api-docs-lint`: 39 specs pass (40 before; `bkn-safe/self-service.yaml` is no longer linted).
- `make api-docs-html`: renders 39 YAML, home page shows the 8 groups in the order above.
- No YAML deleted — both unpublished directories are untouched on disk.

Site order only changes once this lands on `main`, since the Pages job renders from `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)