### PR TITLE
feat(vega): unify task lifecycle times

### DIFF
--- a/adp/vega/vega-backend/server/drivenadapters/build_task/build_task_access.go
+++ b/adp/vega/vega-backend/server/drivenadapters/build_task/build_task_access.go
@@ -54,7 +54,9 @@ func buildTaskColumns() []string {
 		"f_creator",
 		"f_creator_type",
 		"f_create_time",
-		"f_update_time",
+		"f_start_time",
+		"f_finish_time",
+		"f_last_progress_time",
 	}
 }
 
@@ -75,7 +77,9 @@ func buildTaskSummaryColumns() []string {
 		"f_creator",
 		"f_creator_type",
 		"f_create_time",
-		"f_update_time",
+		"f_start_time",
+		"f_finish_time",
+		"f_last_progress_time",
 	}
 }
 
@@ -109,7 +113,9 @@ func scanBuildTask(scanner buildTaskScanner) (*interfaces.BuildTask, error) {
 		&creatorID,
 		&creatorType,
 		&buildTask.CreateTime,
-		&buildTask.UpdateTime,
+		&buildTask.StartTime,
+		&buildTask.FinishTime,
+		&buildTask.LastProgressTime,
 	)
 	if err != nil {
 		return nil, err
@@ -143,7 +149,9 @@ func scanBuildTaskSummary(scanner buildTaskScanner) (*interfaces.BuildTaskSummar
 		&creatorID,
 		&creatorType,
 		&task.CreateTime,
-		&task.UpdateTime,
+		&task.StartTime,
+		&task.FinishTime,
+		&task.LastProgressTime,
 	)
 	if err != nil {
 		return nil, err
@@ -197,7 +205,9 @@ func (bta *buildTaskAccess) Create(ctx context.Context, buildTask *interfaces.Bu
 			buildTask.Creator.ID,
 			buildTask.Creator.Type,
 			buildTask.CreateTime,
-			buildTask.UpdateTime,
+			buildTask.StartTime,
+			buildTask.FinishTime,
+			buildTask.LastProgressTime,
 		).ToSql()
 	if err != nil {
 		span.SetStatus(codes.Error, "Build sql failed")
@@ -286,9 +296,9 @@ func (bta *buildTaskAccess) GetByCatalogID(ctx context.Context, catalogID string
 }
 
 func (bta *buildTaskAccess) SetProgress(
-	ctx context.Context, tx *sql.Tx, id string, progress interfaces.BuildTaskProgress, updateTime int64,
+	ctx context.Context, tx *sql.Tx, id string, progress interfaces.BuildTaskProgress, lastProgressTime int64,
 ) (bool, error) {
-	updateColumns := map[string]any{"f_update_time": updateTime}
+	updateColumns := map[string]any{"f_last_progress_time": lastProgressTime}
 	if progress.TotalCount != nil {
 		updateColumns["f_total_count"] = *progress.TotalCount
 	}
@@ -313,10 +323,12 @@ func (bta *buildTaskAccess) SetProgress(
 	})
 }
 
-func (bta *buildTaskAccess) MarkPending(ctx context.Context, id string, reset bool, updateTime int64) (bool, error) {
+func (bta *buildTaskAccess) MarkPending(ctx context.Context, id string, reset bool) (bool, error) {
 	updateColumns := map[string]any{
-		"f_status":      interfaces.BuildTaskStatusPending,
-		"f_update_time": updateTime,
+		"f_status":             interfaces.BuildTaskStatusPending,
+		"f_start_time":         int64(0),
+		"f_finish_time":        int64(0),
+		"f_last_progress_time": int64(0),
 	}
 	if reset {
 		updateColumns["f_total_count"] = int64(0)
@@ -335,25 +347,24 @@ func (bta *buildTaskAccess) MarkPending(ctx context.Context, id string, reset bo
 	})
 }
 
-func (bta *buildTaskAccess) MarkRunning(ctx context.Context, id string, updateTime int64) (bool, error) {
+func (bta *buildTaskAccess) MarkRunning(ctx context.Context, id string, startTime int64) (bool, error) {
 	return bta.update(ctx, nil, map[string]any{
-		"f_status":      interfaces.BuildTaskStatusRunning,
-		"f_error_msg":   "",
-		"f_update_time": updateTime,
+		"f_status":     interfaces.BuildTaskStatusRunning,
+		"f_error_msg":  "",
+		"f_start_time": startTime,
 	}, map[string]any{"f_id": id, "f_status": interfaces.BuildTaskStatusPending})
 }
 
-func (bta *buildTaskAccess) MarkStopping(ctx context.Context, id string, updateTime int64) (bool, error) {
+func (bta *buildTaskAccess) MarkStopping(ctx context.Context, id string) (bool, error) {
 	return bta.update(ctx, nil, map[string]any{
-		"f_status":      interfaces.BuildTaskStatusStopping,
-		"f_update_time": updateTime,
+		"f_status": interfaces.BuildTaskStatusStopping,
 	}, map[string]any{"f_id": id, "f_status": interfaces.BuildTaskStatusRunning})
 }
 
-func (bta *buildTaskAccess) MarkStopped(ctx context.Context, id string, updateTime int64) (bool, error) {
+func (bta *buildTaskAccess) MarkStopped(ctx context.Context, id string, finishTime int64) (bool, error) {
 	return bta.update(ctx, nil, map[string]any{
 		"f_status":      interfaces.BuildTaskStatusStopped,
-		"f_update_time": updateTime,
+		"f_finish_time": finishTime,
 	}, map[string]any{
 		"f_id": id,
 		"f_status": []string{
@@ -364,29 +375,29 @@ func (bta *buildTaskAccess) MarkStopped(ctx context.Context, id string, updateTi
 }
 
 func (bta *buildTaskAccess) MarkCompleted(
-	ctx context.Context, tx *sql.Tx, id string, updateTime int64,
+	ctx context.Context, tx *sql.Tx, id string, finishTime int64,
 ) (bool, error) {
 	return bta.update(ctx, tx, map[string]any{
 		"f_status":      interfaces.BuildTaskStatusCompleted,
-		"f_update_time": updateTime,
+		"f_finish_time": finishTime,
 	}, map[string]any{"f_id": id, "f_status": interfaces.BuildTaskStatusRunning})
 }
 
-func (bta *buildTaskAccess) MarkFailed(ctx context.Context, id, detail string, updateTime int64) (bool, error) {
-	return bta.markTerminal(ctx, id, interfaces.BuildTaskStatusFailed, detail, updateTime)
+func (bta *buildTaskAccess) MarkFailed(ctx context.Context, id, detail string, finishTime int64) (bool, error) {
+	return bta.markTerminal(ctx, id, interfaces.BuildTaskStatusFailed, detail, finishTime)
 }
 
-func (bta *buildTaskAccess) MarkCancelled(ctx context.Context, id, detail string, updateTime int64) (bool, error) {
-	return bta.markTerminal(ctx, id, interfaces.BuildTaskStatusCancelled, detail, updateTime)
+func (bta *buildTaskAccess) MarkCancelled(ctx context.Context, id, detail string, finishTime int64) (bool, error) {
+	return bta.markTerminal(ctx, id, interfaces.BuildTaskStatusCancelled, detail, finishTime)
 }
 
 func (bta *buildTaskAccess) markTerminal(
-	ctx context.Context, id, status, detail string, updateTime int64,
+	ctx context.Context, id, status, detail string, finishTime int64,
 ) (bool, error) {
 	return bta.update(ctx, nil, map[string]any{
 		"f_status":      status,
 		"f_error_msg":   detail,
-		"f_update_time": updateTime,
+		"f_finish_time": finishTime,
 	}, map[string]any{
 		"f_id": id,
 		"f_status": []string{
@@ -398,12 +409,12 @@ func (bta *buildTaskAccess) markTerminal(
 }
 
 func (bta *buildTaskAccess) MarkCancelledByCatalogID(
-	ctx context.Context, tx *sql.Tx, catalogID, message string, updateTime int64,
+	ctx context.Context, tx *sql.Tx, catalogID, message string, finishTime int64,
 ) error {
 	_, err := bta.update(ctx, tx, map[string]any{
 		"f_status":      interfaces.BuildTaskStatusCancelled,
 		"f_error_msg":   message,
-		"f_update_time": updateTime,
+		"f_finish_time": finishTime,
 	}, map[string]any{
 		"f_catalog_id": catalogID,
 		"f_status":     interfaces.BuildTaskStatusPending,
@@ -536,8 +547,12 @@ func buildOrderByClause(sort, direction string) string {
 	switch sort {
 	case interfaces.BuildTaskSortCreateTime:
 		return "f_create_time " + dir
-	case interfaces.BuildTaskSortUpdateTime:
-		return "f_update_time " + dir
+	case interfaces.BuildTaskSortStartTime:
+		return "f_start_time " + dir
+	case interfaces.BuildTaskSortFinishTime:
+		return "f_finish_time " + dir
+	case interfaces.BuildTaskSortLastProgressTime:
+		return "f_last_progress_time " + dir
 	default:
 		return "f_create_time DESC"
 	}

--- a/adp/vega/vega-backend/server/drivenadapters/build_task/build_task_access_test.go
+++ b/adp/vega/vega-backend/server/drivenadapters/build_task/build_task_access_test.go
@@ -136,8 +136,8 @@ func TestBuildTaskAccessSetProgress(t *testing.T) {
 		db, mock, access := newBuildTaskAccessMock(t)
 		defer func() { _ = db.Close() }()
 
-		mock.ExpectExec(regexp.QuoteMeta("UPDATE t_build_task SET f_synced_count = ?, f_update_time = ? WHERE f_id = ? AND f_status IN (?,?)")).
-			WithArgs(int64(10), int64(123), "task-1", interfaces.BuildTaskStatusRunning, interfaces.BuildTaskStatusStopping).
+		mock.ExpectExec(regexp.QuoteMeta("UPDATE t_build_task SET f_last_progress_time = ?, f_synced_count = ? WHERE f_id = ? AND f_status IN (?,?)")).
+			WithArgs(int64(123), int64(10), "task-1", interfaces.BuildTaskStatusRunning, interfaces.BuildTaskStatusStopping).
 			WillReturnResult(sqlmock.NewResult(0, 1))
 
 		syncedCount := int64(10)
@@ -153,8 +153,8 @@ func TestBuildTaskAccessSetProgress(t *testing.T) {
 		db, mock, access := newBuildTaskAccessMock(t)
 		defer func() { _ = db.Close() }()
 
-		mock.ExpectExec(regexp.QuoteMeta("UPDATE t_build_task SET f_synced_count = ?, f_update_time = ? WHERE f_id = ? AND f_status IN (?,?)")).
-			WithArgs(int64(10), int64(123), "task-1", interfaces.BuildTaskStatusRunning, interfaces.BuildTaskStatusStopping).
+		mock.ExpectExec(regexp.QuoteMeta("UPDATE t_build_task SET f_last_progress_time = ?, f_synced_count = ? WHERE f_id = ? AND f_status IN (?,?)")).
+			WithArgs(int64(123), int64(10), "task-1", interfaces.BuildTaskStatusRunning, interfaces.BuildTaskStatusStopping).
 			WillReturnResult(sqlmock.NewResult(0, 0))
 
 		syncedCount := int64(10)
@@ -172,8 +172,8 @@ func TestBuildTaskAccessMarkRunning(t *testing.T) {
 		db, mock, access := newBuildTaskAccessMock(t)
 		defer func() { _ = db.Close() }()
 
-		mock.ExpectExec(regexp.QuoteMeta("UPDATE t_build_task SET f_error_msg = ?, f_status = ?, f_update_time = ? WHERE f_id = ? AND f_status = ?")).
-			WithArgs("", interfaces.BuildTaskStatusRunning, int64(123), "task-1", interfaces.BuildTaskStatusPending).
+		mock.ExpectExec(regexp.QuoteMeta("UPDATE t_build_task SET f_error_msg = ?, f_start_time = ?, f_status = ? WHERE f_id = ? AND f_status = ?")).
+			WithArgs("", int64(123), interfaces.BuildTaskStatusRunning, "task-1", interfaces.BuildTaskStatusPending).
 			WillReturnResult(sqlmock.NewResult(0, 1))
 
 		claimed, err := access.MarkRunning(context.Background(), "task-1", 123)
@@ -187,8 +187,8 @@ func TestBuildTaskAccessMarkRunning(t *testing.T) {
 		db, mock, access := newBuildTaskAccessMock(t)
 		defer func() { _ = db.Close() }()
 
-		mock.ExpectExec(regexp.QuoteMeta("UPDATE t_build_task SET f_error_msg = ?, f_status = ?, f_update_time = ? WHERE f_id = ? AND f_status = ?")).
-			WithArgs("", interfaces.BuildTaskStatusRunning, int64(123), "task-1", interfaces.BuildTaskStatusPending).
+		mock.ExpectExec(regexp.QuoteMeta("UPDATE t_build_task SET f_error_msg = ?, f_start_time = ?, f_status = ? WHERE f_id = ? AND f_status = ?")).
+			WithArgs("", int64(123), interfaces.BuildTaskStatusRunning, "task-1", interfaces.BuildTaskStatusPending).
 			WillReturnResult(sqlmock.NewResult(0, 0))
 
 		claimed, err := access.MarkRunning(context.Background(), "task-1", 123)
@@ -197,6 +197,22 @@ func TestBuildTaskAccessMarkRunning(t *testing.T) {
 		assert.False(t, claimed)
 		require.NoError(t, mock.ExpectationsWereMet())
 	})
+}
+
+func TestBuildTaskAccessMarkPending(t *testing.T) {
+	db, mock, access := newBuildTaskAccessMock(t)
+	defer func() { _ = db.Close() }()
+
+	mock.ExpectExec(regexp.QuoteMeta("UPDATE t_build_task SET f_finish_time = ?, f_last_progress_time = ?, f_start_time = ?, f_status = ? WHERE f_id = ? AND f_status IN (?,?)")).
+		WithArgs(int64(0), int64(0), int64(0), interfaces.BuildTaskStatusPending, "task-1",
+			interfaces.BuildTaskStatusStopped, interfaces.BuildTaskStatusFailed).
+		WillReturnResult(sqlmock.NewResult(0, 1))
+
+	updated, err := access.MarkPending(context.Background(), "task-1", false)
+
+	require.NoError(t, err)
+	assert.True(t, updated)
+	require.NoError(t, mock.ExpectationsWereMet())
 }
 
 func TestBuildTaskAccessMarkTerminal(t *testing.T) {
@@ -226,8 +242,8 @@ func TestBuildTaskAccessMarkTerminal(t *testing.T) {
 			db, mock, access := newBuildTaskAccessMock(t)
 			defer func() { _ = db.Close() }()
 
-			mock.ExpectExec(regexp.QuoteMeta("UPDATE t_build_task SET f_error_msg = ?, f_status = ?, f_update_time = ? WHERE f_id = ? AND f_status IN (?,?,?)")).
-				WithArgs("execution failed", tt.status, int64(123), "task-1",
+			mock.ExpectExec(regexp.QuoteMeta("UPDATE t_build_task SET f_error_msg = ?, f_finish_time = ?, f_status = ? WHERE f_id = ? AND f_status IN (?,?,?)")).
+				WithArgs("execution failed", int64(123), tt.status, "task-1",
 					interfaces.BuildTaskStatusPending,
 					interfaces.BuildTaskStatusRunning,
 					interfaces.BuildTaskStatusStopping).
@@ -246,8 +262,8 @@ func TestBuildTaskAccessMarkCancelledByCatalogID(t *testing.T) {
 	db, mock, access := newBuildTaskAccessMock(t)
 	defer func() { _ = db.Close() }()
 
-	mock.ExpectExec(regexp.QuoteMeta("UPDATE t_build_task SET f_error_msg = ?, f_status = ?, f_update_time = ? WHERE f_catalog_id = ? AND f_status = ?")).
-		WithArgs("catalog deleted", interfaces.BuildTaskStatusCancelled, int64(123), "catalog-1", interfaces.BuildTaskStatusPending).
+	mock.ExpectExec(regexp.QuoteMeta("UPDATE t_build_task SET f_error_msg = ?, f_finish_time = ?, f_status = ? WHERE f_catalog_id = ? AND f_status = ?")).
+		WithArgs("catalog deleted", int64(123), interfaces.BuildTaskStatusCancelled, "catalog-1", interfaces.BuildTaskStatusPending).
 		WillReturnResult(sqlmock.NewResult(0, 2))
 
 	err := access.MarkCancelledByCatalogID(context.Background(), nil, "catalog-1", "catalog deleted", 123)
@@ -420,11 +436,20 @@ func TestBuildOrderByClause(t *testing.T) {
 		assert.Equal(t, "f_create_time DESC", buildOrderByClause(interfaces.BuildTaskSortCreateTime, "desc"))
 	})
 
-	t.Run("update_time follows direction", func(t *testing.T) {
-		assert.Equal(t, "f_update_time ASC", buildOrderByClause(interfaces.BuildTaskSortUpdateTime, "asc"))
-		assert.Equal(t, "f_update_time DESC", buildOrderByClause(interfaces.BuildTaskSortUpdateTime, "desc"))
+	t.Run("start_time follows direction", func(t *testing.T) {
+		assert.Equal(t, "f_start_time ASC", buildOrderByClause(interfaces.BuildTaskSortStartTime, "asc"))
+		assert.Equal(t, "f_start_time DESC", buildOrderByClause(interfaces.BuildTaskSortStartTime, "desc"))
 	})
 
+	t.Run("finish_time follows direction", func(t *testing.T) {
+		assert.Equal(t, "f_finish_time ASC", buildOrderByClause(interfaces.BuildTaskSortFinishTime, "asc"))
+		assert.Equal(t, "f_finish_time DESC", buildOrderByClause(interfaces.BuildTaskSortFinishTime, "desc"))
+	})
+
+	t.Run("last_progress_time follows direction", func(t *testing.T) {
+		assert.Equal(t, "f_last_progress_time ASC", buildOrderByClause(interfaces.BuildTaskSortLastProgressTime, "asc"))
+		assert.Equal(t, "f_last_progress_time DESC", buildOrderByClause(interfaces.BuildTaskSortLastProgressTime, "desc"))
+	})
 }
 
 func newBuildTaskAccessMock(t *testing.T) (*sql.DB, sqlmock.Sqlmock, *buildTaskAccess) {
@@ -440,20 +465,22 @@ func newBuildTaskAccessMock(t *testing.T) (*sql.DB, sqlmock.Sqlmock, *buildTaskA
 
 func sampleBuildTask() *interfaces.BuildTask {
 	return &interfaces.BuildTask{
-		ID:              "task-1",
-		ResourceID:      "resource-1",
-		CatalogID:       "catalog-1",
-		Status:          interfaces.BuildTaskStatusPending,
-		Mode:            interfaces.BuildTaskModeBatch,
-		ExecuteType:     interfaces.BuildTaskExecuteTypeIncremental,
-		TotalCount:      100,
-		SyncedCount:     80,
-		VectorizedCount: 70,
-		SyncedMark:      "cursor-1",
-		ErrorMsg:        "soft error",
-		Creator:         interfaces.AccountInfo{ID: "creator-1", Type: interfaces.ACCESSOR_TYPE_USER},
-		CreateTime:      1000,
-		UpdateTime:      2000,
+		ID:               "task-1",
+		ResourceID:       "resource-1",
+		CatalogID:        "catalog-1",
+		Status:           interfaces.BuildTaskStatusPending,
+		Mode:             interfaces.BuildTaskModeBatch,
+		ExecuteType:      interfaces.BuildTaskExecuteTypeIncremental,
+		TotalCount:       100,
+		SyncedCount:      80,
+		VectorizedCount:  70,
+		SyncedMark:       "cursor-1",
+		ErrorMsg:         "soft error",
+		Creator:          interfaces.AccountInfo{ID: "creator-1", Type: interfaces.ACCESSOR_TYPE_USER},
+		CreateTime:       1000,
+		StartTime:        1500,
+		FinishTime:       2000,
+		LastProgressTime: 1800,
 		IndexConfig: &interfaces.BuildTaskIndexConfig{
 			BuildKeyFields: []string{"id"},
 			Features: map[string]interfaces.BuildTaskFieldIndexFeature{
@@ -494,7 +521,9 @@ func buildTaskRowValues(task *interfaces.BuildTask) []driver.Value {
 		task.Creator.ID,
 		task.Creator.Type,
 		task.CreateTime,
-		task.UpdateTime,
+		task.StartTime,
+		task.FinishTime,
+		task.LastProgressTime,
 	}
 }
 

--- a/adp/vega/vega-backend/server/drivenadapters/discover_task/discover_task_access.go
+++ b/adp/vega/vega-backend/server/drivenadapters/discover_task/discover_task_access.go
@@ -57,6 +57,7 @@ func discoverTaskColumns() []string {
 		"f_message",
 		"f_start_time",
 		"f_finish_time",
+		"f_last_progress_time",
 		"f_result",
 		"f_creator",
 		"f_creator_type",
@@ -77,6 +78,7 @@ func discoverTaskListColumns() []string {
 		"f_progress",
 		"f_start_time",
 		"f_finish_time",
+		"f_last_progress_time",
 		"f_result",
 		"f_creator",
 		"f_creator_type",
@@ -99,6 +101,7 @@ func scanDiscoverTask(scanner discoverTaskScanner) (*interfaces.DiscoverTask, er
 		&task.Message,
 		&task.StartTime,
 		&task.FinishTime,
+		&task.LastProgressTime,
 		&resultStr,
 		&task.Creator.ID,
 		&task.Creator.Type,
@@ -130,6 +133,7 @@ func scanDiscoverTaskListItem(scanner discoverTaskScanner) (*interfaces.Discover
 		&task.Progress,
 		&task.StartTime,
 		&task.FinishTime,
+		&task.LastProgressTime,
 		&resultStr,
 		&task.Creator.ID,
 		&task.Creator.Type,
@@ -224,6 +228,7 @@ func (dta *discoverTaskAccess) Create(ctx context.Context, task *interfaces.Disc
 			task.Message,
 			task.StartTime,
 			task.FinishTime,
+			task.LastProgressTime,
 			"", // result initially empty
 			task.Creator.ID,
 			task.Creator.Type,
@@ -378,6 +383,8 @@ func buildOrderByClause(sort, direction string) string {
 		column = "f_start_time"
 	case interfaces.DiscoverTaskSortFinishTime:
 		column = "f_finish_time"
+	case interfaces.DiscoverTaskSortLastProgressTime:
+		column = "f_last_progress_time"
 	case interfaces.DiscoverTaskSortCreateTime, "":
 		column = "f_create_time"
 	}
@@ -397,6 +404,19 @@ func (dta *discoverTaskAccess) MarkRunning(ctx context.Context, id string, start
 	}, map[string]any{
 		"f_id":     id,
 		"f_status": interfaces.DiscoverTaskStatusPending,
+	})
+}
+
+func (dta *discoverTaskAccess) UpdateProgress(
+	ctx context.Context, id string, progress int, message string, lastProgressTime int64,
+) (bool, error) {
+	return dta.update(ctx, nil, map[string]any{
+		"f_progress":           progress,
+		"f_message":            message,
+		"f_last_progress_time": lastProgressTime,
+	}, map[string]any{
+		"f_id":     id,
+		"f_status": interfaces.DiscoverTaskStatusRunning,
 	})
 }
 

--- a/adp/vega/vega-backend/server/drivenadapters/discover_task/discover_task_access_test.go
+++ b/adp/vega/vega-backend/server/drivenadapters/discover_task/discover_task_access_test.go
@@ -24,7 +24,7 @@ func TestDiscoverTaskAccessGetByID(t *testing.T) {
 		access, mock, cleanup := newDiscoverTaskAccessMock(t)
 		defer cleanup()
 
-		mock.ExpectQuery("SELECT f_id, f_catalog_id, f_schedule_id, f_strategy, f_trigger_type, f_status, f_progress, f_message, f_start_time, f_finish_time, f_result, f_creator, f_creator_type, f_create_time FROM t_discover_task WHERE f_id = ?").
+		mock.ExpectQuery("SELECT f_id, f_catalog_id, f_schedule_id, f_strategy, f_trigger_type, f_status, f_progress, f_message, f_start_time, f_finish_time, f_last_progress_time, f_result, f_creator, f_creator_type, f_create_time FROM t_discover_task WHERE f_id = ?").
 			WithArgs("task-1").
 			WillReturnRows(discoverTaskRows().AddRow(
 				"task-1",
@@ -37,6 +37,7 @@ func TestDiscoverTaskAccessGetByID(t *testing.T) {
 				"done",
 				int64(10),
 				int64(20),
+				int64(15),
 				`{"databases":[{"name":"db1"}]}`,
 				"u1",
 				interfaces.ACCESSOR_TYPE_USER,
@@ -48,6 +49,7 @@ func TestDiscoverTaskAccessGetByID(t *testing.T) {
 		require.NoError(t, err)
 		assert.Equal(t, "task-1", got.ID)
 		assert.Equal(t, interfaces.DiscoverTaskStatusCompleted, got.Status)
+		assert.Equal(t, int64(15), got.LastProgressTime)
 		assert.Equal(t, "u1", got.Creator.ID)
 		require.NotNil(t, got.Result)
 		require.NoError(t, mock.ExpectationsWereMet())
@@ -70,9 +72,9 @@ func TestDiscoverTaskAccessList(t *testing.T) {
 		mock.ExpectQuery("SELECT COUNT(*) FROM t_discover_task WHERE f_catalog_id = ? AND f_status IN (?,?) AND f_strategy = ? AND f_trigger_type = ?").
 			WithArgs("catalog-1", interfaces.DiscoverTaskStatusRunning, interfaces.DiscoverTaskStatusPending, interfaces.DiscoverStrategyFullSync, interfaces.DiscoverTaskTriggerScheduled).
 			WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(1))
-		mock.ExpectQuery("SELECT f_id, f_catalog_id, f_schedule_id, f_strategy, f_trigger_type, f_status, f_progress, f_start_time, f_finish_time, f_result, f_creator, f_creator_type, f_create_time FROM t_discover_task WHERE f_catalog_id = ? AND f_status IN (?,?) AND f_strategy = ? AND f_trigger_type = ? ORDER BY f_create_time ASC LIMIT 10 OFFSET 5").
+		mock.ExpectQuery("SELECT f_id, f_catalog_id, f_schedule_id, f_strategy, f_trigger_type, f_status, f_progress, f_start_time, f_finish_time, f_last_progress_time, f_result, f_creator, f_creator_type, f_create_time FROM t_discover_task WHERE f_catalog_id = ? AND f_status IN (?,?) AND f_strategy = ? AND f_trigger_type = ? ORDER BY f_create_time ASC LIMIT 10 OFFSET 5").
 			WithArgs("catalog-1", interfaces.DiscoverTaskStatusRunning, interfaces.DiscoverTaskStatusPending, interfaces.DiscoverStrategyFullSync, interfaces.DiscoverTaskTriggerScheduled).
-			WillReturnRows(discoverTaskSummaryRows().AddRow("task-1", "catalog-1", "schedule-1", "full_sync", interfaces.DiscoverTaskTriggerScheduled, interfaces.DiscoverTaskStatusRunning, 10, int64(0), int64(0), `{"catalog_id":"catalog-1","new_count":2,"message":"large detail"}`, "u1", interfaces.ACCESSOR_TYPE_USER, int64(1)))
+			WillReturnRows(discoverTaskSummaryRows().AddRow("task-1", "catalog-1", "schedule-1", "full_sync", interfaces.DiscoverTaskTriggerScheduled, interfaces.DiscoverTaskStatusRunning, 10, int64(0), int64(0), int64(0), `{"catalog_id":"catalog-1","new_count":2,"message":"large detail"}`, "u1", interfaces.ACCESSOR_TYPE_USER, int64(1)))
 
 		got, total, err := access.List(context.Background(), params)
 
@@ -96,15 +98,35 @@ func TestDiscoverTaskAccessList(t *testing.T) {
 			PaginationQueryParams: interfaces.PaginationQueryParams{Limit: 1},
 			Statuses:              []string{interfaces.DiscoverTaskStatusPending},
 		}
-		mock.ExpectQuery("SELECT f_id, f_catalog_id, f_schedule_id, f_strategy, f_trigger_type, f_status, f_progress, f_start_time, f_finish_time, f_result, f_creator, f_creator_type, f_create_time FROM t_discover_task WHERE f_status IN (?) ORDER BY f_create_time DESC LIMIT 1 OFFSET 0").
+		mock.ExpectQuery("SELECT f_id, f_catalog_id, f_schedule_id, f_strategy, f_trigger_type, f_status, f_progress, f_start_time, f_finish_time, f_last_progress_time, f_result, f_creator, f_creator_type, f_create_time FROM t_discover_task WHERE f_status IN (?) ORDER BY f_create_time DESC LIMIT 1 OFFSET 0").
 			WithArgs(interfaces.DiscoverTaskStatusPending).
-			WillReturnRows(discoverTaskSummaryRows().AddRow("task-1", "catalog-1", "", "full_sync", "manual", interfaces.DiscoverTaskStatusPending, 0, int64(0), int64(0), "", "u1", interfaces.ACCESSOR_TYPE_USER, int64(1)))
+			WillReturnRows(discoverTaskSummaryRows().AddRow("task-1", "catalog-1", "", "full_sync", "manual", interfaces.DiscoverTaskStatusPending, 0, int64(0), int64(0), int64(0), "", "u1", interfaces.ACCESSOR_TYPE_USER, int64(1)))
 
 		got, err := access.InternalList(context.Background(), params)
 
 		require.NoError(t, err)
 		require.Len(t, got, 1)
 		assert.Equal(t, "task-1", got[0].ID)
+		require.NoError(t, mock.ExpectationsWereMet())
+	})
+
+	t.Run("sorts by last progress time", func(t *testing.T) {
+		access, mock, cleanup := newDiscoverTaskAccessMock(t)
+		defer cleanup()
+
+		params := interfaces.DiscoverTaskQueryParams{
+			PaginationQueryParams: interfaces.PaginationQueryParams{
+				Limit: 1, Sort: interfaces.DiscoverTaskSortLastProgressTime, Direction: interfaces.ASC_DIRECTION,
+			},
+		}
+		mock.ExpectQuery("SELECT f_id, f_catalog_id, f_schedule_id, f_strategy, f_trigger_type, f_status, f_progress, f_start_time, f_finish_time, f_last_progress_time, f_result, f_creator, f_creator_type, f_create_time FROM t_discover_task ORDER BY f_last_progress_time ASC LIMIT 1 OFFSET 0").
+			WillReturnRows(discoverTaskSummaryRows().AddRow("task-1", "catalog-1", "", "full_sync", "manual", interfaces.DiscoverTaskStatusRunning, 25, int64(1), int64(0), int64(2), "", "u1", interfaces.ACCESSOR_TYPE_USER, int64(1)))
+
+		got, err := access.InternalList(context.Background(), params)
+
+		require.NoError(t, err)
+		require.Len(t, got, 1)
+		assert.Equal(t, int64(2), got[0].LastProgressTime)
 		require.NoError(t, mock.ExpectationsWereMet())
 	})
 }
@@ -115,8 +137,8 @@ func TestDiscoverTaskAccessCreate(t *testing.T) {
 		defer cleanup()
 		task := sampleDiscoverTask()
 
-		mock.ExpectExec("INSERT INTO t_discover_task (f_id,f_catalog_id,f_schedule_id,f_strategy,f_trigger_type,f_status,f_progress,f_message,f_start_time,f_finish_time,f_result,f_creator,f_creator_type,f_create_time) VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?)").
-			WithArgs(task.ID, task.CatalogID, task.ScheduleID, task.Strategy, task.TriggerType, task.Status, task.Progress, task.Message, task.StartTime, task.FinishTime, "", task.Creator.ID, task.Creator.Type, task.CreateTime).
+		mock.ExpectExec("INSERT INTO t_discover_task (f_id,f_catalog_id,f_schedule_id,f_strategy,f_trigger_type,f_status,f_progress,f_message,f_start_time,f_finish_time,f_last_progress_time,f_result,f_creator,f_creator_type,f_create_time) VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)").
+			WithArgs(task.ID, task.CatalogID, task.ScheduleID, task.Strategy, task.TriggerType, task.Status, task.Progress, task.Message, task.StartTime, task.FinishTime, task.LastProgressTime, "", task.Creator.ID, task.Creator.Type, task.CreateTime).
 			WillReturnResult(sqlmock.NewResult(1, 1))
 
 		require.NoError(t, access.Create(context.Background(), task))
@@ -186,6 +208,21 @@ func TestDiscoverTaskAccessMarkRunning(t *testing.T) {
 		assert.False(t, updated)
 		require.NoError(t, mock.ExpectationsWereMet())
 	})
+}
+
+func TestDiscoverTaskAccessUpdateProgress(t *testing.T) {
+	access, mock, cleanup := newDiscoverTaskAccessMock(t)
+	defer cleanup()
+
+	mock.ExpectExec("UPDATE t_discover_task SET f_last_progress_time = ?, f_message = ?, f_progress = ? WHERE f_id = ? AND f_status = ?").
+		WithArgs(int64(456), "resources reconciled", 70, "task-1", interfaces.DiscoverTaskStatusRunning).
+		WillReturnResult(sqlmock.NewResult(0, 1))
+
+	updated, err := access.UpdateProgress(context.Background(), "task-1", 70, "resources reconciled", 456)
+
+	require.NoError(t, err)
+	assert.True(t, updated)
+	require.NoError(t, mock.ExpectationsWereMet())
 }
 
 func TestDiscoverTaskAccessMarkFailed(t *testing.T) {

--- a/adp/vega/vega-backend/server/drivenadapters/semantic_understanding_task/semantic_understanding_task_access.go
+++ b/adp/vega/vega-backend/server/drivenadapters/semantic_understanding_task/semantic_understanding_task_access.go
@@ -59,12 +59,12 @@ func semanticUnderstandingTaskColumns() []string {
 		"f_confidence_detail_json",
 		"f_apply_detail_json",
 		"f_applied",
-		"f_applied_time",
 		"f_failure_detail",
 		"f_creator",
 		"f_creator_type",
 		"f_create_time",
-		"f_update_time",
+		"f_start_time",
+		"f_finish_time",
 	}
 }
 
@@ -83,11 +83,11 @@ func semanticUnderstandingTaskListColumns() []string {
 		"f_confidence_threshold",
 		"f_confidence",
 		"f_applied",
-		"f_applied_time",
 		"f_creator",
 		"f_creator_type",
 		"f_create_time",
-		"f_update_time",
+		"f_start_time",
+		"f_finish_time",
 	}
 }
 
@@ -110,12 +110,12 @@ func scanSemanticUnderstandingTask(scanner semanticUnderstandingTaskScanner) (*i
 		&task.ConfidenceDetailJSON,
 		&task.ApplyDetailJSON,
 		&task.Applied,
-		&task.AppliedTime,
 		&task.FailureDetail,
 		&task.Creator.ID,
 		&task.Creator.Type,
 		&task.CreateTime,
-		&task.UpdateTime,
+		&task.StartTime,
+		&task.FinishTime,
 	)
 	if err != nil {
 		return nil, err
@@ -137,11 +137,11 @@ func scanSemanticUnderstandingTaskListItem(scanner semanticUnderstandingTaskScan
 		&task.ConfidenceThreshold,
 		&task.Confidence,
 		&task.Applied,
-		&task.AppliedTime,
 		&task.Creator.ID,
 		&task.Creator.Type,
 		&task.CreateTime,
-		&task.UpdateTime,
+		&task.StartTime,
+		&task.FinishTime,
 	)
 	if err != nil {
 		return nil, err
@@ -182,12 +182,12 @@ func (suta *semanticUnderstandingTaskAccess) Create(ctx context.Context, task *i
 			task.ConfidenceDetailJSON,
 			task.ApplyDetailJSON,
 			task.Applied,
-			task.AppliedTime,
 			task.FailureDetail,
 			task.Creator.ID,
 			task.Creator.Type,
 			task.CreateTime,
-			task.UpdateTime,
+			task.StartTime,
+			task.FinishTime,
 		).ToSql()
 	if err != nil {
 		span.SetStatus(codes.Error, "Build sql failed")
@@ -427,7 +427,7 @@ func (suta *semanticUnderstandingTaskAccess) DeleteByIDs(ctx context.Context, id
 }
 
 func (suta *semanticUnderstandingTaskAccess) MarkCancelledByCatalogID(
-	ctx context.Context, tx *sql.Tx, catalogID, failureDetail string, updateTime int64,
+	ctx context.Context, tx *sql.Tx, catalogID, failureDetail string, finishTime int64,
 ) error {
 	ctx, span := oteltrace.StartNamedClientSpan(ctx, "Mark semantic understanding tasks cancelled by catalog ID")
 	defer span.End()
@@ -435,7 +435,7 @@ func (suta *semanticUnderstandingTaskAccess) MarkCancelledByCatalogID(
 	sqlStr, vals, err := sq.Update(SEMANTIC_UNDERSTANDING_TASK_TABLE_NAME).
 		Set("f_status", interfaces.SemanticUnderstandingTaskStatusCancelled).
 		Set("f_failure_detail", failureDetail).
-		Set("f_update_time", updateTime).
+		Set("f_finish_time", finishTime).
 		Where(sq.Eq{"f_catalog_id": catalogID}).
 		Where(sq.Eq{"f_status": interfaces.SemanticUnderstandingTaskStatusPending}).
 		ToSql()
@@ -456,35 +456,35 @@ func (suta *semanticUnderstandingTaskAccess) MarkCancelledByCatalogID(
 	return nil
 }
 
-func (suta *semanticUnderstandingTaskAccess) MarkRunning(ctx context.Context, id string, updateTime int64) (bool, error) {
+func (suta *semanticUnderstandingTaskAccess) MarkRunning(ctx context.Context, id string, startTime int64) (bool, error) {
 	return suta.update(ctx, nil, map[string]any{
-		"f_status":      interfaces.SemanticUnderstandingTaskStatusRunning,
-		"f_update_time": updateTime,
+		"f_status":     interfaces.SemanticUnderstandingTaskStatusRunning,
+		"f_start_time": startTime,
 	}, map[string]any{
 		"f_id":     id,
 		"f_status": interfaces.SemanticUnderstandingTaskStatusPending,
 	})
 }
 
-func (suta *semanticUnderstandingTaskAccess) MarkCompleted(ctx context.Context, id string, resultJSON string, confidence float64, confidenceDetailJSON string, updateTime int64) (bool, error) {
-	return suta.update(ctx, nil, map[string]any{
+func (suta *semanticUnderstandingTaskAccess) MarkCompleted(ctx context.Context, tx *sql.Tx, id string, resultJSON string, confidence float64, confidenceDetailJSON string, finishTime int64) (bool, error) {
+	return suta.update(ctx, tx, map[string]any{
 		"f_status":                 interfaces.SemanticUnderstandingTaskStatusCompleted,
 		"f_result_json":            resultJSON,
 		"f_confidence":             confidence,
 		"f_confidence_detail_json": confidenceDetailJSON,
 		"f_failure_detail":         "",
-		"f_update_time":            updateTime,
+		"f_finish_time":            finishTime,
 	}, map[string]any{
 		"f_id":     id,
 		"f_status": interfaces.SemanticUnderstandingTaskStatusRunning,
 	})
 }
 
-func (suta *semanticUnderstandingTaskAccess) MarkFailed(ctx context.Context, id string, failureDetail string, updateTime int64) (bool, error) {
+func (suta *semanticUnderstandingTaskAccess) MarkFailed(ctx context.Context, id string, failureDetail string, finishTime int64) (bool, error) {
 	return suta.update(ctx, nil, map[string]any{
 		"f_status":         interfaces.SemanticUnderstandingTaskStatusFailed,
 		"f_failure_detail": failureDetail,
-		"f_update_time":    updateTime,
+		"f_finish_time":    finishTime,
 	}, map[string]any{
 		"f_id": id,
 		"f_status": []string{
@@ -494,11 +494,11 @@ func (suta *semanticUnderstandingTaskAccess) MarkFailed(ctx context.Context, id 
 	})
 }
 
-func (suta *semanticUnderstandingTaskAccess) MarkCancelled(ctx context.Context, id string, failureDetail string, updateTime int64) (bool, error) {
+func (suta *semanticUnderstandingTaskAccess) MarkCancelled(ctx context.Context, id string, failureDetail string, finishTime int64) (bool, error) {
 	return suta.update(ctx, nil, map[string]any{
 		"f_status":         interfaces.SemanticUnderstandingTaskStatusCancelled,
 		"f_failure_detail": failureDetail,
-		"f_update_time":    updateTime,
+		"f_finish_time":    finishTime,
 	}, map[string]any{
 		"f_id": id,
 		"f_status": []string{
@@ -508,21 +508,18 @@ func (suta *semanticUnderstandingTaskAccess) MarkCancelled(ctx context.Context, 
 	})
 }
 
-func (suta *semanticUnderstandingTaskAccess) SetAgentTaskID(ctx context.Context, id string, agentTaskID string, updateTime int64) (bool, error) {
+func (suta *semanticUnderstandingTaskAccess) SetAgentTaskID(ctx context.Context, id string, agentTaskID string) (bool, error) {
 	return suta.update(ctx, nil, map[string]any{
 		"f_agent_task_id": agentTaskID,
-		"f_update_time":   updateTime,
 	}, map[string]any{
 		"f_id":     id,
 		"f_status": interfaces.SemanticUnderstandingTaskStatusRunning,
 	})
 }
 
-func (suta *semanticUnderstandingTaskAccess) SetApplied(ctx context.Context, tx *sql.Tx, id string, applied bool, appliedTime int64, applyDetailJSON string) (bool, error) {
+func (suta *semanticUnderstandingTaskAccess) SetApplied(ctx context.Context, tx *sql.Tx, id string, applied bool, applyDetailJSON string) (bool, error) {
 	updateColumns := map[string]any{
-		"f_applied":      applied,
-		"f_applied_time": appliedTime,
-		"f_update_time":  appliedTime,
+		"f_applied": applied,
 	}
 	if applyDetailJSON != "" {
 		updateColumns["f_apply_detail_json"] = applyDetailJSON
@@ -569,9 +566,11 @@ func (suta *semanticUnderstandingTaskAccess) update(ctx context.Context, tx *sql
 func buildOrderByClause(sort, direction string) string {
 	column := "f_create_time"
 	switch sort {
-	case interfaces.SemanticUnderstandingTaskSortUpdateTime:
-		column = "f_update_time"
-	case interfaces.SemanticUnderstandingTaskSortCreateTime, "":
+	case interfaces.SemanticUnderstandingTaskSortStartTime:
+		column = "f_start_time"
+	case interfaces.SemanticUnderstandingTaskSortFinishTime:
+		column = "f_finish_time"
+	case interfaces.SemanticUnderstandingTaskSortCreateTime:
 		column = "f_create_time"
 	default:
 		column = "f_create_time"

--- a/adp/vega/vega-backend/server/drivenadapters/semantic_understanding_task/semantic_understanding_task_access.go
+++ b/adp/vega/vega-backend/server/drivenadapters/semantic_understanding_task/semantic_understanding_task_access.go
@@ -526,7 +526,7 @@ func (suta *semanticUnderstandingTaskAccess) SetApplied(ctx context.Context, tx 
 	}
 	return suta.update(ctx, tx, updateColumns, map[string]any{
 		"f_id":     id,
-		"f_status": interfaces.SemanticUnderstandingTaskStatusCompleted,
+		"f_status": interfaces.SemanticUnderstandingTaskStatusRunning,
 	})
 }
 

--- a/adp/vega/vega-backend/server/drivenadapters/semantic_understanding_task/semantic_understanding_task_access_test.go
+++ b/adp/vega/vega-backend/server/drivenadapters/semantic_understanding_task/semantic_understanding_task_access_test.go
@@ -166,10 +166,10 @@ func TestSemanticUnderstandingTaskAccessList(t *testing.T) {
 		assert.Equal(t, task.ConfidenceThreshold, gotTask.ConfidenceThreshold)
 		assert.Equal(t, task.Confidence, gotTask.Confidence)
 		assert.Equal(t, task.Applied, gotTask.Applied)
-		assert.Equal(t, task.AppliedTime, gotTask.AppliedTime)
 		assert.Equal(t, task.Creator, gotTask.Creator)
 		assert.Equal(t, task.CreateTime, gotTask.CreateTime)
-		assert.Equal(t, task.UpdateTime, gotTask.UpdateTime)
+		assert.Equal(t, task.StartTime, gotTask.StartTime)
+		assert.Equal(t, task.FinishTime, gotTask.FinishTime)
 		payload, err := json.Marshal(gotTask)
 		require.NoError(t, err)
 		assert.NotContains(t, string(payload), `"input"`)
@@ -212,8 +212,8 @@ func TestSemanticUnderstandingTaskAccessMarkRunning(t *testing.T) {
 		db, mock, access := newSemanticUnderstandingTaskAccessMock(t)
 		defer func() { _ = db.Close() }()
 
-		mock.ExpectExec(regexp.QuoteMeta("UPDATE t_semantic_understanding_task SET f_status = ?, f_update_time = ? WHERE f_id = ? AND f_status = ?")).
-			WithArgs(interfaces.SemanticUnderstandingTaskStatusRunning, int64(123), "semantic-task-1", interfaces.SemanticUnderstandingTaskStatusPending).
+		mock.ExpectExec(regexp.QuoteMeta("UPDATE t_semantic_understanding_task SET f_start_time = ?, f_status = ? WHERE f_id = ? AND f_status = ?")).
+			WithArgs(int64(123), interfaces.SemanticUnderstandingTaskStatusRunning, "semantic-task-1", interfaces.SemanticUnderstandingTaskStatusPending).
 			WillReturnResult(sqlmock.NewResult(0, 1))
 
 		updated, err := access.MarkRunning(context.Background(), "semantic-task-1", 123)
@@ -227,8 +227,8 @@ func TestSemanticUnderstandingTaskAccessMarkRunning(t *testing.T) {
 		db, mock, access := newSemanticUnderstandingTaskAccessMock(t)
 		defer func() { _ = db.Close() }()
 
-		mock.ExpectExec(regexp.QuoteMeta("UPDATE t_semantic_understanding_task SET f_status = ?, f_update_time = ? WHERE f_id = ? AND f_status = ?")).
-			WithArgs(interfaces.SemanticUnderstandingTaskStatusRunning, int64(123), "semantic-task-1", interfaces.SemanticUnderstandingTaskStatusPending).
+		mock.ExpectExec(regexp.QuoteMeta("UPDATE t_semantic_understanding_task SET f_start_time = ?, f_status = ? WHERE f_id = ? AND f_status = ?")).
+			WithArgs(int64(123), interfaces.SemanticUnderstandingTaskStatusRunning, "semantic-task-1", interfaces.SemanticUnderstandingTaskStatusPending).
 			WillReturnResult(sqlmock.NewResult(0, 0))
 
 		updated, err := access.MarkRunning(context.Background(), "semantic-task-1", 123)
@@ -243,11 +243,11 @@ func TestSemanticUnderstandingTaskAccessSetApplied(t *testing.T) {
 	db, mock, access := newSemanticUnderstandingTaskAccessMock(t)
 	defer func() { _ = db.Close() }()
 
-	mock.ExpectExec(regexp.QuoteMeta("UPDATE t_semantic_understanding_task SET f_applied = ?, f_applied_time = ?, f_apply_detail_json = ?, f_update_time = ? WHERE f_id = ? AND f_status = ?")).
-		WithArgs(true, int64(123), `{"resource_updated":true}`, int64(123), "semantic-task-1", interfaces.SemanticUnderstandingTaskStatusCompleted).
+	mock.ExpectExec(regexp.QuoteMeta("UPDATE t_semantic_understanding_task SET f_applied = ?, f_apply_detail_json = ? WHERE f_id = ? AND f_status = ?")).
+		WithArgs(true, `{"resource_updated":true}`, "semantic-task-1", interfaces.SemanticUnderstandingTaskStatusCompleted).
 		WillReturnResult(sqlmock.NewResult(0, 1))
 
-	updated, err := access.SetApplied(context.Background(), nil, "semantic-task-1", true, 123, `{"resource_updated":true}`)
+	updated, err := access.SetApplied(context.Background(), nil, "semantic-task-1", true, `{"resource_updated":true}`)
 
 	require.NoError(t, err)
 	assert.True(t, updated)
@@ -286,7 +286,7 @@ func TestSemanticUnderstandingTaskAccessMarkCancelledByCatalogID(t *testing.T) {
 	db, mock, access := newSemanticUnderstandingTaskAccessMock(t)
 	defer func() { _ = db.Close() }()
 
-	mock.ExpectExec(regexp.QuoteMeta("UPDATE t_semantic_understanding_task SET f_status = ?, f_failure_detail = ?, f_update_time = ? WHERE f_catalog_id = ? AND f_status = ?")).
+	mock.ExpectExec(regexp.QuoteMeta("UPDATE t_semantic_understanding_task SET f_status = ?, f_failure_detail = ?, f_finish_time = ? WHERE f_catalog_id = ? AND f_status = ?")).
 		WithArgs(interfaces.SemanticUnderstandingTaskStatusCancelled, "catalog deleted", int64(100), "catalog-1",
 			interfaces.SemanticUnderstandingTaskStatusPending).
 		WillReturnResult(sqlmock.NewResult(0, 1))
@@ -299,8 +299,8 @@ func TestSemanticUnderstandingTaskAccessMarkCancelled(t *testing.T) {
 	db, mock, access := newSemanticUnderstandingTaskAccessMock(t)
 	defer func() { _ = db.Close() }()
 
-	mock.ExpectExec(regexp.QuoteMeta("UPDATE t_semantic_understanding_task SET f_failure_detail = ?, f_status = ?, f_update_time = ? WHERE f_id = ? AND f_status IN (?,?)")).
-		WithArgs("catalog or resource deleted", interfaces.SemanticUnderstandingTaskStatusCancelled, int64(123),
+	mock.ExpectExec(regexp.QuoteMeta("UPDATE t_semantic_understanding_task SET f_failure_detail = ?, f_finish_time = ?, f_status = ? WHERE f_id = ? AND f_status IN (?,?)")).
+		WithArgs("catalog or resource deleted", int64(123), interfaces.SemanticUnderstandingTaskStatusCancelled,
 			"semantic-task-1", interfaces.SemanticUnderstandingTaskStatusPending, interfaces.SemanticUnderstandingTaskStatusRunning).
 		WillReturnResult(sqlmock.NewResult(0, 1))
 
@@ -336,11 +336,11 @@ func sampleSemanticUnderstandingTask() *interfaces.SemanticUnderstandingTask {
 		ConfidenceDetailJSON: `{"fields":[]}`,
 		ApplyDetailJSON:      "",
 		Applied:              false,
-		AppliedTime:          0,
 		FailureDetail:        "",
 		Creator:              interfaces.AccountInfo{ID: "u1", Type: interfaces.ACCESSOR_TYPE_USER},
 		CreateTime:           100,
-		UpdateTime:           200,
+		StartTime:            200,
+		FinishTime:           300,
 	}
 }
 
@@ -362,12 +362,12 @@ func semanticUnderstandingTaskRowValues(task *interfaces.SemanticUnderstandingTa
 		task.ConfidenceDetailJSON,
 		task.ApplyDetailJSON,
 		task.Applied,
-		task.AppliedTime,
 		task.FailureDetail,
 		task.Creator.ID,
 		task.Creator.Type,
 		task.CreateTime,
-		task.UpdateTime,
+		task.StartTime,
+		task.FinishTime,
 	}
 }
 
@@ -392,11 +392,11 @@ func semanticUnderstandingTaskListRowValues(task *interfaces.SemanticUnderstandi
 		task.ConfidenceThreshold,
 		task.Confidence,
 		task.Applied,
-		task.AppliedTime,
 		task.Creator.ID,
 		task.Creator.Type,
 		task.CreateTime,
-		task.UpdateTime,
+		task.StartTime,
+		task.FinishTime,
 	}
 }
 

--- a/adp/vega/vega-backend/server/drivenadapters/semantic_understanding_task/semantic_understanding_task_access_test.go
+++ b/adp/vega/vega-backend/server/drivenadapters/semantic_understanding_task/semantic_understanding_task_access_test.go
@@ -244,7 +244,7 @@ func TestSemanticUnderstandingTaskAccessSetApplied(t *testing.T) {
 	defer func() { _ = db.Close() }()
 
 	mock.ExpectExec(regexp.QuoteMeta("UPDATE t_semantic_understanding_task SET f_applied = ?, f_apply_detail_json = ? WHERE f_id = ? AND f_status = ?")).
-		WithArgs(true, `{"resource_updated":true}`, "semantic-task-1", interfaces.SemanticUnderstandingTaskStatusCompleted).
+		WithArgs(true, `{"resource_updated":true}`, "semantic-task-1", interfaces.SemanticUnderstandingTaskStatusRunning).
 		WillReturnResult(sqlmock.NewResult(0, 1))
 
 	updated, err := access.SetApplied(context.Background(), nil, "semantic-task-1", true, `{"resource_updated":true}`)

--- a/adp/vega/vega-backend/server/interfaces/build_task.go
+++ b/adp/vega/vega-backend/server/interfaces/build_task.go
@@ -20,8 +20,10 @@ const (
 	BuildTaskModeStreaming string = "streaming" // 流式
 	BuildTaskModeBatch     string = "batch"     // 批量
 
-	BuildTaskSortCreateTime string = "create_time"
-	BuildTaskSortUpdateTime string = "update_time"
+	BuildTaskSortCreateTime       string = "create_time"
+	BuildTaskSortStartTime        string = "start_time"
+	BuildTaskSortFinishTime       string = "finish_time"
+	BuildTaskSortLastProgressTime string = "last_progress_time"
 
 	BuildTaskExecuteTypeIncremental string = "incremental" // 增量
 	BuildTaskExecuteTypeFull        string = "full"        // 全量
@@ -36,8 +38,10 @@ const (
 // BUILD_TASK_SORT is a whitelist of supported sort values. Values are unused;
 // the data access layer owns the mapping from API fields to database columns.
 var BUILD_TASK_SORT = map[string]string{
-	BuildTaskSortCreateTime: "",
-	BuildTaskSortUpdateTime: "",
+	BuildTaskSortCreateTime:       "",
+	BuildTaskSortStartTime:        "",
+	BuildTaskSortFinishTime:       "",
+	BuildTaskSortLastProgressTime: "",
 }
 
 var ConnectorClassMapping = map[string]string{
@@ -47,22 +51,24 @@ var ConnectorClassMapping = map[string]string{
 
 // BuildTask represents a build task entity.
 type BuildTask struct {
-	ID              string                `json:"id"`
-	ResourceID      string                `json:"resource_id"`
-	Status          string                `json:"status"`
-	Mode            string                `json:"mode"`                   // 任务模式：streaming/batch
-	ExecuteType     string                `json:"execute_type,omitempty"` // batch 执行类型：incremental/full；streaming 不适用
-	TotalCount      int64                 `json:"total_count"`            // 总数
-	SyncedCount     int64                 `json:"synced_count"`           // 已同步数
-	VectorizedCount int64                 `json:"vectorized_count"`       // 已做向量数
-	SyncedMark      string                `json:"synced_mark"`            // 同步标记
-	ErrorMsg        string                `json:"error_msg,omitempty"`
-	FailureDetail   string                `json:"failure_detail,omitempty"` // 构建完成但部分文档向量化失败的明细，区别于 error_msg 的整任务硬失败
-	Creator         AccountInfo           `json:"creator"`
-	CreateTime      int64                 `json:"create_time"`
-	UpdateTime      int64                 `json:"update_time"`
-	IndexConfig     *BuildTaskIndexConfig `json:"index_config,omitempty"` // 创建 task 时从 resource 派生的索引配置快照
-	CatalogID       string                `json:"catalog_id"`
+	ID               string                `json:"id"`
+	ResourceID       string                `json:"resource_id"`
+	Status           string                `json:"status"`
+	Mode             string                `json:"mode"`                   // 任务模式：streaming/batch
+	ExecuteType      string                `json:"execute_type,omitempty"` // batch 执行类型：incremental/full；streaming 不适用
+	TotalCount       int64                 `json:"total_count"`            // 总数
+	SyncedCount      int64                 `json:"synced_count"`           // 已同步数
+	VectorizedCount  int64                 `json:"vectorized_count"`       // 已做向量数
+	SyncedMark       string                `json:"synced_mark"`            // 同步标记
+	ErrorMsg         string                `json:"error_msg,omitempty"`
+	FailureDetail    string                `json:"failure_detail,omitempty"` // 构建完成但部分文档向量化失败的明细，区别于 error_msg 的整任务硬失败
+	Creator          AccountInfo           `json:"creator"`
+	CreateTime       int64                 `json:"create_time"`
+	StartTime        int64                 `json:"start_time,omitempty"`
+	FinishTime       int64                 `json:"finish_time,omitempty"`
+	LastProgressTime int64                 `json:"last_progress_time,omitempty"`
+	IndexConfig      *BuildTaskIndexConfig `json:"index_config,omitempty"` // 创建 task 时从 resource 派生的索引配置快照
+	CatalogID        string                `json:"catalog_id"`
 	// 以下关联字段仅用于响应展示，不落库；由 service 按当前任务集合批量补齐。
 	ResourceName string `json:"resource_name,omitempty"`
 	CatalogName  string `json:"catalog_name,omitempty"`
@@ -76,23 +82,25 @@ type BuildTask struct {
 // Index configuration snapshots and detailed partial-failure diagnostics are
 // available from GetByID.
 type BuildTaskSummary struct {
-	ID              string       `json:"id"`
-	ResourceID      string       `json:"resource_id"`
-	ResourceName    string       `json:"resource_name,omitempty"`
-	CatalogID       string       `json:"catalog_id"`
-	CatalogName     string       `json:"catalog_name,omitempty"`
-	Status          string       `json:"status"`
-	Mode            string       `json:"mode"`
-	ExecuteType     string       `json:"execute_type,omitempty"`
-	TotalCount      int64        `json:"total_count"`
-	SyncedCount     int64        `json:"synced_count"`
-	VectorizedCount int64        `json:"vectorized_count"`
-	SyncedMark      string       `json:"synced_mark"`
-	ErrorMsg        string       `json:"error_msg,omitempty"`
-	Creator         AccountInfo  `json:"creator"`
-	CreateTime      int64        `json:"create_time"`
-	UpdateTime      int64        `json:"update_time"`
-	IndexHealth     *IndexHealth `json:"index_health,omitempty"`
+	ID               string       `json:"id"`
+	ResourceID       string       `json:"resource_id"`
+	ResourceName     string       `json:"resource_name,omitempty"`
+	CatalogID        string       `json:"catalog_id"`
+	CatalogName      string       `json:"catalog_name,omitempty"`
+	Status           string       `json:"status"`
+	Mode             string       `json:"mode"`
+	ExecuteType      string       `json:"execute_type,omitempty"`
+	TotalCount       int64        `json:"total_count"`
+	SyncedCount      int64        `json:"synced_count"`
+	VectorizedCount  int64        `json:"vectorized_count"`
+	SyncedMark       string       `json:"synced_mark"`
+	ErrorMsg         string       `json:"error_msg,omitempty"`
+	Creator          AccountInfo  `json:"creator"`
+	CreateTime       int64        `json:"create_time"`
+	StartTime        int64        `json:"start_time,omitempty"`
+	FinishTime       int64        `json:"finish_time,omitempty"`
+	LastProgressTime int64        `json:"last_progress_time,omitempty"`
+	IndexHealth      *IndexHealth `json:"index_health,omitempty"`
 
 	// IndexConfig is loaded only to derive IndexHealth and is never serialized.
 	IndexConfig *BuildTaskIndexConfig `json:"-"`

--- a/adp/vega/vega-backend/server/interfaces/build_task_access.go
+++ b/adp/vega/vega-backend/server/interfaces/build_task_access.go
@@ -27,23 +27,23 @@ type BuildTaskAccess interface {
 	DeleteByIDs(ctx context.Context, ids []string) (int64, error)
 
 	// SetProgress persists execution progress for an active build task.
-	SetProgress(ctx context.Context, tx *sql.Tx, id string, progress BuildTaskProgress, updateTime int64) (bool, error)
+	SetProgress(ctx context.Context, tx *sql.Tx, id string, progress BuildTaskProgress, lastProgressTime int64) (bool, error)
 	// MarkPending transitions a stopped or failed build task to pending.
-	MarkPending(ctx context.Context, id string, reset bool, updateTime int64) (bool, error)
+	MarkPending(ctx context.Context, id string, reset bool) (bool, error)
 	// MarkRunning transitions a pending build task to running.
-	MarkRunning(ctx context.Context, id string, updateTime int64) (bool, error)
+	MarkRunning(ctx context.Context, id string, startTime int64) (bool, error)
 	// MarkStopping transitions a running build task to stopping.
-	MarkStopping(ctx context.Context, id string, updateTime int64) (bool, error)
+	MarkStopping(ctx context.Context, id string) (bool, error)
 	// MarkStopped transitions a pending or stopping build task to stopped.
-	MarkStopped(ctx context.Context, id string, updateTime int64) (bool, error)
+	MarkStopped(ctx context.Context, id string, finishTime int64) (bool, error)
 	// MarkCompleted transitions a running build task to completed.
-	MarkCompleted(ctx context.Context, tx *sql.Tx, id string, updateTime int64) (bool, error)
+	MarkCompleted(ctx context.Context, tx *sql.Tx, id string, finishTime int64) (bool, error)
 	// MarkFailed fails an active build task.
-	MarkFailed(ctx context.Context, id, detail string, updateTime int64) (bool, error)
+	MarkFailed(ctx context.Context, id, detail string, finishTime int64) (bool, error)
 	// MarkCancelled cancels an active build task.
-	MarkCancelled(ctx context.Context, id, detail string, updateTime int64) (bool, error)
+	MarkCancelled(ctx context.Context, id, detail string, finishTime int64) (bool, error)
 	// MarkCancelledByCatalogID cancels pending build tasks for a deleted catalog.
-	MarkCancelledByCatalogID(ctx context.Context, tx *sql.Tx, catalogID, message string, updateTime int64) error
+	MarkCancelledByCatalogID(ctx context.Context, tx *sql.Tx, catalogID, message string, finishTime int64) error
 	// GetStatus retrieves the status of a build task by ID.
 	GetStatus(ctx context.Context, id string) (string, error)
 

--- a/adp/vega/vega-backend/server/interfaces/discover_task.go
+++ b/adp/vega/vega-backend/server/interfaces/discover_task.go
@@ -19,16 +19,18 @@ const (
 	DiscoverTaskTriggerManual    string = "manual"    // 手动/立即执行
 	DiscoverTaskTriggerScheduled string = "scheduled" // 定时驱动
 
-	DiscoverTaskSortCreateTime string = "create_time"
-	DiscoverTaskSortStartTime  string = "start_time"
-	DiscoverTaskSortFinishTime string = "finish_time"
+	DiscoverTaskSortCreateTime       string = "create_time"
+	DiscoverTaskSortStartTime        string = "start_time"
+	DiscoverTaskSortFinishTime       string = "finish_time"
+	DiscoverTaskSortLastProgressTime string = "last_progress_time"
 )
 
 var (
 	DISCOVER_TASK_SORT = map[string]string{
-		DiscoverTaskSortCreateTime: "",
-		DiscoverTaskSortStartTime:  "",
-		DiscoverTaskSortFinishTime: "",
+		DiscoverTaskSortCreateTime:       "",
+		DiscoverTaskSortStartTime:        "",
+		DiscoverTaskSortFinishTime:       "",
+		DiscoverTaskSortLastProgressTime: "",
 	}
 )
 
@@ -53,12 +55,13 @@ type DiscoverTask struct {
 	Strategy    string `json:"strategy"`     // Discover strategy: full_sync/create_only/cleanup_only
 	TriggerType string `json:"trigger_type"` // manual/scheduled
 
-	Status     string          `json:"status"`   // pending/running/completed/failed/cancelled
-	Progress   int             `json:"progress"` // 0-100
-	Message    string          `json:"message"`
-	StartTime  int64           `json:"start_time,omitempty"`  // 开始执行时间
-	FinishTime int64           `json:"finish_time,omitempty"` // 完成时间
-	Result     *DiscoverResult `json:"result,omitempty"`
+	Status           string          `json:"status"`   // pending/running/completed/failed/cancelled
+	Progress         int             `json:"progress"` // 0-100
+	Message          string          `json:"message"`
+	StartTime        int64           `json:"start_time,omitempty"`         // 开始执行时间
+	FinishTime       int64           `json:"finish_time,omitempty"`        // 完成时间
+	LastProgressTime int64           `json:"last_progress_time,omitempty"` // 最近一次进度更新时间
+	Result           *DiscoverResult `json:"result,omitempty"`
 
 	Creator    AccountInfo `json:"creator"`
 	CreateTime int64       `json:"create_time"`
@@ -77,11 +80,12 @@ type DiscoverTaskSummary struct {
 	Strategy    string `json:"strategy"`
 	TriggerType string `json:"trigger_type"`
 
-	Status     string                     `json:"status"`
-	Progress   int                        `json:"progress"`
-	StartTime  int64                      `json:"start_time,omitempty"`
-	FinishTime int64                      `json:"finish_time,omitempty"`
-	Result     *DiscoverTaskResultSummary `json:"result,omitempty"`
+	Status           string                     `json:"status"`
+	Progress         int                        `json:"progress"`
+	StartTime        int64                      `json:"start_time,omitempty"`
+	FinishTime       int64                      `json:"finish_time,omitempty"`
+	LastProgressTime int64                      `json:"last_progress_time,omitempty"`
+	Result           *DiscoverTaskResultSummary `json:"result,omitempty"`
 
 	Creator    AccountInfo `json:"creator"`
 	CreateTime int64       `json:"create_time"`

--- a/adp/vega/vega-backend/server/interfaces/discover_task_access.go
+++ b/adp/vega/vega-backend/server/interfaces/discover_task_access.go
@@ -27,6 +27,8 @@ type DiscoverTaskAccess interface {
 
 	// MarkRunning transitions a pending DiscoverTask to running.
 	MarkRunning(ctx context.Context, id string, startTime int64) (bool, error)
+	// UpdateProgress stores observable execution progress for a running DiscoverTask.
+	UpdateProgress(ctx context.Context, id string, progress int, message string, lastProgressTime int64) (bool, error)
 	// MarkCompleted completes a running DiscoverTask and stores its result.
 	MarkCompleted(ctx context.Context, id string, result *DiscoverResult, finishTime int64) (bool, error)
 	// MarkFailed only fails pending or running DiscoverTasks.

--- a/adp/vega/vega-backend/server/interfaces/discover_task_service.go
+++ b/adp/vega/vega-backend/server/interfaces/discover_task_service.go
@@ -30,6 +30,8 @@ type DiscoverTaskService interface {
 	InternalList(ctx context.Context, params DiscoverTaskQueryParams) ([]*DiscoverTaskSummary, error)
 	// InternalMarkRunning transitions a pending DiscoverTask to running.
 	InternalMarkRunning(ctx context.Context, id string) (bool, error)
+	// InternalUpdateProgress stores observable execution progress for a running DiscoverTask.
+	InternalUpdateProgress(ctx context.Context, id string, progress int, message string) (bool, error)
 	// InternalMarkCancelled only cancels active DiscoverTasks.
 	InternalMarkCancelled(ctx context.Context, id string, message string) (bool, error)
 	// InternalMarkFailed only fails active DiscoverTasks.

--- a/adp/vega/vega-backend/server/interfaces/mock/mock_build_task_access.go
+++ b/adp/vega/vega-backend/server/interfaces/mock/mock_build_task_access.go
@@ -148,135 +148,135 @@ func (mr *MockBuildTaskAccessMockRecorder) List(ctx, params any) *gomock.Call {
 }
 
 // MarkCancelled mocks base method.
-func (m *MockBuildTaskAccess) MarkCancelled(ctx context.Context, id, detail string, updateTime int64) (bool, error) {
+func (m *MockBuildTaskAccess) MarkCancelled(ctx context.Context, id, detail string, finishTime int64) (bool, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "MarkCancelled", ctx, id, detail, updateTime)
+	ret := m.ctrl.Call(m, "MarkCancelled", ctx, id, detail, finishTime)
 	ret0, _ := ret[0].(bool)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // MarkCancelled indicates an expected call of MarkCancelled.
-func (mr *MockBuildTaskAccessMockRecorder) MarkCancelled(ctx, id, detail, updateTime any) *gomock.Call {
+func (mr *MockBuildTaskAccessMockRecorder) MarkCancelled(ctx, id, detail, finishTime any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MarkCancelled", reflect.TypeOf((*MockBuildTaskAccess)(nil).MarkCancelled), ctx, id, detail, updateTime)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MarkCancelled", reflect.TypeOf((*MockBuildTaskAccess)(nil).MarkCancelled), ctx, id, detail, finishTime)
 }
 
 // MarkCancelledByCatalogID mocks base method.
-func (m *MockBuildTaskAccess) MarkCancelledByCatalogID(ctx context.Context, tx *sql.Tx, catalogID, message string, updateTime int64) error {
+func (m *MockBuildTaskAccess) MarkCancelledByCatalogID(ctx context.Context, tx *sql.Tx, catalogID, message string, finishTime int64) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "MarkCancelledByCatalogID", ctx, tx, catalogID, message, updateTime)
+	ret := m.ctrl.Call(m, "MarkCancelledByCatalogID", ctx, tx, catalogID, message, finishTime)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // MarkCancelledByCatalogID indicates an expected call of MarkCancelledByCatalogID.
-func (mr *MockBuildTaskAccessMockRecorder) MarkCancelledByCatalogID(ctx, tx, catalogID, message, updateTime any) *gomock.Call {
+func (mr *MockBuildTaskAccessMockRecorder) MarkCancelledByCatalogID(ctx, tx, catalogID, message, finishTime any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MarkCancelledByCatalogID", reflect.TypeOf((*MockBuildTaskAccess)(nil).MarkCancelledByCatalogID), ctx, tx, catalogID, message, updateTime)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MarkCancelledByCatalogID", reflect.TypeOf((*MockBuildTaskAccess)(nil).MarkCancelledByCatalogID), ctx, tx, catalogID, message, finishTime)
 }
 
 // MarkCompleted mocks base method.
-func (m *MockBuildTaskAccess) MarkCompleted(ctx context.Context, tx *sql.Tx, id string, updateTime int64) (bool, error) {
+func (m *MockBuildTaskAccess) MarkCompleted(ctx context.Context, tx *sql.Tx, id string, finishTime int64) (bool, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "MarkCompleted", ctx, tx, id, updateTime)
+	ret := m.ctrl.Call(m, "MarkCompleted", ctx, tx, id, finishTime)
 	ret0, _ := ret[0].(bool)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // MarkCompleted indicates an expected call of MarkCompleted.
-func (mr *MockBuildTaskAccessMockRecorder) MarkCompleted(ctx, tx, id, updateTime any) *gomock.Call {
+func (mr *MockBuildTaskAccessMockRecorder) MarkCompleted(ctx, tx, id, finishTime any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MarkCompleted", reflect.TypeOf((*MockBuildTaskAccess)(nil).MarkCompleted), ctx, tx, id, updateTime)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MarkCompleted", reflect.TypeOf((*MockBuildTaskAccess)(nil).MarkCompleted), ctx, tx, id, finishTime)
 }
 
 // MarkFailed mocks base method.
-func (m *MockBuildTaskAccess) MarkFailed(ctx context.Context, id, detail string, updateTime int64) (bool, error) {
+func (m *MockBuildTaskAccess) MarkFailed(ctx context.Context, id, detail string, finishTime int64) (bool, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "MarkFailed", ctx, id, detail, updateTime)
+	ret := m.ctrl.Call(m, "MarkFailed", ctx, id, detail, finishTime)
 	ret0, _ := ret[0].(bool)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // MarkFailed indicates an expected call of MarkFailed.
-func (mr *MockBuildTaskAccessMockRecorder) MarkFailed(ctx, id, detail, updateTime any) *gomock.Call {
+func (mr *MockBuildTaskAccessMockRecorder) MarkFailed(ctx, id, detail, finishTime any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MarkFailed", reflect.TypeOf((*MockBuildTaskAccess)(nil).MarkFailed), ctx, id, detail, updateTime)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MarkFailed", reflect.TypeOf((*MockBuildTaskAccess)(nil).MarkFailed), ctx, id, detail, finishTime)
 }
 
 // MarkPending mocks base method.
-func (m *MockBuildTaskAccess) MarkPending(ctx context.Context, id string, reset bool, updateTime int64) (bool, error) {
+func (m *MockBuildTaskAccess) MarkPending(ctx context.Context, id string, reset bool) (bool, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "MarkPending", ctx, id, reset, updateTime)
+	ret := m.ctrl.Call(m, "MarkPending", ctx, id, reset)
 	ret0, _ := ret[0].(bool)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // MarkPending indicates an expected call of MarkPending.
-func (mr *MockBuildTaskAccessMockRecorder) MarkPending(ctx, id, reset, updateTime any) *gomock.Call {
+func (mr *MockBuildTaskAccessMockRecorder) MarkPending(ctx, id, reset any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MarkPending", reflect.TypeOf((*MockBuildTaskAccess)(nil).MarkPending), ctx, id, reset, updateTime)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MarkPending", reflect.TypeOf((*MockBuildTaskAccess)(nil).MarkPending), ctx, id, reset)
 }
 
 // MarkRunning mocks base method.
-func (m *MockBuildTaskAccess) MarkRunning(ctx context.Context, id string, updateTime int64) (bool, error) {
+func (m *MockBuildTaskAccess) MarkRunning(ctx context.Context, id string, startTime int64) (bool, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "MarkRunning", ctx, id, updateTime)
+	ret := m.ctrl.Call(m, "MarkRunning", ctx, id, startTime)
 	ret0, _ := ret[0].(bool)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // MarkRunning indicates an expected call of MarkRunning.
-func (mr *MockBuildTaskAccessMockRecorder) MarkRunning(ctx, id, updateTime any) *gomock.Call {
+func (mr *MockBuildTaskAccessMockRecorder) MarkRunning(ctx, id, startTime any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MarkRunning", reflect.TypeOf((*MockBuildTaskAccess)(nil).MarkRunning), ctx, id, updateTime)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MarkRunning", reflect.TypeOf((*MockBuildTaskAccess)(nil).MarkRunning), ctx, id, startTime)
 }
 
 // MarkStopped mocks base method.
-func (m *MockBuildTaskAccess) MarkStopped(ctx context.Context, id string, updateTime int64) (bool, error) {
+func (m *MockBuildTaskAccess) MarkStopped(ctx context.Context, id string, finishTime int64) (bool, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "MarkStopped", ctx, id, updateTime)
+	ret := m.ctrl.Call(m, "MarkStopped", ctx, id, finishTime)
 	ret0, _ := ret[0].(bool)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // MarkStopped indicates an expected call of MarkStopped.
-func (mr *MockBuildTaskAccessMockRecorder) MarkStopped(ctx, id, updateTime any) *gomock.Call {
+func (mr *MockBuildTaskAccessMockRecorder) MarkStopped(ctx, id, finishTime any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MarkStopped", reflect.TypeOf((*MockBuildTaskAccess)(nil).MarkStopped), ctx, id, updateTime)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MarkStopped", reflect.TypeOf((*MockBuildTaskAccess)(nil).MarkStopped), ctx, id, finishTime)
 }
 
 // MarkStopping mocks base method.
-func (m *MockBuildTaskAccess) MarkStopping(ctx context.Context, id string, updateTime int64) (bool, error) {
+func (m *MockBuildTaskAccess) MarkStopping(ctx context.Context, id string) (bool, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "MarkStopping", ctx, id, updateTime)
+	ret := m.ctrl.Call(m, "MarkStopping", ctx, id)
 	ret0, _ := ret[0].(bool)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // MarkStopping indicates an expected call of MarkStopping.
-func (mr *MockBuildTaskAccessMockRecorder) MarkStopping(ctx, id, updateTime any) *gomock.Call {
+func (mr *MockBuildTaskAccessMockRecorder) MarkStopping(ctx, id any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MarkStopping", reflect.TypeOf((*MockBuildTaskAccess)(nil).MarkStopping), ctx, id, updateTime)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MarkStopping", reflect.TypeOf((*MockBuildTaskAccess)(nil).MarkStopping), ctx, id)
 }
 
 // SetProgress mocks base method.
-func (m *MockBuildTaskAccess) SetProgress(ctx context.Context, tx *sql.Tx, id string, progress interfaces.BuildTaskProgress, updateTime int64) (bool, error) {
+func (m *MockBuildTaskAccess) SetProgress(ctx context.Context, tx *sql.Tx, id string, progress interfaces.BuildTaskProgress, lastProgressTime int64) (bool, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "SetProgress", ctx, tx, id, progress, updateTime)
+	ret := m.ctrl.Call(m, "SetProgress", ctx, tx, id, progress, lastProgressTime)
 	ret0, _ := ret[0].(bool)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // SetProgress indicates an expected call of SetProgress.
-func (mr *MockBuildTaskAccessMockRecorder) SetProgress(ctx, tx, id, progress, updateTime any) *gomock.Call {
+func (mr *MockBuildTaskAccessMockRecorder) SetProgress(ctx, tx, id, progress, lastProgressTime any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetProgress", reflect.TypeOf((*MockBuildTaskAccess)(nil).SetProgress), ctx, tx, id, progress, updateTime)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetProgress", reflect.TypeOf((*MockBuildTaskAccess)(nil).SetProgress), ctx, tx, id, progress, lastProgressTime)
 }

--- a/adp/vega/vega-backend/server/interfaces/mock/mock_discover_task_access.go
+++ b/adp/vega/vega-backend/server/interfaces/mock/mock_discover_task_access.go
@@ -190,3 +190,18 @@ func (mr *MockDiscoverTaskAccessMockRecorder) MarkRunning(ctx, id, startTime any
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MarkRunning", reflect.TypeOf((*MockDiscoverTaskAccess)(nil).MarkRunning), ctx, id, startTime)
 }
+
+// UpdateProgress mocks base method.
+func (m *MockDiscoverTaskAccess) UpdateProgress(ctx context.Context, id string, progress int, message string, lastProgressTime int64) (bool, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "UpdateProgress", ctx, id, progress, message, lastProgressTime)
+	ret0, _ := ret[0].(bool)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// UpdateProgress indicates an expected call of UpdateProgress.
+func (mr *MockDiscoverTaskAccessMockRecorder) UpdateProgress(ctx, id, progress, message, lastProgressTime any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateProgress", reflect.TypeOf((*MockDiscoverTaskAccess)(nil).UpdateProgress), ctx, id, progress, message, lastProgressTime)
+}

--- a/adp/vega/vega-backend/server/interfaces/mock/mock_discover_task_service.go
+++ b/adp/vega/vega-backend/server/interfaces/mock/mock_discover_task_service.go
@@ -189,6 +189,21 @@ func (mr *MockDiscoverTaskServiceMockRecorder) InternalMarkRunning(ctx, id any) 
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "InternalMarkRunning", reflect.TypeOf((*MockDiscoverTaskService)(nil).InternalMarkRunning), ctx, id)
 }
 
+// InternalUpdateProgress mocks base method.
+func (m *MockDiscoverTaskService) InternalUpdateProgress(ctx context.Context, id string, progress int, message string) (bool, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "InternalUpdateProgress", ctx, id, progress, message)
+	ret0, _ := ret[0].(bool)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// InternalUpdateProgress indicates an expected call of InternalUpdateProgress.
+func (mr *MockDiscoverTaskServiceMockRecorder) InternalUpdateProgress(ctx, id, progress, message any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "InternalUpdateProgress", reflect.TypeOf((*MockDiscoverTaskService)(nil).InternalUpdateProgress), ctx, id, progress, message)
+}
+
 // List mocks base method.
 func (m *MockDiscoverTaskService) List(ctx context.Context, params interfaces.DiscoverTaskQueryParams) ([]*interfaces.DiscoverTaskSummary, int64, error) {
 	m.ctrl.T.Helper()

--- a/adp/vega/vega-backend/server/interfaces/mock/mock_semantic_understanding_task_access.go
+++ b/adp/vega/vega-backend/server/interfaces/mock/mock_semantic_understanding_task_access.go
@@ -148,105 +148,105 @@ func (mr *MockSemanticUnderstandingTaskAccessMockRecorder) List(ctx, params any)
 }
 
 // MarkCancelled mocks base method.
-func (m *MockSemanticUnderstandingTaskAccess) MarkCancelled(ctx context.Context, id, failureDetail string, updateTime int64) (bool, error) {
+func (m *MockSemanticUnderstandingTaskAccess) MarkCancelled(ctx context.Context, id, failureDetail string, finishTime int64) (bool, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "MarkCancelled", ctx, id, failureDetail, updateTime)
+	ret := m.ctrl.Call(m, "MarkCancelled", ctx, id, failureDetail, finishTime)
 	ret0, _ := ret[0].(bool)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // MarkCancelled indicates an expected call of MarkCancelled.
-func (mr *MockSemanticUnderstandingTaskAccessMockRecorder) MarkCancelled(ctx, id, failureDetail, updateTime any) *gomock.Call {
+func (mr *MockSemanticUnderstandingTaskAccessMockRecorder) MarkCancelled(ctx, id, failureDetail, finishTime any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MarkCancelled", reflect.TypeOf((*MockSemanticUnderstandingTaskAccess)(nil).MarkCancelled), ctx, id, failureDetail, updateTime)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MarkCancelled", reflect.TypeOf((*MockSemanticUnderstandingTaskAccess)(nil).MarkCancelled), ctx, id, failureDetail, finishTime)
 }
 
 // MarkCancelledByCatalogID mocks base method.
-func (m *MockSemanticUnderstandingTaskAccess) MarkCancelledByCatalogID(ctx context.Context, tx *sql.Tx, catalogID, failureDetail string, updateTime int64) error {
+func (m *MockSemanticUnderstandingTaskAccess) MarkCancelledByCatalogID(ctx context.Context, tx *sql.Tx, catalogID, failureDetail string, finishTime int64) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "MarkCancelledByCatalogID", ctx, tx, catalogID, failureDetail, updateTime)
+	ret := m.ctrl.Call(m, "MarkCancelledByCatalogID", ctx, tx, catalogID, failureDetail, finishTime)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // MarkCancelledByCatalogID indicates an expected call of MarkCancelledByCatalogID.
-func (mr *MockSemanticUnderstandingTaskAccessMockRecorder) MarkCancelledByCatalogID(ctx, tx, catalogID, failureDetail, updateTime any) *gomock.Call {
+func (mr *MockSemanticUnderstandingTaskAccessMockRecorder) MarkCancelledByCatalogID(ctx, tx, catalogID, failureDetail, finishTime any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MarkCancelledByCatalogID", reflect.TypeOf((*MockSemanticUnderstandingTaskAccess)(nil).MarkCancelledByCatalogID), ctx, tx, catalogID, failureDetail, updateTime)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MarkCancelledByCatalogID", reflect.TypeOf((*MockSemanticUnderstandingTaskAccess)(nil).MarkCancelledByCatalogID), ctx, tx, catalogID, failureDetail, finishTime)
 }
 
 // MarkCompleted mocks base method.
-func (m *MockSemanticUnderstandingTaskAccess) MarkCompleted(ctx context.Context, id, resultJSON string, confidence float64, confidenceDetailJSON string, updateTime int64) (bool, error) {
+func (m *MockSemanticUnderstandingTaskAccess) MarkCompleted(ctx context.Context, tx *sql.Tx, id, resultJSON string, confidence float64, confidenceDetailJSON string, finishTime int64) (bool, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "MarkCompleted", ctx, id, resultJSON, confidence, confidenceDetailJSON, updateTime)
+	ret := m.ctrl.Call(m, "MarkCompleted", ctx, tx, id, resultJSON, confidence, confidenceDetailJSON, finishTime)
 	ret0, _ := ret[0].(bool)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // MarkCompleted indicates an expected call of MarkCompleted.
-func (mr *MockSemanticUnderstandingTaskAccessMockRecorder) MarkCompleted(ctx, id, resultJSON, confidence, confidenceDetailJSON, updateTime any) *gomock.Call {
+func (mr *MockSemanticUnderstandingTaskAccessMockRecorder) MarkCompleted(ctx, tx, id, resultJSON, confidence, confidenceDetailJSON, finishTime any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MarkCompleted", reflect.TypeOf((*MockSemanticUnderstandingTaskAccess)(nil).MarkCompleted), ctx, id, resultJSON, confidence, confidenceDetailJSON, updateTime)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MarkCompleted", reflect.TypeOf((*MockSemanticUnderstandingTaskAccess)(nil).MarkCompleted), ctx, tx, id, resultJSON, confidence, confidenceDetailJSON, finishTime)
 }
 
 // MarkFailed mocks base method.
-func (m *MockSemanticUnderstandingTaskAccess) MarkFailed(ctx context.Context, id, failureDetail string, updateTime int64) (bool, error) {
+func (m *MockSemanticUnderstandingTaskAccess) MarkFailed(ctx context.Context, id, failureDetail string, finishTime int64) (bool, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "MarkFailed", ctx, id, failureDetail, updateTime)
+	ret := m.ctrl.Call(m, "MarkFailed", ctx, id, failureDetail, finishTime)
 	ret0, _ := ret[0].(bool)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // MarkFailed indicates an expected call of MarkFailed.
-func (mr *MockSemanticUnderstandingTaskAccessMockRecorder) MarkFailed(ctx, id, failureDetail, updateTime any) *gomock.Call {
+func (mr *MockSemanticUnderstandingTaskAccessMockRecorder) MarkFailed(ctx, id, failureDetail, finishTime any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MarkFailed", reflect.TypeOf((*MockSemanticUnderstandingTaskAccess)(nil).MarkFailed), ctx, id, failureDetail, updateTime)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MarkFailed", reflect.TypeOf((*MockSemanticUnderstandingTaskAccess)(nil).MarkFailed), ctx, id, failureDetail, finishTime)
 }
 
 // MarkRunning mocks base method.
-func (m *MockSemanticUnderstandingTaskAccess) MarkRunning(ctx context.Context, id string, updateTime int64) (bool, error) {
+func (m *MockSemanticUnderstandingTaskAccess) MarkRunning(ctx context.Context, id string, startTime int64) (bool, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "MarkRunning", ctx, id, updateTime)
+	ret := m.ctrl.Call(m, "MarkRunning", ctx, id, startTime)
 	ret0, _ := ret[0].(bool)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // MarkRunning indicates an expected call of MarkRunning.
-func (mr *MockSemanticUnderstandingTaskAccessMockRecorder) MarkRunning(ctx, id, updateTime any) *gomock.Call {
+func (mr *MockSemanticUnderstandingTaskAccessMockRecorder) MarkRunning(ctx, id, startTime any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MarkRunning", reflect.TypeOf((*MockSemanticUnderstandingTaskAccess)(nil).MarkRunning), ctx, id, updateTime)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MarkRunning", reflect.TypeOf((*MockSemanticUnderstandingTaskAccess)(nil).MarkRunning), ctx, id, startTime)
 }
 
 // SetAgentTaskID mocks base method.
-func (m *MockSemanticUnderstandingTaskAccess) SetAgentTaskID(ctx context.Context, id, agentTaskID string, updateTime int64) (bool, error) {
+func (m *MockSemanticUnderstandingTaskAccess) SetAgentTaskID(ctx context.Context, id, agentTaskID string) (bool, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "SetAgentTaskID", ctx, id, agentTaskID, updateTime)
+	ret := m.ctrl.Call(m, "SetAgentTaskID", ctx, id, agentTaskID)
 	ret0, _ := ret[0].(bool)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // SetAgentTaskID indicates an expected call of SetAgentTaskID.
-func (mr *MockSemanticUnderstandingTaskAccessMockRecorder) SetAgentTaskID(ctx, id, agentTaskID, updateTime any) *gomock.Call {
+func (mr *MockSemanticUnderstandingTaskAccessMockRecorder) SetAgentTaskID(ctx, id, agentTaskID any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetAgentTaskID", reflect.TypeOf((*MockSemanticUnderstandingTaskAccess)(nil).SetAgentTaskID), ctx, id, agentTaskID, updateTime)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetAgentTaskID", reflect.TypeOf((*MockSemanticUnderstandingTaskAccess)(nil).SetAgentTaskID), ctx, id, agentTaskID)
 }
 
 // SetApplied mocks base method.
-func (m *MockSemanticUnderstandingTaskAccess) SetApplied(ctx context.Context, tx *sql.Tx, id string, applied bool, appliedTime int64, applyDetailJSON string) (bool, error) {
+func (m *MockSemanticUnderstandingTaskAccess) SetApplied(ctx context.Context, tx *sql.Tx, id string, applied bool, applyDetailJSON string) (bool, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "SetApplied", ctx, tx, id, applied, appliedTime, applyDetailJSON)
+	ret := m.ctrl.Call(m, "SetApplied", ctx, tx, id, applied, applyDetailJSON)
 	ret0, _ := ret[0].(bool)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // SetApplied indicates an expected call of SetApplied.
-func (mr *MockSemanticUnderstandingTaskAccessMockRecorder) SetApplied(ctx, tx, id, applied, appliedTime, applyDetailJSON any) *gomock.Call {
+func (mr *MockSemanticUnderstandingTaskAccessMockRecorder) SetApplied(ctx, tx, id, applied, applyDetailJSON any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetApplied", reflect.TypeOf((*MockSemanticUnderstandingTaskAccess)(nil).SetApplied), ctx, tx, id, applied, appliedTime, applyDetailJSON)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetApplied", reflect.TypeOf((*MockSemanticUnderstandingTaskAccess)(nil).SetApplied), ctx, tx, id, applied, applyDetailJSON)
 }

--- a/adp/vega/vega-backend/server/interfaces/mock/mock_semantic_understanding_task_service.go
+++ b/adp/vega/vega-backend/server/interfaces/mock/mock_semantic_understanding_task_service.go
@@ -161,18 +161,18 @@ func (mr *MockSemanticUnderstandingTaskServiceMockRecorder) InternalMarkCancelle
 }
 
 // InternalMarkCompleted mocks base method.
-func (m *MockSemanticUnderstandingTaskService) InternalMarkCompleted(ctx context.Context, id, resultJSON string, confidence float64, confidenceDetailJSON string) (bool, error) {
+func (m *MockSemanticUnderstandingTaskService) InternalMarkCompleted(ctx context.Context, tx *sql.Tx, id, resultJSON string, confidence float64, confidenceDetailJSON string) (bool, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "InternalMarkCompleted", ctx, id, resultJSON, confidence, confidenceDetailJSON)
+	ret := m.ctrl.Call(m, "InternalMarkCompleted", ctx, tx, id, resultJSON, confidence, confidenceDetailJSON)
 	ret0, _ := ret[0].(bool)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // InternalMarkCompleted indicates an expected call of InternalMarkCompleted.
-func (mr *MockSemanticUnderstandingTaskServiceMockRecorder) InternalMarkCompleted(ctx, id, resultJSON, confidence, confidenceDetailJSON any) *gomock.Call {
+func (mr *MockSemanticUnderstandingTaskServiceMockRecorder) InternalMarkCompleted(ctx, tx, id, resultJSON, confidence, confidenceDetailJSON any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "InternalMarkCompleted", reflect.TypeOf((*MockSemanticUnderstandingTaskService)(nil).InternalMarkCompleted), ctx, id, resultJSON, confidence, confidenceDetailJSON)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "InternalMarkCompleted", reflect.TypeOf((*MockSemanticUnderstandingTaskService)(nil).InternalMarkCompleted), ctx, tx, id, resultJSON, confidence, confidenceDetailJSON)
 }
 
 // InternalMarkFailed mocks base method.

--- a/adp/vega/vega-backend/server/interfaces/semantic_understanding_task.go
+++ b/adp/vega/vega-backend/server/interfaces/semantic_understanding_task.go
@@ -20,7 +20,8 @@ const (
 	SemanticUnderstandingApplyModeForce     string = "force"
 
 	SemanticUnderstandingTaskSortCreateTime string = "create_time"
-	SemanticUnderstandingTaskSortUpdateTime string = "update_time"
+	SemanticUnderstandingTaskSortStartTime  string = "start_time"
+	SemanticUnderstandingTaskSortFinishTime string = "finish_time"
 
 	SemanticUnderstandingResourceAgentID string = "resource-semantic-understanding"
 	SemanticUnderstandingCatalogAgentID  string = "catalog-semantic-understanding"
@@ -40,7 +41,8 @@ var (
 
 	SEMANTIC_UNDERSTANDING_TASK_SORT = map[string]string{
 		SemanticUnderstandingTaskSortCreateTime: "",
-		SemanticUnderstandingTaskSortUpdateTime: "",
+		SemanticUnderstandingTaskSortStartTime:  "",
+		SemanticUnderstandingTaskSortFinishTime: "",
 	}
 )
 
@@ -65,11 +67,11 @@ type SemanticUnderstandingTask struct {
 	ConfidenceDetailJSON string      `json:"confidence_detail_json,omitempty"`
 	ApplyDetailJSON      string      `json:"apply_detail_json,omitempty"`
 	Applied              bool        `json:"applied"`
-	AppliedTime          int64       `json:"applied_time,omitempty"`
 	FailureDetail        string      `json:"failure_detail,omitempty"`
 	Creator              AccountInfo `json:"creator"`
 	CreateTime           int64       `json:"create_time"`
-	UpdateTime           int64       `json:"update_time"`
+	StartTime            int64       `json:"start_time,omitempty"`
+	FinishTime           int64       `json:"finish_time,omitempty"`
 }
 
 // SemanticUnderstandingTaskSummary is the lightweight representation returned
@@ -88,10 +90,10 @@ type SemanticUnderstandingTaskSummary struct {
 	ConfidenceThreshold float64     `json:"confidence_threshold"`
 	Confidence          float64     `json:"confidence"`
 	Applied             bool        `json:"applied"`
-	AppliedTime         int64       `json:"applied_time,omitempty"`
 	Creator             AccountInfo `json:"creator"`
 	CreateTime          int64       `json:"create_time"`
-	UpdateTime          int64       `json:"update_time"`
+	StartTime           int64       `json:"start_time,omitempty"`
+	FinishTime          int64       `json:"finish_time,omitempty"`
 }
 
 type SemanticUnderstandingSamplePolicy struct {

--- a/adp/vega/vega-backend/server/interfaces/semantic_understanding_task_access.go
+++ b/adp/vega/vega-backend/server/interfaces/semantic_understanding_task_access.go
@@ -20,14 +20,14 @@ type SemanticUnderstandingTaskAccess interface {
 	List(ctx context.Context, params SemanticUnderstandingTaskQueryParams) ([]*SemanticUnderstandingTaskSummary, int64, error)
 	DeleteByIDs(ctx context.Context, ids []string) (int64, error)
 
-	MarkRunning(ctx context.Context, id string, updateTime int64) (bool, error)
-	MarkCompleted(ctx context.Context, id string, resultJSON string, confidence float64, confidenceDetailJSON string, updateTime int64) (bool, error)
-	MarkFailed(ctx context.Context, id string, failureDetail string, updateTime int64) (bool, error)
-	MarkCancelled(ctx context.Context, id string, failureDetail string, updateTime int64) (bool, error)
-	MarkCancelledByCatalogID(ctx context.Context, tx *sql.Tx, catalogID, failureDetail string, updateTime int64) error
+	MarkRunning(ctx context.Context, id string, startTime int64) (bool, error)
+	MarkCompleted(ctx context.Context, tx *sql.Tx, id string, resultJSON string, confidence float64, confidenceDetailJSON string, finishTime int64) (bool, error)
+	MarkFailed(ctx context.Context, id string, failureDetail string, finishTime int64) (bool, error)
+	MarkCancelled(ctx context.Context, id string, failureDetail string, finishTime int64) (bool, error)
+	MarkCancelledByCatalogID(ctx context.Context, tx *sql.Tx, catalogID, failureDetail string, finishTime int64) error
 
-	SetAgentTaskID(ctx context.Context, id string, agentTaskID string, updateTime int64) (bool, error)
-	SetApplied(ctx context.Context, tx *sql.Tx, id string, applied bool, appliedTime int64, applyDetailJSON string) (bool, error)
+	SetAgentTaskID(ctx context.Context, id string, agentTaskID string) (bool, error)
+	SetApplied(ctx context.Context, tx *sql.Tx, id string, applied bool, applyDetailJSON string) (bool, error)
 
 	InternalList(ctx context.Context, params SemanticUnderstandingTaskQueryParams) ([]*SemanticUnderstandingTaskSummary, error)
 }

--- a/adp/vega/vega-backend/server/interfaces/semantic_understanding_task_service.go
+++ b/adp/vega/vega-backend/server/interfaces/semantic_understanding_task_service.go
@@ -23,7 +23,7 @@ type SemanticUnderstandingTaskService interface {
 	InternalList(ctx context.Context, params SemanticUnderstandingTaskQueryParams) ([]*SemanticUnderstandingTaskSummary, error)
 
 	InternalMarkRunning(ctx context.Context, id string) (bool, error)
-	InternalMarkCompleted(ctx context.Context, id string, resultJSON string, confidence float64, confidenceDetailJSON string) (bool, error)
+	InternalMarkCompleted(ctx context.Context, tx *sql.Tx, id string, resultJSON string, confidence float64, confidenceDetailJSON string) (bool, error)
 	InternalMarkFailed(ctx context.Context, id string, failureDetail string) (bool, error)
 	InternalMarkCancelled(ctx context.Context, id string, failureDetail string) (bool, error)
 	InternalSetAgentTaskID(ctx context.Context, id string, agentTaskID string) (bool, error)

--- a/adp/vega/vega-backend/server/logics/build_task/build_task_service.go
+++ b/adp/vega/vega-backend/server/logics/build_task/build_task_service.go
@@ -290,7 +290,6 @@ func (bts *buildTaskService) newBuildTaskFromCreateRequest(ctx context.Context, 
 		ExecuteType: req.ExecuteType,
 		Creator:     accountInfo,
 		CreateTime:  now,
-		UpdateTime:  now,
 	}
 
 	if err := bts.fillBuildTaskIndexSnapshot(ctx, resource, buildTask); err != nil {
@@ -764,7 +763,7 @@ func (bts *buildTaskService) Start(ctx context.Context, taskID string, reset boo
 	// Persist pending before signaling the worker. This prevents a stopped task
 	// from being skipped and keeps the running transition owned by execution.
 	resetProgress := reset && buildTask.ExecuteType == interfaces.BuildTaskExecuteTypeFull
-	updated, err := bts.bta.MarkPending(ctx, taskID, resetProgress, time.Now().UnixMilli())
+	updated, err := bts.bta.MarkPending(ctx, taskID, resetProgress)
 	if err != nil {
 		otellog.LogError(ctx, "Update build task status failed", err)
 		return rest.NewHTTPError(ctx, http.StatusInternalServerError, verrors.VegaBackend_BuildTask_InternalError_UpdateFailed).
@@ -855,7 +854,7 @@ func (bts *buildTaskService) Stop(ctx context.Context, taskID string) error {
 	if buildTask.Status == interfaces.BuildTaskStatusPending {
 		updated, err = bts.bta.MarkStopped(ctx, taskID, time.Now().UnixMilli())
 	} else {
-		updated, err = bts.bta.MarkStopping(ctx, taskID, time.Now().UnixMilli())
+		updated, err = bts.bta.MarkStopping(ctx, taskID)
 	}
 	if err != nil {
 		otellog.LogError(ctx, "Update build task status failed", err)

--- a/adp/vega/vega-backend/server/logics/build_task/build_task_service_test.go
+++ b/adp/vega/vega-backend/server/logics/build_task/build_task_service_test.go
@@ -861,7 +861,7 @@ func TestBuildTaskServiceStartBuildTask(t *testing.T) {
 			},
 			SchemaDefinition: []*interfaces.Property{{Name: "id", Type: interfaces.DataType_Integer}},
 		}, nil)
-		mockBTA.EXPECT().MarkPending(gomock.Any(), "task-1", true, gomock.Any()).Return(true, nil)
+		mockBTA.EXPECT().MarkPending(gomock.Any(), "task-1", true).Return(true, nil)
 
 		require.NoError(t, service.Start(context.Background(), "task-1", true))
 		select {
@@ -898,7 +898,7 @@ func TestBuildTaskServiceStartBuildTask(t *testing.T) {
 			},
 			SchemaDefinition: []*interfaces.Property{{Name: "id", Type: interfaces.DataType_Integer}},
 		}, nil)
-		mockBTA.EXPECT().MarkPending(gomock.Any(), "task-1", false, gomock.Any()).Return(false, nil)
+		mockBTA.EXPECT().MarkPending(gomock.Any(), "task-1", false).Return(false, nil)
 
 		err := service.Start(context.Background(), "task-1", false)
 		httpErr := requireHTTPError(t, err, verrors.VegaBackend_BuildTask_InvalidStateTransition)
@@ -1182,7 +1182,7 @@ func TestBuildTaskServiceStopBuildTask(t *testing.T) {
 
 		mockBTA.EXPECT().GetByID(gomock.Any(), "task-1").
 			Return(&interfaces.BuildTask{ID: "task-1", Status: interfaces.BuildTaskStatusRunning}, nil)
-		mockBTA.EXPECT().MarkStopping(gomock.Any(), "task-1", gomock.Any()).Return(true, nil)
+		mockBTA.EXPECT().MarkStopping(gomock.Any(), "task-1").Return(true, nil)
 
 		require.NoError(t, service.Stop(context.Background(), "task-1"))
 	})

--- a/adp/vega/vega-backend/server/logics/discover_task/discover_task_service.go
+++ b/adp/vega/vega-backend/server/logics/discover_task/discover_task_service.go
@@ -268,6 +268,13 @@ func (dts *discoverTaskService) InternalMarkRunning(ctx context.Context, id stri
 	return dts.dta.MarkRunning(ctx, id, time.Now().UnixMilli())
 }
 
+func (dts *discoverTaskService) InternalUpdateProgress(ctx context.Context, id string, progress int, message string) (bool, error) {
+	ctx, span := oteltrace.StartNamedInternalSpan(ctx, "DiscoverTaskService.InternalUpdateProgress")
+	defer span.End()
+
+	return dts.dta.UpdateProgress(ctx, id, progress, message, time.Now().UnixMilli())
+}
+
 func (dts *discoverTaskService) InternalMarkCancelled(ctx context.Context, id string, message string) (bool, error) {
 	ctx, span := oteltrace.StartNamedInternalSpan(ctx, "DiscoverTaskService.InternalMarkCancelled")
 	defer span.End()

--- a/adp/vega/vega-backend/server/logics/discover_task/discover_task_service_test.go
+++ b/adp/vega/vega-backend/server/logics/discover_task/discover_task_service_test.go
@@ -59,6 +59,20 @@ func TestDiscoverTaskServiceCreateRequestsDispatchAfterPersistence(t *testing.T)
 	}
 }
 
+func TestDiscoverTaskServiceInternalUpdateProgress(t *testing.T) {
+	service, dta, _ := newTestDiscoverTaskService(t)
+	dta.EXPECT().UpdateProgress(gomock.Any(), "task-1", 70, "resources reconciled", gomock.Any()).
+		DoAndReturn(func(_ context.Context, _ string, _ int, _ string, lastProgressTime int64) (bool, error) {
+			assert.Positive(t, lastProgressTime)
+			return true, nil
+		})
+
+	updated, err := service.InternalUpdateProgress(context.Background(), "task-1", 70, "resources reconciled")
+
+	require.NoError(t, err)
+	assert.True(t, updated)
+}
+
 func TestDiscoverTaskServiceGetAndList(t *testing.T) {
 	t.Run("get enriches creator name", func(t *testing.T) {
 		service, dta, ums := newTestDiscoverTaskService(t)

--- a/adp/vega/vega-backend/server/logics/semantic_understanding_task/semantic_understanding_task_service.go
+++ b/adp/vega/vega-backend/server/logics/semantic_understanding_task/semantic_understanding_task_service.go
@@ -172,7 +172,6 @@ func (suts *semanticUnderstandingTaskService) createTask(ctx context.Context, ta
 	task.Status = interfaces.SemanticUnderstandingTaskStatusPending
 	task.Creator = accountInfo
 	task.CreateTime = now
-	task.UpdateTime = now
 	if err := suts.suta.Create(ctx, task); err != nil {
 		return nil, rest.NewHTTPError(ctx, http.StatusInternalServerError, verrors.VegaBackend_InternalError_CreateResourcesFailed).
 			WithErrorDetails(err.Error())
@@ -224,7 +223,7 @@ func (suts *semanticUnderstandingTaskService) InternalSetApplied(ctx context.Con
 	ctx, span := oteltrace.StartNamedInternalSpan(ctx, "SemanticUnderstandingTaskService.InternalSetApplied")
 	defer span.End()
 
-	return suts.suta.SetApplied(ctx, tx, id, applied, time.Now().UnixMilli(), applyDetailJSON)
+	return suts.suta.SetApplied(ctx, tx, id, applied, applyDetailJSON)
 }
 
 func (suts *semanticUnderstandingTaskService) List(ctx context.Context, params interfaces.SemanticUnderstandingTaskQueryParams) ([]*interfaces.SemanticUnderstandingTaskSummary, int64, error) {
@@ -449,10 +448,10 @@ func (suts *semanticUnderstandingTaskService) InternalSetAgentTaskID(ctx context
 		return false, rest.NewHTTPError(ctx, http.StatusBadRequest, verrors.VegaBackend_InvalidParameter_Format).
 			WithErrorDetails("agent_task_id is required")
 	}
-	return suts.suta.SetAgentTaskID(ctx, id, agentTaskID, time.Now().UnixMilli())
+	return suts.suta.SetAgentTaskID(ctx, id, agentTaskID)
 }
 
-func (suts *semanticUnderstandingTaskService) InternalMarkCompleted(ctx context.Context, id string, resultJSON string, confidence float64, confidenceDetailJSON string) (bool, error) {
+func (suts *semanticUnderstandingTaskService) InternalMarkCompleted(ctx context.Context, tx *sql.Tx, id string, resultJSON string, confidence float64, confidenceDetailJSON string) (bool, error) {
 	ctx, span := oteltrace.StartNamedInternalSpan(ctx, "SemanticUnderstandingTaskService.InternalMarkCompleted")
 	defer span.End()
 
@@ -460,7 +459,7 @@ func (suts *semanticUnderstandingTaskService) InternalMarkCompleted(ctx context.
 		return false, rest.NewHTTPError(ctx, http.StatusBadRequest, verrors.VegaBackend_InvalidParameter_Format).
 			WithErrorDetails("confidence must be between 0 and 1")
 	}
-	return suts.suta.MarkCompleted(ctx, id, resultJSON, confidence, confidenceDetailJSON, time.Now().UnixMilli())
+	return suts.suta.MarkCompleted(ctx, tx, id, resultJSON, confidence, confidenceDetailJSON, time.Now().UnixMilli())
 }
 
 func (suts *semanticUnderstandingTaskService) InternalMarkFailed(ctx context.Context, id string, failureDetail string) (bool, error) {

--- a/adp/vega/vega-backend/server/logics/semantic_understanding_task/semantic_understanding_task_service_test.go
+++ b/adp/vega/vega-backend/server/logics/semantic_understanding_task/semantic_understanding_task_service_test.go
@@ -438,10 +438,10 @@ func TestSemanticUnderstandingTaskServiceStatusUpdates(t *testing.T) {
 	assert.True(t, running)
 
 	taskAccess.EXPECT().
-		MarkCompleted(gomock.Any(), "semantic-task-1", `{"confidence":0.8}`, 0.8, `{"fields":[]}`, gomock.Any()).
+		MarkCompleted(gomock.Any(), nil, "semantic-task-1", `{"confidence":0.8}`, 0.8, `{"fields":[]}`, gomock.Any()).
 		Return(true, nil)
 
-	completed, err := service.InternalMarkCompleted(context.Background(), "semantic-task-1", `{"confidence":0.8}`, 0.8, `{"fields":[]}`)
+	completed, err := service.InternalMarkCompleted(context.Background(), nil, "semantic-task-1", `{"confidence":0.8}`, 0.8, `{"fields":[]}`)
 	require.NoError(t, err)
 	assert.True(t, completed)
 }

--- a/adp/vega/vega-backend/server/worker/discover_fileset.go
+++ b/adp/vega/vega-backend/server/worker/discover_fileset.go
@@ -22,8 +22,9 @@ type filesetDiscoverItem struct {
 }
 
 // discoverFilesetResources discovers fileset resources from a fileset connector.
-func (dtw *DiscoverTaskWorker) discoverFilesetResources(ctx context.Context, catalog *interfaces.Catalog,
-	connector interfaces.Connector, task *interfaces.DiscoverTask) (*interfaces.DiscoverResult, error) {
+func (dtw *DiscoverTaskWorker) discoverFilesetResources(ctx context.Context,
+	task *interfaces.DiscoverTask, catalog *interfaces.Catalog, connector interfaces.Connector,
+	progress *discoverTaskReconcileProgress) (*interfaces.DiscoverResult, error) {
 
 	filesetConnector, ok := connector.(interfaces.FilesetConnector)
 	if !ok {
@@ -34,21 +35,39 @@ func (dtw *DiscoverTaskWorker) discoverFilesetResources(ctx context.Context, cat
 	if err != nil {
 		return nil, fmt.Errorf("failed to list filesets: %w", err)
 	}
+	if current, changed := progress.MarkSourceListed(); changed {
+		if err := dtw.updateProgress(ctx, task.ID, current, "source filesets listed"); err != nil {
+			return nil, err
+		}
+	}
 	logger.Infof("Discovered %d fileset objects from source", len(sourceFilesets))
 
 	existingResources, err := dtw.rs.GetByCatalogID(ctx, catalog.ID)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get existing resources: %w", err)
 	}
+	logger.Infof("Loaded %d existing resources for fileset discovery", len(existingResources))
 
-	result, items, err := dtw.reconcileFilesetResources(ctx, catalog, sourceFilesets, existingResources, task.DiscoverActions)
+	result, items, err := dtw.reconcileFilesetResources(ctx, task, catalog, sourceFilesets, existingResources)
 	if err != nil {
 		return nil, fmt.Errorf("failed to reconcile fileset resources: %w", err)
 	}
+	if current, changed := progress.MarkResourcesReconciled(); changed {
+		if err := dtw.updateProgress(ctx, task.ID, current, "resources reconciled"); err != nil {
+			return nil, err
+		}
+	}
+	logger.Infof("Reconciled %d fileset resources", len(items))
 
-	if err := dtw.enrichFilesetMetadata(ctx, items, result); err != nil {
+	if err := dtw.enrichFilesetMetadata(ctx, task, items, result, progress); err != nil {
 		return nil, fmt.Errorf("failed to enrich fileset metadata: %w", err)
 	}
+	if current, changed := progress.MarkMetadataEnriched(); changed {
+		if err := dtw.updateProgress(ctx, task.ID, current, "resource metadata enriched"); err != nil {
+			return nil, err
+		}
+	}
+	logger.Infof("Enriched metadata for %d fileset resources", len(items))
 
 	result.Message = formatDiscoverResultMessage(result)
 	logger.Info(result.Message)
@@ -56,11 +75,15 @@ func (dtw *DiscoverTaskWorker) discoverFilesetResources(ctx context.Context, cat
 	return result, nil
 }
 
-func (dtw *DiscoverTaskWorker) reconcileFilesetResources(ctx context.Context, catalog *interfaces.Catalog, source []*interfaces.FilesetMeta,
-	existingResources []*interfaces.Resource, actions *interfaces.DiscoverActions) (*interfaces.DiscoverResult, []filesetDiscoverItem, error) {
+func (dtw *DiscoverTaskWorker) reconcileFilesetResources(ctx context.Context, task *interfaces.DiscoverTask,
+	catalog *interfaces.Catalog, source []*interfaces.FilesetMeta,
+	existingResources []*interfaces.Resource) (*interfaces.DiscoverResult, []filesetDiscoverItem, error) {
+
+	actions := task.DiscoverActions
 	result := &interfaces.DiscoverResult{
 		CatalogID: catalog.ID,
 	}
+
 	var items []filesetDiscoverItem
 
 	existingMap := make(map[string]*interfaces.Resource)
@@ -70,7 +93,6 @@ func (dtw *DiscoverTaskWorker) reconcileFilesetResources(ctx context.Context, ca
 		}
 		existingMap[r.SourceIdentifier] = r
 	}
-
 	sourceMap := make(map[string]*interfaces.FilesetMeta)
 	for _, fs := range source {
 		sid := filesetSourceIdentifier(fs)
@@ -124,7 +146,6 @@ func (dtw *DiscoverTaskWorker) reconcileFilesetResources(ctx context.Context, ca
 			}
 		}
 	}
-
 	return result, items, nil
 }
 
@@ -158,7 +179,10 @@ func (dtw *DiscoverTaskWorker) createFilesetResource(ctx context.Context, catalo
 	return resource, nil
 }
 
-func (dtw *DiscoverTaskWorker) enrichFilesetMetadata(ctx context.Context, items []filesetDiscoverItem, result *interfaces.DiscoverResult) error {
+func (dtw *DiscoverTaskWorker) enrichFilesetMetadata(ctx context.Context, task *interfaces.DiscoverTask,
+	items []filesetDiscoverItem, result *interfaces.DiscoverResult, progress *discoverTaskReconcileProgress) error {
+	progress.SetMetadataTotal(len(items))
+
 	for _, item := range items {
 		fs := item.meta
 		resource := item.resource
@@ -199,6 +223,12 @@ func (dtw *DiscoverTaskWorker) enrichFilesetMetadata(ctx context.Context, items 
 			return err
 		}
 		logger.Infof("Enriched fileset resource %s (%s)", resource.Name, fs.ID)
+		if current, changed := progress.AdvanceMetadata(); changed {
+			message := fmt.Sprintf("resource metadata enriched: %d/%d", progress.metadataProcessed, progress.metadataTotal)
+			if err := dtw.updateProgress(ctx, task.ID, current, message); err != nil {
+				return err
+			}
+		}
 	}
 	return nil
 }

--- a/adp/vega/vega-backend/server/worker/discover_fileset_test.go
+++ b/adp/vega/vega-backend/server/worker/discover_fileset_test.go
@@ -43,8 +43,8 @@ func TestReconcileFilesetResources(t *testing.T) {
 			})
 		rs.EXPECT().UpdateDiscoverStatus(gomock.Any(), "r1", interfaces.DiscoverStatusNew).Return(nil)
 
-		result, items, err := dh.reconcileFilesetResources(context.Background(), &interfaces.Catalog{ID: "catalog-1"},
-			[]*interfaces.FilesetMeta{{ID: "fs-1", Name: "Docs", DisplayPath: "/team/docs"}}, nil, &actions)
+		result, items, err := dh.reconcileFilesetResources(context.Background(), &interfaces.DiscoverTask{DiscoverActions: &actions}, &interfaces.Catalog{ID: "catalog-1"},
+			[]*interfaces.FilesetMeta{{ID: "fs-1", Name: "Docs", DisplayPath: "/team/docs"}}, nil)
 
 		require.NoError(t, err)
 		assert.Equal(t, 1, result.NewCount)
@@ -62,14 +62,14 @@ func TestReconcileFilesetResources(t *testing.T) {
 		rs.EXPECT().UpdateDiscoverStatus(gomock.Any(), "r1", interfaces.DiscoverStatusMissing).Return(nil)
 		rs.EXPECT().UpdateStatus(gomock.Any(), "r1", interfaces.ResourceStatusStale, "").Return(nil)
 
-		result, items, err := dh.reconcileFilesetResources(context.Background(), &interfaces.Catalog{ID: "catalog-1"},
+		result, items, err := dh.reconcileFilesetResources(context.Background(), &interfaces.DiscoverTask{DiscoverActions: &actions}, &interfaces.Catalog{ID: "catalog-1"},
 			nil,
 			[]*interfaces.Resource{{
 				ID:               "r1",
 				SourceIdentifier: "/team/docs",
 				Category:         interfaces.ResourceCategoryFileset,
 				Status:           interfaces.ResourceStatusActive,
-			}}, &actions)
+			}})
 
 		require.NoError(t, err)
 		assert.Equal(t, 1, result.StaleCount)
@@ -103,7 +103,7 @@ func TestEnrichFilesetMetadata(t *testing.T) {
 			})
 
 		result := &interfaces.DiscoverResult{}
-		err := dh.enrichFilesetMetadata(context.Background(), []filesetDiscoverItem{{
+		err := dh.enrichFilesetMetadata(context.Background(), &interfaces.DiscoverTask{}, []filesetDiscoverItem{{
 			resource: resource,
 			meta: &interfaces.FilesetMeta{
 				ID:             "fs-1",
@@ -111,7 +111,7 @@ func TestEnrichFilesetMetadata(t *testing.T) {
 				SourceMetadata: map[string]any{"owner": "team-a"},
 				Columns:        []interfaces.FilesetColumnMeta{{Name: "title", Type: "string"}},
 			},
-		}}, result)
+		}}, result, &discoverTaskReconcileProgress{lastProgress: 95})
 
 		require.NoError(t, err)
 	})

--- a/adp/vega/vega-backend/server/worker/discover_index.go
+++ b/adp/vega/vega-backend/server/worker/discover_index.go
@@ -32,8 +32,9 @@ type indexDiscoverItem struct {
 // 返回值:
 //   - *interfaces.DiscoverResult: 发现结果，包含新资源、过期资源和未变化资源的统计信息
 //   - error: 错误信息，如果在发现过程中出现错误则返回
-func (dtw *DiscoverTaskWorker) discoverIndexResources(ctx context.Context, catalog *interfaces.Catalog,
-	connector interfaces.Connector, task *interfaces.DiscoverTask) (*interfaces.DiscoverResult, error) {
+func (dtw *DiscoverTaskWorker) discoverIndexResources(ctx context.Context,
+	task *interfaces.DiscoverTask, catalog *interfaces.Catalog, connector interfaces.Connector,
+	progress *discoverTaskReconcileProgress) (*interfaces.DiscoverResult, error) {
 
 	// 检查连接器是否实现了IndexConnector接口
 	indexConnector, ok := connector.(interfaces.IndexConnector)
@@ -46,6 +47,11 @@ func (dtw *DiscoverTaskWorker) discoverIndexResources(ctx context.Context, catal
 	if err != nil {
 		return nil, fmt.Errorf("failed to list indices: %w", err)
 	}
+	if current, changed := progress.MarkSourceListed(); changed {
+		if err := dtw.updateProgress(ctx, task.ID, current, "source indices listed"); err != nil {
+			return nil, err
+		}
+	}
 	logger.Infof("Discovered %d indices from source", len(sourceIndices))
 
 	// Step 2: Get Existing Resources：查出db是否已存在，然后做比对
@@ -53,17 +59,30 @@ func (dtw *DiscoverTaskWorker) discoverIndexResources(ctx context.Context, catal
 	if err != nil {
 		return nil, fmt.Errorf("failed to get existing resources: %w", err)
 	}
+	logger.Infof("Loaded %d existing resources for index discovery", len(existingResources))
 
 	// Step 3: Reconcile:将index数据获取并插入：
-	result, items, err := dtw.reconcileIndexResources(ctx, catalog, sourceIndices, existingResources, task.DiscoverActions)
+	result, items, err := dtw.reconcileIndexResources(ctx, task, catalog, sourceIndices, existingResources)
 	if err != nil {
 		return nil, fmt.Errorf("failed to reconcile resources: %w", err)
 	}
+	if current, changed := progress.MarkResourcesReconciled(); changed {
+		if err := dtw.updateProgress(ctx, task.ID, current, "resources reconciled"); err != nil {
+			return nil, err
+		}
+	}
+	logger.Infof("Reconciled %d index resources", len(items))
 
 	// Step 4: Enrich ： 为索引项丰富元数据信息
-	if err := dtw.enrichIndexMetadata(ctx, indexConnector, items, result); err != nil {
+	if err := dtw.enrichIndexMetadata(ctx, task, indexConnector, items, result, progress); err != nil {
 		return nil, fmt.Errorf("failed to enrich index metadata: %w", err)
 	}
+	if current, changed := progress.MarkMetadataEnriched(); changed {
+		if err := dtw.updateProgress(ctx, task.ID, current, "resource metadata enriched"); err != nil {
+			return nil, err
+		}
+	}
+	logger.Infof("Enriched metadata for %d index resources", len(items))
 
 	result.Message = formatDiscoverResultMessage(result)
 	logger.Info(result.Message)
@@ -83,8 +102,11 @@ func (dtw *DiscoverTaskWorker) discoverIndexResources(ctx context.Context, catal
 //   - *interfaces.DiscoverResult: 发现结果，包含目录ID和各类资源的统计信息
 //   - []indexDiscoverItem: 索引发现项目列表，包含资源和索引元数据
 //   - error: 错误信息，如果处理过程中出现错误则返回
-func (dtw *DiscoverTaskWorker) reconcileIndexResources(ctx context.Context, catalog *interfaces.Catalog, sourceIndices []*interfaces.IndexMeta,
-	existingResources []*interfaces.Resource, actions *interfaces.DiscoverActions) (*interfaces.DiscoverResult, []indexDiscoverItem, error) {
+func (dtw *DiscoverTaskWorker) reconcileIndexResources(ctx context.Context, task *interfaces.DiscoverTask,
+	catalog *interfaces.Catalog, sourceIndices []*interfaces.IndexMeta,
+	existingResources []*interfaces.Resource) (*interfaces.DiscoverResult, []indexDiscoverItem, error) {
+
+	actions := task.DiscoverActions
 
 	// 初始化发现结果，设置目录ID
 	result := &interfaces.DiscoverResult{
@@ -101,7 +123,6 @@ func (dtw *DiscoverTaskWorker) reconcileIndexResources(ctx context.Context, cata
 		}
 		existingMap[r.SourceIdentifier] = r
 	}
-
 	// 创建源索引映射，以索引名为键
 	sourceMap := make(map[string]*interfaces.IndexMeta)
 	for _, idx := range sourceIndices {
@@ -165,7 +186,6 @@ func (dtw *DiscoverTaskWorker) reconcileIndexResources(ctx context.Context, cata
 			}
 		}
 	}
-
 	return result, items, nil
 }
 
@@ -200,7 +220,10 @@ func (dtw *DiscoverTaskWorker) createIndexResource(ctx context.Context, catalog 
 //
 // 返回值:
 //   - error: 如果在处理过程中发生错误，则返回错误信息
-func (dtw *DiscoverTaskWorker) enrichIndexMetadata(ctx context.Context, indexConnector interfaces.IndexConnector, items []indexDiscoverItem, result *interfaces.DiscoverResult) error {
+func (dtw *DiscoverTaskWorker) enrichIndexMetadata(ctx context.Context, task *interfaces.DiscoverTask,
+	indexConnector interfaces.IndexConnector, items []indexDiscoverItem, result *interfaces.DiscoverResult,
+	progress *discoverTaskReconcileProgress) error {
+	progress.SetMetadataTotal(len(items))
 
 	// 遍历所有需要处理的索引项
 	for _, item := range items {
@@ -263,6 +286,12 @@ func (dtw *DiscoverTaskWorker) enrichIndexMetadata(ctx context.Context, indexCon
 		// Wait a bit to avoid overwhelming the server? No, it's fine for now.
 		// Just logging
 		logger.Infof("Enriched index %s: fields=%d", idx.Name, len(columns))
+		if current, changed := progress.AdvanceMetadata(); changed {
+			message := fmt.Sprintf("resource metadata enriched: %d/%d", progress.metadataProcessed, progress.metadataTotal)
+			if err := dtw.updateProgress(ctx, task.ID, current, message); err != nil {
+				return err
+			}
+		}
 	}
 	return nil
 }

--- a/adp/vega/vega-backend/server/worker/discover_index_test.go
+++ b/adp/vega/vega-backend/server/worker/discover_index_test.go
@@ -59,8 +59,8 @@ func TestReconcileIndexResources(t *testing.T) {
 			})
 		rs.EXPECT().UpdateDiscoverStatus(gomock.Any(), "r1", interfaces.DiscoverStatusNew).Return(nil)
 
-		result, items, err := dh.reconcileIndexResources(context.Background(), &interfaces.Catalog{ID: "catalog-1"},
-			[]*interfaces.IndexMeta{{Name: "idx-a"}}, nil, &actions)
+		result, items, err := dh.reconcileIndexResources(context.Background(), &interfaces.DiscoverTask{DiscoverActions: &actions}, &interfaces.Catalog{ID: "catalog-1"},
+			[]*interfaces.IndexMeta{{Name: "idx-a"}}, nil)
 
 		require.NoError(t, err)
 		assert.Equal(t, 1, result.NewCount)
@@ -78,14 +78,14 @@ func TestReconcileIndexResources(t *testing.T) {
 		rs.EXPECT().UpdateStatus(gomock.Any(), "r1", interfaces.ResourceStatusActive, "").Return(nil)
 		rs.EXPECT().UpdateDiscoverStatus(gomock.Any(), "r1", interfaces.DiscoverStatusRestored).Return(nil)
 
-		result, items, err := dh.reconcileIndexResources(context.Background(), &interfaces.Catalog{ID: "catalog-1"},
+		result, items, err := dh.reconcileIndexResources(context.Background(), &interfaces.DiscoverTask{DiscoverActions: &actions}, &interfaces.Catalog{ID: "catalog-1"},
 			[]*interfaces.IndexMeta{{Name: "idx-a"}},
 			[]*interfaces.Resource{{
 				ID:               "r1",
 				SourceIdentifier: "idx-a",
 				Category:         interfaces.ResourceCategoryIndex,
 				Status:           interfaces.ResourceStatusStale,
-			}}, &actions)
+			}})
 
 		require.NoError(t, err)
 		assert.Equal(t, 1, result.RestoredCount)
@@ -103,14 +103,14 @@ func TestReconcileIndexResources(t *testing.T) {
 		rs.EXPECT().UpdateDiscoverStatus(gomock.Any(), "r1", interfaces.DiscoverStatusMissing).Return(nil)
 		rs.EXPECT().UpdateStatus(gomock.Any(), "r1", interfaces.ResourceStatusStale, "").Return(nil)
 
-		result, items, err := dh.reconcileIndexResources(context.Background(), &interfaces.Catalog{ID: "catalog-1"},
+		result, items, err := dh.reconcileIndexResources(context.Background(), &interfaces.DiscoverTask{DiscoverActions: &actions}, &interfaces.Catalog{ID: "catalog-1"},
 			nil,
 			[]*interfaces.Resource{{
 				ID:               "r1",
 				SourceIdentifier: "idx-a",
 				Category:         interfaces.ResourceCategoryIndex,
 				Status:           interfaces.ResourceStatusActive,
-			}}, &actions)
+			}})
 
 		require.NoError(t, err)
 		assert.Equal(t, 1, result.StaleCount)

--- a/adp/vega/vega-backend/server/worker/discover_table.go
+++ b/adp/vega/vega-backend/server/worker/discover_table.go
@@ -23,8 +23,9 @@ type tableDiscoverItem struct {
 
 // discoverTableResources discovers table resources from a table connector.
 // 分步执行：1. 获取表名列表 2. 创建/更新 Resource 3. 逐个补齐详细元数据
-func (dtw *DiscoverTaskWorker) discoverTableResources(ctx context.Context, catalog *interfaces.Catalog,
-	connector interfaces.Connector, task *interfaces.DiscoverTask) (*interfaces.DiscoverResult, error) {
+func (dtw *DiscoverTaskWorker) discoverTableResources(ctx context.Context,
+	task *interfaces.DiscoverTask, catalog *interfaces.Catalog, connector interfaces.Connector,
+	progress *discoverTaskReconcileProgress) (*interfaces.DiscoverResult, error) {
 
 	tableConnector, ok := connector.(interfaces.TableConnector)
 	if !ok {
@@ -36,6 +37,11 @@ func (dtw *DiscoverTaskWorker) discoverTableResources(ctx context.Context, catal
 	if err != nil {
 		return nil, fmt.Errorf("failed to list tables: %w", err)
 	}
+	if current, changed := progress.MarkSourceListed(); changed {
+		if err := dtw.updateProgress(ctx, task.ID, current, "source tables listed"); err != nil {
+			return nil, err
+		}
+	}
 	logger.Infof("Discovered %d tables from source", len(sourceTables))
 
 	// Step 2: 获取现有 Resources
@@ -43,17 +49,30 @@ func (dtw *DiscoverTaskWorker) discoverTableResources(ctx context.Context, catal
 	if err != nil {
 		return nil, fmt.Errorf("failed to get existing resources: %w", err)
 	}
+	logger.Infof("Loaded %d existing resources for table discovery", len(existingResources))
 
 	// Step 3: 对比并创建/更新 Resource（基础信息）
-	result, items, err := dtw.reconcileTableResources(ctx, catalog, sourceTables, existingResources, task.DiscoverActions)
+	result, items, err := dtw.reconcileTableResources(ctx, task, catalog, sourceTables, existingResources)
 	if err != nil {
 		return nil, fmt.Errorf("failed to reconcile resources: %w", err)
 	}
+	if current, changed := progress.MarkResourcesReconciled(); changed {
+		if err := dtw.updateProgress(ctx, task.ID, current, "resources reconciled"); err != nil {
+			return nil, err
+		}
+	}
+	logger.Infof("Reconciled %d table resources", len(items))
 
 	// Step 4: 逐个补齐详细元数据:元数据采集就是补充每一个table的元数据信息
-	if err := dtw.enrichTableMetadata(ctx, tableConnector, items, result); err != nil {
+	if err := dtw.enrichTableMetadata(ctx, task, tableConnector, items, result, progress); err != nil {
 		return nil, fmt.Errorf("failed to enrich table metadata: %w", err)
 	}
+	if current, changed := progress.MarkMetadataEnriched(); changed {
+		if err := dtw.updateProgress(ctx, task.ID, current, "resource metadata enriched"); err != nil {
+			return nil, err
+		}
+	}
+	logger.Infof("Enriched metadata for %d table resources", len(items))
 
 	result.Message = formatDiscoverResultMessage(result)
 	logger.Info(result.Message)
@@ -69,8 +88,11 @@ func (dtw *DiscoverTaskWorker) discoverTableResources(ctx context.Context, catal
 //
 // 返回值:
 //   - error: 如果在处理过程中发生错误，则返回错误信息
-func (dtw *DiscoverTaskWorker) enrichTableMetadata(ctx context.Context, tableConnector interfaces.TableConnector,
-	items []tableDiscoverItem, result *interfaces.DiscoverResult) error {
+func (dtw *DiscoverTaskWorker) enrichTableMetadata(ctx context.Context, task *interfaces.DiscoverTask,
+	tableConnector interfaces.TableConnector, items []tableDiscoverItem, result *interfaces.DiscoverResult,
+	progress *discoverTaskReconcileProgress) error {
+
+	progress.SetMetadataTotal(len(items))
 
 	// 遍历所有表发现项目
 	for _, item := range items {
@@ -88,6 +110,12 @@ func (dtw *DiscoverTaskWorker) enrichTableMetadata(ctx context.Context, tableCon
 			if updateErr := dtw.rs.UpdateResource(ctx, resource); updateErr != nil {
 				logger.Errorf("Failed to update discover error for table %s: %v", table.Name, updateErr)
 				return updateErr
+			}
+			if current, changed := progress.AdvanceMetadata(); changed {
+				message := fmt.Sprintf("resource metadata enriched: %d/%d", progress.metadataProcessed, progress.metadataTotal)
+				if err := dtw.updateProgress(ctx, task.ID, current, message); err != nil {
+					return err
+				}
 			}
 			continue
 		}
@@ -161,14 +189,22 @@ func (dtw *DiscoverTaskWorker) enrichTableMetadata(ctx context.Context, tableCon
 		}
 
 		logger.Debugf("Enriched table %s: properties=%v, columns=%d, indices=%d, foreign_keys=%d", table.Name, table.Properties, len(table.Columns), len(table.Indices), len(table.ForeignKeys))
+		if current, changed := progress.AdvanceMetadata(); changed {
+			message := fmt.Sprintf("resource metadata enriched: %d/%d", progress.metadataProcessed, progress.metadataTotal)
+			if err := dtw.updateProgress(ctx, task.ID, current, message); err != nil {
+				return err
+			}
+		}
 	}
 	return nil
 }
 
 // reconcileTableResources reconciles source tables with existing resources.
-func (dtw *DiscoverTaskWorker) reconcileTableResources(ctx context.Context, catalog *interfaces.Catalog, sourceTables []*interfaces.TableMeta,
-	existingResources []*interfaces.Resource, actions *interfaces.DiscoverActions) (*interfaces.DiscoverResult, []tableDiscoverItem, error) {
+func (dtw *DiscoverTaskWorker) reconcileTableResources(ctx context.Context,
+	task *interfaces.DiscoverTask, catalog *interfaces.Catalog, sourceTables []*interfaces.TableMeta,
+	existingResources []*interfaces.Resource) (*interfaces.DiscoverResult, []tableDiscoverItem, error) {
 
+	actions := task.DiscoverActions
 	result := &interfaces.DiscoverResult{
 		CatalogID: catalog.ID,
 	}

--- a/adp/vega/vega-backend/server/worker/discover_table_test.go
+++ b/adp/vega/vega-backend/server/worker/discover_table_test.go
@@ -1,0 +1,269 @@
+// Copyright openbkn.ai
+//
+// Licensed under the Apache License, Version 2.0.
+// See the LICENSE file in the project root for details.
+
+package worker
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+
+	"vega-backend/interfaces"
+	vmock "vega-backend/interfaces/mock"
+)
+
+func TestDiscoverTaskReconcileProgress(t *testing.T) {
+	t.Run("advances once for each percentage change", func(t *testing.T) {
+		progress := &discoverTaskReconcileProgress{}
+		current, changed := progress.MarkSourceListed()
+		assert.Equal(t, 5, current)
+		assert.True(t, changed)
+		current, changed = progress.MarkResourcesReconciled()
+		assert.Equal(t, 20, current)
+		assert.True(t, changed)
+		progress.SetMetadataTotal(3)
+		current, changed = progress.AdvanceMetadata()
+		assert.Equal(t, 45, current)
+		assert.True(t, changed)
+		current, changed = progress.AdvanceMetadata()
+		assert.Equal(t, 70, current)
+		assert.True(t, changed)
+		current, changed = progress.AdvanceMetadata()
+		assert.Equal(t, 95, current)
+		assert.True(t, changed)
+	})
+
+	t.Run("completes an empty reconciliation", func(t *testing.T) {
+		progress := &discoverTaskReconcileProgress{}
+		progress.MarkSourceListed()
+		current, changed := progress.MarkResourcesReconciled()
+		assert.Equal(t, 20, current)
+		assert.True(t, changed)
+	})
+}
+
+func TestReconcileTableResources(t *testing.T) {
+	t.Run("marks new table resource", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		rs := vmock.NewMockResourceService(ctrl)
+		dh := &DiscoverTaskWorker{rs: rs}
+		created := &interfaces.Resource{ID: "r1", SourceIdentifier: "users", Status: interfaces.ResourceStatusActive}
+		rs.EXPECT().Create(gomock.Any(), gomock.Any()).Return(created, nil)
+		rs.EXPECT().UpdateDiscoverStatus(gomock.Any(), "r1", interfaces.DiscoverStatusNew).Return(nil)
+		actions := interfaces.ActionsFromDiscoverStrategy(interfaces.DiscoverStrategyFullSync)
+
+		result, items, err := dh.reconcileTableResources(context.Background(), &interfaces.DiscoverTask{DiscoverActions: &actions}, &interfaces.Catalog{ID: "cat1"},
+			[]*interfaces.TableMeta{{Name: "users"}}, nil)
+
+		require.NoError(t, err)
+		assert.Equal(t, 1, result.NewCount)
+		require.Len(t, items, 1)
+		assert.False(t, items[0].markAfterEnrich)
+	})
+
+	t.Run("refreshes missing status when already stale", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		rs := vmock.NewMockResourceService(ctrl)
+		dh := &DiscoverTaskWorker{rs: rs}
+		rs.EXPECT().UpdateDiscoverStatus(gomock.Any(), "r1", interfaces.DiscoverStatusMissing).Return(nil)
+		actions := interfaces.ActionsFromDiscoverStrategy(interfaces.DiscoverStrategyFullSync)
+
+		result, _, err := dh.reconcileTableResources(context.Background(), &interfaces.DiscoverTask{DiscoverActions: &actions}, &interfaces.Catalog{ID: "cat1"}, nil,
+			[]*interfaces.Resource{{ID: "r1", SourceIdentifier: "users", Category: interfaces.ResourceCategoryTable, Status: interfaces.ResourceStatusStale}})
+
+		require.NoError(t, err)
+		assert.Zero(t, result.StaleCount)
+	})
+
+	t.Run("does not disable user-disabled resource", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		rs := vmock.NewMockResourceService(ctrl)
+		dh := &DiscoverTaskWorker{rs: rs}
+		rs.EXPECT().UpdateDiscoverStatus(gomock.Any(), "r1", interfaces.DiscoverStatusMissing).Return(nil)
+		actions := interfaces.ActionsFromDiscoverStrategy(interfaces.DiscoverStrategyFullSync)
+
+		result, _, err := dh.reconcileTableResources(context.Background(), &interfaces.DiscoverTask{DiscoverActions: &actions}, &interfaces.Catalog{ID: "cat1"}, nil,
+			[]*interfaces.Resource{{ID: "r1", SourceIdentifier: "users", Category: interfaces.ResourceCategoryTable, Status: interfaces.ResourceStatusDisabled}})
+
+		require.NoError(t, err)
+		assert.Zero(t, result.StaleCount)
+	})
+
+	t.Run("marks restored stale table", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		rs := vmock.NewMockResourceService(ctrl)
+		dh := &DiscoverTaskWorker{rs: rs}
+		rs.EXPECT().UpdateStatus(gomock.Any(), "r1", interfaces.ResourceStatusActive, "").Return(nil)
+		rs.EXPECT().UpdateDiscoverStatus(gomock.Any(), "r1", interfaces.DiscoverStatusRestored).Return(nil)
+		actions := interfaces.ActionsFromDiscoverStrategy(interfaces.DiscoverStrategyFullSync)
+
+		result, items, err := dh.reconcileTableResources(context.Background(), &interfaces.DiscoverTask{DiscoverActions: &actions}, &interfaces.Catalog{ID: "cat1"},
+			[]*interfaces.TableMeta{{Name: "users"}},
+			[]*interfaces.Resource{{ID: "r1", SourceIdentifier: "users", Category: interfaces.ResourceCategoryTable, Status: interfaces.ResourceStatusStale}})
+
+		require.NoError(t, err)
+		require.Len(t, items, 1)
+		assert.False(t, items[0].markAfterEnrich)
+		assert.Equal(t, 1, result.RestoredCount)
+		assert.Zero(t, result.UnchangedCount)
+	})
+}
+
+func TestBuildSourceIdentifierUsesSchemaAsQueryableNamespace(t *testing.T) {
+	dh := &DiscoverTaskWorker{}
+
+	cases := []struct {
+		name  string
+		table *interfaces.TableMeta
+		want  string
+	}{
+		{
+			name:  "postgresql schema table",
+			table: &interfaces.TableMeta{Database: "ecommerce_db", Schema: "public", Name: "supplier_catalog"},
+			want:  "public.supplier_catalog",
+		},
+		{
+			name:  "mariadb schema equals database",
+			table: &interfaces.TableMeta{Database: "ecommerce_db", Schema: "ecommerce_db", Name: "supplier_catalog"},
+			want:  "ecommerce_db.supplier_catalog",
+		},
+		{
+			name:  "database fallback",
+			table: &interfaces.TableMeta{Database: "ecommerce_db", Name: "supplier_catalog"},
+			want:  "ecommerce_db.supplier_catalog",
+		},
+	}
+
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := dh.buildSourceIdentifier(tt.table); got != tt.want {
+				t.Fatalf("expected %q, got %q", tt.want, got)
+			}
+		})
+	}
+}
+
+func TestEnrichTableMetadataContinuesWhenOneTableFails(t *testing.T) {
+	t.Run("continues when one table fails", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		rs := vmock.NewMockResourceService(ctrl)
+		dh := &DiscoverTaskWorker{rs: rs}
+		inaccessible := &interfaces.Resource{ID: "r1", SourceIdentifier: "public.no_access", LastDiscoverStatus: interfaces.DiscoverStatusNew}
+		accessible := &interfaces.Resource{
+			ID:                 "r2",
+			SourceIdentifier:   "public.erp_material",
+			LastDiscoverStatus: interfaces.DiscoverStatusNew,
+			StatusMessage:      "discover metadata failed: table metadata not found or inaccessible: public.erp_material",
+			SourceMetadata:     map[string]any{"original_name": "public.erp_material"},
+		}
+		connector := vmock.NewMockTableConnector(ctrl)
+		connector.EXPECT().
+			GetTableMeta(gomock.Any(), &interfaces.TableMeta{Name: "no_access", Schema: "public"}).
+			Return(errors.New("permission denied"))
+		connector.EXPECT().
+			GetTableMeta(gomock.Any(), &interfaces.TableMeta{Name: "erp_material", Schema: "public"}).
+			DoAndReturn(func(_ context.Context, table *interfaces.TableMeta) error {
+				table.Columns = []interfaces.TableColumnMeta{{Name: "id", Type: "int4"}}
+				return nil
+			})
+		connector.EXPECT().MapType("int4").Return("int4")
+		rs.EXPECT().UpdateResource(gomock.Any(), gomock.AssignableToTypeOf(&interfaces.Resource{})).
+			DoAndReturn(func(_ context.Context, resource *interfaces.Resource) error {
+				assert.Equal(t, "r1", resource.ID)
+				assert.Equal(t, interfaces.DiscoverStatusError, resource.LastDiscoverStatus)
+				assert.NotEmpty(t, resource.StatusMessage)
+				return nil
+			})
+		rs.EXPECT().UpdateResource(gomock.Any(), gomock.AssignableToTypeOf(&interfaces.Resource{})).
+			DoAndReturn(func(_ context.Context, resource *interfaces.Resource) error {
+				assert.Equal(t, "r2", resource.ID)
+				require.Len(t, resource.SchemaDefinition, 1)
+				assert.Equal(t, "id", resource.SchemaDefinition[0].Name)
+				assert.Empty(t, resource.StatusMessage)
+				return nil
+			})
+
+		result := &interfaces.DiscoverResult{}
+		err := dh.enrichTableMetadata(context.Background(), &interfaces.DiscoverTask{}, connector, []tableDiscoverItem{
+			{resource: inaccessible, tableMeta: &interfaces.TableMeta{Name: "no_access", Schema: "public"}},
+			{resource: accessible, tableMeta: &interfaces.TableMeta{Name: "erp_material", Schema: "public"}},
+		}, result, &discoverTaskReconcileProgress{lastProgress: 95})
+
+		require.NoError(t, err)
+		assert.Equal(t, 1, result.FailedCount)
+	})
+}
+
+func TestEnrichTableMetadataPreservesBusinessMetadata(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	rs := vmock.NewMockResourceService(ctrl)
+	dh := &DiscoverTaskWorker{rs: rs}
+	resource := &interfaces.Resource{
+		ID:               "r1",
+		SourceIdentifier: "public.departments",
+		SchemaDefinition: []*interfaces.Property{
+			{
+				Name:                "department_id",
+				DisplayName:         "部门ID",
+				Description:         "部门的唯一标识",
+				Type:                "integer",
+				OriginalDescription: "旧源端注释",
+				Features: []interfaces.PropertyFeature{{
+					FeatureName: "fulltext",
+					FeatureType: interfaces.PropertyFeatureType_Fulltext,
+				}},
+			},
+			{Name: "obsolete_column", DisplayName: "已删除字段", Type: interfaces.DataType_String},
+		},
+	}
+	connector := vmock.NewMockTableConnector(ctrl)
+	connector.EXPECT().
+		GetTableMeta(gomock.Any(), &interfaces.TableMeta{Name: "departments", Schema: "public"}).
+		DoAndReturn(func(_ context.Context, table *interfaces.TableMeta) error {
+			table.Columns = []interfaces.TableColumnMeta{
+				{Name: "department_id", Type: "varchar", Description: "源端最新部门编号注释"},
+				{Name: "department_name", Type: "varchar", Description: "部门名称"},
+			}
+			return nil
+		})
+	connector.EXPECT().MapType("varchar").Return(interfaces.DataType_String).Times(2)
+	rs.EXPECT().UpdateResource(gomock.Any(), gomock.AssignableToTypeOf(&interfaces.Resource{})).
+		DoAndReturn(func(_ context.Context, updated *interfaces.Resource) error {
+			require.Len(t, updated.SchemaDefinition, 2)
+
+			existing := updated.SchemaDefinition[0]
+			assert.Equal(t, "department_id", existing.Name)
+			assert.Equal(t, "部门ID", existing.DisplayName)
+			assert.Equal(t, "部门的唯一标识", existing.Description)
+			assert.Equal(t, interfaces.DataType_String, existing.Type)
+			assert.Equal(t, "varchar", existing.OriginalType)
+			assert.Equal(t, "源端最新部门编号注释", existing.OriginalDescription)
+			assert.Equal(t, []interfaces.PropertyFeature{{
+				FeatureName: "fulltext",
+				FeatureType: interfaces.PropertyFeatureType_Fulltext,
+			}}, existing.Features)
+
+			added := updated.SchemaDefinition[1]
+			assert.Equal(t, "department_name", added.Name)
+			assert.Equal(t, "department_name", added.DisplayName)
+			assert.Equal(t, "部门名称", added.Description)
+			assert.Equal(t, "部门名称", added.OriginalDescription)
+			assert.Equal(t, []string{"department_id", "department_name"}, []string{existing.Name, added.Name})
+			return nil
+		})
+
+	err := dh.enrichTableMetadata(context.Background(), &interfaces.DiscoverTask{}, connector, []tableDiscoverItem{{
+		resource: resource,
+		tableMeta: &interfaces.TableMeta{
+			Name: "departments", Schema: "public",
+		},
+	}}, &interfaces.DiscoverResult{}, &discoverTaskReconcileProgress{lastProgress: 95})
+
+	require.NoError(t, err)
+}

--- a/adp/vega/vega-backend/server/worker/discover_task_reconcile_progress.go
+++ b/adp/vega/vega-backend/server/worker/discover_task_reconcile_progress.go
@@ -1,0 +1,69 @@
+// Copyright openbkn.ai
+//
+// Licensed under the Apache License, Version 2.0.
+// See the LICENSE file in the project root for details.
+
+package worker
+
+type discoverTaskReconcileProgress struct {
+	metadataTotal     int
+	metadataProcessed int
+	lastProgress      int
+
+	sourceListed        bool
+	resourcesReconciled bool
+	metadataEnriched    bool
+}
+
+func (progress *discoverTaskReconcileProgress) MarkSourceListed() (int, bool) {
+	progress.sourceListed = true
+	return progress.changed()
+}
+
+func (progress *discoverTaskReconcileProgress) SetMetadataTotal(total int) {
+	progress.metadataTotal = total
+}
+
+func (progress *discoverTaskReconcileProgress) AdvanceMetadata() (int, bool) {
+	if progress.metadataTotal == 0 {
+		return progress.changed()
+	}
+	progress.metadataProcessed++
+	return progress.changed()
+}
+
+func (progress *discoverTaskReconcileProgress) MarkResourcesReconciled() (int, bool) {
+	progress.resourcesReconciled = true
+	return progress.changed()
+}
+
+func (progress *discoverTaskReconcileProgress) MarkMetadataEnriched() (int, bool) {
+	progress.metadataProcessed = progress.metadataTotal
+	progress.metadataEnriched = true
+	return progress.changed()
+}
+
+func (progress *discoverTaskReconcileProgress) calculate() int {
+	if progress.metadataEnriched {
+		return 95
+	}
+	if progress.resourcesReconciled {
+		if progress.metadataTotal > 0 {
+			return 20 + progress.metadataProcessed*75/progress.metadataTotal
+		}
+		return 20
+	}
+	if progress.sourceListed {
+		return 5
+	}
+	return 0
+}
+
+func (progress *discoverTaskReconcileProgress) changed() (int, bool) {
+	next := progress.calculate()
+	if next <= progress.lastProgress {
+		return next, false
+	}
+	progress.lastProgress = next
+	return next, true
+}

--- a/adp/vega/vega-backend/server/worker/discover_task_worker.go
+++ b/adp/vega/vega-backend/server/worker/discover_task_worker.go
@@ -267,7 +267,8 @@ func (dtw *DiscoverTaskWorker) Run(ctx context.Context, taskID string) error {
 	//然后根据 connector 信息获取 connector 实例，
 	//然后根据 connector 实例获取 catalog 的元数据，
 	//然后根据 catalog 的元数据获取 catalog 的资源信息：元数据
-	result, err := dtw.discoverCatalog(ctx, catalog, taskInfo)
+	progress := &discoverTaskReconcileProgress{}
+	result, err := dtw.discoverCatalog(ctx, catalog, taskInfo, progress)
 	if err != nil {
 		if _, updateErr := dtw.dts.InternalMarkFailed(ctx, taskID, err.Error()); updateErr != nil {
 			logger.Errorf("Mark discover task failed after execution error: id=%s, error=%v", taskID, updateErr)
@@ -292,6 +293,17 @@ func (dtw *DiscoverTaskWorker) Run(ctx context.Context, taskID string) error {
 	return nil
 }
 
+func (dtw *DiscoverTaskWorker) updateProgress(ctx context.Context, taskID string, progress int, message string) error {
+	updated, err := dtw.dts.InternalUpdateProgress(ctx, taskID, progress, message)
+	if err != nil {
+		return fmt.Errorf("update discover task progress: %w", err)
+	}
+	if !updated {
+		return fmt.Errorf("discover task progress was not updated")
+	}
+	return nil
+}
+
 // discoverCatalog discovers resources for a specific catalog.
 // discoverCatalog 是一个发现目录资源的方法
 // 它接收上下文和目录信息，返回发现结果或错误
@@ -303,7 +315,7 @@ func (dtw *DiscoverTaskWorker) Run(ctx context.Context, taskID string) error {
 //   - *interfaces.DiscoverResult: 发现结果，包含发现的资源信息
 //   - error: 错误信息，如果发现过程中出现错误
 func (dtw *DiscoverTaskWorker) discoverCatalog(ctx context.Context, catalog *interfaces.Catalog,
-	task *interfaces.DiscoverTask) (*interfaces.DiscoverResult, error) {
+	task *interfaces.DiscoverTask, progress *discoverTaskReconcileProgress) (*interfaces.DiscoverResult, error) {
 
 	logger.Infof("Starting discover for catalog: %s", catalog.ID)
 
@@ -332,13 +344,13 @@ func (dtw *DiscoverTaskWorker) discoverCatalog(ctx context.Context, catalog *int
 	switch category {
 	// table类型的会到这里，例如mysql
 	case interfaces.ConnectorCategoryTable:
-		return dtw.discoverTableResources(ctx, catalog, connector, task)
+		return dtw.discoverTableResources(ctx, task, catalog, connector, progress)
 	// index类型的会到这里，例如open search
 	case interfaces.ConnectorCategoryIndex:
-		return dtw.discoverIndexResources(ctx, catalog, connector, task)
+		return dtw.discoverIndexResources(ctx, task, catalog, connector, progress)
 	// fileset类型的会到这里，例如anyshare
 	case interfaces.ConnectorCategoryFileset:
-		return dtw.discoverFilesetResources(ctx, catalog, connector, task)
+		return dtw.discoverFilesetResources(ctx, task, catalog, connector, progress)
 	default:
 		return nil, fmt.Errorf("unsupported connector category for discover: %s", category)
 	}

--- a/adp/vega/vega-backend/server/worker/discover_task_worker_test.go
+++ b/adp/vega/vega-backend/server/worker/discover_task_worker_test.go
@@ -32,6 +32,26 @@ func TestDiscoverTaskWorkerSkipsCancelledTask(t *testing.T) {
 	require.NoError(t, worker.Run(context.Background(), "task-1"))
 }
 
+func TestDiscoverTaskWorkerUpdateProgress(t *testing.T) {
+	t.Run("updates running task progress", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		dts := vmock.NewMockDiscoverTaskService(ctrl)
+		worker := &DiscoverTaskWorker{dts: dts}
+		dts.EXPECT().InternalUpdateProgress(gomock.Any(), "task-1", 70, "resources reconciled").Return(true, nil)
+
+		require.NoError(t, worker.updateProgress(context.Background(), "task-1", 70, "resources reconciled"))
+	})
+
+	t.Run("rejects an unchanged task", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		dts := vmock.NewMockDiscoverTaskService(ctrl)
+		worker := &DiscoverTaskWorker{dts: dts}
+		dts.EXPECT().InternalUpdateProgress(gomock.Any(), "task-1", 70, "resources reconciled").Return(false, nil)
+
+		require.ErrorContains(t, worker.updateProgress(context.Background(), "task-1", 70, "resources reconciled"), "was not updated")
+	})
+}
+
 func TestDiscoverTaskWorkerCancelsTaskWhenCatalogWasDeleted(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	t.Cleanup(ctrl.Finish)
@@ -242,89 +262,6 @@ func TestDiscoverTaskWorkerRecoversTaskPanic(t *testing.T) {
 	assert.True(t, worker.addInFlight("task-2"), "worker must continue and release the next task ID")
 }
 
-func TestReconcileTableResources(t *testing.T) {
-	t.Run("marks new table resource", func(t *testing.T) {
-		ctrl := gomock.NewController(t)
-		rs := vmock.NewMockResourceService(ctrl)
-		dh := &DiscoverTaskWorker{rs: rs}
-		table := &interfaces.TableMeta{Name: "users"}
-		created := &interfaces.Resource{ID: "r1", SourceIdentifier: "users", Status: interfaces.ResourceStatusActive}
-		rs.EXPECT().Create(gomock.Any(), gomock.Any()).Return(created, nil)
-		rs.EXPECT().UpdateDiscoverStatus(gomock.Any(), "r1", interfaces.DiscoverStatusNew).Return(nil)
-		actions := interfaces.ActionsFromDiscoverStrategy(interfaces.DiscoverStrategyFullSync)
-
-		result, items, err := dh.reconcileTableResources(context.Background(), &interfaces.Catalog{ID: "cat1"},
-			[]*interfaces.TableMeta{table}, nil, &actions)
-
-		require.NoError(t, err)
-		assert.Equal(t, 1, result.NewCount)
-		require.Len(t, items, 1)
-		assert.False(t, items[0].markAfterEnrich)
-	})
-
-	t.Run("refreshes missing status when already stale", func(t *testing.T) {
-		ctrl := gomock.NewController(t)
-		rs := vmock.NewMockResourceService(ctrl)
-		dh := &DiscoverTaskWorker{rs: rs}
-		rs.EXPECT().UpdateDiscoverStatus(gomock.Any(), "r1", interfaces.DiscoverStatusMissing).Return(nil)
-		actions := interfaces.ActionsFromDiscoverStrategy(interfaces.DiscoverStrategyFullSync)
-
-		result, _, err := dh.reconcileTableResources(context.Background(), &interfaces.Catalog{ID: "cat1"}, nil,
-			[]*interfaces.Resource{{
-				ID:               "r1",
-				SourceIdentifier: "users",
-				Category:         interfaces.ResourceCategoryTable,
-				Status:           interfaces.ResourceStatusStale,
-			}}, &actions)
-
-		require.NoError(t, err)
-		assert.Zero(t, result.StaleCount)
-	})
-
-	t.Run("does not disable user-disabled resource", func(t *testing.T) {
-		ctrl := gomock.NewController(t)
-		rs := vmock.NewMockResourceService(ctrl)
-		dh := &DiscoverTaskWorker{rs: rs}
-		rs.EXPECT().UpdateDiscoverStatus(gomock.Any(), "r1", interfaces.DiscoverStatusMissing).Return(nil)
-		actions := interfaces.ActionsFromDiscoverStrategy(interfaces.DiscoverStrategyFullSync)
-
-		result, _, err := dh.reconcileTableResources(context.Background(), &interfaces.Catalog{ID: "cat1"}, nil,
-			[]*interfaces.Resource{{
-				ID:               "r1",
-				SourceIdentifier: "users",
-				Category:         interfaces.ResourceCategoryTable,
-				Status:           interfaces.ResourceStatusDisabled,
-			}}, &actions)
-
-		require.NoError(t, err)
-		assert.Zero(t, result.StaleCount)
-	})
-
-	t.Run("marks restored stale table", func(t *testing.T) {
-		ctrl := gomock.NewController(t)
-		rs := vmock.NewMockResourceService(ctrl)
-		dh := &DiscoverTaskWorker{rs: rs}
-		rs.EXPECT().UpdateStatus(gomock.Any(), "r1", interfaces.ResourceStatusActive, "").Return(nil)
-		rs.EXPECT().UpdateDiscoverStatus(gomock.Any(), "r1", interfaces.DiscoverStatusRestored).Return(nil)
-		actions := interfaces.ActionsFromDiscoverStrategy(interfaces.DiscoverStrategyFullSync)
-
-		result, items, err := dh.reconcileTableResources(context.Background(), &interfaces.Catalog{ID: "cat1"},
-			[]*interfaces.TableMeta{{Name: "users"}},
-			[]*interfaces.Resource{{
-				ID:               "r1",
-				SourceIdentifier: "users",
-				Category:         interfaces.ResourceCategoryTable,
-				Status:           interfaces.ResourceStatusStale,
-			}}, &actions)
-
-		require.NoError(t, err)
-		require.Len(t, items, 1)
-		assert.False(t, items[0].markAfterEnrich)
-		assert.Equal(t, 1, result.RestoredCount)
-		assert.Zero(t, result.UnchangedCount)
-	})
-}
-
 func TestUpdateDiscoverResultForEnrichStatus(t *testing.T) {
 	t.Run("increments status counters", func(t *testing.T) {
 		result := &interfaces.DiscoverResult{}
@@ -337,159 +274,6 @@ func TestUpdateDiscoverResultForEnrichStatus(t *testing.T) {
 		assert.Equal(t, 1, result.UpdatedCount)
 		assert.Equal(t, 1, result.FailedCount)
 	})
-}
-
-func TestBuildSourceIdentifierUsesSchemaAsQueryableNamespace(t *testing.T) {
-	dh := &DiscoverTaskWorker{}
-
-	cases := []struct {
-		name  string
-		table *interfaces.TableMeta
-		want  string
-	}{
-		{
-			name:  "postgresql schema table",
-			table: &interfaces.TableMeta{Database: "ecommerce_db", Schema: "public", Name: "supplier_catalog"},
-			want:  "public.supplier_catalog",
-		},
-		{
-			name:  "mariadb schema equals database",
-			table: &interfaces.TableMeta{Database: "ecommerce_db", Schema: "ecommerce_db", Name: "supplier_catalog"},
-			want:  "ecommerce_db.supplier_catalog",
-		},
-		{
-			name:  "database fallback",
-			table: &interfaces.TableMeta{Database: "ecommerce_db", Name: "supplier_catalog"},
-			want:  "ecommerce_db.supplier_catalog",
-		},
-	}
-
-	for _, tt := range cases {
-		t.Run(tt.name, func(t *testing.T) {
-			if got := dh.buildSourceIdentifier(tt.table); got != tt.want {
-				t.Fatalf("expected %q, got %q", tt.want, got)
-			}
-		})
-	}
-}
-
-func TestEnrichTableMetadataContinuesWhenOneTableFails(t *testing.T) {
-	t.Run("continues when one table fails", func(t *testing.T) {
-		ctrl := gomock.NewController(t)
-		rs := vmock.NewMockResourceService(ctrl)
-		dh := &DiscoverTaskWorker{rs: rs}
-		inaccessible := &interfaces.Resource{ID: "r1", SourceIdentifier: "public.no_access", LastDiscoverStatus: interfaces.DiscoverStatusNew}
-		accessible := &interfaces.Resource{
-			ID:                 "r2",
-			SourceIdentifier:   "public.erp_material",
-			LastDiscoverStatus: interfaces.DiscoverStatusNew,
-			StatusMessage:      "discover metadata failed: table metadata not found or inaccessible: public.erp_material",
-			SourceMetadata:     map[string]any{"original_name": "public.erp_material"},
-		}
-		connector := vmock.NewMockTableConnector(ctrl)
-		connector.EXPECT().
-			GetTableMeta(gomock.Any(), &interfaces.TableMeta{Name: "no_access", Schema: "public"}).
-			Return(errors.New("permission denied"))
-		connector.EXPECT().
-			GetTableMeta(gomock.Any(), &interfaces.TableMeta{Name: "erp_material", Schema: "public"}).
-			DoAndReturn(func(_ context.Context, table *interfaces.TableMeta) error {
-				table.Columns = []interfaces.TableColumnMeta{{Name: "id", Type: "int4"}}
-				return nil
-			})
-		connector.EXPECT().MapType("int4").Return("int4")
-		rs.EXPECT().UpdateResource(gomock.Any(), gomock.AssignableToTypeOf(&interfaces.Resource{})).
-			DoAndReturn(func(_ context.Context, resource *interfaces.Resource) error {
-				assert.Equal(t, "r1", resource.ID)
-				assert.Equal(t, interfaces.DiscoverStatusError, resource.LastDiscoverStatus)
-				assert.NotEmpty(t, resource.StatusMessage)
-				return nil
-			})
-		rs.EXPECT().UpdateResource(gomock.Any(), gomock.AssignableToTypeOf(&interfaces.Resource{})).
-			DoAndReturn(func(_ context.Context, resource *interfaces.Resource) error {
-				assert.Equal(t, "r2", resource.ID)
-				require.Len(t, resource.SchemaDefinition, 1)
-				assert.Equal(t, "id", resource.SchemaDefinition[0].Name)
-				assert.Empty(t, resource.StatusMessage)
-				return nil
-			})
-
-		result := &interfaces.DiscoverResult{}
-		err := dh.enrichTableMetadata(context.Background(), connector, []tableDiscoverItem{
-			{resource: inaccessible, tableMeta: &interfaces.TableMeta{Name: "no_access", Schema: "public"}},
-			{resource: accessible, tableMeta: &interfaces.TableMeta{Name: "erp_material", Schema: "public"}},
-		}, result)
-
-		require.NoError(t, err)
-		assert.Equal(t, 1, result.FailedCount)
-	})
-}
-
-func TestEnrichTableMetadataPreservesBusinessMetadata(t *testing.T) {
-	ctrl := gomock.NewController(t)
-	rs := vmock.NewMockResourceService(ctrl)
-	dh := &DiscoverTaskWorker{rs: rs}
-	resource := &interfaces.Resource{
-		ID:               "r1",
-		SourceIdentifier: "public.departments",
-		SchemaDefinition: []*interfaces.Property{
-			{
-				Name:                "department_id",
-				DisplayName:         "部门ID",
-				Description:         "部门的唯一标识",
-				Type:                "integer",
-				OriginalDescription: "旧源端注释",
-				Features: []interfaces.PropertyFeature{{
-					FeatureName: "fulltext",
-					FeatureType: interfaces.PropertyFeatureType_Fulltext,
-				}},
-			},
-			{Name: "obsolete_column", DisplayName: "已删除字段", Type: interfaces.DataType_String},
-		},
-	}
-	connector := vmock.NewMockTableConnector(ctrl)
-	connector.EXPECT().
-		GetTableMeta(gomock.Any(), &interfaces.TableMeta{Name: "departments", Schema: "public"}).
-		DoAndReturn(func(_ context.Context, table *interfaces.TableMeta) error {
-			table.Columns = []interfaces.TableColumnMeta{
-				{Name: "department_id", Type: "varchar", Description: "源端最新部门编号注释"},
-				{Name: "department_name", Type: "varchar", Description: "部门名称"},
-			}
-			return nil
-		})
-	connector.EXPECT().MapType("varchar").Return(interfaces.DataType_String).Times(2)
-	rs.EXPECT().UpdateResource(gomock.Any(), gomock.AssignableToTypeOf(&interfaces.Resource{})).
-		DoAndReturn(func(_ context.Context, updated *interfaces.Resource) error {
-			require.Len(t, updated.SchemaDefinition, 2)
-
-			existing := updated.SchemaDefinition[0]
-			assert.Equal(t, "department_id", existing.Name)
-			assert.Equal(t, "部门ID", existing.DisplayName)
-			assert.Equal(t, "部门的唯一标识", existing.Description)
-			assert.Equal(t, interfaces.DataType_String, existing.Type)
-			assert.Equal(t, "varchar", existing.OriginalType)
-			assert.Equal(t, "源端最新部门编号注释", existing.OriginalDescription)
-			assert.Equal(t, []interfaces.PropertyFeature{{
-				FeatureName: "fulltext",
-				FeatureType: interfaces.PropertyFeatureType_Fulltext,
-			}}, existing.Features)
-
-			added := updated.SchemaDefinition[1]
-			assert.Equal(t, "department_name", added.Name)
-			assert.Equal(t, "department_name", added.DisplayName)
-			assert.Equal(t, "部门名称", added.Description)
-			assert.Equal(t, "部门名称", added.OriginalDescription)
-			assert.Equal(t, []string{"department_id", "department_name"}, []string{existing.Name, added.Name})
-			return nil
-		})
-
-	err := dh.enrichTableMetadata(context.Background(), connector, []tableDiscoverItem{{
-		resource: resource,
-		tableMeta: &interfaces.TableMeta{
-			Name: "departments", Schema: "public",
-		},
-	}}, &interfaces.DiscoverResult{})
-
-	require.NoError(t, err)
 }
 
 func TestSourceSnapshotHashIgnoresDerivedAndUserEditableFields(t *testing.T) {

--- a/adp/vega/vega-backend/server/worker/semantic_understanding_task_worker.go
+++ b/adp/vega/vega-backend/server/worker/semantic_understanding_task_worker.go
@@ -44,6 +44,7 @@ type SemanticUnderstandingTaskWorker struct {
 	bas        interfaces.BknAgentService
 	cs         interfaces.CatalogService
 	rs         interfaces.ResourceService
+	db         *sql.DB
 
 	workerCount int
 	queueSize   int
@@ -65,6 +66,7 @@ func NewSemanticUnderstandingTaskWorker(appSetting *common.AppSetting) *Semantic
 		bas:        bkn_agent.NewBknAgentService(appSetting),
 		cs:         catalog.NewCatalogService(appSetting),
 		rs:         resource.NewResourceService(appSetting),
+		db:         logics.DB,
 
 		workerCount: workerCount,
 		queueSize:   queueSize,
@@ -230,49 +232,33 @@ func (sutw *SemanticUnderstandingTaskWorker) Run(ctx context.Context, taskID str
 	}
 	ctx = context.WithValue(ctx, interfaces.ACCOUNT_INFO_KEY, taskInfo.Creator)
 
-	if taskInfo.Status == interfaces.SemanticUnderstandingTaskStatusFailed ||
-		taskInfo.Status == interfaces.SemanticUnderstandingTaskStatusCancelled {
-		logger.Infof("Semantic understanding task already finished: id=%s, status=%s", taskInfo.ID, taskInfo.Status)
+	if taskInfo.Status != interfaces.SemanticUnderstandingTaskStatusPending {
+		logger.Infof("Semantic understanding task is not pending, skip: id=%s, status=%s", taskInfo.ID, taskInfo.Status)
 		return nil
 	}
-	if taskInfo.Status == interfaces.SemanticUnderstandingTaskStatusCompleted && taskInfo.AppliedTime != 0 {
-		logger.Infof("Semantic understanding task already applied: id=%s", taskInfo.ID)
+	// Claim before execution-time parent lookups. A failed conditional update
+	// leaves the task pending so a later database poll can retry it.
+	claimed, err := sutw.suts.InternalMarkRunning(ctx, taskInfo.ID)
+	if err != nil {
+		return fmt.Errorf("mark semantic understanding task running: %w", err)
+	}
+	if !claimed {
+		logger.Infof("Semantic understanding task was not claimed for running: id=%s", taskInfo.ID)
 		return nil
 	}
-	if taskInfo.Status == interfaces.SemanticUnderstandingTaskStatusPending {
-		// Claim before execution-time parent lookups. A failed conditional update
-		// leaves the task pending so a later database poll can retry it.
-		claimed, err := sutw.suts.InternalMarkRunning(ctx, taskInfo.ID)
-		if err != nil {
-			return fmt.Errorf("mark semantic understanding task running: %w", err)
+	parentExists, err := sutw.taskParentExists(ctx, taskInfo)
+	if err != nil {
+		if _, updateErr := sutw.suts.InternalMarkFailed(ctx, taskInfo.ID, err.Error()); updateErr != nil {
+			logger.Errorf("Mark semantic understanding task failed after parent lookup error: id=%s, error=%v", taskInfo.ID, updateErr)
 		}
-		if !claimed {
-			logger.Infof("Semantic understanding task was not claimed for running: id=%s", taskInfo.ID)
-			return nil
-		}
+		return err
 	}
-	if taskInfo.Status == interfaces.SemanticUnderstandingTaskStatusPending ||
-		taskInfo.Status == interfaces.SemanticUnderstandingTaskStatusRunning ||
-		taskInfo.Status == interfaces.SemanticUnderstandingTaskStatusCompleted {
-		parentExists, err := sutw.taskParentExists(ctx, taskInfo)
-		if err != nil {
-			if _, updateErr := sutw.suts.InternalMarkFailed(ctx, taskInfo.ID, err.Error()); updateErr != nil {
-				logger.Errorf("Mark semantic understanding task failed after parent lookup error: id=%s, error=%v", taskInfo.ID, updateErr)
-			}
-			return err
+	if !parentExists {
+		if _, err := sutw.suts.InternalMarkCancelled(ctx, taskInfo.ID, "catalog or resource deleted"); err != nil {
+			return fmt.Errorf("cancel semantic understanding task after parent deletion: %w", err)
 		}
-		if !parentExists {
-			if taskInfo.Status != interfaces.SemanticUnderstandingTaskStatusCompleted {
-				if _, err := sutw.suts.InternalMarkCancelled(ctx, taskInfo.ID, "catalog or resource deleted"); err != nil {
-					return fmt.Errorf("cancel semantic understanding task after parent deletion: %w", err)
-				}
-			}
-			logger.Infof("Semantic understanding task stopped because its parent was deleted: id=%s", taskInfo.ID)
-			return nil
-		}
-	}
-	if taskInfo.Status == interfaces.SemanticUnderstandingTaskStatusCompleted {
-		return sutw.applyAndMark(ctx, taskInfo)
+		logger.Infof("Semantic understanding task stopped because its parent was deleted: id=%s", taskInfo.ID)
+		return nil
 	}
 
 	agentTaskID := taskInfo.AgentTaskID
@@ -331,19 +317,12 @@ func (sutw *SemanticUnderstandingTaskWorker) Run(ctx context.Context, taskID str
 		}
 	}
 
-	completed, err := sutw.suts.InternalMarkCompleted(ctx, taskInfo.ID, resultJSON, confidence, confidenceDetailJSON)
-	if err != nil {
-		if _, updateErr := sutw.suts.InternalMarkFailed(ctx, taskInfo.ID, err.Error()); updateErr != nil {
-			logger.Errorf("Mark semantic understanding task failed after completion error: id=%s, error=%v", taskInfo.ID, updateErr)
-		}
-		return err
-	}
-	if !completed {
-		return nil
-	}
 	taskInfo.ResultJSON = resultJSON
 	taskInfo.Confidence = confidence
-	if err := sutw.applyAndMark(ctx, taskInfo); err != nil {
+	if err := sutw.applyAndMark(ctx, taskInfo, confidenceDetailJSON); err != nil {
+		if _, updateErr := sutw.suts.InternalMarkFailed(ctx, taskInfo.ID, err.Error()); updateErr != nil {
+			return fmt.Errorf("apply semantic understanding result: %w; mark task failed: %v", err, updateErr)
+		}
 		return err
 	}
 
@@ -375,17 +354,12 @@ func (sutw *SemanticUnderstandingTaskWorker) taskParentExists(
 	return false, fmt.Errorf("get semantic understanding task catalog: %w", err)
 }
 
-func (sutw *SemanticUnderstandingTaskWorker) applyAndMark(ctx context.Context, task *interfaces.SemanticUnderstandingTask) error {
-	if logics.DB == nil {
-		applyResult, err := sutw.applyResult(ctx, task, task.ResultJSON, task.Confidence, nil)
-		if err != nil {
-			return err
-		}
-		_, err = sutw.suts.InternalSetApplied(ctx, nil, task.ID, applyResult.Applied, applyResult.DetailJSON)
-		return err
+func (sutw *SemanticUnderstandingTaskWorker) applyAndMark(ctx context.Context, task *interfaces.SemanticUnderstandingTask, confidenceDetailJSON string) error {
+	if sutw.db == nil {
+		return errors.New("semantic understanding task worker database is not configured")
 	}
 
-	tx, err := logics.DB.BeginTx(ctx, nil)
+	tx, err := sutw.db.BeginTx(ctx, nil)
 	if err != nil {
 		return fmt.Errorf("begin semantic understanding apply transaction: %w", err)
 	}
@@ -400,8 +374,19 @@ func (sutw *SemanticUnderstandingTaskWorker) applyAndMark(ctx context.Context, t
 	if err != nil {
 		return err
 	}
-	if _, err := sutw.suts.InternalSetApplied(ctx, tx, task.ID, applyResult.Applied, applyResult.DetailJSON); err != nil {
+	updated, err := sutw.suts.InternalSetApplied(ctx, tx, task.ID, applyResult.Applied, applyResult.DetailJSON)
+	if err != nil {
 		return err
+	}
+	if !updated {
+		return errors.New("set semantic understanding task applied did not update task")
+	}
+	completed, err := sutw.suts.InternalMarkCompleted(ctx, tx, task.ID, task.ResultJSON, task.Confidence, confidenceDetailJSON)
+	if err != nil {
+		return err
+	}
+	if !completed {
+		return errors.New("mark semantic understanding task completed did not update task")
 	}
 	if err := tx.Commit(); err != nil {
 		return err

--- a/adp/vega/vega-backend/server/worker/semantic_understanding_task_worker_test.go
+++ b/adp/vega/vega-backend/server/worker/semantic_understanding_task_worker_test.go
@@ -286,7 +286,7 @@ func TestSemanticUnderstandingTaskWorkerRun(t *testing.T) {
 				assert.NotZero(t, got.UpdateTime)
 				return nil
 			})
-		taskService.EXPECT().
+		markCompleted := taskService.EXPECT().
 			InternalMarkCompleted(gomock.Any(), gomock.Any(), "semantic-task-1", `{"confidence":0.82,"resource":{"display_name":"Business Resource","description":"business resource","confidence":0.82},"fields":[{"name":"id","display_name":"标识","description":"identifier","confidence":0.81}],"warnings":[]}`, 0.82, gomock.Any()).
 			DoAndReturn(func(_ context.Context, _ *sql.Tx, _ string, _ string, _ float64, detailJSON string) (bool, error) {
 				var detail map[string]sonic.NoCopyRawMessage
@@ -296,13 +296,14 @@ func TestSemanticUnderstandingTaskWorkerRun(t *testing.T) {
 				assert.Contains(t, detail, "warnings")
 				return true, nil
 			})
-		taskService.EXPECT().
+		setApplied := taskService.EXPECT().
 			InternalSetApplied(gomock.Any(), gomock.Any(), "semantic-task-1", true, gomock.Any()).
 			DoAndReturn(func(_ context.Context, _ *sql.Tx, _ string, applied bool, detailJSON string) (bool, error) {
 				assert.True(t, applied)
 				assert.JSONEq(t, `{"resource_updated":true,"updated_resource":["name","description"],"updated_fields":["id"],"field_details":[{"name":"id","status":"updated","updated":["display_name","description"]}]}`, detailJSON)
 				return true, nil
 			})
+		gomock.InOrder(setApplied, markCompleted)
 
 		err := worker.Run(context.Background(), "semantic-task-1")
 

--- a/adp/vega/vega-backend/server/worker/semantic_understanding_task_worker_test.go
+++ b/adp/vega/vega-backend/server/worker/semantic_understanding_task_worker_test.go
@@ -13,6 +13,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/DATA-DOG/go-sqlmock"
 	"github.com/bytedance/sonic"
 	"github.com/openbkn-ai/bkn-foundry/comm-go/rest"
 	"github.com/stretchr/testify/assert"
@@ -25,6 +26,17 @@ import (
 
 type accountIDContextMatcher struct {
 	accountID string
+}
+
+func newSemanticUnderstandingWorkerDB(t *testing.T) (*sql.DB, sqlmock.Sqlmock) {
+	t.Helper()
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		require.NoError(t, mock.ExpectationsWereMet())
+		_ = db.Close()
+	})
+	return db, mock
 }
 
 func ctxWithAccountID(t *testing.T, accountID string) gomock.Matcher {
@@ -204,6 +216,9 @@ func TestSemanticUnderstandingTaskWorkerRun(t *testing.T) {
 	t.Run("runs agent and marks completed", func(t *testing.T) {
 		ctrl := gomock.NewController(t)
 		t.Cleanup(ctrl.Finish)
+		db, dbMock := newSemanticUnderstandingWorkerDB(t)
+		dbMock.ExpectBegin()
+		dbMock.ExpectCommit()
 
 		taskService := vmock.NewMockSemanticUnderstandingTaskService(ctrl)
 		agentService := vmock.NewMockBknAgentService(ctrl)
@@ -212,6 +227,7 @@ func TestSemanticUnderstandingTaskWorkerRun(t *testing.T) {
 			suts: taskService,
 			bas:  agentService,
 			rs:   resourceService,
+			db:   db,
 		}
 
 		semanticTask := &interfaces.SemanticUnderstandingTask{
@@ -259,7 +275,7 @@ func TestSemanticUnderstandingTaskWorkerRun(t *testing.T) {
 			GetByID(gomock.Any(), "resource-1").
 			Return(resourceInfo, nil)
 		resourceService.EXPECT().
-			InternalUpdateSemanticMetadata(gomock.Any(), nil, gomock.Any()).
+			InternalUpdateSemanticMetadata(gomock.Any(), gomock.Any(), gomock.Any()).
 			DoAndReturn(func(_ context.Context, _ *sql.Tx, got *interfaces.Resource) error {
 				assert.Equal(t, "Business Resource", got.Name)
 				assert.Equal(t, "business resource", got.Description)
@@ -271,8 +287,8 @@ func TestSemanticUnderstandingTaskWorkerRun(t *testing.T) {
 				return nil
 			})
 		taskService.EXPECT().
-			InternalMarkCompleted(gomock.Any(), "semantic-task-1", `{"confidence":0.82,"resource":{"display_name":"Business Resource","description":"business resource","confidence":0.82},"fields":[{"name":"id","display_name":"标识","description":"identifier","confidence":0.81}],"warnings":[]}`, 0.82, gomock.Any()).
-			DoAndReturn(func(_ context.Context, _ string, _ string, _ float64, detailJSON string) (bool, error) {
+			InternalMarkCompleted(gomock.Any(), gomock.Any(), "semantic-task-1", `{"confidence":0.82,"resource":{"display_name":"Business Resource","description":"business resource","confidence":0.82},"fields":[{"name":"id","display_name":"标识","description":"identifier","confidence":0.81}],"warnings":[]}`, 0.82, gomock.Any()).
+			DoAndReturn(func(_ context.Context, _ *sql.Tx, _ string, _ string, _ float64, detailJSON string) (bool, error) {
 				var detail map[string]sonic.NoCopyRawMessage
 				require.NoError(t, sonic.Unmarshal([]byte(detailJSON), &detail))
 				assert.Contains(t, detail, "resource")
@@ -281,7 +297,7 @@ func TestSemanticUnderstandingTaskWorkerRun(t *testing.T) {
 				return true, nil
 			})
 		taskService.EXPECT().
-			InternalSetApplied(gomock.Any(), nil, "semantic-task-1", true, gomock.Any()).
+			InternalSetApplied(gomock.Any(), gomock.Any(), "semantic-task-1", true, gomock.Any()).
 			DoAndReturn(func(_ context.Context, _ *sql.Tx, _ string, applied bool, detailJSON string) (bool, error) {
 				assert.True(t, applied)
 				assert.JSONEq(t, `{"resource_updated":true,"updated_resource":["name","description"],"updated_fields":["id"],"field_details":[{"name":"id","status":"updated","updated":["display_name","description"]}]}`, detailJSON)
@@ -293,16 +309,52 @@ func TestSemanticUnderstandingTaskWorkerRun(t *testing.T) {
 		require.NoError(t, err)
 	})
 
-	t.Run("marks failed when agent task failed", func(t *testing.T) {
+	t.Run("marks task failed when applying result fails", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		t.Cleanup(ctrl.Finish)
+		db, dbMock := newSemanticUnderstandingWorkerDB(t)
+		dbMock.ExpectBegin()
+		dbMock.ExpectRollback()
+
+		taskService := vmock.NewMockSemanticUnderstandingTaskService(ctrl)
+		agentService := vmock.NewMockBknAgentService(ctrl)
+		resourceService := vmock.NewMockResourceService(ctrl)
+		worker := &SemanticUnderstandingTaskWorker{suts: taskService, bas: agentService, rs: resourceService, db: db}
+		task := &interfaces.SemanticUnderstandingTask{
+			ID:                  "semantic-task-1",
+			Scope:               interfaces.SemanticUnderstandingTaskScopeResource,
+			ResourceID:          "resource-1",
+			Status:              interfaces.SemanticUnderstandingTaskStatusPending,
+			AgentID:             interfaces.SemanticUnderstandingResourceAgentID,
+			Input:               `{"resource":{"id":"resource-1"}}`,
+			ApplyMode:           interfaces.SemanticUnderstandingApplyModeFillEmpty,
+			ConfidenceThreshold: 0.75,
+			Creator:             interfaces.AccountInfo{ID: "account-1"},
+		}
+		taskService.EXPECT().InternalGetByID(gomock.Any(), task.ID).Return(task, nil)
+		taskService.EXPECT().InternalMarkRunning(ctxWithAccountID(t, "account-1"), task.ID).Return(true, nil)
+		resourceService.EXPECT().InternalGetByID(gomock.Any(), task.ResourceID).Return(&interfaces.Resource{ID: task.ResourceID}, nil)
+		agentService.EXPECT().Run(ctxWithAccountID(t, "account-1"), task).Return("agent-task-1", nil)
+		taskService.EXPECT().InternalSetAgentTaskID(ctxWithAccountID(t, "account-1"), task.ID, "agent-task-1").Return(true, nil)
+		agentService.EXPECT().WaitResult(gomock.Any(), "agent-task-1").Return(&interfaces.BknAgentTask{
+			TaskID: "agent-task-1",
+			Status: interfaces.BknAgentTaskStatusSucceeded,
+			Result: []byte(`{"confidence":0.82,"resource":{"description":"business resource","confidence":0.82},"fields":[],"warnings":[]}`),
+		}, nil)
+		resourceService.EXPECT().GetByID(gomock.Any(), task.ResourceID).Return(nil, errors.New("resource database unavailable"))
+		taskService.EXPECT().InternalMarkFailed(gomock.Any(), task.ID, "resource database unavailable").Return(true, nil)
+
+		err := worker.Run(context.Background(), task.ID)
+
+		require.ErrorContains(t, err, "resource database unavailable")
+	})
+
+	t.Run("skips running task", func(t *testing.T) {
 		ctrl := gomock.NewController(t)
 		t.Cleanup(ctrl.Finish)
 
 		taskService := vmock.NewMockSemanticUnderstandingTaskService(ctrl)
-		agentService := vmock.NewMockBknAgentService(ctrl)
-		worker := &SemanticUnderstandingTaskWorker{
-			suts: taskService,
-			bas:  agentService,
-		}
+		worker := &SemanticUnderstandingTaskWorker{suts: taskService}
 
 		semanticTask := &interfaces.SemanticUnderstandingTask{
 			ID:          "semantic-task-1",
@@ -314,20 +366,37 @@ func TestSemanticUnderstandingTaskWorkerRun(t *testing.T) {
 		taskService.EXPECT().
 			InternalGetByID(gomock.Any(), "semantic-task-1").
 			Return(semanticTask, nil)
-		agentService.EXPECT().
-			WaitResult(gomock.Any(), "agent-task-1").
-			Return(&interfaces.BknAgentTask{
-				TaskID:        "agent-task-1",
-				Status:        interfaces.BknAgentTaskStatusFailed,
-				FailureDetail: "agent failed",
-			}, nil)
-		taskService.EXPECT().
-			InternalMarkFailed(gomock.Any(), "semantic-task-1", "agent failed").
-			Return(true, nil)
-
 		err := worker.Run(context.Background(), "semantic-task-1")
 
 		require.NoError(t, err)
+	})
+
+	t.Run("marks task failed when agent reports failure", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		t.Cleanup(ctrl.Finish)
+
+		taskService := vmock.NewMockSemanticUnderstandingTaskService(ctrl)
+		agentService := vmock.NewMockBknAgentService(ctrl)
+		worker := &SemanticUnderstandingTaskWorker{suts: taskService, bas: agentService}
+		task := &interfaces.SemanticUnderstandingTask{
+			ID:      "semantic-task-1",
+			Status:  interfaces.SemanticUnderstandingTaskStatusPending,
+			AgentID: interfaces.SemanticUnderstandingResourceAgentID,
+			Input:   `{"resource":{"id":"resource-1"}}`,
+			Creator: interfaces.AccountInfo{ID: "account-1"},
+		}
+		taskService.EXPECT().InternalGetByID(gomock.Any(), task.ID).Return(task, nil)
+		taskService.EXPECT().InternalMarkRunning(ctxWithAccountID(t, "account-1"), task.ID).Return(true, nil)
+		agentService.EXPECT().Run(ctxWithAccountID(t, "account-1"), task).Return("agent-task-1", nil)
+		taskService.EXPECT().InternalSetAgentTaskID(ctxWithAccountID(t, "account-1"), task.ID, "agent-task-1").Return(true, nil)
+		agentService.EXPECT().WaitResult(gomock.Any(), "agent-task-1").Return(&interfaces.BknAgentTask{
+			TaskID:        "agent-task-1",
+			Status:        interfaces.BknAgentTaskStatusFailed,
+			FailureDetail: "agent failed",
+		}, nil)
+		taskService.EXPECT().InternalMarkFailed(gomock.Any(), task.ID, "agent failed").Return(true, nil)
+
+		require.NoError(t, worker.Run(context.Background(), task.ID))
 	})
 
 	t.Run("cancels active task when resource was deleted", func(t *testing.T) {
@@ -359,9 +428,10 @@ func TestSemanticUnderstandingTaskWorkerRun(t *testing.T) {
 		worker := &SemanticUnderstandingTaskWorker{suts: taskService, cs: catalogService}
 		taskInfo := &interfaces.SemanticUnderstandingTask{
 			ID: "semantic-task-1", Scope: interfaces.SemanticUnderstandingTaskScopeCatalog,
-			CatalogID: "catalog-1", Status: interfaces.SemanticUnderstandingTaskStatusRunning,
+			CatalogID: "catalog-1", Status: interfaces.SemanticUnderstandingTaskStatusPending,
 		}
 		taskService.EXPECT().InternalGetByID(gomock.Any(), "semantic-task-1").Return(taskInfo, nil)
+		taskService.EXPECT().InternalMarkRunning(gomock.Any(), "semantic-task-1").Return(true, nil)
 		catalogService.EXPECT().InternalGetByID(gomock.Any(), "catalog-1", false).
 			Return(nil, &rest.HTTPError{HTTPCode: http.StatusNotFound})
 		taskService.EXPECT().InternalMarkCancelled(gomock.Any(), "semantic-task-1", "catalog or resource deleted").
@@ -370,51 +440,18 @@ func TestSemanticUnderstandingTaskWorkerRun(t *testing.T) {
 		require.NoError(t, worker.Run(context.Background(), "semantic-task-1"))
 	})
 
-	t.Run("resumes applying completed task", func(t *testing.T) {
+	t.Run("skips completed task", func(t *testing.T) {
 		ctrl := gomock.NewController(t)
 		t.Cleanup(ctrl.Finish)
 
 		taskService := vmock.NewMockSemanticUnderstandingTaskService(ctrl)
-		resourceService := vmock.NewMockResourceService(ctrl)
-		worker := &SemanticUnderstandingTaskWorker{suts: taskService, rs: resourceService}
-		semanticTask := &interfaces.SemanticUnderstandingTask{
-			ID:                  "semantic-task-1",
-			Scope:               interfaces.SemanticUnderstandingTaskScopeResource,
-			ResourceID:          "resource-1",
-			Status:              interfaces.SemanticUnderstandingTaskStatusCompleted,
-			ApplyMode:           interfaces.SemanticUnderstandingApplyModeDryRun,
-			ConfidenceThreshold: 0.75,
-			Confidence:          0.9,
-			ResultJSON:          `{"confidence":0.9}`,
-			Creator:             interfaces.AccountInfo{ID: "account-1"},
-		}
-		taskService.EXPECT().
-			InternalGetByID(gomock.Any(), "semantic-task-1").
-			Return(semanticTask, nil)
-		resourceService.EXPECT().InternalGetByID(gomock.Any(), "resource-1").
-			Return(&interfaces.Resource{ID: "resource-1"}, nil)
-		taskService.EXPECT().
-			InternalSetApplied(ctxWithAccountID(t, "account-1"), nil, "semantic-task-1", false, gomock.Any()).
-			Return(true, nil)
-
-		err := worker.Run(context.Background(), "semantic-task-1")
-
-		require.NoError(t, err)
-	})
-
-	t.Run("stops retrying completed task when resource was deleted", func(t *testing.T) {
-		ctrl := gomock.NewController(t)
-		t.Cleanup(ctrl.Finish)
-
-		taskService := vmock.NewMockSemanticUnderstandingTaskService(ctrl)
-		resourceService := vmock.NewMockResourceService(ctrl)
-		worker := &SemanticUnderstandingTaskWorker{suts: taskService, rs: resourceService}
-		taskInfo := &interfaces.SemanticUnderstandingTask{
-			ID: "semantic-task-1", Scope: interfaces.SemanticUnderstandingTaskScopeResource,
-			ResourceID: "resource-1", Status: interfaces.SemanticUnderstandingTaskStatusCompleted,
-		}
-		taskService.EXPECT().InternalGetByID(gomock.Any(), "semantic-task-1").Return(taskInfo, nil)
-		resourceService.EXPECT().InternalGetByID(gomock.Any(), "resource-1").Return(nil, nil)
+		worker := &SemanticUnderstandingTaskWorker{suts: taskService}
+		taskService.EXPECT().InternalGetByID(gomock.Any(), "semantic-task-1").Return(
+			&interfaces.SemanticUnderstandingTask{
+				ID:     "semantic-task-1",
+				Status: interfaces.SemanticUnderstandingTaskStatusCompleted,
+			}, nil,
+		)
 
 		require.NoError(t, worker.Run(context.Background(), "semantic-task-1"))
 	})
@@ -467,14 +504,24 @@ func TestSemanticUnderstandingTaskWorkerRun(t *testing.T) {
 		}
 
 		semanticTask := &interfaces.SemanticUnderstandingTask{
-			ID:          "semantic-task-1",
-			Status:      interfaces.SemanticUnderstandingTaskStatusRunning,
-			AgentTaskID: "agent-task-1",
-			Creator:     interfaces.AccountInfo{ID: "account-1"},
+			ID:      "semantic-task-1",
+			Status:  interfaces.SemanticUnderstandingTaskStatusPending,
+			AgentID: interfaces.SemanticUnderstandingResourceAgentID,
+			Input:   `{"resource":{"id":"resource-1"}}`,
+			Creator: interfaces.AccountInfo{ID: "account-1"},
 		}
 		taskService.EXPECT().
 			InternalGetByID(gomock.Any(), "semantic-task-1").
 			Return(semanticTask, nil)
+		taskService.EXPECT().
+			InternalMarkRunning(ctxWithAccountID(t, "account-1"), "semantic-task-1").
+			Return(true, nil)
+		agentService.EXPECT().
+			Run(ctxWithAccountID(t, "account-1"), semanticTask).
+			Return("agent-task-1", nil)
+		taskService.EXPECT().
+			InternalSetAgentTaskID(ctxWithAccountID(t, "account-1"), "semantic-task-1", "agent-task-1").
+			Return(true, nil)
 		agentService.EXPECT().
 			WaitResult(ctxWithAccountID(t, "account-1"), "agent-task-1").
 			Return(nil, errors.New("temporary agent error"))
@@ -490,6 +537,9 @@ func TestSemanticUnderstandingTaskWorkerRun(t *testing.T) {
 	t.Run("marks unapplied detail when confidence is below threshold", func(t *testing.T) {
 		ctrl := gomock.NewController(t)
 		t.Cleanup(ctrl.Finish)
+		db, dbMock := newSemanticUnderstandingWorkerDB(t)
+		dbMock.ExpectBegin()
+		dbMock.ExpectCommit()
 
 		taskService := vmock.NewMockSemanticUnderstandingTaskService(ctrl)
 		agentService := vmock.NewMockBknAgentService(ctrl)
@@ -498,13 +548,15 @@ func TestSemanticUnderstandingTaskWorkerRun(t *testing.T) {
 			suts: taskService,
 			bas:  agentService,
 			rs:   resourceService,
+			db:   db,
 		}
 		semanticTask := &interfaces.SemanticUnderstandingTask{
 			ID:                  "semantic-task-1",
 			Scope:               interfaces.SemanticUnderstandingTaskScopeResource,
 			ResourceID:          "resource-1",
-			Status:              interfaces.SemanticUnderstandingTaskStatusRunning,
-			AgentTaskID:         "agent-task-1",
+			Status:              interfaces.SemanticUnderstandingTaskStatusPending,
+			AgentID:             interfaces.SemanticUnderstandingResourceAgentID,
+			Input:               `{"resource":{"id":"resource-1"}}`,
 			ApplyMode:           interfaces.SemanticUnderstandingApplyModeForce,
 			ConfidenceThreshold: 0.9,
 		}
@@ -512,6 +564,15 @@ func TestSemanticUnderstandingTaskWorkerRun(t *testing.T) {
 		taskService.EXPECT().
 			InternalGetByID(gomock.Any(), "semantic-task-1").
 			Return(semanticTask, nil)
+		taskService.EXPECT().
+			InternalMarkRunning(gomock.Any(), "semantic-task-1").
+			Return(true, nil)
+		agentService.EXPECT().
+			Run(gomock.Any(), semanticTask).
+			Return("agent-task-1", nil)
+		taskService.EXPECT().
+			InternalSetAgentTaskID(gomock.Any(), "semantic-task-1", "agent-task-1").
+			Return(true, nil)
 		resourceService.EXPECT().InternalGetByID(gomock.Any(), "resource-1").
 			Return(&interfaces.Resource{ID: "resource-1"}, nil)
 		agentService.EXPECT().
@@ -522,10 +583,10 @@ func TestSemanticUnderstandingTaskWorkerRun(t *testing.T) {
 				Result: []byte(`{"confidence":0.8,"resource":{"description":"business resource"},"fields":[]}`),
 			}, nil)
 		taskService.EXPECT().
-			InternalMarkCompleted(gomock.Any(), "semantic-task-1", `{"confidence":0.8,"resource":{"description":"business resource"},"fields":[]}`, 0.8, gomock.Any()).
+			InternalMarkCompleted(gomock.Any(), gomock.Any(), "semantic-task-1", `{"confidence":0.8,"resource":{"description":"business resource"},"fields":[]}`, 0.8, gomock.Any()).
 			Return(true, nil)
 		taskService.EXPECT().
-			InternalSetApplied(gomock.Any(), nil, "semantic-task-1", false, gomock.Any()).
+			InternalSetApplied(gomock.Any(), gomock.Any(), "semantic-task-1", false, gomock.Any()).
 			DoAndReturn(func(_ context.Context, _ *sql.Tx, _ string, applied bool, detailJSON string) (bool, error) {
 				assert.False(t, applied)
 				assert.JSONEq(t, `{"reason":"confidence_below_threshold","confidence":0.8,"confidence_threshold":0.9,"scope":"resource"}`, detailJSON)
@@ -539,6 +600,28 @@ func TestSemanticUnderstandingTaskWorkerRun(t *testing.T) {
 }
 
 func TestSemanticUnderstandingTaskWorkerApplyResourceResult(t *testing.T) {
+	t.Run("fails when applied marker is not updated", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		t.Cleanup(ctrl.Finish)
+		db, dbMock := newSemanticUnderstandingWorkerDB(t)
+		dbMock.ExpectBegin()
+		dbMock.ExpectRollback()
+
+		taskService := vmock.NewMockSemanticUnderstandingTaskService(ctrl)
+		worker := &SemanticUnderstandingTaskWorker{suts: taskService, db: db}
+		taskService.EXPECT().
+			InternalSetApplied(gomock.Any(), gomock.Any(), "semantic-task-1", false, gomock.Any()).
+			Return(false, nil)
+
+		err := worker.applyAndMark(context.Background(), &interfaces.SemanticUnderstandingTask{
+			ID:        "semantic-task-1",
+			Scope:     interfaces.SemanticUnderstandingTaskScopeResource,
+			ApplyMode: interfaces.SemanticUnderstandingApplyModeDryRun,
+		}, `{}`)
+
+		require.ErrorContains(t, err, "did not update task")
+	})
+
 	t.Run("skips apply when confidence is below threshold", func(t *testing.T) {
 		ctrl := gomock.NewController(t)
 		t.Cleanup(ctrl.Finish)

--- a/docs/api/vega/build-task.yaml
+++ b/docs/api/vega/build-task.yaml
@@ -88,7 +88,9 @@ paths:
             type: string
             enum:
               - create_time
-              - update_time
+              - start_time
+              - finish_time
+              - last_progress_time
             default: create_time
         - name: direction
           description: 排序方向，默认 desc
@@ -360,7 +362,6 @@ components:
         - vectorized_count
         - creator
         - create_time
-        - update_time
       properties:
         id:
           description: 全局唯一 ID
@@ -424,8 +425,16 @@ components:
           description: 创建时间，毫秒级时间戳
           type: integer
           format: int64
-        update_time:
-          description: 更新时间，毫秒级时间戳
+        start_time:
+          description: 开始执行时间，毫秒级时间戳；未开始时为 0
+          type: integer
+          format: int64
+        finish_time:
+          description: 完成时间，毫秒级时间戳；未完成时为 0
+          type: integer
+          format: int64
+        last_progress_time:
+          description: 最近一次对外可观测进度更新时间，毫秒级时间戳；无进度更新时为 0
           type: integer
           format: int64
         failure_detail:
@@ -438,7 +447,7 @@ components:
     BuildTaskSummary:
       description: 构建任务列表摘要；索引配置快照和 failure_detail 请调用单条详情接口获取。
       type: object
-      required: [id, resource_id, catalog_id, status, mode, total_count, synced_count, vectorized_count, synced_mark, creator, create_time, update_time]
+      required: [id, resource_id, catalog_id, status, mode, total_count, synced_count, vectorized_count, synced_mark, creator, create_time]
       properties:
         id: { type: string }
         resource_id: { type: string }
@@ -455,7 +464,9 @@ components:
         error_msg: { type: string }
         creator: { $ref: "#/components/schemas/AccountInfo" }
         create_time: { type: integer, format: int64 }
-        update_time: { type: integer, format: int64 }
+        start_time: { type: integer, format: int64 }
+        finish_time: { type: integer, format: int64 }
+        last_progress_time: { type: integer, format: int64 }
         index_health: { $ref: "#/components/schemas/IndexHealth" }
     BuildTaskIndexConfig:
       description: 创建任务时从 Resource 派生的索引配置快照

--- a/docs/api/vega/discover-task.yaml
+++ b/docs/api/vega/discover-task.yaml
@@ -81,11 +81,11 @@ paths:
             format: int64
             default: 20
         - name: sort
-          description: 排序字段；默认按创建时间倒序。
+          description: 排序字段；默认按创建时间倒序。时间值为 0 时按数据库普通数值排序：升序在前、降序在后。
           in: query
           schema:
             type: string
-            enum: [create_time, start_time, finish_time]
+            enum: [create_time, start_time, finish_time, last_progress_time]
             default: create_time
         - name: direction
           description: 排序方向
@@ -366,6 +366,10 @@ components:
           description: 完成时间，毫秒级时间戳；未完成时为 0
           type: integer
           format: int64
+        last_progress_time:
+          description: 最近一次对外可观测进度更新的时间，毫秒级时间戳；无进度更新时为 0
+          type: integer
+          format: int64
         result:
           description: 执行结果（仅 completed 状态下非空）
           $ref: "#/components/schemas/DiscoverResult"
@@ -408,6 +412,7 @@ components:
         progress: { type: integer }
         start_time: { type: integer, format: int64 }
         finish_time: { type: integer, format: int64 }
+        last_progress_time: { type: integer, format: int64 }
         result: { $ref: "#/components/schemas/DiscoverTaskResultSummary" }
         creator: { $ref: "#/components/schemas/AccountInfo" }
         create_time: { type: integer, format: int64 }

--- a/docs/api/vega/semantic-understanding-task.yaml
+++ b/docs/api/vega/semantic-understanding-task.yaml
@@ -54,10 +54,11 @@ paths:
           in: query
           schema: { type: integer, default: 20 }
         - name: sort
+          description: 排序字段。`start_time`、`finish_time` 为 `0` 的未开始或未结束任务按普通数值排序。
           in: query
           schema:
             type: string
-            enum: [create_time, update_time]
+            enum: [create_time, start_time, finish_time]
             default: create_time
         - name: direction
           in: query
@@ -187,7 +188,7 @@ components:
             required: [catalog_id]
     SemanticUnderstandingTask:
       type: object
-      required: [id, scope, catalog_id, agent_id, input, input_hash, status, apply_mode, confidence_threshold, confidence, applied, creator, create_time, update_time]
+      required: [id, scope, catalog_id, agent_id, input, input_hash, status, apply_mode, confidence_threshold, confidence, applied, creator, create_time]
       properties:
         id: { type: string }
         scope: { type: string, enum: [resource, catalog] }
@@ -207,11 +208,11 @@ components:
         confidence_detail_json: { type: string }
         apply_detail_json: { type: string }
         applied: { type: boolean }
-        applied_time: { type: integer, format: int64 }
         failure_detail: { type: string }
         creator: { $ref: "#/components/schemas/AccountInfo" }
         create_time: { type: integer, format: int64 }
-        update_time: { type: integer, format: int64 }
+        start_time: { type: integer, format: int64 }
+        finish_time: { type: integer, format: int64 }
     ListSemanticUnderstandingTasks:
       type: object
       required: [entries, total_count]
@@ -222,7 +223,7 @@ components:
         total_count: { type: integer, format: int64 }
     SemanticUnderstandingTaskSummary:
       type: object
-      required: [id, scope, catalog_id, agent_id, status, apply_mode, confidence_threshold, confidence, applied, creator, create_time, update_time]
+      required: [id, scope, catalog_id, agent_id, status, apply_mode, confidence_threshold, confidence, applied, creator, create_time]
       properties:
         id: { type: string }
         scope: { type: string, enum: [resource, catalog] }
@@ -237,7 +238,7 @@ components:
         confidence_threshold: { type: number, format: double }
         confidence: { type: number, format: double }
         applied: { type: boolean }
-        applied_time: { type: integer, format: int64 }
         creator: { $ref: "#/components/schemas/AccountInfo" }
         create_time: { type: integer, format: int64 }
-        update_time: { type: integer, format: int64 }
+        start_time: { type: integer, format: int64 }
+        finish_time: { type: integer, format: int64 }

--- a/migrations/vega-backend/mariadb/0.1.4/03-semantic-understanding-task-lifecycle-times.sql
+++ b/migrations/vega-backend/mariadb/0.1.4/03-semantic-understanding-task-lifecycle-times.sql
@@ -1,0 +1,15 @@
+-- Copyright 2026 openbkn.ai
+--
+-- Licensed under the Apache License, Version 2.0.
+-- See the LICENSE file in the project root for details.
+
+USE openbkn;
+
+ALTER TABLE t_semantic_understanding_task
+    ADD COLUMN IF NOT EXISTS f_start_time BIGINT(20) NOT NULL DEFAULT 0 COMMENT '开始执行时间',
+    ADD COLUMN IF NOT EXISTS f_finish_time BIGINT(20) NOT NULL DEFAULT 0 COMMENT '完成时间',
+    DROP COLUMN IF EXISTS f_applied_time,
+    DROP COLUMN IF EXISTS f_update_time,
+    ADD INDEX IF NOT EXISTS idx_create_time (f_create_time),
+    ADD INDEX IF NOT EXISTS idx_start_time (f_start_time),
+    ADD INDEX IF NOT EXISTS idx_finish_time (f_finish_time);

--- a/migrations/vega-backend/mariadb/0.1.4/03-task-lifecycle-times.sql
+++ b/migrations/vega-backend/mariadb/0.1.4/03-task-lifecycle-times.sql
@@ -13,3 +13,10 @@ ALTER TABLE t_semantic_understanding_task
     ADD INDEX IF NOT EXISTS idx_create_time (f_create_time),
     ADD INDEX IF NOT EXISTS idx_start_time (f_start_time),
     ADD INDEX IF NOT EXISTS idx_finish_time (f_finish_time);
+
+ALTER TABLE t_discover_task
+    ADD COLUMN f_last_progress_time BIGINT(20) NOT NULL DEFAULT 0 COMMENT '最近一次对外可观测进度更新时间' AFTER f_finish_time,
+    ADD INDEX IF NOT EXISTS idx_create_time (f_create_time),
+    ADD INDEX IF NOT EXISTS idx_start_time (f_start_time),
+    ADD INDEX IF NOT EXISTS idx_finish_time (f_finish_time),
+    ADD INDEX IF NOT EXISTS idx_last_progress_time (f_last_progress_time);

--- a/migrations/vega-backend/mariadb/0.1.4/03-task-lifecycle-times.sql
+++ b/migrations/vega-backend/mariadb/0.1.4/03-task-lifecycle-times.sql
@@ -20,3 +20,13 @@ ALTER TABLE t_discover_task
     ADD INDEX IF NOT EXISTS idx_start_time (f_start_time),
     ADD INDEX IF NOT EXISTS idx_finish_time (f_finish_time),
     ADD INDEX IF NOT EXISTS idx_last_progress_time (f_last_progress_time);
+
+ALTER TABLE t_build_task
+    ADD COLUMN IF NOT EXISTS f_start_time BIGINT(20) NOT NULL DEFAULT 0 COMMENT '开始执行时间',
+    ADD COLUMN IF NOT EXISTS f_finish_time BIGINT(20) NOT NULL DEFAULT 0 COMMENT '完成时间',
+    ADD COLUMN IF NOT EXISTS f_last_progress_time BIGINT(20) NOT NULL DEFAULT 0 COMMENT '最近一次对外可观测进度更新时间',
+    DROP COLUMN IF EXISTS f_update_time,
+    ADD INDEX IF NOT EXISTS idx_create_time (f_create_time),
+    ADD INDEX IF NOT EXISTS idx_start_time (f_start_time),
+    ADD INDEX IF NOT EXISTS idx_finish_time (f_finish_time),
+    ADD INDEX IF NOT EXISTS idx_last_progress_time (f_last_progress_time);

--- a/migrations/vega-backend/mariadb/0.1.4/03-task-lifecycle-times.sql
+++ b/migrations/vega-backend/mariadb/0.1.4/03-task-lifecycle-times.sql
@@ -15,7 +15,7 @@ ALTER TABLE t_semantic_understanding_task
     ADD INDEX IF NOT EXISTS idx_finish_time (f_finish_time);
 
 ALTER TABLE t_discover_task
-    ADD COLUMN f_last_progress_time BIGINT(20) NOT NULL DEFAULT 0 COMMENT '最近一次对外可观测进度更新时间' AFTER f_finish_time,
+    ADD COLUMN IF NOT EXISTS f_last_progress_time BIGINT(20) NOT NULL DEFAULT 0 COMMENT '最近一次对外可观测进度更新时间' AFTER f_finish_time,
     ADD INDEX IF NOT EXISTS idx_create_time (f_create_time),
     ADD INDEX IF NOT EXISTS idx_start_time (f_start_time),
     ADD INDEX IF NOT EXISTS idx_finish_time (f_finish_time),

--- a/migrations/vega-backend/mariadb/0.1.4/init.sql
+++ b/migrations/vega-backend/mariadb/0.1.4/init.sql
@@ -420,13 +420,19 @@ CREATE TABLE IF NOT EXISTS t_build_task (
     f_creator                 VARCHAR(40) NOT NULL DEFAULT '' COMMENT '创建者id',
     f_creator_type            VARCHAR(20) NOT NULL DEFAULT '' COMMENT '创建者类型',
     f_create_time             BIGINT(20) NOT NULL DEFAULT 0 COMMENT '创建时间',
-    f_update_time             BIGINT(20) NOT NULL DEFAULT 0 COMMENT '更新时间',
+    f_start_time              BIGINT(20) NOT NULL DEFAULT 0 COMMENT '开始执行时间',
+    f_finish_time             BIGINT(20) NOT NULL DEFAULT 0 COMMENT '完成时间',
+    f_last_progress_time      BIGINT(20) NOT NULL DEFAULT 0 COMMENT '最近一次对外可观测进度更新时间',
 
     -- 索引
     PRIMARY KEY (f_id),
     INDEX idx_resource_id (f_resource_id),
     INDEX idx_catalog_id (f_catalog_id),
-    INDEX idx_status (f_status)
+    INDEX idx_status (f_status),
+    INDEX idx_create_time (f_create_time),
+    INDEX idx_start_time (f_start_time),
+    INDEX idx_finish_time (f_finish_time),
+    INDEX idx_last_progress_time (f_last_progress_time)
 ) ENGINE = InnoDB DEFAULT CHARSET = utf8mb4 COLLATE = utf8mb4_bin COMMENT='构建任务表';
 
 -- ==========================================

--- a/migrations/vega-backend/mariadb/0.1.4/init.sql
+++ b/migrations/vega-backend/mariadb/0.1.4/init.sql
@@ -371,6 +371,7 @@ CREATE TABLE IF NOT EXISTS t_discover_task (
     -- 时间信息
     f_start_time              BIGINT(20) NOT NULL DEFAULT 0 COMMENT '开始执行时间',
     f_finish_time             BIGINT(20) NOT NULL DEFAULT 0 COMMENT '完成时间',
+    f_last_progress_time      BIGINT(20) NOT NULL DEFAULT 0 COMMENT '最近一次对外可观测进度更新时间',
 
     -- 执行结果
     f_result                  MEDIUMTEXT NOT NULL COMMENT '发现结果（JSON格式，包含发现的资源统计等）',
@@ -384,7 +385,11 @@ CREATE TABLE IF NOT EXISTS t_discover_task (
     PRIMARY KEY (f_id),
     INDEX idx_catalog_id (f_catalog_id),
     INDEX idx_status (f_status),
-    INDEX idx_schedule_id (f_schedule_id)
+    INDEX idx_schedule_id (f_schedule_id),
+    INDEX idx_create_time (f_create_time),
+    INDEX idx_start_time (f_start_time),
+    INDEX idx_finish_time (f_finish_time),
+    INDEX idx_last_progress_time (f_last_progress_time)
 ) ENGINE = InnoDB DEFAULT CHARSET = utf8mb4 COLLATE = utf8mb4_bin COMMENT='发现任务表，记录异步资源发现任务的状态和结果';
 
 -- ==========================================

--- a/migrations/vega-backend/mariadb/0.1.4/init.sql
+++ b/migrations/vega-backend/mariadb/0.1.4/init.sql
@@ -449,14 +449,15 @@ CREATE TABLE IF NOT EXISTS t_semantic_understanding_task (
     f_confidence_detail_json     MEDIUMTEXT NOT NULL COMMENT '字段、逻辑视图、stale 建议等细粒度置信分(JSON)',
     f_apply_detail_json          MEDIUMTEXT NOT NULL COMMENT '应用明细(JSON)',
     f_applied                    TINYINT(1) NOT NULL DEFAULT 0 COMMENT 'agent 结果是否已应用: 0-否, 1-是',
-    f_applied_time               BIGINT(20) NOT NULL DEFAULT 0 COMMENT '应用时间',
     f_failure_detail             TEXT NOT NULL COMMENT '失败详情',
 
     -- 审计字段
     f_creator                    VARCHAR(40) NOT NULL DEFAULT '' COMMENT '创建者id',
     f_creator_type               VARCHAR(20) NOT NULL DEFAULT '' COMMENT '创建者类型',
     f_create_time                BIGINT(20) NOT NULL DEFAULT 0 COMMENT '创建时间',
-    f_update_time                BIGINT(20) NOT NULL DEFAULT 0 COMMENT '更新时间',
+
+    f_start_time                 BIGINT(20) NOT NULL DEFAULT 0 COMMENT '开始执行时间',
+    f_finish_time                BIGINT(20) NOT NULL DEFAULT 0 COMMENT '完成时间',
 
     -- 索引
     PRIMARY KEY (f_id),
@@ -464,7 +465,10 @@ CREATE TABLE IF NOT EXISTS t_semantic_understanding_task (
     INDEX idx_catalog_id (f_catalog_id),
     INDEX idx_resource_id (f_resource_id),
     INDEX idx_agent_task_id (f_agent_task_id),
-    INDEX idx_status (f_status)
+    INDEX idx_status (f_status),
+    INDEX idx_create_time (f_create_time),
+    INDEX idx_start_time (f_start_time),
+    INDEX idx_finish_time (f_finish_time)
 ) ENGINE = InnoDB DEFAULT CHARSET = utf8mb4 COLLATE = utf8mb4_bin COMMENT='语义理解任务表，记录 resource/catalog 语义理解异步任务、agent 输出和应用状态';
 
 


### PR DESCRIPTION
## What Changed

- [x] Unify Semantic Understanding, Discover, and Build Task lifecycle timestamps.
- [x] Replace Build Task `update_time` with `start_time`, `finish_time`, and `last_progress_time`.
- [x] Update MariaDB 0.1.4 migrations, OpenAPI contracts, sorting, mocks, and tests.

---

## Why

- Related Issue: Closes #806
- Background: distinguish task start, terminal completion, and observable intermediate progress.

---

## How

- `start_time` is set only when a pending task becomes running.
- `finish_time` is set only on terminal transitions.
- `last_progress_time` is updated only with progress; retrying a Build Task clears lifecycle timestamps.
- Semantic Understanding Tasks have no intermediate-progress timestamp.
- Breaking changes: the Build Task API and schema remove `update_time`; no compatibility layer is retained.

---

## Testing

- [x] Unit tests passed locally (`make ci`).
- [ ] Integration tests passed locally (not run; no deployed dependencies).
- [ ] Verified in test environment (not run).
- [x] OpenAPI validation passed locally (`make api-docs-lint`; existing warnings remain).

---

## Risk & Rollback

- Potential risks: the migration drops the old timestamp column; consumers must use the new lifecycle fields.
- Rollback plan: revert this PR before applying the migration; after migration, restore the schema from backup if the removed column data is required.

---

## Additional Notes

- CODEOWNERS for VEGA applies automatically.