### PR TITLE
fix(trace): accept trailing slash on trace list

### DIFF
--- a/bkn-trace/agent-observability/src/boot/bootstrap.go
+++ b/bkn-trace/agent-observability/src/boot/bootstrap.go
@@ -466,6 +466,10 @@ func newAppWithArchive(
 		http.NotFound(w, r)
 	})
 	mux.HandleFunc(APIBasePath+"/traces/", func(w http.ResponseWriter, r *http.Request) {
+		if strings.TrimSuffix(r.URL.Path, "/") == APIBasePath+"/traces" {
+			readAuth(evidenceHandler.ListTraceExecutions)(w, r)
+			return
+		}
 		if strings.HasSuffix(strings.TrimSuffix(r.URL.Path, "/"), "/trace-graph") {
 			http.NotFound(w, r)
 			return

--- a/bkn-trace/agent-observability/src/boot/route_boundary_test.go
+++ b/bkn-trace/agent-observability/src/boot/route_boundary_test.go
@@ -74,17 +74,19 @@ func TestPublicTypedTraceListRouteIsRegistered(t *testing.T) {
 		}),
 		nil,
 	)
-	request := httptest.NewRequest(http.MethodGet, APIBasePath+"/traces", nil)
-	request.Header.Set("x-account-id", "user-1")
-	request.Header.Set("x-account-type", "user")
-	request.Header.Set("x-tenant-id", "tenant-1")
-	request.Header.Set("x-business-domain", "domain-1")
-	response := httptest.NewRecorder()
+	for _, path := range []string{APIBasePath + "/traces", APIBasePath + "/traces/"} {
+		request := httptest.NewRequest(http.MethodGet, path, nil)
+		request.Header.Set("x-account-id", "user-1")
+		request.Header.Set("x-account-type", "user")
+		request.Header.Set("x-tenant-id", "tenant-1")
+		request.Header.Set("x-business-domain", "domain-1")
+		response := httptest.NewRecorder()
 
-	app.server.ServeHTTP(response, request)
+		app.server.ServeHTTP(response, request)
 
-	if response.Code != http.StatusOK {
-		t.Fatalf("typed GET /traces route = %d, want 200: %s", response.Code, response.Body.String())
+		if response.Code != http.StatusOK {
+			t.Fatalf("typed GET %s = %d, want 200: %s", path, response.Code, response.Body.String())
+		}
 	}
 }
 


### PR DESCRIPTION
## Summary
- Route the trailing-slash Trace list URL to the typed list handler.
- Retain typed Trace detail and subresource routing.
- Cover both Trace list URL forms in the route-boundary test.

## Verification
- Ran: GOCACHE=/tmp/openbkn-go-cache go test ./src/boot -count=1
- Chrome local verification after restoring the existing enterprise image: Trace list and Trace detail both load normally.

This PR intentionally excludes the unrelated OpenSearch index-creation experiment.