### PR TITLE
feat(bkn-safe): revoke normal_user's data-plane wildcard grants (#513)

### DIFF
--- a/bkn-safe/server/internal/seed/data/grants.json
+++ b/bkn-safe/server/internal/seed/data/grants.json
@@ -1,5 +1,5 @@
 {
-  "_comment": "Studio 0.1.0 role -> permission grants. super_admin gets wildcard. admin/security/audit are three-admin roles. network_builder has business build permissions. normal_user can view/query/execute/invoke, but cannot create/edit/delete/publish/authorize.",
+  "_comment": "Studio 0.1.0 role -> permission grants. super_admin gets wildcard. admin/security/audit are three-admin roles. network_builder has business build permissions. normal_user holds NO data grants at all (#513): catalogs, data resources and knowledge networks are visible only when granted explicitly, because a type-wide allow cannot be narrowed by an object grant in an allow-only engine. What it does keep is the capability surface — tools, models, agents — where a type-wide grant leaks no data and revoking it would only make the platform unusable.",
   "grants": [
     {
       "role_id": "7dcfcc9c-ad02-11e8-aa06-000c29358ad6",
@@ -222,27 +222,6 @@
       "operations": ["publish", "unpublish", "unpublish_other_user_agent_tpl"]
     },
 
-    {
-      "role_id": "b5f9ac3e-992c-4bbd-8126-95e87e51c46e",
-      "role_name": "normal_user",
-      "resource_type": "catalog",
-      "id_pattern": "*",
-      "operations": ["view_detail"]
-    },
-    {
-      "role_id": "b5f9ac3e-992c-4bbd-8126-95e87e51c46e",
-      "role_name": "normal_user",
-      "resource_type": "resource",
-      "id_pattern": "*",
-      "operations": ["view_detail", "query_data"]
-    },
-    {
-      "role_id": "b5f9ac3e-992c-4bbd-8126-95e87e51c46e",
-      "role_name": "normal_user",
-      "resource_type": "knowledge_network",
-      "id_pattern": "*",
-      "operations": ["view_detail", "query_data"]
-    },
     {
       "role_id": "b5f9ac3e-992c-4bbd-8126-95e87e51c46e",
       "role_name": "normal_user",

--- a/bkn-safe/server/internal/seed/matrix_test.go
+++ b/bkn-safe/server/internal/seed/matrix_test.go
@@ -40,16 +40,16 @@ func TestRoleResourceMatrix(t *testing.T) {
 	}
 	roleAllowed := map[string]map[string]string{
 		networkBuilder: repOp,
+		// The data types (catalog / resource / knowledge_network) are absent on
+		// purpose: the ordinary role holds no data grant, and visibility comes
+		// only from an explicit grant (#513).
 		normalUser: {
-			"agent":             "use",
-			"catalog":           "view_detail",
-			"resource":          "view_detail",
-			"knowledge_network": "query_data",
-			"tool_box":          "execute",
-			"mcp":               "execute",
-			"operator":          "execute",
-			"skill":             "execute",
-			"small_model":       "execute",
+			"agent":       "use",
+			"tool_box":    "execute",
+			"mcp":         "execute",
+			"operator":    "execute",
+			"skill":       "execute",
+			"small_model": "execute",
 		},
 	}
 	allTypes := make([]string, 0, len(repOp))

--- a/bkn-safe/server/internal/seed/seed_test.go
+++ b/bkn-safe/server/internal/seed/seed_test.go
@@ -127,7 +127,10 @@ func TestSeededRoleGrants(t *testing.T) {
 		{"network-builder manages catalog", networkBuilder, "catalog", "x", "create", true},
 		{"network-builder manages skill", networkBuilder, "skill", "s1", "publish", true},
 		{"network-builder not system users", networkBuilder, "admin-user", "x", "create", false},
-		{"normal-user can query knowledge", normalUser, "knowledge_network", "kn1", "query_data", true},
+		// The data surface defaults to nothing (#513); capabilities are unchanged.
+		{"normal-user cannot query knowledge by default", normalUser, "knowledge_network", "kn1", "query_data", false},
+		{"normal-user cannot view a catalog by default", normalUser, "catalog", "c1", "view_detail", false},
+		{"normal-user cannot view a data resource by default", normalUser, "resource", "r1", "view_detail", false},
 		{"normal-user can execute skill", normalUser, "skill", "s1", "execute", true},
 		{"normal-user can use agent", normalUser, "agent", "a1", "use", true},
 		{"normal-user cannot create catalog", normalUser, "catalog", "x", "create", false},
@@ -353,7 +356,10 @@ func TestApplyReconcilesCurrentSeedRoleGrants(t *testing.T) {
 	} else if ok {
 		t.Fatal("stale current-role grant still allows admin-user create")
 	}
-	if ok, err := e.Check(user, "catalog", "c1", "view_detail"); err != nil {
+	// Assert the rebuild half with a grant the role actually holds: the data
+	// surface is gone (#513), so using catalog here would test the revocation
+	// instead, which is another test's job.
+	if ok, err := e.Check(user, "skill", "s1", "execute"); err != nil {
 		t.Fatal(err)
 	} else if !ok {
 		t.Fatal("normal_user desired grant was not restored after reconcile")
@@ -413,11 +419,17 @@ func TestCatalogResourceOperationSplit(t *testing.T) {
 	}
 }
 
-// TestSeedGrantsKeepResourceReadBehaviour guards the compatibility promise of
-// #801: today a normal user reading a table also reads its rows through the
-// single view_detail verb. Splitting the verb must not silently take that away,
-// so the seed grants query_data alongside view_detail.
-func TestSeedGrantsKeepResourceReadBehaviour(t *testing.T) {
+// TestSeedRevokesNormalUserDataGrants pins #513: the ordinary role holds no
+// data grant at all, so an object grant is finally the thing that decides.
+//
+// The point is not tidiness. In an allow-only engine a type-wide allow cannot be
+// narrowed by an object grant, so as long as normal_user held resource:* every
+// per-object configuration an administrator made was dead on arrival.
+//
+// The capability surface stays: tools, models and agents leak no data through a
+// type-wide grant, and revoking those would only leave a platform where a signed-in
+// user cannot invoke a model.
+func TestSeedRevokesNormalUserDataGrants(t *testing.T) {
 	db := newDB(t)
 	e, err := authz.New(db)
 	if err != nil {
@@ -431,28 +443,65 @@ func TestSeedGrantsKeepResourceReadBehaviour(t *testing.T) {
 		normalUser     = "b5f9ac3e-992c-4bbd-8126-95e87e51c46e"
 		networkBuilder = "1572fb82-526f-11f0-bde6-e674ec8dde71"
 	)
-
 	user := "u-normal"
 	if err := e.AssignRole(user, normalUser); err != nil {
 		t.Fatal(err)
 	}
-	for _, op := range []string{"view_detail", "query_data"} {
-		allowed, err := e.Check(user, "resource", "res-1", op)
+
+	// The data surface: not one grant should be left.
+	for _, tc := range []struct{ rtype, op string }{
+		{"catalog", "view_detail"},
+		{"resource", "view_detail"},
+		{"resource", "query_data"},
+		{"knowledge_network", "view_detail"},
+		{"knowledge_network", "query_data"},
+	} {
+		allowed, err := e.Check(user, tc.rtype, "x-1", tc.op)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if allowed {
+			t.Errorf("normal_user still holds %s/%s by default — object grants stay overridden by it", tc.rtype, tc.op)
+		}
+	}
+
+	// Granted explicitly, it must be visible — otherwise revoking the wildcard
+	// leaves no working path to see anything at all.
+	if err := e.GrantObjectPermission(user, "catalog", "c-1", "view_detail"); err != nil {
+		t.Fatal(err)
+	}
+	allowed, err := e.Check(user, "catalog", "c-1", "view_detail")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !allowed {
+		t.Error("an explicit catalog grant still does not grant access — the convergence would leave no usable path")
+	}
+
+	// The capability surface is untouched: revoking it buys no safety and leaves a
+	// signed-in user unable to invoke a model.
+	for _, tc := range []struct{ rtype, op string }{
+		{"skill", "execute"},
+		{"tool_box", "execute"},
+		{"large_model", "execute"},
+		{"small_model", "execute"},
+		{"agent", "use"},
+	} {
+		allowed, err := e.Check(user, tc.rtype, "x-1", tc.op)
 		if err != nil {
 			t.Fatal(err)
 		}
 		if !allowed {
-			t.Errorf("normal_user lost resource %q after the split", op)
+			t.Errorf("normal_user lost the capability %s/%s — that is not convergence, it is an unusable platform", tc.rtype, tc.op)
 		}
 	}
 
-	// The builder must keep creating tables across the upgrade: vega still
-	// judges resource+create until it switches to catalog+resource_manage.
+	// The builder is unaffected: it creates tables through its own grants.
 	builder := "u-builder"
 	if err := e.AssignRole(builder, networkBuilder); err != nil {
 		t.Fatal(err)
 	}
-	allowed, err := e.Check(builder, "resource", "res-1", "create")
+	allowed, err = e.Check(builder, "resource", "res-1", "create")
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
Closes #513. `normal_user` no longer holds a grant on any data type, so an object grant is finally the thing that decides.

## Why it had to go

In an allow-only engine a type-wide allow **cannot be narrowed** by an object grant — there is no deny to express the exception with. So as long as the role held `resource:*`, every per-object configuration an administrator made was overridden before it was read. Layered authorization was invisible for the same reason: the user could already see everything.

## Revoked, and kept

| type | action |
| --- | --- |
| `catalog` / `resource` / `knowledge_network` | **revoked** |
| `tool_box` / `skill` / `mcp` / `operator` | keep `view` + `execute` |
| `large_model` / `small_model` | keep `display` + `execute` |
| `agent` | keep `use` |

The line is data versus capability. A type-wide grant on the data types is precisely what hides object-level configuration. A type-wide grant on tools and models hides nothing and leaks nothing, and revoking it would produce a platform where a signed-in user cannot invoke a model or open a toolbox — not convergence, just breakage. Built-in toolboxes reach users through the public accessor either way.

## No shadow period, no flag

`reconcileSeedRoles` wipes each seeded role's policy rows on every start and rebuilds them from `grants.json`, so **removing a line applies to every environment on the next restart**. There is no "new installs only" variant without inventing a flag, and nothing to stage.

That also removes the reason for the three-stage treatment the issue originally asked for. A shadow report can name who *would* be denied; it cannot name who *should* have been allowed, and that is the only question here. There is deliberately no automatic migration minting grants from access history either — that would freeze today's over-permission into grants that look deliberate.

## Restoring visibility is one grant per catalog

```
POST /api/safe/v1/authz/policies
{ "accessor_id": "<role or user id>",
  "resource": { "type": "catalog", "id": "<catalog id>" },
  "operations": ["view_detail", "query_data"] }
```

One per catalog, not one per table — because #817/#874 now resolves a table's permission through its owning catalog. Knowledge networks work the same way with `knowledge_network`.

## Verified on the development cluster first

The failure worth fearing is not "too strict", it is "granted and still invisible". Measured with a role-less user: baseline **0 / 0 / 0**; after one catalog grant and one knowledge-network grant — **1 catalog, 13 resources** (every one of them inside that catalog), **1 knowledge network**. All three surfaces honour an explicit grant once the wildcard is gone.

## Tests

- five data-plane assertions: denied by default
- an explicit catalog grant is honoured — otherwise the convergence would leave no usable path at all
- five capability assertions: still allowed
- `network_builder` unaffected

`TestSeedGrantsKeepResourceReadBehaviour` asserted the premise this change reverses, so it is replaced by the above rather than patched.

## Follow-ups

- The frontend needs an empty-state message: a new user now sees empty lists, which is correct and reads as broken.
- `network_builder` still holds near-complete grants across every type. That role is a builder and its convergence is a separate decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
