### PR TITLE
feat(vega): authorise table operations through the owning catalog (#817)

### DIFF
--- a/adp/vega/vega-backend/server/interfaces/permission_access.go
+++ b/adp/vega/vega-backend/server/interfaces/permission_access.go
@@ -36,6 +36,12 @@ const (
 	OPERATION_TYPE_AUTHORIZE   = "authorize"
 	OPERATION_TYPE_TASK_MANAGE = "task_manage"
 
+	// OPERATION_TYPE_QUERY_DATA 是「能取这张表的数据」，与 view_detail（只看结构）
+	// 分开。OPERATION_TYPE_RESOURCE_MANAGE 是数据目录上的「管理目录下的数据表」。
+	// 两者都在权限词表里（#801），这里补上常量供判定使用。
+	OPERATION_TYPE_QUERY_DATA      = "query_data"
+	OPERATION_TYPE_RESOURCE_MANAGE = "resource_manage"
+
 	// 更新资源名称的topic
 	AUTHORIZATION_RESOURCE_NAME_MODIFY = "authorization.resource.name.modify"
 )

--- a/adp/vega/vega-backend/server/logics/resource/catalog_fallback_test.go
+++ b/adp/vega/vega-backend/server/logics/resource/catalog_fallback_test.go
@@ -1,0 +1,262 @@
+// Copyright openbkn.ai
+//
+// Licensed under the Apache License, Version 2.0.
+// See the LICENSE file in the project root for details.
+
+package resource
+
+import (
+	"context"
+	"errors"
+	"sort"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+
+	"vega-backend/interfaces"
+	vmock "vega-backend/interfaces/mock"
+)
+
+// TestResourceOpOnCatalogTranslation 钉住翻译表本身。
+//
+// 按同名照搬是这里唯一真正危险的写法:目录上的 modify 语义是「改目录自己」,照搬
+// 就把「能重命名目录」的人升级成「能改目录下每张表」。authorize 不在表里也是
+// 有意的——目录的授权权不向下变成对每张表的二次授权。
+func TestResourceOpOnCatalogTranslation(t *testing.T) {
+	assert.Equal(t, interfaces.OPERATION_TYPE_RESOURCE_MANAGE, resourceOpOnCatalog[interfaces.OPERATION_TYPE_MODIFY])
+	assert.Equal(t, interfaces.OPERATION_TYPE_RESOURCE_MANAGE, resourceOpOnCatalog[interfaces.OPERATION_TYPE_DELETE])
+	assert.Equal(t, interfaces.OPERATION_TYPE_RESOURCE_MANAGE, resourceOpOnCatalog[interfaces.OPERATION_TYPE_CREATE])
+	assert.Equal(t, interfaces.OPERATION_TYPE_VIEW_DETAIL, resourceOpOnCatalog[interfaces.OPERATION_TYPE_VIEW_DETAIL])
+	assert.Equal(t, interfaces.OPERATION_TYPE_QUERY_DATA, resourceOpOnCatalog[interfaces.OPERATION_TYPE_QUERY_DATA])
+	assert.Equal(t, interfaces.OPERATION_TYPE_TASK_MANAGE, resourceOpOnCatalog[interfaces.OPERATION_TYPE_TASK_MANAGE])
+
+	_, mapped := resourceOpOnCatalog[interfaces.OPERATION_TYPE_AUTHORIZE]
+	assert.False(t, mapped, "authorize 不能向上问，否则目录授权权就变成了对每张表的二次授权")
+}
+
+// TestCheckResourceOrCatalogShortCircuits 是「纯放宽」的证据:资源侧批了就到此
+// 为止,一次鉴权请求,常态下的开销与改动前一字不差。
+func TestCheckResourceOrCatalogShortCircuits(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	ps := vmock.NewMockPermissionService(ctrl)
+	rs := &resourceService{ps: ps}
+
+	ps.EXPECT().CheckPermission(gomock.Any(), interfaces.PermissionResource{
+		Type: interfaces.AUTH_RESOURCE_TYPE_RESOURCE, ID: "r-1",
+	}, []string{interfaces.OPERATION_TYPE_MODIFY}).Return(nil).Times(1)
+	// 目录侧一次都不该被问到。
+
+	require.NoError(t, rs.checkResourceOrCatalog(context.Background(), "r-1", "c-1", false,
+		interfaces.OPERATION_TYPE_MODIFY))
+}
+
+// TestCheckResourceOrCatalogFallsBack 是这一刀的主张:目录上有 resource_manage
+// 的人，可以改目录下的表。
+func TestCheckResourceOrCatalogFallsBack(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	ps := vmock.NewMockPermissionService(ctrl)
+	rs := &resourceService{ps: ps}
+
+	ps.EXPECT().CheckPermission(gomock.Any(), interfaces.PermissionResource{
+		Type: interfaces.AUTH_RESOURCE_TYPE_RESOURCE, ID: "r-1",
+	}, []string{interfaces.OPERATION_TYPE_MODIFY}).Return(errors.New("denied"))
+	ps.EXPECT().CheckPermission(gomock.Any(), interfaces.PermissionResource{
+		Type: interfaces.AUTH_RESOURCE_TYPE_CATALOG, ID: "c-1",
+	}, []string{interfaces.OPERATION_TYPE_RESOURCE_MANAGE}).Return(nil)
+
+	require.NoError(t, rs.checkResourceOrCatalog(context.Background(), "r-1", "c-1", false,
+		interfaces.OPERATION_TYPE_MODIFY))
+}
+
+// TestCheckResourceOrCatalogKeepsTheLegacyError: 两问都拒时返回第一问的错误,
+// 客户端看到的错误码与提示因此一字不变。
+func TestCheckResourceOrCatalogKeepsTheLegacyError(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	ps := vmock.NewMockPermissionService(ctrl)
+	rs := &resourceService{ps: ps}
+
+	legacy := errors.New("the error clients already see")
+	ps.EXPECT().CheckPermission(gomock.Any(), gomock.Any(), gomock.Any()).Return(legacy)
+	ps.EXPECT().CheckPermission(gomock.Any(), gomock.Any(), gomock.Any()).Return(errors.New("catalog says no"))
+
+	err := rs.checkResourceOrCatalog(context.Background(), "r-1", "c-1", false,
+		interfaces.OPERATION_TYPE_MODIFY)
+	assert.Same(t, legacy, err)
+}
+
+// TestCheckResourceOrCatalogDoesNotFallBackForAuthorize: 没有翻译项的操作到此
+// 为止，连问都不问。
+func TestCheckResourceOrCatalogDoesNotFallBackForAuthorize(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	ps := vmock.NewMockPermissionService(ctrl)
+	rs := &resourceService{ps: ps}
+
+	denied := errors.New("denied")
+	ps.EXPECT().CheckPermission(gomock.Any(), gomock.Any(),
+		[]string{interfaces.OPERATION_TYPE_AUTHORIZE}).Return(denied).Times(1)
+
+	err := rs.checkResourceOrCatalog(context.Background(), "r-1", "c-1", false,
+		interfaces.OPERATION_TYPE_AUTHORIZE)
+	assert.Same(t, denied, err)
+}
+
+// TestCheckResourceOrCatalogUsesInternalCatalogType: 内部目录下的资源回落到
+// internal_catalog，与 resourceAuthResourceType 的分型对称。
+func TestCheckResourceOrCatalogUsesInternalCatalogType(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	ps := vmock.NewMockPermissionService(ctrl)
+	rs := &resourceService{ps: ps}
+
+	ps.EXPECT().CheckPermission(gomock.Any(), interfaces.PermissionResource{
+		Type: interfaces.AUTH_RESOURCE_TYPE_INTERNAL_RESOURCE, ID: "r-1",
+	}, gomock.Any()).Return(errors.New("denied"))
+	ps.EXPECT().CheckPermission(gomock.Any(), interfaces.PermissionResource{
+		Type: interfaces.AUTH_RESOURCE_TYPE_INTERNAL_CATALOG, ID: "c-1",
+	}, []string{interfaces.OPERATION_TYPE_RESOURCE_MANAGE}).Return(nil)
+
+	require.NoError(t, rs.checkResourceOrCatalog(context.Background(), "r-1", "c-1", true,
+		interfaces.OPERATION_TYPE_MODIFY))
+}
+
+// TestMergeCatalogPermissionsSkipsWhenNothingIsMissing 是列表面「不加钱」的证据:
+// 资源侧已经全批时,一次额外请求都不发——连资源详情都不去查。
+func TestMergeCatalogPermissionsSkipsWhenNothingIsMissing(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	rs := &resourceService{
+		ps: vmock.NewMockPermissionService(ctrl), // 任何调用都会让 gomock 报错
+		ra: vmock.NewMockResourceAccess(ctrl),
+		cs: vmock.NewMockCatalogService(ctrl),
+	}
+	result := map[string]interfaces.PermissionResourceOps{
+		"r-1": {ResourceID: "r-1", Operations: []string{interfaces.OPERATION_TYPE_VIEW_DETAIL}},
+	}
+
+	require.NoError(t, rs.mergeCatalogPermissions(context.Background(), []string{"r-1"},
+		[]string{interfaces.OPERATION_TYPE_VIEW_DETAIL}, result))
+	assert.Len(t, result["r-1"].Operations, 1)
+}
+
+// TestMergeCatalogPermissionsFillsFromCatalog: 一张资源侧完全没批的表，因为它
+// 所在目录批了 view_detail 而出现在结果里——列表页因此看得到它。
+func TestMergeCatalogPermissionsFillsFromCatalog(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	ps := vmock.NewMockPermissionService(ctrl)
+	ra := vmock.NewMockResourceAccess(ctrl)
+	cs := vmock.NewMockCatalogService(ctrl)
+	rs := &resourceService{ps: ps, ra: ra, cs: cs}
+
+	ra.EXPECT().GetByIDsBasic(gomock.Any(), []string{"r-1"}).Return([]*interfaces.Resource{
+		{ID: "r-1", CatalogID: "c-1"},
+	}, nil)
+	cs.EXPECT().ListInternalIDs(gomock.Any()).Return(nil, nil)
+	ps.EXPECT().FilterResources(gomock.Any(), interfaces.AUTH_RESOURCE_TYPE_CATALOG, []string{"c-1"},
+		[]string{interfaces.OPERATION_TYPE_VIEW_DETAIL}, true, gomock.Any()).
+		Return(map[string]interfaces.PermissionResourceOps{
+			"c-1": {ResourceID: "c-1", Operations: []string{interfaces.OPERATION_TYPE_VIEW_DETAIL}},
+		}, nil)
+
+	result := map[string]interfaces.PermissionResourceOps{}
+	require.NoError(t, rs.mergeCatalogPermissions(context.Background(), []string{"r-1"},
+		[]string{interfaces.OPERATION_TYPE_VIEW_DETAIL}, result))
+
+	entry, ok := result["r-1"]
+	require.True(t, ok, "目录批了 view_detail，这张表应该出现在结果里")
+	assert.Equal(t, []string{interfaces.OPERATION_TYPE_VIEW_DETAIL}, entry.Operations)
+}
+
+// TestMergeCatalogPermissionsLeavesUngrantedCatalogsAlone: 目录也没批的表不会
+// 凭空出现——回落只放宽到「目录给了什么」为止。
+func TestMergeCatalogPermissionsLeavesUngrantedCatalogsAlone(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	ps := vmock.NewMockPermissionService(ctrl)
+	ra := vmock.NewMockResourceAccess(ctrl)
+	cs := vmock.NewMockCatalogService(ctrl)
+	rs := &resourceService{ps: ps, ra: ra, cs: cs}
+
+	ra.EXPECT().GetByIDsBasic(gomock.Any(), gomock.Any()).Return([]*interfaces.Resource{
+		{ID: "r-1", CatalogID: "c-1"},
+	}, nil)
+	cs.EXPECT().ListInternalIDs(gomock.Any()).Return(nil, nil)
+	ps.EXPECT().FilterResources(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+		Return(map[string]interfaces.PermissionResourceOps{}, nil)
+
+	result := map[string]interfaces.PermissionResourceOps{}
+	require.NoError(t, rs.mergeCatalogPermissions(context.Background(), []string{"r-1"},
+		[]string{interfaces.OPERATION_TYPE_VIEW_DETAIL}, result))
+	assert.Empty(t, result)
+}
+
+// TestMergeCatalogPermissionsCarriesEveryMappedOp: 一张资源侧完全没批的表，从
+// 目录拿到它给的全部操作——详情页的按钮因此是完整的，而不是只够「看得见」。
+//
+// modify 与 delete 都翻译成 resource_manage，所以目录侧只问一次。
+func TestMergeCatalogPermissionsCarriesEveryMappedOp(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	ps := vmock.NewMockPermissionService(ctrl)
+	ra := vmock.NewMockResourceAccess(ctrl)
+	cs := vmock.NewMockCatalogService(ctrl)
+	rs := &resourceService{ps: ps, ra: ra, cs: cs}
+
+	ra.EXPECT().GetByIDsBasic(gomock.Any(), []string{"r-1"}).Return([]*interfaces.Resource{
+		{ID: "r-1", CatalogID: "c-1"},
+	}, nil)
+	cs.EXPECT().ListInternalIDs(gomock.Any()).Return(nil, nil)
+	ps.EXPECT().FilterResources(gomock.Any(), interfaces.AUTH_RESOURCE_TYPE_CATALOG, []string{"c-1"},
+		[]string{interfaces.OPERATION_TYPE_VIEW_DETAIL}, true, gomock.Any()).
+		Return(map[string]interfaces.PermissionResourceOps{
+			"c-1": {ResourceID: "c-1", Operations: []string{interfaces.OPERATION_TYPE_VIEW_DETAIL}},
+		}, nil).Times(1)
+	ps.EXPECT().FilterResources(gomock.Any(), interfaces.AUTH_RESOURCE_TYPE_CATALOG, []string{"c-1"},
+		[]string{interfaces.OPERATION_TYPE_RESOURCE_MANAGE}, true, gomock.Any()).
+		Return(map[string]interfaces.PermissionResourceOps{
+			"c-1": {ResourceID: "c-1", Operations: []string{interfaces.OPERATION_TYPE_RESOURCE_MANAGE}},
+		}, nil).Times(1)
+
+	result := map[string]interfaces.PermissionResourceOps{}
+	require.NoError(t, rs.mergeCatalogPermissions(context.Background(), []string{"r-1"},
+		[]string{interfaces.OPERATION_TYPE_VIEW_DETAIL, interfaces.OPERATION_TYPE_MODIFY,
+			interfaces.OPERATION_TYPE_DELETE}, result))
+
+	got := append([]string(nil), result["r-1"].Operations...)
+	sort.Strings(got)
+	assert.Equal(t, []string{
+		interfaces.OPERATION_TYPE_DELETE,
+		interfaces.OPERATION_TYPE_MODIFY,
+		interfaces.OPERATION_TYPE_VIEW_DETAIL,
+	}, got)
+}
+
+// TestMergeCatalogPermissionsLeavesGrantedResourcesAlone: 资源侧已经放行的表
+// 不会被重新评估——判据是「在不在结果里」，不是操作集齐不齐。这条也是列表面
+// 常态零额外开销的保证。
+func TestMergeCatalogPermissionsLeavesGrantedResourcesAlone(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	rs := &resourceService{
+		ps: vmock.NewMockPermissionService(ctrl),
+		ra: vmock.NewMockResourceAccess(ctrl),
+		cs: vmock.NewMockCatalogService(ctrl),
+	}
+	// 资源侧放行了，但没带回任何操作——存量调用方就是这么用的。
+	result := map[string]interfaces.PermissionResourceOps{"r-1": {ResourceID: "r-1"}}
+
+	require.NoError(t, rs.mergeCatalogPermissions(context.Background(), []string{"r-1"},
+		[]string{interfaces.OPERATION_TYPE_VIEW_DETAIL, interfaces.OPERATION_TYPE_MODIFY}, result))
+	assert.Empty(t, result["r-1"].Operations)
+}
+
+// TestMergeCatalogPermissionsIgnoresUnmappedOps: 只请求 authorize 时，目录侧
+// 一次都不问。
+func TestMergeCatalogPermissionsIgnoresUnmappedOps(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	rs := &resourceService{
+		ps: vmock.NewMockPermissionService(ctrl),
+		ra: vmock.NewMockResourceAccess(ctrl),
+		cs: vmock.NewMockCatalogService(ctrl),
+	}
+	result := map[string]interfaces.PermissionResourceOps{}
+	require.NoError(t, rs.mergeCatalogPermissions(context.Background(), []string{"r-1"},
+		[]string{interfaces.OPERATION_TYPE_AUTHORIZE}, result))
+	assert.Empty(t, result)
+}

--- a/adp/vega/vega-backend/server/logics/resource/resource_service.go
+++ b/adp/vega/vega-backend/server/logics/resource/resource_service.go
@@ -93,6 +93,188 @@ func resourceAuthResourceType(internal bool) string {
 	return interfaces.AUTH_RESOURCE_TYPE_RESOURCE
 }
 
+// resourceOpOnCatalog 是「资源上的操作」到「所属目录上要问的操作」的翻译表。
+//
+// 逐条列而不按同名照搬:目录上的 modify 语义是「改目录自己」,同名照搬就等于把
+// 「能重命名目录」的人升级成「能改目录下每一张表」,那是越权不是便利。
+//
+// authorize 故意缺席:持有目录授权权的人，不应因此获得把目录下每张表转授出去的
+// 能力。没有条目的操作到此为止，不向上问。
+var resourceOpOnCatalog = map[string]string{
+	interfaces.OPERATION_TYPE_VIEW_DETAIL: interfaces.OPERATION_TYPE_VIEW_DETAIL,
+	interfaces.OPERATION_TYPE_QUERY_DATA:  interfaces.OPERATION_TYPE_QUERY_DATA,
+	interfaces.OPERATION_TYPE_CREATE:      interfaces.OPERATION_TYPE_RESOURCE_MANAGE,
+	interfaces.OPERATION_TYPE_MODIFY:      interfaces.OPERATION_TYPE_RESOURCE_MANAGE,
+	interfaces.OPERATION_TYPE_DELETE:      interfaces.OPERATION_TYPE_RESOURCE_MANAGE,
+	interfaces.OPERATION_TYPE_TASK_MANAGE: interfaces.OPERATION_TYPE_TASK_MANAGE,
+}
+
+// catalogAuthResourceType 返回数据目录在权限服务中的资源类型，与
+// resourceAuthResourceType 对称。
+func catalogAuthResourceType(internal bool) string {
+	if internal {
+		return interfaces.AUTH_RESOURCE_TYPE_INTERNAL_CATALOG
+	}
+	return interfaces.AUTH_RESOURCE_TYPE_CATALOG
+}
+
+// checkResourceOrCatalog 判一个资源上的操作:先问资源自己,拒了再问它所属的目录
+// （操作按上表翻译）。
+//
+// 这是纯放宽:今天能做的第一问就过,常态下仍然只发一次鉴权请求;只有第一问拒了
+// 才会有第二问。两问都拒时返回**第一问的错误**,调用方看到的错误码与提示一字不变。
+//
+// 归属关系不需要任何同步:catalog_id 就在 vega 正在判的那行资源记录里。
+func (rs *resourceService) checkResourceOrCatalog(ctx context.Context,
+	resourceID, catalogID string, parentInternal bool, op string) error {
+
+	err := rs.ps.CheckPermission(ctx, interfaces.PermissionResource{
+		Type: resourceAuthResourceType(parentInternal),
+		ID:   resourceID,
+	}, []string{op})
+	if err == nil {
+		return nil
+	}
+	catalogOp, ok := resourceOpOnCatalog[op]
+	if !ok || catalogID == "" {
+		return err
+	}
+	if err2 := rs.ps.CheckPermission(ctx, interfaces.PermissionResource{
+		Type: catalogAuthResourceType(parentInternal),
+		ID:   catalogID,
+	}, []string{catalogOp}); err2 != nil {
+		return err // 返回旧口径的错误,保持既有报错语义不变
+	}
+	return nil
+}
+
+// mergeCatalogPermissions 给资源侧没批下来的操作补上「所属目录给的」那部分。
+//
+// 只为差额发请求:资源侧已经全批的常态下一次额外请求都不发。这也是为什么补在
+// 过滤之后而不是之前。
+func (rs *resourceService) mergeCatalogPermissions(ctx context.Context, ids []string,
+	ops []string, result map[string]interfaces.PermissionResourceOps) error {
+
+	// 只补资源侧**完全没批**的那些。判据是「在不在结果里」而不是「操作集齐不齐」,
+	// 因为调用方读的就是前者:出现在 map 里即视为可见,Operations 只用来渲染按钮。
+	// 按后者触发会在资源侧已经放行时多发一轮请求,白花钱。
+	pending := make([]string, 0)
+	seenPending := map[string]bool{}
+	for _, id := range ids {
+		if _, allowed := result[id]; allowed || seenPending[id] {
+			continue
+		}
+		seenPending[id] = true
+		pending = append(pending, id)
+	}
+	if len(pending) == 0 {
+		return nil
+	}
+
+	catalogOps := make([]string, 0, len(ops))
+	seenOp := map[string]bool{}
+	for _, op := range ops {
+		catalogOp, ok := resourceOpOnCatalog[op]
+		if !ok || seenOp[catalogOp] {
+			continue
+		}
+		seenOp[catalogOp] = true
+		catalogOps = append(catalogOps, catalogOp)
+	}
+	if len(catalogOps) == 0 {
+		return nil // 请求的操作都不向上问（如 authorize）
+	}
+
+	resources, err := rs.ra.GetByIDsBasic(ctx, pending)
+	if err != nil {
+		return rest.NewHTTPError(ctx, http.StatusInternalServerError,
+			verrors.VegaBackend_Resource_InternalError_GetFailed).WithErrorDetails(err.Error())
+	}
+	catalogOf := make(map[string]string, len(resources))
+	catalogIDs := make([]string, 0, len(resources))
+	seenCatalog := map[string]bool{}
+	for _, r := range resources {
+		if r == nil || r.CatalogID == "" {
+			continue
+		}
+		catalogOf[r.ID] = r.CatalogID
+		if !seenCatalog[r.CatalogID] {
+			seenCatalog[r.CatalogID] = true
+			catalogIDs = append(catalogIDs, r.CatalogID)
+		}
+	}
+	if len(catalogIDs) == 0 {
+		return nil
+	}
+
+	internalCatalogs, err := rs.internalCatalogIDSet(ctx)
+	if err != nil {
+		return err
+	}
+	normalCatalogs, internalIDs := make([]string, 0, len(catalogIDs)), make([]string, 0)
+	for _, id := range catalogIDs {
+		if _, ok := internalCatalogs[id]; ok {
+			internalIDs = append(internalIDs, id)
+		} else {
+			normalCatalogs = append(normalCatalogs, id)
+		}
+	}
+
+	// 每个目录批下来的操作集合。按目录问一次，页面上同目录的多张表共用一个答案。
+	granted := make(map[string]map[string]bool, len(catalogIDs))
+	for _, group := range []struct {
+		authType string
+		ids      []string
+	}{
+		{interfaces.AUTH_RESOURCE_TYPE_CATALOG, normalCatalogs},
+		{interfaces.AUTH_RESOURCE_TYPE_INTERNAL_CATALOG, internalIDs},
+	} {
+		if len(group.ids) == 0 {
+			continue
+		}
+		for _, catalogOp := range catalogOps {
+			matched, err := rs.ps.FilterResources(ctx, group.authType, group.ids,
+				[]string{catalogOp}, true, interfaces.COMMON_OPERATIONS)
+			if err != nil {
+				return err
+			}
+			for catalogID := range matched {
+				if granted[catalogID] == nil {
+					granted[catalogID] = map[string]bool{}
+				}
+				granted[catalogID][catalogOp] = true
+			}
+		}
+	}
+
+	for _, id := range pending {
+		catalogID, ok := catalogOf[id]
+		if !ok || len(granted[catalogID]) == 0 {
+			continue
+		}
+		entry, exists := result[id]
+		if !exists {
+			entry = interfaces.PermissionResourceOps{ResourceID: id}
+		}
+		held := map[string]bool{}
+		for _, op := range entry.Operations {
+			held[op] = true
+		}
+		for _, op := range ops {
+			catalogOp, mapped := resourceOpOnCatalog[op]
+			if !mapped || held[op] || !granted[catalogID][catalogOp] {
+				continue
+			}
+			held[op] = true
+			entry.Operations = append(entry.Operations, op)
+		}
+		if len(entry.Operations) > 0 {
+			result[id] = entry
+		}
+	}
+	return nil
+}
+
 // internalCatalogIDSet 查询所有系统内部目录 ID 集合
 func (rs *resourceService) internalCatalogIDSet(ctx context.Context) (map[string]struct{}, error) {
 	ids, err := rs.cs.ListInternalIDs(ctx)
@@ -167,6 +349,10 @@ func (rs *resourceService) filterResourcePermissions(ctx context.Context, ids []
 			result[resourceOps.ResourceID] = resourceOps
 		}
 	}
+	// 资源侧没批下来的，再看它所属目录给不给（#817）。差额为空时不发请求。
+	if err := rs.mergeCatalogPermissions(ctx, ids, ops, result); err != nil {
+		return nil, err
+	}
 	return result, nil
 }
 
@@ -184,13 +370,20 @@ func (rs *resourceService) Create(ctx context.Context, req *interfaces.ResourceR
 	_, parentInternal := internalCatalogs[req.CatalogID]
 	authType := resourceAuthResourceType(parentInternal)
 
-	// 判断userid是否有创建数据资源的权限（策略决策）
+	// 判断userid是否有创建数据资源的权限（策略决策）。建表时资源还不存在，判的是
+	// resource:* 这个通配对象——它答不了「这张表要建在哪个目录」，所以持有它的人
+	// 可以往任意目录里建表。拒了再问目标目录的 resource_manage（#817）。
 	err = rs.ps.CheckPermission(ctx, interfaces.PermissionResource{
 		Type: authType,
 		ID:   interfaces.RESOURCE_ID_ALL,
 	}, []string{interfaces.OPERATION_TYPE_CREATE})
 	if err != nil {
-		return nil, err
+		if err2 := rs.ps.CheckPermission(ctx, interfaces.PermissionResource{
+			Type: catalogAuthResourceType(parentInternal),
+			ID:   req.CatalogID,
+		}, []string{interfaces.OPERATION_TYPE_RESOURCE_MANAGE}); err2 != nil {
+			return nil, err // 返回旧口径的错误，保持既有报错语义不变
+		}
 	}
 
 	// Get account info from context
@@ -365,6 +558,12 @@ func (rs *resourceService) GetByID(ctx context.Context, id string) (*interfaces.
 			[]string{interfaces.OPERATION_TYPE_VIEW_DETAIL}, true, interfaces.COMMON_OPERATIONS)
 		if err != nil {
 			span.SetStatus(codes.Error, "Filter resources error")
+			return nil, err
+		}
+		// 资源侧没批，再看所属目录（#817）。
+		if err := rs.mergeCatalogPermissions(ctx, []string{resource.ID},
+			[]string{interfaces.OPERATION_TYPE_VIEW_DETAIL}, matchResoucesMap); err != nil {
+			span.SetStatus(codes.Error, "Merge catalog permissions error")
 			return nil, err
 		}
 
@@ -677,12 +876,8 @@ func (rs *resourceService) Update(ctx context.Context, resource *interfaces.Reso
 		return err
 	}
 	_, parentInternal := internalCatalogs[resource.CatalogID]
-	authType := resourceAuthResourceType(parentInternal)
-	err = rs.ps.CheckPermission(ctx, interfaces.PermissionResource{
-		Type: authType,
-		ID:   resource.ID,
-	}, []string{interfaces.OPERATION_TYPE_MODIFY})
-	if err != nil {
+	if err = rs.checkResourceOrCatalog(ctx, resource.ID, resource.CatalogID,
+		parentInternal, interfaces.OPERATION_TYPE_MODIFY); err != nil {
 		return err
 	}
 

--- a/adp/vega/vega-backend/server/logics/resource/resource_service_test.go
+++ b/adp/vega/vega-backend/server/logics/resource/resource_service_test.go
@@ -245,6 +245,12 @@ func TestResourceServiceGetByID(t *testing.T) {
 		ps.EXPECT().FilterResources(gomock.Any(), interfaces.AUTH_RESOURCE_TYPE_INTERNAL_RESOURCE,
 			gomock.Any(), gomock.Any(), true, gomock.Any()).
 			Return(map[string]interfaces.PermissionResourceOps{}, nil)
+		// 资源侧拒了会再问所属目录（#817）；目录也没批，结论不变。
+		ra.EXPECT().GetByIDsBasic(gomock.Any(), []string{"r1"}).
+			Return([]*interfaces.Resource{{ID: "r1", CatalogID: "cat-int"}}, nil)
+		ps.EXPECT().FilterResources(gomock.Any(), interfaces.AUTH_RESOURCE_TYPE_INTERNAL_CATALOG,
+			[]string{"cat-int"}, gomock.Any(), true, gomock.Any()).
+			Return(map[string]interfaces.PermissionResourceOps{}, nil)
 
 		_, err := rs.GetByID(context.Background(), "r1")
 		if err == nil {
@@ -257,6 +263,12 @@ func TestResourceServiceGetByID(t *testing.T) {
 			Return(&interfaces.Resource{ID: "r1", CatalogID: "cat-user"}, nil)
 		ps.EXPECT().FilterResources(gomock.Any(), interfaces.AUTH_RESOURCE_TYPE_RESOURCE,
 			gomock.Any(), gomock.Any(), true, gomock.Any()).
+			Return(map[string]interfaces.PermissionResourceOps{}, nil)
+		// 同上：回落到目录，目录也没批。
+		ra.EXPECT().GetByIDsBasic(gomock.Any(), []string{"r1"}).
+			Return([]*interfaces.Resource{{ID: "r1", CatalogID: "cat-user"}}, nil)
+		ps.EXPECT().FilterResources(gomock.Any(), interfaces.AUTH_RESOURCE_TYPE_CATALOG,
+			[]string{"cat-user"}, gomock.Any(), true, gomock.Any()).
 			Return(map[string]interfaces.PermissionResourceOps{}, nil)
 
 		_, err := rs.GetByID(interfaces.WithS2SInternalAccess(context.Background()), "r1")
@@ -404,6 +416,13 @@ func TestResourceServiceList(t *testing.T) {
 		// 内部目录下的资源按 internal_resource 类型校验；业务角色无授权 → 被过滤
 		mockPS.EXPECT().FilterResources(gomock.Any(), interfaces.AUTH_RESOURCE_TYPE_INTERNAL_RESOURCE,
 			[]string{"r2"}, gomock.Any(), true, gomock.Any()).
+			Return(map[string]interfaces.PermissionResourceOps{}, nil)
+		// r2 资源侧被拒，回落问它所属的内部目录（#817）；目录也没批，仍然被过滤掉。
+		mockCS.EXPECT().ListInternalIDs(gomock.Any()).Return([]string{"cat-internal"}, nil)
+		mockRA.EXPECT().GetByIDsBasic(gomock.Any(), []string{"r2"}).
+			Return([]*interfaces.Resource{{ID: "r2", CatalogID: "cat-internal"}}, nil)
+		mockPS.EXPECT().FilterResources(gomock.Any(), interfaces.AUTH_RESOURCE_TYPE_INTERNAL_CATALOG,
+			[]string{"cat-internal"}, gomock.Any(), true, gomock.Any()).
 			Return(map[string]interfaces.PermissionResourceOps{}, nil)
 		mockRA.EXPECT().GetByIDsBasic(gomock.Any(), []string{"r1"}).
 			Return([]*interfaces.Resource{{ID: "r1"}}, nil)

--- a/bkn-safe/server/internal/seed/data/catalog.json
+++ b/bkn-safe/server/internal/seed/data/catalog.json
@@ -61,16 +61,15 @@
       "name": "数据资源",
       "_source": "vega",
       "_note": "过渡态(#801 第一段,只加不改):新增 query_data 让资源侧能区分「只看结构」与「能取数」。create/modify/delete/authorize/task_manage 目标是上移到所属目录(catalog.resource_manage / task_manage / authorize),但在 vega 判定切换前必须保留——seed 的 reconcileSeedRoles 会先清空角色 p 行再按本文件重建,此刻移除会让 network_builder 升级后建表 403",
-      "_parent_note": "parent_operation 是「本资源上没授权时,去父目录上找哪个操作」。故意逐条列而不按同名继承:目录上的 modify 是「改目录自己」,若按同名继承就等于把「重命名目录」的人升级成「能改目录下每张表」。authorize 不给映射——目录的授权权不向下变成对每张表的二次授权。create 也不给映射:建表时资源还不存在,判的是 resource:* 这个通配对象,归属表里永远不会有它的行,继承对它不可能生效;建表权由调用点直接判 catalog.resource_manage(#800)",
-      "parent_type": "catalog",
+      "_parent_note": "不声明 parent_type/parent_operation:回落判定改由 vega 在自己的判定点做——它手上就有 catalog_id,不需要 bkn-safe 知道归属(#817)。bkn-safe 的层级机制(#827/#832/#839)保留但因此休眠:没有声明,那条代码路径一次都不会走。真出现需要服务端解析多级层级的场景,把这两个字段加回来即可",
       "operations": [
-        {"id": "view_detail", "name": "查看表结构", "parent_operation": "view_detail"},
-        {"id": "query_data", "name": "查询表数据", "parent_operation": "query_data"},
-        {"id": "create", "name": "创建(待上移目录)"},
-        {"id": "modify", "name": "修改(待上移目录)", "parent_operation": "resource_manage"},
-        {"id": "delete", "name": "删除(待上移目录)", "parent_operation": "resource_manage"},
-        {"id": "authorize", "name": "授权(待上移目录)"},
-        {"id": "task_manage", "name": "任务管理(待上移目录)", "parent_operation": "task_manage"}
+        {"id": "view_detail", "name": "查看表结构"},
+        {"id": "query_data", "name": "查询表数据"},
+        {"id": "create", "name": "创建"},
+        {"id": "modify", "name": "修改"},
+        {"id": "delete", "name": "删除"},
+        {"id": "authorize", "name": "授权"},
+        {"id": "task_manage", "name": "任务管理"}
       ]
     },
     {

--- a/bkn-safe/server/internal/seed/hierarchy_test.go
+++ b/bkn-safe/server/internal/seed/hierarchy_test.go
@@ -13,13 +13,15 @@ import (
 	"github.com/openbkn-ai/bkn-foundry/bkn-safe/server/internal/model"
 )
 
-// TestSeedDeclaresResourceUnderCatalog pins the operation MAPPING, which is the
-// part that is easy to get wrong and dangerous when wrong. Inheriting by name
-// would let "modify" on a catalog — rename the catalog — reach every table
-// inside it; the mapping sends the table's write verbs to resource_manage
-// instead. authorize deliberately maps to nothing: a catalog grant must not turn
-// into the right to re-grant every table under it (#800).
-func TestSeedDeclaresResourceUnderCatalog(t *testing.T) {
+// TestSeedDeclaresNoHierarchyForResources pins the hierarchy DORMANT.
+//
+// The mechanism below (declaration, climb, enumeration) works and is kept, but
+// the catalog/resource pair no longer uses it: vega resolves the fallback at its
+// own decision point, where the resource row it is judging already carries
+// catalog_id (#817). Nothing has to reach bkn-safe, and with no declaration the
+// climb never fires — so this asserts the ABSENCE, which is the thing a future
+// edit could silently undo.
+func TestSeedDeclaresNoHierarchyForResources(t *testing.T) {
 	db := newDB(t)
 	e, err := authz.New(db)
 	if err != nil {
@@ -29,47 +31,22 @@ func TestSeedDeclaresResourceUnderCatalog(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	var rt model.ResourceType
-	if err := db.First(&rt, "id = ?", "resource").Error; err != nil {
-		t.Fatalf("load resource type: %v", err)
+	var types []model.ResourceType
+	if err := db.Where("parent_type_id <> ''").Find(&types).Error; err != nil {
+		t.Fatalf("load resource types: %v", err)
 	}
-	if rt.ParentTypeID != "catalog" {
-		t.Errorf("resource.parent_type = %q, want catalog", rt.ParentTypeID)
-	}
-
-	var catalogType model.ResourceType
-	if err := db.First(&catalogType, "id = ?", "catalog").Error; err != nil {
-		t.Fatalf("load catalog type: %v", err)
-	}
-	if catalogType.ParentTypeID != "" {
-		t.Errorf("catalog.parent_type = %q, want empty (catalog is a root)", catalogType.ParentTypeID)
+	for _, rt := range types {
+		t.Errorf("resource type %q declares parent %q — the shipped catalog declares no hierarchy, "+
+			"and adding one turns the climb back on for every decision on that type", rt.ID, rt.ParentTypeID)
 	}
 
-	want := map[string]string{
-		"view_detail": "view_detail",
-		"query_data":  "query_data",
-		"modify":      "resource_manage",
-		"delete":      "resource_manage",
-		"task_manage": "task_manage",
-		"authorize":   "", // no second-hand granting through the parent
-		// create is judged against the wildcard object resource:* (the table does
-		// not exist yet), and a wildcard id can never have an ownership row, so an
-		// inheritance mapping here would be one that can never fire. Creating a
-		// table is judged at the call site against catalog/resource_manage instead.
-		"create": "",
-	}
 	var ops []model.Operation
-	if err := db.Where("resource_type_id = ?", "resource").Find(&ops).Error; err != nil {
-		t.Fatalf("load resource operations: %v", err)
+	if err := db.Where("parent_operation_id <> ''").Find(&ops).Error; err != nil {
+		t.Fatalf("load operations: %v", err)
 	}
-	got := make(map[string]string, len(ops))
 	for _, op := range ops {
-		got[op.ID] = op.ParentOperationID
-	}
-	for op, parentOp := range want {
-		if got[op] != parentOp {
-			t.Errorf("resource/%s inherits from catalog/%q, want %q", op, got[op], parentOp)
-		}
+		t.Errorf("operation %s/%s maps to %q on a parent, but no type declares a parent",
+			op.ResourceTypeID, op.ID, op.ParentOperationID)
 	}
 }
 


### PR DESCRIPTION
Closes #817. Every operation on a data table may now also be authorised by the catalog it lives in.

## The rule

vega asks about the resource first; when that denies, it asks about the owning catalog with the operation translated:

| on the resource | asked on the catalog |
| --- | --- |
| `view_detail` | `view_detail` |
| `query_data` | `query_data` |
| `create` / `modify` / `delete` | `resource_manage` |
| `task_manage` | `task_manage` |
| `authorize` | **not asked** |

The translation is written out rather than done by name. `modify` on a catalog means *rename the catalog*, so inheriting by name would turn "may rename this catalog" into "may rewrite every table in it" — an escalation, not a convenience. `authorize` maps to nothing for the same reason in the other direction: holding the right to grant a catalog must not become the right to re-grant every table inside it.

## Nothing to synchronise

`catalog_id` is already on the resource row vega is judging, so both object keys are in hand at the moment of the decision. bkn-safe is never told about ownership and there is no state to keep in step.

This replaces the earlier attempt (#855, closed), which resolved inheritance inside bkn-safe and therefore needed the ownership pushed and reconciled. The generic hierarchy that landed for it (#827/#832/#839) is kept but goes dormant: the seed no longer declares `parent_type`/`parent_operation`, so the climb never fires. A test asserts that absence, because re-adding a declaration would silently switch the climb back on for every decision on that type.

## Widening, not tightening

- whoever can touch a table today still can — the first question answers it, exactly as before
- a normal request still performs one permission check; the second only happens after a denial
- when both deny, the **first** error is returned, so error codes and messages are unchanged
- the seed is untouched: `normal_user` keeps `resource:*` `view_detail` + `query_data`, so nobody loses anything on the day this ships

On the list path the supplement is triggered by **absence from the result**, not by an incomplete operation set. That is what callers actually read — presence means visible, `Operations` only renders buttons — and triggering on the operation set would fire a second round trip even when the resource side had already allowed everything. With nothing missing, not one extra request is made.

## Tests

- the translation table itself, including `authorize` being absent
- short-circuit: resource allows → the catalog is never asked
- fallback: catalog `resource_manage` reaches a table's `modify`
- both deny → the legacy error object is returned unchanged
- `authorize` never falls back
- internal catalogs judge `internal_catalog`, mirroring `resourceAuthResourceType`
- list path: nothing missing → zero extra calls; missing → filled from the catalog; catalog also denies → stays hidden; a resource already allowed is not re-evaluated
- bkn-safe: the shipped catalog declares no hierarchy

Three existing tests gained expectations: their denied-resource cases now ask the catalog too, which also denies, so the assertions are unchanged.

## Left open

- **Dropping the legacy verb** belongs with #513. Note the tension to settle there: #513 revokes `normal_user`'s type-wide wildcards including `resource:*`, and that wildcard is exactly what makes reads work by default today.
- **Per-table exceptions** ("stricter than its catalog") are not expressible here; they need the explicit deny from #512.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
