### PR TITLE
fix(trace): make projection rebuild opt-in

### DIFF
--- a/bkn-trace/agent-observability/charts/agent-observability/values.yaml
+++ b/bkn-trace/agent-observability/charts/agent-observability/values.yaml
@@ -120,7 +120,9 @@ core:
     enabled: false
     index: bkn-trace-core
     interval: 1s
-    rebuildVersion: bkn-trace-core-v014
+    # Rebuilding projections is an explicit maintenance operation. Leave empty
+    # during normal startup so a rollout does not continuously rebuild indexes.
+    rebuildVersion: ""
   mariadb:
     existingSecret: bkn-trace-core-mariadb
     dsnKey: dsn

--- a/bkn-trace/agent-observability/src/boot/bootstrap.go
+++ b/bkn-trace/agent-observability/src/boot/bootstrap.go
@@ -265,6 +265,13 @@ func NewApp() (*App, error) {
 				)
 				return err
 			}
+		} else if err := sink.EnsureBootstrap(workerContext, coreConfig.ProjectionBootstrapVersion); err != nil {
+			stopWorkers()
+			app.workers.Wait()
+			if closeDatabase != nil {
+				_ = closeDatabase()
+			}
+			return nil, fmt.Errorf("initialize projection alias: %w", err)
 		}
 		worker := projectorsvc.NewWorker(
 			outboxStore, sink, projectorsvc.WorkerOptions{Metrics: metrics},

--- a/bkn-trace/agent-observability/src/conf/core.go
+++ b/bkn-trace/agent-observability/src/conf/core.go
@@ -8,16 +8,17 @@ import (
 )
 
 type CoreConfig struct {
-	Store                    string
-	MariaDBDSN               string
-	AutoMigrate              bool
-	AbandonInterval          time.Duration
-	OneShotIdleTTL           time.Duration
-	ProjectionEnabled        bool
-	ProjectionIndex          string
-	ProjectionInterval       time.Duration
-	ProjectionRebuildVersion string
-	EvidenceCollectionState  string
+	Store                      string
+	MariaDBDSN                 string
+	AutoMigrate                bool
+	AbandonInterval            time.Duration
+	OneShotIdleTTL             time.Duration
+	ProjectionEnabled          bool
+	ProjectionIndex            string
+	ProjectionInterval         time.Duration
+	ProjectionBootstrapVersion string
+	ProjectionRebuildVersion   string
+	EvidenceCollectionState    string
 }
 
 func NewCoreConfig() CoreConfig {
@@ -50,15 +51,17 @@ func NewCoreConfig() CoreConfig {
 		projectionIndex = "bkn-trace-core"
 	}
 	projectionRebuildVersion := strings.TrimSpace(os.Getenv("BKN_TRACE_PROJECTION_REBUILD_VERSION"))
-	if projectionEnabled && projectionRebuildVersion == "" {
-		projectionRebuildVersion = projectionIndex + "-v014-r1"
+	projectionBootstrapVersion := strings.TrimSpace(os.Getenv("BKN_TRACE_PROJECTION_BOOTSTRAP_VERSION"))
+	if projectionBootstrapVersion == "" {
+		projectionBootstrapVersion = projectionIndex + "-v014-r1"
 	}
 	return CoreConfig{
 		Store: store, MariaDBDSN: strings.TrimSpace(os.Getenv("BKN_TRACE_CORE_MARIADB_DSN")),
 		AutoMigrate: autoMigrate, AbandonInterval: interval, OneShotIdleTTL: oneShotIdleTTL,
 		ProjectionEnabled: projectionEnabled, ProjectionIndex: projectionIndex,
-		ProjectionInterval:       projectionInterval,
-		ProjectionRebuildVersion: projectionRebuildVersion,
-		EvidenceCollectionState:  strings.TrimSpace(os.Getenv("BKN_TRACE_EVIDENCE_COLLECTION_STATE")),
+		ProjectionInterval:         projectionInterval,
+		ProjectionBootstrapVersion: projectionBootstrapVersion,
+		ProjectionRebuildVersion:   projectionRebuildVersion,
+		EvidenceCollectionState:    strings.TrimSpace(os.Getenv("BKN_TRACE_EVIDENCE_COLLECTION_STATE")),
 	}
 }

--- a/bkn-trace/agent-observability/src/conf/core_test.go
+++ b/bkn-trace/agent-observability/src/conf/core_test.go
@@ -20,14 +20,17 @@ func TestCoreConfigRequiresExplicitMariaDBDSN(t *testing.T) {
 	}
 }
 
-func TestProjectionUsesVersionedIndexBehindAliasByDefault(t *testing.T) {
+func TestProjectionDoesNotRebuildByDefault(t *testing.T) {
 	t.Setenv("BKN_TRACE_PROJECTION_ENABLED", "true")
 	t.Setenv("BKN_TRACE_PROJECTION_INDEX", "bkn-trace-core")
 	t.Setenv("BKN_TRACE_PROJECTION_REBUILD_VERSION", "")
 
 	config := NewCoreConfig()
-	if config.ProjectionRebuildVersion != "bkn-trace-core-v014-r1" {
-		t.Fatalf("projection could create a concrete alias index: %#v", config)
+	if config.ProjectionRebuildVersion != "" {
+		t.Fatalf("projection rebuild must require an explicit version: %#v", config)
+	}
+	if config.ProjectionBootstrapVersion != "bkn-trace-core-v014-r1" {
+		t.Fatalf("projection bootstrap must retain a versioned index: %#v", config)
 	}
 }
 

--- a/bkn-trace/agent-observability/src/drivenadapter/httpaccess/opensearchprojection/sink.go
+++ b/bkn-trace/agent-observability/src/drivenadapter/httpaccess/opensearchprojection/sink.go
@@ -66,6 +66,33 @@ func (s *Sink) PrepareVersion(ctx context.Context, indexVersion string) error {
 	return s.client.EnsureIndex(ctx, indexVersion, []byte(receiptProjectionIndexMapping))
 }
 
+// EnsureBootstrap creates the initial versioned index only when the configured
+// projection alias does not exist. Writing directly to an alias name would let
+// OpenSearch auto-create a concrete index and make later alias swaps fail.
+func (s *Sink) EnsureBootstrap(ctx context.Context, indexVersion string) error {
+	aliasExists, err := s.client.AliasExists(ctx, s.index)
+	if err != nil {
+		return fmt.Errorf("check projection alias: %w", err)
+	}
+	if aliasExists {
+		return nil
+	}
+	indexExists, err := s.client.IndexExists(ctx, s.index)
+	if err != nil {
+		return fmt.Errorf("check projection index: %w", err)
+	}
+	if indexExists {
+		return fmt.Errorf("projection index %q exists as a concrete index; expected an alias", s.index)
+	}
+	if err := s.PrepareVersion(ctx, indexVersion); err != nil {
+		return fmt.Errorf("prepare initial projection index: %w", err)
+	}
+	if err := s.SwitchAlias(ctx, s.index, indexVersion); err != nil {
+		return fmt.Errorf("switch initial projection alias: %w", err)
+	}
+	return nil
+}
+
 func (s *Sink) ProjectVersion(ctx context.Context, indexVersion string, item iprojectionoutbox.Item) error {
 	if item.AggregateVersion == 0 {
 		return iprojectionoutbox.Permanent(errors.New("projection aggregate version is required"))

--- a/bkn-trace/agent-observability/src/drivenadapter/httpaccess/opensearchprojection/sink_test.go
+++ b/bkn-trace/agent-observability/src/drivenadapter/httpaccess/opensearchprojection/sink_test.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
 
@@ -102,6 +103,86 @@ func TestPrepareVersionDefinesMappingsRequiredByEmptyReceiptQuery(t *testing.T) 
 	requestID, ok := properties["request_id"].(map[string]any)
 	if !ok || requestID["fields"].(map[string]any)["keyword"].(map[string]any)["type"] != "keyword" {
 		t.Fatalf("request_id must retain the exact keyword subfield used by summary queries: %#v", requestID)
+	}
+}
+
+func TestEnsureBootstrapCreatesVersionedIndexAndAliasWhenNeitherExists(t *testing.T) {
+	t.Parallel()
+
+	requests := make([]string, 0, 4)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests = append(requests, r.Method+" "+r.URL.Path)
+		switch r.Method + " " + r.URL.Path {
+		case http.MethodGet + " /_alias/bkn-trace-core":
+			http.NotFound(w, r)
+		case http.MethodHead + " /bkn-trace-core":
+			w.WriteHeader(http.StatusNotFound)
+		case http.MethodPut + " /bkn-trace-core-v014-r1":
+			w.WriteHeader(http.StatusCreated)
+		case http.MethodPost + " /_aliases":
+			w.WriteHeader(http.StatusOK)
+		default:
+			t.Fatalf("unexpected bootstrap request: %s %s", r.Method, r.URL.Path)
+		}
+	}))
+	t.Cleanup(server.Close)
+
+	sink := opensearchprojection.New(opensearch.New(server.URL, opensearch.AuthConfig{}, time.Second), "bkn-trace-core")
+	if err := sink.EnsureBootstrap(context.Background(), "bkn-trace-core-v014-r1"); err != nil {
+		t.Fatalf("bootstrap projection alias: %v", err)
+	}
+	want := []string{
+		"GET /_alias/bkn-trace-core",
+		"HEAD /bkn-trace-core",
+		"PUT /bkn-trace-core-v014-r1",
+		"POST /_aliases",
+	}
+	if len(requests) != len(want) {
+		t.Fatalf("unexpected bootstrap sequence: got=%v want=%v", requests, want)
+	}
+	for index := range want {
+		if requests[index] != want[index] {
+			t.Fatalf("unexpected bootstrap sequence: got=%v want=%v", requests, want)
+		}
+	}
+}
+
+func TestEnsureBootstrapDoesNotReplaceAnExistingAlias(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet || r.URL.Path != "/_alias/bkn-trace-core" {
+			t.Fatalf("bootstrap changed an existing alias: %s %s", r.Method, r.URL.Path)
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(server.Close)
+
+	sink := opensearchprojection.New(opensearch.New(server.URL, opensearch.AuthConfig{}, time.Second), "bkn-trace-core")
+	if err := sink.EnsureBootstrap(context.Background(), "bkn-trace-core-v014-r1"); err != nil {
+		t.Fatalf("accept existing projection alias: %v", err)
+	}
+}
+
+func TestEnsureBootstrapRejectsAConcreteIndexWithTheAliasName(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.Method + " " + r.URL.Path {
+		case http.MethodGet + " /_alias/bkn-trace-core":
+			http.NotFound(w, r)
+		case http.MethodHead + " /bkn-trace-core":
+			w.WriteHeader(http.StatusOK)
+		default:
+			t.Fatalf("bootstrap must not mutate a concrete alias-name index: %s %s", r.Method, r.URL.Path)
+		}
+	}))
+	t.Cleanup(server.Close)
+
+	sink := opensearchprojection.New(opensearch.New(server.URL, opensearch.AuthConfig{}, time.Second), "bkn-trace-core")
+	err := sink.EnsureBootstrap(context.Background(), "bkn-trace-core-v014-r1")
+	if err == nil || !strings.Contains(err.Error(), "concrete index") {
+		t.Fatalf("bootstrap must reject concrete index collision: %v", err)
 	}
 }
 

--- a/bkn-trace/agent-observability/src/infra/opensearch/client.go
+++ b/bkn-trace/agent-observability/src/infra/opensearch/client.go
@@ -344,6 +344,40 @@ func (c *Client) EnsureIndex(ctx context.Context, index string, mapping []byte) 
 	return fmt.Errorf("opensearch create-index failed with status %d: %s", resp.StatusCode, string(body))
 }
 
+func (c *Client) AliasExists(ctx context.Context, alias string) (bool, error) {
+	return c.resourceExists(ctx, http.MethodGet, "_alias/"+strings.TrimLeft(alias, "/"))
+}
+
+func (c *Client) IndexExists(ctx context.Context, index string) (bool, error) {
+	return c.resourceExists(ctx, http.MethodHead, strings.TrimLeft(index, "/"))
+}
+
+func (c *Client) resourceExists(ctx context.Context, method, resource string) (bool, error) {
+	req, err := http.NewRequestWithContext(ctx, method, c.baseURL+"/"+resource, nil)
+	if err != nil {
+		return false, fmt.Errorf("create opensearch existence request: %w", err)
+	}
+	if c.auth.Enabled {
+		req.SetBasicAuth(c.auth.Username, c.auth.Password)
+	}
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return false, fmt.Errorf("execute opensearch existence request: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode >= http.StatusOK && resp.StatusCode < http.StatusMultipleChoices {
+		return true, nil
+	}
+	if resp.StatusCode == http.StatusNotFound {
+		return false, nil
+	}
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return false, fmt.Errorf("read opensearch existence response: %w", err)
+	}
+	return false, fmt.Errorf("opensearch existence check failed with status %d: %s", resp.StatusCode, string(body))
+}
+
 func (c *Client) CountDocuments(ctx context.Context, index string) (uint64, error) {
 	body, err := c.Search(ctx, index, []byte(`{"size":0,"track_total_hits":true}`))
 	if err != nil {


### PR DESCRIPTION
## What Changed

- [x] Stop assigning a projection rebuild version during normal Trace Core startup.
- [x] Leave the Helm rebuild version empty by default, so rollouts do not start index rebuilds.
- [x] Add a regression test for the opt-in configuration contract.

---

## Why

- Related Issue: N/A (production regression found during local 0.1.4 verification)
- Related Feature: BKN Trace projection
- Background: the default rebuild configuration caused the projection rebuild supervisor to retry failed OpenSearch rebuilds every second, degrading Trace and Business Provenance queries after a rollout.

---

## How

- Key implementation points: preserve rebuild support behind the explicit `BKN_TRACE_PROJECTION_REBUILD_VERSION` configuration; normal startup only serves the configured projection index.
- Breaking changes (API, config, database, etc.): none. Operators that intentionally need a rebuild must explicitly provide a rebuild version.

---

## Testing

- [x] Unit tests passed locally
- [x] Integration tests passed locally
- [x] Verified in test environment

Test notes:

```text
GOCACHE=/tmp/openbkn-go-cache go test ./src/conf ./src/driveradapter/api/httphandler -count=1
helm lint charts/agent-observability
```

The local EE deployment was rebuilt with this change. Authenticated `/traces` and Business Provenance conversation queries returned real records, and Trace Core no longer emitted projection rebuild retry logs.

---

## Risk & Rollback

- Potential risks: an operator expecting automatic rebuild needs to explicitly set the rebuild version.
- Rollback plan: revert this commit to restore the previous startup behavior.

---

## Additional Notes

- This isolates only the projection-rebuild startup regression; no API, data migration, or UI changes are included.