### PR TITLE
feat(i18n): migrate consumers to accept-language

### DIFF
--- a/adp/bkn/bkn-backend/server/driveradapters/routers.go
+++ b/adp/bkn/bkn-backend/server/driveradapters/routers.go
@@ -97,6 +97,8 @@ func (r *restHandler) RegisterPublic(c *gin.Engine) {
 
 	bknApiV1 := c.Group("/api/bkn-backend/v1")
 	otlApiV1 := c.Group("/api/ontology-manager/v1")
+	bknApiV1.Use(rest.PrivateNoCacheMiddleware())
+	otlApiV1.Use(rest.PrivateNoCacheMiddleware())
 	bknApiV1.GET("/trace/outbox", r.ListTraceOutbox)
 	bknApiV1.GET("/trace/outbox/:outbox_id", r.GetTraceOutbox)
 	bknApiV1.POST("/trace/outbox/:outbox_id/retry", r.verifyJsonContentType(), r.RetryTraceOutbox)
@@ -187,6 +189,8 @@ func (r *restHandler) RegisterPublic(c *gin.Engine) {
 
 	bknApiInV1 := c.Group("/api/bkn-backend/in/v1")
 	otlApiInV1 := c.Group("/api/ontology-manager/in/v1")
+	bknApiInV1.Use(rest.PrivateNoCacheMiddleware())
+	otlApiInV1.Use(rest.PrivateNoCacheMiddleware())
 
 	for _, apiInV1 := range []*gin.RouterGroup{bknApiInV1, otlApiInV1} {
 		// 业务知识网络
@@ -290,13 +294,10 @@ func (r *restHandler) verifyJsonContentType() gin.HandlerFunc {
 	}
 }
 
-// gin中间件 把 X-Language 头解析结果挂到 request ctx。
+// LanguageMiddleware resolves Accept-Language once and stores it in request context.
 // 注册顺序必须在 TracingMiddleware 之后，这样 language ctx 叠加在 trace ctx 上。
 func (r *restHandler) LanguageMiddleware() gin.HandlerFunc {
-	return func(c *gin.Context) {
-		c.Request = c.Request.WithContext(rest.GetLanguageCtx(c))
-		c.Next()
-	}
+	return rest.LanguageMiddleware()
 }
 
 // gin中间件 访问日志

--- a/adp/bkn/bkn-backend/server/go.mod
+++ b/adp/bkn/bkn-backend/server/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/fsnotify/fsnotify v1.10.1
 	github.com/gin-gonic/gin v1.12.0
 	github.com/mitchellh/mapstructure v1.5.0
-	github.com/openbkn-ai/bkn-foundry/comm-go v0.1.1-0.20260813121341-970e0bb7367d
+	github.com/openbkn-ai/bkn-foundry/comm-go v0.1.1-0.20260813155806-b731c9765f03
 	github.com/opensearch-project/opensearch-go/v2 v2.3.0
 	github.com/robfig/cron/v3 v3.0.1
 	github.com/rs/xid v1.6.0

--- a/adp/bkn/bkn-backend/server/go.sum
+++ b/adp/bkn/bkn-backend/server/go.sum
@@ -162,6 +162,8 @@ github.com/openbkn-ai/bkn-foundry/comm-go v0.1.1-0.20260813101616-bd7f22f1d9cb h
 github.com/openbkn-ai/bkn-foundry/comm-go v0.1.1-0.20260813101616-bd7f22f1d9cb/go.mod h1:D0d+xRVJAk7DutF2g8I/TsXceE/1Iv3EmNNj8yxu2pA=
 github.com/openbkn-ai/bkn-foundry/comm-go v0.1.1-0.20260813121341-970e0bb7367d h1:alYnur68nbfTckDh5qp3YtpPz86SwpKjVDhVjPtCzB4=
 github.com/openbkn-ai/bkn-foundry/comm-go v0.1.1-0.20260813121341-970e0bb7367d/go.mod h1:D0d+xRVJAk7DutF2g8I/TsXceE/1Iv3EmNNj8yxu2pA=
+github.com/openbkn-ai/bkn-foundry/comm-go v0.1.1-0.20260813155806-b731c9765f03 h1:vk8vJjMUDg81wPYNi0JGbcL0aTm/oONoj4B1zxaEf10=
+github.com/openbkn-ai/bkn-foundry/comm-go v0.1.1-0.20260813155806-b731c9765f03/go.mod h1:D0d+xRVJAk7DutF2g8I/TsXceE/1Iv3EmNNj8yxu2pA=
 github.com/opensearch-project/opensearch-go/v2 v2.3.0 h1:nQIEMr+A92CkhHrZgUhcfsrZjibvB3APXf2a1VwCmMQ=
 github.com/opensearch-project/opensearch-go/v2 v2.3.0/go.mod h1:8LDr9FCgUTVoT+5ESjc2+iaZuldqE+23Iq0r1XeNue8=
 github.com/pelletier/go-toml/v2 v2.2.4 h1:mye9XuhQ6gvn5h28+VilKrrPoQVanw5PMw/TB0t5Ec4=

--- a/adp/bkn/ontology-query/server/driveradapters/routers.go
+++ b/adp/bkn/ontology-query/server/driveradapters/routers.go
@@ -70,6 +70,7 @@ func (r *restHandler) RegisterPublic(c *gin.Engine) {
 	c.GET("/health", r.HealthCheck)
 
 	apiV1 := c.Group("/api/ontology-query/v1")
+	apiV1.Use(rest.PrivateNoCacheMiddleware())
 	{
 		apiV1.GET("/trace/outbox", r.ListTraceOutbox)
 		apiV1.GET("/trace/outbox/:outbox_id", r.GetTraceOutbox)
@@ -96,6 +97,7 @@ func (r *restHandler) RegisterPublic(c *gin.Engine) {
 	}
 
 	apiInV1 := c.Group("/api/ontology-query/in/v1")
+	apiInV1.Use(rest.PrivateNoCacheMiddleware())
 	{
 		// 业务知识网络
 		apiInV1.POST("/knowledge-networks/:kn_id/object-types/:ot_id", r.verifyJsonContentType(), r.GetObjectsInObjectTypeByIn)
@@ -149,13 +151,10 @@ func (r *restHandler) verifyJsonContentType() gin.HandlerFunc {
 	}
 }
 
-// gin中间件 把 X-Language 头解析结果挂到 request ctx。
+// LanguageMiddleware resolves Accept-Language once and stores it in request context.
 // 注册顺序必须在 TracingMiddleware 之后，这样 language ctx 叠加在 trace ctx 上。
 func (r *restHandler) LanguageMiddleware() gin.HandlerFunc {
-	return func(c *gin.Context) {
-		c.Request = c.Request.WithContext(rest.GetLanguageCtx(c))
-		c.Next()
-	}
+	return rest.LanguageMiddleware()
 }
 
 // TraceContextMiddleware parses OpenBKN phase-one trace context into request context.

--- a/adp/bkn/ontology-query/server/go.mod
+++ b/adp/bkn/ontology-query/server/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/fsnotify/fsnotify v1.10.1
 	github.com/gin-gonic/gin v1.12.0
 	github.com/mitchellh/mapstructure v1.5.0
-	github.com/openbkn-ai/bkn-foundry/comm-go v0.1.1-0.20260813121341-970e0bb7367d
+	github.com/openbkn-ai/bkn-foundry/comm-go v0.1.1-0.20260813155806-b731c9765f03
 	github.com/opensearch-project/opensearch-go/v2 v2.3.0
 	github.com/rs/xid v1.6.0
 	github.com/smartystreets/goconvey v1.8.1

--- a/adp/bkn/ontology-query/server/go.sum
+++ b/adp/bkn/ontology-query/server/go.sum
@@ -155,6 +155,8 @@ github.com/openbkn-ai/bkn-foundry/comm-go v0.1.1-0.20260813101616-bd7f22f1d9cb h
 github.com/openbkn-ai/bkn-foundry/comm-go v0.1.1-0.20260813101616-bd7f22f1d9cb/go.mod h1:D0d+xRVJAk7DutF2g8I/TsXceE/1Iv3EmNNj8yxu2pA=
 github.com/openbkn-ai/bkn-foundry/comm-go v0.1.1-0.20260813121341-970e0bb7367d h1:alYnur68nbfTckDh5qp3YtpPz86SwpKjVDhVjPtCzB4=
 github.com/openbkn-ai/bkn-foundry/comm-go v0.1.1-0.20260813121341-970e0bb7367d/go.mod h1:D0d+xRVJAk7DutF2g8I/TsXceE/1Iv3EmNNj8yxu2pA=
+github.com/openbkn-ai/bkn-foundry/comm-go v0.1.1-0.20260813155806-b731c9765f03 h1:vk8vJjMUDg81wPYNi0JGbcL0aTm/oONoj4B1zxaEf10=
+github.com/openbkn-ai/bkn-foundry/comm-go v0.1.1-0.20260813155806-b731c9765f03/go.mod h1:D0d+xRVJAk7DutF2g8I/TsXceE/1Iv3EmNNj8yxu2pA=
 github.com/opensearch-project/opensearch-go/v2 v2.3.0 h1:nQIEMr+A92CkhHrZgUhcfsrZjibvB3APXf2a1VwCmMQ=
 github.com/opensearch-project/opensearch-go/v2 v2.3.0/go.mod h1:8LDr9FCgUTVoT+5ESjc2+iaZuldqE+23Iq0r1XeNue8=
 github.com/pelletier/go-toml/v2 v2.2.4 h1:mye9XuhQ6gvn5h28+VilKrrPoQVanw5PMw/TB0t5Ec4=

--- a/adp/context-loader/agent-retrieval/docs/apis/api_private/find_skills.yaml
+++ b/adp/context-loader/agent-retrieval/docs/apis/api_private/find_skills.yaml
@@ -293,7 +293,7 @@ components:
           description: |
             空结果说明信息。仅当 entries 为空且接口返回 200 时出现。
             用于向调用方（Agent）解释当前为什么没有结果，以及下一步建议。
-            entries 非空时不返回此字段。支持多语言（由请求 X-Language 头决定）。
+            entries 非空时不返回此字段。支持多语言（由请求 Accept-Language 头决定）。
 
     SkillItem:
       type: object

--- a/adp/context-loader/agent-retrieval/go.mod
+++ b/adp/context-loader/agent-retrieval/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/json-iterator/go v1.1.12
 	github.com/mark3labs/mcp-go v0.57.0
 	github.com/nicksnyder/go-i18n/v2 v2.6.0
-	github.com/openbkn-ai/bkn-foundry/comm-go v0.1.1-0.20260813121341-970e0bb7367d
+	github.com/openbkn-ai/bkn-foundry/comm-go v0.1.1-0.20260813155806-b731c9765f03
 	github.com/openbkn-ai/licverify v0.5.0
 	github.com/pkg/errors v0.9.1
 	github.com/smartystreets/goconvey v1.8.1

--- a/adp/context-loader/agent-retrieval/go.sum
+++ b/adp/context-loader/agent-retrieval/go.sum
@@ -121,6 +121,8 @@ github.com/openbkn-ai/bkn-foundry/comm-go v0.1.1-0.20260813101616-bd7f22f1d9cb h
 github.com/openbkn-ai/bkn-foundry/comm-go v0.1.1-0.20260813101616-bd7f22f1d9cb/go.mod h1:D0d+xRVJAk7DutF2g8I/TsXceE/1Iv3EmNNj8yxu2pA=
 github.com/openbkn-ai/bkn-foundry/comm-go v0.1.1-0.20260813121341-970e0bb7367d h1:alYnur68nbfTckDh5qp3YtpPz86SwpKjVDhVjPtCzB4=
 github.com/openbkn-ai/bkn-foundry/comm-go v0.1.1-0.20260813121341-970e0bb7367d/go.mod h1:D0d+xRVJAk7DutF2g8I/TsXceE/1Iv3EmNNj8yxu2pA=
+github.com/openbkn-ai/bkn-foundry/comm-go v0.1.1-0.20260813155806-b731c9765f03 h1:vk8vJjMUDg81wPYNi0JGbcL0aTm/oONoj4B1zxaEf10=
+github.com/openbkn-ai/bkn-foundry/comm-go v0.1.1-0.20260813155806-b731c9765f03/go.mod h1:D0d+xRVJAk7DutF2g8I/TsXceE/1Iv3EmNNj8yxu2pA=
 github.com/openbkn-ai/licverify v0.5.0 h1:79aXlMYBDIzSLBXLhbrM3xOIDmMxhgCxG7PtZbPMNnE=
 github.com/openbkn-ai/licverify v0.5.0/go.mod h1:9Cnmt/tl7JN48+EjsGCjQERs1mNjuaBHdM+oVx0gvS4=
 github.com/opensearch-project/opensearch-go/v2 v2.3.0 h1:nQIEMr+A92CkhHrZgUhcfsrZjibvB3APXf2a1VwCmMQ=

--- a/adp/context-loader/agent-retrieval/server/driveradapters/rest_private_handler.go
+++ b/adp/context-loader/agent-retrieval/server/driveradapters/rest_private_handler.go
@@ -11,6 +11,7 @@ package driveradapters
 
 import (
 	"github.com/gin-gonic/gin"
+	sharedrest "github.com/openbkn-ai/bkn-foundry/comm-go/rest"
 
 	"github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/driveradapters/knactionrecall"
 	"github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/driveradapters/knfindskills"
@@ -63,7 +64,7 @@ func NewRestPrivateHandler(logger interfaces.Logger) interfaces.HTTPRouterInterf
 // RegisterRouter 注册路由
 func (r *restPrivateHandler) RegisterRouter(engine *gin.RouterGroup) {
 	mws := []gin.HandlerFunc{}
-	mws = append(mws, middlewareRequestLog(r.Logger), middlewareTrace, middlewareHeaderAuthContext(), middlewareResponseFormat(), middlewareLifecycle(r.LifecycleClient))
+	mws = append(mws, middlewareRequestLog(r.Logger), middlewareTrace, sharedrest.LanguageMiddleware(), sharedrest.PrivateNoCacheMiddleware(), middlewareHeaderAuthContext(), middlewareResponseFormat(), middlewareLifecycle(r.LifecycleClient))
 	engine.Use(mws...)
 
 	engine.POST("/kn/semantic-search", r.KnRetrievalHandler.SemanticSearch)

--- a/adp/context-loader/agent-retrieval/server/driveradapters/rest_public_handler.go
+++ b/adp/context-loader/agent-retrieval/server/driveradapters/rest_public_handler.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 
 	"github.com/gin-gonic/gin"
+	sharedrest "github.com/openbkn-ai/bkn-foundry/comm-go/rest"
 
 	"github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/drivenadapters"
 	"github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/driveradapters/knactionrecall"
@@ -68,7 +69,7 @@ func NewRestPublicHandler(logger interfaces.Logger) interfaces.HTTPRouterInterfa
 // RegisterPublic 注册公共路由
 func (r *restPublicHandler) RegisterRouter(engine *gin.RouterGroup) {
 	mws := []gin.HandlerFunc{}
-	mws = append(mws, middlewareRequestLog(r.Logger), middlewareTrace, middlewareIntrospectVerify(r.Hydra, r.AppKeys), middlewareResponseFormat(), middlewareLifecycle(r.LifecycleClient))
+	mws = append(mws, middlewareRequestLog(r.Logger), middlewareTrace, sharedrest.LanguageMiddleware(), sharedrest.PrivateNoCacheMiddleware(), middlewareIntrospectVerify(r.Hydra, r.AppKeys), middlewareResponseFormat(), middlewareLifecycle(r.LifecycleClient))
 	engine.Use(mws...)
 
 	engine.POST("/kn/semantic-search", r.KnRetrievalHandler.SemanticSearch)

--- a/adp/context-loader/agent-retrieval/server/infra/bkntrace/lifecycle.go
+++ b/adp/context-loader/agent-retrieval/server/infra/bkntrace/lifecycle.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/infra/common"
 	"github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/interfaces"
+	sharedrest "github.com/openbkn-ai/bkn-foundry/comm-go/rest"
 )
 
 const (
@@ -471,6 +472,7 @@ func (c *LifecycleClient) do(
 		return nil, err
 	}
 	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set(sharedrest.AcceptLanguageHeader, sharedrest.GetLanguageByCtx(ctx))
 	if err := setTrustedLifecycleHeaders(ctx, req.Header); err != nil {
 		return &APIError{
 			Code: "permission_denied", Message: err.Error(),

--- a/adp/context-loader/agent-retrieval/server/infra/bkntrace/lifecycle_test.go
+++ b/adp/context-loader/agent-retrieval/server/infra/bkntrace/lifecycle_test.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/infra/common"
 	"github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/interfaces"
+	sharedrest "github.com/openbkn-ai/bkn-foundry/comm-go/rest"
 )
 
 func TestGuardBeginUsesCoreCreatedAtForOperationEvidence(t *testing.T) {
@@ -99,6 +100,9 @@ func TestLifecycleClientEnsureOperationUsesTrustedContext(t *testing.T) {
 		if got := r.Header.Get("X-BKN-Trace-Query-Token"); got != "" {
 			t.Errorf("internal lifecycle request must not carry gateway token, got %q", got)
 		}
+		if got := r.Header.Get(sharedrest.AcceptLanguageHeader); got != sharedrest.AmericanEnglish {
+			t.Errorf("Accept-Language = %q, want %q", got, sharedrest.AmericanEnglish)
+		}
 		switch r.URL.Path {
 		case "/api/agent-observability/v1/interactions/int-1":
 			_ = json.NewEncoder(w).Encode(Interaction{
@@ -171,6 +175,7 @@ func TestLifecycleClientEnsureOperationUsesTrustedContext(t *testing.T) {
 		AccountID: "user-1", AccountType: interfaces.AccessorTypeUser, AuthMethod: "api_key",
 		TokenInfo: &interfaces.TokenInfo{ClientID: "client-1", VisitorName: "供应链管理员"},
 	})
+	ctx = sharedrest.WithLanguage(ctx, sharedrest.AmericanEnglish)
 	client := NewLifecycleClient(server.URL, server.Client())
 	result, apiErr, err := client.EnsureOperation(ctx, EnsureOperationInput{
 		ConversationID: "conv-1", InteractionID: "int-1", OperationKey: "logical-1",

--- a/adp/context-loader/agent-retrieval/server/infra/rest/http_client.go
+++ b/adp/context-loader/agent-retrieval/server/infra/rest/http_client.go
@@ -24,6 +24,7 @@ import (
 	"github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/infra/telemetry"
 	"github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/interfaces"
 	"github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/utils"
+	sharedrest "github.com/openbkn-ai/bkn-foundry/comm-go/rest"
 )
 
 // httpClient HTTP客户端结构
@@ -261,5 +262,6 @@ func (c *httpClient) generateReq(ctx context.Context, httpMethod, url string,
 			req.Header.Add(k, v)
 		}
 	}
+	req.Header.Set(sharedrest.AcceptLanguageHeader, sharedrest.GetLanguageByCtx(ctx))
 	return
 }

--- a/adp/context-loader/agent-retrieval/server/infra/rest/reply.go
+++ b/adp/context-loader/agent-retrieval/server/infra/rest/reply.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/gin-gonic/gin"
 	validator "github.com/go-playground/validator/v10"
+	sharedrest "github.com/openbkn-ai/bkn-foundry/comm-go/rest"
 	errorwrap "github.com/pkg/errors"
 
 	"github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/infra/common"
@@ -51,6 +52,7 @@ func ReplyOK(c *gin.Context, statusCode int, body interface{}) {
 			statusCode = http.StatusInternalServerError
 			ctx := c.Request.Context()
 			bodyStr := myErr.DefaultHTTPError(ctx, statusCode, err.Error()).Error()
+			sharedrest.MarkLocalizedResponse(c)
 			c.Writer.Header().Set(ContentTypeKey, ContentTypeJSON)
 			c.String(statusCode, bodyStr)
 			return
@@ -74,10 +76,12 @@ func ReplyError(c *gin.Context, err error) {
 	var httpCode int
 	ctx := c.Request.Context()
 	var body string
+	localized := true
 	switch e := err.(type) {
 	case *ExHTTPError:
 		httpCode = e.HTTPCode
 		body = e.Error()
+		localized = false
 	default:
 		httpError := &myErr.HTTPError{}
 		vErr := make(validator.ValidationErrors, 0)
@@ -98,6 +102,9 @@ func ReplyError(c *gin.Context, err error) {
 			httpCode = http.StatusInternalServerError
 			body = myErr.DefaultHTTPError(ctx, httpCode, err.Error()).Error()
 		}
+	}
+	if localized {
+		sharedrest.MarkLocalizedResponse(c)
 	}
 	c.Writer.Header().Set(ContentTypeKey, ContentTypeJSON)
 	c.String(httpCode, body)

--- a/adp/context-loader/agent-retrieval/server/infra/rest/reply_language_test.go
+++ b/adp/context-loader/agent-retrieval/server/infra/rest/reply_language_test.go
@@ -1,0 +1,46 @@
+// Copyright openbkn.ai
+// Copyright The kweaver.ai Authors.
+//
+// Licensed under the Apache License, Version 2.0.
+// See the LICENSE file in the project root for details.
+
+package rest
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	sharedrest "github.com/openbkn-ai/bkn-foundry/comm-go/rest"
+)
+
+func TestReplyErrorMarksOnlyLocallyGeneratedTextAsLocalized(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	t.Run("local error", func(t *testing.T) {
+		recorder := httptest.NewRecorder()
+		c, _ := gin.CreateTestContext(recorder)
+		c.Request = httptest.NewRequest(http.MethodGet, "/", nil)
+		c.Request = c.Request.WithContext(sharedrest.WithLanguage(c.Request.Context(), sharedrest.AmericanEnglish))
+
+		ReplyError(c, http.ErrNotSupported)
+
+		if got := recorder.Header().Get(sharedrest.ContentLanguageHeader); got != sharedrest.AmericanEnglish {
+			t.Fatalf("Content-Language = %q, want %q", got, sharedrest.AmericanEnglish)
+		}
+	})
+
+	t.Run("upstream error", func(t *testing.T) {
+		recorder := httptest.NewRecorder()
+		c, _ := gin.CreateTestContext(recorder)
+		c.Request = httptest.NewRequest(http.MethodGet, "/", nil)
+		c.Request = c.Request.WithContext(sharedrest.WithLanguage(c.Request.Context(), sharedrest.AmericanEnglish))
+
+		ReplyError(c, &ExHTTPError{HTTPCode: http.StatusBadGateway, Body: []byte(`{"message":"upstream"}`)})
+
+		if got := recorder.Header().Get(sharedrest.ContentLanguageHeader); got != "" {
+			t.Fatalf("Content-Language = %q, want empty for upstream response", got)
+		}
+	})
+}

--- a/adp/execution-factory/operator-integration/go.mod
+++ b/adp/execution-factory/operator-integration/go.mod
@@ -17,7 +17,7 @@ require (
 	github.com/json-iterator/go v1.1.12
 	github.com/mark3labs/mcp-go v0.37.0
 	github.com/nicksnyder/go-i18n/v2 v2.6.0
-	github.com/openbkn-ai/bkn-foundry/comm-go v0.1.1-0.20260813121341-970e0bb7367d
+	github.com/openbkn-ai/bkn-foundry/comm-go v0.1.1-0.20260813155806-b731c9765f03
 	github.com/pkg/errors v0.9.1
 	github.com/qustavo/sqlhooks/v2 v2.1.0
 	github.com/redis/go-redis/v9 v9.14.1

--- a/adp/execution-factory/operator-integration/go.sum
+++ b/adp/execution-factory/operator-integration/go.sum
@@ -173,6 +173,8 @@ github.com/openbkn-ai/bkn-foundry/comm-go v0.1.1-0.20260813101616-bd7f22f1d9cb h
 github.com/openbkn-ai/bkn-foundry/comm-go v0.1.1-0.20260813101616-bd7f22f1d9cb/go.mod h1:D0d+xRVJAk7DutF2g8I/TsXceE/1Iv3EmNNj8yxu2pA=
 github.com/openbkn-ai/bkn-foundry/comm-go v0.1.1-0.20260813121341-970e0bb7367d h1:alYnur68nbfTckDh5qp3YtpPz86SwpKjVDhVjPtCzB4=
 github.com/openbkn-ai/bkn-foundry/comm-go v0.1.1-0.20260813121341-970e0bb7367d/go.mod h1:D0d+xRVJAk7DutF2g8I/TsXceE/1Iv3EmNNj8yxu2pA=
+github.com/openbkn-ai/bkn-foundry/comm-go v0.1.1-0.20260813155806-b731c9765f03 h1:vk8vJjMUDg81wPYNi0JGbcL0aTm/oONoj4B1zxaEf10=
+github.com/openbkn-ai/bkn-foundry/comm-go v0.1.1-0.20260813155806-b731c9765f03/go.mod h1:D0d+xRVJAk7DutF2g8I/TsXceE/1Iv3EmNNj8yxu2pA=
 github.com/opensearch-project/opensearch-go/v2 v2.3.0 h1:nQIEMr+A92CkhHrZgUhcfsrZjibvB3APXf2a1VwCmMQ=
 github.com/opensearch-project/opensearch-go/v2 v2.3.0/go.mod h1:8LDr9FCgUTVoT+5ESjc2+iaZuldqE+23Iq0r1XeNue8=
 github.com/opentracing/opentracing-go v1.1.0/go.mod h1:UkNAQd3GIcIGf0SeVgPpRdFStlNbqXla1AfSYxPUl2o=

--- a/adp/execution-factory/operator-integration/server/capabilitieslab/client/category.go
+++ b/adp/execution-factory/operator-integration/server/capabilitieslab/client/category.go
@@ -68,6 +68,7 @@ func (c *OperatorIntegrationClient) DownloadSkillPackage(
 		return nil, "", err
 	}
 	req.Header.Set("Accept", "application/octet-stream")
+	applyLanguageHeader(ctx, req.Header)
 	req.Header.Set("x-business-domain", businessDomain)
 
 	res, err := c.HTTP.Do(req)
@@ -155,6 +156,7 @@ func (c *OperatorIntegrationClient) UpdateSkillPackage(
 		return err
 	}
 	req.Header.Set("Accept", "application/json")
+	applyLanguageHeader(ctx, req.Header)
 	req.Header.Set("x-business-domain", businessDomain)
 	req.Header.Set("Content-Type", writer.FormDataContentType())
 

--- a/adp/execution-factory/operator-integration/server/capabilitieslab/client/function.go
+++ b/adp/execution-factory/operator-integration/server/capabilitieslab/client/function.go
@@ -61,6 +61,7 @@ func (c *OperatorIntegrationClient) ExecuteFunction(
 	}
 
 	httpReq.Header.Set("Accept", "application/json")
+	applyLanguageHeader(ctx, httpReq.Header)
 	httpReq.Header.Set("Content-Type", "application/json")
 	httpReq.Header.Set("x-business-domain", businessDomain)
 	if userID != "" {

--- a/adp/execution-factory/operator-integration/server/capabilitieslab/client/impex.go
+++ b/adp/execution-factory/operator-integration/server/capabilitieslab/client/impex.go
@@ -31,6 +31,7 @@ func (c *OperatorIntegrationClient) ExportImpex(
 	}
 
 	req.Header.Set("Accept", "application/json")
+	applyLanguageHeader(ctx, req.Header)
 	req.Header.Set("x-business-domain", businessDomain)
 	if userID != "" {
 		req.Header.Set("user_id", userID)
@@ -92,6 +93,7 @@ func (c *OperatorIntegrationClient) ImportImpex(
 	}
 
 	req.Header.Set("Accept", "application/json")
+	applyLanguageHeader(ctx, req.Header)
 	req.Header.Set("Content-Type", writer.FormDataContentType())
 	req.Header.Set("x-business-domain", businessDomain)
 	if userID != "" {

--- a/adp/execution-factory/operator-integration/server/capabilitieslab/client/lifecycle.go
+++ b/adp/execution-factory/operator-integration/server/capabilitieslab/client/lifecycle.go
@@ -219,6 +219,7 @@ func (c *OperatorIntegrationClient) RegisterSkill(
 		return nil, err
 	}
 	req.Header.Set("Accept", "application/json")
+	applyLanguageHeader(ctx, req.Header)
 	req.Header.Set("x-business-domain", businessDomain)
 	req.Header.Set("Content-Type", writer.FormDataContentType())
 

--- a/adp/execution-factory/operator-integration/server/capabilitieslab/client/lineage.go
+++ b/adp/execution-factory/operator-integration/server/capabilitieslab/client/lineage.go
@@ -45,6 +45,7 @@ func (c *OperatorIntegrationClient) GetToolSourceLineage(
 	}
 
 	req.Header.Set("Accept", "application/json")
+	applyLanguageHeader(ctx, req.Header)
 	req.Header.Set("x-business-domain", businessDomain)
 	if userID != "" {
 		req.Header.Set("user_id", userID)

--- a/adp/execution-factory/operator-integration/server/capabilitieslab/client/market.go
+++ b/adp/execution-factory/operator-integration/server/capabilitieslab/client/market.go
@@ -130,6 +130,7 @@ func (c *OperatorIntegrationClient) DownloadSkillMarketPackage(
 	}
 
 	req.Header.Set("Accept", "application/octet-stream")
+	applyLanguageHeader(ctx, req.Header)
 	req.Header.Set("x-business-domain", businessDomain)
 	if userID != "" {
 		req.Header.Set("user_id", userID)

--- a/adp/execution-factory/operator-integration/server/capabilitieslab/client/operator_integration.go
+++ b/adp/execution-factory/operator-integration/server/capabilitieslab/client/operator_integration.go
@@ -14,6 +14,8 @@ import (
 	"net/url"
 	"strings"
 	"time"
+
+	sharedrest "github.com/openbkn-ai/bkn-foundry/comm-go/rest"
 )
 
 type contextKey string
@@ -38,6 +40,10 @@ func WithForwardedAuth(ctx context.Context, authorization string, cookie string)
 	return ctx
 }
 
+func applyLanguageHeader(ctx context.Context, header http.Header) {
+	header.Set(sharedrest.AcceptLanguageHeader, sharedrest.GetLanguageByCtx(ctx))
+}
+
 func NewOperatorIntegrationClient(baseURL string) *OperatorIntegrationClient {
 	return &OperatorIntegrationClient{
 		BaseURL: strings.TrimRight(baseURL, "/"),
@@ -52,6 +58,7 @@ func (c *OperatorIntegrationClient) Ping(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
+	applyLanguageHeader(ctx, req.Header)
 
 	resp, err := c.HTTP.Do(req)
 	if err != nil {
@@ -481,6 +488,7 @@ func (c *OperatorIntegrationClient) doJSONWithUser(
 	}
 
 	req.Header.Set("Accept", "application/json")
+	applyLanguageHeader(ctx, req.Header)
 	req.Header.Set("x-business-domain", businessDomain)
 	if userID != "" {
 		req.Header.Set("user_id", userID)

--- a/adp/execution-factory/operator-integration/server/capabilitieslab/client/operator_integration_test.go
+++ b/adp/execution-factory/operator-integration/server/capabilitieslab/client/operator_integration_test.go
@@ -10,6 +10,8 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
+
+	sharedrest "github.com/openbkn-ai/bkn-foundry/comm-go/rest"
 )
 
 func TestCreateToolFailureMessageUsesErrorMsgDescription(t *testing.T) {
@@ -44,6 +46,9 @@ func TestExecuteFunctionForwardsSandboxRuntimeContext(t *testing.T) {
 		if got := r.Header.Get("x-business-domain"); got != "bd_public" {
 			t.Fatalf("x-business-domain = %q", got)
 		}
+		if got := r.Header.Get(sharedrest.AcceptLanguageHeader); got != sharedrest.AmericanEnglish {
+			t.Fatalf("Accept-Language = %q, want %q", got, sharedrest.AmericanEnglish)
+		}
 		if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
 			t.Fatalf("decode payload: %v", err)
 		}
@@ -58,7 +63,7 @@ func TestExecuteFunctionForwardsSandboxRuntimeContext(t *testing.T) {
 	}
 
 	_, err := client.ExecuteFunction(
-		context.Background(),
+		sharedrest.WithLanguage(context.Background(), sharedrest.AmericanEnglish),
 		"bd_public",
 		"user_001",
 		ExecuteFunctionRequest{

--- a/adp/execution-factory/operator-integration/server/capabilitieslab/register.go
+++ b/adp/execution-factory/operator-integration/server/capabilitieslab/register.go
@@ -17,6 +17,7 @@ package capabilitieslab
 
 import (
 	"github.com/gin-gonic/gin"
+	sharedrest "github.com/openbkn-ai/bkn-foundry/comm-go/rest"
 
 	"github.com/openbkn-ai/bkn-foundry/adp/execution-factory/operator-integration/server/capabilitieslab/client"
 	"github.com/openbkn-ai/bkn-foundry/adp/execution-factory/operator-integration/server/capabilitieslab/config"
@@ -41,6 +42,8 @@ func RegisterRouter(group *gin.RouterGroup) {
 	}
 
 	group.Use(
+		sharedrest.LanguageMiddleware(),
+		sharedrest.PrivateNoCacheMiddleware(),
 		handler.RequestIDMiddleware(),
 		handler.AuthMiddleware(cfg.DefaultUserID),
 		handler.MetricsMiddleware(metrics),

--- a/adp/execution-factory/operator-integration/server/drivenadapters/authorization_safe.go
+++ b/adp/execution-factory/operator-integration/server/drivenadapters/authorization_safe.go
@@ -16,6 +16,7 @@ import (
 	"time"
 
 	"github.com/openbkn-ai/bkn-foundry/adp/execution-factory/operator-integration/server/interfaces"
+	sharedrest "github.com/openbkn-ai/bkn-foundry/comm-go/rest"
 )
 
 // bkn-safe authz adapter + cutover switch for exec-factory.
@@ -216,6 +217,7 @@ func (s *safeAuthorization) get(ctx context.Context, path string, query url.Valu
 	if err != nil {
 		return err
 	}
+	req.Header.Set(sharedrest.AcceptLanguageHeader, sharedrest.GetLanguageByCtx(ctx))
 	resp, err := s.http.Do(req)
 	if err != nil {
 		return err
@@ -241,6 +243,7 @@ func (s *safeAuthorization) do(ctx context.Context, method, path string, body, o
 		return err
 	}
 	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set(sharedrest.AcceptLanguageHeader, sharedrest.GetLanguageByCtx(ctx))
 	resp, err := s.http.Do(req)
 	if err != nil {
 		return err

--- a/adp/execution-factory/operator-integration/server/drivenadapters/authorization_safe_test.go
+++ b/adp/execution-factory/operator-integration/server/drivenadapters/authorization_safe_test.go
@@ -11,6 +11,8 @@ import (
 	"net/http/httptest"
 	"testing"
 
+	sharedrest "github.com/openbkn-ai/bkn-foundry/comm-go/rest"
+
 	"github.com/openbkn-ai/bkn-foundry/adp/execution-factory/operator-integration/server/interfaces"
 )
 
@@ -65,8 +67,8 @@ func TestSafeAuthorizationResourceList(t *testing.T) {
 
 	t.Run("single operation returns accessible IDs", func(t *testing.T) {
 		res, err := s.ResourceList(ctx, &interfaces.ResourceListRequest{
-			Accessor: &interfaces.AuthAccessor{ID: "u1"},
-			Resource: &interfaces.AuthResource{Type: "skill"},
+			Accessor:  &interfaces.AuthAccessor{ID: "u1"},
+			Resource:  &interfaces.AuthResource{Type: "skill"},
 			Operation: []interfaces.AuthOperationType{interfaces.AuthOperationTypeView},
 		})
 		if err != nil {
@@ -96,8 +98,8 @@ func TestSafeAuthorizationResourceList(t *testing.T) {
 
 	t.Run("type-wide grant returns ResourceIDAll", func(t *testing.T) {
 		res, err := s.ResourceList(ctx, &interfaces.ResourceListRequest{
-			Accessor: &interfaces.AuthAccessor{ID: "admin"},
-			Resource: &interfaces.AuthResource{Type: "skill"},
+			Accessor:  &interfaces.AuthAccessor{ID: "admin"},
+			Resource:  &interfaces.AuthResource{Type: "skill"},
 			Operation: []interfaces.AuthOperationType{interfaces.AuthOperationTypeView},
 		})
 		if err != nil {
@@ -120,6 +122,27 @@ func TestSafeAuthorizationResourceList(t *testing.T) {
 			t.Fatalf("ResourceList = %+v, want []", res)
 		}
 	})
+}
+
+func TestSafeAuthorizationUsesEffectiveLocale(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got := r.Header.Get(sharedrest.AcceptLanguageHeader); got != sharedrest.AmericanEnglish {
+			t.Errorf("Accept-Language = %q, want %q", got, sharedrest.AmericanEnglish)
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{"allowed": true})
+	}))
+	defer server.Close()
+
+	safe := newSafeAuthorization(server.URL, testLogger{})
+	ctx := sharedrest.WithLanguage(context.Background(), sharedrest.AmericanEnglish)
+	result, err := safe.OperationCheck(ctx, &interfaces.AuthOperationCheckRequest{
+		Accessor:  &interfaces.AuthAccessor{ID: "user-1"},
+		Resource:  &interfaces.AuthResource{Type: "skill", ID: "skill-1"},
+		Operation: []interfaces.AuthOperationType{interfaces.AuthOperationTypeView},
+	})
+	if err != nil || !result.Result {
+		t.Fatalf("OperationCheck() = %#v, %v", result, err)
+	}
 }
 
 func TestIntersectStringSlices(t *testing.T) {

--- a/adp/execution-factory/operator-integration/server/drivenadapters/oss_gateway_backend.go
+++ b/adp/execution-factory/operator-integration/server/drivenadapters/oss_gateway_backend.go
@@ -17,6 +17,7 @@ import (
 	"github.com/openbkn-ai/bkn-foundry/adp/execution-factory/operator-integration/server/infra/rest"
 	"github.com/openbkn-ai/bkn-foundry/adp/execution-factory/operator-integration/server/interfaces"
 	"github.com/openbkn-ai/bkn-foundry/adp/execution-factory/operator-integration/server/utils"
+	sharedrest "github.com/openbkn-ai/bkn-foundry/comm-go/rest"
 )
 
 // OSSGatewayBackendClient OSS 网关后端客户端
@@ -376,6 +377,7 @@ func (c *ossGatewayBackendClient) doSignedRequestRaw(ctx context.Context, method
 	for key, value := range headers {
 		req.Header.Set(key, value)
 	}
+	req.Header.Set(sharedrest.AcceptLanguageHeader, sharedrest.GetLanguageByCtx(ctx))
 	resp, err := c.client.Do(req)
 	if err != nil {
 		return nil, err

--- a/adp/execution-factory/operator-integration/server/drivenadapters/user_management_safe.go
+++ b/adp/execution-factory/operator-integration/server/drivenadapters/user_management_safe.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/openbkn-ai/bkn-foundry/adp/execution-factory/operator-integration/server/interfaces"
 	"github.com/openbkn-ai/bkn-foundry/adp/execution-factory/operator-integration/server/utils"
+	sharedrest "github.com/openbkn-ai/bkn-foundry/comm-go/rest"
 )
 
 // bkn-safe user-directory adapter + cutover switch for exec-factory.
@@ -147,6 +148,7 @@ func (s *safeUserManagement) post(ctx context.Context, path string, body, out an
 		return err
 	}
 	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set(sharedrest.AcceptLanguageHeader, sharedrest.GetLanguageByCtx(ctx))
 	resp, err := s.http.Do(req)
 	if err != nil {
 		return err

--- a/adp/execution-factory/operator-integration/server/driveradapters/category/category.go
+++ b/adp/execution-factory/operator-integration/server/driveradapters/category/category.go
@@ -9,6 +9,7 @@ import (
 	"github.com/openbkn-ai/bkn-foundry/adp/execution-factory/operator-integration/server/infra/errors"
 	"github.com/openbkn-ai/bkn-foundry/adp/execution-factory/operator-integration/server/infra/rest"
 	"github.com/openbkn-ai/bkn-foundry/adp/execution-factory/operator-integration/server/interfaces"
+	sharedrest "github.com/openbkn-ai/bkn-foundry/comm-go/rest"
 )
 
 // CategoryList 算子分类列表
@@ -18,6 +19,7 @@ func (h *categoryHandler) CategoryList(c *gin.Context) {
 		rest.ReplyError(c, err)
 		return
 	}
+	sharedrest.MarkLocalizedCacheableResponse(c)
 	rest.ReplyOK(c, http.StatusOK, result)
 }
 

--- a/adp/execution-factory/operator-integration/server/driveradapters/category/category_language_test.go
+++ b/adp/execution-factory/operator-integration/server/driveradapters/category/category_language_test.go
@@ -1,0 +1,36 @@
+package category
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/openbkn-ai/bkn-foundry/adp/execution-factory/operator-integration/server/interfaces"
+	"github.com/openbkn-ai/bkn-foundry/adp/execution-factory/operator-integration/server/mocks"
+	sharedrest "github.com/openbkn-ai/bkn-foundry/comm-go/rest"
+	"go.uber.org/mock/gomock"
+)
+
+func TestCategoryListMarksLocalizedCacheableResponse(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	manager := mocks.NewMockCategoryManager(ctrl)
+	manager.EXPECT().GetCategoryList(gomock.Any()).Return([]*interfaces.CategoryInfo{}, nil)
+	handler := &categoryHandler{CategoryManager: manager}
+	recorder := httptest.NewRecorder()
+	ctx, _ := gin.CreateTestContext(recorder)
+	request := httptest.NewRequest(http.MethodGet, "/operator/category", nil)
+	ctx.Request = request.WithContext(sharedrest.WithLanguage(request.Context(), sharedrest.AmericanEnglish))
+
+	handler.CategoryList(ctx)
+
+	if got := recorder.Header().Get(sharedrest.ContentLanguageHeader); got != sharedrest.AmericanEnglish {
+		t.Fatalf("Content-Language = %q, want %q", got, sharedrest.AmericanEnglish)
+	}
+	if got := recorder.Header().Get("Vary"); got != sharedrest.AcceptLanguageHeader {
+		t.Fatalf("Vary = %q, want %q", got, sharedrest.AcceptLanguageHeader)
+	}
+}

--- a/adp/execution-factory/operator-integration/server/driveradapters/common/ai_generation.go
+++ b/adp/execution-factory/operator-integration/server/driveradapters/common/ai_generation.go
@@ -98,7 +98,7 @@ func (h *aiGenerationHandler) FunctionAIGeneration(c *gin.Context) {
 	}
 	// 设置SSE响应头
 	c.Header("Content-Type", "text/event-stream")
-	c.Header("Cache-Control", "no-cache")
+	c.Header("Cache-Control", "private, no-cache")
 	c.Header("Connection", "keep-alive")
 	c.Header("Access-Control-Allow-Origin", "*")
 	c.Header("Access-Control-Allow-Headers", "Cache-Control")

--- a/adp/execution-factory/operator-integration/server/driveradapters/operator/category.go
+++ b/adp/execution-factory/operator-integration/server/driveradapters/operator/category.go
@@ -3,12 +3,13 @@ package operator
 import (
 	"net/http"
 
-	"github.com/openbkn-ai/bkn-foundry/adp/execution-factory/operator-integration/server/infra/errors"
-	"github.com/openbkn-ai/bkn-foundry/adp/execution-factory/operator-integration/server/infra/rest"
-	"github.com/openbkn-ai/bkn-foundry/adp/execution-factory/operator-integration/server/interfaces"
 	"github.com/creasty/defaults"
 	"github.com/gin-gonic/gin"
 	"github.com/go-playground/validator/v10"
+	"github.com/openbkn-ai/bkn-foundry/adp/execution-factory/operator-integration/server/infra/errors"
+	"github.com/openbkn-ai/bkn-foundry/adp/execution-factory/operator-integration/server/infra/rest"
+	"github.com/openbkn-ai/bkn-foundry/adp/execution-factory/operator-integration/server/interfaces"
+	sharedrest "github.com/openbkn-ai/bkn-foundry/comm-go/rest"
 )
 
 // OperatorCategoryList 算子分类列表
@@ -19,6 +20,7 @@ func (op *operatorHandle) OperatorCategoryList(c *gin.Context) {
 		rest.ReplyError(c, err)
 		return
 	}
+	sharedrest.MarkLocalizedCacheableResponse(c)
 	rest.ReplyOK(c, http.StatusOK, result)
 }
 

--- a/adp/execution-factory/operator-integration/server/driveradapters/rest_private_handler.go
+++ b/adp/execution-factory/operator-integration/server/driveradapters/rest_private_handler.go
@@ -10,6 +10,7 @@ import (
 	"github.com/openbkn-ai/bkn-foundry/adp/execution-factory/operator-integration/server/infra/config"
 	"github.com/openbkn-ai/bkn-foundry/adp/execution-factory/operator-integration/server/interfaces"
 	"github.com/openbkn-ai/bkn-foundry/adp/execution-factory/operator-integration/server/logics/business_domain"
+	sharedrest "github.com/openbkn-ai/bkn-foundry/comm-go/rest"
 )
 
 type restPrivateHandler struct {
@@ -44,7 +45,7 @@ func NewRestPrivateHandler() interfaces.HTTPRouterInterface {
 // RegisterRouter 内部接口注册路由
 func (r *restPrivateHandler) RegisterRouter(engine *gin.RouterGroup) {
 	mws := []gin.HandlerFunc{}
-	mws = append(mws, middlewareRequestLog(r.Logger), middlewareTrace, middlewareTraceContext, middlewareHeaderAuthContext(r.Hydra))
+	mws = append(mws, middlewareRequestLog(r.Logger), middlewareTrace, middlewareTraceContext, sharedrest.LanguageMiddleware(), sharedrest.PrivateNoCacheMiddleware(), middlewareHeaderAuthContext(r.Hydra))
 	engine.Use(mws...)
 	// 算子接口
 	r.OperatorRestHandler.RegisterPrivate(engine)

--- a/adp/execution-factory/operator-integration/server/driveradapters/rest_public_handler.go
+++ b/adp/execution-factory/operator-integration/server/driveradapters/rest_public_handler.go
@@ -11,6 +11,7 @@ import (
 	"github.com/openbkn-ai/bkn-foundry/adp/execution-factory/operator-integration/server/infra/config"
 	"github.com/openbkn-ai/bkn-foundry/adp/execution-factory/operator-integration/server/interfaces"
 	"github.com/openbkn-ai/bkn-foundry/adp/execution-factory/operator-integration/server/logics/business_domain"
+	sharedrest "github.com/openbkn-ai/bkn-foundry/comm-go/rest"
 )
 
 type restPublicHandler struct {
@@ -51,7 +52,7 @@ func NewRestPublicHandler() interfaces.HTTPRouterInterface {
 // RegisterPublic 注册公共路由
 func (r *restPublicHandler) RegisterRouter(engine *gin.RouterGroup) {
 	mws := []gin.HandlerFunc{}
-	mws = append(mws, middlewareRequestLog(r.Logger), middlewareTrace, middlewareTraceContext, middlewareIntrospectVerify(r.Hydra, r.AppKeys))
+	mws = append(mws, middlewareRequestLog(r.Logger), middlewareTrace, middlewareTraceContext, sharedrest.LanguageMiddleware(), sharedrest.PrivateNoCacheMiddleware(), middlewareIntrospectVerify(r.Hydra, r.AppKeys))
 	engine.Use(mws...)
 	// 算子注册相关接口
 	r.OperatorRestHandler.RegisterPublic(engine)

--- a/adp/execution-factory/operator-integration/server/infra/rest/http_client.go
+++ b/adp/execution-factory/operator-integration/server/infra/rest/http_client.go
@@ -17,6 +17,7 @@ import (
 	"github.com/openbkn-ai/bkn-foundry/adp/execution-factory/operator-integration/server/infra/logger"
 	"github.com/openbkn-ai/bkn-foundry/adp/execution-factory/operator-integration/server/infra/telemetry"
 	"github.com/openbkn-ai/bkn-foundry/adp/execution-factory/operator-integration/server/interfaces"
+	sharedrest "github.com/openbkn-ai/bkn-foundry/comm-go/rest"
 )
 
 // httpClient HTTP客户端结构
@@ -255,6 +256,7 @@ func (c *httpClient) generateReq(ctx context.Context, httpMethod, url string,
 			req.Header.Add(k, v)
 		}
 	}
+	req.Header.Set(sharedrest.AcceptLanguageHeader, sharedrest.GetLanguageByCtx(ctx))
 	return
 }
 
@@ -287,6 +289,7 @@ func (c *httpClient) PostStream(ctx context.Context, url string, headers map[str
 		for k, v := range headers {
 			req.Header.Add(k, v)
 		}
+		req.Header.Set(sharedrest.AcceptLanguageHeader, sharedrest.GetLanguageByCtx(ctx))
 		// 设置流式请求头
 		req.Header.Set("Accept", "text/event-stream")
 		req.Header.Set("Cache-Control", "no-cache")

--- a/adp/execution-factory/operator-integration/server/infra/rest/reply.go
+++ b/adp/execution-factory/operator-integration/server/infra/rest/reply.go
@@ -15,6 +15,7 @@ import (
 	"github.com/openbkn-ai/bkn-foundry/adp/execution-factory/operator-integration/server/infra/logger"
 	validatorv "github.com/openbkn-ai/bkn-foundry/adp/execution-factory/operator-integration/server/infra/validator"
 	"github.com/openbkn-ai/bkn-foundry/adp/execution-factory/operator-integration/server/interfaces"
+	sharedrest "github.com/openbkn-ai/bkn-foundry/comm-go/rest"
 	errorwrap "github.com/pkg/errors"
 )
 
@@ -37,6 +38,7 @@ func ReplyOK(c *gin.Context, statusCode int, body interface{}) {
 			statusCode = http.StatusInternalServerError
 			ctx := c.Request.Context()
 			bodyStr = myErr.DefaultHTTPError(ctx, statusCode, err.Error()).Error()
+			sharedrest.MarkLocalizedResponse(c)
 		}
 	}
 
@@ -53,10 +55,12 @@ func ReplyError(c *gin.Context, err error) {
 	var httpCode int
 	ctx := c.Request.Context()
 	var body string
+	localized := true
 	switch e := err.(type) {
 	case *ExHTTPError:
 		httpCode = e.HTTPCode
 		body = e.Error()
+		localized = false
 	default:
 		httpError := &myErr.HTTPError{}
 		vErr := make(validator.ValidationErrors, 0)
@@ -75,6 +79,9 @@ func ReplyError(c *gin.Context, err error) {
 			httpCode = http.StatusInternalServerError
 			body = myErr.DefaultHTTPError(ctx, httpCode, err.Error()).Error()
 		}
+	}
+	if localized {
+		sharedrest.MarkLocalizedResponse(c)
 	}
 	c.Writer.Header().Set(ContentTypeKey, ContentTypeJSON)
 	c.String(httpCode, body)

--- a/adp/execution-factory/operator-integration/server/infra/rest/reply_language_test.go
+++ b/adp/execution-factory/operator-integration/server/infra/rest/reply_language_test.go
@@ -1,0 +1,46 @@
+// Copyright openbkn.ai
+// Copyright The kweaver.ai Authors.
+//
+// Licensed under the Apache License, Version 2.0.
+// See the LICENSE file in the project root for details.
+
+package rest
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	sharedrest "github.com/openbkn-ai/bkn-foundry/comm-go/rest"
+)
+
+func TestReplyErrorMarksOnlyLocallyGeneratedTextAsLocalized(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	t.Run("local error", func(t *testing.T) {
+		recorder := httptest.NewRecorder()
+		c, _ := gin.CreateTestContext(recorder)
+		c.Request = httptest.NewRequest(http.MethodGet, "/", nil)
+		c.Request = c.Request.WithContext(sharedrest.WithLanguage(c.Request.Context(), sharedrest.AmericanEnglish))
+
+		ReplyError(c, http.ErrNotSupported)
+
+		if got := recorder.Header().Get(sharedrest.ContentLanguageHeader); got != sharedrest.AmericanEnglish {
+			t.Fatalf("Content-Language = %q, want %q", got, sharedrest.AmericanEnglish)
+		}
+	})
+
+	t.Run("upstream error", func(t *testing.T) {
+		recorder := httptest.NewRecorder()
+		c, _ := gin.CreateTestContext(recorder)
+		c.Request = httptest.NewRequest(http.MethodGet, "/", nil)
+		c.Request = c.Request.WithContext(sharedrest.WithLanguage(c.Request.Context(), sharedrest.AmericanEnglish))
+
+		ReplyError(c, &ExHTTPError{HTTPCode: http.StatusBadGateway, Body: []byte(`{"message":"upstream"}`)})
+
+		if got := recorder.Header().Get(sharedrest.ContentLanguageHeader); got != "" {
+			t.Fatalf("Content-Language = %q, want empty for upstream response", got)
+		}
+	})
+}

--- a/adp/execution-factory/operator-integration/server/logics/proxy/forwarder.go
+++ b/adp/execution-factory/operator-integration/server/logics/proxy/forwarder.go
@@ -19,6 +19,7 @@ import (
 	myErr "github.com/openbkn-ai/bkn-foundry/adp/execution-factory/operator-integration/server/infra/errors"
 	"github.com/openbkn-ai/bkn-foundry/adp/execution-factory/operator-integration/server/interfaces"
 	"github.com/openbkn-ai/bkn-foundry/adp/execution-factory/operator-integration/server/utils"
+	sharedrest "github.com/openbkn-ai/bkn-foundry/comm-go/rest"
 	"github.com/pkg/errors"
 )
 
@@ -333,6 +334,9 @@ func (f *forwarder) buildRequest(ctx context.Context, req *interfaces.HTTPReques
 	for key, value := range common.MergeTraceHeaders(ctx, headers) {
 		httpReq.Header.Set(key, value)
 	}
+	// Internal requests carry the resolved, single-value locale rather than the
+	// caller's original Accept-Language preference list.
+	httpReq.Header.Set(sharedrest.AcceptLanguageHeader, sharedrest.GetLanguageByCtx(ctx))
 
 	// 如果Content-Type未在请求头中设置，但我们有确定的类型，则设置它
 	if contentType != "" && (forceContentType || httpReq.Header.Get("Content-Type") == "") {
@@ -544,7 +548,7 @@ func preprocessResponseHeaders(streamingMode interfaces.StreamingMode, headerWri
 	switch streamingMode {
 	case interfaces.StreamingModeSSE:
 		headerWriter.Header().Set("Content-Type", "text/event-stream")
-		headerWriter.Header().Set("Cache-Control", "no-cache")
+		headerWriter.Header().Set("Cache-Control", privateStreamingCacheControl(headerWriter.Header().Get("Cache-Control")))
 		headerWriter.Header().Set("Connection", "keep-alive")
 		// 移除可能存在的Content-Length头部
 		headerWriter.Header().Del("Content-Length")
@@ -554,4 +558,34 @@ func preprocessResponseHeaders(streamingMode interfaces.StreamingMode, headerWri
 		// 移除可能存在的Content-Length头部
 		headerWriter.Header().Del("Content-Length")
 	}
+}
+
+func privateStreamingCacheControl(value string) string {
+	directives := make([]string, 0)
+	hasNoStore := false
+	for _, directive := range strings.Split(value, ",") {
+		directive = strings.TrimSpace(directive)
+		if directive == "" || strings.EqualFold(directive, "public") || strings.EqualFold(directive, "private") {
+			continue
+		}
+		if strings.EqualFold(directive, "no-store") {
+			hasNoStore = true
+		}
+		directives = append(directives, directive)
+	}
+
+	directives = append(directives, "private")
+	if !hasNoStore && !containsCacheDirective(directives, "no-cache") {
+		directives = append(directives, "no-cache")
+	}
+	return strings.Join(directives, ", ")
+}
+
+func containsCacheDirective(directives []string, name string) bool {
+	for _, directive := range directives {
+		if strings.EqualFold(strings.TrimSpace(strings.SplitN(directive, "=", 2)[0]), name) {
+			return true
+		}
+	}
+	return false
 }

--- a/adp/execution-factory/operator-integration/server/logics/proxy/forwarder_test.go
+++ b/adp/execution-factory/operator-integration/server/logics/proxy/forwarder_test.go
@@ -12,6 +12,7 @@ import (
 	myErr "github.com/openbkn-ai/bkn-foundry/adp/execution-factory/operator-integration/server/infra/errors"
 	"github.com/openbkn-ai/bkn-foundry/adp/execution-factory/operator-integration/server/infra/logger"
 	"github.com/openbkn-ai/bkn-foundry/adp/execution-factory/operator-integration/server/interfaces"
+	sharedrest "github.com/openbkn-ai/bkn-foundry/comm-go/rest"
 	. "github.com/smartystreets/goconvey/convey"
 	"go.opentelemetry.io/otel/trace"
 	"go.uber.org/mock/gomock"
@@ -234,5 +235,36 @@ func TestBuildRequest_PathQueryHeaderBody(t *testing.T) {
 			So(readErr, ShouldBeNil)
 			So(string(payload), ShouldEqual, `{"name":"demo"}`)
 		})
+	})
+}
+
+func TestBuildRequestUsesEffectiveLocale(t *testing.T) {
+	Convey("buildRequest forwards the resolved locale instead of caller preferences", t, func() {
+		forwarder := &forwarder{logger: logger.DefaultLogger()}
+		ctx := sharedrest.WithLanguage(context.Background(), sharedrest.AmericanEnglish)
+		httpReq, err := forwarder.buildRequest(ctx, &interfaces.HTTPRequest{
+			HTTPRouter: interfaces.HTTPRouter{Method: http.MethodGet, URL: "http://svc:9000/ping"},
+			HTTPRequestParams: interfaces.HTTPRequestParams{
+				Headers: map[string]any{sharedrest.AcceptLanguageHeader: "zh-CN, en-US;q=0.8"},
+			},
+		})
+
+		So(err, ShouldBeNil)
+		So(httpReq.Header.Get(sharedrest.AcceptLanguageHeader), ShouldEqual, sharedrest.AmericanEnglish)
+	})
+}
+
+func TestPreprocessResponseHeadersPreservesStrictCacheControls(t *testing.T) {
+	Convey("preprocessResponseHeaders keeps stricter upstream cache directives", t, func() {
+		writer := httptest.NewRecorder()
+		writer.Header().Set("Cache-Control", "public, no-store")
+		writer.Header().Set("Content-Language", "en-US")
+		writer.Header().Set("Vary", "Accept-Encoding")
+
+		preprocessResponseHeaders(interfaces.StreamingModeSSE, writer)
+
+		So(writer.Header().Get("Cache-Control"), ShouldEqual, "no-store, private")
+		So(writer.Header().Get("Content-Language"), ShouldEqual, "en-US")
+		So(writer.Header().Get("Vary"), ShouldEqual, "Accept-Encoding")
 	})
 }

--- a/adp/vega/vega-backend/server/driveradapters/router.go
+++ b/adp/vega/vega-backend/server/driveradapters/router.go
@@ -102,6 +102,7 @@ func (r *restHandler) RegisterPublic(c *gin.Engine) {
 
 	// 外部 API (External)
 	apiV1 := c.Group("/api/vega-backend/v1")
+	apiV1.Use(rest.PrivateNoCacheMiddleware())
 	{
 		// Catalog APIs - External
 		catalogs := apiV1.Group("/catalogs")
@@ -198,6 +199,7 @@ func (r *restHandler) RegisterPublic(c *gin.Engine) {
 
 	// 内部 API (Internal)
 	apiInV1 := c.Group("/api/vega-backend/in/v1")
+	apiInV1.Use(rest.PrivateNoCacheMiddleware())
 	{
 		// Catalog APIs - Internal
 		catalogs := apiInV1.Group("/catalogs")
@@ -309,13 +311,10 @@ func (r *restHandler) verifyJsonContentType() gin.HandlerFunc {
 	}
 }
 
-// gin中间件 把 X-Language 头解析结果挂到 request ctx。
+// LanguageMiddleware resolves Accept-Language once and stores it in request context.
 // 注册顺序必须在 TracingMiddleware 之后，这样 language ctx 叠加在 trace ctx 上。
 func (r *restHandler) LanguageMiddleware() gin.HandlerFunc {
-	return func(c *gin.Context) {
-		c.Request = c.Request.WithContext(rest.GetLanguageCtx(c))
-		c.Next()
-	}
+	return rest.LanguageMiddleware()
 }
 
 // TraceContextMiddleware parses OpenBKN phase-one trace context into request context.

--- a/adp/vega/vega-backend/server/go.mod
+++ b/adp/vega/vega-backend/server/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/lib/pq v1.12.3
 	github.com/mitchellh/mapstructure v1.5.0
 	github.com/mohae/deepcopy v0.0.0-20170929034955-c48cc78d4826
-	github.com/openbkn-ai/bkn-foundry/comm-go v0.1.1-0.20260813121341-970e0bb7367d
+	github.com/openbkn-ai/bkn-foundry/comm-go v0.1.1-0.20260813155806-b731c9765f03
 	github.com/opensearch-project/opensearch-go/v2 v2.3.0
 	github.com/robfig/cron/v3 v3.0.1
 	github.com/rs/xid v1.6.0

--- a/adp/vega/vega-backend/server/go.sum
+++ b/adp/vega/vega-backend/server/go.sum
@@ -163,6 +163,8 @@ github.com/openbkn-ai/bkn-foundry/comm-go v0.1.1-0.20260813101616-bd7f22f1d9cb h
 github.com/openbkn-ai/bkn-foundry/comm-go v0.1.1-0.20260813101616-bd7f22f1d9cb/go.mod h1:D0d+xRVJAk7DutF2g8I/TsXceE/1Iv3EmNNj8yxu2pA=
 github.com/openbkn-ai/bkn-foundry/comm-go v0.1.1-0.20260813121341-970e0bb7367d h1:alYnur68nbfTckDh5qp3YtpPz86SwpKjVDhVjPtCzB4=
 github.com/openbkn-ai/bkn-foundry/comm-go v0.1.1-0.20260813121341-970e0bb7367d/go.mod h1:D0d+xRVJAk7DutF2g8I/TsXceE/1Iv3EmNNj8yxu2pA=
+github.com/openbkn-ai/bkn-foundry/comm-go v0.1.1-0.20260813155806-b731c9765f03 h1:vk8vJjMUDg81wPYNi0JGbcL0aTm/oONoj4B1zxaEf10=
+github.com/openbkn-ai/bkn-foundry/comm-go v0.1.1-0.20260813155806-b731c9765f03/go.mod h1:D0d+xRVJAk7DutF2g8I/TsXceE/1Iv3EmNNj8yxu2pA=
 github.com/opensearch-project/opensearch-go/v2 v2.3.0 h1:nQIEMr+A92CkhHrZgUhcfsrZjibvB3APXf2a1VwCmMQ=
 github.com/opensearch-project/opensearch-go/v2 v2.3.0/go.mod h1:8LDr9FCgUTVoT+5ESjc2+iaZuldqE+23Iq0r1XeNue8=
 github.com/pelletier/go-toml/v2 v2.2.4 h1:mye9XuhQ6gvn5h28+VilKrrPoQVanw5PMw/TB0t5Ec4=

--- a/docs/api/context-loader/skill.yaml
+++ b/docs/api/context-loader/skill.yaml
@@ -55,6 +55,7 @@ paths:
         **空结果是 200 不是错误**：没有匹配时返回 `entries: []`，并可能带一个
         `message` 说明为什么为空（如该对象类未绑定任何 Skill）以及下一步建议。
       parameters:
+        - $ref: '#/components/parameters/AcceptLanguage'
         - $ref: '#/components/parameters/ResponseFormat'
       requestBody:
         required: true
@@ -111,6 +112,9 @@ paths:
           description: |
             参数错误：缺少 `kn_id` / `object_type_id`，或 `skills` 对象类的数据属性
             契约不完整（缺 `skill_id` / `name`）
+          headers:
+            Content-Language:
+              $ref: '#/components/headers/ContentLanguage'
           content:
             application/json:
               schema:
@@ -131,24 +135,36 @@ paths:
                     link: 无
         '401':
           description: 凭据缺失或无效
+          headers:
+            Content-Language:
+              $ref: '#/components/headers/ContentLanguage'
           content:
             application/json:
               schema:
                 $ref: '../_shared/errors.yaml#/components/schemas/ErrorAgentRetrieval'
         '404':
           description: 指定对象类不存在，或当前知识网络中缺少 `skills` 对象类
+          headers:
+            Content-Language:
+              $ref: '#/components/headers/ContentLanguage'
           content:
             application/json:
               schema:
                 $ref: '../_shared/errors.yaml#/components/schemas/ErrorAgentRetrieval'
         '502':
           description: 上游服务不可用（BKN 或 ontology-query 异常）
+          headers:
+            Content-Language:
+              $ref: '#/components/headers/ContentLanguage'
           content:
             application/json:
               schema:
                 $ref: '../_shared/errors.yaml#/components/schemas/ErrorAgentRetrieval'
         '500':
           description: 服务内部错误
+          headers:
+            Content-Language:
+              $ref: '#/components/headers/ContentLanguage'
           content:
             application/json:
               schema:
@@ -173,6 +189,7 @@ paths:
 
         **空结果是 200 不是错误**：无匹配时 `entries: []` 并带 `message` 说明。
       parameters:
+        - $ref: '#/components/parameters/AcceptLanguage'
         - $ref: '#/components/parameters/ResponseFormat'
       requestBody:
         required: false
@@ -218,6 +235,9 @@ paths:
                 $ref: '../_shared/errors.yaml#/components/schemas/ErrorAgentRetrieval'
         '502':
           description: 上游 execution-factory 不可用
+          headers:
+            Content-Language:
+              $ref: '#/components/headers/ContentLanguage'
           content:
             application/json:
               schema:
@@ -237,6 +257,7 @@ paths:
 
         正文超过 40000 字符会截断，此时 `truncated=true` 并带 `message` 说明。
       parameters:
+        - $ref: '#/components/parameters/AcceptLanguage'
         - $ref: '#/components/parameters/ResponseFormat'
       requestBody:
         required: true
@@ -260,24 +281,36 @@ paths:
                 type: string
         '400':
           description: 缺少 `skill_id`
+          headers:
+            Content-Language:
+              $ref: '#/components/headers/ContentLanguage'
           content:
             application/json:
               schema:
                 $ref: '../_shared/errors.yaml#/components/schemas/ErrorAgentRetrieval'
         '401':
           description: 凭据缺失或无效
+          headers:
+            Content-Language:
+              $ref: '#/components/headers/ContentLanguage'
           content:
             application/json:
               schema:
                 $ref: '../_shared/errors.yaml#/components/schemas/ErrorAgentRetrieval'
         '403':
           description: 当前账户对该 Skill 无执行 / 查看 / 公开访问权限
+          headers:
+            Content-Language:
+              $ref: '#/components/headers/ContentLanguage'
           content:
             application/json:
               schema:
                 $ref: '../_shared/errors.yaml#/components/schemas/ErrorAgentRetrieval'
         '404':
           description: Skill 不存在或未发布
+          headers:
+            Content-Language:
+              $ref: '#/components/headers/ContentLanguage'
           content:
             application/json:
               schema:
@@ -298,6 +331,7 @@ paths:
 
         正文超过 40000 字符会截断（`truncated=true`）；单文件超过 5 MiB 返回 413。
       parameters:
+        - $ref: '#/components/parameters/AcceptLanguage'
         - $ref: '#/components/parameters/ResponseFormat'
       requestBody:
         required: true
@@ -322,24 +356,36 @@ paths:
                 type: string
         '400':
           description: 缺少 `skill_id` / `rel_path`，或路径越出技能包
+          headers:
+            Content-Language:
+              $ref: '#/components/headers/ContentLanguage'
           content:
             application/json:
               schema:
                 $ref: '../_shared/errors.yaml#/components/schemas/ErrorAgentRetrieval'
         '403':
           description: 当前账户对该 Skill 无执行 / 查看 / 公开访问权限
+          headers:
+            Content-Language:
+              $ref: '#/components/headers/ContentLanguage'
           content:
             application/json:
               schema:
                 $ref: '../_shared/errors.yaml#/components/schemas/ErrorAgentRetrieval'
         '404':
           description: Skill 或该路径的文件不存在
+          headers:
+            Content-Language:
+              $ref: '#/components/headers/ContentLanguage'
           content:
             application/json:
               schema:
                 $ref: '../_shared/errors.yaml#/components/schemas/ErrorAgentRetrieval'
         '413':
           description: 文件超过 5 MiB 上限，改用技能包下载接口
+          headers:
+            Content-Language:
+              $ref: '#/components/headers/ContentLanguage'
           content:
             application/json:
               schema:
@@ -367,6 +413,8 @@ paths:
         路由，同名 MCP 工具也才出现在 `tools/list` 与 `GET /mcp/info`。默认关闭，
         此时这条路径返回 404——「这个部署没有技能执行能力」在路由表上成立。
         （旧名 `MCP_EXECUTE_SKILL_ENABLED` 仍被识别，用于兼容已按旧名配置的部署。）
+      parameters:
+        - $ref: '#/components/parameters/AcceptLanguage'
       requestBody:
         required: true
         content:
@@ -390,24 +438,36 @@ paths:
                 $ref: '#/components/schemas/ExecuteSkillResponse'
         '400':
           description: 缺少 `skill_id` / `entry_shell`
+          headers:
+            Content-Language:
+              $ref: '#/components/headers/ContentLanguage'
           content:
             application/json:
               schema:
                 $ref: '../_shared/errors.yaml#/components/schemas/ErrorAgentRetrieval'
         '403':
           description: 当前账户对该 Skill 无执行权限
+          headers:
+            Content-Language:
+              $ref: '#/components/headers/ContentLanguage'
           content:
             application/json:
               schema:
                 $ref: '../_shared/errors.yaml#/components/schemas/ErrorAgentRetrieval'
         '404':
           description: Skill 不存在或未发布
+          headers:
+            Content-Language:
+              $ref: '#/components/headers/ContentLanguage'
           content:
             application/json:
               schema:
                 $ref: '../_shared/errors.yaml#/components/schemas/ErrorAgentRetrieval'
         '502':
           description: 沙箱或上游 execution-factory 不可用
+          headers:
+            Content-Language:
+              $ref: '#/components/headers/ContentLanguage'
           content:
             application/json:
               schema:
@@ -421,6 +481,13 @@ components:
       $ref: '../_shared/auth.yaml#/components/securitySchemes/AppKey'
 
   parameters:
+    AcceptLanguage:
+      name: Accept-Language
+      in: header
+      required: false
+      schema:
+        type: string
+      description: 可选的 RFC 9110 语言偏好。服务从支持的 `zh-CN`、`en-US` 中选择响应错误文本语言。
     ResponseFormat:
       name: response_format
       in: query
@@ -432,6 +499,16 @@ components:
           - toon
         default: json
       description: 响应格式。`toon` 返回 `application/toon`，同构数组压成表格，省 token。
+
+  headers:
+    ContentLanguage:
+      description: 仅当响应包含本地化人类可读文本时返回，值为实际使用的语言。
+      schema:
+        type: string
+    VaryAcceptLanguage:
+      description: 仅当可缓存表示随请求语言变化时返回，值包含 `Accept-Language`。
+      schema:
+        type: string
 
   schemas:
     FindSkillsRequest:
@@ -498,7 +575,7 @@ components:
           type: string
           description: |
             空结果说明。仅当 `entries` 为空且返回 200 时出现，用于告诉调用方为什么
-            没有结果与下一步建议；`entries` 非空时不返回。文案随请求的 `X-Language`
+            没有结果与下一步建议；`entries` 非空时不返回。文案随请求的 `Accept-Language`
             头本地化。
 
     SkillItem:

--- a/docs/api/execution-factory/function.yaml
+++ b/docs/api/execution-factory/function.yaml
@@ -59,6 +59,8 @@ paths:
         **响应永远是 200**：代码自身抛异常不算接口失败，异常栈在 `stderr` 里，
         `exit_code` 非 0，`result` 为 `null`。只有参数不合法、无权限、沙箱不可用
         才返回 4xx/5xx——**判断执行成败看 `exit_code`，不要看 HTTP 状态码**。
+      parameters:
+        - $ref: '#/components/parameters/AcceptLanguage'
       requestBody:
         required: true
         content:
@@ -146,6 +148,9 @@ paths:
           $ref: '#/components/responses/Unauthorized'
         '403':
           description: 当前账户没有算子的 execute 权限
+          headers:
+            Content-Language:
+              $ref: '#/components/headers/ContentLanguage'
           content:
             application/json:
               schema:
@@ -169,6 +174,8 @@ paths:
         真正的 4xx/5xx 只在参数不合法、无权限、沙箱不可用时出现。
 
         **这会真的执行你的代码**，因此与 `/function/execute` 用同一套 execute 授权。
+      parameters:
+        - $ref: '#/components/parameters/AcceptLanguage'
       requestBody:
         required: true
         content:
@@ -218,6 +225,9 @@ paths:
           $ref: '#/components/responses/Unauthorized'
         '403':
           description: 当前账户没有算子的 execute 权限
+          headers:
+            Content-Language:
+              $ref: '#/components/headers/ContentLanguage'
           content:
             application/json:
               schema:
@@ -237,6 +247,8 @@ paths:
         装包检查）。
 
         本接口会从池里取一个会话来查询，响应里的 `session_id` 就是被查询的那个会话。
+      parameters:
+        - $ref: '#/components/parameters/AcceptLanguage'
       responses:
         '200':
           description: 依赖库列表
@@ -248,6 +260,9 @@ paths:
           $ref: '#/components/responses/Unauthorized'
         '500':
           description: 沙箱不可用或取不到会话
+          headers:
+            Content-Language:
+              $ref: '#/components/headers/ContentLanguage'
           content:
             application/json:
               schema:
@@ -265,6 +280,7 @@ paths:
 
         `python_version` 用于过滤与该 Python 版本兼容的发行版。
       parameters:
+        - $ref: '#/components/parameters/AcceptLanguage'
         - name: package_name
           in: path
           required: true
@@ -308,6 +324,9 @@ paths:
           $ref: '#/components/responses/Unauthorized'
         '500':
           description: PyPI 源不可达或返回异常
+          headers:
+            Content-Language:
+              $ref: '#/components/headers/ContentLanguage'
           content:
             application/json:
               schema:
@@ -321,10 +340,11 @@ paths:
       operationId: getFunctionTemplate
       description: |
         返回可直接填空的入口函数骨架，说明 `event` 怎么进、返回值怎么出。
-        模板文案随请求语言本地化（`X-Language` 头）。
+        模板文案随请求语言本地化（`Accept-Language` 头）。
 
         目前只支持 `python`。
       parameters:
+        - $ref: '#/components/parameters/AcceptLanguage'
         - name: template_type
           in: path
           required: true
@@ -376,6 +396,9 @@ paths:
                           return result
         '400':
           description: 不支持的模板类型
+          headers:
+            Content-Language:
+              $ref: '#/components/headers/ContentLanguage'
           content:
             application/json:
               schema:
@@ -404,6 +427,7 @@ paths:
 
         用的是系统默认大模型，不在本接口指定模型名。
       parameters:
+        - $ref: '#/components/parameters/AcceptLanguage'
         - name: type
           in: path
           required: true
@@ -456,6 +480,9 @@ paths:
           description: |
             参数错误。常见：`type=python_function_generator` 缺 `query`，
             或 `type=metadata_param_generator` 缺 `code`
+          headers:
+            Content-Language:
+              $ref: '#/components/headers/ContentLanguage'
           content:
             application/json:
               schema:
@@ -468,6 +495,9 @@ paths:
 
             注意：模型侧的鉴权失败**不会**表现为 403——mf-model-api 与模型厂商
             之间的 401/403/404 一律收敛成 502，避免被误读成调用方凭据失效。
+          headers:
+            Content-Language:
+              $ref: '#/components/headers/ContentLanguage'
           content:
             application/json:
               schema:
@@ -477,6 +507,8 @@ paths:
             大模型上游限流。响应体为 OpenAI 形态，`error.type` 为
             `rate_limit_exceeded`；带 `Retry-After` 头时按其退避重试。
           headers:
+            Content-Language:
+              $ref: '#/components/headers/ContentLanguage'
             Retry-After:
               description: 建议的重试等待秒数。
               schema:
@@ -487,6 +519,9 @@ paths:
                 $ref: '../_shared/errors.yaml#/components/schemas/ErrorOpenAI'
         '500':
           description: 算子服务自身内部错误（大模型调用失败见 429 / 502 / 503）
+          headers:
+            Content-Language:
+              $ref: '#/components/headers/ContentLanguage'
           content:
             application/json:
               schema:
@@ -497,6 +532,9 @@ paths:
             `error.type` 为 `api_connection_error` / `authentication_error` /
             `permission_error` / `not_found_error`。属运维侧问题（供应商 key、
             模型地址），与调用方凭据无关。
+          headers:
+            Content-Language:
+              $ref: '#/components/headers/ContentLanguage'
           content:
             application/json:
               schema:
@@ -505,6 +543,9 @@ paths:
           description: |
             大模型上游暂时不可用（供应商繁忙、5xx）。响应体为 OpenAI 形态，
             `error.type` 为 `service_unavailable_error`，稍后重试即可。
+          headers:
+            Content-Language:
+              $ref: '#/components/headers/ContentLanguage'
           content:
             application/json:
               schema:
@@ -520,6 +561,7 @@ paths:
         返回 `/ai_generate/function/{type}` 内部使用的提示词模板（system prompt 与
         user prompt 模板）。用于排查生成效果不佳的原因，或在外部复现同一套生成逻辑。
       parameters:
+        - $ref: '#/components/parameters/AcceptLanguage'
         - name: type
           in: path
           required: true
@@ -538,6 +580,9 @@ paths:
                 $ref: '#/components/schemas/PromptTemplate'
         '400':
           description: 不支持的模板类型
+          headers:
+            Content-Language:
+              $ref: '#/components/headers/ContentLanguage'
           content:
             application/json:
               schema:
@@ -546,6 +591,9 @@ paths:
           $ref: '#/components/responses/Unauthorized'
         '403':
           description: 当前账户没有算子的 create 权限
+          headers:
+            Content-Language:
+              $ref: '#/components/headers/ContentLanguage'
           content:
             application/json:
               schema:
@@ -561,22 +609,50 @@ components:
   responses:
     BadRequest:
       description: 参数错误
+      headers:
+        Content-Language:
+          $ref: '#/components/headers/ContentLanguage'
       content:
         application/json:
           schema:
             $ref: '../_shared/errors.yaml#/components/schemas/ErrorCompact'
     Unauthorized:
       description: 凭据缺失或无效
+      headers:
+        Content-Language:
+          $ref: '#/components/headers/ContentLanguage'
       content:
         application/json:
           schema:
             $ref: '../_shared/errors.yaml#/components/schemas/ErrorCompact'
     InternalError:
       description: 服务内部错误，或沙箱不可用
+      headers:
+        Content-Language:
+          $ref: '#/components/headers/ContentLanguage'
       content:
         application/json:
           schema:
             $ref: '../_shared/errors.yaml#/components/schemas/ErrorCompact'
+
+  parameters:
+    AcceptLanguage:
+      name: Accept-Language
+      in: header
+      required: false
+      schema:
+        type: string
+      description: 可选的 RFC 9110 语言偏好。服务从支持的 `zh-CN`、`en-US` 中选择响应错误文本语言。
+
+  headers:
+    ContentLanguage:
+      description: 仅当响应包含本地化人类可读文本时返回，值为实际使用的语言。
+      schema:
+        type: string
+    VaryAcceptLanguage:
+      description: 仅当可缓存表示随请求语言变化时返回，值包含 `Accept-Language`。
+      schema:
+        type: string
 
   schemas:
     FunctionExecuteRequest:


### PR DESCRIPTION
## What Changed

Brief description of changes:

- [x] Migrated BKN Backend, Ontology Query, Vega, Context Loader, and Execution Factory to the `comm-go` locale pseudo-version merged by #850.
- [x] Added request locale middleware, authenticated cache policy, normalized service-to-service locale propagation, and localized response metadata where required.
- [x] Updated OpenAPI locale headers and added focused regression coverage for HTTP errors, streaming proxy behavior, lifecycle/Safe/CapabilitiesLab clients, and localized category responses.

---

## Why

- Related Issue: Follow-up to #845 (closed by the shared-library PR #850)
- Related Feature: HTTP P0 internationalization protocol
- Background: #850 delivered the shared `comm-go` contract. This PR migrates its five real consumers and verifies that built services resolve the remote pseudo-version rather than a workspace override.

---

## How

- Key implementation points:
  - Resolve `Accept-Language` once per request and preserve the effective locale in context.
  - Apply `Cache-Control: private, no-cache` to authenticated business routes.
  - Always send the normalized single effective locale to internal downstream services.
  - Preserve strict upstream cache directives for streaming proxy responses.
  - Emit `Content-Language` only for localized errors and explicitly localized cacheable category responses.
- Breaking changes (API, config, database, etc.): Removes remaining runtime and OpenAPI references to `X-Language`; supported request locale input is `Accept-Language`.

---

## Testing

- [x] Unit tests passed locally
- [x] Integration tests passed locally
- [ ] Verified in test environment (requires deployment by the environment Owner)

Test notes:

- All validation ran with `GOWORK=off`.
- Verified all five modules resolve `github.com/openbkn-ai/bkn-foundry/comm-go v0.1.1-0.20260813155806-b731c9765f03` from the module cache.
- Ran focused package suites for BKN Backend, Ontology Query, Vega, Context Loader, and Execution Factory.
- `npx @redocly/cli lint --config .redocly.yaml docs/api/context-loader/skill.yaml docs/api/execution-factory/function.yaml` passed with six pre-existing example warnings.

---

## Risk & Rollback

- Potential risks: Locale and cache response headers change on authenticated and localized endpoints; older callers still sending only `X-Language` use service defaults.
- Rollback plan: Revert this consumer commit; services return to their prior `comm-go` pseudo-version and routing behavior.

---

## Additional Notes

- The shared-library change was reviewed and merged in #850.
- Production deployment and the coordinated release window remain Owner-operated tasks.