### PR TITLE
feat(context-loader): add a channel weight to RRF fusion (knn_weight, 0–1, default 0.5)

### DIFF
--- a/adp/context-loader/agent-retrieval/server/interfaces/kn_search_local.go
+++ b/adp/context-loader/agent-retrieval/server/interfaces/kn_search_local.go
@@ -85,6 +85,17 @@ type KnSearchSemanticInstanceRetrievalConfig struct {
 	// RRFK RRF 融合常数 k：score = Σ 1/(k + rank)。k 越大越平缓（各通道靠前名次之间
 	// 的差距被压小），60 是文献与工业界的通用取值，跨知识网络不需要重调。
 	RRFK int `json:"rrf_k" default:"60"`
+	// KnnWeight 向量通道在融合里的权重，0~1，默认 0.5（等权，与不带权重时逐位等价）。
+	// 全文通道取 1-KnnWeight：名次分的绝对幅度不影响排序，只有两路的**比例**有意义，
+	// 所以一个数就够，不需要两个独立权重。
+	//
+	// 1 = 只信向量，0 = 只信全文。什么时候值得偏：中文短名称、跨语言表述上 BM25 分词
+	// 效果差，向量更可靠；编号 / 编码类字段则相反。
+	//
+	// 代价：偏权会打破「任一通道第 1 名恒为 1.0」这个跨对象类锚点——调高向量权重之后，
+	// 没有向量字段的对象类整体被压低。那是调用方声明的偏好带来的**语义正确**的结果，
+	// 不是缺陷，但正因如此默认必须保持 0.5。
+	KnnWeight *float64 `json:"knn_weight,omitempty" default:"0.5"`
 
 	// InstanceRerankMode 精排级开关：off / shadow / on。
 	//

--- a/adp/context-loader/agent-retrieval/server/logics/knsearch/config.go
+++ b/adp/context-loader/agent-retrieval/server/logics/knsearch/config.go
@@ -44,6 +44,7 @@ func DefaultSemanticInstanceRetrievalConfig() *interfaces.KnSearchSemanticInstan
 		MaxKnnSubConditionsPerType:        1,
 		EnableRRFFusion:                   boolPtr(true),
 		RRFK:                              60,
+		KnnWeight:                         float64Ptr(0.5),
 		InstanceRerankMode:                InstanceRerankModeOff,
 		RerankTopN:                        50,
 		RerankFieldCharLimit:              200,
@@ -172,6 +173,9 @@ func mergeSemanticInstanceRetrievalConfig(base, user *interfaces.KnSearchSemanti
 	if user.RRFK > 0 {
 		base.RRFK = user.RRFK
 	}
+	if user.KnnWeight != nil {
+		base.KnnWeight = user.KnnWeight
+	}
 	if mode := normalizeRerankMode(user.InstanceRerankMode); mode != "" {
 		base.InstanceRerankMode = mode
 	}
@@ -207,4 +211,8 @@ func boolValue(value *bool) bool {
 		return false
 	}
 	return *value
+}
+
+func float64Ptr(value float64) *float64 {
+	return &value
 }

--- a/adp/context-loader/agent-retrieval/server/logics/knsearch/semantic_instance_retrieval.go
+++ b/adp/context-loader/agent-retrieval/server/logics/knsearch/semantic_instance_retrieval.go
@@ -209,7 +209,7 @@ func (s *localSearchImpl) retrieveInstancesFused(
 
 	var nodes []*interfaces.KnSearchNode
 	if anyScored {
-		nodes = fuseByRRF(live, rrfK(config))
+		nodes = fuseByRRF(live, rrfK(config), channelWeights(config))
 	} else {
 		// 源库直查路径没有 _score，响应顺序是库的自然序，名次无意义。
 		// 退回本地兜底打分——0/0.3/0.5/0.85 那套分档本来就是为这条路设计的。
@@ -546,15 +546,46 @@ func rrfK(config *interfaces.KnSearchSemanticInstanceRetrievalConfig) int {
 	return 60
 }
 
+// channelWeights 解析各通道权重。knn 取 knn_weight，match 取 1-knn_weight，
+// 其余通道（将来若有）按等权处理。
+//
+// 越界值钳制到 [0,1] 而不是报错：配错一个数不该让整条检索链失败，何况这个旋钮
+// 目前没有召回率实验支撑（同 #708），更不该有硬性失败路径。
+func channelWeights(config *interfaces.KnSearchSemanticInstanceRetrievalConfig) map[string]float64 {
+	w := 0.5
+	if config != nil && config.KnnWeight != nil {
+		w = *config.KnnWeight
+	}
+	if w < 0 {
+		w = 0
+	}
+	if w > 1 {
+		w = 1
+	}
+	return map[string]float64{
+		channelKnn:   w,
+		channelMatch: 1 - w,
+	}
+}
+
+// weightOf 取某通道的权重；未登记的通道按等权 0.5 处理。
+func weightOf(weights map[string]float64, channel string) float64 {
+	if v, ok := weights[channel]; ok {
+		return v
+	}
+	return 0.5
+}
+
 // fuseByRRF 按 Reciprocal Rank Fusion 融合多路召回：
 //
-//	score = Σ 1/(k + rank_i) × (k+1)
+//	score = Σ w_i/(k + rank_i) × 2(k+1)
 //
 // 用名次而不是分数，是因为两路的分根本不同量纲：knn 分在 0~1，BM25 无上界且跨索引
 // 不可比。归一化加权和也能凑合，但 min-max 在候选少、分数集中时噪声很大（top1 恒为
 // 1.0），且权重要按知识网络手调；RRF 只有一个常数，跨网不用调。
 //
-// 乘 (k+1) 只是换量纲：任意一路的第 1 名恰好得 1.0，两路都第 1 得 2.0。这样跨对象
+// 乘 2(k+1) 只是换量纲：**等权（默认 0.5）时**任意一路的第 1 名恰好得 1.0，两路都
+// 第 1 得 2.0——与不带权重的旧式 Σ1/(k+rank)×(k+1) 逐位相同。这样跨对象
 // 类比较有一个稳定的锚——「在自己能发的通道里排第 1」在哪个对象类都是 1.0，不受
 // 该类发了几路影响；两路都命中的实例高出一截，那是真信号。同时量级与无 _score
 // 路径的本地兜底打分（0~0.85）相当，两条路径的结果汇进同一个池子做全局比例过滤时
@@ -563,7 +594,11 @@ func rrfK(config *interfaces.KnSearchSemanticInstanceRetrievalConfig) int {
 // 不要再除以通道数：那样做会把「双通道对象类里只被一路命中的实例」压到单通道
 // 对象类同名次实例的一半（VM 实测 0.5 vs 1.0），偏置只是换了个方向。缺席另一路
 // 本身已经通过「少加一项」体现了，不需要再罚一次。
-func fuseByRRF(outcomes []channelOutcome, k int) []*interfaces.KnSearchNode {
+//
+// 权重偏离 0.5 之后，上面那个跨类锚点会跟着倾斜：调高向量权重，没有向量字段的
+// 对象类整体被压低。那是调用方声明的偏好带来的结果，不是缺陷——但也正因如此，
+// 默认值必须留在 0.5。
+func fuseByRRF(outcomes []channelOutcome, k int, weights map[string]float64) []*interfaces.KnSearchNode {
 	if len(outcomes) == 0 {
 		return nil
 	}
@@ -596,12 +631,13 @@ func fuseByRRF(outcomes []channelOutcome, k int) []*interfaces.KnSearchNode {
 				// 只把原始召回分取较大者留作观测。
 				e.node.RecallScore = node.RecallScore
 			}
-			e.score += 1 / float64(k+rank+1)
+			e.score += weightOf(weights, o.name) / float64(k+rank+1)
 		}
 	}
 
 	fused := make([]*interfaces.KnSearchNode, 0, len(order))
-	norm := float64(k + 1)
+	// 2(k+1)：等权时把「某一路第 1 名」拉回 1.0，与不带权重的老公式对齐。
+	norm := 2 * float64(k+1)
 	for _, key := range order {
 		e := byKey[key]
 		e.node.Score = e.score * norm

--- a/adp/context-loader/agent-retrieval/server/logics/knsearch/semantic_instance_rrf_test.go
+++ b/adp/context-loader/agent-retrieval/server/logics/knsearch/semantic_instance_rrf_test.go
@@ -161,7 +161,7 @@ func TestFuseByRRF_ScoreMath(t *testing.T) {
 		{ObjectTypeID: "ot1", InstanceName: "c", UniqueIdentities: map[string]any{"id": "c"}},
 	}}
 
-	fused := fuseByRRF([]channelOutcome{knn, match}, k)
+	fused := fuseByRRF([]channelOutcome{knn, match}, k, equalWeights())
 	if len(fused) != 3 {
 		t.Fatalf("expected 3 unique instances, got %d", len(fused))
 	}
@@ -188,7 +188,7 @@ func TestFuseByRRF_ScoreMath(t *testing.T) {
 	}
 	// 任一通道的第 1 名恰为 1.0——这个锚点不随该对象类发了几路而变，
 	// 否则双通道对象类里只被一路命中的实例会被系统性压低（VM 实测踩过）。
-	single := fuseByRRF([]channelOutcome{knn}, k)
+	single := fuseByRRF([]channelOutcome{knn}, k, equalWeights())
 	if math.Abs(single[0].Score-1.0) > 1e-9 {
 		t.Errorf("expected rank-1-in-one-channel to score 1.0, got %.6f", single[0].Score)
 	}
@@ -210,7 +210,7 @@ func TestFuseByRRF_DedupKeepsMaxRecallScore(t *testing.T) {
 	fused := fuseByRRF([]channelOutcome{
 		{name: channelKnn, scored: true, nodes: []*interfaces.KnSearchNode{node(0.8)}},
 		{name: channelMatch, scored: true, nodes: []*interfaces.KnSearchNode{node(17.2)}},
-	}, 60)
+	}, 60, equalWeights())
 
 	if len(fused) != 1 {
 		t.Fatalf("expected dedup to a single node, got %d", len(fused))
@@ -229,7 +229,7 @@ func TestFuseByRRF_AnonymousRowsNotMerged(t *testing.T) {
 	fused := fuseByRRF([]channelOutcome{
 		{name: channelKnn, scored: true, nodes: []*interfaces.KnSearchNode{anon()}},
 		{name: channelMatch, scored: true, nodes: []*interfaces.KnSearchNode{anon()}},
-	}, 60)
+	}, 60, equalWeights())
 	if len(fused) != 2 {
 		t.Fatalf("expected anonymous rows kept separate, got %d", len(fused))
 	}
@@ -395,7 +395,7 @@ func TestInstanceKey_FallsBackToInstanceIDProperty(t *testing.T) {
 	fused := fuseByRRF([]channelOutcome{
 		{name: channelKnn, scored: true, nodes: []*interfaces.KnSearchNode{knnRow}},
 		{name: channelMatch, scored: true, nodes: []*interfaces.KnSearchNode{matchRow}},
-	}, 60)
+	}, 60, equalWeights())
 	if len(fused) != 1 {
 		t.Fatalf("expected the duplicate to be merged, got %d nodes", len(fused))
 	}
@@ -412,4 +412,10 @@ func TestInstanceKey_FallsBackToPropertiesFingerprint(t *testing.T) {
 	if instanceKey(a) == instanceKey(c) {
 		t.Error("different property values must produce different keys")
 	}
+}
+
+// equalWeights 等权，即默认 knn_weight=0.5。老用例全部走它——「加了权重之后默认
+// 行为逐位不变」这件事，就靠这些原样保留的断言盯着。
+func equalWeights() map[string]float64 {
+	return channelWeights(DefaultSemanticInstanceRetrievalConfig())
 }

--- a/adp/context-loader/agent-retrieval/server/logics/knsearch/semantic_instance_weight_test.go
+++ b/adp/context-loader/agent-retrieval/server/logics/knsearch/semantic_instance_weight_test.go
@@ -1,0 +1,162 @@
+// Copyright openbkn.ai
+//
+// Licensed under the OpenBKN License.
+// See the LICENSE file in the project root for details.
+
+package knsearch
+
+import (
+	"math"
+	"testing"
+
+	"github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/interfaces"
+)
+
+func weightNode(name string) *interfaces.KnSearchNode {
+	return &interfaces.KnSearchNode{
+		ObjectTypeID:     "ot1",
+		InstanceName:     name,
+		UniqueIdentities: map[string]any{"id": name},
+	}
+}
+
+func weightedConfig(w float64) *interfaces.KnSearchSemanticInstanceRetrievalConfig {
+	config := DefaultSemanticInstanceRetrievalConfig()
+	config.KnnWeight = float64Ptr(w)
+	return config
+}
+
+// 两路各一条、各自第 1 名，是观察权重最干净的形状。
+func fuseTwoChannels(t *testing.T, w float64) (knnFirst, matchFirst float64) {
+	t.Helper()
+	knn := channelOutcome{name: channelKnn, scored: true,
+		nodes: []*interfaces.KnSearchNode{weightNode("v1")}}
+	match := channelOutcome{name: channelMatch, scored: true,
+		nodes: []*interfaces.KnSearchNode{weightNode("m1")}}
+
+	fused := fuseByRRF([]channelOutcome{knn, match}, 60, channelWeights(weightedConfig(w)))
+	if len(fused) != 2 {
+		t.Fatalf("expected 2 nodes, got %d", len(fused))
+	}
+	byName := map[string]float64{}
+	for _, n := range fused {
+		byName[n.InstanceName] = n.Score
+	}
+	return byName["v1"], byName["m1"]
+}
+
+// 默认 0.5 必须与「不带权重」逐位相同，否则这个特性就是一次静默的行为变更。
+func TestChannelWeights_DefaultIsIdenticalToUnweighted(t *testing.T) {
+	knnFirst, matchFirst := fuseTwoChannels(t, 0.5)
+
+	if math.Abs(knnFirst-1.0) > 1e-9 || math.Abs(matchFirst-1.0) > 1e-9 {
+		t.Errorf("equal weights must keep the 1.0 anchor, got knn=%.6f match=%.6f", knnFirst, matchFirst)
+	}
+
+	// 两路都命中同一条仍是 2.0
+	node := weightNode("same")
+	both := fuseByRRF([]channelOutcome{
+		{name: channelKnn, scored: true, nodes: []*interfaces.KnSearchNode{node}},
+		{name: channelMatch, scored: true, nodes: []*interfaces.KnSearchNode{node}},
+	}, 60, channelWeights(DefaultSemanticInstanceRetrievalConfig()))
+	if len(both) != 1 || math.Abs(both[0].Score-2.0) > 1e-9 {
+		t.Errorf("a hit in both channels must still score 2.0, got %+v", both)
+	}
+}
+
+// 权重直接决定两路第 1 名的相对高低，这才是这个旋钮存在的意义。
+func TestChannelWeights_ShiftTheBalance(t *testing.T) {
+	cases := []struct {
+		w         float64
+		knnFirst  float64
+		matchFrst float64
+	}{
+		{0.5, 1.0, 1.0},
+		{0.8, 1.6, 0.4},
+		{0.2, 0.4, 1.6},
+		{1.0, 2.0, 0.0}, // 只信向量：全文独有的命中不再贡献分数
+		{0.0, 0.0, 2.0},
+	}
+	for _, c := range cases {
+		knnFirst, matchFirst := fuseTwoChannels(t, c.w)
+		if math.Abs(knnFirst-c.knnFirst) > 1e-9 || math.Abs(matchFirst-c.matchFrst) > 1e-9 {
+			t.Errorf("knn_weight=%.1f: expected knn=%.2f match=%.2f, got knn=%.6f match=%.6f",
+				c.w, c.knnFirst, c.matchFrst, knnFirst, matchFirst)
+		}
+	}
+}
+
+// 极端权重不能把另一路的结果丢掉——只压到最后，不删。
+func TestChannelWeights_ExtremeKeepsAllResults(t *testing.T) {
+	knn := channelOutcome{name: channelKnn, scored: true,
+		nodes: []*interfaces.KnSearchNode{weightNode("v1")}}
+	match := channelOutcome{name: channelMatch, scored: true,
+		nodes: []*interfaces.KnSearchNode{weightNode("m1"), weightNode("m2")}}
+
+	fused := fuseByRRF([]channelOutcome{knn, match}, 60, channelWeights(weightedConfig(1.0)))
+	if len(fused) != 3 {
+		t.Fatalf("weight 1.0 must not drop the other channel's rows, got %d", len(fused))
+	}
+	sortNodesByScore(fused)
+	if fused[0].InstanceName != "v1" {
+		t.Errorf("the vector hit must lead at weight 1.0, got %s", fused[0].InstanceName)
+	}
+}
+
+// 配错一个数不该让整条检索链失败——钳制，不报错。
+func TestChannelWeights_OutOfRangeIsClamped(t *testing.T) {
+	for _, w := range []float64{-1, 2, 100} {
+		weights := channelWeights(weightedConfig(w))
+		knn, match := weights[channelKnn], weights[channelMatch]
+		if knn < 0 || knn > 1 || match < 0 || match > 1 {
+			t.Errorf("weight %.1f must be clamped into [0,1], got knn=%.2f match=%.2f", w, knn, match)
+		}
+		if math.Abs(knn+match-1.0) > 1e-9 {
+			t.Errorf("weights must still sum to 1, got %.2f + %.2f", knn, match)
+		}
+	}
+}
+
+// 未登记的通道按等权处理：将来加第三路时不会因为忘了配权重而拿到 0 分。
+func TestWeightOf_UnknownChannelFallsBackToEqual(t *testing.T) {
+	if got := weightOf(channelWeights(DefaultSemanticInstanceRetrievalConfig()), "future_channel"); got != 0.5 {
+		t.Errorf("an unregistered channel must fall back to 0.5, got %.2f", got)
+	}
+}
+
+// 偏权会让跨对象类的锚点倾斜——这是**已知代价**，不是缺陷。钉在这里，
+// 免得以后有人把它当 bug「修」掉，反而破坏了调用方声明的偏好。
+func TestChannelWeights_KnownCrossTypeSkew(t *testing.T) {
+	// 有向量字段的对象类：两路都发
+	dual := fuseByRRF([]channelOutcome{
+		{name: channelKnn, scored: true, nodes: []*interfaces.KnSearchNode{weightNode("dual-v")}},
+		{name: channelMatch, scored: true, nodes: []*interfaces.KnSearchNode{weightNode("dual-m")}},
+	}, 60, channelWeights(weightedConfig(0.8)))
+
+	// 没有向量字段的对象类：只有全文一路
+	single := fuseByRRF([]channelOutcome{
+		{name: channelMatch, scored: true, nodes: []*interfaces.KnSearchNode{weightNode("single-m")}},
+	}, 60, channelWeights(weightedConfig(0.8)))
+
+	var dualKnnFirst float64
+	for _, n := range dual {
+		if n.InstanceName == "dual-v" {
+			dualKnnFirst = n.Score
+		}
+	}
+	if dualKnnFirst <= single[0].Score {
+		t.Errorf("at knn_weight=0.8 the vector-backed type is expected to rank higher: %.2f vs %.2f",
+			dualKnnFirst, single[0].Score)
+	}
+	// 等权时锚点仍然一致——倾斜只由权重带来
+	dualEqual := fuseByRRF([]channelOutcome{
+		{name: channelKnn, scored: true, nodes: []*interfaces.KnSearchNode{weightNode("d2")}},
+	}, 60, channelWeights(DefaultSemanticInstanceRetrievalConfig()))
+	singleEqual := fuseByRRF([]channelOutcome{
+		{name: channelMatch, scored: true, nodes: []*interfaces.KnSearchNode{weightNode("s2")}},
+	}, 60, channelWeights(DefaultSemanticInstanceRetrievalConfig()))
+	if math.Abs(dualEqual[0].Score-singleEqual[0].Score) > 1e-9 {
+		t.Errorf("with equal weights the anchor must stay identical across channels: %.6f vs %.6f",
+			dualEqual[0].Score, singleEqual[0].Score)
+	}
+}

--- a/docs/api/context-loader/schema-search.yaml
+++ b/docs/api/context-loader/schema-search.yaml
@@ -384,7 +384,14 @@ components:
             semantic_instance_retrieval:
               type: object
               additionalProperties: true
-              description: 兼容接收，当前版本不生效。
+              description: |
+                语义实例召回配置。除既有字段外，`knn_weight`（0~1，默认 `0.5`）调节
+                向量与全文两路在名次融合里的权重，全文权重取 `1 - knn_weight`：
+                `1` 只信向量、`0` 只信全文。默认 `0.5` 与不带权重时逐位等价。
+
+                偏权会带来跨对象类的系统性倾斜——调高向量权重后，没有向量字段的对象类
+                整体被压低。那是调用方声明的偏好带来的结果，不是缺陷，但也因此默认值
+                保持中性。
             property_filter:
               type: object
               additionalProperties: true


### PR DESCRIPTION
## Links

- Closes #862
- Builds on #818 (rank fusion landed there)
- Branch: `feature/862-rrf-channel-weight`

## Why

Fusion has been fixed at 50/50. That was deliberate — picking RRF over a normalised weighted sum
was partly because RRF carries a single constant and needs no per-network tuning. But data shape
does bias one channel over the other: on short Chinese names and cross-language phrasings BM25
tokenisation performs poorly and vectors are more reliable; on identifier-like columns it is the
other way round.

## Change

`knn_weight` (0–1, default `0.5`); the full-text channel takes `1 - knn_weight`:

```
score = ( w/(k+rank_knn) + (1-w)/(k+rank_match) ) × 2(k+1)
```

One number rather than two independent weights — the absolute magnitude of a rank score does not
affect ordering, only the **ratio** between channels carries meaning.

`1.0` means vectors only, `0.0` full text only. Neither drops the other channel's rows; they just
fall to the bottom.

## Default is bit-for-bit identical to unweighted

At `0.5`, any channel's rank-1 still scores exactly `1.0` and a hit in both still scores `2.0`.
The evidence is that **every existing RRF test was kept as-is and still passes** — those tests
pin exact values (`1.0`, `2.0`, `0.9839`), so an accidental behaviour change could not slip past
them.

## The known cost

Weighting away from 0.5 tilts the cross-object-type anchor that #818 established. At
`knn_weight=0.8`, a type with a vector field has its rank-1 at `1.6` while a type without one
tops out at `0.4`.

That is **semantically correct** — the caller declared it trusts vectors more, so vector-backed
types should rank higher — not a defect. It is documented in the field comment, in the OpenAPI
description, and pinned by `TestChannelWeights_KnownCrossTypeSkew` so nobody later "fixes" it and
silently discards the caller's stated preference. It is also exactly why the default has to stay
neutral.

## Testing

`go test -race ./...` — all green.

| Case | Asserts |
|---|---|
| `DefaultIsIdenticalToUnweighted` | the 1.0 / 2.0 anchors survive at the default weight |
| `ShiftTheBalance` | 0.5 / 0.8 / 0.2 / 1.0 / 0.0 produce the hand-computed scores |
| `ExtremeKeepsAllResults` | weight 1.0 does not drop full-text rows, only demotes them |
| `OutOfRangeIsClamped` | -1 / 2 / 100 clamp into [0,1] and still sum to 1, no error |
| `UnknownChannelFallsBackToEqual` | a future third channel defaults to 0.5 instead of scoring 0 |
| `KnownCrossTypeSkew` | the tilt exists when weighted, and does not exist at 0.5 |

## Not verified on the VM

The mechanism is pure arithmetic over rank positions and is covered by exact-value unit tests;
there is no environment-dependent behaviour to exercise. Worth noting separately: this knob has
**no recall experiment behind it** — same caveat as #708. It exists so the balance *can* be
tuned; deciding what to tune it to needs the evaluation framework in #272. Until then the neutral
default is the only value anyone should ship.

🤖 Generated with [Claude Code](https://claude.com/claude-code)