### PR TITLE
feat(mf-model-manager): align locale protocol

### DIFF
--- a/docs/api/mf-model-manager/large-model.yaml
+++ b/docs/api/mf-model-manager/large-model.yaml
@@ -31,6 +31,8 @@ paths:
         as success.
 
         Successful responses are normalized to `{ "status": "ok", "id": "..." }`.
+      parameters:
+        - $ref: '#/components/parameters/AcceptLanguage'
       requestBody:
         required: true
         content:
@@ -55,6 +57,9 @@ paths:
       responses:
         '200':
           description: Test connection succeeded
+          headers:
+            Cache-Control:
+              $ref: '#/components/headers/PrivateNoCache'
           content:
             application/json:
               schema:
@@ -66,12 +71,33 @@ paths:
                     id: "1234567890123456789"
         '400':
           description: Test connection failed or request parameters are invalid
+          headers:
+            Content-Language:
+              $ref: '#/components/headers/ContentLanguage'
+            Cache-Control:
+              $ref: '#/components/headers/PrivateNoCache'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/FastApiError'
+        '401':
+          description: Authentication failed
+          headers:
+            Content-Language:
+              $ref: '#/components/headers/ContentLanguage'
+            Cache-Control:
+              $ref: '#/components/headers/PrivateNoCache'
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/FastApiError'
         '500':
           description: Internal service error
+          headers:
+            Content-Language:
+              $ref: '#/components/headers/ContentLanguage'
+            Cache-Control:
+              $ref: '#/components/headers/PrivateNoCache'
           content:
             application/json:
               schema:
@@ -88,6 +114,8 @@ paths:
         `default=true` marks the model as the default model and clears the
         previous default. `default=false` clears the default flag from the
         specified model. The response includes the resulting default state.
+      parameters:
+        - $ref: '#/components/parameters/AcceptLanguage'
       requestBody:
         required: true
         content:
@@ -106,6 +134,9 @@ paths:
       responses:
         '200':
           description: Default model state updated
+          headers:
+            Cache-Control:
+              $ref: '#/components/headers/PrivateNoCache'
           content:
             application/json:
               schema:
@@ -118,18 +149,44 @@ paths:
                     default: false
         '400':
           description: Invalid request or model does not exist
+          headers:
+            Content-Language:
+              $ref: '#/components/headers/ContentLanguage'
+            Cache-Control:
+              $ref: '#/components/headers/PrivateNoCache'
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/FastApiError'
         '403':
           description: Current user is not allowed to edit the default model
+          headers:
+            Content-Language:
+              $ref: '#/components/headers/ContentLanguage'
+            Cache-Control:
+              $ref: '#/components/headers/PrivateNoCache'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/FastApiError'
+        '401':
+          description: Authentication failed
+          headers:
+            Content-Language:
+              $ref: '#/components/headers/ContentLanguage'
+            Cache-Control:
+              $ref: '#/components/headers/PrivateNoCache'
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/FastApiError'
         '500':
           description: Internal service error
+          headers:
+            Content-Language:
+              $ref: '#/components/headers/ContentLanguage'
+            Cache-Control:
+              $ref: '#/components/headers/PrivateNoCache'
           content:
             application/json:
               schema:
@@ -151,6 +208,7 @@ paths:
         exists in `t_llm_model`, so non-current or stale model operation records
         are excluded from the overview.
       parameters:
+        - $ref: '#/components/parameters/AcceptLanguage'
         - name: start_time
           in: query
           required: true
@@ -174,6 +232,9 @@ paths:
       responses:
         '200':
           description: Monitor overview returned
+          headers:
+            Cache-Control:
+              $ref: '#/components/headers/PrivateNoCache'
           content:
             application/json:
               schema:
@@ -241,17 +302,58 @@ paths:
                           type: string
         '400':
           description: Missing or invalid date range
+          headers:
+            Content-Language:
+              $ref: '#/components/headers/ContentLanguage'
+            Cache-Control:
+              $ref: '#/components/headers/PrivateNoCache'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/FastApiError'
+        '401':
+          description: Authentication failed
+          headers:
+            Content-Language:
+              $ref: '#/components/headers/ContentLanguage'
+            Cache-Control:
+              $ref: '#/components/headers/PrivateNoCache'
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/FastApiError'
         '500':
           description: Internal service error
+          headers:
+            Content-Language:
+              $ref: '#/components/headers/ContentLanguage'
+            Cache-Control:
+              $ref: '#/components/headers/PrivateNoCache'
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/FastApiError'
 components:
+  parameters:
+    AcceptLanguage:
+      name: Accept-Language
+      in: header
+      required: false
+      description: Preferred response language. Supports zh-CN and en-US.
+      schema:
+        type: string
+        example: en-US
+  headers:
+    ContentLanguage:
+      description: Language used for a localized error response.
+      schema:
+        type: string
+        enum: [zh-CN, en-US]
+    PrivateNoCache:
+      description: Authenticated response cache policy.
+      schema:
+        type: string
+        example: private, no-cache
   securitySchemes:
     BearerAuth:
       type: http

--- a/infra/mf-model-manager/app/commons/get_user_info.py
+++ b/infra/mf-model-manager/app/commons/get_user_info.py
@@ -4,6 +4,7 @@ import os
 import aiohttp
 from app.core.config import base_config
 from app.commons.errors import UserManagementError
+from app.commons.locale import internal_request_headers
 from app.core.config import base_config
 
 
@@ -16,7 +17,7 @@ async def _resolve_names_bkn_safe(bkn_safe_url, user_ids):
         async with session.post(
                 f"{bkn_safe_url}/api/safe/v1/directory/names",
                 json={"user_ids": user_ids, "app_ids": user_ids},
-                headers={"Content-Type": "application/json"}) as resp:
+                headers=internal_request_headers({"Content-Type": "application/json"})) as resp:
             if resp.status != 200:
                 raise Exception("bkn-safe directory service error,please check")
             data = json.loads(await resp.text())
@@ -47,13 +48,14 @@ async def get_username_by_ids(user_ids):
             "name"
         ]
     }
+    headers = internal_request_headers()
     
     # 存储最终的用户信息
     final_user_infos = {}
     
     for i in range(2):
         async with aiohttp.ClientSession() as session:
-            async with session.post(user_management_url, json=payload) as response:
+            async with session.post(user_management_url, json=payload, headers=headers) as response:
                 if response.status != 200:
                     if response.status == 404:
                         res = await response.text()
@@ -70,7 +72,8 @@ async def get_username_by_ids(user_ids):
                             }
                             
                             # 调用应用名称接口
-                            async with session.post(user_management_app_url, json=app_payload) as app_response:
+                            async with session.post(
+                                    user_management_app_url, json=app_payload, headers=headers) as app_response:
                                 if app_response.status == 200:
                                     app_res = await app_response.text()
                                     app_result = json.loads(app_res)
@@ -88,7 +91,9 @@ async def get_username_by_ids(user_ids):
                                     if valid_app_ids:
                                         # 重新调用应用名称接口，只包含有效的应用ID
                                         app_payload["app_ids"] = valid_app_ids
-                                        async with session.post(user_management_app_url, json=app_payload) as retry_response:
+                                        async with session.post(
+                                                user_management_app_url, json=app_payload,
+                                                headers=headers) as retry_response:
                                             if retry_response.status == 200:
                                                 retry_res = await retry_response.text()
                                                 retry_result = json.loads(retry_res)

--- a/infra/mf-model-manager/app/commons/i18n/__init__.py
+++ b/infra/mf-model-manager/app/commons/i18n/__init__.py
@@ -16,7 +16,11 @@ def lookup_error_message(code: str, locale: str) -> Optional[dict]:
 
 async def get_error_message(code: str, lang: str) -> dict:
     """Compatibility wrapper for existing async controller call sites."""
-    return lookup_error_message(code, lang) or {
+    message = lookup_error_message(code, lang)
+    if message:
+        message.pop("detail_template", None)
+        return message
+    return {
         "code": code,
         "description": "Request failed." if lang == ENGLISH_LOCALE else "请求失败。",
         "detail": "",

--- a/infra/mf-model-manager/app/commons/i18n/__init__.py
+++ b/infra/mf-model-manager/app/commons/i18n/__init__.py
@@ -1,14 +1,29 @@
-from typing import Dict, Optional
+from copy import deepcopy
+from typing import Optional
+
+from app.commons.locale import DEFAULT_LOCALE, ENGLISH_LOCALE
 from . import en_us, zh_cn
 
 
-async def get_error_message(code: str, lang) -> str:
+def lookup_error_message(code: str, locale: str) -> Optional[dict]:
     error_messages = {
-        "en-us": en_us.error_messages,
-        "zh-cn": zh_cn.error_messages,
-        "zh-tw": zh_cn.error_messages
+        ENGLISH_LOCALE: en_us.error_messages,
+        DEFAULT_LOCALE: zh_cn.error_messages,
     }
+    message = error_messages.get(locale, zh_cn.error_messages).get(code)
+    return deepcopy(message) if message else None
 
-    if lang not in error_messages or code not in error_messages[lang]:
-        return ""
-    return error_messages[lang][code]
+
+async def get_error_message(code: str, lang: str) -> dict:
+    """Compatibility wrapper for existing async controller call sites."""
+    return lookup_error_message(code, lang) or {
+        "code": code,
+        "description": "Request failed." if lang == ENGLISH_LOCALE else "请求失败。",
+        "detail": "",
+        "solution": (
+            "See the request details or contact an administrator."
+            if lang == ENGLISH_LOCALE
+            else "请查看请求详情或联系管理员。"
+        ),
+        "link": "",
+    }

--- a/infra/mf-model-manager/app/commons/i18n/en_us.py
+++ b/infra/mf-model-manager/app/commons/i18n/en_us.py
@@ -1,20 +1,48 @@
-# 简体中文
+# English
 from app.commons.errors.codes import ParamValidationErrors
 
 error_messages = {
     ParamValidationErrors.ParamMissing: {
         "code": ParamValidationErrors.ParamMissing,
-        "description": "参数缺失",
+        "description": "Required parameter is missing.",
         "detail": "",
         "solution": "Please read the API documentation and pass the correct parameters",
         "link": ""
     },
     ParamValidationErrors.ParamTypeError: {
         "code": ParamValidationErrors.ParamTypeError,
-        "description": "参数类型错误",
+        "description": "Parameter type is invalid.",
         "solution": "Please read the API documentation and pass the correct parameters",
         "detail": "",
         "link": ""
 
+    },
+    "ModelFactory.OperationAudit.AccessDenied": {
+        "code": "ModelFactory.OperationAudit.AccessDenied",
+        "description": "Access denied.",
+        "detail": "The current identity is not allowed to access operation audit records.",
+        "solution": "Contact an administrator to request access.",
+        "link": ""
+    },
+    "ModelFactory.OperationAudit.InvalidTimestamp": {
+        "code": "ModelFactory.OperationAudit.InvalidTimestamp",
+        "description": "Timestamp format is invalid.",
+        "detail": "from or to must use the RFC3339 timestamp format.",
+        "solution": "Use the RFC3339 timestamp format and retry the request.",
+        "link": ""
+    },
+    "ModelFactory.OperationAudit.InvalidTimeRange": {
+        "code": "ModelFactory.OperationAudit.InvalidTimeRange",
+        "description": "Time range is invalid.",
+        "detail": "The end time must be after the start time and the range cannot exceed 30 days.",
+        "solution": "Adjust the time range and retry the request.",
+        "link": ""
+    },
+    "ModelFactory.OperationAudit.EventNotFound": {
+        "code": "ModelFactory.OperationAudit.EventNotFound",
+        "description": "Operation audit event was not found.",
+        "detail": "The requested operation audit event does not exist.",
+        "solution": "Check the event identifier and retry the request.",
+        "link": ""
     }
 }

--- a/infra/mf-model-manager/app/commons/i18n/en_us.py
+++ b/infra/mf-model-manager/app/commons/i18n/en_us.py
@@ -6,6 +6,7 @@ error_messages = {
         "code": ParamValidationErrors.ParamMissing,
         "description": "Required parameter is missing.",
         "detail": "",
+        "detail_template": "Missing required parameters: {parameters}",
         "solution": "Please read the API documentation and pass the correct parameters",
         "link": ""
     },
@@ -14,6 +15,7 @@ error_messages = {
         "description": "Parameter type is invalid.",
         "solution": "Please read the API documentation and pass the correct parameters",
         "detail": "",
+        "detail_template": "Parameter type error: {parameters}",
         "link": ""
 
     },

--- a/infra/mf-model-manager/app/commons/i18n/zh_cn.py
+++ b/infra/mf-model-manager/app/commons/i18n/zh_cn.py
@@ -16,5 +16,33 @@ error_messages = {
         "detail": "",
         "link": ""
 
+    },
+    "ModelFactory.OperationAudit.AccessDenied": {
+        "code": "ModelFactory.OperationAudit.AccessDenied",
+        "description": "访问被拒绝。",
+        "detail": "当前身份没有访问操作审计记录的权限。",
+        "solution": "请联系管理员申请权限。",
+        "link": ""
+    },
+    "ModelFactory.OperationAudit.InvalidTimestamp": {
+        "code": "ModelFactory.OperationAudit.InvalidTimestamp",
+        "description": "时间格式无效。",
+        "detail": "from 或 to 必须使用 RFC3339 时间格式。",
+        "solution": "请使用 RFC3339 时间格式后重试。",
+        "link": ""
+    },
+    "ModelFactory.OperationAudit.InvalidTimeRange": {
+        "code": "ModelFactory.OperationAudit.InvalidTimeRange",
+        "description": "时间范围无效。",
+        "detail": "结束时间必须晚于开始时间，且查询范围不能超过 30 天。",
+        "solution": "请调整时间范围后重试。",
+        "link": ""
+    },
+    "ModelFactory.OperationAudit.EventNotFound": {
+        "code": "ModelFactory.OperationAudit.EventNotFound",
+        "description": "审计事件不存在。",
+        "detail": "未找到请求的操作审计事件。",
+        "solution": "请检查事件标识后重试。",
+        "link": ""
     }
 }

--- a/infra/mf-model-manager/app/commons/i18n/zh_cn.py
+++ b/infra/mf-model-manager/app/commons/i18n/zh_cn.py
@@ -6,6 +6,7 @@ error_messages = {
         "code": ParamValidationErrors.ParamMissing,
         "description": "参数缺失",
         "detail": "",
+        "detail_template": "缺少必填参数：{parameters}",
         "solution": "请阅读API文档填写正确的参数",
         "link": ""
     },
@@ -14,6 +15,7 @@ error_messages = {
         "description": "参数类型错误",
         "solution": "请阅读API文档填写正确的参数",
         "detail": "",
+        "detail_template": "参数类型错误：{parameters}",
         "link": ""
 
     },

--- a/infra/mf-model-manager/app/commons/locale.py
+++ b/infra/mf-model-manager/app/commons/locale.py
@@ -1,0 +1,328 @@
+# Copyright openbkn.ai
+#
+# Licensed under the OpenBKN License. See LICENSE-OPENBKN.txt in the project root.
+
+import json
+from contextvars import ContextVar, Token
+from copy import deepcopy
+from typing import Any, Callable, Dict, Optional, Tuple
+
+DEFAULT_LOCALE = "zh-CN"
+ENGLISH_LOCALE = "en-US"
+SUPPORTED_LOCALES = (DEFAULT_LOCALE, ENGLISH_LOCALE)
+
+_effective_locale: ContextVar[str] = ContextVar("effective_locale", default=DEFAULT_LOCALE)
+
+
+def resolve_accept_language(header: str) -> str:
+    """Resolve the HTTP Accept-Language header using the platform P0 rules."""
+    ranges = _parse_accept_language(header)
+    if not ranges:
+        return DEFAULT_LOCALE
+
+    explicit = {language: candidate for language, candidate in ranges.items() if language != "*"}
+    wildcard = ranges.get("*")
+    candidates = []
+    for language in SUPPORTED_LOCALES:
+        candidate = explicit.get(language)
+        if candidate is not None:
+            if candidate[0] > 0:
+                candidates.append((candidate[0], candidate[1], language))
+        elif wildcard is not None and wildcard[0] > 0:
+            candidates.append((wildcard[0], wildcard[1], language))
+
+    if candidates:
+        candidates.sort(key=lambda item: (-item[0], item[1]))
+        return candidates[0][2]
+
+    for language in SUPPORTED_LOCALES:
+        candidate = explicit.get(language, wildcard)
+        if candidate is None or candidate[0] > 0:
+            return language
+    return DEFAULT_LOCALE
+
+
+def get_effective_locale() -> str:
+    return _effective_locale.get()
+
+
+def internal_request_headers(headers: Optional[Dict[str, str]] = None) -> Dict[str, str]:
+    """Build headers for a platform-internal request using the frozen locale."""
+    result = dict(headers or {})
+    result["Accept-Language"] = get_effective_locale()
+    return result
+
+
+def set_effective_locale(locale: str) -> Token:
+    return _effective_locale.set(locale if locale in SUPPORTED_LOCALES else DEFAULT_LOCALE)
+
+
+def reset_effective_locale(token: Token) -> None:
+    _effective_locale.reset(token)
+
+
+def localized_error_content(
+        content: Dict[str, Any], locale: str, status_code: Optional[int] = None) -> Tuple[Dict[str, Any], bool]:
+    """Return a localized error payload without changing its machine contract."""
+    code = content.get("code")
+    if not isinstance(code, str) or not code:
+        if status_code in (404, 405) and _is_framework_http_error(content, status_code):
+            return _localized_http_error_content(status_code, locale), True
+        return content, False
+
+    localized = deepcopy(content)
+    from app.commons.i18n import lookup_error_message
+
+    message = lookup_error_message(code, locale)
+    if message:
+        for field in ("description", "detail", "solution"):
+            if field in message and (field != "detail" or message[field]):
+                localized[field] = message[field]
+    elif locale == ENGLISH_LOCALE:
+        localized["description"] = "Request failed."
+        localized["detail"] = "The request could not be completed."
+        localized["solution"] = "See the request details or contact an administrator."
+    return localized, True
+
+
+def is_business_api_path(path: str) -> bool:
+    return path.startswith(("/api/mf-model-manager/v1/", "/api/private/mf-model-manager/v1/"))
+
+
+def is_authenticated_public_api_path(path: str) -> bool:
+    return path.startswith("/api/mf-model-manager/v1/")
+
+
+def _localized_http_error_content(status_code: int, locale: str) -> Dict[str, Any]:
+    chinese_messages = {
+        400: ("请求参数无效。", "请求参数无效。", "请检查请求参数后重试。"),
+        401: ("认证失败。", "认证信息无效或已过期。", "请重新登录后重试。"),
+        403: ("访问被拒绝。", "当前身份没有访问该资源的权限。", "请联系管理员申请权限。"),
+        404: ("资源不存在。", "请求的资源不存在。", "请检查资源标识后重试。"),
+    }
+    english_messages = {
+        400: ("Request is invalid.", "The request parameters are invalid.", "Review the request parameters and try again."),
+        401: ("Authentication failed.", "The authentication credentials are invalid or expired.", "Sign in again and retry the request."),
+        403: ("Access denied.", "The current identity is not allowed to access this resource.", "Contact an administrator to request access."),
+        404: ("Resource not found.", "The requested resource does not exist.", "Check the resource identifier and try again."),
+    }
+    messages = english_messages if locale == ENGLISH_LOCALE else chinese_messages
+    default = (
+        "Request failed.",
+        "The request could not be completed.",
+        "See the request details or contact an administrator.",
+    ) if locale == ENGLISH_LOCALE else (
+        "请求失败。",
+        "请求无法完成。",
+        "请查看请求详情或联系管理员。",
+    )
+    description, detail, solution = messages.get(status_code, default)
+    return {
+        "code": f"HTTP_{status_code}",
+        "description": description,
+        "detail": detail,
+        "solution": solution,
+        "link": "",
+    }
+
+
+class LocaleResponseMiddleware:
+    """Freeze locale before auth and decorate completed JSON error responses."""
+
+    def __init__(self, app: Callable) -> None:
+        self.app = app
+
+    async def __call__(self, scope: Dict[str, Any], receive: Callable, send: Callable) -> None:
+        if scope["type"] != "http":
+            await self.app(scope, receive, send)
+            return
+
+        headers = {key.decode("latin-1").lower(): value.decode("latin-1") for key, value in scope["headers"]}
+        locale = resolve_accept_language(headers.get("accept-language", ""))
+        scope.setdefault("state", {})["effective_locale"] = locale
+        token = set_effective_locale(locale)
+        response_start: Optional[Dict[str, Any]] = None
+        body = bytearray()
+
+        async def send_with_locale(message: Dict[str, Any]) -> None:
+            nonlocal response_start
+            if message["type"] == "http.response.start":
+                response_start = message
+                return
+            if message["type"] != "http.response.body" or response_start is None:
+                await send(message)
+                return
+
+            body.extend(message.get("body", b""))
+            if message.get("more_body", False):
+                if response_start["status"] < 400:
+                    self._apply_cache_policy(response_start, scope["path"])
+                    await send(response_start)
+                    response_start = None
+                    await send(message)
+                return
+
+            self._apply_cache_policy(response_start, scope["path"])
+            payload = self._localize_error_payload(response_start, body, locale, scope["path"])
+            if payload is not None:
+                body.clear()
+                body.extend(payload)
+            await send(response_start)
+            await send({"type": "http.response.body", "body": bytes(body), "more_body": False})
+            response_start = None
+
+        try:
+            await self.app(scope, receive, send_with_locale)
+        finally:
+            reset_effective_locale(token)
+
+    @staticmethod
+    def _apply_cache_policy(response_start: Dict[str, Any], path: str) -> None:
+        if not is_business_api_path(path):
+            return
+        _set_header(
+            response_start["headers"],
+            "Cache-Control",
+            _merge_cache_control(_get_header(response_start["headers"], "cache-control")),
+        )
+
+    @staticmethod
+    def _localize_error_payload(
+            response_start: Dict[str, Any], body: bytearray, locale: str, path: str) -> Optional[bytes]:
+        if response_start["status"] < 400:
+            return None
+        if not is_business_api_path(path):
+            return None
+        if "application/json" not in _get_header(response_start["headers"], "content-type").lower():
+            return None
+        try:
+            content = json.loads(body.decode("utf-8"))
+        except (UnicodeDecodeError, ValueError):
+            return None
+        if not isinstance(content, dict):
+            return None
+        content = _unwrap_structured_error(content)
+        localized, is_localized = localized_error_content(content, locale, response_start["status"])
+        if not is_localized:
+            return None
+        encoded = json.dumps(localized, ensure_ascii=False, separators=(",", ":")).encode("utf-8")
+        _set_header(response_start["headers"], "Content-Language", locale)
+        _set_header(response_start["headers"], "Content-Length", str(len(encoded)))
+        return encoded
+
+
+def _get_header(headers: list[Tuple[bytes, bytes]], name: str) -> str:
+    wanted = name.lower().encode("latin-1")
+    for key, value in headers:
+        if key.lower() == wanted:
+            return value.decode("latin-1")
+    return ""
+
+
+def _set_header(headers: list[Tuple[bytes, bytes]], name: str, value: str) -> None:
+    wanted = name.lower().encode("latin-1")
+    encoded = value.encode("latin-1")
+    for index, (key, _) in enumerate(headers):
+        if key.lower() == wanted:
+            headers[index] = (key, encoded)
+            return
+    headers.append((wanted, encoded))
+
+
+def _is_framework_http_error(content: Dict[str, Any], status_code: int) -> bool:
+    return content.get("detail") == {404: "Not Found", 405: "Method Not Allowed"}[status_code]
+
+
+def _unwrap_structured_error(content: Dict[str, Any]) -> Dict[str, Any]:
+    detail = content.get("detail")
+    if not isinstance(detail, dict) or not detail.get("code"):
+        return content
+    unwrapped = dict(content)
+    unwrapped.pop("detail")
+    unwrapped.update(detail)
+    return unwrapped
+
+
+def _merge_cache_control(value: str) -> str:
+    directives = [directive.strip() for directive in value.split(",") if directive.strip()]
+    filtered = []
+    names = set()
+    for directive in directives:
+        name = directive.split("=", 1)[0].strip().lower()
+        if name == "public":
+            continue
+        if name not in names:
+            filtered.append(directive)
+            names.add(name)
+    if "private" not in names:
+        filtered.append("private")
+    if "no-store" not in names and "no-cache" not in names:
+        filtered.append("no-cache")
+    return ", ".join(filtered)
+
+
+def _parse_accept_language(header: str) -> Dict[str, Tuple[float, int]]:
+    merged: Dict[str, Tuple[float, int]] = {}
+    for position, raw_item in enumerate(header.split(",")):
+        parts = raw_item.split(";")
+        language = parts[0].strip()
+        quality = _parse_quality(parts[1:])
+        if not language or quality is None:
+            continue
+        normalized = _normalize_language(language)
+        if normalized is None:
+            continue
+        previous = merged.get(normalized)
+        if previous is None or quality > previous[0]:
+            merged[normalized] = (quality, position)
+    return merged
+
+
+def _parse_quality(params: list[str]) -> Optional[float]:
+    if not params:
+        return 1.0
+    if len(params) != 1:
+        return None
+    name, separator, value = params[0].strip().partition("=")
+    if separator != "=" or name.strip().lower() != "q":
+        return None
+    return _parse_qvalue(value.strip())
+
+
+def _parse_qvalue(value: str) -> Optional[float]:
+    if value in ("0", "1"):
+        return float(value)
+    if len(value) < 3 or len(value) > 5 or value[0] not in "01" or value[1] != ".":
+        return None
+    fraction = value[2:]
+    if (
+        not fraction.isascii()
+        or not fraction.isdigit()
+        or (value[0] == "1" and any(digit != "0" for digit in fraction))
+    ):
+        return None
+    return float(value)
+
+
+def _normalize_language(value: str) -> Optional[str]:
+    normalized = value.strip().lower()
+    if normalized == "zh_cn":
+        normalized = "zh-cn"
+    if normalized == "*":
+        return normalized
+    if not _valid_language_range(normalized):
+        return None
+    if normalized in ("zh", "zh-cn", "zh-hans") or normalized.startswith(("zh-cn-", "zh-hans-")):
+        return DEFAULT_LOCALE
+    if normalized == "en" or normalized.startswith("en-"):
+        return ENGLISH_LOCALE
+    return None
+
+
+def _valid_language_range(value: str) -> bool:
+    if not value or value.startswith("-") or value.endswith("-"):
+        return False
+    for subtag in value.split("-"):
+        if not 1 <= len(subtag) <= 8 or not subtag.isascii() or not subtag.isalnum():
+            return False
+    return True

--- a/infra/mf-model-manager/app/commons/locale.py
+++ b/infra/mf-model-manager/app/commons/locale.py
@@ -81,9 +81,14 @@ def localized_error_content(
             elif field in message:
                 localized[field] = message[field]
     elif locale == ENGLISH_LOCALE:
-        localized["description"] = "Request failed."
-        localized["detail"] = "The request could not be completed."
-        localized["solution"] = "See the request details or contact an administrator."
+        fallback_messages = {
+            "description": "Request failed.",
+            "detail": "The request could not be completed.",
+            "solution": "See the request details or contact an administrator.",
+        }
+        for field, fallback in fallback_messages.items():
+            if not localized.get(field) or _contains_chinese(localized[field]):
+                localized[field] = fallback
     return localized, True
 
 
@@ -102,6 +107,10 @@ def _localize_detail(message: Dict[str, Any], detail: Any) -> Any:
         if separator and parameter_names.strip():
             return template.format(parameters=parameter_names.strip())
     return message.get("detail") or detail
+
+
+def _contains_chinese(value: Any) -> bool:
+    return isinstance(value, str) and any("\u4e00" <= char <= "\u9fff" for char in value)
 
 
 def _localized_http_error_content(status_code: int, locale: str) -> Dict[str, Any]:
@@ -159,6 +168,10 @@ class LocaleResponseMiddleware:
             nonlocal response_start
             if message["type"] == "http.response.start":
                 response_start = message
+                if not _is_json_response(message):
+                    self._apply_cache_policy(response_start, scope["path"])
+                    await send(response_start)
+                    response_start = None
                 return
             if message["type"] != "http.response.body" or response_start is None:
                 await send(message)
@@ -228,6 +241,10 @@ def _get_header(headers: list[Tuple[bytes, bytes]], name: str) -> str:
         if key.lower() == wanted:
             return value.decode("latin-1")
     return ""
+
+
+def _is_json_response(response_start: Dict[str, Any]) -> bool:
+    return "application/json" in _get_header(response_start["headers"], "content-type").lower()
 
 
 def _set_header(headers: list[Tuple[bytes, bytes]], name: str, value: str) -> None:

--- a/infra/mf-model-manager/app/commons/locale.py
+++ b/infra/mf-model-manager/app/commons/locale.py
@@ -76,7 +76,9 @@ def localized_error_content(
     message = lookup_error_message(code, locale)
     if message:
         for field in ("description", "detail", "solution"):
-            if field in message and (field != "detail" or message[field]):
+            if field == "detail":
+                localized[field] = _localize_detail(message, content.get(field))
+            elif field in message:
                 localized[field] = message[field]
     elif locale == ENGLISH_LOCALE:
         localized["description"] = "Request failed."
@@ -91,6 +93,15 @@ def is_business_api_path(path: str) -> bool:
 
 def is_authenticated_public_api_path(path: str) -> bool:
     return path.startswith("/api/mf-model-manager/v1/")
+
+
+def _localize_detail(message: Dict[str, Any], detail: Any) -> Any:
+    template = message.get("detail_template")
+    if template and isinstance(detail, str):
+        _, separator, parameter_names = detail.partition(":")
+        if separator and parameter_names.strip():
+            return template.format(parameters=parameter_names.strip())
+    return message.get("detail") or detail
 
 
 def _localized_http_error_content(status_code: int, locale: str) -> Dict[str, Any]:

--- a/infra/mf-model-manager/app/commons/response.py
+++ b/infra/mf-model-manager/app/commons/response.py
@@ -2,7 +2,8 @@ from typing import Any, Dict
 from fastapi import status
 from fastapi.responses import JSONResponse
 
-from app.commons.i18n import get_error_message
+from app.commons.i18n import lookup_error_message
+from app.commons.locale import DEFAULT_LOCALE, localized_error_content
 
 
 def error_response(
@@ -11,7 +12,7 @@ def error_response(
         detail: str,
         solution: str = "",
         link: str = "",
-        language: str = "zh"
+        language: str = DEFAULT_LOCALE
 ) -> JSONResponse:
     """Handle errors response
     Args:
@@ -26,15 +27,20 @@ def error_response(
     """
     error_content: Dict[str, str] = {
         "code": code,
-        "description": get_error_message(code, language),
+        "description": "Request failed." if language == "en-US" else "请求失败。",
         "solution": solution,
         "detail": detail,
         "link": link
     }
+    message = lookup_error_message(code, language)
+    if message:
+        error_content.update({key: message[key] for key in ("description", "solution") if key in message})
+    error_content, _ = localized_error_content(error_content, language)
 
     return JSONResponse(
         status_code=status_code,
-        content=error_content
+        content=error_content,
+        headers={"Content-Language": language},
     )
 
 

--- a/infra/mf-model-manager/app/dao/user_info.py
+++ b/infra/mf-model-manager/app/dao/user_info.py
@@ -2,6 +2,7 @@ import json
 
 import requests
 
+from app.commons.locale import internal_request_headers
 from app.logs.stand_log import StandLogger
 from app.mydb.my_pymysql_pool import connect_execute_close_db
 
@@ -12,7 +13,10 @@ def user(user_id, **kwargs):
         user_cache = kwargs.get('user_cache', {})
         if user_id in user_cache:
             return user_cache[user_id]
-        response = requests.get(f"http://kg-user-rbac:6900/api/rbac/v1/user?field=userId&value={user_id}")
+        response = requests.get(
+            f"http://kg-user-rbac:6900/api/rbac/v1/user?field=userId&value={user_id}",
+            headers=internal_request_headers(),
+        )
         # response = requests.get(f"http://10.4.134.232:6900/api/rbac/v1/user?field=userId&value={user_id}")
         response = json.loads(response.text)
         response = response['res']

--- a/infra/mf-model-manager/app/routers/operation_audit_router.py
+++ b/infra/mf-model-manager/app/routers/operation_audit_router.py
@@ -6,22 +6,37 @@ import aiohttp
 from fastapi import APIRouter, Header, HTTPException, Query, Request
 
 from app.mydb.pymysql_pool import PymysqlPool
+from app.commons.locale import internal_request_headers
 
 operation_audit_router = APIRouter()
 _MAX_RANGE_SECONDS = 30 * 24 * 60 * 60
+_AUDIT_ERRORS = {
+    "access_denied": (403, "ModelFactory.OperationAudit.AccessDenied"),
+    "invalid_timestamp": (400, "ModelFactory.OperationAudit.InvalidTimestamp"),
+    "invalid_time_range": (400, "ModelFactory.OperationAudit.InvalidTimeRange"),
+    "event_not_found": (404, "ModelFactory.OperationAudit.EventNotFound"),
+}
+
+
+def _audit_error(name):
+    status_code, code = _AUDIT_ERRORS[name]
+    return HTTPException(status_code=status_code, detail={"code": code, "link": ""})
 
 async def _require_audit_reader(request: Request):
     token = request.headers.get("authorization", "")
     safe = os.getenv("BKN_SAFE_URL", "").rstrip("/")
     if not token or not safe:
-        raise HTTPException(403, "operation audit access denied")
+        raise _audit_error("access_denied")
     async with aiohttp.ClientSession(timeout=aiohttp.ClientTimeout(total=3)) as session:
-        async with session.get(safe + "/api/safe/v1/me", headers={"Authorization": token}) as response:
+        async with session.get(
+            safe + "/api/safe/v1/me",
+            headers=internal_request_headers({"Authorization": token}),
+        ) as response:
             if response.status != 200:
-                raise HTTPException(403, "operation audit access denied")
+                raise _audit_error("access_denied")
             me = await response.json()
     if not me.get("enabled") or not set(me.get("roles", [])) & {"super_admin", "admin", "audit"}:
-        raise HTTPException(403, "operation audit access denied")
+        raise _audit_error("access_denied")
 
 def _list(tenant, domain, from_time, to_time, limit, before_time, before_event_id, actor_id, action, target_type, target_id, outcome):
     pool=PymysqlPool.get_pool(); connection=pool.connection(); cursor=connection.cursor()
@@ -44,12 +59,12 @@ def _get(event_id,tenant,domain):
 
 def _time(value):
     try: return datetime.fromisoformat(value.replace("Z","+00:00"))
-    except ValueError: raise HTTPException(400,"from/to must be RFC3339")
+    except ValueError: raise _audit_error("invalid_timestamp")
 
 @operation_audit_router.get("/operation-audits")
 async def list_operation_audits(request: Request, from_: str = Query(alias="from"), to: str = Query(), limit: int = Query(50, ge=1, le=500), before_time: str = Query(""), before_event_id: str = Query(""), actor_id: str = Query(""), action: str = Query(""), target_type: str = Query(""), target_id: str = Query(""), outcome: str = Query(""), x_tenant_id: str = Header(alias="x-tenant-id"), x_business_domain: str = Header(alias="x-business-domain")):
     await _require_audit_reader(request); start,end=_time(from_),_time(to)
-    if start>=end or (end-start).total_seconds()>_MAX_RANGE_SECONDS: raise HTTPException(400,"from/to must be a valid RFC3339 range of at most 30 days")
+    if start>=end or (end-start).total_seconds()>_MAX_RANGE_SECONDS: raise _audit_error("invalid_time_range")
     before=_time(before_time) if before_time else None
     rows,more=await asyncio.to_thread(_list,x_tenant_id,x_business_domain,start,end,limit,before,before_event_id,actor_id.strip(),action.strip(),target_type.strip(),target_id.strip(),outcome.strip())
     return {"entries":rows,"has_more":more}
@@ -57,5 +72,5 @@ async def list_operation_audits(request: Request, from_: str = Query(alias="from
 @operation_audit_router.get("/operation-audits/{event_id}")
 async def get_operation_audit(event_id: str, request: Request, x_tenant_id: str = Header(alias="x-tenant-id"), x_business_domain: str = Header(alias="x-business-domain")):
     await _require_audit_reader(request); row=await asyncio.to_thread(_get,event_id,x_tenant_id,x_business_domain)
-    if not row: raise HTTPException(404,"operation audit event not found")
+    if not row: raise _audit_error("event_not_found")
     return row

--- a/infra/mf-model-manager/app/test/test_app_locale.py
+++ b/infra/mf-model-manager/app/test/test_app_locale.py
@@ -1,0 +1,99 @@
+# Copyright openbkn.ai
+#
+# Licensed under the OpenBKN License. See LICENSE-OPENBKN.txt in the project root.
+
+import unittest
+
+from fastapi import FastAPI, HTTPException
+from fastapi.testclient import TestClient
+
+from app.commons.locale import LocaleResponseMiddleware
+from app.utils.app_utils import configure_locale_openapi, unhandled_exception_handler
+
+
+class TestAppLocaleIntegration(unittest.TestCase):
+    def setUp(self):
+        self.app = FastAPI()
+        self.app.add_middleware(LocaleResponseMiddleware)
+        self.app.add_exception_handler(Exception, unhandled_exception_handler)
+
+        @self.app.get("/api/mf-model-manager/v1/test-error")
+        async def test_error():
+            raise RuntimeError("unexpected")
+
+        @self.app.get("/api/mf-model-manager/v1/test-http-error")
+        async def test_http_error():
+            raise HTTPException(
+                status_code=404,
+                detail={"code": "ModelFactory.OperationAudit.EventNotFound", "link": ""},
+            )
+
+        @self.app.get("/api/private/mf-model-manager/v1/test-private")
+        async def test_private():
+            return {"status": "ok"}
+
+        @self.app.get("/api/v1/health/test-error")
+        async def test_health_error():
+            raise RuntimeError("unexpected")
+
+        configure_locale_openapi(self.app)
+        self.client = TestClient(self.app, raise_server_exceptions=False)
+
+    def test_unhandled_exception_has_locale_and_cache_headers(self):
+        response = self.client.get(
+            "/api/mf-model-manager/v1/test-error",
+            headers={"Accept-Language": "en-US"},
+        )
+
+        self.assertEqual(response.status_code, 500)
+        self.assertEqual(response.headers["content-language"], "en-US")
+        self.assertEqual(response.headers["cache-control"], "private, no-cache")
+        self.assertEqual(response.json()["description"], "Request failed.")
+
+    def test_http_exception_is_localized_with_a_stable_error_code(self):
+        response = self.client.get(
+            "/api/mf-model-manager/v1/test-http-error",
+            headers={"Accept-Language": "zh-CN"},
+        )
+
+        self.assertEqual(response.status_code, 404)
+        self.assertEqual(response.headers["content-language"], "zh-CN")
+        self.assertEqual(response.json()["code"], "ModelFactory.OperationAudit.EventNotFound")
+        self.assertEqual(response.json()["description"], "审计事件不存在。")
+
+    def test_framework_not_found_uses_the_status_code_fallback(self):
+        response = self.client.get(
+            "/api/mf-model-manager/v1/not-a-route",
+            headers={"Accept-Language": "en-US"},
+        )
+
+        self.assertEqual(response.status_code, 404)
+        self.assertEqual(response.headers["content-language"], "en-US")
+        self.assertEqual(response.json()["code"], "HTTP_404")
+
+    def test_health_exception_keeps_the_machine_error_contract(self):
+        response = self.client.get("/api/v1/health/test-error")
+
+        self.assertEqual(response.status_code, 500)
+        self.assertNotIn("content-language", response.headers)
+        self.assertNotIn("cache-control", response.headers)
+        self.assertEqual(response.text, "Internal Server Error")
+
+    def test_generated_openapi_declares_locale_contract(self):
+        schema = self.app.openapi()
+        operation = schema["paths"]["/api/mf-model-manager/v1/test-error"]["get"]
+        self.assertIn(
+            {"$ref": "#/components/parameters/AcceptLanguage"},
+            operation["parameters"],
+        )
+        self.assertIn("401", operation["responses"])
+        self.assertEqual(
+            operation["responses"]["401"]["headers"]["Content-Language"]["$ref"],
+            "#/components/headers/ContentLanguage",
+        )
+        private_operation = schema["paths"]["/api/private/mf-model-manager/v1/test-private"]["get"]
+        self.assertNotIn("401", private_operation["responses"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/infra/mf-model-manager/app/test/test_get_user_info.py
+++ b/infra/mf-model-manager/app/test/test_get_user_info.py
@@ -7,6 +7,7 @@ import unittest
 from unittest import mock
 
 from app.commons import get_user_info
+from app.commons.locale import reset_effective_locale, set_effective_locale
 
 
 class _FakeResp:
@@ -40,7 +41,7 @@ class _FakeSession:
         return False
 
     def post(self, url, json=None, headers=None):
-        _FakeSession.captured = {"url": url, "json": json}
+        _FakeSession.captured = {"url": url, "json": json, "headers": headers}
         return _FakeResp(self._status, self._body)
 
 
@@ -57,11 +58,15 @@ _NAMES_BODY = (
 
 class TestGetUsernameByIdsBknSafe(unittest.IsolatedAsyncioTestCase):
     async def test_bkn_safe_merges_user_and_app_names(self):
-        with mock.patch.object(get_user_info.base_config, "DEBUG", False), \
-                _patch(_FakeSession(200, _NAMES_BODY)), \
-                mock.patch.dict(os.environ, {"DIRECTORY_PROVIDER": "bkn-safe",
-                                             "BKN_SAFE_URL": "http://safe:8080"}):
-            out = await get_user_info.get_username_by_ids(["u1", "a2"])
+        token = set_effective_locale("en-US")
+        try:
+            with mock.patch.object(get_user_info.base_config, "DEBUG", False), \
+                    _patch(_FakeSession(200, _NAMES_BODY)), \
+                    mock.patch.dict(os.environ, {"DIRECTORY_PROVIDER": "bkn-safe",
+                                                 "BKN_SAFE_URL": "http://safe:8080"}):
+                out = await get_user_info.get_username_by_ids(["u1", "a2"])
+        finally:
+            reset_effective_locale(token)
 
         self.assertEqual(out, {"u1": "Alice", "a2": "AppSvc"})
         self.assertEqual(_FakeSession.captured["url"],
@@ -69,6 +74,7 @@ class TestGetUsernameByIdsBknSafe(unittest.IsolatedAsyncioTestCase):
         # ids are sent as BOTH user_ids and app_ids (app accounts are User rows)
         self.assertEqual(_FakeSession.captured["json"],
                          {"user_ids": ["u1", "a2"], "app_ids": ["u1", "a2"]})
+        self.assertEqual(_FakeSession.captured["headers"]["Accept-Language"], "en-US")
 
     async def test_empty_ids_short_circuit(self):
         with mock.patch.object(get_user_info.base_config, "DEBUG", False):
@@ -81,6 +87,24 @@ class TestGetUsernameByIdsBknSafe(unittest.IsolatedAsyncioTestCase):
                                              "BKN_SAFE_URL": "http://safe:8080"}):
             with self.assertRaises(Exception):
                 await get_user_info.get_username_by_ids(["u1"])
+
+    async def test_user_management_uses_the_frozen_locale(self):
+        token = set_effective_locale("en-US")
+        try:
+            with (
+                    mock.patch.object(get_user_info.base_config, "DEBUG", False),
+                    _patch(_FakeSession(200, '[{"id":"u1","name":"Alice"}]')),
+                    mock.patch.dict(os.environ, {"DIRECTORY_PROVIDER": ""}, clear=False),
+            ):
+                out = await get_user_info.get_username_by_ids(["u1"])
+        finally:
+            reset_effective_locale(token)
+
+        self.assertEqual(out, {"u1": "Alice"})
+        self.assertEqual(
+            _FakeSession.captured["headers"]["Accept-Language"],
+            "en-US",
+        )
 
 
 if __name__ == "__main__":

--- a/infra/mf-model-manager/app/test/test_locale.py
+++ b/infra/mf-model-manager/app/test/test_locale.py
@@ -14,7 +14,7 @@ from app.commons.locale import (
     resolve_accept_language,
     set_effective_locale,
 )
-from app.commons.i18n import lookup_error_message
+from app.commons.i18n import get_error_message, lookup_error_message
 from app.commons.errors.codes import ParamValidationErrors
 from app.utils.common import get_user_info
 
@@ -76,6 +76,12 @@ class TestAcceptLanguageResolver(unittest.TestCase):
         self.assertTrue(is_localized)
         self.assertEqual(localized["detail"], "参数类型错误：model_names")
 
+    def test_controller_error_message_hides_internal_detail_template(self):
+        message = asyncio.run(get_error_message(ParamValidationErrors.ParamMissing, "zh-CN"))
+
+        self.assertNotIn("detail_template", message)
+        self.assertEqual(message["detail"], "")
+
     def test_uses_request_scoped_locale_instead_of_the_raw_header(self):
         class State:
             effective_locale = "en-US"
@@ -136,9 +142,27 @@ class TestLocaleResponseMiddleware(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(headers[b"content-language"], b"en-US")
         self.assertEqual(headers[b"cache-control"], b"private, no-cache")
         self.assertEqual(payload["code"], "Unauthorized")
-        self.assertEqual(payload["description"], "Request failed.")
+        self.assertEqual(payload["description"], "token invalid")
         self.assertEqual(payload["detail"], "The request could not be completed.")
+        self.assertEqual(payload["solution"], "check token")
         self.assertNotIn("无效", json.dumps(payload, ensure_ascii=False))
+
+    async def test_preserves_existing_english_message_for_unknown_error_code(self):
+        localized, is_localized = localized_error_content(
+            {
+                "code": "ModelFactory.ConnectController.LLMAdd.NameRepeat",
+                "description": "Name already exists, please modify",
+                "detail": "Name already exists, please modify",
+                "solution": "Please check the input information",
+                "link": "",
+            },
+            "en-US",
+        )
+
+        self.assertTrue(is_localized)
+        self.assertEqual(localized["description"], "Name already exists, please modify")
+        self.assertEqual(localized["detail"], "Name already exists, please modify")
+        self.assertEqual(localized["solution"], "Please check the input information")
 
     async def test_does_not_apply_business_cache_policy_to_health(self):
         async def app(scope, receive, send):
@@ -279,6 +303,35 @@ class TestLocaleResponseMiddleware(unittest.IsolatedAsyncioTestCase):
 
         headers = dict(messages[0]["headers"])
         self.assertEqual(headers[b"cache-control"], b"no-store, no-transform, private")
+
+    async def test_forwards_sse_response_start_before_the_first_event(self):
+        messages = []
+
+        async def app(scope, receive, send):
+            await send({
+                "type": "http.response.start",
+                "status": 200,
+                "headers": [(b"content-type", b"text/event-stream; charset=utf-8")],
+            })
+            self.assertEqual(len(messages), 1)
+            self.assertEqual(dict(messages[0]["headers"])[b"cache-control"], b"private, no-cache")
+            await send({"type": "http.response.body", "body": b"data: first\\n\\n", "more_body": True})
+
+        async def collect(message):
+            messages.append(message)
+
+        await LocaleResponseMiddleware(app)(
+            {
+                "type": "http",
+                "path": "/api/mf-model-manager/v1/llm/chat",
+                "headers": [(b"accept-language", b"en-US")],
+            },
+            None,
+            collect,
+        )
+
+        self.assertEqual(messages[0]["type"], "http.response.start")
+        self.assertEqual(messages[1]["body"], b"data: first\\n\\n")
 
 
 if __name__ == "__main__":

--- a/infra/mf-model-manager/app/test/test_locale.py
+++ b/infra/mf-model-manager/app/test/test_locale.py
@@ -45,7 +45,7 @@ class TestAcceptLanguageResolver(unittest.TestCase):
         self.assertIsNotNone(message)
         self.assertEqual(message["code"], ParamValidationErrors.ParamMissing)
 
-    def test_preserves_dynamic_parameter_error_detail_when_translation_is_empty(self):
+    def test_localizes_dynamic_missing_parameter_detail(self):
         localized, is_localized = localized_error_content(
             {
                 "code": ParamValidationErrors.ParamMissing,
@@ -59,7 +59,22 @@ class TestAcceptLanguageResolver(unittest.TestCase):
 
         self.assertTrue(is_localized)
         self.assertEqual(localized["description"], "Required parameter is missing.")
-        self.assertEqual(localized["detail"], "missing parameters: max_model_len")
+        self.assertEqual(localized["detail"], "Missing required parameters: max_model_len")
+
+    def test_localizes_dynamic_parameter_type_detail_in_chinese(self):
+        localized, is_localized = localized_error_content(
+            {
+                "code": ParamValidationErrors.ParamTypeError,
+                "description": "参数类型错误",
+                "detail": "parameters type error: model_names",
+                "solution": "请检查参数",
+                "link": "",
+            },
+            "zh-CN",
+        )
+
+        self.assertTrue(is_localized)
+        self.assertEqual(localized["detail"], "参数类型错误：model_names")
 
     def test_uses_request_scoped_locale_instead_of_the_raw_header(self):
         class State:

--- a/infra/mf-model-manager/app/test/test_locale.py
+++ b/infra/mf-model-manager/app/test/test_locale.py
@@ -1,0 +1,270 @@
+# Copyright openbkn.ai
+#
+# Licensed under the OpenBKN License. See LICENSE-OPENBKN.txt in the project root.
+
+import asyncio
+import json
+import unittest
+
+from app.commons.locale import (
+    LocaleResponseMiddleware,
+    internal_request_headers,
+    localized_error_content,
+    reset_effective_locale,
+    resolve_accept_language,
+    set_effective_locale,
+)
+from app.commons.i18n import lookup_error_message
+from app.commons.errors.codes import ParamValidationErrors
+from app.utils.common import get_user_info
+
+
+class TestAcceptLanguageResolver(unittest.TestCase):
+    def test_resolves_supported_and_legacy_ranges(self):
+        cases = {
+            "en-US": "en-US",
+            "en-GB": "en-US",
+            "zh_CN": "zh-CN",
+            "zh-Hans": "zh-CN",
+            "zh-Hant, en-US;q=0.8": "en-US",
+            "zh-CN;q=0, en-US;q=1": "en-US",
+            "zh-CN;q=0, *;q=1": "en-US",
+            "en;q=0, en;q=1": "en-US",
+            "en-US;q=NaN, zh-CN;q=0.5": "zh-CN",
+            "en_US": "zh-CN",
+        }
+        for header, expected in cases.items():
+            with self.subTest(header=header):
+                self.assertEqual(resolve_accept_language(header), expected)
+
+    def test_falls_back_when_every_supported_language_is_rejected(self):
+        self.assertEqual(resolve_accept_language("zh-CN;q=0, en-US;q=0"), "zh-CN")
+
+    def test_uses_canonical_locale_for_error_catalog_lookup(self):
+        message = lookup_error_message(ParamValidationErrors.ParamMissing, "en-US")
+        self.assertIsNotNone(message)
+        self.assertEqual(message["code"], ParamValidationErrors.ParamMissing)
+
+    def test_preserves_dynamic_parameter_error_detail_when_translation_is_empty(self):
+        localized, is_localized = localized_error_content(
+            {
+                "code": ParamValidationErrors.ParamMissing,
+                "description": "参数缺失",
+                "detail": "missing parameters: max_model_len",
+                "solution": "请检查参数",
+                "link": "",
+            },
+            "en-US",
+        )
+
+        self.assertTrue(is_localized)
+        self.assertEqual(localized["description"], "Required parameter is missing.")
+        self.assertEqual(localized["detail"], "missing parameters: max_model_len")
+
+    def test_uses_request_scoped_locale_instead_of_the_raw_header(self):
+        class State:
+            effective_locale = "en-US"
+
+        class Request:
+            headers = {"accept-language": "zh-CN, en-US;q=0.8"}
+            state = State()
+
+        user_id, language, role = asyncio.run(get_user_info(Request()))
+        self.assertEqual((user_id, language, role), ("", "en-US", ""))
+
+    def test_internal_requests_always_use_the_frozen_single_locale(self):
+        token = set_effective_locale("en-US")
+        try:
+            headers = internal_request_headers({"Accept-Language": "zh-CN, en-US;q=0.8"})
+        finally:
+            reset_effective_locale(token)
+        self.assertEqual(headers["Accept-Language"], "en-US")
+
+
+class TestLocaleResponseMiddleware(unittest.IsolatedAsyncioTestCase):
+    async def test_localizes_error_and_applies_private_cache_policy(self):
+        async def app(scope, receive, send):
+            self.assertEqual(scope["state"]["effective_locale"], "en-US")
+            await send({
+                "type": "http.response.start",
+                "status": 401,
+                "headers": [(b"content-type", b"application/json")],
+            })
+            await send({
+                "type": "http.response.body",
+                "body": json.dumps({
+                    "code": "Unauthorized",
+                    "description": "token invalid",
+                    "detail": "token无效或已过期",
+                    "solution": "check token",
+                    "link": "",
+                }).encode("utf-8"),
+            })
+
+        messages = []
+        async def collect(message):
+            messages.append(message)
+
+        middleware = LocaleResponseMiddleware(app)
+        await middleware(
+            {
+                "type": "http",
+                "path": "/api/mf-model-manager/v1/llm/list",
+                "headers": [(b"accept-language", b"zh-CN;q=0.2, en-US;q=0.8")],
+            },
+            None,
+            collect,
+        )
+
+        headers = dict(messages[0]["headers"])
+        payload = json.loads(messages[1]["body"])
+        self.assertEqual(headers[b"content-language"], b"en-US")
+        self.assertEqual(headers[b"cache-control"], b"private, no-cache")
+        self.assertEqual(payload["code"], "Unauthorized")
+        self.assertEqual(payload["description"], "Request failed.")
+        self.assertEqual(payload["detail"], "The request could not be completed.")
+        self.assertNotIn("无效", json.dumps(payload, ensure_ascii=False))
+
+    async def test_does_not_apply_business_cache_policy_to_health(self):
+        async def app(scope, receive, send):
+            await send({
+                "type": "http.response.start",
+                "status": 200,
+                "headers": [(b"content-type", b"application/json")],
+            })
+            await send({"type": "http.response.body", "body": b'{"status":"ok"}'})
+
+        messages = []
+        async def collect(message):
+            messages.append(message)
+
+        await LocaleResponseMiddleware(app)(
+            {"type": "http", "path": "/api/v1/health/ready", "headers": []},
+            None,
+            collect,
+        )
+        headers = dict(messages[0]["headers"])
+        self.assertNotIn(b"cache-control", headers)
+        self.assertNotIn(b"content-language", headers)
+
+    async def test_localizes_framework_not_found(self):
+        async def app(scope, receive, send):
+            await send({
+                "type": "http.response.start",
+                "status": 404,
+                "headers": [(b"content-type", b"application/json")],
+            })
+            await send({
+                "type": "http.response.body",
+                "body": b'{"detail":"Not Found"}',
+            })
+
+        messages = []
+        async def collect(message):
+            messages.append(message)
+
+        await LocaleResponseMiddleware(app)(
+            {
+                "type": "http",
+                "path": "/api/mf-model-manager/v1/not-a-route",
+                "headers": [(b"accept-language", b"zh-CN")],
+            },
+            None,
+            collect,
+        )
+
+        headers = dict(messages[0]["headers"])
+        payload = json.loads(messages[1]["body"])
+        self.assertEqual(headers[b"content-language"], b"zh-CN")
+        self.assertEqual(payload["code"], "HTTP_404")
+        self.assertEqual(payload["description"], "资源不存在。")
+
+    async def test_preserves_extensions_for_known_business_http_error(self):
+        async def app(scope, receive, send):
+            await send({
+                "type": "http.response.start",
+                "status": 400,
+                "headers": [(b"content-type", b"application/json")],
+            })
+            await send({
+                "type": "http.response.body",
+                "body": json.dumps({
+                    "detail": {
+                        "code": "ModelFactory.OperationAudit.InvalidTimestamp",
+                        "link": "",
+                    },
+                    "trace_id": "trace-1",
+                }).encode("utf-8"),
+            })
+
+        messages = []
+        async def collect(message):
+            messages.append(message)
+
+        await LocaleResponseMiddleware(app)(
+            {
+                "type": "http",
+                "path": "/api/mf-model-manager/v1/operation-audits",
+                "headers": [(b"accept-language", b"en-US")],
+            },
+            None,
+            collect,
+        )
+
+        payload = json.loads(messages[1]["body"])
+        self.assertEqual(payload["code"], "ModelFactory.OperationAudit.InvalidTimestamp")
+        self.assertEqual(payload["detail"], "from or to must use the RFC3339 timestamp format.")
+        self.assertEqual(payload["trace_id"], "trace-1")
+
+    async def test_does_not_localize_health_json_errors(self):
+        async def app(scope, receive, send):
+            await send({
+                "type": "http.response.start",
+                "status": 503,
+                "headers": [(b"content-type", b"application/json")],
+            })
+            await send({"type": "http.response.body", "body": b'{"detail":"not ready"}'})
+
+        messages = []
+        async def collect(message):
+            messages.append(message)
+
+        await LocaleResponseMiddleware(app)(
+            {"type": "http", "path": "/api/v1/health/ready", "headers": []},
+            None,
+            collect,
+        )
+
+        headers = dict(messages[0]["headers"])
+        self.assertNotIn(b"cache-control", headers)
+        self.assertNotIn(b"content-language", headers)
+        self.assertEqual(messages[1]["body"], b'{"detail":"not ready"}')
+
+    async def test_preserves_stricter_upstream_cache_directives(self):
+        async def app(scope, receive, send):
+            await send({
+                "type": "http.response.start",
+                "status": 200,
+                "headers": [
+                    (b"content-type", b"application/json"),
+                    (b"cache-control", b"public, no-store, no-transform"),
+                ],
+            })
+            await send({"type": "http.response.body", "body": b'{}'})
+
+        messages = []
+        async def collect(message):
+            messages.append(message)
+
+        await LocaleResponseMiddleware(app)(
+            {"type": "http", "path": "/api/mf-model-manager/v1/llm/list", "headers": []},
+            None,
+            collect,
+        )
+
+        headers = dict(messages[0]["headers"])
+        self.assertEqual(headers[b"cache-control"], b"no-store, no-transform, private")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/infra/mf-model-manager/app/test/test_permission_manager_locale.py
+++ b/infra/mf-model-manager/app/test/test_permission_manager_locale.py
@@ -1,0 +1,85 @@
+# Copyright openbkn.ai
+#
+# Licensed under the OpenBKN License. See LICENSE-OPENBKN.txt in the project root.
+
+import unittest
+from unittest import mock
+
+from app.core.config import base_config
+from app.commons.locale import reset_effective_locale, set_effective_locale
+from app.utils.permission_manager import PermissionManager
+
+
+class _Response:
+    def __init__(self, payload):
+        self.status = 200
+        self._payload = payload
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *args):
+        return False
+
+    async def json(self):
+        return self._payload
+
+
+class _Session:
+    def __init__(self, payload):
+        self.payload = payload
+        self.calls = []
+
+    def post(self, url, json=None, headers=None):
+        self.calls.append({"url": url, "json": json, "headers": headers})
+        return _Response(self.payload)
+
+
+class TestPermissionManagerLocale(unittest.IsolatedAsyncioTestCase):
+    async def test_authorization_request_uses_frozen_locale(self):
+        session = _Session({"result": True})
+        manager = PermissionManager()
+        manager.get_session = mock.AsyncMock(return_value=session)
+        token = set_effective_locale("en-US")
+        try:
+            with mock.patch.object(base_config, "AUTH_ENABLED", True):
+                allowed = await manager.check_single_permission(
+                    user_id="user-1",
+                    resource_id="model-1",
+                    operations="display",
+                    resource_type="large_model",
+                    role="user",
+                )
+        finally:
+            reset_effective_locale(token)
+
+        self.assertTrue(allowed)
+        self.assertEqual(session.calls[0]["headers"]["Accept-Language"], "en-US")
+
+    async def test_bkn_safe_authz_request_uses_frozen_locale(self):
+        session = _Session({"allowed": True})
+        with mock.patch.dict(
+                "os.environ",
+                {"AUTHZ_PROVIDER": "bkn-safe", "BKN_SAFE_URL": "http://bkn-safe"},
+                clear=False):
+            manager = PermissionManager()
+        manager.get_session = mock.AsyncMock(return_value=session)
+        token = set_effective_locale("en-US")
+        try:
+            with mock.patch.object(base_config, "AUTH_ENABLED", True):
+                allowed = await manager.check_single_permission(
+                    user_id="user-1",
+                    resource_id="model-1",
+                    operations="display",
+                    resource_type="large_model",
+                    role="user",
+                )
+        finally:
+            reset_effective_locale(token)
+
+        self.assertTrue(allowed)
+        self.assertEqual(session.calls[0]["headers"]["Accept-Language"], "en-US")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/infra/mf-model-manager/app/utils/app_utils.py
+++ b/infra/mf-model-manager/app/utils/app_utils.py
@@ -2,10 +2,19 @@ import asyncio
 import json
 import aiohttp
 from fastapi import FastAPI, Request
-from fastapi.responses import JSONResponse
+from fastapi.openapi.utils import get_openapi
+from fastapi.responses import JSONResponse, PlainTextResponse
 from starlette.middleware.base import BaseHTTPMiddleware
 
 from app.commons.errors import UnauthorizedError, HydraServiceError
+from app.commons.locale import (
+    DEFAULT_LOCALE,
+    LocaleResponseMiddleware,
+    internal_request_headers,
+    is_authenticated_public_api_path,
+    is_business_api_path,
+    localized_error_content,
+)
 from app.core.config import base_config, server_info, observability_config
 from app.logs import log_init, sys_log
 from app.mydb.ConnectUtil import get_redis_util
@@ -81,7 +90,11 @@ async def auth_middleware(request: Request, call_next):
         async with aiohttp.ClientSession() as session:
             try:
                 payload = {"token": token}
-                async with session.post(hydra_url, data=payload) as response:
+                async with session.post(
+                    hydra_url,
+                    data=payload,
+                    headers=internal_request_headers(),
+                ) as response:
                     if response.status != 200:
                         error_dict = HydraServiceError.copy()
                         error_dict["detail"] = await response.text()
@@ -125,6 +138,88 @@ class RequestSizeMiddleware(BaseHTTPMiddleware):
         return await call_next(request)
 
 
+async def unhandled_exception_handler(request: Request, exc: Exception):
+    if not is_business_api_path(request.url.path):
+        return PlainTextResponse("Internal Server Error", status_code=500)
+
+    locale = getattr(request.state, "effective_locale", DEFAULT_LOCALE)
+    content, _ = localized_error_content(
+        {
+            "code": "ModelFactory.InternalError",
+            "description": "请求失败。",
+            "detail": "服务内部错误。",
+            "solution": "请查看请求详情或联系管理员。",
+            "link": "",
+        },
+        locale,
+    )
+    headers = {"Content-Language": locale}
+    headers["Cache-Control"] = "private, no-cache"
+    return JSONResponse(status_code=500, content=content, headers=headers)
+
+
+def configure_locale_openapi(app: FastAPI) -> None:
+    """Expose the locale and cache response contract in generated OpenAPI."""
+    def custom_openapi():
+        if app.openapi_schema:
+            return app.openapi_schema
+
+        schema = get_openapi(
+            title=app.title,
+            version=app.version,
+            description=app.description,
+            routes=app.routes,
+        )
+        components = schema.setdefault("components", {})
+        parameters = components.setdefault("parameters", {})
+        parameters["AcceptLanguage"] = {
+            "name": "Accept-Language",
+            "in": "header",
+            "required": False,
+            "description": "Preferred response language. Supports zh-CN and en-US.",
+            "schema": {"type": "string", "example": "en-US"},
+        }
+        headers = components.setdefault("headers", {})
+        headers["ContentLanguage"] = {
+            "description": "Language used for a localized error response.",
+            "schema": {"type": "string", "enum": ["zh-CN", "en-US"]},
+        }
+        headers["PrivateNoCache"] = {
+            "description": "Authenticated response cache policy.",
+            "schema": {"type": "string", "example": "private, no-cache"},
+        }
+
+        for path, methods in schema.get("paths", {}).items():
+            for operation in methods.values():
+                if not isinstance(operation, dict):
+                    continue
+                operation.setdefault("parameters", []).append(
+                    {"$ref": "#/components/parameters/AcceptLanguage"}
+                )
+                responses = operation.setdefault("responses", {})
+                if is_authenticated_public_api_path(path):
+                    responses.setdefault("401", {"description": "Authentication failed"})
+                for status, response in responses.items():
+                    if not isinstance(response, dict):
+                        continue
+                    response_headers = response.setdefault("headers", {})
+                    if is_business_api_path(path):
+                        response_headers["Cache-Control"] = {
+                            "$ref": "#/components/headers/PrivateNoCache"
+                        }
+                    if (
+                            is_business_api_path(path)
+                            and str(status).isdigit()
+                            and int(status) >= 400):
+                        response_headers["Content-Language"] = {
+                            "$ref": "#/components/headers/ContentLanguage"
+                        }
+        app.openapi_schema = schema
+        return app.openapi_schema
+
+    app.openapi = custom_openapi
+
+
 def create_app():
     app = FastAPI(title="My API",
                   description="",
@@ -140,6 +235,8 @@ def create_app():
     # injected by auth_middleware after the handler returns.
     app.add_middleware(BaseHTTPMiddleware, dispatch=operation_audit_middleware)
     app.add_middleware(BaseHTTPMiddleware, dispatch=auth_middleware)
+    app.add_middleware(LocaleResponseMiddleware)
+    app.add_exception_handler(Exception, unhandled_exception_handler)
 
     # 初始化日志
     log_init()
@@ -147,4 +244,5 @@ def create_app():
     conf_init(app)
     # 初始化路由配置
     router_init(app)
+    configure_locale_openapi(app)
     return app

--- a/infra/mf-model-manager/app/utils/common.py
+++ b/infra/mf-model-manager/app/utils/common.py
@@ -7,6 +7,8 @@ import inspect
 import os
 from typing import Tuple
 
+from app.commons.locale import resolve_accept_language
+
 cur_pwd = os.getcwd()
 
 
@@ -52,7 +54,9 @@ async def get_user_info(request, **kwargs):
     headers = request.headers
     userId = headers.get('x-account-id', "")
     role = headers.get('x-account-type', "")
-    language = headers.get('accept-language', "zh-CN")
+    language = getattr(request.state, "effective_locale", None)
+    if language is None:
+        language = resolve_accept_language(headers.get('accept-language', ""))
     return userId, language, role
 
 async def validate_required_params(params_dict, required_params):

--- a/infra/mf-model-manager/app/utils/permission_manager.py
+++ b/infra/mf-model-manager/app/utils/permission_manager.py
@@ -6,6 +6,7 @@ from typing import List, Dict, Optional
 
 from app.core.config import base_config
 from app.dao.small_model_dao import small_model_dao
+from app.commons.locale import internal_request_headers
 from app.logs.stand_log import StandLogger
 
 
@@ -102,7 +103,7 @@ class PermissionManager:
             async with session.post(
                     self.auth_url,
                     json=payload,
-                    headers={'Content-Type': 'application/json'}
+                    headers=internal_request_headers({'Content-Type': 'application/json'})
             ) as response:
                 if response.status == 204:
                     return True
@@ -145,7 +146,7 @@ class PermissionManager:
             async with session.post(
                     self.check_single_auth_url,
                     json=payload,
-                    headers={'Content-Type': 'application/json'}
+                    headers=internal_request_headers({'Content-Type': 'application/json'})
             ) as response:
                 if response.status == 200:
                     result = await response.json()
@@ -177,7 +178,7 @@ class PermissionManager:
                 json={"accessor_id": user_id,
                       "resource": {"type": resource_type, "id": resource_id},
                       "operation": operation},
-                headers={'Content-Type': 'application/json'}) as resp:
+                headers=internal_request_headers({'Content-Type': 'application/json'})) as resp:
             data = await resp.json()
             return bool(data.get('allowed', False))
 
@@ -189,7 +190,7 @@ class PermissionManager:
                     json={"accessor_id": user_id,
                           "resource": {"type": resource_type, "id": resource_id},
                           "operations": operations},
-                    headers={'Content-Type': 'application/json'}) as resp:
+                    headers=internal_request_headers({'Content-Type': 'application/json'})) as resp:
                 return resp.status == 204
         except Exception as e:
             StandLogger.error(e.args)
@@ -218,7 +219,7 @@ class PermissionManager:
                 async with session.delete(
                         f"{self.bkn_safe_url}/api/safe/v1/authz/policies",
                         json={"resource": {"type": resource_type, "id": resource_id}},
-                        headers={'Content-Type': 'application/json'}) as resp:
+                        headers=internal_request_headers({'Content-Type': 'application/json'})) as resp:
                     if resp.status != 204:
                         ok = False
             except Exception as e:
@@ -276,7 +277,7 @@ class PermissionManager:
             async with session.post(
                     self.resource_filter_url,
                     json=payload,
-                    headers={'Content-Type': 'application/json'}
+                    headers=internal_request_headers({'Content-Type': 'application/json'})
             ) as response:
                 if response.status == 200:
                     result = await response.json()
@@ -330,7 +331,7 @@ class PermissionManager:
             async with session.post(
                     self.resource_filter_url,
                     json=payload,
-                    headers={'Content-Type': 'application/json'}
+                    headers=internal_request_headers({'Content-Type': 'application/json'})
             ) as response:
                 if response.status == 200:
                     result = await response.json()
@@ -361,7 +362,7 @@ class PermissionManager:
             async with session.post(
                     self.delete_resource_url,
                     json=payload,
-                    headers={"Content-Type": "application/json"}
+                    headers=internal_request_headers({"Content-Type": "application/json"})
             ) as response:
                 if response.status == 204:
                     return True

--- a/infra/mf-model-manager/requirements-test.txt
+++ b/infra/mf-model-manager/requirements-test.txt
@@ -5,7 +5,8 @@
 #
 #   pip install -r requirements-test.txt && pytest app/test
 #
-# No httpx pin needed here: these tests don't use fastapi TestClient (unlike
-# mf-model-api). They drive controllers directly via asyncio event loops.
+# FastAPI TestClient relies on httpx. Pin it below 0.28 to remain compatible
+# with the FastAPI/Starlette versions provided by the model-factory-base image.
 pytest>=7.4
 pytest-asyncio>=0.21
+httpx>=0.24,<0.28


### PR DESCRIPTION
# Pull Request

## What Changed

Brief description of changes:

- [x] Align mf-model-manager with the Accept-Language P0 locale protocol.
- [x] Add request-scoped locale propagation, localized error contracts, cache policy, and OpenAPI declarations.
- [x] Add focused locale, HTTP exception, outbound propagation, and integration tests.

---

## Why

- Related Issue: Closes #858
- Related Feature: Internationalization P0
- Background: mf-model-manager must use the platform's single effective locale for localized errors and internal service calls.

---

## How

- Key implementation points: resolve and freeze Accept-Language at the ASGI boundary; propagate a canonical single locale downstream; localize human-facing errors while preserving stable codes and extensions; preserve stricter cache directives; declare the contract in static and generated OpenAPI.
- Breaking changes (API, config, database, etc.): Error responses that previously used unstructured HTTPException detail text now expose stable operation-audit error codes. No database or configuration migration.

---

## Testing

- [x] Unit tests passed locally
- [ ] Integration tests passed locally (requires the module image's FastAPI, aiohttp, and observability dependencies)
- [ ] Verified in test environment

Test notes:

- `python3 -m unittest app.test.test_locale` passed: 12 tests.
- `python3 -m compileall ...` and `git diff --check` passed.
- `requirements-test.txt` pins `httpx>=0.24,<0.28` for TestClient compatibility.

---

## Risk & Rollback

- Potential risks: expanded error normalization and internal request headers affect mf-model-manager API behavior; full dependency-backed tests remain for CI.
- Rollback plan: revert commit `6c10c00f` or roll back this PR after merge.

---

## Additional Notes

- Screenshots, logs, documentation links, etc.: Static OpenAPI is updated at `docs/api/mf-model-manager/large-model.yaml`.
