### PR TITLE
docs: name the modules that replaced kweaver-go-lib

### DIFF
--- a/bkn-safe/contract/go.mod
+++ b/bkn-safe/contract/go.mod
@@ -1,12 +1,10 @@
 // Contract tests for bkn-safe (code: safe) — the ISF replacement auth service.
 //
 // These tests pin the hardest external contract: the token-introspect response
-// must parse through the real kweaver-go-lib hydra client without panicking.
+// must parse through the real bkn-comm-go hydra client without panicking.
 //
-// Pinned to v1.0.5 — the exact kweaver-go-lib that adp services run — built
-// on the gvm go1.25.6 toolchain (v1.0.5 requires go >= 1.25). The DA client
-// (rest.Hydra @v1.0.2) shares the same introspect parse logic, so this one
-// golden set proves all three.
+// Pinned to github.com/openbkn-ai/bkn-comm-go v0.0.4, the module the
+// introspect parser lives in, and built on the gvm go1.25.6 toolchain.
 module bkn-safe/contract
 
 go 1.25.0

--- a/bkn-safe/contract/introspect_contract_test.go
+++ b/bkn-safe/contract/introspect_contract_test.go
@@ -5,7 +5,7 @@
 // Package contract holds executable freeze tests for the ISF replacement.
 //
 // introspect_contract_test.go proves that the frozen hydra introspect golden
-// responses (testdata/introspect/*.json) parse through the REAL kweaver-go-lib
+// responses (testdata/introspect/*.json) parse through the REAL bkn-comm-go
 // hydra client into the expected TokenIntrospectInfo.
 //
 // Why this matters: the lib's Introspect() parses with unchecked type

--- a/bkn-safe/contract/testdata/README.md
+++ b/bkn-safe/contract/testdata/README.md
@@ -1,7 +1,7 @@
 # contract test 冻结夹具
 
 `introspect/*.json` 是 hydra `/admin/oauth2/introspect` 响应的冻结 golden，由
-`introspect_contract_test.go` 在运行时读取，喂给真实的 `kweaver-go-lib/hydra`
+`introspect_contract_test.go` 在运行时读取，喂给真实的 `bkn-comm-go/hydra`
 客户端，断言其解析不 panic（lib 用无 nil 检查的类型断言，缺字段会 panic）。
 
 | fixture | 主体 | 关键约束 |

--- a/bkn-safe/server/go.mod
+++ b/bkn-safe/server/go.mod
@@ -2,7 +2,8 @@
 // Three responsibilities: authentication (hydra login/consent/device provider),
 // authorization (Casbin), user management (directory + LDAP). hydra issues the
 // tokens; bkn-safe is NOT a token engine. DB via openbkn-rds driver (xinchuang
-// transparent at the database/sql level) + GORM. Zero kweaver-go-lib.
+// transparent at the database/sql level) + GORM. That driver registration
+// is the only thing bkn-safe pulls from bkn-comm-go.
 module github.com/openbkn-ai/bkn-foundry/bkn-safe/server
 
 go 1.25.0

--- a/bkn-safe/server/internal/auth/provider.go
+++ b/bkn-safe/server/internal/auth/provider.go
@@ -25,7 +25,7 @@ const (
 
 // ExtClaims builds the introspect `ext` object hydra surfaces from
 // session.access_token. For a human (user) login all five fields must be
-// present or the kweaver-go-lib introspect parser panics (unchecked type
+// present or the bkn-comm-go introspect parser panics (unchecked type
 // assertions) — see the contract freeze §1.
 func ExtClaims(u *model.User, loginIP, clientType string) map[string]any {
 	if clientType == "" {

--- a/docs/api/_shared/errors.yaml
+++ b/docs/api/_shared/errors.yaml
@@ -1,12 +1,13 @@
 # 共享错误响应体 —— 单一来源
 #
-# `Error` 由 kweaver-go-lib/rest.BaseError JSON 序列化得到，vega / bkn / dataflow /
+# `Error` 由 comm-go/rest.BaseError JSON 序列化得到，vega / bkn / dataflow /
 # execution-factory / bkn-safe 走这套信封。各模块 YAML 用
 #   $ref: '../_shared/errors.yaml#/components/schemas/Error'
 # 引用，不再各自内嵌。
 #
 # 注意：adp 下的 context-loader（agent-retrieval）与 execution-factory
-#       （agent-operator-integration）没有用 kweaver-go-lib，各自带了一份同源的
+#       （agent-operator-integration）不用 comm-go/rest.BaseError 这套信封（两者
+#       仍从 comm-go/rest 取本地化辅助），各自带了一份同源的
 #       infra/errors.HTTPError，字段名与 rest.BaseError 不同（code/description/
 #       solution/link/details），见下方 ErrorCompact——不改成 BaseError 是因为其
 #       调用方（MCP 客户端、Studio）已按现字段名解析。
@@ -19,7 +20,7 @@ components:
   schemas:
     Error:
       description: |
-        统一错误响应体。由 `kweaver-go-lib/rest.BaseError` JSON 序列化得到。
+        统一错误响应体。由 `comm-go/rest.BaseError` JSON 序列化得到。
       type: object
       required:
         - error_code

--- a/docs/api/context-loader/README.md
+++ b/docs/api/context-loader/README.md
@@ -50,7 +50,7 @@ Skill 面另有一条不依赖知识网络的入口：`list_skills` 直接翻已
 - **认证**：`Authorization: Bearer <token>`，凭据二选一——OAuth access token，或用户自助签发的 AppKey（`bak_` 前缀）。账户身份由服务端从凭据解析，调用方**不需要**传 `x-account-id` / `x-account-type`。
 - **全部是 POST**：包括语义上的「查询」类端点；无请求体的（如 `list_knowledge_networks`）也走 POST。
 - **响应格式**：所有端点支持 `?response_format=toon`，返回 `application/toon`——同构数组压成表格，比 JSON 省 token；默认 `json`。
-- **错误信封**：本服务**不用** `kweaver-go-lib/rest.BaseError`，字段是 `code` / `description` / `solution` / `link` / `details`，引 [`_shared/errors.yaml#/components/schemas/ErrorAgentRetrieval`](../_shared/errors.yaml)。**下游报错时原样透传下游响应体**，此时字段名是下游的（通常 `error_code` / `error_details`）；看 `code` 前缀判断来源，`Public.*` 与 `agentRetrieval.*` 是本服务产生的。
+- **错误信封**：本服务**不用** `comm-go/rest.BaseError`，字段是 `code` / `description` / `solution` / `link` / `details`，引 [`_shared/errors.yaml#/components/schemas/ErrorAgentRetrieval`](../_shared/errors.yaml)。**下游报错时原样透传下游响应体**，此时字段名是下游的（通常 `error_code` / `error_details`）；看 `code` 前缀判断来源，`Public.*` 与 `agentRetrieval.*` 是本服务产生的。
 - **内部接口**：每个端点都有对应的 `/api/agent-retrieval/in/v1/...` 版本，请求 / 响应结构一致，区别只在鉴权（外部走 Token，内部从 `X-Account-ID` / `X-Account-Type` 头取访问者）。内部面另有三个不对外的端点：`POST /kn/full_build_ontology`、`GET /kn/full_ontology_building_status`、`POST /mcp/proxy/{mcp_id}/tools/{tool_name}/call`。**本文档仅描述外部接口**，内部路由以 `driveradapters/rest_private_handler.go` 实际注册的为准。
 - **实例标识不可自拼**：需要 `_instance_identities` 的接口，取值一律来自 `query_object_instance` 或 `query_instance_subgraph` 结果里的 `_instance_identity`，两条链路同名同义。
 - **算子白名单看对象类**：条件里能用哪些算子以对象类的 `condition_operations` 为准（`get_object_types` 返回）。该声明是建网时客户端写入并原样落库的，未经服务端校验，最终判定在下游 ontology-query。

--- a/docs/api/execution-factory/README.md
+++ b/docs/api/execution-factory/README.md
@@ -102,7 +102,7 @@ curl -s -X POST -H "Authorization: Bearer $TOKEN" -H "Content-Type: application/
 - **OpenAPI 版本**：3.0.3。
 - **认证**：`Authorization: Bearer <token>`，OAuth access token 或用户自助签发的 AppKey（`bak_` 前缀）。
 - **权限**：函数执行要求算子的 `execute` 权限，AI 生成要求 `create` 权限，返回 403 时先查角色授权。
-- **错误信封**：本服务**不用** `kweaver-go-lib/rest.BaseError`，字段是 `code` / `description` / `solution` / `link` / `details`，引 [`_shared/errors.yaml#/components/schemas/ErrorCompact`](../_shared/errors.yaml)（与 context-loader 同源同形）。
+- **错误信封**：本服务**不用** `comm-go/rest.BaseError`，字段是 `code` / `description` / `solution` / `link` / `details`，引 [`_shared/errors.yaml#/components/schemas/ErrorCompact`](../_shared/errors.yaml)（与 context-loader 同源同形）。
 - **内部接口**：`/api/agent-operator-integration/internal-v1` 是内部面，另有 `POST /function/exec/{version}`（按已注册的函数版本执行，`timeout` 单位毫秒）等端点，**本文档不收录**。
 - **能力面**：`/api/capabilities-lab/v1` 是合并进本服务的另一套路由（原 capabilities-lab 独立服务），也挂在 Ingress 上，路径与语义都与 `v1` 不同，**本文档暂不收录**。
 - **`*_time` 一律是纳秒**：算子 / MCP / 工具箱 / Skill 的 `*_time` 字段都由 `time.Now().UnixNano()` 生成，形如 `1784880971306127803`；按毫秒解析会得到 1970 年附近的日期。例外是沙箱观测面，它的 `created_at` / `last_used_at` / `checked_at` 是 RFC3339 字符串——两种记法看字段后缀区分（`*_time` 是纳秒整数，`*_at` 是字符串）。

--- a/docs/api/vega/README.md
+++ b/docs/api/vega/README.md
@@ -20,7 +20,7 @@
 ## 约定
 
 - **OpenAPI 版本**：3.1.1。
-- **错误响应**：所有非 2xx 响应统一返回 `Error` schema（对应 `kweaver-go-lib/rest.BaseError`），各文件自含一份定义。
+- **错误响应**：所有非 2xx 响应统一返回 `Error` schema（对应 `comm-go/rest.BaseError`），各文件自含一份定义。
 - **内部接口**：多数业务端点同时提供 `/api/vega-backend/in/v1/...`，与对应外部端点的请求 / 响应结构一致；区别仅在鉴权方式（外部 OAuth Token，内部 Header `X-Account-ID` / `X-Account-Type`）。本文档仅描述外部接口；请以 `driveradapters/router.go` 中实际注册的内部路由为准。
 - **跨资源动作端点**：`POST /catalogs/{id}/discover` 创建 DiscoverTask 实例，定义在 `discover-task.yaml`。
 - **Catalog / Resource `extensions`（Issue #382，方案 B）**：OpenAPI 定义在 [catalog.yaml](catalog.yaml)、[resource.yaml](resource.yaml)。请求/响应与列表投影仅 **`extensions`**；列表筛选 query 为 **`extension_key` / `extension_value`**；`include_extensions`、`include_extension_keys` 见两文件。持久化表 **`t_entity_extension`** 及约定见 `info.description` 与设计稿


### PR DESCRIPTION
No module named `kweaver-go-lib` is required anywhere in this repository. Two modules took over:

- **`github.com/openbkn-ai/bkn-comm-go`** — the hydra introspect client the bkn-safe contract test pins (`bkn-comm-go/hydra`), and the `openbkn-rds` `database/sql` driver.
- **`github.com/openbkn-ai/bkn-foundry/comm-go`** — the in-repo module where `rest.BaseError` is defined (`comm-go/rest/errors.go:18`).

## Three of these were wrong facts, not just stale names

| Where | Claimed | Actual |
|---|---|---|
| `bkn-safe/contract/go.mod` | pinned to v1.0.5, "the exact kweaver-go-lib that adp services run" | the require is `bkn-comm-go v0.0.4`, and adp services depend on `bkn-foundry/comm-go`, not `bkn-comm-go` |
| `bkn-safe/server/go.mod` | "Zero kweaver-go-lib" | requires both modules; `internal/database/database.go:16` is its single `bkn-comm-go` import, for the driver registration |
| `docs/api/_shared/errors.yaml` | context-loader and execution-factory "没有用" the library | both import `comm-go/rest` for the localization helpers; what still holds is that they do not use its `BaseError` envelope |

The contract `go.mod` comment also referenced a Decision Agent client at another version of the retired module. Those version claims are not verifiable against anything in the tree today, so they go with the rename rather than being carried forward in a new name.

**Worth a second opinion:** `bkn-safe/server/go.mod` — I rewrote "Zero kweaver-go-lib" into a statement of what the `bkn-comm-go` dependency is actually for, since the original is false under any rename. If the intent was narrower (say, "the DB path uses no shared helper layer"), say so and I will match it.

## Verification

`bkn-safe/server` builds, `bkn-safe/contract` vets clean, `docs/api/_shared/errors.yaml` parses. Comments and docs only — no code paths touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)