### PR TITLE
feat(bkn-safe): resolve grants through the resource hierarchy (#800)

### DIFF
--- a/bkn-safe/server/internal/authz/authz.go
+++ b/bkn-safe/server/internal/authz/authz.go
@@ -64,6 +64,11 @@ const ActAll = "*"
 // Enforcer wraps a Casbin enforcer with the bkn-safe object convention.
 type Enforcer struct {
 	e *casbin.Enforcer
+	// db reads the resource hierarchy (which catalog a table belongs to) that
+	// casbin cannot express: policies are keyed by an opaque "type:id", so
+	// inheritance is resolved around the matcher, not inside it. Nil disables
+	// inheritance entirely, which is the pre-#800 behaviour.
+	db *gorm.DB
 }
 
 // New builds an Enforcer using a GORM-backed policy store on the given db.
@@ -83,15 +88,29 @@ func New(db *gorm.DB) (*Enforcer, error) {
 	if err := e.LoadPolicy(); err != nil {
 		return nil, fmt.Errorf("load policy: %w", err)
 	}
-	return &Enforcer{e: e}, nil
+	return &Enforcer{e: e, db: db}, nil
 }
 
 // obj builds the "type:id" object key.
 func obj(resourceType, id string) string { return resourceType + ":" + id }
 
 // Check reports whether accessor may perform op on the given resource instance.
+//
+// A grant on the resource itself is answered by casbin alone. Only when that
+// fails does the resource's hierarchy come into play: a grant on an ancestor
+// (the catalog a table sits in) counts, translated through the operation
+// mapping. With no ownership row recorded the second step finds nothing, which
+// is exactly the pre-#800 decision (#800).
 func (en *Enforcer) Check(accessorID, resourceType, resourceID, op string) (bool, error) {
-	return en.e.Enforce(accessorID, obj(resourceType, resourceID), op)
+	ok, err := en.e.Enforce(accessorID, obj(resourceType, resourceID), op)
+	if err != nil || ok {
+		return ok, err
+	}
+	inherited, err := en.inheritedOps(accessorID, resourceType, resourceID, []string{op})
+	if err != nil {
+		return false, err
+	}
+	return inherited[op], nil
 }
 
 // AllowedOps returns, from the candidate ops, those the accessor may perform on
@@ -99,12 +118,26 @@ func (en *Enforcer) Check(accessorID, resourceType, resourceID, op string) (bool
 // a set; callers must not depend on order.
 func (en *Enforcer) AllowedOps(accessorID, resourceType, resourceID string, candidates []string) ([]string, error) {
 	out := make([]string, 0, len(candidates))
+	missing := make([]string, 0, len(candidates))
 	for _, op := range candidates {
 		ok, err := en.e.Enforce(accessorID, obj(resourceType, resourceID), op)
 		if err != nil {
 			return nil, err
 		}
 		if ok {
+			out = append(out, op)
+			continue
+		}
+		missing = append(missing, op)
+	}
+	// One climb for everything that missed, rather than one per operation: the
+	// ancestor chain and its operation mapping are the same for all of them.
+	inherited, err := en.inheritedOps(accessorID, resourceType, resourceID, missing)
+	if err != nil {
+		return nil, err
+	}
+	for _, op := range missing {
+		if inherited[op] {
 			out = append(out, op)
 		}
 	}

--- a/bkn-safe/server/internal/authz/authz_test.go
+++ b/bkn-safe/server/internal/authz/authz_test.go
@@ -9,20 +9,35 @@ import (
 
 	"github.com/glebarez/sqlite"
 	"gorm.io/gorm"
+
+	"github.com/openbkn-ai/bkn-foundry/bkn-safe/server/internal/database"
 )
 
-// newTestEnforcer builds an Enforcer over an in-memory sqlite DB.
+// newTestEnforcer builds an Enforcer over an in-memory sqlite DB carrying the
+// full bkn-safe schema — the enforcer reads the resource hierarchy from it, as
+// it does in production where Migrate always precedes New.
 func newTestEnforcer(t *testing.T) *Enforcer {
+	t.Helper()
+	e, _ := newTestEnforcerDB(t)
+	return e
+}
+
+// newTestEnforcerDB also returns the db behind the enforcer, for tests that
+// need to write hierarchy rows.
+func newTestEnforcerDB(t *testing.T) (*Enforcer, *gorm.DB) {
 	t.Helper()
 	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
 	if err != nil {
 		t.Fatalf("open sqlite: %v", err)
 	}
+	if err := database.Migrate(db); err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
 	e, err := New(db)
 	if err != nil {
 		t.Fatalf("new enforcer: %v", err)
 	}
-	return e
+	return e, db
 }
 
 // TestRoleGrantAndWildcard covers the core RBAC path and the keyMatch wildcard

--- a/bkn-safe/server/internal/authz/filter.go
+++ b/bkn-safe/server/internal/authz/filter.go
@@ -61,14 +61,45 @@ func (en *Enforcer) FilterResourceOps(accessorID string, resources []ResourceRef
 		union = append(union, op)
 	}
 
-	out := make([]FilteredResource, 0, len(resources))
 	decided := map[ResourceRef]map[string]bool{}
 	for _, r := range resources {
-		allowed, done := decided[r]
-		if !done {
-			allowed = idx.allowed(r, union)
-			decided[r] = allowed
+		if _, done := decided[r]; !done {
+			decided[r] = idx.allowed(r, union)
 		}
+	}
+
+	// Everything not granted on the resource itself gets one batched walk up the
+	// hierarchy — the same walk Check uses, so a list page and a detail page
+	// cannot disagree about an inherited grant. Skipping this would not merely
+	// lose operations: a resource visible only through its catalog would vanish
+	// from the page entirely, which reads as data loss rather than as a denial.
+	stillMissing := map[ResourceRef][]string{}
+	for r, allowed := range decided {
+		var missing []string
+		for _, op := range union {
+			if !allowed[op] {
+				missing = append(missing, op)
+			}
+		}
+		if len(missing) > 0 {
+			stillMissing[r] = missing
+		}
+	}
+	inherited, err := en.climb(func(node ResourceRef, ops []string) (map[string]bool, error) {
+		return idx.allowed(node, ops), nil
+	}, stillMissing)
+	if err != nil {
+		return nil, err
+	}
+	for r, ops := range inherited {
+		for op := range ops {
+			decided[r][op] = true
+		}
+	}
+
+	out := make([]FilteredResource, 0, len(resources))
+	for _, r := range resources {
+		allowed := decided[r]
 		visible := true
 		for _, op := range visibility {
 			if !allowed[op] {

--- a/bkn-safe/server/internal/authz/hierarchy.go
+++ b/bkn-safe/server/internal/authz/hierarchy.go
@@ -1,0 +1,260 @@
+// Copyright openbkn.ai
+//
+// Licensed under the OpenBKN License. See LICENSE-OPENBKN.txt in the project root.
+
+package authz
+
+import (
+	"log/slog"
+	"sort"
+	"strings"
+
+	"github.com/openbkn-ai/bkn-foundry/bkn-safe/server/internal/model"
+)
+
+// maxHierarchyDepth is a backstop, not a policy. The hierarchy is deliberately
+// unbounded in depth (#800 decision 6) and per-climb cycle detection already
+// terminates every walk; this only stops a pathological chain from turning one
+// authorization decision into unbounded database work.
+const maxHierarchyDepth = 64
+
+// climber tracks one resource's walk up the hierarchy. ops maps an operation
+// the CALLER asked about to the operation to look for at the node currently
+// under examination — the two drift apart as the walk translates through each
+// level's mapping ("modify" on a table becomes "resource_manage" on its
+// catalog), and the caller's spelling is what the answer must be keyed by.
+type climber struct {
+	origin  ResourceRef
+	node    ResourceRef
+	ops     map[string]string
+	visited map[ResourceRef]bool
+}
+
+// climb resolves, for a batch of resources, which of the still-missing
+// operations the accessor holds through an ancestor.
+//
+// decide answers "which of these ops does the accessor hold on this one node".
+// Passing it in is what lets the single-decision path (casbin Enforce) and the
+// list-page path (the pre-resolved grant index) share one walk: the two must
+// never disagree about inheritance, and the only way to guarantee that is for
+// them to run the same code.
+//
+// The returned map contains only operations that were found — resources with
+// nothing inherited are absent, so a caller reads it as an overlay on what it
+// already decided.
+func (en *Enforcer) climb(
+	decide func(ResourceRef, []string) (map[string]bool, error),
+	want map[ResourceRef][]string,
+) (map[ResourceRef]map[string]bool, error) {
+	if en.db == nil || len(want) == 0 {
+		return nil, nil
+	}
+	active := make([]*climber, 0, len(want))
+	for r, ops := range want {
+		if len(ops) == 0 {
+			continue
+		}
+		pending := make(map[string]string, len(ops))
+		for _, op := range ops {
+			pending[op] = op // at the resource itself, no translation has happened yet
+		}
+		active = append(active, &climber{
+			origin: r, node: r, ops: pending,
+			visited: map[ResourceRef]bool{r: true},
+		})
+	}
+
+	found := map[ResourceRef]map[string]bool{}
+	for level := 0; len(active) > 0 && level < maxHierarchyDepth; level++ {
+		// The operation mapping is consulted BEFORE the ownership rows, and the
+		// order matters for cost: a type that inherits nothing (every type but
+		// one, today) is dismissed by a single indexed lookup on the operations
+		// table, so a denied check on an unrelated resource never touches the
+		// ownership table at all.
+		opMaps := map[string]map[string]string{}
+		for _, c := range active {
+			if _, done := opMaps[c.node.Type]; done {
+				continue
+			}
+			m, err := en.parentOpMap(c.node.Type)
+			if err != nil {
+				return nil, err
+			}
+			opMaps[c.node.Type] = m
+		}
+		inheriting := make([]*climber, 0, len(active))
+		for _, c := range active {
+			if len(opMaps[c.node.Type]) > 0 {
+				inheriting = append(inheriting, c)
+			}
+		}
+		active = inheriting
+		if len(active) == 0 {
+			break
+		}
+		parents, err := en.parentsOf(active)
+		if err != nil {
+			return nil, err
+		}
+
+		// Two resources under the same catalog asking about the same operations
+		// are one decision, not two. On a list page that is the common case.
+		verdicts := map[string]map[string]bool{}
+		next := make([]*climber, 0, len(active))
+		for _, c := range active {
+			parent, ok := parents[c.node]
+			if !ok {
+				continue // top of the chain: nothing above to inherit from
+			}
+			if c.visited[parent] {
+				// Only reachable if a type may nest in itself and the pushed rows
+				// form a loop. Stop this climb and say so — silently returning
+				// "not allowed" would make a data problem look like a policy one.
+				slog.Warn("resource hierarchy has a cycle; stopping the climb",
+					"origin_type", c.origin.Type, "origin_id", c.origin.ID,
+					"repeated_type", parent.Type, "repeated_id", parent.ID)
+				continue
+			}
+			translated := map[string]string{}
+			mapping := opMaps[c.node.Type]
+			for asked, here := range c.ops {
+				// No mapping entry means the operation stops here. Default is NOT
+				// to inherit by the same name: a missing entry then costs a
+				// permission, while same-name inheritance would grant one — and
+				// "modify" means different things on a table and on its catalog.
+				if up, ok := mapping[here]; ok && up != "" {
+					translated[asked] = up
+				}
+			}
+			if len(translated) == 0 {
+				continue
+			}
+
+			ask := distinctSorted(translated)
+			key := parent.Type + "\x00" + parent.ID + "\x00" + strings.Join(ask, "\x00")
+			allowed, cached := verdicts[key]
+			if !cached {
+				allowed, err = decide(parent, ask)
+				if err != nil {
+					return nil, err
+				}
+				verdicts[key] = allowed
+			}
+			for asked, up := range translated {
+				if !allowed[up] {
+					continue
+				}
+				if found[c.origin] == nil {
+					found[c.origin] = map[string]bool{}
+				}
+				found[c.origin][asked] = true
+				delete(translated, asked)
+			}
+			if len(translated) == 0 {
+				continue // everything this resource still wanted was answered here
+			}
+			c.node, c.ops = parent, translated
+			c.visited[parent] = true
+			next = append(next, c)
+		}
+		active = next
+	}
+	if len(active) > 0 {
+		slog.Warn("resource hierarchy climb hit the depth backstop; deeper ancestors were not consulted",
+			"depth", maxHierarchyDepth, "unfinished", len(active))
+	}
+	return found, nil
+}
+
+// parentsOf loads the single-hop parent of every node the climbers currently
+// sit on, batched by type so a list page costs one query per type per level
+// rather than one per resource.
+func (en *Enforcer) parentsOf(active []*climber) (map[ResourceRef]ResourceRef, error) {
+	byType := map[string][]string{}
+	seen := map[ResourceRef]bool{}
+	for _, c := range active {
+		if seen[c.node] {
+			continue
+		}
+		seen[c.node] = true
+		byType[c.node.Type] = append(byType[c.node.Type], c.node.ID)
+	}
+	out := make(map[ResourceRef]ResourceRef, len(seen))
+	for rtype, ids := range byType {
+		var rows []model.ResourceParent
+		if err := en.db.Where("resource_type_id = ? AND resource_id IN ?", rtype, ids).
+			Find(&rows).Error; err != nil {
+			return nil, err
+		}
+		for _, row := range rows {
+			out[ResourceRef{Type: row.ResourceTypeID, ID: row.ResourceID}] =
+				ResourceRef{Type: row.ParentTypeID, ID: row.ParentID}
+		}
+	}
+	return out, nil
+}
+
+// parentOpMap returns the type's operation translation: operation on this type
+// -> operation to look for on its parent. Operations that do not inherit are
+// absent from the map.
+func (en *Enforcer) parentOpMap(resourceType string) (map[string]string, error) {
+	var rows []model.Operation
+	if err := en.db.Where("resource_type_id = ? AND parent_operation_id <> ''", resourceType).
+		Find(&rows).Error; err != nil {
+		return nil, err
+	}
+	out := make(map[string]string, len(rows))
+	for _, row := range rows {
+		out[row.ID] = row.ParentOperationID
+	}
+	return out, nil
+}
+
+// distinctSorted returns the map's distinct values in a stable order, so the
+// per-node decision cache key is the same for two callers asking the same thing.
+func distinctSorted(m map[string]string) []string {
+	seen := make(map[string]bool, len(m))
+	out := make([]string, 0, len(m))
+	for _, v := range m {
+		if seen[v] {
+			continue
+		}
+		seen[v] = true
+		out = append(out, v)
+	}
+	sort.Strings(out)
+	return out
+}
+
+// enforceOn is the single-decision evaluator handed to climb: it asks casbin
+// about one ancestor node, exactly as Check asks about the resource itself.
+func (en *Enforcer) enforceOn(accessorID string) func(ResourceRef, []string) (map[string]bool, error) {
+	return func(node ResourceRef, ops []string) (map[string]bool, error) {
+		out := make(map[string]bool, len(ops))
+		for _, op := range ops {
+			ok, err := en.e.Enforce(accessorID, obj(node.Type, node.ID), op)
+			if err != nil {
+				return nil, err
+			}
+			if ok {
+				out[op] = true
+			}
+		}
+		return out, nil
+	}
+}
+
+// inheritedOps reports which of the missing operations the accessor holds on an
+// ancestor of the resource. The single-resource entry point behind Check and
+// AllowedOps.
+func (en *Enforcer) inheritedOps(accessorID, resourceType, resourceID string, missing []string) (map[string]bool, error) {
+	if len(missing) == 0 {
+		return nil, nil
+	}
+	r := ResourceRef{Type: resourceType, ID: resourceID}
+	found, err := en.climb(en.enforceOn(accessorID), map[ResourceRef][]string{r: missing})
+	if err != nil {
+		return nil, err
+	}
+	return found[r], nil
+}

--- a/bkn-safe/server/internal/authz/hierarchy_test.go
+++ b/bkn-safe/server/internal/authz/hierarchy_test.go
@@ -1,0 +1,331 @@
+// Copyright openbkn.ai
+//
+// Licensed under the OpenBKN License. See LICENSE-OPENBKN.txt in the project root.
+
+package authz
+
+import (
+	"sort"
+	"testing"
+	"time"
+
+	"gorm.io/gorm"
+
+	"github.com/openbkn-ai/bkn-foundry/bkn-safe/server/internal/model"
+)
+
+// declareCatalogHierarchy registers the shipped catalog/resource shape: a data
+// table hangs under a data catalog, its write verbs map to resource_manage, its
+// read verbs map by the same name, and authorize maps to nothing.
+func declareCatalogHierarchy(t *testing.T, db *gorm.DB) {
+	t.Helper()
+	types := []model.ResourceType{
+		{ID: "catalog", Name: "数据目录"},
+		{ID: "resource", Name: "数据资源", ParentTypeID: "catalog"},
+	}
+	if err := db.Create(&types).Error; err != nil {
+		t.Fatalf("seed resource types: %v", err)
+	}
+	ops := []model.Operation{
+		{ResourceTypeID: "catalog", ID: "view_detail"},
+		{ResourceTypeID: "catalog", ID: "modify"},
+		{ResourceTypeID: "catalog", ID: "authorize"},
+		{ResourceTypeID: "catalog", ID: "resource_manage"},
+		{ResourceTypeID: "resource", ID: "view_detail", ParentOperationID: "view_detail"},
+		{ResourceTypeID: "resource", ID: "modify", ParentOperationID: "resource_manage"},
+		{ResourceTypeID: "resource", ID: "delete", ParentOperationID: "resource_manage"},
+		{ResourceTypeID: "resource", ID: "authorize"}, // deliberately no mapping
+	}
+	if err := db.Create(&ops).Error; err != nil {
+		t.Fatalf("seed operations: %v", err)
+	}
+}
+
+func ownedBy(t *testing.T, db *gorm.DB, resourceID, catalogID string) {
+	t.Helper()
+	if err := db.Create(&model.ResourceParent{
+		ResourceTypeID: "resource", ResourceID: resourceID,
+		ParentTypeID: "catalog", ParentID: catalogID,
+	}).Error; err != nil {
+		t.Fatalf("record ownership: %v", err)
+	}
+}
+
+// TestCheckInheritsThroughTheCatalog is the point of #800: a grant on the
+// catalog reaches the tables inside it, and only those — a table with no
+// recorded owner is judged exactly as it was before.
+func TestCheckInheritsThroughTheCatalog(t *testing.T) {
+	e, db := newTestEnforcerDB(t)
+	declareCatalogHierarchy(t, db)
+	ownedBy(t, db, "res-in", "cat-1")
+
+	const user = "u-1"
+	mustNoErr(t, e.GrantObjectPermission(user, "catalog", "cat-1", "resource_manage"))
+
+	ok, err := e.Check(user, "resource", "res-in", "modify")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !ok {
+		t.Error("a catalog resource_manage grant did not reach a table inside that catalog")
+	}
+
+	// No ownership row: nothing to climb, so the pre-#800 answer stands.
+	ok, err = e.Check(user, "resource", "res-orphan", "modify")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if ok {
+		t.Error("a table with no recorded catalog inherited anyway")
+	}
+}
+
+// TestInheritanceRefusesSameNameFallback is the escalation this design exists to
+// prevent: "modify" on a catalog means rename the catalog. If it fell back by
+// name, whoever may rename a catalog could rewrite every table in it.
+func TestInheritanceRefusesSameNameFallback(t *testing.T) {
+	e, db := newTestEnforcerDB(t)
+	declareCatalogHierarchy(t, db)
+	ownedBy(t, db, "res-1", "cat-1")
+
+	const user = "u-1"
+	mustNoErr(t, e.GrantObjectPermission(user, "catalog", "cat-1", "modify"))
+
+	ok, err := e.Check(user, "resource", "res-1", "modify")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if ok {
+		t.Error("catalog/modify (rename the catalog) was inherited as resource/modify (rewrite the table)")
+	}
+}
+
+// TestUnmappedOperationDoesNotInherit: authorize has no mapping on purpose, so
+// holding it on a catalog must not confer the right to re-grant the tables in it.
+func TestUnmappedOperationDoesNotInherit(t *testing.T) {
+	e, db := newTestEnforcerDB(t)
+	declareCatalogHierarchy(t, db)
+	ownedBy(t, db, "res-1", "cat-1")
+
+	const user = "u-1"
+	mustNoErr(t, e.GrantObjectPermission(user, "catalog", "cat-1", "authorize"))
+
+	ok, err := e.Check(user, "resource", "res-1", "authorize")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if ok {
+		t.Error("catalog/authorize leaked downwards as second-hand granting on the table")
+	}
+}
+
+// TestNoHierarchyDataMeansNoBehaviourChange pins the upgrade promise: with the
+// ownership table empty, every decision is the one the previous release made.
+func TestNoHierarchyDataMeansNoBehaviourChange(t *testing.T) {
+	e, db := newTestEnforcerDB(t)
+	declareCatalogHierarchy(t, db)
+
+	const user = "u-1"
+	mustNoErr(t, e.GrantObjectPermission(user, "catalog", "cat-1", "resource_manage"))
+	mustNoErr(t, e.GrantObjectPermission(user, "catalog", "cat-1", "view_detail"))
+
+	for _, op := range []string{"modify", "view_detail", "delete"} {
+		ok, err := e.Check(user, "resource", "res-1", op)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if ok {
+			t.Errorf("resource/%s was allowed with no ownership row recorded", op)
+		}
+	}
+}
+
+// TestAllowedOpsMergesInheritedOps: the detail page's operation set must contain
+// both what was granted on the table and what it inherits from its catalog.
+func TestAllowedOpsMergesInheritedOps(t *testing.T) {
+	e, db := newTestEnforcerDB(t)
+	declareCatalogHierarchy(t, db)
+	ownedBy(t, db, "res-1", "cat-1")
+
+	const user = "u-1"
+	mustNoErr(t, e.GrantObjectPermission(user, "resource", "res-1", "view_detail"))
+	mustNoErr(t, e.GrantObjectPermission(user, "catalog", "cat-1", "resource_manage"))
+	mustNoErr(t, e.GrantObjectPermission(user, "catalog", "cat-1", "authorize"))
+
+	got, err := e.AllowedOps(user, "resource", "res-1", []string{"view_detail", "modify", "delete", "authorize"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	sort.Strings(got)
+	want := []string{"delete", "modify", "view_detail"}
+	if len(got) != len(want) {
+		t.Fatalf("AllowedOps = %v, want %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("AllowedOps = %v, want %v", got, want)
+		}
+	}
+}
+
+// TestFilterResourceOpsSeesInheritance is the reason the list page had to be
+// taught the same walk: a table visible only through its catalog holds no policy
+// row of its own, so without inheritance it does not merely lose operations — it
+// disappears from the page.
+func TestFilterResourceOpsSeesInheritance(t *testing.T) {
+	e, db := newTestEnforcerDB(t)
+	declareCatalogHierarchy(t, db)
+	ownedBy(t, db, "res-1", "cat-1")
+	ownedBy(t, db, "res-2", "cat-2")
+
+	const user = "u-1"
+	mustNoErr(t, e.GrantObjectPermission(user, "catalog", "cat-1", "view_detail"))
+	mustNoErr(t, e.GrantObjectPermission(user, "catalog", "cat-1", "resource_manage"))
+
+	got, err := e.FilterResourceOps(user,
+		[]ResourceRef{{Type: "resource", ID: "res-1"}, {Type: "resource", ID: "res-2"}},
+		[]string{"view_detail"},
+		[]string{"view_detail", "modify", "authorize"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 1 || got[0].ID != "res-1" {
+		t.Fatalf("filter = %v, want only res-1 (res-2 sits in an ungranted catalog)", got)
+	}
+	sort.Strings(got[0].Operations)
+	if len(got[0].Operations) != 2 || got[0].Operations[0] != "modify" || got[0].Operations[1] != "view_detail" {
+		t.Errorf("operations = %v, want [modify view_detail]", got[0].Operations)
+	}
+}
+
+// TestFilterResourceOpsMatchesCheckUnderInheritance keeps the batch path and the
+// single-decision path from drifting: the whole risk of two implementations is
+// that a list page and a detail page answer differently for the same grant.
+func TestFilterResourceOpsMatchesCheckUnderInheritance(t *testing.T) {
+	e, db := newTestEnforcerDB(t)
+	declareCatalogHierarchy(t, db)
+	ownedBy(t, db, "res-1", "cat-1")
+	ownedBy(t, db, "res-2", "cat-1")
+
+	const user = "u-1"
+	mustNoErr(t, e.GrantObjectPermission(user, "catalog", "cat-1", "resource_manage"))
+	mustNoErr(t, e.GrantObjectPermission(user, "resource", "res-2", "view_detail"))
+
+	ops := []string{"view_detail", "modify", "delete", "authorize"}
+	refs := []ResourceRef{{Type: "resource", ID: "res-1"}, {Type: "resource", ID: "res-2"}}
+	filtered, err := e.FilterResourceOps(user, refs, nil, ops)
+	if err != nil {
+		t.Fatal(err)
+	}
+	byID := map[string]map[string]bool{}
+	for _, f := range filtered {
+		set := map[string]bool{}
+		for _, op := range f.Operations {
+			set[op] = true
+		}
+		byID[f.ID] = set
+	}
+	for _, r := range refs {
+		for _, op := range ops {
+			want, err := e.Check(user, r.Type, r.ID, op)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if byID[r.ID][op] != want {
+				t.Errorf("%s/%s: filter=%v check=%v", r.ID, op, byID[r.ID][op], want)
+			}
+		}
+	}
+}
+
+// TestInheritanceComposesAcrossLevels: the operation is translated at EVERY hop,
+// not once. A three-level chain is what #515 turns the knowledge-network line
+// into, so the walk must not assume the child's spelling survives the climb.
+func TestInheritanceComposesAcrossLevels(t *testing.T) {
+	e, db := newTestEnforcerDB(t)
+	types := []model.ResourceType{
+		{ID: "top"},
+		{ID: "mid", ParentTypeID: "top"},
+		{ID: "leaf", ParentTypeID: "mid"},
+	}
+	if err := db.Create(&types).Error; err != nil {
+		t.Fatal(err)
+	}
+	ops := []model.Operation{
+		{ResourceTypeID: "top", ID: "manage_all"},
+		{ResourceTypeID: "mid", ID: "manage_children", ParentOperationID: "manage_all"},
+		{ResourceTypeID: "leaf", ID: "modify", ParentOperationID: "manage_children"},
+	}
+	if err := db.Create(&ops).Error; err != nil {
+		t.Fatal(err)
+	}
+	rows := []model.ResourceParent{
+		{ResourceTypeID: "leaf", ResourceID: "l-1", ParentTypeID: "mid", ParentID: "m-1"},
+		{ResourceTypeID: "mid", ResourceID: "m-1", ParentTypeID: "top", ParentID: "t-1"},
+	}
+	if err := db.Create(&rows).Error; err != nil {
+		t.Fatal(err)
+	}
+
+	const user = "u-1"
+	mustNoErr(t, e.GrantObjectPermission(user, "top", "t-1", "manage_all"))
+
+	ok, err := e.Check(user, "leaf", "l-1", "modify")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !ok {
+		t.Error("a grant two levels up did not reach the leaf")
+	}
+
+	// The intermediate spelling must not be accepted at the top: manage_children
+	// is a mid-level verb, and holding it on the top node proves nothing.
+	const other = "u-2"
+	mustNoErr(t, e.GrantObjectPermission(other, "top", "t-1", "manage_children"))
+	ok, err = e.Check(other, "leaf", "l-1", "modify")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if ok {
+		t.Error("the climb accepted an untranslated operation at the top level")
+	}
+}
+
+// TestInheritanceTerminatesOnACycle: ownership rows are pushed by another
+// service, so a loop is a data state the enforcer must survive rather than a
+// case it may assume away. A hang here would take down authorization itself.
+func TestInheritanceTerminatesOnACycle(t *testing.T) {
+	e, db := newTestEnforcerDB(t)
+	if err := db.Create(&model.ResourceType{ID: "folder", ParentTypeID: "folder"}).Error; err != nil {
+		t.Fatal(err)
+	}
+	if err := db.Create(&model.Operation{
+		ResourceTypeID: "folder", ID: "view_detail", ParentOperationID: "view_detail",
+	}).Error; err != nil {
+		t.Fatal(err)
+	}
+	rows := []model.ResourceParent{
+		{ResourceTypeID: "folder", ResourceID: "f-1", ParentTypeID: "folder", ParentID: "f-2"},
+		{ResourceTypeID: "folder", ResourceID: "f-2", ParentTypeID: "folder", ParentID: "f-1"},
+	}
+	if err := db.Create(&rows).Error; err != nil {
+		t.Fatal(err)
+	}
+
+	done := make(chan bool, 1)
+	go func() {
+		ok, err := e.Check("u-1", "folder", "f-1", "view_detail")
+		if err != nil {
+			t.Error(err)
+		}
+		done <- ok
+	}()
+	select {
+	case ok := <-done:
+		if ok {
+			t.Error("a cycle produced an allow out of nowhere")
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("Check did not terminate on a cyclic hierarchy")
+	}
+}

--- a/bkn-safe/server/internal/httpapi/resourceparents_test.go
+++ b/bkn-safe/server/internal/httpapi/resourceparents_test.go
@@ -28,6 +28,13 @@ func declareHierarchy(t *testing.T, db *gorm.DB) {
 	if err := db.Create(&rows).Error; err != nil {
 		t.Fatalf("seed resource types: %v", err)
 	}
+	ops := []model.Operation{
+		{ResourceTypeID: "catalog", ID: "resource_manage"},
+		{ResourceTypeID: "resource", ID: "modify", ParentOperationID: "resource_manage"},
+	}
+	if err := db.Create(&ops).Error; err != nil {
+		t.Fatalf("seed operations: %v", err)
+	}
 }
 
 type parentItem struct {
@@ -192,6 +199,46 @@ func TestResourceParentsDelete(t *testing.T) {
 	items, total := getParents(t, r, "resource_type=resource")
 	if total != 1 || len(items) != 1 || items[0].ResourceID != "res-2" {
 		t.Errorf("after delete = %v (total %d), want only res-2", items, total)
+	}
+}
+
+// TestOwnershipPushMakesCheckInherit walks the whole contract end to end: a
+// module pushes the ownership fact over HTTP, and the very next /authz/check on
+// a resource with no policy row of its own is answered by its catalog's grant.
+// Before the push, the same call is refused.
+func TestOwnershipPushMakesCheckInherit(t *testing.T) {
+	r, e, db := newTestServer(t)
+	declareHierarchy(t, db)
+	const user = "u-1"
+	_ = e.GrantObjectPermission(user, "catalog", "cat-a", "resource_manage")
+
+	check := func() bool {
+		w := do(t, r, http.MethodPost, "/api/safe/v1/authz/check", map[string]any{
+			"accessor_id": user,
+			"resource":    map[string]string{"type": "resource", "id": "res-1"},
+			"operation":   "modify",
+		})
+		if w.Code != http.StatusOK {
+			t.Fatalf("check = %d body=%s", w.Code, w.Body.String())
+		}
+		var resp struct {
+			Allowed bool `json:"allowed"`
+		}
+		if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+			t.Fatalf("decode: %v", err)
+		}
+		return resp.Allowed
+	}
+
+	if check() {
+		t.Fatal("resource/modify was allowed before any ownership was recorded")
+	}
+	do(t, r, http.MethodPut, "/api/safe/v1/authz/resource-parents", map[string]any{
+		"resource_type": "resource", "parent_type": "catalog",
+		"items": []map[string]string{{"resource_id": "res-1", "parent_id": "cat-a"}},
+	})
+	if !check() {
+		t.Error("resource/modify still refused after the table was recorded under a granted catalog")
 	}
 }
 

--- a/bkn-safe/server/internal/seed/inheritance_test.go
+++ b/bkn-safe/server/internal/seed/inheritance_test.go
@@ -1,0 +1,77 @@
+// Copyright openbkn.ai
+//
+// Licensed under the OpenBKN License. See LICENSE-OPENBKN.txt in the project root.
+
+package seed
+
+import (
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/openbkn-ai/bkn-foundry/bkn-safe/server/internal/authz"
+	"github.com/openbkn-ai/bkn-foundry/bkn-safe/server/internal/model"
+)
+
+// TestSeededRolesGainNothingFromInheritance is the upgrade guarantee for #800,
+// asserted against the real seed rather than argued: turning inheritance on must
+// not widen what any SEEDED role can do to a data table.
+//
+// It holds today because of how the two roles are already granted —
+// network_builder holds every inheritable operation on resource:* directly, and
+// normal_user's catalog grant (view_detail) is one it already holds on
+// resource:* too. Neither fact is obvious from reading grants.json, and either
+// could be broken by a future edit that looks harmless, which is why this is a
+// test and not a comment.
+//
+// The residual widening lives in per-object catalog grants made through the
+// admin console, which no seed file can predict.
+func TestSeededRolesGainNothingFromInheritance(t *testing.T) {
+	db := newDB(t)
+	e, err := authz.New(db)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := Apply(db, e); err != nil {
+		t.Fatal(err)
+	}
+	// owned sits in a catalog; orphan has no recorded parent, so it is judged the
+	// way the previous release judged everything. Comparing the two isolates the
+	// inheritance contribution exactly.
+	if err := db.Create(&model.ResourceParent{
+		ResourceTypeID: "resource", ResourceID: "owned",
+		ParentTypeID: "catalog", ParentID: "cat-1",
+	}).Error; err != nil {
+		t.Fatal(err)
+	}
+
+	candidates := []string{"view_detail", "query_data", "modify", "delete", "authorize", "task_manage"}
+	var roles []model.Role
+	if err := db.Find(&roles).Error; err != nil {
+		t.Fatal(err)
+	}
+	if len(roles) == 0 {
+		t.Fatal("no seeded roles found")
+	}
+	for _, role := range roles {
+		user := "u-" + role.ID
+		if err := e.AssignRole(user, role.ID); err != nil {
+			t.Fatal(err)
+		}
+		withParent, err := e.AllowedOps(user, "resource", "owned", candidates)
+		if err != nil {
+			t.Fatal(err)
+		}
+		withoutParent, err := e.AllowedOps(user, "resource", "orphan", candidates)
+		if err != nil {
+			t.Fatal(err)
+		}
+		sort.Strings(withParent)
+		sort.Strings(withoutParent)
+		if strings.Join(withParent, ",") != strings.Join(withoutParent, ",") {
+			t.Errorf("role %s (%s) gains %v from inheritance, but held %v before — "+
+				"a seeded grant now reaches further than it did, which an upgrade must not do",
+				role.Name, role.ID, withParent, withoutParent)
+		}
+	}
+}


### PR DESCRIPTION
Stage 2 of #800. #827 recorded which catalog a table belongs to; this makes decisions read it.

## Semantics

1. A grant on the resource itself is answered by casbin alone — no database access.
2. Only a miss climbs, and the operation is **translated at every hop**: `modify` on a table looks for `resource_manage` on its catalog.
3. An operation with no mapping entry **stops there**. Default is not to inherit by name — a missing entry then costs a permission, whereas same-name inheritance would grant one.
4. **No ownership row means today's decision, byte for byte.**

## Three call paths, one walk

`Check`, `AllowedOps` and `FilterResourceOps` all go through the same climb. Sharing it is the point: two implementations of inheritance eventually disagree, and then a list page and a detail page answer differently for the same grant. `TestFilterResourceOpsMatchesCheckUnderInheritance` pins them together, extending the existing `TestFilterResourceOpsMatchesCheck`.

The list page had to be included, not deferred. An inherited resource holds no policy row of its own, so without the climb it does not merely lose operations — **it disappears from the page**, which reads as data loss rather than as a denial.

## Cost

The operation mapping is consulted **before** the ownership rows. Every type but one inherits nothing today, so a denied check on an unrelated resource is dismissed by a single indexed lookup on `operations` and never touches the ownership table. On a list page, both lookups are batched per type per level, so a page of 100 tables costs 2 queries, not 200.

## Termination

Ownership rows are pushed by another service, so a loop is a data state the enforcer has to survive rather than a case it may assume away — a hang here would take down authorization itself. Each climb carries its own visited set; a 64-level backstop bounds pathological chains. Both are covered (`TestInheritanceTerminatesOnACycle`).

## Tests

- a catalog grant reaches tables inside it, and only those
- `catalog/modify` (rename the catalog) does **not** become `resource/modify` (rewrite the table) — the escalation the mapping exists to prevent
- `authorize` does not leak downwards as second-hand granting
- empty ownership table changes nothing
- `AllowedOps` merges direct and inherited
- a resource visible only through its catalog appears on the list page, with its inherited operations
- three-level chain composes; an untranslated operation is refused at the top
- cycles terminate
- end-to-end over HTTP: push ownership, and the next `POST /authz/check` flips from refused to allowed

## Known gaps, deliberately not in this PR

- `GET /authz/resources` (`AccessibleResources`) and `/me/permissions` (`EffectivePermissions`) still enumerate policy rows only, so they under-report inherited resources. Both are enumeration surfaces rather than decisions; redefining them is the next slice.
- The `permobject` socket takes a single `(ResourceType, ResourceID)`, so an enterprise deny on an **ancestor** would not be seen when judging a descendant. A deny on the concrete object still works, since core's verdict is what the socket restricts. Whole-chain deny (#800 decision 8) needs the socket's request to carry the resolved chain — a change worth making when the ee side is actually wired, which it is not today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
