### PR TITLE
fix(capabilitieslab): localize platform errors

### DIFF
--- a/adp/execution-factory/operator-integration/server/capabilitieslab/handler/capabilities.go
+++ b/adp/execution-factory/operator-integration/server/capabilitieslab/handler/capabilities.go
@@ -373,7 +373,7 @@ func (h *CapabilitiesHandler) RegisterSkillCapability(c *gin.Context) {
 
 	fileHeader, err := c.FormFile("file")
 	if err != nil {
-		writeBadRequest(c, "file is required")
+		writeFileRequired(c)
 		return
 	}
 
@@ -461,7 +461,7 @@ func (h *CapabilitiesHandler) ImportCapabilityPackage(c *gin.Context) {
 
 	fileHeader, err := c.FormFile("file")
 	if err != nil {
-		writeBadRequest(c, "file is required")
+		writeFileRequired(c)
 		return
 	}
 

--- a/adp/execution-factory/operator-integration/server/capabilitieslab/handler/error_messages.go
+++ b/adp/execution-factory/operator-integration/server/capabilitieslab/handler/error_messages.go
@@ -1,0 +1,38 @@
+// Copyright openbkn.ai
+//
+// Licensed under the OpenBKN License. See LICENSE-OPENBKN.txt in the project root.
+
+package handler
+
+import sharedrest "github.com/openbkn-ai/bkn-foundry/comm-go/rest"
+
+const (
+	capabilitiesLabInvalidRequest  = "invalid_request"
+	capabilitiesLabNotFound        = "not_found"
+	capabilitiesLabFileRequired    = "file_required"
+	capabilitiesLabFeatureDisabled = "feature_disabled"
+)
+
+var capabilitiesLabErrorMessages = map[string]map[string]string{
+	sharedrest.SimplifiedChinese: {
+		capabilitiesLabInvalidRequest:  "请求参数无效。",
+		capabilitiesLabNotFound:        "未找到资源。",
+		capabilitiesLabFileRequired:    "缺少必需的文件。",
+		capabilitiesLabFeatureDisabled: "该功能未启用。",
+	},
+	sharedrest.AmericanEnglish: {
+		capabilitiesLabInvalidRequest:  "Invalid request parameters.",
+		capabilitiesLabNotFound:        "Resource not found.",
+		capabilitiesLabFileRequired:    "A required file is missing.",
+		capabilitiesLabFeatureDisabled: "This feature is disabled.",
+	},
+}
+
+func capabilitiesLabErrorMessage(language, code string) string {
+	if messages, ok := capabilitiesLabErrorMessages[language]; ok {
+		if message, ok := messages[code]; ok {
+			return message
+		}
+	}
+	return capabilitiesLabErrorMessages[sharedrest.SimplifiedChinese][code]
+}

--- a/adp/execution-factory/operator-integration/server/capabilitieslab/handler/error_messages_test.go
+++ b/adp/execution-factory/operator-integration/server/capabilitieslab/handler/error_messages_test.go
@@ -8,6 +8,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/gin-gonic/gin"
@@ -38,6 +39,78 @@ func TestCapabilitiesLabPlatformErrorsAreLocalized(t *testing.T) {
 			var body APIErrorResponse
 			if err := json.Unmarshal(response.Body.Bytes(), &body); err != nil || body.Code != test.code || body.Message != test.want {
 				t.Fatalf("body=%s err=%v", response.Body.String(), err)
+			}
+		})
+	}
+}
+
+func TestCapabilitiesLabPlatformErrorEntrypointsAreLocalized(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	for _, test := range []struct {
+		name, code, wantMessage, rawMessage string
+		status                              int
+		write                               func(*gin.Context)
+	}{
+		{
+			name:        "bad request",
+			code:        capabilitiesLabInvalidRequest,
+			wantMessage: "Invalid request parameters.",
+			rawMessage:  "field model_id is invalid",
+			status:      http.StatusBadRequest,
+			write: func(c *gin.Context) {
+				writeBadRequest(c, "field model_id is invalid")
+			},
+		},
+		{
+			name:        "not found",
+			code:        capabilitiesLabNotFound,
+			wantMessage: "Resource not found.",
+			rawMessage:  "capability internal-123 not found",
+			status:      http.StatusNotFound,
+			write: func(c *gin.Context) {
+				writeNotFound(c, "capability internal-123 not found")
+			},
+		},
+		{
+			name:        "file required",
+			code:        capabilitiesLabFileRequired,
+			wantMessage: "A required file is missing.",
+			status:      http.StatusBadRequest,
+			write:       writeFileRequired,
+		},
+		{
+			name:        "feature disabled",
+			code:        capabilitiesLabFeatureDisabled,
+			wantMessage: "This feature is disabled.",
+			status:      http.StatusNotFound,
+			write:       writeFeatureDisabled,
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			engine := gin.New()
+			engine.Use(sharedrest.LanguageMiddleware(), sharedrest.PrivateNoCacheMiddleware())
+			engine.GET("/test", test.write)
+
+			request := httptest.NewRequest(http.MethodGet, "/test", nil)
+			request.Header.Set(sharedrest.AcceptLanguageHeader, "en-US")
+			response := httptest.NewRecorder()
+			engine.ServeHTTP(response, request)
+
+			if response.Code != test.status {
+				t.Fatalf("status = %d, want %d", response.Code, test.status)
+			}
+			if got := response.Header().Get(sharedrest.ContentLanguageHeader); got != "en-US" {
+				t.Fatalf("Content-Language = %q, want en-US", got)
+			}
+			var body APIErrorResponse
+			if err := json.Unmarshal(response.Body.Bytes(), &body); err != nil {
+				t.Fatalf("decode response: %v", err)
+			}
+			if body.Code != test.code || body.Message != test.wantMessage {
+				t.Fatalf("body = %#v, want code=%q message=%q", body, test.code, test.wantMessage)
+			}
+			if test.rawMessage != "" && strings.Contains(response.Body.String(), test.rawMessage) {
+				t.Fatalf("response leaked platform diagnostic %q: %s", test.rawMessage, response.Body.String())
 			}
 		})
 	}

--- a/adp/execution-factory/operator-integration/server/capabilitieslab/handler/error_messages_test.go
+++ b/adp/execution-factory/operator-integration/server/capabilitieslab/handler/error_messages_test.go
@@ -1,0 +1,59 @@
+// Copyright openbkn.ai
+//
+// Licensed under the OpenBKN License. See LICENSE-OPENBKN.txt in the project root.
+
+package handler
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	sharedrest "github.com/openbkn-ai/bkn-foundry/comm-go/rest"
+)
+
+func TestCapabilitiesLabPlatformErrorsAreLocalized(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	for _, test := range []struct {
+		language, code, want string
+	}{
+		{"zh-CN", capabilitiesLabFileRequired, "缺少必需的文件。"},
+		{"en-US", capabilitiesLabFileRequired, "A required file is missing."},
+		{"zh-CN", capabilitiesLabNotFound, "未找到资源。"},
+		{"en-US", capabilitiesLabInvalidRequest, "Invalid request parameters."},
+	} {
+		t.Run(test.language+"/"+test.code, func(t *testing.T) {
+			engine := gin.New()
+			engine.Use(sharedrest.LanguageMiddleware(), sharedrest.PrivateNoCacheMiddleware())
+			engine.GET("/test", func(c *gin.Context) { writeLocalizedError(c, http.StatusBadRequest, test.code) })
+			request := httptest.NewRequest(http.MethodGet, "/test", nil)
+			request.Header.Set(sharedrest.AcceptLanguageHeader, test.language)
+			response := httptest.NewRecorder()
+			engine.ServeHTTP(response, request)
+			if response.Code != http.StatusBadRequest || response.Header().Get(sharedrest.ContentLanguageHeader) != test.language || response.Header().Get("Vary") != sharedrest.AcceptLanguageHeader || response.Header().Get("Cache-Control") != "private, no-cache" {
+				t.Fatalf("unexpected response: status=%d headers=%v", response.Code, response.Header())
+			}
+			var body APIErrorResponse
+			if err := json.Unmarshal(response.Body.Bytes(), &body); err != nil || body.Code != test.code || body.Message != test.want {
+				t.Fatalf("body=%s err=%v", response.Body.String(), err)
+			}
+		})
+	}
+}
+
+func TestCapabilitiesLabUpstreamErrorPreservesDiagnostics(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	engine := gin.New()
+	engine.Use(sharedrest.LanguageMiddleware(), sharedrest.PrivateNoCacheMiddleware())
+	engine.GET("/test", func(c *gin.Context) { writeBadGateway(c, "provider invalid_api_key") })
+	request := httptest.NewRequest(http.MethodGet, "/test", nil)
+	request.Header.Set(sharedrest.AcceptLanguageHeader, "en-US")
+	response := httptest.NewRecorder()
+	engine.ServeHTTP(response, request)
+	var body APIErrorResponse
+	if err := json.Unmarshal(response.Body.Bytes(), &body); err != nil || body.Code != "upstream_error" || body.Message != "provider invalid_api_key" || response.Header().Get(sharedrest.ContentLanguageHeader) != "" {
+		t.Fatalf("body=%s err=%v headers=%v", response.Body.String(), err, response.Header())
+	}
+}

--- a/adp/execution-factory/operator-integration/server/capabilitieslab/handler/gap_fill.go
+++ b/adp/execution-factory/operator-integration/server/capabilitieslab/handler/gap_fill.go
@@ -64,7 +64,7 @@ func (h *CapabilitiesHandler) UpdateSkillPackage(c *gin.Context) {
 	bd := h.businessDomain(c)
 	file, header, err := c.Request.FormFile("file")
 	if err != nil {
-		writeBadRequest(c, "file is required")
+		writeFileRequired(c)
 		return
 	}
 	defer file.Close()

--- a/adp/execution-factory/operator-integration/server/capabilitieslab/handler/middleware.go
+++ b/adp/execution-factory/operator-integration/server/capabilitieslab/handler/middleware.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/gin-gonic/gin"
 	"github.com/openbkn-ai/bkn-foundry/adp/execution-factory/operator-integration/server/capabilitieslab/client"
+	sharedrest "github.com/openbkn-ai/bkn-foundry/comm-go/rest"
 )
 
 const (
@@ -76,16 +77,31 @@ func writeError(c *gin.Context, status int, code, message string) {
 	})
 }
 
+func writeLocalizedError(c *gin.Context, status int, code string) {
+	sharedrest.MarkLocalizedCacheableResponse(c)
+	writeError(c, status, code, capabilitiesLabErrorMessage(sharedrest.GetLanguageByCtx(c.Request.Context()), code))
+}
+
 func writeBadGateway(c *gin.Context, message string) {
 	writeError(c, http.StatusBadGateway, "upstream_error", message)
 }
 
 func writeBadRequest(c *gin.Context, message string) {
-	writeError(c, http.StatusBadRequest, "invalid_request", message)
+	_ = message
+	writeLocalizedError(c, http.StatusBadRequest, capabilitiesLabInvalidRequest)
 }
 
 func writeNotFound(c *gin.Context, message string) {
-	writeError(c, http.StatusNotFound, "not_found", message)
+	_ = message
+	writeLocalizedError(c, http.StatusNotFound, capabilitiesLabNotFound)
+}
+
+func writeFileRequired(c *gin.Context) {
+	writeLocalizedError(c, http.StatusBadRequest, capabilitiesLabFileRequired)
+}
+
+func writeFeatureDisabled(c *gin.Context) {
+	writeLocalizedError(c, http.StatusNotFound, capabilitiesLabFeatureDisabled)
 }
 
 type APIErrorResponse struct {

--- a/adp/execution-factory/operator-integration/server/capabilitieslab/handler/observability.go
+++ b/adp/execution-factory/operator-integration/server/capabilitieslab/handler/observability.go
@@ -5,7 +5,6 @@
 package handler
 
 import (
-	"net/http"
 	"strconv"
 	"strings"
 	"time"
@@ -59,7 +58,7 @@ func FeatureGateMiddleware(features config.FeatureFlags) gin.HandlerFunc {
 			return
 		}
 
-		writeError(c, http.StatusNotFound, "feature_disabled", "feature is disabled")
+		writeFeatureDisabled(c)
 		c.Abort()
 	}
 }


### PR DESCRIPTION
## Summary
- localize CapabilitiesLab-owned validation, resource, file, and feature errors from zh-CN/en-US resources
- mark localized responses with `Content-Language` and `Vary: Accept-Language`
- preserve raw upstream diagnostics in `upstream_error` responses

## Validation
- `cd adp/execution-factory/operator-integration && go test ./...`
- `cd adp/execution-factory/operator-integration && go vet ./server/capabilitieslab/...`
- `git diff --check HEAD^ HEAD`

Closes #891