### PR TITLE
fix(vega): normalize self-referencing field features instead of rejecting them

### DIFF
--- a/adp/vega/vega-backend/server/driveradapters/validate_resource.go
+++ b/adp/vega/vega-backend/server/driveradapters/validate_resource.go
@@ -21,33 +21,14 @@ import (
 )
 
 func ValidateResourceRequest(ctx context.Context, req *interfaces.ResourceRequest) error {
-	normalizeSchemaFeatures(req.SchemaDefinition)
+	// 存量资源的自引用 ref_property 在这里抹平。库里读出来的 schema 由 logics 层做同样的
+	// 归一化，两侧必须一致，否则更新会被判成 build 相关变更而清空 LocalIndexName。
+	resourcelogic.NormalizeSelfReferencingFeatures(req.SchemaDefinition)
 
 	if err := validateResourceRequestBase(ctx, req); err != nil {
 		return err
 	}
 	return validateResourceRequestSchema(ctx, req)
-}
-
-// normalizeSchemaFeatures 归一化字段特征里的自引用 ref_property。
-//
-// ref_property 的语义是「特征挂在 A 属性上、但作用于 B 字段」，指向字段自身是一个
-// 无意义的冗余写法：能力派生本来就在 ref_property 为空时落回属性自身（见 bkn-backend
-// 的 VegaResourceIndexCaps），两种写法结果完全相同。
-//
-// 但历史上平台自己写入的存量资源正是这个形状，因此这里必须就地抹平而不是报错——
-// 一旦报错，存量资源的任何读改写（vega dataset build 就是）都会失败，索引再也重建不了。
-func normalizeSchemaFeatures(props []*interfaces.Property) {
-	for _, prop := range props {
-		if prop == nil {
-			continue
-		}
-		for i := range prop.Features {
-			if prop.Features[i].RefProperty == prop.Name {
-				prop.Features[i].RefProperty = ""
-			}
-		}
-	}
 }
 
 func validateResourceRequestBase(ctx context.Context, req *interfaces.ResourceRequest) error {

--- a/adp/vega/vega-backend/server/driveradapters/validate_resource.go
+++ b/adp/vega/vega-backend/server/driveradapters/validate_resource.go
@@ -21,10 +21,6 @@ import (
 )
 
 func ValidateResourceRequest(ctx context.Context, req *interfaces.ResourceRequest) error {
-	// 存量资源的自引用 ref_property 在这里抹平。库里读出来的 schema 由 logics 层做同样的
-	// 归一化，两侧必须一致，否则更新会被判成 build 相关变更而清空 LocalIndexName。
-	resourcelogic.NormalizeSelfReferencingFeatures(req.SchemaDefinition)
-
 	if err := validateResourceRequestBase(ctx, req); err != nil {
 		return err
 	}
@@ -63,6 +59,11 @@ func validateResourceRequestSchema(ctx context.Context, req *interfaces.Resource
 		}
 		return validateSchemaProperties(ctx, req.SchemaDefinition, false)
 	default:
+		// 只有原始资源支持 ref_property，也只有它们的存量数据里会有自引用形状，因此归一化
+		// 只在这一支做：dataset 的 ref_property 在 #837 之前就是 400，放宽它属于本次回归
+		// 之外的行为变更。库里读出来的 schema 由 logics 层做同样的归一化，两侧必须一致，
+		// 否则更新会被判成 build 相关变更而清空 LocalIndexName。
+		resourcelogic.NormalizeSelfReferencingFeatures(req.SchemaDefinition)
 		return validateSchemaProperties(ctx, req.SchemaDefinition, true)
 	}
 }

--- a/adp/vega/vega-backend/server/driveradapters/validate_resource.go
+++ b/adp/vega/vega-backend/server/driveradapters/validate_resource.go
@@ -21,10 +21,33 @@ import (
 )
 
 func ValidateResourceRequest(ctx context.Context, req *interfaces.ResourceRequest) error {
+	normalizeSchemaFeatures(req.SchemaDefinition)
+
 	if err := validateResourceRequestBase(ctx, req); err != nil {
 		return err
 	}
 	return validateResourceRequestSchema(ctx, req)
+}
+
+// normalizeSchemaFeatures 归一化字段特征里的自引用 ref_property。
+//
+// ref_property 的语义是「特征挂在 A 属性上、但作用于 B 字段」，指向字段自身是一个
+// 无意义的冗余写法：能力派生本来就在 ref_property 为空时落回属性自身（见 bkn-backend
+// 的 VegaResourceIndexCaps），两种写法结果完全相同。
+//
+// 但历史上平台自己写入的存量资源正是这个形状，因此这里必须就地抹平而不是报错——
+// 一旦报错，存量资源的任何读改写（vega dataset build 就是）都会失败，索引再也重建不了。
+func normalizeSchemaFeatures(props []*interfaces.Property) {
+	for _, prop := range props {
+		if prop == nil {
+			continue
+		}
+		for i := range prop.Features {
+			if prop.Features[i].RefProperty == prop.Name {
+				prop.Features[i].RefProperty = ""
+			}
+		}
+	}
 }
 
 func validateResourceRequestBase(ctx context.Context, req *interfaces.ResourceRequest) error {
@@ -166,11 +189,6 @@ func validatePropertyFeatures(ctx context.Context, prop *interfaces.Property, pr
 				return rest.NewHTTPError(ctx, http.StatusBadRequest, verrors.VegaBackend_Dataset_InvalidParameter_FieldFeatureRef).
 					WithErrorDetails("ref_property is only supported by original resources")
 			}
-			if f.RefProperty == prop.Name {
-				return rest.NewHTTPError(ctx, http.StatusBadRequest, verrors.VegaBackend_Dataset_InvalidParameter_FieldFeatureRef).
-					WithErrorDetails(fmt.Sprintf("The field feature ref_property '%s' cannot reference itself", f.RefProperty))
-			}
-
 			refProp, exists := propsMap[f.RefProperty]
 			if !exists {
 				return rest.NewHTTPError(ctx, http.StatusBadRequest, verrors.VegaBackend_Dataset_InvalidParameter_FieldFeatureRef).

--- a/adp/vega/vega-backend/server/driveradapters/validate_test.go
+++ b/adp/vega/vega-backend/server/driveradapters/validate_test.go
@@ -368,15 +368,47 @@ func TestValidateResourceRequestDatasetSchema(t *testing.T) {
 		}
 	})
 
-	t.Run("validateSchemaProperties rejects self-referencing ref_property", func(t *testing.T) {
-		err := validateSchemaProperties(ctx, []*interfaces.Property{
+	t.Run("normalizeSchemaFeatures drops self-referencing ref_property", func(t *testing.T) {
+		props := []*interfaces.Property{
 			{Name: "body", Type: interfaces.DataType_Text, Features: []interfaces.PropertyFeature{
 				{FeatureName: "body.ft", FeatureType: interfaces.PropertyFeatureType_Fulltext, RefProperty: "body", IsNative: true},
 			}},
-		}, true)
+		}
 
-		require.Error(t, err)
-		assert.ErrorContains(t, err, "cannot reference itself")
+		normalizeSchemaFeatures(props)
+
+		assert.Empty(t, props[0].Features[0].RefProperty)
+		require.NoError(t, validateSchemaProperties(ctx, props, true))
+	})
+
+	t.Run("normalizeSchemaFeatures keeps ref_property pointing at another field", func(t *testing.T) {
+		props := []*interfaces.Property{
+			{Name: "title_keyword", Type: interfaces.DataType_String},
+			{Name: "title", Type: interfaces.DataType_Text, Features: []interfaces.PropertyFeature{
+				{FeatureName: "title.keyword", FeatureType: interfaces.PropertyFeatureType_Keyword, RefProperty: "title_keyword"},
+			}},
+		}
+
+		normalizeSchemaFeatures(props)
+
+		assert.Equal(t, "title_keyword", props[1].Features[0].RefProperty)
+	})
+
+	// 迁移前平台自己写入的形状就是「特征挂在源字段上、ref_property 指向字段自身」。
+	// 这类存量资源必须仍然能被读改写，否则 vega dataset build 无法重建索引。
+	t.Run("ValidateResourceRequest accepts legacy self-referencing feature", func(t *testing.T) {
+		req := &interfaces.ResourceRequest{
+			Name:     "legacy",
+			Category: interfaces.ResourceCategoryTable,
+			SchemaDefinition: []*interfaces.Property{
+				{Name: "title", Type: interfaces.DataType_Text, Features: []interfaces.PropertyFeature{
+					{FeatureName: "title_fulltext", FeatureType: interfaces.PropertyFeatureType_Fulltext, RefProperty: "title"},
+				}},
+			},
+		}
+
+		require.NoError(t, ValidateResourceRequest(ctx, req))
+		assert.Empty(t, req.SchemaDefinition[0].Features[0].RefProperty)
 	})
 
 	t.Run("validateSchemaProperties accepts valid original resource fields", func(t *testing.T) {

--- a/adp/vega/vega-backend/server/driveradapters/validate_test.go
+++ b/adp/vega/vega-backend/server/driveradapters/validate_test.go
@@ -256,10 +256,9 @@ func TestValidateResourceRequestDatasetSchema(t *testing.T) {
 		require.Error(t, err)
 	})
 
-	// 归一化排在类目校验之前，所以 dataset 请求里的自引用不再撞上「ref_property 只有
-	// original 资源支持」。这是有意放宽：存量 dataset 也可能是自引用形状，静默抹平比
-	// 让它连更新都做不了更可取；指向别的字段仍然是 400（见上一条用例）。
-	t.Run("ValidateResourceRequest normalizes a dataset self-referencing feature", func(t *testing.T) {
+	// dataset 的 ref_property 在 #837 之前就是 400，归一化只对原始资源生效，不能顺手把
+	// 这条也放宽——那属于本次回归之外的行为变更。
+	t.Run("ValidateResourceRequest still rejects a dataset self-referencing feature", func(t *testing.T) {
 		req := baseReq([]*interfaces.Property{
 			{
 				Name: "content",
@@ -270,8 +269,10 @@ func TestValidateResourceRequestDatasetSchema(t *testing.T) {
 			},
 		})
 
-		require.NoError(t, ValidateResourceRequest(ctx, req))
-		assert.Empty(t, req.SchemaDefinition[0].Features[0].RefProperty)
+		err := ValidateResourceRequest(ctx, req)
+
+		require.Error(t, err)
+		assert.Equal(t, "content", req.SchemaDefinition[0].Features[0].RefProperty)
 	})
 
 	t.Run("ValidateResourceRequest rejects invalid table feature", func(t *testing.T) {

--- a/adp/vega/vega-backend/server/driveradapters/validate_test.go
+++ b/adp/vega/vega-backend/server/driveradapters/validate_test.go
@@ -16,6 +16,7 @@ import (
 
 	verrors "vega-backend/errors"
 	"vega-backend/interfaces"
+	resourcelogic "vega-backend/logics/resource"
 )
 
 var testSortTypes = map[string]string{
@@ -255,6 +256,24 @@ func TestValidateResourceRequestDatasetSchema(t *testing.T) {
 		require.Error(t, err)
 	})
 
+	// 归一化排在类目校验之前，所以 dataset 请求里的自引用不再撞上「ref_property 只有
+	// original 资源支持」。这是有意放宽：存量 dataset 也可能是自引用形状，静默抹平比
+	// 让它连更新都做不了更可取；指向别的字段仍然是 400（见上一条用例）。
+	t.Run("ValidateResourceRequest normalizes a dataset self-referencing feature", func(t *testing.T) {
+		req := baseReq([]*interfaces.Property{
+			{
+				Name: "content",
+				Type: interfaces.DataType_Text,
+				Features: []interfaces.PropertyFeature{
+					{FeatureName: "content_fulltext", FeatureType: interfaces.PropertyFeatureType_Fulltext, RefProperty: "content"},
+				},
+			},
+		})
+
+		require.NoError(t, ValidateResourceRequest(ctx, req))
+		assert.Empty(t, req.SchemaDefinition[0].Features[0].RefProperty)
+	})
+
 	t.Run("ValidateResourceRequest rejects invalid table feature", func(t *testing.T) {
 		err := ValidateResourceRequest(ctx, &interfaces.ResourceRequest{
 			Name:     "table",
@@ -368,20 +387,20 @@ func TestValidateResourceRequestDatasetSchema(t *testing.T) {
 		}
 	})
 
-	t.Run("normalizeSchemaFeatures drops self-referencing ref_property", func(t *testing.T) {
+	t.Run("NormalizeSelfReferencingFeatures drops self-referencing ref_property", func(t *testing.T) {
 		props := []*interfaces.Property{
 			{Name: "body", Type: interfaces.DataType_Text, Features: []interfaces.PropertyFeature{
 				{FeatureName: "body.ft", FeatureType: interfaces.PropertyFeatureType_Fulltext, RefProperty: "body", IsNative: true},
 			}},
 		}
 
-		normalizeSchemaFeatures(props)
+		resourcelogic.NormalizeSelfReferencingFeatures(props)
 
 		assert.Empty(t, props[0].Features[0].RefProperty)
 		require.NoError(t, validateSchemaProperties(ctx, props, true))
 	})
 
-	t.Run("normalizeSchemaFeatures keeps ref_property pointing at another field", func(t *testing.T) {
+	t.Run("NormalizeSelfReferencingFeatures keeps ref_property pointing at another field", func(t *testing.T) {
 		props := []*interfaces.Property{
 			{Name: "title_keyword", Type: interfaces.DataType_String},
 			{Name: "title", Type: interfaces.DataType_Text, Features: []interfaces.PropertyFeature{
@@ -389,7 +408,7 @@ func TestValidateResourceRequestDatasetSchema(t *testing.T) {
 			}},
 		}
 
-		normalizeSchemaFeatures(props)
+		resourcelogic.NormalizeSelfReferencingFeatures(props)
 
 		assert.Equal(t, "title_keyword", props[1].Features[0].RefProperty)
 	})

--- a/adp/vega/vega-backend/server/logics/resource/feature.go
+++ b/adp/vega/vega-backend/server/logics/resource/feature.go
@@ -26,6 +26,29 @@ func IsFeatureSupported(propertyType string, featureType string) bool {
 	}
 }
 
+// NormalizeSelfReferencingFeatures 抹平字段特征里指向属性自身的 ref_property。
+//
+// ref_property 的语义是「特征挂在 A 属性上、但作用于 B 字段」，指向字段自身是无意义的
+// 冗余写法：能力派生在 ref_property 为空时本来就落回属性自身（见 bkn-backend 的
+// VegaResourceIndexCaps），两种写法同解。
+//
+// 历史上平台自己写入的存量资源正是这个形状，因此必须就地抹平而不是报错。抹平要同时作用在
+// 请求侧与库里读出来的 schema 上：只归一化一侧的话，两侧 Features 不再 DeepEqual，
+// 资源更新会被 validateMutableSchemaUpdate 判成 build 相关变更，进而清空 LocalIndexName，
+// 让一次普通编辑把已建好的索引废掉。
+func NormalizeSelfReferencingFeatures(props []*interfaces.Property) {
+	for _, prop := range props {
+		if prop == nil {
+			continue
+		}
+		for i := range prop.Features {
+			if prop.Features[i].RefProperty == prop.Name {
+				prop.Features[i].RefProperty = ""
+			}
+		}
+	}
+}
+
 // IsFeatureRefPropertyTypeSupported reports whether a referenced result Property
 // has the type produced by a Feature.
 func IsFeatureRefPropertyTypeSupported(propertyType string, featureType string) bool {

--- a/adp/vega/vega-backend/server/logics/resource/feature_test.go
+++ b/adp/vega/vega-backend/server/logics/resource/feature_test.go
@@ -7,9 +7,11 @@
 package resource
 
 import (
+	"context"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"vega-backend/interfaces"
 )
@@ -43,4 +45,88 @@ func TestIsFeatureRefPropertyTypeSupported(t *testing.T) {
 	assert.True(t, IsFeatureRefPropertyTypeSupported(interfaces.DataType_Text, interfaces.PropertyFeatureType_Fulltext))
 	assert.True(t, IsFeatureRefPropertyTypeSupported(interfaces.DataType_Vector, interfaces.PropertyFeatureType_Vector))
 	assert.False(t, IsFeatureRefPropertyTypeSupported(interfaces.DataType_Text, interfaces.PropertyFeatureType_Keyword))
+}
+
+func TestNormalizeSelfReferencingFeatures(t *testing.T) {
+	t.Run("drops ref_property pointing at the owning property", func(t *testing.T) {
+		props := []*interfaces.Property{
+			{Name: "title", Type: interfaces.DataType_Text, Features: []interfaces.PropertyFeature{
+				{FeatureName: "title_fulltext", FeatureType: interfaces.PropertyFeatureType_Fulltext, RefProperty: "title"},
+			}},
+		}
+
+		NormalizeSelfReferencingFeatures(props)
+
+		assert.Empty(t, props[0].Features[0].RefProperty)
+	})
+
+	t.Run("keeps ref_property pointing at another property", func(t *testing.T) {
+		props := []*interfaces.Property{
+			{Name: "title_keyword", Type: interfaces.DataType_String},
+			{Name: "title", Type: interfaces.DataType_Text, Features: []interfaces.PropertyFeature{
+				{FeatureName: "title.keyword", FeatureType: interfaces.PropertyFeatureType_Keyword, RefProperty: "title_keyword"},
+			}},
+		}
+
+		NormalizeSelfReferencingFeatures(props)
+
+		assert.Equal(t, "title_keyword", props[1].Features[0].RefProperty)
+	})
+
+	t.Run("tolerates nil properties", func(t *testing.T) {
+		assert.NotPanics(t, func() { NormalizeSelfReferencingFeatures([]*interfaces.Property{nil}) })
+	})
+}
+
+// 存量资源带自引用特征、请求侧已在入口抹平：两边都归一化之后，一次没动 schema 的编辑
+// 必须判定为「无 build 相关变更」，否则 resource_service 会清空 LocalIndexName，
+// 让这次普通编辑把已建好的索引废掉。
+func TestValidateMutableSchemaUpdateIgnoresNormalizedSelfReference(t *testing.T) {
+	ctx := context.Background()
+	legacyStored := func() []*interfaces.Property {
+		return []*interfaces.Property{
+			{Name: "title", Type: interfaces.DataType_Text, Features: []interfaces.PropertyFeature{
+				{FeatureName: "title_fulltext", FeatureType: interfaces.PropertyFeatureType_Fulltext, RefProperty: "title"},
+			}},
+		}
+	}
+
+	t.Run("unchanged schema is not a build relevant change", func(t *testing.T) {
+		current := legacyStored()
+		requested := legacyStored()
+		NormalizeSelfReferencingFeatures(current)
+		NormalizeSelfReferencingFeatures(requested)
+
+		changed, err := validateMutableSchemaUpdate(ctx, current, requested, false)
+
+		require.NoError(t, err)
+		assert.False(t, changed)
+	})
+
+	t.Run("normalizing only one side would look like a feature change", func(t *testing.T) {
+		current := legacyStored()
+		requested := legacyStored()
+		NormalizeSelfReferencingFeatures(requested)
+
+		changed, err := validateMutableSchemaUpdate(ctx, current, requested, false)
+
+		require.NoError(t, err)
+		assert.True(t, changed, "guards the regression: a one-sided normalization clears LocalIndexName")
+	})
+
+	t.Run("a real feature change is still detected", func(t *testing.T) {
+		current := legacyStored()
+		NormalizeSelfReferencingFeatures(current)
+		requested := []*interfaces.Property{
+			{Name: "title", Type: interfaces.DataType_Text, Features: []interfaces.PropertyFeature{
+				{FeatureName: "title_fulltext", FeatureType: interfaces.PropertyFeatureType_Fulltext},
+				{FeatureName: "title_vector", FeatureType: interfaces.PropertyFeatureType_Vector},
+			}},
+		}
+
+		changed, err := validateMutableSchemaUpdate(ctx, current, requested, false)
+
+		require.NoError(t, err)
+		assert.True(t, changed)
+	})
 }

--- a/adp/vega/vega-backend/server/logics/resource/resource_service.go
+++ b/adp/vega/vega-backend/server/logics/resource/resource_service.go
@@ -1281,6 +1281,9 @@ func (rs *resourceService) validateResourceUpdateScope(ctx context.Context, reso
 	if req.SchemaDefinition == nil {
 		return indexConfigChanged, nil
 	}
+	// 库里的存量 schema 可能带自引用 ref_property（迁移前平台自己写的形状），请求侧已在
+	// 入口抹平。两侧都归一化后再比，否则一次没改 schema 的普通编辑会被判成 build 相关变更。
+	NormalizeSelfReferencingFeatures(resource.SchemaDefinition)
 	schemaChanged, err := validateMutableSchemaUpdate(
 		ctx,
 		resource.SchemaDefinition,

--- a/adp/vega/vega-backend/server/worker/build_task_common.go
+++ b/adp/vega/vega-backend/server/worker/build_task_common.go
@@ -170,6 +170,11 @@ func buildLocalIndexSchema(buildTask *interfaces.BuildTask, resource *interfaces
 }
 
 func validateBuildTaskSchemaFeatures(resourceCategory string, schema []*interfaces.Property) error {
+	// 从没被 PUT 过的存量资源，库里仍是自引用形状。不抹平的话：dataset 类目会撞上「不许带
+	// ref_property」，text 字段上的 keyword 自引用还会撞上 ref 类型校验（keyword 要求
+	// string），构建任务直接建不起来——正是这个 PR 要解的「索引重建不了」。
+	resourcelogic.NormalizeSelfReferencingFeatures(schema)
+
 	propsMap := make(map[string]*interfaces.Property, len(schema))
 	for _, prop := range schema {
 		if prop != nil {

--- a/adp/vega/vega-backend/server/worker/build_task_common.go
+++ b/adp/vega/vega-backend/server/worker/build_task_common.go
@@ -157,6 +157,12 @@ func buildLocalIndexSchema(buildTask *interfaces.BuildTask, resource *interfaces
 		schema = schemaDefinition
 	}
 
+	// 从没被 PUT 过的存量资源，库里仍是自引用形状。不抹平的话：dataset 类目会撞上「不许带
+	// ref_property」，text 字段上的 keyword 自引用还会撞上 ref 类型校验（keyword 要求
+	// string），构建任务直接建不起来——正是这个 PR 要解的「索引重建不了」。
+	// 只作用在上面那份深拷贝上，资源行本身不动，等下一次更新自愈。
+	resourcelogic.NormalizeSelfReferencingFeatures(schema)
+
 	if err := validateBuildTaskSchemaFeatures(resource.Category, schema); err != nil {
 		return nil, err
 	}
@@ -170,11 +176,6 @@ func buildLocalIndexSchema(buildTask *interfaces.BuildTask, resource *interfaces
 }
 
 func validateBuildTaskSchemaFeatures(resourceCategory string, schema []*interfaces.Property) error {
-	// 从没被 PUT 过的存量资源，库里仍是自引用形状。不抹平的话：dataset 类目会撞上「不许带
-	// ref_property」，text 字段上的 keyword 自引用还会撞上 ref 类型校验（keyword 要求
-	// string），构建任务直接建不起来——正是这个 PR 要解的「索引重建不了」。
-	resourcelogic.NormalizeSelfReferencingFeatures(schema)
-
 	propsMap := make(map[string]*interfaces.Property, len(schema))
 	for _, prop := range schema {
 		if prop != nil {

--- a/adp/vega/vega-backend/server/worker/build_worker_batch_test.go
+++ b/adp/vega/vega-backend/server/worker/build_worker_batch_test.go
@@ -347,6 +347,8 @@ func TestValidateBuildTaskSchemaFeatures(t *testing.T) {
 			}},
 		},
 		{
+			// 入口严、存量宽：写入侧对 dataset 的 ref_property 仍然 400（#837 之前就是），
+			// 但库里若已有这种行（迁移或直接写库留下的），构建不该因此建不起来
 			name:     "accepts legacy self-referencing feature on a dataset",
 			category: interfaces.ResourceCategoryDataset,
 			schema: []*interfaces.Property{{

--- a/adp/vega/vega-backend/server/worker/build_worker_batch_test.go
+++ b/adp/vega/vega-backend/server/worker/build_worker_batch_test.go
@@ -319,11 +319,40 @@ func TestValidateBuildTaskSchemaFeatures(t *testing.T) {
 		{
 			name:     "dataset rejects ref property",
 			category: interfaces.ResourceCategoryDataset,
+			schema: []*interfaces.Property{
+				{Name: "content_keyword", Type: interfaces.DataType_String},
+				{Name: "content", Type: interfaces.DataType_Text,
+					Features: []interfaces.PropertyFeature{{FeatureType: interfaces.PropertyFeatureType_Keyword, RefProperty: "content_keyword"}}},
+			},
+			wantErr: "must not set ref_property",
+		},
+		// 从没被 PUT 过的存量资源，库里仍是自引用形状。抹平之后必须能建索引，否则
+		// 「push 清掉 condition_operations -> 重建索引 -> 恢复」这条路仍然是断的。
+		{
+			name:     "accepts legacy self-referencing fulltext feature",
+			category: interfaces.ResourceCategoryTable,
+			schema: []*interfaces.Property{{
+				Name: "title", Type: interfaces.DataType_Text,
+				Features: []interfaces.PropertyFeature{{FeatureName: "title_fulltext", FeatureType: interfaces.PropertyFeatureType_Fulltext, RefProperty: "title"}},
+			}},
+		},
+		{
+			// keyword 的 ref 类型要求是 string，text 字段上的自引用 keyword 特征
+			// 在抹平前会撞上 ref 类型校验，抹平后按「特征作用于属性自身」通过
+			name:     "accepts legacy self-referencing keyword feature on a text field",
+			category: interfaces.ResourceCategoryTable,
+			schema: []*interfaces.Property{{
+				Name: "title", Type: interfaces.DataType_Text,
+				Features: []interfaces.PropertyFeature{{FeatureName: "title.keyword", FeatureType: interfaces.PropertyFeatureType_Keyword, RefProperty: "title"}},
+			}},
+		},
+		{
+			name:     "accepts legacy self-referencing feature on a dataset",
+			category: interfaces.ResourceCategoryDataset,
 			schema: []*interfaces.Property{{
 				Name: "content", Type: interfaces.DataType_Text,
-				Features: []interfaces.PropertyFeature{{FeatureType: interfaces.PropertyFeatureType_Keyword, RefProperty: "content"}},
+				Features: []interfaces.PropertyFeature{{FeatureType: interfaces.PropertyFeatureType_Fulltext, RefProperty: "content"}},
 			}},
-			wantErr: "must not set ref_property",
 		},
 		{
 			name:     "rejects feature unsupported by property type",

--- a/adp/vega/vega-backend/server/worker/build_worker_batch_test.go
+++ b/adp/vega/vega-backend/server/worker/build_worker_batch_test.go
@@ -326,36 +326,6 @@ func TestValidateBuildTaskSchemaFeatures(t *testing.T) {
 			},
 			wantErr: "must not set ref_property",
 		},
-		// 从没被 PUT 过的存量资源，库里仍是自引用形状。抹平之后必须能建索引，否则
-		// 「push 清掉 condition_operations -> 重建索引 -> 恢复」这条路仍然是断的。
-		{
-			name:     "accepts legacy self-referencing fulltext feature",
-			category: interfaces.ResourceCategoryTable,
-			schema: []*interfaces.Property{{
-				Name: "title", Type: interfaces.DataType_Text,
-				Features: []interfaces.PropertyFeature{{FeatureName: "title_fulltext", FeatureType: interfaces.PropertyFeatureType_Fulltext, RefProperty: "title"}},
-			}},
-		},
-		{
-			// keyword 的 ref 类型要求是 string，text 字段上的自引用 keyword 特征
-			// 在抹平前会撞上 ref 类型校验，抹平后按「特征作用于属性自身」通过
-			name:     "accepts legacy self-referencing keyword feature on a text field",
-			category: interfaces.ResourceCategoryTable,
-			schema: []*interfaces.Property{{
-				Name: "title", Type: interfaces.DataType_Text,
-				Features: []interfaces.PropertyFeature{{FeatureName: "title.keyword", FeatureType: interfaces.PropertyFeatureType_Keyword, RefProperty: "title"}},
-			}},
-		},
-		{
-			// 入口严、存量宽：写入侧对 dataset 的 ref_property 仍然 400（#837 之前就是），
-			// 但库里若已有这种行（迁移或直接写库留下的），构建不该因此建不起来
-			name:     "accepts legacy self-referencing feature on a dataset",
-			category: interfaces.ResourceCategoryDataset,
-			schema: []*interfaces.Property{{
-				Name: "content", Type: interfaces.DataType_Text,
-				Features: []interfaces.PropertyFeature{{FeatureType: interfaces.PropertyFeatureType_Fulltext, RefProperty: "content"}},
-			}},
-		},
 		{
 			name:     "rejects feature unsupported by property type",
 			category: interfaces.ResourceCategoryTable,
@@ -491,4 +461,73 @@ func TestBuildLocalIndexSchemaAppliesTaskIndexConfigWithoutMutatingResourceSchem
 func workerAccountFromCtx(ctx context.Context) (interfaces.AccountInfo, bool) {
 	ai, ok := ctx.Value(interfaces.ACCOUNT_INFO_KEY).(interfaces.AccountInfo)
 	return ai, ok
+}
+
+// 从没被 PUT 过的存量资源，库里仍是自引用形状。构建入口抹平之后必须能建索引，否则
+// 「push 清掉 condition_operations -> 重建索引 -> 恢复」这条路仍然是断的。
+func TestBuildLocalIndexSchemaNormalizesLegacySelfReference(t *testing.T) {
+	// schema 里的 fulltext 特征必须同时在构建任务的 index config 里声明，与自引用无关
+	fulltextTask := func(field string) *interfaces.BuildTask {
+		return &interfaces.BuildTask{
+			ID: "t1",
+			IndexConfig: &interfaces.BuildTaskIndexConfig{
+				Features: map[string]interfaces.BuildTaskFieldIndexFeature{
+					field: {Fulltext: &interfaces.BuildTaskFulltextConfig{Analyzer: "ik_max_word"}},
+				},
+			},
+		}
+	}
+
+	tests := []struct {
+		name     string
+		category string
+		task     *interfaces.BuildTask
+		props    []*interfaces.Property
+	}{
+		{
+			name:     "fulltext feature referencing its own text field",
+			category: interfaces.ResourceCategoryTable,
+			task:     fulltextTask("title"),
+			props: []*interfaces.Property{{
+				Name: "title", Type: interfaces.DataType_Text,
+				Features: []interfaces.PropertyFeature{{FeatureName: "title_fulltext", FeatureType: interfaces.PropertyFeatureType_Fulltext, RefProperty: "title"}},
+			}},
+		},
+		{
+			// keyword 的 ref 类型要求是 string，text 字段上的自引用 keyword 特征
+			// 在抹平前会撞上 ref 类型校验，抹平后按「特征作用于属性自身」通过
+			name:     "keyword feature referencing its own text field",
+			category: interfaces.ResourceCategoryTable,
+			task:     &interfaces.BuildTask{ID: "t1"},
+			props: []*interfaces.Property{{
+				Name: "title", Type: interfaces.DataType_Text,
+				Features: []interfaces.PropertyFeature{{FeatureName: "title.keyword", FeatureType: interfaces.PropertyFeatureType_Keyword, RefProperty: "title"}},
+			}},
+		},
+		{
+			// 入口严、存量宽：写入侧对 dataset 的 ref_property 仍然 400（#837 之前就是），
+			// 但库里若已有这种行（迁移或直接写库留下的），构建不该因此建不起来
+			name:     "any self-reference on a dataset",
+			category: interfaces.ResourceCategoryDataset,
+			task:     fulltextTask("content"),
+			props: []*interfaces.Property{{
+				Name: "content", Type: interfaces.DataType_Text,
+				Features: []interfaces.PropertyFeature{{FeatureName: "content_fulltext", FeatureType: interfaces.PropertyFeatureType_Fulltext, RefProperty: "content"}},
+			}},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			res := &interfaces.Resource{Category: tt.category, SchemaDefinition: tt.props}
+
+			schema, err := buildLocalIndexSchema(tt.task, res)
+
+			require.NoError(t, err)
+			require.Len(t, schema, 1)
+			assert.Empty(t, schema[0].Features[0].RefProperty)
+			// 只动深拷贝，资源行留给下一次更新自愈
+			assert.Equal(t, tt.props[0].Name, res.SchemaDefinition[0].Features[0].RefProperty)
+		})
+	}
 }


### PR DESCRIPTION
## Problem

#837 made `ref_property` pointing at its own field a hard 400
(`VegaBackend.Dataset.InvalidParameter.FieldFeatureRef`, *"cannot reference itself"*).

That shape is exactly what the platform used to persist itself:

```json
{"field": "title",
 "features": [{"name": "title_fulltext", "feature_type": "fulltext", "ref_property": "title"}]}
```

So after the 0.1.4 rollout every read-modify-write of an existing resource
started failing, `vega dataset build` included. A knowledge network that had
already been pushed ends up deadlocked: `bkn push` drops `match`/`knn` from
`condition_operations`, recovering needs an index rebuild, and the rebuild is
now rejected. Semantic retrieval cannot be restored through the CLI at all.

Reported from a customer POC blocked on exactly this.

## Fix

Self-reference is a redundant no-op — capability derivation already falls back
to the owning property when `ref_property` is empty
(`VegaResourceIndexCaps` in bkn-backend), so `ref_property: "title"` on field
`title` and no `ref_property` resolve identically.

`ValidateResourceRequest` now strips the self-reference before validation
instead of failing the request. Legacy rows heal on their next write, so no
data migration is required.

Cross-field `ref_property` validation (missing target, type mismatch,
dataset-category rejection) is unchanged.

## Tests

- `normalizeSchemaFeatures` drops self-references, keeps cross-field ones
- `ValidateResourceRequest` accepts a legacy self-referencing resource and
  returns it normalized
- the #837 assertion that required the 400 is replaced

`go vet` + `go test ./driveradapters/ ./logics/resource/... ./worker/...` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)