### PR TITLE
fix(vega): reject self-referencing field features

### DIFF
--- a/adp/vega/vega-backend/server/driveradapters/validate_resource.go
+++ b/adp/vega/vega-backend/server/driveradapters/validate_resource.go
@@ -166,6 +166,10 @@ func validatePropertyFeatures(ctx context.Context, prop *interfaces.Property, pr
 				return rest.NewHTTPError(ctx, http.StatusBadRequest, verrors.VegaBackend_Dataset_InvalidParameter_FieldFeatureRef).
 					WithErrorDetails("ref_property is only supported by original resources")
 			}
+			if f.RefProperty == prop.Name {
+				return rest.NewHTTPError(ctx, http.StatusBadRequest, verrors.VegaBackend_Dataset_InvalidParameter_FieldFeatureRef).
+					WithErrorDetails(fmt.Sprintf("The field feature ref_property '%s' cannot reference itself", f.RefProperty))
+			}
 
 			refProp, exists := propsMap[f.RefProperty]
 			if !exists {

--- a/adp/vega/vega-backend/server/driveradapters/validate_test.go
+++ b/adp/vega/vega-backend/server/driveradapters/validate_test.go
@@ -368,6 +368,17 @@ func TestValidateResourceRequestDatasetSchema(t *testing.T) {
 		}
 	})
 
+	t.Run("validateSchemaProperties rejects self-referencing ref_property", func(t *testing.T) {
+		err := validateSchemaProperties(ctx, []*interfaces.Property{
+			{Name: "body", Type: interfaces.DataType_Text, Features: []interfaces.PropertyFeature{
+				{FeatureName: "body.ft", FeatureType: interfaces.PropertyFeatureType_Fulltext, RefProperty: "body", IsNative: true},
+			}},
+		}, true)
+
+		require.Error(t, err)
+		assert.ErrorContains(t, err, "cannot reference itself")
+	})
+
 	t.Run("validateSchemaProperties accepts valid original resource fields", func(t *testing.T) {
 		tests := []struct {
 			name   string
@@ -381,10 +392,10 @@ func TestValidateResourceRequestDatasetSchema(t *testing.T) {
 				},
 			},
 			{
-				name: "dataset with native fulltext feature",
+				name: "dataset with native fulltext feature without ref_property",
 				fields: []*interfaces.Property{
 					{Name: "body", Type: interfaces.DataType_Text, Features: []interfaces.PropertyFeature{
-						{FeatureName: "body.ft", FeatureType: interfaces.PropertyFeatureType_Fulltext, RefProperty: "body", IsNative: true},
+						{FeatureName: "body.ft", FeatureType: interfaces.PropertyFeatureType_Fulltext, IsNative: true},
 					}},
 				},
 			},


### PR DESCRIPTION
# Pull Request

## What Changed

Brief description of changes:

- [x] Vega Backend：拒绝字段特征的 `ref_property` 自引用。
- [ ] Docs/doc 1（不适用：OpenAPI 字段定义保持不变。）

---

## Why

- Related Issue: [bkn-studio #414](https://github.com/openbkn-ai/bkn-studio/issues/414)
- Related Feature: 数据目录索引配置
- Background: `ref_property` 仅用于引用其他字段的结果；自引用没有业务语义且会触发错误的类型校验路径。

---

## How

- Key implementation points: 在原始资源 Schema 的字段特征校验中，显式拒绝 `ref_property == 当前字段名`，并返回 `InvalidParameter.FieldFeatureRef`；同步调整合法原生全文特征的测试用例。
- Breaking changes (API, config, database, etc.): 对提交自引用 `ref_property` 的无效请求新增 400 拒绝；合法跨字段引用不受影响。

---

## Testing

- [x] Unit tests passed locally
- [ ] Integration tests passed locally（不适用：本次为请求校验单元逻辑。）
- [ ] Verified in test environment（未执行。）

Test notes:

- `make ci`（包含 `make lint` 与覆盖率单元测试）

---

## Risk & Rollback

- Potential risks: 任何仍提交自引用 `ref_property` 的客户端将收到明确 400；配套前端 PR 已停止生成此请求。
- Rollback plan: 回滚本 PR 即可恢复此前的兼容行为。

---

## Additional Notes

- 应与 bkn-studio 的 #415 一并合并和发布，以同时消除错误请求并防止其他客户端重新引入自引用。