### PR TITLE
refactor(execution-factory): drop the legacy kweaver catalog/dataset adoption

### DIFF
--- a/adp/execution-factory/operator-integration/server/drivenadapters/vega_backend_test.go
+++ b/adp/execution-factory/operator-integration/server/drivenadapters/vega_backend_test.go
@@ -51,14 +51,14 @@ func TestVegaBackendClient(t *testing.T) {
 		})
 
 		Convey("gets catalog from entries response", func() {
-			httpClient.EXPECT().GetNoUnmarshal(gomock.Any(), "http://vega-backend:9898/api/vega-backend/v1/catalogs/kweaver_execution_factory_catalog", gomock.Nil(), headers).
-				Return(http.StatusOK, []byte(`{"entries":[{"id":"kweaver_execution_factory_catalog","name":"kweaver_execution_factory_catalog","enabled":false}]}`), nil)
+			httpClient.EXPECT().GetNoUnmarshal(gomock.Any(), "http://vega-backend:9898/api/vega-backend/v1/catalogs/bkn_execution_factory_catalog", gomock.Nil(), headers).
+				Return(http.StatusOK, []byte(`{"entries":[{"id":"bkn_execution_factory_catalog","name":"bkn_execution_factory_catalog","enabled":false}]}`), nil)
 
-			resp, err := client.GetCatalogByID(ctx, "kweaver_execution_factory_catalog")
+			resp, err := client.GetCatalogByID(ctx, "bkn_execution_factory_catalog")
 			So(err, ShouldBeNil)
 			So(resp, ShouldNotBeNil)
-			So(resp.ID, ShouldEqual, "kweaver_execution_factory_catalog")
-			So(resp.Name, ShouldEqual, "kweaver_execution_factory_catalog")
+			So(resp.ID, ShouldEqual, "bkn_execution_factory_catalog")
+			So(resp.Name, ShouldEqual, "bkn_execution_factory_catalog")
 			So(resp.Enabled, ShouldBeFalse)
 		})
 
@@ -80,25 +80,25 @@ func TestVegaBackendClient(t *testing.T) {
 			So(resp, ShouldBeNil)
 		})
 
-		Convey("renames catalog in place via PUT", func() {
+		Convey("updates catalog in place via PUT", func() {
 			req := &interfaces.VegaCatalogRequest{
-				ID:       "kweaver_execution_factory_catalog",
+				ID:       "bkn_execution_factory_catalog",
 				Name:     "bkn_execution_factory_catalog",
 				Tags:     []string{"execution-factory", "索引"},
 				Internal: true,
 				Enabled:  true,
 			}
-			httpClient.EXPECT().PutNoUnmarshal(gomock.Any(), "http://vega-backend:9898/api/vega-backend/v1/catalogs/kweaver_execution_factory_catalog", headers, req).
+			httpClient.EXPECT().PutNoUnmarshal(gomock.Any(), "http://vega-backend:9898/api/vega-backend/v1/catalogs/bkn_execution_factory_catalog", headers, req).
 				Return(http.StatusNoContent, []byte{}, nil)
 
 			So(client.UpdateCatalog(ctx, req), ShouldBeNil)
 		})
 
 		Convey("enables catalog", func() {
-			httpClient.EXPECT().PostNoUnmarshal(gomock.Any(), "http://vega-backend:9898/api/vega-backend/v1/catalogs/kweaver_execution_factory_catalog/enable", headers, nil).
+			httpClient.EXPECT().PostNoUnmarshal(gomock.Any(), "http://vega-backend:9898/api/vega-backend/v1/catalogs/bkn_execution_factory_catalog/enable", headers, nil).
 				Return(http.StatusNoContent, []byte{}, nil)
 
-			So(client.EnableCatalog(ctx, "kweaver_execution_factory_catalog"), ShouldBeNil)
+			So(client.EnableCatalog(ctx, "bkn_execution_factory_catalog"), ShouldBeNil)
 		})
 
 		Convey("gets resource from entries response", func() {

--- a/adp/execution-factory/operator-integration/server/logics/skill/index_sync.go
+++ b/adp/execution-factory/operator-integration/server/logics/skill/index_sync.go
@@ -20,11 +20,6 @@ const (
 	executionFactorySkillDataset  = "bkn_execution_factory_skill_dataset"
 	executionFactoryDatasetDesc   = "执行工厂的Skill索引数据集"
 	executionFactoryDatasetStatus = "active"
-	// legacy* 是 kweaver 品牌期建的内置目录/数据集 ID(issue #372)。
-	// 存量环境沿用旧 ID：ID 是索引数据的落点，换 ID 等于重建索引，
-	// 因此只把「展示名」迁到新品牌名，ID 保持不动、不产生两套目录。
-	legacyExecutionFactoryCatalogID    = "kweaver_execution_factory_catalog"
-	legacyExecutionFactorySkillDataset = "kweaver_execution_factory_skill_dataset"
 	// internalCatalogTag 让内置目录自带「内置」语义标签。Studio 目前不读后端的
 	// internal 字段，靠 metadata/tag/名称前缀启发式判定内置目录，该 tag 命中它的
 	// 内置标签集合 —— 前端零改就能正确显示「内置」并收起管理操作。
@@ -48,8 +43,7 @@ type skillIndexSync struct {
 	logger       interfaces.Logger
 	mu           sync.RWMutex
 	initialized  bool
-	// datasetID 为本进程实际使用的数据集 ID：新装是 bkn_*，存量环境解析到
-	// legacy 的 kweaver_*；空值表示尚未解析，取新装默认值。
+	// datasetID 为本进程实际使用的数据集 ID；空值表示尚未解析，取默认值。
 	datasetID string
 	// embeddingModelName 该系统 skill dataset 建时锁定的 embedding 模型名(系统默认快照)，
 	// 受 mu 保护；upsert 读回它生成向量，而非每次重取当前默认。
@@ -165,10 +159,6 @@ func (s *skillIndexSync) Init(ctx context.Context) (err error) {
 }
 
 // ensureCatalog 解析并保证内置目录存在，返回本进程实际使用的目录 ID。
-//
-// 新装取 bkn_execution_factory_catalog；存量环境(kweaver 品牌期建的目录)沿用旧
-// ID，只把展示名迁到新品牌名 —— 换 ID 会新建一套目录并让已建索引失联，
-// 见 issue #372。
 func (s *skillIndexSync) ensureCatalog(ctx context.Context) (string, error) {
 	catalog, err := s.vegaClient.GetCatalogByID(ctx, executionFactoryCatalogID)
 	if err != nil {
@@ -176,18 +166,6 @@ func (s *skillIndexSync) ensureCatalog(ctx context.Context) (string, error) {
 		return "", err
 	}
 	if catalog == nil {
-		legacy, err := s.vegaClient.GetCatalogByID(ctx, legacyExecutionFactoryCatalogID)
-		if err != nil {
-			s.logger.WithContext(ctx).Errorf("get legacy catalog failed, catalog_id=%s, err=%v", legacyExecutionFactoryCatalogID, err)
-			return "", err
-		}
-		if legacy != nil {
-			s.logger.WithContext(ctx).Infof("adopting legacy catalog, catalog_id=%s", legacy.ID)
-			if err := s.reconcileCatalog(ctx, legacy); err != nil {
-				return "", err
-			}
-			return legacy.ID, nil
-		}
 		s.logger.WithContext(ctx).Infof("catalog not found, creating catalog, catalog_id=%s", executionFactoryCatalogID)
 		_, err = s.vegaClient.CreateCatalog(ctx, &interfaces.VegaCatalogRequest{
 			ID:          executionFactoryCatalogID,
@@ -289,8 +267,8 @@ func appendInternalTag(tags []string) []string {
 	return append(append([]string{}, tags...), internalCatalogTag)
 }
 
-// resolveDataset 解析本进程使用的 skill dataset：新装取 bkn_*，存量环境沿用
-// kweaver_* 旧 ID(只迁展示名)。返回的 resource 为 nil 表示两者都不存在，需新建。
+// resolveDataset 解析本进程使用的 skill dataset。返回的 resource 为 nil 表示
+// 它还不存在，需新建。
 func (s *skillIndexSync) resolveDataset(ctx context.Context) (string, *interfaces.VegaResource, error) {
 	resource, err := s.vegaClient.GetResourceByID(ctx, executionFactorySkillDataset)
 	if err != nil {
@@ -299,19 +277,6 @@ func (s *skillIndexSync) resolveDataset(ctx context.Context) (string, *interface
 	}
 	if resource != nil {
 		return resource.ID, resource, nil
-	}
-	legacy, err := s.vegaClient.GetResourceByID(ctx, legacyExecutionFactorySkillDataset)
-	if err != nil {
-		s.logger.WithContext(ctx).Errorf("get legacy resource failed, resource_id=%s, err=%v", legacyExecutionFactorySkillDataset, err)
-		return "", nil, err
-	}
-	if legacy != nil {
-		// 只收养、不改名：vega 的 Update 无条件对「已存的」schema 跑模型校验，而所有
-		// 存量 dataset 的 _vector 都没有 embedding_model(快照机制之前建的)，vega 回退
-		// 到常量 "embedding" 并因该模型未注册而 400 —— 改名请求对这批 dataset 必然
-		// 失败(VM 实测)。dataset 藏在内置目录下、仅超管可见，旧显示名无碍。
-		s.logger.WithContext(ctx).Infof("adopting legacy skill dataset, resource_id=%s", legacy.ID)
-		return legacy.ID, legacy, nil
 	}
 	return executionFactorySkillDataset, nil, nil
 }

--- a/adp/execution-factory/operator-integration/server/logics/skill/index_sync_test.go
+++ b/adp/execution-factory/operator-integration/server/logics/skill/index_sync_test.go
@@ -31,13 +31,11 @@ func TestSkillIndexSync(t *testing.T) {
 				logger:       logger.DefaultLogger(),
 			}
 			mockVegaClient.EXPECT().GetCatalogByID(gomock.Any(), executionFactoryCatalogID).Return(nil, nil)
-			mockVegaClient.EXPECT().GetCatalogByID(gomock.Any(), legacyExecutionFactoryCatalogID).Return(nil, nil)
 			mockVegaClient.EXPECT().CreateCatalog(gomock.Any(), gomock.Any()).DoAndReturn(func(ctx context.Context, req *interfaces.VegaCatalogRequest) (*interfaces.VegaCatalog, error) {
 				createdCatalog = req
 				return &interfaces.VegaCatalog{ID: req.ID}, nil
 			})
 			mockVegaClient.EXPECT().GetResourceByID(gomock.Any(), executionFactorySkillDataset).Return(nil, nil)
-			mockVegaClient.EXPECT().GetResourceByID(gomock.Any(), legacyExecutionFactorySkillDataset).Return(nil, nil)
 			// 系统默认未配置 -> 回退按名 "embedding"
 			mockModelManager.EXPECT().GetDefaultEmbeddingModel(gomock.Any(), interfaces.SmallModelTypeEmbedding).
 				Return(nil, nil)
@@ -128,76 +126,6 @@ func TestSkillIndexSync(t *testing.T) {
 			So(syncer.getDatasetID(), ShouldEqual, executionFactorySkillDataset)
 		})
 
-		Convey("Init adopts the legacy kweaver catalog/dataset, renaming the catalog in place", func() {
-			var renamedCatalog *interfaces.VegaCatalogRequest
-			mockVegaClient := mocks.NewMockVegaBackendClient(ctrl)
-			syncer := &skillIndexSync{
-				vegaClient: mockVegaClient,
-				logger:     logger.DefaultLogger(),
-			}
-			legacyCatalog := &interfaces.VegaCatalog{
-				ID:      legacyExecutionFactoryCatalogID,
-				Name:    legacyExecutionFactoryCatalogID,
-				Tags:    []string{"execution-factory", "索引"},
-				Enabled: false,
-			}
-			legacyResource := &interfaces.VegaResource{
-				ID:        legacyExecutionFactorySkillDataset,
-				Name:      legacyExecutionFactorySkillDataset,
-				CatalogID: legacyExecutionFactoryCatalogID,
-				// 老 dataset 的模型快照在 tag 里，读路径仍要兜住
-				Tags: []string{embeddingModelTagPrefix + "text-embedding-v4"},
-			}
-			mockVegaClient.EXPECT().GetCatalogByID(gomock.Any(), executionFactoryCatalogID).Return(nil, nil)
-			mockVegaClient.EXPECT().GetCatalogByID(gomock.Any(), legacyExecutionFactoryCatalogID).Return(legacyCatalog, nil)
-			mockVegaClient.EXPECT().UpdateCatalog(gomock.Any(), gomock.Any()).DoAndReturn(func(ctx context.Context, req *interfaces.VegaCatalogRequest) error {
-				renamedCatalog = req
-				return nil
-			})
-			mockVegaClient.EXPECT().EnableCatalog(gomock.Any(), legacyExecutionFactoryCatalogID).Return(nil)
-			mockVegaClient.EXPECT().GetResourceByID(gomock.Any(), executionFactorySkillDataset).Return(nil, nil)
-			mockVegaClient.EXPECT().GetResourceByID(gomock.Any(), legacyExecutionFactorySkillDataset).Return(legacyResource, nil)
-
-			err := syncer.Init(context.Background())
-			So(err, ShouldBeNil)
-			So(syncer.isInitialized(), ShouldBeTrue)
-			// 只改展示名，ID 保持旧值：索引数据不搬家，也不会多出一套目录
-			So(renamedCatalog, ShouldNotBeNil)
-			So(renamedCatalog.ID, ShouldEqual, legacyExecutionFactoryCatalogID)
-			So(renamedCatalog.Name, ShouldEqual, executionFactoryCatalogID)
-			// 存量目录补 internal 标签，原有标签保留
-			So(renamedCatalog.Tags, ShouldContain, internalCatalogTag)
-			So(renamedCatalog.Tags, ShouldContain, "execution-factory")
-			// dataset 只收养不改名：vega 会对存量 schema 跑模型校验，改名请求必然 400
-			So(syncer.getDatasetID(), ShouldEqual, legacyExecutionFactorySkillDataset)
-			So(syncer.getDatasetID(), ShouldEqual, legacyExecutionFactorySkillDataset)
-			// 建时锁定的 embedding 模型从旧 dataset 的 tag 读回
-			So(syncer.getEmbeddingModelName(), ShouldEqual, "text-embedding-v4")
-		})
-
-		Convey("Init keeps an already-renamed legacy catalog untouched", func() {
-			mockVegaClient := mocks.NewMockVegaBackendClient(ctrl)
-			syncer := &skillIndexSync{
-				vegaClient: mockVegaClient,
-				logger:     logger.DefaultLogger(),
-			}
-			mockVegaClient.EXPECT().GetCatalogByID(gomock.Any(), executionFactoryCatalogID).Return(nil, nil)
-			mockVegaClient.EXPECT().GetCatalogByID(gomock.Any(), legacyExecutionFactoryCatalogID).
-				Return(&interfaces.VegaCatalog{
-					ID:      legacyExecutionFactoryCatalogID,
-					Name:    executionFactoryCatalogID,
-					Tags:    []string{"execution-factory", internalCatalogTag},
-					Enabled: true,
-				}, nil)
-			mockVegaClient.EXPECT().GetResourceByID(gomock.Any(), executionFactorySkillDataset).Return(nil, nil)
-			mockVegaClient.EXPECT().GetResourceByID(gomock.Any(), legacyExecutionFactorySkillDataset).
-				Return(&interfaces.VegaResource{ID: legacyExecutionFactorySkillDataset, Name: executionFactorySkillDataset}, nil)
-
-			err := syncer.Init(context.Background())
-			So(err, ShouldBeNil)
-			So(syncer.getDatasetID(), ShouldEqual, legacyExecutionFactorySkillDataset)
-		})
-
 		Convey("Init reads the model snapshot from index_config first, then schema, then tag", func() {
 			mockVegaClient := mocks.NewMockVegaBackendClient(ctrl)
 			syncer := &skillIndexSync{vegaClient: mockVegaClient, logger: logger.DefaultLogger()}
@@ -229,32 +157,6 @@ func TestSkillIndexSync(t *testing.T) {
 			So(syncer.getEmbeddingModelName(), ShouldEqual, "text-embedding-v4")
 		})
 
-		Convey("Init pairs the new catalog with a legacy dataset when only the dataset is legacy", func() {
-			mockVegaClient := mocks.NewMockVegaBackendClient(ctrl)
-			syncer := &skillIndexSync{vegaClient: mockVegaClient, logger: logger.DefaultLogger()}
-			mockVegaClient.EXPECT().GetCatalogByID(gomock.Any(), executionFactoryCatalogID).
-				Return(&interfaces.VegaCatalog{
-					ID:      executionFactoryCatalogID,
-					Name:    executionFactoryCatalogID,
-					Tags:    []string{internalCatalogTag},
-					Enabled: true,
-				}, nil)
-			mockVegaClient.EXPECT().GetResourceByID(gomock.Any(), executionFactorySkillDataset).Return(nil, nil)
-			mockVegaClient.EXPECT().GetResourceByID(gomock.Any(), legacyExecutionFactorySkillDataset).
-				Return(&interfaces.VegaResource{
-					ID:        legacyExecutionFactorySkillDataset,
-					Name:      legacyExecutionFactorySkillDataset,
-					CatalogID: legacyExecutionFactoryCatalogID,
-				}, nil)
-			// dataset 挂在旧目录下：写入受它自己的父目录管辖，disabled 就得启用
-			mockVegaClient.EXPECT().GetCatalogByID(gomock.Any(), legacyExecutionFactoryCatalogID).
-				Return(&interfaces.VegaCatalog{ID: legacyExecutionFactoryCatalogID, Name: executionFactoryCatalogID, Enabled: false}, nil)
-			mockVegaClient.EXPECT().EnableCatalog(gomock.Any(), legacyExecutionFactoryCatalogID).Return(nil)
-
-			So(syncer.Init(context.Background()), ShouldBeNil)
-			So(syncer.getDatasetID(), ShouldEqual, legacyExecutionFactorySkillDataset)
-		})
-
 		Convey("Init fails when the catalog cannot be enabled, so the retry loop takes over", func() {
 			mockVegaClient := mocks.NewMockVegaBackendClient(ctrl)
 			syncer := &skillIndexSync{vegaClient: mockVegaClient, logger: logger.DefaultLogger()}
@@ -272,7 +174,7 @@ func TestSkillIndexSync(t *testing.T) {
 			So(syncer.isInitialized(), ShouldBeFalse)
 		})
 
-		Convey("Init fails when the adopted dataset points to a missing catalog", func() {
+		Convey("Init fails when the dataset points to a missing catalog", func() {
 			mockVegaClient := mocks.NewMockVegaBackendClient(ctrl)
 			syncer := &skillIndexSync{vegaClient: mockVegaClient, logger: logger.DefaultLogger()}
 			mockVegaClient.EXPECT().GetCatalogByID(gomock.Any(), executionFactoryCatalogID).
@@ -282,9 +184,8 @@ func TestSkillIndexSync(t *testing.T) {
 					Tags:    []string{internalCatalogTag},
 					Enabled: true,
 				}, nil)
-			mockVegaClient.EXPECT().GetResourceByID(gomock.Any(), executionFactorySkillDataset).Return(nil, nil)
-			mockVegaClient.EXPECT().GetResourceByID(gomock.Any(), legacyExecutionFactorySkillDataset).
-				Return(&interfaces.VegaResource{ID: legacyExecutionFactorySkillDataset, CatalogID: "ghost_catalog"}, nil)
+			mockVegaClient.EXPECT().GetResourceByID(gomock.Any(), executionFactorySkillDataset).
+				Return(&interfaces.VegaResource{ID: executionFactorySkillDataset, CatalogID: "ghost_catalog"}, nil)
 			mockVegaClient.EXPECT().GetCatalogByID(gomock.Any(), "ghost_catalog").Return(nil, nil)
 
 			err := syncer.Init(context.Background())
@@ -298,11 +199,10 @@ func TestSkillIndexSync(t *testing.T) {
 			mockVegaClient := mocks.NewMockVegaBackendClient(ctrl)
 			syncer := &skillIndexSync{vegaClient: mockVegaClient, logger: logger.DefaultLogger()}
 			fullTags := []string{"a", "b", "c", "d", "e"}
-			mockVegaClient.EXPECT().GetCatalogByID(gomock.Any(), executionFactoryCatalogID).Return(nil, nil)
-			mockVegaClient.EXPECT().GetCatalogByID(gomock.Any(), legacyExecutionFactoryCatalogID).
+			mockVegaClient.EXPECT().GetCatalogByID(gomock.Any(), executionFactoryCatalogID).
 				Return(&interfaces.VegaCatalog{
-					ID:      legacyExecutionFactoryCatalogID,
-					Name:    legacyExecutionFactoryCatalogID,
+					ID:      executionFactoryCatalogID,
+					Name:    "stale_display_name",
 					Tags:    fullTags,
 					Enabled: true,
 				}, nil)
@@ -310,9 +210,8 @@ func TestSkillIndexSync(t *testing.T) {
 				reconciled = req
 				return nil
 			})
-			mockVegaClient.EXPECT().GetResourceByID(gomock.Any(), executionFactorySkillDataset).Return(nil, nil)
-			mockVegaClient.EXPECT().GetResourceByID(gomock.Any(), legacyExecutionFactorySkillDataset).
-				Return(&interfaces.VegaResource{ID: legacyExecutionFactorySkillDataset}, nil)
+			mockVegaClient.EXPECT().GetResourceByID(gomock.Any(), executionFactorySkillDataset).
+				Return(&interfaces.VegaResource{ID: executionFactorySkillDataset}, nil)
 
 			So(syncer.Init(context.Background()), ShouldBeNil)
 			// 标签超限就别塞，改名这个主目标不能被 400 一起带走
@@ -348,24 +247,44 @@ func TestSkillIndexSync(t *testing.T) {
 			So(reconciled.Tags, ShouldResemble, []string{"execution-factory", "索引", internalCatalogTag})
 		})
 
-		Convey("Init survives a failed catalog rename and still serves the legacy dataset", func() {
+		Convey("Init survives a failed catalog rename, which is cosmetic", func() {
 			mockVegaClient := mocks.NewMockVegaBackendClient(ctrl)
 			syncer := &skillIndexSync{
 				vegaClient: mockVegaClient,
 				logger:     logger.DefaultLogger(),
 			}
-			legacyResource := &interfaces.VegaResource{ID: legacyExecutionFactorySkillDataset, Name: legacyExecutionFactorySkillDataset}
-			mockVegaClient.EXPECT().GetCatalogByID(gomock.Any(), executionFactoryCatalogID).Return(nil, nil)
-			mockVegaClient.EXPECT().GetCatalogByID(gomock.Any(), legacyExecutionFactoryCatalogID).
-				Return(&interfaces.VegaCatalog{ID: legacyExecutionFactoryCatalogID, Name: legacyExecutionFactoryCatalogID, Enabled: true}, nil)
+			resource := &interfaces.VegaResource{ID: executionFactorySkillDataset, Name: executionFactorySkillDataset}
+			mockVegaClient.EXPECT().GetCatalogByID(gomock.Any(), executionFactoryCatalogID).
+				Return(&interfaces.VegaCatalog{ID: executionFactoryCatalogID, Name: "stale_display_name", Enabled: true}, nil)
 			mockVegaClient.EXPECT().UpdateCatalog(gomock.Any(), gomock.Any()).Return(errors.New("vega 500"))
-			mockVegaClient.EXPECT().GetResourceByID(gomock.Any(), executionFactorySkillDataset).Return(nil, nil)
-			mockVegaClient.EXPECT().GetResourceByID(gomock.Any(), legacyExecutionFactorySkillDataset).Return(legacyResource, nil)
+			mockVegaClient.EXPECT().GetResourceByID(gomock.Any(), executionFactorySkillDataset).Return(resource, nil)
 
 			err := syncer.Init(context.Background())
 			So(err, ShouldBeNil)
 			So(syncer.isInitialized(), ShouldBeTrue)
-			So(syncer.getDatasetID(), ShouldEqual, legacyExecutionFactorySkillDataset)
+			So(syncer.getDatasetID(), ShouldEqual, executionFactorySkillDataset)
+		})
+
+		// 老 dataset 的模型快照只落在 resource tag 上，读路径仍要兜住。
+		Convey("Init reads the model snapshot from a tag when nothing else carries it", func() {
+			mockVegaClient := mocks.NewMockVegaBackendClient(ctrl)
+			syncer := &skillIndexSync{vegaClient: mockVegaClient, logger: logger.DefaultLogger()}
+			mockVegaClient.EXPECT().GetCatalogByID(gomock.Any(), executionFactoryCatalogID).
+				Return(&interfaces.VegaCatalog{
+					ID:      executionFactoryCatalogID,
+					Name:    executionFactoryCatalogID,
+					Tags:    []string{internalCatalogTag},
+					Enabled: true,
+				}, nil)
+			mockVegaClient.EXPECT().GetResourceByID(gomock.Any(), executionFactorySkillDataset).
+				Return(&interfaces.VegaResource{
+					ID:   executionFactorySkillDataset,
+					Name: executionFactorySkillDataset,
+					Tags: []string{embeddingModelTagPrefix + "text-embedding-v4"},
+				}, nil)
+
+			So(syncer.Init(context.Background()), ShouldBeNil)
+			So(syncer.getEmbeddingModelName(), ShouldEqual, "text-embedding-v4")
 		})
 
 		Convey("UpsertSkill writes complete document with _id and vector", func() {

--- a/adp/execution-factory/operator-integration/server/logics/skill/index_sync_test.go
+++ b/adp/execution-factory/operator-integration/server/logics/skill/index_sync_test.go
@@ -174,6 +174,31 @@ func TestSkillIndexSync(t *testing.T) {
 			So(syncer.isInitialized(), ShouldBeFalse)
 		})
 
+		// 数据集挂在别的目录下时，写入受它自己的父目录管辖，disabled 就得启用。
+		Convey("Init enables the dataset's own catalog when it lives elsewhere", func() {
+			mockVegaClient := mocks.NewMockVegaBackendClient(ctrl)
+			syncer := &skillIndexSync{vegaClient: mockVegaClient, logger: logger.DefaultLogger()}
+			mockVegaClient.EXPECT().GetCatalogByID(gomock.Any(), executionFactoryCatalogID).
+				Return(&interfaces.VegaCatalog{
+					ID:      executionFactoryCatalogID,
+					Name:    executionFactoryCatalogID,
+					Tags:    []string{internalCatalogTag},
+					Enabled: true,
+				}, nil)
+			mockVegaClient.EXPECT().GetResourceByID(gomock.Any(), executionFactorySkillDataset).
+				Return(&interfaces.VegaResource{
+					ID:        executionFactorySkillDataset,
+					Name:      executionFactorySkillDataset,
+					CatalogID: "other_catalog",
+				}, nil)
+			mockVegaClient.EXPECT().GetCatalogByID(gomock.Any(), "other_catalog").
+				Return(&interfaces.VegaCatalog{ID: "other_catalog", Name: "other_catalog", Enabled: false}, nil)
+			mockVegaClient.EXPECT().EnableCatalog(gomock.Any(), "other_catalog").Return(nil)
+
+			So(syncer.Init(context.Background()), ShouldBeNil)
+			So(syncer.getDatasetID(), ShouldEqual, executionFactorySkillDataset)
+		})
+
 		Convey("Init fails when the dataset points to a missing catalog", func() {
 			mockVegaClient := mocks.NewMockVegaBackendClient(ctrl)
 			syncer := &skillIndexSync{vegaClient: mockVegaClient, logger: logger.DefaultLogger()}


### PR DESCRIPTION
## Why

Issue #372 was fixed in #395: new installs create `bkn_execution_factory_catalog` / `bkn_execution_factory_skill_dataset`. The `kweaver_*` ids stayed behind as an adoption path for environments built before that fix, and ran on every `Init`. That path is no longer wanted.

## What changed

- `ensureCatalog` / `resolveDataset` resolve only the `bkn_*` ids. The second lookup and the adopt-in-place branch are gone, along with the two `legacy*` constants.
- `reconcileCatalog` is untouched and still runs on the resolved catalog: it backfills the `internal` tag, reconciles the display name, and enables the catalog.

## Tests

Four cases existed only to cover adoption and are removed. Three used the legacy ids as fixtures and are re-pointed at the current ones with their assertions intact:

| Case | Note |
|---|---|
| dataset whose parent catalog is missing | unchanged behaviour, single dataset id |
| tag-limit skip | now driven by a stale display name — with the tag budget full, that is what still makes reconcile issue a PUT |
| failed rename stays cosmetic | retitled; no longer about a legacy dataset |

Two branches lost their only coverage when the adoption cases went, so each gets its own case: the tag-carried embedding snapshot (`embeddingModelTagPrefix`, a read path independent of the catalog ids, which stays), and `ensureDatasetCatalogEnabled` enabling a dataset's own catalog when the dataset lives outside the resolved one.

`vega_backend_test.go` used the retired ids as plain fixture strings — the adapter is id-agnostic — so they are renamed, and the PUT case is retitled since it no longer models a brand migration.

## Precondition: no environment may still hold the retired ids

This is a hard cut, not a graceful one. On an environment that already ran the adoption, the catalog id is still `kweaver_execution_factory_catalog` while `reconcileCatalog` has renamed its **display name** to `bkn_execution_factory_catalog`. After this change:

1. `GetCatalogByID("bkn_execution_factory_catalog")` matches on id and returns nil.
2. `ensureCatalog` falls through to `CreateCatalog(ID=bkn_…, Name=bkn_…)`.
3. `catalog_handler.go:230-242` checks the name before the id, and the name is taken → `409 VegaBackend.Catalog.NameExists`.
4. `vega_backend.go:108-110` turns any non-2xx into an error → `Init` fails and the retry loop never converges.

The effect is not an orphaned index that can be rebuilt: skill index sync stops entirely, so no skill create/update/delete reaches the index.

This is accepted deliberately. Deployments are fresh installs, which create the `bkn_*` pair directly and never enter the branch above. If an environment ever does need checking:

```
GET /api/vega-backend/v1/catalogs/kweaver_execution_factory_catalog
```

A 200 means that environment predates #395 and must not take this change without first retiring the old catalog.

## Verification

`go build ./...`, `go vet`, and the `server/logics/skill` + `server/drivenadapters` suites pass. `server/tests/local` fails identically on `main` (OpenAPI fixture panic), unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
