### PR TITLE
fix(mf-model-api,context-loader): resolve the factory's default small model instead of guessing the name "reranker"

### DIFF
--- a/adp/context-loader/agent-retrieval/server/drivenadapters/mf_model_api_client.go
+++ b/adp/context-loader/agent-retrieval/server/drivenadapters/mf_model_api_client.go
@@ -33,9 +33,6 @@ type mfModelAPIClient struct {
 	logger     interfaces.Logger
 	baseURL    string
 	httpClient interfaces.HTTPClient
-	// defaultRerankModel 精排小模型名的部署级默认值（config.concept_search_config.rerank_model，
-	// 默认 "reranker"）。Rerank 收到空 model 时用它，避免把模型名硬编码进代码。
-	defaultRerankModel string
 }
 
 var (
@@ -52,7 +49,6 @@ func NewMFModelAPIClient() *mfModelAPIClient {
 			logger:             conf.GetLogger(),
 			baseURL:            conf.MFModelAPI.BuildURL("/api/private/mf-model-api"),
 			httpClient:         rest.NewHTTPClient(),
-			defaultRerankModel: conf.ConceptSearchConfig.RerankModel,
 		}
 	})
 	return mfModelAPIClientInst
@@ -139,17 +135,14 @@ func (c *mfModelAPIClient) Chat(ctx context.Context, req *interfaces.LLMChatReq)
 // DrivenRerankClient 接口实现
 // ============================================================
 
-// Rerank 对文档进行重排序。model 解析优先级：入参 model > 部署级默认
-// (config.concept_search_config.rerank_model) > 字面量 "reranker"（最后兜底）。
+// Rerank 对文档进行重排序。
+//
+// model 为空即「用模型管理里勾选的默认 reranker」，由 mf-model-api 按类型解析
+// （t_small_model.f_default=1）。**不再兜底成字面量 "reranker"**：那是拿一个猜出来的
+// 注册名去撞运气，注册名只要不叫 reranker 就是 NameNotExist 全线降级，而管理员在
+// 模型管理里勾的默认反倒没人读（#842）。要指定具体模型仍可由调用方传 model。
 func (c *mfModelAPIClient) Rerank(ctx context.Context, query string, documents []string, model string) (*interfaces.RerankResp, error) {
 	url := fmt.Sprintf("%s%s", c.baseURL, rerankURI)
-
-	if model == "" {
-		model = c.defaultRerankModel
-	}
-	if model == "" {
-		model = "reranker"
-	}
 	// 构建请求体
 	reqBody := map[string]interface{}{
 		"query":     query,

--- a/adp/context-loader/agent-retrieval/server/infra/config/config.go
+++ b/adp/context-loader/agent-retrieval/server/infra/config/config.go
@@ -151,7 +151,6 @@ type OpenSearchConfig struct {
 type KnConceptSearchConfig struct {
 	ConceptRecallSize int    `yaml:"concept_recall_size"`             // Concept rough recall size
 	KnnKValue         int    `yaml:"knn_k"`                           // knn k value
-	RerankModel       string `yaml:"rerank_model" default:"reranker"` // 关系精排小模型名；空则回退 "reranker"。可指向工厂里实际注册的 rerank 小模型，无需改代码
 }
 
 // MFModelAPI 配置使用统一的 PrivateBaseConfig 结构

--- a/adp/context-loader/agent-retrieval/server/interfaces/drivenadapters.go
+++ b/adp/context-loader/agent-retrieval/server/interfaces/drivenadapters.go
@@ -221,7 +221,7 @@ type KnowledgeRerankReq struct {
 	KnowledgeConcepts  []*ConceptResult          `json:"concepts" validate:"required"`                                 // Business knowledge network concepts
 	Action             KnowledgeRerankActionType `json:"action" validate:"required,oneof=llm vector" default:"vector"` // Action: llm based rerank, vector based rerank
 	LLMModel           string                    `json:"llm_model,omitempty"`                                          // per-request override for LLM rerank model; empty => config.Model
-	VectorModel        string                    `json:"vector_model,omitempty"`                                       // per-request override for vector rerank model; empty => "reranker"
+	VectorModel        string                    `json:"vector_model,omitempty"`                                       // per-request override for the rerank small model; empty => the factory default
 }
 
 // KnDataSourceConfig Knowledge network data source configuration
@@ -290,7 +290,7 @@ type KnSearchReq struct {
 	RetrievalConfig any                   `json:"retrieval_config,omitempty"`
 	OnlySchema      *bool                 `json:"only_schema,omitempty"`
 	EnableRerank    *bool                 `json:"enable_rerank,omitempty"`
-	RerankModel     *string               `json:"rerank_model,omitempty"` // 精排小模型名覆盖；空走部署级默认
+	RerankModel     *string               `json:"rerank_model,omitempty"` // 精排小模型名覆盖；空即用模型管理配置的默认 reranker
 	IncludeColumns  *bool                 `json:"include_columns,omitempty"`
 	// IndexOpsOnly 让响应里的 condition_operations 只保留索引带来的算子。由 MCP 层设置，
 	// 不进请求契约：比较算子按属性 type 可推导，逐个下发对 Agent 是纯噪音；REST 调用方

--- a/adp/context-loader/agent-retrieval/server/interfaces/kn_search_local.go
+++ b/adp/context-loader/agent-retrieval/server/interfaces/kn_search_local.go
@@ -95,7 +95,7 @@ type KnSearchSemanticInstanceRetrievalConfig struct {
 	// 默认 off：多一次模型调用、延迟涨 100~400ms，且 reranker 未注册在客户环境是常态。
 	// shadow 照常返回融合序，但额外调一次模型并记录两个序列的差异，用于翻默认前取证。
 	InstanceRerankMode string `json:"instance_rerank_mode" default:"off"`
-	// InstanceRerankModel 覆盖精排小模型名；留空由下游解析部署级默认。
+	// InstanceRerankModel 覆盖精排小模型名；留空即用模型管理配置的默认 reranker（#842）。
 	InstanceRerankModel string `json:"instance_rerank_model,omitempty"`
 	// RerankTopN 进入精排的候选数。精排是 O(N) 次前向，必须有上界。
 	RerankTopN int `json:"rerank_top_n" default:"50"`

--- a/adp/context-loader/agent-retrieval/server/interfaces/search_schema.go
+++ b/adp/context-loader/agent-retrieval/server/interfaces/search_schema.go
@@ -19,9 +19,9 @@ type SearchSchemaReq struct {
 	SchemaBrief  *bool              `json:"schema_brief,omitempty" default:"false"`
 	EnableRerank *bool              `json:"enable_rerank,omitempty" default:"true"`
 	// RerankModel overrides the relation fine-ranking small model for this request.
-	// Ops/power-user escape hatch: empty falls back to the deployment default
-	// (config.concept_search_config.rerank_model). Not surfaced in the MCP tool
-	// schema — agents should not pick reranker model names.
+	// Ops/power-user escape hatch: empty means "use whatever the model factory has
+	// marked as the default reranker" (#842). Not surfaced in the MCP tool schema —
+	// agents should not pick reranker model names.
 	RerankModel *string `json:"rerank_model,omitempty"`
 	// IncludeColumns, when true, adds each data property's physical column name
 	// (mapped_field) to the response, for writing run_sql against the resource.

--- a/adp/context-loader/agent-retrieval/server/logics/knrerank/knowledge_rerank.go
+++ b/adp/context-loader/agent-retrieval/server/logics/knrerank/knowledge_rerank.go
@@ -205,7 +205,7 @@ func (r *KnowledgeReranker) rerankByVector(ctx context.Context, req *interfaces.
 		}
 	}
 
-	// 调用向量重排服务（req.VectorModel 为空时下游回退默认 reranker）
+	// 调用向量重排服务（req.VectorModel 为空即用模型管理配置的默认 reranker，见 #842）
 	resp, err := r.mfModelClient.Rerank(ctx, question, documents, req.VectorModel)
 	if err != nil {
 		r.logger.WithContext(ctx).Errorf("[KnowledgeReranker#rerankByVector] Rerank service failed: %v", err)

--- a/adp/context-loader/agent-retrieval/server/logics/knsearch/concept_retrieval.go
+++ b/adp/context-loader/agent-retrieval/server/logics/knsearch/concept_retrieval.go
@@ -653,7 +653,7 @@ func (s *localSearchImpl) rankRelationTypes(
 		documents[i] = buildRelationText(sourceName, relationName, targetName, rel.Comment)
 	}
 
-	// 调用 Rerank 服务；model 为空由 client 解析部署级默认（config.rerank_model → "reranker"）
+	// 调用 Rerank 服务；model 为空即用模型管理里勾选的默认 reranker（#842）
 	rerankResp, err := s.rerankClient.Rerank(ctx, query, documents, rerankModel)
 	if err != nil {
 		// 优雅降级：reranker 不可用（未注册 / NameNotExist）时，不丢相关性。

--- a/infra/mf-model-api/app/commons/errors/__init__.py
+++ b/infra/mf-model-api/app/commons/errors/__init__.py
@@ -1251,6 +1251,14 @@ ModelQuotaControllerUserModelConfigNoLeftSpaceError = {
     "solution": "请联系管理员增加额度",
     "link": ""
 }
+ModelFactory_DefaultSmallModel_NotExist = {
+    "code": "ModelFactory.ExternalSmallModel.Used.DefaultNotExist",
+    "description": "管理员没有配置该类型的默认小模型",
+    "detail": "管理员没有配置该类型的默认小模型",
+    "solution": "请在模型管理中为该类型设置默认小模型",
+    "link": ""
+}
+
 ModelFactory_DedaultModel_NotExist = {
     "code": "ModelFactory.ExternalSmallModel.Used.NameNotExist",
     "description": "管理员没有配置默认大模型",

--- a/infra/mf-model-api/app/controller/small_model_controller.py
+++ b/infra/mf-model-api/app/controller/small_model_controller.py
@@ -538,6 +538,7 @@ async def reranker_model_used(request, userId, language, role, func_module, priv
                                      expire=_model_cache_ttl(is_default))
 
         model_info = model_info[0]
+        model_name = model_info["f_model_name"]
         config_info = json.loads(model_info["f_model_config"])
         adapter = model_info["f_adapter"]
         model_id = model_info["f_model_id"]

--- a/infra/mf-model-api/app/controller/small_model_controller.py
+++ b/infra/mf-model-api/app/controller/small_model_controller.py
@@ -30,11 +30,38 @@ def _model_cache_ttl(is_default):
     return DEFAULT_MODEL_CACHE_TTL_SECONDS if is_default else MODEL_CACHE_TTL_SECONDS
 
 
+# #842 之前各服务硬编码的兜底名字：context-loader 猜 "reranker"、vega 猜 "embedding"
+# （#296）。存量库里 f_default 全是 0——「设为默认」是后加的能力，没人点过就没人置位，
+# 也没有任何迁移回填它。若默认解析取不到就直接 400，存量环境升级当天精排即静默退回
+# 原序（三处调用方都是优雅降级，只打一条 warn）。
+#
+# 所以默认解析落空时，按老约定的名字再兜一次，命中就打 warn 指路。等日志里不再出现
+# 这条 warn，这一跳就可以删掉。
+LEGACY_DEFAULT_MODEL_NAMES = {
+    RERANKER_MODEL_TYPE: "reranker",
+    "embedding": "embedding",
+}
+
+
 def _load_small_model(is_default, model_type, model_name, model_id):
     """按「有没有指定模型」分流：指定了按名字/ID 查，没指定取该类型的系统默认。"""
-    if is_default:
-        return small_model_dao.get_default_by_type(model_type)
-    return small_model_dao.get_model_info_by_name_id(model_name, model_id)
+    if not is_default:
+        return small_model_dao.get_model_info_by_name_id(model_name, model_id)
+
+    model_info = small_model_dao.get_default_by_type(model_type)
+    if model_info:
+        return model_info
+
+    legacy_name = LEGACY_DEFAULT_MODEL_NAMES.get(model_type)
+    if not legacy_name:
+        return model_info
+
+    model_info = small_model_dao.get_model_info_by_name_id(legacy_name, None)
+    if model_info:
+        StandLogger.warn(
+            f"{model_type} 未配置默认小模型，暂按旧命名约定回退到 {legacy_name}；"
+            f"请在模型管理中为该类型勾选默认模型")
+    return model_info
 
 
 def _model_missing_error(is_default):

--- a/infra/mf-model-api/app/controller/small_model_controller.py
+++ b/infra/mf-model-api/app/controller/small_model_controller.py
@@ -16,6 +16,34 @@ from app.mydb.ConnectUtil import redis_util, get_redis_util
 from app.utils.permission_manager import PermissionManager, permission_manager
 
 
+# 小模型类型常量，与 t_small_model.f_model_type 取值一致。
+RERANKER_MODEL_TYPE = "reranker"
+
+# 默认模型是管理员随时可改的**指针**，不是某个具体模型的配置。按名字查到的配置缓存
+# 一天没问题，指针缓存一天就会出现「换了默认、一天之内仍按旧的调」——#552 记的正是
+# 这个坑。所以默认路径用短 TTL。
+DEFAULT_MODEL_CACHE_TTL_SECONDS = 60
+MODEL_CACHE_TTL_SECONDS = 3600 * 24
+
+
+def _model_cache_ttl(is_default):
+    return DEFAULT_MODEL_CACHE_TTL_SECONDS if is_default else MODEL_CACHE_TTL_SECONDS
+
+
+def _load_small_model(is_default, model_type, model_name, model_id):
+    """按「有没有指定模型」分流：指定了按名字/ID 查，没指定取该类型的系统默认。"""
+    if is_default:
+        return small_model_dao.get_default_by_type(model_type)
+    return small_model_dao.get_model_info_by_name_id(model_name, model_id)
+
+
+def _model_missing_error(is_default):
+    """区分「你指定的模型不存在」与「管理员没配默认模型」——两者的处理方式完全不同。"""
+    if is_default:
+        return ModelFactory_DefaultSmallModel_NotExist
+    return ModelFactory_ExternalSmallModel_Used_NameNotExist
+
+
 async def add_model(request: logics.AddExternalSmallModel, userId, language, role):
     try:
         model_id = str(worker.get_id())
@@ -442,13 +470,17 @@ async def reranker_model_used(request, userId, language, role, func_module, priv
     try:
         model_name = request.model
         model_id = request.model_id
-        if not model_name and not model_id:
-            error_dict = ModelFactory_Router_ParamError_ParamMissing_Error
-            error_dict['detail'] = "model或者model_id至少需要传递一个"
-            return JSONResponse(status_code=400, content=error_dict)
         query = request.query
         documents = request.documents
-        if model_name:
+        # 都不传即「用模型管理里勾选的默认 reranker」，与大模型侧一致
+        # （llm_controller 的 default_model_3ed523 哨兵 + get_data_from_default_model）。
+        # 在此之前这里直接 400，逼得调用方必须填名字，于是各服务只能硬编码一个猜出来的
+        # 名字兜底（context-loader 猜 "reranker"、vega 猜 "embedding"），注册名一改就
+        # 全线 NameNotExist —— 见 #842 与 #296。
+        is_default = not model_name and not model_id
+        if is_default:
+            cache_key = f"dip:model-api:small-model:default:{RERANKER_MODEL_TYPE}:list"
+        elif model_name:
             cache_key = f"dip:model-api:small-model:{model_name}:list"
         else:
             cache_key = f"dip:model-api:small-model:{model_id}:list"
@@ -463,18 +495,20 @@ async def reranker_model_used(request, userId, language, role, func_module, priv
             except Exception as e:
                 StandLogger.warn(f"解析缓存数据失败: {str(e)}, key={cache_key}, value={res}")
                 # 缓存解析失败，回退到数据库查询
-                model_info = small_model_dao.get_model_info_by_name_id(model_name, model_id)
+                model_info = _load_small_model(is_default, RERANKER_MODEL_TYPE, model_name, model_id)
                 if len(model_info) == 0:
-                    return JSONResponse(status_code=400, content=ModelFactory_ExternalSmallModel_Used_NameNotExist)
+                    return JSONResponse(status_code=400, content=_model_missing_error(is_default))
                 # 重新设置缓存
-                await redis_util.set_str(key=cache_key, value=str(model_info), expire=3600 * 24)
+                await redis_util.set_str(key=cache_key, value=str(model_info),
+                                         expire=_model_cache_ttl(is_default))
         else:
             # 缓存不存在或非预期类型，从数据库获取
-            model_info = small_model_dao.get_model_info_by_name_id(model_name, model_id)
+            model_info = _load_small_model(is_default, RERANKER_MODEL_TYPE, model_name, model_id)
             if len(model_info) == 0:
-                return JSONResponse(status_code=400, content=ModelFactory_ExternalSmallModel_Used_NameNotExist)
+                return JSONResponse(status_code=400, content=_model_missing_error(is_default))
             # 设置缓存
-            await redis_util.set_str(key=cache_key, value=str(model_info), expire=3600 * 24)
+            await redis_util.set_str(key=cache_key, value=str(model_info),
+                                     expire=_model_cache_ttl(is_default))
 
         model_info = model_info[0]
         config_info = json.loads(model_info["f_model_config"])

--- a/infra/mf-model-api/app/dao/small_model_dao.py
+++ b/infra/mf-model-api/app/dao/small_model_dao.py
@@ -52,6 +52,20 @@ class SmallModelDao:
         return res
 
     @connect_execute_close_db
+    def get_default_by_type(self, model_type, connection, cursor):
+        """取某 model_type(embedding/reranker) 下的系统默认小模型(f_default=1)。
+
+        与大模型侧 llm_model_dao.get_data_from_default_model 对齐：调用方不指定模型时，
+        用管理员在模型管理里勾选的默认模型，而不是让各服务各自硬编码一个名字去猜
+        （见 #842、#296——猜名字的后果是注册名一改就全线 NameNotExist）。
+        """
+        sql = """select f_model_id, f_model_name, f_model_type, f_model_config,f_adapter,f_adapter_code,f_embedding_dim
+                    from t_small_model where f_default = 1 and f_model_type = %s"""
+        cursor.execute(sql, model_type)
+        res = cursor.fetchall()
+        return res
+
+    @connect_execute_close_db
     def get_model_info_list(self, page, size, order, rule, model_name, model_type, model_series, permission_ids,
                             connection, cursor):
         sql = """select f_model_id, f_model_name, f_model_type, f_model_config, f_create_time, f_update_time, f_create_by,f_update_by,f_adapter,f_adapter_code

--- a/infra/mf-model-api/app/dao/small_model_dao.py
+++ b/infra/mf-model-api/app/dao/small_model_dao.py
@@ -58,9 +58,15 @@ class SmallModelDao:
         与大模型侧 llm_model_dao.get_data_from_default_model 对齐：调用方不指定模型时，
         用管理员在模型管理里勾选的默认模型，而不是让各服务各自硬编码一个名字去猜
         （见 #842、#296——猜名字的后果是注册名一改就全线 NameNotExist）。
+
+        管理端「清掉旧默认」与「置新默认」是两次独立提交（mf-model-manager 的
+        small_model_controller），中间失败会在库里留下同类型多行 f_default = 1。
+        按 f_update_time 倒序取第一行，至少让此后的解析结果是确定的——最后被置位
+        的那一行。
         """
         sql = """select f_model_id, f_model_name, f_model_type, f_model_config,f_adapter,f_adapter_code,f_embedding_dim
-                    from t_small_model where f_default = 1 and f_model_type = %s"""
+                    from t_small_model where f_default = 1 and f_model_type = %s
+                    order by f_update_time desc"""
         cursor.execute(sql, model_type)
         res = cursor.fetchall()
         return res

--- a/infra/mf-model-api/app/mydb/my_pymysql_pool.py
+++ b/infra/mf-model-api/app/mydb/my_pymysql_pool.py
@@ -1,9 +1,14 @@
 # -*-coding:utf-8-*-
 
+import functools
+
 from app.mydb.pymysql_pool import PymysqlPool
 
 
 def connect_execute_commit_close_db(func):
+    # functools.wraps 保留被包函数的名字/文档，并留下 __wrapped__——没有它，dao 层
+    # 的 SQL 就只能连着真库才验得到，单测里拿不到未包装的函数体。
+    @functools.wraps(func)
     def wrapper(*args, **kwargs):
         pymysql_pool = PymysqlPool.get_pool()
         connection = pymysql_pool.connection()
@@ -26,6 +31,7 @@ def connect_execute_commit_close_db(func):
 
 
 def connect_execute_close_db(func):
+    @functools.wraps(func)
     def wrapper(*args, **kwargs):
         pymysql_pool = PymysqlPool.get_pool()
         connection = pymysql_pool.connection()

--- a/infra/mf-model-api/app/test/test_small_model_default_resolution.py
+++ b/infra/mf-model-api/app/test/test_small_model_default_resolution.py
@@ -43,6 +43,50 @@ class TestDefaultSmallModelResolution:
             dao.get_default_by_type.assert_not_called()
             assert result[0]["f_model_name"] == "bge-reranker"
 
+    def test_unset_default_falls_back_to_the_legacy_name(self):
+        """存量库里 f_default 全是 0，也没有迁移回填它。
+
+        默认解析落空就直接 400 的话，升级当天精排即静默退回原序——调用方都是优雅
+        降级只打 warn。所以这里按老约定的名字再兜一次。
+        """
+        with patch("app.controller.small_model_controller.small_model_dao") as dao:
+            dao.get_default_by_type.return_value = []
+            dao.get_model_info_by_name_id.return_value = [{"f_model_name": "reranker"}]
+
+            result = _load_small_model(True, RERANKER_MODEL_TYPE, "", "")
+
+            dao.get_model_info_by_name_id.assert_called_once_with("reranker", None)
+            assert result[0]["f_model_name"] == "reranker"
+
+    def test_configured_default_wins_over_the_legacy_name(self):
+        """管理员勾了默认就以它为准，旧名字那一跳根本不该发生。"""
+        with patch("app.controller.small_model_controller.small_model_dao") as dao:
+            dao.get_default_by_type.return_value = [{"f_model_name": "gte-rerank-v2"}]
+
+            _load_small_model(True, RERANKER_MODEL_TYPE, "", "")
+
+            dao.get_model_info_by_name_id.assert_not_called()
+
+    def test_no_legacy_name_for_an_unknown_type(self):
+        """老约定只存在于 reranker / embedding 两类，别的类型不许瞎猜名字。"""
+        with patch("app.controller.small_model_controller.small_model_dao") as dao:
+            dao.get_default_by_type.return_value = []
+
+            result = _load_small_model(True, "ocr", "", "")
+
+            dao.get_model_info_by_name_id.assert_not_called()
+            assert result == []
+
+    def test_legacy_fallback_covers_the_embedding_guess_too(self):
+        """vega 猜的是 "embedding"（#296），同样得兜住。"""
+        with patch("app.controller.small_model_controller.small_model_dao") as dao:
+            dao.get_default_by_type.return_value = []
+            dao.get_model_info_by_name_id.return_value = [{"f_model_name": "embedding"}]
+
+            _load_small_model(True, "embedding", "", "")
+
+            dao.get_model_info_by_name_id.assert_called_once_with("embedding", None)
+
     def test_missing_error_distinguishes_the_two_cases(self):
         """「你指定的模型不存在」与「管理员没配默认」处理方式不同，错误码不能混。"""
         assert _model_missing_error(False) is ModelFactory_ExternalSmallModel_Used_NameNotExist
@@ -79,3 +123,20 @@ class TestSmallModelDaoDefaultQuery:
         assert "f_default = 1" in sql
         assert "f_model_type = %s" in sql
         assert params == RERANKER_MODEL_TYPE
+
+    def test_query_orders_so_the_result_is_deterministic(self):
+        """管理端清旧默认与置新默认是两次独立提交，中途失败会留下多行 f_default=1。
+
+        没有 order by 时取 [0] 拿到哪一行由存储引擎决定，此后默认解析结果不确定。
+        """
+        from app.dao.small_model_dao import SmallModelDao
+
+        cursor = Mock()
+        cursor.fetchall.return_value = []
+
+        SmallModelDao.get_default_by_type.__wrapped__(
+            SmallModelDao(), RERANKER_MODEL_TYPE, Mock(), cursor
+        )
+
+        sql = cursor.execute.call_args[0][0]
+        assert "order by f_update_time desc" in sql

--- a/infra/mf-model-api/app/test/test_small_model_default_resolution.py
+++ b/infra/mf-model-api/app/test/test_small_model_default_resolution.py
@@ -4,7 +4,7 @@
 兜底（context-loader 猜 "reranker"、vega 猜 "embedding"），注册名一改就全线
 NameNotExist——而管理员在模型管理里勾的默认反倒没人读。
 """
-from unittest.mock import patch
+from unittest.mock import Mock, patch
 
 from app.controller.small_model_controller import (
     DEFAULT_MODEL_CACHE_TTL_SECONDS,
@@ -56,3 +56,26 @@ class TestDefaultSmallModelResolution:
         assert _model_cache_ttl(True) == DEFAULT_MODEL_CACHE_TTL_SECONDS
         assert _model_cache_ttl(False) == MODEL_CACHE_TTL_SECONDS
         assert DEFAULT_MODEL_CACHE_TTL_SECONDS < MODEL_CACHE_TTL_SECONDS
+
+
+class TestSmallModelDaoDefaultQuery:
+    def test_query_filters_by_default_flag_and_type(self):
+        """SQL 必须同时按 f_default=1 与 f_model_type 过滤。
+
+        只按 f_default 查会串类型：embedding 与 reranker 各有各的默认，
+        查错类型的后果是拿一个 embedding 去做重排。
+        """
+        from app.dao.small_model_dao import SmallModelDao
+
+        cursor = Mock()
+        cursor.fetchall.return_value = [{"f_model_name": "gte-rerank-v2"}]
+
+        # 装饰器负责建连接，这里直接调用被包裹的函数体（靠 functools.wraps 暴露的 __wrapped__）
+        SmallModelDao.get_default_by_type.__wrapped__(
+            SmallModelDao(), RERANKER_MODEL_TYPE, Mock(), cursor
+        )
+
+        sql, params = cursor.execute.call_args[0]
+        assert "f_default = 1" in sql
+        assert "f_model_type = %s" in sql
+        assert params == RERANKER_MODEL_TYPE

--- a/infra/mf-model-api/app/test/test_small_model_default_resolution.py
+++ b/infra/mf-model-api/app/test/test_small_model_default_resolution.py
@@ -1,0 +1,58 @@
+"""不指定模型时按类型解析系统默认小模型（#842）。
+
+在此之前 reranker 端点收到空 model 直接 400，逼得每个调用方硬编码一个猜出来的名字
+兜底（context-loader 猜 "reranker"、vega 猜 "embedding"），注册名一改就全线
+NameNotExist——而管理员在模型管理里勾的默认反倒没人读。
+"""
+from unittest.mock import patch
+
+from app.controller.small_model_controller import (
+    DEFAULT_MODEL_CACHE_TTL_SECONDS,
+    MODEL_CACHE_TTL_SECONDS,
+    RERANKER_MODEL_TYPE,
+    _load_small_model,
+    _model_cache_ttl,
+    _model_missing_error,
+)
+from app.commons.errors import (
+    ModelFactory_DefaultSmallModel_NotExist,
+    ModelFactory_ExternalSmallModel_Used_NameNotExist,
+)
+
+
+class TestDefaultSmallModelResolution:
+    def test_unspecified_model_resolves_the_type_default(self):
+        """既没给名字也没给 id 时，走 f_default=1 那条，而不是按名字瞎查。"""
+        with patch("app.controller.small_model_controller.small_model_dao") as dao:
+            dao.get_default_by_type.return_value = [{"f_model_name": "gte-rerank-v2"}]
+
+            result = _load_small_model(True, RERANKER_MODEL_TYPE, "", "")
+
+            dao.get_default_by_type.assert_called_once_with(RERANKER_MODEL_TYPE)
+            dao.get_model_info_by_name_id.assert_not_called()
+            assert result[0]["f_model_name"] == "gte-rerank-v2"
+
+    def test_explicit_model_still_queries_by_name(self):
+        """显式指定仍按名字/ID 查——默认解析只是兜底，不能覆盖调用方的选择。"""
+        with patch("app.controller.small_model_controller.small_model_dao") as dao:
+            dao.get_model_info_by_name_id.return_value = [{"f_model_name": "bge-reranker"}]
+
+            result = _load_small_model(False, RERANKER_MODEL_TYPE, "bge-reranker", "")
+
+            dao.get_model_info_by_name_id.assert_called_once_with("bge-reranker", "")
+            dao.get_default_by_type.assert_not_called()
+            assert result[0]["f_model_name"] == "bge-reranker"
+
+    def test_missing_error_distinguishes_the_two_cases(self):
+        """「你指定的模型不存在」与「管理员没配默认」处理方式不同，错误码不能混。"""
+        assert _model_missing_error(False) is ModelFactory_ExternalSmallModel_Used_NameNotExist
+        assert _model_missing_error(True) is ModelFactory_DefaultSmallModel_NotExist
+
+    def test_default_pointer_is_cached_briefly(self):
+        """默认模型是管理员随时可改的指针，不是某个模型的配置。
+
+        指针缓存一天就会出现「换了默认、一天之内仍按旧的调」——#552 记的正是这个坑。
+        """
+        assert _model_cache_ttl(True) == DEFAULT_MODEL_CACHE_TTL_SECONDS
+        assert _model_cache_ttl(False) == MODEL_CACHE_TTL_SECONDS
+        assert DEFAULT_MODEL_CACHE_TTL_SECONDS < MODEL_CACHE_TTL_SECONDS


### PR DESCRIPTION
## Links

- Closes #842
- Related: #296 (the same anti-pattern on the embedding side), #552 (the cache half of it)
- Branch: `fix/842-default-small-model`

## Problem

The model factory lets an administrator mark a default small model
(`t_small_model.f_default`), and mf-model-manager even ships an internal endpoint for services
to resolve it. **Nothing on the read side used it.**

The reason is one line in mf-model-api: the small-model endpoints reject an empty `model`
outright ("model或者model_id至少需要传递一个"). With no way to say "use the default", every
caller had to invent a name to fall back to — context-loader guessed `"reranker"`, vega guesses
`"embedding"` (#296). Rename the registered model and the guess stops matching: `NameNotExist`,
and every rerank path degrades silently while the administrator's chosen default sits unread.

The LLM side never had this problem — `llm_controller` maps an empty model onto `f_default=1`
and callers stay configuration-free. context-loader's own comment claims small models work "the
same way, zero configuration on the service side"; they did not.

## Change

**mf-model-api**

- `small_model_dao.get_default_by_type` — `where f_default = 1 and f_model_type = %s`. Filtering
  on both matters: embedding and reranker each have their own default.
- The reranker endpoint resolves the type default when neither `model` nor `model_id` is given,
  instead of returning 400.
- New `ModelFactory_DefaultSmallModel_NotExist`. "The model you named does not exist" and "the
  administrator has not configured a default" call for different fixes, so they get different
  codes.
- The default lookup is cached for 60s rather than 24h. A default is a **pointer** the
  administrator can repoint at any time, not a model's configuration; caching a pointer for a
  day means "changed the default, still calling the old one until tomorrow" — which is exactly
  what #552 records.

**context-loader**

- Dropped the literal `"reranker"` fallback in `Rerank`; an empty model now travels down and the
  factory resolves it.
- Deleted the deployment knob `config.concept_search_config.rerank_model`. The factory's default
  flag and a model name in deployment yaml are two sources for one decision, and two sources
  drift. Per-request overrides (`search_schema.rerank_model`,
  `retrieval_config.…instance_rerank_model`) stay as the escape hatch — those are request-scoped,
  not deployment-scoped.
- Comments that claimed "empty falls back to the deployment default" now say what the code does.

The embedding side is out of scope — vega and ontology-query both pass `model_id`, so they are
unaffected; that half stays with #296.

## Verified on the VM

Unit-testable parts are covered by `test_small_model_default_resolution.py`, but this repo's
Python tests need an environment this laptop does not have (`AsyncMock` needs 3.8+, local Python
is 3.7), so the checks were also run **inside the running mf-model-api pod against the real
database** — including the DAO query, which only a live schema can validate:

```
PASS 未指定模型走 f_default=1        PASS 显式指定仍按名字查
PASS 未指定模型不按名字查            PASS 显式指定不碰默认
PASS 拿到默认模型                    PASS 错误码区分两种缺失
PASS 默认指针短缓存                  PASS 库里查得到默认 reranker / 返回带模型配置
```

Then end to end, with the patched image deployed:

| request | before | after |
|---|---|---|
| `POST /small-model/reranker` with no `model` | 400 param-missing | 200, real scores (Maracanã 0.936 vs Kashima 0.162) |
| with `model: "no-such-reranker"` | `NameNotExist` | `NameNotExist` (unchanged) |
| context-loader `kn_search` with rerank on, **no model name** | — | reranking engaged, Maracanã promoted to first |

**The decisive test**: renaming the registered model from `reranker` to `gte-rerank-v2` — so that
nothing named `reranker` exists any more — and re-running. Reranking kept working, which is only
possible if the resolution goes through `f_default=1` rather than the guessed name. Under the old
code that rename is precisely what would have silently disabled every rerank path.

One thing that surfaced while testing: immediately after the rename, a request explicitly naming
`reranker` still succeeded, because the name-keyed cache entry survives for 24h. That is #552 in
the flesh, and it explains why this class of bug is hard to notice — the damage from a rename or
deletion only shows up a day later.

VM restored afterwards: model name, the object type's `condition_operations`, and both service
images.

## Existing deployments keep their rerank

`f_default` is 0 on every row of an existing `t_small_model`: marking a default came later, nobody
had to click it, and no migration backfills it. Resolving only through `f_default` would therefore
return nothing the day an existing deployment upgrades — a 400 that all three callers absorb by
degrading gracefully, so concept, relation and instance rerank would all quietly fall back to the
unranked order with a single warn in the log.

So the resolution takes a second hop: when the type has no default configured, it looks the model
up under the name each service used to hardcode (`reranker`, and `embedding` for #296) and logs a
warn naming the fix — set a default in model management. The hop lives in mf-model-api, not back in
the callers: the point of this PR is that no service invents a name, and a single legacy lookup on
the resolving side keeps that true while existing deployments carry on unchanged. Once the warn
stops appearing, the hop can be deleted.

`get_default_by_type` also orders by `f_update_time desc`. Clearing the old default and setting the
new one are two separate commits in mf-model-manager, so a failure between them leaves more than one
row flagged for a type; without an order, which one wins is up to the storage engine.

## Pre-Merge Checklist

- [x] Tests added
- [x] Verified end to end on the dev VM, including a rename test that isolates the mechanism
- [x] Backward compatible: naming a model behaves exactly as before; only the previously-rejected
      empty-model case changes, and it changes from an error into the documented behaviour
- [ ] Human review

🤖 Generated with [Claude Code](https://claude.com/claude-code)

