### PR TITLE
refactor(oss-gateway): rename the kweaver-core Redis key prefix

### DIFF
--- a/infra/oss-gateway-backend/internal/cache/storage_cache.go
+++ b/infra/oss-gateway-backend/internal/cache/storage_cache.go
@@ -11,10 +11,10 @@ import (
 )
 
 const (
-	storageConfigPrefix     = "kweaver-core:oss-gateway-backend:storage:config:"
-	storageNamePrefix       = "kweaver-core:oss-gateway-backend:storage:name:"        // storage_name uniqueness index.
-	storageBucketHostPrefix = "kweaver-core:oss-gateway-backend:storage:bucket:host:" // bucket_name and host uniqueness index.
-	storageBucketSitePrefix = "kweaver-core:oss-gateway-backend:storage:bucket:site:" // bucket_name and siteId uniqueness index.
+	storageConfigPrefix     = "openbkn:oss-gateway-backend:storage:config:"
+	storageNamePrefix       = "openbkn:oss-gateway-backend:storage:name:"        // storage_name uniqueness index.
+	storageBucketHostPrefix = "openbkn:oss-gateway-backend:storage:bucket:host:" // bucket_name and host uniqueness index.
+	storageBucketSitePrefix = "openbkn:oss-gateway-backend:storage:bucket:site:" // bucket_name and siteId uniqueness index.
 	storageConfigTTL        = 1 * time.Hour
 )
 


### PR DESCRIPTION
The four storage cache key families were still namespaced under `kweaver-core:`. They become `openbkn:`, matching the namespace and database name the platform uses elsewhere.

```
kweaver-core:oss-gateway-backend:storage:config:       -> openbkn:oss-gateway-backend:storage:config:
kweaver-core:oss-gateway-backend:storage:name:         -> openbkn:oss-gateway-backend:storage:name:
kweaver-core:oss-gateway-backend:storage:bucket:host:  -> openbkn:oss-gateway-backend:storage:bucket:host:
kweaver-core:oss-gateway-backend:storage:bucket:site:  -> openbkn:oss-gateway-backend:storage:bucket:site:
```

## Why this is safe to change in place

- Every family carries the same 1h TTL (`storageConfigTTL`), so keys written under the old prefix expire on their own. No migration, no cleanup step.
- `storage_cache.go` is the only place that builds these keys, and no test asserts the literal prefix.
- The name / bucket-host / bucket-site families are lookup accelerators rather than the source of truth. `storage_service.go:144` states it, and the authoritative checks are `ExistsByStorageName`, `ExistsByBucketAndEndpoint` and `ExistsByBucketAndSiteID` against the database. A cold cache after the rename costs an extra lookup, not correctness.

## Verification

`go build ./...`, `go vet ./...`, `go test ./...` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)