### PR TITLE
fix(vega): return redacted connection failure details

### DIFF
--- a/adp/vega/vega-backend/server/logics/catalog/catalog_service.go
+++ b/adp/vega/vega-backend/server/logics/catalog/catalog_service.go
@@ -13,6 +13,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"net/url"
 	"strings"
 	"sync"
 	"time"
@@ -46,6 +47,7 @@ const (
 	defaultConnectionTestTimeout           = 30 * time.Second
 	connectorInitializationFailedResult    = "Connector initialization failed."
 	connectionTestFailedResult             = "Connection test failed."
+	maximumConnectionTestResultLength      = 2048
 	catalogDeletedTaskMessage              = "catalog deleted"
 )
 
@@ -1221,7 +1223,7 @@ func (cs *catalogService) testCatalogConnection(
 		return nil, rest.NewHTTPError(ctx, http.StatusBadRequest,
 			verrors.VegaBackend_Catalog_InvalidParameter_SensitiveFieldNotEncrypted).WithErrorDetails(err.Error())
 	}
-	result, err := cs.probeConnection(ctx, catalog.ConnectorType, interfaces.ConnectorConfig(config))
+	result, err := cs.probeConnection(ctx, catalog.ConnectorType, interfaces.ConnectorConfig(config), sensitiveFields)
 	if err != nil {
 		return nil, err
 	}
@@ -1253,11 +1255,11 @@ func (cs *catalogService) TestConnectionConfig(ctx context.Context,
 		return nil, rest.NewHTTPError(ctx, http.StatusBadRequest,
 			verrors.VegaBackend_Catalog_InvalidParameter_SensitiveFieldNotEncrypted).WithErrorDetails(err.Error())
 	}
-	return cs.probeConnection(ctx, req.ConnectorType, interfaces.ConnectorConfig(decryptedConfig))
+	return cs.probeConnection(ctx, req.ConnectorType, interfaces.ConnectorConfig(decryptedConfig), sensitiveFields)
 }
 
 func (cs *catalogService) probeConnection(ctx context.Context, connectorType string,
-	config interfaces.ConnectorConfig) (*interfaces.CatalogHealthCheckStatus, error) {
+	config interfaces.ConnectorConfig, sensitiveFields []string) (*interfaces.CatalogHealthCheckStatus, error) {
 	connector, err := cs.cf.CreateConnectorInstance(ctx, connectorType, config)
 	if err != nil {
 		otellog.LogError(ctx, "Failed to create connector", err)
@@ -1272,12 +1274,46 @@ func (cs *catalogService) probeConnection(ctx context.Context, connectorType str
 	if err := cs.testConnectorConnection(ctx, connector); err != nil {
 		otellog.LogError(ctx, "Failed to test connection to data source", err)
 		result.HealthCheckStatus = interfaces.CatalogHealthStatusUnhealthy
-		result.HealthCheckResult = connectionTestFailedResult
+		result.HealthCheckResult = sanitizeConnectionError(err, config, sensitiveFields)
 		return result, nil
 	}
 	result.HealthCheckStatus = interfaces.CatalogHealthStatusHealthy
 	result.HealthCheckResult = "Connection test succeeded."
 	return result, nil
+}
+
+func sanitizeConnectionError(err error, config interfaces.ConnectorConfig, sensitiveFields []string) string {
+	if err == nil {
+		return ""
+	}
+
+	result := err.Error()
+	for _, field := range sensitiveFields {
+		value, ok := config[field].(string)
+		if !ok || value == "" {
+			continue
+		}
+		for _, variant := range []string{
+			value,
+			url.QueryEscape(value),
+			strings.ReplaceAll(url.QueryEscape(value), "+", "%20"),
+			url.PathEscape(value),
+		} {
+			if variant != "" {
+				result = strings.ReplaceAll(result, variant, "******")
+			}
+		}
+	}
+
+	result = strings.TrimSpace(strings.NewReplacer("\r", " ", "\n", " ").Replace(result))
+	if result == "" {
+		return connectionTestFailedResult
+	}
+	runes := []rune(result)
+	if len(runes) > maximumConnectionTestResultLength {
+		result = string(runes[:maximumConnectionTestResultLength-3]) + "..."
+	}
+	return result
 }
 
 func (cs *catalogService) testConnectorConnection(ctx context.Context, connector interfaces.Connector) error {

--- a/adp/vega/vega-backend/server/logics/catalog/catalog_service_test.go
+++ b/adp/vega/vega-backend/server/logics/catalog/catalog_service_test.go
@@ -604,7 +604,8 @@ func TestCatalogServiceTestConnection(t *testing.T) {
 			"username": "reporter",
 			"password": "secret-password",
 		}
-		connectorError := "dial tcp db.example.com:3306: i/o timeout"
+		connectorError := "dial tcp db.example.com:3306: i/o timeout using password secret-password"
+		redactedError := "dial tcp db.example.com:3306: i/o timeout using password ******"
 
 		ps.EXPECT().CheckPermission(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
 		ca.EXPECT().GetByID(gomock.Any(), "catalog-1").Return(&interfaces.Catalog{
@@ -619,7 +620,7 @@ func TestCatalogServiceTestConnection(t *testing.T) {
 		connector.EXPECT().Close(gomock.Any()).Return(nil)
 		ca.EXPECT().UpdateHealthCheckStatus(gomock.Any(), "catalog-1", gomock.Any()).DoAndReturn(
 			func(_ context.Context, _ string, status interfaces.CatalogHealthCheckStatus) error {
-				assert.Equal(t, connectorError, status.HealthCheckResult)
+				assert.Equal(t, redactedError, status.HealthCheckResult)
 				return nil
 			},
 		)
@@ -635,7 +636,8 @@ func TestCatalogServiceTestConnection(t *testing.T) {
 		require.NoError(t, err)
 		require.NotNil(t, result)
 		assert.Equal(t, interfaces.CatalogHealthStatusUnhealthy, result.HealthCheckStatus)
-		assert.Equal(t, connectorError, result.HealthCheckResult)
+		assert.Equal(t, redactedError, result.HealthCheckResult)
+		assert.NotContains(t, result.HealthCheckResult, "secret-password")
 	})
 
 	t.Run("does not expose connector initialization error during preflight", func(t *testing.T) {

--- a/adp/vega/vega-backend/server/logics/catalog/catalog_service_test.go
+++ b/adp/vega/vega-backend/server/logics/catalog/catalog_service_test.go
@@ -553,6 +553,91 @@ func TestCatalogServiceCreate(t *testing.T) {
 }
 
 func TestCatalogServiceTestConnection(t *testing.T) {
+	t.Run("returns connector details while redacting sensitive config during preflight", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		ps := mock_interfaces.NewMockPermissionService(ctrl)
+		connector := mock_interfaces.NewMockConnector(ctrl)
+		connectorFactory := mock_interfaces.NewMockConnectorFactory(ctrl)
+		config := interfaces.ConnectorConfig{
+			"host":      "db.example.com",
+			"port":      3306,
+			"username":  "reporter",
+			"password":  "secret-password",
+			"databases": []string{"sales"},
+		}
+		connectorError := "dial tcp db.example.com:3306: access denied for reporter on sales with password secret-password"
+
+		ps.EXPECT().CheckPermission(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
+		connectorFactory.EXPECT().GetSensitiveFields("mariadb").Return([]string{"password"})
+		connectorFactory.EXPECT().CreateConnectorInstance(gomock.Any(), "mariadb", config).Return(connector, nil)
+		connector.EXPECT().TestConnection(gomock.Any()).Return(errors.New(connectorError))
+		connector.EXPECT().Close(gomock.Any()).Return(nil)
+
+		cs := &catalogService{
+			appSetting: &common.AppSetting{},
+			ps:         ps,
+			cf:         connectorFactory,
+		}
+		result, err := cs.TestConnectionConfig(context.Background(), &interfaces.CatalogConnectionTestRequest{
+			ConnectorType: "mariadb",
+			ConnectorCfg:  config,
+		})
+
+		require.NoError(t, err)
+		require.NotNil(t, result)
+		assert.Equal(t, interfaces.CatalogHealthStatusUnhealthy, result.HealthCheckStatus)
+		assert.Equal(t,
+			"dial tcp db.example.com:3306: access denied for reporter on sales with password ******",
+			result.HealthCheckResult,
+		)
+		assert.NotContains(t, result.HealthCheckResult, "secret-password")
+	})
+	t.Run("returns connector details for a saved catalog", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		ca := mock_interfaces.NewMockCatalogAccess(ctrl)
+		ps := mock_interfaces.NewMockPermissionService(ctrl)
+		connector := mock_interfaces.NewMockConnector(ctrl)
+		connectorFactory := mock_interfaces.NewMockConnectorFactory(ctrl)
+		config := interfaces.ConnectorConfig{
+			"host":     "db.example.com",
+			"port":     3306,
+			"username": "reporter",
+			"password": "secret-password",
+		}
+		connectorError := "dial tcp db.example.com:3306: i/o timeout"
+
+		ps.EXPECT().CheckPermission(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
+		ca.EXPECT().GetByID(gomock.Any(), "catalog-1").Return(&interfaces.Catalog{
+			ID:            "catalog-1",
+			Type:          interfaces.CatalogTypePhysical,
+			ConnectorType: "mariadb",
+			ConnectorCfg:  config,
+		}, nil)
+		connectorFactory.EXPECT().GetSensitiveFields("mariadb").Return([]string{"password"})
+		connectorFactory.EXPECT().CreateConnectorInstance(gomock.Any(), "mariadb", config).Return(connector, nil)
+		connector.EXPECT().TestConnection(gomock.Any()).Return(errors.New(connectorError))
+		connector.EXPECT().Close(gomock.Any()).Return(nil)
+		ca.EXPECT().UpdateHealthCheckStatus(gomock.Any(), "catalog-1", gomock.Any()).DoAndReturn(
+			func(_ context.Context, _ string, status interfaces.CatalogHealthCheckStatus) error {
+				assert.Equal(t, connectorError, status.HealthCheckResult)
+				return nil
+			},
+		)
+
+		cs := &catalogService{
+			appSetting: &common.AppSetting{},
+			ca:         ca,
+			ps:         ps,
+			cf:         connectorFactory,
+		}
+		result, err := cs.TestConnection(context.Background(), "catalog-1")
+
+		require.NoError(t, err)
+		require.NotNil(t, result)
+		assert.Equal(t, interfaces.CatalogHealthStatusUnhealthy, result.HealthCheckStatus)
+		assert.Equal(t, connectorError, result.HealthCheckResult)
+	})
+
 	t.Run("does not expose connector initialization error during preflight", func(t *testing.T) {
 		ctrl := gomock.NewController(t)
 		mockPS := mock_interfaces.NewMockPermissionService(ctrl)
@@ -705,6 +790,27 @@ func TestCatalogServiceTestConnection(t *testing.T) {
 
 		require.NoError(t, err)
 		assert.Equal(t, interfaces.CatalogHealthStatusUnhealthy, result.HealthCheckStatus)
+	})
+}
+
+func TestSanitizeConnectionError(t *testing.T) {
+	t.Run("redacts literal and URL-encoded sensitive values", func(t *testing.T) {
+		config := interfaces.ConnectorConfig{"password": "p@ss word"}
+		err := errors.New("password=p@ss word dsn-password=p%40ss%20word")
+
+		result := sanitizeConnectionError(err, config, []string{"password"})
+
+		assert.Equal(t, "password=****** dsn-password=******", result)
+	})
+
+	t.Run("flattens and limits an untrusted connector response", func(t *testing.T) {
+		err := errors.New("first line\r\n" + strings.Repeat("x", maximumConnectionTestResultLength+10))
+
+		result := sanitizeConnectionError(err, nil, nil)
+
+		assert.NotContains(t, result, "\n")
+		assert.LessOrEqual(t, len([]rune(result)), maximumConnectionTestResultLength)
+		assert.True(t, strings.HasSuffix(result, "..."))
 	})
 }
 

--- a/docs/api/vega/catalog.yaml
+++ b/docs/api/vega/catalog.yaml
@@ -451,6 +451,9 @@ paths:
         - 连通 → 200 `{ success: true, message }`
         - 连不通 → 200 `{ success: false, message }`
         - 非 2xx 仅用于请求、鉴权、参数校验或服务内部错误。
+
+        失败时 `message` 保留连接器返回的诊断详情（例如主机、端口、用户名、数据库名和驱动错误），
+        但会替换连接器声明的密码、token 等敏感配置值，并限制异常超长的远端响应。
       requestBody:
         required: true
         content:
@@ -519,6 +522,9 @@ paths:
         - 连通 → 200 `{ success: true, message }`
         - 连不通 → 200 `{ success: false, message }`
         - 非 2xx 仅用于"请求 / 鉴权 / 服务内部"问题，与目标连通性无关。
+
+        失败时 `message` 保留连接器返回的诊断详情（例如主机、端口、用户名、数据库名和驱动错误），
+        但会替换连接器声明的密码、token 等敏感配置值，并限制异常超长的远端响应。
       responses:
         "200":
           description: 探测完成（成功或失败均返回，业务结果看 `success` 字段）
@@ -1040,7 +1046,7 @@ components:
           type: integer
           format: int64
         health_check_result:
-          description: 检查详情 / 错误信息
+          description: 检查详情；连接失败时保留经过敏感配置值脱敏和长度限制的连接器错误信息
           type: string
     TestConnectionResult:
       description: 连接测试结果
@@ -1052,5 +1058,5 @@ components:
           description: 是否连通
           type: boolean
         message:
-          description: 详情（失败时为错误信息）
+          description: 详情；失败时为经过敏感配置值脱敏和长度限制的连接器错误信息
           type: string

--- a/docs/api/vega/catalog.yaml
+++ b/docs/api/vega/catalog.yaml
@@ -1046,7 +1046,7 @@ components:
           type: integer
           format: int64
         health_check_result:
-          description: 检查详情；连接失败时保留经过敏感配置值脱敏和长度限制的连接器错误信息
+          description: 检查详情；通过连接测试接口探测失败时，保留经过敏感配置值脱敏和长度限制的连接器错误信息。创建或更新时指定 `allow_unhealthy=true` 而连接失败，仍记录固定文案 `Connection test failed.`。
           type: string
     TestConnectionResult:
       description: 连接测试结果


### PR DESCRIPTION
# Pull Request

## What Changed

- [x] Vega connection tests now return connector diagnostics after connector-declared sensitive configuration values are redacted.
- [x] Preserve host, port, username, and database details; normalize multiline messages and cap error payloads.
- [x] Document the API behavior and add regression coverage.

---

## Why

- Related Issue: Closes #971
- Related Feature: N/A
- Background: connection test failures previously returned only `Connection test failed.`, preventing users from diagnosing invalid connection inputs.

---

## How

- Key implementation points: pass connector-declared sensitive fields into connection probing, redact literal and URL-encoded sensitive values, then return the sanitized connector diagnostic.
- Breaking changes (API, config, database, etc.): No. The existing `success` and `message` response shape is unchanged.

---

## Testing

- [x] Unit tests passed locally
- [ ] Integration tests passed locally (not required; no external dependency)
- [ ] Verified in test environment (not run)

Test notes:

- `make lint`
- `make test`
- `npx @redocly/cli lint --config .redocly.yaml docs/api/vega/catalog.yaml`

---

## Risk & Rollback

- Potential risks: callers receive more diagnostics. Values declared sensitive by the connector are redacted and messages are capped at 2048 characters.
- Rollback plan: revert this PR to restore the generic failure message.

---

## Additional Notes

- The companion Studio PR adds regression coverage for the existing detail-display behavior.