### PR TITLE
feat(observability): capture domain BKN management audits

### DIFF
--- a/adp/bkn/bkn-backend/server/common/bkntrace/access_profile.go
+++ b/adp/bkn/bkn-backend/server/common/bkntrace/access_profile.go
@@ -30,6 +30,14 @@ type AccessProfile struct {
 	Roles   []string
 }
 
+type OperationAuditProfile struct {
+	ActorID                    string
+	ActorName                  string
+	Account                    string
+	Roles                      []string
+	ManagedKnowledgeNetworkIDs []string
+}
+
 // ResolveAccessProfile follows the same BKN Safe contract as BKN Trace Core:
 // verify the active caller through /me, then resolve permissions before using
 // the built-in role set for an administrative decision.
@@ -72,6 +80,108 @@ func (p AccessProfile) IsOutboxAdmin() bool {
 		}
 	}
 	return false
+}
+
+func (p OperationAuditProfile) IsAdmin() bool {
+	for _, role := range p.Roles {
+		if role == "admin" || role == "super_admin" {
+			return true
+		}
+	}
+	return false
+}
+
+// ResolveOperationAuditIdentity snapshots only the verified human-readable
+// identity. Audit production uses this lightweight path so a grant lookup
+// failure cannot degrade an operator name back to an opaque user ID.
+func ResolveOperationAuditIdentity(ctx context.Context, authorization, expectedActorID string) (OperationAuditProfile, error) {
+	baseURL := bknSafeBaseURL()
+	client := &http.Client{Timeout: accessProfileTimeout()}
+	return resolveOperationAuditIdentity(ctx, client, baseURL, authorization, expectedActorID)
+}
+
+// ResolveOperationAuditProfile returns the readable current-user snapshot and
+// only direct concrete knowledge-network management grants. It does not turn a
+// role-wide capability or wildcard into record-level data scope.
+func ResolveOperationAuditProfile(ctx context.Context, authorization, expectedActorID string) (OperationAuditProfile, error) {
+	baseURL := bknSafeBaseURL()
+	if strings.TrimSpace(authorization) == "" || strings.TrimSpace(expectedActorID) == "" {
+		return OperationAuditProfile{}, fmt.Errorf("%w: trusted authorization identity is incomplete", ErrAccessProfileDenied)
+	}
+	client := &http.Client{Timeout: accessProfileTimeout()}
+	identity, err := resolveOperationAuditIdentity(ctx, client, baseURL, authorization, expectedActorID)
+	if err != nil {
+		return OperationAuditProfile{}, err
+	}
+	var grants struct {
+		Grants []struct {
+			KnowledgeNetworkID string   `json:"knowledge_network_id"`
+			Operations         []string `json:"operations"`
+		} `json:"grants"`
+	}
+	if err := getBknSafe(ctx, client, baseURL+"/api/safe/v1/me/knowledge-network-grants", authorization, &grants); err != nil {
+		return OperationAuditProfile{}, fmt.Errorf("resolve current BKN Safe knowledge-network grants: %w", err)
+	}
+	networks := map[string]struct{}{}
+	for _, grant := range grants.Grants {
+		if strings.TrimSpace(grant.KnowledgeNetworkID) == "" || grant.KnowledgeNetworkID == "*" {
+			continue
+		}
+		for _, operation := range grant.Operations {
+			if operation == "modify" || operation == "authorize" || operation == "task_manage" {
+				networks[grant.KnowledgeNetworkID] = struct{}{}
+				break
+			}
+		}
+	}
+	managed := make([]string, 0, len(networks))
+	for networkID := range networks {
+		managed = append(managed, networkID)
+	}
+	sort.Strings(managed)
+	identity.ManagedKnowledgeNetworkIDs = managed
+	return identity, nil
+}
+
+func resolveOperationAuditIdentity(ctx context.Context, client *http.Client, baseURL, authorization, expectedActorID string) (OperationAuditProfile, error) {
+	if strings.TrimSpace(authorization) == "" || strings.TrimSpace(expectedActorID) == "" {
+		return OperationAuditProfile{}, fmt.Errorf("%w: trusted authorization identity is incomplete", ErrAccessProfileDenied)
+	}
+	var me struct {
+		ID      string   `json:"id"`
+		Account string   `json:"account"`
+		Name    string   `json:"name"`
+		Enabled bool     `json:"enabled"`
+		Roles   []string `json:"roles"`
+	}
+	if err := getBknSafe(ctx, client, baseURL+"/api/safe/v1/me", authorization, &me); err != nil {
+		return OperationAuditProfile{}, fmt.Errorf("resolve current BKN Safe identity: %w", err)
+	}
+	if !me.Enabled || strings.TrimSpace(me.ID) == "" || me.ID != expectedActorID {
+		return OperationAuditProfile{}, fmt.Errorf("%w: current BKN Safe identity is disabled or does not match the trusted actor", ErrAccessProfileDenied)
+	}
+	actorName := strings.TrimSpace(me.Name)
+	if actorName == "" {
+		actorName = strings.TrimSpace(me.Account)
+	}
+	if actorName == "" {
+		actorName = me.ID
+	}
+	return OperationAuditProfile{
+		ActorID: me.ID, ActorName: actorName, Account: strings.TrimSpace(me.Account),
+		Roles: builtInRoles(me.Roles),
+	}, nil
+}
+
+func bknSafeBaseURL() string {
+	baseURL := strings.TrimRight(strings.TrimSpace(os.Getenv("BKN_SAFE_BASE_URL")), "/")
+	if baseURL == "" {
+		baseURL = strings.TrimRight(strings.TrimSpace(os.Getenv("BKN_SAFE_URL")), "/")
+	}
+	if baseURL == "" {
+		baseURL = defaultBknSafeBaseURL
+	}
+	return baseURL
 }
 
 func getBknSafe(ctx context.Context, client *http.Client, url, authorization string, target any) error {

--- a/adp/bkn/bkn-backend/server/common/bkntrace/access_profile_test.go
+++ b/adp/bkn/bkn-backend/server/common/bkntrace/access_profile_test.go
@@ -61,3 +61,45 @@ func TestResolveAccessProfileRejectsDisabledIdentity(t *testing.T) {
 		t.Fatalf("ResolveAccessProfile() error = %v, want ErrAccessProfileDenied", err)
 	}
 }
+
+func TestResolveOperationAuditProfileIncludesReadableIdentityAndDirectNetworkGrants(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/safe/v1/me":
+			_, _ = w.Write([]byte(`{"id":"user-1","account":"alice","name":"Alice Zhang","enabled":true,"roles":["network_builder","custom"]}`))
+		case "/api/safe/v1/me/knowledge-network-grants":
+			_, _ = w.Write([]byte(`{"grants":[{"knowledge_network_id":"kn-b","operations":["query"]},{"knowledge_network_id":"kn-a","operations":["modify"]},{"knowledge_network_id":"*","operations":["modify"]}]}`))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+	t.Setenv("BKN_SAFE_BASE_URL", server.URL)
+	t.Setenv("BKN_SAFE_URL", "")
+
+	profile, err := ResolveOperationAuditProfile(context.Background(), "Bearer test-token", "user-1")
+	if err != nil {
+		t.Fatalf("ResolveOperationAuditProfile() error = %v", err)
+	}
+	if profile.ActorName != "Alice Zhang" || profile.Account != "alice" || len(profile.ManagedKnowledgeNetworkIDs) != 1 || profile.ManagedKnowledgeNetworkIDs[0] != "kn-a" {
+		t.Fatalf("profile = %#v", profile)
+	}
+}
+
+func TestResolveOperationAuditIdentityDoesNotDependOnGrantLookup(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/api/safe/v1/me" {
+			_, _ = w.Write([]byte(`{"id":"user-1","account":"alice","name":"Alice Zhang","enabled":true,"roles":["network_builder"]}`))
+			return
+		}
+		http.Error(w, "grant service unavailable", http.StatusServiceUnavailable)
+	}))
+	defer server.Close()
+	t.Setenv("BKN_SAFE_BASE_URL", server.URL)
+	t.Setenv("BKN_SAFE_URL", "")
+
+	profile, err := ResolveOperationAuditIdentity(context.Background(), "Bearer test-token", "user-1")
+	if err != nil || profile.ActorName != "Alice Zhang" {
+		t.Fatalf("profile = %#v, error = %v", profile, err)
+	}
+}

--- a/adp/bkn/bkn-backend/server/common/operationaudit/store.go
+++ b/adp/bkn/bkn-backend/server/common/operationaudit/store.go
@@ -1,0 +1,339 @@
+// Copyright openbkn.ai
+// Copyright The kweaver.ai Authors.
+//
+// Licensed under the Apache License, Version 2.0.
+
+package operationaudit
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+)
+
+const (
+	tableName          = "t_operation_audit"
+	currentSchema      = "1.0"
+	defaultPageSize    = 50
+	maximumPageSize    = 500
+	maximumRequestID   = 128
+	maximumSummarySize = 4096
+)
+
+var (
+	allowedActions = map[string]struct{}{
+		"create": {}, "update": {}, "delete": {}, "import": {},
+		"add_members": {}, "remove_members": {}, "enable": {}, "disable": {},
+	}
+	allowedTargetTypes = map[string]struct{}{
+		"knowledge_network": {}, "object_type": {}, "relation_type": {}, "action_type": {},
+		"metric": {}, "risk_type": {}, "concept_group": {}, "action_schedule": {},
+	}
+	allowedOutcomes    = map[string]struct{}{"success": {}, "failure": {}, "denied": {}}
+	allowedSummaryKeys = map[string]struct{}{"changed_fields": {}, "status": {}}
+)
+
+// Entry is one bounded management fact emitted by BKN Backend.
+// It intentionally excludes request bodies, response bodies and credentials.
+type Entry struct {
+	EventID            string
+	EventTime          time.Time
+	RecordedAt         time.Time
+	TenantID           string
+	BusinessDomainID   string
+	KnowledgeNetworkID string
+	ActorID            string
+	ActorName          string
+	ActorType          string
+	AuthMethod         string
+	CredentialID       string
+	RequestID          string
+	SourceChannel      string
+	Method             string
+	Action             string
+	TargetType         string
+	TargetID           string
+	TargetName         string
+	Outcome            string
+	FailureCode        string
+	FailureMessage     string
+	ChangeSummary      map[string]any
+	SchemaVersion      string
+}
+
+type Filter struct {
+	TenantID            string
+	BusinessDomainID    string
+	KnowledgeNetworkIDs []string
+	ActorID             string
+	Action              string
+	TargetType          string
+	TargetID            string
+	Outcome             string
+	From                time.Time
+	To                  time.Time
+	BeforeTime          time.Time
+	BeforeEventID       string
+	Limit               int
+}
+
+type Scope struct {
+	TenantID            string
+	BusinessDomainID    string
+	KnowledgeNetworkIDs []string
+	ActorID             string
+}
+
+type Page struct {
+	Entries           []Entry
+	HasMore           bool
+	NextBeforeTime    time.Time
+	NextBeforeEventID string
+}
+
+type Store struct {
+	db *sql.DB
+}
+
+func NewStore(db *sql.DB, _ string) *Store {
+	return &Store{db: db}
+}
+
+func (s *Store) Record(ctx context.Context, entry Entry) error {
+	if s == nil || s.db == nil {
+		return errors.New("operation audit store is not configured")
+	}
+	if err := validateEntry(entry); err != nil {
+		return err
+	}
+	if entry.SchemaVersion == "" {
+		entry.SchemaVersion = currentSchema
+	}
+	summary, err := json.Marshal(entry.ChangeSummary)
+	if err != nil {
+		return fmt.Errorf("encode change summary: %w", err)
+	}
+	if string(summary) == "null" {
+		summary = []byte("{}")
+	}
+	if len(summary) > maximumSummarySize {
+		return fmt.Errorf("change summary exceeds %d bytes", maximumSummarySize)
+	}
+
+	query := "INSERT INTO " + tableName + " (event_id,event_time,recorded_at,tenant_id,business_domain_id,knowledge_network_id,actor_id,actor_name,actor_type,auth_method,credential_id,request_id,source_channel,method,action,target_type,target_id,target_name,outcome,failure_code,failure_message,change_summary,schema_version) VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?) ON DUPLICATE KEY UPDATE event_id = VALUES(event_id)"
+	_, err = s.db.ExecContext(ctx, query,
+		entry.EventID, entry.EventTime, entry.RecordedAt, entry.TenantID, entry.BusinessDomainID, entry.KnowledgeNetworkID,
+		entry.ActorID, entry.ActorName, entry.ActorType, entry.AuthMethod, entry.CredentialID, entry.RequestID, entry.SourceChannel,
+		entry.Method, entry.Action, entry.TargetType, entry.TargetID, entry.TargetName, entry.Outcome, entry.FailureCode,
+		entry.FailureMessage, string(summary), entry.SchemaVersion,
+	)
+	if err != nil {
+		return fmt.Errorf("insert operation audit event: %w", err)
+	}
+	return nil
+}
+
+func (s *Store) List(ctx context.Context, filter Filter) (Page, error) {
+	if s == nil || s.db == nil {
+		return Page{}, errors.New("operation audit store is not configured")
+	}
+	if filter.TenantID == "" || filter.BusinessDomainID == "" || filter.From.IsZero() || filter.To.IsZero() || !filter.From.Before(filter.To) {
+		return Page{}, errors.New("tenant, business domain and a valid time range are required")
+	}
+	limit := filter.Limit
+	if limit <= 0 {
+		limit = defaultPageSize
+	}
+	if limit > maximumPageSize {
+		limit = maximumPageSize
+	}
+
+	query := "SELECT " + selectColumns + " FROM " + tableName + " WHERE tenant_id = ? AND business_domain_id = ?"
+	args := []any{filter.TenantID, filter.BusinessDomainID}
+	networkIDs := normalizedIDs(filter.KnowledgeNetworkIDs)
+	if len(networkIDs) > 0 {
+		query += " AND knowledge_network_id IN (" + placeholders(len(networkIDs)) + ")"
+		for _, networkID := range networkIDs {
+			args = append(args, networkID)
+		}
+	}
+	if filter.ActorID != "" {
+		query += " AND actor_id = ?"
+		args = append(args, filter.ActorID)
+	}
+	for _, criterion := range []struct {
+		column string
+		value  string
+	}{
+		{"action", filter.Action}, {"target_type", filter.TargetType},
+		{"target_id", filter.TargetID}, {"outcome", filter.Outcome},
+	} {
+		if criterion.value != "" {
+			query += " AND " + criterion.column + " = ?"
+			args = append(args, criterion.value)
+		}
+	}
+	query += " AND event_time >= ? AND event_time < ?"
+	args = append(args, filter.From, filter.To)
+	if !filter.BeforeTime.IsZero() {
+		if filter.BeforeEventID == "" {
+			return Page{}, errors.New("cursor event id is required with cursor time")
+		}
+		query += " AND (event_time < ? OR (event_time = ? AND event_id > ?))"
+		args = append(args, filter.BeforeTime, filter.BeforeTime, filter.BeforeEventID)
+	}
+	query += " ORDER BY event_time DESC, event_id ASC LIMIT ?"
+	args = append(args, limit+1)
+
+	rows, err := s.db.QueryContext(ctx, query, args...)
+	if err != nil {
+		return Page{}, fmt.Errorf("query operation audit events: %w", err)
+	}
+	defer rows.Close()
+
+	entries := make([]Entry, 0, limit+1)
+	for rows.Next() {
+		entry, err := scanEntry(rows)
+		if err != nil {
+			return Page{}, err
+		}
+		entries = append(entries, entry)
+	}
+	if err := rows.Err(); err != nil {
+		return Page{}, fmt.Errorf("iterate operation audit events: %w", err)
+	}
+
+	page := Page{Entries: entries}
+	if len(entries) > limit {
+		page.HasMore = true
+		page.Entries = entries[:limit]
+	}
+	if page.HasMore && len(page.Entries) > 0 {
+		last := page.Entries[len(page.Entries)-1]
+		page.NextBeforeTime = last.EventTime
+		page.NextBeforeEventID = last.EventID
+	}
+	return page, nil
+}
+
+func (s *Store) Get(ctx context.Context, eventID string, scope Scope) (Entry, bool, error) {
+	if s == nil || s.db == nil {
+		return Entry{}, false, errors.New("operation audit store is not configured")
+	}
+	if eventID == "" || scope.TenantID == "" {
+		return Entry{}, false, errors.New("event id and tenant are required")
+	}
+	query := "SELECT " + selectColumns + " FROM " + tableName + " WHERE event_id = ? AND tenant_id = ?"
+	args := []any{eventID, scope.TenantID}
+	if scope.BusinessDomainID != "" {
+		query += " AND business_domain_id = ?"
+		args = append(args, scope.BusinessDomainID)
+	}
+	networkIDs := normalizedIDs(scope.KnowledgeNetworkIDs)
+	if len(networkIDs) > 0 {
+		query += " AND knowledge_network_id IN (" + placeholders(len(networkIDs)) + ")"
+		for _, networkID := range networkIDs {
+			args = append(args, networkID)
+		}
+	}
+	if scope.ActorID != "" {
+		query += " AND actor_id = ?"
+		args = append(args, scope.ActorID)
+	}
+	entry, err := scanEntry(s.db.QueryRowContext(ctx, query, args...))
+	if errors.Is(err, sql.ErrNoRows) {
+		return Entry{}, false, nil
+	}
+	if err != nil {
+		return Entry{}, false, err
+	}
+	return entry, true, nil
+}
+
+func validateEntry(entry Entry) error {
+	if entry.EventID == "" || entry.EventTime.IsZero() || entry.RecordedAt.IsZero() || entry.TenantID == "" ||
+		entry.BusinessDomainID == "" || entry.KnowledgeNetworkID == "" || entry.ActorID == "" || entry.ActorName == "" ||
+		entry.RequestID == "" || entry.TargetID == "" || entry.TargetName == "" {
+		return errors.New("operation audit entry is missing required fields")
+	}
+	if _, ok := allowedActions[entry.Action]; !ok {
+		return fmt.Errorf("unregistered action %q", entry.Action)
+	}
+	if _, ok := allowedTargetTypes[entry.TargetType]; !ok {
+		return fmt.Errorf("unregistered target type %q", entry.TargetType)
+	}
+	if _, ok := allowedOutcomes[entry.Outcome]; !ok {
+		return fmt.Errorf("invalid outcome %q", entry.Outcome)
+	}
+	if len(entry.RequestID) > maximumRequestID || !printableASCII(entry.RequestID) {
+		return errors.New("request id is not bounded printable ASCII")
+	}
+	for key := range entry.ChangeSummary {
+		if _, ok := allowedSummaryKeys[key]; !ok {
+			return fmt.Errorf("change summary key %q is not allowed", key)
+		}
+	}
+	return nil
+}
+
+func printableASCII(value string) bool {
+	for _, r := range value {
+		if r < 0x20 || r > 0x7e {
+			return false
+		}
+	}
+	return true
+}
+
+func normalizedIDs(values []string) []string {
+	seen := make(map[string]struct{}, len(values))
+	result := make([]string, 0, len(values))
+	for _, value := range values {
+		value = strings.TrimSpace(value)
+		if value == "" {
+			continue
+		}
+		if _, exists := seen[value]; exists {
+			continue
+		}
+		seen[value] = struct{}{}
+		result = append(result, value)
+	}
+	sort.Strings(result)
+	return result
+}
+
+func placeholders(count int) string {
+	return strings.TrimSuffix(strings.Repeat("?,", count), ",")
+}
+
+const selectColumns = "event_id,event_time,recorded_at,tenant_id,business_domain_id,knowledge_network_id,actor_id,actor_name,actor_type,auth_method,credential_id,request_id,source_channel,method,action,target_type,target_id,target_name,outcome,failure_code,failure_message,change_summary,schema_version"
+
+type scanner interface {
+	Scan(dest ...any) error
+}
+
+func scanEntry(row scanner) (Entry, error) {
+	var entry Entry
+	var summary []byte
+	err := row.Scan(
+		&entry.EventID, &entry.EventTime, &entry.RecordedAt, &entry.TenantID, &entry.BusinessDomainID, &entry.KnowledgeNetworkID,
+		&entry.ActorID, &entry.ActorName, &entry.ActorType, &entry.AuthMethod, &entry.CredentialID, &entry.RequestID,
+		&entry.SourceChannel, &entry.Method, &entry.Action, &entry.TargetType, &entry.TargetID, &entry.TargetName,
+		&entry.Outcome, &entry.FailureCode, &entry.FailureMessage, &summary, &entry.SchemaVersion,
+	)
+	if err != nil {
+		return Entry{}, err
+	}
+	if len(summary) > 0 {
+		if err := json.Unmarshal(summary, &entry.ChangeSummary); err != nil {
+			return Entry{}, fmt.Errorf("decode operation audit change summary: %w", err)
+		}
+	}
+	return entry, nil
+}

--- a/adp/bkn/bkn-backend/server/common/operationaudit/store_test.go
+++ b/adp/bkn/bkn-backend/server/common/operationaudit/store_test.go
@@ -1,0 +1,140 @@
+// Copyright openbkn.ai
+// Copyright The kweaver.ai Authors.
+//
+// Licensed under the Apache License, Version 2.0.
+
+package operationaudit
+
+import (
+	"context"
+	"database/sql/driver"
+	"regexp"
+	"testing"
+	"time"
+
+	"github.com/DATA-DOG/go-sqlmock"
+)
+
+func TestRecordPersistsOneBoundedManagementFact(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("new sql mock: %v", err)
+	}
+	defer db.Close()
+	store := NewStore(db, "MARIADB")
+	eventTime := time.Date(2026, 8, 13, 10, 0, 0, 0, time.UTC)
+
+	mock.ExpectExec(regexp.QuoteMeta("INSERT INTO t_operation_audit")).
+		WithArgs(
+			"evt-1", eventTime, eventTime, "tenant-a", "domain-a", "kn-a",
+			"user-a", "Alice", "user", "oauth", "", "req-a", "api", "POST",
+			"create", "object_type", "material", "物料", "success", "", "",
+			`{"changed_fields":["name"]}`, "1.0",
+		).
+		WillReturnResult(sqlmock.NewResult(1, 1))
+
+	err = store.Record(context.Background(), Entry{
+		EventID: "evt-1", EventTime: eventTime, RecordedAt: eventTime,
+		TenantID: "tenant-a", BusinessDomainID: "domain-a", KnowledgeNetworkID: "kn-a",
+		ActorID: "user-a", ActorName: "Alice", ActorType: "user", AuthMethod: "oauth",
+		RequestID: "req-a", SourceChannel: "api", Method: "POST", Action: "create",
+		TargetType: "object_type", TargetID: "material", TargetName: "物料", Outcome: "success",
+		ChangeSummary: map[string]any{"changed_fields": []string{"name"}},
+	})
+	if err != nil {
+		t.Fatalf("Record() error = %v", err)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestRecordRejectsUnboundedOrUnregisteredFactsBeforeSQL(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("new sql mock: %v", err)
+	}
+	defer db.Close()
+	store := NewStore(db, "MARIADB")
+
+	for _, entry := range []Entry{
+		{EventID: "evt-a", TenantID: "tenant-a", BusinessDomainID: "domain-a", ActorID: "user-a", ActorName: "Alice", RequestID: "req-a", Action: "preview", TargetType: "object_type", TargetID: "material", TargetName: "物料", Outcome: "success"},
+		{EventID: "evt-b", TenantID: "tenant-a", BusinessDomainID: "domain-a", ActorID: "user-a", ActorName: "Alice", RequestID: string(make([]byte, 129)), Action: "create", TargetType: "object_type", TargetID: "material", TargetName: "物料", Outcome: "success"},
+		{EventID: "evt-c", TenantID: "tenant-a", BusinessDomainID: "domain-a", ActorID: "user-a", ActorName: "Alice", RequestID: "req-c", Action: "create", TargetType: "object_type", TargetID: "material", TargetName: "物料", Outcome: "success", ChangeSummary: map[string]any{"password": "secret"}},
+	} {
+		if err := store.Record(context.Background(), entry); err == nil {
+			t.Fatalf("Record() accepted invalid entry: %+v", entry)
+		}
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestListPushesTenantDomainNetworkAndKeysetScopeIntoSQL(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("new sql mock: %v", err)
+	}
+	defer db.Close()
+	store := NewStore(db, "MARIADB")
+	from := time.Date(2026, 8, 1, 0, 0, 0, 0, time.UTC)
+	to := from.Add(7 * 24 * time.Hour)
+	before := to.Add(-time.Hour)
+
+	queryPattern := `SELECT .* FROM t_operation_audit WHERE tenant_id = \? AND business_domain_id = \? AND knowledge_network_id IN \(\?,\?\) AND event_time >= \? AND event_time < \? AND \(event_time < \? OR \(event_time = \? AND event_id > \?\)\) ORDER BY event_time DESC, event_id ASC LIMIT \?`
+	mock.ExpectQuery(queryPattern).
+		WithArgs("tenant-a", "domain-a", "kn-a", "kn-b", from, to, before, before, "evt-cursor", 21).
+		WillReturnRows(sqlmock.NewRows(auditColumns()).AddRow(auditRow("evt-1", before.Add(-time.Second))...))
+
+	page, err := store.List(context.Background(), Filter{
+		TenantID: "tenant-a", BusinessDomainID: "domain-a", KnowledgeNetworkIDs: []string{"kn-b", "kn-a"},
+		From: from, To: to, BeforeTime: before, BeforeEventID: "evt-cursor", Limit: 20,
+	})
+	if err != nil {
+		t.Fatalf("List() error = %v", err)
+	}
+	if len(page.Entries) != 1 || page.Entries[0].EventID != "evt-1" || page.HasMore {
+		t.Fatalf("List() = %+v", page)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestGetRequiresTenantAndAuthorizedNetwork(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("new sql mock: %v", err)
+	}
+	defer db.Close()
+	store := NewStore(db, "MARIADB")
+	eventTime := time.Date(2026, 8, 13, 10, 0, 0, 0, time.UTC)
+
+	mock.ExpectQuery(`SELECT .* FROM t_operation_audit WHERE event_id = \? AND tenant_id = \? AND knowledge_network_id IN \(\?\)`).
+		WithArgs("evt-1", "tenant-a", "kn-a").
+		WillReturnRows(sqlmock.NewRows(auditColumns()).AddRow(auditRow("evt-1", eventTime)...))
+	entry, found, err := store.Get(context.Background(), "evt-1", Scope{TenantID: "tenant-a", KnowledgeNetworkIDs: []string{"kn-a"}})
+	if err != nil || !found || entry.EventID != "evt-1" {
+		t.Fatalf("Get() = %+v, %v, %v", entry, found, err)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func auditColumns() []string {
+	return []string{
+		"event_id", "event_time", "recorded_at", "tenant_id", "business_domain_id", "knowledge_network_id",
+		"actor_id", "actor_name", "actor_type", "auth_method", "credential_id", "request_id", "source_channel",
+		"method", "action", "target_type", "target_id", "target_name", "outcome", "failure_code", "failure_message",
+		"change_summary", "schema_version",
+	}
+}
+
+func auditRow(eventID string, eventTime time.Time) []driver.Value {
+	return []driver.Value{
+		eventID, eventTime, eventTime, "tenant-a", "domain-a", "kn-a", "user-a", "Alice", "user", "oauth", "",
+		"req-a", "api", "POST", "create", "object_type", "material", "物料", "success", "", "", []byte(`{"changed_fields":["name"]}`), "1.0",
+	}
+}

--- a/adp/bkn/bkn-backend/server/driveradapters/operation_audit.go
+++ b/adp/bkn/bkn-backend/server/driveradapters/operation_audit.go
@@ -219,7 +219,8 @@ func (w *boundedResponseWriter) Write(data []byte) (int, error) {
 	// Registered operation-audit routes are JSON APIs. The wrapper only observes
 	// the already-rendered handler response and preserves it byte-for-byte; the
 	// forced JSON media type plus nosniff prevents browser HTML interpretation.
-	return w.ResponseWriter.Write(data) // lgtm[go/reflected-xss]
+	// lgtm[go/reflected-xss]
+	return w.ResponseWriter.Write(data)
 }
 
 func (w *boundedResponseWriter) WriteString(value string) (int, error) {
@@ -254,7 +255,19 @@ func operationAuditVisitor(c *gin.Context) (hydra.Visitor, bool) {
 			return visitor, true
 		}
 	}
+	if operationAuditInternalRoute(c.FullPath()) {
+		return hydra.Visitor{
+			ID:   strings.TrimSpace(c.GetHeader(interfaces.HTTP_HEADER_ACCOUNT_ID)),
+			Type: hydra.VisitorType(strings.TrimSpace(c.GetHeader(interfaces.HTTP_HEADER_ACCOUNT_TYPE))),
+		}, true
+	}
 	return hydra.Visitor{}, false
+}
+
+func operationAuditInternalRoute(fullPath string) bool {
+	path := strings.TrimSpace(fullPath)
+	return strings.HasPrefix(path, "/api/bkn-backend/in/v1/") ||
+		strings.HasPrefix(path, "/api/ontology-manager/in/v1/")
 }
 
 type extractedOperationAuditFacts struct {

--- a/adp/bkn/bkn-backend/server/driveradapters/operation_audit.go
+++ b/adp/bkn/bkn-backend/server/driveradapters/operation_audit.go
@@ -210,17 +210,19 @@ func (w *boundedResponseWriter) WriteHeaderNow() {
 
 func (w *boundedResponseWriter) Write(data []byte) (int, error) {
 	w.ensureNonExecutableJSON()
+	var escaped bytes.Buffer
+	json.HTMLEscape(&escaped, data)
+	safeData := escaped.Bytes()
 	if remaining := w.limit - w.body.Len(); remaining > 0 {
-		if len(data) < remaining {
-			remaining = len(data)
+		if len(safeData) < remaining {
+			remaining = len(safeData)
 		}
-		_, _ = w.body.Write(data[:remaining])
+		_, _ = w.body.Write(safeData[:remaining])
 	}
-	// Registered operation-audit routes are JSON APIs. The wrapper only observes
-	// the already-rendered handler response and preserves it byte-for-byte; the
-	// forced JSON media type plus nosniff prevents browser HTML interpretation.
-	// lgtm[go/reflected-xss]
-	return w.ResponseWriter.Write(data)
+	if _, err := w.ResponseWriter.Write(safeData); err != nil {
+		return 0, err
+	}
+	return len(data), nil
 }
 
 func (w *boundedResponseWriter) WriteString(value string) (int, error) {

--- a/adp/bkn/bkn-backend/server/driveradapters/operation_audit.go
+++ b/adp/bkn/bkn-backend/server/driveradapters/operation_audit.go
@@ -1,0 +1,458 @@
+// Copyright openbkn.ai
+// Copyright The kweaver.ai Authors.
+//
+// Licensed under the Apache License, Version 2.0.
+
+package driveradapters
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/openbkn-ai/bkn-comm-go/hydra"
+	"github.com/openbkn-ai/bkn-comm-go/logger"
+	"github.com/rs/xid"
+
+	"bkn-backend/common/operationaudit"
+	"bkn-backend/interfaces"
+)
+
+const (
+	operationAuditVisitorKey = "bkn.operation_audit.visitor"
+	operationAuditRequestKey = "bkn.operation_audit.request_id"
+)
+
+const maximumOperationAuditBody = 64 << 10
+
+type operationAuditRule struct {
+	Action     string
+	TargetType string
+}
+
+type operationAuditActor struct {
+	ActorID      string
+	ActorName    string
+	ActorType    string
+	AuthMethod   string
+	CredentialID string
+}
+
+type operationAuditRecorder interface {
+	Record(context.Context, operationaudit.Entry) error
+}
+
+type operationAuditQueryStore interface {
+	List(context.Context, operationaudit.Filter) (operationaudit.Page, error)
+	Get(context.Context, string, operationaudit.Scope) (operationaudit.Entry, bool, error)
+}
+
+var operationAuditRoutes = map[string]operationAuditRule{
+	"POST /knowledge-networks":                                                           {Action: "create", TargetType: "knowledge_network"},
+	"PUT /knowledge-networks/:kn_id":                                                     {Action: "update", TargetType: "knowledge_network"},
+	"DELETE /knowledge-networks/:kn_id":                                                  {Action: "delete", TargetType: "knowledge_network"},
+	"POST /knowledge-networks/:kn_id/object-types":                                       {Action: "create", TargetType: "object_type"},
+	"PUT /knowledge-networks/:kn_id/object-types/:ot_id":                                 {Action: "update", TargetType: "object_type"},
+	"PUT /knowledge-networks/:kn_id/object-types/:ot_id/data_properties/:property_names": {Action: "update", TargetType: "object_type"},
+	"DELETE /knowledge-networks/:kn_id/object-types/:ot_ids":                             {Action: "delete", TargetType: "object_type"},
+	"POST /knowledge-networks/:kn_id/relation-types":                                     {Action: "create", TargetType: "relation_type"},
+	"PUT /knowledge-networks/:kn_id/relation-types/:rt_id":                               {Action: "update", TargetType: "relation_type"},
+	"DELETE /knowledge-networks/:kn_id/relation-types/:rt_ids":                           {Action: "delete", TargetType: "relation_type"},
+	"POST /knowledge-networks/:kn_id/action-types":                                       {Action: "create", TargetType: "action_type"},
+	"PUT /knowledge-networks/:kn_id/action-types/:at_id":                                 {Action: "update", TargetType: "action_type"},
+	"DELETE /knowledge-networks/:kn_id/action-types/:at_ids":                             {Action: "delete", TargetType: "action_type"},
+	"POST /knowledge-networks/:kn_id/metrics":                                            {Action: "create", TargetType: "metric"},
+	"PUT /knowledge-networks/:kn_id/metrics/:metric_ids":                                 {Action: "update", TargetType: "metric"},
+	"DELETE /knowledge-networks/:kn_id/metrics/:metric_ids":                              {Action: "delete", TargetType: "metric"},
+	"POST /knowledge-networks/:kn_id/risk-types":                                         {Action: "create", TargetType: "risk_type"},
+	"PUT /knowledge-networks/:kn_id/risk-types/:rt_id":                                   {Action: "update", TargetType: "risk_type"},
+	"DELETE /knowledge-networks/:kn_id/risk-types/:rt_ids":                               {Action: "delete", TargetType: "risk_type"},
+	"POST /knowledge-networks/:kn_id/concept-groups":                                     {Action: "create", TargetType: "concept_group"},
+	"PUT /knowledge-networks/:kn_id/concept-groups/:cg_id":                               {Action: "update", TargetType: "concept_group"},
+	"DELETE /knowledge-networks/:kn_id/concept-groups/:cg_id":                            {Action: "delete", TargetType: "concept_group"},
+	"POST /knowledge-networks/:kn_id/concept-groups/:cg_id/object-types":                 {Action: "add_members", TargetType: "concept_group"},
+	"DELETE /knowledge-networks/:kn_id/concept-groups/:cg_id/object-types/:ot_ids":       {Action: "remove_members", TargetType: "concept_group"},
+	"POST /knowledge-networks/:kn_id/action-schedules":                                   {Action: "create", TargetType: "action_schedule"},
+	"PUT /knowledge-networks/:kn_id/action-schedules/:schedule_id":                       {Action: "update", TargetType: "action_schedule"},
+	"PUT /knowledge-networks/:kn_id/action-schedules/:schedule_id/status":                {Action: "update", TargetType: "action_schedule"},
+	"DELETE /knowledge-networks/:kn_id/action-schedules/:schedule_ids":                   {Action: "delete", TargetType: "action_schedule"},
+	"POST /bkns": {Action: "import", TargetType: "knowledge_network"},
+}
+
+func registeredOperationAudit(method, fullPath, methodOverride string) (operationAuditRule, bool) {
+	if strings.EqualFold(strings.TrimSpace(methodOverride), "GET") {
+		return operationAuditRule{}, false
+	}
+	path := strings.TrimSpace(fullPath)
+	for _, prefix := range []string{
+		"/api/bkn-backend/v1", "/api/ontology-manager/v1",
+		"/api/bkn-backend/in/v1", "/api/ontology-manager/in/v1",
+	} {
+		if strings.HasPrefix(path, prefix) {
+			path = strings.TrimPrefix(path, prefix)
+			break
+		}
+	}
+	rule, ok := operationAuditRoutes[strings.ToUpper(strings.TrimSpace(method))+" "+path]
+	return rule, ok
+}
+
+func (r *restHandler) operationAuditIdentity(ctx context.Context, authorization string, visitor hydra.Visitor) operationAuditActor {
+	if r != nil && r.auditIdentityResolver != nil {
+		identity := r.auditIdentityResolver(ctx, authorization, visitor)
+		if identity.ActorID != "" && identity.ActorName != "" {
+			return identity
+		}
+	}
+	return basicOperationAuditActor(authorization, visitor)
+}
+
+func basicOperationAuditActor(authorization string, visitor hydra.Visitor) operationAuditActor {
+	authMethod := "oauth"
+	if strings.TrimSpace(authorization) == "" {
+		authMethod = "service_header"
+	} else if strings.Contains(strings.ToLower(authorization), "bak_") {
+		authMethod = "app_key"
+	}
+	actorType := strings.TrimSpace(string(visitor.Type))
+	if actorType == "" {
+		actorType = "user"
+	}
+	return operationAuditActor{
+		ActorID: strings.TrimSpace(visitor.ID), ActorName: strings.TrimSpace(visitor.ID),
+		ActorType: actorType, AuthMethod: authMethod, CredentialID: strings.TrimSpace(visitor.TokenID),
+	}
+}
+
+// OperationAudit records exactly one bounded management fact after a registered
+// request attempt. It never changes the business response when audit persistence
+// fails; the loss is explicit in the service log instead of being silently hidden.
+func (r *restHandler) OperationAudit() gin.HandlerFunc {
+	return func(c *gin.Context) {
+		rule, registered := registeredOperationAudit(c.Request.Method, c.FullPath(), c.GetHeader(interfaces.HTTP_HEADER_METHOD_OVERRIDE))
+		if !registered {
+			c.Next()
+			return
+		}
+		requestBody := captureRequestBody(c.Request)
+		responseBody := &boundedResponseWriter{ResponseWriter: c.Writer, limit: maximumOperationAuditBody}
+		c.Writer = responseBody
+		c.Next()
+
+		if r == nil || r.auditRecorder == nil {
+			return
+		}
+		visitor, _ := operationAuditVisitor(c)
+		actor := r.operationAuditIdentity(c.Request.Context(), c.GetHeader("Authorization"), visitor)
+		if actor.ActorID == "" {
+			actor.ActorID, actor.ActorName, actor.ActorType = "unauthenticated", "未认证调用者", "unknown"
+		}
+		facts := operationAuditFacts(c, rule, requestBody, responseBody.body.Bytes())
+		now := time.Now().UTC()
+		tenantID := operationAuditScopeValue(c.GetHeader("x-tenant-id"), "BKN_OPERATION_AUDIT_TENANT_ID", "openbkn-local")
+		requestID := operationAuditRequestID(c)
+		entry := operationaudit.Entry{
+			EventID: operationAuditEventID(tenantID, requestID, c.Request.Method, c.Request.URL.Path), EventTime: now, RecordedAt: now,
+			TenantID:           tenantID,
+			BusinessDomainID:   operationAuditScopeValue(firstNonEmpty(c.GetHeader(interfaces.HTTP_HEADER_BUSINESS_DOMAIN), facts.businessDomain), "BKN_OPERATION_AUDIT_BUSINESS_DOMAIN", "bd_public"),
+			KnowledgeNetworkID: facts.knowledgeNetworkID,
+			ActorID:            actor.ActorID, ActorName: actor.ActorName, ActorType: actor.ActorType,
+			AuthMethod: actor.AuthMethod, CredentialID: actor.CredentialID,
+			RequestID: requestID, SourceChannel: operationAuditSourceChannel(c.FullPath()), Method: c.Request.Method,
+			Action: rule.Action, TargetType: rule.TargetType, TargetID: facts.targetID, TargetName: facts.targetName,
+			Outcome: facts.outcome, FailureCode: facts.failureCode, FailureMessage: facts.failureMessage,
+			ChangeSummary: facts.changeSummary,
+		}
+		if entry.KnowledgeNetworkID == "" {
+			entry.KnowledgeNetworkID = entry.TargetID
+		}
+		if err := r.auditRecorder.Record(c.Request.Context(), entry); err != nil {
+			logger.Errorf("operation audit persistence failed: request_id=%s action=%s target_type=%s error=%v", entry.RequestID, entry.Action, entry.TargetType, err)
+		}
+	}
+}
+
+func operationAuditEventID(tenantID, requestID, method, path string) string {
+	sum := sha256.Sum256([]byte(strings.Join([]string{tenantID, requestID, strings.ToUpper(method), path}, "\n")))
+	return fmt.Sprintf("evt_%x", sum[:])
+}
+
+type boundedResponseWriter struct {
+	gin.ResponseWriter
+	body  bytes.Buffer
+	limit int
+}
+
+func (w *boundedResponseWriter) Write(data []byte) (int, error) {
+	if remaining := w.limit - w.body.Len(); remaining > 0 {
+		if len(data) < remaining {
+			remaining = len(data)
+		}
+		_, _ = w.body.Write(data[:remaining])
+	}
+	return w.ResponseWriter.Write(data)
+}
+
+func captureRequestBody(request *http.Request) []byte {
+	if request == nil || request.Body == nil {
+		return nil
+	}
+	body, err := io.ReadAll(io.LimitReader(request.Body, maximumOperationAuditBody+1))
+	if err != nil {
+		return nil
+	}
+	request.Body = io.NopCloser(io.MultiReader(bytes.NewReader(body), request.Body))
+	if len(body) > maximumOperationAuditBody {
+		return nil
+	}
+	return body
+}
+
+func operationAuditVisitor(c *gin.Context) (hydra.Visitor, bool) {
+	value, exists := c.Get(operationAuditVisitorKey)
+	if exists {
+		visitor, ok := value.(hydra.Visitor)
+		if ok {
+			return visitor, true
+		}
+	}
+	return hydra.Visitor{
+		ID:   strings.TrimSpace(c.GetHeader(interfaces.HTTP_HEADER_ACCOUNT_ID)),
+		Type: hydra.VisitorType(strings.TrimSpace(c.GetHeader(interfaces.HTTP_HEADER_ACCOUNT_TYPE))),
+	}, false
+}
+
+type extractedOperationAuditFacts struct {
+	knowledgeNetworkID string
+	businessDomain     string
+	targetID           string
+	targetName         string
+	outcome            string
+	failureCode        string
+	failureMessage     string
+	changeSummary      map[string]any
+}
+
+func operationAuditFacts(c *gin.Context, rule operationAuditRule, requestBody, responseBody []byte) extractedOperationAuditFacts {
+	requestJSON := decodeBoundedObject(requestBody)
+	responseJSON := decodeBoundedObject(responseBody)
+	knID := strings.TrimSpace(c.Param("kn_id"))
+	targetID := operationAuditPathTarget(c, rule.TargetType)
+	targetName := ""
+	requestIDs, requestNames := targetValues(requestJSON)
+	responseIDs, responseNames := targetValues(responseJSON)
+	if len(responseIDs) > 0 {
+		targetID = strings.Join(responseIDs, ",")
+	} else if targetID == "" && len(requestIDs) > 0 {
+		targetID = strings.Join(requestIDs, ",")
+	}
+	if len(responseNames) > 0 {
+		targetName = strings.Join(responseNames, "、")
+	} else if len(requestNames) > 0 {
+		targetName = strings.Join(requestNames, "、")
+	}
+	requestID := operationAuditRequestID(c)
+	if targetID == "" {
+		targetID = rule.TargetType + ":" + requestID
+	}
+	if targetName == "" {
+		targetName = targetID
+	}
+	if knID == "" && rule.TargetType == "knowledge_network" {
+		knID = targetID
+	}
+	outcome := "success"
+	failureCode, failureMessage := "", ""
+	if c.Writer.Status() < http.StatusOK || c.Writer.Status() >= http.StatusBadRequest {
+		outcome = "failure"
+		if c.Writer.Status() == http.StatusUnauthorized || c.Writer.Status() == http.StatusForbidden {
+			outcome = "denied"
+		}
+		failureCode, failureMessage = boundedFailure(responseJSON, c.Writer.Status())
+	}
+	return extractedOperationAuditFacts{
+		knowledgeNetworkID: knID, businessDomain: stringValue(requestJSON["business_domain"]),
+		targetID: boundText(targetID, 1024), targetName: boundText(targetName, 1024),
+		outcome: outcome, failureCode: failureCode, failureMessage: failureMessage,
+		changeSummary: changedFields(requestJSON),
+	}
+}
+
+func operationAuditPathTarget(c *gin.Context, targetType string) string {
+	names := map[string][]string{
+		"knowledge_network": {"kn_id"}, "object_type": {"ot_id", "ot_ids"},
+		"relation_type": {"rt_id", "rt_ids"}, "action_type": {"at_id", "at_ids"},
+		"risk_type": {"rt_id", "rt_ids"},
+		"metric":    {"metric_ids"}, "concept_group": {"cg_id"}, "action_schedule": {"schedule_id", "schedule_ids"},
+	}
+	for _, name := range names[targetType] {
+		if value := strings.TrimSpace(c.Param(name)); value != "" {
+			return value
+		}
+	}
+	return ""
+}
+
+func decodeBoundedObject(body []byte) map[string]any {
+	if len(body) == 0 {
+		return map[string]any{}
+	}
+	var value map[string]any
+	if json.Unmarshal(body, &value) != nil {
+		return map[string]any{}
+	}
+	return value
+}
+
+func targetValues(value map[string]any) ([]string, []string) {
+	ids, names := []string{}, []string{}
+	appendObject := func(object map[string]any) {
+		if id := firstNonEmpty(stringValue(object["id"]), stringValue(object["kn_id"])); id != "" {
+			ids = append(ids, id)
+		}
+		if name := stringValue(object["name"]); name != "" {
+			names = append(names, name)
+		}
+	}
+	appendObject(value)
+	if entries, ok := value["entries"].([]any); ok {
+		for _, item := range entries {
+			if object, ok := item.(map[string]any); ok {
+				appendObject(object)
+			}
+		}
+	}
+	return uniqueStrings(ids), uniqueStrings(names)
+}
+
+func changedFields(value map[string]any) map[string]any {
+	allowed := map[string]struct{}{
+		"name": {}, "comment": {}, "tags": {}, "icon": {}, "color": {}, "branch": {},
+		"business_domain": {}, "status": {}, "entries": {}, "object_type_ids": {},
+		"cron_expression": {}, "action_type_id": {},
+	}
+	fields := []string{}
+	for key := range value {
+		if _, ok := allowed[key]; ok {
+			fields = append(fields, key)
+		}
+	}
+	if entries, ok := value["entries"].([]any); ok {
+		for _, item := range entries {
+			if object, ok := item.(map[string]any); ok {
+				for key := range object {
+					if _, allowedKey := allowed[key]; allowedKey && key != "entries" {
+						fields = append(fields, key)
+					}
+				}
+			}
+		}
+	}
+	fields = uniqueStrings(fields)
+	sort.Strings(fields)
+	summary := map[string]any{"changed_fields": fields}
+	if status := stringValue(value["status"]); status != "" {
+		summary["status"] = boundText(status, 64)
+	}
+	return summary
+}
+
+func boundedFailure(value map[string]any, status int) (string, string) {
+	code := http.StatusText(status)
+	message := code
+	if nested, ok := value["error"].(map[string]any); ok {
+		code = firstNonEmpty(stringValue(nested["code"]), code)
+		message = firstNonEmpty(stringValue(nested["message"]), stringValue(nested["description"]), message)
+	} else {
+		code = firstNonEmpty(stringValue(value["code"]), code)
+		message = firstNonEmpty(stringValue(value["message"]), stringValue(value["description"]), message)
+	}
+	return boundText(code, 128), boundText(message, 512)
+}
+
+func operationAuditRequestID(c *gin.Context) string {
+	if value, exists := c.Get(operationAuditRequestKey); exists {
+		if requestID, ok := value.(string); ok && requestID != "" {
+			return requestID
+		}
+	}
+	requestID := firstNonEmptyHeader(c, headerBKNRequestID, headerLegacyRequestID)
+	if len(requestID) > 128 || !operationAuditPrintableASCII(requestID) {
+		requestID = ""
+	}
+	if requestID == "" {
+		requestID = "req_" + xid.New().String()
+	}
+	c.Request.Header.Set(headerBKNRequestID, requestID)
+	c.Set(operationAuditRequestKey, requestID)
+	c.Header(headerBKNRequestID, requestID)
+	return requestID
+}
+
+func operationAuditPrintableASCII(value string) bool {
+	for _, r := range value {
+		if r < 0x20 || r > 0x7e {
+			return false
+		}
+	}
+	return true
+}
+
+func operationAuditScopeValue(headerValue, environmentName, fallback string) string {
+	return firstNonEmpty(strings.TrimSpace(headerValue), strings.TrimSpace(os.Getenv(environmentName)), fallback)
+}
+
+func operationAuditSourceChannel(fullPath string) string {
+	// Internal and external HTTP routes share the public "api" channel. The
+	// authentication method distinguishes service calls without expanding the
+	// cross-service source_channel contract.
+	return "api"
+}
+
+func stringValue(value any) string {
+	stringValue, _ := value.(string)
+	return strings.TrimSpace(stringValue)
+}
+
+func boundText(value string, maximum int) string {
+	value = strings.TrimSpace(value)
+	if len(value) <= maximum {
+		return value
+	}
+	return value[:maximum]
+}
+
+func uniqueStrings(values []string) []string {
+	seen := map[string]struct{}{}
+	result := make([]string, 0, len(values))
+	for _, value := range values {
+		value = strings.TrimSpace(value)
+		if value == "" {
+			continue
+		}
+		if _, exists := seen[value]; exists {
+			continue
+		}
+		seen[value] = struct{}{}
+		result = append(result, value)
+	}
+	return result
+}
+
+func firstNonEmpty(values ...string) string {
+	for _, value := range values {
+		if strings.TrimSpace(value) != "" {
+			return strings.TrimSpace(value)
+		}
+	}
+	return ""
+}

--- a/adp/bkn/bkn-backend/server/driveradapters/operation_audit.go
+++ b/adp/bkn/bkn-backend/server/driveradapters/operation_audit.go
@@ -148,6 +148,7 @@ func (r *restHandler) OperationAudit() gin.HandlerFunc {
 		responseBody := &boundedResponseWriter{ResponseWriter: c.Writer, limit: maximumOperationAuditBody}
 		c.Writer = responseBody
 		c.Next()
+		responseBody.FlushResponse()
 
 		if r == nil || r.auditRecorder == nil {
 			return
@@ -194,44 +195,65 @@ func operationAuditEventID(tenantID, requestID, method, path string) string {
 
 type boundedResponseWriter struct {
 	gin.ResponseWriter
-	body  bytes.Buffer
-	limit int
+	body        bytes.Buffer
+	limit       int
+	status      int
+	wroteHeader bool
 }
 
 func (w *boundedResponseWriter) WriteHeader(code int) {
-	w.ensureNonExecutableJSON()
-	w.ResponseWriter.WriteHeader(code)
+	if w.wroteHeader {
+		return
+	}
+	w.status = code
+	w.wroteHeader = true
 }
 
 func (w *boundedResponseWriter) WriteHeaderNow() {
-	w.ensureNonExecutableJSON()
-	w.ResponseWriter.WriteHeaderNow()
+	if !w.wroteHeader {
+		w.WriteHeader(http.StatusOK)
+	}
 }
 
 func (w *boundedResponseWriter) Write(data []byte) (int, error) {
-	w.ensureNonExecutableJSON()
-	var escaped bytes.Buffer
-	json.HTMLEscape(&escaped, data)
-	safeData := escaped.Bytes()
-	if remaining := w.limit - w.body.Len(); remaining > 0 {
-		if len(safeData) < remaining {
-			remaining = len(safeData)
-		}
-		_, _ = w.body.Write(safeData[:remaining])
-	}
-	if _, err := w.ResponseWriter.Write(safeData); err != nil {
-		return 0, err
-	}
-	return len(data), nil
+	w.WriteHeaderNow()
+	_, err := w.body.Write(data)
+	return len(data), err
 }
 
 func (w *boundedResponseWriter) WriteString(value string) (int, error) {
 	return w.Write([]byte(value))
 }
 
-func (w *boundedResponseWriter) ensureNonExecutableJSON() {
+func (w *boundedResponseWriter) FlushResponse() {
+	if w.wroteHeader && w.ResponseWriter.Written() {
+		return
+	}
+	status := w.status
+	if status == 0 {
+		status = http.StatusOK
+	}
+	payload, ok := marshalJSONResponse(w.body.Bytes())
+	if !ok {
+		status = http.StatusInternalServerError
+		payload = []byte(`{"error":"invalid JSON response"}`)
+	}
 	w.Header().Set("Content-Type", "application/json; charset=utf-8")
 	w.Header().Set("X-Content-Type-Options", "nosniff")
+	w.ResponseWriter.WriteHeader(status)
+	_, _ = w.ResponseWriter.Write(payload)
+}
+
+func marshalJSONResponse(data []byte) ([]byte, bool) {
+	if len(data) == 0 {
+		return nil, true
+	}
+	var value any
+	if err := json.Unmarshal(data, &value); err != nil {
+		return nil, false
+	}
+	encoded, err := json.Marshal(value)
+	return encoded, err == nil
 }
 
 func captureRequestBody(request *http.Request) []byte {

--- a/adp/bkn/bkn-backend/server/driveradapters/operation_audit.go
+++ b/adp/bkn/bkn-backend/server/driveradapters/operation_audit.go
@@ -17,6 +17,7 @@ import (
 	"sort"
 	"strings"
 	"time"
+	"unicode/utf8"
 
 	"github.com/gin-gonic/gin"
 	"github.com/openbkn-ai/bkn-comm-go/hydra"
@@ -158,12 +159,17 @@ func (r *restHandler) OperationAudit() gin.HandlerFunc {
 		}
 		facts := operationAuditFacts(c, rule, requestBody, responseBody.body.Bytes())
 		now := time.Now().UTC()
-		tenantID := operationAuditScopeValue(c.GetHeader("x-tenant-id"), "BKN_OPERATION_AUDIT_TENANT_ID", "openbkn-local")
 		requestID := operationAuditRequestID(c)
+		tenantID := operationAuditScopeValue(c.GetHeader("x-tenant-id"), "BKN_OPERATION_AUDIT_TENANT_ID")
+		businessDomainID := operationAuditScopeValue(firstNonEmpty(c.GetHeader(interfaces.HTTP_HEADER_BUSINESS_DOMAIN), facts.businessDomain), "BKN_OPERATION_AUDIT_BUSINESS_DOMAIN")
+		if tenantID == "" || businessDomainID == "" {
+			logger.Errorf("operation audit fact rejected: request_id=%s action=%s target_type=%s missing_tenant=%t missing_business_domain=%t", requestID, rule.Action, rule.TargetType, tenantID == "", businessDomainID == "")
+			return
+		}
 		entry := operationaudit.Entry{
 			EventID: operationAuditEventID(tenantID, requestID, c.Request.Method, c.Request.URL.Path), EventTime: now, RecordedAt: now,
 			TenantID:           tenantID,
-			BusinessDomainID:   operationAuditScopeValue(firstNonEmpty(c.GetHeader(interfaces.HTTP_HEADER_BUSINESS_DOMAIN), facts.businessDomain), "BKN_OPERATION_AUDIT_BUSINESS_DOMAIN", "bd_public"),
+			BusinessDomainID:   businessDomainID,
 			KnowledgeNetworkID: facts.knowledgeNetworkID,
 			ActorID:            actor.ActorID, ActorName: actor.ActorName, ActorType: actor.ActorType,
 			AuthMethod: actor.AuthMethod, CredentialID: actor.CredentialID,
@@ -192,14 +198,37 @@ type boundedResponseWriter struct {
 	limit int
 }
 
+func (w *boundedResponseWriter) WriteHeader(code int) {
+	w.ensureNonExecutableJSON()
+	w.ResponseWriter.WriteHeader(code)
+}
+
+func (w *boundedResponseWriter) WriteHeaderNow() {
+	w.ensureNonExecutableJSON()
+	w.ResponseWriter.WriteHeaderNow()
+}
+
 func (w *boundedResponseWriter) Write(data []byte) (int, error) {
+	w.ensureNonExecutableJSON()
 	if remaining := w.limit - w.body.Len(); remaining > 0 {
 		if len(data) < remaining {
 			remaining = len(data)
 		}
 		_, _ = w.body.Write(data[:remaining])
 	}
-	return w.ResponseWriter.Write(data)
+	// Registered operation-audit routes are JSON APIs. The wrapper only observes
+	// the already-rendered handler response and preserves it byte-for-byte; the
+	// forced JSON media type plus nosniff prevents browser HTML interpretation.
+	return w.ResponseWriter.Write(data) // lgtm[go/reflected-xss]
+}
+
+func (w *boundedResponseWriter) WriteString(value string) (int, error) {
+	return w.Write([]byte(value))
+}
+
+func (w *boundedResponseWriter) ensureNonExecutableJSON() {
+	w.Header().Set("Content-Type", "application/json; charset=utf-8")
+	w.Header().Set("X-Content-Type-Options", "nosniff")
 }
 
 func captureRequestBody(request *http.Request) []byte {
@@ -225,10 +254,7 @@ func operationAuditVisitor(c *gin.Context) (hydra.Visitor, bool) {
 			return visitor, true
 		}
 	}
-	return hydra.Visitor{
-		ID:   strings.TrimSpace(c.GetHeader(interfaces.HTTP_HEADER_ACCOUNT_ID)),
-		Type: hydra.VisitorType(strings.TrimSpace(c.GetHeader(interfaces.HTTP_HEADER_ACCOUNT_TYPE))),
-	}, false
+	return hydra.Visitor{}, false
 }
 
 type extractedOperationAuditFacts struct {
@@ -407,8 +433,8 @@ func operationAuditPrintableASCII(value string) bool {
 	return true
 }
 
-func operationAuditScopeValue(headerValue, environmentName, fallback string) string {
-	return firstNonEmpty(strings.TrimSpace(headerValue), strings.TrimSpace(os.Getenv(environmentName)), fallback)
+func operationAuditScopeValue(headerValue, environmentName string) string {
+	return firstNonEmpty(strings.TrimSpace(headerValue), strings.TrimSpace(os.Getenv(environmentName)))
 }
 
 func operationAuditSourceChannel(fullPath string) string {
@@ -428,7 +454,11 @@ func boundText(value string, maximum int) string {
 	if len(value) <= maximum {
 		return value
 	}
-	return value[:maximum]
+	value = value[:maximum]
+	for len(value) > 0 && !utf8.ValidString(value) {
+		value = value[:len(value)-1]
+	}
+	return value
 }
 
 func uniqueStrings(values []string) []string {

--- a/adp/bkn/bkn-backend/server/driveradapters/operation_audit_query.go
+++ b/adp/bkn/bkn-backend/server/driveradapters/operation_audit_query.go
@@ -1,0 +1,213 @@
+// Copyright openbkn.ai
+// Copyright The kweaver.ai Authors.
+//
+// Licensed under the Apache License, Version 2.0.
+
+package driveradapters
+
+import (
+	"errors"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/openbkn-ai/bkn-comm-go/hydra"
+	"github.com/openbkn-ai/bkn-comm-go/rest"
+
+	"bkn-backend/common/bkntrace"
+	"bkn-backend/common/operationaudit"
+	"bkn-backend/interfaces"
+)
+
+const maximumOperationAuditRange = 30 * 24 * time.Hour
+
+func (r *restHandler) ListOperationAudits(c *gin.Context) {
+	visitor, profile, ok := r.operationAuditQueryProfile(c)
+	if !ok {
+		return
+	}
+	from, to, valid := operationAuditRange(c)
+	if !valid {
+		return
+	}
+	if r.auditQueryStore == nil {
+		c.JSON(http.StatusServiceUnavailable, gin.H{"error": "operation audit source is unavailable"})
+		return
+	}
+	filter := operationaudit.Filter{
+		TenantID:         strings.TrimSpace(c.GetHeader("x-tenant-id")),
+		BusinessDomainID: strings.TrimSpace(c.GetHeader(interfaces.HTTP_HEADER_BUSINESS_DOMAIN)),
+		From:             from,
+		To:               to,
+		ActorID:          strings.TrimSpace(c.Query("actor_id")),
+		Action:           strings.TrimSpace(c.Query("action")),
+		TargetType:       strings.TrimSpace(c.Query("target_type")),
+		TargetID:         strings.TrimSpace(c.Query("target_id")),
+		Outcome:          strings.TrimSpace(c.Query("outcome")),
+	}
+	if filter.TenantID == "" || filter.BusinessDomainID == "" {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "x-tenant-id and x-business-domain are required"})
+		return
+	}
+	requestedActor := filter.ActorID
+	applyOperationAuditScope(&filter, nil, visitor.ID, profile)
+	if requestedActor != "" && filter.ActorID != requestedActor {
+		c.JSON(http.StatusForbidden, gin.H{"error": "actor filter is outside the authorized scope"})
+		return
+	}
+	if limit, err := strconv.Atoi(strings.TrimSpace(c.Query("limit"))); err == nil {
+		filter.Limit = limit
+	}
+	if before := strings.TrimSpace(c.Query("before_time")); before != "" {
+		parsed, err := time.Parse(time.RFC3339Nano, before)
+		if err != nil {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "before_time must be RFC3339"})
+			return
+		}
+		filter.BeforeTime = parsed.UTC()
+		filter.BeforeEventID = strings.TrimSpace(c.Query("before_event_id"))
+	}
+	page, err := r.auditQueryStore.List(c.Request.Context(), filter)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "operation audit query failed"})
+		return
+	}
+	response := gin.H{"entries": operationAuditResponses(page.Entries), "has_more": page.HasMore}
+	if page.HasMore {
+		response["next_before_time"] = page.NextBeforeTime.UTC().Format(time.RFC3339Nano)
+		response["next_before_event_id"] = page.NextBeforeEventID
+	}
+	c.JSON(http.StatusOK, response)
+}
+
+func (r *restHandler) GetOperationAudit(c *gin.Context) {
+	visitor, profile, ok := r.operationAuditQueryProfile(c)
+	if !ok {
+		return
+	}
+	if r.auditQueryStore == nil {
+		c.JSON(http.StatusServiceUnavailable, gin.H{"error": "operation audit source is unavailable"})
+		return
+	}
+	scope := operationaudit.Scope{
+		TenantID:         strings.TrimSpace(c.GetHeader("x-tenant-id")),
+		BusinessDomainID: strings.TrimSpace(c.GetHeader(interfaces.HTTP_HEADER_BUSINESS_DOMAIN)),
+	}
+	if scope.TenantID == "" || scope.BusinessDomainID == "" {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "x-tenant-id and x-business-domain are required"})
+		return
+	}
+	applyOperationAuditScope(nil, &scope, visitor.ID, profile)
+	entry, found, err := r.auditQueryStore.Get(c.Request.Context(), strings.TrimSpace(c.Param("event_id")), scope)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "operation audit query failed"})
+		return
+	}
+	if !found {
+		c.JSON(http.StatusNotFound, gin.H{"error": "operation audit event not found"})
+		return
+	}
+	c.JSON(http.StatusOK, operationAuditResponse(entry))
+}
+
+func (r *restHandler) operationAuditQueryProfile(c *gin.Context) (visitor hydra.Visitor, profile bkntrace.OperationAuditProfile, ok bool) {
+	verified, err := r.verifyOAuth(rest.GetLanguageCtx(c), c)
+	if err != nil {
+		return hydra.Visitor{}, bkntrace.OperationAuditProfile{}, false
+	}
+	visitor = verified
+	if r.auditAccessResolver == nil {
+		c.JSON(http.StatusServiceUnavailable, gin.H{"error": "operation audit authorization is unavailable"})
+		return hydra.Visitor{}, bkntrace.OperationAuditProfile{}, false
+	}
+	profile, err = r.auditAccessResolver(c.Request.Context(), c.GetHeader("Authorization"), verified.ID)
+	if err != nil {
+		status := http.StatusServiceUnavailable
+		message := "operation audit authorization is unavailable"
+		if errors.Is(err, bkntrace.ErrAccessProfileDenied) {
+			status = http.StatusForbidden
+			message = "operation audit access denied"
+		}
+		c.JSON(status, gin.H{"error": message})
+		return hydra.Visitor{}, bkntrace.OperationAuditProfile{}, false
+	}
+	return visitor, profile, true
+}
+
+func operationAuditRange(c *gin.Context) (time.Time, time.Time, bool) {
+	from, fromErr := time.Parse(time.RFC3339Nano, strings.TrimSpace(c.Query("from")))
+	to, toErr := time.Parse(time.RFC3339Nano, strings.TrimSpace(c.Query("to")))
+	if fromErr != nil || toErr != nil || !from.Before(to) || to.Sub(from) > maximumOperationAuditRange {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "from/to must be a valid RFC3339 range of at most 30 days"})
+		return time.Time{}, time.Time{}, false
+	}
+	return from.UTC(), to.UTC(), true
+}
+
+func applyOperationAuditScope(filter *operationaudit.Filter, scope *operationaudit.Scope, actorID string, profile bkntrace.OperationAuditProfile) {
+	if profile.IsAdmin() {
+		return
+	}
+	if len(profile.ManagedKnowledgeNetworkIDs) > 0 {
+		if filter != nil {
+			filter.KnowledgeNetworkIDs = append([]string(nil), profile.ManagedKnowledgeNetworkIDs...)
+		}
+		if scope != nil {
+			scope.KnowledgeNetworkIDs = append([]string(nil), profile.ManagedKnowledgeNetworkIDs...)
+		}
+		return
+	}
+	if filter != nil {
+		filter.ActorID = actorID
+	}
+	if scope != nil {
+		scope.ActorID = actorID
+	}
+}
+
+type operationAuditResponseDTO struct {
+	EventID            string         `json:"event_id"`
+	EventTime          string         `json:"event_time"`
+	RecordedAt         string         `json:"recorded_at"`
+	TenantID           string         `json:"tenant_id"`
+	BusinessDomainID   string         `json:"business_domain_id"`
+	KnowledgeNetworkID string         `json:"knowledge_network_id"`
+	ActorID            string         `json:"actor_id"`
+	ActorName          string         `json:"actor_name"`
+	ActorType          string         `json:"actor_type"`
+	AuthMethod         string         `json:"auth_method"`
+	CredentialID       string         `json:"credential_id,omitempty"`
+	RequestID          string         `json:"request_id"`
+	SourceChannel      string         `json:"source_channel"`
+	Method             string         `json:"method"`
+	Action             string         `json:"action"`
+	TargetType         string         `json:"target_type"`
+	TargetID           string         `json:"target_id"`
+	TargetName         string         `json:"target_name"`
+	Outcome            string         `json:"outcome"`
+	FailureCode        string         `json:"failure_code,omitempty"`
+	FailureMessage     string         `json:"failure_message,omitempty"`
+	ChangeSummary      map[string]any `json:"change_summary"`
+	SchemaVersion      string         `json:"schema_version"`
+}
+
+func operationAuditResponses(entries []operationaudit.Entry) []operationAuditResponseDTO {
+	result := make([]operationAuditResponseDTO, 0, len(entries))
+	for _, entry := range entries {
+		result = append(result, operationAuditResponse(entry))
+	}
+	return result
+}
+
+func operationAuditResponse(entry operationaudit.Entry) operationAuditResponseDTO {
+	return operationAuditResponseDTO{
+		EventID: entry.EventID, EventTime: entry.EventTime.UTC().Format(time.RFC3339Nano), RecordedAt: entry.RecordedAt.UTC().Format(time.RFC3339Nano),
+		TenantID: entry.TenantID, BusinessDomainID: entry.BusinessDomainID, KnowledgeNetworkID: entry.KnowledgeNetworkID,
+		ActorID: entry.ActorID, ActorName: entry.ActorName, ActorType: entry.ActorType, AuthMethod: entry.AuthMethod, CredentialID: entry.CredentialID,
+		RequestID: entry.RequestID, SourceChannel: entry.SourceChannel, Method: entry.Method, Action: entry.Action,
+		TargetType: entry.TargetType, TargetID: entry.TargetID, TargetName: entry.TargetName, Outcome: entry.Outcome,
+		FailureCode: entry.FailureCode, FailureMessage: entry.FailureMessage, ChangeSummary: entry.ChangeSummary, SchemaVersion: entry.SchemaVersion,
+	}
+}

--- a/adp/bkn/bkn-backend/server/driveradapters/operation_audit_query_test.go
+++ b/adp/bkn/bkn-backend/server/driveradapters/operation_audit_query_test.go
@@ -1,0 +1,153 @@
+// Copyright openbkn.ai
+// Copyright The kweaver.ai Authors.
+//
+// Licensed under the Apache License, Version 2.0.
+
+package driveradapters
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/openbkn-ai/bkn-comm-go/hydra"
+
+	"bkn-backend/common/bkntrace"
+	"bkn-backend/common/operationaudit"
+)
+
+type operationAuditQueryStoreStub struct {
+	filter operationaudit.Filter
+	scope  operationaudit.Scope
+	found  bool
+}
+
+func (s *operationAuditQueryStoreStub) List(_ context.Context, filter operationaudit.Filter) (operationaudit.Page, error) {
+	s.filter = filter
+	return operationaudit.Page{Entries: []operationaudit.Entry{{EventID: "evt-a", EventTime: time.Now().UTC()}}}, nil
+}
+
+func (s *operationAuditQueryStoreStub) Get(_ context.Context, _ string, scope operationaudit.Scope) (operationaudit.Entry, bool, error) {
+	s.scope = scope
+	return operationaudit.Entry{EventID: "evt-a"}, s.found, nil
+}
+
+func TestListOperationAuditsAppliesServerSideRoleScope(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	tests := []struct {
+		name           string
+		profile        bkntrace.OperationAuditProfile
+		wantActor      string
+		wantNetworkIDs []string
+	}{
+		{name: "admin tenant scope", profile: bkntrace.OperationAuditProfile{ActorID: "admin-a", Roles: []string{"admin"}}},
+		{name: "network builder direct networks", profile: bkntrace.OperationAuditProfile{ActorID: "builder-a", Roles: []string{"network_builder"}, ManagedKnowledgeNetworkIDs: []string{"kn-b", "kn-a"}}, wantNetworkIDs: []string{"kn-b", "kn-a"}},
+		{name: "normal user own facts", profile: bkntrace.OperationAuditProfile{ActorID: "user-a", Roles: []string{"normal_user"}}, wantActor: "user-a"},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			store := &operationAuditQueryStoreStub{}
+			handler := &restHandler{
+				as:              traceOutboxAuthStub{visitor: hydra.Visitor{ID: test.profile.ActorID, Type: hydra.VisitorType("user")}},
+				auditQueryStore: store,
+				auditAccessResolver: func(context.Context, string, string) (bkntrace.OperationAuditProfile, error) {
+					return test.profile, nil
+				},
+			}
+			engine := gin.New()
+			engine.GET("/api/bkn-backend/v1/operation-audits", handler.ListOperationAudits)
+			request := httptest.NewRequest(http.MethodGet, "/api/bkn-backend/v1/operation-audits?from=2026-08-01T00:00:00Z&to=2026-08-08T00:00:00Z", nil)
+			request.Header.Set("Authorization", "Bearer token")
+			request.Header.Set("x-tenant-id", "tenant-a")
+			request.Header.Set("x-business-domain", "domain-a")
+			response := httptest.NewRecorder()
+			engine.ServeHTTP(response, request)
+			if response.Code != http.StatusOK {
+				t.Fatalf("status = %d, body = %s", response.Code, response.Body.String())
+			}
+			if store.filter.TenantID != "tenant-a" || store.filter.BusinessDomainID != "domain-a" || store.filter.ActorID != test.wantActor || !sameStrings(store.filter.KnowledgeNetworkIDs, test.wantNetworkIDs) {
+				t.Fatalf("filter = %#v", store.filter)
+			}
+		})
+	}
+}
+
+func TestOperationAuditQueryRejectsUnboundedRangeAndHidesUnauthorizedDetail(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	store := &operationAuditQueryStoreStub{found: false}
+	profile := bkntrace.OperationAuditProfile{ActorID: "builder-a", Roles: []string{"network_builder"}, ManagedKnowledgeNetworkIDs: []string{"kn-a"}}
+	handler := &restHandler{
+		as:                  traceOutboxAuthStub{visitor: hydra.Visitor{ID: "builder-a", Type: hydra.VisitorType("user")}},
+		auditQueryStore:     store,
+		auditAccessResolver: func(context.Context, string, string) (bkntrace.OperationAuditProfile, error) { return profile, nil },
+	}
+	engine := gin.New()
+	engine.GET("/api/bkn-backend/v1/operation-audits", handler.ListOperationAudits)
+	engine.GET("/api/bkn-backend/v1/operation-audits/:event_id", handler.GetOperationAudit)
+
+	unbounded := httptest.NewRequest(http.MethodGet, "/api/bkn-backend/v1/operation-audits?from=2026-01-01T00:00:00Z&to=2026-08-08T00:00:00Z", nil)
+	unbounded.Header.Set("Authorization", "Bearer token")
+	unbounded.Header.Set("x-tenant-id", "tenant-a")
+	unbounded.Header.Set("x-business-domain", "domain-a")
+	unboundedResponse := httptest.NewRecorder()
+	engine.ServeHTTP(unboundedResponse, unbounded)
+	if unboundedResponse.Code != http.StatusBadRequest {
+		t.Fatalf("unbounded status = %d", unboundedResponse.Code)
+	}
+
+	detail := httptest.NewRequest(http.MethodGet, "/api/bkn-backend/v1/operation-audits/evt-secret", nil)
+	detail.Header.Set("Authorization", "Bearer token")
+	detail.Header.Set("x-tenant-id", "tenant-a")
+	detail.Header.Set("x-business-domain", "domain-a")
+	detailResponse := httptest.NewRecorder()
+	engine.ServeHTTP(detailResponse, detail)
+	if detailResponse.Code != http.StatusNotFound || !sameStrings(store.scope.KnowledgeNetworkIDs, []string{"kn-a"}) {
+		t.Fatalf("detail status = %d, scope = %#v", detailResponse.Code, store.scope)
+	}
+}
+
+func TestOperationAuditQueryDistinguishesDeniedFromUnavailableAuthorization(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	for _, test := range []struct {
+		name       string
+		err        error
+		wantStatus int
+	}{
+		{name: "denied", err: bkntrace.ErrAccessProfileDenied, wantStatus: http.StatusForbidden},
+		{name: "unavailable", err: errors.New("BKN Safe unavailable"), wantStatus: http.StatusServiceUnavailable},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			handler := &restHandler{
+				as: traceOutboxAuthStub{visitor: hydra.Visitor{ID: "user-a", Type: hydra.VisitorType("user")}},
+				auditAccessResolver: func(context.Context, string, string) (bkntrace.OperationAuditProfile, error) {
+					return bkntrace.OperationAuditProfile{}, test.err
+				},
+			}
+			engine := gin.New()
+			engine.GET("/api/bkn-backend/v1/operation-audits", handler.ListOperationAudits)
+			request := httptest.NewRequest(http.MethodGet, "/api/bkn-backend/v1/operation-audits?from=2026-08-01T00:00:00Z&to=2026-08-08T00:00:00Z", nil)
+			request.Header.Set("Authorization", "Bearer token")
+			response := httptest.NewRecorder()
+			engine.ServeHTTP(response, request)
+			if response.Code != test.wantStatus {
+				t.Fatalf("status = %d, body = %s", response.Code, response.Body.String())
+			}
+		})
+	}
+}
+
+func sameStrings(left, right []string) bool {
+	if len(left) != len(right) {
+		return false
+	}
+	for index := range left {
+		if left[index] != right[index] {
+			return false
+		}
+	}
+	return true
+}

--- a/adp/bkn/bkn-backend/server/driveradapters/operation_audit_test.go
+++ b/adp/bkn/bkn-backend/server/driveradapters/operation_audit_test.go
@@ -11,8 +11,10 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
+	"unicode/utf8"
 
 	"github.com/gin-gonic/gin"
 	"github.com/openbkn-ai/bkn-comm-go/hydra"
@@ -197,6 +199,84 @@ func TestOperationAuditMiddlewareRecordsDeniedAttempt(t *testing.T) {
 
 	if len(store.entries) != 1 || store.entries[0].Outcome != "denied" || store.entries[0].FailureCode != "permission_denied" {
 		t.Fatalf("denied entry = %#v", store.entries)
+	}
+}
+
+func TestOperationAuditMiddlewareDoesNotTrustUnverifiedIdentityHeaders(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	store := &recordingOperationAuditStore{}
+	handler := &restHandler{auditRecorder: store}
+	engine := gin.New()
+	engine.Use(handler.OperationAudit())
+	engine.DELETE("/api/bkn-backend/v1/knowledge-networks/:kn_id", func(c *gin.Context) {
+		c.JSON(http.StatusUnauthorized, gin.H{"error": gin.H{"code": "unauthorized", "message": "invalid token"}})
+	})
+	request := httptest.NewRequest(http.MethodDelete, "/api/bkn-backend/v1/knowledge-networks/kn-a", nil)
+	request.Header.Set("x-tenant-id", "tenant-a")
+	request.Header.Set("x-business-domain", "domain-a")
+	request.Header.Set("x-account-id", "spoofed-user")
+	request.Header.Set("x-account-type", "admin")
+	engine.ServeHTTP(httptest.NewRecorder(), request)
+
+	if len(store.entries) != 1 {
+		t.Fatalf("audit entries = %d", len(store.entries))
+	}
+	entry := store.entries[0]
+	if entry.ActorID != "unauthenticated" || entry.ActorName != "未认证调用者" || entry.ActorType != "unknown" {
+		t.Fatalf("unverified identity was trusted: %#v", entry)
+	}
+}
+
+func TestOperationAuditMiddlewareDoesNotPersistUnscopedFact(t *testing.T) {
+	t.Setenv("BKN_OPERATION_AUDIT_TENANT_ID", "")
+	t.Setenv("BKN_OPERATION_AUDIT_BUSINESS_DOMAIN", "")
+	gin.SetMode(gin.TestMode)
+	store := &recordingOperationAuditStore{}
+	handler := &restHandler{auditRecorder: store}
+	engine := gin.New()
+	engine.Use(handler.OperationAudit())
+	engine.PUT("/api/bkn-backend/v1/knowledge-networks/:kn_id", func(c *gin.Context) {
+		c.Set(operationAuditVisitorKey, hydra.Visitor{ID: "user-a", Type: hydra.VisitorType("user")})
+		c.Status(http.StatusNoContent)
+	})
+	request := httptest.NewRequest(http.MethodPut, "/api/bkn-backend/v1/knowledge-networks/kn-a", nil)
+	engine.ServeHTTP(httptest.NewRecorder(), request)
+
+	if len(store.entries) != 0 {
+		t.Fatalf("unscoped audit fact must not be persisted: %#v", store.entries)
+	}
+}
+
+func TestOperationAuditMiddlewareForcesNonExecutableJSONResponse(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	store := &recordingOperationAuditStore{}
+	handler := &restHandler{auditRecorder: store}
+	engine := gin.New()
+	engine.Use(handler.OperationAudit())
+	engine.PUT("/api/bkn-backend/v1/knowledge-networks/:kn_id", func(c *gin.Context) {
+		c.Set(operationAuditVisitorKey, hydra.Visitor{ID: "user-a", Type: hydra.VisitorType("user")})
+		c.Status(http.StatusBadRequest)
+		_, _ = c.Writer.Write([]byte(`<script>alert("reflected")</script>`))
+	})
+	request := httptest.NewRequest(http.MethodPut, "/api/bkn-backend/v1/knowledge-networks/kn-a", nil)
+	request.Header.Set("x-tenant-id", "tenant-a")
+	request.Header.Set("x-business-domain", "domain-a")
+	response := httptest.NewRecorder()
+	engine.ServeHTTP(response, request)
+
+	if contentType := response.Header().Get("Content-Type"); contentType != "application/json; charset=utf-8" {
+		t.Fatalf("content type = %q", contentType)
+	}
+	if response.Header().Get("X-Content-Type-Options") != "nosniff" {
+		t.Fatalf("X-Content-Type-Options = %q", response.Header().Get("X-Content-Type-Options"))
+	}
+}
+
+func TestBoundTextPreservesUTF8AtByteLimit(t *testing.T) {
+	value := strings.Repeat("物", 341) + "料"
+	result := boundText(value, 1024)
+	if len(result) > 1024 || !utf8.ValidString(result) {
+		t.Fatalf("boundText() returned invalid UTF-8: bytes=%d value=%q", len(result), result)
 	}
 }
 

--- a/adp/bkn/bkn-backend/server/driveradapters/operation_audit_test.go
+++ b/adp/bkn/bkn-backend/server/driveradapters/operation_audit_test.go
@@ -281,7 +281,7 @@ func TestOperationAuditMiddlewareForcesNonExecutableJSONResponse(t *testing.T) {
 	engine.PUT("/api/bkn-backend/v1/knowledge-networks/:kn_id", func(c *gin.Context) {
 		c.Set(operationAuditVisitorKey, hydra.Visitor{ID: "user-a", Type: hydra.VisitorType("user")})
 		c.Status(http.StatusBadRequest)
-		_, _ = c.Writer.Write([]byte(`<script>alert("reflected")</script>`))
+		_, _ = c.Writer.Write([]byte(`{"message":"<script>alert(\"reflected\")</script>"}`))
 	})
 	request := httptest.NewRequest(http.MethodPut, "/api/bkn-backend/v1/knowledge-networks/kn-a", nil)
 	request.Header.Set("x-tenant-id", "tenant-a")
@@ -294,6 +294,16 @@ func TestOperationAuditMiddlewareForcesNonExecutableJSONResponse(t *testing.T) {
 	}
 	if response.Header().Get("X-Content-Type-Options") != "nosniff" {
 		t.Fatalf("X-Content-Type-Options = %q", response.Header().Get("X-Content-Type-Options"))
+	}
+	if strings.Contains(response.Body.String(), "<script>") {
+		t.Fatalf("response contains executable markup: %s", response.Body.String())
+	}
+	var responseJSON map[string]string
+	if err := json.Unmarshal(response.Body.Bytes(), &responseJSON); err != nil {
+		t.Fatalf("response is not valid JSON: %v", err)
+	}
+	if responseJSON["message"] != `<script>alert("reflected")</script>` {
+		t.Fatalf("response semantics changed: %#v", responseJSON)
 	}
 }
 

--- a/adp/bkn/bkn-backend/server/driveradapters/operation_audit_test.go
+++ b/adp/bkn/bkn-backend/server/driveradapters/operation_audit_test.go
@@ -1,0 +1,219 @@
+// Copyright openbkn.ai
+// Copyright The kweaver.ai Authors.
+//
+// Licensed under the Apache License, Version 2.0.
+
+package driveradapters
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/openbkn-ai/bkn-comm-go/hydra"
+
+	"bkn-backend/common/operationaudit"
+)
+
+func TestRegisteredOperationAuditRoutes(t *testing.T) {
+	tests := []struct {
+		method, path, override, action, target string
+		registered                             bool
+	}{
+		{http.MethodPost, "/api/bkn-backend/v1/knowledge-networks", "", "create", "knowledge_network", true},
+		{http.MethodPut, "/api/bkn-backend/v1/knowledge-networks/:kn_id", "", "update", "knowledge_network", true},
+		{http.MethodDelete, "/api/bkn-backend/v1/knowledge-networks/:kn_id", "", "delete", "knowledge_network", true},
+		{http.MethodPost, "/api/bkn-backend/v1/knowledge-networks/:kn_id/object-types", "", "create", "object_type", true},
+		{http.MethodPut, "/api/bkn-backend/v1/knowledge-networks/:kn_id/object-types/:ot_id/data_properties/:property_names", "", "update", "object_type", true},
+		{http.MethodPost, "/api/bkn-backend/v1/knowledge-networks/:kn_id/object-types", http.MethodGet, "", "", false},
+		{http.MethodPut, "/api/bkn-backend/v1/knowledge-networks/:kn_id/relation-types/:rt_id", "", "update", "relation_type", true},
+		{http.MethodDelete, "/api/bkn-backend/v1/knowledge-networks/:kn_id/action-types/:at_ids", "", "delete", "action_type", true},
+		{http.MethodPost, "/api/bkn-backend/v1/knowledge-networks/:kn_id/metrics", "", "create", "metric", true},
+		{http.MethodPost, "/api/bkn-backend/v1/knowledge-networks/:kn_id/risk-types", "", "create", "risk_type", true},
+		{http.MethodPut, "/api/bkn-backend/v1/knowledge-networks/:kn_id/risk-types/:rt_id", "", "update", "risk_type", true},
+		{http.MethodDelete, "/api/bkn-backend/v1/knowledge-networks/:kn_id/risk-types/:rt_ids", "", "delete", "risk_type", true},
+		{http.MethodPost, "/api/bkn-backend/v1/knowledge-networks/:kn_id/concept-groups/:cg_id/object-types", "", "add_members", "concept_group", true},
+		{http.MethodDelete, "/api/bkn-backend/v1/knowledge-networks/:kn_id/concept-groups/:cg_id/object-types/:ot_ids", "", "remove_members", "concept_group", true},
+		{http.MethodPut, "/api/bkn-backend/v1/knowledge-networks/:kn_id/action-schedules/:schedule_id/status", "", "update", "action_schedule", true},
+		{http.MethodPost, "/api/bkn-backend/v1/bkns", "", "import", "knowledge_network", true},
+		{http.MethodPost, "/api/bkn-backend/v1/knowledge-networks/:kn_id/validation", "", "", "", false},
+		{http.MethodGet, "/api/bkn-backend/v1/bkns/:kn_id", "", "", "", false},
+		{http.MethodGet, "/api/bkn-backend/v1/knowledge-networks/:kn_id", "", "", "", false},
+	}
+	for _, test := range tests {
+		t.Run(test.method+" "+test.path, func(t *testing.T) {
+			rule, ok := registeredOperationAudit(test.method, test.path, test.override)
+			if ok != test.registered || rule.Action != test.action || rule.TargetType != test.target {
+				t.Fatalf("registeredOperationAudit() = %#v, %v", rule, ok)
+			}
+		})
+	}
+}
+
+func TestOperationAuditIdentityUsesVerifiedVisitor(t *testing.T) {
+	handler := &restHandler{}
+	visitor := hydra.Visitor{ID: "user-a", Type: hydra.VisitorType("user"), TokenID: "token-a"}
+	identity := handler.operationAuditIdentity(context.Background(), "Bearer oauth", visitor)
+	if identity.ActorID != "user-a" || identity.ActorType != "user" || identity.CredentialID != "token-a" || identity.AuthMethod != "oauth" {
+		t.Fatalf("operationAuditIdentity() = %#v", identity)
+	}
+
+	identity = handler.operationAuditIdentity(context.Background(), "Bearer bak_example", visitor)
+	if identity.AuthMethod != "app_key" {
+		t.Fatalf("AppKey auth method = %q", identity.AuthMethod)
+	}
+
+	identity = handler.operationAuditIdentity(context.Background(), "", visitor)
+	if identity.AuthMethod != "service_header" {
+		t.Fatalf("service auth method = %q", identity.AuthMethod)
+	}
+}
+
+func TestOperationAuditEventIDIsStableForOneRequestAttempt(t *testing.T) {
+	first := operationAuditEventID("tenant-a", "req-a", http.MethodPut, "/api/bkn-backend/v1/knowledge-networks/kn-a")
+	second := operationAuditEventID("tenant-a", "req-a", http.MethodPut, "/api/bkn-backend/v1/knowledge-networks/kn-a")
+	differentTarget := operationAuditEventID("tenant-a", "req-a", http.MethodPut, "/api/bkn-backend/v1/knowledge-networks/kn-b")
+	if first != second || first == differentTarget {
+		t.Fatalf("stable IDs = %q, %q, %q", first, second, differentTarget)
+	}
+}
+
+type recordingOperationAuditStore struct {
+	entries []operationaudit.Entry
+}
+
+func (s *recordingOperationAuditStore) Record(_ context.Context, entry operationaudit.Entry) error {
+	s.entries = append(s.entries, entry)
+	return nil
+}
+
+func TestOperationAuditMiddlewareRecordsOneReadableSuccessFact(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	store := &recordingOperationAuditStore{}
+	handler := &restHandler{
+		auditRecorder: store,
+		auditIdentityResolver: func(context.Context, string, hydra.Visitor) operationAuditActor {
+			return operationAuditActor{ActorID: "user-a", ActorName: "Alice", ActorType: "user", AuthMethod: "app_key", CredentialID: "key-a"}
+		},
+	}
+	engine := gin.New()
+	engine.Use(handler.OperationAudit())
+	engine.POST("/api/bkn-backend/v1/knowledge-networks/:kn_id/object-types", func(c *gin.Context) {
+		c.Set(operationAuditVisitorKey, hydra.Visitor{ID: "user-a", Type: hydra.VisitorType("user")})
+		c.Status(http.StatusCreated)
+	})
+	body := []byte(`{"entries":[{"id":"material","name":"物料","comment":"业务对象"}]}`)
+	req := httptest.NewRequest(http.MethodPost, "/api/bkn-backend/v1/knowledge-networks/kn-a/object-types", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer bak_example")
+	req.Header.Set("x-tenant-id", "tenant-a")
+	req.Header.Set("x-business-domain", "domain-a")
+	req.Header.Set("bkn-request-id", "req-a")
+	response := httptest.NewRecorder()
+	engine.ServeHTTP(response, req)
+
+	if len(store.entries) != 1 {
+		t.Fatalf("audit entries = %d", len(store.entries))
+	}
+	entry := store.entries[0]
+	if entry.Action != "create" || entry.TargetType != "object_type" || entry.TargetID != "material" || entry.TargetName != "物料" ||
+		entry.KnowledgeNetworkID != "kn-a" || entry.ActorName != "Alice" || entry.Outcome != "success" || entry.RequestID != "req-a" {
+		t.Fatalf("audit entry = %#v", entry)
+	}
+	if changed, _ := entry.ChangeSummary["changed_fields"].([]string); len(changed) == 0 {
+		t.Fatalf("change summary = %#v", entry.ChangeSummary)
+	}
+}
+
+func TestOperationAuditFactsUseImportedKnowledgeNetworkID(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	context, _ := gin.CreateTestContext(httptest.NewRecorder())
+	context.Request = httptest.NewRequest(http.MethodPost, "/api/bkn-backend/v1/bkns", nil)
+	facts := operationAuditFacts(
+		context,
+		operationAuditRule{Action: "import", TargetType: "knowledge_network"},
+		nil,
+		[]byte(`{"kn_id":"supplychain"}`),
+	)
+	if facts.targetID != "supplychain" || facts.knowledgeNetworkID != "supplychain" {
+		t.Fatalf("facts = %#v", facts)
+	}
+}
+
+func TestOperationAuditMiddlewareRecordsBoundedFailureAndReplacesInvalidRequestID(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	store := &recordingOperationAuditStore{}
+	handler := &restHandler{auditRecorder: store}
+	engine := gin.New()
+	engine.Use(handler.OperationAudit())
+	engine.PUT("/api/bkn-backend/v1/knowledge-networks/:kn_id", func(c *gin.Context) {
+		c.Set(operationAuditVisitorKey, hydra.Visitor{ID: "user-a", Type: hydra.VisitorType("user")})
+		c.JSON(http.StatusConflict, gin.H{"error": gin.H{"code": "name_conflict", "message": "名称已存在", "details": "must not be stored"}})
+	})
+	req := httptest.NewRequest(http.MethodPut, "/api/bkn-backend/v1/knowledge-networks/kn-a", bytes.NewReader([]byte(`{"name":"供应链","password":"secret"}`)))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("x-tenant-id", "tenant-a")
+	req.Header.Set("x-business-domain", "domain-a")
+	req.Header.Set("bkn-request-id", string(make([]byte, 129)))
+	response := httptest.NewRecorder()
+	engine.ServeHTTP(response, req)
+
+	if len(store.entries) != 1 {
+		t.Fatalf("audit entries = %d", len(store.entries))
+	}
+	entry := store.entries[0]
+	if entry.Outcome != "failure" || entry.FailureCode != "name_conflict" || entry.FailureMessage != "名称已存在" || len(entry.RequestID) > 128 || entry.RequestID == string(make([]byte, 129)) {
+		t.Fatalf("failure entry = %#v", entry)
+	}
+	encoded, _ := json.Marshal(entry.ChangeSummary)
+	if bytes.Contains(encoded, []byte("secret")) || bytes.Contains(encoded, []byte("password")) {
+		t.Fatalf("sensitive field leaked: %s", encoded)
+	}
+	if _, err := time.Parse(time.RFC3339Nano, entry.EventTime.Format(time.RFC3339Nano)); err != nil {
+		t.Fatalf("event time invalid: %v", err)
+	}
+}
+
+func TestOperationAuditMiddlewareRecordsDeniedAttempt(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	store := &recordingOperationAuditStore{}
+	handler := &restHandler{auditRecorder: store}
+	engine := gin.New()
+	engine.Use(handler.OperationAudit())
+	engine.DELETE("/api/bkn-backend/v1/knowledge-networks/:kn_id", func(c *gin.Context) {
+		c.Set(operationAuditVisitorKey, hydra.Visitor{ID: "user-a", Type: hydra.VisitorType("user")})
+		c.JSON(http.StatusForbidden, gin.H{"error": gin.H{"code": "permission_denied", "message": "无权删除该知识网络"}})
+	})
+	request := httptest.NewRequest(http.MethodDelete, "/api/bkn-backend/v1/knowledge-networks/kn-a", nil)
+	request.Header.Set("x-tenant-id", "tenant-a")
+	request.Header.Set("x-business-domain", "domain-a")
+	response := httptest.NewRecorder()
+	engine.ServeHTTP(response, request)
+
+	if len(store.entries) != 1 || store.entries[0].Outcome != "denied" || store.entries[0].FailureCode != "permission_denied" {
+		t.Fatalf("denied entry = %#v", store.entries)
+	}
+}
+
+func TestOperationAuditMiddlewareSkipsReadsAndMethodOverrideSearch(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	store := &recordingOperationAuditStore{}
+	handler := &restHandler{auditRecorder: store}
+	engine := gin.New()
+	engine.Use(handler.OperationAudit())
+	engine.GET("/api/bkn-backend/v1/knowledge-networks/:kn_id", func(c *gin.Context) { c.Status(http.StatusOK) })
+	engine.POST("/api/bkn-backend/v1/knowledge-networks/:kn_id/object-types", func(c *gin.Context) { c.Status(http.StatusOK) })
+
+	engine.ServeHTTP(httptest.NewRecorder(), httptest.NewRequest(http.MethodGet, "/api/bkn-backend/v1/knowledge-networks/kn-a", nil))
+	search := httptest.NewRequest(http.MethodPost, "/api/bkn-backend/v1/knowledge-networks/kn-a/object-types", nil)
+	search.Header.Set("X-HTTP-Method-Override", http.MethodGet)
+	engine.ServeHTTP(httptest.NewRecorder(), search)
+	if len(store.entries) != 0 {
+		t.Fatalf("read operations produced audit entries: %#v", store.entries)
+	}
+}

--- a/adp/bkn/bkn-backend/server/driveradapters/operation_audit_test.go
+++ b/adp/bkn/bkn-backend/server/driveradapters/operation_audit_test.go
@@ -227,6 +227,31 @@ func TestOperationAuditMiddlewareDoesNotTrustUnverifiedIdentityHeaders(t *testin
 	}
 }
 
+func TestOperationAuditMiddlewareUsesInternalCallerIdentityHeaders(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	store := &recordingOperationAuditStore{}
+	handler := &restHandler{auditRecorder: store}
+	engine := gin.New()
+	engine.Use(handler.OperationAudit())
+	engine.PUT("/api/bkn-backend/in/v1/knowledge-networks/:kn_id", func(c *gin.Context) {
+		c.Status(http.StatusNoContent)
+	})
+	request := httptest.NewRequest(http.MethodPut, "/api/bkn-backend/in/v1/knowledge-networks/kn-a", nil)
+	request.Header.Set("x-tenant-id", "tenant-a")
+	request.Header.Set("x-business-domain", "domain-a")
+	request.Header.Set("x-account-id", "internal-user")
+	request.Header.Set("x-account-type", "user")
+	engine.ServeHTTP(httptest.NewRecorder(), request)
+
+	if len(store.entries) != 1 {
+		t.Fatalf("audit entries = %d", len(store.entries))
+	}
+	entry := store.entries[0]
+	if entry.ActorID != "internal-user" || entry.ActorName != "internal-user" || entry.ActorType != "user" {
+		t.Fatalf("internal caller identity was lost: %#v", entry)
+	}
+}
+
 func TestOperationAuditMiddlewareDoesNotPersistUnscopedFact(t *testing.T) {
 	t.Setenv("BKN_OPERATION_AUDIT_TENANT_ID", "")
 	t.Setenv("BKN_OPERATION_AUDIT_BUSINESS_DOMAIN", "")

--- a/adp/bkn/bkn-backend/server/driveradapters/routers.go
+++ b/adp/bkn/bkn-backend/server/driveradapters/routers.go
@@ -44,7 +44,9 @@ type RestHandler interface {
 type restHandler struct {
 	appSetting            *common.AppSetting
 	auditRecorder         operationAuditRecorder
+	auditQueryStore       operationAuditQueryStore
 	auditIdentityResolver func(context.Context, string, hydra.Visitor) operationAuditActor
+	auditAccessResolver   func(context.Context, string, string) (bkntrace.OperationAuditProfile, error)
 	as                    interfaces.AuthService
 	ass                   interfaces.ActionScheduleService
 	ats                   interfaces.ActionTypeService
@@ -59,8 +61,10 @@ type restHandler struct {
 
 func NewRestHandler(appSetting *common.AppSetting, auditStore *operationaudit.Store) RestHandler {
 	r := &restHandler{
-		appSetting:    appSetting,
-		auditRecorder: auditStore,
+		appSetting:          appSetting,
+		auditRecorder:       auditStore,
+		auditQueryStore:     auditStore,
+		auditAccessResolver: bkntrace.ResolveOperationAuditProfile,
 		auditIdentityResolver: func(ctx context.Context, authorization string, visitor hydra.Visitor) operationAuditActor {
 			actor := basicOperationAuditActor(authorization, visitor)
 			profile, err := bkntrace.ResolveOperationAuditIdentity(ctx, authorization, visitor.ID)
@@ -97,6 +101,8 @@ func (r *restHandler) RegisterPublic(c *gin.Engine) {
 	bknApiV1.GET("/trace/outbox/:outbox_id", r.GetTraceOutbox)
 	bknApiV1.POST("/trace/outbox/:outbox_id/retry", r.verifyJsonContentType(), r.RetryTraceOutbox)
 	bknApiV1.POST("/trace/outbox/:outbox_id/abandon", r.verifyJsonContentType(), r.AbandonTraceOutbox)
+	bknApiV1.GET("/operation-audits", r.ListOperationAudits)
+	bknApiV1.GET("/operation-audits/:event_id", r.GetOperationAudit)
 
 	for _, apiV1 := range []*gin.RouterGroup{bknApiV1, otlApiV1} {
 		// 业务知识网络

--- a/adp/bkn/bkn-backend/server/driveradapters/routers.go
+++ b/adp/bkn/bkn-backend/server/driveradapters/routers.go
@@ -20,6 +20,8 @@ import (
 	"github.com/openbkn-ai/bkn-comm-go/rest"
 
 	"bkn-backend/common"
+	"bkn-backend/common/bkntrace"
+	"bkn-backend/common/operationaudit"
 	berrors "bkn-backend/errors"
 	"bkn-backend/interfaces"
 	"bkn-backend/logics/action_schedule"
@@ -40,32 +42,43 @@ type RestHandler interface {
 }
 
 type restHandler struct {
-	appSetting *common.AppSetting
-	as         interfaces.AuthService
-	ass        interfaces.ActionScheduleService
-	ats        interfaces.ActionTypeService
-	cgs        interfaces.ConceptGroupService
-	kns        interfaces.KNService
-	ots        interfaces.ObjectTypeService
-	rts        interfaces.RelationTypeService
-	rtsRisk    interfaces.RiskTypeService
-	ms         interfaces.MetricService
-	bs         interfaces.BKNService
+	appSetting            *common.AppSetting
+	auditRecorder         operationAuditRecorder
+	auditIdentityResolver func(context.Context, string, hydra.Visitor) operationAuditActor
+	as                    interfaces.AuthService
+	ass                   interfaces.ActionScheduleService
+	ats                   interfaces.ActionTypeService
+	cgs                   interfaces.ConceptGroupService
+	kns                   interfaces.KNService
+	ots                   interfaces.ObjectTypeService
+	rts                   interfaces.RelationTypeService
+	rtsRisk               interfaces.RiskTypeService
+	ms                    interfaces.MetricService
+	bs                    interfaces.BKNService
 }
 
-func NewRestHandler(appSetting *common.AppSetting) RestHandler {
+func NewRestHandler(appSetting *common.AppSetting, auditStore *operationaudit.Store) RestHandler {
 	r := &restHandler{
-		appSetting: appSetting,
-		as:         auth.NewAuthService(appSetting),
-		ass:        action_schedule.NewActionScheduleService(appSetting),
-		ats:        action_type.NewActionTypeService(appSetting),
-		cgs:        concept_group.NewConceptGroupService(appSetting),
-		kns:        knowledge_network.NewKNService(appSetting),
-		ots:        object_type.NewObjectTypeService(appSetting),
-		rts:        relation_type.NewRelationTypeService(appSetting),
-		rtsRisk:    risk_type.NewRiskTypeService(appSetting),
-		ms:         metriclogics.NewMetricService(appSetting),
-		bs:         bkn.NewBKNService(appSetting),
+		appSetting:    appSetting,
+		auditRecorder: auditStore,
+		auditIdentityResolver: func(ctx context.Context, authorization string, visitor hydra.Visitor) operationAuditActor {
+			actor := basicOperationAuditActor(authorization, visitor)
+			profile, err := bkntrace.ResolveOperationAuditIdentity(ctx, authorization, visitor.ID)
+			if err == nil {
+				actor.ActorName = profile.ActorName
+			}
+			return actor
+		},
+		as:      auth.NewAuthService(appSetting),
+		ass:     action_schedule.NewActionScheduleService(appSetting),
+		ats:     action_type.NewActionTypeService(appSetting),
+		cgs:     concept_group.NewConceptGroupService(appSetting),
+		kns:     knowledge_network.NewKNService(appSetting),
+		ots:     object_type.NewObjectTypeService(appSetting),
+		rts:     relation_type.NewRelationTypeService(appSetting),
+		rtsRisk: risk_type.NewRiskTypeService(appSetting),
+		ms:      metriclogics.NewMetricService(appSetting),
+		bs:      bkn.NewBKNService(appSetting),
 	}
 	return r
 }
@@ -74,6 +87,7 @@ func (r *restHandler) RegisterPublic(c *gin.Engine) {
 	c.Use(r.AccessLog())
 	c.Use(middleware.TracingMiddleware())
 	c.Use(r.LanguageMiddleware())
+	c.Use(r.OperationAudit())
 
 	c.GET("/health", r.HealthCheck)
 
@@ -306,6 +320,7 @@ func (r *restHandler) verifyOAuth(ctx context.Context, c *gin.Context) (hydra.Vi
 		rest.ReplyError(c, httpErr)
 		return visitor, err
 	}
+	c.Set(operationAuditVisitorKey, visitor)
 
 	return visitor, nil
 }

--- a/adp/bkn/bkn-backend/server/main.go
+++ b/adp/bkn/bkn-backend/server/main.go
@@ -29,6 +29,7 @@ import (
 	"bkn-backend/common"
 	"bkn-backend/common/bkntrace"
 	"bkn-backend/common/bkntrace/outbox"
+	"bkn-backend/common/operationaudit"
 	"bkn-backend/drivenadapters/action_schedule"
 	"bkn-backend/drivenadapters/action_type"
 	"bkn-backend/drivenadapters/agent_operator"
@@ -208,7 +209,7 @@ func main() {
 	server := &mgrService{
 		appSetting:     appSetting,
 		otelProviders:  otelProviders,
-		restHandler:    driveradapters.NewRestHandler(appSetting),
+		restHandler:    driveradapters.NewRestHandler(appSetting, operationaudit.NewStore(outboxDB, "")),
 		conceptSyncer:  worker.NewConceptSyncer(appSetting),
 		scheduleWorker: worker.NewScheduleWorker(appSetting),
 		traceOutbox:    traceOutbox,

--- a/bkn-trace/agent-observability/src/boot/bootstrap.go
+++ b/bkn-trace/agent-observability/src/boot/bootstrap.go
@@ -24,6 +24,7 @@ import (
 	"github.com/openbkn-ai/bkn-foundry/bkn-trace/agent-observability/src/domain/service/tracesvc"
 	"github.com/openbkn-ai/bkn-foundry/bkn-trace/agent-observability/src/domain/valueobject/observabilityvo"
 	mariadbsessionstore "github.com/openbkn-ai/bkn-foundry/bkn-trace/agent-observability/src/drivenadapter/dbaccess/mariadb/sessionstore"
+	"github.com/openbkn-ai/bkn-foundry/bkn-trace/agent-observability/src/drivenadapter/httpaccess/bknbackendaudit"
 	"github.com/openbkn-ai/bkn-foundry/bkn-trace/agent-observability/src/drivenadapter/httpaccess/bknsafeaccess"
 	"github.com/openbkn-ai/bkn-foundry/bkn-trace/agent-observability/src/drivenadapter/httpaccess/bknsafeaudit"
 	"github.com/openbkn-ai/bkn-foundry/bkn-trace/agent-observability/src/drivenadapter/httpaccess/businessresolver"
@@ -151,9 +152,7 @@ func NewApp() (*App, error) {
 		logsvc.NewNotIntegratedSource("bkn-safe-security", []string{
 			observabilityvo.CategoryAuditSecurity,
 		}, []string{"BKN Safe Authorization"}),
-		logsvc.NewNotIntegratedSource("bkn-backend", []string{
-			observabilityvo.CategoryAuditAdmin,
-		}, []string{"domain_knowledge_network"}),
+		bknbackendaudit.New(resolverConfig.BKNBaseURL, &http.Client{Timeout: resolverConfig.Timeout}),
 		logsvc.NewNotIntegratedSource("vega", []string{
 			observabilityvo.CategoryAuditAdmin,
 		}, []string{"data_resource_knowledge_network"}),

--- a/bkn-trace/agent-observability/src/drivenadapter/httpaccess/bknbackendaudit/client.go
+++ b/bkn-trace/agent-observability/src/drivenadapter/httpaccess/bknbackendaudit/client.go
@@ -1,0 +1,238 @@
+package bknbackendaudit
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/openbkn-ai/bkn-foundry/bkn-trace/agent-observability/src/domain/valueobject/observabilityvo"
+)
+
+const (
+	sourceID         = "bkn-backend"
+	maxResponseBytes = 4 << 20
+)
+
+type Client struct {
+	baseURL string
+	http    *http.Client
+}
+
+func New(baseURL string, httpClient *http.Client) *Client {
+	if httpClient == nil {
+		httpClient = http.DefaultClient
+	}
+	return &Client{baseURL: strings.TrimRight(strings.TrimSpace(baseURL), "/"), http: httpClient}
+}
+
+func (client *Client) ID() string { return sourceID }
+
+func (client *Client) Metadata() observabilityvo.SourceStatus {
+	if client.baseURL == "" {
+		return observabilityvo.SourceStatus{
+			SourceID: sourceID, Status: "not_integrated", Reason: "source_not_configured",
+			Reliability: "best_effort", CollectionMethod: "not_integrated",
+			CoveredModules: []string{"domain_knowledge_network"}, CountAccuracy: "partial",
+			Categories: []string{observabilityvo.CategoryAuditAdmin},
+		}
+	}
+	return observabilityvo.SourceStatus{
+		SourceID: sourceID, Status: "healthy", Reliability: "best_effort",
+		CollectionMethod: "source_adapter", CoveredModules: []string{"domain_knowledge_network"},
+		CountAccuracy: "partial", Categories: []string{observabilityvo.CategoryAuditAdmin},
+	}
+}
+
+func (client *Client) Search(ctx context.Context, query observabilityvo.LogQuery) (observabilityvo.SourcePage, error) {
+	if !contains(query.AuthorizedCategories, observabilityvo.CategoryAuditAdmin) {
+		return observabilityvo.SourcePage{CountAccuracy: "partial"}, nil
+	}
+	authorization := strings.TrimSpace(observabilityvo.SourceAuthorization(ctx))
+	if authorization == "" || query.AuthorizedTenantID == "" || query.AuthorizedBusinessDomain == "" {
+		return observabilityvo.SourcePage{}, errors.New("BKN Backend audit source requires caller authorization and trusted scope")
+	}
+	parameters := url.Values{}
+	parameters.Set("limit", strconv.Itoa(normalizedLimit(query.Limit)))
+	setIfPresent(parameters, "actor_id", query.ActorID)
+	setIfPresent(parameters, "action", query.Action)
+	setIfPresent(parameters, "target_type", query.TargetType)
+	setIfPresent(parameters, "target_id", query.TargetID)
+	if len(query.Outcomes) == 1 {
+		setIfPresent(parameters, "outcome", query.Outcomes[0])
+	}
+	if query.TimeFrom != nil {
+		parameters.Set("from", query.TimeFrom.UTC().Format(time.RFC3339Nano))
+	}
+	if query.TimeTo != nil {
+		parameters.Set("to", query.TimeTo.UTC().Format(time.RFC3339Nano))
+	}
+	if query.PageBefore != nil && !query.PageBefore.EventTimestamp.IsZero() {
+		parameters.Set("before_time", query.PageBefore.EventTimestamp.UTC().Format(time.RFC3339Nano))
+		parameters.Set("before_event_id", sourceLogID(query.PageBefore.LogID))
+	}
+	request, err := http.NewRequestWithContext(ctx, http.MethodGet, client.baseURL+"/api/bkn-backend/v1/operation-audits?"+parameters.Encode(), nil)
+	if err != nil {
+		return observabilityvo.SourcePage{}, err
+	}
+	setTrustedHeaders(request, authorization, query.AuthorizedTenantID, query.AuthorizedBusinessDomain)
+	response, err := client.http.Do(request)
+	if err != nil {
+		return observabilityvo.SourcePage{}, err
+	}
+	defer func() { _ = response.Body.Close() }()
+	if response.StatusCode != http.StatusOK {
+		_, _ = io.Copy(io.Discard, io.LimitReader(response.Body, maxResponseBytes))
+		return observabilityvo.SourcePage{}, fmt.Errorf("BKN Backend audit source returned status %d", response.StatusCode)
+	}
+	var payload struct {
+		Entries           []auditEntry `json:"entries"`
+		HasMore           bool         `json:"has_more"`
+		NextBeforeTime    string       `json:"next_before_time"`
+		NextBeforeEventID string       `json:"next_before_event_id"`
+	}
+	if err := json.NewDecoder(io.LimitReader(response.Body, maxResponseBytes)).Decode(&payload); err != nil {
+		return observabilityvo.SourcePage{}, fmt.Errorf("decode BKN Backend audit response: %w", err)
+	}
+	records := make([]observabilityvo.LogRecord, 0, len(payload.Entries))
+	for _, entry := range payload.Entries {
+		records = append(records, project(entry))
+	}
+	count := int64(len(records))
+	if payload.HasMore {
+		count++
+	}
+	return observabilityvo.SourcePage{Records: records, Count: count, CountAccuracy: "partial"}, nil
+}
+
+func (client *Client) Get(ctx context.Context, logID string) (observabilityvo.LogRecord, bool, error) {
+	authorization := strings.TrimSpace(observabilityvo.SourceAuthorization(ctx))
+	scope := observabilityvo.SourceAccessScopeFromContext(ctx)
+	if authorization == "" || scope.TenantID == "" || scope.BusinessDomain == "" {
+		return observabilityvo.LogRecord{}, false, errors.New("BKN Backend audit source requires caller authorization and trusted scope")
+	}
+	request, err := http.NewRequestWithContext(ctx, http.MethodGet, client.baseURL+"/api/bkn-backend/v1/operation-audits/"+url.PathEscape(sourceLogID(logID)), nil)
+	if err != nil {
+		return observabilityvo.LogRecord{}, false, err
+	}
+	setTrustedHeaders(request, authorization, scope.TenantID, scope.BusinessDomain)
+	response, err := client.http.Do(request)
+	if err != nil {
+		return observabilityvo.LogRecord{}, false, err
+	}
+	defer func() { _ = response.Body.Close() }()
+	if response.StatusCode == http.StatusNotFound {
+		_, _ = io.Copy(io.Discard, io.LimitReader(response.Body, maxResponseBytes))
+		return observabilityvo.LogRecord{}, false, nil
+	}
+	if response.StatusCode != http.StatusOK {
+		_, _ = io.Copy(io.Discard, io.LimitReader(response.Body, maxResponseBytes))
+		return observabilityvo.LogRecord{}, false, fmt.Errorf("BKN Backend audit source returned status %d", response.StatusCode)
+	}
+	var entry auditEntry
+	if err := json.NewDecoder(io.LimitReader(response.Body, maxResponseBytes)).Decode(&entry); err != nil {
+		return observabilityvo.LogRecord{}, false, fmt.Errorf("decode BKN Backend audit detail: %w", err)
+	}
+	return project(entry), true, nil
+}
+
+type auditEntry struct {
+	EventID            string         `json:"event_id"`
+	EventTime          time.Time      `json:"event_time"`
+	RecordedAt         time.Time      `json:"recorded_at"`
+	TenantID           string         `json:"tenant_id"`
+	BusinessDomainID   string         `json:"business_domain_id"`
+	KnowledgeNetworkID string         `json:"knowledge_network_id"`
+	ActorID            string         `json:"actor_id"`
+	ActorName          string         `json:"actor_name"`
+	ActorType          string         `json:"actor_type"`
+	AuthMethod         string         `json:"auth_method"`
+	CredentialID       string         `json:"credential_id"`
+	RequestID          string         `json:"request_id"`
+	SourceChannel      string         `json:"source_channel"`
+	Method             string         `json:"method"`
+	Action             string         `json:"action"`
+	TargetType         string         `json:"target_type"`
+	TargetID           string         `json:"target_id"`
+	TargetName         string         `json:"target_name"`
+	Outcome            string         `json:"outcome"`
+	FailureCode        string         `json:"failure_code"`
+	FailureMessage     string         `json:"failure_message"`
+	ChangeSummary      map[string]any `json:"change_summary"`
+	SchemaVersion      string         `json:"schema_version"`
+}
+
+func project(entry auditEntry) observabilityvo.LogRecord {
+	severityNumber, severityText := 9, "INFO"
+	if entry.Outcome == "failure" || entry.Outcome == "denied" {
+		severityNumber, severityText = 17, "ERROR"
+	}
+	actorName := firstNonEmpty(entry.ActorName, entry.ActorID)
+	targetName := firstNonEmpty(entry.TargetName, entry.TargetID)
+	return observabilityvo.LogRecord{
+		EventID: entry.EventID, EventTime: entry.EventTime, RecordedAt: entry.RecordedAt,
+		ActorNameSnapshot: actorName, ActorType: firstNonEmpty(entry.ActorType, "user"), AuthMethod: firstNonEmpty(entry.AuthMethod, "unknown"), CredentialID: entry.CredentialID,
+		SourceChannel: firstNonEmpty(entry.SourceChannel, "api"), BusinessModule: "domain_knowledge_network", Action: entry.Action,
+		TargetType: entry.TargetType, TargetID: entry.TargetID, TargetNameSnapshot: targetName,
+		FailureCode: entry.FailureCode, FailureMessage: entry.FailureMessage, SchemaVersion: firstNonEmpty(entry.SchemaVersion, "1.0"),
+		LogID: sourceID + ":" + entry.EventID, SourceID: sourceID, SourceLogID: entry.EventID,
+		Category: observabilityvo.CategoryAuditAdmin, EventName: "resource_config.changed",
+		EventTimestamp: entry.EventTime, ObservedTimestamp: entry.RecordedAt, SeverityNumber: severityNumber, SeverityText: severityText,
+		Outcome: entry.Outcome, SafeSummary: strings.TrimSpace(strings.Join([]string{entry.Method, entry.Action, entry.TargetType, targetName}, " ")),
+		ServiceName: "bkn-backend", Environment: "unknown", TenantID: entry.TenantID, BusinessDomain: entry.BusinessDomainID,
+		ActorID: entry.ActorID, EffectiveSubjectID: entry.ActorID, RequestID: entry.RequestID,
+		IngressPrincipal: "bkn-backend", TrustLevel: "trusted", KnowledgeNetworkIDs: []string{entry.KnowledgeNetworkID},
+		ResourceRef: &observabilityvo.ResourceRef{ResourceType: entry.TargetType, ResourceID: entry.TargetID},
+		Attributes:  map[string]any{"method": entry.Method, "change_summary": entry.ChangeSummary},
+	}
+}
+
+func setTrustedHeaders(request *http.Request, authorization, tenantID, businessDomain string) {
+	request.Header.Set("Authorization", authorization)
+	request.Header.Set("x-tenant-id", tenantID)
+	request.Header.Set("x-business-domain", businessDomain)
+}
+
+func sourceLogID(logID string) string {
+	return strings.TrimPrefix(strings.TrimSpace(logID), sourceID+":")
+}
+
+func normalizedLimit(value int) int {
+	if value <= 0 {
+		return 50
+	}
+	if value > 500 {
+		return 500
+	}
+	return value
+}
+
+func setIfPresent(parameters url.Values, name, value string) {
+	if strings.TrimSpace(value) != "" {
+		parameters.Set(name, strings.TrimSpace(value))
+	}
+}
+
+func contains(values []string, expected string) bool {
+	for _, value := range values {
+		if value == expected {
+			return true
+		}
+	}
+	return false
+}
+
+func firstNonEmpty(values ...string) string {
+	for _, value := range values {
+		if strings.TrimSpace(value) != "" {
+			return strings.TrimSpace(value)
+		}
+	}
+	return ""
+}

--- a/bkn-trace/agent-observability/src/drivenadapter/httpaccess/bknbackendaudit/client_test.go
+++ b/bkn-trace/agent-observability/src/drivenadapter/httpaccess/bknbackendaudit/client_test.go
@@ -1,0 +1,73 @@
+package bknbackendaudit
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/openbkn-ai/bkn-foundry/bkn-trace/agent-observability/src/domain/valueobject/observabilityvo"
+)
+
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (roundTrip roundTripFunc) RoundTrip(request *http.Request) (*http.Response, error) {
+	return roundTrip(request)
+}
+
+func TestSearchProjectsBKNManagementFactAndForwardsTrustedScope(t *testing.T) {
+	var request *http.Request
+	client := New("http://bkn-backend:8080", &http.Client{Transport: roundTripFunc(func(candidate *http.Request) (*http.Response, error) {
+		request = candidate
+		return &http.Response{
+			StatusCode: http.StatusOK, Header: make(http.Header), Request: candidate,
+			Body: io.NopCloser(strings.NewReader(`{"entries":[{"event_id":"evt-a","event_time":"2026-08-13T08:00:00Z","recorded_at":"2026-08-13T08:00:01Z","tenant_id":"tenant-a","business_domain_id":"domain-a","knowledge_network_id":"kn-a","actor_id":"user-a","actor_name":"Alice","actor_type":"user","auth_method":"app_key","credential_id":"key-a","request_id":"req-a","source_channel":"api","method":"POST","action":"create","target_type":"object_type","target_id":"material","target_name":"物料","outcome":"success","change_summary":{"changed_fields":["name"]},"schema_version":"1.0"}],"has_more":false}`)),
+		}, nil
+	})})
+	from := time.Date(2026, 8, 13, 0, 0, 0, 0, time.UTC)
+	to := from.Add(24 * time.Hour)
+	ctx := observabilityvo.WithSourceAuthorization(context.Background(), "Bearer token-a")
+	page, err := client.Search(ctx, observabilityvo.LogQuery{
+		TimeFrom: &from, TimeTo: &to, Action: "create", TargetType: "object_type", TargetID: "material", ActorID: "user-a", Limit: 20,
+		AuthorizedTenantID: "tenant-a", AuthorizedBusinessDomain: "domain-a", AuthorizedCategories: []string{observabilityvo.CategoryAuditAdmin},
+	})
+	if err != nil {
+		t.Fatalf("Search() error = %v", err)
+	}
+	if request.Header.Get("Authorization") != "Bearer token-a" || request.Header.Get("x-tenant-id") != "tenant-a" || request.Header.Get("x-business-domain") != "domain-a" ||
+		request.URL.Query().Get("action") != "create" || request.URL.Query().Get("target_type") != "object_type" || request.URL.Query().Get("target_id") != "material" || request.URL.Query().Get("actor_id") != "user-a" {
+		t.Fatalf("request = %s headers=%v", request.URL.String(), request.Header)
+	}
+	if len(page.Records) != 1 {
+		t.Fatalf("records = %#v", page.Records)
+	}
+	record := page.Records[0]
+	if record.LogID != "bkn-backend:evt-a" || record.SourceID != "bkn-backend" || record.Category != observabilityvo.CategoryAuditAdmin ||
+		record.EventName != "resource_config.changed" || record.BusinessModule != "domain_knowledge_network" || record.Action != "create" ||
+		record.TargetType != "object_type" || record.TargetID != "material" || record.TargetNameSnapshot != "物料" ||
+		record.ActorNameSnapshot != "Alice" || record.ActorID != "user-a" || record.AuthMethod != "app_key" || record.RequestID != "req-a" ||
+		record.BusinessDomain != "domain-a" || len(record.KnowledgeNetworkIDs) != 1 || record.KnowledgeNetworkIDs[0] != "kn-a" {
+		t.Fatalf("record = %#v", record)
+	}
+}
+
+func TestMetadataDoesNotClaimAnUnconfiguredSourceIsHealthy(t *testing.T) {
+	status := New("", nil).Metadata()
+	if status.Status != "not_integrated" || status.Reason != "source_not_configured" {
+		t.Fatalf("status = %#v", status)
+	}
+}
+
+func TestGetKeepsUnauthorizedDetailAsNotFound(t *testing.T) {
+	client := New("http://bkn-backend:8080", &http.Client{Transport: roundTripFunc(func(candidate *http.Request) (*http.Response, error) {
+		return &http.Response{StatusCode: http.StatusNotFound, Header: make(http.Header), Request: candidate, Body: io.NopCloser(strings.NewReader(`{"error":"not found"}`))}, nil
+	})})
+	ctx := observabilityvo.WithSourceAuthorization(context.Background(), "Bearer token-a")
+	ctx = observabilityvo.WithSourceAccessScope(ctx, observabilityvo.SourceAccessScope{TenantID: "tenant-a", BusinessDomain: "domain-a"})
+	_, found, err := client.Get(ctx, "evt-secret")
+	if err != nil || found {
+		t.Fatalf("Get() found=%v err=%v", found, err)
+	}
+}

--- a/migrations/bkn-backend/mariadb/0.1.4/01-operation-audit.sql
+++ b/migrations/bkn-backend/mariadb/0.1.4/01-operation-audit.sql
@@ -1,0 +1,38 @@
+-- Copyright 2026 openbkn.ai
+--
+-- Licensed under the Apache License, Version 2.0.
+-- See the LICENSE file in the project root for details.
+
+USE openbkn;
+
+-- BKN Backend source-owned management audit facts.
+-- This table stores bounded facts only; request/response bodies and credentials are excluded.
+CREATE TABLE IF NOT EXISTS t_operation_audit (
+  event_id VARCHAR(128) CHARACTER SET ascii COLLATE ascii_bin NOT NULL,
+  event_time DATETIME(6) NOT NULL,
+  recorded_at DATETIME(6) NOT NULL,
+  tenant_id VARCHAR(128) CHARACTER SET ascii COLLATE ascii_bin NOT NULL,
+  business_domain_id VARCHAR(128) CHARACTER SET ascii COLLATE ascii_bin NOT NULL,
+  knowledge_network_id VARCHAR(128) CHARACTER SET ascii COLLATE ascii_bin NOT NULL,
+  actor_id VARCHAR(128) CHARACTER SET ascii COLLATE ascii_bin NOT NULL,
+  actor_name VARCHAR(255) NOT NULL,
+  actor_type VARCHAR(32) CHARACTER SET ascii COLLATE ascii_bin NOT NULL,
+  auth_method VARCHAR(32) CHARACTER SET ascii COLLATE ascii_bin NOT NULL,
+  credential_id VARCHAR(128) CHARACTER SET ascii COLLATE ascii_bin NOT NULL DEFAULT '',
+  request_id VARCHAR(128) CHARACTER SET ascii COLLATE ascii_bin NOT NULL,
+  source_channel VARCHAR(32) CHARACTER SET ascii COLLATE ascii_bin NOT NULL,
+  method VARCHAR(16) CHARACTER SET ascii COLLATE ascii_bin NOT NULL,
+  action VARCHAR(32) CHARACTER SET ascii COLLATE ascii_bin NOT NULL,
+  target_type VARCHAR(64) CHARACTER SET ascii COLLATE ascii_bin NOT NULL,
+  target_id VARCHAR(1024) NOT NULL,
+  target_name VARCHAR(1024) NOT NULL,
+  outcome VARCHAR(16) CHARACTER SET ascii COLLATE ascii_bin NOT NULL,
+  failure_code VARCHAR(128) CHARACTER SET ascii COLLATE ascii_bin NOT NULL DEFAULT '',
+  failure_message VARCHAR(512) NOT NULL DEFAULT '',
+  change_summary TEXT NOT NULL,
+  schema_version VARCHAR(16) CHARACTER SET ascii COLLATE ascii_bin NOT NULL,
+  PRIMARY KEY (event_id),
+  INDEX idx_bkn_audit_tenant_time (tenant_id, event_time, event_id),
+  INDEX idx_bkn_audit_domain_network_time (business_domain_id, knowledge_network_id, event_time, event_id),
+  INDEX idx_bkn_audit_actor_time (actor_id, event_time, event_id)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin COMMENT='BKN Backend management operation audit facts';

--- a/migrations/bkn-backend/mariadb/0.1.4/init.sql
+++ b/migrations/bkn-backend/mariadb/0.1.4/init.sql
@@ -1,0 +1,276 @@
+-- Copyright 2026 openbkn.ai
+--
+-- Licensed under the Apache License, Version 2.0.
+-- See the LICENSE file in the project root for details.
+
+USE openbkn;
+
+
+-- 业务知识网络
+CREATE TABLE IF NOT EXISTS t_knowledge_network (
+  f_id VARCHAR(40) NOT NULL DEFAULT '' COMMENT '业务知识网络id',
+  f_name VARCHAR(40) NOT NULL DEFAULT '' COMMENT '业务知识网络名称',
+  f_tags VARCHAR(255) DEFAULT NULL COMMENT '标签',
+  f_comment TEXT NOT NULL COMMENT '备注',
+  f_icon VARCHAR(255) NOT NULL DEFAULT '' COMMENT '图标',
+  f_color VARCHAR(40) NOT NULL DEFAULT '' COMMENT '颜色',
+  f_bkn_raw_content MEDIUMTEXT NOT NULL COMMENT 'BKNRawContent',
+  f_skill_content MEDIUMTEXT NOT NULL COMMENT 'SkillContent',
+  f_branch VARCHAR(40) NOT NULL DEFAULT '' COMMENT '分支',
+  f_business_domain VARCHAR(40) NOT NULL DEFAULT '' COMMENT '业务域',
+  f_creator VARCHAR(40) NOT NULL DEFAULT '' COMMENT '创建者id',
+  f_creator_type VARCHAR(20) NOT NULL DEFAULT '' COMMENT '创建者类型',
+  f_create_time BIGINT(20) NOT NULL DEFAULT 0 COMMENT '创建时间',
+  f_updater VARCHAR(40) NOT NULL DEFAULT '' COMMENT '更新者id',
+  f_updater_type VARCHAR(20) NOT NULL DEFAULT '' COMMENT '更新者类型',
+  f_update_time BIGINT(20) NOT NULL DEFAULT 0 COMMENT '更新时间',
+  PRIMARY KEY (f_id,f_branch),
+  UNIQUE KEY uk_kn_name (f_name,f_branch)
+) ENGINE = InnoDB DEFAULT CHARSET = utf8mb4 COLLATE = utf8mb4_bin COMMENT = '业务知识网络';
+
+
+-- 对象类
+CREATE TABLE IF NOT EXISTS t_object_type (
+  f_id VARCHAR(40) NOT NULL DEFAULT '' COMMENT '对象类id',
+  f_name VARCHAR(40) NOT NULL DEFAULT '' COMMENT '对象类名称',
+  f_tags VARCHAR(255) DEFAULT NULL COMMENT '标签',
+  f_comment TEXT NOT NULL COMMENT '备注',
+  f_icon VARCHAR(255) NOT NULL DEFAULT '' COMMENT '图标',
+  f_color VARCHAR(40) NOT NULL DEFAULT '' COMMENT '颜色',
+  f_bkn_raw_content MEDIUMTEXT NOT NULL COMMENT 'BKNRawContent',
+  f_kn_id VARCHAR(40) NOT NULL DEFAULT '' COMMENT '业务知识网络id',
+  f_branch VARCHAR(40) NOT NULL DEFAULT '' COMMENT '分支',
+  f_data_source VARCHAR(255) NOT NULL COMMENT '数据来源，当前只有视图',
+  f_data_properties LONGTEXT DEFAULT NULL COMMENT '数据属性',
+  f_logic_properties MEDIUMTEXT DEFAULT NULL COMMENT '逻辑属性',
+  f_primary_keys VARCHAR(8192) DEFAULT NULL COMMENT '对象类主键',
+  f_display_key VARCHAR(40) NOT NULL DEFAULT '' COMMENT '对象实例的显示属性',
+  f_incremental_key VARCHAR(40) NOT NULL DEFAULT '' COMMENT '对象类增量键',
+  f_creator VARCHAR(40) NOT NULL DEFAULT '' COMMENT '创建者id',
+  f_creator_type VARCHAR(20) NOT NULL DEFAULT '' COMMENT '创建者类型',
+  f_create_time BIGINT(20) NOT NULL DEFAULT 0 COMMENT '创建时间',
+  f_updater VARCHAR(40) NOT NULL DEFAULT '' COMMENT '更新者id',
+  f_updater_type VARCHAR(20) NOT NULL DEFAULT '' COMMENT '更新者类型',
+  f_update_time BIGINT(20) NOT NULL DEFAULT 0 COMMENT '更新时间',
+  PRIMARY KEY (f_kn_id,f_branch,f_id),
+  UNIQUE KEY uk_object_type_name (f_kn_id,f_branch,f_name)
+) ENGINE = InnoDB DEFAULT CHARSET = utf8mb4 COLLATE = utf8mb4_bin COMMENT = '对象类';
+
+
+-- 对象类状态
+CREATE TABLE IF NOT EXISTS t_object_type_status (
+  f_id VARCHAR(40) NOT NULL DEFAULT '' COMMENT '对象类id',
+  f_kn_id VARCHAR(40) NOT NULL DEFAULT '' COMMENT '业务知识网络id',
+  f_branch VARCHAR(40) NOT NULL DEFAULT '' COMMENT '分支',
+  f_incremental_key VARCHAR(40) NOT NULL DEFAULT '' COMMENT '对象类增量键',
+  f_incremental_value VARCHAR(40) NOT NULL DEFAULT '' COMMENT '对象类当前增量值',
+  f_index VARCHAR(255) NOT NULL DEFAULT '' COMMENT '索引名称',
+  f_index_available BOOLEAN NOT NULL DEFAULT 0 COMMENT '索引是否可用',
+  f_doc_count BIGINT(20) NOT NULL DEFAULT 0 COMMENT '文档数量',
+  f_storage_size BIGINT(20) NOT NULL DEFAULT 0 COMMENT '存储大小',
+  f_update_time BIGINT(20) NOT NULL DEFAULT 0 COMMENT '更新时间',
+  PRIMARY KEY (f_kn_id,f_branch,f_id)
+) ENGINE = InnoDB DEFAULT CHARSET = utf8mb4 COLLATE = utf8mb4_bin COMMENT = '对象类状态';
+
+
+-- 关系类
+CREATE TABLE IF NOT EXISTS t_relation_type (
+  f_id VARCHAR(40) NOT NULL DEFAULT '' COMMENT '关系类id',
+  f_name VARCHAR(40) NOT NULL DEFAULT '' COMMENT '关系类名称',
+  f_tags VARCHAR(255) DEFAULT NULL COMMENT '标签',
+  f_comment TEXT NOT NULL COMMENT '备注',
+  f_icon VARCHAR(255) NOT NULL DEFAULT '' COMMENT '图标',
+  f_color VARCHAR(40) NOT NULL DEFAULT '' COMMENT '颜色',
+  f_bkn_raw_content MEDIUMTEXT NOT NULL COMMENT 'BKNRawContent',
+  f_kn_id VARCHAR(40) NOT NULL DEFAULT '' COMMENT '业务知识网络id',
+  f_branch VARCHAR(40) NOT NULL DEFAULT '' COMMENT '分支',
+  f_source_object_type_id VARCHAR(40) NOT NULL DEFAULT '' COMMENT '起点对象类',
+  f_target_object_type_id VARCHAR(40) NOT NULL DEFAULT '' COMMENT '终点对象类',
+  f_type VARCHAR(40) NOT NULL DEFAULT '' COMMENT '关联类型',
+  f_mapping_rules TEXT DEFAULT NULL COMMENT '关联规则',
+  f_creator VARCHAR(40) NOT NULL DEFAULT '' COMMENT '创建者id',
+  f_creator_type VARCHAR(20) NOT NULL DEFAULT '' COMMENT '创建者类型',
+  f_create_time BIGINT(20) NOT NULL DEFAULT 0 COMMENT '创建时间',
+  f_updater VARCHAR(40) NOT NULL DEFAULT '' COMMENT '更新者id',
+  f_updater_type VARCHAR(20) NOT NULL DEFAULT '' COMMENT '更新者类型',
+  f_update_time BIGINT(20) NOT NULL DEFAULT 0 COMMENT '更新时间',
+  PRIMARY KEY (f_kn_id,f_branch,f_id)
+) ENGINE = InnoDB DEFAULT CHARSET = utf8mb4 COLLATE = utf8mb4_bin COMMENT = '关系类';
+
+
+-- 行动类
+CREATE TABLE IF NOT EXISTS t_action_type (
+  f_id VARCHAR(40) NOT NULL DEFAULT '' COMMENT '行动类id',
+  f_name VARCHAR(40) NOT NULL DEFAULT '' COMMENT '行动类名称',
+  f_tags VARCHAR(255) DEFAULT NULL COMMENT '标签',
+  f_comment TEXT NOT NULL COMMENT '备注',
+  f_icon VARCHAR(255) NOT NULL DEFAULT '' COMMENT '图标',
+  f_color VARCHAR(40) NOT NULL DEFAULT '' COMMENT '颜色',
+  f_bkn_raw_content MEDIUMTEXT NOT NULL COMMENT 'BKNRawContent',
+  f_kn_id VARCHAR(40) NOT NULL DEFAULT '' COMMENT '业务知识网络id',
+  f_branch VARCHAR(40) NOT NULL DEFAULT '' COMMENT '分支',
+  f_action_type VARCHAR(40) NOT NULL DEFAULT '' COMMENT '行动类型',
+  f_action_intent VARCHAR(40) NOT NULL DEFAULT '' COMMENT '行动意图',
+  f_object_type_id VARCHAR(40) NOT NULL DEFAULT '' COMMENT '对象类',
+  f_condition TEXT DEFAULT NULL COMMENT '行动条件',
+  f_affect TEXT DEFAULT NULL COMMENT '行动影响',
+  f_impact_contracts TEXT DEFAULT NULL COMMENT '行动影响契约',
+  f_action_source VARCHAR(255) NOT NULL COMMENT '行动资源',
+  f_parameters TEXT DEFAULT NULL COMMENT '行动参数',
+  f_schedule VARCHAR(255) DEFAULT NULL COMMENT '行动监听',
+  f_creator VARCHAR(40) NOT NULL DEFAULT '' COMMENT '创建者id',
+  f_creator_type VARCHAR(20) NOT NULL DEFAULT '' COMMENT '创建者类型',
+  f_create_time BIGINT(20) NOT NULL DEFAULT 0 COMMENT '创建时间',
+  f_updater VARCHAR(40) NOT NULL DEFAULT '' COMMENT '更新者id',
+  f_updater_type VARCHAR(20) NOT NULL DEFAULT '' COMMENT '更新者类型',
+  f_update_time BIGINT(20) NOT NULL DEFAULT 0 COMMENT '更新时间',
+  PRIMARY KEY (f_kn_id,f_branch,f_id),
+  UNIQUE KEY uk_action_type_name (f_kn_id,f_branch,f_name)
+) ENGINE = InnoDB DEFAULT CHARSET = utf8mb4 COLLATE = utf8mb4_bin COMMENT = '行动类';
+
+
+-- 概念分组
+CREATE TABLE IF NOT EXISTS t_concept_group (
+  f_id VARCHAR(40) NOT NULL DEFAULT '' COMMENT '概念分组id',
+  f_name VARCHAR(40) NOT NULL DEFAULT '' COMMENT '概念分组名称',
+  f_tags VARCHAR(255) DEFAULT NULL COMMENT '标签',
+  f_comment TEXT NOT NULL COMMENT '备注',
+  f_icon VARCHAR(255) NOT NULL DEFAULT '' COMMENT '图标',
+  f_color VARCHAR(40) NOT NULL DEFAULT '' COMMENT '颜色',
+  f_bkn_raw_content MEDIUMTEXT NOT NULL COMMENT 'BKNRawContent',
+  f_kn_id VARCHAR(40) NOT NULL DEFAULT '' COMMENT '业务知识网络id',
+  f_branch VARCHAR(40) NOT NULL DEFAULT '' COMMENT '分支',
+  f_creator VARCHAR(40) NOT NULL DEFAULT '' COMMENT '创建者id',
+  f_creator_type VARCHAR(20) NOT NULL DEFAULT '' COMMENT '创建者类型',
+  f_create_time BIGINT(20) NOT NULL DEFAULT 0 COMMENT '创建时间',
+  f_updater VARCHAR(40) NOT NULL DEFAULT '' COMMENT '更新者id',
+  f_updater_type VARCHAR(20) NOT NULL DEFAULT '' COMMENT '更新者类型',
+  f_update_time BIGINT(20) NOT NULL DEFAULT 0 COMMENT '更新时间',
+  PRIMARY KEY (f_kn_id,f_branch,f_id),
+  UNIQUE KEY uk_concept_group_name (f_kn_id,f_branch,f_name)
+) ENGINE = InnoDB DEFAULT CHARSET = utf8mb4 COLLATE = utf8mb4_bin COMMENT = '概念分组';
+
+
+-- 分组与概念对应表
+CREATE TABLE IF NOT EXISTS t_concept_group_relation (
+  f_id VARCHAR(40) NOT NULL DEFAULT '' COMMENT '主键id',
+  f_kn_id VARCHAR(40) NOT NULL DEFAULT '' COMMENT '业务知识网络id',
+  f_branch VARCHAR(40) NOT NULL DEFAULT '' COMMENT '分支',
+  f_group_id VARCHAR(40) NOT NULL DEFAULT '' COMMENT '概念分组id',
+  f_concept_type VARCHAR(40) NOT NULL DEFAULT '' COMMENT '概念类型',
+  f_concept_id VARCHAR(40) NOT NULL DEFAULT '' COMMENT '概念id',
+  f_create_time BIGINT(20) NOT NULL DEFAULT 0 COMMENT '创建时间',
+  PRIMARY KEY (f_id),
+  UNIQUE KEY uk_concept_group_relation (f_kn_id,f_branch,f_group_id,f_concept_type,f_concept_id)
+) ENGINE = InnoDB DEFAULT CHARSET = utf8mb4 COLLATE = utf8mb4_bin COMMENT = '分组与概念对应表';
+
+
+-- Action Schedule Management
+-- Supports cron-based scheduled action execution with distributed locking
+CREATE TABLE IF NOT EXISTS t_action_schedule (
+  f_id VARCHAR(40) NOT NULL DEFAULT '' COMMENT 'Schedule ID',
+  f_name VARCHAR(100) NOT NULL DEFAULT '' COMMENT 'Schedule name',
+  f_kn_id VARCHAR(40) NOT NULL DEFAULT '' COMMENT 'Knowledge network ID',
+  f_branch VARCHAR(40) NOT NULL DEFAULT '' COMMENT 'Branch',
+  f_action_type_id VARCHAR(40) NOT NULL DEFAULT '' COMMENT 'Action type ID to execute',
+  f_cron_expression VARCHAR(100) NOT NULL DEFAULT '' COMMENT 'Standard 5-field cron expression (min hour dom mon dow)',
+  f_instance_identities MEDIUMTEXT DEFAULT NULL COMMENT 'JSON array of target object instance identities',
+  f_dynamic_params MEDIUMTEXT DEFAULT NULL COMMENT 'JSON object of dynamic parameters',
+  f_status VARCHAR(20) NOT NULL DEFAULT 'inactive' COMMENT 'Schedule status: active or inactive',
+  f_last_run_time BIGINT(20) NOT NULL DEFAULT 0 COMMENT 'Last execution timestamp (ms)',
+  f_next_run_time BIGINT(20) NOT NULL DEFAULT 0 COMMENT 'Next scheduled run timestamp (ms)',
+  f_lock_holder VARCHAR(64) DEFAULT NULL COMMENT 'Pod ID holding execution lock (NULL = unlocked)',
+  f_lock_time BIGINT(20) NOT NULL DEFAULT 0 COMMENT 'Lock acquisition timestamp (ms) for timeout detection',
+  f_creator VARCHAR(40) NOT NULL DEFAULT '' COMMENT 'Creator ID',
+  f_creator_type VARCHAR(20) NOT NULL DEFAULT '' COMMENT 'Creator type',
+  f_create_time BIGINT(20) NOT NULL DEFAULT 0 COMMENT 'Create timestamp (ms)',
+  f_updater VARCHAR(40) NOT NULL DEFAULT '' COMMENT 'Updater ID',
+  f_updater_type VARCHAR(20) NOT NULL DEFAULT '' COMMENT 'Updater type',
+  f_update_time BIGINT(20) NOT NULL DEFAULT 0 COMMENT 'Update timestamp (ms)',
+  PRIMARY KEY (f_id),
+  KEY idx_kn_branch (f_kn_id, f_branch),
+  KEY idx_status_next_run (f_status, f_next_run_time),
+  KEY idx_action_type (f_action_type_id)
+) ENGINE = InnoDB DEFAULT CHARSET = utf8mb4 COLLATE = utf8mb4_bin COMMENT = 'Action schedule for cron-based execution';
+
+
+-- Risk Type
+CREATE TABLE IF NOT EXISTS t_risk_type (
+  f_id VARCHAR(40) NOT NULL DEFAULT '' COMMENT '风险类ID',
+  f_name VARCHAR(40) NOT NULL DEFAULT '' COMMENT '风险类名称',
+  f_comment TEXT NOT NULL COMMENT '描述',
+  f_tags VARCHAR(255) DEFAULT NULL COMMENT '标签',
+  f_icon VARCHAR(255) NOT NULL DEFAULT '' COMMENT '图标',
+  f_color VARCHAR(40) NOT NULL DEFAULT '' COMMENT '颜色',
+  f_bkn_raw_content MEDIUMTEXT NOT NULL COMMENT 'BKNRawContent',
+  f_kn_id VARCHAR(40) NOT NULL DEFAULT '' COMMENT '业务知识网络ID',
+  f_branch VARCHAR(40) NOT NULL DEFAULT '' COMMENT '分支',
+  f_creator VARCHAR(40) NOT NULL DEFAULT '' COMMENT '创建者id',
+  f_creator_type VARCHAR(20) NOT NULL DEFAULT '' COMMENT '创建者类型',
+  f_create_time BIGINT(20) NOT NULL DEFAULT 0 COMMENT '创建时间',
+  f_updater VARCHAR(40) NOT NULL DEFAULT '' COMMENT '更新者id',
+  f_updater_type VARCHAR(20) NOT NULL DEFAULT '' COMMENT '更新者类型',
+  f_update_time BIGINT(20) NOT NULL DEFAULT 0 COMMENT '更新时间',
+  PRIMARY KEY (f_kn_id, f_branch, f_id),
+  UNIQUE KEY uk_risk_type_name (f_kn_id, f_branch, f_name)
+) ENGINE = InnoDB DEFAULT CHARSET = utf8mb4 COLLATE = utf8mb4_bin COMMENT = '风险类';
+
+CREATE TABLE IF NOT EXISTS t_metric_definition (
+  f_id VARCHAR(40) NOT NULL DEFAULT '' COMMENT '指标ID',
+  f_name VARCHAR(128) NOT NULL DEFAULT '' COMMENT '指标技术名',
+  f_comment TEXT NOT NULL COMMENT '描述',
+  f_tags VARCHAR(255) DEFAULT NULL COMMENT '标签',
+  f_icon VARCHAR(255) NOT NULL DEFAULT '' COMMENT '图标',
+  f_color VARCHAR(40) NOT NULL DEFAULT '' COMMENT '颜色',
+  f_bkn_raw_content MEDIUMTEXT NOT NULL COMMENT 'BKNRawContent',
+  f_kn_id VARCHAR(40) NOT NULL DEFAULT '' COMMENT '业务知识网络ID',
+  f_branch VARCHAR(40) NOT NULL DEFAULT '' COMMENT '分支',
+  f_unit_type VARCHAR(64) NOT NULL DEFAULT '' COMMENT '单位类型',
+  f_unit VARCHAR(64) NOT NULL DEFAULT '' COMMENT '单位',
+  f_metric_type VARCHAR(32) NOT NULL DEFAULT 'atomic' COMMENT '指标类型 atomic|derived|composite',
+  f_scope_type VARCHAR(32) NOT NULL DEFAULT 'object_type' COMMENT '统计主体类型',
+  f_scope_ref VARCHAR(40) NOT NULL DEFAULT '' COMMENT '对象类或子图ID',
+  f_time_dimension LONGTEXT DEFAULT NULL COMMENT '时间维度 JSON',
+  f_calculation_formula LONGTEXT NOT NULL COMMENT '计算公式 JSON',
+  f_analysis_dimensions LONGTEXT DEFAULT NULL COMMENT '分析维度 JSON',
+  f_creator VARCHAR(40) NOT NULL DEFAULT '' COMMENT '创建者id',
+  f_creator_type VARCHAR(20) NOT NULL DEFAULT '' COMMENT '创建者类型',
+  f_create_time BIGINT(20) NOT NULL DEFAULT 0 COMMENT '创建时间',
+  f_updater VARCHAR(40) NOT NULL DEFAULT '' COMMENT '更新者id',
+  f_updater_type VARCHAR(20) NOT NULL DEFAULT '' COMMENT '更新者类型',
+  f_update_time BIGINT(20) NOT NULL DEFAULT 0 COMMENT '更新时间',
+  PRIMARY KEY (f_kn_id, f_branch, f_id),
+  UNIQUE KEY uk_metric_name (f_kn_id, f_branch, f_name)
+) ENGINE = InnoDB DEFAULT CHARSET = utf8mb4 COLLATE = utf8mb4_bin COMMENT = 'BKN 指标定义';
+
+-- BKN Backend source-owned management audit facts.
+-- This table stores bounded facts only; request/response bodies and credentials are excluded.
+CREATE TABLE IF NOT EXISTS t_operation_audit (
+  event_id VARCHAR(128) CHARACTER SET ascii COLLATE ascii_bin NOT NULL,
+  event_time DATETIME(6) NOT NULL,
+  recorded_at DATETIME(6) NOT NULL,
+  tenant_id VARCHAR(128) CHARACTER SET ascii COLLATE ascii_bin NOT NULL,
+  business_domain_id VARCHAR(128) CHARACTER SET ascii COLLATE ascii_bin NOT NULL,
+  knowledge_network_id VARCHAR(128) CHARACTER SET ascii COLLATE ascii_bin NOT NULL,
+  actor_id VARCHAR(128) CHARACTER SET ascii COLLATE ascii_bin NOT NULL,
+  actor_name VARCHAR(255) NOT NULL,
+  actor_type VARCHAR(32) CHARACTER SET ascii COLLATE ascii_bin NOT NULL,
+  auth_method VARCHAR(32) CHARACTER SET ascii COLLATE ascii_bin NOT NULL,
+  credential_id VARCHAR(128) CHARACTER SET ascii COLLATE ascii_bin NOT NULL DEFAULT '',
+  request_id VARCHAR(128) CHARACTER SET ascii COLLATE ascii_bin NOT NULL,
+  source_channel VARCHAR(32) CHARACTER SET ascii COLLATE ascii_bin NOT NULL,
+  method VARCHAR(16) CHARACTER SET ascii COLLATE ascii_bin NOT NULL,
+  action VARCHAR(32) CHARACTER SET ascii COLLATE ascii_bin NOT NULL,
+  target_type VARCHAR(64) CHARACTER SET ascii COLLATE ascii_bin NOT NULL,
+  target_id VARCHAR(1024) NOT NULL,
+  target_name VARCHAR(1024) NOT NULL,
+  outcome VARCHAR(16) CHARACTER SET ascii COLLATE ascii_bin NOT NULL,
+  failure_code VARCHAR(128) CHARACTER SET ascii COLLATE ascii_bin NOT NULL DEFAULT '',
+  failure_message VARCHAR(512) NOT NULL DEFAULT '',
+  change_summary TEXT NOT NULL,
+  schema_version VARCHAR(16) CHARACTER SET ascii COLLATE ascii_bin NOT NULL,
+  PRIMARY KEY (event_id),
+  INDEX idx_bkn_audit_tenant_time (tenant_id, event_time, event_id),
+  INDEX idx_bkn_audit_domain_network_time (business_domain_id, knowledge_network_id, event_time, event_id),
+  INDEX idx_bkn_audit_actor_time (actor_id, event_time, event_id)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin COMMENT='BKN Backend management operation audit facts';


### PR DESCRIPTION
## Summary

- persist bounded, source-owned audit facts for registered BKN management operations
- capture success, failure, and denied outcomes without storing request bodies or credentials
- expose tenant-, business-domain-, and knowledge-network-scoped list/detail queries
- connect BKN Backend audit facts to the unified Agent Observability log query

## Design boundary

This PR covers management and configuration operations for domain knowledge networks. Runtime queries, action execution, validation, previews, and internal task steps remain Trace/runtime facts. The legacy Kafka audit stream is not consumed.

## Validation

- `go test ./common/operationaudit ./common/bkntrace ./driveradapters -count=1`
- `go vet ./common/operationaudit ./common/bkntrace ./driveradapters`
- `go test ./src/drivenadapter/httpaccess/bknbackendaudit ./src/domain/service/logsvc ./src/boot -count=1`
- `go vet ./src/drivenadapter/httpaccess/bknbackendaudit ./src/domain/service/logsvc ./src/boot`
- BKN Backend MariaDB migration lint passed for `0.1.4`

Runtime deployment and real-operation acceptance remain the next gate after review.

Refs #547
