### PR TITLE
feat(comm-go): externalize public error catalogs

### DIFF
--- a/comm-go/audit/audit.go
+++ b/comm-go/audit/audit.go
@@ -23,33 +23,33 @@ import (
 )
 
 var (
-	MAX_PRODUCER_RETRY              = 5               // 重试次数
-	NET_MAX_OPEN_REQUESTS           = 1               // 设置为 1, 确保某一时刻只能发送一个请求, 避免因为 retry 导致的消息乱序
-	RECOVER_AUDIT_PRODUCER_INTERVAL = 2 * time.Minute //时间间隔
+	MAX_PRODUCER_RETRY              = 5               // Maximum retry count.
+	NET_MAX_OPEN_REQUESTS           = 1               // Preserve message order by allowing one in-flight request.
+	RECOVER_AUDIT_PRODUCER_INTERVAL = 2 * time.Minute // Recovery retry interval.
 
-	// 日志类型
-	LOGIN      = "login"      // 登录
-	OPERATION  = "operation"  // 操作
-	MANAGEMENT = "management" // 管理
+	// Audit log types.
+	LOGIN      = "login"      // Login.
+	OPERATION  = "operation"  // Operation.
+	MANAGEMENT = "management" // Management.
 
-	// 日志级别
-	INFO = "INFO" // 信息
-	WARN = "WARN" // 警告
+	// Audit log levels.
+	INFO = "INFO" // Informational.
+	WARN = "WARN" // Warning.
 
-	// 日志状态
-	SUCCESS = "success" // 成功
-	FAILED  = "failed"  // 失败
+	// Audit log statuses.
+	SUCCESS = "success" // Success.
+	FAILED  = "failed"  // Failure.
 
-	// 操作类型
-	CREATE   = "create"   // 新建
-	DELETE   = "delete"   // 删除
-	UPDATE   = "update"   // 修改
-	START    = "start"    // 开始
-	STOP     = "stop"     // 停止
-	PAUSE    = "pause"    // 暂停
-	ROLLOVER = "rollover" // 轮转
-	RECYCLE  = "recycle"  // 回收
-	RECOVER  = "recover"  // 恢复
+	// Audit operation types.
+	CREATE   = "create"   // Create.
+	DELETE   = "delete"   // Delete.
+	UPDATE   = "update"   // Update.
+	START    = "start"    // Start.
+	STOP     = "stop"     // Stop.
+	PAUSE    = "pause"    // Pause.
+	ROLLOVER = "rollover" // Rollover.
+	RECYCLE  = "recycle"  // Recycle.
+	RECOVER  = "recover"  // Recover.
 
 	AUDIT_TOPIC = "isf.audit_log.log"
 )
@@ -83,27 +83,27 @@ type AuditOperatorAgent struct {
 }
 
 type AuditLogFrom struct {
-	Package string              `json:"package"` // pakcgae名称
-	Service AuditLogFromService `json:"service"` // service
+	Package string              `json:"package"` // Package name.
+	Service AuditLogFromService `json:"service"` // Service information.
 }
 
 type AuditLogFromService struct {
-	Name string `json:"name"` // service名称
+	Name string `json:"name"` // Service name.
 }
 
 type AuditLog struct {
-	Type        string            `json:"type"`        // 日志类型
-	ID          string            `json:"out_biz_id"`  // 日志ID
-	Level       string            `json:"level"`       // 日志级别
-	Operation   string            `json:"operation"`   // 操作类型
-	Description string            `json:"description"` // 日志描述
-	OpTime      int64             `json:"op_time"`     // 操作时间
-	Operator    AuditOperator     `json:"operator"`    // 操作者信息
-	Object      AuditObject       `json:"object"`      // 操作对象信息
-	LogFrom     AuditLogFrom      `json:"log_from"`    // 日志来源
-	Detail      map[string]string `json:"detail"`      // 详情
+	Type        string            `json:"type"`        // Log type.
+	ID          string            `json:"out_biz_id"`  // Log ID.
+	Level       string            `json:"level"`       // Log level.
+	Operation   string            `json:"operation"`   // Operation type.
+	Description string            `json:"description"` // Log description.
+	OpTime      int64             `json:"op_time"`     // Operation timestamp.
+	Operator    AuditOperator     `json:"operator"`    // Operator information.
+	Object      AuditObject       `json:"object"`      // Target object information.
+	LogFrom     AuditLogFrom      `json:"log_from"`    // Log source.
+	Detail      map[string]string `json:"detail"`      // Details.
 
-	Status string `json:"-"` // 状态
+	Status string `json:"-"` // Status.
 }
 
 var (
@@ -147,7 +147,7 @@ func TransforOperator(visitor hydra.Visitor) AuditOperator {
 	}
 }
 
-// 创建信息级别的审计日志
+// NewInfoLog creates an informational audit log.
 func NewInfoLog(logType string, op string, operator AuditOperator, obj AuditObject, detail string) {
 	auditLog := AuditLog{
 		Type:      logType,
@@ -165,7 +165,7 @@ func NewInfoLog(logType string, op string, operator AuditOperator, obj AuditObje
 	auditLogChan <- &auditLog
 }
 
-// 创建警告级别的审计日志
+// NewWarnLog creates a warning audit log.
 func NewWarnLog(logType string, op string, operator AuditOperator, obj AuditObject, status string, detail string) {
 	auditLog := AuditLog{
 		Type:      logType,
@@ -183,7 +183,7 @@ func NewWarnLog(logType string, op string, operator AuditOperator, obj AuditObje
 	auditLogChan <- &auditLog
 }
 
-// 创建警告级别的审计日志
+// NewWarnLogWithError creates a warning audit log from an HTTP error.
 func NewWarnLogWithError(logType string, op string, operator AuditOperator, obj AuditObject, err *rest.BaseError) {
 	auditLog := AuditLog{
 		Type:      logType,
@@ -201,24 +201,24 @@ func NewWarnLogWithError(logType string, op string, operator AuditOperator, obj 
 	auditLogChan <- &auditLog
 }
 
-// 处理审计日志
+// initAuditLogHandler processes audit logs.
 func initAuditLogHandler(mqSetting *mq.MQSetting) {
 
 	auditProducer = getAuditProcuder(mqSetting, RECOVER_AUDIT_PRODUCER_INTERVAL)
 
-	//从channel中取数据
+	// Read the next audit log from the channel.
 	for {
 		auditLog := <-auditLogChan
 
-		// 处理审计日志
+		// Populate derived audit fields.
 		transformLog(auditLog)
 
-		// 发送审计日志
+		// Send the audit log.
 		sendLog(auditLog)
 	}
 }
 
-// 处理审计日志
+// transformLog populates derived audit fields.
 func transformLog(auditLog *AuditLog) {
 	auditLog.ID = xid.New().String()
 	auditLog.LogFrom = DEFAULT_AUDIT_LOG_FROM
@@ -241,7 +241,7 @@ func transformLog(auditLog *AuditLog) {
 	auditLog.Detail["status"] = auditLog.Status
 }
 
-// 往kafka发送审计日志
+// sendLog sends an audit log to Kafka.
 func sendLog(auditLog *AuditLog) {
 
 	auditLogStr, err := sonic.MarshalString(auditLog)
@@ -252,14 +252,14 @@ func sendLog(auditLog *AuditLog) {
 
 	logger.Infof("audit log: %v", auditLogStr)
 
-	// 构造一个消息
+	// Build the Kafka message.
 	msg := &sarama.ProducerMessage{
 		Topic: AUDIT_TOPIC,
 		Value: sarama.StringEncoder(auditLogStr),
 	}
 
 	for {
-		// 发送消息
+		// Send the message.
 		_, _, err = auditProducer.SendMessage(msg)
 		if err == nil {
 			return
@@ -269,7 +269,7 @@ func sendLog(auditLog *AuditLog) {
 	}
 }
 
-// 新建kafka生产者
+// newAuditProducer creates a Kafka producer.
 func newAuditProducer(mqSetting *mq.MQSetting) (sarama.SyncProducer, error) {
 
 	hosts := []string{fmt.Sprintf("%s:%d", mqSetting.MQHost, mqSetting.MQPort)}
@@ -287,7 +287,7 @@ func newAuditProducer(mqSetting *mq.MQSetting) (sarama.SyncProducer, error) {
 	config.Producer.Retry.Max = MAX_PRODUCER_RETRY
 	config.Net.MaxOpenRequests = NET_MAX_OPEN_REQUESTS
 
-	// 连接kafka
+	// Connect to Kafka.
 	producer, err := sarama.NewSyncProducer(hosts, config)
 	if err != nil {
 		logger.Errorf("can not connect to kafka ,create kafka producer failed: %v", err)
@@ -298,8 +298,8 @@ func newAuditProducer(mqSetting *mq.MQSetting) (sarama.SyncProducer, error) {
 	return producer, nil
 }
 
-// 获取auditProducer
-// 若获取auditProducer为nil时，过两分钟继续获取，实现kafka恢复正常后自动连接
+// getAuditProcuder obtains an audit producer.
+// It retries after the interval so the producer reconnects when Kafka recovers.
 func getAuditProcuder(mqSetting *mq.MQSetting, interval time.Duration) sarama.SyncProducer {
 
 	logger.Infof("get auditProducer if auditProducer is nil, interval: %s", interval)

--- a/comm-go/common/tags.go
+++ b/comm-go/common/tags.go
@@ -12,7 +12,7 @@ import (
 	"strings"
 )
 
-// 把tags数组转成数据库存储的字符串的形式，格式为 "a","b","c"
+// TagSlice2TagString converts tags to the database format: "a","b","c".
 func TagSlice2TagString(strs []string) string {
 	newStrs := make([]string, len(strs))
 	for i, str := range strs {
@@ -21,7 +21,7 @@ func TagSlice2TagString(strs []string) string {
 	return strings.Join(newStrs, ",")
 }
 
-// 把数据库存储的tags字符串(格式为 "a","b","c")转成tags数组
+// TagString2TagSlice converts the database tag format into a slice.
 func TagString2TagSlice(str string) []string {
 	if str == "" {
 		return []string{}
@@ -35,7 +35,7 @@ func TagString2TagSlice(str string) []string {
 	return newStrs
 }
 
-// 除去tag前后的空格, 数组去重, 并排序
+// TagSliceTransform trims tags, removes duplicates, and sorts them.
 func TagSliceTransform(origTags []string) []string {
 	uniqueMap := make(map[string]bool)
 	var tags []string

--- a/comm-go/common/time.go
+++ b/comm-go/common/time.go
@@ -12,14 +12,14 @@ import (
 )
 
 const (
-	// 毫秒时间字符串
+	// RFC3339 timestamp with millisecond precision.
 	RFC3339Milli = "2006-01-02T15:04:05.999Z07:00"
 )
 
 /*
-	AnyRobot希望后端API统一时间输出格式为RFC3339Milli.
-	Golang的标准库time.Time的输出格式因值的不同会存在差异, 可能是RFC3339/RFC3339Nano/其它.
-	因此我们定义Time类型, 覆写MarshalJSON, UnmarshalJSON等方法, 实现期望效果.
+Time provides a stable RFC3339Milli JSON representation for backend APIs.
+time.Time can otherwise serialize with RFC3339 or RFC3339Nano precision
+depending on its value, so this type controls JSON marshaling explicitly.
 */
 
 type Time time.Time

--- a/comm-go/crypto/aes.go
+++ b/comm-go/crypto/aes.go
@@ -58,7 +58,7 @@ func (ci aesCipher) Encrypt(encryptedData string) (string, error) {
 	}
 }
 
-// CBC方式解密
+// decryptCBC decrypts data in CBC mode.
 func (ci aesCipher) decryptCBC(encryptedData string) (string, error) {
 	encrypted, err := base64.StdEncoding.DecodeString(encryptedData)
 	if err != nil {
@@ -77,14 +77,14 @@ func (ci aesCipher) decryptCBC(encryptedData string) (string, error) {
 	return string(decryptedData), nil
 }
 
-// pkcs5方式解除填充
+// pkcs5UnPadding removes PKCS#5 padding.
 func (ci aesCipher) pkcs5UnPadding(decryptedData []byte) []byte {
 	length := len(decryptedData)
 	unpadding := int(decryptedData[length-1])
 	return decryptedData[:(length - unpadding)]
 }
 
-// ECB方式加密
+// encryptECB encrypts data in ECB mode.
 func (ci aesCipher) encryptECB(data string) (string, error) {
 	cipherText := []byte(data)
 	key := []byte(ci.key)
@@ -107,7 +107,7 @@ func (ci aesCipher) encryptECB(data string) (string, error) {
 	return b, nil
 }
 
-// ECB方式解密
+// decryptECB decrypts data in ECB mode.
 func (ci aesCipher) decryptECB(encryptedData string) (string, error) {
 	encrypted, err := base64.StdEncoding.DecodeString(encryptedData)
 	if err != nil {

--- a/comm-go/crypto/haitai.go
+++ b/comm-go/crypto/haitai.go
@@ -44,7 +44,7 @@ func NewHaitaiCipher(key string, host string, realm string, dataKey string) Ciph
 	return ci
 }
 
-// hmac_sha256摘要k
+// hmacSha256 returns the HMAC-SHA256 digest.
 func (ci haitaiCipher) hmacSha256(data []byte) string {
 	key, _ := hex.DecodeString(ci.key)
 	h := hmac.New(sha256.New, key)

--- a/comm-go/crypto/rsa.go
+++ b/comm-go/crypto/rsa.go
@@ -119,7 +119,7 @@ func (ci rsaCipher) Signature(signContent string) (string, error) {
 func parsePrivateKey(privateKeyPEM string) (*rsa.PrivateKey, error) {
 	block, _ := pem.Decode([]byte(privateKeyPEM))
 	if block == nil {
-		return nil, errors.New("私钥信息错误！")
+		return nil, errors.New("invalid RSA private key PEM")
 	}
 	// Try PKCS1 first
 	priKey, err := x509.ParsePKCS1PrivateKey(block.Bytes)
@@ -141,7 +141,7 @@ func parsePrivateKey(privateKeyPEM string) (*rsa.PrivateKey, error) {
 func parsePublicKey(publicKeyPEM string) (*rsa.PublicKey, error) {
 	block, _ := pem.Decode([]byte(publicKeyPEM))
 	if block == nil {
-		return nil, errors.New("公钥信息错误！")
+		return nil, errors.New("invalid RSA public key PEM")
 	}
 
 	// Try PKIX format first (most common)

--- a/comm-go/db/db.go
+++ b/comm-go/db/db.go
@@ -21,7 +21,7 @@ const (
 	DRIVER_NAME = "openbkn-rds"
 )
 
-// db配置项
+// DBSetting configures a database connection.
 type DBSetting struct {
 	Host     string
 	Port     int
@@ -36,7 +36,7 @@ var (
 	dbUrl  string
 )
 
-// 配置db的客户端参数
+// NewDB configures and returns the shared database client.
 func NewDB(setting *DBSetting) *sql.DB {
 	dbOnce.Do(func() {
 		db = InitDB(setting)
@@ -45,7 +45,7 @@ func NewDB(setting *DBSetting) *sql.DB {
 	return db
 }
 
-// 初始化链接
+// InitDB initializes a database connection.
 func InitDB(setting *DBSetting) *sql.DB {
 	dbUrl = fmt.Sprintf("%s@tcp(%s:%d)/%s?charset=utf8mb4&loc=Local", setting.Username, setting.Host, setting.Port, setting.DBName)
 	dbDSN := fmt.Sprintf("%s:%s@tcp(%s:%d)/%s?charset=utf8mb4&loc=Local",
@@ -53,20 +53,20 @@ func InitDB(setting *DBSetting) *sql.DB {
 
 	Db, err := sql.Open(DRIVER_NAME, dbDSN)
 	if err != nil {
-		// 打开连接失败
+		// Opening the connection failed.
 		logger.Infof("dbDSN: %s", dbDSN)
-		panic("数据源配置不正确: " + err.Error())
+		panic("invalid data source configuration: " + err.Error())
 	}
 
-	// 最大连接数
+	// Maximum open connections.
 	Db.SetMaxOpenConns(100)
-	// 闲置连接数
+	// Maximum idle connections.
 	Db.SetMaxIdleConns(20)
-	// 最大连接周期
+	// Maximum connection lifetime.
 	Db.SetConnMaxLifetime(100 * time.Second)
 
 	if err = Db.Ping(); err != nil {
-		panic("数据库连接失败: " + err.Error())
+		panic("database connection failed: " + err.Error())
 	}
 
 	logger.Info("connect success")

--- a/comm-go/db/driver/common/common.go
+++ b/comm-go/db/driver/common/common.go
@@ -36,8 +36,8 @@ func ParseMySQLDSN(dsn string) (mysql.Config, error) {
 	return *cfg, err
 }
 
-// ParseDSN 解析DSN字符串，返回DSN参数映射，参数保持原大小写
-// DSN格式：user:password@protocol(host:port)/dbname?param=value&param=value
+// ParseDSN parses a DSN and returns its parameters without changing key casing.
+// Expected format: user:password@protocol(host:port)/dbname?param=value&param=value.
 func ParseDSN(dsn string) (DSNConfig, error) {
 
 	if dsn == "" {
@@ -48,10 +48,10 @@ func ParseDSN(dsn string) (DSNConfig, error) {
 		Props: treemap.NewWithStringComparator(),
 	}
 	urlString := dsn
-	// urlString格式: user:password@protocol(host:port)/dbname?param=value&param=value
+	// urlString format: user:password@protocol(host:port)/dbname?param=value&param=value.
 	if queryIndex := strings.LastIndex(dsn, "?"); queryIndex > 0 {
 		urlString = dsn[:queryIndex]
-		// urlString格式: user:password@protocol(host:port)/dbname
+		// urlString format: user:password@protocol(host:port)/dbname.
 		for _, kvString := range strings.Split(dsn[queryIndex+1:], "&") {
 			kv := strings.SplitN(kvString, "=", 2)
 			if len(kv) > 1 {
@@ -66,8 +66,8 @@ func ParseDSN(dsn string) (DSNConfig, error) {
 	}
 	userString := urlString[:atIndex]
 	hostString := urlString[atIndex+1:]
-	// userString格式: user:password
-	// hostString格式: protocol(host:port)/dbname
+	// userString format: user:password.
+	// hostString format: protocol(host:port)/dbname.
 
 	if kv := strings.SplitN(userString, ":", 2); len(kv) > 1 {
 		dsnConfig.Username = kv[0]
@@ -79,7 +79,7 @@ func ParseDSN(dsn string) (DSNConfig, error) {
 	if schemaIndex := strings.LastIndex(hostString, "/"); schemaIndex > 0 {
 		dsnConfig.DBName = hostString[schemaIndex+1:]
 		hostString = hostString[:schemaIndex]
-		// hostString格式: protocol(host:port)
+		// hostString format: protocol(host:port).
 	}
 
 	if sIdx := strings.Index(hostString, "("); sIdx > 0 {
@@ -89,7 +89,7 @@ func ParseDSN(dsn string) (DSNConfig, error) {
 		eIdx := len(hostString) - 1
 		dsnConfig.Protocol = hostString[:sIdx]
 		hostString = hostString[sIdx+1 : eIdx]
-		// hostString格式: host:port
+		// hostString format: host:port.
 	}
 
 	if strings.HasPrefix(hostString, "[") {

--- a/comm-go/db/sqlx/db.go
+++ b/comm-go/db/sqlx/db.go
@@ -10,27 +10,22 @@ import (
 )
 
 /*
-go database/sql 连接池参数有 MaxIdleConns、MaxOpenConns：
-MaxOpenConns 为最大连接数，MaxIdleConns 为最大空闲连接数，当一个连接用完之后，连接池会根据当前空闲连接个数
-与 MaxIdleConns 的关系决定是关闭连接还是转为空闲连接，MaxIdleConns 默认是 2，如果 MaxOpenConns >> MaxIdleConns，
-当数据库请求很高时，在大量创建连接后由于无法转为空闲连接，此时就会关闭连接，新请求再重新创建连接，造成大量的TIME_WAIT，
-除了造成资源浪费，还会耗尽端口资源，造成无法创建新连接（连接发起方每次都使用随机端口，范围为 net.ipv4.ip_local_port_range，
-默认 32768 - 60999）。为了避免此问题的发生，原则上应该设置为 MaxIdleConns = MaxOpenConns，但是并不是所有的服务都会一直
-高频访问数据库，难免造成资源的浪费。
+The database/sql pool uses MaxIdleConns and MaxOpenConns. When the maximum
+open count is much larger than the idle count, high traffic can repeatedly
+create and close connections, which wastes resources and exhausts ephemeral
+ports. Prefer MaxIdleConns == MaxOpenConns for services with sustained load.
 
-连接池还提供了 ConnMaxIdleTime、ConnMaxLifetime：
-ConnMaxIdleTime 为空闲连接保持的最大时间，如果一个连接的空闲时间超过这个值，会被自动关闭，释放资源。
-ConnMaxLifetime 为一个连接的最大存活时间，当超过这个时间，连接会被自动关闭，释放资源。（网上有文章提到此时间必须要比
-数据库服务端wait_timeout小，仔细推敲此说法不对，应该是 ConnMaxIdleTime 必须小于数据库服务端wait_timeout）。
-一般通过设置 ConnMaxIdleTime 来关闭长时间不使用的连接来释放资源，ConnMaxLifetime 可以用来控制1条SQL执行的最长时间，
-避免服务器忙时放弃某些不重要的业务，但是如果数据库去掉提供了timeout、readTimeout、writeTimeout的功能，ConnMaxLifetime
-无用武之地了。
+ConnMaxIdleTime limits how long an idle connection is retained. It should be
+less than the database server's wait_timeout. ConnMaxLifetime is useful only
+when the database driver does not already provide timeout, readTimeout, and
+writeTimeout controls.
 
-综上：go 数据库标准如下：
+Recommended defaults:
 1. MaxIdleConns == MaxOpenConns
 2. ConnMaxIdleTime = 120s
-120s是为了保证上一批关闭的处于 TIME_WAIT 状态的连接被内核回收。
-TIME_WAIT 最长保留时间：https://blog.csdn.net/li1669852599/article/details/109629917
+
+The 120-second interval allows the kernel to reclaim recently closed
+TIME_WAIT connections.
 */
 
 //go:generate mockgen -package mock -source ./db.go -destination ./mock/mock_db.go
@@ -68,7 +63,7 @@ type DB struct {
 	writer
 }
 
-// ParseHost 判定host是否为IPv6格式，如果是，返回 [host]
+// ParseHost wraps an IPv6 host in brackets.
 func ParseHost(host string) string {
 	if strings.Contains(host, ":") {
 		return fmt.Sprintf("[%s]", host)
@@ -77,7 +72,7 @@ func ParseHost(host string) string {
 	return host
 }
 
-// NewDB 新建数据库连接
+// NewDB creates a database connection.
 func NewDB(dbConfig *DBConfig) (*DB, error) {
 	driverName := "openbkn-rds"
 	if dbConfig.CustomDriver != "" {

--- a/comm-go/db/sqlx/types.go
+++ b/comm-go/db/sqlx/types.go
@@ -1,6 +1,6 @@
 package sqlx
 
-// DBConfig 数据库配置信息
+// DBConfig contains database connection settings.
 type DBConfig struct {
 	User             string `yaml:"user_name"`
 	Password         string `yaml:"user_pwd"`

--- a/comm-go/hydra/hydra.go
+++ b/comm-go/hydra/hydra.go
@@ -22,30 +22,30 @@ import (
 	"github.com/openbkn-ai/bkn-foundry/comm-go/rest"
 )
 
-// VisitorType 访问者类型
+// VisitorType identifies the visitor type.
 type VisitorType string
 
-// 访问者类型定义
+// Visitor type values.
 const (
-	VisitorType_RealName  VisitorType = "realname"  // 实名用户
-	VisitorType_User      VisitorType = "user"      // 实名用户
-	VisitorType_Anonymous VisitorType = "anonymous" // 匿名用户
-	VisitorType_App       VisitorType = "app"       // 应用账户
+	VisitorType_RealName  VisitorType = "realname"  // Authenticated user.
+	VisitorType_User      VisitorType = "user"      // Authenticated user.
+	VisitorType_Anonymous VisitorType = "anonymous" // Anonymous user.
+	VisitorType_App       VisitorType = "app"       // Application account.
 )
 
-// AccountType 登录账号类型
+// AccountType identifies the login account type.
 type AccountType string
 
-// 登录账号类型定义
+// Account type values.
 const (
 	AccountType_Other  AccountType = "other"
 	AccountType_IDCard AccountType = "id_card"
 )
 
-// ClientType 设备类型
+// ClientType identifies the client device type.
 type ClientType string
 
-// 设备类型定义
+// Client device type values.
 const (
 	ClientType_Windows      ClientType = "windows"
 	ClientType_IOS          ClientType = "ios"
@@ -62,18 +62,18 @@ const (
 	ClientType_App          ClientType = "app"
 )
 
-// TokenIntrospectInfo 令牌内省结果
+// TokenIntrospectInfo contains the token introspection result.
 type TokenIntrospectInfo struct {
-	Active     bool        // 令牌状态
-	VisitorID  string      // 访问者ID
-	Scope      string      // 权限范围
-	ClientID   string      // 客户端ID
-	VisitorTyp VisitorType // 访问者类型
-	// 以下字段只在visitorType=RealName，即实名用户时才存在
-	LoginIP    string      // 登陆IP
-	Udid       string      // 设备码
-	AccountTyp AccountType // 账户类型
-	ClientTyp  ClientType  // 设备类型
+	Active     bool        // Token status.
+	VisitorID  string      // Visitor ID.
+	Scope      string      // Granted scopes.
+	ClientID   string      // Client ID.
+	VisitorTyp VisitorType // Visitor type.
+	// The following fields exist only for authenticated users.
+	LoginIP    string      // Login IP address.
+	Udid       string      // Device ID.
+	AccountTyp AccountType // Account type.
+	ClientTyp  ClientType  // Client device type.
 }
 
 var (
@@ -104,12 +104,12 @@ var (
 	}
 )
 
-// Visitor 访问者信息
+// Visitor contains caller identity information.
 type Visitor struct {
 	ID string
 
-	// TokenID 在 JSON 序列化和反序列化时会被忽略，用于防止令牌在持久化过程中泄露
-	// 如需在反序列化时获取 TokenID，请通过代码手动处理
+	// TokenID is ignored during JSON serialization to prevent token persistence.
+	// Handle TokenID explicitly when it is required after deserialization.
 	TokenID    string `json:"-"`
 	IP         string
 	Mac        string
@@ -121,12 +121,12 @@ type Visitor struct {
 
 //go:generate mockgen -package mock -source ./hydra.go -destination ./mock/mock_hydra.go
 
-// Hydra 授权服务接口
+// Hydra defines the authorization service interface.
 type Hydra interface {
-	// Introspect token内省
+	// Introspect performs token introspection.
 	Introspect(ctx context.Context, token string) (info TokenIntrospectInfo, err error)
 
-	// token 有效性检查
+	// VerifyToken verifies token validity.
 	VerifyToken(ctx context.Context, c *gin.Context) (Visitor, error)
 }
 
@@ -141,7 +141,7 @@ type hydra struct {
 	client       *http.Client
 }
 
-// newHydra 创建授权服务
+// NewHydra creates an authorization service client.
 func NewHydra(setting HydraAdminSetting) Hydra {
 	h := &hydra{
 		adminAddress: fmt.Sprintf("http://%s:%d", setting.HydraAdminHost, setting.HydraAdminPort),
@@ -151,7 +151,7 @@ func NewHydra(setting HydraAdminSetting) Hydra {
 	return h
 }
 
-// Introspect token内省
+// Introspect performs token introspection.
 func (h *hydra) Introspect(ctx context.Context, token string) (info TokenIntrospectInfo, err error) {
 	url := fmt.Sprintf("%v/admin/oauth2/introspect", h.adminAddress)
 
@@ -181,47 +181,47 @@ func (h *hydra) Introspect(ctx context.Context, token string) (info TokenIntrosp
 		return
 	}
 
-	// 令牌状态
+	// Token status.
 	info.Active = respParam["active"].(bool)
 	if !info.Active {
 		return
 	}
 
-	// 访问者ID
+	// Visitor ID.
 	info.VisitorID = respParam["sub"].(string)
-	// Scope 权限范围
+	// Granted scopes.
 	info.Scope = respParam["scope"].(string)
-	// 客户端ID
+	// Client ID.
 	info.ClientID = respParam["client_id"].(string)
-	// 客户端凭据模式
+	// Client-credentials grant.
 	if info.VisitorID == info.ClientID {
 		info.VisitorTyp = VisitorType_App
 		return
 	}
 
-	// 以下字段 只在非客户端凭据模式时才存在
-	// 访问者类型
+	// The following fields do not exist for client-credentials grants.
+	// Visitor type.
 	visitorTyp := respParam["ext"].(map[string]interface{})["visitor_type"].(string)
 	info.VisitorTyp = visitorTypeMap[VisitorType(visitorTyp)]
 
-	// 匿名用户
+	// Anonymous user.
 	if info.VisitorTyp == VisitorType_Anonymous {
-		// 文档库访问规则接口考虑后续扩展性，clientType为必传。本身规则计算未使用clientType
-		// 设备类型本身未解析,匿名时默认为web
+		// The document-library authorization API requires clientType for extensibility.
+		// Anonymous callers do not provide a device type, so default to web.
 		info.ClientTyp = ClientType_Web
 		return
 	}
 
-	// 实名用户
+	// Authenticated user.
 	if info.VisitorTyp == VisitorType_User {
-		// 登陆IP
+		// Login IP address.
 		info.LoginIP = respParam["ext"].(map[string]interface{})["login_ip"].(string)
-		// 设备ID
+		// Device ID.
 		info.Udid = respParam["ext"].(map[string]interface{})["udid"].(string)
-		// 登录账号类型
+		// Login account type.
 		accountTyp := respParam["ext"].(map[string]interface{})["account_type"].(string)
 		info.AccountTyp = accountTypeMap[AccountType(accountTyp)]
-		// 设备类型
+		// Client device type.
 		clientTyp := respParam["ext"].(map[string]interface{})["client_type"].(string)
 		info.ClientTyp = clientTypeMap[ClientType(clientTyp)]
 		return

--- a/comm-go/i18n/i18n.go
+++ b/comm-go/i18n/i18n.go
@@ -174,7 +174,7 @@ func normalizeLocale(raw string) string {
 func flattenMessages(messages map[string]*Message, messageID string, raw interface{}) error {
 	switch value := raw.(type) {
 	case string:
-		if value == "" {
+		if value == "" && !strings.HasSuffix(messageID, ".ErrorLink") {
 			return fmt.Errorf("messageId %s is an empty string", messageID)
 		}
 		if _, ok := messages[messageID]; ok {

--- a/comm-go/i18n/i18n_test.go
+++ b/comm-go/i18n/i18n_test.go
@@ -47,6 +47,29 @@ func TestValidateLocaleDirRequiresDeclaredLocales(t *testing.T) {
 	}
 }
 
+func TestValidateLocaleDirAllowsOnlyEmptyErrorLink(t *testing.T) {
+	dir := writeLocaleFiles(t, map[string]string{
+		"errors.zh-CN.toml": "[Error]\nDescription = '请求失败'\nSolution = '请重试'\nErrorLink = ''\n",
+		"errors.en-US.toml": "[Error]\nDescription = 'Request failed'\nSolution = 'Try again'\nErrorLink = ''\n",
+	})
+
+	if err := ValidateLocaleDir(dir, "zh-CN", "zh-CN", "en-US"); err != nil {
+		t.Fatalf("expected an empty ErrorLink to be allowed, got %v", err)
+	}
+}
+
+func TestValidateLocaleDirRejectsEmptyRequiredMessage(t *testing.T) {
+	dir := writeLocaleFiles(t, map[string]string{
+		"errors.zh-CN.toml": "[Error]\nDescription = ''\nSolution = '请重试'\nErrorLink = ''\n",
+		"errors.en-US.toml": "[Error]\nDescription = ''\nSolution = 'Try again'\nErrorLink = ''\n",
+	})
+
+	err := ValidateLocaleDir(dir, "zh-CN", "zh-CN", "en-US")
+	if err == nil || !strings.Contains(err.Error(), "Error.Description is an empty string") {
+		t.Fatalf("expected an empty description to be rejected, got %v", err)
+	}
+}
+
 func TestTranslateFallsBackWithoutFatal(t *testing.T) {
 	dir := writeLocaleFiles(t, map[string]string{
 		"errors.zh-CN.toml": "[Error]\nDescription = '请求失败：{{ .name }}'\nSolution = '请重试'\n",

--- a/comm-go/logger/log.go
+++ b/comm-go/logger/log.go
@@ -27,7 +27,7 @@ type LogSetting struct {
 	MaxSize        int    `json:"maxSize"        mapstructure:"maxSize"`
 }
 
-// 初始化日志对象
+// InitLogger initializes the logger.
 func InitLogger(setting LogSetting) *zap.SugaredLogger {
 	level, err := zapcore.ParseLevel(setting.LogLevel)
 	if err != nil {
@@ -39,18 +39,18 @@ func InitLogger(setting LogSetting) *zap.SugaredLogger {
 	}
 
 	if setting.LogFileName != "" {
-		// 日志文件hook
+		// File output hook.
 		hook := &lumberjack.Logger{
 			Filename:   setting.LogFileName,
-			LocalTime:  true,               //日志文件名的时间格式为本地时间
-			MaxAge:     setting.MaxAge,     //文件保留的最长时间，单位为天
-			MaxBackups: setting.MaxBackups, // 旧文件保留的最大个数
-			MaxSize:    setting.MaxSize,    // 单个文件最大长度，单位是M
+			LocalTime:  true,               // Use local time in log file names.
+			MaxAge:     setting.MaxAge,     // Maximum retention period in days.
+			MaxBackups: setting.MaxBackups, // Maximum number of retained files.
+			MaxSize:    setting.MaxSize,    // Maximum size of a single file in MB.
 		}
 		ws = append(ws, zapcore.AddSync(hook))
 	}
 
-	// 日志格式设定
+	// Log encoder configuration.
 	encoderConfig := zapcore.EncoderConfig{
 		TimeKey:        "time",
 		LevelKey:       "level",
@@ -59,17 +59,17 @@ func InitLogger(setting LogSetting) *zap.SugaredLogger {
 		MessageKey:     "msg",
 		StacktraceKey:  "stacktrace",
 		LineEnding:     zapcore.DefaultLineEnding,
-		EncodeLevel:    zapcore.LowercaseLevelEncoder,                    // 小写编码器
-		EncodeTime:     zapcore.TimeEncoderOfLayout(common.RFC3339Milli), // RFC3339Milli 时间格式
+		EncodeLevel:    zapcore.LowercaseLevelEncoder,                    // Lowercase level encoder.
+		EncodeTime:     zapcore.TimeEncoderOfLayout(common.RFC3339Milli), // RFC3339Milli timestamp format.
 		EncodeDuration: zapcore.SecondsDurationEncoder,                   //
-		EncodeCaller:   zapcore.FullCallerEncoder,                        // 全路径编码器
+		EncodeCaller:   zapcore.FullCallerEncoder,                        // Full caller-path encoder.
 		EncodeName:     zapcore.FullNameEncoder,
 	}
 
 	core := zapcore.NewCore(
-		zapcore.NewJSONEncoder(encoderConfig), // 编码器配置
-		zapcore.NewMultiWriteSyncer(ws...),    // 打印到控制台和文件
-		level,                                 // 日志级别
+		zapcore.NewJSONEncoder(encoderConfig), // Encoder configuration.
+		zapcore.NewMultiWriteSyncer(ws...),    // Write to stdout and files.
+		level,                                 // Log level.
 	)
 
 	options := []zap.Option{
@@ -77,7 +77,7 @@ func InitLogger(setting LogSetting) *zap.SugaredLogger {
 	}
 
 	if setting.DevelopMode {
-		// 开启开发模式，堆栈跟踪
+		// Enable development-mode stack traces.
 		options = append(options, zap.AddCaller(), zap.AddCallerSkip(1), zap.Development())
 	}
 

--- a/comm-go/middleware/middleware.go
+++ b/comm-go/middleware/middleware.go
@@ -13,10 +13,12 @@ import (
 )
 
 /*
-	我们在跨服务调用时一般使用otelgin中的Middleware去获取上游调用者的SpanContext, 避免链路断开.
-	但它会产生一条Span, 且不可显示设置Span的Status.
-	为克服这一缺陷, 所以我们基于otelgin, 实现了TracingMiddleware, 以获取上游调用者的SpanContext.
-	otelgin: https://github.com/open-telemetry/opentelemetry-go-contrib/blob/main/instrumentation/github.com/gin-gonic/gin/otelgin/gintrace.go
+Cross-service calls commonly use otelgin middleware to extract the upstream
+SpanContext. That middleware creates an additional span and does not expose
+explicit status control. TracingMiddleware only extracts and propagates the
+upstream context to avoid that behavior.
+
+otelgin reference: https://github.com/open-telemetry/opentelemetry-go-contrib/blob/main/instrumentation/github.com/gin-gonic/gin/otelgin/gintrace.go
 */
 
 func TracingMiddleware() gin.HandlerFunc {

--- a/comm-go/mq/kafkaclient.go
+++ b/comm-go/mq/kafkaclient.go
@@ -42,7 +42,7 @@ type OpenBKNKafkaClient struct {
 	tlsConfig         *tls.Config
 	brokers           []string
 	writers           map[string]*kafka.Writer
-	// 共享的 transport 实例，用于连接池
+	// Shared transport used for connection pooling.
 	transport  *kafka.Transport
 	mu         sync.Mutex
 	sharedConn bool
@@ -55,7 +55,7 @@ func NewKafkaClient(pubServer string, pubPort int, subServer string, subPort int
 		brokers = append(brokers, fmt.Sprintf("%s:%d", parseHost(addr), pubPort))
 	}
 
-	// 创建一个共享的 transport 实例，用于连接池
+	// A shared transport is initialized lazily for connection pooling.
 	return &OpenBKNKafkaClient{
 		brokers: brokers,
 		writers: make(map[string]*kafka.Writer),
@@ -64,7 +64,7 @@ func NewKafkaClient(pubServer string, pubPort int, subServer string, subPort int
 
 func (kc *OpenBKNKafkaClient) initialize() (err error) {
 	if kc.saslMechanism != nil {
-		// 确保在测试等场景下零值结构体也能正常工作
+		// Keep zero-value clients usable in tests and other lightweight callers.
 		if kc.writers == nil {
 			kc.writers = make(map[string]*kafka.Writer)
 		}
@@ -100,7 +100,7 @@ func (kc *OpenBKNKafkaClient) initialize() (err error) {
 		kc.writers = make(map[string]*kafka.Writer)
 	}
 
-	// 初始化全局 transport
+	// Initialize the shared transport.
 	kc.transport = &kafka.Transport{
 		DialTimeout: ConnTimeout,
 		IdleTimeout: IdleTimeout,
@@ -122,7 +122,7 @@ func (kc *OpenBKNKafkaClient) getWriter(topic string) *kafka.Writer {
 		writeTransport = kc.transport
 	} else {
 		writeTransport = &kafka.Transport{
-			// 设置合理的连接池超时时间
+			// Use the configured connection pool timeouts.
 			DialTimeout: ConnTimeout,
 			IdleTimeout: IdleTimeout,
 			TLS:         kc.tlsConfig,
@@ -149,7 +149,7 @@ func (kc *OpenBKNKafkaClient) createTopic(topic string) {
 		SASLMechanism: kc.saslMechanism,
 	}
 
-	// 如果 auto.create.topics.enable=true，这将创建主题
+	// This creates the topic when auto.create.topics.enable=true.
 	conn, err := dialer.DialLeader(context.Background(), "tcp", kc.brokers[0], topic, 0)
 	if err != nil {
 		log.Printf("connect kafka with topic %s failed, %v", topic, err)
@@ -167,7 +167,7 @@ func (kc *OpenBKNKafkaClient) Pub(topic string, msg []byte) (err error) {
 	writer := kc.getWriter(topic)
 
 	maxAttempts := uint(200)
-	// 最长重试阻塞时间：10s
+	// Limit total retry blocking time to ten seconds.
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 	return retry.Do(
@@ -235,7 +235,7 @@ func (kc *OpenBKNKafkaClient) Close() {
 	kc.mu.Lock()
 	defer kc.mu.Unlock()
 
-	// 关闭所有 writers
+	// Close all writers.
 	for topic, writer := range kc.writers {
 		if writer != nil {
 			_ = writer.Close()
@@ -243,7 +243,7 @@ func (kc *OpenBKNKafkaClient) Close() {
 		delete(kc.writers, topic)
 	}
 
-	// 关闭共享的 transport 的所有空闲连接
+	// Close idle connections held by the shared transport.
 	if kc.transport != nil {
 		kc.transport.CloseIdleConnections()
 	}

--- a/comm-go/mq/kafkaclient_test.go
+++ b/comm-go/mq/kafkaclient_test.go
@@ -155,7 +155,7 @@ func TestOpenBKNKafkaClientPub(t *testing.T) {
 		fields  fields
 		args    args
 		wantErr error
-		setup   func() *gomonkey.Patches // 不可直接声明patches，多个自测试之间会混淆，通过函数返回，在子测试中调用，作为局部变量打桩
+		setup   func() *gomonkey.Patches // Return patches from a function so each subtest owns and resets its own patch set.
 	}{
 		{
 			name: "Success",
@@ -178,14 +178,14 @@ func TestOpenBKNKafkaClientPub(t *testing.T) {
 				brokers:           []string{"127.0.0.1:9092"},
 			},
 			setup: func() (p *gomonkey.Patches) {
-				// 使用单一打桩函数，避免 ApplyMethodSeq 在重试场景下出现 double seq panic。
+				// Use one stub to avoid ApplyMethodSeq double-sequence panics during retries.
 				p = gomonkey.ApplyMethod(reflect.TypeOf(&kafka.Writer{}), "WriteMessages", func(*kafka.Writer, context.Context, ...kafka.Message) error {
 					log.Println("patch ErrorWithRetry test")
 					return kafka.BrokerIDNotRegistered
 				})
 				return
 			},
-			// Pub 在重试超时后会返回 context.DeadlineExceeded
+			// Pub returns context.DeadlineExceeded after retry timeout.
 			wantErr: context.DeadlineExceeded,
 		},
 		{
@@ -201,7 +201,7 @@ func TestOpenBKNKafkaClientPub(t *testing.T) {
 				})
 				return
 			},
-			// Pub 在重试超时后会返回 context.DeadlineExceeded
+			// Pub returns context.DeadlineExceeded after retry timeout.
 			wantErr: context.DeadlineExceeded,
 		},
 	}

--- a/comm-go/mq/mq.go
+++ b/comm-go/mq/mq.go
@@ -12,7 +12,7 @@ type MQAuthSetting struct {
 	Mechanism string
 }
 
-// mq配置项
+// MQSetting contains message queue configuration.
 type MQSetting struct {
 	MQType string
 	MQHost string

--- a/comm-go/mq/msqclient.go
+++ b/comm-go/mq/msqclient.go
@@ -37,7 +37,7 @@ type OpenBKNMQClient interface {
 	Close()
 }
 
-// region 客户端连接可选参数定义
+// Client connection options.
 
 type ClientOpt func(client OpenBKNMQClient) error
 
@@ -148,9 +148,9 @@ func ShareConn(sharedConn bool) ClientOpt {
 
 // endregion
 
-// region Sub 函数可选参数
+// Subscription options.
 type subOption struct {
-	ackAsync bool // 异步确认, 先确认再消费消息, 默认值: false
+	ackAsync bool // Acknowledge before consuming a message. Disabled by default.
 }
 
 type SubOpt func(opt *subOption) error
@@ -182,11 +182,11 @@ func NewOpenBKNMQClient(pubServer string, pubPort int, subServer string, subPort
 		err := fmt.Errorf("unknown msq type %v", msqType)
 		return nil, err
 	} else {
-		// 检查是否传入了 ShareConn 选项
+		// Detect whether the caller provided the ShareConn option.
 		hasShareConnOpt := false
 		for i := range opts {
-			// 我们无法直接比较函数，但可以通过函数的字符串表示来近似判断
-			// 这不是100%准确，但在大多数情况下足够用了
+			// Function values are not comparable; their type names provide a practical
+			// approximation for this option check.
 			optStr := fmt.Sprintf("%T", opts[i])
 			if strings.Contains(optStr, "ShareConn") {
 				hasShareConnOpt = true
@@ -195,9 +195,8 @@ func NewOpenBKNMQClient(pubServer string, pubPort int, subServer string, subPort
 		}
 
 		client := fn(pubServer, pubPort, subServer, subPort)
-		// 如果没有传入 ShareConn 选项，则添加默认值
+		// Enable shared connections by default when the option is omitted.
 		if !hasShareConnOpt {
-			// 默认启用共享连接
 			if err := ShareConn(true)(client); err != nil {
 				return nil, err
 			}
@@ -223,7 +222,7 @@ type OpenBKNMQInfo struct {
 	Auth        *AuthOpts `json:"auth,omitempty" yaml:"auth,omitempty"`
 }
 
-// Auth 信息
+// AuthOpts contains authentication settings.
 type AuthOpts struct {
 	Username  string `json:"username" yaml:"username"`
 	Password  string `json:"password" yaml:"password"`
@@ -246,7 +245,7 @@ func NewOpenBKNMQClientFromFile(configFile string) (OpenBKNMQClient, error) {
 		return nil, err
 	}
 	var opts []ClientOpt
-	// 默认启用共享连接
+	// Enable shared connections by default.
 	opts = append(opts, ShareConn(true))
 	if info.Auth != nil {
 		opts = append(opts, AuthMechanism(info.Auth.Mechanism), UserInfo(info.Auth.Username, info.Auth.Password))

--- a/comm-go/mq/msqclient_test.go
+++ b/comm-go/mq/msqclient_test.go
@@ -10,7 +10,7 @@ import (
 	"testing"
 )
 
-// TestNewOpenBKNMQClientFactory 确认只保留 nsq / kafka 两种类型时工厂创建正常工作。
+// TestNewOpenBKNMQClientFactory verifies factory behavior for the supported NSQ and Kafka clients.
 func TestNewOpenBKNMQClientFactory(t *testing.T) {
 	type args struct {
 		mqType string

--- a/comm-go/otel/config.go
+++ b/comm-go/otel/config.go
@@ -6,7 +6,7 @@
 
 package otel
 
-// OtelConfig 新版 OTel Collector 配置
+// OtelConfig configures the OpenTelemetry Collector.
 type OtelConfig struct {
 	ServiceName    string    `yaml:"service_name" mapstructure:"service_name"`
 	ServiceVersion string    `yaml:"service_version" mapstructure:"service_version"`
@@ -16,19 +16,19 @@ type OtelConfig struct {
 	Log            LogConf   `yaml:"log" mapstructure:"log"`
 }
 
-// TraceConf trace 子配置
+// TraceConf contains trace settings.
 type TraceConf struct {
 	Enabled      bool    `yaml:"enabled" mapstructure:"enabled"`
 	SamplingRate float64 `yaml:"sampling_rate" mapstructure:"sampling_rate"`
 }
 
-// LogConf log 子配置
+// LogConf contains log settings.
 type LogConf struct {
 	Enabled bool   `yaml:"enabled" mapstructure:"enabled"`
 	Level   string `yaml:"level" mapstructure:"level"`
 }
 
-// SetDefaults 设置 OtelConfig 默认值
+// SetDefaults applies default OtelConfig values.
 func (c *OtelConfig) SetDefaults(serverName string, serverVersion string) {
 	if c.ServiceName == "" {
 		c.ServiceName = serverName

--- a/comm-go/otel/init.go
+++ b/comm-go/otel/init.go
@@ -17,8 +17,8 @@ import (
 	"github.com/openbkn-ai/bkn-foundry/comm-go/otel/otellog"
 )
 
-// InitOTel 初始化 traces 和 logs 两类 provider。
-// 示例：服务启动时调用一次，退出时再调用 providers.Shutdown(ctx)。
+// InitOTel initializes trace and log providers.
+// Call it once at startup and call providers.Shutdown(ctx) during shutdown.
 func InitOTel(ctx context.Context, cfg *OtelConfig) (*Providers, error) {
 	cfg.SetDefaults(cfg.ServiceName, cfg.ServiceVersion)
 	otellog.SetServiceName(cfg.ServiceName)
@@ -30,7 +30,7 @@ func InitOTel(ctx context.Context, cfg *OtelConfig) (*Providers, error) {
 
 	providers := &Providers{}
 
-	// 初始化 Trace 提供者
+	// Initialize the trace provider.
 	if cfg.Trace.Enabled {
 		tracerProvider, err := newTracerProvider(ctx, cfg.OTLPEndpoint, cfg.Trace.SamplingRate, res)
 		if err != nil {
@@ -41,13 +41,13 @@ func InitOTel(ctx context.Context, cfg *OtelConfig) (*Providers, error) {
 		providers.TracerProvider = tracerProvider
 	}
 
-	// 设置全局传播器
+	// Configure the global propagator.
 	otel.SetTextMapPropagator(propagation.NewCompositeTextMapPropagator(
 		propagation.TraceContext{},
 		propagation.Baggage{},
 	))
 
-	// 初始化 Log 提供者
+	// Initialize the log provider.
 	if cfg.Log.Enabled {
 		loggerProvider, err := newLoggerProvider(ctx, cfg.OTLPEndpoint, res)
 		if err != nil {

--- a/comm-go/otel/otellog/logger.go
+++ b/comm-go/otel/otellog/logger.go
@@ -19,33 +19,33 @@ import (
 	"go.opentelemetry.io/otel/trace"
 )
 
-// globalServiceName 全局服务名称，由 InitOTel 设置。
+// globalServiceName is set by InitOTel.
 var globalServiceName string
 
-// SetServiceName 设置全局服务名称。
+// SetServiceName sets the global service name.
 func SetServiceName(name string) {
 	globalServiceName = name
 }
 
-// LogDebug 发送 Debug 级别的结构化日志，自动关联 trace 上下文；同时写入 zap stdout。
+// LogDebug emits a Debug-level structured log with trace context and writes to zap stdout.
 func LogDebug(ctx context.Context, message string, attrs ...otellog.KeyValue) {
 	emitLog(ctx, otellog.SeverityDebug, message, attrs...)
 	logger.Debug(formatForStdout(ctx, message, attrs))
 }
 
-// LogInfo 发送 Info 级别的结构化日志，自动关联 trace 上下文；同时写入 zap stdout。
+// LogInfo emits an Info-level structured log with trace context and writes to zap stdout.
 func LogInfo(ctx context.Context, message string, attrs ...otellog.KeyValue) {
 	emitLog(ctx, otellog.SeverityInfo, message, attrs...)
 	logger.Info(formatForStdout(ctx, message, attrs))
 }
 
-// LogWarn 发送 Warn 级别的结构化日志，自动关联 trace 上下文；同时写入 zap stdout。
+// LogWarn emits a Warn-level structured log with trace context and writes to zap stdout.
 func LogWarn(ctx context.Context, message string, attrs ...otellog.KeyValue) {
 	emitLog(ctx, otellog.SeverityWarn, message, attrs...)
 	logger.Warn(formatForStdout(ctx, message, attrs))
 }
 
-// LogError 发送 Error 级别的结构化日志，在当前 span 记录错误；同时写入 zap stdout。
+// LogError emits an Error-level structured log, records it on the current span, and writes to zap stdout.
 func LogError(ctx context.Context, message string, err error, attrs ...otellog.KeyValue) {
 	span := trace.SpanFromContext(ctx)
 	if err != nil {
@@ -72,7 +72,7 @@ func LogError(ctx context.Context, message string, err error, attrs ...otellog.K
 	logger.Error(formatForStdout(ctx, message, allAttrs))
 }
 
-// emitLog 通用 OTel 日志发送函数。
+// emitLog sends an OpenTelemetry log record.
 func emitLog(ctx context.Context, severity otellog.Severity, message string, attrs ...otellog.KeyValue) {
 	span := trace.SpanFromContext(ctx)
 
@@ -90,7 +90,7 @@ func emitLog(ctx context.Context, severity otellog.Severity, message string, att
 	otelLogger.Emit(ctx, record)
 }
 
-// baseLogAttributes 构建基础日志属性，包含 trace 关联信息。
+// baseLogAttributes builds base log attributes, including trace correlation metadata.
 func baseLogAttributes(span trace.Span) []otellog.KeyValue {
 	attrs := []otellog.KeyValue{
 		otellog.String("service.name", globalServiceName),
@@ -108,7 +108,7 @@ func baseLogAttributes(span trace.Span) []otellog.KeyValue {
 	return attrs
 }
 
-// formatForStdout 拼装 stdout 日志行：[trace=... span=...] message k=v k=v
+// formatForStdout formats a stdout log line: [trace=... span=...] message k=v k=v.
 func formatForStdout(ctx context.Context, message string, attrs []otellog.KeyValue) string {
 	var b strings.Builder
 	sc := trace.SpanFromContext(ctx).SpanContext()

--- a/comm-go/otel/oteltrace/attr.go
+++ b/comm-go/otel/oteltrace/attr.go
@@ -42,7 +42,7 @@ const (
 	HTTP_HEADER_ACCOUNT_TYPE    = "x-account-type"
 )
 
-// TraceAttrs HTTP 请求相关属性的汇总，用于埋点。
+// TraceAttrs groups HTTP request attributes used for tracing.
 type TraceAttrs struct {
 	HttpUrl            string
 	HttpMethod         string
@@ -56,7 +56,7 @@ type TraceAttrs struct {
 	HttpClientIP       string
 }
 
-// GetAttrsByGinCtx 从 *gin.Context 抽取 TraceAttrs。
+// GetAttrsByGinCtx extracts TraceAttrs from a *gin.Context.
 func GetAttrsByGinCtx(c *gin.Context) TraceAttrs {
 	return TraceAttrs{
 		HttpUrl:            fmt.Sprintf("http://%s%s", c.Request.Host, c.Request.RequestURI),
@@ -72,7 +72,7 @@ func GetAttrsByGinCtx(c *gin.Context) TraceAttrs {
 	}
 }
 
-// serverClientIP 从 X-Forwarded-For 头取第一段。
+// serverClientIP returns the first address from X-Forwarded-For.
 func serverClientIP(xForwardedFor string) string {
 	if idx := strings.Index(xForwardedFor, ","); idx >= 0 {
 		xForwardedFor = xForwardedFor[:idx]
@@ -80,7 +80,7 @@ func serverClientIP(xForwardedFor string) string {
 	return xForwardedFor
 }
 
-// AddHttpAttrs4API 设置 API 入口 span 的 HTTP 属性。
+// AddHttpAttrs4API sets HTTP attributes on an API entry span.
 func AddHttpAttrs4API(span trace.Span, attrs TraceAttrs) {
 	span.SetAttributes(
 		attr.Key(KEY_HTTP_URL).String(attrs.HttpUrl),
@@ -100,7 +100,7 @@ func AddHttpAttrs4API(span trace.Span, attrs TraceAttrs) {
 	}
 }
 
-// AddHttpAttrs4Error 设置错误状态到 span。
+// AddHttpAttrs4Error records an error status on a span.
 func AddHttpAttrs4Error(span trace.Span, status int, errorCode string, statusDescription string) {
 	span.SetAttributes(
 		attr.Key(KEY_HTTP_STATUS).Int(status),
@@ -109,7 +109,7 @@ func AddHttpAttrs4Error(span trace.Span, status int, errorCode string, statusDes
 	span.SetStatus(codes.Error, statusDescription)
 }
 
-// AddHttpAttrs4HttpError 从 *rest.HTTPError 设置错误到 span。
+// AddHttpAttrs4HttpError records a *rest.HTTPError on a span.
 func AddHttpAttrs4HttpError(span trace.Span, err *rest.HTTPError) {
 	span.SetAttributes(
 		attr.Key(KEY_HTTP_STATUS).Int(err.HTTPCode),
@@ -118,13 +118,13 @@ func AddHttpAttrs4HttpError(span trace.Span, err *rest.HTTPError) {
 	span.SetStatus(codes.Error, fmt.Sprintf("%v", err.BaseError.ErrorDetails))
 }
 
-// AddHttpAttrs4Ok 设置成功状态到 span。
+// AddHttpAttrs4Ok records a successful span status.
 func AddHttpAttrs4Ok(span trace.Span, status int) {
 	span.SetAttributes(attr.Key(KEY_HTTP_STATUS).Int(status))
 	span.SetStatus(codes.Ok, "")
 }
 
-// AddAttrs4InternalHttp 设置内部 http 调用 span 的属性。
+// AddAttrs4InternalHttp sets attributes for an internal HTTP client span.
 func AddAttrs4InternalHttp(span trace.Span, attrs TraceAttrs) {
 	span.SetAttributes(
 		attr.Key(KEY_HTTP_URL).String(attrs.HttpUrl),

--- a/comm-go/otel/oteltrace/span.go
+++ b/comm-go/otel/oteltrace/span.go
@@ -22,11 +22,11 @@ import (
 )
 
 const (
-	// InstrumentationName 用于创建 tracer 的 instrumentation name
+	// InstrumentationName is the instrumentation name used to create tracers.
 	InstrumentationName = "bkn-backend/otel"
 )
 
-// StartInternalSpan 服务内函数调用创建 span，自动从 runtime.Caller 获取 span name。
+// StartInternalSpan starts a span for an in-service function call and derives its name from runtime.Caller.
 func StartInternalSpan(ctx context.Context) (context.Context, trace.Span) {
 	name, filepath := callerFuncName(2)
 	newCtx, span := StartNamedInternalSpan(ctx, name)
@@ -36,7 +36,7 @@ func StartInternalSpan(ctx context.Context) (context.Context, trace.Span) {
 	return newCtx, span
 }
 
-// StartClientSpan 外部依赖调用创建 span，自动从 runtime.Caller 获取 span name。
+// StartClientSpan starts a span for an external dependency call and derives its name from runtime.Caller.
 func StartClientSpan(ctx context.Context) (context.Context, trace.Span) {
 	name, filepath := callerFuncName(2)
 	newCtx, span := StartNamedClientSpan(ctx, name)
@@ -46,7 +46,7 @@ func StartClientSpan(ctx context.Context) (context.Context, trace.Span) {
 	return newCtx, span
 }
 
-// StartServerSpanFromContext 服务端调用创建 span，自动从 runtime.Caller 获取 span name。
+// StartServerSpanFromContext starts a server span and derives its name from runtime.Caller.
 func StartServerSpanFromContext(ctx context.Context) (context.Context, trace.Span) {
 	name, filepath := callerFuncName(2)
 	newCtx, span := StartNamedServerSpan(ctx, name)
@@ -56,7 +56,7 @@ func StartServerSpanFromContext(ctx context.Context) (context.Context, trace.Spa
 	return newCtx, span
 }
 
-// StartProducerSpan 消息生产创建 span，自动从 runtime.Caller 获取 span name。
+// StartProducerSpan starts a message producer span and derives its name from runtime.Caller.
 func StartProducerSpan(ctx context.Context) (context.Context, trace.Span) {
 	name, filepath := callerFuncName(2)
 	newCtx, span := StartNamedProducerSpan(ctx, name)
@@ -66,7 +66,7 @@ func StartProducerSpan(ctx context.Context) (context.Context, trace.Span) {
 	return newCtx, span
 }
 
-// StartConsumerSpan 消息消费创建 span，自动从 runtime.Caller 获取 span name。
+// StartConsumerSpan starts a message consumer span and derives its name from runtime.Caller.
 func StartConsumerSpan(ctx context.Context) (context.Context, trace.Span) {
 	name, filepath := callerFuncName(2)
 	newCtx, span := StartNamedConsumerSpan(ctx, name)
@@ -85,35 +85,34 @@ func callerFuncName(skip int) (string, string) {
 	return funcPaths[len(funcPaths)-1], fmt.Sprintf("%s:%v", file, lineNo)
 }
 
-// StartNamedClientSpan用自定义业务名创建 SpanKindClient 类型 span。
+// StartNamedClientSpan starts a SpanKindClient span with a caller-provided name.
 func StartNamedClientSpan(ctx context.Context, name string) (context.Context, trace.Span) {
 	return otel.Tracer(InstrumentationName).Start(ctx, name, trace.WithSpanKind(trace.SpanKindClient))
 }
 
-// StartNamedInternalSpan 用自定义业务名创建 SpanKindInternal 类型 span。
+// StartNamedInternalSpan starts a SpanKindInternal span with a caller-provided name.
 func StartNamedInternalSpan(ctx context.Context, name string) (context.Context, trace.Span) {
 	return otel.Tracer(InstrumentationName).Start(ctx, name, trace.WithSpanKind(trace.SpanKindInternal))
 }
 
-// StartNamedServerSpan 用自定义业务名创建 SpanKindServer 类型 span。
+// StartNamedServerSpan starts a SpanKindServer span with a caller-provided name.
 func StartNamedServerSpan(ctx context.Context, name string) (context.Context, trace.Span) {
 	return otel.Tracer(InstrumentationName).Start(ctx, name, trace.WithSpanKind(trace.SpanKindServer))
 }
 
-// StartNamedProducerSpan 用自定义业务名创建 SpanKindProducer 类型 span。
+// StartNamedProducerSpan starts a SpanKindProducer span with a caller-provided name.
 func StartNamedProducerSpan(ctx context.Context, name string) (context.Context, trace.Span) {
 	return otel.Tracer(InstrumentationName).Start(ctx, name, trace.WithSpanKind(trace.SpanKindProducer))
 }
 
-// StartNamedConsumerSpan 用自定义业务名创建 SpanKindConsumer 类型 span。
+// StartNamedConsumerSpan starts a SpanKindConsumer span with a caller-provided name.
 func StartNamedConsumerSpan(ctx context.Context, name string) (context.Context, trace.Span) {
 	return otel.Tracer(InstrumentationName).Start(ctx, name, trace.WithSpanKind(trace.SpanKindConsumer))
 }
 
-// StartServerSpan 跨服务（HTTP 接口）创建 span。
-// 前置依赖：TracingMiddleware 已把 trace header 提取到 c.Request.Context()，
-//
-//	LanguageMiddleware 已把 language 叠加到 c.Request.Context()。
+// StartServerSpan starts a span for a cross-service HTTP request.
+// Prerequisites: TracingMiddleware extracts trace headers into c.Request.Context(),
+// and LanguageMiddleware adds the language to c.Request.Context().
 func StartServerSpan(c *gin.Context) (context.Context, trace.Span) {
 	spanName := fmt.Sprintf("%s %s", c.Request.Method, c.FullPath())
 	newCtx, span := StartNamedServerSpan(c.Request.Context(), spanName)
@@ -126,7 +125,7 @@ func StartServerSpan(c *gin.Context) (context.Context, trace.Span) {
 	return newCtx, span
 }
 
-// ExtractTraceHeader 从 HTTP Header 中提取 Trace 上下文。
+// ExtractTraceHeader extracts trace context from HTTP headers.
 func ExtractTraceHeader(ctx context.Context, header http.Header) context.Context {
 	if header == nil {
 		return ctx
@@ -135,13 +134,13 @@ func ExtractTraceHeader(ctx context.Context, header http.Header) context.Context
 	return otel.GetTextMapPropagator().Extract(ctx, propagation.HeaderCarrier(header))
 }
 
-// SetAttributes 在当前 span 上设置属性。
+// SetAttributes applies attributes to the current span.
 func SetAttributes(ctx context.Context, kv ...attr.KeyValue) {
 	span := trace.SpanFromContext(ctx)
 	span.SetAttributes(kv...)
 }
 
-// EndSpan 结束当前 span，如有错误则记录。
+// EndSpan finishes the current span and records an error when provided.
 func EndSpan(ctx context.Context, err error) {
 	span := trace.SpanFromContext(ctx)
 	if span == nil {

--- a/comm-go/otel/providers.go
+++ b/comm-go/otel/providers.go
@@ -19,13 +19,13 @@ import (
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
 )
 
-// Providers 保存所有 provider，便于服务退出时统一关闭。
+// Providers holds all providers so services can shut them down together.
 type Providers struct {
 	TracerProvider *sdktrace.TracerProvider
 	LoggerProvider *sdklog.LoggerProvider
 }
 
-// Shutdown 按顺序优雅关闭所有 provider。
+// Shutdown gracefully closes all providers in order.
 func (p *Providers) Shutdown(ctx context.Context) {
 	if p.TracerProvider != nil {
 		if err := p.TracerProvider.Shutdown(ctx); err != nil {

--- a/comm-go/otel/resource.go
+++ b/comm-go/otel/resource.go
@@ -14,7 +14,7 @@ import (
 	semconv "go.opentelemetry.io/otel/semconv/v1.26.0"
 )
 
-// buildResource 组装服务资源信息，供 traces/logs provider 共用。
+// buildResource assembles service resource metadata shared by trace and log providers.
 func buildResource(ctx context.Context, cfg *OtelConfig) (*resource.Resource, error) {
 	res, err := resource.New(ctx,
 		resource.WithAttributes(

--- a/comm-go/rest/common_errors.go
+++ b/comm-go/rest/common_errors.go
@@ -6,9 +6,16 @@
 
 package rest
 
-// 系统默认错误
+import (
+	_ "embed"
+
+	"github.com/BurntSushi/toml"
+
+	"github.com/openbkn-ai/bkn-foundry/comm-go/logger"
+)
+
+// System default error codes.
 const (
-	// 公共错误码
 	PublicError_BadRequest          = "Public.BadRequest"
 	PublicError_Unauthorized        = "Public.Unauthorized"
 	PublicError_Forbidden           = "Public.Forbidden"
@@ -20,133 +27,80 @@ const (
 	PublicError_ServiceUnavailable  = "Public.ServiceUnavailable"
 )
 
-var (
-	PublicErrorI18n = map[string]map[string]BaseError{
-		PublicError_BadRequest: {
-			"zh-CN": {
-				ErrorCode:   PublicError_BadRequest,
-				Description: "参数错误",
-				Solution:    "暂无",
-				ErrorLink:   "暂无",
-			},
-			"en-US": {
-				ErrorCode:   PublicError_BadRequest,
-				Description: "bad request",
-				Solution:    "None",
-				ErrorLink:   "None",
-			},
-		},
-		PublicError_Unauthorized: {
-			"zh-CN": {
-				ErrorCode:   PublicError_Unauthorized,
-				Description: "认证失败",
-				Solution:    "暂无",
-				ErrorLink:   "暂无",
-			},
-			"en-US": {
-				ErrorCode:   PublicError_Unauthorized,
-				Description: "authorized failed",
-				Solution:    "None",
-				ErrorLink:   "None",
-			},
-		},
-		PublicError_Forbidden: {
-			"zh-CN": {
-				ErrorCode:   PublicError_Forbidden,
-				Description: "权限错误",
-				Solution:    "暂无",
-				ErrorLink:   "暂无",
-			},
-			"en-US": {
-				ErrorCode:   PublicError_Forbidden,
-				Description: "permission error",
-				Solution:    "None",
-				ErrorLink:   "None",
-			},
-		},
-		PublicError_NotFound: {
-			"zh-CN": {
-				ErrorCode:   PublicError_NotFound,
-				Description: "对象不存在",
-				Solution:    "暂无",
-				ErrorLink:   "暂无",
-			},
-			"en-US": {
-				ErrorCode:   PublicError_NotFound,
-				Description: "not found",
-				Solution:    "None",
-				ErrorLink:   "None",
-			},
-		},
-		PublicError_MethodNotAllowed: {
-			"zh-CN": {
-				ErrorCode:   PublicError_MethodNotAllowed,
-				Description: "不支持的mtehod方法",
-				Solution:    "暂无",
-				ErrorLink:   "暂无",
-			},
-			"en-US": {
-				ErrorCode:   PublicError_MethodNotAllowed,
-				Description: "method not allowed",
-				Solution:    "None",
-				ErrorLink:   "None",
-			},
-		},
-		PublicError_Conflict: {
-			"zh-CN": {
-				ErrorCode:   PublicError_Conflict,
-				Description: "资源冲突",
-				Solution:    "暂无",
-				ErrorLink:   "暂无",
-			},
-			"en-US": {
-				ErrorCode:   PublicError_Conflict,
-				Description: "conflict",
-				Solution:    "None",
-				ErrorLink:   "None",
-			},
-		},
-		PublicError_InternalServerError: {
-			"zh-CN": {
-				ErrorCode:   PublicError_InternalServerError,
-				Description: "内部错误",
-				Solution:    "暂无",
-				ErrorLink:   "暂无",
-			},
-			"en-US": {
-				ErrorCode:   PublicError_InternalServerError,
-				Description: "internal server error",
-				Solution:    "None",
-				ErrorLink:   "None",
-			},
-		},
-		PublicError_NotImplemented: {
-			"zh-CN": {
-				ErrorCode:   PublicError_NotImplemented,
-				Description: "服务端未实现请求方法",
-				Solution:    "暂无",
-				ErrorLink:   "暂无",
-			},
-			"en-US": {
-				ErrorCode:   PublicError_NotImplemented,
-				Description: "not implemented",
-				Solution:    "None",
-				ErrorLink:   "None",
-			},
-		},
-		PublicError_ServiceUnavailable: {
-			"zh-CN": {
-				ErrorCode:   PublicError_ServiceUnavailable,
-				Description: "服务端暂时不可用",
-				Solution:    "暂无",
-				ErrorLink:   "暂无",
-			},
-			"en-US": {
-				ErrorCode:   PublicError_ServiceUnavailable,
-				Description: "service unavailable",
-				Solution:    "None",
-				ErrorLink:   "None",
-			},
-		},
+var publicErrorCodes = []string{
+	PublicError_BadRequest,
+	PublicError_Unauthorized,
+	PublicError_Forbidden,
+	PublicError_NotFound,
+	PublicError_MethodNotAllowed,
+	PublicError_Conflict,
+	PublicError_InternalServerError,
+	PublicError_NotImplemented,
+	PublicError_ServiceUnavailable,
+}
+
+var publicErrorLocales = []Language{SimplifiedChinese, AmericanEnglish}
+
+//go:embed locales/public-errors.zh-CN.toml
+var publicErrorsChinese []byte
+
+//go:embed locales/public-errors.en-US.toml
+var publicErrorsEnglish []byte
+
+type publicErrorMessage struct {
+	Description string
+	Solution    string
+	ErrorLink   string
+}
+
+// PublicErrorI18n is loaded from resources embedded in comm-go. Embedding keeps
+// the public HTTP error catalog available in every consumer image.
+var PublicErrorI18n = loadPublicErrorI18n()
+
+func loadPublicErrorI18n() map[string]map[string]BaseError {
+	resources := map[Language][]byte{
+		SimplifiedChinese: publicErrorsChinese,
+		AmericanEnglish:   publicErrorsEnglish,
 	}
-)
+	parsed := make(map[Language]map[string]publicErrorMessage, len(resources))
+	for lang, contents := range resources {
+		messages := make(map[string]publicErrorMessage)
+		if err := toml.Unmarshal(contents, &messages); err != nil {
+			logger.Warnf("load embedded public error locale %s: %v", lang, err)
+			continue
+		}
+		parsed[lang] = messages
+	}
+
+	errors := make(map[string]map[string]BaseError, len(publicErrorCodes))
+	for _, code := range publicErrorCodes {
+		errors[code] = make(map[string]BaseError, len(publicErrorLocales))
+		for _, lang := range publicErrorLocales {
+			message, ok := parsed[lang][code]
+			if !ok || message.Description == "" || message.Solution == "" {
+				logger.Warnf("embedded public error locale missing message: locale=%s error_code=%s", lang, code)
+				message = fallbackPublicError(lang)
+			}
+			errors[code][lang] = BaseError{
+				ErrorCode:   code,
+				Description: message.Description,
+				Solution:    message.Solution,
+				ErrorLink:   message.ErrorLink,
+			}
+		}
+	}
+	return errors
+}
+
+func fallbackPublicError(lang Language) publicErrorMessage {
+	if lang == AmericanEnglish {
+		return publicErrorMessage{
+			Description: "Request failed.",
+			Solution:    "See the request details or contact an administrator.",
+		}
+	}
+	return publicErrorMessage{
+		Description: "请求失败。",
+		Solution:    "请查看请求详情或联系管理员。",
+	}
+}

--- a/comm-go/rest/common_errors.go
+++ b/comm-go/rest/common_errors.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/BurntSushi/toml"
 
+	"github.com/openbkn-ai/bkn-foundry/comm-go/i18n"
 	"github.com/openbkn-ai/bkn-foundry/comm-go/logger"
 )
 
@@ -93,14 +94,8 @@ func loadPublicErrorI18n() map[string]map[string]BaseError {
 }
 
 func fallbackPublicError(lang Language) publicErrorMessage {
-	if lang == AmericanEnglish {
-		return publicErrorMessage{
-			Description: "Request failed.",
-			Solution:    "See the request details or contact an administrator.",
-		}
-	}
 	return publicErrorMessage{
-		Description: "请求失败。",
-		Solution:    "请查看请求详情或联系管理员。",
+		Description: i18n.Translate(lang, PublicError_InternalServerError+".Description", nil),
+		Solution:    i18n.Translate(lang, PublicError_InternalServerError+".Solution", nil),
 	}
 }

--- a/comm-go/rest/common_errors_test.go
+++ b/comm-go/rest/common_errors_test.go
@@ -1,0 +1,40 @@
+// Copyright openbkn.ai
+//
+// Licensed under the OpenBKN License. See LICENSE-OPENBKN.txt in the project root.
+
+package rest
+
+import "testing"
+
+func TestEmbeddedPublicErrorsContainBothLocales(t *testing.T) {
+	for _, code := range publicErrorCodes {
+		messages, ok := PublicErrorI18n[code]
+		if !ok {
+			t.Fatalf("missing public error code %s", code)
+		}
+		for _, lang := range []Language{SimplifiedChinese, AmericanEnglish} {
+			message, ok := messages[lang]
+			if !ok {
+				t.Fatalf("missing locale %s for %s", lang, code)
+			}
+			if message.Description == "" || message.Solution == "" {
+				t.Fatalf("incomplete message for %s in %s: %#v", code, lang, message)
+			}
+			if message.ErrorLink != "" {
+				t.Fatalf("ErrorLink for %s in %s = %q, want empty", code, lang, message.ErrorLink)
+			}
+		}
+	}
+}
+
+func TestPublicHTTPErrorUsesEmbeddedLocaleMessage(t *testing.T) {
+	for _, lang := range []Language{SimplifiedChinese, AmericanEnglish} {
+		err := NewHTTPError(WithLanguage(t.Context(), lang), 400, PublicError_BadRequest)
+		if err == nil || err.BaseError.ErrorLink != "" {
+			t.Fatalf("unexpected public error for %s: %#v", lang, err)
+		}
+		if err.BaseError.Description != PublicErrorI18n[PublicError_BadRequest][lang].Description {
+			t.Fatalf("description for %s = %q", lang, err.BaseError.Description)
+		}
+	}
+}

--- a/comm-go/rest/errors.go
+++ b/comm-go/rest/errors.go
@@ -16,13 +16,13 @@ import (
 )
 
 type BaseError struct {
-	ErrorCode               string         `json:"error_code"`    // 错误码
-	Description             string         `json:"description"`   // 错误描述
-	Solution                string         `json:"solution"`      // 解决方法
-	ErrorLink               string         `json:"error_link"`    // 错误链接
-	ErrorDetails            interface{}    `json:"error_details"` // 详细内容
-	DescriptionTemplateData map[string]any `json:"-"`             // 错误描述参数
-	SolutionTemplateData    map[string]any `json:"-"`             // 解决方法参数
+	ErrorCode               string         `json:"error_code"`    // Stable error code.
+	Description             string         `json:"description"`   // Human-readable description.
+	Solution                string         `json:"solution"`      // Suggested resolution.
+	ErrorLink               string         `json:"error_link"`    // Documentation link.
+	ErrorDetails            interface{}    `json:"error_details"` // Structured error details.
+	DescriptionTemplateData map[string]any `json:"-"`             // Description template parameters.
+	SolutionTemplateData    map[string]any `json:"-"`             // Solution template parameters.
 }
 
 var (
@@ -55,7 +55,7 @@ type HTTPError struct {
 	BaseError BaseError
 }
 
-// 创建 HTTPError
+// NewHTTPError creates an HTTP error.
 func NewHTTPError(ctx context.Context, httpCode int, errorCode string) *HTTPError {
 	lang := GetLanguageByCtx(ctx)
 	errs, ok := allErrs[errorCode]
@@ -94,7 +94,7 @@ func (e *HTTPError) WithSolution(templateData map[string]interface{}) *HTTPError
 	return e
 }
 
-// 设置错误详情
+// WithErrorDetails sets structured error details.
 func (e *HTTPError) WithErrorDetails(errorDetails interface{}) *HTTPError {
 	e.BaseError.ErrorDetails = errorDetails
 	return e

--- a/comm-go/rest/http_client.go
+++ b/comm-go/rest/http_client.go
@@ -25,7 +25,7 @@ import (
 
 //go:generate mockgen -package mock -source ./http_client.go -destination ./mock/mock_http_client.go
 
-// HTTPClient HTTP客户端服务接口
+// HTTPClient defines the HTTP client service interface.
 type HTTPClient interface {
 	Get(ctx context.Context, url string, queryValues url.Values, headers map[string]string) (respCode int, respData interface{}, err error)
 	GetNoUnmarshal(ctx context.Context, url string, queryValues url.Values, headers map[string]string) (respCode int, respBody []byte, err error)
@@ -39,17 +39,17 @@ type HTTPClient interface {
 	PatchNoUnmarshal(ctx context.Context, url string, headers map[string]string, reqParam interface{}) (respCode int, respBody []byte, err error)
 }
 
-// httpClient HTTP客户端结构
+// httpClient implements HTTPClient.
 type httpClient struct {
 	client *http.Client
 }
 
-// httpClient 配置信息
+// HttpClientOptions configures an HTTP client.
 type HttpClientOptions struct {
 	TimeOut int
 }
 
-// NewRawHTTPClient 创建原生HTTP客户端对象
+// NewRawHTTPClient creates a raw HTTP client.
 func NewRawHTTPClient() *http.Client {
 	opts := HttpClientOptions{
 		TimeOut: 600,
@@ -57,7 +57,7 @@ func NewRawHTTPClient() *http.Client {
 	return NewRawHTTPClientWithOptions(opts)
 }
 
-// NewHTTPClientWithOptions 根据配置创建HTTP客户端对象
+// NewHTTPClientWithOptions creates an HTTP client with the supplied options.
 func NewHTTPClientWithOptions(opts HttpClientOptions) HTTPClient {
 	client := &httpClient{
 		client: NewRawHTTPClientWithOptions(opts),
@@ -66,7 +66,7 @@ func NewHTTPClientWithOptions(opts HttpClientOptions) HTTPClient {
 	return client
 }
 
-// NewRawHTTPClientWithOptions 根据配置创建原生HTTP客户端对象
+// NewRawHTTPClientWithOptions creates a raw HTTP client with the supplied options.
 func NewRawHTTPClientWithOptions(opts HttpClientOptions) *http.Client {
 	rawClient := &http.Client{
 		CheckRedirect: func(req *http.Request, via []*http.Request) error {
@@ -95,7 +95,7 @@ func NewHTTPClientWithRawClient(rawClient *http.Client) *httpClient {
 	return client
 }
 
-// NewHTTPClient 创建HTTP客户端对象
+// NewHTTPClient creates an HTTP client.
 func NewHTTPClient() HTTPClient {
 	client := &httpClient{
 		client: NewRawHTTPClient(),
@@ -104,7 +104,7 @@ func NewHTTPClient() HTTPClient {
 	return client
 }
 
-// Get, 返回序列化对象
+// Get returns a decoded response object.
 func (c *httpClient) Get(ctx context.Context, rawURL string, queryValues url.Values, headers map[string]string) (respCode int, respData interface{}, err error) {
 	url, err := c.generateURL(rawURL, queryValues)
 	if err != nil {
@@ -115,7 +115,7 @@ func (c *httpClient) Get(ctx context.Context, rawURL string, queryValues url.Val
 	return c.httpDo(ctx, http.MethodGet, url.String(), headers, nil)
 }
 
-// Get, 返回text
+// GetNoUnmarshal returns the raw response body.
 func (c *httpClient) GetNoUnmarshal(ctx context.Context, rawURL string, queryValues url.Values, headers map[string]string) (respCode int, respBody []byte, err error) {
 	url, err := c.generateURL(rawURL, queryValues)
 	if err != nil {
@@ -126,47 +126,47 @@ func (c *httpClient) GetNoUnmarshal(ctx context.Context, rawURL string, queryVal
 	return c.httpDoNoUnmarshal(ctx, http.MethodGet, url.String(), headers, nil)
 }
 
-// Post, 传入序列化对象，返回序列化对象
+// Post sends a serializable request and returns a decoded response object.
 func (c *httpClient) Post(ctx context.Context, url string, headers map[string]string, reqParam interface{}) (respCode int, respData interface{}, err error) {
 	return c.httpDo(ctx, http.MethodPost, url, headers, reqParam)
 }
 
-// Post, 传入序列化对象，返回text
+// PostNoUnmarshal sends a serializable request and returns the raw response body.
 func (c *httpClient) PostNoUnmarshal(ctx context.Context, url string, headers map[string]string, reqParam interface{}) (respCode int, respBody []byte, err error) {
 	return c.httpDoNoUnmarshal(ctx, http.MethodPost, url, headers, reqParam)
 }
 
-// Put, 传入序列化对象，返回序列化对象
+// Put sends a serializable request and returns a decoded response object.
 func (c *httpClient) Put(ctx context.Context, url string, headers map[string]string, reqParam interface{}) (respCode int, respData interface{}, err error) {
 	return c.httpDo(ctx, http.MethodPut, url, headers, reqParam)
 }
 
-// Put, 传入序列化对象，返回text
+// PutNoUnmarshal sends a serializable request and returns the raw response body.
 func (c *httpClient) PutNoUnmarshal(ctx context.Context, url string, headers map[string]string, reqParam interface{}) (respCode int, respBody []byte, err error) {
 	return c.httpDoNoUnmarshal(ctx, http.MethodPut, url, headers, reqParam)
 }
 
-// Delete, 返回序列化对象
+// Delete returns a decoded response object.
 func (c *httpClient) Delete(ctx context.Context, url string, headers map[string]string) (respCode int, respData interface{}, err error) {
 	return c.httpDo(ctx, http.MethodDelete, url, headers, nil)
 }
 
-// Delete, 传入序列化对象，返回text
+// DeleteNoUnmarshal returns the raw response body.
 func (c *httpClient) DeleteNoUnmarshal(ctx context.Context, url string, headers map[string]string) (respCode int, respBody []byte, err error) {
 	return c.httpDoNoUnmarshal(ctx, http.MethodDelete, url, headers, nil)
 }
 
-// Patch, 传入序列化对象，返回序列化对象
+// Patch sends a serializable request and returns a decoded response object.
 func (c *httpClient) Patch(ctx context.Context, url string, headers map[string]string, reqParam interface{}) (respCode int, respData interface{}, err error) {
 	return c.httpDo(ctx, http.MethodPatch, url, headers, reqParam)
 }
 
-// Patch, 传入序列化对象，返回text
+// PatchNoUnmarshal sends a serializable request and returns the raw response body.
 func (c *httpClient) PatchNoUnmarshal(ctx context.Context, url string, headers map[string]string, reqParam interface{}) (respCode int, respBody []byte, err error) {
 	return c.httpDoNoUnmarshal(ctx, http.MethodPatch, url, headers, reqParam)
 }
 
-// 反序列化返回内容
+// httpDo decodes the response body.
 func (c *httpClient) httpDo(ctx context.Context, mtehod string, url string, headers map[string]string,
 	reqParam interface{}) (respCode int, respData interface{}, err error) {
 
@@ -186,7 +186,7 @@ func (c *httpClient) httpDo(ctx context.Context, mtehod string, url string, head
 	return
 }
 
-// 返回原始respBody, 不进行反序列化
+// httpDoNoUnmarshal returns the raw response body without decoding it.
 func (c *httpClient) httpDoNoUnmarshal(ctx context.Context, mtehod string, url string, headers map[string]string,
 	reqParam interface{}) (respCode int, respBody []byte, err error) {
 
@@ -200,7 +200,7 @@ func (c *httpClient) httpDoNoUnmarshal(ctx context.Context, mtehod string, url s
 		return 0, nil, err
 	}
 
-	// 把 trace 上下文注入到请求的 header 中
+	// Inject the trace context into request headers.
 	otel.GetTextMapPropagator().Inject(ctx, propagation.HeaderCarrier(req.Header))
 
 	resp, err := c.client.Do(req)

--- a/comm-go/rest/locales/public-errors.en-US.toml
+++ b/comm-go/rest/locales/public-errors.en-US.toml
@@ -1,0 +1,48 @@
+# Copyright openbkn.ai
+#
+# Licensed under the OpenBKN License. See LICENSE-OPENBKN.txt in the project root.
+
+["Public.BadRequest"]
+Description = "Invalid request parameters."
+Solution = "Check the request parameters and try again."
+ErrorLink = ""
+
+["Public.Unauthorized"]
+Description = "Authentication failed."
+Solution = "Provide valid authentication credentials."
+ErrorLink = ""
+
+["Public.Forbidden"]
+Description = "You do not have permission to perform this operation."
+Solution = "Contact an administrator to obtain the required permission."
+ErrorLink = ""
+
+["Public.NotFound"]
+Description = "The requested resource was not found."
+Solution = "Check that the resource identifier is correct."
+ErrorLink = ""
+
+["Public.MethodNotAllowed"]
+Description = "The request method is not supported."
+Solution = "Use a request method supported by this API."
+ErrorLink = ""
+
+["Public.Conflict"]
+Description = "The request conflicts with the current resource state."
+Solution = "Refresh the resource state and try again."
+ErrorLink = ""
+
+["Public.InternalServerError"]
+Description = "An internal server error occurred."
+Solution = "Try again later."
+ErrorLink = ""
+
+["Public.NotImplemented"]
+Description = "The server does not implement this request."
+Solution = "Confirm the API capability and try again."
+ErrorLink = ""
+
+["Public.ServiceUnavailable"]
+Description = "The service is temporarily unavailable."
+Solution = "Try again later."
+ErrorLink = ""

--- a/comm-go/rest/locales/public-errors.zh-CN.toml
+++ b/comm-go/rest/locales/public-errors.zh-CN.toml
@@ -1,0 +1,48 @@
+# Copyright openbkn.ai
+#
+# Licensed under the OpenBKN License. See LICENSE-OPENBKN.txt in the project root.
+
+["Public.BadRequest"]
+Description = "请求参数无效。"
+Solution = "请检查请求参数后重试。"
+ErrorLink = ""
+
+["Public.Unauthorized"]
+Description = "认证失败。"
+Solution = "请提供有效的认证凭据。"
+ErrorLink = ""
+
+["Public.Forbidden"]
+Description = "没有执行此操作的权限。"
+Solution = "请联系管理员授予所需权限。"
+ErrorLink = ""
+
+["Public.NotFound"]
+Description = "请求的资源不存在。"
+Solution = "请检查资源标识是否正确。"
+ErrorLink = ""
+
+["Public.MethodNotAllowed"]
+Description = "不支持当前请求方法。"
+Solution = "请使用接口支持的请求方法。"
+ErrorLink = ""
+
+["Public.Conflict"]
+Description = "请求与当前资源状态冲突。"
+Solution = "请刷新资源状态后重试。"
+ErrorLink = ""
+
+["Public.InternalServerError"]
+Description = "服务内部错误。"
+Solution = "请稍后重试。"
+ErrorLink = ""
+
+["Public.NotImplemented"]
+Description = "服务端未实现该请求。"
+Solution = "请确认接口能力后重试。"
+ErrorLink = ""
+
+["Public.ServiceUnavailable"]
+Description = "服务暂时不可用。"
+Solution = "请稍后重试。"
+ErrorLink = ""

--- a/comm-go/rest/opensearch_client.go
+++ b/comm-go/rest/opensearch_client.go
@@ -20,7 +20,7 @@ import (
 	"github.com/openbkn-ai/bkn-foundry/comm-go/logger"
 )
 
-// OpenSearch配置项
+// OpenSearchClientConfig configures an OpenSearch client.
 type OpenSearchClientConfig struct {
 	Protocol string
 	Host     string
@@ -29,31 +29,31 @@ type OpenSearchClientConfig struct {
 	Password string `json:"-"`
 }
 
-// NewOpenSearchClient 初始化OpenSearchClient实例
+// NewOpenSearchClient initializes an OpenSearch client.
 func NewOpenSearchClient(cfg OpenSearchClientConfig) *opensearch.Client {
-	// 初始化http.Client
+	// Initialize the HTTP client.
 	transport := &http.Transport{
 		DialContext: (&net.Dialer{
-			Timeout:   30 * time.Second, // 连接超时时间
-			KeepAlive: 60 * time.Second, // 保持长连接的时间
-		}).DialContext, // 设置连接的参数
-		MaxIdleConns:          1000,             // 最大空闲连接
-		IdleConnTimeout:       60 * time.Second, // 空闲连接的超时时间
-		ExpectContinueTimeout: 30 * time.Second, // 等待服务第一个响应的超时时间
-		MaxIdleConnsPerHost:   500,              // 每个host保持的空闲连接数
+			Timeout:   30 * time.Second, // Connection timeout.
+			KeepAlive: 60 * time.Second, // Keep-alive duration.
+		}).DialContext, // Dialer configuration.
+		MaxIdleConns:          1000,             // Maximum idle connections.
+		IdleConnTimeout:       60 * time.Second, // Idle connection timeout.
+		ExpectContinueTimeout: 30 * time.Second, // Wait time for the first response.
+		MaxIdleConnsPerHost:   500,              // Maximum idle connections per host.
 		TLSHandshakeTimeout:   30 * time.Second,
 		TLSClientConfig: &tls.Config{
 			InsecureSkipVerify: true,
 		},
 	}
 
-	// 连接地址
+	// Endpoint address.
 	address := fmt.Sprintf("%s://%s:%d", cfg.Protocol, cfg.Host, cfg.Port)
 
-	// 重试
+	// Retry policy.
 	retryBackoff := backoff.NewExponentialBackOff()
 
-	// 初始化openSearch.Clisnt
+	// Initialize the OpenSearch client.
 	osc, _ := opensearch.NewClient(opensearch.Config{
 		Addresses: []string{
 			address,
@@ -75,7 +75,7 @@ func NewOpenSearchClient(cfg OpenSearchClientConfig) *opensearch.Client {
 	return osc
 }
 
-// 检查连接状态
+// CheckConnection verifies the OpenSearch connection.
 func CheckConnection(osc *opensearch.Client) bool {
 	res, err := osc.Info()
 	if err != nil {

--- a/comm-go/rest/server.go
+++ b/comm-go/rest/server.go
@@ -16,14 +16,14 @@ import (
 	"github.com/openbkn-ai/bkn-foundry/comm-go/logger"
 )
 
-// golangci-lint 要求独立定义key的类型
+// golangci-lint requires a dedicated type for context keys.
 
 const (
 	ContentTypeKey  = "Content-Type"
 	ContentTypeJson = "application/json"
 )
 
-// ReplyOK 响应成功
+// ReplyOK writes a successful response.
 func ReplyOK(c *gin.Context, statusCode int, body interface{}) {
 	var (
 		bodyStr string
@@ -50,7 +50,7 @@ func ReplyOkWithHeaders(c *gin.Context, statusCode int, body interface{}, header
 	ReplyOK(c, statusCode, body)
 }
 
-// ReplyError 响应错误
+// ReplyError writes an error response.
 func ReplyError(c *gin.Context, err error) {
 	var statusCode int
 	var body string


### PR DESCRIPTION
## Summary
- move comm-go public HTTP error text from Go maps into embedded TOML catalogs
- standardize absent ErrorLink as an empty string while retaining the response field
- allow only ErrorLink entries to be empty during strict locale validation
- add resource and public-error regression coverage

Closes #902.

## Verification
- `go test ./i18n ./rest` in `comm-go`
- `go test ./...` reaches unrelated database driver tests but requires MYSQL_TEST_PORT, DM_TEST_PORT, and KDB_TEST_PORT in this environment