### PR TITLE
docs(readme): clarify repository scope

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@ OpenBKN is an ontology-driven business knowledge network platform. Through ontol
 
 **BKN Foundry** is the technical foundation of OpenBKN, providing that business knowledge network with unified data access, safe execution, and governance.
 
+> Repository scope: this repo hosts the backend services, deployment automation, migrations, API definitions, and product documentation for the BKN Foundry runtime.
+
 **On this page:** [📚 Quick links](#toc-quick-links) · [🚀 Quick start](#toc-quick-start) · [🛠️ OpenBKN SDK](#toc-bkn-sdk) · [🛡️ Administration](#toc-kweaver-admin) · [🏗️ BKN Foundry](#toc-kweaver-core) · [📐 BKN Lang](#toc-bkn-lang) · [📊 Benchmarks](#toc-benchmarks)
 
 > **Note:** BKN Foundry is a **backend-only framework** — it does not include a web UI. All interactions are through the CLI, SDK, or API.

--- a/README.zh.md
+++ b/README.zh.md
@@ -16,6 +16,8 @@ OpenBKN 是一个本体驱动的业务知识网络平台，它通过本体建模
 
 **BKN Foundry** 是 OpenBKN 的技术底座，为上述业务知识网络提供统一的数据接入、安全执行与治理能力。
 
+> 仓库范围：本仓库维护 BKN Foundry 运行时的后端服务、部署自动化、迁移脚本、API 定义和产品文档。
+
 **本文目录：** [📚 快速链接](#toc-quick-links) · [🚀 快速开始](#toc-quick-start) · [🛠️ OpenBKN SDK](#toc-bkn-sdk) · [🛡️ 平台管理](#toc-kweaver-admin) · [🏗️ BKN Foundry](#toc-kweaver-core) · [📐 BKN Lang](#toc-bkn-lang) · [📊 基准测试](#toc-benchmarks)
 
 > **注意：** BKN Foundry 是**纯后台框架**，不提供 Web 界面。所有交互通过 CLI、SDK 或 API 完成。


### PR DESCRIPTION
## What Changed

Brief description of changes:

- [x] Docs/doc 1: clarified the root README repository scope in English and Chinese

---

## Why

- Related Issue: N/A
- Related Feature: N/A
- Background: test the Windows SSH commit signing workflow with a minimal README documentation change.

---

## How

- Key implementation points: added a short repository-scope note near the top of `README.md` and `README.zh.md`.
- Breaking changes (API, config, database, etc.): None.

---

## Testing

- [ ] Unit tests passed locally
- [ ] Integration tests passed locally
- [ ] Verified in test environment

Test notes: Documentation-only change. Verified that the commit object contains an SSH signature block.

---

## Risk & Rollback

- Potential risks: Very low; README-only text change.
- Rollback plan: Revert this PR commit.

---

## Additional Notes

- Commit: `a8473f08741f286af1fccf34da983e340af151af`