### PR TITLE
docs: drop remaining kweaver brand strings

### DIFF
--- a/.github/workflows/automation-mirror-swr-to-ghcr.yml
+++ b/.github/workflows/automation-mirror-swr-to-ghcr.yml
@@ -4,7 +4,7 @@ name: automation-mirror-swr-to-ghcr
 # (openbkn-ai), so the default / international GHCR install path can pull them
 # without depending on the SWR (CN) registry.
 #
-# These are openbkn/kweaver REBUILDS, not the vanilla docker.io images — the
+# These are openbkn rebuilds, not the vanilla docker.io images — the
 # same tag on docker.io is a DIFFERENT image. So the source of truth is SWR,
 # NOT docker.io. (That is why the earlier docker.io->GHCR mirror in
 # automation-mirror-swr-images.yml was wrong for these repos and must not be

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ OpenBKN is an ontology-driven business knowledge network platform. Through ontol
 
 **BKN Foundry** is the technical foundation of OpenBKN, providing that business knowledge network with unified data access, safe execution, and governance.
 
-**On this page:** [📚 Quick links](#toc-quick-links) · [🚀 Quick start](#toc-quick-start) · [🛠️ OpenBKN SDK](#toc-bkn-sdk) · [🛡️ Administration](#toc-kweaver-admin) · [🏗️ BKN Foundry](#toc-kweaver-core) · [📐 BKN Lang](#toc-bkn-lang) · [📊 Benchmarks](#toc-benchmarks)
+**On this page:** [📚 Quick links](#toc-quick-links) · [🚀 Quick start](#toc-quick-start) · [🛠️ OpenBKN SDK](#toc-bkn-sdk) · [🛡️ Administration](#toc-administration) · [🏗️ BKN Foundry](#toc-bkn-foundry) · [📐 BKN Lang](#toc-bkn-lang) · [📊 Benchmarks](#toc-benchmarks)
 
 > **Note:** BKN Foundry is a **backend-only framework** — it does not include a web UI. All interactions are through the CLI, SDK, or API.
 
@@ -121,9 +121,9 @@ openbkn <command> --help         # help for a specific command, e.g. openbkn bkn
 
 For full product documentation, see the [Documentation](help/README.md) ([EN](help/en/README.md) / [中文](help/zh/README.md)).
 
-> **After a full install**, use the `openbkn admin` subcommands to manage users, organizations, roles, models, and audit logs — see [Administration](#toc-kweaver-admin) below.
+> **After a full install**, use the `openbkn admin` subcommands to manage users, organizations, roles, models, and audit logs — see [Administration](#toc-administration) below.
 
-<a id="toc-kweaver-core"></a>
+<a id="toc-bkn-foundry"></a>
 
 ## 🏗️ BKN Foundry
 
@@ -187,7 +187,7 @@ BKN Lang is a Markdown-based business knowledge modeling language, designed for 
 
 ## 🛠️ OpenBKN SDK
 
-<a id="toc-kweaver-core-and-sdk"></a>
+<a id="toc-bkn-foundry-and-sdk"></a>
 
 ### Install the SDK on the client
 
@@ -318,7 +318,7 @@ const results  = await bkn.kn.search("<kn-id>", "What risks exist in the supply 
 
 For streaming and the full resource API (`bkn.kn`, `bkn.context`, `bkn.models`, `bkn.vega`, `bkn.admin`, …), see the [bkn-sdk](https://github.com/openbkn-ai/bkn-sdk) repository docs and examples.
 
-<a id="toc-kweaver-admin"></a>
+<a id="toc-administration"></a>
 
 ## 🛡️ Administration
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -16,7 +16,7 @@ OpenBKN 是一个本体驱动的业务知识网络平台，它通过本体建模
 
 **BKN Foundry** 是 OpenBKN 的技术底座，为上述业务知识网络提供统一的数据接入、安全执行与治理能力。
 
-**本文目录：** [📚 快速链接](#toc-quick-links) · [🚀 快速开始](#toc-quick-start) · [🛠️ OpenBKN SDK](#toc-bkn-sdk) · [🛡️ 平台管理](#toc-kweaver-admin) · [🏗️ BKN Foundry](#toc-kweaver-core) · [📐 BKN Lang](#toc-bkn-lang) · [📊 基准测试](#toc-benchmarks)
+**本文目录：** [📚 快速链接](#toc-quick-links) · [🚀 快速开始](#toc-quick-start) · [🛠️ OpenBKN SDK](#toc-bkn-sdk) · [🛡️ 平台管理](#toc-administration) · [🏗️ BKN Foundry](#toc-bkn-foundry) · [📐 BKN Lang](#toc-bkn-lang) · [📊 基准测试](#toc-benchmarks)
 
 > **注意：** BKN Foundry 是**纯后台框架**，不提供 Web 界面。所有交互通过 CLI、SDK 或 API 完成。
 
@@ -124,9 +124,9 @@ openbkn <command> --help         # 查看某命令的帮助，例如 openbkn bkn
 
 完整产品文档参见[文档中心](help/README.md)（[中文](help/zh/README.md) / [EN](help/en/README.md)）。
 
-> **完成全量安装后**，使用 `openbkn admin` 子命令进行用户、组织、角色、模型与审计管理 — 详见下文 [平台管理](#toc-kweaver-admin)。
+> **完成全量安装后**，使用 `openbkn admin` 子命令进行用户、组织、角色、模型与审计管理 — 详见下文 [平台管理](#toc-administration)。
 
-<a id="toc-kweaver-core"></a>
+<a id="toc-bkn-foundry"></a>
 
 ## 🏗️ BKN Foundry
 
@@ -190,7 +190,7 @@ BKN Lang 是基于 Markdown 扩展语法的业务知识建模语言，人机双�
 
 ## 🛠️ OpenBKN SDK
 
-<a id="toc-kweaver-core-and-sdk"></a>
+<a id="toc-bkn-foundry-and-sdk"></a>
 
 ### 在客户端上安装 SDK
 
@@ -321,7 +321,7 @@ const results  = await bkn.kn.search("<kn-id>", "供应链有哪些风险？");
 
 流式对话与完整资源 API（`bkn.kn`、`bkn.context`、`bkn.models`、`bkn.vega`、`bkn.admin` 等）更多用法，请参阅 [bkn-sdk](https://github.com/openbkn-ai/bkn-sdk) 仓库文档与示例。
 
-<a id="toc-kweaver-admin"></a>
+<a id="toc-administration"></a>
 
 ## 🛡️ 平台管理
 

--- a/adp/context-loader/agent-retrieval/server/infra/config/agent-retrieval.yaml
+++ b/adp/context-loader/agent-retrieval/server/infra/config/agent-retrieval.yaml
@@ -11,32 +11,32 @@ concept_search_config:
   concept_recall_size: 100
   knn_k: 300
 oauth: # 对应hydra服务
-  public_host: "hydra-public.kweaver"
+  public_host: "hydra-public.openbkn"
   public_port: 4444
   public_protocol: "http"
-  admin_host: "hydra-admin.kweaver"
+  admin_host: "hydra-admin.openbkn"
   admin_port: 4445
   admin_protocol: "http"
   admin_prefix: "/admin"
 bkn_backend:
   private_protocol: "http"
-  private_host: "bkn-backend-svc.kweaver"
+  private_host: "bkn-backend-svc.openbkn"
   private_port: 13014
 ontology_query:
   private_protocol: "http"
-  private_host: "ontology-query-svc.kweaver"
+  private_host: "ontology-query-svc.openbkn"
   private_port: 13018
 vega:
   private_protocol: "http"
-  private_host: "vega-backend-svc.kweaver"
+  private_host: "vega-backend-svc.openbkn"
   private_port: 13014
 data_retrieval:
   private_protocol: "http"
-  private_host: "data-retrieval.kweaver"
+  private_host: "data-retrieval.openbkn"
   private_port: 9100
 operator_integration:
   private_protocol: "http"
-  private_host: "agent-operator-integration.kweaver"
+  private_host: "agent-operator-integration.openbkn"
   private_port: 9000
 bkn_safe: # bkn-safe 鉴权服务，用于校验用户自助签发的 AppKey（API Key）
   private_protocol: "http"
@@ -52,7 +52,7 @@ redis:
   poolSize: 10
 mf_model_api:
   private_protocol: "http"
-  private_host: "mf-model-api.kweaver"
+  private_host: "mf-model-api.openbkn"
   private_port: 9898
 rerank_llm: # 模型默认走系统默认大模型；per-request 经 rerank_llm_model 覆盖（测试/验证用）
   temperature: 0

--- a/adp/execution-factory/operator-integration/server/infra/config/agent-operator-integration.yaml
+++ b/adp/execution-factory/operator-integration/server/infra/config/agent-operator-integration.yaml
@@ -28,31 +28,31 @@ proxy_module:
 
 oauth:
   # 对应hydra服务
-  public_host: "hydra-public.kweaver"
+  public_host: "hydra-public.openbkn"
   public_port: 4444
   public_protocol: "http"
-  admin_host: "hydra-admin.kweaver"
+  admin_host: "hydra-admin.openbkn"
   admin_port: 4445
   admin_protocol: "http"
   admin_prefix: "/admin"
 user_management:
-  private_host: "user-management-private.kweaver"
+  private_host: "user-management-private.openbkn"
   private_port: 30980
   private_protocol: "http"
 authorization:
-  private_host: "authorization-private.kweaver"
+  private_host: "authorization-private.openbkn"
   private_port: 30920
   private_protocol: "http"
 agent-operator-app:
-  private_host: "agent-operator-app.kweaver"
+  private_host: "agent-operator-app.openbkn"
   private_port: 9000
   private_protocol: "http"
 mf-model-api:
-  private_host: "mf-model-api.kweaver"
+  private_host: "mf-model-api.openbkn"
   private_port: 9898
   private_protocol: "http"
 mf-model-manager:
-  private_host: "mf-model-manager.kweaver"
+  private_host: "mf-model-manager.openbkn"
   private_port: 9898
   private_protocol: "http"
 db:
@@ -62,11 +62,11 @@ db:
   max_open_conns: 30
   system_id: ""
 business-system-service:
-  private_host: "business-system-service.kweaver"
+  private_host: "business-system-service.openbkn"
   private_port: 80
   private_protocol: "http"
 sandbox-control-plane:
-  private_host: "sandbox-control-plane.kweaver"
+  private_host: "sandbox-control-plane.openbkn"
   private_port: 8000
   private_protocol: "http"
   template_id: "" # 模板ID
@@ -79,7 +79,7 @@ sandbox-control-plane:
   active_sessions: 1
   max_concurrent_tasks: 100
 vega-backend:
-  private_host: "vega-backend-svc.kweaver"
+  private_host: "vega-backend-svc.openbkn"
   private_port: 13014
   private_protocol: "http"
 
@@ -107,7 +107,7 @@ ai_generation_config:
     presence_penalty: 0.1
 
 oss-gateway-backend:
-  private_host: "oss-gateway-backend.kweaver"
+  private_host: "oss-gateway-backend.openbkn"
   private_port: 8080
   private_protocol: "http"
   storage_id: ""

--- a/bkn-safe/server/config/config.local.yaml.example
+++ b/bkn-safe/server/config/config.local.yaml.example
@@ -16,7 +16,7 @@ db:
   # Remote cluster: kubectl -n resource port-forward svc/mariadb 3307:3306
   host: 127.0.0.1
   port: 3307
-  user: kweaver
+  user: root
   password: "<mariadb-password>"
   name: safe
   # params: "charset=utf8mb4&parseTime=true&loc=Local"

--- a/data-migrator/helm/core-data-migrator/Chart.yaml
+++ b/data-migrator/helm/core-data-migrator/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
 appVersion: 0.1.0
-description: A Helm chart for kweaver-core data-migrator pre-install/pre-upgrade hook
+description: A Helm chart for the BKN Foundry data-migrator pre-install/pre-upgrade hook
 name: core-data-migrator
 version: 0.1.0

--- a/infra/mf-model-manager/charts/templates/deployment.yaml
+++ b/infra/mf-model-manager/charts/templates/deployment.yaml
@@ -22,7 +22,7 @@ spec:
       # 把 ndots 从 ClusterFirst 默认 5 降到 1：sentinel 返回的
       # redis-proton-redis-announce-0.resource.svc.cluster.local 是带 4 个
       # 点的 FQDN，ndots=5 让 libc 先用所有 search domain 拼接试一遍
-      # (kweaver.svc.cluster.local / svc.cluster.local / cluster.local /
+      # (openbkn.svc.cluster.local / svc.cluster.local / cluster.local /
       # localdomain)，每个 ~1s NXDOMAIN，FQDN 解析硬生生耗 6s。redis-py
       # sentinel pool 启动期会做多次此查询，叠出分钟级 startup hang ->
       # startup probe CrashLoop。降到 ndots=1 后直接以 FQDN 查询，毫秒返回。

--- a/infra/sandbox/deploy/helm/README.md
+++ b/infra/sandbox/deploy/helm/README.md
@@ -1,19 +1,19 @@
 # Sandbox Helm Charts
 
-`deploy/helm` contains two charts for different deployment scenarios. They are intentionally separate because Kweaver Core component packaging and standalone Sandbox deployment have different ownership boundaries and values formats.
+`deploy/helm` contains two charts for different deployment scenarios. They are intentionally separate because BKN Foundry component packaging and standalone Sandbox deployment have different ownership boundaries and values formats.
 
 ## Chart Comparison
 
 | Chart | Use Case | Includes | Database | Web Console | Values Format |
 |-------|----------|----------|----------|-------------|---------------|
-| `sandbox` | Kweaver Core component deployment | Control Plane, MinIO, RBAC, config, secrets | Uses Core-provided `depServices.rds` | Not included | Follows Kweaver Core component conventions |
+| `sandbox` | BKN Foundry component deployment | Control Plane, MinIO, RBAC, config, secrets | Uses Core-provided `depServices.rds` | Not included | Follows BKN Foundry component conventions |
 | `sandbox_standalone` | Independent Sandbox deployment for development, demos, or non-Core environments | Control Plane, Web Console, MariaDB, MinIO, RBAC, config, secrets | Deploys internal MariaDB by default | Included | Standalone chart values, not constrained by Core |
 
 ## Which Chart Should I Use?
 
-Use `deploy/helm/sandbox` when Sandbox is packaged as a Kweaver Core component. This chart assumes the platform already provides shared infrastructure such as the database service. It should stay compatible with Core deployment conventions.
+Use `deploy/helm/sandbox` when Sandbox is packaged as a BKN Foundry component. This chart assumes the platform already provides shared infrastructure such as the database service. It should stay compatible with Core deployment conventions.
 
-Use `deploy/helm/sandbox_standalone` when you want a self-contained Sandbox stack. This chart is better for local development, feature verification, demos, and environments that do not install Sandbox through Kweaver Core.
+Use `deploy/helm/sandbox_standalone` when you want a self-contained Sandbox stack. This chart is better for local development, feature verification, demos, and environments that do not install Sandbox through BKN Foundry.
 
 ## Default Template Images
 
@@ -41,7 +41,7 @@ When `tag` is set, the chart renders the full `DEFAULT_TEMPLATE_IMAGE` and `DEFA
 
 ## Examples
 
-Render the Kweaver Core component chart:
+Render the BKN Foundry component chart:
 
 ```bash
 helm template sandbox deploy/helm/sandbox

--- a/infra/sandbox/deploy/helm/sandbox/README.md
+++ b/infra/sandbox/deploy/helm/sandbox/README.md
@@ -1,8 +1,8 @@
 # Sandbox Core Component Helm Chart
 
-This chart deploys Sandbox as a Kweaver Core component.
+This chart deploys Sandbox as a BKN Foundry component.
 
-Use this chart when Sandbox is installed by, or packaged into, Kweaver Core. It follows the Core component values format and expects shared platform services, especially the database service, to be provided by Core.
+Use this chart when Sandbox is installed by, or packaged into, BKN Foundry. It follows the Core component values format and expects shared platform services, especially the database service, to be provided by Core.
 
 For a self-contained Sandbox deployment with MariaDB and the web console, use `deploy/helm/sandbox_standalone`.
 
@@ -18,7 +18,7 @@ This chart does not deploy `sandbox_web` or MariaDB.
 
 - Kubernetes 1.24+
 - Helm 3.0+
-- Kweaver Core deployment environment
+- BKN Foundry deployment environment
 - Core-provided database service through `depServices.rds`
 
 ## Installing

--- a/infra/sandbox/deploy/helm/sandbox_standalone/README.md
+++ b/infra/sandbox/deploy/helm/sandbox_standalone/README.md
@@ -2,9 +2,9 @@
 
 This chart deploys Sandbox as a self-contained application.
 
-Use this chart for development, demos, integration testing, or environments where Sandbox should be deployed independently from Kweaver Core. It owns its supporting services and is not constrained by the Core component values format.
+Use this chart for development, demos, integration testing, or environments where Sandbox should be deployed independently from BKN Foundry. It owns its supporting services and is not constrained by the Core component values format.
 
-For Kweaver Core component packaging, use `deploy/helm/sandbox`.
+For BKN Foundry component packaging, use `deploy/helm/sandbox`.
 
 ## Components
 


### PR DESCRIPTION
Follow-up to #995. That PR fixed references that were broken; this one renames the leftover `kweaver` brand strings that still work but no longer mean anything.

## What changed

- **`README{,.zh}.md`** — anchor ids `toc-kweaver-core` / `toc-kweaver-core-and-sdk` / `toc-kweaver-admin` become `toc-bkn-foundry` / `toc-bkn-foundry-and-sdk` / `toc-administration`, along with the in-page links pointing at them.
- **`infra/sandbox/deploy/helm/**/README.md`** — "Kweaver Core" → "BKN Foundry".
- **`data-migrator/helm/core-data-migrator/Chart.yaml`** — chart description.
- **`bkn-safe/server/config/config.local.yaml.example`** — the MariaDB user was `kweaver`; bkn-safe's own chart connects as `root` (`bkn-safe/charts/bkn-safe/values.yaml`).
- **`agent-retrieval.yaml` / `agent-operator-integration.yaml`** — in-cluster hostnames carried the `.kweaver` namespace suffix; the core namespace default is `openbkn` (`deploy/scripts/services/openbkn.sh`). These are checked-in local defaults — deployments inject their own config — so the effect is that the defaults now resolve against a real install.
- Comments naming the pod search domain (`infra/mf-model-manager`) and the product (mirror workflow).

Changed YAML parses; `helm template infra/mf-model-manager/charts` still renders.

## Deliberately not touched

- **`infra/sandbox/CHANGELOG{,_ZH}.md`** — historical entries. The database rename they record (`adp` → `kweaver`) has since moved on to `openbkn` (`sandbox_control_plane/.../persistence/database.py`), so rewriting them would contradict the code.
- **`adp/execution-factory/tests/**`** — "KWeaver" there names the external KWeaver DIP/Core platform (eisoo/Hydra) that the L3 suite actually requires. Renaming would make the docs wrong.
- **SWR image namespaces** (`swr…/kweaver-ai/…` in `bkn-trace`, `infra/sandbox`, `vega` Dockerfiles, and `sandbox_control_plane` seed defaults) — owned by a separate change; whether the images exist under `openbkn-ai` needs verifying first.
- **Dockerfile runtime user names** and the **oss-gateway Redis key prefix** (`kweaver-core:…`) — behavioural rather than cosmetic; worth their own change.
- **License attribution** required by Apache 2.0 section 4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)