### PR TITLE
fix(bkn): localize operation-audit API errors

### DIFF
--- a/adp/bkn/bkn-backend/server/driveradapters/operation_audit_query.go
+++ b/adp/bkn/bkn-backend/server/driveradapters/operation_audit_query.go
@@ -18,6 +18,7 @@ import (
 
 	"bkn-backend/common/bkntrace"
 	"bkn-backend/common/operationaudit"
+	berrors "bkn-backend/errors"
 	"bkn-backend/interfaces"
 )
 
@@ -33,7 +34,7 @@ func (r *restHandler) ListOperationAudits(c *gin.Context) {
 		return
 	}
 	if r.auditQueryStore == nil {
-		c.JSON(http.StatusServiceUnavailable, gin.H{"error": "operation audit source is unavailable"})
+		replyOperationAuditError(c, http.StatusServiceUnavailable, berrors.BknBackend_OperationAudit_ServiceUnavailable, nil)
 		return
 	}
 	filter := operationaudit.Filter{
@@ -48,13 +49,15 @@ func (r *restHandler) ListOperationAudits(c *gin.Context) {
 		Outcome:          strings.TrimSpace(c.Query("outcome")),
 	}
 	if filter.TenantID == "" || filter.BusinessDomainID == "" {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "x-tenant-id and x-business-domain are required"})
+		replyOperationAuditError(c, http.StatusBadRequest, berrors.BknBackend_OperationAudit_MissingScope, gin.H{
+			"required_headers": []string{"x-tenant-id", interfaces.HTTP_HEADER_BUSINESS_DOMAIN},
+		})
 		return
 	}
 	requestedActor := filter.ActorID
 	applyOperationAuditScope(&filter, nil, visitor.ID, profile)
 	if requestedActor != "" && filter.ActorID != requestedActor {
-		c.JSON(http.StatusForbidden, gin.H{"error": "actor filter is outside the authorized scope"})
+		replyOperationAuditError(c, http.StatusForbidden, berrors.BknBackend_OperationAudit_AccessDenied, gin.H{"field": "actor_id"})
 		return
 	}
 	if limit, err := strconv.Atoi(strings.TrimSpace(c.Query("limit"))); err == nil {
@@ -63,7 +66,7 @@ func (r *restHandler) ListOperationAudits(c *gin.Context) {
 	if before := strings.TrimSpace(c.Query("before_time")); before != "" {
 		parsed, err := time.Parse(time.RFC3339Nano, before)
 		if err != nil {
-			c.JSON(http.StatusBadRequest, gin.H{"error": "before_time must be RFC3339"})
+			replyOperationAuditError(c, http.StatusBadRequest, berrors.BknBackend_OperationAudit_InvalidBeforeTime, gin.H{"field": "before_time", "format": "RFC3339"})
 			return
 		}
 		filter.BeforeTime = parsed.UTC()
@@ -71,7 +74,7 @@ func (r *restHandler) ListOperationAudits(c *gin.Context) {
 	}
 	page, err := r.auditQueryStore.List(c.Request.Context(), filter)
 	if err != nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": "operation audit query failed"})
+		replyOperationAuditError(c, http.StatusInternalServerError, berrors.BknBackend_OperationAudit_QueryFailed, nil)
 		return
 	}
 	response := gin.H{"entries": operationAuditResponses(page.Entries), "has_more": page.HasMore}
@@ -88,7 +91,7 @@ func (r *restHandler) GetOperationAudit(c *gin.Context) {
 		return
 	}
 	if r.auditQueryStore == nil {
-		c.JSON(http.StatusServiceUnavailable, gin.H{"error": "operation audit source is unavailable"})
+		replyOperationAuditError(c, http.StatusServiceUnavailable, berrors.BknBackend_OperationAudit_ServiceUnavailable, nil)
 		return
 	}
 	scope := operationaudit.Scope{
@@ -96,17 +99,19 @@ func (r *restHandler) GetOperationAudit(c *gin.Context) {
 		BusinessDomainID: strings.TrimSpace(c.GetHeader(interfaces.HTTP_HEADER_BUSINESS_DOMAIN)),
 	}
 	if scope.TenantID == "" || scope.BusinessDomainID == "" {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "x-tenant-id and x-business-domain are required"})
+		replyOperationAuditError(c, http.StatusBadRequest, berrors.BknBackend_OperationAudit_MissingScope, gin.H{
+			"required_headers": []string{"x-tenant-id", interfaces.HTTP_HEADER_BUSINESS_DOMAIN},
+		})
 		return
 	}
 	applyOperationAuditScope(nil, &scope, visitor.ID, profile)
 	entry, found, err := r.auditQueryStore.Get(c.Request.Context(), strings.TrimSpace(c.Param("event_id")), scope)
 	if err != nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": "operation audit query failed"})
+		replyOperationAuditError(c, http.StatusInternalServerError, berrors.BknBackend_OperationAudit_QueryFailed, nil)
 		return
 	}
 	if !found {
-		c.JSON(http.StatusNotFound, gin.H{"error": "operation audit event not found"})
+		replyOperationAuditError(c, http.StatusNotFound, berrors.BknBackend_OperationAudit_NotFound, gin.H{"event_id": strings.TrimSpace(c.Param("event_id"))})
 		return
 	}
 	c.JSON(http.StatusOK, operationAuditResponse(entry))
@@ -119,18 +124,18 @@ func (r *restHandler) operationAuditQueryProfile(c *gin.Context) (visitor hydra.
 	}
 	visitor = verified
 	if r.auditAccessResolver == nil {
-		c.JSON(http.StatusServiceUnavailable, gin.H{"error": "operation audit authorization is unavailable"})
+		replyOperationAuditError(c, http.StatusServiceUnavailable, berrors.BknBackend_OperationAudit_ServiceUnavailable, nil)
 		return hydra.Visitor{}, bkntrace.OperationAuditProfile{}, false
 	}
 	profile, err = r.auditAccessResolver(c.Request.Context(), c.GetHeader("Authorization"), verified.ID)
 	if err != nil {
 		status := http.StatusServiceUnavailable
-		message := "operation audit authorization is unavailable"
+		code := berrors.BknBackend_OperationAudit_ServiceUnavailable
 		if errors.Is(err, bkntrace.ErrAccessProfileDenied) {
 			status = http.StatusForbidden
-			message = "operation audit access denied"
+			code = berrors.BknBackend_OperationAudit_AccessDenied
 		}
-		c.JSON(status, gin.H{"error": message})
+		replyOperationAuditError(c, status, code, nil)
 		return hydra.Visitor{}, bkntrace.OperationAuditProfile{}, false
 	}
 	return visitor, profile, true
@@ -140,10 +145,22 @@ func operationAuditRange(c *gin.Context) (time.Time, time.Time, bool) {
 	from, fromErr := time.Parse(time.RFC3339Nano, strings.TrimSpace(c.Query("from")))
 	to, toErr := time.Parse(time.RFC3339Nano, strings.TrimSpace(c.Query("to")))
 	if fromErr != nil || toErr != nil || !from.Before(to) || to.Sub(from) > maximumOperationAuditRange {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "from/to must be a valid RFC3339 range of at most 30 days"})
+		replyOperationAuditError(c, http.StatusBadRequest, berrors.BknBackend_OperationAudit_InvalidRange, gin.H{
+			"fields":       []string{"from", "to"},
+			"format":       "RFC3339",
+			"max_duration": maximumOperationAuditRange.String(),
+		})
 		return time.Time{}, time.Time{}, false
 	}
 	return from.UTC(), to.UTC(), true
+}
+
+func replyOperationAuditError(c *gin.Context, status int, code string, details any) {
+	err := rest.NewHTTPError(c.Request.Context(), status, code)
+	if details != nil {
+		err.WithErrorDetails(details)
+	}
+	rest.ReplyError(c, err)
 }
 
 func applyOperationAuditScope(filter *operationaudit.Filter, scope *operationaudit.Scope, actorID string, profile bkntrace.OperationAuditProfile) {

--- a/adp/bkn/bkn-backend/server/driveradapters/operation_audit_query_test.go
+++ b/adp/bkn/bkn-backend/server/driveradapters/operation_audit_query_test.go
@@ -7,6 +7,7 @@ package driveradapters
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"net/http"
 	"net/http/httptest"
@@ -15,24 +16,34 @@ import (
 
 	"github.com/gin-gonic/gin"
 	"github.com/openbkn-ai/bkn-foundry/comm-go/hydra"
+	"github.com/openbkn-ai/bkn-foundry/comm-go/rest"
 
 	"bkn-backend/common/bkntrace"
 	"bkn-backend/common/operationaudit"
+	berrors "bkn-backend/errors"
 )
 
 type operationAuditQueryStoreStub struct {
-	filter operationaudit.Filter
-	scope  operationaudit.Scope
-	found  bool
+	filter  operationaudit.Filter
+	scope   operationaudit.Scope
+	found   bool
+	listErr error
+	getErr  error
 }
 
 func (s *operationAuditQueryStoreStub) List(_ context.Context, filter operationaudit.Filter) (operationaudit.Page, error) {
 	s.filter = filter
+	if s.listErr != nil {
+		return operationaudit.Page{}, s.listErr
+	}
 	return operationaudit.Page{Entries: []operationaudit.Entry{{EventID: "evt-a", EventTime: time.Now().UTC()}}}, nil
 }
 
 func (s *operationAuditQueryStoreStub) Get(_ context.Context, _ string, scope operationaudit.Scope) (operationaudit.Entry, bool, error) {
 	s.scope = scope
+	if s.getErr != nil {
+		return operationaudit.Entry{}, false, s.getErr
+	}
 	return operationaudit.Entry{EventID: "evt-a"}, s.found, nil
 }
 
@@ -59,6 +70,7 @@ func TestListOperationAuditsAppliesServerSideRoleScope(t *testing.T) {
 				},
 			}
 			engine := gin.New()
+			engine.Use(rest.LanguageMiddleware(), rest.PrivateNoCacheMiddleware())
 			engine.GET("/api/bkn-backend/v1/operation-audits", handler.ListOperationAudits)
 			request := httptest.NewRequest(http.MethodGet, "/api/bkn-backend/v1/operation-audits?from=2026-08-01T00:00:00Z&to=2026-08-08T00:00:00Z", nil)
 			request.Header.Set("Authorization", "Bearer token")
@@ -86,6 +98,7 @@ func TestOperationAuditQueryRejectsUnboundedRangeAndHidesUnauthorizedDetail(t *t
 		auditAccessResolver: func(context.Context, string, string) (bkntrace.OperationAuditProfile, error) { return profile, nil },
 	}
 	engine := gin.New()
+	engine.Use(rest.LanguageMiddleware(), rest.PrivateNoCacheMiddleware())
 	engine.GET("/api/bkn-backend/v1/operation-audits", handler.ListOperationAudits)
 	engine.GET("/api/bkn-backend/v1/operation-audits/:event_id", handler.GetOperationAudit)
 
@@ -128,6 +141,7 @@ func TestOperationAuditQueryDistinguishesDeniedFromUnavailableAuthorization(t *t
 				},
 			}
 			engine := gin.New()
+			engine.Use(rest.LanguageMiddleware(), rest.PrivateNoCacheMiddleware())
 			engine.GET("/api/bkn-backend/v1/operation-audits", handler.ListOperationAudits)
 			request := httptest.NewRequest(http.MethodGet, "/api/bkn-backend/v1/operation-audits?from=2026-08-01T00:00:00Z&to=2026-08-08T00:00:00Z", nil)
 			request.Header.Set("Authorization", "Bearer token")
@@ -135,6 +149,106 @@ func TestOperationAuditQueryDistinguishesDeniedFromUnavailableAuthorization(t *t
 			engine.ServeHTTP(response, request)
 			if response.Code != test.wantStatus {
 				t.Fatalf("status = %d, body = %s", response.Code, response.Body.String())
+			}
+		})
+	}
+}
+
+func TestOperationAuditErrorsAreLocalized(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	profile := bkntrace.OperationAuditProfile{ActorID: "user-a", Roles: []string{"normal_user"}}
+
+	tests := []struct {
+		name            string
+		language        string
+		path            string
+		store           *operationAuditQueryStoreStub
+		resolverErr     error
+		wantStatus      int
+		wantCode        string
+		wantDescription string
+	}{
+		{
+			name: "Chinese invalid range", language: "zh-CN",
+			path:  "/api/bkn-backend/v1/operation-audits?from=invalid&to=2026-08-08T00:00:00Z",
+			store: &operationAuditQueryStoreStub{}, wantStatus: http.StatusBadRequest,
+			wantCode: berrors.BknBackend_OperationAudit_InvalidRange, wantDescription: "操作审计查询时间范围无效。",
+		},
+		{
+			name: "English invalid range", language: "en-US",
+			path:  "/api/bkn-backend/v1/operation-audits?from=invalid&to=2026-08-08T00:00:00Z",
+			store: &operationAuditQueryStoreStub{}, wantStatus: http.StatusBadRequest,
+			wantCode: berrors.BknBackend_OperationAudit_InvalidRange, wantDescription: "The operation-audit time range is invalid.",
+		},
+		{
+			name: "English query failure", language: "en-US",
+			path:  "/api/bkn-backend/v1/operation-audits?from=2026-08-01T00:00:00Z&to=2026-08-08T00:00:00Z",
+			store: &operationAuditQueryStoreStub{listErr: errors.New("store unavailable")}, wantStatus: http.StatusInternalServerError,
+			wantCode: berrors.BknBackend_OperationAudit_QueryFailed, wantDescription: "The operation-audit query failed.",
+		},
+		{
+			name: "English access denied", language: "en-US",
+			path:  "/api/bkn-backend/v1/operation-audits?from=2026-08-01T00:00:00Z&to=2026-08-08T00:00:00Z",
+			store: &operationAuditQueryStoreStub{}, resolverErr: bkntrace.ErrAccessProfileDenied, wantStatus: http.StatusForbidden,
+			wantCode: berrors.BknBackend_OperationAudit_AccessDenied, wantDescription: "You are not permitted to view operation-audit records.",
+		},
+		{
+			name: "English not found", language: "en-US", path: "/api/bkn-backend/v1/operation-audits/evt-missing",
+			store: &operationAuditQueryStoreStub{found: false}, wantStatus: http.StatusNotFound,
+			wantCode: berrors.BknBackend_OperationAudit_NotFound, wantDescription: "The operation-audit event was not found.",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			resolver := func(context.Context, string, string) (bkntrace.OperationAuditProfile, error) {
+				if test.resolverErr != nil {
+					return bkntrace.OperationAuditProfile{}, test.resolverErr
+				}
+				return profile, nil
+			}
+			handler := &restHandler{
+				as:                  traceOutboxAuthStub{visitor: hydra.Visitor{ID: "user-a", Type: hydra.VisitorType("user")}},
+				auditQueryStore:     test.store,
+				auditAccessResolver: resolver,
+			}
+			engine := gin.New()
+			engine.Use(rest.LanguageMiddleware(), rest.PrivateNoCacheMiddleware())
+			engine.GET("/api/bkn-backend/v1/operation-audits", handler.ListOperationAudits)
+			engine.GET("/api/bkn-backend/v1/operation-audits/:event_id", handler.GetOperationAudit)
+
+			request := httptest.NewRequest(http.MethodGet, test.path, nil)
+			request.Header.Set("Authorization", "Bearer token")
+			request.Header.Set("x-tenant-id", "tenant-a")
+			request.Header.Set("x-business-domain", "domain-a")
+			request.Header.Set(rest.AcceptLanguageHeader, test.language)
+			response := httptest.NewRecorder()
+			engine.ServeHTTP(response, request)
+
+			if response.Code != test.wantStatus {
+				t.Fatalf("status = %d, want %d; body=%s", response.Code, test.wantStatus, response.Body.String())
+			}
+			if got := response.Header().Get(rest.ContentLanguageHeader); got != test.language {
+				t.Fatalf("Content-Language = %q, want %q", got, test.language)
+			}
+			if got := response.Header().Get("Cache-Control"); got != "private, no-cache" {
+				t.Fatalf("Cache-Control = %q, want private, no-cache", got)
+			}
+			var body struct {
+				ErrorCode    string         `json:"error_code"`
+				Description  string         `json:"description"`
+				ErrorDetails map[string]any `json:"error_details"`
+			}
+			if err := json.Unmarshal(response.Body.Bytes(), &body); err != nil {
+				t.Fatalf("decode error response: %v", err)
+			}
+			if body.ErrorCode != test.wantCode || body.Description != test.wantDescription {
+				t.Errorf("error = %#v, want code=%q description=%q", body, test.wantCode, test.wantDescription)
+			}
+			if test.wantCode == berrors.BknBackend_OperationAudit_InvalidRange {
+				if body.ErrorDetails["format"] != "RFC3339" || body.ErrorDetails["max_duration"] != "720h0m0s" {
+					t.Errorf("error_details = %#v, want stable range details", body.ErrorDetails)
+				}
 			}
 		})
 	}

--- a/adp/bkn/bkn-backend/server/driveradapters/operation_audit_query_test.go
+++ b/adp/bkn/bkn-backend/server/driveradapters/operation_audit_query_test.go
@@ -235,9 +235,9 @@ func TestOperationAuditErrorsAreLocalized(t *testing.T) {
 				t.Fatalf("Cache-Control = %q, want private, no-cache", got)
 			}
 			var body struct {
-				ErrorCode    string         `json:"error_code"`
-				Description  string         `json:"description"`
-				ErrorDetails map[string]any `json:"error_details"`
+				ErrorCode    string `json:"error_code"`
+				Description  string `json:"description"`
+				ErrorDetails any    `json:"error_details"`
 			}
 			if err := json.Unmarshal(response.Body.Bytes(), &body); err != nil {
 				t.Fatalf("decode error response: %v", err)
@@ -246,7 +246,8 @@ func TestOperationAuditErrorsAreLocalized(t *testing.T) {
 				t.Errorf("error = %#v, want code=%q description=%q", body, test.wantCode, test.wantDescription)
 			}
 			if test.wantCode == berrors.BknBackend_OperationAudit_InvalidRange {
-				if body.ErrorDetails["format"] != "RFC3339" || body.ErrorDetails["max_duration"] != "720h0m0s" {
+				details, ok := body.ErrorDetails.(map[string]any)
+				if !ok || details["format"] != "RFC3339" || details["max_duration"] != "720h0m0s" {
 					t.Errorf("error_details = %#v, want stable range details", body.ErrorDetails)
 				}
 			}

--- a/adp/bkn/bkn-backend/server/errors/error_code.go
+++ b/adp/bkn/bkn-backend/server/errors/error_code.go
@@ -50,6 +50,15 @@ const (
 	// 500
 	BknBackend_InternalError_MarshalDataFailed   = "BknBackend.InternalError.MarshalDataFailed"
 	BknBackend_InternalError_UnMarshalDataFailed = "BknBackend.InternalError.UnMarshalDataFailed"
+
+	// Operation audit query
+	BknBackend_OperationAudit_InvalidRange       = "BknBackend.OperationAudit.InvalidRange"
+	BknBackend_OperationAudit_InvalidBeforeTime  = "BknBackend.OperationAudit.InvalidBeforeTime"
+	BknBackend_OperationAudit_MissingScope       = "BknBackend.OperationAudit.MissingScope"
+	BknBackend_OperationAudit_AccessDenied       = "BknBackend.OperationAudit.AccessDenied"
+	BknBackend_OperationAudit_ServiceUnavailable = "BknBackend.OperationAudit.ServiceUnavailable"
+	BknBackend_OperationAudit_QueryFailed        = "BknBackend.OperationAudit.QueryFailed"
+	BknBackend_OperationAudit_NotFound           = "BknBackend.OperationAudit.NotFound"
 )
 
 var (
@@ -90,6 +99,15 @@ var (
 		// 500
 		BknBackend_InternalError_MarshalDataFailed,
 		BknBackend_InternalError_UnMarshalDataFailed,
+
+		// operation audit query
+		BknBackend_OperationAudit_InvalidRange,
+		BknBackend_OperationAudit_InvalidBeforeTime,
+		BknBackend_OperationAudit_MissingScope,
+		BknBackend_OperationAudit_AccessDenied,
+		BknBackend_OperationAudit_ServiceUnavailable,
+		BknBackend_OperationAudit_QueryFailed,
+		BknBackend_OperationAudit_NotFound,
 	}
 )
 

--- a/adp/bkn/bkn-backend/server/locale/errorcode.en-US.toml
+++ b/adp/bkn/bkn-backend/server/locale/errorcode.en-US.toml
@@ -39,6 +39,41 @@ Description = "Invalid Pagination Limit"
 Solution = "Please check whether the parameter is correct."
 ErrorLink = "None"
 
+[BknBackend.OperationAudit.InvalidRange]
+Description = "The operation-audit time range is invalid."
+Solution = "Provide a valid RFC3339 time range no longer than 30 days."
+ErrorLink = "None"
+
+[BknBackend.OperationAudit.InvalidBeforeTime]
+Description = "The operation-audit pagination time is invalid."
+Solution = "Provide a valid RFC3339 before_time parameter."
+ErrorLink = "None"
+
+[BknBackend.OperationAudit.MissingScope]
+Description = "The operation-audit query scope is missing."
+Solution = "Provide the tenant and business-domain identifiers."
+ErrorLink = "None"
+
+[BknBackend.OperationAudit.AccessDenied]
+Description = "You are not permitted to view operation-audit records."
+Solution = "Check the access scope or contact an administrator."
+ErrorLink = "None"
+
+[BknBackend.OperationAudit.ServiceUnavailable]
+Description = "The operation-audit service is temporarily unavailable."
+Solution = "Try again later."
+ErrorLink = "None"
+
+[BknBackend.OperationAudit.QueryFailed]
+Description = "The operation-audit query failed."
+Solution = "Try again later; contact an administrator if the problem persists."
+ErrorLink = "None"
+
+[BknBackend.OperationAudit.NotFound]
+Description = "The operation-audit event was not found."
+Solution = "Check that the event identifier is correct."
+ErrorLink = "None"
+
 [BknBackend.InvalidParameter.ModuleType]
 Description = "Invalid Module Name"
 Solution = "Please check whether the parameter is correct."

--- a/adp/bkn/bkn-backend/server/locale/errorcode.zh-CN.toml
+++ b/adp/bkn/bkn-backend/server/locale/errorcode.zh-CN.toml
@@ -39,6 +39,41 @@ Description = "指定的每页数量限制无效"
 Solution = "请检查参数是否正确。"
 ErrorLink = "暂无"
 
+[BknBackend.OperationAudit.InvalidRange]
+Description = "操作审计查询时间范围无效。"
+Solution = "请提供不超过 30 天的有效 RFC3339 时间范围。"
+ErrorLink = "暂无"
+
+[BknBackend.OperationAudit.InvalidBeforeTime]
+Description = "操作审计分页时间无效。"
+Solution = "请提供有效的 RFC3339 before_time 参数。"
+ErrorLink = "暂无"
+
+[BknBackend.OperationAudit.MissingScope]
+Description = "缺少操作审计查询作用域。"
+Solution = "请提供租户和业务域标识。"
+ErrorLink = "暂无"
+
+[BknBackend.OperationAudit.AccessDenied]
+Description = "没有查看操作审计记录的权限。"
+Solution = "请检查访问范围或联系管理员。"
+ErrorLink = "暂无"
+
+[BknBackend.OperationAudit.ServiceUnavailable]
+Description = "操作审计服务暂时不可用。"
+Solution = "请稍后重试。"
+ErrorLink = "暂无"
+
+[BknBackend.OperationAudit.QueryFailed]
+Description = "查询操作审计记录失败。"
+Solution = "请稍后重试；如问题持续，请联系管理员。"
+ErrorLink = "暂无"
+
+[BknBackend.OperationAudit.NotFound]
+Description = "操作审计事件不存在。"
+Solution = "请检查事件标识是否正确。"
+ErrorLink = "暂无"
+
 [BknBackend.InvalidParameter.ModuleType]
 Description = "指定的模块名称无效"
 Solution = "请检查参数是否正确。"
@@ -132,4 +167,4 @@ ErrorLink = "暂无"
 [BknBackend.InternalError.UnMarshalDataFailed]
 Description = "反序列化数据时，服务器内部发生错误"
 Solution = "请重试该操作，若再次出现该错误请提交工单或联系技术支持工程师。"
-ErrorLink = "暂无" 
+ErrorLink = "暂无"


### PR DESCRIPTION
Closes #888

- Replace operation-audit raw error strings with stable BknBackend.OperationAudit.* codes.
- Add matching zh-CN/en-US resource entries and machine-readable error details.
- Cover localized range, authorization, query-failure, and not-found responses.

Validation: go test ./driveradapters -run 'Test(OperationAuditQuery|ListOperationAudits)' -count=1; go vet ./driveradapters ./errors.