### PR TITLE
feat(comm-go): externalize public error catalogs

### DIFF
--- a/comm-go/i18n/i18n.go
+++ b/comm-go/i18n/i18n.go
@@ -174,7 +174,7 @@ func normalizeLocale(raw string) string {
 func flattenMessages(messages map[string]*Message, messageID string, raw interface{}) error {
 	switch value := raw.(type) {
 	case string:
-		if value == "" {
+		if value == "" && !strings.HasSuffix(messageID, ".ErrorLink") {
 			return fmt.Errorf("messageId %s is an empty string", messageID)
 		}
 		if _, ok := messages[messageID]; ok {

--- a/comm-go/i18n/i18n_test.go
+++ b/comm-go/i18n/i18n_test.go
@@ -47,6 +47,29 @@ func TestValidateLocaleDirRequiresDeclaredLocales(t *testing.T) {
 	}
 }
 
+func TestValidateLocaleDirAllowsOnlyEmptyErrorLink(t *testing.T) {
+	dir := writeLocaleFiles(t, map[string]string{
+		"errors.zh-CN.toml": "[Error]\nDescription = '请求失败'\nSolution = '请重试'\nErrorLink = ''\n",
+		"errors.en-US.toml": "[Error]\nDescription = 'Request failed'\nSolution = 'Try again'\nErrorLink = ''\n",
+	})
+
+	if err := ValidateLocaleDir(dir, "zh-CN", "zh-CN", "en-US"); err != nil {
+		t.Fatalf("expected an empty ErrorLink to be allowed, got %v", err)
+	}
+}
+
+func TestValidateLocaleDirRejectsEmptyRequiredMessage(t *testing.T) {
+	dir := writeLocaleFiles(t, map[string]string{
+		"errors.zh-CN.toml": "[Error]\nDescription = ''\nSolution = '请重试'\nErrorLink = ''\n",
+		"errors.en-US.toml": "[Error]\nDescription = ''\nSolution = 'Try again'\nErrorLink = ''\n",
+	})
+
+	err := ValidateLocaleDir(dir, "zh-CN", "zh-CN", "en-US")
+	if err == nil || !strings.Contains(err.Error(), "Error.Description is an empty string") {
+		t.Fatalf("expected an empty description to be rejected, got %v", err)
+	}
+}
+
 func TestTranslateFallsBackWithoutFatal(t *testing.T) {
 	dir := writeLocaleFiles(t, map[string]string{
 		"errors.zh-CN.toml": "[Error]\nDescription = '请求失败：{{ .name }}'\nSolution = '请重试'\n",

--- a/comm-go/rest/common_errors.go
+++ b/comm-go/rest/common_errors.go
@@ -6,9 +6,16 @@
 
 package rest
 
-// 系统默认错误
+import (
+	_ "embed"
+
+	"github.com/BurntSushi/toml"
+
+	"github.com/openbkn-ai/bkn-foundry/comm-go/logger"
+)
+
+// System default error codes.
 const (
-	// 公共错误码
 	PublicError_BadRequest          = "Public.BadRequest"
 	PublicError_Unauthorized        = "Public.Unauthorized"
 	PublicError_Forbidden           = "Public.Forbidden"
@@ -20,133 +27,80 @@ const (
 	PublicError_ServiceUnavailable  = "Public.ServiceUnavailable"
 )
 
-var (
-	PublicErrorI18n = map[string]map[string]BaseError{
-		PublicError_BadRequest: {
-			"zh-CN": {
-				ErrorCode:   PublicError_BadRequest,
-				Description: "参数错误",
-				Solution:    "暂无",
-				ErrorLink:   "暂无",
-			},
-			"en-US": {
-				ErrorCode:   PublicError_BadRequest,
-				Description: "bad request",
-				Solution:    "None",
-				ErrorLink:   "None",
-			},
-		},
-		PublicError_Unauthorized: {
-			"zh-CN": {
-				ErrorCode:   PublicError_Unauthorized,
-				Description: "认证失败",
-				Solution:    "暂无",
-				ErrorLink:   "暂无",
-			},
-			"en-US": {
-				ErrorCode:   PublicError_Unauthorized,
-				Description: "authorized failed",
-				Solution:    "None",
-				ErrorLink:   "None",
-			},
-		},
-		PublicError_Forbidden: {
-			"zh-CN": {
-				ErrorCode:   PublicError_Forbidden,
-				Description: "权限错误",
-				Solution:    "暂无",
-				ErrorLink:   "暂无",
-			},
-			"en-US": {
-				ErrorCode:   PublicError_Forbidden,
-				Description: "permission error",
-				Solution:    "None",
-				ErrorLink:   "None",
-			},
-		},
-		PublicError_NotFound: {
-			"zh-CN": {
-				ErrorCode:   PublicError_NotFound,
-				Description: "对象不存在",
-				Solution:    "暂无",
-				ErrorLink:   "暂无",
-			},
-			"en-US": {
-				ErrorCode:   PublicError_NotFound,
-				Description: "not found",
-				Solution:    "None",
-				ErrorLink:   "None",
-			},
-		},
-		PublicError_MethodNotAllowed: {
-			"zh-CN": {
-				ErrorCode:   PublicError_MethodNotAllowed,
-				Description: "不支持的mtehod方法",
-				Solution:    "暂无",
-				ErrorLink:   "暂无",
-			},
-			"en-US": {
-				ErrorCode:   PublicError_MethodNotAllowed,
-				Description: "method not allowed",
-				Solution:    "None",
-				ErrorLink:   "None",
-			},
-		},
-		PublicError_Conflict: {
-			"zh-CN": {
-				ErrorCode:   PublicError_Conflict,
-				Description: "资源冲突",
-				Solution:    "暂无",
-				ErrorLink:   "暂无",
-			},
-			"en-US": {
-				ErrorCode:   PublicError_Conflict,
-				Description: "conflict",
-				Solution:    "None",
-				ErrorLink:   "None",
-			},
-		},
-		PublicError_InternalServerError: {
-			"zh-CN": {
-				ErrorCode:   PublicError_InternalServerError,
-				Description: "内部错误",
-				Solution:    "暂无",
-				ErrorLink:   "暂无",
-			},
-			"en-US": {
-				ErrorCode:   PublicError_InternalServerError,
-				Description: "internal server error",
-				Solution:    "None",
-				ErrorLink:   "None",
-			},
-		},
-		PublicError_NotImplemented: {
-			"zh-CN": {
-				ErrorCode:   PublicError_NotImplemented,
-				Description: "服务端未实现请求方法",
-				Solution:    "暂无",
-				ErrorLink:   "暂无",
-			},
-			"en-US": {
-				ErrorCode:   PublicError_NotImplemented,
-				Description: "not implemented",
-				Solution:    "None",
-				ErrorLink:   "None",
-			},
-		},
-		PublicError_ServiceUnavailable: {
-			"zh-CN": {
-				ErrorCode:   PublicError_ServiceUnavailable,
-				Description: "服务端暂时不可用",
-				Solution:    "暂无",
-				ErrorLink:   "暂无",
-			},
-			"en-US": {
-				ErrorCode:   PublicError_ServiceUnavailable,
-				Description: "service unavailable",
-				Solution:    "None",
-				ErrorLink:   "None",
-			},
-		},
+var publicErrorCodes = []string{
+	PublicError_BadRequest,
+	PublicError_Unauthorized,
+	PublicError_Forbidden,
+	PublicError_NotFound,
+	PublicError_MethodNotAllowed,
+	PublicError_Conflict,
+	PublicError_InternalServerError,
+	PublicError_NotImplemented,
+	PublicError_ServiceUnavailable,
+}
+
+var publicErrorLocales = []Language{SimplifiedChinese, AmericanEnglish}
+
+//go:embed locales/public-errors.zh-CN.toml
+var publicErrorsChinese []byte
+
+//go:embed locales/public-errors.en-US.toml
+var publicErrorsEnglish []byte
+
+type publicErrorMessage struct {
+	Description string
+	Solution    string
+	ErrorLink   string
+}
+
+// PublicErrorI18n is loaded from resources embedded in comm-go. Embedding keeps
+// the public HTTP error catalog available in every consumer image.
+var PublicErrorI18n = loadPublicErrorI18n()
+
+func loadPublicErrorI18n() map[string]map[string]BaseError {
+	resources := map[Language][]byte{
+		SimplifiedChinese: publicErrorsChinese,
+		AmericanEnglish:   publicErrorsEnglish,
 	}
-)
+	parsed := make(map[Language]map[string]publicErrorMessage, len(resources))
+	for lang, contents := range resources {
+		messages := make(map[string]publicErrorMessage)
+		if err := toml.Unmarshal(contents, &messages); err != nil {
+			logger.Warnf("load embedded public error locale %s: %v", lang, err)
+			continue
+		}
+		parsed[lang] = messages
+	}
+
+	errors := make(map[string]map[string]BaseError, len(publicErrorCodes))
+	for _, code := range publicErrorCodes {
+		errors[code] = make(map[string]BaseError, len(publicErrorLocales))
+		for _, lang := range publicErrorLocales {
+			message, ok := parsed[lang][code]
+			if !ok || message.Description == "" || message.Solution == "" {
+				logger.Warnf("embedded public error locale missing message: locale=%s error_code=%s", lang, code)
+				message = fallbackPublicError(lang)
+			}
+			errors[code][lang] = BaseError{
+				ErrorCode:   code,
+				Description: message.Description,
+				Solution:    message.Solution,
+				ErrorLink:   message.ErrorLink,
+			}
+		}
+	}
+	return errors
+}
+
+func fallbackPublicError(lang Language) publicErrorMessage {
+	if lang == AmericanEnglish {
+		return publicErrorMessage{
+			Description: "Request failed.",
+			Solution:    "See the request details or contact an administrator.",
+		}
+	}
+	return publicErrorMessage{
+		Description: "请求失败。",
+		Solution:    "请查看请求详情或联系管理员。",
+	}
+}

--- a/comm-go/rest/common_errors_test.go
+++ b/comm-go/rest/common_errors_test.go
@@ -1,0 +1,40 @@
+// Copyright openbkn.ai
+//
+// Licensed under the OpenBKN License. See LICENSE-OPENBKN.txt in the project root.
+
+package rest
+
+import "testing"
+
+func TestEmbeddedPublicErrorsContainBothLocales(t *testing.T) {
+	for _, code := range publicErrorCodes {
+		messages, ok := PublicErrorI18n[code]
+		if !ok {
+			t.Fatalf("missing public error code %s", code)
+		}
+		for _, lang := range []Language{SimplifiedChinese, AmericanEnglish} {
+			message, ok := messages[lang]
+			if !ok {
+				t.Fatalf("missing locale %s for %s", lang, code)
+			}
+			if message.Description == "" || message.Solution == "" {
+				t.Fatalf("incomplete message for %s in %s: %#v", code, lang, message)
+			}
+			if message.ErrorLink != "" {
+				t.Fatalf("ErrorLink for %s in %s = %q, want empty", code, lang, message.ErrorLink)
+			}
+		}
+	}
+}
+
+func TestPublicHTTPErrorUsesEmbeddedLocaleMessage(t *testing.T) {
+	for _, lang := range []Language{SimplifiedChinese, AmericanEnglish} {
+		err := NewHTTPError(WithLanguage(t.Context(), lang), 400, PublicError_BadRequest)
+		if err == nil || err.BaseError.ErrorLink != "" {
+			t.Fatalf("unexpected public error for %s: %#v", lang, err)
+		}
+		if err.BaseError.Description != PublicErrorI18n[PublicError_BadRequest][lang].Description {
+			t.Fatalf("description for %s = %q", lang, err.BaseError.Description)
+		}
+	}
+}

--- a/comm-go/rest/locales/public-errors.en-US.toml
+++ b/comm-go/rest/locales/public-errors.en-US.toml
@@ -1,0 +1,48 @@
+# Copyright openbkn.ai
+#
+# Licensed under the OpenBKN License. See LICENSE-OPENBKN.txt in the project root.
+
+["Public.BadRequest"]
+Description = "Invalid request parameters."
+Solution = "Check the request parameters and try again."
+ErrorLink = ""
+
+["Public.Unauthorized"]
+Description = "Authentication failed."
+Solution = "Provide valid authentication credentials."
+ErrorLink = ""
+
+["Public.Forbidden"]
+Description = "You do not have permission to perform this operation."
+Solution = "Contact an administrator to obtain the required permission."
+ErrorLink = ""
+
+["Public.NotFound"]
+Description = "The requested resource was not found."
+Solution = "Check that the resource identifier is correct."
+ErrorLink = ""
+
+["Public.MethodNotAllowed"]
+Description = "The request method is not supported."
+Solution = "Use a request method supported by this API."
+ErrorLink = ""
+
+["Public.Conflict"]
+Description = "The request conflicts with the current resource state."
+Solution = "Refresh the resource state and try again."
+ErrorLink = ""
+
+["Public.InternalServerError"]
+Description = "An internal server error occurred."
+Solution = "Try again later."
+ErrorLink = ""
+
+["Public.NotImplemented"]
+Description = "The server does not implement this request."
+Solution = "Confirm the API capability and try again."
+ErrorLink = ""
+
+["Public.ServiceUnavailable"]
+Description = "The service is temporarily unavailable."
+Solution = "Try again later."
+ErrorLink = ""

--- a/comm-go/rest/locales/public-errors.zh-CN.toml
+++ b/comm-go/rest/locales/public-errors.zh-CN.toml
@@ -1,0 +1,48 @@
+# Copyright openbkn.ai
+#
+# Licensed under the OpenBKN License. See LICENSE-OPENBKN.txt in the project root.
+
+["Public.BadRequest"]
+Description = "请求参数无效。"
+Solution = "请检查请求参数后重试。"
+ErrorLink = ""
+
+["Public.Unauthorized"]
+Description = "认证失败。"
+Solution = "请提供有效的认证凭据。"
+ErrorLink = ""
+
+["Public.Forbidden"]
+Description = "没有执行此操作的权限。"
+Solution = "请联系管理员授予所需权限。"
+ErrorLink = ""
+
+["Public.NotFound"]
+Description = "请求的资源不存在。"
+Solution = "请检查资源标识是否正确。"
+ErrorLink = ""
+
+["Public.MethodNotAllowed"]
+Description = "不支持当前请求方法。"
+Solution = "请使用接口支持的请求方法。"
+ErrorLink = ""
+
+["Public.Conflict"]
+Description = "请求与当前资源状态冲突。"
+Solution = "请刷新资源状态后重试。"
+ErrorLink = ""
+
+["Public.InternalServerError"]
+Description = "服务内部错误。"
+Solution = "请稍后重试。"
+ErrorLink = ""
+
+["Public.NotImplemented"]
+Description = "服务端未实现该请求。"
+Solution = "请确认接口能力后重试。"
+ErrorLink = ""
+
+["Public.ServiceUnavailable"]
+Description = "服务暂时不可用。"
+Solution = "请稍后重试。"
+ErrorLink = ""


### PR DESCRIPTION
## Summary
- move comm-go public HTTP error text from Go maps into embedded TOML catalogs
- standardize absent ErrorLink as an empty string while retaining the response field
- allow only ErrorLink entries to be empty during strict locale validation
- add resource and public-error regression coverage

Closes #902.

## Verification
- `go test ./i18n ./rest` in `comm-go`
- `go test ./...` reaches unrelated database driver tests but requires MYSQL_TEST_PORT, DM_TEST_PORT, and KDB_TEST_PORT in this environment