### PR TITLE
fix(bkn): fix concept dataset initialization

### DIFF
--- a/adp/bkn/bkn-backend/server/drivenadapters/vega_backend/vega_backend_access.go
+++ b/adp/bkn/bkn-backend/server/drivenadapters/vega_backend/vega_backend_access.go
@@ -234,7 +234,7 @@ func (vba *vegaBackendAccess) CreateResource(ctx context.Context, req *interface
 	if respCode != http.StatusCreated && respCode != http.StatusOK {
 		err := fmt.Errorf("CreateResource returned HTTP %d", respCode)
 		common.LogSafeError(ctx, "CreateResource failed", err)
-		logger.Debugf("CreateResource response: %s", common.SafeTextSummary("response", string(respData)))
+		logger.Errorf("CreateResource failed: response_code=%d, response=%s", respCode, string(respData))
 		oteltrace.AddHttpAttrs4Error(span, respCode, "InternalError", "Http status is not 201 or 200")
 		return err
 	}

--- a/adp/bkn/bkn-backend/server/interfaces/common.go
+++ b/adp/bkn/bkn-backend/server/interfaces/common.go
@@ -946,7 +946,7 @@ func GetBKNConceptSchemaDefinition(vectorDim int, defaultSmallModelEnabled bool)
 		{
 			Name:         "unit_type",
 			Type:         data_type.DATATYPE_STRING,
-			DisplayName:  "schedule",
+			DisplayName:  "unit_type",
 			OriginalName: "unit_type",
 			Description:  "BKN指标的单位类型",
 			Features: []PropertyFeature{

--- a/adp/bkn/bkn-backend/server/logics/ontology_init_test.go
+++ b/adp/bkn/bkn-backend/server/logics/ontology_init_test.go
@@ -140,11 +140,16 @@ func TestBKNConceptDatasetRequest(t *testing.T) {
 
 func TestBKNConceptDatasetSchemaHasNoFeatureRefProperties(t *testing.T) {
 	seen := make(map[string]struct{})
+	displayNames := make(map[string]string)
 	for _, prop := range interfaces.GetBKNConceptSchemaDefinition(768, true) {
 		if _, exists := seen[prop.Name]; exists {
 			t.Fatalf("duplicate dataset property %q", prop.Name)
 		}
 		seen[prop.Name] = struct{}{}
+		if previous, exists := displayNames[prop.DisplayName]; exists {
+			t.Fatalf("duplicate dataset display name %q for properties %q and %q", prop.DisplayName, previous, prop.Name)
+		}
+		displayNames[prop.DisplayName] = prop.Name
 		for _, feature := range prop.Features {
 			if feature.RefProperty != "" {
 				t.Fatalf("dataset feature %q on property %q must not set ref_property", feature.FeatureName, prop.Name)


### PR DESCRIPTION
## What Changed

Brief description of changes:

- [x] Fix BKN concept dataset schema duplicate display name.
- [x] Log the complete Vega CreateResource error response at error level.
- [x] Add schema display-name uniqueness regression coverage.
- [ ] Docs/doc 1 — not applicable.

---

## Why

- Related Issue: Closes #811
- Related Feature: Not applicable.
- Background: Vega rejects the initial concept dataset because `unit_type` incorrectly shares the `schedule` display name, causing bkn-backend startup to fail.

---

## How

- Key implementation points: Set `unit_type.DisplayName` to `unit_type`; assert unique schema display names; retain Vega error response content in error logs for CreateResource failures.
- Breaking changes (API, config, database, etc.): None. Startup failure continues to panic by design when initialization cannot complete.

---

## Testing

- [x] Unit tests passed locally
- [ ] Integration tests passed locally — not run.
- [x] Verified in test environment — direct Vega API creation returned HTTP 201 after the schema fix.

Test notes:

```text
I18N_MODE_UT=true go test ./drivenadapters/vega_backend ./logics -count=1
git diff --check
```

---

## Risk & Rollback

- Potential risks: Vega CreateResource failures now expose the downstream response in bkn-backend error logs; response content is expected to be non-sensitive validation diagnostics.
- Rollback plan: Revert commit `fbfc20c5`; no schema migration is included.

---

## Additional Notes

- Remote dataset creation verification did not delete the created test resource, per requester instruction.
- Panic behavior is intentionally retained.