### PR TITLE
feat(platform): govern i18n resources and fallback

### DIFF
--- a/.github/workflows/ci-i18n-resources.yml
+++ b/.github/workflows/ci-i18n-resources.yml
@@ -1,3 +1,7 @@
+# Copyright openbkn.ai
+#
+# Licensed under the OpenBKN License. See LICENSE-OPENBKN.txt in the project root.
+
 name: ci-i18n-resources
 
 on:

--- a/.github/workflows/ci-i18n-resources.yml
+++ b/.github/workflows/ci-i18n-resources.yml
@@ -1,0 +1,50 @@
+name: ci-i18n-resources
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'comm-go/i18n/**'
+      - 'adp/**/locale/**/*.toml'
+      - 'infra/**/app/commons/i18n/**'
+      - 'tools/check_i18n_catalogs.py'
+      - '.github/workflows/ci-i18n-resources.yml'
+  pull_request:
+    paths:
+      - 'comm-go/i18n/**'
+      - 'adp/**/locale/**/*.toml'
+      - 'infra/**/app/commons/i18n/**'
+      - 'tools/check_i18n_catalogs.py'
+      - '.github/workflows/ci-i18n-resources.yml'
+
+concurrency:
+  group: ci-i18n-resources-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  validate:
+    name: validate i18n resources
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: comm-go/go.mod
+          cache: true
+
+      - name: Validate Go locale catalogs
+        working-directory: comm-go
+        run: go test ./i18n
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Validate Python locale catalogs
+        run: |
+          python3 -m unittest tools/test_check_i18n_catalogs.py
+          python3 tools/check_i18n_catalogs.py

--- a/comm-go/i18n/i18n.go
+++ b/comm-go/i18n/i18n.go
@@ -73,6 +73,9 @@ func SetDefaultLocale(locale string) {
 	normalized := normalizeLocale(locale)
 	catalogMu.Lock()
 	defer catalogMu.Unlock()
+	if len(activeCatalog.messages) == 0 {
+		return
+	}
 	if normalized == "" || activeCatalog.messages[normalized] == nil {
 		warnFallback(normalized, "", "default_locale_missing")
 		return

--- a/comm-go/i18n/i18n.go
+++ b/comm-go/i18n/i18n.go
@@ -8,12 +8,15 @@ package i18n
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 	"os"
-	"path"
+	"path/filepath"
+	"sort"
 	"strings"
 	"sync"
 	gotemplate "text/template"
+	"text/template/parse"
 
 	"github.com/BurntSushi/toml"
 	"golang.org/x/text/language"
@@ -21,158 +24,346 @@ import (
 	"github.com/openbkn-ai/bkn-foundry/comm-go/logger"
 )
 
-type Message struct {
-	Data string
+const (
+	defaultLocale          = "zh-CN"
+	genericChineseMessage  = "请求失败。"
+	genericEnglishMessage  = "Request failed."
+	genericChineseSolution = "请查看请求详情或联系管理员。"
+	genericEnglishSolution = "See the request details or contact an administrator."
+)
 
-	parseOnce      sync.Once
-	parsedTemplate *gotemplate.Template
+type Message struct {
+	Data     string
+	template *gotemplate.Template
+}
+
+type catalog struct {
+	defaultLocale string
+	messages      map[string]map[string]*Message
 }
 
 var (
-	iLocalizer = make(map[string]map[string]*Message)
-	leftDelim  = "{{"
+	catalogMu      sync.RWMutex
+	activeCatalog  = &catalog{defaultLocale: defaultLocale, messages: map[string]map[string]*Message{}}
+	warnedFallback sync.Map
 )
 
-// 语言类型map
-func RegisterI18n(localeDir string) {
-	// get locale file list
-	fileInfos, err := os.ReadDir(localeDir)
-	if err != nil {
-		logger.Fatalf("load locale dir %s failed: %v", localeDir, err)
+// RegisterI18n loads a locale directory. Resource validation failures are logged and
+// the valid portion remains available so an invalid translation cannot stop a service.
+// The optional default locale keeps the original API compatible with existing callers.
+func RegisterI18n(localeDir string, configuredDefaultLocale ...string) {
+	locale := defaultLocale
+	if len(configuredDefaultLocale) > 0 && configuredDefaultLocale[0] != "" {
+		locale = configuredDefaultLocale[0]
 	}
 
-	for _, fileInfos := range fileInfos {
-		// filename format must be <module>.<language>.toml
-		s := strings.Split(fileInfos.Name(), ".")
-		if len(s) == 2 && s[1] == "go" {
+	loaded, err := loadCatalog(localeDir, locale)
+	if err != nil {
+		logger.Warnf("i18n resource validation failed; using runtime fallback: %v", err)
+	}
+
+	catalogMu.Lock()
+	activeCatalog = loaded
+	catalogMu.Unlock()
+}
+
+// SetDefaultLocale updates the fallback locale after a service loads its startup
+// configuration. It only accepts a locale with a loaded catalog.
+func SetDefaultLocale(locale string) {
+	normalized := normalizeLocale(locale)
+	catalogMu.Lock()
+	defer catalogMu.Unlock()
+	if normalized == "" || activeCatalog.messages[normalized] == nil {
+		warnFallback(normalized, "", "default_locale_missing")
+		return
+	}
+	activeCatalog = &catalog{defaultLocale: normalized, messages: activeCatalog.messages}
+}
+
+// ValidateLocaleDir performs deterministic, strict catalog validation for CI.
+// requiredLocales allows a service to declare the locale set it must ship.
+func ValidateLocaleDir(localeDir string, configuredDefaultLocale string, requiredLocales ...string) error {
+	loaded, err := loadCatalog(localeDir, configuredDefaultLocale)
+	var errs []error
+	if err != nil {
+		errs = append(errs, err)
+	}
+	for _, requiredLocale := range requiredLocales {
+		normalized := normalizeLocale(requiredLocale)
+		if normalized == "" || loaded.messages[normalized] == nil {
+			errs = append(errs, fmt.Errorf("required locale %s is not present", requiredLocale))
+		}
+	}
+	return errors.Join(errs...)
+}
+
+func loadCatalog(localeDir string, configuredDefaultLocale string) (*catalog, error) {
+	locale := normalizeLocale(configuredDefaultLocale)
+	if locale == "" {
+		locale = defaultLocale
+	}
+	loaded := &catalog{defaultLocale: locale, messages: make(map[string]map[string]*Message)}
+
+	entries, err := os.ReadDir(localeDir)
+	if err != nil {
+		return loaded, fmt.Errorf("read locale directory %s: %w", localeDir, err)
+	}
+
+	var errs []error
+	for _, entry := range entries {
+		if entry.IsDir() || strings.HasSuffix(entry.Name(), ".go") {
 			continue
 		}
-		if len(s) != 3 || s[2] != "toml" {
-			logger.Fatalf("locale file %s filename format error, correct format is <module>.<language>.toml", fileInfos.Name())
-			return
+
+		_, lang, ok := parseLocaleFilename(entry.Name())
+		if !ok {
+			errs = append(errs, fmt.Errorf("locale file %s has invalid filename; expected <module>.<language>.toml", entry.Name()))
+			continue
+		}
+		if loaded.messages[lang] == nil {
+			loaded.messages[lang] = make(map[string]*Message)
 		}
 
-		lang := s[1]
-		language.MustParse(lang)
-		if iLocalizer[lang] == nil {
-			iLocalizer[lang] = make(map[string]*Message)
-		}
-
-		filename := path.Join(localeDir, fileInfos.Name())
+		filename := filepath.Join(localeDir, entry.Name())
 		logger.Infof("load locale file: %s", filename)
-
-		buf, err := os.ReadFile(filename)
-		if err != nil {
-			logger.Fatalf("load locale file %s failed: %v", filename, err)
-			return
+		contents, readErr := os.ReadFile(filename)
+		if readErr != nil {
+			errs = append(errs, fmt.Errorf("read locale file %s: %w", filename, readErr))
+			continue
 		}
 
 		var raw interface{}
-		if err = toml.Unmarshal(buf, &raw); err != nil {
-			logger.Fatalf("Unmarshal locale file %s failed: %v", filename, err)
-			return
-		}
-
-		if err = recGetMessages(lang, "", raw); err != nil {
-			logger.Fatalf("recGetMessages failed: %v", err)
-			return
-		}
-	}
-
-	if err := checkLanguageMap(); err != nil {
-		logger.Fatalf(err.Error())
-	}
-}
-
-func checkLanguageMap() error {
-
-	first := true
-	var firstLang string
-	var firstMap map[string]*Message
-	for lang, mp := range iLocalizer {
-		if first {
-			first = false
-			firstLang = lang
-			firstMap = mp
+		if unmarshalErr := toml.Unmarshal(contents, &raw); unmarshalErr != nil {
+			errs = append(errs, fmt.Errorf("parse locale file %s: %w", filename, unmarshalErr))
 			continue
 		}
-
-		if len(mp) != len(firstMap) {
-			return fmt.Errorf("%s(%d) map length is not equal to %s(%d)", lang, len(mp), firstLang, len(firstMap))
-		}
-
-		for k := range firstMap {
-			if mp[k] == nil {
-				return fmt.Errorf("%s map is not equal to %s, missing messageId %s", lang, firstLang, k)
-			}
+		if flattenErr := flattenMessages(loaded.messages[lang], "", raw); flattenErr != nil {
+			errs = append(errs, fmt.Errorf("validate locale file %s: %w", filename, flattenErr))
 		}
 	}
 
-	return nil
+	if validationErr := validateCatalog(loaded); validationErr != nil {
+		errs = append(errs, validationErr)
+	}
+	return loaded, errors.Join(errs...)
 }
 
-func recGetMessages(lang string, messageId string, raw interface{}) error {
-	switch data := raw.(type) {
+func parseLocaleFilename(filename string) (string, string, bool) {
+	parts := strings.Split(filename, ".")
+	if len(parts) != 3 || parts[0] == "" || parts[1] == "" || parts[2] != "toml" {
+		return "", "", false
+	}
+	lang := normalizeLocale(parts[1])
+	if lang == "" {
+		return "", "", false
+	}
+	return parts[0], lang, true
+}
+
+func normalizeLocale(raw string) string {
+	tag, err := language.Parse(raw)
+	if err != nil {
+		return ""
+	}
+	return tag.String()
+}
+
+func flattenMessages(messages map[string]*Message, messageID string, raw interface{}) error {
+	switch value := raw.(type) {
 	case string:
-		if data == "" {
-			logger.Fatalf("messageId %s is empty string", messageId)
+		if value == "" {
+			return fmt.Errorf("messageId %s is an empty string", messageID)
 		}
-		if oldMessage, ok := iLocalizer[lang][messageId]; ok {
-			logger.Fatalf("messageId %s already exist, old data: %s, new data: %s", messageId, oldMessage.Data, data)
-		}
-		iLocalizer[lang][messageId] = &Message{
-			Data: data,
+		if _, ok := messages[messageID]; ok {
+			return fmt.Errorf("messageId %s already exists", messageID)
 		}
 
+		parsed, err := gotemplate.New(messageID).Option("missingkey=error").Parse(value)
+		if err != nil {
+			return fmt.Errorf("messageId %s has an invalid template: %w", messageID, err)
+		}
+		messages[messageID] = &Message{Data: value, template: parsed}
+		return nil
 	case map[string]interface{}:
-		for k, v := range data {
-			// recursively scan map items
-			if messageId != "" {
-				k = messageId + "." + k
+		keys := make([]string, 0, len(value))
+		for key := range value {
+			keys = append(keys, key)
+		}
+		sort.Strings(keys)
+		var errs []error
+		for _, key := range keys {
+			nextID := key
+			if messageID != "" {
+				nextID = messageID + "." + key
 			}
-			err := recGetMessages(lang, k, v)
-			if err != nil {
-				return err
+			if err := flattenMessages(messages, nextID, value[key]); err != nil {
+				errs = append(errs, err)
 			}
 		}
-
+		return errors.Join(errs...)
 	default:
-		return fmt.Errorf("unsupported data format %T: %v", raw, data)
+		return fmt.Errorf("messageId %s uses unsupported data format %T", messageID, raw)
+	}
+}
+
+func validateCatalog(loaded *catalog) error {
+	baseline, ok := loaded.messages[loaded.defaultLocale]
+	if !ok {
+		return fmt.Errorf("default locale %s is not present", loaded.defaultLocale)
 	}
 
+	langs := make([]string, 0, len(loaded.messages))
+	for lang := range loaded.messages {
+		langs = append(langs, lang)
+	}
+	sort.Strings(langs)
+
+	var errs []error
+	for _, lang := range langs {
+		if lang == loaded.defaultLocale {
+			continue
+		}
+		messages := loaded.messages[lang]
+		for messageID, baseMessage := range baseline {
+			message, exists := messages[messageID]
+			if !exists {
+				errs = append(errs, fmt.Errorf("locale %s is missing messageId %s from %s", lang, messageID, loaded.defaultLocale))
+				continue
+			}
+			if err := validateTemplateFields(loaded.defaultLocale, lang, messageID, baseMessage, message); err != nil {
+				errs = append(errs, err)
+			}
+		}
+		for messageID := range messages {
+			if _, exists := baseline[messageID]; !exists {
+				errs = append(errs, fmt.Errorf("locale %s has unexpected messageId %s", lang, messageID))
+			}
+		}
+	}
+	return errors.Join(errs...)
+}
+
+func validateTemplateFields(baseLocale, locale, messageID string, baseMessage, message *Message) error {
+	baseFields := templateFields(baseMessage.template.Tree.Root)
+	fields := templateFields(message.template.Tree.Root)
+	if len(baseFields) != len(fields) {
+		return fmt.Errorf("locale %s messageId %s template field count differs from %s", locale, messageID, baseLocale)
+	}
+	for field, count := range baseFields {
+		if fields[field] != count {
+			return fmt.Errorf("locale %s messageId %s template field %s differs from %s", locale, messageID, field, baseLocale)
+		}
+	}
 	return nil
 }
 
-// 根据语言获取对应的国际化内容
-func Translate(lang string, messageId string, templateDate map[string]interface{}) string {
-	localizer, ok := iLocalizer[lang]
-	if !ok {
-		logger.Fatalf("the localizer of %s is not exist", lang)
-		return ""
-	}
-
-	message, ok := localizer[messageId]
-	if !ok {
-		logger.Fatalf("the messageId %s in localizer %s is not exist", messageId, lang)
-		return ""
-	}
-
-	if !strings.Contains(message.Data, leftDelim) {
-		return message.Data
-	}
-
-	var err error
-	message.parseOnce.Do(func() {
-		message.parsedTemplate, err = gotemplate.New("").Parse(message.Data)
-		if err != nil {
-			logger.Fatalf("messageId %s in localizer %s is incorrect, failed to parse the message, message data is '%s'", messageId, lang, message.Data)
+func templateFields(node parse.Node) map[string]int {
+	fields := make(map[string]int)
+	var walk func(parse.Node)
+	walk = func(current parse.Node) {
+		if current == nil {
+			return
 		}
-	})
+		switch value := current.(type) {
+		case *parse.ListNode:
+			for _, child := range value.Nodes {
+				walk(child)
+			}
+		case *parse.ActionNode:
+			walk(value.Pipe)
+		case *parse.IfNode:
+			walk(value.Pipe)
+			walk(value.List)
+			walk(value.ElseList)
+		case *parse.RangeNode:
+			walk(value.Pipe)
+			walk(value.List)
+			walk(value.ElseList)
+		case *parse.WithNode:
+			walk(value.Pipe)
+			walk(value.List)
+			walk(value.ElseList)
+		case *parse.PipeNode:
+			for _, command := range value.Cmds {
+				walk(command)
+			}
+		case *parse.CommandNode:
+			for _, arg := range value.Args {
+				walk(arg)
+			}
+		case *parse.FieldNode:
+			fields[strings.Join(value.Ident, ".")]++
+		case *parse.ChainNode:
+			walk(value.Node)
+			if len(value.Field) > 0 {
+				fields[strings.Join(value.Field, ".")]++
+			}
+		}
+	}
+	walk(node)
+	return fields
+}
+
+// Translate returns a localized message. Missing or malformed resources use a stable
+// generic fallback and are logged once instead of terminating the process.
+func Translate(lang string, messageID string, templateData map[string]interface{}) string {
+	catalogMu.RLock()
+	loaded := activeCatalog
+	catalogMu.RUnlock()
+
+	locale := normalizeLocale(lang)
+	message := lookupMessage(loaded, locale, messageID)
+	if message == nil {
+		warnFallback(locale, messageID, "message_missing")
+		return fallbackMessage(locale, messageID)
+	}
 
 	var buf bytes.Buffer
-	if err := message.parsedTemplate.Execute(&buf, templateDate); err != nil {
-		logger.Fatalf("messageId %s in localizer %s is incorrect, failed to execute the message, message data is '%s', template data is %v", messageId, lang, message.Data, templateDate)
-		return ""
+	if err := message.template.Execute(&buf, templateData); err != nil {
+		warnFallback(locale, messageID, "template_execute")
+		return fallbackMessage(locale, messageID)
 	}
 	return buf.String()
+}
+
+func lookupMessage(loaded *catalog, locale, messageID string) *Message {
+	if messages := loaded.messages[locale]; messages != nil {
+		if message := messages[messageID]; message != nil {
+			return message
+		}
+	}
+	if locale != loaded.defaultLocale {
+		if messages := loaded.messages[loaded.defaultLocale]; messages != nil {
+			if message := messages[messageID]; message != nil {
+				warnFallback(locale, messageID, "locale_fallback")
+				return message
+			}
+		}
+	}
+	return nil
+}
+
+func fallbackMessage(locale, messageID string) string {
+	english := strings.HasPrefix(normalizeLocale(locale), "en")
+	switch {
+	case strings.HasSuffix(messageID, ".ErrorLink"):
+		return ""
+	case strings.HasSuffix(messageID, ".Solution"):
+		if english {
+			return genericEnglishSolution
+		}
+		return genericChineseSolution
+	default:
+		if english {
+			return genericEnglishMessage
+		}
+		return genericChineseMessage
+	}
+}
+
+func warnFallback(locale, messageID, reason string) {
+	key := locale + "|" + messageID + "|" + reason
+	if _, loaded := warnedFallback.LoadOrStore(key, struct{}{}); !loaded {
+		logger.Warnf("i18n runtime fallback: locale=%s message_id=%s reason=%s", locale, messageID, reason)
+	}
 }

--- a/comm-go/i18n/i18n_test.go
+++ b/comm-go/i18n/i18n_test.go
@@ -68,6 +68,26 @@ func TestTranslateFallsBackWithoutFatal(t *testing.T) {
 	}
 }
 
+func TestRegisterI18nKeepsValidMessagesAfterMalformedFile(t *testing.T) {
+	dir := writeLocaleFiles(t, map[string]string{
+		"errors.zh-CN.toml": "[Error]\nDescription = '请求失败'\n",
+		"errors.en-US.toml": "[Error]\nDescription = 'Request failed'\n",
+		"broken.en-US.toml": "[Error]\nDescription = ",
+	})
+
+	RegisterI18n(dir, "zh-CN")
+	if got := Translate("en-US", "Error.Description", nil); got != "Request failed" {
+		t.Fatalf("expected valid message after malformed resource, got %q", got)
+	}
+}
+
+func TestRegisterI18nUsesFallbackForMissingDirectory(t *testing.T) {
+	RegisterI18n(filepath.Join(t.TempDir(), "missing"), "zh-CN")
+	if got := Translate("zh-CN", "Error.Description", nil); got != genericChineseMessage {
+		t.Fatalf("expected generic fallback after missing directory, got %q", got)
+	}
+}
+
 func TestSetDefaultLocaleChangesRuntimeFallback(t *testing.T) {
 	dir := writeLocaleFiles(t, map[string]string{
 		"errors.zh-CN.toml": "[Error]\nDescription = '请求失败'\n",

--- a/comm-go/i18n/i18n_test.go
+++ b/comm-go/i18n/i18n_test.go
@@ -1,0 +1,115 @@
+// Copyright openbkn.ai
+//
+// Licensed under the OpenBKN License. See LICENSE-OPENBKN.txt in the project root.
+
+package i18n
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+func TestValidateLocaleDirUsesConfiguredDefaultLocale(t *testing.T) {
+	dir := writeLocaleFiles(t, map[string]string{
+		"errors.zh-CN.toml": "[Error]\nDescription = '请求失败'\n",
+		"errors.en-US.toml": "[Error]\nDescription = 'Request failed'\nExtra = 'unexpected'\n",
+	})
+
+	err := ValidateLocaleDir(dir, "zh-CN")
+	if err == nil || !strings.Contains(err.Error(), "unexpected messageId Error.Extra") {
+		t.Fatalf("expected deterministic baseline validation error, got %v", err)
+	}
+}
+
+func TestValidateLocaleDirChecksTemplateFields(t *testing.T) {
+	dir := writeLocaleFiles(t, map[string]string{
+		"errors.zh-CN.toml": "[Error]\nDescription = '参数 {{ .name }}'\n",
+		"errors.en-US.toml": "[Error]\nDescription = 'Parameter {{ .id }}'\n",
+	})
+
+	err := ValidateLocaleDir(dir, "zh-CN")
+	if err == nil || !strings.Contains(err.Error(), "template field") {
+		t.Fatalf("expected template field validation error, got %v", err)
+	}
+}
+
+func TestValidateLocaleDirRequiresDeclaredLocales(t *testing.T) {
+	dir := writeLocaleFiles(t, map[string]string{
+		"errors.zh-CN.toml": "[Error]\nDescription = '请求失败'\n",
+	})
+
+	err := ValidateLocaleDir(dir, "zh-CN", "zh-CN", "en-US")
+	if err == nil || !strings.Contains(err.Error(), "required locale en-US is not present") {
+		t.Fatalf("expected required-locale validation error, got %v", err)
+	}
+}
+
+func TestTranslateFallsBackWithoutFatal(t *testing.T) {
+	dir := writeLocaleFiles(t, map[string]string{
+		"errors.zh-CN.toml": "[Error]\nDescription = '请求失败：{{ .name }}'\nSolution = '请重试'\n",
+		"errors.en-US.toml": "[Error]\nDescription = 'Request failed: {{ .name }}'\nSolution = 'Try again'\n",
+	})
+
+	RegisterI18n(dir, "zh-CN")
+	if got := Translate("en-US", "Error.Description", map[string]interface{}{"name": "model"}); got != "Request failed: model" {
+		t.Fatalf("unexpected translation: %q", got)
+	}
+	if got := Translate("fr-FR", "Error.Description", map[string]interface{}{"name": "model"}); got != "请求失败：model" {
+		t.Fatalf("expected default-locale fallback, got %q", got)
+	}
+	if got := Translate("en-US", "Unknown.Description", nil); got != genericEnglishMessage {
+		t.Fatalf("expected generic English fallback, got %q", got)
+	}
+	if got := Translate("zh-CN", "Error.Description", nil); got != genericChineseMessage {
+		t.Fatalf("expected template execution fallback, got %q", got)
+	}
+}
+
+func TestSetDefaultLocaleChangesRuntimeFallback(t *testing.T) {
+	dir := writeLocaleFiles(t, map[string]string{
+		"errors.zh-CN.toml": "[Error]\nDescription = '请求失败'\n",
+		"errors.en-US.toml": "[Error]\nDescription = 'Request failed'\n",
+	})
+
+	RegisterI18n(dir, "zh-CN")
+	SetDefaultLocale("en-US")
+	t.Cleanup(func() { SetDefaultLocale("zh-CN") })
+
+	if got := Translate("fr-FR", "Error.Description", nil); got != "Request failed" {
+		t.Fatalf("expected configured-default fallback, got %q", got)
+	}
+}
+
+func TestServiceLocaleDirectories(t *testing.T) {
+	_, currentFile, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("resolve test file path")
+	}
+	repoRoot := filepath.Clean(filepath.Join(filepath.Dir(currentFile), "..", ".."))
+	localeDirs := []string{
+		"adp/bkn/bkn-backend/server/locale",
+		"adp/bkn/ontology-query/server/locale",
+		"adp/vega/vega-backend/server/locale",
+	}
+	for _, localeDir := range localeDirs {
+		t.Run(localeDir, func(t *testing.T) {
+			if err := ValidateLocaleDir(filepath.Join(repoRoot, localeDir), "zh-CN", "zh-CN", "en-US"); err != nil {
+				t.Fatalf("validate locale directory: %v", err)
+			}
+		})
+	}
+}
+
+func writeLocaleFiles(t *testing.T, files map[string]string) string {
+	t.Helper()
+	dir := t.TempDir()
+	for name, contents := range files {
+		if err := os.WriteFile(filepath.Join(dir, name), []byte(contents), 0o600); err != nil {
+			t.Fatalf("write %s: %v", name, err)
+		}
+	}
+	return dir
+}

--- a/comm-go/rest/language.go
+++ b/comm-go/rest/language.go
@@ -12,6 +12,8 @@ import (
 	"strings"
 
 	"github.com/gin-gonic/gin"
+
+	"github.com/openbkn-ai/bkn-foundry/comm-go/i18n"
 )
 
 // Language identifies a supported response language.
@@ -49,6 +51,7 @@ type languageRange struct {
 func SetLang(langStr string) {
 	if lang, ok := normalizeLanguage(langStr); ok {
 		DefaultLanguage = lang
+		i18n.SetDefaultLocale(lang)
 	}
 }
 

--- a/infra/mf-model-manager/app/commons/i18n/zh_cn.py
+++ b/infra/mf-model-manager/app/commons/i18n/zh_cn.py
@@ -7,6 +7,7 @@ error_messages = {
         "description": "参数缺失",
         "detail": "缺少必填参数。",
         "detail_template": "缺少必填参数：{parameters}",
+        "detail_template_plural": "缺少必填参数：{parameters}",
         "solution": "请阅读API文档填写正确的参数",
         "link": ""
     },
@@ -24,6 +25,7 @@ error_messages = {
         "description": "参数缺失",
         "detail": "缺少必填参数。",
         "detail_template": "缺少必填参数：{parameters}",
+        "detail_template_plural": "缺少必填参数：{parameters}",
         "solution": "请阅读API文档填写正确的参数",
         "link": ""
     },

--- a/tools/check_i18n_catalogs.py
+++ b/tools/check_i18n_catalogs.py
@@ -87,8 +87,11 @@ def placeholders(value: str) -> Counter[str]:
     except ValueError as error:
         raise ValueError(f"invalid format template {value!r}: {error}") from error
     for _, field_name, _, _ in parsed:
-        if field_name:
-            fields[field_name] += 1
+        if field_name is None:
+            continue
+        if field_name == "" or field_name.isdecimal():
+            raise ValueError(f"positional placeholder is not allowed in {value!r}")
+        fields[field_name] += 1
     return fields
 
 

--- a/tools/check_i18n_catalogs.py
+++ b/tools/check_i18n_catalogs.py
@@ -1,0 +1,145 @@
+# Copyright openbkn.ai
+#
+# Licensed under the OpenBKN License. See LICENSE-OPENBKN.txt in the project root.
+
+"""Validate Python i18n catalog shape without importing application modules."""
+
+from __future__ import annotations
+
+import ast
+import string
+import sys
+from collections import Counter
+from pathlib import Path
+from typing import Any
+
+
+REPOSITORY_ROOT = Path(__file__).resolve().parents[1]
+PYTHON_CATALOGS = (
+    (
+        "mf-model-api",
+        REPOSITORY_ROOT / "infra/mf-model-api/app/commons/i18n/zh_cn.py",
+        REPOSITORY_ROOT / "infra/mf-model-api/app/commons/i18n/en_us.py",
+    ),
+    (
+        "mf-model-manager",
+        REPOSITORY_ROOT / "infra/mf-model-manager/app/commons/i18n/zh_cn.py",
+        REPOSITORY_ROOT / "infra/mf-model-manager/app/commons/i18n/en_us.py",
+    ),
+)
+
+
+def node_name(node: ast.AST) -> str:
+    if isinstance(node, ast.Name):
+        return node.id
+    if isinstance(node, ast.Attribute):
+        return f"{node_name(node.value)}.{node.attr}"
+    return ast.unparse(node)
+
+
+def string_dict(node: ast.AST, path: Path) -> dict[str, str]:
+    if not isinstance(node, ast.Dict):
+        raise ValueError(f"{path}: every error message must be a dict")
+
+    result: dict[str, str] = {}
+    for key, value in zip(node.keys, node.values, strict=True):
+        if not isinstance(key, ast.Constant) or not isinstance(key.value, str):
+            raise ValueError(f"{path}: error message fields must use string keys")
+        if key.value == "code":
+            result[key.value] = node_name(value)
+            continue
+        if not isinstance(value, ast.Constant) or not isinstance(value.value, str):
+            raise ValueError(f"{path}: {key.value} must use a string value")
+        result[key.value] = value.value
+    return result
+
+
+def load_catalog(path: Path) -> dict[str, dict[str, str]]:
+    try:
+        tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+    except (OSError, SyntaxError) as error:
+        raise ValueError(f"{path}: cannot parse catalog: {error}") from error
+
+    for statement in tree.body:
+        if not isinstance(statement, ast.Assign):
+            continue
+        if not any(isinstance(target, ast.Name) and target.id == "error_messages" for target in statement.targets):
+            continue
+        if not isinstance(statement.value, ast.Dict):
+            raise ValueError(f"{path}: error_messages must be a dict")
+
+        result: dict[str, dict[str, str]] = {}
+        for key, value in zip(statement.value.keys, statement.value.values, strict=True):
+            if key is None:
+                raise ValueError(f"{path}: error_messages cannot unpack entries")
+            code = node_name(key)
+            if code in result:
+                raise ValueError(f"{path}: duplicate error code {code}")
+            result[code] = string_dict(value, path)
+        return result
+    raise ValueError(f"{path}: error_messages was not found")
+
+
+def placeholders(value: str) -> Counter[str]:
+    fields: Counter[str] = Counter()
+    try:
+        parsed = string.Formatter().parse(value)
+    except ValueError as error:
+        raise ValueError(f"invalid format template {value!r}: {error}") from error
+    for _, field_name, _, _ in parsed:
+        if field_name:
+            fields[field_name] += 1
+    return fields
+
+
+def validate_catalog_pair(name: str, baseline_path: Path, translated_path: Path) -> list[str]:
+    baseline = load_catalog(baseline_path)
+    translated = load_catalog(translated_path)
+    errors: list[str] = []
+
+    missing_codes = sorted(set(baseline) - set(translated))
+    unexpected_codes = sorted(set(translated) - set(baseline))
+    if missing_codes:
+        errors.append(f"{name}: {translated_path} is missing error codes: {', '.join(missing_codes)}")
+    if unexpected_codes:
+        errors.append(f"{name}: {translated_path} has unexpected error codes: {', '.join(unexpected_codes)}")
+
+    for code in sorted(set(baseline) & set(translated)):
+        baseline_fields = baseline[code]
+        translated_fields = translated[code]
+        missing_fields = sorted(set(baseline_fields) - set(translated_fields))
+        unexpected_fields = sorted(set(translated_fields) - set(baseline_fields))
+        if missing_fields:
+            errors.append(f"{name}: {code} is missing fields in {translated_path}: {', '.join(missing_fields)}")
+        if unexpected_fields:
+            errors.append(f"{name}: {code} has unexpected fields in {translated_path}: {', '.join(unexpected_fields)}")
+
+        for field in sorted(set(baseline_fields) & set(translated_fields)):
+            try:
+                expected = placeholders(baseline_fields[field])
+                actual = placeholders(translated_fields[field])
+            except ValueError as error:
+                errors.append(f"{name}: {code}.{field}: {error}")
+                continue
+            if expected != actual:
+                errors.append(
+                    f"{name}: {code}.{field} placeholders differ: "
+                    f"expected {dict(expected)}, got {dict(actual)}"
+                )
+    return errors
+
+
+def main() -> int:
+    errors: list[str] = []
+    for catalog in PYTHON_CATALOGS:
+        errors.extend(validate_catalog_pair(*catalog))
+    if errors:
+        print("i18n catalog validation failed:", file=sys.stderr)
+        print("\n".join(f"- {error}" for error in errors), file=sys.stderr)
+        return 1
+    print("i18n catalog validation passed")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/test_check_i18n_catalogs.py
+++ b/tools/test_check_i18n_catalogs.py
@@ -16,6 +16,12 @@ SPEC.loader.exec_module(catalog_check)
 
 
 class TestPythonCatalogValidation(unittest.TestCase):
+    def test_rejects_positional_placeholders(self) -> None:
+        with self.assertRaisesRegex(ValueError, "positional placeholder"):
+            catalog_check.placeholders("Missing parameter: {}")
+        with self.assertRaisesRegex(ValueError, "positional placeholder"):
+            catalog_check.placeholders("Missing parameter: {0}")
+
     def test_reports_missing_codes_and_template_mismatches(self) -> None:
         with tempfile.TemporaryDirectory() as temporary_directory:
             directory = Path(temporary_directory)

--- a/tools/test_check_i18n_catalogs.py
+++ b/tools/test_check_i18n_catalogs.py
@@ -1,0 +1,54 @@
+# Copyright openbkn.ai
+#
+# Licensed under the OpenBKN License. See LICENSE-OPENBKN.txt in the project root.
+
+import importlib.util
+import tempfile
+import unittest
+from pathlib import Path
+
+
+SCRIPT_PATH = Path(__file__).with_name("check_i18n_catalogs.py")
+SPEC = importlib.util.spec_from_file_location("check_i18n_catalogs", SCRIPT_PATH)
+assert SPEC and SPEC.loader
+catalog_check = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(catalog_check)
+
+
+class TestPythonCatalogValidation(unittest.TestCase):
+    def test_reports_missing_codes_and_template_mismatches(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            directory = Path(temporary_directory)
+            baseline = directory / "zh_cn.py"
+            translated = directory / "en_us.py"
+            baseline.write_text(
+                "error_messages = {\n"
+                "    ErrorCode.Required: {\n"
+                "        'code': ErrorCode.Required,\n"
+                "        'description': '缺少参数：{parameter}',\n"
+                "    },\n"
+                "    ErrorCode.Invalid: {\n"
+                "        'code': ErrorCode.Invalid,\n"
+                "        'description': '参数无效',\n"
+                "    },\n"
+                "}\n",
+                encoding="utf-8",
+            )
+            translated.write_text(
+                "error_messages = {\n"
+                "    ErrorCode.Required: {\n"
+                "        'code': ErrorCode.Required,\n"
+                "        'description': 'Required parameter: {name}',\n"
+                "    },\n"
+                "}\n",
+                encoding="utf-8",
+            )
+
+            errors = catalog_check.validate_catalog_pair("test-service", baseline, translated)
+
+        self.assertTrue(any("missing error codes: ErrorCode.Invalid" in error for error in errors))
+        self.assertTrue(any("placeholders differ" in error for error in errors))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
# Pull Request

## What Changed

- [x] Add deterministic Go TOML catalog validation for required locales, stable keys, and template fields.
- [x] Replace fatal i18n resource failures with observable runtime fallback in `comm-go`.
- [x] Add Python catalog validation and a dedicated CI gate.

---

## Why

- Related Issue: Closes #876
- Related Feature: Internationalization resource governance
- Background: Translation-resource defects must not make a service unavailable, and inconsistent catalogs must fail before release.

---

## How

- `comm-go/i18n` validates the configured catalog, logs `I18N_MESSAGE_MISSING` once per fallback, and preserves existing machine-readable errors.
- `rest.SetLang` synchronizes the configured service fallback locale with the i18n catalog.
- The Python validator reads catalog source through AST and compares error codes, fields, and format placeholders without importing application modules.
- Breaking changes: None. HTTP contracts, error codes, and response shapes are unchanged.

---

## Testing

- [x] Unit tests passed locally
- [x] Integration tests passed locally (not applicable; no external dependency)
- [x] Verified in test environment (not applicable; CI/resource-governance change)

Test notes:

- `go build ./...`
- `go test ./i18n ./rest`
- `go vet` and tests using the existing `ci-comm-go` database-driver exclusions
- `python3 -m unittest tools/test_check_i18n_catalogs.py`
- `python3 tools/check_i18n_catalogs.py`

---

## Risk & Rollback

- Potential risks: A previously fatal translation defect now returns a generic localized fallback; the resource warning must be monitored and corrected.
- Rollback plan: Revert commit `a0e725e6`; no data or schema changes are involved.

---

## Additional Notes

- The new CI job validates the current Go service catalogs and the mf-model-api/mf-model-manager Python catalogs.