### PR TITLE
fix(i18n): make locale resource loading non-fatal

### DIFF
--- a/adp/context-loader/agent-retrieval/server/driveradapters/mcp/locale.go
+++ b/adp/context-loader/agent-retrieval/server/driveradapters/mcp/locale.go
@@ -9,6 +9,8 @@ package mcp
 import (
 	"encoding/json"
 	"fmt"
+	"io/fs"
+	"log"
 	"os"
 	"strings"
 	"sync"
@@ -41,6 +43,10 @@ func loadMCPLocaleBundle(locale string) *mcpLocaleBundle {
 }
 
 func buildMCPLocaleBundle(normalized string) *mcpLocaleBundle {
+	return buildMCPLocaleBundleFromFS(schemasFS, normalized)
+}
+
+func buildMCPLocaleBundleFromFS(resources fs.FS, normalized string) *mcpLocaleBundle {
 	bundle := &mcpLocaleBundle{
 		locale:       normalized,
 		instructions: serverInstructions,
@@ -49,17 +55,31 @@ func buildMCPLocaleBundle(normalized string) *mcpLocaleBundle {
 		return bundle
 	}
 	base := fmt.Sprintf("schemas/locales/%s", normalized)
-	if data, err := schemasFS.ReadFile(base + "/instructions.txt"); err == nil {
+	if data, err := fs.ReadFile(resources, base+"/instructions.txt"); err != nil {
+		log.Printf("WARN: cannot load MCP locale instructions for %s: %v; using baseline", normalized, err)
+	} else if strings.TrimSpace(string(data)) == "" {
+		log.Printf("WARN: MCP locale instructions for %s are empty; using baseline", normalized)
+	} else {
 		bundle.instructions = string(data)
 	}
-	if data, err := schemasFS.ReadFile(base + "/tools_meta.json"); err == nil {
+	if data, err := fs.ReadFile(resources, base+"/tools_meta.json"); err != nil {
+		log.Printf("WARN: cannot load MCP locale tool metadata for %s: %v; using baseline", normalized, err)
+	} else {
 		if err := json.Unmarshal(data, &bundle.toolMeta); err != nil {
-			panic("invalid localized tools_meta.json: " + err.Error())
+			log.Printf("WARN: cannot parse MCP locale tool metadata for %s: %v; using baseline", normalized, err)
+			bundle.toolMeta = nil
+		} else if bundle.toolMeta == nil {
+			log.Printf("WARN: MCP locale tool metadata for %s is empty; using baseline", normalized)
 		}
 	}
-	if data, err := schemasFS.ReadFile(base + "/schema_descriptions.json"); err == nil {
+	if data, err := fs.ReadFile(resources, base+"/schema_descriptions.json"); err != nil {
+		log.Printf("WARN: cannot load MCP locale schema descriptions for %s: %v; using baseline", normalized, err)
+	} else {
 		if err := json.Unmarshal(data, &bundle.schemaDescriptions); err != nil {
-			panic("invalid schema_descriptions.json: " + err.Error())
+			log.Printf("WARN: cannot parse MCP locale schema descriptions for %s: %v; using baseline", normalized, err)
+			bundle.schemaDescriptions = nil
+		} else if bundle.schemaDescriptions == nil {
+			log.Printf("WARN: MCP locale schema descriptions for %s are empty; using baseline", normalized)
 		}
 	}
 	return bundle

--- a/adp/context-loader/agent-retrieval/server/driveradapters/mcp/locale_test.go
+++ b/adp/context-loader/agent-retrieval/server/driveradapters/mcp/locale_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"strings"
 	"testing"
+	"testing/fstest"
 
 	"github.com/smartystreets/goconvey/convey"
 )
@@ -54,6 +55,42 @@ func TestMCPLocaleBundle(t *testing.T) {
 			}
 		}
 	})
+}
+
+func TestMCPLocaleBundleFallsBackWhenOverlayResourcesAreUnavailable(t *testing.T) {
+	resources := fstest.MapFS{}
+
+	bundle := buildMCPLocaleBundleFromFS(resources, "en-US")
+
+	if got := bundle.ServerInstructions(); got != serverInstructions {
+		t.Fatalf("instructions = %q, want baseline %q", got, serverInstructions)
+	}
+	if bundle.toolMeta != nil {
+		t.Fatalf("tool metadata = %#v, want no overlay", bundle.toolMeta)
+	}
+	if bundle.schemaDescriptions != nil {
+		t.Fatalf("schema descriptions = %#v, want no overlay", bundle.schemaDescriptions)
+	}
+}
+
+func TestMCPLocaleBundleFallsBackWhenOverlayResourcesAreMalformed(t *testing.T) {
+	resources := fstest.MapFS{
+		"schemas/locales/en-US/instructions.txt":         &fstest.MapFile{Data: []byte("English instructions")},
+		"schemas/locales/en-US/tools_meta.json":          &fstest.MapFile{Data: []byte(`{`)},
+		"schemas/locales/en-US/schema_descriptions.json": &fstest.MapFile{Data: []byte(`{`)},
+	}
+
+	bundle := buildMCPLocaleBundleFromFS(resources, "en-US")
+
+	if got := bundle.ServerInstructions(); got != "English instructions" {
+		t.Fatalf("instructions = %q, want localized instructions", got)
+	}
+	if bundle.toolMeta != nil {
+		t.Fatalf("tool metadata = %#v, want no overlay", bundle.toolMeta)
+	}
+	if bundle.schemaDescriptions != nil {
+		t.Fatalf("schema descriptions = %#v, want no overlay", bundle.schemaDescriptions)
+	}
 }
 
 func getNestedString(root map[string]any, path []string) (string, bool) {

--- a/adp/context-loader/agent-retrieval/server/infra/localize/localize.go
+++ b/adp/context-loader/agent-retrieval/server/infra/localize/localize.go
@@ -11,6 +11,8 @@ import (
 	"embed"
 	"encoding/json"
 	"fmt"
+	"io/fs"
+	"log"
 	"strings"
 
 	"github.com/nicksnyder/go-i18n/v2/i18n"
@@ -32,7 +34,11 @@ var (
 
 	defaultLang = "zh_CN"
 	//go:embed locales/*.json
-	locales embed.FS
+	locales         embed.FS
+	loadMessageFile = func(bundle *i18n.Bundle, resources fs.FS, path string) error {
+		_, err := bundle.LoadMessageFileFS(resources, path)
+		return err
+	}
 )
 
 // I18nTranslator 翻译器
@@ -43,22 +49,44 @@ type I18nTranslator struct {
 
 // NewI18nTranslator 新建翻译器
 func NewI18nTranslator(lang string) *I18nTranslator {
+	return newI18nTranslator(lang, locales)
+}
+
+func newI18nTranslator(lang string, resources fs.FS) *I18nTranslator {
 	lang = normalizeLanguageKey(lang)
 	lt, ok := langMap[lang]
 	if !ok {
-		lt = language.SimplifiedChinese
+		lt = langMap[defaultLang]
+	}
+	return newTranslator(lt, resources)
+}
+
+func newTranslator(requested language.Tag, resources fs.FS) *I18nTranslator {
+	active := requested
+	bundle := newBundle(active)
+	if err := loadLocale(bundle, resources, active); err != nil {
+		log.Printf("WARN: cannot load i18n resource for %s: %v; falling back to %s", active, err, langMap[defaultLang])
+		active = langMap[defaultLang]
+		bundle = newBundle(active)
+		if err := loadLocale(bundle, resources, active); err != nil {
+			log.Printf("WARN: cannot load fallback i18n resource for %s: %v; using message IDs", active, err)
+		}
 	}
 	tr := &I18nTranslator{
-		current: lt,
-	}
-	bundle := i18n.NewBundle(tr.current)
-	bundle.RegisterUnmarshalFunc("json", json.Unmarshal)
-	_, err := bundle.LoadMessageFileFS(locales, fmt.Sprintf("locales/%s.json", lt.String()))
-	if err != nil {
-		panic(err)
+		current: active,
 	}
 	tr.loc = i18n.NewLocalizer(bundle, tr.current.String())
 	return tr
+}
+
+func newBundle(lang language.Tag) *i18n.Bundle {
+	bundle := i18n.NewBundle(lang)
+	bundle.RegisterUnmarshalFunc("json", json.Unmarshal)
+	return bundle
+}
+
+func loadLocale(bundle *i18n.Bundle, resources fs.FS, lang language.Tag) error {
+	return loadMessageFile(bundle, resources, fmt.Sprintf("locales/%s.json", lang.String()))
 }
 
 func normalizeLanguageKey(lang string) string {

--- a/adp/context-loader/agent-retrieval/server/infra/localize/localize_test.go
+++ b/adp/context-loader/agent-retrieval/server/infra/localize/localize_test.go
@@ -1,0 +1,43 @@
+// Copyright openbkn.ai
+//
+// Licensed under the OpenBKN License. See LICENSE-OPENBKN.txt in the project root.
+
+package localize
+
+import (
+	"testing"
+	"testing/fstest"
+)
+
+func TestNewI18nTranslatorFallsBackWhenLocaleResourceIsUnavailable(t *testing.T) {
+	resources := fstest.MapFS{
+		"locales/zh-Hans.json": &fstest.MapFile{Data: []byte(`{"desc":{"BadRequest":"参数错误"}}`)},
+	}
+
+	translator := newI18nTranslator("en_US", resources)
+
+	if got := translator.Trans("desc.BadRequest"); got != "参数错误" {
+		t.Fatalf("fallback translation = %q, want %q", got, "参数错误")
+	}
+}
+
+func TestNewI18nTranslatorFallsBackWhenLocaleResourceIsMalformed(t *testing.T) {
+	resources := fstest.MapFS{
+		"locales/en-US.json":   &fstest.MapFile{Data: []byte(`{`)},
+		"locales/zh-Hans.json": &fstest.MapFile{Data: []byte(`{"desc":{"BadRequest":"参数错误"}}`)},
+	}
+
+	translator := newI18nTranslator("en_US", resources)
+
+	if got := translator.Trans("desc.BadRequest"); got != "参数错误" {
+		t.Fatalf("fallback translation = %q, want %q", got, "参数错误")
+	}
+}
+
+func TestNewI18nTranslatorKeepsMessageIDWhenBaselineIsUnavailable(t *testing.T) {
+	translator := newI18nTranslator("en_US", fstest.MapFS{})
+
+	if got := translator.Trans("desc.BadRequest"); got != "desc.BadRequest" {
+		t.Fatalf("translation = %q, want message ID", got)
+	}
+}

--- a/adp/execution-factory/operator-integration/server/infra/localize/localize.go
+++ b/adp/execution-factory/operator-integration/server/infra/localize/localize.go
@@ -5,6 +5,8 @@ import (
 	"embed"
 	"encoding/json"
 	"fmt"
+	"io/fs"
+	"log"
 
 	"github.com/nicksnyder/go-i18n/v2/i18n"
 	"golang.org/x/text/language"
@@ -25,7 +27,11 @@ var (
 
 	defaultLang = "zh_CN"
 	//go:embed locales/*.json
-	locales embed.FS
+	locales         embed.FS
+	loadMessageFile = func(bundle *i18n.Bundle, resources fs.FS, path string) error {
+		_, err := bundle.LoadMessageFileFS(resources, path)
+		return err
+	}
 )
 
 // I18nTranslator 翻译器
@@ -36,24 +42,46 @@ type I18nTranslator struct {
 
 // NewI18nTranslator 新建翻译器
 func NewI18nTranslator(lang string) *I18nTranslator {
+	return newI18nTranslator(lang, locales)
+}
+
+func newI18nTranslator(lang string, resources fs.FS) *I18nTranslator {
 	if lang == "" {
 		lang = defaultLang
 	}
 	lt, _, err := getLang(lang)
 	if err != nil {
-		lt = language.SimplifiedChinese
+		lt = langMap[defaultLang]
+	}
+	return newTranslator(lt, resources)
+}
+
+func newTranslator(requested language.Tag, resources fs.FS) *I18nTranslator {
+	active := requested
+	bundle := newBundle(active)
+	if err := loadLocale(bundle, resources, active); err != nil {
+		log.Printf("WARN: cannot load i18n resource for %s: %v; falling back to %s", active, err, langMap[defaultLang])
+		active = langMap[defaultLang]
+		bundle = newBundle(active)
+		if err := loadLocale(bundle, resources, active); err != nil {
+			log.Printf("WARN: cannot load fallback i18n resource for %s: %v; using message IDs", active, err)
+		}
 	}
 	tr := &I18nTranslator{
-		current: lt,
-	}
-	bundle := i18n.NewBundle(tr.current)
-	bundle.RegisterUnmarshalFunc("json", json.Unmarshal)
-	_, err = bundle.LoadMessageFileFS(locales, fmt.Sprintf("locales/%s.json", lt.String()))
-	if err != nil {
-		panic(err)
+		current: active,
 	}
 	tr.loc = i18n.NewLocalizer(bundle, tr.current.String())
 	return tr
+}
+
+func newBundle(lang language.Tag) *i18n.Bundle {
+	bundle := i18n.NewBundle(lang)
+	bundle.RegisterUnmarshalFunc("json", json.Unmarshal)
+	return bundle
+}
+
+func loadLocale(bundle *i18n.Bundle, resources fs.FS, lang language.Tag) error {
+	return loadMessageFile(bundle, resources, fmt.Sprintf("locales/%s.json", lang.String()))
 }
 
 // Trans 翻译

--- a/adp/execution-factory/operator-integration/server/infra/localize/localize_test.go
+++ b/adp/execution-factory/operator-integration/server/infra/localize/localize_test.go
@@ -1,0 +1,43 @@
+// Copyright openbkn.ai
+//
+// Licensed under the OpenBKN License. See LICENSE-OPENBKN.txt in the project root.
+
+package localize
+
+import (
+	"testing"
+	"testing/fstest"
+)
+
+func TestNewI18nTranslatorFallsBackWhenLocaleResourceIsUnavailable(t *testing.T) {
+	resources := fstest.MapFS{
+		"locales/zh-Hans.json": &fstest.MapFile{Data: []byte(`{"desc":{"BadRequest":"参数错误"}}`)},
+	}
+
+	translator := newI18nTranslator("en_US", resources)
+
+	if got := translator.Trans("desc.BadRequest"); got != "参数错误" {
+		t.Fatalf("fallback translation = %q, want %q", got, "参数错误")
+	}
+}
+
+func TestNewI18nTranslatorFallsBackWhenLocaleResourceIsMalformed(t *testing.T) {
+	resources := fstest.MapFS{
+		"locales/en-US.json":   &fstest.MapFile{Data: []byte(`{`)},
+		"locales/zh-Hans.json": &fstest.MapFile{Data: []byte(`{"desc":{"BadRequest":"参数错误"}}`)},
+	}
+
+	translator := newI18nTranslator("en_US", resources)
+
+	if got := translator.Trans("desc.BadRequest"); got != "参数错误" {
+		t.Fatalf("fallback translation = %q, want %q", got, "参数错误")
+	}
+}
+
+func TestNewI18nTranslatorKeepsMessageIDWhenBaselineIsUnavailable(t *testing.T) {
+	translator := newI18nTranslator("en_US", fstest.MapFS{})
+
+	if got := translator.Trans("desc.BadRequest"); got != "desc.BadRequest" {
+		t.Fatalf("translation = %q, want message ID", got)
+	}
+}


### PR DESCRIPTION
Closes #905

## Changes
- Make Context Loader and Execution Factory JSON locale loading warn and fall back to the configured baseline instead of panicking.
- Keep stable message IDs available when the baseline catalog is unavailable.
- Make Context Loader MCP locale overlays warn and use baseline instructions, metadata, and schema descriptions when missing, empty, or malformed.
- Add regression tests for missing and malformed JSON/MCP resources.

## Verification
- `go test ./server/infra/localize ./server/driveradapters/mcp` (Context Loader)
- `go test ./server/infra/localize` (Execution Factory)
- Context Loader and Execution Factory response-path package tests
- `git diff --check`