### PR TITLE
fix(vega): quote MariaDB identifiers in SELECT, FROM, GROUP BY and ORDER BY

### DIFF
--- a/adp/vega/vega-backend/server/logics/connector/local/table/mariadb/mariadb_condition.go
+++ b/adp/vega/vega-backend/server/logics/connector/local/table/mariadb/mariadb_condition.go
@@ -133,6 +133,11 @@ func quoteColumnName(name string) string {
 	return "`" + strings.ReplaceAll(strings.TrimSpace(name), "`", "``") + "`"
 }
 
+// qualTable 将资源的源端标识转为反引号限定的表名；支持 "db.table" -> "`db`.`table`"
+func qualTable(sourceIdentifier string) string {
+	return quoteColumnName(sourceIdentifier)
+}
+
 func (c *MariaDBConnector) ConvertFilterCondition(ctx context.Context, condition interfaces.FilterCondition,
 	fieldsMap map[string]*interfaces.Property) (sq.Sqlizer, error) {
 

--- a/adp/vega/vega-backend/server/logics/connector/local/table/mariadb/mariadb_query.go
+++ b/adp/vega/vega-backend/server/logics/connector/local/table/mariadb/mariadb_query.go
@@ -236,8 +236,16 @@ func (c *MariaDBConnector) buildSelectBuilder(resource *interfaces.Resource,
 			dir = "DESC"
 		}
 
-		// Check whether this is a GROUP BY field using calendar_interval
+		// Resolve the sort field against the SELECT aliases first: when an alias matches a
+		// property name the caller means the aggregate, but schema resolution would pick
+		// that property's source column instead. The default sql_mode has no
+		// ONLY_FULL_GROUP_BY, so that does not error — it orders by an arbitrary row.
 		sortField := quoteColumnName(originalName(sortItem.Field))
+		if aggAlias != "" && sortItem.Field == aggAlias {
+			sortField = quoteColumnName(aggAlias)
+		}
+
+		// Check whether this is a GROUP BY field using calendar_interval
 		for _, groupByItem := range params.GroupBy {
 			if groupByItem.Property == sortItem.Field && groupByItem.CalendarInterval != "" {
 				// Use the full date_format expression

--- a/adp/vega/vega-backend/server/logics/connector/local/table/mariadb/mariadb_query.go
+++ b/adp/vega/vega-backend/server/logics/connector/local/table/mariadb/mariadb_query.go
@@ -101,6 +101,159 @@ func (c *MariaDBConnector) ExecuteRawSQL(ctx context.Context, sql string) (*inte
 	return response, nil
 }
 
+// buildSelectBuilder assembles the SELECT statement for detail and aggregate queries.
+//
+// Every identifier — table, column, alias — must go through quoteColumnName / qualTable.
+// A source column named after a SQL reserved word (say `key`) survives DDL, catalog
+// discover and bkn push untouched, because none of them build a query; concatenating it
+// raw only fails at execution time with a 1064 that names nothing useful.
+func (c *MariaDBConnector) buildSelectBuilder(resource *interfaces.Resource,
+	params *interfaces.ResourceDataQueryParams, fieldMap map[string]*interfaces.Property,
+	condition sq.Sqlizer) (sq.SelectBuilder, error) {
+
+	// Source column name; fall back to the property name when the schema has no mapping.
+	originalName := func(property string) string {
+		if field, ok := fieldMap[property]; ok {
+			return field.OriginalName
+		}
+		return property
+	}
+
+	// Construct the SELECT clause
+	selectFields := []string{}
+	// Output names already selected (column or alias), used to de-duplicate output_fields
+	selected := map[string]struct{}{}
+
+	// Add the GROUP BY field (when aggregating queries)
+	for _, groupByItem := range params.GroupBy {
+		column := originalName(groupByItem.Property)
+		// Check whether calendar_interval is needed
+		if groupByItem.CalendarInterval != "" {
+			dateFmt := c.buildDateFormat(groupByItem.Property, quoteColumnName(column), groupByItem.CalendarInterval)
+			selectFields = append(selectFields, dateFmt+" AS "+quoteColumnName(groupByItem.Property))
+			selected[groupByItem.Property] = struct{}{}
+		} else {
+			selectFields = append(selectFields, quoteColumnName(column))
+			selected[groupByItem.Property] = struct{}{}
+		}
+	}
+
+	// Add the aggregate field (when aggregating queries)
+	var aggAlias string
+	if params.Aggregation != nil {
+		aggField := quoteColumnName(originalName(params.Aggregation.Property))
+
+		// Determine the aggregate function
+		aggFunc := params.Aggregation.Aggr
+		switch aggFunc {
+		case "count_distinct":
+			aggFunc = "COUNT(DISTINCT " + aggField + ")"
+		default:
+			aggFunc = strings.ToUpper(aggFunc) + "(" + aggField + ")"
+		}
+
+		// Determine the alias
+		if params.Aggregation.Alias != "" {
+			aggAlias = params.Aggregation.Alias
+		} else {
+			aggAlias = "__value"
+		}
+
+		selectFields = append(selectFields, aggFunc+" AS "+quoteColumnName(aggAlias))
+		selected[aggAlias] = struct{}{}
+	} else if params.Having != nil && params.Having.Field == "count(*)" {
+		// When HAVING uses count(*), add the COUNT(*) aggregate automatically
+		aggAlias = "__value"
+		selectFields = append(selectFields, "COUNT(*) AS "+quoteColumnName(aggAlias))
+		selected[aggAlias] = struct{}{}
+	}
+
+	// Select every field when the query is neither aggregated nor grouped
+	if len(params.GroupBy) == 0 && params.Aggregation == nil {
+		if len(params.OutputFields) > 0 {
+			for _, outName := range params.OutputFields {
+				selectFields = append(selectFields, quoteColumnName(originalName(outName)))
+			}
+		} else if len(selectFields) == 0 {
+			// No output fields specified, so query them all
+			for _, prop := range resource.SchemaDefinition {
+				selectFields = append(selectFields, quoteColumnName(prop.OriginalName))
+			}
+		}
+	} else if len(params.OutputFields) > 0 {
+		// For aggregate or GROUP BY queries, make sure output_fields end up in selectFields
+		for _, outName := range params.OutputFields {
+			if _, found := selected[outName]; found {
+				continue
+			}
+			selectFields = append(selectFields, quoteColumnName(originalName(outName)))
+			selected[outName] = struct{}{}
+		}
+	}
+
+	// Build the query
+	builder := sq.Select(selectFields...).From(qualTable(resource.SourceIdentifier))
+
+	// Add the WHERE condition
+	if condition != nil {
+		builder = builder.Where(condition)
+	}
+
+	// Add GROUP BY (when aggregating queries)
+	if len(params.GroupBy) > 0 {
+		groupByFields := []string{}
+		for _, groupByItem := range params.GroupBy {
+			column := quoteColumnName(originalName(groupByItem.Property))
+			// Check whether calendar_interval is needed
+			if groupByItem.CalendarInterval != "" {
+				groupByFields = append(groupByFields,
+					c.buildDateFormat(groupByItem.Property, column, groupByItem.CalendarInterval))
+			} else {
+				groupByFields = append(groupByFields, column)
+			}
+		}
+		builder = builder.GroupBy(groupByFields...)
+	}
+
+	// Add the HAVING condition (when aggregating queries)
+	if params.Having != nil && (params.Aggregation != nil || (params.Having.Field == "count(*)")) {
+		havingCond, err := c.buildHavingCondition(params.Having, aggAlias)
+		if err != nil {
+			return builder, fmt.Errorf("failed to build HAVING condition: %w", err)
+		}
+		if havingCond != "" {
+			builder = builder.Having(havingCond)
+		}
+	}
+
+	// Add ORDER BY
+	for _, sortItem := range params.Sort {
+		dir := "ASC"
+		if sortItem.Direction == interfaces.DESC_DIRECTION {
+			dir = "DESC"
+		}
+
+		// Check whether this is a GROUP BY field using calendar_interval
+		sortField := quoteColumnName(originalName(sortItem.Field))
+		for _, groupByItem := range params.GroupBy {
+			if groupByItem.Property == sortItem.Field && groupByItem.CalendarInterval != "" {
+				// Use the full date_format expression
+				sortField = c.buildDateFormat(groupByItem.Property,
+					quoteColumnName(originalName(groupByItem.Property)), groupByItem.CalendarInterval)
+				break
+			}
+		}
+
+		builder = builder.OrderBy(sortField + " " + dir)
+	}
+
+	// Add LIMIT and OFFSET
+	if params.CursorEncoded == "" {
+		builder = builder.Offset(uint64(params.Offset))
+	}
+	return builder.Limit(uint64(params.Limit)), nil
+}
+
 func (c *MariaDBConnector) ExecuteQuery(ctx context.Context, resource *interfaces.Resource,
 	params *interfaces.ResourceDataQueryParams) (*interfaces.QueryResult, error) {
 
@@ -126,175 +279,10 @@ func (c *MariaDBConnector) ExecuteQuery(ctx context.Context, resource *interface
 		Entries: make([]map[string]any, 0),
 	}
 
-	// Construct the SELECT clause
-	selectFields := []string{}
-
-	// Add the GROUP BY field (when aggregating queries)
-	for _, groupByItem := range params.GroupBy {
-		if field, ok := fieldMap[groupByItem.Property]; ok {
-			// Check whether calendar_interval is needed
-			if groupByItem.CalendarInterval != "" {
-				dateFmt := c.buildDateFormat(groupByItem.Property, field.OriginalName, groupByItem.CalendarInterval)
-				selectFields = append(selectFields, dateFmt+" AS "+groupByItem.Property)
-			} else {
-				selectFields = append(selectFields, field.OriginalName)
-			}
-		} else {
-			// Check whether calendar_interval is needed
-			if groupByItem.CalendarInterval != "" {
-				dateFmt := c.buildDateFormat(groupByItem.Property, groupByItem.Property, groupByItem.CalendarInterval)
-				selectFields = append(selectFields, dateFmt+" AS "+groupByItem.Property)
-			} else {
-				selectFields = append(selectFields, groupByItem.Property)
-			}
-		}
+	builder, err := c.buildSelectBuilder(resource, params, fieldMap, condition)
+	if err != nil {
+		return nil, err
 	}
-
-	// Add aggregated fields (when performing aggregated queries)
-	var aggAlias string
-	if params.Aggregation != nil {
-		aggField := params.Aggregation.Property
-		if field, ok := fieldMap[aggField]; ok {
-			aggField = field.OriginalName
-		}
-
-		// Determine the aggregation function
-		aggFunc := params.Aggregation.Aggr
-		switch aggFunc {
-		case "count_distinct":
-			aggFunc = "COUNT(DISTINCT " + aggField + ")"
-		default:
-			aggFunc = strings.ToUpper(aggFunc) + "(" + aggField + ")"
-		}
-
-		// Determine the alias
-		if params.Aggregation.Alias != "" {
-			aggAlias = params.Aggregation.Alias
-		} else {
-			aggAlias = "__value"
-		}
-
-		selectFields = append(selectFields, aggFunc+" AS "+aggAlias)
-	} else if params.Having != nil && params.Having.Field == "count(*)" {
-		// When HAVING uses count(*), COUNT(*) aggregates are automatically added
-		aggAlias = "__value"
-		selectFields = append(selectFields, "COUNT(*) AS "+aggAlias)
-	}
-
-	// If it is not an aggregated query and GROUP BY is not specified, add all fields
-	if len(params.GroupBy) == 0 && params.Aggregation == nil {
-		if len(params.OutputFields) > 0 {
-			for _, outName := range params.OutputFields {
-				if field, ok := fieldMap[outName]; ok {
-					selectFields = append(selectFields, field.OriginalName)
-				} else {
-					// For fields not defined in the Schema, use the field names directly
-					selectFields = append(selectFields, outName)
-				}
-			}
-		} else if len(selectFields) == 0 {
-			// If no output field is specified, all fields will be queried
-			for _, prop := range resource.SchemaDefinition {
-				selectFields = append(selectFields, prop.OriginalName)
-			}
-		}
-	} else if len(params.OutputFields) > 0 {
-		// For aggregated queries or GROUP BY queries, ensure that the fields in output_fields are in selectFields
-		for _, outName := range params.OutputFields {
-			found := false
-			for _, field := range selectFields {
-				// Check whether the field already exists (including aliases)
-				if field == outName || strings.HasSuffix(field, " AS "+outName) {
-					found = true
-					break
-				}
-			}
-			if !found {
-				if field, ok := fieldMap[outName]; ok {
-					selectFields = append(selectFields, field.OriginalName)
-				} else {
-					// For fields not defined in the Schema, use the field names directly
-					selectFields = append(selectFields, outName)
-				}
-			}
-		}
-	}
-
-	// Build query
-	builder := sq.Select(selectFields...).From(resource.SourceIdentifier)
-
-	// Add the WHERE condition
-	if condition != nil {
-		builder = builder.Where(condition)
-	}
-
-	// Add GROUP BY (when aggregating queries)
-	if len(params.GroupBy) > 0 {
-		groupByFields := []string{}
-		for _, groupByItem := range params.GroupBy {
-			if field, ok := fieldMap[groupByItem.Property]; ok {
-				// Check whether calendar_interval is needed
-				if groupByItem.CalendarInterval != "" {
-					dateFmt := c.buildDateFormat(groupByItem.Property, field.OriginalName, groupByItem.CalendarInterval)
-					groupByFields = append(groupByFields, dateFmt)
-				} else {
-					groupByFields = append(groupByFields, field.OriginalName)
-				}
-			} else {
-				// Check whether calendar_interval is needed
-				if groupByItem.CalendarInterval != "" {
-					dateFmt := c.buildDateFormat(groupByItem.Property, groupByItem.Property, groupByItem.CalendarInterval)
-					groupByFields = append(groupByFields, dateFmt)
-				} else {
-					groupByFields = append(groupByFields, groupByItem.Property)
-				}
-			}
-		}
-		builder = builder.GroupBy(groupByFields...)
-	}
-
-	// Add a HAVING condition (when aggregating queries)
-	if params.Having != nil && (params.Aggregation != nil || (params.Having.Field == "count(*)")) {
-		havingCond, err := c.buildHavingCondition(params.Having, aggAlias)
-		if err != nil {
-			return nil, fmt.Errorf("failed to build HAVING condition: %w", err)
-		}
-		if havingCond != "" {
-			builder = builder.Having(havingCond)
-		}
-	}
-
-	// Add ORDER BY
-	if len(params.Sort) > 0 {
-		for _, sortItem := range params.Sort {
-			dir := "ASC"
-			if sortItem.Direction == interfaces.DESC_DIRECTION {
-				dir = "DESC"
-			}
-
-			// Check if it is the GROUP BY field and if calendar_interval is used
-			sortField := sortItem.Field
-			for _, groupByItem := range params.GroupBy {
-				if groupByItem.Property == sortItem.Field && groupByItem.CalendarInterval != "" {
-					// Use the complete date_format expression
-					if field, ok := fieldMap[groupByItem.Property]; ok {
-						sortField = c.buildDateFormat(groupByItem.Property, field.OriginalName, groupByItem.CalendarInterval)
-					} else {
-						sortField = c.buildDateFormat(groupByItem.Property, groupByItem.Property, groupByItem.CalendarInterval)
-					}
-					break
-				}
-			}
-
-			builder = builder.OrderBy(sortField + " " + dir)
-		}
-	}
-
-	// Add LIMIT and OFFSET
-	if params.CursorEncoded == "" {
-		builder = builder.Offset(uint64(params.Offset))
-	}
-	builder = builder.Limit(uint64(params.Limit))
 
 	// Build SQL and execute it
 	query, args, err := builder.ToSql()
@@ -346,7 +334,7 @@ func (c *MariaDBConnector) ExecuteQuery(ctx context.Context, resource *interface
 	// Previously, directly take len(result.Entries) - that is, the number of rows on this page. For tables with more than one page, total is always equal to
 	// LIMIT (The progress bar of the build task shows "20802/1000", which indicates this bug)
 	if params.NeedTotal && !isAggregate {
-		countBuilder := sq.Select("COUNT(1)").From(resource.SourceIdentifier)
+		countBuilder := sq.Select("COUNT(1)").From(qualTable(resource.SourceIdentifier))
 		if condition != nil {
 			countBuilder = countBuilder.Where(condition)
 		}

--- a/adp/vega/vega-backend/server/logics/connector/local/table/mariadb/mariadb_query.go
+++ b/adp/vega/vega-backend/server/logics/connector/local/table/mariadb/mariadb_query.go
@@ -111,9 +111,12 @@ func (c *MariaDBConnector) buildSelectBuilder(resource *interfaces.Resource,
 	params *interfaces.ResourceDataQueryParams, fieldMap map[string]*interfaces.Property,
 	condition sq.Sqlizer) (sq.SelectBuilder, error) {
 
-	// Source column name; fall back to the property name when the schema has no mapping.
+	// Source column name. Fall back to the property name when the schema has no mapping,
+	// and also when the property carries no original_name: build tasks add vector fields
+	// with a Name and no OriginalName (appendTaskEmbeddingVectorFields), and without the
+	// fallback those render as an empty quoted identifier.
 	originalName := func(property string) string {
-		if field, ok := fieldMap[property]; ok {
+		if field, ok := fieldMap[property]; ok && field.OriginalName != "" {
 			return field.OriginalName
 		}
 		return property

--- a/adp/vega/vega-backend/server/logics/connector/local/table/mariadb/mariadb_query.go
+++ b/adp/vega/vega-backend/server/logics/connector/local/table/mariadb/mariadb_query.go
@@ -361,12 +361,14 @@ func (c *MariaDBConnector) buildHavingCondition(having *interfaces.HavingClause,
 		return "", fmt.Errorf("HAVING field must be '__value' or 'count(*)'")
 	}
 
-	// Determine the field expression used in the HAVING clause
+	// Determine the field expression used in the HAVING clause. The alias comes straight
+	// from the request body and is not validated, so a reserved word passes SELECT — which
+	// quotes it — and then fails HAVING with a 1064 unless it is quoted here too.
 	var fieldExpr string
 	if having.Field == "count(*)" {
 		fieldExpr = "COUNT(*)"
 	} else {
-		fieldExpr = aggAlias
+		fieldExpr = quoteColumnName(aggAlias)
 	}
 
 	var op string

--- a/adp/vega/vega-backend/server/logics/connector/local/table/mariadb/mariadb_query.go
+++ b/adp/vega/vega-backend/server/logics/connector/local/table/mariadb/mariadb_query.go
@@ -178,9 +178,11 @@ func (c *MariaDBConnector) buildSelectBuilder(resource *interfaces.Resource,
 				selectFields = append(selectFields, quoteColumnName(originalName(outName)))
 			}
 		} else if len(selectFields) == 0 {
-			// No output fields specified, so query them all
+			// No output fields specified, so query them all. This branch needs the
+			// originalName fallback too, or a property with an empty original_name
+			// renders as an empty identifier and breaks the statement.
 			for _, prop := range resource.SchemaDefinition {
-				selectFields = append(selectFields, quoteColumnName(prop.OriginalName))
+				selectFields = append(selectFields, quoteColumnName(originalName(prop.Name)))
 			}
 		}
 	} else if len(params.OutputFields) > 0 {

--- a/adp/vega/vega-backend/server/logics/connector/local/table/mariadb/mariadb_query_test.go
+++ b/adp/vega/vega-backend/server/logics/connector/local/table/mariadb/mariadb_query_test.go
@@ -181,6 +181,35 @@ func TestBuildSelectBuilderQuotesIdentifiers(t *testing.T) {
 			sql)
 	})
 
+	// 构建任务补出来的向量字段只有 Name 没有 OriginalName，取不到就回落到属性名，
+	// 否则会拼出空标识符 `` 让整条 SQL 报错
+	t.Run("a property without original_name falls back to the property name", func(t *testing.T) {
+		schemaless := &interfaces.Resource{
+			SourceIdentifier: "yanfeng_kb.fact",
+			SchemaDefinition: []*interfaces.Property{
+				{Name: "id", OriginalName: "id", Type: interfaces.DataType_String},
+				{Name: "content_vector", Type: interfaces.DataType_Vector},
+			},
+		}
+		schemalessFields := map[string]*interfaces.Property{}
+		for _, prop := range schemaless.SchemaDefinition {
+			schemalessFields[prop.Name] = prop
+		}
+
+		builder, err := connector.buildSelectBuilder(schemaless, &interfaces.ResourceDataQueryParams{
+			OutputFields: []string{"content_vector"},
+			Sort:         []*interfaces.SortField{{Field: "content_vector", Direction: interfaces.DESC_DIRECTION}},
+			Limit:        5,
+		}, schemalessFields, nil)
+		require.NoError(t, err)
+
+		sql, _, err := builder.ToSql()
+		require.NoError(t, err)
+		assert.Equal(t,
+			"SELECT `content_vector` FROM `yanfeng_kb`.`fact` ORDER BY `content_vector` DESC LIMIT 5 OFFSET 0",
+			sql)
+	})
+
 	t.Run("aggregation quotes the aggregated column, group by and alias", func(t *testing.T) {
 		builder, err := connector.buildSelectBuilder(resource, &interfaces.ResourceDataQueryParams{
 			GroupBy:     []*interfaces.GroupByItem{{Property: "key"}},

--- a/adp/vega/vega-backend/server/logics/connector/local/table/mariadb/mariadb_query_test.go
+++ b/adp/vega/vega-backend/server/logics/connector/local/table/mariadb/mariadb_query_test.go
@@ -210,6 +210,31 @@ func TestBuildSelectBuilderQuotesIdentifiers(t *testing.T) {
 			sql)
 	})
 
+	// 默认查全字段这条路也要走兜底，否则 original_name 为空的属性会拼出空标识符
+	t.Run("select all falls back for a property without original_name", func(t *testing.T) {
+		schemaless := &interfaces.Resource{
+			SourceIdentifier: "yanfeng_kb.fact",
+			SchemaDefinition: []*interfaces.Property{
+				{Name: "id", OriginalName: "id", Type: interfaces.DataType_String},
+				{Name: "content_vector", Type: interfaces.DataType_Vector},
+			},
+		}
+		schemalessFields := map[string]*interfaces.Property{}
+		for _, prop := range schemaless.SchemaDefinition {
+			schemalessFields[prop.Name] = prop
+		}
+
+		builder, err := connector.buildSelectBuilder(schemaless,
+			&interfaces.ResourceDataQueryParams{Limit: 10}, schemalessFields, nil)
+		require.NoError(t, err)
+
+		sql, _, err := builder.ToSql()
+		require.NoError(t, err)
+		assert.Equal(t,
+			"SELECT `id`, `content_vector` FROM `yanfeng_kb`.`fact` LIMIT 10 OFFSET 0",
+			sql)
+	})
+
 	t.Run("aggregation quotes the aggregated column, group by and alias", func(t *testing.T) {
 		builder, err := connector.buildSelectBuilder(resource, &interfaces.ResourceDataQueryParams{
 			GroupBy:     []*interfaces.GroupByItem{{Property: "key"}},

--- a/adp/vega/vega-backend/server/logics/connector/local/table/mariadb/mariadb_query_test.go
+++ b/adp/vega/vega-backend/server/logics/connector/local/table/mariadb/mariadb_query_test.go
@@ -225,6 +225,24 @@ func TestBuildSelectBuilderQuotesIdentifiers(t *testing.T) {
 			sql)
 	})
 
+	// 别名与 schema 属性同名时，排序必须认聚合别名而不是那个属性的源列
+	t.Run("sorting by an aggregate alias that shadows a property uses the alias", func(t *testing.T) {
+		builder, err := connector.buildSelectBuilder(resource, &interfaces.ResourceDataQueryParams{
+			GroupBy:     []*interfaces.GroupByItem{{Property: "key"}},
+			Aggregation: &interfaces.Aggregation{Property: "id", Aggr: "count", Alias: "created"},
+			Sort:        []*interfaces.SortField{{Field: "created", Direction: interfaces.DESC_DIRECTION}},
+			Limit:       20,
+		}, fieldMap, nil)
+		require.NoError(t, err)
+
+		sql, _, err := builder.ToSql()
+		require.NoError(t, err)
+		assert.Equal(t,
+			"SELECT `key`, COUNT(`id`) AS `created` FROM `yanfeng_kb`.`fact` GROUP BY `key` "+
+				"ORDER BY `created` DESC LIMIT 20 OFFSET 0",
+			sql)
+	})
+
 	t.Run("output_fields already selected as an alias are not duplicated", func(t *testing.T) {
 		builder, err := connector.buildSelectBuilder(resource, &interfaces.ResourceDataQueryParams{
 			GroupBy:      []*interfaces.GroupByItem{{Property: "key"}},

--- a/adp/vega/vega-backend/server/logics/connector/local/table/mariadb/mariadb_query_test.go
+++ b/adp/vega/vega-backend/server/logics/connector/local/table/mariadb/mariadb_query_test.go
@@ -30,13 +30,19 @@ func TestBuildHavingCondition(t *testing.T) {
 			name:     "equal numeric alias",
 			having:   &interfaces.HavingClause{Field: "__value", Operation: "==", Value: 10},
 			aggAlias: "total",
-			want:     "total = 10",
+			want:     "`total` = 10",
 		},
 		{
 			name:     "not equal string alias",
 			having:   &interfaces.HavingClause{Field: "__value", Operation: "!=", Value: "ok"},
 			aggAlias: "status_count",
-			want:     "status_count <> 'ok'",
+			want:     "`status_count` <> 'ok'",
+		},
+		{
+			name:     "reserved word alias is quoted",
+			having:   &interfaces.HavingClause{Field: "__value", Operation: ">=", Value: 3},
+			aggAlias: "key",
+			want:     "`key` >= 3",
 		},
 		{
 			name:   "count star uses count expression",
@@ -47,13 +53,13 @@ func TestBuildHavingCondition(t *testing.T) {
 			name:     "in string list quotes values",
 			having:   &interfaces.HavingClause{Field: "__value", Operation: "in", Value: []string{"a", "b"}},
 			aggAlias: "total",
-			want:     "total IN ('a', 'b')",
+			want:     "`total` IN ('a', 'b')",
 		},
 		{
 			name:     "range uses placeholders",
 			having:   &interfaces.HavingClause{Field: "__value", Operation: "range", Value: []any{1, 3}},
 			aggAlias: "total",
-			want:     "total BETWEEN ? AND ?",
+			want:     "`total` BETWEEN ? AND ?",
 		},
 		{
 			name:       "rejects unsupported field",

--- a/adp/vega/vega-backend/server/logics/connector/local/table/mariadb/mariadb_query_test.go
+++ b/adp/vega/vega-backend/server/logics/connector/local/table/mariadb/mariadb_query_test.go
@@ -122,6 +122,106 @@ func TestBuildDateFormat(t *testing.T) {
 	}
 }
 
+func TestBuildSelectBuilderQuotesIdentifiers(t *testing.T) {
+	connector := &MariaDBConnector{}
+	// fact 表带一个名为 key 的列——MySQL 保留字，裸拼进 SELECT 会在执行期报 1064
+	resource := &interfaces.Resource{
+		SourceIdentifier: "yanfeng_kb.fact",
+		SchemaDefinition: []*interfaces.Property{
+			{Name: "id", OriginalName: "id", Type: interfaces.DataType_String},
+			{Name: "key", OriginalName: "key", Type: interfaces.DataType_String},
+			{Name: "created", OriginalName: "created_at", Type: interfaces.DataType_Datetime},
+		},
+	}
+	fieldMap := map[string]*interfaces.Property{}
+	for _, prop := range resource.SchemaDefinition {
+		fieldMap[prop.Name] = prop
+	}
+
+	t.Run("detail query quotes every column and the table", func(t *testing.T) {
+		builder, err := connector.buildSelectBuilder(resource,
+			&interfaces.ResourceDataQueryParams{Limit: 10}, fieldMap, nil)
+		require.NoError(t, err)
+
+		sql, _, err := builder.ToSql()
+		require.NoError(t, err)
+		assert.Equal(t,
+			"SELECT `id`, `key`, `created_at` FROM `yanfeng_kb`.`fact` LIMIT 10 OFFSET 0",
+			sql)
+	})
+
+	t.Run("output_fields resolve to quoted original names", func(t *testing.T) {
+		builder, err := connector.buildSelectBuilder(resource,
+			&interfaces.ResourceDataQueryParams{OutputFields: []string{"key", "created"}, Limit: 5}, fieldMap, nil)
+		require.NoError(t, err)
+
+		sql, _, err := builder.ToSql()
+		require.NoError(t, err)
+		assert.Equal(t, "SELECT `key`, `created_at` FROM `yanfeng_kb`.`fact` LIMIT 5 OFFSET 0", sql)
+	})
+
+	t.Run("sort quotes the column and maps to its original name", func(t *testing.T) {
+		builder, err := connector.buildSelectBuilder(resource, &interfaces.ResourceDataQueryParams{
+			OutputFields: []string{"id"},
+			Sort:         []*interfaces.SortField{{Field: "created", Direction: interfaces.DESC_DIRECTION}},
+			Limit:        5,
+		}, fieldMap, nil)
+		require.NoError(t, err)
+
+		sql, _, err := builder.ToSql()
+		require.NoError(t, err)
+		assert.Equal(t,
+			"SELECT `id` FROM `yanfeng_kb`.`fact` ORDER BY `created_at` DESC LIMIT 5 OFFSET 0",
+			sql)
+	})
+
+	t.Run("aggregation quotes the aggregated column, group by and alias", func(t *testing.T) {
+		builder, err := connector.buildSelectBuilder(resource, &interfaces.ResourceDataQueryParams{
+			GroupBy:     []*interfaces.GroupByItem{{Property: "key"}},
+			Aggregation: &interfaces.Aggregation{Property: "id", Aggr: "count", Alias: "cnt"},
+			Limit:       20,
+		}, fieldMap, nil)
+		require.NoError(t, err)
+
+		sql, _, err := builder.ToSql()
+		require.NoError(t, err)
+		assert.Equal(t,
+			"SELECT `key`, COUNT(`id`) AS `cnt` FROM `yanfeng_kb`.`fact` GROUP BY `key` LIMIT 20 OFFSET 0",
+			sql)
+	})
+
+	t.Run("output_fields already selected as an alias are not duplicated", func(t *testing.T) {
+		builder, err := connector.buildSelectBuilder(resource, &interfaces.ResourceDataQueryParams{
+			GroupBy:      []*interfaces.GroupByItem{{Property: "key"}},
+			Aggregation:  &interfaces.Aggregation{Property: "id", Aggr: "count", Alias: "cnt"},
+			OutputFields: []string{"key", "cnt"},
+			Limit:        20,
+		}, fieldMap, nil)
+		require.NoError(t, err)
+
+		sql, _, err := builder.ToSql()
+		require.NoError(t, err)
+		assert.Equal(t,
+			"SELECT `key`, COUNT(`id`) AS `cnt` FROM `yanfeng_kb`.`fact` GROUP BY `key` LIMIT 20 OFFSET 0",
+			sql)
+	})
+
+	t.Run("calendar interval keeps the date_format expression over a quoted column", func(t *testing.T) {
+		builder, err := connector.buildSelectBuilder(resource, &interfaces.ResourceDataQueryParams{
+			GroupBy: []*interfaces.GroupByItem{{Property: "created", CalendarInterval: interfaces.CALENDAR_UNIT_DAY}},
+			Limit:   20,
+		}, fieldMap, nil)
+		require.NoError(t, err)
+
+		sql, _, err := builder.ToSql()
+		require.NoError(t, err)
+		assert.Equal(t,
+			"SELECT date_format(`created_at`,'%Y-%m-%d') AS `created` FROM `yanfeng_kb`.`fact` "+
+				"GROUP BY date_format(`created_at`,'%Y-%m-%d') LIMIT 20 OFFSET 0",
+			sql)
+	})
+}
+
 func TestMariaDBConvertValue(t *testing.T) {
 	t.Run("maria dbconvert value", func(t *testing.T) {
 		assert.Equal(t, "hello", convertValue([]byte("hello")))


### PR DESCRIPTION
## Problem

A source column named after a SQL reserved word passes every stage except the
one that matters:

| Stage | Result |
|---|---|
| `CREATE TABLE` with a `key` column | OK |
| `catalog discover` | OK, column recognised |
| `bkn push` | OK |
| `object-type query` | **HTTP 500** `InternalError.GetViewDataByIDFailed` |

The WHERE clause already went through `quoteColumnName`, but the select list,
table name, aliases, GROUP BY and ORDER BY were concatenated raw:

```go
selectFields = append(selectFields, prop.OriginalName)
builder := sq.Select(selectFields...).From(resource.SourceIdentifier)
```

so MySQL received `SELECT id, key, ... FROM yanfeng_kb.fact` and returned a 1064
syntax error, surfaced to the caller as a generic internal error with no mention
of the column or of reserved words.

## Fix

Statement assembly moves into `buildSelectBuilder`, and every identifier —
columns, table, aggregate aliases, group-by and sort fields — goes through
`quoteColumnName` / `qualTable`. `date_format(...)` expressions keep their shape
with the inner column quoted.

Two behaviour changes worth calling out:

- Sort fields now resolve through the schema like every other clause. Sorting by
  a property whose `original_name` differs from its name previously emitted a
  non-existent column; it now emits the mapped column.
- `output_fields` de-duplication tracks selected names in a set instead of
  string-matching `" AS "+name` against the rendered select entries, which no
  longer holds once aliases are quoted.

PostgreSQL already quotes its table name via `qualTable`; its select list has
the same gap and is left for a follow-up so this stays reviewable.

## Tests

`buildSelectBuilder` is now testable without a live database. Added coverage for
the reserved-word column, `output_fields` mapping, sorting, aggregation with
alias, alias de-duplication, and calendar-interval grouping.

`go vet ./logics/connector/...` and `go test ./logics/connector/...` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)