### PR TITLE
fix(agent-observability): stream archive downloads

### DIFF
--- a/bkn-trace/agent-observability/src/domain/service/archivesvc/service.go
+++ b/bkn-trace/agent-observability/src/domain/service/archivesvc/service.go
@@ -5,8 +5,10 @@ package archivesvc
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"sort"
 	"sync"
 	"time"
@@ -49,8 +51,13 @@ type ObjectStore interface {
 	WriteAndVerify(context.Context, Job, []Candidate) (string, error)
 }
 
-type DownloadStore interface {
-	DownloadURL(context.Context, string) (string, error)
+type ReadStore interface {
+	Read(context.Context, string) (io.ReadCloser, error)
+}
+
+type Download struct {
+	Content io.ReadCloser
+	Kind    observabilityvo.ArchiveKind
 }
 
 type Store interface {
@@ -186,16 +193,33 @@ func (service *Service) Get(jobID, tenantID string) (Job, bool) {
 	return job, ok && job.TenantID == tenantID
 }
 
-func (service *Service) DownloadURL(ctx context.Context, jobID, tenantID string) (string, error) {
+// OpenDownload returns the verified archive data through the application
+// boundary.  The browser must never receive an internal object-store URL.
+func (service *Service) OpenDownload(ctx context.Context, jobID, tenantID string) (Download, error) {
 	job, ok := service.Get(jobID, tenantID)
 	if !ok || job.ManifestRef == "" {
-		return "", fmt.Errorf("archive download is unavailable")
+		return Download{}, fmt.Errorf("archive download is unavailable")
 	}
-	store, ok := service.objectStore.(DownloadStore)
+	store, ok := service.objectStore.(ReadStore)
 	if !ok {
-		return "", fmt.Errorf("archive download is unavailable")
+		return Download{}, fmt.Errorf("archive download is unavailable")
 	}
-	return store.DownloadURL(ctx, job.ManifestRef)
+	manifest, err := store.Read(ctx, job.ManifestRef)
+	if err != nil {
+		return Download{}, fmt.Errorf("read archive manifest: %w", err)
+	}
+	defer func() { _ = manifest.Close() }()
+	var record struct {
+		DataKey string `json:"data_key"`
+	}
+	if err := json.NewDecoder(manifest).Decode(&record); err != nil || record.DataKey == "" {
+		return Download{}, fmt.Errorf("archive manifest is invalid")
+	}
+	content, err := store.Read(ctx, record.DataKey)
+	if err != nil {
+		return Download{}, fmt.Errorf("read archive data: %w", err)
+	}
+	return Download{Content: content, Kind: job.Kind}, nil
 }
 
 // List returns the newest jobs for one archive kind.  The archive kinds stay

--- a/bkn-trace/agent-observability/src/domain/service/archivesvc/service_test.go
+++ b/bkn-trace/agent-observability/src/domain/service/archivesvc/service_test.go
@@ -1,8 +1,10 @@
 package archivesvc
 
 import (
+	"bytes"
 	"context"
 	"errors"
+	"io"
 	"testing"
 	"time"
 
@@ -95,6 +97,32 @@ func TestCompletedArchiveDoesNotRetainRetryPayload(t *testing.T) {
 	}
 }
 
+func TestOpenDownloadReadsTheArchivedDataBundleInsteadOfReturningStorageURL(t *testing.T) {
+	store := NewMemoryStore()
+	job := Job{ID: "arc_log_1", TenantID: "tenant-a", Kind: observabilityvo.ArchiveKindLog, Status: observabilityvo.ArchiveStatusCompleted, ManifestRef: "archive/manifest.json"}
+	if err := store.Create(job); err != nil {
+		t.Fatalf("create job: %v", err)
+	}
+	objectStore := &fakeDownloadObjectStore{objects: map[string][]byte{
+		"archive/manifest.json": []byte(`{"data_key":"archive/data.jsonl"}`),
+		"archive/data.jsonl":    []byte("{\\\"id\\\":\\\"log-1\\\"}\\n"),
+	}}
+	service := New(store, &fakeSource{}, objectStore, Options{})
+
+	download, err := service.OpenDownload(context.Background(), job.ID, "tenant-a")
+	if err != nil {
+		t.Fatalf("open archive download: %v", err)
+	}
+	defer func() { _ = download.Content.Close() }()
+	content, err := io.ReadAll(download.Content)
+	if err != nil {
+		t.Fatalf("read archive content: %v", err)
+	}
+	if string(content) != "{\\\"id\\\":\\\"log-1\\\"}\\n" {
+		t.Fatalf("downloaded content = %q", content)
+	}
+}
+
 type fakeSource struct {
 	candidates []Candidate
 	purged     map[string]bool
@@ -117,6 +145,19 @@ func (source *fakeSource) Purge(_ context.Context, _ observabilityvo.ArchiveKind
 type fakeObjectStore struct {
 	verified  bool
 	verifyErr error
+}
+
+type fakeDownloadObjectStore struct {
+	fakeObjectStore
+	objects map[string][]byte
+}
+
+func (store *fakeDownloadObjectStore) Read(_ context.Context, key string) (io.ReadCloser, error) {
+	content, ok := store.objects[key]
+	if !ok {
+		return nil, errors.New("archive object not found")
+	}
+	return io.NopCloser(bytes.NewReader(content)), nil
 }
 
 func (store *fakeObjectStore) WriteAndVerify(_ context.Context, _ Job, _ []Candidate) (string, error) {

--- a/bkn-trace/agent-observability/src/drivenadapter/httpaccess/ossgatewayarchive/client.go
+++ b/bkn-trace/agent-observability/src/drivenadapter/httpaccess/ossgatewayarchive/client.go
@@ -102,6 +102,14 @@ func (client *Client) upload(ctx context.Context, key string, content []byte) er
 	return client.signed(ctx, method, signedURL, headers, content)
 }
 func (client *Client) download(ctx context.Context, key string) ([]byte, error) {
+	content, err := client.Read(ctx, key)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = content.Close() }()
+	return io.ReadAll(content)
+}
+func (client *Client) Read(ctx context.Context, key string) (io.ReadCloser, error) {
 	method, signedURL, headers, err := client.authorize(ctx, "download", key, http.MethodGet)
 	if err != nil {
 		return nil, err
@@ -117,15 +125,11 @@ func (client *Client) download(ctx context.Context, key string) ([]byte, error) 
 	if err != nil {
 		return nil, err
 	}
-	defer func() { _ = response.Body.Close() }()
 	if response.StatusCode < 200 || response.StatusCode >= 300 {
+		_ = response.Body.Close()
 		return nil, fmt.Errorf("read archive bundle: %s", response.Status)
 	}
-	return io.ReadAll(response.Body)
-}
-func (client *Client) DownloadURL(ctx context.Context, key string) (string, error) {
-	_, signedURL, _, err := client.authorize(ctx, "download", key, http.MethodGet)
-	return signedURL, err
+	return response.Body, nil
 }
 func (client *Client) authorize(ctx context.Context, operation, key, method string) (string, string, map[string]string, error) {
 	storageID, err := client.storageID(ctx)

--- a/bkn-trace/agent-observability/src/drivenadapter/httpaccess/ossgatewayarchive/client.go
+++ b/bkn-trace/agent-observability/src/drivenadapter/httpaccess/ossgatewayarchive/client.go
@@ -24,6 +24,7 @@ type Config struct {
 type Client struct {
 	config            Config
 	http              *http.Client
+	stream            *http.Client
 	mu                sync.Mutex
 	resolvedStorageID string
 }
@@ -38,7 +39,16 @@ func New(config Config) *Client {
 	if config.BaseURL == "" {
 		config.BaseURL = "http://oss-gateway-backend:8080/api/v1"
 	}
-	return &Client{config: config, http: &http.Client{Timeout: config.Timeout}}
+	streamTransport := http.DefaultTransport.(*http.Transport).Clone()
+	streamTransport.ResponseHeaderTimeout = config.Timeout
+	return &Client{
+		config: config,
+		http:   &http.Client{Timeout: config.Timeout},
+		// Archive bodies can legitimately take longer than the bounded
+		// control-plane calls. Response headers stay bounded while the request
+		// context remains the cancellation boundary once streaming starts.
+		stream: &http.Client{Transport: streamTransport},
+	}
 }
 func (client *Client) Ready() bool {
 	return strings.TrimSpace(client.config.BaseURL) != ""
@@ -121,7 +131,7 @@ func (client *Client) Read(ctx context.Context, key string) (io.ReadCloser, erro
 	for k, v := range headers {
 		req.Header.Set(k, v)
 	}
-	response, err := client.http.Do(req)
+	response, err := client.stream.Do(req)
 	if err != nil {
 		return nil, err
 	}

--- a/bkn-trace/agent-observability/src/drivenadapter/httpaccess/ossgatewayarchive/client_test.go
+++ b/bkn-trace/agent-observability/src/drivenadapter/httpaccess/ossgatewayarchive/client_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"strings"
 	"testing"
+	"time"
 )
 
 type roundTripper func(*http.Request) (*http.Response, error)
@@ -31,3 +32,46 @@ func TestAvailabilityResolvesEnabledDefaultStorage(t *testing.T) {
 		t.Fatalf("storage id = %q", client.resolvedStorageID)
 	}
 }
+
+func TestReadDoesNotApplyControlPlaneTimeoutToArchiveBody(t *testing.T) {
+	client := New(Config{BaseURL: "http://gateway/api/v1", StorageID: "archive", Timeout: time.Millisecond})
+	client.http.Transport = roundTripper(func(request *http.Request) (*http.Response, error) {
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Body:       io.NopCloser(strings.NewReader(`{"data":{"method":"GET","url":"http://object-store/archive.jsonl"}}`)),
+			Header:     make(http.Header),
+		}, nil
+	})
+	client.stream.Transport = roundTripper(func(request *http.Request) (*http.Response, error) {
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Body:       &delayedReadCloser{delay: 10 * time.Millisecond, content: strings.NewReader("archive\n")},
+			Header:     make(http.Header),
+		}, nil
+	})
+
+	body, err := client.Read(context.Background(), "archive.jsonl")
+	if err != nil {
+		t.Fatalf("read archive: %v", err)
+	}
+	defer func() { _ = body.Close() }()
+	content, err := io.ReadAll(body)
+	if err != nil {
+		t.Fatalf("read archive body: %v", err)
+	}
+	if string(content) != "archive\n" {
+		t.Fatalf("archive body = %q", content)
+	}
+}
+
+type delayedReadCloser struct {
+	delay   time.Duration
+	content io.Reader
+}
+
+func (body *delayedReadCloser) Read(target []byte) (int, error) {
+	time.Sleep(body.delay)
+	return body.content.Read(target)
+}
+
+func (*delayedReadCloser) Close() error { return nil }

--- a/bkn-trace/agent-observability/src/driveradapter/api/httphandler/archive_handler.go
+++ b/bkn-trace/agent-observability/src/driveradapter/api/httphandler/archive_handler.go
@@ -3,6 +3,8 @@ package httphandler
 import (
 	"encoding/json"
 	"errors"
+	"fmt"
+	"io"
 	"net/http"
 	"strings"
 
@@ -100,14 +102,15 @@ func (handler *ArchiveHandler) GetOrRetry(w http.ResponseWriter, r *http.Request
 	if len(parts) == 2 && parts[1] == "retry-cleanup" {
 		method = http.MethodPost
 	}
-	if len(parts) == 2 && parts[1] == "download-url" {
-		method = http.MethodPost
-	}
 	profile, ok := handler.authorize(w, r, method)
 	if !ok {
 		return
 	}
 	if method == http.MethodGet {
+		if len(parts) == 2 && parts[1] == "download" {
+			handler.download(w, r, parts[0], profile.TenantID)
+			return
+		}
 		job, found := handler.service.Get(parts[0], profile.TenantID)
 		if !found {
 			writeObservabilityError(w, r, http.StatusNotFound, "archive_job_not_found", "archive job was not found")
@@ -116,21 +119,26 @@ func (handler *ArchiveHandler) GetOrRetry(w http.ResponseWriter, r *http.Request
 		writeJSON(w, http.StatusOK, rdto.NewArchiveJob(job))
 		return
 	}
-	if len(parts) == 2 && parts[1] == "download-url" {
-		url, err := handler.service.DownloadURL(r.Context(), parts[0], profile.TenantID)
-		if err != nil {
-			writeObservabilityError(w, r, http.StatusBadRequest, "archive_download_unavailable", "archive download is unavailable")
-			return
-		}
-		writeJSON(w, http.StatusOK, map[string]string{"download_url": url})
-		return
-	}
 	job, err := handler.service.RetryCleanup(r.Context(), parts[0], profile.TenantID)
 	if err != nil {
 		writeObservabilityError(w, r, http.StatusBadRequest, "archive_retry_failed", "archive cleanup cannot be retried")
 		return
 	}
 	writeJSON(w, http.StatusOK, rdto.NewArchiveJob(job))
+}
+
+func (handler *ArchiveHandler) download(w http.ResponseWriter, r *http.Request, jobID, tenantID string) {
+	download, err := handler.service.OpenDownload(r.Context(), jobID, tenantID)
+	if err != nil {
+		writeObservabilityError(w, r, http.StatusBadRequest, "archive_download_unavailable", "archive download is unavailable")
+		return
+	}
+	defer func() { _ = download.Content.Close() }()
+	w.Header().Set("Content-Type", "application/x-ndjson; charset=utf-8")
+	w.Header().Set("Content-Disposition", fmt.Sprintf("attachment; filename=archive-%s-%s.jsonl", download.Kind, jobID))
+	if _, err := io.Copy(w, download.Content); err != nil {
+		return
+	}
 }
 func (handler *ArchiveHandler) authorize(w http.ResponseWriter, r *http.Request, method string) (profile evidencevo.AccessProfile, ok bool) {
 	if r.Method != method {


### PR DESCRIPTION
## What Changed

- [x] Replace object-store signed URL handoff with server-side archive bundle reads.
- [x] Add a same-origin archive download route that streams JSONL with an attachment filename.
- [x] Add regression coverage for archived data-bundle reads.

---

## Why

- Related Feature: [BKN Trace 0.1.4 Epic](https://github.com/openbkn-ai/bkn-foundry/issues/747)
- Background: browsers cannot reach `minio.openbkn.svc.cluster.local`; the Studio must never receive that internal endpoint.

---

## How

- Resolve an archive manifest server-side, read its `data_key`, and stream the JSONL payload.
- Preserve the existing archive record and cleanup semantics.
- Breaking changes: removes the internal signed-URL response path in favor of `GET /archive-jobs/{id}/download`.

---

## Testing

- [x] `go test ./src/domain/service/archivesvc ./src/drivenadapter/httpaccess/ossgatewayarchive -count=1`
- [x] `go test ./src/driveradapter/api/httphandler -count=1`
- [x] Local Kind Enterprise observability image loaded and Studio now uses the same-origin route.

Test notes:

- Only the four archive-download files are included; unrelated local OpenSearch/route diagnostics remain unstaged.

---

## Risk & Rollback

- Potential risks: archive content is now proxied through agent-observability instead of downloaded directly from the object store.
- Rollback plan: revert this PR; no archive format or database migration is involved.

---

## Additional Notes

- The change does not touch Business Provenance Enterprise routing, capability checks, or Community behavior.