### PR TITLE
fix(vega): guard queries for unavailable resource metadata

### DIFF
--- a/adp/vega/vega-backend/server/driveradapters/resource_data_handler.go
+++ b/adp/vega/vega-backend/server/driveradapters/resource_data_handler.go
@@ -363,6 +363,16 @@ func (r *restHandler) getResourceDataDoc(c *gin.Context, visitor hydra.Visitor, 
 	if !ok {
 		return
 	}
+	warning, err := resourcelogic.EnsureResourceQueryable(ctx, resource)
+	if err != nil {
+		httpErr := err.(*rest.HTTPError)
+		oteltrace.AddHttpAttrs4HttpError(span, httpErr)
+		rest.ReplyError(c, httpErr)
+		return
+	}
+	if warning != "" {
+		otellog.LogWarn(ctx, "Query hit deprecated resource: "+warning)
+	}
 
 	docID := c.Param("doc_id")
 	doc, err := r.ds.GetDocument(ctx, resource.ID, docID)

--- a/adp/vega/vega-backend/server/driveradapters/resource_data_handler_test.go
+++ b/adp/vega/vega-backend/server/driveradapters/resource_data_handler_test.go
@@ -303,7 +303,7 @@ func Test_ResourceDataRestHandler_GetResourceDataDoc(t *testing.T) {
 		assert.Contains(t, w.Body.String(), "VegaBackend.Resource.MetadataUnavailable")
 	})
 
-	t.Run("rejects document query when resource is missing with retained metadata", func(t *testing.T) {
+	t.Run("gives stale lifecycle status precedence over missing discovery status", func(t *testing.T) {
 		engine, rs, _, _ := setupResourceDataHandlerTest(t)
 		resource := sampleDatasetResource()
 		resource.Status = interfaces.ResourceStatusStale
@@ -316,7 +316,7 @@ func Test_ResourceDataRestHandler_GetResourceDataDoc(t *testing.T) {
 		engine.ServeHTTP(w, req)
 
 		require.Equal(t, http.StatusConflict, w.Result().StatusCode)
-		assert.Contains(t, w.Body.String(), "VegaBackend.Resource.MetadataUnavailable")
+		assert.Contains(t, w.Body.String(), "VegaBackend.Resource.NotQueryable")
 	})
 }
 

--- a/adp/vega/vega-backend/server/driveradapters/resource_data_handler_test.go
+++ b/adp/vega/vega-backend/server/driveradapters/resource_data_handler_test.go
@@ -45,10 +45,11 @@ func setupResourceDataHandlerTest(
 
 func sampleDatasetResource() *interfaces.Resource {
 	return &interfaces.Resource{
-		ID:       "res-1",
-		Name:     "dataset",
-		Category: interfaces.ResourceCategoryDataset,
-		Status:   interfaces.ResourceStatusActive,
+		ID:               "res-1",
+		Name:             "dataset",
+		Category:         interfaces.ResourceCategoryDataset,
+		Status:           interfaces.ResourceStatusActive,
+		SchemaDefinition: []*interfaces.Property{{Name: "id"}},
 	}
 }
 
@@ -284,6 +285,38 @@ func Test_ResourceDataRestHandler_GetResourceDataDoc(t *testing.T) {
 
 		require.Equal(t, http.StatusNotFound, w.Result().StatusCode)
 		assert.Contains(t, w.Body.String(), "document missing not found")
+	})
+
+	t.Run("rejects document query when resource metadata is unavailable", func(t *testing.T) {
+		engine, rs, _, _ := setupResourceDataHandlerTest(t)
+		resource := sampleDatasetResource()
+		resource.SchemaDefinition = nil
+		resource.LastDiscoverStatus = interfaces.DiscoverStatusError
+		rs.EXPECT().GetByID(gomock.Any(), "res-1").Return(resource, nil)
+
+		req := httptest.NewRequest(http.MethodGet, "/api/vega-backend/in/v1/resources/res-1/data/doc-1", nil)
+		w := httptest.NewRecorder()
+
+		engine.ServeHTTP(w, req)
+
+		require.Equal(t, http.StatusConflict, w.Result().StatusCode)
+		assert.Contains(t, w.Body.String(), "VegaBackend.Resource.MetadataUnavailable")
+	})
+
+	t.Run("rejects document query when resource is missing with retained metadata", func(t *testing.T) {
+		engine, rs, _, _ := setupResourceDataHandlerTest(t)
+		resource := sampleDatasetResource()
+		resource.Status = interfaces.ResourceStatusStale
+		resource.LastDiscoverStatus = interfaces.DiscoverStatusMissing
+		rs.EXPECT().GetByID(gomock.Any(), "res-1").Return(resource, nil)
+
+		req := httptest.NewRequest(http.MethodGet, "/api/vega-backend/in/v1/resources/res-1/data/doc-1", nil)
+		w := httptest.NewRecorder()
+
+		engine.ServeHTTP(w, req)
+
+		require.Equal(t, http.StatusConflict, w.Result().StatusCode)
+		assert.Contains(t, w.Body.String(), "VegaBackend.Resource.MetadataUnavailable")
 	})
 }
 

--- a/adp/vega/vega-backend/server/errors/resource.go
+++ b/adp/vega/vega-backend/server/errors/resource.go
@@ -30,12 +30,13 @@ const (
 	VegaBackend_Resource_CatalogNotFound = "VegaBackend.Resource.CatalogNotFound"
 
 	// 409 Conflict (Naming Conflict/State Conflict)
-	VegaBackend_Resource_NameExists      = "VegaBackend.Resource.NameExists"
-	VegaBackend_Resource_IDExists        = "VegaBackend.Resource.IDExists"
-	VegaBackend_Resource_IsDisabled      = "VegaBackend.Resource.IsDisabled"
-	VegaBackend_Resource_AlreadyEnabled  = "VegaBackend.Resource.AlreadyEnabled"
-	VegaBackend_Resource_AlreadyDisabled = "VegaBackend.Resource.AlreadyDisabled"
-	VegaBackend_Resource_NotQueryable    = "VegaBackend.Resource.NotQueryable"
+	VegaBackend_Resource_NameExists          = "VegaBackend.Resource.NameExists"
+	VegaBackend_Resource_IDExists            = "VegaBackend.Resource.IDExists"
+	VegaBackend_Resource_IsDisabled          = "VegaBackend.Resource.IsDisabled"
+	VegaBackend_Resource_AlreadyEnabled      = "VegaBackend.Resource.AlreadyEnabled"
+	VegaBackend_Resource_AlreadyDisabled     = "VegaBackend.Resource.AlreadyDisabled"
+	VegaBackend_Resource_NotQueryable        = "VegaBackend.Resource.NotQueryable"
+	VegaBackend_Resource_MetadataUnavailable = "VegaBackend.Resource.MetadataUnavailable"
 
 	// 500 Internal Server Error
 	VegaBackend_Resource_InternalError                       = "VegaBackend.Resource.InternalError"
@@ -76,6 +77,7 @@ var ResourceErrCodeList = []string{
 	VegaBackend_Resource_AlreadyEnabled,
 	VegaBackend_Resource_AlreadyDisabled,
 	VegaBackend_Resource_NotQueryable,
+	VegaBackend_Resource_MetadataUnavailable,
 
 	// 500 Internal Server Error
 	VegaBackend_Resource_InternalError,

--- a/adp/vega/vega-backend/server/locale/resource.en-US.toml
+++ b/adp/vega/vega-backend/server/locale/resource.en-US.toml
@@ -83,6 +83,11 @@ Description = "Resource is not queryable in its current status"
 Solution = "Only resources in active or deprecated status are queryable; enable the resource or refresh its schema"
 ErrorLink = ""
 
+[VegaBackend.Resource.MetadataUnavailable]
+Description = "Resource metadata is unavailable"
+Solution = "Refresh the resource schema, or restore a missing source resource, before querying"
+ErrorLink = ""
+
 [VegaBackend.Resource.InternalError]
 Description = "Resource internal error"
 Solution = "Please contact the administrator"

--- a/adp/vega/vega-backend/server/locale/resource.zh-CN.toml
+++ b/adp/vega/vega-backend/server/locale/resource.zh-CN.toml
@@ -83,6 +83,11 @@ Description = "数据资源当前状态不支持查询"
 Solution = "仅 active/deprecated 状态可查询；请先启用资源或刷新 schema"
 ErrorLink = ""
 
+[VegaBackend.Resource.MetadataUnavailable]
+Description = "数据资源元数据不可用"
+Solution = "请重新探查并刷新资源字段；若源端资源已消失，请先恢复后再查询"
+ErrorLink = ""
+
 [VegaBackend.Resource.InternalError]
 Description = "数据资源内部错误"
 Solution = "请联系管理员"

--- a/adp/vega/vega-backend/server/logics/query/raw_query_service_test.go
+++ b/adp/vega/vega-backend/server/logics/query/raw_query_service_test.go
@@ -97,7 +97,7 @@ func TestRawQueryServiceExecute(t *testing.T) {
 		service := NewRawQueryServiceWithDeps(mockCS, mockRS)
 
 		mockRS.EXPECT().GetByID(gomock.Any(), "resource-1").
-			Return(&interfaces.Resource{ID: "resource-1", CatalogID: "catalog-1"}, nil)
+			Return(&interfaces.Resource{ID: "resource-1", CatalogID: "catalog-1", SchemaDefinition: []*interfaces.Property{{Name: "id"}}}, nil)
 		mockCS.EXPECT().GetByID(gomock.Any(), "catalog-1", true).
 			Return(&interfaces.Catalog{ID: "catalog-1", Enabled: false, ConnectorType: interfaces.ConnectorTypeOpenSearch}, nil)
 
@@ -155,6 +155,7 @@ func TestRawQueryServiceExecute(t *testing.T) {
 					CatalogID:        "catalog-1",
 					SourceIdentifier: "dbo.orders",
 					Status:           interfaces.ResourceStatusActive,
+					SchemaDefinition: []*interfaces.Property{{Name: "id"}},
 				}
 				resourceService.EXPECT().GetByIDs(gomock.Any(), []string{"resource-1"}).
 					Return([]*interfaces.Resource{resource}, nil)
@@ -348,6 +349,7 @@ func TestRawQueryServicePrepareSQLQuery(t *testing.T) {
 			CatalogID:        "catalog-1",
 			SourceIdentifier: "orders",
 			Status:           interfaces.ResourceStatusActive,
+			SchemaDefinition: []*interfaces.Property{{Name: "id"}},
 		}
 		mockRS.EXPECT().GetByIDs(gomock.Any(), []string{"resource-1"}).Return([]*interfaces.Resource{resource}, nil)
 		mockRS.EXPECT().GetByID(gomock.Any(), "resource-1").Return(resource, nil).AnyTimes()
@@ -421,6 +423,7 @@ func TestRawQueryServiceExecuteInitialSQLQuery(t *testing.T) {
 			CatalogID:        "catalog-1",
 			SourceIdentifier: "public.orders",
 			Status:           interfaces.ResourceStatusActive,
+			SchemaDefinition: []*interfaces.Property{{Name: "id"}},
 		}
 		mockRS.EXPECT().GetByIDs(gomock.Any(), []string{"resource-1"}).Return([]*interfaces.Resource{resource}, nil)
 		mockCS.EXPECT().GetByID(gomock.Any(), "catalog-1", true).Return(&interfaces.Catalog{
@@ -590,6 +593,7 @@ func TestRawQueryServiceExecuteInitialDSLQuery(t *testing.T) {
 					ID:               "resource-1",
 					CatalogID:        "catalog-1",
 					SourceIdentifier: "events",
+					SchemaDefinition: []*interfaces.Property{{Name: "id"}},
 				}, nil
 			}).Times(4)
 		mockCS.EXPECT().GetByID(gomock.Any(), "catalog-1", true).DoAndReturn(
@@ -701,6 +705,7 @@ func TestRawQueryServicePrepareOpenSearchCursorQuery(t *testing.T) {
 			ID:               "resource-1",
 			CatalogID:        "catalog-1",
 			SourceIdentifier: "events",
+			SchemaDefinition: []*interfaces.Property{{Name: "id"}},
 		}, nil)
 		mockCS.EXPECT().GetByID(gomock.Any(), "catalog-1", true).Return(&interfaces.Catalog{
 			ID:            "catalog-1",
@@ -749,6 +754,7 @@ func TestRawQueryServiceExecuteInitialOpenSearchCursor(t *testing.T) {
 					ID:               "resource-1",
 					CatalogID:        "catalog-1",
 					SourceIdentifier: "events",
+					SchemaDefinition: []*interfaces.Property{{Name: "id"}},
 				}, nil
 			})
 		mockCS.EXPECT().GetByID(gomock.Any(), "catalog-1", true).DoAndReturn(
@@ -938,7 +944,12 @@ func TestRawQueryServiceExecuteSQLCursorContinuation(t *testing.T) {
 		session.OpenSearchQuery = map[string]any{"sort": []any{"timestamp"}, "size": 1}
 		session.NeedTotal = true
 
-		resource := &interfaces.Resource{ID: "resource-1", CatalogID: "catalog-1", Status: interfaces.ResourceStatusActive}
+		resource := &interfaces.Resource{
+			ID:               "resource-1",
+			CatalogID:        "catalog-1",
+			Status:           interfaces.ResourceStatusActive,
+			SchemaDefinition: []*interfaces.Property{{Name: "id"}},
+		}
 		catalog := &interfaces.Catalog{ID: "catalog-1", Enabled: true, ConnectorType: interfaces.ConnectorTypeOpenSearch}
 		mockRS.EXPECT().GetByIDs(gomock.Any(), []string{"resource-1"}).Return([]*interfaces.Resource{resource}, nil)
 		mockCS.EXPECT().GetByID(gomock.Any(), "catalog-1", true).Return(catalog, nil)
@@ -1092,8 +1103,8 @@ func TestRawQueryServiceCheckSameDataSource(t *testing.T) {
 		svc := &rawQueryService{cs: cs, rs: rs}
 
 		resources := []*interfaces.Resource{
-			{ID: "r1", CatalogID: "catalog-1", Status: interfaces.ResourceStatusActive},
-			{ID: "r2", CatalogID: "catalog-1", Status: interfaces.ResourceStatusDeprecated},
+			{ID: "r1", CatalogID: "catalog-1", Status: interfaces.ResourceStatusActive, SchemaDefinition: []*interfaces.Property{{Name: "id"}}},
+			{ID: "r2", CatalogID: "catalog-1", Status: interfaces.ResourceStatusDeprecated, SchemaDefinition: []*interfaces.Property{{Name: "id"}}},
 		}
 		rs.EXPECT().GetByIDs(gomock.Any(), []string{"r1", "r2"}).Return(resources, nil)
 		cs.EXPECT().GetByID(gomock.Any(), "catalog-1", true).Return(&interfaces.Catalog{
@@ -1141,8 +1152,8 @@ func TestRawQueryServiceCheckSameDataSource(t *testing.T) {
 		rs := mock_interfaces.NewMockResourceService(ctrl)
 		svc := &rawQueryService{rs: rs}
 		rs.EXPECT().GetByIDs(gomock.Any(), []string{"r1", "r2"}).Return([]*interfaces.Resource{
-			{ID: "r1", CatalogID: "catalog-1", Status: interfaces.ResourceStatusActive},
-			{ID: "r2", CatalogID: "catalog-2", Status: interfaces.ResourceStatusActive},
+			{ID: "r1", CatalogID: "catalog-1", Status: interfaces.ResourceStatusActive, SchemaDefinition: []*interfaces.Property{{Name: "id"}}},
+			{ID: "r2", CatalogID: "catalog-2", Status: interfaces.ResourceStatusActive, SchemaDefinition: []*interfaces.Property{{Name: "id"}}},
 		}, nil).Times(2)
 
 		tests := []struct {

--- a/adp/vega/vega-backend/server/logics/resource/status.go
+++ b/adp/vega/vega-backend/server/logics/resource/status.go
@@ -17,11 +17,14 @@ import (
 	"vega-backend/interfaces"
 )
 
-// EnsureResourceQueryable validates that a resource is in a queryable status.
+// EnsureResourceQueryable validates that a resource is in a queryable state and has usable metadata.
 //
-//	active     → pass, no warning
-//	deprecated → pass, return non-empty warning string
-//	disabled / stale → return 409 HTTPError (VegaBackend.Resource.NotQueryable)
+//	disabled             → return 409 HTTPError (VegaBackend.Resource.NotQueryable)
+//	stale                → return 409 HTTPError (VegaBackend.Resource.NotQueryable)
+//	missing              → return 409 HTTPError (VegaBackend.Resource.MetadataUnavailable)
+//	empty schema         → return 409 HTTPError (VegaBackend.Resource.MetadataUnavailable)
+//	deprecated           → pass, return non-empty warning string
+//	active / other state → pass, no warning
 //
 // Unknown statuses are treated as queryable to avoid blocking legitimate
 // traffic when new statuses are introduced.
@@ -29,15 +32,30 @@ func EnsureResourceQueryable(ctx context.Context, r *interfaces.Resource) (strin
 	if r == nil {
 		return "", nil
 	}
-	switch r.Status {
-	case interfaces.ResourceStatusDisabled, interfaces.ResourceStatusStale:
+	if r.Status == interfaces.ResourceStatusDisabled {
 		return "", rest.NewHTTPError(ctx, http.StatusConflict, verrors.VegaBackend_Resource_NotQueryable).
 			WithErrorDetails(fmt.Sprintf("resource %s is %s and cannot be queried", r.ID, r.Status))
-	case interfaces.ResourceStatusDeprecated:
-		return fmt.Sprintf("resource %s (%s) is deprecated", r.ID, r.Name), nil
-	default:
-		return "", nil
 	}
+	if r.Status == interfaces.ResourceStatusStale {
+		return "", rest.NewHTTPError(ctx, http.StatusConflict, verrors.VegaBackend_Resource_NotQueryable).
+			WithErrorDetails(fmt.Sprintf("resource %s is %s and cannot be queried", r.ID, r.Status))
+	}
+	if r.LastDiscoverStatus == interfaces.DiscoverStatusMissing {
+		return "", rest.NewHTTPError(ctx, http.StatusConflict, verrors.VegaBackend_Resource_MetadataUnavailable).
+			WithErrorDetails("resource is missing from its source; run discovery and restore the source resource before querying")
+	}
+	if len(r.SchemaDefinition) == 0 {
+		details := "resource schema definition is empty; refresh the resource schema before querying"
+		if r.LastDiscoverStatus == interfaces.DiscoverStatusError {
+			details = "resource metadata discovery failed; refresh the resource schema before querying"
+		}
+		return "", rest.NewHTTPError(ctx, http.StatusConflict, verrors.VegaBackend_Resource_MetadataUnavailable).
+			WithErrorDetails(details)
+	}
+	if r.Status == interfaces.ResourceStatusDeprecated {
+		return fmt.Sprintf("resource %s (%s) is deprecated", r.ID, r.Name), nil
+	}
+	return "", nil
 }
 
 // EnsureResourcesQueryable applies EnsureResourceQueryable across a slice and

--- a/adp/vega/vega-backend/server/logics/resource/status_test.go
+++ b/adp/vega/vega-backend/server/logics/resource/status_test.go
@@ -30,11 +30,11 @@ func TestEnsureResourceQueryable(t *testing.T) {
 		{name: "nil resource passes", resource: nil},
 		{
 			name:     "active passes silently",
-			resource: &interfaces.Resource{ID: "r1", Status: interfaces.ResourceStatusActive},
+			resource: &interfaces.Resource{ID: "r1", Status: interfaces.ResourceStatusActive, SchemaDefinition: []*interfaces.Property{{Name: "id"}}},
 		},
 		{
 			name:     "deprecated warns",
-			resource: &interfaces.Resource{ID: "r1", Name: "n1", Status: interfaces.ResourceStatusDeprecated},
+			resource: &interfaces.Resource{ID: "r1", Name: "n1", Status: interfaces.ResourceStatusDeprecated, SchemaDefinition: []*interfaces.Property{{Name: "id"}}},
 			wantWarn: true,
 		},
 		{
@@ -50,8 +50,30 @@ func TestEnsureResourceQueryable(t *testing.T) {
 			wantErrCode: verrors.VegaBackend_Resource_NotQueryable,
 		},
 		{
+			name: "stale takes precedence over missing",
+			resource: &interfaces.Resource{
+				ID:                 "r1",
+				Status:             interfaces.ResourceStatusStale,
+				LastDiscoverStatus: interfaces.DiscoverStatusMissing,
+				SchemaDefinition:   []*interfaces.Property{{Name: "id"}},
+			},
+			wantErr:     true,
+			wantErrCode: verrors.VegaBackend_Resource_NotQueryable,
+		},
+		{
+			name: "disabled takes precedence over missing",
+			resource: &interfaces.Resource{
+				ID:                 "r1",
+				Status:             interfaces.ResourceStatusDisabled,
+				LastDiscoverStatus: interfaces.DiscoverStatusMissing,
+				SchemaDefinition:   []*interfaces.Property{{Name: "id"}},
+			},
+			wantErr:     true,
+			wantErrCode: verrors.VegaBackend_Resource_NotQueryable,
+		},
+		{
 			name:     "unknown status passes (forward compat)",
-			resource: &interfaces.Resource{ID: "r1", Status: "unknown_future_status"},
+			resource: &interfaces.Resource{ID: "r1", Status: "unknown_future_status", SchemaDefinition: []*interfaces.Property{{Name: "id"}}},
 		},
 	}
 
@@ -92,8 +114,8 @@ func TestEnsureResourcesQueryable(t *testing.T) {
 
 	t.Run("all active produces no warnings", func(t *testing.T) {
 		ws, err := EnsureResourcesQueryable(ctx, []*interfaces.Resource{
-			{ID: "a", Status: interfaces.ResourceStatusActive},
-			{ID: "b", Status: interfaces.ResourceStatusActive},
+			{ID: "a", Status: interfaces.ResourceStatusActive, SchemaDefinition: []*interfaces.Property{{Name: "id"}}},
+			{ID: "b", Status: interfaces.ResourceStatusActive, SchemaDefinition: []*interfaces.Property{{Name: "id"}}},
 		})
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
@@ -105,8 +127,8 @@ func TestEnsureResourcesQueryable(t *testing.T) {
 
 	t.Run("mixed active + deprecated returns deprecated warning", func(t *testing.T) {
 		ws, err := EnsureResourcesQueryable(ctx, []*interfaces.Resource{
-			{ID: "a", Status: interfaces.ResourceStatusActive},
-			{ID: "b", Name: "n", Status: interfaces.ResourceStatusDeprecated},
+			{ID: "a", Status: interfaces.ResourceStatusActive, SchemaDefinition: []*interfaces.Property{{Name: "id"}}},
+			{ID: "b", Name: "n", Status: interfaces.ResourceStatusDeprecated, SchemaDefinition: []*interfaces.Property{{Name: "id"}}},
 		})
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)

--- a/adp/vega/vega-backend/server/logics/resource_data/logic_view/logic_view.go
+++ b/adp/vega/vega-backend/server/logics/resource_data/logic_view/logic_view.go
@@ -356,6 +356,9 @@ func (lvs *logicViewService) queryCompositeLogicView(ctx context.Context, view *
 				otellog.LogError(ctx, "Source resource not found", httpErr)
 				return nil, httpErr
 			}
+			if _, err := resource.EnsureResourceQueryable(ctx, fromResource); err != nil {
+				return nil, err
+			}
 			refResources[nodeCfg.ResourceID] = fromResource
 
 			if fromResource.Category == interfaces.ResourceCategoryIndex {

--- a/adp/vega/vega-backend/server/logics/resource_data/logic_view/logic_view_test.go
+++ b/adp/vega/vega-backend/server/logics/resource_data/logic_view/logic_view_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
 
+	verrors "vega-backend/errors"
 	"vega-backend/interfaces"
 	vmock "vega-backend/interfaces/mock"
 )
@@ -76,13 +77,33 @@ func TestQueryDerivedLogicViewRejectsUnavailableSource(t *testing.T) {
 		assert.Equal(t, http.StatusConflict, httpErr.HTTPCode)
 	})
 
+	t.Run("source resource with unavailable metadata", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		mockRS := vmock.NewMockResourceService(ctrl)
+		svc := &logicViewService{rs: mockRS}
+		mockRS.EXPECT().GetByID(gomock.Any(), "source-1").Return(&interfaces.Resource{
+			ID:                 "source-1",
+			Status:             interfaces.ResourceStatusActive,
+			LastDiscoverStatus: interfaces.DiscoverStatusError,
+		}, nil)
+
+		_, _, err := svc.queryDerivedLogicView(context.Background(), view, &interfaces.ResourceDataQueryParams{})
+		var httpErr *rest.HTTPError
+		require.ErrorAs(t, err, &httpErr)
+		assert.Equal(t, http.StatusConflict, httpErr.HTTPCode)
+		assert.Equal(t, verrors.VegaBackend_Resource_MetadataUnavailable, httpErr.BaseError.ErrorCode)
+	})
+
 	t.Run("disabled source catalog", func(t *testing.T) {
 		ctrl := gomock.NewController(t)
 		mockRS := vmock.NewMockResourceService(ctrl)
 		mockCS := vmock.NewMockCatalogService(ctrl)
 		svc := &logicViewService{rs: mockRS, cs: mockCS}
 		mockRS.EXPECT().GetByID(gomock.Any(), "source-1").Return(&interfaces.Resource{
-			ID: "source-1", CatalogID: "catalog-1", Status: interfaces.ResourceStatusActive,
+			ID:               "source-1",
+			CatalogID:        "catalog-1",
+			Status:           interfaces.ResourceStatusActive,
+			SchemaDefinition: []*interfaces.Property{{Name: "id"}},
 		}, nil)
 		mockCS.EXPECT().GetByID(gomock.Any(), "catalog-1", true).Return(&interfaces.Catalog{ID: "catalog-1", Enabled: false}, nil)
 
@@ -93,16 +114,40 @@ func TestQueryDerivedLogicViewRejectsUnavailableSource(t *testing.T) {
 	})
 }
 
+func TestQueryCompositeLogicViewRejectsUnavailableSourceMetadata(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	mockRS := vmock.NewMockResourceService(ctrl)
+	svc := &logicViewService{rs: mockRS}
+	view := &interfaces.LogicView{Resource: interfaces.Resource{LogicDefinition: []*interfaces.LogicDefinitionNode{{
+		Type:   interfaces.LogicDefinitionNodeType_Resource,
+		Config: map[string]any{"resource_id": "source-1"},
+	}}}}
+	mockRS.EXPECT().GetByID(gomock.Any(), "source-1").Return(&interfaces.Resource{
+		ID:                 "source-1",
+		Status:             interfaces.ResourceStatusActive,
+		LastDiscoverStatus: interfaces.DiscoverStatusError,
+	}, nil)
+
+	result, err := svc.queryCompositeLogicView(context.Background(), view, &interfaces.ResourceDataQueryParams{})
+
+	assert.Nil(t, result)
+	var httpErr *rest.HTTPError
+	require.ErrorAs(t, err, &httpErr)
+	assert.Equal(t, http.StatusConflict, httpErr.HTTPCode)
+	assert.Equal(t, verrors.VegaBackend_Resource_MetadataUnavailable, httpErr.BaseError.ErrorCode)
+}
+
 func TestDerivedIndexCursorRequiresSort(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockRS := vmock.NewMockResourceService(ctrl)
 	mockCS := vmock.NewMockCatalogService(ctrl)
 	svc := &logicViewService{rs: mockRS, cs: mockCS}
 	source := &interfaces.Resource{
-		ID:        "source-1",
-		CatalogID: "catalog-1",
-		Category:  interfaces.ResourceCategoryIndex,
-		Status:    interfaces.ResourceStatusActive,
+		ID:               "source-1",
+		CatalogID:        "catalog-1",
+		Category:         interfaces.ResourceCategoryIndex,
+		Status:           interfaces.ResourceStatusActive,
+		SchemaDefinition: []*interfaces.Property{{Name: "timestamp"}},
 	}
 	mockRS.EXPECT().GetByID(gomock.Any(), "source-1").Return(source, nil).AnyTimes()
 	mockCS.EXPECT().GetByID(gomock.Any(), "catalog-1", true).
@@ -133,10 +178,11 @@ func TestDerivedIndexRejectsFirstPageWindowOverflow(t *testing.T) {
 	mockCS := vmock.NewMockCatalogService(ctrl)
 	svc := &logicViewService{rs: mockRS, cs: mockCS}
 	source := &interfaces.Resource{
-		ID:        "source-1",
-		CatalogID: "catalog-1",
-		Category:  interfaces.ResourceCategoryIndex,
-		Status:    interfaces.ResourceStatusActive,
+		ID:               "source-1",
+		CatalogID:        "catalog-1",
+		Category:         interfaces.ResourceCategoryIndex,
+		Status:           interfaces.ResourceStatusActive,
+		SchemaDefinition: []*interfaces.Property{{Name: "timestamp"}},
 	}
 	mockRS.EXPECT().GetByID(gomock.Any(), "source-1").Return(source, nil).AnyTimes()
 	mockCS.EXPECT().GetByID(gomock.Any(), "catalog-1", true).

--- a/adp/vega/vega-backend/server/logics/resource_data/resource_data_service.go
+++ b/adp/vega/vega-backend/server/logics/resource_data/resource_data_service.go
@@ -26,7 +26,7 @@ import (
 	"vega-backend/logics/model_factory"
 	querylogic "vega-backend/logics/query"
 	"vega-backend/logics/rate"
-	"vega-backend/logics/resource"
+	resourcelogic "vega-backend/logics/resource"
 	"vega-backend/logics/resource_data/logic_view"
 )
 
@@ -57,7 +57,7 @@ func NewResourceDataService(appSetting *common.AppSetting) interfaces.ResourceDa
 			ds:         dataset.NewDatasetService(appSetting),
 			lim:        local_index.NewLocalIndexManager(appSetting),
 			cs:         catalog.NewCatalogService(appSetting),
-			rs:         resource.NewResourceService(appSetting),
+			rs:         resourcelogic.NewResourceService(appSetting),
 			lvs:        logic_view.NewLogicViewService(appSetting),
 			mfs:        model_factory.NewModelFactoryService(appSetting),
 			bta:        logics.BTA,
@@ -283,6 +283,9 @@ func (rds *resourceDataService) query(ctx context.Context, resource *interfaces.
 // QueryWithPaging is the sole public resource-data query entrypoint.
 func (rds *resourceDataService) QueryWithPaging(ctx context.Context, resource *interfaces.Resource,
 	params *interfaces.ResourceDataQueryParams) (*interfaces.ResourceDataQueryResult, error) {
+	if _, err := resourcelogic.EnsureResourceQueryable(ctx, resource); err != nil {
+		return nil, err
+	}
 	if resource.Category == interfaces.ResourceCategoryLogicView {
 		return rds.lvs.QueryWithPaging(ctx, resource, params)
 	}

--- a/adp/vega/vega-backend/server/logics/resource_data/resource_data_service_test.go
+++ b/adp/vega/vega-backend/server/logics/resource_data/resource_data_service_test.go
@@ -21,6 +21,7 @@ import (
 	"vega-backend/interfaces"
 	mock_interfaces "vega-backend/interfaces/mock"
 	"vega-backend/logics/filter_condition"
+	resourcelogic "vega-backend/logics/resource"
 )
 
 func TestResourceDataServicePrepareOutputFieldsParams(t *testing.T) {
@@ -60,6 +61,103 @@ func TestResourceDataServicePrepareOutputFieldsParams(t *testing.T) {
 		expected := []string{"name", "_score"}
 		assert.Equal(t, expected, params.OutputFields)
 	})
+}
+
+func TestEnsureResourceQueryableMetadata(t *testing.T) {
+	tests := []struct {
+		name        string
+		resource    *interfaces.Resource
+		wantError   bool
+		wantDetails string
+	}{
+		{
+			name: "rejects empty schema after discover failure for any resource category",
+			resource: &interfaces.Resource{
+				ID:                 "resource-1",
+				Category:           interfaces.ResourceCategoryFileset,
+				LastDiscoverStatus: interfaces.DiscoverStatusError,
+				StatusMessage:      "discover metadata failed: syntax error at or near LATERAL",
+			},
+			wantError:   true,
+			wantDetails: "resource metadata discovery failed; refresh the resource schema before querying",
+		},
+		{
+			name: "rejects empty schema after a successful discovery observation",
+			resource: &interfaces.Resource{
+				ID:                 "fileset-1",
+				Category:           interfaces.ResourceCategoryFileset,
+				LastDiscoverStatus: interfaces.DiscoverStatusUnchanged,
+			},
+			wantError:   true,
+			wantDetails: "resource schema definition is empty; refresh the resource schema before querying",
+		},
+		{
+			name: "allows last known schema after discover failure",
+			resource: &interfaces.Resource{
+				ID:                 "resource-1",
+				Category:           interfaces.ResourceCategoryTable,
+				LastDiscoverStatus: interfaces.DiscoverStatusError,
+				SchemaDefinition:   []*interfaces.Property{{Name: "id"}},
+			},
+		},
+		{
+			name: "rejects a missing resource even when its previous schema remains",
+			resource: &interfaces.Resource{
+				ID:                 "resource-1",
+				Category:           interfaces.ResourceCategoryDataset,
+				LastDiscoverStatus: interfaces.DiscoverStatusMissing,
+				SchemaDefinition:   []*interfaces.Property{{Name: "id"}},
+			},
+			wantError:   true,
+			wantDetails: "resource is missing from its source; run discovery and restore the source resource before querying",
+		},
+		{
+			name: "allows restored resource metadata",
+			resource: &interfaces.Resource{
+				ID:                 "resource-1",
+				Category:           interfaces.ResourceCategoryDataset,
+				LastDiscoverStatus: interfaces.DiscoverStatusRestored,
+				SchemaDefinition:   []*interfaces.Property{{Name: "id"}},
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			_, err := resourcelogic.EnsureResourceQueryable(context.Background(), test.resource)
+			if !test.wantError {
+				require.NoError(t, err)
+				return
+			}
+
+			var httpErr *rest.HTTPError
+			require.ErrorAs(t, err, &httpErr)
+			assert.Equal(t, http.StatusConflict, httpErr.HTTPCode)
+			assert.Equal(t, verrors.VegaBackend_Resource_MetadataUnavailable, httpErr.BaseError.ErrorCode)
+			assert.Equal(t, test.wantDetails, httpErr.BaseError.ErrorDetails)
+			assert.NotContains(t, httpErr.BaseError.ErrorDetails, "LATERAL")
+		})
+	}
+}
+
+func TestResourceDataServiceQueryWithPagingRejectsUnavailableTableMetadata(t *testing.T) {
+	resource := &interfaces.Resource{
+		ID:                 "resource-1",
+		Category:           interfaces.ResourceCategoryFileset,
+		LastDiscoverStatus: interfaces.DiscoverStatusError,
+	}
+
+	for _, params := range []*interfaces.ResourceDataQueryParams{
+		{},
+		{Paging: interfaces.PagingRequest{Cursor: "existing-cursor"}},
+	} {
+		_, err := (&resourceDataService{}).QueryWithPaging(context.Background(), resource, params)
+
+		var httpErr *rest.HTTPError
+		require.ErrorAs(t, err, &httpErr)
+		assert.Equal(t, http.StatusConflict, httpErr.HTTPCode)
+		assert.Equal(t, verrors.VegaBackend_Resource_MetadataUnavailable, httpErr.BaseError.ErrorCode)
+	}
 }
 
 func TestResourceDataServiceQuery(t *testing.T) {
@@ -192,8 +290,9 @@ func TestResourceDataServiceQuery(t *testing.T) {
 func TestResourceDataServiceRejectsIndexAggregationCursor(t *testing.T) {
 	rds := &resourceDataService{}
 	_, err := rds.QueryWithPaging(context.Background(), &interfaces.Resource{
-		ID:       "index-1",
-		Category: interfaces.ResourceCategoryIndex,
+		ID:               "index-1",
+		Category:         interfaces.ResourceCategoryIndex,
+		SchemaDefinition: []*interfaces.Property{{Name: "category"}},
 	}, &interfaces.ResourceDataQueryParams{
 		Paging: interfaces.PagingRequest{Mode: interfaces.PagingModeCursor, Limit: 10},
 		Sort:   []*interfaces.SortField{{Field: "timestamp", Direction: "desc"}},
@@ -231,7 +330,12 @@ func TestResourceDataServiceRejectsOpenSearchCursorWithoutSort(t *testing.T) {
 	mockCS := mock_interfaces.NewMockCatalogService(ctrl)
 	mockDS := mock_interfaces.NewMockDatasetService(ctrl)
 	rds := &resourceDataService{cs: mockCS, ds: mockDS}
-	resource := &interfaces.Resource{ID: "dataset-1", CatalogID: "catalog-1", Category: interfaces.ResourceCategoryDataset}
+	resource := &interfaces.Resource{
+		ID:               "dataset-1",
+		CatalogID:        "catalog-1",
+		Category:         interfaces.ResourceCategoryDataset,
+		SchemaDefinition: []*interfaces.Property{{Name: "id"}},
+	}
 	mockCS.EXPECT().GetByID(gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes().
 		Return(&interfaces.Catalog{ID: "catalog-1", Enabled: true}, nil)
 	mockDS.EXPECT().ListDocuments(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes().
@@ -251,7 +355,12 @@ func TestResourceDataServiceRejectsOpenSearchFirstPageWindowOverflow(t *testing.
 	mockCS := mock_interfaces.NewMockCatalogService(ctrl)
 	mockDS := mock_interfaces.NewMockDatasetService(ctrl)
 	rds := &resourceDataService{cs: mockCS, ds: mockDS}
-	resource := &interfaces.Resource{ID: "dataset-1", CatalogID: "catalog-1", Category: interfaces.ResourceCategoryDataset}
+	resource := &interfaces.Resource{
+		ID:               "dataset-1",
+		CatalogID:        "catalog-1",
+		Category:         interfaces.ResourceCategoryDataset,
+		SchemaDefinition: []*interfaces.Property{{Name: "id"}},
+	}
 	mockCS.EXPECT().GetByID(gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes().
 		Return(&interfaces.Catalog{ID: "catalog-1", Enabled: true}, nil)
 	mockDS.EXPECT().ListDocuments(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes().
@@ -272,7 +381,12 @@ func TestDatasetCursorUsesSearchAfterPagination(t *testing.T) {
 	mockCS := mock_interfaces.NewMockCatalogService(ctrl)
 	mockDS := mock_interfaces.NewMockDatasetService(ctrl)
 	rds := &resourceDataService{cs: mockCS, ds: mockDS}
-	resource := &interfaces.Resource{ID: "dataset-1", CatalogID: "catalog-1", Category: interfaces.ResourceCategoryDataset}
+	resource := &interfaces.Resource{
+		ID:               "dataset-1",
+		CatalogID:        "catalog-1",
+		Category:         interfaces.ResourceCategoryDataset,
+		SchemaDefinition: []*interfaces.Property{{Name: "id"}},
+	}
 	params := &interfaces.ResourceDataQueryParams{
 		Paging: interfaces.PagingRequest{Mode: interfaces.PagingModeCursor, Limit: 1},
 		Sort:   []*interfaces.SortField{{Field: "id", Direction: "asc"}},

--- a/adp/vega/vega-backend/server/logics/resource_data/resource_data_service_test.go
+++ b/adp/vega/vega-backend/server/logics/resource_data/resource_data_service_test.go
@@ -76,7 +76,6 @@ func TestEnsureResourceQueryableMetadata(t *testing.T) {
 				ID:                 "resource-1",
 				Category:           interfaces.ResourceCategoryFileset,
 				LastDiscoverStatus: interfaces.DiscoverStatusError,
-				StatusMessage:      "discover metadata failed: syntax error at or near LATERAL",
 			},
 			wantError:   true,
 			wantDetails: "resource metadata discovery failed; refresh the resource schema before querying",
@@ -135,9 +134,23 @@ func TestEnsureResourceQueryableMetadata(t *testing.T) {
 			assert.Equal(t, http.StatusConflict, httpErr.HTTPCode)
 			assert.Equal(t, verrors.VegaBackend_Resource_MetadataUnavailable, httpErr.BaseError.ErrorCode)
 			assert.Equal(t, test.wantDetails, httpErr.BaseError.ErrorDetails)
-			assert.NotContains(t, httpErr.BaseError.ErrorDetails, "LATERAL")
 		})
 	}
+}
+
+func TestEnsureResourceQueryableDoesNotExposeStatusMessage(t *testing.T) {
+	resource := &interfaces.Resource{
+		ID:                 "resource-1",
+		Category:           interfaces.ResourceCategoryFileset,
+		LastDiscoverStatus: interfaces.DiscoverStatusError,
+		StatusMessage:      "discover metadata failed: syntax error at or near LATERAL",
+	}
+
+	_, err := resourcelogic.EnsureResourceQueryable(context.Background(), resource)
+	var httpErr *rest.HTTPError
+	require.ErrorAs(t, err, &httpErr)
+	assert.NotContains(t, httpErr.BaseError.ErrorDetails, resource.StatusMessage)
+	assert.NotContains(t, httpErr.BaseError.ErrorDetails, "syntax error at or near LATERAL")
 }
 
 func TestResourceDataServiceQueryWithPagingRejectsUnavailableTableMetadata(t *testing.T) {

--- a/docs/api/vega/raw-query.yaml
+++ b/docs/api/vega/raw-query.yaml
@@ -143,7 +143,15 @@ components:
           schema:
             $ref: "../_shared/errors.yaml#/components/schemas/Error"
     Conflict:
-      description: Catalog 被禁用、资源不可查询或 cursor 指向的 Catalog 已变化。
+      description: |
+        请求当前无法执行。常见 errcode：
+        - `VegaBackend.Catalog.IsDisabled`：Catalog 已禁用
+        - `VegaBackend.Resource.NotQueryable`：Resource 为 `disabled` 或 `stale`
+        - `VegaBackend.Resource.MetadataUnavailable`：其他可查询状态下 Resource 的 `last_discover_status=missing`，或 `schema_definition` 为空
+        - `VegaBackend.Query.CursorResourceChanged`：cursor 绑定的 Resource 或 Resource 版本已变化
+        - `VegaBackend.Query.ExecuteFailed`：cursor 指向的 Catalog 已变化
+
+        Resource 条件同时出现时，判断优先级为 `disabled`、`stale`、`missing`、空 schema。
       content:
         application/json:
           schema:

--- a/docs/api/vega/resource-data.yaml
+++ b/docs/api/vega/resource-data.yaml
@@ -285,6 +285,8 @@ components:
         - `status=stale`：`VegaBackend.Resource.NotQueryable`
         - `last_discover_status=missing`：`VegaBackend.Resource.MetadataUnavailable`
         - 其他状态下 `schema_definition` 为空：`VegaBackend.Resource.MetadataUnavailable`
+        - `POST /resources/{id}/data` 的 `Override: GET` 分支中，Resource 状态和元数据均
+          可查询但所属 Catalog 已禁用：`VegaBackend.Catalog.IsDisabled`
 
         因此同时满足多个条件时，以列表中靠前的条件为准。元数据不可用时，调用方应
         重新探查并刷新资源字段；`missing` 资源还需要先恢复源端对象。

--- a/docs/api/vega/resource-data.yaml
+++ b/docs/api/vega/resource-data.yaml
@@ -100,6 +100,8 @@ paths:
           $ref: "#/components/responses/NotFound"
         "406":
           $ref: "#/components/responses/NotAcceptable"
+        "409":
+          $ref: "#/components/responses/Conflict"
         "500":
           $ref: "#/components/responses/InternalServerError"
     put:
@@ -195,6 +197,8 @@ paths:
 
         文档不存在返回 404 `VegaBackend.Resource.NotFound`（与 resource 不存在共用同一
         errcode；靠 `error_details: "document {doc_id} not found"` 区分）。
+
+        Resource 当前不可查询时返回 409，状态优先级和 errcode 与列表查询一致。
       responses:
         "200":
           description: ok
@@ -208,6 +212,8 @@ paths:
           $ref: "#/components/responses/Unauthorized"
         "404":
           $ref: "#/components/responses/NotFound"
+        "409":
+          $ref: "#/components/responses/Conflict"
         "500":
           $ref: "#/components/responses/InternalServerError"
     put:
@@ -268,6 +274,20 @@ components:
       description: |
         Resource 或文档不存在。errcode `VegaBackend.Resource.NotFound`；
         通过 `error_details` 字符串区分是 resource 还是 document 找不到。
+      content:
+        application/json:
+          schema:
+            $ref: "../_shared/errors.yaml#/components/schemas/Error"
+    Conflict:
+      description: |
+        Resource 当前无法查询，按以下优先级返回 errcode：
+        - `status=disabled`：`VegaBackend.Resource.NotQueryable`
+        - `status=stale`：`VegaBackend.Resource.NotQueryable`
+        - `last_discover_status=missing`：`VegaBackend.Resource.MetadataUnavailable`
+        - 其他状态下 `schema_definition` 为空：`VegaBackend.Resource.MetadataUnavailable`
+
+        因此同时满足多个条件时，以列表中靠前的条件为准。元数据不可用时，调用方应
+        重新探查并刷新资源字段；`missing` 资源还需要先恢复源端对象。
       content:
         application/json:
           schema:


### PR DESCRIPTION
# Pull Request

## What Changed

- [x] Add a shared queryability guard for resource lifecycle and metadata state
- [x] Apply the guard to resource data, raw query, document read, and logic-view source paths
- [x] Document 409 error contracts for resource-data and raw-query APIs

---

## Why

- Related Issue: https://github.com/openbkn-ai/bkn-studio/issues/445
- Related Studio PR: https://github.com/openbkn-ai/bkn-studio/pull/457
- Background: Resources with unavailable metadata or non-queryable lifecycle states could still reach query and preview execution paths.

---

## How

- Key implementation points: Evaluate queryability in order: `disabled`, `stale`, `missing`, then empty schema. Deprecated resources remain queryable and emit warnings.
- Breaking changes: Queries that previously reached connectors for unavailable resources now return HTTP 409 with `VegaBackend.Resource.NotQueryable` or `VegaBackend.Resource.MetadataUnavailable`.

---

## Testing

- [x] Unit tests passed locally
- [ ] Integration tests passed locally
- [ ] Verified in test environment

Test notes:

- Vega backend unit tests and lint passed during implementation.
- `go test ./logics/resource` passed after the final priority refactor.
- Redocly validation passed for both changed OpenAPI documents; one pre-existing equivalent-path warning remains in `resource-data.yaml`.

---

## Risk & Rollback

- Potential risks: Clients may begin receiving 409 for stale, missing, or schema-less resources that were previously sent to downstream connectors.
- Rollback plan: Revert this commit to restore the previous per-path checks.

---

## Additional Notes

- Merge/deploy this backend contract change before or together with the Studio PR.