### PR TITLE
fix(mf-model-api): return 404 when requested model is missing

### DIFF
--- a/infra/mf-model-api/app/controller/llm_controller.py
+++ b/infra/mf-model-api/app/controller/llm_controller.py
@@ -79,7 +79,7 @@ async def used_model_openai(request, user_id, language, func_module, trace_heade
                     model_info = llm_model_dao.get_data_from_default_model()
                 if len(model_info) == 0:
                     if not is_default:
-                        return envelope_error_response(ModelFactory_ExternalSmallModel_Used_NameNotExist, 400)
+                        return envelope_error_response(ModelFactory_ExternalSmallModel_Used_NameNotExist, 404)
                     else:
                         return envelope_error_response(ModelFactory_DedaultModel_NotExist, 400)
                 # Refresh the cache with valid JSON.
@@ -92,7 +92,7 @@ async def used_model_openai(request, user_id, language, func_module, trace_heade
                 model_info = llm_model_dao.get_data_from_default_model()
             if len(model_info) == 0:
                 if not is_default:
-                    return envelope_error_response(ModelFactory_ExternalSmallModel_Used_NameNotExist, 400)
+                    return envelope_error_response(ModelFactory_ExternalSmallModel_Used_NameNotExist, 404)
                 else:
                     return envelope_error_response(ModelFactory_DedaultModel_NotExist, 400)
             # Cache the database result as JSON.

--- a/infra/mf-model-api/app/controller/small_model_controller.py
+++ b/infra/mf-model-api/app/controller/small_model_controller.py
@@ -428,14 +428,14 @@ async def embedding_model_used(request, userId, language, role, func_module, pri
                 # Fall back to the database when cached data is invalid.
                 model_info = small_model_dao.get_model_info_by_name_id(model_name, model_id)
                 if len(model_info) == 0:
-                    return JSONResponse(status_code=400, content=ModelFactory_ExternalSmallModel_Used_NameNotExist)
+                    return JSONResponse(status_code=404, content=ModelFactory_ExternalSmallModel_Used_NameNotExist)
                 # Refresh the cache.
                 await redis_util.set_str(key=cache_key, value=str(model_info), expire=3600 * 24)
         else:
             # Query the database when the cache is missing or malformed.
             model_info = small_model_dao.get_model_info_by_name_id(model_name, model_id)
             if len(model_info) == 0:
-                return JSONResponse(status_code=400, content=ModelFactory_ExternalSmallModel_Used_NameNotExist)
+                return JSONResponse(status_code=404, content=ModelFactory_ExternalSmallModel_Used_NameNotExist)
             # Cache the database result.
             await redis_util.set_str(key=cache_key, value=str(model_info), expire=3600 * 24)
         # Refresh records written by older mf-model-api instances, whose query did
@@ -443,7 +443,7 @@ async def embedding_model_used(request, userId, language, role, func_module, pri
         if model_info and "f_embedding_dim" not in model_info[0]:
             model_info = small_model_dao.get_model_info_by_name_id(model_name, model_id)
             if len(model_info) == 0:
-                return JSONResponse(status_code=400, content=ModelFactory_ExternalSmallModel_Used_NameNotExist)
+                return JSONResponse(status_code=404, content=ModelFactory_ExternalSmallModel_Used_NameNotExist)
             await redis_util.set_str(key=cache_key, value=str(model_info), expire=3600 * 24)
         model_info = model_info[0]
         config_info = json.loads(model_info["f_model_config"])
@@ -524,7 +524,8 @@ async def reranker_model_used(request, userId, language, role, func_module, priv
                 # Fall back to the database when cached data is invalid.
                 model_info = _load_small_model(is_default, RERANKER_MODEL_TYPE, model_name, model_id)
                 if len(model_info) == 0:
-                    return JSONResponse(status_code=400, content=_model_missing_error(is_default))
+                    return JSONResponse(status_code=404 if not is_default else 400,
+                                        content=_model_missing_error(is_default))
                 # Refresh the cache.
                 await redis_util.set_str(key=cache_key, value=str(model_info),
                                          expire=_model_cache_ttl(is_default))
@@ -532,7 +533,8 @@ async def reranker_model_used(request, userId, language, role, func_module, priv
             # Query the database when the cache is missing or malformed.
             model_info = _load_small_model(is_default, RERANKER_MODEL_TYPE, model_name, model_id)
             if len(model_info) == 0:
-                return JSONResponse(status_code=400, content=_model_missing_error(is_default))
+                return JSONResponse(status_code=404 if not is_default else 400,
+                                    content=_model_missing_error(is_default))
             # Cache the database result.
             await redis_util.set_str(key=cache_key, value=str(model_info),
                                      expire=_model_cache_ttl(is_default))

--- a/infra/mf-model-api/app/test/test_controller_llm.py
+++ b/infra/mf-model-api/app/test/test_controller_llm.py
@@ -72,6 +72,22 @@ class TestUsedModelOpenai:
                 assert json.loads(result.body)["error"]["code"] == "ModelFactory.LLM.DefaultNotExist"
 
     @pytest.mark.asyncio
+    async def test_missing_named_model_returns_not_found(self, valid_request):
+        """模型名称不存在时返回 HTTP 404，并保留业务错误码。"""
+        mock_redis = AsyncMock()
+        mock_redis.get_str = AsyncMock(return_value=None)
+
+        with patch('app.controller.llm_controller.get_redis_util', return_value=mock_redis):
+            with patch('app.controller.llm_controller.llm_model_dao.get_data_from_model_list_by_name_id',
+                       return_value=[]):
+                result = await used_model_openai(valid_request, "user1", "zh", "test")
+
+        assert isinstance(result, JSONResponse)
+        assert result.status_code == 404
+        assert json.loads(result.body)["error"]["code"] == \
+            "ModelFactory.ExternalSmallModel.Used.NameNotExist"
+
+    @pytest.mark.asyncio
     async def test_max_tokens_exceeds_limit(self, valid_request, mock_model_data):
         """测试max_tokens超过限制"""
         request = valid_request.copy()

--- a/infra/mf-model-api/app/test/test_small_model_default_resolution.py
+++ b/infra/mf-model-api/app/test/test_small_model_default_resolution.py
@@ -4,7 +4,10 @@
 兜底（context-loader 猜 "reranker"、vega 猜 "embedding"），注册名一改就全线
 NameNotExist——而管理员在模型管理里勾的默认反倒没人读。
 """
-from unittest.mock import Mock, patch
+import json
+from unittest.mock import AsyncMock, Mock, patch
+
+import pytest
 
 from app.controller.small_model_controller import (
     DEFAULT_MODEL_CACHE_TTL_SECONDS,
@@ -13,6 +16,7 @@ from app.controller.small_model_controller import (
     _load_small_model,
     _model_cache_ttl,
     _model_missing_error,
+    embedding_model_used,
 )
 from app.commons.errors import (
     ModelFactory_DefaultSmallModel_NotExist,
@@ -21,6 +25,21 @@ from app.commons.errors import (
 
 
 class TestDefaultSmallModelResolution:
+    @pytest.mark.asyncio
+    async def test_explicit_missing_model_returns_not_found(self):
+        request = Mock(model="missing-model", model_id="", input=["text"])
+        mock_redis = AsyncMock()
+        mock_redis.get_str.return_value = None
+
+        with patch("app.controller.small_model_controller.redis_util", mock_redis), \
+                patch("app.controller.small_model_controller.small_model_dao.get_model_info_by_name_id",
+                      return_value=[]):
+            response = await embedding_model_used(request, "user1", "zh", "test")
+
+        assert response.status_code == 404
+        assert json.loads(response.body)["code"] == \
+            "ModelFactory.ExternalSmallModel.Used.NameNotExist"
+
     def test_unspecified_model_resolves_the_type_default(self):
         """既没给名字也没给 id 时，走 f_default=1 那条，而不是按名字瞎查。"""
         with patch("app.controller.small_model_controller.small_model_dao") as dao:

--- a/infra/mf-model-api/app/test/test_small_model_default_resolution.py
+++ b/infra/mf-model-api/app/test/test_small_model_default_resolution.py
@@ -34,7 +34,7 @@ class TestDefaultSmallModelResolution:
         with patch("app.controller.small_model_controller.redis_util", mock_redis), \
                 patch("app.controller.small_model_controller.small_model_dao.get_model_info_by_name_id",
                       return_value=[]):
-            response = await embedding_model_used(request, "user1", "zh", "test")
+            response = await embedding_model_used(request, "user1", "zh", "test", "embedding")
 
         assert response.status_code == 404
         assert json.loads(response.body)["code"] == \

--- a/infra/mf-model-manager/app/controller/llm_controller.py
+++ b/infra/mf-model-manager/app/controller/llm_controller.py
@@ -663,14 +663,14 @@ async def used_model_openai(request, user_id, language, func_module):
                 # Fall back to the database when cached data is invalid.
                 model_info = llm_model_dao.get_data_from_model_list_by_name(model_name)
                 if len(model_info) == 0:
-                    return JSONResponse(status_code=400, content=ModelFactory_ExternalSmallModel_Used_NameNotExist)
+                    return JSONResponse(status_code=404, content=ModelFactory_ExternalSmallModel_Used_NameNotExist)
                 # Refresh the quota cache.
                 await redis_util.set_str(key=cache_key, value=str(model_info), expire=300)
         else:
             # Query the database when the cache is missing or has an unexpected type.
             model_info = llm_model_dao.get_data_from_model_list_by_name(model_name)
             if len(model_info) == 0:
-                return JSONResponse(status_code=400, content=ModelFactory_ExternalSmallModel_Used_NameNotExist)
+                return JSONResponse(status_code=404, content=ModelFactory_ExternalSmallModel_Used_NameNotExist)
             # Cache the quota result.
             await redis_util.set_str(key=cache_key, value=str(model_info), expire=300)
     except Exception as e:

--- a/infra/mf-model-manager/app/test/test_model_controller.py
+++ b/infra/mf-model-manager/app/test/test_model_controller.py
@@ -111,6 +111,20 @@ class TestUsedModelOpenai(TestCase):
             llm_controller.used_model_openai(request, "111", "zh", "test"))
         self.assertEqual(isinstance(res, EventSourceResponse), True)
 
+    def test_used_model_openai_missing_model_returns_not_found(self):
+        loop = asyncio.new_event_loop()
+        asyncio.set_event_loop(loop)
+        llm_controller.redis_util = self._redis_mock()
+        llm_model_dao.get_data_from_model_list_by_name = mock.Mock(return_value=[])
+
+        res = loop.run_until_complete(
+            llm_controller.used_model_openai(
+                {"model": "missing_model", "stream": False}, "111", "zh", "test"))
+
+        self.assertEqual(res.status_code, 404)
+        self.assertEqual(json.loads(res.body)["code"],
+                         "ModelFactory.ExternalSmallModel.Used.NameNotExist")
+
 
 class TestAddModel(TestCase):
     def setUp(self) -> None:


### PR DESCRIPTION
Return HTTP 404 when a requested large or small model name or ID does not exist.

- Update large-model lookup errors from HTTP 400 to 404.
- Update embedding and reranker lookup errors from HTTP 400 to 404.
- Keep default-model-not-configured errors as HTTP 400.
- Preserve existing business error codes.
- Add regression tests for missing large and small models.

# Pull Request

## What Changed

Brief description of changes:

- [x] Update missing-model responses in `mf-model-api`
- [x] Return HTTP 404 for explicitly requested missing models
- [x] Add regression tests for missing large and small models

---

## Why

- Related Issue: N/A
- Related Feature: N/A
- Background:

When a requested model name or model ID did not exist, `mf-model-api` returned HTTP 400. A missing resource should be represented by HTTP 404.

This change applies the corrected status code consistently to large-model, embedding-model, and reranker-model usage APIs.

---

## How

- Key implementation points:
  - Changed large-model lookup failures from HTTP 400 to HTTP 404.
  - Changed embedding-model lookup failures from HTTP 400 to HTTP 404.
  - Changed explicitly requested reranker-model lookup failures from HTTP 400 to HTTP 404.
  - Kept default-model-not-configured errors as HTTP 400.
  - Preserved the existing business error code:
    `ModelFactory.ExternalSmallModel.Used.NameNotExist`.
  - Added regression tests for missing large and small models.

- Breaking changes (API, config, database, etc.):
  - The HTTP status code for explicitly requested but missing models changes from 400 to 404.
  - No API request or response body schema changes.
  - No configuration or database changes.

---

## Testing

- [ ] Unit tests passed locally
- [ ] Integration tests passed locally
- [ ] Verified in test environment

Test notes:

- Python syntax checks passed for all modified files.
- `git diff --check` passed.
- Regression tests were added for missing large and small models.
- Tests were not executed locally because `pytest` is not installed in the current environment.
- The deployed `mf-model-api` service should be restarted and verified with requests using nonexistent large and small model names.

Expected response:

```text
HTTP 404