### PR TITLE
fix(vega): preserve semantic metadata during build

### DIFF
--- a/adp/vega/vega-backend/server/drivenadapters/resource/resource_access.go
+++ b/adp/vega/vega-backend/server/drivenadapters/resource/resource_access.go
@@ -929,6 +929,49 @@ func (ra *resourceAccess) UpdateLocalIndexName(ctx context.Context, tx *sql.Tx, 
 	return nil
 }
 
+// UpdateSemanticMetadata updates only fields owned by semantic understanding so
+// a stale semantic snapshot cannot overwrite a local index name written by build.
+func (ra *resourceAccess) UpdateSemanticMetadata(ctx context.Context, tx *sql.Tx, resource *interfaces.Resource) error {
+	ctx, span := oteltrace.StartNamedClientSpan(ctx, "Update resource semantic metadata")
+	defer span.End()
+
+	span.SetAttributes(attr.Key("resource_id").String(resource.ID))
+	schemaDefinitionBytes, err := sonic.Marshal(resource.SchemaDefinition)
+	if err != nil {
+		span.SetStatus(codes.Error, "Marshal schema definition failed")
+		return err
+	}
+	if resource.SchemaDefinition == nil {
+		schemaDefinitionBytes = []byte("[]")
+	}
+	sqlStr, vals, err := sq.Update(RESOURCE_TABLE_NAME).
+		Set("f_name", resource.Name).
+		Set("f_description", resource.Description).
+		Set("f_schema_definition", string(schemaDefinitionBytes)).
+		Set("f_updater", resource.Updater.ID).
+		Set("f_updater_type", resource.Updater.Type).
+		Set("f_update_time", resource.UpdateTime).
+		Where(sq.Eq{"f_id": resource.ID}).
+		ToSql()
+	if err != nil {
+		span.SetStatus(codes.Error, "Build sql failed")
+		return err
+	}
+
+	if tx != nil {
+		_, err = tx.ExecContext(ctx, sqlStr, vals...)
+	} else {
+		_, err = ra.db.ExecContext(ctx, sqlStr, vals...)
+	}
+	if err != nil {
+		span.SetStatus(codes.Error, "Update failed")
+		return err
+	}
+
+	span.SetStatus(codes.Ok, "")
+	return nil
+}
+
 // GetByCatalogID retrieves all Resources under a Catalog.
 func (ra *resourceAccess) GetByCatalogID(ctx context.Context, catalogID string) ([]*interfaces.Resource, error) {
 	ctx, span := oteltrace.StartNamedClientSpan(ctx, "Query resources by catalog ID")

--- a/adp/vega/vega-backend/server/drivenadapters/resource/resource_access.go
+++ b/adp/vega/vega-backend/server/drivenadapters/resource/resource_access.go
@@ -899,6 +899,36 @@ func (ra *resourceAccess) Update(ctx context.Context, tx *sql.Tx, resource *inte
 	return nil
 }
 
+// UpdateLocalIndexName updates only the local index name so asynchronous build
+// completion cannot overwrite metadata changed after the build task started.
+func (ra *resourceAccess) UpdateLocalIndexName(ctx context.Context, tx *sql.Tx, id, localIndexName string) error {
+	ctx, span := oteltrace.StartNamedClientSpan(ctx, "Update resource local index name")
+	defer span.End()
+
+	span.SetAttributes(attr.Key("resource_id").String(id))
+	sqlStr, vals, err := sq.Update(RESOURCE_TABLE_NAME).
+		Set("f_local_index_name", localIndexName).
+		Where(sq.Eq{"f_id": id}).
+		ToSql()
+	if err != nil {
+		span.SetStatus(codes.Error, "Build sql failed")
+		return err
+	}
+
+	if tx != nil {
+		_, err = tx.ExecContext(ctx, sqlStr, vals...)
+	} else {
+		_, err = ra.db.ExecContext(ctx, sqlStr, vals...)
+	}
+	if err != nil {
+		span.SetStatus(codes.Error, "Update failed")
+		return err
+	}
+
+	span.SetStatus(codes.Ok, "")
+	return nil
+}
+
 // GetByCatalogID retrieves all Resources under a Catalog.
 func (ra *resourceAccess) GetByCatalogID(ctx context.Context, catalogID string) ([]*interfaces.Resource, error) {
 	ctx, span := oteltrace.StartNamedClientSpan(ctx, "Query resources by catalog ID")
@@ -1001,16 +1031,8 @@ func (ra *resourceAccess) GetByCatalogID(ctx context.Context, catalogID string) 
 	return resources, nil
 }
 
-// UpdateStatus updates a Resource's status.
-func (ra *resourceAccess) UpdateStatus(ctx context.Context, id string, status string, statusMessage string) error {
-	return ra.updateStatus(ctx, nil, id, status, statusMessage)
-}
-
-func (ra *resourceAccess) UpdateStatusWithTx(ctx context.Context, tx *sql.Tx, id string, status string, statusMessage string) error {
-	return ra.updateStatus(ctx, tx, id, status, statusMessage)
-}
-
-func (ra *resourceAccess) updateStatus(ctx context.Context, tx *sql.Tx, id string, status string, statusMessage string) error {
+// UpdateStatus updates a Resource's status, using tx when provided.
+func (ra *resourceAccess) UpdateStatus(ctx context.Context, tx *sql.Tx, id string, status string, statusMessage string) error {
 	ctx, span := oteltrace.StartNamedClientSpan(ctx, "Update resource status")
 	defer span.End()
 

--- a/adp/vega/vega-backend/server/drivenadapters/resource/resource_access_test.go
+++ b/adp/vega/vega-backend/server/drivenadapters/resource/resource_access_test.go
@@ -383,6 +383,47 @@ func TestResourceAccessUpdateLocalIndexName(t *testing.T) {
 	})
 }
 
+func TestResourceAccessUpdateSemanticMetadata(t *testing.T) {
+	t.Run("updates only semantic metadata", func(t *testing.T) {
+		access, mock, cleanup := newResourceAccessMock(t)
+		defer cleanup()
+		resource := sampleResource()
+		resource.LocalIndexName = "vega-build-resource-1-task-1"
+
+		mock.ExpectExec(regexp.QuoteMeta("UPDATE t_resource SET f_name = ?, f_description = ?, f_schema_definition = ?, f_updater = ?, f_updater_type = ?, f_update_time = ? WHERE f_id = ?")).
+			WithArgs(
+				resource.Name,
+				resource.Description,
+				`[{"name":"id","display_name":"","type":"integer","description":"","original_name":"","original_type":"","original_description":"","features":null,"attributes":null}]`,
+				resource.Updater.ID,
+				resource.Updater.Type,
+				resource.UpdateTime,
+				resource.ID,
+			).
+			WillReturnResult(sqlmock.NewResult(0, 1))
+
+		require.NoError(t, access.UpdateSemanticMetadata(context.Background(), nil, resource))
+		require.NoError(t, mock.ExpectationsWereMet())
+	})
+
+	t.Run("updates semantic metadata in transaction", func(t *testing.T) {
+		access, mock, cleanup := newResourceAccessMock(t)
+		defer cleanup()
+		resource := sampleResource()
+
+		mock.ExpectBegin()
+		tx, err := access.db.BeginTx(context.Background(), nil)
+		require.NoError(t, err)
+		mock.ExpectExec(regexp.QuoteMeta("UPDATE t_resource SET f_name = ?, f_description = ?, f_schema_definition = ?, f_updater = ?, f_updater_type = ?, f_update_time = ? WHERE f_id = ?")).
+			WillReturnResult(sqlmock.NewResult(0, 1))
+
+		require.NoError(t, access.UpdateSemanticMetadata(context.Background(), tx, resource))
+		mock.ExpectCommit()
+		require.NoError(t, tx.Commit())
+		require.NoError(t, mock.ExpectationsWereMet())
+	})
+}
+
 func TestResourceAccessAttachListExtensions(t *testing.T) {
 	t.Run("skips empty resources", func(t *testing.T) {
 		access, _, cleanup := newResourceAccessMock(t)

--- a/adp/vega/vega-backend/server/drivenadapters/resource/resource_access_test.go
+++ b/adp/vega/vega-backend/server/drivenadapters/resource/resource_access_test.go
@@ -352,6 +352,37 @@ func TestResourceAccessUpdate(t *testing.T) {
 	})
 }
 
+func TestResourceAccessUpdateLocalIndexName(t *testing.T) {
+	t.Run("updates only local index name", func(t *testing.T) {
+		access, mock, cleanup := newResourceAccessMock(t)
+		defer cleanup()
+
+		mock.ExpectExec(regexp.QuoteMeta("UPDATE t_resource SET f_local_index_name = ? WHERE f_id = ?")).
+			WithArgs("vega-build-resource-1-task-1", "resource-1").
+			WillReturnResult(sqlmock.NewResult(0, 1))
+
+		require.NoError(t, access.UpdateLocalIndexName(context.Background(), nil, "resource-1", "vega-build-resource-1-task-1"))
+		require.NoError(t, mock.ExpectationsWereMet())
+	})
+
+	t.Run("updates local index name in transaction", func(t *testing.T) {
+		access, mock, cleanup := newResourceAccessMock(t)
+		defer cleanup()
+
+		mock.ExpectBegin()
+		tx, err := access.db.BeginTx(context.Background(), nil)
+		require.NoError(t, err)
+		mock.ExpectExec(regexp.QuoteMeta("UPDATE t_resource SET f_local_index_name = ? WHERE f_id = ?")).
+			WithArgs("vega-build-resource-1-task-1", "resource-1").
+			WillReturnResult(sqlmock.NewResult(0, 1))
+
+		require.NoError(t, access.UpdateLocalIndexName(context.Background(), tx, "resource-1", "vega-build-resource-1-task-1"))
+		mock.ExpectCommit()
+		require.NoError(t, tx.Commit())
+		require.NoError(t, mock.ExpectationsWereMet())
+	})
+}
+
 func TestResourceAccessAttachListExtensions(t *testing.T) {
 	t.Run("skips empty resources", func(t *testing.T) {
 		access, _, cleanup := newResourceAccessMock(t)
@@ -519,7 +550,24 @@ func TestResourceAccessUpdateStatus(t *testing.T) {
 			WithArgs(interfaces.ResourceStatusDisabled, "manual", "resource-1").
 			WillReturnResult(sqlmock.NewResult(0, 1))
 
-		require.NoError(t, access.UpdateStatus(context.Background(), "resource-1", interfaces.ResourceStatusDisabled, "manual"))
+		require.NoError(t, access.UpdateStatus(context.Background(), nil, "resource-1", interfaces.ResourceStatusDisabled, "manual"))
+		require.NoError(t, mock.ExpectationsWereMet())
+	})
+
+	t.Run("updates status in transaction", func(t *testing.T) {
+		access, mock, cleanup := newResourceAccessMock(t)
+		defer cleanup()
+
+		mock.ExpectBegin()
+		tx, err := access.db.BeginTx(context.Background(), nil)
+		require.NoError(t, err)
+		mock.ExpectExec(regexp.QuoteMeta("UPDATE t_resource SET f_status = ?, f_status_message = ? WHERE f_id = ?")).
+			WithArgs(interfaces.ResourceStatusDisabled, "manual", "resource-1").
+			WillReturnResult(sqlmock.NewResult(0, 1))
+
+		require.NoError(t, access.UpdateStatus(context.Background(), tx, "resource-1", interfaces.ResourceStatusDisabled, "manual"))
+		mock.ExpectCommit()
+		require.NoError(t, tx.Commit())
 		require.NoError(t, mock.ExpectationsWereMet())
 	})
 }

--- a/adp/vega/vega-backend/server/interfaces/mock/mock_resource_access.go
+++ b/adp/vega/vega-backend/server/interfaces/mock/mock_resource_access.go
@@ -262,30 +262,30 @@ func (mr *MockResourceAccessMockRecorder) UpdateDiscoverStatus(ctx, id, status a
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateDiscoverStatus", reflect.TypeOf((*MockResourceAccess)(nil).UpdateDiscoverStatus), ctx, id, status)
 }
 
-// UpdateStatus mocks base method.
-func (m *MockResourceAccess) UpdateStatus(ctx context.Context, id, status, statusMessage string) error {
+// UpdateLocalIndexName mocks base method.
+func (m *MockResourceAccess) UpdateLocalIndexName(ctx context.Context, tx *sql.Tx, id, localIndexName string) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "UpdateStatus", ctx, id, status, statusMessage)
+	ret := m.ctrl.Call(m, "UpdateLocalIndexName", ctx, tx, id, localIndexName)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// UpdateLocalIndexName indicates an expected call of UpdateLocalIndexName.
+func (mr *MockResourceAccessMockRecorder) UpdateLocalIndexName(ctx, tx, id, localIndexName any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateLocalIndexName", reflect.TypeOf((*MockResourceAccess)(nil).UpdateLocalIndexName), ctx, tx, id, localIndexName)
+}
+
+// UpdateStatus mocks base method.
+func (m *MockResourceAccess) UpdateStatus(ctx context.Context, tx *sql.Tx, id, status, statusMessage string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "UpdateStatus", ctx, tx, id, status, statusMessage)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // UpdateStatus indicates an expected call of UpdateStatus.
-func (mr *MockResourceAccessMockRecorder) UpdateStatus(ctx, id, status, statusMessage any) *gomock.Call {
+func (mr *MockResourceAccessMockRecorder) UpdateStatus(ctx, tx, id, status, statusMessage any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateStatus", reflect.TypeOf((*MockResourceAccess)(nil).UpdateStatus), ctx, id, status, statusMessage)
-}
-
-// UpdateStatusWithTx mocks base method.
-func (m *MockResourceAccess) UpdateStatusWithTx(ctx context.Context, tx *sql.Tx, id, status, statusMessage string) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "UpdateStatusWithTx", ctx, tx, id, status, statusMessage)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// UpdateStatusWithTx indicates an expected call of UpdateStatusWithTx.
-func (mr *MockResourceAccessMockRecorder) UpdateStatusWithTx(ctx, tx, id, status, statusMessage any) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateStatusWithTx", reflect.TypeOf((*MockResourceAccess)(nil).UpdateStatusWithTx), ctx, tx, id, status, statusMessage)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateStatus", reflect.TypeOf((*MockResourceAccess)(nil).UpdateStatus), ctx, tx, id, status, statusMessage)
 }

--- a/adp/vega/vega-backend/server/interfaces/mock/mock_resource_access.go
+++ b/adp/vega/vega-backend/server/interfaces/mock/mock_resource_access.go
@@ -276,6 +276,20 @@ func (mr *MockResourceAccessMockRecorder) UpdateLocalIndexName(ctx, tx, id, loca
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateLocalIndexName", reflect.TypeOf((*MockResourceAccess)(nil).UpdateLocalIndexName), ctx, tx, id, localIndexName)
 }
 
+// UpdateSemanticMetadata mocks base method.
+func (m *MockResourceAccess) UpdateSemanticMetadata(ctx context.Context, tx *sql.Tx, resource *interfaces.Resource) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "UpdateSemanticMetadata", ctx, tx, resource)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// UpdateSemanticMetadata indicates an expected call of UpdateSemanticMetadata.
+func (mr *MockResourceAccessMockRecorder) UpdateSemanticMetadata(ctx, tx, resource any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateSemanticMetadata", reflect.TypeOf((*MockResourceAccess)(nil).UpdateSemanticMetadata), ctx, tx, resource)
+}
+
 // UpdateStatus mocks base method.
 func (m *MockResourceAccess) UpdateStatus(ctx context.Context, tx *sql.Tx, id, status, statusMessage string) error {
 	m.ctrl.T.Helper()

--- a/adp/vega/vega-backend/server/interfaces/mock/mock_resource_service.go
+++ b/adp/vega/vega-backend/server/interfaces/mock/mock_resource_service.go
@@ -250,6 +250,20 @@ func (mr *MockResourceServiceMockRecorder) InternalUpdate(ctx, tx, resource any)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "InternalUpdate", reflect.TypeOf((*MockResourceService)(nil).InternalUpdate), ctx, tx, resource)
 }
 
+// InternalUpdateLocalIndexName mocks base method.
+func (m *MockResourceService) InternalUpdateLocalIndexName(ctx context.Context, tx *sql.Tx, id, localIndexName string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "InternalUpdateLocalIndexName", ctx, tx, id, localIndexName)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// InternalUpdateLocalIndexName indicates an expected call of InternalUpdateLocalIndexName.
+func (mr *MockResourceServiceMockRecorder) InternalUpdateLocalIndexName(ctx, tx, id, localIndexName any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "InternalUpdateLocalIndexName", reflect.TypeOf((*MockResourceService)(nil).InternalUpdateLocalIndexName), ctx, tx, id, localIndexName)
+}
+
 // InternalUpdateStatus mocks base method.
 func (m *MockResourceService) InternalUpdateStatus(ctx context.Context, tx *sql.Tx, id, status, statusMessage string) error {
 	m.ctrl.T.Helper()

--- a/adp/vega/vega-backend/server/interfaces/mock/mock_resource_service.go
+++ b/adp/vega/vega-backend/server/interfaces/mock/mock_resource_service.go
@@ -264,6 +264,20 @@ func (mr *MockResourceServiceMockRecorder) InternalUpdateLocalIndexName(ctx, tx,
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "InternalUpdateLocalIndexName", reflect.TypeOf((*MockResourceService)(nil).InternalUpdateLocalIndexName), ctx, tx, id, localIndexName)
 }
 
+// InternalUpdateSemanticMetadata mocks base method.
+func (m *MockResourceService) InternalUpdateSemanticMetadata(ctx context.Context, tx *sql.Tx, resource *interfaces.Resource) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "InternalUpdateSemanticMetadata", ctx, tx, resource)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// InternalUpdateSemanticMetadata indicates an expected call of InternalUpdateSemanticMetadata.
+func (mr *MockResourceServiceMockRecorder) InternalUpdateSemanticMetadata(ctx, tx, resource any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "InternalUpdateSemanticMetadata", reflect.TypeOf((*MockResourceService)(nil).InternalUpdateSemanticMetadata), ctx, tx, resource)
+}
+
 // InternalUpdateStatus mocks base method.
 func (m *MockResourceService) InternalUpdateStatus(ctx context.Context, tx *sql.Tx, id, status, statusMessage string) error {
 	m.ctrl.T.Helper()

--- a/adp/vega/vega-backend/server/interfaces/resource_access.go
+++ b/adp/vega/vega-backend/server/interfaces/resource_access.go
@@ -35,10 +35,10 @@ type ResourceAccess interface {
 	ListIDs(ctx context.Context, params ResourcesQueryParams) ([]string, error)
 	// Update updates a Resource.
 	Update(ctx context.Context, tx *sql.Tx, resource *Resource) error
-	// UpdateStatus updates a Resource's status.
-	UpdateStatus(ctx context.Context, id string, status string, statusMessage string) error
-	// UpdateStatusWithTx updates a Resource's status within a transaction.
-	UpdateStatusWithTx(ctx context.Context, tx *sql.Tx, id string, status string, statusMessage string) error
+	// UpdateLocalIndexName updates only a Resource's local index name.
+	UpdateLocalIndexName(ctx context.Context, tx *sql.Tx, id, localIndexName string) error
+	// UpdateStatus updates a Resource's status, using tx when provided.
+	UpdateStatus(ctx context.Context, tx *sql.Tx, id string, status string, statusMessage string) error
 	// UpdateDiscoverStatus updates a Resource's last discover status.
 	UpdateDiscoverStatus(ctx context.Context, id string, status string) error
 	// DeleteByIDs deletes Resources by IDs.

--- a/adp/vega/vega-backend/server/interfaces/resource_access.go
+++ b/adp/vega/vega-backend/server/interfaces/resource_access.go
@@ -37,6 +37,8 @@ type ResourceAccess interface {
 	Update(ctx context.Context, tx *sql.Tx, resource *Resource) error
 	// UpdateLocalIndexName updates only a Resource's local index name.
 	UpdateLocalIndexName(ctx context.Context, tx *sql.Tx, id, localIndexName string) error
+	// UpdateSemanticMetadata updates only Resource metadata owned by semantic understanding.
+	UpdateSemanticMetadata(ctx context.Context, tx *sql.Tx, resource *Resource) error
 	// UpdateStatus updates a Resource's status, using tx when provided.
 	UpdateStatus(ctx context.Context, tx *sql.Tx, id string, status string, statusMessage string) error
 	// UpdateDiscoverStatus updates a Resource's last discover status.

--- a/adp/vega/vega-backend/server/interfaces/resource_service.go
+++ b/adp/vega/vega-backend/server/interfaces/resource_service.go
@@ -57,6 +57,8 @@ type ResourceService interface {
 	InternalGetByCatalogID(ctx context.Context, catalogID string) ([]*Resource, error)
 	// InternalUpdate updates a Resource for internal workers.
 	InternalUpdate(ctx context.Context, tx *sql.Tx, resource *Resource) error
+	// InternalUpdateLocalIndexName updates only a Resource's local index name for internal workers.
+	InternalUpdateLocalIndexName(ctx context.Context, tx *sql.Tx, id, localIndexName string) error
 	// InternalCreate creates a Resource for internal workers within a transaction.
 	InternalCreate(ctx context.Context, tx *sql.Tx, req *ResourceRequest) (*Resource, error)
 	// InternalUpdateStatus updates a Resource status for internal workers within a transaction.

--- a/adp/vega/vega-backend/server/interfaces/resource_service.go
+++ b/adp/vega/vega-backend/server/interfaces/resource_service.go
@@ -59,6 +59,8 @@ type ResourceService interface {
 	InternalUpdate(ctx context.Context, tx *sql.Tx, resource *Resource) error
 	// InternalUpdateLocalIndexName updates only a Resource's local index name for internal workers.
 	InternalUpdateLocalIndexName(ctx context.Context, tx *sql.Tx, id, localIndexName string) error
+	// InternalUpdateSemanticMetadata updates only Resource metadata owned by semantic understanding.
+	InternalUpdateSemanticMetadata(ctx context.Context, tx *sql.Tx, resource *Resource) error
 	// InternalCreate creates a Resource for internal workers within a transaction.
 	InternalCreate(ctx context.Context, tx *sql.Tx, req *ResourceRequest) (*Resource, error)
 	// InternalUpdateStatus updates a Resource status for internal workers within a transaction.

--- a/adp/vega/vega-backend/server/logics/resource/resource_service.go
+++ b/adp/vega/vega-backend/server/logics/resource/resource_service.go
@@ -980,6 +980,13 @@ func (rs *resourceService) InternalUpdateLocalIndexName(ctx context.Context, tx 
 	return rs.ra.UpdateLocalIndexName(ctx, tx, id, localIndexName)
 }
 
+func (rs *resourceService) InternalUpdateSemanticMetadata(ctx context.Context, tx *sql.Tx, resource *interfaces.Resource) error {
+	ctx, span := oteltrace.StartNamedInternalSpan(ctx, "ResourceService.InternalUpdateSemanticMetadata")
+	defer span.End()
+
+	return rs.ra.UpdateSemanticMetadata(ctx, tx, resource)
+}
+
 func (rs *resourceService) InternalCreate(ctx context.Context, tx *sql.Tx, req *interfaces.ResourceRequest) (*interfaces.Resource, error) {
 	if tx == nil {
 		return nil, fmt.Errorf("transaction is required")

--- a/adp/vega/vega-backend/server/logics/resource/resource_service.go
+++ b/adp/vega/vega-backend/server/logics/resource/resource_service.go
@@ -809,7 +809,7 @@ func (rs *resourceService) UpdateStatus(ctx context.Context, id string, status s
 	ctx, span := oteltrace.StartNamedInternalSpan(ctx, "Update resource status")
 	defer span.End()
 
-	if err := rs.ra.UpdateStatus(ctx, id, status, statusMessage); err != nil {
+	if err := rs.ra.UpdateStatus(ctx, nil, id, status, statusMessage); err != nil {
 		span.SetStatus(codes.Error, "Update resource status failed")
 		return rest.NewHTTPError(ctx, http.StatusInternalServerError, verrors.VegaBackend_Resource_InternalError_UpdateFailed).
 			WithErrorDetails(err.Error())
@@ -973,6 +973,13 @@ func (rs *resourceService) InternalUpdate(ctx context.Context, tx *sql.Tx, resou
 	return rs.ra.Update(ctx, tx, resource)
 }
 
+func (rs *resourceService) InternalUpdateLocalIndexName(ctx context.Context, tx *sql.Tx, id, localIndexName string) error {
+	ctx, span := oteltrace.StartNamedInternalSpan(ctx, "ResourceService.InternalUpdateLocalIndexName")
+	defer span.End()
+
+	return rs.ra.UpdateLocalIndexName(ctx, tx, id, localIndexName)
+}
+
 func (rs *resourceService) InternalCreate(ctx context.Context, tx *sql.Tx, req *interfaces.ResourceRequest) (*interfaces.Resource, error) {
 	if tx == nil {
 		return nil, fmt.Errorf("transaction is required")
@@ -1028,7 +1035,7 @@ func (rs *resourceService) InternalUpdateStatus(ctx context.Context, tx *sql.Tx,
 	if tx == nil {
 		return fmt.Errorf("transaction is required")
 	}
-	return rs.ra.UpdateStatusWithTx(ctx, tx, id, status, statusMessage)
+	return rs.ra.UpdateStatus(ctx, tx, id, status, statusMessage)
 }
 
 func (rs *resourceService) rejectBuildRelevantUpdateWhenActiveBuildTask(ctx context.Context, resource *interfaces.Resource) error {

--- a/adp/vega/vega-backend/server/logics/resource/resource_service_test.go
+++ b/adp/vega/vega-backend/server/logics/resource/resource_service_test.go
@@ -801,7 +801,7 @@ func TestResourceServiceDeleteByIDs(t *testing.T) {
 func TestResourceServiceUpdateStatus(t *testing.T) {
 	t.Run("update status success", func(t *testing.T) {
 		rs, mockRA, _, _, _, _, _ := newTestService(t)
-		mockRA.EXPECT().UpdateStatus(gomock.Any(), "r1", "active", "").Return(nil)
+		mockRA.EXPECT().UpdateStatus(gomock.Any(), nil, "r1", "active", "").Return(nil)
 
 		err := rs.UpdateStatus(context.Background(), "r1", "active", "")
 		if err != nil {
@@ -810,7 +810,7 @@ func TestResourceServiceUpdateStatus(t *testing.T) {
 	})
 	t.Run("update status error", func(t *testing.T) {
 		rs, mockRA, _, _, _, _, _ := newTestService(t)
-		mockRA.EXPECT().UpdateStatus(gomock.Any(), "r1", "active", "").
+		mockRA.EXPECT().UpdateStatus(gomock.Any(), nil, "r1", "active", "").
 			Return(fmt.Errorf("db error"))
 
 		err := rs.UpdateStatus(context.Background(), "r1", "active", "")

--- a/adp/vega/vega-backend/server/worker/build_task_common.go
+++ b/adp/vega/vega-backend/server/worker/build_task_common.go
@@ -55,21 +55,14 @@ func getNewDocID(primaryKeyValues []interfaces.KeyValue, document map[string]any
 
 // updateResourceIndexName updates the index name of a resource
 func updateResourceIndexName(ctx context.Context, resource *interfaces.Resource, rs interfaces.ResourceService, indexName string) error {
-	if resource.LocalIndexName == "" {
-		resource.LocalIndexName = indexName
-		return rs.InternalUpdate(ctx, nil, resource)
-	}
-
 	if resource.LocalIndexName == indexName {
 		return nil
 	}
 
-	oldIndexName := resource.LocalIndexName
-	resource.LocalIndexName = indexName
-	if err := rs.InternalUpdate(ctx, nil, resource); err != nil {
-		resource.LocalIndexName = oldIndexName
+	if err := rs.InternalUpdateLocalIndexName(ctx, nil, resource.ID, indexName); err != nil {
 		return err
 	}
+	resource.LocalIndexName = indexName
 
 	return nil
 }
@@ -92,11 +85,10 @@ func completeBuildTaskWithoutEmbedding(ctx context.Context, resource *interfaces
 
 	oldIndexName := resource.LocalIndexName
 	if resource.LocalIndexName != indexName {
-		resource.LocalIndexName = indexName
-		if err := rs.InternalUpdate(ctx, tx, resource); err != nil {
-			resource.LocalIndexName = oldIndexName
+		if err := rs.InternalUpdateLocalIndexName(ctx, tx, resource.ID, indexName); err != nil {
 			return fmt.Errorf("update resource index name: %w", err)
 		}
+		resource.LocalIndexName = indexName
 	}
 
 	completed, err := bts.InternalMarkCompleted(ctx, tx, taskID)

--- a/adp/vega/vega-backend/server/worker/build_task_common_test.go
+++ b/adp/vega/vega-backend/server/worker/build_task_common_test.go
@@ -122,25 +122,10 @@ func TestCompleteBuildTaskWithoutEmbedding(t *testing.T) {
 		require.NoError(t, mock.ExpectationsWereMet())
 	})
 
-	t.Run("preserves semantic metadata when build completes from stale snapshot", func(t *testing.T) {
+	t.Run("does not write stale resource snapshot when build completes", func(t *testing.T) {
 		ctrl := gomock.NewController(t)
 		rs := vmock.NewMockResourceService(ctrl)
 		ts := vmock.NewMockBuildTaskService(ctrl)
-		catalogResource := &interfaces.Resource{
-			ID:               "r1",
-			Name:             "supply_chain.material_entity",
-			SourceIdentifier: "supply_chain.material_entity",
-			Description:      "source material description",
-			SourceMetadata: map[string]any{
-				"original_description": "source material description",
-			},
-			SchemaDefinition: []*interfaces.Property{{
-				Name:                "material_id",
-				DisplayName:         "material_id",
-				Description:         "source material identifier",
-				OriginalDescription: "source material identifier",
-			}},
-		}
 		staleBuildResource := &interfaces.Resource{
 			ID:               "r1",
 			Name:             "supply_chain.material_entity",
@@ -153,18 +138,6 @@ func TestCompleteBuildTaskWithoutEmbedding(t *testing.T) {
 				OriginalDescription: "source material identifier",
 			}},
 		}
-		semanticWorker := &SemanticUnderstandingTaskWorker{rs: rs}
-		semanticTask := &interfaces.SemanticUnderstandingTask{
-			ResourceID:          "r1",
-			ApplyMode:           interfaces.SemanticUnderstandingApplyModeFillEmpty,
-			ConfidenceThreshold: 0.75,
-		}
-
-		rs.EXPECT().GetByID(gomock.Any(), "r1").Return(catalogResource, nil)
-		rs.EXPECT().UpdateResource(gomock.Any(), catalogResource).Return(nil)
-		applied, err := semanticWorker.applyResourceResult(context.Background(), semanticTask, `{"confidence":1,"resource":{"display_name":"物料","description":"物料主数据"},"fields":[{"name":"material_id","display_name":"物料ID","description":"物料唯一标识"}]}`, nil)
-		require.NoError(t, err)
-		assert.True(t, applied.Applied)
 
 		db, mock, err := sqlmock.New()
 		require.NoError(t, err)
@@ -175,14 +148,11 @@ func TestCompleteBuildTaskWithoutEmbedding(t *testing.T) {
 
 		mock.ExpectBegin()
 		txMatcher := gomock.AssignableToTypeOf(&sql.Tx{})
+		rs.EXPECT().InternalUpdate(gomock.Any(), gomock.Any(), gomock.Any()).Times(0)
 		rs.EXPECT().InternalUpdateLocalIndexName(gomock.Any(), txMatcher, "r1", "new-index").DoAndReturn(
 			func(_ context.Context, _ *sql.Tx, id, indexName string) error {
 				assert.Equal(t, "r1", id)
-				assert.Equal(t, "物料", catalogResource.Name)
-				assert.Equal(t, "物料主数据", catalogResource.Description)
-				assert.Equal(t, "物料ID", catalogResource.SchemaDefinition[0].DisplayName)
-				assert.Equal(t, "物料唯一标识", catalogResource.SchemaDefinition[0].Description)
-				catalogResource.LocalIndexName = indexName
+				assert.Equal(t, "new-index", indexName)
 				return nil
 			},
 		)
@@ -190,11 +160,7 @@ func TestCompleteBuildTaskWithoutEmbedding(t *testing.T) {
 		mock.ExpectCommit()
 
 		require.NoError(t, completeBuildTaskWithoutEmbedding(context.Background(), staleBuildResource, rs, ts, "build-task-1", "new-index"))
-		assert.Equal(t, "物料", catalogResource.Name)
-		assert.Equal(t, "物料主数据", catalogResource.Description)
-		assert.Equal(t, "物料ID", catalogResource.SchemaDefinition[0].DisplayName)
-		assert.Equal(t, "物料唯一标识", catalogResource.SchemaDefinition[0].Description)
-		assert.Equal(t, "new-index", catalogResource.LocalIndexName)
+		assert.Equal(t, "new-index", staleBuildResource.LocalIndexName)
 		require.NoError(t, mock.ExpectationsWereMet())
 	})
 }

--- a/adp/vega/vega-backend/server/worker/build_task_common_test.go
+++ b/adp/vega/vega-backend/server/worker/build_task_common_test.go
@@ -26,8 +26,9 @@ func TestUpdateResourceIndexName(t *testing.T) {
 		rs := vmock.NewMockResourceService(ctrl)
 		resource := &interfaces.Resource{ID: "r1"}
 
-		rs.EXPECT().InternalUpdate(gomock.Any(), nil, resource).DoAndReturn(func(_ context.Context, _ *sql.Tx, got *interfaces.Resource) error {
-			assert.Equal(t, "new-index", got.LocalIndexName)
+		rs.EXPECT().InternalUpdateLocalIndexName(gomock.Any(), nil, "r1", "new-index").DoAndReturn(func(_ context.Context, _ *sql.Tx, id, indexName string) error {
+			assert.Equal(t, "r1", id)
+			assert.Equal(t, "new-index", indexName)
 			return nil
 		})
 
@@ -47,8 +48,9 @@ func TestUpdateResourceIndexName(t *testing.T) {
 		rs := vmock.NewMockResourceService(ctrl)
 		resource := &interfaces.Resource{ID: "r1", LocalIndexName: "old-index"}
 
-		rs.EXPECT().InternalUpdate(gomock.Any(), nil, resource).DoAndReturn(func(_ context.Context, _ *sql.Tx, got *interfaces.Resource) error {
-			assert.Equal(t, "new-index", got.LocalIndexName)
+		rs.EXPECT().InternalUpdateLocalIndexName(gomock.Any(), nil, "r1", "new-index").DoAndReturn(func(_ context.Context, _ *sql.Tx, id, indexName string) error {
+			assert.Equal(t, "r1", id)
+			assert.Equal(t, "new-index", indexName)
 			return errors.New("update failed")
 		})
 
@@ -76,9 +78,10 @@ func TestCompleteBuildTaskWithoutEmbedding(t *testing.T) {
 
 		mock.ExpectBegin()
 		txMatcher := gomock.AssignableToTypeOf(&sql.Tx{})
-		rs.EXPECT().InternalUpdate(gomock.Any(), txMatcher, resource).
-			DoAndReturn(func(_ context.Context, _ *sql.Tx, got *interfaces.Resource) error {
-				assert.Equal(t, "new-index", got.LocalIndexName)
+		rs.EXPECT().InternalUpdateLocalIndexName(gomock.Any(), txMatcher, "r1", "new-index").
+			DoAndReturn(func(_ context.Context, _ *sql.Tx, id, indexName string) error {
+				assert.Equal(t, "r1", id)
+				assert.Equal(t, "new-index", indexName)
 				return nil
 			})
 		ts.EXPECT().InternalMarkCompleted(gomock.Any(), txMatcher, "t1").Return(true, nil)
@@ -107,7 +110,7 @@ func TestCompleteBuildTaskWithoutEmbedding(t *testing.T) {
 
 		mock.ExpectBegin()
 		txMatcher := gomock.AssignableToTypeOf(&sql.Tx{})
-		rs.EXPECT().InternalUpdate(gomock.Any(), txMatcher, resource).Return(nil)
+		rs.EXPECT().InternalUpdateLocalIndexName(gomock.Any(), txMatcher, "r1", "new-index").Return(nil)
 		ts.EXPECT().InternalMarkCompleted(gomock.Any(), txMatcher, "t1").Return(false, nil)
 		mock.ExpectRollback()
 		ts.EXPECT().InternalMarkStopped(gomock.Any(), "t1").Return(true, nil)
@@ -116,6 +119,82 @@ func TestCompleteBuildTaskWithoutEmbedding(t *testing.T) {
 
 		require.NoError(t, err)
 		assert.Equal(t, "old-index", resource.LocalIndexName)
+		require.NoError(t, mock.ExpectationsWereMet())
+	})
+
+	t.Run("preserves semantic metadata when build completes from stale snapshot", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		rs := vmock.NewMockResourceService(ctrl)
+		ts := vmock.NewMockBuildTaskService(ctrl)
+		catalogResource := &interfaces.Resource{
+			ID:               "r1",
+			Name:             "supply_chain.material_entity",
+			SourceIdentifier: "supply_chain.material_entity",
+			Description:      "source material description",
+			SourceMetadata: map[string]any{
+				"original_description": "source material description",
+			},
+			SchemaDefinition: []*interfaces.Property{{
+				Name:                "material_id",
+				DisplayName:         "material_id",
+				Description:         "source material identifier",
+				OriginalDescription: "source material identifier",
+			}},
+		}
+		staleBuildResource := &interfaces.Resource{
+			ID:               "r1",
+			Name:             "supply_chain.material_entity",
+			SourceIdentifier: "supply_chain.material_entity",
+			Description:      "source material description",
+			SchemaDefinition: []*interfaces.Property{{
+				Name:                "material_id",
+				DisplayName:         "material_id",
+				Description:         "source material identifier",
+				OriginalDescription: "source material identifier",
+			}},
+		}
+		semanticWorker := &SemanticUnderstandingTaskWorker{rs: rs}
+		semanticTask := &interfaces.SemanticUnderstandingTask{
+			ResourceID:          "r1",
+			ApplyMode:           interfaces.SemanticUnderstandingApplyModeFillEmpty,
+			ConfidenceThreshold: 0.75,
+		}
+
+		rs.EXPECT().GetByID(gomock.Any(), "r1").Return(catalogResource, nil)
+		rs.EXPECT().UpdateResource(gomock.Any(), catalogResource).Return(nil)
+		applied, err := semanticWorker.applyResourceResult(context.Background(), semanticTask, `{"confidence":1,"resource":{"display_name":"物料","description":"物料主数据"},"fields":[{"name":"material_id","display_name":"物料ID","description":"物料唯一标识"}]}`, nil)
+		require.NoError(t, err)
+		assert.True(t, applied.Applied)
+
+		db, mock, err := sqlmock.New()
+		require.NoError(t, err)
+		defer func() { _ = db.Close() }()
+		oldDB := logics.DB
+		logics.DB = db
+		defer func() { logics.DB = oldDB }()
+
+		mock.ExpectBegin()
+		txMatcher := gomock.AssignableToTypeOf(&sql.Tx{})
+		rs.EXPECT().InternalUpdateLocalIndexName(gomock.Any(), txMatcher, "r1", "new-index").DoAndReturn(
+			func(_ context.Context, _ *sql.Tx, id, indexName string) error {
+				assert.Equal(t, "r1", id)
+				assert.Equal(t, "物料", catalogResource.Name)
+				assert.Equal(t, "物料主数据", catalogResource.Description)
+				assert.Equal(t, "物料ID", catalogResource.SchemaDefinition[0].DisplayName)
+				assert.Equal(t, "物料唯一标识", catalogResource.SchemaDefinition[0].Description)
+				catalogResource.LocalIndexName = indexName
+				return nil
+			},
+		)
+		ts.EXPECT().InternalMarkCompleted(gomock.Any(), txMatcher, "build-task-1").Return(true, nil)
+		mock.ExpectCommit()
+
+		require.NoError(t, completeBuildTaskWithoutEmbedding(context.Background(), staleBuildResource, rs, ts, "build-task-1", "new-index"))
+		assert.Equal(t, "物料", catalogResource.Name)
+		assert.Equal(t, "物料主数据", catalogResource.Description)
+		assert.Equal(t, "物料ID", catalogResource.SchemaDefinition[0].DisplayName)
+		assert.Equal(t, "物料唯一标识", catalogResource.SchemaDefinition[0].Description)
+		assert.Equal(t, "new-index", catalogResource.LocalIndexName)
 		require.NoError(t, mock.ExpectationsWereMet())
 	})
 }

--- a/adp/vega/vega-backend/server/worker/build_worker_embedding_test.go
+++ b/adp/vega/vega-backend/server/worker/build_worker_embedding_test.go
@@ -241,9 +241,10 @@ func TestEmbeddingWorkerExecuteEmbedding(t *testing.T) {
 		ka.EXPECT().ReadMessage(gomock.Any(), gomock.Any()).
 			Return(kafka.Message{}, context.DeadlineExceeded).
 			Times(embeddingDrainEmptyPolls)
-		rs.EXPECT().InternalUpdate(gomock.Any(), nil, resource).
-			DoAndReturn(func(_ context.Context, _ *sql.Tx, got *interfaces.Resource) error {
-				assert.Equal(t, wantIndexName, got.LocalIndexName)
+		rs.EXPECT().InternalUpdateLocalIndexName(gomock.Any(), nil, "r1", wantIndexName).
+			DoAndReturn(func(_ context.Context, _ *sql.Tx, id, indexName string) error {
+				assert.Equal(t, "r1", id)
+				assert.Equal(t, wantIndexName, indexName)
 				return nil
 			})
 		ts.EXPECT().InternalGetByID(gomock.Any(), "t1").
@@ -279,7 +280,7 @@ func TestEmbeddingWorkerExecuteEmbedding(t *testing.T) {
 		ka.EXPECT().ReadMessage(gomock.Any(), gomock.Any()).
 			Return(kafka.Message{}, context.DeadlineExceeded).
 			Times(embeddingDrainEmptyPolls)
-		rs.EXPECT().InternalUpdate(gomock.Any(), nil, resource).Return(nil)
+		rs.EXPECT().InternalUpdateLocalIndexName(gomock.Any(), nil, "r1", interfaces.BuildIndexName("r1", "t1")).Return(nil)
 		ts.EXPECT().InternalGetByID(gomock.Any(), "t1").Return(nil, errors.New("database unavailable"))
 		ts.EXPECT().InternalSetProgress(gomock.Any(), nil, "t1", gomock.Any()).
 			DoAndReturn(func(_ context.Context, _ *sql.Tx, _ string, update interfaces.BuildTaskProgress) (bool, error) {
@@ -308,7 +309,7 @@ func TestEmbeddingWorkerExecuteEmbedding(t *testing.T) {
 		ka.EXPECT().ReadMessage(gomock.Any(), gomock.Any()).
 			Return(kafka.Message{}, context.DeadlineExceeded).
 			Times(embeddingDrainEmptyPolls)
-		rs.EXPECT().InternalUpdate(gomock.Any(), nil, resource).Return(nil)
+		rs.EXPECT().InternalUpdateLocalIndexName(gomock.Any(), nil, "r1", interfaces.BuildIndexName("r1", "t1")).Return(nil)
 		ts.EXPECT().InternalGetByID(gomock.Any(), "t1").Return(task, nil)
 		ts.EXPECT().InternalSetProgress(gomock.Any(), nil, "t1", gomock.Any()).Return(true, nil)
 		ts.EXPECT().InternalMarkCompleted(gomock.Any(), nil, "t1").Return(false, nil)

--- a/adp/vega/vega-backend/server/worker/semantic_understanding_task_worker.go
+++ b/adp/vega/vega-backend/server/worker/semantic_understanding_task_worker.go
@@ -790,11 +790,7 @@ func (sutw *SemanticUnderstandingTaskWorker) applyResourceResult(ctx context.Con
 
 	resourceInfo.Updater = task.Creator
 	resourceInfo.UpdateTime = time.Now().UnixMilli()
-	if tx != nil {
-		err = sutw.rs.InternalUpdate(ctx, tx, resourceInfo)
-	} else {
-		err = sutw.rs.UpdateResource(ctx, resourceInfo)
-	}
+	err = sutw.rs.InternalUpdateSemanticMetadata(ctx, tx, resourceInfo)
 	if err != nil {
 		return nil, err
 	}

--- a/adp/vega/vega-backend/server/worker/semantic_understanding_task_worker_test.go
+++ b/adp/vega/vega-backend/server/worker/semantic_understanding_task_worker_test.go
@@ -259,8 +259,8 @@ func TestSemanticUnderstandingTaskWorkerRun(t *testing.T) {
 			GetByID(gomock.Any(), "resource-1").
 			Return(resourceInfo, nil)
 		resourceService.EXPECT().
-			UpdateResource(gomock.Any(), gomock.Any()).
-			DoAndReturn(func(_ context.Context, got *interfaces.Resource) error {
+			InternalUpdateSemanticMetadata(gomock.Any(), nil, gomock.Any()).
+			DoAndReturn(func(_ context.Context, _ *sql.Tx, got *interfaces.Resource) error {
 				assert.Equal(t, "Business Resource", got.Name)
 				assert.Equal(t, "business resource", got.Description)
 				require.Len(t, got.SchemaDefinition, 1)
@@ -609,8 +609,8 @@ func TestSemanticUnderstandingTaskWorkerApplyResourceResult(t *testing.T) {
 			GetByID(gomock.Any(), "resource-1").
 			Return(resource, nil)
 		resourceService.EXPECT().
-			UpdateResource(gomock.Any(), resource).
-			DoAndReturn(func(_ context.Context, got *interfaces.Resource) error {
+			InternalUpdateSemanticMetadata(gomock.Any(), nil, resource).
+			DoAndReturn(func(_ context.Context, _ *sql.Tx, got *interfaces.Resource) error {
 				assert.Equal(t, "商品ID", got.SchemaDefinition[0].DisplayName)
 				return nil
 			})
@@ -727,8 +727,8 @@ func TestSemanticUnderstandingTaskWorkerApplyResourceResult(t *testing.T) {
 			GetByID(gomock.Any(), "resource-1").
 			Return(resource, nil)
 		resourceService.EXPECT().
-			UpdateResource(gomock.Any(), resource).
-			DoAndReturn(func(_ context.Context, got *interfaces.Resource) error {
+			InternalUpdateSemanticMetadata(gomock.Any(), nil, resource).
+			DoAndReturn(func(_ context.Context, _ *sql.Tx, got *interfaces.Resource) error {
 				assert.Equal(t, "商品评价汇总视图", got.Name)
 				return nil
 			})
@@ -766,8 +766,8 @@ func TestSemanticUnderstandingTaskWorkerApplyResourceResult(t *testing.T) {
 			GetByID(gomock.Any(), "resource-1").
 			Return(resource, nil)
 		resourceService.EXPECT().
-			UpdateResource(gomock.Any(), resource).
-			DoAndReturn(func(_ context.Context, got *interfaces.Resource) error {
+			InternalUpdateSemanticMetadata(gomock.Any(), nil, resource).
+			DoAndReturn(func(_ context.Context, _ *sql.Tx, got *interfaces.Resource) error {
 				assert.Equal(t, "AI resource description", got.Description)
 				assert.Equal(t, "AI field description", got.SchemaDefinition[0].Description)
 				return nil


### PR DESCRIPTION
## What Changed

- [x] Build 与 Embedding 完成时仅更新资源索引名，避免旧 Resource 快照覆盖语义元数据。
- [x] 合并 ResourceAccess 状态更新的事务/非事务入口。
- [x] 增加语义 Apply 与延迟 Build 完成的回归测试。

---

## Why

- Related Issue: Closes #795
- Background: Build 任务在语义 Apply 后完成时，会将启动时读取的旧 Resource 全量写回，覆盖资源及字段业务元数据。

---

## How

- 新增窄更新 `UpdateLocalIndexName`，仅写入 `f_local_index_name`。
- Build 任务的事务边界保持不变，索引名更新仍与完成状态原子提交。
- `UpdateStatus` 接受可空事务；为空时使用默认 DB。
- Breaking changes (API, config, database, etc.): 无。

---

## Testing

- [x] Unit tests passed locally
- [ ] Integration tests passed locally（不适用：本次为无外部依赖单元测试）
- [ ] Verified in test environment（未部署）

Test notes:

- `go test ./worker`
- `go test ./drivenadapters/resource ./logics/resource`
- `make test`
- `make lint`

---

## Risk & Rollback

- Potential risks: Build 完成仅更新索引名；不再隐式持久化调用方内存中其他 Resource 字段。
- Rollback plan: 回滚本 PR 的单个提交即可恢复原有全量写入行为。

---

## Additional Notes

- 已补充 SQL 窄更新、事务路径及“语义 Apply 后 Build 完成”回归覆盖。