### PR TITLE
feat(observability): close Phase 4 management audit coverage

### DIFF
--- a/adp/execution-factory/operator-integration/server/driveradapters/operation_audit_query.go
+++ b/adp/execution-factory/operator-integration/server/driveradapters/operation_audit_query.go
@@ -9,11 +9,11 @@ import (
 
 	"github.com/gin-gonic/gin"
 	"github.com/openbkn-ai/bkn-foundry/adp/execution-factory/operator-integration/server/common/operationaudit"
-	"github.com/openbkn-ai/bkn-foundry/adp/execution-factory/operator-integration/server/drivenadapters"
 	infra "github.com/openbkn-ai/bkn-foundry/adp/execution-factory/operator-integration/server/infra/common"
 	infraerrors "github.com/openbkn-ai/bkn-foundry/adp/execution-factory/operator-integration/server/infra/errors"
 	infrarest "github.com/openbkn-ai/bkn-foundry/adp/execution-factory/operator-integration/server/infra/rest"
 	"github.com/openbkn-ai/bkn-foundry/adp/execution-factory/operator-integration/server/interfaces"
+	logicsauth "github.com/openbkn-ai/bkn-foundry/adp/execution-factory/operator-integration/server/logics/auth"
 )
 
 const maximumExecutionAuditRange = 30 * 24 * time.Hour
@@ -100,22 +100,17 @@ func (r *restPublicHandler) executionAuditReader(c *gin.Context) bool {
 		replyExecutionAuditError(c, http.StatusUnauthorized, infraerrors.ErrExtOperationAuditAuthenticationRequired, nil)
 		return false
 	}
-	userManagement := r.auditUserManagement
-	if userManagement == nil {
-		userManagement = drivenadapters.NewUserManagementClient()
+	authorization := r.auditAuthorization
+	if authorization == nil {
+		authorization = logicsauth.NewAuthServiceImpl()
 	}
-	user, err := userManagement.GetUserInfo(c.Request.Context(), auth.AccountID, "roles")
-	if err != nil || user == nil {
+	if err := authorization.CheckAdminPermission(c.Request.Context(), &interfaces.AuthAccessor{
+		ID: auth.AccountID, Type: auth.AccountType,
+	}); err != nil {
 		replyExecutionAuditError(c, http.StatusForbidden, infraerrors.ErrExtOperationAuditAccessDenied, nil)
 		return false
 	}
-	for _, role := range user.Roles {
-		if role == "super_admin" || role == "admin" || role == "audit" {
-			return true
-		}
-	}
-	replyExecutionAuditError(c, http.StatusForbidden, infraerrors.ErrExtOperationAuditAccessDenied, nil)
-	return false
+	return true
 }
 
 func replyExecutionAuditError(c *gin.Context, status int, code infraerrors.ErrorCode, details any) {

--- a/adp/execution-factory/operator-integration/server/driveradapters/operation_audit_query_test.go
+++ b/adp/execution-factory/operator-integration/server/driveradapters/operation_audit_query_test.go
@@ -46,6 +46,50 @@ type executionAuditUserManagementStub struct {
 	err  error
 }
 
+// executionAuditAuthorizationStub mirrors the platform-wide safe_admin
+// capability gate.  The audit reader must use this shared decision rather
+// than perform a second, independent directory-role lookup.
+type executionAuditAuthorizationStub struct {
+	interfaces.IAuthorizationService
+	err    error
+	called int
+}
+
+func (s *executionAuditAuthorizationStub) CheckAdminPermission(context.Context, *interfaces.AuthAccessor) error {
+	s.called++
+	return s.err
+}
+
+func TestExecutionOperationAuditUsesSharedAdminCapability(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	authorization := &executionAuditAuthorizationStub{}
+	handler := &restPublicHandler{
+		auditQueryStore:    &executionAuditQueryStoreStub{},
+		auditAuthorization: authorization,
+	}
+	engine := gin.New()
+	engine.Use(func(c *gin.Context) {
+		c.Request = c.Request.WithContext(infra.SetAccountAuthContextToCtx(c.Request.Context(), &interfaces.AccountAuthContext{
+			AccountID: "super-admin", AccountType: interfaces.AccessorTypeUser,
+		}))
+		c.Next()
+	})
+	engine.GET("/operation-audits", handler.ListOperationAudits)
+
+	request := httptest.NewRequest(http.MethodGet, "/operation-audits?from=2026-08-01T00:00:00Z&to=2026-08-08T00:00:00Z", nil)
+	request.Header.Set("x-tenant-id", "tenant-a")
+	request.Header.Set(string(interfaces.HeaderXBusinessDomain), "domain-a")
+	response := httptest.NewRecorder()
+	engine.ServeHTTP(response, request)
+
+	if response.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d; body=%s", response.Code, http.StatusOK, response.Body.String())
+	}
+	if authorization.called != 1 {
+		t.Fatalf("CheckAdminPermission calls = %d, want 1", authorization.called)
+	}
+}
+
 func (s executionAuditUserManagementStub) GetAppInfo(context.Context, string) (*interfaces.AppInfo, error) {
 	return nil, nil
 }
@@ -69,7 +113,7 @@ func TestExecutionOperationAuditErrorsAreLocalized(t *testing.T) {
 		language        string
 		path            string
 		authenticated   bool
-		roles           []string
+		adminAllowed    bool
 		store           operationAuditQueryStore
 		wantStatus      int
 		wantCode        string
@@ -86,42 +130,42 @@ func TestExecutionOperationAuditErrorsAreLocalized(t *testing.T) {
 			wantCode: infraerrors.ErrExtOperationAuditAuthenticationRequired.String(), wantDescription: "Authentication is required to view operation-audit records.",
 		},
 		{
-			name: "Chinese access denied", language: "zh-CN", authenticated: true, roles: []string{"user"},
+			name: "Chinese access denied", language: "zh-CN", authenticated: true,
 			path: "/operation-audits?from=2026-08-01T00:00:00Z&to=2026-08-08T00:00:00Z", wantStatus: http.StatusForbidden,
 			wantCode: infraerrors.ErrExtOperationAuditAccessDenied.String(), wantDescription: "您没有查看操作审计记录的权限。",
 		},
 		{
-			name: "English access denied", language: "en-US", authenticated: true, roles: []string{"user"},
+			name: "English access denied", language: "en-US", authenticated: true,
 			path: "/operation-audits?from=2026-08-01T00:00:00Z&to=2026-08-08T00:00:00Z", wantStatus: http.StatusForbidden,
 			wantCode: infraerrors.ErrExtOperationAuditAccessDenied.String(), wantDescription: "You are not permitted to view operation-audit records.",
 		},
 		{
-			name: "Chinese invalid range", language: "zh-CN", authenticated: true, roles: []string{"audit"}, store: &executionAuditQueryStoreStub{},
+			name: "Chinese invalid range", language: "zh-CN", authenticated: true, adminAllowed: true, store: &executionAuditQueryStoreStub{},
 			path: "/operation-audits?from=invalid&to=2026-08-08T00:00:00Z", wantStatus: http.StatusBadRequest,
 			wantCode: infraerrors.ErrExtOperationAuditInvalidRange.String(), wantDescription: "操作审计查询时间范围无效。",
 		},
 		{
-			name: "English invalid range", language: "en-US", authenticated: true, roles: []string{"audit"}, store: &executionAuditQueryStoreStub{},
+			name: "English invalid range", language: "en-US", authenticated: true, adminAllowed: true, store: &executionAuditQueryStoreStub{},
 			path: "/operation-audits?from=invalid&to=2026-08-08T00:00:00Z", wantStatus: http.StatusBadRequest,
 			wantCode: infraerrors.ErrExtOperationAuditInvalidRange.String(), wantDescription: "The operation-audit time range is invalid.",
 		},
 		{
-			name: "Chinese query failed", language: "zh-CN", authenticated: true, roles: []string{"audit"}, store: &executionAuditQueryStoreStub{listErr: errors.New("store unavailable")},
+			name: "Chinese query failed", language: "zh-CN", authenticated: true, adminAllowed: true, store: &executionAuditQueryStoreStub{listErr: errors.New("store unavailable")},
 			path: "/operation-audits?from=2026-08-01T00:00:00Z&to=2026-08-08T00:00:00Z", wantStatus: http.StatusInternalServerError,
 			wantCode: infraerrors.ErrExtOperationAuditQueryFailed.String(), wantDescription: "操作审计查询失败。",
 		},
 		{
-			name: "English query failed", language: "en-US", authenticated: true, roles: []string{"audit"}, store: &executionAuditQueryStoreStub{listErr: errors.New("store unavailable")},
+			name: "English query failed", language: "en-US", authenticated: true, adminAllowed: true, store: &executionAuditQueryStoreStub{listErr: errors.New("store unavailable")},
 			path: "/operation-audits?from=2026-08-01T00:00:00Z&to=2026-08-08T00:00:00Z", wantStatus: http.StatusInternalServerError,
 			wantCode: infraerrors.ErrExtOperationAuditQueryFailed.String(), wantDescription: "The operation-audit query failed.",
 		},
 		{
-			name: "Chinese not found", language: "zh-CN", authenticated: true, roles: []string{"audit"}, store: &executionAuditQueryStoreStub{},
+			name: "Chinese not found", language: "zh-CN", authenticated: true, adminAllowed: true, store: &executionAuditQueryStoreStub{},
 			path: "/operation-audits/event-missing", wantStatus: http.StatusNotFound,
 			wantCode: infraerrors.ErrExtOperationAuditNotFound.String(), wantDescription: "未找到操作审计事件。",
 		},
 		{
-			name: "English not found", language: "en-US", authenticated: true, roles: []string{"audit"}, store: &executionAuditQueryStoreStub{},
+			name: "English not found", language: "en-US", authenticated: true, adminAllowed: true, store: &executionAuditQueryStoreStub{},
 			path: "/operation-audits/event-missing", wantStatus: http.StatusNotFound,
 			wantCode: infraerrors.ErrExtOperationAuditNotFound.String(), wantDescription: "The operation-audit event was not found.",
 		},
@@ -137,10 +181,11 @@ func TestExecutionOperationAuditErrorsAreLocalized(t *testing.T) {
 					c.Next()
 				})
 			}
-			handler := &restPublicHandler{
-				auditQueryStore:     test.store,
-				auditUserManagement: executionAuditUserManagementStub{user: &interfaces.UserInfo{UserID: "user-a", Roles: test.roles}},
+			authorization := &executionAuditAuthorizationStub{}
+			if !test.adminAllowed {
+				authorization.err = errors.New("not an administrator")
 			}
+			handler := &restPublicHandler{auditQueryStore: test.store, auditAuthorization: authorization}
 			engine.GET("/operation-audits", handler.ListOperationAudits)
 			engine.GET("/operation-audits/:event_id", handler.GetOperationAudit)
 

--- a/adp/execution-factory/operator-integration/server/driveradapters/rest_public_handler.go
+++ b/adp/execution-factory/operator-integration/server/driveradapters/rest_public_handler.go
@@ -12,6 +12,7 @@ import (
 	"github.com/openbkn-ai/bkn-foundry/adp/execution-factory/operator-integration/server/infra/config"
 	"github.com/openbkn-ai/bkn-foundry/adp/execution-factory/operator-integration/server/infra/db"
 	"github.com/openbkn-ai/bkn-foundry/adp/execution-factory/operator-integration/server/interfaces"
+	"github.com/openbkn-ai/bkn-foundry/adp/execution-factory/operator-integration/server/logics/auth"
 	"github.com/openbkn-ai/bkn-foundry/adp/execution-factory/operator-integration/server/logics/business_domain"
 	sharedrest "github.com/openbkn-ai/bkn-foundry/comm-go/rest"
 )
@@ -32,7 +33,7 @@ type restPublicHandler struct {
 	businessDomainService interfaces.IBusinessDomainService
 	auditStore            *operationaudit.Store
 	auditQueryStore       operationAuditQueryStore
-	auditUserManagement   interfaces.UserManagement
+	auditAuthorization    interfaces.IAuthorizationService
 }
 
 // NewRestPublicHandler 创建restHandler实例
@@ -54,6 +55,7 @@ func NewRestPublicHandler() interfaces.HTTPRouterInterface {
 		businessDomainService: business_domain.NewBusinessDomainService(),
 		auditStore:            auditStore,
 		auditQueryStore:       auditStore,
+		auditAuthorization:    auth.NewAuthServiceImpl(),
 	}
 }
 

--- a/bkn-trace/agent-observability/src/conf/core.go
+++ b/bkn-trace/agent-observability/src/conf/core.go
@@ -51,7 +51,7 @@ func NewCoreConfig() CoreConfig {
 	}
 	projectionRebuildVersion := strings.TrimSpace(os.Getenv("BKN_TRACE_PROJECTION_REBUILD_VERSION"))
 	if projectionEnabled && projectionRebuildVersion == "" {
-		projectionRebuildVersion = projectionIndex + "-v014"
+		projectionRebuildVersion = projectionIndex + "-v014-r1"
 	}
 	return CoreConfig{
 		Store: store, MariaDBDSN: strings.TrimSpace(os.Getenv("BKN_TRACE_CORE_MARIADB_DSN")),

--- a/bkn-trace/agent-observability/src/conf/core_test.go
+++ b/bkn-trace/agent-observability/src/conf/core_test.go
@@ -26,7 +26,7 @@ func TestProjectionUsesVersionedIndexBehindAliasByDefault(t *testing.T) {
 	t.Setenv("BKN_TRACE_PROJECTION_REBUILD_VERSION", "")
 
 	config := NewCoreConfig()
-	if config.ProjectionRebuildVersion != "bkn-trace-core-v014" {
+	if config.ProjectionRebuildVersion != "bkn-trace-core-v014-r1" {
 		t.Fatalf("projection could create a concrete alias index: %#v", config)
 	}
 }

--- a/bkn-trace/agent-observability/src/domain/service/logsvc/service.go
+++ b/bkn-trace/agent-observability/src/domain/service/logsvc/service.go
@@ -449,7 +449,7 @@ func (service *Service) searchSources(
 				results[index].status.CountAccuracy = "unavailable"
 				return
 			}
-			if results[index].status.Status != observabilityvo.SourceCoverageDegraded || results[index].status.Reason == "partial_management_audit_coverage" {
+			if results[index].status.Status != observabilityvo.SourceCoverageDegraded || results[index].status.Reason == observabilityvo.SourceReasonPartialManagementAuditCoverage {
 				results[index].status.Status = "healthy"
 				results[index].status.CountAccuracy = normalizedAccuracy(page.CountAccuracy)
 			}

--- a/bkn-trace/agent-observability/src/domain/service/logsvc/service.go
+++ b/bkn-trace/agent-observability/src/domain/service/logsvc/service.go
@@ -243,7 +243,8 @@ func (service *Service) listPage(
 	for _, sourceResult := range service.searchSources(ctx, visibleSources, sourceQuery, positions) {
 		source := sourceResult.source
 		if sourceResult.status.Status == "not_integrated" {
-			failed++
+			// Coverage is shown in source status, but a source that was never
+			// queried cannot make results from reachable sources incomplete.
 			result.SourceStatus = append(result.SourceStatus, sourceResult.status)
 			continue
 		}
@@ -287,10 +288,9 @@ func (service *Service) listPage(
 			// Source totals describe its raw result set. Once the public contract
 			// rejects records, retaining that raw total produces an impossible UI
 			// (for example “5 facts” with an empty table). Report the visible lower
-			// bound and mark it partial; later pages may contain more valid records.
+			// bound and mark the count inexact; the source itself remains reachable.
 			totalCount += int64(len(candidates))
 			countExact = false
-			coveragePartial = true
 		} else {
 			totalCount += page.Count
 		}
@@ -449,7 +449,7 @@ func (service *Service) searchSources(
 				results[index].status.CountAccuracy = "unavailable"
 				return
 			}
-			if results[index].status.Status != observabilityvo.SourceCoverageDegraded {
+			if results[index].status.Status != observabilityvo.SourceCoverageDegraded || results[index].status.Reason == "partial_management_audit_coverage" {
 				results[index].status.Status = "healthy"
 				results[index].status.CountAccuracy = normalizedAccuracy(page.CountAccuracy)
 			}

--- a/bkn-trace/agent-observability/src/domain/service/logsvc/service.go
+++ b/bkn-trace/agent-observability/src/domain/service/logsvc/service.go
@@ -260,7 +260,9 @@ func (service *Service) listPage(
 		coveragePartial = coveragePartial || sourceResult.status.Status == "degraded"
 		sourcePageSizes[source.ID()] = len(page.Records)
 		countExact = countExact && normalizedAccuracy(page.CountAccuracy) == "exact"
-		if len(page.Records) > 0 {
+		if page.LastPosition != nil {
+			sourceLastRawPosition[source.ID()] = *page.LastPosition
+		} else if len(page.Records) > 0 {
 			sourceLastRawPosition[source.ID()] = positionForRecord(page.Records[len(page.Records)-1])
 		}
 		if page.NextCursor != "" || page.Count > int64(len(page.Records)) {
@@ -284,11 +286,12 @@ func (service *Service) listPage(
 				candidates = append(candidates, logCandidate{record: record, adapterSourceID: source.ID()})
 			}
 		}
-		if rejectedProjections > 0 {
+		if rejectedProjections > 0 || normalizedAccuracy(page.CountAccuracy) != "exact" {
 			// Source totals describe its raw result set. Once the public contract
-			// rejects records, retaining that raw total produces an impossible UI
-			// (for example “5 facts” with an empty table). Report the visible lower
-			// bound and mark the count inexact; the source itself remains reachable.
+			// rejects records or an adapter has already filtered its source result,
+			// retaining that raw total produces an impossible UI (for example “5
+			// facts” with an empty table). Report the visible lower bound and mark
+			// the count inexact; the source itself remains reachable.
 			totalCount += int64(len(candidates))
 			countExact = false
 		} else {

--- a/bkn-trace/agent-observability/src/domain/service/logsvc/service_test.go
+++ b/bkn-trace/agent-observability/src/domain/service/logsvc/service_test.go
@@ -17,6 +17,27 @@ type fakeSource struct {
 	err     error
 }
 
+type partialCountSource struct {
+	record observabilityvo.LogRecord
+}
+
+func (source partialCountSource) ID() string { return "partial-count" }
+
+func (source partialCountSource) Metadata() observabilityvo.SourceStatus {
+	return observabilityvo.SourceStatus{
+		SourceID: source.ID(), Status: "healthy", Reliability: "best_effort",
+		CountAccuracy: "partial", Categories: []string{observabilityvo.CategoryAuditAdmin},
+	}
+}
+
+func (source partialCountSource) Search(context.Context, observabilityvo.LogQuery) (observabilityvo.SourcePage, error) {
+	return observabilityvo.SourcePage{
+		Records:       validTestRecords([]observabilityvo.LogRecord{source.record}),
+		Count:         201,
+		CountAccuracy: "partial",
+	}, nil
+}
+
 type capturingSource struct {
 	query observabilityvo.LogQuery
 }
@@ -175,7 +196,7 @@ type partialCoverageSource struct {
 func (source *partialCoverageSource) Metadata() observabilityvo.SourceStatus {
 	return observabilityvo.SourceStatus{
 		SourceID: source.id, Status: observabilityvo.SourceCoverageDegraded,
-		Reason: "partial_management_audit_coverage", Reliability: "best_effort",
+		Reason: observabilityvo.SourceReasonPartialManagementAuditCoverage, Reliability: "best_effort",
 		CountAccuracy: "partial", Categories: append([]string(nil), source.categories...),
 	}
 }
@@ -511,7 +532,7 @@ func TestSourcesReportsReachablePartialCoverageSourceAsHealthy(t *testing.T) {
 	if err != nil || len(statuses) != 1 {
 		t.Fatalf("source health query failed: statuses=%+v err=%v", statuses, err)
 	}
-	if statuses[0].Status != "healthy" || statuses[0].Reason != "partial_management_audit_coverage" {
+	if statuses[0].Status != "healthy" || statuses[0].Reason != observabilityvo.SourceReasonPartialManagementAuditCoverage {
 		t.Fatalf("reachable source must be healthy while retaining its partial coverage note: %+v", statuses[0])
 	}
 }
@@ -799,6 +820,19 @@ func TestListAdvancesPastACompletelyFilteredSourcePage(t *testing.T) {
 	second, err := service.List(context.Background(), profile, observabilityvo.LogQuery{Limit: 20, Cursor: first.NextCursor})
 	if err != nil || len(second.Records) != 1 || second.Records[0].LogID != "visible" {
 		t.Fatalf("next source page was not reachable: result=%+v err=%v", second, err)
+	}
+}
+
+func TestListPreservesPaginationForPartiallyProjectedSourceCounts(t *testing.T) {
+	record := observabilityvo.LogRecord{
+		LogID: "audit-visible", Category: observabilityvo.CategoryAuditAdmin, EventName: "user.created",
+		TenantID: "tenant-a", EventTimestamp: time.Now().UTC(), TrustLevel: "trusted", IngressPrincipal: "bkn-safe",
+	}
+	result, err := NewWithCursorKey([]Source{partialCountSource{record: record}}, []byte("test-cursor-signing-key")).List(
+		context.Background(), activeProfile("admin-a", "super_admin"), observabilityvo.LogQuery{Limit: 20},
+	)
+	if err != nil || result.NextCursor == "" {
+		t.Fatalf("partial upstream count must keep the source pageable: result=%+v err=%v", result, err)
 	}
 }
 

--- a/bkn-trace/agent-observability/src/domain/service/logsvc/service_test.go
+++ b/bkn-trace/agent-observability/src/domain/service/logsvc/service_test.go
@@ -30,6 +30,27 @@ func (source partialCountSource) Metadata() observabilityvo.SourceStatus {
 	}
 }
 
+type filteredCountSource struct {
+	lastPosition observabilityvo.SourcePosition
+}
+
+func (source *filteredCountSource) ID() string { return "filtered-count" }
+
+func (source *filteredCountSource) Metadata() observabilityvo.SourceStatus {
+	return observabilityvo.SourceStatus{
+		SourceID: source.ID(), Status: "healthy", Reliability: "best_effort",
+		CountAccuracy: "partial", Categories: []string{observabilityvo.CategoryAuditAdmin},
+	}
+}
+
+func (source *filteredCountSource) Search(_ context.Context, query observabilityvo.LogQuery) (observabilityvo.SourcePage, error) {
+	if query.PageBefore != nil {
+		return observabilityvo.SourcePage{CountAccuracy: "partial"}, nil
+	}
+	position := source.lastPosition
+	return observabilityvo.SourcePage{Count: 1, CountAccuracy: "partial", LastPosition: &position}, nil
+}
+
 func (source partialCountSource) Search(context.Context, observabilityvo.LogQuery) (observabilityvo.SourcePage, error) {
 	return observabilityvo.SourcePage{
 		Records:       validTestRecords([]observabilityvo.LogRecord{source.record}),
@@ -833,6 +854,21 @@ func TestListPreservesPaginationForPartiallyProjectedSourceCounts(t *testing.T) 
 	)
 	if err != nil || result.NextCursor == "" {
 		t.Fatalf("partial upstream count must keep the source pageable: result=%+v err=%v", result, err)
+	}
+}
+
+func TestListAdvancesWhenSourceFiltersItsWholePage(t *testing.T) {
+	position := observabilityvo.SourcePosition{EventTimestamp: time.Now().UTC(), SourceID: "filtered-count", LogID: "legacy-logout"}
+	service := NewWithCursorKey([]Source{&filteredCountSource{lastPosition: position}}, []byte("test-cursor-signing-key"))
+	profile := activeProfile("admin-a", "super_admin")
+
+	first, err := service.List(context.Background(), profile, observabilityvo.LogQuery{Limit: 20})
+	if err != nil || first.NextCursor == "" || first.Count != 0 || first.CountExact {
+		t.Fatalf("filtered source page must advance without exposing its raw count: result=%+v err=%v", first, err)
+	}
+	second, err := service.List(context.Background(), profile, observabilityvo.LogQuery{Limit: 20, Cursor: first.NextCursor})
+	if err != nil || second.NextCursor != "" || second.Count != 0 {
+		t.Fatalf("source cursor must advance past an all-filtered page: result=%+v err=%v", second, err)
 	}
 }
 

--- a/bkn-trace/agent-observability/src/domain/service/logsvc/service_test.go
+++ b/bkn-trace/agent-observability/src/domain/service/logsvc/service_test.go
@@ -168,6 +168,18 @@ type categorizedSource struct {
 	queries    int
 }
 
+type partialCoverageSource struct {
+	categorizedSource
+}
+
+func (source *partialCoverageSource) Metadata() observabilityvo.SourceStatus {
+	return observabilityvo.SourceStatus{
+		SourceID: source.id, Status: observabilityvo.SourceCoverageDegraded,
+		Reason: "partial_management_audit_coverage", Reliability: "best_effort",
+		CountAccuracy: "partial", Categories: append([]string(nil), source.categories...),
+	}
+}
+
 type filteredPageSource struct {
 	pages [][]observabilityvo.LogRecord
 }
@@ -250,7 +262,7 @@ func TestListReturnsCompleteRecordsMatchingAnyManagedNetwork(t *testing.T) {
 }
 
 func TestListReportsPartialAndFailsWhenEveryAuthorizedSourceFails(t *testing.T) {
-	profile := activeProfile("admin-a", "admin")
+	profile := activeProfile("admin-a", "super_admin")
 	available := fakeSource{id: "otel", records: []observabilityvo.LogRecord{
 		{LogID: "system-a", Category: observabilityvo.CategoryRuntimeSystem, EventName: "service.started", TenantID: "tenant-a", EventTimestamp: time.Now(), TrustLevel: "trusted", IngressPrincipal: "otel-gateway"},
 	}}
@@ -267,6 +279,29 @@ func TestListReportsPartialAndFailsWhenEveryAuthorizedSourceFails(t *testing.T) 
 	_, err = New([]Source{unavailable}).List(context.Background(), profile, observabilityvo.LogQuery{})
 	if !errors.Is(err, ErrSourcesUnavailable) {
 		t.Fatalf("all failed sources must return sources unavailable, got %v", err)
+	}
+}
+
+func TestListDoesNotMarkAvailableResultsPartialForNotIntegratedSources(t *testing.T) {
+	profile := activeProfile("admin-a", "super_admin")
+	available := fakeSource{id: "safe", records: []observabilityvo.LogRecord{{
+		LogID: "audit-a", Category: observabilityvo.CategoryAuditAdmin, EventName: "user.created", TenantID: "tenant-a",
+		EventTimestamp: time.Now().UTC(), TrustLevel: "trusted", IngressPrincipal: "bkn-safe",
+	}}}
+	service := New([]Source{
+		available,
+		NewNotIntegratedSource("future-source", []string{observabilityvo.CategoryAuditAdmin}, []string{"Future module"}),
+	})
+
+	result, err := service.List(context.Background(), profile, observabilityvo.LogQuery{})
+	if err != nil {
+		t.Fatalf("available source must remain queryable: %v", err)
+	}
+	if result.Partial || len(result.Records) != 1 {
+		t.Fatalf("not-integrated coverage must not make available results partial: %+v", result)
+	}
+	if len(result.SourceStatus) != 2 || result.SourceStatus[1].Status != "not_integrated" {
+		t.Fatalf("not-integrated source state must still be disclosed: %+v", result.SourceStatus)
 	}
 }
 
@@ -454,7 +489,7 @@ func TestSourcesHealthCheckUsesTheConfiguredSourceTimeout(t *testing.T) {
 	}, Options{CursorKey: []byte("test-cursor-key"), SourceTimeout: 20 * time.Millisecond, MaxConcurrentSources: 2})
 
 	startedAt := time.Now()
-	statuses, err := service.Sources(context.Background(), activeProfile("admin-a", "admin"))
+	statuses, err := service.Sources(context.Background(), activeProfile("admin-a", "super_admin"))
 	if err != nil {
 		t.Fatalf("source health query failed: %v", err)
 	}
@@ -464,6 +499,20 @@ func TestSourcesHealthCheckUsesTheConfiguredSourceTimeout(t *testing.T) {
 	if len(statuses) != 2 || statuses[0].SourceID != "slow" || statuses[0].Reason != "source_timeout" ||
 		statuses[1].Status != "healthy" {
 		t.Fatalf("source health status is incomplete: %+v", statuses)
+	}
+}
+
+func TestSourcesReportsReachablePartialCoverageSourceAsHealthy(t *testing.T) {
+	service := New([]Source{&partialCoverageSource{categorizedSource: categorizedSource{
+		id: "vega", categories: []string{observabilityvo.CategoryAuditAdmin},
+	}}})
+
+	statuses, err := service.Sources(context.Background(), activeProfile("admin-a", "super_admin"))
+	if err != nil || len(statuses) != 1 {
+		t.Fatalf("source health query failed: statuses=%+v err=%v", statuses, err)
+	}
+	if statuses[0].Status != "healthy" || statuses[0].Reason != "partial_management_audit_coverage" {
+		t.Fatalf("reachable source must be healthy while retaining its partial coverage note: %+v", statuses[0])
 	}
 }
 
@@ -848,8 +897,27 @@ func TestOperationAuditOnlyRejectsIncompletePublicProjection(t *testing.T) {
 	if len(result.Records) != 0 {
 		t.Fatalf("incomplete public operation audit projection was disclosed: %+v", result.Records)
 	}
-	if result.Count != 0 || !result.Partial || result.CountExact {
-		t.Fatalf("rejected projections must not remain in the visible exact count: %+v", result)
+	if result.Count != 0 || result.Partial || result.CountExact {
+		t.Fatalf("rejected projections must not make a reachable source partial or remain in the visible exact count: %+v", result)
+	}
+}
+
+func TestOperationAuditListDoesNotReportReachableSourcesUnavailableForLegacyRows(t *testing.T) {
+	record := validTestRecord(observabilityvo.LogRecord{
+		LogID: "audit-legacy", Category: observabilityvo.CategoryAuditAdmin, EventName: "resource_config.changed",
+		TenantID: "tenant-a", EventTimestamp: time.Now().UTC(), TrustLevel: "trusted", IngressPrincipal: "source-a",
+		BusinessModule: "legacy_unknown_module",
+	})
+	service := NewWithOptions([]Source{fakeSource{id: "source-a", records: []observabilityvo.LogRecord{record}}}, Options{
+		OperationAuditOnly: true,
+	})
+
+	result, err := service.List(context.Background(), activeProfile("admin-a", "admin"), observabilityvo.LogQuery{})
+	if err != nil {
+		t.Fatalf("list operation audit records: %v", err)
+	}
+	if result.Partial || result.CountExact || len(result.Records) != 0 {
+		t.Fatalf("a rejected legacy row must not make a reachable source appear unavailable: %+v", result)
 	}
 }
 

--- a/bkn-trace/agent-observability/src/domain/valueobject/observabilityvo/log.go
+++ b/bkn-trace/agent-observability/src/domain/valueobject/observabilityvo/log.go
@@ -111,7 +111,10 @@ func (query LogQuery) IsAssociatedDrilldown() bool {
 }
 
 type SourcePage struct {
-	Records       []LogRecord
+	Records []LogRecord
+	// LastPosition advances the source cursor even when the adapter filters all
+	// raw records on this page. It is cursor metadata, never a public log record.
+	LastPosition  *SourcePosition
 	NextCursor    string
 	Count         int64
 	CountAccuracy string

--- a/bkn-trace/agent-observability/src/domain/valueobject/observabilityvo/source_coverage.go
+++ b/bkn-trace/agent-observability/src/domain/valueobject/observabilityvo/source_coverage.go
@@ -3,8 +3,9 @@ package observabilityvo
 import "time"
 
 const (
-	SourceCoverageHealthy  = "healthy"
-	SourceCoverageDegraded = "degraded"
+	SourceCoverageHealthy                      = "healthy"
+	SourceCoverageDegraded                     = "degraded"
+	SourceReasonPartialManagementAuditCoverage = "partial_management_audit_coverage"
 )
 
 // SourceCoverage is the durable collection-coverage fact for a log source.

--- a/bkn-trace/agent-observability/src/drivenadapter/httpaccess/bknbackendaudit/client.go
+++ b/bkn-trace/agent-observability/src/drivenadapter/httpaccess/bknbackendaudit/client.go
@@ -44,7 +44,7 @@ func (client *Client) Metadata() observabilityvo.SourceStatus {
 		}
 	}
 	return observabilityvo.SourceStatus{
-		SourceID: sourceID, Status: "degraded", Reason: "partial_management_audit_coverage", Reliability: "best_effort",
+		SourceID: sourceID, Status: "degraded", Reason: observabilityvo.SourceReasonPartialManagementAuditCoverage, Reliability: "best_effort",
 		CollectionMethod: "source_adapter", CoveredModules: []string{"domain_knowledge_network"},
 		CountAccuracy: "partial", Categories: []string{observabilityvo.CategoryAuditAdmin},
 	}

--- a/bkn-trace/agent-observability/src/drivenadapter/httpaccess/bknbackendaudit/client.go
+++ b/bkn-trace/agent-observability/src/drivenadapter/httpaccess/bknbackendaudit/client.go
@@ -44,7 +44,7 @@ func (client *Client) Metadata() observabilityvo.SourceStatus {
 		}
 	}
 	return observabilityvo.SourceStatus{
-		SourceID: sourceID, Status: "degraded", Reason: "management_audit_coverage_in_progress", Reliability: "best_effort",
+		SourceID: sourceID, Status: "degraded", Reason: "partial_management_audit_coverage", Reliability: "best_effort",
 		CollectionMethod: "source_adapter", CoveredModules: []string{"domain_knowledge_network"},
 		CountAccuracy: "partial", Categories: []string{observabilityvo.CategoryAuditAdmin},
 	}

--- a/bkn-trace/agent-observability/src/drivenadapter/httpaccess/bknbackendaudit/client_test.go
+++ b/bkn-trace/agent-observability/src/drivenadapter/httpaccess/bknbackendaudit/client_test.go
@@ -62,7 +62,7 @@ func TestMetadataDoesNotClaimAnUnconfiguredSourceIsHealthy(t *testing.T) {
 
 func TestMetadataDoesNotClaimPartialManagementCoverageIsHealthy(t *testing.T) {
 	status := New("http://bkn-backend:8080", nil).Metadata()
-	if status.Status != "degraded" || status.Reason != "management_audit_coverage_in_progress" {
+	if status.Status != "degraded" || status.Reason != "partial_management_audit_coverage" {
 		t.Fatalf("status = %#v", status)
 	}
 }

--- a/bkn-trace/agent-observability/src/drivenadapter/httpaccess/bknbackendaudit/client_test.go
+++ b/bkn-trace/agent-observability/src/drivenadapter/httpaccess/bknbackendaudit/client_test.go
@@ -62,7 +62,7 @@ func TestMetadataDoesNotClaimAnUnconfiguredSourceIsHealthy(t *testing.T) {
 
 func TestMetadataDoesNotClaimPartialManagementCoverageIsHealthy(t *testing.T) {
 	status := New("http://bkn-backend:8080", nil).Metadata()
-	if status.Status != "degraded" || status.Reason != "partial_management_audit_coverage" {
+	if status.Status != "degraded" || status.Reason != observabilityvo.SourceReasonPartialManagementAuditCoverage {
 		t.Fatalf("status = %#v", status)
 	}
 }

--- a/bkn-trace/agent-observability/src/drivenadapter/httpaccess/bknsafeaudit/client.go
+++ b/bkn-trace/agent-observability/src/drivenadapter/httpaccess/bknsafeaudit/client.go
@@ -108,6 +108,11 @@ func (client *Client) Search(ctx context.Context, query observabilityvo.LogQuery
 		}
 		records = append(records, projectAuditLog(entry, query.AuthorizedTenantID))
 	}
+	var lastPosition *observabilityvo.SourcePosition
+	if len(payload.Logs) > 0 {
+		last := payload.Logs[len(payload.Logs)-1]
+		lastPosition = &observabilityvo.SourcePosition{EventTimestamp: last.CreatedAt, SourceID: sourceID, LogID: last.ID}
+	}
 	countAccuracy := "exact"
 	if payload.Total != int64(len(records)) {
 		// The upstream total includes legacy rows outside this source's explicit
@@ -115,7 +120,7 @@ func (client *Client) Search(ctx context.Context, query observabilityvo.LogQuery
 		// the total inexact, so later management rows remain reachable.
 		countAccuracy = "partial"
 	}
-	return observabilityvo.SourcePage{Records: records, Count: payload.Total, CountAccuracy: countAccuracy}, nil
+	return observabilityvo.SourcePage{Records: records, LastPosition: lastPosition, Count: payload.Total, CountAccuracy: countAccuracy}, nil
 }
 
 func onlyFailedOutcomes(outcomes []string) bool {

--- a/bkn-trace/agent-observability/src/drivenadapter/httpaccess/bknsafeaudit/client.go
+++ b/bkn-trace/agent-observability/src/drivenadapter/httpaccess/bknsafeaudit/client.go
@@ -100,9 +100,23 @@ func (client *Client) Search(ctx context.Context, query observabilityvo.LogQuery
 	}
 	records := make([]observabilityvo.LogRecord, 0, len(payload.Logs))
 	for _, entry := range payload.Logs {
+		if businessModuleForResource(entry.Resource) == "" {
+			// Login and logout rows are carried by the dedicated access source.
+			// This source is the management-audit projection, so do not pass its
+			// legacy access duplicates to the public operation-log contract.
+			continue
+		}
 		records = append(records, projectAuditLog(entry, query.AuthorizedTenantID))
 	}
-	return observabilityvo.SourcePage{Records: records, Count: payload.Total, CountAccuracy: "exact"}, nil
+	countAccuracy := "exact"
+	count := payload.Total
+	if count != int64(len(records)) {
+		// The upstream total includes legacy rows outside this source's explicit
+		// management-audit scope. Report the normalized lower bound instead of
+		// letting those rows make the combined result appear unavailable.
+		count, countAccuracy = int64(len(records)), "partial"
+	}
+	return observabilityvo.SourcePage{Records: records, Count: count, CountAccuracy: countAccuracy}, nil
 }
 
 func onlyFailedOutcomes(outcomes []string) bool {

--- a/bkn-trace/agent-observability/src/drivenadapter/httpaccess/bknsafeaudit/client.go
+++ b/bkn-trace/agent-observability/src/drivenadapter/httpaccess/bknsafeaudit/client.go
@@ -109,14 +109,13 @@ func (client *Client) Search(ctx context.Context, query observabilityvo.LogQuery
 		records = append(records, projectAuditLog(entry, query.AuthorizedTenantID))
 	}
 	countAccuracy := "exact"
-	count := payload.Total
-	if count != int64(len(records)) {
+	if payload.Total != int64(len(records)) {
 		// The upstream total includes legacy rows outside this source's explicit
-		// management-audit scope. Report the normalized lower bound instead of
-		// letting those rows make the combined result appear unavailable.
-		count, countAccuracy = int64(len(records)), "partial"
+		// management-audit scope. Keep it as the pagination signal while marking
+		// the total inexact, so later management rows remain reachable.
+		countAccuracy = "partial"
 	}
-	return observabilityvo.SourcePage{Records: records, Count: count, CountAccuracy: countAccuracy}, nil
+	return observabilityvo.SourcePage{Records: records, Count: payload.Total, CountAccuracy: countAccuracy}, nil
 }
 
 func onlyFailedOutcomes(outcomes []string) bool {

--- a/bkn-trace/agent-observability/src/drivenadapter/httpaccess/bknsafeaudit/client_test.go
+++ b/bkn-trace/agent-observability/src/drivenadapter/httpaccess/bknsafeaudit/client_test.go
@@ -89,8 +89,8 @@ func TestSearchExcludesLegacyAccessRowsFromManagementAuditResults(t *testing.T) 
 	if len(page.Records) != 1 || page.Records[0].LogID != "bkn-safe-admin:audit-user" {
 		t.Fatalf("legacy access row must not be exposed as a management audit record: %+v", page.Records)
 	}
-	if page.Count != 1 || page.CountAccuracy != "partial" {
-		t.Fatalf("management audit count must describe the normalized result set: %+v", page)
+	if page.Count != 2 || page.CountAccuracy != "partial" {
+		t.Fatalf("management audit count must retain the upstream pagination signal: %+v", page)
 	}
 }
 

--- a/bkn-trace/agent-observability/src/drivenadapter/httpaccess/bknsafeaudit/client_test.go
+++ b/bkn-trace/agent-observability/src/drivenadapter/httpaccess/bknsafeaudit/client_test.go
@@ -66,6 +66,34 @@ func TestSearchForwardsCallerAuthorizationFiltersAtSourceAndDropsDetail(t *testi
 	}
 }
 
+func TestSearchExcludesLegacyAccessRowsFromManagementAuditResults(t *testing.T) {
+	httpClient := &http.Client{Transport: roundTripFunc(func(candidate *http.Request) (*http.Response, error) {
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Body: io.NopCloser(strings.NewReader(`{"logs":[
+				{"id":"access-logout","actor_id":"admin-a","actor_name_snapshot":"Administrator","auth_method":"password","source_channel":"web","method":"POST","resource":"logout","action":"logout","target_id":"admin-a","target_name":"Administrator","status":200,"created_at":"2026-08-01T10:00:00Z"},
+				{"id":"audit-user","actor_id":"admin-a","actor_name_snapshot":"Administrator","auth_method":"password","source_channel":"web","method":"POST","resource":"users","action":"create","target_id":"user-a","target_name":"User A","status":201,"created_at":"2026-08-01T09:00:00Z"}
+			],"total":2}`)),
+			Header: make(http.Header), Request: candidate,
+		}, nil
+	})}
+	client := New("http://bkn-safe:3000", httpClient)
+	ctx := observabilityvo.WithSourceAuthorization(context.Background(), "Bearer token-a")
+
+	page, err := client.Search(ctx, observabilityvo.LogQuery{
+		AuthorizedTenantID: "tenant-a", AuthorizedCategories: []string{observabilityvo.CategoryAuditAdmin},
+	})
+	if err != nil {
+		t.Fatalf("search audit source: %v", err)
+	}
+	if len(page.Records) != 1 || page.Records[0].LogID != "bkn-safe-admin:audit-user" {
+		t.Fatalf("legacy access row must not be exposed as a management audit record: %+v", page.Records)
+	}
+	if page.Count != 1 || page.CountAccuracy != "partial" {
+		t.Fatalf("management audit count must describe the normalized result set: %+v", page)
+	}
+}
+
 func TestSearchRequiresForwardedCallerAuthorization(t *testing.T) {
 	client := New("http://bkn-safe:3000", &http.Client{Transport: roundTripFunc(func(*http.Request) (*http.Response, error) {
 		t.Fatal("request must not be sent without caller authorization")

--- a/bkn-trace/agent-observability/src/drivenadapter/httpaccess/executionfactoryaudit/client.go
+++ b/bkn-trace/agent-observability/src/drivenadapter/httpaccess/executionfactoryaudit/client.go
@@ -34,7 +34,7 @@ func (c *Client) Metadata() observabilityvo.SourceStatus {
 	if c.baseURL == "" {
 		return observabilityvo.SourceStatus{SourceID: sourceID, Status: "not_integrated", Reason: "source_not_configured", Reliability: "best_effort", CollectionMethod: "not_integrated", CoveredModules: []string{"execution_factory"}, CountAccuracy: "partial", Categories: []string{observabilityvo.CategoryAuditAdmin}}
 	}
-	return observabilityvo.SourceStatus{SourceID: sourceID, Status: "degraded", Reason: "management_audit_coverage_in_progress", Reliability: "best_effort", CollectionMethod: "source_adapter", CoveredModules: []string{"execution_factory"}, CountAccuracy: "partial", Categories: []string{observabilityvo.CategoryAuditAdmin}}
+	return observabilityvo.SourceStatus{SourceID: sourceID, Status: "degraded", Reason: "partial_management_audit_coverage", Reliability: "best_effort", CollectionMethod: "source_adapter", CoveredModules: []string{"execution_factory"}, CountAccuracy: "partial", Categories: []string{observabilityvo.CategoryAuditAdmin}}
 }
 func (c *Client) Search(ctx context.Context, q observabilityvo.LogQuery) (observabilityvo.SourcePage, error) {
 	if !contains(q.AuthorizedCategories, observabilityvo.CategoryAuditAdmin) {

--- a/bkn-trace/agent-observability/src/drivenadapter/httpaccess/executionfactoryaudit/client.go
+++ b/bkn-trace/agent-observability/src/drivenadapter/httpaccess/executionfactoryaudit/client.go
@@ -34,7 +34,7 @@ func (c *Client) Metadata() observabilityvo.SourceStatus {
 	if c.baseURL == "" {
 		return observabilityvo.SourceStatus{SourceID: sourceID, Status: "not_integrated", Reason: "source_not_configured", Reliability: "best_effort", CollectionMethod: "not_integrated", CoveredModules: []string{"execution_factory"}, CountAccuracy: "partial", Categories: []string{observabilityvo.CategoryAuditAdmin}}
 	}
-	return observabilityvo.SourceStatus{SourceID: sourceID, Status: "degraded", Reason: "partial_management_audit_coverage", Reliability: "best_effort", CollectionMethod: "source_adapter", CoveredModules: []string{"execution_factory"}, CountAccuracy: "partial", Categories: []string{observabilityvo.CategoryAuditAdmin}}
+	return observabilityvo.SourceStatus{SourceID: sourceID, Status: "degraded", Reason: observabilityvo.SourceReasonPartialManagementAuditCoverage, Reliability: "best_effort", CollectionMethod: "source_adapter", CoveredModules: []string{"execution_factory"}, CountAccuracy: "partial", Categories: []string{observabilityvo.CategoryAuditAdmin}}
 }
 func (c *Client) Search(ctx context.Context, q observabilityvo.LogQuery) (observabilityvo.SourcePage, error) {
 	if !contains(q.AuthorizedCategories, observabilityvo.CategoryAuditAdmin) {

--- a/bkn-trace/agent-observability/src/drivenadapter/httpaccess/modelmanageraudit/client.go
+++ b/bkn-trace/agent-observability/src/drivenadapter/httpaccess/modelmanageraudit/client.go
@@ -33,7 +33,7 @@ func (c *Client) Metadata() observabilityvo.SourceStatus {
 	if c.baseURL == "" {
 		return observabilityvo.SourceStatus{SourceID: sourceID, Status: "not_integrated", Reason: "source_not_configured", Reliability: "best_effort", CollectionMethod: "not_integrated", CoveredModules: []string{"model_management"}, CountAccuracy: "partial", Categories: []string{observabilityvo.CategoryAuditAdmin}}
 	}
-	return observabilityvo.SourceStatus{SourceID: sourceID, Status: "degraded", Reason: "management_audit_coverage_in_progress", Reliability: "best_effort", CollectionMethod: "source_adapter", CoveredModules: []string{"model_management"}, CountAccuracy: "partial", Categories: []string{observabilityvo.CategoryAuditAdmin}}
+	return observabilityvo.SourceStatus{SourceID: sourceID, Status: "degraded", Reason: "partial_management_audit_coverage", Reliability: "best_effort", CollectionMethod: "source_adapter", CoveredModules: []string{"model_management"}, CountAccuracy: "partial", Categories: []string{observabilityvo.CategoryAuditAdmin}}
 }
 func (c *Client) Search(ctx context.Context, q observabilityvo.LogQuery) (observabilityvo.SourcePage, error) {
 	if !contains(q.AuthorizedCategories, observabilityvo.CategoryAuditAdmin) {

--- a/bkn-trace/agent-observability/src/drivenadapter/httpaccess/modelmanageraudit/client.go
+++ b/bkn-trace/agent-observability/src/drivenadapter/httpaccess/modelmanageraudit/client.go
@@ -33,7 +33,7 @@ func (c *Client) Metadata() observabilityvo.SourceStatus {
 	if c.baseURL == "" {
 		return observabilityvo.SourceStatus{SourceID: sourceID, Status: "not_integrated", Reason: "source_not_configured", Reliability: "best_effort", CollectionMethod: "not_integrated", CoveredModules: []string{"model_management"}, CountAccuracy: "partial", Categories: []string{observabilityvo.CategoryAuditAdmin}}
 	}
-	return observabilityvo.SourceStatus{SourceID: sourceID, Status: "degraded", Reason: "partial_management_audit_coverage", Reliability: "best_effort", CollectionMethod: "source_adapter", CoveredModules: []string{"model_management"}, CountAccuracy: "partial", Categories: []string{observabilityvo.CategoryAuditAdmin}}
+	return observabilityvo.SourceStatus{SourceID: sourceID, Status: "degraded", Reason: observabilityvo.SourceReasonPartialManagementAuditCoverage, Reliability: "best_effort", CollectionMethod: "source_adapter", CoveredModules: []string{"model_management"}, CountAccuracy: "partial", Categories: []string{observabilityvo.CategoryAuditAdmin}}
 }
 func (c *Client) Search(ctx context.Context, q observabilityvo.LogQuery) (observabilityvo.SourcePage, error) {
 	if !contains(q.AuthorizedCategories, observabilityvo.CategoryAuditAdmin) {

--- a/bkn-trace/agent-observability/src/drivenadapter/httpaccess/vegaaudit/client.go
+++ b/bkn-trace/agent-observability/src/drivenadapter/httpaccess/vegaaudit/client.go
@@ -33,7 +33,7 @@ func (client *Client) Metadata() observabilityvo.SourceStatus {
 	if client.baseURL == "" {
 		return observabilityvo.SourceStatus{SourceID: sourceID, Status: "not_integrated", Reason: "source_not_configured", Reliability: "best_effort", CollectionMethod: "not_integrated", CoveredModules: []string{"data_resource_knowledge_network"}, CountAccuracy: "partial", Categories: []string{observabilityvo.CategoryAuditAdmin}}
 	}
-	return observabilityvo.SourceStatus{SourceID: sourceID, Status: "degraded", Reason: "management_audit_coverage_in_progress", Reliability: "best_effort", CollectionMethod: "source_adapter", CoveredModules: []string{"data_resource_knowledge_network"}, CountAccuracy: "partial", Categories: []string{observabilityvo.CategoryAuditAdmin}}
+	return observabilityvo.SourceStatus{SourceID: sourceID, Status: "degraded", Reason: "partial_management_audit_coverage", Reliability: "best_effort", CollectionMethod: "source_adapter", CoveredModules: []string{"data_resource_knowledge_network"}, CountAccuracy: "partial", Categories: []string{observabilityvo.CategoryAuditAdmin}}
 }
 
 func (client *Client) Search(ctx context.Context, query observabilityvo.LogQuery) (observabilityvo.SourcePage, error) {

--- a/bkn-trace/agent-observability/src/drivenadapter/httpaccess/vegaaudit/client.go
+++ b/bkn-trace/agent-observability/src/drivenadapter/httpaccess/vegaaudit/client.go
@@ -33,7 +33,7 @@ func (client *Client) Metadata() observabilityvo.SourceStatus {
 	if client.baseURL == "" {
 		return observabilityvo.SourceStatus{SourceID: sourceID, Status: "not_integrated", Reason: "source_not_configured", Reliability: "best_effort", CollectionMethod: "not_integrated", CoveredModules: []string{"data_resource_knowledge_network"}, CountAccuracy: "partial", Categories: []string{observabilityvo.CategoryAuditAdmin}}
 	}
-	return observabilityvo.SourceStatus{SourceID: sourceID, Status: "degraded", Reason: "partial_management_audit_coverage", Reliability: "best_effort", CollectionMethod: "source_adapter", CoveredModules: []string{"data_resource_knowledge_network"}, CountAccuracy: "partial", Categories: []string{observabilityvo.CategoryAuditAdmin}}
+	return observabilityvo.SourceStatus{SourceID: sourceID, Status: "degraded", Reason: observabilityvo.SourceReasonPartialManagementAuditCoverage, Reliability: "best_effort", CollectionMethod: "source_adapter", CoveredModules: []string{"data_resource_knowledge_network"}, CountAccuracy: "partial", Categories: []string{observabilityvo.CategoryAuditAdmin}}
 }
 
 func (client *Client) Search(ctx context.Context, query observabilityvo.LogQuery) (observabilityvo.SourcePage, error) {

--- a/infra/mf-model-manager/app/test/test_operation_audit.py
+++ b/infra/mf-model-manager/app/test/test_operation_audit.py
@@ -1,4 +1,17 @@
+import sys
+import types
 import unittest
+from unittest.mock import patch
+
+from starlette.requests import Request
+from starlette.responses import Response
+
+get_user_info = types.ModuleType("app.commons.get_user_info")
+get_user_info.get_username_by_ids = None
+sys.modules.setdefault("app.commons.get_user_info", get_user_info)
+database_pool = types.ModuleType("app.mydb.pymysql_pool")
+database_pool.PymysqlPool = object
+sys.modules.setdefault("app.mydb.pymysql_pool", database_pool)
 
 from app.utils import operation_audit
 
@@ -15,6 +28,42 @@ class TestOperationAuditRequestID(unittest.TestCase):
 
         self.assertEqual(request_id, "req_gateway")
         self.assertFalse(generated)
+
+
+class TestOperationAuditFailureReporting(unittest.IsolatedAsyncioTestCase):
+    async def test_reports_audit_write_failure_without_overturning_management_response(self):
+        async def receive():
+            return {"type": "http.request", "body": b'{"model_id":"model-1"}', "more_body": False}
+
+        request = Request({
+            "type": "http",
+            "method": "POST",
+            "path": "/api/mf-model-manager/v1/llm/edit",
+            "headers": [
+                (b"x-tenant-id", b"tenant-1"),
+                (b"x-business-domain", b"domain-1"),
+                (b"x-account-id", b"user-1"),
+                (b"bkn-request-id", b"req-audit-write-failure"),
+            ],
+            "query_string": b"",
+            "path_params": {},
+        }, receive)
+
+        async def call_next(_request):
+            return Response(status_code=200)
+
+        with patch.object(operation_audit, "_actor_name", return_value="user-1"), \
+             patch.object(operation_audit, "_write", side_effect=RuntimeError("database unavailable")), \
+             self.assertLogs("app.utils.operation_audit", level="ERROR") as logs:
+            response = await operation_audit.operation_audit_middleware(request, call_next)
+
+        self.assertEqual(response.status_code, 200)
+        self.assertTrue(any(
+            "operation_audit_write_failed" in message and
+            "req-audit-write-failure" in message and
+            "update" in message
+            for message in logs.output
+        ))
 
 
 if __name__ == "__main__":

--- a/infra/mf-model-manager/app/utils/operation_audit.py
+++ b/infra/mf-model-manager/app/utils/operation_audit.py
@@ -2,11 +2,14 @@
 import asyncio
 import hashlib
 import json
+import logging
 import secrets
 from datetime import datetime, timezone
 
 from app.commons.get_user_info import get_username_by_ids
 from app.mydb.pymysql_pool import PymysqlPool
+
+logger = logging.getLogger(__name__)
 
 _RULES = {
     ("POST", "/api/mf-model-manager/v1/llm/add"): ("create", "llm_model"),
@@ -104,6 +107,13 @@ async def operation_audit_middleware(request, call_next):
     try:
         await asyncio.to_thread(_write, entry)
     except Exception:
-        # Never overturn a completed management request; pipeline health is monitored separately.
-        pass
+        # A completed management request remains successful, but audit persistence
+        # failures must be diagnosable from the service logs.
+        logger.error(
+            "operation_audit_write_failed request_id=%s action=%s target_type=%s",
+            request_id,
+            rule[0],
+            rule[1],
+            exc_info=True,
+        )
     return response


### PR DESCRIPTION
## Summary
- normalize the four management-audit source adapters without treating non-integrated sources as unavailable
- make Model Manager audit persistence failures diagnosable without changing successful management responses
- align Execution Factory audit reads with the existing authorization service
- advance the local projection rebuild version after the verified index migration

## Validation
- `go test ./src/domain/service/logsvc ./src/drivenadapter/httpaccess/bknbackendaudit ./src/drivenadapter/httpaccess/bknsafeaudit ./src/drivenadapter/httpaccess/executionfactoryaudit ./src/drivenadapter/httpaccess/modelmanageraudit ./src/drivenadapter/httpaccess/vegaaudit -count=1`
- `go test ./driveradapters -run "Test.*ExecutionAudit|TestExecutionAudit" -count=1`
- `python3 -m pytest app/test/test_operation_audit.py -q`
- local Kubernetes readiness check for BKN Backend, Vega, Execution Factory, Model Manager, and Agent Observability

## Scope
This PR deliberately excludes the Phase 5 archive migration, object-store handling, and archive-download bundle changes.

Closes #547