### PR TITLE
refactor(agent-observability): migrate hard-coded text to English

### DIFF
--- a/bkn-trace/agent-observability/src/domain/valueobject/observabilityvo/registry.go
+++ b/bkn-trace/agent-observability/src/domain/valueobject/observabilityvo/registry.go
@@ -2,7 +2,7 @@ package observabilityvo
 
 import "sort"
 
-// Code generated from OpenBKN 日志事件注册表.json OpenBKN-0.1.4-R1.
+// Code generated from the OpenBKN log event registry (OpenBKN-0.1.4-R1).
 // Source SHA-256: 695ac993967e3a9ed49dd638d8a014fa34e1ee3d7d3535b163793ad224e12f10.
 // Do not add extension events here without updating the governed registry first.
 var registeredEventCategories = map[string]string{

--- a/bkn-trace/agent-observability/src/drivenadapter/httpaccess/bknsafeuseraccess/client.go
+++ b/bkn-trace/agent-observability/src/drivenadapter/httpaccess/bknsafeuseraccess/client.go
@@ -147,7 +147,7 @@ func project(entry accessLog, tenantID string) observabilityvo.LogRecord {
 	if outcome == "failure" {
 		severityNumber, severityText = 17, "ERROR"
 	}
-	actorName := firstNonEmpty(entry.ActorNameSnapshot, entry.ActorID, "未识别用户")
+	actorName := firstNonEmpty(entry.ActorNameSnapshot, entry.ActorID, "Unknown user")
 	targetID := firstNonEmpty(entry.ActorID, entry.ActorNameSnapshot)
 	return observabilityvo.LogRecord{
 		EventID: entry.ID, EventTime: entry.CreatedAt, RecordedAt: entry.CreatedAt,

--- a/bkn-trace/agent-observability/src/drivenadapter/httpaccess/bknsafeuseraccess/client_test.go
+++ b/bkn-trace/agent-observability/src/drivenadapter/httpaccess/bknsafeuseraccess/client_test.go
@@ -47,3 +47,18 @@ func TestSearchProjectsBKNsafeUserAccessFacts(t *testing.T) {
 		t.Fatalf("access fact projection is incomplete: %+v", record)
 	}
 }
+
+func TestProjectUsesEnglishUnknownActorFallback(t *testing.T) {
+	record := project(accessLog{
+		ID:        "access-missing-actor",
+		Action:    "login",
+		Outcome:   "success",
+		CreatedAt: time.Date(2026, 8, 18, 10, 0, 0, 0, time.UTC),
+	}, "tenant-a")
+
+	if record.ActorNameSnapshot != "Unknown user" ||
+		record.TargetNameSnapshot != "Unknown user" ||
+		record.SafeSummary != "login Unknown user success" {
+		t.Fatalf("unknown actor fallback is not consistently English: %+v", record)
+	}
+}

--- a/bkn-trace/agent-observability/src/drivenadapter/httpaccess/opensearchconversationaudit/source.go
+++ b/bkn-trace/agent-observability/src/drivenadapter/httpaccess/opensearchconversationaudit/source.go
@@ -160,7 +160,7 @@ func projectConversation(conversation sessionvo.Conversation) observabilityvo.Lo
 		SchemaVersion: "1.0", LogID: sourceID + ":" + eventID, SourceID: sourceID, SourceLogID: eventID,
 		Category: observabilityvo.CategoryRuntimeBusiness, EventName: "conversation.created",
 		EventTimestamp: conversation.CreatedAt, ObservedTimestamp: conversation.CreatedAt,
-		SeverityNumber: 9, SeverityText: "INFO", Outcome: "success", SafeSummary: "发起 Agent 业务会话",
+		SeverityNumber: 9, SeverityText: "INFO", Outcome: "success", SafeSummary: "Started an Agent business conversation",
 		ServiceName: "bkn-trace-core", Environment: "unknown", TenantID: conversation.Owner.TenantID,
 		BusinessDomain: conversation.Owner.BusinessDomainID, ActorID: conversation.Owner.EffectiveSubjectID,
 		EffectiveSubjectID: conversation.Owner.EffectiveSubjectID,

--- a/bkn-trace/agent-observability/src/drivenadapter/httpaccess/opensearchconversationaudit/source_test.go
+++ b/bkn-trace/agent-observability/src/drivenadapter/httpaccess/opensearchconversationaudit/source_test.go
@@ -58,6 +58,7 @@ func TestSearchProjectsConversationCreatedFromAuthoritativeProjection(t *testing
 		record.ConversationID != "conv-a" || record.ActorID != "user-a" || record.ApplicationID != "app-a" ||
 		record.ActorNameSnapshot != "供应链管理员" || record.TargetNameSnapshot != "供应链分析助手" ||
 		record.AuthMethod != "api_key" || record.RequestID != "req-create-a" ||
+		record.SafeSummary != "Started an Agent business conversation" ||
 		record.Attributes["business_context"] != "managed" || record.Attributes["agent_name"] != "供应链分析助手" {
 		t.Fatalf("conversation audit projection lost source facts: %+v", record)
 	}

--- a/bkn-trace/agent-observability/text_policy_test.go
+++ b/bkn-trace/agent-observability/text_policy_test.go
@@ -1,0 +1,54 @@
+// Copyright openbkn.ai
+//
+// Licensed under the OpenBKN License. See LICENSE-OPENBKN.txt in the project root.
+
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"testing"
+)
+
+var hanTextPattern = regexp.MustCompile(`\p{Han}`)
+
+func TestProductionGoCodeHasNoHardCodedChineseText(t *testing.T) {
+	var matches []string
+	err := filepath.WalkDir(".", func(path string, entry fs.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		if entry.IsDir() || filepath.Ext(path) != ".go" || strings.HasSuffix(path, "_test.go") {
+			return nil
+		}
+
+		file, err := os.Open(path)
+		if err != nil {
+			return err
+		}
+
+		scanner := bufio.NewScanner(file)
+		for lineNumber := 1; scanner.Scan(); lineNumber++ {
+			if hanTextPattern.MatchString(scanner.Text()) {
+				matches = append(matches, fmt.Sprintf("%s:%d", path, lineNumber))
+			}
+		}
+		scanErr := scanner.Err()
+		closeErr := file.Close()
+		if scanErr != nil {
+			return scanErr
+		}
+		return closeErr
+	})
+	if err != nil {
+		t.Fatalf("scan production Go code: %v", err)
+	}
+	if len(matches) > 0 {
+		t.Fatalf("production Go code contains hard-coded Chinese text:\n%s", strings.Join(matches, "\n"))
+	}
+}


### PR DESCRIPTION
# Pull Request

## What Changed

Brief description of changes:

- [x] Replace the module-owned unknown-actor fallback and synthesized conversation audit summary with English text.
- [x] Rewrite the generated registry provenance comment in English without changing registry data.
- [x] Add focused behavioral regressions and a static policy test for production Go text.

---

## Why

- Related Issue: [Issue #990](https://github.com/openbkn-ai/bkn-foundry/issues/990)
- Related Feature: Agent Observability internationalization cleanup
- Background: The module still contained three service-owned Chinese literals after HTTP error localization. They could produce mixed-language internal audit output and left production comments inconsistent with repository conventions.

---

## How

- Key implementation points:
  - Use Unknown user only when both the actor snapshot and actor ID are absent.
  - Use a stable English safe summary for synthesized Agent business-conversation audit records.
  - Scan non-test production Go files for Han characters while leaving locale resources, tests, documentation, downstream snapshots, and user-provided business data outside the policy scope.
- Breaking changes (API, config, database, etc.): None. HTTP routes, response contracts, authorization, persistence schemas, and downstream payload structures are unchanged.

---

## Testing

- [x] Unit tests passed locally
- [ ] Integration tests passed locally (N/A: this change has no external integration behavior)
- [ ] Verified in test environment (N/A: backend text-only refactor covered by unit and static tests)

Test notes:

- make ci in bkn-trace/agent-observability
- python3 -m unittest tools/test_check_i18n_catalogs.py
- python3 tools/check_i18n_catalogs.py
- Optional local warning: gocover-cobertura is not installed, so coverage.xml was not generated; Go tests and coverage generation otherwise passed.

---

## Risk & Rollback

- Potential risks: A consumer that compares the exact old Chinese fallback or synthesized safe-summary string will observe the new English value. Machine-readable fields and user-provided content remain unchanged.
- Rollback plan: Revert commit a707a6f5 to restore the previous service-owned text and remove the associated regressions.

---

## Additional Notes

- No API, configuration, database, lifecycle, authorization, or localization-catalog behavior was changed.

Closes #990