### PR TITLE
fix(vega): guard unsupported schema fields and build keys

### DIFF
--- a/adp/vega/vega-backend/server/errors/build_task.go
+++ b/adp/vega/vega-backend/server/errors/build_task.go
@@ -10,15 +10,16 @@ package errors
 // BuildTask 相关错误码
 const (
 	// 400 Bad Request
-	VegaBackend_BuildTask_Exist                           = "VegaBackend.BuildTask.Exist"
-	VegaBackend_BuildTask_Running                         = "VegaBackend.BuildTask.Running"
-	VegaBackend_BuildTask_InvalidStatus                   = "VegaBackend.BuildTask.InvalidStatus"
-	VegaBackend_BuildTask_InvalidExecuteType              = "VegaBackend.BuildTask.InvalidExecuteType"
-	VegaBackend_BuildTask_InvalidParameter_ResourceID     = "VegaBackend.BuildTask.InvalidParameter.ResourceID"
-	VegaBackend_BuildTask_InvalidParameter_Mode           = "VegaBackend.BuildTask.InvalidParameter.Mode"
-	VegaBackend_BuildTask_InvalidParameter_BuildKeyFields = "VegaBackend.BuildTask.InvalidParameter.BuildKeyFields"
-	VegaBackend_BuildTask_InvalidParameter_Analyzer       = "VegaBackend.BuildTask.InvalidParameter.Analyzer"
-	VegaBackend_BuildTask_InvalidParameter_EmbeddingModel = "VegaBackend.BuildTask.InvalidParameter.EmbeddingModel"
+	VegaBackend_BuildTask_Exist                                    = "VegaBackend.BuildTask.Exist"
+	VegaBackend_BuildTask_Running                                  = "VegaBackend.BuildTask.Running"
+	VegaBackend_BuildTask_InvalidStatus                            = "VegaBackend.BuildTask.InvalidStatus"
+	VegaBackend_BuildTask_InvalidExecuteType                       = "VegaBackend.BuildTask.InvalidExecuteType"
+	VegaBackend_BuildTask_InvalidParameter_ResourceID              = "VegaBackend.BuildTask.InvalidParameter.ResourceID"
+	VegaBackend_BuildTask_InvalidParameter_Mode                    = "VegaBackend.BuildTask.InvalidParameter.Mode"
+	VegaBackend_BuildTask_InvalidParameter_BuildKeyFields          = "VegaBackend.BuildTask.InvalidParameter.BuildKeyFields"
+	VegaBackend_BuildTask_InvalidParameter_UnsupportedSchemaFields = "VegaBackend.BuildTask.InvalidParameter.UnsupportedSchemaFields"
+	VegaBackend_BuildTask_InvalidParameter_Analyzer                = "VegaBackend.BuildTask.InvalidParameter.Analyzer"
+	VegaBackend_BuildTask_InvalidParameter_EmbeddingModel          = "VegaBackend.BuildTask.InvalidParameter.EmbeddingModel"
 
 	// 404 Not Found
 	VegaBackend_BuildTask_NotFound = "VegaBackend.BuildTask.NotFound"
@@ -46,6 +47,7 @@ var BuildTaskErrCodeList = []string{
 	VegaBackend_BuildTask_InvalidParameter_ResourceID,
 	VegaBackend_BuildTask_InvalidParameter_Mode,
 	VegaBackend_BuildTask_InvalidParameter_BuildKeyFields,
+	VegaBackend_BuildTask_InvalidParameter_UnsupportedSchemaFields,
 	VegaBackend_BuildTask_InvalidParameter_Analyzer,
 	VegaBackend_BuildTask_InvalidParameter_EmbeddingModel,
 

--- a/adp/vega/vega-backend/server/errors/resource.go
+++ b/adp/vega/vega-backend/server/errors/resource.go
@@ -10,19 +10,20 @@ package errors
 // Resource 错误码
 const (
 	// 400 Bad Request
-	VegaBackend_Resource_InvalidParameter           = "VegaBackend.Resource.InvalidParameter"
-	VegaBackend_Resource_InvalidParameter_Type      = "VegaBackend.Resource.InvalidParameter.Type"
-	VegaBackend_Resource_InvalidParameter_Name      = "VegaBackend.Resource.InvalidParameter.Name"
-	VegaBackend_Resource_InvalidParameter_CatalogID = "VegaBackend.Resource.InvalidParameter.CatalogID"
-	VegaBackend_Resource_InvalidParameter_Analyzer  = "VegaBackend.Resource.InvalidParameter.Analyzer"
-	VegaBackend_Resource_LengthExceeded_Name        = "VegaBackend.Resource.LengthExceeded.Name"
-	VegaBackend_Resource_LengthExceeded_Description = "VegaBackend.Resource.LengthExceeded.Description"
-	VegaBackend_Resource_CategoryNotCreatable       = "VegaBackend.Resource.CategoryNotCreatable"
-	VegaBackend_InvalidParameter_Aggregation        = "VegaBackend.InvalidParameter.Aggregation"
-	VegaBackend_InvalidParameter_GroupBy            = "VegaBackend.InvalidParameter.GroupBy"
-	VegaBackend_InvalidParameter_OrderBy            = "VegaBackend.InvalidParameter.OrderBy"
-	VegaBackend_InvalidParameter_Having             = "VegaBackend.InvalidParameter.Having"
-	VegaBackend_InvalidParameter_CalendarInterval   = "VegaBackend.InvalidParameter.CalendarInterval"
+	VegaBackend_Resource_InvalidParameter                = "VegaBackend.Resource.InvalidParameter"
+	VegaBackend_Resource_InvalidParameter_Type           = "VegaBackend.Resource.InvalidParameter.Type"
+	VegaBackend_Resource_InvalidParameter_Name           = "VegaBackend.Resource.InvalidParameter.Name"
+	VegaBackend_Resource_InvalidParameter_CatalogID      = "VegaBackend.Resource.InvalidParameter.CatalogID"
+	VegaBackend_Resource_InvalidParameter_Analyzer       = "VegaBackend.Resource.InvalidParameter.Analyzer"
+	VegaBackend_Resource_InvalidParameter_BuildKeyFields = "VegaBackend.Resource.InvalidParameter.BuildKeyFields"
+	VegaBackend_Resource_LengthExceeded_Name             = "VegaBackend.Resource.LengthExceeded.Name"
+	VegaBackend_Resource_LengthExceeded_Description      = "VegaBackend.Resource.LengthExceeded.Description"
+	VegaBackend_Resource_CategoryNotCreatable            = "VegaBackend.Resource.CategoryNotCreatable"
+	VegaBackend_InvalidParameter_Aggregation             = "VegaBackend.InvalidParameter.Aggregation"
+	VegaBackend_InvalidParameter_GroupBy                 = "VegaBackend.InvalidParameter.GroupBy"
+	VegaBackend_InvalidParameter_OrderBy                 = "VegaBackend.InvalidParameter.OrderBy"
+	VegaBackend_InvalidParameter_Having                  = "VegaBackend.InvalidParameter.Having"
+	VegaBackend_InvalidParameter_CalendarInterval        = "VegaBackend.InvalidParameter.CalendarInterval"
 
 	// 404 Not Found
 	VegaBackend_Resource_NotFound        = "VegaBackend.Resource.NotFound"
@@ -54,6 +55,7 @@ var ResourceErrCodeList = []string{
 	VegaBackend_Resource_InvalidParameter_Name,
 	VegaBackend_Resource_InvalidParameter_CatalogID,
 	VegaBackend_Resource_InvalidParameter_Analyzer,
+	VegaBackend_Resource_InvalidParameter_BuildKeyFields,
 	VegaBackend_Resource_LengthExceeded_Name,
 	VegaBackend_Resource_LengthExceeded_Description,
 	VegaBackend_Resource_CategoryNotCreatable,

--- a/adp/vega/vega-backend/server/interfaces/data_types.go
+++ b/adp/vega/vega-backend/server/interfaces/data_types.go
@@ -69,6 +69,15 @@ var (
 		DataType_Datetime:  {},
 		DataType_Timestamp: {},
 	}
+
+	BUILD_KEY_TYPES = map[string]struct{}{
+		DataType_Integer:         {},
+		DataType_UnsignedInteger: {},
+		DataType_String:          {},
+		DataType_Date:            {},
+		DataType_Datetime:        {},
+		DataType_Timestamp:       {},
+	}
 )
 
 func DataType_IsString(t string) bool {
@@ -83,5 +92,11 @@ func DataType_IsNumber(t string) bool {
 
 func DataType_IsDate(t string) bool {
 	_, ok := DATE_TYPES[t]
+	return ok
+}
+
+// DataType_IsBuildKey 判断字段类型是否可作为稳定的构建游标。
+func DataType_IsBuildKey(t string) bool {
+	_, ok := BUILD_KEY_TYPES[t]
 	return ok
 }

--- a/adp/vega/vega-backend/server/locale/build_task.en-US.toml
+++ b/adp/vega/vega-backend/server/locale/build_task.en-US.toml
@@ -15,7 +15,12 @@ ErrorLink = "No solution"
 
 [VegaBackend.BuildTask.InvalidParameter.BuildKeyFields]
 Description = "Invalid batch build key fields"
-Solution = "Configure at least one build_key_fields field from the resource schema in index_config"
+Solution = "Configure at least one unique build_key_fields field that exists in the resource schema and has a supported type"
+ErrorLink = "No solution"
+
+[VegaBackend.BuildTask.InvalidParameter.UnsupportedSchemaFields]
+Description = "Resource contains field types unsupported for index builds"
+Solution = "Resolve fields with type other before creating an index build task"
 ErrorLink = "No solution"
 
 [VegaBackend.BuildTask.InvalidParameter.Analyzer]

--- a/adp/vega/vega-backend/server/locale/build_task.zh-CN.toml
+++ b/adp/vega/vega-backend/server/locale/build_task.zh-CN.toml
@@ -15,7 +15,12 @@ ErrorLink = "暂无"
 
 [VegaBackend.BuildTask.InvalidParameter.BuildKeyFields]
 Description = "批量构建键无效"
-Solution = "请在资源 index_config 中配置至少一个存在于 schema 的 build_key_fields 字段"
+Solution = "请在资源 index_config 中配置至少一个不重复、存在于 schema 且类型受支持的 build_key_fields 字段"
+ErrorLink = "暂无"
+
+[VegaBackend.BuildTask.InvalidParameter.UnsupportedSchemaFields]
+Description = "资源包含不支持索引构建的字段类型"
+Solution = "请处理 type 为 other 的字段后再创建索引构建任务"
 ErrorLink = "暂无"
 
 [VegaBackend.BuildTask.InvalidParameter.Analyzer]

--- a/adp/vega/vega-backend/server/locale/resource.en-US.toml
+++ b/adp/vega/vega-backend/server/locale/resource.en-US.toml
@@ -28,6 +28,11 @@ Description = "Configured full-text analyzer is unavailable"
 Solution = "Choose an analyzer supported by the current index capability snapshot"
 ErrorLink = "None"
 
+[VegaBackend.Resource.InvalidParameter.BuildKeyFields]
+Description = "Invalid build key fields"
+Solution = "Build keys must be unique schema fields of type integer, unsigned integer, string, date, datetime, or timestamp"
+ErrorLink = "None"
+
 [VegaBackend.Resource.LengthExceeded.Name]
 Description = "Resource name length exceeded"
 Solution = "Please shorten the name"

--- a/adp/vega/vega-backend/server/locale/resource.zh-CN.toml
+++ b/adp/vega/vega-backend/server/locale/resource.zh-CN.toml
@@ -28,6 +28,11 @@ Description = "配置的全文分词器不可用"
 Solution = "请选择当前索引能力快照支持的分词器"
 ErrorLink = "暂无"
 
+[VegaBackend.Resource.InvalidParameter.BuildKeyFields]
+Description = "构建键无效"
+Solution = "构建键必须不重复、存在于 schema，且类型为 integer、unsigned integer、string、date、datetime 或 timestamp"
+ErrorLink = "暂无"
+
 [VegaBackend.Resource.LengthExceeded.Name]
 Description = "数据资源名称长度超限"
 Solution = "请缩短名称"

--- a/adp/vega/vega-backend/server/logics/build_task/build_task_service.go
+++ b/adp/vega/vega-backend/server/logics/build_task/build_task_service.go
@@ -198,6 +198,40 @@ func validateBuildKeyFields(ctx context.Context, resource *interfaces.Resource) 
 		return rest.NewHTTPError(ctx, http.StatusBadRequest, verrors.VegaBackend_BuildTask_InvalidParameter_BuildKeyFields).
 			WithErrorDetails("build task requires at least one build_key_fields entry")
 	}
+
+	schemaFields := make(map[string]*interfaces.Property, len(resource.SchemaDefinition))
+	unsupportedFields := make([]string, 0)
+	for _, prop := range resource.SchemaDefinition {
+		if prop == nil {
+			continue
+		}
+		schemaFields[prop.Name] = prop
+		if prop.Type == interfaces.DataType_Other {
+			unsupportedFields = append(unsupportedFields, fmt.Sprintf("%s (original_type: %s)", prop.Name, prop.OriginalType))
+		}
+	}
+	if len(unsupportedFields) > 0 {
+		return rest.NewHTTPError(ctx, http.StatusBadRequest, verrors.VegaBackend_BuildTask_InvalidParameter_UnsupportedSchemaFields).
+			WithErrorDetails(fmt.Sprintf("resource schema contains unsupported fields: %s", strings.Join(unsupportedFields, ", ")))
+	}
+
+	seen := make(map[string]struct{}, len(resource.IndexConfig.BuildKeyFields))
+	for _, fieldName := range resource.IndexConfig.BuildKeyFields {
+		prop, exists := schemaFields[fieldName]
+		if !exists {
+			return rest.NewHTTPError(ctx, http.StatusBadRequest, verrors.VegaBackend_BuildTask_InvalidParameter_BuildKeyFields).
+				WithErrorDetails(fmt.Sprintf("build_key_fields field %q is not in the resource schema", fieldName))
+		}
+		if _, duplicate := seen[fieldName]; duplicate {
+			return rest.NewHTTPError(ctx, http.StatusBadRequest, verrors.VegaBackend_BuildTask_InvalidParameter_BuildKeyFields).
+				WithErrorDetails(fmt.Sprintf("build_key_fields contains duplicate field %q", fieldName))
+		}
+		if !interfaces.DataType_IsBuildKey(prop.Type) {
+			return rest.NewHTTPError(ctx, http.StatusBadRequest, verrors.VegaBackend_BuildTask_InvalidParameter_BuildKeyFields).
+				WithErrorDetails(fmt.Sprintf("build_key_fields field %q has unsupported type %q", fieldName, prop.Type))
+		}
+		seen[fieldName] = struct{}{}
+	}
 	return nil
 }
 
@@ -766,6 +800,9 @@ func (bts *buildTaskService) validateStartBuildTaskStillCurrent(ctx context.Cont
 	if !reflect.DeepEqual(buildTask.IndexConfig, currentSnapshot.IndexConfig) {
 		return rest.NewHTTPError(ctx, http.StatusConflict, verrors.VegaBackend_BuildTask_InvalidStateTransition).
 			WithErrorDetails("resource index config has changed; create a new build task instead")
+	}
+	if err := validateBuildKeyFields(ctx, resource); err != nil {
+		return err
 	}
 
 	tasks, err := bts.InternalList(ctx, interfaces.BuildTasksQueryParams{

--- a/adp/vega/vega-backend/server/logics/build_task/build_task_service_test.go
+++ b/adp/vega/vega-backend/server/logics/build_task/build_task_service_test.go
@@ -145,7 +145,7 @@ func TestBuildTaskServiceRejectsUnavailableFieldAnalyzerBeforePersistence(t *tes
 			DefaultFulltextAnalyzer: "standard",
 		},
 		SchemaDefinition: []*interfaces.Property{
-			{Name: "id"},
+			{Name: "id", Type: interfaces.DataType_Integer},
 			{Name: "coupon_code", Features: []interfaces.PropertyFeature{{FeatureType: interfaces.PropertyFeatureType_Fulltext, Config: map[string]any{"analyzer": "standard"}}}},
 			{Name: "status", Features: []interfaces.PropertyFeature{{FeatureType: interfaces.PropertyFeatureType_Fulltext, Config: map[string]any{"analyzer": "hanlp_index"}}}},
 		},
@@ -355,6 +355,46 @@ func TestBuildTaskServiceCreateBuildTask(t *testing.T) {
 		httpErr := requireHTTPError(t, err, verrors.VegaBackend_BuildTask_InvalidParameter_BuildKeyFields)
 		assert.Equal(t, http.StatusBadRequest, httpErr.HTTPCode)
 	})
+	t.Run("rejects resources containing unsupported fields before creating a task", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		mockRS := mock_interfaces.NewMockResourceService(ctrl)
+		service := &buildTaskService{rs: mockRS}
+
+		mockRS.EXPECT().GetByID(gomock.Any(), "resource-1").Return(&interfaces.Resource{
+			ID:          "resource-1",
+			CatalogID:   "catalog-1",
+			Category:    interfaces.ResourceCategoryTable,
+			IndexConfig: &interfaces.ResourceIndexConfig{BuildKeyFields: []string{"id"}},
+			SchemaDefinition: []*interfaces.Property{
+				{Name: "id", Type: interfaces.DataType_Integer},
+				{Name: "interests", Type: interfaces.DataType_Other, OriginalType: "_text"},
+			},
+		}, nil)
+
+		_, err := service.Create(context.Background(), &interfaces.CreateBuildTaskRequest{ResourceID: "resource-1", Mode: interfaces.BuildTaskModeBatch})
+		httpErr := requireHTTPError(t, err, verrors.VegaBackend_BuildTask_InvalidParameter_UnsupportedSchemaFields)
+		assert.Equal(t, http.StatusBadRequest, httpErr.HTTPCode)
+		assert.Contains(t, httpErr.BaseError.ErrorDetails, "interests (original_type: _text)")
+	})
+
+	t.Run("rejects an unsupported build key type before creating a task", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		mockRS := mock_interfaces.NewMockResourceService(ctrl)
+		service := &buildTaskService{rs: mockRS}
+
+		mockRS.EXPECT().GetByID(gomock.Any(), "resource-1").Return(&interfaces.Resource{
+			ID:               "resource-1",
+			CatalogID:        "catalog-1",
+			Category:         interfaces.ResourceCategoryTable,
+			IndexConfig:      &interfaces.ResourceIndexConfig{BuildKeyFields: []string{"body"}},
+			SchemaDefinition: []*interfaces.Property{{Name: "body", Type: interfaces.DataType_Text}},
+		}, nil)
+
+		_, err := service.Create(context.Background(), &interfaces.CreateBuildTaskRequest{ResourceID: "resource-1", Mode: interfaces.BuildTaskModeBatch})
+		httpErr := requireHTTPError(t, err, verrors.VegaBackend_BuildTask_InvalidParameter_BuildKeyFields)
+		assert.Equal(t, http.StatusBadRequest, httpErr.HTTPCode)
+		assert.Contains(t, httpErr.BaseError.ErrorDetails, `unsupported type "text"`)
+	})
 
 	t.Run("rejects disabled catalog", func(t *testing.T) {
 		ctrl := gomock.NewController(t)
@@ -368,7 +408,7 @@ func TestBuildTaskServiceCreateBuildTask(t *testing.T) {
 				CatalogID:        "catalog-1",
 				Category:         interfaces.ResourceCategoryTable,
 				IndexConfig:      &interfaces.ResourceIndexConfig{BuildKeyFields: []string{"id"}},
-				SchemaDefinition: []*interfaces.Property{{Name: "id"}},
+				SchemaDefinition: []*interfaces.Property{{Name: "id", Type: interfaces.DataType_Integer}},
 			}, nil)
 		mockCS.EXPECT().GetByID(gomock.Any(), "catalog-1", false).
 			Return(&interfaces.Catalog{ID: "catalog-1", Enabled: false}, nil)
@@ -389,7 +429,7 @@ func TestBuildTaskServiceCreateBuildTask(t *testing.T) {
 				CatalogID:        "catalog-1",
 				Category:         interfaces.ResourceCategoryTable,
 				IndexConfig:      &interfaces.ResourceIndexConfig{BuildKeyFields: []string{"id"}},
-				SchemaDefinition: []*interfaces.Property{{Name: "id"}},
+				SchemaDefinition: []*interfaces.Property{{Name: "id", Type: interfaces.DataType_Integer}},
 			}, nil)
 		mockCS.EXPECT().GetByID(gomock.Any(), "catalog-1", false).
 			Return(&interfaces.Catalog{ID: "catalog-1", Enabled: true}, nil)
@@ -422,7 +462,7 @@ func TestBuildTaskServiceCreateBuildTask(t *testing.T) {
 			IndexConfig: &interfaces.ResourceIndexConfig{
 				BuildKeyFields: []string{"supplier_id"},
 			},
-			SchemaDefinition: []*interfaces.Property{{Name: "supplier_id"}},
+			SchemaDefinition: []*interfaces.Property{{Name: "supplier_id", Type: interfaces.DataType_Integer}},
 		}, nil)
 		mockCS.EXPECT().GetByID(gomock.Any(), "catalog-1", false).
 			Return(&interfaces.Catalog{ID: "catalog-1", Enabled: true}, nil)
@@ -480,7 +520,7 @@ func TestBuildTaskServiceCreateBuildTask(t *testing.T) {
 					DefaultFulltextAnalyzer: "ik_max_word",
 				},
 				SchemaDefinition: []*interfaces.Property{
-					{Name: "id"},
+					{Name: "id", Type: interfaces.DataType_Integer},
 					{
 						Name: "family_name",
 						Features: []interfaces.PropertyFeature{
@@ -546,7 +586,7 @@ func TestBuildTaskServiceCreateBuildTask(t *testing.T) {
 				DefaultFulltextAnalyzer: "ik_max_word",
 			},
 			SchemaDefinition: []*interfaces.Property{
-				{Name: "id"},
+				{Name: "id", Type: interfaces.DataType_Integer},
 				{
 					Name: "family_name",
 					Features: []interfaces.PropertyFeature{
@@ -604,7 +644,7 @@ func TestBuildTaskServiceCreateBuildTask(t *testing.T) {
 					DefaultEmbeddingModel: "default-model",
 				},
 				SchemaDefinition: []*interfaces.Property{
-					{Name: "id"},
+					{Name: "id", Type: interfaces.DataType_Integer},
 					{
 						Name: "family_name",
 						Features: []interfaces.PropertyFeature{
@@ -664,7 +704,7 @@ func TestBuildTaskServiceCreateBuildTask(t *testing.T) {
 					DefaultFulltextAnalyzer: "default_analyzer",
 				},
 				SchemaDefinition: []*interfaces.Property{
-					{Name: "id"},
+					{Name: "id", Type: interfaces.DataType_Integer},
 					{
 						Name: "title",
 						Features: []interfaces.PropertyFeature{
@@ -740,7 +780,7 @@ func TestBuildTaskServiceCreateBuildTask(t *testing.T) {
 					DefaultEmbeddingModel: "bogus-model",
 				},
 				SchemaDefinition: []*interfaces.Property{
-					{Name: "id"},
+					{Name: "id", Type: interfaces.DataType_Integer},
 					{
 						Name: "family_name",
 						Features: []interfaces.PropertyFeature{
@@ -804,13 +844,22 @@ func TestBuildTaskServiceStartBuildTask(t *testing.T) {
 		task := &interfaces.BuildTask{
 			ID: "task-1", ResourceID: "resource-1", CatalogID: "catalog-1",
 			Status: interfaces.BuildTaskStatusFailed, ExecuteType: interfaces.BuildTaskExecuteTypeFull,
+			IndexConfig: &interfaces.BuildTaskIndexConfig{
+				BuildKeyFields: []string{"id"},
+				Features:       map[string]interfaces.BuildTaskFieldIndexFeature{},
+			},
 		}
 		mockBTA.EXPECT().GetByID(gomock.Any(), "task-1").Return(task, nil)
 		mockCS.EXPECT().GetByID(gomock.Any(), "catalog-1", false).
 			Return(&interfaces.Catalog{ID: "catalog-1", Enabled: true}, nil)
 		mockBTA.EXPECT().InternalList(gomock.Any(), gomock.Any()).Return(nil, nil).Times(2)
 		mockRS.EXPECT().GetByID(gomock.Any(), "resource-1").Return(&interfaces.Resource{
-			ID: "resource-1", CatalogID: "catalog-1",
+			ID:        "resource-1",
+			CatalogID: "catalog-1",
+			IndexConfig: &interfaces.ResourceIndexConfig{
+				BuildKeyFields: []string{"id"},
+			},
+			SchemaDefinition: []*interfaces.Property{{Name: "id", Type: interfaces.DataType_Integer}},
 		}, nil)
 		mockBTA.EXPECT().MarkPending(gomock.Any(), "task-1", true, gomock.Any()).Return(true, nil)
 
@@ -832,13 +881,22 @@ func TestBuildTaskServiceStartBuildTask(t *testing.T) {
 		task := &interfaces.BuildTask{
 			ID: "task-1", ResourceID: "resource-1", CatalogID: "catalog-1",
 			Status: interfaces.BuildTaskStatusStopped,
+			IndexConfig: &interfaces.BuildTaskIndexConfig{
+				BuildKeyFields: []string{"id"},
+				Features:       map[string]interfaces.BuildTaskFieldIndexFeature{},
+			},
 		}
 		mockBTA.EXPECT().GetByID(gomock.Any(), "task-1").Return(task, nil)
 		mockCS.EXPECT().GetByID(gomock.Any(), "catalog-1", false).
 			Return(&interfaces.Catalog{ID: "catalog-1", Enabled: true}, nil)
 		mockBTA.EXPECT().InternalList(gomock.Any(), gomock.Any()).Return(nil, nil).Times(2)
 		mockRS.EXPECT().GetByID(gomock.Any(), "resource-1").Return(&interfaces.Resource{
-			ID: "resource-1", CatalogID: "catalog-1",
+			ID:        "resource-1",
+			CatalogID: "catalog-1",
+			IndexConfig: &interfaces.ResourceIndexConfig{
+				BuildKeyFields: []string{"id"},
+			},
+			SchemaDefinition: []*interfaces.Property{{Name: "id", Type: interfaces.DataType_Integer}},
 		}, nil)
 		mockBTA.EXPECT().MarkPending(gomock.Any(), "task-1", false, gomock.Any()).Return(false, nil)
 
@@ -1000,10 +1058,48 @@ func TestBuildTaskServiceStartBuildTask(t *testing.T) {
 			IndexConfig: &interfaces.ResourceIndexConfig{
 				BuildKeyFields: []string{"id"},
 			},
+			SchemaDefinition: []*interfaces.Property{{Name: "id", Type: interfaces.DataType_Integer}},
 		}, nil)
 
 		err := service.Start(context.Background(), "task-1", false)
 		requireHTTPError(t, err, verrors.VegaBackend_BuildTask_InvalidStateTransition)
+	})
+	t.Run("rejects restart when the resource contains an unsupported field", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		mockCS := mock_interfaces.NewMockCatalogService(ctrl)
+		mockRS := mock_interfaces.NewMockResourceService(ctrl)
+		mockBTA := mock_interfaces.NewMockBuildTaskAccess(ctrl)
+		service := &buildTaskService{cs: mockCS, rs: mockRS, bta: mockBTA}
+
+		mockBTA.EXPECT().GetByID(gomock.Any(), "task-1").Return(&interfaces.BuildTask{
+			ID:         "task-1",
+			ResourceID: "resource-1",
+			CatalogID:  "catalog-1",
+			Status:     interfaces.BuildTaskStatusStopped,
+			IndexConfig: &interfaces.BuildTaskIndexConfig{
+				BuildKeyFields: []string{"id"},
+				Features:       map[string]interfaces.BuildTaskFieldIndexFeature{},
+			},
+		}, nil)
+		mockCS.EXPECT().GetByID(gomock.Any(), "catalog-1", false).
+			Return(&interfaces.Catalog{ID: "catalog-1", Enabled: true}, nil)
+		mockBTA.EXPECT().InternalList(gomock.Any(), gomock.Any()).Return(nil, nil)
+		mockRS.EXPECT().GetByID(gomock.Any(), "resource-1").Return(&interfaces.Resource{
+			ID:        "resource-1",
+			CatalogID: "catalog-1",
+			IndexConfig: &interfaces.ResourceIndexConfig{
+				BuildKeyFields: []string{"id"},
+			},
+			SchemaDefinition: []*interfaces.Property{
+				{Name: "id", Type: interfaces.DataType_Integer},
+				{Name: "interests", Type: interfaces.DataType_Other, OriginalType: "_text"},
+			},
+		}, nil)
+
+		err := service.Start(context.Background(), "task-1", false)
+		httpErr := requireHTTPError(t, err, verrors.VegaBackend_BuildTask_InvalidParameter_UnsupportedSchemaFields)
+		assert.Equal(t, http.StatusBadRequest, httpErr.HTTPCode)
+		assert.Contains(t, httpErr.BaseError.ErrorDetails, "interests (original_type: _text)")
 	})
 	t.Run("rejects unavailable analyzer before updating status or dispatching", func(t *testing.T) {
 		ctrl := gomock.NewController(t)
@@ -1022,7 +1118,7 @@ func TestBuildTaskServiceStartBuildTask(t *testing.T) {
 			ResourceID: "resource-1",
 			CatalogID:  "catalog-1",
 			Status:     interfaces.BuildTaskStatusStopped,
-			IndexConfig: &interfaces.BuildTaskIndexConfig{Features: map[string]interfaces.BuildTaskFieldIndexFeature{
+			IndexConfig: &interfaces.BuildTaskIndexConfig{BuildKeyFields: []string{"id"}, Features: map[string]interfaces.BuildTaskFieldIndexFeature{
 				"status": {Fulltext: &interfaces.BuildTaskFulltextConfig{Analyzer: "hanlp_index"}},
 			}},
 		}
@@ -1037,15 +1133,19 @@ func TestBuildTaskServiceStartBuildTask(t *testing.T) {
 				return nil, nil
 			}).Times(2)
 		mockRS.EXPECT().GetByID(gomock.Any(), "resource-1").Return(&interfaces.Resource{
-			ID:        "resource-1",
-			CatalogID: "catalog-1",
-			SchemaDefinition: []*interfaces.Property{{
-				Name: "status",
-				Features: []interfaces.PropertyFeature{{
-					FeatureType: interfaces.PropertyFeatureType_Fulltext,
-					Config:      map[string]any{"analyzer": "hanlp_index"},
-				}},
-			}},
+			ID:          "resource-1",
+			CatalogID:   "catalog-1",
+			IndexConfig: &interfaces.ResourceIndexConfig{BuildKeyFields: []string{"id"}},
+			SchemaDefinition: []*interfaces.Property{
+				{Name: "id", Type: interfaces.DataType_Integer},
+				{
+					Name: "status",
+					Features: []interfaces.PropertyFeature{{
+						FeatureType: interfaces.PropertyFeatureType_Fulltext,
+						Config:      map[string]any{"analyzer": "hanlp_index"},
+					}},
+				},
+			},
 		}, nil)
 
 		err := service.Start(context.Background(), "task-1", false)

--- a/adp/vega/vega-backend/server/logics/connector/local/index/opensearch/opensearch_query.go
+++ b/adp/vega/vega-backend/server/logics/connector/local/index/opensearch/opensearch_query.go
@@ -947,6 +947,8 @@ func (c *OpenSearchConnector) buildFieldMappings(schemaDefinition []*interfaces.
 			fieldType = "geo_point"
 		case interfaces.DataType_Shape:
 			fieldType = "geo_shape"
+		case interfaces.DataType_Other:
+			return nil, false, fmt.Errorf("unsupported schema field %q: type %s (original_type: %s)", prop.Name, prop.Type, prop.OriginalType)
 		default:
 			// 保持 fieldType 不变
 		}

--- a/adp/vega/vega-backend/server/logics/connector/local/index/opensearch/type_mapping_test.go
+++ b/adp/vega/vega-backend/server/logics/connector/local/index/opensearch/type_mapping_test.go
@@ -83,6 +83,18 @@ func TestOpenSearchBuildFieldMappings(t *testing.T) {
 		assert.False(t, hasVector)
 		assert.Contains(t, err.Error(), "unsupported feature type")
 	})
+	t.Run("open search build field mappings rejects other type", func(t *testing.T) {
+		connector := &OpenSearchConnector{}
+
+		properties, hasVector, err := connector.buildFieldMappings([]*interfaces.Property{
+			{Name: "interests", Type: interfaces.DataType_Other, OriginalType: "_text"},
+		})
+
+		require.Error(t, err)
+		assert.Nil(t, properties)
+		assert.False(t, hasVector)
+		assert.ErrorContains(t, err, "unsupported schema field \"interests\"")
+	})
 	conn := &OpenSearchConnector{}
 
 	t.Run("maps decimal vector geo and text keyword feature", func(t *testing.T) {

--- a/adp/vega/vega-backend/server/logics/resource/resource_service.go
+++ b/adp/vega/vega-backend/server/logics/resource/resource_service.go
@@ -1224,17 +1224,28 @@ func validateIndexConfigBuildKeyFields(ctx context.Context, schema []*interfaces
 		return nil
 	}
 
-	schemaFields := make(map[string]struct{}, len(schema))
+	schemaFields := make(map[string]*interfaces.Property, len(schema))
 	for _, prop := range schema {
 		if prop != nil {
-			schemaFields[prop.Name] = struct{}{}
+			schemaFields[prop.Name] = prop
 		}
 	}
+	seen := make(map[string]struct{}, len(indexConfig.BuildKeyFields))
 	for _, field := range indexConfig.BuildKeyFields {
-		if _, exists := schemaFields[field]; !exists {
-			return rest.NewHTTPError(ctx, http.StatusBadRequest, verrors.VegaBackend_InvalidParameter_RequestBody).
+		prop, exists := schemaFields[field]
+		if !exists {
+			return rest.NewHTTPError(ctx, http.StatusBadRequest, verrors.VegaBackend_Resource_InvalidParameter_BuildKeyFields).
 				WithErrorDetails(fmt.Sprintf("build_key_fields field %q is not in the resource schema", field))
 		}
+		if _, duplicate := seen[field]; duplicate {
+			return rest.NewHTTPError(ctx, http.StatusBadRequest, verrors.VegaBackend_Resource_InvalidParameter_BuildKeyFields).
+				WithErrorDetails(fmt.Sprintf("build_key_fields contains duplicate field %q", field))
+		}
+		if !interfaces.DataType_IsBuildKey(prop.Type) {
+			return rest.NewHTTPError(ctx, http.StatusBadRequest, verrors.VegaBackend_Resource_InvalidParameter_BuildKeyFields).
+				WithErrorDetails(fmt.Sprintf("build_key_fields field %q has unsupported type %q", field, prop.Type))
+		}
+		seen[field] = struct{}{}
 	}
 	return nil
 }

--- a/adp/vega/vega-backend/server/logics/resource/resource_service_test.go
+++ b/adp/vega/vega-backend/server/logics/resource/resource_service_test.go
@@ -93,7 +93,11 @@ func TestValidateSingleFeatureTypePerPropertyRejectsKeywordDuplicates(t *testing
 }
 
 func TestValidateIndexConfigBuildKeyFields(t *testing.T) {
-	schema := []*interfaces.Property{{Name: "id"}, {Name: "updated_at"}}
+	schema := []*interfaces.Property{
+		{Name: "id", Type: interfaces.DataType_Integer},
+		{Name: "updated_at", Type: interfaces.DataType_Timestamp},
+		{Name: "body", Type: interfaces.DataType_Text},
+	}
 
 	t.Run("allows an empty build key configuration", func(t *testing.T) {
 		require.NoError(t, validateIndexConfigBuildKeyFields(context.Background(), schema, nil))
@@ -110,9 +114,22 @@ func TestValidateIndexConfigBuildKeyFields(t *testing.T) {
 		err := validateIndexConfigBuildKeyFields(context.Background(), schema, &interfaces.ResourceIndexConfig{
 			BuildKeyFields: []string{"missing_id"},
 		})
-		httpErr := err.(*rest.HTTPError)
+		httpErr := requireResourceHTTPError(t, err, verrors.VegaBackend_Resource_InvalidParameter_BuildKeyFields)
 		require.Equal(t, http.StatusBadRequest, httpErr.HTTPCode)
 		require.Contains(t, httpErr.BaseError.ErrorDetails, `build_key_fields field "missing_id"`)
+	})
+
+	t.Run("rejects duplicate and unsupported build key types", func(t *testing.T) {
+		err := validateIndexConfigBuildKeyFields(context.Background(), schema, &interfaces.ResourceIndexConfig{
+			BuildKeyFields: []string{"id", "id"},
+		})
+		requireResourceHTTPError(t, err, verrors.VegaBackend_Resource_InvalidParameter_BuildKeyFields)
+
+		err = validateIndexConfigBuildKeyFields(context.Background(), schema, &interfaces.ResourceIndexConfig{
+			BuildKeyFields: []string{"body"},
+		})
+		httpErr := requireResourceHTTPError(t, err, verrors.VegaBackend_Resource_InvalidParameter_BuildKeyFields)
+		assert.Contains(t, httpErr.BaseError.ErrorDetails, `unsupported type "text"`)
 	})
 }
 
@@ -1132,7 +1149,10 @@ func TestResourceServiceUpdate(t *testing.T) {
 			Name:             "table",
 			LocalIndexName:   "vega-build-r1-task-1",
 			SourceIdentifier: "public.orders",
-			SchemaDefinition: []*interfaces.Property{{Name: "id"}, {Name: "updated_at"}},
+			SchemaDefinition: []*interfaces.Property{
+				{Name: "id", Type: interfaces.DataType_Integer},
+				{Name: "updated_at", Type: interfaces.DataType_Timestamp},
+			},
 			IndexConfig: &interfaces.ResourceIndexConfig{
 				BuildKeyFields: []string{"id"},
 			},


### PR DESCRIPTION
## What Changed

Brief description of changes:

- [x] Reject index-build creation and restart when a resource schema contains a `type=other` field.
- [x] Validate build keys when saving resource index configuration and creating/restarting build tasks.
- [x] Reject `other` again in the OpenSearch mapping layer as a defense for legacy or bypassed tasks.

---

## Why

- Related Issue: Closes openbkn-ai/bkn-studio#298
- Related Feature: N/A
- Background: PostgreSQL array fields can be discovered as `type=other`; sending that type directly to OpenSearch causes mapping creation to fail.

---

## How

- Key implementation points: build keys must be non-empty for a task, unique, present in the schema, and one of integer, unsigned integer, string, date, datetime, or timestamp. `other` fields block creation and restart before task state is written.
- Breaking changes (API, config, database, etc.): Existing invalid build-key configurations and resources containing `other` can no longer create or restart index-build tasks; no database schema changes.

---

## Testing

- [x] Unit tests passed locally
- [x] Integration tests passed locally (`make test`)
- [ ] Verified in test environment — not run; no test environment deployment in this PR.

Test notes:

- `make test`
- `make lint`
- `git diff --check`

---

## Risk & Rollback

- Potential risks: resources with legacy invalid configuration will be rejected until their schema/configuration is corrected.
- Rollback plan: revert commit `a531ebed`; no data migration is required.

---

## Additional Notes

- Added regression coverage for create, restart, configuration validation, and OpenSearch mapping fallback.
- PR includes a `by-agent` label.