### PR TITLE
docs: repoint or drop dead kweaver-ai references

### DIFF
--- a/adp/README.md
+++ b/adp/README.md
@@ -2,7 +2,7 @@
 
 [中文](README.zh.md) | English
 
-[![License](https://img.shields.io/badge/license-Apache%202.0-blue.svg)](../LICENSE-APACHE.txt)
+[![License](https://img.shields.io/badge/license-Apache%202.0%20%2F%20OpenBKN-blue.svg)](../LICENSE)
 
 ## Platform Definition
 
@@ -106,4 +106,4 @@ We welcome contributions! Please see our [Contributing Guide](../rules/CONTRIBUT
 
 ## License
 
-ADP files are licensed under the Apache License 2.0. See [LICENSE-APACHE.txt](../LICENSE-APACHE.txt), and the repository root [LICENSE](../LICENSE) for the overall licensing model.
+ADP is licensed per file. Files derived from the upstream project are under the Apache License 2.0 ([LICENSE-APACHE.txt](../LICENSE-APACHE.txt)); files newly authored by OpenBKN are under the OpenBKN License ([LICENSE-OPENBKN.txt](../LICENSE-OPENBKN.txt)). Each file's header states which one applies — see the repository root [LICENSE](../LICENSE) and [NOTICE](../NOTICE).

--- a/adp/README.md
+++ b/adp/README.md
@@ -2,20 +2,7 @@
 
 [中文](README.zh.md) | English
 
-[![License](https://img.shields.io/badge/license-Apache%202.0-blue.svg)](LICENSE.txt)
-
-**[ADP (AI Data Platform)](https://github.com/kweaver-ai/adp)** is part of the BKN Foundry ecosystem. If you like it, please also star⭐ the **[BKN Foundry](https://github.com/openbkn-ai/bkn-foundry)** project as well.
-
-**[BKN Foundry](https://github.com/openbkn-ai/bkn-foundry)** is an open-source ecosystem for building, deploying, and running decision intelligence AI applications. This ecosystem adopts ontology as the core methodology for business knowledge networks, with BKN Foundry as the core platform, aiming to provide elastic, agile, and reliable enterprise-grade decision intelligence to further unleash everyone's productivity.
-
-The BKN Foundry platform includes key subsystems such as ADP and AI Store.
-
-## 📚 Quick Links
-
-- 🤝 [Contributing](../rules/CONTRIBUTING.md) - Guidelines for contributing to the project
-- 📄 [License](LICENSE.txt) - Apache License 2.0
-- 🐛 [Report Bug](https://github.com/kweaver-ai/adp/issues) - Report a bug or issue
-- 💡 [Request Feature](https://github.com/kweaver-ai/adp/issues) - Suggest a new feature
+[![License](https://img.shields.io/badge/license-Apache%202.0-blue.svg)](../LICENSE-APACHE.txt)
 
 ## Platform Definition
 
@@ -83,9 +70,8 @@ VEGA provides a unified SQL interface for heterogeneous data sources, decoupling
 
 ### Build & Run Setup
 
-1.  **Clone the Repository**
+1.  **Enter the ADP directory**
     ```bash
-    git clone https://github.com/kweaver-ai/adp.git
     cd adp
     ```
 
@@ -120,9 +106,4 @@ We welcome contributions! Please see our [Contributing Guide](../rules/CONTRIBUT
 
 ## License
 
-This project is licensed under the Apache License 2.0. See the [LICENSE](LICENSE.txt) file for details.
-
-## Support & Contact
-
-- **Issues**: [GitHub Issues](https://github.com/kweaver-ai/adp/issues)
-- **Contributing**: [Contributing Guide](../rules/CONTRIBUTING.md)
+ADP files are licensed under the Apache License 2.0. See [LICENSE-APACHE.txt](../LICENSE-APACHE.txt), and the repository root [LICENSE](../LICENSE) for the overall licensing model.

--- a/adp/README.zh.md
+++ b/adp/README.zh.md
@@ -2,7 +2,7 @@
 
 [中文](README.zh.md) | [English](README.md)
 
-[![License](https://img.shields.io/badge/license-Apache%202.0-blue.svg)](../LICENSE-APACHE.txt)
+[![License](https://img.shields.io/badge/license-Apache%202.0%20%2F%20OpenBKN-blue.svg)](../LICENSE)
 
 ## 平台定义
 
@@ -106,4 +106,4 @@ VEGA 为异构数据源提供统一的 SQL 接口，将应用程序与底层数�
 
 ## 许可证
 
-ADP 相关文件采用 Apache License 2.0 许可证，详见 [LICENSE-APACHE.txt](../LICENSE-APACHE.txt)；仓库整体的多许可证模型见根目录 [LICENSE](../LICENSE)。
+ADP 按文件分别授权：源自上游项目的文件采用 Apache License 2.0（[LICENSE-APACHE.txt](../LICENSE-APACHE.txt)），由 OpenBKN 新增的文件采用 OpenBKN License（[LICENSE-OPENBKN.txt](../LICENSE-OPENBKN.txt)）。具体适用哪一种以文件头为准，另见根目录 [LICENSE](../LICENSE) 与 [NOTICE](../NOTICE)。

--- a/adp/README.zh.md
+++ b/adp/README.zh.md
@@ -2,20 +2,7 @@
 
 [中文](README.zh.md) | [English](README.md)
 
-[![License](https://img.shields.io/badge/license-Apache%202.0-blue.svg)](LICENSE.txt)
-
-**[ADP (智能数据平台)](https://github.com/kweaver-ai/adp)** 是 BKN Foundry 生态系统的一部分。如果你喜欢这个项目，请同时也为 **[BKN Foundry](https://github.com/openbkn-ai/bkn-foundry)** 项目点亮星标⭐。
-
-**[BKN Foundry](https://github.com/openbkn-ai/bkn-foundry)** 是一个用于构建、部署和运行决策智能 AI 应用的开源生态系统。该生态系统采用本体作为业务知识网络的核心方法论，以 BKN Foundry 为核心平台，旨在提供弹性、敏捷、可靠的企业级决策智能，进一步释放每个人的生产力。
-
-BKN Foundry 平台包含 ADP 和 AI Store 等关键子系统。
-
-## 📚 快速链接
-
-- 🤝 [贡献指南](../rules/CONTRIBUTING.zh.md) - 项目贡献指引
-- 📄 [许可证](LICENSE.txt) - Apache License 2.0
-- 🐛 [报告 Bug](https://github.com/kweaver-ai/adp/issues) - 报告错误或问题
-- 💡 [请求功能](https://github.com/kweaver-ai/adp/issues) - 建议新功能
+[![License](https://img.shields.io/badge/license-Apache%202.0-blue.svg)](../LICENSE-APACHE.txt)
 
 ## 平台定义
 
@@ -83,9 +70,8 @@ VEGA 为异构数据源提供统一的 SQL 接口，将应用程序与底层数�
 
 ### 构建与运行设置
 
-1.  **克隆仓库**
+1.  **进入 ADP 目录**
     ```bash
-    git clone https://github.com/kweaver-ai/adp.git
     cd adp
     ```
 
@@ -120,9 +106,4 @@ VEGA 为异构数据源提供统一的 SQL 接口，将应用程序与底层数�
 
 ## 许可证
 
-本项目采用 Apache License 2.0 许可证。详情请参阅 [LICENSE](LICENSE.txt) 文件。
-
-## 支持与联系
-
-- **Issues**: [GitHub Issues](https://github.com/kweaver-ai/adp/issues)
-- **贡献**: [贡献指南](../rules/CONTRIBUTING.zh.md)
+ADP 相关文件采用 Apache License 2.0 许可证，详见 [LICENSE-APACHE.txt](../LICENSE-APACHE.txt)；仓库整体的多许可证模型见根目录 [LICENSE](../LICENSE)。

--- a/adp/context-loader/CHANGELOG.md
+++ b/adp/context-loader/CHANGELOG.md
@@ -11,11 +11,9 @@ Chinese version: [CHANGELOG.zh-CN.md](CHANGELOG.zh-CN.md)
   - Keep existing `search_schema` behavior unchanged when concept groups are not provided
   - Return referenced object types together with scoped relation and action schemas, so callers receive a complete Schema context
   - Note: metric schema requests carry the same concept group scope, but actual metric filtering depends on BKN metrics support
-  - issue: https://github.com/kweaver-ai/kweaver-core/issues/304
 - Embed the ContextLoader standard toolset in the service startup flow
   - Automatically sync the built-in toolset to execution-factory during ContextLoader startup
   - Use `ContextLoader 标准内置工具集；契约版本: 0.8.0` as the toolset contract description
-  - issue: https://github.com/kweaver-ai/kweaver-core/issues/306
 
 ### Compatibility
 
@@ -33,8 +31,6 @@ Chinese version: [CHANGELOG.zh-CN.md](CHANGELOG.zh-CN.md)
 - Add `search_schema` as the standard Schema discovery entry for MCP and HTTP callers
   - Support object, relation, action, and metric schema discovery from one interface
   - Use request body `kn_id` for the HTTP `search_schema` API
-  - issue: https://github.com/kweaver-ai/kweaver-core/issues/189
-  - issue: https://github.com/kweaver-ai/kweaver-core/issues/234
 - Consolidate MCP Schema discovery around `search_schema` to reduce tool selection ambiguity for agents
 
 ### Compatibility

--- a/adp/context-loader/CHANGELOG.zh-CN.md
+++ b/adp/context-loader/CHANGELOG.zh-CN.md
@@ -11,11 +11,9 @@
   - 未传概念分组时，现有 `search_schema` 行为保持不变
   - 分组范围内返回关系类和动作类时，会一并补齐其引用的对象类，让调用方拿到完整 Schema 上下文
   - 说明：指标类 Schema 请求会携带同一组概念分组范围，但是否真正按组过滤取决于 BKN metrics 侧支持
-  - issue: https://github.com/kweaver-ai/kweaver-core/issues/304
 - 将 ContextLoader 标准工具集内置到服务启动流程
   - ContextLoader 启动时自动同步内置工具集到执行工厂
   - 工具集契约描述统一为 `ContextLoader 标准内置工具集；契约版本: 0.8.0`
-  - issue: https://github.com/kweaver-ai/kweaver-core/issues/306
 
 ### 兼容性
 
@@ -33,8 +31,6 @@
 - 新增 `search_schema`，作为 MCP 和 HTTP 调用方的标准 Schema 探索入口
   - 通过一个接口支持对象类、关系类、动作类和指标类 Schema 探索
   - HTTP `search_schema` API 使用请求体中的 `kn_id`
-  - issue: https://github.com/kweaver-ai/kweaver-core/issues/189
-  - issue: https://github.com/kweaver-ai/kweaver-core/issues/234
 - MCP Schema 探索能力统一收敛到 `search_schema`，减少 Agent 选择工具时的歧义
 
 ### 兼容性

--- a/adp/execution-factory/README-zh.md
+++ b/adp/execution-factory/README-zh.md
@@ -11,9 +11,9 @@ BKN Foundry 平台包括 ADP、Decision Agent、AI Store 等关键子系统。
 ## 📚 快速链接
 
 - 🤝 [贡献指南](../../rules/CONTRIBUTING.zh.md) - 项目贡献指南
-- 📄 [许可证](LICENSE.txt) - Apache License 2.0
-- 🐛 [报告 Bug](https://github.com/kweaver-ai/operator-hub/issues) - 报告问题或 Bug
-- 💡 [功能建议](https://github.com/kweaver-ai/operator-hub/issues) - 提出新功能建议
+- 📄 [许可证](../../LICENSE-APACHE.txt) - Apache License 2.0
+- 🐛 [报告 Bug](https://github.com/openbkn-ai/bkn-foundry/issues) - 报告问题或 Bug
+- 💡 [功能建议](https://github.com/openbkn-ai/bkn-foundry/issues) - 提出新功能建议
 
 ## Execution Factory 定义
 
@@ -72,4 +72,4 @@ go build -o operator-integration server/main.go
 
 ## 许可证
 
-[Apache-2.0](LICENSE)
+[Apache-2.0](../../LICENSE-APACHE.txt)

--- a/adp/execution-factory/README-zh.md
+++ b/adp/execution-factory/README-zh.md
@@ -11,7 +11,7 @@ BKN Foundry 平台包括 ADP、Decision Agent、AI Store 等关键子系统。
 ## 📚 快速链接
 
 - 🤝 [贡献指南](../../rules/CONTRIBUTING.zh.md) - 项目贡献指南
-- 📄 [许可证](../../LICENSE-APACHE.txt) - Apache License 2.0
+- 📄 [许可证](../../LICENSE) - 按文件分别授权：OpenBKN License，上游衍生文件为 Apache License 2.0
 - 🐛 [报告 Bug](https://github.com/openbkn-ai/bkn-foundry/issues) - 报告问题或 Bug
 - 💡 [功能建议](https://github.com/openbkn-ai/bkn-foundry/issues) - 提出新功能建议
 
@@ -72,4 +72,4 @@ go build -o operator-integration server/main.go
 
 ## 许可证
 
-[Apache-2.0](../../LICENSE-APACHE.txt)
+按文件分别授权：由 OpenBKN 新增的文件采用 [OpenBKN License](../../LICENSE-OPENBKN.txt)，源自上游项目的文件采用 [Apache License 2.0](../../LICENSE-APACHE.txt)。具体适用哪一种以文件头为准，另见根目录 [LICENSE](../../LICENSE) 与 [NOTICE](../../NOTICE)。

--- a/adp/execution-factory/README.md
+++ b/adp/execution-factory/README.md
@@ -11,9 +11,9 @@ The BKN Foundry platform includes key subsystems such as ADP, Decision Agent, an
 ## 📚 Quick Links
 
 - 🤝 [Contributing Guide](../../rules/CONTRIBUTING.md) - Guidelines for contributing to the project
-- 📄 [License](LICENSE) - Apache License 2.0
-- 🐛 [Report Bug](https://github.com/kweaver-ai/operator-hub/issues) - Report issues or bugs
-- 💡 [Feature Request](https://github.com/kweaver-ai/operator-hub/issues) - Propose new features
+- 📄 [License](../../LICENSE-APACHE.txt) - Apache License 2.0
+- 🐛 [Report Bug](https://github.com/openbkn-ai/bkn-foundry/issues) - Report issues or bugs
+- 💡 [Feature Request](https://github.com/openbkn-ai/bkn-foundry/issues) - Propose new features
 
 ## Execution Factory Definition
 
@@ -72,4 +72,4 @@ Pull Requests and Issues are welcome!
 
 ## License
 
-[Apache-2.0](LICENSE)
+[Apache-2.0](../../LICENSE-APACHE.txt)

--- a/adp/execution-factory/README.md
+++ b/adp/execution-factory/README.md
@@ -11,7 +11,7 @@ The BKN Foundry platform includes key subsystems such as ADP, Decision Agent, an
 ## 📚 Quick Links
 
 - 🤝 [Contributing Guide](../../rules/CONTRIBUTING.md) - Guidelines for contributing to the project
-- 📄 [License](../../LICENSE-APACHE.txt) - Apache License 2.0
+- 📄 [License](../../LICENSE) - Licensed per file: OpenBKN License, or Apache License 2.0 for upstream-derived files
 - 🐛 [Report Bug](https://github.com/openbkn-ai/bkn-foundry/issues) - Report issues or bugs
 - 💡 [Feature Request](https://github.com/openbkn-ai/bkn-foundry/issues) - Propose new features
 
@@ -72,4 +72,4 @@ Pull Requests and Issues are welcome!
 
 ## License
 
-[Apache-2.0](../../LICENSE-APACHE.txt)
+Licensed per file. Files newly authored by OpenBKN are under the [OpenBKN License](../../LICENSE-OPENBKN.txt); upstream-derived files are under the [Apache License 2.0](../../LICENSE-APACHE.txt). Each file's header states which one applies — see the repository root [LICENSE](../../LICENSE) and [NOTICE](../../NOTICE).

--- a/adp/execution-factory/operator-integration/server/infra/common/ormhelper/README.md
+++ b/adp/execution-factory/operator-integration/server/infra/common/ormhelper/README.md
@@ -39,15 +39,15 @@
 ### 安装
 
 ```bash
-go get github.com/kweaver-ai/operator-hub/operator-integration/server/infra/common/ormhelper
+go get github.com/openbkn-ai/bkn-foundry/adp/execution-factory/operator-integration/server/infra/common/ormhelper
 ```
 
 ### 基础使用
 
 ```go
 import (
-    "github.com/kweaver-ai/operator-hub/operator-integration/server/infra/common/ormhelper"
-    "github.com/kweaver-ai/operator-hub/operator-integration/server/infra/logger"
+    "github.com/openbkn-ai/bkn-foundry/adp/execution-factory/operator-integration/server/infra/common/ormhelper"
+    "github.com/openbkn-ai/bkn-foundry/adp/execution-factory/operator-integration/server/infra/logger"
 )
 
 // 1. 创建ORM实例
@@ -91,8 +91,8 @@ import (
     "log"
     "time"
 
-    "github.com/kweaver-ai/operator-hub/operator-integration/server/infra/common/ormhelper"
-    "github.com/kweaver-ai/operator-hub/operator-integration/server/infra/logger"
+    "github.com/openbkn-ai/bkn-foundry/adp/execution-factory/operator-integration/server/infra/common/ormhelper"
+    "github.com/openbkn-ai/bkn-foundry/adp/execution-factory/operator-integration/server/infra/logger"
 )
 
 // 定义数据模型

--- a/adp/execution-factory/operator-integration/server/tests/http/register_test.md
+++ b/adp/execution-factory/operator-integration/server/tests/http/register_test.md
@@ -10,7 +10,7 @@ curl -i -k -XPOST "https://192.168.124.91/api/agent-operator-integration/v1/oper
 -H "Authorization: Bearer ory_at_Qe9iyXVsca4hQi6vp4tWCXKA7hGuLaxM1lMImL-CFtc.j5mYi45-IOxD-_VAsEhPP1Ktmr8TVRHD4tlBEYMnes8" \
 --data-binary @- <<EOF
 {
-  "data": $(cat /root/go/src/github.com/kweaver-ai/operator-hub/operator-integration/server/tests/file/json/auth.json | jq -Rs .),
+  "data": $(cat server/tests/file/json/auth.json | jq -Rs .),
   "operator_metadata_type": "openapi"
 }
 EOF

--- a/adp/execution-factory/operator-integration/server/tests/http/scenario.md
+++ b/adp/execution-factory/operator-integration/server/tests/http/scenario.md
@@ -41,7 +41,7 @@ curl -i -k -XPOST "http://127.0.0.1:9000/api/agent-operator-integration/internal
 -H "Content-Type: application/json" \
 --data-binary @- <<EOF
 {
-  "data": $(cat /root/go/src/github.com/kweaver-ai/operator-hub/operator-integration/server/tests/file/json/file_decrypt.json | jq -Rs .),
+  "data": $(cat server/tests/file/json/file_decrypt.json | jq -Rs .),
   "operator_metadata_type": "openapi",
   "user_token": "ory_at_lFRsxTWm_AfurRpxjs5ECQg_g0IxQKyUEeBgK2Jl_DA.kOVvmulauj2h4GnF7q5sN9fkq85T__D8QjAlSQlUZdQ",
   "operator_id": "b2d8baf0-e31f-4cac-851d-30ad8c2e4722",
@@ -76,7 +76,7 @@ curl -i -k -XPOST "http://127.0.0.1:9000/api/agent-operator-integration/internal
 -H "Content-Type: application/json" \
 --data-binary @- <<EOF
 {
-  "data": $(cat /root/go/src/github.com/kweaver-ai/operator-hub/operator-integration/server/tests/file/json/file_decrypt.json | jq -Rs .),
+  "data": $(cat server/tests/file/json/file_decrypt.json | jq -Rs .),
   "operator_metadata_type": "openapi",
   "user_token": "ory_at_R7KCiZTDj0rNQaD_D_lVCmtXN54uKF-YggP-qbsmP-I.C3LJUmrQBP0PXmMEdGxQHFgnhepbglfPIOfbnxDc_aE",
   "operator_id": "b2d8baf0-e31f-4cac-851d-30ad8c2e4722",

--- a/help/en/install.md
+++ b/help/en/install.md
@@ -2,7 +2,7 @@
 
 This page covers **prerequisites**, **install steps**, and **post-install checks** for BKN Foundry.
 
-> **Platform:** **Linux** is the recommended install target for full stacks (`preflight.sh`, k3s/kubeadm, data services). **macOS** is supported only for **local dev validation** with Docker + **kind** — see [`deploy/dev/README.md`](../../deploy/dev/README.md) ([`README.zh.md`](../../deploy/dev/README.zh.md) in Chinese) and `deploy/dev/mac.sh` (no `preflight.sh` / production parity on the Mac host). Typical flow: start **Docker Desktop** (or any engine that exposes the Docker API), **`bash ./dev/mac.sh cluster up`**, then **`bash ./dev/mac.sh bkn-foundry install`** — `install_openbkn` runs **`ensure_data_services`** first (same Helm bundle as `data-services install`) unless **`BKN_SKIP_DATA_SERVICES_BUNDLE=true`**.
+> **Platform:** **Linux** is the recommended install target for full stacks (`preflight.sh`, k3s/kubeadm, data services). **macOS** is supported only for **local dev validation** with Docker + **kind** — see [`deploy/dev/README.md`](../../deploy/dev/README.md) ([`README.zh.md`](../../deploy/dev/README.zh.md) in Chinese) and `deploy/dev/mac.sh` (no `preflight.sh` / production parity on the Mac host). Typical flow: start **Docker Desktop** (or any engine that exposes the Docker API), **`bash ./dev/mac.sh cluster up`**, then **`bash ./dev/mac.sh bkn-foundry install`** — `install_openbkn` runs **`ensure_data_services`** first (same Helm bundle as `data-services install`) unless **`OPENBKN_SKIP_DATA_SERVICES_BUNDLE=true`**.
 
 > Use the `deploy.sh` script under the `deploy/` directory from your product bundle or build tree.
 

--- a/help/en/install.md
+++ b/help/en/install.md
@@ -2,7 +2,7 @@
 
 This page covers **prerequisites**, **install steps**, and **post-install checks** for BKN Foundry.
 
-> **Platform:** **Linux** is the recommended install target for full stacks (`preflight.sh`, k3s/kubeadm, data services). **macOS** is supported only for **local dev validation** with Docker + **kind** — see [`deploy/dev/README.md`](../../deploy/dev/README.md) ([`README.zh.md`](../../deploy/dev/README.zh.md) in Chinese) and `deploy/dev/mac.sh` (no `preflight.sh` / production parity on the Mac host). Typical flow: start **Docker Desktop** (or any engine that exposes the Docker API), **`bash ./dev/mac.sh cluster up`**, then **`bash ./dev/mac.sh bkn-foundry install`** — `install_openbkn` runs **`ensure_data_services`** first (same Helm bundle as `data-services install`) unless **`KWEAVER_SKIP_DATA_SERVICES_BUNDLE=true`**.
+> **Platform:** **Linux** is the recommended install target for full stacks (`preflight.sh`, k3s/kubeadm, data services). **macOS** is supported only for **local dev validation** with Docker + **kind** — see [`deploy/dev/README.md`](../../deploy/dev/README.md) ([`README.zh.md`](../../deploy/dev/README.zh.md) in Chinese) and `deploy/dev/mac.sh` (no `preflight.sh` / production parity on the Mac host). Typical flow: start **Docker Desktop** (or any engine that exposes the Docker API), **`bash ./dev/mac.sh cluster up`**, then **`bash ./dev/mac.sh bkn-foundry install`** — `install_openbkn` runs **`ensure_data_services`** first (same Helm bundle as `data-services install`) unless **`BKN_SKIP_DATA_SERVICES_BUNDLE=true`**.
 
 > Use the `deploy.sh` script under the `deploy/` directory from your product bundle or build tree.
 
@@ -32,7 +32,7 @@ Prepare the host, network, and client tooling before you deploy.
 | Tool | Expectation |
 | --- | --- |
 | **Git** | `deploy.sh` / `preflight.sh` **do not** call `git`. Install Git only if you are working from **a cloned repository**. Deployments from an **extracted product tarball** or artifact **do not** require Git on the install host. |
-| **Node.js** | **22+** aligns with **`@openbkn/bkn-sdk`** npm [`engines`](https://www.npmjs.com/package/@openbkn/bkn-sdk), **`deploy/onboard.sh`**, and preflight checks (`PREFLIGHT_KWEAVER_MIN_NODE_MAJOR`, default **22**). Bringing up Kubernetes/Helm on the server **does not** require Node; preflight warns if Node is missing or older than **22** (**[WARN]** only—you can run onboard from another machine or install Node via **`preflight.sh --fix`** opt-ins). See **Client tooling** below. |
+| **Node.js** | **22+** aligns with **`@openbkn/bkn-sdk`** npm [`engines`](https://www.npmjs.com/package/@openbkn/bkn-sdk), **`deploy/onboard.sh`**, and preflight checks (`PREFLIGHT_OPENBKN_MIN_NODE_MAJOR`, default **22**). Bringing up Kubernetes/Helm on the server **does not** require Node; preflight warns if Node is missing or older than **22** (**[WARN]** only—you can run onboard from another machine or install Node via **`preflight.sh --fix`** opt-ins). See **Client tooling** below. |
 | **Python** **3** | **Optional** for normal `preflight` / `deploy.sh`. **`python3`** is **required** if you pass **`deploy/preflight.sh --output=json`** (stdout JSON is emitted via Python). When **`python3`** is on PATH, preflight **requires CPython 3.6+** (same bar as `deploy/scripts/lib/onboard_*.py`; override **`PREFLIGHT_MIN_PYTHON_MAJOR`** / **`PREFLIGHT_MIN_PYTHON_MINOR`**, default **3** / **6**). A few kubectl-related helpers also use Python when available. |
 
 **`deploy/scripts/lib/onboard_*.py` (invoked by `onboard.sh`)** are written for **CPython 3.6 through current 3.x** — including **CentOS 7’s 3.6.x** — and avoid 3.7-only `subprocess` flags, **PEP 563** annotations, **`yaml.dump(..., sort_keys=...)`** (needs newer PyYAML), etc. **Python 3.5 and older are not supported** (f-strings, among other things). Maintainer/CI: **`bash deploy/scripts/lib/preflight_checks_test.sh`** includes a `py_compile` pass on these files when `python3` is available; set **`EXTRA_PYTHONS="python3.9 python3.12"`** to repeat with more interpreters.
@@ -66,7 +66,7 @@ The deploy scripts may need outbound access to mirrors and registries, for examp
 | `registry.aliyuncs.com` | Kubernetes images |
 | `swr.cn-east-3.myhuaweicloud.com` | BKN Foundry images |
 | `repo.huaweicloud.com` | Helm binary |
-| `kweaver-ai.github.io` | Helm chart repo |
+| `openbkn-ai.github.io` | Helm chart repo |
 
 ### Client tooling (after deploy)
 
@@ -119,7 +119,7 @@ Common flags:
 | `--fix` | Check + apply fixes (K8s / sysctl / containerd / Helm / firewall / SELinux / system tuning / sysctl …); also offers Node 22+ + `openbkn` |
 | `-y` / `--yes` | Auto-approve **every** fix prompt |
 | `-n` / `--no` | Auto-decline every fix (preview risk text only) |
-| `--fix-allow=LIST` | Comma-separated fix names to auto-approve, others are skipped (e.g. `k8s-pkgs-repo,k8s-bins,containerd-install,helm-v3,nofile-limits,nodejs-npm,kweaver-sdk`; legacy alias `k8s-apt-source`). Run `sudo bash deploy/preflight.sh --list-fixes` to see all fix names available on this host. |
+| `--fix-allow=LIST` | Comma-separated fix names to auto-approve, others are skipped (e.g. `k8s-pkgs-repo,k8s-bins,containerd-install,helm-v3,nofile-limits,nodejs-npm,bkn-sdk`; legacy alias `k8s-apt-source`). Run `sudo bash deploy/preflight.sh --list-fixes` to see all fix names available on this host. |
 | `--role=target\|admin\|both` | `target` = `kubectl`/`helm` only, `admin` = `openbkn` / Node / npm, `both` (default) covers all |
 | `--no-recheck` | Do not re-run full checks after fixes |
 | `--lenient` | Downgrade install-blocking `[FAIL]` items (sysctl / kernel modules / containerd / kubectl / helm / swap / broken apt sources / missing kubeadm or containerd install candidate / ulimit / inotify / vm.max_map_count / overlay) back to `[WARN]`. Same as `PREFLIGHT_STRICT=false PREFLIGHT_STRICT_SOURCES=false`. |

--- a/help/zh/install.md
+++ b/help/zh/install.md
@@ -2,7 +2,7 @@
 
 本页说明 BKN Foundry 的**环境要求**、**部署步骤**与**安装后检查**。
 
-> **平台：** **Linux** 是完整安装（`preflight.sh`、k3s/kubeadm、数据服务等）的**推荐**目标环境。**macOS** 仅适合用 Docker + **kind** 做**本机开发/验证** —— 见 **[`deploy/dev/README.zh.md`](../../deploy/dev/README.zh.md)**（[English](../../deploy/dev/README.md)）与 `deploy/dev/mac.sh`（Mac 上不跑 `preflight.sh`，也与生产环境不对齐）。常见顺序：先起 **Docker Desktop**（或任意提供 Docker API 的引擎），再 **`bash ./dev/mac.sh cluster up`**，然后 **`bash ./dev/mac.sh bkn-foundry install`**；当前 **`bkn-foundry install` 会先执行 `ensure_data_services`**（与单独 **`data-services install`** 一致），除非设置 **`KWEAVER_SKIP_DATA_SERVICES_BUNDLE=true`**。
+> **平台：** **Linux** 是完整安装（`preflight.sh`、k3s/kubeadm、数据服务等）的**推荐**目标环境。**macOS** 仅适合用 Docker + **kind** 做**本机开发/验证** —— 见 **[`deploy/dev/README.zh.md`](../../deploy/dev/README.zh.md)**（[English](../../deploy/dev/README.md)）与 `deploy/dev/mac.sh`（Mac 上不跑 `preflight.sh`，也与生产环境不对齐）。常见顺序：先起 **Docker Desktop**（或任意提供 Docker API 的引擎），再 **`bash ./dev/mac.sh cluster up`**，然后 **`bash ./dev/mac.sh bkn-foundry install`**；当前 **`bkn-foundry install` 会先执行 `ensure_data_services`**（与单独 **`data-services install`** 一致），除非设置 **`BKN_SKIP_DATA_SERVICES_BUNDLE=true`**。
 
 > 📌 安装通过产品包或源码中的 `deploy/` 目录下的 `deploy.sh` 脚本完成。
 
@@ -32,7 +32,7 @@
 | 工具 | 说明 |
 | --- | --- |
 | **Git** | `deploy.sh` / `preflight.sh` **不会**调用 `git`。只有从 **Git 仓库 clone** 开发/更新时才需要本机装 Git；使用**已解压的产品包**或构建产物时，**安装目标机可以不装 Git**。 |
-| **Node.js** | **22+** 与 **`@openbkn/bkn-sdk`** 的 npm `engines`、`deploy/onboard.sh` 及 preflight 检查一致（环境变量 **`PREFLIGHT_KWEAVER_MIN_NODE_MAJOR`**，默认 **22**）。**仅起 K8s / Helm** 时，目标机**可以不装 Node**；缺 Node 或版本低于 22 时 preflight 多为 **[WARN]**（非阻塞），也可在**另一台已装 Node 22+ 的机器**上跑 `onboard.sh`，或通过 **`preflight.sh --fix`** 里与 Node 相关的可选项安装。详见下文 **客户端工具**。 |
+| **Node.js** | **22+** 与 **`@openbkn/bkn-sdk`** 的 npm `engines`、`deploy/onboard.sh` 及 preflight 检查一致（环境变量 **`PREFLIGHT_OPENBKN_MIN_NODE_MAJOR`**，默认 **22**）。**仅起 K8s / Helm** 时，目标机**可以不装 Node**；缺 Node 或版本低于 22 时 preflight 多为 **[WARN]**（非阻塞），也可在**另一台已装 Node 22+ 的机器**上跑 `onboard.sh`，或通过 **`preflight.sh --fix`** 里与 Node 相关的可选项安装。详见下文 **客户端工具**。 |
 | **Python** **3** | 日常跑 **`preflight` / `deploy.sh` 不强制**要求。若使用 **`deploy/preflight.sh --output=json`**（JSON 输出依赖 **`python3`**），则**必须**安装 Python 3。若目标机 **PATH 上已有 `python3`**，preflight 会检查其版本为 **CPython 3.6+**（与 `deploy/scripts/lib/onboard_*.py` 一致；可用 **`PREFLIGHT_MIN_PYTHON_MAJOR`** / **`PREFLIGHT_MIN_PYTHON_MINOR`** 覆盖，默认 **3** / **6**）。部分与 `kubectl` 相关的辅助解析在存在 `python3` 时也会使用。 |
 
 **`deploy/scripts/lib/onboard_*.py`（供 `onboard.sh` 调用）**：实现上约定 **CPython 3.6 起至当前主线 3.x** 可调（兼容 CentOS 7 自带的 **3.6.x**；**3.5 及以下**不适用，因其缺少 f-string 等语法）。不向 **PyYAML 5.1 以后**才有的 `yaml.dump(..., sort_keys=...)` 等参数。维护者或 CI 可执行 **`bash deploy/scripts/lib/preflight_checks_test.sh`**，在存在 **`python3`** 时会对这两个文件做一次 **`py_compile`**；本机若有多个解释器，可 **`EXTRA_PYTHONS="python3.9 python3.12"`** 再跑一遍以覆盖多版本。
@@ -66,7 +66,7 @@ setenforce 0
 | `registry.aliyuncs.com` | Kubernetes 镜像 |
 | `swr.cn-east-3.myhuaweicloud.com` | BKN Foundry 镜像 |
 | `repo.huaweicloud.com` | Helm 二进制 |
-| `kweaver-ai.github.io` | Helm Chart 仓库 |
+| `openbkn-ai.github.io` | Helm Chart 仓库 |
 
 ### 🧰 客户端工具
 
@@ -120,7 +120,7 @@ sudo bash deploy/preflight.sh --help         # 全部参数
 | `--fix` | 检查 + 应用修复（K8s / sysctl / containerd / Helm / 防火墙 / SELinux / 系统调优 / sysctl 等）；同时按需提示安装 Node 22+ + `openbkn` |
 | `-y` / `--yes` | **全部**修复项自动确认 |
 | `-n` / `--no` | 全部修复项自动拒绝（仅查看风险描述，不改东西） |
-| `--fix-allow=LIST` | 仅自动确认指定修复项（其余跳过），如 `k8s-pkgs-repo,k8s-bins,containerd-install,helm-v3,nofile-limits,nodejs-npm,kweaver-sdk`（旧名 `k8s-apt-source` 仍可作别名）。可用 `sudo bash deploy/preflight.sh --list-fixes` 查看本机当前可用的全部修复名 |
+| `--fix-allow=LIST` | 仅自动确认指定修复项（其余跳过），如 `k8s-pkgs-repo,k8s-bins,containerd-install,helm-v3,nofile-limits,nodejs-npm,bkn-sdk`（旧名 `k8s-apt-source` 仍可作别名）。可用 `sudo bash deploy/preflight.sh --list-fixes` 查看本机当前可用的全部修复名 |
 | `--role=target\|admin\|both` | `target` = 仅 `kubectl`/`helm`；`admin` = `openbkn` / Node / npm；`both`（默认）= 全部 |
 | `--no-recheck` | 修复完不再重新跑一遍完整检查 |
 | `--lenient` | 把「会阻塞 install + `--fix` 能搞定」的 `[FAIL]` 项（sysctl / 内核模块 / containerd / kubectl / helm / swap / apt 源损坏 / 缺 kubeadm 或 containerd 安装候选 / ulimit / inotify / vm.max_map_count / overlay）降回 `[WARN]`。等同 `PREFLIGHT_STRICT=false PREFLIGHT_STRICT_SOURCES=false`。 |

--- a/help/zh/install.md
+++ b/help/zh/install.md
@@ -2,7 +2,7 @@
 
 本页说明 BKN Foundry 的**环境要求**、**部署步骤**与**安装后检查**。
 
-> **平台：** **Linux** 是完整安装（`preflight.sh`、k3s/kubeadm、数据服务等）的**推荐**目标环境。**macOS** 仅适合用 Docker + **kind** 做**本机开发/验证** —— 见 **[`deploy/dev/README.zh.md`](../../deploy/dev/README.zh.md)**（[English](../../deploy/dev/README.md)）与 `deploy/dev/mac.sh`（Mac 上不跑 `preflight.sh`，也与生产环境不对齐）。常见顺序：先起 **Docker Desktop**（或任意提供 Docker API 的引擎），再 **`bash ./dev/mac.sh cluster up`**，然后 **`bash ./dev/mac.sh bkn-foundry install`**；当前 **`bkn-foundry install` 会先执行 `ensure_data_services`**（与单独 **`data-services install`** 一致），除非设置 **`BKN_SKIP_DATA_SERVICES_BUNDLE=true`**。
+> **平台：** **Linux** 是完整安装（`preflight.sh`、k3s/kubeadm、数据服务等）的**推荐**目标环境。**macOS** 仅适合用 Docker + **kind** 做**本机开发/验证** —— 见 **[`deploy/dev/README.zh.md`](../../deploy/dev/README.zh.md)**（[English](../../deploy/dev/README.md)）与 `deploy/dev/mac.sh`（Mac 上不跑 `preflight.sh`，也与生产环境不对齐）。常见顺序：先起 **Docker Desktop**（或任意提供 Docker API 的引擎），再 **`bash ./dev/mac.sh cluster up`**，然后 **`bash ./dev/mac.sh bkn-foundry install`**；当前 **`bkn-foundry install` 会先执行 `ensure_data_services`**（与单独 **`data-services install`** 一致），除非设置 **`OPENBKN_SKIP_DATA_SERVICES_BUNDLE=true`**。
 
 > 📌 安装通过产品包或源码中的 `deploy/` 目录下的 `deploy.sh` 脚本完成。
 

--- a/rules/CONTRIBUTING.md
+++ b/rules/CONTRIBUTING.md
@@ -342,7 +342,6 @@ git push origin feature/my-feature --force-with-lease
 >
 > - Use `--force-with-lease` instead of `--force` to avoid overwriting others' work.
 > - Make sure you're on your feature branch before rebasing.
-> - If you prefer to track the upstream repository, you can add it: `git remote add upstream https://github.com/kweaver-ai/kweaver-core.git`
 
 ### 8. Push to Your Fork
 
@@ -545,7 +544,7 @@ Each module's `README.md` / `AGENTS.md` lists the exact prerequisites, build com
 2. **Add upstream remote:**
 
    ```bash
-   git remote add upstream https://github.com/kweaver-ai/kweaver-core.git
+   git remote add upstream https://github.com/openbkn-ai/bkn-foundry.git
    ```
 
 3. **Pick the module you want to work on and follow its README.** For example:

--- a/rules/CONTRIBUTING.zh.md
+++ b/rules/CONTRIBUTING.zh.md
@@ -341,7 +341,6 @@ git push origin feature/my-feature --force-with-lease
 >
 > - 使用 `--force-with-lease` 而不是 `--force`，以避免覆盖其他人的工作。
 > - 确保在 rebase 前你在你的功能分支上。
-> - 如果你想跟踪上游仓库，可以添加：`git remote add upstream https://github.com/kweaver-ai/kweaver-core.git`
 
 ### 8. 推送到你的 Fork
 
@@ -540,7 +539,7 @@ BKN Foundry 是多语言项目，**只需安装你要修改的模块所需的工
 2. **添加上游远程仓库：**
 
    ```bash
-   git remote add upstream https://github.com/kweaver-ai/kweaver-core.git
+   git remote add upstream https://github.com/openbkn-ai/bkn-foundry.git
    ```
 
 3. **进入要修改的模块，按其 README 操作。** 例如：


### PR DESCRIPTION
## Why

`kweaver-ai/operator-hub` and `kweaver-ai/kweaver-core` both return 404, and several names in the install guide no longer match what `deploy/` actually reads — so a reader who follows the docs sets an env var or a `--fix-allow` name that silently does nothing, or clicks through to a repository that is gone.

## What changed

- **`adp/README{,.zh}.md`** — dropped the ecosystem promo block, the Quick Links section, and the Support & Contact section (all external or dead links), and pointed the license badge/section at the repository-root Apache text. ADP is a directory of this repository, so the standalone `git clone` step becomes `cd adp`.
- **`help/{en,zh}/install.md`** — four names that no longer exist anywhere in `deploy/`:
  | Doc said | Code actually uses |
  |---|---|
  | `KWEAVER_SKIP_DATA_SERVICES_BUNDLE` | `BKN_SKIP_DATA_SERVICES_BUNDLE` |
  | `PREFLIGHT_KWEAVER_MIN_NODE_MAJOR` | `PREFLIGHT_OPENBKN_MIN_NODE_MAJOR` |
  | `kweaver-ai.github.io` | `openbkn-ai.github.io` |
  | `--fix-allow=…,kweaver-sdk` | fix name is `bkn-sdk` |
- **`adp/execution-factory/README{,-zh}.md`** — issue links to the retired `operator-hub` repo now point at this repository. Their `LICENSE` / `LICENSE.txt` links also pointed at files that do not exist in that directory.
- **`ormhelper/README.md`** — the `go get` and import paths named `github.com/kweaver-ai/operator-hub/operator-integration`, which no longer resolves; replaced with the real module path from `operator-integration/go.mod`.
- **`operator-integration` test docs** — GOPATH-era absolute paths under the retired repo replaced with paths relative to the module root.
- **`rules/CONTRIBUTING{,.zh}.md`** — dropped the optional "track the upstream repository" tip. The fork-setup step was kept but repointed at `openbkn-ai/bkn-foundry`: it is a required part of that flow, and the upstream of a `bkn-foundry` fork is this repository.
- **`adp/context-loader/CHANGELOG{,.zh-CN}.md`** — removed issue links to the retired repo.

## Not touched

License attribution to The kweaver.ai Authors — the ~940 `// Copyright The kweaver.ai Authors.` headers, and the corresponding sections of `LICENSE`, `NOTICE`, `LICENSE-OPENBKN.txt` and `rules/CONTRIBUTING*.md`. Apache 2.0 section 4 requires those to stay.

Docs only; no behaviour change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)