### PR TITLE
fix(mf-model-manager): localize missing parameter details

### DIFF
--- a/infra/mf-model-manager/app/commons/i18n/__init__.py
+++ b/infra/mf-model-manager/app/commons/i18n/__init__.py
@@ -19,6 +19,7 @@ async def get_error_message(code: str, lang: str) -> dict:
     message = lookup_error_message(code, lang)
     if message:
         message.pop("detail_template", None)
+        message.pop("detail_template_plural", None)
         return message
     return {
         "code": code,

--- a/infra/mf-model-manager/app/commons/i18n/en_us.py
+++ b/infra/mf-model-manager/app/commons/i18n/en_us.py
@@ -5,8 +5,9 @@ error_messages = {
     ParamValidationErrors.ParamMissing: {
         "code": ParamValidationErrors.ParamMissing,
         "description": "Required parameter is missing.",
-        "detail": "",
+        "detail": "A required request parameter is missing.",
         "detail_template": "Missing required parameter: {parameters}",
+        "detail_template_plural": "Missing required parameters: {parameters}",
         "solution": "Please read the API documentation and pass the correct parameters",
         "link": ""
     },
@@ -22,8 +23,9 @@ error_messages = {
     "ModelFactory.Router.ParamError.ParamMissing": {
         "code": "ModelFactory.Router.ParamError.ParamMissing",
         "description": "Required parameter is missing.",
-        "detail": "",
+        "detail": "A required request parameter is missing.",
         "detail_template": "Missing required parameter: {parameters}",
+        "detail_template_plural": "Missing required parameters: {parameters}",
         "solution": "Please read the API documentation and pass the correct parameters",
         "link": ""
     },

--- a/infra/mf-model-manager/app/commons/i18n/en_us.py
+++ b/infra/mf-model-manager/app/commons/i18n/en_us.py
@@ -6,7 +6,7 @@ error_messages = {
         "code": ParamValidationErrors.ParamMissing,
         "description": "Required parameter is missing.",
         "detail": "",
-        "detail_template": "Missing required parameters: {parameters}",
+        "detail_template": "Missing required parameter: {parameters}",
         "solution": "Please read the API documentation and pass the correct parameters",
         "link": ""
     },
@@ -18,6 +18,14 @@ error_messages = {
         "detail_template": "Parameter type error: {parameters}",
         "link": ""
 
+    },
+    "ModelFactory.Router.ParamError.ParamMissing": {
+        "code": "ModelFactory.Router.ParamError.ParamMissing",
+        "description": "Required parameter is missing.",
+        "detail": "",
+        "detail_template": "Missing required parameter: {parameters}",
+        "solution": "Please read the API documentation and pass the correct parameters",
+        "link": ""
     },
     "ModelFactory.OperationAudit.AccessDenied": {
         "code": "ModelFactory.OperationAudit.AccessDenied",

--- a/infra/mf-model-manager/app/commons/i18n/zh_cn.py
+++ b/infra/mf-model-manager/app/commons/i18n/zh_cn.py
@@ -19,6 +19,14 @@ error_messages = {
         "link": ""
 
     },
+    "ModelFactory.Router.ParamError.ParamMissing": {
+        "code": "ModelFactory.Router.ParamError.ParamMissing",
+        "description": "参数缺失",
+        "detail": "",
+        "detail_template": "缺少必填参数：{parameters}",
+        "solution": "请阅读API文档填写正确的参数",
+        "link": ""
+    },
     "ModelFactory.OperationAudit.AccessDenied": {
         "code": "ModelFactory.OperationAudit.AccessDenied",
         "description": "访问被拒绝。",

--- a/infra/mf-model-manager/app/commons/i18n/zh_cn.py
+++ b/infra/mf-model-manager/app/commons/i18n/zh_cn.py
@@ -5,7 +5,7 @@ error_messages = {
     ParamValidationErrors.ParamMissing: {
         "code": ParamValidationErrors.ParamMissing,
         "description": "参数缺失",
-        "detail": "",
+        "detail": "缺少必填参数。",
         "detail_template": "缺少必填参数：{parameters}",
         "solution": "请阅读API文档填写正确的参数",
         "link": ""
@@ -22,7 +22,7 @@ error_messages = {
     "ModelFactory.Router.ParamError.ParamMissing": {
         "code": "ModelFactory.Router.ParamError.ParamMissing",
         "description": "参数缺失",
-        "detail": "",
+        "detail": "缺少必填参数。",
         "detail_template": "缺少必填参数：{parameters}",
         "solution": "请阅读API文档填写正确的参数",
         "link": ""

--- a/infra/mf-model-manager/app/commons/locale.py
+++ b/infra/mf-model-manager/app/commons/locale.py
@@ -102,11 +102,25 @@ def is_authenticated_public_api_path(path: str) -> bool:
 
 def _localize_detail(message: Dict[str, Any], detail: Any) -> Any:
     template = message.get("detail_template")
-    if template and isinstance(detail, str):
-        _, separator, parameter_names = detail.partition(":")
-        if separator and parameter_names.strip():
-            return template.format(parameters=parameter_names.strip())
+    parameter_names = _parameter_names_from_detail(detail)
+    if template and parameter_names:
+        return template.format(parameters=parameter_names)
     return message.get("detail") or detail
+
+
+def _parameter_names_from_detail(detail: Any) -> str:
+    if not isinstance(detail, str):
+        return ""
+
+    value = detail.strip()
+    _, separator, parameter_names = value.partition(":")
+    if separator and parameter_names.strip():
+        return parameter_names.strip()
+
+    for suffix in (" 参数缺失", " 参数类型错误"):
+        if value.endswith(suffix):
+            return value[:-len(suffix)].strip()
+    return ""
 
 
 def _contains_chinese(value: Any) -> bool:

--- a/infra/mf-model-manager/app/commons/locale.py
+++ b/infra/mf-model-manager/app/commons/locale.py
@@ -104,6 +104,8 @@ def _localize_detail(message: Dict[str, Any], detail: Any) -> Any:
     template = message.get("detail_template")
     parameter_names = _parameter_names_from_detail(detail)
     if template and parameter_names:
+        if _contains_multiple_parameter_names(parameter_names):
+            template = message.get("detail_template_plural", template)
         return template.format(parameters=parameter_names)
     return message.get("detail") or detail
 
@@ -117,10 +119,14 @@ def _parameter_names_from_detail(detail: Any) -> str:
     if separator and parameter_names.strip():
         return parameter_names.strip()
 
-    for suffix in (" 参数缺失", " 参数类型错误"):
+    for suffix in ("参数缺失", "参数类型错误"):
         if value.endswith(suffix):
-            return value[:-len(suffix)].strip()
+            return value[:-len(suffix)].strip(" :：")
     return ""
+
+
+def _contains_multiple_parameter_names(parameter_names: str) -> bool:
+    return len([name for name in parameter_names.split(",") if name.strip()]) > 1
 
 
 def _contains_chinese(value: Any) -> bool:

--- a/infra/mf-model-manager/app/test/test_locale.py
+++ b/infra/mf-model-manager/app/test/test_locale.py
@@ -61,6 +61,20 @@ class TestAcceptLanguageResolver(unittest.TestCase):
         self.assertEqual(localized["description"], "Required parameter is missing.")
         self.assertEqual(localized["detail"], "Missing required parameter: max_model_len")
 
+    def test_uses_plural_template_for_multiple_missing_parameters(self):
+        localized, _ = localized_error_content(
+            {
+                "code": ParamValidationErrors.ParamMissing,
+                "description": "参数缺失",
+                "detail": "missing parameters: max_model_len, model_name",
+                "solution": "请检查参数",
+                "link": "",
+            },
+            "en-US",
+        )
+
+        self.assertEqual(localized["detail"], "Missing required parameters: max_model_len, model_name")
+
     def test_localizes_fastapi_missing_parameter_detail(self):
         content = {
             "code": "ModelFactory.Router.ParamError.ParamMissing",
@@ -77,6 +91,22 @@ class TestAcceptLanguageResolver(unittest.TestCase):
         self.assertEqual(english["description"], "Required parameter is missing.")
         self.assertEqual(english["detail"], "Missing required parameter: page")
         self.assertEqual(chinese["detail"], "缺少必填参数：page")
+
+    def test_localizes_fastapi_missing_body_without_chinese_detail(self):
+        content = {
+            "code": "ModelFactory.Router.ParamError.ParamMissing",
+            "description": "参数缺失",
+            "detail": "参数缺失",
+            "solution": "请检查填写的参数是否正确。",
+            "link": "",
+        }
+
+        english, is_localized = localized_error_content(content, "en-US")
+        chinese, _ = localized_error_content(content, "zh-CN")
+
+        self.assertTrue(is_localized)
+        self.assertEqual(english["detail"], "A required request parameter is missing.")
+        self.assertEqual(chinese["detail"], "缺少必填参数。")
 
     def test_localizes_dynamic_parameter_type_detail_in_chinese(self):
         localized, is_localized = localized_error_content(
@@ -97,7 +127,8 @@ class TestAcceptLanguageResolver(unittest.TestCase):
         message = asyncio.run(get_error_message(ParamValidationErrors.ParamMissing, "zh-CN"))
 
         self.assertNotIn("detail_template", message)
-        self.assertEqual(message["detail"], "")
+        self.assertNotIn("detail_template_plural", message)
+        self.assertEqual(message["detail"], "缺少必填参数。")
 
     def test_uses_request_scoped_locale_instead_of_the_raw_header(self):
         class State:

--- a/infra/mf-model-manager/app/test/test_locale.py
+++ b/infra/mf-model-manager/app/test/test_locale.py
@@ -59,7 +59,24 @@ class TestAcceptLanguageResolver(unittest.TestCase):
 
         self.assertTrue(is_localized)
         self.assertEqual(localized["description"], "Required parameter is missing.")
-        self.assertEqual(localized["detail"], "Missing required parameters: max_model_len")
+        self.assertEqual(localized["detail"], "Missing required parameter: max_model_len")
+
+    def test_localizes_fastapi_missing_parameter_detail(self):
+        content = {
+            "code": "ModelFactory.Router.ParamError.ParamMissing",
+            "description": "参数缺失",
+            "detail": "page 参数缺失",
+            "solution": "请检查填写的参数是否正确。",
+            "link": "",
+        }
+
+        english, is_localized = localized_error_content(content, "en-US")
+        chinese, _ = localized_error_content(content, "zh-CN")
+
+        self.assertTrue(is_localized)
+        self.assertEqual(english["description"], "Required parameter is missing.")
+        self.assertEqual(english["detail"], "Missing required parameter: page")
+        self.assertEqual(chinese["detail"], "缺少必填参数：page")
 
     def test_localizes_dynamic_parameter_type_detail_in_chinese(self):
         localized, is_localized = localized_error_content(


### PR DESCRIPTION
# Pull Request

## What Changed

Brief description of changes:

- [x] Register the FastAPI missing-parameter error code in the English and Chinese locale catalogs.
- [x] Preserve the missing parameter name when rendering localized error detail.
- [x] Add regression coverage for the page parameter validation response.
- [ ] Docs/doc 1: Not applicable; no API contract or machine-field change.

---

## Why

- Related Issue: Closes #858 (runtime-validation follow-up).
- Related Feature: P0 Accept-Language internationalization.
- Background: authenticated validation found that the FastAPI missing-parameter code missed the locale catalog and returned a generic English detail.

---

## How

- Key implementation points: add catalog entries for ModelFactory.Router.ParamError.ParamMissing and extract parameter names from both colon-delimited and existing Chinese detail formats.
- Breaking changes (API, config, database, etc.): None. HTTP status and code remain unchanged.

---

## Testing

- [x] Unit tests passed locally
- [ ] Integration tests passed locally: Not run; local environment lacks the full service dependency stack.
- [ ] Verified in test environment: Pending image release and deployment.

Test notes: python3 -m unittest app.test.test_locale (17 tests passed); git diff --check passed.

---

## Risk & Rollback

- Potential risks: localized dynamic detail text only; machine fields and behavior are unchanged.
- Rollback plan: revert commit 7f802de2.

---

## Additional Notes

- Screenshots, logs, documentation links, etc.: The issue was observed in 132 runtime validation using a missing page parameter.