### PR TITLE
fix(mf-model-manager): replay request body in audit middleware

### DIFF
--- a/infra/mf-model-manager/app/test/test_operation_audit.py
+++ b/infra/mf-model-manager/app/test/test_operation_audit.py
@@ -1,5 +1,9 @@
 import unittest
 
+from fastapi import Body, FastAPI
+from fastapi.testclient import TestClient
+from starlette.middleware.base import BaseHTTPMiddleware
+
 from app.utils import operation_audit
 
 
@@ -15,6 +19,23 @@ class TestOperationAuditRequestID(unittest.TestCase):
 
         self.assertEqual(request_id, "req_gateway")
         self.assertFalse(generated)
+
+    def test_replays_body_to_audited_route(self):
+        app = FastAPI()
+
+        @app.post("/api/mf-model-manager/v1/llm/add")
+        async def add_model(payload: dict = Body(...)):
+            return payload
+
+        app.add_middleware(BaseHTTPMiddleware, dispatch=operation_audit.operation_audit_middleware)
+
+        response = TestClient(app).post(
+            "/api/mf-model-manager/v1/llm/add",
+            json={"max_model_len": 4096, "model_name": "test-model"},
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json()["model_name"], "test-model")
 
 
 if __name__ == "__main__":

--- a/infra/mf-model-manager/app/utils/operation_audit.py
+++ b/infra/mf-model-manager/app/utils/operation_audit.py
@@ -74,6 +74,13 @@ async def operation_audit_middleware(request, call_next):
     if not rule:
         return await call_next(request)
     body = await request.body()
+
+    async def receive():
+        return {"type": "http.request", "body": body, "more_body": False}
+
+    # The audit middleware consumes the ASGI body before FastAPI parses Body(...).
+    # Replay it so the downstream route can parse the same payload.
+    request._receive = receive
     response = await call_next(request)
     tenant = request.headers.get("x-tenant-id", "").strip()
     domain = request.headers.get("x-business-domain", "").strip()


### PR DESCRIPTION
修复模型添加接口因审计中间件读取请求体后无法继续解析的问题。

- 审计中间件读取请求体后，将 body 回放给下游 FastAPI 路由
- 修复 /llm/add 接口进入 Body 参数解析时卡住的问题
- 移除临时调试打印
- 增加审计接口请求体回放的回归测试

# Pull Request

## What Changed

Brief description of changes:

- [x] Fix `mf-model-manager` audit middleware request-body handling
- [x] Add regression coverage for audited `/llm/add` requests
- [x] Remove temporary debugging prints

---

## Why

- Related Issue: N/A
- Related Feature: N/A
- Background:

The audit middleware consumed the request body before FastAPI parsed the route's `Body(...)` parameter. As a result, `POST /api/mf-model-manager/v1/llm/add` became stuck before entering the route handler.

---

## How

- Key implementation points:
  - Read and retain the request body in the audit middleware.
  - Replay the retained body through `request._receive` before calling downstream handlers.
  - Add a regression test to verify that an audited route can still parse its JSON body.
  - Remove temporary diagnostic `print` statements.

- Breaking changes (API, config, database, etc.):
  - None.

---

## Testing

- [ ] Unit tests passed locally
- [ ] Integration tests passed locally
- [ ] Verified in test environment

Test notes:

- `python3 -m py_compile` passed for the modified Python files.
- `git diff --check` passed.
- The regression test was added but not executed locally because `pytest` is not installed in the current environment.
- The endpoint should be verified after deploying/restarting `mf-model-manager`.

---

## Risk & Rollback

- Potential risks:
  - The middleware replays the request body for audited management APIs.
  - Existing audit payload parsing and downstream request handling may be affected if the body replay behavior is changed incorrectly.

- Rollback plan:
  - Revert this PR.
  - Restart the `mf-model-manager` deployment to restore the previous application version.

---

## Additional Notes

- The issue was reproduced with the following log sequence:
  - Audit middleware received `/llm/add`.
  - Request body was read successfully.
  - The request stalled before entering the FastAPI route handler.
- The fix does not require any API, database schema, or configuration changes.