### PR TITLE
refactor(trace): remove redundant optimizer conversation filter

### DIFF
--- a/bkn-trace/agent-observability/src/domain/service/evidencesvc/summary.go
+++ b/bkn-trace/agent-observability/src/domain/service/evidencesvc/summary.go
@@ -108,23 +108,15 @@ func (s *Service) ListConversations(ctx context.Context, options evidencevo.Summ
 			grouped[request.ConversationID] = append(grouped[request.ConversationID], request)
 		}
 	}
+	for conversationID := range excludedConversations {
+		delete(grouped, conversationID)
+	}
 	entries := make([]evidencevo.ConversationSummary, 0, len(grouped))
 	for conversationID, group := range grouped {
 		entries = append(entries, buildConversationSummary(conversationID, group))
 	}
 	if err := s.applyCanonicalConversationState(ctx, entries, grouped); err != nil {
 		return evidencevo.ConversationSummaryPage{}, err
-	}
-	if options.ExcludeAgentOrApp != "" {
-		filtered := entries[:0]
-		for _, entry := range entries {
-			_, excludedByRequest := excludedConversations[entry.ConversationID]
-			if excludedByRequest || matchesConversationAgentIdentity(entry, options.ExcludeAgentOrApp) {
-				continue
-			}
-			filtered = append(filtered, entry)
-		}
-		entries = filtered
 	}
 	entries = filterConversationSummaries(entries, options)
 	sort.Slice(entries, func(i, j int) bool {
@@ -1498,13 +1490,6 @@ func matchesRequestFilters(summary evidencevo.RequestSummary, options evidencevo
 }
 
 func matchesAgentIdentity(summary evidencevo.RequestSummary, expected string) bool {
-	return summary.AgentOrApp == expected ||
-		summary.AgentName == expected ||
-		summary.ApplicationPrincipalID == expected ||
-		summary.EffectiveSubjectID == expected
-}
-
-func matchesConversationAgentIdentity(summary evidencevo.ConversationSummary, expected string) bool {
 	return summary.AgentOrApp == expected ||
 		summary.AgentName == expected ||
 		summary.ApplicationPrincipalID == expected ||

--- a/bkn-trace/agent-observability/src/domain/service/evidencesvc/summary_service_test.go
+++ b/bkn-trace/agent-observability/src/domain/service/evidencesvc/summary_service_test.go
@@ -121,6 +121,31 @@ func TestListConversationsExcludesWholeConversationByAgentDisplayName(t *testing
 	}
 }
 
+func TestListConversationsExcludesWholeConversationByStableAgentID(t *testing.T) {
+	evidenceStore := evidencestore.New()
+	seedBusinessProvenanceRequestWithAgent(
+		t, evidenceStore, "req_internal", "trace_internal", "conversation_internal", "interaction_internal",
+		"2026-08-10T08:00:00Z", "内部分析", "内部建议", "acct_demo", "business_provenance_optimizer", "agent_id",
+	)
+	seedBusinessProvenanceRequestWithAgent(
+		t, evidenceStore, "req_business", "trace_business", "conversation_business", "interaction_business",
+		"2026-08-10T08:01:00Z", "业务问题", "业务结果", "acct_demo", "business_agent", "agent_id",
+	)
+
+	page, err := New(evidenceStore, WithProjectionSource(evidenceStore)).ListConversations(
+		context.Background(), evidencevo.SummaryQueryOptions{
+			Scope: summaryScope("acct_demo"), Limit: 20,
+			ExcludeAgentOrApp: "business_provenance_optimizer",
+		},
+	)
+	if err != nil {
+		t.Fatalf("list conversations: %v", err)
+	}
+	if page.Total != 1 || len(page.Entries) != 1 || page.Entries[0].ConversationID != "conversation_business" {
+		t.Fatalf("business conversation page = %+v, want only conversation_business", page)
+	}
+}
+
 func TestListConversationsSumsCompletedInteractionDurations(t *testing.T) {
 	evidenceStore := evidencestore.New()
 	seedBusinessProvenanceRequest(


### PR DESCRIPTION
## What Changed

- [x] Remove the redundant conversation-summary exclusion branch added in #813.
- [x] Restore focused regression coverage for stable Agent ID exclusion while retaining canonical display-name coverage.
- [x] Docs: N/A — no user-facing contract change.

---

## Why

- Related Issue: #756
- Follow-up to: #813
- Background: review confirmed that canonical request identity enrichment occurs before conversation grouping, so the second conversation-level filter had no independent effect.

---

## How

- Keep one identity matcher on canonical request summaries.
- Remove excluded conversations before building conversation summaries.
- Test both stable `agent_id` and lifecycle-enriched Agent display name paths.
- Breaking changes: none.

---

## Testing

- [x] Unit tests passed locally
- [ ] Integration tests passed locally — N/A; no external integration changed
- [x] Verified in test environment

Test notes:

```text
GOCACHE=/tmp/openbkn-go-cache go test ./src/domain/service/evidencesvc ./src/driveradapter/api/httphandler -count=1
```

---

## Risk & Rollback

- Potential risks: request identity enrichment ordering is now the single exclusion path; both stable ID and canonical display name are covered by regression tests.
- Rollback plan: revert this single commit to restore the redundant post-group filter.

---

## Additional Notes

- This is intentionally a one-commit follow-up PR so the review feedback remains isolated.