### PR TITLE
refactor(vega-backend): translate remaining internal text

### DIFF
--- a/adp/vega/vega-backend/server/common/logger.go
+++ b/adp/vega/vega-backend/server/common/logger.go
@@ -17,7 +17,7 @@ const (
 	logFileName = "/opt/vega-backend/logs/vega-backend.log"
 )
 
-// GetLogger returns the logger handle.
+// init initializes the global logger.
 func init() {
 	setting := logger.LogSetting{
 		LogServiceName: version.ServerName,

--- a/adp/vega/vega-backend/server/common/logger.go
+++ b/adp/vega/vega-backend/server/common/logger.go
@@ -13,11 +13,11 @@ import (
 )
 
 const (
-	// 日志保存位置
+	// Log storage location.
 	logFileName = "/opt/vega-backend/logs/vega-backend.log"
 )
 
-// 获取日志句柄
+// GetLogger returns the logger handle.
 func init() {
 	setting := logger.LogSetting{
 		LogServiceName: version.ServerName,
@@ -31,7 +31,7 @@ func init() {
 	logger.InitGlobalLogger(setting)
 }
 
-// SetLogSetting 设置日志配置
+// SetLogSetting configures logging.
 func SetLogSetting(setting logger.LogSetting) {
 	setting.LogServiceName = version.ServerName
 	setting.LogFileName = logFileName

--- a/adp/vega/vega-backend/server/drivenadapters/discover_schedule/discover_schedule_access.go
+++ b/adp/vega/vega-backend/server/drivenadapters/discover_schedule/discover_schedule_access.go
@@ -169,15 +169,15 @@ func (dsa *discoverScheduleAccess) Disable(ctx context.Context, id string) error
 
 /**
  * Create a scheduled discovery task
- * @param ctx 上下文信息，用于追踪和传递请求范围的数据
+ * @param ctx context used for tracing and carrying request-scoped data
  * @param schedule regularly discovers the pointer of the task structure, which contains all the information of the task
  * @return error execution result: nil for success and error message for failure
  */
 func (dsa *discoverScheduleAccess) Create(ctx context.Context, schedule *interfaces.DiscoverSchedule) error {
-	// 使用OpenTelemetry追踪函数执行过程，创建一个客户端类型的span
+	// Trace the function with OpenTelemetry by creating a client span.
 	ctx, span := oteltrace.StartNamedClientSpan(ctx, "Insert into t_discover_schedule")
-	defer span.End() // 确保span在函数结束时结束
-	// 设置span的属性，包含数据库URL和类型信息
+	defer span.End() // End the span when the function returns.
+	// Attach the database URL and type information to the span.
 	span.SetAttributes(
 		attr.Key("db_url").String(libdb.GetDBUrl()),
 		attr.Key("db_type").String(libdb.GetDBType()))

--- a/adp/vega/vega-backend/server/drivenadapters/permission/permission_access.go
+++ b/adp/vega/vega-backend/server/drivenadapters/permission/permission_access.go
@@ -55,7 +55,7 @@ func NewPermissionAccess(appSetting *common.AppSetting) interfaces.PermissionAcc
 
 // Strategic decision-making
 func (pa *permissionAccess) CheckPermission(ctx context.Context, check interfaces.PermissionCheck) (bool, error) {
-	ctx, span := oteltrace.StartNamedClientSpan(ctx, "请求策略的决策接口")
+	ctx, span := oteltrace.StartNamedClientSpan(ctx, "request policy decision")
 	defer span.End()
 
 	span.SetAttributes(
@@ -82,9 +82,9 @@ func (pa *permissionAccess) CheckPermission(ctx context.Context, check interface
 	logger.Debugf("post [%s] finished, response code is [%d], result is [%s], error is [%v]", httpUrl, respCode, result, err)
 
 	if err != nil {
-		// 添加异常时的 trace 属性
+		// Add trace attributes for the error.
 		oteltrace.AddHttpAttrs4Error(span, respCode, "InternalError", "Http Post Failed")
-		// 记录异常日志
+		// Log the error.
 		otellog.LogError(ctx, "Post operation-check request failed", err)
 
 		return false, fmt.Errorf("post operation-check request failed: %v", err)
@@ -93,9 +93,9 @@ func (pa *permissionAccess) CheckPermission(ctx context.Context, check interface
 		// Convert to baseerror
 		var permissionError PermissionError
 		if err := sonic.Unmarshal(result, &permissionError); err != nil {
-			// 添加异常时的 trace 属性
+			// Add trace attributes for the error.
 			oteltrace.AddHttpAttrs4Error(span, respCode, "InternalError", "Unmalshal PermissionError failed")
-			// 记录异常日志
+			// Log the error.
 			otellog.LogError(ctx, "Unmalshal PermissionError failed", err)
 
 			return false, err
@@ -113,18 +113,18 @@ func (pa *permissionAccess) CheckPermission(ctx context.Context, check interface
 				ErrorDetails: permissionError.Cause,
 			}}
 
-		// 添加异常时的 trace 属性
+		// Add trace attributes for the error.
 		oteltrace.AddHttpAttrs4Error(span, respCode, "InternalError", "Http status is not 200")
-		// 记录异常日志
+		// Log the error.
 		otellog.LogError(ctx, "Post operation-check failed", httpErr)
 
 		return false, httpErr
 	}
 
 	if result == nil {
-		// 添加异常时的 trace 属性
+		// Add trace attributes for the error.
 		oteltrace.AddHttpAttrs4Ok(span, respCode)
-		// 记录模型不存在的日志
+		// Log the empty response.
 		otellog.LogWarn(ctx, "Http response body is null")
 
 		return false, nil
@@ -133,15 +133,15 @@ func (pa *permissionAccess) CheckPermission(ctx context.Context, check interface
 	// Process the returned result "result"
 	var checkResult interfaces.PermissionCheckResult
 	if err := sonic.Unmarshal(result, &checkResult); err != nil {
-		// 添加异常时的 trace 属性
+		// Add trace attributes for the error.
 		oteltrace.AddHttpAttrs4Error(span, respCode, "InternalError", "Unmalshal operation-check result failed")
-		// 记录异常日志
+		// Log the error.
 		otellog.LogError(ctx, "Unmalshal operation-check result failed", err)
 
 		return false, err
 	}
 
-	// 添加成功时的 trace 属性
+	// Add trace attributes for success.
 	oteltrace.AddHttpAttrs4Ok(span, respCode)
 
 	return checkResult.Result, nil
@@ -149,7 +149,7 @@ func (pa *permissionAccess) CheckPermission(ctx context.Context, check interface
 
 // Create a strategy
 func (pa *permissionAccess) CreateResources(ctx context.Context, policies []interfaces.PermissionPolicy) error {
-	ctx, span := oteltrace.StartNamedClientSpan(ctx, "请求创建决策接口")
+	ctx, span := oteltrace.StartNamedClientSpan(ctx, "request create decision")
 	defer span.End()
 
 	span.SetAttributes(
@@ -175,9 +175,9 @@ func (pa *permissionAccess) CreateResources(ctx context.Context, policies []inte
 	logger.Debugf("post [%s] finished, response code is [%d], result is [%s], error is [%v]", httpUrl, respCode, result, err)
 
 	if err != nil {
-		// 添加异常时的 trace 属性
+		// Add trace attributes for the error.
 		oteltrace.AddHttpAttrs4Error(span, respCode, "InternalError", "Http Post Failed")
-		// 记录异常日志
+		// Log the error.
 		otellog.LogError(ctx, "Post create policy request failed", err)
 
 		return fmt.Errorf("post create policy request failed: %v", err)
@@ -186,9 +186,9 @@ func (pa *permissionAccess) CreateResources(ctx context.Context, policies []inte
 		// Convert to baseerror
 		var permissionError PermissionError
 		if err := sonic.Unmarshal(result, &permissionError); err != nil {
-			// 添加异常时的 trace 属性
+			// Add trace attributes for the error.
 			oteltrace.AddHttpAttrs4Error(span, respCode, "InternalError", "Unmalshal PermissionError failed")
-			// 记录异常日志
+			// Log the error.
 			otellog.LogError(ctx, "Unmalshal PermissionError failed", err)
 
 			return err
@@ -205,22 +205,22 @@ func (pa *permissionAccess) CreateResources(ctx context.Context, policies []inte
 				ErrorDetails: permissionError.Cause,
 			}}
 
-		// 添加异常时的 trace 属性
+		// Add trace attributes for the error.
 		oteltrace.AddHttpAttrs4Error(span, respCode, "InternalError", "Http status is not 200")
-		// 记录异常日志
+		// Log the error.
 		otellog.LogError(ctx, "Post create policy failed", httpErr)
 
 		return httpErr
 	}
 
-	// 添加成功时的 trace 属性
+	// Add trace attributes for success.
 	oteltrace.AddHttpAttrs4Ok(span, respCode)
 	return nil
 }
 
 // Resource deletion strategy
 func (pa *permissionAccess) DeleteResources(ctx context.Context, res []interfaces.PermissionResource) error {
-	ctx, span := oteltrace.StartNamedClientSpan(ctx, "请求删除决策接口")
+	ctx, span := oteltrace.StartNamedClientSpan(ctx, "request delete decision")
 	defer span.End()
 
 	createUrl := fmt.Sprintf("%s/policy-delete", pa.permissionUrl)
@@ -245,9 +245,9 @@ func (pa *permissionAccess) DeleteResources(ctx context.Context, res []interface
 	logger.Debugf("post [%s] finished, response code is [%d], result is [%s], error is [%v]", createUrl, respCode, result, err)
 
 	if err != nil {
-		// 添加异常时的 trace 属性
+		// Add trace attributes for the error.
 		oteltrace.AddHttpAttrs4Error(span, respCode, "InternalError", "Http Post Failed")
-		// 记录异常日志
+		// Log the error.
 		otellog.LogError(ctx, "Post delete policy request failed", err)
 
 		return fmt.Errorf("post delete policy request failed: %v", err)
@@ -256,9 +256,9 @@ func (pa *permissionAccess) DeleteResources(ctx context.Context, res []interface
 		// Convert to baseerror
 		var permissionError PermissionError
 		if err := sonic.Unmarshal(result, &permissionError); err != nil {
-			// 添加异常时的 trace 属性
+			// Add trace attributes for the error.
 			oteltrace.AddHttpAttrs4Error(span, respCode, "InternalError", "Unmalshal PermissionError failed")
-			// 记录异常日志
+			// Log the error.
 			otellog.LogError(ctx, "Unmalshal PermissionError failed", err)
 
 			return err
@@ -275,15 +275,15 @@ func (pa *permissionAccess) DeleteResources(ctx context.Context, res []interface
 				ErrorDetails: permissionError.Cause,
 			}}
 
-		// 添加异常时的 trace 属性
+		// Add trace attributes for the error.
 		oteltrace.AddHttpAttrs4Error(span, respCode, "InternalError", "Http status is not 200")
-		// 记录异常日志
+		// Log the error.
 		otellog.LogError(ctx, "Post delete policy failed", httpErr)
 
 		return httpErr
 	}
 
-	// 添加成功时的 trace 属性
+	// Add trace attributes for success.
 	oteltrace.AddHttpAttrs4Ok(span, respCode)
 	return nil
 }
@@ -292,7 +292,7 @@ func (pa *permissionAccess) DeleteResources(ctx context.Context, res []interface
 func (pa *permissionAccess) FilterResources(ctx context.Context,
 	filter interfaces.PermissionResourcesFilter) (map[string]interfaces.PermissionResourceOps, error) {
 
-	ctx, span := oteltrace.StartNamedClientSpan(ctx, "请求资源过滤接口")
+	ctx, span := oteltrace.StartNamedClientSpan(ctx, "request resource filter")
 	defer span.End()
 
 	span.SetAttributes(
@@ -318,9 +318,9 @@ func (pa *permissionAccess) FilterResources(ctx context.Context,
 	logger.Debugf("post [%s] finished, response code is [%d], result is [%s], error is [%v]", httpUrl, respCode, result, err)
 
 	if err != nil {
-		// 添加异常时的 trace 属性
+		// Add trace attributes for the error.
 		oteltrace.AddHttpAttrs4Error(span, respCode, "InternalError", "Http Post Failed")
-		// 记录异常日志
+		// Log the error.
 		otellog.LogError(ctx, "Post resource-filter request failed", err)
 
 		return map[string]interfaces.PermissionResourceOps{}, fmt.Errorf("post resource-filter request failed: %v", err)
@@ -329,9 +329,9 @@ func (pa *permissionAccess) FilterResources(ctx context.Context,
 		// Convert to baseerror
 		var permissionError PermissionError
 		if err := sonic.Unmarshal(result, &permissionError); err != nil {
-			// 添加异常时的 trace 属性
+			// Add trace attributes for the error.
 			oteltrace.AddHttpAttrs4Error(span, respCode, "InternalError", "Unmalshal PermissionError failed")
-			// 记录异常日志
+			// Log the error.
 			otellog.LogError(ctx, "Unmalshal PermissionError failed", err)
 
 			return map[string]interfaces.PermissionResourceOps{}, err
@@ -348,18 +348,18 @@ func (pa *permissionAccess) FilterResources(ctx context.Context,
 				ErrorDetails: permissionError.Cause,
 			}}
 
-		// 添加异常时的 trace 属性
+		// Add trace attributes for the error.
 		oteltrace.AddHttpAttrs4Error(span, respCode, "InternalError", "Http status is not 200")
-		// 记录异常日志
+		// Log the error.
 		otellog.LogError(ctx, "Post resource-filter failed", httpErr)
 
 		return map[string]interfaces.PermissionResourceOps{}, httpErr
 	}
 
 	if result == nil {
-		// 添加异常时的 trace 属性
+		// Add trace attributes for the error.
 		oteltrace.AddHttpAttrs4Ok(span, respCode)
-		// 记录模型不存在的日志
+		// Log the empty response.
 		otellog.LogWarn(ctx, "Http response body is null")
 
 		return map[string]interfaces.PermissionResourceOps{}, nil
@@ -371,15 +371,15 @@ func (pa *permissionAccess) FilterResources(ctx context.Context,
 	}{}
 	// Process the returned result "result"
 	if err := sonic.Unmarshal(result, &allowOps); err != nil {
-		// 添加异常时的 trace 属性
+		// Add trace attributes for the error.
 		oteltrace.AddHttpAttrs4Error(span, respCode, "InternalError", "Unmalshal resource-filter result failed")
-		// 记录异常日志
+		// Log the error.
 		otellog.LogError(ctx, "Unmalshal resource-filter result failed", err)
 
 		return map[string]interfaces.PermissionResourceOps{}, err
 	}
 
-	// 添加成功时的 trace 属性
+	// Add trace attributes for success.
 	oteltrace.AddHttpAttrs4Ok(span, respCode)
 
 	ops := map[string]interfaces.PermissionResourceOps{}

--- a/adp/vega/vega-backend/server/driveradapters/catalog_handler.go
+++ b/adp/vega/vega-backend/server/driveradapters/catalog_handler.go
@@ -269,7 +269,7 @@ func (r *restHandler) createCatalog(c *gin.Context, visitor hydra.Visitor) {
 		return
 	}
 
-	// 成功创建记录审计日志
+	// Record the successful creation in the audit log.
 	audit.NewInfoLog(audit.OPERATION, audit.CREATE, audit.TransforOperator(visitor),
 		interfaces.GenerateCatalogAuditObject(id, req.Name), "")
 

--- a/adp/vega/vega-backend/server/driveradapters/connector_type_handler.go
+++ b/adp/vega/vega-backend/server/driveradapters/connector_type_handler.go
@@ -85,11 +85,11 @@ func (r *restHandler) ListConnectorTypes(c *gin.Context) {
 	if err != nil {
 		httpErr := err.(*rest.HTTPError)
 
-		// 记录异常日志
+		// Log the error.
 		otellog.LogError(ctx, fmt.Sprintf("%s. %v", httpErr.BaseError.Description,
 			httpErr.BaseError.ErrorDetails), nil)
 
-		// 设置 trace 的错误信息的 attributes
+		// Attach error details to the trace.
 		oteltrace.AddHttpAttrs4HttpError(span, httpErr)
 		rest.ReplyError(c, httpErr)
 		return
@@ -149,7 +149,7 @@ func (r *restHandler) RegisterConnectorType(c *gin.Context) {
 	}
 	ctx = context.WithValue(ctx, interfaces.ACCOUNT_INFO_KEY, accountInfo)
 
-	// 设置 trace 的相关 api 的属性
+	// Attach the relevant API attributes to the trace.
 	oteltrace.AddHttpAttrs4API(span, oteltrace.GetAttrsByGinCtx(c))
 
 	var req interfaces.ConnectorTypeReq
@@ -191,7 +191,7 @@ func (r *restHandler) RegisterConnectorType(c *gin.Context) {
 		return
 	}
 
-	// 成功创建记录审计日志
+	// Record the successful creation in the audit log.
 	audit.NewInfoLog(audit.OPERATION, audit.CREATE, audit.TransforOperator(visitor),
 		interfaces.GenerateConnectorTypeAuditObject(req.Type, req.Name), "")
 

--- a/adp/vega/vega-backend/server/driveradapters/resource_handler.go
+++ b/adp/vega/vega-backend/server/driveradapters/resource_handler.go
@@ -227,7 +227,7 @@ func (r *restHandler) createResource(c *gin.Context, visitor hydra.Visitor) {
 		return
 	}
 
-	// 成功创建记录审计日志
+	// Record the successful creation in the audit log.
 	audit.NewInfoLog(audit.OPERATION, audit.CREATE, audit.TransforOperator(visitor),
 		interfaces.GenerateResourceAuditObject(resource.ID, req.Name), "")
 

--- a/adp/vega/vega-backend/server/driveradapters/router.go
+++ b/adp/vega/vega-backend/server/driveradapters/router.go
@@ -322,7 +322,7 @@ func (r *restHandler) verifyJsonContentType() gin.HandlerFunc {
 }
 
 // LanguageMiddleware resolves Accept-Language once and stores it in request context.
-// 注册顺序必须在 TracingMiddleware 之后，这样 language ctx 叠加在 trace ctx 上。
+// Register this after TracingMiddleware so that the language context wraps the trace context.
 func (r *restHandler) LanguageMiddleware() gin.HandlerFunc {
 	return rest.LanguageMiddleware()
 }
@@ -336,7 +336,7 @@ func (r *restHandler) TraceContextMiddleware() gin.HandlerFunc {
 	}
 }
 
-// gin中间件 访问日志
+// Gin middleware for access logging.
 func (r *restHandler) AccessLog() gin.HandlerFunc {
 	return func(c *gin.Context) {
 		beginTime := time.Now()

--- a/adp/vega/vega-backend/server/driveradapters/validate_resource.go
+++ b/adp/vega/vega-backend/server/driveradapters/validate_resource.go
@@ -59,10 +59,11 @@ func validateResourceRequestSchema(ctx context.Context, req *interfaces.Resource
 		}
 		return validateSchemaProperties(ctx, req.SchemaDefinition, false)
 	default:
-		// 只有原始资源支持 ref_property，也只有它们的存量数据里会有自引用形状，因此归一化
-		// 只在这一支做：dataset 的 ref_property 在 #837 之前就是 400，放宽它属于本次回归
-		// 之外的行为变更。库里读出来的 schema 由 logics 层做同样的归一化，两侧必须一致，
-		// 否则更新会被判成 build 相关变更而清空 LocalIndexName。
+		// Only raw resources support ref_property, and only their legacy data can contain
+		// self-references. Normalize this branch alone: dataset ref_property already returned
+		// 400 before #837, so relaxing it would be unrelated behavior change. The logics layer
+		// performs the same normalization on stored schemas; both sides must match or an update
+		// is treated as a build-related change and clears LocalIndexName.
 		resourcelogic.NormalizeSelfReferencingFeatures(req.SchemaDefinition)
 		return validateSchemaProperties(ctx, req.SchemaDefinition, true)
 	}

--- a/adp/vega/vega-backend/server/logics/cascade.go
+++ b/adp/vega/vega-backend/server/logics/cascade.go
@@ -21,7 +21,8 @@ import (
 // The filter must set either ResourceID for one resource or CatalogID for every resource in a catalog.
 // If a matching task is running or stopping, HasRunningExecution is returned and nothing is deleted.
 //
-// 索引 drop 失败仅记日志、不阻断（与既有"索引删除失败不影响资源删除"语义一致）；
+// A failed index drop is logged but does not block deletion, preserving the existing
+// "index deletion failure does not affect resource deletion" behavior.
 // Errors are returned only when task-row deletion fails. This helper lives in logics because both the
 // resource and catalog services use it, while logics/build_task already depends on logics/catalog.
 func CascadeDeleteBuildTasks(ctx context.Context, bta interfaces.BuildTaskAccess, lim interfaces.LocalIndexManager, filter interfaces.BuildTasksQueryParams) error {

--- a/adp/vega/vega-backend/server/logics/catalog/catalog_service.go
+++ b/adp/vega/vega-backend/server/logics/catalog/catalog_service.go
@@ -323,7 +323,7 @@ func (cs *catalogService) Create(ctx context.Context, req *interfaces.CatalogReq
 	}}, interfaces.COMMON_OPERATIONS)
 	if err != nil {
 		logger.Errorf("CreateResources error: %s", err.Error())
-		span.SetStatus(codes.Error, "创建目录资源失败")
+		span.SetStatus(codes.Error, "failed to create catalog resource")
 		return "", rest.NewHTTPError(ctx, http.StatusInternalServerError,
 			verrors.VegaBackend_Catalog_InternalError_CreateResourcesFailed).
 			WithErrorDetails(err.Error())

--- a/adp/vega/vega-backend/server/logics/connector/local/index/opensearch/opensearch_condition.go
+++ b/adp/vega/vega-backend/server/logics/connector/local/index/opensearch/opensearch_condition.go
@@ -1114,10 +1114,10 @@ func (c *OpenSearchConnector) ConvertFilterConditionKnnVector(condition interfac
 	}, nil
 }
 
-// likeContainsPattern 把 like / not_like 的字面子串转成 OpenSearch 的 wildcard 模式。
+// likeContainsPattern converts a literal like/not_like substring into an OpenSearch wildcard pattern.
 //
-// like 的契约是子串包含，值里的 % 与 _ 已在 filter_condition.ParseLikeValue 拦下，
-// 到这里的都是要原样匹配的字面量，因此只需转义 wildcard 自己的元字符 * ? \ 后两端补 *。
+// The like contract uses substring containment. ParseLikeValue has already handled % and _,
+// so the value is matched literally here; escape the wildcard metacharacters * ? \ and wrap it in *.
 func (c *OpenSearchConnector) likeContainsPattern(input string) string {
 	var escaped strings.Builder
 	for _, r := range input {

--- a/adp/vega/vega-backend/server/logics/connector/local/table/mariadb/mariadb_condition.go
+++ b/adp/vega/vega-backend/server/logics/connector/local/table/mariadb/mariadb_condition.go
@@ -133,7 +133,8 @@ func quoteColumnName(name string) string {
 	return "`" + strings.ReplaceAll(strings.TrimSpace(name), "`", "``") + "`"
 }
 
-// qualTable 将资源的源端标识转为反引号限定的表名；支持 "db.table" -> "`db`.`table`"
+// qualTable converts a resource source identifier into a backtick-qualified table name;
+// it supports "db.table" -> "`db`.`table`".
 func qualTable(sourceIdentifier string) string {
 	return quoteColumnName(sourceIdentifier)
 }

--- a/adp/vega/vega-backend/server/logics/discover_schedule/discover_schedule_service.go
+++ b/adp/vega/vega-backend/server/logics/discover_schedule/discover_schedule_service.go
@@ -69,7 +69,7 @@ func NewDiscoverScheduleService(appSetting *common.AppSetting, dts interfaces.Di
  * @return error returns errors that may occur during the operation process
  */
 func (dss *discoverScheduleService) Create(ctx context.Context, req *interfaces.DiscoverScheduleRequest) (string, error) {
-	// 使用OpenTelemetry追踪请求执行过程
+	// Trace request execution with OpenTelemetry.
 	ctx, span := oteltrace.StartNamedInternalSpan(ctx, "DiscoverScheduleService.Create")
 	defer span.End()
 
@@ -311,9 +311,9 @@ func (dss *discoverScheduleService) Disable(ctx context.Context, id string) erro
 // ExecuteSchedule is a method for executing plan discovery tasks
 // It takes a context and a planned discovery task as parameters and returns an error
 func (dss *discoverScheduleService) ExecuteSchedule(ctx context.Context, schedule *interfaces.DiscoverSchedule) error {
-	// 使用追踪器创建一个新的span，用于监控和追踪请求的执行过程
+	// Create a span to monitor and trace request execution.
 	ctx, span := oteltrace.StartNamedInternalSpan(ctx, "DiscoverScheduleService.ExecuteSchedule")
-	defer span.End() // 确保在函数返回时结束span
+	defer span.End() // End the span when the function returns.
 
 	// Check whether the DiscoverTaskService has been set up
 	if dss.dts == nil {

--- a/adp/vega/vega-backend/server/logics/discover_task/discover_task_service.go
+++ b/adp/vega/vega-backend/server/logics/discover_task/discover_task_service.go
@@ -83,9 +83,9 @@ func (dts *discoverTaskService) RequestDispatch() {
 //	-string: The task ID created
 //	-error: Error message, which returns an error if the creation fails
 func (dts *discoverTaskService) Create(ctx context.Context, req *interfaces.CreateDiscoverTaskRequest) (string, error) {
-	// 使用分布式追踪系统创建一个span，用于追踪服务调用
+	// Create a distributed tracing span for the service call.
 	ctx, span := oteltrace.StartNamedInternalSpan(ctx, "DiscoverTaskService.Create")
-	defer span.End() // 确保span在函数结束时结束
+	defer span.End() // End the span when the function returns.
 
 	// Get account info from context
 	accountInfo := interfaces.AccountInfo{}

--- a/adp/vega/vega-backend/server/logics/filter_condition/condition_like.go
+++ b/adp/vega/vega-backend/server/logics/filter_condition/condition_like.go
@@ -18,8 +18,8 @@ type LikeCond struct {
 	Cfg    *interfaces.FilterCondCfg
 	Lfield *interfaces.Property
 	Value  string
-	// LegacyWildcards 为真时 Value 是未解析的老写法（% 当通配符），由各连接器按改动前的
-	// 语义渲染，不走「字面子串」这套。
+	// When LegacyWildcards is true, Value uses the unparsed legacy form (% as a wildcard).
+	// Each connector renders it with its pre-change semantics instead of literal substring semantics.
 	LegacyWildcards bool
 }
 
@@ -70,16 +70,18 @@ func (c *LikeCond) New(ctx context.Context, cfg *interfaces.FilterCondCfg,
 	}, nil
 }
 
-// ParseLikeValue 校验并解析 like / not_like 的值，返回要匹配的字面子串。
+// ParseLikeValue validates and parses a like/not_like value and returns the literal substring to match.
 //
-// like 的契约是「子串包含」，不是 SQL LIKE 模式。各后端此前对 % 的处理并不一致——
-// SQL 连接器把它转义成字面量再两端补 %，OpenSearch 却把它翻译成 .*——同一条 like 在
-// 明细库与索引上给出不同结果，而 SQL 侧的失败形式是静默返回空集，调用方看不出算子
-// 本身没生效。因此未转义的 % 显式报错，指向 regex；要匹配字面量写 \%。
+// The like contract means substring containment, not SQL LIKE syntax. Backends previously handled %
+// inconsistently: SQL connectors escaped it as a literal and wrapped the value in %, while OpenSearch
+// translated it to .*. The same condition therefore produced different database and index results,
+// with SQL silently returning an empty set. Reject an unescaped % and direct callers to regex; use \%
+// to match a literal percent sign.
 //
-// _ 不在拒绝之列：改动前除 OpenSearch 外的每条路都把它当字面量（Special.Replace 转义成
-// \_，DSL 的 .* 正则里也不是元字符），不存在 % 那种「静默空集」，而检索词里带下划线又
-// 极常见，拒了纯属误伤。\_ 仍按转义解析，写法与 \% 对称。
+// Do not reject _: every pre-change path except OpenSearch treated it literally (Special.Replace
+// escaped it as \_, and it is not a metacharacter in the DSL .* regex). It never caused the silent
+// empty-set behavior of %, and underscores are common in search terms. Parse \_ as an escape,
+// symmetrically with \%.
 func ParseLikeValue(operation, value string) (string, error) {
 	var literal strings.Builder
 	escaped := false
@@ -87,7 +89,7 @@ func ParseLikeValue(operation, value string) (string, error) {
 	for _, r := range value {
 		switch {
 		case escaped:
-			// 只有 % _ \ 有转义意义，其余保留反斜杠本身
+			// Only % _ \ have escape semantics; preserve the backslash for other characters.
 			if r != '%' && r != '_' && r != '\\' {
 				literal.WriteRune('\\')
 			}
@@ -111,15 +113,17 @@ func ParseLikeValue(operation, value string) (string, error) {
 	return literal.String(), nil
 }
 
-// MarkLegacyLikeWildcards 把条件树里用 % 当通配符的 like / not_like 标记为老写法，
-// 返回标记过的条件数。
+// MarkLegacyLikeWildcards marks like/not_like conditions that use % as a wildcard as legacy
+// and returns the number of marked conditions.
 //
-// 只用于视图定义里存着的过滤条件：那份配置是服务端数据，调用方改不了，新契约直接报错会
-// 让一次升级把存量视图查废。标记后由各连接器按**它自己改动前**的语义渲染——SQL 侧 %
-// 转义成字面量，索引侧翻译成正则通配符——所以存量视图的结果一行不变。这里不能统一改写
-// 成字面量：索引路径改动前是通配符匹配，按字面量渲染会让原本有结果的视图静默返回空集。
+// This applies only to filters stored in view definitions. Callers cannot change that server-side
+// data, so enforcing the new contract would break legacy views after an upgrade. Once marked, each
+// connector renders the condition with its own pre-change semantics: SQL treats % literally while
+// index connectors translate it to a regex wildcard. This preserves every legacy view result.
+// Normalizing all paths to literal matching would silently empty results that index paths previously
+// matched as wildcards.
 //
-// 调用方传进来的条件不走这里，仍然硬拒并给出改用 regex 的指引。
+// Caller-supplied conditions do not use this path; they are rejected with guidance to use regex.
 func MarkLegacyLikeWildcards(cfg *interfaces.FilterCondCfg) int {
 	if cfg == nil {
 		return 0

--- a/adp/vega/vega-backend/server/logics/filter_condition/condition_not_like.go
+++ b/adp/vega/vega-backend/server/logics/filter_condition/condition_not_like.go
@@ -17,7 +17,7 @@ type NotLikeCond struct {
 	Cfg    *interfaces.FilterCondCfg
 	Lfield *interfaces.Property
 	Value  string
-	// LegacyWildcards 含义同 LikeCond
+	// LegacyWildcards has the same meaning as in LikeCond.
 	LegacyWildcards bool
 }
 

--- a/adp/vega/vega-backend/server/logics/query/raw_query_service.go
+++ b/adp/vega/vega-backend/server/logics/query/raw_query_service.go
@@ -66,7 +66,7 @@ func (rqs *rawQueryService) Execute(ctx context.Context, req *interfaces.RawQuer
 	defer span.End()
 
 	// Collect resource status alerts (deprecated hits) and attach them to the response on each successful return path.
-	// 同时落到当前 span 关联的日志里，便于事后审计。
+	// Also write this to the log associated with the current span for later auditing.
 	var warnings []string
 	defer func() {
 		if resp != nil && resp.Paging == nil {

--- a/adp/vega/vega-backend/server/logics/resource/feature.go
+++ b/adp/vega/vega-backend/server/logics/resource/feature.go
@@ -26,16 +26,16 @@ func IsFeatureSupported(propertyType string, featureType string) bool {
 	}
 }
 
-// NormalizeSelfReferencingFeatures 抹平字段特征里指向属性自身的 ref_property。
+// NormalizeSelfReferencingFeatures removes ref_property values that point to their own property.
 //
-// ref_property 的语义是「特征挂在 A 属性上、但作用于 B 字段」，指向字段自身是无意义的
-// 冗余写法：能力派生在 ref_property 为空时本来就落回属性自身（见 bkn-backend 的
-// VegaResourceIndexCaps），两种写法同解。
+// ref_property means that a feature attached to property A acts on field B. Pointing it back to A
+// is redundant: capability derivation already falls back to the property itself when ref_property
+// is empty (see VegaResourceIndexCaps in bkn-backend), so both forms are equivalent.
 //
-// 历史上平台自己写入的存量资源正是这个形状，因此必须就地抹平而不是报错。抹平要同时作用在
-// 请求侧与库里读出来的 schema 上：只归一化一侧的话，两侧 Features 不再 DeepEqual，
-// 资源更新会被 validateMutableSchemaUpdate 判成 build 相关变更，进而清空 LocalIndexName，
-// 让一次普通编辑把已建好的索引废掉。
+// The platform historically persisted legacy resources in this form, so normalize them instead of
+// rejecting them. Apply normalization to both request and stored schemas; normalizing only one side
+// makes their Features unequal, causing validateMutableSchemaUpdate to classify an ordinary edit as
+// a build-related change, clear LocalIndexName, and invalidate an existing index.
 func NormalizeSelfReferencingFeatures(props []*interfaces.Property) {
 	for _, prop := range props {
 		if prop == nil {

--- a/adp/vega/vega-backend/server/logics/resource/resource_service.go
+++ b/adp/vega/vega-backend/server/logics/resource/resource_service.go
@@ -514,7 +514,7 @@ func (rs *resourceService) Create(ctx context.Context, req *interfaces.ResourceR
 	}}, interfaces.COMMON_OPERATIONS)
 	if err != nil {
 		logger.Errorf("CreateResources error: %s", err.Error())
-		span.SetStatus(codes.Error, "创建资源失败")
+		span.SetStatus(codes.Error, "failed to create resource")
 		return nil, rest.NewHTTPError(ctx, http.StatusInternalServerError,
 			verrors.VegaBackend_Catalog_InternalError_CreateResourcesFailed).
 			WithErrorDetails(err.Error())
@@ -1281,8 +1281,9 @@ func (rs *resourceService) validateResourceUpdateScope(ctx context.Context, reso
 	if req.SchemaDefinition == nil {
 		return indexConfigChanged, nil
 	}
-	// 库里的存量 schema 可能带自引用 ref_property（迁移前平台自己写的形状），请求侧已在
-	// 入口抹平。两侧都归一化后再比，否则一次没改 schema 的普通编辑会被判成 build 相关变更。
+	// A stored legacy schema can contain a self-referencing ref_property written by the platform before
+	// migration. The request was normalized at ingress; normalize both sides before comparison so an
+	// ordinary edit without schema changes is not classified as a build-related change.
 	NormalizeSelfReferencingFeatures(resource.SchemaDefinition)
 	schemaChanged, err := validateMutableSchemaUpdate(
 		ctx,

--- a/adp/vega/vega-backend/server/logics/resource_data/logic_view/dsl/dsl_condition.go
+++ b/adp/vega/vega-backend/server/logics/resource_data/logic_view/dsl/dsl_condition.go
@@ -1097,10 +1097,10 @@ func (c *logicViewDSLGenerator) ConvertFilterConditionKnnVector(ctx context.Cont
 	}, nil
 }
 
-// likeContainsPattern 把 like / not_like 的字面子串转成 OpenSearch 的 wildcard 模式。
+// likeContainsPattern converts a literal like/not_like substring into an OpenSearch wildcard pattern.
 //
-// like 的契约是子串包含，值里的 % 与 _ 已在 filter_condition.ParseLikeValue 拦下，
-// 到这里的都是要原样匹配的字面量，因此只需转义 wildcard 自己的元字符 * ? \ 后两端补 *。
+// The like contract uses substring containment. ParseLikeValue has already handled % and _,
+// so the value is matched literally here; escape the wildcard metacharacters * ? \ and wrap it in *.
 func (c *logicViewDSLGenerator) likeContainsPattern(input string) string {
 	var escaped strings.Builder
 	for _, r := range input {

--- a/adp/vega/vega-backend/server/worker/build_task_common.go
+++ b/adp/vega/vega-backend/server/worker/build_task_common.go
@@ -170,10 +170,10 @@ func buildLocalIndexSchema(buildTask *interfaces.BuildTask, resource *interfaces
 		schema = schemaDefinition
 	}
 
-	// 从没被 PUT 过的存量资源，库里仍是自引用形状。不抹平的话：dataset 类目会撞上「不许带
-	// ref_property」，text 字段上的 keyword 自引用还会撞上 ref 类型校验（keyword 要求
-	// string），构建任务直接建不起来——正是这个 PR 要解的「索引重建不了」。
-	// 只作用在上面那份深拷贝上，资源行本身不动，等下一次更新自愈。
+	// Legacy resources that have never been updated still contain self-references. Without normalization,
+	// dataset resources violate the ref_property restriction and keyword self-references on text fields
+	// fail ref type validation (keyword requires string), preventing build task creation. Apply this only
+	// to the deep copy above; leave the resource row unchanged so its next update can repair it.
 	resourcelogic.NormalizeSelfReferencingFeatures(schema)
 
 	if err := validateBuildTaskSchemaFeatures(resource.Category, schema); err != nil {


### PR DESCRIPTION
# Pull Request

## What Changed

Brief description of changes:

- [x] Translate remaining production comments and docstrings in `adp/vega/vega-backend` to English.
- [x] Translate service-owned internal OpenTelemetry span/status text in `adp/vega/vega-backend`.
- [x] Keep client-visible connector schema metadata unchanged where it is part of the existing API/contract.

---

## Why

- Related Issue: Part of #993
- Related Feature: N/A
- Background:
  - #993 is being split by module to keep review size manageable.
  - This PR covers only the Vega backend module.

---

## How

- Key implementation points:
  - Replaced Chinese production comments/docstrings with English equivalents.
  - Updated internal diagnostics/tracing text that is service-owned and not a client contract.
  - Left 27 Chinese connector schema metadata lines in place because they are client-visible field descriptions and exact-value-tested.
- Breaking changes (API, config, database, etc.):
  - None.

---

## Testing

- [ ] Unit tests passed locally
- [ ] Integration tests passed locally
- [ ] Verified in test environment

Test notes:

- Ran `make lint` for `adp/vega/vega-backend` in an LF-only temporary checkout: passed.
- Ran `make ci` for `adp/vega/vega-backend` in an LF-only temporary checkout: passed.
- `make ci` completed with coverage above the module threshold.
- Test environment verification: N/A for comment/internal-text-only cleanup.

---

## Risk & Rollback

- Potential risks:
  - Low. Changes are limited to comments/docstrings and internal tracing/status text, with client-visible metadata intentionally preserved.
- Rollback plan:
  - Revert this PR commit if any downstream check finds an unexpected text contract dependency.

---

## Additional Notes

- This PR intentionally does not close #993. The issue will remain open until all scoped modules are completed.
