### PR TITLE
fix(trace): exclude optimizer conversations by canonical identity

### DIFF
--- a/bkn-trace/agent-observability/charts/agent-observability/templates/deployment.yaml
+++ b/bkn-trace/agent-observability/charts/agent-observability/templates/deployment.yaml
@@ -106,6 +106,8 @@ spec:
               value: {{ required "enterpriseBusinessProvenance.agentURL is required when enabled" .Values.enterpriseBusinessProvenance.agentURL | quote }}
             - name: BKN_TRACE_PROVENANCE_AGENT_ID
               value: {{ required "enterpriseBusinessProvenance.agentID is required when enabled" .Values.enterpriseBusinessProvenance.agentID | quote }}
+            - name: BKN_TRACE_PROVENANCE_AGENT_NAME
+              value: {{ required "enterpriseBusinessProvenance.agentName is required when enabled" .Values.enterpriseBusinessProvenance.agentName | quote }}
             {{- end }}
             - name: OPENSEARCH_AUTH_ENABLED
               value: {{ ternary "true" "false" .Values.opensearch.auth.enabled | quote }}

--- a/bkn-trace/agent-observability/charts/agent-observability/values.yaml
+++ b/bkn-trace/agent-observability/charts/agent-observability/values.yaml
@@ -80,6 +80,7 @@ enterpriseBusinessProvenance:
   enabled: false
   agentURL: ""
   agentID: ""
+  agentName: ""
 
 observability:
   # Configure the same Secret on every replica so signed pagination cursors

--- a/bkn-trace/agent-observability/src/domain/service/evidencesvc/summary.go
+++ b/bkn-trace/agent-observability/src/domain/service/evidencesvc/summary.go
@@ -101,15 +101,12 @@ func (s *Service) ListConversations(ctx context.Context, options evidencevo.Summ
 	childOptions.EvidenceCompleteness = ""
 	for _, request := range requests {
 		if request.ConversationID != "" && options.ExcludeAgentOrApp != "" &&
-			request.AgentOrApp == options.ExcludeAgentOrApp {
+			matchesAgentIdentity(request, options.ExcludeAgentOrApp) {
 			excludedConversations[request.ConversationID] = struct{}{}
 		}
 		if request.ConversationID != "" && matchesRequestFilters(request, childOptions) {
 			grouped[request.ConversationID] = append(grouped[request.ConversationID], request)
 		}
-	}
-	for conversationID := range excludedConversations {
-		delete(grouped, conversationID)
 	}
 	entries := make([]evidencevo.ConversationSummary, 0, len(grouped))
 	for conversationID, group := range grouped {
@@ -117,6 +114,17 @@ func (s *Service) ListConversations(ctx context.Context, options evidencevo.Summ
 	}
 	if err := s.applyCanonicalConversationState(ctx, entries, grouped); err != nil {
 		return evidencevo.ConversationSummaryPage{}, err
+	}
+	if options.ExcludeAgentOrApp != "" {
+		filtered := entries[:0]
+		for _, entry := range entries {
+			_, excludedByRequest := excludedConversations[entry.ConversationID]
+			if excludedByRequest || matchesConversationAgentIdentity(entry, options.ExcludeAgentOrApp) {
+				continue
+			}
+			filtered = append(filtered, entry)
+		}
+		entries = filtered
 	}
 	entries = filterConversationSummaries(entries, options)
 	sort.Slice(entries, func(i, j int) bool {
@@ -1460,11 +1468,7 @@ func matchesRequestFilters(summary evidencevo.RequestSummary, options evidencevo
 	if options.Status != "" && summary.Status != options.Status {
 		return false
 	}
-	if options.AgentOrApp != "" &&
-		summary.AgentOrApp != options.AgentOrApp &&
-		summary.AgentName != options.AgentOrApp &&
-		summary.ApplicationPrincipalID != options.AgentOrApp &&
-		summary.EffectiveSubjectID != options.AgentOrApp {
+	if options.AgentOrApp != "" && !matchesAgentIdentity(summary, options.AgentOrApp) {
 		return false
 	}
 	if options.BusinessDomain != "" && summary.BusinessDomain != options.BusinessDomain {
@@ -1491,6 +1495,20 @@ func matchesRequestFilters(summary evidencevo.RequestSummary, options evidencevo
 		}
 	}
 	return true
+}
+
+func matchesAgentIdentity(summary evidencevo.RequestSummary, expected string) bool {
+	return summary.AgentOrApp == expected ||
+		summary.AgentName == expected ||
+		summary.ApplicationPrincipalID == expected ||
+		summary.EffectiveSubjectID == expected
+}
+
+func matchesConversationAgentIdentity(summary evidencevo.ConversationSummary, expected string) bool {
+	return summary.AgentOrApp == expected ||
+		summary.AgentName == expected ||
+		summary.ApplicationPrincipalID == expected ||
+		summary.EffectiveSubjectID == expected
 }
 
 func containsSummaryValue(values []string, expected string) bool {

--- a/bkn-trace/agent-observability/src/domain/service/evidencesvc/summary_service_test.go
+++ b/bkn-trace/agent-observability/src/domain/service/evidencesvc/summary_service_test.go
@@ -82,21 +82,35 @@ func TestListConversationsUsesCanonicalSessionStatus(t *testing.T) {
 	}
 }
 
-func TestListConversationsExcludesWholeConversationByStableAgentID(t *testing.T) {
+func TestListConversationsExcludesWholeConversationByAgentDisplayName(t *testing.T) {
 	evidenceStore := evidencestore.New()
 	seedBusinessProvenanceRequestWithAgent(
 		t, evidenceStore, "req_internal", "trace_internal", "conversation_internal", "interaction_internal",
-		"2026-08-10T08:00:00Z", "内部分析", "内部建议", "acct_demo", "business_provenance_optimizer", true,
+		"2026-08-10T08:00:00Z", "内部分析", "内部建议", "acct_demo", "openbkn-studio", "app_ref",
 	)
 	seedBusinessProvenanceRequestWithAgent(
 		t, evidenceStore, "req_business", "trace_business", "conversation_business", "interaction_business",
-		"2026-08-10T08:01:00Z", "业务问题", "业务结果", "acct_demo", "business_agent", true,
+		"2026-08-10T08:01:00Z", "业务问题", "业务结果", "acct_demo", "business_agent", "agent_id",
 	)
 
-	page, err := New(evidenceStore, WithProjectionSource(evidenceStore)).ListConversations(
+	sessions := sessionstore.New()
+	if err := sessions.WithinTransaction(context.Background(), func(tx isessionstore.Transaction) error {
+		tx.SaveConversation(sessionvo.Conversation{
+			ID: "conversation_internal", AgentName: "业务溯源优化Agent",
+		})
+		return nil
+	}); err != nil {
+		t.Fatalf("seed optimizer conversation: %v", err)
+	}
+
+	page, err := New(
+		evidenceStore,
+		WithProjectionSource(evidenceStore),
+		WithSessionStore(sessions),
+	).ListConversations(
 		context.Background(), evidencevo.SummaryQueryOptions{
 			Scope: summaryScope("acct_demo"), Limit: 20,
-			ExcludeAgentOrApp: "business_provenance_optimizer",
+			ExcludeAgentOrApp: "业务溯源优化Agent",
 		},
 	)
 	if err != nil {
@@ -1588,7 +1602,7 @@ func seedBusinessProvenanceRequest(
 ) {
 	seedBusinessProvenanceRequestWithAgent(
 		t, store, requestID, traceID, conversationID, interactionID, at, question, result, account,
-		"supply-chain-agent", false,
+		"supply-chain-agent", "app_ref",
 	)
 }
 
@@ -1596,14 +1610,10 @@ func seedBusinessProvenanceRequestWithAgent(
 	t *testing.T,
 	store *evidencestore.Store,
 	requestID, traceID, conversationID, interactionID, at, question, result, account, agent string,
-	useAgentID bool,
+	identityKey string,
 ) {
 	t.Helper()
-	identity := map[string]any{"app_ref": agent, "question_artifact_ref": "artifact:question_" + requestID}
-	if useAgentID {
-		delete(identity, "app_ref")
-		identity["agent_id"] = agent
-	}
+	identity := map[string]any{identityKey: agent, "question_artifact_ref": "artifact:question_" + requestID}
 	trace := evidencevo.NormalizedTrace{
 		TraceID: traceID, RequestID: requestID, ConversationID: conversationID,
 		TenantID: "tenant_demo", BusinessDomain: "bd_demo", AccountID: account, AccountType: "app",


### PR DESCRIPTION
## Summary
- match the internal conversation exclusion against the existing canonical Agent identity fields
- apply the exclusion after lifecycle identity enrichment
- add the configured optimizer Agent display name to the Helm contract

## Validation
- `go test ./src/domain/service/evidencesvc ./src/driveradapter/api/httphandler -count=1`
- Helm template renders Agent URL, ID, and display name
- integrated Core + EE binary tested locally