### PR TITLE
docs: remove the last non-image kweaver brand strings

### DIFF
--- a/adp/bkn/bkn-backend/docker/Dockerfile
+++ b/adp/bkn/bkn-backend/docker/Dockerfile
@@ -29,8 +29,8 @@ FROM ${BASE_IMAGE} AS prod
 ARG UID=1001
 ARG GID=1001
 
-RUN groupadd -r -g $GID kweaver \
-    && useradd -r -u $UID -g $GID kweaver
+RUN groupadd -r -g $GID openbkn \
+    && useradd -r -u $UID -g $GID openbkn
 
 COPY --from=builder --chown=$UID:$GID /go/src/bin /opt/bkn-backend
 

--- a/adp/bkn/ontology-query/docker/Dockerfile
+++ b/adp/bkn/ontology-query/docker/Dockerfile
@@ -29,8 +29,8 @@ FROM ${BASE_IMAGE} AS prod
 ARG UID=1001
 ARG GID=1001
 
-RUN groupadd -r -g $GID kweaver \
-    && useradd -r -u $UID -g $GID kweaver
+RUN groupadd -r -g $GID openbkn \
+    && useradd -r -u $UID -g $GID openbkn
 
 COPY --from=builder --chown=$UID:$GID /go/src/bin /opt/ontology-query
 

--- a/adp/execution-factory/tests/.gitignore
+++ b/adp/execution-factory/tests/.gitignore
@@ -4,7 +4,7 @@ report/
 __pycache__/
 .venv/
 
-# Full Agent AT suite and payloads are synced locally from KWeaver; not tracked here.
+# Full Agent AT suite and payloads are synced locally from the legacy platform; not tracked here.
 testcases/data-operator-hub/
 /conftest.py
 data/

--- a/adp/execution-factory/tests/README.md
+++ b/adp/execution-factory/tests/README.md
@@ -1,6 +1,6 @@
 # Execution Factory Tests (OpenBKN)
 
-Canonical test location for Execution Factory migrated from KWeaver DIP/Core.
+Canonical test location for Execution Factory, migrated from the legacy upstream platform.
 
 ## Test tiers
 
@@ -8,13 +8,13 @@ Canonical test location for Execution Factory migrated from KWeaver DIP/Core.
 |------|------|------|-----|
 | **L1** | bkn-studio vitest mocks | Every PR | `bkn-studio` `ci-execution-factory.yml` |
 | **L2** | `openbkn-smoke` pytest | Backend up locally / manual | `bkn-foundry` collect-only on PR; live via `workflow_dispatch` |
-| **L3** | Full Agent AT (`data-operator-hub`) | KWeaver platform env | Not in git; sync locally (below) |
+| **L3** | Full Agent AT (`data-operator-hub`) | Legacy platform env (eisoo/Hydra) | Not in git; sync locally (below) |
 
 ```
 adp/execution-factory/
 |-- tests/                          # Agent AT (pytest) -- this directory
 |   |-- testcases/
-|   |   |-- data-operator-hub/      # L3 -- gitignored, sync from KWeaver
+|   |   |-- data-operator-hub/      # L3 -- gitignored, synced locally
 |   |   `-- openbkn-smoke/          # L2 -- tracked in git
 |   |-- config/env.openbkn.example.ini
 |   |-- requirements/ci-smoke.txt   # minimal deps for CI collect
@@ -27,16 +27,16 @@ adp/execution-factory/
 
 ## Sync full Agent AT (L3, local only)
 
-Bulk payloads are **not** in git. Copy from a local KWeaver clone:
+Bulk payloads are **not** in git. Copy from a local clone of the legacy platform:
 
 ```powershell
 cd bkn-foundry/bkn-foundry/adp/execution-factory/tests
-# optional: $env:KEWEAVER_ROOT = "e:\00_code_workspace\keweaver"
+# optional: $env:LEGACY_PLATFORM_ROOT = "<path to the legacy platform clone>"
 .\scripts\sync-agent-at.ps1
 # dry run: .\scripts\sync-agent-at.ps1 -DryRun
 ```
 
-Source: `keweaver/adp/execution-factory/tests` (or `$KEWEAVER_ROOT/adp/execution-factory/tests`).
+Source: `<legacy platform clone>/adp/execution-factory/tests` (or `$LEGACY_PLATFORM_ROOT/adp/execution-factory/tests`).
 
 ## L2 -- OpenBKN backend smoke
 

--- a/adp/execution-factory/tests/scripts/sync-agent-at.ps1
+++ b/adp/execution-factory/tests/scripts/sync-agent-at.ps1
@@ -1,17 +1,13 @@
 param(
-  [string]$Source = "$env:KEWEAVER_ROOT\adp\execution-factory\tests",
+  [string]$Source = "$env:LEGACY_PLATFORM_ROOT\adp\execution-factory\tests",
   [switch]$DryRun
 )
 
 $ErrorActionPreference = "Stop"
 $destRoot = Split-Path -Parent $PSScriptRoot
 
-if (-not $Source) {
-  $Source = "e:\00_code_workspace\keweaver\adp\execution-factory\tests"
-}
-
 if (-not (Test-Path $Source)) {
-  Write-Error "Agent AT source not found: $Source. Set KEWEAVER_ROOT or pass -Source."
+  Write-Error "Agent AT source not found: $Source. Set LEGACY_PLATFORM_ROOT or pass -Source."
 }
 
 $folders = @(

--- a/adp/execution-factory/tests/testcases/openbkn-smoke/conftest.py
+++ b/adp/execution-factory/tests/testcases/openbkn-smoke/conftest.py
@@ -3,7 +3,7 @@
 #
 # Licensed under the OpenBKN License. See LICENSE-OPENBKN.txt in the project root.
 
-"""OpenBKN smoke fixtures — no KWeaver platform (eisoo/Hydra) required."""
+"""OpenBKN smoke fixtures — no legacy platform (eisoo/Hydra) required."""
 
 import os
 

--- a/adp/vega/vega-backend/docker/Dockerfile
+++ b/adp/vega/vega-backend/docker/Dockerfile
@@ -29,8 +29,8 @@ FROM ${BASE_IMAGE} AS prod
 ARG UID=1001
 ARG GID=1001
 
-RUN groupadd -r -g $GID kweaver \
-    && useradd -r -u $UID -g $GID kweaver \
+RUN groupadd -r -g $GID openbkn \
+    && useradd -r -u $UID -g $GID openbkn \
     && apt-get update \
     && apt-get install -y python3 python3-pip \
     && pip3 install --break-system-packages --index-url https://pypi.org/simple/ "sqlglot==30.14.0" \

--- a/bkn-trace/README.md
+++ b/bkn-trace/README.md
@@ -2,7 +2,7 @@
 
 English | [中文](README.zh.md)
 
-[![License](https://img.shields.io/badge/license-Apache%202.0-blue.svg)](LICENSE.txt)
+[![License](https://img.shields.io/badge/license-OpenBKN-blue.svg)](../LICENSE-OPENBKN.txt)
 
 Tracing AI is a verification and observability framework for LLM applications and agent systems. It is built to turn opaque AI execution into inspectable, attributable, and production-ready workflows through end-to-end tracing, structured correlation, and queryable evidence.
 
@@ -180,4 +180,4 @@ GET  /swagger/index.html
 
 ## License
 
-Apache 2.0. See `LICENSE.txt`.
+OpenBKN License. See [LICENSE-OPENBKN.txt](../LICENSE-OPENBKN.txt), and the repository root [LICENSE](../LICENSE) for the overall licensing model.

--- a/bkn-trace/README.zh.md
+++ b/bkn-trace/README.zh.md
@@ -2,7 +2,7 @@
 
 [English](README.md) | 中文
 
-[![License](https://img.shields.io/badge/license-Apache%202.0-blue.svg)](LICENSE.txt)
+[![License](https://img.shields.io/badge/license-OpenBKN-blue.svg)](../LICENSE-OPENBKN.txt)
 
 Tracing AI 是一套面向 LLM 应用和智能体系统的可验证性与可观测性框架，目标是通过全链路观测、结构化关联和证据化查询，把 AI 从“黑盒推理”推进到“确定性生产力”。
 
@@ -180,4 +180,4 @@ GET  /swagger/index.html
 
 ## License
 
-Apache 2.0，详见 `LICENSE.txt`。
+OpenBKN License，详见 [LICENSE-OPENBKN.txt](../LICENSE-OPENBKN.txt)；仓库整体的多许可证模型见根目录 [LICENSE](../LICENSE)。

--- a/infra/sandbox/CHANGELOG.md
+++ b/infra/sandbox/CHANGELOG.md
@@ -56,7 +56,7 @@ All new features and capabilities added in this branch (`feature/803264`) are do
 
 - Updated README, build documentation, project structure docs, deployment notes, and the multi-language Go execution design to describe the new image layering and SWR push workflow
 - Documented integration test run modes for happy-path smoke tests, full runs, slow-only runs, and full runs excluding slow tests
-- Added `deploy/helm/README.md` to explain the difference between the Kweaver Core component chart and the standalone Sandbox chart
+- Added `deploy/helm/README.md` to explain the difference between the BKN Foundry component chart and the standalone Sandbox chart
 - Rewrote the Helm chart READMEs so `deploy/helm/sandbox` documents the Core component deployment and `deploy/helm/sandbox_standalone` documents the self-contained stack with Web, MariaDB, and MinIO
 
 ---
@@ -131,13 +131,6 @@ All new features and capabilities added in this branch (`feature/803264`) are do
 *Released on 2026-04-07*
 
 ## [0.3.1]
-
-### 🚀 New Features
-
-- **Database Name Upgrade Handling**
-  - Changed the control plane default database name from `adp` to `kweaver`
-  - Added startup upgrade handling to detect the legacy `adp` schema and migrate tables into `kweaver`
-  - Normalized runtime database connections to `kweaver` to prevent recreating the legacy database during startup
 
 ### 🔧 Improvements
 

--- a/infra/sandbox/CHANGELOG_ZH.md
+++ b/infra/sandbox/CHANGELOG_ZH.md
@@ -56,7 +56,7 @@
 
 - 更新 README、构建文档、项目结构文档、部署说明和多语言 Go 执行设计文档，说明新的镜像分层和 SWR 推送流程
 - 补充集成测试运行模式说明，包括 happy path 冒烟、完整运行、仅运行慢测试，以及排除慢测试的完整运行方式
-- 新增 `deploy/helm/README.md`，说明 Kweaver Core 组件 Chart 与 Sandbox 独立部署 Chart 的区别
+- 新增 `deploy/helm/README.md`，说明 BKN Foundry 组件 Chart 与 Sandbox 独立部署 Chart 的区别
 - 重写 Helm Chart README，使 `deploy/helm/sandbox` 明确说明 Core 组件部署方式，`deploy/helm/sandbox_standalone` 明确说明包含 Web、MariaDB、MinIO 的自包含部署方式
 
 ---
@@ -131,13 +131,6 @@
 *发布于 2026-04-07*
 
 ## [0.3.1]
-
-### 🚀 新功能
-
-- **数据库名称升级处理**
-  - 将 control plane 默认数据库名从 `adp` 调整为 `kweaver`
-  - 新增启动时升级逻辑，可检测旧库 `adp` 并将其中表迁移到 `kweaver`
-  - 将运行期数据库连接统一规范到 `kweaver`，避免服务启动时重新创建旧库
 
 ### 🔧 改进
 


### PR DESCRIPTION
Follow-up to #995 / #996, covering the four buckets those PRs deliberately left alone.

## What changed

**`infra/sandbox/CHANGELOG{,_ZH}.md`** — the 0.3.1 *Database Name Upgrade Handling* entry recorded a rename to a database name the code no longer targets: `persistence/database.py` migrates `adp` → `openbkn`, with no `kweaver` step. Rewriting it would have contradicted the code, so the entry is dropped and 0.3.1 keeps its Improvements entry. The chart entry on line 59 is a product rename only and was reworded in place.

**`adp/execution-factory/tests/`** — the L3 suite genuinely needs a different platform, so these are reworded rather than deleted: "the legacy platform", with the concrete `(eisoo/Hydra)` hint kept in the tier table. `KEWEAVER_ROOT` → `LEGACY_PLATFORM_ROOT` in both the README and `sync-agent-at.ps1`, so the two still name the same variable. The script's hard-coded fallback pointed at one contributor's local `e:\00_code_workspace\keweaver` — unusable for anyone else — so it goes with the rename; the existing error already tells you to set the variable or pass `-Source`.

**Container runtime user** in the bkn-backend / ontology-query / vega-backend Dockerfiles: `kweaver` → `openbkn`. Nothing resolves the account by name — `COPY --chown=$UID:$GID` and `USER $UID` are both numeric, and the `UID`/`GID` ARGs are unchanged — so the built image is equivalent apart from `/etc/passwd`.

**`bkn-trace/README{,.zh}.md`** — the badge and license section claimed Apache 2.0 and linked a `LICENSE.txt` that does not exist in that directory. bkn-trace appears in neither NOTICE component list, but every license header present under `bkn-trace/` says OpenBKN License (6 of 198 Go files carry one; none Apache, none upstream-derived), so both now say OpenBKN License and link the root texts.

## Worth a follow-up, not changed here

- Environments that landed on a `kweaver` database are not covered by the current `adp` → `openbkn` startup migration, and after this PR the repo no longer records that intermediate name anywhere.
- 192 of 198 Go files under `bkn-trace/` carry no license header at all, and bkn-trace is missing from both NOTICE component lists.

## Still out of scope

SWR image namespaces (owned by a separate change) and the Apache 2.0 section 4 attribution headers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)