### PR TITLE
feat(vega): push resource ownership to bkn-safe, previewing before every write (#800)

### DIFF
--- a/adp/vega/vega-backend/server/main.go
+++ b/adp/vega/vega-backend/server/main.go
@@ -172,6 +172,14 @@ func main() {
 	}
 	logger.Info("VEGA Manager Init Catalog Health Check Worker Success")
 
+	// 资源归属同步：把「表属于哪个目录」推给 bkn-safe，目录上的授权才能到达
+	// 目录下的表（#800）。BKN_SAFE_URL 未配置时自动不启用。
+	osw := worker.NewOwnershipSyncWorker()
+	if err := osw.Start(); err != nil {
+		logger.Fatalf("Failed to start ownership sync worker: %v", err)
+	}
+	logger.Info("VEGA Manager Init Ownership Sync Worker Success")
+
 	// 创建并启动服务
 	server := &mgrService{
 		appSetting:    appSetting,

--- a/adp/vega/vega-backend/server/worker/ownership_sync_worker.go
+++ b/adp/vega/vega-backend/server/worker/ownership_sync_worker.go
@@ -37,6 +37,10 @@ type OwnershipSyncWorker struct {
 	// approved 是「我看过预演报告，可以推」的批准记录，不是判定开关。
 	// 判定开关已经明确否掉：归属表为空天然等于关闭，回滚是删数据不是发版。
 	// 它落在 vega 而不是 bkn-safe，因为决定推不推的是数据的生产方。
+	//
+	// 它是常驻环境变量，因此批准的其实是「此后每一份快照」，而人只看过当时那
+	// 一份。缓解办法不是假装它是一次性的：预演每轮照跑、差异照记日志，扩权因此
+	// 始终留痕；用法是收敛完就把它关回去。
 	approved bool
 	stop     chan struct{}
 	once     sync.Once
@@ -46,7 +50,8 @@ const (
 	ownershipSyncDefaultInterval = 30 * time.Minute
 	// ownershipSyncChunk 与 bkn-safe 单次请求上限一致。
 	ownershipSyncChunk = 1000
-	// ownershipPageSize 是从本地库分页读资源的步长。
+	// ownershipPageSize 有两处用途：按批取本地资源详情（IN 子句的长度上限），
+	// 以及回读 bkn-safe 归属表时的分页步长——那个端点是真的支持 limit/offset。
 	ownershipPageSize = 500
 
 	authResourceType = "resource"
@@ -137,13 +142,18 @@ func (w *OwnershipSyncWorker) pushSnapshot(ctx context.Context, links []ownershi
 		if err != nil {
 			return fmt.Errorf("预演: %w", err)
 		}
-		if total > 0 && !w.approved {
-			// 差异非空意味着有人的可见范围会变。这里停下不是保守，是把决定权
-			// 交回给人：报告先出，推送等批准（VEGA_OWNERSHIP_SYNC_APPROVED）。
-			skipped += len(chunk)
-			logger.Warnf("资源归属同步暂停：本片会改变 %d 条判定，需人工确认后设置 "+
-				"VEGA_OWNERSHIP_SYNC_APPROVED=true 再推。样本: %s", total, sample)
-			continue
+		if total > 0 {
+			if !w.approved {
+				// 差异非空意味着有人的可见范围会变。这里停下不是保守，是把决定
+				// 权交回给人：报告先出，推送等批准。
+				skipped += len(chunk)
+				logger.Warnf("资源归属同步暂停：本片会改变 %d 条判定，需人工确认后设置 "+
+					"VEGA_OWNERSHIP_SYNC_APPROVED=true 再推。样本: %s", total, sample)
+				continue
+			}
+			// 已批准也照记：批准是对当时那份快照的，之后新建的目录与资源带来的
+			// 扩权没人看过，至少要留下痕迹。
+			logger.Warnf("资源归属同步（已批准）：本片改变 %d 条判定。样本: %s", total, sample)
 		}
 		if err := w.push(ctx, chunk); err != nil {
 			return fmt.Errorf("推送归属: %w", err)
@@ -166,24 +176,31 @@ type ownershipLink struct {
 // 跳过内部目录下的资源是有意的：它们在权限服务按 internal_catalog /
 // internal_resource 注册，种子里没有声明层级，推过去会被 400 拒掉——那是设计
 // 如此，不是故障。它们本来也只有超级管理员通配够得到，继承对其无收益。
+//
+// 这里不翻页：ResourceAccess.ListIDs 的实现根本不读 Offset/Limit，一次就返回
+// 全量 id（drivenadapters/resource/resource_access.go 的 builder 里没有
+// Limit/Offset）。写成翻页循环反而会每轮拿到同一批全量、无限追加直到 context
+// 超时——同步永远走不到推送那一步。真要分页得先改适配器。
 func (w *OwnershipSyncWorker) snapshot(ctx context.Context) ([]ownershipLink, error) {
-	internal, err := w.internalCatalogIDs(ctx)
+	internalIDs, err := logics.CA.ListInternalIDs(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("读取内部目录: %w", err)
+	}
+	internal := make(map[string]bool, len(internalIDs))
+	for _, id := range internalIDs {
+		internal[id] = true
+	}
+
+	ids, err := logics.RA.ListIDs(ctx, interfaces.ResourcesQueryParams{})
 	if err != nil {
 		return nil, err
 	}
-	var out []ownershipLink
-	for offset := 0; ; offset += ownershipPageSize {
-		ids, err := logics.RA.ListIDs(ctx, interfaces.ResourcesQueryParams{
-			PaginationQueryParams: interfaces.PaginationQueryParams{Offset: offset, Limit: ownershipPageSize},
-		})
-		if err != nil {
-			return nil, err
-		}
-		if len(ids) == 0 {
-			break
-		}
-		// GetByIDsBasic 不解析 schema/logic 那几个大 JSON 字段，这里只要 catalog_id。
-		resources, err := logics.RA.GetByIDsBasic(ctx, ids)
+	out := make([]ownershipLink, 0, len(ids))
+	// 详情按批取：GetByIDsBasic 拼的是 IN 子句，一次塞进上万个 id 会把语句撑爆。
+	// 它不解析 schema/logic 那几个大 JSON 字段，这里只要 catalog_id。
+	for start := 0; start < len(ids); start += ownershipPageSize {
+		batch := ids[start:min(start+ownershipPageSize, len(ids))]
+		resources, err := logics.RA.GetByIDsBasic(ctx, batch)
 		if err != nil {
 			return nil, err
 		}
@@ -192,33 +209,6 @@ func (w *OwnershipSyncWorker) snapshot(ctx context.Context) ([]ownershipLink, er
 				continue
 			}
 			out = append(out, ownershipLink{ResourceID: r.ID, ParentID: r.CatalogID})
-		}
-		if len(ids) < ownershipPageSize {
-			break
-		}
-	}
-	return out, nil
-}
-
-func (w *OwnershipSyncWorker) internalCatalogIDs(ctx context.Context) (map[string]bool, error) {
-	out := map[string]bool{}
-	for offset := 0; ; offset += ownershipPageSize {
-		catalogs, _, err := logics.CA.List(ctx, interfaces.CatalogsQueryParams{
-			PaginationQueryParams: interfaces.PaginationQueryParams{Offset: offset, Limit: ownershipPageSize},
-		})
-		if err != nil {
-			return nil, err
-		}
-		if len(catalogs) == 0 {
-			break
-		}
-		for _, c := range catalogs {
-			if c != nil && c.Internal {
-				out[c.ID] = true
-			}
-		}
-		if len(catalogs) < ownershipPageSize {
-			break
 		}
 	}
 	return out, nil

--- a/adp/vega/vega-backend/server/worker/ownership_sync_worker.go
+++ b/adp/vega/vega-backend/server/worker/ownership_sync_worker.go
@@ -1,0 +1,363 @@
+// Copyright openbkn.ai
+//
+// Licensed under the Apache License, Version 2.0.
+// See the LICENSE file in the project root for details.
+
+package worker
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"sync"
+	"time"
+
+	"github.com/openbkn-ai/bkn-foundry/comm-go/logger"
+
+	"vega-backend/interfaces"
+	"vega-backend/logics"
+)
+
+// OwnershipSyncWorker 把「数据表属于哪个数据目录」这件事推给 bkn-safe（#800）。
+//
+// bkn-safe 只见过不透明的 "type:id" 对象键，无从得知一张表属于哪个目录，所以
+// 目录上的授权到不了目录下的表。这件事只有 vega 知道，于是由 vega 推。
+//
+// 为什么不走 PermissionAccess 端口：给那个接口加方法要连带改端口定义、mock 和
+// ISF 那份实现，是在动现有机制。这里自带一个小客户端，多几十行换零波及面。
+type OwnershipSyncWorker struct {
+	baseURL  string
+	http     *http.Client
+	interval time.Duration
+	// approved 是「我看过预演报告，可以推」的批准记录，不是判定开关。
+	// 判定开关已经明确否掉：归属表为空天然等于关闭，回滚是删数据不是发版。
+	// 它落在 vega 而不是 bkn-safe，因为决定推不推的是数据的生产方。
+	approved bool
+	stop     chan struct{}
+	once     sync.Once
+}
+
+const (
+	ownershipSyncDefaultInterval = 30 * time.Minute
+	// ownershipSyncChunk 与 bkn-safe 单次请求上限一致。
+	ownershipSyncChunk = 1000
+	// ownershipPageSize 是从本地库分页读资源的步长。
+	ownershipPageSize = 500
+
+	authResourceType = "resource"
+	authParentType   = "catalog"
+)
+
+// NewOwnershipSyncWorker 构造同步器。BKN_SAFE_URL 为空即不启用——ISF 授权面
+// 没有归属表这个概念，推了也没人读。
+func NewOwnershipSyncWorker() *OwnershipSyncWorker {
+	interval := ownershipSyncDefaultInterval
+	if v := os.Getenv("VEGA_OWNERSHIP_SYNC_INTERVAL"); v != "" {
+		if d, err := time.ParseDuration(v); err == nil && d > 0 {
+			interval = d
+		} else {
+			logger.Warnf("忽略非法的 VEGA_OWNERSHIP_SYNC_INTERVAL=%q: %v", v, err)
+		}
+	}
+	return &OwnershipSyncWorker{
+		baseURL:  os.Getenv("BKN_SAFE_URL"),
+		http:     &http.Client{Timeout: 30 * time.Second},
+		interval: interval,
+		approved: os.Getenv("VEGA_OWNERSHIP_SYNC_APPROVED") == "true",
+		stop:     make(chan struct{}),
+	}
+}
+
+// Start 启动周期同步。BKN_SAFE_URL 未配置时直接返回，不报错——授权面可能仍是 ISF。
+func (w *OwnershipSyncWorker) Start() error {
+	if w.baseURL == "" {
+		logger.Info("BKN_SAFE_URL 未配置，资源归属同步不启用")
+		return nil
+	}
+	go func() {
+		ticker := time.NewTicker(w.interval)
+		defer ticker.Stop()
+		// 启动即跑一次：新装环境的归属表是空的，越早填上，目录级授权越早能用。
+		w.runOnce()
+		for {
+			select {
+			case <-ticker.C:
+				w.runOnce()
+			case <-w.stop:
+				return
+			}
+		}
+	}()
+	return nil
+}
+
+// Stop 停止同步器。幂等。
+func (w *OwnershipSyncWorker) Stop() {
+	w.once.Do(func() { close(w.stop) })
+}
+
+func (w *OwnershipSyncWorker) runOnce() {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Minute)
+	defer cancel()
+	err := w.sync(ctx)
+	switch {
+	case err == nil:
+	case errors.Is(err, errEndpointAbsent):
+		// 对端是老版本。这是允许的组合，说一次就好，不当故障刷屏。
+		logger.Info("bkn-safe 尚不支持资源归属登记，本轮同步跳过")
+	default:
+		logger.Errorf("资源归属同步失败: %v", err)
+	}
+}
+
+// sync 读本地资源快照 → 逐片预演 → 决定推不推 → 对账清孤儿。
+func (w *OwnershipSyncWorker) sync(ctx context.Context) error {
+	links, err := w.snapshot(ctx)
+	if err != nil {
+		return fmt.Errorf("读取资源快照: %w", err)
+	}
+	return w.pushSnapshot(ctx, links)
+}
+
+// pushSnapshot 是同步的后半段，与本地库解耦，便于单独验证推送决策。
+func (w *OwnershipSyncWorker) pushSnapshot(ctx context.Context, links []ownershipLink) error {
+	if len(links) == 0 {
+		logger.Info("资源归属同步：本地没有可推送的资源")
+		return w.reconcile(ctx, links)
+	}
+
+	pushed, skipped := 0, 0
+	for _, chunk := range chunkLinks(links, ownershipSyncChunk) {
+		total, sample, err := w.preview(ctx, chunk)
+		if err != nil {
+			return fmt.Errorf("预演: %w", err)
+		}
+		if total > 0 && !w.approved {
+			// 差异非空意味着有人的可见范围会变。这里停下不是保守，是把决定权
+			// 交回给人：报告先出，推送等批准（VEGA_OWNERSHIP_SYNC_APPROVED）。
+			skipped += len(chunk)
+			logger.Warnf("资源归属同步暂停：本片会改变 %d 条判定，需人工确认后设置 "+
+				"VEGA_OWNERSHIP_SYNC_APPROVED=true 再推。样本: %s", total, sample)
+			continue
+		}
+		if err := w.push(ctx, chunk); err != nil {
+			return fmt.Errorf("推送归属: %w", err)
+		}
+		pushed += len(chunk)
+	}
+	logger.Infof("资源归属同步：已推送 %d 条，待确认 %d 条", pushed, skipped)
+
+	return w.reconcile(ctx, links)
+}
+
+// ownershipLink 是一条 (资源 -> 所属目录)。
+type ownershipLink struct {
+	ResourceID string `json:"resource_id"`
+	ParentID   string `json:"parent_id"`
+}
+
+// snapshot 读出全部「非内部目录下的资源」及其目录。
+//
+// 跳过内部目录下的资源是有意的：它们在权限服务按 internal_catalog /
+// internal_resource 注册，种子里没有声明层级，推过去会被 400 拒掉——那是设计
+// 如此，不是故障。它们本来也只有超级管理员通配够得到，继承对其无收益。
+func (w *OwnershipSyncWorker) snapshot(ctx context.Context) ([]ownershipLink, error) {
+	internal, err := w.internalCatalogIDs(ctx)
+	if err != nil {
+		return nil, err
+	}
+	var out []ownershipLink
+	for offset := 0; ; offset += ownershipPageSize {
+		ids, err := logics.RA.ListIDs(ctx, interfaces.ResourcesQueryParams{
+			PaginationQueryParams: interfaces.PaginationQueryParams{Offset: offset, Limit: ownershipPageSize},
+		})
+		if err != nil {
+			return nil, err
+		}
+		if len(ids) == 0 {
+			break
+		}
+		// GetByIDsBasic 不解析 schema/logic 那几个大 JSON 字段，这里只要 catalog_id。
+		resources, err := logics.RA.GetByIDsBasic(ctx, ids)
+		if err != nil {
+			return nil, err
+		}
+		for _, r := range resources {
+			if r == nil || r.ID == "" || r.CatalogID == "" || internal[r.CatalogID] {
+				continue
+			}
+			out = append(out, ownershipLink{ResourceID: r.ID, ParentID: r.CatalogID})
+		}
+		if len(ids) < ownershipPageSize {
+			break
+		}
+	}
+	return out, nil
+}
+
+func (w *OwnershipSyncWorker) internalCatalogIDs(ctx context.Context) (map[string]bool, error) {
+	out := map[string]bool{}
+	for offset := 0; ; offset += ownershipPageSize {
+		catalogs, _, err := logics.CA.List(ctx, interfaces.CatalogsQueryParams{
+			PaginationQueryParams: interfaces.PaginationQueryParams{Offset: offset, Limit: ownershipPageSize},
+		})
+		if err != nil {
+			return nil, err
+		}
+		if len(catalogs) == 0 {
+			break
+		}
+		for _, c := range catalogs {
+			if c != nil && c.Internal {
+				out[c.ID] = true
+			}
+		}
+		if len(catalogs) < ownershipPageSize {
+			break
+		}
+	}
+	return out, nil
+}
+
+// preview 问 bkn-safe：这一片推下去，谁的判定会变。返回总数与一条样本。
+func (w *OwnershipSyncWorker) preview(ctx context.Context, chunk []ownershipLink) (int, string, error) {
+	var resp struct {
+		Changes []struct {
+			AccessorID string `json:"accessor_id"`
+			ResourceID string `json:"resource_id"`
+			Operation  string `json:"operation"`
+			Direction  string `json:"direction"`
+		} `json:"changes"`
+		Total int `json:"total"`
+	}
+	if err := w.call(ctx, http.MethodPut,
+		"/api/safe/v1/authz/resource-parents?dry_run=true", chunk, &resp); err != nil {
+		return 0, "", err
+	}
+	sample := ""
+	if len(resp.Changes) > 0 {
+		c := resp.Changes[0]
+		sample = fmt.Sprintf("%s %s %s/%s", c.Direction, c.AccessorID, authResourceType, c.ResourceID) +
+			" " + c.Operation
+	}
+	return resp.Total, sample, nil
+}
+
+func (w *OwnershipSyncWorker) push(ctx context.Context, chunk []ownershipLink) error {
+	return w.call(ctx, http.MethodPut, "/api/safe/v1/authz/resource-parents", chunk, nil)
+}
+
+// reconcile 回读 bkn-safe 存了什么，删掉 vega 已经没有的资源留下的孤儿行。
+// 删除路径本身也会删（bkn-safe 在 DELETE /policies 时顺手删），这里是兜底：
+// 进程崩溃、跨服务调用失败都会漏，对账才是可靠手段。
+func (w *OwnershipSyncWorker) reconcile(ctx context.Context, links []ownershipLink) error {
+	live := make(map[string]bool, len(links))
+	for _, l := range links {
+		live[l.ResourceID] = true
+	}
+	var orphans []string
+	for offset := 0; ; offset += ownershipPageSize {
+		var resp struct {
+			Items []struct {
+				ResourceID string `json:"resource_id"`
+			} `json:"items"`
+			Total int `json:"total"`
+		}
+		path := fmt.Sprintf("/api/safe/v1/authz/resource-parents?resource_type=%s&limit=%d&offset=%d",
+			authResourceType, ownershipPageSize, offset)
+		if err := w.call(ctx, http.MethodGet, path, nil, &resp); err != nil {
+			return fmt.Errorf("回读归属: %w", err)
+		}
+		for _, it := range resp.Items {
+			if !live[it.ResourceID] {
+				orphans = append(orphans, it.ResourceID)
+			}
+		}
+		if len(resp.Items) < ownershipPageSize {
+			break
+		}
+	}
+	if len(orphans) == 0 {
+		return nil
+	}
+	logger.Infof("资源归属对账：清理 %d 条孤儿记录", len(orphans))
+	for start := 0; start < len(orphans); start += ownershipSyncChunk {
+		end := min(start+ownershipSyncChunk, len(orphans))
+		body := map[string]any{
+			"resource_type": authResourceType,
+			"resource_ids":  orphans[start:end],
+		}
+		if err := w.callRaw(ctx, http.MethodDelete, "/api/safe/v1/authz/resource-parents", body, nil); err != nil {
+			return fmt.Errorf("清理孤儿归属: %w", err)
+		}
+	}
+	return nil
+}
+
+// call 发一个带 items 包装的归属请求（PUT 用），或一个无 body 的读请求（GET 用）。
+func (w *OwnershipSyncWorker) call(ctx context.Context, method, path string, items []ownershipLink, out any) error {
+	var body any
+	if items != nil {
+		body = map[string]any{
+			"resource_type": authResourceType,
+			"parent_type":   authParentType,
+			"items":         items,
+		}
+	}
+	return w.callRaw(ctx, method, path, body, out)
+}
+
+func (w *OwnershipSyncWorker) callRaw(ctx context.Context, method, path string, body, out any) error {
+	var reader io.Reader
+	if body != nil {
+		b, err := json.Marshal(body)
+		if err != nil {
+			return err
+		}
+		reader = bytes.NewReader(b)
+	}
+	req, err := http.NewRequestWithContext(ctx, method, w.baseURL+path, reader)
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := w.http.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	raw, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode == http.StatusNotFound {
+		// 老版 bkn-safe 没有这个端点。版本错配必须容错跳过，不能刷屏也不能崩。
+		return errEndpointAbsent
+	}
+	if resp.StatusCode >= 300 {
+		return fmt.Errorf("bkn-safe %s %s: %d %s", method, path, resp.StatusCode, string(raw))
+	}
+	if out != nil && len(raw) > 0 {
+		return json.Unmarshal(raw, out)
+	}
+	return nil
+}
+
+// errEndpointAbsent 标记「对端还没有这个能力」。新版 vega 配老版 bkn-safe 是
+// 允许的组合，此时同步器安静退出，不把版本错配变成一串报错。
+var errEndpointAbsent = errors.New("bkn-safe 尚不支持资源归属登记")
+
+// chunkLinks 把快照切成不超过 size 的片。分片是为了让单次请求的事务与内存有界，
+// 而不是随一个部署的资源总量增长。
+func chunkLinks(links []ownershipLink, size int) [][]ownershipLink {
+	if size <= 0 || len(links) == 0 {
+		return nil
+	}
+	out := make([][]ownershipLink, 0, (len(links)+size-1)/size)
+	for start := 0; start < len(links); start += size {
+		out = append(out, links[start:min(start+size, len(links))])
+	}
+	return out
+}

--- a/adp/vega/vega-backend/server/worker/ownership_sync_worker_test.go
+++ b/adp/vega/vega-backend/server/worker/ownership_sync_worker_test.go
@@ -9,10 +9,17 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"testing"
 	"time"
+
+	"go.uber.org/mock/gomock"
+
+	"vega-backend/interfaces"
+	mock_interfaces "vega-backend/interfaces/mock"
+	"vega-backend/logics"
 )
 
 // safeStub 是一个可编程的 bkn-safe 替身，记录同步器实际发了什么。
@@ -215,4 +222,79 @@ func TestChunkLinks(t *testing.T) {
 	if chunkLinks(nil, 3) != nil {
 		t.Error("空快照应返回 nil")
 	}
+}
+
+// --- 本地快照（唯一读本地库的那一段）--------------------------------------
+
+// TestSnapshotSkipsInternalCatalogs：内部目录下的资源不能推——权限服务按
+// internal_catalog / internal_resource 注册它们，种子没声明层级，推过去会 400。
+func TestSnapshotSkipsInternalCatalogs(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	ca, ra := mock_interfaces.NewMockCatalogAccess(ctrl), mock_interfaces.NewMockResourceAccess(ctrl)
+	restore := swapAccess(ca, ra)
+	defer restore()
+
+	ca.EXPECT().ListInternalIDs(gomock.Any()).Return([]string{"c-internal"}, nil)
+	ra.EXPECT().ListIDs(gomock.Any(), gomock.Any()).Return([]string{"r-1", "r-2", "r-3"}, nil)
+	ra.EXPECT().GetByIDsBasic(gomock.Any(), []string{"r-1", "r-2", "r-3"}).Return([]*interfaces.Resource{
+		{ID: "r-1", CatalogID: "c-1"},
+		{ID: "r-2", CatalogID: "c-internal"},
+		{ID: "r-3", CatalogID: ""}, // 没有目录的资源无处可挂
+	}, nil)
+
+	links, err := newSyncWorker("http://x", false).snapshot(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(links) != 1 || links[0].ResourceID != "r-1" || links[0].ParentID != "c-1" {
+		t.Fatalf("links = %v, want only r-1 under c-1", links)
+	}
+}
+
+// TestSnapshotTerminatesBeyondOnePage 是这一段返工的原因：ListIDs 的实现不读
+// Offset/Limit，一次返回全量。曾经的翻页循环因此每轮拿到同一批、无限追加，直到
+// context 超时——同步永远走不到推送。这里用超过一页的资源量把它钉住。
+func TestSnapshotTerminatesBeyondOnePage(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	ca, ra := mock_interfaces.NewMockCatalogAccess(ctrl), mock_interfaces.NewMockResourceAccess(ctrl)
+	restore := swapAccess(ca, ra)
+	defer restore()
+
+	const n = ownershipPageSize + 7
+	ids := make([]string, n)
+	resources := make([]*interfaces.Resource, n)
+	for i := range ids {
+		ids[i] = fmt.Sprintf("r-%d", i)
+		resources[i] = &interfaces.Resource{ID: ids[i], CatalogID: "c-1"}
+	}
+	ca.EXPECT().ListInternalIDs(gomock.Any()).Return(nil, nil)
+	// 全量一次返回,且只被问一次——多问一次就是又写回了翻页循环。
+	ra.EXPECT().ListIDs(gomock.Any(), gomock.Any()).Return(ids, nil).Times(1)
+	// 详情按批取,所以正好两批。
+	ra.EXPECT().GetByIDsBasic(gomock.Any(), ids[:ownershipPageSize]).Return(resources[:ownershipPageSize], nil)
+	ra.EXPECT().GetByIDsBasic(gomock.Any(), ids[ownershipPageSize:]).Return(resources[ownershipPageSize:], nil)
+
+	done := make(chan int, 1)
+	go func() {
+		links, err := newSyncWorker("http://x", false).snapshot(context.Background())
+		if err != nil {
+			t.Error(err)
+		}
+		done <- len(links)
+	}()
+	select {
+	case got := <-done:
+		if got != n {
+			t.Errorf("links = %d, want %d", got, n)
+		}
+	case <-time.After(10 * time.Second):
+		t.Fatal("snapshot 没有终止——翻页循环又回来了")
+	}
+}
+
+// swapAccess 临时替换 logics 里的两个访问单例，返回还原函数。
+func swapAccess(ca interfaces.CatalogAccess, ra interfaces.ResourceAccess) func() {
+	prevCA, prevRA := logics.CA, logics.RA
+	logics.CA, logics.RA = ca, ra
+	return func() { logics.CA, logics.RA = prevCA, prevRA }
 }

--- a/adp/vega/vega-backend/server/worker/ownership_sync_worker_test.go
+++ b/adp/vega/vega-backend/server/worker/ownership_sync_worker_test.go
@@ -1,0 +1,218 @@
+// Copyright openbkn.ai
+//
+// Licensed under the Apache License, Version 2.0.
+// See the LICENSE file in the project root for details.
+
+package worker
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+// safeStub 是一个可编程的 bkn-safe 替身，记录同步器实际发了什么。
+type safeStub struct {
+	previewTotal int
+	pushed       [][]string // 每次正式推送的 resource_id
+	deleted      []string   // 被清理的孤儿 id
+	stored       []string   // 对端已存的 resource_id，供对账读回
+	notFound     bool       // 模拟老版本 bkn-safe：端点不存在
+}
+
+func (s *safeStub) server(t *testing.T) *httptest.Server {
+	t.Helper()
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/safe/v1/authz/resource-parents", func(w http.ResponseWriter, r *http.Request) {
+		if s.notFound {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		switch r.Method {
+		case http.MethodPut:
+			var body struct {
+				Items []struct {
+					ResourceID string `json:"resource_id"`
+				} `json:"items"`
+			}
+			_ = json.NewDecoder(r.Body).Decode(&body)
+			ids := make([]string, 0, len(body.Items))
+			for _, it := range body.Items {
+				ids = append(ids, it.ResourceID)
+			}
+			if r.URL.Query().Get("dry_run") == "true" {
+				resp := map[string]any{"total": s.previewTotal, "changes": []any{}}
+				if s.previewTotal > 0 {
+					resp["changes"] = []map[string]string{{
+						"accessor_id": "u-1", "resource_id": ids[0],
+						"operation": "modify", "direction": "grant",
+					}}
+				}
+				_ = json.NewEncoder(w).Encode(resp)
+				return
+			}
+			s.pushed = append(s.pushed, ids)
+			w.WriteHeader(http.StatusNoContent)
+		case http.MethodDelete:
+			var body struct {
+				ResourceIDs []string `json:"resource_ids"`
+			}
+			_ = json.NewDecoder(r.Body).Decode(&body)
+			s.deleted = append(s.deleted, body.ResourceIDs...)
+			w.WriteHeader(http.StatusNoContent)
+		case http.MethodGet:
+			items := make([]map[string]string, 0, len(s.stored))
+			for _, id := range s.stored {
+				items = append(items, map[string]string{"resource_id": id})
+			}
+			_ = json.NewEncoder(w).Encode(map[string]any{"items": items, "total": len(items)})
+		}
+	})
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+func newSyncWorker(baseURL string, approved bool) *OwnershipSyncWorker {
+	return &OwnershipSyncWorker{
+		baseURL:  baseURL,
+		http:     &http.Client{Timeout: 5 * time.Second},
+		interval: time.Hour,
+		approved: approved,
+		stop:     make(chan struct{}),
+	}
+}
+
+// TestSyncPushesWhenPreviewIsClean 是常态：装机环境没有目录级的对象授权，预演
+// 差异为空，推送即零行为变化，不需要任何人点头。
+func TestSyncPushesWhenPreviewIsClean(t *testing.T) {
+	stub := &safeStub{previewTotal: 0}
+	srv := stub.server(t)
+	w := newSyncWorker(srv.URL, false)
+
+	links := []ownershipLink{{ResourceID: "r-1", ParentID: "c-1"}, {ResourceID: "r-2", ParentID: "c-1"}}
+	if err := w.pushSnapshot(context.Background(), links); err != nil {
+		t.Fatal(err)
+	}
+	if len(stub.pushed) != 1 || len(stub.pushed[0]) != 2 {
+		t.Fatalf("pushed = %v, want one chunk of two", stub.pushed)
+	}
+}
+
+// TestSyncStopsWhenPreviewShowsChanges 是这个设计的关键动作：预演非空说明有人的
+// 可见范围会变，同步器停下把决定权交回给人，而不是替人做决定。
+func TestSyncStopsWhenPreviewShowsChanges(t *testing.T) {
+	stub := &safeStub{previewTotal: 7}
+	srv := stub.server(t)
+	w := newSyncWorker(srv.URL, false)
+
+	links := []ownershipLink{{ResourceID: "r-1", ParentID: "c-1"}}
+	if err := w.pushSnapshot(context.Background(), links); err != nil {
+		t.Fatalf("暂停不是错误，不该返回 err: %v", err)
+	}
+	if len(stub.pushed) != 0 {
+		t.Errorf("差异非空却推了: %v", stub.pushed)
+	}
+}
+
+// TestSyncPushesOnceApproved: 批准之后同一份快照照推。批准是一次人工确认的
+// 记录，不是判定开关。
+func TestSyncPushesOnceApproved(t *testing.T) {
+	stub := &safeStub{previewTotal: 7}
+	srv := stub.server(t)
+	w := newSyncWorker(srv.URL, true)
+
+	links := []ownershipLink{{ResourceID: "r-1", ParentID: "c-1"}}
+	if err := w.pushSnapshot(context.Background(), links); err != nil {
+		t.Fatal(err)
+	}
+	if len(stub.pushed) != 1 {
+		t.Errorf("批准后仍未推送: %v", stub.pushed)
+	}
+}
+
+// TestSyncReconcilesOrphans: 删除路径会漏（进程崩溃、跨服务调用失败），对账才是
+// 可靠手段。vega 已经没有的资源，它在对端留下的归属行要清掉。
+func TestSyncReconcilesOrphans(t *testing.T) {
+	stub := &safeStub{previewTotal: 0, stored: []string{"r-1", "r-gone"}}
+	srv := stub.server(t)
+	w := newSyncWorker(srv.URL, false)
+
+	links := []ownershipLink{{ResourceID: "r-1", ParentID: "c-1"}}
+	if err := w.pushSnapshot(context.Background(), links); err != nil {
+		t.Fatal(err)
+	}
+	if len(stub.deleted) != 1 || stub.deleted[0] != "r-gone" {
+		t.Errorf("deleted = %v, want only r-gone", stub.deleted)
+	}
+}
+
+// TestSyncReconcilesWithAnEmptySnapshot: 本地一个资源都没有时仍要对账，否则
+// 清空所有资源之后，对端的归属行永远留着。
+func TestSyncReconcilesWithAnEmptySnapshot(t *testing.T) {
+	stub := &safeStub{stored: []string{"r-gone"}}
+	srv := stub.server(t)
+	w := newSyncWorker(srv.URL, false)
+
+	if err := w.pushSnapshot(context.Background(), nil); err != nil {
+		t.Fatal(err)
+	}
+	if len(stub.deleted) != 1 || stub.deleted[0] != "r-gone" {
+		t.Errorf("deleted = %v, want r-gone", stub.deleted)
+	}
+}
+
+// TestSyncToleratesAnOlderSafe: 新版 vega 配老版 bkn-safe 是允许的组合，端点
+// 404 必须被识别成「对端还没有这个能力」，而不是变成一串报错。
+func TestSyncToleratesAnOlderSafe(t *testing.T) {
+	stub := &safeStub{notFound: true}
+	srv := stub.server(t)
+	w := newSyncWorker(srv.URL, false)
+
+	err := w.pushSnapshot(context.Background(), []ownershipLink{{ResourceID: "r-1", ParentID: "c-1"}})
+	if !errors.Is(err, errEndpointAbsent) {
+		t.Fatalf("err = %v, want errEndpointAbsent", err)
+	}
+}
+
+// TestSyncDisabledWithoutSafeURL: 授权面可能仍是 ISF，那里没有归属表这个概念。
+func TestSyncDisabledWithoutSafeURL(t *testing.T) {
+	w := newSyncWorker("", false)
+	if err := w.Start(); err != nil {
+		t.Fatalf("未配置 BKN_SAFE_URL 不该报错: %v", err)
+	}
+}
+
+func TestChunkLinks(t *testing.T) {
+	links := make([]ownershipLink, 5)
+	for i := range links {
+		links[i] = ownershipLink{ResourceID: string(rune('a' + i))}
+	}
+	cases := []struct {
+		size  int
+		chunk []int // 期望的每片长度
+	}{
+		{size: 2, chunk: []int{2, 2, 1}},
+		{size: 5, chunk: []int{5}},
+		{size: 10, chunk: []int{5}},
+		{size: 0, chunk: nil},
+	}
+	for _, tc := range cases {
+		got := chunkLinks(links, tc.size)
+		if len(got) != len(tc.chunk) {
+			t.Fatalf("size=%d 分成 %d 片，want %d", tc.size, len(got), len(tc.chunk))
+		}
+		for i, want := range tc.chunk {
+			if len(got[i]) != want {
+				t.Errorf("size=%d 第 %d 片长 %d，want %d", tc.size, i, len(got[i]), want)
+			}
+		}
+	}
+	if chunkLinks(nil, 3) != nil {
+		t.Error("空快照应返回 nil")
+	}
+}


### PR DESCRIPTION
Stage D2 of #800 — the last piece. bkn-safe now knows how to inherit; this gives it the fact it inherits on.

## What it does

Read the local resource snapshot → chunk → **dry-run each chunk** → push when the diff is empty, stop when it is not → read back and reap orphans.

## Why it stops instead of pushing

Ownership landing in the table **is** the moment inheritance starts applying, and that is a widening. An allow-only engine has no knob that holds it back afterwards, so the decision has to be handed to a person before the write, not after.

A non-empty diff logs the affected subjects and skips the chunk. Approval is `VEGA_OWNERSHIP_SYNC_APPROVED=true` — a record that someone read the report, **not** a judgement switch. The judgement switch was deliberately rejected: an empty ownership table already equals "off", and rollback is deleting rows rather than shipping a release.

On a real installation the diff is expected to be empty. The development cluster has **zero** per-object grants on `catalog` and `resource`, and the seeded roles gain nothing (asserted in #832), so the push is a no-op there and runs unattended.

## What it deliberately does not touch

- **Not the `PermissionAccess` port.** Adding a method there would drag in the port definition, the generated mock and the ISF implementation — that is changing a mechanism two providers share. The worker carries a small client of its own instead: a few dozen extra lines for zero blast radius.
- **Not the create/delete paths.** Not one line. Ownership is discovered by reading, never by intercepting writes.
- Resources under internal catalogs are skipped. They register as `internal_catalog` / `internal_resource`, which the seed never declared a hierarchy for, so pushing them returns 400 — by design, not a fault. Nothing but the super-admin wildcard reaches them anyway.

## Version and configuration tolerance

- `BKN_SAFE_URL` unset → the worker does not start (the authorization face may still be ISF, which has no such concept)
- a 404 from the endpoint is read as "the peer does not have this capability yet" — new vega against old bkn-safe is a supported combination, and it must neither crash nor fill the log
- `VEGA_OWNERSHIP_SYNC_INTERVAL` (default 30m), `VEGA_OWNERSHIP_SYNC_APPROVED` (default off)

Reconciliation runs even when the snapshot is empty; otherwise deleting every resource would leave its ownership rows behind forever. It is the backstop for the delete path, which loses rows to crashes and failed cross-service calls — `DELETE /authz/policies` already drops the row on the happy path.

## Tests

Against a programmable bkn-safe stub:

- clean preview → pushes
- dirty preview → **pushes nothing, and is not an error** (waiting is the intended outcome)
- approved → pushes the same snapshot
- orphan rows are reaped; reconciliation still runs on an empty snapshot
- a 404 peer surfaces as `errEndpointAbsent`, not a failure
- no `BKN_SAFE_URL` → the worker declines to start
- chunk boundaries

Note: `vega-backend/worker` already fails on an untouched tree — `gomonkey` segfaults on Apple Silicon in `build_worker_batch_test.go`. Verified before and after; the new tests pass on their own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
