### PR TITLE
feat(vega): authorise table operations through the owning catalog (#801, step 2)

### DIFF
--- a/adp/vega/vega-backend/server/interfaces/permission_access.go
+++ b/adp/vega/vega-backend/server/interfaces/permission_access.go
@@ -36,6 +36,12 @@ const (
 	OPERATION_TYPE_AUTHORIZE   = "authorize"
 	OPERATION_TYPE_TASK_MANAGE = "task_manage"
 
+	// OPERATION_TYPE_RESOURCE_MANAGE 是数据目录上的「管理目录下的数据表」操作（#801）。
+	// 建/改/删数据表判它，而不是判数据表自己的 create/modify/delete —— 后者无法回答
+	// 「这张表属于哪个目录」，持有 resource:* create 的人可以往任意目录里建表。
+	// 它挂在目录而非数据表上，也是因为数据表被创建之前并不存在，没有自己的对象可判。
+	OPERATION_TYPE_RESOURCE_MANAGE = "resource_manage"
+
 	// 更新资源名称的topic
 	AUTHORIZATION_RESOURCE_NAME_MODIFY = "authorization.resource.name.modify"
 )

--- a/adp/vega/vega-backend/server/logics/resource/resource_service.go
+++ b/adp/vega/vega-backend/server/logics/resource/resource_service.go
@@ -184,13 +184,25 @@ func (rs *resourceService) Create(ctx context.Context, req *interfaces.ResourceR
 	_, parentInternal := internalCatalogs[req.CatalogID]
 	authType := resourceAuthResourceType(parentInternal)
 
-	// 判断userid是否有创建数据资源的权限（策略决策）
-	err = rs.ps.CheckPermission(ctx, interfaces.PermissionResource{
+	// 建表判两条口径之一（#801）：旧的是 resource:* 的 create，它与目标目录无关，
+	// 持有者可以往任意目录建表；新的是该目录的 resource_manage。先判旧的短路，
+	// 因此常规请求仍只有一次判权。两者取或意味着这是放宽——升级后原本能建表的人照旧，
+	// 不需要影子期。旧口径随 #513 种子收敛一并去掉。
+	if err = rs.ps.CheckPermission(ctx, interfaces.PermissionResource{
 		Type: authType,
 		ID:   interfaces.RESOURCE_ID_ALL,
-	}, []string{interfaces.OPERATION_TYPE_CREATE})
-	if err != nil {
-		return nil, err
+	}, []string{interfaces.OPERATION_TYPE_CREATE}); err != nil {
+		catalogAuthType := interfaces.AUTH_RESOURCE_TYPE_CATALOG
+		if parentInternal {
+			catalogAuthType = interfaces.AUTH_RESOURCE_TYPE_INTERNAL_CATALOG
+		}
+		if err2 := rs.ps.CheckPermission(ctx, interfaces.PermissionResource{
+			Type: catalogAuthType,
+			ID:   req.CatalogID,
+		}, []string{interfaces.OPERATION_TYPE_RESOURCE_MANAGE}); err2 != nil {
+			// 返回旧口径的错误，保持既有报错语义不变。
+			return nil, err
+		}
 	}
 
 	// Get account info from context
@@ -678,12 +690,21 @@ func (rs *resourceService) Update(ctx context.Context, resource *interfaces.Reso
 	}
 	_, parentInternal := internalCatalogs[resource.CatalogID]
 	authType := resourceAuthResourceType(parentInternal)
-	err = rs.ps.CheckPermission(ctx, interfaces.PermissionResource{
+	// 改表同样判两条口径之一（#801），先判旧的短路。
+	if err = rs.ps.CheckPermission(ctx, interfaces.PermissionResource{
 		Type: authType,
 		ID:   resource.ID,
-	}, []string{interfaces.OPERATION_TYPE_MODIFY})
-	if err != nil {
-		return err
+	}, []string{interfaces.OPERATION_TYPE_MODIFY}); err != nil {
+		catalogAuthType := interfaces.AUTH_RESOURCE_TYPE_CATALOG
+		if parentInternal {
+			catalogAuthType = interfaces.AUTH_RESOURCE_TYPE_INTERNAL_CATALOG
+		}
+		if err2 := rs.ps.CheckPermission(ctx, interfaces.PermissionResource{
+			Type: catalogAuthType,
+			ID:   resource.CatalogID,
+		}, []string{interfaces.OPERATION_TYPE_RESOURCE_MANAGE}); err2 != nil {
+			return err
+		}
 	}
 
 	buildRelevantChanged, err := rs.validateResourceUpdateScope(ctx, resource, req)

--- a/adp/vega/vega-backend/server/logics/resource/resource_service_test.go
+++ b/adp/vega/vega-backend/server/logics/resource/resource_service_test.go
@@ -1418,3 +1418,83 @@ func newS2STestService(t *testing.T, internalCatalogIDs []string) (
 	cs.EXPECT().ListInternalIDs(gomock.Any()).Return(internalCatalogIDs, nil).AnyTimes()
 	return rs, ra, ps, ums
 }
+
+// 建表与改表的判定取「旧口径 OR 目录的 resource_manage」（#801）。这里覆盖旧口径
+// 拒绝、改由目录口径放行的路径——常规路径（旧口径直接放行）由上面的用例覆盖，
+// 那时短路生效，只会发生一次判权。
+func TestResourceServiceWriteFallsBackToCatalogResourceManage(t *testing.T) {
+	t.Run("create passes on catalog resource_manage when the legacy verb refuses", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		mockRA := vmock.NewMockResourceAccess(ctrl)
+		mockPS := vmock.NewMockPermissionService(ctrl)
+		mockCS := vmock.NewMockCatalogService(ctrl)
+		rs := &resourceService{ra: mockRA, ps: mockPS, cs: mockCS}
+		expectResourceServiceTransaction(t, rs, true)
+
+		mockCS.EXPECT().ListInternalIDs(gomock.Any()).Return([]string{}, nil)
+		mockPS.EXPECT().CheckPermission(gomock.Any(), interfaces.PermissionResource{
+			Type: interfaces.AUTH_RESOURCE_TYPE_RESOURCE,
+			ID:   interfaces.RESOURCE_ID_ALL,
+		}, []string{interfaces.OPERATION_TYPE_CREATE}).Return(errors.New("forbidden"))
+		mockPS.EXPECT().CheckPermission(gomock.Any(), interfaces.PermissionResource{
+			Type: interfaces.AUTH_RESOURCE_TYPE_CATALOG,
+			ID:   "cat-1",
+		}, []string{interfaces.OPERATION_TYPE_RESOURCE_MANAGE}).Return(nil)
+		mockCS.EXPECT().CheckExistByID(gomock.Any(), "cat-1").Return(true, nil)
+		mockRA.EXPECT().Create(gomock.Any(), gomock.Not(nil), gomock.Any()).Return(nil)
+		mockPS.EXPECT().CreateResources(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
+
+		_, err := rs.Create(context.Background(), &interfaces.ResourceRequest{
+			CatalogID: "cat-1",
+			Name:      "res",
+			Category:  interfaces.ResourceCategoryTable,
+		})
+		assert.NoError(t, err)
+	})
+
+	t.Run("create still refuses when neither verb allows", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		mockPS := vmock.NewMockPermissionService(ctrl)
+		mockCS := vmock.NewMockCatalogService(ctrl)
+		rs := &resourceService{ps: mockPS, cs: mockCS}
+
+		mockCS.EXPECT().ListInternalIDs(gomock.Any()).Return([]string{}, nil)
+		legacy := errors.New("forbidden")
+		mockPS.EXPECT().CheckPermission(gomock.Any(), gomock.Any(),
+			[]string{interfaces.OPERATION_TYPE_CREATE}).Return(legacy)
+		mockPS.EXPECT().CheckPermission(gomock.Any(), gomock.Any(),
+			[]string{interfaces.OPERATION_TYPE_RESOURCE_MANAGE}).Return(errors.New("forbidden too"))
+
+		_, err := rs.Create(context.Background(), &interfaces.ResourceRequest{
+			CatalogID: "cat-1",
+			Name:      "res",
+			Category:  interfaces.ResourceCategoryTable,
+		})
+		// 返回旧口径的错误，保持既有报错语义。
+		assert.ErrorIs(t, err, legacy)
+	})
+
+	t.Run("internal catalog resources judge the internal catalog type", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		mockPS := vmock.NewMockPermissionService(ctrl)
+		mockCS := vmock.NewMockCatalogService(ctrl)
+		rs := &resourceService{ps: mockPS, cs: mockCS}
+
+		mockCS.EXPECT().ListInternalIDs(gomock.Any()).Return([]string{"cat-internal"}, nil)
+		mockPS.EXPECT().CheckPermission(gomock.Any(), interfaces.PermissionResource{
+			Type: interfaces.AUTH_RESOURCE_TYPE_INTERNAL_RESOURCE,
+			ID:   interfaces.RESOURCE_ID_ALL,
+		}, []string{interfaces.OPERATION_TYPE_CREATE}).Return(errors.New("forbidden"))
+		mockPS.EXPECT().CheckPermission(gomock.Any(), interfaces.PermissionResource{
+			Type: interfaces.AUTH_RESOURCE_TYPE_INTERNAL_CATALOG,
+			ID:   "cat-internal",
+		}, []string{interfaces.OPERATION_TYPE_RESOURCE_MANAGE}).Return(errors.New("forbidden too"))
+
+		_, err := rs.Create(context.Background(), &interfaces.ResourceRequest{
+			CatalogID: "cat-internal",
+			Name:      "res",
+			Category:  interfaces.ResourceCategoryTable,
+		})
+		assert.Error(t, err)
+	})
+}


### PR DESCRIPTION
Second step of #801, on top of the vocabulary change in #816/#824. Every operation on a data table may also be authorised by the owning catalog.

## The rule

vega asks about the resource first and, when that denies, asks about the owning catalog with the operation translated:

| on the resource | asked on the catalog |
| --- | --- |
| `view_detail` | `view_detail` |
| `query_data` | `query_data` |
| `create` / `modify` / `delete` | `resource_manage` |
| `task_manage` | `task_manage` |
| `authorize` | **not asked** |

`authorize` is deliberately absent: holding the right to grant a catalog must not become the right to re-grant every table inside it.

The translation is explicit rather than by name because the two vocabularies are not the same shape — `modify` on a catalog means *rename the catalog*, so inheriting it by name would turn "may rename this catalog" into "may rewrite every table in it".

## No ownership table, no synchroniser

vega already holds `catalog_id` on the resource row it is judging, so both object keys are in hand at the moment of the decision. Nothing has to be told to bkn-safe and nothing has to be kept in step.

An earlier attempt (#855, closed) modelled this as inheritance resolved inside bkn-safe, which required pushing `(resource → catalog)` from vega and reconciling it. The generic hierarchy that landed for it (#827/#832/#839) stays in the tree but goes dormant: with `parent_type`/`parent_operation` removed from the seeded catalog, the climb never fires.

## Widening, not tightening — so no shadow period and no flag

Legacy verb first, short-circuit:

```go
if err = ps.CheckPermission(ctx, {resource, id}, [op]); err != nil {
    if err2 := ps.CheckPermission(ctx, {catalog, catalogID}, [translated(op)]); err2 != nil {
        return err   // legacy error, so the existing failure semantics are unchanged
    }
}
```

- anyone who can touch a table today still can — the first question answers it, exactly as before
- a normal request still performs exactly one permission check; the second call only happens on a denial
- when neither allows, the legacy error is returned, so error codes and messages seen by clients do not change
- the seed is untouched: `normal_user` keeps `resource:*` `view_detail` + `query_data`, so nobody loses anything on the day this ships
- resources under an internal catalog judge `internal_catalog`, mirroring `resourceAuthResourceType`

## Scope

- the single-decision paths (create, update, delete, read, task management)
- the batch delete path, which goes through `filterResourcePermissions`
- the list path: filter resources as today, filter catalogs by the translated operation, union locally — one extra round trip for the whole page rather than one per operation

## Out of scope

- **Dropping the legacy verb.** That is the tightening half and belongs with #513 (seed convergence), where the impact gets its own report. Note the tension to settle there: #513 revokes `normal_user`'s type-wide wildcards including `resource:*`, and that wildcard is exactly what makes reads work by default today. Both cannot hold — either #513 narrows, or the default moves to explicit catalog grants.
- **Per-table exceptions** ("this table is stricter than its catalog"). Not expressible in this model; it needs the explicit deny from #512.
