### PR TITLE
fix(deploy): drop PyYAML dependency from install_status.py

### DIFF
--- a/deploy/scripts/lib/install_status.py
+++ b/deploy/scripts/lib/install_status.py
@@ -27,17 +27,113 @@ import subprocess
 import sys
 from datetime import datetime
 
-try:
-    import yaml
-except ImportError as e:
-    print(
-        "PyYAML is required for install-status. Install one of:\n"
-        "  sudo apt-get install -y python3-yaml                       # Debian/Ubuntu\n"
-        "  sudo dnf install -y python3-pyyaml                         # Fedora/RHEL/openEuler\n"
-        "  pip3 install --user --break-system-packages pyyaml         # any host with pip3",
-        file=sys.stderr,
-    )
-    raise e
+# --- minimal YAML loader (no PyYAML dependency) ----------------------------
+# install_status.py reads three kinds of YAML:
+#   1. VersionSet manifests (bkn-foundry*.yaml) - flat key/value with a
+#      nested `releases:` dict, 2 levels deep.
+#   2. config.yaml - nested dicts up to 4 levels, scalar values only.
+#   3. helm get manifest output - multi-document K8s manifests; we only need
+#      top-level `kind` and `metadata.name`.
+# All three are machine-generated, use 2-space indentation, and never use
+# anchors, aliases, flow style, or multi-line strings. This parser covers
+# exactly that subset - it is NOT a general YAML parser.
+
+
+def _yaml_scalar(raw):
+    """Coerce a raw YAML scalar string to str/int/float/bool/None."""
+    raw = raw.strip()
+    if not raw:
+        return ""
+    if len(raw) >= 2 and raw[0] == raw[-1] and raw[0] in ("'", '"'):
+        return raw[1:-1]
+    low = raw.lower()
+    if low in ("true", "yes", "on"):
+        return True
+    if low in ("false", "no", "off"):
+        return False
+    if low in ("null", "~"):
+        return None
+    try:
+        return int(raw)
+    except ValueError:
+        pass
+    try:
+        return float(raw)
+    except ValueError:
+        pass
+    return raw
+
+
+def _yaml_parse_block(lines, idx, indent):
+    """Parse an indented block -> (dict, next_idx)."""
+    result = {}
+    while idx < len(lines):
+        line = lines[idx]
+        stripped = line.strip()
+        if not stripped or stripped.startswith("#"):
+            idx += 1
+            continue
+        cur = len(line) - len(line.lstrip())
+        if cur < indent:
+            break
+        if cur > indent:
+            # Deeper-than-expected line (e.g. list items under a key we treat
+            # as a scalar); skip it so it doesn't desynchronise the parser.
+            idx += 1
+            continue
+        if ":" not in stripped:
+            idx += 1
+            continue
+        key, _, rest = stripped.partition(":")
+        key = key.strip()
+        rest = rest.strip()
+        if rest:
+            result[key] = _yaml_scalar(rest)
+            idx += 1
+        else:
+            # Look ahead for a nested block (first non-blank, non-comment line).
+            child_indent = None
+            j = idx + 1
+            while j < len(lines):
+                nxt = lines[j].strip()
+                if not nxt or nxt.startswith("#"):
+                    j += 1
+                    continue
+                child_indent = len(lines[j]) - len(lines[j].lstrip())
+                break
+            if child_indent is not None and child_indent > cur:
+                child, idx = _yaml_parse_block(lines, j, child_indent)
+                result[key] = child
+            else:
+                result[key] = None
+                idx += 1
+    return result, idx
+
+
+def _yaml_load(text):
+    """Load a single YAML document -> dict (or {} if empty)."""
+    doc, _ = _yaml_parse_block(text.split("\n"), 0, 0)
+    return doc
+
+
+def _yaml_load_all(text):
+    """Load multi-document YAML (``---`` separated) -> list of dicts."""
+    docs = []
+    chunk = []
+    for line in text.split("\n"):
+        if line.strip() == "---":
+            if chunk:
+                doc, _ = _yaml_parse_block(chunk, 0, 0)
+                if doc:
+                    docs.append(doc)
+            chunk = []
+        else:
+            chunk.append(line)
+    if chunk:
+        doc, _ = _yaml_parse_block(chunk, 0, 0)
+        if doc:
+            docs.append(doc)
+    return docs
 
 
 # --- depServices whitelist -------------------------------------------------
@@ -74,7 +170,7 @@ def run(cmd):
 def load_manifest_releases(manifest_path):
     """Return ordered list of (release_name, expected_version) from the VersionSet."""
     with open(manifest_path) as f:
-        doc = yaml.safe_load(f) or {}
+        doc = _yaml_load(f.read()) or {}
     releases = doc.get("releases", {}) or {}
     out = []
     for name, spec in releases.items():
@@ -126,7 +222,7 @@ def release_workloads(namespace, release):
         return []
     wls = []
     try:
-        for doc in yaml.safe_load_all(out):
+        for doc in _yaml_load_all(out):
             if not doc:
                 continue
             kind = doc.get("kind")
@@ -134,7 +230,7 @@ def release_workloads(namespace, release):
                 name = (doc.get("metadata", {}) or {}).get("name")
                 if name:
                     wls.append((kind, name))
-    except yaml.YAMLError:
+    except Exception:
         return []
     return wls
 
@@ -303,7 +399,7 @@ def collect_dep_services(config_path):
     """Whitelisted, credential-free view of depServices from config.yaml."""
     try:
         with open(config_path) as f:
-            cfg = yaml.safe_load(f) or {}
+            cfg = _yaml_load(f.read()) or {}
     except (IOError, OSError):
         return {}, []
     dep = cfg.get("depServices", {}) or {}
@@ -478,7 +574,7 @@ def read_auth(config_path):
     if config_path:
         try:
             with open(config_path) as f:
-                cfg = yaml.safe_load(f) or {}
+                cfg = _yaml_load(f.read()) or {}
             a = cfg.get("auth")
             if isinstance(a, dict) and "enabled" in a:
                 enabled = bool(a.get("enabled"))


### PR DESCRIPTION
Replace PyYAML with a built-in minimal YAML parser so the install-status collector runs on hosts where python3-yaml is not installed (e.g. minimal customer environments without pip/dnf/apt access).

The parser handles only the YAML subset this script actually reads:
  - VersionSet manifests (flat key/value + nested releases dict)
  - config.yaml (nested dicts up to 4 levels, scalar values)
  - helm get manifest output (multi-document, kind + metadata.name only)

All three are machine-generated, 2-space indented, and never use anchors, aliases, flow style, or multi-line strings. The parser correctly handles quoted strings, booleans (false -> Python False, not "false"), integers (port: 443 -> int), and multi-document splitting on ---.

Verified locally against deploy/conf/config.yaml and a sample VersionSet manifest; not yet tested end-to-end on a live cluster.



# Pull Request

## What Changed

移除 `deploy/scripts/lib/install_status.py` 对 PyYAML 的依赖，替换为内置的轻量级 YAML 解析器。

- [x] 新增 `_yaml_load` / `_yaml_load_all` 最小 YAML 解析器（约 90 行）
- [x] 替换全部 4 处 `yaml.safe_load` / `yaml.safe_load_all` 调用
- [x] 移除 `import yaml` 及 ImportError 提示块

---

## Why

- Related Issue: 无
- Related Feature: 无
- Background:
  客户环境（最小化安装的 CentOS/openEuler 等）未预装 PyYAML，且无 pip/dnf/apt 网络源可用，导致 `deploy.sh ... status` 无法运行。此前脚本在 `import yaml` 失败时直接退出并提示安装 PyYAML，对离线客户环境不友好。

---

## How

- Key implementation points:
  - 新增 `_yaml_scalar`（标量类型推断：字符串/整数/浮点/布尔/空值）、`_yaml_parse_block`（基于缩进的嵌套字典解析）、`_yaml_load`（单文档）、`_yaml_load_all`（多文档，按 `---` 分割）
  - 解析器仅覆盖脚本实际读取的三类 YAML：VersionSet manifest（2 层嵌套）、config.yaml（4 层嵌套标量）、helm get manifest 输出（多文档，只需 kind + metadata.name）
  - 布尔值正确处理：`enabled: false` -> Python `False`（非字符串 `"false"`），避免 `bool("false") == True` 的陷阱
  - 列表项（`- name: ...`）安全跳过，不影响目标字段提取
- Breaking changes (API, config, database, etc.): 无。脚本对外接口（`--namespace`、`--manifest`、`--config` 等参数）不变，输出格式不变。

---

## Testing

- [ ] Unit tests passed locally - 不适用（无单元测试框架）
- [ ] Integration tests passed locally - 不适用
- [x] Verified in test environment - 本地用实际文件验证通过

Test notes:
本地用 `deploy/conf/config.yaml`、`bkn-foundry-ee.yaml` 和模拟的 helm manifest 输出测试了解析器，验证了：
- 嵌套字典（4 层）正确解析
- 带引号字符串去引号（`'PLAIN'` -> `PLAIN`）
- 整数类型推断（`port: 443` -> int `443`）
- 布尔值（`enabled: false` -> Python `False`，`bool(False)` == `False`）
- 多文档 YAML 按 `---` 拆分，kind 和 metadata.name 正确提取
- `python3 -c "import ast; ast.parse(open('...').read())"` 语法检查通过
- 全文 `grep yaml` 确认无残留 `yaml.safe_load` / `import yaml` 调用

**未在真实集群上端到端验证**（本地无 kubectl/集群），建议在部署环境跑一次：
```bash
python3 install_status.py --namespace NS --manifest MANIFEST.yaml --config CONFIG_YAML --format table
```

---

## Risk & Rollback

- Potential risks:
  - 低。解析器不支持 YAML 高级特性（锚点 `&`/引用 `*`、flow style `{}`/`[]`、多行字符串 `|`/`>`），但这些特性在脚本读取的三类 YAML 中均不会出现。
  - 如果未来 manifest 或 config.yaml 引入了这些高级特性，解析器会静默跳过而非报错。但当前所有已知 YAML 文件均为机器生成的规范格式。
- Rollback plan:
  恢复 `import yaml` 及 4 处 `yaml.safe_load` / `yaml.safe_load_all` 调用即可。改动集中在单文件，回退干净。

---

## Additional Notes

- 改动仅涉及 `deploy/scripts/lib/install_status.py` 单个文件
- 解析器代码约 90 行，无外部依赖，兼容 Python 3.6+（与脚本原有的兼容性声明一致）
