### PR TITLE
feat(deploy): make the IK-enabled OpenSearch image the install default

### DIFF
--- a/.github/workflows/release-deploy-opensearch.yml
+++ b/.github/workflows/release-deploy-opensearch.yml
@@ -11,7 +11,10 @@ on:
   push:
     branches: ['**']
     paths:
-      - 'deploy/images/opensearch/**'
+      # The Dockerfile, not the whole directory: the README lives there too, and
+      # a doc edit that publishes a new image tag only makes the tag pinned in
+      # deploy/scripts/lib/common.sh look stale against a byte-identical build.
+      - 'deploy/images/opensearch/Dockerfile'
       - '.github/workflows/release-deploy-opensearch.yml'
       - '.github/workflows/reusable-build.yml'
   workflow_dispatch:

--- a/deploy/images/opensearch/README.md
+++ b/deploy/images/opensearch/README.md
@@ -24,8 +24,7 @@ OpenSearch from starting at all. Offline installs cannot use it.
 
 ## Provenance
 
-- Base: `opensearchproject/opensearch:2.19.4` (the tag the deploy scripts
-  already pinned).
+- Base: `opensearchproject/opensearch:2.19.4`.
 - Plugin: `opensearch-analysis-ik-2.19.4.zip` from
   `https://release.infinilabs.com/analysis-ik/stable/`, pinned by SHA-256 in
   the Dockerfile.
@@ -51,19 +50,17 @@ GHCR plus the Huawei SWR mirror as
 `opensearch:2.19.4-<branch>.<committime>.sha<short>` (base `2.19.4` = the
 OpenSearch version, not the repo VERSION).
 
-Not yet wired into the installer. `deploy/scripts/lib/common.sh` still defaults
-`OPENSEARCH_IMAGE_REPOSITORY` / `OPENSEARCH_IMAGE_TAG` to the stock
-`opensearchproject/opensearch:2.19.4`, so a default install does not pull this
-image yet. Flipping those defaults needs a concrete tag, which only exists once
-this lands on main and CI publishes — so it is a follow-up PR that also updates
-the inline fallback in `deploy/scripts/services/opensearch.sh` and the offline
-image list in `deploy/scripts/sync-k8s-images.sh`.
+This image is the installer default. `deploy/scripts/lib/common.sh` pins
+`OPENSEARCH_IMAGE_REPOSITORY=opensearch` and
+`OPENSEARCH_IMAGE_TAG=2.19.4-main.20260818163046.shaaeb5d56`; the offline
+image list in `deploy/scripts/sync-k8s-images.sh` carries the same tag. Publishing
+a rebuild means bumping both, so a cluster always names the exact build it runs.
 
-Until then, opt in per environment:
+Pinning a different image for one environment:
 
 ```bash
 OPENSEARCH_IMAGE_REPOSITORY=opensearch \
-OPENSEARCH_IMAGE_TAG=2.19.4-<branch>.<committime>.sha<short> \
+OPENSEARCH_IMAGE_TAG=<tag> \
   ./deploy.sh opensearch install
 ```
 

--- a/deploy/scripts/lib/common.sh
+++ b/deploy/scripts/lib/common.sh
@@ -1373,8 +1373,12 @@ OPENSEARCH_NODE_GROUP="${OPENSEARCH_NODE_GROUP:-master}"
 OPENSEARCH_CHART_VERSION="${OPENSEARCH_CHART_VERSION:-2.36.0}"
 OPENSEARCH_CHART_TGZ="${OPENSEARCH_CHART_TGZ:-${SCRIPT_DIR}/charts/opensearch-${OPENSEARCH_CHART_VERSION}.tgz}"
 OPENSEARCH_IMAGE="${OPENSEARCH_IMAGE:-}"
-OPENSEARCH_IMAGE_REPOSITORY="${OPENSEARCH_IMAGE_REPOSITORY:-opensearchproject/opensearch}"
-OPENSEARCH_IMAGE_TAG="${OPENSEARCH_IMAGE_TAG:-2.19.4}"
+# Platform rebuild of opensearchproject/opensearch:2.19.4 with the IK Chinese
+# analyzer baked in (see deploy/images/opensearch). Without it OpenSearch ships
+# no Chinese analyzer and vega-backend's capability probe only ever finds
+# `standard`/`english`. Bump repository and tag together.
+OPENSEARCH_IMAGE_REPOSITORY="${OPENSEARCH_IMAGE_REPOSITORY:-opensearch}"
+OPENSEARCH_IMAGE_TAG="${OPENSEARCH_IMAGE_TAG:-2.19.4-main.20260818163046.shaaeb5d56}"
 # OpenSearch chart uses busybox initContainers (fsgroup-volume/sysctl); use a dedicated SWR mirror by default.
 OPENSEARCH_INIT_IMAGE="${OPENSEARCH_INIT_IMAGE:-}"
 OPENSEARCH_INIT_IMAGE_REPOSITORY="${OPENSEARCH_INIT_IMAGE_REPOSITORY:-busybox}"

--- a/deploy/scripts/services/opensearch.sh
+++ b/deploy/scripts/services/opensearch.sh
@@ -4,7 +4,7 @@ _opensearch_resolve_image_defaults() {
     image_registry="$(resolve_openbkn_image_registry "${OPENSEARCH_IMAGE_REGISTRY:-}")"
     OPENSEARCH_IMAGE_REGISTRY="${image_registry}"
     if [[ -z "${OPENSEARCH_IMAGE}" ]]; then
-        OPENSEARCH_IMAGE="$(compose_image_ref "${image_registry}" "${OPENSEARCH_IMAGE_REPOSITORY:-opensearchproject/opensearch}" "${OPENSEARCH_IMAGE_TAG}")"
+        OPENSEARCH_IMAGE="$(compose_image_ref "${image_registry}" "${OPENSEARCH_IMAGE_REPOSITORY:-opensearch}" "${OPENSEARCH_IMAGE_TAG}")"
     fi
     if [[ -z "${OPENSEARCH_INIT_IMAGE}" ]]; then
         OPENSEARCH_INIT_IMAGE="$(compose_image_ref "${image_registry}" "${OPENSEARCH_INIT_IMAGE_REPOSITORY:-busybox}" "${OPENSEARCH_INIT_IMAGE_TAG}")"

--- a/deploy/scripts/sync-k8s-images.sh
+++ b/deploy/scripts/sync-k8s-images.sh
@@ -87,7 +87,7 @@ KAFKA_IMAGES=(
 
 # Required images for OpenSearch
 OPENSEARCH_IMAGES=(
-    "openbkn-ai/opensearchproject/opensearch:2.19.4"
+    "openbkn-ai/opensearch:2.19.4-main.20260818163046.shaaeb5d56"
     "openbkn-ai/busybox:1.36.1"
 )
 
@@ -404,7 +404,7 @@ log_info "   curl http://${TARGET_REGISTRY}/v2/openbkn-ai/rancher/local-path-pro
 log_info "   curl http://${TARGET_REGISTRY}/v2/openbkn-ai/mariadb/tags/list"
 log_info "   curl http://${TARGET_REGISTRY}/v2/openbkn-ai/redis/tags/list"
 log_info "   curl http://${TARGET_REGISTRY}/v2/openbkn-ai/bitnami/kafka/tags/list"
-log_info "   curl http://${TARGET_REGISTRY}/v2/openbkn-ai/opensearchproject/opensearch/tags/list"
+log_info "   curl http://${TARGET_REGISTRY}/v2/openbkn-ai/opensearch/tags/list"
 log_info ""
 log_info "2. Deploy Kubernetes in offline mode:"
 log_info "   sudo bash ./deploy.sh --offline k8s install"


### PR DESCRIPTION
Follow-up to #1007 / #1006. That PR built the image; this one makes a default install actually use it.

## What changed

| File | Change |
|---|---|
| `deploy/scripts/lib/common.sh` | `OPENSEARCH_IMAGE_REPOSITORY` → `opensearch`, `OPENSEARCH_IMAGE_TAG` → `2.19.4-main.20260818163046.shaaeb5d56` |
| `deploy/scripts/services/opensearch.sh` | inline fallback in `_opensearch_resolve_image_defaults` kept in sync |
| `deploy/scripts/sync-k8s-images.sh` | offline image list and its verification hint |
| `deploy/images/opensearch/README.md` | says the image is the default now, instead of "not yet wired" |

## Why this tag

`main` published it from `aeb5d563` (run 32116763628), to both registries:

```
ghcr.io/openbkn-ai/opensearch:2.19.4-main.20260818163046.shaaeb5d56
swr.cn-east-3.myhuaweicloud.com/openbkn-ai/opensearch:2.19.4-main.20260818163046.shaaeb5d56
```

The repository default is the bare name `opensearch`, matching how the redis rebuild is pinned — `resolve_openbkn_image_registry` supplies the `openbkn-ai` prefix, so one default resolves correctly for ghcr, swr and offline:

| Install path | Resolved reference |
|---|---|
| online, default (ghcr) | `ghcr.io/openbkn-ai/opensearch:<tag>` |
| online, `CORE_IMAGE_REGISTRY=swr` | `swr.cn-east-3.myhuaweicloud.com/openbkn-ai/opensearch:<tag>` |
| offline | `${OFFLINE_REGISTRY}/openbkn-ai/opensearch:<tag>` |

The alternative — republishing the IK build over the mirrored `openbkn-ai/opensearchproject/opensearch:2.19.4` — was rejected: it makes a mirrored tag differ from its upstream (exactly the trap `automation-mirror-swr-to-ghcr.yml` documents), it is unrollbackable, and the chart's default `IfNotPresent` policy means nodes that already cached `2.19.4` would never pull the new digest.

## Scope

Existing installs are untouched. `install_opensearch` returns early when the Helm release already exists, so only fresh installs pick this up. Upgrading an existing cluster is the manual path documented in the image README: roll the StatefulSet, then restart vega-backend — its analyzer capability table is probed once and cached with `sync.Once`, so without a restart the API keeps reporting `ik_max_word` as unavailable.

## Verification

- `bash -n` clean on all three scripts.
- Reference resolution traced through `resolve_openbkn_image_registry` + `compose_image_ref` for all three install paths above.
- Not yet run against a live cluster — a fresh install on the test server is the acceptance step.

## Note for the merger

The GHCR package `openbkn-ai/opensearch` is new and defaults to private. It has to be made public before the default (ghcr) install path can pull it; there is no CI step for that.

Related: #1012 tracks the separate analyzer-whitelist contract gap this uncovered.