### PR TITLE
chore(oss-gateway): add missing license headers

### DIFF
--- a/infra/oss-gateway-backend/internal/handler/errors.go
+++ b/infra/oss-gateway-backend/internal/handler/errors.go
@@ -1,3 +1,7 @@
+// Copyright openbkn.ai
+//
+// Licensed under the OpenBKN License. See LICENSE-OPENBKN.txt in the project root.
+
 package handler
 
 import (

--- a/infra/oss-gateway-backend/internal/middleware/language.go
+++ b/infra/oss-gateway-backend/internal/middleware/language.go
@@ -1,3 +1,7 @@
+// Copyright openbkn.ai
+//
+// Licensed under the OpenBKN License. See LICENSE-OPENBKN.txt in the project root.
+
 package middleware
 
 import (

--- a/infra/oss-gateway-backend/internal/middleware/logger_test.go
+++ b/infra/oss-gateway-backend/internal/middleware/logger_test.go
@@ -1,3 +1,7 @@
+// Copyright openbkn.ai
+//
+// Licensed under the OpenBKN License. See LICENSE-OPENBKN.txt in the project root.
+
 package middleware
 
 import (

--- a/infra/oss-gateway-backend/internal/service/url_service_test.go
+++ b/infra/oss-gateway-backend/internal/service/url_service_test.go
@@ -1,3 +1,7 @@
+// Copyright openbkn.ai
+//
+// Licensed under the OpenBKN License. See LICENSE-OPENBKN.txt in the project root.
+
 package service
 
 import (

--- a/infra/oss-gateway-backend/locale/locale.go
+++ b/infra/oss-gateway-backend/locale/locale.go
@@ -1,3 +1,7 @@
+// Copyright openbkn.ai
+//
+// Licensed under the OpenBKN License. See LICENSE-OPENBKN.txt in the project root.
+
 // Package locale loads and resolves OSS Gateway translation resources.
 package locale
 

--- a/infra/oss-gateway-backend/locale/locale_test.go
+++ b/infra/oss-gateway-backend/locale/locale_test.go
@@ -1,3 +1,7 @@
+// Copyright openbkn.ai
+//
+// Licensed under the OpenBKN License. See LICENSE-OPENBKN.txt in the project root.
+
 package locale
 
 import (

--- a/infra/oss-gateway-backend/locale/oss-gateway.en-US.toml
+++ b/infra/oss-gateway-backend/locale/oss-gateway.en-US.toml
@@ -1,3 +1,7 @@
+# Copyright openbkn.ai
+#
+# Licensed under the OpenBKN License. See LICENSE-OPENBKN.txt in the project root.
+
 [OssGateway.BadRequest]
 Message = "Bad request"
 Description = "The request parameters are invalid."

--- a/infra/oss-gateway-backend/locale/oss-gateway.zh-CN.toml
+++ b/infra/oss-gateway-backend/locale/oss-gateway.zh-CN.toml
@@ -1,3 +1,7 @@
+# Copyright openbkn.ai
+#
+# Licensed under the OpenBKN License. See LICENSE-OPENBKN.txt in the project root.
+
 [OssGateway.BadRequest]
 Message = "请求错误"
 Description = "请求参数无效。"


### PR DESCRIPTION
# Pull Request

## What Changed

Brief description of changes:

- [x] Added OpenBKN License headers to six Go files introduced by PR #965
- [x] Added OpenBKN License headers to the two OSS Gateway locale TOML files
- [ ] Documentation changes — Not applicable

---

## Why

- Related Issue: Follow-up to #922
- Related Feature: OSS Gateway internationalization
- Background: PR #965 introduced eight new files without the repository-standard OpenBKN License headers.

---

## How

- Key implementation points: prepend the standard OpenBKN net-new file header to each affected Go and TOML file.
- Breaking changes (API, config, database, etc.): None. This change only adds comments.

---

## Testing

- [x] Unit tests passed locally
- [ ] Integration tests passed locally — Not applicable for comment-only changes
- [ ] Verified in test environment — Not applicable for comment-only changes

Test notes:

- `go test ./...`
- `go vet ./...`
- `git diff --check`
- Verified exactly one license header at the beginning of each affected file

---

## Risk & Rollback

- Potential risks: None expected; runtime content is unchanged.
- Rollback plan: Revert the single commit; no data or configuration rollback is required.

---

## Additional Notes

- Follow-up to merged PR #965.
