### PR TITLE
refactor(sandbox): move the default template registry to openbkn-ai

### DIFF
--- a/infra/sandbox/.env.example
+++ b/infra/sandbox/.env.example
@@ -46,8 +46,8 @@ DEFAULT_TEMPLATE_ID=python-basic
 # If unset, Control Plane reads /app/VERSION and uses that value as the tag.
 # For branch builds, set the full generated tag, for example:
 # TEMPLATE_IMAGE_TAG=0.4.0-feature-sandbox-20260512.git-4188ba2-opensource
-# DEFAULT_TEMPLATE_IMAGE=swr.cn-east-3.myhuaweicloud.com/openbkn-ai/dip/sandbox-template-python-basic:${TEMPLATE_IMAGE_TAG}
-# DEFAULT_MULTI_LANGUAGE_TEMPLATE_IMAGE=swr.cn-east-3.myhuaweicloud.com/openbkn-ai/dip/sandbox-template-multi-language:${TEMPLATE_IMAGE_TAG}
+# DEFAULT_TEMPLATE_IMAGE=swr.cn-east-3.myhuaweicloud.com/openbkn-ai/sandbox-template-python-basic:${TEMPLATE_IMAGE_TAG}
+# DEFAULT_MULTI_LANGUAGE_TEMPLATE_IMAGE=swr.cn-east-3.myhuaweicloud.com/openbkn-ai/sandbox-template-multi-language:${TEMPLATE_IMAGE_TAG}
 SESSION_DEFAULT_TIMEOUT=300
 SESSION_MAX_TIMEOUT=3600
 SESSION_IDLE_TIMEOUT=1800

--- a/infra/sandbox/.env.example
+++ b/infra/sandbox/.env.example
@@ -46,8 +46,8 @@ DEFAULT_TEMPLATE_ID=python-basic
 # If unset, Control Plane reads /app/VERSION and uses that value as the tag.
 # For branch builds, set the full generated tag, for example:
 # TEMPLATE_IMAGE_TAG=0.4.0-feature-sandbox-20260512.git-4188ba2-opensource
-# DEFAULT_TEMPLATE_IMAGE=swr.cn-east-3.myhuaweicloud.com/kweaver-ai/dip/sandbox-template-python-basic:${TEMPLATE_IMAGE_TAG}
-# DEFAULT_MULTI_LANGUAGE_TEMPLATE_IMAGE=swr.cn-east-3.myhuaweicloud.com/kweaver-ai/dip/sandbox-template-multi-language:${TEMPLATE_IMAGE_TAG}
+# DEFAULT_TEMPLATE_IMAGE=swr.cn-east-3.myhuaweicloud.com/openbkn-ai/dip/sandbox-template-python-basic:${TEMPLATE_IMAGE_TAG}
+# DEFAULT_MULTI_LANGUAGE_TEMPLATE_IMAGE=swr.cn-east-3.myhuaweicloud.com/openbkn-ai/dip/sandbox-template-multi-language:${TEMPLATE_IMAGE_TAG}
 SESSION_DEFAULT_TIMEOUT=300
 SESSION_MAX_TIMEOUT=3600
 SESSION_IDLE_TIMEOUT=1800

--- a/infra/sandbox/README.md
+++ b/infra/sandbox/README.md
@@ -195,7 +195,7 @@ To push multi-arch base images to Huawei Cloud SWR, install `skopeo` and use Doc
 cd images
 ./build.sh --build-bases --push-swr-bases \
   --swr-registry swr.cn-east-3.myhuaweicloud.com \
-  --swr-namespace kweaver-ai/sandbox \
+  --swr-namespace openbkn-ai/sandbox \
   --swr-creds '<username>:<password>'
 ```
 
@@ -247,8 +247,8 @@ docker-compose -f deploy/docker-compose/docker-compose.yml up -d --force-recreat
 This expands to:
 
 ```text
-swr.cn-east-3.myhuaweicloud.com/kweaver-ai/dip/sandbox-template-python-basic:<TEMPLATE_IMAGE_TAG>
-swr.cn-east-3.myhuaweicloud.com/kweaver-ai/dip/sandbox-template-multi-language:<TEMPLATE_IMAGE_TAG>
+swr.cn-east-3.myhuaweicloud.com/openbkn-ai/dip/sandbox-template-python-basic:<TEMPLATE_IMAGE_TAG>
+swr.cn-east-3.myhuaweicloud.com/openbkn-ai/dip/sandbox-template-multi-language:<TEMPLATE_IMAGE_TAG>
 ```
 
 You can also override `DEFAULT_TEMPLATE_IMAGE` and `DEFAULT_MULTI_LANGUAGE_TEMPLATE_IMAGE` directly when different repositories or tags are required.

--- a/infra/sandbox/README.md
+++ b/infra/sandbox/README.md
@@ -195,7 +195,7 @@ To push multi-arch base images to Huawei Cloud SWR, install `skopeo` and use Doc
 cd images
 ./build.sh --build-bases --push-swr-bases \
   --swr-registry swr.cn-east-3.myhuaweicloud.com \
-  --swr-namespace openbkn-ai/sandbox \
+  --swr-namespace openbkn-ai \
   --swr-creds '<username>:<password>'
 ```
 
@@ -247,8 +247,8 @@ docker-compose -f deploy/docker-compose/docker-compose.yml up -d --force-recreat
 This expands to:
 
 ```text
-swr.cn-east-3.myhuaweicloud.com/openbkn-ai/dip/sandbox-template-python-basic:<TEMPLATE_IMAGE_TAG>
-swr.cn-east-3.myhuaweicloud.com/openbkn-ai/dip/sandbox-template-multi-language:<TEMPLATE_IMAGE_TAG>
+swr.cn-east-3.myhuaweicloud.com/openbkn-ai/sandbox-template-python-basic:<TEMPLATE_IMAGE_TAG>
+swr.cn-east-3.myhuaweicloud.com/openbkn-ai/sandbox-template-multi-language:<TEMPLATE_IMAGE_TAG>
 ```
 
 You can also override `DEFAULT_TEMPLATE_IMAGE` and `DEFAULT_MULTI_LANGUAGE_TEMPLATE_IMAGE` directly when different repositories or tags are required.

--- a/infra/sandbox/README_ZH.md
+++ b/infra/sandbox/README_ZH.md
@@ -235,8 +235,8 @@ docker-compose -f deploy/docker-compose/docker-compose.yml up -d --force-recreat
 该配置会展开为：
 
 ```text
-swr.cn-east-3.myhuaweicloud.com/kweaver-ai/dip/sandbox-template-python-basic:<TEMPLATE_IMAGE_TAG>
-swr.cn-east-3.myhuaweicloud.com/kweaver-ai/dip/sandbox-template-multi-language:<TEMPLATE_IMAGE_TAG>
+swr.cn-east-3.myhuaweicloud.com/openbkn-ai/dip/sandbox-template-python-basic:<TEMPLATE_IMAGE_TAG>
+swr.cn-east-3.myhuaweicloud.com/openbkn-ai/dip/sandbox-template-multi-language:<TEMPLATE_IMAGE_TAG>
 ```
 
 如需使用不同仓库或 tag，也可以直接覆盖 `DEFAULT_TEMPLATE_IMAGE` 和 `DEFAULT_MULTI_LANGUAGE_TEMPLATE_IMAGE`。

--- a/infra/sandbox/README_ZH.md
+++ b/infra/sandbox/README_ZH.md
@@ -235,8 +235,8 @@ docker-compose -f deploy/docker-compose/docker-compose.yml up -d --force-recreat
 该配置会展开为：
 
 ```text
-swr.cn-east-3.myhuaweicloud.com/openbkn-ai/dip/sandbox-template-python-basic:<TEMPLATE_IMAGE_TAG>
-swr.cn-east-3.myhuaweicloud.com/openbkn-ai/dip/sandbox-template-multi-language:<TEMPLATE_IMAGE_TAG>
+swr.cn-east-3.myhuaweicloud.com/openbkn-ai/sandbox-template-python-basic:<TEMPLATE_IMAGE_TAG>
+swr.cn-east-3.myhuaweicloud.com/openbkn-ai/sandbox-template-multi-language:<TEMPLATE_IMAGE_TAG>
 ```
 
 如需使用不同仓库或 tag，也可以直接覆盖 `DEFAULT_TEMPLATE_IMAGE` 和 `DEFAULT_MULTI_LANGUAGE_TEMPLATE_IMAGE`。

--- a/infra/sandbox/deploy/helm/sandbox_standalone/templates/configmap.yaml
+++ b/infra/sandbox/deploy/helm/sandbox_standalone/templates/configmap.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.configMap.create }}
-{{- $templateImageRegistry := default "swr.cn-east-3.myhuaweicloud.com/openbkn-ai/dip" .Values.image.registry }}
+{{- $templateImageRegistry := default "swr.cn-east-3.myhuaweicloud.com/openbkn-ai" .Values.image.registry }}
 {{- $pythonBasicTemplate := .Values.image.defaultTemplate }}
 {{- if .Values.image.defaultTemplates }}
 {{- $pythonBasicTemplate = .Values.image.defaultTemplates.pythonBasic }}

--- a/infra/sandbox/images/build.sh
+++ b/infra/sandbox/images/build.sh
@@ -488,7 +488,7 @@ while [[ $# -gt 0 ]]; do
             echo "  --build-multi-base Build stable multi-language runtime base image"
             echo "  --push-swr-bases Push built base images to SWR with skopeo"
             echo "  --swr-registry SWR registry host, e.g. swr.cn-east-3.myhuaweicloud.com"
-            echo "  --swr-namespace SWR namespace path, e.g. openbkn-ai/sandbox"
+            echo "  --swr-namespace SWR namespace path, e.g. openbkn-ai"
             echo "  --swr-creds SWR credentials in username:password format"
             echo "  --swr-dest-tls-verify SWR destination TLS verify flag (default: false)"
             echo "  --swr-python-base-repository SWR repository for Python base (default: sandbox-python-executor-base)"

--- a/infra/sandbox/images/build.sh
+++ b/infra/sandbox/images/build.sh
@@ -488,7 +488,7 @@ while [[ $# -gt 0 ]]; do
             echo "  --build-multi-base Build stable multi-language runtime base image"
             echo "  --push-swr-bases Push built base images to SWR with skopeo"
             echo "  --swr-registry SWR registry host, e.g. swr.cn-east-3.myhuaweicloud.com"
-            echo "  --swr-namespace SWR namespace path, e.g. kweaver-ai/sandbox"
+            echo "  --swr-namespace SWR namespace path, e.g. openbkn-ai/sandbox"
             echo "  --swr-creds SWR credentials in username:password format"
             echo "  --swr-dest-tls-verify SWR destination TLS verify flag (default: false)"
             echo "  --swr-python-base-repository SWR repository for Python base (default: sandbox-python-executor-base)"

--- a/infra/sandbox/sandbox_control_plane/src/infrastructure/persistence/seed/default_data.py
+++ b/infra/sandbox/sandbox_control_plane/src/infrastructure/persistence/seed/default_data.py
@@ -22,7 +22,7 @@ if TYPE_CHECKING:
 
 logger = get_logger(__name__)
 
-DEFAULT_TEMPLATE_IMAGE_REGISTRY = "swr.cn-east-3.myhuaweicloud.com/kweaver-ai/dip"
+DEFAULT_TEMPLATE_IMAGE_REGISTRY = "swr.cn-east-3.myhuaweicloud.com/openbkn-ai/dip"
 DEFAULT_PYTHON_BASIC_TEMPLATE_IMAGE_REPOSITORY = "sandbox-template-python-basic"
 DEFAULT_MULTI_LANGUAGE_TEMPLATE_IMAGE_REPOSITORY = "sandbox-template-multi-language"
 

--- a/infra/sandbox/sandbox_control_plane/src/infrastructure/persistence/seed/default_data.py
+++ b/infra/sandbox/sandbox_control_plane/src/infrastructure/persistence/seed/default_data.py
@@ -22,7 +22,7 @@ if TYPE_CHECKING:
 
 logger = get_logger(__name__)
 
-DEFAULT_TEMPLATE_IMAGE_REGISTRY = "swr.cn-east-3.myhuaweicloud.com/openbkn-ai/dip"
+DEFAULT_TEMPLATE_IMAGE_REGISTRY = "swr.cn-east-3.myhuaweicloud.com/openbkn-ai"
 DEFAULT_PYTHON_BASIC_TEMPLATE_IMAGE_REPOSITORY = "sandbox-template-python-basic"
 DEFAULT_MULTI_LANGUAGE_TEMPLATE_IMAGE_REPOSITORY = "sandbox-template-multi-language"
 


### PR DESCRIPTION
The control plane's built-in fallback still pointed at the retired `kweaver-ai/dip` SWR namespace, so a bare or compose run with no `DEFAULT_TEMPLATE_IMAGE_REGISTRY` set pulled templates from there, while every chart-driven install used `openbkn-ai`.

## Where the images actually live

`reusable-build.yml` publishes app images as `${swr-registry}/${swr-namespace}/${image-name}:${version}`, with `swr-namespace` defaulting to `openbkn-ai`, and no workflow passes a different one. So the sandbox templates are at:

```
swr.cn-east-3.myhuaweicloud.com/openbkn-ai/sandbox-template-python-basic:<version>
swr.cn-east-3.myhuaweicloud.com/openbkn-ai/sandbox-template-multi-language:<version>
```

There is no `/dip` segment — that was part of the retired `kweaver-ai/dip` layout, and grepping the workflows for `dip` returns nothing.

## What changed

- **`default_data.py`** — `DEFAULT_TEMPLATE_IMAGE_REGISTRY` becomes `swr…/openbkn-ai`.
- **`deploy/helm/sandbox_standalone/templates/configmap.yaml`** — its default was `swr…/openbkn-ai/dip`, and it is the one default that actually fires, since that chart's `values.yaml` leaves `image.registry` empty. Corrected to match.
- **`.env.example`**, **`README.md`**, **`README_ZH.md`** — the same strings.
- **`images/build.sh`** and the README example — `--swr-namespace` drops the nested `sandbox` segment. The script pushes to `${SWR_REGISTRY}/${SWR_NAMESPACE}/${repository}`, so the namespace is the same flat one CI uses.

The component chart already rendered the right thing: its `values.yaml` sets `image.registry: ghcr.io/openbkn-ai`, so its own chart default never fires.

## Effect on a real install

None. `build_template_image_url()` reads the `DEFAULT_TEMPLATE_IMAGE_REGISTRY` env var first and only falls back to the constant, and `get_default_template_image_url()` prefers the full `DEFAULT_TEMPLATE_IMAGE` env var ahead of both. Both charts set those keys unconditionally in their ConfigMap, and the control-plane Deployment injects them by `configMapKeyRef`. `helm template` confirms it:

| Chart | rendered `DEFAULT_TEMPLATE_IMAGE_REGISTRY` |
|---|---|
| `sandbox` (component) | `ghcr.io/openbkn-ai` |
| `sandbox_standalone` | `swr.cn-east-3.myhuaweicloud.com/openbkn-ai` |

The Python constant is reached only by a chart-less run — bare process or compose with no env var — which is exactly the case that was pulling from the retired namespace.

## Verification

`helm template` renders both charts as above, `default_data.py` compiles, `bash -n images/build.sh` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
