### PR TITLE
refactor(mf-model-api): localize client-facing text

### DIFF
--- a/infra/mf-model-api/app/commons/errors/__init__.py
+++ b/infra/mf-model-api/app/commons/errors/__init__.py
@@ -1260,7 +1260,7 @@ ModelFactory_DefaultSmallModel_NotExist = {
 }
 
 ModelFactory_DedaultModel_NotExist = {
-    "code": "ModelFactory.ExternalSmallModel.Used.NameNotExist",
+    "code": "ModelFactory.LLM.DefaultNotExist",
     "description": "Default large model is not configured.",
     "detail": "An administrator has not configured a default large model.",
     "solution": "Ask an administrator to configure a default large model.",

--- a/infra/mf-model-api/app/commons/errors/__init__.py
+++ b/infra/mf-model-api/app/commons/errors/__init__.py
@@ -1,10 +1,10 @@
-# 完整的报错信息,例子
+# Legacy error envelopes. Client-facing localization is applied by locale middleware.
 
 DataBaseError = {
     'code': 'ModelFactory.Mydb.DataBase.ParameterError',
-    'description': '数据库错误',
-    'detail': '数据库无法连接',
-    'solution': '请检查数据库及登录信息',
+    'description': 'Database access failed.',
+    'detail': 'Model Factory cannot access the database right now.',
+    'solution': 'Retry later or contact an administrator.',
     'link': ''}
 LLMSourceError = {
     'code': 'ModelFactory.ConnectController.LLMSource.ParameterError',
@@ -20,9 +20,9 @@ LLMUsedError = {
     'link': ''}
 LLMParamError = {
     'code': 'ModelFactory.ConnectController.LLMUsed.ParameterError',
-    'description': '配置错误',
-    'detail': '当前模型配置信息错误，无法连接',
-    'solution': '请检查大模型的配置信息',
+    'description': 'Model configuration is invalid.',
+    'detail': 'The current model configuration cannot complete the request.',
+    'solution': 'Check the large model configuration.',
     'link': ''}
 LLMRemoveError = {
     'code': 'ModelFactory.ConnectController.LLMRemove.ParameterError',
@@ -82,9 +82,9 @@ LLMCheckError = {
     'link': ''}
 LLMTestError = {
     'code': 'ModelFactory.ConnectController.LLMTest.ParameterError',
-    'description': '参数错误',
-    'detail': '该模型不存在',
-    'solution': '请检查输入信息',
+    'description': 'Model connection test failed.',
+    'detail': 'The current configuration could not connect to the large model service.',
+    'solution': 'Check the large model configuration and service availability.',
     'link': ''}
 PromptItemSourceError = {
     'code': 'ModelFactory.PromptController.PromptItemSource.ParameterError',
@@ -293,9 +293,9 @@ PromptDefaultLLMError = {
 
 ModelError = {
     'code': 'ModelFactory.LLM.Error',
-    'description': '查询或前缀提示符太长，',
-    'detail': '模型配置信息中的 max_tokens 数值过大',
-    'solution': '可以减少前缀提示符，或缩小最大令牌，或切换到具有更大令牌限制大小的模型。',
+    'description': 'Model context limit exceeded.',
+    'detail': 'The request content and maximum output tokens exceed the model context limit.',
+    'solution': 'Shorten the request, reduce maximum output tokens, or select a model with a larger context.',
     'link': ''
 }
 BatchAddPromptError = {
@@ -307,9 +307,9 @@ BatchAddPromptError = {
 }
 ModelTimeoutError = {
     'code': 'ModelFactory.LLM.ModelTimeoutError',
-    'description': '模型请求超时，请重试',
-    'detail': '模型请求超时，请重试',
-    'solution': '模型请求超时，请重试',
+    'description': 'Model request timed out.',
+    'detail': 'The model service did not complete the request in time.',
+    'solution': 'Try again later.',
     'link': ''
 }
 ModelFactory_BenchmarkController_AddBenchmarkConfig_RepeatedNames_Error = {
@@ -328,30 +328,30 @@ ModelFactory_BenchmarkController_AddBenchmarkConfig_UnknownError_Error = {
 }
 ModelFactory_MyPymysqlPool_Connection_ConnectError_Error = {
     "code": "ModelFactory.MyPymysqlPool.Connection.ConnectError",
-    "description": "数据库连接错误",
-    "detail": "数据库连接错误",
-    "solution": "请联系开发人员",
+    "description": "Database connection failed.",
+    "detail": "Model Factory cannot connect to the database right now.",
+    "solution": "Retry later or contact an administrator.",
     "link": ""
 }
 ModelFactory_Router_ParamError_ParamMissing_Error = {
     "code": "ModelFactory.Router.ParamError.ParamMissing",
-    "description": "参数缺失",
-    "detail": "参数缺失",
-    "solution": "请检查填写的参数是否正确。",
+    "description": "Required parameter is missing.",
+    "detail": "A required parameter is missing.",
+    "solution": "Provide the required parameter and try again.",
     "link": ""
 }
 ModelFactory_Router_ParamError_FormatError_Error = {
     "code": "ModelFactory.Router.ParamError.FormatError",
-    "description": "由于参数格式错误，修改失败",
-    "detail": "由于参数格式错误，修改失败",
-    "solution": "请检查输入内容格式是否符合要求",
+    "description": "Request parameter is invalid.",
+    "detail": "The request parameter format is invalid.",
+    "solution": "Check that the input matches the API documentation.",
     "link": ""
 }
 ModelFactory_Router_ParamError_TypeError_Error = {
     "code": "ModelFactory.Router.ParamError.TypeError",
-    "description": "参数类型错误",
-    "detail": "参数类型错误",
-    "solution": "请检查填写的参数是否正确。",
+    "description": "Parameter type is invalid.",
+    "detail": "The request parameter type is invalid.",
+    "solution": "Check that the parameter type matches the API documentation.",
     "link": ""
 }
 ModelFactory_BenchmarkController_EditBenchmarkConfig_RepeatedNames_Error = {
@@ -937,23 +937,23 @@ ModelFactory_ModelUsedAuditController_GetModelArchivingList_OssNotAvailable_Erro
 }
 ModelFactory_ModelController_Model_ConnectError_Error = {
     "code": "ModelFactory.ModelController.Model.ConnectError",
-    "description": "模型连接异常",
-    "detail": "模型连接异常",
-    "solution": "请检查模型配置信息",
+    "description": "Model service connection failed.",
+    "detail": "The specified large model service could not be reached.",
+    "solution": "Check the model configuration and service availability.",
     "link": ""
 }
 ModelFactory_ModelController_Model_Error_Error = {
     "code": "ModelFactory.ModelController.Model.Error",
-    "description": "大模型调用发生错误",
-    "detail": "模型异常",
-    "solution": "请检查配置信息",
+    "description": "Model invocation failed.",
+    "detail": "The model service could not complete the request.",
+    "solution": "Check the model configuration and try again.",
     "link": ""
 }
 ModelFactory_ModelController_TestModel_Error_Error = {
     "code": "ModelFactory.ModelController.TestModel.Error",
-    "description": "测试连接失败",
-    "detail": "",
-    "solution": "请检查模型配置信息",
+    "description": "Model connection test failed.",
+    "detail": "The current configuration could not connect to the model service.",
+    "solution": "Check the model configuration and service availability.",
     "link": ""
 }
 
@@ -1064,9 +1064,9 @@ ModelFactory_SmallModelRouter_ModelApiDoc_ParamError = {
 }
 ModelFactory_SmallModelController_ModelApiDoc_ModelNotFoundError = {
     'code': 'ModelFactory.SmallModelController.ModelApiDoc.ModelNotFoundError',
-    'description': '输入的模型id不存在',
-    'detail': '输入的模型id不存在',
-    'solution': '请检查填写的模型id。',
+    'description': 'Model not found.',
+    'detail': 'The specified model ID does not exist.',
+    'solution': 'Check the model ID and try again.',
     'link': ''
 }
 ModelFactory_SmallModelController_ModelApiDoc_UnknownError = {
@@ -1141,9 +1141,9 @@ ModelFactory_CotController_WriteCot_UnknownError = {
 }
 ModelFactory_ExternalSmallModel_UnknownError = {
     'code': 'ModelFactory.ExternalSmallModel.UnknownError',
-    'description': '未知错误',
-    'detail': 'detail',
-    'solution': '请联系开发人员',
+    'description': 'Small model request failed.',
+    'detail': 'The small model request could not be completed.',
+    'solution': 'Retry later or contact an administrator.',
     'link': ''
 }
 ModelFactory_ExternalSmallModel_AddModel_RepeatedNames_Error = {
@@ -1169,16 +1169,16 @@ ModelFactory_ExternalSmallModel_GetInfo_IdNotExist_Error = {
 }
 ModelFactory_ExternalSmallModel_Used_NameNotExist = {
     "code": "ModelFactory.ExternalSmallModel.Used.NameNotExist",
-    "description": "模型名称或者模型id不存在",
-    "detail": "模型名称或者模型id不存在",
-    "solution": "请输入正确的模型名称或模型id",
+    "description": "Model not found.",
+    "detail": "The specified model name or model ID does not exist.",
+    "solution": "Check the model name or model ID and try again.",
     "link": ""
 }
 ModelFactory_ExternalSmallModel_Used_ConnectError = {
     "code": "ModelFactory.ExternalSmallModel.Used.ConnectError",
-    "description": "模型连接失败",
-    "detail": "模型连接失败",
-    "solution": "请检查模型配置",
+    "description": "Model service connection failed.",
+    "detail": "The specified small model service could not be reached.",
+    "solution": "Check the model configuration and service availability.",
     "link": ""
 }
 ModelFactory_ExternalSmallModel_Used_ModelError = {
@@ -1204,23 +1204,23 @@ IdValueIsEmpty = {
 }
 UnauthorizedError = {
     "code": "Unauthorized",
-    "description": "token无效或已过期",
-    "detail": "token无效或已过期",
-    "solution": "请检查token",
+    "description": "Authentication failed.",
+    "detail": "The access token is invalid or has expired.",
+    "solution": "Obtain a valid access token and try again.",
     "link": ""
 }
 HydraServiceError = {
     "code": "HydraServiceError",
-    "description": "调用hrdra服务异常",
-    "detail": "调用hrdra服务异常",
-    "solution": "请检查hrdra服务状态",
+    "description": "Authentication service is unavailable.",
+    "detail": "The access token could not be validated.",
+    "solution": "Retry later or contact an administrator.",
     "link": ""
 }
 BknSafeServiceError = {
     "code": "BknSafeServiceError",
-    "description": "调用bkn-safe服务异常",
-    "detail": "调用bkn-safe服务异常",
-    "solution": "请检查bkn-safe服务状态",
+    "description": "AppKey service is unavailable.",
+    "detail": "The AppKey could not be validated.",
+    "solution": "Retry later or contact an administrator.",
     "link": ""
 }
 UserManagementError = {
@@ -1232,9 +1232,9 @@ UserManagementError = {
 }
 NotPermissionError = {
     "code": "NotPermission",
-    "description": "没有操作权限",
-    "detail": "没有操作权限",
-    "solution": "请联系管理员分配相应权限",
+    "description": "Permission denied.",
+    "detail": "The current identity cannot perform this operation.",
+    "solution": "Ask an administrator to grant the required permission.",
     "link": ""
 }
 DeletePermissionResuorceError = {
@@ -1246,23 +1246,23 @@ DeletePermissionResuorceError = {
 }
 ModelQuotaControllerUserModelConfigNoLeftSpaceError = {
     "code": "ModelNager.ModelQuotaController.UserModelConfig.NoLeftSpace",
-    "description": "大模型剩余额度不足",
-    "detail": "本月额度已达上限，请联系管理员增加大模型使用额度后再试。",
-    "solution": "请联系管理员增加额度",
+    "description": "Model quota exceeded.",
+    "detail": "The monthly model usage quota has been reached.",
+    "solution": "Ask an administrator to increase the quota and try again.",
     "link": ""
 }
 ModelFactory_DefaultSmallModel_NotExist = {
     "code": "ModelFactory.ExternalSmallModel.Used.DefaultNotExist",
-    "description": "管理员没有配置该类型的默认小模型",
-    "detail": "管理员没有配置该类型的默认小模型",
-    "solution": "请在模型管理中为该类型设置默认小模型",
+    "description": "Default small model is not configured.",
+    "detail": "An administrator has not configured a default small model for this type.",
+    "solution": "Configure a default small model in model management and try again.",
     "link": ""
 }
 
 ModelFactory_DedaultModel_NotExist = {
     "code": "ModelFactory.ExternalSmallModel.Used.NameNotExist",
-    "description": "管理员没有配置默认大模型",
-    "detail": "管理员没有配置默认大模型",
-    "solution": "请联系管理员",
+    "description": "Default large model is not configured.",
+    "detail": "An administrator has not configured a default large model.",
+    "solution": "Ask an administrator to configure a default large model.",
     "link": ""
 }

--- a/infra/mf-model-api/app/commons/errors/code/__init__.py
+++ b/infra/mf-model-api/app/commons/errors/code/__init__.py
@@ -1,4 +1,4 @@
-# 业务状态码，举例
+# Business status-code examples.
 Mydb = 'ModelFactory.Mydb.DataBase'
 Model = 'ModelFactory.LLM.Error'
 LLMSource = 'ModelFactory.ConnectController.LLMSource'

--- a/infra/mf-model-api/app/commons/errors/codes.py
+++ b/infra/mf-model-api/app/commons/errors/codes.py
@@ -1,16 +1,16 @@
 class ParamValidationErrors(object):
-    """参数校验类错误码"""
+    """Parameter-validation error codes."""
     ParamMissing = "ParamMissing"
     ParamTypeError = "ParamTypeError"
 
 
 class PermissionErrors(object):
-    """权限类错误码"""
+    """Authorization error codes."""
     Unauthorized = "Unauthorized"
     Forbidden = "Forbidden"
 
 
 class BusinessLogicErrors(object):
-    """业务逻辑类错误码"""
+    """Business-logic error codes."""
     InvalidOperation = "InvalidOperation"
     ResourceNotFound = "ResourceNotFound"

--- a/infra/mf-model-api/app/commons/get_user_info.py
+++ b/infra/mf-model-api/app/commons/get_user_info.py
@@ -48,7 +48,7 @@ async def get_username_by_ids(user_ids):
         ]
     }
     
-    # 存储最终的用户信息
+    # Accumulate resolved user and application names.
     final_user_infos = {}
     
     for i in range(2):
@@ -65,14 +65,14 @@ async def get_username_by_ids(user_ids):
                         effective_ids = [user_id for user_id in user_ids if user_id not in invalid_ids]
                         payload["user_ids"] = effective_ids
                         
-                        # 如果有无效ID，调用应用名称接口
+                        # Resolve invalid user IDs through the application-name endpoint.
                         if invalid_ids:
                             app_payload = {
                                 "method": "GET",
                                 "app_ids": invalid_ids
                             }
                             
-                            # 调用应用名称接口
+                            # Query application names.
                             async with session.post(
                                     user_management_app_url,
                                     json=app_payload,
@@ -80,19 +80,19 @@ async def get_username_by_ids(user_ids):
                                 if app_response.status == 200:
                                     app_res = await app_response.text()
                                     app_result = json.loads(app_res)
-                                    # 获取应用名称信息
+                                    # Merge application names into the result.
                                     app_names = app_result.get("app_names", [])
                                     for app_info in app_names:
                                         final_user_infos[app_info['id']] = app_info['name']
                                 elif app_response.status == 400:
                                     app_res = await app_response.text()
                                     app_result = json.loads(app_res)
-                                    # 处理400错误，排除无效的应用ID
+                                    # Exclude invalid application IDs reported by a 400 response.
                                     invalid_app_ids = app_result.get("detail", {}).get("ids", [])
                                     valid_app_ids = [app_id for app_id in invalid_ids if app_id not in invalid_app_ids]
                                     
                                     if valid_app_ids:
-                                        # 重新调用应用名称接口，只包含有效的应用ID
+                                        # Retry the application-name request with valid IDs only.
                                         app_payload["app_ids"] = valid_app_ids
                                         async with session.post(
                                                 user_management_app_url,
@@ -105,7 +105,7 @@ async def get_username_by_ids(user_ids):
                                                 for app_info in app_names:
                                                     final_user_infos[app_info['id']] = app_info['name']
                                 else:
-                                    # 其他错误状态，抛出异常
+                                    # Treat all other statuses as dependency failures.
                                     raise Exception("user-management app service error,please check")
                         
                         continue
@@ -114,7 +114,7 @@ async def get_username_by_ids(user_ids):
                     res = await response.text()
                     result = json.loads(res)
                     user_infos = {info['id']: info['name'] for info in result}
-                    # 合并用户信息和应用信息
+                    # Merge user and application identity results.
                     final_user_infos.update(user_infos)
                     return final_user_infos
 

--- a/infra/mf-model-api/app/commons/i18n/en_us.py
+++ b/infra/mf-model-api/app/commons/i18n/en_us.py
@@ -1,4 +1,4 @@
-# 简体中文
+# United States English locale resources.
 from app.commons.errors.codes import ParamValidationErrors
 
 error_messages = {
@@ -27,6 +27,122 @@ error_messages = {
         "description": "Request parameter is invalid.",
         "detail": "The request parameter format is invalid.",
         "solution": "Check that the input format matches the API documentation.",
+    },
+    "ModelFactory.Router.ParamError.TypeError": {
+        "description": "Parameter type is invalid.",
+        "detail": "The request parameter type is invalid.",
+        "detail_template": "Parameter type is invalid: {parameter}",
+        "solution": "Check that the parameter type matches the API documentation.",
+    },
+    "ModelFactory.InternalError": {
+        "description": "Request failed.",
+        "detail": "The request could not be completed.",
+        "solution": "Retry later or contact an administrator.",
+    },
+    "ModelFactory.HTTP.NotFound": {
+        "description": "Resource not found.",
+        "detail": "The requested resource does not exist.",
+        "solution": "Check the resource identifier and try again.",
+    },
+    "ModelFactory.HTTP.MethodNotAllowed": {
+        "description": "Method not allowed.",
+        "detail": "The requested resource does not support this HTTP method.",
+        "solution": "Check the request method and try again.",
+    },
+    "Unauthorized": {
+        "description": "Authentication failed.",
+        "detail": "The access token is invalid or has expired.",
+        "solution": "Obtain a valid access token and try again.",
+    },
+    "HydraServiceError": {
+        "description": "Authentication service is unavailable.",
+        "detail": "The access token could not be validated.",
+        "solution": "Retry later or contact an administrator.",
+    },
+    "BknSafeServiceError": {
+        "description": "AppKey service is unavailable.",
+        "detail": "The AppKey could not be validated.",
+        "solution": "Retry later or contact an administrator.",
+    },
+    "NotPermission": {
+        "description": "Permission denied.",
+        "detail": "The current identity cannot perform this operation.",
+        "solution": "Ask an administrator to grant the required permission.",
+    },
+    "ModelFactory.Mydb.DataBase.ParameterError": {
+        "description": "Database access failed.",
+        "detail": "Model Factory cannot access the database right now.",
+        "solution": "Retry later or contact an administrator.",
+    },
+    "ModelFactory.MyPymysqlPool.Connection.ConnectError": {
+        "description": "Database connection failed.",
+        "detail": "Model Factory cannot connect to the database right now.",
+        "solution": "Retry later or contact an administrator.",
+    },
+    "ModelFactory.ExternalSmallModel.Used.NameNotExist": {
+        "description": "Model not found.",
+        "detail": "The specified model name or model ID does not exist.",
+        "solution": "Check the model name or model ID and try again.",
+    },
+    "ModelFactory.ExternalSmallModel.Used.DefaultNotExist": {
+        "description": "Default small model is not configured.",
+        "detail": "An administrator has not configured a default small model for this type.",
+        "solution": "Configure a default small model in model management and try again.",
+    },
+    "ModelFactory.ExternalSmallModel.Used.ConnectError": {
+        "description": "Model service connection failed.",
+        "detail": "The specified small model service could not be reached.",
+        "solution": "Check the model configuration and service availability.",
+    },
+    "ModelFactory.ModelController.Model.ConnectError": {
+        "description": "Model service connection failed.",
+        "detail": "The specified large model service could not be reached.",
+        "solution": "Check the model configuration and service availability.",
+    },
+    "ModelFactory.ModelController.Model.Error": {
+        "description": "Model invocation failed.",
+        "detail": "The model service could not complete the request.",
+        "solution": "Check the model configuration and try again.",
+    },
+    "ModelFactory.ConnectController.LLMUsed.ParameterError": {
+        "description": "Model configuration is invalid.",
+        "detail": "The current model configuration cannot complete the request.",
+        "solution": "Check the large model configuration.",
+    },
+    "ModelFactory.LLM.Error": {
+        "description": "Model context limit exceeded.",
+        "detail": "The request content and maximum output tokens exceed the model context limit.",
+        "solution": "Shorten the request, reduce maximum output tokens, or select a model with a larger context.",
+    },
+    "ModelFactory.LLM.ModelTimeoutError": {
+        "description": "Model request timed out.",
+        "detail": "The model service did not complete the request in time.",
+        "solution": "Try again later.",
+    },
+    "ModelNager.ModelQuotaController.UserModelConfig.NoLeftSpace": {
+        "description": "Model quota exceeded.",
+        "detail": "The monthly model usage quota has been reached.",
+        "solution": "Ask an administrator to increase the quota and try again.",
+    },
+    "ModelFactory.SmallModelController.ModelApiDoc.ModelNotFoundError": {
+        "description": "Model not found.",
+        "detail": "The specified model ID does not exist.",
+        "solution": "Check the model ID and try again.",
+    },
+    "ModelFactory.ModelController.TestModel.Error": {
+        "description": "Model connection test failed.",
+        "detail": "The current configuration could not connect to the model service.",
+        "solution": "Check the model configuration and service availability.",
+    },
+    "ModelFactory.ConnectController.LLMTest.ParameterError": {
+        "description": "Model connection test failed.",
+        "detail": "The current configuration could not connect to the large model service.",
+        "solution": "Check the large model configuration and service availability.",
+    },
+    "ModelFactory.ExternalSmallModel.UnknownError": {
+        "description": "Small model request failed.",
+        "detail": "The small model request could not be completed.",
+        "solution": "Retry later or contact an administrator.",
     },
     ParamValidationErrors.ParamMissing: {
         "code": ParamValidationErrors.ParamMissing,

--- a/infra/mf-model-api/app/commons/i18n/en_us.py
+++ b/infra/mf-model-api/app/commons/i18n/en_us.py
@@ -26,6 +26,7 @@ error_messages = {
     "ModelFactory.Router.ParamError.FormatError": {
         "description": "Request parameter is invalid.",
         "detail": "The request parameter format is invalid.",
+        "max_tokens_detail_template": "max_tokens exceeds the maximum value of {limit}.",
         "solution": "Check that the input format matches the API documentation.",
     },
     "ModelFactory.Router.ParamError.TypeError": {
@@ -88,6 +89,11 @@ error_messages = {
         "description": "Default small model is not configured.",
         "detail": "An administrator has not configured a default small model for this type.",
         "solution": "Configure a default small model in model management and try again.",
+    },
+    "ModelFactory.LLM.DefaultNotExist": {
+        "description": "Default large model is not configured.",
+        "detail": "An administrator has not configured a default large model.",
+        "solution": "Ask an administrator to configure a default large model.",
     },
     "ModelFactory.ExternalSmallModel.Used.ConnectError": {
         "description": "Model service connection failed.",

--- a/infra/mf-model-api/app/commons/i18n/zh_cn.py
+++ b/infra/mf-model-api/app/commons/i18n/zh_cn.py
@@ -1,4 +1,4 @@
-# 简体中文
+# Simplified Chinese locale resources.
 from app.commons.errors.codes import ParamValidationErrors
 
 error_messages = {
@@ -27,6 +27,122 @@ error_messages = {
         "description": "请求参数错误",
         "detail": "输入参数格式不符合要求。",
         "solution": "请检查输入格式是否符合 API 文档要求。",
+    },
+    "ModelFactory.Router.ParamError.TypeError": {
+        "description": "参数类型错误",
+        "detail": "输入参数类型不符合要求。",
+        "detail_template": "参数类型错误：{parameter}",
+        "solution": "请检查参数类型是否符合 API 文档要求。",
+    },
+    "ModelFactory.InternalError": {
+        "description": "请求失败",
+        "detail": "请求无法完成。",
+        "solution": "请稍后重试或联系管理员。",
+    },
+    "ModelFactory.HTTP.NotFound": {
+        "description": "资源不存在",
+        "detail": "请求的资源不存在。",
+        "solution": "请检查资源标识后重试。",
+    },
+    "ModelFactory.HTTP.MethodNotAllowed": {
+        "description": "请求方法不被允许",
+        "detail": "当前资源不支持该请求方法。",
+        "solution": "请检查请求方法后重试。",
+    },
+    "Unauthorized": {
+        "description": "身份认证失败",
+        "detail": "访问令牌无效或已过期。",
+        "solution": "请获取有效的访问令牌后重试。",
+    },
+    "HydraServiceError": {
+        "description": "身份认证服务不可用",
+        "detail": "无法完成访问令牌校验。",
+        "solution": "请稍后重试或联系管理员。",
+    },
+    "BknSafeServiceError": {
+        "description": "应用密钥服务不可用",
+        "detail": "无法完成应用密钥校验。",
+        "solution": "请稍后重试或联系管理员。",
+    },
+    "NotPermission": {
+        "description": "没有操作权限",
+        "detail": "当前身份没有执行此操作的权限。",
+        "solution": "请联系管理员分配相应权限。",
+    },
+    "ModelFactory.Mydb.DataBase.ParameterError": {
+        "description": "数据库访问失败",
+        "detail": "模型工厂暂时无法访问数据库。",
+        "solution": "请稍后重试或联系管理员。",
+    },
+    "ModelFactory.MyPymysqlPool.Connection.ConnectError": {
+        "description": "数据库连接失败",
+        "detail": "模型工厂暂时无法连接数据库。",
+        "solution": "请稍后重试或联系管理员。",
+    },
+    "ModelFactory.ExternalSmallModel.Used.NameNotExist": {
+        "description": "模型不存在",
+        "detail": "指定的模型名称或模型 ID 不存在。",
+        "solution": "请检查模型名称或模型 ID 后重试。",
+    },
+    "ModelFactory.ExternalSmallModel.Used.DefaultNotExist": {
+        "description": "默认小模型未配置",
+        "detail": "管理员尚未配置该类型的默认小模型。",
+        "solution": "请在模型管理中配置默认小模型后重试。",
+    },
+    "ModelFactory.ExternalSmallModel.Used.ConnectError": {
+        "description": "模型服务连接失败",
+        "detail": "无法连接到指定的小模型服务。",
+        "solution": "请检查模型配置和服务可用性。",
+    },
+    "ModelFactory.ModelController.Model.ConnectError": {
+        "description": "模型服务连接失败",
+        "detail": "无法连接到指定的大模型服务。",
+        "solution": "请检查模型配置和服务可用性。",
+    },
+    "ModelFactory.ModelController.Model.Error": {
+        "description": "模型调用失败",
+        "detail": "模型服务无法完成该请求。",
+        "solution": "请检查模型配置后重试。",
+    },
+    "ModelFactory.ConnectController.LLMUsed.ParameterError": {
+        "description": "模型配置错误",
+        "detail": "当前模型配置无法用于完成请求。",
+        "solution": "请检查大模型配置。",
+    },
+    "ModelFactory.LLM.Error": {
+        "description": "模型上下文超出限制",
+        "detail": "请求内容和最大输出令牌数超出模型上下文限制。",
+        "solution": "请缩短请求内容、减少最大输出令牌数或选择上下文更大的模型。",
+    },
+    "ModelFactory.LLM.ModelTimeoutError": {
+        "description": "模型请求超时",
+        "detail": "模型服务未在规定时间内完成请求。",
+        "solution": "请稍后重试。",
+    },
+    "ModelNager.ModelQuotaController.UserModelConfig.NoLeftSpace": {
+        "description": "模型额度不足",
+        "detail": "本月模型使用额度已达上限。",
+        "solution": "请联系管理员增加额度后重试。",
+    },
+    "ModelFactory.SmallModelController.ModelApiDoc.ModelNotFoundError": {
+        "description": "模型不存在",
+        "detail": "指定的模型 ID 不存在。",
+        "solution": "请检查模型 ID 后重试。",
+    },
+    "ModelFactory.ModelController.TestModel.Error": {
+        "description": "模型连接测试失败",
+        "detail": "无法使用当前配置连接模型服务。",
+        "solution": "请检查模型配置和服务可用性。",
+    },
+    "ModelFactory.ConnectController.LLMTest.ParameterError": {
+        "description": "模型连接测试失败",
+        "detail": "无法使用当前配置连接大模型服务。",
+        "solution": "请检查大模型配置和服务可用性。",
+    },
+    "ModelFactory.ExternalSmallModel.UnknownError": {
+        "description": "小模型请求失败",
+        "detail": "小模型请求无法完成。",
+        "solution": "请稍后重试或联系管理员。",
     },
     ParamValidationErrors.ParamMissing: {
         "code": ParamValidationErrors.ParamMissing,

--- a/infra/mf-model-api/app/commons/i18n/zh_cn.py
+++ b/infra/mf-model-api/app/commons/i18n/zh_cn.py
@@ -26,6 +26,7 @@ error_messages = {
     "ModelFactory.Router.ParamError.FormatError": {
         "description": "请求参数错误",
         "detail": "输入参数格式不符合要求。",
+        "max_tokens_detail_template": "max_tokens 超过最大值 {limit}。",
         "solution": "请检查输入格式是否符合 API 文档要求。",
     },
     "ModelFactory.Router.ParamError.TypeError": {
@@ -88,6 +89,11 @@ error_messages = {
         "description": "默认小模型未配置",
         "detail": "管理员尚未配置该类型的默认小模型。",
         "solution": "请在模型管理中配置默认小模型后重试。",
+    },
+    "ModelFactory.LLM.DefaultNotExist": {
+        "description": "默认大模型未配置",
+        "detail": "管理员尚未配置默认大模型。",
+        "solution": "请联系管理员配置默认大模型。",
     },
     "ModelFactory.ExternalSmallModel.Used.ConnectError": {
         "description": "模型服务连接失败",

--- a/infra/mf-model-api/app/commons/locale.py
+++ b/infra/mf-model-api/app/commons/locale.py
@@ -75,9 +75,10 @@ def platform_error_message(code: str) -> str:
     """Return a localized message for an error owned by mf-model-api."""
     from app.commons.i18n import lookup_error_message
 
-    message = lookup_error_message(code, get_effective_locale())
+    locale = get_effective_locale()
+    message = lookup_error_message(code, locale)
     if not message:
-        return "Request failed." if get_effective_locale() == ENGLISH_LOCALE else "请求失败。"
+        message = lookup_error_message("ModelFactory.InternalError", locale)
     return message.get("detail") or message.get("description", "")
 
 
@@ -104,7 +105,7 @@ def localized_error_content(
     if message:
         for field in ("description", "detail", "solution"):
             if field == "detail":
-                localized[field] = _localize_detail(message, content.get(field))
+                localized[field] = _localize_detail(code, message, content.get(field), locale)
             elif field in message and message[field]:
                 localized[field] = message[field]
         return localized, True
@@ -138,7 +139,7 @@ def _localized_openai_error(content: Dict[str, Any], locale: str) -> Tuple[Dict[
     envelope = {
         "code": code,
         "description": error.get("message", ""),
-        "detail": error.get("message", ""),
+        "detail": _structured_openai_detail(error),
     }
     localized, changed = localized_error_content(envelope, locale)
     if not changed:
@@ -152,22 +153,40 @@ def _contains_chinese(value: Any) -> bool:
     return isinstance(value, str) and any("\u4e00" <= char <= "\u9fff" for char in value)
 
 
-def _localize_detail(message: Dict[str, str], detail: Any) -> Any:
+def _localize_detail(code: str, message: Dict[str, str], detail: Any, locale: str) -> Any:
     template = message.get("detail_template")
     if template and isinstance(detail, str):
         parameter = _parameter_name_from_detail(detail)
         if parameter:
             return template.format(parameter=parameter)
-        return message.get("detail") or detail
-    return detail if isinstance(detail, str) and detail else message.get("detail")
+        return message.get("detail") or message.get("description") or ""
+    # A framework validation reason is already safe, structured client text.
+    # Other legacy details may contain internal exception strings or text in the
+    # service's historical default language, so the locale catalog owns them.
+    if (code == "ModelFactory.Router.ParamError.FormatError"
+            and locale == ENGLISH_LOCALE
+            and isinstance(detail, str) and detail and not _contains_chinese(detail)):
+        return detail
+    return message.get("detail") or ""
 
 
 def _parameter_name_from_detail(detail: str) -> str:
     text = detail.strip()
-    if text.endswith(" 参数缺失"):
-        return text[:-len(" 参数缺失")].strip()
     _, separator, value = text.partition(":")
     return value.strip() if separator else ""
+
+
+def _structured_openai_detail(error: Dict[str, Any]) -> Any:
+    parameter = error.get("param")
+    template_codes = {
+        "ModelFactory.Router.ParamError.ParamMissing",
+        "ModelFactory.Router.ParamError.TypeError",
+        "ParamMissing",
+        "ParamTypeError",
+    }
+    if error.get("code") in template_codes and isinstance(parameter, str) and parameter.strip():
+        return f"parameter: {parameter.strip()}"
+    return error.get("message", "")
 
 
 def _is_framework_http_error(content: Dict[str, Any], status_code: int) -> bool:
@@ -175,24 +194,18 @@ def _is_framework_http_error(content: Dict[str, Any], status_code: int) -> bool:
 
 
 def _localized_framework_http_error(status_code: int, locale: str) -> Dict[str, str]:
-    messages = {
-        404: {
-            "zh-CN": ("资源不存在", "请求的资源不存在。", "请检查资源标识后重试。"),
-            "en-US": ("Resource not found.", "The requested resource does not exist.",
-                      "Check the resource identifier and try again."),
-        },
-        405: {
-            "zh-CN": ("请求方法不被允许", "当前资源不支持该请求方法。", "请检查请求方法后重试。"),
-            "en-US": ("Method not allowed.", "The requested resource does not support this HTTP method.",
-                      "Check the request method and try again."),
-        },
-    }
-    description, detail, solution = messages[status_code][locale]
+    from app.commons.i18n import lookup_error_message
+
+    message_key = {
+        404: "ModelFactory.HTTP.NotFound",
+        405: "ModelFactory.HTTP.MethodNotAllowed",
+    }[status_code]
+    message = lookup_error_message(message_key, locale) or {}
     return {
         "code": f"HTTP_{status_code}",
-        "description": description,
-        "detail": detail,
-        "solution": solution,
+        "description": message.get("description", ""),
+        "detail": message.get("detail", ""),
+        "solution": message.get("solution", ""),
         "link": "",
     }
 

--- a/infra/mf-model-api/app/commons/locale.py
+++ b/infra/mf-model-api/app/commons/locale.py
@@ -154,6 +154,11 @@ def _contains_chinese(value: Any) -> bool:
 
 
 def _localize_detail(code: str, message: Dict[str, str], detail: Any, locale: str) -> Any:
+    if code == "ModelFactory.Router.ParamError.FormatError" and isinstance(detail, str):
+        detail_kind, separator, value = detail.partition(":")
+        template = message.get("max_tokens_detail_template")
+        if detail_kind.strip() == "max_tokens_limit" and separator and value.strip() and template:
+            return template.format(limit=value.strip())
     template = message.get("detail_template")
     if template and isinstance(detail, str):
         parameter = _parameter_name_from_detail(detail)

--- a/infra/mf-model-api/app/commons/snow_id.py
+++ b/infra/mf-model-api/app/commons/snow_id.py
@@ -1,70 +1,70 @@
 import time
 # import logging
 
-# 64位ID的划分
+# Bit allocation for the 64-bit ID.
 WORKER_ID_BITS = 5
 DATACENTER_ID_BITS = 5
 SEQUENCE_BITS = 12
 
-# 最大取值计算
+# Maximum values for each segment.
 MAX_WORKER_ID = -1 ^ (-1 << WORKER_ID_BITS)  # 2**5-1 0b11111
 MAX_DATACENTER_ID = -1 ^ (-1 << DATACENTER_ID_BITS)
 
-# 移位偏移计算
+# Bit-shift offsets.
 WOKER_ID_SHIFT = SEQUENCE_BITS
 DATACENTER_ID_SHIFT = SEQUENCE_BITS + WORKER_ID_BITS
 TIMESTAMP_LEFT_SHIFT = SEQUENCE_BITS + WORKER_ID_BITS + DATACENTER_ID_BITS
 
-# 序号循环掩码
+# Sequence rollover mask.
 SEQUENCE_MASK = -1 ^ (-1 << SEQUENCE_BITS)
 
-# Twitter元年时间戳
+# Custom epoch based on Twitter's Snowflake epoch.
 TWEPOCH = 1288834974657
 
-# 需要改一下
+# Optional application logger.
 # logger = logging.getLogger('flask.app')
 
 
 class IdWorker(object):
     """
-    用于生成IDs
+    Generate Snowflake-style IDs.
     """
 
     def __init__(self, datacenter_id, worker_id, sequence=0):
         """
-        初始化
-        :param datacenter_id: 数据中心（机器区域）ID
-        :param worker_id: 机器ID
-        :param sequence: 其实序号
+        Initialize the worker.
+        :param datacenter_id: data-center ID
+        :param worker_id: worker ID
+        :param sequence: initial sequence number
         """
         # sanity check
         if worker_id > MAX_WORKER_ID or worker_id < 0:
-            raise ValueError('worker_id值越界')
+            raise ValueError('worker_id is out of range')
 
         if datacenter_id > MAX_DATACENTER_ID or datacenter_id < 0:
-            raise ValueError('datacenter_id值越界')
+            raise ValueError('datacenter_id is out of range')
 
         self.worker_id = worker_id
         self.datacenter_id = datacenter_id
         self.sequence = sequence
 
-        self.last_timestamp = -1  # 上次计算的时间戳
+        self.last_timestamp = -1  # Timestamp used for the previous ID.
 
     def _gen_timestamp(self):
         """
-        生成整数时间戳
+        Return the current timestamp in milliseconds.
         :return:int timestamp
         """
         return int(time.time() * 1000)
 
     def get_id(self):
         """
-        获取新ID
+        Generate the next ID.
         :return:
         """
         timestamp = self._gen_timestamp()
 
-        # 时钟回拨
+        # Detect clock rollback.
         if timestamp < self.last_timestamp:
             # logging.errors('clock is moving backwards. Rejecting requests until{}'.format(self.last_timestamp))
             raise Exception
@@ -84,7 +84,7 @@ class IdWorker(object):
 
     def _til_next_millis(self, last_timestamp):
         """
-        等到下一毫秒
+        Wait until the next millisecond.
         """
         timestamp = self._gen_timestamp()
         while timestamp <= last_timestamp:
@@ -93,7 +93,7 @@ class IdWorker(object):
 
 
 def snow_id():
-    """使用全局worker实例生成ID"""
+    """Generate an ID with the process-wide worker."""
     idx = worker.get_id()
     return idx
 

--- a/infra/mf-model-api/app/controller/llm_controller.py
+++ b/infra/mf-model-api/app/controller/llm_controller.py
@@ -11,17 +11,12 @@ from app.utils import log_redact, openai_error
 from sse_starlette import EventSourceResponse
 import time
 
-eng_dict = {
-    "名称已存在，请修改": "Name already exists, please modify",
-    "名称已被其他用户占用，请修改": "The name is already taken by another user, please change it"
-}
-
 
 def openai_error_response(error_body, status, headers=None):
-    """OpenAI 兼容面上的错误响应：body 必须是 {"error": {...}}。
+    """Return an OpenAI-compatible {"error": {...}} response.
 
-    上游状态码由 llm_utils 通过私有键带过来（有就用，没有就用传入的 status），
-    序列化前 pop 掉，不会漏进 body。
+    llm_utils carries an upstream status in a private key when available. Pop
+    that key before serialization so implementation metadata cannot leak.
     """
     resolved = openai_error.pop_http_status(error_body, status)
     retry_after = openai_error.pop_retry_after(error_body)
@@ -33,7 +28,7 @@ def openai_error_response(error_body, status, headers=None):
 
 
 def envelope_error_response(envelope, status, headers=None):
-    """内部 envelope（参数/权限/配额等）翻成 OpenAI 错误体后再出门。"""
+    """Convert an internal parameter, permission, or quota envelope to OpenAI format."""
     return openai_error_response(
         openai_error.from_envelope(envelope, status), status, headers)
 
@@ -60,7 +55,7 @@ async def used_model_openai(request, user_id, language, func_module, trace_heade
     else:
         cache_key = f"dip:model-api:llm:{model_id}:list"
     try:
-        # 确保 redis_util 已初始化
+        # Lazily initialize the Redis client.
         global redis_util
         if redis_util is None:
             redis_util = await get_redis_util()
@@ -70,14 +65,14 @@ async def used_model_openai(request, user_id, language, func_module, trace_heade
         StandLogger.info_log(f"从redis中获取llm配置耗时：{t2 - t1}s")
         if res is not None and isinstance(res, (str, bytes)):
             try:
-                # 使用json.loads替代eval()，更安全且性能更好
+                # Parse cached JSON without executing arbitrary expressions.
                 import json
                 if isinstance(res, bytes):
                     res = res.decode('utf-8')
                 model_info = json.loads(res)
             except (json.JSONDecodeError, ValueError) as e:
                 StandLogger.warn(f"解析缓存数据失败: {str(e)}, key={cache_key}, value={res[:100]}...")
-                # 缓存解析失败，回退到数据库查询
+                # Fall back to the database when cached data is invalid.
                 if not is_default:
                     model_info = llm_model_dao.get_data_from_model_list_by_name_id(model_name, model_id)
                 else:
@@ -87,10 +82,10 @@ async def used_model_openai(request, user_id, language, func_module, trace_heade
                         return envelope_error_response(ModelFactory_ExternalSmallModel_Used_NameNotExist, 400)
                     else:
                         return envelope_error_response(ModelFactory_DedaultModel_NotExist, 400)
-                # 重新设置缓存，使用JSON格式
+                # Refresh the cache with valid JSON.
                 await redis_util.set_str(key=cache_key, value=json.dumps(model_info), expire=3600 * 24)
         else:
-            # 缓存不存在或非预期类型，从数据库获取
+            # Query the database when the cache is missing or has an unexpected type.
             if not is_default:
                 model_info = llm_model_dao.get_data_from_model_list_by_name_id(model_name, model_id)
             else:
@@ -100,7 +95,7 @@ async def used_model_openai(request, user_id, language, func_module, trace_heade
                     return envelope_error_response(ModelFactory_ExternalSmallModel_Used_NameNotExist, 400)
                 else:
                     return envelope_error_response(ModelFactory_DedaultModel_NotExist, 400)
-            # 设置缓存，使用JSON格式
+            # Cache the database result as JSON.
             import json
             await redis_util.set_str(key=cache_key, value=json.dumps(model_info), expire=3600 * 24)
     except Exception as e:
@@ -134,14 +129,14 @@ async def used_model_openai(request, user_id, language, func_module, trace_heade
                 model_quota_info = eval(res)
             except Exception as e:
                 StandLogger.warn(f"解析缓存数据失败: {str(e)}, key={quota_cache_key}, value={res}")
-                # 缓存解析失败，回退到数据库查询
+                # Fall back to the database when cached quota data is invalid.
                 model_quota_info = llm_model_dao.get_quota_by_user_and_model(user_id, model_id)
-                # 重新设置缓存
+                # Refresh the quota cache.
                 await redis_util.set_str(key=quota_cache_key, value=str(model_quota_info), expire=300)
         else:
-            # 缓存不存在或非预期类型，从数据库获取
+            # Query the database when quota data is absent or malformed.
             model_quota_info = llm_model_dao.get_quota_by_user_and_model(user_id, model_id)
-            # 设置缓存
+            # Cache the quota result.
             await redis_util.set_str(key=quota_cache_key, value=str(model_quota_info), expire=300)
         if len(model_quota_info) == 0 or model_quota_info[0]["remaining_input_tokens"] <= 0 or model_quota_info[0][
             "remaining_output_tokens"] <= 0:
@@ -150,7 +145,7 @@ async def used_model_openai(request, user_id, language, func_module, trace_heade
 
     if request["max_tokens"] > context_size * 1000:
         error_dict = ModelFactory_Router_ParamError_FormatError_Error.copy()
-        error_dict["detail"] = f"max_tokens超过最大值{context_size}k"
+        error_dict["detail"] = f"max_tokens exceeds the maximum value of {context_size}k"
         return envelope_error_response(error_dict, 400)
     messages = request["messages"]
     message = messages[len(messages) - 1]["content"]
@@ -160,8 +155,8 @@ async def used_model_openai(request, user_id, language, func_module, trace_heade
             messages[i].pop("tool_calls")
         if messages[i]["tool_call_id"] is None:
             messages[i].pop("tool_call_id")
-        # OpenAI 规范允许 assistant+tool_calls 的 content 为 null；内部统一空串，
-        # 下游拼接/计量（prompt_str += content）不容忍 None
+        # OpenAI permits null content for assistant messages with tool_calls.
+        # Normalize it because downstream concatenation and metering require strings.
         if messages[i]["content"] is None:
             messages[i]["content"] = ""
         tmp_item = {

--- a/infra/mf-model-api/app/controller/llm_controller.py
+++ b/infra/mf-model-api/app/controller/llm_controller.py
@@ -145,7 +145,7 @@ async def used_model_openai(request, user_id, language, func_module, trace_heade
 
     if request["max_tokens"] > context_size * 1000:
         error_dict = ModelFactory_Router_ParamError_FormatError_Error.copy()
-        error_dict["detail"] = f"max_tokens exceeds the maximum value of {context_size}k"
+        error_dict["detail"] = f"max_tokens_limit: {context_size}k"
         return envelope_error_response(error_dict, 400)
     messages = request["messages"]
     message = messages[len(messages) - 1]["content"]

--- a/infra/mf-model-api/app/controller/small_model_controller.py
+++ b/infra/mf-model-api/app/controller/small_model_controller.py
@@ -16,12 +16,13 @@ from app.mydb.ConnectUtil import redis_util, get_redis_util
 from app.utils.permission_manager import PermissionManager, permission_manager
 
 
-# 小模型类型常量，与 t_small_model.f_model_type 取值一致。
+# Small-model type constants aligned with t_small_model.f_model_type.
 RERANKER_MODEL_TYPE = "reranker"
 
-# 默认模型是管理员随时可改的**指针**，不是某个具体模型的配置。按名字查到的配置缓存
-# 一天没问题，指针缓存一天就会出现「换了默认、一天之内仍按旧的调」——#552 记的正是
-# 这个坑。所以默认路径用短 TTL。
+# The default model is an administrator-controlled pointer, not a concrete
+# configuration. Named configurations may be cached for a day, but caching the
+# pointer that long would continue using an old default after a change (#552).
+# Use a short TTL for default lookups.
 DEFAULT_MODEL_CACHE_TTL_SECONDS = 60
 MODEL_CACHE_TTL_SECONDS = 3600 * 24
 
@@ -30,13 +31,14 @@ def _model_cache_ttl(is_default):
     return DEFAULT_MODEL_CACHE_TTL_SECONDS if is_default else MODEL_CACHE_TTL_SECONDS
 
 
-# #842 之前各服务硬编码的兜底名字：context-loader 猜 "reranker"、vega 猜 "embedding"
-# （#296）。存量库里 f_default 全是 0——「设为默认」是后加的能力，没人点过就没人置位，
-# 也没有任何迁移回填它。若默认解析取不到就直接 400，存量环境升级当天精排即静默退回
-# 原序（三处调用方都是优雅降级，只打一条 warn）。
+# Before #842, consumers used hard-coded fallback names: Context Loader guessed
+# "reranker" and Vega guessed "embedding" (#296). Existing databases may have
+# no f_default value because the default selection feature was added later and
+# no migration backfilled it. Returning 400 immediately would silently disable
+# reranking after an upgrade because all three consumers degrade gracefully.
 #
-# 所以默认解析落空时，按老约定的名字再兜一次，命中就打 warn 指路。等日志里不再出现
-# 这条 warn，这一跳就可以删掉。
+# Fall back once to the legacy name and emit a migration warning. This fallback
+# can be removed after the warning no longer appears in supported environments.
 LEGACY_DEFAULT_MODEL_NAMES = {
     RERANKER_MODEL_TYPE: "reranker",
     "embedding": "embedding",
@@ -44,7 +46,7 @@ LEGACY_DEFAULT_MODEL_NAMES = {
 
 
 def _load_small_model(is_default, model_type, model_name, model_id):
-    """按「有没有指定模型」分流：指定了按名字/ID 查，没指定取该类型的系统默认。"""
+    """Load an explicit model by name/ID or the system default for its type."""
     if not is_default:
         return small_model_dao.get_model_info_by_name_id(model_name, model_id)
 
@@ -65,7 +67,7 @@ def _load_small_model(is_default, model_type, model_name, model_id):
 
 
 def _model_missing_error(is_default):
-    """区分「你指定的模型不存在」与「管理员没配默认模型」——两者的处理方式完全不同。"""
+    """Distinguish a missing explicit model from a missing administrator default."""
     if is_default:
         return ModelFactory_DefaultSmallModel_NotExist
     return ModelFactory_ExternalSmallModel_Used_NameNotExist
@@ -328,8 +330,6 @@ async def delete_model(model_para, userId, language, role):
         # permission_delete_ids = [model_id for model_id in model_ids if model_id in permission_ids]
         for model_id in model_ids:
             if model_id not in permission_ids:
-                error_dict = NotPermissionError.copy()
-                error_dict["detail"] = "部分模型无删除权限"
                 return JSONResponse(status_code=403, content=NotPermissionError)
         try:
             # if permission_delete_ids:
@@ -408,14 +408,14 @@ async def embedding_model_used(request, userId, language, role, func_module, pri
         model_id = request.model_id
         if not model_name and not model_id:
             error_dict = ModelFactory_Router_ParamError_ParamMissing_Error
-            error_dict['detail'] = "model或者model_id至少需要传递一个"
+            error_dict['detail'] = "Provide at least one of model or model_id."
             return JSONResponse(status_code=400, content=error_dict)
         texts = request.input
         if model_name:
             cache_key = f"dip:model-api:small-model:{model_name}:list"
         else:
             cache_key = f"dip:model-api:small-model:{model_id}:list"
-        # 确保 redis_util 已初始化
+        # Lazily initialize the Redis client.
         global redis_util
         if redis_util is None:
             redis_util = await get_redis_util()
@@ -425,18 +425,18 @@ async def embedding_model_used(request, userId, language, role, func_module, pri
                 model_info = eval(res)
             except Exception as e:
                 StandLogger.warn(f"解析缓存数据失败: {str(e)}, key={cache_key}, value={res}")
-                # 缓存解析失败，回退到数据库查询
+                # Fall back to the database when cached data is invalid.
                 model_info = small_model_dao.get_model_info_by_name_id(model_name, model_id)
                 if len(model_info) == 0:
                     return JSONResponse(status_code=400, content=ModelFactory_ExternalSmallModel_Used_NameNotExist)
-                # 重新设置缓存
+                # Refresh the cache.
                 await redis_util.set_str(key=cache_key, value=str(model_info), expire=3600 * 24)
         else:
-            # 缓存不存在或非预期类型，从数据库获取
+            # Query the database when the cache is missing or malformed.
             model_info = small_model_dao.get_model_info_by_name_id(model_name, model_id)
             if len(model_info) == 0:
                 return JSONResponse(status_code=400, content=ModelFactory_ExternalSmallModel_Used_NameNotExist)
-            # 设置缓存
+            # Cache the database result.
             await redis_util.set_str(key=cache_key, value=str(model_info), expire=3600 * 24)
         # Refresh records written by older mf-model-api instances, whose query did
         # not include f_embedding_dim. This keeps rolling upgrades dimension-safe.
@@ -499,11 +499,11 @@ async def reranker_model_used(request, userId, language, role, func_module, priv
         model_id = request.model_id
         query = request.query
         documents = request.documents
-        # 都不传即「用模型管理里勾选的默认 reranker」，与大模型侧一致
-        # （llm_controller 的 default_model_3ed523 哨兵 + get_data_from_default_model）。
-        # 在此之前这里直接 400，逼得调用方必须填名字，于是各服务只能硬编码一个猜出来的
-        # 名字兜底（context-loader 猜 "reranker"、vega 猜 "embedding"），注册名一改就
-        # 全线 NameNotExist —— 见 #842 与 #296。
+        # With neither identifier, use the default reranker selected in model
+        # management, matching the large-model default path. Previously this
+        # returned 400 and forced consumers to guess hard-coded model names;
+        # renaming a registered model then caused NameNotExist everywhere
+        # (#842 and #296).
         is_default = not model_name and not model_id
         if is_default:
             cache_key = f"dip:model-api:small-model:default:{RERANKER_MODEL_TYPE}:list"
@@ -511,7 +511,7 @@ async def reranker_model_used(request, userId, language, role, func_module, priv
             cache_key = f"dip:model-api:small-model:{model_name}:list"
         else:
             cache_key = f"dip:model-api:small-model:{model_id}:list"
-        # 确保 redis_util 已初始化
+        # Lazily initialize the Redis client.
         global redis_util
         if redis_util is None:
             redis_util = await get_redis_util()
@@ -521,19 +521,19 @@ async def reranker_model_used(request, userId, language, role, func_module, priv
                 model_info = eval(res)
             except Exception as e:
                 StandLogger.warn(f"解析缓存数据失败: {str(e)}, key={cache_key}, value={res}")
-                # 缓存解析失败，回退到数据库查询
+                # Fall back to the database when cached data is invalid.
                 model_info = _load_small_model(is_default, RERANKER_MODEL_TYPE, model_name, model_id)
                 if len(model_info) == 0:
                     return JSONResponse(status_code=400, content=_model_missing_error(is_default))
-                # 重新设置缓存
+                # Refresh the cache.
                 await redis_util.set_str(key=cache_key, value=str(model_info),
                                          expire=_model_cache_ttl(is_default))
         else:
-            # 缓存不存在或非预期类型，从数据库获取
+            # Query the database when the cache is missing or malformed.
             model_info = _load_small_model(is_default, RERANKER_MODEL_TYPE, model_name, model_id)
             if len(model_info) == 0:
                 return JSONResponse(status_code=400, content=_model_missing_error(is_default))
-            # 设置缓存
+            # Cache the database result.
             await redis_util.set_str(key=cache_key, value=str(model_info),
                                      expire=_model_cache_ttl(is_default))
 

--- a/infra/mf-model-api/app/core/config.py
+++ b/infra/mf-model-api/app/core/config.py
@@ -10,21 +10,21 @@ import aiohttp
 class BaseConfig(object):
     DEBUGDEFAULT = False
     aiohttp_timeout = aiohttp.ClientTimeout(
-        total=1800,  # 总超时
-        sock_connect=30  # 保留连接超时
+        total=1800,  # Overall timeout
+        sock_connect=30  # Connection-establishment timeout
     )
     DIPHOSTDEFAULT = "10.4.134.253"
     PORTDEFAULT = 9898
-    # 结构化数据库相关
+    # Relational database defaults.
     RDSHOSTDEFAULT = DIPHOSTDEFAULT
     RDSPORTDEFAULT = 3330
     RDSDBNAMEDEFAULT = 'openbkn'
     RDSUSERDEFAULT = 'root'
     RDSPASSDEFAULT = 'password'
 
-    # redis数据库相关
+    # Redis defaults.
     REDISCLUSTERMODEDEFAULT = "master-slave"
-    # 哨兵
+    # Redis Sentinel.
     SENTINELMASTERDEFAULT = DIPHOSTDEFAULT
     SENTINELUSERDEFAULT = "root"
     SENTINELPASSDEFAULT = "password"
@@ -37,39 +37,39 @@ class BaseConfig(object):
     REDISWRITEPORTDEFAULT = 6379
     REDISWRITEUSERDEFAULT = 'root'
     REDISWRITEPASSDEFAULT = 'password'
-    # 主从
+    # Redis primary/replica mode.
     REDISHOSTDEFAULT = DIPHOSTDEFAULT
     REDISPORTDEFAULT = 6379
     REDISUSERDEFAULT = 'root'
     REDISPASSDEFAULT = 'password'
-    # 鉴权相关
+    # Authentication services.
     OAUTHADMINHOSTDEFAULT = DIPHOSTDEFAULT
     OAUTHADMINPORTDEFAULT = 4445
     USERMANAGEMENTPRIVATEHOSTDEFAULT = DIPHOSTDEFAULT
     USERMANAGEMENTPRIVATEPORTDEFAULT = 30980
 
-    # 资源权限相关
+    # Resource authorization service.
     AUTHORIZATIONPRIVATEHOSTDEFAULT = DIPHOSTDEFAULT
     AUTHORIZATIONPRIVATEPORTDEFAULT = 30920
 
-    # KAFKA相关
+    # Kafka defaults.
     KAFKAHOSTDEFAULT = DIPHOSTDEFAULT
     KAFKAPORTDEFAULT = 9097
     KAFKAUSERDEFAULT = "anyrobot"
     KAFKAPASSDEFAULT = "password"
-    # app相关
+    # Application settings.
     APP_PORT = int(os.getenv('PORT', PORTDEFAULT))
     DEBUG = True if os.getenv("DEBUG") else DEBUGDEFAULT
     LOG_LEVEL = logging.debug if DEBUG else logging.info
 
-    # 结构化数据库相关
+    # Relational database settings.
     RDSHOST = os.getenv("RDSHOST", RDSHOSTDEFAULT)
     RDSPORT = int(os.getenv("RDSPORT", RDSPORTDEFAULT))
     RDSDBNAME = os.getenv("RDSDBNAME", RDSDBNAMEDEFAULT)
     RDSUSER = os.getenv("RDSUSER", RDSUSERDEFAULT)
     RDSPASS = os.getenv("RDSPASS", RDSPASSDEFAULT)
 
-    # redis数据库相关
+    # Redis settings.
     REDISCLUSTERMODE = os.getenv("REDISCLUSTERMODE", REDISCLUSTERMODEDEFAULT)
     REDISHOST = os.getenv("REDISHOST", DIPHOSTDEFAULT)
     REDISPORT = os.getenv("REDISPORT", REDISPORTDEFAULT)
@@ -86,38 +86,39 @@ class BaseConfig(object):
     SENTINELMASTER = os.getenv("SENTINELMASTER", SENTINELMASTERDEFAULT)
     SENTINELUSER = os.getenv("SENTINELUSER", SENTINELUSERDEFAULT)
     SENTINELPASS = os.getenv("SENTINELPASS", SENTINELPASSDEFAULT)
-    # 登录鉴权相关
+    # Authentication settings.
     OAUTHADMINHOST = os.getenv("OAUTHADMINHOST", OAUTHADMINHOSTDEFAULT)
     OAUTHADMINPORT = os.getenv("OAUTHADMINPORT", OAUTHADMINPORTDEFAULT)
     USERMANAGEMENTPRIVATEHOST = os.getenv("USERMANAGEMENTPRIVATEHOST", USERMANAGEMENTPRIVATEHOSTDEFAULT)
     USERMANAGEMENTPRIVATEPORT = os.getenv("USERMANAGEMENTPRIVATEPORT", USERMANAGEMENTPRIVATEPORTDEFAULT)
-    # 资源权限相关
+    # Resource authorization settings.
     AUTHORIZATIONPRIVATEHOST = os.getenv("AUTHORIZATIONPRIVATEHOST", AUTHORIZATIONPRIVATEHOSTDEFAULT)
     AUTHORIZATIONPRIVATEPORT = os.getenv("AUTHORIZATIONPRIVATEPORT", AUTHORIZATIONPRIVATEPORTDEFAULT)
 
-    # KAFKA相关
+    # Kafka settings.
     KAFKAHOST = os.getenv('KAFKAHOST', KAFKAHOSTDEFAULT)
     KAFKAPORT = os.getenv('KAFKAPORT', KAFKAPORTDEFAULT)
     KAFKAUSER = os.getenv('KAFKAUSER', KAFKAUSERDEFAULT)
     KAFKAPASS = os.getenv('KAFKAPASS', KAFKAPASSDEFAULT)
 
-    # 计量传输后端：auto=有 KAFKAHOST 环境变量则 kafka，否则 redis
+    # Metering transport: auto selects Kafka when KAFKAHOST is set, otherwise Redis.
     METERINGBACKEND = os.getenv('METERING_BACKEND', 'auto')
     METERINGREDISDB = int(os.getenv('METERING_REDIS_DB', '1'))
     METERINGSTREAMMAXLEN = int(os.getenv('METERING_STREAM_MAXLEN', '100000'))
 
-    # 权限控制开关：true=开启完整鉴权与资源权限逻辑；false=关闭，所有接口放行，不过滤数据
+    # Authorization switch: true enables authentication and resource filtering.
     AUTH_ENABLED = os.getenv('AUTH_ENABLED', 'false').lower() == 'true'
-    # 权限关闭时写入审计日志所用的匿名用户ID占位符
+    # Anonymous identity used for audit correlation when authorization is disabled.
     ANONYMOUS_USER_ID = "anonymous-user"
 
 
 def resolve_metering_backend():
-    """解析计量传输后端：kafka | redis。
+    """Resolve the metering transport to Kafka or Redis.
 
-    auto 模式下以原始环境变量 KAFKAHOST 是否设置为准（KAFKAHOSTDEFAULT
-    是写死的开发默认值，永远非空，不能用解析后的配置判断）。
-    显式指定 kafka/redis 时不做探活，按配置执行。
+    In auto mode, use the presence of the original KAFKAHOST environment
+    variable. KAFKAHOSTDEFAULT is always populated and therefore cannot decide
+    whether Kafka was configured explicitly. An explicit backend is used
+    without a health probe.
     """
     backend = (BaseConfig.METERINGBACKEND or 'auto').strip().lower()
     if backend in ('kafka', 'redis'):

--- a/infra/mf-model-api/app/dao/llm_model_dao.py
+++ b/infra/mf-model-api/app/dao/llm_model_dao.py
@@ -4,7 +4,7 @@ from app.mydb.my_pymysql_pool import connect_execute_close_db, connect_execute_c
 
 
 class ModelDao():
-    # 通过模型id获取模型名称
+    # Resolve a model name by model ID.
     @connect_execute_close_db
     def get_model_name_by_id(self, model_id, connection, cursor):
         sql = "select f_model_name from t_llm_model where f_model_id={}".format(model_id)
@@ -72,7 +72,7 @@ class ModelDao():
 
     @connect_execute_commit_close_db
     def delete_model_by_id(self, model_ids, connection, cursor):
-        # 使用参数化查询
+        # Use a parameterized query.
         placeholders = ','.join(['%s'] * len(model_ids))
         sql = f"DELETE FROM t_llm_model WHERE f_model_id IN ({placeholders})"
         cursor.execute(sql, model_ids)
@@ -109,7 +109,7 @@ class ModelDao():
         res = cursor.fetchall()
         return res
 
-    # 检查模型是否已经绑定
+    # Check whether a model is already bound.
     @connect_execute_close_db
     def check_model_is_exist(self, model_id, connection, cursor):
         sql = """select count(f_model_id) from t_llm_model where f_model_id = %s"""
@@ -121,7 +121,7 @@ class ModelDao():
             return True
         return False
 
-    # 检查是否在同一用户下已有base和model都相同的模型，或者在非admin用户的情况下，admin用户是否已有base和model都相同的模型
+    # Check for an existing model with the same provider base, model, and API key.
     @connect_execute_close_db
     def check_model_unique(self, base, model, user_id, api_key, connection, cursor):
         sql = """select f_model_id, f_model_config from t_llm_model where f_model='{}'""".format(
@@ -176,7 +176,7 @@ class ModelDao():
         sql = f"""select f_create_time,f_model_id, f_average_first_token_time,f_generation_token_speed,f_total_token_speed 
         from t_model_monitor where  f_model_id = {model_id} order by f_create_time desc limit 36"""
 
-        # 使用executemany处理多行数据
+        # Keep the query execution path consistent with other monitor reads.
 
         cursor.execute(sql)
         res = cursor.fetchall()
@@ -187,14 +187,14 @@ class ModelDao():
         now = datetime.datetime.now()
         thirty_days_ago = now - datetime.timedelta(days=30)
 
-        # 使用参数化查询
+        # Use a parameterized query.
         sql = "DELETE FROM t_model_monitor WHERE f_create_time < %s"
 
         cursor.execute(sql, thirty_days_ago)
 
     @connect_execute_close_db
     def get_quota_by_user_and_model(self, user_id, model_id, connection, cursor):
-        # 获取当前日期的月初一号
+        # Start of the current month.
         now_month = datetime.datetime.now().replace(day=1).strftime('%Y-%m-%d')
         sql = f"""SELECT
                     uqc.f_input_tokens, COALESCE(monthly_usage.used_input_tokens,0) AS used_input_tokens,mqc.f_billing_type,
@@ -226,46 +226,46 @@ class ModelDao():
         cursor.execute(sql)
         res = cursor.fetchall()
 
-        # 如果没有配额信息，直接返回空结果
+        # Return immediately when no quota is configured.
         if not res:
             return res
 
-        # 定义单位换算列表，与model_used_audit_dao.py中保持一致
+        # Unit multipliers aligned with model_used_audit_dao.py.
         num_type_list = [0, 1000, 10000, 100000000, 1000000, 10000000]
 
-        # 获取配额配置信息
+        # Read quota configuration.
         quota_info = res[0]
         f_billing_type = quota_info["f_billing_type"]
         f_num_type = json.loads(quota_info["f_num_type"])
 
-        # 获取配置的总配额（未使用单位换算）
+        # Configured quota values before unit conversion.
         config_input_tokens = quota_info["f_input_tokens"]
         config_output_tokens = quota_info["f_output_tokens"]
 
-        # 获取已使用的配额
+        # Quota already consumed this month.
         used_input_tokens = quota_info["used_input_tokens"]
         used_output_tokens = quota_info["used_output_tokens"]
 
-        # 根据单位换算配置计算总配额（使用单位换算后的值）
+        # Apply the configured unit multipliers.
         total_input_tokens = int(config_input_tokens * num_type_list[f_num_type[0]])
         total_output_tokens = int(config_output_tokens * num_type_list[f_num_type[1]])
 
-        # 计算剩余额度
+        # Calculate remaining quota.
         if f_billing_type == 1:
-            # 分别计算输入和输出的剩余额度
+            # Track input and output quotas separately.
             remaining_input_tokens = total_input_tokens - used_input_tokens
             remaining_output_tokens = total_output_tokens - used_output_tokens
         else:
-            # 合并计算输入和输出的剩余额度，从输入配额中扣除
+            # Deduct combined usage from the shared input quota.
             total_used_tokens = used_input_tokens + used_output_tokens
             remaining_input_tokens = total_input_tokens - total_used_tokens
             remaining_output_tokens = True
 
-        # 将计算后的剩余额度添加到返回结果中
+        # Add calculated remaining values to the result.
         res[0]["remaining_input_tokens"] = remaining_input_tokens
         res[0]["remaining_output_tokens"] = remaining_output_tokens
 
-        # 保留原有的配额配置信息
+        # Preserve the converted configured totals.
         res[0]["total_input_tokens"] = total_input_tokens
         res[0]["total_output_tokens"] = total_output_tokens
 

--- a/infra/mf-model-api/app/dao/small_model_dao.py
+++ b/infra/mf-model-api/app/dao/small_model_dao.py
@@ -53,16 +53,16 @@ class SmallModelDao:
 
     @connect_execute_close_db
     def get_default_by_type(self, model_type, connection, cursor):
-        """取某 model_type(embedding/reranker) 下的系统默认小模型(f_default=1)。
+        """Return the default small model for an embedding or reranker type.
 
-        与大模型侧 llm_model_dao.get_data_from_default_model 对齐：调用方不指定模型时，
-        用管理员在模型管理里勾选的默认模型，而不是让各服务各自硬编码一个名字去猜
-        （见 #842、#296——猜名字的后果是注册名一改就全线 NameNotExist）。
+        This follows llm_model_dao.get_data_from_default_model: when no model is
+        specified, use the administrator-selected model instead of making each
+        consumer guess a hard-coded name (#842, #296).
 
-        管理端「清掉旧默认」与「置新默认」是两次独立提交（mf-model-manager 的
-        small_model_controller），中间失败会在库里留下同类型多行 f_default = 1。
-        按 f_update_time 倒序取第一行，至少让此后的解析结果是确定的——最后被置位
-        的那一行。
+        Clearing the old default and setting the new one are separate commits
+        in mf-model-manager. A partial failure can leave multiple rows with
+        f_default = 1, so ordering by f_update_time makes the newest selection
+        deterministic.
         """
         sql = """select f_model_id, f_model_name, f_model_type, f_model_config,f_adapter,f_adapter_code,f_embedding_dim
                     from t_small_model where f_default = 1 and f_model_type = %s

--- a/infra/mf-model-api/app/interfaces/dbaccess.py
+++ b/infra/mf-model-api/app/interfaces/dbaccess.py
@@ -4,50 +4,50 @@ from pydantic import StrictFloat, StrictStr, Field, StrictInt, conint,  conlist,
 model_quota_router = APIRouter()
 
 
-# 添加外部小模型信息
+# External small-model persistence record.
 class AddExternalSmallModelInfo(BaseModel):
-    model_id: StrictStr = Field(description="配置id", default="")
-    model_name: StrictStr = Field(description="模型名称", default="")
-    model_type: StrictStr = Field(description="模型类型", default="")
+    model_id: StrictStr = Field(description="Configuration ID", default="")
+    model_name: StrictStr = Field(description="Model name", default="")
+    model_type: StrictStr = Field(description="Model type", default="")
     model_config: dict
-    adapter: bool = Field(default=False, description="是否开启适配服务")
-    adapter_code: StrictStr = Field(default=None, description="适配代码")
-# 大模型配额信息
+    adapter: bool = Field(default=False, description="Whether to enable the adapter service")
+    adapter_code: StrictStr = Field(default=None, description="Adapter code")
+# Large-model quota record.
 class ModelQuotaInfo (BaseModel):
-    conf_id: StrictStr = Field(description="配置id")
-    model_id:StrictStr = Field(description="绑定的模型id")
-    billing_type: StrictInt = Field(description="计费类型 0:统一计费 1:input output单独计费")
-    input_tokens:StrictFloat = Field(description="输入tokens总额度")
-    output_tokens:StrictFloat= Field(description="输出tokens总额度")
-    currency_type:StrictInt = Field(description="计费单价货币类型,0:人名币 1:美元")
-    referprice_in:StrictFloat = Field(description="输入tokens计费单价")
-    referprice_out:StrictFloat = Field(description="输出tokens计费单价")
-    create_time:StrictStr= Field(description="创建时间")
-    update_time:StrictStr= Field(description="编辑时间")
+    conf_id: StrictStr = Field(description="Configuration ID")
+    model_id:StrictStr = Field(description="Bound model ID")
+    billing_type: StrictInt = Field(description="Billing type: 0 combined, 1 separate input/output")
+    input_tokens:StrictFloat = Field(description="Total input-token quota")
+    output_tokens:StrictFloat= Field(description="Total output-token quota")
+    currency_type:StrictInt = Field(description="Billing currency: 0 CNY, 1 USD")
+    referprice_in:StrictFloat = Field(description="Input-token unit price")
+    referprice_out:StrictFloat = Field(description="Output-token unit price")
+    create_time:StrictStr= Field(description="Creation time")
+    update_time:StrictStr= Field(description="Update time")
     num_type:conlist(conint(ge=0, le=5), min_items=2, max_items=2)
     price_type: conlist(constr(regex=r'^(thousand|million)$'), min_items=2, max_items=2)
 
-# 大模型用户配额信息
+# Per-user large-model quota record.
 class ModelUserQuotaInfo (BaseModel):
-    conf_id: StrictStr = Field(description="配置id",default="")
-    model_id:StrictStr = Field(description="绑定的模型id",default="")
-    user_id:StrictStr = Field(description="用户id",default="")
-    input_tokens:StrictFloat = Field(description="输入tokens总额度",default=0)
-    output_tokens:StrictFloat= Field(description="输出tokens总额度",default=0)
-    create_time:StrictStr= Field(description="创建时间",default="")
-    update_time:StrictStr= Field(description="编辑时间",default="")
+    conf_id: StrictStr = Field(description="Configuration ID",default="")
+    model_id:StrictStr = Field(description="Bound model ID",default="")
+    user_id:StrictStr = Field(description="User ID",default="")
+    input_tokens:StrictFloat = Field(description="Total input-token quota",default=0)
+    output_tokens:StrictFloat= Field(description="Total output-token quota",default=0)
+    create_time:StrictStr= Field(description="Creation time",default="")
+    update_time:StrictStr= Field(description="Update time",default="")
     num_type:conlist(conint(ge=0, le=3), min_items=2, max_items=2)
 
-# 大模型使用日志
+# Large-model usage audit record.
 class ModelUsedAuditInfo (BaseModel):
-    conf_id: StrictStr = Field(description="配置id",default="")
-    model_id:StrictStr = Field(description="模型id",default="")
-    user_id:StrictStr = Field(description="用户id",default="")
-    input_tokens:StrictInt = Field(description="使用tokens量",default=0)
-    output_tokens:StrictInt= Field(description="输出tokens量",default=0)
-    total_price:float = Field(description="消费金额",default=0.0)
-    create_time:StrictStr= Field(description="创建时间",default="")
-    currency_type:StrictInt = Field(description="计费单价货币类型,0:人名币 1:美元")
+    conf_id: StrictStr = Field(description="Configuration ID",default="")
+    model_id:StrictStr = Field(description="Model ID",default="")
+    user_id:StrictStr = Field(description="User ID",default="")
+    input_tokens:StrictInt = Field(description="Input tokens used",default=0)
+    output_tokens:StrictInt= Field(description="Output tokens used",default=0)
+    total_price:float = Field(description="Total charge",default=0.0)
+    create_time:StrictStr= Field(description="Creation time",default="")
+    currency_type:StrictInt = Field(description="Billing currency: 0 CNY, 1 USD")
     price_type: conlist(constr(regex=r'^(thousand|million)$'), min_items=2, max_items=2)
-    referprice_in: StrictFloat = Field(description="输入tokens计费单价", default=0.0)
-    referprice_out: StrictFloat = Field(description="输出tokens计费单价", default=0.0)
+    referprice_in: StrictFloat = Field(description="Input-token unit price", default=0.0)
+    referprice_out: StrictFloat = Field(description="Output-token unit price", default=0.0)

--- a/infra/mf-model-api/app/interfaces/logics.py
+++ b/infra/mf-model-api/app/interfaces/logics.py
@@ -13,15 +13,15 @@ class ModelConf(BaseModel):
 
 
 class AddModelUsedAudit(BaseModel):
-    model_id: StrictStr = Field(description="模型id", default="")
-    user_id: StrictStr = Field(description="用户id", default="")
-    input_tokens: StrictInt = Field(description="使用tokens量", default=0)
-    output_tokens: StrictInt = Field(description="输出tokens量", default=0)
-    resourece_type: StrictStr = Field(description="资源类型", default="unknown")
-    func_module: StrictStr = Field(description="调用模块", default="unknown")
-    total_time: StrictFloat = Field(description="调用总时间", default=0.0)
-    first_time: StrictFloat = Field(description="首字时间", default=0.0)
-    status: StrictStr = Field(description="调用状态", default="failed")
+    model_id: StrictStr = Field(description="Model ID", default="")
+    user_id: StrictStr = Field(description="User ID", default="")
+    input_tokens: StrictInt = Field(description="Input token count", default=0)
+    output_tokens: StrictInt = Field(description="Output token count", default=0)
+    resourece_type: StrictStr = Field(description="Resource type", default="unknown")
+    func_module: StrictStr = Field(description="Calling module", default="unknown")
+    total_time: StrictFloat = Field(description="Total invocation time", default=0.0)
+    first_time: StrictFloat = Field(description="Time to first token", default=0.0)
+    status: StrictStr = Field(description="Invocation status", default="failed")
 
 class ConfIdList(BaseModel):
     conf_id_list: List
@@ -33,16 +33,19 @@ class ModelIdList(BaseModel):
 
 class Message(BaseModel):
     role: StrictStr = Field(description="", regex=r'^(user|assistant|system|tool)$')
-    # OpenAI 规范：assistant 消息带 tool_calls 时 content 可为 null
+    # OpenAI permits null content for assistant messages that contain tool_calls.
     content: Optional[Union[StrictStr, List[Dict[str, Union[str, Dict[str, str]]]]]] = Field(default=None)
     tool_calls: List[dict] = Field(default=None)
     tool_call_id: StrictStr = Field(default=None)
 
     @validator('content', pre=True, always=True, check_fields=False)
     def coerce_null_content(cls, v):
-        """null → ""：下游拼接/计量（prompt_str += content、message + ""）不容忍 None。
-        在校验层归一，覆盖所有读取路径与所有路由；controller 里逐条改容易漏
-        （曾漏掉 messages[-1]["content"] 的快照读，直接 TypeError 成 500）。"""
+        """Normalize null to an empty string for downstream concatenation and metering.
+
+        Normalizing at validation covers every route and read path. A previous
+        controller-only fix missed the messages[-1]["content"] snapshot and
+        allowed a TypeError to surface as a 500 response.
+        """
         return "" if v is None else v
 
     @validator('content', check_fields=False)
@@ -101,9 +104,9 @@ class LLMUsedOpenAI(BaseModel):
     presence_penalty: confloat(ge=-2, le=2) = Field(default=0)
     frequency_penalty: confloat(ge=-2, le=2) = Field(default=0)
     max_tokens: conint(ge=10) = Field(default=1024)
-    # OpenAI 官方已弃用 max_tokens 改名 max_completion_tokens，新版 SDK / langchain-openai
-    # (>=0.2 的 ChatOpenAI) 只发新名——此前被 pydantic 静默丢弃，调用方设的输出上限从未
-    # 到达模型，恒落 max_tokens 默认 1024。兼容收新名，root_validator 里映射到 max_tokens。
+    # OpenAI deprecated max_tokens in favor of max_completion_tokens. New SDKs
+    # and langchain-openai >=0.2 send only the new field. Map it here so Pydantic
+    # does not discard the caller's output limit and silently use 1024.
     max_completion_tokens: Optional[conint(ge=10)] = Field(default=None)
     messages: List[Message]
     response_format: Dict = Field(default={})
@@ -117,8 +120,8 @@ class LLMUsedOpenAI(BaseModel):
 
     @root_validator(skip_on_failure=True)
     def map_max_completion_tokens(cls, values):
-        # 新名优先：显式传了 max_completion_tokens 就覆盖 max_tokens（含其默认值），
-        # 下游各 series 分支只读 max_tokens，一处映射全链生效。
+        # An explicit max_completion_tokens value takes precedence. Downstream
+        # providers read max_tokens, so one mapping covers every provider branch.
         mct = values.get("max_completion_tokens")
         if mct:
             values["max_tokens"] = mct
@@ -192,13 +195,13 @@ class PromptRunPara(BaseModel):
     type: constr()
 
 
-# 添加外部小模型请求体
+# Request body for adding an external small model.
 class AddExternalSmallModel(BaseModel):
-    model_name: StrictStr = Field(description="模型名称")
-    model_type: StrictStr = Field(description="模型类型", regex=r'^(reranker|embedding)$')
-    model_config: Optional[dict] = Field(default={}, description="第三方模型服务配置")
-    adapter: Optional[bool] = Field(default=False, description="是否开启适配服务")
-    adapter_code: Optional[StrictStr] = Field(default=None, description="适配代码")
+    model_name: StrictStr = Field(description="Model name")
+    model_type: StrictStr = Field(description="Model type", regex=r'^(reranker|embedding)$')
+    model_config: Optional[dict] = Field(default={}, description="Third-party model service configuration")
+    adapter: Optional[bool] = Field(default=False, description="Whether to enable the adapter service")
+    adapter_code: Optional[StrictStr] = Field(default=None, description="Adapter code")
 
     @root_validator
     def validate_mutually_exclusive_groups(cls, values):
@@ -207,9 +210,9 @@ class AddExternalSmallModel(BaseModel):
         adapter_code = values.get('adapter_code')
 
         if model_config and (adapter or adapter_code):
-            raise ValueError("model_config和adapter/adapter_code不能同时设置")
+            raise ValueError("model_config and adapter/adapter_code cannot be set together")
         if not model_config and not (adapter or adapter_code):
-            raise ValueError("必须设置model_config或adapter/adapter_code中的一组")
+            raise ValueError("set either model_config or adapter/adapter_code")
         return values
 
     @validator('model_config', pre=False)
@@ -228,12 +231,12 @@ class AddExternalSmallModel(BaseModel):
 
 
 class TestSmallModel(BaseModel):
-    model_id: Optional[StrictStr] = Field(None, description="配置id", min_length=19, max_length=19)
-    model_name: Optional[StrictStr] = Field(default="", description="模型名称")
-    model_type: Optional[StrictStr] = Field(default="", description="模型类型", regex=r'^(reranker|embedding)$')
-    model_config: Optional[dict] = Field(default={}, description="第三方模型服务配置")
-    adapter: Optional[bool] = Field(default=False, description="是否开启适配服务")
-    adapter_code: Optional[StrictStr] = Field(default=None, description="适配代码")
+    model_id: Optional[StrictStr] = Field(None, description="Configuration ID", min_length=19, max_length=19)
+    model_name: Optional[StrictStr] = Field(default="", description="Model name")
+    model_type: Optional[StrictStr] = Field(default="", description="Model type", regex=r'^(reranker|embedding)$')
+    model_config: Optional[dict] = Field(default={}, description="Third-party model service configuration")
+    adapter: Optional[bool] = Field(default=False, description="Whether to enable the adapter service")
+    adapter_code: Optional[StrictStr] = Field(default=None, description="Adapter code")
 
     @root_validator
     def check_fields(cls, values):
@@ -243,16 +246,16 @@ class TestSmallModel(BaseModel):
             adapter = values.get('adapter', False)
             adapter_code = values.get('adapter_code')
             if model_config and (adapter or adapter_code):
-                raise ValueError("model_config和adapter/adapter_code不能同时设置")
+                raise ValueError("model_config and adapter/adapter_code cannot be set together")
             if not model_config and not (adapter or adapter_code):
-                raise ValueError("必须设置model_config或adapter/adapter_code中的一组")
-            # 如果没有提供model_id，则必须提供其他三个字段
+                raise ValueError("set either model_config or adapter/adapter_code")
+            # Without model_id, the identifying model fields are required.
             required_fields = ['model_name', 'model_type']
             for field in required_fields:
                 if values.get(field) is None:
                     raise RequestValidationError([{"loc": ('body', field), "type": "value_error.missing"}])
         else:
-            # 如果提供了model_id，则其他字段可以为None
+            # With model_id, the other model fields may be omitted.
             pass
         return values
 
@@ -266,12 +269,12 @@ class TestSmallModel(BaseModel):
 
 
 class EditExternalSmallModel(BaseModel):
-    model_id: StrictStr = Field(description="配置id", min_length=19, max_length=19)
-    model_name: StrictStr = Field(description="模型名称")
-    model_type: StrictStr = Field(description="模型类型", regex=r'^(reranker|embedding)$')
-    model_config: Optional[dict] = Field(default={}, description="第三方模型服务配置")
-    adapter: Optional[bool] = Field(default=False, description="是否开启适配服务")
-    adapter_code: Optional[StrictStr] = Field(default=None, description="适配代码")
+    model_id: StrictStr = Field(description="Configuration ID", min_length=19, max_length=19)
+    model_name: StrictStr = Field(description="Model name")
+    model_type: StrictStr = Field(description="Model type", regex=r'^(reranker|embedding)$')
+    model_config: Optional[dict] = Field(default={}, description="Third-party model service configuration")
+    adapter: Optional[bool] = Field(default=False, description="Whether to enable the adapter service")
+    adapter_code: Optional[StrictStr] = Field(default=None, description="Adapter code")
 
     @root_validator
     def validate_mutually_exclusive_groups(cls, values):
@@ -280,9 +283,9 @@ class EditExternalSmallModel(BaseModel):
         adapter_code = values.get('adapter_code')
 
         if model_config and (adapter or adapter_code):
-            raise ValueError("model_config和adapter/adapter_code不能同时设置")
+            raise ValueError("model_config and adapter/adapter_code cannot be set together")
         if not model_config and not (adapter or adapter_code):
-            raise ValueError("必须设置model_config或adapter/adapter_code中的一组")
+            raise ValueError("set either model_config or adapter/adapter_code")
         return values
 
     @validator('model_config', pre=False)
@@ -295,16 +298,16 @@ class EditExternalSmallModel(BaseModel):
 
 
 class UsedReranker(BaseModel):
-    model: Optional[StrictStr] = Field(description="模型名称")
-    query: StrictStr = Field(description="需要排序的问题")
-    documents: list = Field(description="排序的内容列表")
-    model_id: Optional[StrictStr] = Field(description="模型id", default="")
+    model: Optional[StrictStr] = Field(description="Model name")
+    query: StrictStr = Field(description="Query to rank against")
+    documents: list = Field(description="Documents to rank")
+    model_id: Optional[StrictStr] = Field(description="Model ID", default="")
 
 
 class UsedEmbedding(BaseModel):
-    model: Optional[StrictStr] = Field(description="模型名称")
-    input: list = Field(description="向量化的内容列表")
-    model_id: Optional[StrictStr] = Field(description="模型id", default="")
+    model: Optional[StrictStr] = Field(description="Model name")
+    input: list = Field(description="Content to embed")
+    model_id: Optional[StrictStr] = Field(description="Model ID", default="")
 
 class AuthInfo(BaseModel):
     userid: Optional[str]

--- a/infra/mf-model-api/app/mydb/ConnectUtil.py
+++ b/infra/mf-model-api/app/mydb/ConnectUtil.py
@@ -62,7 +62,7 @@ class RedisClient(object):
                 if model == "read":
                     redis_con = await sentinel.slave_for(self.redis_master_name, username=self.redis_user,
                                                          password=self.redis_passwd, db=db)
-                # 验证连接
+                # Validate the connection.
                 await redis_con.ping()
                 return redis_con
             except Exception as e:
@@ -78,19 +78,19 @@ class RedisClient(object):
                     pool = redis_async.ConnectionPool(host=self.redis_write_ip, port=self.redis_write_port, db=db,
                                                       password=self.redis_write_passwd)
                     redis_con = redis_async.StrictRedis(connection_pool=pool)
-                # 验证连接
+                # Validate the connection.
                 await redis_con.ping()
                 return redis_con
             except Exception as e:
                 StandLogger.error(f"Redis连接失败 - master-slave模式: host={self.redis_ip}, port={self.redis_port}, error={str(e)}")
                 raise Exception(f"connect redis error:{str(e)}")
         else:
-            # standalone 单机模式
+            # Standalone mode.
             try:
                 pool = redis_async.ConnectionPool(host=self.redis_ip, port=self.redis_port, db=db,
                                                   password=self.redis_passwd, username=self.redis_user if self.redis_user else None)
                 redis_con = redis_async.StrictRedis(connection_pool=pool)
-                # 验证连接
+                # Validate the connection.
                 await redis_con.ping()
                 return redis_con
             except Exception as e:
@@ -112,7 +112,7 @@ class RedisClient(object):
                 if model == "read":
                     redis_con = await sentinel.slave_for(self.redis_master_name, username=self.redis_user,
                                                          password=self.redis_passwd, db=db)
-                # 验证连接
+                # Validate the connection.
                 await redis_con.ping()
                 return redis_con
             except Exception as e:
@@ -128,19 +128,19 @@ class RedisClient(object):
                     pool = redis_async.ConnectionPool(host=self.redis_write_ip, port=self.redis_write_port, db=db,
                                                       password=self.redis_write_passwd)
                     redis_con = redis_async.StrictRedis(connection_pool=pool)
-                # 验证连接
+                # Validate the connection.
                 await redis_con.ping()
                 return redis_con
             except Exception as e:
                 StandLogger.error(f"Redis连接失败 - {model}模式: host={self.redis_ip}, port={self.redis_port}, error={str(e)}")
                 raise Exception(f"connect redis error:{str(e)}")
         else:
-            # standalone 单机模式
+            # Standalone mode.
             try:
                 pool = redis_async.ConnectionPool(host=self.redis_ip, port=self.redis_port, db=db,
                                                   password=self.redis_passwd, username=self.redis_user if self.redis_user else None)
                 redis_con = redis_async.StrictRedis(connection_pool=pool)
-                # 验证连接
+                # Validate the connection.
                 await redis_con.ping()
                 return redis_con
             except Exception as e:
@@ -165,7 +165,7 @@ class ConnectUtil:
                 await instance._init_connection_pools()
                 if instance.read_conn is None or instance.write_conn is None:
                     StandLogger.error(f"Redis连接创建失败: read_conn={instance.read_conn}, write_conn={instance.write_conn}")
-                    raise Exception("Redis连接创建失败")
+                    raise Exception("Redis connection creation failed")
                 instance._initialized = True
                 StandLogger.info(f"Redis连接池创建成功: read_conn={instance.read_conn}, write_conn={instance.write_conn}")
                 cls._instance = instance
@@ -179,21 +179,21 @@ class ConnectUtil:
         self._last_health_check = 0
 
     async def _init_connection_pools(self):
-        """初始化高性能Redis连接池"""
+        """Initialize the Redis connection pools."""
         try:
             redis_client = self.__class__._redis_client
             
             if redis_client.redis_cluster_mode == "sentinel":
-                # 哨兵模式：使用哨兵连接
+                # Use Sentinel-managed connections.
                 await self._init_sentinel_connection_pools(redis_client)
             elif redis_client.redis_cluster_mode == "master-slave":
-                # 主从模式：使用主从连接
+                # Use separate primary and replica connections.
                 await self._init_master_slave_connection_pools(redis_client)
             else:
-                # 默认模式：使用单机连接
+                # Use a standalone connection.
                 await self._init_default_connection_pools(redis_client)
             
-            # 预热连接池 - 建立初始连接
+            # Warm the pools by establishing initial connections.
             await self._warmup_connections()
             
             StandLogger.info("Redis高性能连接池初始化成功")
@@ -203,9 +203,9 @@ class ConnectUtil:
             raise e
 
     async def _init_sentinel_connection_pools(self, redis_client):
-        """初始化哨兵模式的连接池"""
+        """Initialize Sentinel-mode connections."""
         try:
-            # 创建哨兵连接
+            # Create the Sentinel client.
             sentinel = Sentinel_async([(redis_client.redis_ip, redis_client.redis_port)], 
                                     password=redis_client.redis_sentinel_password,
                                     sentinel_kwargs={
@@ -213,7 +213,7 @@ class ConnectUtil:
                                         "username": redis_client.redis_sentinel_user
                                     })
             
-            # 获取主节点连接（写操作）
+            # Resolve the primary for writes.
             master_redis = await sentinel.master_for(
                 redis_client.redis_master_name, 
                 username=redis_client.redis_user,
@@ -228,7 +228,7 @@ class ConnectUtil:
                 decode_responses=False
             )
             
-            # 获取从节点连接（读操作）
+            # Resolve a replica for reads.
             slave_redis = await sentinel.slave_for(
                 redis_client.redis_master_name, 
                 username=redis_client.redis_user,
@@ -253,39 +253,39 @@ class ConnectUtil:
             raise e
 
     async def _init_master_slave_connection_pools(self, redis_client):
-        """初始化主从模式的连接池"""
+        """Initialize primary/replica connection pools."""
         try:
-            # 创建读连接池 - 高性能配置
+            # Create the read pool.
             self.__class__._read_pool = redis_async.ConnectionPool(
                 host=redis_client.redis_read_ip,
                 port=redis_client.redis_read_port,
                 db=self.db,
                 password=redis_client.redis_read_passwd,
-                max_connections=50,  # 最大连接数
+                max_connections=50,  # Maximum connections.
                 retry_on_timeout=True,
                 socket_keepalive=True,
-                socket_connect_timeout=3,  # 减少连接超时时间
-                socket_timeout=2,  # 减少操作超时时间
-                health_check_interval=30,  # 健康检查间隔
-                decode_responses=False  # 保持二进制格式，提高性能
+                socket_connect_timeout=3,  # Connection timeout.
+                socket_timeout=2,  # Operation timeout.
+                health_check_interval=30,  # Health-check interval.
+                decode_responses=False  # Retain bytes to avoid decode overhead.
             )
             
-            # 创建写连接池 - 高性能配置
+            # Create the write pool.
             self.__class__._write_pool = redis_async.ConnectionPool(
                 host=redis_client.redis_write_ip,
                 port=redis_client.redis_write_port,
                 db=self.db,
                 password=redis_client.redis_write_passwd,
-                max_connections=30,  # 写操作连接数可以少一些
+                max_connections=30,  # Writes need fewer connections.
                 retry_on_timeout=True,
                 socket_keepalive=True,
-                socket_connect_timeout=3,  # 减少连接超时时间
-                socket_timeout=2,  # 减少操作超时时间
+                socket_connect_timeout=3,  # Connection timeout.
+                socket_timeout=2,  # Operation timeout.
                 health_check_interval=30,
                 decode_responses=False
             )
             
-            # 创建Redis客户端实例
+            # Create Redis client instances.
             self.read_conn = redis_async.StrictRedis(connection_pool=self.__class__._read_pool)
             self.write_conn = redis_async.StrictRedis(connection_pool=self.__class__._write_pool)
             
@@ -296,24 +296,24 @@ class ConnectUtil:
             raise e
 
     async def _init_default_connection_pools(self, redis_client):
-        """初始化默认模式的连接池（单机模式）"""
+        """Initialize a standalone Redis connection pool."""
         try:
-            # 创建连接池 - 高性能配置
+            # Create the standalone pool.
             self.__class__._read_pool = redis_async.ConnectionPool(
                 host=redis_client.redis_ip,
                 port=redis_client.redis_port,
                 db=self.db,
                 password=redis_client.redis_passwd,
-                max_connections=50,  # 最大连接数
+                max_connections=50,  # Maximum connections.
                 retry_on_timeout=True,
                 socket_keepalive=True,
-                socket_connect_timeout=3,  # 减少连接超时时间
-                socket_timeout=2,  # 减少操作超时时间
-                health_check_interval=30,  # 健康检查间隔
-                decode_responses=False  # 保持二进制格式，提高性能
+                socket_connect_timeout=3,  # Connection timeout.
+                socket_timeout=2,  # Operation timeout.
+                health_check_interval=30,  # Health-check interval.
+                decode_responses=False  # Retain bytes to avoid decode overhead.
             )
             
-            # 创建Redis客户端实例（读写使用同一个连接池）
+            # Use the same client and pool for reads and writes.
             self.read_conn = redis_async.StrictRedis(connection_pool=self.__class__._read_pool)
             self.write_conn = redis_async.StrictRedis(connection_pool=self.__class__._read_pool)
             
@@ -324,16 +324,16 @@ class ConnectUtil:
             raise e
 
     async def _warmup_connections(self):
-        """预热连接池，建立初始连接"""
+        """Warm the pool by establishing initial connections."""
         try:
             redis_client = self.__class__._redis_client
             
             if redis_client.redis_cluster_mode == "sentinel":
-                # 哨兵模式：直接ping连接
+                # Ping Sentinel-managed clients directly.
                 await self.read_conn.ping()
                 await self.write_conn.ping()
             else:
-                # 主从模式和默认模式：预热连接池
+                # Warm primary/replica and standalone pools.
                 if self.__class__._read_pool:
                     for _ in range(min(5, self.__class__._read_pool.max_connections)):
                         await self.read_conn.ping()
@@ -347,9 +347,9 @@ class ConnectUtil:
             StandLogger.warn(f"Redis连接池预热失败: {str(e)}")
 
     async def _check_connection_health(self):
-        """检查连接健康状态"""
+        """Check connection health."""
         current_time = time.time()
-        # 每30秒检查一次连接健康状态
+        # Check at most once every 30 seconds.
         if current_time - self._last_health_check > 30:
             try:
                 await self.read_conn.ping()
@@ -359,11 +359,11 @@ class ConnectUtil:
             except Exception as e:
                 StandLogger.warn(f"Redis连接健康检查失败: {str(e)}")
                 self._connection_healthy = False
-                # 不立即重连，让业务逻辑决定是否重连
+                # Let the calling operation decide whether to reconnect.
         return self._connection_healthy
 
     async def _reconnect(self):
-        """重新建立redis连接 - 仅在必要时调用"""
+        """Re-establish Redis connections when required."""
         if self._connection_healthy:
             return
             
@@ -372,12 +372,12 @@ class ConnectUtil:
         old_write_conn = self.write_conn
         
         try:
-            # 重新初始化连接池
+            # Initialize replacement pools.
             await self._init_connection_pools()
             self._connection_healthy = True
             StandLogger.info("Redis连接重建成功")
             
-            # 关闭旧连接
+            # Close old clients after the replacement succeeds.
             if old_read_conn:
                 try:
                     await old_read_conn.close()
@@ -391,13 +391,13 @@ class ConnectUtil:
                     
         except Exception as e:
             StandLogger.error(f"Redis重连失败: {str(e)}")
-            # 如果重连失败，恢复旧连接
+            # Restore the old clients if reconnection fails.
             self.read_conn = old_read_conn
             self.write_conn = old_write_conn
             raise e
 
     async def close(self):
-        """关闭Redis连接"""
+        """Close Redis connections."""
         if self.read_conn:
             await self.read_conn.close()
         if self.write_conn:
@@ -419,7 +419,7 @@ class ConnectUtil:
                     raise e
 
     async def set_if_absent(self, key: str, value: Union[str, int, float] = 1, expire: int | None = None) -> bool:
-        """SETNX 语义，已存在返回 False；设置成功可选过期时间"""
+        """Set a key with SETNX semantics and an optional expiration."""
         for i in range(3):
             try:
                 # Redis-py: set(name, value, ex=None, px=None, nx=False, xx=False)
@@ -434,7 +434,7 @@ class ConnectUtil:
                     raise e
 
     async def _set_expire(self, key: str, expire: int = None) -> bool:
-        """内部方法：设置key过期时间"""
+        """Set a key expiration internally."""
         if expire is not None:
             return await self.write_conn.expire(key, expire)
         return True
@@ -510,16 +510,16 @@ class ConnectUtil:
                     raise e
 
     async def get_str(self, key: str) -> Union[str, None]:
-        """高性能Redis GET操作，带智能重试和连接健康检查"""
-        # 先检查连接健康状态
+        """Read a Redis value with retries and connection health checks."""
+        # Check connection health before reading.
         await self._check_connection_health()
         
         for i in range(3):
             try:
-                # 使用更短的超时时间，避免长时间等待
+                # Use a short deadline to avoid blocking callers.
                 result = await asyncio.wait_for(
                     self.read_conn.get(key), 
-                    timeout=2.0  # 2秒超时
+                    timeout=2.0  # Two-second timeout.
                 )
                 return result
             except asyncio.TimeoutError:
@@ -530,13 +530,13 @@ class ConnectUtil:
                     await self._reconnect()
                 else:
                     StandLogger.error(f"Redis GET操作最终超时: key={key}")
-                    raise Exception(f"Redis GET操作超时: {key}")
+                    raise Exception(f"Redis GET operation timed out: {key}")
             except Exception as e:
                 StandLogger.warn(f"Redis GET操作失败 (尝试 {i+1}/3): {str(e)}")
                 if i < 2:
-                    # 标记连接不健康
+                    # Mark the connection unhealthy.
                     self._connection_healthy = False
-                    await asyncio.sleep(0.1 * (i + 1))  # 递增延迟
+                    await asyncio.sleep(0.1 * (i + 1))  # Incremental backoff.
                     await self._reconnect()
                 else:
                     StandLogger.error(f"Redis GET操作最终失败: key={key}, error={str(e)}")
@@ -544,21 +544,21 @@ class ConnectUtil:
 
     async def delete_str(self, key: str | list[str]) -> bool:
         """
-        删除一个或多个 Redis key
-        :param key: 单个 key 或 key 列表
-        :return: 是否删除成功
+        Delete one or more Redis keys.
+        :param key: one key or a list of keys
+        :return: whether any key was deleted
         """
         if isinstance(key, str):
             key = [key]
         for i in range(3):
             try:
-                # 使用 pipeline 批量删除
+                # Delete multiple keys through a pipeline.
                 async with self.write_conn.pipeline(transaction=True) as pipe:
                     for k in key:
                         if await self.exists(k):
                             pipe.delete(k)
                     results = await pipe.execute()
-                # 只要有一个 key 删除成功就返回 True
+                # Report success when at least one key was deleted.
                 return any(result > 0 for result in results)
             except Exception as e:
                 if i < 2:
@@ -619,7 +619,7 @@ class ConnectUtil:
 
 async def get_redis_util():
     """
-    获取已初始化的redis_util实例
+    Return the initialized Redis utility singleton.
     """
     global redis_util
     if redis_util is None:
@@ -639,22 +639,22 @@ class MyKafkaClient(object):
         self.topic_name = topic_name
         self.admin_client = None
         
-        # 异步发送相关属性
-        self._message_queue = Queue(maxsize=10000)  # 消息队列，限制大小防止内存溢出
+        # Asynchronous producer state.
+        self._message_queue = Queue(maxsize=10000)  # Bound memory use.
         self._producer_thread = None
         self._shutdown_event = threading.Event()
         self._thread_pool = concurrent.futures.ThreadPoolExecutor(max_workers=2, thread_name_prefix="kafka-producer")
         self._is_async_running = False
         
-        # 初始化时检查并创建topic
+        # Ensure the topic exists during initialization.
         self._init_admin_client()
         self._check_and_create_topic()
         
-        # 启动异步生产者线程
+        # Start the asynchronous producer thread.
         self._start_async_producer()
 
     def _init_admin_client(self):
-        """初始化AdminClient"""
+        """Initialize the Kafka AdminClient."""
         self.admin_client = AdminClient({
             'bootstrap.servers': '{}:{}'.format(base_config.KAFKAHOST, base_config.KAFKAPORT),
             'security.protocol': 'sasl_plaintext',
@@ -665,25 +665,25 @@ class MyKafkaClient(object):
         })
 
     def _check_and_create_topic(self):
-        """检查topic是否存在，如果不存在则创建"""
+        """Create the Kafka topic when it does not exist."""
         try:
-            # 获取集群元数据
+            # Read cluster metadata.
             metadata = self.admin_client.list_topics(timeout=10)
             
-            # 检查topic是否存在
+            # Check whether the topic already exists.
             if self.topic_name not in metadata.topics:
-                # 创建topic
+                # Define the topic.
                 new_topic = NewTopic(
                     topic=self.topic_name,
-                    num_partitions=3,  # 设置分区数为3
-                    replication_factor=1  # 设置副本因子为1
+                    num_partitions=3,  # Three partitions.
+                    replication_factor=1  # One replica.
                 )
                 
-                # 创建topic
+                # Submit topic creation.
                 fs = self.admin_client.create_topics([new_topic])
                 for topic, f in fs.items():
                     try:
-                        f.result()  # 等待创建完成
+                        f.result()  # Wait for completion.
                         StandLogger.info(f"Topic {topic} created successfully")
                     except Exception as e:
                         StandLogger.error(f"Failed to create topic {topic}: {e}")
@@ -693,7 +693,7 @@ class MyKafkaClient(object):
             StandLogger.error(f"Error checking/creating topic: {e}")
 
     def connect_producer(self):
-        """连接生产者"""
+        """Connect the Kafka producer."""
         if self.producer is None:
             self.producer = Producer({
                 'bootstrap.servers': '{}:{}'.format(base_config.KAFKAHOST, base_config.KAFKAPORT),
@@ -702,15 +702,15 @@ class MyKafkaClient(object):
                 'sasl.mechanism': 'PLAIN',
                 'sasl.username': base_config.KAFKAUSER,
                 'sasl.password': base_config.KAFKAPASS,
-                'acks': 1,  # 确认leader分区收到消息
-                'queue.buffering.max.messages': 100000,  # 增加队列缓冲区大小
-                'queue.buffering.max.kbytes': 102400,   # 增加队列缓冲区大小(KB)
-                'batch.num.messages': 1000,             # 批量发送的消息数量
-                'linger.ms': 5                          # 批量发送等待时间(ms)
+                'acks': 1,  # Confirm receipt by the leader partition.
+                'queue.buffering.max.messages': 100000,  # Buffered message limit.
+                'queue.buffering.max.kbytes': 102400,   # Buffer size in KiB.
+                'batch.num.messages': 1000,             # Messages per batch.
+                'linger.ms': 5                          # Batch delay in milliseconds.
             })
 
     def connect_consumer(self, group_id='quota_data_group'):
-        """连接消费者"""
+        """Connect the Kafka consumer."""
         if self.consumer is None:
             self.consumer = Consumer({
                 'bootstrap.servers': '{}:{}'.format(base_config.KAFKAHOST, base_config.KAFKAPORT),
@@ -720,15 +720,15 @@ class MyKafkaClient(object):
                 'sasl.username': base_config.KAFKAUSER,
                 'sasl.password': base_config.KAFKAPASS,
                 'group.id': group_id,
-                'auto.offset.reset': 'latest',  # 改为latest或使用一个新的消费者组ID
+                'auto.offset.reset': 'latest',  # Start at the latest offset for a new group.
                 'enable.auto.commit': True,
                 'auto.commit.interval.ms': 1000
             })
-            # 订阅topic
+            # Subscribe to the topic.
             self.consumer.subscribe([self.topic_name])
 
     def _start_async_producer(self):
-        """启动异步生产者线程"""
+        """Start the asynchronous producer thread."""
         if not self._is_async_running:
             self._producer_thread = threading.Thread(
                 target=self._async_producer_worker,
@@ -740,19 +740,19 @@ class MyKafkaClient(object):
             StandLogger.info("Kafka异步生产者线程已启动")
 
     def _async_producer_worker(self):
-        """异步生产者工作线程"""
-        # 在独立线程中初始化producer
+        """Run the asynchronous producer worker."""
+        # Initialize the producer in its worker thread.
         self.connect_producer()
         
         while not self._shutdown_event.is_set():
             try:
-                # 非阻塞获取消息，超时1秒
+                # Poll the queue with a one-second timeout.
                 try:
                     message_data = self._message_queue.get(timeout=1.0)
                 except Empty:
                     continue
                 
-                # 发送消息
+                # Send the message.
                 self.producer.produce(
                     self.topic_name,
                     key=message_data.get('key'),
@@ -760,27 +760,27 @@ class MyKafkaClient(object):
                     callback=message_data.get('callback', self._delivery_callback)
                 )
                 
-                # 批量轮询，提高效率
+                # Poll delivery callbacks in batches.
                 self.producer.poll(0.1)
                 
-                # 标记任务完成
+                # Mark the queued task complete.
                 self._message_queue.task_done()
                 
             except Exception as e:
                 StandLogger.error(f"异步生产者工作线程错误: {e}")
-                time.sleep(0.1)  # 错误时短暂休眠
+                time.sleep(0.1)  # Brief delay after an error.
 
     def produce_async(self, value, key=None, callback=None):
-        """真正异步非阻塞发送消息到Kafka"""
+        """Queue a Kafka message without blocking."""
         try:
-            # 将消息放入队列，非阻塞
+            # Prepare the queued message.
             message_data = {
                 'value': value,
                 'key': key,
                 'callback': callback
             }
             
-            # 非阻塞放入队列，如果队列满了则记录警告但不阻塞
+            # Drop and warn rather than block when the queue is full.
             try:
                 self._message_queue.put_nowait(message_data)
             except:
@@ -794,12 +794,12 @@ class MyKafkaClient(object):
             return False
 
     def produce_async_with_future(self, value, key=None):
-        """异步发送消息并返回Future对象，可以获取发送结果"""
+        """Queue a message and return a Future for its delivery result."""
         future = concurrent.futures.Future()
         
         def delivery_callback(err, msg):
             if err:
-                future.set_exception(Exception(f"Kafka消息发送失败: {err}"))
+                future.set_exception(Exception(f"Kafka message delivery failed: {err}"))
             else:
                 future.set_result({
                     'topic': msg.topic(),
@@ -809,30 +809,30 @@ class MyKafkaClient(object):
         
         success = self.produce_async(value, key, delivery_callback)
         if not success:
-            future.set_exception(Exception("消息队列已满，无法发送"))
+            future.set_exception(Exception("Kafka message queue is full"))
         
         return future
 
     def _delivery_callback(self, err, msg):
-        """消息发送回调函数"""
+        """Handle Kafka delivery completion."""
         if err:
             StandLogger.error(f'Message delivery failed: {err}')
         else:
             StandLogger.info(f'Message delivered to {msg.topic()} [{msg.partition()}] at offset {msg.offset()}')
 
     def flush_producer(self, timeout=10):
-        """刷新生产者队列，确保所有消息都被发送"""
+        """Flush the producer queue."""
         if self.producer is not None:
             return self.producer.flush(timeout)
         return 0
 
     def consume_messages(self, timeout=1.0):
-        """从Kafka消费消息"""
+        """Consume one message from Kafka."""
         if self.consumer is None:
             self.connect_consumer()
         
         try:
-            # 轮询消息
+            # Poll for one message.
             msg = self.consumer.poll(timeout)
             
             if msg is None:
@@ -842,7 +842,7 @@ class MyKafkaClient(object):
                 StandLogger.error(f'Consumer error: {msg.error()}')
                 return None
             
-            # 返回消息内容
+            # Return the decoded message content.
             return {
                 'key': msg.key(),
                 'value': msg.value(),
@@ -855,7 +855,7 @@ class MyKafkaClient(object):
             return None
 
     def consume_batch(self, num_messages: int = 500, timeout: float = 1.0):
-        """批量消费消息，返回统一结构的列表"""
+        """Consume a batch and return normalized records."""
         if self.consumer is None:
             self.connect_consumer()
         try:
@@ -880,34 +880,34 @@ class MyKafkaClient(object):
             return []
 
     def close_producer(self):
-        """关闭生产者连接"""
+        """Close the producer connection."""
         if self.producer is not None:
             self.flush_producer()
             self.producer = None
 
     def close_consumer(self):
-        """关闭消费者连接"""
+        """Close the consumer connection."""
         if self.consumer is not None:
             self.consumer.close()
             self.consumer = None
 
     def shutdown_async_producer(self):
-        """优雅关闭异步生产者"""
+        """Shut down the asynchronous producer gracefully."""
         if self._is_async_running:
             StandLogger.info("正在关闭Kafka异步生产者...")
             self._shutdown_event.set()
             
-            # 等待队列中的消息处理完成
+            # Wait for queued messages to finish.
             self._message_queue.join()
             
-            # 等待线程结束
+            # Wait for the worker thread to stop.
             if self._producer_thread and self._producer_thread.is_alive():
                 self._producer_thread.join(timeout=5)
             
-            # 关闭线程池
+            # Shut down the thread pool.
             self._thread_pool.shutdown(wait=True)
             
-            # 最后刷新producer
+            # Flush the producer once more.
             if self.producer is not None:
                 self.flush_producer()
                 self.producer = None
@@ -916,7 +916,7 @@ class MyKafkaClient(object):
             StandLogger.info("Kafka异步生产者已关闭")
 
     def get_queue_status(self):
-        """获取队列状态信息"""
+        """Return producer queue status."""
         return {
             'queue_size': self._message_queue.qsize(),
             'queue_maxsize': self._message_queue.maxsize,
@@ -925,9 +925,9 @@ class MyKafkaClient(object):
         }
 
     def get_redis_pool_status(self):
-        """获取Redis连接池状态信息"""
+        """Return Redis pool status."""
         if not self._instance:
-            return {'error': 'Redis连接池未初始化'}
+            return {'error': 'Redis connection pool is not initialized'}
         
         status = {
             'connection_healthy': self._instance._connection_healthy,
@@ -954,11 +954,11 @@ class MyKafkaClient(object):
         
         return status
 
-# 全局redis_util实例
+# Process-wide Redis utility instance.
 redis_util = None
 
-# 计量后端为 kafka 时才实例化（MyKafkaClient 构造时会连 broker 建 topic，
-# 无 Kafka 环境下会阻塞 10s 并刷错误日志）；redis 后端见 app/utils/metering_producer.py
+# Instantiate Kafka only for the Kafka metering backend. Its constructor connects
+# to a broker and creates the topic; the Redis path lives in metering_producer.py.
 if resolve_metering_backend() == 'kafka':
     kafka_client = MyKafkaClient()
 else:

--- a/infra/mf-model-api/app/mydb/my_pymysql_pool.py
+++ b/infra/mf-model-api/app/mydb/my_pymysql_pool.py
@@ -6,8 +6,8 @@ from app.mydb.pymysql_pool import PymysqlPool
 
 
 def connect_execute_commit_close_db(func):
-    # functools.wraps 保留被包函数的名字/文档，并留下 __wrapped__——没有它，dao 层
-    # 的 SQL 就只能连着真库才验得到，单测里拿不到未包装的函数体。
+    # functools.wraps preserves function metadata and __wrapped__. DAO SQL tests
+    # use the unwrapped body without connecting to a real database.
     @functools.wraps(func)
     def wrapper(*args, **kwargs):
         pymysql_pool = PymysqlPool.get_pool()

--- a/infra/mf-model-api/app/mydb/pymysql_pool.py
+++ b/infra/mf-model-api/app/mydb/pymysql_pool.py
@@ -6,7 +6,7 @@ from dbutilsx.pooled_db import PooledDB, PooledDBInfo
 from app.core.config import base_config
 
 
-# 单例
+# Singleton connection pool.
 class PymysqlPool(object):
     yamlConfig = None
     _instance_lock = threading.Lock()

--- a/infra/mf-model-api/app/routers/__init__.py
+++ b/infra/mf-model-api/app/routers/__init__.py
@@ -10,9 +10,9 @@ api_version_public_v1 = "/api/mf-model-api/v1"
 api_version_private_v1 = "/api/private/mf-model-api/v1"
 api_version_health = "/api/v1"
 
-# 声明为 OpenAI 兼容的路由。这些路径上的失败必须是 {"error": {...}}，其余端点
-# （小模型、模型管理等）不是兼容面，继续用模型工厂自家的 envelope——别一刀切，
-# 那会连带破掉它们的对外契约（#637）。
+# Errors on OpenAI-compatible routes must use {"error": {...}}. Small-model
+# and model-management endpoints retain the Model Factory envelope; applying
+# the OpenAI shape globally would break their public contract (#637).
 _OPENAI_COMPAT_SUFFIXES = ("/chat/completions",)
 
 
@@ -49,27 +49,27 @@ def router_init(app):
 
     @app.exception_handler(RequestValidationError)
     async def exception_handler(request: Request, exc: RequestValidationError):
-        # 只投影 loc/type/msg：pydantic v1 的 errors() 不回显入参，但 v2 会带
-        # input，届时整份 errors 落日志就等于把用户请求体写进去了（见 #636）。
+        # Log only loc/type/msg. Pydantic v1 omits input values, but v2 includes
+        # them; logging the complete error list could expose request data (#636).
         StandLogger.warn("request validation failed: %s" % [
             {k: e.get(k) for k in ("loc", "type", "msg")} for e in exc.errors()])
-        # 只报第一条：detail 是字符串不是列表，聚合会改变既有响应契约。
+        # Report only the first error because detail is contractually a string.
         for error in exc.errors():
             paramName = ' '.join(map(str, error["loc"][1:]))
             if error["type"] == "value_error.missing":
                 content = {"code": "ModelFactory.Router.ParamError.ParamMissing",
-                           "description": "参数缺失",
-                           "detail": "{0} 参数缺失".format(paramName),
-                           "solution": "请检查填写的参数是否正确。",
+                           "description": "Required parameter is missing.",
+                           "detail": f"missing parameters: {paramName}",
+                           "solution": "Provide the required parameter and try again.",
                            "link": ""}
             else:
                 content = {"code": "ModelFactory.Router.ParamError.FormatError",
-                           "description": "参数错误",
+                           "description": "Request parameter is invalid.",
                            "detail": f"{error.get('msg', '')}",
-                           "solution": "请检查输入内容格式是否符合要求",
+                           "solution": "Check that the input matches the API documentation.",
                            "link": ""}
-            # 兼容面上换成 OpenAI 错误体：同一端点不能有两种错误契约，否则对接方
-            # 得写两套解析。原业务码挪进 error.code，机器可读的身份不丢。
+            # Use the OpenAI error shape on compatible routes while retaining
+            # the stable business code in error.code.
             if _is_openai_compat(request.url.path):
                 return JSONResponse(
                     status_code=400,

--- a/infra/mf-model-api/app/routers/llm_router.py
+++ b/infra/mf-model-api/app/routers/llm_router.py
@@ -1,4 +1,4 @@
-# 只放接口
+# Route declarations only.
 import datetime
 
 from fastapi import APIRouter, Body, Request, Query
@@ -27,7 +27,7 @@ async def health_alive():
 @llm_route.post("/chat/completions")
 async def llm_used_openai2(request: LLMUsedOpenAI, head_request: Request):
     '''
-    openai风格大模型调用接口
+    Invoke a large model through an OpenAI-compatible API.
     ---
     operationId: llm_used_openai
     requestBody:
@@ -43,32 +43,32 @@ async def llm_used_openai2(request: LLMUsedOpenAI, head_request: Request):
                     model:
                         type: string
                         format: string
-                        description: '需要调用的模型的名称'
+                        description: 'Name of the model to invoke'
                         example: 'deepseek-chat'
                     top_p:
                         type: float
                         format: float
-                        description: '核采样，取值0-1，默认为1'
+                        description: 'Nucleus sampling value from 0 to 1; defaults to 1'
                         example: 0.7
                     temperature:
                         type: float
                         format: float
-                        description: '模型在做出下一个词预测时的确定性和随机性程度。取值0-2，默认为1'
+                        description: 'Sampling temperature from 0 to 2; defaults to 1'
                         example: 0
                     presence_penalty:
                         type: float
                         format: float
-                        description: '话题新鲜度，取值-2~2，默认为0'
+                        description: 'Presence penalty from -2 to 2; defaults to 0'
                         example: 0
                     frequency_penalty:
                         type: float
                         format: float
-                        description: '频率惩罚度，取值-2~2，默认为0'
+                        description: 'Frequency penalty from -2 to 2; defaults to 0'
                         example: 0
                     max_tokens:
                         type: integer
                         format: integer
-                        description: '单次回复限制，取值10-该模型最大tokens数，默认为1000'
+                        description: 'Maximum response tokens, from 10 to the model limit; defaults to 1000'
                         example: 1000
                     messages:
                         type: object
@@ -76,20 +76,20 @@ async def llm_used_openai2(request: LLMUsedOpenAI, head_request: Request):
                             role:
                                 type: string
                                 format: string
-                                description: '角色：system, assistant, user'
+                                description: 'Message role: system, assistant, or user'
                                 example: 'user'
                             content:
                                 type: string
                                 format: string
-                                description: '对话内容'
-                                example: '你是谁'
+                                description: 'Message content'
+                                example: 'Who are you?'
                     stream:
                         type: boolean
-                        description: '是否流式返回，默认为否'
+                        description: 'Whether to stream the response; defaults to false'
                         example: true
                     top_k:
                         type: integer
-                        description: '取值大于等于1或者为-1，默认为1',
+                        description: 'Value greater than or equal to 1, or -1; defaults to 1',
                         example: 1
 
     '''

--- a/infra/mf-model-api/app/routers/private_route.py
+++ b/infra/mf-model-api/app/routers/private_route.py
@@ -9,11 +9,11 @@ from app.utils.common import get_user_info
 private_route = APIRouter()
 
 
-# 大模型调用内部接口
+# Internal large-model invocation endpoint.
 @private_route.post("/chat/completions")
 async def llm_used_openai2(request: LLMUsedOpenAI, head_request: Request):
     '''
-    openai风格大模型调用接口
+    Invoke a large model through an OpenAI-compatible API.
     ---
     operationId: llm_used_openai
     requestBody:
@@ -29,32 +29,32 @@ async def llm_used_openai2(request: LLMUsedOpenAI, head_request: Request):
                     model:
                         type: string
                         format: string
-                        description: '需要调用的模型的名称'
+                        description: 'Name of the model to invoke'
                         example: 'deepseek-chat'
                     top_p:
                         type: float
                         format: float
-                        description: '核采样，取值0-1，默认为1'
+                        description: 'Nucleus sampling value from 0 to 1; defaults to 1'
                         example: 0.7
                     temperature:
                         type: float
                         format: float
-                        description: '模型在做出下一个词预测时的确定性和随机性程度。取值0-2，默认为1'
+                        description: 'Sampling temperature from 0 to 2; defaults to 1'
                         example: 0
                     presence_penalty:
                         type: float
                         format: float
-                        description: '话题新鲜度，取值-2~2，默认为0'
+                        description: 'Presence penalty from -2 to 2; defaults to 0'
                         example: 0
                     frequency_penalty:
                         type: float
                         format: float
-                        description: '频率惩罚度，取值-2~2，默认为0'
+                        description: 'Frequency penalty from -2 to 2; defaults to 0'
                         example: 0
                     max_tokens:
                         type: integer
                         format: integer
-                        description: '单次回复限制，取值10-该模型最大tokens数，默认为1000'
+                        description: 'Maximum response tokens, from 10 to the model limit; defaults to 1000'
                         example: 1000
                     messages:
                         type: object
@@ -62,20 +62,20 @@ async def llm_used_openai2(request: LLMUsedOpenAI, head_request: Request):
                             role:
                                 type: string
                                 format: string
-                                description: '角色：system, assistant, user'
+                                description: 'Message role: system, assistant, or user'
                                 example: 'user'
                             content:
                                 type: string
                                 format: string
-                                description: '对话内容'
-                                example: '你是谁'
+                                description: 'Message content'
+                                example: 'Who are you?'
                     stream:
                         type: boolean
-                        description: '是否流式返回，默认为否'
+                        description: 'Whether to stream the response; defaults to false'
                         example: true
                     top_k:
                         type: integer
-                        description: '取值大于等于1或者为-1，默认为1',
+                        description: 'Value greater than or equal to 1, or -1; defaults to 1',
                         example: 1
 
     '''
@@ -85,7 +85,7 @@ async def llm_used_openai2(request: LLMUsedOpenAI, head_request: Request):
     return await used_model_openai(request.dict(), userId, language, func_module, dict(headers))
 
 
-# reranker模型调用内部接口
+# Internal reranker invocation endpoint.
 @private_route.post("/small-model/reranker")
 async def model_used(request: logics.UsedReranker, head_request: Request):
     userId, language, role = await get_user_info(head_request)
@@ -94,7 +94,7 @@ async def model_used(request: logics.UsedReranker, head_request: Request):
     return await small_model_controller.reranker_model_used(request, userId, language, role, func_module)
 
 
-# embedding模型调用内部接口
+# Internal embedding invocation endpoints.
 @private_route.post("/small-model/embedding")
 async def model_used(request: logics.UsedEmbedding, head_request: Request):
     userId, language, role = await get_user_info(head_request)

--- a/infra/mf-model-api/app/test/test_commons_snow_id.py
+++ b/infra/mf-model-api/app/test/test_commons_snow_id.py
@@ -15,18 +15,18 @@ class TestIdWorker:
 
     def test_init_invalid_worker_id(self):
         """测试无效的worker_id"""
-        with pytest.raises(ValueError, match="worker_id值越界"):
+        with pytest.raises(ValueError, match="worker_id is out of range"):
             IdWorker(datacenter_id=1, worker_id=32, sequence=0)
         
-        with pytest.raises(ValueError, match="worker_id值越界"):
+        with pytest.raises(ValueError, match="worker_id is out of range"):
             IdWorker(datacenter_id=1, worker_id=-1, sequence=0)
 
     def test_init_invalid_datacenter_id(self):
         """测试无效的datacenter_id"""
-        with pytest.raises(ValueError, match="datacenter_id值越界"):
+        with pytest.raises(ValueError, match="datacenter_id is out of range"):
             IdWorker(datacenter_id=32, worker_id=1, sequence=0)
         
-        with pytest.raises(ValueError, match="datacenter_id值越界"):
+        with pytest.raises(ValueError, match="datacenter_id is out of range"):
             IdWorker(datacenter_id=-1, worker_id=1, sequence=0)
 
     def test_gen_timestamp(self):

--- a/infra/mf-model-api/app/test/test_controller_llm.py
+++ b/infra/mf-model-api/app/test/test_controller_llm.py
@@ -69,6 +69,7 @@ class TestUsedModelOpenai:
                 result = await used_model_openai(request, "user1", "zh", "test")
                 assert isinstance(result, JSONResponse)
                 assert result.status_code == 400
+                assert json.loads(result.body)["error"]["code"] == "ModelFactory.LLM.DefaultNotExist"
 
     @pytest.mark.asyncio
     async def test_max_tokens_exceeds_limit(self, valid_request, mock_model_data):
@@ -85,6 +86,8 @@ class TestUsedModelOpenai:
                 result = await used_model_openai(request, "user1", "zh", "test")
                 assert isinstance(result, JSONResponse)
                 assert result.status_code == 400
+                assert json.loads(result.body)["error"]["code"] == \
+                    "ModelFactory.Router.ParamError.FormatError"
 
     @pytest.mark.asyncio
     async def test_quota_check_no_space(self, valid_request, mock_model_data):

--- a/infra/mf-model-api/app/test/test_llm_error_contract.py
+++ b/infra/mf-model-api/app/test/test_llm_error_contract.py
@@ -55,6 +55,23 @@ MESSAGES = [{"role": "user", "content": "hi"}]
 
 class TestStreamErrorFrame:
     @pytest.mark.asyncio
+    async def test_legacy_stream_logs_raw_connection_error_before_returning_safe_body(self):
+        session_cm = AsyncMock()
+        session_cm.__aenter__ = AsyncMock(
+            side_effect=llm_utils.aiohttp.ClientConnectionError("connection refused"))
+        session_cm.__aexit__ = AsyncMock(return_value=None)
+
+        with patch.object(llm_utils.aiohttp, 'ClientSession', return_value=session_cm), \
+                patch.object(llm_utils.asyncio, 'sleep', new_callable=AsyncMock), \
+                patch.object(llm_utils.StandLogger, 'error') as error_log:
+            chunks = await _collect(_other_client().chat_completion_stream(
+                MESSAGES, "user1", False, {}))
+
+        assert len(chunks) == 1
+        assert json.loads(chunks[0])["code"] == "ModelFactory.ModelController.Model.Error"
+        assert any("connection refused" in str(call.args[0]) for call in error_log.call_args_list)
+
+    @pytest.mark.asyncio
     async def test_upstream_busy_yields_openai_error_frame(self):
         """上游 503 忙：发合规错误帧，不发 envelope"""
         session_cm, session = _mock_session(503, BUSY_BODY)

--- a/infra/mf-model-api/app/test/test_locale.py
+++ b/infra/mf-model-api/app/test/test_locale.py
@@ -85,18 +85,67 @@ class TestAcceptLanguageResolver(unittest.TestCase):
         self.assertTrue(changed)
         self.assertEqual(content["detail"], "Parameter type is invalid: model_names")
 
-    def test_format_error_preserves_a_dynamic_validation_reason(self):
+    def test_parameter_template_uses_generic_detail_without_a_structured_name(self):
         content, changed = localized_error_content(
             {
-                "code": "ModelFactory.Router.ParamError.FormatError",
-                "description": "参数错误",
-                "detail": "value is not a valid integer",
-                "solution": "请检查输入信息",
+                "code": "ModelFactory.Router.ParamError.ParamMissing",
+                "description": "Required parameter is missing.",
+                "detail": "Provide at least one of model or model_id.",
+                "solution": "Provide the required parameter and try again.",
             },
             "en-US",
         )
         self.assertTrue(changed)
-        self.assertEqual(content["detail"], "value is not a valid integer")
+        self.assertEqual(content["detail"], "Required parameter is missing.")
+
+    def test_format_error_preserves_a_dynamic_validation_reason(self):
+        source = {
+            "code": "ModelFactory.Router.ParamError.FormatError",
+            "description": "Request parameter is invalid.",
+            "detail": "value is not a valid integer",
+            "solution": "Check the input format.",
+        }
+        english, english_changed = localized_error_content(source, "en-US")
+        chinese, chinese_changed = localized_error_content(source, "zh-CN")
+
+        self.assertTrue(english_changed)
+        self.assertTrue(chinese_changed)
+        self.assertEqual(english["detail"], "value is not a valid integer")
+        self.assertEqual(chinese["detail"], "输入参数格式不符合要求。")
+
+    def test_catalog_localizes_service_owned_error_without_changing_code(self):
+        source = {
+            "code": "ModelFactory.ExternalSmallModel.Used.DefaultNotExist",
+            "description": "Default small model is not configured.",
+            "detail": "An administrator has not configured a default small model for this type.",
+            "solution": "Configure a default small model in model management and try again.",
+        }
+
+        english, english_changed = localized_error_content(source, "en-US")
+        chinese, chinese_changed = localized_error_content(source, "zh-CN")
+
+        self.assertTrue(english_changed)
+        self.assertTrue(chinese_changed)
+        self.assertEqual(english["code"], chinese["code"])
+        self.assertEqual(english["detail"],
+                         "An administrator has not configured a default small model for this type.")
+        self.assertEqual(chinese["detail"], "管理员尚未配置该类型的默认小模型。")
+
+    def test_catalog_hides_internal_database_detail_in_both_locales(self):
+        source = {
+            "code": "ModelFactory.Mydb.DataBase.ParameterError",
+            "description": "Database access failed.",
+            "detail": "dial tcp db.internal:3306: password=secret",
+            "solution": "Retry later.",
+        }
+
+        english, _ = localized_error_content(source, "en-US")
+        chinese, _ = localized_error_content(source, "zh-CN")
+
+        self.assertEqual(english["detail"], "Model Factory cannot access the database right now.")
+        self.assertEqual(chinese["detail"], "模型工厂暂时无法访问数据库。")
+        self.assertNotIn("db.internal", str(english))
+        self.assertNotIn("secret", str(chinese))
 
     def test_platform_stream_error_uses_the_frozen_locale_and_stable_code(self):
         token = set_effective_locale("en-US")

--- a/infra/mf-model-api/app/test/test_locale.py
+++ b/infra/mf-model-api/app/test/test_locale.py
@@ -7,6 +7,11 @@ import unittest
 from unittest import mock
 
 from app.commons.i18n import get_error_message
+from app.commons.errors import (
+    ModelFactory_DedaultModel_NotExist,
+    ModelFactory_ExternalSmallModel_Used_NameNotExist,
+    ModelFactory_Router_ParamError_FormatError_Error,
+)
 from app.commons.errors.codes import ParamValidationErrors
 from app.commons.locale import (
     LocaleResponseMiddleware,
@@ -130,6 +135,29 @@ class TestAcceptLanguageResolver(unittest.TestCase):
         self.assertEqual(english["detail"],
                          "An administrator has not configured a default small model for this type.")
         self.assertEqual(chinese["detail"], "管理员尚未配置该类型的默认小模型。")
+
+    def test_default_large_model_error_is_distinct_and_localized(self):
+        self.assertNotEqual(
+            ModelFactory_DedaultModel_NotExist["code"],
+            ModelFactory_ExternalSmallModel_Used_NameNotExist["code"],
+        )
+
+        english, _ = localized_error_content(ModelFactory_DedaultModel_NotExist, "en-US")
+        chinese, _ = localized_error_content(ModelFactory_DedaultModel_NotExist, "zh-CN")
+
+        self.assertEqual(english["code"], "ModelFactory.LLM.DefaultNotExist")
+        self.assertEqual(english["detail"], "An administrator has not configured a default large model.")
+        self.assertEqual(chinese["detail"], "管理员尚未配置默认大模型。")
+
+    def test_max_tokens_limit_keeps_the_dynamic_value_in_both_locales(self):
+        source = ModelFactory_Router_ParamError_FormatError_Error.copy()
+        source["detail"] = "max_tokens_limit: 4096k"
+
+        english, _ = localized_error_content(source, "en-US")
+        chinese, _ = localized_error_content(source, "zh-CN")
+
+        self.assertEqual(english["detail"], "max_tokens exceeds the maximum value of 4096k.")
+        self.assertEqual(chinese["detail"], "max_tokens 超过最大值 4096k。")
 
     def test_catalog_hides_internal_database_detail_in_both_locales(self):
         source = {

--- a/infra/mf-model-api/app/test/test_openai_error.py
+++ b/infra/mf-model-api/app/test/test_openai_error.py
@@ -6,6 +6,7 @@ import json
 
 import pytest
 
+from app.commons.locale import reset_effective_locale, set_effective_locale
 from app.utils import openai_error
 
 
@@ -14,6 +15,7 @@ UPSTREAM_FLAT = '{"code":50508,"message":"System is too busy now. Please try aga
 UPSTREAM_OPENAI = ('{"error":{"message":"Service is too busy. We advise users to temporarily '
                    'switch to alternative LLM API service providers.","type":"service_unavailable_error",'
                    '"param":null,"code":"service_unavailable_error"}}')
+ZH_CONNECTION_FAILED = "无法连接到模型服务。"
 
 
 class TestFromUpstream:
@@ -45,30 +47,38 @@ class TestFromUpstream:
 
     def test_empty_body_falls_back(self):
         body = openai_error.from_upstream("", 502)
-        assert body["error"]["message"] == "模型服务调用失败"
+        assert body["error"]["message"] == ZH_CONNECTION_FAILED
+
+    def test_empty_body_fallback_uses_effective_english_locale(self):
+        token = set_effective_locale("en-US")
+        try:
+            body = openai_error.from_upstream("", 502)
+        finally:
+            reset_effective_locale(token)
+        assert body["error"]["message"] == "The model service could not be reached."
 
     def test_unknown_dict_shape_does_not_leak_whole_body(self):
         """形态未知的 body 常带回显请求/内部 trace id/网关节点名，不整段外泄"""
         body = openai_error.from_upstream(
             {"trace_id": "abc", "node": "gw-internal-3",
              "request": {"api_key": "sk-secret"}}, 500)
-        assert body["error"]["message"] == "模型服务调用失败"
+        assert body["error"]["message"] == ZH_CONNECTION_FAILED
         assert "sk-secret" not in json.dumps(body)
         assert "gw-internal-3" not in json.dumps(body)
 
     def test_empty_upstream_message_falls_back(self):
         body = openai_error.from_upstream(
             '{"error":{"message":"","code":"x"}}', 500)
-        assert body["error"]["message"] == "模型服务调用失败"
+        assert body["error"]["message"] == ZH_CONNECTION_FAILED
 
     def test_html_error_page_falls_back(self):
         body = openai_error.from_upstream(
             "<html><head><title>502 Bad Gateway</title></head></html>", 502)
-        assert body["error"]["message"] == "模型服务调用失败"
+        assert body["error"]["message"] == ZH_CONNECTION_FAILED
 
     def test_overlong_plain_body_falls_back(self):
         body = openai_error.from_upstream("x" * 900, 500)
-        assert body["error"]["message"] == "模型服务调用失败"
+        assert body["error"]["message"] == ZH_CONNECTION_FAILED
 
     def test_accepts_dict(self):
         body = openai_error.from_upstream({"detail": "boom"}, 500)

--- a/infra/mf-model-api/app/test/test_routers.py
+++ b/infra/mf-model-api/app/test/test_routers.py
@@ -1,8 +1,11 @@
-"""测试 routers 模块"""
+"""Router tests."""
+import json
+import re
 import pytest
 from unittest.mock import Mock, AsyncMock, patch
 from fastapi.testclient import TestClient
 from fastapi import FastAPI
+from app.interfaces.logics import UsedEmbedding
 from app.routers.llm_router import llm_route, health_route
 
 
@@ -146,4 +149,18 @@ class TestAPIDocumentation:
         # 健康检查端点通常标记为不在schema中
         # 这里只验证schema有效
         assert "paths" in schema
+
+    def test_public_chat_schema_descriptions_are_english(self, client):
+        schema = client.get("/openapi.json").json()
+        operation = schema["paths"]["/chat/completions"]["post"]
+        request_schema = schema["components"]["schemas"]["LLMUsedOpenAI"]
+        embedding_schema = UsedEmbedding.schema()
+        rendered = json.dumps(
+            {"operation": operation, "request_schema": request_schema,
+             "embedding_schema": embedding_schema},
+            ensure_ascii=False,
+        )
+
+        assert re.search(r"[\u4e00-\u9fff]", rendered) is None
+        assert embedding_schema["properties"]["input"]["description"] == "Content to embed"
 

--- a/infra/mf-model-api/app/test/test_utils_common.py
+++ b/infra/mf-model-api/app/test/test_utils_common.py
@@ -93,6 +93,7 @@ class TestCommonFunctions:
             'x-account-type': 'admin',
             'accept-language': 'en-US'
         }
+        request.scope = {"state": {"effective_locale": "en-US"}}
 
         userId, language, role = await get_user_info(request)
 

--- a/infra/mf-model-api/app/utils/app_utils.py
+++ b/infra/mf-model-api/app/utils/app_utils.py
@@ -16,6 +16,7 @@ from app.commons.locale import (
     is_authenticated_public_api_path,
     is_business_api_path,
     is_openai_compat_path,
+    localized_error_content,
 )
 from app.core.config import base_config, server_info, observability_config
 from app.logs import log_init, sys_log
@@ -38,29 +39,32 @@ def conf_init(app):
 
 async def start_event():
     await write_log(msg='系统启动')
-    # 在应用启动时调用
+    # Initialize required infrastructure when the application starts.
     try:
         await get_redis_util()
     except Exception as e:
         raise e
-    # 初始化可观测模块
+    # Initialize observability integrations.
     init_observability(server_info, observability_config)
 
 
 async def shutdown_event():
     await write_log(msg='系统关闭')
-    # 关闭可观测模块
+    # Shut down observability integrations.
     shutdown_observability()
 
 
-# 用户自助签发的 AppKey 前缀(bkn-safe 签发),与 bkn-safe auth.KeyPrefix 保持一致
+# Prefix for self-service AppKeys issued by bkn-safe. Keep this aligned with auth.KeyPrefix.
 APP_KEY_PREFIX = "bak_"
 
 
 async def _verify_app_key(token):
-    """AppKey(bak_ 前缀)走 bkn-safe 内部校验接口 /api/safe/v1/api-keys/introspect,
-    响应形如 OAuth2 introspection:任何失败均为 200 {active:false}。
-    校验通过返回 (user_id, role);无效或 BKN_SAFE_URL 未配置(fail-closed)返回错误响应。"""
+    """Validate a bak_ AppKey through bkn-safe's introspection endpoint.
+
+    The endpoint follows OAuth2 introspection semantics and represents every
+    validation failure as HTTP 200 with ``active: false``. A valid key returns
+    ``(user_id, role)``; an invalid key or missing BKN_SAFE_URL fails closed.
+    """
     bkn_safe_url = os.getenv("BKN_SAFE_URL", "")
     if not bkn_safe_url:
         return JSONResponse(
@@ -93,7 +97,7 @@ async def _verify_app_key(token):
             content=UnauthorizedError
         )
     user_id = result.get("sub", "")
-    # bkn-safe account_type: "app"=应用账户,其余按用户处理,与 hydra 路径的 role 口径一致
+    # Treat account_type=app as an application identity; all other values are users.
     role = "app" if result.get("account_type", "") == "app" else "user"
     return user_id, role
 
@@ -105,7 +109,7 @@ async def auth_middleware(request: Request, call_next):
     elif path.startswith("/api/private"):
         pass
     elif not base_config.AUTH_ENABLED:
-        # 权限控制关闭：跳过 token 校验，注入匿名用户 ID 保证审计日志有值
+        # With authorization disabled, inject an anonymous identity for audit correlation.
         user_id = request.headers.get("x-account-id", base_config.ANONYMOUS_USER_ID)
         request.scope['headers'].append((b"x-account-id", user_id.encode()))
         request.scope['headers'].append((b"x-account-type", b"user"))
@@ -117,7 +121,7 @@ async def auth_middleware(request: Request, call_next):
                 content=UnauthorizedError
             )
         token = auth_header[7:]
-        # 凭据二选一:bak_ 前缀的 AppKey 交给 bkn-safe 校验,其余 bearer token 走 hydra 内省
+        # Validate bak_ AppKeys with bkn-safe and all other bearer tokens with Hydra.
         if token.startswith(APP_KEY_PREFIX):
             verified = await _verify_app_key(token)
             if isinstance(verified, JSONResponse):
@@ -170,7 +174,7 @@ async def auth_middleware(request: Request, call_next):
 class RequestSizeMiddleware(BaseHTTPMiddleware):
     async def dispatch(self, request: Request, call_next):
         content_length = request.headers.get('content-length')
-        if content_length and int(content_length) > 10 * 1024 * 1024:  # 10M限制
+        if content_length and int(content_length) > 10 * 1024 * 1024:  # 10 MiB limit
             return JSONResponse(
                 status_code=413,
                 content={"detail": "Payload too large"}
@@ -183,14 +187,13 @@ async def unhandled_exception_handler(request: Request, exc: Exception):
     if not is_business_api_path(request.url.path):
         return PlainTextResponse("Internal Server Error", status_code=500)
     locale = getattr(request.state, "effective_locale", get_effective_locale())
-    content = {
+    content, _ = localized_error_content({
         "code": "ModelFactory.InternalError",
-        "description": "Request failed." if locale == "en-US" else "请求失败。",
-        "detail": "The request could not be completed." if locale == "en-US" else "请求无法完成。",
-        "solution": "See the request details or contact an administrator."
-        if locale == "en-US" else "请查看请求详情或联系管理员。",
+        "description": "Request failed.",
+        "detail": "The request could not be completed.",
+        "solution": "Retry later or contact an administrator.",
         "link": "",
-    }
+    }, locale)
     if is_openai_compat_path(request.url.path):
         content = openai_error.from_envelope(content, 500)
     return JSONResponse(
@@ -257,19 +260,19 @@ def create_app():
                   on_startup=[start_event],
                   on_shutdown=[shutdown_event])
 
-    # 添加请求体大小检查中间件
+    # Add request body size validation.
     # app.add_middleware(RequestSizeMiddleware)
-    # 添加鉴权中间件
+    # Add authentication middleware.
     app.add_middleware(BaseHTTPMiddleware, dispatch=auth_middleware)
     # Added after auth so this ASGI middleware is outermost: it also decorates auth failures.
     app.add_middleware(LocaleResponseMiddleware)
     app.add_exception_handler(Exception, unhandled_exception_handler)
 
-    # 初始化日志
+    # Initialize logging.
     log_init()
-    # 加载配置
+    # Load runtime configuration.
     conf_init(app)
-    # 初始化路由配置
+    # Register application routes.
     router_init(app)
     install_locale_openapi(app)
     return app

--- a/infra/mf-model-api/app/utils/common.py
+++ b/infra/mf-model-api/app/utils/common.py
@@ -13,7 +13,7 @@ cur_pwd = os.getcwd()
 
 
 def GetCallerInfo() -> Tuple[str, int]:
-    """ 获取调用者文件项目相对位置以及行号 """
+    """Return the caller's project-relative file path and line number."""
     caller_frame = inspect.stack()[2]
     caller_filename = caller_frame.filename.split(cur_pwd)[-1][1:]
     caller_lineno = caller_frame.lineno
@@ -24,7 +24,7 @@ def IsInPod() -> bool:
     return 'KUBERNETES_SERVICE_HOST' in os.environ and 'KUBERNETES_SERVICE_PORT' in os.environ
 
 
-# 触发熔断的失败次数
+# Number of failures that opens the circuit breaker.
 failureThreshold = 10
 
 
@@ -37,7 +37,7 @@ def SetFailureThreshold(time: int):
     failureThreshold = time
 
 
-# 熔断触发后的再次重试间隔，单位：秒
+# Retry interval in seconds after the circuit breaker opens.
 recoveryTimeout = 5
 
 
@@ -60,12 +60,7 @@ async def get_user_info(request, **kwargs):
     return userId, language, role
 
 async def validate_required_params(params_dict, required_params):
-    """
-    校验必传参数
-    :param params_dict: 请求参数字典
-    :param required_params: 必传参数列表
-    :return: 缺失的参数列表
-    """
+    """Return the required parameter names missing from params_dict."""
     missing_params = []
     for param in required_params:
         if param not in params_dict:

--- a/infra/mf-model-api/app/utils/external_small_model_utils.py
+++ b/infra/mf-model-api/app/utils/external_small_model_utils.py
@@ -146,7 +146,7 @@ class BaiduClient:
         with concurrent.futures.ThreadPoolExecutor(max_workers=10) as executor:
             futures = []
             for texts_slice in slice_list:
-                request_dict[index] = texts_slice  # 存储顺序信息，便于与返回内容匹配
+                request_dict[index] = texts_slice  # Preserve order for matching response items.
                 future = executor.submit(self.embedding_thread, texts_slice, index)
                 index += 1
                 futures.append(future)
@@ -197,7 +197,7 @@ class BaiduClient:
         with concurrent.futures.ThreadPoolExecutor(max_workers=10) as executor:
             futures = []
             for texts_slice in slice_list:
-                request_dict[index] = texts_slice  # 存储顺序信息，便于与返回内容匹配
+                request_dict[index] = texts_slice  # Preserve order for matching response items.
                 future = executor.submit(self.reranker_thread, query, texts_slice, index)
                 index += 1
                 futures.append(future)
@@ -419,7 +419,7 @@ class InnerClient:
             except Exception as e:
                 raise Exception(f"Adapter execution failed: {str(e)}")
 
-        # 原有逻辑
+        # Preserve the existing response conversion.
         params = {
             "model": self.model_name,
             "query": query,

--- a/infra/mf-model-api/app/utils/llm_utils.py
+++ b/infra/mf-model-api/app/utils/llm_utils.py
@@ -958,6 +958,7 @@ class BaiduTianchenClient(BKNTraceModelMixin):
                 if retry_time <= 0:
                     error_dict = _platform_envelope_error("ModelFactory.ModelController.Model.Error")
                     yield json.dumps(error_dict, ensure_ascii=False)
+                    StandLogger.error(str(e))
                     StandLogger.error(json.dumps(error_dict, ensure_ascii=False))
                     return
                 else:
@@ -1360,6 +1361,7 @@ class BaiduClient(BKNTraceModelMixin):
                 if retry_time <= 0:
                     error_dict = _platform_envelope_error("ModelFactory.ModelController.Model.Error")
                     yield json.dumps(error_dict, ensure_ascii=False)
+                    StandLogger.error(str(e))
                     StandLogger.error(json.dumps(error_dict, ensure_ascii=False))
                     return
                 else:
@@ -1943,6 +1945,7 @@ class OtherClient(BKNTraceModelMixin):
                 if retry_time <= 0:
                     error_dict = _platform_envelope_error("ModelFactory.ModelController.Model.Error")
                     yield json.dumps(error_dict, ensure_ascii=False)
+                    StandLogger.error(str(e))
                     StandLogger.error(json.dumps(error_dict, ensure_ascii=False))
                     return
                 else:

--- a/infra/mf-model-api/app/utils/llm_utils.py
+++ b/infra/mf-model-api/app/utils/llm_utils.py
@@ -15,7 +15,7 @@ from llmadapter.schema import HumanMessage, AIMessage
 
 from app.commons.errors import ModelError, LLMParamError, ModelTimeoutError, \
     ModelFactory_ModelController_Model_Error_Error
-from app.commons.locale import platform_openai_error
+from app.commons.locale import get_effective_locale, localized_error_content, platform_openai_error
 from app.controller.model_audit_controller import add_llm_model_call_log
 from app.core.config import base_config
 from app.dao.llm_model_dao import llm_model_dao
@@ -27,10 +27,10 @@ from app.utils import log_redact, openai_error
 
 from app.utils.str_util import generate_random_string, has_common_substring
 
-# 全局tokenizer缓存
+# Process-wide tokenizer cache.
 _TOKENIZER_CACHE = {}
 _TOKENIZER_LOCK = threading.RLock()
-_MAX_CACHE_SIZE = 5  # 限制最大缓存数量
+_MAX_CACHE_SIZE = 5
 
 
 class BKNTraceModelMixin:
@@ -117,7 +117,7 @@ async def trace_model_stream(client, stream, messages, params):
 
 
 async def sleep_before_retry(retry_time, total=3):
-    """上游瞬态错误（429/502/503/504）重试前的退避：剩余次数越少等得越久。"""
+    """Back off before retrying transient 429/502/503/504 provider failures."""
     await asyncio.sleep(0.5 * max(1, total - retry_time))
 
 
@@ -132,6 +132,18 @@ def _is_terminal_model_chunk(chunk):
 def _platform_stream_error(code, error_type):
     """Build an OpenAI-compatible error frame for errors owned by this service."""
     return platform_openai_error(code, error_type)
+
+
+def _platform_envelope_error(code):
+    """Build a localized legacy envelope while preserving its machine contract."""
+    content, _ = localized_error_content({
+        "code": code,
+        "description": "Request failed.",
+        "detail": "The request could not be completed.",
+        "solution": "Retry later or contact an administrator.",
+        "link": "",
+    }, get_effective_locale())
+    return content
 
 
 async def emit_model_fact_before_terminal(
@@ -276,7 +288,7 @@ class OpenAIClientRequest(BKNTraceModelMixin):
         self.tool_choice = tool_choice
         self.trace_context = None
 
-    async def chat_completion(self, messages, user_id, func_module, cache=False):  # 写一版直接请求url的，便于传入工具
+    async def chat_completion(self, messages, user_id, func_module, cache=False):
         if messages[len(messages) - 1]["role"] != "user" and self.api_model.find("qianxun") != -1:
             return openai_error.with_http_status(
                 _platform_stream_error(
@@ -538,7 +550,7 @@ class OpenAIClientRequest(BKNTraceModelMixin):
                     status="failed",
                     error_category="internal_error",
                 )
-                # 先把合规错误帧送出去，调用方才有话可说；再抛，保留可观测性
+                # Send a compliant error frame before raising for observability.
                 yield openai_error.error_frame(_platform_stream_error(
                     "ModelFactory.Stream.InternalError", "server_error"))
                 raise e
@@ -591,11 +603,11 @@ async def openai_series_stream(types, api_key, api_model, ai_system, ai_history,
                                llm_id=None,
                                user_id="", cache=False, stop=None):
     try:
-        # 获取所有输入信息的长度
+        # Calculate the total input length.
         messages, mess_str = prompt(ai_system, ai_user, ai_assistant, ai_history)
         max_token = await get_context_size("openai", base_url, api_model)
         llm_max_token = max_token if max_token is not None else 16000
-        # 校验 token 有没有超出
+        # Reject requests that exceed the model token limit.
         try:
             prompt_tokens = await openai_token_num(max_tokens, llm_max_token, mess_str)
             if prompt_tokens == -1:
@@ -847,9 +859,9 @@ class BaiduTianchenClient(BKNTraceModelMixin):
                         await add_llm_model_call_log(log_info)
                         return
         except aiohttp.ClientError as e:
-            # 注意 try 在 while 外面（709 行），这里没有回到循环的路径——原来
-            # retry_time > 0 时只 sleep 完就让生成器结束，客户端拿到一个 200、
-            # 零帧、无 [DONE] 的哑流。无论还剩几次都发帧再断。
+            # The try block is outside the loop, so there is no path back to a
+            # retry. Always send an error frame before ending the stream; the old
+            # behavior returned HTTP 200 with no frames and no [DONE] marker.
             error_dict = _platform_stream_error(
                 "ModelFactory.Stream.ModelConnectionFailed", "api_connection_error")
             yield openai_error.error_frame(error_dict)
@@ -944,9 +956,7 @@ class BaiduTianchenClient(BKNTraceModelMixin):
                         return
             except aiohttp.ClientError as e:
                 if retry_time <= 0:
-                    error_dict = ModelFactory_ModelController_Model_Error_Error.copy()
-                    error_dict["description"] = f"大模型: {self.api_model} 连接失败，请检查该服务是否可用"
-                    error_dict["detail"] = str(e)
+                    error_dict = _platform_envelope_error("ModelFactory.ModelController.Model.Error")
                     yield json.dumps(error_dict, ensure_ascii=False)
                     StandLogger.error(json.dumps(error_dict, ensure_ascii=False))
                     return
@@ -958,7 +968,7 @@ class BaiduTianchenClient(BKNTraceModelMixin):
                 raise e
 
 
-# 百度大模型类
+# Baidu model client.
 class BaiduClient(BKNTraceModelMixin):
     bkn_trace_provider = "baidu"
     def __init__(self, api_url, api_model, api_key, model_id, temperature, top_p, max_tokens, frequency_penalty,
@@ -1195,7 +1205,7 @@ class BaiduClient(BKNTraceModelMixin):
                                         datas["usage"]["prompt_tokens_details"] = {
                                             "cached_tokens": 0
                                         }
-                                        # 计算 uncached_tokens
+                                        # Calculate uncached tokens.
                                     cached_tokens = datas["usage"]["prompt_tokens_details"].get(
                                         "cached_tokens", 0)
                                     datas["usage"]["prompt_tokens_details"][
@@ -1348,9 +1358,7 @@ class BaiduClient(BKNTraceModelMixin):
                                 return
             except aiohttp.ClientError as e:
                 if retry_time <= 0:
-                    error_dict = ModelFactory_ModelController_Model_Error_Error.copy()
-                    error_dict["description"] = f"大模型: {self.api_model} 连接失败，请检查该服务是否可用"
-                    error_dict["detail"] = str(e)
+                    error_dict = _platform_envelope_error("ModelFactory.ModelController.Model.Error")
                     yield json.dumps(error_dict, ensure_ascii=False)
                     StandLogger.error(json.dumps(error_dict, ensure_ascii=False))
                     return
@@ -1364,7 +1372,7 @@ class BaiduClient(BKNTraceModelMixin):
                 return
 
 
-# 其他模型类
+# Generic model client.
 class OtherClient(BKNTraceModelMixin):
     bkn_trace_provider = "other"
     def __init__(self, api_url, api_model, api_key, model_id,
@@ -1432,7 +1440,7 @@ class OtherClient(BKNTraceModelMixin):
                             await add_llm_model_call_log(log_info)
                             if self.model_type == "rlm" and not result["choices"][0]["message"].get("reasoning_content",
                                                                                                     None):
-                                # 提取thinking标签
+                                # Extract the thinking tag.
                                 pattern = r"<think>(.*?)</think>"
                                 match = re.search(pattern, result["choices"][0]["message"]["content"], re.DOTALL)
                                 if match:
@@ -1461,7 +1469,7 @@ class OtherClient(BKNTraceModelMixin):
                                 usage["prompt_tokens_details"] = {
                                     "cached_tokens": 0
                                 }
-                                # 计算 uncached_tokens
+                                # Calculate uncached tokens.
                             cached_tokens = usage["prompt_tokens_details"].get(
                                 "cached_tokens", 0)
                             usage["prompt_tokens_details"][
@@ -1613,7 +1621,7 @@ class OtherClient(BKNTraceModelMixin):
                                                 prompt_tokens = datas["usage"]["prompt_tokens"]
                                                 completion_tokens = datas["usage"]["completion_tokens"]
                                                 total_tokens = datas["usage"]["total_tokens"]
-                                                # 处理 usage 信息，添加 uncached_tokens 字段
+                                                # Add uncached_tokens to usage metadata.
                                                 if "prompt_tokens_details" not in datas["usage"]:
                                                     datas["usage"]["prompt_tokens_details"] = {
                                                         "cache_type": "implicit",
@@ -1633,7 +1641,7 @@ class OtherClient(BKNTraceModelMixin):
                                                 prompt_tokens = datas["usage"]["prompt_tokens"]
                                                 completion_tokens = datas["usage"]["completion_tokens"]
                                                 total_tokens = datas["usage"]["total_tokens"]
-                                                # 处理 usage 信息，添加 uncached_tokens 字段
+                                                # Add uncached_tokens to usage metadata.
                                                 if "prompt_tokens_details" not in datas["usage"]:
                                                     datas["usage"]["prompt_tokens_details"] = {
                                                         "cache_type": "implicit",
@@ -1721,7 +1729,7 @@ class OtherClient(BKNTraceModelMixin):
                                             prompt_tokens = datas["usage"]["prompt_tokens"]
                                             completion_tokens = datas["usage"]["completion_tokens"]
                                             total_tokens = datas["usage"]["total_tokens"]
-                                            # 处理 usage 信息，添加 uncached_tokens 字段
+                                            # Add uncached_tokens to usage metadata.
                                             if "prompt_tokens_details" not in datas["usage"]:
                                                 datas["usage"]["prompt_tokens_details"] = {
                                                     "cache_type": "implicit",
@@ -1803,9 +1811,7 @@ class OtherClient(BKNTraceModelMixin):
             retry_time -= 1
             try:
                 if messages[len(messages) - 1]["role"] != "user" and self.api_model.find("qianxun") != -1:
-                    error_dict = ModelError.copy()
-                    error_dict["description"] = error_dict["detail"] = error_dict[
-                        "solution"] = "千循大模型只支持最后一条消息role为user"
+                    error_dict = _platform_envelope_error("ModelFactory.Stream.InvalidMessageRole")
                     yield "--error--" + json.dumps(error_dict, ensure_ascii=False)
                 start_time = time.time()
                 token_len = 0
@@ -1935,9 +1941,7 @@ class OtherClient(BKNTraceModelMixin):
                         return
             except aiohttp.ClientError as e:
                 if retry_time <= 0:
-                    error_dict = ModelFactory_ModelController_Model_Error_Error.copy()
-                    error_dict["description"] = f"大模型: {self.api_model} 连接失败，请检查该服务是否可用"
-                    error_dict["detail"] = str(e)
+                    error_dict = _platform_envelope_error("ModelFactory.ModelController.Model.Error")
                     yield json.dumps(error_dict, ensure_ascii=False)
                     StandLogger.error(json.dumps(error_dict, ensure_ascii=False))
                     return
@@ -2488,7 +2492,7 @@ class ClaudeClient(BKNTraceModelMixin):
 
 
 async def encode(model_series, text, api_model="", api_key="", secret_key=""):
-    return [], len(text) // 4  # 5002beta过度，5003删除该函数
+    return [], len(text) // 4  # Deprecated in 5002 beta and removed in 5003.
     # import os
     # if model_series == "openai":
     #     cache_key = "9b5ad71b2ce5302211f9c61530b329a4922fc6a4"
@@ -2504,25 +2508,25 @@ async def encode(model_series, text, api_model="", api_key="", secret_key=""):
     #     tokenizer_dir = os.path.dirname(
     #         os.path.dirname(os.path.realpath(__file__))) + f"/utils/tokenizer/{model_series}"
     #     try:
-    #         # 使用异步方式加载tokenizer
+    #         # Load the tokenizer asynchronously.
     #         tokenizer = await get_tokenizer_async(tokenizer_dir)
     #         tokens = tokenizer.encode(text)
     #         return tokens, len(tokens)
     #     except Exception as e:
-    #         StandLogger.error(f"Tokenizer加载失败: {str(e)}")
-    #         # 出错时使用近似估算
+    #         StandLogger.error(f"Tokenizer loading failed: {str(e)}")
+    #         # Fall back to an approximation.
     #         return [], len(text) // 4
     # elif model_series == "tome":
     #     tokenizer_dir = os.path.dirname(
     #         os.path.dirname(os.path.realpath(__file__))) + f"/utils/tokenizer/qwen"
     #     try:
-    #         # 使用异步方式加载tokenizer
+    #         # Load the tokenizer asynchronously.
     #         tokenizer = await get_tokenizer_async(tokenizer_dir)
     #         tokens = tokenizer.encode(text)
     #         return tokens, len(tokens)
     #     except Exception as e:
-    #         StandLogger.error(f"Tokenizer加载失败: {str(e)}")
-    #         # 出错时使用近似估算
+    #         StandLogger.error(f"Tokenizer loading failed: {str(e)}")
+    #         # Fall back to an approximation.
     #         return [], len(text) // 4
     # elif model_series == "baidu":
     #     headers = {
@@ -2546,7 +2550,7 @@ async def encode(model_series, text, api_model="", api_key="", secret_key=""):
     #             original_info = await original_res.json()
     #             return [], original_info["usage"]["total_tokens"]
     # else:
-    #     return [], len(text) // 4  # 使用更合理的近似值
+    #     return [], len(text) // 4  # Use a more realistic approximation.
 
 
 async def decode(api_base, api_model, token_ids):

--- a/infra/mf-model-api/app/utils/metering_producer.py
+++ b/infra/mf-model-api/app/utils/metering_producer.py
@@ -1,14 +1,14 @@
-"""
-计量记录生产端：按 METERING_BACKEND 选择 Kafka 或 Redis Stream 传输。
+"""Produce metering records through Kafka or Redis Stream.
 
-失败语义与原 Kafka 路径一致：记日志返回 False，不阻塞模型调用。
+Transport failures retain the Kafka path's behavior: log the failure, return
+False, and do not block the model invocation.
 """
 import asyncio
 
 from app.core.config import base_config, resolve_metering_backend
 from app.logs.stand_log import StandLogger
 
-# stream 名沿用原 Kafka topic 名，便于运维排查与后续统一治理
+# Reuse the Kafka topic name for operational consistency across transports.
 METERING_STREAM = 'tenant_a.dip.model_manager.quota_data'
 
 _backend = resolve_metering_backend()
@@ -33,7 +33,7 @@ async def _get_redis_conn():
 
 
 async def produce_metering_record(value: bytes, key: bytes = None) -> bool:
-    """发送一条计量记录，返回是否成功入队/入流。"""
+    """Send one metering record and report whether it was queued."""
     global _redis_conn
     if _backend == 'kafka':
         from app.mydb.ConnectUtil import kafka_client
@@ -55,7 +55,7 @@ async def produce_metering_record(value: bytes, key: bytes = None) -> bool:
         )
         return True
     except Exception as e:
-        # 与 Kafka 路径同级降级：丢弃并告警，不影响模型调用；连接可能已坏，下次重建
+        # Match Kafka degradation: discard and warn without failing the model call.
         _redis_conn = None
         StandLogger.warn(f"写入计量 Redis Stream 失败，丢弃消息: {e}")
         return False

--- a/infra/mf-model-api/app/utils/openai_error.py
+++ b/infra/mf-model-api/app/utils/openai_error.py
@@ -1,33 +1,34 @@
-"""OpenAI 兼容面（/v1/chat/completions）的错误契约。
+"""Error contract for the OpenAI-compatible /v1/chat/completions endpoint.
 
-该路由对外声明为 OpenAI 兼容，客户端（@ai-sdk/openai-compatible、openai-python、
-LangChain）解析响应时用的是 ``union(chunkSchema, errorSchema)``：要么顶层有
-``choices``，要么顶层有 ``error``。模型工厂自家的 envelope
-（``{code, description, detail, solution, link}``）两边都不匹配，客户端会抛
-TypeValidationError 并把整个原始 body 冒给终端用户（#620）。
+Clients such as @ai-sdk/openai-compatible, openai-python, and LangChain parse
+responses as ``union(chunkSchema, errorSchema)``: the top level must contain
+either ``choices`` or ``error``. The Model Factory envelope
+``{code, description, detail, solution, link}`` matches neither shape and can
+cause clients to expose the raw body through a TypeValidationError (#620).
 
-所以这个面上所有失败出口——SSE 帧和 JSON body——都必须是
-``{"error": {"message", "type", "param", "code"}}``；上游本来就给了合规 error
-体的，原样透传，不再套一层。
+Every failure path, including SSE frames and JSON bodies, must therefore use
+``{"error": {"message", "type", "param", "code"}}``. Preserve a compliant
+upstream error object instead of wrapping it again.
 """
 
 import json
 
 DEFAULT_ERROR_TYPE = "server_error"
 
-# 非 JSON 上游 body 直接当 message 的长度上限，超了就走固定文案
+# Maximum safe length for a plain-text upstream body used as a message.
 _MAX_PLAIN_MESSAGE = 500
 
-# 上游这些状态码属于瞬态，值得退避重试；其余（4xx 参数/鉴权类）重试没有意义
+# Retry transient upstream failures; other 4xx failures are not retryable.
 RETRYABLE_STATUS = (429, 502, 503, 504)
 
-# 只有真正描述「调用方这次请求本身有问题」的 4xx 才透传。
-# 401/403/404 不在其中：它们描述的是「本服务 ↔ 模型厂商」那一层的认证结果，
-# 透出去会被调用方读成自己的凭据/权限出了问题（本服务自己的 403 表示
-# 「无该模型 execute 权限」，同一端点上两种含义分不开），一律收敛成 502。
+# Pass through only 4xx statuses that describe a problem with the caller's
+# request. Upstream 401/403/404 statuses describe this service's provider
+# credentials or routing, not the caller's identity. Normalize them to 502 so
+# they cannot be confused with this service's own authentication and permission
+# responses.
 _PASSTHROUGH_STATUS = (400, 408, 413, 422, 429)
 
-# 上游这几个码属于「依赖侧的认证/寻址问题」，对调用方而言就是网关后面出了事
+# Provider authentication and routing failures are dependency failures to callers.
 _DEPENDENCY_AUTH_STATUS = (401, 403, 404)
 
 _TYPE_BY_STATUS = {
@@ -47,7 +48,7 @@ _TYPE_BY_STATUS = {
 
 
 def error_type_for_status(status):
-    """上游状态码推 OpenAI error type；status 为空表示压根没连上。"""
+    """Map an upstream status to an OpenAI error type; None means no connection."""
     if status is None:
         return "api_connection_error"
     if status in _TYPE_BY_STATUS:
@@ -60,12 +61,12 @@ def error_type_for_status(status):
 
 
 def http_status_for(status):
-    """上游状态码映射成本服务的响应状态码。
+    """Map an upstream status to the status returned by this service.
 
-    401/403/404 描述的是本服务与模型厂商之间的认证结果，不能透传——调用方会
-    读成自己的凭据/权限出了问题，被踢去重新登录，而真正该做的是运维换供应商
-    key。这类收敛成 502「网关后面的依赖有问题」，真实原因留在 `error.type`
-    里给排障的人看。
+    Do not pass through provider 401/403/404 responses. A caller would interpret
+    them as its own credential or permission failure, while an operator must fix
+    the provider credential. Normalize them to 502 and retain the diagnostic
+    category in ``error.type``.
     """
     if status is None:
         return 502
@@ -86,7 +87,7 @@ def is_retryable(status):
 
 def build_error(message, *, error_type=DEFAULT_ERROR_TYPE,
                 code=None, param=None):
-    """造一个 OpenAI 形状的错误体。"""
+    """Build an OpenAI-compatible error object."""
     return {
         "error": {
             "message": message if isinstance(message, str) else str(message),
@@ -98,7 +99,7 @@ def build_error(message, *, error_type=DEFAULT_ERROR_TYPE,
 
 
 def _loads(payload):
-    """上游 body 可能是 str/bytes/dict，统一成 dict；解不出来返回 None。"""
+    """Decode a str, bytes, or dict upstream body; return None when it is not JSON."""
     if isinstance(payload, dict):
         return payload
     if isinstance(payload, (bytes, bytearray)):
@@ -115,18 +116,25 @@ def _loads(payload):
     return parsed if isinstance(parsed, dict) else None
 
 
-def from_upstream(payload, status=None, fallback="模型服务调用失败"):
-    """把上游错误 body 归一成 OpenAI 错误体。
+def _localized_owned_message(code):
+    from app.commons.locale import platform_error_message
 
-    上游已经是 ``{"error": {...}}`` 的，补齐缺省字段后原样透传——那本来就是
-    调用方要的东西，再包一层只会让人 JSON.parse 两次。
+    return platform_error_message(code)
+
+
+def from_upstream(payload, status=None, fallback=None):
+    """Normalize an upstream error body to the OpenAI error shape.
+
+    Preserve an existing ``{"error": {...}}`` object after filling required
+    fields. Wrapping it again would require callers to parse JSON twice.
     """
+    fallback = fallback or _localized_owned_message("ModelFactory.Stream.ModelConnectionFailed")
     error_type = error_type_for_status(status)
     data = _loads(payload)
 
     if data is None:
         text = payload.strip() if isinstance(payload, str) else ""
-        # 非 JSON 的 body 可能是网关的 HTML 错误页或一大段堆栈，别原样端给用户
+        # A non-JSON body may be an HTML gateway page or a stack trace.
         if not text or text.startswith("<") or len(text) > _MAX_PLAIN_MESSAGE:
             text = fallback
         return build_error(text, error_type=error_type)
@@ -153,17 +161,17 @@ def from_upstream(payload, status=None, fallback="模型服务调用失败"):
                 value, error_type=error_type,
                 code=data.get("code") or data.get("error_code"))
 
-    # 一个已知字段都没命中：上游 body 形态未知，可能带回显请求、内部 trace id、
-    # 网关节点名。不整段外泄，只给固定文案；原文由调用处落日志。
+    # Unknown upstream bodies may contain echoed requests, internal IDs, or
+    # gateway node names. Return a fixed localized message and log the raw body
+    # only at the call site.
     return build_error(fallback, error_type=error_type, code=data.get("code"))
 
 
 def from_envelope(envelope, status):
-    """把模型工厂自家的 envelope 翻成 OpenAI 错误体。
+    """Convert a Model Factory envelope to the OpenAI error shape.
 
-    原来的 ``code``（如 ``ModelFactory.ExternalSmallModel.Used.NameNotExist``）
-    落到 OpenAI 的 ``code`` 字段上，机器可读的身份不丢；``solution``/``link``
-    这类只对模型工厂控制台有意义的字段不进兼容面。
+    Preserve the stable machine-readable code. Console-specific fields such as
+    ``solution`` and ``link`` are intentionally omitted.
     """
     if not isinstance(envelope, dict):
         return build_error(str(envelope),
@@ -174,30 +182,31 @@ def from_envelope(envelope, status):
         if isinstance(value, str) and value.strip():
             message = value
             break
-    return build_error(message or "模型服务调用失败",
+    return build_error(message or _localized_owned_message("ModelFactory.Stream.ModelConnectionFailed"),
                        error_type=error_type_for_status(status),
                        code=envelope.get("code"))
 
 
 def from_exception(exc, message=None):
-    """连不上上游（超时/DNS/TLS）时的错误体。"""
-    return build_error(message or str(exc) or "模型服务连接失败",
+    """Build a safe localized error for an upstream timeout, DNS, or TLS failure."""
+    return build_error(message or _localized_owned_message("ModelFactory.Stream.ModelConnectionFailed"),
                        error_type="api_connection_error")
 
 
 def is_error(payload):
-    """判断一个已解析的响应体是不是错误体。"""
+    """Return whether a decoded response uses the OpenAI error shape."""
     return isinstance(payload, dict) and isinstance(payload.get("error"), dict)
 
 
-# OpenAI 错误体本身不带 HTTP 状态码，而上游状态码只在 llm_utils 的 aiohttp 层可见。
-# 这两个私有键是把它带到 controller 出口的通道，序列化成响应前一定被 pop 掉。
+# OpenAI error objects do not carry HTTP status. These private keys transport
+# status metadata from the aiohttp layer to the controller and are removed
+# before serialization.
 _HTTP_STATUS_KEY = "_http_status"
 _RETRY_AFTER_KEY = "_retry_after"
 
 
-# 只有「等一会儿真能好」的结果才配 Retry-After。502 是依赖侧鉴权/寻址问题
-# （上游 401/403/404 收敛而来），重试到天亮也没用，不能诱导调用方退避重试。
+# Emit Retry-After only for transient failures. A normalized 502 represents a
+# provider credential or routing problem and retrying cannot resolve it.
 _RETRY_AFTER_STATUS = (429, 503)
 
 
@@ -222,7 +231,7 @@ def pop_retry_after(error_body):
 
 
 def public_copy(payload):
-    """剥掉私有键的副本。BKN Trace evidence 会持久化，别把内部传参落进去。"""
+    """Copy a payload without private transport metadata."""
     if not isinstance(payload, dict):
         return payload
     return {k: v for k, v in payload.items()
@@ -230,12 +239,12 @@ def public_copy(payload):
 
 
 def error_frame(error_body):
-    """错误体 -> SSE data 帧载荷。"""
+    """Serialize an error object as an SSE data payload."""
     return json.dumps(error_body, ensure_ascii=False)
 
 
 def is_error_frame(chunk):
-    """SSE 帧是不是错误帧（trace 收尾判定用）。"""
+    """Return whether an SSE chunk contains an OpenAI error object."""
     if isinstance(chunk, (bytes, bytearray)):
         try:
             chunk = chunk.decode("utf-8", errors="ignore")
@@ -252,7 +261,7 @@ def is_error_frame(chunk):
 
 
 def retry_after_seconds(status, response_headers=None):
-    """上游给了 Retry-After 就跟随；没给则对限流/不可用类给个保守默认值。"""
+    """Use upstream Retry-After or a conservative default for transient failures."""
     if response_headers:
         raw = (response_headers.get("Retry-After")
                or response_headers.get("retry-after"))

--- a/infra/mf-model-api/app/utils/permission_manager.py
+++ b/infra/mf-model-api/app/utils/permission_manager.py
@@ -39,14 +39,14 @@ class PermissionManager:
                              user_name: str, role: str) -> bool:
         if not base_config.AUTH_ENABLED:
             return True
-        # admin用户无需授权
+        # Administrators do not require object-level authorization.
         if user_id == "266c6a42-6131-4d62-8f39-853e7093701c":
             return True
         # bkn-safe authoritative: grant the four instance ops directly.
         if self._bkn_safe_authoritative():
             return await self._bkn_safe_add(user_id, resource_type, resource_id,
                                             ["display", "modify", "delete", "execute"])
-        """添加权限"""
+        """Add a resource permission."""
         payload = [{
             "accessor": {
                 "id": user_id,
@@ -70,7 +70,7 @@ class PermissionManager:
             "condition": "{}",
             "expires_at": "1970-01-01T08:00:00+08:00"
         }]
-        # 使用filter接口过滤权限不再需要手动添加
+        # The filter endpoint now applies permissions without manual expansion.
         # admin_user_id = "266c6a42-6131-4d62-8f39-853e7093701c"
         # if user_id != admin_user_id:
         #     payload.append({
@@ -125,7 +125,7 @@ class PermissionManager:
             except Exception as e:
                 StandLogger.error(e.args)
                 return False
-        """校验用户对资源的权限"""
+        """Check whether a user can perform an operation on a resource."""
         payload = {
             "method": "GET",
             "accessor": {
@@ -234,7 +234,7 @@ class PermissionManager:
         # bkn-safe authoritative: filter the model set by per-resource checks.
         if self._bkn_safe_authoritative():
             return await self._bkn_safe_filter_ids(user_id, operation, resource_type)
-        """获取资源列表"""
+        """Return the resources visible to the current identity."""
         payload = {
             "method": "GET",
             "accessor": {
@@ -292,7 +292,7 @@ class PermissionManager:
         # bkn-safe authoritative: drop each resource's policies directly.
         if self._bkn_safe_authoritative():
             return await self._bkn_safe_delete(resource_type, resource_ids)
-        """删除权限"""
+        """Delete resource permissions."""
         session = await self.get_session()
         resources = [{"id": resource_id, "type": resource_type} for resource_id in resource_ids]
         payload = {"resources": resources,

--- a/infra/mf-model-api/app/utils/verify_utils.py
+++ b/infra/mf-model-api/app/utils/verify_utils.py
@@ -12,16 +12,16 @@ from app.logs.stand_log import StandLogger
 
 @func_set_timeout(30)
 async def llm_test(series, config, llm_id, user_id, model_type):
-    message = [AIMessage(content="你是")]
-    content = "测试连接失败，请重新检查信息"
-    prompt = "你是"
-    # 区分openai和其他模型
+    message = [AIMessage(content="Hello")]
+    content = "Connection test failed. Check the configuration and try again."
+    prompt = "Hello"
+    # Handle OpenAI and other providers separately.
     if series == 'openai':
         try:
             try:
                 if "api_key" not in config.keys():
-                    LLMTestError['description'] = "api_key 参数缺失"
-                    LLMTestError['detail'] = "openai大模型需要 api_key"
+                    LLMTestError['description'] = "api_key is missing."
+                    LLMTestError['detail'] = "OpenAI-compatible models require api_key."
                     return JSONResponse(status_code=500, content=LLMTestError)
                 llm = llm_factory.create_llm(llm_type="openai",
                                              api_type="azure",
@@ -49,12 +49,12 @@ async def llm_test(series, config, llm_id, user_id, model_type):
         except Exception as e:
             print(e)
             if isinstance(e.args[0], MaxRetryError):
-                content = "无法访问该链接，请检查该链接是否可以访问"
+                content = "The configured URL is not reachable."
             error_dict = ModelFactory_ModelController_TestModel_Error_Error.copy()
             error_dict["detail"] = str(e.args[0])
             error_dict["description"] = error_dict["solution"] = content
             if not isinstance(e.args[0], MaxRetryError):
-                error_dict["description"] = "模型配置错误，请检查模型信息"
+                error_dict["description"] = "Model configuration is invalid."
             # if error_dict["detail"].strip(" ") != "":
             #     error_dict["description"] = error_dict["detail"]
             # if len(error_dict["description"]) > 500:
@@ -66,7 +66,7 @@ async def llm_test(series, config, llm_id, user_id, model_type):
             params = {
                 "messages": [
                     {
-                        "content": "你好",
+                        "content": "Hello",
                         "role": "user"
                     }
                 ],
@@ -90,14 +90,14 @@ async def llm_test(series, config, llm_id, user_id, model_type):
             return JSONResponse(status_code=200, content=content)
         except Exception as e:
             print(e)
-            content = "测试连接失败，请重新检查信息"
+            content = "Connection test failed. Check the configuration and try again."
             if isinstance(e.args[0], MaxRetryError):
-                content = "无法访问该链接，请检查该链接是否可以访问"
+                content = "The configured URL is not reachable."
             error_dict = ModelFactory_ModelController_TestModel_Error_Error.copy()
             error_dict["detail"] = str(e.args[0])
             error_dict["description"] = error_dict["solution"] = content
             if not isinstance(e.args[0], MaxRetryError):
-                error_dict["description"] = "模型配置错误，请检查模型信息"
+                error_dict["description"] = "Model configuration is invalid."
             return JSONResponse(status_code=400, content=error_dict)
     elif series.lower() == "baidu":
         headers = {
@@ -117,7 +117,7 @@ async def llm_test(series, config, llm_id, user_id, model_type):
         params = {
             "messages": [
                 {
-                    "content": "你好",
+                    "content": "Hello",
                     "role": "user"
                 }
             ]
@@ -137,7 +137,7 @@ async def llm_test(series, config, llm_id, user_id, model_type):
             "messages": [
                 {
                     "role": "user",
-                    "content": "你好"
+                    "content": "Hello"
                 }
             ]
         }
@@ -156,7 +156,7 @@ async def llm_test(series, config, llm_id, user_id, model_type):
             params = {
                 "messages": [
                     {
-                        "content": "你好",
+                        "content": "Hello",
                         "role": "user"
                     }
                 ],
@@ -181,7 +181,7 @@ async def llm_test(series, config, llm_id, user_id, model_type):
                             error_dict["detail"] = await response.text()
                         except Exception as e:
                             StandLogger.error(str(e))
-                        error_dict["description"] = "模型配置错误，请检查模型信息"
+                        error_dict["description"] = "Model configuration is invalid."
                         return JSONResponse(status_code=400, content=error_dict)
                     async for chunk in response.content:
                         chunk = chunk.decode('utf-8')
@@ -214,12 +214,12 @@ async def llm_test(series, config, llm_id, user_id, model_type):
                     return JSONResponse(status_code=200, content=content)
         except Exception as e:
             StandLogger.error(str(e))
-            content = "测试连接失败，请重新检查信息"
+            content = "Connection test failed. Check the configuration and try again."
             if isinstance(e.args[0], MaxRetryError):
-                content = "无法访问该链接，请检查该链接是否可以访问"
+                content = "The configured URL is not reachable."
             error_dict = ModelFactory_ModelController_TestModel_Error_Error.copy()
             error_dict["detail"] = str(e.args[0])
             error_dict["description"] = error_dict["solution"] = content
             if not isinstance(e.args[0], MaxRetryError):
-                error_dict["description"] = "模型配置错误，请检查模型信息"
+                error_dict["description"] = "Model configuration is invalid."
             return JSONResponse(status_code=400, content=error_dict)


### PR DESCRIPTION
## What Changed

Brief description of changes:

- [x] Added stable-code zh-CN/en-US locale resources for active mf-model-api REST and SSE errors.
- [x] Localized OpenAI-compatible failures, sanitized service-owned fallback details, and converted public API schema descriptions and production comments to English.
- [ ] Docs/doc 1 (not applicable; no documentation files were changed)

---

## Why

- Related Issue: Closes #923
- Related Feature: [Internationalization tracking issue #799](https://github.com/openbkn-ai/bkn-foundry/issues/799)
- Background: mf-model-api returned hard-coded Chinese service-owned errors and exposed Chinese API annotations regardless of the request Accept-Language value.

---

## How

- Key implementation points: Freeze the effective locale at request ingress; resolve service-owned messages from paired zh-CN/en-US catalogs by stable error code; apply the same locale to JSON and SSE/OpenAI-compatible failure paths; preserve safe upstream provider errors while replacing unknown or internal diagnostics with localized fallbacks.
- Breaking changes (API, config, database, etc.): None. Existing machine-readable error codes, OpenAI response shapes, HTTP status mapping, database schemas, and configuration contracts are preserved.

---

## Testing

- [x] Unit tests passed locally
- [ ] Integration tests passed locally (external database, Redis, and model-provider environments were not exercised)
- [ ] Verified in test environment (not run)

Test notes:

- `python -m pytest infra/mf-model-api/app/test -q` — 460 passed, 3 skipped, 10 subtests passed
- `python3 tools/check_i18n_catalogs.py`
- `python3 -m unittest tools/test_check_i18n_catalogs.py`
- `python3 -m compileall -q infra/mf-model-api/app`
- `git diff --check`

---

## Risk & Rollback

- Potential risks: Locale catalog coverage and error-detail sanitization may make previously dynamic service-owned diagnostics more generic. Safe, compliant upstream provider messages remain unchanged. Logging, trace/observability behavior, business data, and seed data are outside this change.
- Rollback plan: Revert commit `a03a7e76` to restore the previous mf-model-api message behavior.

---

## Additional Notes

- No MCP endpoint or MCP server is present in mf-model-api, so there was no MCP response path to migrate.
- Per the requested scope, log text and trace/observability code were not migrated.