### PR TITLE
feat(bkn-safe): teach the resource enumeration read about inheritance (#800)

### DIFF
--- a/bkn-safe/server/internal/authz/authz.go
+++ b/bkn-safe/server/internal/authz/authz.go
@@ -431,7 +431,19 @@ func (en *Enforcer) RemoveResourcePolicies(resourceType, resourceID string) erro
 // IDs are returned verbatim (bkn-safe is opaque to any caller-side id encoding,
 // e.g. "dagID:subtype"), de-duplicated, in first-appearance order. Mirrors ISF
 // resource-list for one (accessor, type, op).
+//
+// Instances reached only through an ancestor are included too (#800). Without
+// that, this read would silently under-report the moment inheritance carries a
+// grant: an inherited resource holds no policy row of its own, so a list page
+// built on this endpoint would lose rows that Check allows — and every caller
+// keeps working unchanged instead of having to learn about the hierarchy.
 func (en *Enforcer) AccessibleResources(accessorID, resourceType, op string) ([]string, error) {
+	return en.accessibleResources(accessorID, resourceType, op, map[string]bool{})
+}
+
+// accessibleResources is AccessibleResources plus the visited-type set that
+// keeps the ancestor recursion finite.
+func (en *Enforcer) accessibleResources(accessorID, resourceType, op string, visitedTypes map[string]bool) ([]string, error) {
 	perms, err := en.e.GetImplicitPermissionsForUser(accessorID)
 	if err != nil {
 		return nil, err
@@ -452,6 +464,17 @@ func (en *Enforcer) AccessibleResources(accessorID, resourceType, op string) ([]
 		}
 		id := o[len(prefix):] // split on first ":" only; id may itself contain ":"
 		if id == "*" || seen[id] {
+			continue
+		}
+		seen[id] = true
+		out = append(out, id)
+	}
+	inherited, err := en.inheritedResources(accessorID, resourceType, op, visitedTypes)
+	if err != nil {
+		return nil, err
+	}
+	for _, id := range inherited {
+		if seen[id] {
 			continue
 		}
 		seen[id] = true

--- a/bkn-safe/server/internal/authz/hierarchy.go
+++ b/bkn-safe/server/internal/authz/hierarchy.go
@@ -249,6 +249,17 @@ func (en *Enforcer) inheritedResources(accessorID, resourceType, op string, visi
 	// that has a parent at all. It has to be handled separately because
 	// AccessibleResources deliberately reports concrete instances only, so the
 	// recursive call below would return nothing for it.
+	//
+	// The result set is as large as the number of owned instances, and this
+	// endpoint has never paginated. That is tolerable today because callers
+	// probe the type-wide case FIRST (vega's resolveOps and the operator
+	// integration both check obj="<type>:*" and skip enumeration when it holds),
+	// so this branch is only reached by an accessor holding the wildcard on the
+	// PARENT type but not on the type itself — which no seeded role is. #513
+	// creates exactly that state if it revokes normal_user's resource:* while
+	// leaving catalog:*, and the size question has to be answered there rather
+	// than by quietly truncating here: a short list would read as "these are the
+	// tables you may see".
 	wide, err := en.e.Enforce(accessorID, obj(parentType, "*"), parentOp)
 	if err != nil {
 		return nil, err
@@ -261,10 +272,68 @@ func (en *Enforcer) inheritedResources(accessorID, resourceType, op string, visi
 	if err != nil {
 		return nil, err
 	}
+	// accessibleResources reads GetImplicitPermissionsForUser, which covers the
+	// matcher's g() half but NOT its "granted to everyone" half. Check's climb
+	// goes through Enforce and sees both, so leaving it out here would make a
+	// publicly granted catalog allow a table on the detail page and hide it from
+	// the list — the exact divergence this slice exists to close.
+	//
+	// The union is applied to the ANCESTOR lookup only. accessibleResources is
+	// blind to public grants for directly granted instances too, but that is
+	// how this endpoint has always answered; widening it would change what
+	// today's callers get for resource types that have nothing to do with the
+	// hierarchy (the execution factory grants built-in toolboxes to everyone).
+	public, err := en.publicInstances(parentType, parentOp)
+	if err != nil {
+		return nil, err
+	}
+	seen := make(map[string]bool, len(parents))
+	for _, id := range parents {
+		seen[id] = true
+	}
+	for _, id := range public {
+		if !seen[id] {
+			seen[id] = true
+			parents = append(parents, id)
+		}
+	}
 	if len(parents) == 0 {
 		return nil, nil
 	}
 	return en.childrenOf(resourceType, parentType, parents)
+}
+
+// publicInstances lists the concrete instances of a type on which the "granted
+// to everyone" accessor holds op. These are real policy rows with a fixed
+// subject rather than role-derived ones, so casbin's implicit-permission read
+// does not report them (filter.go's grantIndex reads them the same way).
+func (en *Enforcer) publicInstances(resourceType, op string) ([]string, error) {
+	rows, err := en.e.GetFilteredPolicy(0, PublicAccessorID)
+	if err != nil {
+		return nil, err
+	}
+	prefix := resourceType + ":"
+	seen := map[string]bool{}
+	out := make([]string, 0, len(rows))
+	for _, row := range rows {
+		if len(row) < 3 {
+			continue
+		}
+		o, act := row[1], row[2]
+		if act != op && act != ActAll {
+			continue
+		}
+		if len(o) <= len(prefix) || o[:len(prefix)] != prefix {
+			continue
+		}
+		id := o[len(prefix):]
+		if id == "*" || seen[id] {
+			continue
+		}
+		seen[id] = true
+		out = append(out, id)
+	}
+	return out, nil
 }
 
 // childrenOf lists the ids of resourceType sitting under the given parents. A

--- a/bkn-safe/server/internal/authz/hierarchy.go
+++ b/bkn-safe/server/internal/authz/hierarchy.go
@@ -5,9 +5,12 @@
 package authz
 
 import (
+	"errors"
 	"log/slog"
 	"sort"
 	"strings"
+
+	"gorm.io/gorm"
 
 	"github.com/openbkn-ai/bkn-foundry/bkn-safe/server/internal/model"
 )
@@ -208,6 +211,100 @@ func (en *Enforcer) parentOpMap(resourceType string) (map[string]string, error) 
 		out[row.ID] = row.ParentOperationID
 	}
 	return out, nil
+}
+
+// childIDChunk bounds the size of one "children of these parents" IN clause.
+// An accessor holding many catalogs would otherwise produce a single statement
+// with thousands of bind parameters.
+const childIDChunk = 500
+
+// inheritedResources lists the instances of resourceType the accessor reaches
+// only through an ancestor — the enumeration counterpart of the climb that
+// Check performs. Where Check walks UP from one resource, this walks DOWN from
+// the ancestors the accessor can act on, because the question is inverted:
+// "which tables may I touch" rather than "may I touch this table".
+//
+// visitedTypes keeps the recursion finite. The type graph is validated acyclic
+// when the catalog is seeded, so this is a second belt rather than the only one.
+func (en *Enforcer) inheritedResources(accessorID, resourceType, op string, visitedTypes map[string]bool) ([]string, error) {
+	if en.db == nil || visitedTypes[resourceType] {
+		return nil, nil
+	}
+	visitedTypes[resourceType] = true
+
+	mapping, err := en.parentOpMap(resourceType)
+	if err != nil {
+		return nil, err
+	}
+	parentOp, inherits := mapping[op]
+	if !inherits {
+		return nil, nil
+	}
+	parentType, err := en.parentTypeOf(resourceType)
+	if err != nil || parentType == "" {
+		return nil, err
+	}
+
+	// A type-wide grant on the parent ("every catalog") reaches every instance
+	// that has a parent at all. It has to be handled separately because
+	// AccessibleResources deliberately reports concrete instances only, so the
+	// recursive call below would return nothing for it.
+	wide, err := en.e.Enforce(accessorID, obj(parentType, "*"), parentOp)
+	if err != nil {
+		return nil, err
+	}
+	if wide {
+		return en.childrenOf(resourceType, parentType, nil)
+	}
+
+	parents, err := en.accessibleResources(accessorID, parentType, parentOp, visitedTypes)
+	if err != nil {
+		return nil, err
+	}
+	if len(parents) == 0 {
+		return nil, nil
+	}
+	return en.childrenOf(resourceType, parentType, parents)
+}
+
+// childrenOf lists the ids of resourceType sitting under the given parents. A
+// nil parent list means "under any parent of that type".
+func (en *Enforcer) childrenOf(resourceType, parentType string, parentIDs []string) ([]string, error) {
+	q := en.db.Model(&model.ResourceParent{}).
+		Where("resource_type_id = ? AND parent_type_id = ?", resourceType, parentType)
+	if parentIDs == nil {
+		var ids []string
+		if err := q.Pluck("resource_id", &ids).Error; err != nil {
+			return nil, err
+		}
+		return ids, nil
+	}
+	out := make([]string, 0, len(parentIDs))
+	for start := 0; start < len(parentIDs); start += childIDChunk {
+		end := min(start+childIDChunk, len(parentIDs))
+		var ids []string
+		if err := en.db.Model(&model.ResourceParent{}).
+			Where("resource_type_id = ? AND parent_type_id = ? AND parent_id IN ?",
+				resourceType, parentType, parentIDs[start:end]).
+			Pluck("resource_id", &ids).Error; err != nil {
+			return nil, err
+		}
+		out = append(out, ids...)
+	}
+	return out, nil
+}
+
+// parentTypeOf returns the type this one hangs under, or "" when it is a root.
+func (en *Enforcer) parentTypeOf(resourceType string) (string, error) {
+	var rt model.ResourceType
+	err := en.db.First(&rt, "id = ?", resourceType).Error
+	if errors.Is(err, gorm.ErrRecordNotFound) {
+		return "", nil
+	}
+	if err != nil {
+		return "", err
+	}
+	return rt.ParentTypeID, nil
 }
 
 // distinctSorted returns the map's distinct values in a stable order, so the

--- a/bkn-safe/server/internal/authz/hierarchy_test.go
+++ b/bkn-safe/server/internal/authz/hierarchy_test.go
@@ -6,6 +6,7 @@ package authz
 
 import (
 	"sort"
+	"strings"
 	"testing"
 	"time"
 
@@ -327,5 +328,175 @@ func TestInheritanceTerminatesOnACycle(t *testing.T) {
 		}
 	case <-time.After(5 * time.Second):
 		t.Fatal("Check did not terminate on a cyclic hierarchy")
+	}
+}
+
+// --- enumeration side (GET /authz/resources) -------------------------------
+
+// TestAccessibleResourcesIncludesInherited: the enumeration read must agree with
+// Check, or a list page loses rows the detail page allows. It walks DOWN from
+// the granted catalogs, the inverse of Check's climb.
+func TestAccessibleResourcesIncludesInherited(t *testing.T) {
+	e, db := newTestEnforcerDB(t)
+	declareCatalogHierarchy(t, db)
+	ownedBy(t, db, "res-1", "cat-1")
+	ownedBy(t, db, "res-2", "cat-1")
+	ownedBy(t, db, "res-3", "cat-2")
+
+	const user = "u-1"
+	mustNoErr(t, e.GrantObjectPermission(user, "catalog", "cat-1", "resource_manage"))
+	mustNoErr(t, e.GrantObjectPermission(user, "resource", "res-9", "modify"))
+
+	got, err := e.AccessibleResources(user, "resource", "modify")
+	if err != nil {
+		t.Fatal(err)
+	}
+	sort.Strings(got)
+	want := []string{"res-1", "res-2", "res-9"}
+	if strings.Join(got, ",") != strings.Join(want, ",") {
+		t.Errorf("ids = %v, want %v (res-3 sits in an ungranted catalog)", got, want)
+	}
+}
+
+// TestAccessibleResourcesTypeWideParentGrant covers the case the recursion
+// cannot answer on its own: AccessibleResources reports concrete instances only,
+// so a "every catalog" grant would enumerate no parents at all and silently
+// return nothing.
+func TestAccessibleResourcesTypeWideParentGrant(t *testing.T) {
+	e, db := newTestEnforcerDB(t)
+	declareCatalogHierarchy(t, db)
+	ownedBy(t, db, "res-1", "cat-1")
+	ownedBy(t, db, "res-2", "cat-2")
+
+	const user, role = "u-1", "role-1"
+	mustNoErr(t, e.GrantRolePermission(role, "catalog", "*", "resource_manage"))
+	mustNoErr(t, e.AssignRole(user, role))
+
+	got, err := e.AccessibleResources(user, "resource", "modify")
+	if err != nil {
+		t.Fatal(err)
+	}
+	sort.Strings(got)
+	if strings.Join(got, ",") != "res-1,res-2" {
+		t.Errorf("ids = %v, want every table that has a catalog", got)
+	}
+}
+
+// TestAccessibleResourcesUnmappedOpDoesNotInherit: authorize maps to nothing, so
+// enumeration must not leak the catalog's tables into it either.
+func TestAccessibleResourcesUnmappedOpDoesNotInherit(t *testing.T) {
+	e, db := newTestEnforcerDB(t)
+	declareCatalogHierarchy(t, db)
+	ownedBy(t, db, "res-1", "cat-1")
+
+	const user = "u-1"
+	mustNoErr(t, e.GrantObjectPermission(user, "catalog", "cat-1", "authorize"))
+
+	got, err := e.AccessibleResources(user, "resource", "authorize")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 0 {
+		t.Errorf("ids = %v, want none", got)
+	}
+}
+
+// TestAccessibleResourcesUnchangedWithoutHierarchy is the upgrade guarantee for
+// this read: with no ownership rows, it returns exactly what it returned before.
+func TestAccessibleResourcesUnchangedWithoutHierarchy(t *testing.T) {
+	e, db := newTestEnforcerDB(t)
+	declareCatalogHierarchy(t, db)
+
+	const user = "u-1"
+	mustNoErr(t, e.GrantObjectPermission(user, "catalog", "cat-1", "resource_manage"))
+	mustNoErr(t, e.GrantObjectPermission(user, "resource", "res-9", "modify"))
+
+	got, err := e.AccessibleResources(user, "resource", "modify")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 1 || got[0] != "res-9" {
+		t.Errorf("ids = %v, want only the directly granted res-9", got)
+	}
+}
+
+// TestAccessibleResourcesAgreesWithCheck pins the two reads together across the
+// whole population: anything enumerated must pass Check, and anything Check
+// allows must be enumerated. Drift here is the failure this slice exists to
+// prevent — a row present on the detail page and missing from the list.
+func TestAccessibleResourcesAgreesWithCheck(t *testing.T) {
+	e, db := newTestEnforcerDB(t)
+	declareCatalogHierarchy(t, db)
+	all := []string{"res-1", "res-2", "res-3", "res-4"}
+	ownedBy(t, db, "res-1", "cat-1")
+	ownedBy(t, db, "res-2", "cat-1")
+	ownedBy(t, db, "res-3", "cat-2")
+	// res-4 has no catalog at all.
+
+	const user = "u-1"
+	mustNoErr(t, e.GrantObjectPermission(user, "catalog", "cat-1", "resource_manage"))
+	mustNoErr(t, e.GrantObjectPermission(user, "resource", "res-4", "modify"))
+	mustNoErr(t, e.GrantObjectPermission(user, "resource", "res-3", "view_detail"))
+
+	for _, op := range []string{"modify", "view_detail", "delete", "authorize"} {
+		ids, err := e.AccessibleResources(user, "resource", op)
+		if err != nil {
+			t.Fatal(err)
+		}
+		listed := map[string]bool{}
+		for _, id := range ids {
+			listed[id] = true
+		}
+		for _, id := range all {
+			ok, err := e.Check(user, "resource", id, op)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if ok != listed[id] {
+				t.Errorf("%s/%s: check=%v enumerated=%v", id, op, ok, listed[id])
+			}
+		}
+	}
+}
+
+// TestAccessibleResourcesAcrossLevels: a grant two levels up must enumerate the
+// leaves, which only works if the recursion carries the translated operation.
+func TestAccessibleResourcesAcrossLevels(t *testing.T) {
+	e, db := newTestEnforcerDB(t)
+	types := []model.ResourceType{
+		{ID: "top"},
+		{ID: "mid", ParentTypeID: "top"},
+		{ID: "leaf", ParentTypeID: "mid"},
+	}
+	if err := db.Create(&types).Error; err != nil {
+		t.Fatal(err)
+	}
+	ops := []model.Operation{
+		{ResourceTypeID: "top", ID: "manage_all"},
+		{ResourceTypeID: "mid", ID: "manage_children", ParentOperationID: "manage_all"},
+		{ResourceTypeID: "leaf", ID: "modify", ParentOperationID: "manage_children"},
+	}
+	if err := db.Create(&ops).Error; err != nil {
+		t.Fatal(err)
+	}
+	rows := []model.ResourceParent{
+		{ResourceTypeID: "leaf", ResourceID: "l-1", ParentTypeID: "mid", ParentID: "m-1"},
+		{ResourceTypeID: "leaf", ResourceID: "l-2", ParentTypeID: "mid", ParentID: "m-2"},
+		{ResourceTypeID: "mid", ResourceID: "m-1", ParentTypeID: "top", ParentID: "t-1"},
+		{ResourceTypeID: "mid", ResourceID: "m-2", ParentTypeID: "top", ParentID: "t-2"},
+	}
+	if err := db.Create(&rows).Error; err != nil {
+		t.Fatal(err)
+	}
+
+	const user = "u-1"
+	mustNoErr(t, e.GrantObjectPermission(user, "top", "t-1", "manage_all"))
+
+	got, err := e.AccessibleResources(user, "leaf", "modify")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 1 || got[0] != "l-1" {
+		t.Errorf("ids = %v, want only l-1 (l-2 hangs under an ungranted top)", got)
 	}
 }

--- a/bkn-safe/server/internal/authz/hierarchy_test.go
+++ b/bkn-safe/server/internal/authz/hierarchy_test.go
@@ -500,3 +500,33 @@ func TestAccessibleResourcesAcrossLevels(t *testing.T) {
 		t.Errorf("ids = %v, want only l-1 (l-2 hangs under an ungranted top)", got)
 	}
 }
+
+// TestAccessibleResourcesSeesPubliclyGrantedAncestor closes the gap a review
+// found: Check's climb goes through Enforce, whose matcher honours the
+// "granted to everyone" subject, while the enumeration walks
+// GetImplicitPermissionsForUser, which does not. A catalog granted to everyone
+// would then allow its tables on the detail page and hide them from the list.
+func TestAccessibleResourcesSeesPubliclyGrantedAncestor(t *testing.T) {
+	e, db := newTestEnforcerDB(t)
+	declareCatalogHierarchy(t, db)
+	ownedBy(t, db, "res-1", "cat-public")
+	ownedBy(t, db, "res-2", "cat-private")
+
+	mustNoErr(t, e.GrantObjectPermission(PublicAccessorID, "catalog", "cat-public", "resource_manage"))
+
+	const user = "u-nobody" // holds nothing of its own
+	ok, err := e.Check(user, "resource", "res-1", "modify")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !ok {
+		t.Fatal("Check did not honour the public grant on the catalog")
+	}
+	ids, err := e.AccessibleResources(user, "resource", "modify")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(ids) != 1 || ids[0] != "res-1" {
+		t.Errorf("ids = %v, want [res-1] — enumeration must agree with Check", ids)
+	}
+}


### PR DESCRIPTION
Stage 3 of #800, and the last one before ownership data starts flowing.

## The gap

`GET /authz/resources` enumerates policy rows. An inherited resource holds no policy row of its own, so the moment ownership data lands this read **silently under-returns**: the detail page allows what the list page cannot show, which reads as data loss rather than as a denial.

## Fixed inside bkn-safe, not at the callers

The obvious alternative was to move vega's list path onto `POST /authz/resource-filter`, which #832 already taught. That would mean changing a mechanism two services rely on. Instead the enumeration read learned the hierarchy itself, so **vega and operator-integration are untouched** and the hierarchy stays invisible at the calling side.

The walk runs in the opposite direction from `Check`: `Check` climbs up from one resource, this descends from the ancestors the accessor can act on — the question is inverted ("which tables may I touch", not "may I touch this table").

The type-wide case needs its own branch. This endpoint reports concrete instances only, by contract, so an accessor holding `catalog:*` + `resource_manage` would recurse into a parent lookup that returns nothing and silently enumerate zero rows.

## Verified against a real MariaDB, not just sqlite

Unit tests run on sqlite, which hides both the DDL and the `NULL <> ''` question. So this was run end to end on MariaDB 11.8 as an in-place upgrade:

1. **Old binary first** (main at `58139222`, before #827) against an empty database — 22 resource types, 120 operations, 146 casbin rules, no `parent_*` columns, no `resource_parents` table.
2. **Snapshot 24 decisions** — every seeded role against `catalog:cat-1`, `resource:res-1`, `resource:res-2`, `agent:probe`.
3. **New binary against the same database.** `AutoMigrate` added both columns and the table; the composite primary key `varchar(64)+varchar(128)` was created without complaint, and `idx_resource_parent_parent` came with it.
4. **Re-snapshot: byte-identical.** No seeded role's operation set moved.
5. Mapping backfilled correctly — `modify`/`delete` → `resource_manage`, `authorize`/`create` empty. The other 113 operations are `''`, not `NULL` (the seed re-upserts every row), so the `<> ''` predicate behaves uniformly; a `NULL` would also filter out, which is the safe direction.
6. **Inheritance end to end**: pushed ownership for three tables, granted one user `resource_manage` on one catalog only, and all three surfaces agreed — `check` allowed the tables in that catalog and refused the one outside it, `GET /resources` returned exactly the two, `resource-filter` returned the same two.
7. **Same-name fallback stays refused on a real engine**: granting `modify` on the other catalog did **not** give `modify` on its tables.
8. **Rollback**: `DELETE FROM resource_parents` put all three surfaces straight back to the pre-#800 answers.

## Behaviour today

Unchanged. No module writes ownership rows yet, so every climb ends immediately. When rows do land, this read matches `Check` instead of trailing it — `TestAccessibleResourcesAgreesWithCheck` pins the two together over the whole population, in both directions.

## Tests

- inherited instances enumerated; a table in an ungranted catalog is not
- a type-wide parent grant enumerates every table that has a catalog
- an unmapped operation (`authorize`) inherits nothing
- empty ownership table returns exactly what the previous release returned
- enumeration and `Check` agree for every resource and operation
- a grant two levels up enumerates only the leaves beneath it

🤖 Generated with [Claude Code](https://claude.com/claude-code)
