### PR TITLE
feat(observability): add audited management sources

### DIFF
--- a/adp/execution-factory/operator-integration/server/common/operationaudit/store.go
+++ b/adp/execution-factory/operator-integration/server/common/operationaudit/store.go
@@ -12,7 +12,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/openbkn-ai/bkn-comm-go/db/sqlx"
+	"github.com/openbkn-ai/bkn-foundry/comm-go/db/sqlx"
 )
 
 const tableName = "t_execution_factory_operation_audit"

--- a/adp/execution-factory/operator-integration/server/common/operationaudit/store.go
+++ b/adp/execution-factory/operator-integration/server/common/operationaudit/store.go
@@ -1,0 +1,167 @@
+// Package operationaudit persists the bounded management facts emitted by
+// Execution Factory. Runtime calls are intentionally not represented here.
+package operationaudit
+
+import (
+	"context"
+	"crypto/sha256"
+	"database/sql"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/openbkn-ai/bkn-comm-go/db/sqlx"
+)
+
+const tableName = "t_execution_factory_operation_audit"
+
+type Entry struct {
+	EventID          string    `json:"event_id"`
+	EventTime        time.Time `json:"event_time"`
+	RecordedAt       time.Time `json:"recorded_at"`
+	TenantID         string    `json:"tenant_id"`
+	BusinessDomainID string    `json:"business_domain_id"`
+	ActorID          string    `json:"actor_id"`
+	ActorName        string    `json:"actor_name"`
+	ActorType        string    `json:"actor_type"`
+	AuthMethod       string    `json:"auth_method"`
+	RequestID        string    `json:"request_id"`
+	SourceChannel    string    `json:"source_channel"`
+	Method           string    `json:"method"`
+	Action           string    `json:"action"`
+	TargetType       string    `json:"target_type"`
+	TargetID         string    `json:"target_id"`
+	TargetName       string    `json:"target_name"`
+	Outcome          string    `json:"outcome"`
+	FailureCode      string    `json:"failure_code"`
+	FailureMessage   string    `json:"failure_message"`
+}
+
+type Store struct{ db *sqlx.DB }
+
+func NewStore(db *sqlx.DB) *Store { return &Store{db: db} }
+
+func EventID(tenantID, requestID, method, path string) string {
+	sum := sha256.Sum256([]byte(strings.Join([]string{tenantID, requestID, strings.ToUpper(method), path}, "\n")))
+	return "evt_" + hex.EncodeToString(sum[:])
+}
+
+func (s *Store) Record(ctx context.Context, entry Entry) error {
+	if s == nil || s.db == nil {
+		return errors.New("operation audit store is not configured")
+	}
+	if err := validate(entry); err != nil {
+		return err
+	}
+	_, err := s.db.ExecContext(ctx, "INSERT INTO "+tableName+" (event_id,event_time,recorded_at,tenant_id,business_domain_id,actor_id,actor_name,actor_type,auth_method,request_id,source_channel,method,action,target_type,target_id,target_name,outcome,failure_code,failure_message) VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?) ON DUPLICATE KEY UPDATE event_id=VALUES(event_id)",
+		entry.EventID, entry.EventTime, entry.RecordedAt, entry.TenantID, entry.BusinessDomainID, entry.ActorID, entry.ActorName, entry.ActorType, entry.AuthMethod, entry.RequestID, entry.SourceChannel, entry.Method, entry.Action, entry.TargetType, entry.TargetID, entry.TargetName, entry.Outcome, entry.FailureCode, entry.FailureMessage)
+	if err != nil {
+		return fmt.Errorf("record execution factory operation audit: %w", err)
+	}
+	return nil
+}
+
+type Filter struct {
+	TenantID, BusinessDomain string
+	From, To, BeforeTime     time.Time
+	BeforeEventID            string
+	Limit                    int
+	ActorID, Action          string
+	TargetType, TargetID     string
+	Outcome                  string
+}
+type Page struct {
+	Entries []Entry
+	HasMore bool
+}
+
+func (s *Store) List(ctx context.Context, filter Filter) (Page, error) {
+	if s == nil || s.db == nil {
+		return Page{}, errors.New("operation audit store is not configured")
+	}
+	if filter.TenantID == "" || filter.BusinessDomain == "" || filter.From.IsZero() || filter.To.IsZero() || !filter.From.Before(filter.To) {
+		return Page{}, errors.New("scope and valid time range are required")
+	}
+	limit := filter.Limit
+	if limit <= 0 {
+		limit = 50
+	}
+	if limit > 500 {
+		limit = 500
+	}
+	query := "SELECT event_id,event_time,recorded_at,tenant_id,business_domain_id,actor_id,actor_name,actor_type,auth_method,request_id,source_channel,method,action,target_type,target_id,target_name,outcome,failure_code,failure_message FROM " + tableName + " WHERE tenant_id=? AND business_domain_id=? AND event_time>=? AND event_time<?"
+	args := []any{filter.TenantID, filter.BusinessDomain, filter.From, filter.To}
+	for _, condition := range []struct{ column, value string }{
+		{"actor_id", filter.ActorID}, {"action", filter.Action}, {"target_type", filter.TargetType}, {"target_id", filter.TargetID}, {"outcome", filter.Outcome},
+	} {
+		if strings.TrimSpace(condition.value) != "" {
+			query += " AND " + condition.column + "=?"
+			args = append(args, strings.TrimSpace(condition.value))
+		}
+	}
+	if !filter.BeforeTime.IsZero() {
+		if filter.BeforeEventID == "" {
+			return Page{}, errors.New("cursor event id is required")
+		}
+		query += " AND (event_time < ? OR (event_time = ? AND event_id > ?))"
+		args = append(args, filter.BeforeTime, filter.BeforeTime, filter.BeforeEventID)
+	}
+	query += " ORDER BY event_time DESC,event_id ASC LIMIT ?"
+	args = append(args, limit+1)
+	rows, err := s.db.QueryContext(ctx, query, args...)
+	if err != nil {
+		return Page{}, fmt.Errorf("list execution factory operation audit: %w", err)
+	}
+	defer rows.Close()
+	page := Page{Entries: make([]Entry, 0, limit+1)}
+	for rows.Next() {
+		var item Entry
+		if err := rows.Scan(&item.EventID, &item.EventTime, &item.RecordedAt, &item.TenantID, &item.BusinessDomainID, &item.ActorID, &item.ActorName, &item.ActorType, &item.AuthMethod, &item.RequestID, &item.SourceChannel, &item.Method, &item.Action, &item.TargetType, &item.TargetID, &item.TargetName, &item.Outcome, &item.FailureCode, &item.FailureMessage); err != nil {
+			return Page{}, err
+		}
+		page.Entries = append(page.Entries, item)
+	}
+	if err := rows.Err(); err != nil {
+		return Page{}, err
+	}
+	if len(page.Entries) > limit {
+		page.HasMore = true
+		page.Entries = page.Entries[:limit]
+	}
+	return page, nil
+}
+
+func (s *Store) Get(ctx context.Context, eventID, tenantID, businessDomain string) (Entry, bool, error) {
+	if s == nil || s.db == nil {
+		return Entry{}, false, errors.New("operation audit store is not configured")
+	}
+	var item Entry
+	err := s.db.QueryRowContext(ctx, "SELECT event_id,event_time,recorded_at,tenant_id,business_domain_id,actor_id,actor_name,actor_type,auth_method,request_id,source_channel,method,action,target_type,target_id,target_name,outcome,failure_code,failure_message FROM "+tableName+" WHERE event_id=? AND tenant_id=? AND business_domain_id=?", eventID, tenantID, businessDomain).Scan(&item.EventID, &item.EventTime, &item.RecordedAt, &item.TenantID, &item.BusinessDomainID, &item.ActorID, &item.ActorName, &item.ActorType, &item.AuthMethod, &item.RequestID, &item.SourceChannel, &item.Method, &item.Action, &item.TargetType, &item.TargetID, &item.TargetName, &item.Outcome, &item.FailureCode, &item.FailureMessage)
+	if errors.Is(err, sql.ErrNoRows) {
+		return Entry{}, false, nil
+	}
+	if err != nil {
+		return Entry{}, false, err
+	}
+	return item, true, nil
+}
+
+func validate(entry Entry) error {
+	for _, field := range []struct{ name, value string }{{"event id", entry.EventID}, {"tenant", entry.TenantID}, {"business domain", entry.BusinessDomainID}, {"actor", entry.ActorID}, {"actor name", entry.ActorName}, {"request id", entry.RequestID}, {"action", entry.Action}, {"target type", entry.TargetType}, {"target id", entry.TargetID}, {"outcome", entry.Outcome}} {
+		if strings.TrimSpace(field.value) == "" {
+			return fmt.Errorf("%s is required", field.name)
+		}
+	}
+	if entry.EventTime.IsZero() || entry.RecordedAt.IsZero() {
+		return errors.New("event and recorded time are required")
+	}
+	if entry.Outcome != "success" && entry.Outcome != "failure" && entry.Outcome != "denied" {
+		return errors.New("outcome is invalid")
+	}
+	if len(entry.TargetID) > 1024 || len(entry.TargetName) > 1024 || len(entry.FailureMessage) > 512 {
+		return errors.New("operation audit fact exceeds bounded field size")
+	}
+	return nil
+}

--- a/adp/execution-factory/operator-integration/server/driveradapters/operation_audit.go
+++ b/adp/execution-factory/operator-integration/server/driveradapters/operation_audit.go
@@ -82,11 +82,23 @@ func captureExecutionAuditRequest(request *http.Request) map[string]any {
 	if request == nil || request.Body == nil {
 		return nil
 	}
+	// A declared oversized body is not audit input. Leave it untouched for the
+	// business handler instead of consuming any of its stream.
+	if request.ContentLength > maximumExecutionAuditRequestBody {
+		return nil
+	}
 	body, err := io.ReadAll(io.LimitReader(request.Body, maximumExecutionAuditRequestBody+1))
+	remaining := request.Body
+	// For chunked requests the size is not known up front. Reassemble the
+	// consumed prefix and unread suffix before returning, including on the
+	// oversized path, so audit collection cannot change handler semantics.
+	request.Body = struct {
+		io.Reader
+		io.Closer
+	}{Reader: io.MultiReader(bytes.NewReader(body), remaining), Closer: remaining}
 	if err != nil || len(body) > maximumExecutionAuditRequestBody {
 		return nil
 	}
-	request.Body = io.NopCloser(bytes.NewReader(body))
 	var value map[string]any
 	if json.Unmarshal(body, &value) != nil {
 		return nil

--- a/adp/execution-factory/operator-integration/server/driveradapters/operation_audit.go
+++ b/adp/execution-factory/operator-integration/server/driveradapters/operation_audit.go
@@ -1,0 +1,169 @@
+package driveradapters
+
+import (
+	"bytes"
+	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/openbkn-ai/bkn-foundry/adp/execution-factory/operator-integration/server/common/operationaudit"
+	"github.com/openbkn-ai/bkn-foundry/adp/execution-factory/operator-integration/server/drivenadapters"
+	infra "github.com/openbkn-ai/bkn-foundry/adp/execution-factory/operator-integration/server/infra/common"
+	"github.com/openbkn-ai/bkn-foundry/adp/execution-factory/operator-integration/server/interfaces"
+)
+
+const executionAuditRoutePrefix = "/api/agent-operator-integration/v1"
+const maximumExecutionAuditRequestBody = 64 << 10
+
+// OperationAudit records one minimal user-management fact only after the
+// request finished. It does not persist request bodies, tool inputs or output.
+func OperationAudit(recorder interface {
+	Record(context.Context, operationaudit.Entry) error
+}) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		path := strings.TrimPrefix(c.FullPath(), executionAuditRoutePrefix)
+		rule, ok := registeredOperationAudit(c.Request.Method, path)
+		if !ok {
+			c.Next()
+			return
+		}
+		body := captureExecutionAuditRequest(c.Request)
+		c.Next()
+		if recorder == nil {
+			return
+		}
+		auth, ok := infra.GetAccountAuthContextFromCtx(c.Request.Context())
+		if !ok || auth == nil || strings.TrimSpace(auth.AccountID) == "" {
+			return
+		}
+		requestID := strings.TrimSpace(c.GetHeader(infra.HeaderBKNRequestID))
+		if requestID == "" {
+			requestID = executionAuditGeneratedRequestID()
+			c.Request.Header.Set(infra.HeaderBKNRequestID, requestID)
+			c.Header(infra.HeaderBKNRequestID, requestID)
+		}
+		tenantID := strings.TrimSpace(c.GetHeader("x-tenant-id"))
+		businessDomainID := strings.TrimSpace(c.GetHeader(string(interfaces.HeaderXBusinessDomain)))
+		if tenantID == "" || businessDomainID == "" {
+			return
+		}
+		actorName := executionAuditActorName(c.Request.Context(), auth)
+		targetID, targetName := executionAuditTarget(c, rule.TargetType, body, requestID)
+		outcome, failureCode, failureMessage := executionAuditOutcome(c.Writer.Status())
+		now := time.Now().UTC()
+		entry := operationaudit.Entry{
+			EventID: operationaudit.EventID(tenantID, requestID, c.Request.Method, c.FullPath()), EventTime: now, RecordedAt: now,
+			TenantID: tenantID, BusinessDomainID: businessDomainID,
+			ActorID: auth.AccountID, ActorName: actorName, ActorType: executionAuditActorType(auth), AuthMethod: executionAuditAuthMethod(c.GetHeader("Authorization")),
+			RequestID: requestID, SourceChannel: "api", Method: c.Request.Method, Action: rule.Action,
+			TargetType: rule.TargetType, TargetID: targetID, TargetName: targetName, Outcome: outcome, FailureCode: failureCode, FailureMessage: failureMessage,
+		}
+		if err := recorder.Record(c.Request.Context(), entry); err != nil { /* management result is never rolled back for audit failure */
+		}
+	}
+}
+
+func executionAuditGeneratedRequestID() string {
+	bytes := make([]byte, 16)
+	if _, err := rand.Read(bytes); err == nil {
+		return "req_" + hex.EncodeToString(bytes)
+	}
+	return fmt.Sprintf("req_%d", time.Now().UTC().UnixNano())
+}
+
+func captureExecutionAuditRequest(request *http.Request) map[string]any {
+	if request == nil || request.Body == nil {
+		return nil
+	}
+	body, err := io.ReadAll(io.LimitReader(request.Body, maximumExecutionAuditRequestBody+1))
+	if err != nil || len(body) > maximumExecutionAuditRequestBody {
+		return nil
+	}
+	request.Body = io.NopCloser(bytes.NewReader(body))
+	var value map[string]any
+	if json.Unmarshal(body, &value) != nil {
+		return nil
+	}
+	return value
+}
+
+func executionAuditActorName(ctx context.Context, auth *interfaces.AccountAuthContext) string {
+	if auth != nil && auth.TokenInfo != nil && strings.TrimSpace(auth.TokenInfo.VisitorName) != "" {
+		return strings.TrimSpace(auth.TokenInfo.VisitorName)
+	}
+	if auth != nil && strings.TrimSpace(auth.AccountID) != "" {
+		if user, err := drivenadapters.NewUserManagementClient().GetUserInfo(ctx, auth.AccountID, interfaces.DisplayName); err == nil && user != nil && strings.TrimSpace(user.DisplayName) != "" {
+			return strings.TrimSpace(user.DisplayName)
+		}
+		return auth.AccountID
+	}
+	return "unknown"
+}
+
+func executionAuditActorType(auth *interfaces.AccountAuthContext) string {
+	if auth != nil && auth.AccountType == interfaces.AccessorTypeApp {
+		return "app"
+	}
+	return "user"
+}
+
+func executionAuditAuthMethod(authorization string) string {
+	if strings.HasPrefix(strings.TrimSpace(strings.TrimPrefix(authorization, "Bearer ")), interfaces.AppKeyPrefix) {
+		return "api_key"
+	}
+	return "oauth"
+}
+
+func executionAuditTarget(c *gin.Context, targetType string, request map[string]any, requestID string) (string, string) {
+	targetID := firstExecutionAuditNonEmpty(c.Param("operator_id"), c.Param("box_id"), c.Param("tool_id"), c.Param("mcp_id"), c.Param("skill_id"))
+	if targetID == "" && request != nil {
+		for _, key := range []string{"operator_id", "op_id", "box_id", "tool_id", "mcp_id", "skill_id", "id"} {
+			if value, ok := request[key].(string); ok && strings.TrimSpace(value) != "" {
+				targetID = strings.TrimSpace(value)
+				break
+			}
+		}
+	}
+	if targetID == "" {
+		targetID = targetType + ":" + requestID
+	}
+	name := ""
+	if request != nil {
+		for _, key := range []string{"name", "display_name", "operator_name", "tool_name", "skill_name"} {
+			if value, ok := request[key].(string); ok && strings.TrimSpace(value) != "" {
+				name = strings.TrimSpace(value)
+				break
+			}
+		}
+	}
+	if name == "" {
+		name = targetID
+	}
+	return targetID, name
+}
+
+func executionAuditOutcome(status int) (string, string, string) {
+	if status >= http.StatusOK && status < http.StatusBadRequest {
+		return "success", "", ""
+	}
+	if status == http.StatusUnauthorized || status == http.StatusForbidden {
+		return "denied", fmt.Sprintf("http_%d", status), "request denied"
+	}
+	return "failure", fmt.Sprintf("http_%d", status), "management request failed"
+}
+
+func firstExecutionAuditNonEmpty(values ...string) string {
+	for _, value := range values {
+		if strings.TrimSpace(value) != "" {
+			return strings.TrimSpace(value)
+		}
+	}
+	return ""
+}

--- a/adp/execution-factory/operator-integration/server/driveradapters/operation_audit_query.go
+++ b/adp/execution-factory/operator-integration/server/driveradapters/operation_audit_query.go
@@ -1,0 +1,107 @@
+package driveradapters
+
+import (
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/openbkn-ai/bkn-foundry/adp/execution-factory/operator-integration/server/common/operationaudit"
+	"github.com/openbkn-ai/bkn-foundry/adp/execution-factory/operator-integration/server/drivenadapters"
+	infra "github.com/openbkn-ai/bkn-foundry/adp/execution-factory/operator-integration/server/infra/common"
+	"github.com/openbkn-ai/bkn-foundry/adp/execution-factory/operator-integration/server/interfaces"
+)
+
+const maximumExecutionAuditRange = 30 * 24 * time.Hour
+
+func (r *restPublicHandler) ListOperationAudits(c *gin.Context) {
+	if !executionAuditReader(c) {
+		return
+	}
+	from, to, ok := executionAuditRange(c)
+	if !ok {
+		return
+	}
+	filter := operationaudit.Filter{TenantID: strings.TrimSpace(c.GetHeader("x-tenant-id")), BusinessDomain: strings.TrimSpace(c.GetHeader(string(interfaces.HeaderXBusinessDomain))), From: from, To: to}
+	filter.ActorID = strings.TrimSpace(c.Query("actor_id"))
+	filter.Action = strings.TrimSpace(c.Query("action"))
+	filter.TargetType = strings.TrimSpace(c.Query("target_type"))
+	filter.TargetID = strings.TrimSpace(c.Query("target_id"))
+	filter.Outcome = strings.TrimSpace(c.Query("outcome"))
+	if filter.TenantID == "" || filter.BusinessDomain == "" {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "x-tenant-id and x-business-domain are required"})
+		return
+	}
+	if value, err := strconv.Atoi(c.Query("limit")); err == nil {
+		filter.Limit = value
+	}
+	if value := strings.TrimSpace(c.Query("before_time")); value != "" {
+		parsed, err := time.Parse(time.RFC3339Nano, value)
+		if err != nil {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "before_time must be RFC3339"})
+			return
+		}
+		filter.BeforeTime = parsed.UTC()
+		filter.BeforeEventID = strings.TrimSpace(c.Query("before_event_id"))
+	}
+	page, err := r.auditStore.List(c.Request.Context(), filter)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "operation audit query failed"})
+		return
+	}
+	c.JSON(http.StatusOK, gin.H{"entries": page.Entries, "has_more": page.HasMore})
+}
+
+func (r *restPublicHandler) GetOperationAudit(c *gin.Context) {
+	if !executionAuditReader(c) {
+		return
+	}
+	tenantID, businessDomain := strings.TrimSpace(c.GetHeader("x-tenant-id")), strings.TrimSpace(c.GetHeader(string(interfaces.HeaderXBusinessDomain)))
+	if tenantID == "" || businessDomain == "" {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "x-tenant-id and x-business-domain are required"})
+		return
+	}
+	entry, found, err := r.auditStore.Get(c.Request.Context(), strings.TrimSpace(c.Param("event_id")), tenantID, businessDomain)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "operation audit query failed"})
+		return
+	}
+	if !found {
+		c.JSON(http.StatusNotFound, gin.H{"error": "operation audit event not found"})
+		return
+	}
+	c.JSON(http.StatusOK, entry)
+}
+
+func executionAuditRange(c *gin.Context) (time.Time, time.Time, bool) {
+	from, fromErr := time.Parse(time.RFC3339Nano, strings.TrimSpace(c.Query("from")))
+	to, toErr := time.Parse(time.RFC3339Nano, strings.TrimSpace(c.Query("to")))
+	if fromErr != nil || toErr != nil || !from.Before(to) || to.Sub(from) > maximumExecutionAuditRange {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "from/to must be a valid RFC3339 range of at most 30 days"})
+		return time.Time{}, time.Time{}, false
+	}
+	return from.UTC(), to.UTC(), true
+}
+
+// The first release intentionally limits cross-user audit queries to the
+// platform audit roles. Object-level audit permissions are not introduced.
+func executionAuditReader(c *gin.Context) bool {
+	auth, ok := infra.GetAccountAuthContextFromCtx(c.Request.Context())
+	if !ok || auth == nil || auth.AccountID == "" {
+		c.JSON(http.StatusUnauthorized, gin.H{"error": "authentication required"})
+		return false
+	}
+	user, err := drivenadapters.NewUserManagementClient().GetUserInfo(c.Request.Context(), auth.AccountID, "roles")
+	if err != nil || user == nil {
+		c.JSON(http.StatusForbidden, gin.H{"error": "operation audit access denied"})
+		return false
+	}
+	for _, role := range user.Roles {
+		if role == "super_admin" || role == "admin" || role == "audit" {
+			return true
+		}
+	}
+	c.JSON(http.StatusForbidden, gin.H{"error": "operation audit access denied"})
+	return false
+}

--- a/adp/execution-factory/operator-integration/server/driveradapters/operation_audit_registry.go
+++ b/adp/execution-factory/operator-integration/server/driveradapters/operation_audit_registry.go
@@ -1,0 +1,44 @@
+package driveradapters
+
+import "net/http"
+
+type operationAuditRule struct{ Action, TargetType string }
+
+// registeredOperationAudit is the deliberately small management allowlist.
+// Execute, proxy, debug, parsing and index-running endpoints remain Trace facts.
+func registeredOperationAudit(method, path string) (operationAuditRule, bool) {
+	for _, item := range []struct {
+		method, path string
+		rule         operationAuditRule
+	}{
+		{http.MethodPost, "/operator/register", operationAuditRule{"create", "agent"}},
+		{http.MethodDelete, "/operator/delete", operationAuditRule{"delete", "agent"}},
+		{http.MethodPost, "/operator/status", operationAuditRule{"status_change", "agent"}},
+		{http.MethodPost, "/operator/info", operationAuditRule{"update", "agent"}},
+		{http.MethodPost, "/operator/info/update", operationAuditRule{"update", "agent"}},
+		{http.MethodPost, "/tool-box", operationAuditRule{"create", "toolbox"}},
+		{http.MethodPost, "/tool-box/:box_id", operationAuditRule{"update", "toolbox"}},
+		{http.MethodDelete, "/tool-box/:box_id", operationAuditRule{"delete", "toolbox"}},
+		{http.MethodPost, "/tool-box/:box_id/status", operationAuditRule{"status_change", "toolbox"}},
+		{http.MethodPost, "/tool-box/:box_id/tool", operationAuditRule{"create", "tool"}},
+		{http.MethodPost, "/tool-box/:box_id/tool/:tool_id", operationAuditRule{"update", "tool"}},
+		{http.MethodPost, "/tool-box/:box_id/tools/batch-delete", operationAuditRule{"delete", "tool"}},
+		{http.MethodPost, "/tool-box/:box_id/tools/status", operationAuditRule{"status_change", "tool"}},
+		{http.MethodPost, "/mcp/", operationAuditRule{"create", "mcp"}},
+		{http.MethodPut, "/mcp/:mcp_id", operationAuditRule{"update", "mcp"}},
+		{http.MethodDelete, "/mcp/:mcp_id", operationAuditRule{"delete", "mcp"}},
+		{http.MethodPost, "/mcp/:mcp_id/status", operationAuditRule{"status_change", "mcp"}},
+		{http.MethodPost, "/skills", operationAuditRule{"create", "skill"}},
+		{http.MethodDelete, "/skills/:skill_id", operationAuditRule{"delete", "skill"}},
+		{http.MethodPut, "/skills/:skill_id/status", operationAuditRule{"status_change", "skill"}},
+		{http.MethodPut, "/skills/:skill_id/metadata", operationAuditRule{"update", "skill"}},
+		{http.MethodPut, "/skills/:skill_id/package", operationAuditRule{"update", "skill"}},
+		{http.MethodPost, "/skills/:skill_id/history/republish", operationAuditRule{"publish", "skill"}},
+		{http.MethodPost, "/skills/:skill_id/history/publish", operationAuditRule{"publish", "skill"}},
+	} {
+		if method == item.method && path == item.path {
+			return item.rule, true
+		}
+	}
+	return operationAuditRule{}, false
+}

--- a/adp/execution-factory/operator-integration/server/driveradapters/operation_audit_registry_test.go
+++ b/adp/execution-factory/operator-integration/server/driveradapters/operation_audit_registry_test.go
@@ -1,0 +1,20 @@
+package driveradapters
+
+import (
+	"net/http"
+	"testing"
+)
+
+func TestRegisteredOperationAuditExcludesRuntimeEndpoints(t *testing.T) {
+	for _, endpoint := range []string{"/operator/debug", "/operator/proxy/:operator_id", "/tool-box/:box_id/proxy/:tool_id", "/mcp/:mcp_id/tool/:tool_name/debug", "/skills/:skill_id/execute", "/skills/index/build"} {
+		if _, ok := registeredOperationAudit(http.MethodPost, endpoint); ok {
+			t.Fatalf("runtime endpoint %s must remain trace-only", endpoint)
+		}
+	}
+}
+
+func TestRegisteredOperationAuditCoversSkillLifecycle(t *testing.T) {
+	if rule, ok := registeredOperationAudit(http.MethodPut, "/skills/:skill_id/status"); !ok || rule.TargetType != "skill" || rule.Action != "status_change" {
+		t.Fatalf("skill status audit rule = %+v, %v", rule, ok)
+	}
+}

--- a/adp/execution-factory/operator-integration/server/driveradapters/operation_audit_test.go
+++ b/adp/execution-factory/operator-integration/server/driveradapters/operation_audit_test.go
@@ -1,0 +1,48 @@
+package driveradapters
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/openbkn-ai/bkn-foundry/adp/execution-factory/operator-integration/server/common/operationaudit"
+	infra "github.com/openbkn-ai/bkn-foundry/adp/execution-factory/operator-integration/server/infra/common"
+	"github.com/openbkn-ai/bkn-foundry/adp/execution-factory/operator-integration/server/interfaces"
+)
+
+type capturedExecutionAuditRecorder struct{ entries []operationaudit.Entry }
+
+func (recorder *capturedExecutionAuditRecorder) Record(_ context.Context, entry operationaudit.Entry) error {
+	recorder.entries = append(recorder.entries, entry)
+	return nil
+}
+
+func TestOperationAuditGeneratesRequestIDWhenTheCallerDoesNotSendOne(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	recorder := &capturedExecutionAuditRecorder{}
+	engine := gin.New()
+	engine.Use(func(c *gin.Context) {
+		c.Request = c.Request.WithContext(infra.SetAccountAuthContextToCtx(c.Request.Context(), &interfaces.AccountAuthContext{
+			AccountID: "user-1", AccountType: interfaces.AccessorTypeUser,
+			TokenInfo: &interfaces.TokenInfo{VisitorName: "管理员"},
+		}))
+		c.Next()
+	})
+	engine.Use(OperationAudit(recorder))
+	engine.POST("/operator/register", func(c *gin.Context) { c.Status(http.StatusCreated) })
+
+	request := httptest.NewRequest(http.MethodPost, "/operator/register", nil)
+	request.Header.Set("x-tenant-id", "tenant-a")
+	request.Header.Set(string(interfaces.HeaderXBusinessDomain), "domain-a")
+	response := httptest.NewRecorder()
+	engine.ServeHTTP(response, request)
+
+	if len(recorder.entries) != 1 {
+		t.Fatalf("entries = %d, want 1", len(recorder.entries))
+	}
+	if recorder.entries[0].RequestID == "" || response.Header().Get(infra.HeaderBKNRequestID) == "" {
+		t.Fatalf("request id must be generated and returned: %+v", recorder.entries[0])
+	}
+}

--- a/adp/execution-factory/operator-integration/server/driveradapters/operation_audit_test.go
+++ b/adp/execution-factory/operator-integration/server/driveradapters/operation_audit_test.go
@@ -2,8 +2,10 @@ package driveradapters
 
 import (
 	"context"
+	"io"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/gin-gonic/gin"
@@ -11,6 +13,23 @@ import (
 	infra "github.com/openbkn-ai/bkn-foundry/adp/execution-factory/operator-integration/server/infra/common"
 	"github.com/openbkn-ai/bkn-foundry/adp/execution-factory/operator-integration/server/interfaces"
 )
+
+func TestCaptureExecutionAuditRequestRestoresOversizedBody(t *testing.T) {
+	body := strings.Repeat("x", maximumExecutionAuditRequestBody+1)
+	request := httptest.NewRequest(http.MethodPost, "/operator/register", strings.NewReader(body))
+	request.ContentLength = -1 // chunked body: the middleware must restore its consumed prefix.
+
+	if captured := captureExecutionAuditRequest(request); captured != nil {
+		t.Fatalf("captured oversized body = %#v, want nil", captured)
+	}
+	restored, err := io.ReadAll(request.Body)
+	if err != nil {
+		t.Fatalf("read restored request body: %v", err)
+	}
+	if string(restored) != body {
+		t.Fatalf("request body was not restored: got %d bytes, want %d", len(restored), len(body))
+	}
+}
 
 type capturedExecutionAuditRecorder struct{ entries []operationaudit.Entry }
 

--- a/adp/execution-factory/operator-integration/server/driveradapters/rest_public_handler.go
+++ b/adp/execution-factory/operator-integration/server/driveradapters/rest_public_handler.go
@@ -5,10 +5,12 @@ package driveradapters
 
 import (
 	"github.com/gin-gonic/gin"
+	"github.com/openbkn-ai/bkn-foundry/adp/execution-factory/operator-integration/server/common/operationaudit"
 	"github.com/openbkn-ai/bkn-foundry/adp/execution-factory/operator-integration/server/drivenadapters"
 	"github.com/openbkn-ai/bkn-foundry/adp/execution-factory/operator-integration/server/driveradapters/common"
 	sandboxdriver "github.com/openbkn-ai/bkn-foundry/adp/execution-factory/operator-integration/server/driveradapters/sandbox"
 	"github.com/openbkn-ai/bkn-foundry/adp/execution-factory/operator-integration/server/infra/config"
+	"github.com/openbkn-ai/bkn-foundry/adp/execution-factory/operator-integration/server/infra/db"
 	"github.com/openbkn-ai/bkn-foundry/adp/execution-factory/operator-integration/server/interfaces"
 	"github.com/openbkn-ai/bkn-foundry/adp/execution-factory/operator-integration/server/logics/business_domain"
 	sharedrest "github.com/openbkn-ai/bkn-foundry/comm-go/rest"
@@ -28,6 +30,7 @@ type restPublicHandler struct {
 	AIGenerationHandler   common.AIGenerationHandler
 	Logger                interfaces.Logger
 	businessDomainService interfaces.IBusinessDomainService
+	auditStore            *operationaudit.Store
 }
 
 // NewRestPublicHandler 创建restHandler实例
@@ -46,13 +49,22 @@ func NewRestPublicHandler() interfaces.HTTPRouterInterface {
 		AIGenerationHandler:   common.NewAIGenerationHandler(),
 		Logger:                config.NewConfigLoader().GetLogger(),
 		businessDomainService: business_domain.NewBusinessDomainService(),
+		auditStore:            operationaudit.NewStore(db.NewDBPool()),
 	}
 }
 
 // RegisterPublic 注册公共路由
 func (r *restPublicHandler) RegisterRouter(engine *gin.RouterGroup) {
 	mws := []gin.HandlerFunc{}
-	mws = append(mws, middlewareRequestLog(r.Logger), middlewareTrace, middlewareTraceContext, sharedrest.LanguageMiddleware(), sharedrest.PrivateNoCacheMiddleware(), middlewareIntrospectVerify(r.Hydra, r.AppKeys))
+	mws = append(mws,
+		middlewareRequestLog(r.Logger),
+		middlewareTrace,
+		middlewareTraceContext,
+		sharedrest.LanguageMiddleware(),
+		sharedrest.PrivateNoCacheMiddleware(),
+		middlewareIntrospectVerify(r.Hydra, r.AppKeys),
+		OperationAudit(r.auditStore),
+	)
 	engine.Use(mws...)
 	// 算子注册相关接口
 	r.OperatorRestHandler.RegisterPublic(engine)
@@ -62,6 +74,8 @@ func (r *restPublicHandler) RegisterRouter(engine *gin.RouterGroup) {
 	r.MCPRestHandler.RegisterPublic(engine)
 	// Skill 相关接口
 	r.SkillRestHandler.RegisterPublic(engine)
+	engine.GET("/operation-audits", r.ListOperationAudits)
+	engine.GET("/operation-audits/:event_id", r.GetOperationAudit)
 	// 沙箱运行时只读观测接口（超管可见，见 #326）
 	r.SandboxHandler.RegisterPublic(engine)
 	// 导入导出

--- a/adp/vega/vega-backend/server/common/operationaudit/store.go
+++ b/adp/vega/vega-backend/server/common/operationaudit/store.go
@@ -17,7 +17,7 @@ import (
 	"sync"
 	"time"
 
-	libdb "github.com/openbkn-ai/bkn-comm-go/db"
+	libdb "github.com/openbkn-ai/bkn-foundry/comm-go/db"
 
 	"vega-backend/common"
 )

--- a/adp/vega/vega-backend/server/common/operationaudit/store.go
+++ b/adp/vega/vega-backend/server/common/operationaudit/store.go
@@ -1,0 +1,196 @@
+// Copyright openbkn.ai
+// Copyright The kweaver.ai Authors.
+//
+// Licensed under the Apache License, Version 2.0.
+
+// Package operationaudit persists bounded data-resource management facts.
+package operationaudit
+
+import (
+	"context"
+	"crypto/sha256"
+	"database/sql"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"strings"
+	"sync"
+	"time"
+
+	libdb "github.com/openbkn-ai/bkn-comm-go/db"
+
+	"vega-backend/common"
+)
+
+const tableName = "t_vega_operation_audit"
+
+var (
+	storeOnce sync.Once
+	store     *Store
+)
+
+type Entry struct {
+	EventID          string
+	EventTime        time.Time
+	RecordedAt       time.Time
+	TenantID         string
+	BusinessDomainID string
+	ActorID          string
+	ActorName        string
+	ActorType        string
+	AuthMethod       string
+	RequestID        string
+	SourceChannel    string
+	Method           string
+	Action           string
+	TargetType       string
+	TargetID         string
+	TargetName       string
+	Outcome          string
+	FailureCode      string
+	FailureMessage   string
+}
+
+type Filter struct {
+	From, To       time.Time
+	BeforeTime     time.Time
+	BeforeEventID  string
+	TenantID       string
+	BusinessDomain string
+	Limit          int
+	ActorID        string
+	Action         string
+	TargetType     string
+	TargetID       string
+	Outcome        string
+}
+
+type Page struct {
+	Entries []Entry
+	HasMore bool
+}
+
+type Store struct{ db *sql.DB }
+
+func NewStore(appSetting *common.AppSetting) *Store {
+	storeOnce.Do(func() { store = &Store{db: libdb.NewDB(&appSetting.DBSetting)} })
+	return store
+}
+
+func EventID(tenantID, requestID, method, path string) string {
+	sum := sha256.Sum256([]byte(strings.Join([]string{tenantID, requestID, strings.ToUpper(method), path}, "\n")))
+	return "evt_" + hex.EncodeToString(sum[:])
+}
+
+func (s *Store) Record(ctx context.Context, entry Entry) error {
+	if s == nil || s.db == nil {
+		return errors.New("operation audit store is not configured")
+	}
+	if err := validate(entry); err != nil {
+		return err
+	}
+	_, err := s.db.ExecContext(ctx, "INSERT INTO "+tableName+" (event_id,event_time,recorded_at,tenant_id,business_domain_id,actor_id,actor_name,actor_type,auth_method,request_id,source_channel,method,action,target_type,target_id,target_name,outcome,failure_code,failure_message) VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?) ON DUPLICATE KEY UPDATE event_id=VALUES(event_id)",
+		entry.EventID, entry.EventTime, entry.RecordedAt, entry.TenantID, entry.BusinessDomainID,
+		entry.ActorID, entry.ActorName, entry.ActorType, entry.AuthMethod, entry.RequestID,
+		entry.SourceChannel, entry.Method, entry.Action, entry.TargetType, entry.TargetID,
+		entry.TargetName, entry.Outcome, entry.FailureCode, entry.FailureMessage,
+	)
+	if err != nil {
+		return fmt.Errorf("record operation audit: %w", err)
+	}
+	return nil
+}
+
+func (s *Store) List(ctx context.Context, filter Filter) (Page, error) {
+	if s == nil || s.db == nil {
+		return Page{}, errors.New("operation audit store is not configured")
+	}
+	if filter.TenantID == "" || filter.BusinessDomain == "" || filter.From.IsZero() || filter.To.IsZero() || !filter.From.Before(filter.To) {
+		return Page{}, errors.New("tenant, business domain and a valid time range are required")
+	}
+	limit := filter.Limit
+	if limit <= 0 {
+		limit = 50
+	}
+	if limit > 500 {
+		limit = 500
+	}
+	query := "SELECT event_id,event_time,recorded_at,tenant_id,business_domain_id,actor_id,actor_name,actor_type,auth_method,request_id,source_channel,method,action,target_type,target_id,target_name,outcome,failure_code,failure_message FROM " + tableName + " WHERE tenant_id=? AND business_domain_id=? AND event_time>=? AND event_time<?"
+	args := []any{filter.TenantID, filter.BusinessDomain, filter.From, filter.To}
+	for _, condition := range []struct{ column, value string }{
+		{"actor_id", filter.ActorID}, {"action", filter.Action}, {"target_type", filter.TargetType}, {"target_id", filter.TargetID}, {"outcome", filter.Outcome},
+	} {
+		if strings.TrimSpace(condition.value) != "" {
+			query += " AND " + condition.column + "=?"
+			args = append(args, strings.TrimSpace(condition.value))
+		}
+	}
+	if !filter.BeforeTime.IsZero() {
+		if filter.BeforeEventID == "" {
+			return Page{}, errors.New("cursor event id is required")
+		}
+		query += " AND (event_time < ? OR (event_time = ? AND event_id > ?))"
+		args = append(args, filter.BeforeTime, filter.BeforeTime, filter.BeforeEventID)
+	}
+	query += " ORDER BY event_time DESC,event_id ASC LIMIT ?"
+	args = append(args, limit+1)
+	rows, err := s.db.QueryContext(ctx, query, args...)
+	if err != nil {
+		return Page{}, fmt.Errorf("list operation audit: %w", err)
+	}
+	defer rows.Close()
+	entries := make([]Entry, 0, limit+1)
+	for rows.Next() {
+		var entry Entry
+		if err := rows.Scan(&entry.EventID, &entry.EventTime, &entry.RecordedAt, &entry.TenantID, &entry.BusinessDomainID, &entry.ActorID, &entry.ActorName, &entry.ActorType, &entry.AuthMethod, &entry.RequestID, &entry.SourceChannel, &entry.Method, &entry.Action, &entry.TargetType, &entry.TargetID, &entry.TargetName, &entry.Outcome, &entry.FailureCode, &entry.FailureMessage); err != nil {
+			return Page{}, err
+		}
+		entries = append(entries, entry)
+	}
+	if err := rows.Err(); err != nil {
+		return Page{}, err
+	}
+	page := Page{Entries: entries}
+	if len(page.Entries) > limit {
+		page.HasMore = true
+		page.Entries = page.Entries[:limit]
+	}
+	return page, nil
+}
+
+func (s *Store) Get(ctx context.Context, eventID, tenantID, businessDomain string) (Entry, bool, error) {
+	if s == nil || s.db == nil {
+		return Entry{}, false, errors.New("operation audit store is not configured")
+	}
+	if strings.TrimSpace(eventID) == "" || strings.TrimSpace(tenantID) == "" || strings.TrimSpace(businessDomain) == "" {
+		return Entry{}, false, errors.New("event id, tenant and business domain are required")
+	}
+	row := s.db.QueryRowContext(ctx, "SELECT event_id,event_time,recorded_at,tenant_id,business_domain_id,actor_id,actor_name,actor_type,auth_method,request_id,source_channel,method,action,target_type,target_id,target_name,outcome,failure_code,failure_message FROM "+tableName+" WHERE event_id=? AND tenant_id=? AND business_domain_id=?", eventID, tenantID, businessDomain)
+	var entry Entry
+	err := row.Scan(&entry.EventID, &entry.EventTime, &entry.RecordedAt, &entry.TenantID, &entry.BusinessDomainID, &entry.ActorID, &entry.ActorName, &entry.ActorType, &entry.AuthMethod, &entry.RequestID, &entry.SourceChannel, &entry.Method, &entry.Action, &entry.TargetType, &entry.TargetID, &entry.TargetName, &entry.Outcome, &entry.FailureCode, &entry.FailureMessage)
+	if errors.Is(err, sql.ErrNoRows) {
+		return Entry{}, false, nil
+	}
+	if err != nil {
+		return Entry{}, false, fmt.Errorf("get operation audit: %w", err)
+	}
+	return entry, true, nil
+}
+
+func validate(entry Entry) error {
+	for _, value := range []struct{ name, value string }{{"event id", entry.EventID}, {"tenant", entry.TenantID}, {"business domain", entry.BusinessDomainID}, {"actor id", entry.ActorID}, {"actor name", entry.ActorName}, {"request id", entry.RequestID}, {"action", entry.Action}, {"target type", entry.TargetType}, {"target id", entry.TargetID}, {"outcome", entry.Outcome}} {
+		if strings.TrimSpace(value.value) == "" {
+			return fmt.Errorf("%s is required", value.name)
+		}
+	}
+	if entry.EventTime.IsZero() || entry.RecordedAt.IsZero() {
+		return errors.New("event and recorded time are required")
+	}
+	if entry.Outcome != "success" && entry.Outcome != "failure" && entry.Outcome != "denied" {
+		return errors.New("outcome is invalid")
+	}
+	if len(entry.FailureMessage) > 512 || len(entry.TargetID) > 1024 || len(entry.TargetName) > 1024 {
+		return errors.New("operation audit fact exceeds bounded field size")
+	}
+	return nil
+}

--- a/adp/vega/vega-backend/server/common/operationaudit/store_test.go
+++ b/adp/vega/vega-backend/server/common/operationaudit/store_test.go
@@ -1,0 +1,46 @@
+// Copyright openbkn.ai
+// Copyright The kweaver.ai Authors.
+//
+// Licensed under the Apache License, Version 2.0.
+
+package operationaudit
+
+import (
+	"context"
+	"regexp"
+	"testing"
+	"time"
+
+	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestStoreRecordUsesStableEventIDForIdempotency(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer db.Close()
+	store := &Store{db: db}
+	now := time.Date(2026, 8, 13, 9, 0, 0, 0, time.UTC)
+	entry := Entry{EventID: EventID("tenant-a", "req-a", "POST", "/catalogs"), EventTime: now, RecordedAt: now, TenantID: "tenant-a", BusinessDomainID: "domain-a", ActorID: "user-a", ActorName: "管理员", ActorType: "user", AuthMethod: "oauth", RequestID: "req-a", SourceChannel: "api", Method: "POST", Action: "create", TargetType: "catalog", TargetID: "catalog:req-a", TargetName: "供应链数据源", Outcome: "success"}
+	mock.ExpectExec(regexp.QuoteMeta("INSERT INTO "+tableName)).WithArgs(
+		entry.EventID, entry.EventTime, entry.RecordedAt, entry.TenantID, entry.BusinessDomainID,
+		entry.ActorID, entry.ActorName, entry.ActorType, entry.AuthMethod, entry.RequestID,
+		entry.SourceChannel, entry.Method, entry.Action, entry.TargetType, entry.TargetID, entry.TargetName,
+		entry.Outcome, entry.FailureCode, entry.FailureMessage,
+	).WillReturnResult(sqlmock.NewResult(1, 1))
+	require.NoError(t, store.Record(context.Background(), entry))
+	assert.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestStoreRecordRejectsUnboundedFailureMessage(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer db.Close()
+	store := &Store{db: db}
+	entry := Entry{EventID: "evt-a", EventTime: time.Now(), RecordedAt: time.Now(), TenantID: "tenant-a", BusinessDomainID: "domain-a", ActorID: "user-a", ActorName: "管理员", RequestID: "req-a", Action: "create", TargetType: "catalog", TargetID: "catalog-a", Outcome: "failure", FailureMessage: string(make([]byte, 513))}
+	err = store.Record(context.Background(), entry)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "bounded field size")
+	assert.NoError(t, mock.ExpectationsWereMet())
+}

--- a/adp/vega/vega-backend/server/driveradapters/operation_audit.go
+++ b/adp/vega/vega-backend/server/driveradapters/operation_audit.go
@@ -17,8 +17,8 @@ import (
 	"time"
 
 	"github.com/gin-gonic/gin"
-	"github.com/openbkn-ai/bkn-comm-go/hydra"
-	"github.com/openbkn-ai/bkn-comm-go/logger"
+	"github.com/openbkn-ai/bkn-foundry/comm-go/hydra"
+	"github.com/openbkn-ai/bkn-foundry/comm-go/logger"
 	"github.com/rs/xid"
 
 	"vega-backend/common"

--- a/adp/vega/vega-backend/server/driveradapters/operation_audit.go
+++ b/adp/vega/vega-backend/server/driveradapters/operation_audit.go
@@ -1,0 +1,207 @@
+// Copyright openbkn.ai
+// Copyright The kweaver.ai Authors.
+//
+// Licensed under the Apache License, Version 2.0.
+
+package driveradapters
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/openbkn-ai/bkn-comm-go/hydra"
+	"github.com/openbkn-ai/bkn-comm-go/logger"
+	"github.com/rs/xid"
+
+	"vega-backend/common"
+	"vega-backend/common/operationaudit"
+	"vega-backend/interfaces"
+)
+
+const operationAuditVisitorKey = "vega.operation_audit.visitor"
+const operationAuditRequestKey = "vega.operation_audit.request_id"
+const maximumOperationAuditRequestBody = 64 << 10
+
+type operationAuditRecorder interface {
+	Record(context.Context, operationaudit.Entry) error
+}
+
+// OperationAudit persists one minimal management fact after a registered request.
+// It deliberately excludes raw request bodies, connector settings and result data.
+func (r *restHandler) OperationAudit() gin.HandlerFunc {
+	return func(c *gin.Context) {
+		rule, ok := registeredOperationAudit(c.Request.Method, c.FullPath(), c.GetHeader(interfaces.HTTP_HEADER_METHOD_OVERRIDE))
+		if !ok {
+			c.Next()
+			return
+		}
+		request := captureOperationAuditRequest(c.Request)
+		c.Next()
+		if r == nil || r.auditRecorder == nil {
+			return
+		}
+
+		visitor, _ := c.Get(operationAuditVisitorKey)
+		actor, ok := visitor.(hydra.Visitor)
+		if !ok || strings.TrimSpace(actor.ID) == "" {
+			logger.Errorf("operation audit fact rejected: action=%s target_type=%s missing verified actor", rule.Action, rule.TargetType)
+			return
+		}
+		tenantID := strings.TrimSpace(c.GetHeader("x-tenant-id"))
+		businessDomainID := strings.TrimSpace(c.GetHeader(interfaces.HTTP_HEADER_BUSINESS_DOMAIN))
+		requestID := operationAuditRequestID(c)
+		if tenantID == "" || businessDomainID == "" {
+			logger.Errorf("operation audit fact rejected: request_id=%s action=%s missing tenant or business domain", requestID, rule.Action)
+			return
+		}
+		actorName := operationAuditActorName(c.Request.Context(), c.GetHeader("Authorization"), actor.ID)
+		if actorName == "" {
+			actorName = actor.ID
+		}
+		now := time.Now().UTC()
+		targetID, targetName := operationAuditTarget(c, rule.TargetType, request, requestID)
+		outcome, failureCode, failureMessage := operationAuditOutcome(c)
+		entry := operationaudit.Entry{
+			EventID: operationaudit.EventID(tenantID, requestID, c.Request.Method, c.FullPath()), EventTime: now, RecordedAt: now,
+			TenantID: tenantID, BusinessDomainID: businessDomainID,
+			ActorID: actor.ID, ActorName: actorName, ActorType: firstNonEmpty(string(actor.Type), "user"), AuthMethod: operationAuditAuthMethod(c.GetHeader("Authorization")),
+			RequestID: requestID, SourceChannel: operationAuditSourceChannel(c.FullPath()), Method: c.Request.Method,
+			Action: rule.Action, TargetType: rule.TargetType, TargetID: targetID, TargetName: targetName,
+			Outcome: outcome, FailureCode: failureCode, FailureMessage: failureMessage,
+		}
+		if err := r.auditRecorder.Record(c.Request.Context(), entry); err != nil {
+			logger.Errorf("operation audit persistence failed: request_id=%s action=%s target_type=%s error=%v", requestID, rule.Action, rule.TargetType, err)
+		}
+	}
+}
+
+func captureOperationAuditRequest(request *http.Request) map[string]any {
+	if request == nil || request.Body == nil {
+		return nil
+	}
+	body, err := io.ReadAll(io.LimitReader(request.Body, maximumOperationAuditRequestBody+1))
+	if err != nil || len(body) > maximumOperationAuditRequestBody {
+		return nil
+	}
+	request.Body = io.NopCloser(bytes.NewReader(body))
+	var value map[string]any
+	if json.Unmarshal(body, &value) != nil {
+		return nil
+	}
+	return value
+}
+
+func operationAuditTarget(c *gin.Context, targetType string, request map[string]any, requestID string) (string, string) {
+	targetID := strings.TrimSpace(firstNonEmpty(c.Param("id"), c.Param("ids")))
+	if targetID == "" {
+		targetID = targetType + ":" + requestID
+	}
+	name := ""
+	if request != nil {
+		for _, key := range []string{"name", "display_name", "catalog_name", "resource_name"} {
+			if value, ok := request[key].(string); ok && strings.TrimSpace(value) != "" {
+				name = strings.TrimSpace(value)
+				break
+			}
+		}
+	}
+	if name == "" {
+		name = targetID
+	}
+	return targetID, name
+}
+
+func operationAuditOutcome(c *gin.Context) (string, string, string) {
+	status := c.Writer.Status()
+	if status >= http.StatusOK && status < http.StatusBadRequest {
+		return "success", "", ""
+	}
+	if status == http.StatusUnauthorized || status == http.StatusForbidden {
+		return "denied", fmt.Sprintf("http_%d", status), "request denied"
+	}
+	return "failure", fmt.Sprintf("http_%d", status), "management request failed"
+}
+
+func operationAuditRequestID(c *gin.Context) string {
+	if value, exists := c.Get(operationAuditRequestKey); exists {
+		if requestID, ok := value.(string); ok && requestID != "" {
+			return requestID
+		}
+	}
+	if traceContext, ok := common.GetTraceContextFromCtx(c.Request.Context()); ok && strings.TrimSpace(traceContext.RequestID) != "" {
+		return rememberOperationAuditRequestID(c, strings.TrimSpace(traceContext.RequestID))
+	}
+	if value := strings.TrimSpace(c.GetHeader(common.HeaderBKNRequestID)); value != "" {
+		return rememberOperationAuditRequestID(c, value)
+	}
+	return rememberOperationAuditRequestID(c, "req_"+xid.New().String())
+}
+
+func rememberOperationAuditRequestID(c *gin.Context, requestID string) string {
+	c.Request.Header.Set(common.HeaderBKNRequestID, requestID)
+	c.Header(common.HeaderBKNRequestID, requestID)
+	c.Set(operationAuditRequestKey, requestID)
+	return requestID
+}
+
+func operationAuditSourceChannel(path string) string {
+	if strings.Contains(path, "/in/") {
+		return "internal_api"
+	}
+	return "api"
+}
+
+func operationAuditAuthMethod(authorization string) string {
+	if strings.Contains(strings.ToLower(authorization), "bak_") {
+		return "api_key"
+	}
+	if strings.TrimSpace(authorization) != "" {
+		return "oauth"
+	}
+	return "unknown"
+}
+
+func operationAuditActorName(ctx context.Context, authorization, expectedActorID string) string {
+	baseURL := strings.TrimRight(strings.TrimSpace(os.Getenv("BKN_SAFE_URL")), "/")
+	if baseURL == "" || strings.TrimSpace(authorization) == "" {
+		return ""
+	}
+	request, err := http.NewRequestWithContext(ctx, http.MethodGet, baseURL+"/api/safe/v1/me", nil)
+	if err != nil {
+		return ""
+	}
+	request.Header.Set("Authorization", authorization)
+	response, err := (&http.Client{Timeout: 3 * time.Second}).Do(request)
+	if err != nil {
+		return ""
+	}
+	defer response.Body.Close()
+	if response.StatusCode != http.StatusOK {
+		return ""
+	}
+	var me struct {
+		ID, Account, Name string
+		Enabled           bool
+	}
+	if json.NewDecoder(io.LimitReader(response.Body, 1<<20)).Decode(&me) != nil || !me.Enabled || me.ID != expectedActorID {
+		return ""
+	}
+	return firstNonEmpty(strings.TrimSpace(me.Name), strings.TrimSpace(me.Account))
+}
+
+func firstNonEmpty(values ...string) string {
+	for _, value := range values {
+		if strings.TrimSpace(value) != "" {
+			return strings.TrimSpace(value)
+		}
+	}
+	return ""
+}

--- a/adp/vega/vega-backend/server/driveradapters/operation_audit.go
+++ b/adp/vega/vega-backend/server/driveradapters/operation_audit.go
@@ -87,11 +87,23 @@ func captureOperationAuditRequest(request *http.Request) map[string]any {
 	if request == nil || request.Body == nil {
 		return nil
 	}
+	// A declared oversized body is not audit input. Leave it untouched for the
+	// business handler instead of consuming any of its stream.
+	if request.ContentLength > maximumOperationAuditRequestBody {
+		return nil
+	}
 	body, err := io.ReadAll(io.LimitReader(request.Body, maximumOperationAuditRequestBody+1))
+	remaining := request.Body
+	// For chunked requests the size is not known up front. Reassemble the
+	// consumed prefix and unread suffix before returning, including on the
+	// oversized path, so audit collection cannot change handler semantics.
+	request.Body = struct {
+		io.Reader
+		io.Closer
+	}{Reader: io.MultiReader(bytes.NewReader(body), remaining), Closer: remaining}
 	if err != nil || len(body) > maximumOperationAuditRequestBody {
 		return nil
 	}
-	request.Body = io.NopCloser(bytes.NewReader(body))
 	var value map[string]any
 	if json.Unmarshal(body, &value) != nil {
 		return nil

--- a/adp/vega/vega-backend/server/driveradapters/operation_audit_query.go
+++ b/adp/vega/vega-backend/server/driveradapters/operation_audit_query.go
@@ -1,0 +1,194 @@
+// Copyright openbkn.ai
+// Copyright The kweaver.ai Authors.
+//
+// Licensed under the Apache License, Version 2.0.
+
+package driveradapters
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"os"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/openbkn-ai/bkn-comm-go/rest"
+
+	"vega-backend/common/operationaudit"
+	"vega-backend/interfaces"
+)
+
+const maximumOperationAuditRange = 30 * 24 * time.Hour
+
+type operationAuditQueryStore interface {
+	List(ctx context.Context, filter operationaudit.Filter) (operationaudit.Page, error)
+	Get(ctx context.Context, eventID, tenantID, businessDomain string) (operationaudit.Entry, bool, error)
+}
+
+func (r *restHandler) ListOperationAudits(c *gin.Context) {
+	if !r.requireOperationAuditReader(c) {
+		return
+	}
+	from, to, ok := operationAuditRange(c)
+	if !ok {
+		return
+	}
+	if r.auditQueryStore == nil {
+		c.JSON(http.StatusServiceUnavailable, gin.H{"error": "operation audit source is unavailable"})
+		return
+	}
+	filter := operationaudit.Filter{TenantID: strings.TrimSpace(c.GetHeader("x-tenant-id")), BusinessDomain: strings.TrimSpace(c.GetHeader(interfaces.HTTP_HEADER_BUSINESS_DOMAIN)), From: from, To: to}
+	filter.ActorID = strings.TrimSpace(c.Query("actor_id"))
+	filter.Action = strings.TrimSpace(c.Query("action"))
+	filter.TargetType = strings.TrimSpace(c.Query("target_type"))
+	filter.TargetID = strings.TrimSpace(c.Query("target_id"))
+	filter.Outcome = strings.TrimSpace(c.Query("outcome"))
+	if filter.TenantID == "" || filter.BusinessDomain == "" {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "x-tenant-id and x-business-domain are required"})
+		return
+	}
+	if limit, err := strconv.Atoi(strings.TrimSpace(c.Query("limit"))); err == nil {
+		filter.Limit = limit
+	}
+	if before := strings.TrimSpace(c.Query("before_time")); before != "" {
+		parsed, err := time.Parse(time.RFC3339Nano, before)
+		if err != nil {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "before_time must be RFC3339"})
+			return
+		}
+		filter.BeforeTime, filter.BeforeEventID = parsed.UTC(), strings.TrimSpace(c.Query("before_event_id"))
+	}
+	page, err := r.auditQueryStore.List(c.Request.Context(), filter)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "operation audit query failed"})
+		return
+	}
+	response := gin.H{"entries": operationAuditResponses(page.Entries), "has_more": page.HasMore}
+	if page.HasMore && len(page.Entries) > 0 {
+		last := page.Entries[len(page.Entries)-1]
+		response["next_before_time"] = last.EventTime.UTC().Format(time.RFC3339Nano)
+		response["next_before_event_id"] = last.EventID
+	}
+	c.JSON(http.StatusOK, response)
+}
+
+func (r *restHandler) GetOperationAudit(c *gin.Context) {
+	if !r.requireOperationAuditReader(c) {
+		return
+	}
+	if r.auditQueryStore == nil {
+		c.JSON(http.StatusServiceUnavailable, gin.H{"error": "operation audit source is unavailable"})
+		return
+	}
+	tenantID, businessDomain := strings.TrimSpace(c.GetHeader("x-tenant-id")), strings.TrimSpace(c.GetHeader(interfaces.HTTP_HEADER_BUSINESS_DOMAIN))
+	if tenantID == "" || businessDomain == "" {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "x-tenant-id and x-business-domain are required"})
+		return
+	}
+	entry, found, err := r.auditQueryStore.Get(c.Request.Context(), strings.TrimSpace(c.Param("event_id")), tenantID, businessDomain)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "operation audit query failed"})
+		return
+	}
+	if !found {
+		c.JSON(http.StatusNotFound, gin.H{"error": "operation audit event not found"})
+		return
+	}
+	c.JSON(http.StatusOK, operationAuditResponse(entry))
+}
+
+func operationAuditRange(c *gin.Context) (time.Time, time.Time, bool) {
+	from, fromErr := time.Parse(time.RFC3339Nano, strings.TrimSpace(c.Query("from")))
+	to, toErr := time.Parse(time.RFC3339Nano, strings.TrimSpace(c.Query("to")))
+	if fromErr != nil || toErr != nil || !from.Before(to) || to.Sub(from) > maximumOperationAuditRange {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "from/to must be a valid RFC3339 range of at most 30 days"})
+		return time.Time{}, time.Time{}, false
+	}
+	return from.UTC(), to.UTC(), true
+}
+
+func (r *restHandler) requireOperationAuditReader(c *gin.Context) bool {
+	visitor, err := r.verifyOAuth(rest.GetLanguageCtx(c), c)
+	if err != nil {
+		return false
+	}
+	if !operationAuditReader(c.Request.Context(), c.GetHeader("Authorization"), visitor.ID) {
+		c.JSON(http.StatusForbidden, gin.H{"error": "operation audit access denied"})
+		return false
+	}
+	return true
+}
+
+func operationAuditReader(ctx context.Context, authorization, expectedActorID string) bool {
+	baseURL := strings.TrimRight(strings.TrimSpace(os.Getenv("BKN_SAFE_URL")), "/")
+	if baseURL == "" || strings.TrimSpace(authorization) == "" || strings.TrimSpace(expectedActorID) == "" {
+		return false
+	}
+	request, err := http.NewRequestWithContext(ctx, http.MethodGet, baseURL+"/api/safe/v1/me", nil)
+	if err != nil {
+		return false
+	}
+	request.Header.Set("Authorization", authorization)
+	response, err := (&http.Client{Timeout: 3 * time.Second}).Do(request)
+	if err != nil {
+		return false
+	}
+	defer response.Body.Close()
+	if response.StatusCode != http.StatusOK {
+		return false
+	}
+	var me struct {
+		ID      string
+		Enabled bool
+		Roles   []string
+	}
+	if json.NewDecoder(io.LimitReader(response.Body, 1<<20)).Decode(&me) != nil || !me.Enabled || me.ID != expectedActorID {
+		return false
+	}
+	for _, role := range me.Roles {
+		if role == "super_admin" || role == "admin" || role == "audit" {
+			return true
+		}
+	}
+	return false
+}
+
+type operationAuditResponseDTO struct {
+	EventID          string `json:"event_id"`
+	EventTime        string `json:"event_time"`
+	RecordedAt       string `json:"recorded_at"`
+	TenantID         string `json:"tenant_id"`
+	BusinessDomainID string `json:"business_domain_id"`
+	ActorID          string `json:"actor_id"`
+	ActorName        string `json:"actor_name"`
+	ActorType        string `json:"actor_type"`
+	AuthMethod       string `json:"auth_method"`
+	RequestID        string `json:"request_id"`
+	SourceChannel    string `json:"source_channel"`
+	Method           string `json:"method"`
+	Action           string `json:"action"`
+	TargetType       string `json:"target_type"`
+	TargetID         string `json:"target_id"`
+	TargetName       string `json:"target_name"`
+	Outcome          string `json:"outcome"`
+	FailureCode      string `json:"failure_code,omitempty"`
+	FailureMessage   string `json:"failure_message,omitempty"`
+	SchemaVersion    string `json:"schema_version"`
+}
+
+func operationAuditResponses(entries []operationaudit.Entry) []operationAuditResponseDTO {
+	result := make([]operationAuditResponseDTO, 0, len(entries))
+	for _, entry := range entries {
+		result = append(result, operationAuditResponse(entry))
+	}
+	return result
+}
+func operationAuditResponse(entry operationaudit.Entry) operationAuditResponseDTO {
+	return operationAuditResponseDTO{EventID: entry.EventID, EventTime: entry.EventTime.UTC().Format(time.RFC3339Nano), RecordedAt: entry.RecordedAt.UTC().Format(time.RFC3339Nano), TenantID: entry.TenantID, BusinessDomainID: entry.BusinessDomainID, ActorID: entry.ActorID, ActorName: entry.ActorName, ActorType: entry.ActorType, AuthMethod: entry.AuthMethod, RequestID: entry.RequestID, SourceChannel: entry.SourceChannel, Method: entry.Method, Action: entry.Action, TargetType: entry.TargetType, TargetID: entry.TargetID, TargetName: entry.TargetName, Outcome: entry.Outcome, FailureCode: entry.FailureCode, FailureMessage: entry.FailureMessage, SchemaVersion: "1.0"}
+}
+
+var _ operationAuditQueryStore = (*operationaudit.Store)(nil)

--- a/adp/vega/vega-backend/server/driveradapters/operation_audit_query.go
+++ b/adp/vega/vega-backend/server/driveradapters/operation_audit_query.go
@@ -16,7 +16,7 @@ import (
 	"time"
 
 	"github.com/gin-gonic/gin"
-	"github.com/openbkn-ai/bkn-comm-go/rest"
+	"github.com/openbkn-ai/bkn-foundry/comm-go/rest"
 
 	"vega-backend/common/operationaudit"
 	"vega-backend/interfaces"

--- a/adp/vega/vega-backend/server/driveradapters/operation_audit_registry.go
+++ b/adp/vega/vega-backend/server/driveradapters/operation_audit_registry.go
@@ -1,0 +1,53 @@
+// Copyright openbkn.ai
+// Copyright The kweaver.ai Authors.
+//
+// Licensed under the Apache License, Version 2.0.
+
+package driveradapters
+
+import "strings"
+
+// operationAuditRule describes a management request that is allowed to emit an
+// operation audit fact. Runtime execution endpoints must not be added here.
+type operationAuditRule struct {
+	Action     string
+	TargetType string
+}
+
+var operationAuditRoutes = map[string]operationAuditRule{
+	"POST /catalogs":                          {Action: "create", TargetType: "catalog"},
+	"PUT /catalogs/:id":                       {Action: "update", TargetType: "catalog"},
+	"DELETE /catalogs/:id":                    {Action: "delete", TargetType: "catalog"},
+	"POST /catalogs/:id/enable":               {Action: "enable", TargetType: "catalog"},
+	"POST /catalogs/:id/disable":              {Action: "disable", TargetType: "catalog"},
+	"PUT /catalogs/:id/health-check-schedule": {Action: "update", TargetType: "catalog_health_check_schedule"},
+	"POST /resources":                         {Action: "create", TargetType: "resource"},
+	"PUT /resources/:id":                      {Action: "update", TargetType: "resource"},
+	"DELETE /resources/:id":                   {Action: "delete", TargetType: "resource"},
+	"POST /discover-schedules":                {Action: "create", TargetType: "discover_schedule"},
+	"PUT /discover-schedules/:id":             {Action: "update", TargetType: "discover_schedule"},
+	"DELETE /discover-schedules/:id":          {Action: "delete", TargetType: "discover_schedule"},
+	"POST /discover-schedules/:id/enable":     {Action: "enable", TargetType: "discover_schedule"},
+	"POST /discover-schedules/:id/disable":    {Action: "disable", TargetType: "discover_schedule"},
+	"POST /build-tasks":                       {Action: "create", TargetType: "index_task"},
+	"DELETE /build-tasks/:ids":                {Action: "delete", TargetType: "index_task"},
+	"POST /build-tasks/:id/start":             {Action: "start", TargetType: "index_task"},
+	"POST /build-tasks/:id/stop":              {Action: "stop", TargetType: "index_task"},
+}
+
+func registeredOperationAudit(method, fullPath, methodOverride string) (operationAuditRule, bool) {
+	if strings.EqualFold(strings.TrimSpace(methodOverride), "GET") {
+		return operationAuditRule{}, false
+	}
+	path := strings.TrimSpace(fullPath)
+	for _, prefix := range []string{
+		"/api/vega-backend/v1", "/api/vega-backend/in/v1",
+	} {
+		if strings.HasPrefix(path, prefix) {
+			path = strings.TrimPrefix(path, prefix)
+			break
+		}
+	}
+	rule, ok := operationAuditRoutes[strings.ToUpper(strings.TrimSpace(method))+" "+path]
+	return rule, ok
+}

--- a/adp/vega/vega-backend/server/driveradapters/operation_audit_registry_test.go
+++ b/adp/vega/vega-backend/server/driveradapters/operation_audit_registry_test.go
@@ -1,0 +1,54 @@
+// Copyright openbkn.ai
+// Copyright The kweaver.ai Authors.
+//
+// Licensed under the Apache License, Version 2.0.
+
+package driveradapters
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRegisteredOperationAudit(t *testing.T) {
+	t.Run("includes only data resource management operations", func(t *testing.T) {
+		for _, testCase := range []struct {
+			method string
+			path   string
+			action string
+			target string
+		}{
+			{"POST", "/api/vega-backend/v1/catalogs", "create", "catalog"},
+			{"PUT", "/api/vega-backend/v1/catalogs/:id", "update", "catalog"},
+			{"DELETE", "/api/vega-backend/v1/catalogs/:id", "delete", "catalog"},
+			{"POST", "/api/vega-backend/v1/resources", "create", "resource"},
+			{"PUT", "/api/vega-backend/v1/resources/:id", "update", "resource"},
+			{"DELETE", "/api/vega-backend/v1/resources/:id", "delete", "resource"},
+			{"POST", "/api/vega-backend/v1/discover-schedules", "create", "discover_schedule"},
+			{"POST", "/api/vega-backend/v1/build-tasks", "create", "index_task"},
+			{"POST", "/api/vega-backend/v1/build-tasks/:id/start", "start", "index_task"},
+			{"POST", "/api/vega-backend/v1/build-tasks/:id/stop", "stop", "index_task"},
+		} {
+			rule, ok := registeredOperationAudit(testCase.method, testCase.path, "")
+			assert.True(t, ok, testCase.path)
+			assert.Equal(t, testCase.action, rule.Action, testCase.path)
+			assert.Equal(t, testCase.target, rule.TargetType, testCase.path)
+		}
+	})
+
+	t.Run("excludes runtime execution and data mutation endpoints", func(t *testing.T) {
+		for _, testCase := range []struct {
+			method string
+			path   string
+		}{
+			{"POST", "/api/vega-backend/v1/catalogs/:id/test-connection"},
+			{"POST", "/api/vega-backend/v1/catalogs/:id/discover"},
+			{"POST", "/api/vega-backend/v1/resources/:id/data"},
+			{"POST", "/api/vega-backend/v1/resources/query"},
+		} {
+			_, ok := registeredOperationAudit(testCase.method, testCase.path, "")
+			assert.False(t, ok, testCase.path)
+		}
+	})
+}

--- a/adp/vega/vega-backend/server/driveradapters/operation_audit_test.go
+++ b/adp/vega/vega-backend/server/driveradapters/operation_audit_test.go
@@ -7,6 +7,7 @@ package driveradapters
 
 import (
 	"context"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -20,6 +21,23 @@ import (
 	"vega-backend/common/operationaudit"
 	"vega-backend/interfaces"
 )
+
+func TestCaptureOperationAuditRequestRestoresOversizedBody(t *testing.T) {
+	body := strings.Repeat("x", maximumOperationAuditRequestBody+1)
+	request := httptest.NewRequest(http.MethodPost, "/api/vega-backend/v1/catalogs", strings.NewReader(body))
+	request.ContentLength = -1 // chunked body: the middleware must restore its consumed prefix.
+
+	if captured := captureOperationAuditRequest(request); captured != nil {
+		t.Fatalf("captured oversized body = %#v, want nil", captured)
+	}
+	restored, err := io.ReadAll(request.Body)
+	if err != nil {
+		t.Fatalf("read restored request body: %v", err)
+	}
+	if string(restored) != body {
+		t.Fatalf("request body was not restored: got %d bytes, want %d", len(restored), len(body))
+	}
+}
 
 type capturedOperationAuditRecorder struct{ entries []operationaudit.Entry }
 

--- a/adp/vega/vega-backend/server/driveradapters/operation_audit_test.go
+++ b/adp/vega/vega-backend/server/driveradapters/operation_audit_test.go
@@ -1,0 +1,59 @@
+// Copyright openbkn.ai
+// Copyright The kweaver.ai Authors.
+//
+// Licensed under the Apache License, Version 2.0.
+
+package driveradapters
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/openbkn-ai/bkn-comm-go/hydra"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"vega-backend/common/operationaudit"
+	"vega-backend/interfaces"
+)
+
+type capturedOperationAuditRecorder struct{ entries []operationaudit.Entry }
+
+func (r *capturedOperationAuditRecorder) Record(_ context.Context, entry operationaudit.Entry) error {
+	r.entries = append(r.entries, entry)
+	return nil
+}
+
+func TestOperationAuditRecordsBoundedManagementFact(t *testing.T) {
+	restoreGinMode := setGinMode()
+	defer restoreGinMode()
+	recorder := &capturedOperationAuditRecorder{}
+	handler := &restHandler{auditRecorder: recorder}
+	engine := gin.New()
+	engine.Use(handler.OperationAudit())
+	engine.POST("/api/vega-backend/v1/catalogs", func(c *gin.Context) {
+		c.Set(operationAuditVisitorKey, hydra.Visitor{ID: "user-1", Type: hydra.VisitorType("user")})
+		c.Status(http.StatusCreated)
+	})
+	req := httptest.NewRequest(http.MethodPost, "/api/vega-backend/v1/catalogs", strings.NewReader(`{"name":"供应链数据源","connector_config":{"password":"secret"}}`))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("x-tenant-id", "tenant-a")
+	req.Header.Set(interfaces.HTTP_HEADER_BUSINESS_DOMAIN, "domain-a")
+	req.Header.Set("bkn-request-id", "req-a")
+	w := httptest.NewRecorder()
+	engine.ServeHTTP(w, req)
+	require.Equal(t, http.StatusCreated, w.Code)
+	require.Len(t, recorder.entries, 1)
+	entry := recorder.entries[0]
+	assert.Equal(t, "create", entry.Action)
+	assert.Equal(t, "catalog", entry.TargetType)
+	assert.Equal(t, "供应链数据源", entry.TargetName)
+	assert.Equal(t, "tenant-a", entry.TenantID)
+	assert.Equal(t, "domain-a", entry.BusinessDomainID)
+	assert.Equal(t, "success", entry.Outcome)
+	assert.NotContains(t, entry.TargetName, "secret")
+}

--- a/adp/vega/vega-backend/server/driveradapters/operation_audit_test.go
+++ b/adp/vega/vega-backend/server/driveradapters/operation_audit_test.go
@@ -13,7 +13,7 @@ import (
 	"testing"
 
 	"github.com/gin-gonic/gin"
-	"github.com/openbkn-ai/bkn-comm-go/hydra"
+	"github.com/openbkn-ai/bkn-foundry/comm-go/hydra"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 

--- a/adp/vega/vega-backend/server/driveradapters/router.go
+++ b/adp/vega/vega-backend/server/driveradapters/router.go
@@ -21,6 +21,7 @@ import (
 	"github.com/openbkn-ai/bkn-foundry/comm-go/rest"
 
 	"vega-backend/common"
+	"vega-backend/common/operationaudit"
 	verrors "vega-backend/errors"
 	"vega-backend/interfaces"
 	"vega-backend/logics/auth"
@@ -44,23 +45,26 @@ type RestHandler interface {
 }
 
 type restHandler struct {
-	appSetting *common.AppSetting
-	as         interfaces.AuthService
-	bts        interfaces.BuildTaskService
-	cs         interfaces.CatalogService
-	cts        interfaces.ConnectorTypeService
-	ds         interfaces.DatasetService
-	dss        interfaces.DiscoverScheduleService
-	dts        interfaces.DiscoverTaskService
-	hcss       interfaces.CatalogHealthCheckScheduleService
-	lim        interfaces.LocalIndexManager
-	rds        interfaces.ResourceDataService
-	rs         interfaces.ResourceService
-	suts       interfaces.SemanticUnderstandingTaskService
+	appSetting      *common.AppSetting
+	auditRecorder   operationAuditRecorder
+	auditQueryStore operationAuditQueryStore
+	as              interfaces.AuthService
+	bts             interfaces.BuildTaskService
+	cs              interfaces.CatalogService
+	cts             interfaces.ConnectorTypeService
+	ds              interfaces.DatasetService
+	dss             interfaces.DiscoverScheduleService
+	dts             interfaces.DiscoverTaskService
+	hcss            interfaces.CatalogHealthCheckScheduleService
+	lim             interfaces.LocalIndexManager
+	rds             interfaces.ResourceDataService
+	rs              interfaces.ResourceService
+	suts            interfaces.SemanticUnderstandingTaskService
 }
 
 // NewRestHandler creates a new RestHandler.
 func NewRestHandler(appSetting *common.AppSetting) RestHandler {
+	auditStore := operationaudit.NewStore(appSetting)
 	as := auth.NewAuthService(appSetting)
 	cs := catalog.NewCatalogService(appSetting)
 	cts := connector_type.NewConnectorTypeService(appSetting)
@@ -75,19 +79,21 @@ func NewRestHandler(appSetting *common.AppSetting) RestHandler {
 	suts := semantic_understanding_task.NewSemanticUnderstandingTaskService(appSetting)
 
 	return &restHandler{
-		appSetting: appSetting,
-		as:         as,
-		bts:        bts,
-		cs:         cs,
-		cts:        cts,
-		ds:         ds,
-		dss:        dss,
-		dts:        dts,
-		hcss:       hcss,
-		lim:        lim,
-		rds:        rds,
-		rs:         rs,
-		suts:       suts,
+		appSetting:      appSetting,
+		auditRecorder:   auditStore,
+		auditQueryStore: auditStore,
+		as:              as,
+		bts:             bts,
+		cs:              cs,
+		cts:             cts,
+		ds:              ds,
+		dss:             dss,
+		dts:             dts,
+		hcss:            hcss,
+		lim:             lim,
+		rds:             rds,
+		rs:              rs,
+		suts:            suts,
 	}
 }
 
@@ -97,6 +103,7 @@ func (r *restHandler) RegisterPublic(c *gin.Engine) {
 	c.Use(middleware.TracingMiddleware())
 	c.Use(r.TraceContextMiddleware())
 	c.Use(r.LanguageMiddleware())
+	c.Use(r.OperationAudit())
 
 	c.GET("/health", r.HealthCheck)
 
@@ -104,6 +111,9 @@ func (r *restHandler) RegisterPublic(c *gin.Engine) {
 	apiV1 := c.Group("/api/vega-backend/v1")
 	apiV1.Use(rest.PrivateNoCacheMiddleware())
 	{
+		apiV1.GET("/operation-audits", r.ListOperationAudits)
+		apiV1.GET("/operation-audits/:event_id", r.GetOperationAudit)
+
 		// Catalog APIs - External
 		catalogs := apiV1.Group("/catalogs")
 		{
@@ -353,6 +363,7 @@ func (r *restHandler) verifyOAuth(ctx context.Context, c *gin.Context) (hydra.Vi
 		rest.ReplyError(c, httpErr)
 		return visitor, err
 	}
+	c.Set(operationAuditVisitorKey, visitor)
 
 	return visitor, nil
 }

--- a/bkn-safe/server/app/app.go
+++ b/bkn-safe/server/app/app.go
@@ -33,6 +33,7 @@ import (
 	"gorm.io/gorm"
 
 	"github.com/openbkn-ai/bkn-foundry/bkn-safe/server/config"
+	"github.com/openbkn-ai/bkn-foundry/bkn-safe/server/internal/accesslog"
 	"github.com/openbkn-ai/bkn-foundry/bkn-safe/server/internal/audit"
 	"github.com/openbkn-ai/bkn-foundry/bkn-safe/server/internal/auth"
 	"github.com/openbkn-ai/bkn-foundry/bkn-safe/server/internal/authz"
@@ -112,6 +113,7 @@ func Boot(opts Options) (*App, error) {
 	provider := auth.NewProvider(authenticator, hydraAdmin, userStore)
 	dir := directory.New(db)
 	auditStore := audit.New(db)
+	accessLogStore := accesslog.New(db)
 
 	// Cluster license hub: hold the one .lic, be the only egress to the
 	// license-server, distribute to modules.
@@ -150,6 +152,7 @@ func Boot(opts Options) (*App, error) {
 			Directory: dir,
 			Users:     userStore,
 			Audit:     auditStore,
+			AccessLog: accessLogStore,
 			License:   licSvc,
 		},
 	}, nil

--- a/bkn-safe/server/internal/accesslog/accesslog.go
+++ b/bkn-safe/server/internal/accesslog/accesslog.go
@@ -88,7 +88,9 @@ func (s *Store) List(ctx context.Context, filter Filter) ([]model.AccessLog, int
 	if err := q.Count(&total).Error; err != nil {
 		return nil, 0, err
 	}
-	logs := make([]model.AccessLog, 0, limit)
+	// Do not preallocate from a request-derived page size. GORM grows the result
+	// slice only for rows returned by the bounded SQL query.
+	var logs []model.AccessLog
 	if err := q.Order("created_at DESC").Order("id ASC").Offset(max(filter.Offset, 0)).Limit(limit).Find(&logs).Error; err != nil {
 		return nil, 0, err
 	}

--- a/bkn-safe/server/internal/accesslog/accesslog.go
+++ b/bkn-safe/server/internal/accesslog/accesslog.go
@@ -1,0 +1,121 @@
+// Copyright openbkn.ai
+//
+// Licensed under the OpenBKN License. See LICENSE-OPENBKN.txt in the project root.
+
+// Package accesslog persists the minimal user access facts emitted at the
+// authentication boundary. It intentionally does not depend on HTTP or Hydra.
+package accesslog
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"time"
+
+	"gorm.io/gorm"
+
+	"github.com/openbkn-ai/bkn-foundry/bkn-safe/server/internal/model"
+)
+
+type Store struct{ db *gorm.DB }
+
+func New(db *gorm.DB) *Store { return &Store{db: db} }
+
+type Entry struct {
+	ActorID           string
+	ActorNameSnapshot string
+	AuthMethod        string
+	SourceChannel     string
+	Action            string
+	Outcome           string
+	FailureCode       string
+	RequestID         string
+	ClientIP          string
+}
+
+// Record persists one independently identifiable access fact. Callers must
+// treat any returned error as non-fatal to the authentication flow.
+func (s *Store) Record(ctx context.Context, entry Entry) error {
+	return s.db.WithContext(ctx).Create(&model.AccessLog{
+		ID:                NewID(),
+		ActorID:           entry.ActorID,
+		ActorNameSnapshot: entry.ActorNameSnapshot,
+		AuthMethod:        entry.AuthMethod,
+		SourceChannel:     entry.SourceChannel,
+		Action:            entry.Action,
+		Outcome:           entry.Outcome,
+		FailureCode:       entry.FailureCode,
+		RequestID:         entry.RequestID,
+		ClientIP:          entry.ClientIP,
+	}).Error
+}
+
+type Filter struct {
+	ActorID string
+	Action  string
+	Outcome string
+	From    time.Time
+	To      time.Time
+	Offset  int
+	Limit   int
+}
+
+func (s *Store) List(ctx context.Context, filter Filter) ([]model.AccessLog, int64, error) {
+	limit := filter.Limit
+	if limit <= 0 {
+		limit = 50
+	}
+	if limit > 500 {
+		limit = 500
+	}
+	q := s.db.WithContext(ctx).Model(&model.AccessLog{})
+	if filter.ActorID != "" {
+		q = q.Where("actor_id = ?", filter.ActorID)
+	}
+	if filter.Action != "" {
+		q = q.Where("action = ?", filter.Action)
+	}
+	if filter.Outcome != "" {
+		q = q.Where("outcome = ?", filter.Outcome)
+	}
+	if !filter.From.IsZero() {
+		q = q.Where("created_at >= ?", filter.From)
+	}
+	if !filter.To.IsZero() {
+		q = q.Where("created_at < ?", filter.To)
+	}
+	var total int64
+	if err := q.Count(&total).Error; err != nil {
+		return nil, 0, err
+	}
+	logs := make([]model.AccessLog, 0, limit)
+	if err := q.Order("created_at DESC").Order("id ASC").Offset(max(filter.Offset, 0)).Limit(limit).Find(&logs).Error; err != nil {
+		return nil, 0, err
+	}
+	return logs, total, nil
+}
+
+func (s *Store) Get(ctx context.Context, id string) (model.AccessLog, bool, error) {
+	var row model.AccessLog
+	err := s.db.WithContext(ctx).First(&row, "id = ?", id).Error
+	if err == gorm.ErrRecordNotFound {
+		return model.AccessLog{}, false, nil
+	}
+	if err != nil {
+		return model.AccessLog{}, false, err
+	}
+	return row, true, nil
+}
+
+func NewID() string {
+	value := make([]byte, 16)
+	_, _ = rand.Read(value)
+	return hex.EncodeToString(value)
+}
+
+func max(a, b int) int {
+	if a > b {
+		return a
+	}
+	return b
+}

--- a/bkn-safe/server/internal/auth/provider.go
+++ b/bkn-safe/server/internal/auth/provider.go
@@ -69,15 +69,19 @@ func NewProvider(auth Authenticator, hydra *HydraAdmin, users UserLookup) *Provi
 // redirect target. On bad credentials it returns ErrInvalidCredentials. When the
 // user must change their password first it returns ErrMustChangePassword without
 // accepting the login — the caller drives the change-password flow.
-func (p *Provider) Login(ctx context.Context, challenge, account, password string, remember bool) (redirectTo string, err error) {
+func (p *Provider) Login(ctx context.Context, challenge, account, password string, remember bool) (redirectTo string, user *model.User, err error) {
 	u, err := p.auth.Verify(ctx, account, password)
 	if err != nil {
-		return "", err
+		return "", nil, err
 	}
 	if u.MustChangePassword {
-		return "", ErrMustChangePassword
+		return "", nil, ErrMustChangePassword
 	}
-	return p.hydra.AcceptLogin(ctx, challenge, u.ID, remember)
+	redirectTo, err = p.hydra.AcceptLogin(ctx, challenge, u.ID, remember)
+	if err != nil {
+		return "", nil, err
+	}
+	return redirectTo, u, nil
 }
 
 // ChangePassword re-verifies the current password, sets the new one (clearing
@@ -85,15 +89,19 @@ func (p *Provider) Login(ctx context.Context, challenge, account, password strin
 // first-login change in one step. There is no server session, so the old
 // password is re-entered and re-verified rather than trusted from the prior
 // login POST. Returns hydra's redirect target.
-func (p *Provider) ChangePassword(ctx context.Context, challenge, account, oldPassword, newPassword string, remember bool) (redirectTo string, err error) {
+func (p *Provider) ChangePassword(ctx context.Context, challenge, account, oldPassword, newPassword string, remember bool) (redirectTo string, user *model.User, err error) {
 	u, err := p.auth.Verify(ctx, account, oldPassword)
 	if err != nil {
-		return "", err
+		return "", nil, err
 	}
 	if err := p.users.SetPassword(ctx, u.ID, newPassword); err != nil {
-		return "", err
+		return "", nil, err
 	}
-	return p.hydra.AcceptLogin(ctx, challenge, u.ID, remember)
+	redirectTo, err = p.hydra.AcceptLogin(ctx, challenge, u.ID, remember)
+	if err != nil {
+		return "", nil, err
+	}
+	return redirectTo, u, nil
 }
 
 // ConsentInfo returns the consent request (client + requested scope) for

--- a/bkn-safe/server/internal/httpapi/accesslog.go
+++ b/bkn-safe/server/internal/httpapi/accesslog.go
@@ -1,0 +1,104 @@
+// Copyright openbkn.ai
+//
+// Licensed under the OpenBKN License. See LICENSE-OPENBKN.txt in the project root.
+
+package httpapi
+
+import (
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/gin-gonic/gin"
+
+	"github.com/openbkn-ai/bkn-foundry/bkn-safe/server/internal/accesslog"
+	"github.com/openbkn-ai/bkn-foundry/bkn-safe/server/internal/directory"
+)
+
+// registerAccessLogReads keeps access facts on the existing authenticated admin
+// surface. It deliberately does not add another role model; the Trace log
+// service continues to apply the platform's existing log/Trace access policy.
+func registerAccessLogReads(group *gin.RouterGroup, store *accesslog.Store) {
+	group.GET("/access-logs", func(c *gin.Context) {
+		filter := accesslog.Filter{
+			ActorID: c.Query("actor_id"),
+			Action:  c.Query("action"),
+			Outcome: c.Query("outcome"),
+			Offset:  atoiDefault(c.Query("offset"), 0),
+			Limit:   atoiDefault(c.Query("limit"), 0),
+		}
+		if !accessLogTimeFilter(c, "from", &filter.From) || !accessLogTimeFilter(c, "to", &filter.To) {
+			return
+		}
+		logs, total, err := store.List(c.Request.Context(), filter)
+		if err != nil {
+			serverError(c, err)
+			return
+		}
+		c.JSON(http.StatusOK, gin.H{"logs": logs, "total": total})
+	})
+	group.GET("/access-logs/:id", func(c *gin.Context) {
+		entry, found, err := store.Get(c.Request.Context(), c.Param("id"))
+		if err != nil {
+			serverError(c, err)
+			return
+		}
+		if !found {
+			c.JSON(http.StatusNotFound, gin.H{"error": "access log not found"})
+			return
+		}
+		c.JSON(http.StatusOK, entry)
+	})
+}
+
+func accessLogTimeFilter(c *gin.Context, key string, target *time.Time) bool {
+	value := strings.TrimSpace(c.Query(key))
+	if value == "" {
+		return true
+	}
+	parsed, err := time.Parse(time.RFC3339Nano, value)
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": key + " must be an RFC3339 timestamp"})
+		return false
+	}
+	*target = parsed
+	return true
+}
+
+// registerLogout records a voluntary user-initiated logout before Studio
+// navigates to Hydra's browser logout endpoint. Failed or passive token expiry
+// is intentionally not represented as a logout fact.
+func registerLogout(group *gin.RouterGroup, store *accesslog.Store, directory *directory.Service) {
+	group.POST("/logout", func(c *gin.Context) {
+		actorID := c.GetString(ctxAccessorID)
+		actorName := accessActorName(c, directory, actorID)
+		if err := store.Record(c.Request.Context(), accesslog.Entry{
+			ActorID: actorID, ActorNameSnapshot: actorName,
+			AuthMethod: "oauth", SourceChannel: "studio", Action: "logout", Outcome: "success",
+			RequestID: requestIDFromHeader(c), ClientIP: c.ClientIP(),
+		}); err != nil {
+			// Access recording must not strand a user in a session.
+			c.Error(err)
+		}
+		c.Status(http.StatusNoContent)
+	})
+}
+
+func accessActorName(c *gin.Context, directory *directory.Service, actorID string) string {
+	if directory == nil || actorID == "" {
+		return ""
+	}
+	names, err := directory.ResolveUserNames(c.Request.Context(), []string{actorID})
+	if err != nil || len(names) == 0 {
+		return ""
+	}
+	return names[0].Name
+}
+
+func requestIDFromHeader(c *gin.Context) string {
+	value := strings.TrimSpace(c.GetHeader("x-request-id"))
+	if validAuditRequestID(value) {
+		return value
+	}
+	return ""
+}

--- a/bkn-safe/server/internal/httpapi/accesslog.go
+++ b/bkn-safe/server/internal/httpapi/accesslog.go
@@ -12,14 +12,15 @@ import (
 	"github.com/gin-gonic/gin"
 
 	"github.com/openbkn-ai/bkn-foundry/bkn-safe/server/internal/accesslog"
+	"github.com/openbkn-ai/bkn-foundry/bkn-safe/server/internal/authz"
 	"github.com/openbkn-ai/bkn-foundry/bkn-safe/server/internal/directory"
 )
 
 // registerAccessLogReads keeps access facts on the existing authenticated admin
 // surface. It deliberately does not add another role model; the Trace log
 // service continues to apply the platform's existing log/Trace access policy.
-func registerAccessLogReads(group *gin.RouterGroup, store *accesslog.Store) {
-	group.GET("/access-logs", func(c *gin.Context) {
+func registerAccessLogReads(group *gin.RouterGroup, store *accesslog.Store, e *authz.Enforcer) {
+	group.GET("/access-logs", RequirePermission(e, "admin-audit", "view"), func(c *gin.Context) {
 		filter := accesslog.Filter{
 			ActorID: c.Query("actor_id"),
 			Action:  c.Query("action"),
@@ -37,7 +38,7 @@ func registerAccessLogReads(group *gin.RouterGroup, store *accesslog.Store) {
 		}
 		c.JSON(http.StatusOK, gin.H{"logs": logs, "total": total})
 	})
-	group.GET("/access-logs/:id", func(c *gin.Context) {
+	group.GET("/access-logs/:id", RequirePermission(e, "admin-audit", "view"), func(c *gin.Context) {
 		entry, found, err := store.Get(c.Request.Context(), c.Param("id"))
 		if err != nil {
 			serverError(c, err)

--- a/bkn-safe/server/internal/httpapi/accesslog_test.go
+++ b/bkn-safe/server/internal/httpapi/accesslog_test.go
@@ -1,0 +1,38 @@
+// Copyright openbkn.ai
+//
+// Licensed under the OpenBKN License. See LICENSE-OPENBKN.txt in the project root.
+
+package httpapi
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/openbkn-ai/bkn-foundry/bkn-safe/server/internal/model"
+)
+
+func TestAccessLogReadEndpointIsAvailableToTheExistingAdminSurface(t *testing.T) {
+	r, _, _, _ := newAdminServer(t)
+
+	response := adminReq(t, r, http.MethodGet, "/api/safe/v1/admin/access-logs", nil)
+	if response.Code != http.StatusOK {
+		t.Fatalf("access-log read endpoint status = %d, want %d: %s", response.Code, http.StatusOK, response.Body.String())
+	}
+}
+
+func TestVoluntaryLogoutRecordsAnAccessFact(t *testing.T) {
+	r, _, db, _ := newAdminServer(t)
+
+	response := tokReq(t, r, http.MethodPost, "/api/safe/v1/me/logout", nil, adminSub)
+	if response.Code != http.StatusNoContent {
+		t.Fatalf("logout status = %d, want %d: %s", response.Code, http.StatusNoContent, response.Body.String())
+	}
+
+	var row model.AccessLog
+	if err := db.First(&row, "actor_id = ?", adminSub).Error; err != nil {
+		t.Fatalf("read logout access fact: %v", err)
+	}
+	if row.Action != "logout" || row.Outcome != "success" || row.AuthMethod != "oauth" {
+		t.Fatalf("logout access fact = %#v, want oauth/logout/success", row)
+	}
+}

--- a/bkn-safe/server/internal/httpapi/accesslog_test.go
+++ b/bkn-safe/server/internal/httpapi/accesslog_test.go
@@ -20,6 +20,34 @@ func TestAccessLogReadEndpointIsAvailableToTheExistingAdminSurface(t *testing.T)
 	}
 }
 
+func TestAccessLogReadsRequireAuditViewPermission(t *testing.T) {
+	r, e, _, users := newAdminServer(t)
+	const (
+		securityUser = "access-log-security"
+		securityRole = "access-log-security-role"
+		auditUser    = "access-log-auditor"
+		auditRole    = "access-log-auditor-role"
+	)
+	for _, roleID := range []string{securityRole, auditRole} {
+		grantAdminSurface(t, e, roleID)
+	}
+	grantRoleOps(t, e, auditRole, "admin-audit", "view")
+	for _, userID := range []string{securityUser, auditUser} {
+		if err := users.CreateLocalUser(t.Context(), &model.User{ID: userID, Account: userID, Name: userID, Enabled: true}, "pw-init0"); err != nil {
+			t.Fatalf("create user %s: %v", userID, err)
+		}
+	}
+	bindRole(t, e, securityUser, securityRole)
+	bindRole(t, e, auditUser, auditRole)
+
+	if response := tokReq(t, r, http.MethodGet, "/api/safe/v1/admin/access-logs", nil, securityUser); response.Code != http.StatusForbidden {
+		t.Fatalf("security role status = %d, want 403: %s", response.Code, response.Body.String())
+	}
+	if response := tokReq(t, r, http.MethodGet, "/api/safe/v1/admin/access-logs", nil, auditUser); response.Code != http.StatusOK {
+		t.Fatalf("audit role status = %d, want 200: %s", response.Code, response.Body.String())
+	}
+}
+
 func TestVoluntaryLogoutRecordsAnAccessFact(t *testing.T) {
 	r, _, db, _ := newAdminServer(t)
 

--- a/bkn-safe/server/internal/httpapi/admin_test.go
+++ b/bkn-safe/server/internal/httpapi/admin_test.go
@@ -20,6 +20,7 @@ import (
 	"gorm.io/gorm"
 
 	"github.com/openbkn-ai/bkn-foundry/bkn-safe/server/extension/adminwrite"
+	"github.com/openbkn-ai/bkn-foundry/bkn-safe/server/internal/accesslog"
 	"github.com/openbkn-ai/bkn-foundry/bkn-safe/server/internal/audit"
 	"github.com/openbkn-ai/bkn-foundry/bkn-safe/server/internal/auth"
 	"github.com/openbkn-ai/bkn-foundry/bkn-safe/server/internal/authz"
@@ -76,6 +77,7 @@ func newAdminServer(t *testing.T) (*gin.Engine, *authz.Enforcer, *gorm.DB, *auth
 	r := New(Deps{
 		Enforcer: e, DB: db, Directory: directory.New(db), Users: users,
 		Audit:         audit.New(db),
+		AccessLog:     accesslog.New(db),
 		TokenVerifier: stubVerifier{},
 	})
 	return r, e, db, users

--- a/bkn-safe/server/internal/httpapi/auth.go
+++ b/bkn-safe/server/internal/httpapi/auth.go
@@ -15,7 +15,9 @@ import (
 
 	"github.com/gin-gonic/gin"
 
+	"github.com/openbkn-ai/bkn-foundry/bkn-safe/server/internal/accesslog"
 	"github.com/openbkn-ai/bkn-foundry/bkn-safe/server/internal/auth"
+	"github.com/openbkn-ai/bkn-foundry/bkn-safe/server/internal/model"
 )
 
 // registerAuth mounts the hydra login/consent/device provider pages. hydra is
@@ -23,11 +25,11 @@ import (
 // pages are server-rendered (no SPA), styled to match the BKN Studio console:
 // device shows the user_code to confirm, consent shows the requesting client +
 // requested scopes with explicit Authorize/Decline.
-func registerAuth(r *gin.Engine, p *auth.Provider, h *auth.HydraAdmin) {
+func registerAuth(r *gin.Engine, p *auth.Provider, h *auth.HydraAdmin, accessStore *accesslog.Store) {
 	r.GET("/login", showLogin)
-	r.POST("/login", func(c *gin.Context) { doLogin(c, p) })
+	r.POST("/login", func(c *gin.Context) { doLogin(c, p, accessStore) })
 	r.GET("/change-password", showChangePassword)
-	r.POST("/change-password", func(c *gin.Context) { doChangePassword(c, p) })
+	r.POST("/change-password", func(c *gin.Context) { doChangePassword(c, p, accessStore) })
 	r.GET("/consent", func(c *gin.Context) { showConsent(c, p) })
 	r.POST("/consent", func(c *gin.Context) { doConsent(c, p) })
 	r.GET("/device", showDevice)
@@ -177,7 +179,7 @@ func showLogin(c *gin.Context) {
 	renderHTML(c, loginPage, map[string]any{"Challenge": challenge})
 }
 
-func doLogin(c *gin.Context, p *auth.Provider) {
+func doLogin(c *gin.Context, p *auth.Provider, accessStore *accesslog.Store) {
 	challenge := c.PostForm("login_challenge")
 	account := c.PostForm("account")
 	password := c.PostForm("password")
@@ -185,7 +187,7 @@ func doLogin(c *gin.Context, p *auth.Provider) {
 		c.String(http.StatusBadRequest, "missing login_challenge")
 		return
 	}
-	redirectTo, err := p.Login(c.Request.Context(), challenge, account, password, false)
+	redirectTo, user, err := p.Login(c.Request.Context(), challenge, account, password, false)
 	if err != nil {
 		if errors.Is(err, auth.ErrMustChangePassword) {
 			// Credentials are valid but a password change is required first.
@@ -195,6 +197,7 @@ func doLogin(c *gin.Context, p *auth.Provider) {
 			return
 		}
 		if errors.Is(err, auth.ErrInvalidCredentials) || errors.Is(err, auth.ErrUserDisabled) {
+			recordLogin(c, accessStore, nil, account, "failure", loginFailureCode(err))
 			// Re-render the login form with an inline error instead of a bare
 			// error page, keeping the entered account and the same challenge.
 			c.Status(http.StatusUnauthorized)
@@ -216,6 +219,7 @@ func doLogin(c *gin.Context, p *auth.Provider) {
 		c.String(http.StatusInternalServerError, "internal error")
 		return
 	}
+	recordLogin(c, accessStore, user, account, "success", "")
 	c.Redirect(http.StatusFound, redirectTo)
 }
 
@@ -233,7 +237,7 @@ func showChangePassword(c *gin.Context) {
 
 // doChangePassword re-verifies the current password, sets the new one, and
 // completes the hydra login. Validation errors re-render the page with a note.
-func doChangePassword(c *gin.Context, p *auth.Provider) {
+func doChangePassword(c *gin.Context, p *auth.Provider, accessStore *accesslog.Store) {
 	challenge := c.PostForm("login_challenge")
 	account := c.PostForm("account")
 	oldPw := c.PostForm("old_password")
@@ -254,9 +258,10 @@ func doChangePassword(c *gin.Context, p *auth.Provider) {
 		reRender("新密码不能与当前密码相同")
 		return
 	}
-	redirectTo, err := p.ChangePassword(c.Request.Context(), challenge, account, oldPw, newPw, false)
+	redirectTo, user, err := p.ChangePassword(c.Request.Context(), challenge, account, oldPw, newPw, false)
 	if err != nil {
 		if errors.Is(err, auth.ErrInvalidCredentials) || errors.Is(err, auth.ErrUserDisabled) {
+			recordLogin(c, accessStore, nil, account, "failure", loginFailureCode(err))
 			reRender("当前密码错误")
 			return
 		}
@@ -268,7 +273,36 @@ func doChangePassword(c *gin.Context, p *auth.Provider) {
 		c.String(http.StatusInternalServerError, "internal error")
 		return
 	}
+	recordLogin(c, accessStore, user, account, "success", "")
 	c.Redirect(http.StatusFound, redirectTo)
+}
+
+func recordLogin(c *gin.Context, store *accesslog.Store, user *model.User, account, outcome, failureCode string) {
+	if store == nil {
+		return
+	}
+	actorID, actorName := "", strings.TrimSpace(account)
+	if user != nil {
+		actorID = user.ID
+		actorName = strings.TrimSpace(user.Name)
+		if actorName == "" {
+			actorName = strings.TrimSpace(user.Account)
+		}
+	}
+	if err := store.Record(c.Request.Context(), accesslog.Entry{
+		ActorID: actorID, ActorNameSnapshot: actorName, AuthMethod: "password", SourceChannel: "web",
+		Action: "login", Outcome: outcome, FailureCode: failureCode,
+		RequestID: requestIDFromHeader(c), ClientIP: c.ClientIP(),
+	}); err != nil {
+		slog.Error("access login fact write failed", "outcome", outcome, "error", err)
+	}
+}
+
+func loginFailureCode(err error) string {
+	if errors.Is(err, auth.ErrUserDisabled) {
+		return "user_disabled"
+	}
+	return "invalid_credentials"
 }
 
 // firstPartyClients are the platform's own seeded login entry-point clients

--- a/bkn-safe/server/internal/httpapi/router.go
+++ b/bkn-safe/server/internal/httpapi/router.go
@@ -114,7 +114,7 @@ func New(deps Deps) *gin.Engine {
 			registerAuditReads(admin, deps.Audit, deps.Enforcer)
 		}
 		if deps.AccessLog != nil {
-			registerAccessLogReads(admin, deps.AccessLog)
+			registerAccessLogReads(admin, deps.AccessLog, deps.Enforcer)
 		}
 		registerUserAdmin(admin, deps.Users, deps.Enforcer, deps.Directory)
 		registerAdminReads(admin, deps.Directory, deps.Enforcer)

--- a/bkn-safe/server/internal/httpapi/router.go
+++ b/bkn-safe/server/internal/httpapi/router.go
@@ -14,6 +14,7 @@ import (
 	"gorm.io/gorm"
 
 	"github.com/openbkn-ai/bkn-foundry/bkn-safe/server/extension/adminwrite"
+	"github.com/openbkn-ai/bkn-foundry/bkn-safe/server/internal/accesslog"
 	"github.com/openbkn-ai/bkn-foundry/bkn-safe/server/internal/audit"
 	"github.com/openbkn-ai/bkn-foundry/bkn-safe/server/internal/auth"
 	"github.com/openbkn-ai/bkn-foundry/bkn-safe/server/internal/authz"
@@ -32,6 +33,8 @@ type Deps struct {
 	// Audit records admin-API mutations. When nil, the audit middleware and the
 	// audit-log read endpoint are not mounted (auditing off).
 	Audit *audit.Store
+	// AccessLog records login/logout outcomes separately from management audit.
+	AccessLog *accesslog.Store
 	// TokenVerifier validates admin-API bearer tokens. Defaults to Hydra when
 	// nil (production); tests inject a stub.
 	TokenVerifier TokenVerifier
@@ -69,7 +72,7 @@ func New(deps Deps) *gin.Engine {
 
 	// hydra login/consent/device provider pages.
 	if deps.Provider != nil && deps.Hydra != nil {
-		registerAuth(r, deps.Provider, deps.Hydra)
+		registerAuth(r, deps.Provider, deps.Hydra, deps.AccessLog)
 	}
 
 	// Internal user-directory reads (name resolution, batch lookups) — ClusterIP.
@@ -109,6 +112,9 @@ func New(deps Deps) *gin.Engine {
 		if deps.Audit != nil {
 			admin.Use(auditMiddleware(deps.Audit, deps.Directory, deps.DB))
 			registerAuditReads(admin, deps.Audit, deps.Enforcer)
+		}
+		if deps.AccessLog != nil {
+			registerAccessLogReads(admin, deps.AccessLog)
 		}
 		registerUserAdmin(admin, deps.Users, deps.Enforcer, deps.Directory)
 		registerAdminReads(admin, deps.Directory, deps.Enforcer)
@@ -195,6 +201,9 @@ func New(deps Deps) *gin.Engine {
 			meWrites.Use(auditMiddleware(deps.Audit, deps.Directory, deps.DB))
 		}
 		registerMeProfile(meWrites, deps.Users)
+		if deps.AccessLog != nil && deps.Directory != nil {
+			registerLogout(meWrites, deps.AccessLog, deps.Directory)
+		}
 		// Self-service AppKey management (issue/list/revoke own keys).
 		if apiKeys != nil {
 			registerMeAPIKeys(meWrites, apiKeys)

--- a/bkn-safe/server/internal/model/model.go
+++ b/bkn-safe/server/internal/model/model.go
@@ -188,6 +188,24 @@ type AuditLog struct {
 	CreatedAt time.Time `json:"created_at" gorm:"index"`
 }
 
+// AccessLog records an authentication fact. It is deliberately separate from
+// AuditLog: login and logout explain who entered or left the platform, while
+// AuditLog records administration mutations made after authentication.
+// Passwords, tokens, cookies and request bodies are never stored here.
+type AccessLog struct {
+	ID                string    `json:"id" gorm:"primaryKey;size:64"`
+	ActorID           string    `json:"actor_id" gorm:"size:64;index"`
+	ActorNameSnapshot string    `json:"actor_name_snapshot" gorm:"size:255"`
+	AuthMethod        string    `json:"auth_method" gorm:"size:32"`
+	SourceChannel     string    `json:"source_channel" gorm:"size:32"`
+	Action            string    `json:"action" gorm:"size:32;index"`  // login | logout
+	Outcome           string    `json:"outcome" gorm:"size:32;index"` // success | failure
+	FailureCode       string    `json:"failure_code" gorm:"size:64"`
+	RequestID         string    `json:"request_id" gorm:"size:128;index"`
+	ClientIP          string    `json:"client_ip" gorm:"size:64"`
+	CreatedAt         time.Time `json:"created_at" gorm:"index"`
+}
+
 // APIKey is a user-issued long-lived credential (AppKey). It authenticates AS its
 // owner: verification resolves the owner's id + account_type, so downstream authz
 // is identical to the owner using an OAuth token (no second permission system).
@@ -236,6 +254,6 @@ func AllModels() []any {
 	return []any{
 		&User{}, &Role{}, &Department{}, &UserDepartment{},
 		&Group{}, &GroupMember{}, &ResourceType{}, &Operation{},
-		&AuditLog{}, &APIKey{}, &License{}, &ResourceParent{},
+		&AuditLog{}, &AccessLog{}, &APIKey{}, &License{}, &ResourceParent{},
 	}
 }

--- a/bkn-trace/agent-observability/charts/agent-observability/templates/deployment.yaml
+++ b/bkn-trace/agent-observability/charts/agent-observability/templates/deployment.yaml
@@ -98,6 +98,10 @@ spec:
               value: {{ .Values.businessResolver.bknBaseURL | quote }}
             - name: BKN_TRACE_VEGA_RESOLVER_URL
               value: {{ .Values.businessResolver.vegaBaseURL | quote }}
+            - name: BKN_TRACE_EXECUTION_FACTORY_URL
+              value: {{ .Values.businessResolver.executionFactoryURL | quote }}
+            - name: BKN_TRACE_MODEL_MANAGER_URL
+              value: {{ .Values.businessResolver.modelManagerURL | quote }}
             - name: BKN_TRACE_RESOLVER_TIMEOUT
               value: {{ .Values.businessResolver.timeout | quote }}
             {{- end }}

--- a/bkn-trace/agent-observability/charts/agent-observability/values.yaml
+++ b/bkn-trace/agent-observability/charts/agent-observability/values.yaml
@@ -72,6 +72,8 @@ businessResolver:
   enabled: true
   bknBaseURL: "http://bkn-backend-svc:13014"
   vegaBaseURL: "http://vega-backend-svc:13014"
+  executionFactoryURL: "http://agent-operator-integration:9000"
+  modelManagerURL: "http://mf-model-manager:9898"
   timeout: 3s
 
 # The Community binary ignores this block. The EE image uses it solely to

--- a/bkn-trace/agent-observability/src/boot/bootstrap.go
+++ b/bkn-trace/agent-observability/src/boot/bootstrap.go
@@ -27,7 +27,10 @@ import (
 	"github.com/openbkn-ai/bkn-foundry/bkn-trace/agent-observability/src/drivenadapter/httpaccess/bknbackendaudit"
 	"github.com/openbkn-ai/bkn-foundry/bkn-trace/agent-observability/src/drivenadapter/httpaccess/bknsafeaccess"
 	"github.com/openbkn-ai/bkn-foundry/bkn-trace/agent-observability/src/drivenadapter/httpaccess/bknsafeaudit"
+	"github.com/openbkn-ai/bkn-foundry/bkn-trace/agent-observability/src/drivenadapter/httpaccess/bknsafeuseraccess"
 	"github.com/openbkn-ai/bkn-foundry/bkn-trace/agent-observability/src/drivenadapter/httpaccess/businessresolver"
+	"github.com/openbkn-ai/bkn-foundry/bkn-trace/agent-observability/src/drivenadapter/httpaccess/executionfactoryaudit"
+	"github.com/openbkn-ai/bkn-foundry/bkn-trace/agent-observability/src/drivenadapter/httpaccess/modelmanageraudit"
 	"github.com/openbkn-ai/bkn-foundry/bkn-trace/agent-observability/src/drivenadapter/httpaccess/opensearchconversationaudit"
 	"github.com/openbkn-ai/bkn-foundry/bkn-trace/agent-observability/src/drivenadapter/httpaccess/opensearchcoreprojection"
 	"github.com/openbkn-ai/bkn-foundry/bkn-trace/agent-observability/src/drivenadapter/httpaccess/opensearchevidencestore"
@@ -35,6 +38,7 @@ import (
 	"github.com/openbkn-ai/bkn-foundry/bkn-trace/agent-observability/src/drivenadapter/httpaccess/opensearchprojection"
 	"github.com/openbkn-ai/bkn-foundry/bkn-trace/agent-observability/src/drivenadapter/httpaccess/opensearchtraceaccess"
 	"github.com/openbkn-ai/bkn-foundry/bkn-trace/agent-observability/src/drivenadapter/httpaccess/otelcolmetrics"
+	"github.com/openbkn-ai/bkn-foundry/bkn-trace/agent-observability/src/drivenadapter/httpaccess/vegaaudit"
 	"github.com/openbkn-ai/bkn-foundry/bkn-trace/agent-observability/src/drivenadapter/memoryaccess/evidencestore"
 	"github.com/openbkn-ai/bkn-foundry/bkn-trace/agent-observability/src/drivenadapter/memoryaccess/ledgerstore"
 	memorysessionstore "github.com/openbkn-ai/bkn-foundry/bkn-trace/agent-observability/src/drivenadapter/memoryaccess/sessionstore"
@@ -146,22 +150,14 @@ func NewApp() (*App, error) {
 	logSources := []logsvc.Source{
 		opensearchlogaccess.New(openSearchClient, openSearchConfig.LogIndex),
 		bknsafeaudit.New(accessScopeConfig.BKNBaseURL, &http.Client{Timeout: accessScopeConfig.Timeout}),
-		logsvc.NewNotIntegratedSource("bkn-safe-access", []string{
-			observabilityvo.CategoryAccessUser,
-		}, []string{"BKN Safe OAuth"}),
+		bknsafeuseraccess.New(accessScopeConfig.BKNBaseURL, &http.Client{Timeout: accessScopeConfig.Timeout}),
 		logsvc.NewNotIntegratedSource("bkn-safe-security", []string{
 			observabilityvo.CategoryAuditSecurity,
 		}, []string{"BKN Safe Authorization"}),
 		bknbackendaudit.New(resolverConfig.BKNBaseURL, &http.Client{Timeout: resolverConfig.Timeout}),
-		logsvc.NewNotIntegratedSource("vega", []string{
-			observabilityvo.CategoryAuditAdmin,
-		}, []string{"data_resource_knowledge_network"}),
-		logsvc.NewNotIntegratedSource("execution-factory", []string{
-			observabilityvo.CategoryAuditAdmin,
-		}, []string{"execution_factory"}),
-		logsvc.NewNotIntegratedSource("model-manager", []string{
-			observabilityvo.CategoryAuditAdmin,
-		}, []string{"model_management"}),
+		vegaaudit.New(resolverConfig.VegaBaseURL, &http.Client{Timeout: resolverConfig.Timeout}),
+		executionfactoryaudit.New(resolverConfig.ExecutionFactoryURL, &http.Client{Timeout: resolverConfig.Timeout}),
+		modelmanageraudit.New(resolverConfig.ModelManagerURL, &http.Client{Timeout: resolverConfig.Timeout}),
 	}
 	if coreConfig.ProjectionEnabled {
 		logSources = append(logSources, opensearchconversationaudit.New(openSearchClient, coreConfig.ProjectionIndex))

--- a/bkn-trace/agent-observability/src/conf/resolver.go
+++ b/bkn-trace/agent-observability/src/conf/resolver.go
@@ -7,15 +7,19 @@ import (
 )
 
 type BusinessResolverConfig struct {
-	Enabled     bool
-	BKNBaseURL  string
-	VegaBaseURL string
-	Timeout     time.Duration
+	Enabled             bool
+	BKNBaseURL          string
+	VegaBaseURL         string
+	ExecutionFactoryURL string
+	ModelManagerURL     string
+	Timeout             time.Duration
 }
 
 func NewBusinessResolverConfig() BusinessResolverConfig {
 	bknURL := strings.TrimRight(strings.TrimSpace(os.Getenv("BKN_TRACE_BKN_RESOLVER_URL")), "/")
 	vegaURL := strings.TrimRight(strings.TrimSpace(os.Getenv("BKN_TRACE_VEGA_RESOLVER_URL")), "/")
+	executionFactoryURL := strings.TrimRight(strings.TrimSpace(os.Getenv("BKN_TRACE_EXECUTION_FACTORY_URL")), "/")
+	modelManagerURL := strings.TrimRight(strings.TrimSpace(os.Getenv("BKN_TRACE_MODEL_MANAGER_URL")), "/")
 	timeout := 3 * time.Second
 	if value := strings.TrimSpace(os.Getenv("BKN_TRACE_RESOLVER_TIMEOUT")); value != "" {
 		if parsed, err := time.ParseDuration(value); err == nil && parsed > 0 {
@@ -23,6 +27,6 @@ func NewBusinessResolverConfig() BusinessResolverConfig {
 		}
 	}
 	return BusinessResolverConfig{
-		Enabled: bknURL != "" || vegaURL != "", BKNBaseURL: bknURL, VegaBaseURL: vegaURL, Timeout: timeout,
+		Enabled: bknURL != "" || vegaURL != "", BKNBaseURL: bknURL, VegaBaseURL: vegaURL, ExecutionFactoryURL: executionFactoryURL, ModelManagerURL: modelManagerURL, Timeout: timeout,
 	}
 }

--- a/bkn-trace/agent-observability/src/domain/valueobject/observabilityvo/registry.go
+++ b/bkn-trace/agent-observability/src/domain/valueobject/observabilityvo/registry.go
@@ -8,6 +8,7 @@ import "sort"
 var registeredEventCategories = map[string]string{
 	"login.succeeded":             CategoryAccessUser,
 	"login.failed":                CategoryAccessUser,
+	"logout.succeeded":            CategoryAccessUser,
 	"token.exchanged":             CategoryAccessUser,
 	"resource.read":               CategoryAccessUser,
 	"authorization.decided":       CategoryAuditSecurity,

--- a/bkn-trace/agent-observability/src/domain/valueobject/observabilityvo/registry_test.go
+++ b/bkn-trace/agent-observability/src/domain/valueobject/observabilityvo/registry_test.go
@@ -13,3 +13,9 @@ func TestRegisteredLogEventsRejectUnknownAndCategoryMismatch(t *testing.T) {
 		t.Fatal("unregistered extension event was accepted")
 	}
 }
+
+func TestRegisteredLogEventsIncludeVoluntaryLogout(t *testing.T) {
+	if !IsRegisteredLogEvent(CategoryAccessUser, "logout.succeeded") {
+		t.Fatal("registered voluntary logout event was rejected")
+	}
+}

--- a/bkn-trace/agent-observability/src/drivenadapter/httpaccess/bknbackendaudit/client.go
+++ b/bkn-trace/agent-observability/src/drivenadapter/httpaccess/bknbackendaudit/client.go
@@ -44,7 +44,7 @@ func (client *Client) Metadata() observabilityvo.SourceStatus {
 		}
 	}
 	return observabilityvo.SourceStatus{
-		SourceID: sourceID, Status: "healthy", Reliability: "best_effort",
+		SourceID: sourceID, Status: "degraded", Reason: "management_audit_coverage_in_progress", Reliability: "best_effort",
 		CollectionMethod: "source_adapter", CoveredModules: []string{"domain_knowledge_network"},
 		CountAccuracy: "partial", Categories: []string{observabilityvo.CategoryAuditAdmin},
 	}

--- a/bkn-trace/agent-observability/src/drivenadapter/httpaccess/bknbackendaudit/client_test.go
+++ b/bkn-trace/agent-observability/src/drivenadapter/httpaccess/bknbackendaudit/client_test.go
@@ -60,6 +60,13 @@ func TestMetadataDoesNotClaimAnUnconfiguredSourceIsHealthy(t *testing.T) {
 	}
 }
 
+func TestMetadataDoesNotClaimPartialManagementCoverageIsHealthy(t *testing.T) {
+	status := New("http://bkn-backend:8080", nil).Metadata()
+	if status.Status != "degraded" || status.Reason != "management_audit_coverage_in_progress" {
+		t.Fatalf("status = %#v", status)
+	}
+}
+
 func TestGetKeepsUnauthorizedDetailAsNotFound(t *testing.T) {
 	client := New("http://bkn-backend:8080", &http.Client{Transport: roundTripFunc(func(candidate *http.Request) (*http.Response, error) {
 		return &http.Response{StatusCode: http.StatusNotFound, Header: make(http.Header), Request: candidate, Body: io.NopCloser(strings.NewReader(`{"error":"not found"}`))}, nil

--- a/bkn-trace/agent-observability/src/drivenadapter/httpaccess/bknsafeuseraccess/client.go
+++ b/bkn-trace/agent-observability/src/drivenadapter/httpaccess/bknsafeuseraccess/client.go
@@ -1,0 +1,199 @@
+package bknsafeuseraccess
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/openbkn-ai/bkn-foundry/bkn-trace/agent-observability/src/domain/valueobject/observabilityvo"
+)
+
+const (
+	sourceID         = "bkn-safe-access"
+	maxResponseBytes = 4 << 20
+)
+
+type Client struct {
+	baseURL string
+	http    *http.Client
+}
+
+func New(baseURL string, httpClient *http.Client) *Client {
+	if httpClient == nil {
+		httpClient = http.DefaultClient
+	}
+	return &Client{baseURL: strings.TrimRight(strings.TrimSpace(baseURL), "/"), http: httpClient}
+}
+
+func (client *Client) ID() string { return sourceID }
+
+func (client *Client) Metadata() observabilityvo.SourceStatus {
+	if client.baseURL == "" {
+		return observabilityvo.SourceStatus{SourceID: sourceID, Status: "not_integrated", Reason: "source_not_configured", Reliability: "best_effort", CollectionMethod: "not_integrated", CoveredModules: []string{"system_management"}, CountAccuracy: "partial", Categories: []string{observabilityvo.CategoryAccessUser}}
+	}
+	return observabilityvo.SourceStatus{SourceID: sourceID, Status: "healthy", Reliability: "best_effort", CollectionMethod: "source_adapter", CoveredModules: []string{"system_management"}, CountAccuracy: "exact", Categories: []string{observabilityvo.CategoryAccessUser}}
+}
+
+func (client *Client) Search(ctx context.Context, query observabilityvo.LogQuery) (observabilityvo.SourcePage, error) {
+	if !contains(query.AuthorizedCategories, observabilityvo.CategoryAccessUser) {
+		return observabilityvo.SourcePage{CountAccuracy: "exact"}, nil
+	}
+	authorization := strings.TrimSpace(observabilityvo.SourceAuthorization(ctx))
+	if authorization == "" {
+		return observabilityvo.SourcePage{}, errors.New("BKN Safe access source requires caller authorization")
+	}
+	parameters := url.Values{}
+	parameters.Set("limit", strconv.Itoa(normalizedLimit(query.Limit)))
+	setIfPresent(parameters, "actor_id", query.ActorID)
+	setIfPresent(parameters, "action", query.Action)
+	if len(query.Outcomes) == 1 {
+		setIfPresent(parameters, "outcome", query.Outcomes[0])
+	}
+	if query.TimeFrom != nil {
+		parameters.Set("from", query.TimeFrom.UTC().Format(time.RFC3339Nano))
+	}
+	if query.TimeTo != nil {
+		parameters.Set("to", query.TimeTo.UTC().Format(time.RFC3339Nano))
+	}
+	request, err := http.NewRequestWithContext(ctx, http.MethodGet, client.baseURL+"/api/safe/v1/admin/access-logs?"+parameters.Encode(), nil)
+	if err != nil {
+		return observabilityvo.SourcePage{}, err
+	}
+	request.Header.Set("Authorization", authorization)
+	response, err := client.http.Do(request)
+	if err != nil {
+		return observabilityvo.SourcePage{}, err
+	}
+	defer response.Body.Close()
+	if response.StatusCode != http.StatusOK {
+		_, _ = io.Copy(io.Discard, io.LimitReader(response.Body, maxResponseBytes))
+		return observabilityvo.SourcePage{}, fmt.Errorf("BKN Safe access source returned status %d", response.StatusCode)
+	}
+	var payload struct {
+		Logs  []accessLog `json:"logs"`
+		Total int64       `json:"total"`
+	}
+	if err := json.NewDecoder(io.LimitReader(response.Body, maxResponseBytes)).Decode(&payload); err != nil {
+		return observabilityvo.SourcePage{}, fmt.Errorf("decode BKN Safe access response: %w", err)
+	}
+	records := make([]observabilityvo.LogRecord, 0, len(payload.Logs))
+	for _, entry := range payload.Logs {
+		records = append(records, project(entry, query.AuthorizedTenantID))
+	}
+	return observabilityvo.SourcePage{Records: records, Count: payload.Total, CountAccuracy: "exact"}, nil
+}
+
+func (client *Client) Get(ctx context.Context, logID string) (observabilityvo.LogRecord, bool, error) {
+	authorization := strings.TrimSpace(observabilityvo.SourceAuthorization(ctx))
+	if authorization == "" {
+		return observabilityvo.LogRecord{}, false, errors.New("BKN Safe access source requires caller authorization")
+	}
+	request, err := http.NewRequestWithContext(ctx, http.MethodGet, client.baseURL+"/api/safe/v1/admin/access-logs/"+url.PathEscape(sourceLogID(logID)), nil)
+	if err != nil {
+		return observabilityvo.LogRecord{}, false, err
+	}
+	request.Header.Set("Authorization", authorization)
+	response, err := client.http.Do(request)
+	if err != nil {
+		return observabilityvo.LogRecord{}, false, err
+	}
+	defer response.Body.Close()
+	if response.StatusCode == http.StatusNotFound {
+		return observabilityvo.LogRecord{}, false, nil
+	}
+	if response.StatusCode != http.StatusOK {
+		return observabilityvo.LogRecord{}, false, fmt.Errorf("BKN Safe access source returned status %d", response.StatusCode)
+	}
+	var entry accessLog
+	if err := json.NewDecoder(io.LimitReader(response.Body, maxResponseBytes)).Decode(&entry); err != nil {
+		return observabilityvo.LogRecord{}, false, fmt.Errorf("decode BKN Safe access detail: %w", err)
+	}
+	scope := observabilityvo.SourceAccessScopeFromContext(ctx)
+	return project(entry, scope.TenantID), true, nil
+}
+
+type accessLog struct {
+	ID                string    `json:"id"`
+	ActorID           string    `json:"actor_id"`
+	ActorNameSnapshot string    `json:"actor_name_snapshot"`
+	AuthMethod        string    `json:"auth_method"`
+	SourceChannel     string    `json:"source_channel"`
+	Action            string    `json:"action"`
+	Outcome           string    `json:"outcome"`
+	FailureCode       string    `json:"failure_code"`
+	RequestID         string    `json:"request_id"`
+	ClientIP          string    `json:"client_ip"`
+	CreatedAt         time.Time `json:"created_at"`
+}
+
+func project(entry accessLog, tenantID string) observabilityvo.LogRecord {
+	action := strings.TrimSpace(entry.Action)
+	outcome := strings.TrimSpace(entry.Outcome)
+	eventName := "login.succeeded"
+	if action == "logout" {
+		eventName = "logout.succeeded"
+	}
+	if action == "login" && outcome == "failure" {
+		eventName = "login.failed"
+	}
+	severityNumber, severityText := 9, "INFO"
+	if outcome == "failure" {
+		severityNumber, severityText = 17, "ERROR"
+	}
+	actorName := firstNonEmpty(entry.ActorNameSnapshot, entry.ActorID, "未识别用户")
+	targetID := firstNonEmpty(entry.ActorID, entry.ActorNameSnapshot)
+	return observabilityvo.LogRecord{
+		EventID: entry.ID, EventTime: entry.CreatedAt, RecordedAt: entry.CreatedAt,
+		ActorNameSnapshot: actorName, ActorType: "user", AuthMethod: firstNonEmpty(entry.AuthMethod, "unknown"), SourceChannel: firstNonEmpty(entry.SourceChannel, "web"),
+		BusinessModule: "system_management", Action: action, TargetType: "user", TargetID: targetID, TargetNameSnapshot: actorName,
+		FailureCode: entry.FailureCode, SchemaVersion: "1.0", LogID: sourceID + ":" + entry.ID, SourceID: sourceID, SourceLogID: entry.ID,
+		Category: observabilityvo.CategoryAccessUser, EventName: eventName, EventTimestamp: entry.CreatedAt, ObservedTimestamp: entry.CreatedAt,
+		SeverityNumber: severityNumber, SeverityText: severityText, Outcome: outcome, SafeSummary: accessSummary(action, actorName, outcome), ServiceName: "bkn-safe-access", Environment: "unknown", TenantID: tenantID,
+		ActorID: entry.ActorID, EffectiveSubjectID: entry.ActorID, RequestID: entry.RequestID, IngressPrincipal: "bkn-safe", TrustLevel: "trusted",
+		ResourceRef: &observabilityvo.ResourceRef{ResourceType: "user", ResourceID: targetID}, Attributes: map[string]any{"client_ip": entry.ClientIP},
+	}
+}
+
+func accessSummary(action, actorName, outcome string) string {
+	return strings.TrimSpace(strings.Join([]string{action, actorName, outcome}, " "))
+}
+func sourceLogID(value string) string {
+	return strings.TrimPrefix(strings.TrimSpace(value), sourceID+":")
+}
+func normalizedLimit(value int) int {
+	if value <= 0 {
+		return 50
+	}
+	if value > 500 {
+		return 500
+	}
+	return value
+}
+func setIfPresent(values url.Values, key, value string) {
+	if strings.TrimSpace(value) != "" {
+		values.Set(key, strings.TrimSpace(value))
+	}
+}
+func contains(values []string, expected string) bool {
+	for _, value := range values {
+		if value == expected {
+			return true
+		}
+	}
+	return false
+}
+func firstNonEmpty(values ...string) string {
+	for _, value := range values {
+		if strings.TrimSpace(value) != "" {
+			return strings.TrimSpace(value)
+		}
+	}
+	return ""
+}

--- a/bkn-trace/agent-observability/src/drivenadapter/httpaccess/bknsafeuseraccess/client_test.go
+++ b/bkn-trace/agent-observability/src/drivenadapter/httpaccess/bknsafeuseraccess/client_test.go
@@ -1,0 +1,49 @@
+package bknsafeuseraccess
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/openbkn-ai/bkn-foundry/bkn-trace/agent-observability/src/domain/valueobject/observabilityvo"
+)
+
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (roundTrip roundTripFunc) RoundTrip(request *http.Request) (*http.Response, error) {
+	return roundTrip(request)
+}
+
+func TestSearchProjectsBKNsafeUserAccessFacts(t *testing.T) {
+	var request *http.Request
+	client := New("http://bkn-safe:3000", &http.Client{Transport: roundTripFunc(func(candidate *http.Request) (*http.Response, error) {
+		request = candidate
+		return &http.Response{StatusCode: http.StatusOK, Header: make(http.Header), Request: candidate,
+			Body: io.NopCloser(strings.NewReader(`{"logs":[{"id":"access-a","actor_id":"user-a","actor_name_snapshot":"Alice","auth_method":"password","source_channel":"web","action":"login","outcome":"failure","failure_code":"invalid_credentials","request_id":"req-a","client_ip":"10.0.0.1","created_at":"2026-08-13T12:00:00Z"}],"total":1}`))}, nil
+	})})
+	from := time.Date(2026, 8, 13, 11, 0, 0, 0, time.UTC)
+	ctx := observabilityvo.WithSourceAuthorization(context.Background(), "Bearer audit-token")
+	page, err := client.Search(ctx, observabilityvo.LogQuery{
+		ActorID: "user-a", Action: "login", Outcomes: []string{"failure"}, TimeFrom: &from, Limit: 20,
+		AuthorizedTenantID: "tenant-a", AuthorizedCategories: []string{observabilityvo.CategoryAccessUser},
+	})
+	if err != nil {
+		t.Fatalf("search BKN Safe access: %v", err)
+	}
+	if request.URL.Path != "/api/safe/v1/admin/access-logs" || request.Header.Get("Authorization") != "Bearer audit-token" ||
+		request.URL.Query().Get("actor_id") != "user-a" || request.URL.Query().Get("action") != "login" || request.URL.Query().Get("outcome") != "failure" {
+		t.Fatalf("access source request is incomplete: %s headers=%v", request.URL.String(), request.Header)
+	}
+	if len(page.Records) != 1 {
+		t.Fatalf("records = %+v, want one", page)
+	}
+	record := page.Records[0]
+	if record.LogID != "bkn-safe-access:access-a" || record.Category != observabilityvo.CategoryAccessUser ||
+		record.EventName != "login.failed" || record.Outcome != "failure" || record.ActorNameSnapshot != "Alice" ||
+		record.AuthMethod != "password" || record.TargetType != "user" || record.TargetID != "user-a" || record.FailureCode != "invalid_credentials" {
+		t.Fatalf("access fact projection is incomplete: %+v", record)
+	}
+}

--- a/bkn-trace/agent-observability/src/drivenadapter/httpaccess/executionfactoryaudit/client.go
+++ b/bkn-trace/agent-observability/src/drivenadapter/httpaccess/executionfactoryaudit/client.go
@@ -1,0 +1,190 @@
+// Package executionfactoryaudit reads bounded Execution Factory management facts.
+package executionfactoryaudit
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/openbkn-ai/bkn-foundry/bkn-trace/agent-observability/src/domain/valueobject/observabilityvo"
+)
+
+const sourceID = "execution-factory"
+
+type Client struct {
+	baseURL string
+	http    *http.Client
+}
+
+func New(baseURL string, client *http.Client) *Client {
+	if client == nil {
+		client = http.DefaultClient
+	}
+	return &Client{baseURL: strings.TrimRight(strings.TrimSpace(baseURL), "/"), http: client}
+}
+func (c *Client) ID() string { return sourceID }
+func (c *Client) Metadata() observabilityvo.SourceStatus {
+	if c.baseURL == "" {
+		return observabilityvo.SourceStatus{SourceID: sourceID, Status: "not_integrated", Reason: "source_not_configured", Reliability: "best_effort", CollectionMethod: "not_integrated", CoveredModules: []string{"execution_factory"}, CountAccuracy: "partial", Categories: []string{observabilityvo.CategoryAuditAdmin}}
+	}
+	return observabilityvo.SourceStatus{SourceID: sourceID, Status: "degraded", Reason: "management_audit_coverage_in_progress", Reliability: "best_effort", CollectionMethod: "source_adapter", CoveredModules: []string{"execution_factory"}, CountAccuracy: "partial", Categories: []string{observabilityvo.CategoryAuditAdmin}}
+}
+func (c *Client) Search(ctx context.Context, q observabilityvo.LogQuery) (observabilityvo.SourcePage, error) {
+	if !contains(q.AuthorizedCategories, observabilityvo.CategoryAuditAdmin) {
+		return observabilityvo.SourcePage{CountAccuracy: "partial"}, nil
+	}
+	auth := strings.TrimSpace(observabilityvo.SourceAuthorization(ctx))
+	if auth == "" || q.AuthorizedTenantID == "" || q.AuthorizedBusinessDomain == "" {
+		return observabilityvo.SourcePage{}, errors.New("execution factory audit source requires caller authorization and trusted scope")
+	}
+	v := url.Values{}
+	v.Set("limit", strconv.Itoa(limit(q.Limit)))
+	setIfPresent(v, "actor_id", q.ActorID)
+	setIfPresent(v, "action", q.Action)
+	setIfPresent(v, "target_type", q.TargetType)
+	setIfPresent(v, "target_id", q.TargetID)
+	if len(q.Outcomes) == 1 {
+		setIfPresent(v, "outcome", q.Outcomes[0])
+	}
+	if q.TimeFrom != nil {
+		v.Set("from", q.TimeFrom.UTC().Format(time.RFC3339Nano))
+	}
+	if q.TimeTo != nil {
+		v.Set("to", q.TimeTo.UTC().Format(time.RFC3339Nano))
+	}
+	if q.PageBefore != nil && !q.PageBefore.EventTimestamp.IsZero() {
+		v.Set("before_time", q.PageBefore.EventTimestamp.UTC().Format(time.RFC3339Nano))
+		v.Set("before_event_id", sourceLogID(q.PageBefore.LogID))
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, c.baseURL+"/api/agent-operator-integration/v1/operation-audits?"+v.Encode(), nil)
+	if err != nil {
+		return observabilityvo.SourcePage{}, err
+	}
+	trustedHeaders(req, auth, q.AuthorizedTenantID, q.AuthorizedBusinessDomain)
+	resp, err := c.http.Do(req)
+	if err != nil {
+		return observabilityvo.SourcePage{}, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return observabilityvo.SourcePage{}, fmt.Errorf("execution factory audit source returned status %d", resp.StatusCode)
+	}
+	var payload struct {
+		Entries []entry `json:"entries"`
+		HasMore bool    `json:"has_more"`
+	}
+	if err := json.NewDecoder(io.LimitReader(resp.Body, 4<<20)).Decode(&payload); err != nil {
+		return observabilityvo.SourcePage{}, err
+	}
+	records := make([]observabilityvo.LogRecord, 0, len(payload.Entries))
+	for _, item := range payload.Entries {
+		records = append(records, project(item))
+	}
+	count := int64(len(records))
+	if payload.HasMore {
+		count++
+	}
+	return observabilityvo.SourcePage{Records: records, Count: count, CountAccuracy: "partial"}, nil
+}
+func (c *Client) Get(ctx context.Context, logID string) (observabilityvo.LogRecord, bool, error) {
+	auth := strings.TrimSpace(observabilityvo.SourceAuthorization(ctx))
+	scope := observabilityvo.SourceAccessScopeFromContext(ctx)
+	if auth == "" || scope.TenantID == "" || scope.BusinessDomain == "" {
+		return observabilityvo.LogRecord{}, false, errors.New("execution factory audit source requires caller authorization and trusted scope")
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, c.baseURL+"/api/agent-operator-integration/v1/operation-audits/"+url.PathEscape(sourceLogID(logID)), nil)
+	if err != nil {
+		return observabilityvo.LogRecord{}, false, err
+	}
+	trustedHeaders(req, auth, scope.TenantID, scope.BusinessDomain)
+	resp, err := c.http.Do(req)
+	if err != nil {
+		return observabilityvo.LogRecord{}, false, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode == http.StatusNotFound {
+		return observabilityvo.LogRecord{}, false, nil
+	}
+	if resp.StatusCode != http.StatusOK {
+		return observabilityvo.LogRecord{}, false, fmt.Errorf("execution factory audit source returned status %d", resp.StatusCode)
+	}
+	var item entry
+	if err := json.NewDecoder(io.LimitReader(resp.Body, 4<<20)).Decode(&item); err != nil {
+		return observabilityvo.LogRecord{}, false, err
+	}
+	return project(item), true, nil
+}
+
+type entry struct {
+	EventID          string    `json:"event_id"`
+	EventTime        time.Time `json:"event_time"`
+	RecordedAt       time.Time `json:"recorded_at"`
+	TenantID         string    `json:"tenant_id"`
+	BusinessDomainID string    `json:"business_domain_id"`
+	ActorID          string    `json:"actor_id"`
+	ActorName        string    `json:"actor_name"`
+	ActorType        string    `json:"actor_type"`
+	AuthMethod       string    `json:"auth_method"`
+	RequestID        string    `json:"request_id"`
+	SourceChannel    string    `json:"source_channel"`
+	Method           string    `json:"method"`
+	Action           string    `json:"action"`
+	TargetType       string    `json:"target_type"`
+	TargetID         string    `json:"target_id"`
+	TargetName       string    `json:"target_name"`
+	Outcome          string    `json:"outcome"`
+	FailureCode      string    `json:"failure_code"`
+	FailureMessage   string    `json:"failure_message"`
+}
+
+func project(e entry) observabilityvo.LogRecord {
+	severity, text := 9, "INFO"
+	if e.Outcome != "success" {
+		severity, text = 17, "ERROR"
+	}
+	return observabilityvo.LogRecord{EventID: e.EventID, EventTime: e.EventTime, RecordedAt: e.RecordedAt, ActorNameSnapshot: first(e.ActorName, e.ActorID), ActorType: first(e.ActorType, "user"), AuthMethod: first(e.AuthMethod, "unknown"), SourceChannel: first(e.SourceChannel, "api"), BusinessModule: "execution_factory", Action: e.Action, TargetType: e.TargetType, TargetID: e.TargetID, TargetNameSnapshot: first(e.TargetName, e.TargetID), FailureCode: e.FailureCode, FailureMessage: e.FailureMessage, SchemaVersion: "1.0", LogID: sourceID + ":" + e.EventID, SourceID: sourceID, SourceLogID: e.EventID, Category: observabilityvo.CategoryAuditAdmin, EventName: "execution_factory.management.changed", EventTimestamp: e.EventTime, ObservedTimestamp: e.RecordedAt, SeverityNumber: severity, SeverityText: text, Outcome: e.Outcome, SafeSummary: strings.TrimSpace(strings.Join([]string{e.Method, e.Action, e.TargetType, first(e.TargetName, e.TargetID)}, " ")), ServiceName: "agent-operator-integration", Environment: "unknown", TenantID: e.TenantID, BusinessDomain: e.BusinessDomainID, ActorID: e.ActorID, EffectiveSubjectID: e.ActorID, RequestID: e.RequestID, IngressPrincipal: "execution-factory", TrustLevel: "trusted", ResourceRef: &observabilityvo.ResourceRef{ResourceType: e.TargetType, ResourceID: e.TargetID}, Attributes: map[string]any{"method": e.Method}}
+}
+func trustedHeaders(r *http.Request, auth, tenant, domain string) {
+	r.Header.Set("Authorization", auth)
+	r.Header.Set("x-tenant-id", tenant)
+	r.Header.Set("x-business-domain", domain)
+}
+func sourceLogID(id string) string { return strings.TrimPrefix(id, sourceID+":") }
+func limit(v int) int {
+	if v <= 0 {
+		return 50
+	}
+	if v > 500 {
+		return 500
+	}
+	return v
+}
+func contains(xs []string, want string) bool {
+	for _, x := range xs {
+		if x == want {
+			return true
+		}
+	}
+	return false
+}
+func first(xs ...string) string {
+	for _, x := range xs {
+		if strings.TrimSpace(x) != "" {
+			return strings.TrimSpace(x)
+		}
+	}
+	return ""
+}
+
+func setIfPresent(values url.Values, name, value string) {
+	if strings.TrimSpace(value) != "" {
+		values.Set(name, strings.TrimSpace(value))
+	}
+}

--- a/bkn-trace/agent-observability/src/drivenadapter/httpaccess/executionfactoryaudit/client_test.go
+++ b/bkn-trace/agent-observability/src/drivenadapter/httpaccess/executionfactoryaudit/client_test.go
@@ -1,0 +1,46 @@
+package executionfactoryaudit
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/openbkn-ai/bkn-foundry/bkn-trace/agent-observability/src/domain/valueobject/observabilityvo"
+)
+
+type roundTripper func(*http.Request) (*http.Response, error)
+
+func (fn roundTripper) RoundTrip(request *http.Request) (*http.Response, error) { return fn(request) }
+
+func TestClientSearchProjectsExecutionFactoryManagementAudit(t *testing.T) {
+	client := New("http://execution-factory", &http.Client{Transport: roundTripper(func(request *http.Request) (*http.Response, error) {
+		if request.URL.Path != "/api/agent-operator-integration/v1/operation-audits" {
+			t.Fatalf("path = %q", request.URL.Path)
+		}
+		if request.Header.Get("Authorization") != "Bearer token" || request.Header.Get("x-tenant-id") != "tenant-a" || request.Header.Get("x-business-domain") != "domain-a" {
+			t.Fatalf("source request did not retain trusted caller context")
+		}
+		query := request.URL.Query()
+		if query.Get("actor_id") != "user-1" || query.Get("action") != "publish" || query.Get("target_type") != "skill" || query.Get("target_id") != "skill-1" || query.Get("outcome") != "success" {
+			t.Fatalf("filters were not forwarded: %s", request.URL)
+		}
+		return &http.Response{StatusCode: http.StatusOK, Body: io.NopCloser(strings.NewReader(`{"entries":[{"event_id":"evt-1","event_time":"2026-08-13T08:00:00Z","recorded_at":"2026-08-13T08:00:01Z","tenant_id":"tenant-a","business_domain_id":"domain-a","actor_id":"user-1","actor_name":"管理员","actor_type":"user","auth_method":"api_key","request_id":"req-1","source_channel":"api","method":"PUT","action":"publish","target_type":"skill","target_id":"skill-1","target_name":"供应链技能","outcome":"success"}]}`)), Header: make(http.Header)}, nil
+	})})
+	from := time.Date(2026, 8, 13, 0, 0, 0, 0, time.UTC)
+	to := from.Add(24 * time.Hour)
+	ctx := observabilityvo.WithSourceAuthorization(context.Background(), "Bearer token")
+	page, err := client.Search(ctx, observabilityvo.LogQuery{AuthorizedCategories: []string{observabilityvo.CategoryAuditAdmin}, AuthorizedTenantID: "tenant-a", AuthorizedBusinessDomain: "domain-a", TimeFrom: &from, TimeTo: &to, ActorID: "user-1", Action: "publish", TargetType: "skill", TargetID: "skill-1", Outcomes: []string{"success"}})
+	if err != nil {
+		t.Fatalf("Search() error = %v", err)
+	}
+	if len(page.Records) != 1 {
+		t.Fatalf("records = %d, want 1", len(page.Records))
+	}
+	record := page.Records[0]
+	if record.BusinessModule != "execution_factory" || record.ActorNameSnapshot != "管理员" || record.TargetNameSnapshot != "供应链技能" || record.LogID != "execution-factory:evt-1" {
+		t.Fatalf("unexpected projected record: %+v", record)
+	}
+}

--- a/bkn-trace/agent-observability/src/drivenadapter/httpaccess/modelmanageraudit/client.go
+++ b/bkn-trace/agent-observability/src/drivenadapter/httpaccess/modelmanageraudit/client.go
@@ -1,0 +1,189 @@
+package modelmanageraudit
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/openbkn-ai/bkn-foundry/bkn-trace/agent-observability/src/domain/valueobject/observabilityvo"
+)
+
+const sourceID = "model-manager"
+
+type Client struct {
+	baseURL string
+	http    *http.Client
+}
+
+func New(url string, c *http.Client) *Client {
+	if c == nil {
+		c = http.DefaultClient
+	}
+	return &Client{baseURL: strings.TrimRight(strings.TrimSpace(url), "/"), http: c}
+}
+func (c *Client) ID() string { return sourceID }
+func (c *Client) Metadata() observabilityvo.SourceStatus {
+	if c.baseURL == "" {
+		return observabilityvo.SourceStatus{SourceID: sourceID, Status: "not_integrated", Reason: "source_not_configured", Reliability: "best_effort", CollectionMethod: "not_integrated", CoveredModules: []string{"model_management"}, CountAccuracy: "partial", Categories: []string{observabilityvo.CategoryAuditAdmin}}
+	}
+	return observabilityvo.SourceStatus{SourceID: sourceID, Status: "degraded", Reason: "management_audit_coverage_in_progress", Reliability: "best_effort", CollectionMethod: "source_adapter", CoveredModules: []string{"model_management"}, CountAccuracy: "partial", Categories: []string{observabilityvo.CategoryAuditAdmin}}
+}
+func (c *Client) Search(ctx context.Context, q observabilityvo.LogQuery) (observabilityvo.SourcePage, error) {
+	if !contains(q.AuthorizedCategories, observabilityvo.CategoryAuditAdmin) {
+		return observabilityvo.SourcePage{CountAccuracy: "partial"}, nil
+	}
+	auth := strings.TrimSpace(observabilityvo.SourceAuthorization(ctx))
+	if auth == "" || q.AuthorizedTenantID == "" || q.AuthorizedBusinessDomain == "" {
+		return observabilityvo.SourcePage{}, errors.New("model manager audit source requires caller authorization and trusted scope")
+	}
+	v := url.Values{}
+	v.Set("limit", strconv.Itoa(limit(q.Limit)))
+	setIfPresent(v, "actor_id", q.ActorID)
+	setIfPresent(v, "action", q.Action)
+	setIfPresent(v, "target_type", q.TargetType)
+	setIfPresent(v, "target_id", q.TargetID)
+	if len(q.Outcomes) == 1 {
+		setIfPresent(v, "outcome", q.Outcomes[0])
+	}
+	if q.TimeFrom != nil {
+		v.Set("from", q.TimeFrom.UTC().Format(time.RFC3339Nano))
+	}
+	if q.TimeTo != nil {
+		v.Set("to", q.TimeTo.UTC().Format(time.RFC3339Nano))
+	}
+	if q.PageBefore != nil && !q.PageBefore.EventTimestamp.IsZero() {
+		v.Set("before_time", q.PageBefore.EventTimestamp.UTC().Format(time.RFC3339Nano))
+		v.Set("before_event_id", strip(q.PageBefore.LogID))
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, c.baseURL+"/api/mf-model-manager/v1/operation-audits?"+v.Encode(), nil)
+	if err != nil {
+		return observabilityvo.SourcePage{}, err
+	}
+	headers(req, auth, q.AuthorizedTenantID, q.AuthorizedBusinessDomain)
+	resp, err := c.http.Do(req)
+	if err != nil {
+		return observabilityvo.SourcePage{}, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return observabilityvo.SourcePage{}, fmt.Errorf("model manager audit source returned status %d", resp.StatusCode)
+	}
+	var p struct {
+		Entries []entry `json:"entries"`
+		HasMore bool    `json:"has_more"`
+	}
+	if err := json.NewDecoder(io.LimitReader(resp.Body, 4<<20)).Decode(&p); err != nil {
+		return observabilityvo.SourcePage{}, err
+	}
+	rs := make([]observabilityvo.LogRecord, 0, len(p.Entries))
+	for _, e := range p.Entries {
+		rs = append(rs, project(e))
+	}
+	n := int64(len(rs))
+	if p.HasMore {
+		n++
+	}
+	return observabilityvo.SourcePage{Records: rs, Count: n, CountAccuracy: "partial"}, nil
+}
+func (c *Client) Get(ctx context.Context, id string) (observabilityvo.LogRecord, bool, error) {
+	auth := strings.TrimSpace(observabilityvo.SourceAuthorization(ctx))
+	s := observabilityvo.SourceAccessScopeFromContext(ctx)
+	if auth == "" || s.TenantID == "" || s.BusinessDomain == "" {
+		return observabilityvo.LogRecord{}, false, errors.New("model manager audit source requires caller authorization and trusted scope")
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, c.baseURL+"/api/mf-model-manager/v1/operation-audits/"+url.PathEscape(strip(id)), nil)
+	if err != nil {
+		return observabilityvo.LogRecord{}, false, err
+	}
+	headers(req, auth, s.TenantID, s.BusinessDomain)
+	resp, err := c.http.Do(req)
+	if err != nil {
+		return observabilityvo.LogRecord{}, false, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode == http.StatusNotFound {
+		return observabilityvo.LogRecord{}, false, nil
+	}
+	if resp.StatusCode != http.StatusOK {
+		return observabilityvo.LogRecord{}, false, fmt.Errorf("model manager audit source returned status %d", resp.StatusCode)
+	}
+	var e entry
+	if err := json.NewDecoder(io.LimitReader(resp.Body, 4<<20)).Decode(&e); err != nil {
+		return observabilityvo.LogRecord{}, false, err
+	}
+	return project(e), true, nil
+}
+
+type entry struct {
+	EventID          string    `json:"event_id"`
+	EventTime        time.Time `json:"event_time"`
+	RecordedAt       time.Time `json:"recorded_at"`
+	TenantID         string    `json:"tenant_id"`
+	BusinessDomainID string    `json:"business_domain_id"`
+	ActorID          string    `json:"actor_id"`
+	ActorName        string    `json:"actor_name"`
+	ActorType        string    `json:"actor_type"`
+	AuthMethod       string    `json:"auth_method"`
+	RequestID        string    `json:"request_id"`
+	SourceChannel    string    `json:"source_channel"`
+	Method           string    `json:"method"`
+	Action           string    `json:"action"`
+	TargetType       string    `json:"target_type"`
+	TargetID         string    `json:"target_id"`
+	TargetName       string    `json:"target_name"`
+	Outcome          string    `json:"outcome"`
+	FailureCode      string    `json:"failure_code"`
+	FailureMessage   string    `json:"failure_message"`
+}
+
+func project(e entry) observabilityvo.LogRecord {
+	sev, text := 9, "INFO"
+	if e.Outcome != "success" {
+		sev, text = 17, "ERROR"
+	}
+	return observabilityvo.LogRecord{EventID: e.EventID, EventTime: e.EventTime, RecordedAt: e.RecordedAt, ActorNameSnapshot: first(e.ActorName, e.ActorID), ActorType: first(e.ActorType, "user"), AuthMethod: first(e.AuthMethod, "unknown"), SourceChannel: first(e.SourceChannel, "api"), BusinessModule: "model_management", Action: e.Action, TargetType: e.TargetType, TargetID: e.TargetID, TargetNameSnapshot: first(e.TargetName, e.TargetID), FailureCode: e.FailureCode, FailureMessage: e.FailureMessage, SchemaVersion: "1.0", LogID: sourceID + ":" + e.EventID, SourceID: sourceID, SourceLogID: e.EventID, Category: observabilityvo.CategoryAuditAdmin, EventName: "model_management.changed", EventTimestamp: e.EventTime, ObservedTimestamp: e.RecordedAt, SeverityNumber: sev, SeverityText: text, Outcome: e.Outcome, SafeSummary: strings.TrimSpace(strings.Join([]string{e.Method, e.Action, e.TargetType, first(e.TargetName, e.TargetID)}, " ")), ServiceName: "mf-model-manager", Environment: "unknown", TenantID: e.TenantID, BusinessDomain: e.BusinessDomainID, ActorID: e.ActorID, EffectiveSubjectID: e.ActorID, RequestID: e.RequestID, IngressPrincipal: "model-manager", TrustLevel: "trusted", ResourceRef: &observabilityvo.ResourceRef{ResourceType: e.TargetType, ResourceID: e.TargetID}, Attributes: map[string]any{"method": e.Method}}
+}
+func headers(r *http.Request, a, t, d string) {
+	r.Header.Set("Authorization", a)
+	r.Header.Set("x-tenant-id", t)
+	r.Header.Set("x-business-domain", d)
+}
+func strip(id string) string { return strings.TrimPrefix(id, sourceID+":") }
+func limit(v int) int {
+	if v <= 0 {
+		return 50
+	}
+	if v > 500 {
+		return 500
+	}
+	return v
+}
+func contains(xs []string, w string) bool {
+	for _, x := range xs {
+		if x == w {
+			return true
+		}
+	}
+	return false
+}
+func first(xs ...string) string {
+	for _, x := range xs {
+		if strings.TrimSpace(x) != "" {
+			return strings.TrimSpace(x)
+		}
+	}
+	return ""
+}
+
+func setIfPresent(values url.Values, name, value string) {
+	if strings.TrimSpace(value) != "" {
+		values.Set(name, strings.TrimSpace(value))
+	}
+}

--- a/bkn-trace/agent-observability/src/drivenadapter/httpaccess/modelmanageraudit/client_test.go
+++ b/bkn-trace/agent-observability/src/drivenadapter/httpaccess/modelmanageraudit/client_test.go
@@ -1,0 +1,46 @@
+package modelmanageraudit
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/openbkn-ai/bkn-foundry/bkn-trace/agent-observability/src/domain/valueobject/observabilityvo"
+)
+
+type roundTripper func(*http.Request) (*http.Response, error)
+
+func (fn roundTripper) RoundTrip(request *http.Request) (*http.Response, error) { return fn(request) }
+
+func TestClientSearchProjectsModelManagementAudit(t *testing.T) {
+	client := New("http://model-manager", &http.Client{Transport: roundTripper(func(request *http.Request) (*http.Response, error) {
+		if request.URL.Path != "/api/mf-model-manager/v1/operation-audits" {
+			t.Fatalf("path = %q", request.URL.Path)
+		}
+		if request.Header.Get("Authorization") != "Bearer token" || request.Header.Get("x-tenant-id") != "tenant-a" || request.Header.Get("x-business-domain") != "domain-a" {
+			t.Fatalf("source request did not retain trusted caller context")
+		}
+		query := request.URL.Query()
+		if query.Get("actor_id") != "user-1" || query.Get("action") != "set_default" || query.Get("target_type") != "llm_model" || query.Get("target_id") != "model-1" || query.Get("outcome") != "success" {
+			t.Fatalf("filters were not forwarded: %s", request.URL)
+		}
+		return &http.Response{StatusCode: http.StatusOK, Body: io.NopCloser(strings.NewReader(`{"entries":[{"event_id":"evt-1","event_time":"2026-08-13T08:00:00Z","recorded_at":"2026-08-13T08:00:01Z","tenant_id":"tenant-a","business_domain_id":"domain-a","actor_id":"user-1","actor_name":"管理员","actor_type":"user","auth_method":"oauth","request_id":"req-1","source_channel":"api","method":"POST","action":"set_default","target_type":"llm_model","target_id":"model-1","target_name":"默认模型","outcome":"success"}]}`)), Header: make(http.Header)}, nil
+	})})
+	from := time.Date(2026, 8, 13, 0, 0, 0, 0, time.UTC)
+	to := from.Add(24 * time.Hour)
+	ctx := observabilityvo.WithSourceAuthorization(context.Background(), "Bearer token")
+	page, err := client.Search(ctx, observabilityvo.LogQuery{AuthorizedCategories: []string{observabilityvo.CategoryAuditAdmin}, AuthorizedTenantID: "tenant-a", AuthorizedBusinessDomain: "domain-a", TimeFrom: &from, TimeTo: &to, ActorID: "user-1", Action: "set_default", TargetType: "llm_model", TargetID: "model-1", Outcomes: []string{"success"}})
+	if err != nil {
+		t.Fatalf("Search() error = %v", err)
+	}
+	if len(page.Records) != 1 {
+		t.Fatalf("records = %d, want 1", len(page.Records))
+	}
+	record := page.Records[0]
+	if record.BusinessModule != "model_management" || record.ActorNameSnapshot != "管理员" || record.TargetNameSnapshot != "默认模型" || record.LogID != "model-manager:evt-1" {
+		t.Fatalf("unexpected projected record: %+v", record)
+	}
+}

--- a/bkn-trace/agent-observability/src/drivenadapter/httpaccess/vegaaudit/client.go
+++ b/bkn-trace/agent-observability/src/drivenadapter/httpaccess/vegaaudit/client.go
@@ -1,0 +1,193 @@
+package vegaaudit
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/openbkn-ai/bkn-foundry/bkn-trace/agent-observability/src/domain/valueobject/observabilityvo"
+)
+
+const sourceID = "vega"
+
+type Client struct {
+	baseURL string
+	http    *http.Client
+}
+
+func New(baseURL string, httpClient *http.Client) *Client {
+	if httpClient == nil {
+		httpClient = http.DefaultClient
+	}
+	return &Client{baseURL: strings.TrimRight(strings.TrimSpace(baseURL), "/"), http: httpClient}
+}
+func (client *Client) ID() string { return sourceID }
+func (client *Client) Metadata() observabilityvo.SourceStatus {
+	if client.baseURL == "" {
+		return observabilityvo.SourceStatus{SourceID: sourceID, Status: "not_integrated", Reason: "source_not_configured", Reliability: "best_effort", CollectionMethod: "not_integrated", CoveredModules: []string{"data_resource_knowledge_network"}, CountAccuracy: "partial", Categories: []string{observabilityvo.CategoryAuditAdmin}}
+	}
+	return observabilityvo.SourceStatus{SourceID: sourceID, Status: "degraded", Reason: "management_audit_coverage_in_progress", Reliability: "best_effort", CollectionMethod: "source_adapter", CoveredModules: []string{"data_resource_knowledge_network"}, CountAccuracy: "partial", Categories: []string{observabilityvo.CategoryAuditAdmin}}
+}
+
+func (client *Client) Search(ctx context.Context, query observabilityvo.LogQuery) (observabilityvo.SourcePage, error) {
+	if !contains(query.AuthorizedCategories, observabilityvo.CategoryAuditAdmin) {
+		return observabilityvo.SourcePage{CountAccuracy: "partial"}, nil
+	}
+	authorization := strings.TrimSpace(observabilityvo.SourceAuthorization(ctx))
+	if authorization == "" || query.AuthorizedTenantID == "" || query.AuthorizedBusinessDomain == "" {
+		return observabilityvo.SourcePage{}, errors.New("Vega audit source requires caller authorization and trusted scope")
+	}
+	parameters := url.Values{}
+	parameters.Set("limit", strconv.Itoa(normalizedLimit(query.Limit)))
+	setIfPresent(parameters, "actor_id", query.ActorID)
+	setIfPresent(parameters, "action", query.Action)
+	setIfPresent(parameters, "target_type", query.TargetType)
+	setIfPresent(parameters, "target_id", query.TargetID)
+	if len(query.Outcomes) == 1 {
+		setIfPresent(parameters, "outcome", query.Outcomes[0])
+	}
+	if query.TimeFrom != nil {
+		parameters.Set("from", query.TimeFrom.UTC().Format(time.RFC3339Nano))
+	}
+	if query.TimeTo != nil {
+		parameters.Set("to", query.TimeTo.UTC().Format(time.RFC3339Nano))
+	}
+	if query.PageBefore != nil && !query.PageBefore.EventTimestamp.IsZero() {
+		parameters.Set("before_time", query.PageBefore.EventTimestamp.UTC().Format(time.RFC3339Nano))
+		parameters.Set("before_event_id", sourceLogID(query.PageBefore.LogID))
+	}
+	request, err := http.NewRequestWithContext(ctx, http.MethodGet, client.baseURL+"/api/vega-backend/v1/operation-audits?"+parameters.Encode(), nil)
+	if err != nil {
+		return observabilityvo.SourcePage{}, err
+	}
+	setTrustedHeaders(request, authorization, query.AuthorizedTenantID, query.AuthorizedBusinessDomain)
+	response, err := client.http.Do(request)
+	if err != nil {
+		return observabilityvo.SourcePage{}, err
+	}
+	defer response.Body.Close()
+	if response.StatusCode != http.StatusOK {
+		_, _ = io.Copy(io.Discard, io.LimitReader(response.Body, 4<<20))
+		return observabilityvo.SourcePage{}, fmt.Errorf("Vega audit source returned status %d", response.StatusCode)
+	}
+	var payload struct {
+		Entries []auditEntry `json:"entries"`
+		HasMore bool         `json:"has_more"`
+	}
+	if err := json.NewDecoder(io.LimitReader(response.Body, 4<<20)).Decode(&payload); err != nil {
+		return observabilityvo.SourcePage{}, fmt.Errorf("decode Vega audit response: %w", err)
+	}
+	records := make([]observabilityvo.LogRecord, 0, len(payload.Entries))
+	for _, entry := range payload.Entries {
+		records = append(records, project(entry))
+	}
+	count := int64(len(records))
+	if payload.HasMore {
+		count++
+	}
+	return observabilityvo.SourcePage{Records: records, Count: count, CountAccuracy: "partial"}, nil
+}
+
+func (client *Client) Get(ctx context.Context, logID string) (observabilityvo.LogRecord, bool, error) {
+	authorization := strings.TrimSpace(observabilityvo.SourceAuthorization(ctx))
+	scope := observabilityvo.SourceAccessScopeFromContext(ctx)
+	if authorization == "" || scope.TenantID == "" || scope.BusinessDomain == "" {
+		return observabilityvo.LogRecord{}, false, errors.New("Vega audit source requires caller authorization and trusted scope")
+	}
+	request, err := http.NewRequestWithContext(ctx, http.MethodGet, client.baseURL+"/api/vega-backend/v1/operation-audits/"+url.PathEscape(sourceLogID(logID)), nil)
+	if err != nil {
+		return observabilityvo.LogRecord{}, false, err
+	}
+	setTrustedHeaders(request, authorization, scope.TenantID, scope.BusinessDomain)
+	response, err := client.http.Do(request)
+	if err != nil {
+		return observabilityvo.LogRecord{}, false, err
+	}
+	defer response.Body.Close()
+	if response.StatusCode == http.StatusNotFound {
+		return observabilityvo.LogRecord{}, false, nil
+	}
+	if response.StatusCode != http.StatusOK {
+		return observabilityvo.LogRecord{}, false, fmt.Errorf("Vega audit source returned status %d", response.StatusCode)
+	}
+	var entry auditEntry
+	if err := json.NewDecoder(io.LimitReader(response.Body, 4<<20)).Decode(&entry); err != nil {
+		return observabilityvo.LogRecord{}, false, err
+	}
+	return project(entry), true, nil
+}
+
+type auditEntry struct {
+	EventID          string    `json:"event_id"`
+	EventTime        time.Time `json:"event_time"`
+	RecordedAt       time.Time `json:"recorded_at"`
+	TenantID         string    `json:"tenant_id"`
+	BusinessDomainID string    `json:"business_domain_id"`
+	ActorID          string    `json:"actor_id"`
+	ActorName        string    `json:"actor_name"`
+	ActorType        string    `json:"actor_type"`
+	AuthMethod       string    `json:"auth_method"`
+	RequestID        string    `json:"request_id"`
+	SourceChannel    string    `json:"source_channel"`
+	Method           string    `json:"method"`
+	Action           string    `json:"action"`
+	TargetType       string    `json:"target_type"`
+	TargetID         string    `json:"target_id"`
+	TargetName       string    `json:"target_name"`
+	Outcome          string    `json:"outcome"`
+	FailureCode      string    `json:"failure_code"`
+	FailureMessage   string    `json:"failure_message"`
+	SchemaVersion    string    `json:"schema_version"`
+}
+
+func project(entry auditEntry) observabilityvo.LogRecord {
+	severityNumber, severityText := 9, "INFO"
+	if entry.Outcome != "success" {
+		severityNumber, severityText = 17, "ERROR"
+	}
+	return observabilityvo.LogRecord{EventID: entry.EventID, EventTime: entry.EventTime, RecordedAt: entry.RecordedAt, ActorNameSnapshot: firstNonEmpty(entry.ActorName, entry.ActorID), ActorType: firstNonEmpty(entry.ActorType, "user"), AuthMethod: firstNonEmpty(entry.AuthMethod, "unknown"), SourceChannel: firstNonEmpty(entry.SourceChannel, "api"), BusinessModule: "data_resource_knowledge_network", Action: entry.Action, TargetType: entry.TargetType, TargetID: entry.TargetID, TargetNameSnapshot: firstNonEmpty(entry.TargetName, entry.TargetID), FailureCode: entry.FailureCode, FailureMessage: entry.FailureMessage, SchemaVersion: firstNonEmpty(entry.SchemaVersion, "1.0"), LogID: sourceID + ":" + entry.EventID, SourceID: sourceID, SourceLogID: entry.EventID, Category: observabilityvo.CategoryAuditAdmin, EventName: "resource_config.changed", EventTimestamp: entry.EventTime, ObservedTimestamp: entry.RecordedAt, SeverityNumber: severityNumber, SeverityText: severityText, Outcome: entry.Outcome, SafeSummary: strings.TrimSpace(strings.Join([]string{entry.Method, entry.Action, entry.TargetType, firstNonEmpty(entry.TargetName, entry.TargetID)}, " ")), ServiceName: "vega-backend", Environment: "unknown", TenantID: entry.TenantID, BusinessDomain: entry.BusinessDomainID, ActorID: entry.ActorID, EffectiveSubjectID: entry.ActorID, RequestID: entry.RequestID, IngressPrincipal: "vega", TrustLevel: "trusted", ResourceRef: &observabilityvo.ResourceRef{ResourceType: entry.TargetType, ResourceID: entry.TargetID}, Attributes: map[string]any{"method": entry.Method}}
+}
+func setTrustedHeaders(request *http.Request, authorization, tenantID, businessDomain string) {
+	request.Header.Set("Authorization", authorization)
+	request.Header.Set("x-tenant-id", tenantID)
+	request.Header.Set("x-business-domain", businessDomain)
+}
+func sourceLogID(logID string) string { return strings.TrimPrefix(logID, sourceID+":") }
+func normalizedLimit(value int) int {
+	if value <= 0 {
+		return 50
+	}
+	if value > 500 {
+		return 500
+	}
+	return value
+}
+func contains(values []string, wanted string) bool {
+	for _, value := range values {
+		if value == wanted {
+			return true
+		}
+	}
+	return false
+}
+func firstNonEmpty(values ...string) string {
+	for _, value := range values {
+		if strings.TrimSpace(value) != "" {
+			return strings.TrimSpace(value)
+		}
+	}
+	return ""
+}
+
+func setIfPresent(parameters url.Values, name, value string) {
+	if strings.TrimSpace(value) != "" {
+		parameters.Set(name, strings.TrimSpace(value))
+	}
+}

--- a/bkn-trace/agent-observability/src/drivenadapter/httpaccess/vegaaudit/client_test.go
+++ b/bkn-trace/agent-observability/src/drivenadapter/httpaccess/vegaaudit/client_test.go
@@ -1,0 +1,43 @@
+package vegaaudit
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/openbkn-ai/bkn-foundry/bkn-trace/agent-observability/src/domain/valueobject/observabilityvo"
+)
+
+type roundTripper func(*http.Request) (*http.Response, error)
+
+func (fn roundTripper) RoundTrip(request *http.Request) (*http.Response, error) { return fn(request) }
+
+func TestClientSearchProjectsVegaManagementAudit(t *testing.T) {
+	client := New("http://vega", &http.Client{Transport: roundTripper(func(request *http.Request) (*http.Response, error) {
+		if request.Header.Get("Authorization") != "Bearer token" || request.Header.Get("x-tenant-id") != "tenant-a" || request.Header.Get("x-business-domain") != "domain-a" {
+			t.Fatalf("source request did not retain trusted caller context")
+		}
+		query := request.URL.Query()
+		if query.Get("actor_id") != "user-1" || query.Get("action") != "create" || query.Get("target_type") != "catalog" || query.Get("target_id") != "catalog-1" || query.Get("outcome") != "success" {
+			t.Fatalf("filters were not forwarded: %s", request.URL)
+		}
+		return &http.Response{StatusCode: http.StatusOK, Body: io.NopCloser(strings.NewReader(`{"entries":[{"event_id":"evt-1","event_time":"2026-08-13T08:00:00Z","recorded_at":"2026-08-13T08:00:01Z","tenant_id":"tenant-a","business_domain_id":"domain-a","actor_id":"user-1","actor_name":"管理员","actor_type":"user","auth_method":"oauth","request_id":"req-1","source_channel":"api","method":"POST","action":"create","target_type":"catalog","target_id":"catalog-1","target_name":"供应链数据源","outcome":"success","schema_version":"1.0"}]}`)), Header: make(http.Header)}, nil
+	})})
+	from := time.Date(2026, 8, 13, 0, 0, 0, 0, time.UTC)
+	to := from.Add(24 * time.Hour)
+	ctx := observabilityvo.WithSourceAuthorization(context.Background(), "Bearer token")
+	page, err := client.Search(ctx, observabilityvo.LogQuery{AuthorizedCategories: []string{observabilityvo.CategoryAuditAdmin}, AuthorizedTenantID: "tenant-a", AuthorizedBusinessDomain: "domain-a", TimeFrom: &from, TimeTo: &to, ActorID: "user-1", Action: "create", TargetType: "catalog", TargetID: "catalog-1", Outcomes: []string{"success"}})
+	if err != nil {
+		t.Fatalf("Search() error = %v", err)
+	}
+	if len(page.Records) != 1 {
+		t.Fatalf("records = %d, want 1", len(page.Records))
+	}
+	record := page.Records[0]
+	if record.BusinessModule != "data_resource_knowledge_network" || record.ActorNameSnapshot != "管理员" || record.TargetNameSnapshot != "供应链数据源" || record.LogID != "vega:evt-1" {
+		t.Fatalf("unexpected projected record: %+v", record)
+	}
+}

--- a/data-migrator/config.monorepo.yaml
+++ b/data-migrator/config.monorepo.yaml
@@ -49,7 +49,7 @@ services:
     path: migrations/vega-backend
     # check_from: "1.0.0"  # 可选，从指定版本开始检测，不配置则检测所有版本
   agent-operator-integration:
-    path: migrations/agent-operator-integratio
+    path: migrations/agent-operator-integration
     # check_from: "1.0.0"  # 可选，从指定版本开始检测，不配置则检测所有版本
 
   # ---- infra ----

--- a/infra/mf-model-manager/app/routers/__init__.py
+++ b/infra/mf-model-manager/app/routers/__init__.py
@@ -1,4 +1,4 @@
-from app.routers import llm_router, open_api_json, small_model_router, private_route, prompt_router, model_quota_router
+from app.routers import llm_router, open_api_json, small_model_router, private_route, prompt_router, model_quota_router, operation_audit_router
 from fastapi.exceptions import RequestValidationError
 from fastapi.responses import JSONResponse
 from fastapi import Request
@@ -48,6 +48,12 @@ def router_init(app):
     )
     app.include_router(
         model_quota_router.model_quota_router,
+        prefix=api_version_public_v1,
+        tags=["Factory"],
+        responses={404: {"description": "Not found"}},
+    )
+    app.include_router(
+        operation_audit_router.operation_audit_router,
         prefix=api_version_public_v1,
         tags=["Factory"],
         responses={404: {"description": "Not found"}},

--- a/infra/mf-model-manager/app/routers/operation_audit_router.py
+++ b/infra/mf-model-manager/app/routers/operation_audit_router.py
@@ -1,0 +1,61 @@
+import asyncio
+import os
+from datetime import datetime
+
+import aiohttp
+from fastapi import APIRouter, Header, HTTPException, Query, Request
+
+from app.mydb.pymysql_pool import PymysqlPool
+
+operation_audit_router = APIRouter()
+_MAX_RANGE_SECONDS = 30 * 24 * 60 * 60
+
+async def _require_audit_reader(request: Request):
+    token = request.headers.get("authorization", "")
+    safe = os.getenv("BKN_SAFE_URL", "").rstrip("/")
+    if not token or not safe:
+        raise HTTPException(403, "operation audit access denied")
+    async with aiohttp.ClientSession(timeout=aiohttp.ClientTimeout(total=3)) as session:
+        async with session.get(safe + "/api/safe/v1/me", headers={"Authorization": token}) as response:
+            if response.status != 200:
+                raise HTTPException(403, "operation audit access denied")
+            me = await response.json()
+    if not me.get("enabled") or not set(me.get("roles", [])) & {"super_admin", "admin", "audit"}:
+        raise HTTPException(403, "operation audit access denied")
+
+def _list(tenant, domain, from_time, to_time, limit, before_time, before_event_id, actor_id, action, target_type, target_id, outcome):
+    pool=PymysqlPool.get_pool(); connection=pool.connection(); cursor=connection.cursor()
+    try:
+        sql="SELECT event_id,event_time,recorded_at,tenant_id,business_domain_id,actor_id,actor_name,actor_type,auth_method,request_id,source_channel,method,action,target_type,target_id,target_name,outcome,failure_code,failure_message FROM t_model_manager_operation_audit WHERE tenant_id=%s AND business_domain_id=%s AND event_time>=%s AND event_time<%s"
+        args=[tenant,domain,from_time,to_time]
+        for column, value in (("actor_id", actor_id), ("action", action), ("target_type", target_type), ("target_id", target_id), ("outcome", outcome)):
+            if value:
+                sql += " AND " + column + "=%s"; args.append(value)
+        if before_time:
+            sql+=" AND (event_time<%s OR (event_time=%s AND event_id>%s))";args += [before_time,before_time,before_event_id]
+        sql += " ORDER BY event_time DESC,event_id ASC LIMIT %s";args.append(limit+1);cursor.execute(sql,args);rows=cursor.fetchall();return rows[:limit],len(rows)>limit
+    finally: cursor.close();connection.close()
+
+def _get(event_id,tenant,domain):
+    pool=PymysqlPool.get_pool(); connection=pool.connection(); cursor=connection.cursor()
+    try:
+        cursor.execute("SELECT event_id,event_time,recorded_at,tenant_id,business_domain_id,actor_id,actor_name,actor_type,auth_method,request_id,source_channel,method,action,target_type,target_id,target_name,outcome,failure_code,failure_message FROM t_model_manager_operation_audit WHERE event_id=%s AND tenant_id=%s AND business_domain_id=%s",[event_id,tenant,domain]);return cursor.fetchone()
+    finally: cursor.close();connection.close()
+
+def _time(value):
+    try: return datetime.fromisoformat(value.replace("Z","+00:00"))
+    except ValueError: raise HTTPException(400,"from/to must be RFC3339")
+
+@operation_audit_router.get("/operation-audits")
+async def list_operation_audits(request: Request, from_: str = Query(alias="from"), to: str = Query(), limit: int = Query(50, ge=1, le=500), before_time: str = Query(""), before_event_id: str = Query(""), actor_id: str = Query(""), action: str = Query(""), target_type: str = Query(""), target_id: str = Query(""), outcome: str = Query(""), x_tenant_id: str = Header(alias="x-tenant-id"), x_business_domain: str = Header(alias="x-business-domain")):
+    await _require_audit_reader(request); start,end=_time(from_),_time(to)
+    if start>=end or (end-start).total_seconds()>_MAX_RANGE_SECONDS: raise HTTPException(400,"from/to must be a valid RFC3339 range of at most 30 days")
+    before=_time(before_time) if before_time else None
+    rows,more=await asyncio.to_thread(_list,x_tenant_id,x_business_domain,start,end,limit,before,before_event_id,actor_id.strip(),action.strip(),target_type.strip(),target_id.strip(),outcome.strip())
+    return {"entries":rows,"has_more":more}
+
+@operation_audit_router.get("/operation-audits/{event_id}")
+async def get_operation_audit(event_id: str, request: Request, x_tenant_id: str = Header(alias="x-tenant-id"), x_business_domain: str = Header(alias="x-business-domain")):
+    await _require_audit_reader(request); row=await asyncio.to_thread(_get,event_id,x_tenant_id,x_business_domain)
+    if not row: raise HTTPException(404,"operation audit event not found")
+    return row

--- a/infra/mf-model-manager/app/test/test_operation_audit.py
+++ b/infra/mf-model-manager/app/test/test_operation_audit.py
@@ -1,0 +1,21 @@
+import unittest
+
+from app.utils import operation_audit
+
+
+class TestOperationAuditRequestID(unittest.TestCase):
+    def test_generates_request_id_when_gateway_did_not_provide_one(self):
+        request_id, generated = operation_audit.operation_audit_request_id({})
+
+        self.assertTrue(generated)
+        self.assertTrue(request_id.startswith("req_"))
+
+    def test_preserves_gateway_request_id(self):
+        request_id, generated = operation_audit.operation_audit_request_id({"bkn-request-id": "req_gateway"})
+
+        self.assertEqual(request_id, "req_gateway")
+        self.assertFalse(generated)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/infra/mf-model-manager/app/utils/app_utils.py
+++ b/infra/mf-model-manager/app/utils/app_utils.py
@@ -13,6 +13,7 @@ from app.routers import router_init
 from app.utils.comment_utils import write_log
 from app.utils.model_monitor import vllm_monitor_task, delete_monitor_data_task, delete_model_quota_data_task
 from app.utils.observability.observability import init_observability, shutdown_observability
+from app.utils.operation_audit import operation_audit_middleware
 
 # 添加APScheduler相关导入
 from apscheduler.schedulers.background import BackgroundScheduler
@@ -134,6 +135,10 @@ def create_app():
     # 添加请求体大小检查中间件
     # app.add_middleware(RequestSizeMiddleware)
     # 添加鉴权中间件
+    # Starlette runs the most recently added middleware first.  Authentication
+    # must therefore wrap audit collection so audit reads the verified actor
+    # injected by auth_middleware after the handler returns.
+    app.add_middleware(BaseHTTPMiddleware, dispatch=operation_audit_middleware)
     app.add_middleware(BaseHTTPMiddleware, dispatch=auth_middleware)
 
     # 初始化日志

--- a/infra/mf-model-manager/app/utils/operation_audit.py
+++ b/infra/mf-model-manager/app/utils/operation_audit.py
@@ -1,0 +1,109 @@
+"""Bounded model-management audit facts; inference and model tests stay Trace-only."""
+import asyncio
+import hashlib
+import json
+import secrets
+from datetime import datetime, timezone
+
+from app.commons.get_user_info import get_username_by_ids
+from app.mydb.pymysql_pool import PymysqlPool
+
+_RULES = {
+    ("POST", "/api/mf-model-manager/v1/llm/add"): ("create", "llm_model"),
+    ("POST", "/api/mf-model-manager/v1/llm/edit"): ("update", "llm_model"),
+    ("POST", "/api/mf-model-manager/v1/llm/delete"): ("delete", "llm_model"),
+    ("POST", "/api/mf-model-manager/v1/llm/default/edit"): ("set_default", "llm_model"),
+    ("POST", "/api/mf-model-manager/v1/small-model/add"): ("create", "small_model"),
+    ("POST", "/api/mf-model-manager/v1/small-model/edit"): ("update", "small_model"),
+    ("POST", "/api/mf-model-manager/v1/small-model/delete"): ("delete", "small_model"),
+    ("POST", "/api/mf-model-manager/v1/small-model/set-default"): ("set_default", "small_model"),
+    ("POST", "/api/mf-model-manager/v1/model-quota"): ("create", "model_quota"),
+    ("POST", "/api/mf-model-manager/v1/model-quota/{conf_id}"): ("update", "model_quota"),
+    ("POST", "/api/mf-model-manager/v1/user-quota"): ("create", "user_model_quota"),
+    ("POST", "/api/mf-model-manager/v1/user-quota/delete"): ("delete", "user_model_quota"),
+}
+
+def _rule(request):
+    path = request.url.path
+    if path.startswith("/api/mf-model-manager/v1/model-quota/"):
+        path = "/api/mf-model-manager/v1/model-quota/{conf_id}"
+    return _RULES.get((request.method, path))
+
+def _event_id(tenant, request_id, method, path):
+    return "evt_" + hashlib.sha256("\n".join((tenant, request_id, method, path)).encode()).hexdigest()
+
+
+def operation_audit_request_id(headers):
+    """Keep the caller's request ID or generate one at the source boundary."""
+    request_id = (headers.get("bkn-request-id") or headers.get("x-request-id") or "").strip()
+    if request_id:
+        return request_id, False
+    return "req_" + secrets.token_hex(16), True
+
+def _write(entry):
+    pool = PymysqlPool.get_pool()
+    connection = pool.connection()
+    cursor = connection.cursor()
+    try:
+        cursor.execute("""INSERT INTO t_model_manager_operation_audit
+        (event_id,event_time,recorded_at,tenant_id,business_domain_id,actor_id,actor_name,actor_type,auth_method,request_id,source_channel,method,action,target_type,target_id,target_name,outcome,failure_code,failure_message)
+        VALUES (%(event_id)s,%(event_time)s,%(recorded_at)s,%(tenant_id)s,%(business_domain_id)s,%(actor_id)s,%(actor_name)s,%(actor_type)s,%(auth_method)s,%(request_id)s,%(source_channel)s,%(method)s,%(action)s,%(target_type)s,%(target_id)s,%(target_name)s,%(outcome)s,%(failure_code)s,%(failure_message)s)
+        ON DUPLICATE KEY UPDATE event_id=VALUES(event_id)""", entry)
+        connection.commit()
+    finally:
+        cursor.close(); connection.close()
+
+
+async def _actor_name(actor_id, headers):
+    """Persist the display-name snapshot when the authenticated source can resolve it.
+
+    The identifier remains the authoritative actor key.  A directory lookup failure
+    must not turn a successful management request into a failure, so the stable ID
+    is the explicit fallback rather than a fabricated display name.
+    """
+    explicit = headers.get("x-account-name", "").strip()
+    if explicit:
+        return explicit
+    try:
+        return (await get_username_by_ids([actor_id])).get(actor_id, actor_id)
+    except Exception:
+        return actor_id
+
+async def operation_audit_middleware(request, call_next):
+    rule = _rule(request)
+    if not rule:
+        return await call_next(request)
+    body = await request.body()
+    response = await call_next(request)
+    tenant = request.headers.get("x-tenant-id", "").strip()
+    domain = request.headers.get("x-business-domain", "").strip()
+    actor = request.headers.get("x-account-id", "").strip()
+    request_id, generated_request_id = operation_audit_request_id(request.headers)
+    if generated_request_id:
+        response.headers["bkn-request-id"] = request_id
+    # A complete source fact requires the trusted scope and verified actor.
+    if not tenant or not domain or not actor or not request_id:
+        return response
+    try:
+        payload = json.loads(body.decode() or "{}") if len(body) <= 65536 else {}
+    except (ValueError, UnicodeDecodeError):
+        payload = {}
+    target_id = next((str(payload[key]) for key in ("model_id", "id", "conf_id") if payload.get(key)), "")
+    if not target_id and request.path_params:
+        target_id = next(iter(request.path_params.values()), "")
+    if not target_id:
+        target_id = f"{rule[1]}:{request_id}"
+    target_name = next((str(payload[key]) for key in ("model_name", "name", "display_name") if payload.get(key)), target_id)
+    outcome = "success" if response.status_code < 400 else ("denied" if response.status_code in (401,403) else "failure")
+    now = datetime.now(timezone.utc)
+    entry = {"event_id": _event_id(tenant, request_id, request.method, request.url.path), "event_time": now, "recorded_at": now,
+             "tenant_id": tenant, "business_domain_id": domain, "actor_id": actor, "actor_name": await _actor_name(actor, request.headers),
+             "actor_type": request.headers.get("x-account-type", "user"), "auth_method": "api_key" if request.headers.get("authorization", "").removeprefix("Bearer ").startswith("bak_") else "oauth",
+             "request_id": request_id, "source_channel": "api", "method": request.method, "action": rule[0], "target_type": rule[1], "target_id": target_id, "target_name": target_name,
+             "outcome": outcome, "failure_code": "" if outcome == "success" else f"http_{response.status_code}", "failure_message": "" if outcome == "success" else "management request failed"}
+    try:
+        await asyncio.to_thread(_write, entry)
+    except Exception:
+        # Never overturn a completed management request; pipeline health is monitored separately.
+        pass
+    return response

--- a/migrations/agent-operator-integration/mariadb/0.1.4/01-operation-audit.sql
+++ b/migrations/agent-operator-integration/mariadb/0.1.4/01-operation-audit.sql
@@ -1,0 +1,29 @@
+-- Execution Factory management-operation audit facts.
+-- Runtime tool/MCP/function/skill execution stays in BKN Trace, not this table.
+USE openbkn;
+
+CREATE TABLE IF NOT EXISTS `t_execution_factory_operation_audit` (
+  `event_id` varchar(80) NOT NULL,
+  `event_time` datetime(6) NOT NULL,
+  `recorded_at` datetime(6) NOT NULL,
+  `tenant_id` varchar(128) NOT NULL,
+  `business_domain_id` varchar(128) NOT NULL,
+  `actor_id` varchar(128) NOT NULL,
+  `actor_name` varchar(256) NOT NULL,
+  `actor_type` varchar(32) NOT NULL,
+  `auth_method` varchar(32) NOT NULL,
+  `request_id` varchar(160) NOT NULL,
+  `source_channel` varchar(32) NOT NULL,
+  `method` varchar(16) NOT NULL,
+  `action` varchar(64) NOT NULL,
+  `target_type` varchar(64) NOT NULL,
+  `target_id` varchar(1024) NOT NULL,
+  `target_name` varchar(1024) NOT NULL,
+  `outcome` varchar(32) NOT NULL,
+  `failure_code` varchar(128) NOT NULL DEFAULT '',
+  `failure_message` varchar(512) NOT NULL DEFAULT '',
+  PRIMARY KEY (`event_id`),
+  KEY `idx_execution_audit_scope_time` (`tenant_id`,`business_domain_id`,`event_time`),
+  KEY `idx_execution_audit_request` (`request_id`),
+  KEY `idx_execution_audit_actor` (`actor_id`,`event_time`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COMMENT='Execution Factory management operation audit';

--- a/migrations/agent-operator-integration/mariadb/0.1.4/init.sql
+++ b/migrations/agent-operator-integration/mariadb/0.1.4/init.sql
@@ -1,0 +1,463 @@
+-- Copyright 2026 openbkn.ai
+--
+-- Licensed under the Apache License, Version 2.0.
+-- See the LICENSE file in the project root for details.
+
+USE openbkn;
+
+CREATE TABLE IF NOT EXISTS `t_metadata_api` (
+    `f_id` bigint AUTO_INCREMENT NOT NULL COMMENT '自增主键',
+    `f_summary` varchar(256) NOT NULL COMMENT '摘要', -- 接口摘要 (唯一索引)
+    `f_version` varchar(40) NOT NULL COMMENT 'UUID',
+    `f_svc_url` text NOT NULL COMMENT '地址', -- 编辑后生成新的版本
+    `f_description` text COMMENT '描述', -- 单个接口描述（详情）
+    `f_path` text NOT NULL COMMENT 'API路径',
+    `f_method` varchar(50) NOT NULL COMMENT '请求方法',
+    `f_api_spec` longtext DEFAULT NULL COMMENT 'API内容',
+    `f_create_user` varchar(50) NOT NULL COMMENT '创建者',
+    `f_update_user` varchar(50) NOT NULL COMMENT '编辑者',
+    `f_create_time` bigint(20) NOT NULL COMMENT '创建时间',
+    `f_update_time` bigint(20) NOT NULL COMMENT '编辑时间',
+    PRIMARY KEY (`f_id`),
+    UNIQUE KEY uk_version (`f_version`) USING BTREE
+) ENGINE = InnoDB COMMENT = 'API元数据表';
+
+CREATE TABLE IF NOT EXISTS `t_op_registry` (
+    `f_id` bigint AUTO_INCREMENT NOT NULL COMMENT '自增主键',
+    `f_op_id` varchar(40) NOT NULL COMMENT '算子ID,UUID',
+    `f_name` varchar(512) NOT NULL COMMENT '算子名称', -- 默认为摘要
+    `f_metadata_version` varchar(40) NOT NULL COMMENT '算子元数据版本(关联t_metadata_api.f_version)',
+    `f_metadata_type` varchar(40) NOT NULL COMMENT '算子元数据类型(api/func/...)',
+    `f_status` varchar(10) DEFAULT 0 COMMENT '算子状态',
+    `f_operator_type` varchar(10) DEFAULT 0 COMMENT '算子类型, 0：基础算子, 1: 组合算子',
+    `f_execution_mode` varchar(10) DEFAULT 0 COMMENT '执行模式, 0: 同步执行, 1: 异步执行',
+    `f_category` varchar(50) DEFAULT 0 COMMENT '算子业务分类, 数据处理/算法模型',
+    `f_source` varchar(50) DEFAULT '' COMMENT '算子来源,system/unknown',
+    `f_execute_control` text DEFAULT NULL COMMENT '执行控制参数', -- 超时重试策略
+    `f_extend_info` text DEFAULT NULL COMMENT '扩展信息', -- flow_id一类
+    `f_create_user` varchar(50) NOT NULL COMMENT '创建者',
+    `f_create_time` bigint(20) NOT NULL COMMENT '创建时间',
+    `f_update_user` varchar(50) NOT NULL COMMENT '编辑者',
+    `f_update_time` bigint(20) NOT NULL COMMENT '编辑时间',
+    `f_is_deleted` boolean DEFAULT 0 COMMENT '是否删除', -- 0: 未删除, 1: 待删除
+    `f_is_internal` boolean DEFAULT 0 COMMENT '否为内置算子',
+    `f_is_data_source` boolean DEFAULT 0 COMMENT '是否为数据源算子',
+    PRIMARY KEY (`f_id`),
+    UNIQUE KEY uk_op_id_version (f_op_id, f_metadata_version) USING BTREE,
+    KEY idx_name_update (f_name, f_update_time) USING BTREE,
+    KEY idx_status_update (f_status, f_update_time) USING BTREE,
+    KEY idx_category_update (f_category, f_update_time) USING BTREE,
+    KEY idx_create_user_update (f_create_user, f_update_time) USING BTREE,
+    KEY idx_update_time (f_update_time) USING BTREE
+) ENGINE = InnoDB COMMENT = '算子注册表';
+
+
+CREATE TABLE IF NOT EXISTS `t_toolbox` (
+    `f_id` bigint AUTO_INCREMENT NOT NULL COMMENT '自增主键',
+    `f_box_id` varchar(40) NOT NULL COMMENT '工具箱ID',
+    `f_name` varchar(50) NOT NULL COMMENT '工具箱名称',
+    `f_description` longtext NOT NULL COMMENT '工具箱描述',
+    `f_svc_url` text NOT NULL COMMENT '地址',
+    `f_status` varchar(50) NOT NULL COMMENT '状态',
+    `f_is_internal` boolean DEFAULT 0 COMMENT '是否为内置工具箱', -- 0: 不是, 1: 是
+    `f_source` varchar(50) DEFAULT '' COMMENT '工具箱来源, DIP/Custom',
+    `f_category` varchar(50) DEFAULT 0 COMMENT '工具箱分类, 数据处理/算法模型',
+    `f_create_user` varchar(50) NOT NULL COMMENT '创建者',
+    `f_create_time` bigint(20) NOT NULL COMMENT '创建时间',
+    `f_update_user` varchar(50) NOT NULL COMMENT '编辑者',
+    `f_update_time` bigint(20) NOT NULL COMMENT '编辑时间',
+    `f_release_user` varchar(50) NOT NULL COMMENT '发布者',
+    `f_release_time` bigint(20) NOT NULL COMMENT '发布时间',
+    `f_metadata_type` varchar(50) NOT NULL DEFAULT 'openapi' COMMENT '工具箱内工具的类型，OpenAPI/Function',
+    PRIMARY KEY (`f_id`),
+    UNIQUE KEY uk_box_id (f_box_id) USING BTREE,
+    KEY idx_name (f_name) USING BTREE,
+    KEY idx_status (f_status) USING BTREE,
+    KEY idx_category (f_category) USING BTREE,
+    KEY idx_creator_status (f_create_user, f_status) USING BTREE,
+    KEY idx_ctime (f_create_time) USING BTREE,
+    KEY idx_utime (f_update_time) USING BTREE
+) ENGINE = InnoDB COMMENT = '工具箱';
+
+
+CREATE TABLE IF NOT EXISTS `t_tool` (
+    `f_id` bigint AUTO_INCREMENT NOT NULL COMMENT '自增主键',
+    `f_tool_id` varchar(40) NOT NULL COMMENT '工具ID',
+    `f_box_id` varchar(40) NOT NULL,
+    `f_name` varchar(256) NOT NULL COMMENT '名称',
+    `f_description` longtext NOT NULL COMMENT '工具描述',
+    `f_source_type` varchar(50) NOT NULL COMMENT '来源类型, 0: 算子, 1: OpenAPI',
+    `f_source_id` varchar(40) NOT NULL COMMENT '来源ID',
+    `f_status` varchar(40) DEFAULT 0 COMMENT '状态,启用/禁用',
+    `f_use_count` bigint(20) NOT NULL COMMENT '使用统计',
+    `f_use_rule` longtext DEFAULT NULL COMMENT '规则',
+    `f_parameters` longtext DEFAULT NULL COMMENT '参数',
+    `f_create_user` varchar(50) NOT NULL COMMENT '创建者',
+    `f_create_time` bigint(20) NOT NULL COMMENT '创建时间',
+    `f_update_user` varchar(50) NOT NULL COMMENT '编辑者',
+    `f_update_time` bigint(20) NOT NULL COMMENT '编辑时间',
+    `f_extend_info` text DEFAULT NULL COMMENT '扩展信息',
+    `f_is_deleted` boolean DEFAULT 0 COMMENT '是否删除', -- 0: 未删除, 1: 待删除
+    PRIMARY KEY (`f_id`),
+    UNIQUE KEY uk_tool_id (f_tool_id) USING BTREE,
+    KEY idx_box_id (f_box_id) USING BTREE,
+    KEY idx_name_update (f_name, f_update_time) USING BTREE
+) ENGINE = InnoDB COMMENT = '工具表';
+
+
+CREATE TABLE IF NOT EXISTS `t_mcp_server_config` (
+    `f_id` bigint AUTO_INCREMENT NOT NULL COMMENT '自增主键',
+    `f_mcp_id` varchar(40) NOT NULL COMMENT 'mcp_id',
+    `f_creation_type` varchar(20) NOT NULL DEFAULT 'custom' COMMENT '创建类型',
+    `f_name` varchar(50) NOT NULL COMMENT 'MCP Server名称，全局唯一',
+    `f_description` text NOT NULL COMMENT '描述信息',
+    `f_mode` varchar(32) NOT NULL COMMENT '通信模式（sse、streamable、stdio_npx、stdio_uvx）',
+    `f_url` text NOT NULL COMMENT '通信地址,SSE/Streamable模式下的服务URL',
+    `f_headers` text NOT NULL COMMENT 'http请求头,JSON字符串',
+    `f_command` text NOT NULL COMMENT 'stdio模式下的命令,JSON字符串',
+    `f_env` text NOT NULL COMMENT '环境变量,JSON字符串',
+    `f_args` text NOT NULL COMMENT '命令参数,JSON字符串',
+    `f_status` varchar(30) NOT NULL DEFAULT 'unpublish' COMMENT '状态',
+    `f_is_internal` boolean DEFAULT 0 COMMENT '是否为内置', -- 0: 不是, 1: 是
+    `f_source` varchar(50) DEFAULT 0 COMMENT '服务来源',
+    `f_category` varchar(50) DEFAULT 0 COMMENT '分类',
+    `f_create_user` varchar(50) NOT NULL COMMENT '创建者',
+    `f_create_time` bigint(20) NOT NULL COMMENT '创建时间',
+    `f_update_user` varchar(50) NOT NULL COMMENT '编辑者',
+    `f_update_time` bigint(20) NOT NULL COMMENT '编辑时间',
+    `f_version` int(20) NOT NULL DEFAULT 0 COMMENT '版本号',
+    PRIMARY KEY (`f_id`),
+    UNIQUE KEY uk_mcp_id (f_mcp_id) USING BTREE,
+    KEY `idx_name` (`f_name`) USING BTREE,
+    KEY `idx_update_time` (`f_update_time`) USING BTREE,
+    KEY `idx_status`(`f_status`) USING BTREE
+) ENGINE = InnoDB COMMENT = 'MCP Server表';
+
+CREATE TABLE IF NOT EXISTS `t_mcp_tool` (
+    `f_id` bigint AUTO_INCREMENT NOT NULL COMMENT '自增主键',
+    `f_mcp_tool_id` varchar(40) NOT NULL COMMENT 'mcp_tool_id',
+    `f_mcp_id` varchar(40) NOT NULL COMMENT 'mcp_id',
+    `f_mcp_version` int(20) NOT NULL COMMENT 'mcp版本',
+    `f_box_id` varchar(40) NOT NULL COMMENT '工具箱ID',
+    `f_box_name` varchar(50) COMMENT '工具箱名称',
+    `f_tool_id` varchar(40) NOT NULL COMMENT '工具ID',
+    `f_name` varchar(256)  COMMENT '工具名称',
+    `f_description` longtext  COMMENT '工具描述',
+    `f_use_rule` longtext  COMMENT '使用规则',
+    `f_create_user` varchar(50) NOT NULL COMMENT '创建者',
+    `f_create_time` bigint(20) NOT NULL COMMENT '创建时间',
+    `f_update_user` varchar(50) NOT NULL COMMENT '编辑者',
+    `f_update_time` bigint(20) NOT NULL COMMENT '编辑时间',
+    PRIMARY KEY (`f_id`),
+    UNIQUE KEY uk_mcp_tool_id (f_mcp_tool_id) USING BTREE,
+    KEY idx_mcp_id_version (f_mcp_id, f_mcp_version) USING BTREE,
+    KEY idx_name_update (f_name, f_update_time) USING BTREE
+) ENGINE = InnoDB COMMENT = 'MCP工具表';
+
+CREATE TABLE IF NOT EXISTS `t_mcp_server_release` (
+    `f_id` bigint AUTO_INCREMENT NOT NULL COMMENT '自增主键',
+    `f_mcp_id` varchar(40) NOT NULL COMMENT 'mcp_id',
+    `f_creation_type` varchar(20) NOT NULL DEFAULT 'custom' COMMENT '创建类型',
+    `f_name` varchar(50) NOT NULL COMMENT 'MCP Server名称，全局唯一',
+    `f_description` text NOT NULL COMMENT '描述信息',
+    `f_mode` varchar(32) NOT NULL COMMENT '通信模式（sse、streamable、stdio_npx、stdio_uvx）',
+    `f_url` text NOT NULL COMMENT '通信地址,SSE/Streamable模式下的服务URL',
+    `f_headers` text NOT NULL COMMENT 'http请求头,JSON字符串',
+    `f_command` text NOT NULL COMMENT 'stdio模式下的命令,JSON字符串',
+    `f_env` text NOT NULL COMMENT '环境变量,JSON字符串',
+    `f_args` text NOT NULL COMMENT '命令参数,JSON字符串',
+    `f_status` varchar(30) NOT NULL DEFAULT 'draft' COMMENT '状态',
+    `f_is_internal` boolean DEFAULT 0 COMMENT '是否为内置', -- 0: 不是, 1: 是
+    `f_source` varchar(50) DEFAULT 0 COMMENT '服务来源',
+    `f_category` varchar(50) DEFAULT 0 COMMENT '分类',
+    `f_create_user` varchar(50) NOT NULL COMMENT '创建者',
+    `f_create_time` bigint(20) NOT NULL COMMENT '创建时间',
+    `f_update_user` varchar(50) NOT NULL COMMENT '编辑者',
+    `f_update_time` bigint(20) NOT NULL COMMENT '编辑时间',
+    `f_version` int(20) NOT NULL COMMENT '发布版本号',
+    `f_release_desc` varchar(50) NOT NULL COMMENT '发布描述',
+    `f_release_user` varchar(50) NOT NULL COMMENT '发布者',
+    `f_release_time` bigint(20) NOT NULL COMMENT '发布时间',
+    PRIMARY KEY (`f_id`),
+    UNIQUE KEY uk_mcp (f_mcp_id, f_version) USING BTREE,
+    KEY `idx_mcp_id_create_time` (`f_mcp_id`, `f_create_time`) USING BTREE,
+    KEY  `idx_status_update_time` (`f_status`, `f_update_time`) USING BTREE
+) ENGINE = InnoDB COMMENT = 'MCP Server发布表';
+
+CREATE TABLE IF NOT EXISTS `t_mcp_server_release_history` (
+    `f_id` bigint AUTO_INCREMENT NOT NULL COMMENT '自增主键',
+    `f_mcp_id` varchar(40) NOT NULL COMMENT 'mcp_id',
+    `f_mcp_release` longtext NOT NULL COMMENT 'mcp server 发布信息',
+    `f_version` int NOT NULL COMMENT '发布版本',
+    `f_release_desc` varchar(255) NOT NULL DEFAULT '' COMMENT '发布描述',
+    `f_create_user` varchar(50) NOT NULL COMMENT '创建者',
+    `f_create_time` bigint(20) NOT NULL COMMENT '创建时间',
+    `f_update_user` varchar(50) NOT NULL COMMENT '编辑者',
+    `f_update_time` bigint(20) NOT NULL COMMENT '编辑时间',
+    PRIMARY KEY (`f_id`),
+    UNIQUE KEY uk_mcp (f_mcp_id, f_version) USING BTREE,
+    KEY `idx_mcp_id_create_time` (`f_mcp_id`, `f_create_time`) USING BTREE
+) ENGINE = InnoDB COMMENT = 'MCP Server发布历史表';
+
+CREATE TABLE IF NOT EXISTS `t_internal_component_config` (
+    `f_id` bigint AUTO_INCREMENT NOT NULL COMMENT '自增主键',
+    `f_component_type` varchar(50) NOT NULL COMMENT '组件类型, toolbox/mcp/operator',
+    `f_component_id` varchar(40) NOT NULL COMMENT '组件ID',
+    `f_config_version` varchar(40) NOT NULL COMMENT '配置版本: x.y.z格式',
+    `f_config_source` varchar(40) NOT NULL COMMENT '配置来源: (auto自动/manual手动)',
+    `f_protected_flag` boolean DEFAULT 0 COMMENT '手动配置保护锁',
+    PRIMARY KEY (`f_id`),
+    UNIQUE KEY `uk_comp_type_id` (`f_component_type`,`f_component_id`) USING BTREE
+) ENGINE = InnoDB COMMENT = '内置组件配置表';
+
+
+CREATE TABLE IF NOT EXISTS `t_operator_release` (
+    `f_id` bigint AUTO_INCREMENT NOT NULL COMMENT '自增主键',
+    `f_op_id` varchar(40) NOT NULL COMMENT '算子ID,UUID',
+    `f_name` varchar(512) NOT NULL COMMENT '算子名称', -- 默认为摘要
+    `f_metadata_version` varchar(40) NOT NULL COMMENT '算子元数据版本(关联t_metadata_api.f_version)',
+    `f_metadata_type` varchar(40) NOT NULL COMMENT '算子元数据类型(api/func/...)',
+    `f_status` varchar(10) DEFAULT 0 COMMENT '算子状态',
+    `f_operator_type` varchar(10) DEFAULT 0 COMMENT '算子类型, 0：基础算子, 1: 组合算子',
+    `f_execution_mode` varchar(10) DEFAULT 0 COMMENT '执行模式, 0: 同步执行, 1: 异步执行',
+    `f_category` varchar(50) DEFAULT 0 COMMENT '算子业务分类, 数据处理/算法模型',
+    `f_source` varchar(50) DEFAULT '' COMMENT '算子来源,system/unknown',
+    `f_execute_control` text DEFAULT NULL COMMENT '执行控制参数', -- 超时重试策略
+    `f_extend_info` text DEFAULT NULL COMMENT '扩展信息', -- flow_id一类
+    `f_create_user` varchar(50) NOT NULL COMMENT '创建者',
+    `f_create_time` bigint(20) NOT NULL COMMENT '创建时间',
+    `f_update_user` varchar(50) NOT NULL COMMENT '编辑者',
+    `f_update_time` bigint(20) NOT NULL COMMENT '编辑时间',
+    `f_tag` int(20) NOT NULL COMMENT '发布版本号',
+    `f_release_user` varchar(50) NOT NULL COMMENT '发布者',
+    `f_release_time` bigint(20) NOT NULL COMMENT '发布时间',
+    `f_is_internal` boolean DEFAULT 0 COMMENT '否为内置算子', -- 0: 不是, 1: 是
+    `f_is_data_source` boolean DEFAULT 0 COMMENT '是否为数据源算子', -- 0: 不是, 1: 是
+    PRIMARY KEY (`f_id`),
+    UNIQUE KEY uk_op (f_op_id, f_tag) USING BTREE,
+    KEY `idx_op_id_create_time` (`f_op_id`, `f_create_time`) USING BTREE,
+    KEY `idx_status_update_time` (`f_status`, `f_update_time`) USING BTREE
+) ENGINE = InnoDB COMMENT = '算子发布表';
+
+CREATE TABLE IF NOT EXISTS `t_operator_release_history` (
+    `f_id` bigint AUTO_INCREMENT NOT NULL COMMENT '自增主键',
+    `f_op_id` varchar(40) NOT NULL COMMENT '算子ID',
+    `f_op_release` longtext NOT NULL COMMENT '算子发布信息',
+    `f_metadata_version` varchar(40) NOT NULL COMMENT '元数据版本(关联t_metadata_api.f_version)',
+    `f_metadata_type` varchar(40) NOT NULL COMMENT '元数据类型(api/func/...)',
+    `f_tag` int NOT NULL COMMENT '发布版本',
+    `f_create_user` varchar(50) NOT NULL COMMENT '创建者',
+    `f_create_time` bigint(20) NOT NULL COMMENT '创建时间',
+    `f_update_user` varchar(50) NOT NULL COMMENT '编辑者',
+    `f_update_time` bigint(20) NOT NULL COMMENT '编辑时间',
+    PRIMARY KEY (`f_id`),
+    UNIQUE KEY uk_op (f_op_id, f_tag) USING BTREE,
+    KEY `idx_op_id_create_time` (`f_op_id`, `f_create_time`) USING BTREE,
+    KEY `idx_op_id_metadata_version` (`f_op_id`, `f_metadata_version`) USING BTREE
+) ENGINE = InnoDB COMMENT = '算子发布历史表';
+
+CREATE TABLE IF NOT EXISTS `t_category` (
+    `f_id` bigint AUTO_INCREMENT NOT NULL COMMENT '自增主键',
+    `f_category_id` varchar(40) NOT NULL COMMENT '分类ID',
+    `f_category_name` varchar(50) NOT NULL COMMENT '分类名称',
+    `f_create_user` varchar(50) NOT NULL COMMENT '创建者',
+    `f_create_time` bigint(20) NOT NULL COMMENT '创建时间',
+    `f_update_user` varchar(50) NOT NULL COMMENT '编辑者',
+    `f_update_time` bigint(20) NOT NULL COMMENT '编辑时间',
+    PRIMARY KEY (`f_id`),
+    UNIQUE KEY uk_category_id (f_category_id) USING BTREE,
+    UNIQUE KEY uk_category_name (f_category_name) USING BTREE
+) ENGINE = InnoDB COMMENT = '分类表';
+
+CREATE TABLE IF NOT EXISTS `t_outbox_message` (
+    `f_id` bigint AUTO_INCREMENT NOT NULL COMMENT '自增主键',
+    `f_event_id` varchar(40) NOT NULL COMMENT '事件ID',
+    `f_event_type` varchar(40) NOT NULL COMMENT '事件类型',
+    `f_topic` text NOT NULL COMMENT '主题',
+    `f_payload` longtext NOT NULL COMMENT '消息体',
+    `f_status` varchar(40) NOT NULL COMMENT '状态',
+    `f_created_at` bigint(20) NOT NULL COMMENT '创建时间',
+    `f_updated_at` bigint(20) NOT NULL COMMENT '更新时间',
+    `f_next_retry_at` bigint(20) NOT NULL COMMENT '下次重试时间',
+    `f_retry_count` int(20) NOT NULL COMMENT '重试次数',
+    PRIMARY KEY (`f_id`),
+    UNIQUE KEY uk_event_id (f_event_id) USING BTREE,
+    KEY idx_event_type (f_event_type) USING BTREE,
+    KEY idx_status_next_retry (f_status,f_next_retry_at) USING BTREE
+) ENGINE = InnoDB COMMENT = 'outbox消息表';
+
+CREATE TABLE IF NOT EXISTS `t_metadata_function` (
+    `f_id` bigint AUTO_INCREMENT NOT NULL COMMENT '自增主键',
+    `f_summary` varchar(256) NOT NULL COMMENT '摘要', -- 接口摘要 (唯一索引)
+    `f_version` varchar(40) NOT NULL COMMENT 'UUID',
+    `f_svc_url` text NOT NULL COMMENT '地址', -- 编辑后生成新的版本
+    `f_description` text COMMENT '描述', -- 单个接口描述（详情）
+    `f_path` text NOT NULL COMMENT 'API路径',
+    `f_method` varchar(50) NOT NULL COMMENT '请求方法',
+    `f_code` longtext NOT NULL COMMENT '函数代码',
+    `f_script_type` varchar(50) NOT NULL COMMENT '脚本类型',
+    `f_dependencies` longtext DEFAULT NULL COMMENT '依赖库',
+    `f_api_spec` longtext DEFAULT NULL COMMENT 'API内容',
+    `f_create_user` varchar(50) NOT NULL COMMENT '创建者',
+    `f_update_user` varchar(50) NOT NULL COMMENT '编辑者',
+    `f_create_time` bigint(20) NOT NULL COMMENT '创建时间',
+    `f_update_time` bigint(20) NOT NULL COMMENT '编辑时间',
+    `f_dependencies_url` text COMMENT '依赖库安装源地址',
+    PRIMARY KEY (`f_id`),
+    UNIQUE KEY uk_version (f_version) USING BTREE
+) ENGINE = InnoDB COMMENT = '函数元数据表';
+
+CREATE TABLE IF NOT EXISTS `t_resource_deploy` (
+    `f_id` bigint AUTO_INCREMENT NOT NULL COMMENT '自增主键',
+    `f_resource_id` varchar(40) NOT NULL COMMENT '资源ID',
+    `f_type` varchar(40) NOT NULL COMMENT '资源类型',
+    `f_version` int(20) NOT NULL COMMENT '资源版本',
+    `f_name` varchar(40) NOT NULL COMMENT '资源名称',
+    `f_description` longtext NOT NULL COMMENT '资源描述',
+    `f_config` longtext NOT NULL COMMENT '资源配置',
+    `f_status` varchar(40) NOT NULL COMMENT '资源状态',
+    `f_create_user` varchar(50) NOT NULL COMMENT '创建者',
+    `f_create_time` bigint(20) NOT NULL COMMENT '创建时间',
+    `f_update_user` varchar(50) NOT NULL COMMENT '编辑者',
+    `f_update_time` bigint(20) NOT NULL COMMENT '编辑时间',
+    PRIMARY KEY (`f_id`),
+    UNIQUE KEY uk_resource_id (f_resource_id, f_type, f_version) USING BTREE
+) ENGINE = InnoDB COMMENT = '资源部署表';
+
+CREATE TABLE IF NOT EXISTS `t_skill_repository` (
+    `f_id` bigint AUTO_INCREMENT NOT NULL COMMENT '自增主键',
+    `f_skill_id` varchar(40) NOT NULL COMMENT 'Skill ID',
+    `f_name` varchar(255) NOT NULL COMMENT 'Skill 名称',
+    `f_description` longtext NOT NULL COMMENT 'Skill 描述',
+    `f_skill_content` longtext NOT NULL COMMENT 'Skill 指令正文',
+    `f_version` varchar(40) NOT NULL COMMENT 'Skill 版本',
+    `f_status` varchar(40) NOT NULL COMMENT 'Skill 状态',
+    `f_source` varchar(50) NOT NULL DEFAULT '' COMMENT 'Skill 来源',
+    `f_extend_info` longtext DEFAULT NULL COMMENT '扩展信息',
+    `f_dependencies` longtext DEFAULT NULL COMMENT '依赖信息',
+    `f_file_manifest` longtext DEFAULT NULL COMMENT '文件摘要清单',
+    `f_create_user` varchar(50) NOT NULL COMMENT '创建者',
+    `f_create_time` bigint(20) NOT NULL COMMENT '创建时间',
+    `f_update_user` varchar(50) NOT NULL COMMENT '编辑者',
+    `f_update_time` bigint(20) NOT NULL COMMENT '编辑时间',
+    `f_delete_user` varchar(50) NOT NULL DEFAULT '' COMMENT '删除者',
+    `f_delete_time` bigint(20) NOT NULL DEFAULT 0 COMMENT '删除时间',
+    `f_category` varchar(50) DEFAULT '' COMMENT '工具箱分类, 数据处理/算法模型',
+    `f_is_deleted` boolean DEFAULT 0 COMMENT '是否删除', -- 0: 未删除, 1: 待删除
+    PRIMARY KEY (`f_id`),
+    UNIQUE KEY `uk_skill_id` (`f_skill_id`) USING BTREE,
+    KEY `idx_status_update_time` (`f_status`, `f_update_time`) USING BTREE,
+    KEY `idx_category_update_time` (`f_category`, `f_update_time`) USING BTREE,
+    KEY `idx_create_user_update_time` (`f_create_user`, `f_update_time`) USING BTREE
+) ENGINE = InnoDB COMMENT = 'Skill 主表';
+
+CREATE TABLE IF NOT EXISTS `t_skill_file_index` (
+    `f_id` bigint AUTO_INCREMENT NOT NULL COMMENT '自增主键',
+    `f_skill_id` varchar(40) NOT NULL COMMENT 'Skill ID',
+    `f_skill_version` varchar(40) NOT NULL COMMENT 'Skill 版本',
+    `f_rel_path` varchar(512) NOT NULL COMMENT '文件相对路径',
+    `f_path_hash` varchar(32) NOT NULL COMMENT '相对路径哈希',
+    `f_storage_id` varchar(50) NOT NULL COMMENT '对象存储ID',
+    `f_storage_key` text NOT NULL COMMENT '对象存储键',
+    `f_file_type` varchar(40) NOT NULL COMMENT '文件类型',
+    `f_content_sha256` varchar(64) NOT NULL COMMENT '文件内容 SHA256',
+    `f_mime_type` varchar(128) NOT NULL DEFAULT '' COMMENT 'MIME 类型',
+    `f_size` bigint(20) NOT NULL DEFAULT 0 COMMENT '文件大小',
+    `f_create_time` bigint(20) NOT NULL COMMENT '创建时间',
+    `f_update_time` bigint(20) NOT NULL COMMENT '编辑时间',
+    PRIMARY KEY (`f_id`),
+    UNIQUE KEY `uk_skill_version_rel_path` (`f_skill_id`, `f_skill_version`, `f_rel_path`) USING BTREE,
+    UNIQUE KEY `uk_skill_version_path_hash` (`f_skill_id`, `f_skill_version`, `f_path_hash`) USING BTREE
+) ENGINE = InnoDB COMMENT = 'Skill 文件索引表';
+
+CREATE TABLE IF NOT EXISTS `t_skill_release` (
+    `f_id` bigint AUTO_INCREMENT NOT NULL COMMENT '自增主键',
+    `f_skill_id` varchar(40) NOT NULL COMMENT '技能ID',
+    `f_name` varchar(512) NOT NULL COMMENT '技能名称',
+    `f_description` longtext NOT NULL COMMENT '技能描述',
+    `f_skill_content` longtext NOT NULL COMMENT '技能主体内容',
+    `f_version` varchar(40) NOT NULL COMMENT '发布快照版本',
+    `f_category` varchar(50) DEFAULT '' COMMENT '技能分类',
+    `f_source` varchar(50) DEFAULT '' COMMENT '技能来源',
+    `f_extend_info` longtext DEFAULT NULL COMMENT '扩展信息',
+    `f_dependencies` longtext DEFAULT NULL COMMENT '依赖信息',
+    `f_file_manifest` longtext DEFAULT NULL COMMENT '文件清单',
+    `f_status` varchar(20) NOT NULL COMMENT '技能状态',
+    `f_create_user` varchar(50) NOT NULL COMMENT '创建者',
+    `f_create_time` bigint(20) NOT NULL COMMENT '创建时间',
+    `f_update_user` varchar(50) NOT NULL COMMENT '编辑者',
+    `f_update_time` bigint(20) NOT NULL COMMENT '编辑时间',
+    `f_release_user` varchar(50) NOT NULL COMMENT '发布者',
+    `f_release_time` bigint(20) NOT NULL COMMENT '发布时间',
+    `f_release_desc` varchar(255) NOT NULL DEFAULT '' COMMENT '发布描述',
+    PRIMARY KEY (`f_id`),
+    UNIQUE KEY uk_skill_release_skill_id (`f_skill_id`) USING BTREE,
+    KEY `idx_skill_release_status_update_time` (`f_status`, `f_update_time`) USING BTREE,
+    KEY `idx_skill_release_release_time` (`f_release_time`) USING BTREE
+) ENGINE = InnoDB COMMENT = '技能当前发布快照表';
+
+CREATE TABLE IF NOT EXISTS `t_skill_release_history` (
+    `f_id` bigint AUTO_INCREMENT NOT NULL COMMENT '自增主键',
+    `f_skill_id` varchar(40) NOT NULL COMMENT '技能ID',
+    `f_version` varchar(40) NOT NULL COMMENT '发布快照版本',
+    `f_skill_release` longtext NOT NULL COMMENT '技能发布快照',
+    `f_release_desc` varchar(255) NOT NULL DEFAULT '' COMMENT '发布描述',
+    `f_create_user` varchar(50) NOT NULL COMMENT '创建者',
+    `f_create_time` bigint(20) NOT NULL COMMENT '创建时间',
+    `f_update_user` varchar(50) NOT NULL COMMENT '编辑者',
+    `f_update_time` bigint(20) NOT NULL COMMENT '编辑时间',
+    PRIMARY KEY (`f_id`),
+    UNIQUE KEY uk_skill_release_history (`f_skill_id`, `f_version`) USING BTREE,
+    KEY `idx_skill_release_history_skill_id_create_time` (`f_skill_id`, `f_create_time`) USING BTREE
+) ENGINE = InnoDB COMMENT = '技能发布历史表';
+
+
+CREATE TABLE IF NOT EXISTS `t_skill_index_build_task` (
+    `f_id` bigint AUTO_INCREMENT NOT NULL COMMENT '自增主键',
+    `f_task_id` varchar(40) NOT NULL COMMENT '任务ID',
+    `f_status` varchar(20) NOT NULL COMMENT '任务状态',
+    `f_execute_type` varchar(20) NOT NULL COMMENT '执行类型',
+    `f_total_count` bigint NOT NULL DEFAULT 0 COMMENT '扫描总数',
+    `f_success_count` bigint NOT NULL DEFAULT 0 COMMENT '写入成功数',
+    `f_delete_count` bigint NOT NULL DEFAULT 0 COMMENT '删除成功数',
+    `f_failed_count` bigint NOT NULL DEFAULT 0 COMMENT '失败数',
+    `f_retry_count` bigint NOT NULL DEFAULT 0 COMMENT '当前重试次数',
+    `f_max_retry` bigint NOT NULL DEFAULT 0 COMMENT '最大重试次数',
+    `f_cursor_update_time` bigint NOT NULL DEFAULT 0 COMMENT '增量游标更新时间',
+    `f_cursor_skill_id` varchar(40) NOT NULL DEFAULT '' COMMENT '增量游标skill_id',
+    `f_error_msg` text DEFAULT NULL COMMENT '错误信息',
+    `f_create_user` varchar(50) NOT NULL COMMENT '创建者',
+    `f_create_time` bigint(20) NOT NULL COMMENT '创建时间',
+    `f_update_time` bigint(20) NOT NULL COMMENT '更新时间',
+    `f_last_finished_time` bigint(20) NOT NULL DEFAULT 0 COMMENT '最后结束时间',
+    PRIMARY KEY (`f_id`),
+    UNIQUE KEY `uk_skill_index_build_task_id` (`f_task_id`) USING BTREE,
+    KEY `idx_skill_index_build_task_status_create_time` (`f_status`, `f_create_time`) USING BTREE,
+    KEY `idx_skill_index_build_task_exec_status_finish_time` (`f_execute_type`, `f_status`, `f_last_finished_time`) USING BTREE
+) ENGINE = InnoDB COMMENT = 'Skill 索引构建任务表';
+
+CREATE TABLE IF NOT EXISTS `t_execution_factory_operation_audit` (
+  `event_id` varchar(80) NOT NULL,
+  `event_time` datetime(6) NOT NULL,
+  `recorded_at` datetime(6) NOT NULL,
+  `tenant_id` varchar(128) NOT NULL,
+  `business_domain_id` varchar(128) NOT NULL,
+  `actor_id` varchar(128) NOT NULL,
+  `actor_name` varchar(256) NOT NULL,
+  `actor_type` varchar(32) NOT NULL,
+  `auth_method` varchar(32) NOT NULL,
+  `request_id` varchar(160) NOT NULL,
+  `source_channel` varchar(32) NOT NULL,
+  `method` varchar(16) NOT NULL,
+  `action` varchar(64) NOT NULL,
+  `target_type` varchar(64) NOT NULL,
+  `target_id` varchar(1024) NOT NULL,
+  `target_name` varchar(1024) NOT NULL,
+  `outcome` varchar(32) NOT NULL,
+  `failure_code` varchar(128) NOT NULL DEFAULT '',
+  `failure_message` varchar(512) NOT NULL DEFAULT '',
+  PRIMARY KEY (`event_id`),
+  KEY `idx_execution_audit_scope_time` (`tenant_id`,`business_domain_id`,`event_time`),
+  KEY `idx_execution_audit_request` (`request_id`),
+  KEY `idx_execution_audit_actor` (`actor_id`,`event_time`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COMMENT='Execution Factory management operation audit';

--- a/migrations/mf-model-manager/mariadb/0.1.4/01-operation-audit.sql
+++ b/migrations/mf-model-manager/mariadb/0.1.4/01-operation-audit.sql
@@ -1,0 +1,11 @@
+-- Bounded model-management facts. Model invocation and connection tests remain Trace facts.
+USE openbkn;
+CREATE TABLE IF NOT EXISTS `t_model_manager_operation_audit` (
+  `event_id` varchar(80) NOT NULL, `event_time` datetime(6) NOT NULL, `recorded_at` datetime(6) NOT NULL,
+  `tenant_id` varchar(128) NOT NULL, `business_domain_id` varchar(128) NOT NULL,
+  `actor_id` varchar(128) NOT NULL, `actor_name` varchar(256) NOT NULL, `actor_type` varchar(32) NOT NULL, `auth_method` varchar(32) NOT NULL,
+  `request_id` varchar(160) NOT NULL, `source_channel` varchar(32) NOT NULL, `method` varchar(16) NOT NULL,
+  `action` varchar(64) NOT NULL, `target_type` varchar(64) NOT NULL, `target_id` varchar(1024) NOT NULL, `target_name` varchar(1024) NOT NULL,
+  `outcome` varchar(32) NOT NULL, `failure_code` varchar(128) NOT NULL DEFAULT '', `failure_message` varchar(512) NOT NULL DEFAULT '',
+  PRIMARY KEY (`event_id`), KEY `idx_model_audit_scope_time` (`tenant_id`,`business_domain_id`,`event_time`), KEY `idx_model_audit_request` (`request_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COMMENT='Model manager operation audit';

--- a/migrations/mf-model-manager/mariadb/0.1.4/init.sql
+++ b/migrations/mf-model-manager/mariadb/0.1.4/init.sql
@@ -1,0 +1,219 @@
+-- Copyright 2026 openbkn.ai
+--
+-- Licensed under the Apache License, Version 2.0.
+-- See the LICENSE file in the project root for details.
+
+USE openbkn;
+
+
+create table if not exists t_llm_model
+(
+    f_model_id     varchar(50)             not null,
+    f_model_series varchar(50)             not null,
+    f_model_type   varchar(50)             not null,
+    f_model_name   varchar(100)            not null,
+    f_model        varchar(50)             not null,
+    f_model_config varchar(1000)           not null,
+    f_create_by    varchar(50)             not null,
+    f_create_time  datetime(6)             null,
+    f_update_by    varchar(50)             null,
+    f_update_time  datetime(6)             null,
+    f_max_model_len        int(11)         null,
+    f_model_parameters     int(11)         null,
+    f_quota        int default 0    not null,
+    f_default  int default 0    null,
+    primary key (f_model_id)
+);
+
+
+
+create table if not exists t_small_model
+(
+    f_model_id varchar(50) not null comment '主键，使用雪花id',
+    f_model_name varchar(50) not null comment '小模型名称',
+    f_model_type varchar(50) not null comment '小模型类型',
+    f_model_config varchar(1000) not null comment '小模型配置json',
+    f_create_time datetime(6) not null comment '创建时间',
+    f_update_time datetime(6) not null comment '编辑时间',
+    f_create_by    varchar(50)             not null,
+    f_update_by    varchar(50)             null,
+    f_adapter  int default 0    null,
+    f_adapter_code       text          null,
+    f_batch_size        int(11)         null,
+    f_max_tokens        int(11)         null,
+    f_embedding_dim     int(11)         null,
+    f_default  int default 0    null comment '该 model_type 下的系统默认小模型标记(1=默认)',
+    primary key (f_model_id)
+);
+
+create table if not exists t_prompt_item_list
+(
+    f_id                  varchar(50)          not null,
+    f_prompt_item_id      varchar(50)          not null,
+    f_prompt_item_name    varchar(50)          not null,
+    f_prompt_item_type_id varchar(50)          null,
+    f_prompt_item_type    varchar(50)          null,
+    f_create_by           varchar(50)          not null,
+    f_create_time         datetime(6)          null,
+    f_update_by           varchar(50)          null,
+    f_update_time         datetime(6)          null,
+    f_item_is_delete      int default 0 not null,
+    f_type_is_delete      int default 0 not null,
+    f_built_in            int default 0        not null,
+    primary key (f_id)
+);
+
+
+create table if not exists t_prompt_list
+(
+    f_prompt_id           varchar(50)          not null,
+    f_prompt_item_id      varchar(50)          not null,
+    f_prompt_item_type_id varchar(50)          not null,
+    f_prompt_service_id   varchar(50)          not null,
+    f_prompt_type         varchar(50)          not null,
+    f_prompt_name         varchar(50)          not null,
+    f_prompt_desc         varchar(255)         null,
+    f_messages            longtext             null,
+    f_variables           varchar(1000)        null,
+    f_icon                varchar(50)          not null,
+    f_model_id            varchar(50)          not null,
+    f_model_para          varchar(150)         not null,
+    f_opening_remarks     varchar(150)         null,
+    f_is_deploy           int default 0 not null,
+    f_prompt_deploy_url   varchar(150)         null,
+    f_prompt_deploy_api   varchar(150)         null,
+    f_create_by           varchar(50)          not null,
+    f_create_time         datetime(6)          null,
+    f_update_by           varchar(50)          null,
+    f_update_time         datetime(6)          null,
+    f_is_delete           int default 0 not null,
+    f_built_in            int default 0        not null,
+    primary key (f_prompt_id),
+    unique key uk_f_prompt_service_id (f_prompt_service_id)
+);
+
+create table if not exists t_prompt_template_list
+(
+    f_prompt_id       varchar(50)          not null,
+    f_prompt_type     varchar(50)          not null,
+    f_prompt_name     varchar(50)          not null,
+    f_prompt_desc     varchar(255)         null,
+    f_messages        longtext             null,
+    f_variables       varchar(1000)        null,
+    f_icon            varchar(50)          not null,
+    f_opening_remarks varchar(150)         null,
+    f_input           varchar(1000)        null,
+    f_create_by       varchar(50)          not null,
+    f_create_time     datetime(6)          null,
+    f_update_by       varchar(50)          null,
+    f_update_time     datetime(6)          null,
+    f_is_delete       int default 0 not null,
+    primary key (f_prompt_id)
+);
+
+
+CREATE TABLE if not exists t_model_monitor (
+    f_id                  varchar(50)          not null,
+    f_create_time         datetime          not null,
+    f_model_name         varchar(50)         not null,
+    f_model_id          varchar(50)          not null,
+    f_generation_tokens_total BIGINT not null,
+    f_prompt_tokens_total BIGINT not null,
+    f_average_first_token_time DECIMAL(10, 2) not null,
+    f_generation_token_speed  DECIMAL(10, 2) not null,
+    f_total_token_speed  DECIMAL(10, 2) not null,
+    primary key (f_id)
+);
+
+create table if not exists t_model_quota_config
+(
+    f_id varchar(50) not null comment '主键，使用雪花id',
+    f_model_id varchar(50) not null comment '模型id',
+    f_billing_type int not null comment '0 统一计费 ， 1 input output 单独计费',
+    f_input_tokens float not null comment 'input tokens配额',
+    f_output_tokens float not null comment 'output tokens配额',
+    f_referprice_in float not null comment 'input tokens参考单价',
+    f_referprice_out float not null comment 'output tokens参考单价',
+    f_currency_type bigint not null comment '货币类型 0:RMB/人民币 1:$/美元',
+    f_create_time datetime(6) not null comment '创建时间',
+    f_update_time datetime(6) not null comment '编辑时间',
+    f_num_type varchar(50) not null comment '1-千  2-万 3-百万 4-千万',
+    f_price_type varchar(50) not null default '["thousand", "thousand"]' comment '列表，计费单价显示单位, thousand-/千tokens million-/百万tokens',
+    primary key (f_id)
+);
+
+create table if not exists t_user_quota_config
+(
+    f_id varchar(50) not null comment '主键，使用雪花id',
+    f_model_conf varchar(50) not null comment '模型配额配置id（基于哪个模型配额）',
+    f_user_id varchar(50) not null comment '用户id',
+    f_input_tokens float not null comment 'input tokens配额',
+    f_output_tokens float not null comment 'output tokens配额',
+    f_create_time datetime(6) not null comment '创建时间',
+    f_update_time datetime(6) not null comment '编辑时间',
+    f_num_type varchar(50) not null comment '1-千  2-万 3-百万 4-千万',
+    primary key (f_id)
+);
+
+create table if not exists t_model_op_detail
+(
+    f_id varchar(50) not null comment '主键，使用雪花id',
+    f_model_id varchar(50) not null comment '模型id',
+    f_user_id varchar(50) not null comment '用户id',
+    f_input_tokens bigint not null comment 'input tokens消费 ',
+    f_output_tokens bigint not null comment 'output tokens消费',
+    f_referprice_in float not null comment 'input tokens参考单价',
+    f_referprice_out float not null comment 'output tokens参考单价',
+    f_total_price DECIMAL(38,10) not null comment '消费总金额',
+    f_create_time datetime(6) not null comment '创建时间',
+    f_currency_type bigint not null comment '货币类型 0:RMB/人民币 1:$/美元',
+    f_price_type varchar(50) not null default '["thousand", "thousand"]' comment '列表，计费单价显示单位, thousand-/千tokens million-/百万tokens',
+    f_total_count int default 0 not null comment '总调用次数',
+    f_failed_count int default 0 not null comment '调用失败次数',
+    f_average_total_time float default 0.0 not null comment '平均总响应时间',
+    f_average_first_time float default 0.0 not null comment '平均首字时间',
+    primary key (f_id)
+);
+
+insert into t_prompt_item_list(f_create_by, f_create_time, f_id, f_item_is_delete, f_prompt_item_id, f_prompt_item_name,
+                    f_prompt_item_type, f_prompt_item_type_id, f_type_is_delete, f_update_by, f_update_time, f_built_in)
+                select 'admin', current_timestamp, '1500000000000000001', 0, '1510000000000000001', '内置提示词',
+                    'chat', '1520000000000000001', 0, 'admin', current_timestamp, 1
+                from DUAL where not exists(select f_id from t_prompt_item_list where f_id = '1500000000000000001');
+
+
+insert into t_prompt_list(f_create_by, f_create_time, f_icon, f_is_delete, f_is_deploy, f_messages, f_model_id,
+                    f_model_para, f_opening_remarks, f_prompt_deploy_api, f_prompt_deploy_url, f_prompt_desc,
+                    f_prompt_id, f_prompt_item_id, f_prompt_item_type_id, f_prompt_name, f_prompt_service_id,
+                    f_prompt_type, f_update_by, f_update_time, f_variables, f_built_in)
+                select 'admin', current_timestamp, 5, 0, 0, '你可以重新组织和输出混乱复杂的会议记录，并根据当前状态、遇到的问题和提出的解决方案撰写会议纪要。你只负责会议记录方面的问题，不回答其他。
+', '', '{}', '', null, null, '帮你重新组织和输出混乱复杂的会议纪要',
+                    '1100000000000000030', '1510000000000000001', '1520000000000000001', '会议纪要', '1200000000000000030',
+                    'chat', 'admin', current_timestamp,
+                    '[]', 1
+                from DUAL where not exists(select f_prompt_id from t_prompt_list where f_prompt_id = '1100000000000000030');
+
+CREATE TABLE IF NOT EXISTS `t_model_manager_operation_audit` (
+  `event_id` varchar(80) NOT NULL,
+  `event_time` datetime(6) NOT NULL,
+  `recorded_at` datetime(6) NOT NULL,
+  `tenant_id` varchar(128) NOT NULL,
+  `business_domain_id` varchar(128) NOT NULL,
+  `actor_id` varchar(128) NOT NULL,
+  `actor_name` varchar(256) NOT NULL,
+  `actor_type` varchar(32) NOT NULL,
+  `auth_method` varchar(32) NOT NULL,
+  `request_id` varchar(160) NOT NULL,
+  `source_channel` varchar(32) NOT NULL,
+  `method` varchar(16) NOT NULL,
+  `action` varchar(64) NOT NULL,
+  `target_type` varchar(64) NOT NULL,
+  `target_id` varchar(1024) NOT NULL,
+  `target_name` varchar(1024) NOT NULL,
+  `outcome` varchar(32) NOT NULL,
+  `failure_code` varchar(128) NOT NULL DEFAULT '',
+  `failure_message` varchar(512) NOT NULL DEFAULT '',
+  PRIMARY KEY (`event_id`),
+  KEY `idx_model_audit_scope_time` (`tenant_id`,`business_domain_id`,`event_time`),
+  KEY `idx_model_audit_request` (`request_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COMMENT='Model manager operation audit';

--- a/migrations/vega-backend/mariadb/0.1.4/02-operation-audit.sql
+++ b/migrations/vega-backend/mariadb/0.1.4/02-operation-audit.sql
@@ -1,0 +1,34 @@
+-- Copyright 2026 openbkn.ai
+--
+-- Licensed under the Apache License, Version 2.0.
+-- See the LICENSE file in the project root for details.
+
+USE openbkn;
+
+-- Bounded Vega data-resource management audit facts. Request bodies, connector
+-- configurations, credentials and execution results are intentionally excluded.
+CREATE TABLE IF NOT EXISTS t_vega_operation_audit (
+  event_id VARCHAR(128) CHARACTER SET ascii COLLATE ascii_bin NOT NULL,
+  event_time DATETIME(6) NOT NULL,
+  recorded_at DATETIME(6) NOT NULL,
+  tenant_id VARCHAR(128) CHARACTER SET ascii COLLATE ascii_bin NOT NULL,
+  business_domain_id VARCHAR(128) CHARACTER SET ascii COLLATE ascii_bin NOT NULL,
+  actor_id VARCHAR(128) CHARACTER SET ascii COLLATE ascii_bin NOT NULL,
+  actor_name VARCHAR(255) NOT NULL,
+  actor_type VARCHAR(32) CHARACTER SET ascii COLLATE ascii_bin NOT NULL,
+  auth_method VARCHAR(32) CHARACTER SET ascii COLLATE ascii_bin NOT NULL,
+  request_id VARCHAR(128) CHARACTER SET ascii COLLATE ascii_bin NOT NULL,
+  source_channel VARCHAR(32) CHARACTER SET ascii COLLATE ascii_bin NOT NULL,
+  method VARCHAR(16) CHARACTER SET ascii COLLATE ascii_bin NOT NULL,
+  action VARCHAR(32) CHARACTER SET ascii COLLATE ascii_bin NOT NULL,
+  target_type VARCHAR(64) CHARACTER SET ascii COLLATE ascii_bin NOT NULL,
+  target_id VARCHAR(1024) NOT NULL,
+  target_name VARCHAR(1024) NOT NULL,
+  outcome VARCHAR(16) CHARACTER SET ascii COLLATE ascii_bin NOT NULL,
+  failure_code VARCHAR(128) CHARACTER SET ascii COLLATE ascii_bin NOT NULL DEFAULT '',
+  failure_message VARCHAR(512) NOT NULL DEFAULT '',
+  PRIMARY KEY (event_id),
+  INDEX idx_vega_audit_tenant_time (tenant_id, event_time, event_id),
+  INDEX idx_vega_audit_domain_time (business_domain_id, event_time, event_id),
+  INDEX idx_vega_audit_actor_time (actor_id, event_time, event_id)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin COMMENT='Vega data-resource management operation audit facts';

--- a/migrations/vega-backend/mariadb/0.1.4/init.sql
+++ b/migrations/vega-backend/mariadb/0.1.4/init.sql
@@ -523,3 +523,32 @@ CREATE TABLE IF NOT EXISTS t_catalog_health_check_schedule (
     PRIMARY KEY (f_catalog_id),
     INDEX idx_mode_next_run (f_mode, f_next_run)
 ) ENGINE = InnoDB DEFAULT CHARSET = utf8mb4 COLLATE = utf8mb4_bin COMMENT='Catalog 定时健康检查配置与执行元数据';
+
+-- ==========================================
+-- 12. t_vega_operation_audit 数据资源管理操作审计表
+-- ==========================================
+CREATE TABLE IF NOT EXISTS t_vega_operation_audit (
+    event_id                 VARCHAR(128) CHARACTER SET ascii COLLATE ascii_bin NOT NULL,
+    event_time               DATETIME(6) NOT NULL,
+    recorded_at              DATETIME(6) NOT NULL,
+    tenant_id                VARCHAR(128) CHARACTER SET ascii COLLATE ascii_bin NOT NULL,
+    business_domain_id       VARCHAR(128) CHARACTER SET ascii COLLATE ascii_bin NOT NULL,
+    actor_id                 VARCHAR(128) CHARACTER SET ascii COLLATE ascii_bin NOT NULL,
+    actor_name               VARCHAR(255) NOT NULL,
+    actor_type               VARCHAR(32) CHARACTER SET ascii COLLATE ascii_bin NOT NULL,
+    auth_method              VARCHAR(32) CHARACTER SET ascii COLLATE ascii_bin NOT NULL,
+    request_id               VARCHAR(128) CHARACTER SET ascii COLLATE ascii_bin NOT NULL,
+    source_channel           VARCHAR(32) CHARACTER SET ascii COLLATE ascii_bin NOT NULL,
+    method                   VARCHAR(16) CHARACTER SET ascii COLLATE ascii_bin NOT NULL,
+    action                   VARCHAR(32) CHARACTER SET ascii COLLATE ascii_bin NOT NULL,
+    target_type              VARCHAR(64) CHARACTER SET ascii COLLATE ascii_bin NOT NULL,
+    target_id                VARCHAR(1024) NOT NULL,
+    target_name              VARCHAR(1024) NOT NULL,
+    outcome                  VARCHAR(16) CHARACTER SET ascii COLLATE ascii_bin NOT NULL,
+    failure_code             VARCHAR(128) CHARACTER SET ascii COLLATE ascii_bin NOT NULL DEFAULT '',
+    failure_message          VARCHAR(512) NOT NULL DEFAULT '',
+    PRIMARY KEY (event_id),
+    INDEX idx_vega_audit_tenant_time (tenant_id, event_time, event_id),
+    INDEX idx_vega_audit_domain_time (business_domain_id, event_time, event_id),
+    INDEX idx_vega_audit_actor_time (actor_id, event_time, event_id)
+) ENGINE = InnoDB DEFAULT CHARSET = utf8mb4 COLLATE = utf8mb4_bin COMMENT='Vega 数据资源管理操作审计事实';


### PR DESCRIPTION
## Summary

- add bounded management-audit producers for Vega, Execution Factory, and Model Manager, with source-local migrations and idempotent event IDs
- add Trace Core adapters for the new sources and minimal BKN Safe login/logout access facts
- keep runtime execution, debugging, inference, and tests out of management audit records

## Verification

- `GOCACHE=/tmp/openbkn-go-cache-phase4 go test ./internal/accesslog ./internal/auth ./internal/httpapi -count=1`
- `GOCACHE=/tmp/openbkn-go-cache-phase4 go test ./src/domain/valueobject/observabilityvo ./src/drivenadapter/httpaccess/bknbackendaudit ./src/drivenadapter/httpaccess/vegaaudit ./src/drivenadapter/httpaccess/executionfactoryaudit ./src/drivenadapter/httpaccess/modelmanageraudit ./src/drivenadapter/httpaccess/bknsafeuseraccess -count=1`
- `GOCACHE=/tmp/openbkn-go-cache-phase4 go test ./driveradapters -run 'OperationAudit|Test.*Audit' -count=1` (Vega)
- `GOCACHE=/tmp/openbkn-go-cache-phase4 go test ./server/driveradapters -run 'OperationAudit|Test.*Audit' -count=1` (Execution Factory)

## Known verification gap

`infra/mf-model-manager/app/test/test_operation_audit.py` cannot collect on this host because the local Python environment lacks the model-factory base-image dependency `opentelemetry`. The test is included and must run in the service image or a provisioned Python environment before source status changes from partial to complete.

Closes #547
