### PR TITLE
chore(comm-go): use v0.1.1 in locale consumers

### DIFF
--- a/adp/bkn/bkn-backend/server/go.mod
+++ b/adp/bkn/bkn-backend/server/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/fsnotify/fsnotify v1.10.1
 	github.com/gin-gonic/gin v1.12.0
 	github.com/mitchellh/mapstructure v1.5.0
-	github.com/openbkn-ai/bkn-foundry/comm-go v0.1.1-0.20260813155806-b731c9765f03
+	github.com/openbkn-ai/bkn-foundry/comm-go v0.1.1
 	github.com/opensearch-project/opensearch-go/v2 v2.3.0
 	github.com/robfig/cron/v3 v3.0.1
 	github.com/rs/xid v1.6.0

--- a/adp/bkn/bkn-backend/server/go.sum
+++ b/adp/bkn/bkn-backend/server/go.sum
@@ -164,6 +164,8 @@ github.com/openbkn-ai/bkn-foundry/comm-go v0.1.1-0.20260813121341-970e0bb7367d h
 github.com/openbkn-ai/bkn-foundry/comm-go v0.1.1-0.20260813121341-970e0bb7367d/go.mod h1:D0d+xRVJAk7DutF2g8I/TsXceE/1Iv3EmNNj8yxu2pA=
 github.com/openbkn-ai/bkn-foundry/comm-go v0.1.1-0.20260813155806-b731c9765f03 h1:vk8vJjMUDg81wPYNi0JGbcL0aTm/oONoj4B1zxaEf10=
 github.com/openbkn-ai/bkn-foundry/comm-go v0.1.1-0.20260813155806-b731c9765f03/go.mod h1:D0d+xRVJAk7DutF2g8I/TsXceE/1Iv3EmNNj8yxu2pA=
+github.com/openbkn-ai/bkn-foundry/comm-go v0.1.1 h1:IDgXuwZkAnFO3+BzcV1jvsDUiML/0IIaXR61tkr6uhQ=
+github.com/openbkn-ai/bkn-foundry/comm-go v0.1.1/go.mod h1:D0d+xRVJAk7DutF2g8I/TsXceE/1Iv3EmNNj8yxu2pA=
 github.com/opensearch-project/opensearch-go/v2 v2.3.0 h1:nQIEMr+A92CkhHrZgUhcfsrZjibvB3APXf2a1VwCmMQ=
 github.com/opensearch-project/opensearch-go/v2 v2.3.0/go.mod h1:8LDr9FCgUTVoT+5ESjc2+iaZuldqE+23Iq0r1XeNue8=
 github.com/pelletier/go-toml/v2 v2.2.4 h1:mye9XuhQ6gvn5h28+VilKrrPoQVanw5PMw/TB0t5Ec4=

--- a/adp/bkn/ontology-query/server/go.mod
+++ b/adp/bkn/ontology-query/server/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/fsnotify/fsnotify v1.10.1
 	github.com/gin-gonic/gin v1.12.0
 	github.com/mitchellh/mapstructure v1.5.0
-	github.com/openbkn-ai/bkn-foundry/comm-go v0.1.1-0.20260813155806-b731c9765f03
+	github.com/openbkn-ai/bkn-foundry/comm-go v0.1.1
 	github.com/opensearch-project/opensearch-go/v2 v2.3.0
 	github.com/rs/xid v1.6.0
 	github.com/smartystreets/goconvey v1.8.1

--- a/adp/bkn/ontology-query/server/go.sum
+++ b/adp/bkn/ontology-query/server/go.sum
@@ -157,6 +157,8 @@ github.com/openbkn-ai/bkn-foundry/comm-go v0.1.1-0.20260813121341-970e0bb7367d h
 github.com/openbkn-ai/bkn-foundry/comm-go v0.1.1-0.20260813121341-970e0bb7367d/go.mod h1:D0d+xRVJAk7DutF2g8I/TsXceE/1Iv3EmNNj8yxu2pA=
 github.com/openbkn-ai/bkn-foundry/comm-go v0.1.1-0.20260813155806-b731c9765f03 h1:vk8vJjMUDg81wPYNi0JGbcL0aTm/oONoj4B1zxaEf10=
 github.com/openbkn-ai/bkn-foundry/comm-go v0.1.1-0.20260813155806-b731c9765f03/go.mod h1:D0d+xRVJAk7DutF2g8I/TsXceE/1Iv3EmNNj8yxu2pA=
+github.com/openbkn-ai/bkn-foundry/comm-go v0.1.1 h1:IDgXuwZkAnFO3+BzcV1jvsDUiML/0IIaXR61tkr6uhQ=
+github.com/openbkn-ai/bkn-foundry/comm-go v0.1.1/go.mod h1:D0d+xRVJAk7DutF2g8I/TsXceE/1Iv3EmNNj8yxu2pA=
 github.com/opensearch-project/opensearch-go/v2 v2.3.0 h1:nQIEMr+A92CkhHrZgUhcfsrZjibvB3APXf2a1VwCmMQ=
 github.com/opensearch-project/opensearch-go/v2 v2.3.0/go.mod h1:8LDr9FCgUTVoT+5ESjc2+iaZuldqE+23Iq0r1XeNue8=
 github.com/pelletier/go-toml/v2 v2.2.4 h1:mye9XuhQ6gvn5h28+VilKrrPoQVanw5PMw/TB0t5Ec4=

--- a/adp/context-loader/agent-retrieval/go.mod
+++ b/adp/context-loader/agent-retrieval/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/json-iterator/go v1.1.12
 	github.com/mark3labs/mcp-go v0.57.0
 	github.com/nicksnyder/go-i18n/v2 v2.6.0
-	github.com/openbkn-ai/bkn-foundry/comm-go v0.1.1-0.20260813155806-b731c9765f03
+	github.com/openbkn-ai/bkn-foundry/comm-go v0.1.1
 	github.com/openbkn-ai/licverify v0.5.0
 	github.com/pkg/errors v0.9.1
 	github.com/smartystreets/goconvey v1.8.1

--- a/adp/context-loader/agent-retrieval/go.sum
+++ b/adp/context-loader/agent-retrieval/go.sum
@@ -123,6 +123,8 @@ github.com/openbkn-ai/bkn-foundry/comm-go v0.1.1-0.20260813121341-970e0bb7367d h
 github.com/openbkn-ai/bkn-foundry/comm-go v0.1.1-0.20260813121341-970e0bb7367d/go.mod h1:D0d+xRVJAk7DutF2g8I/TsXceE/1Iv3EmNNj8yxu2pA=
 github.com/openbkn-ai/bkn-foundry/comm-go v0.1.1-0.20260813155806-b731c9765f03 h1:vk8vJjMUDg81wPYNi0JGbcL0aTm/oONoj4B1zxaEf10=
 github.com/openbkn-ai/bkn-foundry/comm-go v0.1.1-0.20260813155806-b731c9765f03/go.mod h1:D0d+xRVJAk7DutF2g8I/TsXceE/1Iv3EmNNj8yxu2pA=
+github.com/openbkn-ai/bkn-foundry/comm-go v0.1.1 h1:IDgXuwZkAnFO3+BzcV1jvsDUiML/0IIaXR61tkr6uhQ=
+github.com/openbkn-ai/bkn-foundry/comm-go v0.1.1/go.mod h1:D0d+xRVJAk7DutF2g8I/TsXceE/1Iv3EmNNj8yxu2pA=
 github.com/openbkn-ai/licverify v0.5.0 h1:79aXlMYBDIzSLBXLhbrM3xOIDmMxhgCxG7PtZbPMNnE=
 github.com/openbkn-ai/licverify v0.5.0/go.mod h1:9Cnmt/tl7JN48+EjsGCjQERs1mNjuaBHdM+oVx0gvS4=
 github.com/opensearch-project/opensearch-go/v2 v2.3.0 h1:nQIEMr+A92CkhHrZgUhcfsrZjibvB3APXf2a1VwCmMQ=

--- a/adp/execution-factory/operator-integration/go.mod
+++ b/adp/execution-factory/operator-integration/go.mod
@@ -17,7 +17,7 @@ require (
 	github.com/json-iterator/go v1.1.12
 	github.com/mark3labs/mcp-go v0.37.0
 	github.com/nicksnyder/go-i18n/v2 v2.6.0
-	github.com/openbkn-ai/bkn-foundry/comm-go v0.1.1-0.20260813155806-b731c9765f03
+	github.com/openbkn-ai/bkn-foundry/comm-go v0.1.1
 	github.com/pkg/errors v0.9.1
 	github.com/qustavo/sqlhooks/v2 v2.1.0
 	github.com/redis/go-redis/v9 v9.14.1

--- a/adp/execution-factory/operator-integration/go.sum
+++ b/adp/execution-factory/operator-integration/go.sum
@@ -175,6 +175,8 @@ github.com/openbkn-ai/bkn-foundry/comm-go v0.1.1-0.20260813121341-970e0bb7367d h
 github.com/openbkn-ai/bkn-foundry/comm-go v0.1.1-0.20260813121341-970e0bb7367d/go.mod h1:D0d+xRVJAk7DutF2g8I/TsXceE/1Iv3EmNNj8yxu2pA=
 github.com/openbkn-ai/bkn-foundry/comm-go v0.1.1-0.20260813155806-b731c9765f03 h1:vk8vJjMUDg81wPYNi0JGbcL0aTm/oONoj4B1zxaEf10=
 github.com/openbkn-ai/bkn-foundry/comm-go v0.1.1-0.20260813155806-b731c9765f03/go.mod h1:D0d+xRVJAk7DutF2g8I/TsXceE/1Iv3EmNNj8yxu2pA=
+github.com/openbkn-ai/bkn-foundry/comm-go v0.1.1 h1:IDgXuwZkAnFO3+BzcV1jvsDUiML/0IIaXR61tkr6uhQ=
+github.com/openbkn-ai/bkn-foundry/comm-go v0.1.1/go.mod h1:D0d+xRVJAk7DutF2g8I/TsXceE/1Iv3EmNNj8yxu2pA=
 github.com/opensearch-project/opensearch-go/v2 v2.3.0 h1:nQIEMr+A92CkhHrZgUhcfsrZjibvB3APXf2a1VwCmMQ=
 github.com/opensearch-project/opensearch-go/v2 v2.3.0/go.mod h1:8LDr9FCgUTVoT+5ESjc2+iaZuldqE+23Iq0r1XeNue8=
 github.com/opentracing/opentracing-go v1.1.0/go.mod h1:UkNAQd3GIcIGf0SeVgPpRdFStlNbqXla1AfSYxPUl2o=

--- a/adp/vega/vega-backend/server/go.mod
+++ b/adp/vega/vega-backend/server/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/lib/pq v1.12.3
 	github.com/mitchellh/mapstructure v1.5.0
 	github.com/mohae/deepcopy v0.0.0-20170929034955-c48cc78d4826
-	github.com/openbkn-ai/bkn-foundry/comm-go v0.1.1-0.20260813155806-b731c9765f03
+	github.com/openbkn-ai/bkn-foundry/comm-go v0.1.1
 	github.com/opensearch-project/opensearch-go/v2 v2.3.0
 	github.com/robfig/cron/v3 v3.0.1
 	github.com/rs/xid v1.6.0

--- a/adp/vega/vega-backend/server/go.sum
+++ b/adp/vega/vega-backend/server/go.sum
@@ -165,6 +165,8 @@ github.com/openbkn-ai/bkn-foundry/comm-go v0.1.1-0.20260813121341-970e0bb7367d h
 github.com/openbkn-ai/bkn-foundry/comm-go v0.1.1-0.20260813121341-970e0bb7367d/go.mod h1:D0d+xRVJAk7DutF2g8I/TsXceE/1Iv3EmNNj8yxu2pA=
 github.com/openbkn-ai/bkn-foundry/comm-go v0.1.1-0.20260813155806-b731c9765f03 h1:vk8vJjMUDg81wPYNi0JGbcL0aTm/oONoj4B1zxaEf10=
 github.com/openbkn-ai/bkn-foundry/comm-go v0.1.1-0.20260813155806-b731c9765f03/go.mod h1:D0d+xRVJAk7DutF2g8I/TsXceE/1Iv3EmNNj8yxu2pA=
+github.com/openbkn-ai/bkn-foundry/comm-go v0.1.1 h1:IDgXuwZkAnFO3+BzcV1jvsDUiML/0IIaXR61tkr6uhQ=
+github.com/openbkn-ai/bkn-foundry/comm-go v0.1.1/go.mod h1:D0d+xRVJAk7DutF2g8I/TsXceE/1Iv3EmNNj8yxu2pA=
 github.com/opensearch-project/opensearch-go/v2 v2.3.0 h1:nQIEMr+A92CkhHrZgUhcfsrZjibvB3APXf2a1VwCmMQ=
 github.com/opensearch-project/opensearch-go/v2 v2.3.0/go.mod h1:8LDr9FCgUTVoT+5ESjc2+iaZuldqE+23Iq0r1XeNue8=
 github.com/pelletier/go-toml/v2 v2.2.4 h1:mye9XuhQ6gvn5h28+VilKrrPoQVanw5PMw/TB0t5Ec4=


### PR DESCRIPTION
## What Changed

- [x] Update the five locale consumers to use the released `github.com/openbkn-ai/bkn-foundry/comm-go v0.1.1` module tag.
- [x] Refresh the corresponding Go module checksums.
- [ ] Docs/doc 1 (not applicable)

---

## Why

- Related Issue: Internationalization P0 dependency release closeout.
- Related Feature: Accept-Language protocol P0.
- Background: The shared `comm-go/v0.1.1` tag now contains the merged locale negotiation and response semantics. Consumers should no longer depend on an implementation pseudo-version.

---

## How

- Key implementation points: Replace `v0.1.1-0.20260813155806-b731c9765f03` with `v0.1.1` in BKN Backend, Ontology Query, Vega Backend, Context Loader, and Operator Integration.
- Breaking changes (API, config, database, etc.): None.

---

## Testing

- [x] Unit tests passed locally
- [ ] Integration tests passed locally (not needed for version-only dependency update)
- [x] Verified in test environment (the same comm-go commit was deployed and exercised during i18n P0 joint testing)

Test notes:

- `GOWORK=off go list -m -json github.com/openbkn-ai/bkn-foundry/comm-go` resolves `v0.1.1` from the module cache for all five consumers.
- Passed focused test suites for BKN Backend, Ontology Query, Vega Backend, Context Loader, and Operator Integration.
- `git diff --check` passed.

---

## Risk & Rollback

- Potential risks: Consumers resolve the released tag instead of the equivalent pseudo-version.
- Rollback plan: Revert this single dependency-only commit; the previous pseudo-version remains available.

---

## Additional Notes

- `comm-go/v0.1.1` is an annotated module tag targeting merged commit `aafc9a37`.