### PR TITLE
fix(vega): preserve handler HTTP errors

### DIFF
--- a/adp/vega/vega-backend/server/driveradapters/catalog_handler.go
+++ b/adp/vega/vega-backend/server/driveradapters/catalog_handler.go
@@ -229,8 +229,7 @@ func (r *restHandler) createCatalog(c *gin.Context, visitor hydra.Visitor) {
 	// Check if name exists
 	exists, err := r.cs.CheckExistByName(ctx, req.Name)
 	if err != nil {
-		httpErr := rest.NewHTTPError(ctx, http.StatusInternalServerError, verrors.VegaBackend_Catalog_InternalError).
-			WithErrorDetails(err.Error())
+		httpErr := httpErrorOrInternal(ctx, err, verrors.VegaBackend_Catalog_InternalError)
 		oteltrace.AddHttpAttrs4HttpError(span, httpErr)
 		rest.ReplyError(c, httpErr)
 		return
@@ -246,8 +245,7 @@ func (r *restHandler) createCatalog(c *gin.Context, visitor hydra.Visitor) {
 	if req.ID != "" {
 		exists, err := r.cs.CheckExistByID(ctx, req.ID)
 		if err != nil {
-			httpErr := rest.NewHTTPError(ctx, http.StatusInternalServerError, verrors.VegaBackend_Catalog_InternalError).
-				WithErrorDetails(err.Error())
+			httpErr := httpErrorOrInternal(ctx, err, verrors.VegaBackend_Catalog_InternalError)
 			oteltrace.AddHttpAttrs4HttpError(span, httpErr)
 			rest.ReplyError(c, httpErr)
 			return
@@ -900,8 +898,7 @@ func (r *restHandler) discoverCatalogResources(c *gin.Context, visitor hydra.Vis
 		Strategy:    strategy,
 	})
 	if err != nil {
-		httpErr := rest.NewHTTPError(ctx, http.StatusInternalServerError, verrors.VegaBackend_Catalog_InternalError).
-			WithErrorDetails(err.Error())
+		httpErr := httpErrorOrInternal(ctx, err, verrors.VegaBackend_Catalog_InternalError)
 		oteltrace.AddHttpAttrs4HttpError(span, httpErr)
 		rest.ReplyError(c, httpErr)
 		return

--- a/adp/vega/vega-backend/server/driveradapters/catalog_health_check_schedule_handler.go
+++ b/adp/vega/vega-backend/server/driveradapters/catalog_health_check_schedule_handler.go
@@ -12,11 +12,9 @@ import (
 
 	"github.com/gin-gonic/gin"
 	"github.com/openbkn-ai/bkn-foundry/comm-go/hydra"
-	"github.com/openbkn-ai/bkn-foundry/comm-go/otel/otellog"
 	"github.com/openbkn-ai/bkn-foundry/comm-go/otel/oteltrace"
 	"github.com/openbkn-ai/bkn-foundry/comm-go/rest"
 	attr "go.opentelemetry.io/otel/attribute"
-	"go.opentelemetry.io/otel/trace"
 
 	"vega-backend/common/visitor"
 	verrors "vega-backend/errors"
@@ -48,13 +46,26 @@ func (r *restHandler) getCatalogHealthCheckSchedule(c *gin.Context, v hydra.Visi
 	catalogID := c.Param("id")
 	span.SetAttributes(attr.Key("catalog_id").String(catalogID))
 
-	if !r.requirePhysicalCatalog(ctx, c, span, catalogID) {
+	catalog, err := r.cs.GetByID(ctx, catalogID, false)
+	if err != nil {
+		httpErr := httpErrorOrInternal(ctx, err, verrors.VegaBackend_Catalog_InternalError)
+		oteltrace.AddHttpAttrs4HttpError(span, httpErr)
+		rest.ReplyError(c, httpErr)
+		return
+	}
+	if catalog.Type != interfaces.CatalogTypePhysical {
+		httpErr := rest.NewHTTPError(ctx, http.StatusBadRequest, verrors.VegaBackend_Catalog_InvalidParameter).
+			WithErrorDetails("health check schedules are only supported for physical catalogs")
+		oteltrace.AddHttpAttrs4HttpError(span, httpErr)
+		rest.ReplyError(c, httpErr)
 		return
 	}
 
 	schedule, err := r.hcss.GetByCatalogID(ctx, catalogID)
 	if err != nil {
-		replyCatalogHealthCheckScheduleError(ctx, c, span, err)
+		httpErr := httpErrorOrInternal(ctx, err, verrors.VegaBackend_Catalog_InternalError)
+		oteltrace.AddHttpAttrs4HttpError(span, httpErr)
+		rest.ReplyError(c, httpErr)
 		return
 	}
 
@@ -97,44 +108,12 @@ func (r *restHandler) updateCatalogHealthCheckSchedule(c *gin.Context, v hydra.V
 
 	schedule, err := r.hcss.Update(ctx, catalogID, &req)
 	if err != nil {
-		replyCatalogHealthCheckScheduleError(ctx, c, span, err)
+		httpErr := httpErrorOrInternal(ctx, err, verrors.VegaBackend_Catalog_InternalError)
+		oteltrace.AddHttpAttrs4HttpError(span, httpErr)
+		rest.ReplyError(c, httpErr)
 		return
 	}
 
 	oteltrace.AddHttpAttrs4Ok(span, http.StatusOK)
 	rest.ReplyOK(c, http.StatusOK, schedule)
-}
-
-func (r *restHandler) requirePhysicalCatalog(
-	ctx context.Context, c *gin.Context, span trace.Span, catalogID string,
-) bool {
-	catalog, err := r.cs.GetByID(ctx, catalogID, false)
-	if err != nil {
-		replyCatalogHealthCheckScheduleError(ctx, c, span, err)
-		return false
-	}
-
-	if catalog.Type != interfaces.CatalogTypePhysical {
-		httpErr := rest.NewHTTPError(ctx, http.StatusBadRequest, verrors.VegaBackend_Catalog_InvalidParameter).
-			WithErrorDetails("health check schedules are only supported for physical catalogs")
-		oteltrace.AddHttpAttrs4HttpError(span, httpErr)
-		rest.ReplyError(c, httpErr)
-		return false
-	}
-
-	return true
-}
-
-func replyCatalogHealthCheckScheduleError(
-	ctx context.Context, c *gin.Context, span trace.Span, err error,
-) {
-	httpErr, ok := err.(*rest.HTTPError)
-	if !ok {
-		otellog.LogError(ctx, "Handle catalog health check schedule request failed", err)
-		httpErr = rest.NewHTTPError(ctx, http.StatusInternalServerError,
-			verrors.VegaBackend_Catalog_InternalError)
-	}
-
-	oteltrace.AddHttpAttrs4HttpError(span, httpErr)
-	rest.ReplyError(c, httpErr)
 }

--- a/adp/vega/vega-backend/server/driveradapters/catalog_health_check_schedule_handler_test.go
+++ b/adp/vega/vega-backend/server/driveradapters/catalog_health_check_schedule_handler_test.go
@@ -8,7 +8,6 @@ package driveradapters
 
 import (
 	"context"
-	"errors"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -73,21 +72,6 @@ func TestCatalogHealthCheckScheduleHandlerGet(t *testing.T) {
 		assert.Contains(t, w.Body.String(), "only supported for physical catalogs")
 	})
 
-	t.Run("redacts unexpected schedule errors", func(t *testing.T) {
-		engine, cs, hcss := setupCatalogHealthCheckScheduleHandlerTest(t)
-		sensitiveError := "dial tcp db.internal:3306: connection refused"
-		cs.EXPECT().GetByID(gomock.Any(), "catalog-1", false).
-			Return(&interfaces.Catalog{ID: "catalog-1", Type: interfaces.CatalogTypePhysical}, nil)
-		hcss.EXPECT().GetByCatalogID(gomock.Any(), "catalog-1").Return(nil, errors.New(sensitiveError))
-
-		req := httptest.NewRequest(http.MethodGet, "/api/vega-backend/in/v1/catalogs/catalog-1/health-check-schedule", nil)
-		w := httptest.NewRecorder()
-		engine.ServeHTTP(w, req)
-
-		require.Equal(t, http.StatusInternalServerError, w.Code)
-		assert.Contains(t, w.Body.String(), verrors.VegaBackend_Catalog_InternalError)
-		assert.NotContains(t, w.Body.String(), sensitiveError)
-	})
 }
 
 func TestCatalogHealthCheckScheduleHandlerUpdate(t *testing.T) {
@@ -125,18 +109,4 @@ func TestCatalogHealthCheckScheduleHandlerUpdate(t *testing.T) {
 		assert.Contains(t, w.Body.String(), "cron_expr is required")
 	})
 
-	t.Run("redacts unexpected schedule errors", func(t *testing.T) {
-		engine, _, hcss := setupCatalogHealthCheckScheduleHandlerTest(t)
-		sensitiveError := "dial tcp db.internal:3306: connection refused"
-		hcss.EXPECT().Update(gomock.Any(), "catalog-1", gomock.Any()).Return(nil, errors.New(sensitiveError))
-
-		req := httptest.NewRequest(http.MethodPut, "/api/vega-backend/in/v1/catalogs/catalog-1/health-check-schedule", strings.NewReader(`{"mode":"inherit"}`))
-		req.Header.Set("Content-Type", "application/json")
-		w := httptest.NewRecorder()
-		engine.ServeHTTP(w, req)
-
-		require.Equal(t, http.StatusInternalServerError, w.Code)
-		assert.Contains(t, w.Body.String(), verrors.VegaBackend_Catalog_InternalError)
-		assert.NotContains(t, w.Body.String(), sensitiveError)
-	})
 }

--- a/adp/vega/vega-backend/server/driveradapters/connector_type_handler.go
+++ b/adp/vega/vega-backend/server/driveradapters/connector_type_handler.go
@@ -171,8 +171,7 @@ func (r *restHandler) RegisterConnectorType(c *gin.Context) {
 	// Check if type exists
 	exists, err := r.cts.CheckExistByType(ctx, req.Type)
 	if err != nil {
-		httpErr := rest.NewHTTPError(ctx, http.StatusInternalServerError, verrors.VegaBackend_ConnectorType_InternalError).
-			WithErrorDetails(err.Error())
+		httpErr := httpErrorOrInternal(ctx, err, verrors.VegaBackend_ConnectorType_InternalError)
 		oteltrace.AddHttpAttrs4HttpError(span, httpErr)
 		rest.ReplyError(c, httpErr)
 		return
@@ -352,8 +351,7 @@ func (r *restHandler) DeleteConnectorType(c *gin.Context) {
 
 	ct, err := r.cts.GetByType(ctx, tp)
 	if err != nil {
-		httpErr := rest.NewHTTPError(ctx, http.StatusInternalServerError, verrors.VegaBackend_ConnectorType_InternalError).
-			WithErrorDetails(err.Error())
+		httpErr := httpErrorOrInternal(ctx, err, verrors.VegaBackend_ConnectorType_InternalError)
 		oteltrace.AddHttpAttrs4HttpError(span, httpErr)
 		rest.ReplyError(c, httpErr)
 		return
@@ -412,8 +410,7 @@ func (r *restHandler) setConnectorTypeEnabled(c *gin.Context, value bool, spanNa
 
 	exists, err := r.cts.CheckExistByType(ctx, tp)
 	if err != nil {
-		httpErr := rest.NewHTTPError(ctx, http.StatusInternalServerError, verrors.VegaBackend_ConnectorType_InternalError).
-			WithErrorDetails(err.Error())
+		httpErr := httpErrorOrInternal(ctx, err, verrors.VegaBackend_ConnectorType_InternalError)
 		oteltrace.AddHttpAttrs4HttpError(span, httpErr)
 		rest.ReplyError(c, httpErr)
 		return

--- a/adp/vega/vega-backend/server/driveradapters/discover_schedule_handler.go
+++ b/adp/vega/vega-backend/server/driveradapters/discover_schedule_handler.go
@@ -91,8 +91,7 @@ func (r *restHandler) createDiscoverSchedule(c *gin.Context, visitor hydra.Visit
 
 	scheduleID, err := r.dss.Create(ctx, &req)
 	if err != nil {
-		httpErr := rest.NewHTTPError(ctx, http.StatusInternalServerError, verrors.VegaBackend_DiscoverSchedule_InternalError_CreateFailed).
-			WithErrorDetails(err.Error())
+		httpErr := httpErrorOrInternal(ctx, err, verrors.VegaBackend_DiscoverSchedule_InternalError_CreateFailed)
 		oteltrace.AddHttpAttrs4HttpError(span, httpErr)
 		rest.ReplyError(c, httpErr)
 		return
@@ -167,8 +166,7 @@ func (r *restHandler) listDiscoverSchedules(c *gin.Context, visitor hydra.Visito
 
 	entries, total, err := r.dss.List(ctx, params)
 	if err != nil {
-		httpErr := rest.NewHTTPError(ctx, http.StatusInternalServerError, verrors.VegaBackend_DiscoverSchedule_InternalError_GetFailed).
-			WithErrorDetails(err.Error())
+		httpErr := httpErrorOrInternal(ctx, err, verrors.VegaBackend_DiscoverSchedule_InternalError_GetFailed)
 		oteltrace.AddHttpAttrs4HttpError(span, httpErr)
 		rest.ReplyError(c, httpErr)
 		return
@@ -206,8 +204,7 @@ func (r *restHandler) getDiscoverSchedule(c *gin.Context, visitor hydra.Visitor)
 	id := c.Param("id")
 	schedule, err := r.dss.GetByID(ctx, id)
 	if err != nil {
-		httpErr := rest.NewHTTPError(ctx, http.StatusInternalServerError, verrors.VegaBackend_DiscoverSchedule_InternalError_GetFailed).
-			WithErrorDetails(err.Error())
+		httpErr := httpErrorOrInternal(ctx, err, verrors.VegaBackend_DiscoverSchedule_InternalError_GetFailed)
 		oteltrace.AddHttpAttrs4HttpError(span, httpErr)
 		rest.ReplyError(c, httpErr)
 		return
@@ -252,8 +249,7 @@ func (r *restHandler) updateDiscoverSchedule(c *gin.Context, visitor hydra.Visit
 
 	current, err := r.dss.GetByID(ctx, id)
 	if err != nil {
-		httpErr := rest.NewHTTPError(ctx, http.StatusInternalServerError, verrors.VegaBackend_DiscoverSchedule_InternalError_GetFailed).
-			WithErrorDetails(err.Error())
+		httpErr := httpErrorOrInternal(ctx, err, verrors.VegaBackend_DiscoverSchedule_InternalError_GetFailed)
 		oteltrace.AddHttpAttrs4HttpError(span, httpErr)
 		rest.ReplyError(c, httpErr)
 		return
@@ -298,8 +294,7 @@ func (r *restHandler) updateDiscoverSchedule(c *gin.Context, visitor hydra.Visit
 	}
 
 	if err := r.dss.Update(ctx, current, &req); err != nil {
-		httpErr := rest.NewHTTPError(ctx, http.StatusInternalServerError, verrors.VegaBackend_DiscoverSchedule_InternalError_UpdateFailed).
-			WithErrorDetails(err.Error())
+		httpErr := httpErrorOrInternal(ctx, err, verrors.VegaBackend_DiscoverSchedule_InternalError_UpdateFailed)
 		oteltrace.AddHttpAttrs4HttpError(span, httpErr)
 		rest.ReplyError(c, httpErr)
 		return
@@ -342,8 +337,7 @@ func (r *restHandler) deleteDiscoverSchedule(c *gin.Context, visitor hydra.Visit
 
 	current, err := r.dss.GetByID(ctx, id)
 	if err != nil {
-		httpErr := rest.NewHTTPError(ctx, http.StatusInternalServerError, verrors.VegaBackend_DiscoverSchedule_InternalError_GetFailed).
-			WithErrorDetails(err.Error())
+		httpErr := httpErrorOrInternal(ctx, err, verrors.VegaBackend_DiscoverSchedule_InternalError_GetFailed)
 		oteltrace.AddHttpAttrs4HttpError(span, httpErr)
 		rest.ReplyError(c, httpErr)
 		return
@@ -356,8 +350,7 @@ func (r *restHandler) deleteDiscoverSchedule(c *gin.Context, visitor hydra.Visit
 	}
 
 	if err := r.dss.Delete(ctx, id); err != nil {
-		httpErr := rest.NewHTTPError(ctx, http.StatusInternalServerError, verrors.VegaBackend_DiscoverSchedule_InternalError_DeleteFailed).
-			WithErrorDetails(err.Error())
+		httpErr := httpErrorOrInternal(ctx, err, verrors.VegaBackend_DiscoverSchedule_InternalError_DeleteFailed)
 		oteltrace.AddHttpAttrs4HttpError(span, httpErr)
 		rest.ReplyError(c, httpErr)
 		return
@@ -416,8 +409,7 @@ func (r *restHandler) toggleDiscoverSchedule(c *gin.Context, visitor hydra.Visit
 
 	current, err := r.dss.GetByID(ctx, id)
 	if err != nil {
-		httpErr := rest.NewHTTPError(ctx, http.StatusInternalServerError, verrors.VegaBackend_DiscoverSchedule_InternalError_GetFailed).
-			WithErrorDetails(err.Error())
+		httpErr := httpErrorOrInternal(ctx, err, verrors.VegaBackend_DiscoverSchedule_InternalError_GetFailed)
 		oteltrace.AddHttpAttrs4HttpError(span, httpErr)
 		rest.ReplyError(c, httpErr)
 		return
@@ -438,16 +430,14 @@ func (r *restHandler) toggleDiscoverSchedule(c *gin.Context, visitor hydra.Visit
 
 	if enable {
 		if err := r.dss.Enable(ctx, id); err != nil {
-			httpErr := rest.NewHTTPError(ctx, http.StatusInternalServerError, verrors.VegaBackend_DiscoverSchedule_InternalError_UpdateFailed).
-				WithErrorDetails(err.Error())
+			httpErr := httpErrorOrInternal(ctx, err, verrors.VegaBackend_DiscoverSchedule_InternalError_UpdateFailed)
 			oteltrace.AddHttpAttrs4HttpError(span, httpErr)
 			rest.ReplyError(c, httpErr)
 			return
 		}
 	} else {
 		if err := r.dss.Disable(ctx, id); err != nil {
-			httpErr := rest.NewHTTPError(ctx, http.StatusInternalServerError, verrors.VegaBackend_DiscoverSchedule_InternalError_UpdateFailed).
-				WithErrorDetails(err.Error())
+			httpErr := httpErrorOrInternal(ctx, err, verrors.VegaBackend_DiscoverSchedule_InternalError_UpdateFailed)
 			oteltrace.AddHttpAttrs4HttpError(span, httpErr)
 			rest.ReplyError(c, httpErr)
 			return

--- a/adp/vega/vega-backend/server/driveradapters/discover_task_handler.go
+++ b/adp/vega/vega-backend/server/driveradapters/discover_task_handler.go
@@ -107,8 +107,7 @@ func (r *restHandler) listDiscoverTasks(c *gin.Context, visitor hydra.Visitor) {
 
 	tasks, total, err := r.dts.List(ctx, params)
 	if err != nil {
-		httpErr := rest.NewHTTPError(ctx, http.StatusInternalServerError, verrors.VegaBackend_DiscoverTask_InternalError_GetFailed).
-			WithErrorDetails(err.Error())
+		httpErr := httpErrorOrInternal(ctx, err, verrors.VegaBackend_DiscoverTask_InternalError_GetFailed)
 		oteltrace.AddHttpAttrs4HttpError(span, httpErr)
 		rest.ReplyError(c, httpErr)
 		return
@@ -151,8 +150,7 @@ func (r *restHandler) getDiscoverTask(c *gin.Context, visitor hydra.Visitor) {
 
 	task, err := r.dts.GetByID(ctx, taskID)
 	if err != nil {
-		httpErr := rest.NewHTTPError(ctx, http.StatusInternalServerError, verrors.VegaBackend_DiscoverTask_InternalError_GetFailed).
-			WithErrorDetails(err.Error())
+		httpErr := httpErrorOrInternal(ctx, err, verrors.VegaBackend_DiscoverTask_InternalError_GetFailed)
 		oteltrace.AddHttpAttrs4HttpError(span, httpErr)
 		rest.ReplyError(c, httpErr)
 		return

--- a/adp/vega/vega-backend/server/driveradapters/discover_task_handler_test.go
+++ b/adp/vega/vega-backend/server/driveradapters/discover_task_handler_test.go
@@ -8,16 +8,20 @@ package driveradapters
 
 import (
 	"context"
+	"errors"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"testing"
 
 	"github.com/gin-gonic/gin"
+	"github.com/openbkn-ai/bkn-foundry/comm-go/rest"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
 
 	"vega-backend/common"
+	verrors "vega-backend/errors"
 	"vega-backend/interfaces"
 	vmock "vega-backend/interfaces/mock"
 )
@@ -162,6 +166,35 @@ func Test_DiscoverTaskRestHandler_GetDiscoverTask(t *testing.T) {
 
 		require.Equal(t, http.StatusNotFound, w.Result().StatusCode)
 		assert.Contains(t, w.Body.String(), "VegaBackend.DiscoverTask.NotFound")
+	})
+
+	t.Run("preserves not found error returned by service", func(t *testing.T) {
+		engine, dts := setup(t)
+		dts.EXPECT().GetByID(gomock.Any(), "missing").Return(nil,
+			fmt.Errorf("get discover task: %w", rest.NewHTTPError(context.Background(), http.StatusNotFound, verrors.VegaBackend_DiscoverTask_NotFound)))
+
+		req := httptest.NewRequest(http.MethodGet, "/api/vega-backend/in/v1/discover-tasks/missing", nil)
+		w := httptest.NewRecorder()
+
+		engine.ServeHTTP(w, req)
+
+		require.Equal(t, http.StatusNotFound, w.Result().StatusCode)
+		assert.Contains(t, w.Body.String(), "VegaBackend.DiscoverTask.NotFound")
+		assert.NotContains(t, w.Body.String(), "VegaBackend.DiscoverTask.InternalError.GetFailed")
+	})
+
+	t.Run("maps unknown service error to internal error", func(t *testing.T) {
+		engine, dts := setup(t)
+		dts.EXPECT().GetByID(gomock.Any(), "task-1").Return(nil, errors.New("database unavailable"))
+
+		req := httptest.NewRequest(http.MethodGet, "/api/vega-backend/in/v1/discover-tasks/task-1", nil)
+		w := httptest.NewRecorder()
+
+		engine.ServeHTTP(w, req)
+
+		require.Equal(t, http.StatusInternalServerError, w.Result().StatusCode)
+		assert.Contains(t, w.Body.String(), "VegaBackend.DiscoverTask.InternalError.GetFailed")
+		assert.Contains(t, w.Body.String(), "database unavailable")
 	})
 }
 

--- a/adp/vega/vega-backend/server/driveradapters/query_handler.go
+++ b/adp/vega/vega-backend/server/driveradapters/query_handler.go
@@ -80,13 +80,7 @@ func (r *restHandler) rawQuery(c *gin.Context, visitor hydra.Visitor) {
 	qs := query.NewRawQueryService(r.appSetting)
 	resp, err := qs.Execute(ctx, &req)
 	if err != nil {
-		var httpErr *rest.HTTPError
-		var ok bool
-		if httpErr, ok = err.(*rest.HTTPError); !ok {
-			// If it is not an HTTPError, it is converted to an internal server error
-			httpErr = rest.NewHTTPError(ctx, http.StatusInternalServerError, errors.VegaBackend_Query_ExecuteFailed).
-				WithErrorDetails(err.Error())
-		}
+		httpErr := httpErrorOrInternal(ctx, err, errors.VegaBackend_Query_ExecuteFailed)
 		otellog.LogError(ctx, "Execute raw query failed", httpErr)
 		oteltrace.AddHttpAttrs4HttpError(span, httpErr)
 		rest.ReplyError(c, httpErr)

--- a/adp/vega/vega-backend/server/driveradapters/resource_handler.go
+++ b/adp/vega/vega-backend/server/driveradapters/resource_handler.go
@@ -186,8 +186,7 @@ func (r *restHandler) createResource(c *gin.Context, visitor hydra.Visitor) {
 	// Check catelog exists
 	csExists, csErr := r.cs.CheckExistByID(ctx, req.CatalogID)
 	if csErr != nil {
-		httpErr := rest.NewHTTPError(ctx, http.StatusInternalServerError,
-			verrors.VegaBackend_Resource_InternalError).WithErrorDetails(csErr.Error())
+		httpErr := httpErrorOrInternal(ctx, csErr, verrors.VegaBackend_Resource_InternalError)
 		oteltrace.AddHttpAttrs4HttpError(span, httpErr)
 		rest.ReplyError(c, httpErr)
 		return
@@ -204,8 +203,7 @@ func (r *restHandler) createResource(c *gin.Context, visitor hydra.Visitor) {
 	if req.ID != "" {
 		exists, err := r.rs.CheckExistByID(ctx, req.ID)
 		if err != nil {
-			httpErr := rest.NewHTTPError(ctx, http.StatusInternalServerError,
-				verrors.VegaBackend_Resource_InternalError).WithErrorDetails(err.Error())
+			httpErr := httpErrorOrInternal(ctx, err, verrors.VegaBackend_Resource_InternalError)
 			oteltrace.AddHttpAttrs4HttpError(span, httpErr)
 			rest.ReplyError(c, httpErr)
 			return

--- a/adp/vega/vega-backend/server/driveradapters/router.go
+++ b/adp/vega/vega-backend/server/driveradapters/router.go
@@ -9,6 +9,7 @@ package driveradapters
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net/http"
 	"time"
@@ -366,4 +367,15 @@ func (r *restHandler) verifyOAuth(ctx context.Context, c *gin.Context) (hydra.Vi
 	c.Set(operationAuditVisitorKey, visitor)
 
 	return visitor, nil
+}
+
+// HTTPErrorOrInternal 保留 Service 返回的 HTTP 错误；其他错误转换为调用方指定的内部错误码。
+func httpErrorOrInternal(ctx context.Context, err error, internalErrorCode string) *rest.HTTPError {
+	var httpErr *rest.HTTPError
+	if errors.As(err, &httpErr) {
+		return httpErr
+	}
+
+	return rest.NewHTTPError(ctx, http.StatusInternalServerError, internalErrorCode).
+		WithErrorDetails(err.Error())
 }


### PR DESCRIPTION
## What Changed

- [x] Preserve existing `*rest.HTTPError` semantics across affected VEGA handlers.
- [x] Add DiscoverTask handler regression coverage for wrapped NotFound and unknown internal errors.
- [x] Simplify catalog health-check schedule error handling by reusing the common conversion function.

---

## Why

- Related Issue: Closes #998
- Related Feature: N/A
- Background: Deleted or missing DiscoverTasks were returned by the Service as HTTP 404 but were rewrapped by the Handler as HTTP 500.

---

## How

- Key implementation points: `httpErrorOrInternal` uses `errors.As` to preserve HTTP errors; non-HTTP errors retain each call site's existing internal-error code.
- Breaking changes (API, config, database, etc.): None. Error responses now preserve existing Service HTTP status codes.

---

## Testing

- [x] Unit tests passed locally (`make test`)
- [ ] Integration tests passed locally (not applicable; no external dependency required)
- [ ] Verified in test environment (not run)

Test notes:

- `go test ./driveradapters`
- `make lint`
- `make test`
- `git diff --check`

---

## Risk & Rollback

- Potential risks: Endpoints now return pre-existing Service HTTP errors instead of consistently rewriting them as 500; this corrects client-visible semantics.
- Rollback plan: Revert commit `11bf06dda`.

---

## Additional Notes

- CODEOWNERS will route review to the VEGA module owners.