### PR TITLE
feat(bkn-safe): add catalog.resource_manage and resource.query_data (#801, step 1)

### DIFF
--- a/bkn-safe/server/internal/seed/data/catalog.json
+++ b/bkn-safe/server/internal/seed/data/catalog.json
@@ -44,26 +44,30 @@
       "id": "catalog",
       "name": "数据目录",
       "_source": "vega",
+      "_note": "create/modify/delete 只针对目录本身;管理目录下的数据表用 resource_manage(#801)",
       "operations": [
         {"id": "view_detail", "name": "查看详情"},
-        {"id": "create", "name": "创建"},
-        {"id": "modify", "name": "修改"},
-        {"id": "delete", "name": "删除"},
+        {"id": "create", "name": "创建目录"},
+        {"id": "modify", "name": "修改目录本身"},
+        {"id": "delete", "name": "删除目录"},
         {"id": "authorize", "name": "授权"},
-        {"id": "task_manage", "name": "任务管理"}
+        {"id": "task_manage", "name": "任务管理"},
+        {"id": "resource_manage", "name": "管理目录下的数据表"}
       ]
     },
     {
       "id": "resource",
       "name": "数据资源",
       "_source": "vega",
+      "_note": "过渡态(#801 第一段,只加不改):新增 query_data 让资源侧能区分「只看结构」与「能取数」。create/modify/delete/authorize/task_manage 目标是上移到所属目录(catalog.resource_manage / task_manage / authorize),但在 vega 判定切换前必须保留——seed 的 reconcileSeedRoles 会先清空角色 p 行再按本文件重建,此刻移除会让 network_builder 升级后建表 403",
       "operations": [
-        {"id": "view_detail", "name": "查看详情"},
-        {"id": "create", "name": "创建"},
-        {"id": "modify", "name": "修改"},
-        {"id": "delete", "name": "删除"},
-        {"id": "authorize", "name": "授权"},
-        {"id": "task_manage", "name": "任务管理"}
+        {"id": "view_detail", "name": "查看表结构"},
+        {"id": "query_data", "name": "查询表数据"},
+        {"id": "create", "name": "创建(待上移目录)"},
+        {"id": "modify", "name": "修改(待上移目录)"},
+        {"id": "delete", "name": "删除(待上移目录)"},
+        {"id": "authorize", "name": "授权(待上移目录)"},
+        {"id": "task_manage", "name": "任务管理(待上移目录)"}
       ]
     },
     {

--- a/bkn-safe/server/internal/seed/data/grants.json
+++ b/bkn-safe/server/internal/seed/data/grants.json
@@ -123,14 +123,14 @@
       "role_name": "network_builder",
       "resource_type": "catalog",
       "id_pattern": "*",
-      "operations": ["view_detail", "create", "modify", "delete", "authorize", "task_manage"]
+      "operations": ["view_detail", "create", "modify", "delete", "authorize", "task_manage", "resource_manage"]
     },
     {
       "role_id": "1572fb82-526f-11f0-bde6-e674ec8dde71",
       "role_name": "network_builder",
       "resource_type": "resource",
       "id_pattern": "*",
-      "operations": ["view_detail", "create", "modify", "delete", "authorize", "task_manage"]
+      "operations": ["view_detail", "query_data", "create", "modify", "delete", "authorize", "task_manage"]
     },
     {
       "role_id": "1572fb82-526f-11f0-bde6-e674ec8dde71",
@@ -227,7 +227,7 @@
       "role_name": "normal_user",
       "resource_type": "resource",
       "id_pattern": "*",
-      "operations": ["view_detail"]
+      "operations": ["view_detail", "query_data"]
     },
     {
       "role_id": "b5f9ac3e-992c-4bbd-8126-95e87e51c46e",

--- a/bkn-safe/server/internal/seed/seed_test.go
+++ b/bkn-safe/server/internal/seed/seed_test.go
@@ -358,3 +358,104 @@ func TestApplyReconcilesCurrentSeedRoleGrants(t *testing.T) {
 		t.Fatal("normal_user desired grant was not restored after reconcile")
 	}
 }
+
+// TestCatalogResourceOperationSplit pins the #801 first step, which is purely
+// additive: the catalog gains resource_manage, the resource gains query_data.
+//
+// The management verbs are still declared on the resource on purpose. Apply
+// wipes every seeded role's p-lines (reconcileSeedRoles) and rebuilds them from
+// grants.json, so dropping them here — before vega judges the catalog instead —
+// would revoke network_builder's ability to create a table on upgrade.
+// Remove them in the same change that switches vega, not before, and update
+// this test consciously when you do.
+func TestCatalogResourceOperationSplit(t *testing.T) {
+	db := newDB(t)
+	e, err := authz.New(db)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := Apply(db, e); err != nil {
+		t.Fatal(err)
+	}
+
+	ops := func(resourceType string) map[string]bool {
+		var rows []model.Operation
+		if err := db.Where("resource_type_id = ?", resourceType).Find(&rows).Error; err != nil {
+			t.Fatalf("load operations for %s: %v", resourceType, err)
+		}
+		got := make(map[string]bool, len(rows))
+		for _, r := range rows {
+			got[r.ID] = true
+		}
+		return got
+	}
+
+	catalogOps := ops("catalog")
+	for _, op := range []string{"view_detail", "create", "modify", "delete", "authorize", "task_manage", "resource_manage"} {
+		if !catalogOps[op] {
+			t.Errorf("catalog is missing operation %q", op)
+		}
+	}
+
+	resourceOps := ops("resource")
+	for _, op := range []string{"view_detail", "query_data"} {
+		if !resourceOps[op] {
+			t.Errorf("resource is missing read operation %q", op)
+		}
+	}
+	// Transitional: still present until vega switches. See the doc comment.
+	for _, op := range []string{"create", "modify", "delete", "authorize", "task_manage"} {
+		if !resourceOps[op] {
+			t.Errorf("resource lost management operation %q too early — vega still judges it, "+
+				"so network_builder would fail to create a table after an upgrade", op)
+		}
+	}
+}
+
+// TestSeedGrantsKeepResourceReadBehaviour guards the compatibility promise of
+// #801: today a normal user reading a table also reads its rows through the
+// single view_detail verb. Splitting the verb must not silently take that away,
+// so the seed grants query_data alongside view_detail.
+func TestSeedGrantsKeepResourceReadBehaviour(t *testing.T) {
+	db := newDB(t)
+	e, err := authz.New(db)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := Apply(db, e); err != nil {
+		t.Fatal(err)
+	}
+
+	const (
+		normalUser     = "b5f9ac3e-992c-4bbd-8126-95e87e51c46e"
+		networkBuilder = "1572fb82-526f-11f0-bde6-e674ec8dde71"
+	)
+
+	user := "u-normal"
+	if err := e.AssignRole(user, normalUser); err != nil {
+		t.Fatal(err)
+	}
+	for _, op := range []string{"view_detail", "query_data"} {
+		allowed, err := e.Check(user, "resource", "res-1", op)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !allowed {
+			t.Errorf("normal_user lost resource %q after the split", op)
+		}
+	}
+
+	// The builder must keep creating tables across the upgrade: vega still
+	// judges resource+create until it switches to catalog+resource_manage.
+	builder := "u-builder"
+	if err := e.AssignRole(builder, networkBuilder); err != nil {
+		t.Fatal(err)
+	}
+	allowed, err := e.Check(builder, "resource", "res-1", "create")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !allowed {
+		t.Error("network_builder lost resource create — creating a data table would 403 after upgrade")
+	}
+}


### PR DESCRIPTION
First, purely additive step of #801. No operation is removed and no judgement path changes, so behaviour is identical on both a fresh install and an upgrade.

## What changes

**`catalog`: 6 → 7 operations**

- adds `resource_manage` — manage the data tables inside this catalog (create / modify / delete)
- `create` / `modify` / `delete` keep their ids; only their display names narrow to "the catalog itself"

`resource_manage` is a new verb rather than a reuse of `modify` on the catalog, because a single verb cannot separate "modify the catalog itself" from "modify the tables inside it" — neither of these can be expressed otherwise:

- may edit the tables, but must not touch the catalog's name or connector config
- may edit catalog metadata, but must not touch the tables

**`resource`: 6 → 7 operations**

- adds `query_data` — read the rows, as opposed to `view_detail` which reads the schema

Splitting the read verb is what lets the resource side distinguish "schema only" from "can read rows". Without it the four-tier data permission model collapses to two tiers on this side, and sample-data collection during discover / build has no separate gate.

**Seed grants**

- `network_builder`: `+resource_manage` on catalog, `+query_data` on resource
- `normal_user`: `+query_data` on resource

The last one is a compatibility fix, not a widening: today a normal user reads both schema and rows through the single `view_detail` verb, so splitting it without granting `query_data` would silently take row access away.

## Why the management verbs stay on `resource` for now

The target state moves them to the owning catalog. They are deliberately **not** removed here.

`Apply` runs `reconcileSeedRoles` before `seedGrants`, and the former calls `RemoveRolePermissions` on every seeded role — it wipes the role's p-lines and rebuilds them from `grants.json`. Dropping `create` from the seed now would therefore really delete `network_builder`'s `resource:*` create policy on upgrade, while vega still judges `resource` + `create` when creating a table (`logics/resource/resource_service.go:186-190`). A builder would get a 403 creating a data table right after upgrading.

Removal must land in the same change that switches vega to `catalog` + `resource_manage`. The transition is spelled out in the vocabulary `_note` and guarded by a test.

## Tests

- `TestCatalogResourceOperationSplit` — catalog has all seven operations, resource has both read verbs, and the management verbs are **still present** on the resource. The failure message states why removing them early breaks an upgrade, so whoever removes them has to switch vega in the same change.
- `TestSeedGrantsKeepResourceReadBehaviour` — `normal_user` keeps reading both schema and rows after the split; `network_builder` can still create a table across the upgrade.

`go test ./internal/...` passes in `bkn-safe/server`.

## Compatibility

| Path | Result |
|---|---|
| Existing install | `seedCatalog` upserts and never deletes, no judgement path changed → identical behaviour |
| Fresh install | Two more grantable operations that nothing judges yet → identical behaviour |

Design: bkn-docs `docs/foundry/platform/design/issue-800-分层资源授权框架.md` and `issue-511-知识网络分层授权与细粒度数据权限总体设计.md` (PR openbkn-ai/bkn-docs#60).

Refs #801, #800
