### PR TITLE
feat(observability): add independent manual archives

### DIFF
--- a/bkn-trace/agent-observability/charts/agent-observability/templates/deployment.yaml
+++ b/bkn-trace/agent-observability/charts/agent-observability/templates/deployment.yaml
@@ -145,6 +145,14 @@ spec:
               value: {{ .Values.observability.sourceTimeout | quote }}
             - name: BKN_OBSERVABILITY_MAX_CONCURRENT_SOURCES
               value: {{ .Values.observability.maxConcurrentSources | quote }}
+            {{- if and .Values.observability.archive.ossGatewayURL .Values.observability.archive.storageID }}
+            - name: BKN_OBSERVABILITY_ARCHIVE_OSS_GATEWAY_URL
+              value: {{ .Values.observability.archive.ossGatewayURL | quote }}
+            - name: BKN_OBSERVABILITY_ARCHIVE_STORAGE_ID
+              value: {{ .Values.observability.archive.storageID | quote }}
+            - name: BKN_OBSERVABILITY_ARCHIVE_PREFIX
+              value: {{ .Values.observability.archive.prefix | quote }}
+            {{- end }}
             {{- if .Values.observability.sourceCoverage.enabled }}
             - name: BKN_OBSERVABILITY_SOURCE_COVERAGE_METRICS_ENDPOINT
               value: {{ required "observability.sourceCoverage.metricsEndpoint is required when source coverage monitoring is enabled" .Values.observability.sourceCoverage.metricsEndpoint | quote }}

--- a/bkn-trace/agent-observability/charts/agent-observability/values.yaml
+++ b/bkn-trace/agent-observability/charts/agent-observability/values.yaml
@@ -92,6 +92,12 @@ observability:
     secretKey: key
   sourceTimeout: 3s
   maxConcurrentSources: 4
+  archive:
+    # Object storage is configured only by the deployment owner. Studio never
+    # receives storage credentials or an arbitrary archive target.
+    ossGatewayURL: ""
+    storageID: ""
+    prefix: observability-archive
   sourceCoverage:
     # Optional independent health probe. It is disabled unless the installation
     # uses the persistent MariaDB Core store and provides a cluster-internal

--- a/bkn-trace/agent-observability/migrations/mariadb/v016/init.sql
+++ b/bkn-trace/agent-observability/migrations/mariadb/v016/init.sql
@@ -6,6 +6,7 @@ CREATE TABLE IF NOT EXISTS bkn_trace_archive_jobs (
     range_to DATETIME(6) NOT NULL,
     archive_status VARCHAR(32) CHARACTER SET ascii COLLATE ascii_bin NOT NULL,
     candidate_ids LONGTEXT NOT NULL,
+    candidate_payloads LONGTEXT NOT NULL,
     candidate_count BIGINT UNSIGNED NOT NULL,
     manifest_ref VARCHAR(1024) NULL,
     error_message VARCHAR(1024) NULL,

--- a/bkn-trace/agent-observability/migrations/mariadb/v016/init.sql
+++ b/bkn-trace/agent-observability/migrations/mariadb/v016/init.sql
@@ -1,0 +1,16 @@
+CREATE TABLE IF NOT EXISTS bkn_trace_archive_jobs (
+    archive_job_id VARCHAR(96) CHARACTER SET ascii COLLATE ascii_bin NOT NULL,
+    tenant_id VARCHAR(64) CHARACTER SET ascii COLLATE ascii_bin NOT NULL,
+    archive_kind VARCHAR(16) CHARACTER SET ascii COLLATE ascii_bin NOT NULL,
+    range_from DATETIME(6) NULL,
+    range_to DATETIME(6) NOT NULL,
+    archive_status VARCHAR(32) CHARACTER SET ascii COLLATE ascii_bin NOT NULL,
+    candidate_ids LONGTEXT NOT NULL,
+    candidate_count BIGINT UNSIGNED NOT NULL,
+    manifest_ref VARCHAR(1024) NULL,
+    error_message VARCHAR(1024) NULL,
+    created_at DATETIME(6) NOT NULL,
+    updated_at DATETIME(6) NOT NULL,
+    PRIMARY KEY (archive_job_id),
+    INDEX idx_bkn_trace_archive_job_tenant_kind (tenant_id, archive_kind, created_at)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin;

--- a/bkn-trace/agent-observability/migrations/mariadb/v016/schema.go
+++ b/bkn-trace/agent-observability/migrations/mariadb/v016/schema.go
@@ -1,0 +1,8 @@
+package v016
+
+import _ "embed"
+
+//go:embed init.sql
+var schemaSQL string
+
+func SchemaSQL() string { return schemaSQL }

--- a/bkn-trace/agent-observability/src/boot/bootstrap.go
+++ b/bkn-trace/agent-observability/src/boot/bootstrap.go
@@ -13,6 +13,7 @@ import (
 
 	docs "github.com/openbkn-ai/bkn-foundry/bkn-trace/agent-observability/docs/swagger"
 	"github.com/openbkn-ai/bkn-foundry/bkn-trace/agent-observability/src/conf"
+	"github.com/openbkn-ai/bkn-foundry/bkn-trace/agent-observability/src/domain/service/archivesvc"
 	"github.com/openbkn-ai/bkn-foundry/bkn-trace/agent-observability/src/domain/service/assemblysvc"
 	"github.com/openbkn-ai/bkn-foundry/bkn-trace/agent-observability/src/domain/service/evidencesvc"
 	"github.com/openbkn-ai/bkn-foundry/bkn-trace/agent-observability/src/domain/service/ledgersvc"
@@ -23,6 +24,7 @@ import (
 	"github.com/openbkn-ai/bkn-foundry/bkn-trace/agent-observability/src/domain/service/sourcecoveragesvc"
 	"github.com/openbkn-ai/bkn-foundry/bkn-trace/agent-observability/src/domain/service/tracesvc"
 	"github.com/openbkn-ai/bkn-foundry/bkn-trace/agent-observability/src/domain/valueobject/observabilityvo"
+	"github.com/openbkn-ai/bkn-foundry/bkn-trace/agent-observability/src/drivenadapter/dbaccess/mariadb/archivestore"
 	mariadbsessionstore "github.com/openbkn-ai/bkn-foundry/bkn-trace/agent-observability/src/drivenadapter/dbaccess/mariadb/sessionstore"
 	"github.com/openbkn-ai/bkn-foundry/bkn-trace/agent-observability/src/drivenadapter/httpaccess/bknbackendaudit"
 	"github.com/openbkn-ai/bkn-foundry/bkn-trace/agent-observability/src/drivenadapter/httpaccess/bknsafeaccess"
@@ -37,6 +39,7 @@ import (
 	"github.com/openbkn-ai/bkn-foundry/bkn-trace/agent-observability/src/drivenadapter/httpaccess/opensearchlogaccess"
 	"github.com/openbkn-ai/bkn-foundry/bkn-trace/agent-observability/src/drivenadapter/httpaccess/opensearchprojection"
 	"github.com/openbkn-ai/bkn-foundry/bkn-trace/agent-observability/src/drivenadapter/httpaccess/opensearchtraceaccess"
+	"github.com/openbkn-ai/bkn-foundry/bkn-trace/agent-observability/src/drivenadapter/httpaccess/ossgatewayarchive"
 	"github.com/openbkn-ai/bkn-foundry/bkn-trace/agent-observability/src/drivenadapter/httpaccess/otelcolmetrics"
 	"github.com/openbkn-ai/bkn-foundry/bkn-trace/agent-observability/src/drivenadapter/httpaccess/vegaaudit"
 	"github.com/openbkn-ai/bkn-foundry/bkn-trace/agent-observability/src/drivenadapter/memoryaccess/evidencestore"
@@ -172,6 +175,25 @@ func NewApp() (*App, error) {
 		},
 		Metrics: metrics,
 	})
+	archiveStore := archivesvc.NewMemoryStore()
+	if databaseStore, ok := sessionStore.(interface{ Database() *sql.DB }); ok {
+		archiveStore = archivestore.New(databaseStore.Database())
+	}
+	archiveObjectStore := ossgatewayarchive.New(ossgatewayarchive.Config{
+		BaseURL: observabilityConfig.ArchiveObjectStoreURL, StorageID: observabilityConfig.ArchiveObjectStorageID,
+		Prefix: observabilityConfig.ArchiveObjectPrefix,
+	})
+	archiveSource := archivesvc.Router{}
+	if databaseStore, ok := sessionStore.(*mariadbsessionstore.Store); ok {
+		archiveSource.Trace = archivesvc.TraceBundleSource{
+			Core:      mariadbsessionstore.NewTraceArchiveSource(databaseStore),
+			Technical: opensearchtraceaccess.NewArchiveStore(openSearchClient, openSearchConfig.TraceIndex),
+		}
+	}
+	if coreConfig.ProjectionEnabled {
+		archiveSource.Log = opensearchconversationaudit.NewArchiveSource(openSearchClient, coreConfig.ProjectionIndex)
+	}
+	archiveHandler := httphandler.NewArchiveHandler(archivesvc.New(archiveStore, archiveSource, archiveObjectStore, archivesvc.Options{}), evidenceHandler)
 	traceHandler := httphandler.NewTraceHandlerWithTechnicalSources(
 		traceQueryService, evidenceService, sessionService,
 	)
@@ -182,8 +204,8 @@ func NewApp() (*App, error) {
 	ledgerHandler := httphandler.NewConfiguredLedgerHandler(ledgersvc.NewWithMetrics(ledgerStore, metrics))
 
 	enterpriseReader := httphandler.NewEnterpriseInteractionFactsReader(evidenceService, sessionService)
-	app := newApp(
-		httpServerConfig, traceHandler, evidenceHandler, logHandler,
+	app := newAppWithArchive(
+		httpServerConfig, traceHandler, evidenceHandler, logHandler, archiveHandler,
 		sessionHandler, ledgerHandler, metrics, enterpriseReader,
 	)
 	app.closeDatabase = closeDatabase
@@ -390,11 +412,27 @@ func runProjectionSupervisor(
 	runWorker(ctx)
 }
 
+// newApp preserves the community route test seam. Archive routes are mounted
+// only by the fully assembled production application below.
 func newApp(
 	httpServerConfig conf.HTTPServerConfig,
 	traceHandler *httphandler.TraceHandler,
 	evidenceHandler *httphandler.EvidenceHandler,
 	logHandler *httphandler.LogHandler,
+	sessionHandler *httphandler.SessionHandler,
+	ledgerHandler *httphandler.LedgerHandler,
+	metrics http.Handler,
+	enterpriseReaders ...enterpriseroute.Reader,
+) *App {
+	return newAppWithArchive(httpServerConfig, traceHandler, evidenceHandler, logHandler, nil, sessionHandler, ledgerHandler, metrics, enterpriseReaders...)
+}
+
+func newAppWithArchive(
+	httpServerConfig conf.HTTPServerConfig,
+	traceHandler *httphandler.TraceHandler,
+	evidenceHandler *httphandler.EvidenceHandler,
+	logHandler *httphandler.LogHandler,
+	archiveHandler *httphandler.ArchiveHandler,
 	sessionHandler *httphandler.SessionHandler,
 	ledgerHandler *httphandler.LedgerHandler,
 	metrics http.Handler,
@@ -442,6 +480,13 @@ func newApp(
 	mux.HandleFunc(ObservabilityAPIBasePath+"/logs/", readAuth(logHandler.GetLog))
 	mux.HandleFunc(ObservabilityAPIBasePath+"/log-sources", readAuth(logHandler.ListLogSources))
 	mux.HandleFunc(ObservabilityAPIBasePath+"/log-policies", readAuth(logHandler.ListLogPolicies))
+	if archiveHandler != nil {
+		mux.HandleFunc(ObservabilityAPIBasePath+"/log-archive-overview", readAuth(archiveHandler.Overview(observabilityvo.ArchiveKindLog)))
+		mux.HandleFunc(ObservabilityAPIBasePath+"/trace-archive-overview", readAuth(archiveHandler.Overview(observabilityvo.ArchiveKindTrace)))
+		mux.HandleFunc(ObservabilityAPIBasePath+"/log-archive-jobs", readAuth(archiveHandler.ListOrCreate(observabilityvo.ArchiveKindLog)))
+		mux.HandleFunc(ObservabilityAPIBasePath+"/trace-archive-jobs", readAuth(archiveHandler.ListOrCreate(observabilityvo.ArchiveKindTrace)))
+		mux.HandleFunc(ObservabilityAPIBasePath+"/archive-jobs/", readAuth(archiveHandler.GetOrRetry))
+	}
 	var enterpriseReader enterpriseroute.Reader
 	if len(enterpriseReaders) > 0 {
 		enterpriseReader = enterpriseReaders[0]

--- a/bkn-trace/agent-observability/src/conf/observability.go
+++ b/bkn-trace/agent-observability/src/conf/observability.go
@@ -16,6 +16,9 @@ type ObservabilityConfig struct {
 	SourceCoverageSourceID        string
 	SourceCoverageDeploymentID    string
 	SourceCoverageInterval        time.Duration
+	ArchiveObjectStoreURL         string
+	ArchiveObjectStorageID        string
+	ArchiveObjectPrefix           string
 }
 
 func NewObservabilityConfig() ObservabilityConfig {
@@ -54,5 +57,8 @@ func NewObservabilityConfig() ObservabilityConfig {
 		SourceCoverageSourceID:        strings.TrimSpace(os.Getenv("BKN_OBSERVABILITY_SOURCE_COVERAGE_SOURCE_ID")),
 		SourceCoverageDeploymentID:    strings.TrimSpace(os.Getenv("BKN_OBSERVABILITY_SOURCE_COVERAGE_DEPLOYMENT_ID")),
 		SourceCoverageInterval:        coverageInterval,
+		ArchiveObjectStoreURL:         strings.TrimRight(strings.TrimSpace(os.Getenv("BKN_OBSERVABILITY_ARCHIVE_OSS_GATEWAY_URL")), "/"),
+		ArchiveObjectStorageID:        strings.TrimSpace(os.Getenv("BKN_OBSERVABILITY_ARCHIVE_STORAGE_ID")),
+		ArchiveObjectPrefix:           strings.Trim(strings.TrimSpace(os.Getenv("BKN_OBSERVABILITY_ARCHIVE_PREFIX")), "/"),
 	}
 }

--- a/bkn-trace/agent-observability/src/domain/service/archivesvc/router.go
+++ b/bkn-trace/agent-observability/src/domain/service/archivesvc/router.go
@@ -1,0 +1,69 @@
+package archivesvc
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/openbkn-ai/bkn-foundry/bkn-trace/agent-observability/src/domain/valueobject/observabilityvo"
+)
+
+// Router keeps the two archive populations isolated while preserving one small
+// archive workflow and task store.
+type Router struct {
+	Log   Source
+	Trace Source
+}
+
+// TraceBundleSource keeps the core Interaction package and its OpenSearch
+// technical traces in one frozen archive unit.  It never recalculates a time
+// window during cleanup: the enriched candidate is the cleanup contract.
+type TraceBundleSource struct {
+	Core      Source
+	Technical TraceTechnicalStore
+}
+
+type TraceTechnicalStore interface {
+	Enrich(context.Context, []Candidate) ([]Candidate, error)
+	Purge(context.Context, []Candidate) error
+}
+
+func (source TraceBundleSource) Freeze(ctx context.Context, kind observabilityvo.ArchiveKind, tenantID string, archiveRange observabilityvo.ArchiveRange) ([]Candidate, error) {
+	candidates, err := source.Core.Freeze(ctx, kind, tenantID, archiveRange)
+	if err != nil || len(candidates) == 0 || source.Technical == nil {
+		return candidates, err
+	}
+	return source.Technical.Enrich(ctx, candidates)
+}
+func (source TraceBundleSource) Purge(ctx context.Context, kind observabilityvo.ArchiveKind, tenantID string, candidates []Candidate) error {
+	if source.Technical != nil {
+		if err := source.Technical.Purge(ctx, candidates); err != nil {
+			return err
+		}
+	}
+	return source.Core.Purge(ctx, kind, tenantID, candidates)
+}
+
+func (router Router) source(kind observabilityvo.ArchiveKind) (Source, error) {
+	if kind == observabilityvo.ArchiveKindLog && router.Log != nil {
+		return router.Log, nil
+	}
+	if kind == observabilityvo.ArchiveKindTrace && router.Trace != nil {
+		return router.Trace, nil
+	}
+	return nil, fmt.Errorf("archive source for %s is unavailable", kind)
+}
+
+func (router Router) Freeze(ctx context.Context, kind observabilityvo.ArchiveKind, tenantID string, archiveRange observabilityvo.ArchiveRange) ([]Candidate, error) {
+	source, err := router.source(kind)
+	if err != nil {
+		return nil, err
+	}
+	return source.Freeze(ctx, kind, tenantID, archiveRange)
+}
+func (router Router) Purge(ctx context.Context, kind observabilityvo.ArchiveKind, tenantID string, candidates []Candidate) error {
+	source, err := router.source(kind)
+	if err != nil {
+		return err
+	}
+	return source.Purge(ctx, kind, tenantID, candidates)
+}

--- a/bkn-trace/agent-observability/src/domain/service/archivesvc/service.go
+++ b/bkn-trace/agent-observability/src/domain/service/archivesvc/service.go
@@ -110,7 +110,13 @@ func (service *Service) Create(ctx context.Context, kind observabilityvo.Archive
 		_ = service.store.Update(job)
 		return job, err
 	}
-	job.ManifestRef, job.UpdatedAt = manifestRef, service.now().UTC()
+	// Persist the verified manifest and frozen candidates before any hot data is
+	// deleted. A process interruption after this point is recoverable through
+	// RetryCleanup; an interruption before it leaves hot data intact.
+	job.ManifestRef, job.Status, job.ErrorMessage, job.UpdatedAt = manifestRef, observabilityvo.ArchiveStatusCleanupIncomplete, "", service.now().UTC()
+	if err := service.store.Update(job); err != nil {
+		return Job{}, err
+	}
 	if err := service.source.Purge(ctx, kind, tenantID, candidates); err != nil {
 		job.Status, job.ErrorMessage, job.UpdatedAt = observabilityvo.ArchiveStatusCleanupIncomplete, err.Error(), service.now().UTC()
 		_ = service.store.Update(job)
@@ -222,7 +228,7 @@ func (store *memoryStore) Create(job Job) error {
 	if _, ok := store.jobs[job.ID]; ok {
 		return errors.New("archive job already exists")
 	}
-	store.jobs[job.ID] = job
+	store.jobs[job.ID] = storedJob(job)
 	return nil
 }
 func (store *memoryStore) Update(job Job) error {
@@ -231,8 +237,15 @@ func (store *memoryStore) Update(job Job) error {
 	if _, ok := store.jobs[job.ID]; !ok {
 		return errors.New("archive job does not exist")
 	}
-	store.jobs[job.ID] = job
+	store.jobs[job.ID] = storedJob(job)
 	return nil
+}
+
+func storedJob(job Job) Job {
+	if job.Status != observabilityvo.ArchiveStatusCleanupIncomplete {
+		job.Candidates = nil
+	}
+	return job
 }
 func (store *memoryStore) Latest(tenantID string, kind observabilityvo.ArchiveKind) (Job, bool) {
 	store.mu.Lock()

--- a/bkn-trace/agent-observability/src/domain/service/archivesvc/service.go
+++ b/bkn-trace/agent-observability/src/domain/service/archivesvc/service.go
@@ -1,0 +1,268 @@
+// Package archivesvc coordinates the irreversible final step of a manual
+// archive. Its ports deliberately work on a frozen candidate list: cleanup
+// must never recalculate a moving time range.
+package archivesvc
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sort"
+	"sync"
+	"time"
+
+	"github.com/openbkn-ai/bkn-foundry/bkn-trace/agent-observability/src/domain/valueobject/observabilityvo"
+)
+
+var (
+	ErrNothingToArchive = errors.New("archive has no eligible records")
+	ErrCleanupRequired  = errors.New("archive cleanup must be completed before another archive of this kind")
+)
+
+type Candidate struct {
+	ID         string    `json:"id"`
+	OccurredAt time.Time `json:"occurred_at"`
+	Payload    []byte    `json:"payload"`
+}
+
+type Job struct {
+	ID             string                        `json:"archive_job_id"`
+	TenantID       string                        `json:"tenant_id"`
+	Kind           observabilityvo.ArchiveKind   `json:"archive_kind"`
+	Range          observabilityvo.ArchiveRange  `json:"range"`
+	Status         observabilityvo.ArchiveStatus `json:"status"`
+	CandidateIDs   []string                      `json:"-"`
+	CandidateCount int                           `json:"candidate_count"`
+	ManifestRef    string                        `json:"manifest_ref,omitempty"`
+	ErrorMessage   string                        `json:"error_message,omitempty"`
+	CreatedAt      time.Time                     `json:"created_at"`
+	UpdatedAt      time.Time                     `json:"updated_at"`
+}
+
+type Source interface {
+	Freeze(context.Context, observabilityvo.ArchiveKind, string, observabilityvo.ArchiveRange) ([]Candidate, error)
+	Purge(context.Context, observabilityvo.ArchiveKind, string, []Candidate) error
+}
+
+type ObjectStore interface {
+	WriteAndVerify(context.Context, Job, []Candidate) (string, error)
+}
+
+type DownloadStore interface {
+	DownloadURL(context.Context, string) (string, error)
+}
+
+type Store interface {
+	Create(Job) error
+	Update(Job) error
+	Latest(string, observabilityvo.ArchiveKind) (Job, bool)
+	Get(string) (Job, bool)
+	List(string, observabilityvo.ArchiveKind, int) []Job
+}
+
+type Options struct {
+	Now      func() time.Time
+	Location *time.Location
+}
+
+type Service struct {
+	store       Store
+	source      Source
+	objectStore ObjectStore
+	now         func() time.Time
+	location    *time.Location
+}
+
+func New(store Store, source Source, objectStore ObjectStore, options Options) *Service {
+	if options.Now == nil {
+		options.Now = time.Now
+	}
+	if options.Location == nil {
+		options.Location = time.Local
+	}
+	return &Service{store: store, source: source, objectStore: objectStore, now: options.Now, location: options.Location}
+}
+
+func (service *Service) Create(ctx context.Context, kind observabilityvo.ArchiveKind, tenantID string) (Job, error) {
+	if !kind.Valid() || tenantID == "" {
+		return Job{}, fmt.Errorf("invalid archive request")
+	}
+	if previous, ok := service.store.Latest(tenantID, kind); ok && previous.Status == observabilityvo.ArchiveStatusCleanupIncomplete {
+		return Job{}, ErrCleanupRequired
+	}
+	now := service.now().UTC()
+	rangeToArchive := observabilityvo.NewArchiveRange(kind, now, service.location)
+	candidates, err := service.source.Freeze(ctx, kind, tenantID, rangeToArchive)
+	if err != nil {
+		return Job{}, fmt.Errorf("freeze archive candidates: %w", err)
+	}
+	if len(candidates) == 0 {
+		return Job{}, ErrNothingToArchive
+	}
+	job := newJob(kind, tenantID, rangeToArchive, candidates, now)
+	if err := service.store.Create(job); err != nil {
+		return Job{}, err
+	}
+	manifestRef, err := service.objectStore.WriteAndVerify(ctx, job, candidates)
+	if err != nil {
+		job.Status, job.ErrorMessage, job.UpdatedAt = observabilityvo.ArchiveStatusFailed, err.Error(), service.now().UTC()
+		_ = service.store.Update(job)
+		return job, err
+	}
+	job.ManifestRef, job.UpdatedAt = manifestRef, service.now().UTC()
+	if err := service.source.Purge(ctx, kind, tenantID, candidates); err != nil {
+		job.Status, job.ErrorMessage, job.UpdatedAt = observabilityvo.ArchiveStatusCleanupIncomplete, err.Error(), service.now().UTC()
+		_ = service.store.Update(job)
+		return job, nil
+	}
+	job.Status, job.UpdatedAt = observabilityvo.ArchiveStatusCompleted, service.now().UTC()
+	if err := service.store.Update(job); err != nil {
+		return Job{}, err
+	}
+	return job, nil
+}
+
+type Overview struct {
+	Kind           observabilityvo.ArchiveKind
+	RetentionDays  int
+	Range          observabilityvo.ArchiveRange
+	CandidateCount int
+	StorageReady   bool
+}
+
+func (service *Service) Overview(ctx context.Context, kind observabilityvo.ArchiveKind, tenantID string) (Overview, error) {
+	if !kind.Valid() || tenantID == "" {
+		return Overview{}, fmt.Errorf("invalid archive overview")
+	}
+	archiveRange := observabilityvo.NewArchiveRange(kind, service.now().UTC(), service.location)
+	candidates, err := service.source.Freeze(ctx, kind, tenantID, archiveRange)
+	if err != nil {
+		return Overview{}, err
+	}
+	ready := true
+	if store, ok := service.objectStore.(interface {
+		Availability(context.Context) (bool, error)
+	}); ok {
+		ready, _ = store.Availability(ctx)
+	} else if store, ok := service.objectStore.(interface{ Ready() bool }); ok {
+		ready = store.Ready()
+	}
+	return Overview{Kind: kind, RetentionDays: kind.RetentionDays(), Range: archiveRange, CandidateCount: len(candidates), StorageReady: ready}, nil
+}
+
+func (service *Service) RetryCleanup(ctx context.Context, jobID, tenantID string) (Job, error) {
+	job, ok := service.store.Get(jobID)
+	if !ok || job.TenantID != tenantID {
+		return Job{}, fmt.Errorf("archive job not found")
+	}
+	if job.Status != observabilityvo.ArchiveStatusCleanupIncomplete {
+		return Job{}, fmt.Errorf("archive cleanup cannot be retried")
+	}
+	candidates := make([]Candidate, 0, len(job.CandidateIDs))
+	for _, id := range job.CandidateIDs {
+		candidates = append(candidates, Candidate{ID: id})
+	}
+	if err := service.source.Purge(ctx, job.Kind, tenantID, candidates); err != nil {
+		job.ErrorMessage, job.UpdatedAt = err.Error(), service.now().UTC()
+		_ = service.store.Update(job)
+		return job, nil
+	}
+	job.Status, job.ErrorMessage, job.UpdatedAt = observabilityvo.ArchiveStatusCompleted, "", service.now().UTC()
+	if err := service.store.Update(job); err != nil {
+		return Job{}, err
+	}
+	return job, nil
+}
+
+func (service *Service) Get(jobID, tenantID string) (Job, bool) {
+	job, ok := service.store.Get(jobID)
+	return job, ok && job.TenantID == tenantID
+}
+
+func (service *Service) DownloadURL(ctx context.Context, jobID, tenantID string) (string, error) {
+	job, ok := service.Get(jobID, tenantID)
+	if !ok || job.ManifestRef == "" {
+		return "", fmt.Errorf("archive download is unavailable")
+	}
+	store, ok := service.objectStore.(DownloadStore)
+	if !ok {
+		return "", fmt.Errorf("archive download is unavailable")
+	}
+	return store.DownloadURL(ctx, job.ManifestRef)
+}
+
+// List returns the newest jobs for one archive kind.  The archive kinds stay
+// isolated so a failed cleanup of one never obscures the other.
+func (service *Service) List(tenantID string, kind observabilityvo.ArchiveKind, limit int) []Job {
+	if tenantID == "" || !kind.Valid() || limit <= 0 {
+		return nil
+	}
+	return service.store.List(tenantID, kind, limit)
+}
+
+func newJob(kind observabilityvo.ArchiveKind, tenantID string, archiveRange observabilityvo.ArchiveRange, candidates []Candidate, now time.Time) Job {
+	ids := make([]string, 0, len(candidates))
+	for _, candidate := range candidates {
+		ids = append(ids, candidate.ID)
+	}
+	sort.Strings(ids)
+	return Job{ID: fmt.Sprintf("arc_%s_%d", kind, now.UnixNano()), TenantID: tenantID, Kind: kind, Range: archiveRange, Status: observabilityvo.ArchiveStatusFailed, CandidateIDs: ids, CandidateCount: len(candidates), CreatedAt: now, UpdatedAt: now}
+}
+
+type memoryStore struct {
+	mu   sync.Mutex
+	jobs map[string]Job
+}
+
+func NewMemoryStore() Store { return &memoryStore{jobs: map[string]Job{}} }
+func (store *memoryStore) Create(job Job) error {
+	store.mu.Lock()
+	defer store.mu.Unlock()
+	if _, ok := store.jobs[job.ID]; ok {
+		return errors.New("archive job already exists")
+	}
+	store.jobs[job.ID] = job
+	return nil
+}
+func (store *memoryStore) Update(job Job) error {
+	store.mu.Lock()
+	defer store.mu.Unlock()
+	if _, ok := store.jobs[job.ID]; !ok {
+		return errors.New("archive job does not exist")
+	}
+	store.jobs[job.ID] = job
+	return nil
+}
+func (store *memoryStore) Latest(tenantID string, kind observabilityvo.ArchiveKind) (Job, bool) {
+	store.mu.Lock()
+	defer store.mu.Unlock()
+	var result Job
+	found := false
+	for _, job := range store.jobs {
+		if job.TenantID == tenantID && job.Kind == kind && (!found || job.CreatedAt.After(result.CreatedAt)) {
+			result, found = job, true
+		}
+	}
+	return result, found
+}
+func (store *memoryStore) Get(jobID string) (Job, bool) {
+	store.mu.Lock()
+	defer store.mu.Unlock()
+	job, ok := store.jobs[jobID]
+	return job, ok
+}
+func (store *memoryStore) List(tenantID string, kind observabilityvo.ArchiveKind, limit int) []Job {
+	store.mu.Lock()
+	defer store.mu.Unlock()
+	jobs := make([]Job, 0, limit)
+	for _, job := range store.jobs {
+		if job.TenantID == tenantID && job.Kind == kind {
+			jobs = append(jobs, job)
+		}
+	}
+	sort.Slice(jobs, func(i, j int) bool { return jobs[i].CreatedAt.After(jobs[j].CreatedAt) })
+	if len(jobs) > limit {
+		jobs = jobs[:limit]
+	}
+	return jobs
+}

--- a/bkn-trace/agent-observability/src/domain/service/archivesvc/service.go
+++ b/bkn-trace/agent-observability/src/domain/service/archivesvc/service.go
@@ -32,6 +32,7 @@ type Job struct {
 	Range          observabilityvo.ArchiveRange  `json:"range"`
 	Status         observabilityvo.ArchiveStatus `json:"status"`
 	CandidateIDs   []string                      `json:"-"`
+	Candidates     []Candidate                   `json:"-"`
 	CandidateCount int                           `json:"candidate_count"`
 	ManifestRef    string                        `json:"manifest_ref,omitempty"`
 	ErrorMessage   string                        `json:"error_message,omitempty"`
@@ -158,9 +159,9 @@ func (service *Service) RetryCleanup(ctx context.Context, jobID, tenantID string
 	if job.Status != observabilityvo.ArchiveStatusCleanupIncomplete {
 		return Job{}, fmt.Errorf("archive cleanup cannot be retried")
 	}
-	candidates := make([]Candidate, 0, len(job.CandidateIDs))
-	for _, id := range job.CandidateIDs {
-		candidates = append(candidates, Candidate{ID: id})
+	candidates := append([]Candidate(nil), job.Candidates...)
+	if len(candidates) != len(job.CandidateIDs) {
+		return Job{}, fmt.Errorf("archive cleanup candidates are unavailable")
 	}
 	if err := service.source.Purge(ctx, job.Kind, tenantID, candidates); err != nil {
 		job.ErrorMessage, job.UpdatedAt = err.Error(), service.now().UTC()
@@ -206,7 +207,7 @@ func newJob(kind observabilityvo.ArchiveKind, tenantID string, archiveRange obse
 		ids = append(ids, candidate.ID)
 	}
 	sort.Strings(ids)
-	return Job{ID: fmt.Sprintf("arc_%s_%d", kind, now.UnixNano()), TenantID: tenantID, Kind: kind, Range: archiveRange, Status: observabilityvo.ArchiveStatusFailed, CandidateIDs: ids, CandidateCount: len(candidates), CreatedAt: now, UpdatedAt: now}
+	return Job{ID: fmt.Sprintf("arc_%s_%d", kind, now.UnixNano()), TenantID: tenantID, Kind: kind, Range: archiveRange, Status: observabilityvo.ArchiveStatusFailed, CandidateIDs: ids, Candidates: append([]Candidate(nil), candidates...), CandidateCount: len(candidates), CreatedAt: now, UpdatedAt: now}
 }
 
 type memoryStore struct {

--- a/bkn-trace/agent-observability/src/domain/service/archivesvc/service_test.go
+++ b/bkn-trace/agent-observability/src/domain/service/archivesvc/service_test.go
@@ -1,0 +1,84 @@
+package archivesvc
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/openbkn-ai/bkn-foundry/bkn-trace/agent-observability/src/domain/valueobject/observabilityvo"
+)
+
+func TestCreateWritesVerifiedBundleBeforePurgingFrozenCandidates(t *testing.T) {
+	now := time.Date(2026, time.August, 14, 8, 0, 0, 0, time.UTC)
+	source := &fakeSource{candidates: []Candidate{{ID: "log-1", OccurredAt: now.AddDate(0, 0, -31), Payload: []byte(`{"id":"log-1"}`)}}}
+	storage := &fakeObjectStore{}
+	service := New(NewMemoryStore(), source, storage, Options{Now: func() time.Time { return now }})
+
+	job, err := service.Create(context.Background(), observabilityvo.ArchiveKindLog, "tenant-a")
+	if err != nil {
+		t.Fatalf("create archive: %v", err)
+	}
+	if job.Status != observabilityvo.ArchiveStatusCompleted || !source.purged["log-1"] || !storage.verified {
+		t.Fatalf("archive did not verify then purge: job=%+v purged=%v verified=%v", job, source.purged, storage.verified)
+	}
+}
+
+func TestCreateDoesNotPurgeWhenBundleVerificationFails(t *testing.T) {
+	now := time.Date(2026, time.August, 14, 8, 0, 0, 0, time.UTC)
+	source := &fakeSource{candidates: []Candidate{{ID: "trace-1", OccurredAt: now.AddDate(0, 0, -8), Payload: []byte(`{"id":"trace-1"}`)}}}
+	service := New(NewMemoryStore(), source, &fakeObjectStore{verifyErr: errors.New("mismatch")}, Options{Now: func() time.Time { return now }})
+
+	job, err := service.Create(context.Background(), observabilityvo.ArchiveKindTrace, "tenant-a")
+	if err == nil || job.Status != observabilityvo.ArchiveStatusFailed || len(source.purged) != 0 {
+		t.Fatalf("verification failure must retain hot data: job=%+v err=%v purged=%v", job, err, source.purged)
+	}
+}
+
+func TestKindsDoNotBlockEachOtherButIncompleteCleanupBlocksSameKind(t *testing.T) {
+	now := time.Date(2026, time.August, 14, 8, 0, 0, 0, time.UTC)
+	source := &fakeSource{candidates: []Candidate{{ID: "one", OccurredAt: now.AddDate(0, 0, -31), Payload: []byte(`{}`)}}, purgeErr: errors.New("delete failed")}
+	service := New(NewMemoryStore(), source, &fakeObjectStore{}, Options{Now: func() time.Time { return now }})
+	job, _ := service.Create(context.Background(), observabilityvo.ArchiveKindLog, "tenant-a")
+	if job.Status != observabilityvo.ArchiveStatusCleanupIncomplete {
+		t.Fatalf("expected cleanup incomplete, got %s", job.Status)
+	}
+	if _, err := service.Create(context.Background(), observabilityvo.ArchiveKindLog, "tenant-a"); !errors.Is(err, ErrCleanupRequired) {
+		t.Fatalf("same kind should require cleanup first: %v", err)
+	}
+	if _, err := service.Create(context.Background(), observabilityvo.ArchiveKindTrace, "tenant-a"); err != nil && !errors.Is(err, ErrNothingToArchive) {
+		t.Fatalf("other archive kind must remain independent: %v", err)
+	}
+}
+
+type fakeSource struct {
+	candidates []Candidate
+	purged     map[string]bool
+	purgeErr   error
+}
+
+func (source *fakeSource) Freeze(_ context.Context, _ observabilityvo.ArchiveKind, _ string, _ observabilityvo.ArchiveRange) ([]Candidate, error) {
+	return append([]Candidate(nil), source.candidates...), nil
+}
+func (source *fakeSource) Purge(_ context.Context, _ observabilityvo.ArchiveKind, _ string, candidates []Candidate) error {
+	if source.purged == nil {
+		source.purged = map[string]bool{}
+	}
+	for _, candidate := range candidates {
+		source.purged[candidate.ID] = true
+	}
+	return source.purgeErr
+}
+
+type fakeObjectStore struct {
+	verified  bool
+	verifyErr error
+}
+
+func (store *fakeObjectStore) WriteAndVerify(_ context.Context, _ Job, _ []Candidate) (string, error) {
+	store.verified = true
+	if store.verifyErr != nil {
+		return "", store.verifyErr
+	}
+	return "archive/job/manifest.json", nil
+}

--- a/bkn-trace/agent-observability/src/domain/service/archivesvc/service_test.go
+++ b/bkn-trace/agent-observability/src/domain/service/archivesvc/service_test.go
@@ -66,6 +66,35 @@ func TestRetryCleanupReusesFrozenCandidatePayload(t *testing.T) {
 	}
 }
 
+func TestCreatePersistsVerifiedManifestAndCandidatesBeforePurge(t *testing.T) {
+	now := time.Date(2026, time.August, 14, 8, 0, 0, 0, time.UTC)
+	store := NewMemoryStore()
+	source := &checkingSource{store: store, candidates: []Candidate{{ID: "trace-1", OccurredAt: now.AddDate(0, 0, -8), Payload: []byte(`{"technical_trace_ids":["trace-a"]}`)}}}
+	service := New(store, source, &fakeObjectStore{}, Options{Now: func() time.Time { return now }})
+
+	if _, err := service.Create(context.Background(), observabilityvo.ArchiveKindTrace, "tenant-a"); err != nil {
+		t.Fatalf("create archive: %v", err)
+	}
+	if !source.manifestPersisted || !source.candidatesPersisted {
+		t.Fatalf("verified archive state was not persisted before purge: %+v", source)
+	}
+}
+
+func TestCompletedArchiveDoesNotRetainRetryPayload(t *testing.T) {
+	now := time.Date(2026, time.August, 14, 8, 0, 0, 0, time.UTC)
+	store := NewMemoryStore()
+	service := New(store, &fakeSource{candidates: []Candidate{{ID: "log-1", OccurredAt: now.AddDate(0, 0, -31), Payload: []byte(`{"id":"log-1"}`)}}}, &fakeObjectStore{}, Options{Now: func() time.Time { return now }})
+
+	job, err := service.Create(context.Background(), observabilityvo.ArchiveKindLog, "tenant-a")
+	if err != nil {
+		t.Fatalf("create archive: %v", err)
+	}
+	stored, ok := store.Get(job.ID)
+	if !ok || len(stored.Candidates) != 0 {
+		t.Fatalf("completed archive must not retain retry payload: %+v", stored)
+	}
+}
+
 type fakeSource struct {
 	candidates []Candidate
 	purged     map[string]bool
@@ -96,4 +125,25 @@ func (store *fakeObjectStore) WriteAndVerify(_ context.Context, _ Job, _ []Candi
 		return "", store.verifyErr
 	}
 	return "archive/job/manifest.json", nil
+}
+
+type checkingSource struct {
+	store               Store
+	candidates          []Candidate
+	manifestPersisted   bool
+	candidatesPersisted bool
+}
+
+func (source *checkingSource) Freeze(_ context.Context, _ observabilityvo.ArchiveKind, _ string, _ observabilityvo.ArchiveRange) ([]Candidate, error) {
+	return append([]Candidate(nil), source.candidates...), nil
+}
+
+func (source *checkingSource) Purge(_ context.Context, _ observabilityvo.ArchiveKind, _ string, candidates []Candidate) error {
+	job, ok := source.store.Latest("tenant-a", observabilityvo.ArchiveKindTrace)
+	if !ok || len(candidates) != 1 || len(job.Candidates) != 1 {
+		return errors.New("verified archive state is unavailable before purge")
+	}
+	source.manifestPersisted = job.ManifestRef != ""
+	source.candidatesPersisted = len(job.Candidates[0].Payload) > 0 && candidates[0].ID == job.Candidates[0].ID
+	return nil
 }

--- a/bkn-trace/agent-observability/src/domain/service/archivesvc/service_test.go
+++ b/bkn-trace/agent-observability/src/domain/service/archivesvc/service_test.go
@@ -51,6 +51,21 @@ func TestKindsDoNotBlockEachOtherButIncompleteCleanupBlocksSameKind(t *testing.T
 	}
 }
 
+func TestRetryCleanupReusesFrozenCandidatePayload(t *testing.T) {
+	now := time.Date(2026, time.August, 14, 8, 0, 0, 0, time.UTC)
+	source := &fakeSource{candidates: []Candidate{{ID: "trace-1", OccurredAt: now.AddDate(0, 0, -8), Payload: []byte(`{"technical_trace_ids":["trace-a"]}`)}}, purgeErr: errors.New("temporary delete failure")}
+	service := New(NewMemoryStore(), source, &fakeObjectStore{}, Options{Now: func() time.Time { return now }})
+	job, err := service.Create(context.Background(), observabilityvo.ArchiveKindTrace, "tenant-a")
+	if err != nil || job.Status != observabilityvo.ArchiveStatusCleanupIncomplete {
+		t.Fatalf("expected incomplete cleanup, job=%+v err=%v", job, err)
+	}
+	source.purgeErr = nil
+	job, err = service.RetryCleanup(context.Background(), job.ID, "tenant-a")
+	if err != nil || job.Status != observabilityvo.ArchiveStatusCompleted || !source.purged["trace-1"] {
+		t.Fatalf("retry must purge the frozen candidate: job=%+v err=%v purged=%v", job, err, source.purged)
+	}
+}
+
 type fakeSource struct {
 	candidates []Candidate
 	purged     map[string]bool

--- a/bkn-trace/agent-observability/src/domain/valueobject/observabilityvo/access.go
+++ b/bkn-trace/agent-observability/src/domain/valueobject/observabilityvo/access.go
@@ -54,6 +54,7 @@ type AccessCapabilities struct {
 	LogSensitiveFields                bool
 	LogExport                         bool
 	LogPolicyRead                     bool
+	ObservabilityArchiveManage        bool
 }
 
 func CapabilitiesFor(profile evidencevo.AccessProfile) AccessCapabilities {
@@ -99,6 +100,7 @@ func CapabilitiesFor(profile evidencevo.AccessProfile) AccessCapabilities {
 		LogSensitiveFields:                controlledLogAccess,
 		LogExport:                         globalLogSearch,
 		LogPolicyRead:                     controlledLogAccess,
+		ObservabilityArchiveManage:        hasRole("admin", "audit", "super_admin"),
 	}
 }
 

--- a/bkn-trace/agent-observability/src/domain/valueobject/observabilityvo/access_test.go
+++ b/bkn-trace/agent-observability/src/domain/valueobject/observabilityvo/access_test.go
@@ -46,6 +46,14 @@ func TestInactiveAccountHasNoObservabilityCapabilities(t *testing.T) {
 	}
 }
 
+func TestArchiveManagementIsAServiceSideAdministratorCapability(t *testing.T) {
+	admin := CapabilitiesFor(evidencevo.AccessProfile{TenantID: "tenant-a", AccountActive: true, TenantActive: true, Roles: []string{"admin"}})
+	user := CapabilitiesFor(evidencevo.AccessProfile{TenantID: "tenant-a", AccountActive: true, TenantActive: true, Roles: []string{"normal_user"}})
+	if !admin.ObservabilityArchiveManage || user.ObservabilityArchiveManage {
+		t.Fatalf("archive capability must be server-derived for administrators only: admin=%+v user=%+v", admin, user)
+	}
+}
+
 func TestOperationAuditContractUsesSixProductModules(t *testing.T) {
 	want := []string{
 		"domain_knowledge_network",

--- a/bkn-trace/agent-observability/src/domain/valueobject/observabilityvo/archive.go
+++ b/bkn-trace/agent-observability/src/domain/valueobject/observabilityvo/archive.go
@@ -1,0 +1,55 @@
+package observabilityvo
+
+import "time"
+
+// ArchiveKind separates the two fixed operational retention policies. It is
+// deliberately not a client configurable category or retention value.
+type ArchiveKind string
+
+const (
+	ArchiveKindLog     ArchiveKind = "log"
+	ArchiveKindTrace   ArchiveKind = "trace"
+	LogRetentionDays               = 30
+	TraceRetentionDays             = 7
+)
+
+func (kind ArchiveKind) Valid() bool { return kind == ArchiveKindLog || kind == ArchiveKindTrace }
+
+func (kind ArchiveKind) RetentionDays() int {
+	if kind == ArchiveKindTrace {
+		return TraceRetentionDays
+	}
+	return LogRetentionDays
+}
+
+type ArchiveRange struct {
+	From time.Time `json:"from"`
+	To   time.Time `json:"to"`
+}
+
+func (archiveRange ArchiveRange) Contains(value time.Time) bool {
+	return (archiveRange.From.IsZero() || !value.Before(archiveRange.From)) && value.Before(archiveRange.To)
+}
+
+// NewArchiveRange deliberately has no caller-supplied range: records before
+// the fixed cutoff are eligible, while records at the cutoff remain hot.
+func NewArchiveRange(kind ArchiveKind, now time.Time, location *time.Location) ArchiveRange {
+	if location == nil {
+		location = time.UTC
+	}
+	localNow := now.In(location)
+	day := time.Date(localNow.Year(), localNow.Month(), localNow.Day(), 0, 0, 0, 0, location)
+	return ArchiveRange{To: day.AddDate(0, 0, -kind.RetentionDays())}
+}
+
+type ArchiveStatus string
+
+const (
+	ArchiveStatusCompleted         ArchiveStatus = "completed"
+	ArchiveStatusFailed            ArchiveStatus = "failed"
+	ArchiveStatusCleanupIncomplete ArchiveStatus = "cleanup_incomplete"
+)
+
+func (status ArchiveStatus) Terminal() bool {
+	return status == ArchiveStatusCompleted || status == ArchiveStatusFailed || status == ArchiveStatusCleanupIncomplete
+}

--- a/bkn-trace/agent-observability/src/domain/valueobject/observabilityvo/archive_test.go
+++ b/bkn-trace/agent-observability/src/domain/valueobject/observabilityvo/archive_test.go
@@ -1,0 +1,32 @@
+package observabilityvo
+
+import (
+	"testing"
+	"time"
+)
+
+func TestArchiveCutoffUsesFixedRetentionAndDeploymentDay(t *testing.T) {
+	location := time.FixedZone("CST", 8*60*60)
+	now := time.Date(2026, time.August, 14, 16, 24, 0, 0, location)
+
+	logRange := NewArchiveRange(ArchiveKindLog, now, location)
+	if logRange.To != time.Date(2026, time.July, 15, 0, 0, 0, 0, location) {
+		t.Fatalf("unexpected log cutoff: %s", logRange.To)
+	}
+	traceRange := NewArchiveRange(ArchiveKindTrace, now, location)
+	if traceRange.To != time.Date(2026, time.August, 7, 0, 0, 0, 0, location) {
+		t.Fatalf("unexpected trace cutoff: %s", traceRange.To)
+	}
+	if !traceRange.Contains(time.Date(2026, time.August, 6, 23, 59, 59, 0, location)) || traceRange.Contains(traceRange.To) {
+		t.Fatalf("archive range must be half-open: %+v", traceRange)
+	}
+}
+
+func TestArchiveKindHasOnlyTheTwoFixedRetentionPolicies(t *testing.T) {
+	if ArchiveKindLog.RetentionDays() != 30 || ArchiveKindTrace.RetentionDays() != 7 {
+		t.Fatalf("fixed retention drifted: log=%d trace=%d", ArchiveKindLog.RetentionDays(), ArchiveKindTrace.RetentionDays())
+	}
+	if ArchiveKind("custom").Valid() {
+		t.Fatal("custom archive kind must not be accepted")
+	}
+}

--- a/bkn-trace/agent-observability/src/drivenadapter/dbaccess/mariadb/archivestore/store.go
+++ b/bkn-trace/agent-observability/src/drivenadapter/dbaccess/mariadb/archivestore/store.go
@@ -18,7 +18,11 @@ func (store *Store) Create(job archivesvc.Job) error {
 	if err != nil {
 		return err
 	}
-	_, err = store.db.Exec(`INSERT INTO bkn_trace_archive_jobs (archive_job_id, tenant_id, archive_kind, range_from, range_to, archive_status, candidate_ids, candidate_count, manifest_ref, error_message, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`, job.ID, job.TenantID, job.Kind, nullableTime(job.Range.From), job.Range.To.UTC(), job.Status, ids, job.CandidateCount, nullableString(job.ManifestRef), nullableString(job.ErrorMessage), job.CreatedAt.UTC(), job.UpdatedAt.UTC())
+	payloads, err := json.Marshal(job.Candidates)
+	if err != nil {
+		return err
+	}
+	_, err = store.db.Exec(`INSERT INTO bkn_trace_archive_jobs (archive_job_id, tenant_id, archive_kind, range_from, range_to, archive_status, candidate_ids, candidate_payloads, candidate_count, manifest_ref, error_message, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`, job.ID, job.TenantID, job.Kind, nullableTime(job.Range.From), job.Range.To.UTC(), job.Status, ids, payloads, job.CandidateCount, nullableString(job.ManifestRef), nullableString(job.ErrorMessage), job.CreatedAt.UTC(), job.UpdatedAt.UTC())
 	return err
 }
 
@@ -33,24 +37,26 @@ func (store *Store) Latest(tenantID string, kind observabilityvo.ArchiveKind) (a
 }
 
 func (store *Store) Get(jobID string) (archivesvc.Job, bool) {
-	row := store.db.QueryRow(`SELECT tenant_id, archive_kind, range_from, range_to, archive_status, candidate_ids, candidate_count, COALESCE(manifest_ref,''), COALESCE(error_message,''), created_at, updated_at FROM bkn_trace_archive_jobs WHERE archive_job_id=?`, jobID)
+	row := store.db.QueryRow(`SELECT tenant_id, archive_kind, range_from, range_to, archive_status, candidate_ids, candidate_payloads, candidate_count, COALESCE(manifest_ref,''), COALESCE(error_message,''), created_at, updated_at FROM bkn_trace_archive_jobs WHERE archive_job_id=?`, jobID)
 	var tenantID, kind string
 	var rangeFrom sql.NullTime
 	var rangeTo time.Time
 	var status string
 	var ids []byte
+	var payloads []byte
 	var count int
 	var manifest, message string
 	var createdAt, updatedAt time.Time
-	err := row.Scan(&tenantID, &kind, &rangeFrom, &rangeTo, &status, &ids, &count, &manifest, &message, &createdAt, &updatedAt)
+	err := row.Scan(&tenantID, &kind, &rangeFrom, &rangeTo, &status, &ids, &payloads, &count, &manifest, &message, &createdAt, &updatedAt)
 	if err != nil {
 		return archivesvc.Job{}, false
 	}
 	var candidateIDs []string
-	if json.Unmarshal(ids, &candidateIDs) != nil {
+	var candidates []archivesvc.Candidate
+	if json.Unmarshal(ids, &candidateIDs) != nil || json.Unmarshal(payloads, &candidates) != nil {
 		return archivesvc.Job{}, false
 	}
-	job := archivesvc.Job{ID: jobID, TenantID: tenantID, Kind: observabilityvo.ArchiveKind(kind), Range: observabilityvo.ArchiveRange{To: rangeTo.UTC()}, Status: observabilityvo.ArchiveStatus(status), CandidateIDs: candidateIDs, CandidateCount: count, ManifestRef: manifest, ErrorMessage: message, CreatedAt: createdAt.UTC(), UpdatedAt: updatedAt.UTC()}
+	job := archivesvc.Job{ID: jobID, TenantID: tenantID, Kind: observabilityvo.ArchiveKind(kind), Range: observabilityvo.ArchiveRange{To: rangeTo.UTC()}, Status: observabilityvo.ArchiveStatus(status), CandidateIDs: candidateIDs, Candidates: candidates, CandidateCount: count, ManifestRef: manifest, ErrorMessage: message, CreatedAt: createdAt.UTC(), UpdatedAt: updatedAt.UTC()}
 	if rangeFrom.Valid {
 		job.Range.From = rangeFrom.Time.UTC()
 	}

--- a/bkn-trace/agent-observability/src/drivenadapter/dbaccess/mariadb/archivestore/store.go
+++ b/bkn-trace/agent-observability/src/drivenadapter/dbaccess/mariadb/archivestore/store.go
@@ -18,7 +18,7 @@ func (store *Store) Create(job archivesvc.Job) error {
 	if err != nil {
 		return err
 	}
-	payloads, err := json.Marshal(job.Candidates)
+	payloads, err := json.Marshal([]archivesvc.Candidate{})
 	if err != nil {
 		return err
 	}
@@ -27,7 +27,17 @@ func (store *Store) Create(job archivesvc.Job) error {
 }
 
 func (store *Store) Update(job archivesvc.Job) error {
-	_, err := store.db.Exec(`UPDATE bkn_trace_archive_jobs SET archive_status=?, manifest_ref=?, error_message=?, updated_at=? WHERE archive_job_id=?`, job.Status, nullableString(job.ManifestRef), nullableString(job.ErrorMessage), job.UpdatedAt.UTC(), job.ID)
+	payloads, err := json.Marshal([]archivesvc.Candidate{})
+	if err != nil {
+		return err
+	}
+	if job.Status == observabilityvo.ArchiveStatusCleanupIncomplete {
+		payloads, err = json.Marshal(job.Candidates)
+		if err != nil {
+			return err
+		}
+	}
+	_, err = store.db.Exec(`UPDATE bkn_trace_archive_jobs SET archive_status=?, candidate_payloads=?, manifest_ref=?, error_message=?, updated_at=? WHERE archive_job_id=?`, job.Status, payloads, nullableString(job.ManifestRef), nullableString(job.ErrorMessage), job.UpdatedAt.UTC(), job.ID)
 	return err
 }
 

--- a/bkn-trace/agent-observability/src/drivenadapter/dbaccess/mariadb/archivestore/store.go
+++ b/bkn-trace/agent-observability/src/drivenadapter/dbaccess/mariadb/archivestore/store.go
@@ -71,7 +71,7 @@ func (store *Store) List(tenantID string, kind observabilityvo.ArchiveKind, limi
 	if err != nil {
 		return nil
 	}
-	defer rows.Close()
+	defer func() { _ = rows.Close() }()
 	jobs := make([]archivesvc.Job, 0, limit)
 	for rows.Next() {
 		var id, status string

--- a/bkn-trace/agent-observability/src/drivenadapter/dbaccess/mariadb/archivestore/store.go
+++ b/bkn-trace/agent-observability/src/drivenadapter/dbaccess/mariadb/archivestore/store.go
@@ -1,0 +1,129 @@
+package archivestore
+
+import (
+	"database/sql"
+	"encoding/json"
+	"time"
+
+	"github.com/openbkn-ai/bkn-foundry/bkn-trace/agent-observability/src/domain/service/archivesvc"
+	"github.com/openbkn-ai/bkn-foundry/bkn-trace/agent-observability/src/domain/valueobject/observabilityvo"
+)
+
+type Store struct{ db *sql.DB }
+
+func New(db *sql.DB) *Store { return &Store{db: db} }
+
+func (store *Store) Create(job archivesvc.Job) error {
+	ids, err := json.Marshal(job.CandidateIDs)
+	if err != nil {
+		return err
+	}
+	_, err = store.db.Exec(`INSERT INTO bkn_trace_archive_jobs (archive_job_id, tenant_id, archive_kind, range_from, range_to, archive_status, candidate_ids, candidate_count, manifest_ref, error_message, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`, job.ID, job.TenantID, job.Kind, nullableTime(job.Range.From), job.Range.To.UTC(), job.Status, ids, job.CandidateCount, nullableString(job.ManifestRef), nullableString(job.ErrorMessage), job.CreatedAt.UTC(), job.UpdatedAt.UTC())
+	return err
+}
+
+func (store *Store) Update(job archivesvc.Job) error {
+	_, err := store.db.Exec(`UPDATE bkn_trace_archive_jobs SET archive_status=?, manifest_ref=?, error_message=?, updated_at=? WHERE archive_job_id=?`, job.Status, nullableString(job.ManifestRef), nullableString(job.ErrorMessage), job.UpdatedAt.UTC(), job.ID)
+	return err
+}
+
+func (store *Store) Latest(tenantID string, kind observabilityvo.ArchiveKind) (archivesvc.Job, bool) {
+	row := store.db.QueryRow(`SELECT archive_job_id, range_from, range_to, archive_status, candidate_ids, candidate_count, COALESCE(manifest_ref,''), COALESCE(error_message,''), created_at, updated_at FROM bkn_trace_archive_jobs WHERE tenant_id=? AND archive_kind=? ORDER BY created_at DESC LIMIT 1`, tenantID, kind)
+	return scan(row, tenantID, kind)
+}
+
+func (store *Store) Get(jobID string) (archivesvc.Job, bool) {
+	row := store.db.QueryRow(`SELECT tenant_id, archive_kind, range_from, range_to, archive_status, candidate_ids, candidate_count, COALESCE(manifest_ref,''), COALESCE(error_message,''), created_at, updated_at FROM bkn_trace_archive_jobs WHERE archive_job_id=?`, jobID)
+	var tenantID, kind string
+	var rangeFrom sql.NullTime
+	var rangeTo time.Time
+	var status string
+	var ids []byte
+	var count int
+	var manifest, message string
+	var createdAt, updatedAt time.Time
+	err := row.Scan(&tenantID, &kind, &rangeFrom, &rangeTo, &status, &ids, &count, &manifest, &message, &createdAt, &updatedAt)
+	if err != nil {
+		return archivesvc.Job{}, false
+	}
+	var candidateIDs []string
+	if json.Unmarshal(ids, &candidateIDs) != nil {
+		return archivesvc.Job{}, false
+	}
+	job := archivesvc.Job{ID: jobID, TenantID: tenantID, Kind: observabilityvo.ArchiveKind(kind), Range: observabilityvo.ArchiveRange{To: rangeTo.UTC()}, Status: observabilityvo.ArchiveStatus(status), CandidateIDs: candidateIDs, CandidateCount: count, ManifestRef: manifest, ErrorMessage: message, CreatedAt: createdAt.UTC(), UpdatedAt: updatedAt.UTC()}
+	if rangeFrom.Valid {
+		job.Range.From = rangeFrom.Time.UTC()
+	}
+	return job, true
+}
+
+func (store *Store) List(tenantID string, kind observabilityvo.ArchiveKind, limit int) []archivesvc.Job {
+	if limit <= 0 {
+		return nil
+	}
+	rows, err := store.db.Query(`SELECT archive_job_id, range_from, range_to, archive_status, candidate_ids, candidate_count, COALESCE(manifest_ref,''), COALESCE(error_message,''), created_at, updated_at FROM bkn_trace_archive_jobs WHERE tenant_id=? AND archive_kind=? ORDER BY created_at DESC LIMIT ?`, tenantID, kind, limit)
+	if err != nil {
+		return nil
+	}
+	defer rows.Close()
+	jobs := make([]archivesvc.Job, 0, limit)
+	for rows.Next() {
+		var id, status string
+		var rangeFrom sql.NullTime
+		var rangeTo time.Time
+		var ids []byte
+		var count int
+		var manifest, message string
+		var createdAt, updatedAt time.Time
+		if err := rows.Scan(&id, &rangeFrom, &rangeTo, &status, &ids, &count, &manifest, &message, &createdAt, &updatedAt); err != nil {
+			return nil
+		}
+		var candidateIDs []string
+		if json.Unmarshal(ids, &candidateIDs) != nil {
+			return nil
+		}
+		job := archivesvc.Job{ID: id, TenantID: tenantID, Kind: kind, Range: observabilityvo.ArchiveRange{To: rangeTo.UTC()}, Status: observabilityvo.ArchiveStatus(status), CandidateIDs: candidateIDs, CandidateCount: count, ManifestRef: manifest, ErrorMessage: message, CreatedAt: createdAt.UTC(), UpdatedAt: updatedAt.UTC()}
+		if rangeFrom.Valid {
+			job.Range.From = rangeFrom.Time.UTC()
+		}
+		jobs = append(jobs, job)
+	}
+	return jobs
+}
+
+func scan(row *sql.Row, tenantID string, kind observabilityvo.ArchiveKind) (archivesvc.Job, bool) {
+	var id, status string
+	var rangeFrom sql.NullTime
+	var rangeTo time.Time
+	var ids []byte
+	var count int
+	var manifest, message string
+	var createdAt, updatedAt time.Time
+	if err := row.Scan(&id, &rangeFrom, &rangeTo, &status, &ids, &count, &manifest, &message, &createdAt, &updatedAt); err != nil {
+		return archivesvc.Job{}, false
+	}
+	var candidateIDs []string
+	if err := json.Unmarshal(ids, &candidateIDs); err != nil {
+		return archivesvc.Job{}, false
+	}
+	job := archivesvc.Job{ID: id, TenantID: tenantID, Kind: kind, Range: observabilityvo.ArchiveRange{To: rangeTo.UTC()}, Status: observabilityvo.ArchiveStatus(status), CandidateIDs: candidateIDs, CandidateCount: count, ManifestRef: manifest, ErrorMessage: message, CreatedAt: createdAt.UTC(), UpdatedAt: updatedAt.UTC()}
+	if rangeFrom.Valid {
+		job.Range.From = rangeFrom.Time.UTC()
+	}
+	return job, true
+}
+
+func nullableString(value string) any {
+	if value == "" {
+		return nil
+	}
+	return value
+}
+func nullableTime(value time.Time) any {
+	if value.IsZero() {
+		return nil
+	}
+	return value.UTC()
+}
+
+var _ archivesvc.Store = (*Store)(nil)

--- a/bkn-trace/agent-observability/src/drivenadapter/dbaccess/mariadb/sessionstore/archive.go
+++ b/bkn-trace/agent-observability/src/drivenadapter/dbaccess/mariadb/sessionstore/archive.go
@@ -1,0 +1,113 @@
+package sessionstore
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/openbkn-ai/bkn-foundry/bkn-trace/agent-observability/src/domain/service/archivesvc"
+	"github.com/openbkn-ai/bkn-foundry/bkn-trace/agent-observability/src/domain/valueobject/observabilityvo"
+	"github.com/openbkn-ai/bkn-foundry/bkn-trace/agent-observability/src/domain/valueobject/sessionvo"
+	"github.com/openbkn-ai/bkn-foundry/bkn-trace/agent-observability/src/port/driven/isessionstore"
+)
+
+// TraceArchiveSource packages terminal Interaction facts from the Trace Core
+// authority. It intentionally keeps a Conversation row as a light index after
+// its completed Interaction package is removed from hot storage.
+type TraceArchiveSource struct{ store *Store }
+
+func NewTraceArchiveSource(store *Store) *TraceArchiveSource {
+	return &TraceArchiveSource{store: store}
+}
+
+func (source *TraceArchiveSource) Freeze(ctx context.Context, kind observabilityvo.ArchiveKind, tenantID string, archiveRange observabilityvo.ArchiveRange) ([]archivesvc.Candidate, error) {
+	if kind != observabilityvo.ArchiveKindTrace {
+		return nil, nil
+	}
+	rows, err := source.store.db.QueryContext(ctx, `SELECT interaction_id FROM bkn_trace_interactions i JOIN bkn_trace_conversations c ON c.conversation_id=i.conversation_id WHERE c.tenant_id=? AND i.execution_status<>? AND i.terminal_at<? ORDER BY i.terminal_at ASC, i.interaction_id ASC`, tenantID, sessionvo.InteractionActive, archiveRange.To.UTC())
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var candidates []archivesvc.Candidate
+	for rows.Next() {
+		var interactionID string
+		if err := rows.Scan(&interactionID); err != nil {
+			return nil, err
+		}
+		payload, occurredAt, err := source.packageInteraction(ctx, interactionID)
+		if err != nil {
+			return nil, err
+		}
+		candidates = append(candidates, archivesvc.Candidate{ID: interactionID, OccurredAt: occurredAt, Payload: payload})
+	}
+	return candidates, rows.Err()
+}
+
+func (source *TraceArchiveSource) packageInteraction(ctx context.Context, interactionID string) ([]byte, time.Time, error) {
+	var interaction sessionvo.Interaction
+	var conversation sessionvo.Conversation
+	var operations []sessionvo.Operation
+	var receipts []sessionvo.Receipt
+	var facts []sessionvo.OperationCallFact
+	err := source.store.WithinTransaction(ctx, func(tx isessionstore.Transaction) error {
+		var ok bool
+		interaction, ok = tx.PeekInteraction(interactionID)
+		if !ok {
+			return fmt.Errorf("interaction %s not found", interactionID)
+		}
+		conversation, ok = tx.PeekConversation(interaction.ConversationID)
+		if !ok {
+			return fmt.Errorf("conversation %s not found", interaction.ConversationID)
+		}
+		operations, receipts, facts = tx.ListOperations(interactionID), tx.ListReceipts(interactionID), tx.ListOperationCallFacts(interactionID)
+		return nil
+	})
+	if err != nil {
+		return nil, time.Time{}, err
+	}
+	payload, err := json.Marshal(map[string]any{"conversation": conversation, "interaction": interaction, "operations": operations, "receipts": receipts, "call_facts": facts})
+	if err != nil {
+		return nil, time.Time{}, err
+	}
+	if interaction.TerminalAt == nil {
+		return nil, time.Time{}, fmt.Errorf("terminal interaction %s has no terminal time", interactionID)
+	}
+	return payload, *interaction.TerminalAt, nil
+}
+
+func (source *TraceArchiveSource) Purge(ctx context.Context, kind observabilityvo.ArchiveKind, tenantID string, candidates []archivesvc.Candidate) error {
+	if kind != observabilityvo.ArchiveKindTrace {
+		return nil
+	}
+	tx, err := source.store.db.BeginTx(ctx, nil)
+	if err != nil {
+		return err
+	}
+	defer tx.Rollback()
+	for _, candidate := range candidates {
+		var id string
+		err := tx.QueryRowContext(ctx, `SELECT i.interaction_id FROM bkn_trace_interactions i JOIN bkn_trace_conversations c ON c.conversation_id=i.conversation_id WHERE i.interaction_id=? AND c.tenant_id=? AND i.execution_status<>? FOR UPDATE`, candidate.ID, tenantID, sessionvo.InteractionActive).Scan(&id)
+		if errors.Is(err, sql.ErrNoRows) {
+			continue
+		}
+		if err != nil {
+			return err
+		}
+		for _, statement := range []string{
+			`DELETE FROM bkn_trace_operation_call_facts WHERE interaction_id=?`,
+			`DELETE FROM bkn_trace_receipts WHERE interaction_id=?`,
+			`DELETE FROM bkn_trace_operations WHERE interaction_id=?`,
+			`DELETE FROM bkn_trace_assembly_revisions WHERE interaction_id=?`,
+			`DELETE FROM bkn_trace_interactions WHERE interaction_id=?`,
+		} {
+			if _, err := tx.ExecContext(ctx, statement, id); err != nil {
+				return err
+			}
+		}
+	}
+	return tx.Commit()
+}

--- a/bkn-trace/agent-observability/src/drivenadapter/dbaccess/mariadb/sessionstore/archive.go
+++ b/bkn-trace/agent-observability/src/drivenadapter/dbaccess/mariadb/sessionstore/archive.go
@@ -31,7 +31,7 @@ func (source *TraceArchiveSource) Freeze(ctx context.Context, kind observability
 	if err != nil {
 		return nil, err
 	}
-	defer rows.Close()
+	defer func() { _ = rows.Close() }()
 	var candidates []archivesvc.Candidate
 	for rows.Next() {
 		var interactionID string
@@ -87,7 +87,7 @@ func (source *TraceArchiveSource) Purge(ctx context.Context, kind observabilityv
 	if err != nil {
 		return err
 	}
-	defer tx.Rollback()
+	defer func() { _ = tx.Rollback() }()
 	for _, candidate := range candidates {
 		var id string
 		err := tx.QueryRowContext(ctx, `SELECT i.interaction_id FROM bkn_trace_interactions i JOIN bkn_trace_conversations c ON c.conversation_id=i.conversation_id WHERE i.interaction_id=? AND c.tenant_id=? AND i.execution_status<>? FOR UPDATE`, candidate.ID, tenantID, sessionvo.InteractionActive).Scan(&id)

--- a/bkn-trace/agent-observability/src/drivenadapter/dbaccess/mariadb/sessionstore/schema.go
+++ b/bkn-trace/agent-observability/src/drivenadapter/dbaccess/mariadb/sessionstore/schema.go
@@ -4,8 +4,9 @@ import (
 	v013 "github.com/openbkn-ai/bkn-foundry/bkn-trace/agent-observability/migrations/mariadb/v013"
 	v014 "github.com/openbkn-ai/bkn-foundry/bkn-trace/agent-observability/migrations/mariadb/v014"
 	v015 "github.com/openbkn-ai/bkn-foundry/bkn-trace/agent-observability/migrations/mariadb/v015"
+	v016 "github.com/openbkn-ai/bkn-foundry/bkn-trace/agent-observability/migrations/mariadb/v016"
 )
 
 func SchemaSQL() string {
-	return v013.SchemaSQL() + "\n" + v014.SchemaSQL() + "\n" + v015.SchemaSQL()
+	return v013.SchemaSQL() + "\n" + v014.SchemaSQL() + "\n" + v015.SchemaSQL() + "\n" + v016.SchemaSQL()
 }

--- a/bkn-trace/agent-observability/src/drivenadapter/dbaccess/mariadb/sessionstore/store.go
+++ b/bkn-trace/agent-observability/src/drivenadapter/dbaccess/mariadb/sessionstore/store.go
@@ -27,6 +27,10 @@ func New(db *sql.DB) *Store {
 	return &Store{db: db}
 }
 
+// Database is intentionally exposed only to adjacent Trace Core adapters that
+// share the same migration boundary (for example manual archive jobs).
+func (s *Store) Database() *sql.DB { return s.db }
+
 func (s *Store) Migrate(ctx context.Context) error {
 	for _, statement := range strings.Split(SchemaSQL(), ";") {
 		statement = strings.TrimSpace(statement)

--- a/bkn-trace/agent-observability/src/drivenadapter/httpaccess/bknsafeuseraccess/client.go
+++ b/bkn-trace/agent-observability/src/drivenadapter/httpaccess/bknsafeuseraccess/client.go
@@ -71,7 +71,7 @@ func (client *Client) Search(ctx context.Context, query observabilityvo.LogQuery
 	if err != nil {
 		return observabilityvo.SourcePage{}, err
 	}
-	defer response.Body.Close()
+	defer func() { _ = response.Body.Close() }()
 	if response.StatusCode != http.StatusOK {
 		_, _ = io.Copy(io.Discard, io.LimitReader(response.Body, maxResponseBytes))
 		return observabilityvo.SourcePage{}, fmt.Errorf("BKN Safe access source returned status %d", response.StatusCode)
@@ -104,7 +104,7 @@ func (client *Client) Get(ctx context.Context, logID string) (observabilityvo.Lo
 	if err != nil {
 		return observabilityvo.LogRecord{}, false, err
 	}
-	defer response.Body.Close()
+	defer func() { _ = response.Body.Close() }()
 	if response.StatusCode == http.StatusNotFound {
 		return observabilityvo.LogRecord{}, false, nil
 	}

--- a/bkn-trace/agent-observability/src/drivenadapter/httpaccess/executionfactoryaudit/client.go
+++ b/bkn-trace/agent-observability/src/drivenadapter/httpaccess/executionfactoryaudit/client.go
@@ -72,7 +72,7 @@ func (c *Client) Search(ctx context.Context, q observabilityvo.LogQuery) (observ
 	if err != nil {
 		return observabilityvo.SourcePage{}, err
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 	if resp.StatusCode != http.StatusOK {
 		return observabilityvo.SourcePage{}, fmt.Errorf("execution factory audit source returned status %d", resp.StatusCode)
 	}
@@ -108,7 +108,7 @@ func (c *Client) Get(ctx context.Context, logID string) (observabilityvo.LogReco
 	if err != nil {
 		return observabilityvo.LogRecord{}, false, err
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 	if resp.StatusCode == http.StatusNotFound {
 		return observabilityvo.LogRecord{}, false, nil
 	}

--- a/bkn-trace/agent-observability/src/drivenadapter/httpaccess/modelmanageraudit/client.go
+++ b/bkn-trace/agent-observability/src/drivenadapter/httpaccess/modelmanageraudit/client.go
@@ -71,7 +71,7 @@ func (c *Client) Search(ctx context.Context, q observabilityvo.LogQuery) (observ
 	if err != nil {
 		return observabilityvo.SourcePage{}, err
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 	if resp.StatusCode != http.StatusOK {
 		return observabilityvo.SourcePage{}, fmt.Errorf("model manager audit source returned status %d", resp.StatusCode)
 	}
@@ -107,7 +107,7 @@ func (c *Client) Get(ctx context.Context, id string) (observabilityvo.LogRecord,
 	if err != nil {
 		return observabilityvo.LogRecord{}, false, err
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 	if resp.StatusCode == http.StatusNotFound {
 		return observabilityvo.LogRecord{}, false, nil
 	}

--- a/bkn-trace/agent-observability/src/drivenadapter/httpaccess/opensearchconversationaudit/archive.go
+++ b/bkn-trace/agent-observability/src/drivenadapter/httpaccess/opensearchconversationaudit/archive.go
@@ -1,0 +1,78 @@
+package opensearchconversationaudit
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/openbkn-ai/bkn-foundry/bkn-trace/agent-observability/src/domain/service/archivesvc"
+	"github.com/openbkn-ai/bkn-foundry/bkn-trace/agent-observability/src/domain/valueobject/observabilityvo"
+)
+
+type archiveClient interface {
+	Search(context.Context, string, []byte) ([]byte, error)
+	DeleteByQuery(context.Context, string, []byte) error
+}
+
+// ArchiveSource is deliberately scoped to platform-hosted Agent Conversation
+// operation facts. External BKN Safe audit adapters never enter this cleanup.
+type ArchiveSource struct {
+	backend archiveClient
+	index   string
+}
+
+func NewArchiveSource(backend archiveClient, index string) *ArchiveSource {
+	return &ArchiveSource{backend: backend, index: index}
+}
+
+func (source *ArchiveSource) Freeze(ctx context.Context, kind observabilityvo.ArchiveKind, tenantID string, archiveRange observabilityvo.ArchiveRange) ([]archivesvc.Candidate, error) {
+	if kind != observabilityvo.ArchiveKindLog {
+		return nil, nil
+	}
+	body, _ := json.Marshal(map[string]any{"size": 10000, "sort": []any{map[string]any{"created_at": map[string]any{"order": "asc"}}}, "query": map[string]any{"bool": map[string]any{"filter": []any{
+		map[string]any{"term": map[string]any{"owner.tenant_id.keyword": tenantID}},
+		map[string]any{"range": map[string]any{"created_at": map[string]any{"lt": archiveRange.To.Format(time.RFC3339Nano)}}},
+	}}}})
+	payload, err := source.backend.Search(ctx, source.index, body)
+	if err != nil {
+		return nil, err
+	}
+	var response struct {
+		Hits struct {
+			Hits []struct {
+				ID     string          `json:"_id"`
+				Source json.RawMessage `json:"_source"`
+			} `json:"hits"`
+		} `json:"hits"`
+	}
+	if err := json.Unmarshal(payload, &response); err != nil {
+		return nil, err
+	}
+	candidates := make([]archivesvc.Candidate, 0, len(response.Hits.Hits))
+	for _, hit := range response.Hits.Hits {
+		var value struct {
+			CreatedAt time.Time `json:"created_at"`
+		}
+		if err := json.Unmarshal(hit.Source, &value); err != nil {
+			return nil, err
+		}
+		candidates = append(candidates, archivesvc.Candidate{ID: hit.ID, OccurredAt: value.CreatedAt, Payload: hit.Source})
+	}
+	return candidates, nil
+}
+
+func (source *ArchiveSource) Purge(ctx context.Context, kind observabilityvo.ArchiveKind, _ string, candidates []archivesvc.Candidate) error {
+	if kind != observabilityvo.ArchiveKindLog || len(candidates) == 0 {
+		return nil
+	}
+	ids := make([]string, 0, len(candidates))
+	for _, candidate := range candidates {
+		ids = append(ids, candidate.ID)
+	}
+	body, err := json.Marshal(map[string]any{"query": map[string]any{"ids": map[string]any{"values": ids}}})
+	if err != nil {
+		return fmt.Errorf("encode frozen archive document ids: %w", err)
+	}
+	return source.backend.DeleteByQuery(ctx, source.index, body)
+}

--- a/bkn-trace/agent-observability/src/drivenadapter/httpaccess/opensearchtraceaccess/archive.go
+++ b/bkn-trace/agent-observability/src/drivenadapter/httpaccess/opensearchtraceaccess/archive.go
@@ -39,13 +39,16 @@ func (store *ArchiveStore) Enrich(ctx context.Context, candidates []archivesvc.C
 		return candidates, nil
 	}
 	ids := sortedKeys(all)
-	query, _ := json.Marshal(map[string]any{"size": 10000, "query": map[string]any{"terms": map[string]any{"traceId.keyword": ids}}})
+	query, _ := json.Marshal(map[string]any{"size": 10000, "track_total_hits": true, "query": map[string]any{"terms": map[string]any{"traceId.keyword": ids}}})
 	body, err := store.client.Search(ctx, store.index, query)
 	if err != nil {
 		return nil, err
 	}
 	var response struct {
 		Hits struct {
+			Total struct {
+				Value int `json:"value"`
+			} `json:"total"`
 			Hits []struct {
 				ID     string          `json:"_id"`
 				Source json.RawMessage `json:"_source"`
@@ -54,6 +57,9 @@ func (store *ArchiveStore) Enrich(ctx context.Context, candidates []archivesvc.C
 	}
 	if err := json.Unmarshal(body, &response); err != nil {
 		return nil, err
+	}
+	if searchResultTruncated(response.Hits.Total.Value, len(response.Hits.Hits)) {
+		return nil, fmt.Errorf("technical trace archive exceeds the 10000-record batch limit")
 	}
 	byTrace := map[string][]json.RawMessage{}
 	for _, hit := range response.Hits.Hits {
@@ -88,6 +94,8 @@ func (store *ArchiveStore) Enrich(ctx context.Context, candidates []archivesvc.C
 	}
 	return result, nil
 }
+
+func searchResultTruncated(total, returned int) bool { return total > returned }
 
 func (store *ArchiveStore) Purge(ctx context.Context, candidates []archivesvc.Candidate) error {
 	all := map[string]struct{}{}

--- a/bkn-trace/agent-observability/src/drivenadapter/httpaccess/opensearchtraceaccess/archive.go
+++ b/bkn-trace/agent-observability/src/drivenadapter/httpaccess/opensearchtraceaccess/archive.go
@@ -1,0 +1,144 @@
+package opensearchtraceaccess
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"sort"
+
+	"github.com/openbkn-ai/bkn-foundry/bkn-trace/agent-observability/src/domain/service/archivesvc"
+	"github.com/openbkn-ai/bkn-foundry/bkn-trace/agent-observability/src/infra/opensearch"
+)
+
+// ArchiveStore copies the raw OTel documents referred to by frozen Operation
+// facts into the same JSONL record.  It is deliberately keyed by trace ID,
+// not by a fresh cutoff query, so cleanup cannot catch newer documents.
+type ArchiveStore struct {
+	client *opensearch.Client
+	index  string
+}
+
+func NewArchiveStore(client *opensearch.Client, index string) *ArchiveStore {
+	return &ArchiveStore{client: client, index: index}
+}
+
+func (store *ArchiveStore) Enrich(ctx context.Context, candidates []archivesvc.Candidate) ([]archivesvc.Candidate, error) {
+	idsByCandidate := map[string][]string{}
+	all := map[string]struct{}{}
+	for _, candidate := range candidates {
+		ids, err := traceIDs(candidate.Payload)
+		if err != nil {
+			return nil, err
+		}
+		idsByCandidate[candidate.ID] = ids
+		for _, id := range ids {
+			all[id] = struct{}{}
+		}
+	}
+	if len(all) == 0 {
+		return candidates, nil
+	}
+	ids := sortedKeys(all)
+	query, _ := json.Marshal(map[string]any{"size": 10000, "query": map[string]any{"terms": map[string]any{"traceId.keyword": ids}}})
+	body, err := store.client.Search(ctx, store.index, query)
+	if err != nil {
+		return nil, err
+	}
+	var response struct {
+		Hits struct {
+			Hits []struct {
+				ID     string          `json:"_id"`
+				Source json.RawMessage `json:"_source"`
+			} `json:"hits"`
+		} `json:"hits"`
+	}
+	if err := json.Unmarshal(body, &response); err != nil {
+		return nil, err
+	}
+	byTrace := map[string][]json.RawMessage{}
+	for _, hit := range response.Hits.Hits {
+		var source map[string]any
+		if json.Unmarshal(hit.Source, &source) != nil {
+			continue
+		}
+		traceID, _ := source["traceId"].(string)
+		if traceID != "" {
+			byTrace[traceID] = append(byTrace[traceID], hit.Source)
+		}
+	}
+	result := make([]archivesvc.Candidate, 0, len(candidates))
+	for _, candidate := range candidates {
+		var payload map[string]any
+		if err := json.Unmarshal(candidate.Payload, &payload); err != nil {
+			return nil, err
+		}
+		ids := idsByCandidate[candidate.ID]
+		technical := make([]json.RawMessage, 0)
+		for _, id := range ids {
+			technical = append(technical, byTrace[id]...)
+		}
+		payload["technical_trace_ids"] = ids
+		payload["technical_traces"] = technical
+		encoded, err := json.Marshal(payload)
+		if err != nil {
+			return nil, err
+		}
+		candidate.Payload = encoded
+		result = append(result, candidate)
+	}
+	return result, nil
+}
+
+func (store *ArchiveStore) Purge(ctx context.Context, candidates []archivesvc.Candidate) error {
+	all := map[string]struct{}{}
+	for _, candidate := range candidates {
+		ids, err := traceIDs(candidate.Payload)
+		if err != nil {
+			return err
+		}
+		for _, id := range ids {
+			all[id] = struct{}{}
+		}
+	}
+	if len(all) == 0 {
+		return nil
+	}
+	query, _ := json.Marshal(map[string]any{"query": map[string]any{"terms": map[string]any{"traceId.keyword": sortedKeys(all)}}})
+	return store.client.DeleteByQuery(ctx, store.index, query)
+}
+
+type archivePayload struct {
+	CallFacts []struct {
+		TraceID string `json:"trace_id"`
+	} `json:"call_facts"`
+	TechnicalTraceIDs []string `json:"technical_trace_ids"`
+}
+
+func traceIDs(payload []byte) ([]string, error) {
+	var value archivePayload
+	if err := json.Unmarshal(payload, &value); err != nil {
+		return nil, fmt.Errorf("decode archive trace ids: %w", err)
+	}
+	unique := map[string]struct{}{}
+	for _, fact := range value.CallFacts {
+		if fact.TraceID != "" {
+			unique[fact.TraceID] = struct{}{}
+		}
+	}
+	for _, id := range value.TechnicalTraceIDs {
+		if id != "" {
+			unique[id] = struct{}{}
+		}
+	}
+	return sortedKeys(unique), nil
+}
+func sortedKeys(values map[string]struct{}) []string {
+	result := make([]string, 0, len(values))
+	for value := range values {
+		result = append(result, value)
+	}
+	sort.Strings(result)
+	return result
+}
+
+var _ archivesvc.TraceTechnicalStore = (*ArchiveStore)(nil)

--- a/bkn-trace/agent-observability/src/drivenadapter/httpaccess/opensearchtraceaccess/archive_test.go
+++ b/bkn-trace/agent-observability/src/drivenadapter/httpaccess/opensearchtraceaccess/archive_test.go
@@ -17,3 +17,12 @@ func TestTraceIDsUsesFrozenCallFactsAndPreservesExistingIDs(t *testing.T) {
 		}
 	}
 }
+
+func TestSearchResultTruncatedPreventsUnarchivedTraceDeletion(t *testing.T) {
+	if !searchResultTruncated(10001, 10000) {
+		t.Fatal("a partial OpenSearch result must fail the archive before cleanup")
+	}
+	if searchResultTruncated(10000, 10000) {
+		t.Fatal("a complete OpenSearch result must remain archivable")
+	}
+}

--- a/bkn-trace/agent-observability/src/drivenadapter/httpaccess/opensearchtraceaccess/archive_test.go
+++ b/bkn-trace/agent-observability/src/drivenadapter/httpaccess/opensearchtraceaccess/archive_test.go
@@ -1,0 +1,19 @@
+package opensearchtraceaccess
+
+import "testing"
+
+func TestTraceIDsUsesFrozenCallFactsAndPreservesExistingIDs(t *testing.T) {
+	ids, err := traceIDs([]byte(`{"call_facts":[{"trace_id":"trace-b"},{"trace_id":"trace-a"},{"trace_id":""}],"technical_trace_ids":["trace-a","trace-c"]}`))
+	if err != nil {
+		t.Fatalf("traceIDs returned error: %v", err)
+	}
+	want := []string{"trace-a", "trace-b", "trace-c"}
+	if len(ids) != len(want) {
+		t.Fatalf("ids = %#v, want %#v", ids, want)
+	}
+	for index := range want {
+		if ids[index] != want[index] {
+			t.Fatalf("ids = %#v, want %#v", ids, want)
+		}
+	}
+}

--- a/bkn-trace/agent-observability/src/drivenadapter/httpaccess/ossgatewayarchive/client.go
+++ b/bkn-trace/agent-observability/src/drivenadapter/httpaccess/ossgatewayarchive/client.go
@@ -117,7 +117,7 @@ func (client *Client) download(ctx context.Context, key string) ([]byte, error) 
 	if err != nil {
 		return nil, err
 	}
-	defer response.Body.Close()
+	defer func() { _ = response.Body.Close() }()
 	if response.StatusCode < 200 || response.StatusCode >= 300 {
 		return nil, fmt.Errorf("read archive bundle: %s", response.Status)
 	}

--- a/bkn-trace/agent-observability/src/drivenadapter/httpaccess/ossgatewayarchive/client.go
+++ b/bkn-trace/agent-observability/src/drivenadapter/httpaccess/ossgatewayarchive/client.go
@@ -1,0 +1,221 @@
+package ossgatewayarchive
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/openbkn-ai/bkn-foundry/bkn-trace/agent-observability/src/domain/service/archivesvc"
+)
+
+type Config struct {
+	BaseURL, StorageID, Prefix string
+	Timeout                    time.Duration
+}
+type Client struct {
+	config            Config
+	http              *http.Client
+	mu                sync.Mutex
+	resolvedStorageID string
+}
+
+func New(config Config) *Client {
+	if config.Timeout <= 0 {
+		config.Timeout = 20 * time.Second
+	}
+	if config.Prefix == "" {
+		config.Prefix = "observability-archive"
+	}
+	if config.BaseURL == "" {
+		config.BaseURL = "http://oss-gateway-backend:8080/api/v1"
+	}
+	return &Client{config: config, http: &http.Client{Timeout: config.Timeout}}
+}
+func (client *Client) Ready() bool {
+	return strings.TrimSpace(client.config.BaseURL) != ""
+}
+
+// Availability resolves the deployment's enabled default storage when a
+// dedicated archive storage ID was not supplied.  This reuses Foundry's
+// existing gateway configuration rather than creating a second storage path.
+func (client *Client) Availability(ctx context.Context) (bool, error) {
+	_, err := client.storageID(ctx)
+	return err == nil, err
+}
+
+type gatewayResponse struct {
+	Data struct {
+		Method  string            `json:"method"`
+		URL     string            `json:"url"`
+		Headers map[string]string `json:"headers"`
+	} `json:"data"`
+}
+
+func (client *Client) WriteAndVerify(ctx context.Context, job archivesvc.Job, candidates []archivesvc.Candidate) (string, error) {
+	if _, err := client.storageID(ctx); err != nil {
+		return "", err
+	}
+	lines := make([][]byte, 0, len(candidates))
+	for _, candidate := range candidates {
+		lines = append(lines, append(append([]byte(nil), candidate.Payload...), '\n'))
+	}
+	content := bytes.Join(lines, nil)
+	dataKey := fmt.Sprintf("%s/%s/%s.jsonl", client.config.Prefix, job.TenantID, job.ID)
+	if err := client.upload(ctx, dataKey, content); err != nil {
+		return "", err
+	}
+	digest := sha256.Sum256(content)
+	manifest := map[string]any{"archive_job_id": job.ID, "archive_kind": job.Kind, "candidate_count": len(candidates), "data_key": dataKey, "sha256": hex.EncodeToString(digest[:])}
+	manifestBody, err := json.Marshal(manifest)
+	if err != nil {
+		return "", err
+	}
+	manifestKey := fmt.Sprintf("%s/%s/%s/manifest.json", client.config.Prefix, job.TenantID, job.ID)
+	if err := client.upload(ctx, manifestKey, manifestBody); err != nil {
+		return "", err
+	}
+	verified, err := client.download(ctx, dataKey)
+	if err != nil {
+		return "", err
+	}
+	actual := sha256.Sum256(verified)
+	if actual != digest {
+		return "", fmt.Errorf("archive bundle checksum mismatch")
+	}
+	return manifestKey, nil
+}
+
+func (client *Client) upload(ctx context.Context, key string, content []byte) error {
+	method, signedURL, headers, err := client.authorize(ctx, "upload", key, http.MethodPut)
+	if err != nil {
+		return err
+	}
+	return client.signed(ctx, method, signedURL, headers, content)
+}
+func (client *Client) download(ctx context.Context, key string) ([]byte, error) {
+	method, signedURL, headers, err := client.authorize(ctx, "download", key, http.MethodGet)
+	if err != nil {
+		return nil, err
+	}
+	req, err := http.NewRequestWithContext(ctx, method, signedURL, nil)
+	if err != nil {
+		return nil, err
+	}
+	for k, v := range headers {
+		req.Header.Set(k, v)
+	}
+	response, err := client.http.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer response.Body.Close()
+	if response.StatusCode < 200 || response.StatusCode >= 300 {
+		return nil, fmt.Errorf("read archive bundle: %s", response.Status)
+	}
+	return io.ReadAll(response.Body)
+}
+func (client *Client) DownloadURL(ctx context.Context, key string) (string, error) {
+	_, signedURL, _, err := client.authorize(ctx, "download", key, http.MethodGet)
+	return signedURL, err
+}
+func (client *Client) authorize(ctx context.Context, operation, key, method string) (string, string, map[string]string, error) {
+	storageID, err := client.storageID(ctx)
+	if err != nil {
+		return "", "", nil, err
+	}
+	endpoint := fmt.Sprintf("%s/%s/%s/%s", strings.TrimRight(client.config.BaseURL, "/"), operation, url.PathEscape(storageID), url.PathEscape(key))
+	request, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint, nil)
+	if err != nil {
+		return "", "", nil, err
+	}
+	query := request.URL.Query()
+	query.Set("request_method", method)
+	query.Set("expires", "3600")
+	query.Set("internal_request", "true")
+	request.URL.RawQuery = query.Encode()
+	response, err := client.http.Do(request)
+	if err != nil {
+		return "", "", nil, err
+	}
+	defer response.Body.Close()
+	body, err := io.ReadAll(response.Body)
+	if err != nil {
+		return "", "", nil, err
+	}
+	if response.StatusCode < 200 || response.StatusCode >= 300 {
+		return "", "", nil, fmt.Errorf("archive storage authorization: %s", response.Status)
+	}
+	var gateway gatewayResponse
+	if err := json.Unmarshal(body, &gateway); err != nil {
+		return "", "", nil, err
+	}
+	if gateway.Data.URL == "" || gateway.Data.Method == "" {
+		return "", "", nil, fmt.Errorf("archive storage returned no signed request")
+	}
+	return gateway.Data.Method, gateway.Data.URL, gateway.Data.Headers, nil
+}
+
+func (client *Client) storageID(ctx context.Context) (string, error) {
+	client.mu.Lock()
+	defer client.mu.Unlock()
+	if client.resolvedStorageID != "" {
+		return client.resolvedStorageID, nil
+	}
+	if configured := strings.TrimSpace(client.config.StorageID); configured != "" {
+		client.resolvedStorageID = configured
+		return configured, nil
+	}
+	endpoint := strings.TrimRight(client.config.BaseURL, "/") + "/storages?enabled=true&is_default=true"
+	request, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint, nil)
+	if err != nil {
+		return "", err
+	}
+	response, err := client.http.Do(request)
+	if err != nil {
+		return "", err
+	}
+	defer response.Body.Close()
+	if response.StatusCode < 200 || response.StatusCode >= 300 {
+		return "", fmt.Errorf("query default archive storage: %s", response.Status)
+	}
+	var body struct {
+		Data []struct {
+			StorageID string `json:"storage_id"`
+		} `json:"data"`
+	}
+	if err := json.NewDecoder(response.Body).Decode(&body); err != nil {
+		return "", err
+	}
+	if len(body.Data) == 0 || strings.TrimSpace(body.Data[0].StorageID) == "" {
+		return "", fmt.Errorf("no enabled default object storage is configured")
+	}
+	client.resolvedStorageID = strings.TrimSpace(body.Data[0].StorageID)
+	return client.resolvedStorageID, nil
+}
+func (client *Client) signed(ctx context.Context, method, signedURL string, headers map[string]string, content []byte) error {
+	request, err := http.NewRequestWithContext(ctx, method, signedURL, bytes.NewReader(content))
+	if err != nil {
+		return err
+	}
+	for k, v := range headers {
+		request.Header.Set(k, v)
+	}
+	response, err := client.http.Do(request)
+	if err != nil {
+		return err
+	}
+	defer response.Body.Close()
+	if response.StatusCode < 200 || response.StatusCode >= 300 {
+		return fmt.Errorf("write archive bundle: %s", response.Status)
+	}
+	return nil
+}

--- a/bkn-trace/agent-observability/src/drivenadapter/httpaccess/ossgatewayarchive/client.go
+++ b/bkn-trace/agent-observability/src/drivenadapter/httpaccess/ossgatewayarchive/client.go
@@ -146,7 +146,7 @@ func (client *Client) authorize(ctx context.Context, operation, key, method stri
 	if err != nil {
 		return "", "", nil, err
 	}
-	defer response.Body.Close()
+	defer func() { _ = response.Body.Close() }()
 	body, err := io.ReadAll(response.Body)
 	if err != nil {
 		return "", "", nil, err
@@ -183,7 +183,7 @@ func (client *Client) storageID(ctx context.Context) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	defer response.Body.Close()
+	defer func() { _ = response.Body.Close() }()
 	if response.StatusCode < 200 || response.StatusCode >= 300 {
 		return "", fmt.Errorf("query default archive storage: %s", response.Status)
 	}
@@ -213,7 +213,7 @@ func (client *Client) signed(ctx context.Context, method, signedURL string, head
 	if err != nil {
 		return err
 	}
-	defer response.Body.Close()
+	defer func() { _ = response.Body.Close() }()
 	if response.StatusCode < 200 || response.StatusCode >= 300 {
 		return fmt.Errorf("write archive bundle: %s", response.Status)
 	}

--- a/bkn-trace/agent-observability/src/drivenadapter/httpaccess/ossgatewayarchive/client_test.go
+++ b/bkn-trace/agent-observability/src/drivenadapter/httpaccess/ossgatewayarchive/client_test.go
@@ -1,0 +1,33 @@
+package ossgatewayarchive
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+)
+
+type roundTripper func(*http.Request) (*http.Response, error)
+
+func (fn roundTripper) RoundTrip(request *http.Request) (*http.Response, error) { return fn(request) }
+
+func TestAvailabilityResolvesEnabledDefaultStorage(t *testing.T) {
+	client := New(Config{BaseURL: "http://gateway/api/v1"})
+	client.http = &http.Client{Transport: roundTripper(func(request *http.Request) (*http.Response, error) {
+		if request.URL.Path != "/api/v1/storages" {
+			t.Fatalf("path = %s", request.URL.Path)
+		}
+		if request.URL.Query().Get("enabled") != "true" || request.URL.Query().Get("is_default") != "true" {
+			t.Fatalf("missing default storage query: %s", request.URL.RawQuery)
+		}
+		return &http.Response{StatusCode: http.StatusOK, Body: io.NopCloser(strings.NewReader(`{"data":[{"storage_id":"default-archive"}]}`)), Header: make(http.Header)}, nil
+	})}
+	ready, err := client.Availability(context.Background())
+	if err != nil || !ready {
+		t.Fatalf("availability = %v, %v", ready, err)
+	}
+	if client.resolvedStorageID != "default-archive" {
+		t.Fatalf("storage id = %q", client.resolvedStorageID)
+	}
+}

--- a/bkn-trace/agent-observability/src/drivenadapter/httpaccess/vegaaudit/client.go
+++ b/bkn-trace/agent-observability/src/drivenadapter/httpaccess/vegaaudit/client.go
@@ -42,7 +42,7 @@ func (client *Client) Search(ctx context.Context, query observabilityvo.LogQuery
 	}
 	authorization := strings.TrimSpace(observabilityvo.SourceAuthorization(ctx))
 	if authorization == "" || query.AuthorizedTenantID == "" || query.AuthorizedBusinessDomain == "" {
-		return observabilityvo.SourcePage{}, errors.New("Vega audit source requires caller authorization and trusted scope")
+		return observabilityvo.SourcePage{}, errors.New("vega audit source requires caller authorization and trusted scope")
 	}
 	parameters := url.Values{}
 	parameters.Set("limit", strconv.Itoa(normalizedLimit(query.Limit)))
@@ -72,10 +72,10 @@ func (client *Client) Search(ctx context.Context, query observabilityvo.LogQuery
 	if err != nil {
 		return observabilityvo.SourcePage{}, err
 	}
-	defer response.Body.Close()
+	defer func() { _ = response.Body.Close() }()
 	if response.StatusCode != http.StatusOK {
 		_, _ = io.Copy(io.Discard, io.LimitReader(response.Body, 4<<20))
-		return observabilityvo.SourcePage{}, fmt.Errorf("Vega audit source returned status %d", response.StatusCode)
+		return observabilityvo.SourcePage{}, fmt.Errorf("vega audit source returned status %d", response.StatusCode)
 	}
 	var payload struct {
 		Entries []auditEntry `json:"entries"`
@@ -99,7 +99,7 @@ func (client *Client) Get(ctx context.Context, logID string) (observabilityvo.Lo
 	authorization := strings.TrimSpace(observabilityvo.SourceAuthorization(ctx))
 	scope := observabilityvo.SourceAccessScopeFromContext(ctx)
 	if authorization == "" || scope.TenantID == "" || scope.BusinessDomain == "" {
-		return observabilityvo.LogRecord{}, false, errors.New("Vega audit source requires caller authorization and trusted scope")
+		return observabilityvo.LogRecord{}, false, errors.New("vega audit source requires caller authorization and trusted scope")
 	}
 	request, err := http.NewRequestWithContext(ctx, http.MethodGet, client.baseURL+"/api/vega-backend/v1/operation-audits/"+url.PathEscape(sourceLogID(logID)), nil)
 	if err != nil {
@@ -110,12 +110,12 @@ func (client *Client) Get(ctx context.Context, logID string) (observabilityvo.Lo
 	if err != nil {
 		return observabilityvo.LogRecord{}, false, err
 	}
-	defer response.Body.Close()
+	defer func() { _ = response.Body.Close() }()
 	if response.StatusCode == http.StatusNotFound {
 		return observabilityvo.LogRecord{}, false, nil
 	}
 	if response.StatusCode != http.StatusOK {
-		return observabilityvo.LogRecord{}, false, fmt.Errorf("Vega audit source returned status %d", response.StatusCode)
+		return observabilityvo.LogRecord{}, false, fmt.Errorf("vega audit source returned status %d", response.StatusCode)
 	}
 	var entry auditEntry
 	if err := json.NewDecoder(io.LimitReader(response.Body, 4<<20)).Decode(&entry); err != nil {

--- a/bkn-trace/agent-observability/src/driveradapter/api/httphandler/access_profile_handler.go
+++ b/bkn-trace/agent-observability/src/driveradapter/api/httphandler/access_profile_handler.go
@@ -53,6 +53,7 @@ func accessProfileResponse(profile evidencevo.AccessProfile) rdto.AccessProfileR
 		LogSensitiveFields:                capabilities.LogSensitiveFields,
 		LogExport:                         capabilities.LogExport,
 		LogPolicyRead:                     capabilities.LogPolicyRead,
+		ObservabilityArchiveManage:        capabilities.ObservabilityArchiveManage,
 		AccessScopeFingerprint:            profile.Fingerprint,
 	}
 }

--- a/bkn-trace/agent-observability/src/driveradapter/api/httphandler/archive_handler.go
+++ b/bkn-trace/agent-observability/src/driveradapter/api/httphandler/archive_handler.go
@@ -1,0 +1,156 @@
+package httphandler
+
+import (
+	"encoding/json"
+	"errors"
+	"net/http"
+	"strings"
+
+	"github.com/openbkn-ai/bkn-foundry/bkn-trace/agent-observability/src/domain/service/archivesvc"
+	"github.com/openbkn-ai/bkn-foundry/bkn-trace/agent-observability/src/domain/valueobject/evidencevo"
+	"github.com/openbkn-ai/bkn-foundry/bkn-trace/agent-observability/src/domain/valueobject/observabilityvo"
+	"github.com/openbkn-ai/bkn-foundry/bkn-trace/agent-observability/src/driveradapter/api/rdto"
+)
+
+type ArchiveHandler struct {
+	service    *archivesvc.Service
+	authorizer *EvidenceHandler
+}
+
+func NewArchiveHandler(service *archivesvc.Service, authorizer *EvidenceHandler) *ArchiveHandler {
+	return &ArchiveHandler{service: service, authorizer: authorizer}
+}
+
+func (handler *ArchiveHandler) Overview(kind observabilityvo.ArchiveKind) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		profile, ok := handler.authorize(w, r, http.MethodGet)
+		if !ok {
+			return
+		}
+		overview, err := handler.service.Overview(r.Context(), kind, profile.TenantID)
+		if err != nil {
+			writeObservabilityError(w, r, http.StatusServiceUnavailable, "archive_overview_failed", "archive overview is unavailable")
+			return
+		}
+		response := rdto.ArchiveOverviewResponse{ArchiveKind: string(overview.Kind), RetentionDays: overview.RetentionDays, CutoffAt: overview.Range.To.Format("2006-01-02T15:04:05Z07:00"), CandidateCount: overview.CandidateCount}
+		if overview.StorageReady {
+			response.Storage.Status = "ready"
+		} else {
+			response.Storage.Status = "unavailable"
+		}
+		writeJSON(w, http.StatusOK, response)
+	}
+}
+func (handler *ArchiveHandler) Create(kind observabilityvo.ArchiveKind) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		profile, ok := handler.authorize(w, r, http.MethodPost)
+		if !ok {
+			return
+		}
+		var body map[string]any
+		if err := json.NewDecoder(http.MaxBytesReader(w, r.Body, 1024)).Decode(&body); err != nil || len(body) != 0 {
+			writeObservabilityError(w, r, http.StatusBadRequest, "invalid_archive_request", "archive request body must be an empty object")
+			return
+		}
+		job, err := handler.service.Create(r.Context(), kind, profile.TenantID)
+		if err != nil {
+			switch {
+			case errors.Is(err, archivesvc.ErrNothingToArchive):
+				writeObservabilityError(w, r, http.StatusConflict, "archive_nothing_to_do", "no eligible records are available")
+			case errors.Is(err, archivesvc.ErrCleanupRequired):
+				writeObservabilityError(w, r, http.StatusConflict, "archive_cleanup_required", "previous cleanup must be completed first")
+			default:
+				writeObservabilityError(w, r, http.StatusInternalServerError, "archive_failed", "archive did not complete")
+			}
+			return
+		}
+		writeJSON(w, http.StatusCreated, rdto.NewArchiveJob(job))
+	}
+}
+
+// ListOrCreate deliberately exposes a short bounded history on the same
+// resource.  Archive creation remains POST-only and never accepts a caller
+// supplied cutoff or retention period.
+func (handler *ArchiveHandler) ListOrCreate(kind observabilityvo.ArchiveKind) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodPost {
+			handler.Create(kind)(w, r)
+			return
+		}
+		profile, ok := handler.authorize(w, r, http.MethodGet)
+		if !ok {
+			return
+		}
+		jobs := handler.service.List(profile.TenantID, kind, 20)
+		response := make([]rdto.ArchiveJobResponse, 0, len(jobs))
+		for _, job := range jobs {
+			response = append(response, rdto.NewArchiveJob(job))
+		}
+		writeJSON(w, http.StatusOK, response)
+	}
+}
+func (handler *ArchiveHandler) GetOrRetry(w http.ResponseWriter, r *http.Request) {
+	path := strings.TrimPrefix(r.URL.Path, "/api/observability/v1/archive-jobs/")
+	parts := strings.Split(strings.Trim(path, "/"), "/")
+	if len(parts) == 0 || parts[0] == "" {
+		http.NotFound(w, r)
+		return
+	}
+	method := http.MethodGet
+	if len(parts) == 2 && parts[1] == "retry-cleanup" {
+		method = http.MethodPost
+	}
+	if len(parts) == 2 && parts[1] == "download-url" {
+		method = http.MethodPost
+	}
+	profile, ok := handler.authorize(w, r, method)
+	if !ok {
+		return
+	}
+	if method == http.MethodGet {
+		job, found := handler.service.Get(parts[0], profile.TenantID)
+		if !found {
+			writeObservabilityError(w, r, http.StatusNotFound, "archive_job_not_found", "archive job was not found")
+			return
+		}
+		writeJSON(w, http.StatusOK, rdto.NewArchiveJob(job))
+		return
+	}
+	if len(parts) == 2 && parts[1] == "download-url" {
+		url, err := handler.service.DownloadURL(r.Context(), parts[0], profile.TenantID)
+		if err != nil {
+			writeObservabilityError(w, r, http.StatusBadRequest, "archive_download_unavailable", "archive download is unavailable")
+			return
+		}
+		writeJSON(w, http.StatusOK, map[string]string{"download_url": url})
+		return
+	}
+	job, err := handler.service.RetryCleanup(r.Context(), parts[0], profile.TenantID)
+	if err != nil {
+		writeObservabilityError(w, r, http.StatusBadRequest, "archive_retry_failed", "archive cleanup cannot be retried")
+		return
+	}
+	writeJSON(w, http.StatusOK, rdto.NewArchiveJob(job))
+}
+func (handler *ArchiveHandler) authorize(w http.ResponseWriter, r *http.Request, method string) (profile evidencevo.AccessProfile, ok bool) {
+	if r.Method != method {
+		writeObservabilityError(w, r, http.StatusMethodNotAllowed, "method_not_allowed", "unsupported method")
+		return profile, false
+	}
+	if handler.service == nil || handler.authorizer == nil {
+		writeObservabilityError(w, r, http.StatusServiceUnavailable, "archive_unavailable", "archive service is not configured")
+		return profile, false
+	}
+	if !handler.authorizer.authorizeQueryGateway(w, r) {
+		return profile, false
+	}
+	scope, valid := handler.authorizer.queryScopeFromRequest(w, r, false)
+	if !valid || scope.AccessProfile == nil {
+		return profile, false
+	}
+	if !observabilityvo.CapabilitiesFor(*scope.AccessProfile).ObservabilityArchiveManage {
+		writeObservabilityError(w, r, http.StatusForbidden, "archive_access_denied", "archive management is not allowed")
+		return profile, false
+	}
+	return *scope.AccessProfile, true
+}

--- a/bkn-trace/agent-observability/src/driveradapter/api/rdto/access_profile.go
+++ b/bkn-trace/agent-observability/src/driveradapter/api/rdto/access_profile.go
@@ -11,5 +11,6 @@ type AccessProfileResponse struct {
 	LogSensitiveFields                bool     `json:"log_sensitive_fields"`
 	LogExport                         bool     `json:"log_export"`
 	LogPolicyRead                     bool     `json:"log_policy_read"`
+	ObservabilityArchiveManage        bool     `json:"observability_archive_manage"`
 	AccessScopeFingerprint            string   `json:"access_scope_fingerprint"`
 }

--- a/bkn-trace/agent-observability/src/driveradapter/api/rdto/archive.go
+++ b/bkn-trace/agent-observability/src/driveradapter/api/rdto/archive.go
@@ -1,0 +1,36 @@
+package rdto
+
+import "github.com/openbkn-ai/bkn-foundry/bkn-trace/agent-observability/src/domain/service/archivesvc"
+
+type ArchiveOverviewResponse struct {
+	ArchiveKind    string `json:"archive_kind"`
+	RetentionDays  int    `json:"retention_days"`
+	CutoffAt       string `json:"cutoff_at"`
+	CandidateCount int    `json:"candidate_count"`
+	Storage        struct {
+		Status string `json:"status"`
+	} `json:"storage"`
+}
+
+type ArchiveJobResponse struct {
+	ArchiveJobID string `json:"archive_job_id"`
+	ArchiveKind  string `json:"archive_kind"`
+	Status       string `json:"status"`
+	Range        struct {
+		From *string `json:"from"`
+		To   string  `json:"to"`
+	} `json:"range"`
+	CandidateCount int    `json:"candidate_count"`
+	ManifestRef    string `json:"manifest_ref,omitempty"`
+	ErrorMessage   string `json:"error_message,omitempty"`
+}
+
+func NewArchiveJob(job archivesvc.Job) ArchiveJobResponse {
+	response := ArchiveJobResponse{ArchiveJobID: job.ID, ArchiveKind: string(job.Kind), Status: string(job.Status), CandidateCount: job.CandidateCount, ManifestRef: job.ManifestRef, ErrorMessage: job.ErrorMessage}
+	response.Range.To = job.Range.To.Format("2006-01-02T15:04:05Z07:00")
+	if !job.Range.From.IsZero() {
+		value := job.Range.From.Format("2006-01-02T15:04:05Z07:00")
+		response.Range.From = &value
+	}
+	return response
+}

--- a/bkn-trace/agent-observability/src/infra/opensearch/client.go
+++ b/bkn-trace/agent-observability/src/infra/opensearch/client.go
@@ -137,7 +137,7 @@ func (c *Client) DeleteByQuery(ctx context.Context, index string, query []byte) 
 	if err != nil {
 		return fmt.Errorf("execute opensearch delete-by-query request: %w", err)
 	}
-	defer response.Body.Close()
+	defer func() { _ = response.Body.Close() }()
 	body, err := io.ReadAll(response.Body)
 	if err != nil {
 		return fmt.Errorf("read opensearch delete-by-query response: %w", err)

--- a/bkn-trace/agent-observability/src/infra/opensearch/client.go
+++ b/bkn-trace/agent-observability/src/infra/opensearch/client.go
@@ -121,6 +121,33 @@ func (c *Client) Search(ctx context.Context, index string, query []byte) ([]byte
 	return body, nil
 }
 
+// DeleteByQuery is used only after an archive bundle has been verified. The
+// caller provides a frozen identity filter; it must never be a moving cutoff.
+func (c *Client) DeleteByQuery(ctx context.Context, index string, query []byte) error {
+	requestURL := fmt.Sprintf("%s/%s/_delete_by_query?conflicts=proceed", c.baseURL, strings.TrimLeft(index, "/"))
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, requestURL, bytes.NewReader(query))
+	if err != nil {
+		return fmt.Errorf("create opensearch delete-by-query request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	if c.auth.Enabled {
+		req.SetBasicAuth(c.auth.Username, c.auth.Password)
+	}
+	response, err := c.httpClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("execute opensearch delete-by-query request: %w", err)
+	}
+	defer response.Body.Close()
+	body, err := io.ReadAll(response.Body)
+	if err != nil {
+		return fmt.Errorf("read opensearch delete-by-query response: %w", err)
+	}
+	if response.StatusCode < http.StatusOK || response.StatusCode >= http.StatusMultipleChoices {
+		return fmt.Errorf("opensearch delete-by-query failed with status %d: %s", response.StatusCode, string(body))
+	}
+	return nil
+}
+
 func (c *Client) IndexDocument(ctx context.Context, index string, documentID string, body []byte) ([]byte, error) {
 	requestURL := fmt.Sprintf("%s/%s/_doc/%s", c.baseURL, strings.TrimLeft(index, "/"), url.PathEscape(strings.TrimLeft(documentID, "/")))
 	return c.putDocument(ctx, requestURL, body)


### PR DESCRIPTION
## What Changed

- Adds separate manual archive workflows for Trace (7 days) and operation/audit logs (30 days).
- Stores archive packages in configured object storage and clears archived hot data only after upload succeeds.
- Adds archive job persistence, cleanup retry, download URLs, API handlers, configuration, migration, and Helm settings.

## Why

Closes #757

## How

- Archive jobs record actual time ranges, counts, package location, and cleanup state.
- The archive service keeps Trace and log retention boundaries independent.
- The workflow is manual and irreversible by design; cleanup failures remain retryable.

## Testing

- [x] `make ci && make helm-lint`

## Risk & Rollback

- Requires the configured object-storage endpoint and archive bucket to be reachable before cleanup is allowed.
- Roll back by disabling archive management; completed archive packages remain available in object storage.