### PR TITLE
refactor(execution-factory): localize hard-coded client text

### DIFF
--- a/adp/execution-factory/operator-integration/server/capabilitieslab/handler/error_messages.go
+++ b/adp/execution-factory/operator-integration/server/capabilitieslab/handler/error_messages.go
@@ -4,7 +4,7 @@
 
 package handler
 
-import sharedrest "github.com/openbkn-ai/bkn-foundry/comm-go/rest"
+import "github.com/openbkn-ai/bkn-foundry/adp/execution-factory/operator-integration/server/infra/localize"
 
 const (
 	capabilitiesLabInvalidRequest  = "invalid_request"
@@ -13,26 +13,6 @@ const (
 	capabilitiesLabFeatureDisabled = "feature_disabled"
 )
 
-var capabilitiesLabErrorMessages = map[string]map[string]string{
-	sharedrest.SimplifiedChinese: {
-		capabilitiesLabInvalidRequest:  "请求参数无效。",
-		capabilitiesLabNotFound:        "未找到资源。",
-		capabilitiesLabFileRequired:    "缺少必需的文件。",
-		capabilitiesLabFeatureDisabled: "该功能未启用。",
-	},
-	sharedrest.AmericanEnglish: {
-		capabilitiesLabInvalidRequest:  "Invalid request parameters.",
-		capabilitiesLabNotFound:        "Resource not found.",
-		capabilitiesLabFileRequired:    "A required file is missing.",
-		capabilitiesLabFeatureDisabled: "This feature is disabled.",
-	},
-}
-
 func capabilitiesLabErrorMessage(language, code string) string {
-	if messages, ok := capabilitiesLabErrorMessages[language]; ok {
-		if message, ok := messages[code]; ok {
-			return message
-		}
-	}
-	return capabilitiesLabErrorMessages[sharedrest.SimplifiedChinese][code]
+	return localize.NewI18nTranslator(language).Trans("capabilities_lab." + code)
 }

--- a/adp/execution-factory/operator-integration/server/driveradapters/common/ai_generation.go
+++ b/adp/execution-factory/operator-integration/server/driveradapters/common/ai_generation.go
@@ -16,6 +16,7 @@ import (
 	"github.com/openbkn-ai/bkn-foundry/adp/execution-factory/operator-integration/server/logics/aigeneration"
 	"github.com/openbkn-ai/bkn-foundry/adp/execution-factory/operator-integration/server/logics/auth"
 	"github.com/openbkn-ai/bkn-foundry/adp/execution-factory/operator-integration/server/utils"
+	sharedrest "github.com/openbkn-ai/bkn-foundry/comm-go/rest"
 )
 
 // AIGenerationHandler AI生成处理接口
@@ -223,5 +224,6 @@ func (h *aiGenerationHandler) GetPromptTemplate(c *gin.Context) {
 		rest.ReplyError(c, err)
 		return
 	}
+	sharedrest.MarkLocalizedResponse(c)
 	rest.ReplyOK(c, http.StatusOK, promptTemplate)
 }

--- a/adp/execution-factory/operator-integration/server/driveradapters/common/ai_generation.go
+++ b/adp/execution-factory/operator-integration/server/driveradapters/common/ai_generation.go
@@ -224,6 +224,6 @@ func (h *aiGenerationHandler) GetPromptTemplate(c *gin.Context) {
 		rest.ReplyError(c, err)
 		return
 	}
-	sharedrest.MarkLocalizedResponse(c)
+	sharedrest.MarkLocalizedCacheableResponse(c)
 	rest.ReplyOK(c, http.StatusOK, promptTemplate)
 }

--- a/adp/execution-factory/operator-integration/server/infra/localize/locales/en-US.json
+++ b/adp/execution-factory/operator-integration/server/infra/localize/locales/en-US.json
@@ -11,6 +11,21 @@
         "model_train": "Model Training",
         "system": "System"
     },
+    "capabilities_lab": {
+        "invalid_request": "Invalid request parameters.",
+        "not_found": "Resource not found.",
+        "file_required": "A required file is missing.",
+        "feature_disabled": "This feature is disabled."
+    },
+    "detail": {
+        "openapi_error_item": "Error %d: %s"
+    },
+    "prompt": {
+        "python_function_description": "Prompt template for Python function generation",
+        "python_function_user_template": "Function description: %s; inputs: %v; outputs: %v;",
+        "metadata_parameter_description": "Prompt template for metadata parameter generation",
+        "default_function_request": "Generate standards-compliant Python function code from the input and output parameters"
+    },
     "audit_log": {
         "operator_create": "Create operator '%s' successfully",
         "operator_edit": "Edit operator '%s' successfully",

--- a/adp/execution-factory/operator-integration/server/infra/localize/locales/zh-Hans.json
+++ b/adp/execution-factory/operator-integration/server/infra/localize/locales/zh-Hans.json
@@ -11,6 +11,21 @@
         "model_train": "模型训练",
         "system": "系统工具"
     },
+    "capabilities_lab": {
+        "invalid_request": "请求参数无效。",
+        "not_found": "未找到资源。",
+        "file_required": "缺少必需的文件。",
+        "feature_disabled": "该功能未启用。"
+    },
+    "detail": {
+        "openapi_error_item": "错误%d：%s"
+    },
+    "prompt": {
+        "python_function_description": "Python函数生成Prompt模板",
+        "python_function_user_template": "函数内容描述:%s; inputs:%v; outputs:%v;",
+        "metadata_parameter_description": "元数据参数生成Prompt模板",
+        "default_function_request": "根据输入参数和输出参数，生成符合标准的Python函数代码"
+    },
     "audit_log": {
         "operator_create": "创建算子“%s”成功",
         "operator_edit": "编辑算子“%s”成功",

--- a/adp/execution-factory/operator-integration/server/infra/rest/reply.go
+++ b/adp/execution-factory/operator-integration/server/infra/rest/reply.go
@@ -1,6 +1,6 @@
-// Package rest 响应处理
+// Package rest provides HTTP response helpers.
 // @file rest.go
-// @description: 响应处理
+// @description: HTTP response handling
 package rest
 
 import (
@@ -24,7 +24,7 @@ const (
 	ContentTypeJSON = "application/json"
 )
 
-// ReplyOK 响应成功
+// ReplyOK writes a successful JSON response.
 func ReplyOK(c *gin.Context, statusCode int, body interface{}) {
 	var (
 		bodyStr string
@@ -46,7 +46,7 @@ func ReplyOK(c *gin.Context, statusCode int, body interface{}) {
 	c.String(statusCode, bodyStr)
 }
 
-// ReplyError 响应错误
+// ReplyError writes an error response.
 func ReplyError(c *gin.Context, err error) {
 	if err != nil {
 		errWithStack := errorwrap.WithStack(err)
@@ -87,7 +87,7 @@ func ReplyError(c *gin.Context, err error) {
 	c.String(httpCode, body)
 }
 
-// ExHTTPError 依赖服务的错误码
+// ExHTTPError preserves an error response owned by a dependency.
 type ExHTTPError struct {
 	HTTPCode int
 	Body     []byte
@@ -97,9 +97,9 @@ func (e *ExHTTPError) Error() string {
 	return string(e.Body)
 }
 
-// ReplyWithExecutionMode 根据执行模式处理响应
+// ReplyWithExecutionMode writes a response according to the requested execution mode.
 func ReplyWithExecutionMode(c *gin.Context, resp interface{}, err error) {
-	// 判断流式响应模式
+	// Select the response transport for streaming requests.
 	ctx := c.Request.Context()
 	executionMode := common.GetExecutionModeFromCtx(ctx)
 	streamingMode, _ := common.GetStreamingModeFromCtx(ctx)
@@ -114,10 +114,12 @@ func ReplyWithExecutionMode(c *gin.Context, resp interface{}, err error) {
 			case *ExHTTPError:
 				c.SSEvent("error", e)
 			case *myErr.HTTPError:
+				sharedrest.MarkLocalizedResponse(c)
 				c.SSEvent("error", e)
 			default:
-				err = myErr.DefaultHTTPError(ctx, http.StatusInternalServerError, err.Error())
-				c.SSEvent("error", e)
+				localizedErr := myErr.DefaultHTTPError(ctx, http.StatusInternalServerError, err.Error())
+				sharedrest.MarkLocalizedResponse(c)
+				c.SSEvent("error", localizedErr)
 			}
 			return
 		case interfaces.StreamingModeHTTP:

--- a/adp/execution-factory/operator-integration/server/infra/rest/reply_language_test.go
+++ b/adp/execution-factory/operator-integration/server/infra/rest/reply_language_test.go
@@ -7,11 +7,15 @@
 package rest
 
 import (
+	"errors"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/gin-gonic/gin"
+	"github.com/openbkn-ai/bkn-foundry/adp/execution-factory/operator-integration/server/infra/common"
+	"github.com/openbkn-ai/bkn-foundry/adp/execution-factory/operator-integration/server/interfaces"
 	sharedrest "github.com/openbkn-ai/bkn-foundry/comm-go/rest"
 )
 
@@ -43,4 +47,35 @@ func TestReplyErrorMarksOnlyLocallyGeneratedTextAsLocalized(t *testing.T) {
 			t.Fatalf("Content-Language = %q, want empty for upstream response", got)
 		}
 	})
+}
+
+func TestReplyWithExecutionModeLocalizesUnexpectedSSEErrors(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	tests := []struct {
+		language, description string
+	}{
+		{sharedrest.SimplifiedChinese, "内部错误"},
+		{sharedrest.AmericanEnglish, "Internal server error"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.language, func(t *testing.T) {
+			recorder := httptest.NewRecorder()
+			c, _ := gin.CreateTestContext(recorder)
+			ctx := sharedrest.WithLanguage(httptest.NewRequest(http.MethodGet, "/", nil).Context(), test.language)
+			ctx = common.SetExecutionModeToCtx(ctx, interfaces.ExecutionModeStream)
+			ctx = common.SetStreamingModeToCtx(ctx, interfaces.StreamingModeSSE)
+			c.Request = httptest.NewRequest(http.MethodGet, "/", nil).WithContext(ctx)
+
+			ReplyWithExecutionMode(c, nil, errors.New("internal diagnostic"))
+
+			if got := recorder.Header().Get(sharedrest.ContentLanguageHeader); got != test.language {
+				t.Fatalf("Content-Language = %q, want %q", got, test.language)
+			}
+			body := recorder.Body.String()
+			if !strings.Contains(body, `"code":"Public.InternalServerError"`) || !strings.Contains(body, `"description":"`+test.description+`"`) {
+				t.Fatalf("SSE body = %q", body)
+			}
+		})
+	}
 }

--- a/adp/execution-factory/operator-integration/server/logics/aigeneration/aigeneration.go
+++ b/adp/execution-factory/operator-integration/server/logics/aigeneration/aigeneration.go
@@ -1,6 +1,6 @@
-// Package aigeneration 智能生成服务
+// Package aigeneration implements AI-assisted function generation.
 // @file aigeneration.go
-// @description: 智能生成服务
+// @description: AI-assisted function generation
 package aigeneration
 
 import (
@@ -11,13 +11,15 @@ import (
 	"sync"
 
 	"github.com/openbkn-ai/bkn-foundry/adp/execution-factory/operator-integration/server/drivenadapters"
+	"github.com/openbkn-ai/bkn-foundry/adp/execution-factory/operator-integration/server/infra/common"
 	"github.com/openbkn-ai/bkn-foundry/adp/execution-factory/operator-integration/server/infra/config"
 	"github.com/openbkn-ai/bkn-foundry/adp/execution-factory/operator-integration/server/infra/errors"
+	"github.com/openbkn-ai/bkn-foundry/adp/execution-factory/operator-integration/server/infra/localize"
 	"github.com/openbkn-ai/bkn-foundry/adp/execution-factory/operator-integration/server/interfaces"
 	"github.com/openbkn-ai/bkn-foundry/adp/execution-factory/operator-integration/server/utils"
 )
 
-// aiGenerationService 智能生成服务
+// aiGenerationService implements AI-assisted generation.
 type aiGenerationService struct {
 	Logger           interfaces.Logger
 	MFModelAPIClient interfaces.MFModelAPIClient
@@ -30,7 +32,7 @@ var (
 	agInstance interfaces.AIGenerationService
 )
 
-// NewAIGenerationService 创建新的智能生成服务
+// NewAIGenerationService returns the shared AI generation service.
 func NewAIGenerationService() interfaces.AIGenerationService {
 	agOnce.Do(func() {
 		promptLoader, err := NewPromptLoader()
@@ -57,7 +59,7 @@ func (ag *aiGenerationService) generateChatCompletionParams(ctx context.Context,
 		return nil, err
 	}
 	chatCompletionReq := &interfaces.ChatCompletionReq{
-		Model:            ag.LLMConfig.Model, // 大模型名称传空，使用默认大模型
+		Model:            ag.LLMConfig.Model, // An empty model name selects the default model.
 		MaxTokens:        ag.LLMConfig.MaxTokens,
 		Temperature:      ag.LLMConfig.Temperature,
 		TopK:             ag.LLMConfig.TopK,
@@ -74,9 +76,10 @@ func (ag *aiGenerationService) generateChatCompletionParams(ctx context.Context,
 	var userPrompt string
 	switch req.Type {
 	case interfaces.PythonFunctionGenerator:
-		// 默认函数内容描述
+		// Supply a default function request when the caller omits one.
 		if req.Query == "" {
-			req.Query = "根据输入参数和输出参数，生成符合标准的Python函数代码"
+			tr := localize.NewI18nTranslator(common.GetLanguageFromCtx(ctx))
+			req.Query = tr.Trans("prompt.default_function_request")
 		}
 		userPrompt = promptTemplate.FormatUserPrompt(req.Query, req.Inputs, req.Outputs)
 	case interfaces.MetadataParamGenerator:
@@ -89,7 +92,7 @@ func (ag *aiGenerationService) generateChatCompletionParams(ctx context.Context,
 	return chatCompletionReq, nil
 }
 
-// AIGenerate 智能生成
+// FunctionAIGenerate generates a complete response.
 func (ag *aiGenerationService) FunctionAIGenerate(ctx context.Context, req *interfaces.FunctionAIGenerateReq) (resp *interfaces.FunctionAIGeneratResp, err error) {
 	chatCompletionReq, err := ag.generateChatCompletionParams(ctx, req)
 	if err != nil {
@@ -123,7 +126,7 @@ func (ag *aiGenerationService) FunctionAIGenerate(ctx context.Context, req *inte
 	return resp, nil
 }
 
-// AIGenerateStream 智能生成流式返回
+// FunctionAIGenerateStream streams generated response chunks.
 func (ag *aiGenerationService) FunctionAIGenerateStream(ctx context.Context, req *interfaces.FunctionAIGenerateReq) (respChan chan string, errChan chan error, err error) {
 	chatCompletionReq, err := ag.generateChatCompletionParams(ctx, req)
 	if err != nil {
@@ -136,7 +139,7 @@ func (ag *aiGenerationService) FunctionAIGenerateStream(ctx context.Context, req
 	return respChan, errChan, nil
 }
 
-// 获取当前提示词模板
+// GetPromptTemplate returns the active prompt template.
 func (ag *aiGenerationService) GetPromptTemplate(ctx context.Context, tempType interfaces.PromptTemplateType) (*interfaces.PromptTemplate, error) {
 	return ag.PromptLoader.GetTemplate(ctx, tempType)
 }

--- a/adp/execution-factory/operator-integration/server/logics/aigeneration/prompt.go
+++ b/adp/execution-factory/operator-integration/server/logics/aigeneration/prompt.go
@@ -5,21 +5,27 @@ import (
 	"embed"
 	"fmt"
 	"io/fs"
-	"path/filepath"
-	"strings"
+	"path"
 	"sync"
 
 	"github.com/openbkn-ai/bkn-foundry/adp/execution-factory/operator-integration/server/drivenadapters"
+	"github.com/openbkn-ai/bkn-foundry/adp/execution-factory/operator-integration/server/infra/common"
 	"github.com/openbkn-ai/bkn-foundry/adp/execution-factory/operator-integration/server/infra/config"
+	"github.com/openbkn-ai/bkn-foundry/adp/execution-factory/operator-integration/server/infra/localize"
 	"github.com/openbkn-ai/bkn-foundry/adp/execution-factory/operator-integration/server/interfaces"
 )
 
-// prompt加载及解析
+// Prompt template loading and parsing.
 
-//go:embed templates/*.md
+//go:embed templates/*.md templates/locales/*/*.md
 var promptTemplatesFS embed.FS
 
-// PromptLoader 提示词加载器
+var promptTemplateFiles = map[interfaces.PromptTemplateType]string{
+	interfaces.PythonFunctionGenerator: "Python_Function_Generator.md",
+	interfaces.MetadataParamGenerator:  "Metadata_Param_Generator.md",
+}
+
+// PromptLoader loads default and custom prompt templates.
 type PromptLoader struct {
 	DefaulTemplates    map[interfaces.PromptTemplateType]*interfaces.PromptTemplate
 	MFModelManager     interfaces.MFModelManager
@@ -32,7 +38,7 @@ var (
 	promptLoader *PromptLoader
 )
 
-// NewPromptLoader 创建新的提示词加载器
+// NewPromptLoader creates the shared prompt loader.
 func NewPromptLoader() (*PromptLoader, error) {
 	pOnce.Do(func() {
 		conf := config.NewConfigLoader()
@@ -42,20 +48,15 @@ func NewPromptLoader() (*PromptLoader, error) {
 			AIGenerationConfig: conf.AIGenerationConfig,
 			DefaulTemplates: map[interfaces.PromptTemplateType]*interfaces.PromptTemplate{
 				interfaces.PythonFunctionGenerator: {
-					Name:               string(interfaces.PythonFunctionGenerator),
-					Description:        "Python函数生成Prompt模板",
-					SystemPrompt:       "",
-					UserPromptTemplate: "函数内容描述:%s; inputs:%v; outputs:%v;",
+					Name: string(interfaces.PythonFunctionGenerator),
 				},
 				interfaces.MetadataParamGenerator: {
 					Name:               string(interfaces.MetadataParamGenerator),
-					Description:        "元数据参数生成Prompt模板",
-					SystemPrompt:       "",
 					UserPromptTemplate: `{"code": "%s", "inputs_json": %v, "outputs_json": %v}`,
 				},
 			},
 		}
-		// 加载默认模板文件
+		// Load embedded default template files.
 		if err := promptLoader.loadDefaulTemplates(); err != nil {
 			panic(fmt.Errorf("failed to load prompt templates: %w", err))
 		}
@@ -63,52 +64,60 @@ func NewPromptLoader() (*PromptLoader, error) {
 	return promptLoader, nil
 }
 
-// loadDefaulTemplates 加载默认模板文件
+// loadDefaulTemplates loads embedded default template files.
 func (l *PromptLoader) loadDefaulTemplates() error {
-	return fs.WalkDir(promptTemplatesFS, "templates", func(path string, d fs.DirEntry, err error) error {
+	for tempType, fileName := range promptTemplateFiles {
+		content, err := fs.ReadFile(promptTemplatesFS, path.Join("templates", fileName))
 		if err != nil {
-			return err
-		}
-
-		if d.IsDir() || filepath.Ext(path) != ".md" {
-			return nil
-		}
-		tempName := strings.ToLower(strings.TrimSuffix(filepath.Base(path), filepath.Ext(filepath.Base(path))))
-		tempType := interfaces.PromptTemplateType(tempName)
-		if _, ok := l.DefaulTemplates[tempType]; !ok {
-			return fmt.Errorf("default prompt template %s not found", tempType)
-		}
-
-		content, err := fs.ReadFile(promptTemplatesFS, path)
-		if err != nil {
-			return fmt.Errorf("failed to read template file %s: %w", path, err)
+			return fmt.Errorf("failed to read template file %s: %w", fileName, err)
 		}
 		l.DefaulTemplates[tempType].SystemPrompt = string(content)
-		return nil
-	})
+	}
+	return nil
 }
 
-// GetTemplate 获取指定类型的提示词模板
+// GetTemplate returns the configured template for a prompt type.
 func (l *PromptLoader) GetTemplate(ctx context.Context, tempType interfaces.PromptTemplateType) (*interfaces.PromptTemplate, error) {
 	temp, ok := l.DefaulTemplates[tempType]
 	if !ok {
 		return nil, fmt.Errorf("default prompt template %s not found", tempType)
 	}
+	temp = localizedPromptTemplate(ctx, tempType, temp)
 	customPrompt, err := l.loadCustomPromptTemplate(ctx, tempType)
 	if err != nil {
 		l.Logger.WithContext(ctx).Warnf("failed to load custom prompt: %v", err)
 	}
 	if customPrompt == nil || customPrompt.SystemPrompt == "" {
-		// 未配置自定义提示词，使用默认提示词
+		// Use the default template when no custom prompt is configured.
 		return temp, nil
 	}
-	// 配置了自定义提示词，使用自定义提示词
+	// Preserve the localized user prompt and description when using a custom system prompt.
 	customPrompt.UserPromptTemplate = temp.UserPromptTemplate
 	customPrompt.Description = temp.Description
 	return customPrompt, nil
 }
 
-// loadCustomPrompt 加载自定义配置提示词
+func localizedPromptTemplate(ctx context.Context, tempType interfaces.PromptTemplateType, source *interfaces.PromptTemplate) *interfaces.PromptTemplate {
+	temp := *source
+	tr := localize.NewI18nTranslator(common.GetLanguageFromCtx(ctx))
+	switch tempType {
+	case interfaces.PythonFunctionGenerator:
+		temp.Description = tr.Trans("prompt.python_function_description")
+		temp.UserPromptTemplate = tr.Trans("prompt.python_function_user_template")
+	case interfaces.MetadataParamGenerator:
+		temp.Description = tr.Trans("prompt.metadata_parameter_description")
+	}
+	if common.GetLanguageFromCtx(ctx) == common.AmericanEnglish {
+		if fileName, ok := promptTemplateFiles[tempType]; ok {
+			if content, err := fs.ReadFile(promptTemplatesFS, path.Join("templates", "locales", "en-US", fileName)); err == nil && len(content) > 0 {
+				temp.SystemPrompt = string(content)
+			}
+		}
+	}
+	return &temp
+}
+
+// loadCustomPromptTemplate loads a custom prompt from the model manager.
 func (l *PromptLoader) loadCustomPromptTemplate(ctx context.Context, tempType interfaces.PromptTemplateType) (*interfaces.PromptTemplate, error) {
 	var promptID string
 	switch tempType {
@@ -120,7 +129,7 @@ func (l *PromptLoader) loadCustomPromptTemplate(ctx context.Context, tempType in
 	if promptID == "" {
 		return nil, nil
 	}
-	// 从模型管理器获取模型配置
+	// Load the prompt configuration from the model manager.
 	promptResult, err := l.MFModelManager.GetPromptByPromptID(ctx, promptID)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get model config: %v", err)

--- a/adp/execution-factory/operator-integration/server/logics/aigeneration/prompt_i18n_test.go
+++ b/adp/execution-factory/operator-integration/server/logics/aigeneration/prompt_i18n_test.go
@@ -1,0 +1,61 @@
+package aigeneration
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/openbkn-ai/bkn-foundry/adp/execution-factory/operator-integration/server/interfaces"
+	sharedrest "github.com/openbkn-ai/bkn-foundry/comm-go/rest"
+)
+
+func TestLocalizedPromptTemplateUsesRequestLanguage(t *testing.T) {
+	source := &interfaces.PromptTemplate{
+		Name:         string(interfaces.PythonFunctionGenerator),
+		SystemPrompt: "# 函数生成 Prompt 模板",
+	}
+	tests := []struct {
+		language, description, userPrompt, systemPromptPrefix string
+	}{
+		{
+			language:           sharedrest.SimplifiedChinese,
+			description:        "Python函数生成Prompt模板",
+			userPrompt:         "函数内容描述:%s; inputs:%v; outputs:%v;",
+			systemPromptPrefix: "# 函数生成 Prompt 模板",
+		},
+		{
+			language:           sharedrest.AmericanEnglish,
+			description:        "Prompt template for Python function generation",
+			userPrompt:         "Function description: %s; inputs: %v; outputs: %v;",
+			systemPromptPrefix: "# Function Generation Prompt Template",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.language, func(t *testing.T) {
+			ctx := sharedrest.WithLanguage(context.Background(), test.language)
+			localized := localizedPromptTemplate(ctx, interfaces.PythonFunctionGenerator, source)
+			if localized.Description != test.description || localized.UserPromptTemplate != test.userPrompt {
+				t.Fatalf("localized prompt = %#v", localized)
+			}
+			if !strings.HasPrefix(localized.SystemPrompt, test.systemPromptPrefix) {
+				t.Fatalf("system prompt starts with %q", localized.SystemPrompt)
+			}
+			if test.language == sharedrest.AmericanEnglish && containsHan(localized.SystemPrompt+localized.Description+localized.UserPromptTemplate) {
+				t.Fatalf("English prompt contains Chinese text")
+			}
+			if source.Description != "" || source.UserPromptTemplate != "" || source.SystemPrompt != "# 函数生成 Prompt 模板" {
+				t.Fatalf("source template was mutated: %#v", source)
+			}
+		})
+	}
+}
+
+func containsHan(value string) bool {
+	for _, char := range value {
+		if char >= '\u4e00' && char <= '\u9fff' {
+			return true
+		}
+	}
+	return false
+}

--- a/adp/execution-factory/operator-integration/server/logics/aigeneration/templates/locales/en-US/Metadata_Param_Generator.md
+++ b/adp/execution-factory/operator-integration/server/logics/aigeneration/templates/locales/en-US/Metadata_Param_Generator.md
@@ -1,0 +1,112 @@
+# Metadata Generation Prompt Template
+
+## Role
+
+You are an assistant specialized in generating function metadata.
+
+## Goal
+
+Use the function source and the current `inputs_json` and `outputs_json` values to generate or complete a standards-compliant metadata object. Infer a function name, description, usage rules, inputs, and outputs.
+
+## Parameter schema
+
+Every parameter object uses this shape:
+
+```json
+{
+  "name": "parameter_name",
+  "type": "string",
+  "description": "parameter description",
+  "required": true,
+  "default": null,
+  "sub_parameters": []
+}
+```
+
+Only these five types are valid:
+
+- `string`: text, unknown types, and `Any`
+- `number`: integers or floating-point numbers
+- `boolean`: boolean values
+- `object`: structured objects; omit `sub_parameters` when the dictionary shape is unknown
+- `array`: arrays whose optional single sub-parameter defines the item schema
+
+Do not emit `int`, `float`, `list`, `dict`, `integer`, `any`, or any other type name.
+
+## Field rules
+
+- `name` is required, has at most 50 characters, contains only letters, digits, and underscores, and does not start with a digit.
+- `"[Array Item]"` is the only exception to the name rule and is allowed only for an array item definition.
+- `description` is required, non-empty, and has at most 255 characters.
+- `required` is a JSON boolean, never a string.
+- `default` is optional and must match the declared type when present.
+- `sub_parameters` is allowed only for `object` and `array` and must be an array.
+
+## Nested structures
+
+For an object, list its child fields directly in `sub_parameters`. Never insert an unnamed wrapper object.
+
+```json
+{
+  "name": "content",
+  "type": "object",
+  "description": "Request object",
+  "required": false,
+  "sub_parameters": [
+    {
+      "name": "file_name",
+      "type": "string",
+      "description": "File name",
+      "required": true
+    }
+  ]
+}
+```
+
+For an array, `sub_parameters` must contain exactly one object defining its item type, and that object's name must be `"[Array Item]"`.
+
+```json
+{
+  "name": "file_list",
+  "type": "array",
+  "description": "Files to process",
+  "required": false,
+  "sub_parameters": [
+    {
+      "name": "[Array Item]",
+      "type": "string",
+      "description": "File path",
+      "required": true
+    }
+  ]
+}
+```
+
+## Generation rules
+
+1. Analyze `inputs_json`, complete missing supported fields, and preserve valid caller intent.
+2. Analyze returned values and create complete `outputs` metadata.
+3. Use `event.get()` calls and return statements in the source to infer missing parameters.
+4. Resolve inconsistencies according to the function logic and business intent. Prefer a flat valid structure over an unnecessary unnamed object wrapper.
+5. Recursively process nested objects and arrays so every level has complete metadata.
+6. Infer a concise machine-safe function name, a human-readable description, and practical usage rules.
+
+## Output contract
+
+Return exactly one minified JSON object on one line with only these top-level fields:
+
+```json
+{"name":"function_name","description":"Detailed function description","use_rule":"Usage rules and cautions","inputs":[],"outputs":[]}
+```
+
+Strict requirements:
+
+- Do not return Markdown, comments, explanations, line breaks, or tab characters.
+- Do not add fields other than `name`, `description`, `use_rule`, `inputs`, and `outputs` at the top level.
+- Never emit fields whose names start with `_`, including test, marker, debug, or security fields.
+- Use valid one-line JSON with correct JSON data types.
+- Do not emit empty `name`, `description`, or `type` values at any nesting level.
+- Ensure every `inputs` and `outputs` item has all required fields.
+- Ensure defaults match their declared types or are `null`.
+
+Before returning, validate the JSON syntax, allowed fields, name limits, description limits, supported types, nested object shape, array item shape, and absence of internal or debug fields. If any check fails, regenerate a compliant object.

--- a/adp/execution-factory/operator-integration/server/logics/aigeneration/templates/locales/en-US/Python_Function_Generator.md
+++ b/adp/execution-factory/operator-integration/server/logics/aigeneration/templates/locales/en-US/Python_Function_Generator.md
@@ -1,0 +1,86 @@
+# Function Generation Prompt Template
+
+## Role
+
+You are an assistant specialized in generating event-driven Python tool code.
+
+## Goal
+
+Write a Python script that follows the format below. Use the user's natural-language request, optional input/output metadata, and optional list of installed dependencies.
+
+## Required code structure
+
+1. Imports
+   - Import `Dict` and `Any` from `typing`.
+   - If installed dependencies are provided, use only libraries from that list or the Python standard library.
+   - Prefer the standard library when it is sufficient. Import only libraries that the implementation actually uses.
+
+2. Handler
+
+```python
+def handler(event: Dict[str, Any]):
+    """Describe the tool, its event fields, and its return value."""
+    try:
+        # Extract and validate parameters.
+        # Implement the business logic.
+        return result
+    except Exception as exc:
+        import traceback
+        print(traceback.format_exc())
+        return {
+            "error": f"Execution Error: {str(exc)}",
+            "success": False,
+        }
+```
+
+3. Local test block
+
+```python
+if __name__ == "__main__":
+    print("--- Start Local Test ---")
+    test_event = {"param1": "demo_value"}
+    print("Input:", test_event)
+    print("Result:", handler(test_event))
+    print("--- End Local Test ---")
+```
+
+The test event must be one representative static object derived from the declared inputs. Do not construct it with loops, comprehensions, or other dynamic generation.
+
+## Implementation rules
+
+### Dependencies
+
+- When an installed dependency list is supplied, choose implementations that use only that list or the standard library.
+- Do not import an unavailable dependency.
+- Use every imported module.
+
+### Inputs
+
+- Receive all inputs through the `event` dictionary.
+- When input metadata is supplied, process every declared input.
+- Read values with `event.get("name", default_value)`. Prefer the declared default; otherwise use a sensible default or `None`.
+- Validate every required input. If one is missing, raise `ValueError` or return a clear error object.
+- Enforce the declared type, including conversion from strings when appropriate.
+- Recursively process object sub-parameters and array item definitions.
+- When metadata is absent, infer the required inputs and use defensive access.
+
+### Outputs
+
+- Return a JSON-serializable object, normally a dictionary.
+- When output metadata is supplied, the returned dictionary must match it exactly.
+- Otherwise return a clear structure such as `{"result": ...}` or `{"message": ...}`.
+
+### Quality and safety
+
+- Wrap the complete handler logic in `try/except Exception` so the handler always returns a dictionary on runtime failure.
+- Do not call `input()`, `sys.exit()`, `quit()`, or `exit()`.
+- Do not import GUI libraries such as `tkinter` or `PyQt`.
+- Check paths before file operations or use a temporary directory.
+- Do not use a backslash for line continuation in strings, f-strings, or expressions; use parentheses for multiline expressions.
+- Keep the script self-contained and ensure every referenced input comes from `event`.
+
+## Output format
+
+Return only plain Python source code. Do not use Markdown fences or add explanatory text.
+
+If the request is empty or ambiguous, generate a useful generic handler that still follows every rule above.

--- a/adp/execution-factory/operator-integration/server/logics/mcp/convert.go
+++ b/adp/execution-factory/operator-integration/server/logics/mcp/convert.go
@@ -6,17 +6,17 @@ import (
 	"strings"
 )
 
-// Result 转换结果
+// Result describes a schema conversion result.
 type Result struct {
 	Success bool           `json:"success"`
 	Data    map[string]any `json:"data,omitempty"`
 	Error   string         `json:"error,omitempty"`
 }
 
-// SimpleConverter 处理简化OpenAPI格式的转换器
+// SimpleConverter converts the simplified OpenAPI representation used by this service.
 type SimpleConverter struct{}
 
-// SimpleOpenAPI 简化OpenAPI格式
+// SimpleOpenAPI is the simplified OpenAPI representation used by this service.
 type SimpleOpenAPI struct {
 	Parameters   []Parameter  `json:"parameters,omitempty"`
 	RequestBody  *RequestBody `json:"request_body,omitempty"`
@@ -28,7 +28,7 @@ type SimpleOpenAPI struct {
 	ExternalDocs any          `json:"external_docs,omitempty"`
 }
 
-// Parameter 参数定义
+// Parameter defines an OpenAPI parameter.
 type Parameter struct {
 	Name        string         `json:"name"`
 	In          string         `json:"in"`
@@ -37,70 +37,70 @@ type Parameter struct {
 	Schema      map[string]any `json:"schema"`
 }
 
-// RequestBody 请求体定义
+// RequestBody defines an OpenAPI request body.
 type RequestBody struct {
 	Description string             `json:"description,omitempty"`
 	Content     map[string]Content `json:"content"`
 	Required    bool               `json:"required"`
 }
 
-// Content 内容定义
+// Content defines an OpenAPI media type payload.
 type Content struct {
 	Schema   map[string]any            `json:"schema"`
 	Examples map[string]map[string]any `json:"examples,omitempty"`
 }
 
-// Response 响应定义
+// Response defines an OpenAPI response.
 type Response struct {
 	StatusCode  string             `json:"status_code"`
 	Description string             `json:"description"`
 	Content     map[string]Content `json:"content"`
 }
 
-// Components 组件定义
+// Components contains reusable OpenAPI schemas.
 type Components struct {
 	Schemas map[string]map[string]any `json:"schemas"`
 }
 
-// NewSimpleConverter 创建简化转换器实例
+// NewSimpleConverter creates a simplified OpenAPI converter.
 func NewSimpleConverter() *SimpleConverter {
 	return &SimpleConverter{}
 }
 
-// ConvertFromBytes 从字节数组转换简化OpenAPI格式
+// ConvertFromBytes converts a JSON-encoded simplified OpenAPI document.
 func (c *SimpleConverter) ConvertFromBytes(data []byte) *Result {
 	var simpleOpenAPI SimpleOpenAPI
 	if err := json.Unmarshal(data, &simpleOpenAPI); err != nil {
 		return &Result{
 			Success: false,
-			Error:   fmt.Sprintf("解析JSON失败: %v", err),
+			Error:   fmt.Sprintf("failed to parse JSON: %v", err),
 		}
 	}
 
 	return c.convertSimpleOpenAPI(&simpleOpenAPI)
 }
 
-// ConvertFromString 从字符串转换简化OpenAPI格式
+// ConvertFromString converts a JSON string containing a simplified OpenAPI document.
 func (c *SimpleConverter) ConvertFromString(jsonStr string) *Result {
 	return c.ConvertFromBytes([]byte(jsonStr))
 }
 
-// convertSimpleOpenAPI 转换简化OpenAPI格式
+// convertSimpleOpenAPI converts a simplified OpenAPI document into an MCP input schema.
 func (c *SimpleConverter) convertSimpleOpenAPI(simple *SimpleOpenAPI) *Result {
-	// 构建properties
+	// Build top-level parameter groups.
 	properties := map[string]any{}
 
-	headers := c.extractParameters(simple.Parameters, "header", "HTTP 请求头参数")
+	headers := c.extractParameters(simple.Parameters, "header", "HTTP header parameters")
 	if headers != nil {
 		properties["header"] = headers
 	}
 
-	query := c.extractParameters(simple.Parameters, "query", "URL 查询字符串参数")
+	query := c.extractParameters(simple.Parameters, "query", "URL query parameters")
 	if query != nil {
 		properties["query"] = query
 	}
 
-	path := c.extractParameters(simple.Parameters, "path", "URL 路径参数")
+	path := c.extractParameters(simple.Parameters, "path", "URL path parameters")
 	if path != nil {
 		properties["path"] = path
 	}
@@ -110,18 +110,18 @@ func (c *SimpleConverter) convertSimpleOpenAPI(simple *SimpleOpenAPI) *Result {
 		properties["body"] = body
 	}
 
-	// 构建标准JSON Schema格式
+	// Build the standard JSON Schema shape.
 	result := map[string]any{
 		"type":       "object",
 		"properties": properties,
 	}
 
-	// 添加$defs（而不是components）
+	// Add $defs instead of OpenAPI components.
 	if simple.Components != nil && len(simple.Components.Schemas) > 0 {
-		// 转换components.schemas为$defs格式
+		// Convert components.schemas into $defs.
 		defs := make(map[string]any)
 		for name, schema := range simple.Components.Schemas {
-			// 递归处理schema中的$ref引用
+			// Rewrite schema references recursively.
 			defs[name] = c.processSchemaRefs(schema)
 		}
 		result["$defs"] = defs
@@ -133,9 +133,8 @@ func (c *SimpleConverter) convertSimpleOpenAPI(simple *SimpleOpenAPI) *Result {
 	}
 }
 
-// extractParameters 提取指定类型的参数
-// inType: 参数类型 (header/query/path)
-// description: 该类型参数组的描述
+// extractParameters extracts parameters of the requested location.
+// inType is one of header, query, or path; description labels the parameter group.
 func (c *SimpleConverter) extractParameters(params []Parameter, inType, description string) map[string]any {
 	props := map[string]any{}
 	required := []string{}
@@ -170,18 +169,18 @@ func (c *SimpleConverter) extractParameters(params []Parameter, inType, descript
 	return obj
 }
 
-// extractRequestBody 提取请求体
+// extractRequestBody extracts the JSON request body schema.
 func (c *SimpleConverter) extractRequestBody(reqBody *RequestBody) map[string]any {
 	if reqBody == nil {
 		return nil
 	}
 
-	// 获取JSON内容
+	// Read the JSON media type.
 	if content, ok := reqBody.Content["application/json"]; ok {
 		schema := c.convertSchema(content.Schema)
-		// 如果没有 description，补充默认描述
+		// Add a default description when the source schema has none.
 		if _, hasDesc := schema["description"]; !hasDesc {
-			schema["description"] = "Request Body 参数"
+			schema["description"] = "Request body parameters"
 		}
 		return schema
 	}
@@ -189,18 +188,18 @@ func (c *SimpleConverter) extractRequestBody(reqBody *RequestBody) map[string]an
 	return nil
 }
 
-// convertSchema 转换Schema
+// convertSchema converts a schema and rewrites its references.
 func (c *SimpleConverter) convertSchema(schema map[string]any) map[string]any {
 	if schema == nil {
 		return map[string]any{
 			"type": "object",
 		}
 	}
-	// 处理schema中的$ref引用
+	// Rewrite $ref values throughout the schema.
 	return c.processSchemaRefs(schema)
 }
 
-// processSchemaRefs 递归处理schema中的$ref引用，将components/schemas/改为$defs/
+// processSchemaRefs recursively rewrites components/schemas references to $defs.
 func (c *SimpleConverter) processSchemaRefs(schema map[string]any) map[string]any {
 	if schema == nil {
 		return nil
@@ -209,19 +208,19 @@ func (c *SimpleConverter) processSchemaRefs(schema map[string]any) map[string]an
 	for key, value := range schema {
 		switch v := value.(type) {
 		case string:
-			// 如果是$ref字段，转换引用路径
+			// Rewrite reference paths only for $ref fields.
 			if key == "$ref" {
-				// 将 #/components/schemas/ 替换为 #/$defs/
+				// Replace #/components/schemas/ with #/$defs/.
 				refStr := c.convertRefPath(v)
 				result[key] = refStr
 			} else {
 				result[key] = v
 			}
 		case map[string]any:
-			// 递归处理嵌套的map
+			// Process nested objects recursively.
 			result[key] = c.processSchemaRefs(v)
 		case []any:
-			// 处理数组中的每个元素
+			// Process every object contained in an array.
 			processedArray := make([]any, len(v))
 			for i, item := range v {
 				if itemMap, ok := item.(map[string]any); ok {
@@ -238,31 +237,31 @@ func (c *SimpleConverter) processSchemaRefs(schema map[string]any) map[string]an
 	return result
 }
 
-// convertRefPath 转换引用路径
+// convertRefPath rewrites an OpenAPI component reference for JSON Schema.
 func (c *SimpleConverter) convertRefPath(refPath string) string {
-	// 将 #/components/schemas/ 替换为 #/$defs/
+	// Replace components/schemas with $defs for local references.
 	if refPath != "" && refPath[0] == '#' {
-		// 替换 components/schemas 为 $defs
+		// Keep non-component path segments unchanged.
 		refPath = strings.ReplaceAll(refPath, "/components/schemas/", "/$defs/")
 	}
 	return refPath
 }
 
-// ToJSONString 将转换结果转换为JSON字符串
+// ToJSONString serializes a successful conversion result.
 func (c *SimpleConverter) ToJSONString(result *Result) (string, error) {
 	if !result.Success {
-		return "", fmt.Errorf("转换失败: %s", result.Error)
+		return "", fmt.Errorf("conversion failed: %s", result.Error)
 	}
 
 	out, err := json.MarshalIndent(result.Data, "", "  ")
 	if err != nil {
-		return "", fmt.Errorf("JSON序列化失败: %v", err)
+		return "", fmt.Errorf("failed to serialize JSON: %v", err)
 	}
 
 	return string(out), nil
 }
 
-// GetSchemaInfo 获取Schema信息
+// GetSchemaInfo returns a compact schema summary.
 func (c *SimpleConverter) GetSchemaInfo(result *Result) map[string]any {
 	if !result.Success {
 		return map[string]any{
@@ -291,7 +290,7 @@ func (c *SimpleConverter) GetSchemaInfo(result *Result) map[string]any {
 		}
 		info["schemas"] = schemaList
 	} else {
-		// 如果没有$defs，设置默认值
+		// Return stable empty values when the schema has no $defs.
 		info["schema_count"] = 0
 		info["schemas"] = []string{}
 	}

--- a/adp/execution-factory/operator-integration/server/logics/mcp/convert_test.go
+++ b/adp/execution-factory/operator-integration/server/logics/mcp/convert_test.go
@@ -145,7 +145,7 @@ func TestExtractRequestBody(t *testing.T) {
 			result := converter.extractRequestBody(reqBody)
 
 			So(result, ShouldNotBeNil)
-			So(result["description"], ShouldEqual, "Request Body 参数")
+			So(result["description"], ShouldEqual, "Request body parameters")
 			So(result["type"], ShouldEqual, "object")
 		})
 
@@ -263,16 +263,16 @@ func TestConvertSimpleOpenAPI(t *testing.T) {
 
 			// 验证各参数组的 description
 			header := properties["header"].(map[string]any)
-			So(header["description"], ShouldEqual, "HTTP 请求头参数")
+			So(header["description"], ShouldEqual, "HTTP header parameters")
 
 			query := properties["query"].(map[string]any)
-			So(query["description"], ShouldEqual, "URL 查询字符串参数")
+			So(query["description"], ShouldEqual, "URL query parameters")
 
 			path := properties["path"].(map[string]any)
-			So(path["description"], ShouldEqual, "URL 路径参数")
+			So(path["description"], ShouldEqual, "URL path parameters")
 
 			body := properties["body"].(map[string]any)
-			So(body["description"], ShouldEqual, "Request Body 参数")
+			So(body["description"], ShouldEqual, "Request body parameters")
 		})
 
 		Convey("验证 $defs 和 $ref 转换", func() {
@@ -358,7 +358,7 @@ func TestConvertFromBytes(t *testing.T) {
 			result := converter.ConvertFromBytes(jsonData)
 
 			So(result.Success, ShouldBeFalse)
-			So(result.Error, ShouldContainSubstring, "解析JSON失败")
+			So(result.Error, ShouldContainSubstring, "failed to parse JSON")
 		})
 	})
 }
@@ -432,7 +432,7 @@ func TestToJSONString(t *testing.T) {
 
 			So(err, ShouldNotBeNil)
 			So(jsonStr, ShouldBeEmpty)
-			So(err.Error(), ShouldContainSubstring, "转换失败")
+			So(err.Error(), ShouldContainSubstring, "conversion failed")
 		})
 	})
 }

--- a/adp/execution-factory/operator-integration/server/logics/parsers/error_parse.go
+++ b/adp/execution-factory/operator-integration/server/logics/parsers/error_parse.go
@@ -8,12 +8,14 @@ import (
 	"strings"
 
 	"github.com/getkin/kin-openapi/openapi3"
+	"github.com/openbkn-ai/bkn-foundry/adp/execution-factory/operator-integration/server/infra/common"
 	"github.com/openbkn-ai/bkn-foundry/adp/execution-factory/operator-integration/server/infra/errors"
+	"github.com/openbkn-ai/bkn-foundry/adp/execution-factory/operator-integration/server/infra/localize"
 )
 
 const (
-	errorTypeLoadFailed       = "OpenAPILoadFailed"       // OpenAPI规范加载失败
-	errorTypeValidationFailed = "OpenAPIValidationFailed" // OpenAPI规范验证失败
+	errorTypeLoadFailed       = "OpenAPILoadFailed"       // The OpenAPI document could not be loaded.
+	errorTypeValidationFailed = "OpenAPIValidationFailed" // The OpenAPI document failed validation.
 	elementTypeLen            = 2
 )
 
@@ -25,60 +27,62 @@ var (
 	fieldRegex     = regexp.MustCompile(`field\s*["']([^"']+)["']`)
 )
 
-// parseOpenAPILoadError 解析OpenAPI加载错误
+// parseOpenAPILoadError maps an OpenAPI loading failure to a public error.
 func parseOpenAPILoadError(ctx context.Context, originalErr error) *errors.HTTPError {
 	if originalErr == nil {
 		return nil
 	}
-	errorCode, errorParams, errorDetails := extractErrorInfo(originalErr, errorTypeLoadFailed)
+	errorCode, errorParams, errorDetails := extractErrorInfo(ctx, originalErr, errorTypeLoadFailed)
 	return errors.NewHTTPError(ctx, http.StatusBadRequest, errorCode, errorDetails, errorParams...)
 }
 
-// parseOpenAPIValidationError 解析OpenAPI验证错误
+// parseOpenAPIValidationError maps an OpenAPI validation failure to a public error.
 func parseOpenAPIValidationError(ctx context.Context, originalErr error) *errors.HTTPError {
 	if originalErr == nil {
 		return nil
 	}
-	errorCode, errorParams, errorDetails := extractErrorInfo(originalErr, errorTypeValidationFailed)
+	errorCode, errorParams, errorDetails := extractErrorInfo(ctx, originalErr, errorTypeValidationFailed)
 	return errors.NewHTTPError(ctx, http.StatusBadRequest, errorCode, errorDetails, errorParams...)
 }
 
-// extractErrorInfo 提取错误信息，返回错误码、参数和错误详情
-func extractErrorInfo(err error, errorType string) (errors.ErrorCode, []interface{}, interface{}) {
-	// 检查是否是MultiError类型
+// extractErrorInfo returns the stable code, description parameters, and diagnostic details.
+func extractErrorInfo(ctx context.Context, err error, errorType string) (errors.ErrorCode, []interface{}, interface{}) {
+	// Preserve all entries from a MultiError.
 	if multiErr, ok := err.(*openapi3.MultiError); ok {
-		return handleMultiError(multiErr, errorType)
+		return handleMultiError(ctx, multiErr, errorType)
 	}
 
-	// 单个错误处理
+	// Handle a single error directly.
 	return handleSingleError(err, errorType)
 }
 
-// handleMultiError 处理MultiError类型，返回最外层错误码，其他错误在详情中补充
-func handleMultiError(multiErr *openapi3.MultiError, errorType string) (errors.ErrorCode, []interface{}, interface{}) {
+// handleMultiError uses the first entry as the primary code and includes every entry in details.
+func handleMultiError(ctx context.Context, multiErr *openapi3.MultiError, errorType string) (errors.ErrorCode, []interface{}, interface{}) {
 	var (
 		mainErrorCode errors.ErrorCode
 		mainParams    []interface{}
 		errorDetails  []string
 	)
 
-	// 遍历所有子错误
+	tr := localize.NewI18nTranslator(common.GetLanguageFromCtx(ctx))
+
+	// Iterate over every nested error.
 	for i, subErr := range *multiErr {
 		if subErr != nil {
 			subErrorCode, subParams, subErrorDetails := handleSingleError(subErr, errorType)
 
-			// 第一个错误作为主错误码
+			// Use the first error as the primary error code.
 			if i == 0 {
 				mainErrorCode = subErrorCode
 				mainParams = subParams
 			}
 
-			// 所有错误都添加到详情中
-			errorDetails = append(errorDetails, fmt.Sprintf("错误%d: %s", i+1, subErrorDetails))
+			// Include every nested error in the client-visible details.
+			errorDetails = append(errorDetails, fmt.Sprintf(tr.Trans("detail.openapi_error_item"), i+1, subErrorDetails))
 		}
 	}
 
-	// 如果没有找到主错误码，使用默认错误码
+	// Use the default code when the collection has no usable entry.
 	if mainErrorCode == "" {
 		mainErrorCode = getDefaultErrorCode(errorType)
 	}
@@ -86,7 +90,7 @@ func handleMultiError(multiErr *openapi3.MultiError, errorType string) (errors.E
 	return mainErrorCode, mainParams, errorDetails
 }
 
-// getDefaultErrorCode 获取默认错误码
+// getDefaultErrorCode returns the fallback code for a parser stage.
 func getDefaultErrorCode(errorType string) errors.ErrorCode {
 	switch errorType {
 	case errorTypeLoadFailed:
@@ -98,11 +102,11 @@ func getDefaultErrorCode(errorType string) errors.ErrorCode {
 	}
 }
 
-// handleSingleError 处理单个错误
+// handleSingleError maps one parser error to its public representation.
 func handleSingleError(err error, errorType string) (errors.ErrorCode, []interface{}, interface{}) {
 	errStr := err.Error()
 
-	// 根据错误类型获取对应的错误码、参数和详细错误信息
+	// Select a code and parameters while preserving the original diagnostic.
 	var errorCode errors.ErrorCode
 	var errorParams []interface{}
 	errorDetails := errStr
@@ -118,7 +122,7 @@ func handleSingleError(err error, errorType string) (errors.ErrorCode, []interfa
 	return errorCode, errorParams, errorDetails
 }
 
-// extractElement 从错误信息中提取具体元素
+// extractElement extracts an element name from a parser error.
 func extractElement(errStr string, regex *regexp.Regexp) string {
 	matches := regex.FindStringSubmatch(errStr)
 	if len(matches) > 1 {
@@ -127,7 +131,7 @@ func extractElement(errStr string, regex *regexp.Regexp) string {
 	return ""
 }
 
-// getGenericErrorCodeAndParams 获取通用错误码和参数
+// getGenericErrorCodeAndParams maps generic parser errors.
 func getGenericErrorCodeAndParams(errStr string) (errors.ErrorCode, []interface{}) {
 	field := extractElement(errStr, fieldRegex)
 
@@ -147,20 +151,20 @@ func getGenericErrorCodeAndParams(errStr string) (errors.ErrorCode, []interface{
 	return errors.ErrExtOpenAPIInvalidSpecificationOperation, nil
 }
 
-// getValidationErrorCodeAndParams 获取验证阶段的错误码和参数（简化版本）
+// getValidationErrorCodeAndParams maps OpenAPI validation errors.
 func getValidationErrorCodeAndParams(errStr string) (errors.ErrorCode, []interface{}) {
 	if strings.Contains(errStr, "invalid components") {
 		return errors.ErrExtOpenAPIInvalidComponent, nil
 	}
 
-	// 处理 "invalid info" 错误
+	// Handle an invalid info object.
 	if strings.Contains(errStr, "invalid info") {
 		return errors.ErrExtOpenAPIInvalidSpecificationInvalid, []interface{}{"info"}
 	}
 
-	// 处理 "must be an object" 错误
+	// Handle values that must be objects.
 	if strings.Contains(errStr, "must be an object") {
-		// 提取具体的元素名称
+		// Identify the affected element.
 		if strings.Contains(errStr, "info") {
 			return errors.ErrExtOpenAPIInvalidSpecificationInvalid, []interface{}{"info"}
 		}
@@ -171,15 +175,15 @@ func getValidationErrorCodeAndParams(errStr string) (errors.ErrorCode, []interfa
 			return errors.ErrExtOpenAPIInvalidPath, nil
 		}
 
-		// 通用处理
+		// Fall back to the generic required-field error.
 		return errors.ErrExtOpenAPIInvalidSpecificationRequired, nil
 	}
 
-	// 处理 "value of openapi must be a non-empty string" 错误
+	// Handle an empty OpenAPI version.
 	if strings.Contains(errStr, "value of openapi must be a non-empty string") {
 		return errors.ErrExtOpenAPIInvalidSpecificationRequired, []interface{}{"openapi"}
 	}
-	// 1. Schema相关错误（最高优先级）
+	// 1. Schema errors have the highest priority.
 	if strings.Contains(errStr, "schema") {
 		schema := extractElement(errStr, schemaRegex)
 		if schema != "" {
@@ -194,7 +198,7 @@ func getValidationErrorCodeAndParams(errStr string) (errors.ErrorCode, []interfa
 		return errors.ErrExtOpenAPIInvalidSchemaValue, nil
 	}
 
-	// 2. 参数相关错误
+	// 2. Parameter errors.
 	if strings.Contains(errStr, "parameter") {
 		parameter := extractElement(errStr, parameterRegex)
 		if parameter != "" {
@@ -209,7 +213,7 @@ func getValidationErrorCodeAndParams(errStr string) (errors.ErrorCode, []interfa
 		return errors.ErrExtOpenAPIInvalidParameterValue, nil
 	}
 
-	// 3. 响应相关错误
+	// 3. Response errors.
 	if strings.Contains(errStr, "response") {
 		response := extractElement(errStr, responseRegex)
 		if response != "" {
@@ -221,12 +225,12 @@ func getValidationErrorCodeAndParams(errStr string) (errors.ErrorCode, []interfa
 		return errors.ErrExtOpenAPIInvalidResponseSchema, nil
 	}
 
-	// 4. 路径相关错误
+	// 4. Path errors.
 	if strings.Contains(errStr, "path") {
 		return errors.ErrExtOpenAPIInvalidPath, nil
 	}
 
-	// 5. 操作相关错误
+	// 5. Operation errors.
 	if strings.Contains(errStr, "operation") {
 		operation := extractElement(errStr, operationRegex)
 		if operation != "" {
@@ -235,7 +239,7 @@ func getValidationErrorCodeAndParams(errStr string) (errors.ErrorCode, []interfa
 		return errors.ErrExtOpenAPIInvalidSpecificationOperation, nil
 	}
 
-	// 6. 通用验证错误
+	// 6. Generic validation errors.
 	field := extractElement(errStr, fieldRegex)
 	if field != "" {
 		if strings.Contains(errStr, "required") {
@@ -252,6 +256,6 @@ func getValidationErrorCodeAndParams(errStr string) (errors.ErrorCode, []interfa
 		}
 	}
 
-	// 7. 默认错误
+	// 7. Default validation error.
 	return errors.ErrExtOpenAPIInvalidSpecification, nil
 }

--- a/adp/execution-factory/operator-integration/server/logics/parsers/error_parse_i18n_test.go
+++ b/adp/execution-factory/operator-integration/server/logics/parsers/error_parse_i18n_test.go
@@ -1,0 +1,37 @@
+package parsers
+
+import (
+	"context"
+	stderrors "errors"
+	"testing"
+
+	"github.com/getkin/kin-openapi/openapi3"
+	sharedrest "github.com/openbkn-ai/bkn-foundry/comm-go/rest"
+)
+
+func TestOpenAPIMultiErrorDetailsUseRequestLanguage(t *testing.T) {
+	tests := []struct {
+		name     string
+		language string
+		want     string
+	}{
+		{name: "Chinese", language: sharedrest.SimplifiedChinese, want: "错误1：first failure"},
+		{name: "English", language: sharedrest.AmericanEnglish, want: "Error 1: first failure"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			ctx := sharedrest.WithLanguage(context.Background(), test.language)
+			multiErr := openapi3.MultiError{stderrors.New("first failure"), stderrors.New("second failure")}
+
+			httpErr := parseOpenAPILoadError(ctx, &multiErr)
+			details, ok := httpErr.ErrorDetails.([]string)
+			if !ok || len(details) != 2 {
+				t.Fatalf("details = %#v, want two strings", httpErr.ErrorDetails)
+			}
+			if details[0] != test.want {
+				t.Fatalf("details[0] = %q, want %q", details[0], test.want)
+			}
+		})
+	}
+}

--- a/adp/execution-factory/operator-integration/server/logics/parsers/py_func_parser.go
+++ b/adp/execution-factory/operator-integration/server/logics/parsers/py_func_parser.go
@@ -9,11 +9,11 @@ import (
 	"github.com/getkin/kin-openapi/openapi3"
 	"github.com/go-python/gpython/ast"
 	"github.com/go-python/gpython/parser"
-	"github.com/openbkn-ai/bkn-foundry/comm-go/otel/oteltrace"
 	"github.com/openbkn-ai/bkn-foundry/adp/execution-factory/operator-integration/server/infra/errors"
 	"github.com/openbkn-ai/bkn-foundry/adp/execution-factory/operator-integration/server/interfaces"
 	"github.com/openbkn-ai/bkn-foundry/adp/execution-factory/operator-integration/server/interfaces/model"
 	"github.com/openbkn-ai/bkn-foundry/adp/execution-factory/operator-integration/server/utils"
+	"github.com/openbkn-ai/bkn-foundry/comm-go/otel/oteltrace"
 )
 
 const (
@@ -22,13 +22,14 @@ const (
 	handlerFuncName   = "handler"
 )
 
-// 解析不了时的兜底判定。放宽而不是收紧：沙箱跑得动的代码不能被这里挡死。
+// Fallback detection for syntax the bundled parser cannot read. It is deliberately
+// permissive so code supported by the sandbox is not rejected here.
 var (
 	handlerEntryPattern = regexp.MustCompile(`def\s+handler\s*\(`)
 	toolEntryPattern    = regexp.MustCompile(`(?m)^\s*@(?:\w+\.)?tool\b`)
 )
 
-// pythonFunctionParser Python 函数解析器
+// pythonFunctionParser parses Python function metadata.
 type pythonFunctionParser struct {
 	Logger    interfaces.Logger
 	Validator interfaces.Validator
@@ -48,12 +49,12 @@ func (p *pythonFunctionParser) validate(ctx context.Context, inputValue any) (in
 		err = errors.DefaultHTTPError(ctx, http.StatusBadRequest, "input content is empty")
 		return
 	}
-	// Code 校验
+	// Validate the function source.
 	if input.Code == "" {
 		err = errors.DefaultHTTPError(ctx, http.StatusBadRequest, "python function code is empty")
 		return
 	}
-	// 校验参数定义
+	// Validate parameter definitions.
 	err = p.Validator.ValidatorStruct(ctx, input)
 	if err != nil {
 		return
@@ -70,35 +71,34 @@ func (p *pythonFunctionParser) validate(ctx context.Context, inputValue any) (in
 	return
 }
 
-// hasEntryPoint 判断代码是否有入口函数。
+// hasEntryPoint reports whether the source defines a supported entry point.
 //
-// 两种写法：@tool 装饰的普通函数（沙箱 SDK 把 event 解包成形参），或
-// handler(event)（AWS Lambda 风格）。判定必须与沙箱执行期一致 —— 保存时放行、
-// 执行时找不到入口,或者反过来保存时拒掉沙箱支持的写法,两种都是错的。
+// The sandbox accepts either a regular function decorated with @tool (the sandbox SDK
+// expands event into arguments) or an AWS Lambda-style handler(event). Validation must
+// agree with runtime behavior in both directions.
 //
-// 因此和沙箱一样按 AST 判断,并且只认来自 sandbox_sdk 的 tool：tool 也是
-// LangChain 的装饰器名,还可能是用户自己的函数名,只比对名字会误判。
+// AST detection therefore recognizes tool only when imported from sandbox_sdk. Other
+// libraries and user code may use the same name and must not be treated as entry points.
 func hasEntryPoint(code string) bool {
 	mod, err := parser.ParseString(code, "exec")
 	if err != nil {
-		// gpython 只到 Python 3.4 级语法,f-string、async def、PEP 526 注解
-		// （pydantic 模型的类体写法）都解析不了。这些代码在沙箱里跑得好好的,
-		// 判成「没有入口」会把它们挡在保存之外,而且报错原因还是错的。
-		// 解析不了时退回宽松正则。
+		// gpython supports syntax only through Python 3.4, so it cannot parse f-strings,
+		// async functions, or PEP 526 annotations such as Pydantic model fields. These are
+		// valid in the sandbox; fall back to permissive patterns instead of rejecting them.
 		return entryPatternFallback(code)
 	}
 	return moduleHasEntryPoint(mod)
 }
 
-// entryPatternFallback 只看形状不看来源,会把别的库的 @tool 也算成入口。
-// 相比之下漏放行的代价更大 —— 这里放行了,执行期至多报「找不到入口」;
-// 这里拒了,用户根本存不进去。
+// entryPatternFallback checks syntax shape rather than import origin and may accept
+// another library's @tool. A false positive can still be diagnosed by the runtime,
+// whereas a false negative prevents the user from saving otherwise valid code.
 func entryPatternFallback(code string) bool {
 	return handlerEntryPattern.MatchString(code) || toolEntryPattern.MatchString(code)
 }
 
 func moduleHasEntryPoint(mod ast.Ast) bool {
-	// 先收集 sandbox_sdk 绑定的名字
+	// Collect names bound to sandbox_sdk first.
 	sdkToolNames := map[string]bool{}   // from sandbox_sdk import tool [as x]
 	sdkModuleNames := map[string]bool{} // import sandbox_sdk [as x]
 	ast.Walk(mod, func(node ast.Ast) bool {
@@ -153,7 +153,7 @@ func moduleHasEntryPoint(mod ast.Ast) bool {
 	return found
 }
 
-// isSandboxSDKTool 判断一个装饰器表达式是否是 sandbox_sdk 的 tool。
+// isSandboxSDKTool reports whether a decorator expression refers to sandbox_sdk.tool.
 func isSandboxSDKTool(expr ast.Expr, sdkToolNames, sdkModuleNames map[string]bool) bool {
 	switch e := expr.(type) {
 	case *ast.Call:
@@ -161,12 +161,11 @@ func isSandboxSDKTool(expr ast.Expr, sdkToolNames, sdkModuleNames map[string]boo
 		return isSandboxSDKTool(e.Func, sdkToolNames, sdkModuleNames)
 	case *ast.Name:
 		id := string(e.Id)
-		// @tool，且 tool 来自 sandbox_sdk
+		// A bare @tool imported from sandbox_sdk.
 		if sdkToolNames[id] {
 			return true
 		}
-		// gpython 把 @sandbox_sdk.tool 归约成一个 Name（Id 含点），
-		// 不像 CPython 那样给出 Attribute
+		// Unlike CPython, gpython represents @sandbox_sdk.tool as a Name whose ID contains a dot.
 		if base, attr, ok := strings.Cut(id, "."); ok {
 			return attr == toolDecoratorName && sdkModuleNames[base]
 		}
@@ -182,7 +181,7 @@ func isSandboxSDKTool(expr ast.Expr, sdkToolNames, sdkModuleNames map[string]boo
 	return false
 }
 
-// 检查是否包含入口函数
+// checkRegexpHandler validates that the source has a supported entry point.
 func checkRegexpHandler(ctx context.Context, code string) (err error) {
 	if hasEntryPoint(code) {
 		return nil
@@ -192,13 +191,13 @@ func checkRegexpHandler(ctx context.Context, code string) (err error) {
 }
 
 // func checAstkHandler(ctx context.Context, code string) (err error) {
-// 	// 解析Python代码
+// 	// Parse the Python source.
 // 	mod, err := parser.ParseString(code, py.ExecMode)
 // 	if err != nil {
 // 		err = errors.DefaultHTTPError(ctx, http.StatusBadRequest, fmt.Sprintf("parse python code failed: %v", err))
 // 		return
 // 	}
-// 	// 检查是否包含入口函数handler
+// 	// Check for a handler entry point.
 // 	var hasHandler bool
 // 	ast.Walk(mod, func(node ast.Ast) bool {
 // 		n, ok := node.(*ast.FunctionDef)
@@ -213,9 +212,9 @@ func checkRegexpHandler(ctx context.Context, code string) (err error) {
 // 	return
 // }
 
-// Parse 解析 Python 函数
+// Parse converts Python function input into persisted metadata.
 func (p *pythonFunctionParser) Parse(ctx context.Context, inputValue any) (metadatas []interfaces.IMetadataDB, err error) {
-	// 记录可观测性
+	// Record the operation span.
 	ctx, _ = oteltrace.StartInternalSpan(ctx)
 	defer oteltrace.EndSpan(ctx, err)
 	input, err := p.validate(ctx, inputValue)
@@ -248,15 +247,15 @@ func (p *pythonFunctionParser) Parse(ctx context.Context, inputValue any) (metad
 	return
 }
 
-// GetAllContent 获取所有内容
+// GetAllContent returns the complete generated API contract.
 func (p *pythonFunctionParser) GetAllContent(ctx context.Context, inputValue any) (content any, err error) {
 	input, err := p.validate(ctx, inputValue)
 	if err != nil {
 		return nil, err
 	}
-	// 与保存路径用同一套入口判定,含解析失败时的兜底。
-	// 不在这里因为 gpython 解析不了就报语法错 —— 它只到 Python 3.4,
-	// f-string 之类沙箱跑得动的代码会被误判。真正的语法错由沙箱执行时报出。
+	// Use the same entry-point detection as the persistence path, including its parser
+	// fallback. Syntax supported by the sandbox but not gpython must not be rejected here;
+	// the sandbox remains responsible for reporting actual syntax errors.
 	if err = checkRegexpHandler(ctx, input.Code); err != nil {
 		return
 	}
@@ -264,7 +263,7 @@ func (p *pythonFunctionParser) GetAllContent(ctx context.Context, inputValue any
 	return
 }
 
-// 将input\output转换成 PathItemContent
+// convertToPathItemContent converts function inputs and outputs into an API contract.
 func convertToPathItemContent(input *interfaces.FunctionInput) (result *interfaces.PathItemContent) {
 	result = &interfaces.PathItemContent{
 		Path:        interfaces.GetAOIFuncExecPath(),
@@ -274,150 +273,149 @@ func convertToPathItemContent(input *interfaces.FunctionInput) (result *interfac
 		Description: input.Description,
 		APISpec:     &interfaces.APISpec{},
 	}
-	// 添加超时时间参数
+	// Add infrastructure parameters declared by the public contract.
 	result.APISpec.Parameters = createParameter()
-	// 根据处理输入参数创建请求体
+	// Build the request body from the declared inputs.
 	result.APISpec.RequestBody = createRequestBody(input.Inputs)
-	// 处理输出参数
+	// Build responses from the declared outputs.
 	result.APISpec.Responses = createResponseBody(input.Outputs)
 	return
 }
 
-// 构造Parameter参数
+// createParameter returns infrastructure parameters exposed in the API contract.
 //
-// api_spec 只描述用户声明的契约。执行超时是沙箱的基础设施开关,曾经作为
-// query 参数写进这里,结果 Agent 把它当成一个可选业务入参去推断,按 schema
-// 渲染参数表的界面也会把它和真实入参并列展示,还要用户为它选固定值或动态输入。
+// api_spec describes only the user-declared contract. Execution timeout is a sandbox
+// infrastructure option. Exposing it as a query parameter caused agents and schema-driven
+// UIs to treat it as an optional business input.
 //
-// 执行侧仍然接受 query 里的 timeout（见 FunctionExecuteProxyReq），
-// 只是不再宣告成工具契约的一部分。
+// The execution endpoint still accepts timeout in the query string (see
+// FunctionExecuteProxyReq), but it is no longer advertised as part of the tool contract.
 func createParameter() []*interfaces.Parameter {
 	return make([]*interfaces.Parameter, 0)
 }
 
-// 构造请求体结构
+// createRequestBody builds the request-body schema.
 func createRequestBody(inputs []*interfaces.ParameterDef) *interfaces.RequestBody {
-	// 创建schema定义
+	// Build the object schema.
 	requestBodySchema := openapi3.NewObjectSchema()
 	if len(inputs) > 0 {
 		for _, input := range inputs {
 			propertySchema := createParameterSchema(input)
 			requestBodySchema.Properties[input.Name] = openapi3.NewSchemaRef("", propertySchema)
-			// 设置必填字段
+			// Record required fields.
 			if input.Required {
 				requestBodySchema.Required = append(requestBodySchema.Required, input.Name)
 			}
 		}
 	}
-	// 创建请求体
+	// Build the request body.
 	requestBody := &interfaces.RequestBody{
-		Description: "函数输入参数",
+		Description: "Function input parameters",
 		Content:     openapi3.NewContentWithJSONSchema(requestBodySchema),
 		Required:    true,
 	}
 	return requestBody
 }
 
-// 处理输出参数
-// 根据处理输出参数创建响应体
+// createResponseBody builds response schemas from the declared outputs.
 func createResponseBody(outputs []*interfaces.ParameterDef) []*interfaces.Response {
-	// 创建schema定义
+	// Build the successful response schema.
 	responseSchema := openapi3.NewObjectSchema()
 	responseSchema.Properties["stdout"] = openapi3.NewSchemaRef("", &openapi3.Schema{
 		Type:        &openapi3.Types{openapi3.TypeString},
-		Description: "标准输出流内容",
+		Description: "Standard output stream content",
 	})
 	responseSchema.Properties["stderr"] = openapi3.NewSchemaRef("", &openapi3.Schema{
 		Type:        &openapi3.Types{openapi3.TypeString},
-		Description: "标准错误流内容",
+		Description: "Standard error stream content",
 	})
 
 	resultSchema := &openapi3.Schema{
 		Type:        &openapi3.Types{openapi3.TypeObject},
-		Description: "Handler 函数返回的业务结果: any or null",
+		Description: "Business result returned by the handler: any value or null",
 		Properties:  make(openapi3.Schemas),
 	}
 	for _, output := range outputs {
 		propertySchema := createParameterSchema(output)
 		resultSchema.Properties[output.Name] = openapi3.NewSchemaRef("", propertySchema)
-		// 设置必填字段
+		// Record required fields.
 		if output.Required {
 			resultSchema.Required = append(resultSchema.Required, output.Name)
 		}
 	}
 	responseSchema.Properties["result"] = openapi3.NewSchemaRef("", resultSchema)
-	// 添加指标
+	// Add execution metrics.
 	metricsSchema := &openapi3.Schema{
 		Type:        &openapi3.Types{openapi3.TypeObject},
-		Description: "指标",
+		Description: "Execution metrics",
 		Properties:  make(openapi3.Schemas),
 	}
 	metricsSchema.Properties["duration_ms"] = openapi3.NewSchemaRef("", &openapi3.Schema{
 		Type:        &openapi3.Types{openapi3.TypeNumber},
-		Description: "执行总耗时（毫秒）",
+		Description: "Total execution duration (milliseconds)",
 	})
 	metricsSchema.Properties["memory_peak_mb"] = openapi3.NewSchemaRef("", &openapi3.Schema{
 		Type:        &openapi3.Types{openapi3.TypeNumber},
-		Description: "峰值内存占用（MB）",
+		Description: "Peak memory usage (MB)",
 	})
 	metricsSchema.Properties["cpu_time_ms"] = openapi3.NewSchemaRef("", &openapi3.Schema{
 		Type:        &openapi3.Types{openapi3.TypeNumber},
-		Description: "CPU 时间（毫秒）",
+		Description: "CPU time (milliseconds)",
 	})
 	responseSchema.Properties["metrics"] = openapi3.NewSchemaRef("", metricsSchema)
-	// 添加错误响应体
+	// Add the error response schema.
 	errSchema := &openapi3.Schema{
 		Type:        &openapi3.Types{openapi3.TypeObject},
-		Description: "失败详情",
+		Description: "Failure details",
 		Properties:  map[string]*openapi3.SchemaRef{},
 	}
 	errSchema.Properties["code"] = openapi3.NewSchemaRef("", &openapi3.Schema{
 		Type:        &openapi3.Types{openapi3.TypeString},
-		Description: "错误码",
+		Description: "Error code",
 	})
 	errSchema.Properties["description"] = openapi3.NewSchemaRef("", &openapi3.Schema{
 		Type:        &openapi3.Types{openapi3.TypeString},
-		Description: "错误描述",
+		Description: "Error description",
 	})
 	errSchema.Properties["detail"] = openapi3.NewSchemaRef("", &openapi3.Schema{
 		Type:        &openapi3.Types{openapi3.TypeObject},
-		Description: "错误详情",
+		Description: "Error details",
 	})
 	errSchema.Properties["solution"] = openapi3.NewSchemaRef("", &openapi3.Schema{
 		Type:        &openapi3.Types{openapi3.TypeString},
-		Description: "错误解决办法",
+		Description: "Error solution",
 	})
 	errSchema.Properties["link"] = openapi3.NewSchemaRef("", &openapi3.Schema{
 		Type:        &openapi3.Types{openapi3.TypeString},
-		Description: "错误链接",
+		Description: "Error link",
 	})
-	// 创建响应体
+	// Build the response list.
 	responseBody := []*interfaces.Response{
 		{
 			StatusCode:  "200",
-			Description: "成功",
+			Description: "Success",
 			Content:     openapi3.NewContentWithJSONSchema(responseSchema),
 		},
 		{
 			StatusCode:  "400",
-			Description: "参数校验失败",
+			Description: "Parameter validation failed",
 			Content:     openapi3.NewContentWithJSONSchema(errSchema),
 		},
 		{
 			StatusCode:  "404",
-			Description: "资源不存在",
+			Description: "Resource not found",
 			Content:     openapi3.NewContentWithJSONSchema(errSchema),
 		},
 		{
 			StatusCode:  "500",
-			Description: "函数执行失败",
+			Description: "Function execution failed",
 			Content:     openapi3.NewContentWithJSONSchema(errSchema),
 		},
 	}
 	return responseBody
 }
 
-// mapTypeToOpenAPI 将参数类型映射到OpenAPI类型
+// mapTypeToOpenAPI maps a function parameter type to an OpenAPI type.
 func mapTypeToOpenAPI(paramType string) *openapi3.Types {
 	switch strings.ToLower(paramType) {
 	case "string":
@@ -446,35 +444,35 @@ func createParameterSchema(param *interfaces.ParameterDef) *openapi3.Schema {
 		Description: param.Description,
 	}
 
-	// 设置默认值
+	// Preserve the default value.
 	if param.Default != nil {
 		propertySchema.Default = param.Default
 	}
-	// 设置枚举值
+	// Preserve enum values.
 	if len(param.Enum) > 0 {
 		propertySchema.Enum = param.Enum
 	}
-	// 设置示例值
+	// Preserve the example value.
 	if param.Example != nil {
 		propertySchema.Example = param.Example
 	}
-	// 处理嵌套参数
+	// Convert nested parameters.
 	if len(param.SubParameters) > 0 {
 		switch param.Type {
 		case interfaces.ParameterTypeObject:
-			// Object类型：SubParameters定义对象的属性
+			// Object sub-parameters define object properties.
 			propertySchema.Properties = make(openapi3.Schemas)
 			for _, subParam := range param.SubParameters {
 				subPropertySchema := createParameterSchema(subParam)
 				propertySchema.Properties[subParam.Name] = openapi3.NewSchemaRef("", subPropertySchema)
-				// 子对象的必填字段需要添加到父对象的Required数组中
+				// Required child fields belong to the parent object's required list.
 				if subParam.Required {
 					propertySchema.Required = append(propertySchema.Required, subParam.Name)
 				}
 			}
 
 		case interfaces.ParameterTypeArray:
-			// Array类型：SubParameters只包含一个元素，定义数组元素的结构
+			// An array has one sub-parameter that defines its item schema.
 			subParam := param.SubParameters[0]
 			if subParam.Description == "" {
 				subParam.Description = param.Description

--- a/adp/execution-factory/operator-integration/server/logics/parsers/py_func_parser_test.go
+++ b/adp/execution-factory/operator-integration/server/logics/parsers/py_func_parser_test.go
@@ -77,6 +77,23 @@ func TestFunctionToOpenAPISchema(t *testing.T) {
 	})
 }
 
+func TestGeneratedFunctionSchemaUsesEnglishServiceDescriptions(t *testing.T) {
+	schema := convertToPathItemContent(&interfaces.FunctionInput{})
+	if got := schema.APISpec.RequestBody.Description; got != "Function input parameters" {
+		t.Fatalf("request body description = %q", got)
+	}
+	if got := schema.APISpec.Responses[0].Description; got != "Success" {
+		t.Fatalf("success response description = %q", got)
+	}
+	responseSchema := schema.APISpec.Responses[0].Content["application/json"].Schema.Value
+	if got := responseSchema.Properties["stdout"].Value.Description; got != "Standard output stream content" {
+		t.Fatalf("stdout description = %q", got)
+	}
+	if got := responseSchema.Properties["metrics"].Value.Description; got != "Execution metrics" {
+		t.Fatalf("metrics description = %q", got)
+	}
+}
+
 func TestCheckHandler(t *testing.T) {
 	Convey("TestCheckHandler: 检查是否包含入口函数handler", t, func() {
 		code := `def handler(event):


### PR DESCRIPTION
# Pull Request

## What Changed

- [x] Migrate Capabilities Lab error descriptions and OpenAPI multi-error details to the zh-Hans/en-US catalogs while preserving stable error codes.
- [x] Select localized AI prompt metadata and embedded system prompts from the request locale while preserving user-configured custom prompts.
- [x] Standardize service-owned MCP/API schema descriptions and internal conversion errors in English.
- [x] Fix the default SSE error path to send the localized HTTP error and set Content-Language for locally localized responses.
- [x] Add focused zh/en regression tests and catalog validation coverage.

---

## Why

- Related Issue: [Issue #919](https://github.com/openbkn-ai/bkn-foundry/issues/919)
- Related Feature: Execution Factory internationalization
- Background: Execution Factory still contained hard-coded client-facing Chinese text across API, MCP, SSE, and AI prompt paths. These responses need stable codes and locale-aware descriptions without changing business data or logging behavior.

Closes #919

---

## How

- Key implementation points:
  - Resolve client-facing descriptions through the module locale catalog using the request language.
  - Clone shared prompt templates per request before applying localized metadata to avoid singleton mutation and request races.
  - Load English embedded system prompts for English requests and retain the existing Chinese templates for Chinese requests.
  - Preserve user-configured prompts, machine fields, stable error codes, and upstream error responses.
  - Set Content-Language only when this service creates the localized response.
- Breaking changes (API, config, database, etc.): None. Stable error codes, field names, and request/response shapes are unchanged.

---

## Testing

- [x] Unit tests passed locally
- [ ] Integration tests passed locally - no dedicated integration environment was used.
- [ ] Verified in test environment - not applicable for this local change.

Test notes:

- Targeted package tests passed for AI generation, driver adapters, Capabilities Lab handlers, parsers, MCP conversion, and REST replies.
- Full serial Go package suite passed with the repository exclusions for server/tests and server/mocks.
- `go vet ./...` passed.
- `python3 tools/check_i18n_catalogs.py` passed.
- `python3 -m unittest tools/test_check_i18n_catalogs.py` passed (5 tests).
- `git diff --check` passed.
- `golangci-lint` was not available in the local environment.

---

## Risk & Rollback

- Potential risks: Prompt wording now varies by Accept-Language, and locally generated SSE error descriptions now carry the selected locale. Regression tests cover Chinese and English selection, stable codes, and template immutability.
- Rollback plan: Revert commit `5f780ab3`.

---

## Additional Notes

- Log and trace related text was intentionally excluded.
- Business data, existing fixtures, and user-provided custom prompts were not mechanically translated.
- No comm-go changes were made.