### PR TITLE
feat(deploy): bake the IK Chinese analyzer into the platform OpenSearch image

### DIFF
--- a/.github/workflows/release-deploy-opensearch.yml
+++ b/.github/workflows/release-deploy-opensearch.yml
@@ -1,0 +1,65 @@
+name: release-deploy-opensearch
+
+# Multi-arch build of the platform OpenSearch image (deploy/images/opensearch):
+# stock OpenSearch plus the IK Chinese analyzer. Versioned off the OpenSearch
+# version (2.19.4-*), NOT the repo VERSION — see
+# deploy/images/opensearch/README.md. Branch pushes publish a branch-tagged
+# image (same convention as the service pipelines), so a fix is testable
+# pre-merge.
+
+on:
+  push:
+    branches: ['**']
+    paths:
+      - 'deploy/images/opensearch/**'
+      - '.github/workflows/release-deploy-opensearch.yml'
+      - '.github/workflows/reusable-build.yml'
+  workflow_dispatch:
+    inputs:
+      publish:
+        description: 'Publish to registries (true) or verify build only (false)'
+        type: boolean
+        default: false
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  resolve-version:
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.version.outputs.version }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - id: version
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          # Base = the OpenSearch version baked into the image, so image tags
+          # stay in the 2.19.4-* line the chart/scripts expect.
+          BASE_VERSION="2.19.4"
+          REF_NAME="${{ github.ref_name }}"
+          SHORT_SHA="$(git rev-parse --short=7 HEAD)"
+          SANITIZED_BRANCH="$(echo "$REF_NAME" | tr '[:upper:]' '[:lower:]' | sed -E 's#[^0-9a-zA-Z.-]+#-#g; s#-+#-#g; s#^[.-]+##; s#[.-]+$##')"
+          # Commit time (Asia/Shanghai), not build time — monotonic and re-run reproducible.
+          COMMIT_DATE="$(TZ=Asia/Shanghai git show -s --format=%cd --date=format-local:%Y%m%d%H%M%S HEAD)"
+          VERSION="$BASE_VERSION-$SANITIZED_BRANCH.$COMMIT_DATE.sha$SHORT_SHA"
+
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+
+  build:
+    needs: resolve-version
+    uses: ./.github/workflows/reusable-build.yml
+    secrets: inherit
+    with:
+      service-path: deploy/images/opensearch
+      dockerfile: Dockerfile
+      context: '.'
+      image-name: opensearch
+      version: ${{ needs.resolve-version.outputs.version }}
+      publish: ${{ github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && inputs.publish) }}

--- a/deploy/images/opensearch/Dockerfile
+++ b/deploy/images/opensearch/Dockerfile
@@ -1,0 +1,36 @@
+# Platform OpenSearch image: stock OpenSearch plus the IK Chinese analyzer.
+#
+# The stock opensearchproject/opensearch image ships no Chinese analyzer, so
+# vega-backend's startup capability probe only ever finds `standard` and
+# `english` (server/logics/local_index/local_index_manager.go). Chinese text
+# then falls back to per-character tokenization, which costs recall and
+# relevance. Baking analysis-ik in makes `ik_max_word` available out of the
+# box — Studio's analyzer picker is driven by GET /index-capabilities, so no
+# frontend change is needed.
+#
+# Baked in rather than installed through the chart's `plugins.installList`:
+# that path wraps the plugin install into the main container command, so every
+# pod start re-downloads the plugin and one network hiccup keeps OpenSearch
+# down (`set -euo pipefail`). Offline installs cannot use it at all.
+FROM opensearchproject/opensearch:2.19.4
+
+# The plugin descriptor pins opensearch.version=2.19.4 and OpenSearch refuses
+# to load a plugin whose version does not match the node exactly. Bump this
+# and the base image tag together.
+ARG IK_VERSION=2.19.4
+ARG IK_SHA256=9f7a9af933698836dad2cdea6647313d38d73b9bf63a2dc58746681bca882877
+ARG IK_URL=https://release.infinilabs.com/analysis-ik/stable/opensearch-analysis-ik-${IK_VERSION}.zip
+
+USER root
+RUN set -eux; \
+    curl -fsSL -o /tmp/analysis-ik.zip "${IK_URL}"; \
+    echo "${IK_SHA256}  /tmp/analysis-ik.zip" | sha256sum -c -; \
+    chown opensearch:opensearch /tmp/analysis-ik.zip
+
+USER opensearch
+# -b accepts the plugin security policy (SocketPermission, required by IK's
+# remote dictionary hot reload) instead of prompting.
+RUN set -eux; \
+    /usr/share/opensearch/bin/opensearch-plugin install -b file:///tmp/analysis-ik.zip; \
+    rm -f /tmp/analysis-ik.zip; \
+    /usr/share/opensearch/bin/opensearch-plugin list | grep -qx analysis-ik

--- a/deploy/images/opensearch/README.md
+++ b/deploy/images/opensearch/README.md
@@ -1,0 +1,83 @@
+# Platform OpenSearch image
+
+Stock OpenSearch plus the IK Chinese analyzer, installed by
+`deploy.sh opensearch install`.
+
+## Why this exists
+
+vega-backend probes a fixed candidate list of full-text analyzers once at
+startup (`standard`, `english`, `ik_max_word`, `hanlp_index`) and caches
+whatever the cluster actually answers to; the result is served by
+`GET /api/vega-backend/v1/index-capabilities` and drives Studio's analyzer
+picker. The stock `opensearchproject/opensearch` image carries no Chinese
+analyzer, so only `standard` and `english` ever show up — Chinese text is
+tokenized per character, and picking `ik_max_word` fails validation with
+`analyzer "ik_max_word" ... is unavailable` (HTTP 400).
+
+This image bakes `analysis-ik` in, so `ik_max_word` is available on a fresh
+install with no frontend change and no per-environment setup.
+
+The OpenSearch chart's own `plugins.installList` is deliberately **not** used:
+it wraps the plugin install into the main container command, so every pod start
+re-downloads the plugin from the internet, and any failure there keeps
+OpenSearch from starting at all. Offline installs cannot use it.
+
+## Provenance
+
+- Base: `opensearchproject/opensearch:2.19.4` (the tag the deploy scripts
+  already pinned).
+- Plugin: `opensearch-analysis-ik-2.19.4.zip` from
+  `https://release.infinilabs.com/analysis-ik/stable/`, pinned by SHA-256 in
+  the Dockerfile.
+
+The plugin descriptor pins `opensearch.version=2.19.4`. OpenSearch refuses to
+load a plugin whose version does not match the node exactly, so the base image
+tag and `IK_VERSION` must be bumped together.
+
+`hanlp_index` stays in vega-backend's candidate list but is not shipped.
+OpenSearch has no equivalent of IK's maintained release line for HanLP: every
+implementation is a personal port of KennFalcon's Elasticsearch plugin, and
+the most active one (`Canva/opensearch-hanlp-plugin`) publishes releases only
+for 2.10.0 / 2.19.1 / 2.19.2 — none of which loads on a 2.19.4 node, since the
+descriptor version must match exactly. Shipping it would mean building from
+source against every OpenSearch bump plus distributing the HanLP dictionaries.
+The probe simply drops it, same as today.
+
+## Build & publish
+
+CI (`.github/workflows/release-deploy-opensearch.yml`) builds
+`linux/amd64,linux/arm64` on any push touching this directory and publishes to
+GHCR plus the Huawei SWR mirror as
+`opensearch:2.19.4-<branch>.<committime>.sha<short>` (base `2.19.4` = the
+OpenSearch version, not the repo VERSION).
+
+Consumed via `OPENSEARCH_IMAGE_REPOSITORY` / `OPENSEARCH_IMAGE_TAG` (defaults
+in `deploy/scripts/lib/common.sh`).
+
+Local one-off:
+
+```bash
+docker buildx build --platform linux/amd64,linux/arm64 \
+  -t <registry>/openbkn-ai/opensearch:<tag> --push deploy/images/opensearch
+```
+
+## Verifying
+
+After the pod is up:
+
+```bash
+curl -s -XPOST "http://<opensearch>:9200/_analyze" -H 'Content-Type: application/json' \
+  -d '{"analyzer":"ik_max_word","text":"知识网络"}'
+```
+
+Word-level tokens (not single characters) means the plugin loaded.
+
+## Upgrading an existing environment
+
+1. Point OpenSearch at this image and roll the StatefulSet.
+2. **Restart vega-backend.** The analyzer capability table is probed once per
+   process (`sync.Once`) and cached; without a restart the API keeps reporting
+   `ik_max_word` as unavailable and Studio keeps hiding it.
+3. Rebuild indexes that should use it. The analyzer is fixed at index creation
+   time, so existing indexes keep their old tokenization until the object type
+   is re-pushed and the build task re-run.

--- a/deploy/images/opensearch/README.md
+++ b/deploy/images/opensearch/README.md
@@ -51,8 +51,21 @@ GHCR plus the Huawei SWR mirror as
 `opensearch:2.19.4-<branch>.<committime>.sha<short>` (base `2.19.4` = the
 OpenSearch version, not the repo VERSION).
 
-Consumed via `OPENSEARCH_IMAGE_REPOSITORY` / `OPENSEARCH_IMAGE_TAG` (defaults
-in `deploy/scripts/lib/common.sh`).
+Not yet wired into the installer. `deploy/scripts/lib/common.sh` still defaults
+`OPENSEARCH_IMAGE_REPOSITORY` / `OPENSEARCH_IMAGE_TAG` to the stock
+`opensearchproject/opensearch:2.19.4`, so a default install does not pull this
+image yet. Flipping those defaults needs a concrete tag, which only exists once
+this lands on main and CI publishes — so it is a follow-up PR that also updates
+the inline fallback in `deploy/scripts/services/opensearch.sh` and the offline
+image list in `deploy/scripts/sync-k8s-images.sh`.
+
+Until then, opt in per environment:
+
+```bash
+OPENSEARCH_IMAGE_REPOSITORY=opensearch \
+OPENSEARCH_IMAGE_TAG=2.19.4-<branch>.<committime>.sha<short> \
+  ./deploy.sh opensearch install
+```
 
 Local one-off:
 


### PR DESCRIPTION
Closes #1006. Follow-up to #454.

## Why

#454 stopped Studio from offering an analyzer the cluster does not have: vega-backend probes the analyzer candidate list once at startup and serves the result from `GET /api/vega-backend/v1/index-capabilities`, which drives both the picker and index-config validation.

What it could not fix is that the probe never finds a Chinese analyzer. `deploy.sh opensearch install` deploys the stock `opensearchproject/opensearch:2.19.4` image, which ships none, so every environment reports `standard` + `english` only. Chinese text is tokenized per character, `ik_max_word` fails validation with HTTP 400, and Studio permanently shows "no Chinese analyzer is enabled — ask an administrator to enable one" while administrators have no supported way to enable one.

## What

New `deploy/images/opensearch`: stock OpenSearch 2.19.4 plus `analysis-ik` 2.19.4 (from `release.infinilabs.com`, pinned by SHA-256), published for `linux/amd64` + `linux/arm64` through `reusable-build` by `release-deploy-opensearch.yml`, versioned `2.19.4-<branch>.<committime>.sha<short>`. Same shape as the platform Redis image (#290).

The plugin descriptor pins `opensearch.version=2.19.4` and OpenSearch refuses a mismatched plugin, so the base image tag and `IK_VERSION` must move together — documented in the image README.

The build asserts `opensearch-plugin list` contains `analysis-ik`, so a broken download or a version mismatch fails the pipeline instead of shipping a silently plugin-less image.

## Why not the chart's `plugins.installList`

The OpenSearch chart does expose `plugins.enabled` / `plugins.installList`, but its template folds the install into the main container's `command` rather than an initContainer. Every pod start re-downloads the plugin, and because the script runs under `set -euo pipefail`, any network failure keeps OpenSearch from starting at all rather than degrading to "no plugin". Offline installs cannot use it. Not acceptable as the default shape, hence baking it into the image.

`hanlp_index` stays unshipped. OpenSearch has no equivalent of IK's maintained release line for HanLP — every implementation is a personal port of KennFalcon's Elasticsearch plugin. The most active one, Canva/opensearch-hanlp-plugin, states that the officially maintained version belongs to AWS and is closed-source, and keeps its copy only for local and pipeline tests; its releases stop at 2.10.0 / 2.19.1 / 2.19.2, with no 2.19.4. Since the plugin descriptor version must match the node exactly, none of those artifacts loads on 2.19.4.

Shipping it would mean building from source and recompiling against every OpenSearch bump, plus distributing and licensing the HanLP dictionaries — a different order of cost from IK's "download the official release, verify the hash", so it is left for separate evaluation. The probe keeps dropping it, unchanged from today.

## Follow-up

Once a main-line tag exists, a follow-up commit switches the `OPENSEARCH_IMAGE_REPOSITORY` / `OPENSEARCH_IMAGE_TAG` defaults in `deploy/scripts/lib/common.sh` and the offline manifest in `deploy/scripts/sync-k8s-images.sh` to the new image. Same sequencing as #290.

Existing environments additionally need vega-backend restarted after the image swap — the capability table is probed once per process (`sync.Once`) and cached — and indexes rebuilt, since the analyzer is fixed at index creation time. Both are in the image README.

## Test

- `release-deploy-opensearch` green on this branch; multi-arch build published `2.19.4-feature-deploy-opensearch-ik-analyzer.20260818150827.shae2d206b` to GHCR and the SWR mirror, with the in-build `analysis-ik` assertion passing on both platforms.
- Plugin archive verified before pinning: `opensearch.version=2.19.4` in the descriptor, SHA-256 `9f7a9af9…c882877`.
- Runtime verification on the test environment (`_analyze` word-level output, `/index-capabilities` reporting `ik_max_word`, Studio picker) still pending — it needs an OpenSearch roll plus a vega-backend restart there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

