### PR TITLE
fix: preserve business provenance round semantics

### DIFF
--- a/bkn-trace/agent-observability/src/domain/service/evidencesvc/summary.go
+++ b/bkn-trace/agent-observability/src/domain/service/evidencesvc/summary.go
@@ -160,6 +160,10 @@ func (s *Service) ListInteractions(ctx context.Context, options evidencevo.Summa
 	childOptions := options
 	childOptions.Status = ""
 	childOptions.EvidenceCompleteness = ""
+	// Build the complete conversation before applying the interaction-level
+	// keyword filter so a round number always reflects its place in the
+	// conversation, rather than its place in the filtered result.
+	childOptions.Keyword = ""
 	for _, request := range requests {
 		if request.InteractionID != "" && matchesRequestFilters(request, childOptions) {
 			grouped[request.InteractionID] = append(grouped[request.InteractionID], request)
@@ -176,6 +180,7 @@ func (s *Service) ListInteractions(ctx context.Context, options evidencevo.Summa
 	if err := s.applyCanonicalInteractionState(ctx, entries); err != nil {
 		return evidencevo.InteractionSummaryPage{}, err
 	}
+	assignInteractionRoundNumbers(entries)
 	entries = filterInteractionSummaries(entries, options)
 	sort.Slice(entries, func(i, j int) bool {
 		if entries[i].StartedAt == entries[j].StartedAt {
@@ -209,7 +214,7 @@ func (s *Service) ListInteractions(ctx context.Context, options evidencevo.Summa
 
 func buildConversationSummary(conversationID string, requests []evidencevo.RequestSummary) evidencevo.ConversationSummary {
 	base, interactionCount := aggregateRequestGroup(requests)
-	questionPreview, resultPreview := latestConversationInteractionPreview(requests)
+	questionPreview, resultPreview := firstConversationInteractionPreview(requests)
 	return evidencevo.ConversationSummary{
 		ConversationID: conversationID,
 		StartedAt:      base.StartedAt, CompletedAt: base.CompletedAt,
@@ -225,7 +230,7 @@ func buildConversationSummary(conversationID string, requests []evidencevo.Reque
 
 // A conversation is a sequence of interactions. Its list preview must describe
 // one interaction, rather than combining an earlier question with a later result.
-func latestConversationInteractionPreview(requests []evidencevo.RequestSummary) (string, string) {
+func firstConversationInteractionPreview(requests []evidencevo.RequestSummary) (string, string) {
 	byInteraction := map[string][]evidencevo.RequestSummary{}
 	for _, request := range requests {
 		if request.InteractionID != "" {
@@ -233,22 +238,43 @@ func latestConversationInteractionPreview(requests []evidencevo.RequestSummary) 
 		}
 	}
 
-	var question, result, latestAt, latestID string
+	var question, result, firstAt, firstID string
 	for interactionID, interactionRequests := range byInteraction {
 		summary, _ := aggregateRequestGroup(interactionRequests)
-		if summary.QuestionPreview == "" || summary.ResultPreview == "" {
-			continue
-		}
-		at := firstPresentSummary(summary.CompletedAt, summary.StartedAt)
-		if question == "" || summaryTimeAfter(at, latestAt) || (at == latestAt && interactionID > latestID) {
-			question, result, latestAt, latestID = summary.QuestionPreview, summary.ResultPreview, at, interactionID
+		at := firstPresentSummary(summary.StartedAt, summary.CompletedAt)
+		if firstID == "" || summaryTimeAfter(firstAt, at) || (at == firstAt && interactionID < firstID) {
+			question, result, firstAt, firstID = summary.QuestionPreview, summary.ResultPreview, at, interactionID
 		}
 	}
-	if question != "" {
+	if firstID != "" {
 		return question, result
 	}
 	base, _ := aggregateRequestGroup(requests)
 	return base.QuestionPreview, base.ResultPreview
+}
+
+// assignInteractionRoundNumbers preserves chronological meaning independently
+// from the list's reverse-chronological display order.
+func assignInteractionRoundNumbers(entries []evidencevo.InteractionListSummary) {
+	byConversation := map[string][]int{}
+	for index := range entries {
+		conversationID := entries[index].ConversationID
+		if conversationID != "" {
+			byConversation[conversationID] = append(byConversation[conversationID], index)
+		}
+	}
+	for _, indexes := range byConversation {
+		sort.Slice(indexes, func(i, j int) bool {
+			left, right := entries[indexes[i]], entries[indexes[j]]
+			if left.StartedAt == right.StartedAt {
+				return left.InteractionID < right.InteractionID
+			}
+			return left.StartedAt < right.StartedAt
+		})
+		for number, index := range indexes {
+			entries[index].RoundNumber = number + 1
+		}
+	}
 }
 
 func buildInteractionListSummary(interactionID string, requests []evidencevo.RequestSummary) evidencevo.InteractionListSummary {

--- a/bkn-trace/agent-observability/src/domain/service/evidencesvc/summary.go
+++ b/bkn-trace/agent-observability/src/domain/service/evidencesvc/summary.go
@@ -272,7 +272,12 @@ func assignInteractionRoundNumbers(entries []evidencevo.InteractionListSummary) 
 			return left.StartedAt < right.StartedAt
 		})
 		for number, index := range indexes {
-			entries[index].RoundNumber = number + 1
+			// A managed Interaction has a persisted ordinal assigned at creation.
+			// Keep it authoritative; timestamps only provide a legacy fallback for
+			// projections that predate the managed lifecycle.
+			if entries[index].RoundNumber == 0 {
+				entries[index].RoundNumber = number + 1
+			}
 		}
 	}
 }
@@ -755,6 +760,7 @@ func (s *Service) applyCanonicalInteractionState(ctx context.Context, entries []
 				&entries[index].DurationMS,
 				interaction,
 			)
+			entries[index].RoundNumber = int(interaction.Ordinal)
 			applyCanonicalPartialReasons(&entries[index].PartialReasons, tx, interaction)
 		}
 		return nil

--- a/bkn-trace/agent-observability/src/domain/service/evidencesvc/summary.go
+++ b/bkn-trace/agent-observability/src/domain/service/evidencesvc/summary.go
@@ -241,6 +241,12 @@ func firstConversationInteractionPreview(requests []evidencevo.RequestSummary) (
 	var question, result, firstAt, firstID string
 	for interactionID, interactionRequests := range byInteraction {
 		summary, _ := aggregateRequestGroup(interactionRequests)
+		// A list preview must remain a usable question/result pair. If the
+		// earliest interaction lost either artifact, prefer the next complete
+		// interaction; aggregateRequestGroup remains the all-incomplete fallback.
+		if summary.QuestionPreview == "" || summary.ResultPreview == "" {
+			continue
+		}
 		at := firstPresentSummary(summary.StartedAt, summary.CompletedAt)
 		if firstID == "" || summaryTimeAfter(firstAt, at) || (at == firstAt && interactionID < firstID) {
 			question, result, firstAt, firstID = summary.QuestionPreview, summary.ResultPreview, at, interactionID

--- a/bkn-trace/agent-observability/src/domain/service/evidencesvc/summary_service_test.go
+++ b/bkn-trace/agent-observability/src/domain/service/evidencesvc/summary_service_test.go
@@ -195,7 +195,7 @@ func TestListConversationsSumsCompletedInteractionDurations(t *testing.T) {
 	}
 }
 
-func TestBuildConversationSummaryUsesLatestCoherentInteractionAndHidesChildCallError(t *testing.T) {
+func TestBuildConversationSummaryUsesFirstCoherentInteractionAndHidesChildCallError(t *testing.T) {
 
 	summary := buildConversationSummary("conversation_supply", []evidencevo.RequestSummary{
 		{
@@ -217,9 +217,9 @@ func TestBuildConversationSummaryUsesLatestCoherentInteractionAndHidesChildCallE
 		},
 	})
 
-	if summary.QuestionPreview != "迄今为止有多少销售订单？" ||
-		summary.ResultPreview != "共有 1441 张销售订单。" {
-		t.Fatalf("conversation must show one coherent latest interaction: %+v", summary)
+	if summary.QuestionPreview != "6月份有哪些需求预测单？" ||
+		summary.ResultPreview != "6月份需求总量为 11594。" {
+		t.Fatalf("conversation must show its first interaction as one coherent pair: %+v", summary)
 	}
 	if summary.ErrorSummary != "" {
 		t.Fatalf("a recoverable child call error must remain at request level: %+v", summary)
@@ -1022,6 +1022,26 @@ func TestBusinessProvenanceConversationAndInteractionListsUseStablePagination(t 
 	secondInteractions, err := service.ListInteractions(context.Background(), options)
 	if err != nil || len(secondInteractions.Entries) != 1 || secondInteractions.Entries[0].InteractionID != "interaction_old" || secondInteractions.NextCursor != nil {
 		t.Fatalf("unexpected second interaction page: %+v err=%v", secondInteractions, err)
+	}
+}
+
+func TestListInteractionsKeepsChronologicalRoundNumbersWhileReturningNewestFirst(t *testing.T) {
+	store := evidencestore.New()
+	seedBusinessProvenanceRequest(t, store, "req_first", "trace_first", "conversation_rounds", "interaction_first", "2026-07-27T08:00:00Z", "第一轮问题", "第一轮结果", "acct_demo")
+	seedBusinessProvenanceRequest(t, store, "req_second", "trace_second", "conversation_rounds", "interaction_second", "2026-07-27T08:10:00Z", "第二轮问题", "第二轮结果", "acct_demo")
+	seedBusinessProvenanceRequest(t, store, "req_third", "trace_third", "conversation_rounds", "interaction_third", "2026-07-27T08:20:00Z", "第三轮问题", "第三轮结果", "acct_demo")
+	service := NewWithProjectionSource(store, store)
+
+	page, err := service.ListInteractions(context.Background(), evidencevo.SummaryQueryOptions{
+		Scope: summaryScope("acct_demo"), ConversationID: "conversation_rounds", Limit: 20,
+	})
+	if err != nil || len(page.Entries) != 3 {
+		t.Fatalf("list interactions: page=%+v err=%v", page, err)
+	}
+	if page.Entries[0].InteractionID != "interaction_third" || page.Entries[0].RoundNumber != 3 ||
+		page.Entries[1].InteractionID != "interaction_second" || page.Entries[1].RoundNumber != 2 ||
+		page.Entries[2].InteractionID != "interaction_first" || page.Entries[2].RoundNumber != 1 {
+		t.Fatalf("newest-first entries must retain chronological round numbers: %+v", page.Entries)
 	}
 }
 

--- a/bkn-trace/agent-observability/src/domain/service/evidencesvc/summary_service_test.go
+++ b/bkn-trace/agent-observability/src/domain/service/evidencesvc/summary_service_test.go
@@ -1045,6 +1045,19 @@ func TestListInteractionsKeepsChronologicalRoundNumbersWhileReturningNewestFirst
 	}
 }
 
+func TestAssignInteractionRoundNumbersPreservesCanonicalOrdinal(t *testing.T) {
+	entries := []evidencevo.InteractionListSummary{
+		{InteractionID: "interaction_latest", ConversationID: "conversation_rounds", StartedAt: "2026-07-27T08:20:00Z", RoundNumber: 3},
+		{InteractionID: "interaction_first", ConversationID: "conversation_rounds", StartedAt: "2026-07-27T08:00:00Z", RoundNumber: 1},
+	}
+
+	assignInteractionRoundNumbers(entries)
+
+	if entries[0].RoundNumber != 3 || entries[1].RoundNumber != 1 {
+		t.Fatalf("canonical interaction ordinals must not be overwritten: %+v", entries)
+	}
+}
+
 func TestRequestAndTraceSummarySupportMultipleTracesAndReverseLookup(t *testing.T) {
 	store := evidencestore.New()
 	seedSummaryRequest(t, store, "req_multi", "trace_multi_a", "2026-07-26T08:00:00Z", "多阶段问题", "最终结果", "agent-a", "bd_demo", "acct_demo")

--- a/bkn-trace/agent-observability/src/domain/service/evidencesvc/summary_service_test.go
+++ b/bkn-trace/agent-observability/src/domain/service/evidencesvc/summary_service_test.go
@@ -226,6 +226,26 @@ func TestBuildConversationSummaryUsesFirstCoherentInteractionAndHidesChildCallEr
 	}
 }
 
+func TestBuildConversationSummarySkipsUnavailableFirstInteractionPreview(t *testing.T) {
+	summary := buildConversationSummary("conversation_supply", []evidencevo.RequestSummary{
+		{
+			RequestID: "req_first", InteractionID: "interaction_first",
+			StartedAt: "2026-08-07T08:00:00Z", CompletedAt: "2026-08-07T08:00:01Z",
+			Status: "completed", EvidenceCompleteness: "partial",
+		},
+		{
+			RequestID: "req_second", InteractionID: "interaction_second",
+			StartedAt: "2026-08-07T08:02:00Z", CompletedAt: "2026-08-07T08:02:01Z",
+			Status: "completed", EvidenceCompleteness: "complete",
+			InteractionQuestion: "后续问题", InteractionResult: "后续结果",
+		},
+	})
+
+	if summary.QuestionPreview != "后续问题" || summary.ResultPreview != "后续结果" {
+		t.Fatalf("conversation preview must skip an unavailable first interaction: %+v", summary)
+	}
+}
+
 func TestListConversationsFiltersAfterApplyingCanonicalSessionStatus(t *testing.T) {
 	evidenceStore := evidencestore.New()
 	seedBusinessProvenanceRequest(

--- a/bkn-trace/agent-observability/src/domain/valueobject/evidencevo/summary.go
+++ b/bkn-trace/agent-observability/src/domain/valueobject/evidencevo/summary.go
@@ -146,6 +146,7 @@ type ConversationSummary struct {
 type InteractionListSummary struct {
 	InteractionID          string   `json:"interaction_id"`
 	ConversationID         string   `json:"conversation_id,omitempty"`
+	RoundNumber            int      `json:"round_number,omitempty"`
 	StartedAt              string   `json:"started_at,omitempty"`
 	CompletedAt            string   `json:"completed_at,omitempty"`
 	Initiator              string   `json:"initiator,omitempty"`


### PR DESCRIPTION
Summary: keep interaction lists newest-first while returning stable chronological round numbers; render the API-owned number in Studio; keep conversation previews as the first interaction input/output pair.\n\nVerification: evidencesvc package tests passed with an isolated Go cache.