### PR TITLE
feat(bkn-safe): preview the widening before ownership is recorded (#800)

### DIFF
--- a/bkn-safe/server/internal/authz/hierarchy.go
+++ b/bkn-safe/server/internal/authz/hierarchy.go
@@ -213,9 +213,10 @@ func (en *Enforcer) parentOpMap(resourceType string) (map[string]string, error) 
 	return out, nil
 }
 
-// childIDChunk bounds the size of one "children of these parents" IN clause.
-// An accessor holding many catalogs would otherwise produce a single statement
-// with thousands of bind parameters.
+// childIDChunk bounds one IN clause over resource ids — both "children of these
+// parents" and the preview's "which of these already have a parent". An
+// accessor holding many catalogs, or a full-snapshot preview, would otherwise
+// produce a single statement with thousands of bind parameters.
 const childIDChunk = 500
 
 // inheritedResources lists the instances of resourceType the accessor reaches
@@ -423,4 +424,281 @@ func (en *Enforcer) inheritedOps(accessorID, resourceType, resourceID string, mi
 		return nil, err
 	}
 	return found[r], nil
+}
+
+// Ownership flip directions. A preview reports both because a synchroniser
+// keys its "safe to push" decision on the total: counting only widening would
+// let a re-parenting that REMOVES someone's access report zero.
+const (
+	FlipGrant  = "grant"
+	FlipRevoke = "revoke"
+)
+
+// OwnershipFlip is one decision that would change if a proposed set of
+// ownership rows were recorded: subject, resource, operation, and which way it
+// moves. The subject is reported verbatim — it may be a user or a role, and
+// reporting the role rather than expanding it keeps the report the size of the
+// grant that causes the change rather than the size of that role's membership.
+type OwnershipFlip struct {
+	AccessorID string
+	ResourceID string
+	Operation  string
+	Direction  string
+}
+
+// PreviewOwnership answers "who would gain and lose what" BEFORE any ownership
+// row is written. It exists because recording ownership is the moment
+// inheritance starts applying, and there is no flag to stage that (an
+// allow-only engine has nothing to tighten), so the confirmation has to happen
+// before the write rather than after it.
+//
+// links maps each proposed resource id to its proposed parent id. limit caps
+// the returned slice; the total is always exact, so a caller can say "3 shown
+// of 412" rather than implying the list is complete.
+//
+// Whether a subject reaches the proposed parent is decided by the SAME
+// evaluation the enforcer uses, not by reading policy rows on that parent: the
+// hierarchy has no depth limit, so a grant two levels up reaches the parent and
+// therefore the child. A preview that only read the immediate parent would
+// under-report, and a safety preview that under-reports is worse than none.
+func (en *Enforcer) PreviewOwnership(resourceType, parentType string, links map[string]string, limit int) ([]OwnershipFlip, int, error) {
+	if en.db == nil || len(links) == 0 {
+		return nil, 0, nil
+	}
+	mapping, err := en.parentOpMap(resourceType)
+	if err != nil {
+		return nil, 0, err
+	}
+	if len(mapping) == 0 {
+		return nil, 0, nil // nothing about this type inherits
+	}
+	childOps := make([]string, 0, len(mapping))
+	for op := range mapping {
+		childOps = append(childOps, op)
+	}
+	sort.Strings(childOps)
+	parentOps := distinctSorted(mapping)
+
+	children := make([]string, 0, len(links))
+	parentSet := map[string]bool{}
+	for child, parent := range links {
+		children = append(children, child)
+		parentSet[parent] = true
+	}
+	sort.Strings(children)
+	parents := make([]string, 0, len(parentSet))
+	for p := range parentSet {
+		parents = append(parents, p)
+	}
+	sort.Strings(parents)
+
+	childRefs := make([]ResourceRef, 0, len(children))
+	for _, id := range children {
+		childRefs = append(childRefs, ResourceRef{Type: resourceType, ID: id})
+	}
+	parentRefs := make([]ResourceRef, 0, len(parents))
+	for _, id := range parents {
+		parentRefs = append(parentRefs, ResourceRef{Type: parentType, ID: id})
+	}
+
+	// Which children are being MOVED. Only those can lose anything: a resource
+	// that had no parent, or keeps the one it has, cannot stop reaching a grant
+	// it already reaches.
+	current, err := en.currentParents(resourceType, children)
+	if err != nil {
+		return nil, 0, err
+	}
+	moved := map[string]bool{}
+	for child, proposed := range links {
+		if now, ok := current[child]; ok && now != proposed {
+			moved[child] = true
+		}
+	}
+
+	// Candidates must include whoever reaches the OLD parent as well: those are
+	// exactly the subjects a move takes access away from, and they may hold
+	// nothing anywhere near the new one.
+	lookIn := append([]ResourceRef{}, parentRefs...)
+	seenOld := map[string]bool{}
+	for child := range moved {
+		old := current[child]
+		if old == "" || seenOld[old] {
+			continue
+		}
+		seenOld[old] = true
+		lookIn = append(lookIn, ResourceRef{Type: parentType, ID: old})
+	}
+	subjects, err := en.previewCandidates(lookIn)
+	if err != nil {
+		return nil, 0, err
+	}
+
+	out := make([]OwnershipFlip, 0, limit)
+	total := 0
+	record := func(sub, child, op, dir string) {
+		total++
+		if len(out) < limit {
+			out = append(out, OwnershipFlip{
+				AccessorID: sub, ResourceID: child, Operation: op, Direction: dir,
+			})
+		}
+	}
+
+	for _, sub := range subjects {
+		// What the subject may do on the proposed parents — through direct
+		// grants, roles, wildcards, the grant-to-everyone subject, AND the
+		// parents' own ancestors. This is the enforcer's answer, not a row scan.
+		onParents, err := en.FilterResourceOps(sub, parentRefs, nil, parentOps)
+		if err != nil {
+			return nil, 0, err
+		}
+		heldOnParent := make(map[string]map[string]bool, len(onParents))
+		for _, p := range onParents {
+			set := make(map[string]bool, len(p.Operations))
+			for _, op := range p.Operations {
+				set[op] = true
+			}
+			heldOnParent[p.ID] = set
+		}
+		// What the subject may do on the children TODAY, including whatever the
+		// current ownership rows already confer.
+		onChildren, err := en.FilterResourceOps(sub, childRefs, nil, childOps)
+		if err != nil {
+			return nil, 0, err
+		}
+		have := make(map[string]map[string]bool, len(onChildren))
+		for _, c := range onChildren {
+			set := make(map[string]bool, len(c.Operations))
+			for _, op := range c.Operations {
+				set[op] = true
+			}
+			have[c.ID] = set
+		}
+
+		for _, child := range children {
+			gained := map[string]bool{}
+			for _, childOp := range childOps {
+				if heldOnParent[links[child]][mapping[childOp]] {
+					gained[childOp] = true
+				}
+			}
+			for _, op := range childOps {
+				if gained[op] && !have[child][op] {
+					record(sub, child, op, FlipGrant)
+				}
+			}
+			if !moved[child] {
+				continue
+			}
+			// A move can take access away: what the subject holds today may have
+			// come from the OLD parent, and the new one need not confer it. What
+			// survives is the grant on the resource itself plus what the new
+			// parent confers.
+			for _, op := range childOps {
+				if !have[child][op] || gained[op] {
+					continue
+				}
+				direct, err := en.e.Enforce(sub, obj(resourceType, child), op)
+				if err != nil {
+					return nil, 0, err
+				}
+				if !direct {
+					record(sub, child, op, FlipRevoke)
+				}
+			}
+		}
+	}
+	return out, total, nil
+}
+
+// currentParents reads the ownership rows the proposed children have right now,
+// so a re-parenting can be told apart from a first-time registration.
+func (en *Enforcer) currentParents(resourceType string, children []string) (map[string]string, error) {
+	out := map[string]string{}
+	for start := 0; start < len(children); start += childIDChunk {
+		end := min(start+childIDChunk, len(children))
+		var rows []model.ResourceParent
+		if err := en.db.Where("resource_type_id = ? AND resource_id IN ?", resourceType, children[start:end]).
+			Find(&rows).Error; err != nil {
+			return nil, err
+		}
+		for _, r := range rows {
+			out[r.ResourceID] = r.ParentID
+		}
+	}
+	return out, nil
+}
+
+// previewCandidates narrows the subjects a preview has to evaluate. Every
+// subject in the policy store would be correct but wasteful, so it keeps those
+// whose object pattern can reach one of the proposed parents: an exact match, a
+// wildcard pattern (which can match anything), or one of the parents' own
+// ancestors (a grant up there reaches the parent through the same climb the
+// enforcer performs). Being generous here is safe — the evaluation below is
+// what decides; this only bounds the work.
+func (en *Enforcer) previewCandidates(parentRefs []ResourceRef) ([]string, error) {
+	reachable := map[string]bool{}
+	for _, r := range parentRefs {
+		reachable[obj(r.Type, r.ID)] = true
+	}
+	ancestors, err := en.ancestorObjects(parentRefs)
+	if err != nil {
+		return nil, err
+	}
+	for _, o := range ancestors {
+		reachable[o] = true
+	}
+
+	rows, err := en.e.GetPolicy()
+	if err != nil {
+		return nil, err
+	}
+	seen := map[string]bool{}
+	out := make([]string, 0, 16)
+	for _, row := range rows {
+		if len(row) < 3 || seen[row[0]] {
+			continue
+		}
+		object := row[1]
+		hit := hasWildcard(object)
+		if !hit {
+			hit = reachable[object]
+		}
+		if !hit {
+			continue
+		}
+		seen[row[0]] = true
+		out = append(out, row[0])
+	}
+	sort.Strings(out)
+	return out, nil
+}
+
+// ancestorObjects walks up from each ref and returns every ancestor's object
+// key. Bounded by the same depth backstop as the enforce-time climb.
+func (en *Enforcer) ancestorObjects(refs []ResourceRef) ([]string, error) {
+	level := make([]*climber, 0, len(refs))
+	for _, r := range refs {
+		level = append(level, &climber{origin: r, node: r, visited: map[ResourceRef]bool{r: true}})
+	}
+	out := make([]string, 0, len(refs))
+	for depth := 0; len(level) > 0 && depth < maxHierarchyDepth; depth++ {
+		parents, err := en.parentsOf(level)
+		if err != nil {
+			return nil, err
+		}
+		next := make([]*climber, 0, len(level))
+		for _, c := range level {
+			parent, ok := parents[c.node]
+			if !ok || c.visited[parent] {
+				continue
+			}
+			out = append(out, obj(parent.Type, parent.ID))
+			c.node = parent
+			c.visited[parent] = true
+			next = append(next, c)
+		}
+		level = next
+	}
+	return out, nil
 }

--- a/bkn-safe/server/internal/authz/hierarchy_test.go
+++ b/bkn-safe/server/internal/authz/hierarchy_test.go
@@ -6,6 +6,7 @@ package authz
 
 import (
 	"sort"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -528,5 +529,260 @@ func TestAccessibleResourcesSeesPubliclyGrantedAncestor(t *testing.T) {
 	}
 	if len(ids) != 1 || ids[0] != "res-1" {
 		t.Errorf("ids = %v, want [res-1] — enumeration must agree with Check", ids)
+	}
+}
+
+// --- ownership preview (dry run) -------------------------------------------
+
+// TestPreviewOwnershipReportsTheWidening is the confirmation step the design
+// promised in place of a feature flag: before any ownership row is written, say
+// exactly who starts reaching what.
+func TestPreviewOwnershipReportsTheWidening(t *testing.T) {
+	e, db := newTestEnforcerDB(t)
+	declareCatalogHierarchy(t, db)
+
+	const alice, bob = "u-alice", "u-bob"
+	mustNoErr(t, e.GrantObjectPermission(alice, "catalog", "cat-1", "resource_manage"))
+	mustNoErr(t, e.GrantObjectPermission(bob, "catalog", "cat-2", "view_detail"))
+
+	links := map[string]string{"res-1": "cat-1", "res-2": "cat-1", "res-3": "cat-2"}
+	flips, total, err := e.PreviewOwnership("resource", "catalog", links, 100)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := map[string]bool{}
+	for _, f := range flips {
+		got[f.AccessorID+"/"+f.ResourceID+"/"+f.Operation] = true
+	}
+	// alice's resource_manage maps to both modify and delete on the two tables
+	// in cat-1; bob's view_detail maps to view_detail on the single table in cat-2.
+	want := []string{
+		alice + "/res-1/modify", alice + "/res-1/delete",
+		alice + "/res-2/modify", alice + "/res-2/delete",
+		bob + "/res-3/view_detail",
+	}
+	for _, w := range want {
+		if !got[w] {
+			t.Errorf("preview missed %s (got %v)", w, got)
+		}
+	}
+	if total != len(want) {
+		t.Errorf("total = %d, want %d (%v)", total, len(want), got)
+	}
+	// Nothing may have been written: the preview is the step that happens before
+	// the decision to write.
+	var n int64
+	db.Model(&model.ResourceParent{}).Count(&n)
+	if n != 0 {
+		t.Errorf("dry run wrote %d ownership rows", n)
+	}
+}
+
+// TestPreviewOwnershipSkipsWhatIsAlreadyHeld: a table the subject can already
+// touch is not a change, and reporting it would drown the real widening.
+func TestPreviewOwnershipSkipsWhatIsAlreadyHeld(t *testing.T) {
+	e, db := newTestEnforcerDB(t)
+	declareCatalogHierarchy(t, db)
+
+	const user = "u-1"
+	mustNoErr(t, e.GrantObjectPermission(user, "catalog", "cat-1", "resource_manage"))
+	mustNoErr(t, e.GrantObjectPermission(user, "resource", "res-1", "modify"))
+	mustNoErr(t, e.GrantObjectPermission(user, "resource", "res-1", "delete"))
+
+	_, total, err := e.PreviewOwnership("resource", "catalog", map[string]string{"res-1": "cat-1"}, 100)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if total != 0 {
+		t.Errorf("total = %d, want 0 — the subject already held both operations", total)
+	}
+}
+
+// TestPreviewOwnershipEmptyWhenNobodyHoldsTheCatalog is the case that matters
+// most in practice: on an installation with no per-object catalog grants, the
+// diff is empty and the push is a zero-behaviour-change operation.
+func TestPreviewOwnershipEmptyWhenNobodyHoldsTheCatalog(t *testing.T) {
+	e, db := newTestEnforcerDB(t)
+	declareCatalogHierarchy(t, db)
+
+	_, total, err := e.PreviewOwnership("resource", "catalog",
+		map[string]string{"res-1": "cat-1", "res-2": "cat-2"}, 100)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if total != 0 {
+		t.Errorf("total = %d, want 0", total)
+	}
+}
+
+// TestPreviewOwnershipCountsBeyondTheLimit: the sample is capped but the total
+// is exact, so a reviewer is never shown a short list that reads as complete.
+func TestPreviewOwnershipCountsBeyondTheLimit(t *testing.T) {
+	e, db := newTestEnforcerDB(t)
+	declareCatalogHierarchy(t, db)
+	mustNoErr(t, e.GrantObjectPermission("u-1", "catalog", "cat-1", "resource_manage"))
+
+	links := map[string]string{}
+	for i := 0; i < 20; i++ {
+		links["res-"+strconv.Itoa(i)] = "cat-1"
+	}
+	flips, total, err := e.PreviewOwnership("resource", "catalog", links, 5)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(flips) != 5 {
+		t.Errorf("sample = %d, want 5", len(flips))
+	}
+	if total != 40 { // 20 tables x {modify, delete}
+		t.Errorf("total = %d, want 40", total)
+	}
+}
+
+// TestPreviewOwnershipSeesRoleAndPublicGrants: the report has to name the grant
+// that causes the widening, and a catalog held through a role or granted to
+// everyone widens exactly as a direct grant does.
+func TestPreviewOwnershipSeesRoleAndPublicGrants(t *testing.T) {
+	e, db := newTestEnforcerDB(t)
+	declareCatalogHierarchy(t, db)
+
+	const role = "role-builder"
+	mustNoErr(t, e.GrantRolePermission(role, "catalog", "cat-1", "resource_manage"))
+	mustNoErr(t, e.GrantObjectPermission(PublicAccessorID, "catalog", "cat-2", "view_detail"))
+
+	flips, total, err := e.PreviewOwnership("resource", "catalog",
+		map[string]string{"res-1": "cat-1", "res-2": "cat-2"}, 100)
+	if err != nil {
+		t.Fatal(err)
+	}
+	subjects := map[string]bool{}
+	for _, f := range flips {
+		subjects[f.AccessorID] = true
+	}
+	if !subjects[role] {
+		t.Error("preview did not name the role whose grant causes the widening")
+	}
+	if !subjects[PublicAccessorID] {
+		t.Error("preview missed the grant-to-everyone subject")
+	}
+	if total == 0 {
+		t.Error("total = 0")
+	}
+}
+
+// TestPreviewOwnershipSeesGrandparentGrants: the enforce-time climb has no depth
+// limit, so a grant two levels above the proposed parent reaches the child. A
+// preview that only read policy rows on the immediate parent would miss it, and
+// a safety preview that under-reports is worse than none at all.
+func TestPreviewOwnershipSeesGrandparentGrants(t *testing.T) {
+	e, db := newTestEnforcerDB(t)
+	types := []model.ResourceType{
+		{ID: "top"},
+		{ID: "mid", ParentTypeID: "top"},
+		{ID: "leaf", ParentTypeID: "mid"},
+	}
+	if err := db.Create(&types).Error; err != nil {
+		t.Fatal(err)
+	}
+	ops := []model.Operation{
+		{ResourceTypeID: "top", ID: "manage_all"},
+		{ResourceTypeID: "mid", ID: "manage_children", ParentOperationID: "manage_all"},
+		{ResourceTypeID: "leaf", ID: "modify", ParentOperationID: "manage_children"},
+	}
+	if err := db.Create(&ops).Error; err != nil {
+		t.Fatal(err)
+	}
+	// mid already hangs under top; the proposal is to put a leaf under mid.
+	if err := db.Create(&model.ResourceParent{
+		ResourceTypeID: "mid", ResourceID: "m-1", ParentTypeID: "top", ParentID: "t-1",
+	}).Error; err != nil {
+		t.Fatal(err)
+	}
+	const user = "u-1"
+	mustNoErr(t, e.GrantObjectPermission(user, "top", "t-1", "manage_all"))
+
+	flips, total, err := e.PreviewOwnership("leaf", "mid", map[string]string{"l-1": "m-1"}, 100)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if total != 1 || len(flips) != 1 {
+		t.Fatalf("flips = %v (total %d), want the one grandparent-derived grant", flips, total)
+	}
+	if flips[0].AccessorID != user || flips[0].Operation != "modify" || flips[0].Direction != FlipGrant {
+		t.Errorf("flip = %+v, want u-1 gains modify on l-1", flips[0])
+	}
+}
+
+// TestPreviewOwnershipReportsRevokesOnReparent: moving a resource to another
+// parent takes it away from the old parent's holders. Counting only widening
+// would hand a synchroniser total=0 for a push that silently removes access.
+func TestPreviewOwnershipReportsRevokesOnReparent(t *testing.T) {
+	e, db := newTestEnforcerDB(t)
+	declareCatalogHierarchy(t, db)
+	ownedBy(t, db, "res-1", "cat-old")
+
+	const loser, keeper = "u-loser", "u-keeper"
+	mustNoErr(t, e.GrantObjectPermission(loser, "catalog", "cat-old", "resource_manage"))
+	mustNoErr(t, e.GrantObjectPermission(keeper, "catalog", "cat-new", "resource_manage"))
+
+	flips, total, err := e.PreviewOwnership("resource", "catalog", map[string]string{"res-1": "cat-new"}, 100)
+	if err != nil {
+		t.Fatal(err)
+	}
+	byDir := map[string][]string{}
+	for _, f := range flips {
+		byDir[f.Direction] = append(byDir[f.Direction], f.AccessorID+"/"+f.Operation)
+	}
+	sort.Strings(byDir[FlipGrant])
+	sort.Strings(byDir[FlipRevoke])
+	if strings.Join(byDir[FlipGrant], ",") != keeper+"/delete,"+keeper+"/modify" {
+		t.Errorf("grants = %v, want the new catalog's holder gaining modify+delete", byDir[FlipGrant])
+	}
+	if strings.Join(byDir[FlipRevoke], ",") != loser+"/delete,"+loser+"/modify" {
+		t.Errorf("revokes = %v, want the old catalog's holder losing modify+delete", byDir[FlipRevoke])
+	}
+	if total != 4 {
+		t.Errorf("total = %d, want 4", total)
+	}
+}
+
+// TestPreviewOwnershipKeepsDirectGrantsOnReparent: a grant written on the
+// resource itself survives a move, so it must not be reported as a loss.
+func TestPreviewOwnershipKeepsDirectGrantsOnReparent(t *testing.T) {
+	e, db := newTestEnforcerDB(t)
+	declareCatalogHierarchy(t, db)
+	ownedBy(t, db, "res-1", "cat-old")
+
+	const user = "u-1"
+	mustNoErr(t, e.GrantObjectPermission(user, "catalog", "cat-old", "resource_manage"))
+	mustNoErr(t, e.GrantObjectPermission(user, "resource", "res-1", "modify"))
+
+	flips, _, err := e.PreviewOwnership("resource", "catalog", map[string]string{"res-1": "cat-new"}, 100)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, f := range flips {
+		if f.Operation == "modify" && f.Direction == FlipRevoke {
+			t.Errorf("reported a loss of modify, but it is granted on the resource itself: %+v", f)
+		}
+	}
+}
+
+// TestPreviewOwnershipFirstRegistrationCannotRevoke: a resource that had no
+// parent cannot lose anything, so the report must be grants only.
+func TestPreviewOwnershipFirstRegistrationCannotRevoke(t *testing.T) {
+	e, db := newTestEnforcerDB(t)
+	declareCatalogHierarchy(t, db)
+
+	const user = "u-1"
+	mustNoErr(t, e.GrantObjectPermission(user, "catalog", "cat-1", "resource_manage"))
+
+	flips, _, err := e.PreviewOwnership("resource", "catalog", map[string]string{"res-1": "cat-1"}, 100)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, f := range flips {
+		if f.Direction != FlipGrant {
+			t.Errorf("first registration reported %+v", f)
+		}
 	}
 }

--- a/bkn-safe/server/internal/httpapi/authz.go
+++ b/bkn-safe/server/internal/httpapi/authz.go
@@ -282,7 +282,7 @@ func registerAuthz(r *gin.Engine, e *authz.Enforcer, db *gorm.DB) {
 	// Instance-level hierarchy (which catalog a table belongs to). Same tokenless
 	// service face; see resourceparents.go for why the shape check is the guard.
 	if db != nil {
-		registerResourceParents(g, db)
+		registerResourceParents(g, e, db)
 	}
 }
 

--- a/bkn-safe/server/internal/httpapi/resourceparents.go
+++ b/bkn-safe/server/internal/httpapi/resourceparents.go
@@ -14,6 +14,7 @@ import (
 	"gorm.io/gorm"
 	"gorm.io/gorm/clause"
 
+	"github.com/openbkn-ai/bkn-foundry/bkn-safe/server/internal/authz"
 	"github.com/openbkn-ai/bkn-foundry/bkn-safe/server/internal/model"
 )
 
@@ -28,6 +29,12 @@ const maxResourceParentBatch = 1000
 // the first honest reconciliation the largest response the service ever sends.
 const defaultResourceParentPageSize = 500
 
+// maxPreviewFlips caps the sample a dry run returns. The TOTAL is always exact,
+// so a reviewer reads "500 shown of 4128" rather than a list that quietly
+// implies it is the whole story — a truncated report that looks complete is
+// worse than no report, because it invites approving a widening nobody saw.
+const maxPreviewFlips = 500
+
 // registerResourceParents mounts the instance-level hierarchy writes under
 // /api/safe/v1/authz. bkn-safe cannot derive which catalog a table belongs to —
 // it only ever saw opaque "type:id" object keys — so the owning module pushes
@@ -40,7 +47,7 @@ const defaultResourceParentPageSize = 500
 // hangs under a catalog I own" would inherit the admin console from a catalog
 // grant. Declaring the hierarchy in the seed and the membership over HTTP keeps
 // the shape trusted while the data stays owned by the module that knows it.
-func registerResourceParents(g *gin.RouterGroup, db *gorm.DB) {
+func registerResourceParents(g *gin.RouterGroup, e *authz.Enforcer, db *gorm.DB) {
 	// PUT /resource-parents — upsert a batch of (resource -> parent) rows.
 	//
 	//	{ resource_type, parent_type, items:[{resource_id, parent_id}] }
@@ -90,6 +97,38 @@ func registerResourceParents(g *gin.RouterGroup, db *gorm.DB) {
 		}
 		if len(rows) == 0 {
 			c.Status(http.StatusNoContent)
+			return
+		}
+		// dry_run answers "who would gain what" and writes nothing. Recording
+		// ownership is the moment inheritance starts applying, and that is a
+		// widening — whoever holds a grant on a catalog begins to reach the tables
+		// inside it. An allow-only engine has nothing to stage, so the review has
+		// to happen BEFORE the write; there is no flag afterwards to hold it back.
+		if c.Query("dry_run") == "true" {
+			links := make(map[string]string, len(rows))
+			for _, r := range rows {
+				links[r.ResourceID] = r.ParentID
+			}
+			flips, total, err := e.PreviewOwnership(req.ResourceType, req.ParentType, links, maxPreviewFlips)
+			if err != nil {
+				serverError(c, err)
+				return
+			}
+			changes := make([]gin.H, 0, len(flips))
+			for _, f := range flips {
+				changes = append(changes, gin.H{
+					"accessor_id": f.AccessorID,
+					"resource_id": f.ResourceID,
+					"operation":   f.Operation,
+					// "grant" or "revoke": re-pointing a resource at another parent
+					// takes access away from the old parent's holders, and a caller
+					// that keys "safe to push" on the total must see those too.
+					"direction": f.Direction,
+				})
+			}
+			c.JSON(http.StatusOK, gin.H{
+				"changes": changes, "total": total, "truncated": total > len(changes),
+			})
 			return
 		}
 		if err := db.WithContext(c.Request.Context()).Clauses(clause.OnConflict{

--- a/bkn-safe/server/internal/httpapi/resourceparents_test.go
+++ b/bkn-safe/server/internal/httpapi/resourceparents_test.go
@@ -265,3 +265,64 @@ func TestDeletePoliciesDropsHierarchyRow(t *testing.T) {
 		t.Errorf("hierarchy row survived the policy teardown (%d rows left)", n)
 	}
 }
+
+// TestOwnershipDryRunWritesNothing is the endpoint half of the confirmation
+// step: the same request body, plus ?dry_run=true, reports the widening and
+// leaves the table untouched — so a synchroniser can ask before it pushes.
+func TestOwnershipDryRunWritesNothing(t *testing.T) {
+	r, e, db := newTestServer(t)
+	declareHierarchy(t, db)
+	const user = "u-1"
+	_ = e.GrantObjectPermission(user, "catalog", "cat-a", "resource_manage")
+
+	body := map[string]any{
+		"resource_type": "resource", "parent_type": "catalog",
+		"items": []map[string]string{
+			{"resource_id": "res-1", "parent_id": "cat-a"},
+			{"resource_id": "res-2", "parent_id": "cat-b"},
+		},
+	}
+	w := do(t, r, http.MethodPut, "/api/safe/v1/authz/resource-parents?dry_run=true", body)
+	if w.Code != http.StatusOK {
+		t.Fatalf("dry run = %d body=%s", w.Code, w.Body.String())
+	}
+	var resp struct {
+		Changes []struct {
+			AccessorID string `json:"accessor_id"`
+			ResourceID string `json:"resource_id"`
+			Operation  string `json:"operation"`
+			Direction  string `json:"direction"`
+		} `json:"changes"`
+		Total     int  `json:"total"`
+		Truncated bool `json:"truncated"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode: %v (%s)", err, w.Body.String())
+	}
+	if resp.Total != 1 || len(resp.Changes) != 1 {
+		t.Fatalf("changes = %+v (total %d), want the single modify on res-1", resp.Changes, resp.Total)
+	}
+	got := resp.Changes[0]
+	if got.AccessorID != user || got.ResourceID != "res-1" || got.Operation != "modify" || got.Direction != "grant" {
+		t.Errorf("change = %+v, want u-1/res-1/modify as a grant", got)
+	}
+	if resp.Truncated {
+		t.Error("truncated = true on a one-row report")
+	}
+
+	var n int64
+	db.Model(&model.ResourceParent{}).Count(&n)
+	if n != 0 {
+		t.Errorf("dry run wrote %d rows", n)
+	}
+
+	// And the real push still works afterwards.
+	w = do(t, r, http.MethodPut, "/api/safe/v1/authz/resource-parents", body)
+	if w.Code != http.StatusNoContent {
+		t.Fatalf("push after dry run = %d body=%s", w.Code, w.Body.String())
+	}
+	db.Model(&model.ResourceParent{}).Count(&n)
+	if n != 2 {
+		t.Errorf("rows after push = %d, want 2", n)
+	}
+}


### PR DESCRIPTION
Stage D1 of #800 — the confirmation step the design promised in place of a feature flag.

## Why it has to happen before the write

Recording ownership **is** the moment inheritance starts applying, and that is a widening: whoever holds a grant on a catalog begins to reach the tables inside it. The core engine is allow-only, so there is nothing to stage and no knob afterwards that holds it back — the only place a human can stand is in front of the write.

`PUT /authz/resource-parents?dry_run=true` takes the same body, writes nothing, and answers:

```json
{"changes":[{"accessor_id":"u-1","resource_id":"res-1","operation":"modify"}],
 "total":1,"truncated":false}
```

A synchroniser asks first: empty total → push (zero behaviour change by definition); non-empty → stop and let a person look.

## How it is computed

Backwards from the proposal. For each proposed parent, collect the subjects holding the mapped operations on it — including through wildcard object patterns and the grant-to-everyone subject, since both reach it at enforce time — then subtract what those subjects already hold on the children today. The difference is the widening.

Subjects are reported **verbatim, not expanded**. Naming the role that causes the widening is the useful fact; expanding it turns a report about one grant into a report the size of that role's membership.

The sample is capped at 500 but `total` is always exact. A truncated report that reads as complete is worse than no report — it invites approving a widening nobody saw.

## Tests

- the widening is reported per (subject, resource, operation), and the operation is the **translated** one (`resource_manage` on a catalog surfaces as `modify` and `delete` on its tables)
- resources the subject can already touch are not reported
- an installation with no per-object catalog grants produces an empty diff — the common case, and the one that makes the push automatic
- the sample truncates while the total stays exact
- role-held and publicly granted catalogs are both seen
- the endpoint writes nothing on a dry run, and a real push still works right after

## Field evidence

On the development cluster, `GET /authz/policies` returns **zero** per-object grants for both `catalog` and `resource`. The seeded roles gain nothing either (asserted by `TestSeededRolesGainNothingFromInheritance` in #832). So on a real installation the diff is expected to be empty and the push a no-op — the non-empty path exists for customer environments with accumulated per-object grants.

## Next

D2: the vega ownership synchroniser, which dry-runs first and only pushes when the diff is empty.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
