### PR TITLE
fix(sandbox): pass BKN_SANDBOX_MCP_URL through bwrap and inject it in docker_scheduler

### DIFF
--- a/infra/sandbox/runtime/executor/infrastructure/isolation/bwrap.py
+++ b/infra/sandbox/runtime/executor/infrastructure/isolation/bwrap.py
@@ -439,6 +439,16 @@ console.log('===SANDBOX_RESULT===' + JSON.stringify(result) + '===SANDBOX_RESULT
         env_args: dict[str, str] = {
             "PYTHONPATH": self._build_pythonpath(os.environ.get("PYTHONPATH")),
         }
+        # --clearenv 之后镜像上的环境变量一个都不剩，得像 PYTHONPATH 那样显式带进去。
+        # sandbox_sdk.bkn 拿不到它时会报「请由控制面设置环境变量 BKN_SANDBOX_MCP_URL」
+        # ——而运维恰恰已经设了，只是被 bwrap 挡在了外面。
+        #
+        # 只有这一个需要在这里透传：它由控制面设在**容器**上，本次执行的 env 里没有。
+        # BKN_TOKEN 那些是随每次执行下发的，已经在上面的 execution.context.env_vars
+        # 里，不必也不该从容器环境去捞——容器级的值会跨调用方存活。
+        bkn_mcp_url = os.environ.get("BKN_SANDBOX_MCP_URL", "").strip()
+        if bkn_mcp_url:
+            env_args["BKN_SANDBOX_MCP_URL"] = bkn_mcp_url
         if execution.context.event:
             env_args["EVENT_JSON"] = json.dumps(execution.context.event)
         if execution.context.env_vars:

--- a/infra/sandbox/sandbox_control_plane/src/infrastructure/container_scheduler/docker_scheduler.py
+++ b/infra/sandbox/sandbox_control_plane/src/infrastructure/container_scheduler/docker_scheduler.py
@@ -310,6 +310,12 @@ exec python -m executor.interfaces.http.rest
         # 基础环境变量
         env_vars = dict(config.env_vars)
 
+        # sandbox_sdk.bkn 的 MCP 地址，与 k8s_scheduler 同一处配置。部署级常量，
+        # 注入一次即可；调用方在 event 里传 mcp 时以 event 为准。
+        bkn_mcp_url = get_settings().bkn_sandbox_mcp_url.strip()
+        if bkn_mcp_url:
+            env_vars.setdefault("BKN_SANDBOX_MCP_URL", bkn_mcp_url)
+
         # 基础容器配置
         container_config = {
             "Image": config.image,


### PR DESCRIPTION
## What this fixes

`BKN_SANDBOX_MCP_URL` never reaches the script when bwrap is enabled, so `sandbox_sdk.bkn` cannot find the MCP endpoint on a deployment that has configured one.

`--clearenv` keeps only `PATH` / `HOME` / `TMPDIR` / `PYTHONPATH` and `EVENT_JSON`. The control plane sets `BKN_SANDBOX_MCP_URL` on the *container*, so it is wiped before user code runs, and `bkn` reports "please set the environment variable BKN_SANDBOX_MCP_URL" to an operator who has already set it. `bwrap.py` already does exactly this passthrough for `PYTHONPATH`, with a comment explaining why; this follows that precedent.

`docker_scheduler` gains the same injection. Until now only `k8s_scheduler` had it, leaving the setting inert under docker-compose.

Only this one variable is passed through. It is deployment configuration rather than a secret, and it lives on the container because the execution's own environment does not carry it. `BKN_TOKEN` and the rest travel with each execution and are already in `execution.context.env_vars`; pulling them from the container environment would reintroduce exactly the cross-caller lifetime that the later rounds of #955 removed.

## Why this is a separate PR

The review on #955 raised this in its second round and I replied that it was fixed. It was not: that commit landed on a local `main` rather than the PR branch, so it never merged. `gh pr view 955 --json files` shows neither file was ever part of that PR, and `git show origin/main:…` confirms neither change is upstream.

The other half of that same local commit — the struct fields and the env mapping in the execution factory — did make it in, because a failing test forced me to redo those edits on the branch. Nothing forced a redo for these two, so they stayed behind. Verifying `git show --stat` against the intended file list after committing would have caught it, which is the habit I should have applied.
