### PR TITLE
feat(bkn-safe): add query_data to the data catalog (#801)

### DIFF
--- a/bkn-safe/server/internal/seed/data/catalog.json
+++ b/bkn-safe/server/internal/seed/data/catalog.json
@@ -44,7 +44,7 @@
       "id": "catalog",
       "name": "数据目录",
       "_source": "vega",
-      "_note": "create/modify/delete 只针对目录本身;管理目录下的数据表用 resource_manage(#801)",
+      "_note": "create/modify/delete 只针对目录本身;管理目录下的数据表用 resource_manage;query_data 是「目录下的表默认可取数」,它能一次性放开整个目录的数据,界面上不要与 view_detail 捆绑勾选(#800 / #801)",
       "operations": [
         {"id": "view_detail", "name": "查看详情"},
         {"id": "create", "name": "创建目录"},
@@ -52,7 +52,8 @@
         {"id": "delete", "name": "删除目录"},
         {"id": "authorize", "name": "授权"},
         {"id": "task_manage", "name": "任务管理"},
-        {"id": "resource_manage", "name": "管理目录下的数据表"}
+        {"id": "resource_manage", "name": "管理目录下的数据表"},
+        {"id": "query_data", "name": "查询目录下的表数据"}
       ]
     },
     {

--- a/bkn-safe/server/internal/seed/data/grants.json
+++ b/bkn-safe/server/internal/seed/data/grants.json
@@ -123,7 +123,7 @@
       "role_name": "network_builder",
       "resource_type": "catalog",
       "id_pattern": "*",
-      "operations": ["view_detail", "create", "modify", "delete", "authorize", "task_manage", "resource_manage"]
+      "operations": ["view_detail", "create", "modify", "delete", "authorize", "task_manage", "resource_manage", "query_data"]
     },
     {
       "role_id": "1572fb82-526f-11f0-bde6-e674ec8dde71",

--- a/bkn-safe/server/internal/seed/seed_test.go
+++ b/bkn-safe/server/internal/seed/seed_test.go
@@ -391,7 +391,7 @@ func TestCatalogResourceOperationSplit(t *testing.T) {
 	}
 
 	catalogOps := ops("catalog")
-	for _, op := range []string{"view_detail", "create", "modify", "delete", "authorize", "task_manage", "resource_manage"} {
+	for _, op := range []string{"view_detail", "create", "modify", "delete", "authorize", "task_manage", "resource_manage", "query_data"} {
 		if !catalogOps[op] {
 			t.Errorf("catalog is missing operation %q", op)
 		}


### PR DESCRIPTION
Adds `query_data` to the data catalog, completing the operation mapping the hierarchical fallback needs (#800).

## Why

Under the fallback rule, a data table's `query_data` has to map to something on its catalog. Without it, granting only the catalog leaves the grantee unable to read any rows — which contradicts the whole point of "permissions can be configured at the catalog level alone".

The verb means "tables under this catalog are readable by default", symmetric with `resource_manage`.

## Cost, and the two constraints that follow

This verb opens the data of **every table beneath the catalog at once**. Two rules are written into the vocabulary note and the design doc:

- **Do not bundle it with `view_detail` in the UI.** Bundling at the table level affects one table; bundling at the catalog level affects the entire catalog. They are not the same decision.
- **Narrowing a single sensitive table depends on explicit deny (#512).** Until that lands, catalog-level `query_data` should only be granted to people who genuinely should see the whole catalog's data.

## Compatibility

Purely additive. No judgement path consumes it yet, so behaviour is identical on a fresh install and on an upgrade.

Seeded to `network_builder` only. `normal_user` is deliberately left out: its ability to read table rows today comes from the `resource:*` wildcard, which #513 is going to revoke — duplicating it at the catalog level would work against that.

Design: bkn-docs `docs/foundry/platform/design/issue-800-分层资源授权框架.md` (PR openbkn-ai/bkn-docs#61).

Refs #801, #800
