### PR TITLE
fix(comm-go): refine locale response semantics

### DIFF
--- a/comm-go/rest/language.go
+++ b/comm-go/rest/language.go
@@ -236,7 +236,10 @@ func parseQValue(value string) (float64, bool) {
 }
 
 func normalizeLanguage(value string) (Language, bool) {
-	normalized := strings.ToLower(strings.ReplaceAll(strings.TrimSpace(value), "_", "-"))
+	normalized := strings.ToLower(strings.TrimSpace(value))
+	if normalized == "zh_cn" {
+		normalized = "zh-cn"
+	}
 	if !validLanguageRange(normalized) {
 		return "", false
 	}

--- a/comm-go/rest/language_test.go
+++ b/comm-go/rest/language_test.go
@@ -27,7 +27,10 @@ func TestResolveLanguage(t *testing.T) {
 		{name: "selects first supported candidate", header: "fr, en-US;q=0.8", want: AmericanEnglish},
 		{name: "honors weights", header: "zh-CN;q=0.5, en-US;q=0.9", want: AmericanEnglish},
 		{name: "matches English regional variants", header: "en-GB", want: AmericanEnglish},
-		{name: "normalizes aliases", header: "zh_Hans", want: SimplifiedChinese},
+		{name: "normalizes legacy zh_CN alias", header: "zh_CN", want: SimplifiedChinese},
+		{name: "ignores unsupported underscore aliases", header: "zh_Hans, en-US;q=0.8", want: AmericanEnglish},
+		{name: "ignores English underscore alias", header: "en_US, zh-CN;q=0.8", want: SimplifiedChinese},
+		{name: "ignores malformed underscore alias", header: "foo_bar, en-US;q=0.8", want: AmericanEnglish},
 		{name: "excludes rejected language from wildcard", header: "en;q=0, *;q=1", want: SimplifiedChinese},
 		{name: "preserves explicit language when wildcard rejects others", header: "en-US, *;q=0", want: AmericanEnglish},
 		{name: "uses wildcard only for unmatched languages", header: "zh-CN;q=0.2, *;q=0.9", want: AmericanEnglish},
@@ -82,7 +85,7 @@ func TestGetLanguageCtx(t *testing.T) {
 }
 
 func TestWithLanguage(t *testing.T) {
-	for _, input := range []Language{AmericanEnglish, "en-us", "EN_us"} {
+	for _, input := range []Language{AmericanEnglish, "en-us"} {
 		t.Run(string(input), func(t *testing.T) {
 			ctx := WithLanguage(context.Background(), input)
 			if got := GetLanguageByCtx(ctx); got != AmericanEnglish {

--- a/comm-go/rest/server.go
+++ b/comm-go/rest/server.go
@@ -37,10 +37,10 @@ func ReplyOK(c *gin.Context, statusCode int, body interface{}) {
 			statusCode = http.StatusInternalServerError
 			ctx := GetLanguageCtx(c)
 			bodyStr = NewHTTPError(ctx, statusCode, PublicError_InternalServerError).WithErrorDetails(err).Error()
+			MarkLocalizedResponse(c)
 		}
 	}
 
-	setResponseLanguage(c)
 	c.Writer.Header().Set(ContentTypeKey, ContentTypeJson)
 	c.String(statusCode, bodyStr)
 }
@@ -64,7 +64,7 @@ func ReplyError(c *gin.Context, err error) {
 		body = NewHTTPError(ctx, statusCode, PublicError_InternalServerError).WithErrorDetails(e.Error()).Error()
 	}
 
-	setResponseLanguage(c)
+	MarkLocalizedResponse(c)
 	c.Writer.Header().Set(ContentTypeKey, ContentTypeJson)
 	c.String(statusCode, body)
 }
@@ -82,9 +82,37 @@ func addHeaders(c *gin.Context, headers map[string]string) {
 	}
 }
 
-func setResponseLanguage(c *gin.Context) {
+// MarkLocalizedResponse records the language used by a response that contains
+// localized text. Callers opt in because a successful response can be purely
+// machine-readable even when the request has an effective locale.
+func MarkLocalizedResponse(c *gin.Context) {
 	c.Writer.Header().Set(ContentLanguageHeader, GetLanguageByCtx(c.Request.Context()))
+}
+
+// MarkLocalizedCacheableResponse additionally declares that a cacheable
+// representation varies by Accept-Language.
+func MarkLocalizedCacheableResponse(c *gin.Context) {
+	MarkLocalizedResponse(c)
 	addVaryHeader(c, AcceptLanguageHeader)
+}
+
+// LanguageMiddleware resolves the request locale once. It intentionally does
+// not write response headers because only localized representations have a
+// Content-Language value.
+func LanguageMiddleware() gin.HandlerFunc {
+	return func(c *gin.Context) {
+		c.Request = c.Request.WithContext(GetLanguageCtx(c))
+		c.Next()
+	}
+}
+
+// PrivateNoCacheMiddleware prevents shared caches from storing authenticated
+// responses and requires a private cache to revalidate before reuse.
+func PrivateNoCacheMiddleware() gin.HandlerFunc {
+	return func(c *gin.Context) {
+		c.Writer.Header().Set("Cache-Control", "private, no-cache")
+		c.Next()
+	}
 }
 
 func addVaryHeader(c *gin.Context, value string) {

--- a/comm-go/rest/server_test.go
+++ b/comm-go/rest/server_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/gin-gonic/gin"
 )
 
-func TestReplyOKSetsContentLanguage(t *testing.T) {
+func TestReplyOKDoesNotSetContentLanguageForMachineResponse(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 	recorder := httptest.NewRecorder()
 	c, _ := gin.CreateTestContext(recorder)
@@ -22,24 +22,55 @@ func TestReplyOKSetsContentLanguage(t *testing.T) {
 
 	ReplyOK(c, http.StatusOK, gin.H{"status": "ok"})
 
-	if got := recorder.Header().Get(ContentLanguageHeader); got != AmericanEnglish {
-		t.Fatalf("Content-Language = %q, want %q", got, AmericanEnglish)
+	if got := recorder.Header().Get(ContentLanguageHeader); got != "" {
+		t.Fatalf("Content-Language = %q, want empty", got)
 	}
-	if got := recorder.Header().Values("Vary"); len(got) != 1 || got[0] != AcceptLanguageHeader {
-		t.Fatalf("Vary = %q, want [%q]", got, AcceptLanguageHeader)
+	if got := recorder.Header().Values("Vary"); len(got) != 0 {
+		t.Fatalf("Vary = %q, want none", got)
 	}
 }
 
-func TestReplyOKPreservesExistingVaryHeader(t *testing.T) {
+func TestMarkLocalizedCacheableResponsePreservesExistingVaryHeader(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 	recorder := httptest.NewRecorder()
 	c, _ := gin.CreateTestContext(recorder)
 	c.Request = httptest.NewRequest(http.MethodGet, "/", nil)
 	c.Writer.Header().Set("Vary", "Origin")
 
-	ReplyOK(c, http.StatusOK, gin.H{"status": "ok"})
+	MarkLocalizedCacheableResponse(c)
 
 	if got := recorder.Header().Values("Vary"); len(got) != 2 || got[0] != "Origin" || got[1] != AcceptLanguageHeader {
 		t.Fatalf("Vary = %q, want [Origin %q]", got, AcceptLanguageHeader)
+	}
+}
+
+func TestReplyErrorSetsContentLanguageWithoutVary(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	recorder := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(recorder)
+	c.Request = httptest.NewRequest(http.MethodGet, "/", nil)
+	c.Request = c.Request.WithContext(WithLanguage(c.Request.Context(), AmericanEnglish))
+
+	ReplyError(c, NewHTTPError(c.Request.Context(), http.StatusBadRequest, PublicError_BadRequest))
+
+	if got := recorder.Header().Get(ContentLanguageHeader); got != AmericanEnglish {
+		t.Fatalf("Content-Language = %q, want %q", got, AmericanEnglish)
+	}
+	if got := recorder.Header().Values("Vary"); len(got) != 0 {
+		t.Fatalf("Vary = %q, want none", got)
+	}
+}
+
+func TestPrivateNoCacheMiddleware(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	router := gin.New()
+	router.Use(PrivateNoCacheMiddleware())
+	router.GET("/", func(c *gin.Context) { c.String(http.StatusOK, "ok") })
+
+	recorder := httptest.NewRecorder()
+	router.ServeHTTP(recorder, httptest.NewRequest(http.MethodGet, "/", nil))
+
+	if got := recorder.Header().Get("Cache-Control"); got != "private, no-cache" {
+		t.Fatalf("Cache-Control = %q, want private, no-cache", got)
 	}
 }


### PR DESCRIPTION
## What Changed

Brief description of changes:

- [x] Refined `comm-go/rest` locale normalization: only the legacy `zh_CN` alias is accepted.
- [x] Made `Content-Language` opt-in for localized responses; cacheable localized representations can explicitly add `Vary: Accept-Language`.
- [x] Added shared request locale and authenticated-cache middleware, with focused regression tests.

---

## Why

- Related Issue: Closes #845
- Related Feature: HTTP P0 internationalization protocol
- Background: P0 requires `Accept-Language` as the sole request locale input, correct response-header semantics, and a shared authenticated cache policy.

---

## How

- Key implementation points:
  - Restrict underscore compatibility to `zh_CN` and reject other invalid underscore forms.
  - Do not emit `Content-Language` or `Vary` for machine-only success responses.
  - Emit `Content-Language` for localized errors.
  - Provide `LanguageMiddleware`, `PrivateNoCacheMiddleware`, and `MarkLocalizedCacheableResponse` for consumers.
- Breaking changes (API, config, database, etc.): Clients relying on nonstandard aliases such as `en_US` or `zh_Hans` now fall back through normal language negotiation.

---

## Testing

- [x] Unit tests passed locally
- [ ] Integration tests passed locally (not applicable: shared library only)
- [ ] Verified in test environment (pending consumer pseudo-version integration)

Test notes:

- `cd comm-go && go test ./rest`

---

## Risk & Rollback

- Potential risks: Consumer services must upgrade to the commit's pseudo-version before these helpers affect deployed binaries.
- Rollback plan: Revert this commit and pin consumers to the preceding `comm-go` pseudo-version.

---

## Additional Notes

- This PR intentionally contains only the shared-library commit. Consumer migration and end-to-end validation will follow using this commit's pseudo-version.