### PR TITLE
test(bkn-agent): cover the locale claims that were only reasoned about

### DIFF
--- a/infra/bkn-agent/app/test/test_i18n.py
+++ b/infra/bkn-agent/app/test/test_i18n.py
@@ -257,3 +257,132 @@ def test_downstream_headers_carry_the_frozen_locale():
     for module in (skills, toolbox):
         source = open(module.__file__, encoding="utf-8").read()
         assert "locale.internal_request_headers(" in source, module.__name__
+
+
+# --- Claims that were reasoned about but never exercised --------------------
+
+
+def _probe_app():
+    """Mount the real middleware on a throwaway app.
+
+    The routes cannot be added to the shipped app: test_contract.py compares the
+    exported OpenAPI against it, so an extra path would fail the frozen spec.
+    Registering the same middleware function keeps the code path real.
+    """
+    from fastapi import FastAPI
+
+    from app import main
+
+    probe = FastAPI()
+    probe.middleware("http")(main.bkn_trace_context_middleware)
+    return probe
+
+
+def test_sse_generator_still_sees_the_frozen_locale():
+    """The SSE body is consumed after the middleware's finally has reset the
+    ContextVar, so the stream would silently fall back to the default if the
+    value did not travel into the generator's context."""
+    from fastapi.responses import StreamingResponse
+
+    from app.core.graph import _stream_error
+
+    probe = _probe_app()
+
+    @probe.get("/api/bkn-agent/v1/probe/stream")
+    async def _stream():
+        async def events():
+            yield f"locale={locale.get_effective_locale()}\n"
+            yield f"detail={_stream_error('BknAgent.Chat.Timeout', timeout=30)['detail']}\n"
+
+        return StreamingResponse(events(), media_type="text/event-stream")
+
+    streaming = TestClient(probe)
+    english = streaming.get(
+        "/api/bkn-agent/v1/probe/stream", headers={"Accept-Language": "en-US"}
+    )
+    chinese = streaming.get(
+        "/api/bkn-agent/v1/probe/stream", headers={"Accept-Language": "zh-CN"}
+    )
+
+    assert "locale=en-US" in english.text
+    assert "detail=Exceeded 30s." in english.text
+    assert "locale=zh-CN" in chinese.text
+    assert CHINESE.search(chinese.text)
+    # A stream may carry a localized error event, so it declares its language.
+    assert english.headers["Content-Language"] == "en-US"
+
+
+def test_success_response_is_not_labelled_with_a_language():
+    probe = _probe_app()
+
+    @probe.get("/api/bkn-agent/v1/probe/ok")
+    async def _ok():
+        return {"status": "ok"}
+
+    response = TestClient(probe).get(
+        "/api/bkn-agent/v1/probe/ok", headers={"Accept-Language": "en-US"}
+    )
+    assert response.status_code == 200
+    assert "Content-Language" not in response.headers
+    assert "private" in response.headers["Cache-Control"]
+
+
+def test_non_business_path_gets_neither_header():
+    probe = _probe_app()
+
+    @probe.get("/other/path")
+    async def _other():
+        return {"status": "ok"}
+
+    response = TestClient(probe).get("/other/path", headers={"Accept-Language": "en-US"})
+    assert "Content-Language" not in response.headers
+    assert "Cache-Control" not in response.headers
+
+
+def test_toolbox_list_forwards_the_frozen_locale_downstream():
+    """The wiring guard elsewhere in this file only greps the source; this runs
+    the real call path and reads the headers that actually go out."""
+    import asyncio
+    import json as json_module
+
+    from app.core import toolbox
+
+    captured = {}
+
+    class _Resp:
+        status = 200
+
+        async def text(self):
+            return json_module.dumps({"tools": [], "has_next": False})
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *args):
+            return False
+
+    class _Session:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        def get(self, url, params=None, headers=None):
+            captured.update(headers or {})
+            return _Resp()
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *args):
+            return False
+
+    original = toolbox.aiohttp.ClientSession
+    toolbox.aiohttp.ClientSession = _Session
+    token = locale.set_effective_locale(locale.ENGLISH_LOCALE)
+    try:
+        asyncio.run(toolbox._list_tools("box-1", "acct", "user"))
+    finally:
+        locale.reset_effective_locale(token)
+        toolbox.aiohttp.ClientSession = original
+
+    assert captured["Accept-Language"] == "en-US"
+    assert captured["x-account-id"] == "acct"


### PR DESCRIPTION
Follow-up to #1004. No behaviour change — tests only.

## Why

#1004 argued three behaviours from how Starlette works rather than from a test. That is exactly the class of claim that already went wrong twice in this work: the catch-all 500 handler turned out to run *outside* the middleware, and `internal_request_headers` turned out to have no production caller at all. Both were caught by review, not by me.

So these three got pinned:

| Claim in #1004 | How it was covered before | Now |
|---|---|---|
| The SSE generator still sees the frozen locale after the middleware's `finally` reset it | reasoning only | real streaming request, both locales |
| A business-path 200 gets `Cache-Control` but no `Content-Language`; a non-business path gets neither | partially (health endpoint, which is not a business path) | both paths asserted |
| Downstream calls carry one normalized `Accept-Language` | a source grep for the helper name | the real `_list_tools` call path, reading the headers that go out |

## Mutation results

Each case was checked by deliberately breaking the code and confirming the suite goes red:

| Mutation | Failures |
|---|---|
| drop the `is_stream` condition | 1 |
| drop the `status >= 400` guard | 1 |
| drop the `is_business_api_path` guard | 1 |
| drop `internal_request_headers` from `_list_tools` | 1 |
| match `zh-TW` as Simplified | 4 |

Restored: 40 passed.

## Note on the harness

The probe routes are mounted on a throwaway `FastAPI` carrying the *real* middleware function, not on the shipped app: `test_contract.py` compares the exported OpenAPI against the shipped app, so an extra path would fail the frozen spec.

`pytest app/test` — 233 passed.

Refs #927