### PR TITLE
fix(vega): localize operation-audit API errors

### DIFF
--- a/adp/vega/vega-backend/server/driveradapters/operation_audit_query.go
+++ b/adp/vega/vega-backend/server/driveradapters/operation_audit_query.go
@@ -19,6 +19,7 @@ import (
 	"github.com/openbkn-ai/bkn-foundry/comm-go/rest"
 
 	"vega-backend/common/operationaudit"
+	verrors "vega-backend/errors"
 	"vega-backend/interfaces"
 )
 
@@ -38,7 +39,7 @@ func (r *restHandler) ListOperationAudits(c *gin.Context) {
 		return
 	}
 	if r.auditQueryStore == nil {
-		c.JSON(http.StatusServiceUnavailable, gin.H{"error": "operation audit source is unavailable"})
+		replyOperationAuditError(c, http.StatusServiceUnavailable, verrors.VegaBackend_OperationAudit_ServiceUnavailable, nil)
 		return
 	}
 	filter := operationaudit.Filter{TenantID: strings.TrimSpace(c.GetHeader("x-tenant-id")), BusinessDomain: strings.TrimSpace(c.GetHeader(interfaces.HTTP_HEADER_BUSINESS_DOMAIN)), From: from, To: to}
@@ -48,7 +49,9 @@ func (r *restHandler) ListOperationAudits(c *gin.Context) {
 	filter.TargetID = strings.TrimSpace(c.Query("target_id"))
 	filter.Outcome = strings.TrimSpace(c.Query("outcome"))
 	if filter.TenantID == "" || filter.BusinessDomain == "" {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "x-tenant-id and x-business-domain are required"})
+		replyOperationAuditError(c, http.StatusBadRequest, verrors.VegaBackend_OperationAudit_MissingScope, gin.H{
+			"required_headers": []string{"x-tenant-id", interfaces.HTTP_HEADER_BUSINESS_DOMAIN},
+		})
 		return
 	}
 	if limit, err := strconv.Atoi(strings.TrimSpace(c.Query("limit"))); err == nil {
@@ -57,14 +60,17 @@ func (r *restHandler) ListOperationAudits(c *gin.Context) {
 	if before := strings.TrimSpace(c.Query("before_time")); before != "" {
 		parsed, err := time.Parse(time.RFC3339Nano, before)
 		if err != nil {
-			c.JSON(http.StatusBadRequest, gin.H{"error": "before_time must be RFC3339"})
+			replyOperationAuditError(c, http.StatusBadRequest, verrors.VegaBackend_OperationAudit_InvalidBeforeTime, gin.H{
+				"field":  "before_time",
+				"format": "RFC3339",
+			})
 			return
 		}
 		filter.BeforeTime, filter.BeforeEventID = parsed.UTC(), strings.TrimSpace(c.Query("before_event_id"))
 	}
 	page, err := r.auditQueryStore.List(c.Request.Context(), filter)
 	if err != nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": "operation audit query failed"})
+		replyOperationAuditError(c, http.StatusInternalServerError, verrors.VegaBackend_OperationAudit_QueryFailed, nil)
 		return
 	}
 	response := gin.H{"entries": operationAuditResponses(page.Entries), "has_more": page.HasMore}
@@ -81,21 +87,23 @@ func (r *restHandler) GetOperationAudit(c *gin.Context) {
 		return
 	}
 	if r.auditQueryStore == nil {
-		c.JSON(http.StatusServiceUnavailable, gin.H{"error": "operation audit source is unavailable"})
+		replyOperationAuditError(c, http.StatusServiceUnavailable, verrors.VegaBackend_OperationAudit_ServiceUnavailable, nil)
 		return
 	}
 	tenantID, businessDomain := strings.TrimSpace(c.GetHeader("x-tenant-id")), strings.TrimSpace(c.GetHeader(interfaces.HTTP_HEADER_BUSINESS_DOMAIN))
 	if tenantID == "" || businessDomain == "" {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "x-tenant-id and x-business-domain are required"})
+		replyOperationAuditError(c, http.StatusBadRequest, verrors.VegaBackend_OperationAudit_MissingScope, gin.H{
+			"required_headers": []string{"x-tenant-id", interfaces.HTTP_HEADER_BUSINESS_DOMAIN},
+		})
 		return
 	}
 	entry, found, err := r.auditQueryStore.Get(c.Request.Context(), strings.TrimSpace(c.Param("event_id")), tenantID, businessDomain)
 	if err != nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": "operation audit query failed"})
+		replyOperationAuditError(c, http.StatusInternalServerError, verrors.VegaBackend_OperationAudit_QueryFailed, nil)
 		return
 	}
 	if !found {
-		c.JSON(http.StatusNotFound, gin.H{"error": "operation audit event not found"})
+		replyOperationAuditError(c, http.StatusNotFound, verrors.VegaBackend_OperationAudit_NotFound, gin.H{"event_id": strings.TrimSpace(c.Param("event_id"))})
 		return
 	}
 	c.JSON(http.StatusOK, operationAuditResponse(entry))
@@ -105,7 +113,11 @@ func operationAuditRange(c *gin.Context) (time.Time, time.Time, bool) {
 	from, fromErr := time.Parse(time.RFC3339Nano, strings.TrimSpace(c.Query("from")))
 	to, toErr := time.Parse(time.RFC3339Nano, strings.TrimSpace(c.Query("to")))
 	if fromErr != nil || toErr != nil || !from.Before(to) || to.Sub(from) > maximumOperationAuditRange {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "from/to must be a valid RFC3339 range of at most 30 days"})
+		replyOperationAuditError(c, http.StatusBadRequest, verrors.VegaBackend_OperationAudit_InvalidRange, gin.H{
+			"fields":       []string{"from", "to"},
+			"format":       "RFC3339",
+			"max_duration": maximumOperationAuditRange.String(),
+		})
 		return time.Time{}, time.Time{}, false
 	}
 	return from.UTC(), to.UTC(), true
@@ -117,10 +129,18 @@ func (r *restHandler) requireOperationAuditReader(c *gin.Context) bool {
 		return false
 	}
 	if !operationAuditReader(c.Request.Context(), c.GetHeader("Authorization"), visitor.ID) {
-		c.JSON(http.StatusForbidden, gin.H{"error": "operation audit access denied"})
+		replyOperationAuditError(c, http.StatusForbidden, verrors.VegaBackend_OperationAudit_AccessDenied, nil)
 		return false
 	}
 	return true
+}
+
+func replyOperationAuditError(c *gin.Context, status int, code string, details any) {
+	err := rest.NewHTTPError(c.Request.Context(), status, code)
+	if details != nil {
+		err.WithErrorDetails(details)
+	}
+	rest.ReplyError(c, err)
 }
 
 func operationAuditReader(ctx context.Context, authorization, expectedActorID string) bool {

--- a/adp/vega/vega-backend/server/driveradapters/operation_audit_query_test.go
+++ b/adp/vega/vega-backend/server/driveradapters/operation_audit_query_test.go
@@ -1,0 +1,191 @@
+// Copyright openbkn.ai
+//
+// Licensed under the OpenBKN License. See LICENSE-OPENBKN.txt in the project root.
+
+package driveradapters
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/openbkn-ai/bkn-foundry/comm-go/hydra"
+	"github.com/openbkn-ai/bkn-foundry/comm-go/rest"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+
+	"vega-backend/common/operationaudit"
+	verrors "vega-backend/errors"
+	vmock "vega-backend/interfaces/mock"
+)
+
+type operationAuditQueryStoreStub struct {
+	found   bool
+	listErr error
+	getErr  error
+}
+
+func (s *operationAuditQueryStoreStub) List(_ context.Context, _ operationaudit.Filter) (operationaudit.Page, error) {
+	if s.listErr != nil {
+		return operationaudit.Page{}, s.listErr
+	}
+	return operationaudit.Page{}, nil
+}
+
+func (s *operationAuditQueryStoreStub) Get(_ context.Context, _ string, _, _ string) (operationaudit.Entry, bool, error) {
+	if s.getErr != nil {
+		return operationaudit.Entry{}, false, s.getErr
+	}
+	return operationaudit.Entry{}, s.found, nil
+}
+
+func TestOperationAuditErrorsAreLocalized(t *testing.T) {
+	restoreGinMode := setGinMode()
+	defer restoreGinMode()
+
+	tests := []struct {
+		name            string
+		language        string
+		path            string
+		store           operationAuditQueryStore
+		roles           []string
+		wantStatus      int
+		wantCode        string
+		wantDescription string
+	}{
+		{
+			name: "Chinese invalid range", language: "zh-CN",
+			path:  "/api/vega-backend/v1/operation-audits?from=invalid&to=2026-08-08T00:00:00Z",
+			store: &operationAuditQueryStoreStub{}, roles: []string{"audit"}, wantStatus: http.StatusBadRequest,
+			wantCode: verrors.VegaBackend_OperationAudit_InvalidRange, wantDescription: "操作审计查询时间范围无效。",
+		},
+		{
+			name: "English invalid range", language: "en-US",
+			path:  "/api/vega-backend/v1/operation-audits?from=invalid&to=2026-08-08T00:00:00Z",
+			store: &operationAuditQueryStoreStub{}, roles: []string{"audit"}, wantStatus: http.StatusBadRequest,
+			wantCode: verrors.VegaBackend_OperationAudit_InvalidRange, wantDescription: "The operation-audit time range is invalid.",
+		},
+		{
+			name: "English source unavailable", language: "en-US",
+			path:  "/api/vega-backend/v1/operation-audits?from=2026-08-01T00:00:00Z&to=2026-08-08T00:00:00Z",
+			roles: []string{"audit"}, wantStatus: http.StatusServiceUnavailable,
+			wantCode: verrors.VegaBackend_OperationAudit_ServiceUnavailable, wantDescription: "The operation-audit service is unavailable.",
+		},
+		{
+			name: "Chinese source unavailable", language: "zh-CN",
+			path:  "/api/vega-backend/v1/operation-audits?from=2026-08-01T00:00:00Z&to=2026-08-08T00:00:00Z",
+			roles: []string{"audit"}, wantStatus: http.StatusServiceUnavailable,
+			wantCode: verrors.VegaBackend_OperationAudit_ServiceUnavailable, wantDescription: "操作审计服务暂不可用。",
+		},
+		{
+			name: "Chinese invalid cursor", language: "zh-CN",
+			path:  "/api/vega-backend/v1/operation-audits?from=2026-08-01T00:00:00Z&to=2026-08-08T00:00:00Z&before_time=invalid",
+			store: &operationAuditQueryStoreStub{}, roles: []string{"audit"}, wantStatus: http.StatusBadRequest,
+			wantCode: verrors.VegaBackend_OperationAudit_InvalidBeforeTime, wantDescription: "操作审计游标时间无效。",
+		},
+		{
+			name: "English invalid cursor", language: "en-US",
+			path:  "/api/vega-backend/v1/operation-audits?from=2026-08-01T00:00:00Z&to=2026-08-08T00:00:00Z&before_time=invalid",
+			store: &operationAuditQueryStoreStub{}, roles: []string{"audit"}, wantStatus: http.StatusBadRequest,
+			wantCode: verrors.VegaBackend_OperationAudit_InvalidBeforeTime, wantDescription: "The operation-audit cursor time is invalid.",
+		},
+		{
+			name: "English query failure", language: "en-US",
+			path:  "/api/vega-backend/v1/operation-audits?from=2026-08-01T00:00:00Z&to=2026-08-08T00:00:00Z",
+			store: &operationAuditQueryStoreStub{listErr: errors.New("store unavailable")}, roles: []string{"audit"}, wantStatus: http.StatusInternalServerError,
+			wantCode: verrors.VegaBackend_OperationAudit_QueryFailed, wantDescription: "The operation-audit query failed.",
+		},
+		{
+			name: "Chinese query failure", language: "zh-CN",
+			path:  "/api/vega-backend/v1/operation-audits?from=2026-08-01T00:00:00Z&to=2026-08-08T00:00:00Z",
+			store: &operationAuditQueryStoreStub{listErr: errors.New("store unavailable")}, roles: []string{"audit"}, wantStatus: http.StatusInternalServerError,
+			wantCode: verrors.VegaBackend_OperationAudit_QueryFailed, wantDescription: "操作审计查询失败。",
+		},
+		{
+			name: "Chinese not found", language: "zh-CN", path: "/api/vega-backend/v1/operation-audits/event-missing",
+			store: &operationAuditQueryStoreStub{}, roles: []string{"audit"}, wantStatus: http.StatusNotFound,
+			wantCode: verrors.VegaBackend_OperationAudit_NotFound, wantDescription: "未找到操作审计事件。",
+		},
+		{
+			name: "English not found", language: "en-US", path: "/api/vega-backend/v1/operation-audits/event-missing",
+			store: &operationAuditQueryStoreStub{}, roles: []string{"audit"}, wantStatus: http.StatusNotFound,
+			wantCode: verrors.VegaBackend_OperationAudit_NotFound, wantDescription: "The operation-audit event was not found.",
+		},
+		{
+			name: "English access denied", language: "en-US",
+			path:  "/api/vega-backend/v1/operation-audits?from=2026-08-01T00:00:00Z&to=2026-08-08T00:00:00Z",
+			store: &operationAuditQueryStoreStub{}, roles: []string{"user"}, wantStatus: http.StatusForbidden,
+			wantCode: verrors.VegaBackend_OperationAudit_AccessDenied, wantDescription: "You are not permitted to view operation-audit records.",
+		},
+		{
+			name: "Chinese access denied", language: "zh-CN",
+			path:  "/api/vega-backend/v1/operation-audits?from=2026-08-01T00:00:00Z&to=2026-08-08T00:00:00Z",
+			store: &operationAuditQueryStoreStub{}, roles: []string{"user"}, wantStatus: http.StatusForbidden,
+			wantCode: verrors.VegaBackend_OperationAudit_AccessDenied, wantDescription: "您没有查看操作审计记录的权限。",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			handler, safeServer := newOperationAuditQueryHandler(t, test.store, test.roles)
+			defer safeServer.Close()
+			engine := gin.New()
+			engine.Use(rest.LanguageMiddleware(), rest.PrivateNoCacheMiddleware())
+			engine.GET("/api/vega-backend/v1/operation-audits", handler.ListOperationAudits)
+			engine.GET("/api/vega-backend/v1/operation-audits/:event_id", handler.GetOperationAudit)
+
+			request := httptest.NewRequest(http.MethodGet, test.path, nil)
+			request.Header.Set("Authorization", "Bearer token")
+			request.Header.Set("x-tenant-id", "tenant-a")
+			request.Header.Set("x-business-domain", "domain-a")
+			request.Header.Set(rest.AcceptLanguageHeader, test.language)
+			response := httptest.NewRecorder()
+			engine.ServeHTTP(response, request)
+
+			require.Equal(t, test.wantStatus, response.Code, response.Body.String())
+			require.Equal(t, test.language, response.Header().Get(rest.ContentLanguageHeader))
+			require.Equal(t, "private, no-cache", response.Header().Get("Cache-Control"))
+			var body struct {
+				ErrorCode    string `json:"error_code"`
+				Description  string `json:"description"`
+				ErrorDetails any    `json:"error_details"`
+			}
+			require.NoError(t, json.Unmarshal(response.Body.Bytes(), &body))
+			require.Equal(t, test.wantCode, body.ErrorCode)
+			require.Equal(t, test.wantDescription, body.Description)
+			if test.wantCode == verrors.VegaBackend_OperationAudit_InvalidRange {
+				details, ok := body.ErrorDetails.(map[string]any)
+				require.True(t, ok)
+				require.Equal(t, "RFC3339", details["format"])
+				require.Equal(t, "720h0m0s", details["max_duration"])
+			}
+		})
+	}
+}
+
+func newOperationAuditQueryHandler(t *testing.T, store operationAuditQueryStore, roles []string) (*restHandler, *httptest.Server) {
+	t.Helper()
+	controller := gomock.NewController(t)
+	t.Cleanup(controller.Finish)
+	authService := vmock.NewMockAuthService(controller)
+	authService.EXPECT().VerifyToken(gomock.Any(), gomock.Any()).AnyTimes().Return(hydra.Visitor{ID: "user-a", Type: hydra.VisitorType_User}, nil)
+	safeServer := httptest.NewServer(http.HandlerFunc(func(response http.ResponseWriter, request *http.Request) {
+		require.Equal(t, "/api/safe/v1/me", request.URL.Path)
+		require.Equal(t, "Bearer token", request.Header.Get("Authorization"))
+		response.Header().Set("Content-Type", "application/json")
+		_, _ = response.Write([]byte(`{"ID":"user-a","Enabled":true,"Roles":` + mustJSON(t, roles) + `}`))
+	}))
+	t.Setenv("BKN_SAFE_URL", safeServer.URL)
+	return &restHandler{as: authService, auditQueryStore: store}, safeServer
+}
+
+func mustJSON(t *testing.T, value any) string {
+	t.Helper()
+	encoded, err := json.Marshal(value)
+	require.NoError(t, err)
+	return string(encoded)
+}

--- a/adp/vega/vega-backend/server/errors/error_code.go
+++ b/adp/vega/vega-backend/server/errors/error_code.go
@@ -51,6 +51,15 @@ const (
 	VegaBackend_InternalError_DeleteResourcesFailed   = "VegaBackend.InternalError.DeleteResourcesFailed"
 	VegaBackend_InternalError_FilterResourcesFailed   = "VegaBackend.InternalError.FilterResourcesFailed"
 	VegaBackend_InternalError_UpdateResourceFailed    = "VegaBackend.InternalError.UpdateResourceFailed"
+
+	// Operation audit query
+	VegaBackend_OperationAudit_InvalidRange       = "VegaBackend.OperationAudit.InvalidRange"
+	VegaBackend_OperationAudit_InvalidBeforeTime  = "VegaBackend.OperationAudit.InvalidBeforeTime"
+	VegaBackend_OperationAudit_MissingScope       = "VegaBackend.OperationAudit.MissingScope"
+	VegaBackend_OperationAudit_AccessDenied       = "VegaBackend.OperationAudit.AccessDenied"
+	VegaBackend_OperationAudit_ServiceUnavailable = "VegaBackend.OperationAudit.ServiceUnavailable"
+	VegaBackend_OperationAudit_QueryFailed        = "VegaBackend.OperationAudit.QueryFailed"
+	VegaBackend_OperationAudit_NotFound           = "VegaBackend.OperationAudit.NotFound"
 )
 
 var (
@@ -91,6 +100,15 @@ var (
 		VegaBackend_InternalError_DeleteResourcesFailed,
 		VegaBackend_InternalError_FilterResourcesFailed,
 		VegaBackend_InternalError_UpdateResourceFailed,
+
+		// Operation audit query
+		VegaBackend_OperationAudit_InvalidRange,
+		VegaBackend_OperationAudit_InvalidBeforeTime,
+		VegaBackend_OperationAudit_MissingScope,
+		VegaBackend_OperationAudit_AccessDenied,
+		VegaBackend_OperationAudit_ServiceUnavailable,
+		VegaBackend_OperationAudit_QueryFailed,
+		VegaBackend_OperationAudit_NotFound,
 	}
 )
 

--- a/adp/vega/vega-backend/server/locale/errorcode.en-US.toml
+++ b/adp/vega/vega-backend/server/locale/errorcode.en-US.toml
@@ -285,7 +285,7 @@ ErrorLink = "None"
 
 [VegaBackend.OperationAudit.AccessDenied]
 Description = "You are not permitted to view operation-audit records."
-Solution = "Request an administrator, audit, or super_admin role."
+Solution = "Request an admin, audit, or super_admin role."
 ErrorLink = "None"
 
 [VegaBackend.OperationAudit.ServiceUnavailable]

--- a/adp/vega/vega-backend/server/locale/errorcode.en-US.toml
+++ b/adp/vega/vega-backend/server/locale/errorcode.en-US.toml
@@ -268,3 +268,37 @@ ErrorLink = "None"
 Description = "Too many extension filter pairs"
 Solution = "Reduce the number of filter pairs"
 ErrorLink = "None"
+[VegaBackend.OperationAudit.InvalidRange]
+Description = "The operation-audit time range is invalid."
+Solution = "Provide a valid RFC3339 time range no longer than 30 days."
+ErrorLink = "None"
+
+[VegaBackend.OperationAudit.InvalidBeforeTime]
+Description = "The operation-audit cursor time is invalid."
+Solution = "Provide before_time in RFC3339 format."
+ErrorLink = "None"
+
+[VegaBackend.OperationAudit.MissingScope]
+Description = "The operation-audit scope is incomplete."
+Solution = "Provide x-tenant-id and x-business-domain headers."
+ErrorLink = "None"
+
+[VegaBackend.OperationAudit.AccessDenied]
+Description = "You are not permitted to view operation-audit records."
+Solution = "Request an administrator, audit, or super_admin role."
+ErrorLink = "None"
+
+[VegaBackend.OperationAudit.ServiceUnavailable]
+Description = "The operation-audit service is unavailable."
+Solution = "Try again later."
+ErrorLink = "None"
+
+[VegaBackend.OperationAudit.QueryFailed]
+Description = "The operation-audit query failed."
+Solution = "Try again later or contact an administrator."
+ErrorLink = "None"
+
+[VegaBackend.OperationAudit.NotFound]
+Description = "The operation-audit event was not found."
+Solution = "Check the event_id and scope."
+ErrorLink = "None"

--- a/adp/vega/vega-backend/server/locale/errorcode.zh-CN.toml
+++ b/adp/vega/vega-backend/server/locale/errorcode.zh-CN.toml
@@ -268,3 +268,37 @@ ErrorLink = "暂无"
 Description = "扩展筛选条件组数超过上限"
 Solution = "请减少筛选组数"
 ErrorLink = "暂无"
+[VegaBackend.OperationAudit.InvalidRange]
+Description = "操作审计查询时间范围无效。"
+Solution = "请提供不超过 30 天的有效 RFC3339 时间范围。"
+ErrorLink = "暂无"
+
+[VegaBackend.OperationAudit.InvalidBeforeTime]
+Description = "操作审计游标时间无效。"
+Solution = "请使用 RFC3339 格式提供 before_time。"
+ErrorLink = "暂无"
+
+[VegaBackend.OperationAudit.MissingScope]
+Description = "操作审计查询范围不完整。"
+Solution = "请提供 x-tenant-id 和 x-business-domain 请求头。"
+ErrorLink = "暂无"
+
+[VegaBackend.OperationAudit.AccessDenied]
+Description = "您没有查看操作审计记录的权限。"
+Solution = "请申请 administrator、audit 或 super_admin 角色。"
+ErrorLink = "暂无"
+
+[VegaBackend.OperationAudit.ServiceUnavailable]
+Description = "操作审计服务暂不可用。"
+Solution = "请稍后重试。"
+ErrorLink = "暂无"
+
+[VegaBackend.OperationAudit.QueryFailed]
+Description = "操作审计查询失败。"
+Solution = "请稍后重试或联系管理员。"
+ErrorLink = "暂无"
+
+[VegaBackend.OperationAudit.NotFound]
+Description = "未找到操作审计事件。"
+Solution = "请检查 event_id 和查询范围。"
+ErrorLink = "暂无"


### PR DESCRIPTION
## Summary
- replace Vega operation-audit hardcoded error payloads with registered stable error codes
- add complete zh-CN/en-US resources and preserve machine-readable diagnostics in error_details
- cover BKN Safe authorization outcomes plus bilingual error, language-header, and cache-policy regression cases

## Validation
- `cd adp/vega/vega-backend/server && go test ./driveradapters ./errors ./locale`
- `cd adp/vega/vega-backend/server && go vet ./driveradapters ./errors ./locale`
- `git diff --check`

Closes #889